### PR TITLE
fix: tighten tool descriptions to prevent cross-contamination between stores

### DIFF
--- a/internal/facts/tools.go
+++ b/internal/facts/tools.go
@@ -213,14 +213,14 @@ func (t *Tools) GetDefinitions() []map[string]any {
 			"type": "function",
 			"function": map[string]any{
 				"name":        "remember_fact",
-				"description": "Store a piece of information for later recall. Use for user preferences, home layout, device mappings, or observed patterns.",
+				"description": "Store a discrete, stable piece of information for later recall. Best for user preferences, home layout, device mappings, routines, or observed patterns. Each fact should be a single, self-contained piece of knowledge — not a project spec or design document. Do NOT store complex/evolving knowledge here — use workspace files instead. Do NOT store person-specific attributes — use save_contact instead.",
 				"parameters": map[string]any{
 					"type": "object",
 					"properties": map[string]any{
 						"category": map[string]any{
 							"type":        "string",
 							"enum":        []string{"user", "home", "device", "routine", "preference", "architecture"},
-							"description": "Category for organizing the fact",
+							"description": "Category: user (preferences, habits), home (household, rooms, pets), device (hardware, mappings), routine (schedules, workflows), preference (interaction/communication prefs), architecture (system design decisions)",
 						},
 						"key": map[string]any{
 							"type":        "string",

--- a/internal/tools/contact_tools.go
+++ b/internal/tools/contact_tools.go
@@ -21,7 +21,7 @@ func (r *Registry) registerContactTools() {
 
 	r.Register(&Tool{
 		Name:        "save_contact",
-		Description: "Store or update a person or organization in the contact directory. Use for people, companies, or organizations you interact with. Supports structured attributes like email, phone, role, etc. When updating an existing contact, only non-empty fields are overwritten.",
+		Description: "Store or update a person or organization in the contact directory. Contact facts should be personal attributes only: relationship notes, communication preferences, trust levels, aliases, and contact info (email, phone, role). Do NOT store project knowledge, design philosophy, technical insights, or collaboration patterns here — use remember_fact or workspace files instead. When updating an existing contact, only non-empty fields are overwritten.",
 		Parameters: map[string]any{
 			"type": "object",
 			"properties": map[string]any{
@@ -48,7 +48,7 @@ func (r *Registry) registerContactTools() {
 				},
 				"facts": map[string]any{
 					"type":                 "object",
-					"description":          "Structured attributes as key-value pairs (e.g., {\"email\": \"alice@example.com\", \"phone\": \"555-1234\"})",
+					"description":          "Personal attributes as key-value pairs (e.g., {\"email\": \"alice@example.com\", \"phone\": \"555-1234\", \"preferred_name\": \"Ali\"}). Only store contact info and personal traits — not project knowledge or technical notes.",
 					"additionalProperties": map[string]any{"type": "string"},
 				},
 			},

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -110,14 +110,14 @@ func (r *Registry) registerFactTools() {
 
 	r.Register(&Tool{
 		Name:        "remember_fact",
-		Description: "Store a piece of information for later recall. Use for user preferences, home layout, device mappings, or observed patterns.",
+		Description: "Store a discrete, stable piece of information for later recall. Best for user preferences, home layout, device mappings, routines, or observed patterns. Each fact should be a single, self-contained piece of knowledge — not a project spec or design document. Do NOT store complex/evolving knowledge here — use workspace files instead. Do NOT store person-specific attributes — use save_contact instead.",
 		Parameters: map[string]any{
 			"type": "object",
 			"properties": map[string]any{
 				"category": map[string]any{
 					"type":        "string",
 					"enum":        []string{"user", "home", "device", "routine", "preference"},
-					"description": "Category for organizing the fact",
+					"description": "Category: user (preferences, habits), home (household, rooms, pets), device (hardware, mappings), routine (schedules, workflows), preference (interaction/communication prefs)",
 				},
 				"key": map[string]any{
 					"type":        "string",


### PR DESCRIPTION
## Summary
- Update `remember_fact` description to clarify it's for discrete, stable knowledge — not project specs or design documents. Adds explicit "Do NOT" guidance for workspace files and contacts.
- Update `save_contact` description to clarify contact facts are personal attributes only — not project knowledge or technical insights.
- Add per-category descriptions to the `category` enum parameter so the model understands what belongs in each bucket.
- Updates applied to both `internal/tools/tools.go` and `internal/facts/tools.go` (dual definition sites for fact tools).

Closes #289

## Test plan
- [x] `just ci` passes clean — no schema changes, description-only updates
- Behavioral validation: observe Thane's storage choices in production to confirm reduced cross-contamination

🤖 Generated with [Claude Code](https://claude.com/claude-code)