### PR TITLE
fix: remove lifecycle indexes from initial migrate()

### DIFF
--- a/internal/memory/sqlite.go
+++ b/internal/memory/sqlite.go
@@ -88,8 +88,8 @@ func (s *SQLiteStore) migrate() error {
 	CREATE INDEX IF NOT EXISTS idx_tool_calls_conversation ON tool_calls(conversation_id, started_at);
 	CREATE INDEX IF NOT EXISTS idx_tool_calls_tool ON tool_calls(tool_name);
 	CREATE INDEX IF NOT EXISTS idx_tool_calls_message ON tool_calls(message_id);
-	CREATE INDEX IF NOT EXISTS idx_tool_calls_session ON tool_calls(session_id, started_at);
-	CREATE INDEX IF NOT EXISTS idx_tool_calls_status ON tool_calls(conversation_id, status);
+	-- idx_tool_calls_session and idx_tool_calls_status are created by
+	-- MigrateUnifyToolCalls after the lifecycle columns exist.
 
 	-- Entity facts (for Phase 3)
 	CREATE TABLE IF NOT EXISTS entity_facts (


### PR DESCRIPTION
## Problem

Startup crashes on existing databases with:
```
open memory database ./db/thane.db: migrate: no such column: session_id
```

The `tool_calls` CREATE TABLE in `migrate()` was updated (#434 phases) to include lifecycle columns (`session_id`, `status`), but for **existing databases** the table already exists without them. `CREATE TABLE IF NOT EXISTS` is a no-op, but the `CREATE INDEX IF NOT EXISTS` statements on `session_id` and `status` fail because those columns don't exist yet — `MigrateUnifyToolCalls` runs *after* `NewSQLiteStore`.

## Fix

Remove `idx_tool_calls_session` and `idx_tool_calls_status` from `migrate()`. They already exist in `MigrateUnifyToolCalls` (line 386-387 of migrate_unify.go), which runs after the columns are added.

For new databases: columns exist in CREATE TABLE, migration creates indexes.  
For existing databases: migration adds columns, then creates indexes.

## Test plan

- `just ci` passes (fmt + lint + race tests)
- No schema changes for new databases (indexes still get created, just by migration instead of initial schema)