### PR TITLE
docs: v0.8.1 release preparation

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -481,6 +481,18 @@ Built-in operational visibility interface (`internal/server/web/`):
 
 Served on the same port as the native API (8080). Uses embedded HTML templates and static assets (htmx).
 
+The session detail page includes a **Session Logs** panel that queries the structured log index for entries matching that session's ID, with level and subsystem filters.
+
+### Structured Logging
+
+Three-layer logging infrastructure (`internal/logging/`):
+
+1. **Self-managed rotation** — `Rotator` implements `io.WriteCloser` with daily file rotation and optional gzip compression. No external log rotation tooling needed.
+2. **Context propagation** — `WithLogger`/`FromContext` thread a session-scoped logger through the call chain. Subsystem tags (`agent`, `delegate`, `metacog`, `scheduler`, `signal`, `api`) are attached automatically so every log line carries its origin.
+3. **SQLite index** — `IndexHandler` wraps the primary `slog.Handler` and asynchronously indexes every record into a `log_entries` table. Promoted fields (`session_id`, `conversation_id`, `subsystem`, `tool`, `model`, `level`) get their own indexed columns; remaining attributes go into a JSON catch-all.
+
+The index enables fast queries (by session, level, subsystem, time range) without parsing raw log files. A background pruner removes old DEBUG/TRACE entries based on a configurable retention policy (default: 7 days) while preserving raw log files as the canonical record.
+
 ## Technology Choices
 
 | Choice | Rationale |

--- a/examples/config.example.yaml
+++ b/examples/config.example.yaml
@@ -277,6 +277,7 @@ embeddings:
 #   level: info             # default: info
 #   format: json            # json (default) or text (human-readable)
 #   compress: true          # gzip rotated files; default: true
+#   retention_days: 7       # prune DEBUG/TRACE index entries older than N days; 0 = keep all
 #
 # DEPRECATED: log_level and log_format are still accepted at the top level
 # for backwards compatibility but will be removed in a future release.

--- a/internal/README.md
+++ b/internal/README.md
@@ -60,5 +60,6 @@ Thane's internal packages, organized by architectural role.
 | `usage/` | LLM token usage and cost tracking |
 | `httpkit/` | Shared HTTP client construction (User-Agent, timeouts) |
 | `connwatch/` | Service health monitoring with exponential backoff |
+| `logging/` | Self-managed log rotation, context-propagated structured logging, and queryable SQLite index |
 | `buildinfo/` | Build metadata injected via ldflags |
 | `paths/` | Named path prefix resolution (e.g., `kb:file.md`) |


### PR DESCRIPTION
## Summary

Documentation updates for the v0.8.1 release, covering the structured logging infrastructure added in PRs #521–#526.

- Add `retention_days` to `config.example.yaml` logging section
- Add `logging/` package to `internal/README.md` platform table
- Add **Structured Logging** subsection to ARCHITECTURE.md (rotation, context propagation, SQLite index, retention)
- Note Session Logs panel in Web Dashboard section

## Changes since v0.8.0

- **Self-managed log rotation** with daily rotation and optional gzip (#521)
- **Context-propagated structured logging** with subsystem tags and session correlation (#522)
- **SQLite log index** with promoted fields for fast queries (#523, #524)
- **Log index retention policy** with configurable pruning (default: 7 days for DEBUG/TRACE) (#525)
- **Session log viewer** in the web dashboard with level/subsystem filters (#525)
- **Email polling debug logging** for IMAP troubleshooting (#525)
- **Duration rounding** standardized to `Round(time.Second)` across logging (#524, #525)
- **Nil-interface fix** for `newLogStore` preventing panic when log indexing is disabled (#526)

## Release steps after merge

```bash
just release v0.8.1
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)