### PR TITLE
fix: increase HA retry window (3 × 2s)

### DIFF
--- a/internal/homeassistant/client.go
+++ b/internal/homeassistant/client.go
@@ -31,7 +31,7 @@ func NewClient(baseURL, token string, logger *slog.Logger) *Client {
 		token:   token,
 		httpClient: httpkit.NewClient(
 			httpkit.WithTimeout(30*time.Second),
-			httpkit.WithRetry(2, 500*time.Millisecond),
+			httpkit.WithRetry(3, 2*time.Second),
 			httpkit.WithLogger(logger),
 		),
 	}


### PR DESCRIPTION
500ms delay was too short — all 3 attempts failed within 1.5s. Investigation shows macOS USB ethernet adapter power management can drop routes for longer periods (pocket's `UserIsActive: 0` suggests power nap transitions).

New: 3 retries × 2s = 6s total window.

If this still isn't enough, the real fix is likely `pmset` or `caffeinate` to keep the USB ethernet adapter awake.