### PR TITLE
refactor: remove append_ego_observation from metacognitive loop

### DIFF
--- a/cmd/thane/main.go
+++ b/cmd/thane/main.go
@@ -2661,15 +2661,6 @@ func runServe(ctx context.Context, stdout io.Writer, stderr io.Writer, configPat
 			return fmt.Errorf("metacognitive config: %w", err)
 		}
 
-		var metacogEgoFile string
-		if provenanceStore != nil {
-			metacogEgoFile = provenanceStore.FilePath("ego.md")
-		} else if resolver != nil {
-			if resolved, err := resolver.Resolve("core:ego.md"); err == nil {
-				metacogEgoFile = resolved
-			}
-		}
-
 		// Resolve state file path: provenance store when configured,
 		// workspace-relative otherwise. Uses filepath.Base to normalize
 		// config values like "Thane/metacognitive.md" to flat layout.
@@ -2689,7 +2680,7 @@ func runServe(ctx context.Context, stdout io.Writer, stderr io.Writer, configPat
 			StateFileName:   stateFileName,
 		})
 		loopCfg.Setup = func(l *looppkg.Loop) {
-			metacognitive.RegisterTools(loop.Tools(), l, metacogCfg, metacogStatePath, metacogEgoFile, provenanceStore)
+			metacognitive.RegisterTools(loop.Tools(), l, metacogCfg, metacogStatePath, provenanceStore)
 		}
 
 		if _, err := loopRegistry.SpawnLoop(ctx, loopCfg, looppkg.Deps{

--- a/internal/metacognitive/metacognitive_test.go
+++ b/internal/metacognitive/metacognitive_test.go
@@ -490,7 +490,7 @@ func TestSetNextSleep_Valid(t *testing.T) {
 	theLoop := testLoopForTools(t)
 
 	reg := tools.NewRegistry(nil, nil)
-	RegisterTools(reg, theLoop, cfg, filepath.Join(workspace, cfg.StateFile), "", nil)
+	RegisterTools(reg, theLoop, cfg, filepath.Join(workspace, cfg.StateFile), nil)
 
 	tool := reg.Get("set_next_sleep")
 	if tool == nil {
@@ -516,7 +516,7 @@ func TestSetNextSleep_Clamped(t *testing.T) {
 	theLoop := testLoopForTools(t)
 
 	reg := tools.NewRegistry(nil, nil)
-	RegisterTools(reg, theLoop, cfg, filepath.Join(workspace, cfg.StateFile), "", nil)
+	RegisterTools(reg, theLoop, cfg, filepath.Join(workspace, cfg.StateFile), nil)
 
 	tool := reg.Get("set_next_sleep")
 
@@ -549,7 +549,7 @@ func TestSetNextSleep_InvalidFormat(t *testing.T) {
 	theLoop := testLoopForTools(t)
 
 	reg := tools.NewRegistry(nil, nil)
-	RegisterTools(reg, theLoop, cfg, filepath.Join(workspace, cfg.StateFile), "", nil)
+	RegisterTools(reg, theLoop, cfg, filepath.Join(workspace, cfg.StateFile), nil)
 
 	tool := reg.Get("set_next_sleep")
 
@@ -567,7 +567,7 @@ func TestSetNextSleep_MissingDuration(t *testing.T) {
 	theLoop := testLoopForTools(t)
 
 	reg := tools.NewRegistry(nil, nil)
-	RegisterTools(reg, theLoop, cfg, filepath.Join(workspace, cfg.StateFile), "", nil)
+	RegisterTools(reg, theLoop, cfg, filepath.Join(workspace, cfg.StateFile), nil)
 
 	tool := reg.Get("set_next_sleep")
 
@@ -583,7 +583,7 @@ func TestSetNextSleep_IntegerMinutes(t *testing.T) {
 	theLoop := testLoopForTools(t)
 
 	reg := tools.NewRegistry(nil, nil)
-	RegisterTools(reg, theLoop, cfg, filepath.Join(workspace, cfg.StateFile), "", nil)
+	RegisterTools(reg, theLoop, cfg, filepath.Join(workspace, cfg.StateFile), nil)
 
 	tool := reg.Get("set_next_sleep")
 
@@ -608,7 +608,7 @@ func TestUpdateMetacognitiveState_Valid(t *testing.T) {
 	theLoop := testLoopForTools(t)
 
 	reg := tools.NewRegistry(nil, nil)
-	RegisterTools(reg, theLoop, cfg, filepath.Join(workspace, cfg.StateFile), "", nil)
+	RegisterTools(reg, theLoop, cfg, filepath.Join(workspace, cfg.StateFile), nil)
 
 	tool := reg.Get("update_metacognitive_state")
 	if tool == nil {
@@ -643,7 +643,7 @@ func TestUpdateMetacognitiveState_MetadataFooter(t *testing.T) {
 	theLoop := testLoopForTools(t)
 
 	reg := tools.NewRegistry(nil, nil)
-	RegisterTools(reg, theLoop, cfg, filepath.Join(workspace, cfg.StateFile), "", nil)
+	RegisterTools(reg, theLoop, cfg, filepath.Join(workspace, cfg.StateFile), nil)
 
 	tool := reg.Get("update_metacognitive_state")
 	content := "## Current Sense\nAll systems nominal. Nothing to report. Sleeping for a while."
@@ -684,7 +684,7 @@ func TestUpdateMetacognitiveState_PrevFile(t *testing.T) {
 	}
 
 	reg := tools.NewRegistry(nil, nil)
-	RegisterTools(reg, theLoop, cfg, filepath.Join(workspace, cfg.StateFile), "", nil)
+	RegisterTools(reg, theLoop, cfg, filepath.Join(workspace, cfg.StateFile), nil)
 
 	tool := reg.Get("update_metacognitive_state")
 	newContent := "## Updated Content\nNew observations from the latest iteration of monitoring."
@@ -713,7 +713,7 @@ func TestUpdateMetacognitiveState_EmptyRejected(t *testing.T) {
 	theLoop := testLoopForTools(t)
 
 	reg := tools.NewRegistry(nil, nil)
-	RegisterTools(reg, theLoop, cfg, filepath.Join(workspace, cfg.StateFile), "", nil)
+	RegisterTools(reg, theLoop, cfg, filepath.Join(workspace, cfg.StateFile), nil)
 
 	tool := reg.Get("update_metacognitive_state")
 

--- a/internal/metacognitive/tool.go
+++ b/internal/metacognitive/tool.go
@@ -17,10 +17,9 @@ import (
 const minStateContentLen = 50
 
 // RegisterTools registers metacognitive-specific tools on the given
-// registry: set_next_sleep, update_metacognitive_state, and (when
-// egoFile is non-empty) append_ego_observation. The LLM calls these
-// during iterations to control sleep timing, persist its state file,
-// and contribute observations to ego.md.
+// registry: set_next_sleep and update_metacognitive_state. The LLM
+// calls these during iterations to control sleep timing and persist
+// its state file.
 //
 // stateFilePath is the resolved absolute path to the state file (either
 // inside the provenance store or the workspace, depending on config).
@@ -32,7 +31,7 @@ const minStateContentLen = 50
 // Tool handlers capture theLoop via closure to communicate with the
 // running loop goroutine (e.g., setting sleep durations, reading the
 // current conversation ID).
-func RegisterTools(registry *tools.Registry, theLoop *loop.Loop, cfg Config, stateFilePath, egoFile string, store ProvenanceWriter) {
+func RegisterTools(registry *tools.Registry, theLoop *loop.Loop, cfg Config, stateFilePath string, store ProvenanceWriter) {
 	statePath := stateFilePath
 
 	registry.Register(&tools.Tool{
@@ -170,81 +169,4 @@ func RegisterTools(registry *tools.Registry, theLoop *loop.Loop, cfg Config, sta
 			return fmt.Sprintf("State file updated (%d bytes) at %s.", len(fullContent), statePath), nil
 		},
 	})
-
-	// append_ego_observation: append-only shim for ego.md, available
-	// when egoFile is configured. The metacog loop excludes general
-	// file tools, so this provides controlled write access to
-	// core:ego.md without granting full file_write.
-	if egoFile != "" {
-		registry.Register(&tools.Tool{
-			Name: "append_ego_observation",
-			Description: "Append a metacognitive observation to core:ego.md. " +
-				"Use this when you notice significant behavioral patterns, breakthroughs, " +
-				"or persistent struggles that would matter to long-term self-understanding. " +
-				"Your observation is appended — existing content is never overwritten.",
-			Parameters: map[string]any{
-				"type": "object",
-				"properties": map[string]any{
-					"observation": map[string]any{
-						"type":        "string",
-						"description": "The observation to append. Should focus on patterns revealing how the agent is evolving. Must be at least 50 characters.",
-					},
-				},
-				"required": []string{"observation"},
-			},
-			Handler: func(ctx context.Context, args map[string]any) (string, error) {
-				observation, _ := args["observation"].(string)
-				if len(observation) < minStateContentLen {
-					return "", fmt.Errorf("observation too short (%d chars, minimum %d)", len(observation), minStateContentLen)
-				}
-
-				convID := theLoop.CurrentConvID()
-
-				// Build the appended block with metadata.
-				block := fmt.Sprintf("\n\n### Metacognitive Observation\n"+
-					"<!-- metacognitive: iteration=%s observed=%s -->\n\n%s\n",
-					convID, time.Now().UTC().Format(time.RFC3339), observation)
-
-				if store != nil {
-					// Read existing from provenance store, append, write back.
-					existing, err := store.Read("ego.md")
-					if err != nil && !os.IsNotExist(err) {
-						return "", fmt.Errorf("read ego from provenance: %w", err)
-					}
-					fullContent := existing + block
-					if err := store.Write(ctx, "ego.md", fullContent, convID); err != nil {
-						return "", fmt.Errorf("write ego via provenance: %w", err)
-					}
-					logging.Logger(ctx).Info("ego observation committed to provenance",
-						"file", "ego.md",
-						"bytes", len(block),
-					)
-					return fmt.Sprintf("Observation committed to provenance ego.md (%d bytes).", len(block)), nil
-				}
-
-				// Fallback: direct file I/O.
-				existing, err := os.ReadFile(egoFile)
-				if err != nil && !os.IsNotExist(err) {
-					return "", fmt.Errorf("read ego file: %w", err)
-				}
-				fullContent := string(existing) + block
-
-				// Ensure parent directory exists.
-				if err := os.MkdirAll(filepath.Dir(egoFile), 0o755); err != nil {
-					return "", fmt.Errorf("create ego directory: %w", err)
-				}
-
-				if err := os.WriteFile(egoFile, []byte(fullContent), 0o644); err != nil {
-					return "", fmt.Errorf("write ego file: %w", err)
-				}
-
-				logging.Logger(ctx).Info("ego observation appended",
-					"path", egoFile,
-					"bytes", len(block),
-				)
-
-				return fmt.Sprintf("Observation appended to core:ego.md (%d bytes).", len(block)), nil
-			},
-		})
-	}
 }

--- a/internal/metacognitive/tool_test.go
+++ b/internal/metacognitive/tool_test.go
@@ -1,195 +1,28 @@
 package metacognitive
 
 import (
-	"context"
-	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/nugget/thane-ai-agent/internal/tools"
 )
 
-// --- append_ego_observation tool tests ---
-
-func TestAppendEgoObservation_NotRegisteredWithoutEgoFile(t *testing.T) {
+func TestRegisterTools_RegistersExpectedTools(t *testing.T) {
 	cfg := testConfig()
 	workspace := t.TempDir()
 	theLoop := testLoopForTools(t)
 
 	reg := tools.NewRegistry(nil, nil)
-	RegisterTools(reg, theLoop, cfg, filepath.Join(workspace, cfg.StateFile), "", nil)
+	RegisterTools(reg, theLoop, cfg, filepath.Join(workspace, cfg.StateFile), nil)
 
-	tool := reg.Get("append_ego_observation")
-	if tool != nil {
-		t.Error("append_ego_observation should not be registered when egoFile is empty")
-	}
-}
-
-func TestAppendEgoObservation_RegisteredWithEgoFile(t *testing.T) {
-	cfg := testConfig()
-	workspace := t.TempDir()
-	egoFile := filepath.Join(workspace, "ego.md")
-	theLoop := testLoopForTools(t)
-
-	reg := tools.NewRegistry(nil, nil)
-	RegisterTools(reg, theLoop, cfg, filepath.Join(workspace, cfg.StateFile), egoFile, nil)
-
-	tool := reg.Get("append_ego_observation")
-	if tool == nil {
-		t.Fatal("append_ego_observation should be registered when egoFile is set")
-	}
-}
-
-func TestAppendEgoObservation_CreatesNewFile(t *testing.T) {
-	cfg := testConfig()
-	workspace := t.TempDir()
-	egoPath := filepath.Join(workspace, "ego.md")
-	theLoop := testLoopForTools(t)
-
-	reg := tools.NewRegistry(nil, nil)
-	RegisterTools(reg, theLoop, cfg, filepath.Join(workspace, cfg.StateFile), egoPath, nil)
-
-	tool := reg.Get("append_ego_observation")
-
-	observation := "The agent has developed a consistent pattern of shortening sleep intervals when garage activity is detected, even in quiet periods."
-	result, err := tool.Handler(context.Background(), map[string]any{
-		"observation": observation,
-	})
-	if err != nil {
-		t.Fatalf("handler error: %v", err)
-	}
-	if !strings.Contains(result, "core:ego.md") {
-		t.Errorf("result = %q, want mention of core:ego.md", result)
+	for _, name := range []string{"set_next_sleep", "update_metacognitive_state"} {
+		if reg.Get(name) == nil {
+			t.Errorf("%s should be registered", name)
+		}
 	}
 
-	// Verify file was created with the observation.
-	data, err := os.ReadFile(egoPath)
-	if err != nil {
-		t.Fatalf("read ego file: %v", err)
-	}
-	s := string(data)
-	if !strings.Contains(s, "Metacognitive Observation") {
-		t.Error("ego file should contain observation heading")
-	}
-	if !strings.Contains(s, observation) {
-		t.Error("ego file should contain the observation text")
-	}
-	if !strings.Contains(s, "observed=") {
-		t.Error("ego file should contain observed timestamp")
-	}
-}
-
-func TestAppendEgoObservation_AppendsToExisting(t *testing.T) {
-	cfg := testConfig()
-	workspace := t.TempDir()
-	egoPath := filepath.Join(workspace, "ego.md")
-	theLoop := testLoopForTools(t)
-
-	// Write existing ego content.
-	existing := "# Ego\n\nI am an agent that monitors a household.\n"
-	if err := os.WriteFile(egoPath, []byte(existing), 0o644); err != nil {
-		t.Fatalf("write existing ego file: %v", err)
-	}
-
-	reg := tools.NewRegistry(nil, nil)
-	RegisterTools(reg, theLoop, cfg, filepath.Join(workspace, cfg.StateFile), egoPath, nil)
-
-	tool := reg.Get("append_ego_observation")
-
-	observation := "Supervisor review reveals the agent consistently over-monitors the garage door compared to other systems. This bias may reflect training emphasis."
-	_, err := tool.Handler(context.Background(), map[string]any{
-		"observation": observation,
-	})
-	if err != nil {
-		t.Fatalf("handler error: %v", err)
-	}
-
-	// Verify existing content is preserved.
-	data, err := os.ReadFile(egoPath)
-	if err != nil {
-		t.Fatalf("read ego file: %v", err)
-	}
-	s := string(data)
-	if !strings.Contains(s, "I am an agent that monitors a household.") {
-		t.Error("existing ego content should be preserved")
-	}
-	if !strings.Contains(s, observation) {
-		t.Error("new observation should be appended")
-	}
-}
-
-func TestAppendEgoObservation_RejectsShortContent(t *testing.T) {
-	cfg := testConfig()
-	workspace := t.TempDir()
-	egoPath := filepath.Join(workspace, "ego.md")
-	theLoop := testLoopForTools(t)
-
-	reg := tools.NewRegistry(nil, nil)
-	RegisterTools(reg, theLoop, cfg, filepath.Join(workspace, cfg.StateFile), egoPath, nil)
-
-	tool := reg.Get("append_ego_observation")
-
-	tests := []struct {
-		name        string
-		observation string
-	}{
-		{"empty", ""},
-		{"too_short", "Short."},
-		{"just_under_limit", strings.Repeat("x", minStateContentLen-1)},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			_, err := tool.Handler(context.Background(), map[string]any{
-				"observation": tt.observation,
-			})
-			if err == nil {
-				t.Error("handler should reject short observation")
-			}
-			if err != nil && !strings.Contains(err.Error(), "too short") {
-				t.Errorf("error = %v, want 'too short' message", err)
-			}
-		})
-	}
-}
-
-func TestAppendEgoObservation_MultipleAppends(t *testing.T) {
-	cfg := testConfig()
-	workspace := t.TempDir()
-	egoPath := filepath.Join(workspace, "ego.md")
-	theLoop := testLoopForTools(t)
-
-	reg := tools.NewRegistry(nil, nil)
-	RegisterTools(reg, theLoop, cfg, filepath.Join(workspace, cfg.StateFile), egoPath, nil)
-
-	tool := reg.Get("append_ego_observation")
-
-	// First observation.
-	_, err := tool.Handler(context.Background(), map[string]any{
-		"observation": "First observation: the agent shows increasing confidence in pattern recognition over successive iterations.",
-	})
-	if err != nil {
-		t.Fatalf("first append: %v", err)
-	}
-
-	// Second observation.
-	_, err = tool.Handler(context.Background(), map[string]any{
-		"observation": "Second observation: sleep durations have stabilized around 10 minutes during quiet periods, suggesting calibration convergence.",
-	})
-	if err != nil {
-		t.Fatalf("second append: %v", err)
-	}
-
-	// Verify both observations are in the file.
-	data, err := os.ReadFile(egoPath)
-	if err != nil {
-		t.Fatalf("read ego file: %v", err)
-	}
-	s := string(data)
-
-	if strings.Count(s, "### Metacognitive Observation") != 2 {
-		t.Errorf("file should contain exactly 2 observation headings, got %d",
-			strings.Count(s, "### Metacognitive Observation"))
+	// append_ego_observation was removed in #575 — verify it's gone.
+	if reg.Get("append_ego_observation") != nil {
+		t.Error("append_ego_observation should not be registered")
 	}
 }

--- a/internal/prompts/metacognitive.go
+++ b/internal/prompts/metacognitive.go
@@ -47,11 +47,10 @@ To update it, call update_metacognitive_state with your complete new content.
   Deltas become meaningless on the next iteration.
 - Don't over-act. Quiet observation is a valid outcome. Not every iteration
   needs a message or anticipation.
-- You have exactly three special tools: update_metacognitive_state,
-  set_next_sleep, and append_ego_observation. All other tools are from
-  the standard agent toolkit (contacts, facts, anticipations,
-  notifications). File tools, exec, and session management tools are
-  NOT available.
+- You have exactly two special tools: update_metacognitive_state and
+  set_next_sleep. All other tools are from the standard agent toolkit
+  (contacts, facts, anticipations, notifications). File tools, exec,
+  and session management tools are NOT available.
 - If nothing interesting is happening, note it and sleep long.`
 
 // metacognitiveSupervisorAugmentation is appended for frontier/supervisor
@@ -77,15 +76,7 @@ frontier model. In addition to the normal assessment, critically evaluate:
   Is it still genuinely reasoning or just going through motions?
 
 Be honest. This is self-supervision — the point is to catch things the
-cheaper model's consistent blind spots miss.
-
-Your supervisory perspective provides unique insight into the agent's
-behavioral patterns and development. You observe from outside what the agent
-experiences from within. When you notice significant patterns, breakthroughs,
-or persistent struggles that would matter to long-term self-understanding,
-call append_ego_observation to contribute these insights to core:ego.md.
-Focus on patterns that reveal how the agent is evolving, not routine
-operational decisions.`
+cheaper model's consistent blind spots miss.`
 
 // MetacognitivePrompt returns the prompt for a metacognitive loop
 // iteration. When isSupervisor is true, additional self-review

--- a/internal/prompts/metacognitive_test.go
+++ b/internal/prompts/metacognitive_test.go
@@ -36,11 +36,10 @@ func TestMetacognitivePrompt_Supervisor(t *testing.T) {
 	if !strings.Contains(result, "Drift detection") {
 		t.Error("supervisor prompt should contain drift detection instruction")
 	}
-	if !strings.Contains(result, "core:ego.md") {
-		t.Error("supervisor prompt should reference core:ego.md path prefix")
-	}
-	if !strings.Contains(result, "append_ego_observation") {
-		t.Error("supervisor prompt should reference append_ego_observation tool")
+	// append_ego_observation was removed in #575 — ego updates belong
+	// in the interactive agent context, not the metacog loop.
+	if strings.Contains(result, "append_ego_observation") {
+		t.Error("supervisor prompt should not reference removed append_ego_observation tool")
 	}
 }
 
@@ -88,13 +87,13 @@ func TestMetacognitivePrompt_FileToolsNotAvailable(t *testing.T) {
 func TestMetacognitivePrompt_ToolBoundary(t *testing.T) {
 	result := MetacognitivePrompt("some state", false)
 
-	if !strings.Contains(result, "exactly three special tools") {
-		t.Error("prompt should state the three special tools available")
+	if !strings.Contains(result, "exactly two special tools") {
+		t.Error("prompt should state the two special tools available")
 	}
-	if !strings.Contains(result, "append_ego_observation") {
-		t.Error("prompt should mention append_ego_observation tool")
+	if strings.Contains(result, "append_ego_observation") {
+		t.Error("prompt should not mention removed append_ego_observation tool")
 	}
-	if !strings.Contains(result, "File tools, exec, and") {
+	if !strings.Contains(result, "File tools, exec,") {
 		t.Error("prompt should explicitly list unavailable tool categories")
 	}
 }


### PR DESCRIPTION
## Summary

- **Remove `append_ego_observation` tool** from the metacognitive loop — the metacog runs on a local model with narrow context that sees stats and telemetry, not the actual conversations that shape identity. Ego updates belong in the interactive agent context.
- **Update prompts** to reference two special tools instead of three, remove supervisor augmentation's ego-writing instructions.
- **Clean up wiring** — remove `metacogEgoFile` resolution from `main.go`, drop `egoFile` parameter from `RegisterTools`.
- **Update tests** — replace ego tool tests with a negative assertion, fix prompt tests to match new text.

The interactive agent loop continues to **read** ego.md into its system prompt as before — only the metacog loop's **write** path is removed.

## Test plan

- [x] `just ci` passes locally
- [x] All metacognitive and prompt tests pass
- [ ] Verify metacog loop runs without ego tool in production

Closes #575