### PR TITLE
feat: unify tool call storage (#434 phase 2)

### DIFF
--- a/internal/memory/migrate_unify_test.go
+++ b/internal/memory/migrate_unify_test.go
@@ -360,6 +360,412 @@ func TestUnifiedMode_ArchiveMessages(t *testing.T) {
 	}
 }
 
+// TestMigrateUnifyToolCalls_AddsLifecycleColumns verifies that the migration
+// adds session_id, status, archived_at, and iteration_index columns to the
+// tool_calls table.
+func TestMigrateUnifyToolCalls_AddsLifecycleColumns(t *testing.T) {
+	store := newTestWorkingDB(t)
+
+	if err := MigrateUnifyToolCalls(store.DB(), "", slog.Default()); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, col := range []string{"session_id", "status", "archived_at", "iteration_index"} {
+		if !hasColumn(store.DB(), "tool_calls", col) {
+			t.Errorf("expected column %q to exist after migration", col)
+		}
+	}
+}
+
+// TestMigrateUnifyToolCalls_BackfillsStatus verifies that existing tool calls
+// with NULL status get set to 'active'.
+func TestMigrateUnifyToolCalls_BackfillsStatus(t *testing.T) {
+	store := newTestWorkingDB(t)
+
+	store.GetOrCreateConversation("conv-1")
+	store.RecordToolCall("conv-1", "", "tc-1", "get_state", `{}`)
+	store.RecordToolCall("conv-1", "", "tc-2", "call_service", `{}`)
+
+	// Simulate pre-migration rows by NULLing out the status column.
+	_, err := store.DB().Exec(`UPDATE tool_calls SET status = NULL`)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := MigrateUnifyToolCalls(store.DB(), "", slog.Default()); err != nil {
+		t.Fatal(err)
+	}
+
+	var activeCount int
+	_ = store.DB().QueryRow(`SELECT COUNT(*) FROM tool_calls WHERE status = 'active'`).Scan(&activeCount)
+	if activeCount != 2 {
+		t.Errorf("expected 2 active tool calls, got %d", activeCount)
+	}
+}
+
+// TestMigrateUnifyToolCalls_MergesArchive verifies that archived tool calls
+// from archive.db are merged into the working tool_calls table.
+func TestMigrateUnifyToolCalls_MergesArchive(t *testing.T) {
+	tmpDir := t.TempDir()
+	workingPath := tmpDir + "/working.db"
+	archivePath := tmpDir + "/archive.db"
+
+	// Create working store with an active tool call.
+	workingStore, err := NewSQLiteStore(workingPath, 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer workingStore.Close()
+
+	workingStore.GetOrCreateConversation("conv-1")
+	workingStore.RecordToolCall("conv-1", "", "tc-working", "get_state", `{}`)
+
+	// Create archive store with different tool calls.
+	archiveStore, err := NewArchiveStore(archivePath, nil, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sess, _ := archiveStore.StartSession("conv-1")
+	now := time.Now().UTC()
+	completed := now.Add(100 * time.Millisecond)
+	if err := archiveStore.ArchiveToolCalls([]ArchivedToolCall{
+		{
+			ID: "tc-arch-1", ConversationID: "conv-1", SessionID: sess.ID,
+			ToolName: "web_search", Arguments: `{"q":"test"}`,
+			Result: "results", StartedAt: now,
+			CompletedAt: &completed, DurationMs: 100,
+		},
+		{
+			ID: "tc-arch-2", ConversationID: "conv-1", SessionID: sess.ID,
+			ToolName: "file_read", Arguments: `{"path":"x.md"}`,
+			Error: "not found", StartedAt: now.Add(time.Second),
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	archiveStore.Close()
+
+	// Run migration.
+	if err := MigrateUnifyToolCalls(workingStore.DB(), archivePath, slog.Default()); err != nil {
+		t.Fatal(err)
+	}
+
+	var activeCount, archivedCount int
+	_ = workingStore.DB().QueryRow(`SELECT COUNT(*) FROM tool_calls WHERE status = 'active'`).Scan(&activeCount)
+	_ = workingStore.DB().QueryRow(`SELECT COUNT(*) FROM tool_calls WHERE status = 'archived'`).Scan(&archivedCount)
+
+	if activeCount != 1 {
+		t.Errorf("expected 1 active tool call, got %d", activeCount)
+	}
+	if archivedCount != 2 {
+		t.Errorf("expected 2 archived tool calls, got %d", archivedCount)
+	}
+
+	// Verify session_id was preserved from archive.
+	var sessionID string
+	_ = workingStore.DB().QueryRow(`SELECT session_id FROM tool_calls WHERE id = 'tc-arch-1'`).Scan(&sessionID)
+	if sessionID != sess.ID {
+		t.Errorf("expected session_id=%s, got %s", sess.ID, sessionID)
+	}
+}
+
+// TestMigrateUnifyToolCalls_UpsertPreservesSessionID verifies that when a tool
+// call exists in both working and archive, the UPSERT preserves the archive's
+// session_id and sets status to archived.
+func TestMigrateUnifyToolCalls_UpsertPreservesSessionID(t *testing.T) {
+	tmpDir := t.TempDir()
+	workingPath := tmpDir + "/working.db"
+	archivePath := tmpDir + "/archive.db"
+
+	workingStore, err := NewSQLiteStore(workingPath, 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer workingStore.Close()
+
+	// Insert a tool call with a known ID into working store (no session_id).
+	workingStore.GetOrCreateConversation("conv-1")
+	workingStore.RecordToolCall("conv-1", "", "shared-tc", "get_state", `{}`)
+
+	// Create archive with the same tool call ID but with session_id.
+	archiveStore, err := NewArchiveStore(archivePath, nil, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sess, _ := archiveStore.StartSession("conv-1")
+	archiveStore.ArchiveToolCalls([]ArchivedToolCall{
+		{
+			ID: "shared-tc", ConversationID: "conv-1", SessionID: sess.ID,
+			ToolName: "get_state", Arguments: `{}`,
+			StartedAt: time.Now(),
+		},
+	})
+	archiveStore.Close()
+
+	if err := MigrateUnifyToolCalls(workingStore.DB(), archivePath, slog.Default()); err != nil {
+		t.Fatal(err)
+	}
+
+	var sessionID sql.NullString
+	var status string
+	err = workingStore.DB().QueryRow(`SELECT session_id, status FROM tool_calls WHERE id = 'shared-tc'`).Scan(&sessionID, &status)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !sessionID.Valid || sessionID.String != sess.ID {
+		t.Errorf("expected session_id=%s, got %v", sess.ID, sessionID)
+	}
+	if status != "archived" {
+		t.Errorf("expected status=archived, got %s", status)
+	}
+}
+
+// TestMigrateUnifyToolCalls_Idempotent verifies that running the migration
+// twice does not duplicate data or error.
+func TestMigrateUnifyToolCalls_Idempotent(t *testing.T) {
+	tmpDir := t.TempDir()
+	workingPath := tmpDir + "/working.db"
+	archivePath := tmpDir + "/archive.db"
+
+	workingStore, err := NewSQLiteStore(workingPath, 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer workingStore.Close()
+
+	archiveStore, err := NewArchiveStore(archivePath, nil, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sess, _ := archiveStore.StartSession("conv-1")
+	archiveStore.ArchiveToolCalls([]ArchivedToolCall{
+		{
+			ID: "tc-1", ConversationID: "conv-1", SessionID: sess.ID,
+			ToolName: "test", Arguments: `{}`, StartedAt: time.Now(),
+		},
+	})
+	archiveStore.Close()
+
+	// First run.
+	if err := MigrateUnifyToolCalls(workingStore.DB(), archivePath, slog.Default()); err != nil {
+		t.Fatal(err)
+	}
+	var count1 int
+	_ = workingStore.DB().QueryRow(`SELECT COUNT(*) FROM tool_calls`).Scan(&count1)
+
+	// Second run — should be a no-op.
+	if err := MigrateUnifyToolCalls(workingStore.DB(), archivePath, slog.Default()); err != nil {
+		t.Fatal(err)
+	}
+	var count2 int
+	_ = workingStore.DB().QueryRow(`SELECT COUNT(*) FROM tool_calls`).Scan(&count2)
+
+	if count1 != count2 {
+		t.Errorf("idempotency violated: first run %d rows, second run %d rows", count1, count2)
+	}
+}
+
+// TestMigrateUnifyToolCalls_NoArchiveDB verifies that migration succeeds
+// gracefully when there is no archive database.
+func TestMigrateUnifyToolCalls_NoArchiveDB(t *testing.T) {
+	store := newTestWorkingDB(t)
+
+	if err := MigrateUnifyToolCalls(store.DB(), "/nonexistent/archive.db", slog.Default()); err != nil {
+		t.Fatalf("expected no error for missing archive, got: %v", err)
+	}
+}
+
+// TestUnifiedMode_ArchiveToolCalls verifies that SQLiteStore.ArchiveToolCalls
+// updates tool call status to 'archived' in the unified table.
+func TestUnifiedMode_ArchiveToolCalls(t *testing.T) {
+	store := newTestWorkingDB(t)
+
+	store.GetOrCreateConversation("conv-1")
+	store.RecordToolCall("conv-1", "", "tc-1", "get_state", `{}`)
+	store.RecordToolCall("conv-1", "", "tc-2", "call_service", `{}`)
+	store.CompleteToolCall("tc-1", "on", "")
+	store.CompleteToolCall("tc-2", "", "error")
+
+	// Verify they start as active.
+	var activeCount int
+	_ = store.DB().QueryRow(`SELECT COUNT(*) FROM tool_calls WHERE status = 'active' AND conversation_id = 'conv-1'`).Scan(&activeCount)
+	if activeCount != 2 {
+		t.Fatalf("expected 2 active tool calls, got %d", activeCount)
+	}
+
+	// Archive them.
+	affected, err := store.ArchiveToolCalls("conv-1", "sess-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if affected != 2 {
+		t.Errorf("expected 2 affected rows, got %d", affected)
+	}
+
+	// Verify status changed.
+	var archivedCount int
+	_ = store.DB().QueryRow(`SELECT COUNT(*) FROM tool_calls WHERE status = 'archived' AND conversation_id = 'conv-1'`).Scan(&archivedCount)
+	if archivedCount != 2 {
+		t.Errorf("expected 2 archived tool calls, got %d", archivedCount)
+	}
+
+	// Verify session_id was set.
+	var sid string
+	_ = store.DB().QueryRow(`SELECT session_id FROM tool_calls WHERE id = 'tc-1'`).Scan(&sid)
+	if sid != "sess-1" {
+		t.Errorf("expected session_id=sess-1, got %q", sid)
+	}
+
+	// Verify archived_at was set.
+	var archivedAt sql.NullString
+	_ = store.DB().QueryRow(`SELECT archived_at FROM tool_calls WHERE id = 'tc-1'`).Scan(&archivedAt)
+	if !archivedAt.Valid || archivedAt.String == "" {
+		t.Error("expected archived_at to be set")
+	}
+}
+
+// TestUnifiedMode_GetToolCallsFiltersArchived verifies that GetToolCalls
+// only returns active tool calls (not archived ones).
+func TestUnifiedMode_GetToolCallsFiltersArchived(t *testing.T) {
+	store := newTestWorkingDB(t)
+
+	store.GetOrCreateConversation("conv-1")
+	store.RecordToolCall("conv-1", "", "tc-1", "get_state", `{}`)
+	store.RecordToolCall("conv-1", "", "tc-2", "call_service", `{}`)
+	store.RecordToolCall("conv-1", "", "tc-3", "get_state", `{}`)
+
+	// Archive tc-1 and tc-2 but leave tc-3 active.
+	_, _ = store.DB().Exec(`UPDATE tool_calls SET status = 'archived' WHERE id IN ('tc-1', 'tc-2')`)
+
+	// GetToolCalls should only return the active one.
+	calls := store.GetToolCalls("conv-1", 10)
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 active tool call, got %d", len(calls))
+	}
+	if calls[0].ID != "tc-3" {
+		t.Errorf("expected tc-3, got %s", calls[0].ID)
+	}
+}
+
+// TestUnifiedMode_GetToolCallsByNameFiltersArchived verifies that
+// GetToolCallsByName only returns active tool calls.
+func TestUnifiedMode_GetToolCallsByNameFiltersArchived(t *testing.T) {
+	store := newTestWorkingDB(t)
+
+	store.GetOrCreateConversation("conv-1")
+	store.RecordToolCall("conv-1", "", "tc-1", "get_state", `{}`)
+	store.RecordToolCall("conv-1", "", "tc-2", "get_state", `{}`)
+
+	// Archive tc-1.
+	_, _ = store.DB().Exec(`UPDATE tool_calls SET status = 'archived' WHERE id = 'tc-1'`)
+
+	calls := store.GetToolCallsByName("get_state", 10)
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 active get_state call, got %d", len(calls))
+	}
+	if calls[0].ID != "tc-2" {
+		t.Errorf("expected tc-2, got %s", calls[0].ID)
+	}
+}
+
+// TestUnifiedMode_GetSessionToolCalls verifies that GetSessionToolCalls in
+// unified mode reads tool calls from the working DB's tool_calls table.
+func TestUnifiedMode_GetSessionToolCalls(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	workingStore, err := NewSQLiteStore(tmpDir+"/working.db", 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer workingStore.Close()
+
+	MigrateUnifyMessages(workingStore.DB(), "", slog.Default())
+
+	archiveStore, err := NewArchiveStore(tmpDir+"/archive.db", workingStore.DB(), nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer archiveStore.Close()
+
+	sess, _ := archiveStore.StartSession("conv-1")
+
+	// Insert tool calls directly into the unified table with session_id set.
+	now := time.Now().UTC()
+	for i, name := range []string{"get_state", "call_service", "web_search"} {
+		_, err := workingStore.DB().Exec(`
+			INSERT INTO tool_calls (id, conversation_id, session_id, tool_name, arguments,
+			    started_at, status, archived_at)
+			VALUES (?, 'conv-1', ?, ?, '{}', ?, 'archived', ?)
+		`, fmt.Sprintf("tc-%d", i), sess.ID, name,
+			now.Add(time.Duration(i)*time.Second).Format(time.RFC3339Nano),
+			now.Format(time.RFC3339Nano))
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	calls, err := archiveStore.GetSessionToolCalls(sess.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(calls) != 3 {
+		t.Fatalf("expected 3 tool calls, got %d", len(calls))
+	}
+	if calls[0].ToolName != "get_state" {
+		t.Errorf("expected first tool call 'get_state', got %q", calls[0].ToolName)
+	}
+	if calls[2].ToolName != "web_search" {
+		t.Errorf("expected last tool call 'web_search', got %q", calls[2].ToolName)
+	}
+}
+
+// TestUnifiedMode_LinkToolCallsToIteration verifies that
+// LinkToolCallsToIteration updates iteration_index in the unified table.
+func TestUnifiedMode_LinkToolCallsToIteration(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	workingStore, err := NewSQLiteStore(tmpDir+"/working.db", 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer workingStore.Close()
+
+	MigrateUnifyMessages(workingStore.DB(), "", slog.Default())
+
+	archiveStore, err := NewArchiveStore(tmpDir+"/archive.db", workingStore.DB(), nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer archiveStore.Close()
+
+	sess, _ := archiveStore.StartSession("conv-1")
+	now := time.Now().UTC()
+
+	// Insert tool calls into unified table.
+	for _, id := range []string{"tc-a", "tc-b"} {
+		_, err := workingStore.DB().Exec(`
+			INSERT INTO tool_calls (id, conversation_id, session_id, tool_name, arguments,
+			    started_at, status)
+			VALUES (?, 'conv-1', ?, 'test', '{}', ?, 'archived')
+		`, id, sess.ID, now.Format(time.RFC3339Nano))
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Link both tool calls to iteration 0.
+	if err := archiveStore.LinkToolCallsToIteration(sess.ID, 0, []string{"tc-a", "tc-b"}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify iteration_index was set.
+	var iterIdx sql.NullInt64
+	_ = workingStore.DB().QueryRow(`SELECT iteration_index FROM tool_calls WHERE id = 'tc-a'`).Scan(&iterIdx)
+	if !iterIdx.Valid || iterIdx.Int64 != 0 {
+		t.Errorf("expected iteration_index=0, got %v", iterIdx)
+	}
+}
+
 // TestUnifiedMode_SessionMessageCount verifies that session message counts
 // are computed from the unified messages table.
 func TestUnifiedMode_SessionMessageCount(t *testing.T) {


### PR DESCRIPTION
## Summary
- Apply the same lifecycle-column unification from PR #435 (messages) to tool calls
- Tool calls now use `status='active'/'archived'` in the unified `tool_calls` table instead of being copied between `thane.db` and `archive.db`
- Migration (`MigrateUnifyToolCalls`) adds lifecycle columns, backfills status, and merges existing `archive_tool_calls` data via UPSERT
- `GetToolCalls` and `GetToolCallsByName` now filter by `status = 'active'` so archived tool calls don't appear in the working API
- `ArchiveToolCalls` does an in-place UPDATE instead of cross-DB copy + clear
- `GetSessionToolCalls`, `LinkToolCallsToIteration`, `Stats`, and `PurgeImported` all route through the unified table in unified mode

### Files changed
- `internal/memory/migrate_unify.go` — `MigrateUnifyToolCalls` function (lifecycle columns, backfill, UPSERT merge)
- `internal/memory/archive.go` — `tcTableName` routing, method updates for unified mode
- `internal/memory/archive_adapter.go` — `ToolCallArchiver` interface, unified archival path
- `internal/memory/sqlite.go` — `ArchiveToolCalls` method, `status = 'active'` query filters, schema update
- `cmd/thane/main.go` — migration wiring and `SetToolCallStore` call
- `internal/memory/migrate_unify_test.go` — 13 new tests for migration and unified-mode behavior
- `internal/memory/archive_adapter_test.go` — unified-mode adapter test

## Test plan
- [x] `just ci` passes (fmt, lint, test with -race)
- [ ] Manual: start with existing thane.db + archive.db, verify archived tool calls appear in unified table
- [ ] Session detail page still shows tool calls
- [ ] API `/v1/tools/calls` shows only active tool calls
- [ ] New session: tool calls recorded, archived on session end

Phase 2 of 4 for issue #434 (storage unification).