### PR TITLE
refactor: address thane-agent review feedback on provenance

### DIFF
--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -705,7 +705,7 @@ func (l *Loop) injectEgoFromProvenance(ctx context.Context, sb *strings.Builder,
 	if hist, err := l.provenanceStore.History(ctx, "ego.md"); err == nil && hist.RevisionCount > 0 {
 		ago := time.Since(hist.LastModified).Truncate(time.Second)
 		sb.WriteString(fmt.Sprintf("(updated %s ago by %s, revision %d)\n",
-			formatDeltaDuration(ago), hist.LastAuthor, hist.RevisionCount))
+			formatDeltaDuration(ago), hist.LastMessage, hist.RevisionCount))
 	}
 
 	sb.WriteString("\n")

--- a/internal/provenance/git.go
+++ b/internal/provenance/git.go
@@ -221,7 +221,7 @@ func (s *Store) fileHistory(ctx context.Context, filename string) (*FileHistory,
 
 	if len(edits) > 0 {
 		hist.LastModified = edits[0].Timestamp
-		hist.LastAuthor = edits[0].Message
+		hist.LastMessage = edits[0].Message
 	}
 
 	return hist, nil

--- a/internal/provenance/provenance.go
+++ b/internal/provenance/provenance.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	"golang.org/x/crypto/ssh"
@@ -53,7 +54,7 @@ func NewSSHFileSigner(keyPath string) (*SSHFileSigner, error) {
 		var ppErr *ssh.PassphraseMissingError
 		if errors.As(err, &ppErr) {
 			return nil, fmt.Errorf("provenance: signing key %s is passphrase-protected; "+
-				"use an unencrypted key or configure provenance.passphrase", keyPath)
+				"use an unencrypted key or load via ssh-agent", keyPath)
 		}
 		return nil, fmt.Errorf("provenance: parse signing key: %w", err)
 	}
@@ -119,9 +120,9 @@ type FileHistory struct {
 	// this file.
 	LastModified time.Time
 
-	// LastAuthor is the commit message of the most recent commit
+	// LastMessage is the commit message of the most recent commit
 	// (typically a loop name or conversation ID).
-	LastAuthor string
+	LastMessage string
 
 	// RevisionCount is the total number of commits touching this file.
 	RevisionCount int
@@ -140,7 +141,12 @@ type EditEntry struct {
 // Store wraps a git repository to provide signed, auditable file
 // management. Every [Store.Write] creates a signed git commit. Read and
 // History operations query the repository without modification.
+//
+// Store is safe for concurrent use; a mutex serializes git operations
+// to prevent interleaved add/commit sequences from corrupting the
+// repository.
 type Store struct {
+	mu     sync.Mutex
 	path   string
 	signer Signer
 	logger *slog.Logger
@@ -183,6 +189,9 @@ func (s *Store) Write(ctx context.Context, filename, content, message string) er
 	if err := validateFilename(filename); err != nil {
 		return fmt.Errorf("provenance: %w", err)
 	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
 
 	absPath := filepath.Join(s.path, filename)
 
@@ -236,6 +245,8 @@ func (s *Store) Read(filename string) (string, error) {
 // History returns git metadata for filename. If the file has no commits
 // yet, History returns a zero-value FileHistory with no error.
 func (s *Store) History(ctx context.Context, filename string) (*FileHistory, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	return s.fileHistory(ctx, filename)
 }
 

--- a/internal/provenance/provenance_test.go
+++ b/internal/provenance/provenance_test.go
@@ -141,8 +141,8 @@ func TestStoreHistory(t *testing.T) {
 		t.Errorf("RevisionCount = %d, want 3", hist.RevisionCount)
 	}
 
-	if hist.LastAuthor != "third-write" {
-		t.Errorf("LastAuthor = %q, want %q", hist.LastAuthor, "third-write")
+	if hist.LastMessage != "third-write" {
+		t.Errorf("LastMessage = %q, want %q", hist.LastMessage, "third-write")
 	}
 
 	if hist.LastModified.IsZero() {


### PR DESCRIPTION
## Summary
- Rename `FileHistory.LastAuthor` → `LastMessage` — the field holds the commit message (e.g., `loop-metacognitive-42`), not a committer identity
- Add `sync.Mutex` to `Store` to serialize git operations and prevent interleaved add/commit sequences from concurrent writers
- Fix passphrase error message to reference `ssh-agent` instead of nonexistent `provenance.passphrase` config field

Follow-up to #556 based on thane-agent's review.

## Test plan
- [x] `just ci` passes locally (0 lint issues, all tests pass with `-race`)
- [ ] CI passes on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)