### PR TITLE
feat: add web_fetch tool for page content extraction

### DIFF
--- a/cmd/thane/main.go
+++ b/cmd/thane/main.go
@@ -35,6 +35,7 @@ import (
 	"github.com/nugget/thane-ai-agent/internal/config"
 	"github.com/nugget/thane-ai-agent/internal/embeddings"
 	"github.com/nugget/thane-ai-agent/internal/facts"
+	"github.com/nugget/thane-ai-agent/internal/fetch"
 	"github.com/nugget/thane-ai-agent/internal/homeassistant"
 	"github.com/nugget/thane-ai-agent/internal/ingest"
 	"github.com/nugget/thane-ai-agent/internal/llm"
@@ -567,6 +568,12 @@ func runServe(ctx context.Context, stdout io.Writer, stderr io.Writer, configPat
 	} else {
 		logger.Warn("web search disabled (no providers configured)")
 	}
+
+	// --- Web Fetch ---
+	// Always available — no configuration needed. Fetches web pages and
+	// extracts readable text content.
+	loop.Tools().SetFetcher(fetch.New())
+	logger.Info("web fetch enabled")
 
 	// --- Embeddings ---
 	// Optional semantic search over the fact store. When enabled, facts

--- a/go.mod
+++ b/go.mod
@@ -6,19 +6,20 @@ toolchain go1.24.4
 
 require (
 	github.com/google/uuid v1.6.0
+	github.com/gorilla/websocket v1.5.3
 	github.com/mattn/go-sqlite3 v1.14.33
+	golang.org/x/net v0.50.0
 	gopkg.in/yaml.v3 v3.0.1
 	modernc.org/sqlite v1.45.0
 )
 
 require (
 	github.com/dustin/go-humanize v1.0.1 // indirect
-	github.com/gorilla/websocket v1.5.3 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/ncruces/go-strftime v1.0.0 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	golang.org/x/exp v0.0.0-20251023183803-a4bb9ffd2546 // indirect
-	golang.org/x/sys v0.37.0 // indirect
+	golang.org/x/sys v0.41.0 // indirect
 	modernc.org/libc v1.67.6 // indirect
 	modernc.org/mathutil v1.7.1 // indirect
 	modernc.org/memory v1.11.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -20,11 +20,13 @@ golang.org/x/exp v0.0.0-20251023183803-a4bb9ffd2546 h1:mgKeJMpvi0yx/sU5GsxQ7p6s2
 golang.org/x/exp v0.0.0-20251023183803-a4bb9ffd2546/go.mod h1:j/pmGrbnkbPtQfxEe5D0VQhZC6qKbfKifgD0oM7sR70=
 golang.org/x/mod v0.29.0 h1:HV8lRxZC4l2cr3Zq1LvtOsi/ThTgWnUk/y64QSs8GwA=
 golang.org/x/mod v0.29.0/go.mod h1:NyhrlYXJ2H4eJiRy/WDBO6HMqZQ6q9nk4JzS3NuCK+w=
+golang.org/x/net v0.50.0 h1:ucWh9eiCGyDR3vtzso0WMQinm2Dnt8cFMuQa9K33J60=
+golang.org/x/net v0.50.0/go.mod h1:UgoSli3F/pBgdJBHCTc+tp3gmrU4XswgGRgtnwWTfyM=
 golang.org/x/sync v0.17.0 h1:l60nONMj9l5drqw6jlhIELNv9I0A4OFgRsG9k2oT9Ug=
 golang.org/x/sync v0.17.0/go.mod h1:9KTHXmSnoGruLpwFjVSX0lNNA75CykiMECbovNTZqGI=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.37.0 h1:fdNQudmxPjkdUTPnLn5mdQv7Zwvbvpaxqs831goi9kQ=
-golang.org/x/sys v0.37.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
+golang.org/x/sys v0.41.0 h1:Ivj+2Cp/ylzLiEU89QhWblYnOE9zerudt9Ftecq2C6k=
+golang.org/x/sys v0.41.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
 golang.org/x/tools v0.38.0 h1:Hx2Xv8hISq8Lm16jvBZ2VQf+RLmbd7wVUsALibYI/IQ=
 golang.org/x/tools v0.38.0/go.mod h1:yEsQ/d/YK8cjh0L6rZlY8tgtlKiBNTL14pGDJPJpYQs=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=

--- a/internal/fetch/extract.go
+++ b/internal/fetch/extract.go
@@ -1,0 +1,159 @@
+package fetch
+
+import (
+	"io"
+	"strings"
+
+	"golang.org/x/net/html"
+	"golang.org/x/net/html/atom"
+)
+
+// skipElements are HTML elements whose content should be excluded.
+var skipElements = map[atom.Atom]bool{
+	atom.Script:   true,
+	atom.Style:    true,
+	atom.Noscript: true,
+	atom.Iframe:   true,
+	atom.Svg:      true,
+	atom.Head:     true, // We extract title separately
+	atom.Nav:      true,
+	atom.Footer:   true,
+	atom.Header:   true,
+}
+
+// extractHTML parses HTML and returns (title, readable text content).
+func extractHTML(raw string) (string, string) {
+	doc, err := html.Parse(strings.NewReader(raw))
+	if err != nil {
+		// Fallback: strip tags naively
+		return "", stripTags(raw)
+	}
+
+	var title string
+	var content strings.Builder
+
+	// First pass: find title
+	title = findTitle(doc)
+
+	// Second pass: extract text
+	extractText(doc, &content, false)
+
+	// Clean up whitespace
+	text := cleanWhitespace(content.String())
+	return title, text
+}
+
+// findTitle walks the DOM looking for a <title> element.
+func findTitle(n *html.Node) string {
+	if n.Type == html.ElementNode && n.DataAtom == atom.Title {
+		return getTextContent(n)
+	}
+	for c := n.FirstChild; c != nil; c = c.NextSibling {
+		if t := findTitle(c); t != "" {
+			return t
+		}
+	}
+	return ""
+}
+
+// getTextContent returns concatenated text of all children.
+func getTextContent(n *html.Node) string {
+	if n.Type == html.TextNode {
+		return n.Data
+	}
+	var b strings.Builder
+	for c := n.FirstChild; c != nil; c = c.NextSibling {
+		b.WriteString(getTextContent(c))
+	}
+	return b.String()
+}
+
+// extractText recursively extracts visible text from the DOM.
+func extractText(n *html.Node, w *strings.Builder, skip bool) {
+	if skip {
+		return
+	}
+
+	if n.Type == html.ElementNode {
+		if skipElements[n.DataAtom] {
+			return
+		}
+		// Add line breaks for block elements
+		if isBlockElement(n.DataAtom) && w.Len() > 0 {
+			w.WriteString("\n\n")
+		}
+	}
+
+	if n.Type == html.TextNode {
+		text := strings.TrimSpace(n.Data)
+		if text != "" {
+			w.WriteString(text)
+			w.WriteString(" ")
+		}
+	}
+
+	for c := n.FirstChild; c != nil; c = c.NextSibling {
+		extractText(c, w, false)
+	}
+
+	// Add newline after certain inline-block elements
+	if n.Type == html.ElementNode && (n.DataAtom == atom.Br || n.DataAtom == atom.Li) {
+		w.WriteString("\n")
+	}
+}
+
+// isBlockElement returns true for elements that typically render as blocks.
+func isBlockElement(a atom.Atom) bool {
+	switch a {
+	case atom.P, atom.Div, atom.Section, atom.Article, atom.Main,
+		atom.H1, atom.H2, atom.H3, atom.H4, atom.H5, atom.H6,
+		atom.Blockquote, atom.Pre, atom.Ul, atom.Ol, atom.Table,
+		atom.Tr, atom.Dl, atom.Dd, atom.Dt, atom.Figcaption, atom.Figure,
+		atom.Details, atom.Summary, atom.Hr:
+		return true
+	}
+	return false
+}
+
+// cleanWhitespace normalizes whitespace in extracted text.
+func cleanWhitespace(s string) string {
+	// Collapse runs of spaces/tabs within lines
+	lines := strings.Split(s, "\n")
+	var cleaned []string
+	prevEmpty := false
+
+	for _, line := range lines {
+		line = strings.Join(strings.Fields(line), " ")
+		if line == "" {
+			if prevEmpty {
+				continue // Skip consecutive blank lines
+			}
+			prevEmpty = true
+		} else {
+			prevEmpty = false
+		}
+		cleaned = append(cleaned, line)
+	}
+
+	return strings.TrimSpace(strings.Join(cleaned, "\n"))
+}
+
+// stripTags is a fallback that removes HTML tags naively.
+func stripTags(s string) string {
+	tokenizer := html.NewTokenizer(strings.NewReader(s))
+	var b strings.Builder
+
+	for {
+		tt := tokenizer.Next()
+		switch tt {
+		case html.ErrorToken:
+			if tokenizer.Err() == io.EOF {
+				return cleanWhitespace(b.String())
+			}
+			return cleanWhitespace(b.String())
+		case html.TextToken:
+			b.WriteString(tokenizer.Token().Data)
+			b.WriteString(" ")
+		}
+	}
+}

--- a/internal/fetch/fetch.go
+++ b/internal/fetch/fetch.go
@@ -1,0 +1,157 @@
+// Package fetch provides web page fetching and content extraction.
+// It downloads a URL's HTML and extracts readable text content,
+// stripping navigation, ads, and other boilerplate.
+package fetch
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"github.com/nugget/thane-ai-agent/internal/buildinfo"
+)
+
+// DefaultTimeout is the HTTP request timeout for fetching pages.
+const DefaultTimeout = 30 * time.Second
+
+// DefaultMaxBytes is the maximum response body size (5 MB).
+const DefaultMaxBytes int64 = 5 * 1024 * 1024
+
+// DefaultMaxChars is the default character limit for extracted text.
+const DefaultMaxChars = 50000
+
+// Result holds the fetched and extracted content from a URL.
+type Result struct {
+	URL         string `json:"url"`
+	Title       string `json:"title,omitempty"`
+	Content     string `json:"content"`
+	ContentType string `json:"content_type,omitempty"`
+	Truncated   bool   `json:"truncated,omitempty"`
+	Length      int    `json:"length"`
+	StatusCode  int    `json:"status_code"`
+}
+
+// Fetcher downloads and extracts readable content from web pages.
+type Fetcher struct {
+	client   *http.Client
+	maxBytes int64
+}
+
+// New creates a Fetcher with default settings.
+func New() *Fetcher {
+	return &Fetcher{
+		client: &http.Client{
+			Timeout: DefaultTimeout,
+		},
+		maxBytes: DefaultMaxBytes,
+	}
+}
+
+// Fetch downloads the URL and extracts readable text content.
+// maxChars limits the output length; 0 uses DefaultMaxChars.
+func (f *Fetcher) Fetch(ctx context.Context, rawURL string, maxChars int) (*Result, error) {
+	if rawURL == "" {
+		return nil, fmt.Errorf("web_fetch: url is required")
+	}
+
+	// Normalize URL
+	if !strings.HasPrefix(rawURL, "http://") && !strings.HasPrefix(rawURL, "https://") {
+		rawURL = "https://" + rawURL
+	}
+
+	if maxChars <= 0 {
+		maxChars = DefaultMaxChars
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("web_fetch: invalid url: %w", err)
+	}
+
+	req.Header.Set("User-Agent", buildinfo.UserAgent())
+	req.Header.Set("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,text/plain;q=0.8,*/*;q=0.7")
+	req.Header.Set("Accept-Language", "en-US,en;q=0.9")
+
+	resp, err := f.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("web_fetch: request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	// Limit body size
+	limited := io.LimitReader(resp.Body, f.maxBytes)
+	body, err := io.ReadAll(limited)
+	if err != nil {
+		return nil, fmt.Errorf("web_fetch: failed to read response: %w", err)
+	}
+
+	contentType := resp.Header.Get("Content-Type")
+
+	// Extract readable text based on content type
+	var title, content string
+	if isHTML(contentType) {
+		title, content = extractHTML(string(body))
+	} else if isPlainText(contentType) {
+		content = string(body)
+	} else {
+		// For other types, try to use as text if it's valid UTF-8
+		if utf8.Valid(body) {
+			content = string(body)
+		} else {
+			return &Result{
+				URL:         rawURL,
+				ContentType: contentType,
+				StatusCode:  resp.StatusCode,
+				Content:     fmt.Sprintf("Binary content (%s), %d bytes", contentType, len(body)),
+				Length:      len(body),
+			}, nil
+		}
+	}
+
+	// Truncate if needed
+	truncated := false
+	if len(content) > maxChars {
+		content = truncateUTF8(content, maxChars)
+		truncated = true
+	}
+
+	return &Result{
+		URL:         rawURL,
+		Title:       title,
+		Content:     content,
+		ContentType: contentType,
+		Truncated:   truncated,
+		Length:      len(content),
+		StatusCode:  resp.StatusCode,
+	}, nil
+}
+
+func isHTML(ct string) bool {
+	ct = strings.ToLower(ct)
+	return strings.Contains(ct, "text/html") || strings.Contains(ct, "application/xhtml")
+}
+
+func isPlainText(ct string) bool {
+	return strings.Contains(strings.ToLower(ct), "text/plain")
+}
+
+// truncateUTF8 truncates a string to maxChars, ensuring it doesn't
+// break in the middle of a multi-byte character.
+func truncateUTF8(s string, maxChars int) string {
+	if len(s) <= maxChars {
+		return s
+	}
+	// Walk runes to find safe cut point
+	count := 0
+	for i := range s {
+		if count >= maxChars {
+			return s[:i]
+		}
+		count++
+	}
+	return s
+}

--- a/internal/fetch/fetch_test.go
+++ b/internal/fetch/fetch_test.go
@@ -1,0 +1,171 @@
+package fetch
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestExtractHTML(t *testing.T) {
+	html := `<!DOCTYPE html>
+<html>
+<head><title>Test Page</title></head>
+<body>
+<nav>Navigation stuff</nav>
+<script>var x = 1;</script>
+<style>.foo { color: red; }</style>
+<main>
+<h1>Hello World</h1>
+<p>This is a test paragraph with <strong>bold text</strong>.</p>
+<p>Second paragraph.</p>
+</main>
+<footer>Footer stuff</footer>
+</body>
+</html>`
+
+	title, content := extractHTML(html)
+
+	if title != "Test Page" {
+		t.Errorf("expected title 'Test Page', got %q", title)
+	}
+	if !strings.Contains(content, "Hello World") {
+		t.Errorf("expected content to contain 'Hello World', got %q", content)
+	}
+	if !strings.Contains(content, "bold text") {
+		t.Errorf("expected content to contain 'bold text', got %q", content)
+	}
+	if strings.Contains(content, "var x = 1") {
+		t.Error("content should not contain script text")
+	}
+	if strings.Contains(content, "Navigation stuff") {
+		t.Error("content should not contain nav text")
+	}
+	if strings.Contains(content, "Footer stuff") {
+		t.Error("content should not contain footer text")
+	}
+}
+
+func TestFetch(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Verify User-Agent is set
+		ua := r.Header.Get("User-Agent")
+		if !strings.HasPrefix(ua, "Thane/") {
+			t.Errorf("expected Thane User-Agent, got %q", ua)
+		}
+
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		w.Write([]byte(`<html><head><title>Test</title></head><body><p>Hello from test server</p></body></html>`))
+	}))
+	defer ts.Close()
+
+	f := New()
+	result, err := f.Fetch(context.Background(), ts.URL, 0)
+	if err != nil {
+		t.Fatalf("Fetch failed: %v", err)
+	}
+
+	if result.Title != "Test" {
+		t.Errorf("expected title 'Test', got %q", result.Title)
+	}
+	if !strings.Contains(result.Content, "Hello from test server") {
+		t.Errorf("expected content to contain 'Hello from test server', got %q", result.Content)
+	}
+	if result.StatusCode != 200 {
+		t.Errorf("expected status 200, got %d", result.StatusCode)
+	}
+}
+
+func TestFetchPlainText(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		w.Write([]byte("Just plain text content"))
+	}))
+	defer ts.Close()
+
+	f := New()
+	result, err := f.Fetch(context.Background(), ts.URL, 0)
+	if err != nil {
+		t.Fatalf("Fetch failed: %v", err)
+	}
+
+	if result.Content != "Just plain text content" {
+		t.Errorf("expected plain text content, got %q", result.Content)
+	}
+}
+
+func TestFetchTruncation(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		w.Write([]byte(strings.Repeat("x", 1000)))
+	}))
+	defer ts.Close()
+
+	f := New()
+	result, err := f.Fetch(context.Background(), ts.URL, 100)
+	if err != nil {
+		t.Fatalf("Fetch failed: %v", err)
+	}
+
+	if !result.Truncated {
+		t.Error("expected truncated=true")
+	}
+	if result.Length > 100 {
+		t.Errorf("expected length <= 100, got %d", result.Length)
+	}
+}
+
+func TestFetchURLNormalization(t *testing.T) {
+	f := New()
+	_, err := f.Fetch(context.Background(), "", 0)
+	if err == nil {
+		t.Error("expected error for empty URL")
+	}
+}
+
+func TestCleanWhitespace(t *testing.T) {
+	input := "  Hello   world  \n\n\n\n  Second line  \n\n\n Third  "
+	got := cleanWhitespace(input)
+	if strings.Contains(got, "\n\n\n") {
+		t.Errorf("should not have triple newlines: %q", got)
+	}
+}
+
+func TestTruncateUTF8(t *testing.T) {
+	// Ensure we don't break multi-byte characters
+	s := "Héllo wörld café"
+	truncated := truncateUTF8(s, 5)
+	if len([]rune(truncated)) > 5 {
+		t.Errorf("expected at most 5 runes, got %d: %q", len([]rune(truncated)), truncated)
+	}
+}
+
+func TestToolHandler(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		w.Write([]byte(`<html><head><title>Tool Test</title></head><body><p>Content here</p></body></html>`))
+	}))
+	defer ts.Close()
+
+	f := New()
+	handler := ToolHandler(f)
+
+	result, err := handler(context.Background(), map[string]any{"url": ts.URL})
+	if err != nil {
+		t.Fatalf("handler failed: %v", err)
+	}
+	if !strings.Contains(result, "Content here") {
+		t.Errorf("expected result to contain 'Content here', got %q", result)
+	}
+}
+
+func TestToolHandlerMissingURL(t *testing.T) {
+	f := New()
+	handler := ToolHandler(f)
+
+	_, err := handler(context.Background(), map[string]any{})
+	if err == nil {
+		t.Error("expected error for missing URL")
+	}
+}

--- a/internal/fetch/tool.go
+++ b/internal/fetch/tool.go
@@ -1,0 +1,54 @@
+package fetch
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+)
+
+// ToolHandler returns a function compatible with the tools.Tool Handler
+// signature. It wraps the Fetcher for use as an agent tool.
+func ToolHandler(f *Fetcher) func(ctx context.Context, args map[string]any) (string, error) {
+	return func(ctx context.Context, args map[string]any) (string, error) {
+		url, _ := args["url"].(string)
+		if url == "" {
+			return "", fmt.Errorf("web_fetch: url is required")
+		}
+
+		maxChars := 0
+		if mc, ok := args["max_chars"].(float64); ok && mc > 0 {
+			maxChars = int(mc)
+		}
+
+		result, err := f.Fetch(ctx, url, maxChars)
+		if err != nil {
+			return "", err
+		}
+
+		// Return JSON for structured consumption by the agent.
+		out, err := json.Marshal(result)
+		if err != nil {
+			// Fallback to plain text
+			return fmt.Sprintf("Title: %s\n\n%s", result.Title, result.Content), nil
+		}
+		return string(out), nil
+	}
+}
+
+// ToolDefinition returns the JSON Schema parameters for the web_fetch tool.
+func ToolDefinition() map[string]any {
+	return map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"url": map[string]any{
+				"type":        "string",
+				"description": "URL to fetch and extract content from.",
+			},
+			"max_chars": map[string]any{
+				"type":        "integer",
+				"description": "Maximum characters to return. Default: 50000.",
+			},
+		},
+		"required": []string{"url"},
+	}
+}

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -11,6 +11,7 @@ import (
 	"github.com/nugget/thane-ai-agent/internal/anticipation"
 	"github.com/nugget/thane-ai-agent/internal/buildinfo"
 	"github.com/nugget/thane-ai-agent/internal/facts"
+	"github.com/nugget/thane-ai-agent/internal/fetch"
 	"github.com/nugget/thane-ai-agent/internal/homeassistant"
 	"github.com/nugget/thane-ai-agent/internal/scheduler"
 	"github.com/nugget/thane-ai-agent/internal/search"
@@ -78,6 +79,16 @@ func (r *Registry) SetSearchManager(mgr *search.Manager) {
 		Description: "Search the web for information. Returns titles, URLs, and snippets.",
 		Parameters:  search.ToolDefinition(),
 		Handler:     search.ToolHandler(mgr),
+	})
+}
+
+// SetFetcher adds the web_fetch tool to the registry.
+func (r *Registry) SetFetcher(f *fetch.Fetcher) {
+	r.Register(&Tool{
+		Name:        "web_fetch",
+		Description: "Fetch a web page and extract its readable text content. Use to read articles, documentation, or any web page. Complements web_search.",
+		Parameters:  fetch.ToolDefinition(),
+		Handler:     fetch.ToolHandler(f),
 	})
 }
 


### PR DESCRIPTION
## Summary

Adds `web_fetch` tool — downloads a URL and extracts readable text content. Complements `web_search` by letting the agent read full pages.

## New Package: `internal/fetch/`

- **fetch.go** — `Fetcher` with configurable timeout, max body size, and proper `Thane/<version>` User-Agent
- **extract.go** — HTML→text extraction using `golang.org/x/net/html` parser. Strips script, style, nav, footer, header elements.
- **tool.go** — Tool handler and JSON schema definition
- **fetch_test.go** — 9 tests covering extraction, truncation, UTF-8 safety, tool handler

## Tool Schema

```json
{"url": "string (required)", "max_chars": "integer (optional, default 50000)"}
```

## Wiring

- Always enabled (no config needed)
- Registered via `Registry.SetFetcher()` in tools.go
- New dependency: `golang.org/x/net/html`

## CI

All new tests pass. Only pre-existing `TestFindConfig_SearchPath` failure.