### PR TITLE
feat: session management tools (close, checkpoint, split)

### DIFF
--- a/cmd/thane/main.go
+++ b/cmd/thane/main.go
@@ -857,6 +857,7 @@ func runServe(ctx context.Context, stdout io.Writer, stderr io.Writer, configPat
 	// Gives the agent the ability to search and recall past conversations.
 	loop.Tools().SetArchiveStore(archiveStore)
 	loop.Tools().SetConversationResetter(loop)
+	loop.Tools().SetSessionManager(loop)
 	logger.Info("web fetch enabled")
 
 	// --- Embeddings ---

--- a/internal/agent/session_management_test.go
+++ b/internal/agent/session_management_test.go
@@ -1,0 +1,495 @@
+package agent
+
+import (
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nugget/thane-ai-agent/internal/memory"
+)
+
+// mockArchiver records session lifecycle calls for testing.
+type mockArchiver struct {
+	archived     []archivedCall
+	sessions     []sessionCall
+	activeID     string
+	startedAt    time.Time
+	sessionCount int
+}
+
+type archivedCall struct {
+	conversationID string
+	messages       []memory.Message
+	reason         string
+}
+
+type sessionCall struct {
+	action string // "start", "end"
+	id     string
+	reason string
+}
+
+func (m *mockArchiver) ArchiveConversation(convID string, msgs []memory.Message, reason string) error {
+	m.archived = append(m.archived, archivedCall{convID, msgs, reason})
+	return nil
+}
+
+func (m *mockArchiver) StartSession(convID string) (string, error) {
+	m.sessionCount++
+	id := "session-" + convID
+	m.activeID = id
+	m.sessions = append(m.sessions, sessionCall{"start", id, ""})
+	return id, nil
+}
+
+func (m *mockArchiver) EndSession(sessionID, reason string) error {
+	m.sessions = append(m.sessions, sessionCall{"end", sessionID, reason})
+	m.activeID = ""
+	return nil
+}
+
+func (m *mockArchiver) ActiveSessionID(string) string {
+	return m.activeID
+}
+
+func (m *mockArchiver) EnsureSession(convID string) string {
+	if m.activeID != "" {
+		return m.activeID
+	}
+	id, _ := m.StartSession(convID)
+	return id
+}
+
+func (m *mockArchiver) OnMessage(string) {}
+
+func (m *mockArchiver) ActiveSessionStartedAt(string) time.Time {
+	return m.startedAt
+}
+
+// mockMemWithCompaction extends mockMem with AddCompactionSummary support.
+type mockMemWithCompaction struct {
+	*mockMem
+	summaries []compactionSummary
+}
+
+type compactionSummary struct {
+	conversationID string
+	summary        string
+}
+
+func newMockMemWithCompaction() *mockMemWithCompaction {
+	return &mockMemWithCompaction{mockMem: newMockMem()}
+}
+
+func (m *mockMemWithCompaction) AddCompactionSummary(convID, summary string) error {
+	m.summaries = append(m.summaries, compactionSummary{convID, summary})
+	// Also add as a message so GetMessages sees it.
+	return m.AddMessage(convID, "system", summary)
+}
+
+func (m *mockMemWithCompaction) GetAllMessages(convID string) []memory.Message {
+	return m.GetMessages(convID)
+}
+
+// newTestLoop creates a Loop with mocks suitable for session management tests.
+func newTestLoop(mem MemoryStore, archiver SessionArchiver) *Loop {
+	return &Loop{
+		logger:   slog.Default(),
+		memory:   mem,
+		archiver: archiver,
+	}
+}
+
+func TestCloseSession(t *testing.T) {
+	tests := []struct {
+		name         string
+		messages     []memory.Message
+		reason       string
+		carryForward string
+		wantArchived int
+		wantReason   string
+		wantHandoff  bool
+	}{
+		{
+			name: "basic close with carry-forward",
+			messages: []memory.Message{
+				{Role: "user", Content: "hello"},
+				{Role: "assistant", Content: "hi there"},
+			},
+			reason:       "topic change",
+			carryForward: "User was discussing greetings.",
+			wantArchived: 1,
+			wantReason:   "topic change",
+			wantHandoff:  true,
+		},
+		{
+			name: "close with empty reason defaults",
+			messages: []memory.Message{
+				{Role: "user", Content: "test"},
+			},
+			reason:       "",
+			carryForward: "Notes here.",
+			wantArchived: 1,
+			wantReason:   "close",
+			wantHandoff:  true,
+		},
+		{
+			name: "close with empty carry-forward",
+			messages: []memory.Message{
+				{Role: "user", Content: "bye"},
+			},
+			reason:       "done",
+			carryForward: "",
+			wantArchived: 1,
+			wantReason:   "done",
+			wantHandoff:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mem := newMockMemWithCompaction()
+			archiver := &mockArchiver{activeID: "old-session"}
+			loop := newTestLoop(mem, archiver)
+
+			// Seed messages.
+			for _, m := range tt.messages {
+				_ = mem.AddMessage("conv1", m.Role, m.Content)
+			}
+
+			err := loop.CloseSession("conv1", tt.reason, tt.carryForward)
+			if err != nil {
+				t.Fatalf("CloseSession() error: %v", err)
+			}
+
+			// Verify archive was called.
+			if len(archiver.archived) != tt.wantArchived {
+				t.Errorf("archived calls = %d, want %d", len(archiver.archived), tt.wantArchived)
+			}
+			if len(archiver.archived) > 0 && archiver.archived[0].reason != tt.wantReason {
+				t.Errorf("archive reason = %q, want %q", archiver.archived[0].reason, tt.wantReason)
+			}
+
+			// Verify old session ended.
+			endCalls := filterSessions(archiver.sessions, "end")
+			if len(endCalls) != 1 {
+				t.Errorf("end session calls = %d, want 1", len(endCalls))
+			}
+
+			// Verify new session started.
+			startCalls := filterSessions(archiver.sessions, "start")
+			if len(startCalls) != 1 {
+				t.Errorf("start session calls = %d, want 1", len(startCalls))
+			}
+
+			// Verify carry-forward injection.
+			if tt.wantHandoff {
+				if len(mem.summaries) != 1 {
+					t.Fatalf("summaries = %d, want 1", len(mem.summaries))
+				}
+				if !strings.Contains(mem.summaries[0].summary, "[Session Handoff]") {
+					t.Errorf("summary missing [Session Handoff] prefix: %q", mem.summaries[0].summary)
+				}
+				if !strings.Contains(mem.summaries[0].summary, tt.carryForward) {
+					t.Errorf("summary missing carry-forward content")
+				}
+			} else {
+				if len(mem.summaries) != 0 {
+					t.Errorf("summaries = %d, want 0 (no carry-forward)", len(mem.summaries))
+				}
+			}
+
+			// Verify old messages were cleared (only carry-forward remains, if any).
+			msgs := mem.GetMessages("conv1")
+			for _, m := range msgs {
+				if m.Role != "system" {
+					t.Errorf("non-system message survived close: role=%s content=%q", m.Role, m.Content)
+				}
+			}
+		})
+	}
+}
+
+func TestCheckpointSession(t *testing.T) {
+	tests := []struct {
+		name       string
+		messages   []memory.Message
+		label      string
+		wantReason string
+		wantErr    bool
+	}{
+		{
+			name: "basic checkpoint",
+			messages: []memory.Message{
+				{Role: "user", Content: "hello"},
+				{Role: "assistant", Content: "hi"},
+			},
+			label:      "pre-refactor",
+			wantReason: "checkpoint:pre-refactor",
+		},
+		{
+			name: "checkpoint with empty label",
+			messages: []memory.Message{
+				{Role: "user", Content: "test"},
+			},
+			label:      "",
+			wantReason: "checkpoint",
+		},
+		{
+			name:     "checkpoint with no messages fails",
+			messages: nil,
+			label:    "empty",
+			wantErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mem := newMockMemWithCompaction()
+			archiver := &mockArchiver{activeID: "active-session"}
+			loop := newTestLoop(mem, archiver)
+
+			for _, m := range tt.messages {
+				_ = mem.AddMessage("conv1", m.Role, m.Content)
+			}
+
+			err := loop.CheckpointSession("conv1", tt.label)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("CheckpointSession() error: %v", err)
+			}
+
+			// Verify archive was called with checkpoint reason.
+			if len(archiver.archived) != 1 {
+				t.Fatalf("archived calls = %d, want 1", len(archiver.archived))
+			}
+			if archiver.archived[0].reason != tt.wantReason {
+				t.Errorf("archive reason = %q, want %q", archiver.archived[0].reason, tt.wantReason)
+			}
+
+			// Verify session was NOT ended (checkpoint doesn't end sessions).
+			endCalls := filterSessions(archiver.sessions, "end")
+			if len(endCalls) != 0 {
+				t.Errorf("end session calls = %d, want 0 (checkpoint should not end session)", len(endCalls))
+			}
+
+			// Verify messages are still in memory (checkpoint doesn't clear).
+			msgs := mem.GetMessages("conv1")
+			if len(msgs) != len(tt.messages) {
+				t.Errorf("messages after checkpoint = %d, want %d", len(msgs), len(tt.messages))
+			}
+		})
+	}
+}
+
+func TestCheckpointSession_NoArchiver(t *testing.T) {
+	mem := newMockMemWithCompaction()
+	loop := newTestLoop(mem, nil) // no archiver
+
+	err := loop.CheckpointSession("conv1", "test")
+	if err == nil {
+		t.Fatal("expected error when no archiver configured")
+	}
+}
+
+func TestSplitSession(t *testing.T) {
+	tests := []struct {
+		name          string
+		messages      []memory.Message
+		atIndex       int
+		atMessage     string
+		wantPreSplit  int
+		wantPostSplit int
+		wantErr       bool
+		errContains   string
+	}{
+		{
+			name: "split by negative index",
+			messages: []memory.Message{
+				{Role: "user", Content: "msg1"},
+				{Role: "assistant", Content: "msg2"},
+				{Role: "user", Content: "msg3"},
+				{Role: "assistant", Content: "msg4"},
+				{Role: "user", Content: "msg5"},
+			},
+			atIndex:       -2,
+			wantPreSplit:  3,
+			wantPostSplit: 2,
+		},
+		{
+			name: "split by message content",
+			messages: []memory.Message{
+				{Role: "user", Content: "let's talk about weather"},
+				{Role: "assistant", Content: "sure, it's sunny"},
+				{Role: "user", Content: "now let's discuss cooking"},
+				{Role: "assistant", Content: "great topic"},
+			},
+			atMessage:     "discuss cooking",
+			wantPreSplit:  2,
+			wantPostSplit: 2,
+		},
+		{
+			name: "split at -1 keeps only last message",
+			messages: []memory.Message{
+				{Role: "user", Content: "old"},
+				{Role: "assistant", Content: "also old"},
+				{Role: "user", Content: "newest"},
+			},
+			atIndex:       -1,
+			wantPreSplit:  2,
+			wantPostSplit: 1,
+		},
+		{
+			name: "index out of range",
+			messages: []memory.Message{
+				{Role: "user", Content: "only one"},
+			},
+			atIndex:     -5,
+			wantErr:     true,
+			errContains: "out of range",
+		},
+		{
+			name: "no matching message",
+			messages: []memory.Message{
+				{Role: "user", Content: "hello"},
+				{Role: "assistant", Content: "hi"},
+			},
+			atMessage:   "nonexistent content",
+			wantErr:     true,
+			errContains: "no message found",
+		},
+		{
+			name:     "empty messages",
+			messages: nil,
+			atIndex:  -1,
+			wantErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mem := newMockMemWithCompaction()
+			archiver := &mockArchiver{activeID: "active-session"}
+			loop := newTestLoop(mem, archiver)
+
+			for _, m := range tt.messages {
+				_ = mem.AddMessage("conv1", m.Role, m.Content)
+			}
+
+			err := loop.SplitSession("conv1", tt.atIndex, tt.atMessage)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				if tt.errContains != "" && !strings.Contains(err.Error(), tt.errContains) {
+					t.Errorf("error %q should contain %q", err.Error(), tt.errContains)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("SplitSession() error: %v", err)
+			}
+
+			// Verify pre-split messages were archived.
+			if len(archiver.archived) != 1 {
+				t.Fatalf("archived calls = %d, want 1", len(archiver.archived))
+			}
+			if len(archiver.archived[0].messages) != tt.wantPreSplit {
+				t.Errorf("archived messages = %d, want %d", len(archiver.archived[0].messages), tt.wantPreSplit)
+			}
+			if archiver.archived[0].reason != "split" {
+				t.Errorf("archive reason = %q, want %q", archiver.archived[0].reason, "split")
+			}
+
+			// Verify old session ended.
+			endCalls := filterSessions(archiver.sessions, "end")
+			if len(endCalls) != 1 {
+				t.Errorf("end session calls = %d, want 1", len(endCalls))
+			}
+
+			// Verify new session started.
+			startCalls := filterSessions(archiver.sessions, "start")
+			if len(startCalls) != 1 {
+				t.Errorf("start session calls = %d, want 1", len(startCalls))
+			}
+
+			// Verify post-split messages retained in memory.
+			msgs := mem.GetMessages("conv1")
+			if len(msgs) != tt.wantPostSplit {
+				t.Errorf("messages after split = %d, want %d", len(msgs), tt.wantPostSplit)
+			}
+		})
+	}
+}
+
+func TestSplitSession_NoArchiver(t *testing.T) {
+	mem := newMockMemWithCompaction()
+	loop := newTestLoop(mem, nil)
+
+	err := loop.SplitSession("conv1", -1, "")
+	if err == nil {
+		t.Fatal("expected error when no archiver configured")
+	}
+}
+
+func TestFindSplitPoint(t *testing.T) {
+	msgs := []memory.Message{
+		{Role: "user", Content: "first message"},
+		{Role: "assistant", Content: "second message"},
+		{Role: "user", Content: "third message about cooking"},
+		{Role: "assistant", Content: "fourth message"},
+		{Role: "user", Content: "fifth message"},
+	}
+
+	tests := []struct {
+		name      string
+		atIndex   int
+		atMessage string
+		want      int
+		wantErr   bool
+	}{
+		{name: "index -1", atIndex: -1, want: 4},
+		{name: "index -3", atIndex: -3, want: 2},
+		{name: "index -4", atIndex: -4, want: 1},
+		{name: "message match", atMessage: "cooking", want: 2},
+		{name: "message match first occurrence", atMessage: "message", want: 1},
+		{name: "index too far back", atIndex: -5, wantErr: true},
+		{name: "index at zero", atIndex: -6, wantErr: true},
+		{name: "no match", atMessage: "nonexistent", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := findSplitPoint(msgs, tt.atIndex, tt.atMessage)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("findSplitPoint() error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("findSplitPoint() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+// filterSessions returns session calls matching the given action.
+func filterSessions(calls []sessionCall, action string) []sessionCall {
+	var filtered []sessionCall
+	for _, c := range calls {
+		if c.action == action {
+			filtered = append(filtered, c)
+		}
+	}
+	return filtered
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -813,6 +813,7 @@ func (c *Config) applyDefaults() {
 			"save_contact",
 			"lookup_contact",
 			"session_working_memory",
+			"session_close",
 			"archive_search",
 		}
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -109,7 +109,7 @@ func TestAgentConfig_DefaultIter0Tools(t *testing.T) {
 		t.Fatal("expected delegation_required to be true")
 	}
 
-	want := []string{"thane_delegate", "recall_fact", "remember_fact", "save_contact", "lookup_contact", "session_working_memory", "archive_search"}
+	want := []string{"thane_delegate", "recall_fact", "remember_fact", "save_contact", "lookup_contact", "session_working_memory", "session_close", "archive_search"}
 	if len(cfg.Agent.Iter0Tools) != len(want) {
 		t.Fatalf("iter0_tools length = %d, want %d; got %v", len(cfg.Agent.Iter0Tools), len(want), cfg.Agent.Iter0Tools)
 	}

--- a/internal/tools/session_tools.go
+++ b/internal/tools/session_tools.go
@@ -1,11 +1,30 @@
 package tools
 
-import "context"
+import (
+	"context"
+	"fmt"
+)
 
 // ConversationResetter is the interface for resetting conversations.
 // Implemented by agent.Loop.
 type ConversationResetter interface {
 	ResetConversation(conversationID string) error
+}
+
+// SessionManager provides granular session lifecycle control beyond
+// the nuclear conversation_reset. Implemented by agent.Loop.
+type SessionManager interface {
+	// CloseSession gracefully closes the current session, archives messages,
+	// injects a carry-forward handoff into the new session, and starts fresh.
+	CloseSession(conversationID, reason, carryForward string) error
+	// CheckpointSession snapshots current conversation state without ending
+	// the session. A safety net against crashes or compaction losing state.
+	CheckpointSession(conversationID, label string) error
+	// SplitSession retroactively splits the current session at a past message
+	// boundary. Everything before the split point is archived; everything
+	// after becomes the current session. Exactly one of atIndex or atMessage
+	// must be provided (atIndex is a negative offset from the end).
+	SplitSession(conversationID string, atIndex int, atMessage string) error
 }
 
 // SetConversationResetter adds conversation management tools to the registry.
@@ -36,6 +55,146 @@ func (r *Registry) SetConversationResetter(resetter ConversationResetter) {
 			}
 
 			return "Conversation " + convID + " reset successfully. All previous messages have been archived. Reason: " + reason, nil
+		},
+	})
+}
+
+// SetSessionManager adds granular session management tools to the registry.
+func (r *Registry) SetSessionManager(mgr SessionManager) {
+	r.registerSessionClose(mgr)
+	r.registerSessionCheckpoint(mgr)
+	r.registerSessionSplit(mgr)
+}
+
+// registerSessionClose registers the session_close tool.
+func (r *Registry) registerSessionClose(mgr SessionManager) {
+	r.Register(&Tool{
+		Name: "session_close",
+		Description: "Gracefully close the current session and start a fresh one. " +
+			"Archives all messages, triggers summarization, and injects a carry-forward " +
+			"handoff summary into the new session. Use when transitioning between distinct " +
+			"topics or when context has grown stale but you want to preserve continuity. " +
+			"Prefer this over conversation_reset when you want to maintain a thread of context.",
+		Parameters: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"reason": map[string]any{
+					"type":        "string",
+					"description": "Why the session is being closed (e.g., 'topic change', 'context refresh')",
+				},
+				"carry_forward": map[string]any{
+					"type": "string",
+					"description": "Handoff summary for the new session. Include key context, decisions, " +
+						"and open threads that the new session should know about. Write as notes " +
+						"to your future self.",
+				},
+			},
+			"required": []string{"carry_forward"},
+		},
+		Handler: func(ctx context.Context, args map[string]any) (string, error) {
+			convID := ConversationIDFromContext(ctx)
+			reason, _ := args["reason"].(string)
+			if reason == "" {
+				reason = "session close"
+			}
+			carryForward, _ := args["carry_forward"].(string)
+
+			if err := mgr.CloseSession(convID, reason, carryForward); err != nil {
+				return "", fmt.Errorf("close session: %w", err)
+			}
+
+			return fmt.Sprintf("Session closed (%s). New session started with carry-forward context injected.", reason), nil
+		},
+	})
+}
+
+// registerSessionCheckpoint registers the session_checkpoint tool.
+func (r *Registry) registerSessionCheckpoint(mgr SessionManager) {
+	r.Register(&Tool{
+		Name: "session_checkpoint",
+		Description: "Create a checkpoint of the current session state without ending it. " +
+			"Archives a snapshot of all messages as a safety net. The current session " +
+			"continues uninterrupted. Use before risky operations or when you want to " +
+			"preserve state at a known-good point.",
+		Parameters: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"label": map[string]any{
+					"type":        "string",
+					"description": "Short label for this checkpoint (e.g., 'pre-refactor', 'before migration')",
+				},
+			},
+		},
+		Handler: func(ctx context.Context, args map[string]any) (string, error) {
+			convID := ConversationIDFromContext(ctx)
+			label, _ := args["label"].(string)
+			if label == "" {
+				label = "manual"
+			}
+
+			if err := mgr.CheckpointSession(convID, label); err != nil {
+				return "", fmt.Errorf("checkpoint session: %w", err)
+			}
+
+			return fmt.Sprintf("Checkpoint created (%s). Session continues.", label), nil
+		},
+	})
+}
+
+// registerSessionSplit registers the session_split tool.
+func (r *Registry) registerSessionSplit(mgr SessionManager) {
+	r.Register(&Tool{
+		Name: "session_split",
+		Description: "Retroactively split the current session at a past message boundary. " +
+			"Everything before the split point is archived as a completed session; " +
+			"everything after becomes the start of the current session. " +
+			"Provide either at_index (negative offset from end) or at_message (substring match), not both.",
+		Parameters: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"at_index": map[string]any{
+					"type":        "integer",
+					"description": "Split at this message offset from the end (negative, e.g., -5 means 5 messages back from the end)",
+				},
+				"at_message": map[string]any{
+					"type":        "string",
+					"description": "Split before the first message whose content contains this substring",
+				},
+			},
+		},
+		Handler: func(ctx context.Context, args map[string]any) (string, error) {
+			convID := ConversationIDFromContext(ctx)
+
+			var atIndex int
+			var atMessage string
+
+			if v, ok := args["at_index"]; ok {
+				switch n := v.(type) {
+				case float64:
+					atIndex = int(n)
+				case int:
+					atIndex = n
+				}
+			}
+			if v, ok := args["at_message"].(string); ok {
+				atMessage = v
+			}
+
+			if atIndex == 0 && atMessage == "" {
+				return "", fmt.Errorf("provide either at_index (negative offset) or at_message (substring match)")
+			}
+			if atIndex != 0 && atMessage != "" {
+				return "", fmt.Errorf("provide either at_index or at_message, not both")
+			}
+			if atIndex > 0 {
+				return "", fmt.Errorf("at_index must be negative (offset from end)")
+			}
+
+			if err := mgr.SplitSession(convID, atIndex, atMessage); err != nil {
+				return "", fmt.Errorf("split session: %w", err)
+			}
+
+			return "Session split successfully. Pre-split messages archived; post-split messages retained in current session.", nil
 		},
 	})
 }


### PR DESCRIPTION
## Summary

- Adds three new session management tools for granular session lifecycle control (#258):
  - **`session_close`**: Gracefully closes the current session, archives messages, and injects a carry-forward handoff summary (`[Session Handoff]`) into the new session for continuity across topic transitions
  - **`session_checkpoint`**: Archives a snapshot of current conversation state without ending the session — a safety net before risky operations
  - **`session_split`**: Retroactively splits the current session at a past message boundary (by negative index or substring match), archiving pre-split messages and retaining post-split
- Refactors `ResetConversation` and `ShutdownArchive` to share new `archiveAndEndSession`/`getAllMessages` helpers, eliminating duplicated archive+end logic
- Adds `session_close` to default `iter0_tools` for orchestrator mode access
- Wired via `SessionManager` interface + `SetSessionManager(loop)` in `main.go`

## Test plan

- [x] Unit tests for `CloseSession` (carry-forward injection, reason defaults, memory clearing)
- [x] Unit tests for `CheckpointSession` (archive without session end, memory preserved)
- [x] Unit tests for `SplitSession` (index-based, substring-based, edge cases)
- [x] Unit tests for `findSplitPoint` (boundary conditions, error cases)
- [x] `just ci` passes (lint, fmt, race-tested)
- [ ] Manual smoke test: invoke `session_close` and verify carry-forward appears in new session

Closes #258

🤖 Generated with [Claude Code](https://claude.com/claude-code)