### PR TITLE
fix: rescue top-level save_contact fields as facts

### DIFF
--- a/internal/contacts/tools.go
+++ b/internal/contacts/tools.go
@@ -77,6 +77,10 @@ func (t *Tools) SaveContact(argsJSON string) (string, error) {
 			if saveContactKnownFields[k] {
 				continue
 			}
+			// Do not overwrite facts that were explicitly provided.
+			if _, exists := args.Facts[k]; exists {
+				continue
+			}
 			if s, ok := v.(string); ok && s != "" {
 				args.Facts[k] = s
 				rescued = append(rescued, k)
@@ -84,7 +88,7 @@ func (t *Tools) SaveContact(argsJSON string) (string, error) {
 		}
 		if len(rescued) > 0 {
 			sort.Strings(rescued)
-			slog.Warn("rescued top-level fields as facts",
+			slog.Debug("rescued top-level fields as facts",
 				"name", args.Name, "fields", rescued)
 		}
 	}

--- a/internal/contacts/tools_test.go
+++ b/internal/contacts/tools_test.go
@@ -170,6 +170,34 @@ func TestSaveContact_TopLevelFieldsMergeWithExplicitFacts(t *testing.T) {
 	}
 }
 
+func TestSaveContact_ExplicitFactsTakePrecedence(t *testing.T) {
+	tools := newTestTools(t)
+
+	// When the same key appears both top-level and in facts, the explicit
+	// facts value must win — rescue should not overwrite it.
+	_, err := tools.SaveContact(`{
+		"name": "Conflict Fields",
+		"email": "top-level@example.com",
+		"facts": {"email": "explicit@example.com"}
+	}`)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	c, err := tools.store.FindByName("Conflict Fields")
+	if err != nil {
+		t.Fatal(err)
+	}
+	facts, err := tools.store.GetFacts(c.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(facts["email"]) != 1 || facts["email"][0] != "explicit@example.com" {
+		t.Errorf("email = %v, want [explicit@example.com] (explicit facts should win)", facts["email"])
+	}
+}
+
 func TestSaveContact_TopLevelFieldsIgnoreNonString(t *testing.T) {
 	tools := newTestTools(t)
 


### PR DESCRIPTION
## Summary

- Models consistently pass `email`, `phone`, `notes`, `organization` as top-level JSON keys instead of nesting under `facts`
- Go's `json.Unmarshal` silently ignores unknown fields, causing data loss (caught in production — James Harren contact lost email and notes)
- After initial unmarshal, re-parse into `map[string]any` and migrate unrecognized top-level string values into the `Facts` map
- Non-string values (numbers, booleans) are ignored
- `slog.Warn` emitted when fields are rescued for debug visibility
- Backward-compatible: properly structured calls with `facts:{}` work exactly as before

## Test plan

- [x] Top-level email, phone, notes rescued as facts on new contact
- [x] Top-level fields merge with explicit `facts` map entries
- [x] Non-string top-level values (int, bool) ignored
- [x] Rescue works on update path (existing contact)
- [x] Existing tests still pass (backward compatibility)

Fixes #268