### PR TITLE
feat: add FTS5 full-text search to facts store

### DIFF
--- a/cmd/thane/main.go
+++ b/cmd/thane/main.go
@@ -257,7 +257,7 @@ func runIngest(ctx context.Context, stdout io.Writer, stderr io.Writer, configPa
 		return fmt.Errorf("create data directory: %w", err)
 	}
 
-	factStore, err := facts.NewStore(cfg.DataDir + "/facts.db")
+	factStore, err := facts.NewStore(cfg.DataDir+"/facts.db", logger)
 	if err != nil {
 		return fmt.Errorf("open fact store: %w", err)
 	}
@@ -667,7 +667,7 @@ func runServe(ctx context.Context, stdout io.Writer, stderr io.Writer, configPat
 	// --- Fact store ---
 	// Long-term memory backed by SQLite. Facts are discrete pieces of
 	// knowledge that persist across conversations and restarts.
-	factStore, err := facts.NewStore(cfg.DataDir + "/facts.db")
+	factStore, err := facts.NewStore(cfg.DataDir+"/facts.db", logger)
 	if err != nil {
 		return fmt.Errorf("open fact store: %w", err)
 	}

--- a/internal/facts/context_test.go
+++ b/internal/facts/context_test.go
@@ -2,6 +2,7 @@ package facts
 
 import (
 	"context"
+	"log/slog"
 	"os"
 	"testing"
 
@@ -30,7 +31,7 @@ func TestContextProvider_GetContext_Empty(t *testing.T) {
 	defer os.Remove(tmpDB.Name())
 	tmpDB.Close()
 
-	store, err := NewStore(tmpDB.Name())
+	store, err := NewStore(tmpDB.Name(), slog.Default())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -70,7 +71,7 @@ func TestContextProvider_Config(t *testing.T) {
 	defer os.Remove(tmpDB.Name())
 	tmpDB.Close()
 
-	store, err := NewStore(tmpDB.Name())
+	store, err := NewStore(tmpDB.Name(), slog.Default())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -106,7 +107,7 @@ func TestNewContextProvider(t *testing.T) {
 	defer os.Remove(tmpDB.Name())
 	tmpDB.Close()
 
-	store, err := NewStore(tmpDB.Name())
+	store, err := NewStore(tmpDB.Name(), slog.Default())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/facts/store_test.go
+++ b/internal/facts/store_test.go
@@ -1,8 +1,12 @@
 package facts
 
 import (
+	"log/slog"
 	"math"
+	"os"
 	"testing"
+
+	_ "github.com/mattn/go-sqlite3"
 )
 
 func TestEmbeddingEncodeDecode(t *testing.T) {
@@ -85,5 +89,223 @@ func TestCosineSimilarity(t *testing.T) {
 				t.Errorf("got %f, want %f", got, tc.expected)
 			}
 		})
+	}
+}
+
+func newTestStore(t *testing.T) *Store {
+	t.Helper()
+	tmpFile, err := os.CreateTemp("", "thane-facts-test-*.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmpFile.Close()
+	t.Cleanup(func() { os.Remove(tmpFile.Name()) })
+
+	store, err := NewStore(tmpFile.Name(), slog.Default())
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { store.Close() })
+	return store
+}
+
+func TestFTS5_Enabled(t *testing.T) {
+	store := newTestStore(t)
+	if !store.ftsEnabled {
+		t.Skip("FTS5 not available in test environment")
+	}
+}
+
+func TestFTS5_SearchByKeyword(t *testing.T) {
+	store := newTestStore(t)
+	if !store.ftsEnabled {
+		t.Skip("FTS5 not available")
+	}
+
+	// Insert test facts.
+	_, err := store.Set(CategoryHome, "living_room_layout", "Large room with sectional sofa facing the TV", "user", 1.0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = store.Set(CategoryDevice, "office_light", "Hue Go lamp on the desk", "observation", 1.0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = store.Set(CategoryPreference, "music_volume", "Prefers volume at 40% during work hours", "user", 1.0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name    string
+		query   string
+		wantMin int // minimum expected results
+		wantKey string
+	}{
+		{
+			name:    "search by value word",
+			query:   "sofa",
+			wantMin: 1,
+			wantKey: "living_room_layout",
+		},
+		{
+			name:    "search by key word",
+			query:   "office",
+			wantMin: 1,
+			wantKey: "office_light",
+		},
+		{
+			name:    "search by source",
+			query:   "observation",
+			wantMin: 1,
+			wantKey: "office_light",
+		},
+		{
+			name:    "no results",
+			query:   "xyznonexistent",
+			wantMin: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			results, err := store.Search(tt.query)
+			if err != nil {
+				t.Fatalf("Search(%q) error = %v", tt.query, err)
+			}
+			if len(results) < tt.wantMin {
+				t.Errorf("Search(%q) returned %d results, want >= %d", tt.query, len(results), tt.wantMin)
+			}
+			if tt.wantKey != "" {
+				found := false
+				for _, f := range results {
+					if f.Key == tt.wantKey {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("Search(%q) did not return fact with key %q", tt.query, tt.wantKey)
+				}
+			}
+		})
+	}
+}
+
+func TestFTS5_SearchExcludesDeleted(t *testing.T) {
+	store := newTestStore(t)
+	if !store.ftsEnabled {
+		t.Skip("FTS5 not available")
+	}
+
+	_, err := store.Set(CategoryDevice, "garage_sensor", "Temperature sensor in the garage", "observation", 1.0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify it's searchable.
+	results, err := store.Search("garage")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result before delete, got %d", len(results))
+	}
+
+	// Soft-delete the fact.
+	if err := store.Delete(CategoryDevice, "garage_sensor"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify it's no longer searchable.
+	results, err = store.Search("garage")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 0 {
+		t.Errorf("expected 0 results after delete, got %d", len(results))
+	}
+}
+
+func TestFTS5_SearchAfterUpdate(t *testing.T) {
+	store := newTestStore(t)
+	if !store.ftsEnabled {
+		t.Skip("FTS5 not available")
+	}
+
+	_, err := store.Set(CategoryPreference, "color_temp", "Prefers warm white lights", "user", 1.0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Update the value.
+	_, err = store.Set(CategoryPreference, "color_temp", "Prefers cool daylight during work hours", "user", 1.0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Search for the new value.
+	results, err := store.Search("daylight")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result for 'daylight', got %d", len(results))
+	}
+	if results[0].Value != "Prefers cool daylight during work hours" {
+		t.Errorf("unexpected value: %s", results[0].Value)
+	}
+
+	// Old value should not be found.
+	results, err = store.Search("warm")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 0 {
+		t.Errorf("expected 0 results for old value 'warm', got %d", len(results))
+	}
+}
+
+func TestSanitizeFTS5Query(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"simple word", "hello", `"hello"`},
+		{"two words", "pool heater", `"pool" "heater"`},
+		{"special chars", "models.yaml config", `"models.yaml" "config"`},
+		{"empty", "", ""},
+		{"with quotes", `say "hello"`, `"say" """hello"""`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := sanitizeFTS5Query(tt.input)
+			if got != tt.want {
+				t.Errorf("sanitizeFTS5Query(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFTS5_LIKEFallbackPath(t *testing.T) {
+	// Test the LIKE search path directly (independent of FTS5 availability).
+	store := newTestStore(t)
+
+	_, err := store.Set(CategoryHome, "bedroom_size", "Master bedroom is 14x16 feet", "user", 1.0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	results, err := store.searchLIKE("bedroom")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("searchLIKE('bedroom') returned %d results, want 1", len(results))
+	}
+	if results[0].Key != "bedroom_size" {
+		t.Errorf("unexpected key: %s", results[0].Key)
 	}
 }

--- a/internal/facts/tools_test.go
+++ b/internal/facts/tools_test.go
@@ -2,6 +2,7 @@ package facts
 
 import (
 	"context"
+	"log/slog"
 	"os"
 	"testing"
 
@@ -29,7 +30,7 @@ func TestRememberWithEmbedding(t *testing.T) {
 	defer os.Remove(tmpFile.Name())
 	tmpFile.Close()
 
-	store, err := NewStore(tmpFile.Name())
+	store, err := NewStore(tmpFile.Name(), slog.Default())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -79,7 +80,7 @@ func TestRememberWithoutEmbedding(t *testing.T) {
 	defer os.Remove(tmpFile.Name())
 	tmpFile.Close()
 
-	store, err := NewStore(tmpFile.Name())
+	store, err := NewStore(tmpFile.Name(), slog.Default())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -115,7 +116,7 @@ func TestGenerateMissingEmbeddings(t *testing.T) {
 	defer os.Remove(tmpFile.Name())
 	tmpFile.Close()
 
-	store, err := NewStore(tmpFile.Name())
+	store, err := NewStore(tmpFile.Name(), slog.Default())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -168,7 +169,7 @@ func TestGenerateMissingEmbeddingsNoClient(t *testing.T) {
 	defer os.Remove(tmpFile.Name())
 	tmpFile.Close()
 
-	store, err := NewStore(tmpFile.Name())
+	store, err := NewStore(tmpFile.Name(), slog.Default())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/ingest/integration_test.go
+++ b/internal/ingest/integration_test.go
@@ -2,6 +2,7 @@ package ingest
 
 import (
 	"context"
+	"log/slog"
 	"os"
 	"testing"
 
@@ -62,7 +63,7 @@ Steep for 4 minutes, then press slowly to avoid agitation.
 	tmpMD.Close()
 
 	// Open fact store
-	store, err := facts.NewStore(tmpDB.Name())
+	store, err := facts.NewStore(tmpDB.Name(), slog.Default())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -124,7 +125,7 @@ func TestArchitectureIngesterReimport(t *testing.T) {
 	defer os.Remove(tmpDB.Name())
 	tmpDB.Close()
 
-	store, err := facts.NewStore(tmpDB.Name())
+	store, err := facts.NewStore(tmpDB.Name(), slog.Default())
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
## Summary
- Adds FTS5 virtual table (`facts_fts`) to the facts store for fast keyword search
- `Search()` now uses FTS5 with automatic LIKE fallback when FTS5 is unavailable
- FTS index stays in sync via `syncFTS()` on writes and `rebuildFTS()` on deletes
- Query sanitization wraps each word in double quotes to escape FTS5 special characters

## Details
The facts table is small (typically <1000 rows), so the implementation uses `INSERT INTO facts_fts(facts_fts) VALUES('rebuild')` for index maintenance rather than incremental updates. This keeps the code simple and the rebuild is effectively instant at this scale.

The FTS5 table uses `content=facts, content_rowid=rowid` (external content pattern), matching the approach already used in the archive package.

## Test plan
- [x] `TestFTS5_Enabled` — verifies FTS5 virtual table creation
- [x] `TestFTS5_SearchByKeyword` — table-driven: search by value, key, source, no results
- [x] `TestFTS5_SearchExcludesDeleted` — soft-deleted facts excluded from results
- [x] `TestFTS5_SearchAfterUpdate` — updated values searchable, old values gone
- [x] `TestSanitizeFTS5Query` — special character handling
- [x] `TestFTS5_LIKEFallbackPath` — LIKE path works independently
- [x] `just ci` passes (fmt, lint, tests with -race)

Closes #136