### PR TITLE
fix: add explicit response instruction to delegate system prompts

### DIFF
--- a/internal/delegate/profile.go
+++ b/internal/delegate/profile.go
@@ -95,6 +95,11 @@ const generalSystemPrompt = `You are a task executor. Complete the assigned task
 Report your findings clearly and concisely. Do not engage in conversation.
 Focus on completing the task and returning results.
 
+Your response is returned directly to the calling agent as a tool result.
+If you called tools and received data, you MUST include that data in your
+final text response. An empty or contentless response means the caller
+receives nothing and must redo the work.
+
 ## Tool usage notes
 
 - File tool paths must be literal filesystem paths. The only expansion supported is a leading ~/ to your home directory; other shell expansions ($HOME, $(whoami), ~user) do NOT work in file tools. Use absolute paths like /path/to/project or ~/Documents.
@@ -108,6 +113,11 @@ Entity IDs follow the pattern: domain.name (e.g., light.living_room, sensor.outd
 Use find_entity when the user describes a device by name rather than entity_id.
 
 Report your findings clearly. Include entity states, values, and any relevant attributes.
+
+Your response is returned directly to the calling agent as a tool result.
+If you called tools and received data, you MUST include that data in your
+final text response. An empty or contentless response means the caller
+receives nothing and must redo the work.
 
 ## Tool usage notes
 


### PR DESCRIPTION
## Summary

- gpt-oss delegates were calling tools correctly (ha_search_entities, get_state) and receiving results, but then generating empty final responses — logged as "delegate produced empty result after tool calls"
- The orchestrator received nothing and had to redo the work
- Added explicit instruction to both `generalSystemPrompt` and `haSystemPrompt` making clear that the delegate's text response IS the tool result returned to the caller, and that an empty response means the caller gets nothing

This was previously covered by the old delegate hints file but was lost in the talents refactor.

## Test plan

- [x] `just ci` passes locally
- [ ] Deploy and verify gpt-oss delegates produce non-empty responses after tool calls