### PR TITLE
fix: raise anticipation wake quality floor from 1 to 5

### DIFF
--- a/cmd/thane/wakebridge.go
+++ b/cmd/thane/wakebridge.go
@@ -162,7 +162,7 @@ func (b *WakeBridge) runWake(anticipationID, description, message string) {
 			"source":                "anticipation",
 			"anticipation_id":       anticipationID,
 			router.HintLocalOnly:    "true",
-			router.HintQualityFloor: "1",
+			router.HintQualityFloor: "5",
 			router.HintMission:      "anticipation",
 		},
 	}

--- a/cmd/thane/wakebridge_test.go
+++ b/cmd/thane/wakebridge_test.go
@@ -101,8 +101,8 @@ func TestWakeBridge_MatchTriggersRun(t *testing.T) {
 		if req.Hints[router.HintLocalOnly] != "true" {
 			t.Errorf("hint local_only = %q, want %q", req.Hints[router.HintLocalOnly], "true")
 		}
-		if req.Hints[router.HintQualityFloor] != "1" {
-			t.Errorf("hint quality_floor = %q, want %q", req.Hints[router.HintQualityFloor], "1")
+		if req.Hints[router.HintQualityFloor] != "5" {
+			t.Errorf("hint quality_floor = %q, want %q", req.Hints[router.HintQualityFloor], "5")
 		}
 		if req.Hints[router.HintMission] != "anticipation" {
 			t.Errorf("hint mission = %q, want %q", req.Hints[router.HintMission], "anticipation")


### PR DESCRIPTION
## Summary

- Raise `quality_floor` routing hint from `"1"` to `"5"` for anticipation wakes
- Steers the router toward models with enough capacity for nuanced anticipation responses (deciding who triggered an event, whether to notify, what context matters)
- Previously the router could pick a 20b model that produced mechanical responses

Closes #197

## Test plan

- [x] Updated `TestWakeBridge_MatchTriggersRun` assertion to expect `"5"`
- [x] `just ci` passes (lint clean, all tests with `-race`)