### PR TITLE
fix: replace hand-rolled number formatting with strconv.Itoa

### DIFF
--- a/internal/checkpoint/types.go
+++ b/internal/checkpoint/types.go
@@ -2,6 +2,7 @@
 package checkpoint
 
 import (
+	"strconv"
 	"time"
 
 	"github.com/google/uuid"
@@ -120,5 +121,5 @@ func formatCount(n int, unit string) string {
 	if n == 1 {
 		return "1 " + unit
 	}
-	return string(rune('0'+n%10)) + " " + unit + "s"
+	return strconv.Itoa(n) + " " + unit + "s"
 }

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -4,6 +4,7 @@ package router
 import (
 	"context"
 	"log/slog"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -310,7 +311,7 @@ func (r *Router) selectModel(req Request, decision *Decision) string {
 	}
 
 	reasoning.WriteString("Selected " + best.Name)
-	reasoning.WriteString(" (score=" + itoa(bestScore) + ")")
+	reasoning.WriteString(" (score=" + strconv.Itoa(bestScore) + ")")
 	reasoning.WriteString(" for " + decision.Complexity.String() + " " + decision.DetectedIntent + " query.")
 
 	if r.config.LocalFirst && best.CostTier == 0 {
@@ -408,26 +409,4 @@ func priorityString(p Priority) string {
 		return "interactive"
 	}
 	return "background"
-}
-
-func itoa(i int) string {
-	if i == 0 {
-		return "0"
-	}
-	var b [20]byte
-	n := len(b)
-	neg := i < 0
-	if neg {
-		i = -i
-	}
-	for i > 0 {
-		n--
-		b[n] = byte('0' + i%10)
-		i /= 10
-	}
-	if neg {
-		n--
-		b[n] = '-'
-	}
-	return string(b[n:])
 }


### PR DESCRIPTION
## What

Two fixes for hand-rolled number-to-string conversions that should use `strconv.Itoa`.

### 1. `formatCount` bug (checkpoint/types.go)

**Broken:** `formatCount(42, "msg")` returned `"2 msgs"` (only last digit)

Used `string(rune('0'+n%10))` which only works for 0-9. Any checkpoint with 10+ messages or facts showed wrong counts in summaries.

**Fixed:** Uses `strconv.Itoa(n)` — correct for all values.

### 2. Hand-rolled `itoa` (router/router.go)

20-line reimplementation of `strconv.Itoa`. Functionally correct but unnecessary. Removed and replaced with stdlib call.

## Changes

- 2 files changed, 4 insertions, 24 deletions
- `just ci` passes (gofmt + vet + tests with race detector)

## Risk

Minimal. Both changes produce identical output for all inputs, except formatCount now produces *correct* output for n >= 10.