### PR TITLE
chore: remove stale request_capability/drop_capability references

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -280,8 +280,11 @@ Full IMAP/SMTP email support (`internal/email/`):
 | `list_anticipations` | planning | List active anticipations |
 | `cancel_anticipation` | planning | Cancel an anticipation |
 | **Capabilities** | | |
-| `request_capability` | always | Activate capability tags for current session |
-| `drop_capability` | always | Deactivate capability tags |
+| `activate_capability` | always | Activate capability tags for current conversation |
+| `deactivate_capability` | always | Deactivate capability tags |
+| `activate_lens` | always | Activate a persistent global behavioral lens |
+| `deactivate_lens` | always | Deactivate a global behavioral lens |
+| `list_lenses` | always | List active behavioral lenses |
 | **Forge (GitHub/Forgejo)** | | |
 | `forge_issue_create` | forge | Create an issue |
 | `forge_issue_get` | forge | Get issue details |

--- a/cmd/thane/main.go
+++ b/cmd/thane/main.go
@@ -1843,7 +1843,7 @@ func runServe(ctx context.Context, stdout io.Writer, stderr io.Writer, configPat
 	// --- Capability tags ---
 	// Tag-driven tool and talent filtering. When configured, tools and
 	// talents are grouped into named capabilities that can be activated
-	// per-session via request_capability/drop_capability tools.
+	// per-conversation via activate_capability/deactivate_capability tools.
 	if len(cfg.CapabilityTags) > 0 {
 		// Load parsed talents for tag-aware filtering.
 		parsedTalents, err := talentLoader.LoadAll()

--- a/internal/agent/capability_activation_test.go
+++ b/internal/agent/capability_activation_test.go
@@ -149,7 +149,7 @@ func TestCapabilityActivation_MidLoop(t *testing.T) {
 
 // TestIllegalStrikes_NotResetByMetaTool verifies that the illegal strike
 // counter is not reset by capability meta-tools (activate_capability,
-// drop_capability), preventing infinite request→blocked→request loops.
+// deactivate_capability), preventing infinite activate→blocked→activate loops.
 func TestIllegalStrikes_NotResetByMetaTool(t *testing.T) {
 	mock := &mockLLM{
 		responses: []*llm.ChatResponse{

--- a/internal/agent/capability_scope.go
+++ b/internal/agent/capability_scope.go
@@ -2,8 +2,9 @@
 //
 // This file implements per-Run capability scoping. Each Run() call
 // creates a capabilityScope seeded with always-active and channel-pinned
-// tags, stored in the context. Tool handlers (request_capability,
-// drop_capability) mutate the scope via context, giving each
+// tags and global lenses, stored in the context. Tool handlers
+// (activate_capability, deactivate_capability) mutate the scope via
+// context, giving each
 // conversation its own isolated capability state.
 package agent
 

--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -1168,7 +1168,7 @@ func (l *Loop) Run(ctx context.Context, req *Request, stream StreamCallback) (re
 
 	// Request-level exclusions are static for the run, so compute once.
 	// Tag-based filtering is recomputed each iteration inside the loop
-	// to reflect tags activated via request_capability mid-run.
+	// to reflect tags activated via activate_capability mid-run.
 	baseTools := l.tools
 	if len(req.ExcludeTools) > 0 {
 		baseTools = l.tools.FilteredCopyExcluding(req.ExcludeTools)
@@ -1199,7 +1199,7 @@ func (l *Loop) Run(ctx context.Context, req *Request, stream StreamCallback) (re
 		FallbackContent: prompts.EmptyResponseFallback,
 
 		// Per-iteration tool definitions: recompute effective tools each
-		// iteration so tags activated via request_capability are reflected.
+		// iteration so tags activated via activate_capability are reflected.
 		ToolDefs: func(i int) []map[string]any {
 			effectiveTools := baseTools
 			if scope != nil && !skipTagFilter {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -166,7 +166,7 @@ type Config struct {
 	// CapabilityTags defines named groups of tools and talents that
 	// can be activated or deactivated per session. Tags marked
 	// always_active are loaded unconditionally. Other tags are
-	// activated via request_capability/drop_capability tools or
+	// activated via activate_capability/deactivate_capability tools or
 	// channel-pinned configuration.
 	CapabilityTags map[string]CapabilityTagConfig `yaml:"capability_tags"`
 

--- a/internal/server/web/static/detail.js
+++ b/internal/server/web/static/detail.js
@@ -245,7 +245,7 @@ function applyLoopEvent(evt) {
 
 // refreshActiveTags fetches current loop status and updates
 // the active_tags field so capability chips reflect changes
-// from request_capability / drop_capability tool calls.
+// from activate_capability / deactivate_capability tool calls.
 async function refreshActiveTags() {
   try {
     const resp = await fetch('/api/loops');

--- a/internal/server/web/static/shared.js
+++ b/internal/server/web/static/shared.js
@@ -840,7 +840,8 @@ function applyLoopEventToLoop(evt, ctx) {
       }
       // Signal that active capabilities may have changed so the
       // caller can refetch loop status for updated active_tags.
-      if (d.tool === 'request_capability' || d.tool === 'drop_capability') {
+      if (d.tool === 'activate_capability' || d.tool === 'deactivate_capability' ||
+          d.tool === 'activate_lens' || d.tool === 'deactivate_lens') {
         return { capabilityChanged: true };
       }
       return null;


### PR DESCRIPTION
Cleanup after PR #608 (capability rename). Updates all comments, docs, and web UI JavaScript that still referenced the old tool names.

- ARCHITECTURE.md: tool table updated with new names + lens tools added
- config.go, capability_scope.go, loop.go, main.go: doc comments
- capability_activation_test.go: test comment
- detail.js: comment
- shared.js: dashboard capability-change detection now also triggers on lens tool calls

Zero stale references remain (verified with recursive grep across .go, .md, .yaml, .js).

🤖 Generated with [Claude Code](https://claude.com/claude-code)