### PR TITLE
feat: MQTT wake dashboard integration and loop renames

### DIFF
--- a/internal/app/mqttwake.go
+++ b/internal/app/mqttwake.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"path"
 	"strings"
+	"sync/atomic"
 	"time"
 	"unicode/utf8"
 
@@ -31,7 +32,7 @@ const mqttWakeTimeout = 5 * time.Minute
 type mqttWakeDeps struct {
 	registry *looppkg.Registry
 	eventBus *events.Bus
-	parentID func() string // deferred: mqtt parent loop ID may not exist yet
+	parentID *atomic.Value // stores string; set by deferred worker, read by handler goroutines
 }
 
 // mqttWakeHandler returns a MessageHandler that dispatches agent
@@ -63,9 +64,6 @@ func mqttWakeHandler(
 		// Dispatch in a goroutine so the MQTT message handler does not
 		// block the inbound message loop.
 		go func() {
-			ctx, cancel := context.WithTimeout(context.Background(), mqttWakeTimeout)
-			defer cancel()
-
 			convID := fmt.Sprintf("mqtt-wake-%d", time.Now().UnixMilli())
 			msg := buildWakeMessage(topic, payload, ws.Seed.Instructions)
 
@@ -93,8 +91,10 @@ func mqttWakeHandler(
 			loopName := "mqtt/" + path.Base(topic)
 
 			if deps.registry != nil {
-				dispatchViaLoop(ctx, deps, runner, req, loopName, topic, convID, logger)
+				dispatchViaLoop(deps, runner, req, loopName, topic, convID, logger)
 			} else {
+				ctx, cancel := context.WithTimeout(context.Background(), mqttWakeTimeout)
+				defer cancel()
 				dispatchDirect(ctx, runner, req, topic, convID, logger)
 			}
 		}()
@@ -102,29 +102,50 @@ func mqttWakeHandler(
 }
 
 // dispatchViaLoop spawns a one-shot child loop under the MQTT parent
-// so the wake conversation appears on the dashboard.
+// so the wake conversation appears on the dashboard. The loop manages
+// its own lifecycle via MaxDuration — no external context timeout is
+// needed (SpawnLoop is non-blocking, so the caller must not use a
+// short-lived context that would cancel the child loop).
 func dispatchViaLoop(
-	ctx context.Context,
 	deps mqttWakeDeps,
 	runner agentRunner,
 	req *agent.Request,
 	loopName, topic, convID string,
 	logger *slog.Logger,
 ) {
-	parentID := ""
+	var parentID string
 	if deps.parentID != nil {
-		parentID = deps.parentID()
+		if v, ok := deps.parentID.Load().(string); ok {
+			parentID = v
+		}
 	}
 
-	_, err := deps.registry.SpawnLoop(ctx, looppkg.Config{
-		Name:        loopName,
-		MaxIter:     1,
-		MaxDuration: mqttWakeTimeout,
-		ParentID:    parentID,
+	// Use a background context: SpawnLoop is non-blocking (starts a
+	// goroutine and returns immediately), so a timeout context here
+	// would cancel the child loop as soon as defer fires. The loop's
+	// MaxDuration enforces the wall-clock bound instead.
+	//
+	// Sleep values are set to 1ms so the initial sleep is effectively
+	// zero — this is a one-shot loop that should execute immediately.
+	const immediate = time.Millisecond
+	_, err := deps.registry.SpawnLoop(context.Background(), looppkg.Config{
+		Name:         loopName,
+		MaxIter:      1,
+		MaxDuration:  mqttWakeTimeout,
+		SleepMin:     immediate,
+		SleepMax:     immediate,
+		SleepDefault: immediate,
+		Jitter:       looppkg.Float64Ptr(0),
+		ParentID:     parentID,
 		Handler: func(hCtx context.Context, _ any) error {
 			resp, err := runner.Run(hCtx, req, nil)
 			if err != nil {
-				return err
+				logger.Error("mqtt wake agent failed",
+					"conv_id", convID,
+					"topic", topic,
+					"error", err,
+				)
+				return fmt.Errorf("mqtt wake %s on %s: %w", convID, topic, err)
 			}
 			logger.Info("mqtt wake complete",
 				"conv_id", convID,
@@ -151,6 +172,8 @@ func dispatchViaLoop(
 		)
 		// Fall back to direct dispatch if loop spawn fails (e.g.,
 		// concurrency limit reached).
+		ctx, cancel := context.WithTimeout(context.Background(), mqttWakeTimeout)
+		defer cancel()
 		dispatchDirect(ctx, runner, req, topic, convID, logger)
 	}
 }

--- a/internal/app/mqttwake_test.go
+++ b/internal/app/mqttwake_test.go
@@ -3,6 +3,7 @@ package app
 import (
 	"context"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -10,6 +11,8 @@ import (
 	"github.com/nugget/thane-ai-agent/internal/channels/mqtt"
 	"github.com/nugget/thane-ai-agent/internal/config"
 	"github.com/nugget/thane-ai-agent/internal/database"
+	"github.com/nugget/thane-ai-agent/internal/events"
+	looppkg "github.com/nugget/thane-ai-agent/internal/loop"
 	"github.com/nugget/thane-ai-agent/internal/router"
 
 	_ "github.com/mattn/go-sqlite3"
@@ -127,6 +130,49 @@ func TestMQTTWakeHandlerNoMatchFallback(t *testing.T) {
 	}
 	if reqs := runner.requests(); len(reqs) != 0 {
 		t.Errorf("expected 0 requests, got %d", len(reqs))
+	}
+}
+
+func TestMQTTWakeHandlerWithRegistry(t *testing.T) {
+	store := newTestWakeStore(t)
+	seed := router.LoopSeed{Instructions: "test instructions"}
+	store.LoadConfig([]config.SubscriptionConfig{
+		{Topic: "home/sensor/wake", Wake: &seed},
+	})
+
+	runner := &mqttMockRunner{}
+	registry := looppkg.NewRegistry()
+	bus := events.New()
+
+	var parentID atomic.Value
+	parentID.Store("parent-loop-123")
+
+	deps := mqttWakeDeps{
+		registry: registry,
+		eventBus: bus,
+		parentID: &parentID,
+	}
+
+	handler := mqttWakeHandler(store, runner, nil, nil, deps)
+	handler("home/sensor/wake", []byte(`{"temp": 22}`))
+
+	// Wait for the spawned loop to complete.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if reqs := runner.requests(); len(reqs) > 0 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	reqs := runner.requests()
+	if len(reqs) != 1 {
+		t.Fatalf("expected 1 request via registry dispatch, got %d", len(reqs))
+	}
+
+	req := reqs[0]
+	if req.Hints["source"] != "mqtt_wake" {
+		t.Errorf("source hint = %q, want %q", req.Hints["source"], "mqtt_wake")
 	}
 }
 

--- a/internal/app/new_servers.go
+++ b/internal/app/new_servers.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	cdav "github.com/nugget/thane-ai-agent/internal/carddav"
@@ -287,12 +288,14 @@ func (a *App) initServers(s *newState) error {
 		}
 
 		// Track the mqtt parent loop ID once it's spawned (deferred
-		// worker runs after this wiring, so we use a closure).
-		var mqttParentID string
+		// worker runs after this wiring, so we use atomic.Value for
+		// safe cross-goroutine access).
+		var mqttParentID atomic.Value
+		mqttParentID.Store("") // initialize with zero-value string
 		wakeDeps := mqttWakeDeps{
 			registry: a.loopRegistry,
 			eventBus: a.eventBus,
-			parentID: func() string { return mqttParentID },
+			parentID: &mqttParentID,
 		}
 
 		// Wrap with the wake handler: wake-configured topics dispatch
@@ -355,7 +358,7 @@ func (a *App) initServers(s *newState) error {
 			if err != nil {
 				return fmt.Errorf("spawn mqtt loop: %w", err)
 			}
-			mqttParentID = parentID
+			mqttParentID.Store(parentID)
 
 			logger.Info("mqtt connected",
 				"broker", cfg.MQTT.Broker,


### PR DESCRIPTION
## Summary

- **MQTT wake conversations now appear on the dashboard** — each wake dispatch spawns a one-shot child loop (`MaxIter: 1`) under the mqtt parent, following the same parent/child pattern as OWU. Loop name uses last topic segment: `mqtt/{suffix}`
- **Rename `mqtt-publisher` → `mqtt`** — the parent loop for all MQTT activity, shorter and more accurate
- **Rename `mqtt-telemetry` → `telemetry`** — the telemetry loop is protocol-agnostic; transport is an implementation detail
- Graceful fallback to direct dispatch if loop spawn fails (e.g., concurrency limit)
- `mqttWakeDeps` struct with deferred `parentID` func handles the timing gap (handler is wired before the mqtt loop is spawned)

## Files

| File | Change |
|------|--------|
| `internal/app/mqttwake.go` | Add `mqttWakeDeps`, `dispatchViaLoop`, `dispatchDirect`; loop registration for wake conversations |
| `internal/app/mqttwake_test.go` | Update handler call sites for new deps parameter |
| `internal/app/new_servers.go` | Capture mqtt parent loop ID, wire deps, rename loops |

## Test plan

- [x] `just ci` passes locally
- [ ] Deploy and trigger MQTT wake — verify child node appears under `mqtt` on dashboard
- [ ] Verify `telemetry` loop name on dashboard (no `mqtt-` prefix)
- [ ] Verify child loop auto-deregisters after wake conversation completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)