### PR TITLE
feat: add event bus for operational observability (#368)

### DIFF
--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -16,6 +16,7 @@ import (
 	"github.com/nugget/thane-ai-agent/internal/buildinfo"
 	"github.com/nugget/thane-ai-agent/internal/checkpoint"
 	"github.com/nugget/thane-ai-agent/internal/config"
+	"github.com/nugget/thane-ai-agent/internal/events"
 	"github.com/nugget/thane-ai-agent/internal/memory"
 	"github.com/nugget/thane-ai-agent/internal/router"
 	"github.com/nugget/thane-ai-agent/internal/usage"
@@ -60,6 +61,7 @@ type Server struct {
 	archiveStore  *memory.ArchiveStore
 	healthDeps    HealthStatusFunc
 	tokenObserver TokenObserver
+	eventBus      *events.Bus
 	logger        *slog.Logger
 	server        *http.Server
 	stats         *SessionStats
@@ -75,6 +77,11 @@ func (s *Server) SetConnManager(fn HealthStatusFunc) {
 // by the MQTT publisher's daily token accumulator.
 func (s *Server) SetTokenObserver(obs TokenObserver) {
 	s.tokenObserver = obs
+}
+
+// SetEventBus configures the event bus for the WebSocket event stream.
+func (s *Server) SetEventBus(bus *events.Bus) {
+	s.eventBus = bus
 }
 
 // LastRequest returns when the most recent LLM request completed.

--- a/internal/events/bus.go
+++ b/internal/events/bus.go
@@ -1,0 +1,178 @@
+// Package events provides a publish/subscribe event bus for operational
+// observability. Events flow from components (agent loop, signal bridge,
+// scheduler, etc.) to subscribers (WebSocket handler, future metrics
+// collector). The bus is nil-safe: calling Publish on a nil *Bus is a
+// no-op, so components do not need guard checks.
+package events
+
+import (
+	"sync"
+	"time"
+)
+
+// Source constants identify which component published an event.
+const (
+	// SourceAgent identifies events from the core agent loop.
+	SourceAgent = "agent"
+	// SourceSignal identifies events from the Signal bridge.
+	SourceSignal = "signal"
+	// SourceDelegate identifies events from delegate task execution.
+	SourceDelegate = "delegate"
+	// SourceEmail identifies events from the email poller.
+	SourceEmail = "email"
+	// SourceMetacog identifies events from the metacognitive loop.
+	SourceMetacog = "metacog"
+	// SourceScheduler identifies events from the task scheduler.
+	SourceScheduler = "scheduler"
+)
+
+// Kind constants describe the type of event within a source.
+const (
+	// KindRequestStart signals the beginning of an agent request.
+	// Data: request_id, conversation_id, channel.
+	KindRequestStart = "request_start"
+	// KindLLMCall signals the start of an LLM API call.
+	// Data: request_id, iter, model.
+	KindLLMCall = "llm_call"
+	// KindLLMResponse signals completion of an LLM API call.
+	// Data: request_id, iter, model, tokens_in, tokens_out,
+	// cost_usd, tool_calls.
+	KindLLMResponse = "llm_response"
+	// KindToolCall signals the start of a tool execution.
+	// Data: request_id, tool.
+	KindToolCall = "tool_call"
+	// KindToolDone signals completion of a tool execution.
+	// Data: request_id, tool, ok, duration_ms.
+	KindToolDone = "tool_done"
+	// KindRequestComplete signals the end of an agent request.
+	// Data: request_id, model, iterations, total_tokens_in,
+	// total_tokens_out, total_cost_usd, elapsed_ms.
+	KindRequestComplete = "request_complete"
+
+	// KindMessageReceived signals an incoming Signal message.
+	// Data: sender, conversation_id, message_len.
+	KindMessageReceived = "message_received"
+	// KindReactionReceived signals an incoming Signal reaction.
+	// Data: sender, emoji.
+	KindReactionReceived = "reaction_received"
+	// KindSessionRotated signals a session was rotated due to inactivity.
+	// Data: conversation_id, sender.
+	KindSessionRotated = "session_rotated"
+
+	// KindSpawn signals a delegate task was spawned.
+	// Data: delegate_id, profile, task_len.
+	KindSpawn = "spawn"
+	// KindComplete signals a delegate task completed.
+	// Data: delegate_id, iterations, total_tokens_in,
+	// total_tokens_out, total_cost_usd, exhausted.
+	KindComplete = "complete"
+
+	// KindPollStart signals the start of an email poll cycle.
+	// Data: accounts.
+	KindPollStart = "poll_start"
+	// KindPollComplete signals the end of an email poll cycle.
+	// Data: new_messages, accounts.
+	KindPollComplete = "poll_complete"
+
+	// KindIterationStart signals the start of a metacognitive iteration.
+	// Data: conversation_id, supervisor.
+	KindIterationStart = "iteration_start"
+	// KindSleepAdjust signals a metacognitive sleep duration change.
+	// Data: sleep_seconds.
+	KindSleepAdjust = "sleep_adjust"
+
+	// KindTaskFired signals a scheduled task has begun executing.
+	// Data: task_id, task_name.
+	KindTaskFired = "task_fired"
+	// KindTaskComplete signals a scheduled task has finished executing.
+	// Data: task_id, task_name, ok, duration_ms.
+	KindTaskComplete = "task_complete"
+)
+
+// Event represents a single operational event published by a component.
+type Event struct {
+	// Timestamp is when the event occurred.
+	Timestamp time.Time `json:"ts"`
+	// Source identifies the component that published the event.
+	Source string `json:"source"`
+	// Kind describes the type of event within the source.
+	Kind string `json:"kind"`
+	// Data holds event-specific key/value pairs.
+	Data map[string]any `json:"data,omitempty"`
+}
+
+// Bus is a non-blocking broadcast event bus. Subscribers receive events
+// on buffered channels; slow subscribers miss events rather than
+// blocking publishers.
+type Bus struct {
+	mu   sync.RWMutex
+	subs map[chan Event]struct{}
+	// recvToSend maps the receive-only channel returned by Subscribe
+	// back to the bidirectional channel stored in subs. This allows
+	// Unsubscribe to accept <-chan Event (the caller's view) without
+	// an illegal type conversion.
+	recvToSend map[<-chan Event]chan Event
+}
+
+// New creates a new event bus ready for use.
+func New() *Bus {
+	return &Bus{
+		subs:       make(map[chan Event]struct{}),
+		recvToSend: make(map[<-chan Event]chan Event),
+	}
+}
+
+// Publish sends an event to all subscribers. Non-blocking: if a
+// subscriber's channel is full, the event is dropped for that
+// subscriber. Safe to call on a nil receiver (no-op).
+func (b *Bus) Publish(e Event) {
+	if b == nil {
+		return
+	}
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	for ch := range b.subs {
+		select {
+		case ch <- e:
+		default:
+			// Subscriber is full — drop the event rather than block.
+		}
+	}
+}
+
+// Subscribe returns a channel that receives published events. The
+// caller must eventually call Unsubscribe to avoid resource leaks.
+// bufSize controls the channel buffer; 64 is a reasonable default for
+// WebSocket consumers.
+func (b *Bus) Subscribe(bufSize int) <-chan Event {
+	ch := make(chan Event, bufSize)
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.subs[ch] = struct{}{}
+	b.recvToSend[ch] = ch
+	return ch
+}
+
+// Unsubscribe removes a subscription and closes the channel. Safe to
+// call with a channel that is already unsubscribed (no-op).
+func (b *Bus) Unsubscribe(ch <-chan Event) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	sendCh, ok := b.recvToSend[ch]
+	if !ok {
+		return
+	}
+	delete(b.subs, sendCh)
+	delete(b.recvToSend, ch)
+	close(sendCh)
+}
+
+// SubscriberCount returns the number of active subscribers.
+func (b *Bus) SubscriberCount() int {
+	if b == nil {
+		return 0
+	}
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	return len(b.subs)
+}

--- a/internal/events/bus_test.go
+++ b/internal/events/bus_test.go
@@ -1,0 +1,201 @@
+package events
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestNilBusPublish(t *testing.T) {
+	var b *Bus
+	// Must not panic.
+	b.Publish(Event{Source: SourceAgent, Kind: KindRequestStart})
+}
+
+func TestNilBusSubscriberCount(t *testing.T) {
+	var b *Bus
+	if got := b.SubscriberCount(); got != 0 {
+		t.Errorf("SubscriberCount() on nil bus = %d, want 0", got)
+	}
+}
+
+func TestPublishSingleSubscriber(t *testing.T) {
+	b := New()
+	ch := b.Subscribe(8)
+	defer b.Unsubscribe(ch)
+
+	want := Event{
+		Timestamp: time.Now(),
+		Source:    SourceAgent,
+		Kind:      KindRequestStart,
+		Data:      map[string]any{"request_id": "r_abc"},
+	}
+	b.Publish(want)
+
+	select {
+	case got := <-ch:
+		if got.Source != want.Source || got.Kind != want.Kind {
+			t.Errorf("got event %v, want %v", got, want)
+		}
+		reqID, ok := got.Data["request_id"].(string)
+		if !ok || reqID != "r_abc" {
+			t.Errorf("got request_id %v, want %q", got.Data["request_id"], "r_abc")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for event")
+	}
+}
+
+func TestPublishMultipleSubscribers(t *testing.T) {
+	b := New()
+	const n = 5
+	channels := make([]<-chan Event, n)
+	for i := range n {
+		channels[i] = b.Subscribe(8)
+	}
+	defer func() {
+		for _, ch := range channels {
+			b.Unsubscribe(ch)
+		}
+	}()
+
+	evt := Event{Source: SourceSignal, Kind: KindMessageReceived}
+	b.Publish(evt)
+
+	for i, ch := range channels {
+		select {
+		case got := <-ch:
+			if got.Source != evt.Source || got.Kind != evt.Kind {
+				t.Errorf("subscriber %d: got %v, want %v", i, got, evt)
+			}
+		case <-time.After(time.Second):
+			t.Fatalf("subscriber %d: timed out", i)
+		}
+	}
+}
+
+func TestDropOnFull(t *testing.T) {
+	b := New()
+	// Buffer size 1 — second publish should be dropped.
+	ch := b.Subscribe(1)
+	defer b.Unsubscribe(ch)
+
+	b.Publish(Event{Kind: "first"})
+	b.Publish(Event{Kind: "second"})
+
+	got := <-ch
+	if got.Kind != "first" {
+		t.Errorf("got kind %q, want %q", got.Kind, "first")
+	}
+
+	// Channel should be empty — the second event was dropped.
+	select {
+	case evt := <-ch:
+		t.Errorf("expected empty channel, got event %v", evt)
+	default:
+		// Correct — channel is empty.
+	}
+}
+
+func TestUnsubscribeClosesChannel(t *testing.T) {
+	b := New()
+	ch := b.Subscribe(8)
+
+	b.Unsubscribe(ch)
+
+	// Reading from a closed channel returns the zero value immediately.
+	_, ok := <-ch
+	if ok {
+		t.Error("expected channel to be closed after Unsubscribe")
+	}
+}
+
+func TestDoubleUnsubscribe(t *testing.T) {
+	b := New()
+	ch := b.Subscribe(8)
+
+	b.Unsubscribe(ch)
+	// Must not panic.
+	b.Unsubscribe(ch)
+}
+
+func TestSubscriberCount(t *testing.T) {
+	b := New()
+
+	if got := b.SubscriberCount(); got != 0 {
+		t.Errorf("initial count = %d, want 0", got)
+	}
+
+	ch1 := b.Subscribe(4)
+	ch2 := b.Subscribe(4)
+
+	if got := b.SubscriberCount(); got != 2 {
+		t.Errorf("after 2 subscribes = %d, want 2", got)
+	}
+
+	b.Unsubscribe(ch1)
+	if got := b.SubscriberCount(); got != 1 {
+		t.Errorf("after 1 unsubscribe = %d, want 1", got)
+	}
+
+	b.Unsubscribe(ch2)
+	if got := b.SubscriberCount(); got != 0 {
+		t.Errorf("after all unsubscribed = %d, want 0", got)
+	}
+}
+
+func TestConcurrentPublishSubscribe(t *testing.T) {
+	b := New()
+	const publishers = 10
+	const eventsPerPublisher = 100
+
+	var wg sync.WaitGroup
+
+	// Start a subscriber that drains events.
+	ch := b.Subscribe(64)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		count := 0
+		for range ch {
+			count++
+			// We don't assert exact count because drops are expected.
+		}
+	}()
+
+	// Launch concurrent publishers.
+	var pubWg sync.WaitGroup
+	for i := range publishers {
+		pubWg.Add(1)
+		go func() {
+			defer pubWg.Done()
+			for j := range eventsPerPublisher {
+				b.Publish(Event{
+					Timestamp: time.Now(),
+					Source:    SourceAgent,
+					Kind:      KindToolCall,
+					Data:      map[string]any{"publisher": i, "seq": j},
+				})
+			}
+		}()
+	}
+
+	pubWg.Wait()
+	b.Unsubscribe(ch) // Closes the channel, ending the draining goroutine.
+	wg.Wait()
+}
+
+func TestPublishNoSubscribers(t *testing.T) {
+	b := New()
+	// Must not panic when publishing with no subscribers.
+	b.Publish(Event{Source: SourceScheduler, Kind: KindTaskFired})
+}
+
+func TestPublishAfterUnsubscribe(t *testing.T) {
+	b := New()
+	ch := b.Subscribe(8)
+	b.Unsubscribe(ch)
+
+	// Publishing after the only subscriber is gone must not panic.
+	b.Publish(Event{Source: SourceEmail, Kind: KindPollStart})
+}


### PR DESCRIPTION
## Summary

- New `internal/events/` package: non-blocking broadcast event bus (`Bus`, `Event`, source/kind constants)
- `Bus.Publish()` is nil-safe (no-op on nil receiver) and non-blocking (drops events for slow subscribers)
- Add `SetEventBus(*events.Bus)` setter on `api.Server` for future WebSocket endpoint
- Create and wire event bus in `main.go`

This is **PR 1 of 3** for issue #368 (Web Dashboard Phase 1). It establishes the event bus infrastructure. Follow-up PRs will add event publishing in components (PR 2) and the WebSocket endpoint + dashboard frontend (PR 3).

Part of #368. Do not close #294.

## Test plan

- [x] `just ci` passes (fmt, lint, race-enabled tests)
- [x] New `internal/events/bus_test.go`: nil bus no-op, single/multi subscriber, drop-on-full, unsubscribe closes channel, double unsubscribe, concurrent publish+subscribe under `-race`, subscriber count
- [x] Existing tests unaffected (bus is wired but nothing publishes yet)