### PR TITLE
fix: pass long-lived context to MQTT ConnectionManager

### DIFF
--- a/cmd/thane/main.go
+++ b/cmd/thane/main.go
@@ -2451,9 +2451,11 @@ func runServe(ctx context.Context, stdout io.Writer, stderr io.Writer, configPat
 			})
 		}
 
-		connectCtx, connectCancel := context.WithTimeout(ctx, 5*time.Second)
-		err = mqttPub.Connect(connectCtx)
-		connectCancel()
+		// Pass the long-lived server context as the lifecycle context
+		// for the MQTT ConnectionManager. A short-lived context here
+		// would kill the connection as soon as it expired (#572).
+		// The initial connection await has its own internal timeout.
+		err = mqttPub.Connect(ctx)
 		if err != nil {
 			logger.Error("mqtt publisher connection failed", "error", err)
 		} else {

--- a/internal/channels/mqtt/publisher.go
+++ b/internal/channels/mqtt/publisher.go
@@ -140,9 +140,12 @@ func (p *Publisher) PublishDynamicState(ctx context.Context, entitySuffix, state
 // Connect establishes the MQTT broker connection, publishes discovery
 // configs, and configures subscriptions. It does not start the periodic
 // publish loop — use [Publisher.PublishStates] in a loop infrastructure
-// handler for that. Returns after the connection is established (or
-// after a 30-second timeout, in which case autopaho retries in the
-// background).
+// handler for that.
+//
+// ctx is the lifecycle context for the MQTT connection manager — it
+// must remain valid for as long as the connection should stay alive.
+// Do NOT pass a short-lived or timeout-bounded context here; the
+// initial connection await uses its own internal timeout.
 func (p *Publisher) Connect(ctx context.Context) error {
 	return p.connect(ctx)
 }
@@ -278,20 +281,22 @@ func (p *Publisher) Start(ctx context.Context) error {
 // message before closing the MQTT connection. The provided context
 // controls how long to wait for the publish and disconnect to complete.
 func (p *Publisher) Stop(ctx context.Context) error {
-	if p.cm == nil {
+	cm := p.getCM()
+	if cm == nil {
 		return nil
 	}
-	p.publishAvailability(ctx, p.cm, "offline")
-	return p.cm.Disconnect(ctx)
+	p.publishAvailability(ctx, cm, "offline")
+	return cm.Disconnect(ctx)
 }
 
 // AwaitConnection blocks until the MQTT broker connection is
 // established or ctx expires. Useful for connwatch health probes.
 func (p *Publisher) AwaitConnection(ctx context.Context) error {
-	if p.cm == nil {
+	cm := p.getCM()
+	if cm == nil {
 		return fmt.Errorf("mqtt publisher not started")
 	}
-	return p.cm.AwaitConnection(ctx)
+	return cm.AwaitConnection(ctx)
 }
 
 // getCM returns the connection manager under the mutex, safe for
@@ -544,7 +549,8 @@ func (p *Publisher) runLoop(ctx context.Context) {
 }
 
 func (p *Publisher) publishStates(ctx context.Context) {
-	if p.cm == nil {
+	cm := p.getCM()
+	if cm == nil {
 		return
 	}
 
@@ -565,7 +571,7 @@ func (p *Publisher) publishStates(ctx context.Context) {
 	}
 
 	for entity, value := range states {
-		if _, err := p.cm.Publish(ctx, &paho.Publish{
+		if _, err := cm.Publish(ctx, &paho.Publish{
 			Topic:   p.StateTopic(entity),
 			Payload: []byte(value),
 			QoS:     0,


### PR DESCRIPTION
## Summary

- **Root cause**: `main.go` passed a 5-second timeout context to `mqttPub.Connect()`, but `autopaho.NewConnection()` uses that context as the ConnectionManager's lifecycle context. When the timeout expired, the entire connection was torn down, causing all subsequent `PublishDynamicState` calls to fail with stale connection errors.
- **Fix**: Pass the long-lived server context (`ctx`) instead of a short-lived timeout context. The initial connection await has its own internal timeout.
- **Secondary fix**: `publishStates()`, `Stop()`, and `AwaitConnection()` accessed `p.cm` directly without the mutex. Updated to use the existing `getCM()` accessor for thread safety.

## Test plan

- [x] `just ci` passes locally
- [ ] Deploy and verify MQTT telemetry publishes survive reconnection cycles
- [ ] Confirm `PublishDynamicState` no longer fails after initial connect timeout expires

Closes #572