### PR TITLE
fix: flaky TestFindConfig_SearchPath finds /usr/local/etc/thane/config.yaml

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -39,6 +39,11 @@ import (
 //   - /config/config.yaml (container convention)
 //   - /usr/local/etc/thane/config.yaml (macOS/BSD local sysconfig)
 //   - /etc/thane/config.yaml (system-wide)
+
+// searchPathsFunc is the function used to generate search paths.
+// Overridden in tests to avoid finding real config files on the host.
+var searchPathsFunc = DefaultSearchPaths
+
 func DefaultSearchPaths() []string {
 	paths := []string{"config.yaml"}
 
@@ -65,7 +70,7 @@ func FindConfig(explicit string) (string, error) {
 		return explicit, nil
 	}
 
-	for _, p := range DefaultSearchPaths() {
+	for _, p := range searchPathsFunc() {
 		if _, err := os.Stat(p); err == nil {
 			return p, nil
 		}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -30,14 +30,15 @@ func TestFindConfig_ExplicitMissing(t *testing.T) {
 
 func TestFindConfig_SearchPath(t *testing.T) {
 	// When no config exists anywhere, should error.
-	// Override both CWD and HOME so DefaultSearchPaths won't find
-	// a real ~/Thane/config.yaml on developer machines.
+	// Override searchPathsFunc to avoid finding real config files
+	// on developer/deploy machines (~/Thane/config.yaml,
+	// /usr/local/etc/thane/config.yaml, etc.).
 	dir := t.TempDir()
-	orig, _ := os.Getwd()
-	os.Chdir(dir)
-	defer os.Chdir(orig)
-
-	t.Setenv("HOME", dir)
+	orig := searchPathsFunc
+	searchPathsFunc = func() []string {
+		return []string{filepath.Join(dir, "config.yaml")}
+	}
+	defer func() { searchPathsFunc = orig }()
 
 	_, err := FindConfig("")
 	if err == nil {


### PR DESCRIPTION
Supersedes #180.

## Problem

The HOME override from #180 was not sufficient — `DefaultSearchPaths()` also includes absolute system paths (`/usr/local/etc/thane/config.yaml`) that exist on pocket. The test still fails.

## Fix

Make the search path function injectable via a package-level `searchPathsFunc` variable. Tests override it to return only temp dir paths, completely isolating from the host filesystem.

`FindConfig` now calls `searchPathsFunc()` instead of `DefaultSearchPaths()` directly. The default value is `DefaultSearchPaths`, so behavior is unchanged for non-test code.

## Verification

Needs to pass on pocket where `/usr/local/etc/thane/config.yaml` exists.