### PR TITLE
feat: add live Anthropic cost dashboard

### DIFF
--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -2790,11 +2790,19 @@ func (l *Loop) recordUsage(ctx context.Context, req *Request, model string, tota
 
 	identity := usage.ResolveModelIdentity(model, l.currentModelCatalog())
 	cost := usage.ComputeDetailedCostForIdentity(identity, totalIn, cacheCreateIn, cacheReadIn, totalOut, l.pricing)
+	loopID := ""
+	loopName := ""
+	if req.Hints != nil {
+		loopID = req.Hints["loop_id"]
+		loopName = req.Hints["loop_name"]
+	}
 	rec := usage.Record{
 		Timestamp:                time.Now(),
 		RequestID:                requestID,
 		SessionID:                sessionTag,
 		ConversationID:           convID,
+		LoopID:                   loopID,
+		LoopName:                 loopName,
 		Model:                    identity.Model,
 		UpstreamModel:            identity.UpstreamModel,
 		Resource:                 identity.Resource,

--- a/internal/app/new_servers.go
+++ b/internal/app/new_servers.go
@@ -499,6 +499,7 @@ func (a *App) initServers(s *newState) error {
 		webCfg := web.Config{
 			LoopRegistry: a.loopRegistry,
 			EventBus:     a.eventBus,
+			UsageStore:   a.usageStore,
 			SystemStatus: &systemStatusAdapter{connMgr: a.connMgr, modelRegistry: a.modelRegistry, router: a.rtr, capSurface: a.capSurface},
 			Logger:       logger,
 		}

--- a/internal/delegate/delegate.go
+++ b/internal/delegate/delegate.go
@@ -770,6 +770,7 @@ type preparedExecution struct {
 	conversationID   string
 	archiveSessionID string
 	parentLoopID     string
+	parentLoopName   string
 	channelBinding   *memory.ChannelBinding
 	profile          *Profile
 	routeHints       map[string]string
@@ -1149,6 +1150,7 @@ func (e *Executor) prepareExecution(ctx context.Context, task, profileName, guid
 		conversationID:   conversationID,
 		archiveSessionID: archiveSessionID,
 		parentLoopID:     tools.LoopIDFromContext(ctx),
+		parentLoopName:   tools.HintsFromContext(ctx)["loop_name"],
 		channelBinding:   tools.ChannelBindingFromContext(ctx),
 		profile:          profile,
 		routeHints:       e.effectiveDelegateRouterHints(ctx, profile),
@@ -1213,6 +1215,8 @@ type completionRecord struct {
 	log              *slog.Logger
 	delegateID       string
 	conversationID   string
+	parentLoopID     string
+	parentLoopName   string
 	archiveSessionID string
 	task             string
 	guidance         string
@@ -1299,6 +1303,8 @@ func (e *Executor) recordCompletion(rec *completionRecord) {
 			Timestamp:                now,
 			RequestID:                rec.delegateID,
 			ConversationID:           rec.conversationID,
+			LoopID:                   rec.parentLoopID,
+			LoopName:                 rec.parentLoopName,
 			Model:                    identity.Model,
 			UpstreamModel:            identity.UpstreamModel,
 			Resource:                 identity.Resource,

--- a/internal/server/web/handlers.go
+++ b/internal/server/web/handlers.go
@@ -11,7 +11,23 @@ import (
 
 	"github.com/nugget/thane-ai-agent/internal/events"
 	"github.com/nugget/thane-ai-agent/internal/logging"
+	"github.com/nugget/thane-ai-agent/internal/usage"
 )
+
+type usageOverviewResponse struct {
+	Start       string                 `json:"start"`
+	End         string                 `json:"end"`
+	Hours       int                    `json:"hours"`
+	Summary     *usage.Summary         `json:"summary"`
+	ByProvider  []usage.GroupedSummary `json:"by_provider,omitempty"`
+	ByResource  []usage.GroupedSummary `json:"by_resource,omitempty"`
+	ByModel     []usage.GroupedSummary `json:"by_model,omitempty"`
+	ByUpstream  []usage.GroupedSummary `json:"by_upstream_model,omitempty"`
+	ByRole      []usage.GroupedSummary `json:"by_role,omitempty"`
+	ByTask      []usage.GroupedSummary `json:"by_task,omitempty"`
+	ByLoop      []usage.LoopSummary    `json:"by_loop,omitempty"`
+	TopRequests []usage.RequestSummary `json:"top_requests,omitempty"`
+}
 
 // handleSystem returns runtime health, uptime, and version info for
 // the system node on the dashboard canvas.
@@ -153,6 +169,89 @@ func (s *WebServer) handleRequestDetail(w http.ResponseWriter, r *http.Request) 
 func (s *WebServer) handleRequestDetailProbe(w http.ResponseWriter, _ *http.Request) {
 	w.Header().Set("X-Request-Detail-Available", strconv.FormatBool(s.contentQuerier != nil))
 	w.WriteHeader(http.StatusNoContent)
+}
+
+func parsePositiveIntParam(raw string, fallback, max int) (int, error) {
+	if strings.TrimSpace(raw) == "" {
+		return fallback, nil
+	}
+	n, err := strconv.Atoi(strings.TrimSpace(raw))
+	if err != nil || n <= 0 {
+		return 0, fmt.Errorf("must be a positive integer")
+	}
+	if max > 0 && n > max {
+		return max, nil
+	}
+	return n, nil
+}
+
+func (s *WebServer) handleUsageOverview(w http.ResponseWriter, r *http.Request) {
+	if s.usageStore == nil {
+		s.writeJSONError(w, "usage overview not available", http.StatusServiceUnavailable)
+		return
+	}
+
+	hours, err := parsePositiveIntParam(r.URL.Query().Get("hours"), 24, 24*365)
+	if err != nil {
+		s.writeJSONError(w, "hours must be a positive integer", http.StatusBadRequest)
+		return
+	}
+	limit, err := parsePositiveIntParam(r.URL.Query().Get("limit"), 20, 100)
+	if err != nil {
+		s.writeJSONError(w, "limit must be a positive integer", http.StatusBadRequest)
+		return
+	}
+
+	end := time.Now().UTC().Truncate(time.Second)
+	start := end.Add(-time.Duration(hours) * time.Hour)
+	queryEnd := end.Add(1 * time.Second)
+
+	summary, err := s.usageStore.Summary(start, queryEnd)
+	if err != nil {
+		s.logger.Warn("usage overview summary query failed", "error", err, "hours", hours)
+		s.writeJSONError(w, "usage summary query failed", http.StatusInternalServerError)
+		return
+	}
+
+	groupNames := []string{"provider", "resource", "model", "upstream_model", "role", "task"}
+	groupResults := make(map[string][]usage.GroupedSummary, len(groupNames))
+	for _, groupName := range groupNames {
+		grouped, err := s.usageStore.SummaryByGroup(groupName, start, queryEnd)
+		if err != nil {
+			s.logger.Warn("usage overview group query failed", "group_by", groupName, "error", err)
+			s.writeJSONError(w, "usage group query failed", http.StatusInternalServerError)
+			return
+		}
+		groupResults[groupName] = grouped
+	}
+
+	byLoop, err := s.usageStore.SummaryByLoop(start, queryEnd)
+	if err != nil {
+		s.logger.Warn("usage overview loop query failed", "error", err)
+		s.writeJSONError(w, "usage loop query failed", http.StatusInternalServerError)
+		return
+	}
+	topRequests, err := s.usageStore.TopRequests(start, queryEnd, limit)
+	if err != nil {
+		s.logger.Warn("usage overview request query failed", "error", err, "limit", limit)
+		s.writeJSONError(w, "usage request query failed", http.StatusInternalServerError)
+		return
+	}
+
+	s.writeJSON(w, usageOverviewResponse{
+		Start:       start.UTC().Format(time.RFC3339),
+		End:         end.UTC().Format(time.RFC3339),
+		Hours:       hours,
+		Summary:     summary,
+		ByProvider:  groupResults["provider"],
+		ByResource:  groupResults["resource"],
+		ByModel:     groupResults["model"],
+		ByUpstream:  groupResults["upstream_model"],
+		ByRole:      groupResults["role"],
+		ByTask:      groupResults["task"],
+		ByLoop:      byLoop,
+		TopRequests: topRequests,
+	})
 }
 
 // handleSystemLogs returns all log entries across the entire runtime.

--- a/internal/server/web/handlers_test.go
+++ b/internal/server/web/handlers_test.go
@@ -9,12 +9,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/nugget/thane-ai-agent/internal/database"
 	"github.com/nugget/thane-ai-agent/internal/events"
 	"github.com/nugget/thane-ai-agent/internal/logging"
 	"github.com/nugget/thane-ai-agent/internal/loop"
 	"github.com/nugget/thane-ai-agent/internal/models"
 	"github.com/nugget/thane-ai-agent/internal/router"
 	"github.com/nugget/thane-ai-agent/internal/toolcatalog"
+	"github.com/nugget/thane-ai-agent/internal/usage"
 )
 
 // --- Test Doubles ---
@@ -53,6 +55,27 @@ type stubContentQuerier struct {
 func (q *stubContentQuerier) QueryRequestDetail(requestID string) (*logging.RequestDetail, error) {
 	q.lastRequestID = requestID
 	return q.detail, q.err
+}
+
+func newUsageStoreForTest(t *testing.T, records ...usage.Record) *usage.Store {
+	t.Helper()
+
+	db, err := database.OpenMemory()
+	if err != nil {
+		t.Fatalf("database.OpenMemory: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+
+	store, err := usage.NewStore(db)
+	if err != nil {
+		t.Fatalf("usage.NewStore: %v", err)
+	}
+	for _, rec := range records {
+		if err := store.Record(t.Context(), rec); err != nil {
+			t.Fatalf("store.Record(%q): %v", rec.RequestID, err)
+		}
+	}
+	return store
 }
 
 func newTestServer(reg LoopRegistry, lq LogQuerier, bus *events.Bus) *WebServer {
@@ -681,5 +704,122 @@ func TestHandleRequestDetail_AllowsLiteralProbeRequestID(t *testing.T) {
 	}
 	if cq.lastRequestID != "_probe" {
 		t.Fatalf("queried request id = %q, want _probe", cq.lastRequestID)
+	}
+}
+
+func TestHandleUsageOverview(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now().UTC()
+	store := newUsageStoreForTest(t,
+		usage.Record{
+			Timestamp:      now.Add(-2 * time.Hour),
+			RequestID:      "r_123",
+			ConversationID: "conv-1",
+			SessionID:      "sess-1",
+			LoopID:         "loop-a",
+			LoopName:       "battery watch",
+			Model:          "edge/claude-sonnet",
+			UpstreamModel:  "claude-sonnet",
+			Resource:       "edge",
+			Provider:       "anthropic",
+			InputTokens:    100,
+			OutputTokens:   50,
+			CostUSD:        3.50,
+			Role:           "scheduled",
+			TaskName:       "battery_scan",
+		},
+		usage.Record{
+			Timestamp:      now.Add(-1 * time.Hour),
+			RequestID:      "r_456",
+			ConversationID: "conv-2",
+			SessionID:      "sess-2",
+			LoopID:         "loop-a",
+			LoopName:       "battery watch",
+			Model:          "edge/claude-sonnet",
+			UpstreamModel:  "claude-sonnet",
+			Resource:       "edge",
+			Provider:       "anthropic",
+			InputTokens:    200,
+			OutputTokens:   100,
+			CostUSD:        0.75,
+			Role:           "scheduled",
+			TaskName:       "battery_scan",
+		},
+	)
+
+	srv := NewWebServer(Config{
+		LoopRegistry: &stubRegistry{},
+		EventBus:     events.New(),
+		UsageStore:   store,
+	})
+	mux := http.NewServeMux()
+	srv.RegisterRoutes(mux)
+
+	req := httptest.NewRequest("GET", "/api/usage/overview?hours=48&limit=7", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+
+	var resp usageOverviewResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Hours != 48 {
+		t.Fatalf("hours = %d, want 48", resp.Hours)
+	}
+	if resp.Summary == nil || resp.Summary.TotalCostUSD != 4.25 {
+		t.Fatalf("summary = %#v, want total cost 4.25", resp.Summary)
+	}
+	if len(resp.ByProvider) != 1 || resp.ByProvider[0].Key != "anthropic" {
+		t.Fatalf("by_provider = %#v, want anthropic", resp.ByProvider)
+	}
+	if len(resp.ByLoop) != 1 || resp.ByLoop[0].LoopID != "loop-a" {
+		t.Fatalf("by_loop = %#v, want loop-a", resp.ByLoop)
+	}
+	if len(resp.TopRequests) != 2 || resp.TopRequests[0].RequestID != "r_123" {
+		t.Fatalf("top_requests = %#v, want r_123 first and two rows", resp.TopRequests)
+	}
+	if resp.TopRequests[0].Summary.TotalCostUSD != 3.50 {
+		t.Fatalf("top_requests[0] = %#v, want total cost 3.50", resp.TopRequests[0])
+	}
+}
+
+func TestHandleUsageOverview_RequiresUsageQuerier(t *testing.T) {
+	t.Parallel()
+
+	srv := newTestServer(&stubRegistry{}, nil, events.New())
+	mux := http.NewServeMux()
+	srv.RegisterRoutes(mux)
+
+	req := httptest.NewRequest("GET", "/api/usage/overview", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503", w.Code)
+	}
+}
+
+func TestHandleUsageOverview_RejectsBadHours(t *testing.T) {
+	t.Parallel()
+
+	srv := NewWebServer(Config{
+		LoopRegistry: &stubRegistry{},
+		EventBus:     events.New(),
+		UsageStore:   newUsageStoreForTest(t),
+	})
+	mux := http.NewServeMux()
+	srv.RegisterRoutes(mux)
+
+	req := httptest.NewRequest("GET", "/api/usage/overview?hours=bogus", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", w.Code)
 	}
 }

--- a/internal/server/web/server.go
+++ b/internal/server/web/server.go
@@ -19,6 +19,7 @@ import (
 	"github.com/nugget/thane-ai-agent/internal/models"
 	"github.com/nugget/thane-ai-agent/internal/router"
 	"github.com/nugget/thane-ai-agent/internal/toolcatalog"
+	"github.com/nugget/thane-ai-agent/internal/usage"
 )
 
 //go:embed static/*
@@ -97,6 +98,8 @@ type Config struct {
 	// ContentQuerier enables request detail drill-down. Nil disables
 	// the /api/requests/{id} endpoint.
 	ContentQuerier ContentQuerier
+	// UsageStore enables the cost dashboard API. Nil disables it.
+	UsageStore *usage.Store
 	// SystemStatus provides runtime health for the system canvas node.
 	// Nil disables the system node.
 	SystemStatus SystemStatusProvider
@@ -110,6 +113,7 @@ type WebServer struct {
 	eventBus       *events.Bus
 	logQuerier     LogQuerier
 	contentQuerier ContentQuerier
+	usageStore     *usage.Store
 	systemStatus   SystemStatusProvider
 	logger         *slog.Logger
 }
@@ -125,6 +129,7 @@ func NewWebServer(cfg Config) *WebServer {
 		eventBus:       cfg.EventBus,
 		logQuerier:     cfg.LogQuerier,
 		contentQuerier: cfg.ContentQuerier,
+		usageStore:     cfg.UsageStore,
 		systemStatus:   cfg.SystemStatus,
 		logger:         logger,
 	}
@@ -141,6 +146,7 @@ func (s *WebServer) RegisterRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("GET /api/loops/{id}/logs", s.handleLoopLogs)
 	mux.HandleFunc("GET /api/request-detail/_probe", s.handleRequestDetailProbe)
 	mux.HandleFunc("GET /api/requests/{id}", s.handleRequestDetail)
+	mux.HandleFunc("GET /api/usage/overview", s.handleUsageOverview)
 	mux.HandleFunc("GET /api/system/logs", s.handleSystemLogs)
 }
 

--- a/internal/server/web/static/app.js
+++ b/internal/server/web/static/app.js
@@ -1933,6 +1933,15 @@ const detailPlaceholder = $('#detail-placeholder');
 const detailPanel = $('#detail-panel');
 const detailContent = $('#detail-content');
 const detailEntity = $('#detail-entity');
+const costDashboardPanel = $('#cost-dashboard');
+const costDashboardEls = {
+  subtitle: $('#cost-dashboard-subtitle'),
+  hours: $('#cost-dashboard-hours'),
+  refresh: $('#cost-dashboard-refresh'),
+  close: $('#cost-dashboard-close'),
+  empty: $('#cost-dashboard-empty'),
+  content: $('#cost-dashboard-content'),
+};
 const emptyState = $('#empty-state');
 const logEmpty = $('#log-empty');
 const logScroll = $('#log-scroll');
@@ -1955,6 +1964,7 @@ const SCHEMA_CARD_PRESET_HEIGHTS = Object.freeze({
   widget: 220,
 });
 const SCHEMA_CARD_LAYOUT_ORDER = Object.freeze(['title', 'widget', 'full']);
+const COST_DASHBOARD_REFRESH_MS = 15000;
 
 function loadDashboardPrefs() {
   try {
@@ -3600,6 +3610,32 @@ function appendSchemaRow(body, label, value, opts = {}) {
   return { row, valueEl };
 }
 
+function appendSchemaNodeRow(body, labelContent, valueContent, opts = {}) {
+  if (valueContent === null || valueContent === undefined || valueContent === '') return null;
+  const row = document.createElement('div');
+  row.className = 'schema-row' + (opts.multiline ? ' schema-row--multiline' : '');
+
+  const labelEl = document.createElement('div');
+  labelEl.className = 'schema-row__label';
+  if (typeof labelContent === 'string' || typeof labelContent === 'number' || typeof labelContent === 'boolean') {
+    labelEl.textContent = String(labelContent);
+  } else if (labelContent) {
+    labelEl.appendChild(labelContent);
+  }
+  row.appendChild(labelEl);
+
+  const valueEl = document.createElement('div');
+  valueEl.className = 'schema-row__value';
+  if (typeof valueContent === 'string' || typeof valueContent === 'number' || typeof valueContent === 'boolean') {
+    valueEl.textContent = String(valueContent);
+  } else if (valueContent) {
+    valueEl.appendChild(valueContent);
+  }
+  row.appendChild(valueEl);
+  body.appendChild(row);
+  return { row, valueEl };
+}
+
 function makeSchemaIDList(ids, opts = {}) {
   const wrap = document.createElement('div');
   wrap.className = 'schema-chip-list schema-chip-list--ids';
@@ -3648,6 +3684,286 @@ function makeInspectorUtility(label, content) {
   }
 
   return wrap;
+}
+
+let costDashboardVisible = false;
+let costDashboardAbort = null;
+let costDashboardData = null;
+let costDashboardRefreshedAt = '';
+
+function formatUSD(value) {
+  const n = Number(value || 0);
+  if (!Number.isFinite(n)) return '$0.00';
+  if (Math.abs(n) >= 100 || n === 0) return '$' + n.toFixed(2);
+  if (Math.abs(n) >= 1) return '$' + n.toFixed(2);
+  if (Math.abs(n) >= 0.01) return '$' + n.toFixed(3);
+  return '$' + n.toFixed(4);
+}
+
+function getUsageGroup(groups, key) {
+  return (groups || []).find((entry) => entry && entry.key === key);
+}
+
+function formatUsageSummaryLine(summary, opts = {}) {
+  const sum = summary || {};
+  const bits = [
+    formatUSD(sum.total_cost_usd || 0),
+    formatTokens((sum.total_input_tokens || 0) + (sum.total_output_tokens || 0)) + ' tok',
+  ];
+  if (opts.requests && opts.requests > 0) {
+    bits.push(formatNumber(opts.requests) + ' req');
+  } else if ((sum.total_records || 0) > 0) {
+    bits.push(formatNumber(sum.total_records || 0) + ' calls');
+  }
+  return bits.join(' · ');
+}
+
+function makeInlineWrap() {
+  const wrap = document.createElement('div');
+  wrap.style.display = 'flex';
+  wrap.style.flexWrap = 'wrap';
+  wrap.style.gap = '0.35rem';
+  wrap.style.alignItems = 'center';
+  return wrap;
+}
+
+function renderCostDashboardShell() {
+  detailPlaceholder.hidden = true;
+  detailContent.hidden = true;
+  requestDetailPanel.hidden = true;
+  costDashboardPanel.hidden = false;
+}
+
+function renderCostDashboardEmpty(message) {
+  renderCostDashboardShell();
+  costDashboardEls.empty.hidden = false;
+  costDashboardEls.empty.textContent = message;
+  costDashboardEls.content.hidden = true;
+  costDashboardEls.content.innerHTML = '';
+}
+
+function buildUsageGroupedCard(title, meta, groups, opts = {}) {
+  const card = makeSchemaCard(title, meta, {
+    titleSummary: opts.titleSummary || '',
+    widgetFacts: opts.widgetFacts || [],
+    key: 'cost-' + title.toLowerCase().replace(/[^a-z0-9]+/g, '-'),
+    entityKind: 'cost-dashboard',
+  });
+  const entries = (groups || []).slice(0, opts.limit || 8);
+  if (entries.length === 0) {
+    appendSchemaRow(card.body, 'status', 'No records in this window.');
+    return card.card;
+  }
+  for (const entry of entries) {
+    const label = truncate(entry.key || '(unset)', opts.maxLabel || 32);
+    appendSchemaRow(card.body, label, formatUsageSummaryLine(entry.summary));
+  }
+  return card.card;
+}
+
+function buildLoopUsageCard(data) {
+  const card = makeSchemaCard('Loop burn', 'Current loop attribution', {
+    titleSummary: 'Loop-linked Anthropic and local spend, grouped by the loop that triggered the request.',
+    widgetFacts: [
+      { label: 'loops', value: formatNumber((data.by_loop || []).length) },
+      { label: 'window', value: data.hours + 'h' },
+    ],
+    key: 'cost-loop-burn',
+    entityKind: 'cost-dashboard',
+  });
+  const entries = (data.by_loop || []).slice(0, 10);
+  if (entries.length === 0) {
+    appendSchemaRow(card.body, 'status', 'No loop-attributed usage in this window.');
+    return card.card;
+  }
+  for (const entry of entries) {
+    const valueWrap = makeInlineWrap();
+    const summary = document.createElement('span');
+    summary.textContent = formatUsageSummaryLine(entry.summary, { requests: entry.request_count || 0 });
+    valueWrap.appendChild(summary);
+    if (entry.loop_id && state.loops.has(entry.loop_id)) {
+      const btn = document.createElement('button');
+      btn.className = 'btn btn--sm';
+      btn.textContent = 'Select';
+      btn.addEventListener('click', (e) => {
+        e.stopPropagation();
+        closeCostDashboard();
+        selectLoop(entry.loop_id);
+      });
+      valueWrap.appendChild(btn);
+    }
+    appendSchemaRow(card.body, truncate(entry.loop_name || entry.loop_id || '(loop)', 28), valueWrap);
+  }
+  return card.card;
+}
+
+function buildRequestUsageCard(data) {
+  const card = makeSchemaCard('Top requests', 'Request-level drill-down', {
+    titleSummary: 'Highest-cost requests in the selected window. Request chips open the existing request detail pane.',
+    widgetFacts: [
+      { label: 'shown', value: formatNumber((data.top_requests || []).length) },
+      { label: 'window', value: data.hours + 'h' },
+    ],
+    key: 'cost-top-requests',
+    entityKind: 'cost-dashboard',
+  });
+  const entries = (data.top_requests || []).slice(0, 10);
+  if (entries.length === 0) {
+    appendSchemaRow(card.body, 'status', 'No request records in this window.');
+    return card.card;
+  }
+  for (const entry of entries) {
+    const label = makeRequestChip(entry.request_id);
+    const valueWrap = makeInlineWrap();
+    const summary = document.createElement('span');
+    summary.textContent = formatUsageSummaryLine(entry.summary);
+    valueWrap.appendChild(summary);
+    if (entry.loop_name) {
+      const loopNote = document.createElement('span');
+      loopNote.className = 'schema-card__fact';
+      loopNote.textContent = 'loop: ' + truncate(entry.loop_name, 18);
+      valueWrap.appendChild(loopNote);
+    }
+    if (entry.loop_id && state.loops.has(entry.loop_id)) {
+      const btn = document.createElement('button');
+      btn.className = 'btn btn--sm';
+      btn.textContent = 'Select loop';
+      btn.addEventListener('click', (e) => {
+        e.stopPropagation();
+        closeCostDashboard();
+        selectLoop(entry.loop_id);
+      });
+      valueWrap.appendChild(btn);
+    }
+    appendSchemaNodeRow(card.body, label, valueWrap);
+  }
+  return card.card;
+}
+
+function renderCostDashboardContent(data) {
+  renderCostDashboardShell();
+  costDashboardEls.empty.hidden = true;
+  costDashboardEls.content.hidden = false;
+  costDashboardEls.content.innerHTML = '';
+
+  const providerAnthropic = getUsageGroup(data.by_provider, 'anthropic');
+  const summary = data.summary || {};
+  const totalRequests = summary.total_records || 0;
+  const anthropicCost = providerAnthropic && providerAnthropic.summary ? providerAnthropic.summary.total_cost_usd || 0 : 0;
+  costDashboardEls.subtitle.textContent =
+    `${data.hours}h window · anthropic ${formatUSD(anthropicCost)} · refreshed ${costDashboardRefreshedAt || 'just now'}`;
+
+  const overview = makeSchemaCard('Spend snapshot', 'Current lookback window', {
+    titleSummary: 'Single-pane token and API spend view, anchored on persistent usage records and linked back to live request detail.',
+    widgetFacts: [
+      { label: 'Anthropic', value: formatUSD(anthropicCost) },
+      { label: 'Total', value: formatUSD(summary.total_cost_usd || 0) },
+      { label: 'Requests', value: formatNumber(totalRequests) },
+      { label: 'Total I/O', value: formatTokens((summary.total_input_tokens || 0) + (summary.total_output_tokens || 0)) },
+    ],
+    key: 'cost-overview',
+    entityKind: 'cost-dashboard',
+  });
+  appendSchemaRow(overview.body, 'input', formatTokens(summary.total_input_tokens || 0));
+  appendSchemaRow(overview.body, 'output', formatTokens(summary.total_output_tokens || 0));
+  appendSchemaRow(overview.body, 'cache write', formatTokens(summary.total_cache_creation_input_tokens || 0));
+  appendSchemaRow(overview.body, 'cache read', formatTokens(summary.total_cache_read_input_tokens || 0));
+  appendSchemaRow(overview.body, 'records', formatNumber(summary.total_records || 0));
+  costDashboardEls.content.appendChild(overview.card);
+
+  costDashboardEls.content.appendChild(buildLoopUsageCard(data));
+  costDashboardEls.content.appendChild(buildRequestUsageCard(data));
+  costDashboardEls.content.appendChild(buildUsageGroupedCard('By provider', 'Where spend lands', data.by_provider, {
+    titleSummary: 'Anthropic should stand out immediately here when frontier spend is active.',
+    widgetFacts: [{ label: 'providers', value: formatNumber((data.by_provider || []).length) }],
+  }));
+  costDashboardEls.content.appendChild(buildUsageGroupedCard('By resource', 'Which runtime resource burned it', data.by_resource, {
+    widgetFacts: [{ label: 'resources', value: formatNumber((data.by_resource || []).length) }],
+  }));
+  costDashboardEls.content.appendChild(buildUsageGroupedCard('By deployment', 'Resolved deployment IDs', data.by_model, {
+    widgetFacts: [{ label: 'deployments', value: formatNumber((data.by_model || []).length) }],
+  }));
+  costDashboardEls.content.appendChild(buildUsageGroupedCard('By upstream model', 'Provider-native model names', data.by_upstream_model, {
+    widgetFacts: [{ label: 'models', value: formatNumber((data.by_upstream_model || []).length) }],
+  }));
+  costDashboardEls.content.appendChild(buildUsageGroupedCard('By role', 'Interactive vs delegate vs scheduled burn', data.by_role, {
+    widgetFacts: [{ label: 'roles', value: formatNumber((data.by_role || []).length) }],
+  }));
+  costDashboardEls.content.appendChild(buildUsageGroupedCard('By task', 'Named task buckets when present', data.by_task, {
+    widgetFacts: [{ label: 'tasks', value: formatNumber((data.by_task || []).length) }],
+  }));
+}
+
+async function fetchCostDashboard() {
+  if (!costDashboardVisible) return;
+  const hours = Number(costDashboardEls.hours && costDashboardEls.hours.value) || 24;
+  if (costDashboardAbort) {
+    costDashboardAbort.abort();
+  }
+  const controller = new AbortController();
+  costDashboardAbort = controller;
+
+  if (!costDashboardData) {
+    renderCostDashboardEmpty('Loading usage overview…');
+  }
+
+  try {
+    const resp = await fetch('/api/usage/overview?hours=' + encodeURIComponent(hours) + '&limit=20', {
+      signal: controller.signal,
+    });
+    if (costDashboardAbort !== controller) return;
+    if (!resp.ok) {
+      renderCostDashboardEmpty('Usage overview failed to load (' + resp.status + ').');
+      return;
+    }
+    const data = await resp.json();
+    if (costDashboardAbort !== controller) return;
+    costDashboardData = data;
+    costDashboardRefreshedAt = new Date().toLocaleTimeString();
+    renderCostDashboardContent(data);
+  } catch (err) {
+    if (err.name === 'AbortError') return;
+    console.warn('Failed to fetch cost dashboard:', err);
+    renderCostDashboardEmpty('Usage overview failed to load.');
+  }
+}
+
+function openCostDashboard(opts = {}) {
+  costDashboardVisible = true;
+  if (!detailPanel.hidden) {
+    // no-op; the panel is already available
+  } else {
+    setInspectorVisible(true);
+  }
+  focusSystem();
+  if (requestDetailAbort) {
+    requestDetailAbort.abort();
+    requestDetailAbort = null;
+  }
+  activeRequestID = null;
+  activeRequestJSON = null;
+  requestDetailPanel.hidden = true;
+  renderDetail();
+  if (!opts.skipHash) {
+    window.location.hash = 'costs';
+  }
+  void fetchCostDashboard();
+}
+
+function closeCostDashboard(opts = {}) {
+  if (!costDashboardVisible) return;
+  costDashboardVisible = false;
+  costDashboardPanel.hidden = true;
+  costDashboardEls.content.hidden = true;
+  costDashboardEls.empty.hidden = false;
+  if (costDashboardAbort) {
+    costDashboardAbort.abort();
+    costDashboardAbort = null;
+  }
+  renderAll();
+  if (!opts.skipHash && window.location.hash === '#costs') {
+    history.replaceState(null, '', window.location.pathname + window.location.search);
+  }
 }
 
 function copyLoopEntityJSON(loop) {
@@ -4414,6 +4730,7 @@ function buildSystemContextMenu(sys) {
     { label: 'services: ' + entity.readyCount + '/' + entity.serviceCount + ' ready', disabled: true },
     { label: 'routing: ' + entity.routingMode + (entity.defaultModel ? ' · ' + entity.defaultModel : ''), disabled: true },
     { separator: true },
+    { label: 'Open cost dashboard', action: () => openCostDashboard() },
     { label: 'Open core window', action: () => openDetailWindow('system') },
     { label: 'Open toolbox window', action: () => openRegistryWindow('toolbox') },
     { label: 'Open model registry', action: () => openRegistryWindow('models') },
@@ -4425,6 +4742,16 @@ function buildSystemContextMenu(sys) {
 
 function renderDetail(opts = {}) {
   withPreservedDetailScroll(() => {
+    if (costDashboardVisible) {
+      renderCostDashboardShell();
+      if (costDashboardData) {
+        renderCostDashboardContent(costDashboardData);
+      } else {
+        renderCostDashboardEmpty('Loading usage overview…');
+      }
+      return;
+    }
+
     const isSystem = state.selected === '__system__';
     const isLoop = state.selected && state.loops.has(state.selected);
 
@@ -5130,6 +5457,7 @@ async function showRequestDetail(requestID) {
     // Show the request detail panel, hide others.
     detailPlaceholder.hidden = true;
     detailContent.hidden = true;
+    costDashboardPanel.hidden = true;
     requestDetailPanel.hidden = false;
 
     renderRequestDetail(detail, requestDetailEls);
@@ -5154,8 +5482,12 @@ function closeRequestDetail() {
   requestDetailPanel.hidden = true;
   // Restore the previous detail panel state.
   renderAll();
-  // Clear hash while preserving path and query string.
-  history.replaceState(null, '', window.location.pathname + window.location.search);
+  if (costDashboardVisible) {
+    history.replaceState(null, '', window.location.pathname + window.location.search + '#costs');
+  } else {
+    // Clear hash while preserving path and query string.
+    history.replaceState(null, '', window.location.pathname + window.location.search);
+  }
 }
 
 $('#request-detail-close').addEventListener('click', closeRequestDetail);
@@ -5170,6 +5502,17 @@ $('#request-detail-copy').addEventListener('click', () => {
       btn.classList.remove('copy-btn--copied');
     }, 1200);
   });
+});
+
+costDashboardEls.refresh?.addEventListener('click', () => {
+  if (!costDashboardVisible) return;
+  void fetchCostDashboard();
+});
+costDashboardEls.close?.addEventListener('click', () => closeCostDashboard());
+costDashboardEls.hours?.addEventListener('change', () => {
+  if (!costDashboardVisible) return;
+  costDashboardData = null;
+  void fetchCostDashboard();
 });
 
 // Override renderDetail to respect active request detail view.
@@ -5204,6 +5547,7 @@ async function probeContentRetention() {
 function handleHashRoute() {
   const hash = window.location.hash;
   const match = hash && hash.match(/^#request\/(.+)$/);
+  const wantsCosts = hash === '#costs';
 
   if (match) {
     const id = decodeURIComponent(match[1]);
@@ -5212,6 +5556,11 @@ function handleHashRoute() {
     if (id !== activeRequestID) {
       showRequestDetail(id);
     }
+    return;
+  }
+
+  if (wantsCosts) {
+    openCostDashboard({ skipHash: true });
     return;
   }
 
@@ -5226,6 +5575,9 @@ function handleHashRoute() {
     }
     requestDetailPanel.hidden = true;
     renderAll();
+  }
+  if (costDashboardVisible) {
+    closeCostDashboard({ skipHash: true });
   }
 }
 
@@ -5243,4 +5595,9 @@ probeContentRetention().then(handleHashRoute);
 setInterval(updateUptime, 1000);
 // Refresh system status every 10s.
 setInterval(fetchSystemStatus, 10000);
+// Refresh the cost dashboard while it is open.
+setInterval(() => {
+  if (!costDashboardVisible) return;
+  void fetchCostDashboard();
+}, COST_DASHBOARD_REFRESH_MS);
 requestAnimationFrame(tick);

--- a/internal/server/web/static/index.html
+++ b/internal/server/web/static/index.html
@@ -42,6 +42,27 @@
       <div id="detail-content" class="detail-content" hidden>
         <div id="detail-entity" class="detail-entity"></div>
       </div>
+      <div id="cost-dashboard" class="detail-content" hidden>
+        <div class="detail-header">
+          <div class="cost-dashboard__heading">
+            <h2 class="detail-name">Usage &amp; Cost</h2>
+            <p id="cost-dashboard-subtitle" class="detail-subtitle">Live token burn and API spend.</p>
+          </div>
+          <div class="cost-dashboard__controls">
+            <select id="cost-dashboard-hours" class="log-select" title="Usage lookback window">
+              <option value="1">1h</option>
+              <option value="6">6h</option>
+              <option value="24" selected>24h</option>
+              <option value="72">72h</option>
+              <option value="168">7d</option>
+            </select>
+            <button id="cost-dashboard-refresh" class="btn btn--sm">Refresh</button>
+            <button id="cost-dashboard-close" class="btn btn--sm" title="Close cost dashboard">&times;</button>
+          </div>
+        </div>
+        <div id="cost-dashboard-empty" class="request-window__empty">Loading usage overview…</div>
+        <div id="cost-dashboard-content" hidden></div>
+      </div>
       <div id="request-detail" class="detail-content" hidden>
         <div class="detail-header">
           <h2 class="detail-name">Request Detail</h2>

--- a/internal/server/web/static/style.css
+++ b/internal/server/web/static/style.css
@@ -1070,11 +1070,35 @@ body.resize-col .schema-card__fade {
 
 .detail-header .state-badge { margin-left: auto; }
 
+.cost-dashboard__heading {
+  min-width: 0;
+}
+
+.cost-dashboard__controls {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 0.35rem;
+  margin-left: auto;
+  flex-wrap: wrap;
+}
+
 .detail-name {
   font-size: 1rem;
   font-weight: 600;
   color: var(--accent);
   text-wrap: balance;
+}
+
+.detail-subtitle {
+  margin: 0.12rem 0 0;
+  font-size: 0.72rem;
+  color: var(--text-muted);
+}
+
+#cost-dashboard-content {
+  display: grid;
+  gap: 0.75rem;
 }
 
 .state-badge {

--- a/internal/usage/store.go
+++ b/internal/usage/store.go
@@ -23,6 +23,8 @@ type Record struct {
 	RequestID                string
 	SessionID                string
 	ConversationID           string
+	LoopID                   string
+	LoopName                 string
 	Model                    string // Selected deployment ID when known
 	UpstreamModel            string
 	Resource                 string
@@ -63,6 +65,31 @@ type GroupedSummary struct {
 	Summary Summary `json:"summary"`
 }
 
+// LoopSummary describes aggregated usage attributed to a loop.
+type LoopSummary struct {
+	LoopID       string  `json:"loop_id"`
+	LoopName     string  `json:"loop_name,omitempty"`
+	RequestCount int     `json:"request_count"`
+	Summary      Summary `json:"summary"`
+}
+
+// RequestSummary describes aggregated usage for a single request.
+type RequestSummary struct {
+	RequestID      string  `json:"request_id"`
+	CreatedAt      string  `json:"created_at"`
+	ConversationID string  `json:"conversation_id,omitempty"`
+	SessionID      string  `json:"session_id,omitempty"`
+	LoopID         string  `json:"loop_id,omitempty"`
+	LoopName       string  `json:"loop_name,omitempty"`
+	Model          string  `json:"model,omitempty"`
+	UpstreamModel  string  `json:"upstream_model,omitempty"`
+	Resource       string  `json:"resource,omitempty"`
+	Provider       string  `json:"provider,omitempty"`
+	Role           string  `json:"role,omitempty"`
+	TaskName       string  `json:"task_name,omitempty"`
+	Summary        Summary `json:"summary"`
+}
+
 // Store is an append-only SQLite store for token usage records. All
 // public methods are safe for concurrent use (SQLite serializes writes).
 type Store struct {
@@ -93,6 +120,8 @@ func (s *Store) migrate() error {
 		request_id      TEXT NOT NULL,
 		session_id      TEXT,
 		conversation_id TEXT,
+		loop_id         TEXT,
+		loop_name       TEXT,
 		model           TEXT NOT NULL,
 		provider        TEXT NOT NULL,
 		input_tokens    INTEGER NOT NULL,
@@ -102,6 +131,7 @@ func (s *Store) migrate() error {
 		task_name       TEXT
 	);
 	CREATE INDEX IF NOT EXISTS idx_usage_timestamp ON usage_records(timestamp);
+	CREATE INDEX IF NOT EXISTS idx_usage_request ON usage_records(request_id);
 	CREATE INDEX IF NOT EXISTS idx_usage_session ON usage_records(session_id);
 	CREATE INDEX IF NOT EXISTS idx_usage_conversation ON usage_records(conversation_id);
 	`
@@ -114,10 +144,19 @@ func (s *Store) migrate() error {
 	if err := database.AddColumn(s.db, "usage_records", "resource", "TEXT NOT NULL DEFAULT ''"); err != nil {
 		return err
 	}
+	if err := database.AddColumn(s.db, "usage_records", "loop_id", "TEXT NOT NULL DEFAULT ''"); err != nil {
+		return err
+	}
+	if err := database.AddColumn(s.db, "usage_records", "loop_name", "TEXT NOT NULL DEFAULT ''"); err != nil {
+		return err
+	}
 	if err := database.AddColumn(s.db, "usage_records", "cache_creation_input_tokens", "INTEGER NOT NULL DEFAULT 0"); err != nil {
 		return err
 	}
 	if err := database.AddColumn(s.db, "usage_records", "cache_read_input_tokens", "INTEGER NOT NULL DEFAULT 0"); err != nil {
+		return err
+	}
+	if _, err := s.db.Exec(`CREATE INDEX IF NOT EXISTS idx_usage_loop ON usage_records(loop_id);`); err != nil {
 		return err
 	}
 	return nil
@@ -139,14 +178,16 @@ func (s *Store) Record(ctx context.Context, rec Record) error {
 
 	_, err := s.db.ExecContext(ctx,
 		`INSERT INTO usage_records
-			(id, timestamp, request_id, session_id, conversation_id, model, upstream_model, resource, provider,
+			(id, timestamp, request_id, session_id, conversation_id, loop_id, loop_name, model, upstream_model, resource, provider,
 			 input_tokens, output_tokens, cache_creation_input_tokens, cache_read_input_tokens, cost_usd, role, task_name)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		rec.ID,
 		rec.Timestamp.UTC().Format(time.RFC3339),
 		rec.RequestID,
 		rec.SessionID,
 		rec.ConversationID,
+		rec.LoopID,
+		rec.LoopName,
 		rec.Model,
 		rec.UpstreamModel,
 		rec.Resource,
@@ -219,60 +260,6 @@ func (s *Store) SummaryByRole(start, end time.Time) ([]GroupedSummary, error) {
 // task_name are grouped under the key "".
 func (s *Store) SummaryByTask(start, end time.Time) ([]GroupedSummary, error) {
 	return s.summaryGroupedBy("task_name", start, end)
-}
-
-// SummaryByGroup dispatches the grouped summary query based on the
-// caller-provided grouping key.
-func (s *Store) SummaryByGroup(groupBy string, start, end time.Time) ([]GroupedSummary, error) {
-	switch strings.TrimSpace(groupBy) {
-	case "deployment", "model":
-		return s.SummaryByModel(start, end)
-	case "upstream_model":
-		return s.SummaryByUpstreamModel(start, end)
-	case "provider":
-		return s.SummaryByProvider(start, end)
-	case "resource":
-		return s.SummaryByResource(start, end)
-	case "role":
-		return s.SummaryByRole(start, end)
-	case "task":
-		return s.SummaryByTask(start, end)
-	default:
-		return nil, fmt.Errorf("unsupported group_by %q; use one of [\"deployment\" \"model\" \"upstream_model\" \"provider\" \"resource\" \"role\" \"task\"]", groupBy)
-	}
-}
-
-func (s *Store) summaryGroupedBy(column string, start, end time.Time) ([]GroupedSummary, error) {
-	// column is always a compile-time constant from our own methods,
-	// never user input, so embedding it directly is safe.
-	query := fmt.Sprintf(
-		`SELECT COALESCE(%s, ''), COUNT(*), COALESCE(SUM(input_tokens), 0), COALESCE(SUM(output_tokens), 0),
-		        COALESCE(SUM(cache_creation_input_tokens), 0), COALESCE(SUM(cache_read_input_tokens), 0), COALESCE(SUM(cost_usd), 0)
-		 FROM usage_records
-		 WHERE timestamp >= ? AND timestamp < ?
-		 GROUP BY %s
-		 ORDER BY SUM(cost_usd) DESC`,
-		column, column,
-	)
-
-	rows, err := s.db.Query(query,
-		start.UTC().Format(time.RFC3339),
-		end.UTC().Format(time.RFC3339),
-	)
-	if err != nil {
-		return nil, fmt.Errorf("query usage by %s: %w", column, err)
-	}
-	defer rows.Close()
-
-	var result []GroupedSummary
-	for rows.Next() {
-		var gs GroupedSummary
-		if err := rows.Scan(&gs.Key, &gs.Summary.TotalRecords, &gs.Summary.TotalInputTokens, &gs.Summary.TotalOutputTokens, &gs.Summary.TotalCacheCreationInputTokens, &gs.Summary.TotalCacheReadInputTokens, &gs.Summary.TotalCostUSD); err != nil {
-			return nil, fmt.Errorf("scan usage by %s: %w", column, err)
-		}
-		result = append(result, gs)
-	}
-	return result, rows.Err()
 }
 
 // ResolveModelIdentity resolves usage-facing metadata for a selected

--- a/internal/usage/store_queries.go
+++ b/internal/usage/store_queries.go
@@ -1,0 +1,171 @@
+package usage
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+// SummaryByLoop returns per-loop aggregated totals for records within
+// [start, end), ordered by cost descending. Records without a loop_id
+// are excluded from this view.
+func (s *Store) SummaryByLoop(start, end time.Time) ([]LoopSummary, error) {
+	rows, err := s.db.Query(
+		`SELECT loop_id, COALESCE(MAX(loop_name), ''), COUNT(DISTINCT request_id),
+		        COUNT(*), COALESCE(SUM(input_tokens), 0), COALESCE(SUM(output_tokens), 0),
+		        COALESCE(SUM(cache_creation_input_tokens), 0), COALESCE(SUM(cache_read_input_tokens), 0),
+		        COALESCE(SUM(cost_usd), 0)
+		 FROM usage_records
+		 WHERE timestamp >= ? AND timestamp < ? AND loop_id <> ''
+		 GROUP BY loop_id
+		 ORDER BY SUM(cost_usd) DESC, MAX(timestamp) DESC`,
+		start.UTC().Format(time.RFC3339),
+		end.UTC().Format(time.RFC3339),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("query usage by loop: %w", err)
+	}
+	defer rows.Close()
+
+	var result []LoopSummary
+	for rows.Next() {
+		var ls LoopSummary
+		if err := rows.Scan(
+			&ls.LoopID,
+			&ls.LoopName,
+			&ls.RequestCount,
+			&ls.Summary.TotalRecords,
+			&ls.Summary.TotalInputTokens,
+			&ls.Summary.TotalOutputTokens,
+			&ls.Summary.TotalCacheCreationInputTokens,
+			&ls.Summary.TotalCacheReadInputTokens,
+			&ls.Summary.TotalCostUSD,
+		); err != nil {
+			return nil, fmt.Errorf("scan usage by loop: %w", err)
+		}
+		result = append(result, ls)
+	}
+	return result, rows.Err()
+}
+
+// TopRequests returns the highest-cost requests within [start, end),
+// ordered by total cost descending. Each row aggregates all LLM usage
+// records written for that request.
+func (s *Store) TopRequests(start, end time.Time, limit int) ([]RequestSummary, error) {
+	if limit <= 0 {
+		limit = 20
+	}
+
+	rows, err := s.db.Query(
+		`SELECT request_id,
+		        COALESCE(MAX(timestamp), ''),
+		        COALESCE(MAX(conversation_id), ''),
+		        COALESCE(MAX(session_id), ''),
+		        COALESCE(MAX(loop_id), ''),
+		        COALESCE(MAX(loop_name), ''),
+		        COALESCE(MAX(model), ''),
+		        COALESCE(MAX(upstream_model), ''),
+		        COALESCE(MAX(resource), ''),
+		        COALESCE(MAX(provider), ''),
+		        COALESCE(MAX(role), ''),
+		        COALESCE(MAX(task_name), ''),
+		        COUNT(*), COALESCE(SUM(input_tokens), 0), COALESCE(SUM(output_tokens), 0),
+		        COALESCE(SUM(cache_creation_input_tokens), 0), COALESCE(SUM(cache_read_input_tokens), 0),
+		        COALESCE(SUM(cost_usd), 0)
+		 FROM usage_records
+		 WHERE timestamp >= ? AND timestamp < ?
+		 GROUP BY request_id
+		 ORDER BY SUM(cost_usd) DESC, MAX(timestamp) DESC
+		 LIMIT ?`,
+		start.UTC().Format(time.RFC3339),
+		end.UTC().Format(time.RFC3339),
+		limit,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("query top requests: %w", err)
+	}
+	defer rows.Close()
+
+	var result []RequestSummary
+	for rows.Next() {
+		var rs RequestSummary
+		if err := rows.Scan(
+			&rs.RequestID,
+			&rs.CreatedAt,
+			&rs.ConversationID,
+			&rs.SessionID,
+			&rs.LoopID,
+			&rs.LoopName,
+			&rs.Model,
+			&rs.UpstreamModel,
+			&rs.Resource,
+			&rs.Provider,
+			&rs.Role,
+			&rs.TaskName,
+			&rs.Summary.TotalRecords,
+			&rs.Summary.TotalInputTokens,
+			&rs.Summary.TotalOutputTokens,
+			&rs.Summary.TotalCacheCreationInputTokens,
+			&rs.Summary.TotalCacheReadInputTokens,
+			&rs.Summary.TotalCostUSD,
+		); err != nil {
+			return nil, fmt.Errorf("scan top requests: %w", err)
+		}
+		result = append(result, rs)
+	}
+	return result, rows.Err()
+}
+
+// SummaryByGroup dispatches the grouped summary query based on the
+// caller-provided grouping key.
+func (s *Store) SummaryByGroup(groupBy string, start, end time.Time) ([]GroupedSummary, error) {
+	switch strings.TrimSpace(groupBy) {
+	case "deployment", "model":
+		return s.SummaryByModel(start, end)
+	case "upstream_model":
+		return s.SummaryByUpstreamModel(start, end)
+	case "provider":
+		return s.SummaryByProvider(start, end)
+	case "resource":
+		return s.SummaryByResource(start, end)
+	case "role":
+		return s.SummaryByRole(start, end)
+	case "task":
+		return s.SummaryByTask(start, end)
+	default:
+		return nil, fmt.Errorf("unsupported group_by %q; use one of [\"deployment\" \"model\" \"upstream_model\" \"provider\" \"resource\" \"role\" \"task\"]", groupBy)
+	}
+}
+
+func (s *Store) summaryGroupedBy(column string, start, end time.Time) ([]GroupedSummary, error) {
+	// column is always a compile-time constant from our own methods,
+	// never user input, so embedding it directly is safe.
+	query := fmt.Sprintf(
+		`SELECT COALESCE(%s, ''), COUNT(*), COALESCE(SUM(input_tokens), 0), COALESCE(SUM(output_tokens), 0),
+		        COALESCE(SUM(cache_creation_input_tokens), 0), COALESCE(SUM(cache_read_input_tokens), 0), COALESCE(SUM(cost_usd), 0)
+		 FROM usage_records
+		 WHERE timestamp >= ? AND timestamp < ?
+		 GROUP BY %s
+		 ORDER BY SUM(cost_usd) DESC`,
+		column, column,
+	)
+
+	rows, err := s.db.Query(query,
+		start.UTC().Format(time.RFC3339),
+		end.UTC().Format(time.RFC3339),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("query usage by %s: %w", column, err)
+	}
+	defer rows.Close()
+
+	var result []GroupedSummary
+	for rows.Next() {
+		var gs GroupedSummary
+		if err := rows.Scan(&gs.Key, &gs.Summary.TotalRecords, &gs.Summary.TotalInputTokens, &gs.Summary.TotalOutputTokens, &gs.Summary.TotalCacheCreationInputTokens, &gs.Summary.TotalCacheReadInputTokens, &gs.Summary.TotalCostUSD); err != nil {
+			return nil, fmt.Errorf("scan usage by %s: %w", column, err)
+		}
+		result = append(result, gs)
+	}
+	return result, rows.Err()
+}

--- a/internal/usage/store_test.go
+++ b/internal/usage/store_test.go
@@ -252,6 +252,90 @@ func TestSummaryByTask(t *testing.T) {
 	}
 }
 
+func TestSummaryByLoop(t *testing.T) {
+	s := testStore(t)
+	ctx := context.Background()
+
+	now := time.Now().UTC()
+	recs := []Record{
+		{Timestamp: now, RequestID: "r1", LoopID: "loop-a", LoopName: "battery watch", Model: "m", Provider: "anthropic", InputTokens: 100, OutputTokens: 50, CostUSD: 1.5, Role: "scheduled"},
+		{Timestamp: now, RequestID: "r2", LoopID: "loop-a", LoopName: "battery watch", Model: "m", Provider: "anthropic", InputTokens: 200, OutputTokens: 100, CostUSD: 2.5, Role: "scheduled"},
+		{Timestamp: now, RequestID: "r3", LoopID: "loop-b", LoopName: "mail triage", Model: "m", Provider: "anthropic", InputTokens: 50, OutputTokens: 25, CostUSD: 0.5, Role: "scheduled"},
+		{Timestamp: now, RequestID: "r4", Model: "m", Provider: "anthropic", InputTokens: 10, OutputTokens: 5, CostUSD: 0.1, Role: "interactive"},
+	}
+	for _, rec := range recs {
+		if err := s.Record(ctx, rec); err != nil {
+			t.Fatalf("Record: %v", err)
+		}
+	}
+
+	start := now.Add(-1 * time.Minute)
+	end := now.Add(1 * time.Minute)
+	result, err := s.SummaryByLoop(start, end)
+	if err != nil {
+		t.Fatalf("SummaryByLoop: %v", err)
+	}
+
+	if len(result) != 2 {
+		t.Fatalf("got %d loop groups, want 2", len(result))
+	}
+	if result[0].LoopID != "loop-a" {
+		t.Fatalf("first loop = %q, want loop-a", result[0].LoopID)
+	}
+	if result[0].LoopName != "battery watch" {
+		t.Errorf("first loop name = %q, want battery watch", result[0].LoopName)
+	}
+	if result[0].RequestCount != 2 {
+		t.Errorf("loop-a RequestCount = %d, want 2", result[0].RequestCount)
+	}
+	if result[0].Summary.TotalCostUSD != 4.0 {
+		t.Errorf("loop-a cost = %f, want 4.0", result[0].Summary.TotalCostUSD)
+	}
+}
+
+func TestTopRequests(t *testing.T) {
+	s := testStore(t)
+	ctx := context.Background()
+
+	base := time.Now().UTC()
+	recs := []Record{
+		{Timestamp: base.Add(-2 * time.Second), RequestID: "r-top", LoopID: "loop-a", LoopName: "battery watch", ConversationID: "conv-a", SessionID: "sess-a", Model: "edge/claude-sonnet", UpstreamModel: "claude-sonnet", Resource: "edge", Provider: "anthropic", InputTokens: 100, OutputTokens: 50, CostUSD: 1.25, Role: "scheduled", TaskName: "battery_scan"},
+		{Timestamp: base.Add(-1 * time.Second), RequestID: "r-top", LoopID: "loop-a", LoopName: "battery watch", ConversationID: "conv-a", SessionID: "sess-a", Model: "edge/claude-sonnet", UpstreamModel: "claude-sonnet", Resource: "edge", Provider: "anthropic", InputTokens: 200, OutputTokens: 75, CostUSD: 2.25, Role: "scheduled", TaskName: "battery_scan"},
+		{Timestamp: base, RequestID: "r-low", LoopID: "loop-b", LoopName: "mail triage", ConversationID: "conv-b", SessionID: "sess-b", Model: "edge/claude-sonnet", UpstreamModel: "claude-sonnet", Resource: "edge", Provider: "anthropic", InputTokens: 50, OutputTokens: 25, CostUSD: 0.5, Role: "scheduled", TaskName: "mail_scan"},
+	}
+	for _, rec := range recs {
+		if err := s.Record(ctx, rec); err != nil {
+			t.Fatalf("Record: %v", err)
+		}
+	}
+
+	start := base.Add(-1 * time.Minute)
+	end := base.Add(1 * time.Minute)
+	result, err := s.TopRequests(start, end, 10)
+	if err != nil {
+		t.Fatalf("TopRequests: %v", err)
+	}
+
+	if len(result) != 2 {
+		t.Fatalf("got %d request groups, want 2", len(result))
+	}
+	if result[0].RequestID != "r-top" {
+		t.Fatalf("top request = %q, want r-top", result[0].RequestID)
+	}
+	if result[0].LoopID != "loop-a" || result[0].LoopName != "battery watch" {
+		t.Errorf("top request loop = %q/%q, want loop-a/battery watch", result[0].LoopID, result[0].LoopName)
+	}
+	if result[0].Summary.TotalRecords != 2 {
+		t.Errorf("top request records = %d, want 2", result[0].Summary.TotalRecords)
+	}
+	if result[0].Summary.TotalCostUSD != 3.5 {
+		t.Errorf("top request cost = %f, want 3.5", result[0].Summary.TotalCostUSD)
+	}
+	if result[0].ConversationID != "conv-a" || result[0].SessionID != "sess-a" {
+		t.Errorf("top request conversation/session = %q/%q, want conv-a/sess-a", result[0].ConversationID, result[0].SessionID)
+	}
+}
+
 func TestQueryByPeriod_Filters(t *testing.T) {
 	s := testStore(t)
 	ctx := context.Background()
@@ -670,6 +754,12 @@ func TestMigrate_AddsDeploymentMetadataColumns(t *testing.T) {
 	}
 	if !database.HasColumn(db, "usage_records", "resource") {
 		t.Fatal("expected resource column after migration")
+	}
+	if !database.HasColumn(db, "usage_records", "loop_id") {
+		t.Fatal("expected loop_id column after migration")
+	}
+	if !database.HasColumn(db, "usage_records", "loop_name") {
+		t.Fatal("expected loop_name column after migration")
 	}
 	if !database.HasColumn(db, "usage_records", "cache_creation_input_tokens") {
 		t.Fatal("expected cache_creation_input_tokens column after migration")


### PR DESCRIPTION
## Summary
- add a live cost dashboard in the web inspector, opened from the core node context menu
- expose usage overview data grouped by provider, resource, model, upstream model, role, task, loop, and request
- attribute new usage records to loops so spend can be traced from aggregate views down to existing request detail links

## What Changed
- stamp `loop_id` and `loop_name` onto interactive and delegate usage records
- add usage-store queries for per-loop summaries and highest-cost requests
- add `/api/usage/overview` for the dashboard's single-pane cost view
- add a dashboard inspector pane with refresh, time window selection, request drill-down, and loop selection affordances

## Validation
- `just ci`
