### PR TITLE
fix: address Copilot review of PR #80

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -350,6 +350,9 @@ func (c *Config) applyDefaults() {
 	if c.ShellExec.DefaultTimeoutSec == 0 {
 		c.ShellExec.DefaultTimeoutSec = 30
 	}
+	if c.Archive.MetadataModel == "" {
+		c.Archive.MetadataModel = c.Models.Default
+	}
 
 	for i := range c.Models.Available {
 		if c.Models.Available[i].Provider == "" {

--- a/internal/tools/archive_tools.go
+++ b/internal/tools/archive_tools.go
@@ -135,7 +135,12 @@ func (r *Registry) registerArchiveSessionList(store *memory.ArchiveStore) {
 				}
 				title := memory.ShortID(s.ID)
 				if s.Title != "" {
-					title = fmt.Sprintf("%s — %s", memory.ShortID(s.ID), s.Title)
+					// Sanitize: single line, cap length
+					t := strings.ReplaceAll(s.Title, "\n", " ")
+					if len(t) > 80 {
+						t = t[:80] + "…"
+					}
+					title = fmt.Sprintf("%s — %s", memory.ShortID(s.ID), t)
 				}
 				sb.WriteString(fmt.Sprintf("- **%s** — %s, %d messages, %s\n",
 					title,


### PR DESCRIPTION
Fixes flagged in Copilot review of PR #80 (merged before review completed):

- **Log corrupt JSON:** Warn on malformed tags/metadata rows instead of silently ignoring
- **Sanitize titles:** Strip newlines, cap at 80 chars in tool output to prevent markdown injection
- **Config default:** `Archive.MetadataModel` now properly defaults to `Models.Default` in `applyDefaults()`
- **Test coverage:** `TestSetSessionMetadata` — full round-trip test for title, tags, and all metadata fields

38 tests in memory package.