### PR TITLE
fix: suppress no-change state_changed events in WakeBridge

### DIFF
--- a/cmd/thane/wakebridge.go
+++ b/cmd/thane/wakebridge.go
@@ -83,6 +83,13 @@ const cleanupInterval = 10 * time.Minute
 // for system prompt injection, queries the anticipation store for
 // matches, and fires async agent runs for each match not on cooldown.
 func (b *WakeBridge) HandleStateChange(entityID, oldState, newState string) {
+	// HA fires state_changed on attribute updates even when the state
+	// itself hasn't changed. Skip these to avoid log noise and
+	// unnecessary anticipation matching.
+	if oldState == newState {
+		return
+	}
+
 	// Periodically evict stale cooldown entries to prevent unbounded map growth.
 	b.maybeCleanup()
 


### PR DESCRIPTION
## Summary

- Adds early return in `WakeBridge.HandleStateChange` when `oldState == newState`, skipping logging, provider updates, and anticipation matching entirely
- Eliminates log noise from HA attribute-only `state_changed` events (GPS accuracy changes, WiFi updates, etc.) that don't represent actual state transitions

Closes #194

## Test plan

- [x] `TestWakeBridge_SameStateSuppressed` — verifies runner is not called and provider is not updated when old and new state are identical
- [x] Existing tests pass (match triggers, cooldown, error handling, multiple matches)
- [x] `just ci` passes (fmt, lint, race tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)