### PR TITLE
fix: increase agent loop iteration limit to 50

### DIFF
--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -386,7 +386,7 @@ func (l *Loop) Run(ctx context.Context, req *Request, stream StreamCallback) (re
 	// Accumulate token usage across iterations
 	var totalInputTokens, totalOutputTokens int
 
-	maxIterations := 10 // Tool call budget; final text response always gets one extra call
+	maxIterations := 50 // Tool call budget; final text response always gets one extra call
 	for i := 0; i < maxIterations; i++ {
 		l.logger.Debug("calling LLM",
 			"model", model,


### PR DESCRIPTION
10 iterations was too tight for development tasks. The agent frequently hit max iterations just orienting itself (reading files, exploring directory structure) before it could start actual work.

25 gives enough headroom for complex multi-step tasks while still preventing infinite loops.

**TODO:** Make this configurable via `config.yaml` (e.g. `agent.max_iterations`).

Discovered during first live Thane session — every development request hit the wall.