### PR TITLE
docs: introduce autonomous loop terminology and document loop modes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,9 +85,11 @@ on GitHub Actions to catch what you could have caught locally.
 
 - **Dual-port**: Port 8080 (native OpenAI-compatible API + web dashboard)
   and port 11434 (Ollama-compatible API for HA integration).
-- **Agent loop**: Iterates up to 10 times per request. Each iteration:
-  LLM call, tool execution, repeat or respond. On exhaustion, a final
-  `tools=nil` call forces a text response.
+- **Agent loop**: The universal execution primitive. Three modes:
+  *request/reply* (one-shot conversations, up to 10 iterations),
+  *background tasks* (detached delegation), and *autonomous loops*
+  (persistent, self-paced — the agent controls its own timing and
+  directs its own attention). A registry tracks all active loops.
 - **Delegation**: Orchestrator model plans; small local models execute
   tool-heavy work at zero API cost.
 - **Model routing**: Scores models on quality, speed, and cost. Routing

--- a/docs/understanding/agent-loop.md
+++ b/docs/understanding/agent-loop.md
@@ -1,12 +1,50 @@
 # The Agent Loop
 
-The agent loop is Thane's core reasoning cycle. Every request — whether from
-a user typing in the dashboard, a Home Assistant voice command, an MQTT wake
-subscription, or a scheduled task — enters the same loop.
+The loop is Thane's universal execution primitive. Every piece of work —
+a user conversation, a background watcher, a delegation task — runs as a
+loop with the same core reasoning cycle.
 
-## The Cycle
+## Loop Operations
 
-Each request runs through up to ten iterations:
+Loops come in three modes:
+
+**Request/Reply** — A user asks, the agent reasons and responds, the loop
+ends. This is what drives conversations through the API and Home Assistant.
+One-shot, synchronous, bounded.
+
+**Background Task** — A detached task whose result is delivered later
+through a non-blocking path (injected into a conversation, sent to a
+channel, or delivered via notification). Delegation runs in this mode —
+the orchestrator spawns a background loop for the delegate, continues
+reasoning, and picks up the result when it's ready.
+
+**Autonomous Loop** — A persistent loop that runs continuously alongside
+the main agent, directing its own attention. This is where Thane's agency
+lives: the ability to wonder about something and then actively look for
+it. Autonomous loops don't run on a fixed schedule — the agent controls
+its own pacing through `set_next_sleep`, deciding after each iteration
+how long until it looks again. Jitter randomizes the timing further,
+ensuring no two cycles are identical and that data sampling reflects
+genuine observation rather than mechanical polling.
+
+Autonomous loops come in two flavors: *self-paced* loops wake on a
+model-controlled sleep schedule (metacognitive reflection, ego
+maintenance — the agent decides when to look and how long to dwell),
+while *event-driven* loops block until an external event arrives (MQTT
+wake subscriptions that fire when a topic receives a message). Both
+observe the environment and act when something is worth responding to.
+
+An optional **supervisor** model can be invoked probabilistically during
+autonomous loop iterations — a frontier-quality model that provides
+periodic oversight of the local model's work.
+
+A **loop registry** tracks all active loops, enforces concurrency limits,
+and coordinates graceful shutdown. The registry provides operational
+visibility into what's running, health status, and resource consumption.
+
+## The Reasoning Cycle
+
+Each loop iteration runs through the same steps:
 
 ### 1. Context Assembly
 
@@ -105,11 +143,18 @@ Tags activated during a conversation persist for the duration of that
 session. A request that starts by activating `email` doesn't need to
 reactivate it on subsequent turns. Tags reset when the session closes.
 
-## Iteration Budget
+## Iteration Budgets
 
-The loop runs a maximum of ten iterations per request. Each iteration is
+**Request/reply loops** run a maximum of ten iterations. Each iteration is
 one LLM call plus tool execution. This prevents runaway tool-call chains
-while giving the agent enough room for multi-step reasoning.
+while giving the agent enough room for multi-step reasoning. On exhaustion,
+a final `tools=nil` call forces a text response.
+
+**Autonomous loops** iterate indefinitely with model-controlled pacing
+(bounded by `sleep_min` / `sleep_max`, randomized by jitter). The agent
+decides its own cadence — how long to dwell, when to look again.
+
+**Background tasks** have configurable iteration and wall-clock limits.
 
 The agent sees its token budget in the context, so it can make informed
 decisions about when to checkpoint, delegate, or wrap up.

--- a/docs/understanding/architecture.md
+++ b/docs/understanding/architecture.md
@@ -100,10 +100,14 @@ This means Thane works with HA out of the box — no custom integration needed.
 
 ### Agent Loop
 
-The core reasoning cycle. Receives a request — from a user, event trigger,
-or scheduled task — assembles context from memory, contacts, and home state,
-activates capability tags, plans tool calls, delegates tool-heavy work to
-local models, and shapes a response.
+The universal execution primitive. Every piece of work — a user
+conversation, a background delegation, a persistent watcher — runs as
+a loop with the same reasoning cycle: context assembly, tag activation,
+planning, tool execution, response. Loops come in three modes:
+request/reply (one-shot conversations), background tasks (detached
+delegation), and autonomous loops (persistent, self-paced — the agent
+directs its own attention). A registry tracks all active loops and
+coordinates shutdown.
 See [The Agent Loop](agent-loop.md).
 
 ### Model Router

--- a/docs/understanding/glossary.md
+++ b/docs/understanding/glossary.md
@@ -7,9 +7,13 @@ discussing Thane, use these terms consistently.
 
 ### Agent Loop
 
-The core reasoning cycle that runs once per request or event. Each iteration:
-context assembly, tag activation, planning, tool execution, response shaping.
-The loop runs up to ten iterations per request before forcing a final response.
+The universal execution primitive. Every piece of work — conversations,
+delegations, background watchers — runs as a loop with the same reasoning
+cycle: context assembly, tag activation, planning, tool execution, response.
+Three operation modes: *request/reply* (one-shot, up to ten iterations),
+*background task* (detached, result delivered later), and *autonomous loop*
+(persistent, self-paced — the agent directs its own attention and controls
+its own timing). A registry tracks all active loops.
 See [The Agent Loop](agent-loop.md).
 
 ### Capability Tag


### PR DESCRIPTION
## Summary

Recovered from #687 which merged into the wrong base branch.

Rewrite agent loop docs to cover the full loop taxonomy: request/reply, background tasks, and autonomous loops. The old docs described loops as purely "up to 10 iterations per request" — missing background tasks and autonomous loops entirely.

Autonomous loops are where Thane's agency lives — the ability to direct its own attention. The agent controls pacing via `set_next_sleep`, deciding after each iteration how long until it looks again. Jitter ensures no two cycles are identical.

Updated agent-loop.md, architecture.md, glossary.md, and AGENTS.md.

## Test plan

- [ ] Terminology consistent across all four files
- [ ] `just ci` passes