### PR TITLE
fix: parse text-based tool calls from content

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ thane.local.yaml
 # Logs
 *.log
 logs/
+thane-darwin-arm64

--- a/internal/llm/ollama.go
+++ b/internal/llm/ollama.go
@@ -120,6 +120,9 @@ func (c *OllamaClient) ChatStream(ctx context.Context, model string, messages []
 		return nil, fmt.Errorf("API error %d: %s", resp.StatusCode, string(body))
 	}
 
+	// Extract valid tool names for validation
+	validToolNames := extractToolNames(tools)
+
 	if !stream {
 		// Non-streaming: single JSON response
 		var chatResp ChatResponse
@@ -128,7 +131,7 @@ func (c *OllamaClient) ChatStream(ctx context.Context, model string, messages []
 		}
 		// Try to parse text-based tool calls if no native tool_calls
 		if len(chatResp.Message.ToolCalls) == 0 && chatResp.Message.Content != "" {
-			if parsed := parseTextToolCalls(chatResp.Message.Content); len(parsed) > 0 {
+			if parsed := parseTextToolCalls(chatResp.Message.Content, validToolNames); len(parsed) > 0 {
 				chatResp.Message.ToolCalls = parsed
 				chatResp.Message.Content = "" // Clear content since it was a tool call
 			}
@@ -173,7 +176,7 @@ func (c *OllamaClient) ChatStream(ctx context.Context, model string, messages []
 
 	// Try to parse text-based tool calls if no native tool_calls
 	if len(finalResp.Message.ToolCalls) == 0 && finalResp.Message.Content != "" {
-		if parsed := parseTextToolCalls(finalResp.Message.Content); len(parsed) > 0 {
+		if parsed := parseTextToolCalls(finalResp.Message.Content, validToolNames); len(parsed) > 0 {
 			finalResp.Message.ToolCalls = parsed
 			finalResp.Message.Content = "" // Clear content since it was a tool call
 		}
@@ -182,13 +185,34 @@ func (c *OllamaClient) ChatStream(ctx context.Context, model string, messages []
 	return &finalResp, nil
 }
 
+// extractToolNames extracts tool names from the tools definition.
+// Tools are expected to be in OpenAI/Ollama format with function.name.
+func extractToolNames(tools []map[string]any) []string {
+	if len(tools) == 0 {
+		return nil
+	}
+	names := make([]string, 0, len(tools))
+	for _, tool := range tools {
+		if fn, ok := tool["function"].(map[string]any); ok {
+			if name, ok := fn["name"].(string); ok && name != "" {
+				names = append(names, name)
+			}
+		}
+	}
+	return names
+}
+
 // parseTextToolCalls attempts to extract tool calls from content text.
 // Many models output tool calls as JSON in the content rather than using
 // the native tool_calls field. This function handles common formats:
 // - Raw JSON object: {"name": "...", "arguments": {...}}
 // - JSON array: [{"name": "...", "arguments": {...}}]
 // - Tagged: <tool_call>...</tool_call>
-func parseTextToolCalls(content string) []ToolCall {
+//
+// If validTools is non-empty, only tool calls with names in that list are returned.
+// This prevents false positives when models output JSON that happens to have
+// name/arguments fields but isn't meant to be a tool call.
+func parseTextToolCalls(content string, validTools []string) []ToolCall {
 	content = strings.TrimSpace(content)
 	if content == "" {
 		return nil
@@ -206,16 +230,30 @@ func parseTextToolCalls(content string) []ToolCall {
 		}
 	}
 
+	var result []ToolCall
+
 	// Try parsing as array of tool calls
 	var calls []struct {
 		Name      string         `json:"name"`
 		Arguments map[string]any `json:"arguments"`
 	}
 	if err := json.Unmarshal([]byte(content), &calls); err == nil && len(calls) > 0 {
-		result := make([]ToolCall, len(calls))
-		for i, c := range calls {
-			result[i].Function.Name = c.Name
-			result[i].Function.Arguments = c.Arguments
+		for _, c := range calls {
+			if c.Name == "" {
+				continue
+			}
+			if !isValidTool(c.Name, validTools) {
+				continue
+			}
+			result = append(result, ToolCall{
+				Function: struct {
+					Name      string         `json:"name"`
+					Arguments map[string]any `json:"arguments"`
+				}{
+					Name:      c.Name,
+					Arguments: c.Arguments,
+				},
+			})
 		}
 		return result
 	}
@@ -226,18 +264,34 @@ func parseTextToolCalls(content string) []ToolCall {
 		Arguments map[string]any `json:"arguments"`
 	}
 	if err := json.Unmarshal([]byte(content), &single); err == nil && single.Name != "" {
-		return []ToolCall{{
-			Function: struct {
-				Name      string         `json:"name"`
-				Arguments map[string]any `json:"arguments"`
-			}{
-				Name:      single.Name,
-				Arguments: single.Arguments,
-			},
-		}}
+		if isValidTool(single.Name, validTools) {
+			return []ToolCall{{
+				Function: struct {
+					Name      string         `json:"name"`
+					Arguments map[string]any `json:"arguments"`
+				}{
+					Name:      single.Name,
+					Arguments: single.Arguments,
+				},
+			}}
+		}
 	}
 
 	return nil
+}
+
+// isValidTool checks if a tool name is in the valid tools list.
+// Returns true if validTools is nil or empty (no validation).
+func isValidTool(name string, validTools []string) bool {
+	if len(validTools) == 0 {
+		return true
+	}
+	for _, v := range validTools {
+		if v == name {
+			return true
+		}
+	}
+	return false
 }
 
 // Ping checks if Ollama is reachable.

--- a/internal/llm/ollama_test.go
+++ b/internal/llm/ollama_test.go
@@ -1,0 +1,230 @@
+package llm
+
+import (
+	"testing"
+)
+
+func TestParseTextToolCalls(t *testing.T) {
+	tests := []struct {
+		name       string
+		content    string
+		validTools []string
+		wantCount  int
+		wantName   string // First tool name if wantCount > 0
+	}{
+		{
+			name:      "empty content",
+			content:   "",
+			wantCount: 0,
+		},
+		{
+			name:      "whitespace only",
+			content:   "   \n\t  ",
+			wantCount: 0,
+		},
+		{
+			name:      "plain text no JSON",
+			content:   "The sun is currently up.",
+			wantCount: 0,
+		},
+		{
+			name:      "single tool call object",
+			content:   `{"name": "get_state", "arguments": {"entity_id": "sun.sun"}}`,
+			wantCount: 1,
+			wantName:  "get_state",
+		},
+		{
+			name:      "single tool call with whitespace",
+			content:   `  {"name": "get_state", "arguments": {"entity_id": "sun.sun"}}  `,
+			wantCount: 1,
+			wantName:  "get_state",
+		},
+		{
+			name:      "array of tool calls",
+			content:   `[{"name": "get_state", "arguments": {"entity_id": "sun.sun"}}, {"name": "list_entities", "arguments": {}}]`,
+			wantCount: 2,
+			wantName:  "get_state",
+		},
+		{
+			name:      "tagged tool call",
+			content:   `<tool_call>{"name": "call_service", "arguments": {"domain": "light", "service": "turn_on"}}</tool_call>`,
+			wantCount: 1,
+			wantName:  "call_service",
+		},
+		{
+			name:      "tagged tool call without closing tag",
+			content:   `<tool_call>{"name": "get_state", "arguments": {"entity_id": "light.kitchen"}}`,
+			wantCount: 1,
+			wantName:  "get_state",
+		},
+		{
+			name:      "tagged with preamble",
+			content:   `Let me check that for you. <tool_call>{"name": "get_state", "arguments": {"entity_id": "sun.sun"}}</tool_call>`,
+			wantCount: 1,
+			wantName:  "get_state",
+		},
+		{
+			name:      "empty arguments",
+			content:   `{"name": "list_entities", "arguments": {}}`,
+			wantCount: 1,
+			wantName:  "list_entities",
+		},
+		{
+			name:      "nested arguments",
+			content:   `{"name": "call_service", "arguments": {"domain": "light", "service": "turn_on", "data": {"brightness": 255}}}`,
+			wantCount: 1,
+			wantName:  "call_service",
+		},
+		{
+			name:      "malformed JSON",
+			content:   `{"name": "get_state", "arguments": {`,
+			wantCount: 0,
+		},
+		{
+			name:      "JSON without name field",
+			content:   `{"foo": "bar", "arguments": {}}`,
+			wantCount: 0,
+		},
+		{
+			name:      "JSON with empty name",
+			content:   `{"name": "", "arguments": {}}`,
+			wantCount: 0,
+		},
+		// Validation tests
+		{
+			name:       "valid tool with validation",
+			content:    `{"name": "get_state", "arguments": {"entity_id": "sun.sun"}}`,
+			validTools: []string{"get_state", "call_service"},
+			wantCount:  1,
+			wantName:   "get_state",
+		},
+		{
+			name:       "invalid tool rejected by validation",
+			content:    `{"name": "hack_the_planet", "arguments": {}}`,
+			validTools: []string{"get_state", "call_service"},
+			wantCount:  0,
+		},
+		{
+			name:       "mixed valid/invalid in array",
+			content:    `[{"name": "get_state", "arguments": {}}, {"name": "invalid_tool", "arguments": {}}]`,
+			validTools: []string{"get_state", "call_service"},
+			wantCount:  1,
+			wantName:   "get_state",
+		},
+		{
+			name:       "no validation (nil validTools)",
+			content:    `{"name": "any_tool_name", "arguments": {}}`,
+			validTools: nil,
+			wantCount:  1,
+			wantName:   "any_tool_name",
+		},
+		{
+			name:       "no validation (empty validTools)",
+			content:    `{"name": "any_tool_name", "arguments": {}}`,
+			validTools: []string{},
+			wantCount:  1,
+			wantName:   "any_tool_name",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseTextToolCalls(tt.content, tt.validTools)
+
+			if len(got) != tt.wantCount {
+				t.Errorf("parseTextToolCalls() returned %d tools, want %d", len(got), tt.wantCount)
+				return
+			}
+
+			if tt.wantCount > 0 && got[0].Function.Name != tt.wantName {
+				t.Errorf("parseTextToolCalls() first tool name = %q, want %q", got[0].Function.Name, tt.wantName)
+			}
+		})
+	}
+}
+
+func TestExtractToolNames(t *testing.T) {
+	tests := []struct {
+		name  string
+		tools []map[string]any
+		want  []string
+	}{
+		{
+			name:  "nil tools",
+			tools: nil,
+			want:  nil,
+		},
+		{
+			name:  "empty tools",
+			tools: []map[string]any{},
+			want:  nil,
+		},
+		{
+			name: "single tool",
+			tools: []map[string]any{
+				{"function": map[string]any{"name": "get_state", "description": "Gets entity state"}},
+			},
+			want: []string{"get_state"},
+		},
+		{
+			name: "multiple tools",
+			tools: []map[string]any{
+				{"function": map[string]any{"name": "get_state"}},
+				{"function": map[string]any{"name": "call_service"}},
+				{"function": map[string]any{"name": "list_entities"}},
+			},
+			want: []string{"get_state", "call_service", "list_entities"},
+		},
+		{
+			name: "malformed tool (no function)",
+			tools: []map[string]any{
+				{"name": "orphan_name"},
+			},
+			want: []string{},
+		},
+		{
+			name: "mixed valid and malformed",
+			tools: []map[string]any{
+				{"function": map[string]any{"name": "valid_tool"}},
+				{"broken": "entry"},
+				{"function": map[string]any{"name": "another_valid"}},
+			},
+			want: []string{"valid_tool", "another_valid"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractToolNames(tt.tools)
+			if len(got) != len(tt.want) {
+				t.Errorf("extractToolNames() = %v, want %v", got, tt.want)
+				return
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("extractToolNames()[%d] = %q, want %q", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestParseTextToolCalls_Arguments(t *testing.T) {
+	content := `{"name": "call_service", "arguments": {"domain": "light", "service": "turn_on", "entity_id": "light.kitchen"}}`
+
+	calls := parseTextToolCalls(content, nil)
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 tool call, got %d", len(calls))
+	}
+
+	args := calls[0].Function.Arguments
+	if args["domain"] != "light" {
+		t.Errorf("domain = %v, want 'light'", args["domain"])
+	}
+	if args["service"] != "turn_on" {
+		t.Errorf("service = %v, want 'turn_on'", args["service"])
+	}
+	if args["entity_id"] != "light.kitchen" {
+		t.Errorf("entity_id = %v, want 'light.kitchen'", args["entity_id"])
+	}
+}


### PR DESCRIPTION
Many models (granite, qwen2.5-coder) output tool calls as JSON in the content field rather than using Ollama's native `tool_calls` field.

## The Problem
Models return:
```json
{"response": "{\"name\": \"get_state\", \"arguments\": {\"entity_id\": \"sun.sun\"}}"}
```

Instead of:
```json
{"message": {"tool_calls": [{"function": {...}}]}}
```

## The Fix
Adds `parseTextToolCalls()` which handles:
- Raw JSON object: `{"name": ..., "arguments": ...}`
- JSON array: `[{...}]`
- Tagged format: `<tool_call>...</tool_call>`

## Result
granite3.1-dense:8b now works with tool calling:
- 7.9 seconds for complete tool-calling round-trip
- Successfully checked sun.sun and returned natural language answer

## Testing
```bash
curl -s http://localhost:8080/v1/chat -d '{"message": "Use get_state to check sun.sun"}' 
# {"response":"The sun is currently not up, as it's below the horizon."}
```