### PR TITLE
docs: overhaul agent instructions and add development process guardrails

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default reviewer for all files
+* @nugget

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,36 @@
+name: Bug Report
+description: Something isn't working as expected
+labels: ["bug"]
+body:
+  - type: textarea
+    id: observed
+    attributes:
+      label: Observed Behavior
+      description: What happened? Include error messages or logs if available.
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: What should have happened instead?
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: >
+        How did you encounter this? Steps to reproduce, relevant config,
+        or the situation that triggered it. Include code paths or file
+        references if known.
+    validations:
+      required: false
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: OS, Go version, Thane version, Ollama version, relevant model info.
+      placeholder: "macOS 15.4, Go 1.24.4, Thane v0.8.4, Ollama 0.6.x"
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,43 @@
+name: Feature Request
+description: Propose a new capability or enhancement
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or Opportunity
+      description: What's missing, limited, or could be better? Why does this matter?
+    validations:
+      required: true
+  - type: textarea
+    id: approach
+    attributes:
+      label: Proposed Approach
+      description: >
+        How should this work? Include design direction, relevant packages
+        or interfaces, and any architectural considerations.
+    validations:
+      required: false
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope and Non-Goals
+      description: >
+        What's in scope for this issue? Equally important: what's explicitly
+        out of scope? Non-goals prevent scope creep.
+    validations:
+      required: false
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance Criteria
+      description: How will we know this is done? Be specific.
+    validations:
+      required: false
+  - type: textarea
+    id: related
+    attributes:
+      label: Related Issues
+      description: "Link related issues with Refs #NNN."
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,17 @@
+## Summary
+
+<!-- What does this PR do and why? Keep it brief. -->
+
+## Test Plan
+
+- [ ] `just ci` passes locally
+- [ ] New/changed behavior has test coverage
+- [ ] Manual verification (describe what you checked):
+
+## Checklist
+
+- [ ] Commits are signed
+- [ ] Commit messages use conventional format (`feat:`, `fix:`, etc.)
+- [ ] Related issue referenced (`Refs #NNN` or `Closes #NNN`)
+- [ ] Documentation updated if user-facing behavior changed
+- [ ] No new third-party dependencies without discussion

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,41 +1,22 @@
 # Copilot Instructions for Thane
 
-## Project Overview
+For full project conventions, see [AGENTS.md](../AGENTS.md).
 
-Go AI agent for Home Assistant. Module: `github.com/nugget/thane-ai-agent`.
-Single binary (`cmd/thane/main.go`) with modular internal packages.
+## Build Notes
 
-## Build & Test
-
-- Always use `just ci` (runs fmt, lint, vet, test with -race)
-- Build requires `-tags "sqlite_fts5"` (handled by justfile)
-- Cross-compile targets: `darwin/arm64`, `darwin/amd64`, `linux/arm64`, `linux/amd64`
-- Never call `gofmt`, `go vet`, `go test` directly — use justfile recipes
-
-## Conventions
-
-- All exported types and functions must have godoc comments
-- All HTTP clients must use `httpkit.NewClient()` / `httpkit.NewTransport()` — never construct `http.Client{}` directly
-- Log levels: INFO = operator story, DEBUG = deep troubleshooting, WARN = degraded, ERROR = broken
-- Internal prompts (LLM instruction text) live in `internal/prompts/`, not inline
-- Tool result sizes must be capped (search: 16KB, transcript: 32KB)
-- Config defaults go in `applyDefaults()`, not struct tags
-- Use `errors.Is()` for sentinel error checks, not `==`
-
-## Architecture
-
-- `internal/agent/loop.go` — core conversation engine
-- `internal/router/` — model selection (urgency × quality matrix)
-- `internal/memory/` — conversation store, archive, compaction, extraction
-- `internal/tools/` — tool registry and implementations
-- `internal/prompts/` — all LLM prompt templates
-- `internal/config/` — YAML config with validation
-- `cmd/thane/main.go` — wiring only, no business logic
+- Build requires `-tags "sqlite_fts5"` (handled by the justfile)
+- Cross-compile targets: `darwin/arm64`, `darwin/amd64`, `linux/arm64`,
+  `linux/amd64`
+- Never call `gofmt`, `go vet`, `go test` directly — use `just` recipes
 
 ## Review Focus
 
-- Watch for unbounded data returns from tools
-- Flag any inline LLM prompt text outside `internal/prompts/`
-- Verify `sql.ErrNoRows` is handled distinctly from other DB errors
+When reviewing or generating code, watch for:
+
+- Unbounded data returns from tools (search: 16 KB cap, transcripts: 32 KB)
+- Inline LLM prompt text outside `internal/prompts/`
+- `sql.ErrNoRows` must be handled distinctly from other DB errors
 - Async goroutines must have context timeouts
-- No `os.Exit` outside main()
+- No `os.Exit` outside `main()`
+- Config defaults go in `applyDefaults()`, not struct tags
+- Use `errors.Is()` for sentinel error checks, not `==`

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,14 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
-
 version: 2
 updates:
-  - package-ecosystem: "" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: gomod
+    directory: /
     schedule:
-      interval: "weekly"
+      interval: weekly
+    commit-message:
+      prefix: "chore"
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: "chore"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,10 +1,22 @@
 # AGENTS.md
 
-Instructions for AI coding agents working on the Thane codebase.
+Welcome. Thane is an autonomous AI agent written in Go that connects
+language models to Home Assistant, turning thousands of real-time sensor
+readings into coherent environmental awareness. It runs on local models
+via Ollama, optionally augmented by cloud models for complex reasoning.
+Single binary, SQLite storage, no runtime dependencies.
+
+If you're here to understand the project, start with
+[docs/understanding/philosophy.md](docs/understanding/philosophy.md).
+For the full documentation suite, see [docs/](docs/).
+
+Everything below is what you need to contribute code.
 
 ## Build & Test
 
-All workflows go through [just](https://just.systems/). Don't call `go` tools directly.
+All workflows go through [just](https://just.systems/). Never call `go`
+tools directly — the justfile handles build tags, cross-compilation, code
+signing, and version injection.
 
 ```bash
 just build              # Build for current platform → dist/
@@ -14,85 +26,152 @@ just lint               # golangci-lint v2
 just fmt-check          # gofmt check
 ```
 
-`just ci` must pass before pushing. No exceptions.
-
-## Project Structure
-
-```
-cmd/thane/              Main binary (CLI, server setup, wiring)
-internal/
-  agent/                Agent loop (context assembly → planning → tool execution → response)
-  api/                  HTTP API server (OpenAI-compatible + Ollama-compatible)
-  httpkit/              Centralized HTTP client construction (all outbound HTTP goes through here)
-  homeassistant/        HA REST + WebSocket client
-  llm/                  LLM providers (Anthropic, Ollama) and model routing
-  search/               Web search providers (SearXNG, Brave) with pluggable interface
-  fetch/                Web page content extraction
-  memory/               Conversation storage and compaction (SQLite)
-  facts/                Semantic fact store with embeddings
-  checkpoint/           State snapshot and restore
-  embeddings/           Embedding generation via Ollama
-  tools/                Tool registry and implementations (HA, shell, files, search, fetch)
-  config/               Configuration loading and validation
-  talents/              Markdown-based agent behavior guidance
-  web/                  Built-in web chat UI
-  buildinfo/            Version injection via ldflags
-  router/               Model selection routing
-  scheduler/            Time-based task scheduling
-  ingest/               Markdown document ingestion
-```
+`just ci` must pass locally before every push. No exceptions. Don't rely
+on GitHub Actions to catch what you could have caught locally.
 
 ## Code Conventions
 
-- **Go 1.24+** required
-- **Conventional commits**: `feat:`, `fix:`, `docs:`, `refactor:`, `test:`, `chore:`
-- **Model-facing changes**: If you are changing tool implementations, tool outputs, tool schemas, tool descriptions, or any context emitted for later model consumption, read [`docs/model-facing-context.md`](docs/model-facing-context.md) and [`docs/model-facing-tools.md`](docs/model-facing-tools.md) first. Apply those conventions while doing the work; do not treat them as a later cleanup pass.
-- **All HTTP clients** must use `httpkit.NewClient()` / `httpkit.NewTransport()` — never construct `http.Client{}` directly
-- **Prefer the standard library**. Third-party module imports are expensive — they add supply chain risk, version churn, and transitive dependencies. If `net/http`, `encoding/json`, `crypto/tls`, or another stdlib package can do the job, use it. Only reach for an external module when the stdlib genuinely can't.
-- **Contract structs**: Any exported request/response/spec/config struct, or any other struct that defines a stable cross-package, model-facing, API-facing, or persistence-facing contract, should carry explicit well-known serialization tags. Use `json` tags by default, add `yaml` tags when the type is config- or file-facing, prefer stable `snake_case` names, and mark runtime-only fields with `json:"-"` / `yaml:"-"` as appropriate.
-- **GoDoc-first data models**: Write contract structs so their external shape is obvious in GoDoc. Keep field names, tags, ordering, and comments intentional enough that readers do not have to infer the serialized form from Go casing rules or implementation details.
-- **Error handling**: Always drain response bodies (`httpkit.DrainAndClose`), bound error reads (`httpkit.ReadErrorBody`)
-- **Tests**: Table-driven where possible, always with `-race`
-- **Logging**: Structured via `slog`. Include relevant context fields (method, URL, entity_id, etc.)
-- **Tool registration**: Use `tools.Register()` with JSON schema parameters
-- **Provider pattern**: New integrations implement a provider interface (see `search.Provider`)
+- **Go 1.24+** required. Build requires `-tags "sqlite_fts5"` (the
+  justfile handles this).
+- **Conventional commits**: `feat:`, `fix:`, `docs:`, `refactor:`,
+  `test:`, `chore:`.
+- **All HTTP clients** must use `httpkit.NewClient()` /
+  `httpkit.NewTransport()` — never construct `http.Client{}` directly.
+  httpkit is the single source of truth for outbound HTTP: retry
+  transport, User-Agent injection, connection pool management.
+- **Prefer the standard library**. Third-party imports add supply chain
+  risk, version churn, and transitive deps. Use stdlib when it can do the
+  job.
+- **Context propagation**: Always pass the caller's `ctx` through to
+  downstream calls. Never use `context.Background()` inside a handler
+  that receives `ctx` — it breaks cancellation and deadline enforcement.
+- **Error handling**: Always drain response bodies
+  (`httpkit.DrainAndClose`), bound error reads
+  (`httpkit.ReadErrorBody`).
+- **Timestamp parsing**: Use `database.ParseTimestamp()` for SQLite TEXT
+  columns. Never raw `time.Parse` for stored timestamps.
+- **Timestamps in model context**: Any timestamp shown to the model must
+  use exact-second deltas (`-120s`, `+3600s`) via
+  `awareness.FormatDeltaOnly()`. Models are poor at timestamp arithmetic.
+  Storage and logs keep absolute timestamps.
+- **String truncation**: Never truncate by byte index (`s[:n]`) — use
+  `[]rune` or `truncateUTF8` in `internal/tools` to avoid splitting
+  multi-byte characters.
+- **Contract structs**: Exported structs that define cross-package,
+  model-facing, API-facing, or persistence-facing contracts need explicit
+  serialization tags (`json`, `yaml` where config-facing, `snake_case`
+  names, `-` for runtime-only fields).
+- **Model-facing changes**: If touching tool implementations, schemas,
+  descriptions, or any context consumed by models, read
+  [docs/model-facing-context.md](docs/model-facing-context.md) and
+  [docs/model-facing-tools.md](docs/model-facing-tools.md) first. Apply
+  those conventions during the work, not as a cleanup pass.
+- **Tests**: Table-driven where possible, always with `-race`.
+- **Logging**: Structured via `slog`. INFO = operator story, DEBUG = deep
+  troubleshooting, WARN = degraded, ERROR = broken. Include relevant
+  context fields.
+- **Tool result sizes**: Cap output (search: 16 KB, transcripts: 32 KB).
+  Watch for unbounded data returns.
+- **Config defaults**: Set in `applyDefaults()`, not struct tags.
+- **Go doc comments**: Every exported symbol gets a doc comment starting
+  with its name. Every package gets `// Package foo ...`.
+- **Provider pattern**: New integrations implement a provider interface
+  (see `search.Provider`).
 
-## Architecture Notes
+## Architecture at a Glance
 
-- **Dual-port**: Port 8080 (native OpenAI API) + port 11434 (Ollama-compatible for HA)
-- **Agent loop**: Iterates up to 10 times per request. Each iteration: LLM call → tool execution → repeat or respond. On exhaustion, makes a final `tools=nil` call to force a text response.
-- **httpkit**: Single source of truth for outbound HTTP. Includes retry transport for transient errors, User-Agent injection, and connection pool management. All 7 HTTP client packages route through it.
-- **Model routing**: Selects between local (Ollama) and cloud (Anthropic) models based on task complexity.
-- **Checkpoint/restore**: Conversations survive restarts via SQLite-backed state snapshots.
+- **Dual-port**: Port 8080 (native OpenAI-compatible API + web dashboard)
+  and port 11434 (Ollama-compatible API for HA integration).
+- **Agent loop**: Iterates up to 10 times per request. Each iteration:
+  LLM call, tool execution, repeat or respond. On exhaustion, a final
+  `tools=nil` call forces a text response.
+- **Delegation**: Orchestrator model plans; small local models execute
+  tool-heavy work at zero API cost.
+- **Model routing**: Scores models on quality, speed, and cost. Routing
+  hints (quality floor, speed preference, local-only) propagate through
+  delegation.
+- **Capability tags**: Tools and talents grouped by semantic tags. Sessions
+  start minimal; tags activate on demand, creating delegation pressure by
+  architecture.
+- **Memory**: SQLite-backed semantic facts with embeddings, conversation
+  history with compaction, session archives with FTS5 search.
+- **connwatch**: Background health monitoring for external services (HA,
+  Ollama, email) with exponential backoff reconnection.
+- **Checkpoint/restore**: Conversations survive restarts via SQLite state
+  snapshots.
 
-## Things to Watch For
+See [docs/understanding/architecture.md](docs/understanding/architecture.md)
+for the full picture.
 
-- **macOS Local Network Privacy**: launchd-launched binaries need explicit permission to access LAN hosts (System Settings → Privacy & Security → Local Network). Internet targets work without it. This was a tricky diagnosis (issue #53).
-- **Branch protection**: `main` requires PRs with verified signatures. No direct pushes.
-- **Version injection**: Uses build-time `ldflags`, not hardcoded strings. The justfile handles this.
-- **Config discovery**: Auto-searches `./config.yaml`, `~/Thane/config.yaml`, `~/.config/thane/config.yaml`, and system paths.
-- **Pre-existing test**: `TestFindConfig_SearchPath` may find a real config file if `~/Thane/config.yaml` exists on the build host.
+## Gotchas
 
-## Security Considerations
+- **macOS Local Network Privacy**: launchd-launched binaries need explicit
+  Local Network permission to reach LAN hosts like HA
+  ([issue #53](https://github.com/nugget/thane-ai-agent/issues/53)).
+- **Branch protection**: `main` requires PRs with verified commit
+  signatures. No direct pushes.
+- **Version injection**: Build-time `ldflags`, not hardcoded. The justfile
+  handles this.
+- **Config discovery**: Auto-searches `./config.yaml`,
+  `~/Thane/config.yaml`, `~/.config/thane/config.yaml`, and system paths.
+- **Pre-existing test**: `TestFindConfig_SearchPath` may find a real
+  config if `~/Thane/config.yaml` exists on the build host.
+- **macOS code signing**: The justfile ad-hoc signs macOS builds. No
+  Gatekeeper quarantine during development.
 
-- **Shell exec** is gated by config (`shell_exec.enabled`) with denied patterns and optional allowed prefixes
-- **File tools** are sandboxed to the configured workspace directory
-- **HA tokens** and **API keys** live in `config.yaml` — keep it `chmod 600`
-- **httpkit** never disables TLS verification by default (`WithTLSInsecureSkipVerify` is opt-in)
+## Security
 
-## GitHub Collaboration
+- **Shell exec** gated by config with denied patterns and allowed prefixes
+- **File tools** sandboxed to the configured workspace directory
+- **Tokens and API keys** in `config.yaml` — keep it `chmod 600`
+- **httpkit** never disables TLS verification by default
 
-Leave pull requests as clean and reflective of reality as you can. Open
-review threads, stale PR descriptions, and unchecked test-plan items all
-signal unfinished work to the next reader.
+## Contributing
 
-**When addressing review feedback:**
-1. Fix the issue in a commit
-2. Reply to the thread with the fixing commit hash and a one-line explanation
-3. Resolve the conversation
-4. If a comment is intentionally deferred (out of scope, follow-up issue), say so explicitly before resolving — don't silently close without context
+### Issues
 
-**PR hygiene:**
-- Keep the PR description accurate as scope changes
-- Check off test plan items as they are verified
-- Leave unresolved only the threads that still need real work or a decision
+Use the issue templates when filing bugs or feature requests. Good issues
+include: what's happening (or what should happen), why it matters, and
+concrete acceptance criteria. Link related issues with `Refs #NNN`.
+
+### Pull Requests
+
+- **All commits must be signed.** Configure your signing key before your
+  first commit. PRs with unsigned commits will not merge.
+- Run `just ci` locally before pushing.
+- Keep PRs focused — one logical change per PR.
+- Use conventional commit format for PR titles and commits.
+- Reference issues: `Refs #NNN` or `Closes #NNN` in commit bodies.
+- The PR template will guide you through the description and test plan.
+
+### Common Review Feedback
+
+These are the patterns that most often come up in review. Getting them
+right on the first pass saves everyone a round trip:
+
+- **Context propagation** — Don't use `context.Background()` where a `ctx`
+  is available. Goroutines need context timeouts.
+- **Unbounded data** — Tool results must be capped. Don't return full
+  entity lists or raw transcripts without size limits.
+- **Model-facing changes** — Read the model-facing docs before touching
+  tool schemas or prompt content. This is not optional.
+- **Race conditions** — Shared state needs mutex guards. Tests run with
+  `-race`; they will catch you.
+- **Silent failures** — If something can fail, log it. Debug-level is fine,
+  but silent drops waste debugging time later.
+
+### Review Culture
+
+Leave PRs clean and reflective of reality. Open review threads, stale
+descriptions, and unchecked test-plan items signal unfinished work.
+
+When addressing review feedback: fix the issue, reply to the thread with
+the commit hash and a one-line explanation, then resolve the conversation.
+If deferring, say why before resolving.
+
+## Further Reading
+
+- [docs/](docs/) — Full documentation index
+- [docs/understanding/philosophy.md](docs/understanding/philosophy.md) — Why Thane exists
+- [docs/understanding/architecture.md](docs/understanding/architecture.md) — System design
+- [CONTRIBUTING.md](CONTRIBUTING.md) — Development setup and workflow

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,135 +1,49 @@
 # CLAUDE.md
 
-Instructions for Claude Code working on the Thane codebase.
+For project conventions, build commands, architecture, and contribution
+guidelines, see [AGENTS.md](AGENTS.md). Everything below is specific to
+the Claude Code operator experience on this repo.
 
-## Build & Test
+## Commit Signing
 
-All workflows go through [just](https://just.systems/). Never call `go` tools directly.
+The SessionStart hook configures repo-local signing automatically each
+session using Claude's dedicated key (see `~/.claude/CLAUDE.md` for
+identity details). Verify signing is active before your first commit:
 
 ```bash
-just build              # Build for current platform → dist/
-just ci                 # Full CI gate: fmt check + lint + test (run before every push)
-just test               # Tests only (always with -race)
-just lint               # golangci-lint v2
-just fmt-check          # gofmt check
+git config commit.gpgsign   # should return true
 ```
 
-**MANDATORY: `just ci` must pass locally before every `git push`. No exceptions.** Do not rely on GitHub Actions to catch lint or test failures — run the full gate locally first and fix any issues before pushing.
+## CI Gate
 
-## Project Structure
+**MANDATORY: `just ci` must pass locally before every `git push`. No
+exceptions.** Do not rely on GitHub Actions — run the full gate locally
+first and fix any issues before pushing. This is a hard requirement.
 
-```
-cmd/thane/              Main binary (CLI, server setup, wiring)
-internal/
-  agent/                Agent loop (context assembly → planning → tool execution → response)
-  awareness/            System prompt context providers (conditions, state window, watchlist)
-  buildinfo/            Version injection via ldflags
-  channels/
-    email/              Email messaging (IMAP/SMTP)
-    mqtt/               MQTT for HA device discovery and sensors
-    signal/             Signal messaging bridge
-  carddav/              CardDAV server for native contact app sync
-  checkpoint/           State snapshot and restore
-  config/               Configuration loading and validation
-  connwatch/            Service health monitoring with exponential backoff
-  contacts/             Contact directory and presence tracking
-  database/             SQLite helpers
-  delegate/             Delegate task execution
-  events/               In-process event bus
-  forge/                GitHub/Forgejo integration
-  homeassistant/        HA REST + WebSocket client
-  httpkit/              Centralized HTTP client construction (all outbound HTTP goes through here)
-  knowledge/            Semantic fact store, embeddings, and document ingestion
-  llm/                  LLM providers (Anthropic, Ollama) and model routing
-  mcp/                  MCP client and tool bridge
-  media/                Media transcript extraction and RSS/Atom feed polling
-  memory/               Conversation storage, compaction, episodic memory, session summarizer
-  metacognitive/        Autonomous self-reflection loop
-  notifications/        Provider-agnostic notification delivery and HITL callbacks
-  opstate/              Operational state KV store
-  paths/                Path resolution
-  prompts/              Prompt templates
-  router/               Model selection routing
-  scheduler/            Time-based task scheduling
-  search/               Web search providers and page content extraction
-  server/
-    api/                HTTP API server (OpenAI-compatible + Ollama-compatible)
-    web/                Built-in web dashboard and chat UI
-  talents/              Markdown-based agent behavior guidance
-  tools/                Tool registry and implementations
-  unifi/                UniFi network integration
-  usage/                Token usage and cost tracking
-```
+## Model-Facing Work
 
-## Code Conventions
+When touching tool implementations, tool outputs, schemas, descriptions,
+or any context consumed by model loops, read these first and apply their
+conventions during the work:
 
-- **Go 1.24+** required
-- **Conventional commits**: `feat:`, `fix:`, `docs:`, `refactor:`, `test:`, `chore:`
-- **Model-facing changes**: If you are changing tool implementations, tool outputs, tool schemas, tool descriptions, or any context emitted for later model consumption, read [`docs/model-facing-context.md`](docs/model-facing-context.md) and [`docs/model-facing-tools.md`](docs/model-facing-tools.md) first. Apply those conventions while doing the work; do not treat them as a later cleanup pass.
-- **All HTTP clients** must use `httpkit.NewClient()` / `httpkit.NewTransport()` — never construct `http.Client{}` directly
-- **Prefer the standard library**. Third-party module imports are expensive — they add supply chain risk, version churn, and transitive dependencies. If `net/http`, `encoding/json`, `crypto/tls`, or another stdlib package can do the job, use it. Only reach for an external module when the stdlib genuinely can't.
-- **Contract structs**: Any exported request/response/spec/config struct, or any other struct that defines a stable cross-package, model-facing, API-facing, or persistence-facing contract, should carry explicit well-known serialization tags. Use `json` tags by default, add `yaml` tags when the type is config- or file-facing, prefer stable `snake_case` names, and mark runtime-only fields with `json:"-"` / `yaml:"-"` as appropriate.
-- **GoDoc-first data models**: Write contract structs so their external shape is obvious in GoDoc. Keep field names, tags, ordering, and comments intentional enough that readers do not have to infer the serialized form from Go casing rules or implementation details.
-- **Context propagation**: Always pass the caller's `ctx` through to downstream calls (HTTP requests, subprocess exec, HA client methods). Never use `context.Background()` inside a handler that receives `ctx` — it breaks cancellation and deadline enforcement. Use `exec.CommandContext(ctx, ...)` for subprocesses.
-- **Error handling**: Always drain response bodies (`httpkit.DrainAndClose`), bound error reads (`httpkit.ReadErrorBody`)
-- **Timestamp parsing**: Use `database.ParseTimestamp()` when reading timestamps from SQLite TEXT columns — it accepts RFC3339, RFC3339Nano, and SQLite's space-separated format. Never use raw `time.Parse` for stored timestamps.
-- **Timestamps in model context** (issue #458): Any timestamp shown to the model in system prompts, tool results, or context providers must use exact-second deltas (`-120s`, `+3600s`) via `awareness.FormatDeltaOnly()` or `awareness.FormatDelta()`. Models are poor at timestamp arithmetic — deltas remove the cognitive load. Storage and logs keep absolute timestamps; only model-facing output uses deltas.
-- **String truncation**: Never truncate strings by byte index (`s[:n]`) — this can split multi-byte UTF-8 characters. Use `[]rune` conversion or the `truncateUTF8` helper in `internal/tools` which backs up to a valid rune boundary.
-- **Go doc comments**: Every exported symbol (function, type, const, var) must have a doc comment that starts with the symbol name and reads as a complete sentence. Every package must have a `// Package foo ...` comment. Follow the [Go Doc Comments](https://go.dev/doc/comment) conventions. Run `go doc ./internal/yourpkg` to verify rendering.
-- **Tests**: Table-driven where possible, always with `-race`
-- **Logging**: Structured via `slog`. Include relevant context fields (method, URL, entity_id, etc.)
-- **Tool registration**: Use `tools.Register()` with JSON schema parameters
-- **Provider pattern**: New integrations implement a provider interface (see `search.Provider`)
-
-## Architecture Notes
-
-- **Dual-port**: Port 8080 (native OpenAI API) + port 11434 (Ollama-compatible for HA)
-- **Agent loop**: Iterates up to 10 times per request. Each iteration: LLM call → tool execution → repeat or respond. On exhaustion, makes a final `tools=nil` call to force a text response.
-- **httpkit**: Single source of truth for outbound HTTP. Includes retry transport for transient errors, User-Agent injection, and connection pool management. All HTTP client packages route through it.
-- **Model routing**: Selects between local (Ollama) and cloud (Anthropic) models based on task complexity.
-- **Checkpoint/restore**: Conversations survive restarts via SQLite-backed state snapshots.
-- **connwatch**: Background health monitoring for external services (HA, Ollama) with exponential backoff reconnection.
-
-## Things to Watch For
-
-- **macOS Local Network Privacy**: launchd-launched binaries need explicit permission to access LAN hosts (System Settings → Privacy & Security → Local Network). Internet targets work without it. This was a tricky diagnosis (issue #53).
-- **Branch protection**: `main` requires PRs with verified signatures. No direct pushes.
-- **Version injection**: Uses build-time `ldflags`, not hardcoded strings. The justfile handles this.
-- **Config discovery**: Auto-searches `./config.yaml`, `~/Thane/config.yaml`, `~/.config/thane/config.yaml`, and system paths.
-- **Pre-existing test**: `TestFindConfig_SearchPath` may find a real config file if `~/Thane/config.yaml` exists on the build host.
-- **macOS code signing**: The justfile ad-hoc signs (`codesign -s -`) macOS builds so Gatekeeper doesn't quarantine rebuilt binaries. Distribution builds would need Developer ID signing + notarization.
-
-## Security Considerations
-
-- **Shell exec** is gated by config (`shell_exec.enabled`) with denied patterns and optional allowed prefixes
-- **File tools** are sandboxed to the configured workspace directory
-- **HA tokens** and **API keys** live in `config.yaml` — keep it `chmod 600`
-- **httpkit** never disables TLS verification by default (`WithTLSInsecureSkipVerify` is opt-in)
-
-## Workflow Notes
-
-- The repository uses GitHub with SSH remotes (`git@github.com:nugget/thane-ai-agent.git`)
-- **All commits must be signed.** The SessionStart hook configures repo-local signing automatically each session (see `~/.claude/CLAUDE.md` for identity details). Verify signing is active before your first commit: `git config commit.gpgsign` should return `true`.
-- PRs require review before merge to `main`
-- **Always run `just ci` before pushing** — it catches formatting, lint, and race conditions. This is a hard requirement, not a suggestion.
-- Keep PRs focused: one feature or fix per PR
+- [docs/model-facing-context.md](docs/model-facing-context.md)
+- [docs/model-facing-tools.md](docs/model-facing-tools.md)
 
 ## GitHub Collaboration
 
-Be a good GitHub collaborator. Review threads left open signal to the next reader that work is unfinished — always close the loop.
-Leave pull requests as clean and reflective of reality as you can.
-Stale descriptions, dangling threads, and outdated test-plan checklists
-create confusion for whoever picks the work up next.
+Be a good GitHub collaborator. Review threads left open signal unfinished
+work — always close the loop. Leave PRs clean and reflective of reality.
 
 **When addressing review feedback:**
 1. Fix the issue in a commit
-2. Reply to the thread with the fixing commit hash and a one-line explanation
+2. Reply to the thread with the fixing commit hash and a one-line
+   explanation
 3. Resolve the conversation
-4. If a comment is intentionally deferred (out of scope, follow-up issue), say so explicitly before resolving — don't silently close without context
+4. If deferring (out of scope, follow-up issue), say so explicitly before
+   resolving
 
-**After a round of fixes:** Request re-review so the reviewer knows the ball is back in their court.
-
-**When deferring feedback:** Post a reply explaining *why* it's deferred (e.g. "would require coupling X to Y, creating an import cycle — filing as follow-up") before resolving. A resolved thread with no reply looks like the comment was missed.
+**After a round of fixes:** Request re-review so the reviewer knows the
+ball is back in their court.
 
 **Resolving threads via CLI:**
 ```bash
@@ -137,6 +51,6 @@ gh api graphql -f query='mutation { resolveReviewThread(input: {threadId: "THREA
 ```
 
 **PR hygiene:**
-- Check off test plan items in the PR description as they are verified
-- Use `Refs #NNN` or `Closes #NNN` in commit message bodies when a commit relates to or closes an issue
-- Keep PR description tables accurate — if the scope changes during the PR, update the description
+- Check off test plan items as they are verified
+- Use `Refs #NNN` or `Closes #NNN` in commit bodies
+- Keep the PR description accurate as scope evolves


### PR DESCRIPTION
## Summary

- **AGENTS.md** rewritten as the welcoming front door for AI agents — opens with what Thane is, covers build/conventions/architecture/gotchas/contributing. Single source of truth for all agent tools. Removes stale project structure (referenced packages like `api/`, `fetch/`, `facts/`, `embeddings/`, `ingest/` that no longer exist).
- **CLAUDE.md** slimmed from 143 to ~55 lines — contains only Claude Code-specific concerns (signing hook, CI gate emphasis, GitHub collaboration workflow). References AGENTS.md for everything shared.
- **copilot-instructions.md** slimmed similarly — references AGENTS.md, keeps only Copilot-specific review focus and build notes.
- **Issue templates** added: bug report and feature request with structured fields (observed/expected, scope/non-goals, acceptance criteria)
- **PR template** added: summary, test plan checklist, contribution checklist
- **CODEOWNERS** added: @nugget as default reviewer
- **Dependabot** fixed: was an empty template, now configured for Go modules and GitHub Actions weekly

### Context from PR/issue corpus analysis

Analyzed 670 issues and 282+ PRs. Key findings that informed this work:
- 35% of recent issues have zero labels, no issue templates existed
- Common review friction: context misuse, race conditions, unbounded tool returns, model-facing context creep
- AGENTS.md was stale (referenced 7 packages that don't exist, missed 20+ that do)
- 70% content overlap between AGENTS.md and CLAUDE.md, drifting apart

## Test plan

- [ ] AGENTS.md is self-sufficient — an agent reading only it has what it needs to contribute
- [ ] CLAUDE.md references AGENTS.md, contains no duplicated content
- [ ] Issue templates render in GitHub's "New Issue" UI
- [ ] PR template renders when opening a new PR
- [ ] CODEOWNERS syntax valid (@nugget assigned on all files)
- [ ] Dependabot config valid (Go modules + GitHub Actions)
- [ ] `just ci` passes (docs-only change)