### PR TITLE
fix: Use background context for HA API calls

### DIFF
--- a/cmd/thane/main.go
+++ b/cmd/thane/main.go
@@ -260,6 +260,11 @@ func runServe(logger *slog.Logger, configPath string, portOverride int) {
 	if cfg.HomeAssistant.URL != "" && cfg.HomeAssistant.Token != "" {
 		ha = homeassistant.NewClient(cfg.HomeAssistant.URL, cfg.HomeAssistant.Token)
 		logger.Info("Home Assistant configured", "url", cfg.HomeAssistant.URL)
+		if err := ha.Ping(context.Background()); err != nil {
+			logger.Error("Home Assistant ping failed", "error", err)
+		} else {
+			logger.Info("Home Assistant ping succeeded")
+		}
 	} else {
 		logger.Warn("Home Assistant not configured - tools will be limited")
 	}

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -682,7 +682,7 @@ func (r *Registry) handleGetState(ctx context.Context, args map[string]any) (str
 		return "", fmt.Errorf("entity_id is required")
 	}
 
-	state, err := r.ha.GetState(ctx, entityID)
+	state, err := r.ha.GetState(context.Background(), entityID)
 	if err != nil {
 		return "", err
 	}
@@ -722,7 +722,7 @@ func (r *Registry) handleListEntities(ctx context.Context, args map[string]any) 
 		limit = int(l)
 	}
 
-	states, err := r.ha.GetStates(ctx)
+	states, err := r.ha.GetStates(context.Background())
 	if err != nil {
 		return "", err
 	}
@@ -773,7 +773,7 @@ func (r *Registry) handleCallService(ctx context.Context, args map[string]any) (
 		}
 	}
 
-	if err := r.ha.CallService(ctx, domain, service, data); err != nil {
+	if err := r.ha.CallService(context.Background(), domain, service, data); err != nil {
 		return "", err
 	}
 
@@ -811,7 +811,7 @@ func (r *Registry) handleControlDevice(ctx context.Context, args map[string]any)
 	}
 
 	// Find the entity
-	entities, err := r.ha.GetEntities(ctx, domain)
+	entities, err := r.ha.GetEntities(context.Background(), domain)
 	if err != nil {
 		return "", fmt.Errorf("failed to get entities: %w", err)
 	}
@@ -860,7 +860,7 @@ func (r *Registry) handleControlDevice(ctx context.Context, args map[string]any)
 	}
 
 	// Execute the service call
-	if err := r.ha.CallService(ctx, domain, service, data); err != nil {
+	if err := r.ha.CallService(context.Background(), domain, service, data); err != nil {
 		return "", fmt.Errorf("failed to control %s: %w", foundName, err)
 	}
 


### PR DESCRIPTION
The HTTP request context from streaming responses was being cancelled before HA API calls could complete, causing intermittent no-route-to-host and broken-pipe errors.

Tool calls now use context.Background() for HA operations. Also adds HA connectivity check (Ping) at startup.