### PR TITLE
fix: replace StdioTransport mutex with context-aware semaphore

### DIFF
--- a/internal/mcp/stdio_test.go
+++ b/internal/mcp/stdio_test.go
@@ -1,0 +1,203 @@
+package mcp
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestStdioTransport_AcquireRespectsContext(t *testing.T) {
+	tr := NewStdioTransport(StdioConfig{Command: "echo"})
+
+	// Pre-fill the semaphore to simulate another goroutine holding it.
+	tr.sem <- struct{}{}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	err := tr.acquire(ctx)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Errorf("acquire() = %v, want context.DeadlineExceeded", err)
+	}
+}
+
+func TestStdioTransport_AcquireSuccess(t *testing.T) {
+	tr := NewStdioTransport(StdioConfig{Command: "echo"})
+
+	ctx := context.Background()
+	if err := tr.acquire(ctx); err != nil {
+		t.Fatalf("acquire() = %v, want nil", err)
+	}
+	tr.release()
+}
+
+func TestStdioTransport_AcquireAlreadyCancelled(t *testing.T) {
+	tr := NewStdioTransport(StdioConfig{Command: "echo"})
+
+	// Pre-fill semaphore.
+	tr.sem <- struct{}{}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // Cancel before acquire.
+
+	err := tr.acquire(ctx)
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("acquire() = %v, want context.Canceled", err)
+	}
+}
+
+func TestStdioTransport_AcquireAlreadyCancelledSemaphoreFree(t *testing.T) {
+	tr := NewStdioTransport(StdioConfig{Command: "echo"})
+
+	// Cancel the context before attempting to acquire with a free semaphore.
+	// The post-acquire double-check must catch this and release the token.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := tr.acquire(ctx)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("acquire() with cancelled context = %v, want context.Canceled", err)
+	}
+
+	// Verify the semaphore was not left held.
+	select {
+	case <-tr.sem:
+		t.Fatal("semaphore was acquired despite cancelled context")
+	default:
+		// OK: semaphore is free.
+	}
+}
+
+func TestStdioTransport_ReleaseFreesSlot(t *testing.T) {
+	tr := NewStdioTransport(StdioConfig{Command: "echo"})
+
+	ctx := context.Background()
+
+	// First acquire.
+	if err := tr.acquire(ctx); err != nil {
+		t.Fatalf("first acquire: %v", err)
+	}
+
+	// Release.
+	tr.release()
+
+	// Second acquire should succeed without blocking.
+	if err := tr.acquire(ctx); err != nil {
+		t.Fatalf("second acquire after release: %v", err)
+	}
+	tr.release()
+}
+
+func TestStdioTransport_ConcurrentAcquireTimeout(t *testing.T) {
+	tr := NewStdioTransport(StdioConfig{Command: "echo"})
+
+	ctx := context.Background()
+	if err := tr.acquire(ctx); err != nil {
+		t.Fatalf("initial acquire: %v", err)
+	}
+
+	// Second goroutine tries to acquire with a short timeout.
+	shortCtx, cancel := context.WithTimeout(ctx, 100*time.Millisecond)
+	defer cancel()
+
+	var wg sync.WaitGroup
+	var acquireErr error
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		acquireErr = tr.acquire(shortCtx)
+	}()
+
+	wg.Wait()
+
+	if !errors.Is(acquireErr, context.DeadlineExceeded) {
+		t.Errorf("concurrent acquire = %v, want context.DeadlineExceeded", acquireErr)
+	}
+
+	// Release the original hold — transport is still usable.
+	tr.release()
+
+	// Subsequent acquire should work.
+	if err := tr.acquire(ctx); err != nil {
+		t.Fatalf("acquire after release: %v", err)
+	}
+	tr.release()
+}
+
+func TestStdioTransport_SendReturnsErrWhenSemaphoreBusy(t *testing.T) {
+	tr := NewStdioTransport(StdioConfig{Command: "echo"})
+
+	// Hold the semaphore to simulate a long-running operation.
+	tr.sem <- struct{}{}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	_, err := tr.Send(ctx, &Request{
+		JSONRPC: "2.0",
+		ID:      99,
+		Method:  "ping",
+	})
+
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Errorf("Send() = %v, want context.DeadlineExceeded", err)
+	}
+}
+
+func TestStdioTransport_NotifyReturnsErrWhenSemaphoreBusy(t *testing.T) {
+	tr := NewStdioTransport(StdioConfig{Command: "echo"})
+
+	// Hold the semaphore.
+	tr.sem <- struct{}{}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	err := tr.Notify(ctx, &Notification{
+		JSONRPC: "2.0",
+		Method:  "notifications/test",
+	})
+
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Errorf("Notify() = %v, want context.DeadlineExceeded", err)
+	}
+}
+
+func TestStdioTransport_CloseBlocksUntilSemaphoreAvailable(t *testing.T) {
+	tr := NewStdioTransport(StdioConfig{Command: "echo"})
+
+	// Acquire the semaphore.
+	ctx := context.Background()
+	if err := tr.acquire(ctx); err != nil {
+		t.Fatalf("acquire: %v", err)
+	}
+
+	closeDone := make(chan error, 1)
+	go func() {
+		closeDone <- tr.Close()
+	}()
+
+	// Close should be blocked.
+	select {
+	case <-closeDone:
+		t.Fatal("Close() returned before semaphore was released")
+	case <-time.After(200 * time.Millisecond):
+		// Expected: Close is blocked.
+	}
+
+	// Release semaphore — Close should proceed.
+	tr.release()
+
+	select {
+	case err := <-closeDone:
+		// Close on an unstarted transport returns nil.
+		if err != nil {
+			t.Errorf("Close() = %v, want nil", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Close() did not return after semaphore release")
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #237 — MCP client health tracking kills Signal bridge poll loop.

- The connwatch health probe's `Ping()` competes with the Signal bridge's long-poll `receive_message` for the `StdioTransport` mutex. When the ping's 10s context timeout expires while blocked at `sync.Mutex.Lock()`, the goroutine can't act on it. Once the poll releases the mutex, the ping enters `Send()`, discovers its context already expired, and calls `cleanup()` — killing the subprocess permanently.
- Replace `sync.Mutex` with a capacity-1 channel semaphore. The new `acquire()` method `select`s on both the semaphore and `ctx.Done()`, so a timed-out caller returns `ctx.Err()` immediately without touching the subprocess.
- Only behavioral change: context expiration **while waiting for the semaphore** returns a clean error instead of eventually killing the subprocess. Context expiration **during an active read** (genuinely unresponsive subprocess) still calls `cleanup()` as before.

## Test plan

- [x] `just ci` passes (fmt, lint, race tests)
- [x] `TestStdioTransport_AcquireRespectsContext` — timeout returns `DeadlineExceeded`, not a subprocess kill
- [x] `TestStdioTransport_AcquireSuccess` — immediate acquire when semaphore is free
- [x] `TestStdioTransport_AcquireAlreadyCancelled` — pre-cancelled context returns `Canceled`
- [x] `TestStdioTransport_ReleaseFreesSlot` — acquire/release/acquire cycle works
- [x] `TestStdioTransport_ConcurrentAcquireTimeout` — second goroutine times out, first completes, transport survives
- [x] `TestStdioTransport_SendReturnsErrWhenSemaphoreBusy` — full `Send()` path returns context error
- [x] `TestStdioTransport_NotifyReturnsErrWhenSemaphoreBusy` — full `Notify()` path returns context error
- [x] `TestStdioTransport_CloseBlocksUntilSemaphoreAvailable` — `Close()` waits for in-flight operation


🤖 Generated with [Claude Code](https://claude.com/claude-code)