### PR TITLE
refactor: remove legacy dual-mode branches from adapter and compactor

### DIFF
--- a/cmd/thane/main.go
+++ b/cmd/thane/main.go
@@ -513,10 +513,7 @@ func runServe(ctx context.Context, stdout io.Writer, stderr io.Writer, configPat
 	}
 	logger.Info("delegation store initialized")
 
-	archiveAdapter := memory.NewArchiveAdapter(archiveStore, logger)
-	archiveAdapter.SetToolCallSource(mem)
-	archiveAdapter.SetMessageStore(mem)
-	archiveAdapter.SetToolCallStore(mem)
+	archiveAdapter := memory.NewArchiveAdapter(archiveStore, mem, mem, logger)
 
 	// --- Talents ---
 	// Talents are markdown files that extend the system prompt with
@@ -612,7 +609,6 @@ func runServe(ctx context.Context, stdout io.Writer, stderr io.Writer, configPat
 
 	compactSummarizer := memory.NewLLMSummarizer(summarizeFunc)
 	compactor := memory.NewCompactor(mem, compactionConfig, compactSummarizer, logger)
-	compactor.SetArchiver(archiveStore)
 	compactor.SetWorkingMemoryStore(wmStore)
 
 	// --- Session metadata summarizer ---


### PR DESCRIPTION
## Summary

Phase 4 of #434 (unified storage). Removes code complexity left over from the two-database era:

- **ArchiveAdapter**: `MessageArchiver` and `ToolCallArchiver` are now required at construction — removed 3 setter methods, `ToolCallSource` interface, and all nil-guard branches
- **Compactor**: Removed `Archiver` interface and archive-before-compact step — messages persist in the unified table with lifecycle status, so the archive step was a no-op
- **main.go**: Wiring simplified from 5 lines to 2

Net result: **-296 lines** of dead code paths and optional-dependency gymnastics.

## What this does NOT change

- `ArchiveStore` internal dual-path routing (`msgTableName` toggles, `messagesDB` field) — still needed by `NewArchiveStore` for openclaw-import. Separate follow-up.
- Type unification (`ArchivedMessage`/`Message` merge) — separate follow-up.

## Test plan

- [x] `just ci` passes (fmt + lint + race tests)
- [x] All adapter, compaction, and integration tests updated and passing
- [x] No new dependencies or schema changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)