### PR TITLE
fix: make drop_capability survive capability tag filtering

### DIFF
--- a/internal/tools/capability_tools.go
+++ b/internal/tools/capability_tools.go
@@ -70,8 +70,9 @@ func (r *Registry) registerRequestCapability(mgr CapabilityManager, manifest []C
 	availableDesc.WriteString("Use drop_capability to deactivate a tag when you no longer need those tools.")
 
 	r.Register(&Tool{
-		Name:        "request_capability",
-		Description: availableDesc.String(),
+		Name:            "request_capability",
+		AlwaysAvailable: true,
+		Description:     availableDesc.String(),
 		Parameters: map[string]any{
 			"type": "object",
 			"properties": map[string]any{
@@ -115,8 +116,9 @@ func (r *Registry) registerRequestCapability(mgr CapabilityManager, manifest []C
 // registerDropCapability registers the drop_capability tool.
 func (r *Registry) registerDropCapability(mgr CapabilityManager, tagManifest map[string]CapabilityManifest) {
 	r.Register(&Tool{
-		Name:        "drop_capability",
-		Description: "Deactivate a capability tag to remove its tools from the active set. Always-active tags cannot be dropped. Use when you no longer need a capability's tools to keep the tool set focused.",
+		Name:            "drop_capability",
+		AlwaysAvailable: true,
+		Description:     "Deactivate a capability tag to remove its tools from the active set. Always-active tags cannot be dropped. Use when you no longer need a capability's tools to keep the tool set focused.",
 		Parameters: map[string]any{
 			"type": "object",
 			"properties": map[string]any{
@@ -137,11 +139,19 @@ func (r *Registry) registerDropCapability(mgr CapabilityManager, tagManifest map
 				return "", err
 			}
 
-			// List the tools that were unloaded.
+			// List the tools that were unloaded and the remaining active tags.
 			var result strings.Builder
 			fmt.Fprintf(&result, "Capability **%s** deactivated.", tag)
 			if m, ok := tagManifest[tag]; ok && len(m.Tools) > 0 {
 				fmt.Fprintf(&result, " Tools removed: %s.", strings.Join(m.Tools, ", "))
+			}
+			if remaining := mgr.ActiveTags(); len(remaining) > 0 {
+				tags := make([]string, 0, len(remaining))
+				for t := range remaining {
+					tags = append(tags, t)
+				}
+				sort.Strings(tags)
+				fmt.Fprintf(&result, " Active tags: %s.", strings.Join(tags, ", "))
 			}
 			return result.String(), nil
 		},

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -24,10 +24,11 @@ import (
 
 // Tool represents a callable tool.
 type Tool struct {
-	Name        string                                                         `json:"name"`
-	Description string                                                         `json:"description"`
-	Parameters  map[string]any                                                 `json:"parameters"`
-	Handler     func(ctx context.Context, args map[string]any) (string, error) `json:"-"`
+	Name            string                                                         `json:"name"`
+	Description     string                                                         `json:"description"`
+	Parameters      map[string]any                                                 `json:"parameters"`
+	Handler         func(ctx context.Context, args map[string]any) (string, error) `json:"-"`
+	AlwaysAvailable bool                                                           `json:"-"` // Survives capability tag filtering.
 }
 
 // Registry holds available tools.
@@ -988,8 +989,9 @@ func (r *Registry) SetTagIndex(tags map[string][]string) {
 }
 
 // FilterByTags creates a new Registry containing only the tools that
-// belong to at least one of the given tags. If tags is empty or the
-// tag index is nil, returns a copy of the full registry.
+// belong to at least one of the given tags, plus any tools marked as
+// AlwaysAvailable. If tags is empty or the tag index is nil, returns a
+// copy of the full registry.
 func (r *Registry) FilterByTags(tags []string) *Registry {
 	if len(tags) == 0 || r.tagIndex == nil {
 		// No filtering — return a shallow copy with all tools.
@@ -1008,8 +1010,8 @@ func (r *Registry) FilterByTags(tags []string) *Registry {
 	}
 
 	filtered := &Registry{tools: make(map[string]*Tool, len(allowed))}
-	for name := range allowed {
-		if t := r.tools[name]; t != nil {
+	for name, t := range r.tools {
+		if allowed[name] || t.AlwaysAvailable {
 			filtered.tools[name] = t
 		}
 	}


### PR DESCRIPTION
Closes #393

## Summary
- `drop_capability` (and `request_capability`) were being filtered out by `FilterByTags` because they aren't assigned to any tag group. The model could discover them in the manifest but calls were blocked with "tool not available in this context"
- Added `AlwaysAvailable` flag on `Tool` struct — meta-tools that must survive tag filtering set this to `true`
- `FilterByTags` now preserves tools with `AlwaysAvailable: true` alongside tools from active tags
- `drop_capability` response now includes remaining active tags for confirmation
- Non-meta untagged tools are still correctly filtered out (existing `TestSkipTagFilter_DefaultPreserves` passes unchanged)

## Test plan
- [x] `just ci` passes (fmt, lint, tests with -race)
- [x] `TestRegistryFilterByTags_AlwaysAvailable` — verifies AlwaysAvailable tools survive all filter scenarios while plain untagged tools are filtered out
- [x] `TestDropCapability` — verifies remaining active tags appear in response
- [x] `TestSkipTagFilter_DefaultPreserves` — existing test still passes (untagged tools without AlwaysAvailable are still filtered)

🤖 Generated with [Claude Code](https://claude.com/claude-code)