### PR TITLE
feat: add dynamic entity watchlist for context injection

### DIFF
--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -15,6 +15,7 @@ import (
 	"github.com/nugget/thane-ai-agent/internal/homeassistant"
 	"github.com/nugget/thane-ai-agent/internal/scheduler"
 	"github.com/nugget/thane-ai-agent/internal/search"
+	"github.com/nugget/thane-ai-agent/internal/watchlist"
 )
 
 // Tool represents a callable tool.
@@ -34,6 +35,7 @@ type Registry struct {
 	anticipationTools *anticipation.Tools
 	fileTools         *FileTools
 	shellExec         *ShellExec
+	watchlistStore    *watchlist.Store
 }
 
 // NewEmptyRegistry creates an empty tool registry with no built-in tools.

--- a/internal/tools/watchlist_tools.go
+++ b/internal/tools/watchlist_tools.go
@@ -1,0 +1,86 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/nugget/thane-ai-agent/internal/watchlist"
+)
+
+// SetWatchlistStore adds the add_context_entity and remove_context_entity
+// tools to the registry.
+func (r *Registry) SetWatchlistStore(store *watchlist.Store) {
+	r.watchlistStore = store
+	r.registerWatchlistTools()
+}
+
+func (r *Registry) registerWatchlistTools() {
+	if r.watchlistStore == nil {
+		return
+	}
+
+	r.Register(&Tool{
+		Name: "add_context_entity",
+		Description: "Add a Home Assistant entity to the watched list. " +
+			"Watched entities have their live state injected into your context every turn, " +
+			"eliminating the need for repeated get_state calls. " +
+			"Use this to monitor sensors, doors, batteries, or any entity you want to keep an eye on.",
+		Parameters: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"entity_id": map[string]any{
+					"type":        "string",
+					"description": "The Home Assistant entity ID to watch (e.g., sensor.office_temperature)",
+				},
+			},
+			"required": []string{"entity_id"},
+		},
+		Handler: r.handleAddContextEntity,
+	})
+
+	r.Register(&Tool{
+		Name: "remove_context_entity",
+		Description: "Remove a Home Assistant entity from the watched list. " +
+			"The entity's state will no longer appear in your context each turn.",
+		Parameters: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"entity_id": map[string]any{
+					"type":        "string",
+					"description": "The Home Assistant entity ID to stop watching",
+				},
+			},
+			"required": []string{"entity_id"},
+		},
+		Handler: r.handleRemoveContextEntity,
+	})
+}
+
+func (r *Registry) handleAddContextEntity(_ context.Context, args map[string]any) (string, error) {
+	entityID, _ := args["entity_id"].(string)
+	if entityID == "" {
+		return "", fmt.Errorf("entity_id is required")
+	}
+
+	if err := r.watchlistStore.Add(entityID); err != nil {
+		return "", fmt.Errorf("add to watchlist: %w", err)
+	}
+
+	slog.Info("context entity added", "entity_id", entityID)
+	return fmt.Sprintf("Now watching %s — its state will appear in your context each turn.", entityID), nil
+}
+
+func (r *Registry) handleRemoveContextEntity(_ context.Context, args map[string]any) (string, error) {
+	entityID, _ := args["entity_id"].(string)
+	if entityID == "" {
+		return "", fmt.Errorf("entity_id is required")
+	}
+
+	if err := r.watchlistStore.Remove(entityID); err != nil {
+		return "", fmt.Errorf("remove from watchlist: %w", err)
+	}
+
+	slog.Info("context entity removed", "entity_id", entityID)
+	return fmt.Sprintf("Stopped watching %s.", entityID), nil
+}

--- a/internal/tools/watchlist_tools_test.go
+++ b/internal/tools/watchlist_tools_test.go
@@ -1,0 +1,118 @@
+package tools
+
+import (
+	"context"
+	"database/sql"
+	"strings"
+	"testing"
+
+	"github.com/nugget/thane-ai-agent/internal/watchlist"
+	_ "modernc.org/sqlite"
+)
+
+func setupWatchlistRegistry(t *testing.T) (*Registry, *watchlist.Store) {
+	t.Helper()
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+
+	store, err := watchlist.NewStore(db)
+	if err != nil {
+		t.Fatalf("new store: %v", err)
+	}
+
+	r := NewEmptyRegistry()
+	r.SetWatchlistStore(store)
+	return r, store
+}
+
+func TestSetWatchlistStore_RegistersTools(t *testing.T) {
+	r, _ := setupWatchlistRegistry(t)
+
+	if r.Get("add_context_entity") == nil {
+		t.Error("add_context_entity should be registered")
+	}
+	if r.Get("remove_context_entity") == nil {
+		t.Error("remove_context_entity should be registered")
+	}
+}
+
+func TestAddContextEntity_MissingEntityID(t *testing.T) {
+	r, _ := setupWatchlistRegistry(t)
+
+	_, err := r.handleAddContextEntity(context.Background(), map[string]any{})
+	if err == nil {
+		t.Fatal("expected error for missing entity_id")
+	}
+	if !strings.Contains(err.Error(), "entity_id is required") {
+		t.Errorf("error = %q, want to contain %q", err.Error(), "entity_id is required")
+	}
+}
+
+func TestAddContextEntity_Success(t *testing.T) {
+	r, store := setupWatchlistRegistry(t)
+
+	result, err := r.handleAddContextEntity(context.Background(), map[string]any{
+		"entity_id": "sensor.temperature",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(result, "sensor.temperature") {
+		t.Errorf("result = %q, want to contain entity_id", result)
+	}
+	if !strings.Contains(result, "watching") {
+		t.Errorf("result = %q, want to contain 'watching'", result)
+	}
+
+	// Verify it was actually stored.
+	ids, err := store.List()
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(ids) != 1 || ids[0] != "sensor.temperature" {
+		t.Errorf("store.List() = %v, want [sensor.temperature]", ids)
+	}
+}
+
+func TestRemoveContextEntity_MissingEntityID(t *testing.T) {
+	r, _ := setupWatchlistRegistry(t)
+
+	_, err := r.handleRemoveContextEntity(context.Background(), map[string]any{})
+	if err == nil {
+		t.Fatal("expected error for missing entity_id")
+	}
+	if !strings.Contains(err.Error(), "entity_id is required") {
+		t.Errorf("error = %q, want to contain %q", err.Error(), "entity_id is required")
+	}
+}
+
+func TestRemoveContextEntity_Success(t *testing.T) {
+	r, store := setupWatchlistRegistry(t)
+
+	// Add first, then remove.
+	if err := store.Add("sensor.temperature"); err != nil {
+		t.Fatalf("add: %v", err)
+	}
+
+	result, err := r.handleRemoveContextEntity(context.Background(), map[string]any{
+		"entity_id": "sensor.temperature",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(result, "sensor.temperature") {
+		t.Errorf("result = %q, want to contain entity_id", result)
+	}
+
+	// Verify it was actually removed.
+	ids, err := store.List()
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(ids) != 0 {
+		t.Errorf("store.List() = %v, want empty", ids)
+	}
+}

--- a/internal/watchlist/provider.go
+++ b/internal/watchlist/provider.go
@@ -1,0 +1,82 @@
+package watchlist
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/nugget/thane-ai-agent/internal/homeassistant"
+)
+
+// StateGetter abstracts the Home Assistant REST client for fetching
+// entity state. Using an interface keeps the provider testable without
+// a real HA instance.
+type StateGetter interface {
+	GetState(ctx context.Context, entityID string) (*homeassistant.State, error)
+}
+
+// Provider implements agent.ContextProvider by fetching live state for
+// all watched entities and formatting them as a markdown block for
+// system prompt injection.
+type Provider struct {
+	store  *Store
+	ha     StateGetter
+	logger *slog.Logger
+}
+
+// NewProvider creates a watchlist context provider.
+func NewProvider(store *Store, ha StateGetter, logger *slog.Logger) *Provider {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Provider{
+		store:  store,
+		ha:     ha,
+		logger: logger,
+	}
+}
+
+// GetContext returns a formatted markdown block of watched entity states
+// for injection into the agent's system prompt. Returns an empty string
+// when the watchlist is empty. Implements agent.ContextProvider.
+func (p *Provider) GetContext(ctx context.Context, _ string) (string, error) {
+	ids, err := p.store.List()
+	if err != nil {
+		return "", fmt.Errorf("list watched entities: %w", err)
+	}
+	if len(ids) == 0 {
+		return "", nil
+	}
+
+	var sb strings.Builder
+	sb.WriteString("### Watched Entities\n\n")
+
+	for _, id := range ids {
+		state, err := p.ha.GetState(ctx, id)
+		if err != nil {
+			p.logger.Warn("failed to fetch watched entity state",
+				"entity_id", id,
+				"error", err,
+			)
+			fmt.Fprintf(&sb, "- **%s**: unavailable\n", id)
+			continue
+		}
+
+		displayName := id
+		if name, ok := state.Attributes["friendly_name"].(string); ok && name != "" {
+			displayName = name
+		}
+
+		stateValue := state.State
+		if unit, ok := state.Attributes["unit_of_measurement"].(string); ok && unit != "" {
+			stateValue += " " + unit
+		}
+
+		since := state.LastChanged.Format(time.RFC3339)
+		fmt.Fprintf(&sb, "- **%s** (%s): %s (since %s)\n", displayName, id, stateValue, since)
+	}
+
+	return sb.String(), nil
+}

--- a/internal/watchlist/provider_test.go
+++ b/internal/watchlist/provider_test.go
@@ -1,0 +1,203 @@
+package watchlist
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nugget/thane-ai-agent/internal/homeassistant"
+	_ "modernc.org/sqlite"
+)
+
+// fakeHA implements StateGetter for testing.
+type fakeHA struct {
+	states map[string]*homeassistant.State
+	err    error // returned for any entity not in states
+}
+
+func (f *fakeHA) GetState(_ context.Context, entityID string) (*homeassistant.State, error) {
+	if s, ok := f.states[entityID]; ok {
+		return s, nil
+	}
+	if f.err != nil {
+		return nil, f.err
+	}
+	return nil, errors.New("entity not found")
+}
+
+func setupTestProvider(t *testing.T, ha StateGetter) (*Provider, *Store) {
+	t.Helper()
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+
+	store, err := NewStore(db)
+	if err != nil {
+		t.Fatalf("new store: %v", err)
+	}
+
+	p := NewProvider(store, ha, slog.Default())
+	return p, store
+}
+
+func TestProvider_EmptyWatchlist(t *testing.T) {
+	p, _ := setupTestProvider(t, &fakeHA{})
+
+	got, err := p.GetContext(context.Background(), "")
+	if err != nil {
+		t.Fatalf("GetContext: %v", err)
+	}
+	if got != "" {
+		t.Errorf("expected empty string for empty watchlist, got %q", got)
+	}
+}
+
+func TestProvider_SingleEntity(t *testing.T) {
+	ha := &fakeHA{
+		states: map[string]*homeassistant.State{
+			"sensor.office_temperature": {
+				EntityID:    "sensor.office_temperature",
+				State:       "72.4",
+				LastChanged: time.Date(2025, 1, 15, 16, 30, 0, 0, time.UTC),
+				Attributes: map[string]any{
+					"friendly_name":       "Office Temperature",
+					"unit_of_measurement": "°F",
+				},
+			},
+		},
+	}
+
+	p, store := setupTestProvider(t, ha)
+	if err := store.Add("sensor.office_temperature"); err != nil {
+		t.Fatalf("add: %v", err)
+	}
+
+	got, err := p.GetContext(context.Background(), "")
+	if err != nil {
+		t.Fatalf("GetContext: %v", err)
+	}
+
+	if !strings.Contains(got, "### Watched Entities") {
+		t.Error("missing header")
+	}
+	if !strings.Contains(got, "Office Temperature") {
+		t.Error("missing friendly_name")
+	}
+	if !strings.Contains(got, "sensor.office_temperature") {
+		t.Error("missing entity_id")
+	}
+	if !strings.Contains(got, "72.4 °F") {
+		t.Error("missing state with unit")
+	}
+}
+
+func TestProvider_EntityFetchFailure(t *testing.T) {
+	ha := &fakeHA{
+		err: errors.New("connection refused"),
+	}
+
+	p, store := setupTestProvider(t, ha)
+	if err := store.Add("sensor.broken"); err != nil {
+		t.Fatalf("add: %v", err)
+	}
+
+	got, err := p.GetContext(context.Background(), "")
+	if err != nil {
+		t.Fatalf("GetContext: %v", err)
+	}
+
+	if !strings.Contains(got, "sensor.broken") {
+		t.Error("missing entity_id for failed fetch")
+	}
+	if !strings.Contains(got, "unavailable") {
+		t.Error("failed entity should show as unavailable")
+	}
+}
+
+func TestProvider_MultipleEntities(t *testing.T) {
+	ha := &fakeHA{
+		states: map[string]*homeassistant.State{
+			"sensor.temperature": {
+				EntityID:    "sensor.temperature",
+				State:       "68",
+				LastChanged: time.Date(2025, 1, 15, 10, 0, 0, 0, time.UTC),
+				Attributes: map[string]any{
+					"friendly_name":       "Temperature",
+					"unit_of_measurement": "°F",
+				},
+			},
+			"binary_sensor.door": {
+				EntityID:    "binary_sensor.door",
+				State:       "off",
+				LastChanged: time.Date(2025, 1, 15, 8, 0, 0, 0, time.UTC),
+				Attributes: map[string]any{
+					"friendly_name": "Front Door",
+				},
+			},
+		},
+	}
+
+	p, store := setupTestProvider(t, ha)
+	if err := store.Add("sensor.temperature"); err != nil {
+		t.Fatalf("add: %v", err)
+	}
+	if err := store.Add("binary_sensor.door"); err != nil {
+		t.Fatalf("add: %v", err)
+	}
+
+	got, err := p.GetContext(context.Background(), "")
+	if err != nil {
+		t.Fatalf("GetContext: %v", err)
+	}
+
+	if !strings.Contains(got, "Temperature") {
+		t.Error("missing first entity")
+	}
+	if !strings.Contains(got, "Front Door") {
+		t.Error("missing second entity")
+	}
+	if !strings.Contains(got, "68 °F") {
+		t.Error("missing temperature state with unit")
+	}
+	if !strings.Contains(got, "off") {
+		t.Error("missing door state")
+	}
+}
+
+func TestProvider_NoFriendlyName(t *testing.T) {
+	ha := &fakeHA{
+		states: map[string]*homeassistant.State{
+			"sensor.raw": {
+				EntityID:    "sensor.raw",
+				State:       "42",
+				LastChanged: time.Date(2025, 1, 15, 12, 0, 0, 0, time.UTC),
+				Attributes:  map[string]any{},
+			},
+		},
+	}
+
+	p, store := setupTestProvider(t, ha)
+	if err := store.Add("sensor.raw"); err != nil {
+		t.Fatalf("add: %v", err)
+	}
+
+	got, err := p.GetContext(context.Background(), "")
+	if err != nil {
+		t.Fatalf("GetContext: %v", err)
+	}
+
+	// When no friendly_name, entity_id is used as the display name.
+	// It should appear as both the name and the parenthetical ID.
+	if !strings.Contains(got, "sensor.raw") {
+		t.Error("missing entity_id fallback as display name")
+	}
+	if !strings.Contains(got, "42") {
+		t.Error("missing state value")
+	}
+}

--- a/internal/watchlist/store.go
+++ b/internal/watchlist/store.go
@@ -1,0 +1,72 @@
+// Package watchlist manages a dynamic set of Home Assistant entities whose
+// state is injected into the agent's system prompt each turn. Entities are
+// persisted in SQLite so the watchlist survives restarts.
+package watchlist
+
+import (
+	"database/sql"
+	"fmt"
+)
+
+// Store persists the set of watched entity IDs in SQLite.
+type Store struct {
+	db *sql.DB
+}
+
+// NewStore creates a watchlist store, running migrations on first use.
+func NewStore(db *sql.DB) (*Store, error) {
+	s := &Store{db: db}
+	if err := s.migrate(); err != nil {
+		return nil, fmt.Errorf("migrate watchlist: %w", err)
+	}
+	return s, nil
+}
+
+func (s *Store) migrate() error {
+	_, err := s.db.Exec(`
+		CREATE TABLE IF NOT EXISTS watched_entities (
+			entity_id TEXT PRIMARY KEY,
+			added_at  TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+		)
+	`)
+	return err
+}
+
+// Add inserts an entity into the watchlist. Duplicates are silently ignored.
+func (s *Store) Add(entityID string) error {
+	_, err := s.db.Exec(
+		`INSERT OR IGNORE INTO watched_entities (entity_id) VALUES (?)`,
+		entityID,
+	)
+	return err
+}
+
+// Remove deletes an entity from the watchlist. Non-existent IDs are a no-op.
+func (s *Store) Remove(entityID string) error {
+	_, err := s.db.Exec(
+		`DELETE FROM watched_entities WHERE entity_id = ?`,
+		entityID,
+	)
+	return err
+}
+
+// List returns all watched entity IDs in insertion order.
+func (s *Store) List() ([]string, error) {
+	rows, err := s.db.Query(
+		`SELECT entity_id FROM watched_entities ORDER BY added_at ASC`,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var ids []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		ids = append(ids, id)
+	}
+	return ids, rows.Err()
+}

--- a/internal/watchlist/store_test.go
+++ b/internal/watchlist/store_test.go
@@ -1,0 +1,108 @@
+package watchlist
+
+import (
+	"database/sql"
+	"testing"
+
+	_ "modernc.org/sqlite"
+)
+
+func setupTestStore(t *testing.T) *Store {
+	t.Helper()
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+
+	store, err := NewStore(db)
+	if err != nil {
+		t.Fatalf("new store: %v", err)
+	}
+	return store
+}
+
+func TestStore_ListEmpty(t *testing.T) {
+	store := setupTestStore(t)
+
+	ids, err := store.List()
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(ids) != 0 {
+		t.Errorf("expected empty list, got %v", ids)
+	}
+}
+
+func TestStore_AddAndList(t *testing.T) {
+	store := setupTestStore(t)
+
+	if err := store.Add("sensor.office_temperature"); err != nil {
+		t.Fatalf("add: %v", err)
+	}
+	if err := store.Add("binary_sensor.front_door"); err != nil {
+		t.Fatalf("add: %v", err)
+	}
+
+	ids, err := store.List()
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(ids) != 2 {
+		t.Fatalf("expected 2 entities, got %d", len(ids))
+	}
+	if ids[0] != "sensor.office_temperature" {
+		t.Errorf("ids[0] = %q, want %q", ids[0], "sensor.office_temperature")
+	}
+	if ids[1] != "binary_sensor.front_door" {
+		t.Errorf("ids[1] = %q, want %q", ids[1], "binary_sensor.front_door")
+	}
+}
+
+func TestStore_AddDuplicate(t *testing.T) {
+	store := setupTestStore(t)
+
+	if err := store.Add("sensor.temperature"); err != nil {
+		t.Fatalf("add: %v", err)
+	}
+	// Second add of the same entity should be a no-op.
+	if err := store.Add("sensor.temperature"); err != nil {
+		t.Fatalf("add duplicate: %v", err)
+	}
+
+	ids, err := store.List()
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(ids) != 1 {
+		t.Errorf("expected 1 entity after duplicate add, got %d", len(ids))
+	}
+}
+
+func TestStore_Remove(t *testing.T) {
+	store := setupTestStore(t)
+
+	if err := store.Add("sensor.temperature"); err != nil {
+		t.Fatalf("add: %v", err)
+	}
+	if err := store.Remove("sensor.temperature"); err != nil {
+		t.Fatalf("remove: %v", err)
+	}
+
+	ids, err := store.List()
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(ids) != 0 {
+		t.Errorf("expected empty list after remove, got %v", ids)
+	}
+}
+
+func TestStore_RemoveNonExistent(t *testing.T) {
+	store := setupTestStore(t)
+
+	// Removing a non-existent entity should be a no-op.
+	if err := store.Remove("sensor.does_not_exist"); err != nil {
+		t.Fatalf("remove non-existent: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `add_context_entity` / `remove_context_entity` tools so the agent can dynamically manage which HA entities get their live state injected into the system prompt each turn
- New `internal/watchlist` package with SQLite-backed store and `ContextProvider` implementation
- Watchlist persists across restarts; watched entities appear in context automatically every turn
- Provider fetches live state from HA, shows friendly names and units, marks unavailable entities

Closes #225

## Test plan

- [ ] Store tests: add, add-duplicate, remove, remove-missing, list-empty
- [ ] Provider tests: empty watchlist, single entity with attributes, fetch failure shows "unavailable", multiple entities, no friendly_name fallback
- [ ] Tool tests: missing entity_id validation, add/remove success, tool registration via `SetWatchlistStore`
- [ ] `just ci` passes (fmt, lint, test with -race)

🤖 Generated with [Claude Code](https://claude.com/claude-code)