### PR TITLE
fix: return interface type from newLogStore to avoid nil-interface panic

### DIFF
--- a/cmd/thane/main.go
+++ b/cmd/thane/main.go
@@ -2507,8 +2507,10 @@ func (a *logStoreAdapter) QueryBySession(sessionID, level, subsystem string, lim
 }
 
 // newLogStore returns a [web.LogStore] backed by the given database, or
-// nil when db is nil (log indexing disabled).
-func newLogStore(db *sql.DB) *logStoreAdapter {
+// nil when db is nil (log indexing disabled). The return type is the
+// interface itself so that a nil db produces a true nil interface value
+// rather than a non-nil interface wrapping a nil pointer.
+func newLogStore(db *sql.DB) web.LogStore {
 	if db == nil {
 		return nil
 	}


### PR DESCRIPTION
## Summary

- `newLogStore(nil)` returned a nil `*logStoreAdapter`, which when assigned to the `web.LogStore` interface field became a non-nil interface (type info present, value nil)
- This caused `s.logStore != nil` to always be true, `LogsEnabled` always true in the template, and a nil-pointer panic when `QueryBySession` was called without a database
- Fix: change return type from `*logStoreAdapter` to `web.LogStore` so `nil` produces a true nil interface

## Test plan

- [x] `just ci` passes
- [ ] Start without log indexing configured → session detail page should not show "Session Logs" card
- [ ] Start with log indexing → session detail page should show and load logs normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)