### PR TITLE
feat: add scoped watchlist subscriptions

### DIFF
--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -16,6 +16,7 @@ Tools marked `always` are available regardless of tag state.
 | `list_entities` | Browse entities by domain or pattern |
 | `call_service` | Direct HA service invocation |
 | `add_context_entity` | Add entity to the state watchlist |
+| `list_context_entities` | List live context watchlist subscriptions |
 | `remove_context_entity` | Remove entity from the state watchlist |
 | `ha_notify` | HA companion app push notification |
 

--- a/internal/app/new_awareness.go
+++ b/internal/app/new_awareness.go
@@ -87,6 +87,13 @@ func (a *App) initAwareness(s *newState) error {
 	}
 
 	a.loop.Tools().SetWatchlistStore(watchlistStore)
+	a.loop.Tools().OnWatchlistTagAdded(func(tag string) {
+		if a.ha == nil || strings.TrimSpace(tag) == "" {
+			return
+		}
+		a.loop.RegisterTagContextProvider(tag,
+			awareness.NewWatchlistTagProvider(tag, watchlistStore, a.ha, logger))
+	})
 
 	// --- State change window ---
 	// Maintains a rolling buffer of recent HA state changes, injected

--- a/internal/awareness/entity_format.go
+++ b/internal/awareness/entity_format.go
@@ -325,19 +325,21 @@ func roundState(state, deviceClass string) string {
 		return state // non-numeric, pass through
 	}
 
-	var places int
+	places := statePrecision(deviceClass)
+	return roundFloat(f, places)
+}
+
+func statePrecision(deviceClass string) int {
 	switch deviceClass {
 	case "temperature":
-		places = 1
+		return 1
 	case "humidity", "battery":
-		places = 0
+		return 0
 	case "power", "energy", "voltage", "current":
-		places = 1
+		return 1
 	default:
-		places = 2
+		return 2
 	}
-
-	return roundFloat(f, places)
 }
 
 // roundFloat formats a float to the given decimal places, stripping

--- a/internal/awareness/watchlist_history.go
+++ b/internal/awareness/watchlist_history.go
@@ -1,0 +1,286 @@
+package awareness
+
+import (
+	"context"
+	"encoding/json"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/nugget/thane-ai-agent/internal/homeassistant"
+)
+
+const (
+	maxWatchlistHistoryWindows     = 4
+	maxWatchlistRecentDiscreteKeys = 4
+)
+
+func buildWatchlistHistorySummaries(
+	ctx context.Context,
+	history StateGetter,
+	current *homeassistant.State,
+	offsets []int,
+	now time.Time,
+) ([]map[string]any, bool, error) {
+	if current == nil || len(offsets) == 0 {
+		return nil, false, nil
+	}
+
+	windows, truncated := normalizeHistoryOffsets(offsets)
+	if len(windows) == 0 {
+		return nil, truncated, nil
+	}
+
+	startTime := now.Add(-time.Duration(windows[len(windows)-1]) * time.Second)
+	states, err := history.GetStateHistory(ctx, current.EntityID, startTime, now)
+	if err != nil {
+		return nil, truncated, err
+	}
+
+	series := normalizeHistoryStates(states, current)
+	if len(series) == 0 {
+		return nil, truncated, nil
+	}
+
+	summaries := make([]map[string]any, 0, len(windows))
+	for _, offset := range windows {
+		window := historyWindowStates(series, now.Add(-time.Duration(offset)*time.Second))
+		if len(window) == 0 {
+			continue
+		}
+		summary := summarizeHistoryWindow(window, current, offset)
+		if len(summary) > 0 {
+			summaries = append(summaries, summary)
+		}
+	}
+
+	return summaries, truncated, nil
+}
+
+func mergeHistoryIntoEntityContext(base string, summaries []map[string]any, truncated bool) string {
+	if len(summaries) == 0 && !truncated {
+		return base
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(base), &payload); err == nil {
+		payload["history"] = summaries
+		if truncated {
+			payload["history_truncated"] = true
+		}
+		return marshalCompact(payload)
+	}
+
+	fallback := map[string]any{"history": summaries}
+	if truncated {
+		fallback["history_truncated"] = true
+	}
+	return base + "\n" + marshalCompact(fallback)
+}
+
+func normalizeHistoryOffsets(offsets []int) ([]int, bool) {
+	seen := make(map[int]bool, len(offsets))
+	windows := make([]int, 0, len(offsets))
+	for _, offset := range offsets {
+		if offset <= 0 || seen[offset] {
+			continue
+		}
+		seen[offset] = true
+		windows = append(windows, offset)
+	}
+	sort.Ints(windows)
+	if len(windows) <= maxWatchlistHistoryWindows {
+		return windows, false
+	}
+	return windows[:maxWatchlistHistoryWindows], true
+}
+
+func normalizeHistoryStates(states []homeassistant.State, current *homeassistant.State) []homeassistant.State {
+	series := append([]homeassistant.State(nil), states...)
+	sort.Slice(series, func(i, j int) bool {
+		return historyStateTime(series[i]).Before(historyStateTime(series[j]))
+	})
+
+	out := make([]homeassistant.State, 0, len(series)+1)
+	for _, state := range series {
+		if current != nil && state.EntityID == "" {
+			state.EntityID = current.EntityID
+		}
+		if len(out) > 0 && sameHistoryState(out[len(out)-1], state) {
+			continue
+		}
+		out = append(out, state)
+	}
+
+	if current != nil {
+		currentCopy := *current
+		if len(out) == 0 || !sameHistoryState(out[len(out)-1], currentCopy) {
+			out = append(out, currentCopy)
+		} else {
+			out[len(out)-1] = currentCopy
+		}
+	}
+
+	return out
+}
+
+func historyWindowStates(series []homeassistant.State, cutoff time.Time) []homeassistant.State {
+	baselineIdx := -1
+	for i, state := range series {
+		if !historyStateTime(state).After(cutoff) {
+			baselineIdx = i
+			continue
+		}
+		break
+	}
+
+	window := make([]homeassistant.State, 0, len(series))
+	if baselineIdx >= 0 {
+		window = append(window, series[baselineIdx])
+	}
+	for _, state := range series {
+		if historyStateTime(state).After(cutoff) {
+			if len(window) > 0 && sameHistoryState(window[len(window)-1], state) {
+				continue
+			}
+			window = append(window, state)
+		}
+	}
+	if len(window) == 0 && len(series) > 0 {
+		window = append(window, series[len(series)-1])
+	}
+	return window
+}
+
+func summarizeHistoryWindow(window []homeassistant.State, current *homeassistant.State, offsetSeconds int) map[string]any {
+	if len(window) == 0 {
+		return nil
+	}
+
+	if summary, ok := summarizeNumericHistory(window, current, offsetSeconds); ok {
+		return summary
+	}
+	return summarizeDiscreteHistory(window, offsetSeconds)
+}
+
+func summarizeNumericHistory(window []homeassistant.State, current *homeassistant.State, offsetSeconds int) (map[string]any, bool) {
+	values := make([]float64, 0, len(window))
+	for _, state := range window {
+		value, err := strconv.ParseFloat(strings.TrimSpace(state.State), 64)
+		if err != nil {
+			return nil, false
+		}
+		values = append(values, value)
+	}
+	if len(values) == 0 {
+		return nil, false
+	}
+
+	places := historyPrecision(current)
+	first := values[0]
+	last := values[len(values)-1]
+	minValue := values[0]
+	maxValue := values[0]
+	for _, value := range values[1:] {
+		if value < minValue {
+			minValue = value
+		}
+		if value > maxValue {
+			maxValue = value
+		}
+	}
+
+	delta := last - first
+	summary := map[string]any{
+		"lookback":     historyLookbackDelta(offsetSeconds),
+		"kind":         "numeric",
+		"sample_count": len(values),
+		"start_state":  roundFloat(first, places),
+		"end_state":    roundFloat(last, places),
+		"value_delta":  formatSignedFloat(delta, places),
+		"min_value":    roundFloat(minValue, places),
+		"max_value":    roundFloat(maxValue, places),
+		"trend":        numericTrendLabel(delta),
+	}
+	return summary, true
+}
+
+func summarizeDiscreteHistory(window []homeassistant.State, offsetSeconds int) map[string]any {
+	if len(window) == 0 {
+		return nil
+	}
+
+	changes := 0
+	recent := make([]string, 0, maxWatchlistRecentDiscreteKeys)
+	recentTruncated := false
+	for i, state := range window {
+		if i > 0 && window[i-1].State != state.State {
+			changes++
+		}
+		if len(recent) == 0 || recent[len(recent)-1] != state.State {
+			recent = append(recent, state.State)
+			if len(recent) > maxWatchlistRecentDiscreteKeys {
+				recent = recent[len(recent)-maxWatchlistRecentDiscreteKeys:]
+				recentTruncated = true
+			}
+		}
+	}
+
+	summary := map[string]any{
+		"lookback":                historyLookbackDelta(offsetSeconds),
+		"kind":                    "discrete",
+		"sample_count":            len(window),
+		"change_count":            changes,
+		"start_state":             window[0].State,
+		"end_state":               window[len(window)-1].State,
+		"recent_states":           recent,
+		"recent_states_truncated": recentTruncated,
+	}
+	if changes == 0 {
+		summary["trend"] = "stable"
+	}
+	return summary
+}
+
+func numericTrendLabel(delta float64) string {
+	switch {
+	case delta > 0.001:
+		return "rising"
+	case delta < -0.001:
+		return "falling"
+	default:
+		return "flat"
+	}
+}
+
+func formatSignedFloat(value float64, places int) string {
+	formatted := roundFloat(value, places)
+	if value > 0 {
+		return "+" + formatted
+	}
+	return formatted
+}
+
+func historyLookbackDelta(offsetSeconds int) string {
+	base := time.Unix(0, 0).UTC()
+	return FormatDeltaOnly(base.Add(-time.Duration(offsetSeconds)*time.Second), base)
+}
+
+func historyPrecision(current *homeassistant.State) int {
+	if current == nil {
+		return 2
+	}
+	return statePrecision(attrString(current.Attributes, "device_class"))
+}
+
+func historyStateTime(state homeassistant.State) time.Time {
+	if !state.LastChanged.IsZero() {
+		return state.LastChanged
+	}
+	return state.LastUpdated
+}
+
+func sameHistoryState(a, b homeassistant.State) bool {
+	return a.State == b.State && historyStateTime(a).Equal(historyStateTime(b))
+}

--- a/internal/awareness/watchlist_provider.go
+++ b/internal/awareness/watchlist_provider.go
@@ -10,11 +10,12 @@ import (
 	"github.com/nugget/thane-ai-agent/internal/homeassistant"
 )
 
-// StateGetter abstracts the Home Assistant REST client for fetching
-// entity state. Using an interface keeps the provider testable without
-// a real HA instance.
+// StateGetter abstracts the Home Assistant client methods the watchlist
+// providers need. Using an interface keeps the providers testable without a
+// real HA instance.
 type StateGetter interface {
 	GetState(ctx context.Context, entityID string) (*homeassistant.State, error)
+	GetStateHistory(ctx context.Context, entityID string, startTime, endTime time.Time) ([]homeassistant.State, error)
 }
 
 // WatchlistProvider implements agent.ContextProvider by fetching live state for
@@ -50,11 +51,11 @@ func (p *WatchlistProvider) GetContext(ctx context.Context, _ string) (string, e
 	// Only emit untagged entities in the always-on context provider.
 	// Tagged entities are emitted through WatchlistTagProvider when
 	// their capability tag is active.
-	ids, err := p.store.ListUntagged()
+	subs, err := p.store.ListUntaggedSubscriptions()
 	if err != nil {
 		return "", fmt.Errorf("list watched entities: %w", err)
 	}
-	if len(ids) == 0 {
+	if len(subs) == 0 {
 		return "", nil
 	}
 
@@ -63,18 +64,8 @@ func (p *WatchlistProvider) GetContext(ctx context.Context, _ string) (string, e
 	var sb strings.Builder
 	sb.WriteString("### Watched Entities\n\n")
 
-	for _, id := range ids {
-		state, err := p.ha.GetState(ctx, id)
-		if err != nil {
-			p.logger.Warn("failed to fetch watched entity state",
-				"entity_id", id,
-				"error", err,
-			)
-			fmt.Fprintf(&sb, "- **%s**: unavailable\n", id)
-			continue
-		}
-
-		sb.WriteString(formatEntityContext(state, now))
+	for _, sub := range subs {
+		sb.WriteString(p.renderSubscriptionContext(ctx, sub, now))
 		sb.WriteByte('\n')
 	}
 
@@ -113,16 +104,73 @@ func (p *WatchlistTagProvider) TagContext(ctx context.Context) (string, error) {
 	fmt.Fprintf(&sb, "### Watched Entities (%s)\n\n", p.tag)
 
 	for _, e := range entities {
-		state, err := p.ha.GetState(ctx, e.EntityID)
-		if err != nil {
-			p.logger.Warn("failed to fetch tagged entity state",
-				"entity_id", e.EntityID, "tag", p.tag, "error", err)
-			continue
-		}
-
-		sb.WriteString(formatEntityContext(state, now))
+		sb.WriteString(p.renderSubscriptionContext(ctx, e, now))
 		sb.WriteByte('\n')
 	}
 
 	return sb.String(), nil
+}
+
+func (p *WatchlistProvider) renderSubscriptionContext(ctx context.Context, sub WatchedSubscription, now time.Time) string {
+	state, err := p.ha.GetState(ctx, sub.EntityID)
+	if err != nil {
+		p.logger.Warn("failed to fetch watched entity state",
+			"entity_id", sub.EntityID,
+			"error", err,
+		)
+		return fmt.Sprintf("- **%s**: unavailable", sub.EntityID)
+	}
+
+	content := formatEntityContext(state, now)
+	if len(sub.History) == 0 {
+		return content
+	}
+
+	summaries, truncated, err := buildWatchlistHistorySummaries(ctx, p.ha, state, sub.History, now)
+	if err != nil {
+		p.logger.Warn("failed to fetch watched entity history",
+			"entity_id", sub.EntityID,
+			"history", sub.History,
+			"error", err,
+		)
+		return content
+	}
+	if len(summaries) == 0 && !truncated {
+		return content
+	}
+
+	return mergeHistoryIntoEntityContext(content, summaries, truncated)
+}
+
+func (p *WatchlistTagProvider) renderSubscriptionContext(ctx context.Context, sub WatchedSubscription, now time.Time) string {
+	state, err := p.ha.GetState(ctx, sub.EntityID)
+	if err != nil {
+		p.logger.Warn("failed to fetch tagged entity state",
+			"entity_id", sub.EntityID,
+			"tag", p.tag,
+			"error", err,
+		)
+		return ""
+	}
+
+	content := formatEntityContext(state, now)
+	if len(sub.History) == 0 {
+		return content
+	}
+
+	summaries, truncated, err := buildWatchlistHistorySummaries(ctx, p.ha, state, sub.History, now)
+	if err != nil {
+		p.logger.Warn("failed to fetch tagged entity history",
+			"entity_id", sub.EntityID,
+			"tag", p.tag,
+			"history", sub.History,
+			"error", err,
+		)
+		return content
+	}
+	if len(summaries) == 0 && !truncated {
+		return content
+	}
+
+	return mergeHistoryIntoEntityContext(content, summaries, truncated)
 }

--- a/internal/awareness/watchlist_provider_test.go
+++ b/internal/awareness/watchlist_provider_test.go
@@ -3,6 +3,7 @@ package awareness
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"log/slog"
 	"strings"
@@ -15,8 +16,10 @@ import (
 
 // fakeHA implements StateGetter for testing.
 type fakeHA struct {
-	states map[string]*homeassistant.State
-	err    error // returned for any entity not in states
+	states  map[string]*homeassistant.State
+	history map[string][]homeassistant.State
+	err     error // returned for any entity not in states
+	histErr error
 }
 
 func (f *fakeHA) GetState(_ context.Context, entityID string) (*homeassistant.State, error) {
@@ -27,6 +30,14 @@ func (f *fakeHA) GetState(_ context.Context, entityID string) (*homeassistant.St
 		return nil, f.err
 	}
 	return nil, errors.New("entity not found")
+}
+
+func (f *fakeHA) GetStateHistory(_ context.Context, entityID string, _ time.Time, _ time.Time) ([]homeassistant.State, error) {
+	if f.histErr != nil {
+		return nil, f.histErr
+	}
+	history := f.history[entityID]
+	return append([]homeassistant.State(nil), history...), nil
 }
 
 func setupTestProvider(t *testing.T, ha StateGetter) (*WatchlistProvider, *WatchlistStore) {
@@ -205,4 +216,139 @@ func TestProvider_NoFriendlyName(t *testing.T) {
 	if strings.Contains(got, `"name"`) {
 		t.Error("name should be omitted when no friendly_name")
 	}
+}
+
+func TestProvider_IncludesNumericHistorySummaries(t *testing.T) {
+	now := time.Now().UTC().Round(time.Second)
+	ha := &fakeHA{
+		states: map[string]*homeassistant.State{
+			"sensor.office_temperature": {
+				EntityID:    "sensor.office_temperature",
+				State:       "72.4",
+				LastChanged: now,
+				Attributes: map[string]any{
+					"friendly_name":       "Office Temperature",
+					"unit_of_measurement": "°F",
+					"device_class":        "temperature",
+				},
+			},
+		},
+		history: map[string][]homeassistant.State{
+			"sensor.office_temperature": {
+				{EntityID: "sensor.office_temperature", State: "70.1", LastChanged: now.Add(-26 * time.Hour)},
+				{EntityID: "sensor.office_temperature", State: "71.0", LastChanged: now.Add(-23 * time.Hour)},
+				{EntityID: "sensor.office_temperature", State: "71.8", LastChanged: now.Add(-6 * time.Hour)},
+				{EntityID: "sensor.office_temperature", State: "72.0", LastChanged: now.Add(-90 * time.Minute)},
+			},
+		},
+	}
+
+	p, store := setupTestProvider(t, ha)
+	if err := store.AddWithOptions("sensor.office_temperature", nil, []int{24 * 60 * 60}, 0); err != nil {
+		t.Fatalf("AddWithOptions: %v", err)
+	}
+
+	got, err := p.GetContext(context.Background(), "")
+	if err != nil {
+		t.Fatalf("GetContext: %v", err)
+	}
+
+	payload := decodeWatchlistPayload(t, got)
+	history, ok := payload["history"].([]any)
+	if !ok || len(history) != 1 {
+		t.Fatalf("history = %#v, want one summary", payload["history"])
+	}
+	summary, ok := history[0].(map[string]any)
+	if !ok {
+		t.Fatalf("history[0] = %#v, want object", history[0])
+	}
+	if summary["kind"] != "numeric" {
+		t.Fatalf("kind = %#v, want numeric", summary["kind"])
+	}
+	if summary["lookback"] != "-86400s" {
+		t.Fatalf("lookback = %#v, want -86400s", summary["lookback"])
+	}
+	if summary["trend"] != "rising" {
+		t.Fatalf("trend = %#v, want rising", summary["trend"])
+	}
+	if summary["value_delta"] != "+2.3" {
+		t.Fatalf("value_delta = %#v, want +2.3", summary["value_delta"])
+	}
+	if summary["sample_count"] != float64(5) {
+		t.Fatalf("sample_count = %#v, want 5", summary["sample_count"])
+	}
+}
+
+func TestProvider_IncludesDiscreteHistorySummaries(t *testing.T) {
+	now := time.Now().UTC().Round(time.Second)
+	ha := &fakeHA{
+		states: map[string]*homeassistant.State{
+			"binary_sensor.front_door": {
+				EntityID:    "binary_sensor.front_door",
+				State:       "off",
+				LastChanged: now,
+				Attributes: map[string]any{
+					"friendly_name": "Front Door",
+				},
+			},
+		},
+		history: map[string][]homeassistant.State{
+			"binary_sensor.front_door": {
+				{EntityID: "binary_sensor.front_door", State: "off", LastChanged: now.Add(-25 * time.Hour)},
+				{EntityID: "binary_sensor.front_door", State: "on", LastChanged: now.Add(-20 * time.Hour)},
+				{EntityID: "binary_sensor.front_door", State: "off", LastChanged: now.Add(-2 * time.Hour)},
+			},
+		},
+	}
+
+	p, store := setupTestProvider(t, ha)
+	if err := store.AddWithOptions("binary_sensor.front_door", nil, []int{24 * 60 * 60}, 0); err != nil {
+		t.Fatalf("AddWithOptions: %v", err)
+	}
+
+	got, err := p.GetContext(context.Background(), "")
+	if err != nil {
+		t.Fatalf("GetContext: %v", err)
+	}
+
+	payload := decodeWatchlistPayload(t, got)
+	history, ok := payload["history"].([]any)
+	if !ok || len(history) != 1 {
+		t.Fatalf("history = %#v, want one summary", payload["history"])
+	}
+	summary, ok := history[0].(map[string]any)
+	if !ok {
+		t.Fatalf("history[0] = %#v, want object", history[0])
+	}
+	if summary["kind"] != "discrete" {
+		t.Fatalf("kind = %#v, want discrete", summary["kind"])
+	}
+	if summary["lookback"] != "-86400s" {
+		t.Fatalf("lookback = %#v, want -86400s", summary["lookback"])
+	}
+	if summary["change_count"] != float64(2) {
+		t.Fatalf("change_count = %#v, want 2", summary["change_count"])
+	}
+	if summary["end_state"] != "off" {
+		t.Fatalf("end_state = %#v, want off", summary["end_state"])
+	}
+	if summary["recent_states_truncated"] != false {
+		t.Fatalf("recent_states_truncated = %#v, want false", summary["recent_states_truncated"])
+	}
+}
+
+func decodeWatchlistPayload(t *testing.T, got string) map[string]any {
+	t.Helper()
+
+	lines := strings.Split(strings.TrimSpace(got), "\n")
+	if len(lines) < 3 {
+		t.Fatalf("unexpected watchlist context: %q", got)
+	}
+
+	payloadLine := strings.TrimSpace(lines[len(lines)-1])
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(payloadLine), &payload); err != nil {
+		t.Fatalf("unmarshal payload %q: %v", payloadLine, err)
+	}
+	return payload
 }

--- a/internal/awareness/watchlist_store.go
+++ b/internal/awareness/watchlist_store.go
@@ -6,16 +6,24 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"time"
 )
 
-// WatchedEntity represents a single watchlist entry with its options.
-type WatchedEntity struct {
-	EntityID string
-	Tags     []string // capability tags — empty means always visible
-	History  []int    // delta offsets in seconds (e.g., [600, 3600, 86400])
+const (
+	legacyWatchlistTable       = "watched_entities"
+	watchlistSubscriptionTable = "watched_entity_subscriptions"
+)
+
+// WatchedSubscription represents one entity subscription scope with its stored
+// options. Empty Scope means the entity is always visible.
+type WatchedSubscription struct {
+	EntityID  string
+	Scope     string
+	History   []int
+	ExpiresAt *time.Time
 }
 
-// WatchlistStore persists the set of watched entity IDs in SQLite.
+// WatchlistStore persists the set of watched entity subscriptions in SQLite.
 type WatchlistStore struct {
 	db *sql.DB
 }
@@ -30,182 +38,210 @@ func NewWatchlistStore(db *sql.DB) (*WatchlistStore, error) {
 }
 
 func (s *WatchlistStore) migrate() error {
-	// Create table if it doesn't exist.
 	_, err := s.db.Exec(`
-		CREATE TABLE IF NOT EXISTS watched_entities (
-			entity_id TEXT PRIMARY KEY,
+		CREATE TABLE IF NOT EXISTS watched_entity_subscriptions (
+			entity_id TEXT NOT NULL,
+			scope     TEXT NOT NULL DEFAULT '',
 			added_at  TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-			tags      TEXT NOT NULL DEFAULT '',
-			options   TEXT NOT NULL DEFAULT '{}'
+			options   TEXT NOT NULL DEFAULT '{}',
+			PRIMARY KEY (scope, entity_id)
 		)
 	`)
 	if err != nil {
 		return err
 	}
 
-	// Add columns for existing databases (idempotent). Only the
-	// "duplicate column" error is expected and ignored; other ALTER
-	// failures are surfaced.
-	for _, col := range []struct{ name, def string }{
-		{"tags", "TEXT NOT NULL DEFAULT ''"},
-		{"options", "TEXT NOT NULL DEFAULT '{}'"},
-	} {
-		_, err = s.db.Exec(fmt.Sprintf(
-			`ALTER TABLE watched_entities ADD COLUMN %s %s`, col.name, col.def,
-		))
-		if err != nil && !strings.Contains(strings.ToLower(err.Error()), "duplicate column") {
-			return fmt.Errorf("alter watched_entities add column %s: %w", col.name, err)
-		}
+	ok, err := s.hasTable(legacyWatchlistTable)
+	if err != nil {
+		return fmt.Errorf("check legacy watchlist table: %w", err)
+	}
+	if !ok {
+		return nil
+	}
+
+	if err := s.ensureLegacyWatchlistColumns(); err != nil {
+		return fmt.Errorf("ensure legacy watchlist columns: %w", err)
+	}
+
+	if err := s.migrateLegacyWatchlist(); err != nil {
+		return fmt.Errorf("migrate legacy watchlist rows: %w", err)
 	}
 
 	return nil
 }
 
-// Add inserts an entity into the watchlist with no tags or options.
+func (s *WatchlistStore) ensureLegacyWatchlistColumns() error {
+	for _, col := range []struct{ name, def string }{
+		{"tags", "TEXT NOT NULL DEFAULT ''"},
+		{"options", "TEXT NOT NULL DEFAULT '{}'"},
+	} {
+		_, err := s.db.Exec(fmt.Sprintf(
+			`ALTER TABLE %s ADD COLUMN %s %s`,
+			legacyWatchlistTable,
+			col.name,
+			col.def,
+		))
+		if err != nil && !strings.Contains(strings.ToLower(err.Error()), "duplicate column") {
+			return fmt.Errorf("alter %s add column %s: %w", legacyWatchlistTable, col.name, err)
+		}
+	}
+	return nil
+}
+
+// Add inserts an entity into the watchlist with no scope or options.
 // Duplicates are silently ignored. Use [AddWithOptions] for richer
 // subscriptions.
 func (s *WatchlistStore) Add(entityID string) error {
 	_, err := s.db.Exec(
-		`INSERT OR IGNORE INTO watched_entities (entity_id) VALUES (?)`,
+		`INSERT INTO watched_entity_subscriptions (entity_id, scope, options)
+		 VALUES (?, '', '{}')
+		 ON CONFLICT(scope, entity_id) DO NOTHING`,
 		entityID,
 	)
 	return err
 }
 
-// AddWithOptions inserts or updates an entity with tags and history
-// offsets. On conflict (duplicate entity_id), the tags and options are
-// updated to the new values.
-func (s *WatchlistStore) AddWithOptions(entityID string, tags []string, history []int) error {
-	tagsStr := strings.Join(tags, ",")
+// AddWithOptions inserts or updates entity subscriptions with tag scopes,
+// historical offsets, and an optional TTL. Empty tags means the entity is
+// always visible in context.
+func (s *WatchlistStore) AddWithOptions(entityID string, tags []string, history []int, ttlSeconds int) error {
+	scopes := normalizeScopes(tags)
 
-	opts := map[string]any{}
-	if len(history) > 0 {
-		opts["history"] = history
-	}
-	optsJSON, err := json.Marshal(opts)
+	optsJSON, err := marshalWatchlistOptions(history, ttlSeconds)
 	if err != nil {
 		return fmt.Errorf("marshal options: %w", err)
 	}
 
-	_, err = s.db.Exec(`
-		INSERT INTO watched_entities (entity_id, tags, options)
-		VALUES (?, ?, ?)
-		ON CONFLICT(entity_id) DO UPDATE SET tags = excluded.tags, options = excluded.options
-	`, entityID, tagsStr, string(optsJSON))
-	return err
+	tx, err := s.db.Begin()
+	if err != nil {
+		return fmt.Errorf("begin watchlist tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	for _, scope := range scopes {
+		if _, err := tx.Exec(`
+			INSERT INTO watched_entity_subscriptions (entity_id, scope, options)
+			VALUES (?, ?, ?)
+			ON CONFLICT(scope, entity_id) DO UPDATE SET options = excluded.options
+		`, entityID, scope, string(optsJSON)); err != nil {
+			return fmt.Errorf("upsert watchlist subscription for %s/%s: %w", entityID, scope, err)
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit watchlist tx: %w", err)
+	}
+	return nil
 }
 
-// Remove deletes an entity from the watchlist. Non-existent IDs are a no-op.
+// Remove deletes all subscriptions for an entity. Non-existent IDs are a no-op.
 func (s *WatchlistStore) Remove(entityID string) error {
-	_, err := s.db.Exec(
-		`DELETE FROM watched_entities WHERE entity_id = ?`,
-		entityID,
-	)
-	return err
+	return s.RemoveWithScopes(entityID, nil)
 }
 
-// List returns all watched entity IDs in insertion order (unfiltered).
+// RemoveWithScopes deletes subscriptions for an entity. When scopes is empty,
+// all subscriptions for the entity are removed.
+func (s *WatchlistStore) RemoveWithScopes(entityID string, scopes []string) error {
+	if len(scopes) == 0 {
+		_, err := s.db.Exec(
+			`DELETE FROM watched_entity_subscriptions WHERE entity_id = ?`,
+			entityID,
+		)
+		return err
+	}
+
+	tx, err := s.db.Begin()
+	if err != nil {
+		return fmt.Errorf("begin watchlist delete tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	for _, scope := range normalizeScopes(scopes) {
+		if _, err := tx.Exec(
+			`DELETE FROM watched_entity_subscriptions WHERE entity_id = ? AND scope = ?`,
+			entityID, scope,
+		); err != nil {
+			return err
+		}
+	}
+	return tx.Commit()
+}
+
+// List returns all watched entity IDs in insertion order, deduplicated across
+// scoped subscriptions.
 func (s *WatchlistStore) List() ([]string, error) {
-	rows, err := s.db.Query(
-		`SELECT entity_id FROM watched_entities ORDER BY added_at ASC`,
-	)
+	subs, err := s.ListSubscriptions("")
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
 
-	var ids []string
-	for rows.Next() {
-		var id string
-		if err := rows.Scan(&id); err != nil {
-			return nil, err
+	ids := make([]string, 0, len(subs))
+	seen := make(map[string]bool, len(subs))
+	for _, sub := range subs {
+		if seen[sub.EntityID] {
+			continue
 		}
-		ids = append(ids, id)
+		seen[sub.EntityID] = true
+		ids = append(ids, sub.EntityID)
 	}
-	return ids, rows.Err()
+	return ids, nil
 }
 
-// ListUntagged returns watched entities that have no capability tags
-// (always visible in context regardless of active tags).
+// ListUntagged returns watched entities that have no capability scope
+// and are always visible in context regardless of active tags.
 func (s *WatchlistStore) ListUntagged() ([]string, error) {
-	rows, err := s.db.Query(
-		`SELECT entity_id FROM watched_entities WHERE tags = '' ORDER BY added_at ASC`,
-	)
+	subs, err := s.ListUntaggedSubscriptions()
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
 
-	var ids []string
-	for rows.Next() {
-		var id string
-		if err := rows.Scan(&id); err != nil {
-			return nil, err
-		}
-		ids = append(ids, id)
+	ids := make([]string, 0, len(subs))
+	for _, sub := range subs {
+		ids = append(ids, sub.EntityID)
 	}
-	return ids, rows.Err()
+	return ids, nil
 }
 
-// ListByTag returns watched entities that include the given capability
-// tag. Used by the tag context assembler to inject entity context only
-// when a tag is active.
-func (s *WatchlistStore) ListByTag(tag string) ([]WatchedEntity, error) {
-	// SQLite doesn't have array types, so tags are stored as
-	// comma-separated values. We match with LIKE for single-tag
-	// queries and post-filter for exactness.
-	rows, err := s.db.Query(
-		`SELECT entity_id, tags, options FROM watched_entities
-		 WHERE tags LIKE ? ORDER BY added_at ASC`,
-		"%"+tag+"%",
-	)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-
-	var entities []WatchedEntity
-	for rows.Next() {
-		var id, tagsStr, optsJSON string
-		if err := rows.Scan(&id, &tagsStr, &optsJSON); err != nil {
-			return nil, err
-		}
-		tags := splitTags(tagsStr)
-		if !containsTag(tags, tag) {
-			continue // LIKE matched a substring, not the exact tag
-		}
-		entities = append(entities, WatchedEntity{
-			EntityID: id,
-			Tags:     tags,
-			History:  parseHistory(optsJSON),
-		})
-	}
-	return entities, rows.Err()
+// ListUntaggedSubscriptions returns all always-visible subscriptions with their
+// stored options intact.
+func (s *WatchlistStore) ListUntaggedSubscriptions() ([]WatchedSubscription, error) {
+	return s.listScopedSubscriptions("")
 }
 
-// DistinctTags returns all unique tags across all watched entities.
+// ListByTag returns watched entity subscriptions for the given capability
+// tag. Used by the tag context assembler to inject entity context only when a
+// tag is active.
+func (s *WatchlistStore) ListByTag(tag string) ([]WatchedSubscription, error) {
+	return s.listScopedSubscriptions(tag)
+}
+
+// ListSubscriptions returns active subscriptions. When scope is empty, all
+// scopes are returned.
+func (s *WatchlistStore) ListSubscriptions(scope string) ([]WatchedSubscription, error) {
+	query := `SELECT entity_id, scope, options FROM watched_entity_subscriptions`
+	var args []any
+	if scope != "" {
+		query += ` WHERE scope = ?`
+		args = append(args, scope)
+	}
+	query += ` ORDER BY added_at ASC`
+	return s.scanActiveSubscriptions(query, args...)
+}
+
+// DistinctTags returns all unique active scopes across watched entities.
 // Used at startup to register tag-scoped watchlist providers.
 func (s *WatchlistStore) DistinctTags() ([]string, error) {
-	rows, err := s.db.Query(
-		`SELECT DISTINCT tags FROM watched_entities WHERE tags != '' ORDER BY tags ASC`,
-	)
+	subs, err := s.ListSubscriptions("")
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
 
 	seen := make(map[string]bool)
-	for rows.Next() {
-		var tagsStr string
-		if err := rows.Scan(&tagsStr); err != nil {
-			return nil, err
+	for _, sub := range subs {
+		if sub.Scope == "" {
+			continue
 		}
-		for _, tag := range splitTags(tagsStr) {
-			seen[tag] = true
-		}
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
+		seen[sub.Scope] = true
 	}
 
 	tags := make([]string, 0, len(seen))
@@ -214,6 +250,217 @@ func (s *WatchlistStore) DistinctTags() ([]string, error) {
 	}
 	sort.Strings(tags)
 	return tags, nil
+}
+
+func (s *WatchlistStore) listScopedSubscriptions(scope string) ([]WatchedSubscription, error) {
+	return s.scanActiveSubscriptions(
+		`SELECT entity_id, scope, options FROM watched_entity_subscriptions
+		 WHERE scope = ? ORDER BY added_at ASC`,
+		scope,
+	)
+}
+
+func (s *WatchlistStore) scanActiveSubscriptions(query string, args ...any) ([]WatchedSubscription, error) {
+	rows, err := s.db.Query(query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	now := time.Now().UTC()
+	var (
+		subs    []WatchedSubscription
+		expired []subscriptionKey
+	)
+	for rows.Next() {
+		var entityID, scope, optsJSON string
+		if err := rows.Scan(&entityID, &scope, &optsJSON); err != nil {
+			return nil, err
+		}
+		opts := parseWatchlistOptions(optsJSON)
+		if opts.expired(now) {
+			expired = append(expired, subscriptionKey{EntityID: entityID, Scope: scope})
+			continue
+		}
+		subs = append(subs, WatchedSubscription{
+			EntityID:  entityID,
+			Scope:     scope,
+			History:   append([]int(nil), opts.History...),
+			ExpiresAt: cloneTimePtr(opts.ExpiresAt),
+		})
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	if err := s.removeExpiredSubscriptions(expired); err != nil {
+		return nil, err
+	}
+	return subs, nil
+}
+
+func (s *WatchlistStore) removeExpiredSubscriptions(keys []subscriptionKey) error {
+	if len(keys) == 0 {
+		return nil
+	}
+	tx, err := s.db.Begin()
+	if err != nil {
+		return fmt.Errorf("begin expired watchlist cleanup: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	for _, key := range keys {
+		if _, err := tx.Exec(
+			`DELETE FROM watched_entity_subscriptions WHERE entity_id = ? AND scope = ?`,
+			key.EntityID, key.Scope,
+		); err != nil {
+			return fmt.Errorf("delete expired watchlist subscription %s/%s: %w", key.EntityID, key.Scope, err)
+		}
+	}
+	return tx.Commit()
+}
+
+func (s *WatchlistStore) hasTable(name string) (bool, error) {
+	var found string
+	err := s.db.QueryRow(`SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?`, name).Scan(&found)
+	if err == sql.ErrNoRows {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func (s *WatchlistStore) subscriptionCount() (int, error) {
+	var count int
+	if err := s.db.QueryRow(`SELECT COUNT(*) FROM watched_entity_subscriptions`).Scan(&count); err != nil {
+		return 0, err
+	}
+	return count, nil
+}
+
+func (s *WatchlistStore) migrateLegacyWatchlist() error {
+	tx, err := s.db.Begin()
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	rows, err := tx.Query(`SELECT entity_id, tags, options, added_at FROM watched_entities ORDER BY added_at ASC`)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var entityID, tagsStr, optsJSON, addedAt string
+		if err := rows.Scan(&entityID, &tagsStr, &optsJSON, &addedAt); err != nil {
+			return err
+		}
+		for _, scope := range normalizeScopes(splitTags(tagsStr)) {
+			if _, err := tx.Exec(`
+				INSERT OR IGNORE INTO watched_entity_subscriptions (entity_id, scope, added_at, options)
+				VALUES (?, ?, ?, ?)
+			`, entityID, scope, addedAt, normalizeLegacyOptions(optsJSON)); err != nil {
+				return err
+			}
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
+type subscriptionKey struct {
+	EntityID string
+	Scope    string
+}
+
+type watchlistOptions struct {
+	History   []int
+	ExpiresAt *time.Time
+}
+
+type watchlistOptionsWire struct {
+	History   []int  `json:"history,omitempty"`
+	ExpiresAt string `json:"expires_at,omitempty"`
+}
+
+func marshalWatchlistOptions(history []int, ttlSeconds int) ([]byte, error) {
+	wire := watchlistOptionsWire{
+		History: append([]int(nil), history...),
+	}
+	if ttlSeconds > 0 {
+		wire.ExpiresAt = time.Now().UTC().Add(time.Duration(ttlSeconds) * time.Second).Format(time.RFC3339)
+	}
+	return json.Marshal(wire)
+}
+
+func parseWatchlistOptions(optsJSON string) watchlistOptions {
+	if optsJSON == "" || optsJSON == "{}" {
+		return watchlistOptions{}
+	}
+	var wire watchlistOptionsWire
+	if err := json.Unmarshal([]byte(optsJSON), &wire); err != nil {
+		return watchlistOptions{}
+	}
+	out := watchlistOptions{
+		History: append([]int(nil), wire.History...),
+	}
+	if wire.ExpiresAt != "" {
+		if ts, err := time.Parse(time.RFC3339, wire.ExpiresAt); err == nil {
+			ts = ts.UTC()
+			out.ExpiresAt = &ts
+		}
+	}
+	return out
+}
+
+func (o watchlistOptions) expired(now time.Time) bool {
+	return o.ExpiresAt != nil && !o.ExpiresAt.After(now)
+}
+
+func normalizeLegacyOptions(optsJSON string) string {
+	if optsJSON == "" {
+		return "{}"
+	}
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(optsJSON), &payload); err != nil {
+		return "{}"
+	}
+	normalized, err := json.Marshal(payload)
+	if err != nil {
+		return "{}"
+	}
+	return string(normalized)
+}
+
+func normalizeScopes(tags []string) []string {
+	if len(tags) == 0 {
+		return []string{""}
+	}
+	var scopes []string
+	seen := make(map[string]bool, len(tags))
+	for _, tag := range tags {
+		tag = strings.TrimSpace(tag)
+		if tag == "" || seen[tag] {
+			continue
+		}
+		seen[tag] = true
+		scopes = append(scopes, tag)
+	}
+	if len(scopes) == 0 {
+		return []string{""}
+	}
+	return scopes
+}
+
+func cloneTimePtr(src *time.Time) *time.Time {
+	if src == nil {
+		return nil
+	}
+	cp := *src
+	return &cp
 }
 
 func splitTags(s string) []string {
@@ -228,26 +475,4 @@ func splitTags(s string) []string {
 		}
 	}
 	return tags
-}
-
-func containsTag(tags []string, tag string) bool {
-	for _, t := range tags {
-		if t == tag {
-			return true
-		}
-	}
-	return false
-}
-
-func parseHistory(optsJSON string) []int {
-	if optsJSON == "" || optsJSON == "{}" {
-		return nil
-	}
-	var opts struct {
-		History []int `json:"history"`
-	}
-	if err := json.Unmarshal([]byte(optsJSON), &opts); err != nil {
-		return nil
-	}
-	return opts.History
 }

--- a/internal/awareness/watchlist_store_test.go
+++ b/internal/awareness/watchlist_store_test.go
@@ -2,7 +2,10 @@ package awareness
 
 import (
 	"database/sql"
+	"encoding/json"
+	"slices"
 	"testing"
+	"time"
 
 	_ "modernc.org/sqlite"
 )
@@ -104,5 +107,240 @@ func TestStore_RemoveNonExistent(t *testing.T) {
 	// Removing a non-existent entity should be a no-op.
 	if err := store.Remove("sensor.does_not_exist"); err != nil {
 		t.Fatalf("remove non-existent: %v", err)
+	}
+}
+
+func TestStore_AddWithOptionsScopedSubscriptions(t *testing.T) {
+	store := setupTestStore(t)
+
+	if err := store.AddWithOptions("sensor.battery", []string{"battery_focus", "interactive", "battery_focus"}, []int{600, 3600}, 300); err != nil {
+		t.Fatalf("AddWithOptions: %v", err)
+	}
+
+	ids, err := store.List()
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if !slices.Equal(ids, []string{"sensor.battery"}) {
+		t.Fatalf("List() = %v, want [sensor.battery]", ids)
+	}
+
+	untagged, err := store.ListUntagged()
+	if err != nil {
+		t.Fatalf("ListUntagged: %v", err)
+	}
+	if len(untagged) != 0 {
+		t.Fatalf("ListUntagged() = %v, want empty", untagged)
+	}
+
+	tags, err := store.DistinctTags()
+	if err != nil {
+		t.Fatalf("DistinctTags: %v", err)
+	}
+	if !slices.Equal(tags, []string{"battery_focus", "interactive"}) {
+		t.Fatalf("DistinctTags() = %v, want [battery_focus interactive]", tags)
+	}
+
+	batteryFocus, err := store.ListByTag("battery_focus")
+	if err != nil {
+		t.Fatalf("ListByTag(battery_focus): %v", err)
+	}
+	if len(batteryFocus) != 1 {
+		t.Fatalf("ListByTag(battery_focus) len = %d, want 1", len(batteryFocus))
+	}
+	if batteryFocus[0].Scope != "battery_focus" {
+		t.Fatalf("scope = %q, want battery_focus", batteryFocus[0].Scope)
+	}
+	if !slices.Equal(batteryFocus[0].History, []int{600, 3600}) {
+		t.Fatalf("history = %v, want [600 3600]", batteryFocus[0].History)
+	}
+	if batteryFocus[0].ExpiresAt == nil {
+		t.Fatal("expected expiration to be set")
+	}
+}
+
+func TestStore_RemoveWithScopesPreservesOtherSubscriptions(t *testing.T) {
+	store := setupTestStore(t)
+
+	if err := store.Add("sensor.battery"); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	if err := store.AddWithOptions("sensor.battery", []string{"battery_focus"}, nil, 0); err != nil {
+		t.Fatalf("AddWithOptions: %v", err)
+	}
+
+	if err := store.RemoveWithScopes("sensor.battery", []string{"battery_focus"}); err != nil {
+		t.Fatalf("RemoveWithScopes: %v", err)
+	}
+
+	untagged, err := store.ListUntagged()
+	if err != nil {
+		t.Fatalf("ListUntagged: %v", err)
+	}
+	if !slices.Equal(untagged, []string{"sensor.battery"}) {
+		t.Fatalf("ListUntagged() = %v, want [sensor.battery]", untagged)
+	}
+
+	scoped, err := store.ListByTag("battery_focus")
+	if err != nil {
+		t.Fatalf("ListByTag: %v", err)
+	}
+	if len(scoped) != 0 {
+		t.Fatalf("ListByTag(battery_focus) = %v, want empty", scoped)
+	}
+}
+
+func TestStore_ListSubscriptionsSkipsExpiredAndCleansUp(t *testing.T) {
+	store := setupTestStore(t)
+
+	wire := watchlistOptionsWire{
+		ExpiresAt: time.Now().UTC().Add(-time.Minute).Format(time.RFC3339),
+	}
+	optsJSON, err := json.Marshal(wire)
+	if err != nil {
+		t.Fatalf("marshal options: %v", err)
+	}
+
+	if _, err := store.db.Exec(
+		`INSERT INTO watched_entity_subscriptions (entity_id, scope, options) VALUES (?, ?, ?)`,
+		"sensor.expired_battery", "battery_focus", string(optsJSON),
+	); err != nil {
+		t.Fatalf("insert expired subscription: %v", err)
+	}
+
+	subs, err := store.ListSubscriptions("")
+	if err != nil {
+		t.Fatalf("ListSubscriptions: %v", err)
+	}
+	if len(subs) != 0 {
+		t.Fatalf("ListSubscriptions() = %v, want empty after cleanup", subs)
+	}
+
+	count, err := store.subscriptionCount()
+	if err != nil {
+		t.Fatalf("subscriptionCount: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("subscriptionCount() = %d, want 0 after cleanup", count)
+	}
+}
+
+func TestStore_MigratesLegacyRowsIntoScopedSubscriptions(t *testing.T) {
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+
+	_, err = db.Exec(`
+		CREATE TABLE watched_entities (
+			entity_id TEXT PRIMARY KEY,
+			added_at  TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+			tags      TEXT NOT NULL DEFAULT '',
+			options   TEXT NOT NULL DEFAULT '{}'
+		)
+	`)
+	if err != nil {
+		t.Fatalf("create legacy table: %v", err)
+	}
+	if _, err := db.Exec(
+		`INSERT INTO watched_entities (entity_id, tags, options) VALUES (?, ?, ?)`,
+		"sensor.battery", "battery_focus,interactive", `{"history":[600]}`,
+	); err != nil {
+		t.Fatalf("insert legacy row: %v", err)
+	}
+
+	store, err := NewWatchlistStore(db)
+	if err != nil {
+		t.Fatalf("new store: %v", err)
+	}
+
+	tags, err := store.DistinctTags()
+	if err != nil {
+		t.Fatalf("DistinctTags: %v", err)
+	}
+	if !slices.Equal(tags, []string{"battery_focus", "interactive"}) {
+		t.Fatalf("DistinctTags() = %v, want [battery_focus interactive]", tags)
+	}
+
+	subs, err := store.ListByTag("battery_focus")
+	if err != nil {
+		t.Fatalf("ListByTag: %v", err)
+	}
+	if len(subs) != 1 {
+		t.Fatalf("ListByTag(battery_focus) len = %d, want 1", len(subs))
+	}
+	if !slices.Equal(subs[0].History, []int{600}) {
+		t.Fatalf("history = %v, want [600]", subs[0].History)
+	}
+}
+
+func TestStore_MigratesLegacyRowsEvenWhenNormalizedRowsExist(t *testing.T) {
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+
+	_, err = db.Exec(`
+		CREATE TABLE watched_entities (
+			entity_id TEXT PRIMARY KEY,
+			added_at  TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+			tags      TEXT NOT NULL DEFAULT '',
+			options   TEXT NOT NULL DEFAULT '{}'
+		)
+	`)
+	if err != nil {
+		t.Fatalf("create legacy table: %v", err)
+	}
+
+	_, err = db.Exec(`
+		CREATE TABLE watched_entity_subscriptions (
+			entity_id TEXT NOT NULL,
+			scope     TEXT NOT NULL DEFAULT '',
+			added_at  TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+			options   TEXT NOT NULL DEFAULT '{}',
+			PRIMARY KEY (scope, entity_id)
+		)
+	`)
+	if err != nil {
+		t.Fatalf("create normalized table: %v", err)
+	}
+
+	if _, err := db.Exec(
+		`INSERT INTO watched_entity_subscriptions (entity_id, scope, options) VALUES (?, ?, ?)`,
+		"sensor.existing", "", `{}`,
+	); err != nil {
+		t.Fatalf("insert normalized row: %v", err)
+	}
+	if _, err := db.Exec(
+		`INSERT INTO watched_entities (entity_id, tags, options) VALUES (?, ?, ?)`,
+		"sensor.battery", "battery_focus", `{"history":[600]}`,
+	); err != nil {
+		t.Fatalf("insert legacy row: %v", err)
+	}
+
+	store, err := NewWatchlistStore(db)
+	if err != nil {
+		t.Fatalf("new store: %v", err)
+	}
+
+	ids, err := store.List()
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if !slices.Equal(ids, []string{"sensor.existing", "sensor.battery"}) {
+		t.Fatalf("List() = %v, want [sensor.existing sensor.battery]", ids)
+	}
+
+	subs, err := store.ListByTag("battery_focus")
+	if err != nil {
+		t.Fatalf("ListByTag: %v", err)
+	}
+	if len(subs) != 1 {
+		t.Fatalf("ListByTag(battery_focus) len = %d, want 1", len(subs))
+	}
+	if subs[0].EntityID != "sensor.battery" {
+		t.Fatalf("entity_id = %q, want sensor.battery", subs[0].EntityID)
 	}
 }

--- a/internal/homeassistant/client.go
+++ b/internal/homeassistant/client.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"net/url"
 	"time"
 
 	"github.com/nugget/thane-ai-agent/internal/httpkit"
@@ -138,6 +139,42 @@ func (c *Client) GetState(ctx context.Context, entityID string) (*State, error) 
 		return nil, err
 	}
 	return &state, nil
+}
+
+// GetStateHistory retrieves recorder-backed state history for one entity across
+// a time window. The result is sorted in Home Assistant's returned order, which
+// is typically chronological.
+func (c *Client) GetStateHistory(ctx context.Context, entityID string, startTime, endTime time.Time) ([]State, error) {
+	if entityID == "" {
+		return nil, nil
+	}
+
+	query := url.Values{}
+	query.Set("filter_entity_id", entityID)
+	query.Set("end_time", endTime.UTC().Format(time.RFC3339))
+	query.Set("no_attributes", "1")
+	query.Set("significant_changes_only", "0")
+
+	path := "/api/history/period/" + startTime.UTC().Format(time.RFC3339)
+	if encoded := query.Encode(); encoded != "" {
+		path += "?" + encoded
+	}
+
+	var payload [][]State
+	if err := c.get(ctx, path, &payload); err != nil {
+		return nil, err
+	}
+	if len(payload) == 0 {
+		return nil, nil
+	}
+
+	states := append([]State(nil), payload[0]...)
+	for i := range states {
+		if states[i].EntityID == "" {
+			states[i].EntityID = entityID
+		}
+	}
+	return states, nil
 }
 
 // CallService calls a Home Assistant service.

--- a/internal/homeassistant/client_history_test.go
+++ b/internal/homeassistant/client_history_test.go
@@ -1,0 +1,53 @@
+package homeassistant
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestClient_GetStateHistory(t *testing.T) {
+	var capturedPath string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedPath = r.URL.RequestURI()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[
+			[
+				{
+					"entity_id":"sensor.temp",
+					"state":"70.1",
+					"last_changed":"2025-01-15T10:00:00Z",
+					"last_updated":"2025-01-15T10:00:00Z"
+				},
+				{
+					"entity_id":"sensor.temp",
+					"state":"71.4",
+					"last_changed":"2025-01-15T11:00:00Z",
+					"last_updated":"2025-01-15T11:00:00Z"
+				}
+			]
+		]`))
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "token", nil)
+	start := time.Date(2025, 1, 15, 9, 0, 0, 0, time.UTC)
+	end := time.Date(2025, 1, 15, 12, 0, 0, 0, time.UTC)
+
+	states, err := client.GetStateHistory(context.Background(), "sensor.temp", start, end)
+	if err != nil {
+		t.Fatalf("GetStateHistory: %v", err)
+	}
+	if len(states) != 2 {
+		t.Fatalf("len(states) = %d, want 2", len(states))
+	}
+	if states[0].State != "70.1" || states[1].State != "71.4" {
+		t.Fatalf("states = %#v", states)
+	}
+	wantPath := "/api/history/period/2025-01-15T09:00:00Z?end_time=2025-01-15T12%3A00%3A00Z&filter_entity_id=sensor.temp&no_attributes=1&significant_changes_only=0"
+	if capturedPath != wantPath {
+		t.Fatalf("path = %q, want %q", capturedPath, wantPath)
+	}
+}

--- a/internal/toolcatalog/catalog.go
+++ b/internal/toolcatalog/catalog.go
@@ -355,6 +355,7 @@ var builtinToolSpecs = map[string]BuiltinToolSpec{
 	"web_fetch":                   {CanonicalID: "native:web_fetch", Source: NativeToolSource, DefaultTags: []string{"web"}},
 	"web_search":                  {CanonicalID: "native:web_search", Source: NativeToolSource, DefaultTags: []string{"web"}},
 	"add_context_entity":          {CanonicalID: "native:add_context_entity", Source: NativeToolSource, DefaultTags: []string{"awareness"}},
+	"list_context_entities":       {CanonicalID: "native:list_context_entities", Source: NativeToolSource, DefaultTags: []string{"awareness"}},
 	"remove_context_entity":       {CanonicalID: "native:remove_context_entity", Source: NativeToolSource, DefaultTags: []string{"awareness"}},
 }
 

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -47,28 +47,29 @@ type Tool struct {
 
 // Registry holds available tools.
 type Registry struct {
-	tools           map[string]*Tool
-	tagIndex        map[string][]string // tag → tool names
-	ha              *homeassistant.Client
-	scheduler       *scheduler.Scheduler
-	factTools       *knowledge.Tools
-	contactTools    *contacts.Tools
-	emailTools      *email.Tools
-	mqttSubTools    *mqtt.Tools
-	notifier        *notifications.Sender
-	notifRecords    *notifications.RecordStore
-	notifRouter     *notifications.NotificationRouter
-	notifDispatcher CallbackDispatcher
-	platformCaller  platformCallFunc
-	forgeTools      forgeHandler
-	fileTools       *FileTools
-	shellExec       *ShellExec
-	attachmentTools *attachments.Tools
-	watchlistStore  *awareness.WatchlistStore
-	tempFileStore   *TempFileStore
-	usageStore      *usage.Store
-	lensStore       *LensStore
-	logIndexDB      *sql.DB
+	tools                 map[string]*Tool
+	tagIndex              map[string][]string // tag → tool names
+	ha                    *homeassistant.Client
+	scheduler             *scheduler.Scheduler
+	factTools             *knowledge.Tools
+	contactTools          *contacts.Tools
+	emailTools            *email.Tools
+	mqttSubTools          *mqtt.Tools
+	notifier              *notifications.Sender
+	notifRecords          *notifications.RecordStore
+	notifRouter           *notifications.NotificationRouter
+	notifDispatcher       CallbackDispatcher
+	platformCaller        platformCallFunc
+	forgeTools            forgeHandler
+	fileTools             *FileTools
+	shellExec             *ShellExec
+	attachmentTools       *attachments.Tools
+	watchlistStore        *awareness.WatchlistStore
+	watchlistTagRegistrar func(string)
+	tempFileStore         *TempFileStore
+	usageStore            *usage.Store
+	lensStore             *LensStore
+	logIndexDB            *sql.DB
 
 	modelRegistry                              *models.Registry
 	modelRouter                                *routepkg.Router

--- a/internal/tools/watchlist_tools.go
+++ b/internal/tools/watchlist_tools.go
@@ -2,18 +2,26 @@ package tools
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"strings"
+	"time"
 
 	"github.com/nugget/thane-ai-agent/internal/awareness"
 )
 
-// SetWatchlistStore adds the add_context_entity and remove_context_entity
-// tools to the registry.
+// SetWatchlistStore adds the add_context_entity, list_context_entities, and
+// remove_context_entity tools to the registry.
 func (r *Registry) SetWatchlistStore(store *awareness.WatchlistStore) {
 	r.watchlistStore = store
 	r.registerWatchlistTools()
+}
+
+// OnWatchlistTagAdded configures a callback that is invoked whenever new
+// scoped entity subscriptions introduce tags that need live context providers.
+func (r *Registry) OnWatchlistTagAdded(fn func(tag string)) {
+	r.watchlistTagRegistrar = fn
 }
 
 func (r *Registry) registerWatchlistTools() {
@@ -27,7 +35,9 @@ func (r *Registry) registerWatchlistTools() {
 			"Watched entities have their live state injected into your context every turn, " +
 			"eliminating the need for repeated get_state calls. " +
 			"Rich domains (weather, climate, light, person) automatically include relevant attributes. " +
-			"Use tags to scope entity context to specific capabilities (only visible when that tag is active). " +
+			"Use tags to scope entity context to specific capabilities or loop-owned focus tags (only visible when that tag is active). " +
+			"Subscriptions are additive: the same entity can appear in multiple scoped contexts. " +
+			"Use ttl_seconds when the watch should expire automatically after a bounded task ends. " +
 			"Use history to include historical state snapshots at specific intervals.",
 		Parameters: map[string]any{
 			"type": "object",
@@ -44,7 +54,11 @@ func (r *Registry) registerWatchlistTools() {
 				"history": map[string]any{
 					"type":        "array",
 					"items":       map[string]any{"type": "integer"},
-					"description": "(Reserved) Historical snapshot offsets in seconds. Stored for future use — historical context injection is not yet implemented. E.g., [600, 3600, 86400] would include snapshots from 10min, 1hr, and 1day ago.",
+					"description": "Historical context windows in seconds. When set, watched-entity context includes a compact summary for each window. E.g., [600, 3600, 86400] adds recent summaries for 10min, 1hr, and 1day windows.",
+				},
+				"ttl_seconds": map[string]any{
+					"type":        "integer",
+					"description": "Optional expiration in seconds. After this TTL elapses, the subscription is automatically removed from future context injection.",
 				},
 			},
 			"required": []string{"entity_id"},
@@ -53,15 +67,40 @@ func (r *Registry) registerWatchlistTools() {
 	})
 
 	r.Register(&Tool{
+		Name:        "list_context_entities",
+		Description: "List watched entity subscriptions used for live context injection. Returns one row per subscription scope so you can inspect always-on entities, tag-scoped entities, TTLs, and stored history options before changing them.",
+		Parameters: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"tag": map[string]any{
+					"type":        "string",
+					"description": "Optional scope tag to filter by. Omit to list all active subscriptions.",
+				},
+				"entity_id": map[string]any{
+					"type":        "string",
+					"description": "Optional exact entity_id filter.",
+				},
+			},
+		},
+		Handler: r.handleListContextEntities,
+	})
+
+	r.Register(&Tool{
 		Name: "remove_context_entity",
 		Description: "Remove a Home Assistant entity from the watched list. " +
-			"The entity's state will no longer appear in your context each turn.",
+			"By default this removes every subscription for the entity. " +
+			"Use tags to remove only specific scoped subscriptions while leaving other loops or always-on contexts intact.",
 		Parameters: map[string]any{
 			"type": "object",
 			"properties": map[string]any{
 				"entity_id": map[string]any{
 					"type":        "string",
 					"description": "The Home Assistant entity ID to stop watching",
+				},
+				"tags": map[string]any{
+					"type":        "array",
+					"items":       map[string]any{"type": "string"},
+					"description": "Optional scope tags to remove. Omit to remove every subscription for this entity.",
 				},
 			},
 			"required": []string{"entity_id"},
@@ -76,51 +115,24 @@ func (r *Registry) handleAddContextEntity(_ context.Context, args map[string]any
 		return "", fmt.Errorf("entity_id is required")
 	}
 
-	var tags []string
-	if rawTags, ok := args["tags"].([]any); ok {
-		seen := make(map[string]bool)
-		for _, rt := range rawTags {
-			s, ok := rt.(string)
-			if !ok || s == "" {
-				continue
-			}
-			s = strings.TrimSpace(s)
-			if strings.Contains(s, ",") {
-				return "", fmt.Errorf("tag %q must not contain commas", s)
-			}
-			if !seen[s] {
-				seen[s] = true
-				tags = append(tags, s)
-			}
-		}
+	tags, err := parseTagArgs(args["tags"])
+	if err != nil {
+		return "", err
+	}
+	history, err := parseHistoryArg(args["history"])
+	if err != nil {
+		return "", err
+	}
+	ttlSeconds, err := intArg(args["ttl_seconds"], "ttl_seconds")
+	if err != nil {
+		return "", err
+	}
+	if ttlSeconds < 0 {
+		return "", fmt.Errorf("ttl_seconds must be >= 0")
 	}
 
-	var history []int
-	if rawHist, ok := args["history"].([]any); ok {
-		for i, rh := range rawHist {
-			switch v := rh.(type) {
-			case float64:
-				if v != float64(int(v)) {
-					return "", fmt.Errorf("history[%d]: must be a whole number of seconds, got %v", i, v)
-				}
-				iv := int(v)
-				if iv <= 0 {
-					return "", fmt.Errorf("history[%d]: must be positive, got %d", i, iv)
-				}
-				history = append(history, iv)
-			case int:
-				if v <= 0 {
-					return "", fmt.Errorf("history[%d]: must be positive, got %d", i, v)
-				}
-				history = append(history, v)
-			default:
-				return "", fmt.Errorf("history[%d]: expected integer seconds, got %T", i, rh)
-			}
-		}
-	}
-
-	if len(tags) > 0 || len(history) > 0 {
-		if err := r.watchlistStore.AddWithOptions(entityID, tags, history); err != nil {
+	if len(tags) > 0 || len(history) > 0 || ttlSeconds > 0 {
+		if err := r.watchlistStore.AddWithOptions(entityID, tags, history, ttlSeconds); err != nil {
 			return "", fmt.Errorf("add to watchlist: %w", err)
 		}
 	} else {
@@ -138,13 +150,59 @@ func (r *Registry) handleAddContextEntity(_ context.Context, args map[string]any
 		for i, h := range history {
 			parts[i] = fmt.Sprintf("%ds", h)
 		}
-		msg += fmt.Sprintf(" (history: %s ago, reserved)", strings.Join(parts, ", "))
+		msg += fmt.Sprintf(" (history windows: %s)", strings.Join(parts, ", "))
+	}
+	if ttlSeconds > 0 {
+		msg += fmt.Sprintf(" (expires in %ds)", ttlSeconds)
 	}
 	msg += "."
 
 	slog.Info("context entity added",
-		"entity_id", entityID, "tags", tags, "history", history)
+		"entity_id", entityID, "tags", tags, "history", history, "ttl_seconds", ttlSeconds)
+	if r.watchlistTagRegistrar != nil {
+		for _, tag := range tags {
+			r.watchlistTagRegistrar(tag)
+		}
+	}
 	return msg, nil
+}
+
+func (r *Registry) handleListContextEntities(_ context.Context, args map[string]any) (string, error) {
+	tag, _ := args["tag"].(string)
+	entityID, _ := args["entity_id"].(string)
+
+	subs, err := r.watchlistStore.ListSubscriptions(strings.TrimSpace(tag))
+	if err != nil {
+		return "", fmt.Errorf("list watchlist subscriptions: %w", err)
+	}
+
+	items := make([]map[string]any, 0, len(subs))
+	for _, sub := range subs {
+		if entityID != "" && sub.EntityID != entityID {
+			continue
+		}
+		item := map[string]any{
+			"entity_id":      sub.EntityID,
+			"scope":          sub.Scope,
+			"always_visible": sub.Scope == "",
+		}
+		if len(sub.History) > 0 {
+			item["history"] = append([]int(nil), sub.History...)
+		}
+		if sub.ExpiresAt != nil {
+			item["expires_at"] = sub.ExpiresAt.Format(time.RFC3339)
+		}
+		items = append(items, item)
+	}
+
+	payload, err := json.Marshal(map[string]any{
+		"count": len(items),
+		"items": items,
+	})
+	if err != nil {
+		return "", fmt.Errorf("marshal watchlist subscriptions: %w", err)
+	}
+	return string(payload), nil
 }
 
 func (r *Registry) handleRemoveContextEntity(_ context.Context, args map[string]any) (string, error) {
@@ -153,10 +211,95 @@ func (r *Registry) handleRemoveContextEntity(_ context.Context, args map[string]
 		return "", fmt.Errorf("entity_id is required")
 	}
 
-	if err := r.watchlistStore.Remove(entityID); err != nil {
+	tags, err := parseTagArgs(args["tags"])
+	if err != nil {
+		return "", err
+	}
+
+	if len(tags) > 0 {
+		err = r.watchlistStore.RemoveWithScopes(entityID, tags)
+	} else {
+		err = r.watchlistStore.Remove(entityID)
+	}
+	if err != nil {
 		return "", fmt.Errorf("remove from watchlist: %w", err)
 	}
 
-	slog.Info("context entity removed", "entity_id", entityID)
+	slog.Info("context entity removed", "entity_id", entityID, "tags", tags)
+	if len(tags) > 0 {
+		return fmt.Sprintf("Stopped watching %s in scopes %v.", entityID, tags), nil
+	}
 	return fmt.Sprintf("Stopped watching %s.", entityID), nil
+}
+
+func parseTagArgs(raw any) ([]string, error) {
+	rawTags, ok := raw.([]any)
+	if !ok {
+		return nil, nil
+	}
+	var tags []string
+	seen := make(map[string]bool)
+	for _, rt := range rawTags {
+		s, ok := rt.(string)
+		if !ok || s == "" {
+			continue
+		}
+		s = strings.TrimSpace(s)
+		if s == "" {
+			continue
+		}
+		if strings.Contains(s, ",") {
+			return nil, fmt.Errorf("tag %q must not contain commas", s)
+		}
+		if !seen[s] {
+			seen[s] = true
+			tags = append(tags, s)
+		}
+	}
+	return tags, nil
+}
+
+func parseHistoryArg(raw any) ([]int, error) {
+	rawHist, ok := raw.([]any)
+	if !ok {
+		return nil, nil
+	}
+	var history []int
+	for i, rh := range rawHist {
+		switch v := rh.(type) {
+		case float64:
+			if v != float64(int(v)) {
+				return nil, fmt.Errorf("history[%d]: must be a whole number of seconds, got %v", i, v)
+			}
+			iv := int(v)
+			if iv <= 0 {
+				return nil, fmt.Errorf("history[%d]: must be positive, got %d", i, iv)
+			}
+			history = append(history, iv)
+		case int:
+			if v <= 0 {
+				return nil, fmt.Errorf("history[%d]: must be positive, got %d", i, v)
+			}
+			history = append(history, v)
+		default:
+			return nil, fmt.Errorf("history[%d]: expected integer seconds, got %T", i, rh)
+		}
+	}
+	return history, nil
+}
+
+func intArg(raw any, field string) (int, error) {
+	switch v := raw.(type) {
+	case nil:
+		return 0, nil
+	case float64:
+		if v != float64(int(v)) {
+			return 0, fmt.Errorf("%s must be a whole number, got %v", field, v)
+		}
+		return int(v), nil
+	case int:
+		return v, nil
+	default:
+		return 0, fmt.Errorf("%s must be an integer, got %T", field, raw)
+	}
 }

--- a/internal/tools/watchlist_tools_test.go
+++ b/internal/tools/watchlist_tools_test.go
@@ -3,6 +3,8 @@ package tools
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
+	"slices"
 	"strings"
 	"testing"
 
@@ -33,6 +35,9 @@ func TestSetWatchlistStore_RegistersTools(t *testing.T) {
 
 	if r.Get("add_context_entity") == nil {
 		t.Error("add_context_entity should be registered")
+	}
+	if r.Get("list_context_entities") == nil {
+		t.Error("list_context_entities should be registered")
 	}
 	if r.Get("remove_context_entity") == nil {
 		t.Error("remove_context_entity should be registered")
@@ -77,6 +82,100 @@ func TestAddContextEntity_Success(t *testing.T) {
 	}
 }
 
+func TestAddContextEntity_WithScopesTTLAndHistory(t *testing.T) {
+	r, store := setupWatchlistRegistry(t)
+
+	var registered []string
+	r.OnWatchlistTagAdded(func(tag string) {
+		registered = append(registered, tag)
+	})
+
+	result, err := r.handleAddContextEntity(context.Background(), map[string]any{
+		"entity_id":   "sensor.battery",
+		"tags":        []any{"battery_focus", "battery_focus"},
+		"history":     []any{60, 3600},
+		"ttl_seconds": 120,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(result, "expires in 120s") {
+		t.Fatalf("result = %q, want TTL text", result)
+	}
+
+	if !slices.Equal(registered, []string{"battery_focus"}) {
+		t.Fatalf("registered tags = %v, want [battery_focus]", registered)
+	}
+
+	subs, err := store.ListByTag("battery_focus")
+	if err != nil {
+		t.Fatalf("ListByTag: %v", err)
+	}
+	if len(subs) != 1 {
+		t.Fatalf("ListByTag len = %d, want 1", len(subs))
+	}
+	if !slices.Equal(subs[0].History, []int{60, 3600}) {
+		t.Fatalf("history = %v, want [60 3600]", subs[0].History)
+	}
+	if subs[0].ExpiresAt == nil {
+		t.Fatal("expected subscription expiration")
+	}
+}
+
+func TestParseTagArgs_IgnoresWhitespaceOnlyTags(t *testing.T) {
+	tags, err := parseTagArgs([]any{"battery_focus", "   ", "\t", " interactive "})
+	if err != nil {
+		t.Fatalf("parseTagArgs: %v", err)
+	}
+
+	if !slices.Equal(tags, []string{"battery_focus", "interactive"}) {
+		t.Fatalf("parseTagArgs() = %v, want [battery_focus interactive]", tags)
+	}
+}
+
+func TestListContextEntities_ReturnsScopedSubscriptions(t *testing.T) {
+	r, store := setupWatchlistRegistry(t)
+
+	if err := store.Add("sensor.always_on"); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	if err := store.AddWithOptions("sensor.battery", []string{"battery_focus"}, []int{600}, 300); err != nil {
+		t.Fatalf("AddWithOptions: %v", err)
+	}
+
+	raw, err := r.handleListContextEntities(context.Background(), map[string]any{
+		"tag": "battery_focus",
+	})
+	if err != nil {
+		t.Fatalf("handleListContextEntities: %v", err)
+	}
+
+	var payload struct {
+		Count int `json:"count"`
+		Items []struct {
+			EntityID      string `json:"entity_id"`
+			Scope         string `json:"scope"`
+			AlwaysVisible bool   `json:"always_visible"`
+			ExpiresAt     string `json:"expires_at"`
+		} `json:"items"`
+	}
+	if err := json.Unmarshal([]byte(raw), &payload); err != nil {
+		t.Fatalf("unmarshal payload: %v", err)
+	}
+	if payload.Count != 1 {
+		t.Fatalf("count = %d, want 1", payload.Count)
+	}
+	if payload.Items[0].EntityID != "sensor.battery" || payload.Items[0].Scope != "battery_focus" {
+		t.Fatalf("item = %+v, want sensor.battery/battery_focus", payload.Items[0])
+	}
+	if payload.Items[0].AlwaysVisible {
+		t.Fatal("tagged subscription should not be always visible")
+	}
+	if payload.Items[0].ExpiresAt == "" {
+		t.Fatal("expected expires_at in payload")
+	}
+}
+
 func TestRemoveContextEntity_MissingEntityID(t *testing.T) {
 	r, _ := setupWatchlistRegistry(t)
 
@@ -114,5 +213,43 @@ func TestRemoveContextEntity_Success(t *testing.T) {
 	}
 	if len(ids) != 0 {
 		t.Errorf("store.List() = %v, want empty", ids)
+	}
+}
+
+func TestRemoveContextEntity_ScopedRemovalKeepsOtherSubscriptions(t *testing.T) {
+	r, store := setupWatchlistRegistry(t)
+
+	if err := store.Add("sensor.battery"); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	if err := store.AddWithOptions("sensor.battery", []string{"battery_focus"}, nil, 0); err != nil {
+		t.Fatalf("AddWithOptions: %v", err)
+	}
+
+	result, err := r.handleRemoveContextEntity(context.Background(), map[string]any{
+		"entity_id": "sensor.battery",
+		"tags":      []any{"battery_focus"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(result, "scopes [battery_focus]") {
+		t.Fatalf("result = %q, want scoped-removal text", result)
+	}
+
+	untagged, err := store.ListUntagged()
+	if err != nil {
+		t.Fatalf("ListUntagged: %v", err)
+	}
+	if !slices.Equal(untagged, []string{"sensor.battery"}) {
+		t.Fatalf("ListUntagged() = %v, want [sensor.battery]", untagged)
+	}
+
+	tagged, err := store.ListByTag("battery_focus")
+	if err != nil {
+		t.Fatalf("ListByTag: %v", err)
+	}
+	if len(tagged) != 0 {
+		t.Fatalf("ListByTag(battery_focus) = %v, want empty", tagged)
 	}
 }


### PR DESCRIPTION
## Summary
- replace single-row watchlist entries with additive scoped subscriptions keyed by `scope + entity_id`
- add scoped listing and removal plus `ttl_seconds` support for bounded monitoring tasks
- register new tag-scoped watchlist providers at runtime when fresh scoped subscriptions appear
- fetch recorder-backed entity history for configured `history` windows and merge compact summaries into watchlist context
- shape history summaries conservatively: numeric entities get trend/min/max/delta windows, while discrete entities get transition summaries
- migrate legacy `watched_entities` rows into the normalized subscription table
- add regression coverage for migration, scoped removal, TTL cleanup, the history client, and the tool surface

## Loop Ownership Model
Loop-specific watchlists ride on capability tags rather than a dedicated watchlist field on the loop definition. Orchestrator can create a loop with a task-specific tag in `profile.initial_tags` (or per-launch `initial_tags`), then subscribe entities against that same tag. That gives each loop its own curated context lane without adding another ownership model to the dynamic loop-definition table.

## Why
The remaining useful part of this older PR was scoped ownership for watched entities. Current `main` already has explicit wake paths (`mqtt_wake` and `notify_loop`), so this PR focuses on the watchlist subscription gap that was still missing and makes the existing `history` field do real work without turning the branch into a general analytics system.

## Out Of Scope
- new manual loop wake tooling
- declarative watchlist fields on loop definitions
- broad HA analytics or per-domain historical analysis frameworks beyond compact current/trend summaries

## Validation
- `just test`
- `just ci`