### PR TITLE
fix: nudge model when tool calls produce empty response

### DIFF
--- a/internal/agent/empty_response_test.go
+++ b/internal/agent/empty_response_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/nugget/thane-ai-agent/internal/llm"
+	"github.com/nugget/thane-ai-agent/internal/prompts"
 )
 
 func TestEmptyResponse_NudgeRecovery(t *testing.T) {
@@ -67,7 +68,7 @@ func TestEmptyResponse_NudgeRecovery(t *testing.T) {
 	lastCall := mock.calls[2]
 	nudgeFound := false
 	for _, msg := range lastCall.Messages {
-		if msg.Role == "user" && msg.Content == "You executed tool calls but did not provide a response to the user. Please respond now." {
+		if msg.Role == "user" && msg.Content == prompts.EmptyResponseNudge {
 			nudgeFound = true
 			break
 		}
@@ -138,9 +139,8 @@ func TestEmptyResponse_FallbackAfterNudge(t *testing.T) {
 	}
 
 	// Response should be the fallback message.
-	want := "I processed your request but wasn't able to compose a response. Please try again."
-	if resp.Content != want {
-		t.Errorf("response content = %q, want %q", resp.Content, want)
+	if resp.Content != prompts.EmptyResponseFallback {
+		t.Errorf("response content = %q, want %q", resp.Content, prompts.EmptyResponseFallback)
 	}
 }
 

--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -753,7 +753,7 @@ iterLoop:
 				)
 				llmMessages = append(llmMessages, llm.Message{
 					Role:    "user",
-					Content: "You executed tool calls but did not provide a response to the user. Please respond now.",
+					Content: prompts.EmptyResponseNudge,
 				})
 				emptyRetried = true
 				continue
@@ -763,7 +763,7 @@ iterLoop:
 				"input_tokens", totalInputTokens,
 				"output_tokens", totalOutputTokens,
 			)
-			llmResp.Message.Content = "I processed your request but wasn't able to compose a response. Please try again."
+			llmResp.Message.Content = prompts.EmptyResponseFallback
 		}
 
 		resp := &Response{
@@ -871,7 +871,7 @@ iterLoop:
 				"input_tokens", totalInputTokens,
 				"output_tokens", totalOutputTokens,
 			)
-			content = "I processed your request but wasn't able to compose a response. Please try again."
+			content = prompts.EmptyResponseFallback
 		}
 
 		resp := &Response{

--- a/internal/prompts/agent.go
+++ b/internal/prompts/agent.go
@@ -1,0 +1,11 @@
+package prompts
+
+// EmptyResponseNudge is the prompt injected when the model returns no
+// content after executing tool calls. It gives the model one more
+// chance to produce a user-visible response.
+const EmptyResponseNudge = "You executed tool calls but did not provide a response to the user. Please respond now."
+
+// EmptyResponseFallback is the user-facing message returned when the
+// model fails to produce content even after being nudged (or during
+// max-iterations recovery).
+const EmptyResponseFallback = "I processed your request but wasn't able to compose a response. Please try again."


### PR DESCRIPTION
## Summary

- When the LLM spends iterations on tool calls then returns empty content (just stop tokens, no text), the agent loop now injects a nudge message ("You executed tool calls but did not provide a response to the user. Please respond now.") and retries once.
- If the retry also produces empty content, a fallback message is returned instead of silence.
- Same empty-content guard applied to the max-iterations recovery path.

Closes #167

### Changes

- `internal/agent/loop.go` — empty-content detection after tool-call iterations with single retry via nudge; fallback on second empty; exhaustion path guard
- `internal/agent/empty_response_test.go` — three tests: nudge recovery, fallback after nudge, first-iteration empty not nudged

## Test plan

- [x] `just ci` passes (fmt, lint, tests with `-race`)
- [ ] Manual: observe logs for `"empty response after tool calls, nudging model"` when the scenario occurs in production