### PR TITLE
chore: add godoclint and lychee link-check to CI gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,11 @@ jobs:
       - name: Install golangci-lint
         run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.9.0
 
+      - name: Install lychee
+        run: |
+          curl -sSfL "https://github.com/lycheeverse/lychee/releases/download/lychee-v0.23.0/lychee-x86_64-unknown-linux-gnu.tar.gz" \
+            | sudo tar xz -C /usr/local/bin
+
       - name: Run CI checks
         run: just ci
         # Runs: fmt-check, lint, test

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,10 @@
 version: "2"
 linters:
+  enable:
+    - godoclint
   settings:
+    godoclint:
+      require-pkg-doc: true
     errcheck:
       check-type-assertions: true
     staticcheck:

--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -2378,7 +2378,6 @@ func (l *Loop) MemoryStats() map[string]any {
 	return l.memory.Stats()
 }
 
-// GetTokenCount returns the estimated token count for a conversation.
 // GetHistory returns the conversation messages for a given conversation.
 func (l *Loop) GetHistory(conversationID string) []memory.Message {
 	return l.memory.GetMessages(conversationID)

--- a/internal/awareness/statewindow.go
+++ b/internal/awareness/statewindow.go
@@ -9,7 +9,7 @@ import (
 	"time"
 )
 
-// Entry records a single state transition observed from the Home
+// StateWindowEntry records a single state transition observed from the Home
 // Assistant WebSocket event stream.
 type StateWindowEntry struct {
 	EntityID  string
@@ -18,7 +18,7 @@ type StateWindowEntry struct {
 	Timestamp time.Time
 }
 
-// Provider maintains a rolling window of recent state changes and
+// StateWindowProvider maintains a rolling window of recent state changes and
 // implements the agent.ContextProvider interface. It is safe for
 // concurrent use: HandleStateChange writes under a write lock while
 // GetContext reads under a read lock.

--- a/internal/awareness/watchlist_provider.go
+++ b/internal/awareness/watchlist_provider.go
@@ -17,7 +17,7 @@ type StateGetter interface {
 	GetState(ctx context.Context, entityID string) (*homeassistant.State, error)
 }
 
-// Provider implements agent.ContextProvider by fetching live state for
+// WatchlistProvider implements agent.ContextProvider by fetching live state for
 // all watched entities and formatting them as a markdown block for
 // system prompt injection.
 type WatchlistProvider struct {
@@ -26,7 +26,7 @@ type WatchlistProvider struct {
 	logger *slog.Logger
 }
 
-// NewProvider creates a watchlist context provider.
+// NewWatchlistProvider creates a watchlist context provider.
 func NewWatchlistProvider(store *WatchlistStore, ha StateGetter, logger *slog.Logger) *WatchlistProvider {
 	if logger == nil {
 		logger = slog.Default()

--- a/internal/contacts/presence.go
+++ b/internal/contacts/presence.go
@@ -56,7 +56,7 @@ type PresenceTracker struct {
 	logger    *slog.Logger
 }
 
-// NewTracker creates a person tracker for the given entity IDs. All
+// NewPresenceTracker creates a person tracker for the given entity IDs. All
 // entities start in "Unknown" state until Initialize is called. The
 // timezone is an IANA location string (e.g., "America/Chicago"); an
 // empty or invalid timezone falls back to the system local timezone.

--- a/internal/homeassistant/websocket.go
+++ b/internal/homeassistant/websocket.go
@@ -265,7 +265,7 @@ func (c *WSClient) GetAreaRegistry(ctx context.Context) ([]Area, error) {
 	return areas, nil
 }
 
-// GetEntityRegistry retrieves the entity registry via WebSocket.
+// GetEntityRegistryWS retrieves the entity registry via WebSocket.
 func (c *WSClient) GetEntityRegistryWS(ctx context.Context) ([]EntityRegistryEntry, error) {
 	id := c.msgID.Add(1)
 	msg := map[string]any{

--- a/internal/models/providers/ollama.go
+++ b/internal/models/providers/ollama.go
@@ -399,7 +399,7 @@ func (c *OllamaClient) Ping(ctx context.Context) error {
 	return nil
 }
 
-// ListModels returns available models.
+// ListModelInfos returns available models.
 func (c *OllamaClient) ListModelInfos(ctx context.Context) ([]OllamaModelInfo, error) {
 	httpReq, err := http.NewRequestWithContext(ctx, "GET", c.baseURL+"/api/tags", nil)
 	if err != nil {

--- a/internal/search/fetch.go
+++ b/internal/search/fetch.go
@@ -21,7 +21,7 @@ const DefaultMaxBytes int64 = 5 * 1024 * 1024
 // DefaultMaxChars is the default character limit for extracted text.
 const DefaultMaxChars = 50000
 
-// Result holds the fetched and extracted content from a URL.
+// FetchResult holds the fetched and extracted content from a URL.
 type FetchResult struct {
 	URL         string `json:"url"`
 	Title       string `json:"title,omitempty"`
@@ -38,7 +38,7 @@ type Fetcher struct {
 	maxBytes int64
 }
 
-// New creates a Fetcher with default settings.
+// NewFetcher creates a Fetcher with default settings.
 func NewFetcher() *Fetcher {
 	return &Fetcher{
 		client: httpkit.NewClient(

--- a/internal/search/fetch_tool.go
+++ b/internal/search/fetch_tool.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 )
 
-// ToolHandler returns a function compatible with the tools.Tool Handler
+// FetchToolHandler returns a function compatible with the tools.Tool Handler
 // signature. It wraps the Fetcher for use as an agent tool.
 func FetchToolHandler(f *Fetcher) func(ctx context.Context, args map[string]any) (string, error) {
 	return func(ctx context.Context, args map[string]any) (string, error) {
@@ -35,7 +35,7 @@ func FetchToolHandler(f *Fetcher) func(ctx context.Context, args map[string]any)
 	}
 }
 
-// ToolDefinition returns the JSON Schema parameters for the web_fetch tool.
+// FetchToolDefinition returns the JSON Schema parameters for the web_fetch tool.
 func FetchToolDefinition() map[string]any {
 	return map[string]any{
 		"type": "object",

--- a/justfile
+++ b/justfile
@@ -93,9 +93,14 @@ architecture:
 architecture-check:
     @bash scripts/architecture.sh check
 
+# Check internal markdown links (no network requests)
+[group('test')]
+link-check:
+    lychee --offline --no-progress '**/*.md'
+
 # CI: format check, lint, and tests
 [group('test')]
-ci: fmt-check mod-tidy-check config-generate-check architecture-check lint test
+ci: fmt-check mod-tidy-check config-generate-check architecture-check link-check lint test
 
 # --- Install ---
 


### PR DESCRIPTION
## Summary

- Enable **godoclint** in golangci-lint with `require-pkg-doc`
- Add **lychee** for offline markdown link checking (new `link-check` justfile recipe)
- Fix 12 existing godoclint violations (doc comments with shortened symbol names)

Depends on #685 (bump-dependencies) for Go 1.25 CI runner.

## Test plan

- [ ] `just ci` passes locally (includes new `link-check` step)
- [ ] `golangci-lint run ./...` reports 0 issues with godoclint enabled
- [ ] `lychee --offline --no-progress '**/*.md'` reports 0 errors