### PR TITLE
fix: logs_query safety — default INFO, 50KB byte cap, compact JSON

### DIFF
--- a/internal/tools/log_tools.go
+++ b/internal/tools/log_tools.go
@@ -219,7 +219,9 @@ func (r *Registry) handleLogsQuery(_ context.Context, args map[string]any) (stri
 		included++
 	}
 
-	// Build final JSON.
+	// Build final JSON with a hard cap enforcement. The entry
+	// collection above uses an estimated budget; this final pass
+	// guarantees the output never exceeds maxLogsResultBytes.
 	var sb strings.Builder
 	fmt.Fprintf(&sb, `{"count":%d,"returned":%d,"entries":[`, included, returned)
 	for i, entry := range marshaledEntries {
@@ -234,7 +236,32 @@ func (r *Registry) handleLogsQuery(_ context.Context, args map[string]any) (stri
 	}
 	sb.WriteString("}")
 
-	return sb.String(), nil
+	// Hard cap: if the assembled output still exceeds the limit
+	// (shouldn't happen with the budget above, but defense in depth),
+	// drop entries from the end until it fits.
+	out := sb.String()
+	if len(out) > maxLogsResultBytes {
+		// Rebuild with fewer entries.
+		for len(marshaledEntries) > 0 && len(out) > maxLogsResultBytes {
+			marshaledEntries = marshaledEntries[:len(marshaledEntries)-1]
+			included = len(marshaledEntries)
+
+			var rebuild strings.Builder
+			fmt.Fprintf(&rebuild, `{"count":%d,"returned":%d,"entries":[`, included, returned)
+			for i, entry := range marshaledEntries {
+				if i > 0 {
+					rebuild.WriteByte(',')
+				}
+				rebuild.Write(entry)
+			}
+			rebuild.WriteString("]")
+			fmt.Fprintf(&rebuild, `,"truncated":true,"note":"showing %d of %d returned entries (byte limit). Narrow filters for more targeted results."`, included, returned)
+			rebuild.WriteString("}")
+			out = rebuild.String()
+		}
+	}
+
+	return out, nil
 }
 
 // stringArg extracts a string value from the args map.

--- a/internal/tools/log_tools_test.go
+++ b/internal/tools/log_tools_test.go
@@ -228,8 +228,8 @@ func TestLogsQuery_ResultTruncation(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if len(result) > maxLogsResultBytes+512 {
-		t.Errorf("result should be near %d byte cap, got %d bytes", maxLogsResultBytes, len(result))
+	if len(result) > maxLogsResultBytes {
+		t.Errorf("result must not exceed %d-byte hard cap, got %d bytes", maxLogsResultBytes, len(result))
 	}
 	if !strings.Contains(result, `"truncated":true`) {
 		t.Error("truncated result should include truncated:true")


### PR DESCRIPTION
## Summary

Fixes a production incident where `logs_query` returned 174KB of DEBUG entries, causing a delegate to hit its 5-minute wall clock timeout.

### 1. Default level: INFO

When no level is specified (or null), the tool now defaults to INFO instead of returning everything including DEBUG/TRACE. DEBUG is explicitly opt-in. This alone prevents the most common context bomb scenario.

### 2. Byte cap: 50KB

Results are built incrementally with a byte budget. When the next entry would exceed 50KB, output truncates with metadata:

```json
{"count":23,"total":665,"entries":[...],"truncated":true,
 "note":"showing 23 of 665 entries. Narrow filters (time range, level, pattern) for more targeted results."}
```

The `total` field tells the model how many entries matched so it knows to refine filters. The model can always query again with tighter constraints.

### 3. Compact JSON

Switched from `json.MarshalIndent` (pretty-printed, ~870 bytes/entry) to compact `json.Marshal` (~350 bytes/entry). Shortened `"timestamp"` to `"ts"`. Same data, ~60% less output.

### Also

- Handles `int` type for limit parameter (not just `float64`)

## Test plan

- [x] Default level excludes DEBUG entries
- [x] Explicit `level: "DEBUG"` includes DEBUG entries
- [x] `limit` parameter respected (count matches limit)
- [x] Result truncation triggers at ~50KB with `truncated: true` and note
- [x] Total matching entries reported even when truncated
- [x] `just ci` passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)