### PR TITLE
refactor: merge ArchivedMessage into Message (#439)

### DIFF
--- a/cmd/openclaw-import/main.go
+++ b/cmd/openclaw-import/main.go
@@ -211,7 +211,7 @@ type parsedSession struct {
 	id        string
 	startedAt time.Time
 	endedAt   time.Time
-	messages  []memory.ArchivedMessage
+	messages  []memory.Message
 	toolCalls []memory.ArchivedToolCall
 }
 
@@ -300,16 +300,16 @@ func parseSessionFile(path string, logger *slog.Logger) (parsedSession, error) {
 	return sess, nil
 }
 
-func convertMessage(entry openclawLine, sessionID string, ts time.Time) ([]memory.ArchivedMessage, []memory.ArchivedToolCall) {
+func convertMessage(entry openclawLine, sessionID string, ts time.Time) ([]memory.Message, []memory.ArchivedToolCall) {
 	msg := entry.Message
-	var messages []memory.ArchivedMessage
+	var messages []memory.Message
 	var toolCalls []memory.ArchivedToolCall
 
 	switch msg.Role {
 	case "user":
 		text := extractText(msg.Content)
 		if text != "" {
-			messages = append(messages, memory.ArchivedMessage{
+			messages = append(messages, memory.Message{
 				ID:             entry.ID,
 				ConversationID: "openclaw-import",
 				SessionID:      sessionID,
@@ -326,7 +326,7 @@ func convertMessage(entry openclawLine, sessionID string, ts time.Time) ([]memor
 		text, tcs := extractAssistantContent(msg.Content)
 
 		if text != "" {
-			messages = append(messages, memory.ArchivedMessage{
+			messages = append(messages, memory.Message{
 				ID:             entry.ID,
 				ConversationID: "openclaw-import",
 				SessionID:      sessionID,
@@ -357,7 +357,7 @@ func convertMessage(entry openclawLine, sessionID string, ts time.Time) ([]memor
 	case "toolResult":
 		text := extractText(msg.Content)
 
-		messages = append(messages, memory.ArchivedMessage{
+		messages = append(messages, memory.Message{
 			ID:             entry.ID,
 			ConversationID: "openclaw-import",
 			SessionID:      sessionID,

--- a/internal/delegate/delegate.go
+++ b/internal/delegate/delegate.go
@@ -1037,9 +1037,9 @@ func (e *Executor) archiveSession(rec *completionRecord, now time.Time) {
 	convID := rec.conversationID
 
 	// Archive messages from the LLM conversation.
-	var archived []memory.ArchivedMessage
+	var archived []memory.Message
 	for i, m := range rec.messages {
-		archived = append(archived, memory.ArchivedMessage{
+		archived = append(archived, memory.Message{
 			ConversationID: convID,
 			SessionID:      sessionID,
 			Role:           m.Role,

--- a/internal/episodic/provider.go
+++ b/internal/episodic/provider.go
@@ -29,7 +29,7 @@ type ArchiveReader interface {
 
 	// GetSessionTranscript returns all archived messages for a session
 	// in chronological order.
-	GetSessionTranscript(sessionID string) ([]memory.ArchivedMessage, error)
+	GetSessionTranscript(sessionID string) ([]memory.Message, error)
 }
 
 // Config holds configuration for the episodic memory provider.

--- a/internal/episodic/provider_test.go
+++ b/internal/episodic/provider_test.go
@@ -16,7 +16,7 @@ import (
 // mockArchive implements ArchiveReader for testing.
 type mockArchive struct {
 	sessions      []*memory.Session
-	transcripts   map[string][]memory.ArchivedMessage
+	transcripts   map[string][]memory.Message
 	listErr       error
 	transcriptErr error
 }
@@ -28,7 +28,7 @@ func (m *mockArchive) ListSessions(_ string, _ int) ([]*memory.Session, error) {
 	return m.sessions, nil
 }
 
-func (m *mockArchive) GetSessionTranscript(sessionID string) ([]memory.ArchivedMessage, error) {
+func (m *mockArchive) GetSessionTranscript(sessionID string) ([]memory.Message, error) {
 	if m.transcriptErr != nil {
 		return nil, m.transcriptErr
 	}
@@ -109,7 +109,7 @@ func TestGetContext_HistoryOnly(t *testing.T) {
 				},
 			},
 		},
-		transcripts: map[string][]memory.ArchivedMessage{
+		transcripts: map[string][]memory.Message{
 			"s1": {
 				{Role: "user", Content: "How does delegation work?", Timestamp: timeAt(now, 1)},
 				{Role: "assistant", Content: "Delegation uses profiles to filter tools.", Timestamp: timeAt(now, 0.9)},
@@ -163,7 +163,7 @@ func TestGetContext_Combined(t *testing.T) {
 				Metadata:  &memory.SessionMetadata{OneLiner: "Quick chat"},
 			},
 		},
-		transcripts: map[string][]memory.ArchivedMessage{
+		transcripts: map[string][]memory.Message{
 			"s1": {
 				{Role: "user", Content: "Hello", Timestamp: timeAt(now, 2)},
 				{Role: "assistant", Content: "Hi there!", Timestamp: timeAt(now, 1.9)},
@@ -242,7 +242,7 @@ func TestRecencyGradient(t *testing.T) {
 	now := time.Now().UTC()
 
 	sessions := make([]*memory.Session, 6)
-	transcripts := make(map[string][]memory.ArchivedMessage)
+	transcripts := make(map[string][]memory.Message)
 
 	for i := range 6 {
 		id := fmt.Sprintf("s%d", i)
@@ -257,7 +257,7 @@ func TestRecencyGradient(t *testing.T) {
 				Paragraph: fmt.Sprintf("Paragraph summary for session %d with more detail.", i),
 			},
 		}
-		transcripts[id] = []memory.ArchivedMessage{
+		transcripts[id] = []memory.Message{
 			{Role: "user", Content: fmt.Sprintf("User message in session %d", i), Timestamp: timeAt(now, float64(i)+1)},
 			{Role: "assistant", Content: fmt.Sprintf("Assistant reply in session %d", i), Timestamp: timeAt(now, float64(i)+0.9)},
 		}
@@ -314,7 +314,7 @@ func TestTokenBudget(t *testing.T) {
 
 	archive := &mockArchive{
 		sessions: sessions,
-		transcripts: map[string][]memory.ArchivedMessage{
+		transcripts: map[string][]memory.Message{
 			"s0": {
 				{Role: "user", Content: "Hello", Timestamp: timeAt(now, 1)},
 				{Role: "assistant", Content: "Hi!", Timestamp: timeAt(now, 0.9)},
@@ -360,7 +360,7 @@ func TestGapDetection(t *testing.T) {
 				Metadata:  &memory.SessionMetadata{OneLiner: "Earlier session"},
 			},
 		},
-		transcripts: map[string][]memory.ArchivedMessage{
+		transcripts: map[string][]memory.Message{
 			"s0": {{Role: "user", Content: "Hey", Timestamp: timeAt(now, 1)}},
 		},
 	}
@@ -391,7 +391,7 @@ func TestNoMetadata(t *testing.T) {
 				// No Title, no Metadata, no Summary.
 			},
 		},
-		transcripts: map[string][]memory.ArchivedMessage{
+		transcripts: map[string][]memory.Message{
 			"s0": {
 				{Role: "user", Content: "Test message", Timestamp: timeAt(now, 1)},
 			},
@@ -449,7 +449,7 @@ func TestEmptySessionsSkipped(t *testing.T) {
 				Metadata:  &memory.SessionMetadata{SessionType: "empty", OneLiner: "Empty session (no transcript)"},
 			},
 		},
-		transcripts: map[string][]memory.ArchivedMessage{
+		transcripts: map[string][]memory.Message{
 			"s1": {{Role: "user", Content: "Hello", Timestamp: timeAt(now, 1)}},
 		},
 	}
@@ -687,7 +687,7 @@ func TestMessageTimestamps(t *testing.T) {
 				Metadata:  &memory.SessionMetadata{OneLiner: "Testing timestamps"},
 			},
 		},
-		transcripts: map[string][]memory.ArchivedMessage{
+		transcripts: map[string][]memory.Message{
 			"s1": {
 				{Role: "user", Content: "what time is it", Timestamp: msgTime},
 				{Role: "assistant", Content: "It's 8:50 PM", Timestamp: msgTime.Add(5 * time.Second)},
@@ -725,7 +725,7 @@ func TestSessionHeaderRFC3339(t *testing.T) {
 				Metadata:  &memory.SessionMetadata{OneLiner: "Testing header format"},
 			},
 		},
-		transcripts: map[string][]memory.ArchivedMessage{
+		transcripts: map[string][]memory.Message{
 			"s1": {
 				{Role: "user", Content: "Hello", Timestamp: base},
 			},

--- a/internal/memory/archive.go
+++ b/internal/memory/archive.go
@@ -77,21 +77,6 @@ func DefaultArchiveConfig() ArchiveConfig {
 	}
 }
 
-// ArchivedMessage represents a message preserved in the archive.
-type ArchivedMessage struct {
-	ID             string    `json:"id"`
-	ConversationID string    `json:"conversation_id"`
-	SessionID      string    `json:"session_id"`
-	Role           string    `json:"role"`
-	Content        string    `json:"content"`
-	Timestamp      time.Time `json:"timestamp"`
-	TokenCount     int       `json:"token_count,omitempty"`
-	ToolCalls      string    `json:"tool_calls,omitempty"`
-	ToolCallID     string    `json:"tool_call_id,omitempty"`
-	ArchivedAt     time.Time `json:"archived_at"`
-	ArchiveReason  string    `json:"archive_reason"`
-}
-
 // Session represents a conversation session with boundaries.
 type Session struct {
 	ID               string           `json:"id"`
@@ -219,11 +204,11 @@ type ArchivedIteration struct {
 
 // SearchResult represents a search hit with surrounding context.
 type SearchResult struct {
-	Match         ArchivedMessage   `json:"match"`
-	SessionID     string            `json:"session_id"`
-	ContextBefore []ArchivedMessage `json:"context_before"`
-	ContextAfter  []ArchivedMessage `json:"context_after"`
-	Highlight     string            `json:"highlight,omitempty"`
+	Match         Message   `json:"match"`
+	SessionID     string    `json:"session_id"`
+	ContextBefore []Message `json:"context_before"`
+	ContextAfter  []Message `json:"context_after"`
+	Highlight     string    `json:"highlight,omitempty"`
 }
 
 // SearchOptions configures a search query.
@@ -723,7 +708,7 @@ func (s *ArchiveStore) tryEnableFTS() bool {
 //
 // In unified mode (messagesDB set), this is a no-op — messages already live
 // in the unified table and are archived via status UPDATE by SQLiteStore.
-func (s *ArchiveStore) ArchiveMessages(messages []ArchivedMessage) error {
+func (s *ArchiveStore) ArchiveMessages(messages []Message) error {
 	if s.messagesDB != nil {
 		return nil // Unified mode: archival is a status UPDATE, not a cross-DB copy.
 	}
@@ -854,7 +839,7 @@ func (s *ArchiveStore) ArchiveToolCalls(calls []ArchivedToolCall) error {
 // In legacy mode, this delegates to ArchiveMessages. In unified mode, rows are
 // inserted directly into the messages table with status='archived'. FTS triggers
 // keep the full-text index in sync automatically.
-func (s *ArchiveStore) ImportMessages(messages []ArchivedMessage) error {
+func (s *ArchiveStore) ImportMessages(messages []Message) error {
 	if s.messagesDB == nil {
 		return s.ArchiveMessages(messages)
 	}
@@ -1279,13 +1264,13 @@ func (s *ArchiveStore) Search(opts SearchOptions) ([]SearchResult, error) {
 	// Collect all matches first (must close rows before doing context expansion
 	// queries, since SQLite may not support concurrent readers on same connection)
 	type matchWithHighlight struct {
-		msg       ArchivedMessage
+		msg       Message
 		highlight string
 	}
 	var matches []matchWithHighlight
 
 	for rows.Next() {
-		var m ArchivedMessage
+		var m Message
 		var highlight string
 		var tsStr, archivedStr string
 		var toolCalls, toolCallID sql.NullString
@@ -1318,7 +1303,7 @@ func (s *ArchiveStore) Search(opts SearchOptions) ([]SearchResult, error) {
 	// Now expand context for each match (safe to query again)
 	var results []SearchResult
 	for _, mh := range matches {
-		var before, after []ArchivedMessage
+		var before, after []Message
 		if !opts.NoContext {
 			before = s.expandContext(mh.msg.ConversationID, mh.msg.Timestamp, true, opts)
 			after = s.expandContext(mh.msg.ConversationID, mh.msg.Timestamp, false, opts)
@@ -1342,7 +1327,7 @@ func (s *ArchiveStore) expandContext(
 	from time.Time,
 	backward bool,
 	opts SearchOptions,
-) []ArchivedMessage {
+) []Message {
 	var query string
 	var boundary time.Time
 
@@ -1378,11 +1363,11 @@ func (s *ArchiveStore) expandContext(
 	}
 	defer rows.Close()
 
-	var messages []ArchivedMessage
+	var messages []Message
 	prevTime := from
 
 	for rows.Next() {
-		var m ArchivedMessage
+		var m Message
 		var tsStr, archivedStr string
 		var toolCalls, toolCallID sql.NullString
 
@@ -1853,7 +1838,7 @@ func (s *ArchiveStore) UnsummarizedSessions(limit int) ([]*Session, error) {
 }
 
 // GetSessionTranscript returns all archived messages for a session in chronological order.
-func (s *ArchiveStore) GetSessionTranscript(sessionID string) ([]ArchivedMessage, error) {
+func (s *ArchiveStore) GetSessionTranscript(sessionID string) ([]Message, error) {
 	query := fmt.Sprintf(`
 		SELECT %s
 		FROM %s
@@ -1871,7 +1856,7 @@ func (s *ArchiveStore) GetSessionTranscript(sessionID string) ([]ArchivedMessage
 }
 
 // GetMessagesByTimeRange returns archived messages within a time range.
-func (s *ArchiveStore) GetMessagesByTimeRange(from, to time.Time, conversationID string, limit int) ([]ArchivedMessage, error) {
+func (s *ArchiveStore) GetMessagesByTimeRange(from, to time.Time, conversationID string, limit int) ([]Message, error) {
 	if limit <= 0 {
 		limit = 500
 	}
@@ -2155,10 +2140,10 @@ func populateSession(sess *Session, startStr string, endStr, endReason, summary,
 	}
 }
 
-func (s *ArchiveStore) scanMessages(rows *sql.Rows) ([]ArchivedMessage, error) {
-	var messages []ArchivedMessage
+func (s *ArchiveStore) scanMessages(rows *sql.Rows) ([]Message, error) {
+	var messages []Message
 	for rows.Next() {
-		var m ArchivedMessage
+		var m Message
 		var tsStr, archivedStr string
 		var toolCalls, toolCallID sql.NullString
 

--- a/internal/memory/archive_integration_test.go
+++ b/internal/memory/archive_integration_test.go
@@ -69,7 +69,7 @@ func TestSearch_NoContext(t *testing.T) {
 	store := newTestArchiveStore(t)
 
 	base := time.Date(2026, 2, 12, 10, 0, 0, 0, time.UTC)
-	msgs := []ArchivedMessage{
+	msgs := []Message{
 		{ID: "m1", ConversationID: "c1", SessionID: "s1", Role: "user",
 			Content: "before the match", Timestamp: base,
 			ArchiveReason: "reset"},
@@ -150,9 +150,9 @@ func TestSessionMessageCount(t *testing.T) {
 	sess, _ := store.StartSession("conv-1")
 
 	// Archive 3 messages.
-	msgs := make([]ArchivedMessage, 3)
+	msgs := make([]Message, 3)
 	for i := range msgs {
-		msgs[i] = ArchivedMessage{
+		msgs[i] = Message{
 			ID: fmt.Sprintf("msg-%d", i), ConversationID: "conv-1", SessionID: sess.ID,
 			Role: "user", Content: fmt.Sprintf("msg %d", i),
 			Timestamp: time.Now(), ArchivedAt: time.Now(), ArchiveReason: "test",
@@ -321,7 +321,7 @@ func TestPurgeImported(t *testing.T) {
 	sess1, _ := store.StartSessionAt("imported", time.Date(2026, 2, 1, 10, 0, 0, 0, time.UTC))
 	sess2, _ := store.StartSessionAt("imported", time.Date(2026, 2, 2, 10, 0, 0, 0, time.UTC))
 
-	msgs := []ArchivedMessage{
+	msgs := []Message{
 		{ID: "m1", ConversationID: "imported", SessionID: sess1.ID,
 			Role: "user", Content: "hello from session 1",
 			Timestamp: time.Now(), ArchiveReason: "import"},
@@ -342,7 +342,7 @@ func TestPurgeImported(t *testing.T) {
 
 	// Also create a non-imported session that should survive the purge
 	nativeSess, _ := store.StartSession("native")
-	store.ArchiveMessages([]ArchivedMessage{
+	store.ArchiveMessages([]Message{
 		{ID: "m3", ConversationID: "native", SessionID: nativeSess.ID,
 			Role: "user", Content: "native message",
 			Timestamp: time.Now(), ArchiveReason: "reset"},

--- a/internal/memory/archive_provider_test.go
+++ b/internal/memory/archive_provider_test.go
@@ -32,7 +32,7 @@ func TestArchiveContextProvider_GetContext(t *testing.T) {
 	makeResult := func(sessionID, role, content string) SearchResult {
 		return SearchResult{
 			SessionID: sessionID,
-			Match: ArchivedMessage{
+			Match: Message{
 				Role:      role,
 				Content:   content,
 				Timestamp: ts,
@@ -40,10 +40,10 @@ func TestArchiveContextProvider_GetContext(t *testing.T) {
 		}
 	}
 
-	makeResultWithContext := func(sessionID, matchRole, matchContent string, before, after []ArchivedMessage) SearchResult {
+	makeResultWithContext := func(sessionID, matchRole, matchContent string, before, after []Message) SearchResult {
 		return SearchResult{
 			SessionID:     sessionID,
-			Match:         ArchivedMessage{Role: matchRole, Content: matchContent, Timestamp: ts},
+			Match:         Message{Role: matchRole, Content: matchContent, Timestamp: ts},
 			ContextBefore: before,
 			ContextAfter:  after,
 		}
@@ -259,10 +259,10 @@ func TestArchiveContextProvider_GetContext(t *testing.T) {
 		mock := &mockArchiveSearcher{
 			results: []SearchResult{
 				makeResultWithContext("sess-ctx", "assistant", "The answer is 42.",
-					[]ArchivedMessage{
+					[]Message{
 						{Role: "user", Content: "What is the answer?", Timestamp: ts.Add(-time.Minute)},
 					},
-					[]ArchivedMessage{
+					[]Message{
 						{Role: "user", Content: "Thanks!", Timestamp: ts.Add(time.Minute)},
 					},
 				),

--- a/internal/memory/archive_test.go
+++ b/internal/memory/archive_test.go
@@ -22,7 +22,7 @@ func newTestArchiveStore(t *testing.T) *ArchiveStore {
 func TestArchiveMessages_BasicInsert(t *testing.T) {
 	store := newTestArchiveStore(t)
 
-	msgs := []ArchivedMessage{
+	msgs := []Message{
 		{
 			ID: "msg-1", ConversationID: "conv-1", SessionID: "sess-1",
 			Role: "user", Content: "hello there",
@@ -60,7 +60,7 @@ func TestArchiveMessages_BasicInsert(t *testing.T) {
 func TestArchiveMessages_Deduplication(t *testing.T) {
 	store := newTestArchiveStore(t)
 
-	msg := ArchivedMessage{
+	msg := Message{
 		ID: "msg-1", ConversationID: "conv-1", SessionID: "sess-1",
 		Role: "user", Content: "hello",
 		Timestamp:     time.Date(2026, 2, 12, 10, 0, 0, 0, time.UTC),
@@ -68,10 +68,10 @@ func TestArchiveMessages_Deduplication(t *testing.T) {
 	}
 
 	// Insert twice — should not error or duplicate
-	if err := store.ArchiveMessages([]ArchivedMessage{msg}); err != nil {
+	if err := store.ArchiveMessages([]Message{msg}); err != nil {
 		t.Fatal(err)
 	}
-	if err := store.ArchiveMessages([]ArchivedMessage{msg}); err != nil {
+	if err := store.ArchiveMessages([]Message{msg}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -87,7 +87,7 @@ func TestArchiveMessages_Deduplication(t *testing.T) {
 func TestSearch_BasicFTS(t *testing.T) {
 	store := newTestArchiveStore(t)
 
-	msgs := []ArchivedMessage{
+	msgs := []Message{
 		{
 			ID: "msg-1", ConversationID: "conv-1", SessionID: "sess-1",
 			Role: "user", Content: "what about the pool heater timer",
@@ -135,7 +135,7 @@ func TestSearch_SilenceGapContextExpansion(t *testing.T) {
 
 	base := time.Date(2026, 2, 12, 10, 0, 0, 0, time.UTC)
 
-	msgs := []ArchivedMessage{
+	msgs := []Message{
 		// Conversation cluster 1: rapid fire
 		{ID: "m1", ConversationID: "c1", SessionID: "s1", Role: "user",
 			Content: "starting topic A", Timestamp: base,
@@ -251,7 +251,7 @@ func TestSessionLifecycle(t *testing.T) {
 	}
 
 	// Archive real messages so the computed count works.
-	if err := store.ArchiveMessages([]ArchivedMessage{
+	if err := store.ArchiveMessages([]Message{
 		{ID: "msg-1", ConversationID: "conv-1", SessionID: sess.ID, Role: "user", Content: "hello", Timestamp: time.Now(), ArchivedAt: time.Now(), ArchiveReason: "test"},
 		{ID: "msg-2", ConversationID: "conv-1", SessionID: sess.ID, Role: "assistant", Content: "hi", Timestamp: time.Now(), ArchivedAt: time.Now(), ArchiveReason: "test"},
 	}); err != nil {
@@ -310,9 +310,9 @@ func TestGetMessagesByTimeRange(t *testing.T) {
 	store := newTestArchiveStore(t)
 
 	base := time.Date(2026, 2, 12, 10, 0, 0, 0, time.UTC)
-	msgs := make([]ArchivedMessage, 10)
+	msgs := make([]Message, 10)
 	for i := range msgs {
-		msgs[i] = ArchivedMessage{
+		msgs[i] = Message{
 			ID: fmt.Sprintf("msg-%d", i), ConversationID: "conv-1", SessionID: "sess-1",
 			Role: "user", Content: fmt.Sprintf("message %d", i),
 			Timestamp:     base.Add(time.Duration(i) * time.Minute),
@@ -342,7 +342,7 @@ func TestExportSessionMarkdown(t *testing.T) {
 
 	sess, _ := store.StartSession("conv-1")
 
-	msgs := []ArchivedMessage{
+	msgs := []Message{
 		{ID: "m1", ConversationID: "conv-1", SessionID: sess.ID, Role: "user",
 			Content: "hello", Timestamp: time.Date(2026, 2, 12, 10, 0, 0, 0, time.UTC),
 			ArchiveReason: "manual"},
@@ -373,7 +373,7 @@ func TestExportSessionMarkdown(t *testing.T) {
 func TestArchiveStats(t *testing.T) {
 	store := newTestArchiveStore(t)
 
-	msgs := []ArchivedMessage{
+	msgs := []Message{
 		{ID: "m1", ConversationID: "c1", SessionID: "s1", Role: "user",
 			Content: "hello", Timestamp: time.Now(), ArchiveReason: "reset"},
 		{ID: "m2", ConversationID: "c1", SessionID: "s1", Role: "assistant",
@@ -501,7 +501,7 @@ func TestUnsummarizedSessions(t *testing.T) {
 			t.Fatal(err)
 		}
 		// Archive a real message so the EXISTS subquery finds it.
-		err = store.ArchiveMessages([]ArchivedMessage{{
+		err = store.ArchiveMessages([]Message{{
 			ID:             fmt.Sprintf("msg-%d", i),
 			ConversationID: convID,
 			SessionID:      sess.ID,
@@ -524,7 +524,7 @@ func TestUnsummarizedSessions(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = store.ArchiveMessages([]ArchivedMessage{{
+	err = store.ArchiveMessages([]Message{{
 		ID:             "msg-summarized",
 		ConversationID: "conv-summarized",
 		SessionID:      summarized.ID,
@@ -549,7 +549,7 @@ func TestUnsummarizedSessions(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = store.ArchiveMessages([]ArchivedMessage{{
+	err = store.ArchiveMessages([]Message{{
 		ID:             "msg-active",
 		ConversationID: "conv-active",
 		SessionID:      active.ID,
@@ -1198,7 +1198,7 @@ func TestActiveSessionsWithLastActivity(t *testing.T) {
 		t.Fatal(err)
 	}
 	msgTime := time.Now().UTC().Add(-1 * time.Hour)
-	msgs := []ArchivedMessage{
+	msgs := []Message{
 		{
 			ID:             "msg-1",
 			ConversationID: "conv-1",
@@ -1348,7 +1348,7 @@ func TestImportMessages_Legacy(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	msgs := []ArchivedMessage{
+	msgs := []Message{
 		{
 			ID:             "imp-msg-1",
 			ConversationID: "conv-import",
@@ -1401,7 +1401,7 @@ func TestImportMessages_Unified(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	msgs := []ArchivedMessage{
+	msgs := []Message{
 		{
 			ID:             "imp-msg-u1",
 			ConversationID: "conv-import",

--- a/internal/memory/migrate_unify_test.go
+++ b/internal/memory/migrate_unify_test.go
@@ -102,7 +102,7 @@ func TestMigrateUnifyMessages_MergesArchive(t *testing.T) {
 	}
 
 	sess, _ := archiveStore.StartSession("conv-1")
-	if err := archiveStore.ArchiveMessages([]ArchivedMessage{
+	if err := archiveStore.ArchiveMessages([]Message{
 		{ID: "arch-1", ConversationID: "conv-1", SessionID: sess.ID,
 			Role: "user", Content: "archived msg 1",
 			Timestamp: time.Now(), ArchiveReason: "reset"},
@@ -170,7 +170,7 @@ func TestMigrateUnifyMessages_UpsertPreservesSessionID(t *testing.T) {
 	}
 
 	sess, _ := archiveStore.StartSession("conv-1")
-	if err := archiveStore.ArchiveMessages([]ArchivedMessage{
+	if err := archiveStore.ArchiveMessages([]Message{
 		{ID: "shared-msg", ConversationID: "conv-1", SessionID: sess.ID,
 			Role: "user", Content: "hello",
 			Timestamp: time.Now(), ArchiveReason: "reset"},
@@ -217,7 +217,7 @@ func TestMigrateUnifyMessages_Idempotent(t *testing.T) {
 		t.Fatal(err)
 	}
 	sess, _ := archiveStore.StartSession("conv-1")
-	archiveStore.ArchiveMessages([]ArchivedMessage{
+	archiveStore.ArchiveMessages([]Message{
 		{ID: "m1", ConversationID: "conv-1", SessionID: sess.ID,
 			Role: "user", Content: "hello",
 			Timestamp: time.Now(), ArchiveReason: "reset"},

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -31,14 +31,22 @@ type MemoryStore interface {
 	Stats() map[string]any
 }
 
-// Message represents a conversation message.
+// Message represents a conversation message. This is the unified type for
+// both active working-memory messages and archived session transcripts.
+// Archive-specific fields (ConversationID, SessionID, TokenCount, ArchivedAt,
+// ArchiveReason) are zero-valued for active messages.
 type Message struct {
-	ID         string    `json:"id"`   // Stable UUIDv7 assigned at creation time
-	Role       string    `json:"role"` // system, user, assistant, tool
-	Content    string    `json:"content"`
-	Timestamp  time.Time `json:"timestamp"`
-	ToolCalls  string    `json:"tool_calls,omitempty"`   // JSON array of tool calls (assistant messages)
-	ToolCallID string    `json:"tool_call_id,omitempty"` // Tool call ID (tool response messages)
+	ID             string    `json:"id"`                        // Stable UUIDv7 assigned at creation time
+	ConversationID string    `json:"conversation_id,omitempty"` // Set for archived messages
+	SessionID      string    `json:"session_id,omitempty"`      // Set for archived messages
+	Role           string    `json:"role"`                      // system, user, assistant, tool
+	Content        string    `json:"content"`
+	Timestamp      time.Time `json:"timestamp"`
+	TokenCount     int       `json:"token_count,omitempty"`    // Estimated token count
+	ToolCalls      string    `json:"tool_calls,omitempty"`     // JSON array of tool calls (assistant messages)
+	ToolCallID     string    `json:"tool_call_id,omitempty"`   // Tool call ID (tool response messages)
+	ArchivedAt     time.Time `json:"archived_at,omitzero"`     // When the message was archived
+	ArchiveReason  string    `json:"archive_reason,omitempty"` // Why: compaction, reset, shutdown, import
 }
 
 // Conversation holds the state of a single conversation.

--- a/internal/summarizer/summarizer.go
+++ b/internal/summarizer/summarizer.go
@@ -353,7 +353,7 @@ func (w *Worker) markEmpty(sessionID string) {
 
 // buildTranscript creates a condensed transcript from archived messages,
 // truncated at maxTranscriptBytes.
-func buildTranscript(messages []memory.ArchivedMessage) string {
+func buildTranscript(messages []memory.Message) string {
 	var b strings.Builder
 	for _, m := range messages {
 		if m.Role == "system" {

--- a/internal/summarizer/summarizer_test.go
+++ b/internal/summarizer/summarizer_test.go
@@ -95,7 +95,7 @@ func createUnsummarizedSession(t *testing.T, store *memory.ArchiveStore, convID 
 	}
 
 	// Archive a message so the transcript is non-empty.
-	msgs := []memory.ArchivedMessage{
+	msgs := []memory.Message{
 		{
 			ID:             fmt.Sprintf("msg-%s", sess.ID),
 			ConversationID: convID,
@@ -306,7 +306,7 @@ func TestWorker_ClosesOrphanedSessions(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	msgs := []memory.ArchivedMessage{
+	msgs := []memory.Message{
 		{
 			ID:             fmt.Sprintf("msg-%s", sess.ID),
 			ConversationID: "conv-orphan",
@@ -417,7 +417,7 @@ func TestWorker_StaleCountSessionExcluded(t *testing.T) {
 }
 
 func TestBuildTranscript(t *testing.T) {
-	messages := []memory.ArchivedMessage{
+	messages := []memory.Message{
 		{Role: "system", Content: "You are a helpful assistant.", Timestamp: time.Now()},
 		{Role: "user", Content: "Hello", Timestamp: time.Now()},
 		{Role: "assistant", Content: "Hi there!", Timestamp: time.Now()},
@@ -444,7 +444,7 @@ func TestBuildTranscript_Truncation(t *testing.T) {
 		longContent[i] = 'x'
 	}
 
-	messages := []memory.ArchivedMessage{
+	messages := []memory.Message{
 		{Role: "user", Content: string(longContent), Timestamp: time.Now()},
 		{Role: "assistant", Content: "Should not appear", Timestamp: time.Now()},
 	}
@@ -528,7 +528,7 @@ func TestWorker_ClosesIdleSessions(t *testing.T) {
 		t.Fatal(err)
 	}
 	oldTime := time.Now().Add(-2 * time.Hour)
-	msgs := []memory.ArchivedMessage{
+	msgs := []memory.Message{
 		{
 			ID:             fmt.Sprintf("msg-%s", sess.ID),
 			ConversationID: "conv-idle",
@@ -588,7 +588,7 @@ func TestWorker_SkipsActiveSessionsWithinTimeout(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	msgs := []memory.ArchivedMessage{
+	msgs := []memory.Message{
 		{
 			ID:             fmt.Sprintf("msg-%s", sess.ID),
 			ConversationID: "conv-active",
@@ -642,7 +642,7 @@ func TestWorker_IdleTimeoutDisabledWhenZero(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	msgs := []memory.ArchivedMessage{
+	msgs := []memory.Message{
 		{
 			ID:             fmt.Sprintf("msg-%s", sess.ID),
 			ConversationID: "conv-old",

--- a/internal/tools/archive_tools.go
+++ b/internal/tools/archive_tools.go
@@ -317,7 +317,7 @@ func formatSearchResults(results []memory.SearchResult) string {
 	return sb.String()
 }
 
-func formatArchiveMessage(m memory.ArchivedMessage) string {
+func formatArchiveMessage(m memory.Message) string {
 	return fmt.Sprintf("    [%s] %s: %s\n",
 		m.Timestamp.Format("15:04:05"),
 		m.Role,

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -87,7 +87,7 @@ type SessionStore interface {
 	ListSessions(conversationID string, limit int) ([]*memory.Session, error)
 	ListChildSessions(parentSessionID string) ([]*memory.Session, error)
 	GetSession(sessionID string) (*memory.Session, error)
-	GetSessionTranscript(sessionID string) ([]memory.ArchivedMessage, error)
+	GetSessionTranscript(sessionID string) ([]memory.Message, error)
 	GetSessionToolCalls(sessionID string) ([]memory.ArchivedToolCall, error)
 	GetSessionIterations(sessionID string) ([]memory.ArchivedIteration, error)
 }

--- a/internal/web/sessions.go
+++ b/internal/web/sessions.go
@@ -301,7 +301,7 @@ func buildSessionDetailView(sess *memory.Session) *sessionDetailView {
 	return v
 }
 
-func messagesToRows(messages []memory.ArchivedMessage) []*messageRow {
+func messagesToRows(messages []memory.Message) []*messageRow {
 	rows := make([]*messageRow, 0, len(messages))
 	for _, m := range messages {
 		rows = append(rows, &messageRow{

--- a/internal/web/sessions_test.go
+++ b/internal/web/sessions_test.go
@@ -14,7 +14,7 @@ import (
 // mockSessionStore is a test double for SessionStore.
 type mockSessionStore struct {
 	sessions   []*memory.Session
-	transcript []memory.ArchivedMessage
+	transcript []memory.Message
 	toolCalls  []memory.ArchivedToolCall
 	iterations []memory.ArchivedIteration
 }
@@ -41,7 +41,7 @@ func (m *mockSessionStore) GetSession(sessionID string) (*memory.Session, error)
 	return nil, nil
 }
 
-func (m *mockSessionStore) GetSessionTranscript(sessionID string) ([]memory.ArchivedMessage, error) {
+func (m *mockSessionStore) GetSessionTranscript(sessionID string) ([]memory.Message, error) {
 	return m.transcript, nil
 }
 
@@ -105,9 +105,9 @@ func testSessions() []*memory.Session {
 	}
 }
 
-func testTranscript() []memory.ArchivedMessage {
+func testTranscript() []memory.Message {
 	now := time.Now()
-	return []memory.ArchivedMessage{
+	return []memory.Message{
 		{
 			Role:      "user",
 			Content:   "Hello, can you help me debug this?",


### PR DESCRIPTION
## Summary

- Expands `Message` in `store.go` with five archive-specific fields (`ConversationID`, `SessionID`, `TokenCount`, `ArchivedAt`, `ArchiveReason`) that were previously only on `ArchivedMessage`
- Deletes the `ArchivedMessage` struct — all 16 files that referenced it now use `Message` directly
- Archive-specific fields are zero-valued for active/working messages, so no behavioral change
- No schema changes — both types already mapped to the same `messages` table row

## Context

With unified storage (#434), `messages` and `archive_messages` are the same table. The Go code still had two structs — `Message` (6 fields) and `ArchivedMessage` (11 fields) — mapping to the same row. `ArchivedMessage` was a superset of `Message`, a leftover from the two-database era. This collapses them into one type.

## What stays unchanged

- `ArchivedToolCall` — separate type, different table, not in scope
- `ArchivedIteration` — separate type, not in scope  
- `checkpoint.Message` / `agent.Message` — different packages, different purposes
- Database schema — no changes
- Runtime behavior — no changes

## Test plan

- [x] `just ci` passes (0 lint issues, all tests green with `-race`)
- [x] `grep -r ArchivedMessage` returns zero hits in `.go` files

Closes #439

🤖 Generated with [Claude Code](https://claude.com/claude-code)