### PR TITLE
chore: add go mod tidy check to CI (#371)

### DIFF
--- a/justfile
+++ b/justfile
@@ -67,9 +67,15 @@ fmt-check:
 lint: generate
     golangci-lint run ./...
 
+# Check go.mod/go.sum are tidy
+[group('test')]
+mod-tidy-check:
+    go mod tidy
+    @test -z "$(git diff --name-only go.mod go.sum)" || (echo "go.mod/go.sum not tidy — run 'go mod tidy'" && git diff go.mod go.sum && exit 1)
+
 # CI: format check, lint, and tests
 [group('test')]
-ci: fmt-check lint test
+ci: fmt-check mod-tidy-check lint test
 
 # --- Install ---
 


### PR DESCRIPTION
## Summary

- Add `mod-tidy-check` recipe to justfile: runs `go mod tidy` then fails if `go.mod`/`go.sum` changed
- Include `mod-tidy-check` in the `ci` recipe (before `lint`)
- Existing modules are already tidy — no `go.mod`/`go.sum` changes needed

Closes #371

## Test plan

- [x] `just ci` passes with new `mod-tidy-check` step
- [x] `just mod-tidy-check` passes standalone
- [x] Verified `go mod tidy` produces no diff on current `main`