### PR TITLE
fix: email tool type coercion and parameter name handling (#365)

### DIFF
--- a/internal/email/tools_test.go
+++ b/internal/email/tools_test.go
@@ -54,70 +54,107 @@ func TestIntArg(t *testing.T) {
 
 func TestUint32SliceArg(t *testing.T) {
 	tests := []struct {
-		name string
-		args map[string]any
-		key  string
-		want []uint32
+		name    string
+		args    map[string]any
+		key     string
+		want    []uint32
+		wantNil bool // true when we expect nil specifically (not empty slice)
 	}{
 		{
-			"float64 array",
-			map[string]any{"uids": []any{float64(1), float64(2), float64(3)}},
-			"uids",
-			[]uint32{1, 2, 3},
+			name: "float64 array",
+			args: map[string]any{"uids": []any{float64(1), float64(2), float64(3)}},
+			key:  "uids",
+			want: []uint32{1, 2, 3},
 		},
 		{
-			"string array",
-			map[string]any{"uids": []any{"100", "200"}},
-			"uids",
-			[]uint32{100, 200},
+			name: "string array",
+			args: map[string]any{"uids": []any{"100", "200"}},
+			key:  "uids",
+			want: []uint32{100, 200},
 		},
 		{
-			"mixed array",
-			map[string]any{"uids": []any{float64(1), "2", int(3)}},
-			"uids",
-			[]uint32{1, 2, 3},
+			name: "mixed array",
+			args: map[string]any{"uids": []any{float64(1), "2", int(3)}},
+			key:  "uids",
+			want: []uint32{1, 2, 3},
 		},
 		{
-			"single float64",
-			map[string]any{"uids": float64(42)},
-			"uids",
-			[]uint32{42},
+			name: "single float64",
+			args: map[string]any{"uids": float64(42)},
+			key:  "uids",
+			want: []uint32{42},
 		},
 		{
-			"single int",
-			map[string]any{"uids": int(99)},
-			"uids",
-			[]uint32{99},
+			name: "single int",
+			args: map[string]any{"uids": int(99)},
+			key:  "uids",
+			want: []uint32{99},
 		},
 		{
-			"single string",
-			map[string]any{"uids": "395"},
-			"uids",
-			[]uint32{395},
+			name: "single string",
+			args: map[string]any{"uids": "395"},
+			key:  "uids",
+			want: []uint32{395},
 		},
 		{
-			"missing key",
-			map[string]any{},
-			"uids",
-			nil,
+			name:    "missing key",
+			args:    map[string]any{},
+			key:     "uids",
+			wantNil: true,
 		},
 		{
-			"invalid string",
-			map[string]any{"uids": "abc"},
-			"uids",
-			nil,
+			name:    "invalid string",
+			args:    map[string]any{"uids": "abc"},
+			key:     "uids",
+			wantNil: true,
 		},
 		{
-			"array with invalid strings skipped",
-			map[string]any{"uids": []any{float64(1), "bad", float64(3)}},
-			"uids",
-			[]uint32{1, 3},
+			name: "array with invalid strings skipped",
+			args: map[string]any{"uids": []any{float64(1), "bad", float64(3)}},
+			key:  "uids",
+			want: []uint32{1, 3},
+		},
+		{
+			name:    "negative float64 rejected",
+			args:    map[string]any{"uids": float64(-1)},
+			key:     "uids",
+			wantNil: true,
+		},
+		{
+			name:    "zero rejected",
+			args:    map[string]any{"uids": float64(0)},
+			key:     "uids",
+			wantNil: true,
+		},
+		{
+			name:    "non-integer float64 rejected",
+			args:    map[string]any{"uids": float64(1.5)},
+			key:     "uids",
+			wantNil: true,
+		},
+		{
+			name:    "negative int rejected",
+			args:    map[string]any{"uids": int(-5)},
+			key:     "uids",
+			wantNil: true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := uint32SliceArg(tt.args, tt.key)
+
+			if tt.wantNil {
+				if got != nil {
+					t.Errorf("uint32SliceArg() = %v, want nil", got)
+				}
+				return
+			}
+
+			if got == nil {
+				t.Errorf("uint32SliceArg() = nil, want %v", tt.want)
+				return
+			}
 			if len(got) != len(tt.want) {
 				t.Errorf("uint32SliceArg() = %v, want %v", got, tt.want)
 				return

--- a/internal/tools/email_tools.go
+++ b/internal/tools/email_tools.go
@@ -268,7 +268,7 @@ func (r *Registry) registerEmailTools() {
 					"description": "Email account name (default: primary account)",
 				},
 			},
-			"required": []string{"destination"},
+			// destination is validated by the handler (folder accepted as alias).
 		},
 		Handler: func(ctx context.Context, args map[string]any) (string, error) {
 			return r.emailTools.HandleMove(ctx, args)


### PR DESCRIPTION
## Summary

- **UID type coercion**: `intArg` now accepts `float64`, `int`, and `string` — fixes `email_read`/`email_reply` failures when models pass UIDs as `"395"` instead of `395`
- **Singular `uid` fallback**: `email_move` and `email_mark` accept `"uid": 395` alongside `"uids": [395]` — models naturally use singular form (matching `email_read`)
- **Folder/destination alias**: `email_move` treats `"folder"` as destination when `"destination"` is omitted — models use `"folder"` (consistent with `email_list`) instead of `"destination"`
- **DRY**: Extracts duplicated UID array parsing into shared `uint32SliceArg` helper with full type coercion
- **Updated tool descriptions**: `email_move` and `email_mark` schemas now document `uid` parameter and clarify folder/destination behavior

### Files changed

| File | Change |
|------|--------|
| `internal/email/tools.go` | Enhanced `intArg`, new `uint32SliceArg`, updated `HandleMark`/`HandleMove` |
| `internal/email/tools_test.go` | Expanded `TestIntArg`, new `TestUint32SliceArg` (9 cases) |
| `internal/tools/email_tools.go` | Updated schemas for `email_mark` and `email_move` |

## Test plan

- [x] `TestIntArg` — expanded with `int`, `string "395"`, `string "abc"` cases
- [x] `TestUint32SliceArg` — 9 table-driven cases: float64/string/mixed arrays, single values, missing, invalid
- [x] All existing email tool tests still pass
- [x] `just ci` passes (fmt, lint, race-enabled tests)

Closes #365

🤖 Generated with [Claude Code](https://claude.com/claude-code)