### PR TITLE
fix: prevent email poller high-water mark regression

### DIFF
--- a/internal/email/poller_test.go
+++ b/internal/email/poller_test.go
@@ -168,10 +168,12 @@ func TestAdvanceHighWaterMark_Increases(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	p.advanceHighWaterMark("test", "test:INBOX", 100, []Envelope{
+	if err := p.advanceHighWaterMark("test", "test:INBOX", 100, []Envelope{
 		{UID: 105},
 		{UID: 103},
-	})
+	}); err != nil {
+		t.Fatalf("advanceHighWaterMark: %v", err)
+	}
 
 	val, _ := state.Get(pollNamespace, "test:INBOX")
 	if val != "105" {
@@ -189,10 +191,12 @@ func TestAdvanceHighWaterMark_NeverDecreases(t *testing.T) {
 
 	// Simulate messages with lower UIDs (e.g., after moves/deletes
 	// changed what's in INBOX).
-	p.advanceHighWaterMark("test", "test:INBOX", 391, []Envelope{
+	if err := p.advanceHighWaterMark("test", "test:INBOX", 391, []Envelope{
 		{UID: 286},
 		{UID: 200},
-	})
+	}); err != nil {
+		t.Fatalf("advanceHighWaterMark: %v", err)
+	}
 
 	val, _ := state.Get(pollNamespace, "test:INBOX")
 	if val != "391" {
@@ -209,7 +213,9 @@ func TestAdvanceHighWaterMark_EmptyMessages(t *testing.T) {
 	}
 
 	// Empty message list should not change the mark.
-	p.advanceHighWaterMark("test", "test:INBOX", 100, nil)
+	if err := p.advanceHighWaterMark("test", "test:INBOX", 100, nil); err != nil {
+		t.Fatalf("advanceHighWaterMark: %v", err)
+	}
 
 	val, _ := state.Get(pollNamespace, "test:INBOX")
 	if val != "100" {


### PR DESCRIPTION
## Summary

Fixes #315 — the email poller re-processes old messages every cycle because the IMAP UID-range query `X:*` always returns at least the highest UID (per RFC 9051 §6.4.4), and the high-water mark can regress when messages are moved/deleted.

- **Client-side UID filtering**: Replace IMAP `UID X:*` range search with a full UID search + client-side `uid > threshold` filter, avoiding the RFC 9051 §6.4.4 edge case where `*` always resolves to the highest existing UID
- **Monotonic high-water mark**: `advanceHighWaterMark()` scans all fetched messages for the highest UID and only writes if it exceeds the current mark — never decreases
- **Self-sent message filtering**: `filterSelfSent()` compares From against the account's `DefaultFrom` address so the agent doesn't triage its own outbound replies; mark is advanced *before* filtering so self-sent UIDs don't re-appear

## Test plan

- [x] `TestAdvanceHighWaterMark_Increases` — mark advances to highest UID in batch
- [x] `TestAdvanceHighWaterMark_NeverDecreases` — mark stays at 391 when messages have lower UIDs (286, 200)
- [x] `TestAdvanceHighWaterMark_EmptyMessages` — empty list doesn't change mark
- [x] `TestFilterSelfSent` — both `Name <addr>` and bare `addr` formats filtered
- [x] `TestFilterSelfSent_NoDefaultFrom` — no filtering when DefaultFrom is empty
- [x] All existing poller and list tests pass
- [x] `just ci` passes clean