### PR TITLE
fix: metacognitive tools blocked by capability tag filtering

### DIFF
--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -41,6 +41,7 @@ type Request struct {
 	Hints          map[string]string `json:"hints,omitempty"` // Routing hints (channel, mission, etc.)
 	SkipContext    bool              `json:"-"`               // Skip memory, tools, and context injection (for lightweight completions)
 	ExcludeTools   []string          `json:"-"`               // Tool names to exclude from this run (e.g., lifecycle tools for recurring wakes)
+	SkipTagFilter  bool              `json:"-"`               // Bypass capability tag filtering (for self-scoping contexts like metacognitive)
 }
 
 // StreamEvent is a single event in a streaming response.
@@ -903,7 +904,7 @@ func (l *Loop) Run(ctx context.Context, req *Request, stream StreamCallback) (re
 	// exclusions (e.g., lifecycle tools stripped from recurring wakes) are
 	// applied on top.
 	effectiveTools := l.tools
-	if l.activeTags != nil {
+	if l.activeTags != nil && !req.SkipTagFilter {
 		activeTags := make([]string, 0, len(l.activeTags))
 		for tag := range l.activeTags {
 			activeTags = append(activeTags, tag)

--- a/internal/agent/skip_tag_filter_test.go
+++ b/internal/agent/skip_tag_filter_test.go
@@ -1,0 +1,184 @@
+package agent
+
+import (
+	"context"
+	"testing"
+
+	"github.com/nugget/thane-ai-agent/internal/config"
+	"github.com/nugget/thane-ai-agent/internal/llm"
+	"github.com/nugget/thane-ai-agent/internal/tools"
+)
+
+func TestSkipTagFilter_Bypasses(t *testing.T) {
+	// When SkipTagFilter is true, untagged tools should still be visible
+	// and executable even when capability tags are active.
+	mock := &mockLLM{
+		responses: []*llm.ChatResponse{
+			{
+				Model: "test-model",
+				Message: llm.Message{
+					Role: "assistant",
+					ToolCalls: []llm.ToolCall{{
+						ID: "call-1",
+						Function: struct {
+							Name      string         `json:"name"`
+							Arguments map[string]any `json:"arguments"`
+						}{
+							Name:      "untagged_tool",
+							Arguments: map[string]any{},
+						},
+					}},
+				},
+				InputTokens:  100,
+				OutputTokens: 10,
+			},
+			{
+				Model:        "test-model",
+				Message:      llm.Message{Role: "assistant", Content: "Tool worked."},
+				InputTokens:  200,
+				OutputTokens: 5,
+			},
+		},
+	}
+
+	loop := buildTestLoop(mock, []string{"tagged_tool"})
+
+	// Register an untagged tool.
+	untaggedExecuted := false
+	loop.tools.Register(&tools.Tool{
+		Name:        "untagged_tool",
+		Description: "An untagged tool",
+		Parameters:  map[string]any{"type": "object", "properties": map[string]any{}},
+		Handler: func(_ context.Context, _ map[string]any) (string, error) {
+			untaggedExecuted = true
+			return "ok", nil
+		},
+	})
+
+	// Set up capability tags: only "tagged_tool" is tagged.
+	loop.SetCapabilityTags(
+		map[string]config.CapabilityTagConfig{
+			"testing": {
+				Tools:        []string{"tagged_tool"},
+				AlwaysActive: true,
+			},
+		},
+		nil,
+	)
+
+	resp, err := loop.Run(context.Background(), &Request{
+		Messages:      []Message{{Role: "user", Content: "use the untagged tool"}},
+		SkipTagFilter: true,
+	}, nil)
+	if err != nil {
+		t.Fatalf("Run() error: %v", err)
+	}
+
+	// The untagged tool should have executed because SkipTagFilter=true.
+	if !untaggedExecuted {
+		t.Error("untagged_tool should have executed with SkipTagFilter=true")
+	}
+
+	// Both tools should appear in definitions sent to the model.
+	if len(mock.calls) < 1 {
+		t.Fatal("expected at least 1 LLM call")
+	}
+	names := toolNames(mock.calls[0].Tools)
+	if !hasName(names, "untagged_tool") {
+		t.Errorf("untagged_tool should appear in tool definitions with SkipTagFilter=true: %v", names)
+	}
+	if !hasName(names, "tagged_tool") {
+		t.Errorf("tagged_tool should appear in tool definitions: %v", names)
+	}
+
+	if resp == nil || resp.Content == "" {
+		t.Error("expected a non-empty response")
+	}
+}
+
+func TestSkipTagFilter_DefaultPreserves(t *testing.T) {
+	// When SkipTagFilter is false (default), untagged tools should be
+	// filtered out when capability tags are active.
+	mock := &mockLLM{
+		responses: []*llm.ChatResponse{
+			{
+				Model: "test-model",
+				Message: llm.Message{
+					Role: "assistant",
+					ToolCalls: []llm.ToolCall{{
+						ID: "call-1",
+						Function: struct {
+							Name      string         `json:"name"`
+							Arguments map[string]any `json:"arguments"`
+						}{
+							Name:      "untagged_tool",
+							Arguments: map[string]any{},
+						},
+					}},
+				},
+				InputTokens:  100,
+				OutputTokens: 10,
+			},
+			{
+				Model:        "test-model",
+				Message:      llm.Message{Role: "assistant", Content: "Tool blocked."},
+				InputTokens:  200,
+				OutputTokens: 5,
+			},
+		},
+	}
+
+	loop := buildTestLoop(mock, []string{"tagged_tool"})
+
+	// Register an untagged tool.
+	untaggedExecuted := false
+	loop.tools.Register(&tools.Tool{
+		Name:        "untagged_tool",
+		Description: "An untagged tool",
+		Parameters:  map[string]any{"type": "object", "properties": map[string]any{}},
+		Handler: func(_ context.Context, _ map[string]any) (string, error) {
+			untaggedExecuted = true
+			return "ok", nil
+		},
+	})
+
+	// Set up capability tags: only "tagged_tool" is tagged.
+	loop.SetCapabilityTags(
+		map[string]config.CapabilityTagConfig{
+			"testing": {
+				Tools:        []string{"tagged_tool"},
+				AlwaysActive: true,
+			},
+		},
+		nil,
+	)
+
+	resp, err := loop.Run(context.Background(), &Request{
+		Messages: []Message{{Role: "user", Content: "use the untagged tool"}},
+		// SkipTagFilter defaults to false.
+	}, nil)
+	if err != nil {
+		t.Fatalf("Run() error: %v", err)
+	}
+
+	// The untagged tool should NOT have executed.
+	if untaggedExecuted {
+		t.Error("untagged_tool should NOT have executed with default SkipTagFilter=false")
+	}
+
+	// The untagged tool should NOT appear in definitions sent to the model.
+	if len(mock.calls) < 1 {
+		t.Fatal("expected at least 1 LLM call")
+	}
+	names := toolNames(mock.calls[0].Tools)
+	if hasName(names, "untagged_tool") {
+		t.Errorf("untagged_tool should NOT appear in tool definitions with SkipTagFilter=false: %v", names)
+	}
+	if !hasName(names, "tagged_tool") {
+		t.Errorf("tagged_tool should appear in tool definitions: %v", names)
+	}
+
+	if resp == nil || resp.Content == "" {
+		t.Error("expected a non-empty response")
+	}
+}

--- a/internal/metacognitive/metacognitive.go
+++ b/internal/metacognitive/metacognitive.go
@@ -311,6 +311,7 @@ func (l *Loop) iterate(ctx context.Context, isSupervisor bool, convID string) (*
 		ConversationID: convID,
 		Messages:       []agent.Message{{Role: "user", Content: promptText}},
 		ExcludeTools:   metacogExcludeTools,
+		SkipTagFilter:  true,
 		Hints: map[string]string{
 			"source":                    "metacognitive",
 			"supervisor":                strconv.FormatBool(isSupervisor),


### PR DESCRIPTION
## Summary

Closes #386.

- Adds `SkipTagFilter bool` to `agent.Request` so self-scoping contexts can bypass capability tag filtering
- Gates the `FilterByTags` call in `loop.go` with `!req.SkipTagFilter`
- Sets `SkipTagFilter: true` in the metacognitive loop's `iterate()` request
- The metacog loop already manages its own tool scope via `ExcludeTools`, so tag filtering was incorrectly blocking `update_metacognitive_state` and `set_next_sleep`

## Context

After #373 enforced tool execution through the tag filter, untagged metacog tools were silently dropped from the effective registry. Every iteration wasted tokens retrying blocked tools. This implements Option B from the issue — cleanest approach since it doesn't leak metacog-specific tools into the global tag namespace.

## Test plan

- [x] `just ci` passes (fmt, lint, tests with -race)
- [x] New test: `SkipTagFilter=true` bypasses tag filtering, untagged tools remain visible and executable
- [x] New test: `SkipTagFilter=false` (default) preserves existing behavior, untagged tools are filtered out
- [x] Existing exclude_tools, tag_context, and orchestrator tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)