### PR TITLE
feat: Chat history persistence across page reloads

### DIFF
--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -524,6 +524,11 @@ func (l *Loop) MemoryStats() map[string]any {
 }
 
 // GetTokenCount returns the estimated token count for a conversation.
+// GetHistory returns the conversation messages for a given conversation.
+func (l *Loop) GetHistory(conversationID string) []memory.Message {
+	return l.memory.GetMessages(conversationID)
+}
+
 func (l *Loop) GetTokenCount(conversationID string) int {
 	return l.memory.GetTokenCount(conversationID)
 }

--- a/internal/web/static/index.html
+++ b/internal/web/static/index.html
@@ -754,6 +754,23 @@
         refreshStats();
         setInterval(refreshStats, 30000);
 
+        // Load chat history on page load
+        async function loadHistory() {
+            try {
+                const resp = await fetch('/v1/session/history');
+                const data = await resp.json();
+                if (data.messages && data.messages.length > 0) {
+                    for (const msg of data.messages) {
+                        addMessage(msg.role, msg.content);
+                    }
+                    messagesEl.scrollTop = messagesEl.scrollHeight;
+                }
+            } catch (e) {
+                console.log('Failed to load history:', e);
+            }
+        }
+        loadHistory();
+
         // Focus input on load
         inputEl.focus();
     </script>


### PR DESCRIPTION
Load conversation history when the web UI is opened or refreshed.

Changes:
- New endpoint: GET /v1/session/history
- Returns user/assistant messages (filters out system/tool)
- UI fetches and renders history on page load
- Includes all pending changes from PR #49 (persona, context bar, etc.)