### PR TITLE
fix: resolve metacognitive state file split-brain with provenance store

### DIFF
--- a/cmd/thane/main.go
+++ b/cmd/thane/main.go
@@ -2664,12 +2664,26 @@ func runServe(ctx context.Context, stdout io.Writer, stderr io.Writer, configPat
 			}
 		}
 
+		// Resolve state file path: provenance store when configured,
+		// workspace-relative otherwise. Uses filepath.Base to normalize
+		// config values like "Thane/metacognitive.md" to flat layout.
+		stateFileName := filepath.Base(metacogCfg.StateFile)
+		var metacogStatePath string
+		if provenanceStore != nil {
+			metacogStatePath = provenanceStore.FilePath(stateFileName)
+		} else {
+			metacogStatePath = filepath.Join(cfg.Workspace.Path, metacogCfg.StateFile)
+		}
+
 		adapter := &loopAdapter{agentLoop: loop, router: rtr}
 		loopCfg := metacognitive.BuildLoopConfig(metacogCfg, metacognitive.Opts{
-			WorkspacePath: cfg.Workspace.Path,
+			WorkspacePath:   cfg.Workspace.Path,
+			StateFilePath:   metacogStatePath,
+			ProvenanceStore: provenanceStore,
+			StateFileName:   stateFileName,
 		})
 		loopCfg.Setup = func(l *looppkg.Loop) {
-			metacognitive.RegisterTools(loop.Tools(), l, metacogCfg, cfg.Workspace.Path, metacogEgoFile, provenanceStore)
+			metacognitive.RegisterTools(loop.Tools(), l, metacogCfg, metacogStatePath, metacogEgoFile, provenanceStore)
 		}
 
 		if _, err := loopRegistry.SpawnLoop(ctx, loopCfg, looppkg.Deps{

--- a/internal/metacognitive/metacognitive.go
+++ b/internal/metacognitive/metacognitive.go
@@ -47,6 +47,13 @@ const iterationLogRetention = 5
 // blocks. Used for scanning/pruning.
 const iterationLogPrefix = "<!-- iteration_log:"
 
+// ProvenanceWriter is the subset of [provenance.Store] needed by the
+// metacognitive loop for committing state file updates.
+type ProvenanceWriter interface {
+	Read(filename string) (string, error)
+	Write(ctx context.Context, filename, content, message string) error
+}
+
 // Config holds the parsed metacognitive loop configuration with
 // time.Duration fields (as opposed to the YAML string representation
 // in [config.MetacognitiveConfig]).
@@ -94,7 +101,22 @@ func ParseConfig(raw config.MetacognitiveConfig) (Config, error) {
 // Opts holds options for [BuildLoopConfig] that are not part of [Config].
 type Opts struct {
 	// WorkspacePath is the absolute path to the workspace directory.
+	// Used only as a fallback when ProvenanceStore is nil.
 	WorkspacePath string
+
+	// StateFilePath is the resolved absolute path to the state file.
+	// When a provenance store is configured, this points inside the
+	// store; otherwise it falls back to workspace-relative resolution.
+	StateFilePath string
+
+	// ProvenanceStore, when non-nil, is used by the iteration logger
+	// to commit state file updates with SSH signatures.
+	ProvenanceStore ProvenanceWriter
+
+	// StateFileName is the bare filename (e.g. "metacognitive.md") used
+	// for provenance store reads and writes. Ignored when ProvenanceStore
+	// is nil.
+	StateFileName string
 }
 
 // BuildLoopConfig returns a [loop.Config] that implements the
@@ -124,17 +146,17 @@ func BuildLoopConfig(cfg Config, opts Opts) loop.Config {
 		},
 
 		TaskBuilder: func(ctx context.Context, isSupervisor bool) (string, error) {
-			stateContent, err := readStateFile(opts.WorkspacePath, cfg.StateFile)
+			stateContent, err := readStateFile(opts.StateFilePath)
 			if err != nil {
 				log := logging.Logger(ctx)
 				if errors.Is(err, fs.ErrNotExist) {
 					log.Info("metacognitive state file not found, starting fresh",
-						"path", stateFilePath(opts.WorkspacePath, cfg.StateFile),
+						"path", opts.StateFilePath,
 					)
 				} else {
 					log.Warn("metacognitive state file read failed, starting with empty state",
 						"error", err,
-						"path", stateFilePath(opts.WorkspacePath, cfg.StateFile),
+						"path", opts.StateFilePath,
 					)
 				}
 				stateContent = ""
@@ -144,7 +166,7 @@ func BuildLoopConfig(cfg Config, opts Opts) loop.Config {
 
 		PostIterate: func(ctx context.Context, result loop.IterationResult) error {
 			log := logging.Logger(ctx)
-			appendIterationLog(log, stateFilePath(opts.WorkspacePath, cfg.StateFile), &result)
+			appendIterationLog(ctx, log, opts.StateFilePath, opts.ProvenanceStore, opts.StateFileName, &result)
 			return nil
 		},
 	}
@@ -163,11 +185,11 @@ var metacogExcludeTools = []string{
 	"request_capability", "drop_capability",
 }
 
-// readStateFile reads the metacognitive state file from the workspace.
+// readStateFile reads the metacognitive state file from the given path.
 // Returns an error if the file does not exist (first iteration).
 // Content is capped at [maxStateBytes].
-func readStateFile(workspacePath, stateFile string) (string, error) {
-	data, err := os.ReadFile(stateFilePath(workspacePath, stateFile))
+func readStateFile(path string) (string, error) {
+	data, err := os.ReadFile(path)
 	if err != nil {
 		if errors.Is(err, fs.ErrNotExist) {
 			return "", err
@@ -180,35 +202,43 @@ func readStateFile(workspacePath, stateFile string) (string, error) {
 	return string(data), nil
 }
 
-// stateFilePath returns the absolute path to the state file.
-func stateFilePath(workspacePath, stateFile string) string {
-	return filepath.Join(workspacePath, stateFile)
-}
-
 // appendIterationLog appends an HTML comment summary block to the state
 // file after a successful iteration. Old logs beyond
 // [iterationLogRetention] are pruned. This is best-effort: errors are
 // logged but never disrupt the loop.
 //
+// When store is non-nil, reads and writes go through the provenance
+// store (committed with SSH signatures). When nil, direct file I/O is
+// used at statePath.
+//
 // Unlike [readStateFile], this reads the full file without the
 // maxStateBytes cap to avoid silently truncating user/model state on
 // rewrite.
-func appendIterationLog(log *slog.Logger, statePath string, result *loop.IterationResult) {
+func appendIterationLog(ctx context.Context, log *slog.Logger, statePath string, store ProvenanceWriter, stateFileName string, result *loop.IterationResult) {
 	// Read the full file (uncapped) to avoid truncation on rewrite.
 	var content string
-	data, err := os.ReadFile(statePath)
-	if err != nil {
-		if !errors.Is(err, fs.ErrNotExist) {
-			// Non-trivial read error — abort to avoid data loss.
-			log.Warn("failed to read state file for iteration log, skipping append",
+	if store != nil {
+		existing, err := store.Read(stateFileName)
+		if err != nil && !os.IsNotExist(err) {
+			log.Warn("failed to read state file from provenance for iteration log, skipping append",
 				"error", err,
 			)
 			return
 		}
-		// File doesn't exist yet — start with empty content.
-		content = ""
+		content = existing
 	} else {
-		content = string(data)
+		data, err := os.ReadFile(statePath)
+		if err != nil {
+			if !errors.Is(err, fs.ErrNotExist) {
+				log.Warn("failed to read state file for iteration log, skipping append",
+					"error", err,
+				)
+				return
+			}
+			// File doesn't exist yet — start with empty content.
+		} else {
+			content = string(data)
+		}
 	}
 
 	// Prune old iteration logs before appending.
@@ -236,6 +266,16 @@ func appendIterationLog(log *slog.Logger, statePath string, result *loop.Iterati
 
 	fullContent := content + logBlock
 
+	if store != nil {
+		if err := store.Write(ctx, stateFileName, fullContent, "iteration-log"); err != nil {
+			log.Warn("failed to commit iteration log to provenance",
+				"error", err,
+			)
+		}
+		return
+	}
+
+	// Fallback: direct file I/O.
 	// Ensure the parent directory exists (state file may be in a subdir).
 	if err := os.MkdirAll(filepath.Dir(statePath), 0o755); err != nil {
 		log.Warn("failed to create directory for iteration log",

--- a/internal/metacognitive/metacognitive_test.go
+++ b/internal/metacognitive/metacognitive_test.go
@@ -114,7 +114,7 @@ func TestParseConfig_InvalidDuration(t *testing.T) {
 
 func TestReadStateFile_Missing(t *testing.T) {
 	tmpDir := t.TempDir()
-	_, err := readStateFile(tmpDir, "metacognitive.md")
+	_, err := readStateFile(filepath.Join(tmpDir, "metacognitive.md"))
 	if err == nil {
 		t.Fatal("readStateFile should return error for missing file")
 	}
@@ -128,7 +128,7 @@ func TestReadStateFile_Present(t *testing.T) {
 		t.Fatalf("write state file: %v", err)
 	}
 
-	got, err := readStateFile(tmpDir, "metacognitive.md")
+	got, err := readStateFile(stateFile)
 	if err != nil {
 		t.Fatalf("readStateFile: %v", err)
 	}
@@ -145,7 +145,7 @@ func TestReadStateFile_Truncated(t *testing.T) {
 		t.Fatalf("write state file: %v", err)
 	}
 
-	got, err := readStateFile(tmpDir, "metacognitive.md")
+	got, err := readStateFile(stateFile)
 	if err != nil {
 		t.Fatalf("readStateFile: %v", err)
 	}
@@ -180,7 +180,7 @@ func TestAppendIterationLog(t *testing.T) {
 		Sleep:        8 * time.Minute,
 	}
 
-	appendIterationLog(slog.Default(), statePath, result)
+	appendIterationLog(context.Background(), slog.Default(), statePath, nil, "", result)
 
 	data, err := os.ReadFile(statePath)
 	if err != nil {
@@ -239,7 +239,7 @@ func TestAppendIterationLog_NoStateFile(t *testing.T) {
 		Sleep:        5 * time.Minute,
 	}
 
-	appendIterationLog(slog.Default(), statePath, result)
+	appendIterationLog(context.Background(), slog.Default(), statePath, nil, "", result)
 
 	data, err := os.ReadFile(statePath)
 	if err != nil {
@@ -347,8 +347,12 @@ func TestFormatToolsUsed_Sorted(t *testing.T) {
 // --- BuildLoopConfig tests ---
 
 func TestBuildLoopConfig(t *testing.T) {
+	tmpDir := t.TempDir()
 	cfg := testConfig()
-	opts := Opts{WorkspacePath: t.TempDir()}
+	opts := Opts{
+		WorkspacePath: tmpDir,
+		StateFilePath: filepath.Join(tmpDir, cfg.StateFile),
+	}
 
 	lc := BuildLoopConfig(cfg, opts)
 
@@ -398,12 +402,15 @@ func TestBuildLoopConfig(t *testing.T) {
 func TestBuildLoopConfig_TaskBuilder(t *testing.T) {
 	tmpDir := t.TempDir()
 	cfg := testConfig()
-	opts := Opts{WorkspacePath: tmpDir}
+	statePath := filepath.Join(tmpDir, cfg.StateFile)
+	opts := Opts{
+		WorkspacePath: tmpDir,
+		StateFilePath: statePath,
+	}
 
 	// Write a state file for the TaskBuilder to read.
 	stateContent := "## Current Sense\nAll systems nominal."
-	stateFile := filepath.Join(tmpDir, cfg.StateFile)
-	if err := os.WriteFile(stateFile, []byte(stateContent), 0644); err != nil {
+	if err := os.WriteFile(statePath, []byte(stateContent), 0644); err != nil {
 		t.Fatalf("write state file: %v", err)
 	}
 
@@ -421,7 +428,10 @@ func TestBuildLoopConfig_TaskBuilder(t *testing.T) {
 func TestBuildLoopConfig_TaskBuilderNoState(t *testing.T) {
 	tmpDir := t.TempDir()
 	cfg := testConfig()
-	opts := Opts{WorkspacePath: tmpDir}
+	opts := Opts{
+		WorkspacePath: tmpDir,
+		StateFilePath: filepath.Join(tmpDir, cfg.StateFile),
+	}
 
 	lc := BuildLoopConfig(cfg, opts)
 	prompt, err := lc.TaskBuilder(context.Background(), false)
@@ -438,7 +448,11 @@ func TestBuildLoopConfig_TaskBuilderNoState(t *testing.T) {
 func TestBuildLoopConfig_PostIterate(t *testing.T) {
 	tmpDir := t.TempDir()
 	cfg := testConfig()
-	opts := Opts{WorkspacePath: tmpDir}
+	statePath := filepath.Join(tmpDir, cfg.StateFile)
+	opts := Opts{
+		WorkspacePath: tmpDir,
+		StateFilePath: statePath,
+	}
 
 	lc := BuildLoopConfig(cfg, opts)
 
@@ -457,7 +471,6 @@ func TestBuildLoopConfig_PostIterate(t *testing.T) {
 	}
 
 	// Verify state file was written with iteration log.
-	statePath := filepath.Join(tmpDir, cfg.StateFile)
 	data, err := os.ReadFile(statePath)
 	if err != nil {
 		t.Fatalf("read state: %v", err)
@@ -477,7 +490,7 @@ func TestSetNextSleep_Valid(t *testing.T) {
 	theLoop := testLoopForTools(t)
 
 	reg := tools.NewRegistry(nil, nil)
-	RegisterTools(reg, theLoop, cfg, workspace, "", nil)
+	RegisterTools(reg, theLoop, cfg, filepath.Join(workspace, cfg.StateFile), "", nil)
 
 	tool := reg.Get("set_next_sleep")
 	if tool == nil {
@@ -503,7 +516,7 @@ func TestSetNextSleep_Clamped(t *testing.T) {
 	theLoop := testLoopForTools(t)
 
 	reg := tools.NewRegistry(nil, nil)
-	RegisterTools(reg, theLoop, cfg, workspace, "", nil)
+	RegisterTools(reg, theLoop, cfg, filepath.Join(workspace, cfg.StateFile), "", nil)
 
 	tool := reg.Get("set_next_sleep")
 
@@ -536,7 +549,7 @@ func TestSetNextSleep_InvalidFormat(t *testing.T) {
 	theLoop := testLoopForTools(t)
 
 	reg := tools.NewRegistry(nil, nil)
-	RegisterTools(reg, theLoop, cfg, workspace, "", nil)
+	RegisterTools(reg, theLoop, cfg, filepath.Join(workspace, cfg.StateFile), "", nil)
 
 	tool := reg.Get("set_next_sleep")
 
@@ -554,7 +567,7 @@ func TestSetNextSleep_MissingDuration(t *testing.T) {
 	theLoop := testLoopForTools(t)
 
 	reg := tools.NewRegistry(nil, nil)
-	RegisterTools(reg, theLoop, cfg, workspace, "", nil)
+	RegisterTools(reg, theLoop, cfg, filepath.Join(workspace, cfg.StateFile), "", nil)
 
 	tool := reg.Get("set_next_sleep")
 
@@ -570,7 +583,7 @@ func TestSetNextSleep_IntegerMinutes(t *testing.T) {
 	theLoop := testLoopForTools(t)
 
 	reg := tools.NewRegistry(nil, nil)
-	RegisterTools(reg, theLoop, cfg, workspace, "", nil)
+	RegisterTools(reg, theLoop, cfg, filepath.Join(workspace, cfg.StateFile), "", nil)
 
 	tool := reg.Get("set_next_sleep")
 
@@ -595,7 +608,7 @@ func TestUpdateMetacognitiveState_Valid(t *testing.T) {
 	theLoop := testLoopForTools(t)
 
 	reg := tools.NewRegistry(nil, nil)
-	RegisterTools(reg, theLoop, cfg, workspace, "", nil)
+	RegisterTools(reg, theLoop, cfg, filepath.Join(workspace, cfg.StateFile), "", nil)
 
 	tool := reg.Get("update_metacognitive_state")
 	if tool == nil {
@@ -630,7 +643,7 @@ func TestUpdateMetacognitiveState_MetadataFooter(t *testing.T) {
 	theLoop := testLoopForTools(t)
 
 	reg := tools.NewRegistry(nil, nil)
-	RegisterTools(reg, theLoop, cfg, workspace, "", nil)
+	RegisterTools(reg, theLoop, cfg, filepath.Join(workspace, cfg.StateFile), "", nil)
 
 	tool := reg.Get("update_metacognitive_state")
 	content := "## Current Sense\nAll systems nominal. Nothing to report. Sleeping for a while."
@@ -671,7 +684,7 @@ func TestUpdateMetacognitiveState_PrevFile(t *testing.T) {
 	}
 
 	reg := tools.NewRegistry(nil, nil)
-	RegisterTools(reg, theLoop, cfg, workspace, "", nil)
+	RegisterTools(reg, theLoop, cfg, filepath.Join(workspace, cfg.StateFile), "", nil)
 
 	tool := reg.Get("update_metacognitive_state")
 	newContent := "## Updated Content\nNew observations from the latest iteration of monitoring."
@@ -700,7 +713,7 @@ func TestUpdateMetacognitiveState_EmptyRejected(t *testing.T) {
 	theLoop := testLoopForTools(t)
 
 	reg := tools.NewRegistry(nil, nil)
-	RegisterTools(reg, theLoop, cfg, workspace, "", nil)
+	RegisterTools(reg, theLoop, cfg, filepath.Join(workspace, cfg.StateFile), "", nil)
 
 	tool := reg.Get("update_metacognitive_state")
 

--- a/internal/metacognitive/tool.go
+++ b/internal/metacognitive/tool.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/nugget/thane-ai-agent/internal/logging"
 	"github.com/nugget/thane-ai-agent/internal/loop"
-	"github.com/nugget/thane-ai-agent/internal/provenance"
 	"github.com/nugget/thane-ai-agent/internal/tools"
 )
 
@@ -23,6 +22,9 @@ const minStateContentLen = 50
 // during iterations to control sleep timing, persist its state file,
 // and contribute observations to ego.md.
 //
+// stateFilePath is the resolved absolute path to the state file (either
+// inside the provenance store or the workspace, depending on config).
+//
 // When store is non-nil, file writes go through the provenance store
 // (auto-committed with SSH signatures). When nil, files are written
 // directly via os.WriteFile (backward compatible).
@@ -30,8 +32,8 @@ const minStateContentLen = 50
 // Tool handlers capture theLoop via closure to communicate with the
 // running loop goroutine (e.g., setting sleep durations, reading the
 // current conversation ID).
-func RegisterTools(registry *tools.Registry, theLoop *loop.Loop, cfg Config, workspacePath, egoFile string, store *provenance.Store) {
-	statePath := stateFilePath(workspacePath, cfg.StateFile)
+func RegisterTools(registry *tools.Registry, theLoop *loop.Loop, cfg Config, stateFilePath, egoFile string, store ProvenanceWriter) {
+	statePath := stateFilePath
 
 	registry.Register(&tools.Tool{
 		Name: "set_next_sleep",
@@ -125,12 +127,14 @@ func RegisterTools(registry *tools.Registry, theLoop *loop.Loop, cfg Config, wor
 
 			if store != nil {
 				// Write through provenance store — auto-committed
-				// with SSH signature.
-				if err := store.Write(ctx, cfg.StateFile, fullContent, convID); err != nil {
+				// with SSH signature. Use filepath.Base to normalize
+				// paths like "Thane/metacognitive.md" to a flat layout.
+				storeFilename := filepath.Base(cfg.StateFile)
+				if err := store.Write(ctx, storeFilename, fullContent, convID); err != nil {
 					return "", fmt.Errorf("write state via provenance: %w", err)
 				}
 				log.Info("metacognitive state committed to provenance",
-					"file", cfg.StateFile,
+					"file", storeFilename,
 					"bytes", len(fullContent),
 				)
 				return fmt.Sprintf("State file committed (%d bytes) to provenance store.", len(fullContent)), nil

--- a/internal/metacognitive/tool_test.go
+++ b/internal/metacognitive/tool_test.go
@@ -18,7 +18,7 @@ func TestAppendEgoObservation_NotRegisteredWithoutEgoFile(t *testing.T) {
 	theLoop := testLoopForTools(t)
 
 	reg := tools.NewRegistry(nil, nil)
-	RegisterTools(reg, theLoop, cfg, workspace, "", nil)
+	RegisterTools(reg, theLoop, cfg, filepath.Join(workspace, cfg.StateFile), "", nil)
 
 	tool := reg.Get("append_ego_observation")
 	if tool != nil {
@@ -33,7 +33,7 @@ func TestAppendEgoObservation_RegisteredWithEgoFile(t *testing.T) {
 	theLoop := testLoopForTools(t)
 
 	reg := tools.NewRegistry(nil, nil)
-	RegisterTools(reg, theLoop, cfg, workspace, egoFile, nil)
+	RegisterTools(reg, theLoop, cfg, filepath.Join(workspace, cfg.StateFile), egoFile, nil)
 
 	tool := reg.Get("append_ego_observation")
 	if tool == nil {
@@ -48,7 +48,7 @@ func TestAppendEgoObservation_CreatesNewFile(t *testing.T) {
 	theLoop := testLoopForTools(t)
 
 	reg := tools.NewRegistry(nil, nil)
-	RegisterTools(reg, theLoop, cfg, workspace, egoPath, nil)
+	RegisterTools(reg, theLoop, cfg, filepath.Join(workspace, cfg.StateFile), egoPath, nil)
 
 	tool := reg.Get("append_ego_observation")
 
@@ -93,7 +93,7 @@ func TestAppendEgoObservation_AppendsToExisting(t *testing.T) {
 	}
 
 	reg := tools.NewRegistry(nil, nil)
-	RegisterTools(reg, theLoop, cfg, workspace, egoPath, nil)
+	RegisterTools(reg, theLoop, cfg, filepath.Join(workspace, cfg.StateFile), egoPath, nil)
 
 	tool := reg.Get("append_ego_observation")
 
@@ -126,7 +126,7 @@ func TestAppendEgoObservation_RejectsShortContent(t *testing.T) {
 	theLoop := testLoopForTools(t)
 
 	reg := tools.NewRegistry(nil, nil)
-	RegisterTools(reg, theLoop, cfg, workspace, egoPath, nil)
+	RegisterTools(reg, theLoop, cfg, filepath.Join(workspace, cfg.StateFile), egoPath, nil)
 
 	tool := reg.Get("append_ego_observation")
 
@@ -161,7 +161,7 @@ func TestAppendEgoObservation_MultipleAppends(t *testing.T) {
 	theLoop := testLoopForTools(t)
 
 	reg := tools.NewRegistry(nil, nil)
-	RegisterTools(reg, theLoop, cfg, workspace, egoPath, nil)
+	RegisterTools(reg, theLoop, cfg, filepath.Join(workspace, cfg.StateFile), egoPath, nil)
 
 	tool := reg.Get("append_ego_observation")
 


### PR DESCRIPTION
## Summary

- Unifies metacognitive state file read/write paths so all components (TaskBuilder, update_metacognitive_state tool, iteration logger) use the same resolved path — provenance store when configured, workspace otherwise
- Adds `ProvenanceWriter` interface to decouple metacognitive package from provenance import
- Iteration logger now commits through provenance store with SSH signatures when available
- Normalizes config paths like `"Thane/metacognitive.md"` via `filepath.Base()` to match ego.md's flat layout

## Test plan

- [x] `just ci` passes (0 lint issues, all tests with `-race`)
- [x] Existing metacognitive tests updated for new signatures
- [x] `readStateFile` tests use resolved path
- [x] `appendIterationLog` tests pass `nil` store (direct I/O fallback)
- [ ] Manual: verify with provenance store enabled that metacog reads from provenance path
- [ ] Manual: verify iteration logs appear in provenance git history

Closes #565

🤖 Generated with [Claude Code](https://claude.com/claude-code)