### PR TITLE
feat: per-context capability scoping

### DIFF
--- a/cmd/thane/main.go
+++ b/cmd/thane/main.go
@@ -1957,7 +1957,7 @@ func runServe(ctx context.Context, stdout io.Writer, stderr io.Writer, configPat
 		// spawned through the registry so the dashboard can display
 		// dynamically activated capabilities.
 		loopRegistry.SetDefaultActiveTagsFunc(func() []string {
-			tags := loop.ActiveTags()
+			tags := loop.LastRunTags()
 			if tags == nil {
 				return nil
 			}
@@ -1978,7 +1978,7 @@ func runServe(ctx context.Context, stdout io.Writer, stderr io.Writer, configPat
 		})
 
 		var activeTags []string
-		for tag := range loop.ActiveTags() {
+		for tag := range loop.LastRunTags() {
 			activeTags = append(activeTags, tag)
 		}
 		logger.Info("capability tags enabled",

--- a/internal/agent/capability_scope.go
+++ b/internal/agent/capability_scope.go
@@ -1,0 +1,113 @@
+// Package agent provides the core agent loop implementation.
+//
+// This file implements per-Run capability scoping. Each Run() call
+// creates a capabilityScope seeded with always-active and channel-pinned
+// tags, stored in the context. Tool handlers (request_capability,
+// drop_capability) mutate the scope via context, giving each
+// conversation its own isolated capability state.
+package agent
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/nugget/thane-ai-agent/internal/config"
+)
+
+type capScopeKey struct{}
+
+// withCapabilityScope stores the scope in ctx.
+func withCapabilityScope(ctx context.Context, scope *capabilityScope) context.Context {
+	return context.WithValue(ctx, capScopeKey{}, scope)
+}
+
+// capabilityScopeFromContext extracts the scope, or nil if not set.
+func capabilityScopeFromContext(ctx context.Context) *capabilityScope {
+	if s, ok := ctx.Value(capScopeKey{}).(*capabilityScope); ok {
+		return s
+	}
+	return nil
+}
+
+// snapshotTagsFromContext returns a copy of the active tags from the
+// context-scoped capability scope. Returns nil if no scope is set.
+func snapshotTagsFromContext(ctx context.Context) map[string]bool {
+	if s := capabilityScopeFromContext(ctx); s != nil {
+		return s.Snapshot()
+	}
+	return nil
+}
+
+// capabilityScope holds the active capability tags for a single Run()
+// call. It is stored in the context and mutated by tool handlers.
+// Each scope is independent — concurrent Run() calls get separate scopes.
+type capabilityScope struct {
+	mu      sync.Mutex
+	active  map[string]bool                       // tags currently active
+	pinned  map[string]bool                       // channel-pinned (cannot be dropped)
+	capTags map[string]config.CapabilityTagConfig // read-only reference to config
+}
+
+// newCapabilityScope creates a scope seeded with all always-active tags.
+// The capTags reference is stored read-only for configured-tag checks.
+func newCapabilityScope(capTags map[string]config.CapabilityTagConfig) *capabilityScope {
+	s := &capabilityScope{
+		active:  make(map[string]bool),
+		pinned:  make(map[string]bool),
+		capTags: capTags,
+	}
+	for tag, cfg := range capTags {
+		if cfg.AlwaysActive {
+			s.active[tag] = true
+		}
+	}
+	return s
+}
+
+// PinChannelTags adds the given tags as channel-pinned. They become
+// active and cannot be dropped via Drop().
+func (s *capabilityScope) PinChannelTags(tags []string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, tag := range tags {
+		s.active[tag] = true
+		s.pinned[tag] = true
+	}
+}
+
+// Snapshot returns a copy of the active tags map. Safe for concurrent use.
+func (s *capabilityScope) Snapshot() map[string]bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	snap := make(map[string]bool, len(s.active))
+	for k, v := range s.active {
+		snap[k] = v
+	}
+	return snap
+}
+
+// Request activates a capability tag. Both configured tags (with tools
+// and static context) and ad-hoc tags (KB articles, talents, live
+// providers only) are accepted.
+func (s *capabilityScope) Request(tag string) error {
+	s.mu.Lock()
+	s.active[tag] = true
+	s.mu.Unlock()
+	return nil
+}
+
+// Drop deactivates a capability tag. Always-active and channel-pinned
+// tags cannot be dropped.
+func (s *capabilityScope) Drop(tag string) error {
+	if cfg, ok := s.capTags[tag]; ok && cfg.AlwaysActive {
+		return fmt.Errorf("cannot drop always-active tag: %q", tag)
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.pinned[tag] {
+		return fmt.Errorf("cannot drop channel-pinned tag %q (active for current channel)", tag)
+	}
+	delete(s.active, tag)
+	return nil
+}

--- a/internal/agent/channel_tags_test.go
+++ b/internal/agent/channel_tags_test.go
@@ -281,33 +281,21 @@ func TestChannelTags_UnknownChannel(t *testing.T) {
 }
 
 func TestChannelTags_DropPinnedTagRejected(t *testing.T) {
-	// Channel-pinned tags cannot be dropped via DropCapability.
-	// Simulate the state that Run() creates when a channel source is set.
-	loop := buildTestLoop(&mockLLM{}, nil)
-	loop.SetCapabilityTags(map[string]config.CapabilityTagConfig{
-		"signal": {
-			Description: "Signal messaging",
-			Tools:       []string{"signal_tool"},
-		},
-		"extra": {
-			Description: "Extra tools",
-			Tools:       []string{"extra_tool"},
-		},
-	}, nil)
-	loop.SetChannelTags(map[string][]string{
-		"signal": {"signal"},
-	})
+	// Channel-pinned tags cannot be dropped via capabilityScope.Drop.
+	capTags := map[string]config.CapabilityTagConfig{
+		"signal": {Description: "Signal messaging", Tools: []string{"signal_tool"}},
+		"extra":  {Description: "Extra tools", Tools: []string{"extra_tool"}},
+	}
+	scope := newCapabilityScope(capTags)
+	scope.PinChannelTags([]string{"signal"})
+	_ = scope.Request("extra") // agent-requested, not pinned
 
-	// Simulate what Run() does: activate the channel tag and ref-count it.
-	loop.tagMu.Lock()
-	loop.activeTags["signal"] = true
-	loop.channelPinnedTags["signal"] = 1
-	// Also activate "extra" as an agent-requested tag (not channel-pinned).
-	loop.activeTags["extra"] = true
-	loop.tagMu.Unlock()
+	ctx := withCapabilityScope(context.Background(), scope)
 
 	// Dropping the channel-pinned tag should fail.
-	err := loop.DropCapability("signal")
+	loop := buildTestLoop(&mockLLM{}, nil)
+	loop.SetCapabilityTags(capTags, nil)
+	err := loop.DropCapability(ctx, "signal")
 	if err == nil {
 		t.Fatal("expected error when dropping channel-pinned tag")
 	}
@@ -316,7 +304,7 @@ func TestChannelTags_DropPinnedTagRejected(t *testing.T) {
 	}
 
 	// The tag should still be active.
-	active := loop.ActiveTags()
+	active := scope.Snapshot()
 	if !active["signal"] {
 		t.Error("signal tag should still be active after rejected drop")
 	}
@@ -324,35 +312,25 @@ func TestChannelTags_DropPinnedTagRejected(t *testing.T) {
 
 func TestChannelTags_DropNonPinnedTagAllowed(t *testing.T) {
 	// Tags that are active but not channel-pinned can still be dropped.
-	loop := buildTestLoop(&mockLLM{}, nil)
-	loop.SetCapabilityTags(map[string]config.CapabilityTagConfig{
-		"signal": {
-			Description: "Signal messaging",
-			Tools:       []string{"signal_tool"},
-		},
-		"extra": {
-			Description: "Extra tools",
-			Tools:       []string{"extra_tool"},
-		},
-	}, nil)
-	loop.SetChannelTags(map[string][]string{
-		"signal": {"signal"},
-	})
+	capTags := map[string]config.CapabilityTagConfig{
+		"signal": {Description: "Signal messaging", Tools: []string{"signal_tool"}},
+		"extra":  {Description: "Extra tools", Tools: []string{"extra_tool"}},
+	}
+	scope := newCapabilityScope(capTags)
+	scope.PinChannelTags([]string{"signal"})
+	_ = scope.Request("extra") // agent-requested, not pinned
 
-	// Simulate: "signal" is channel-pinned, "extra" is agent-requested.
-	loop.tagMu.Lock()
-	loop.activeTags["signal"] = true
-	loop.channelPinnedTags["signal"] = 1
-	loop.activeTags["extra"] = true
-	loop.tagMu.Unlock()
+	ctx := withCapabilityScope(context.Background(), scope)
 
 	// Dropping the non-pinned tag should succeed.
-	err := loop.DropCapability("extra")
+	loop := buildTestLoop(&mockLLM{}, nil)
+	loop.SetCapabilityTags(capTags, nil)
+	err := loop.DropCapability(ctx, "extra")
 	if err != nil {
 		t.Fatalf("unexpected error dropping non-pinned tag: %v", err)
 	}
 
-	active := loop.ActiveTags()
+	active := scope.Snapshot()
 	if active["extra"] {
 		t.Error("extra tag should no longer be active after drop")
 	}

--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -204,22 +204,20 @@ type Loop struct {
 	usageStore        *usage.Store                   // nil = no usage recording
 	pricing           map[string]config.PricingEntry // model→cost for usage recording
 
-	// Capability tags — per-session tool/talent filtering.
+	// Capability tags — per-Run tool/talent filtering.
 	//
-	// activeTags is scoped to the Loop instance. All conversation
-	// channels (Signal, API, wake) share the same Loop, so active
-	// tags are effectively global. Channel-pinned tags are merged
-	// per-Run and removed on return to avoid cross-channel bleed.
-	//
-	// tagMu serializes all reads and writes to activeTags. Multiple
-	// HTTP handlers can call Run() concurrently, so every access
-	// must hold the lock.
-	tagMu             sync.Mutex
-	capTags           map[string]config.CapabilityTagConfig // tag definitions from config
-	activeTags        map[string]bool                       // currently active tags
-	channelPinnedTags map[string]int                        // ref-counted channel-pinned tags (per concurrent Run)
-	parsedTalents     []talents.Talent                      // pre-loaded talent structs for tag filtering
-	channelTags       map[string][]string                   // channel name → tag names (auto-activated per Run)
+	// Each Run() creates its own capabilityScope (stored in context)
+	// seeded with always-active + channel-pinned tags. Tool handlers
+	// mutate the scope via context, so concurrent Run() calls from
+	// different channels are fully isolated.
+	capTags       map[string]config.CapabilityTagConfig // tag definitions from config (static)
+	parsedTalents []talents.Talent                      // pre-loaded talent structs for tag filtering (static)
+	channelTags   map[string][]string                   // channel name → tag names (static)
+
+	// lastRunTags is a snapshot of the most recent Run()'s active
+	// tags, used by the dashboard callback (which has no context).
+	lastRunTagsMu sync.Mutex
+	lastRunTags   map[string]bool
 
 	// tagProviders holds live context providers keyed by capability tag.
 	// Registered via RegisterTagContextProvider and called during
@@ -247,18 +245,17 @@ type Loop struct {
 // NewLoop creates a new agent loop.
 func NewLoop(logger *slog.Logger, mem MemoryStore, compactor Compactor, rtr *router.Router, ha *homeassistant.Client, sched *scheduler.Scheduler, llmClient llm.Client, defaultModel, talents, persona string, contextWindow int) *Loop {
 	return &Loop{
-		logger:            logger,
-		memory:            mem,
-		compactor:         compactor,
-		router:            rtr,
-		llm:               llmClient,
-		tools:             tools.NewRegistry(ha, sched),
-		model:             defaultModel,
-		talents:           talents,
-		persona:           persona,
-		contextWindow:     contextWindow,
-		channelPinnedTags: make(map[string]int),
-		nowFunc:           time.Now,
+		logger:        logger,
+		memory:        mem,
+		compactor:     compactor,
+		router:        rtr,
+		llm:           llmClient,
+		tools:         tools.NewRegistry(ha, sched),
+		model:         defaultModel,
+		talents:       talents,
+		persona:       persona,
+		contextWindow: contextWindow,
+		nowFunc:       time.Now,
 	}
 }
 
@@ -391,15 +388,15 @@ func (l *Loop) SetCapabilityTags(capTags map[string]config.CapabilityTagConfig, 
 	}
 	l.tools.SetTagIndex(tagIndex)
 
-	// Activate always_active tags.
-	l.tagMu.Lock()
-	l.activeTags = make(map[string]bool)
+	// Seed lastRunTags with always-active tags for initial dashboard display.
+	l.lastRunTagsMu.Lock()
+	l.lastRunTags = make(map[string]bool)
 	for tag, cfg := range capTags {
 		if cfg.AlwaysActive {
-			l.activeTags[tag] = true
+			l.lastRunTags[tag] = true
 		}
 	}
-	l.tagMu.Unlock()
+	l.lastRunTagsMu.Unlock()
 }
 
 // SetUsageRecorder configures persistent token usage recording. When
@@ -447,70 +444,80 @@ func (l *Loop) OpenClawConfig() *config.OpenClawConfig {
 }
 
 // ActiveTags returns a snapshot of the currently active capability tags.
-// Returns nil when capability tagging is not configured. The returned
-// map is a copy — callers may read it without holding any lock.
-func (l *Loop) ActiveTags() map[string]bool {
-	return l.snapshotActiveTags()
+// ActiveTags returns the active tags from the context-scoped capability
+// scope when available, falling back to the most recent Run()'s
+// snapshot. This satisfies the [tools.CapabilityManager] interface.
+func (l *Loop) ActiveTags(ctx context.Context) map[string]bool {
+	if scope := capabilityScopeFromContext(ctx); scope != nil {
+		return scope.Snapshot()
+	}
+	return l.LastRunTags()
 }
 
-// snapshotActiveTags returns a copy of activeTags under the lock.
-// Used by read paths that need a consistent view without holding
-// the lock for the duration of their work.
-func (l *Loop) snapshotActiveTags() map[string]bool {
-	l.tagMu.Lock()
-	defer l.tagMu.Unlock()
-	if l.activeTags == nil {
+// LastRunTags returns a snapshot of the most recent Run()'s active
+// tags. Used by the dashboard callback which has no Run context.
+func (l *Loop) LastRunTags() map[string]bool {
+	l.lastRunTagsMu.Lock()
+	defer l.lastRunTagsMu.Unlock()
+	if l.lastRunTags == nil {
 		return nil
 	}
-	snap := make(map[string]bool, len(l.activeTags))
-	for k, v := range l.activeTags {
+	snap := make(map[string]bool, len(l.lastRunTags))
+	for k, v := range l.lastRunTags {
 		snap[k] = v
 	}
 	return snap
 }
 
-// RequestCapability activates a capability tag for the current session.
-// Both configured tags (with tools and static context) and ad-hoc tags
-// (with only tagged KB articles, talents, or live providers) are
-// accepted. Ad-hoc tags allow site-specific capability sets to be
-// created through KB articles and talents without config changes.
-func (l *Loop) RequestCapability(tag string) error {
-	l.tagMu.Lock()
-	if l.activeTags == nil {
-		l.activeTags = make(map[string]bool)
+// RequestCapability activates a capability tag for the current Run.
+// Delegates to the context-scoped capabilityScope. Both configured
+// tags and ad-hoc tags are accepted.
+func (l *Loop) RequestCapability(ctx context.Context, tag string) error {
+	scope := capabilityScopeFromContext(ctx)
+	if scope == nil {
+		return fmt.Errorf("no capability scope in context")
 	}
-	l.activeTags[tag] = true
-	l.tagMu.Unlock()
+	if err := scope.Request(tag); err != nil {
+		return err
+	}
 
-	configured := ""
+	// Update dashboard snapshot.
+	l.updateLastRunTags(scope)
+
+	configured := "ad-hoc"
 	if _, ok := l.capTags[tag]; ok {
 		configured = "configured"
-	} else {
-		configured = "ad-hoc"
 	}
 	l.logger.Info("capability activated", "tag", tag, "type", configured)
 	return nil
 }
 
-// DropCapability deactivates a capability tag for the current session.
-// Always-active and channel-pinned tags cannot be dropped. Ad-hoc tags
-// (not in config) can always be dropped.
-func (l *Loop) DropCapability(tag string) error {
-	// Check configured-tag constraints (always-active, channel-pinned).
-	if cfg, ok := l.capTags[tag]; ok {
-		if cfg.AlwaysActive {
-			return fmt.Errorf("cannot drop always-active tag: %q", tag)
-		}
+// DropCapability deactivates a capability tag for the current Run.
+// Delegates to the context-scoped capabilityScope. Always-active and
+// channel-pinned tags cannot be dropped.
+func (l *Loop) DropCapability(ctx context.Context, tag string) error {
+	scope := capabilityScopeFromContext(ctx)
+	if scope == nil {
+		return fmt.Errorf("no capability scope in context")
 	}
-	l.tagMu.Lock()
-	if l.channelPinnedTags[tag] > 0 {
-		l.tagMu.Unlock()
-		return fmt.Errorf("cannot drop channel-pinned tag %q (active for current channel)", tag)
+	if err := scope.Drop(tag); err != nil {
+		return err
 	}
-	delete(l.activeTags, tag)
-	l.tagMu.Unlock()
+
+	// Update dashboard snapshot.
+	l.updateLastRunTags(scope)
+
 	l.logger.Info("capability deactivated", "tag", tag)
 	return nil
+}
+
+// updateLastRunTags copies the scope's active tags into lastRunTags
+// so the dashboard (which has no context) can display current state.
+func (l *Loop) updateLastRunTags(scope *capabilityScope) {
+	snap := scope.Snapshot()
+	l.lastRunTagsMu.Lock()
+	l.lastRunTags = snap
+	l.lastRunTagsMu.Unlock()
 }
 
 // Tools returns the tool registry for adding additional tools.
@@ -572,9 +579,8 @@ type promptSection struct {
 func (l *Loop) buildSystemPrompt(ctx context.Context, userMessage string, history []memory.Message) string {
 	var sb strings.Builder
 
-	// Snapshot active tags once for the duration of prompt assembly.
-	// This avoids holding tagMu across file I/O, HA fetches, etc.
-	tags := l.snapshotActiveTags()
+	// Snapshot active tags from the per-Run capability scope.
+	tags := snapshotTagsFromContext(ctx)
 
 	// Track section boundaries for debug dump.
 	var sections []promptSection
@@ -968,47 +974,25 @@ func (l *Loop) Run(ctx context.Context, req *Request, stream StreamCallback) (re
 		}, nil
 	}
 
-	// Activate channel-pinned tags for this Run() call. Look up the
-	// request's source channel and merge matching capability tags into
-	// activeTags. Tags are ref-counted in channelPinnedTags so that
-	// concurrent Run() calls from the same channel don't clobber each
-	// other, and DropCapability can reject attempts to shed them.
-	var channelActivatedTags []string
-	l.tagMu.Lock()
-	if l.channelTags != nil && l.activeTags != nil {
+	// Create a per-Run capability scope seeded with always-active tags.
+	// Channel-pinned tags are merged based on the request's source hint.
+	// The scope is stored in the context so tool handlers and system
+	// prompt assembly read/write per-Run state, not global state.
+	var scope *capabilityScope
+	if l.capTags != nil {
+		scope = newCapabilityScope(l.capTags)
 		if source := req.Hints["source"]; source != "" {
 			if pinnedTags, ok := l.channelTags[source]; ok {
-				for _, tag := range pinnedTags {
-					l.channelPinnedTags[tag]++
-					if !l.activeTags[tag] {
-						l.activeTags[tag] = true
-					}
-					channelActivatedTags = append(channelActivatedTags, tag)
-				}
+				scope.PinChannelTags(pinnedTags)
+				log.Info("channel tags activated",
+					"source", source,
+					"pinned_tags", pinnedTags,
+				)
 			}
 		}
+		ctx = withCapabilityScope(ctx, scope)
+		l.updateLastRunTags(scope)
 	}
-	l.tagMu.Unlock()
-	if len(channelActivatedTags) > 0 {
-		log.Info("channel tags activated",
-			"source", req.Hints["source"],
-			"pinned_tags", channelActivatedTags,
-		)
-	}
-	defer func() {
-		l.tagMu.Lock()
-		for _, tag := range channelActivatedTags {
-			l.channelPinnedTags[tag]--
-			if l.channelPinnedTags[tag] <= 0 {
-				delete(l.channelPinnedTags, tag)
-				// Only remove from activeTags if not always-active.
-				if cfg, ok := l.capTags[tag]; !ok || !cfg.AlwaysActive {
-					delete(l.activeTags, tag)
-				}
-			}
-		}
-		l.tagMu.Unlock()
-	}()
 
 	// Pre-compaction memory flush: when the request has a custom system
 	// prompt (OpenClaw profile) and tokens are approaching the compaction
@@ -1206,12 +1190,14 @@ func (l *Loop) Run(ctx context.Context, req *Request, stream StreamCallback) (re
 		// iteration so tags activated via request_capability are reflected.
 		ToolDefs: func(i int) []map[string]any {
 			effectiveTools := baseTools
-			if tagSnap := l.snapshotActiveTags(); tagSnap != nil && !skipTagFilter {
-				activeTags := make([]string, 0, len(tagSnap))
-				for tag := range tagSnap {
-					activeTags = append(activeTags, tag)
+			if scope != nil && !skipTagFilter {
+				if tagSnap := scope.Snapshot(); len(tagSnap) > 0 {
+					tagList := make([]string, 0, len(tagSnap))
+					for tag := range tagSnap {
+						tagList = append(tagList, tag)
+					}
+					effectiveTools = baseTools.FilterByTags(tagList)
 				}
-				effectiveTools = baseTools.FilterByTags(activeTags)
 			}
 			if gatingActive {
 				return effectiveTools.FilteredCopy(l.orchestratorTools).List()
@@ -1222,12 +1208,14 @@ func (l *Loop) Run(ctx context.Context, req *Request, stream StreamCallback) (re
 		// Tool availability check using the effective tools for this iteration.
 		CheckToolAvail: func(toolName string) bool {
 			effectiveTools := baseTools
-			if tagSnap := l.snapshotActiveTags(); tagSnap != nil && !skipTagFilter {
-				activeTags := make([]string, 0, len(tagSnap))
-				for tag := range tagSnap {
-					activeTags = append(activeTags, tag)
+			if scope != nil && !skipTagFilter {
+				if tagSnap := scope.Snapshot(); len(tagSnap) > 0 {
+					tagList := make([]string, 0, len(tagSnap))
+					for tag := range tagSnap {
+						tagList = append(tagList, tag)
+					}
+					effectiveTools = baseTools.FilterByTags(tagList)
 				}
-				effectiveTools = baseTools.FilterByTags(activeTags)
 			}
 			return effectiveTools.Get(toolName) != nil
 		},

--- a/internal/agent/orchestrator_tools_test.go
+++ b/internal/agent/orchestrator_tools_test.go
@@ -104,13 +104,12 @@ func buildTestLoop(mock *mockLLM, extraNames []string) *Loop {
 	}
 
 	l := &Loop{
-		logger:            slog.Default(),
-		memory:            newMockMem(),
-		llm:               mock,
-		tools:             reg,
-		model:             "test-model",
-		talents:           "",
-		channelPinnedTags: make(map[string]int),
+		logger:  slog.Default(),
+		memory:  newMockMem(),
+		llm:     mock,
+		tools:   reg,
+		model:   "test-model",
+		talents: "",
 	}
 	return l
 }

--- a/internal/agent/tag_context_test.go
+++ b/internal/agent/tag_context_test.go
@@ -36,6 +36,16 @@ func setTagsWithAssembler(l *Loop, capTags map[string]config.CapabilityTagConfig
 	}))
 }
 
+// testCtxForLoop creates a context containing a capabilityScope seeded
+// from the loop's capTags (always-active tags are activated). This
+// mirrors what Run() does before calling buildSystemPrompt.
+func testCtxForLoop(l *Loop) context.Context {
+	if l.capTags == nil {
+		return context.Background()
+	}
+	return withCapabilityScope(context.Background(), newCapabilityScope(l.capTags))
+}
+
 func TestBuildSystemPrompt_TagContextIncluded(t *testing.T) {
 	dir := t.TempDir()
 	f1 := filepath.Join(dir, "arch.md")
@@ -53,7 +63,7 @@ func TestBuildSystemPrompt_TagContextIncluded(t *testing.T) {
 		},
 	}, nil)
 
-	prompt := l.buildSystemPrompt(context.Background(), "hello", nil)
+	prompt := l.buildSystemPrompt(testCtxForLoop(l), "hello", nil)
 
 	if !strings.Contains(prompt, "hexagonal pattern") {
 		t.Error("system prompt should contain first context file content")
@@ -81,7 +91,7 @@ func TestBuildSystemPrompt_TagContextInactiveExcluded(t *testing.T) {
 		},
 	}, nil)
 
-	prompt := l.buildSystemPrompt(context.Background(), "hello", nil)
+	prompt := l.buildSystemPrompt(testCtxForLoop(l), "hello", nil)
 
 	if strings.Contains(prompt, "Secret content") {
 		t.Error("system prompt should not contain context from inactive tags")
@@ -112,7 +122,7 @@ func TestBuildSystemPrompt_TagContextDedup(t *testing.T) {
 		},
 	}, nil)
 
-	prompt := l.buildSystemPrompt(context.Background(), "hello", nil)
+	prompt := l.buildSystemPrompt(testCtxForLoop(l), "hello", nil)
 
 	// The shared file should appear exactly once.
 	count := strings.Count(prompt, "shared knowledge")
@@ -137,7 +147,7 @@ func TestBuildSystemPrompt_TagContextMissingFile(t *testing.T) {
 		},
 	}, nil)
 
-	prompt := l.buildSystemPrompt(context.Background(), "hello", nil)
+	prompt := l.buildSystemPrompt(testCtxForLoop(l), "hello", nil)
 
 	// Good file should still be included despite missing file.
 	if !strings.Contains(prompt, "good content") {
@@ -160,7 +170,7 @@ func TestBuildSystemPrompt_TagContextRereadPerTurn(t *testing.T) {
 		},
 	}, nil)
 
-	prompt1 := l.buildSystemPrompt(context.Background(), "hello", nil)
+	prompt1 := l.buildSystemPrompt(testCtxForLoop(l), "hello", nil)
 	if !strings.Contains(prompt1, "version-1") {
 		t.Fatal("first prompt should contain version-1")
 	}
@@ -168,7 +178,7 @@ func TestBuildSystemPrompt_TagContextRereadPerTurn(t *testing.T) {
 	// Modify the file between turns.
 	os.WriteFile(f, []byte("version-2"), 0644)
 
-	prompt2 := l.buildSystemPrompt(context.Background(), "hello", nil)
+	prompt2 := l.buildSystemPrompt(testCtxForLoop(l), "hello", nil)
 	if strings.Contains(prompt2, "version-1") {
 		t.Error("second prompt should not contain stale version-1")
 	}
@@ -181,7 +191,7 @@ func TestBuildSystemPrompt_TagContextNoCapTags(t *testing.T) {
 	l := newMinimalLoop()
 	// capTags not set — should not inject any tag context
 
-	prompt := l.buildSystemPrompt(context.Background(), "hello", nil)
+	prompt := l.buildSystemPrompt(testCtxForLoop(l), "hello", nil)
 
 	if strings.Contains(prompt, "Capability Context") {
 		t.Error("system prompt should not contain capability context section when capTags is nil")
@@ -206,7 +216,7 @@ func TestBuildSystemPrompt_TagContextOrderAfterInjected(t *testing.T) {
 		},
 	}, []talents.Talent{})
 
-	prompt := l.buildSystemPrompt(context.Background(), "hello", nil)
+	prompt := l.buildSystemPrompt(testCtxForLoop(l), "hello", nil)
 
 	injectedIdx := strings.Index(prompt, "INJECTED_MARKER")
 	tagCtxIdx := strings.Index(prompt, "TAG_CONTEXT_MARKER")
@@ -263,7 +273,7 @@ func TestBuildSystemPrompt_HAInjectResolved(t *testing.T) {
 		},
 	}, nil)
 
-	prompt := l.buildSystemPrompt(context.Background(), "hello", nil)
+	prompt := l.buildSystemPrompt(testCtxForLoop(l), "hello", nil)
 
 	if !strings.Contains(prompt, "## Current HA State (live)") {
 		t.Error("prompt should contain live state header")
@@ -292,7 +302,7 @@ func TestBuildSystemPrompt_HAInjectNilFetcher(t *testing.T) {
 	}, nil)
 	// haInject not set — should pass through without resolving
 
-	prompt := l.buildSystemPrompt(context.Background(), "hello", nil)
+	prompt := l.buildSystemPrompt(testCtxForLoop(l), "hello", nil)
 
 	if strings.Contains(prompt, "## Current HA State") {
 		t.Error("prompt should not contain state block when haInject is nil")
@@ -318,7 +328,7 @@ func TestBuildSystemPrompt_HAInjectFetchFailure(t *testing.T) {
 		},
 	}, nil)
 
-	prompt := l.buildSystemPrompt(context.Background(), "hello", nil)
+	prompt := l.buildSystemPrompt(testCtxForLoop(l), "hello", nil)
 
 	if !strings.Contains(prompt, "⚠️ HA entity state unavailable") {
 		t.Error("prompt should contain unavailability warning when all fetches fail")
@@ -481,7 +491,7 @@ func TestBuildSystemPrompt_TagContextViaProvider(t *testing.T) {
 		content: `{"accounts":["github-primary"]}`,
 	})
 
-	prompt := l.buildSystemPrompt(context.Background(), "hello", nil)
+	prompt := l.buildSystemPrompt(testCtxForLoop(l), "hello", nil)
 
 	if !strings.Contains(prompt, "github-primary") {
 		t.Error("system prompt should contain live provider content")

--- a/internal/tools/capability_tools.go
+++ b/internal/tools/capability_tools.go
@@ -7,15 +7,16 @@ import (
 	"strings"
 )
 
-// CapabilityManager controls per-session capability tag activation.
-// Implemented by agent.Loop.
+// CapabilityManager controls per-Run capability tag activation.
+// Implemented by agent.Loop. All methods operate on the
+// context-scoped capability scope created at the start of each Run().
 type CapabilityManager interface {
-	// RequestCapability activates a capability tag for the session.
-	RequestCapability(tag string) error
-	// DropCapability deactivates a capability tag for the session.
-	DropCapability(tag string) error
-	// ActiveTags returns the set of currently active tags.
-	ActiveTags() map[string]bool
+	// RequestCapability activates a capability tag for the current Run.
+	RequestCapability(ctx context.Context, tag string) error
+	// DropCapability deactivates a capability tag for the current Run.
+	DropCapability(ctx context.Context, tag string) error
+	// ActiveTags returns the set of currently active tags for the Run.
+	ActiveTags(ctx context.Context) map[string]bool
 }
 
 // CapabilityManifest describes a capability tag for the manifest.
@@ -89,7 +90,7 @@ func (r *Registry) registerRequestCapability(mgr CapabilityManager, manifest []C
 				return "", fmt.Errorf("tag is required")
 			}
 
-			if err := mgr.RequestCapability(tag); err != nil {
+			if err := mgr.RequestCapability(ctx, tag); err != nil {
 				return "", err
 			}
 
@@ -137,7 +138,7 @@ func (r *Registry) registerDropCapability(mgr CapabilityManager, tagManifest map
 				return "", fmt.Errorf("tag is required")
 			}
 
-			if err := mgr.DropCapability(tag); err != nil {
+			if err := mgr.DropCapability(ctx, tag); err != nil {
 				return "", err
 			}
 
@@ -147,7 +148,7 @@ func (r *Registry) registerDropCapability(mgr CapabilityManager, tagManifest map
 			if m, ok := tagManifest[tag]; ok && len(m.Tools) > 0 {
 				fmt.Fprintf(&result, " Tools removed: %s.", strings.Join(m.Tools, ", "))
 			}
-			if remaining := mgr.ActiveTags(); len(remaining) > 0 {
+			if remaining := mgr.ActiveTags(ctx); len(remaining) > 0 {
 				tags := make([]string, 0, len(remaining))
 				for t := range remaining {
 					tags = append(tags, t)

--- a/internal/tools/capability_tools_test.go
+++ b/internal/tools/capability_tools_test.go
@@ -24,7 +24,7 @@ func newMockCapabilityManager(validTags ...string) *mockCapabilityManager {
 	return m
 }
 
-func (m *mockCapabilityManager) RequestCapability(tag string) error {
+func (m *mockCapabilityManager) RequestCapability(_ context.Context, tag string) error {
 	if !m.allTags[tag] {
 		return fmt.Errorf("unknown capability tag: %q", tag)
 	}
@@ -32,7 +32,7 @@ func (m *mockCapabilityManager) RequestCapability(tag string) error {
 	return nil
 }
 
-func (m *mockCapabilityManager) DropCapability(tag string) error {
+func (m *mockCapabilityManager) DropCapability(_ context.Context, tag string) error {
 	if !m.allTags[tag] {
 		return fmt.Errorf("unknown capability tag: %q", tag)
 	}
@@ -40,7 +40,7 @@ func (m *mockCapabilityManager) DropCapability(tag string) error {
 	return nil
 }
 
-func (m *mockCapabilityManager) ActiveTags() map[string]bool {
+func (m *mockCapabilityManager) ActiveTags(_ context.Context) map[string]bool {
 	return m.activeTags
 }
 


### PR DESCRIPTION
## Summary

Closes #597. Replaces the global `activeTags` map on `agent.Loop` with a per-Run `capabilityScope` stored in `context.Value`.

- Each `Run()` gets its own isolated scope seeded with always-active + channel-pinned tags
- `request_capability` / `drop_capability` mutate the per-Run scope, not global state
- Concurrent conversations from different channels are fully isolated
- Dashboard shows most-recent-Run state via `LastRunTags()`
- No ref-counting needed — each scope is GC'd when Run returns

## What changed

| Before | After |
|--------|-------|
| Global `activeTags` map + `tagMu` mutex | Per-Run `capabilityScope` in context |
| `channelPinnedTags` ref-counting | `scope.pinned` map (no ref-count needed) |
| Signal "ha" leaks to OWU/email | Each Run starts fresh |
| `CapabilityManager` methods take no ctx | All methods take `context.Context` |

## New file

- `internal/agent/capability_scope.go` — scope type with `Snapshot`, `Request`, `Drop`, `PinChannelTags`

## Test plan

- [x] `just ci` passes (lint, fmt, race tests)
- [x] `TestCapabilityActivation_MidLoop` — mid-loop request still works
- [x] `TestChannelTags_*` — channel pinning, drop-pinned rejected
- [ ] Deploy locally: Signal request "ha" → only Signal loop shows it
- [ ] New OWU session → should NOT inherit Signal's capabilities