### PR TITLE
feat: add jittered initial sleep for timer-driven loops

### DIFF
--- a/internal/events/bus.go
+++ b/internal/events/bus.go
@@ -103,7 +103,8 @@ const (
 	// Data: loop_id, loop_name, model, input_tokens, output_tokens, elapsed_ms.
 	KindLoopIterationComplete = "loop_iteration_complete"
 	// KindLoopSleepStart signals a loop has entered its sleep phase.
-	// Data: loop_id, loop_name, sleep_duration.
+	// Data: loop_id, loop_name, sleep_duration, initial (bool, true
+	// only for the pre-first-iteration startup sleep).
 	KindLoopSleepStart = "loop_sleep_start"
 	// KindLoopWaitStart signals a loop has entered its wait phase,
 	// blocking on a WaitFunc for an external event.

--- a/internal/loop/loop.go
+++ b/internal/loop/loop.go
@@ -414,7 +414,7 @@ func (l *Loop) run(ctx context.Context) {
 	// Initial state depends on whether the loop waits for events or
 	// sleeps on a timer. WaitFunc loops enter StateWaiting immediately
 	// (they block at the top of the loop); timer loops enter
-	// StateSleeping (they process first, then sleep).
+	// StateSleeping (they sleep on startup, then process, then sleep).
 	if l.config.WaitFunc != nil {
 		l.setState(StateWaiting)
 	} else {
@@ -475,18 +475,7 @@ func (l *Loop) run(ctx context.Context) {
 
 		if !sleepCtx(ctx, initialSleep) {
 			logger.Info("loop stopped during initial sleep")
-			l.setState(StateStopped)
-			l.publishEvent(events.Event{
-				Timestamp: time.Now(),
-				Source:    events.SourceLoop,
-				Kind:      events.KindLoopStopped,
-				Data: map[string]any{
-					"loop_id":    l.id,
-					"loop_name":  l.config.Name,
-					"iterations": l.iterations,
-					"attempts":   l.attempts,
-				},
-			})
+			l.emitStopped()
 			return
 		}
 	}
@@ -861,6 +850,12 @@ func (l *Loop) run(ctx context.Context) {
 		}
 	}
 
+	l.emitStopped()
+}
+
+// emitStopped transitions the loop to StateStopped and publishes a
+// KindLoopStopped event. It is called from every exit path in run().
+func (l *Loop) emitStopped() {
 	l.setState(StateStopped)
 	l.publishEvent(events.Event{
 		Timestamp: time.Now(),

--- a/internal/loop/loop_test.go
+++ b/internal/loop/loop_test.go
@@ -1915,6 +1915,7 @@ func TestTimerLoopInitialSleep_PublishesEvent(t *testing.T) {
 
 	bus := events.New()
 	sub := bus.Subscribe(16)
+	defer bus.Unsubscribe(sub)
 
 	l, err := New(Config{
 		Name:         "initial-event",
@@ -1997,7 +1998,11 @@ func TestWaitFuncLoopNoInitialSleep(t *testing.T) {
 	mu.Unlock()
 
 	// Event-driven loop should fire quickly — well under SleepDefault.
-	if elapsed > 50*time.Millisecond {
-		t.Errorf("event-driven loop took %v to first iteration, expected near-instant", elapsed)
+	// Use a fraction of SleepDefault rather than a hard-coded bound
+	// so the assertion stays meaningful under scheduler load.
+	maxElapsed := 100 * time.Millisecond / 2 // 50% of SleepDefault
+	if elapsed > maxElapsed {
+		t.Errorf("event-driven loop took %v to first iteration, want < %v (SleepDefault = %v)",
+			elapsed, maxElapsed, 100*time.Millisecond)
 	}
 }


### PR DESCRIPTION
## Summary

- Timer-driven loops now sleep for a jittered `SleepDefault` duration before their first iteration, preventing all loops from firing expensive iterations simultaneously on Thane restart
- Event-driven loops (with `WaitFunc`) are unaffected — they naturally block until their first event arrives
- Initial sleep publishes a `loop.sleep_start` event with `initial: true` for observability

## Context

Frequent restarts during development/deployment caused every timer-driven loop (including the expensive metacognitive loop) to fire immediately and simultaneously. This adds a staggered startup delay using the existing jitter infrastructure (`applyJitter` + `clamp`) so loops spread their first iterations over a randomized window.

## Test plan

- [x] `TestTimerLoopInitialSleep` — verifies first iteration fires only after initial sleep delay
- [x] `TestTimerLoopInitialSleep_Cancelled` — verifies clean shutdown if cancelled during initial sleep
- [x] `TestTimerLoopInitialSleep_PublishesEvent` — verifies sleep_start event with `initial: true`
- [x] `TestWaitFuncLoopNoInitialSleep` — verifies event-driven loops fire near-instantly (no initial sleep)
- [x] `just ci` passes clean (0 lint issues, all tests pass with `-race`)