### PR TITLE
fix: skip episodic sessions with no summary or title

### DIFF
--- a/internal/episodic/provider.go
+++ b/internal/episodic/provider.go
@@ -379,7 +379,7 @@ func sessionHasContent(sess *memory.Session) bool {
 		return true
 	}
 	if sess.Metadata != nil {
-		if sess.Metadata.OneLiner != "" || sess.Metadata.Paragraph != "" {
+		if sess.Metadata.OneLiner != "" || sess.Metadata.Paragraph != "" || sess.Metadata.Detailed != "" {
 			return true
 		}
 	}

--- a/internal/episodic/provider_test.go
+++ b/internal/episodic/provider_test.go
@@ -474,6 +474,7 @@ func TestSessionHasContent(t *testing.T) {
 		{"summary only", &memory.Session{Summary: "A summary"}, true},
 		{"metadata oneliner", &memory.Session{Metadata: &memory.SessionMetadata{OneLiner: "short"}}, true},
 		{"metadata paragraph", &memory.Session{Metadata: &memory.SessionMetadata{Paragraph: "long"}}, true},
+		{"metadata detailed", &memory.Session{Metadata: &memory.SessionMetadata{Detailed: "full detail"}}, true},
 		{"empty metadata", &memory.Session{Metadata: &memory.SessionMetadata{}}, false},
 		{"nil metadata", &memory.Session{}, false},
 		{"completely empty", &memory.Session{}, false},


### PR DESCRIPTION
## Summary

- Add `sessionHasContent()` predicate that checks for title, summary, or metadata summaries
- Skip sessions with no useful content in the episodic history loop, eliminating noisy `(no summary)` one-liners from delegate sessions
- Use formatted-count index for tier selection so skipped sessions don't shift tier assignments
- Track previously emitted session for gap detection instead of raw loop index

Closes #200

## Test plan

- [x] `TestNoMetadata` updated — empty session now produces no output instead of a transcript excerpt
- [x] `TestEmptySessionsSkipped` — mixed sessions with some empty delegates, verifies only sessions with content appear
- [x] `TestSessionHasContent` — table-driven tests for the predicate (title, summary, metadata.OneLiner, metadata.Paragraph, empty cases)
- [x] All existing episodic tests pass unchanged
- [x] `just ci` passes (lint clean, all tests with `-race`)