### PR TITLE
refactor: extract background worker starts from New() into StartWorkers()

### DIFF
--- a/cmd/thane/main.go
+++ b/cmd/thane/main.go
@@ -305,6 +305,7 @@ func runServe(ctx context.Context, stdout io.Writer, stderr io.Writer, configPat
 	if err != nil {
 		return err
 	}
+	defer a.Close()
 
 	// Log with the fully-configured logger (file handler, index handler,
 	// correct level/format) so this line is captured in rotated logs.

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -8,10 +8,10 @@
 package app
 
 import (
-	"context"
 	"database/sql"
 	"io"
 	"log/slog"
+	"sync"
 
 	"github.com/nugget/thane-ai-agent/internal/agent"
 	"github.com/nugget/thane-ai-agent/internal/attachments"
@@ -149,5 +149,8 @@ type App struct {
 	signalBridge *sigcli.Bridge
 
 	// Deferred worker starts, populated by New(), executed by StartWorkers().
-	pendingWorkers []func(ctx context.Context) error
+	pendingWorkers []pendingWorker
+
+	// closeOnce ensures shutdown runs exactly once across Close and Serve.
+	closeOnce sync.Once
 }

--- a/internal/app/new.go
+++ b/internal/app/new.go
@@ -169,7 +169,7 @@ func New(ctx context.Context, cfg *config.Config, logger *slog.Logger, stdout io
 	// the index database is available.
 	if a.indexDB != nil {
 		if retention := cfg.Logging.RetentionDaysDuration(); retention > 0 {
-			a.deferWorker(func(ctx context.Context) error {
+			a.deferWorker("log-index-pruner", func(ctx context.Context) error {
 				go func() {
 					ticker := time.NewTicker(24 * time.Hour)
 					defer ticker.Stop()
@@ -200,7 +200,7 @@ func New(ctx context.Context, cfg *config.Config, logger *slog.Logger, stdout io
 			if archiveDur := cfg.Logging.ContentArchiveDuration(); archiveDur > 0 && a.contentWriter != nil {
 				archiveDir := cfg.Logging.ContentArchiveDirPath(logDir)
 				archiver := logging.NewArchiver(a.indexDB, archiveDir, logger)
-				a.deferWorker(func(ctx context.Context) error {
+				a.deferWorker("content-archiver", func(ctx context.Context) error {
 					go func() {
 						ticker := time.NewTicker(24 * time.Hour)
 						defer ticker.Stop()
@@ -259,7 +259,7 @@ func New(ctx context.Context, cfg *config.Config, logger *slog.Logger, stdout io
 
 	// --- Demo loops (debug) ---
 	if cfg.Debug.DemoLoops {
-		a.deferWorker(func(ctx context.Context) error {
+		a.deferWorker("demo-loops", func(ctx context.Context) error {
 			if err := looppkg.SpawnDemoLoops(ctx, loopRegistry, eventBus, logger); err != nil {
 				return fmt.Errorf("spawn demo loops: %w", err)
 			}
@@ -553,7 +553,7 @@ func New(ctx context.Context, cfg *config.Config, logger *slog.Logger, stdout io
 
 	sched := scheduler.New(logger, schedStore, executeTask)
 	a.sched = sched
-	a.deferWorker(func(ctx context.Context) error {
+	a.deferWorker("scheduler", func(ctx context.Context) error {
 		if err := sched.Start(ctx); err != nil {
 			return fmt.Errorf("start scheduler: %w", err)
 		}
@@ -736,7 +736,7 @@ func New(ctx context.Context, cfg *config.Config, logger *slog.Logger, stdout io
 	summaryWorker.SetInteractionCallback(func(conversationID, sessionID string, endedAt time.Time, topics []string) {
 		updateContactInteraction(contactStore, logger, conversationID, sessionID, endedAt, topics)
 	})
-	a.deferWorker(func(ctx context.Context) error {
+	a.deferWorker("summary-worker", func(ctx context.Context) error {
 		summaryWorker.Start(ctx)
 		return nil
 	})
@@ -821,7 +821,7 @@ func New(ctx context.Context, cfg *config.Config, logger *slog.Logger, stdout io
 				Logger:   logger,
 				EventBus: eventBus,
 			}
-			a.deferWorker(func(ctx context.Context) error {
+			a.deferWorker("email-poller", func(ctx context.Context) error {
 				if _, err := loopRegistry.SpawnLoop(ctx, loopCfg, loopDeps); err != nil {
 					return fmt.Errorf("spawn email poller loop: %w", err)
 				}
@@ -1237,7 +1237,7 @@ func New(ctx context.Context, cfg *config.Config, logger *slog.Logger, stdout io
 			Logger:   logger,
 			EventBus: eventBus,
 		}
-		a.deferWorker(func(ctx context.Context) error {
+		a.deferWorker("media-feed-poller", func(ctx context.Context) error {
 			if _, err := loopRegistry.SpawnLoop(ctx, loopCfg, loopDeps); err != nil {
 				return fmt.Errorf("spawn media feed poller loop: %w", err)
 			}
@@ -1586,7 +1586,7 @@ func New(ctx context.Context, cfg *config.Config, logger *slog.Logger, stdout io
 			a.notifRecords, a.notifCallbackDispatcher, escalationSender,
 			30*time.Second, logger,
 		)
-		a.deferWorker(func(ctx context.Context) error {
+		a.deferWorker("notification-timeout-watcher", func(ctx context.Context) error {
 			go timeoutWatcher.Start(ctx)
 			return nil
 		})
@@ -1939,7 +1939,7 @@ func New(ctx context.Context, cfg *config.Config, logger *slog.Logger, stdout io
 			Logger:   logger,
 			EventBus: eventBus,
 		}
-		a.deferWorker(func(ctx context.Context) error {
+		a.deferWorker("unifi-poller", func(ctx context.Context) error {
 			if _, err := loopRegistry.SpawnLoop(ctx, unifiLoopCfg, unifiLoopDeps); err != nil {
 				return fmt.Errorf("spawn unifi poller loop: %w", err)
 			}
@@ -2061,7 +2061,7 @@ func New(ctx context.Context, cfg *config.Config, logger *slog.Logger, stdout io
 		watcher := homeassistant.NewStateWatcher(a.haWS.Events(), filter, limiter, handler, logger)
 		haEvents := watcher.Events()
 
-		a.deferWorker(func(ctx context.Context) error {
+		a.deferWorker("ha-state-watcher", func(ctx context.Context) error {
 			// Derive a cancellable context so the loop exits cleanly
 			// when the HA event channel closes.
 			haLoopCtx, haLoopCancel := context.WithCancel(ctx)
@@ -2151,14 +2151,13 @@ func New(ctx context.Context, cfg *config.Config, logger *slog.Logger, stdout io
 			}); err != nil {
 				return fmt.Errorf("spawn ha-state-watcher loop: %w", err)
 			}
+			logger.Info("state watcher started",
+				"entity_globs", globs,
+				"rate_limit_per_minute", cfg.HomeAssistant.Subscribe.RateLimitPerMinute,
+				"cooldown", cooldown,
+			)
 			return nil
 		})
-
-		logger.Info("state watcher started",
-			"entity_globs", globs,
-			"rate_limit_per_minute", cfg.HomeAssistant.Subscribe.RateLimitPerMinute,
-			"cooldown", cooldown,
-		)
 	}
 
 	// --- API server ---
@@ -2395,7 +2394,7 @@ func New(ctx context.Context, cfg *config.Config, logger *slog.Logger, stdout io
 				Logger:   logger,
 				EventBus: eventBus,
 			}
-			a.deferWorker(func(ctx context.Context) error {
+			a.deferWorker("mqtt-publisher", func(ctx context.Context) error {
 				if _, err := loopRegistry.SpawnLoop(ctx, mqttLoopCfg, mqttLoopDeps); err != nil {
 					return fmt.Errorf("spawn mqtt-publisher loop: %w", err)
 				}
@@ -2551,7 +2550,7 @@ func New(ctx context.Context, cfg *config.Config, logger *slog.Logger, stdout io
 			Logger:   logger,
 			EventBus: eventBus,
 		}
-		a.deferWorker(func(ctx context.Context) error {
+		a.deferWorker("mqtt-telemetry", func(ctx context.Context) error {
 			if _, err := loopRegistry.SpawnLoop(ctx, telLoopCfg, telLoopDeps); err != nil {
 				return fmt.Errorf("spawn mqtt-telemetry loop: %w", err)
 			}
@@ -2620,7 +2619,7 @@ func New(ctx context.Context, cfg *config.Config, logger *slog.Logger, stdout io
 			Logger:   logger,
 			EventBus: eventBus,
 		}
-		a.deferWorker(func(ctx context.Context) error {
+		a.deferWorker("metacognitive", func(ctx context.Context) error {
 			if _, err := loopRegistry.SpawnLoop(ctx, loopCfg, metacogDeps); err != nil {
 				return fmt.Errorf("spawn metacognitive loop: %w", err)
 			}

--- a/internal/app/serve.go
+++ b/internal/app/serve.go
@@ -13,7 +13,7 @@ import (
 // Cleanup of all resources opened during [New] is handled by
 // [App.shutdown], which Serve defers at entry.
 func (a *App) Serve(ctx context.Context) error {
-	defer a.shutdown()
+	defer a.Close()
 
 	// Periodic cleanup of expired opstate keys (issue #457). Expired
 	// keys are already invisible on read; this reclaims storage.

--- a/internal/app/workers.go
+++ b/internal/app/workers.go
@@ -5,27 +5,45 @@ import (
 	"fmt"
 )
 
-// deferWorker enqueues a function to be executed by [StartWorkers].
+// pendingWorker pairs a descriptive name with its start function so
+// errors from [StartWorkers] identify the failing subsystem.
+type pendingWorker struct {
+	name string
+	fn   func(ctx context.Context) error
+}
+
+// deferWorker enqueues a named function to be executed by [StartWorkers].
 // The function receives the context passed to StartWorkers and should
 // return a non-nil error only when the failure is fatal to startup.
-func (a *App) deferWorker(fn func(ctx context.Context) error) {
-	a.pendingWorkers = append(a.pendingWorkers, fn)
+func (a *App) deferWorker(name string, fn func(ctx context.Context) error) {
+	a.pendingWorkers = append(a.pendingWorkers, pendingWorker{name: name, fn: fn})
 }
 
 // StartWorkers launches all background goroutines and persistent loops
-// that were deferred during [New]. It must be called exactly once,
-// after New returns and before [App.Serve].
+// that were deferred during [New]. It is intended to be called once,
+// after New returns and before [App.Serve], as part of application startup.
 //
 // Workers are started in the order they were registered (matching the
 // original initialization order in New). If any worker returns a fatal
 // error, StartWorkers returns immediately without starting remaining
-// workers — the caller should treat this as a startup failure.
+// workers — the caller should treat this as a startup failure. Subsequent
+// calls after all pending workers have been started do not start any
+// additional workers and return nil.
 func (a *App) StartWorkers(ctx context.Context) error {
-	for i, fn := range a.pendingWorkers {
-		if err := fn(ctx); err != nil {
-			return fmt.Errorf("start worker %d: %w", i, err)
+	for _, w := range a.pendingWorkers {
+		if err := w.fn(ctx); err != nil {
+			return fmt.Errorf("start worker %q: %w", w.name, err)
 		}
 	}
 	a.pendingWorkers = nil // release closures
 	return nil
+}
+
+// Close releases all resources opened during [New]. It is safe to call
+// multiple times and safe to call even if [StartWorkers] or [Serve]
+// were never called — only non-nil resources are cleaned up. Callers
+// should defer Close immediately after a successful New to guarantee
+// cleanup on all exit paths.
+func (a *App) Close() {
+	a.closeOnce.Do(a.shutdown)
 }

--- a/internal/app/workers_test.go
+++ b/internal/app/workers_test.go
@@ -11,8 +11,11 @@ func TestStartWorkers(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name       string
-		workers    []func(ctx context.Context) error
+		name    string
+		workers []struct {
+			name string
+			fn   func(ctx context.Context) error
+		}
 		wantErr    bool
 		wantCalls  int // how many workers should have been called
 		errContain string
@@ -24,23 +27,29 @@ func TestStartWorkers(t *testing.T) {
 		},
 		{
 			name: "all succeed",
-			workers: []func(ctx context.Context) error{
-				func(context.Context) error { return nil },
-				func(context.Context) error { return nil },
-				func(context.Context) error { return nil },
+			workers: []struct {
+				name string
+				fn   func(ctx context.Context) error
+			}{
+				{"alpha", func(context.Context) error { return nil }},
+				{"beta", func(context.Context) error { return nil }},
+				{"gamma", func(context.Context) error { return nil }},
 			},
 			wantCalls: 3,
 		},
 		{
 			name: "second fails stops early",
-			workers: []func(ctx context.Context) error{
-				func(context.Context) error { return nil },
-				func(context.Context) error { return errors.New("boom") },
-				func(context.Context) error { return nil },
+			workers: []struct {
+				name string
+				fn   func(ctx context.Context) error
+			}{
+				{"alpha", func(context.Context) error { return nil }},
+				{"beta", func(context.Context) error { return errors.New("boom") }},
+				{"gamma", func(context.Context) error { return nil }},
 			},
 			wantErr:    true,
 			wantCalls:  2,
-			errContain: "boom",
+			errContain: `"beta"`,
 		},
 	}
 
@@ -50,11 +59,11 @@ func TestStartWorkers(t *testing.T) {
 
 			called := 0
 			a := &App{}
-			for _, fn := range tt.workers {
-				fn := fn // capture
-				a.deferWorker(func(ctx context.Context) error {
+			for _, w := range tt.workers {
+				w := w // capture
+				a.deferWorker(w.name, func(ctx context.Context) error {
 					called++
-					return fn(ctx)
+					return w.fn(ctx)
 				})
 			}
 
@@ -80,5 +89,26 @@ func TestStartWorkers(t *testing.T) {
 				t.Error("pendingWorkers not cleared after successful StartWorkers")
 			}
 		})
+	}
+}
+
+func TestStartWorkers_subsequent_call_is_noop(t *testing.T) {
+	t.Parallel()
+
+	called := 0
+	a := &App{}
+	a.deferWorker("once", func(context.Context) error {
+		called++
+		return nil
+	})
+
+	if err := a.StartWorkers(context.Background()); err != nil {
+		t.Fatalf("first call: %v", err)
+	}
+	if err := a.StartWorkers(context.Background()); err != nil {
+		t.Fatalf("second call: %v", err)
+	}
+	if called != 1 {
+		t.Errorf("worker called %d times, want 1", called)
 	}
 }


### PR DESCRIPTION
## Summary

- `New()` no longer starts any background goroutines or persistent loops — it only opens resources and wires dependencies
- New `StartWorkers(ctx)` method on `App` launches all deferred workers in registration order
- Call site in `cmd/thane` becomes `New() → StartWorkers(ctx) → Serve(ctx)`
- Signal client `Start()` intentionally remains in `New()` due to tight coupling with bridge/tool registration

## Workers moved (13 total)

| Worker | Type | Was |
|--------|------|-----|
| Log index pruner | `go func()` ticker | Direct goroutine in `New()` |
| Content archiver | `go func()` ticker | Direct goroutine in `New()` |
| Demo loops | `SpawnDemoLoops()` | Called in `New()` |
| Scheduler | `.Start(ctx)` | Called in `New()` |
| Summary worker | `.Start(ctx)` | Called in `New()` |
| Email poller | `SpawnLoop()` | Called in `New()` |
| Media feed poller | `SpawnLoop()` | Called in `New()` |
| UniFi poller | `SpawnLoop()` | Called in `New()` |
| HA state watcher | `SpawnLoop()` | Called in `New()` |
| MQTT publisher | `SpawnLoop()` | Called in `New()` |
| MQTT telemetry | `SpawnLoop()` | Called in `New()` |
| Metacognitive loop | `SpawnLoop()` | Called in `New()` |
| Notification timeout watcher | `go .Start(ctx)` | Direct goroutine in `New()` |

## Design

Workers are collected via `a.deferWorker(fn)` during `New()` into a `[]func(ctx context.Context) error` slice. `StartWorkers` iterates and calls each in order, stopping on the first fatal error. The slice is cleared after execution.

Key ordering constraint: the HA state watcher derives its cancellable context inside the deferred closure (from the `StartWorkers` ctx) rather than from the `New` ctx, so it gets the correct parent context regardless of when `StartWorkers` is called.

## Test plan

- [x] `just ci` passes (fmt, lint, architecture check, tests with -race)
- [x] Table-driven tests for `StartWorkers`: no workers, all succeed, early failure stops execution
- [ ] Deploy and verify all 13 workers start correctly (scheduler fires tasks, MQTT publishes, HA state events are processed, etc.)

🐾 First step of the `app/new.go` pure-builder refactoring series.