### PR TITLE
feat: add send_message tool for proactive notifications

### DIFF
--- a/cmd/thane/main.go
+++ b/cmd/thane/main.go
@@ -835,6 +835,14 @@ func runServe(ctx context.Context, stdout io.Writer, stderr io.Writer, configPat
 	// extracts readable text content.
 	loop.Tools().SetFetcher(fetch.New())
 
+	// --- Notifications ---
+	// When configured, gives the agent the ability to proactively send
+	// messages to the user via a Home Assistant notification service.
+	if cfg.Notifications.Service != "" {
+		loop.Tools().SetNotificationConfig(cfg.Notifications.Service, cfg.Notifications.Title)
+		logger.Info("send_message tool enabled", "service", cfg.Notifications.Service)
+	}
+
 	// --- Archive tools ---
 	// Gives the agent the ability to search and recall past conversations.
 	loop.Tools().SetArchiveStore(archiveStore)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -151,6 +151,11 @@ type Config struct {
 	// set, Thane connects to the broker and registers as an HA device.
 	MQTT MQTTConfig `yaml:"mqtt"`
 
+	// Notifications configures the send_message tool's delivery target.
+	// When Service is set, the agent can proactively send notifications
+	// via a Home Assistant service (e.g., notify/mobile_app_nugget).
+	Notifications NotificationConfig `yaml:"notifications"`
+
 	// Person configures household member presence tracking. When Track
 	// contains entity IDs, the agent receives a "People & Presence"
 	// section in its system prompt on every wake, eliminating tool
@@ -473,6 +478,20 @@ func (c MQTTConfig) Configured() bool {
 	return c.Broker != "" && c.DeviceName != ""
 }
 
+// NotificationConfig configures the send_message tool's delivery
+// target. When Service is set, the agent can proactively send
+// notifications via a Home Assistant service call.
+type NotificationConfig struct {
+	// Service is the HA service target in "domain/service" format
+	// (e.g., "notify/mobile_app_nugget", "persistent_notification/create").
+	// When empty, the send_message tool is not registered.
+	Service string `yaml:"service"`
+
+	// Title is the default notification title. Can be overridden per
+	// send_message call. Default: "Thane".
+	Title string `yaml:"title"`
+}
+
 // PersonConfig configures household member presence tracking. When
 // Track contains entity IDs, the person tracker maintains in-memory
 // state from Home Assistant and injects a presence summary into the
@@ -698,6 +717,10 @@ func (c *Config) applyDefaults() {
 	}
 	if c.MQTT.PublishIntervalSec == 0 {
 		c.MQTT.PublishIntervalSec = 60
+	}
+
+	if c.Notifications.Title == "" {
+		c.Notifications.Title = "Thane"
 	}
 
 	if c.Unifi.PollIntervalSec == 0 {

--- a/internal/tools/send_message_test.go
+++ b/internal/tools/send_message_test.go
@@ -1,0 +1,149 @@
+package tools
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/nugget/thane-ai-agent/internal/homeassistant"
+)
+
+func TestHandleSendMessage(t *testing.T) {
+	// Fake HA server that accepts any service call.
+	var lastPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		lastPath = r.URL.Path
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	ha := homeassistant.NewClient(srv.URL, "test-token", slog.Default())
+
+	tests := []struct {
+		name         string
+		service      string
+		title        string
+		ha           *homeassistant.Client
+		args         map[string]any
+		wantErr      string
+		wantContains string
+		wantHAPath   string
+	}{
+		{
+			name:    "unconfigured service",
+			service: "",
+			ha:      ha,
+			args:    map[string]any{"message": "hello"},
+			wantErr: "not configured",
+		},
+		{
+			name:    "no HA client",
+			service: "notify/mobile_app_test",
+			ha:      nil,
+			args:    map[string]any{"message": "hello"},
+			wantErr: "requires Home Assistant",
+		},
+		{
+			name:    "missing message",
+			service: "notify/mobile_app_test",
+			ha:      ha,
+			args:    map[string]any{},
+			wantErr: "message is required",
+		},
+		{
+			name:    "invalid service format",
+			service: "bad-format",
+			ha:      ha,
+			args:    map[string]any{"message": "hello"},
+			wantErr: "invalid notification service format",
+		},
+		{
+			name:         "notify service success",
+			service:      "notify/mobile_app_test",
+			title:        "Thane",
+			ha:           ha,
+			args:         map[string]any{"message": "Garage door open"},
+			wantContains: "Notification sent via notify/mobile_app_test",
+			wantHAPath:   "/api/services/notify/mobile_app_test",
+		},
+		{
+			name:         "custom title override",
+			service:      "notify/mobile_app_test",
+			title:        "Default Title",
+			ha:           ha,
+			args:         map[string]any{"message": "Alert!", "title": "Custom"},
+			wantContains: "Notification sent",
+			wantHAPath:   "/api/services/notify/mobile_app_test",
+		},
+		{
+			name:         "persistent notification",
+			service:      "persistent_notification/create",
+			title:        "Thane",
+			ha:           ha,
+			args:         map[string]any{"message": "Reminder"},
+			wantContains: "Notification sent via persistent_notification/create",
+			wantHAPath:   "/api/services/persistent_notification/create",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lastPath = ""
+			r := &Registry{
+				tools:         make(map[string]*Tool),
+				ha:            tt.ha,
+				notifyService: tt.service,
+				notifyTitle:   tt.title,
+			}
+
+			result, err := r.handleSendMessage(context.Background(), tt.args)
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tt.wantErr)
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Errorf("error = %q, want to contain %q", err.Error(), tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tt.wantContains != "" && !strings.Contains(result, tt.wantContains) {
+				t.Errorf("result = %q, want to contain %q", result, tt.wantContains)
+			}
+			if tt.wantHAPath != "" && lastPath != tt.wantHAPath {
+				t.Errorf("HA path = %q, want %q", lastPath, tt.wantHAPath)
+			}
+		})
+	}
+}
+
+func TestSetNotificationConfig_RegistersTool(t *testing.T) {
+	r := NewEmptyRegistry()
+	if r.Get("send_message") != nil {
+		t.Fatal("send_message should not be registered before SetNotificationConfig")
+	}
+
+	r.SetNotificationConfig("notify/test", "Test Title")
+
+	tool := r.Get("send_message")
+	if tool == nil {
+		t.Fatal("send_message should be registered after SetNotificationConfig")
+	}
+	if tool.Name != "send_message" {
+		t.Errorf("tool.Name = %q, want %q", tool.Name, "send_message")
+	}
+}
+
+func TestSetNotificationConfig_EmptyServiceNoRegister(t *testing.T) {
+	r := NewEmptyRegistry()
+	r.SetNotificationConfig("", "Title")
+
+	if r.Get("send_message") != nil {
+		t.Fatal("send_message should not be registered with empty service")
+	}
+}


### PR DESCRIPTION
## Summary

- New `send_message` tool delivers notifications via a configurable Home Assistant service
- Configurable target: `notify/mobile_app_*`, `persistent_notification/create`, `tts/speak`, or any HA notify service
- Only registered when `notifications.service` is set in config (no-op when unconfigured)
- For `persistent_notification` targets, adds timestamp-based `notification_id` to prevent stacking

## Background

Anticipation wakes and scheduled tasks run in isolated sessions with no chat UI attached. When the agent decides something is worth telling the user about (garage door open, timer expired, etc.), there's no way to deliver the message. OWU is pull-based, so push notifications go through Home Assistant's service infrastructure.

## Configuration

```yaml
notifications:
  service: "notify/mobile_app_nugget"
  title: "Thane"           # default title, overridable per call
```

## Tool interface

```
send_message(message: "The garage door has been open for 20 minutes")
send_message(message: "Timer expired", title: "Kitchen")
```

## Test plan

- [x] `just ci` passes (fmt, lint, test with `-race`)
- [x] Table-driven tests: unconfigured error, missing message, bad format, notify success, persistent notification, custom title override
- [x] Registration tests: tool registered only when service is configured

Closes #227.