### PR TITLE
feat: add message envelope bus foundation

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -34,6 +34,7 @@ import (
 	"github.com/nugget/thane-ai-agent/internal/mcp"
 	"github.com/nugget/thane-ai-agent/internal/media"
 	"github.com/nugget/thane-ai-agent/internal/memory"
+	"github.com/nugget/thane-ai-agent/internal/messages"
 	"github.com/nugget/thane-ai-agent/internal/metacognitive"
 	"github.com/nugget/thane-ai-agent/internal/models"
 	modelproviders "github.com/nugget/thane-ai-agent/internal/models/providers"
@@ -169,6 +170,9 @@ type App struct {
 
 	// Event bus
 	eventBus *events.Bus
+
+	// Inter-component message bus
+	messageBus *messages.Bus
 
 	// Email manager (for Close on shutdown)
 	emailMgr *email.Manager

--- a/internal/app/message_bus_setup.go
+++ b/internal/app/message_bus_setup.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log/slog"
 
+	looppkg "github.com/nugget/thane-ai-agent/internal/loop"
 	"github.com/nugget/thane-ai-agent/internal/messages"
 )
 
@@ -19,12 +20,32 @@ func (a *App) initMessageBus() {
 		return
 	}
 	route := &messages.LoopHandler{
-		ByID: func(ctx context.Context, id string, env messages.Envelope) (any, error) {
-			return a.loopRegistry.SignalLoop(ctx, id, env)
+		ByID: func(ctx context.Context, id string, env messages.Envelope) (messages.DeliveryResult, error) {
+			receipt, err := a.loopRegistry.SignalLoop(ctx, id, env)
+			if err != nil {
+				return messages.DeliveryResult{}, err
+			}
+			return loopSignalDeliveryResult(receipt), nil
 		},
-		ByName: func(ctx context.Context, name string, env messages.Envelope) (any, error) {
-			return a.loopRegistry.SignalLoopByName(ctx, name, env)
+		ByName: func(ctx context.Context, name string, env messages.Envelope) (messages.DeliveryResult, error) {
+			receipt, err := a.loopRegistry.SignalLoopByName(ctx, name, env)
+			if err != nil {
+				return messages.DeliveryResult{}, err
+			}
+			return loopSignalDeliveryResult(receipt), nil
 		},
 	}
 	a.messageBus.RegisterRoute(messages.DestinationLoop, route.Deliver)
+}
+
+func loopSignalDeliveryResult(receipt looppkg.SignalReceipt) messages.DeliveryResult {
+	status := messages.DeliveryDelivered
+	if receipt.QueuedForNextWake {
+		status = messages.DeliveryQueued
+	}
+	return messages.DeliveryResult{
+		Route:   "loop",
+		Status:  status,
+		Details: receipt,
+	}
 }

--- a/internal/app/message_bus_setup.go
+++ b/internal/app/message_bus_setup.go
@@ -1,0 +1,30 @@
+package app
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/nugget/thane-ai-agent/internal/messages"
+)
+
+func (a *App) initMessageInfrastructure(logger *slog.Logger) {
+	if a == nil || a.messageBus != nil {
+		return
+	}
+	a.messageBus = messages.NewBus(logger)
+}
+
+func (a *App) initMessageBus() {
+	if a == nil || a.messageBus == nil || a.loopRegistry == nil {
+		return
+	}
+	route := &messages.LoopHandler{
+		ByID: func(ctx context.Context, id string, env messages.Envelope) (any, error) {
+			return a.loopRegistry.SignalLoop(ctx, id, env)
+		},
+		ByName: func(ctx context.Context, name string, env messages.Envelope) (any, error) {
+			return a.loopRegistry.SignalLoopByName(ctx, name, env)
+		},
+	}
+	a.messageBus.RegisterRoute(messages.DestinationLoop, route.Deliver)
+}

--- a/internal/app/message_bus_setup.go
+++ b/internal/app/message_bus_setup.go
@@ -21,24 +21,24 @@ func (a *App) initMessageBus() {
 	}
 	route := &messages.LoopHandler{
 		ByID: func(ctx context.Context, id string, env messages.Envelope) (messages.DeliveryResult, error) {
-			receipt, err := a.loopRegistry.SignalLoop(ctx, id, env)
+			receipt, err := a.loopRegistry.NotifyLoop(ctx, id, env)
 			if err != nil {
 				return messages.DeliveryResult{}, err
 			}
-			return loopSignalDeliveryResult(receipt), nil
+			return loopNotifyDeliveryResult(receipt), nil
 		},
 		ByName: func(ctx context.Context, name string, env messages.Envelope) (messages.DeliveryResult, error) {
-			receipt, err := a.loopRegistry.SignalLoopByName(ctx, name, env)
+			receipt, err := a.loopRegistry.NotifyLoopByName(ctx, name, env)
 			if err != nil {
 				return messages.DeliveryResult{}, err
 			}
-			return loopSignalDeliveryResult(receipt), nil
+			return loopNotifyDeliveryResult(receipt), nil
 		},
 	}
 	a.messageBus.RegisterRoute(messages.DestinationLoop, route.Deliver)
 }
 
-func loopSignalDeliveryResult(receipt looppkg.SignalReceipt) messages.DeliveryResult {
+func loopNotifyDeliveryResult(receipt looppkg.NotifyReceipt) messages.DeliveryResult {
 	status := messages.DeliveryDelivered
 	if receipt.QueuedForNextWake {
 		status = messages.DeliveryQueued

--- a/internal/app/new_channels.go
+++ b/internal/app/new_channels.go
@@ -373,6 +373,10 @@ func (a *App) initChannels(s *newState) error {
 		Registry:   a.loopRegistry,
 		LaunchLoop: a.launchLoop,
 	})
+	a.initMessageBus()
+	a.loop.Tools().ConfigureMessageTools(tools.MessageToolDeps{
+		Bus: a.messageBus,
+	})
 
 	// --- Log index query ---
 	// Expose the structured log index so the agent can query its own

--- a/internal/app/new_stores.go
+++ b/internal/app/new_stores.go
@@ -49,6 +49,8 @@ func (a *App) initStores(s *newState) error {
 	eventBus := events.New()
 	a.eventBus = eventBus
 
+	a.initMessageInfrastructure(logger)
+
 	// --- Loop registry ---
 	// Tracks all persistent background loops (metacognitive, pollers,
 	// watchers). Created early so component init blocks can register

--- a/internal/loop/loop.go
+++ b/internal/loop/loop.go
@@ -245,9 +245,9 @@ type Loop struct {
 	// iteration. Buffered size 1 coalesces multiple wake requests.
 	wakeCh chan struct{}
 
-	// pendingSignals are one-shot envelopes injected into the next
+	// pendingNotifies are one-shot envelopes injected into the next
 	// iteration prompt or handler context.
-	pendingSignals []pendingSignal
+	pendingNotifies []pendingNotify
 }
 
 // New creates a loop with the given configuration and dependencies.
@@ -787,7 +787,7 @@ func (l *Loop) run(ctx context.Context) {
 			}
 		}
 
-		signals, forceSupervisor := l.consumePendingSignals()
+		signals, forceSupervisor := l.consumePendingNotifies()
 
 		// --- PROCESSING PHASE ---
 		// Reset tool-provided sleep override and set current conversation ID.
@@ -839,7 +839,7 @@ func (l *Loop) run(ctx context.Context) {
 			handlerCtx = context.WithValue(handlerCtx, progressFuncKey{}, l.makeProgressFunc())
 			handlerCtx = withLoopID(handlerCtx, l.id)
 			handlerCtx = withFallbackContent(handlerCtx, l.config.FallbackContent)
-			handlerCtx = withSignalEnvelopes(handlerCtx, signals)
+			handlerCtx = withNotifyEnvelopes(handlerCtx, signals)
 			if handlerErr := l.config.Handler(handlerCtx, event); handlerErr != nil {
 				if errors.Is(handlerErr, ErrNoOp) {
 					noOp = true
@@ -1290,7 +1290,7 @@ func (l *Loop) iterate(ctx context.Context, isSupervisor bool, convID string, si
 	if l.requestInstructions != "" {
 		task = "Instructions: " + l.requestInstructions + "\n\n" + task
 	}
-	if signalSummary := summarizeSignalEnvelopes(signals); signalSummary != "" {
+	if signalSummary := summarizeNotifyEnvelopes(signals); signalSummary != "" {
 		task = signalSummary + "\n\n" + task
 	}
 

--- a/internal/loop/loop.go
+++ b/internal/loop/loop.go
@@ -14,6 +14,7 @@ import (
 	"github.com/nugget/thane-ai-agent/internal/events"
 	"github.com/nugget/thane-ai-agent/internal/logging"
 	"github.com/nugget/thane-ai-agent/internal/memory"
+	"github.com/nugget/thane-ai-agent/internal/messages"
 	"github.com/nugget/thane-ai-agent/internal/toolcatalog"
 )
 
@@ -239,6 +240,14 @@ type Loop struct {
 
 	// consecutiveErrors tracks sequential failures for backoff.
 	consecutiveErrors int
+
+	// wakeCh interrupts timer sleep when a signal is queued for the next
+	// iteration. Buffered size 1 coalesces multiple wake requests.
+	wakeCh chan struct{}
+
+	// pendingSignals are one-shot envelopes injected into the next
+	// iteration prompt or handler context.
+	pendingSignals []pendingSignal
 }
 
 // New creates a loop with the given configuration and dependencies.
@@ -272,6 +281,7 @@ func New(cfg Config, deps Deps) (*Loop, error) {
 		config: cfg,
 		deps:   deps,
 		state:  StatePending,
+		wakeCh: make(chan struct{}, 1),
 	}, nil
 }
 
@@ -673,7 +683,7 @@ func (l *Loop) run(ctx context.Context) {
 			"duration", initialSleep.Round(time.Second),
 		)
 
-		if !sleepCtx(ctx, initialSleep) {
+		if !l.sleep(ctx, initialSleep) {
 			logger.Debug("loop stopped during initial sleep",
 				"phase", "initial_sleep",
 			)
@@ -750,7 +760,7 @@ func (l *Loop) run(ctx context.Context) {
 					"consecutive_errors", consecutiveErrors,
 					"backoff", backoff.Round(time.Second),
 				)
-				if !sleepCtx(ctx, backoff) {
+				if !l.sleep(ctx, backoff) {
 					logger.Debug("loop stopped during wait backoff",
 						"phase", "wait_backoff",
 						"backoff", backoff.Round(time.Second),
@@ -777,6 +787,8 @@ func (l *Loop) run(ctx context.Context) {
 			}
 		}
 
+		signals, forceSupervisor := l.consumePendingSignals()
+
 		// --- PROCESSING PHASE ---
 		// Reset tool-provided sleep override and set current conversation ID.
 		convID := fmt.Sprintf("loop-%s-%d-%d", l.config.Name, attemptCount+1, time.Now().UnixMilli())
@@ -786,7 +798,7 @@ func (l *Loop) run(ctx context.Context) {
 		l.mu.Unlock()
 
 		// Determine if this is a supervisor iteration.
-		isSupervisor := l.config.Supervisor && l.config.SupervisorProb > 0 && l.deps.Rand.Float64() < l.config.SupervisorProb
+		isSupervisor := forceSupervisor || (l.config.Supervisor && l.config.SupervisorProb > 0 && l.deps.Rand.Float64() < l.config.SupervisorProb)
 
 		iterLog := logger.With(
 			"conversation_id", convID,
@@ -810,11 +822,12 @@ func (l *Loop) run(ctx context.Context) {
 			Source:    events.SourceLoop,
 			Kind:      events.KindLoopIterationStart,
 			Data: map[string]any{
-				"loop_id":         l.id,
-				"loop_name":       l.config.Name,
-				"conversation_id": convID,
-				"supervisor":      isSupervisor,
-				"attempt":         attemptCount + 1,
+				"loop_id":          l.id,
+				"loop_name":        l.config.Name,
+				"conversation_id":  convID,
+				"supervisor":       isSupervisor,
+				"attempt":          attemptCount + 1,
+				"signal_envelopes": len(signals),
 			},
 		})
 		iterLog.Debug("loop iteration starting")
@@ -826,6 +839,7 @@ func (l *Loop) run(ctx context.Context) {
 			handlerCtx = context.WithValue(handlerCtx, progressFuncKey{}, l.makeProgressFunc())
 			handlerCtx = withLoopID(handlerCtx, l.id)
 			handlerCtx = withFallbackContent(handlerCtx, l.config.FallbackContent)
+			handlerCtx = withSignalEnvelopes(handlerCtx, signals)
 			if handlerErr := l.config.Handler(handlerCtx, event); handlerErr != nil {
 				if errors.Is(handlerErr, ErrNoOp) {
 					noOp = true
@@ -905,7 +919,7 @@ func (l *Loop) run(ctx context.Context) {
 				l.recentConvIDs = l.recentConvIDs[:recentConvIDsCap]
 			}
 			l.mu.Unlock()
-			result, err = l.iterate(iterCtx, isSupervisor, convID)
+			result, err = l.iterate(iterCtx, isSupervisor, convID, signals)
 		}
 
 		// Clear in-flight state after iteration completes.
@@ -1124,7 +1138,7 @@ func (l *Loop) run(ctx context.Context) {
 
 			iterLog.Debug("loop sleeping", "duration", sleep.Round(time.Second))
 
-			if !sleepCtx(ctx, sleep) {
+			if !l.sleep(ctx, sleep) {
 				logger.Debug("loop stopped during sleep",
 					"phase", "sleep",
 				)
@@ -1233,7 +1247,7 @@ func (l *Loop) makeProgressFunc() func(string, map[string]any) {
 
 // iterate performs a single loop iteration: build prompt and run the
 // LLM via the agent runner.
-func (l *Loop) iterate(ctx context.Context, isSupervisor bool, convID string) (*IterationResult, error) {
+func (l *Loop) iterate(ctx context.Context, isSupervisor bool, convID string, signals []messages.Envelope) (*IterationResult, error) {
 	iterStart := time.Now()
 
 	// Build routing hints.
@@ -1275,6 +1289,9 @@ func (l *Loop) iterate(ctx context.Context, isSupervisor bool, convID string) (*
 
 	if l.requestInstructions != "" {
 		task = "Instructions: " + l.requestInstructions + "\n\n" + task
+	}
+	if signalSummary := summarizeSignalEnvelopes(signals); signalSummary != "" {
+		task = signalSummary + "\n\n" + task
 	}
 
 	// Merge loops-ng profile hints over loop-generated defaults.
@@ -1515,18 +1532,5 @@ func (l *Loop) setState(s State) {
 func (l *Loop) publishEvent(e events.Event) {
 	if l.deps.EventBus != nil {
 		l.deps.EventBus.Publish(e)
-	}
-}
-
-// sleepCtx sleeps for d or until ctx is cancelled. Returns false if
-// cancelled.
-func sleepCtx(ctx context.Context, d time.Duration) bool {
-	timer := time.NewTimer(d)
-	defer timer.Stop()
-	select {
-	case <-ctx.Done():
-		return false
-	case <-timer.C:
-		return true
 	}
 }

--- a/internal/loop/registry_signal.go
+++ b/internal/loop/registry_signal.go
@@ -7,34 +7,34 @@ import (
 	"github.com/nugget/thane-ai-agent/internal/messages"
 )
 
-// SignalLoop delivers one signal envelope to a live loop by ID.
-func (r *Registry) SignalLoop(ctx context.Context, id string, env messages.Envelope) (SignalReceipt, error) {
+// NotifyLoop delivers one notification envelope to a live loop by ID.
+func (r *Registry) NotifyLoop(ctx context.Context, id string, env messages.Envelope) (NotifyReceipt, error) {
 	if err := ctx.Err(); err != nil {
-		return SignalReceipt{}, err
+		return NotifyReceipt{}, err
 	}
 	l := r.Get(id)
 	if l == nil {
-		return SignalReceipt{}, fmt.Errorf("loop %q not found", id)
+		return NotifyReceipt{}, fmt.Errorf("loop %q not found", id)
 	}
-	return l.enqueueSignal(env)
+	return l.enqueueNotify(env)
 }
 
-// SignalLoopByName delivers one signal envelope to a live loop by exact name.
-func (r *Registry) SignalLoopByName(ctx context.Context, name string, env messages.Envelope) (SignalReceipt, error) {
+// NotifyLoopByName delivers one notification envelope to a live loop by exact name.
+func (r *Registry) NotifyLoopByName(ctx context.Context, name string, env messages.Envelope) (NotifyReceipt, error) {
 	if err := ctx.Err(); err != nil {
-		return SignalReceipt{}, err
+		return NotifyReceipt{}, err
 	}
 	matches := r.FindByName(name)
 	switch len(matches) {
 	case 0:
-		return SignalReceipt{}, fmt.Errorf("loop named %q not found", name)
+		return NotifyReceipt{}, fmt.Errorf("loop named %q not found", name)
 	case 1:
-		return matches[0].enqueueSignal(env)
+		return matches[0].enqueueNotify(env)
 	default:
 		ids := make([]string, 0, len(matches))
 		for _, l := range matches {
 			ids = append(ids, l.id)
 		}
-		return SignalReceipt{}, fmt.Errorf("loop name %q is ambiguous; retry with loop_id from %v", name, ids)
+		return NotifyReceipt{}, fmt.Errorf("loop name %q is ambiguous; retry with loop_id from %v", name, ids)
 	}
 }

--- a/internal/loop/registry_signal.go
+++ b/internal/loop/registry_signal.go
@@ -1,0 +1,36 @@
+package loop
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/nugget/thane-ai-agent/internal/messages"
+)
+
+// SignalLoop delivers one signal envelope to a live loop by ID.
+func (r *Registry) SignalLoop(ctx context.Context, id string, env messages.Envelope) (SignalReceipt, error) {
+	_ = ctx
+	l := r.Get(id)
+	if l == nil {
+		return SignalReceipt{}, fmt.Errorf("loop %q not found", id)
+	}
+	return l.enqueueSignal(env)
+}
+
+// SignalLoopByName delivers one signal envelope to a live loop by exact name.
+func (r *Registry) SignalLoopByName(ctx context.Context, name string, env messages.Envelope) (SignalReceipt, error) {
+	_ = ctx
+	matches := r.FindByName(name)
+	switch len(matches) {
+	case 0:
+		return SignalReceipt{}, fmt.Errorf("loop named %q not found", name)
+	case 1:
+		return matches[0].enqueueSignal(env)
+	default:
+		ids := make([]string, 0, len(matches))
+		for _, l := range matches {
+			ids = append(ids, l.id)
+		}
+		return SignalReceipt{}, fmt.Errorf("loop name %q is ambiguous; retry with loop_id from %v", name, ids)
+	}
+}

--- a/internal/loop/registry_signal.go
+++ b/internal/loop/registry_signal.go
@@ -7,7 +7,8 @@ import (
 	"github.com/nugget/thane-ai-agent/internal/messages"
 )
 
-// NotifyLoop delivers one notification envelope to a live loop by ID.
+// NotifyLoop delivers one inter-loop process notification to a live loop by ID.
+// This is loop-runtime control messaging, not Signal-channel transport.
 func (r *Registry) NotifyLoop(ctx context.Context, id string, env messages.Envelope) (NotifyReceipt, error) {
 	if err := ctx.Err(); err != nil {
 		return NotifyReceipt{}, err
@@ -19,7 +20,9 @@ func (r *Registry) NotifyLoop(ctx context.Context, id string, env messages.Envel
 	return l.enqueueNotify(env)
 }
 
-// NotifyLoopByName delivers one notification envelope to a live loop by exact name.
+// NotifyLoopByName delivers one inter-loop process notification to a live loop
+// by exact name. This is loop-runtime control messaging, not Signal-channel
+// transport.
 func (r *Registry) NotifyLoopByName(ctx context.Context, name string, env messages.Envelope) (NotifyReceipt, error) {
 	if err := ctx.Err(); err != nil {
 		return NotifyReceipt{}, err

--- a/internal/loop/registry_signal.go
+++ b/internal/loop/registry_signal.go
@@ -9,7 +9,9 @@ import (
 
 // SignalLoop delivers one signal envelope to a live loop by ID.
 func (r *Registry) SignalLoop(ctx context.Context, id string, env messages.Envelope) (SignalReceipt, error) {
-	_ = ctx
+	if err := ctx.Err(); err != nil {
+		return SignalReceipt{}, err
+	}
 	l := r.Get(id)
 	if l == nil {
 		return SignalReceipt{}, fmt.Errorf("loop %q not found", id)
@@ -19,7 +21,9 @@ func (r *Registry) SignalLoop(ctx context.Context, id string, env messages.Envel
 
 // SignalLoopByName delivers one signal envelope to a live loop by exact name.
 func (r *Registry) SignalLoopByName(ctx context.Context, name string, env messages.Envelope) (SignalReceipt, error) {
-	_ = ctx
+	if err := ctx.Err(); err != nil {
+		return SignalReceipt{}, err
+	}
 	matches := r.FindByName(name)
 	switch len(matches) {
 	case 0:

--- a/internal/loop/signals.go
+++ b/internal/loop/signals.go
@@ -11,7 +11,12 @@ import (
 	"github.com/nugget/thane-ai-agent/internal/messages"
 )
 
-const maxPendingNotifications = 32
+// maxPendingNotifications bounds how many one-shot inter-loop notifications a
+// live loop may queue while it is busy or sleeping. enqueueNotify rejects new
+// notifications once this cap is reached so a runaway caller cannot grow the
+// in-memory pending-notify slice without bound before the loop gets a chance
+// to drain it on the next iteration.
+const maxPendingNotifications = 8
 
 type pendingNotify struct {
 	Envelope        messages.Envelope

--- a/internal/loop/signals.go
+++ b/internal/loop/signals.go
@@ -1,0 +1,188 @@
+package loop
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/nugget/thane-ai-agent/internal/messages"
+)
+
+type pendingSignal struct {
+	Envelope        messages.Envelope
+	ForceSupervisor bool
+}
+
+// SignalReceipt summarizes the effect of signaling a live loop.
+type SignalReceipt struct {
+	LoopID            string `json:"loop_id"`
+	LoopName          string `json:"loop_name"`
+	State             State  `json:"state"`
+	WokeImmediately   bool   `json:"woke_immediately,omitempty"`
+	QueuedForNextWake bool   `json:"queued_for_next_wake,omitempty"`
+	ForceSupervisor   bool   `json:"force_supervisor,omitempty"`
+	PendingSignals    int    `json:"pending_signals,omitempty"`
+}
+
+type signalContextKey struct{}
+
+// SignalEnvelopesFromContext returns one-shot message envelopes delivered to
+// the current loop iteration, if any.
+func SignalEnvelopesFromContext(ctx context.Context) []messages.Envelope {
+	envs, _ := ctx.Value(signalContextKey{}).([]messages.Envelope)
+	if len(envs) == 0 {
+		return nil
+	}
+	out := make([]messages.Envelope, len(envs))
+	copy(out, envs)
+	return out
+}
+
+func withSignalEnvelopes(ctx context.Context, envs []messages.Envelope) context.Context {
+	if len(envs) == 0 {
+		return ctx
+	}
+	cp := make([]messages.Envelope, len(envs))
+	copy(cp, envs)
+	return context.WithValue(ctx, signalContextKey{}, cp)
+}
+
+func decodeLoopSignalPayload(raw any) (messages.LoopSignalPayload, error) {
+	switch got := raw.(type) {
+	case nil:
+		return messages.LoopSignalPayload{}, nil
+	case messages.LoopSignalPayload:
+		return got, nil
+	case *messages.LoopSignalPayload:
+		if got == nil {
+			return messages.LoopSignalPayload{}, nil
+		}
+		return *got, nil
+	case map[string]any:
+		var payload messages.LoopSignalPayload
+		if msg, ok := got["message"].(string); ok {
+			payload.Message = msg
+		}
+		if force, ok := got["force_supervisor"].(bool); ok {
+			payload.ForceSupervisor = force
+		}
+		return payload, nil
+	default:
+		return messages.LoopSignalPayload{}, fmt.Errorf("unsupported loop signal payload %T", raw)
+	}
+}
+
+func summarizeSignalEnvelopes(envs []messages.Envelope) string {
+	if len(envs) == 0 {
+		return ""
+	}
+	type signalView struct {
+		ID       string            `json:"id"`
+		From     messages.Identity `json:"from"`
+		Priority messages.Priority `json:"priority,omitempty"`
+		Scope    []string          `json:"scope,omitempty"`
+		Payload  map[string]any    `json:"payload,omitempty"`
+	}
+	views := make([]signalView, 0, len(envs))
+	for _, env := range envs {
+		payload, _ := decodeLoopSignalPayload(env.Payload)
+		view := signalView{
+			ID:       env.ID,
+			From:     env.From,
+			Priority: env.Priority,
+			Scope:    append([]string(nil), env.Scope...),
+		}
+		if strings.TrimSpace(payload.Message) != "" || payload.ForceSupervisor {
+			view.Payload = map[string]any{}
+			if strings.TrimSpace(payload.Message) != "" {
+				view.Payload["message"] = payload.Message
+			}
+			if payload.ForceSupervisor {
+				view.Payload["force_supervisor"] = true
+			}
+		}
+		views = append(views, view)
+	}
+	blob, err := json.Marshal(views)
+	if err != nil {
+		return ""
+	}
+	return "Signal envelopes for this run:\n" + string(blob)
+}
+
+func (l *Loop) enqueueSignal(env messages.Envelope) (SignalReceipt, error) {
+	payload, err := decodeLoopSignalPayload(env.Payload)
+	if err != nil {
+		return SignalReceipt{}, err
+	}
+
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.stopped || !l.started {
+		return SignalReceipt{}, fmt.Errorf("loop %q is not running", l.config.Name)
+	}
+	if l.config.WaitFunc != nil {
+		return SignalReceipt{}, fmt.Errorf("loop %q is event-driven and cannot be interrupted by signal yet", l.config.Name)
+	}
+
+	l.pendingSignals = append(l.pendingSignals, pendingSignal{
+		Envelope:        env,
+		ForceSupervisor: payload.ForceSupervisor,
+	})
+	receipt := SignalReceipt{
+		LoopID:          l.id,
+		LoopName:        l.config.Name,
+		State:           l.state,
+		ForceSupervisor: payload.ForceSupervisor,
+		PendingSignals:  len(l.pendingSignals),
+	}
+	if l.state == StateSleeping {
+		select {
+		case l.wakeCh <- struct{}{}:
+		default:
+		}
+		receipt.WokeImmediately = true
+	} else {
+		receipt.QueuedForNextWake = true
+	}
+	return receipt, nil
+}
+
+func (l *Loop) consumePendingSignals() ([]messages.Envelope, bool) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if len(l.pendingSignals) == 0 {
+		select {
+		case <-l.wakeCh:
+		default:
+		}
+		return nil, false
+	}
+	envs := make([]messages.Envelope, 0, len(l.pendingSignals))
+	forceSupervisor := false
+	for _, sig := range l.pendingSignals {
+		envs = append(envs, sig.Envelope)
+		forceSupervisor = forceSupervisor || sig.ForceSupervisor
+	}
+	l.pendingSignals = nil
+	select {
+	case <-l.wakeCh:
+	default:
+	}
+	return envs, forceSupervisor
+}
+
+func (l *Loop) sleep(ctx context.Context, d time.Duration) bool {
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return false
+	case <-timer.C:
+		return true
+	case <-l.wakeCh:
+		return true
+	}
+}

--- a/internal/loop/signals.go
+++ b/internal/loop/signals.go
@@ -4,11 +4,14 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"strings"
 	"time"
 
 	"github.com/nugget/thane-ai-agent/internal/messages"
 )
+
+const maxPendingSignals = 32
 
 type pendingSignal struct {
 	Envelope        messages.Envelope
@@ -62,11 +65,13 @@ func decodeLoopSignalPayload(raw any) (messages.LoopSignalPayload, error) {
 		return *got, nil
 	case map[string]any:
 		var payload messages.LoopSignalPayload
-		if msg, ok := got["message"].(string); ok {
-			payload.Message = msg
+		// Generic decoded JSON payloads arrive as map[string]any.
+		blob, err := json.Marshal(got)
+		if err != nil {
+			return messages.LoopSignalPayload{}, fmt.Errorf("marshal loop signal payload: %w", err)
 		}
-		if force, ok := got["force_supervisor"].(bool); ok {
-			payload.ForceSupervisor = force
+		if err := json.Unmarshal(blob, &payload); err != nil {
+			return messages.LoopSignalPayload{}, fmt.Errorf("decode loop signal payload: %w", err)
 		}
 		return payload, nil
 	default:
@@ -107,6 +112,7 @@ func summarizeSignalEnvelopes(envs []messages.Envelope) string {
 	}
 	blob, err := json.Marshal(views)
 	if err != nil {
+		slog.Warn("loop: failed to summarize signal envelopes", "count", len(views), "error", err)
 		return ""
 	}
 	return "Signal envelopes for this run:\n" + string(blob)
@@ -125,6 +131,9 @@ func (l *Loop) enqueueSignal(env messages.Envelope) (SignalReceipt, error) {
 	}
 	if l.config.WaitFunc != nil {
 		return SignalReceipt{}, fmt.Errorf("loop %q is event-driven and cannot be interrupted by signal yet", l.config.Name)
+	}
+	if len(l.pendingSignals) >= maxPendingSignals {
+		return SignalReceipt{}, fmt.Errorf("loop %q signal queue full (%d pending)", l.config.Name, len(l.pendingSignals))
 	}
 
 	l.pendingSignals = append(l.pendingSignals, pendingSignal{
@@ -154,6 +163,9 @@ func (l *Loop) consumePendingSignals() ([]messages.Envelope, bool) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 	if len(l.pendingSignals) == 0 {
+		// A concurrent wake can leave one coalesced token behind even after the
+		// corresponding signal was already consumed elsewhere; clear it so the
+		// next timer sleep is not interrupted spuriously.
 		select {
 		case <-l.wakeCh:
 		default:

--- a/internal/loop/signals.go
+++ b/internal/loop/signals.go
@@ -11,30 +11,30 @@ import (
 	"github.com/nugget/thane-ai-agent/internal/messages"
 )
 
-const maxPendingSignals = 32
+const maxPendingNotifications = 32
 
-type pendingSignal struct {
+type pendingNotify struct {
 	Envelope        messages.Envelope
 	ForceSupervisor bool
 }
 
-// SignalReceipt summarizes the effect of signaling a live loop.
-type SignalReceipt struct {
-	LoopID            string `json:"loop_id"`
-	LoopName          string `json:"loop_name"`
-	State             State  `json:"state"`
-	WokeImmediately   bool   `json:"woke_immediately,omitempty"`
-	QueuedForNextWake bool   `json:"queued_for_next_wake,omitempty"`
-	ForceSupervisor   bool   `json:"force_supervisor,omitempty"`
-	PendingSignals    int    `json:"pending_signals,omitempty"`
+// NotifyReceipt summarizes the effect of notifying a live loop.
+type NotifyReceipt struct {
+	LoopID               string `json:"loop_id"`
+	LoopName             string `json:"loop_name"`
+	State                State  `json:"state"`
+	WokeImmediately      bool   `json:"woke_immediately,omitempty"`
+	QueuedForNextWake    bool   `json:"queued_for_next_wake,omitempty"`
+	ForceSupervisor      bool   `json:"force_supervisor,omitempty"`
+	PendingNotifications int    `json:"pending_notifications,omitempty"`
 }
 
-type signalContextKey struct{}
+type notifyContextKey struct{}
 
-// SignalEnvelopesFromContext returns one-shot message envelopes delivered to
+// NotifyEnvelopesFromContext returns one-shot message envelopes delivered to
 // the current loop iteration, if any.
-func SignalEnvelopesFromContext(ctx context.Context) []messages.Envelope {
-	envs, _ := ctx.Value(signalContextKey{}).([]messages.Envelope)
+func NotifyEnvelopesFromContext(ctx context.Context) []messages.Envelope {
+	envs, _ := ctx.Value(notifyContextKey{}).([]messages.Envelope)
 	if len(envs) == 0 {
 		return nil
 	}
@@ -43,57 +43,57 @@ func SignalEnvelopesFromContext(ctx context.Context) []messages.Envelope {
 	return out
 }
 
-func withSignalEnvelopes(ctx context.Context, envs []messages.Envelope) context.Context {
+func withNotifyEnvelopes(ctx context.Context, envs []messages.Envelope) context.Context {
 	if len(envs) == 0 {
 		return ctx
 	}
 	cp := make([]messages.Envelope, len(envs))
 	copy(cp, envs)
-	return context.WithValue(ctx, signalContextKey{}, cp)
+	return context.WithValue(ctx, notifyContextKey{}, cp)
 }
 
-func decodeLoopSignalPayload(raw any) (messages.LoopSignalPayload, error) {
+func decodeLoopNotifyPayload(raw any) (messages.LoopNotifyPayload, error) {
 	switch got := raw.(type) {
 	case nil:
-		return messages.LoopSignalPayload{}, nil
-	case messages.LoopSignalPayload:
+		return messages.LoopNotifyPayload{}, nil
+	case messages.LoopNotifyPayload:
 		return got, nil
-	case *messages.LoopSignalPayload:
+	case *messages.LoopNotifyPayload:
 		if got == nil {
-			return messages.LoopSignalPayload{}, nil
+			return messages.LoopNotifyPayload{}, nil
 		}
 		return *got, nil
 	case map[string]any:
-		var payload messages.LoopSignalPayload
+		var payload messages.LoopNotifyPayload
 		// Generic decoded JSON payloads arrive as map[string]any.
 		blob, err := json.Marshal(got)
 		if err != nil {
-			return messages.LoopSignalPayload{}, fmt.Errorf("marshal loop signal payload: %w", err)
+			return messages.LoopNotifyPayload{}, fmt.Errorf("marshal loop notify payload: %w", err)
 		}
 		if err := json.Unmarshal(blob, &payload); err != nil {
-			return messages.LoopSignalPayload{}, fmt.Errorf("decode loop signal payload: %w", err)
+			return messages.LoopNotifyPayload{}, fmt.Errorf("decode loop notify payload: %w", err)
 		}
 		return payload, nil
 	default:
-		return messages.LoopSignalPayload{}, fmt.Errorf("unsupported loop signal payload %T", raw)
+		return messages.LoopNotifyPayload{}, fmt.Errorf("unsupported loop notify payload %T", raw)
 	}
 }
 
-func summarizeSignalEnvelopes(envs []messages.Envelope) string {
+func summarizeNotifyEnvelopes(envs []messages.Envelope) string {
 	if len(envs) == 0 {
 		return ""
 	}
-	type signalView struct {
+	type notifyView struct {
 		ID       string            `json:"id"`
 		From     messages.Identity `json:"from"`
 		Priority messages.Priority `json:"priority,omitempty"`
 		Scope    []string          `json:"scope,omitempty"`
 		Payload  map[string]any    `json:"payload,omitempty"`
 	}
-	views := make([]signalView, 0, len(envs))
+	views := make([]notifyView, 0, len(envs))
 	for _, env := range envs {
-		payload, _ := decodeLoopSignalPayload(env.Payload)
-		view := signalView{
+		payload, _ := decodeLoopNotifyPayload(env.Payload)
+		view := notifyView{
 			ID:       env.ID,
 			From:     env.From,
 			Priority: env.Priority,
@@ -112,40 +112,40 @@ func summarizeSignalEnvelopes(envs []messages.Envelope) string {
 	}
 	blob, err := json.Marshal(views)
 	if err != nil {
-		slog.Warn("loop: failed to summarize signal envelopes", "count", len(views), "error", err)
+		slog.Warn("loop: failed to summarize notify envelopes", "count", len(views), "error", err)
 		return ""
 	}
-	return "Signal envelopes for this run:\n" + string(blob)
+	return "Loop notifications for this run:\n" + string(blob)
 }
 
-func (l *Loop) enqueueSignal(env messages.Envelope) (SignalReceipt, error) {
-	payload, err := decodeLoopSignalPayload(env.Payload)
+func (l *Loop) enqueueNotify(env messages.Envelope) (NotifyReceipt, error) {
+	payload, err := decodeLoopNotifyPayload(env.Payload)
 	if err != nil {
-		return SignalReceipt{}, err
+		return NotifyReceipt{}, err
 	}
 
 	l.mu.Lock()
 	defer l.mu.Unlock()
 	if l.stopped || !l.started {
-		return SignalReceipt{}, fmt.Errorf("loop %q is not running", l.config.Name)
+		return NotifyReceipt{}, fmt.Errorf("loop %q is not running", l.config.Name)
 	}
 	if l.config.WaitFunc != nil {
-		return SignalReceipt{}, fmt.Errorf("loop %q is event-driven and cannot be interrupted by signal yet", l.config.Name)
+		return NotifyReceipt{}, fmt.Errorf("loop %q is event-driven and cannot be interrupted by notification yet", l.config.Name)
 	}
-	if len(l.pendingSignals) >= maxPendingSignals {
-		return SignalReceipt{}, fmt.Errorf("loop %q signal queue full (%d pending)", l.config.Name, len(l.pendingSignals))
+	if len(l.pendingNotifies) >= maxPendingNotifications {
+		return NotifyReceipt{}, fmt.Errorf("loop %q notify queue full (%d pending)", l.config.Name, len(l.pendingNotifies))
 	}
 
-	l.pendingSignals = append(l.pendingSignals, pendingSignal{
+	l.pendingNotifies = append(l.pendingNotifies, pendingNotify{
 		Envelope:        env,
 		ForceSupervisor: payload.ForceSupervisor,
 	})
-	receipt := SignalReceipt{
-		LoopID:          l.id,
-		LoopName:        l.config.Name,
-		State:           l.state,
-		ForceSupervisor: payload.ForceSupervisor,
-		PendingSignals:  len(l.pendingSignals),
+	receipt := NotifyReceipt{
+		LoopID:               l.id,
+		LoopName:             l.config.Name,
+		State:                l.state,
+		ForceSupervisor:      payload.ForceSupervisor,
+		PendingNotifications: len(l.pendingNotifies),
 	}
 	if l.state == StateSleeping {
 		select {
@@ -159,12 +159,12 @@ func (l *Loop) enqueueSignal(env messages.Envelope) (SignalReceipt, error) {
 	return receipt, nil
 }
 
-func (l *Loop) consumePendingSignals() ([]messages.Envelope, bool) {
+func (l *Loop) consumePendingNotifies() ([]messages.Envelope, bool) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
-	if len(l.pendingSignals) == 0 {
+	if len(l.pendingNotifies) == 0 {
 		// A concurrent wake can leave one coalesced token behind even after the
-		// corresponding signal was already consumed elsewhere; clear it so the
+		// corresponding notification was already consumed elsewhere; clear it so the
 		// next timer sleep is not interrupted spuriously.
 		select {
 		case <-l.wakeCh:
@@ -172,13 +172,13 @@ func (l *Loop) consumePendingSignals() ([]messages.Envelope, bool) {
 		}
 		return nil, false
 	}
-	envs := make([]messages.Envelope, 0, len(l.pendingSignals))
+	envs := make([]messages.Envelope, 0, len(l.pendingNotifies))
 	forceSupervisor := false
-	for _, sig := range l.pendingSignals {
+	for _, sig := range l.pendingNotifies {
 		envs = append(envs, sig.Envelope)
 		forceSupervisor = forceSupervisor || sig.ForceSupervisor
 	}
-	l.pendingSignals = nil
+	l.pendingNotifies = nil
 	select {
 	case <-l.wakeCh:
 	default:

--- a/internal/loop/signals_test.go
+++ b/internal/loop/signals_test.go
@@ -130,6 +130,44 @@ func TestLoopSignalRejectsEventDrivenLoop(t *testing.T) {
 	}
 }
 
+func TestLoopSignalQueueBounded(t *testing.T) {
+	t.Parallel()
+
+	l, err := New(Config{
+		Name: "queue-bounded",
+		Task: "watch",
+	}, Deps{Runner: &noopRunner{}})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	l.mu.Lock()
+	l.started = true
+	l.state = StateProcessing
+	l.mu.Unlock()
+
+	env, err := (messages.Envelope{
+		From: messages.Identity{Kind: messages.IdentityCore},
+		To: messages.Destination{
+			Kind:     messages.DestinationLoop,
+			Target:   l.Name(),
+			Selector: messages.SelectorName,
+		},
+		Type: messages.TypeSignal,
+	}).Normalize(time.Now())
+	if err != nil {
+		t.Fatalf("Normalize: %v", err)
+	}
+
+	for i := 0; i < maxPendingSignals; i++ {
+		if _, err := l.enqueueSignal(env); err != nil {
+			t.Fatalf("enqueueSignal(%d): %v", i, err)
+		}
+	}
+	if _, err := l.enqueueSignal(env); err == nil || !strings.Contains(err.Error(), "queue full") {
+		t.Fatalf("enqueueSignal overflow err = %v, want queue-full rejection", err)
+	}
+}
+
 func waitForLoopState(t *testing.T, l *Loop, want State) {
 	t.Helper()
 	deadline := time.Now().Add(2 * time.Second)

--- a/internal/loop/signals_test.go
+++ b/internal/loop/signals_test.go
@@ -1,0 +1,143 @@
+package loop
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nugget/thane-ai-agent/internal/messages"
+)
+
+func TestLoopSignalWakesSleepingLoopAndPrependsSignalContext(t *testing.T) {
+	t.Parallel()
+
+	reqs := make(chan RunRequest, 1)
+	runner := &inspectingRunner{
+		onRun: func(req RunRequest) {
+			reqs <- req
+		},
+	}
+	l, err := New(Config{
+		Name:         "signal-test",
+		Task:         "Maintain a current view.",
+		SleepMin:     time.Hour,
+		SleepMax:     time.Hour,
+		SleepDefault: time.Hour,
+		Jitter:       Float64Ptr(0),
+		MaxIter:      1,
+		Supervisor:   true,
+	}, Deps{Runner: runner, Rand: fixedRand{0}})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := l.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	waitForLoopState(t, l, StateSleeping)
+
+	env, err := (messages.Envelope{
+		From: messages.Identity{Kind: messages.IdentityCore, Name: "core"},
+		To: messages.Destination{
+			Kind:     messages.DestinationLoop,
+			Target:   l.Name(),
+			Selector: messages.SelectorName,
+		},
+		Type: messages.TypeSignal,
+		Payload: messages.LoopSignalPayload{
+			Message:         "The garage reading is CPU temperature, not ambient.",
+			ForceSupervisor: true,
+		},
+	}).Normalize(time.Now())
+	if err != nil {
+		t.Fatalf("Normalize: %v", err)
+	}
+
+	receipt, err := l.enqueueSignal(env)
+	if err != nil {
+		t.Fatalf("enqueueSignal: %v", err)
+	}
+	if !receipt.WokeImmediately {
+		t.Fatalf("receipt = %#v, want woke_immediately", receipt)
+	}
+
+	select {
+	case req := <-reqs:
+		if req.Hints["supervisor"] != "true" {
+			t.Fatalf("supervisor hint = %q, want true", req.Hints["supervisor"])
+		}
+		content := req.Messages[0].Content
+		if !strings.Contains(content, "Signal envelopes for this run:") {
+			t.Fatalf("task content missing signal prefix: %q", content)
+		}
+		if !strings.Contains(content, "garage reading is CPU temperature") {
+			t.Fatalf("task content missing signal message: %q", content)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("loop did not wake after signal")
+	}
+	l.Stop()
+
+	select {
+	case <-l.Done():
+	case <-time.After(2 * time.Second):
+		t.Fatal("loop did not finish")
+	}
+}
+
+func TestLoopSignalRejectsEventDrivenLoop(t *testing.T) {
+	t.Parallel()
+
+	waitCh := make(chan struct{})
+	l, err := New(Config{
+		Name: "event-driven",
+		WaitFunc: func(ctx context.Context) (any, error) {
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-waitCh:
+				return nil, nil
+			}
+		},
+		Task: "watch",
+	}, Deps{Runner: &noopRunner{}})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := l.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer l.Stop()
+
+	waitForLoopState(t, l, StateWaiting)
+
+	env, err := (messages.Envelope{
+		From: messages.Identity{Kind: messages.IdentityCore},
+		To: messages.Destination{
+			Kind:     messages.DestinationLoop,
+			Target:   l.Name(),
+			Selector: messages.SelectorName,
+		},
+		Type: messages.TypeSignal,
+	}).Normalize(time.Now())
+	if err != nil {
+		t.Fatalf("Normalize: %v", err)
+	}
+
+	if _, err := l.enqueueSignal(env); err == nil || !strings.Contains(err.Error(), "event-driven") {
+		t.Fatalf("enqueueSignal err = %v, want event-driven rejection", err)
+	}
+}
+
+func waitForLoopState(t *testing.T, l *Loop, want State) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if l.Status().State == want {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("state = %q, want %q", l.Status().State, want)
+}

--- a/internal/loop/signals_test.go
+++ b/internal/loop/signals_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/nugget/thane-ai-agent/internal/messages"
 )
 
-func TestLoopSignalWakesSleepingLoopAndPrependsSignalContext(t *testing.T) {
+func TestLoopNotifyWakesSleepingLoopAndPrependsSignalContext(t *testing.T) {
 	t.Parallel()
 
 	reqs := make(chan RunRequest, 1)
@@ -45,7 +45,7 @@ func TestLoopSignalWakesSleepingLoopAndPrependsSignalContext(t *testing.T) {
 			Selector: messages.SelectorName,
 		},
 		Type: messages.TypeSignal,
-		Payload: messages.LoopSignalPayload{
+		Payload: messages.LoopNotifyPayload{
 			Message:         "The garage reading is CPU temperature, not ambient.",
 			ForceSupervisor: true,
 		},
@@ -54,9 +54,9 @@ func TestLoopSignalWakesSleepingLoopAndPrependsSignalContext(t *testing.T) {
 		t.Fatalf("Normalize: %v", err)
 	}
 
-	receipt, err := l.enqueueSignal(env)
+	receipt, err := l.enqueueNotify(env)
 	if err != nil {
-		t.Fatalf("enqueueSignal: %v", err)
+		t.Fatalf("enqueueNotify: %v", err)
 	}
 	if !receipt.WokeImmediately {
 		t.Fatalf("receipt = %#v, want woke_immediately", receipt)
@@ -68,7 +68,7 @@ func TestLoopSignalWakesSleepingLoopAndPrependsSignalContext(t *testing.T) {
 			t.Fatalf("supervisor hint = %q, want true", req.Hints["supervisor"])
 		}
 		content := req.Messages[0].Content
-		if !strings.Contains(content, "Signal envelopes for this run:") {
+		if !strings.Contains(content, "Loop notifications for this run:") {
 			t.Fatalf("task content missing signal prefix: %q", content)
 		}
 		if !strings.Contains(content, "garage reading is CPU temperature") {
@@ -86,7 +86,7 @@ func TestLoopSignalWakesSleepingLoopAndPrependsSignalContext(t *testing.T) {
 	}
 }
 
-func TestLoopSignalRejectsEventDrivenLoop(t *testing.T) {
+func TestLoopNotifyRejectsEventDrivenLoop(t *testing.T) {
 	t.Parallel()
 
 	waitCh := make(chan struct{})
@@ -125,12 +125,12 @@ func TestLoopSignalRejectsEventDrivenLoop(t *testing.T) {
 		t.Fatalf("Normalize: %v", err)
 	}
 
-	if _, err := l.enqueueSignal(env); err == nil || !strings.Contains(err.Error(), "event-driven") {
-		t.Fatalf("enqueueSignal err = %v, want event-driven rejection", err)
+	if _, err := l.enqueueNotify(env); err == nil || !strings.Contains(err.Error(), "event-driven") {
+		t.Fatalf("enqueueNotify err = %v, want event-driven rejection", err)
 	}
 }
 
-func TestLoopSignalQueueBounded(t *testing.T) {
+func TestLoopNotifyQueueBounded(t *testing.T) {
 	t.Parallel()
 
 	l, err := New(Config{
@@ -158,13 +158,13 @@ func TestLoopSignalQueueBounded(t *testing.T) {
 		t.Fatalf("Normalize: %v", err)
 	}
 
-	for i := 0; i < maxPendingSignals; i++ {
-		if _, err := l.enqueueSignal(env); err != nil {
-			t.Fatalf("enqueueSignal(%d): %v", i, err)
+	for i := 0; i < maxPendingNotifications; i++ {
+		if _, err := l.enqueueNotify(env); err != nil {
+			t.Fatalf("enqueueNotify(%d): %v", i, err)
 		}
 	}
-	if _, err := l.enqueueSignal(env); err == nil || !strings.Contains(err.Error(), "queue full") {
-		t.Fatalf("enqueueSignal overflow err = %v, want queue-full rejection", err)
+	if _, err := l.enqueueNotify(env); err == nil || !strings.Contains(err.Error(), "queue full") {
+		t.Fatalf("enqueueNotify overflow err = %v, want queue-full rejection", err)
 	}
 }
 

--- a/internal/messages/bus.go
+++ b/internal/messages/bus.go
@@ -57,7 +57,11 @@ func loggingAuditFunc(logger *slog.Logger) AuditFunc {
 			logger.Warn("message envelope delivery failed", fields...)
 			return
 		}
-		logger.Info("message envelope delivered", fields...)
+		msg := "message envelope delivered"
+		if result != nil && result.Status == DeliveryQueued {
+			msg = "message envelope queued"
+		}
+		logger.Info(msg, fields...)
 	}
 }
 

--- a/internal/messages/bus.go
+++ b/internal/messages/bus.go
@@ -1,0 +1,126 @@
+package messages
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+)
+
+// DeliveryStatus describes the outcome of one routed envelope.
+type DeliveryStatus string
+
+const (
+	DeliveryDelivered DeliveryStatus = "delivered"
+	DeliveryQueued    DeliveryStatus = "queued"
+)
+
+// DeliveryResult summarizes one routed envelope.
+type DeliveryResult struct {
+	Envelope Envelope       `json:"envelope"`
+	Route    string         `json:"route"`
+	Status   DeliveryStatus `json:"status"`
+	Details  any            `json:"details,omitempty"`
+}
+
+// HandlerFunc delivers one normalized envelope for a destination kind.
+type HandlerFunc func(context.Context, Envelope) (DeliveryResult, error)
+
+// AuditFunc records attempted bus deliveries for later inspection.
+type AuditFunc func(context.Context, Envelope, *DeliveryResult, error)
+
+func loggingAuditFunc(logger *slog.Logger) AuditFunc {
+	return func(_ context.Context, env Envelope, result *DeliveryResult, err error) {
+		if logger == nil {
+			return
+		}
+		fields := []any{
+			"envelope_id", env.ID,
+			"type", env.Type,
+			"from_kind", env.From.Kind,
+			"from_name", env.From.Name,
+			"from_id", env.From.ID,
+			"to_kind", env.To.Kind,
+			"to_target", env.To.Target,
+			"to_selector", env.To.Selector,
+			"priority", env.Priority,
+		}
+		if result != nil {
+			fields = append(fields,
+				"route", result.Route,
+				"delivery_status", result.Status,
+			)
+		}
+		if err != nil {
+			fields = append(fields, "error", err)
+			logger.Warn("message envelope delivery failed", fields...)
+			return
+		}
+		logger.Info("message envelope delivered", fields...)
+	}
+}
+
+// Bus routes normalized envelopes to destination-specific handlers.
+type Bus struct {
+	mu       sync.RWMutex
+	handlers map[DestinationKind]HandlerFunc
+	logger   *slog.Logger
+	audit    AuditFunc
+	now      func() time.Time
+}
+
+// NewBus constructs a message bus with a logging-backed audit sink.
+func NewBus(logger *slog.Logger) *Bus {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Bus{
+		handlers: make(map[DestinationKind]HandlerFunc),
+		logger:   logger,
+		audit:    loggingAuditFunc(logger.With("component", "message_bus")),
+		now:      time.Now,
+	}
+}
+
+// RegisterRoute installs a destination-specific delivery handler.
+func (b *Bus) RegisterRoute(kind DestinationKind, handler HandlerFunc) {
+	if b == nil || handler == nil {
+		return
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.handlers[kind] = handler
+}
+
+// Send validates and routes one envelope.
+func (b *Bus) Send(ctx context.Context, env Envelope) (DeliveryResult, error) {
+	if b == nil {
+		return DeliveryResult{}, fmt.Errorf("message bus is not configured")
+	}
+	env, err := env.Normalize(b.now())
+	if err != nil {
+		return DeliveryResult{}, err
+	}
+
+	b.mu.RLock()
+	handler := b.handlers[env.To.Kind]
+	audit := b.audit
+	b.mu.RUnlock()
+	if handler == nil {
+		err := fmt.Errorf("no message route registered for destination kind %q", env.To.Kind)
+		if audit != nil {
+			audit(ctx, env, nil, err)
+		}
+		return DeliveryResult{}, err
+	}
+
+	result, err := handler(ctx, env)
+	if err == nil {
+		result.Envelope = env
+	}
+	if audit != nil {
+		audit(ctx, env, &result, err)
+	}
+	return result, err
+}

--- a/internal/messages/bus_test.go
+++ b/internal/messages/bus_test.go
@@ -1,0 +1,70 @@
+package messages
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+)
+
+type recordingHandler struct {
+	env Envelope
+}
+
+func (h *recordingHandler) Deliver(_ context.Context, env Envelope) (DeliveryResult, error) {
+	h.env = env
+	return DeliveryResult{
+		Route:  "test",
+		Status: DeliveryDelivered,
+	}, nil
+}
+
+func TestBusSendNormalizesAndRoutes(t *testing.T) {
+	t.Parallel()
+
+	bus := NewBus(slog.New(slog.NewTextHandler(io.Discard, nil)))
+	handler := &recordingHandler{}
+	bus.RegisterRoute(DestinationLoop, handler.Deliver)
+
+	result, err := bus.Send(context.Background(), Envelope{
+		From: Identity{Kind: IdentityCore, Name: "core"},
+		To: Destination{
+			Kind:   DestinationLoop,
+			Target: "battery-watch",
+		},
+		Type: TypeSignal,
+	})
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if result.Route != "test" || result.Status != DeliveryDelivered {
+		t.Fatalf("result = %#v", result)
+	}
+	if handler.env.ID == "" {
+		t.Fatal("normalized envelope id is empty")
+	}
+	if handler.env.CreatedAt.IsZero() {
+		t.Fatal("normalized envelope created_at is zero")
+	}
+	if handler.env.To.Selector != SelectorName {
+		t.Fatalf("selector = %q, want %q", handler.env.To.Selector, SelectorName)
+	}
+}
+
+func TestBusSendRejectsMissingRoute(t *testing.T) {
+	t.Parallel()
+
+	bus := NewBus(slog.New(slog.NewTextHandler(io.Discard, nil)))
+	_, err := bus.Send(context.Background(), Envelope{
+		From: Identity{Kind: IdentityCore},
+		To: Destination{
+			Kind:     DestinationLoop,
+			Target:   "battery-watch",
+			Selector: SelectorName,
+		},
+		Type: TypeSignal,
+	})
+	if err == nil || err.Error() == "" {
+		t.Fatal("expected missing-route error")
+	}
+}

--- a/internal/messages/bus_test.go
+++ b/internal/messages/bus_test.go
@@ -1,9 +1,11 @@
 package messages
 
 import (
+	"bytes"
 	"context"
 	"io"
 	"log/slog"
+	"strings"
 	"testing"
 )
 
@@ -66,5 +68,33 @@ func TestBusSendRejectsMissingRoute(t *testing.T) {
 	})
 	if err == nil || err.Error() == "" {
 		t.Fatal("expected missing-route error")
+	}
+}
+
+func TestLoggingAuditFuncUsesQueuedMessage(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, nil))
+	audit := loggingAuditFunc(logger)
+	env := Envelope{
+		ID:   "m_123",
+		Type: TypeSignal,
+		From: Identity{Kind: IdentityCore, Name: "conversation"},
+		To: Destination{
+			Kind:     DestinationLoop,
+			Target:   "battery-watch",
+			Selector: SelectorName,
+		},
+		Priority: PriorityNormal,
+	}
+	audit(context.Background(), env, &DeliveryResult{Route: "loop", Status: DeliveryQueued}, nil)
+
+	logged := buf.String()
+	if !strings.Contains(logged, "message envelope queued") {
+		t.Fatalf("log = %q, want queued message", logged)
+	}
+	if strings.Contains(logged, "message envelope delivered") {
+		t.Fatalf("log = %q, should not claim delivered", logged)
 	}
 }

--- a/internal/messages/doc.go
+++ b/internal/messages/doc.go
@@ -1,0 +1,6 @@
+// Package messages defines the shared envelope and delivery substrate for
+// inter-component communication inside Thane. It is intentionally narrower
+// than a full workflow layer: callers construct envelopes, the bus routes
+// them, and concrete delivery backends implement the destination-specific
+// behavior.
+package messages

--- a/internal/messages/envelope.go
+++ b/internal/messages/envelope.go
@@ -184,8 +184,8 @@ func (e Envelope) Normalize(now time.Time) (Envelope, error) {
 	return e, nil
 }
 
-// LoopSignalPayload is the first concrete signal payload shape.
-type LoopSignalPayload struct {
+// LoopNotifyPayload is the first concrete loop-notification payload shape.
+type LoopNotifyPayload struct {
 	Message         string `json:"message,omitempty"`
 	ForceSupervisor bool   `json:"force_supervisor,omitempty"`
 }

--- a/internal/messages/envelope.go
+++ b/internal/messages/envelope.go
@@ -135,6 +135,11 @@ func (e Envelope) Normalize(now time.Time) (Envelope, error) {
 	if e.From.Kind == "" {
 		return Envelope{}, fmt.Errorf("messages: from.kind is required")
 	}
+	switch e.From.Kind {
+	case IdentityCore, IdentityLoop, IdentityDelegate, IdentitySystem:
+	default:
+		return Envelope{}, fmt.Errorf("messages: unsupported identity kind %q", e.From.Kind)
+	}
 	if e.To.Kind == "" {
 		return Envelope{}, fmt.Errorf("messages: to.kind is required")
 	}

--- a/internal/messages/envelope.go
+++ b/internal/messages/envelope.go
@@ -138,9 +138,13 @@ func (e Envelope) Normalize(now time.Time) (Envelope, error) {
 	if e.To.Kind == "" {
 		return Envelope{}, fmt.Errorf("messages: to.kind is required")
 	}
-	if strings.TrimSpace(e.To.Target) == "" {
+	e.From.Name = strings.TrimSpace(e.From.Name)
+	e.From.ID = strings.TrimSpace(e.From.ID)
+	target := strings.TrimSpace(e.To.Target)
+	if target == "" {
 		return Envelope{}, fmt.Errorf("messages: to.target is required")
 	}
+	e.To.Target = target
 	switch e.To.Kind {
 	case DestinationLoop:
 		if e.To.Selector == "" {
@@ -170,6 +174,12 @@ func (e Envelope) Normalize(now time.Time) (Envelope, error) {
 	}
 	if len(e.Scope) > 0 {
 		e.Scope = append([]string(nil), e.Scope...)
+	}
+	if len(e.Signature) > 0 {
+		e.Signature = append([]byte(nil), e.Signature...)
+	}
+	if len(e.SignerCert) > 0 {
+		e.SignerCert = append([]byte(nil), e.SignerCert...)
 	}
 	return e, nil
 }

--- a/internal/messages/envelope.go
+++ b/internal/messages/envelope.go
@@ -1,0 +1,181 @@
+package messages
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// Type describes the delivery contract a message expects.
+type Type string
+
+const (
+	TypeRequest   Type = "request"
+	TypeReply     Type = "reply"
+	TypeSignal    Type = "signal"
+	TypeBroadcast Type = "broadcast"
+	TypeStatus    Type = "status"
+)
+
+// IdentityKind identifies the sender category.
+type IdentityKind string
+
+const (
+	IdentityCore     IdentityKind = "core"
+	IdentityLoop     IdentityKind = "loop"
+	IdentityDelegate IdentityKind = "delegate"
+	IdentitySystem   IdentityKind = "system"
+)
+
+// DestinationKind identifies how the bus should route the envelope.
+type DestinationKind string
+
+const (
+	DestinationLoop DestinationKind = "loop"
+)
+
+// Selector identifies how a destination target should be interpreted.
+type Selector string
+
+const (
+	SelectorName Selector = "name"
+	SelectorID   Selector = "id"
+)
+
+// Priority describes relative delivery urgency.
+type Priority string
+
+const (
+	PriorityLow    Priority = "low"
+	PriorityNormal Priority = "normal"
+	PriorityUrgent Priority = "urgent"
+)
+
+// Duration renders as a Go duration string instead of raw nanoseconds in JSON.
+type Duration time.Duration
+
+// IsZero reports whether the duration is unset.
+func (d Duration) IsZero() bool { return time.Duration(d) <= 0 }
+
+// Std returns the underlying time.Duration.
+func (d Duration) Std() time.Duration { return time.Duration(d) }
+
+// MarshalJSON renders the duration as a string.
+func (d Duration) MarshalJSON() ([]byte, error) {
+	return json.Marshal(time.Duration(d).String())
+}
+
+// UnmarshalJSON accepts a Go duration string.
+func (d *Duration) UnmarshalJSON(raw []byte) error {
+	if d == nil {
+		return fmt.Errorf("messages: nil duration")
+	}
+	var s string
+	if err := json.Unmarshal(raw, &s); err != nil {
+		return fmt.Errorf("messages: duration must be a string: %w", err)
+	}
+	if strings.TrimSpace(s) == "" {
+		*d = 0
+		return nil
+	}
+	parsed, err := time.ParseDuration(s)
+	if err != nil {
+		return fmt.Errorf("messages: invalid duration %q: %w", s, err)
+	}
+	*d = Duration(parsed)
+	return nil
+}
+
+// Identity identifies the sender of an envelope.
+type Identity struct {
+	Kind IdentityKind `json:"kind"`
+	Name string       `json:"name,omitempty"`
+	ID   string       `json:"id,omitempty"`
+}
+
+// Destination identifies where an envelope should be delivered.
+type Destination struct {
+	Kind     DestinationKind `json:"kind"`
+	Target   string          `json:"target,omitempty"`
+	Selector Selector        `json:"selector,omitempty"`
+}
+
+// Envelope is the shared inter-component message primitive.
+type Envelope struct {
+	ID        string       `json:"id"`
+	CreatedAt time.Time    `json:"created_at"`
+	From      Identity     `json:"from"`
+	To        Destination  `json:"to"`
+	Type      Type         `json:"type"`
+	Payload   any          `json:"payload,omitempty"`
+	ReplyTo   *Destination `json:"reply_to,omitempty"`
+	TTL       Duration     `json:"ttl,omitempty"`
+	Priority  Priority     `json:"priority,omitempty"`
+	Scope     []string     `json:"scope,omitempty"`
+
+	// Cryptographic fields are intentionally present now; signing is wired by #697.
+	Signature  []byte `json:"signature,omitempty"`
+	SignerCert []byte `json:"signer_cert,omitempty"`
+	ChainDepth int    `json:"chain_depth,omitempty"`
+}
+
+// Normalize validates the envelope and fills default ID/timestamps.
+func (e Envelope) Normalize(now time.Time) (Envelope, error) {
+	if e.Type == "" {
+		return Envelope{}, fmt.Errorf("messages: type is required")
+	}
+	switch e.Type {
+	case TypeRequest, TypeReply, TypeSignal, TypeBroadcast, TypeStatus:
+	default:
+		return Envelope{}, fmt.Errorf("messages: unsupported type %q", e.Type)
+	}
+	if e.From.Kind == "" {
+		return Envelope{}, fmt.Errorf("messages: from.kind is required")
+	}
+	if e.To.Kind == "" {
+		return Envelope{}, fmt.Errorf("messages: to.kind is required")
+	}
+	if strings.TrimSpace(e.To.Target) == "" {
+		return Envelope{}, fmt.Errorf("messages: to.target is required")
+	}
+	switch e.To.Kind {
+	case DestinationLoop:
+		if e.To.Selector == "" {
+			e.To.Selector = SelectorName
+		}
+		if e.To.Selector != SelectorName && e.To.Selector != SelectorID {
+			return Envelope{}, fmt.Errorf("messages: unsupported loop selector %q", e.To.Selector)
+		}
+	default:
+		return Envelope{}, fmt.Errorf("messages: unsupported destination kind %q", e.To.Kind)
+	}
+	if e.ID == "" {
+		id, err := uuid.NewV7()
+		if err != nil {
+			return Envelope{}, fmt.Errorf("messages: generate id: %w", err)
+		}
+		e.ID = id.String()
+	}
+	if e.CreatedAt.IsZero() {
+		e.CreatedAt = now.UTC()
+	}
+	if e.Priority == "" {
+		e.Priority = PriorityNormal
+	}
+	if e.TTL.Std() < 0 {
+		return Envelope{}, fmt.Errorf("messages: ttl must be non-negative")
+	}
+	if len(e.Scope) > 0 {
+		e.Scope = append([]string(nil), e.Scope...)
+	}
+	return e, nil
+}
+
+// LoopSignalPayload is the first concrete signal payload shape.
+type LoopSignalPayload struct {
+	Message         string `json:"message,omitempty"`
+	ForceSupervisor bool   `json:"force_supervisor,omitempty"`
+}

--- a/internal/messages/envelope_test.go
+++ b/internal/messages/envelope_test.go
@@ -1,6 +1,7 @@
 package messages
 
 import (
+	"strings"
 	"testing"
 	"time"
 )
@@ -35,5 +36,21 @@ func TestEnvelopeNormalizeTrimsTargetAndClonesBinaryFields(t *testing.T) {
 	}
 	if got.SignerCert[0] != 4 {
 		t.Fatalf("signer_cert = %v, want cloned data", got.SignerCert)
+	}
+}
+
+func TestEnvelopeNormalizeRejectsUnsupportedIdentityKind(t *testing.T) {
+	t.Parallel()
+
+	_, err := (Envelope{
+		From: Identity{Kind: IdentityKind("typo")},
+		To: Destination{
+			Kind:   DestinationLoop,
+			Target: "battery-watch",
+		},
+		Type: TypeSignal,
+	}).Normalize(time.Now())
+	if err == nil || !strings.Contains(err.Error(), "unsupported identity kind") {
+		t.Fatalf("Normalize err = %v, want unsupported identity kind", err)
 	}
 }

--- a/internal/messages/envelope_test.go
+++ b/internal/messages/envelope_test.go
@@ -1,0 +1,39 @@
+package messages
+
+import (
+	"testing"
+	"time"
+)
+
+func TestEnvelopeNormalizeTrimsTargetAndClonesBinaryFields(t *testing.T) {
+	t.Parallel()
+
+	sig := []byte{1, 2, 3}
+	cert := []byte{4, 5, 6}
+	got, err := (Envelope{
+		From: Identity{Kind: IdentityCore, Name: " core "},
+		To: Destination{
+			Kind:   DestinationLoop,
+			Target: "  battery-watch  ",
+		},
+		Type:       TypeSignal,
+		Signature:  sig,
+		SignerCert: cert,
+	}).Normalize(time.Now())
+	if err != nil {
+		t.Fatalf("Normalize: %v", err)
+	}
+
+	sig[0] = 9
+	cert[0] = 9
+
+	if got.To.Target != "battery-watch" {
+		t.Fatalf("target = %q, want trimmed target", got.To.Target)
+	}
+	if got.Signature[0] != 1 {
+		t.Fatalf("signature = %v, want cloned data", got.Signature)
+	}
+	if got.SignerCert[0] != 4 {
+		t.Fatalf("signer_cert = %v, want cloned data", got.SignerCert)
+	}
+}

--- a/internal/messages/loop_handler.go
+++ b/internal/messages/loop_handler.go
@@ -5,25 +5,25 @@ import (
 	"fmt"
 )
 
-// LoopSignalByID delivers one signal envelope to a live loop identified by ID.
-type LoopSignalByID func(context.Context, string, Envelope) (DeliveryResult, error)
+// LoopNotifyByID delivers one notification envelope to a live loop identified by ID.
+type LoopNotifyByID func(context.Context, string, Envelope) (DeliveryResult, error)
 
-// LoopSignalByName delivers one signal envelope to a live loop identified by exact name.
-type LoopSignalByName func(context.Context, string, Envelope) (DeliveryResult, error)
+// LoopNotifyByName delivers one notification envelope to a live loop identified by exact name.
+type LoopNotifyByName func(context.Context, string, Envelope) (DeliveryResult, error)
 
 // LoopHandler routes loop-destination envelopes into the live loop registry.
 type LoopHandler struct {
-	ByID   LoopSignalByID
-	ByName LoopSignalByName
+	ByID   LoopNotifyByID
+	ByName LoopNotifyByName
 }
 
-// Deliver sends one signal envelope to a live loop.
+// Deliver sends one notification envelope to a live loop.
 func (h *LoopHandler) Deliver(ctx context.Context, env Envelope) (DeliveryResult, error) {
 	if h == nil || (h.ByID == nil && h.ByName == nil) {
 		return DeliveryResult{}, fmt.Errorf("loop message route is not configured")
 	}
 	if env.Type != TypeSignal {
-		return DeliveryResult{}, fmt.Errorf("loop route only supports signal envelopes for live loops, got %q", env.Type)
+		return DeliveryResult{}, fmt.Errorf("loop route only supports loop notifications (signal envelopes), got %q", env.Type)
 	}
 
 	var (

--- a/internal/messages/loop_handler.go
+++ b/internal/messages/loop_handler.go
@@ -5,10 +5,12 @@ import (
 	"fmt"
 )
 
-// LoopNotifyByID delivers one notification envelope to a live loop identified by ID.
+// LoopNotifyByID delivers one inter-loop process notification to a live loop
+// identified by ID.
 type LoopNotifyByID func(context.Context, string, Envelope) (DeliveryResult, error)
 
-// LoopNotifyByName delivers one notification envelope to a live loop identified by exact name.
+// LoopNotifyByName delivers one inter-loop process notification to a live loop
+// identified by exact name.
 type LoopNotifyByName func(context.Context, string, Envelope) (DeliveryResult, error)
 
 // LoopHandler routes loop-destination envelopes into the live loop registry.
@@ -17,13 +19,13 @@ type LoopHandler struct {
 	ByName LoopNotifyByName
 }
 
-// Deliver sends one notification envelope to a live loop.
+// Deliver sends one inter-loop process notification to a live loop.
 func (h *LoopHandler) Deliver(ctx context.Context, env Envelope) (DeliveryResult, error) {
 	if h == nil || (h.ByID == nil && h.ByName == nil) {
 		return DeliveryResult{}, fmt.Errorf("loop message route is not configured")
 	}
 	if env.Type != TypeSignal {
-		return DeliveryResult{}, fmt.Errorf("loop route only supports loop notifications (signal envelopes), got %q", env.Type)
+		return DeliveryResult{}, fmt.Errorf("loop route only supports inter-loop notifications (signal envelopes), got %q", env.Type)
 	}
 
 	var (

--- a/internal/messages/loop_handler.go
+++ b/internal/messages/loop_handler.go
@@ -1,0 +1,58 @@
+package messages
+
+import (
+	"context"
+	"fmt"
+)
+
+// LoopSignalByID delivers one signal envelope to a live loop identified by ID.
+type LoopSignalByID func(context.Context, string, Envelope) (any, error)
+
+// LoopSignalByName delivers one signal envelope to a live loop identified by exact name.
+type LoopSignalByName func(context.Context, string, Envelope) (any, error)
+
+// LoopHandler routes loop-destination envelopes into the live loop registry.
+type LoopHandler struct {
+	ByID   LoopSignalByID
+	ByName LoopSignalByName
+}
+
+// Deliver sends one signal envelope to a live loop.
+func (h *LoopHandler) Deliver(ctx context.Context, env Envelope) (DeliveryResult, error) {
+	if h == nil || (h.ByID == nil && h.ByName == nil) {
+		return DeliveryResult{}, fmt.Errorf("loop message route is not configured")
+	}
+	if env.Type != TypeSignal {
+		return DeliveryResult{}, fmt.Errorf("loop route only supports signal envelopes, got %q", env.Type)
+	}
+
+	var (
+		details any
+		err     error
+	)
+	switch env.To.Selector {
+	case SelectorID:
+		if h.ByID == nil {
+			err = fmt.Errorf("loop-id signaling is not configured")
+			break
+		}
+		details, err = h.ByID(ctx, env.To.Target, env)
+	case "", SelectorName:
+		if h.ByName == nil {
+			err = fmt.Errorf("loop-name signaling is not configured")
+			break
+		}
+		details, err = h.ByName(ctx, env.To.Target, env)
+	default:
+		err = fmt.Errorf("unsupported loop selector %q", env.To.Selector)
+	}
+	if err != nil {
+		return DeliveryResult{}, err
+	}
+	status := DeliveryDelivered
+	return DeliveryResult{
+		Route:   "loop",
+		Status:  status,
+		Details: details,
+	}, nil
+}

--- a/internal/messages/loop_handler.go
+++ b/internal/messages/loop_handler.go
@@ -6,10 +6,10 @@ import (
 )
 
 // LoopSignalByID delivers one signal envelope to a live loop identified by ID.
-type LoopSignalByID func(context.Context, string, Envelope) (any, error)
+type LoopSignalByID func(context.Context, string, Envelope) (DeliveryResult, error)
 
 // LoopSignalByName delivers one signal envelope to a live loop identified by exact name.
-type LoopSignalByName func(context.Context, string, Envelope) (any, error)
+type LoopSignalByName func(context.Context, string, Envelope) (DeliveryResult, error)
 
 // LoopHandler routes loop-destination envelopes into the live loop registry.
 type LoopHandler struct {
@@ -23,12 +23,12 @@ func (h *LoopHandler) Deliver(ctx context.Context, env Envelope) (DeliveryResult
 		return DeliveryResult{}, fmt.Errorf("loop message route is not configured")
 	}
 	if env.Type != TypeSignal {
-		return DeliveryResult{}, fmt.Errorf("loop route only supports signal envelopes, got %q", env.Type)
+		return DeliveryResult{}, fmt.Errorf("loop route only supports signal envelopes for live loops, got %q", env.Type)
 	}
 
 	var (
-		details any
-		err     error
+		result DeliveryResult
+		err    error
 	)
 	switch env.To.Selector {
 	case SelectorID:
@@ -36,23 +36,24 @@ func (h *LoopHandler) Deliver(ctx context.Context, env Envelope) (DeliveryResult
 			err = fmt.Errorf("loop-id signaling is not configured")
 			break
 		}
-		details, err = h.ByID(ctx, env.To.Target, env)
+		result, err = h.ByID(ctx, env.To.Target, env)
 	case "", SelectorName:
 		if h.ByName == nil {
 			err = fmt.Errorf("loop-name signaling is not configured")
 			break
 		}
-		details, err = h.ByName(ctx, env.To.Target, env)
+		result, err = h.ByName(ctx, env.To.Target, env)
 	default:
 		err = fmt.Errorf("unsupported loop selector %q", env.To.Selector)
 	}
 	if err != nil {
 		return DeliveryResult{}, err
 	}
-	status := DeliveryDelivered
-	return DeliveryResult{
-		Route:   "loop",
-		Status:  status,
-		Details: details,
-	}, nil
+	if result.Route == "" {
+		result.Route = "loop"
+	}
+	if result.Status == "" {
+		result.Status = DeliveryDelivered
+	}
+	return result, nil
 }

--- a/internal/messages/loop_handler_test.go
+++ b/internal/messages/loop_handler_test.go
@@ -1,0 +1,43 @@
+package messages
+
+import (
+	"context"
+	"testing"
+)
+
+func TestLoopHandlerDeliverPreservesQueuedStatus(t *testing.T) {
+	t.Parallel()
+
+	handler := &LoopHandler{
+		ByName: func(_ context.Context, target string, env Envelope) (DeliveryResult, error) {
+			if target != "battery-watch" {
+				t.Fatalf("target = %q", target)
+			}
+			if env.Type != TypeSignal {
+				t.Fatalf("type = %q", env.Type)
+			}
+			return DeliveryResult{
+				Status:  DeliveryQueued,
+				Details: map[string]any{"queued": true},
+			}, nil
+		},
+	}
+
+	got, err := handler.Deliver(context.Background(), Envelope{
+		To: Destination{
+			Kind:     DestinationLoop,
+			Target:   "battery-watch",
+			Selector: SelectorName,
+		},
+		Type: TypeSignal,
+	})
+	if err != nil {
+		t.Fatalf("Deliver: %v", err)
+	}
+	if got.Status != DeliveryQueued {
+		t.Fatalf("status = %q, want %q", got.Status, DeliveryQueued)
+	}
+	if got.Route != "loop" {
+		t.Fatalf("route = %q, want loop", got.Route)
+	}
+}

--- a/internal/toolcatalog/catalog.go
+++ b/internal/toolcatalog/catalog.go
@@ -319,7 +319,7 @@ var builtinToolSpecs = map[string]BuiltinToolSpec{
 	"loop_definition_summary":     {CanonicalID: "native:loop_definition_summary", Source: NativeToolSource, DefaultTags: []string{"loops"}},
 	"spawn_loop":                  {CanonicalID: "native:spawn_loop", Source: NativeToolSource, DefaultTags: []string{"loops"}},
 	"stop_loop":                   {CanonicalID: "native:stop_loop", Source: NativeToolSource, DefaultTags: []string{"loops"}},
-	"signal_loop":                 {CanonicalID: "native:signal_loop", Source: NativeToolSource, DefaultTags: []string{"loops"}},
+	"notify_loop":                 {CanonicalID: "native:notify_loop", Source: NativeToolSource, DefaultTags: []string{"loops"}},
 	"macos_calendar_events":       {CanonicalID: "native:macos_calendar_events", Source: NativeToolSource, DefaultTags: []string{"platform"}},
 	"media_feeds":                 {CanonicalID: "native:media_feeds", Source: NativeToolSource, DefaultTags: []string{"feeds"}},
 	"media_follow":                {CanonicalID: "native:media_follow", Source: NativeToolSource, DefaultTags: []string{"feeds"}},

--- a/internal/toolcatalog/catalog.go
+++ b/internal/toolcatalog/catalog.go
@@ -319,6 +319,7 @@ var builtinToolSpecs = map[string]BuiltinToolSpec{
 	"loop_definition_summary":     {CanonicalID: "native:loop_definition_summary", Source: NativeToolSource, DefaultTags: []string{"loops"}},
 	"spawn_loop":                  {CanonicalID: "native:spawn_loop", Source: NativeToolSource, DefaultTags: []string{"loops"}},
 	"stop_loop":                   {CanonicalID: "native:stop_loop", Source: NativeToolSource, DefaultTags: []string{"loops"}},
+	"signal_loop":                 {CanonicalID: "native:signal_loop", Source: NativeToolSource, DefaultTags: []string{"loops"}},
 	"macos_calendar_events":       {CanonicalID: "native:macos_calendar_events", Source: NativeToolSource, DefaultTags: []string{"platform"}},
 	"media_feeds":                 {CanonicalID: "native:media_feeds", Source: NativeToolSource, DefaultTags: []string{"feeds"}},
 	"media_follow":                {CanonicalID: "native:media_follow", Source: NativeToolSource, DefaultTags: []string{"feeds"}},

--- a/internal/tools/message_tools.go
+++ b/internal/tools/message_tools.go
@@ -32,6 +32,10 @@ func (r *Registry) registerMessageTools() {
 			"if it is already processing, the signal is queued for the next iteration.",
 		Parameters: map[string]any{
 			"type": "object",
+			"anyOf": []any{
+				map[string]any{"required": []string{"loop_id"}},
+				map[string]any{"required": []string{"name"}},
+			},
 			"properties": map[string]any{
 				"loop_id": map[string]any{
 					"type":        "string",
@@ -114,6 +118,9 @@ func senderIdentityFromContext(ctx context.Context) messages.Identity {
 	case source == "delegate":
 		return messages.Identity{Kind: messages.IdentityDelegate, Name: source}
 	default:
+		if source == "" {
+			source = "conversation"
+		}
 		return messages.Identity{Kind: messages.IdentityCore, Name: source}
 	}
 }

--- a/internal/tools/message_tools.go
+++ b/internal/tools/message_tools.go
@@ -25,11 +25,11 @@ func (r *Registry) registerMessageTools() {
 		return
 	}
 	r.Register(&Tool{
-		Name: "signal_loop",
-		Description: "Send a one-shot signal envelope to a live timer-driven loop. " +
+		Name: "notify_loop",
+		Description: "Send a one-shot message envelope to a live timer-driven loop. " +
 			"Use this to tap a sleeping watcher with fresh context or force the next iteration " +
 			"to run in supervisor mode. If the loop is currently sleeping, it wakes immediately; " +
-			"if it is already processing, the signal is queued for the next iteration.",
+			"if it is already processing, the message is queued for the next iteration.",
 		Parameters: map[string]any{
 			"type": "object",
 			"anyOf": []any{
@@ -60,11 +60,11 @@ func (r *Registry) registerMessageTools() {
 				},
 			},
 		},
-		Handler: r.handleSignalLoop,
+		Handler: r.handleNotifyLoop,
 	})
 }
 
-func (r *Registry) handleSignalLoop(ctx context.Context, args map[string]any) (string, error) {
+func (r *Registry) handleNotifyLoop(ctx context.Context, args map[string]any) (string, error) {
 	if r.messageBus == nil {
 		return "", fmt.Errorf("message bus is not configured")
 	}
@@ -84,7 +84,7 @@ func (r *Registry) handleSignalLoop(ctx context.Context, args map[string]any) (s
 		destination.Selector = messages.SelectorName
 	}
 
-	payload := messages.LoopSignalPayload{
+	payload := messages.LoopNotifyPayload{
 		Message:         strings.TrimSpace(ldStringArg(args, "message")),
 		ForceSupervisor: boolArg(args, "force_supervisor"),
 	}

--- a/internal/tools/message_tools.go
+++ b/internal/tools/message_tools.go
@@ -1,0 +1,132 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/nugget/thane-ai-agent/internal/messages"
+)
+
+// MessageToolDeps wires the shared envelope bus into the tool registry.
+type MessageToolDeps struct {
+	Bus *messages.Bus
+}
+
+// ConfigureMessageTools registers thin envelope-construction tools over the
+// shared message bus.
+func (r *Registry) ConfigureMessageTools(deps MessageToolDeps) {
+	r.messageBus = deps.Bus
+	r.registerMessageTools()
+}
+
+func (r *Registry) registerMessageTools() {
+	if r.messageBus == nil {
+		return
+	}
+	r.Register(&Tool{
+		Name: "signal_loop",
+		Description: "Send a one-shot signal envelope to a live timer-driven loop. " +
+			"Use this to tap a sleeping watcher with fresh context or force the next iteration " +
+			"to run in supervisor mode. If the loop is currently sleeping, it wakes immediately; " +
+			"if it is already processing, the signal is queued for the next iteration.",
+		Parameters: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"loop_id": map[string]any{
+					"type":        "string",
+					"description": "Exact live loop ID to signal. Preferred when available from loop_status.",
+				},
+				"name": map[string]any{
+					"type":        "string",
+					"description": "Exact live loop name to signal when loop_id is not known.",
+				},
+				"message": map[string]any{
+					"type":        "string",
+					"description": "Optional one-shot context message delivered only to the next loop iteration.",
+				},
+				"force_supervisor": map[string]any{
+					"type":        "boolean",
+					"description": "When true, force the next triggered iteration to run in supervisor mode.",
+				},
+				"priority": map[string]any{
+					"type":        "string",
+					"enum":        []string{"low", "normal", "urgent"},
+					"description": "Optional delivery priority recorded in the envelope audit trail.",
+				},
+			},
+		},
+		Handler: r.handleSignalLoop,
+	})
+}
+
+func (r *Registry) handleSignalLoop(ctx context.Context, args map[string]any) (string, error) {
+	if r.messageBus == nil {
+		return "", fmt.Errorf("message bus is not configured")
+	}
+	loopID := strings.TrimSpace(ldStringArg(args, "loop_id"))
+	name := strings.TrimSpace(ldStringArg(args, "name"))
+	if loopID == "" && name == "" {
+		return "", fmt.Errorf("loop_id or name is required")
+	}
+
+	destination := messages.Destination{Kind: messages.DestinationLoop}
+	switch {
+	case loopID != "":
+		destination.Target = loopID
+		destination.Selector = messages.SelectorID
+	default:
+		destination.Target = name
+		destination.Selector = messages.SelectorName
+	}
+
+	payload := messages.LoopSignalPayload{
+		Message:         strings.TrimSpace(ldStringArg(args, "message")),
+		ForceSupervisor: boolArg(args, "force_supervisor"),
+	}
+
+	env := messages.Envelope{
+		From:     senderIdentityFromContext(ctx),
+		To:       destination,
+		Type:     messages.TypeSignal,
+		Payload:  payload,
+		Priority: messagePriorityArg(args),
+	}
+
+	result, err := r.messageBus.Send(ctx, env)
+	if err != nil {
+		return "", err
+	}
+	return ldMarshalToolJSON(map[string]any{
+		"status":   "ok",
+		"delivery": result,
+	})
+}
+
+func senderIdentityFromContext(ctx context.Context) messages.Identity {
+	hints := HintsFromContext(ctx)
+	source := strings.TrimSpace(hints["source"])
+	loopID := strings.TrimSpace(LoopIDFromContext(ctx))
+	loopName := strings.TrimSpace(hints["loop_name"])
+	switch {
+	case loopID != "":
+		return messages.Identity{Kind: messages.IdentityLoop, ID: loopID, Name: loopName}
+	case source == "delegate":
+		return messages.Identity{Kind: messages.IdentityDelegate, Name: source}
+	default:
+		return messages.Identity{Kind: messages.IdentityCore, Name: source}
+	}
+}
+
+func messagePriorityArg(args map[string]any) messages.Priority {
+	switch strings.TrimSpace(ldStringArg(args, "priority")) {
+	case "", "normal":
+		return messages.PriorityNormal
+	case "low":
+		return messages.PriorityLow
+	case "urgent":
+		return messages.PriorityUrgent
+	default:
+		return messages.PriorityNormal
+	}
+}

--- a/internal/tools/message_tools_test.go
+++ b/internal/tools/message_tools_test.go
@@ -23,7 +23,7 @@ func (h *recordingMessageHandler) Deliver(_ context.Context, env messages.Envelo
 	}, nil
 }
 
-func TestConfigureMessageToolsRegistersSignalLoop(t *testing.T) {
+func TestConfigureMessageToolsRegistersNotifyLoop(t *testing.T) {
 	t.Parallel()
 
 	bus := messages.NewBus(slog.New(slog.NewTextHandler(io.Discard, nil)))
@@ -33,12 +33,12 @@ func TestConfigureMessageToolsRegistersSignalLoop(t *testing.T) {
 	reg := NewEmptyRegistry()
 	reg.ConfigureMessageTools(MessageToolDeps{Bus: bus})
 
-	tool := reg.Get("signal_loop")
+	tool := reg.Get("notify_loop")
 	if tool == nil {
-		t.Fatal("signal_loop tool not registered")
+		t.Fatal("notify_loop tool not registered")
 	}
 	if _, ok := tool.Parameters["anyOf"]; !ok {
-		t.Fatal("signal_loop schema missing anyOf guardrail")
+		t.Fatal("notify_loop schema missing anyOf guardrail")
 	}
 
 	ctx := WithLoopID(context.Background(), "loop-parent-1")
@@ -53,7 +53,7 @@ func TestConfigureMessageToolsRegistersSignalLoop(t *testing.T) {
 		"priority":         "urgent",
 	})
 	if err != nil {
-		t.Fatalf("signal_loop: %v", err)
+		t.Fatalf("notify_loop: %v", err)
 	}
 
 	if handler.env.From.Kind != messages.IdentityLoop || handler.env.From.ID != "loop-parent-1" {
@@ -96,11 +96,11 @@ func TestSenderIdentityFromContextDefaultsToConversation(t *testing.T) {
 	}
 }
 
-func messagesPayload(raw any) (messages.LoopSignalPayload, error) {
+func messagesPayload(raw any) (messages.LoopNotifyPayload, error) {
 	switch got := raw.(type) {
-	case messages.LoopSignalPayload:
+	case messages.LoopNotifyPayload:
 		return got, nil
 	default:
-		return messages.LoopSignalPayload{}, fmt.Errorf("unexpected payload type %T", raw)
+		return messages.LoopNotifyPayload{}, fmt.Errorf("unexpected payload type %T", raw)
 	}
 }

--- a/internal/tools/message_tools_test.go
+++ b/internal/tools/message_tools_test.go
@@ -37,6 +37,9 @@ func TestConfigureMessageToolsRegistersSignalLoop(t *testing.T) {
 	if tool == nil {
 		t.Fatal("signal_loop tool not registered")
 	}
+	if _, ok := tool.Parameters["anyOf"]; !ok {
+		t.Fatal("signal_loop schema missing anyOf guardrail")
+	}
 
 	ctx := WithLoopID(context.Background(), "loop-parent-1")
 	ctx = WithHints(ctx, map[string]string{
@@ -78,6 +81,18 @@ func TestConfigureMessageToolsRegistersSignalLoop(t *testing.T) {
 	}
 	if got.Status != "ok" {
 		t.Fatalf("status = %q, want ok", got.Status)
+	}
+}
+
+func TestSenderIdentityFromContextDefaultsToConversation(t *testing.T) {
+	t.Parallel()
+
+	got := senderIdentityFromContext(context.Background())
+	if got.Kind != messages.IdentityCore {
+		t.Fatalf("kind = %q, want core", got.Kind)
+	}
+	if got.Name != "conversation" {
+		t.Fatalf("name = %q, want conversation", got.Name)
 	}
 }
 

--- a/internal/tools/message_tools_test.go
+++ b/internal/tools/message_tools_test.go
@@ -1,0 +1,91 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/nugget/thane-ai-agent/internal/messages"
+)
+
+type recordingMessageHandler struct {
+	env messages.Envelope
+}
+
+func (h *recordingMessageHandler) Deliver(_ context.Context, env messages.Envelope) (messages.DeliveryResult, error) {
+	h.env = env
+	return messages.DeliveryResult{
+		Route:  "loop",
+		Status: messages.DeliveryDelivered,
+	}, nil
+}
+
+func TestConfigureMessageToolsRegistersSignalLoop(t *testing.T) {
+	t.Parallel()
+
+	bus := messages.NewBus(slog.New(slog.NewTextHandler(io.Discard, nil)))
+	handler := &recordingMessageHandler{}
+	bus.RegisterRoute(messages.DestinationLoop, handler.Deliver)
+
+	reg := NewEmptyRegistry()
+	reg.ConfigureMessageTools(MessageToolDeps{Bus: bus})
+
+	tool := reg.Get("signal_loop")
+	if tool == nil {
+		t.Fatal("signal_loop tool not registered")
+	}
+
+	ctx := WithLoopID(context.Background(), "loop-parent-1")
+	ctx = WithHints(ctx, map[string]string{
+		"source":    "loop",
+		"loop_name": "metacognitive",
+	})
+	out, err := tool.Handler(ctx, map[string]any{
+		"name":             "battery-watch",
+		"message":          "Fresh context for the next iteration.",
+		"force_supervisor": true,
+		"priority":         "urgent",
+	})
+	if err != nil {
+		t.Fatalf("signal_loop: %v", err)
+	}
+
+	if handler.env.From.Kind != messages.IdentityLoop || handler.env.From.ID != "loop-parent-1" {
+		t.Fatalf("from = %#v, want loop identity", handler.env.From)
+	}
+	if handler.env.To.Kind != messages.DestinationLoop || handler.env.To.Target != "battery-watch" || handler.env.To.Selector != messages.SelectorName {
+		t.Fatalf("to = %#v", handler.env.To)
+	}
+	payload, err := messagesPayload(handler.env.Payload)
+	if err != nil {
+		t.Fatalf("messagesPayload: %v", err)
+	}
+	if payload.Message != "Fresh context for the next iteration." || !payload.ForceSupervisor {
+		t.Fatalf("payload = %#v", payload)
+	}
+	if handler.env.Priority != messages.PriorityUrgent {
+		t.Fatalf("priority = %q, want urgent", handler.env.Priority)
+	}
+
+	var got struct {
+		Status string `json:"status"`
+	}
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got.Status != "ok" {
+		t.Fatalf("status = %q, want ok", got.Status)
+	}
+}
+
+func messagesPayload(raw any) (messages.LoopSignalPayload, error) {
+	switch got := raw.(type) {
+	case messages.LoopSignalPayload:
+		return got, nil
+	default:
+		return messages.LoopSignalPayload{}, fmt.Errorf("unexpected payload type %T", raw)
+	}
+}

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -20,6 +20,7 @@ import (
 	"github.com/nugget/thane-ai-agent/internal/knowledge"
 	looppkg "github.com/nugget/thane-ai-agent/internal/loop"
 	"github.com/nugget/thane-ai-agent/internal/media"
+	"github.com/nugget/thane-ai-agent/internal/messages"
 	"github.com/nugget/thane-ai-agent/internal/models"
 	"github.com/nugget/thane-ai-agent/internal/notifications"
 	routepkg "github.com/nugget/thane-ai-agent/internal/router"
@@ -86,6 +87,7 @@ type Registry struct {
 	launchLoopDefinition                       func(context.Context, string, looppkg.Launch) (looppkg.LaunchResult, error)
 	liveLoopRegistry                           *looppkg.Registry
 	launchLoop                                 func(context.Context, looppkg.Launch) (looppkg.LaunchResult, error)
+	messageBus                                 *messages.Bus
 
 	contentResolver *ContentResolver
 }

--- a/scripts/architecture.baseline
+++ b/scripts/architecture.baseline
@@ -1,4 +1,4 @@
-packages=49
+packages=50
 interfaces=71
 large_files=30
 set_mutators=105

--- a/talents/loops-doctrine.md
+++ b/talents/loops-doctrine.md
@@ -25,11 +25,20 @@ now:
 - `loop_status`
 - `spawn_loop`
 - `stop_loop`
+- `signal_loop`
 
 `spawn_loop` is for ad hoc work that should start immediately without
 first becoming part of the persistent loop-definition registry. Reach
 for it when the loop is temporary, experimental, or tightly tied to the
 current moment.
+
+`signal_loop` is for an already-running timer-driven loop that needs a
+single tap on the shoulder:
+
+- wake a sleeping loop immediately with one-shot context
+- force the next iteration into supervisor mode when that is the real need
+- do not use it as a persistence mechanism; the signal is only for the
+  next iteration
 
 For one-shot curiosity or side research, think in the same shape as a
 delegate:

--- a/talents/loops-doctrine.md
+++ b/talents/loops-doctrine.md
@@ -25,19 +25,19 @@ now:
 - `loop_status`
 - `spawn_loop`
 - `stop_loop`
-- `signal_loop`
+- `notify_loop`
 
 `spawn_loop` is for ad hoc work that should start immediately without
 first becoming part of the persistent loop-definition registry. Reach
 for it when the loop is temporary, experimental, or tightly tied to the
 current moment.
 
-`signal_loop` is for an already-running timer-driven loop that needs a
+`notify_loop` is for an already-running timer-driven loop that needs a
 single tap on the shoulder:
 
 - wake a sleeping loop immediately with one-shot context
 - force the next iteration into supervisor mode when that is the real need
-- do not use it as a persistence mechanism; the signal is only for the
+- do not use it as a persistence mechanism; the notification is only for the
   next iteration
 
 For one-shot curiosity or side research, think in the same shape as a

--- a/talents/loops-examples.md
+++ b/talents/loops-examples.md
@@ -162,3 +162,26 @@ decision boundary.
 
 This is the most reliable way to get delegate-like behavior without
 flattening the parent loop into the entire investigation.
+
+## Pattern: Wake A Sleeping Service Loop With New Context
+
+Use this when a timer-driven service loop is already running and new
+information should reach its next iteration now instead of waiting for
+the normal sleep cycle.
+
+- Tool: `signal_loop`
+- Shape: one-shot signal envelope
+- Effect: wake now if the loop is sleeping, otherwise queue for the next
+  iteration
+- Persistence: none; use document tools inside the loop for durable state
+
+```json
+{
+  "name": "battery-watch",
+  "message": "The garage sensor reading is CPU temperature, not ambient. Treat prior spikes there as expected device heat unless another signal disagrees.",
+  "force_supervisor": true
+}
+```
+
+This is the right tool when the loop already exists and only needs a
+single corrective or time-sensitive nudge.

--- a/talents/loops-examples.md
+++ b/talents/loops-examples.md
@@ -169,8 +169,8 @@ Use this when a timer-driven service loop is already running and new
 information should reach its next iteration now instead of waiting for
 the normal sleep cycle.
 
-- Tool: `signal_loop`
-- Shape: one-shot signal envelope
+- Tool: `notify_loop`
+- Shape: one-shot loop notification
 - Effect: wake now if the loop is sleeping, otherwise queue for the next
   iteration
 - Persistence: none; use document tools inside the loop for durable state

--- a/talents/operations-entry-point.md
+++ b/talents/operations-entry-point.md
@@ -18,9 +18,10 @@ Choose the next move deliberately:
 - If the work is about scheduled tasks or timing policy, activate
   `scheduler`.
 - If you need live loop status, loop stops, ad hoc loop spawns, durable
-  loop definitions, loop policy, or a detached research task that
-  should report back later, activate `loops`. That branch also carries
-  concrete loop-launch recipes when you need a known-good pattern.
+  loop definitions, loop policy, detached research that should report
+  back later, or a one-shot signal to a sleeping service loop, activate
+  `loops`. That branch also carries concrete loop-launch recipes when
+  you need a known-good pattern.
 - If the operational question is really about session boundaries,
   resets, splits, checkpoints, or carry-forward, activate `session`.
 - If the work is MQTT plumbing or wake subscriptions, activate `mqtt`.


### PR DESCRIPTION
## Summary
- add a new `internal/messages` package with a shared envelope type, normalization, and bus routing seam
- make live timer-driven loops the first real delivery backend, including immediate wake plus one-shot notification injection into the next iteration
- add the first thin model-facing wrapper, `notify_loop`, so loop notifications use the shared message substrate instead of a bespoke trigger path

## Why
Issue #696 is becoming a blocker for several follow-on features. We now have enough loop lifecycle and process-management tooling that the missing piece is no longer generic control, but a principled way to move structured messages between components with delivery contracts.

This PR intentionally starts narrow. It establishes the envelope/bus foundation and proves it against one real destination class: live loops. That gives later loop orchestration work a clean path forward and keeps request/reply, escalation, broadcast, and contact-routing work from turning into one-off transports.

## What changed
- added `internal/messages` with:
  - `Envelope`, sender/destination identity, priorities, and signing placeholders
  - normalization and validation
  - a small in-memory bus with route registration and audit logging
  - a loop delivery handler
- taught timer-driven loops to:
  - queue one-shot notification envelopes for the next iteration
  - interrupt sleep immediately when a notification arrives
  - optionally force supervisor mode for that triggered iteration
  - inject notification payload into the next iteration prompt or handler context
  - bound pending notifications and reject event-driven loops for now
- added registry-level helpers to notify live loops by ID or exact name
- wired the app to create the message bus, register the loop route, and expose `notify_loop` under the `loops` capability
- updated loops doctrine/examples so the model learns when to use `notify_loop`
- updated the architecture baseline to account for the intentionally new package boundary
- folded in review hardening that now ships in the merged code:
  - trim and store normalized loop-name targets before routing
  - clone signature/certificate byte slices during normalization
  - validate `from.kind` against supported identity kinds
  - preserve queued-vs-delivered status in audit output

## Current scope
This PR covers the first vertical slice of #696:
- envelope primitive
- bus/router seam
- audit/logging hook
- live loop notification delivery
- `notify_loop`

## Intentionally out of scope
- full request/reply tools like `request_decision`
- broadcast/message-board tooling from #666
- contact routing migration for notifications/escalation
- cryptographic signing from #697
- interrupting arbitrary event-driven `WaitFunc` loops
