### PR TITLE
fix: remove lifecycle indexes from initial migrate()

### DIFF
--- a/internal/memory/sqlite.go
+++ b/internal/memory/sqlite.go
@@ -88,8 +88,6 @@ func (s *SQLiteStore) migrate() error {
 	CREATE INDEX IF NOT EXISTS idx_tool_calls_conversation ON tool_calls(conversation_id, started_at);
 	CREATE INDEX IF NOT EXISTS idx_tool_calls_tool ON tool_calls(tool_name);
 	CREATE INDEX IF NOT EXISTS idx_tool_calls_message ON tool_calls(message_id);
-	CREATE INDEX IF NOT EXISTS idx_tool_calls_session ON tool_calls(session_id, started_at);
-	CREATE INDEX IF NOT EXISTS idx_tool_calls_status ON tool_calls(conversation_id, status);
 
 	-- Entity facts (for Phase 3)
 	CREATE TABLE IF NOT EXISTS entity_facts (


### PR DESCRIPTION
## Summary

- Removes `idx_tool_calls_session` and `idx_tool_calls_status` from the initial `migrate()` schema in `sqlite.go`
- These indexes reference `session_id` and `status` columns that don't exist on pre-#434 databases, causing startup crashes: `no such column: session_id`
- The indexes are already created by `MigrateUnifyToolCalls` (migrate_unify.go:386-387) after the columns are added

Closes #440

## Test plan

- [x] `just ci` passes (fmt + lint + race tests)
- [x] New databases still get the indexes via `MigrateUnifyToolCalls`
- [x] Existing databases no longer crash on startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)