### PR TITLE
fix: omit empty sessions from conversation history context

### DIFF
--- a/internal/episodic/provider.go
+++ b/internal/episodic/provider.go
@@ -370,8 +370,13 @@ func sessionParagraph(sess *memory.Session) string {
 
 // sessionHasContent reports whether a session has any meaningful content
 // worth including in the episodic history. Delegate sessions typically
-// have no title, summary, or metadata and should be skipped.
+// have no title, summary, or metadata and should be skipped. Sessions
+// explicitly marked as empty by the summarizer (SessionType "empty")
+// are also excluded — they have metadata but no real transcript.
 func sessionHasContent(sess *memory.Session) bool {
+	if sess.Metadata != nil && sess.Metadata.SessionType == "empty" {
+		return false
+	}
 	if sess.Title != "" {
 		return true
 	}

--- a/internal/episodic/provider_test.go
+++ b/internal/episodic/provider_test.go
@@ -440,6 +440,14 @@ func TestEmptySessionsSkipped(t *testing.T) {
 				StartedAt: timeAt(now, 4),
 				EndedAt:   ptrTime(timeAt(now, 3.5)),
 			},
+			// Fifth: empty session marked by summarizer → should be skipped.
+			{
+				ID:        "s5",
+				StartedAt: timeAt(now, 5),
+				EndedAt:   ptrTime(timeAt(now, 4.5)),
+				Title:     "(empty session)",
+				Metadata:  &memory.SessionMetadata{SessionType: "empty", OneLiner: "Empty session (no transcript)"},
+			},
 		},
 		transcripts: map[string][]memory.ArchivedMessage{
 			"s1": {{Role: "user", Content: "Hello", Timestamp: timeAt(now, 1)}},
@@ -462,6 +470,9 @@ func TestEmptySessionsSkipped(t *testing.T) {
 	if strings.Contains(got, "(no summary)") {
 		t.Error("empty sessions should not produce '(no summary)' entries")
 	}
+	if strings.Contains(got, "empty session") {
+		t.Error("sessions with SessionType 'empty' should not appear in history")
+	}
 }
 
 func TestSessionHasContent(t *testing.T) {
@@ -478,6 +489,10 @@ func TestSessionHasContent(t *testing.T) {
 		{"empty metadata", &memory.Session{Metadata: &memory.SessionMetadata{}}, false},
 		{"nil metadata", &memory.Session{}, false},
 		{"completely empty", &memory.Session{}, false},
+		{"empty session type", &memory.Session{
+			Title:    "(empty session)",
+			Metadata: &memory.SessionMetadata{SessionType: "empty", OneLiner: "Empty session (no transcript)"},
+		}, false},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
## Summary

- Filter out sessions with `SessionType == "empty"` in `sessionHasContent()` before they reach the episodic history formatter
- These are wake events with no transcript, marked by the summarizer with title "(empty session)" — they pass the existing content check because Title is non-empty
- Empty sessions remain archived and searchable, just excluded from the system prompt context window

## Change

One-line guard added to `sessionHasContent()` in `internal/episodic/provider.go`:

```go
if sess.Metadata != nil && sess.Metadata.SessionType == "empty" {
    return false
}
```

## Test plan

- [x] New test case in `TestSessionHasContent` for empty session type
- [x] New test session in `TestEmptySessionsSkipped` integration test with assertion
- [x] All existing episodic tests pass
- [x] `just ci` passes

Closes #328

🤖 Generated with [Claude Code](https://claude.com/claude-code)