### PR TITLE
feat: add session working memory for experiential continuity

### DIFF
--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -433,11 +433,14 @@ func (l *Loop) Run(ctx context.Context, req *Request, stream StreamCallback) (re
 		}, nil
 	}
 
-	// Build messages for LLM
+	// Build messages for LLM. Enrich ctx with conversation ID so that
+	// context providers (e.g. working memory) can scope their output.
+	promptCtx := tools.WithConversationID(ctx, convID)
+
 	var llmMessages []llm.Message
 	llmMessages = append(llmMessages, llm.Message{
 		Role:    "system",
-		Content: l.buildSystemPrompt(ctx, userMessage),
+		Content: l.buildSystemPrompt(promptCtx, userMessage),
 	})
 
 	// Add history

--- a/internal/memory/archive.go
+++ b/internal/memory/archive.go
@@ -213,6 +213,13 @@ func (s *ArchiveStore) FTSEnabled() bool {
 	return s.ftsEnabled
 }
 
+// DB returns the underlying database connection. This allows other
+// stores (e.g. WorkingMemoryStore) to share the archive database
+// without opening a separate connection.
+func (s *ArchiveStore) DB() *sql.DB {
+	return s.db
+}
+
 // Close closes the underlying database connection.
 func (s *ArchiveStore) Close() error {
 	return s.db.Close()

--- a/internal/memory/working.go
+++ b/internal/memory/working.go
@@ -1,0 +1,88 @@
+package memory
+
+import (
+	"database/sql"
+	"fmt"
+	"time"
+)
+
+// WorkingMemoryStore persists free-form working memory per conversation.
+// Working memory captures experiential context that mechanical
+// summarisation destroys: emotional tone, conversational arc,
+// relationship temperature, and unresolved threads. The table lives in
+// archive.db alongside session transcripts.
+type WorkingMemoryStore struct {
+	db *sql.DB
+}
+
+// NewWorkingMemoryStore creates a working memory store using the given
+// database connection (typically from [ArchiveStore.DB]). It creates the
+// working_memory table if it does not already exist.
+func NewWorkingMemoryStore(db *sql.DB) (*WorkingMemoryStore, error) {
+	s := &WorkingMemoryStore{db: db}
+	if err := s.migrate(); err != nil {
+		return nil, fmt.Errorf("working memory migration: %w", err)
+	}
+	return s, nil
+}
+
+// migrate creates the working_memory table if it does not exist.
+func (s *WorkingMemoryStore) migrate() error {
+	_, err := s.db.Exec(`
+		CREATE TABLE IF NOT EXISTS working_memory (
+			conversation_id TEXT NOT NULL PRIMARY KEY,
+			content         TEXT NOT NULL,
+			updated_at      TEXT NOT NULL
+		)
+	`)
+	return err
+}
+
+// Get returns the working memory content and last-updated timestamp for
+// a conversation. If no working memory exists, it returns an empty
+// string and zero time with no error.
+func (s *WorkingMemoryStore) Get(conversationID string) (string, time.Time, error) {
+	var content string
+	var updatedAtStr string
+
+	err := s.db.QueryRow(`
+		SELECT content, updated_at FROM working_memory
+		WHERE conversation_id = ?
+	`, conversationID).Scan(&content, &updatedAtStr)
+
+	if err == sql.ErrNoRows {
+		return "", time.Time{}, nil
+	}
+	if err != nil {
+		return "", time.Time{}, fmt.Errorf("get working memory: %w", err)
+	}
+
+	updatedAt, _ := time.Parse(time.RFC3339Nano, updatedAtStr)
+	return content, updatedAt, nil
+}
+
+// Set writes or replaces the working memory content for a conversation.
+func (s *WorkingMemoryStore) Set(conversationID, content string) error {
+	_, err := s.db.Exec(`
+		INSERT INTO working_memory (conversation_id, content, updated_at)
+		VALUES (?, ?, ?)
+		ON CONFLICT(conversation_id) DO UPDATE SET
+			content = excluded.content,
+			updated_at = excluded.updated_at
+	`, conversationID, content, time.Now().UTC().Format(time.RFC3339Nano))
+	if err != nil {
+		return fmt.Errorf("set working memory: %w", err)
+	}
+	return nil
+}
+
+// Delete removes the working memory for a conversation.
+func (s *WorkingMemoryStore) Delete(conversationID string) error {
+	_, err := s.db.Exec(`
+		DELETE FROM working_memory WHERE conversation_id = ?
+	`, conversationID)
+	if err != nil {
+		return fmt.Errorf("delete working memory: %w", err)
+	}
+	return nil
+}

--- a/internal/memory/working_provider.go
+++ b/internal/memory/working_provider.go
@@ -1,0 +1,53 @@
+package memory
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// WorkingMemoryProvider implements the agent.ContextProvider interface
+// for auto-injecting working memory into the system prompt. When the
+// current conversation has working memory content, it is included
+// under a "### Working Memory" heading so the agent has experiential
+// continuity without needing to explicitly read it.
+type WorkingMemoryProvider struct {
+	store            *WorkingMemoryStore
+	conversationFunc func(context.Context) string
+}
+
+// NewWorkingMemoryProvider creates a context provider that auto-injects
+// working memory for the current conversation. The convFunc parameter
+// extracts the conversation ID from the request context — typically
+// [tools.ConversationIDFromContext].
+func NewWorkingMemoryProvider(store *WorkingMemoryStore, convFunc func(context.Context) string) *WorkingMemoryProvider {
+	return &WorkingMemoryProvider{
+		store:            store,
+		conversationFunc: convFunc,
+	}
+}
+
+// GetContext returns the working memory content for the current
+// conversation, formatted for system prompt injection. Returns empty
+// string if no working memory exists.
+func (p *WorkingMemoryProvider) GetContext(ctx context.Context, _ string) (string, error) {
+	convID := p.conversationFunc(ctx)
+
+	content, updatedAt, err := p.store.Get(convID)
+	if err != nil {
+		return "", fmt.Errorf("read working memory: %w", err)
+	}
+	if content == "" {
+		return "", nil
+	}
+
+	var sb strings.Builder
+	sb.WriteString("### Working Memory\n\n")
+	if !updatedAt.IsZero() {
+		sb.WriteString(fmt.Sprintf("*Last updated: %s*\n\n", updatedAt.Format(time.RFC3339)))
+	}
+	sb.WriteString(content)
+
+	return sb.String(), nil
+}

--- a/internal/memory/working_provider_test.go
+++ b/internal/memory/working_provider_test.go
@@ -1,0 +1,93 @@
+package memory
+
+import (
+	"context"
+	"database/sql"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	_ "github.com/mattn/go-sqlite3"
+)
+
+func newTestWorkingMemoryProvider(t *testing.T, convID string) (*WorkingMemoryProvider, *WorkingMemoryStore) {
+	t.Helper()
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+	db, err := sql.Open("sqlite3", dbPath)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+
+	store, err := NewWorkingMemoryStore(db)
+	if err != nil {
+		t.Fatalf("new store: %v", err)
+	}
+
+	convFunc := func(context.Context) string { return convID }
+	return NewWorkingMemoryProvider(store, convFunc), store
+}
+
+func TestWorkingMemoryProvider_Empty(t *testing.T) {
+	p, _ := newTestWorkingMemoryProvider(t, "default")
+
+	got, err := p.GetContext(context.Background(), "hello")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "" {
+		t.Errorf("expected empty string, got %q", got)
+	}
+}
+
+func TestWorkingMemoryProvider_WithContent(t *testing.T) {
+	p, store := newTestWorkingMemoryProvider(t, "default")
+
+	if err := store.Set("default", "Feeling productive. Working on episodic memory."); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := p.GetContext(context.Background(), "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !strings.Contains(got, "### Working Memory") {
+		t.Error("expected Working Memory heading")
+	}
+	if !strings.Contains(got, "Feeling productive") {
+		t.Error("expected working memory content")
+	}
+	if !strings.Contains(got, "Last updated") {
+		t.Error("expected Last updated timestamp")
+	}
+}
+
+func TestWorkingMemoryProvider_ConversationScoped(t *testing.T) {
+	// Create a provider scoped to conv-b — should not see conv-a's memory.
+	pB, store := newTestWorkingMemoryProvider(t, "conv-b")
+
+	if err := store.Set("conv-a", "Memory for conversation A"); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := pB.GetContext(context.Background(), "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "" {
+		t.Errorf("expected empty for conv-b, got %q", got)
+	}
+
+	// Create a provider scoped to conv-a — should see its memory.
+	convFuncA := func(context.Context) string { return "conv-a" }
+	pA := NewWorkingMemoryProvider(store, convFuncA)
+
+	got, err = pA.GetContext(context.Background(), "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(got, "Memory for conversation A") {
+		t.Error("expected conv-a working memory content")
+	}
+}

--- a/internal/memory/working_test.go
+++ b/internal/memory/working_test.go
@@ -1,0 +1,135 @@
+package memory
+
+import (
+	"database/sql"
+	"path/filepath"
+	"testing"
+	"time"
+
+	_ "github.com/mattn/go-sqlite3"
+)
+
+func newTestWorkingMemoryStore(t *testing.T) *WorkingMemoryStore {
+	t.Helper()
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+	db, err := sql.Open("sqlite3", dbPath)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+
+	s, err := NewWorkingMemoryStore(db)
+	if err != nil {
+		t.Fatalf("new store: %v", err)
+	}
+	return s
+}
+
+func TestWorkingMemory_GetEmpty(t *testing.T) {
+	s := newTestWorkingMemoryStore(t)
+
+	content, updatedAt, err := s.Get("default")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if content != "" {
+		t.Errorf("expected empty content, got %q", content)
+	}
+	if !updatedAt.IsZero() {
+		t.Errorf("expected zero time, got %v", updatedAt)
+	}
+}
+
+func TestWorkingMemory_SetAndGet(t *testing.T) {
+	s := newTestWorkingMemoryStore(t)
+
+	before := time.Now().UTC().Add(-time.Second)
+	if err := s.Set("default", "feeling productive today"); err != nil {
+		t.Fatalf("set: %v", err)
+	}
+
+	content, updatedAt, err := s.Get("default")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if content != "feeling productive today" {
+		t.Errorf("got %q, want %q", content, "feeling productive today")
+	}
+	if updatedAt.Before(before) {
+		t.Errorf("updated_at %v is before test start %v", updatedAt, before)
+	}
+}
+
+func TestWorkingMemory_Upsert(t *testing.T) {
+	s := newTestWorkingMemoryStore(t)
+
+	if err := s.Set("default", "first version"); err != nil {
+		t.Fatalf("first set: %v", err)
+	}
+	if err := s.Set("default", "second version"); err != nil {
+		t.Fatalf("second set: %v", err)
+	}
+
+	content, _, err := s.Get("default")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if content != "second version" {
+		t.Errorf("got %q, want %q", content, "second version")
+	}
+}
+
+func TestWorkingMemory_MultiConversation(t *testing.T) {
+	s := newTestWorkingMemoryStore(t)
+
+	if err := s.Set("conv-a", "memory for A"); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Set("conv-b", "memory for B"); err != nil {
+		t.Fatal(err)
+	}
+
+	contentA, _, err := s.Get("conv-a")
+	if err != nil {
+		t.Fatal(err)
+	}
+	contentB, _, err := s.Get("conv-b")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if contentA != "memory for A" {
+		t.Errorf("conv-a: got %q", contentA)
+	}
+	if contentB != "memory for B" {
+		t.Errorf("conv-b: got %q", contentB)
+	}
+}
+
+func TestWorkingMemory_Delete(t *testing.T) {
+	s := newTestWorkingMemoryStore(t)
+
+	if err := s.Set("default", "some content"); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Delete("default"); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+
+	content, _, err := s.Get("default")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if content != "" {
+		t.Errorf("expected empty after delete, got %q", content)
+	}
+}
+
+func TestWorkingMemory_DeleteNonexistent(t *testing.T) {
+	s := newTestWorkingMemoryStore(t)
+
+	// Should not error when deleting something that doesn't exist.
+	if err := s.Delete("nonexistent"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/internal/prompts/compaction.go
+++ b/internal/prompts/compaction.go
@@ -1,6 +1,9 @@
 package prompts
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
 
 // compactionTemplate is the prompt sent to an LLM to summarize a conversation
 // during memory compaction. The single format verb is the conversation text.
@@ -17,9 +20,26 @@ Conversation:
 
 Summary:`
 
+// workingMemorySection is appended to the compaction prompt when the agent
+// has written working memory for this conversation. It provides the LLM with
+// experiential context that should be preserved through compaction.
+const workingMemorySection = `
+
+## Agent Working Memory (self-authored context)
+%s
+
+Preserve the experiential texture from working memory in your summary — emotional
+tone, relationship dynamics, and unresolved threads matter as much as facts.`
+
 // CompactionPrompt returns the fully interpolated prompt for conversation
 // compaction. The caller passes the formatted conversation text (role: content
-// pairs) to be summarized.
-func CompactionPrompt(conversationText string) string {
-	return fmt.Sprintf(compactionTemplate, conversationText)
+// pairs) to be summarized. An optional working memory string, if non-empty,
+// is appended so the summarizer preserves experiential context.
+func CompactionPrompt(conversationText string, workingMemory string) string {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf(compactionTemplate, conversationText))
+	if workingMemory != "" {
+		sb.WriteString(fmt.Sprintf(workingMemorySection, workingMemory))
+	}
+	return sb.String()
 }

--- a/internal/tools/working_memory_tools.go
+++ b/internal/tools/working_memory_tools.go
@@ -1,0 +1,67 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/nugget/thane-ai-agent/internal/memory"
+)
+
+// SetWorkingMemoryStore adds the session_working_memory tool to the registry.
+// This tool allows the agent to read and write free-form experiential notes
+// for the current conversation, capturing texture that mechanical compaction
+// destroys.
+func (r *Registry) SetWorkingMemoryStore(store *memory.WorkingMemoryStore) {
+	r.Register(&Tool{
+		Name: "session_working_memory",
+		Description: "Read or write your working memory for this conversation. " +
+			"Working memory is your private scratchpad for experiential context: " +
+			"emotional tone, conversational arc, relationship dynamics, and unresolved threads. " +
+			"It persists across compaction and is auto-injected into your context each turn. " +
+			"Use 'read' to see current contents, 'write' to replace entirely.",
+		Parameters: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"action": map[string]any{
+					"type":        "string",
+					"enum":        []string{"read", "write"},
+					"description": "Action to perform: 'read' returns current working memory, 'write' replaces it entirely",
+				},
+				"content": map[string]any{
+					"type":        "string",
+					"description": "New working memory content (required for 'write'). Write in first person as notes to your future self.",
+				},
+			},
+			"required": []string{"action"},
+		},
+		Handler: func(ctx context.Context, args map[string]any) (string, error) {
+			action, _ := args["action"].(string)
+			convID := ConversationIDFromContext(ctx)
+
+			switch action {
+			case "read":
+				content, updatedAt, err := store.Get(convID)
+				if err != nil {
+					return "", fmt.Errorf("read working memory: %w", err)
+				}
+				if content == "" {
+					return "(no working memory for this conversation)", nil
+				}
+				return fmt.Sprintf("Last updated: %s\n\n%s", updatedAt.Format("2006-01-02 15:04:05"), content), nil
+
+			case "write":
+				content, _ := args["content"].(string)
+				if content == "" {
+					return "", fmt.Errorf("content is required for write action")
+				}
+				if err := store.Set(convID, content); err != nil {
+					return "", fmt.Errorf("write working memory: %w", err)
+				}
+				return "Working memory updated.", nil
+
+			default:
+				return "", fmt.Errorf("unknown action %q: expected 'read' or 'write'", action)
+			}
+		},
+	})
+}

--- a/talents/working-memory.md
+++ b/talents/working-memory.md
@@ -1,0 +1,37 @@
+# Working Memory
+
+Your `session_working_memory` tool is a private scratchpad for experiential context — the texture that mechanical compaction destroys.
+
+## What to capture
+
+- **Emotional tone**: Is the user frustrated, excited, relaxed? How has the mood shifted?
+- **Conversational arc**: What's the throughline? Where are we headed?
+- **Relationship dynamics**: Trust level, communication style, inside references
+- **Unresolved threads**: Questions deferred, topics promised for later, loose ends
+- **Your own uncertainty**: What you're unsure about, hypotheses you're testing
+
+## When to write
+
+- After a meaningful shift in tone or direction
+- When you notice something you'd lose to compaction (emotional context, subtle cues)
+- Before the conversation is likely to be compacted (long sessions, high message count)
+- When you form a hypothesis about what the user needs or expects
+- After resolving something previously uncertain — update your notes
+
+## When not to write
+
+- Don't write after every turn — be selective
+- Don't duplicate facts that belong in `remember_fact`
+- Don't narrate tool calls or mechanical details the summary will capture
+
+## Style
+
+Write in first person, as notes to your future self. Be concise but preserve nuance. This isn't a transcript — it's your subjective read on the conversation.
+
+**Good**: "Dan seems stressed about the deployment timeline. He's being terse but not irritated — more like focused urgency. The episodic memory PR matters to him personally, not just as a feature."
+
+**Bad**: "User asked about episodic memory. I provided information about the PR. User asked follow-up questions."
+
+## Working memory is auto-injected
+
+You don't need to read it — it's included in your context every turn. Just write to it when something worth preserving comes up.


### PR DESCRIPTION
## Summary

Implements session working memory (issue #120) — a private scratchpad for experiential context that survives compaction. Post-compaction, the agent retains facts but loses texture: emotional tone, conversational arc, relationship dynamics. Working memory preserves what mechanical summarisation destroys.

- **WorkingMemoryStore**: SQLite table (`working_memory`) in archive.db with CRUD operations and auto-migration
- **`session_working_memory` tool**: read/write actions scoped to conversation via context
- **WorkingMemoryProvider**: auto-injects working memory into the system prompt each turn
- **Compaction integration**: working memory is included in the compaction prompt so the LLM summarizer preserves experiential context
- **Talent file**: behavioral guidance teaching the agent when and how to use working memory
- **Context enrichment**: `loop.go` now passes conversation ID to `buildSystemPrompt` so context providers can scope their output

## Test plan

- [x] `just ci` passes (fmt, lint, test with `-race`)
- [x] Store unit tests: Get (empty), Set+Get, Upsert, MultiConversation, Delete, DeleteNonexistent
- [x] Provider unit tests: Empty, WithContent, ConversationScoped
- [x] Existing compaction tests pass with updated `Summarizer` interface
- [x] `just build` succeeds

Closes #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)