### PR TITLE
refactor: simplify talents loader and strengthen NewLoop typing

### DIFF
--- a/cmd/thane/main.go
+++ b/cmd/thane/main.go
@@ -248,14 +248,14 @@ func runAsk(ctx context.Context, stdout io.Writer, stderr io.Writer, configPath 
 	llmClient := createLLMClient(cfg, logger, ollamaClient)
 
 	talentLoader := talents.NewLoader(cfg.TalentsDir)
-	talentContent, _ := talentLoader.Load()
+	cliTalents, _ := talentLoader.Talents()
 
 	// In-memory store is fine for a single question — nothing to persist.
 	mem := memory.NewStore(100)
 
 	// Minimal loop: no router, no scheduler, no compactor. The default
 	// model handles everything for CLI one-shots.
-	loop := agent.NewLoop(logger, mem, nil, nil, ha, nil, llmClient, cfg.Models.Default, talentContent, "", 0)
+	loop := agent.NewLoop(logger, mem, nil, nil, ha, nil, llmClient, cfg.Models.Default, cliTalents, "", 0)
 	if ha != nil {
 		loop.SetHAInject(ha)
 	}
@@ -653,13 +653,16 @@ func runServe(ctx context.Context, stdout io.Writer, stderr io.Writer, configPat
 	// Talents are markdown files that extend the system prompt with
 	// domain-specific knowledge and instructions.
 	talentLoader := talents.NewLoader(cfg.TalentsDir)
-	talentContent, err := talentLoader.Load()
+	parsedTalents, err := talentLoader.Talents()
 	if err != nil {
 		return fmt.Errorf("load talents: %w", err)
 	}
-	if talentContent != "" {
-		talentList, _ := talentLoader.List()
-		logger.Info("talents loaded", "count", len(talentList), "talents", talentList)
+	if len(parsedTalents) > 0 {
+		talentNames := make([]string, len(parsedTalents))
+		for i, t := range parsedTalents {
+			talentNames[i] = t.Name
+		}
+		logger.Info("talents loaded", "count", len(parsedTalents), "talents", talentNames)
 	}
 
 	// --- Persona ---
@@ -878,7 +881,7 @@ func runServe(ctx context.Context, stdout io.Writer, stderr io.Writer, configPat
 	// into it.
 	defaultContextWindow := cfg.ContextWindowForModel(cfg.Models.Default, 200000)
 
-	loop = agent.NewLoop(logger, mem, compactor, rtr, ha, sched, llmClient, cfg.Models.Default, talentContent, personaContent, defaultContextWindow)
+	loop = agent.NewLoop(logger, mem, compactor, rtr, ha, sched, llmClient, cfg.Models.Default, parsedTalents, personaContent, defaultContextWindow)
 	loop.SetTimezone(cfg.Timezone)
 	if contentWriter != nil {
 		loop.SetContentWriter(contentWriter)
@@ -1872,11 +1875,9 @@ func runServe(ctx context.Context, stdout io.Writer, stderr io.Writer, configPat
 	// talents are grouped into named capabilities that can be activated
 	// per-conversation via activate_capability/deactivate_capability tools.
 	if len(cfg.CapabilityTags) > 0 {
-		// Load parsed talents for tag-aware filtering.
-		parsedTalents, err := talentLoader.LoadAll()
-		if err != nil {
-			return fmt.Errorf("load talents for capability tags: %w", err)
-		}
+		// parsedTalents was loaded above; copy the slice header so the
+		// manifest prepend below doesn't modify the outer variable.
+		capTalents := append([]talents.Talent(nil), parsedTalents...)
 
 		// Warn about tools referenced in config but not registered.
 		// This catches typos, missing MCP servers, and tools gated by config
@@ -1955,7 +1956,7 @@ func runServe(ctx context.Context, stdout io.Writer, stderr io.Writer, configPat
 				adHocTags[tag] = true
 			}
 		}
-		for _, t := range parsedTalents {
+		for _, t := range capTalents {
 			for _, tag := range t.Tags {
 				if !configuredTags[tag] {
 					adHocTags[tag] = true
@@ -1971,10 +1972,10 @@ func runServe(ctx context.Context, stdout io.Writer, stderr io.Writer, configPat
 		}
 
 		if manifestTalent := talents.GenerateManifest(manifestEntries); manifestTalent != nil {
-			parsedTalents = append([]talents.Talent{*manifestTalent}, parsedTalents...)
+			capTalents = append([]talents.Talent{*manifestTalent}, capTalents...)
 		}
 
-		loop.SetCapabilityTags(cfg.CapabilityTags, parsedTalents)
+		loop.SetCapabilityTags(cfg.CapabilityTags, capTalents)
 		loop.Tools().SetCapabilityTools(loop, manifest)
 		loop.SetTagContextAssembler(tagCtxAssembler)
 		loop.SetCapabilityTagStore(agent.NewOpstateCapabilityTagStore(opStore))

--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -193,7 +193,6 @@ type Loop struct {
 	model             string
 	recoveryModel     string            // Fast model for timeout recovery summaries (empty = disabled)
 	retryBaseDelay    time.Duration     // Base backoff delay between timeout retries (0 = use default)
-	talents           string            // Combined talent content for system prompt
 	persona           string            // Persona content (replaces base system prompt if set)
 	egoFile           string            // Path to ego.md — read fresh each turn for system prompt
 	provenanceStore   *provenance.Store // Optional provenance store for ego.md metadata injection
@@ -250,7 +249,7 @@ type Loop struct {
 }
 
 // NewLoop creates a new agent loop.
-func NewLoop(logger *slog.Logger, mem MemoryStore, compactor Compactor, rtr *router.Router, ha *homeassistant.Client, sched *scheduler.Scheduler, llmClient llm.Client, defaultModel, talents, persona string, contextWindow int) *Loop {
+func NewLoop(logger *slog.Logger, mem MemoryStore, compactor Compactor, rtr *router.Router, ha *homeassistant.Client, sched *scheduler.Scheduler, llmClient llm.Client, defaultModel string, parsedTalents []talents.Talent, persona string, contextWindow int) *Loop {
 	return &Loop{
 		logger:        logger,
 		memory:        mem,
@@ -259,7 +258,7 @@ func NewLoop(logger *slog.Logger, mem MemoryStore, compactor Compactor, rtr *rou
 		llm:           llmClient,
 		tools:         tools.NewRegistry(ha, sched),
 		model:         defaultModel,
-		talents:       talents,
+		parsedTalents: parsedTalents,
 		persona:       persona,
 		contextWindow: contextWindow,
 		nowFunc:       time.Now,
@@ -690,12 +689,8 @@ func (l *Loop) buildSystemPrompt(ctx context.Context, userMessage string, histor
 	seal()
 
 	// 5. Talents (behavior — how should I act)
-	// When capability tagging is configured, filter talents by active tags.
-	// Otherwise, use the pre-combined static string.
-	talentContent := l.talents
-	if l.parsedTalents != nil {
-		talentContent = talents.FilterByTags(l.parsedTalents, tags)
-	}
+	// Filter by active tags; nil tags means no filtering (all talents load).
+	talentContent := talents.FilterByTags(l.parsedTalents, tags)
 	if talentContent != "" {
 		mark("TALENTS")
 		sb.WriteString("\n\n## Behavioral Guidance\n\n")

--- a/internal/agent/orchestrator_tools_test.go
+++ b/internal/agent/orchestrator_tools_test.go
@@ -104,12 +104,11 @@ func buildTestLoop(mock *mockLLM, extraNames []string) *Loop {
 	}
 
 	l := &Loop{
-		logger:  slog.Default(),
-		memory:  newMockMem(),
-		llm:     mock,
-		tools:   reg,
-		model:   "test-model",
-		talents: "",
+		logger: slog.Default(),
+		memory: newMockMem(),
+		llm:    mock,
+		tools:  reg,
+		model:  "test-model",
 	}
 	return l
 }

--- a/internal/talents/loader.go
+++ b/internal/talents/loader.go
@@ -27,55 +27,12 @@ type Talent struct {
 	Content string   // Markdown content (frontmatter stripped)
 }
 
-// Load reads all .md files from the talents directory and returns
-// their combined content, suitable for injection into system prompts.
-func (l *Loader) Load() (string, error) {
-	if l.dir == "" {
-		return "", nil
-	}
-
-	entries, err := os.ReadDir(l.dir)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return "", nil // No talents dir is fine
-		}
-		return "", fmt.Errorf("read talents dir: %w", err)
-	}
-
-	var files []string
-	for _, e := range entries {
-		if !e.IsDir() && strings.HasSuffix(e.Name(), ".md") {
-			files = append(files, e.Name())
-		}
-	}
-
-	// Sort for deterministic ordering
-	sort.Strings(files)
-
-	var parts []string
-	for _, f := range files {
-		content, err := os.ReadFile(filepath.Join(l.dir, f))
-		if err != nil {
-			return "", fmt.Errorf("read talent %s: %w", f, err)
-		}
-		parts = append(parts, string(content))
-	}
-
-	if len(parts) == 0 {
-		return "", nil
-	}
-
-	return strings.Join(parts, "\n\n---\n\n"), nil
-}
-
-// LoadAll reads all talent files and parses their frontmatter. Returns
-// parsed Talent structs with tags extracted. Use FilterByTags to select
-// talents matching active capability tags.
-func (l *Loader) LoadAll() ([]Talent, error) {
+// listFiles returns a sorted slice of .md filenames in l.dir.
+// Returns nil, nil when dir is unset or does not exist.
+func (l *Loader) listFiles() ([]string, error) {
 	if l.dir == "" {
 		return nil, nil
 	}
-
 	entries, err := os.ReadDir(l.dir)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -83,33 +40,36 @@ func (l *Loader) LoadAll() ([]Talent, error) {
 		}
 		return nil, fmt.Errorf("read talents dir: %w", err)
 	}
-
 	var files []string
 	for _, e := range entries {
 		if !e.IsDir() && strings.HasSuffix(e.Name(), ".md") {
 			files = append(files, e.Name())
 		}
 	}
-
 	sort.Strings(files)
+	return files, nil
+}
 
-	var talents []Talent
+// Talents reads all .md files from the talents directory, parses their
+// YAML frontmatter, and returns one Talent per file. Tags are extracted
+// from frontmatter; Content has the frontmatter stripped. Use
+// FilterByTags to select the subset matching active capability tags.
+func (l *Loader) Talents() ([]Talent, error) {
+	files, err := l.listFiles()
+	if err != nil {
+		return nil, err
+	}
+	var ts []Talent
 	for _, f := range files {
 		data, err := os.ReadFile(filepath.Join(l.dir, f))
 		if err != nil {
 			return nil, fmt.Errorf("read talent %s: %w", f, err)
 		}
-
 		name := strings.TrimSuffix(f, ".md")
 		tags, content := ParseFrontmatter(string(data))
-		talents = append(talents, Talent{
-			Name:    name,
-			Tags:    tags,
-			Content: content,
-		})
+		ts = append(ts, Talent{Name: name, Tags: tags, Content: content})
 	}
-
-	return talents, nil
+	return ts, nil
 }
 
 // FilterByTags returns the combined content of talents matching the
@@ -311,30 +271,4 @@ func GenerateManifest(entries []ManifestEntry) *Talent {
 		Tags:    nil, // Untagged — always loads
 		Content: sb.String(),
 	}
-}
-
-// List returns the names of available talent files.
-func (l *Loader) List() ([]string, error) {
-	if l.dir == "" {
-		return nil, nil
-	}
-
-	entries, err := os.ReadDir(l.dir)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil, nil
-		}
-		return nil, err
-	}
-
-	var names []string
-	for _, e := range entries {
-		if !e.IsDir() && strings.HasSuffix(e.Name(), ".md") {
-			name := strings.TrimSuffix(e.Name(), ".md")
-			names = append(names, name)
-		}
-	}
-
-	sort.Strings(names)
-	return names, nil
 }

--- a/internal/talents/loader_test.go
+++ b/internal/talents/loader_test.go
@@ -169,7 +169,7 @@ func TestFilterByTags_Empty(t *testing.T) {
 	}
 }
 
-func TestLoadAll(t *testing.T) {
+func TestTalents(t *testing.T) {
 	dir := t.TempDir()
 
 	// Write talent files with and without frontmatter.
@@ -178,7 +178,7 @@ func TestLoadAll(t *testing.T) {
 	writeFile(t, dir, "search.md", "---\ntags: [search, web]\n---\n# Search\nSearch guidance.")
 
 	loader := NewLoader(dir)
-	talents, err := loader.LoadAll()
+	talents, err := loader.Talents()
 	if err != nil {
 		t.Fatalf("LoadAll() error = %v", err)
 	}
@@ -216,25 +216,25 @@ func TestLoadAll(t *testing.T) {
 	}
 }
 
-func TestLoadAll_EmptyDir(t *testing.T) {
+func TestTalents_EmptyDir(t *testing.T) {
 	loader := NewLoader("")
-	talents, err := loader.LoadAll()
+	talents, err := loader.Talents()
 	if err != nil {
-		t.Fatalf("LoadAll() error = %v", err)
+		t.Fatalf("Talents() error = %v", err)
 	}
 	if talents != nil {
-		t.Errorf("LoadAll() = %v, want nil for empty dir", talents)
+		t.Errorf("Talents() = %v, want nil for empty dir", talents)
 	}
 }
 
-func TestLoadAll_MissingDir(t *testing.T) {
+func TestTalents_MissingDir(t *testing.T) {
 	loader := NewLoader("/nonexistent/path")
-	talents, err := loader.LoadAll()
+	talents, err := loader.Talents()
 	if err != nil {
-		t.Fatalf("LoadAll() error = %v", err)
+		t.Fatalf("Talents() error = %v", err)
 	}
 	if talents != nil {
-		t.Errorf("LoadAll() = %v, want nil for missing dir", talents)
+		t.Errorf("Talents() = %v, want nil for missing dir", talents)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Extract `listFiles()` helper, eliminating three copies of the directory-listing loop across `Load()`, `LoadAll()`, and `List()`
- Rename `LoadAll()` → `Talents()` for clarity; remove `Load()` and `List()` — callers now work directly with `[]Talent`
- Change `NewLoop` to accept `[]talents.Talent` instead of a string, removing the `l.talents string` field from `Loop`
- Drop the `parsedTalents` nil-check in system prompt assembly; `FilterByTags(nil, nil)` already returns `""` so the string fallback was redundant
- Fix subtle bug: `Load()` previously passed raw frontmatter YAML into the system prompt; the new path always strips it via `ParseFrontmatter`
- `main.go`: one `talentLoader.Talents()` call replaces two separate `Load()`/`LoadAll()` calls that read the same directory twice

Net: -71 lines, one directory read at startup instead of two, type-safe `NewLoop` signature.

## Test plan

- [x] `just ci` passes (fmt, lint, race tests)
- [ ] Smoke test: start server, send a chat message, confirm behavioral guidance appears in system prompt
- [ ] If capability tags configured: activate a tag, confirm tagged talent content loads; deactivate, confirm it unloads

🤖 Generated with [Claude Code](https://claude.com/claude-code)