### PR TITLE
fix: flaky TestFindConfig_SearchPath on machines with ~/Thane/config.yaml

### DIFF
--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -29,12 +29,15 @@ func TestFindConfig_ExplicitMissing(t *testing.T) {
 }
 
 func TestFindConfig_SearchPath(t *testing.T) {
-	// When no config exists anywhere, should error
-	// (Save and restore CWD to avoid finding the repo's config.yaml)
+	// When no config exists anywhere, should error.
+	// Override both CWD and HOME so DefaultSearchPaths won't find
+	// a real ~/Thane/config.yaml on developer machines.
 	dir := t.TempDir()
 	orig, _ := os.Getwd()
 	os.Chdir(dir)
 	defer os.Chdir(orig)
+
+	t.Setenv("HOME", dir)
 
 	_, err := FindConfig("")
 	if err == nil {


### PR DESCRIPTION
## Problem

`TestFindConfig_SearchPath` always fails on pocket (and any machine with `~/Thane/config.yaml`) because it only overrides CWD, not HOME. `DefaultSearchPaths()` finds the real config via `os.UserHomeDir()`.

## Fix

Add `t.Setenv("HOME", dir)` so the search path resolves into the temp directory. `t.Setenv` automatically restores the original value after the test.

## Testing

This has been failing on every `just ci` run on pocket. One-line fix.