### PR TITLE
fix: expose missing create_anticipation tool schema parameters

### DIFF
--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -246,6 +246,19 @@ func (r *Registry) registerAnticipationTools() {
 					"type":        "string",
 					"description": "Duration until expiration (e.g., '2h', '24h', '7d'). Omit for no expiration.",
 				},
+				"cooldown": map[string]any{
+					"type":        "string",
+					"description": "Minimum time between wake firings for this anticipation (e.g., '5m', '1h'). Omit to use the global default.",
+				},
+				"recurring": map[string]any{
+					"type":        "boolean",
+					"description": "If true, the anticipation persists after firing (keeps firing on matches, subject to cooldown). If false (default), auto-resolved after the first wake.",
+				},
+				"context_entities": map[string]any{
+					"type":        "array",
+					"items":       map[string]any{"type": "string"},
+					"description": "Entity IDs to fetch and inject as context when this anticipation fires (max 10). The triggering entity is auto-included.",
+				},
 			},
 			"required": []string{"description", "context"},
 		},


### PR DESCRIPTION
## Summary

- Adds `cooldown`, `recurring`, and `context_entities` to the `create_anticipation` tool schema in `internal/tools/tools.go`
- These parameters were already handled by the anticipation tool handler but invisible to the model because the outer schema didn't include them
- Thane was silently failing when trying to set cooldowns on new anticipations

Closes #254

## Test plan

- [x] `just ci` passes
- [ ] Verify Thane can set `cooldown` and `recurring` on new anticipations via the tool

🤖 Generated with [Claude Code](https://claude.com/claude-code)