### PR TITLE
feat: add rolling state change window for ambient HA context

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -161,6 +161,10 @@ type Config struct {
 	// reception and response routing via a signal-mcp MCP server.
 	Signal SignalConfig `yaml:"signal"`
 
+	// StateWindow configures the rolling window of recent Home Assistant
+	// state changes injected into the agent's system prompt on every run.
+	StateWindow StateWindowConfig `yaml:"state_window"`
+
 	// Unifi configures the UniFi network controller connection for
 	// room-level presence detection via wireless AP client associations.
 	Unifi UnifiConfig `yaml:"unifi"`
@@ -638,6 +642,21 @@ func (c SignalConfig) Configured() bool {
 	return c.Enabled && c.MCPServer != ""
 }
 
+// StateWindowConfig configures the rolling window of recent Home
+// Assistant state changes that is injected into the agent's system
+// prompt on every run. The window provides ambient awareness of
+// recent state transitions without requiring tool calls.
+type StateWindowConfig struct {
+	// MaxEntries is the circular buffer capacity. When the buffer is
+	// full, the oldest entry is overwritten. Default: 50.
+	MaxEntries int `yaml:"max_entries"`
+
+	// MaxAgeMinutes controls how long entries remain visible. Entries
+	// older than this are excluded from the context output at read
+	// time. Default: 30.
+	MaxAgeMinutes int `yaml:"max_age_minutes"`
+}
+
 // Load reads a YAML configuration file, expands environment variables,
 // applies defaults for any unset fields, and validates the result.
 //
@@ -770,6 +789,13 @@ func (c *Config) applyDefaults() {
 		c.Signal.RateLimitPerMinute = 10
 	}
 
+	if c.StateWindow.MaxEntries == 0 {
+		c.StateWindow.MaxEntries = 50
+	}
+	if c.StateWindow.MaxAgeMinutes == 0 {
+		c.StateWindow.MaxAgeMinutes = 30
+	}
+
 	for i := range c.Models.Available {
 		if c.Models.Available[i].Provider == "" {
 			c.Models.Available[i].Provider = "ollama"
@@ -871,6 +897,12 @@ func (c *Config) Validate() error {
 	}
 	if err := c.validateSignal(); err != nil {
 		return err
+	}
+	if c.StateWindow.MaxEntries < 1 {
+		return fmt.Errorf("state_window.max_entries %d must be positive", c.StateWindow.MaxEntries)
+	}
+	if c.StateWindow.MaxAgeMinutes < 1 {
+		return fmt.Errorf("state_window.max_age_minutes %d must be positive", c.StateWindow.MaxAgeMinutes)
 	}
 	return nil
 }

--- a/internal/statewindow/provider.go
+++ b/internal/statewindow/provider.go
@@ -1,0 +1,128 @@
+// Package statewindow maintains a rolling window of Home Assistant state
+// changes and injects them into the agent's system prompt. The window
+// uses a circular buffer with dual eviction: count-based (buffer
+// capacity) and age-based (configurable max age applied at read time).
+package statewindow
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+	"sync"
+	"time"
+)
+
+// Entry records a single state transition observed from the Home
+// Assistant WebSocket event stream.
+type Entry struct {
+	EntityID  string
+	OldState  string
+	NewState  string
+	Timestamp time.Time
+}
+
+// Provider maintains a rolling window of recent state changes and
+// implements the agent.ContextProvider interface. It is safe for
+// concurrent use: HandleStateChange writes under a write lock while
+// GetContext reads under a read lock.
+type Provider struct {
+	mu      sync.RWMutex
+	entries []Entry // circular buffer, pre-allocated
+	head    int     // next write position
+	count   int     // entries currently stored (≤ len(entries))
+	maxAge  time.Duration
+	loc     *time.Location
+	nowFunc func() time.Time
+	logger  *slog.Logger
+}
+
+// NewProvider creates a state window provider with the given buffer
+// capacity and maximum entry age. The loc parameter controls the
+// timezone used for ISO 8601 timestamps in the context output; nil
+// falls back to time.Local. Entries older than maxAge are filtered
+// out at read time in GetContext.
+func NewProvider(maxEntries int, maxAge time.Duration, loc *time.Location, logger *slog.Logger) *Provider {
+	if maxEntries <= 0 {
+		maxEntries = 50
+	}
+	if maxAge <= 0 {
+		maxAge = 30 * time.Minute
+	}
+	if loc == nil {
+		loc = time.Local
+	}
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Provider{
+		entries: make([]Entry, maxEntries),
+		maxAge:  maxAge,
+		loc:     loc,
+		nowFunc: time.Now,
+		logger:  logger,
+	}
+}
+
+// HandleStateChange records a state transition in the circular buffer.
+// It matches the homeassistant.StateWatchHandler function signature and
+// can be composed directly into the state watcher handler chain.
+func (p *Provider) HandleStateChange(entityID, oldState, newState string) {
+	now := p.nowFunc()
+
+	p.mu.Lock()
+	p.entries[p.head] = Entry{
+		EntityID:  entityID,
+		OldState:  oldState,
+		NewState:  newState,
+		Timestamp: now,
+	}
+	p.head = (p.head + 1) % len(p.entries)
+	if p.count < len(p.entries) {
+		p.count++
+	}
+	p.mu.Unlock()
+}
+
+// GetContext returns a formatted context block listing recent state
+// changes for injection into the agent's system prompt. Entries older
+// than maxAge are excluded. Returns an empty string when no valid
+// entries exist.
+func (p *Provider) GetContext(_ context.Context, _ string) (string, error) {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+
+	if p.count == 0 {
+		return "", nil
+	}
+
+	now := p.nowFunc()
+	cutoff := now.Add(-p.maxAge)
+	bufLen := len(p.entries)
+
+	// Collect valid entries in reverse chronological order (newest first).
+	// The newest entry is at (head-1) mod bufLen, walking backwards.
+	var lines []string
+	for i := 0; i < p.count; i++ {
+		idx := (p.head - 1 - i + bufLen) % bufLen
+		e := p.entries[idx]
+		if e.Timestamp.Before(cutoff) {
+			continue
+		}
+		ts := e.Timestamp.In(p.loc).Format(time.RFC3339)
+		lines = append(lines, fmt.Sprintf("- %s: %s → %s (%s)", e.EntityID, e.OldState, e.NewState, ts))
+	}
+
+	if len(lines) == 0 {
+		return "", nil
+	}
+
+	var sb strings.Builder
+	sb.WriteString("### Recent State Changes\n\n")
+	for _, line := range lines {
+		sb.WriteString(line)
+		sb.WriteByte('\n')
+	}
+
+	return sb.String(), nil
+}

--- a/internal/statewindow/provider_test.go
+++ b/internal/statewindow/provider_test.go
@@ -1,0 +1,231 @@
+package statewindow
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// fixedClock returns a nowFunc that returns a fixed time.
+func fixedClock(t time.Time) func() time.Time {
+	return func() time.Time { return t }
+}
+
+// advancingClock returns a nowFunc that advances by step on each call,
+// starting from start.
+func advancingClock(start time.Time, step time.Duration) func() time.Time {
+	current := start
+	var mu sync.Mutex
+	return func() time.Time {
+		mu.Lock()
+		defer mu.Unlock()
+		t := current
+		current = current.Add(step)
+		return t
+	}
+}
+
+func TestProvider_EmptyBuffer(t *testing.T) {
+	p := NewProvider(10, 30*time.Minute, time.UTC, nil)
+
+	got, err := p.GetContext(context.Background(), "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "" {
+		t.Errorf("expected empty string, got %q", got)
+	}
+}
+
+func TestProvider_SingleEntry(t *testing.T) {
+	now := time.Date(2025, 6, 15, 14, 30, 0, 0, time.UTC)
+	p := NewProvider(10, 30*time.Minute, time.UTC, nil)
+	p.nowFunc = fixedClock(now)
+
+	p.HandleStateChange("binary_sensor.front_door", "off", "on")
+
+	got, err := p.GetContext(context.Background(), "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !strings.Contains(got, "### Recent State Changes") {
+		t.Error("missing header")
+	}
+	if !strings.Contains(got, "binary_sensor.front_door") {
+		t.Error("missing entity ID")
+	}
+	if !strings.Contains(got, "off → on") {
+		t.Error("missing state transition")
+	}
+	if !strings.Contains(got, "2025-06-15T14:30:00Z") {
+		t.Errorf("missing ISO 8601 timestamp, got:\n%s", got)
+	}
+}
+
+func TestProvider_MultipleEntries_NewestFirst(t *testing.T) {
+	base := time.Date(2025, 6, 15, 14, 0, 0, 0, time.UTC)
+	p := NewProvider(10, 30*time.Minute, time.UTC, nil)
+	clock := advancingClock(base, time.Minute)
+	p.nowFunc = clock
+
+	p.HandleStateChange("sensor.temp", "20", "21")
+	p.HandleStateChange("light.living_room", "on", "off")
+	p.HandleStateChange("person.nugget", "not_home", "home")
+
+	got, err := p.GetContext(context.Background(), "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify newest first: person.nugget should appear before sensor.temp.
+	nuggetIdx := strings.Index(got, "person.nugget")
+	tempIdx := strings.Index(got, "sensor.temp")
+	if nuggetIdx < 0 || tempIdx < 0 {
+		t.Fatalf("missing expected entries:\n%s", got)
+	}
+	if nuggetIdx > tempIdx {
+		t.Errorf("entries not in newest-first order:\n%s", got)
+	}
+}
+
+func TestProvider_CircularEviction(t *testing.T) {
+	now := time.Date(2025, 6, 15, 14, 0, 0, 0, time.UTC)
+	p := NewProvider(3, time.Hour, time.UTC, nil)
+	clock := advancingClock(now, time.Minute)
+	p.nowFunc = clock
+
+	// Fill buffer with 5 entries; only last 3 should survive.
+	p.HandleStateChange("entity.a", "0", "1")
+	p.HandleStateChange("entity.b", "0", "1")
+	p.HandleStateChange("entity.c", "0", "1")
+	p.HandleStateChange("entity.d", "0", "1")
+	p.HandleStateChange("entity.e", "0", "1")
+
+	got, err := p.GetContext(context.Background(), "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// entity.a and entity.b should be evicted.
+	if strings.Contains(got, "entity.a") {
+		t.Error("entity.a should have been evicted")
+	}
+	if strings.Contains(got, "entity.b") {
+		t.Error("entity.b should have been evicted")
+	}
+	// entity.c, d, e should remain.
+	for _, id := range []string{"entity.c", "entity.d", "entity.e"} {
+		if !strings.Contains(got, id) {
+			t.Errorf("expected %s to be present", id)
+		}
+	}
+}
+
+func TestProvider_AgeEviction(t *testing.T) {
+	now := time.Date(2025, 6, 15, 14, 0, 0, 0, time.UTC)
+	p := NewProvider(10, 10*time.Minute, time.UTC, nil)
+
+	// Insert an entry 15 minutes ago.
+	p.nowFunc = fixedClock(now.Add(-15 * time.Minute))
+	p.HandleStateChange("sensor.old", "0", "1")
+
+	// Insert a recent entry.
+	p.nowFunc = fixedClock(now.Add(-2 * time.Minute))
+	p.HandleStateChange("sensor.recent", "0", "1")
+
+	// Read at "now" — old entry should be filtered out.
+	p.nowFunc = fixedClock(now)
+	got, err := p.GetContext(context.Background(), "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if strings.Contains(got, "sensor.old") {
+		t.Error("sensor.old should be filtered by age")
+	}
+	if !strings.Contains(got, "sensor.recent") {
+		t.Error("sensor.recent should be present")
+	}
+}
+
+func TestProvider_AllExpired(t *testing.T) {
+	now := time.Date(2025, 6, 15, 14, 0, 0, 0, time.UTC)
+	p := NewProvider(10, 5*time.Minute, time.UTC, nil)
+
+	// Insert entries 10 minutes ago.
+	p.nowFunc = fixedClock(now.Add(-10 * time.Minute))
+	p.HandleStateChange("sensor.a", "0", "1")
+	p.HandleStateChange("sensor.b", "0", "1")
+
+	// Read at "now" — all entries expired.
+	p.nowFunc = fixedClock(now)
+	got, err := p.GetContext(context.Background(), "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "" {
+		t.Errorf("expected empty string when all entries expired, got %q", got)
+	}
+}
+
+func TestProvider_ISO8601_Timezone(t *testing.T) {
+	loc, err := time.LoadLocation("America/Chicago")
+	if err != nil {
+		t.Skip("timezone America/Chicago not available")
+	}
+
+	now := time.Date(2025, 6, 15, 14, 30, 0, 0, time.UTC)
+	p := NewProvider(10, 30*time.Minute, loc, nil)
+	p.nowFunc = fixedClock(now)
+
+	p.HandleStateChange("sensor.test", "a", "b")
+
+	got, err := p.GetContext(context.Background(), "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// 14:30 UTC = 09:30 CDT (UTC-5)
+	if !strings.Contains(got, "2025-06-15T09:30:00-05:00") {
+		t.Errorf("expected Chicago timezone timestamp, got:\n%s", got)
+	}
+}
+
+func TestProvider_HandleStateChange_Concurrent(t *testing.T) {
+	p := NewProvider(100, time.Hour, time.UTC, nil)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			p.HandleStateChange("sensor.concurrent", "0", "1")
+		}()
+	}
+	wg.Wait()
+
+	got, err := p.GetContext(context.Background(), "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(got, "sensor.concurrent") {
+		t.Error("expected entries after concurrent writes")
+	}
+}
+
+func TestProvider_NilDefaults(t *testing.T) {
+	// Verify constructor handles zero/nil values gracefully.
+	p := NewProvider(0, 0, nil, nil)
+	if len(p.entries) != 50 {
+		t.Errorf("expected default maxEntries=50, got %d", len(p.entries))
+	}
+	if p.maxAge != 30*time.Minute {
+		t.Errorf("expected default maxAge=30m, got %v", p.maxAge)
+	}
+	if p.loc != time.Local {
+		t.Error("expected time.Local as default location")
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `internal/statewindow` package with a `Provider` that maintains a circular buffer of recent HA state changes
- Injects a `### Recent State Changes` section into the system prompt on every agent run, giving the agent ambient awareness of recent transitions (entity ID, old → new state, ISO 8601 timestamp)
- Dual eviction: count-based (buffer capacity, default 50) and age-based (configurable max age, default 30 min)
- Composed into the state watcher handler chain alongside person tracker and wake bridge

## Config
```yaml
state_window:
  max_entries: 50
  max_age_minutes: 30
```

## Test plan
- [x] `just ci` passes (fmt, lint, test with -race)
- [x] Tests cover: empty buffer, single entry, circular eviction, age eviction, concurrent writes, ISO 8601 timezone formatting, nil defaults
- [x] Config defaults applied correctly
- [x] Handler chain composition verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)