### PR TITLE
refactor: remove duplicate min/max, use Go builtins

### DIFF
--- a/internal/memory/compaction.go
+++ b/internal/memory/compaction.go
@@ -207,10 +207,3 @@ func (s *SimpleSummarizer) Summarize(ctx context.Context, messages []Message) (s
 
 	return sb.String(), nil
 }
-
-func min(a, b int) int {
-	if a < b {
-		return a
-	}
-	return b
-}

--- a/internal/tools/find_entity.go
+++ b/internal/tools/find_entity.go
@@ -334,17 +334,3 @@ func inferDomainFromDescription(description string) string {
 	// No match - return empty to search all domains
 	return ""
 }
-
-func min(a, b int) int {
-	if a < b {
-		return a
-	}
-	return b
-}
-
-func max(a, b float64) float64 {
-	if a > b {
-		return a
-	}
-	return b
-}


### PR DESCRIPTION
## What

Remove package-local `min()` and `max()` functions that shadow Go 1.21+ builtins.

## Why

- `min(a, b int)` was defined in both `memory/compaction.go` and `tools/find_entity.go`
- `max(a, b float64)` was defined in `tools/find_entity.go`
- Go 1.21+ (we use 1.24) provides these as builtins for all ordered types
- Duplicate definitions shadow builtins and create confusion

## Changes

- **2 files changed, 19 deletions, 0 additions**
- Pure deletion — no call sites or behavior changed
- Builtin `min`/`max` have compatible signatures

## Risk

Minimal. The builtin functions have identical behavior to the removed implementations.