### PR TITLE
fix: metacognitive loop routing, tooling, logging, performance

### DIFF
--- a/internal/prompts/metacognitive.go
+++ b/internal/prompts/metacognitive.go
@@ -25,8 +25,8 @@ last time. Read it carefully — it IS your continuity.
 2. **Act if warranted** — Create anticipations, send messages, or use any
    available tool if the situation calls for it.
 3. **Update metacognitive.md** — Rewrite your state file with current
-   observations, active concerns, recent actions, and sleep reasoning. Use
-   file_write to save it.
+   observations, active concerns, recent actions, and sleep reasoning. Call
+   update_metacognitive_state with your updated content.
 4. **Set your sleep** — Call set_next_sleep with your chosen duration and
    reasoning. Short (2–5m) for active situations. Long (15–30m) for quiet
    periods.
@@ -71,7 +71,7 @@ cheaper model's consistent blind spots miss.`
 // instructions are appended for frontier-model iterations.
 func MetacognitivePrompt(currentState string, isSupervisor bool) string {
 	if currentState == "" {
-		currentState = "(metacognitive.md does not exist yet — this is your first iteration. Create it with file_write.)"
+		currentState = "(metacognitive.md does not exist yet — this is your first iteration. Call update_metacognitive_state to create it.)"
 	}
 	prompt := fmt.Sprintf(metacognitiveBaseTemplate, currentState)
 	if isSupervisor {

--- a/internal/prompts/metacognitive_test.go
+++ b/internal/prompts/metacognitive_test.go
@@ -44,8 +44,8 @@ func TestMetacognitivePrompt_EmptyState(t *testing.T) {
 	if !strings.Contains(result, "does not exist yet") {
 		t.Error("empty state should produce first-iteration placeholder")
 	}
-	if !strings.Contains(result, "file_write") {
-		t.Error("first-iteration placeholder should mention file_write")
+	if !strings.Contains(result, "update_metacognitive_state") {
+		t.Error("first-iteration placeholder should mention update_metacognitive_state")
 	}
 }
 
@@ -54,5 +54,16 @@ func TestMetacognitivePrompt_SetNextSleepMentioned(t *testing.T) {
 
 	if !strings.Contains(result, "set_next_sleep") {
 		t.Error("prompt should mention set_next_sleep tool")
+	}
+}
+
+func TestMetacognitivePrompt_MentionsUpdateTool(t *testing.T) {
+	result := MetacognitivePrompt("some state", false)
+
+	if !strings.Contains(result, "update_metacognitive_state") {
+		t.Error("prompt should mention update_metacognitive_state tool")
+	}
+	if strings.Contains(result, "file_write") {
+		t.Error("prompt should not mention file_write (replaced by update_metacognitive_state)")
 	}
 }


### PR DESCRIPTION
## Summary

Fixes 6 issues from the first production run of the metacognitive loop (#319):

- **Router**: Supervisor iterations now reach frontier models — `local_only=false` disables `free_model_bonus`, `local_first`, and mission bonuses so quality-based scoring dominates
- **set_next_sleep**: Accepts integer minutes (`duration: 8` → `"8m"`) for local models that don't produce Go duration strings
- **update_metacognitive_state**: New dedicated tool replaces `file_write` — writes to configured path, saves `.prev` backup, appends metadata footer with iteration ID and timestamp
- **ExcludeTools**: Restricts metacognitive loop to only relevant tools, preventing 13-minute `file_grep` scans and `exec` usage
- **Logging**: All metacognitive log lines include `conversation_id` and `supervisor` flag; new "iteration starting" entry at cycle start
- **Prompts**: Updated to reference `update_metacognitive_state` instead of `file_write`

## Test plan

- [x] `TestRoute_LocalOnlyFalseDisablesLocalBias` — cloud model wins when `local_only=false` + high quality_floor
- [x] `TestSetNextSleep_IntegerMinutes` — `duration: 8` (float64) → 8m
- [x] `TestIterate_ExcludesTools` — request has ExcludeTools populated with dangerous tools
- [x] `TestIterate_PassesConvID` — conversation ID propagated through iterate
- [x] `TestUpdateMetacognitiveState_Valid` — writes to configured path
- [x] `TestUpdateMetacognitiveState_MetadataFooter` — footer with iteration ID + timestamp
- [x] `TestUpdateMetacognitiveState_PrevFile` — previous version saved to .prev
- [x] `TestUpdateMetacognitiveState_EmptyRejected` — short/empty content rejected
- [x] `TestMetacognitivePrompt_MentionsUpdateTool` — prompt references new tool, not file_write
- [x] `just ci` passes (0 lint issues, all tests pass with -race)

Closes #333