### PR TITLE
fix: filter Apple X-ABLABEL and PRODID from vCard import

### DIFF
--- a/internal/contacts/vcard.go
+++ b/internal/contacts/vcard.go
@@ -36,6 +36,15 @@ var coreProperties = map[string]bool{
 	"X-THANE-AI-SUMMARY":     true,
 }
 
+// skipProperties lists vCard properties that should never be stored as
+// contact_properties rows. These are either metadata about the vCard
+// file itself or Apple-specific grouped labels that lose meaning when
+// the group prefix is stripped during parsing.
+var skipProperties = map[string]bool{
+	"X-ABLABEL": true, // Apple grouped label — orphaned without group context
+	"PRODID":    true, // vCard generator identifier, not contact data
+}
+
 // ContactToCard converts a Contact with its Properties into a
 // vcard.Card.  The contact must have Properties populated (via
 // GetWithProperties).
@@ -179,10 +188,10 @@ func CardToContact(card vcard.Card) (*Contact, []Property) {
 
 	c.AISummary = card.PreferredValue("X-THANE-AI-SUMMARY")
 
-	// Multi-value properties: everything not in coreProperties.
+	// Multi-value properties: everything not in coreProperties or skipProperties.
 	var props []Property
 	for name, fields := range card {
-		if coreProperties[name] {
+		if coreProperties[name] || skipProperties[name] {
 			continue
 		}
 		for _, f := range fields {

--- a/internal/contacts/vcard_test.go
+++ b/internal/contacts/vcard_test.go
@@ -658,6 +658,47 @@ func TestFilterCardForTrustZone_ZonePhoto_UnknownStrips(t *testing.T) {
 	}
 }
 
+func TestCardToContact_SkipsAppleGarbage(t *testing.T) {
+	card := make(vcard.Card)
+	card.SetValue(vcard.FieldVersion, "4.0")
+	card.SetValue(vcard.FieldFormattedName, "Apple User")
+
+	// Legitimate property.
+	card.Add(vcard.FieldEmail, &vcard.Field{
+		Value: "user@example.com",
+	})
+
+	// Apple X-ABLABEL entries (should be skipped).
+	card.Add("X-ABLABEL", &vcard.Field{Value: "_$!<Other>!$_"})
+	card.Add("X-ABLABEL", &vcard.Field{Value: "iCloud"})
+	card.Add("X-ABLABEL", &vcard.Field{Value: "_$!<HomePage>!$_"})
+
+	// PRODID (should be skipped).
+	card.Add("PRODID", &vcard.Field{Value: "-//Apple Inc.//macOS 26.3.1//EN"})
+
+	_, props := CardToContact(card)
+
+	for _, p := range props {
+		if p.Property == "X-ABLABEL" {
+			t.Errorf("X-ABLABEL should be filtered, got value %q", p.Value)
+		}
+		if p.Property == "PRODID" {
+			t.Errorf("PRODID should be filtered, got value %q", p.Value)
+		}
+	}
+
+	// Legitimate EMAIL should still be present.
+	found := false
+	for _, p := range props {
+		if p.Property == "EMAIL" && p.Value == "user@example.com" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("EMAIL property should be preserved")
+	}
+}
+
 // buildTestCard creates a vCard with common fields for filter tests.
 func buildTestCard() vcard.Card {
 	card := make(vcard.Card)


### PR DESCRIPTION
## Summary
- Add `skipProperties` set to filter `X-ABLABEL` and `PRODID` during vCard import
- Apple-generated vCards include grouped labels and generator metadata that pollute the contact_properties table
- The import loop now checks `skipProperties` alongside `coreProperties`, preventing these from being stored as property rows

Closes #494

## Test plan
- [x] New test: import vCard with X-ABLABEL and PRODID → neither appears in properties
- [x] Verify legitimate properties (EMAIL) are preserved
- [x] All existing vCard tests pass
- [x] `just ci` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)