### PR TITLE
fix: add DB-backed idle session timeout in summarizer

### DIFF
--- a/cmd/thane/main.go
+++ b/cmd/thane/main.go
@@ -615,12 +615,17 @@ func runServe(ctx context.Context, stdout io.Writer, stderr io.Writer, configPat
 	// Background worker that generates titles, tags, and summaries for
 	// sessions that ended without metadata (e.g., during shutdown).
 	// Runs immediately on startup to catch up, then periodically.
+	var idleTimeoutMinutes int
+	if cfg.Archive.SessionIdleMinutes != nil {
+		idleTimeoutMinutes = *cfg.Archive.SessionIdleMinutes
+	}
 	summarizerCfg := sessionsummarizer.Config{
 		Interval:        time.Duration(cfg.Archive.SummarizeInterval) * time.Second,
 		Timeout:         time.Duration(cfg.Archive.SummarizeTimeout) * time.Second,
 		PauseBetween:    5 * time.Second,
 		BatchSize:       10,
 		ModelPreference: cfg.Archive.MetadataModel,
+		IdleTimeout:     time.Duration(idleTimeoutMinutes) * time.Minute,
 	}
 	summaryWorker := sessionsummarizer.New(archiveStore, llmClient, rtr, logger, summarizerCfg)
 	summaryWorker.Start(ctx)


### PR DESCRIPTION
## Summary

- **Problem**: The Signal bridge's idle timeout is in-memory (`lastInboundTS` map) — crash recovery wipes it, and it only fires on inbound messages. Sessions stay open indefinitely across crashes and overnight gaps. Evidence: conversation spanning 5 days with 10 sessions, all ended by `crash_recovery`, zero by idle timeout.

- **Fix**: Hook idle session detection into the `summarizer.Worker`'s periodic loop (5-min tick) as a crash-recovery backstop. Each tick queries `MAX(timestamp)` from the messages table for all active sessions and silently closes any that exceed the idle timeout via `EndSession`. The bridge's interactive path (farewell messages, carry-forward) stays as the fast/nice path.

- **Config**: New `archive.session_idle_minutes` field. Inherits from `signal.session_idle_minutes` if not explicitly set, so existing configs work without changes.

### Changes
- `internal/memory/archive.go` — Add `IdleSessionInfo` type and `ActiveSessionsWithLastActivity()` method
- `internal/summarizer/summarizer.go` — Add `IdleTimeout` config, `closeIdleSessions()` method, hook into `run()` (startup + each tick)
- `internal/config/config.go` — Add `SessionIdleMinutes` to `ArchiveConfig` with default inheritance and validation
- `cmd/thane/main.go` — Wire `IdleTimeout` into summarizer config

Closes #442

## Test plan

- [x] `just ci` passes (fmt + lint + race tests)
- [x] `TestActiveSessionsWithLastActivity` — verifies DB query returns correct last activity times
- [x] `TestWorker_ClosesIdleSessions` — session 2h old with 30m timeout → closed as `idle_timeout` → summarized
- [x] `TestWorker_SkipsActiveSessionsWithinTimeout` — recent session → not closed
- [x] `TestWorker_IdleTimeoutDisabledWhenZero` — old session stays open when `IdleTimeout == 0`
- [x] All existing summarizer tests unchanged and passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)