### PR TITLE
chore: downgrade noisy periodic logs from DEBUG to TRACE

### DIFF
--- a/cmd/thane/wakebridge.go
+++ b/cmd/thane/wakebridge.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/nugget/thane-ai-agent/internal/agent"
 	"github.com/nugget/thane-ai-agent/internal/anticipation"
+	"github.com/nugget/thane-ai-agent/internal/config"
 	"github.com/nugget/thane-ai-agent/internal/homeassistant"
 	"github.com/nugget/thane-ai-agent/internal/router"
 	"github.com/nugget/thane-ai-agent/internal/tools"
@@ -129,7 +130,7 @@ func (b *WakeBridge) HandleStateChange(entityID, oldState, newState string) {
 	}
 
 	if len(matched) == 0 {
-		b.logger.Debug("state change, no anticipation match",
+		b.logger.Log(b.ctx, config.LevelTrace, "state change, no anticipation match",
 			"entity_id", entityID,
 			"old_state", oldState,
 			"new_state", newState,

--- a/internal/mqtt/publisher.go
+++ b/internal/mqtt/publisher.go
@@ -538,6 +538,6 @@ func (p *Publisher) publishStates(ctx context.Context) {
 		}
 	}
 
-	p.logger.Debug("mqtt sensor states published",
+	p.logger.Log(ctx, config.LevelTrace, "mqtt sensor states published",
 		"entities", len(states))
 }

--- a/internal/unifi/poller.go
+++ b/internal/unifi/poller.go
@@ -166,7 +166,7 @@ func (p *Poller) poll(ctx context.Context) {
 		pend.count++
 		if pend.count >= debounceThreshold {
 			p.cfg.Updater.UpdateRoom(entityID, best.room, best.source)
-			p.cfg.Logger.Debug("room update committed",
+			p.cfg.Logger.Log(ctx, slog.Level(-8), "room update committed", // config.LevelTrace
 				"entity_id", entityID,
 				"room", best.room,
 				"source", best.source,


### PR DESCRIPTION
## Summary

Three high-frequency log messages that fire on every poll cycle or state change clutter DEBUG output. Moves them to TRACE level.

- `"state change, no anticipation match"` — fires on every HA state change with no anticipation rule match (wakebridge)
- `"room update committed"` — fires when UniFi poller commits a room update (unifi poller)
- `"mqtt sensor states published"` — fires on every MQTT publish cycle (mqtt publisher)

## Test plan

- [x] `just ci` passes (0 lint issues, all tests)