### PR TITLE
feat: add email send, reply, and move tools with SMTP support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,9 +7,11 @@ toolchain go1.24.4
 require (
 	github.com/eclipse/paho.golang v0.23.0
 	github.com/emersion/go-imap/v2 v2.0.0-beta.8
+	github.com/emersion/go-message v0.18.2
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/websocket v1.5.3
 	github.com/mattn/go-sqlite3 v1.14.33
+	github.com/yuin/goldmark v1.4.13
 	golang.org/x/net v0.50.0
 	gopkg.in/yaml.v3 v3.0.1
 	modernc.org/sqlite v1.45.0
@@ -17,7 +19,6 @@ require (
 
 require (
 	github.com/dustin/go-humanize v1.0.1 // indirect
-	github.com/emersion/go-message v0.18.2 // indirect
 	github.com/emersion/go-sasl v0.0.0-20241020182733-b788ff22d5a6 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/ncruces/go-strftime v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -32,6 +32,7 @@ github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+github.com/yuin/goldmark v1.4.13 h1:fVcFKWvrslecOb/tg+Cc05dkeYx540o0FuFt3nUVDoE=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=

--- a/internal/email/compose.go
+++ b/internal/email/compose.go
@@ -1,0 +1,215 @@
+package email
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/emersion/go-message/mail"
+	"github.com/yuin/goldmark"
+)
+
+// ComposeOptions holds everything needed to build a complete RFC 5322
+// message. The Body field is expected to be markdown.
+type ComposeOptions struct {
+	// From is the sender address (e.g., "Name <addr@host>").
+	From string
+
+	// To is the list of recipient addresses.
+	To []string
+
+	// Cc is the list of CC addresses.
+	Cc []string
+
+	// Bcc is the list of BCC addresses.
+	Bcc []string
+
+	// Subject is the message subject line.
+	Subject string
+
+	// Body is the message body in markdown format.
+	Body string
+
+	// InReplyTo is the Message-ID of the parent message (for replies).
+	InReplyTo string
+
+	// References is the full References chain (for threading).
+	References []string
+}
+
+// ComposeMessage builds a complete RFC 5322 MIME message from the given
+// options. The body markdown is converted to both text/plain and
+// text/html parts in a multipart/alternative structure.
+func ComposeMessage(opts ComposeOptions) ([]byte, error) {
+	var buf bytes.Buffer
+
+	// Build the mail header.
+	var h mail.Header
+
+	h.SetDate(time.Now())
+	if err := h.GenerateMessageID(); err != nil {
+		return nil, fmt.Errorf("generate message-id: %w", err)
+	}
+	h.SetSubject(opts.Subject)
+
+	from, err := mail.ParseAddress(opts.From)
+	if err != nil {
+		return nil, fmt.Errorf("parse from address %q: %w", opts.From, err)
+	}
+	h.SetAddressList("From", []*mail.Address{from})
+
+	toAddrs, err := parseAddressList(opts.To)
+	if err != nil {
+		return nil, fmt.Errorf("parse to addresses: %w", err)
+	}
+	h.SetAddressList("To", toAddrs)
+
+	if len(opts.Cc) > 0 {
+		ccAddrs, err := parseAddressList(opts.Cc)
+		if err != nil {
+			return nil, fmt.Errorf("parse cc addresses: %w", err)
+		}
+		h.SetAddressList("Cc", ccAddrs)
+	}
+
+	if len(opts.Bcc) > 0 {
+		bccAddrs, err := parseAddressList(opts.Bcc)
+		if err != nil {
+			return nil, fmt.Errorf("parse bcc addresses: %w", err)
+		}
+		h.SetAddressList("Bcc", bccAddrs)
+	}
+
+	// Threading headers for replies.
+	if opts.InReplyTo != "" {
+		h.SetMsgIDList("In-Reply-To", []string{opts.InReplyTo})
+	}
+	if len(opts.References) > 0 {
+		h.SetMsgIDList("References", opts.References)
+	}
+
+	// Create the mail writer.
+	mw, err := mail.CreateWriter(&buf, h)
+	if err != nil {
+		return nil, fmt.Errorf("create mail writer: %w", err)
+	}
+
+	// Create multipart/alternative inline section.
+	tw, err := mw.CreateInline()
+	if err != nil {
+		return nil, fmt.Errorf("create inline writer: %w", err)
+	}
+
+	// text/plain part: markdown stripped to plain text.
+	plainText := markdownToPlain(opts.Body)
+
+	var ph mail.InlineHeader
+	ph.Set("Content-Type", "text/plain; charset=utf-8")
+	pw, err := tw.CreatePart(ph)
+	if err != nil {
+		return nil, fmt.Errorf("create plain text part: %w", err)
+	}
+	if _, err := io.WriteString(pw, plainText); err != nil {
+		return nil, fmt.Errorf("write plain text: %w", err)
+	}
+	if err := pw.Close(); err != nil {
+		return nil, fmt.Errorf("close plain text part: %w", err)
+	}
+
+	// text/html part: markdown rendered to HTML.
+	htmlContent, err := markdownToHTML(opts.Body)
+	if err != nil {
+		return nil, fmt.Errorf("render markdown to HTML: %w", err)
+	}
+
+	var hh mail.InlineHeader
+	hh.Set("Content-Type", "text/html; charset=utf-8")
+	hw, err := tw.CreatePart(hh)
+	if err != nil {
+		return nil, fmt.Errorf("create html part: %w", err)
+	}
+	if _, err := io.WriteString(hw, htmlContent); err != nil {
+		return nil, fmt.Errorf("write html: %w", err)
+	}
+	if err := hw.Close(); err != nil {
+		return nil, fmt.Errorf("close html part: %w", err)
+	}
+
+	if err := tw.Close(); err != nil {
+		return nil, fmt.Errorf("close inline writer: %w", err)
+	}
+	if err := mw.Close(); err != nil {
+		return nil, fmt.Errorf("close mail writer: %w", err)
+	}
+
+	return buf.Bytes(), nil
+}
+
+// parseAddressList parses a slice of email address strings into
+// mail.Address values. Each string can be "Name <addr>" or just "addr".
+func parseAddressList(addrs []string) ([]*mail.Address, error) {
+	result := make([]*mail.Address, 0, len(addrs))
+	for _, a := range addrs {
+		parsed, err := mail.ParseAddress(a)
+		if err != nil {
+			return nil, fmt.Errorf("parse address %q: %w", a, err)
+		}
+		result = append(result, parsed)
+	}
+	return result, nil
+}
+
+// markdownToHTML renders markdown to an HTML document fragment suitable
+// for email. The output is wrapped in minimal HTML structure with no
+// external resources.
+func markdownToHTML(md string) (string, error) {
+	var buf bytes.Buffer
+	if err := goldmark.Convert([]byte(md), &buf); err != nil {
+		return "", err
+	}
+
+	// Wrap in minimal HTML envelope.
+	html := fmt.Sprintf(`<!DOCTYPE html>
+<html><head><meta charset="utf-8"></head>
+<body style="font-family: sans-serif; font-size: 14px; line-height: 1.5;">
+%s
+</body></html>`, buf.String())
+
+	return html, nil
+}
+
+// Patterns for stripping markdown formatting.
+var (
+	mdBold       = regexp.MustCompile(`\*\*(.+?)\*\*`)
+	mdItalic     = regexp.MustCompile(`\*(.+?)\*`)
+	mdLink       = regexp.MustCompile(`\[([^\]]+)\]\(([^)]+)\)`)
+	mdImage      = regexp.MustCompile(`!\[([^\]]*)\]\([^)]+\)`)
+	mdHeading    = regexp.MustCompile(`(?m)^#{1,6}\s+`)
+	mdCodeBlock  = regexp.MustCompile("(?s)```[a-zA-Z]*\n?(.*?)```")
+	mdInlineCode = regexp.MustCompile("`([^`]+)`")
+)
+
+// markdownToPlain converts markdown to plain text by stripping
+// formatting characters while preserving structure.
+func markdownToPlain(md string) string {
+	s := md
+
+	// Strip code blocks first (preserve content).
+	s = mdCodeBlock.ReplaceAllString(s, "$1")
+
+	// Strip inline formatting.
+	s = mdImage.ReplaceAllString(s, "$1")
+	s = mdLink.ReplaceAllString(s, "$1 ($2)")
+	s = mdBold.ReplaceAllString(s, "$1")
+	s = mdItalic.ReplaceAllString(s, "$1")
+	s = mdInlineCode.ReplaceAllString(s, "$1")
+	s = mdHeading.ReplaceAllString(s, "")
+
+	// Clean up list markers — leave them as-is since "- item" and
+	// "1. item" are perfectly readable as plain text.
+
+	return strings.TrimSpace(s)
+}

--- a/internal/email/compose_test.go
+++ b/internal/email/compose_test.go
@@ -1,0 +1,187 @@
+package email
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestMarkdownToPlain(t *testing.T) {
+	tests := []struct {
+		name string
+		md   string
+		want string
+	}{
+		{
+			name: "bold",
+			md:   "This is **bold** text",
+			want: "This is bold text",
+		},
+		{
+			name: "italic",
+			md:   "This is *italic* text",
+			want: "This is italic text",
+		},
+		{
+			name: "link",
+			md:   "Visit [Example](https://example.com) now",
+			want: "Visit Example (https://example.com) now",
+		},
+		{
+			name: "heading",
+			md:   "## Section Title\n\nSome text",
+			want: "Section Title\n\nSome text",
+		},
+		{
+			name: "inline code",
+			md:   "Use the `fmt.Println` function",
+			want: "Use the fmt.Println function",
+		},
+		{
+			name: "code block",
+			md:   "Before\n```go\nfmt.Println(\"hello\")\n```\nAfter",
+			want: "Before\nfmt.Println(\"hello\")\n\nAfter",
+		},
+		{
+			name: "image",
+			md:   "See ![alt text](https://example.com/img.png) here",
+			want: "See alt text here",
+		},
+		{
+			name: "list items preserved",
+			md:   "- item one\n- item two\n- item three",
+			want: "- item one\n- item two\n- item three",
+		},
+		{
+			name: "plain text unchanged",
+			md:   "Just some regular text.",
+			want: "Just some regular text.",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := markdownToPlain(tt.md)
+			if got != tt.want {
+				t.Errorf("markdownToPlain(%q) =\n  %q\nwant\n  %q", tt.md, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMarkdownToHTML(t *testing.T) {
+	html, err := markdownToHTML("Hello **world**")
+	if err != nil {
+		t.Fatalf("markdownToHTML() error: %v", err)
+	}
+
+	if !strings.Contains(html, "<strong>world</strong>") {
+		t.Error("HTML should contain <strong> tag for bold")
+	}
+	if !strings.Contains(html, "<!DOCTYPE html>") {
+		t.Error("HTML should have DOCTYPE wrapper")
+	}
+	if !strings.Contains(html, "charset=\"utf-8\"") && !strings.Contains(html, "charset=utf-8") {
+		t.Error("HTML should declare utf-8 charset")
+	}
+}
+
+func TestComposeMessage(t *testing.T) {
+	msg, err := ComposeMessage(ComposeOptions{
+		From:    "Test User <test@example.com>",
+		To:      []string{"recipient@example.com"},
+		Subject: "Test Subject",
+		Body:    "Hello **world**",
+	})
+	if err != nil {
+		t.Fatalf("ComposeMessage() error: %v", err)
+	}
+
+	s := string(msg)
+
+	// Check required headers.
+	// go-message quotes display names: From: "Test User" <test@example.com>.
+	if !strings.Contains(s, "From:") || !strings.Contains(s, "test@example.com") {
+		t.Errorf("message should contain From header with address, got headers:\n%s", s[:min(len(s), 500)])
+	}
+	if !strings.Contains(s, "To:") || !strings.Contains(s, "recipient@example.com") {
+		t.Errorf("message should contain To header with address, got headers:\n%s", s[:min(len(s), 500)])
+	}
+	if !strings.Contains(s, "Subject: Test Subject") {
+		t.Error("message should contain Subject header")
+	}
+	if !strings.Contains(s, "Message-Id:") {
+		t.Error("message should contain Message-Id header")
+	}
+	if !strings.Contains(s, "Date:") {
+		t.Error("message should contain Date header")
+	}
+
+	// Check multipart/alternative structure.
+	if !strings.Contains(s, "multipart/alternative") {
+		t.Error("message should be multipart/alternative")
+	}
+	if !strings.Contains(s, "text/plain") {
+		t.Error("message should contain text/plain part")
+	}
+	if !strings.Contains(s, "text/html") {
+		t.Error("message should contain text/html part")
+	}
+}
+
+func TestComposeMessage_WithThreading(t *testing.T) {
+	msg, err := ComposeMessage(ComposeOptions{
+		From:       "Test User <test@example.com>",
+		To:         []string{"recipient@example.com"},
+		Subject:    "Re: Original Subject",
+		Body:       "Reply body",
+		InReplyTo:  "abc123@example.com",
+		References: []string{"parent@example.com", "abc123@example.com"},
+	})
+	if err != nil {
+		t.Fatalf("ComposeMessage() error: %v", err)
+	}
+
+	s := string(msg)
+
+	if !strings.Contains(s, "In-Reply-To:") {
+		t.Error("reply message should contain In-Reply-To header")
+	}
+	if !strings.Contains(s, "References:") {
+		t.Error("reply message should contain References header")
+	}
+}
+
+func TestComposeMessage_WithCcBcc(t *testing.T) {
+	msg, err := ComposeMessage(ComposeOptions{
+		From:    "sender@example.com",
+		To:      []string{"to@example.com"},
+		Cc:      []string{"cc@example.com"},
+		Bcc:     []string{"bcc@example.com"},
+		Subject: "Test",
+		Body:    "Body",
+	})
+	if err != nil {
+		t.Fatalf("ComposeMessage() error: %v", err)
+	}
+
+	s := string(msg)
+
+	if !strings.Contains(s, "Cc:") {
+		t.Error("message should contain Cc header")
+	}
+	if !strings.Contains(s, "Bcc:") {
+		t.Error("message should contain Bcc header")
+	}
+}
+
+func TestComposeMessage_InvalidFrom(t *testing.T) {
+	_, err := ComposeMessage(ComposeOptions{
+		From:    "not-an-email",
+		To:      []string{"to@example.com"},
+		Subject: "Test",
+		Body:    "Body",
+	})
+	if err == nil {
+		t.Error("ComposeMessage should fail with invalid From address")
+	}
+}

--- a/internal/email/email_test.go
+++ b/internal/email/email_test.go
@@ -60,3 +60,74 @@ func TestMessage_Embeds_Envelope(t *testing.T) {
 		t.Errorf("TextBody = %q, want %q", msg.TextBody, "Hello")
 	}
 }
+
+func TestMessage_ThreadingFields(t *testing.T) {
+	msg := Message{
+		MessageID:  "abc123@example.com",
+		InReplyTo:  []string{"parent@example.com"},
+		References: []string{"root@example.com", "parent@example.com"},
+		Cc:         []string{"cc@example.com"},
+		ReplyTo:    "reply@example.com",
+	}
+	if msg.MessageID != "abc123@example.com" {
+		t.Errorf("MessageID = %q, want %q", msg.MessageID, "abc123@example.com")
+	}
+	if len(msg.InReplyTo) != 1 {
+		t.Errorf("InReplyTo length = %d, want 1", len(msg.InReplyTo))
+	}
+	if len(msg.References) != 2 {
+		t.Errorf("References length = %d, want 2", len(msg.References))
+	}
+	if len(msg.Cc) != 1 {
+		t.Errorf("Cc length = %d, want 1", len(msg.Cc))
+	}
+	if msg.ReplyTo != "reply@example.com" {
+		t.Errorf("ReplyTo = %q, want %q", msg.ReplyTo, "reply@example.com")
+	}
+}
+
+func TestSendOptions(t *testing.T) {
+	opts := SendOptions{
+		To:      []string{"to@example.com"},
+		Cc:      []string{"cc@example.com"},
+		Subject: "Test",
+		Body:    "Hello",
+		Account: "personal",
+	}
+	if len(opts.To) != 1 {
+		t.Errorf("To length = %d, want 1", len(opts.To))
+	}
+	if len(opts.Cc) != 1 {
+		t.Errorf("Cc length = %d, want 1", len(opts.Cc))
+	}
+	if opts.Subject != "Test" {
+		t.Errorf("Subject = %q, want %q", opts.Subject, "Test")
+	}
+	if opts.Body != "Hello" {
+		t.Errorf("Body = %q, want %q", opts.Body, "Hello")
+	}
+	if opts.Account != "personal" {
+		t.Errorf("Account = %q, want %q", opts.Account, "personal")
+	}
+}
+
+func TestMoveOptions(t *testing.T) {
+	opts := MoveOptions{
+		UIDs:        []uint32{100, 200},
+		Folder:      "INBOX",
+		Destination: "Archive",
+		Account:     "work",
+	}
+	if len(opts.UIDs) != 2 {
+		t.Errorf("UIDs length = %d, want 2", len(opts.UIDs))
+	}
+	if opts.Folder != "INBOX" {
+		t.Errorf("Folder = %q, want %q", opts.Folder, "INBOX")
+	}
+	if opts.Destination != "Archive" {
+		t.Errorf("Destination = %q, want %q", opts.Destination, "Archive")
+	}
+	if opts.Account != "work" {
+		t.Errorf("Account = %q, want %q", opts.Account, "work")
+	}
+}

--- a/internal/email/move.go
+++ b/internal/email/move.go
@@ -1,0 +1,50 @@
+package email
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/emersion/go-imap/v2"
+)
+
+// MoveMessages moves the specified messages from the source folder to
+// the destination folder. Uses the IMAP MOVE extension when available,
+// falling back to COPY + STORE \Deleted + EXPUNGE automatically.
+func (c *Client) MoveMessages(ctx context.Context, opts MoveOptions) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if err := c.ensureConnected(ctx); err != nil {
+		return err
+	}
+
+	if len(opts.UIDs) == 0 {
+		return fmt.Errorf("no UIDs specified")
+	}
+
+	folder := opts.Folder
+	if folder == "" {
+		folder = "INBOX"
+	}
+
+	if opts.Destination == "" {
+		return fmt.Errorf("destination folder is required")
+	}
+
+	if _, err := c.selectFolder(folder); err != nil {
+		return err
+	}
+
+	uidSet := imap.UIDSet{}
+	for _, uid := range opts.UIDs {
+		uidSet.AddNum(imap.UID(uid))
+	}
+
+	// Move handles MOVE extension with COPY+DELETE+EXPUNGE fallback.
+	moveCmd := c.client.Move(uidSet, opts.Destination)
+	if _, err := moveCmd.Wait(); err != nil {
+		return fmt.Errorf("move to %s: %w", opts.Destination, err)
+	}
+
+	return nil
+}

--- a/internal/email/smtp.go
+++ b/internal/email/smtp.go
@@ -1,0 +1,108 @@
+package email
+
+import (
+	"crypto/tls"
+	"fmt"
+	"net"
+	"net/smtp"
+)
+
+// SendMail connects to the SMTP server, authenticates, and delivers the
+// given message. Connections are ephemeral — each call opens and closes
+// its own connection. The msg parameter should be a complete RFC 5322
+// message (as returned by ComposeMessage).
+func SendMail(cfg SMTPConfig, from string, recipients []string, msg []byte) error {
+	addr := net.JoinHostPort(cfg.Host, fmt.Sprintf("%d", cfg.Port))
+
+	// Connect to SMTP server.
+	client, err := smtp.Dial(addr)
+	if err != nil {
+		return fmt.Errorf("dial SMTP %s: %w", addr, err)
+	}
+	defer client.Close()
+
+	// EHLO.
+	if err := client.Hello("localhost"); err != nil {
+		return fmt.Errorf("EHLO: %w", err)
+	}
+
+	// Upgrade to TLS if configured.
+	if cfg.StartTLS {
+		tlsCfg := &tls.Config{ServerName: cfg.Host}
+		if err := client.StartTLS(tlsCfg); err != nil {
+			return fmt.Errorf("STARTTLS: %w", err)
+		}
+	}
+
+	// Authenticate.
+	auth := smtp.PlainAuth("", cfg.Username, cfg.Password, cfg.Host)
+	if err := client.Auth(auth); err != nil {
+		return fmt.Errorf("AUTH: %w", err)
+	}
+
+	// Set the sender.
+	if err := client.Mail(from); err != nil {
+		return fmt.Errorf("MAIL FROM: %w", err)
+	}
+
+	// Set all recipients (To + Cc + Bcc).
+	for _, rcpt := range recipients {
+		if err := client.Rcpt(rcpt); err != nil {
+			return fmt.Errorf("RCPT TO %s: %w", rcpt, err)
+		}
+	}
+
+	// Write the message body.
+	w, err := client.Data()
+	if err != nil {
+		return fmt.Errorf("DATA: %w", err)
+	}
+	if _, err := w.Write(msg); err != nil {
+		return fmt.Errorf("write message: %w", err)
+	}
+	if err := w.Close(); err != nil {
+		return fmt.Errorf("close DATA: %w", err)
+	}
+
+	return client.Quit()
+}
+
+// extractAddress extracts the bare email address from a string that
+// may be in "Name <addr>" or just "addr" format.
+func extractAddress(s string) string {
+	if idx := len(s) - 1; idx > 0 && s[idx] == '>' {
+		if start := lastIndexByte(s, '<'); start >= 0 {
+			return s[start+1 : idx]
+		}
+	}
+	return s
+}
+
+// lastIndexByte returns the index of the last occurrence of c in s, or -1.
+func lastIndexByte(s string, c byte) int {
+	for i := len(s) - 1; i >= 0; i-- {
+		if s[i] == c {
+			return i
+		}
+	}
+	return -1
+}
+
+// collectRecipients gathers all unique bare email addresses from the
+// To, Cc, and Bcc fields for SMTP RCPT TO commands.
+func collectRecipients(to, cc, bcc []string) []string {
+	seen := make(map[string]bool)
+	var result []string
+
+	for _, lists := range [][]string{to, cc, bcc} {
+		for _, addr := range lists {
+			bare := extractAddress(addr)
+			if bare != "" && !seen[bare] {
+				seen[bare] = true
+				result = append(result, bare)
+			}
+		}
+	}
+
+	return result
+}

--- a/internal/email/smtp_test.go
+++ b/internal/email/smtp_test.go
@@ -1,0 +1,57 @@
+package email
+
+import "testing"
+
+func TestExtractAddress(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"bare address", "user@example.com", "user@example.com"},
+		{"name and address", "Alice <alice@example.com>", "alice@example.com"},
+		{"just angle brackets", "<user@test.com>", "user@test.com"},
+		{"empty", "", ""},
+		{"no closing bracket", "Alice <user@test.com", "Alice <user@test.com"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractAddress(tt.input)
+			if got != tt.want {
+				t.Errorf("extractAddress(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCollectRecipients(t *testing.T) {
+	result := collectRecipients(
+		[]string{"Alice <alice@example.com>", "bob@example.com"},
+		[]string{"cc@example.com"},
+		[]string{"bcc@example.com", "alice@example.com"}, // duplicate of alice
+	)
+
+	// Should have 4 unique addresses (alice deduplicated).
+	if len(result) != 4 {
+		t.Errorf("collectRecipients = %d addresses, want 4: %v", len(result), result)
+	}
+
+	// Check that alice appears only once.
+	count := 0
+	for _, r := range result {
+		if r == "alice@example.com" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("alice should appear once, got %d", count)
+	}
+}
+
+func TestCollectRecipients_Empty(t *testing.T) {
+	result := collectRecipients(nil, nil, nil)
+	if len(result) != 0 {
+		t.Errorf("empty inputs should return empty, got %v", result)
+	}
+}

--- a/internal/email/trust.go
+++ b/internal/email/trust.go
@@ -1,0 +1,100 @@
+package email
+
+import "fmt"
+
+// ContactResolver resolves email addresses to trust zone levels.
+// Implementations wrap a contact store without requiring the email
+// package to import the contacts package directly.
+type ContactResolver interface {
+	// ResolveTrustZone returns the trust zone ("owner", "trusted",
+	// "known") for the given email address. Returns ("", false, nil)
+	// if no matching contact is found.
+	ResolveTrustZone(email string) (zone string, found bool, err error)
+}
+
+// TrustResult categorizes recipient addresses by their trust zone
+// disposition for outbound email.
+type TrustResult struct {
+	// Allowed contains addresses that can be sent to freely
+	// (trust zone "owner" or "trusted").
+	Allowed []string
+
+	// Warnings contains human-readable messages for "known" trust
+	// zone contacts that require user confirmation.
+	Warnings []string
+
+	// Blocked contains human-readable messages for addresses with
+	// no contact record.
+	Blocked []string
+}
+
+// CheckRecipientTrust evaluates each address against the contact store
+// and categorizes them by trust zone. If cr is nil, all addresses are
+// allowed (trust gating is disabled).
+func CheckRecipientTrust(cr ContactResolver, addresses []string) TrustResult {
+	var result TrustResult
+
+	if cr == nil {
+		result.Allowed = addresses
+		return result
+	}
+
+	for _, addr := range addresses {
+		bare := extractAddress(addr)
+		zone, found, err := cr.ResolveTrustZone(bare)
+		if err != nil {
+			result.Blocked = append(result.Blocked,
+				fmt.Sprintf("Cannot send to %s: contact lookup failed: %v", bare, err))
+			continue
+		}
+
+		if !found {
+			result.Blocked = append(result.Blocked,
+				fmt.Sprintf("Cannot send to %s: no contact record. Add with save_contact first.", bare))
+			continue
+		}
+
+		switch zone {
+		case "owner", "trusted":
+			result.Allowed = append(result.Allowed, addr)
+		case "known":
+			result.Warnings = append(result.Warnings,
+				fmt.Sprintf("Contact for %s is 'known' trust level — confirm with user before sending.", bare))
+		default:
+			result.Blocked = append(result.Blocked,
+				fmt.Sprintf("Cannot send to %s: unrecognized trust zone %q.", bare, zone))
+		}
+	}
+
+	return result
+}
+
+// HasIssues reports whether the trust check found any warnings or
+// blocked addresses that prevent immediate sending.
+func (tr TrustResult) HasIssues() bool {
+	return len(tr.Warnings) > 0 || len(tr.Blocked) > 0
+}
+
+// FormatIssues returns a human-readable summary of all trust issues.
+func (tr TrustResult) FormatIssues() string {
+	var parts []string
+	for _, w := range tr.Warnings {
+		parts = append(parts, "⚠ "+w)
+	}
+	for _, b := range tr.Blocked {
+		parts = append(parts, "✗ "+b)
+	}
+	return fmt.Sprintf("Email not sent — trust zone issues:\n\n%s", joinLines(parts))
+}
+
+// joinLines joins strings with newlines.
+func joinLines(parts []string) string {
+	result := ""
+	for i, p := range parts {
+		if i > 0 {
+			result += "\n"
+		}
+		result += p
+	}
+	return result
+}

--- a/internal/email/trust_test.go
+++ b/internal/email/trust_test.go
@@ -1,0 +1,154 @@
+package email
+
+import (
+	"fmt"
+	"testing"
+)
+
+// mockResolver implements ContactResolver for testing.
+type mockResolver struct {
+	zones map[string]string // email → trust zone
+}
+
+func (m *mockResolver) ResolveTrustZone(email string) (string, bool, error) {
+	zone, ok := m.zones[email]
+	if !ok {
+		return "", false, nil
+	}
+	if zone == "error" {
+		return "", false, fmt.Errorf("database error")
+	}
+	return zone, true, nil
+}
+
+func TestCheckRecipientTrust_NilResolver(t *testing.T) {
+	result := CheckRecipientTrust(nil, []string{"a@example.com", "b@example.com"})
+
+	if len(result.Allowed) != 2 {
+		t.Errorf("nil resolver should allow all, got %d allowed", len(result.Allowed))
+	}
+	if result.HasIssues() {
+		t.Error("nil resolver should not have issues")
+	}
+}
+
+func TestCheckRecipientTrust(t *testing.T) {
+	resolver := &mockResolver{
+		zones: map[string]string{
+			"owner@example.com":   "owner",
+			"trusted@example.com": "trusted",
+			"known@example.com":   "known",
+		},
+	}
+
+	tests := []struct {
+		name         string
+		addresses    []string
+		wantAllowed  int
+		wantWarnings int
+		wantBlocked  int
+	}{
+		{
+			name:        "owner allowed",
+			addresses:   []string{"owner@example.com"},
+			wantAllowed: 1,
+		},
+		{
+			name:        "trusted allowed",
+			addresses:   []string{"trusted@example.com"},
+			wantAllowed: 1,
+		},
+		{
+			name:         "known warns",
+			addresses:    []string{"known@example.com"},
+			wantWarnings: 1,
+		},
+		{
+			name:        "unknown blocked",
+			addresses:   []string{"stranger@example.com"},
+			wantBlocked: 1,
+		},
+		{
+			name:         "mixed recipients",
+			addresses:    []string{"owner@example.com", "known@example.com", "stranger@example.com"},
+			wantAllowed:  1,
+			wantWarnings: 1,
+			wantBlocked:  1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := CheckRecipientTrust(resolver, tt.addresses)
+
+			if len(result.Allowed) != tt.wantAllowed {
+				t.Errorf("Allowed = %d, want %d", len(result.Allowed), tt.wantAllowed)
+			}
+			if len(result.Warnings) != tt.wantWarnings {
+				t.Errorf("Warnings = %d, want %d", len(result.Warnings), tt.wantWarnings)
+			}
+			if len(result.Blocked) != tt.wantBlocked {
+				t.Errorf("Blocked = %d, want %d", len(result.Blocked), tt.wantBlocked)
+			}
+		})
+	}
+}
+
+func TestCheckRecipientTrust_ExtractsAddress(t *testing.T) {
+	resolver := &mockResolver{
+		zones: map[string]string{
+			"user@example.com": "trusted",
+		},
+	}
+
+	// "Name <addr>" format should extract the bare address.
+	result := CheckRecipientTrust(resolver, []string{"Alice <user@example.com>"})
+
+	if len(result.Allowed) != 1 {
+		t.Errorf("should extract and match bare address, got %d allowed", len(result.Allowed))
+	}
+}
+
+func TestCheckRecipientTrust_Error(t *testing.T) {
+	resolver := &mockResolver{
+		zones: map[string]string{
+			"error@example.com": "error",
+		},
+	}
+
+	result := CheckRecipientTrust(resolver, []string{"error@example.com"})
+
+	if len(result.Blocked) != 1 {
+		t.Errorf("error should block, got %d blocked", len(result.Blocked))
+	}
+}
+
+func TestTrustResult_HasIssues(t *testing.T) {
+	clean := TrustResult{Allowed: []string{"a@test.com"}}
+	if clean.HasIssues() {
+		t.Error("clean result should not have issues")
+	}
+
+	warned := TrustResult{Warnings: []string{"warning"}}
+	if !warned.HasIssues() {
+		t.Error("warned result should have issues")
+	}
+
+	blocked := TrustResult{Blocked: []string{"blocked"}}
+	if !blocked.HasIssues() {
+		t.Error("blocked result should have issues")
+	}
+}
+
+func TestTrustResult_FormatIssues(t *testing.T) {
+	result := TrustResult{
+		Warnings: []string{"warn message"},
+		Blocked:  []string{"block message"},
+	}
+
+	formatted := result.FormatIssues()
+
+	if formatted == "" {
+		t.Error("FormatIssues should return non-empty string")
+	}
+}

--- a/internal/tools/email_tools.go
+++ b/internal/tools/email_tools.go
@@ -165,4 +165,105 @@ func (r *Registry) registerEmailTools() {
 			return r.emailTools.HandleMark(ctx, args)
 		},
 	})
+
+	r.Register(&Tool{
+		Name:        "email_send",
+		Description: "Compose and send a new email. The body is written in markdown and automatically converted to both plain text and HTML. All recipients must have a contact record with appropriate trust zone.",
+		Parameters: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"to": map[string]any{
+					"type":        "array",
+					"items":       map[string]any{"type": "string"},
+					"description": "Recipient email addresses",
+				},
+				"cc": map[string]any{
+					"type":        "array",
+					"items":       map[string]any{"type": "string"},
+					"description": "CC email addresses",
+				},
+				"subject": map[string]any{
+					"type":        "string",
+					"description": "Email subject line",
+				},
+				"body": map[string]any{
+					"type":        "string",
+					"description": "Email body in markdown format. Will be converted to text/plain and text/html automatically.",
+				},
+				"account": map[string]any{
+					"type":        "string",
+					"description": "Email account name (default: primary account)",
+				},
+			},
+			"required": []string{"to", "subject", "body"},
+		},
+		Handler: func(ctx context.Context, args map[string]any) (string, error) {
+			return r.emailTools.HandleSend(ctx, args)
+		},
+	})
+
+	r.Register(&Tool{
+		Name:        "email_reply",
+		Description: "Reply to an existing email. Preserves threading headers (In-Reply-To, References) for proper conversation threading. The body is written in markdown. Use reply_all to include all original recipients.",
+		Parameters: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"uid": map[string]any{
+					"type":        "integer",
+					"description": "UID of the message to reply to (from email_list or email_read)",
+				},
+				"folder": map[string]any{
+					"type":        "string",
+					"description": "Folder containing the original message (default: INBOX)",
+				},
+				"body": map[string]any{
+					"type":        "string",
+					"description": "Reply body in markdown format",
+				},
+				"reply_all": map[string]any{
+					"type":        "boolean",
+					"description": "Reply to all original recipients (default: false)",
+				},
+				"account": map[string]any{
+					"type":        "string",
+					"description": "Email account name (default: primary account)",
+				},
+			},
+			"required": []string{"uid", "body"},
+		},
+		Handler: func(ctx context.Context, args map[string]any) (string, error) {
+			return r.emailTools.HandleReply(ctx, args)
+		},
+	})
+
+	r.Register(&Tool{
+		Name:        "email_move",
+		Description: "Move email messages between folders. Useful for archiving messages after reading or replying.",
+		Parameters: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"uids": map[string]any{
+					"type":        "array",
+					"items":       map[string]any{"type": "integer"},
+					"description": "Message UIDs to move",
+				},
+				"folder": map[string]any{
+					"type":        "string",
+					"description": "Source folder (default: INBOX)",
+				},
+				"destination": map[string]any{
+					"type":        "string",
+					"description": "Destination folder (e.g., Archive, Trash)",
+				},
+				"account": map[string]any{
+					"type":        "string",
+					"description": "Email account name (default: primary account)",
+				},
+			},
+			"required": []string{"uids", "destination"},
+		},
+		Handler: func(ctx context.Context, args map[string]any) (string, error) {
+			return r.emailTools.HandleMove(ctx, args)
+		},
+	})
 }


### PR DESCRIPTION
## Summary

Completes the native email workflow (issue #299) by adding three new tools on top of the IMAP read-side from #298:

- **`email_send`** — Compose and send new email with markdown-to-MIME conversion (multipart/alternative: text/plain + text/html via goldmark)
- **`email_reply`** — Reply to existing messages with proper threading headers (In-Reply-To, References) and reply-all support
- **`email_move`** — Move messages between IMAP folders (archive, trash, etc.)

### Supporting infrastructure

- **SMTP delivery** via `net/smtp` with STARTTLS + PlainAuth (ephemeral connect-per-send)
- **Trust zone gating** — All outbound recipients are checked against the contacts store; owner/trusted pass, known warn, unknown block
- **Auto-Bcc owner** — Configurable audit trail address receives blind copies of all agent-sent email
- **SMTP config** — New `smtp` and `default_from` fields in account config with validation and sensible defaults (port 587, STARTTLS)
- **Threading extraction** — `ReadMessage` now extracts MessageID, InReplyTo, References, Cc, and ReplyTo from IMAP messages

### Files

**New**: `compose.go`, `smtp.go`, `trust.go`, `move.go` + tests for each
**Modified**: `email.go` (types), `config.go` (SMTP config), `manager.go` (AccountConfig/BccOwner), `read.go` (threading headers), `tools.go` (3 handlers), `email_tools.go` (3 registrations), `main.go` (contacts adapter wiring)

Closes #299

## Test plan

- [x] `just ci` passes (0 lint issues, all tests green with `-race`)
- [ ] Configure SMTP in config.yaml alongside existing IMAP
- [ ] Send test email via `email_send` — verify multipart/alternative arrives
- [ ] Reply to a message via `email_reply` — verify In-Reply-To/References threading
- [ ] Move a message via `email_move` — verify it appears in destination folder
- [ ] Test trust zone gating: send to unknown → blocked, known → warning, trusted → allowed
- [ ] Verify auto-Bcc owner appears in owner's mailbox

🤖 Generated with [Claude Code](https://claude.com/claude-code)