### PR TITLE
fix: assign stable message IDs to prevent archive duplicates

### DIFF
--- a/internal/memory/archive_adapter.go
+++ b/internal/memory/archive_adapter.go
@@ -52,6 +52,7 @@ func (a *ArchiveAdapter) ArchiveConversation(conversationID string, messages []M
 	archived := make([]ArchivedMessage, len(messages))
 	for i, m := range messages {
 		archived[i] = ArchivedMessage{
+			ID:             m.ID,
 			ConversationID: conversationID,
 			SessionID:      sessionID,
 			Role:           m.Role,

--- a/internal/memory/compaction.go
+++ b/internal/memory/compaction.go
@@ -127,6 +127,7 @@ func (c *Compactor) Compact(ctx context.Context, conversationID string) error {
 		archived := make([]ArchivedMessage, len(messages))
 		for i, m := range messages {
 			archived[i] = ArchivedMessage{
+				ID:             m.ID,
 				ConversationID: conversationID,
 				SessionID:      sessionID,
 				Role:           m.Role,

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -15,8 +15,11 @@
 package memory
 
 import (
+	"fmt"
 	"sync"
 	"time"
+
+	"github.com/google/uuid"
 )
 
 // Store is the interface for memory storage.
@@ -30,6 +33,7 @@ type MemoryStore interface {
 
 // Message represents a conversation message.
 type Message struct {
+	ID         string    `json:"id"`   // Stable UUIDv7 assigned at creation time
 	Role       string    `json:"role"` // system, user, assistant, tool
 	Content    string    `json:"content"`
 	Timestamp  time.Time `json:"timestamp"`
@@ -113,7 +117,12 @@ func (s *Store) AddMessage(conversationID string, role, content string) error {
 		s.conversations[conversationID] = conv
 	}
 
+	msgID, err := uuid.NewV7()
+	if err != nil {
+		return fmt.Errorf("generate message ID: %w", err)
+	}
 	conv.Messages = append(conv.Messages, Message{
+		ID:        msgID.String(),
 		Role:      role,
 		Content:   content,
 		Timestamp: time.Now(),


### PR DESCRIPTION
## Summary

- Adds a stable `ID` (UUIDv7) to `memory.Message`, assigned at `AddMessage()` time rather than at archive time
- Passes the stable ID through all archival paths (`ArchiveConversation`, `Compact`) so `INSERT OR IGNORE` on the primary key correctly deduplicates
- Updates `SQLiteStore` query methods (`GetMessages`, `GetAllMessages`, `GetMessagesForCompaction`) to select and populate `Message.ID`
- Existing `if m.ID == ""` fallback in `ArchiveMessages()` provides backwards compatibility for pre-existing messages

## Test plan

- [x] `just ci` passes (fmt, lint, tests with `-race`)
- [ ] Verify that checkpointing + resetting a session no longer produces duplicate rows in `archive_messages`
- [ ] Verify that `GetSessionTranscript()` returns each message exactly once

Closes #431

🤖 Generated with [Claude Code](https://claude.com/claude-code)