### PR TITLE
fix: YouTube @handle resolution fails — 512KB read limit too small

### DIFF
--- a/internal/media/feed.go
+++ b/internal/media/feed.go
@@ -177,9 +177,17 @@ var ytChannelIDRe = regexp.MustCompile(`"channelId"\s*:\s*"(UC[a-zA-Z0-9_-]+)"`)
 var ytCanonicalRe = regexp.MustCompile(`<link\s+rel="canonical"\s+href="https://www\.youtube\.com/channel/(UC[a-zA-Z0-9_-]+)"`)
 
 // ytAlternateFeedRe matches the RSS alternate link that YouTube embeds
-// in channel pages. This is the most direct signal — it contains the
-// full feed URL rather than requiring channel ID extraction.
-var ytAlternateFeedRe = regexp.MustCompile(`<link[^>]+type="application/rss\+xml"[^>]+href="([^"]+)"`)
+// in channel pages. Handles both attribute orderings (type before href
+// and href before type) and single/double quotes. Requires rel="alternate"
+// to avoid false matches.
+var ytAlternateFeedRe = regexp.MustCompile(
+	`<link[^>]+rel=['"]alternate['"][^>]+` +
+		`(?:` +
+		`type=['"]application/rss\+xml['"][^>]+href=['"]([^'"]+)['"]` +
+		`|` +
+		`href=['"]([^'"]+)['"][^>]+type=['"]application/rss\+xml['"]` +
+		`)`,
+)
 
 // isYouTubeHost reports whether host is a known YouTube hostname.
 func isYouTubeHost(host string) bool {
@@ -240,16 +248,26 @@ func resolveYouTubeFeed(ctx context.Context, httpClient *http.Client, rawURL str
 	// YouTube @handle pages are ~1.1MB; all channel metadata (canonical
 	// link, alternate feed link, channelId JSON) sits at ~600KB+.
 	// The old 512KB limit silently missed everything.
-	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	const maxChannelPageBytes = 1 << 20
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxChannelPageBytes+1))
 	if err != nil {
 		return "", fmt.Errorf("read channel page: %w", err)
+	}
+	if len(body) > maxChannelPageBytes {
+		return "", fmt.Errorf("channel page exceeded %d-byte limit; try the direct RSS URL: https://www.youtube.com/feeds/videos.xml?channel_id=CHANNEL_ID", maxChannelPageBytes)
 	}
 	html := string(body)
 
 	// Try alternate RSS link first (most direct — contains full feed URL),
 	// then canonical link, then JSON metadata.
-	if m := ytAlternateFeedRe.FindStringSubmatch(html); len(m) == 2 {
-		return m[1], nil
+	if m := ytAlternateFeedRe.FindStringSubmatch(html); m != nil {
+		// Two alternation groups — one will be empty depending on attr order.
+		if m[1] != "" {
+			return m[1], nil
+		}
+		if m[2] != "" {
+			return m[2], nil
+		}
 	}
 	if m := ytCanonicalRe.FindStringSubmatch(html); len(m) == 2 {
 		return "https://www.youtube.com/feeds/videos.xml?channel_id=" + m[1], nil

--- a/internal/media/feed_test.go
+++ b/internal/media/feed_test.go
@@ -271,15 +271,54 @@ func TestResolveYouTubeFeed_NonYouTube(t *testing.T) {
 	}
 }
 
-func TestYTAlternateFeedRe(t *testing.T) {
-	html := `<link rel="alternate" type="application/rss+xml" title="RSS" href="https://www.youtube.com/feeds/videos.xml?channel_id=UCabc123xyz">`
+// ytAlternateFeedMatch extracts the feed URL from a ytAlternateFeedRe match,
+// handling both alternation groups (type-before-href and href-before-type).
+func ytAlternateFeedMatch(html string) string {
 	m := ytAlternateFeedRe.FindStringSubmatch(html)
-	if len(m) != 2 {
-		t.Fatalf("ytAlternateFeedRe did not match; got %d groups", len(m))
+	if m == nil {
+		return ""
 	}
+	if m[1] != "" {
+		return m[1]
+	}
+	return m[2]
+}
+
+func TestYTAlternateFeedRe(t *testing.T) {
 	want := "https://www.youtube.com/feeds/videos.xml?channel_id=UCabc123xyz"
-	if m[1] != want {
-		t.Errorf("got %q, want %q", m[1], want)
+
+	tests := []struct {
+		name string
+		html string
+	}{
+		{
+			name: "type before href, double quotes",
+			html: `<link rel="alternate" type="application/rss+xml" title="RSS" href="https://www.youtube.com/feeds/videos.xml?channel_id=UCabc123xyz">`,
+		},
+		{
+			name: "href before type, double quotes",
+			html: `<link rel="alternate" href="https://www.youtube.com/feeds/videos.xml?channel_id=UCabc123xyz" type="application/rss+xml" title="RSS">`,
+		},
+		{
+			name: "type before href, single quotes",
+			html: `<link rel='alternate' type='application/rss+xml' title='RSS' href='https://www.youtube.com/feeds/videos.xml?channel_id=UCabc123xyz'>`,
+		},
+		{
+			name: "href before type, single quotes",
+			html: `<link rel='alternate' href='https://www.youtube.com/feeds/videos.xml?channel_id=UCabc123xyz' type='application/rss+xml' title='RSS'>`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ytAlternateFeedMatch(tt.html)
+			if got == "" {
+				t.Fatal("ytAlternateFeedRe did not match")
+			}
+			if got != want {
+				t.Errorf("got %q, want %q", got, want)
+			}
+		})
 	}
 }
 
@@ -301,8 +340,8 @@ func TestYTRegexes_LargePageOffset(t *testing.T) {
 		page = page[:limit]
 	}
 
-	if m := ytAlternateFeedRe.FindStringSubmatch(page); len(m) != 2 || m[1] != wantFeed {
-		t.Errorf("ytAlternateFeedRe failed at 600KB offset: got %v", m)
+	if got := ytAlternateFeedMatch(page); got != wantFeed {
+		t.Errorf("ytAlternateFeedRe failed at 600KB offset: got %q", got)
 	}
 	if m := ytCanonicalRe.FindStringSubmatch(page); len(m) != 2 || m[1] != "UCtest600k" {
 		t.Errorf("ytCanonicalRe failed at 600KB offset: got %v", m)
@@ -313,7 +352,7 @@ func TestYTRegexes_LargePageOffset(t *testing.T) {
 
 	// Verify the old 512KB limit would have missed these.
 	truncated := page[:512*1024]
-	if m := ytAlternateFeedRe.FindStringSubmatch(truncated); len(m) != 0 {
+	if got := ytAlternateFeedMatch(truncated); got != "" {
 		t.Error("ytAlternateFeedRe should NOT match within 512KB")
 	}
 	if m := ytCanonicalRe.FindStringSubmatch(truncated); len(m) != 0 {


### PR DESCRIPTION
## Summary
- Bumps the YouTube channel page read limit from 512KB to 1MB — all channel metadata sits at ~600KB+ in `@handle` pages
- Adds `ytAlternateFeedRe` to match the RSS alternate `<link>` directly (more robust than extracting channel ID and constructing the URL)
- Tries alternate link first, then canonical, then JSON metadata fallback

## Test plan
- [x] `TestYTAlternateFeedRe` — verifies the new regex extracts feed URLs
- [x] `TestYTRegexes_LargePageOffset` — content at 600KB is found with the 1MB limit and confirms the old 512KB limit would have missed it
- [x] Existing YouTube resolution tests pass unchanged
- [x] `just ci` passes

Closes #517