### PR TITLE
feat: dump assembled system prompt to disk for debugging

### DIFF
--- a/cmd/thane/main.go
+++ b/cmd/thane/main.go
@@ -675,6 +675,7 @@ func runServe(ctx context.Context, stdout io.Writer, stderr io.Writer, configPat
 
 	loop = agent.NewLoop(logger, mem, compactor, rtr, ha, sched, llmClient, cfg.Models.Default, talentContent, personaContent, defaultContextWindow)
 	loop.SetTimezone(cfg.Timezone)
+	loop.SetDebugConfig(cfg.Debug)
 	loop.SetArchiver(archiveAdapter)
 
 	// --- Static context injection ---

--- a/examples/config.example.yaml
+++ b/examples/config.example.yaml
@@ -176,6 +176,14 @@ embeddings:
 # archive:
 #   metadata_model: qwen2.5-coder:32b  # Defaults to models.default
 
+# Debug options — diagnostic tools for system prompt visibility.
+# When dump_system_prompt is true, the fully assembled system prompt is
+# written to {dump_dir}/system-prompt-latest.txt on every LLM call,
+# with section markers and character counts per section.
+# debug:
+#   dump_system_prompt: true
+#   dump_dir: ./debug          # default
+
 # Logging level: trace, debug, info (default), warn, error
 # - info: normal operation (loop start/end, failover, compaction)
 # - debug: per-request detail (LLM calls, tool execution, token counts)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -161,6 +161,10 @@ type Config struct {
 	// room-level presence detection via wireless AP client associations.
 	Unifi UnifiConfig `yaml:"unifi"`
 
+	// Debug configures diagnostic options for inspecting the assembled
+	// system prompt and other internal state.
+	Debug DebugConfig `yaml:"debug"`
+
 	// Timezone is the IANA timezone for the household (e.g.,
 	// "America/Chicago"). Used in the Current Conditions system prompt
 	// section so the agent reasons about local time. If empty, the
@@ -510,6 +514,20 @@ func (c UnifiConfig) Configured() bool {
 	return c.URL != "" && c.APIKey != ""
 }
 
+// DebugConfig configures diagnostic options for inspecting the
+// assembled system prompt and other internal state.
+type DebugConfig struct {
+	// DumpSystemPrompt enables writing the fully assembled system
+	// prompt to disk on every LLM call, with section markers and
+	// size annotations. The file is overwritten each call so it
+	// always reflects the most recent prompt.
+	DumpSystemPrompt bool `yaml:"dump_system_prompt"`
+
+	// DumpDir is the directory where debug output files are written.
+	// Created automatically on first write. Default: "./debug".
+	DumpDir string `yaml:"dump_dir"`
+}
+
 // ShellExecConfig configures the agent's ability to execute shell
 // commands on the host. Disabled by default for safety. When enabled,
 // commands are filtered through allow and deny lists before execution.
@@ -679,6 +697,10 @@ func (c *Config) applyDefaults() {
 	}
 	if c.Episodic.SessionGapMinutes == 0 {
 		c.Episodic.SessionGapMinutes = 30
+	}
+
+	if c.Debug.DumpSystemPrompt && c.Debug.DumpDir == "" {
+		c.Debug.DumpDir = "./debug"
 	}
 
 	if c.Agent.DelegationRequired && len(c.Agent.Iter0Tools) == 0 {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -209,6 +209,39 @@ func TestApplyDefaults_UnifiPollInterval(t *testing.T) {
 	}
 }
 
+func TestApplyDefaults_DebugDumpDir(t *testing.T) {
+	t.Run("sets default when dump enabled", func(t *testing.T) {
+		cfg := Default()
+		cfg.Debug.DumpSystemPrompt = true
+		cfg.applyDefaults()
+
+		if cfg.Debug.DumpDir != "./debug" {
+			t.Errorf("expected default dump_dir './debug', got %q", cfg.Debug.DumpDir)
+		}
+	})
+
+	t.Run("leaves empty when dump disabled", func(t *testing.T) {
+		cfg := Default()
+		cfg.Debug.DumpSystemPrompt = false
+		cfg.applyDefaults()
+
+		if cfg.Debug.DumpDir != "" {
+			t.Errorf("expected empty dump_dir when dump disabled, got %q", cfg.Debug.DumpDir)
+		}
+	})
+
+	t.Run("preserves custom dir", func(t *testing.T) {
+		cfg := Default()
+		cfg.Debug.DumpSystemPrompt = true
+		cfg.Debug.DumpDir = "/tmp/thane-debug"
+		cfg.applyDefaults()
+
+		if cfg.Debug.DumpDir != "/tmp/thane-debug" {
+			t.Errorf("expected custom dump_dir preserved, got %q", cfg.Debug.DumpDir)
+		}
+	})
+}
+
 func TestValidate_PersonDevicesValid(t *testing.T) {
 	cfg := Default()
 	cfg.Person.Track = []string{"person.alice"}


### PR DESCRIPTION
## Summary

- Adds `debug.dump_system_prompt` config option that writes the fully assembled system prompt to `{dump_dir}/system-prompt-latest.txt` on every LLM call
- Output includes section markers with character counts (`=== PERSONA (2,274 chars) ===`) for all 5 prompt sections plus a total
- Section sizes are also logged at INFO level when dump is enabled
- Default dump directory is `./debug`, created lazily on first write

Closes #188

## Test plan

- [x] `TestApplyDefaults_DebugDumpDir` — verifies default dir set when enabled, empty when disabled, custom dir preserved
- [x] `just ci` passes (fmt, lint, race tests)
- [ ] Manual: set `debug.dump_system_prompt: true` in config, send a message, verify `./debug/system-prompt-latest.txt` written with section markers

🤖 Generated with [Claude Code](https://claude.com/claude-code)