### PR TITLE
fix: MQTT message handler registration and deferred tool validation

### DIFF
--- a/internal/app/new_servers.go
+++ b/internal/app/new_servers.go
@@ -289,9 +289,6 @@ func (a *App) initServers(s *newState) error {
 		// Wrap with the wake handler: wake-configured topics dispatch
 		// agent conversations, everything else falls through to the
 		// base handler above.
-		// Wrap with the wake handler: wake-configured topics dispatch
-		// agent conversations, everything else falls through to the
-		// base handler above.
 		mqttPub.SetMessageHandler(mqttWakeHandler(subStore, a.loop, baseMsgHandler, logger))
 
 		// Register MQTT wake subscription tools.

--- a/internal/channels/mqtt/publisher.go
+++ b/internal/channels/mqtt/publisher.go
@@ -205,22 +205,11 @@ func (p *Publisher) PublishInterval() time.Duration {
 	return interval
 }
 
-// connect establishes the MQTT broker connection, publishes discovery
-// configs, configures subscriptions, and waits for initial connection.
-// Shared by both [Connect] and [Start].
-func (p *Publisher) connect(ctx context.Context) error {
-	if p.tokens == nil {
-		return fmt.Errorf("mqtt publisher: tokens must not be nil")
-	}
-	if p.stats == nil {
-		return fmt.Errorf("mqtt publisher: stats must not be nil")
-	}
-
-	brokerURL, err := url.Parse(p.cfg.Broker)
-	if err != nil {
-		return fmt.Errorf("parse mqtt broker URL: %w", err)
-	}
-
+// buildClientConfig constructs the autopaho.ClientConfig for the broker
+// connection. It is called by [connect] and is separated for testability
+// — callers can inspect the returned config (e.g. OnPublishReceived
+// handlers) without needing a live broker.
+func (p *Publisher) buildClientConfig(brokerURL *url.URL) autopaho.ClientConfig {
 	availTopic := p.AvailabilityTopic()
 
 	pahoCfg := autopaho.ClientConfig{
@@ -257,8 +246,8 @@ func (p *Publisher) connect(ctx context.Context) error {
 		}
 	}
 
-	// Wire inbound message handler BEFORE NewConnection so it is baked
-	// into the paho.ClientConfig. autopaho copies the config on every
+	// Wire inbound message handler into the paho.ClientConfig so it is
+	// baked in BEFORE NewConnection. autopaho copies the config on every
 	// (re-)connect, so handlers registered here persist across reconnects.
 	// In contrast, cm.AddOnPublishReceived() only registers on the
 	// *current* paho.Client instance and is lost on reconnect — and if
@@ -269,7 +258,6 @@ func (p *Publisher) connect(ctx context.Context) error {
 			p.handler = defaultMessageHandler(p.logger)
 		}
 		p.rateLimiter = newMessageRateLimiter(100, time.Second, p.logger)
-		go p.rateLimiter.start(ctx)
 
 		pahoCfg.OnPublishReceived = append(
 			pahoCfg.OnPublishReceived,
@@ -293,11 +281,38 @@ func (p *Publisher) connect(ctx context.Context) error {
 		)
 	}
 
+	return pahoCfg
+}
+
+// connect establishes the MQTT broker connection, publishes discovery
+// configs, configures subscriptions, and waits for initial connection.
+// Shared by both [Connect] and [Start].
+func (p *Publisher) connect(ctx context.Context) error {
+	if p.tokens == nil {
+		return fmt.Errorf("mqtt publisher: tokens must not be nil")
+	}
+	if p.stats == nil {
+		return fmt.Errorf("mqtt publisher: stats must not be nil")
+	}
+
+	brokerURL, err := url.Parse(p.cfg.Broker)
+	if err != nil {
+		return fmt.Errorf("parse mqtt broker URL: %w", err)
+	}
+
+	pahoCfg := p.buildClientConfig(brokerURL)
+
 	cm, err := autopaho.NewConnection(ctx, pahoCfg)
 	if err != nil {
 		return fmt.Errorf("mqtt connect: %w", err)
 	}
 	p.setCM(cm)
+
+	// Start the rate limiter after NewConnection succeeds to avoid
+	// leaking a goroutine on the error path.
+	if p.rateLimiter != nil {
+		go p.rateLimiter.start(ctx)
+	}
 
 	// Wait for the initial connection before starting the publish loop.
 	connCtx, connCancel := context.WithTimeout(ctx, 30*time.Second)

--- a/internal/channels/mqtt/publisher_test.go
+++ b/internal/channels/mqtt/publisher_test.go
@@ -2,12 +2,14 @@ package mqtt
 
 import (
 	"encoding/json"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/eclipse/paho.golang/paho"
 	"github.com/nugget/thane-ai-agent/internal/config"
 )
 
@@ -360,6 +362,92 @@ func TestSensorConfig_JsonAttributesTopic(t *testing.T) {
 	}
 	if strings.Contains(string(data), `"json_attributes_topic"`) {
 		t.Errorf("json_attributes_topic should be omitted when empty:\n%s", data)
+	}
+}
+
+func TestPublisher_BuildClientConfig_HandlerRegistered(t *testing.T) {
+	cfg := config.MQTTConfig{
+		Broker:     "mqtt://localhost:1883",
+		DeviceName: "test-thane",
+		Subscriptions: []config.SubscriptionConfig{
+			{Topic: "test/topic"},
+		},
+	}
+
+	var handlerCalled bool
+	p := New(cfg, "instance-123", NewDailyTokens(time.UTC), nil, nil)
+	p.SetMessageHandler(func(topic string, payload []byte) {
+		handlerCalled = true
+	})
+
+	brokerURL, err := url.Parse(cfg.Broker)
+	if err != nil {
+		t.Fatalf("parse broker URL: %v", err)
+	}
+
+	pahoCfg := p.buildClientConfig(brokerURL)
+
+	// The handler must be registered on pahoCfg.OnPublishReceived so it
+	// persists across autopaho reconnects. Previously this was done via
+	// cm.AddOnPublishReceived() which silently no-oped when c.cli was nil.
+	if len(pahoCfg.OnPublishReceived) == 0 {
+		t.Fatal("OnPublishReceived is empty; handler was not registered on the config")
+	}
+
+	// Verify the registered handler actually routes to our MessageHandler.
+	pr := paho.PublishReceived{
+		Packet: &paho.Publish{
+			Topic:   "test/topic",
+			Payload: []byte("hello"),
+		},
+	}
+	if _, err := pahoCfg.OnPublishReceived[0](pr); err != nil {
+		t.Fatalf("OnPublishReceived handler returned error: %v", err)
+	}
+	if !handlerCalled {
+		t.Error("OnPublishReceived handler did not invoke the MessageHandler")
+	}
+}
+
+func TestPublisher_BuildClientConfig_NoHandlerWithoutSubs(t *testing.T) {
+	cfg := config.MQTTConfig{
+		Broker:     "mqtt://localhost:1883",
+		DeviceName: "test-thane",
+		// No subscriptions.
+	}
+	p := New(cfg, "instance-123", NewDailyTokens(time.UTC), nil, nil)
+
+	brokerURL, err := url.Parse(cfg.Broker)
+	if err != nil {
+		t.Fatalf("parse broker URL: %v", err)
+	}
+
+	pahoCfg := p.buildClientConfig(brokerURL)
+
+	if len(pahoCfg.OnPublishReceived) != 0 {
+		t.Errorf("OnPublishReceived should be empty without subscriptions, got %d handlers",
+			len(pahoCfg.OnPublishReceived))
+	}
+}
+
+func TestPublisher_BuildClientConfig_DynamicTopicsTriggersHandler(t *testing.T) {
+	cfg := config.MQTTConfig{
+		Broker:     "mqtt://localhost:1883",
+		DeviceName: "test-thane",
+		// No config subscriptions, but dynamic topics set.
+	}
+	p := New(cfg, "instance-123", NewDailyTokens(time.UTC), nil, nil)
+	p.SetDynamicTopics(func() []string { return []string{"dynamic/topic"} })
+
+	brokerURL, err := url.Parse(cfg.Broker)
+	if err != nil {
+		t.Fatalf("parse broker URL: %v", err)
+	}
+
+	pahoCfg := p.buildClientConfig(brokerURL)
+
+	if len(pahoCfg.OnPublishReceived) == 0 {
+		t.Fatal("OnPublishReceived should be registered when dynamicTopics is set")
 	}
 }
 


### PR DESCRIPTION
## Summary

- **Fix broken MQTT message handler** — `cm.AddOnPublishReceived()` was called after `autopaho.NewConnection()`, but the connection isn't up yet at that point (`c.cli == nil`), so the handler was **silently dropped**. On reconnect, dynamically added handlers are also lost because autopaho creates a new `paho.Client` from the config copy. Moved handler registration to `pahoCfg.OnPublishReceived` before `NewConnection` so it's baked into the config and persists across all (re-)connects.
- **Suppress spurious startup warnings** — adds `mqtt_wake_list`, `mqtt_wake_add`, `mqtt_wake_remove` to `deferredTools` so `initDelegation`'s capability tag validation doesn't warn about tools registered later in `initServers`

## Root cause

`autopaho.ConnectionManager.AddOnPublishReceived()` acquires a lock and checks `if c.cli != nil` — if the connection goroutine hasn't established yet, the handler is never registered. This meant all MQTT subscriptions (wake, notifications, debug logging) were silently receiving nothing.

## Test plan

- [x] `just ci` passes locally
- [ ] Deploy and verify MQTT wake subscriptions trigger agent conversations
- [ ] Verify message handler survives broker reconnect
- [ ] Startup logs no longer show warnings about `mqtt_wake_list`/`mqtt_wake_add`/`mqtt_wake_remove`

🤖 Generated with [Claude Code](https://claude.com/claude-code)