### PR TITLE
fix: address review feedback on telemetry package

### DIFF
--- a/internal/telemetry/collector.go
+++ b/internal/telemetry/collector.go
@@ -9,6 +9,7 @@ import (
 	"sort"
 	"time"
 
+	"github.com/nugget/thane-ai-agent/internal/database"
 	"github.com/nugget/thane-ai-agent/internal/loop"
 	"github.com/nugget/thane-ai-agent/internal/usage"
 )
@@ -80,7 +81,10 @@ func (c *Collector) collectDBSizes(m *Metrics) {
 		}
 		info, err := os.Stat(path)
 		if err != nil {
-			// File may not exist yet — normal for optional subsystems.
+			if !os.IsNotExist(err) {
+				c.src.Logger.Warn("telemetry: stat db file failed",
+					"db", name, "path", path, "error", err)
+			}
 			continue
 		}
 		m.DBSizes[name] = info.Size()
@@ -230,8 +234,8 @@ func (c *Collector) collectRequests(ctx context.Context, m *Metrics) {
 		if err := rows.Scan(&reqID, &minTS, &maxTS); err != nil {
 			continue
 		}
-		tMin, err1 := time.Parse(time.RFC3339Nano, minTS)
-		tMax, err2 := time.Parse(time.RFC3339Nano, maxTS)
+		tMin, err1 := database.ParseTimestamp(minTS)
+		tMax, err2 := database.ParseTimestamp(maxTS)
 		if err1 != nil || err2 != nil {
 			continue
 		}

--- a/internal/telemetry/publisher.go
+++ b/internal/telemetry/publisher.go
@@ -75,13 +75,18 @@ func (p *Publisher) Publish(ctx context.Context) error {
 	p.publishInt64(ctx, "tokens_24h_output", m.TokensOutput, &errs)
 
 	costStr := strconv.FormatFloat(m.TokensCost, 'f', 4, 64)
-	if err := p.publish(ctx, "tokens_24h_cost", costStr); err != nil {
-		errs++
-	} else if len(m.TokensByModel) > 0 {
-		// Publish per-model breakdown as attributes.
+	if len(m.TokensByModel) > 0 {
+		// Publish state + per-model breakdown as attributes in one call.
 		attrs, err := json.Marshal(m.TokensByModel)
-		if err == nil {
-			_ = p.publishWithAttrs(ctx, "tokens_24h_cost", costStr, attrs)
+		if err != nil {
+			p.logger.Error("telemetry: marshal tokens by model", "error", err)
+			errs++
+		} else if err := p.publishWithAttrs(ctx, "tokens_24h_cost", costStr, attrs); err != nil {
+			errs++
+		}
+	} else {
+		if err := p.publish(ctx, "tokens_24h_cost", costStr); err != nil {
+			errs++
 		}
 	}
 
@@ -121,22 +126,33 @@ func (p *Publisher) Publish(ctx context.Context) error {
 
 // publishLoopDetails publishes per-loop state and iteration sensors.
 // New loops are detected and their sensors registered dynamically.
+// Loop names are sanitized for use in MQTT topic paths.
 func (p *Publisher) publishLoopDetails(ctx context.Context, details []LoopMetric, errs *int) {
-	p.mu.Lock()
-	defer p.mu.Unlock()
+	// Determine newly seen loops under lock, then release before I/O.
+	var newLoops []string
 
+	p.mu.Lock()
 	for _, lm := range details {
-		// Register sensors for newly discovered loops.
 		if !p.knownLoops[lm.Name] {
 			p.knownLoops[lm.Name] = true
-			sensors := p.builder.LoopSensors(lm.Name)
-			p.mqtt.RegisterSensors(sensors)
-			p.logger.Info("telemetry: registered loop sensors",
-				"loop", lm.Name, "sensors", len(sensors))
+			newLoops = append(newLoops, lm.Name)
 		}
+	}
+	p.mu.Unlock()
 
-		stateSuffix := "loop_" + lm.Name + "_state"
-		iterSuffix := "loop_" + lm.Name + "_iterations"
+	// Register sensors for newly discovered loops (may do MQTT I/O).
+	for _, loopName := range newLoops {
+		sensors := p.builder.LoopSensors(loopName)
+		p.mqtt.RegisterSensors(sensors)
+		p.logger.Info("telemetry: registered loop sensors",
+			"loop", loopName, "sensors", len(sensors))
+	}
+
+	// Publish per-loop state and iteration counts.
+	for _, lm := range details {
+		slug := sanitizeLoopName(lm.Name)
+		stateSuffix := "loop_" + slug + "_state"
+		iterSuffix := "loop_" + slug + "_iterations"
 
 		if err := p.publish(ctx, stateSuffix, lm.State); err != nil {
 			*errs++

--- a/internal/telemetry/publisher_test.go
+++ b/internal/telemetry/publisher_test.go
@@ -205,3 +205,36 @@ func TestLoopSensors(t *testing.T) {
 		t.Errorf("sensor[1].EntitySuffix = %q", sensors[1].EntitySuffix)
 	}
 }
+
+func TestLoopSensors_Sanitization(t *testing.T) {
+	builder := testBuilder()
+
+	// Loop names with MQTT topic separators must be sanitized.
+	sensors := builder.LoopSensors("signal/Alice")
+	if sensors[0].EntitySuffix != "loop_signal_Alice_state" {
+		t.Errorf("sensor[0].EntitySuffix = %q, want loop_signal_Alice_state", sensors[0].EntitySuffix)
+	}
+	if sensors[1].EntitySuffix != "loop_signal_Alice_iterations" {
+		t.Errorf("sensor[1].EntitySuffix = %q, want loop_signal_Alice_iterations", sensors[1].EntitySuffix)
+	}
+}
+
+func TestSanitizeLoopName(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"simple", "simple"},
+		{"signal/Alice", "signal_Alice"},
+		{"a/b/c", "a_b_c"},
+		{"with+plus", "with_plus"},
+		{"with#hash", "with_hash"},
+		{"clean_name", "clean_name"},
+	}
+	for _, tt := range tests {
+		got := sanitizeLoopName(tt.input)
+		if got != tt.want {
+			t.Errorf("sanitizeLoopName(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}

--- a/internal/telemetry/sensors.go
+++ b/internal/telemetry/sensors.go
@@ -1,6 +1,8 @@
 package telemetry
 
 import (
+	"strings"
+
 	"github.com/nugget/thane-ai-agent/internal/channels/mqtt"
 )
 
@@ -73,11 +75,20 @@ func (b *SensorBuilder) StaticSensors() []mqtt.DynamicSensor {
 	return sensors
 }
 
+// sanitizeLoopName replaces characters that are invalid in MQTT topic
+// segments (/ and +) with underscores to prevent malformed topic paths.
+func sanitizeLoopName(name string) string {
+	r := strings.NewReplacer("/", "_", "+", "_", "#", "_")
+	return r.Replace(name)
+}
+
 // LoopSensors returns sensor definitions for a single named loop.
 // Two sensors per loop: state (enum) and iterations (measurement).
+// Loop names are sanitized to avoid MQTT topic separator conflicts.
 func (b *SensorBuilder) LoopSensors(loopName string) []mqtt.DynamicSensor {
-	stateSuffix := "loop_" + loopName + "_state"
-	iterSuffix := "loop_" + loopName + "_iterations"
+	slug := sanitizeLoopName(loopName)
+	stateSuffix := "loop_" + slug + "_state"
+	iterSuffix := "loop_" + slug + "_iterations"
 
 	return []mqtt.DynamicSensor{
 		b.buildSensor(sensorSpec{


### PR DESCRIPTION
## Summary

Addresses review feedback from PR #563 (MQTT telemetry publishing):

- **Sanitize loop names** for MQTT topic safety — replace `/`, `+`, `#` with `_` to prevent malformed topic paths (e.g. `signal/Alice` → `signal_Alice`)
- **Narrow mutex scope** in `publishLoopDetails` — check/update `knownLoops` under lock, then release before MQTT I/O
- **Eliminate duplicate publish** of `tokens_24h_cost` — publish state+attrs in one call when model breakdown is available
- **Log non-IsNotExist errors** in `collectDBSizes` — permission errors and other unexpected failures are now warned instead of silently swallowed
- **Use `database.ParseTimestamp`** for reading SQLite timestamps — follows project convention for multi-format timestamp handling

Dismissed false positives:
- `*errs++` is valid Go (statement applied to `*errs` expression, not C-style pointer arithmetic)
- RFC3339 vs RFC3339Nano for `since` bound — lexicographic ISO 8601 ordering is correct for `>=`
- RegisterSensors-after-Connect timing — pre-existing pattern shared with AP sensors, not a telemetry-specific issue

## Test plan

- [x] New `TestLoopSensors_Sanitization` and `TestSanitizeLoopName` tests added
- [x] All existing tests pass with `-race`
- [x] `just ci` passes clean