### PR TITLE
fix: add timestamps and temporal framing to episodic history

### DIFF
--- a/internal/episodic/provider.go
+++ b/internal/episodic/provider.go
@@ -17,6 +17,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/nugget/thane-ai-agent/internal/memory"
+	"github.com/nugget/thane-ai-agent/internal/prompts"
 )
 
 // ArchiveReader is the subset of [memory.ArchiveStore] needed by the
@@ -177,7 +178,8 @@ func (p *Provider) getRecentHistory() string {
 		return ""
 	}
 
-	budget := p.historyTokens
+	framing := prompts.EpisodicHistoryFraming() + "\n\n"
+	budget := p.historyTokens - estimateTokens(framing)
 	var entries []string
 
 	for i, sess := range sessions {
@@ -230,7 +232,7 @@ func (p *Provider) getRecentHistory() string {
 	}
 
 	var sb strings.Builder
-	sb.WriteString("⚠️ **ARCHIVED HISTORY** — The messages below are from PAST sessions, NOT the current conversation. Timestamps and time references within these messages reflect when they were originally said, not the current time. Current time is in the \"Current Conditions\" block above.\n\n")
+	sb.WriteString(framing)
 	for _, e := range entries {
 		sb.WriteString(e)
 		if !strings.HasSuffix(e, "\n") {

--- a/internal/episodic/provider_test.go
+++ b/internal/episodic/provider_test.go
@@ -648,9 +648,10 @@ func TestSessionHeaderRFC3339(t *testing.T) {
 
 	got := p.getRecentHistory()
 
-	// Session header should use RFC3339 format, not "Jan 2 15:04".
-	if !strings.Contains(got, "2026-02-15T21:04:00-06:00") {
-		t.Errorf("expected RFC3339 in session header, got:\n%s", got)
+	// Match the full header pattern so message timestamps alone can't
+	// satisfy this assertion.
+	if !strings.Contains(got, "**[2026-02-15T21:04:00-06:00 — RFC3339 header test]**") {
+		t.Errorf("expected RFC3339-formatted session header, got:\n%s", got)
 	}
 	// Should NOT contain old-style "Feb 15 21:04".
 	if strings.Contains(got, "Feb 15 21:04") {

--- a/internal/prompts/episodic.go
+++ b/internal/prompts/episodic.go
@@ -1,0 +1,11 @@
+package prompts
+
+// EpisodicHistoryFraming returns the framing text prepended to archived
+// conversation history. It warns the model that timestamps and time
+// references are historical, not current.
+func EpisodicHistoryFraming() string {
+	return "⚠️ **ARCHIVED HISTORY** — The messages below are from PAST sessions, " +
+		"NOT the current conversation. Timestamps and time references within " +
+		"these messages reflect when they were originally said, not the current " +
+		"time. Current time is in the \"Current Conditions\" block above."
+}


### PR DESCRIPTION
## Summary

- Adds RFC3339 timestamps to each transcript message line in episodic history, using the existing `ArchivedMessage.Timestamp` field that was previously unused in formatting
- Replaces the soft "active session" preamble with an explicit ⚠️ **ARCHIVED HISTORY** temporal boundary warning that tells the model these are past sessions and time references are historical
- Changes session header timestamps from human format (`Feb 15 21:04`) to ISO 8601 (`2026-02-15T21:04:00-06:00`) for consistency and machine readability

Closes #189

## Test plan

- [x] `TestMessageTimestamps` — verifies RFC3339 timestamps appear on user and assistant message lines with correct timezone
- [x] `TestSessionHeaderRFC3339` — verifies session headers use RFC3339 format and do not contain old-style format
- [x] `TestGetContext_HistoryOnly` — updated to check for new "ARCHIVED HISTORY" framing instead of "active session"
- [x] `just ci` passes (fmt, lint, race tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)