### PR TITLE
fix: expand ~ in file_read/file_write paths

### DIFF
--- a/internal/tools/file_tools.go
+++ b/internal/tools/file_tools.go
@@ -38,6 +38,14 @@ func (ft *FileTools) resolvePath(path string) (string, bool, error) {
 		return "", false, fmt.Errorf("workspace not configured")
 	}
 
+	// Expand ~ to home directory
+	if strings.HasPrefix(path, "~/") || path == "~" {
+		home, err := os.UserHomeDir()
+		if err == nil {
+			path = filepath.Join(home, path[1:])
+		}
+	}
+
 	// Clean and resolve the path
 	var absPath string
 	if filepath.IsAbs(path) {


### PR DESCRIPTION
The agent tries to read `~/.agents.md` but `resolvePath` treated `~` as a literal character, resulting in "file not found" errors.

Now expands `~/...` to the user home directory before path resolution. Discovered during first live Thane session — she kept failing to read her own breadcrumb file.