### PR TITLE
feat: invite metacog supervisor to contribute observations to ego.md

### DIFF
--- a/internal/prompts/metacognitive.go
+++ b/internal/prompts/metacognitive.go
@@ -76,7 +76,15 @@ frontier model. In addition to the normal assessment, critically evaluate:
   Is it still genuinely reasoning or just going through motions?
 
 Be honest. This is self-supervision — the point is to catch things the
-cheaper model's consistent blind spots miss.`
+cheaper model's consistent blind spots miss.
+
+Your supervisory perspective provides unique insight into the agent's
+behavioral patterns and development. You observe from outside what the agent
+experiences from within. When you notice significant patterns, breakthroughs,
+or persistent struggles that would matter to long-term self-understanding,
+you are invited to contribute these observations to ego.md. Mark your
+contributions clearly as metacognitive observations. Focus on patterns that
+reveal how the agent is evolving, not routine operational decisions.`
 
 // MetacognitivePrompt returns the prompt for a metacognitive loop
 // iteration. When isSupervisor is true, additional self-review

--- a/internal/prompts/metacognitive_test.go
+++ b/internal/prompts/metacognitive_test.go
@@ -36,6 +36,12 @@ func TestMetacognitivePrompt_Supervisor(t *testing.T) {
 	if !strings.Contains(result, "Drift detection") {
 		t.Error("supervisor prompt should contain drift detection instruction")
 	}
+	if !strings.Contains(result, "contribute these observations to ego.md") {
+		t.Error("supervisor prompt should invite ego.md contributions")
+	}
+	if !strings.Contains(result, "metacognitive observations") {
+		t.Error("supervisor prompt should instruct marking contributions as metacognitive observations")
+	}
 }
 
 func TestMetacognitivePrompt_EmptyState(t *testing.T) {


### PR DESCRIPTION
## Summary

- Add ego.md contribution guidance to the metacognitive supervisor augmentation prompt
- Encourages the frontier-model supervisor to write significant behavioral pattern observations to ego.md, marked as metacognitive observations
- Focuses on patterns revealing agent evolution, not routine operational decisions

## Test plan

- [x] `TestMetacognitivePrompt_Supervisor` asserts ego.md contribution guidance and metacognitive observation marking are present
- [x] All existing metacognitive prompt tests pass
- [x] `just ci` passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)