### PR TITLE
feat: replace Thane Runtime with Current Conditions context section

### DIFF
--- a/cmd/thane/main.go
+++ b/cmd/thane/main.go
@@ -609,6 +609,7 @@ func runServe(ctx context.Context, stdout io.Writer, stderr io.Writer, configPat
 	defaultContextWindow := cfg.ContextWindowForModel(cfg.Models.Default, 200000)
 
 	loop := agent.NewLoop(logger, mem, compactor, rtr, ha, sched, llmClient, cfg.Models.Default, talentContent, personaContent, defaultContextWindow)
+	loop.SetTimezone(cfg.Timezone)
 	loop.SetArchiver(archiveAdapter)
 
 	// --- Static context injection ---

--- a/examples/config.example.yaml
+++ b/examples/config.example.yaml
@@ -74,6 +74,10 @@ talents_dir: ./talents
 # Copy persona.default.md to persona.md and customize for your instance.
 # persona_file: ./persona.md
 
+# Timezone for the household (IANA format). Used in the system prompt so
+# the agent reasons about local time. Defaults to the system timezone.
+# timezone: America/Chicago
+
 # Context injection — files to pre-load into the system prompt.
 # Saves the agent from spending tool call iterations reading files it
 # needs every session. Supports ~ expansion. Missing files are skipped.

--- a/internal/conditions/conditions.go
+++ b/internal/conditions/conditions.go
@@ -1,0 +1,117 @@
+// Package conditions generates the "Current Conditions" section of the
+// system prompt. This gives the agent real-time awareness of when and
+// where it's running — information that affects every decision (e.g.,
+// "should I wake the user at 3am?").
+//
+// The section is placed early in the system prompt (after persona and
+// inject files, before talents) because models attend more strongly to
+// content near the beginning. The heading level (H1) signals importance.
+package conditions
+
+import (
+	"fmt"
+	"os"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/nugget/thane-ai-agent/internal/buildinfo"
+)
+
+// CurrentConditions returns a formatted "# Current Conditions" section
+// for injection into the system prompt. The timezone parameter should be
+// an IANA timezone name (e.g., "America/Chicago"). If empty or invalid,
+// the system's local timezone is used.
+func CurrentConditions(timezone string) string {
+	var sb strings.Builder
+
+	sb.WriteString("# Current Conditions\n\n")
+
+	// Time — use configured timezone, fall back to system local.
+	loc := time.Now().Location()
+	tzResolved := false
+	if timezone != "" {
+		if parsed, err := time.LoadLocation(timezone); err == nil {
+			loc = parsed
+			tzResolved = true
+		}
+	}
+	now := time.Now().In(loc)
+	zoneName, _ := now.Zone()
+
+	// Format: Saturday, February 14, 2026 at 15:45 CST (America/Chicago)
+	sb.WriteString("**Time:** ")
+	sb.WriteString(now.Format("Monday, January 2, 2006 at 15:04 "))
+	sb.WriteString(zoneName)
+	// Include IANA name when we successfully resolved a configured timezone.
+	if tzResolved && timezone != zoneName {
+		sb.WriteString(" (")
+		sb.WriteString(timezone)
+		sb.WriteString(")")
+	}
+	sb.WriteString("\n")
+
+	// Host — hostname, OS/arch, bare metal vs container.
+	hostname, _ := os.Hostname()
+	if hostname == "" {
+		hostname = "unknown"
+	}
+	env := detectEnvironment()
+	sb.WriteString(fmt.Sprintf("**Host:** %s (%s/%s, %s)\n", hostname, runtime.GOOS, runtime.GOARCH, env))
+
+	// Thane — version and commit.
+	sb.WriteString(fmt.Sprintf("**Thane:** %s (%s@%s)\n", buildinfo.Version, buildinfo.GitCommit, buildinfo.GitBranch))
+
+	// Uptime.
+	uptime := buildinfo.Uptime()
+	sb.WriteString(fmt.Sprintf("**Uptime:** %s", formatUptime(uptime)))
+
+	return sb.String()
+}
+
+// detectEnvironment returns "container" or "bare metal" based on
+// heuristics appropriate for the current OS.
+func detectEnvironment() string {
+	// Check for Docker / container indicators on Linux.
+	if runtime.GOOS == "linux" {
+		// /.dockerenv is created by Docker.
+		if _, err := os.Stat("/.dockerenv"); err == nil {
+			return "container"
+		}
+		// Check cgroup for container runtimes (docker, lxc, kubepods).
+		if data, err := os.ReadFile("/proc/1/cgroup"); err == nil {
+			content := string(data)
+			if strings.Contains(content, "docker") ||
+				strings.Contains(content, "lxc") ||
+				strings.Contains(content, "kubepods") {
+				return "container"
+			}
+		}
+		// Check for container environment variables.
+		if os.Getenv("container") != "" || os.Getenv("KUBERNETES_SERVICE_HOST") != "" {
+			return "container"
+		}
+	}
+	return "bare metal"
+}
+
+// formatUptime formats a duration as a human-readable uptime string.
+// Examples: "4h 23m", "2d 5h", "45m", "30s".
+func formatUptime(d time.Duration) string {
+	if d < time.Minute {
+		return fmt.Sprintf("%ds", int(d.Seconds()))
+	}
+
+	days := int(d.Hours()) / 24
+	hours := int(d.Hours()) % 24
+	minutes := int(d.Minutes()) % 60
+
+	switch {
+	case days > 0:
+		return fmt.Sprintf("%dd %dh", days, hours)
+	case hours > 0:
+		return fmt.Sprintf("%dh %dm", hours, minutes)
+	default:
+		return fmt.Sprintf("%dm", minutes)
+	}
+}

--- a/internal/conditions/conditions_test.go
+++ b/internal/conditions/conditions_test.go
@@ -1,0 +1,92 @@
+package conditions
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestCurrentConditions_ContainsRequiredSections(t *testing.T) {
+	result := CurrentConditions("")
+
+	required := []string{
+		"# Current Conditions",
+		"**Time:**",
+		"**Host:**",
+		"**Thane:**",
+		"**Uptime:**",
+	}
+
+	for _, section := range required {
+		if !strings.Contains(result, section) {
+			t.Errorf("CurrentConditions() missing %q\nGot:\n%s", section, result)
+		}
+	}
+}
+
+func TestCurrentConditions_WithTimezone(t *testing.T) {
+	result := CurrentConditions("America/Chicago")
+
+	if !strings.Contains(result, "America/Chicago") {
+		t.Errorf("CurrentConditions(America/Chicago) should include timezone name\nGot:\n%s", result)
+	}
+}
+
+func TestCurrentConditions_InvalidTimezone(t *testing.T) {
+	// Use a timezone name that time.LoadLocation rejects on all platforms.
+	const bogus = "Bogus/ZZZZZ_Not_Real_12345"
+	if _, err := time.LoadLocation(bogus); err == nil {
+		t.Skip("platform resolved bogus timezone; cannot test fallback")
+	}
+
+	result := CurrentConditions(bogus)
+
+	if !strings.Contains(result, "**Time:**") {
+		t.Errorf("CurrentConditions with invalid timezone should still include time\nGot:\n%s", result)
+	}
+	// Should NOT contain the invalid timezone name.
+	if strings.Contains(result, bogus) {
+		t.Errorf("CurrentConditions with invalid timezone should not include invalid name\nGot:\n%s", result)
+	}
+}
+
+func TestCurrentConditions_EmptyTimezone(t *testing.T) {
+	// Should use local timezone.
+	result := CurrentConditions("")
+	if !strings.Contains(result, "**Time:**") {
+		t.Errorf("CurrentConditions('') should still include time\nGot:\n%s", result)
+	}
+}
+
+func TestDetectEnvironment(t *testing.T) {
+	// On a standard dev machine, this should return "bare metal".
+	// In CI containers, it might return "container" — both are valid.
+	env := detectEnvironment()
+	if env != "bare metal" && env != "container" {
+		t.Errorf("detectEnvironment() = %q; want 'bare metal' or 'container'", env)
+	}
+}
+
+func TestFormatUptime(t *testing.T) {
+	tests := []struct {
+		duration time.Duration
+		want     string
+	}{
+		{30 * time.Second, "30s"},
+		{5 * time.Minute, "5m"},
+		{45 * time.Minute, "45m"},
+		{2*time.Hour + 15*time.Minute, "2h 15m"},
+		{25 * time.Hour, "1d 1h"},
+		{48*time.Hour + 30*time.Minute, "2d 0h"},
+		{72 * time.Hour, "3d 0h"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.duration.String(), func(t *testing.T) {
+			got := formatUptime(tt.duration)
+			if got != tt.want {
+				t.Errorf("formatUptime(%v) = %q, want %q", tt.duration, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/nugget/thane-ai-agent/internal/search"
 	"gopkg.in/yaml.v3"
@@ -122,6 +123,12 @@ type Config struct {
 
 	// Search configures web search providers.
 	Search SearchConfig `yaml:"search"`
+
+	// Timezone is the IANA timezone for the household (e.g.,
+	// "America/Chicago"). Used in the Current Conditions system prompt
+	// section so the agent reasons about local time. If empty, the
+	// system's local timezone is used.
+	Timezone string `yaml:"timezone"`
 
 	// LogLevel sets the minimum log level. Valid values: trace, debug,
 	// info, warn, error. Default: info. See [ParseLogLevel].
@@ -434,6 +441,11 @@ func (c *Config) Validate() error {
 		// valid
 	default:
 		return fmt.Errorf("log_format %q invalid (expected text or json)", c.LogFormat)
+	}
+	if c.Timezone != "" {
+		if _, err := time.LoadLocation(c.Timezone); err != nil {
+			return fmt.Errorf("timezone %q invalid (expected IANA timezone, e.g. America/Chicago): %w", c.Timezone, err)
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary

- Replaces `## Thane Runtime` in the system prompt with a structured `# Current Conditions` section
- New `internal/conditions` package generates time, host, version, and uptime fields
- Adds `timezone` config field (IANA format, validated at load time) for explicit household timezone
- Detects container vs bare metal on Linux (Docker, LXC, Kubernetes)
- Moves environmental context before talents in prompt assembly order

## Example output

```markdown
# Current Conditions

**Time:** Friday, February 14, 2026 at 15:45 CST (America/Chicago)
**Host:** pocket.hollowoak.net (darwin/arm64, bare metal)
**Thane:** v0.3.1 (abc1234@main)
**Uptime:** 4h 23m
```

## Prompt assembly order (updated)

1. Persona (identity)
2. Injected context (knowledge)
3. **Current Conditions** (environment) ← was "Thane Runtime", now earlier and H1
4. Talents (behavior)
5. Dynamic context (facts, anticipations)

## Test plan

- [x] `just ci` passes (fmt-check, lint, test)
- [x] Table-driven tests for `formatUptime`
- [x] Tests for section content, valid/invalid/empty timezone handling
- [x] Container detection test (bare metal on dev machines, container in CI)
- [ ] Manual: set `timezone: America/Chicago` in config, verify prompt shows local time

Closes #127