### PR TITLE
feat: add knowledge base references to facts (#352)

### DIFF
--- a/cmd/thane/main.go
+++ b/cmd/thane/main.go
@@ -985,6 +985,10 @@ func runServe(ctx context.Context, stdout io.Writer, stderr io.Writer, configPat
 	// files within that directory. All paths are sandboxed.
 	if cfg.Workspace.Path != "" {
 		fileTools := tools.NewFileTools(cfg.Workspace.Path, cfg.Workspace.ReadOnlyDirs)
+		if cfg.KnowledgeBase.Path != "" {
+			fileTools.SetKnowledgeBasePath(cfg.KnowledgeBase.Path)
+			logger.Info("knowledge base path configured", "path", cfg.KnowledgeBase.Path)
+		}
 		loop.Tools().SetFileTools(fileTools)
 		loop.SetEgoFile(filepath.Join(cfg.Workspace.Path, "ego.md"))
 		logger.Info("file tools enabled", "workspace", cfg.Workspace.Path)
@@ -2118,7 +2122,7 @@ func (f *factSetterFunc) SetFact(category, key, value, source string, confidence
 		}
 	}
 
-	_, err = f.store.Set(facts.Category(category), key, value, source, confidence, nil)
+	_, err = f.store.Set(facts.Category(category), key, value, source, confidence, nil, "")
 	return err
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -108,6 +108,10 @@ type Config struct {
 	// Workspace configures the agent's sandboxed file system access.
 	Workspace WorkspaceConfig `yaml:"workspace"`
 
+	// KnowledgeBase configures the knowledge base directory for
+	// long-form reference documents linked from facts.
+	KnowledgeBase KnowledgeBaseConfig `yaml:"knowledge_base"`
+
 	// ShellExec configures the agent's ability to run shell commands.
 	ShellExec ShellExecConfig `yaml:"shell_exec"`
 
@@ -509,6 +513,17 @@ type WorkspaceConfig struct {
 	// but not write to. Useful for giving the agent access to reference
 	// material outside its workspace.
 	ReadOnlyDirs []string `yaml:"read_only_dirs"`
+}
+
+// KnowledgeBaseConfig configures the knowledge base directory for
+// long-form reference documents. Facts can link to KB pages via the
+// ref field, and file tools resolve kb: prefixed paths against this
+// directory.
+type KnowledgeBaseConfig struct {
+	// Path is the root directory for knowledge base files. When set,
+	// file tools resolve "kb:foo.md" to files in this directory.
+	// Should be within the workspace for write access.
+	Path string `yaml:"path"`
 }
 
 // MQTTConfig configures the MQTT connection for Home Assistant device

--- a/internal/facts/subject_context.go
+++ b/internal/facts/subject_context.go
@@ -95,6 +95,9 @@ func (p *SubjectContextProvider) GetContext(ctx context.Context, _ string) (stri
 		}
 		sb.WriteString("\n")
 		sb.WriteString(f.Value)
+		if f.Ref != "" {
+			sb.WriteString(fmt.Sprintf("\n📎 Full details: kb:%s", f.Ref))
+		}
 	}
 
 	p.logger.Debug("subject context injected",

--- a/internal/ingest/markdown.go
+++ b/internal/ingest/markdown.go
@@ -70,6 +70,7 @@ func (m *MarkdownIngester) ingestChunks(ctx context.Context, chunks []Chunk) (in
 			m.source,
 			1.0,
 			nil,
+			"",
 		)
 		if err != nil {
 			continue // Skip failures


### PR DESCRIPTION
## Summary

- Add `ref` TEXT column to facts table so facts can link to full knowledge base pages (dossiers, analyses, design docs)
- `remember_fact` tool gains optional `ref` parameter for storing KB-relative paths
- `SubjectContextProvider` renders ref annotations (`📎 Full details: kb:path`) in system prompt
- `kb:` prefix resolution in `FileTools.resolvePath()` alongside existing `temp:` and `~` expansion
- New `knowledge_base.path` config field with `KnowledgeBaseConfig` struct
- Wiring in `cmd/thane/main.go` to configure KB path on file tools

## Test plan

- [x] All existing tests pass with mechanical `""` additions to `Store.Set()` calls
- [x] `TestSet_WithRef` — stores and retrieves fact with ref
- [x] `TestSet_UpdateRef` — updates ref on existing fact
- [x] `TestRemember_WithRef` — Remember tool stores ref from JSON args
- [x] `TestRecall_ShowsRef` — Recall tool includes `kb:` ref in output
- [x] `TestGetContext_WithRef` — subject context renders `📎 Full details: kb:...`
- [x] `TestGetContext_WithoutRef_NoAnnotation` — no annotation when ref is empty
- [x] `TestResolvePath_KBPrefix` — resolves `kb:path` to correct absolute path
- [x] `TestResolvePath_KBPrefix_NotConfigured` — errors when KB path not configured
- [x] `TestResolvePath_KBPrefix_ReadViaFileRead` — end-to-end file read via kb: prefix
- [x] `just ci` passes clean

Closes #352

🤖 Generated with [Claude Code](https://claude.com/claude-code)