### PR TITLE
chore: final structured logging polish

### DIFF
--- a/internal/carddav/server.go
+++ b/internal/carddav/server.go
@@ -226,7 +226,7 @@ func (s *Server) withLogging(next http.Handler) http.Handler {
 		s.logger.Info("carddav request",
 			"method", r.Method,
 			"path", r.URL.Path,
-			"duration", time.Since(start),
+			"duration", time.Since(start).Round(time.Millisecond),
 		)
 	})
 }

--- a/internal/logging/context.go
+++ b/internal/logging/context.go
@@ -1,5 +1,6 @@
-// Package logging provides self-managed log file rotation and
-// context-propagated structured logging for Thane.
+// Package logging provides self-managed log file rotation,
+// context-propagated structured logging, and a queryable SQLite
+// index for Thane.
 //
 // The [Rotator] implements [io.WriteCloser] and handles daily log
 // rotation with optional gzip compression of previous days' files.
@@ -18,6 +19,14 @@
 //
 // [ShortenSource] strips the module prefix from source file paths
 // when slog's AddSource option is enabled, keeping log lines compact.
+//
+// The [IndexHandler] wraps any [slog.Handler] and simultaneously
+// indexes every log record into a SQLite database. Promoted fields
+// (request_id, session_id, conversation_id, subsystem, tool, model)
+// are extracted into indexed columns for fast queries; remaining
+// attributes go into a JSON catch-all. Use [Prune] to manage index
+// retention while preserving the raw log files as the canonical
+// record.
 package logging
 
 import (

--- a/internal/logging/indexer.go
+++ b/internal/logging/indexer.go
@@ -240,6 +240,48 @@ func Migrate(db *sql.DB) error {
 	return nil
 }
 
+// Prune deletes log index entries older than maxAge for levels below
+// minLevel. For example, Prune(db, 90*24*time.Hour, slog.LevelInfo)
+// removes DEBUG and TRACE entries older than 90 days while keeping
+// INFO, WARN, and ERROR entries forever. The canonical raw log files
+// are unaffected — this only trims the queryable index.
+//
+// Returns the number of rows deleted.
+func Prune(db *sql.DB, maxAge time.Duration, minLevel slog.Level) (int64, error) {
+	cutoff := time.Now().Add(-maxAge).Format(time.RFC3339Nano)
+
+	// Collect level strings that should be pruned (levels below minLevel).
+	var levels []string
+	for _, l := range []slog.Level{slog.Level(-8), slog.LevelDebug} { // -8 = TRACE
+		if l < minLevel {
+			levels = append(levels, l.String())
+		}
+	}
+	if len(levels) == 0 {
+		return 0, nil
+	}
+
+	// Build placeholders for the IN clause.
+	placeholders := make([]string, len(levels))
+	args := make([]any, 0, len(levels)+1)
+	for i, l := range levels {
+		placeholders[i] = "?"
+		args = append(args, l)
+	}
+	args = append(args, cutoff)
+
+	query := fmt.Sprintf(
+		"DELETE FROM log_entries WHERE level IN (%s) AND timestamp < ?",
+		strings.Join(placeholders, ", "),
+	)
+
+	result, err := db.Exec(query, args...)
+	if err != nil {
+		return 0, fmt.Errorf("prune log index: %w", err)
+	}
+	return result.RowsAffected()
+}
+
 // drain runs in a goroutine, reading entries from the channel and
 // inserting them into SQLite. It exits when the channel is closed.
 func (h *IndexHandler) drain() {

--- a/internal/logging/indexer_test.go
+++ b/internal/logging/indexer_test.go
@@ -339,6 +339,85 @@ func TestMigrate_Idempotent(t *testing.T) {
 	}
 }
 
+func TestPrune_RemovesOldDebugEntries(t *testing.T) {
+	db := openTestDB(t)
+
+	// Insert entries at various levels with timestamps.
+	old := time.Now().Add(-100 * 24 * time.Hour).Format(time.RFC3339Nano)
+	recent := time.Now().Add(-1 * time.Hour).Format(time.RFC3339Nano)
+
+	for _, e := range []struct {
+		ts    string
+		level string
+		msg   string
+	}{
+		{old, "DEBUG", "old debug"},
+		{old, "INFO", "old info"},
+		{old, "ERROR", "old error"},
+		{recent, "DEBUG", "recent debug"},
+		{recent, "INFO", "recent info"},
+	} {
+		_, err := db.Exec(
+			`INSERT INTO log_entries (timestamp, level, msg) VALUES (?, ?, ?)`,
+			e.ts, e.level, e.msg,
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Prune DEBUG entries older than 90 days.
+	deleted, err := Prune(db, 90*24*time.Hour, slog.LevelInfo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if deleted != 1 {
+		t.Errorf("deleted = %d, want 1", deleted)
+	}
+
+	// Verify remaining entries.
+	var count int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM log_entries`).Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	if count != 4 {
+		t.Errorf("remaining = %d, want 4", count)
+	}
+
+	// Old INFO and ERROR should still be present.
+	var oldInfoCount int
+	if err := db.QueryRow(
+		`SELECT COUNT(*) FROM log_entries WHERE level = 'INFO' AND timestamp = ?`, old,
+	).Scan(&oldInfoCount); err != nil {
+		t.Fatal(err)
+	}
+	if oldInfoCount != 1 {
+		t.Errorf("old INFO entries = %d, want 1", oldInfoCount)
+	}
+}
+
+func TestPrune_NothingToPrune(t *testing.T) {
+	db := openTestDB(t)
+
+	// Insert only INFO entries.
+	_, err := db.Exec(
+		`INSERT INTO log_entries (timestamp, level, msg) VALUES (?, ?, ?)`,
+		time.Now().Add(-200*24*time.Hour).Format(time.RFC3339Nano), "INFO", "old info",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Prune DEBUG below INFO — should delete nothing.
+	deleted, err := Prune(db, 90*24*time.Hour, slog.LevelInfo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if deleted != 0 {
+		t.Errorf("deleted = %d, want 0", deleted)
+	}
+}
+
 // discardWriter is an io.Writer that discards all data.
 type discardWriter struct{}
 

--- a/internal/metacognitive/metacognitive.go
+++ b/internal/metacognitive/metacognitive.go
@@ -249,7 +249,7 @@ func (l *Loop) run(ctx context.Context) {
 			l.appendIterationLog(result, convID, sleep)
 		}
 
-		iterLog.Info("metacognitive sleeping", "duration", sleep)
+		iterLog.Info("metacognitive sleeping", "duration", sleep.Round(time.Second))
 
 		if !sleepCtx(ctx, sleep) {
 			logger.Info("metacognitive loop stopped")

--- a/internal/metacognitive/tool.go
+++ b/internal/metacognitive/tool.go
@@ -74,7 +74,7 @@ func (l *Loop) RegisterTools(registry *tools.Registry) {
 
 			l.setNextSleep(d)
 			l.deps.Logger.Info("metacognitive sleep set",
-				"duration", d,
+				"duration", d.Round(time.Second),
 				"reason", reason,
 			)
 

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -291,7 +291,7 @@ func (s *Scheduler) executeTask(ctx context.Context, task *Task, scheduledAt tim
 		"task_id", task.ID,
 		"execution_id", exec.ID,
 		"status", exec.Status,
-		"duration", completed.Sub(*exec.StartedAt),
+		"duration", completed.Sub(*exec.StartedAt).Round(time.Millisecond),
 	)
 
 	return exec, execErr

--- a/internal/server/api/ollama_server.go
+++ b/internal/server/api/ollama_server.go
@@ -109,7 +109,7 @@ func (s *OllamaServer) withLogging(next http.Handler) http.Handler {
 		s.logger.Info("ollama request",
 			"method", r.Method,
 			"path", r.URL.Path,
-			"duration", time.Since(start),
+			"duration", time.Since(start).Round(time.Millisecond),
 		)
 	})
 }

--- a/internal/server/api/server.go
+++ b/internal/server/api/server.go
@@ -319,7 +319,7 @@ func (s *Server) withLogging(next http.Handler) http.Handler {
 		s.logger.Info("request",
 			"method", r.Method,
 			"path", r.URL.Path,
-			"duration", time.Since(start),
+			"duration", time.Since(start).Round(time.Millisecond),
 		)
 	})
 }


### PR DESCRIPTION
Closes #420
Closes #502

## Summary

Final polish PR that wraps up both structured logging (#502) and execution traces (#420):

- **Duration rounding**: All `time.Duration` values in log output rounded to human-friendly precision — request/task durations to milliseconds, sleep/interval durations to seconds. Eliminates raw nanosecond values like `"duration":64279000000` across carddav, scheduler, API servers, and metacognitive loop
- **Index retention**: `Prune()` function for the SQLite log index — removes old DEBUG/TRACE entries beyond a configurable age while preserving INFO+ entries and raw log files forever
- **Package doc**: Updated to cover `IndexHandler` and `Prune`

## Files changed

| File | Change |
|------|--------|
| `internal/logging/context.go` | Package doc updated |
| `internal/logging/indexer.go` | Added `Prune()` function |
| `internal/logging/indexer_test.go` | Added prune tests (removes old DEBUG, preserves INFO/ERROR) |
| `internal/carddav/server.go` | Round request duration |
| `internal/scheduler/scheduler.go` | Round task execution duration |
| `internal/server/api/server.go` | Round request duration |
| `internal/server/api/ollama_server.go` | Round request duration |
| `internal/metacognitive/metacognitive.go` | Round sleep duration |
| `internal/metacognitive/tool.go` | Round sleep-set duration |

## Test plan
- [x] `just ci` passes (0 lint issues, all tests pass with `-race`)
- [ ] Verify no raw nanosecond durations in JSON log output
- [ ] Verify `Prune` correctly removes old DEBUG entries