### PR TITLE
fix: prevent response text duplication when model returns text + tool_call

### DIFF
--- a/internal/agent/empty_response_test.go
+++ b/internal/agent/empty_response_test.go
@@ -179,3 +179,180 @@ func TestEmptyResponse_FirstIterNotNudged(t *testing.T) {
 		t.Errorf("response content = %q, want empty", resp.Content)
 	}
 }
+
+func TestDeferredText_SkipsNudge(t *testing.T) {
+	// Issue #347: when iter 0 returns text + tool call and iter 1 returns
+	// empty, the deferred text from iter 0 should be used as the final
+	// response — no nudge, no duplicate.
+	mock := &mockLLM{
+		responses: []*llm.ChatResponse{
+			// Iter 0: text + tool call
+			{
+				Model: "test-model",
+				Message: llm.Message{
+					Role:    "assistant",
+					Content: "Let me check that for you.",
+					ToolCalls: []llm.ToolCall{{
+						ID: "call-1",
+						Function: struct {
+							Name      string         `json:"name"`
+							Arguments map[string]any `json:"arguments"`
+						}{
+							Name:      "recall_fact",
+							Arguments: map[string]any{},
+						},
+					}},
+				},
+				InputTokens:  100,
+				OutputTokens: 50,
+			},
+			// Iter 1: empty (model thinks it already said its piece)
+			{
+				Model:        "test-model",
+				Message:      llm.Message{Role: "assistant", Content: ""},
+				InputTokens:  200,
+				OutputTokens: 2,
+			},
+		},
+	}
+
+	loop := buildTestLoop(mock, []string{"recall_fact"})
+
+	resp, err := loop.Run(context.Background(), &Request{
+		Messages: []Message{{Role: "user", Content: "what's the weather"}},
+	}, nil)
+	if err != nil {
+		t.Fatalf("Run() error: %v", err)
+	}
+
+	// Should have made only 2 LLM calls — no nudge needed.
+	if len(mock.calls) != 2 {
+		t.Fatalf("expected 2 LLM calls (no nudge), got %d", len(mock.calls))
+	}
+
+	// Response should be the deferred text from iter 0.
+	if resp.Content != "Let me check that for you." {
+		t.Errorf("response content = %q, want %q", resp.Content, "Let me check that for you.")
+	}
+
+	// Verify no nudge message was injected.
+	for _, call := range mock.calls {
+		for _, msg := range call.Messages {
+			if msg.Role == "user" && msg.Content == prompts.EmptyResponseNudge {
+				t.Error("nudge message should not be present when deferred text exists")
+			}
+		}
+	}
+}
+
+func TestDeferredText_FreshTextOverrides(t *testing.T) {
+	// When the model produces new text after tool execution, the deferred
+	// text is discarded and the fresh response is used.
+	mock := &mockLLM{
+		responses: []*llm.ChatResponse{
+			// Iter 0: text + tool call
+			{
+				Model: "test-model",
+				Message: llm.Message{
+					Role:    "assistant",
+					Content: "Checking now...",
+					ToolCalls: []llm.ToolCall{{
+						ID: "call-1",
+						Function: struct {
+							Name      string         `json:"name"`
+							Arguments map[string]any `json:"arguments"`
+						}{
+							Name:      "recall_fact",
+							Arguments: map[string]any{},
+						},
+					}},
+				},
+				InputTokens:  100,
+				OutputTokens: 30,
+			},
+			// Iter 1: fresh text informed by tool result
+			{
+				Model:        "test-model",
+				Message:      llm.Message{Role: "assistant", Content: "The lights are all on."},
+				InputTokens:  200,
+				OutputTokens: 15,
+			},
+		},
+	}
+
+	loop := buildTestLoop(mock, []string{"recall_fact"})
+
+	resp, err := loop.Run(context.Background(), &Request{
+		Messages: []Message{{Role: "user", Content: "check the lights"}},
+	}, nil)
+	if err != nil {
+		t.Fatalf("Run() error: %v", err)
+	}
+
+	// Should have made 2 LLM calls.
+	if len(mock.calls) != 2 {
+		t.Fatalf("expected 2 LLM calls, got %d", len(mock.calls))
+	}
+
+	// Response should be the fresh text, not the deferred text.
+	if resp.Content != "The lights are all on." {
+		t.Errorf("response content = %q, want %q", resp.Content, "The lights are all on.")
+	}
+}
+
+func TestDeferredText_StrippedFromContext(t *testing.T) {
+	// The text from a mixed (text + tool_call) response should be stripped
+	// from the assistant message in llmMessages so the model doesn't see
+	// its own text and restate it.
+	mock := &mockLLM{
+		responses: []*llm.ChatResponse{
+			// Iter 0: text + tool call
+			{
+				Model: "test-model",
+				Message: llm.Message{
+					Role:    "assistant",
+					Content: "Here's what I found.",
+					ToolCalls: []llm.ToolCall{{
+						ID: "call-1",
+						Function: struct {
+							Name      string         `json:"name"`
+							Arguments map[string]any `json:"arguments"`
+						}{
+							Name:      "recall_fact",
+							Arguments: map[string]any{},
+						},
+					}},
+				},
+				InputTokens:  100,
+				OutputTokens: 40,
+			},
+			// Iter 1: text response
+			{
+				Model:        "test-model",
+				Message:      llm.Message{Role: "assistant", Content: "Done."},
+				InputTokens:  200,
+				OutputTokens: 5,
+			},
+		},
+	}
+
+	loop := buildTestLoop(mock, []string{"recall_fact"})
+
+	_, err := loop.Run(context.Background(), &Request{
+		Messages: []Message{{Role: "user", Content: "check something"}},
+	}, nil)
+	if err != nil {
+		t.Fatalf("Run() error: %v", err)
+	}
+
+	// Inspect the messages sent to the second LLM call. The assistant
+	// message from iter 0 should have empty Content (text stripped).
+	secondCall := mock.calls[1]
+	for _, msg := range secondCall.Messages {
+		if msg.Role == "assistant" && len(msg.ToolCalls) > 0 {
+			if msg.Content != "" {
+				t.Errorf("assistant message with tool calls should have empty Content, got %q", msg.Content)
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- When the LLM returns both text and a tool call in the same iteration, the text is now **deferred** — saved but stripped from the assistant message context so the model doesn't see its own text and restate it
- When a subsequent iteration returns empty content and deferred text exists, the deferred text is used as the final response instead of triggering the nudge mechanism — saving an LLM call and preventing duplication
- If the model produces fresh text after tool execution, the deferred text is discarded in favor of the new response

## Root cause
Production logs showed: iter 0 produced 408 tokens of text + `session_working_memory` tool call → iter 1 returned empty (2 tokens) → nudge fired → iter 2 restated the same 231 tokens. Both iter 0 and iter 2 text were streamed, producing duplicated output.

## Test plan
- [x] `TestDeferredText_SkipsNudge` — text + tool in iter 0, empty in iter 1 → uses deferred text, only 2 LLM calls (no nudge)
- [x] `TestDeferredText_FreshTextOverrides` — text + tool in iter 0, new text in iter 1 → uses fresh text, deferred discarded
- [x] `TestDeferredText_StrippedFromContext` — verifies assistant message in subsequent call has empty Content when original had text + tools
- [x] Existing `TestEmptyResponse_NudgeRecovery` still passes (iter 0 has tools but no text → nudge fires as before)
- [x] `just ci` passes clean (lint + race tests)

Closes #347