### PR TITLE
Remove macOS Local Network permission note

### DIFF
--- a/docs/operating/homeassistant.md
+++ b/docs/operating/homeassistant.md
@@ -132,11 +132,3 @@ particularly useful:
 - **`thane:trigger`** — Cheapest option for HA automations calling Thane
 - **`thane:ops`** — Direct tool access when you need the primary model to
   see HA state firsthand
-
-## macOS Note
-
-If running Thane as a launchd service on macOS, you must grant **Local
-Network** permission in System Settings > Privacy & Security > Local Network.
-Without this, macOS silently blocks unsigned binaries from accessing LAN
-hosts like Home Assistant. See
-[issue #53](https://github.com/nugget/thane-ai-agent/issues/53).


### PR DESCRIPTION
Removed macOS note about granting Local Network permission for Thane. Out of scope for this page and out of date information.

## Summary

<!-- What does this PR do and why? Keep it brief. -->

## Test Plan

- [ ] `just ci` passes locally
- [ ] New/changed behavior has test coverage
- [ ] Manual verification (describe what you checked):

## Checklist

- [ ] Commits are signed
- [ ] Commit messages use conventional format (`feat:`, `fix:`, etc.)
- [ ] Related issue referenced (`Refs #NNN` or `Closes #NNN`)
- [ ] Impacted documentation updated (`docs/`, `AGENTS.md`, config examples, CLI help)
- [ ] No new third-party dependencies without discussion
