### PR TITLE
fix: restore ALTER TABLE migration for last_interaction_meta

### DIFF
--- a/internal/contacts/store.go
+++ b/internal/contacts/store.go
@@ -182,6 +182,15 @@ func (s *Store) migrate() error {
 		return err
 	}
 
+	// Backfill last_interaction_meta for databases created between #482
+	// (schema v2 baseline) and #485. The column is in the DDL for fresh
+	// databases; this handles existing ones.
+	if _, err := s.db.Exec(`ALTER TABLE contacts ADD COLUMN last_interaction_meta TEXT`); err != nil {
+		if !strings.Contains(err.Error(), "duplicate column") {
+			return fmt.Errorf("add last_interaction_meta column: %w", err)
+		}
+	}
+
 	// Enforce active name uniqueness (case-insensitive).
 	if _, err := s.db.Exec(`CREATE UNIQUE INDEX IF NOT EXISTS idx_contacts_fn_active ON contacts(LOWER(formatted_name)) WHERE deleted_at IS NULL`); err != nil {
 		s.logger.Warn("unique active name index not created", "error", err)


### PR DESCRIPTION
## Summary
- Production databases created between #482 and #485 don't have the `last_interaction_meta` column, causing `/contacts` web UI to fail with `no such column: last_interaction_meta`
- Restores the `ALTER TABLE` migration that backfills the column on existing databases (duplicate column errors silently ignored)
- The column remains in the `CREATE TABLE` DDL for fresh databases

## Test plan
- [x] `just ci` passes
- [ ] Deploy to production, verify `/contacts` loads without error