### PR TITLE
fix: add object_id and has_entity_name to MQTT sensor discovery

### DIFF
--- a/internal/mqtt/device.go
+++ b/internal/mqtt/device.go
@@ -19,6 +19,8 @@ type DeviceInfo struct {
 // broker (re-)connect.
 type SensorConfig struct {
 	Name              string     `json:"name"`
+	ObjectID          string     `json:"object_id,omitempty"`
+	HasEntityName     bool       `json:"has_entity_name,omitempty"`
 	UniqueID          string     `json:"unique_id"`
 	StateTopic        string     `json:"state_topic"`
 	AvailabilityTopic string     `json:"availability_topic"`

--- a/internal/mqtt/publisher.go
+++ b/internal/mqtt/publisher.go
@@ -221,6 +221,8 @@ func (p *Publisher) sensorDefinitions() []sensorDef {
 			entitySuffix: "uptime",
 			config: SensorConfig{
 				Name:              "Uptime",
+				ObjectID:          "uptime",
+				HasEntityName:     true,
 				UniqueID:          p.instanceID + "_uptime",
 				StateTopic:        p.stateTopic("uptime"),
 				AvailabilityTopic: avail,
@@ -233,6 +235,8 @@ func (p *Publisher) sensorDefinitions() []sensorDef {
 			entitySuffix: "version",
 			config: SensorConfig{
 				Name:              "Version",
+				ObjectID:          "version",
+				HasEntityName:     true,
 				UniqueID:          p.instanceID + "_version",
 				StateTopic:        p.stateTopic("version"),
 				AvailabilityTopic: avail,
@@ -245,6 +249,8 @@ func (p *Publisher) sensorDefinitions() []sensorDef {
 			entitySuffix: "tokens_today",
 			config: SensorConfig{
 				Name:              "Tokens Today",
+				ObjectID:          "tokens_today",
+				HasEntityName:     true,
 				UniqueID:          p.instanceID + "_tokens_today",
 				StateTopic:        p.stateTopic("tokens_today"),
 				AvailabilityTopic: avail,
@@ -258,6 +264,8 @@ func (p *Publisher) sensorDefinitions() []sensorDef {
 			entitySuffix: "last_request",
 			config: SensorConfig{
 				Name:              "Last Request",
+				ObjectID:          "last_request",
+				HasEntityName:     true,
 				UniqueID:          p.instanceID + "_last_request",
 				StateTopic:        p.stateTopic("last_request"),
 				AvailabilityTopic: avail,
@@ -270,6 +278,8 @@ func (p *Publisher) sensorDefinitions() []sensorDef {
 			entitySuffix: "default_model",
 			config: SensorConfig{
 				Name:              "Default Model",
+				ObjectID:          "default_model",
+				HasEntityName:     true,
 				UniqueID:          p.instanceID + "_default_model",
 				StateTopic:        p.stateTopic("default_model"),
 				AvailabilityTopic: avail,

--- a/internal/mqtt/publisher_test.go
+++ b/internal/mqtt/publisher_test.go
@@ -170,6 +170,19 @@ func TestPublisher_SensorDefinitions(t *testing.T) {
 				d.entitySuffix, d.config.UniqueID, "instance-123_")
 		}
 
+		// ObjectID must match entitySuffix so HA derives clean entity IDs.
+		if d.config.ObjectID != d.entitySuffix {
+			t.Errorf("sensor %s: ObjectID = %q, want %q",
+				d.entitySuffix, d.config.ObjectID, d.entitySuffix)
+		}
+
+		// HasEntityName must be true so HA treats the sensor Name as
+		// relative to the device name (avoids double-prefix #207).
+		if !d.config.HasEntityName {
+			t.Errorf("sensor %s: HasEntityName = false, want true",
+				d.entitySuffix)
+		}
+
 		// Every sensor should reference the device.
 		if len(d.config.Device.Identifiers) == 0 {
 			t.Errorf("sensor %s: Device.Identifiers is empty", d.entitySuffix)


### PR DESCRIPTION
## Summary
- Add `ObjectID` and `HasEntityName` fields to `SensorConfig` struct
- Set `ObjectID` (matching entity suffix) and `HasEntityName: true` on all five sensor definitions
- HA now derives entity IDs from device name + object_id, eliminating the double-prefix stutter (e.g., `sensor.aimee_thane_aimee_thane_uptime` → `sensor.aimee_thane_uptime`)

## Test plan
- [x] Existing `TestPublisher_SensorDefinitions` passes
- [x] New assertions verify `ObjectID` matches `entitySuffix` and `HasEntityName` is `true` for all sensors
- [x] `just ci` passes clean

Closes #207