### PR TITLE
feat: auto-register core: path prefix for workspace root

### DIFF
--- a/cmd/thane/main.go
+++ b/cmd/thane/main.go
@@ -737,12 +737,20 @@ func runServe(ctx context.Context, stdout io.Writer, stderr io.Writer, configPat
 	// resolver expands ~ in base directories at construction time.
 	// Auto-register core: prefix pointing at the workspace root so
 	// models can reference core:ego.md without knowing the filesystem
-	// path. User-defined core: in config takes precedence.
+	// path. User-defined core: (with or without trailing colon) in
+	// config takes precedence.
 	if cfg.Workspace.Path != "" {
 		if cfg.Paths == nil {
 			cfg.Paths = make(map[string]string)
 		}
-		if _, exists := cfg.Paths["core"]; !exists {
+		hasCore := false
+		for k := range cfg.Paths {
+			if strings.TrimSuffix(k, ":") == "core" {
+				hasCore = true
+				break
+			}
+		}
+		if !hasCore {
 			cfg.Paths["core"] = cfg.Workspace.Path
 		}
 	}
@@ -998,7 +1006,17 @@ func runServe(ctx context.Context, stdout io.Writer, stderr io.Writer, configPat
 			fileTools.SetResolver(resolver)
 		}
 		loop.Tools().SetFileTools(fileTools)
-		egoPath, _ := resolver.Resolve("core:ego.md")
+		egoPath := filepath.Join(cfg.Workspace.Path, "ego.md")
+		if resolver != nil {
+			if resolved, err := resolver.Resolve("core:ego.md"); err != nil {
+				logger.Warn("failed to resolve core:ego.md, using default",
+					"error", err,
+					"default_path", egoPath,
+				)
+			} else {
+				egoPath = resolved
+			}
+		}
 		loop.SetEgoFile(egoPath)
 		logger.Info("file tools enabled", "workspace", cfg.Workspace.Path)
 	} else {
@@ -2131,10 +2149,17 @@ func runServe(ctx context.Context, stdout io.Writer, stderr io.Writer, configPat
 			return fmt.Errorf("metacognitive config: %w", err)
 		}
 
+		var metacogEgoFile string
+		if resolver != nil {
+			if resolved, err := resolver.Resolve("core:ego.md"); err == nil {
+				metacogEgoFile = resolved
+			}
+		}
 		metacogLoop := metacognitive.New(metacogCfg, metacognitive.Deps{
 			Runner:        loop,
 			Logger:        logger,
 			WorkspacePath: cfg.Workspace.Path,
+			EgoFile:       metacogEgoFile,
 		})
 		metacogLoop.RegisterTools(loop.Tools())
 

--- a/internal/metacognitive/metacognitive.go
+++ b/internal/metacognitive/metacognitive.go
@@ -122,6 +122,7 @@ type Deps struct {
 	Runner        agentRunner
 	Logger        *slog.Logger
 	WorkspacePath string
+	EgoFile       string     // absolute path to ego.md; empty disables append_ego_observation tool
 	RandSource    RandSource // nil uses math/rand/v2 default
 }
 

--- a/internal/metacognitive/tool.go
+++ b/internal/metacognitive/tool.go
@@ -15,9 +15,10 @@ import (
 const minStateContentLen = 50
 
 // RegisterTools registers metacognitive-specific tools on the given
-// registry: set_next_sleep and update_metacognitive_state. The LLM
-// calls these during iterations to control sleep timing and persist
-// its state file.
+// registry: set_next_sleep, update_metacognitive_state, and (when
+// EgoFile is configured) append_ego_observation. The LLM calls these
+// during iterations to control sleep timing, persist its state file,
+// and contribute observations to ego.md.
 //
 // The handler captures the [Loop] pointer via closure so it can
 // communicate the chosen duration back to the loop goroutine. This
@@ -142,4 +143,67 @@ func (l *Loop) RegisterTools(registry *tools.Registry) {
 			return fmt.Sprintf("State file updated (%d bytes) at %s.", len(fullContent), statePath), nil
 		},
 	})
+
+	// append_ego_observation: append-only shim for ego.md, available
+	// when EgoFile is configured. The metacog loop excludes general
+	// file tools, so this provides controlled write access to
+	// core:ego.md without granting full file_write.
+	if l.deps.EgoFile != "" {
+		registry.Register(&tools.Tool{
+			Name: "append_ego_observation",
+			Description: "Append a metacognitive observation to core:ego.md. " +
+				"Use this when you notice significant behavioral patterns, breakthroughs, " +
+				"or persistent struggles that would matter to long-term self-understanding. " +
+				"Your observation is appended — existing content is never overwritten.",
+			Parameters: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"observation": map[string]any{
+						"type":        "string",
+						"description": "The observation to append. Should focus on patterns revealing how the agent is evolving. Must be at least 50 characters.",
+					},
+				},
+				"required": []string{"observation"},
+			},
+			Handler: func(_ context.Context, args map[string]any) (string, error) {
+				observation, _ := args["observation"].(string)
+				if len(observation) < minStateContentLen {
+					return "", fmt.Errorf("observation too short (%d chars, minimum %d)", len(observation), minStateContentLen)
+				}
+
+				egoPath := l.deps.EgoFile
+
+				// Read existing content (empty file is fine).
+				existing, err := os.ReadFile(egoPath)
+				if err != nil && !os.IsNotExist(err) {
+					return "", fmt.Errorf("read ego file: %w", err)
+				}
+
+				// Build the appended block with metadata.
+				convID := l.getCurrentConvID()
+				block := fmt.Sprintf("\n\n### Metacognitive Observation\n"+
+					"<!-- metacognitive: iteration=%s observed=%s -->\n\n%s\n",
+					convID, time.Now().UTC().Format(time.RFC3339), observation)
+
+				fullContent := string(existing) + block
+
+				// Ensure parent directory exists.
+				if err := os.MkdirAll(filepath.Dir(egoPath), 0o755); err != nil {
+					return "", fmt.Errorf("create ego directory: %w", err)
+				}
+
+				if err := os.WriteFile(egoPath, []byte(fullContent), 0o644); err != nil {
+					return "", fmt.Errorf("write ego file: %w", err)
+				}
+
+				l.deps.Logger.Info("ego observation appended",
+					"path", egoPath,
+					"bytes", len(block),
+					"conversation_id", convID,
+				)
+
+				return fmt.Sprintf("Observation appended to core:ego.md (%d bytes).", len(block)), nil
+			},
+		})
+	}
 }

--- a/internal/metacognitive/tool_test.go
+++ b/internal/metacognitive/tool_test.go
@@ -1,0 +1,209 @@
+package metacognitive
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nugget/thane-ai-agent/internal/tools"
+)
+
+// --- append_ego_observation tool tests ---
+
+func TestAppendEgoObservation_NotRegisteredWithoutEgoFile(t *testing.T) {
+	deps := testDeps(t, nil)
+	// EgoFile is empty by default in testDeps.
+	l := New(testConfig(), deps)
+
+	reg := tools.NewRegistry(nil, nil)
+	l.RegisterTools(reg)
+
+	tool := reg.Get("append_ego_observation")
+	if tool != nil {
+		t.Error("append_ego_observation should not be registered when EgoFile is empty")
+	}
+}
+
+func TestAppendEgoObservation_RegisteredWithEgoFile(t *testing.T) {
+	deps := testDeps(t, nil)
+	deps.EgoFile = filepath.Join(deps.WorkspacePath, "ego.md")
+	l := New(testConfig(), deps)
+
+	reg := tools.NewRegistry(nil, nil)
+	l.RegisterTools(reg)
+
+	tool := reg.Get("append_ego_observation")
+	if tool == nil {
+		t.Fatal("append_ego_observation should be registered when EgoFile is set")
+	}
+}
+
+func TestAppendEgoObservation_CreatesNewFile(t *testing.T) {
+	deps := testDeps(t, nil)
+	egoPath := filepath.Join(deps.WorkspacePath, "ego.md")
+	deps.EgoFile = egoPath
+	l := New(testConfig(), deps)
+	l.setCurrentConvID("metacog-ego-1")
+
+	reg := tools.NewRegistry(nil, nil)
+	l.RegisterTools(reg)
+
+	tool := reg.Get("append_ego_observation")
+
+	observation := "The agent has developed a consistent pattern of shortening sleep intervals when garage activity is detected, even in quiet periods."
+	result, err := tool.Handler(context.Background(), map[string]any{
+		"observation": observation,
+	})
+	if err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+	if !strings.Contains(result, "core:ego.md") {
+		t.Errorf("result = %q, want mention of core:ego.md", result)
+	}
+
+	// Verify file was created with the observation.
+	data, err := os.ReadFile(egoPath)
+	if err != nil {
+		t.Fatalf("read ego file: %v", err)
+	}
+	s := string(data)
+	if !strings.Contains(s, "Metacognitive Observation") {
+		t.Error("ego file should contain observation heading")
+	}
+	if !strings.Contains(s, observation) {
+		t.Error("ego file should contain the observation text")
+	}
+	if !strings.Contains(s, "iteration=metacog-ego-1") {
+		t.Error("ego file should contain conversation ID in metadata")
+	}
+	if !strings.Contains(s, "observed=") {
+		t.Error("ego file should contain observed timestamp")
+	}
+}
+
+func TestAppendEgoObservation_AppendsToExisting(t *testing.T) {
+	deps := testDeps(t, nil)
+	egoPath := filepath.Join(deps.WorkspacePath, "ego.md")
+	deps.EgoFile = egoPath
+	l := New(testConfig(), deps)
+	l.setCurrentConvID("metacog-ego-2")
+
+	// Write existing ego content.
+	existing := "# Ego\n\nI am an agent that monitors a household.\n"
+	if err := os.WriteFile(egoPath, []byte(existing), 0o644); err != nil {
+		t.Fatalf("write existing ego file: %v", err)
+	}
+
+	reg := tools.NewRegistry(nil, nil)
+	l.RegisterTools(reg)
+
+	tool := reg.Get("append_ego_observation")
+
+	observation := "Supervisor review reveals the agent consistently over-monitors the garage door compared to other systems. This bias may reflect training emphasis."
+	_, err := tool.Handler(context.Background(), map[string]any{
+		"observation": observation,
+	})
+	if err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+
+	// Verify existing content is preserved.
+	data, err := os.ReadFile(egoPath)
+	if err != nil {
+		t.Fatalf("read ego file: %v", err)
+	}
+	s := string(data)
+	if !strings.Contains(s, "I am an agent that monitors a household.") {
+		t.Error("existing ego content should be preserved")
+	}
+	if !strings.Contains(s, observation) {
+		t.Error("new observation should be appended")
+	}
+	if !strings.Contains(s, "iteration=metacog-ego-2") {
+		t.Error("metadata should contain conversation ID")
+	}
+}
+
+func TestAppendEgoObservation_RejectsShortContent(t *testing.T) {
+	deps := testDeps(t, nil)
+	deps.EgoFile = filepath.Join(deps.WorkspacePath, "ego.md")
+	l := New(testConfig(), deps)
+
+	reg := tools.NewRegistry(nil, nil)
+	l.RegisterTools(reg)
+
+	tool := reg.Get("append_ego_observation")
+
+	tests := []struct {
+		name        string
+		observation string
+	}{
+		{"empty", ""},
+		{"too_short", "Short."},
+		{"just_under_limit", strings.Repeat("x", minStateContentLen-1)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := tool.Handler(context.Background(), map[string]any{
+				"observation": tt.observation,
+			})
+			if err == nil {
+				t.Error("handler should reject short observation")
+			}
+			if err != nil && !strings.Contains(err.Error(), "too short") {
+				t.Errorf("error = %v, want 'too short' message", err)
+			}
+		})
+	}
+}
+
+func TestAppendEgoObservation_MultipleAppends(t *testing.T) {
+	deps := testDeps(t, nil)
+	egoPath := filepath.Join(deps.WorkspacePath, "ego.md")
+	deps.EgoFile = egoPath
+	l := New(testConfig(), deps)
+
+	reg := tools.NewRegistry(nil, nil)
+	l.RegisterTools(reg)
+
+	tool := reg.Get("append_ego_observation")
+
+	// First observation.
+	l.setCurrentConvID("metacog-first")
+	_, err := tool.Handler(context.Background(), map[string]any{
+		"observation": "First observation: the agent shows increasing confidence in pattern recognition over successive iterations.",
+	})
+	if err != nil {
+		t.Fatalf("first append: %v", err)
+	}
+
+	// Second observation.
+	l.setCurrentConvID("metacog-second")
+	_, err = tool.Handler(context.Background(), map[string]any{
+		"observation": "Second observation: sleep durations have stabilized around 10 minutes during quiet periods, suggesting calibration convergence.",
+	})
+	if err != nil {
+		t.Fatalf("second append: %v", err)
+	}
+
+	// Verify both observations are in the file.
+	data, err := os.ReadFile(egoPath)
+	if err != nil {
+		t.Fatalf("read ego file: %v", err)
+	}
+	s := string(data)
+
+	if !strings.Contains(s, "iteration=metacog-first") {
+		t.Error("file should contain first observation metadata")
+	}
+	if !strings.Contains(s, "iteration=metacog-second") {
+		t.Error("file should contain second observation metadata")
+	}
+	if strings.Count(s, "### Metacognitive Observation") != 2 {
+		t.Errorf("file should contain exactly 2 observation headings, got %d",
+			strings.Count(s, "### Metacognitive Observation"))
+	}
+}

--- a/internal/prompts/metacognitive.go
+++ b/internal/prompts/metacognitive.go
@@ -47,10 +47,11 @@ To update it, call update_metacognitive_state with your complete new content.
   Deltas become meaningless on the next iteration.
 - Don't over-act. Quiet observation is a valid outcome. Not every iteration
   needs a message or anticipation.
-- You have exactly two special tools: update_metacognitive_state and
-  set_next_sleep. All other tools are from the standard agent toolkit
-  (contacts, facts, anticipations, notifications). File tools, exec, and
-  session management tools are NOT available.
+- You have exactly three special tools: update_metacognitive_state,
+  set_next_sleep, and append_ego_observation. All other tools are from
+  the standard agent toolkit (contacts, facts, anticipations,
+  notifications). File tools, exec, and session management tools are
+  NOT available.
 - If nothing interesting is happening, note it and sleep long.`
 
 // metacognitiveSupervisorAugmentation is appended for frontier/supervisor
@@ -82,9 +83,9 @@ Your supervisory perspective provides unique insight into the agent's
 behavioral patterns and development. You observe from outside what the agent
 experiences from within. When you notice significant patterns, breakthroughs,
 or persistent struggles that would matter to long-term self-understanding,
-you are invited to contribute these observations to core:ego.md. Mark your
-contributions clearly as metacognitive observations. Focus on patterns that
-reveal how the agent is evolving, not routine operational decisions.`
+call append_ego_observation to contribute these insights to core:ego.md.
+Focus on patterns that reveal how the agent is evolving, not routine
+operational decisions.`
 
 // MetacognitivePrompt returns the prompt for a metacognitive loop
 // iteration. When isSupervisor is true, additional self-review

--- a/internal/prompts/metacognitive_test.go
+++ b/internal/prompts/metacognitive_test.go
@@ -39,8 +39,8 @@ func TestMetacognitivePrompt_Supervisor(t *testing.T) {
 	if !strings.Contains(result, "core:ego.md") {
 		t.Error("supervisor prompt should reference core:ego.md path prefix")
 	}
-	if !strings.Contains(result, "metacognitive observations") {
-		t.Error("supervisor prompt should instruct marking contributions as metacognitive observations")
+	if !strings.Contains(result, "append_ego_observation") {
+		t.Error("supervisor prompt should reference append_ego_observation tool")
 	}
 }
 
@@ -88,8 +88,11 @@ func TestMetacognitivePrompt_FileToolsNotAvailable(t *testing.T) {
 func TestMetacognitivePrompt_ToolBoundary(t *testing.T) {
 	result := MetacognitivePrompt("some state", false)
 
-	if !strings.Contains(result, "exactly two special tools") {
-		t.Error("prompt should state the two special tools available")
+	if !strings.Contains(result, "exactly three special tools") {
+		t.Error("prompt should state the three special tools available")
+	}
+	if !strings.Contains(result, "append_ego_observation") {
+		t.Error("prompt should mention append_ego_observation tool")
 	}
 	if !strings.Contains(result, "File tools, exec, and") {
 		t.Error("prompt should explicitly list unavailable tool categories")


### PR DESCRIPTION
## Summary

- Auto-inject `core:` prefix into the path resolver when a workspace is configured, pointing at the workspace root
- Models can now reference `core:ego.md` (and other core files) without knowing filesystem paths
- User-defined `core:` in config takes precedence over the auto-registered default
- Ego file path setup now uses the resolver instead of hardcoded `filepath.Join`
- Add supervisor prompt guidance inviting metacognitive observations to `core:ego.md`

Supersedes #462

## Test plan

- [x] `TestMetacognitivePrompt_Supervisor` asserts `core:ego.md` reference and metacognitive observation marking
- [x] All existing prompt and path tests pass
- [x] `just ci` passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)