### PR TITLE
feat: MQTT telemetry publishing for Home Assistant sensors

### DIFF
--- a/cmd/thane/main.go
+++ b/cmd/thane/main.go
@@ -72,6 +72,7 @@ import (
 	"github.com/nugget/thane-ai-agent/internal/server/api"
 	"github.com/nugget/thane-ai-agent/internal/server/web"
 	"github.com/nugget/thane-ai-agent/internal/talents"
+	"github.com/nugget/thane-ai-agent/internal/telemetry"
 	"github.com/nugget/thane-ai-agent/internal/tools"
 	"github.com/nugget/thane-ai-agent/internal/unifi"
 	"github.com/nugget/thane-ai-agent/internal/usage"
@@ -2561,6 +2562,75 @@ func runServe(ctx context.Context, stdout io.Writer, stderr io.Writer, configPat
 		})
 
 		logger.Info("mqtt AP presence sensors registered", "count", len(apSensors))
+	}
+
+	// --- MQTT telemetry ---
+	// When enabled, a dedicated loop collects operational metrics
+	// (DB sizes, token usage, loop states, sessions, request perf,
+	// attachments) and publishes them as native HA sensors.
+	if mqttPub != nil && cfg.MQTT.Telemetry.Enabled {
+		telBuilder := &telemetry.SensorBuilder{
+			InstanceID:        mqttInstanceID,
+			Prefix:            mqttPub.ObjectIDPrefix(),
+			StateTopicFn:      mqttPub.StateTopic,
+			AttributesTopicFn: mqttPub.AttributesTopic,
+			AvailabilityTopic: mqttPub.AvailabilityTopic(),
+			Device:            mqttPub.Device(),
+		}
+
+		mqttPub.RegisterSensors(telBuilder.StaticSensors())
+
+		dbPaths := map[string]string{
+			"main":  filepath.Join(cfg.DataDir, "thane.db"),
+			"usage": filepath.Join(cfg.DataDir, "usage.db"),
+		}
+		if logDir := cfg.Logging.DirPath(); logDir != "" {
+			dbPaths["logs"] = filepath.Join(logDir, "logs.db")
+		}
+		if cfg.Attachments.StoreDir != "" {
+			dbPaths["attachments"] = filepath.Join(cfg.DataDir, "attachments.db")
+		}
+
+		telSources := telemetry.Sources{
+			LoopRegistry: loopRegistry,
+			UsageStore:   usageStore,
+			ArchiveStore: archiveStore,
+			LogsDB:       indexDB,
+			DBPaths:      dbPaths,
+			Logger:       logger,
+		}
+		if attachmentStore != nil {
+			telSources.AttachmentSource = attachmentStore
+		}
+
+		telCollector := telemetry.NewCollector(telSources)
+		telPub := telemetry.NewPublisher(telCollector, mqttPub, telBuilder, logger)
+
+		telInterval := time.Duration(cfg.MQTT.Telemetry.Interval) * time.Second
+		if _, err := loopRegistry.SpawnLoop(ctx, looppkg.Config{
+			Name:         "mqtt-telemetry",
+			SleepMin:     telInterval,
+			SleepMax:     telInterval,
+			SleepDefault: telInterval,
+			Jitter:       looppkg.Float64Ptr(0),
+			Handler: func(ctx context.Context, _ any) error {
+				return telPub.Publish(ctx)
+			},
+			Metadata: map[string]string{
+				"subsystem": "mqtt",
+				"category":  "telemetry",
+			},
+		}, looppkg.Deps{
+			Logger:   logger,
+			EventBus: eventBus,
+		}); err != nil {
+			return fmt.Errorf("spawn mqtt-telemetry loop: %w", err)
+		}
+
+		logger.Info("mqtt telemetry enabled",
+			"interval", cfg.MQTT.Telemetry.Interval,
+			"db_paths", len(dbPaths),
+		)
 	}
 
 	// --- Loop visualizer ---

--- a/examples/config.example.yaml
+++ b/examples/config.example.yaml
@@ -77,6 +77,9 @@ models:
 #   discovery_prefix: homeassistant    # default
 #   device_name: thane-ai-agent        # unique name for this instance
 #   publish_interval: 60               # seconds, default
+#   telemetry:                         # operational metric publishing
+#     enabled: true                    # publish system health, token usage, loops, etc.
+#     interval: 60                     # seconds between telemetry publishes (min 10)
 #   subscriptions:                     # topics to subscribe for ambient awareness
 #     - topic: homeassistant/+/+/state   # HA entity state changes
 #     - topic: frigate/events            # Frigate camera events

--- a/internal/attachments/store.go
+++ b/internal/attachments/store.go
@@ -431,6 +431,16 @@ func (s *Store) Search(ctx context.Context, params SearchParams) ([]*Record, err
 	return records, nil
 }
 
+// TelemetryStats returns aggregate attachment statistics for
+// operational dashboards. The three counts (total records, total bytes,
+// unique content hashes) are computed in a single query.
+func (s *Store) TelemetryStats(ctx context.Context) (total, totalBytes, unique int64, err error) {
+	err = s.db.QueryRowContext(ctx,
+		`SELECT COUNT(*), COALESCE(SUM(size), 0), COUNT(DISTINCT hash) FROM attachments`,
+	).Scan(&total, &totalBytes, &unique)
+	return
+}
+
 // Close closes the underlying database connection.
 func (s *Store) Close() error {
 	return s.db.Close()

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -796,6 +796,11 @@ type MQTTConfig struct {
 	// acted upon. Future phases will route messages to the anticipation
 	// engine. Supports MQTT wildcard characters (+ and #).
 	Subscriptions []SubscriptionConfig `yaml:"subscriptions"`
+
+	// Telemetry configures operational metric publishing. When enabled,
+	// a separate mqtt-telemetry loop publishes system health, token usage,
+	// loop states, and other operational data as native HA sensors.
+	Telemetry TelemetryConfig `yaml:"telemetry"`
 }
 
 // SubscriptionConfig describes a single MQTT topic subscription.
@@ -805,6 +810,20 @@ type SubscriptionConfig struct {
 	// Topic is the MQTT topic filter (e.g., "homeassistant/+/+/state",
 	// "frigate/events"). Supports MQTT wildcard characters.
 	Topic string `yaml:"topic"`
+}
+
+// TelemetryConfig configures MQTT telemetry publishing. When Enabled
+// is true and MQTT is configured, a dedicated loop publishes
+// operational metrics (DB sizes, token usage, loop states, etc.) as
+// native Home Assistant sensors via MQTT Discovery.
+type TelemetryConfig struct {
+	// Enabled activates the mqtt-telemetry loop. Requires MQTT to be
+	// configured (broker + device_name).
+	Enabled bool `yaml:"enabled"`
+
+	// Interval is how often (in seconds) telemetry metrics are
+	// collected and published. Default: 60. Minimum: 10.
+	Interval int `yaml:"interval"`
 }
 
 // Configured reports whether both Broker and DeviceName are set. A
@@ -1348,6 +1367,9 @@ func (c *Config) applyDefaults() {
 	if c.MQTT.PublishIntervalSec == 0 {
 		c.MQTT.PublishIntervalSec = 60
 	}
+	if c.MQTT.Telemetry.Interval == 0 {
+		c.MQTT.Telemetry.Interval = 60
+	}
 
 	if c.Unifi.PollIntervalSec == 0 {
 		c.Unifi.PollIntervalSec = 30
@@ -1585,6 +1607,9 @@ func (c *Config) Validate() error {
 			if sub.Topic == "" {
 				return fmt.Errorf("mqtt.subscriptions[%d].topic must not be empty", i)
 			}
+		}
+		if c.MQTT.Telemetry.Enabled && c.MQTT.Telemetry.Interval < 10 {
+			return fmt.Errorf("mqtt.telemetry.interval %d too low (minimum 10 seconds)", c.MQTT.Telemetry.Interval)
 		}
 	}
 	if err := c.validateSubscribe(); err != nil {

--- a/internal/memory/archive.go
+++ b/internal/memory/archive.go
@@ -1668,6 +1668,16 @@ func (s *ArchiveStore) ActiveSession(conversationID string) (*Session, error) {
 	return sess, err
 }
 
+// ActiveSessionCount returns the number of unclosed (active) sessions.
+// This is a lightweight query for telemetry dashboards — use
+// [ArchiveStore.ActiveSessionsWithLastActivity] when per-session
+// details are needed.
+func (s *ArchiveStore) ActiveSessionCount() (int, error) {
+	var count int
+	err := s.db.QueryRow(`SELECT COUNT(*) FROM sessions WHERE ended_at IS NULL`).Scan(&count)
+	return count, err
+}
+
 // ActiveSessionsWithLastActivity returns all unclosed sessions and the
 // timestamp of the most recent message in each. Sessions with no messages
 // use the session's started_at as the last activity time. This powers the

--- a/internal/telemetry/collector.go
+++ b/internal/telemetry/collector.go
@@ -1,0 +1,284 @@
+package telemetry
+
+import (
+	"context"
+	"database/sql"
+	"log/slog"
+	"math"
+	"os"
+	"sort"
+	"time"
+
+	"github.com/nugget/thane-ai-agent/internal/loop"
+	"github.com/nugget/thane-ai-agent/internal/usage"
+)
+
+// ArchiveSource provides active session counts for telemetry without
+// coupling this package to the full memory package.
+type ArchiveSource interface {
+	ActiveSessionCount() (int, error)
+}
+
+// AttachmentSource provides aggregate attachment statistics without
+// coupling this package to the full attachments package.
+type AttachmentSource interface {
+	TelemetryStats(ctx context.Context) (total, totalBytes, unique int64, err error)
+}
+
+// Sources holds references to all subsystems that provide telemetry
+// data. Nil sources are handled gracefully — the corresponding
+// metrics are reported as zero.
+type Sources struct {
+	LoopRegistry     *loop.Registry
+	UsageStore       *usage.Store
+	ArchiveStore     ArchiveSource
+	LogsDB           *sql.DB
+	AttachmentSource AttachmentSource
+	DBPaths          map[string]string // name → file path for os.Stat
+	Logger           *slog.Logger
+}
+
+// Collector aggregates operational metrics from multiple subsystems.
+// All collection methods are safe for concurrent use — each call
+// produces an independent [Metrics] snapshot.
+type Collector struct {
+	src Sources
+}
+
+// NewCollector creates a Collector backed by the given sources.
+func NewCollector(src Sources) *Collector {
+	if src.Logger == nil {
+		src.Logger = slog.Default()
+	}
+	return &Collector{src: src}
+}
+
+// Collect gathers a point-in-time snapshot of all operational metrics.
+// Individual subsystem failures are logged and result in zero values
+// for the affected metrics — collection never returns an error.
+func (c *Collector) Collect(ctx context.Context) *Metrics {
+	m := &Metrics{
+		CollectedAt: time.Now().UTC(),
+		DBSizes:     make(map[string]int64),
+	}
+
+	c.collectDBSizes(m)
+	c.collectTokens(ctx, m)
+	c.collectSessions(m)
+	c.collectLoops(m)
+	c.collectRequests(ctx, m)
+	c.collectAttachments(ctx, m)
+
+	return m
+}
+
+// collectDBSizes stat's each configured database file.
+func (c *Collector) collectDBSizes(m *Metrics) {
+	for name, path := range c.src.DBPaths {
+		if path == "" {
+			continue
+		}
+		info, err := os.Stat(path)
+		if err != nil {
+			// File may not exist yet — normal for optional subsystems.
+			continue
+		}
+		m.DBSizes[name] = info.Size()
+	}
+}
+
+// collectTokens queries 24h rolling token usage.
+func (c *Collector) collectTokens(ctx context.Context, m *Metrics) {
+	if c.src.UsageStore == nil {
+		return
+	}
+	_ = ctx // usage.Store methods don't take ctx yet
+
+	now := time.Now().UTC()
+	start := now.Add(-24 * time.Hour)
+
+	summary, err := c.src.UsageStore.Summary(start, now)
+	if err != nil {
+		c.src.Logger.Warn("telemetry: token summary failed", "error", err)
+		return
+	}
+	m.TokensInput = summary.TotalInputTokens
+	m.TokensOutput = summary.TotalOutputTokens
+	m.TokensCost = summary.TotalCostUSD
+
+	byModel, err := c.src.UsageStore.SummaryByModel(start, now)
+	if err != nil {
+		c.src.Logger.Warn("telemetry: token by-model failed", "error", err)
+		return
+	}
+	if len(byModel) > 0 {
+		m.TokensByModel = make(map[string]ModelTokens, len(byModel))
+		for _, gs := range byModel {
+			m.TokensByModel[gs.Key] = ModelTokens{
+				Input:  gs.Summary.TotalInputTokens,
+				Output: gs.Summary.TotalOutputTokens,
+				Cost:   gs.Summary.TotalCostUSD,
+			}
+		}
+	}
+}
+
+// collectSessions counts active sessions and estimates context utilization.
+func (c *Collector) collectSessions(m *Metrics) {
+	if c.src.ArchiveStore != nil {
+		count, err := c.src.ArchiveStore.ActiveSessionCount()
+		if err != nil {
+			c.src.Logger.Warn("telemetry: active session count failed", "error", err)
+		} else {
+			m.ActiveSessions = count
+		}
+	}
+
+	// Context utilization: find the main interactive loop and compute
+	// token usage as a percentage of context window.
+	if c.src.LoopRegistry != nil {
+		for _, status := range c.src.LoopRegistry.Statuses() {
+			if status.Name == "interactive" && status.ContextWindow > 0 {
+				m.ContextUtilization = float64(status.TotalInputTokens+status.TotalOutputTokens) /
+					float64(status.ContextWindow) * 100
+				if m.ContextUtilization > 100 {
+					m.ContextUtilization = 100
+				}
+				break
+			}
+		}
+	}
+}
+
+// collectLoops gathers loop registry status.
+func (c *Collector) collectLoops(m *Metrics) {
+	if c.src.LoopRegistry == nil {
+		return
+	}
+
+	statuses := c.src.LoopRegistry.Statuses()
+	m.LoopsTotal = len(statuses)
+	m.LoopDetails = make([]LoopMetric, len(statuses))
+
+	for i, s := range statuses {
+		m.LoopDetails[i] = LoopMetric{
+			Name:       s.Name,
+			State:      string(s.State),
+			Iterations: s.Iterations,
+		}
+
+		switch s.State {
+		case loop.StateProcessing:
+			m.LoopsActive++
+		case loop.StateSleeping, loop.StateWaiting:
+			m.LoopsSleeping++
+		case loop.StateError:
+			m.LoopsErrored++
+		}
+	}
+}
+
+// collectRequests queries the log index for 24h request and error counts,
+// and computes approximate p50/p95 latencies from request durations.
+func (c *Collector) collectRequests(ctx context.Context, m *Metrics) {
+	if c.src.LogsDB == nil {
+		return
+	}
+
+	now := time.Now().UTC()
+	since := now.Add(-24 * time.Hour).Format(time.RFC3339)
+
+	// Count distinct request IDs (non-empty) in the last 24h.
+	var reqCount int
+	err := c.src.LogsDB.QueryRowContext(ctx,
+		`SELECT COUNT(DISTINCT request_id) FROM log_entries
+		 WHERE request_id != '' AND timestamp >= ?`, since,
+	).Scan(&reqCount)
+	if err != nil {
+		c.src.Logger.Warn("telemetry: request count query failed", "error", err)
+	}
+	m.Requests24h = reqCount
+
+	// Count error-level entries in the last 24h.
+	var errCount int
+	err = c.src.LogsDB.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM log_entries
+		 WHERE level = 'ERROR' AND timestamp >= ?`, since,
+	).Scan(&errCount)
+	if err != nil {
+		c.src.Logger.Warn("telemetry: error count query failed", "error", err)
+	}
+	m.Errors24h = errCount
+
+	// Compute request latencies: for each request_id, duration = max(ts) - min(ts).
+	rows, err := c.src.LogsDB.QueryContext(ctx,
+		`SELECT request_id, MIN(timestamp), MAX(timestamp)
+		 FROM log_entries
+		 WHERE request_id != '' AND timestamp >= ?
+		 GROUP BY request_id
+		 HAVING COUNT(*) > 1`, since,
+	)
+	if err != nil {
+		c.src.Logger.Warn("telemetry: latency query failed", "error", err)
+		return
+	}
+	defer rows.Close()
+
+	var durations []float64
+	for rows.Next() {
+		var reqID, minTS, maxTS string
+		if err := rows.Scan(&reqID, &minTS, &maxTS); err != nil {
+			continue
+		}
+		tMin, err1 := time.Parse(time.RFC3339Nano, minTS)
+		tMax, err2 := time.Parse(time.RFC3339Nano, maxTS)
+		if err1 != nil || err2 != nil {
+			continue
+		}
+		ms := tMax.Sub(tMin).Seconds() * 1000
+		if ms > 0 {
+			durations = append(durations, ms)
+		}
+	}
+
+	if len(durations) > 0 {
+		sort.Float64s(durations)
+		m.LatencyP50Ms = percentile(durations, 50)
+		m.LatencyP95Ms = percentile(durations, 95)
+	}
+}
+
+// percentile computes the p-th percentile of sorted data using linear
+// interpolation.
+func percentile(sorted []float64, p float64) float64 {
+	if len(sorted) == 0 {
+		return 0
+	}
+	if len(sorted) == 1 {
+		return sorted[0]
+	}
+	rank := p / 100 * float64(len(sorted)-1)
+	lower := int(math.Floor(rank))
+	upper := lower + 1
+	if upper >= len(sorted) {
+		return sorted[len(sorted)-1]
+	}
+	frac := rank - float64(lower)
+	return sorted[lower] + frac*(sorted[upper]-sorted[lower])
+}
+
+// collectAttachments queries aggregate attachment store statistics.
+func (c *Collector) collectAttachments(ctx context.Context, m *Metrics) {
+	if c.src.AttachmentSource == nil {
+		return
+	}
+
+	total, totalBytes, unique, err := c.src.AttachmentSource.TelemetryStats(ctx)
+	if err != nil {
+		c.src.Logger.Warn("telemetry: attachment stats failed", "error", err)
+		return
+	}
+	m.AttachmentsTotal = total
+	m.AttachmentsTotalBytes = totalBytes
+	m.AttachmentsUnique = unique
+}

--- a/internal/telemetry/collector_test.go
+++ b/internal/telemetry/collector_test.go
@@ -1,0 +1,218 @@
+package telemetry
+
+import (
+	"context"
+	"database/sql"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	_ "github.com/mattn/go-sqlite3"
+)
+
+// mockArchiveSource implements ArchiveSource for testing.
+type mockArchiveSource struct {
+	count int
+	err   error
+}
+
+func (m *mockArchiveSource) ActiveSessionCount() (int, error) {
+	return m.count, m.err
+}
+
+// mockAttachmentSource implements AttachmentSource for testing.
+type mockAttachmentSource struct {
+	total, totalBytes, unique int64
+	err                       error
+}
+
+func (m *mockAttachmentSource) TelemetryStats(_ context.Context) (int64, int64, int64, error) {
+	return m.total, m.totalBytes, m.unique, m.err
+}
+
+func TestCollect_AllNilSources(t *testing.T) {
+	c := NewCollector(Sources{
+		Logger: slog.New(slog.NewTextHandler(os.Stderr, nil)),
+	})
+
+	m := c.Collect(context.Background())
+	if m == nil {
+		t.Fatal("expected non-nil metrics")
+	}
+	if m.CollectedAt.IsZero() {
+		t.Error("CollectedAt should be set")
+	}
+	if m.LoopsTotal != 0 {
+		t.Errorf("LoopsTotal = %d, want 0", m.LoopsTotal)
+	}
+	if m.ActiveSessions != 0 {
+		t.Errorf("ActiveSessions = %d, want 0", m.ActiveSessions)
+	}
+}
+
+func TestCollect_DBSizes(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create a test file with known size.
+	dbFile := filepath.Join(dir, "test.db")
+	if err := os.WriteFile(dbFile, make([]byte, 4096), 0o640); err != nil {
+		t.Fatal(err)
+	}
+
+	c := NewCollector(Sources{
+		DBPaths: map[string]string{
+			"main":    dbFile,
+			"missing": filepath.Join(dir, "nonexistent.db"),
+		},
+		Logger: slog.New(slog.NewTextHandler(os.Stderr, nil)),
+	})
+
+	m := c.Collect(context.Background())
+	if m.DBSizes["main"] != 4096 {
+		t.Errorf("DBSizes[main] = %d, want 4096", m.DBSizes["main"])
+	}
+	if m.DBSizes["missing"] != 0 {
+		t.Errorf("DBSizes[missing] = %d, want 0 (file doesn't exist)", m.DBSizes["missing"])
+	}
+}
+
+func TestCollect_Sessions(t *testing.T) {
+	c := NewCollector(Sources{
+		ArchiveStore: &mockArchiveSource{count: 3},
+		Logger:       slog.New(slog.NewTextHandler(os.Stderr, nil)),
+	})
+
+	m := c.Collect(context.Background())
+	if m.ActiveSessions != 3 {
+		t.Errorf("ActiveSessions = %d, want 3", m.ActiveSessions)
+	}
+}
+
+func TestCollect_Attachments(t *testing.T) {
+	c := NewCollector(Sources{
+		AttachmentSource: &mockAttachmentSource{
+			total:      42,
+			totalBytes: 1024 * 1024,
+			unique:     30,
+		},
+		Logger: slog.New(slog.NewTextHandler(os.Stderr, nil)),
+	})
+
+	m := c.Collect(context.Background())
+	if m.AttachmentsTotal != 42 {
+		t.Errorf("AttachmentsTotal = %d, want 42", m.AttachmentsTotal)
+	}
+	if m.AttachmentsTotalBytes != 1024*1024 {
+		t.Errorf("AttachmentsTotalBytes = %d, want 1048576", m.AttachmentsTotalBytes)
+	}
+	if m.AttachmentsUnique != 30 {
+		t.Errorf("AttachmentsUnique = %d, want 30", m.AttachmentsUnique)
+	}
+}
+
+func TestCollect_Requests(t *testing.T) {
+	db := openTestLogsDB(t)
+
+	now := time.Now().UTC()
+	// Insert log entries for two requests.
+	for _, e := range []struct {
+		reqID string
+		ts    time.Time
+		level string
+	}{
+		{"req-1", now.Add(-1 * time.Hour), "INFO"},
+		{"req-1", now.Add(-1*time.Hour + 500*time.Millisecond), "INFO"},
+		{"req-2", now.Add(-30 * time.Minute), "INFO"},
+		{"req-2", now.Add(-30*time.Minute + 2*time.Second), "INFO"},
+		{"", now.Add(-10 * time.Minute), "ERROR"}, // error without request_id
+		{"req-3", now.Add(-5 * time.Minute), "ERROR"},
+	} {
+		_, err := db.Exec(
+			`INSERT INTO log_entries (timestamp, level, msg, request_id, session_id, conversation_id, subsystem, tool, model)
+			 VALUES (?, ?, 'test', ?, '', '', '', '', '')`,
+			e.ts.Format(time.RFC3339Nano), e.level, e.reqID,
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	c := NewCollector(Sources{
+		LogsDB: db,
+		Logger: slog.New(slog.NewTextHandler(os.Stderr, nil)),
+	})
+
+	m := c.Collect(context.Background())
+
+	// 3 distinct request IDs.
+	if m.Requests24h != 3 {
+		t.Errorf("Requests24h = %d, want 3", m.Requests24h)
+	}
+
+	// 2 error entries (one without request_id, one with req-3).
+	if m.Errors24h != 2 {
+		t.Errorf("Errors24h = %d, want 2", m.Errors24h)
+	}
+
+	// Latency: req-1 = 500ms, req-2 = 2000ms. req-3 has only 1 entry
+	// so it's excluded from latency (HAVING COUNT(*) > 1).
+	// p50 of [500, 2000] = 500 + 0.5*(2000-500) = 1250.
+	if m.LatencyP50Ms < 1200 || m.LatencyP50Ms > 1300 {
+		t.Errorf("LatencyP50Ms = %.1f, want ~1250", m.LatencyP50Ms)
+	}
+}
+
+func TestPercentile(t *testing.T) {
+	tests := []struct {
+		name   string
+		data   []float64
+		p      float64
+		wantLo float64
+		wantHi float64
+	}{
+		{"empty", nil, 50, 0, 0},
+		{"single", []float64{100}, 50, 100, 100},
+		{"two values p50", []float64{100, 200}, 50, 140, 160},
+		{"three values p95", []float64{10, 20, 30}, 95, 28, 30},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := percentile(tt.data, tt.p)
+			if got < tt.wantLo || got > tt.wantHi {
+				t.Errorf("percentile(%v, %.0f) = %.1f, want [%.1f, %.1f]",
+					tt.data, tt.p, got, tt.wantLo, tt.wantHi)
+			}
+		})
+	}
+}
+
+// openTestLogsDB creates an in-memory SQLite database with the
+// log_entries schema matching the logging indexer.
+func openTestLogsDB(t *testing.T) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("sqlite3", ":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { db.Close() })
+
+	_, err = db.Exec(`CREATE TABLE log_entries (
+		id INTEGER PRIMARY KEY AUTOINCREMENT,
+		timestamp TEXT NOT NULL,
+		level TEXT NOT NULL DEFAULT '',
+		msg TEXT NOT NULL DEFAULT '',
+		request_id TEXT NOT NULL DEFAULT '',
+		session_id TEXT NOT NULL DEFAULT '',
+		conversation_id TEXT NOT NULL DEFAULT '',
+		subsystem TEXT NOT NULL DEFAULT '',
+		tool TEXT NOT NULL DEFAULT '',
+		model TEXT NOT NULL DEFAULT ''
+	)`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return db
+}

--- a/internal/telemetry/metrics.go
+++ b/internal/telemetry/metrics.go
@@ -1,0 +1,61 @@
+// Package telemetry collects and publishes operational metrics via
+// MQTT for Home Assistant sensor integration. Metrics include system
+// health (DB sizes), token usage, active sessions, request performance,
+// loop states, and attachment store statistics.
+package telemetry
+
+import "time"
+
+// Metrics holds a point-in-time snapshot of all collected operational
+// metrics. The zero value is safe — nil maps and zero counts produce
+// valid (empty) sensor states.
+type Metrics struct {
+	CollectedAt time.Time
+
+	// System health — database file sizes in bytes.
+	DBSizes map[string]int64
+
+	// Token usage (24h rolling window).
+	TokensInput   int64
+	TokensOutput  int64
+	TokensCost    float64
+	TokensByModel map[string]ModelTokens
+
+	// Sessions & context.
+	ActiveSessions     int
+	ContextUtilization float64 // 0–100 percentage
+
+	// Request performance (24h rolling window).
+	Requests24h  int
+	Errors24h    int
+	LatencyP50Ms float64
+	LatencyP95Ms float64
+
+	// Loop aggregate counts.
+	LoopsActive   int
+	LoopsSleeping int
+	LoopsErrored  int
+	LoopsTotal    int
+	LoopDetails   []LoopMetric
+
+	// Attachment store.
+	AttachmentsTotal      int64
+	AttachmentsTotalBytes int64
+	AttachmentsUnique     int64
+}
+
+// LoopMetric captures the state and iteration count for a single
+// registered loop.
+type LoopMetric struct {
+	Name       string
+	State      string
+	Iterations int
+}
+
+// ModelTokens holds per-model token usage for the 24h window. Used
+// as JSON attributes on the tokens_24h_cost sensor.
+type ModelTokens struct {
+	Input  int64   `json:"input"`
+	Output int64   `json:"output"`
+	Cost   float64 `json:"cost"`
+}

--- a/internal/telemetry/publisher.go
+++ b/internal/telemetry/publisher.go
@@ -1,0 +1,180 @@
+package telemetry
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"strconv"
+	"sync"
+
+	"github.com/nugget/thane-ai-agent/internal/channels/mqtt"
+)
+
+// MQTTPublisher is the subset of [mqtt.Publisher] used by the
+// telemetry publisher. Defined as an interface for testability.
+type MQTTPublisher interface {
+	PublishDynamicState(ctx context.Context, entitySuffix, state string, attrJSON []byte) error
+	RegisterSensors(sensors []mqtt.DynamicSensor)
+}
+
+// Publisher bridges collected metrics to MQTT state publishing. On
+// each call to [Publisher.Publish], it collects fresh metrics and
+// publishes state values for every registered telemetry sensor.
+// New loops discovered at publish time are registered as dynamic
+// sensors automatically.
+type Publisher struct {
+	collector *Collector
+	mqtt      MQTTPublisher
+	builder   *SensorBuilder
+	logger    *slog.Logger
+
+	mu         sync.Mutex
+	knownLoops map[string]bool
+}
+
+// NewPublisher creates a telemetry publisher that collects metrics via
+// the given collector and publishes them through the MQTT publisher.
+func NewPublisher(collector *Collector, mqttPub MQTTPublisher, builder *SensorBuilder, logger *slog.Logger) *Publisher {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Publisher{
+		collector:  collector,
+		mqtt:       mqttPub,
+		builder:    builder,
+		logger:     logger,
+		knownLoops: make(map[string]bool),
+	}
+}
+
+// Publish collects a fresh metrics snapshot and publishes all sensor
+// states to MQTT. Called by the mqtt-telemetry loop handler on each
+// iteration.
+func (p *Publisher) Publish(ctx context.Context) error {
+	m := p.collector.Collect(ctx)
+
+	// Track publish errors but don't abort — publish as many as possible.
+	var errs int
+
+	// System health — DB sizes.
+	for _, db := range []struct{ name, suffix string }{
+		{"main", "db_main_size"},
+		{"logs", "db_logs_size"},
+		{"usage", "db_usage_size"},
+		{"attachments", "db_attachments_size"},
+	} {
+		val := m.DBSizes[db.name]
+		if err := p.publish(ctx, db.suffix, strconv.FormatInt(val, 10)); err != nil {
+			errs++
+		}
+	}
+
+	// Token usage.
+	p.publishInt64(ctx, "tokens_24h_input", m.TokensInput, &errs)
+	p.publishInt64(ctx, "tokens_24h_output", m.TokensOutput, &errs)
+
+	costStr := strconv.FormatFloat(m.TokensCost, 'f', 4, 64)
+	if err := p.publish(ctx, "tokens_24h_cost", costStr); err != nil {
+		errs++
+	} else if len(m.TokensByModel) > 0 {
+		// Publish per-model breakdown as attributes.
+		attrs, err := json.Marshal(m.TokensByModel)
+		if err == nil {
+			_ = p.publishWithAttrs(ctx, "tokens_24h_cost", costStr, attrs)
+		}
+	}
+
+	// Sessions & context.
+	p.publishInt(ctx, "active_sessions", m.ActiveSessions, &errs)
+
+	utilStr := strconv.FormatFloat(m.ContextUtilization, 'f', 1, 64)
+	if err := p.publish(ctx, "context_utilization", utilStr); err != nil {
+		errs++
+	}
+
+	// Request performance.
+	p.publishInt(ctx, "requests_24h", m.Requests24h, &errs)
+	p.publishInt(ctx, "errors_24h", m.Errors24h, &errs)
+	p.publishFloat(ctx, "request_latency_p50", m.LatencyP50Ms, &errs)
+	p.publishFloat(ctx, "request_latency_p95", m.LatencyP95Ms, &errs)
+
+	// Loop aggregates.
+	p.publishInt(ctx, "loops_active", m.LoopsActive, &errs)
+	p.publishInt(ctx, "loops_sleeping", m.LoopsSleeping, &errs)
+	p.publishInt(ctx, "loops_errored", m.LoopsErrored, &errs)
+	p.publishInt(ctx, "loops_total", m.LoopsTotal, &errs)
+
+	// Per-loop sensors.
+	p.publishLoopDetails(ctx, m.LoopDetails, &errs)
+
+	// Attachment store.
+	p.publishInt64(ctx, "attachments_total", m.AttachmentsTotal, &errs)
+	p.publishInt64(ctx, "attachments_total_bytes", m.AttachmentsTotalBytes, &errs)
+	p.publishInt64(ctx, "attachments_unique_files", m.AttachmentsUnique, &errs)
+
+	if errs > 0 {
+		return fmt.Errorf("telemetry: %d publish errors", errs)
+	}
+	return nil
+}
+
+// publishLoopDetails publishes per-loop state and iteration sensors.
+// New loops are detected and their sensors registered dynamically.
+func (p *Publisher) publishLoopDetails(ctx context.Context, details []LoopMetric, errs *int) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	for _, lm := range details {
+		// Register sensors for newly discovered loops.
+		if !p.knownLoops[lm.Name] {
+			p.knownLoops[lm.Name] = true
+			sensors := p.builder.LoopSensors(lm.Name)
+			p.mqtt.RegisterSensors(sensors)
+			p.logger.Info("telemetry: registered loop sensors",
+				"loop", lm.Name, "sensors", len(sensors))
+		}
+
+		stateSuffix := "loop_" + lm.Name + "_state"
+		iterSuffix := "loop_" + lm.Name + "_iterations"
+
+		if err := p.publish(ctx, stateSuffix, lm.State); err != nil {
+			*errs++
+		}
+		if err := p.publish(ctx, iterSuffix, strconv.Itoa(lm.Iterations)); err != nil {
+			*errs++
+		}
+	}
+}
+
+// publish publishes a state value for the given entity suffix.
+func (p *Publisher) publish(ctx context.Context, entity, state string) error {
+	if err := p.mqtt.PublishDynamicState(ctx, entity, state, nil); err != nil {
+		p.logger.Debug("telemetry publish failed", "entity", entity, "error", err)
+		return err
+	}
+	return nil
+}
+
+// publishWithAttrs publishes state and JSON attributes.
+func (p *Publisher) publishWithAttrs(ctx context.Context, entity, state string, attrs []byte) error {
+	return p.mqtt.PublishDynamicState(ctx, entity, state, attrs)
+}
+
+func (p *Publisher) publishInt(ctx context.Context, entity string, val int, errs *int) {
+	if err := p.publish(ctx, entity, strconv.Itoa(val)); err != nil {
+		*errs++
+	}
+}
+
+func (p *Publisher) publishInt64(ctx context.Context, entity string, val int64, errs *int) {
+	if err := p.publish(ctx, entity, strconv.FormatInt(val, 10)); err != nil {
+		*errs++
+	}
+}
+
+func (p *Publisher) publishFloat(ctx context.Context, entity string, val float64, errs *int) {
+	if err := p.publish(ctx, entity, strconv.FormatFloat(val, 'f', 1, 64)); err != nil {
+		*errs++
+	}
+}

--- a/internal/telemetry/publisher_test.go
+++ b/internal/telemetry/publisher_test.go
@@ -1,0 +1,207 @@
+package telemetry
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"strconv"
+	"sync"
+	"testing"
+
+	"github.com/nugget/thane-ai-agent/internal/channels/mqtt"
+)
+
+// mockMQTT captures published sensor states for verification.
+type mockMQTT struct {
+	mu      sync.Mutex
+	states  map[string]string // entity → state value
+	attrs   map[string][]byte // entity → attribute JSON
+	sensors []mqtt.DynamicSensor
+}
+
+func newMockMQTT() *mockMQTT {
+	return &mockMQTT{
+		states: make(map[string]string),
+		attrs:  make(map[string][]byte),
+	}
+}
+
+func (m *mockMQTT) PublishDynamicState(_ context.Context, entity, state string, attrJSON []byte) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.states[entity] = state
+	if len(attrJSON) > 0 {
+		m.attrs[entity] = attrJSON
+	}
+	return nil
+}
+
+func (m *mockMQTT) RegisterSensors(sensors []mqtt.DynamicSensor) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.sensors = append(m.sensors, sensors...)
+}
+
+func testBuilder() *SensorBuilder {
+	return &SensorBuilder{
+		InstanceID:        "test-instance",
+		Prefix:            "thane_test_",
+		StateTopicFn:      func(s string) string { return "thane/test/" + s + "/state" },
+		AttributesTopicFn: func(s string) string { return "thane/test/" + s + "/attributes" },
+		AvailabilityTopic: "thane/test/availability",
+		Device:            mqtt.DeviceInfo{Name: "test"},
+	}
+}
+
+func TestPublish_PublishesAllSensors(t *testing.T) {
+	mqttMock := newMockMQTT()
+	builder := testBuilder()
+
+	// Create a collector with known fixed metrics.
+	c := NewCollector(Sources{
+		DBPaths: map[string]string{},
+		Logger:  slog.New(slog.NewTextHandler(os.Stderr, nil)),
+	})
+
+	pub := NewPublisher(c, mqttMock, builder, slog.New(slog.NewTextHandler(os.Stderr, nil)))
+
+	if err := pub.Publish(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify key sensors were published.
+	expectedEntities := []string{
+		"db_main_size", "db_logs_size", "db_usage_size", "db_attachments_size",
+		"tokens_24h_input", "tokens_24h_output", "tokens_24h_cost",
+		"active_sessions", "context_utilization",
+		"requests_24h", "errors_24h", "request_latency_p50", "request_latency_p95",
+		"loops_active", "loops_sleeping", "loops_errored", "loops_total",
+		"attachments_total", "attachments_total_bytes", "attachments_unique_files",
+	}
+
+	mqttMock.mu.Lock()
+	defer mqttMock.mu.Unlock()
+
+	for _, entity := range expectedEntities {
+		if _, ok := mqttMock.states[entity]; !ok {
+			t.Errorf("missing published state for %q", entity)
+		}
+	}
+}
+
+func TestPublish_LoopDetails(t *testing.T) {
+	mqttMock := newMockMQTT()
+	builder := testBuilder()
+
+	// Use a collector with sessions that return loop details.
+	c := NewCollector(Sources{
+		Logger: slog.New(slog.NewTextHandler(os.Stderr, nil)),
+	})
+
+	pub := NewPublisher(c, mqttMock, builder, slog.New(slog.NewTextHandler(os.Stderr, nil)))
+
+	// Manually set up metrics with loop details by doing a publish
+	// then checking. Since Collect returns empty loops, let's verify
+	// the zero case first, then simulate loop data.
+	if err := pub.Publish(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify loops_total published as "0".
+	mqttMock.mu.Lock()
+	if mqttMock.states["loops_total"] != "0" {
+		t.Errorf("loops_total = %q, want \"0\"", mqttMock.states["loops_total"])
+	}
+	mqttMock.mu.Unlock()
+}
+
+func TestPublish_DynamicLoopRegistration(t *testing.T) {
+	mqttMock := newMockMQTT()
+	builder := testBuilder()
+
+	c := NewCollector(Sources{
+		Logger: slog.New(slog.NewTextHandler(os.Stderr, nil)),
+	})
+
+	pub := NewPublisher(c, mqttMock, builder, slog.New(slog.NewTextHandler(os.Stderr, nil)))
+
+	// Simulate publishing loop details directly.
+	var errs int
+	pub.publishLoopDetails(context.Background(), []LoopMetric{
+		{Name: "mqtt_publisher", State: "sleeping", Iterations: 42},
+		{Name: "email_poll", State: "processing", Iterations: 7},
+	}, &errs)
+
+	if errs != 0 {
+		t.Errorf("publish errors = %d, want 0", errs)
+	}
+
+	// Verify dynamic sensors were registered.
+	mqttMock.mu.Lock()
+	sensorCount := len(mqttMock.sensors)
+	loopState := mqttMock.states["loop_mqtt_publisher_state"]
+	loopIter := mqttMock.states["loop_mqtt_publisher_iterations"]
+	mqttMock.mu.Unlock()
+
+	if sensorCount != 4 { // 2 loops × 2 sensors each
+		t.Errorf("registered sensors = %d, want 4", sensorCount)
+	}
+	if loopState != "sleeping" {
+		t.Errorf("loop state = %q, want sleeping", loopState)
+	}
+	if loopIter != strconv.Itoa(42) {
+		t.Errorf("loop iterations = %q, want 42", loopIter)
+	}
+
+	// Second publish should NOT re-register.
+	pub.publishLoopDetails(context.Background(), []LoopMetric{
+		{Name: "mqtt_publisher", State: "processing", Iterations: 43},
+	}, &errs)
+
+	mqttMock.mu.Lock()
+	sensorCountAfter := len(mqttMock.sensors)
+	mqttMock.mu.Unlock()
+
+	if sensorCountAfter != 4 { // should not grow
+		t.Errorf("sensors after re-publish = %d, want 4 (no duplicates)", sensorCountAfter)
+	}
+}
+
+func TestStaticSensors_Count(t *testing.T) {
+	builder := testBuilder()
+	sensors := builder.StaticSensors()
+
+	// 4 DB + 3 tokens + 2 sessions + 4 request + 4 loops + 3 attachments = 20
+	if len(sensors) != 20 {
+		t.Errorf("StaticSensors count = %d, want 20", len(sensors))
+	}
+
+	// Verify each has required fields.
+	for _, s := range sensors {
+		if s.EntitySuffix == "" {
+			t.Error("sensor has empty EntitySuffix")
+		}
+		if s.Config.UniqueID == "" {
+			t.Error("sensor has empty UniqueID")
+		}
+		if s.Config.StateTopic == "" {
+			t.Error("sensor has empty StateTopic")
+		}
+	}
+}
+
+func TestLoopSensors(t *testing.T) {
+	builder := testBuilder()
+	sensors := builder.LoopSensors("email_poll")
+
+	if len(sensors) != 2 {
+		t.Fatalf("LoopSensors count = %d, want 2", len(sensors))
+	}
+
+	if sensors[0].EntitySuffix != "loop_email_poll_state" {
+		t.Errorf("sensor[0].EntitySuffix = %q", sensors[0].EntitySuffix)
+	}
+	if sensors[1].EntitySuffix != "loop_email_poll_iterations" {
+		t.Errorf("sensor[1].EntitySuffix = %q", sensors[1].EntitySuffix)
+	}
+}

--- a/internal/telemetry/sensors.go
+++ b/internal/telemetry/sensors.go
@@ -1,0 +1,127 @@
+package telemetry
+
+import (
+	"github.com/nugget/thane-ai-agent/internal/channels/mqtt"
+)
+
+// SensorBuilder constructs Home Assistant MQTT sensor definitions for
+// telemetry metrics. It uses topic and device info from the MQTT
+// publisher to produce correctly namespaced discovery payloads.
+type SensorBuilder struct {
+	InstanceID        string
+	Prefix            string // HA object_id prefix, e.g. "aimee_thane_"
+	StateTopicFn      func(string) string
+	AttributesTopicFn func(string) string
+	AvailabilityTopic string
+	Device            mqtt.DeviceInfo
+}
+
+// sensorSpec describes a single telemetry sensor for registration.
+type sensorSpec struct {
+	suffix   string // entity suffix in topic path
+	name     string // human-readable HA name
+	icon     string // MDI icon
+	unit     string // unit_of_measurement (empty = none)
+	class    string // state_class (empty = none)
+	category string // entity_category (empty = none)
+	hasAttrs bool   // whether this sensor publishes JSON attributes
+}
+
+// StaticSensors returns all telemetry sensor definitions to register
+// with the MQTT publisher via [mqtt.Publisher.RegisterSensors]. These
+// are the fixed sensors — per-loop sensors are registered dynamically
+// as loops appear.
+func (b *SensorBuilder) StaticSensors() []mqtt.DynamicSensor {
+	specs := []sensorSpec{
+		// System health — DB sizes.
+		{suffix: "db_main_size", name: "DB Main Size", icon: "mdi:database", unit: "B", class: "measurement", category: "diagnostic"},
+		{suffix: "db_logs_size", name: "DB Logs Size", icon: "mdi:database", unit: "B", class: "measurement", category: "diagnostic"},
+		{suffix: "db_usage_size", name: "DB Usage Size", icon: "mdi:database", unit: "B", class: "measurement", category: "diagnostic"},
+		{suffix: "db_attachments_size", name: "DB Attachments Size", icon: "mdi:database", unit: "B", class: "measurement", category: "diagnostic"},
+
+		// Token usage (24h).
+		{suffix: "tokens_24h_input", name: "Tokens 24h Input", icon: "mdi:arrow-down", unit: "tokens", class: "measurement"},
+		{suffix: "tokens_24h_output", name: "Tokens 24h Output", icon: "mdi:arrow-up", unit: "tokens", class: "measurement"},
+		{suffix: "tokens_24h_cost", name: "Tokens 24h Cost", icon: "mdi:currency-usd", unit: "USD", class: "measurement", hasAttrs: true},
+
+		// Sessions & context.
+		{suffix: "active_sessions", name: "Active Sessions", icon: "mdi:message-text-outline", unit: "sessions", class: "measurement"},
+		{suffix: "context_utilization", name: "Context Utilization", icon: "mdi:gauge", unit: "%", class: "measurement"},
+
+		// Request performance.
+		{suffix: "requests_24h", name: "Requests 24h", icon: "mdi:counter", unit: "requests", class: "measurement"},
+		{suffix: "errors_24h", name: "Errors 24h", icon: "mdi:alert-circle", unit: "errors", class: "measurement"},
+		{suffix: "request_latency_p50", name: "Latency P50", icon: "mdi:timer-outline", unit: "ms", class: "measurement"},
+		{suffix: "request_latency_p95", name: "Latency P95", icon: "mdi:timer-alert-outline", unit: "ms", class: "measurement"},
+
+		// Loop aggregates.
+		{suffix: "loops_active", name: "Loops Active", icon: "mdi:cog-play", unit: "loops", class: "measurement"},
+		{suffix: "loops_sleeping", name: "Loops Sleeping", icon: "mdi:cog-pause", unit: "loops", class: "measurement"},
+		{suffix: "loops_errored", name: "Loops Errored", icon: "mdi:cog-off", unit: "loops", class: "measurement"},
+		{suffix: "loops_total", name: "Loops Total", icon: "mdi:cog", unit: "loops", class: "measurement"},
+
+		// Attachment store.
+		{suffix: "attachments_total", name: "Attachments Total", icon: "mdi:paperclip", unit: "files", class: "measurement"},
+		{suffix: "attachments_total_bytes", name: "Attachments Size", icon: "mdi:paperclip", unit: "B", class: "measurement"},
+		{suffix: "attachments_unique_files", name: "Attachments Unique", icon: "mdi:file-check", unit: "files", class: "measurement"},
+	}
+
+	sensors := make([]mqtt.DynamicSensor, 0, len(specs))
+	for _, s := range specs {
+		sensors = append(sensors, b.buildSensor(s))
+	}
+	return sensors
+}
+
+// LoopSensors returns sensor definitions for a single named loop.
+// Two sensors per loop: state (enum) and iterations (measurement).
+func (b *SensorBuilder) LoopSensors(loopName string) []mqtt.DynamicSensor {
+	stateSuffix := "loop_" + loopName + "_state"
+	iterSuffix := "loop_" + loopName + "_iterations"
+
+	return []mqtt.DynamicSensor{
+		b.buildSensor(sensorSpec{
+			suffix:   stateSuffix,
+			name:     "Loop " + loopName + " State",
+			icon:     "mdi:cog-outline",
+			category: "diagnostic",
+		}),
+		b.buildSensor(sensorSpec{
+			suffix: iterSuffix,
+			name:   "Loop " + loopName + " Iterations",
+			icon:   "mdi:counter",
+			unit:   "iterations",
+			class:  "measurement",
+		}),
+	}
+}
+
+// buildSensor constructs a DynamicSensor from a spec.
+func (b *SensorBuilder) buildSensor(s sensorSpec) mqtt.DynamicSensor {
+	cfg := mqtt.SensorConfig{
+		Name:              s.name,
+		ObjectID:          b.Prefix + s.suffix,
+		HasEntityName:     true,
+		UniqueID:          b.InstanceID + "_" + s.suffix,
+		StateTopic:        b.StateTopicFn(s.suffix),
+		AvailabilityTopic: b.AvailabilityTopic,
+		Device:            b.Device,
+		Icon:              s.icon,
+	}
+	if s.unit != "" {
+		cfg.UnitOfMeasurement = s.unit
+	}
+	if s.class != "" {
+		cfg.StateClass = s.class
+	}
+	if s.category != "" {
+		cfg.EntityCategory = s.category
+	}
+	if s.hasAttrs {
+		cfg.JsonAttributesTopic = b.AttributesTopicFn(s.suffix)
+	}
+	return mqtt.DynamicSensor{
+		EntitySuffix: s.suffix,
+		Config:       cfg,
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `internal/telemetry/` package with a `Collector` that aggregates operational metrics from multiple subsystems (DB sizes, token usage, sessions, request performance, loops, attachments) and a `Publisher` that bridges them to MQTT via `DynamicSensor` state updates
- Registers 20 static HA sensors + dynamic per-loop sensors (state + iterations) via MQTT Discovery, published on a configurable interval (default 60s, min 10s)
- Adds narrow interfaces (`ArchiveSource`, `AttachmentSource`) to decouple telemetry from memory/attachments packages, plus `ActiveSessionCount()` and `TelemetryStats()` helper methods

## Sensors

| Category | Sensors |
|----------|---------|
| System health | `db_main_size`, `db_logs_size`, `db_usage_size`, `db_attachments_size` |
| Token usage (24h) | `tokens_24h_input`, `tokens_24h_output`, `tokens_24h_cost` (with per-model attrs) |
| Sessions | `active_sessions`, `context_utilization` |
| Requests (24h) | `requests_24h`, `errors_24h`, `request_latency_p50`, `request_latency_p95` |
| Loops | `loops_active`, `loops_sleeping`, `loops_errored`, `loops_total` + per-loop `state`/`iterations` |
| Attachments | `attachments_total`, `attachments_total_bytes`, `attachments_unique_files` |

## Configuration

```yaml
mqtt:
  telemetry:
    enabled: true
    interval: 60  # seconds (min 10)
```

## Test plan

- [x] `just ci` passes (0 lint issues, all tests pass with `-race`)
- [x] Unit tests for collector with mock sources (nil and populated)
- [x] Unit tests for publisher with mock MQTT (all 20 entities, dynamic loop registration)
- [x] Percentile computation tested (empty, single, interpolation cases)
- [x] Request latency from in-memory SQLite logs.db tested
- [ ] Integration: enable telemetry in config, verify sensors appear in HA

Closes #537