### PR TITLE
fix: use per-execution conversation ID for scheduled tasks

### DIFF
--- a/cmd/thane/taskexec.go
+++ b/cmd/thane/taskexec.go
@@ -107,9 +107,11 @@ func runScheduledTask(ctx context.Context, task *scheduler.Task, exec *scheduler
 		qualityFloor = qf
 	}
 
-	// Each task gets its own conversation to isolate from interactive chat.
+	// Each execution gets a fresh conversation so prior poll/wake context
+	// doesn't accumulate across cycles. The execution ID (UUIDv7) ensures
+	// uniqueness while the task ID prefix aids log correlation.
 	req := &agent.Request{
-		ConversationID: fmt.Sprintf("sched-%s", task.ID),
+		ConversationID: fmt.Sprintf("sched-%s-%s", task.ID, exec.ID),
 		Model:          model,
 		Messages:       []agent.Message{{Role: "user", Content: msg}},
 		Hints: map[string]string{

--- a/cmd/thane/taskexec_test.go
+++ b/cmd/thane/taskexec_test.go
@@ -39,7 +39,7 @@ func TestRunScheduledTask_WakePayload(t *testing.T) {
 			Data: map[string]any{"message": "Check sensors and report."},
 		},
 	}
-	exec := &scheduler.Execution{}
+	exec := &scheduler.Execution{ID: "exec-aaa"}
 
 	err := runScheduledTask(context.Background(), task, exec, taskExecDeps{runner: runner, logger: slog.Default()})
 	if err != nil {
@@ -82,9 +82,9 @@ func TestRunScheduledTask_WakePayload(t *testing.T) {
 		t.Errorf("hint delegation_gating = %q, want %q", runner.req.Hints[router.HintDelegationGating], "disabled")
 	}
 
-	// Scheduled tasks should use an isolated conversation ID.
-	if runner.req.ConversationID != "sched-task-1" {
-		t.Errorf("ConversationID = %q, want %q", runner.req.ConversationID, "sched-task-1")
+	// Each execution should get a unique conversation ID (task + exec).
+	if runner.req.ConversationID != "sched-task-1-exec-aaa" {
+		t.Errorf("ConversationID = %q, want %q", runner.req.ConversationID, "sched-task-1-exec-aaa")
 	}
 
 	// Verify execution result was populated.


### PR DESCRIPTION
Closes #313

## Summary
- Change conversation ID from `sched-{taskID}` to `sched-{taskID}-{execID}` so each scheduled task execution gets a fresh conversation
- Prevents context accumulation across poll cycles — no more 22+ message conversations from prior triage history
- Applies to all scheduled wake tasks (email poll, periodic reflection, etc.)

## Test plan
- [x] Updated `TestRunScheduledTask_WakePayload` to verify per-execution conversation ID format
- [x] All existing taskexec tests pass (14 tests)
- [x] `just ci` passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)