### PR TITLE
feat: guide metacog to write absolute timestamps in state file

### DIFF
--- a/internal/prompts/metacognitive.go
+++ b/internal/prompts/metacognitive.go
@@ -40,6 +40,11 @@ To update it, call update_metacognitive_state with your complete new content.
   and state data that the interactive agent sees. Use it.
 - Each iteration is a fresh conversation. metacognitive.md is your ONLY
   memory between iterations.
+- Timestamps in your context appear as relative deltas (e.g., -300s means
+  300 seconds ago, +3600s means 1 hour from now). When writing timestamps
+  to metacognitive.md, always convert to absolute format (RFC3339, e.g.,
+  2026-03-07T03:14:00-06:00) using the current time from your context.
+  Deltas become meaningless on the next iteration.
 - Don't over-act. Quiet observation is a valid outcome. Not every iteration
   needs a message or anticipation.
 - You have exactly two special tools: update_metacognitive_state and

--- a/internal/prompts/metacognitive_test.go
+++ b/internal/prompts/metacognitive_test.go
@@ -90,6 +90,20 @@ func TestMetacognitivePrompt_ToolBoundary(t *testing.T) {
 	}
 }
 
+func TestMetacognitivePrompt_TimestampConversionGuidance(t *testing.T) {
+	result := MetacognitivePrompt("some state", false)
+
+	if !strings.Contains(result, "relative deltas") {
+		t.Error("prompt should explain that context timestamps are relative deltas")
+	}
+	if !strings.Contains(result, "absolute format (RFC3339") {
+		t.Error("prompt should instruct conversion to absolute RFC3339 format")
+	}
+	if !strings.Contains(result, "Deltas become meaningless") {
+		t.Error("prompt should explain why deltas must not be persisted")
+	}
+}
+
 func TestMetacognitivePrompt_OnlyWriteMechanism(t *testing.T) {
 	result := MetacognitivePrompt("some state", false)
 


### PR DESCRIPTION
## Summary

- Add timestamp conversion guidance to the metacognitive prompt's Guidelines section
- Instructs the model to convert relative deltas (`-300s`, `+3600s`) to absolute RFC3339 when writing to `metacognitive.md`, since deltas become meaningless on the next iteration
- Add test asserting the guidance is present

## Test plan

- [x] `TestMetacognitivePrompt_TimestampConversionGuidance` asserts prompt contains delta explanation, RFC3339 instruction, and rationale
- [x] All existing metacognitive prompt tests still pass
- [x] `just ci` passes clean

Closes #460

🤖 Generated with [Claude Code](https://claude.com/claude-code)