### PR TITLE
build: ad-hoc codesign macOS binaries after build

### DIFF
--- a/justfile
+++ b/justfile
@@ -22,6 +22,8 @@ default:
 build target_os=host_os target_arch=host_arch:
     @mkdir -p dist
     GOOS={{target_os}} GOARCH={{target_arch}} go build -ldflags "{{ldflags}}" -o dist/thane-{{target_os}}-{{target_arch}} ./cmd/thane
+    @# Ad-hoc sign macOS binaries so Gatekeeper doesn't kill them on each rebuild
+    @if [ "{{target_os}}" = "darwin" ]; then codesign -s - dist/thane-{{target_os}}-{{target_arch}} 2>/dev/null && echo "Signed dist/thane-{{target_os}}-{{target_arch}}"; fi
     @echo "Built dist/thane-{{target_os}}-{{target_arch}}"
 
 # Build for all release targets


### PR DESCRIPTION
macOS kills unsigned binaries and prompts for permissions on every rebuild. Ad-hoc signing stabilizes the identity so Gatekeeper doesn't treat each build as a new app.

One-line addition to the `build` recipe in justfile. Only runs for darwin targets.