### PR TITLE
fix: re-read inject_files on every turn instead of only at startup

### DIFF
--- a/internal/agent/ego_prompt_test.go
+++ b/internal/agent/ego_prompt_test.go
@@ -97,3 +97,78 @@ func TestBuildSystemPrompt_NoEgoFile(t *testing.T) {
 		t.Error("system prompt should not contain ego section when egoFile is not set")
 	}
 }
+
+// --- inject_files tests ---
+
+func TestBuildSystemPrompt_InjectFilesIncluded(t *testing.T) {
+	dir := t.TempDir()
+	f1 := filepath.Join(dir, "MEMORY.md")
+	f2 := filepath.Join(dir, "USER.md")
+	os.WriteFile(f1, []byte("# Shared Memory\nkey fact"), 0644)
+	os.WriteFile(f2, []byte("# User Notes\npreference"), 0644)
+
+	l := newMinimalLoop()
+	l.SetInjectFiles([]string{f1, f2})
+
+	prompt := l.buildSystemPrompt(context.Background(), "hello", nil)
+
+	if !strings.Contains(prompt, "key fact") {
+		t.Error("system prompt should contain first inject file content")
+	}
+	if !strings.Contains(prompt, "preference") {
+		t.Error("system prompt should contain second inject file content")
+	}
+	if !strings.Contains(prompt, "Injected Context") {
+		t.Error("system prompt should contain injected context section heading")
+	}
+	if !strings.Contains(prompt, "---") {
+		t.Error("system prompt should contain separator between inject files")
+	}
+}
+
+func TestBuildSystemPrompt_InjectFilesRereadOnChange(t *testing.T) {
+	dir := t.TempDir()
+	f := filepath.Join(dir, "MEMORY.md")
+	os.WriteFile(f, []byte("version-1"), 0644)
+
+	l := newMinimalLoop()
+	l.SetInjectFiles([]string{f})
+
+	prompt1 := l.buildSystemPrompt(context.Background(), "hello", nil)
+	if !strings.Contains(prompt1, "version-1") {
+		t.Fatal("first prompt should contain version-1")
+	}
+
+	// Modify the file between turns.
+	os.WriteFile(f, []byte("version-2"), 0644)
+
+	prompt2 := l.buildSystemPrompt(context.Background(), "hello", nil)
+	if strings.Contains(prompt2, "version-1") {
+		t.Error("second prompt should not contain stale version-1")
+	}
+	if !strings.Contains(prompt2, "version-2") {
+		t.Error("second prompt should contain updated version-2")
+	}
+}
+
+func TestBuildSystemPrompt_InjectFilesMissing(t *testing.T) {
+	l := newMinimalLoop()
+	l.SetInjectFiles([]string{filepath.Join(t.TempDir(), "nonexistent.md")})
+
+	prompt := l.buildSystemPrompt(context.Background(), "hello", nil)
+
+	if strings.Contains(prompt, "Injected Context") {
+		t.Error("system prompt should not contain injected context section when all files are missing")
+	}
+}
+
+func TestBuildSystemPrompt_InjectFilesEmpty(t *testing.T) {
+	l := newMinimalLoop()
+	// injectFiles not set — default nil
+
+	prompt := l.buildSystemPrompt(context.Background(), "hello", nil)
+
+	if strings.Contains(prompt, "Injected Context") {
+		t.Error("system prompt should not contain injected context section when no files configured")
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -328,14 +328,14 @@ type EmbeddingsConfig struct {
 	BaseURL string `yaml:"baseurl"` // Ollama URL for embeddings. Default: models.ollama_url
 }
 
-// ContextConfig configures static context injection into the system prompt.
-// Files listed in InjectFiles are read at session start and appended to the
-// system prompt, giving the agent immediate access to key knowledge without
-// spending tool call iterations reading files.
+// ContextConfig configures context injection into the system prompt.
+// Files listed in InjectFiles are re-read on every agent turn so that
+// external edits (e.g. MEMORY.md updated by another runtime) are
+// visible without restart. Paths are resolved once at startup.
 type ContextConfig struct {
-	// InjectFiles is a list of file paths to read and inject into the
-	// system prompt. Paths support ~ expansion. Missing or unreadable
-	// files are skipped with a warning.
+	// InjectFiles is a list of file paths to re-read and inject into
+	// the system prompt on every turn. Paths support ~ expansion.
+	// Missing or unreadable files are silently skipped at read time.
 	InjectFiles []string `yaml:"inject_files"`
 }
 


### PR DESCRIPTION
## Summary
- `inject_files` (MEMORY.md, USER.md, etc.) were read once at startup and cached as a static string — on-disk changes were invisible until restart
- Now files are re-read on every agent turn in `buildSystemPrompt()`, matching the existing `ego.md` fresh-read pattern
- Startup wiring simplified: resolves paths (tilde expansion, existence warnings) but defers content reads to call time
- Files that appear after startup are also picked up (paths are always included even if missing at boot)

## Test plan
- [x] `just ci` passes locally (fmt-check + lint + test with `-race`)
- [x] `TestBuildSystemPrompt_InjectFilesIncluded` — content from multiple files appears with separators
- [x] `TestBuildSystemPrompt_InjectFilesRereadOnChange` — file modified between turns, new content picked up
- [x] `TestBuildSystemPrompt_InjectFilesMissing` — missing files silently skipped, no section emitted
- [x] `TestBuildSystemPrompt_InjectFilesEmpty` — no section when no files configured
- [x] No references to `injectedContext` or `SetInjectedContext` remain
- [ ] Verify cross-runtime: edit MEMORY.md externally while Thane is running, confirm next turn sees changes

Closes #284