### PR TITLE
fix: correct send_read_receipt param name and add response debug logging

### DIFF
--- a/cmd/thane/signalbridge.go
+++ b/cmd/thane/signalbridge.go
@@ -133,6 +133,11 @@ func (b *SignalBridge) Start(ctx context.Context) {
 			continue
 		}
 
+		b.logger.Debug("signal receive_message raw response",
+			"result", truncate(result, 500),
+			"parsed_timestamp", msg.Timestamp,
+		)
+
 		if msg.Error != "" {
 			b.logger.Warn("signal receive_message error",
 				"error", msg.Error,
@@ -155,7 +160,7 @@ func (b *SignalBridge) Start(ctx context.Context) {
 		// Acknowledge receipt before the potentially long agent loop.
 		// Best-effort — failure does not prevent message processing.
 		if _, err := b.mcp.CallTool(ctx, "send_read_receipt", map[string]any{
-			"user_id":    msg.SenderID,
+			"recipient":  msg.SenderID,
 			"timestamps": []int64{msg.Timestamp},
 		}); err != nil {
 			b.logger.Warn("signal read receipt failed",

--- a/cmd/thane/signalbridge_test.go
+++ b/cmd/thane/signalbridge_test.go
@@ -497,8 +497,8 @@ func TestSignalBridge_ReadReceiptSentBeforeHandle(t *testing.T) {
 	if receiptCall == nil {
 		t.Fatal("send_read_receipt was not called")
 	}
-	if receiptCall.Args["user_id"] != "+15551234567" {
-		t.Errorf("read receipt user_id = %v, want %q", receiptCall.Args["user_id"], "+15551234567")
+	if receiptCall.Args["recipient"] != "+15551234567" {
+		t.Errorf("read receipt recipient = %v, want %q", receiptCall.Args["recipient"], "+15551234567")
 	}
 	ts, ok := receiptCall.Args["timestamps"]
 	if !ok {


### PR DESCRIPTION
## Summary

- **Fixed `send_read_receipt` parameter name**: Changed `user_id` → `recipient`. Unlike `send_message_to_user` (which uses `user_id`), the `send_read_receipt` MCP tool expects `recipient`. PR #240 incorrectly unified both to `user_id`.
- **Added debug logging** for the raw `receive_message` response payload and parsed timestamp value to diagnose the zero-timestamp issue.
- **Updated test assertion** to verify the corrected `recipient` parameter name.

## Test plan

- [x] `just ci` passes (lint, fmt, tests with `-race`)
- [ ] Deploy and verify `send_read_receipt` no longer returns validation errors
- [ ] Check debug logs to diagnose why `msg.Timestamp` is zero in production

Fixes #242

🤖 Generated with [Claude Code](https://claude.com/claude-code)