### PR TITLE
fix: update openclaw-import to write directly to thane.db (#445)

### DIFF
--- a/cmd/openclaw-import/main.go
+++ b/cmd/openclaw-import/main.go
@@ -1,14 +1,13 @@
-// Command openclaw-import migrates OpenClaw session data into Thane's archive.
+// Command openclaw-import migrates OpenClaw session data into Thane's
+// conversation archive.
 //
 // This is a one-time migration tool — the last thing we run on OpenClaw
-// before switching to Thane for real.
+// before switching to Thane for real. Sessions are imported directly into
+// thane.db (the unified conversation database).
 //
 // Usage:
 //
 //	openclaw-import -openclaw /path/to/.openclaw -data /path/to/thane/data
-//
-// It reads JSONL session files from OpenClaw's session directory, converts
-// them to Thane's archive format, and writes them to Thane's archive.db.
 package main
 
 import (
@@ -29,7 +28,7 @@ const sourceType = "openclaw"
 
 func main() {
 	openclawDir := flag.String("openclaw", "", "Path to .openclaw directory")
-	dataDir := flag.String("data", "", "Path to Thane data directory (where archive.db will be created)")
+	dataDir := flag.String("data", "", "Path to Thane data directory (containing thane.db)")
 	dryRun := flag.Bool("dry-run", false, "Parse and report without writing to database")
 	purge := flag.Bool("purge", false, "Remove all previously imported OpenClaw data and re-import")
 	verbose := flag.Bool("verbose", false, "Verbose output")
@@ -117,19 +116,45 @@ func main() {
 		return
 	}
 
-	// Create archive store
+	// Open the unified database (thane.db) and ensure schema is ready.
 	if err := os.MkdirAll(*dataDir, 0755); err != nil {
 		logger.Error("failed to create data directory", "error", err)
 		os.Exit(1)
 	}
 
-	archivePath := filepath.Join(*dataDir, "archive.db")
-	store, err := memory.NewArchiveStore(archivePath, nil, nil, logger)
+	thanePath := filepath.Join(*dataDir, "thane.db")
+	workingStore, err := memory.NewSQLiteStore(thanePath, 1000)
+	if err != nil {
+		logger.Error("failed to open working store", "error", err)
+		os.Exit(1)
+	}
+	defer workingStore.Close()
+
+	// Run unification migrations so the unified schema (status column,
+	// lifecycle indexes) exists before importing.
+	if err := memory.MigrateUnifyMessages(workingStore.DB(), "", nil); err != nil {
+		logger.Error("unify messages migration failed", "error", err)
+		os.Exit(1)
+	}
+	if err := memory.MigrateUnifyToolCalls(workingStore.DB(), "", nil); err != nil {
+		logger.Error("unify tool calls migration failed", "error", err)
+		os.Exit(1)
+	}
+
+	store, err := memory.NewArchiveStoreFromDB(workingStore.DB(), nil, logger)
 	if err != nil {
 		logger.Error("failed to open archive store", "error", err)
 		os.Exit(1)
 	}
-	defer store.Close()
+	defer store.Close() // no-op — connection owned by workingStore
+
+	// Ensure the conversation record exists so imported messages have a
+	// valid parent. FK constraints are currently disabled, but this
+	// future-proofs against enabling them.
+	if _, err := workingStore.GetOrCreateConversation("openclaw-import"); err != nil {
+		logger.Error("failed to create conversation", "error", err)
+		os.Exit(1)
+	}
 
 	// Purge previously imported data if requested
 	if *purge {
@@ -168,13 +193,13 @@ func main() {
 		"imported", imported,
 		"skipped", skipped,
 		"failed", len(allSessions)-imported-skipped,
-		"archive_path", archivePath,
+		"database", thanePath,
 	)
 
 	// Print stats
 	stats, _ := store.Stats()
 	fmt.Printf("\n=== Import Complete ===\n")
-	fmt.Printf("Archive: %s\n", archivePath)
+	fmt.Printf("Database: %s\n", thanePath)
 	fmt.Printf("Sessions imported: %d / %d\n", imported, len(allSessions))
 	fmt.Printf("Total archived messages: %v\n", stats["total_messages"])
 	fmt.Printf("Total archived tool calls: %v\n", stats["total_tool_calls"])
@@ -424,18 +449,18 @@ func importSession(store *memory.ArchiveStore, sess parsedSession, logger *slog.
 		return fmt.Errorf("create session: %w", err)
 	}
 
-	// Archive messages
+	// Import messages
 	if len(sess.messages) > 0 {
 		// Fix session IDs to point to our new session
 		for i := range sess.messages {
 			sess.messages[i].SessionID = archiveSess.ID
 		}
-		if err := store.ArchiveMessages(sess.messages); err != nil {
-			return fmt.Errorf("archive messages: %w", err)
+		if err := store.ImportMessages(sess.messages); err != nil {
+			return fmt.Errorf("import messages: %w", err)
 		}
 	}
 
-	// Archive tool calls
+	// Import tool calls
 	if len(sess.toolCalls) > 0 {
 		for i := range sess.toolCalls {
 			sess.toolCalls[i].SessionID = archiveSess.ID
@@ -455,8 +480,8 @@ func importSession(store *memory.ArchiveStore, sess parsedSession, logger *slog.
 			}
 		}
 
-		if err := store.ArchiveToolCalls(sess.toolCalls); err != nil {
-			return fmt.Errorf("archive tool calls: %w", err)
+		if err := store.ImportToolCalls(sess.toolCalls); err != nil {
+			return fmt.Errorf("import tool calls: %w", err)
 		}
 	}
 

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -40,12 +40,12 @@ Working memory bridges the gap between ephemeral conversation context and perman
 
 Complete, immutable transcripts of all conversations with full-text search:
 
-- **Storage:** SQLite FTS5 for fast text search
+- **Storage:** Unified `messages` table in thane.db with lifecycle `status` column (`active` → `compacted` → `archived`). FTS5 index for fast text search.
 - **Tool:** `archive_search` — search across all historical conversations
 - **Import:** OpenClaw session import tool (migrates external conversation history)
 - **Use:** "What did we discuss about MQTT last week?" → searches across all sessions
 
-The archive is never modified after writing — it's a permanent record.
+Archived messages are never modified after writing — they're a permanent record.
 
 ### Checkpoints
 
@@ -72,11 +72,12 @@ All memory lives in SQLite databases under `data_dir`:
 
 ```
 ~/Thane/data/
-├── thane.db          # Conversations, messages, checkpoints
+├── thane.db          # Conversations, messages, sessions, tool calls, checkpoints
 ├── facts.db          # Semantic facts with embeddings
-├── anticipations.db  # Event-driven triggers
-└── archive.db        # Immutable session transcripts (FTS5)
+└── anticipations.db  # Event-driven triggers
 ```
+
+Active and archived messages share the `messages` table, differentiated by a lifecycle `status` column. FTS5 triggers keep the full-text index in sync automatically.
 
 ## Integration with Agent Loop
 

--- a/internal/memory/archive.go
+++ b/internal/memory/archive.go
@@ -846,6 +846,130 @@ func (s *ArchiveStore) ArchiveToolCalls(calls []ArchivedToolCall) error {
 	return tx.Commit()
 }
 
+// ImportMessages inserts externally-sourced messages (e.g. from openclaw-import)
+// into the archive. Unlike ArchiveMessages, which is a no-op in unified mode
+// (since archival is a status UPDATE on existing rows), ImportMessages performs
+// real INSERTs in both modes — the data doesn't already exist in any table.
+//
+// In legacy mode, this delegates to ArchiveMessages. In unified mode, rows are
+// inserted directly into the messages table with status='archived'. FTS triggers
+// keep the full-text index in sync automatically.
+func (s *ArchiveStore) ImportMessages(messages []ArchivedMessage) error {
+	if s.messagesDB == nil {
+		return s.ArchiveMessages(messages)
+	}
+	if len(messages) == 0 {
+		return nil
+	}
+
+	db := s.msgDB()
+	tx, err := db.Begin()
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	stmt, err := tx.Prepare(fmt.Sprintf(`
+		INSERT OR IGNORE INTO %s
+			(id, conversation_id, session_id, role, content, timestamp,
+			 token_count, tool_calls, tool_call_id,
+			 status, archived_at, archive_reason)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 'archived', ?, ?)
+	`, s.msgTableName))
+	if err != nil {
+		return fmt.Errorf("prepare: %w", err)
+	}
+	defer stmt.Close()
+
+	for _, m := range messages {
+		if m.ID == "" {
+			id, err := uuid.NewV7()
+			if err != nil {
+				return fmt.Errorf("generate UUID: %w", err)
+			}
+			m.ID = id.String()
+		}
+		if m.ArchivedAt.IsZero() {
+			m.ArchivedAt = time.Now().UTC()
+		}
+
+		if _, err := stmt.Exec(
+			m.ID, m.ConversationID, m.SessionID, m.Role, m.Content,
+			m.Timestamp.Format(time.RFC3339Nano),
+			m.TokenCount, nullString(m.ToolCalls), nullString(m.ToolCallID),
+			m.ArchivedAt.Format(time.RFC3339Nano), m.ArchiveReason,
+		); err != nil {
+			return fmt.Errorf("insert message %s: %w", m.ID, err)
+		}
+	}
+
+	return tx.Commit()
+}
+
+// ImportToolCalls inserts externally-sourced tool calls (e.g. from
+// openclaw-import) into the archive. Like ImportMessages, this performs real
+// INSERTs in both modes rather than being a no-op in unified mode.
+func (s *ArchiveStore) ImportToolCalls(calls []ArchivedToolCall) error {
+	if s.messagesDB == nil {
+		return s.ArchiveToolCalls(calls)
+	}
+	if len(calls) == 0 {
+		return nil
+	}
+
+	db := s.msgDB()
+	tx, err := db.Begin()
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	stmt, err := tx.Prepare(fmt.Sprintf(`
+		INSERT OR IGNORE INTO %s
+			(id, conversation_id, session_id, tool_name, arguments,
+			 result, error, started_at, completed_at, duration_ms,
+			 status, archived_at, iteration_index)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'archived', ?, ?)
+	`, s.tcTableName))
+	if err != nil {
+		return fmt.Errorf("prepare: %w", err)
+	}
+	defer stmt.Close()
+
+	now := time.Now().UTC()
+	for _, tc := range calls {
+		if tc.ID == "" {
+			id, err := uuid.NewV7()
+			if err != nil {
+				return fmt.Errorf("generate UUID: %w", err)
+			}
+			tc.ID = id.String()
+		}
+
+		archivedAt := now
+		if !tc.ArchivedAt.IsZero() {
+			archivedAt = tc.ArchivedAt
+		}
+
+		var completedAt any
+		if tc.CompletedAt != nil {
+			completedAt = tc.CompletedAt.Format(time.RFC3339Nano)
+		}
+
+		if _, err := stmt.Exec(
+			tc.ID, tc.ConversationID, tc.SessionID, tc.ToolName, tc.Arguments,
+			nullString(tc.Result), nullString(tc.Error),
+			tc.StartedAt.Format(time.RFC3339Nano), completedAt,
+			tc.DurationMs, archivedAt.Format(time.RFC3339Nano),
+			tc.IterationIndex,
+		); err != nil {
+			return fmt.Errorf("insert tool call %s: %w", tc.ID, err)
+		}
+	}
+
+	return tx.Commit()
+}
+
 // GetSessionToolCalls returns archived tool calls for a session in chronological order.
 func (s *ArchiveStore) GetSessionToolCalls(sessionID string) ([]ArchivedToolCall, error) {
 	rows, err := s.msgDB().Query(fmt.Sprintf(`

--- a/internal/memory/archive_test.go
+++ b/internal/memory/archive_test.go
@@ -916,8 +916,12 @@ func TestNewArchiveStoreFromDB(t *testing.T) {
 	}
 	defer workingStore.Close()
 
-	MigrateUnifyMessages(workingStore.DB(), "", nil)
-	MigrateUnifyToolCalls(workingStore.DB(), "", nil)
+	if err := MigrateUnifyMessages(workingStore.DB(), "", nil); err != nil {
+		t.Fatal(err)
+	}
+	if err := MigrateUnifyToolCalls(workingStore.DB(), "", nil); err != nil {
+		t.Fatal(err)
+	}
 
 	archiveStore, err := NewArchiveStoreFromDB(workingStore.DB(), nil, nil)
 	if err != nil {
@@ -991,8 +995,12 @@ func TestConsolidatedMode_FullLifecycle(t *testing.T) {
 	}
 	defer workingStore.Close()
 
-	MigrateUnifyMessages(workingStore.DB(), "", nil)
-	MigrateUnifyToolCalls(workingStore.DB(), "", nil)
+	if err := MigrateUnifyMessages(workingStore.DB(), "", nil); err != nil {
+		t.Fatal(err)
+	}
+	if err := MigrateUnifyToolCalls(workingStore.DB(), "", nil); err != nil {
+		t.Fatal(err)
+	}
 
 	archiveStore, err := NewArchiveStoreFromDB(workingStore.DB(), nil, nil)
 	if err != nil {
@@ -1277,8 +1285,12 @@ func TestActiveSessionsWithLastActivity_Unified(t *testing.T) {
 	}
 	defer workingStore.Close()
 
-	MigrateUnifyMessages(workingStore.DB(), "", nil)
-	MigrateUnifyToolCalls(workingStore.DB(), "", nil)
+	if err := MigrateUnifyMessages(workingStore.DB(), "", nil); err != nil {
+		t.Fatal(err)
+	}
+	if err := MigrateUnifyToolCalls(workingStore.DB(), "", nil); err != nil {
+		t.Fatal(err)
+	}
 
 	store, err := NewArchiveStoreFromDB(workingStore.DB(), nil, nil)
 	if err != nil {
@@ -1325,5 +1337,173 @@ func TestActiveSessionsWithLastActivity_Unified(t *testing.T) {
 	if diff > time.Second {
 		t.Errorf("LastActivity = %v, want ~%v (diff = %v); query may have missed NULL-session_id message",
 			info.LastActivity, msgTime, diff)
+	}
+}
+
+func TestImportMessages_Legacy(t *testing.T) {
+	store := newTestArchiveStore(t)
+
+	sess, err := store.StartSession("conv-import")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	msgs := []ArchivedMessage{
+		{
+			ID:             "imp-msg-1",
+			ConversationID: "conv-import",
+			SessionID:      sess.ID,
+			Role:           "user",
+			Content:        "imported message",
+			Timestamp:      time.Now().UTC(),
+			ArchiveReason:  "import",
+		},
+	}
+
+	if err := store.ImportMessages(msgs); err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify the message is retrievable via transcript.
+	transcript, err := store.GetSessionTranscript(sess.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(transcript) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(transcript))
+	}
+	if transcript[0].Content != "imported message" {
+		t.Errorf("content = %q, want %q", transcript[0].Content, "imported message")
+	}
+}
+
+func TestImportMessages_Unified(t *testing.T) {
+	workingStore, err := NewSQLiteStore(t.TempDir()+"/working.db", 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer workingStore.Close()
+
+	if err := MigrateUnifyMessages(workingStore.DB(), "", nil); err != nil {
+		t.Fatal(err)
+	}
+	if err := MigrateUnifyToolCalls(workingStore.DB(), "", nil); err != nil {
+		t.Fatal(err)
+	}
+
+	store, err := NewArchiveStoreFromDB(workingStore.DB(), nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sess, err := store.StartSession("conv-import")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	msgs := []ArchivedMessage{
+		{
+			ID:             "imp-msg-u1",
+			ConversationID: "conv-import",
+			SessionID:      sess.ID,
+			Role:           "user",
+			Content:        "unified import",
+			Timestamp:      time.Now().UTC(),
+			ArchiveReason:  "import",
+		},
+	}
+
+	if err := store.ImportMessages(msgs); err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify the message landed in the messages table with status='archived'.
+	var status string
+	err = workingStore.DB().QueryRow(
+		`SELECT status FROM messages WHERE id = ?`, "imp-msg-u1",
+	).Scan(&status)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status != "archived" {
+		t.Errorf("status = %q, want %q", status, "archived")
+	}
+
+	// Verify transcript retrieval works.
+	transcript, err := store.GetSessionTranscript(sess.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(transcript) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(transcript))
+	}
+	if transcript[0].Content != "unified import" {
+		t.Errorf("content = %q, want %q", transcript[0].Content, "unified import")
+	}
+}
+
+func TestImportToolCalls_Unified(t *testing.T) {
+	workingStore, err := NewSQLiteStore(t.TempDir()+"/working.db", 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer workingStore.Close()
+
+	if err := MigrateUnifyMessages(workingStore.DB(), "", nil); err != nil {
+		t.Fatal(err)
+	}
+	if err := MigrateUnifyToolCalls(workingStore.DB(), "", nil); err != nil {
+		t.Fatal(err)
+	}
+
+	store, err := NewArchiveStoreFromDB(workingStore.DB(), nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sess, err := store.StartSession("conv-import")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	now := time.Now().UTC()
+	calls := []ArchivedToolCall{
+		{
+			ID:             "imp-tc-1",
+			ConversationID: "conv-import",
+			SessionID:      sess.ID,
+			ToolName:       "get_state",
+			Arguments:      `{"entity_id":"light.test"}`,
+			Result:         "on",
+			StartedAt:      now,
+		},
+	}
+
+	if err := store.ImportToolCalls(calls); err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify tool call is retrievable.
+	got, err := store.GetSessionToolCalls(sess.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected 1 tool call, got %d", len(got))
+	}
+	if got[0].ToolName != "get_state" {
+		t.Errorf("tool_name = %q, want %q", got[0].ToolName, "get_state")
+	}
+
+	// Verify status='archived' in the database.
+	var status string
+	err = workingStore.DB().QueryRow(
+		`SELECT status FROM tool_calls WHERE id = ?`, "imp-tc-1",
+	).Scan(&status)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status != "archived" {
+		t.Errorf("status = %q, want %q", status, "archived")
 	}
 }


### PR DESCRIPTION
## Summary

With unified storage complete (#434), `archive.db` is no longer needed at runtime. This PR:

- Adds `ImportMessages()` and `ImportToolCalls()` methods to `ArchiveStore` that perform real INSERTs in both legacy and unified mode (unlike `ArchiveMessages`/`ArchiveToolCalls` which are no-ops in unified mode)
- Updates `openclaw-import` to open `thane.db` directly via `NewArchiveStoreFromDB`, using the new import methods
- Updates `docs/memory.md` to reflect the consolidated storage layout (no more `archive.db` in the diagram)
- Adds tests for import methods in both legacy and unified mode

### What stays unchanged

- Migration code in `main.go` — idempotent, handles missing `archive.db` gracefully, needed for users upgrading from older versions
- `NewArchiveStore` constructor — still used by tests
- Legacy mode branches — still exercised by tests

### Operational follow-up

After merging, `archive.db` can be safely deleted from the data directory (back it up first). The migrations will no-op on next startup when the file is absent.

Closes #445

## Test plan

- [ ] `just ci` passes (0 lint issues, all tests green including new import tests)
- [ ] `TestImportMessages_Legacy` — legacy mode import via delegation to ArchiveMessages
- [ ] `TestImportMessages_Unified` — unified mode INSERT with status='archived'
- [ ] `TestImportToolCalls_Unified` — unified mode tool call import
- [ ] `openclaw-import --dry-run` still parses sessions correctly (no DB interaction)