### PR TITLE
fix: ensure final response after max tool iterations

### DIFF
--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -543,7 +543,7 @@ func (l *Loop) Run(ctx context.Context, req *Request, stream StreamCallback) (*R
 	// make one final LLM call with tools disabled to generate a response.
 	if len(llmMessages) > 0 && llmMessages[len(llmMessages)-1].Role == "tool" {
 		l.logger.Warn("max iterations reached with pending tool results, making final LLM call",
-			"iterations", maxIterations,
+			"maxIterations", maxIterations,
 		)
 
 		llmResp, err := l.llm.ChatStream(ctx, model, llmMessages, nil, stream) // nil tools = no more tool calls
@@ -582,7 +582,7 @@ func (l *Loop) Run(ctx context.Context, req *Request, stream StreamCallback) (*R
 	}
 
 	l.logger.Error("max iterations reached without tool results or response",
-		"iterations", maxIterations,
+		"maxIterations", maxIterations,
 		"model", model,
 	)
 	return &Response{


### PR DESCRIPTION
Closes #72

## Problem

When the LLM uses all `maxIterations` for tool calls, there is no remaining iteration for the final text response. The user sees streamed thinking but gets the canned fallback message instead of an actual answer.

Reproduced with: "what's the outside illuminance?" — the model needed 5 tool calls (find_entity → list_entities → exec → find_entity → get_state), exhausting the budget of 5.

## Fix

1. **Bumped `maxIterations` from 5 to 10** — more headroom for complex multi-tool queries
2. **Recovery after exhaustion** — if the loop exits and the last message is a tool result, make one final LLM call with **tools disabled** (`nil` tool defs) to force a text response
3. **Token tracking** — accumulated input/output tokens are included in all response paths
4. **Logging** — warns when recovery path is taken so we can tune the limit

## Why tools=nil on the final call?

Passing `nil` tools prevents the model from requesting more tool calls, guaranteeing it produces a text response from the data already gathered. This is the "you have all the info, now answer" pattern.

## Testing

- `just ci` passes (lint + race tests)
- No test files for agent package yet (pre-existing; would need LLM mocking)