### PR TITLE
feat: per-anticipation cooldown stored in SQLite

### DIFF
--- a/internal/anticipation/store.go
+++ b/internal/anticipation/store.go
@@ -6,6 +6,7 @@ package anticipation
 import (
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -18,10 +19,12 @@ type Anticipation struct {
 	Context         string            `json:"context"`                    // Injected on match: instructions/reasoning
 	ContextEntities []string          `json:"context_entities,omitempty"` // Entity IDs to snapshot on wake
 	Recurring       bool              `json:"recurring,omitempty"`        // true = keep firing; false = auto-resolve after wake
+	CooldownSeconds int               `json:"cooldown_seconds,omitempty"` // 0 = use global default
 	Trigger         Trigger           `json:"trigger"`                    // When this anticipation activates
 	CreatedAt       time.Time         `json:"created_at"`
 	ExpiresAt       *time.Time        `json:"expires_at,omitempty"` // nil = no expiration
 	ResolvedAt      *time.Time        `json:"resolved_at,omitempty"`
+	LastFiredAt     *time.Time        `json:"last_fired_at,omitempty"`
 	Metadata        map[string]string `json:"metadata,omitempty"` // Arbitrary k/v for matching
 }
 
@@ -88,6 +91,8 @@ func (s *Store) migrate() error {
 	}{
 		{`ALTER TABLE anticipations ADD COLUMN context_entities_json TEXT`, "context_entities_json"},
 		{`ALTER TABLE anticipations ADD COLUMN recurring BOOLEAN DEFAULT 0`, "recurring"},
+		{`ALTER TABLE anticipations ADD COLUMN cooldown_seconds INTEGER DEFAULT 0`, "cooldown_seconds"},
+		{`ALTER TABLE anticipations ADD COLUMN last_fired_at TIMESTAMP`, "last_fired_at"},
 	} {
 		if _, err := s.db.Exec(stmt.sql); err != nil {
 			if !strings.Contains(err.Error(), "duplicate column name") {
@@ -124,9 +129,9 @@ func (s *Store) Create(a *Anticipation) error {
 	}
 
 	_, err = s.db.Exec(`
-		INSERT INTO anticipations (id, description, context, trigger_json, metadata_json, context_entities_json, recurring, created_at, expires_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
-	`, a.ID, a.Description, a.Context, string(triggerJSON), string(metadataJSON), string(contextEntitiesJSON), a.Recurring, a.CreatedAt, a.ExpiresAt)
+		INSERT INTO anticipations (id, description, context, trigger_json, metadata_json, context_entities_json, recurring, cooldown_seconds, created_at, expires_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	`, a.ID, a.Description, a.Context, string(triggerJSON), string(metadataJSON), string(contextEntitiesJSON), a.Recurring, a.CooldownSeconds, a.CreatedAt, a.ExpiresAt)
 
 	return err
 }
@@ -134,7 +139,7 @@ func (s *Store) Create(a *Anticipation) error {
 // Active returns all non-resolved, non-expired, non-deleted anticipations.
 func (s *Store) Active() ([]*Anticipation, error) {
 	rows, err := s.db.Query(`
-		SELECT id, description, context, trigger_json, metadata_json, context_entities_json, recurring, created_at, expires_at
+		SELECT id, description, context, trigger_json, metadata_json, context_entities_json, recurring, cooldown_seconds, created_at, expires_at, last_fired_at
 		FROM anticipations
 		WHERE resolved_at IS NULL
 		  AND deleted_at IS NULL
@@ -152,17 +157,17 @@ func (s *Store) Active() ([]*Anticipation, error) {
 // Get retrieves a single anticipation by ID.
 func (s *Store) Get(id string) (*Anticipation, error) {
 	row := s.db.QueryRow(`
-		SELECT id, description, context, trigger_json, metadata_json, context_entities_json, recurring, created_at, expires_at, resolved_at
+		SELECT id, description, context, trigger_json, metadata_json, context_entities_json, recurring, cooldown_seconds, created_at, expires_at, resolved_at, last_fired_at
 		FROM anticipations
 		WHERE id = ? AND deleted_at IS NULL
 	`, id)
 
 	a := &Anticipation{}
 	var triggerJSON, metadataJSON, contextEntitiesJSON sql.NullString
-	var expiresAt, resolvedAt sql.NullTime
+	var expiresAt, resolvedAt, lastFiredAt sql.NullTime
 
 	err := row.Scan(&a.ID, &a.Description, &a.Context, &triggerJSON, &metadataJSON,
-		&contextEntitiesJSON, &a.Recurring, &a.CreatedAt, &expiresAt, &resolvedAt)
+		&contextEntitiesJSON, &a.Recurring, &a.CooldownSeconds, &a.CreatedAt, &expiresAt, &resolvedAt, &lastFiredAt)
 	if err == sql.ErrNoRows {
 		return nil, nil
 	}
@@ -185,6 +190,9 @@ func (s *Store) Get(id string) (*Anticipation, error) {
 	if resolvedAt.Valid {
 		a.ResolvedAt = &resolvedAt.Time
 	}
+	if lastFiredAt.Valid {
+		a.LastFiredAt = &lastFiredAt.Time
+	}
 
 	return a, nil
 }
@@ -205,15 +213,55 @@ func (s *Store) Delete(id string) error {
 	return err
 }
 
+// MarkFired records the current time as the last fire time for the
+// anticipation. This persists across restarts unlike the previous
+// in-memory tracking.
+func (s *Store) MarkFired(id string) error {
+	_, err := s.db.Exec(`
+		UPDATE anticipations SET last_fired_at = CURRENT_TIMESTAMP WHERE id = ?
+	`, id)
+	return err
+}
+
+// OnCooldown reports whether the anticipation has fired too recently.
+// If the anticipation has a per-row cooldown_seconds > 0, that value
+// is used; otherwise globalDefault applies. Returns false, nil if the
+// anticipation has never fired or does not exist. Database errors other
+// than sql.ErrNoRows are returned so the caller can decide how to
+// handle them.
+func (s *Store) OnCooldown(id string, globalDefault time.Duration) (bool, error) {
+	var cooldownSec int
+	var lastFired sql.NullTime
+
+	err := s.db.QueryRow(`
+		SELECT cooldown_seconds, last_fired_at FROM anticipations WHERE id = ?
+	`, id).Scan(&cooldownSec, &lastFired)
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("query cooldown for %s: %w", id, err)
+	}
+	if !lastFired.Valid {
+		return false, nil
+	}
+
+	cooldown := globalDefault
+	if cooldownSec > 0 {
+		cooldown = time.Duration(cooldownSec) * time.Second
+	}
+	return time.Since(lastFired.Time) < cooldown, nil
+}
+
 func (s *Store) scanAnticipations(rows *sql.Rows) ([]*Anticipation, error) {
 	var result []*Anticipation
 	for rows.Next() {
 		a := &Anticipation{}
 		var triggerJSON, metadataJSON, contextEntitiesJSON sql.NullString
-		var expiresAt sql.NullTime
+		var expiresAt, lastFiredAt sql.NullTime
 
 		err := rows.Scan(&a.ID, &a.Description, &a.Context, &triggerJSON, &metadataJSON,
-			&contextEntitiesJSON, &a.Recurring, &a.CreatedAt, &expiresAt)
+			&contextEntitiesJSON, &a.Recurring, &a.CooldownSeconds, &a.CreatedAt, &expiresAt, &lastFiredAt)
 		if err != nil {
 			return nil, err
 		}
@@ -229,6 +277,9 @@ func (s *Store) scanAnticipations(rows *sql.Rows) ([]*Anticipation, error) {
 		}
 		if expiresAt.Valid {
 			a.ExpiresAt = &expiresAt.Time
+		}
+		if lastFiredAt.Valid {
+			a.LastFiredAt = &lastFiredAt.Time
 		}
 
 		result = append(result, a)


### PR DESCRIPTION
## Summary

- Moves cooldown tracking from in-memory `map[string]time.Time` in WakeBridge to SQLite columns (`cooldown_seconds`, `last_fired_at`) on the anticipations table
- Each anticipation can now specify its own cooldown via the `cooldown` parameter on `create_anticipation` (e.g., `"30s"`, `"5m"`, `"1h"`) — `0` falls back to the global default
- `MarkFired` persists `last_fired_at` across restarts, fixing cooldown state loss on process restart
- Removes in-memory mutex and map from WakeBridge, delegating to `Store.OnCooldown` and `Store.MarkFired`

## Test plan

- [x] `just ci` passes (fmt, lint, race tests)
- [x] Store tests: `MarkFired` sets `last_fired_at`, `OnCooldown` returns correct values
- [x] Store tests: per-anticipation cooldown overrides global default
- [x] Store tests: `cooldown_seconds = 0` falls back to global default
- [x] Store tests: nonexistent ID and never-fired ID return not-on-cooldown
- [x] WakeBridge tests: mock delegates to `OnCooldown`/`MarkFired`, cooldown behavior preserved
- [x] Round-trip tests: cooldown_seconds survives Create → Get and Create → Active


🤖 Generated with [Claude Code](https://claude.com/claude-code)