### PR TITLE
docs: unify architecture philosophy into ARCHITECTURE.md

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -182,9 +182,9 @@ docker run -d -p 8080:8080 -p 11434:11434 \
   ghcr.io/nugget/thane:latest
 ```
 
-### Home Assistant Add-on (planned)
+### Home Assistant App (planned)
 
-Native HA Add-on packaging is on the roadmap.
+Native HA App packaging is on the roadmap.
 
 ## Roadmap
 
@@ -198,7 +198,7 @@ Native HA Add-on packaging is on the roadmap.
 - Wire events to anticipation triggers, proactive notifications, intent-parser architecture
 
 ### Phase 4: Ecosystem
-- HA Add-on packaging, Apple ecosystem integration, companion app, multi-instance deployment, git-backed identity store
+- HA App packaging, Apple ecosystem integration, companion app, multi-instance deployment, git-backed identity store
 
 ## License
 


### PR DESCRIPTION
Supersedes #56

Merges the philosophy and preamble documents from #56 into a new **Philosophy** section at the top of the existing `ARCHITECTURE.md`.

## Changes

- Added Philosophy section with the vibration sensor metaphor, core principles (understanding over rules, boring tech, open source as gift culture), and the "what we're building / not building" framing
- Removed site-specific and personal references from the original drafts
- No changes to the existing technical architecture content

## What was removed

- References to specific people/collaborators (appropriate for a public repo)
- Duplicate content between the two source files
- The two standalone files (`ARCHITECTURE_PHILOSOPHY.md`, `ARCHITECTURE_PREAMBLE.md`) — all content now lives in one place

If this merges, #56 can be closed.