### PR TITLE
feat: streamline macOS release engineering workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,9 +46,10 @@ multi-arch container image on `ghcr.io/nugget/thane-ai-agent`. The intended
 release path is to build, sign, notarize, staple, and upload the macOS
 installer product archives alongside the Linux tarballs from a local release
 workstation via `just`. Those macOS artifacts install `thane` into
-`/usr/local/bin`, carry first-party installer metadata for inspection, and
-can be stapled cleanly after notarization. GitHub Actions publishes the
-tagged container image and its provenance attestation.
+`~/Thane/bin`, carry first-party installer metadata for inspection, avoid a
+machine-wide admin prompt, and can be stapled cleanly after notarization.
+GitHub Actions publishes the tagged container image and its provenance
+attestation.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -41,11 +41,12 @@ Point Home Assistant's Ollama integration at `http://thane-host:11434`, select m
 
 ## Releases
 
-Tagged releases publish locally prepared archives on GitHub plus a multi-arch
-container image on `ghcr.io/nugget/thane-ai-agent`. The intended release path
-is to build, sign, notarize, and upload the macOS and Linux archives from a
-local release workstation via `just`, while GitHub Actions publishes the tagged
-container image and its provenance attestation.
+Tagged releases publish locally prepared release artifacts on GitHub plus a
+multi-arch container image on `ghcr.io/nugget/thane-ai-agent`. The intended
+release path is to build, sign, notarize, staple, and upload the macOS
+installer packages alongside the Linux tarballs from a local release
+workstation via `just`, while GitHub Actions publishes the tagged container
+image and its provenance attestation.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -44,9 +44,11 @@ Point Home Assistant's Ollama integration at `http://thane-host:11434`, select m
 Tagged releases publish locally prepared release artifacts on GitHub plus a
 multi-arch container image on `ghcr.io/nugget/thane-ai-agent`. The intended
 release path is to build, sign, notarize, staple, and upload the macOS
-installer packages alongside the Linux tarballs from a local release
-workstation via `just`, while GitHub Actions publishes the tagged container
-image and its provenance attestation.
+installer product archives alongside the Linux tarballs from a local release
+workstation via `just`. Those macOS artifacts install `thane` into
+`/usr/local/bin`, carry first-party installer metadata for inspection, and
+can be stapled cleanly after notarization. GitHub Actions publishes the
+tagged container image and its provenance attestation.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,14 @@ workstation via `just`. Those macOS artifacts install `thane` into
 `~/Thane/bin`, carry first-party installer metadata for inspection, avoid a
 machine-wide admin prompt, and can be stapled cleanly after notarization.
 GitHub Actions publishes the tagged container image and its provenance
-attestation.
+attestation. The preferred operator workflows are:
+
+- `just release-github 0.9.0`
+- `just release-github 0.9.0 prerelease`
+- `just deploy-macos-pkg user@host`
+
+See [Release Engineering](docs/operating/release-engineering.md) for the full
+workflow and credential requirements.
 
 ## Documentation
 
@@ -65,6 +72,7 @@ attestation.
 - [Home Assistant](docs/operating/homeassistant.md) — HA integration setup
 - [Configuration](docs/operating/configuration.md) — Config guide by concern
 - [Deployment](docs/operating/deployment.md) — macOS and Linux service installation
+- [Release Engineering](docs/operating/release-engineering.md) — GitHub release and pkg-based live-host deployment workflows
 
 ### Extend It
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -52,6 +52,8 @@ complete onboarding guide for Home Assistant users.
   production observations, minimum specs
 - **[Deployment](operating/deployment.md)** — Service installation for
   macOS and Linux
+- **[Release Engineering](operating/release-engineering.md)** — Preferred
+  macOS Tahoe workflows for GitHub releases and pkg-based live-host deploys
 
 ## Reference
 

--- a/docs/operating/deployment.md
+++ b/docs/operating/deployment.md
@@ -30,9 +30,11 @@ macOS silently blocks unsigned binaries from accessing LAN hosts. This was
 a tricky diagnosis — see
 [issue #53](https://github.com/nugget/thane-ai-agent/issues/53). The
 justfile ad-hoc signs macOS builds (`codesign -s -`) to reduce friction,
-and the release recipes can use a Developer ID certificate plus
-`notarytool` when `THANE_CODESIGN_IDENTITY` and `THANE_NOTARY_PROFILE`
-are configured. The Local Network permission still needs manual approval.
+and the release recipes can use a Developer ID Application certificate,
+a Developer ID Installer certificate, `notarytool`, and `stapler` when
+`THANE_CODESIGN_IDENTITY`, `THANE_INSTALLER_IDENTITY`, and
+`THANE_NOTARY_PROFILE` are configured. The Local Network permission still
+needs manual approval.
 
 ### macOS Companion App
 
@@ -89,11 +91,11 @@ just build darwin amd64       # macOS Intel
 just build-all                # All release targets
 ```
 
-Release archives are prepared on a local macOS release workstation with the
-`just` release recipes. That keeps Developer ID signing and Apple notarization
-in local control while still producing Linux `amd64` and `arm64` artifacts for
-GitHub Releases. The tagged GitHub workflow publishes the multi-arch container
-image and its provenance attestation.
+Release artifacts are prepared on a local macOS release workstation with the
+`just` release recipes. That keeps Developer ID signing, installer packaging,
+Apple notarization, and stapling in local control while still producing Linux
+`amd64` and `arm64` artifacts for GitHub Releases. The tagged GitHub workflow
+publishes the multi-arch container image and its provenance attestation.
 
 ## Container
 

--- a/docs/operating/deployment.md
+++ b/docs/operating/deployment.md
@@ -95,8 +95,9 @@ Release artifacts are prepared on a local macOS release workstation with the
 `just` release recipes. That keeps Developer ID signing, installer packaging,
 Apple notarization, and stapling in local control while still producing Linux
 `amd64` and `arm64` artifacts for GitHub Releases. The macOS artifacts are
-flat installer product archives that install `thane` into `/usr/local/bin`,
-advertise the intended CPU family to Installer, and carry first-party
+flat installer product archives that install `thane` into `~/Thane/bin` for
+the current macOS account, advertise the intended CPU family to Installer,
+avoid a machine-wide admin prompt, and carry first-party
 welcome/readme/license metadata for inspection. The tagged GitHub workflow
 publishes the multi-arch container image and its provenance attestation.
 

--- a/docs/operating/deployment.md
+++ b/docs/operating/deployment.md
@@ -94,7 +94,10 @@ just build-all                # All release targets
 Release artifacts are prepared on a local macOS release workstation with the
 `just` release recipes. That keeps Developer ID signing, installer packaging,
 Apple notarization, and stapling in local control while still producing Linux
-`amd64` and `arm64` artifacts for GitHub Releases. The tagged GitHub workflow
+`amd64` and `arm64` artifacts for GitHub Releases. The macOS artifacts are
+flat installer product archives that install `thane` into `/usr/local/bin`,
+advertise the intended CPU family to Installer, and carry first-party
+welcome/readme/license metadata for inspection. The tagged GitHub workflow
 publishes the multi-arch container image and its provenance attestation.
 
 ## Container

--- a/docs/operating/deployment.md
+++ b/docs/operating/deployment.md
@@ -101,6 +101,12 @@ avoid a machine-wide admin prompt, and carry first-party
 welcome/readme/license metadata for inspection. The tagged GitHub workflow
 publishes the multi-arch container image and its provenance attestation.
 
+For the human-facing operator workflows, see
+[Release Engineering](release-engineering.md). The preferred paths are:
+
+- `just release-github <version>` for real GitHub releases from a clean main checkout
+- `just deploy-macos-pkg user@host` for pkg-based live-host testing on another macOS Tahoe system
+
 ## Container
 
 Thane also ships as a multi-arch container image on GHCR:

--- a/docs/operating/release-engineering.md
+++ b/docs/operating/release-engineering.md
@@ -1,0 +1,109 @@
+# Release Engineering
+
+Thane now has two operator paths on macOS Tahoe:
+
+- a guarded GitHub release path for real published releases
+- a pkg-based remote deploy path for live-host testing
+
+Both flows are designed for the human who coordinates release work often.
+They keep the high-level progress readable while still letting the underlying
+tool output stream through in real time.
+
+## Preferred Workflows
+
+### Publish A GitHub Release
+
+Use this when you are cutting a real release for GitHub, the macOS companion
+app, and manual operator installs.
+
+```bash
+just release-github 0.9.0
+just release-github 0.9.0 prerelease
+```
+
+What it does:
+
+- requires a clean checkout
+- requires `main`
+- requires local `main` to match `origin/main`
+- runs the normal CI gate
+- builds the macOS installer packages and Linux tarballs
+- signs, notarizes, and staples the macOS `.pkg` artifacts
+- writes checksums
+- smoke-tests the release container image locally
+- creates or updates the GitHub release with either release or prerelease state
+
+Required environment for this path:
+
+- `THANE_CODESIGN_IDENTITY`
+- `THANE_INSTALLER_IDENTITY`
+- `THANE_NOTARY_PROFILE`
+- `THANE_GH_TOKEN`
+
+`release_kind` can be:
+
+- `auto`
+  - marks versions containing `-` as prereleases
+- `prerelease`
+  - always creates or updates a prerelease
+- `release`
+  - always creates or updates a full release
+
+If you intentionally want a breakpoint between local artifact preparation and
+GitHub publication, the lower-level building blocks still exist:
+
+```bash
+just prepare-release 0.9.0
+just publish-release 0.9.0
+```
+
+Most operators should prefer `just release-github ...` instead.
+
+### Deploy A Pkg To A Live macOS Host
+
+Use this when you want to test the real installer path on a remote Thane host
+without cutting a GitHub release.
+
+```bash
+just deploy-macos-pkg aimee@pocket.hollowoak.net
+```
+
+What it does:
+
+- requires a clean checkout
+- builds a signed macOS installer package from the current branch
+- copies the `.pkg` to the remote host over SSH
+- checks the package signature on the remote host
+- installs it into `CurrentUserHomeDirectory`
+- restarts the launch agent
+- verifies the installed binary with `~/Thane/bin/thane version`
+
+This path assumes the remote host is also macOS Tahoe and that Thane is run
+from a dedicated account whose normal home-scoped install location is
+`~/Thane/bin/thane`.
+
+Required environment for this path:
+
+- `THANE_CODESIGN_IDENTITY`
+- `THANE_INSTALLER_IDENTITY`
+
+Useful variants:
+
+```bash
+just build-macos-pkg
+just deploy-macos-pkg aimee@pocket.hollowoak.net arm64
+just deploy-macos-pkg aimee@pocket.hollowoak.net arm64 0.9.0 /tmp/thane-releng 'launchctl kickstart -k gui/$(id -u)/info.nugget.thane'
+```
+
+## Why Pkg-Based Deploys
+
+Even during development, Thane should exercise the same installation shape it
+ships to operators:
+
+- package metadata is inspectable with normal Apple tooling
+- install domain stays home-scoped instead of requiring admin privileges
+- `~/Thane/bin/thane` stays the single managed macOS binary location
+- release engineering can converge on one trustworthy artifact type
+
+Raw binary copies are still possible with lower-level tooling, but they are no
+longer the preferred operational path.

--- a/docs/operating/release-engineering.md
+++ b/docs/operating/release-engineering.md
@@ -75,7 +75,7 @@ What it does:
 - copies the `.pkg` to the remote host over SSH
 - checks the package signature on the remote host
 - installs it into `CurrentUserHomeDirectory`
-- restarts the launch agent
+- lets the target-side binary watcher react to the new install
 - polls the remote Thane API until `/v1/version` reports the expected build version
 
 This path assumes the remote host is also macOS Tahoe and that Thane is run
@@ -92,8 +92,8 @@ Useful variants:
 ```bash
 just build-macos-pkg
 just deploy-macos-pkg aimee@pocket.hollowoak.net arm64
-just deploy-macos-pkg aimee@pocket.hollowoak.net arm64 0.9.0 /tmp/thane-releng 'launchctl kickstart -k gui/$(id -u)/info.nugget.thane'
-just deploy-macos-pkg aimee@pocket.hollowoak.net arm64 0.9.0 /tmp/thane-releng '' http://127.0.0.1:18080/v1/version 90
+just deploy-macos-pkg aimee@pocket.hollowoak.net arm64 0.9.0 /tmp/thane-releng
+just deploy-macos-pkg aimee@pocket.hollowoak.net arm64 0.9.0 /tmp/thane-releng http://127.0.0.1:18080/v1/version 90
 ```
 
 ## Why Pkg-Based Deploys

--- a/docs/operating/release-engineering.md
+++ b/docs/operating/release-engineering.md
@@ -71,7 +71,9 @@ just deploy-macos-pkg aimee@pocket.hollowoak.net
 What it does:
 
 - requires a clean checkout
+- requires `THANE_NOTARY_PROFILE`
 - builds a signed macOS installer package from the current branch
+- notarizes and staples that package before deployment
 - copies the `.pkg` to the remote host over SSH
 - checks the package signature on the remote host
 - installs it into `CurrentUserHomeDirectory`
@@ -86,6 +88,7 @@ Required environment for this path:
 
 - `THANE_CODESIGN_IDENTITY`
 - `THANE_INSTALLER_IDENTITY`
+- `THANE_NOTARY_PROFILE`
 
 Useful variants:
 

--- a/docs/operating/release-engineering.md
+++ b/docs/operating/release-engineering.md
@@ -76,7 +76,7 @@ What it does:
 - checks the package signature on the remote host
 - installs it into `CurrentUserHomeDirectory`
 - restarts the launch agent
-- verifies the installed binary with `~/Thane/bin/thane version`
+- polls the remote Thane API until `/v1/version` reports the expected build version
 
 This path assumes the remote host is also macOS Tahoe and that Thane is run
 from a dedicated account whose normal home-scoped install location is
@@ -93,6 +93,7 @@ Useful variants:
 just build-macos-pkg
 just deploy-macos-pkg aimee@pocket.hollowoak.net arm64
 just deploy-macos-pkg aimee@pocket.hollowoak.net arm64 0.9.0 /tmp/thane-releng 'launchctl kickstart -k gui/$(id -u)/info.nugget.thane'
+just deploy-macos-pkg aimee@pocket.hollowoak.net arm64 0.9.0 /tmp/thane-releng '' http://127.0.0.1:18080/v1/version 90
 ```
 
 ## Why Pkg-Based Deploys

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -18,12 +18,13 @@ easy to roll back.
 - [ ] `just prepare-release <version>` completes on the macOS release workstation
 - [ ] Prepared release metadata matches the commit being published
 - [ ] Release tag created with `just publish-release <version>` from a clean, up-to-date `main`
-- [ ] Local release upload publishes the four archives plus a version-scoped `thane_<version>_checksums.txt` to the GitHub release
+- [ ] Local release upload publishes the two macOS `.pkg` files, the two Linux tarballs, and a version-scoped `thane_<version>_checksums.txt` to the GitHub release
 - [ ] GitHub release workflow publishes the GHCR multi-arch container image
 - [ ] GitHub build provenance attestations are available for the container image
 - [ ] GitHub release token is set explicitly (`THANE_GH_TOKEN`) for tag creation and release upload
 - [ ] macOS release signing credentials are set (`THANE_CODESIGN_IDENTITY`) if shipping a Developer ID-signed build
-- [ ] macOS notarization profile is set (`THANE_NOTARY_PROFILE`) if shipping a notarized macOS archive
+- [ ] macOS installer signing credentials are set (`THANE_INSTALLER_IDENTITY`) if shipping signed `.pkg` artifacts
+- [ ] macOS notarization profile is set (`THANE_NOTARY_PROFILE`) if shipping a notarized/stapled macOS installer package
 
 ## Documentation Audit
 

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -25,6 +25,7 @@ easy to roll back.
 - [ ] macOS release signing credentials are set (`THANE_CODESIGN_IDENTITY`) if shipping a Developer ID-signed build
 - [ ] macOS installer signing credentials are set (`THANE_INSTALLER_IDENTITY`) if shipping signed `.pkg` artifacts
 - [ ] macOS notarization profile is set (`THANE_NOTARY_PROFILE`) if shipping a notarized/stapled macOS installer package
+- [ ] macOS installer packages inspect cleanly (`pkgutil --check-signature`, distribution metadata, install domain, and architecture gating all match the intended release)
 
 ## Documentation Audit
 

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -68,7 +68,7 @@ easy to roll back.
 - [ ] One Home Assistant request succeeds if HA is production-critical
 - [ ] One scheduler/background loop completes after restart
 - [ ] Dashboard, request viewer, and registry windows load cleanly enough for incident response
-- [ ] If a live host was used for pkg validation, `just deploy-macos-pkg user@host` completed and `~/Thane/bin/thane version` on that host reports the intended build
+- [ ] If a live host was used for pkg validation, `just deploy-macos-pkg user@host` completed and the target Thane API reported the intended build version after restart
 
 ## Log Review
 

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -25,7 +25,7 @@ easy to roll back.
 - [ ] macOS release signing credentials are set (`THANE_CODESIGN_IDENTITY`) if shipping a Developer ID-signed build
 - [ ] macOS installer signing credentials are set (`THANE_INSTALLER_IDENTITY`) if shipping signed `.pkg` artifacts
 - [ ] macOS notarization profile is set (`THANE_NOTARY_PROFILE`) if shipping a notarized/stapled macOS installer package
-- [ ] macOS installer packages inspect cleanly (`pkgutil --check-signature`, distribution metadata, install domain, and architecture gating all match the intended release)
+- [ ] macOS installer packages inspect cleanly (`pkgutil --check-signature`, distribution metadata, current-user-home install domain, and architecture gating all match the intended release)
 
 ## Documentation Audit
 

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -9,15 +9,18 @@ easy to roll back.
 - [ ] `just ci`
 - [ ] `just build`
 - [ ] `just release-build-snapshot <version>` for at least the primary operator target
+- [ ] Preferred operator path chosen up front:
+  - [ ] `just release-github <version> [auto|prerelease|release]` for a real published release
+  - [ ] `just deploy-macos-pkg user@host` for live-host pkg testing without cutting a release
 - [ ] Generated files are committed, especially [`examples/config.example.yaml`](../examples/config.example.yaml)
 - [ ] New exported Go types/functions read cleanly in Go Doc form
 - [ ] Logs for new code paths use inherited/component loggers instead of ad hoc `slog.Default()` where request or subsystem context matters
 
 ## Artifact Publication
 
-- [ ] `just prepare-release <version>` completes on the macOS release workstation
+- [ ] `just release-github <version>` completes on the macOS Tahoe release workstation
 - [ ] Prepared release metadata matches the commit being published
-- [ ] Release tag created with `just publish-release <version>` from a clean, up-to-date `main`
+- [ ] Release tag created from a clean, up-to-date `main`
 - [ ] Local release upload publishes the two macOS `.pkg` files, the two Linux tarballs, and a version-scoped `thane_<version>_checksums.txt` to the GitHub release
 - [ ] GitHub release workflow publishes the GHCR multi-arch container image
 - [ ] GitHub build provenance attestations are available for the container image
@@ -26,6 +29,7 @@ easy to roll back.
 - [ ] macOS installer signing credentials are set (`THANE_INSTALLER_IDENTITY`) if shipping signed `.pkg` artifacts
 - [ ] macOS notarization profile is set (`THANE_NOTARY_PROFILE`) if shipping a notarized/stapled macOS installer package
 - [ ] macOS installer packages inspect cleanly (`pkgutil --check-signature`, distribution metadata, current-user-home install domain, and architecture gating all match the intended release)
+- [ ] If a manual breakpoint was needed, `just prepare-release <version>` and `just publish-release <version> [auto|prerelease|release]` were used intentionally instead of by habit
 
 ## Documentation Audit
 
@@ -64,6 +68,7 @@ easy to roll back.
 - [ ] One Home Assistant request succeeds if HA is production-critical
 - [ ] One scheduler/background loop completes after restart
 - [ ] Dashboard, request viewer, and registry windows load cleanly enough for incident response
+- [ ] If a live host was used for pkg validation, `just deploy-macos-pkg user@host` completed and `~/Thane/bin/thane version` on that host reports the intended build
 
 ## Log Review
 

--- a/justfile
+++ b/justfile
@@ -13,6 +13,7 @@ thane-home := home_directory() / "Thane"
 install-prefix := if os() == "macos" { env("INSTALL_PREFIX", thane-home) } else { env("INSTALL_PREFIX", "/usr/local") }
 release-dir := "dist/release"
 codesign-identity := env("THANE_CODESIGN_IDENTITY", "-")
+installer-identity := env("THANE_INSTALLER_IDENTITY", "")
 codesign-options := env("THANE_CODESIGN_OPTIONS", "runtime")
 codesign-timestamp := env("THANE_CODESIGN_TIMESTAMP", "true")
 notary-profile := env("THANE_NOTARY_PROFILE", "")
@@ -442,15 +443,29 @@ release-sign-macos binary identity=codesign-identity options=codesign-options ti
     codesign --verify --verbose=2 "$binary"
     codesign -dv --verbose=4 "$binary"
 
-[doc("Building block: notarize a packaged macOS archive")]
+[doc("Building block: notarize a packaged macOS release artifact")]
 [group('release-engineering')]
 [macos]
 release-notarize-macos archive profile=notary-profile:
     test "{{codesign-identity}}" != "-" || (echo "Notarization requires THANE_CODESIGN_IDENTITY to name a Developer ID Application certificate" && exit 1)
+    test -n "{{installer-identity}}" || (echo "Notarization of macOS installer packages requires THANE_INSTALLER_IDENTITY to name a Developer ID Installer certificate" && exit 1)
     test -n "{{profile}}" || (echo "Set THANE_NOTARY_PROFILE or pass a notary profile name" && exit 1)
     xcrun notarytool submit "{{archive}}" --keychain-profile "{{profile}}" --wait
 
-[doc("Building block: build one release archive for a target")]
+[doc("Building block: package a macOS binary as a signed flat installer product archive")]
+[group('release-engineering')]
+[macos]
+release-package-macos-pkg version target_arch binary installer_identity=installer-identity:
+    scripts/package-macos-pkg.sh "{{version}}" "{{target_arch}}" "{{binary}}" "{{release-dir}}" "{{installer_identity}}"
+
+[doc("Building block: staple and validate a notarized macOS installer package")]
+[group('release-engineering')]
+[macos]
+release-staple-macos archive:
+    xcrun stapler staple "{{archive}}"
+    xcrun stapler validate "{{archive}}"
+
+[doc("Building block: build one release artifact for a target")]
 [group('release-engineering')]
 release-build-archive version target_os=host_os target_arch=host_arch cc="":
     #!/usr/bin/env bash
@@ -468,19 +483,25 @@ release-build-archive version target_os=host_os target_arch=host_arch cc="":
         THANE_VERSION="v${version}" just build "$target_os" "$target_arch"
     fi
 
-    if [ "$target_os" = "darwin" ] && [ "{{host_os}}" = "darwin" ]; then
+    if [ "$target_os" = "darwin" ]; then
+        test "{{host_os}}" = "darwin" || { echo "release-build-archive for darwin targets requires a macOS host"; exit 1; }
         just release-sign-macos "$binary"
-    fi
-
-    archive="$(scripts/package-release.sh "$version" "$target_os" "$target_arch" "$binary" "{{release-dir}}")"
-
-    if [ "$target_os" = "darwin" ] && [ "{{host_os}}" = "darwin" ] && [ -n "${THANE_NOTARY_PROFILE:-}" ]; then
-        just release-notarize-macos "$archive"
+        if [ -n "${THANE_NOTARY_PROFILE:-}" ] && { [ -z "{{installer-identity}}" ] || [ "{{installer-identity}}" = "-" ]; }; then
+            echo "Set THANE_INSTALLER_IDENTITY to a Developer ID Installer certificate before notarizing macOS release packages." >&2
+            exit 1
+        fi
+        archive="$(just --quiet release-package-macos-pkg "v${version}" "$target_arch" "$binary" | tail -n 1)"
+        if [ -n "${THANE_NOTARY_PROFILE:-}" ]; then
+            just release-notarize-macos "$archive"
+            just release-staple-macos "$archive"
+        fi
+    else
+        archive="$(scripts/package-release.sh "$version" "$target_os" "$target_arch" "$binary" "{{release-dir}}")"
     fi
 
     printf '%s\n' "$archive"
 
-[doc("Building block: write checksums for prepared archives")]
+[doc("Building block: write checksums for prepared release artifacts")]
 [group('release-engineering')]
 release-write-checksums version:
     #!/usr/bin/env bash
@@ -491,13 +512,13 @@ release-write-checksums version:
 
     cd "{{release-dir}}"
     shopt -s nullglob
-    archives=("./thane_${version}_"*.tar.gz "./thane_${version}_"*.zip)
+    archives=("./thane_${version}_"*.tar.gz "./thane_${version}_"*.pkg)
     if [ "${#archives[@]}" -eq 0 ]; then
-        echo "No release archives found for version ${version} in {{release-dir}}" >&2
+        echo "No release artifacts found for version ${version} in {{release-dir}}" >&2
         exit 1
     fi
     if [ "${#archives[@]}" -ne 4 ]; then
-        echo "Expected 4 release archives for version ${version}, found ${#archives[@]} in {{release-dir}}" >&2
+        echo "Expected 4 release artifacts for version ${version}, found ${#archives[@]} in {{release-dir}}" >&2
         printf '  %s\n' "${archives[@]}" >&2
         exit 1
     fi
@@ -549,8 +570,8 @@ release-github-check version:
     metadata_path="{{release-dir}}/.thane_${version}_prepared.env"
     checksum_path="{{release-dir}}/thane_${version}_checksums.txt"
     assets=(
-        "{{release-dir}}/thane_${version}_darwin_amd64.zip"
-        "{{release-dir}}/thane_${version}_darwin_arm64.zip"
+        "{{release-dir}}/thane_${version}_darwin_amd64.pkg"
+        "{{release-dir}}/thane_${version}_darwin_arm64.pkg"
         "{{release-dir}}/thane_${version}_linux_amd64.tar.gz"
         "{{release-dir}}/thane_${version}_linux_arm64.tar.gz"
         "{{release-dir}}/thane_${version}_checksums.txt"
@@ -589,15 +610,15 @@ release-github-check version:
 
     checksum_assets="$(awk '{print $NF}' "$checksum_path" | LC_ALL=C sort)"
     expected_checksum_assets=(
-        "thane_${version}_darwin_amd64.zip"
-        "thane_${version}_darwin_arm64.zip"
+        "thane_${version}_darwin_amd64.pkg"
+        "thane_${version}_darwin_arm64.pkg"
         "thane_${version}_linux_amd64.tar.gz"
         "thane_${version}_linux_arm64.tar.gz"
     )
     checksum_asset_count="$(printf '%s\n' "$checksum_assets" | sed '/^$/d' | wc -l | tr -d ' ')"
 
     if [ "$checksum_asset_count" -ne "${#expected_checksum_assets[@]}" ]; then
-        echo "Checksum file $checksum_path should describe ${#expected_checksum_assets[@]} release archives, found ${checksum_asset_count} entries." >&2
+        echo "Checksum file $checksum_path should describe ${#expected_checksum_assets[@]} release artifacts, found ${checksum_asset_count} entries." >&2
         printf '  %s\n' "$checksum_assets" >&2
         exit 1
     fi
@@ -620,8 +641,8 @@ release-github-upload version target_commit="":
     target_commit="{{target_commit}}"
     release_exists=0
     assets=(
-        "{{release-dir}}/thane_${version}_darwin_amd64.zip"
-        "{{release-dir}}/thane_${version}_darwin_arm64.zip"
+        "{{release-dir}}/thane_${version}_darwin_amd64.pkg"
+        "{{release-dir}}/thane_${version}_darwin_arm64.pkg"
         "{{release-dir}}/thane_${version}_linux_amd64.tar.gz"
         "{{release-dir}}/thane_${version}_linux_arm64.tar.gz"
         "{{release-dir}}/thane_${version}_checksums.txt"
@@ -698,7 +719,7 @@ prepare-release version container_tag="thane:prepare-release":
 
     mkdir -p "{{release-dir}}"
     rm -f \
-        "{{release-dir}}/thane_${version}_"*.zip \
+        "{{release-dir}}/thane_${version}_"*.pkg \
         "{{release-dir}}/thane_${version}_"*.tar.gz \
         "{{release-dir}}/thane_${version}_checksums.txt" \
         "{{release-dir}}/.thane_${version}_prepared.env"
@@ -722,13 +743,13 @@ prepare-release version container_tag="thane:prepare-release":
 
     echo ""
     echo "Local release preparation complete."
-    echo "  Archives/checksums: {{release-dir}}/"
+    echo "  Release artifacts/checksums: {{release-dir}}/"
     echo "  Release metadata: $metadata_path"
-    echo "  Included archives: darwin/amd64, darwin/arm64, linux/amd64, linux/arm64"
+    echo "  Included release artifacts: darwin/amd64 pkg, darwin/arm64 pkg, linux/amd64 tar.gz, linux/arm64 tar.gz"
     echo "  Container smoke tag: $container_tag"
     echo ""
     echo "Nothing was tagged, pushed, or uploaded to GitHub."
-    echo "If THANE_NOTARY_PROFILE was set, Apple notarization was completed during this run."
+    echo "If THANE_NOTARY_PROFILE was set, Apple notarization and stapling were completed during this run."
     echo "Next off-machine step when ready:"
     echo "  just publish-release v${version}"
 
@@ -802,12 +823,12 @@ publish-release version:
 
         echo "Remote tag $tag already exists at the current commit. Treating publish as idempotent."
         just release-github-upload "$tag"
-        echo "Uploaded local release archives/checksums. GitHub Actions can publish or republish the container image separately."
+        echo "Uploaded local release artifacts/checksums. GitHub Actions can publish or republish the container image separately."
         exit 0
     fi
 
     just release-github-upload "$tag" "$head_commit"
-    echo "Created $tag via the GitHub release API, uploaded local release archives/checksums, and triggered GitHub Actions to publish the container image."
+    echo "Created $tag via the GitHub release API, uploaded local release artifacts/checksums, and triggered GitHub Actions to publish the container image."
 
 [private]
 macos-sign binary identity=codesign-identity options=codesign-options timestamp=codesign-timestamp:
@@ -817,6 +838,11 @@ macos-sign binary identity=codesign-identity options=codesign-options timestamp=
 [macos]
 macos-notarize archive profile=notary-profile:
     just release-notarize-macos "{{archive}}" "{{profile}}"
+
+[private]
+[macos]
+macos-staple archive:
+    just release-staple-macos "{{archive}}"
 
 [private]
 release-archive version target_os=host_os target_arch=host_arch cc="":

--- a/justfile
+++ b/justfile
@@ -369,11 +369,11 @@ deploy-scp host remote_bin="Thane/bin/thane" target_os=host_os target_arch=host_
 build-macos-pkg version="" target_arch=host_arch output_dir=pkg-dir:
     scripts/releng/build-macos-pkg.sh "{{version}}" "{{target_arch}}" "{{output_dir}}" true
 
-[doc("Operator path: build a signed macOS pkg, install it on a remote Tahoe host via SSH, and restart Thane there")]
+[doc("Operator path: build a signed macOS pkg, install it on a remote Tahoe host via SSH, restart Thane there, and verify the live API version")]
 [group('deploy')]
 [macos]
-deploy-macos-pkg host target_arch=host_arch version="" remote_pkg_dir="/tmp/thane-releng" restart_cmd="":
-    scripts/releng/deploy-macos-pkg.sh "{{host}}" "{{target_arch}}" "{{version}}" "{{remote_pkg_dir}}" "{{restart_cmd}}"
+deploy-macos-pkg host target_arch=host_arch version="" remote_pkg_dir="/tmp/thane-releng" restart_cmd="" verify_url="http://127.0.0.1:8080/v1/version" verify_timeout_seconds="60":
+    scripts/releng/deploy-macos-pkg.sh "{{host}}" "{{target_arch}}" "{{version}}" "{{remote_pkg_dir}}" "{{restart_cmd}}" "{{verify_url}}" "{{verify_timeout_seconds}}"
 
 # Build and run from the local Thane/ working directory (for development)
 [group('operations')]

--- a/justfile
+++ b/justfile
@@ -12,6 +12,7 @@ host_arch := if arch() == "aarch64" { "arm64" } else if arch() == "x86_64" { "am
 thane-home := home_directory() / "Thane"
 install-prefix := if os() == "macos" { env("INSTALL_PREFIX", thane-home) } else { env("INSTALL_PREFIX", "/usr/local") }
 release-dir := "dist/release"
+pkg-dir := "dist/pkg"
 codesign-identity := env("THANE_CODESIGN_IDENTITY", "-")
 installer-identity := env("THANE_INSTALLER_IDENTITY", "")
 codesign-options := env("THANE_CODESIGN_OPTIONS", "runtime")
@@ -361,6 +362,18 @@ deploy-scp host remote_bin="Thane/bin/thane" target_os=host_os target_arch=host_
     fi
     echo "Deployed $binary to ${host}:${remote_bin}"
 
+[doc("Operator path: build a signed macOS installer package from the current clean checkout")]
+[group('release-engineering')]
+[macos]
+build-macos-pkg version="" target_arch=host_arch output_dir=pkg-dir:
+    scripts/releng/build-macos-pkg.sh "{{version}}" "{{target_arch}}" "{{output_dir}}" true
+
+[doc("Operator path: build a signed macOS pkg, install it on a remote Tahoe host via SSH, and restart Thane there")]
+[group('deploy')]
+[macos]
+deploy-macos-pkg host target_arch=host_arch version="" remote_pkg_dir="/tmp/thane-releng" restart_cmd="":
+    scripts/releng/deploy-macos-pkg.sh "{{host}}" "{{target_arch}}" "{{version}}" "{{remote_pkg_dir}}" "{{restart_cmd}}"
+
 # Build and run from the local Thane/ working directory (for development)
 [group('operations')]
 serve: build
@@ -455,8 +468,8 @@ release-notarize-macos archive profile=notary-profile:
 [doc("Building block: package a macOS binary as a signed flat installer product archive")]
 [group('release-engineering')]
 [macos]
-release-package-macos-pkg version target_arch binary installer_identity=installer-identity:
-    scripts/package-macos-pkg.sh "{{version}}" "{{target_arch}}" "{{binary}}" "{{release-dir}}" "{{installer_identity}}"
+release-package-macos-pkg version target_arch binary output_dir=release-dir installer_identity=installer-identity:
+    scripts/package-macos-pkg.sh "{{version}}" "{{target_arch}}" "{{binary}}" "{{output_dir}}" "{{installer_identity}}"
 
 [doc("Building block: staple and validate a notarized macOS installer package")]
 [group('release-engineering')]
@@ -632,14 +645,20 @@ release-github-check version:
 
 [doc("Building block: create or update the GitHub release from prepared assets")]
 [group('release-engineering')]
-release-github-upload version target_commit="":
+release-github-upload version target_commit="" release_kind="auto":
     #!/usr/bin/env bash
     set -euo pipefail
     version="{{version}}"
     version="${version#v}"
     tag="v${version}"
     target_commit="{{target_commit}}"
+    release_kind="{{release_kind}}"
     release_exists=0
+    prerelease=0
+    release_id=""
+    current_prerelease=""
+    current_draft=""
+    is_immutable=""
     assets=(
         "{{release-dir}}/thane_${version}_darwin_amd64.pkg"
         "{{release-dir}}/thane_${version}_darwin_arm64.pkg"
@@ -651,9 +670,28 @@ release-github-upload version target_commit="":
     just --quiet release-github-check "$version"
     export GH_TOKEN="${THANE_GH_TOKEN}"
 
+    case "$release_kind" in
+        auto)
+            if printf '%s' "$version" | grep -q -- '-'; then
+                prerelease=1
+            fi
+            ;;
+        prerelease)
+            prerelease=1
+            ;;
+        release)
+            prerelease=0
+            ;;
+        *)
+            echo "release_kind must be one of: auto, prerelease, release" >&2
+            exit 1
+            ;;
+    esac
+
     create_args=("${tag}" --title "${tag}" --generate-notes)
-    if printf '%s' "$version" | grep -q -- '-'; then
+    if [ "$prerelease" -eq 1 ]; then
         create_args+=(--prerelease)
+        create_args+=(--latest=false)
     fi
     if [ -n "$target_commit" ]; then
         create_args+=(--target "$target_commit")
@@ -661,8 +699,12 @@ release-github-upload version target_commit="":
         create_args+=(--verify-tag)
     fi
 
-    if gh release view "$tag" >/dev/null 2>&1; then
+    if gh release view "$tag" --json id,isImmutable,isDraft,isPrerelease >/dev/null 2>&1; then
         release_exists=1
+        release_id="$(gh release view "$tag" --json id --jq '.id')"
+        current_prerelease="$(gh release view "$tag" --json isPrerelease --jq '.isPrerelease')"
+        current_draft="$(gh release view "$tag" --json isDraft --jq '.isDraft')"
+        is_immutable="$(gh release view "$tag" --json isImmutable --jq '.isImmutable')"
     fi
 
     if [ "$release_exists" -eq 0 ]; then
@@ -670,7 +712,6 @@ release-github-upload version target_commit="":
         exit 0
     fi
 
-    is_immutable="$(gh release view "$tag" --json isImmutable --jq '.isImmutable')"
     if [ "$is_immutable" = "true" ]; then
         remote_assets="$(gh release view "$tag" --json assets --jq '.assets[].name' 2>/dev/null || true)"
         missing_remote=0
@@ -688,14 +729,36 @@ release-github-upload version target_commit="":
             exit 1
         fi
 
+        desired_prerelease="false"
+        if [ "$prerelease" -eq 1 ]; then
+            desired_prerelease="true"
+        fi
+        if [ "$current_prerelease" != "$desired_prerelease" ]; then
+            echo "Immutable release $tag already exists with prerelease=$current_prerelease; cannot change it to $desired_prerelease." >&2
+            exit 1
+        fi
+
         echo "Release $tag is already published and immutable with the expected assets. Treating upload as idempotent."
         exit 0
     fi
 
     gh release upload "$tag" "${assets[@]}" --clobber
 
-    if [ "$(gh release view "$tag" --json isDraft --jq '.isDraft')" = "true" ]; then
+    if [ "$current_draft" = "true" ]; then
         gh release edit "$tag" --draft=false
+    fi
+
+    desired_prerelease=false
+    if [ "$prerelease" -eq 1 ]; then
+        desired_prerelease=true
+    fi
+    if [ "$current_prerelease" != "$desired_prerelease" ]; then
+        repo="$(gh repo view --json nameWithOwner --jq '.nameWithOwner')"
+        gh api \
+            --method PATCH \
+            "repos/${repo}/releases/${release_id}" \
+            -F prerelease="${desired_prerelease}" \
+            >/dev/null
     fi
 
 [doc("Operator path: build, sign/notarize, package, checksum, and smoke-test the release locally")]
@@ -755,12 +818,13 @@ prepare-release version container_tag="thane:prepare-release":
 
 [doc("Operator path: create the release tag and publish prepared assets to GitHub")]
 [group('release-engineering')]
-publish-release version:
+publish-release version release_kind="auto":
     #!/usr/bin/env bash
     set -euo pipefail
     version="{{version}}"
     version="${version#v}"
     tag="v${version}"
+    release_kind="{{release_kind}}"
     metadata_path="{{release-dir}}/.thane_${version}_prepared.env"
     repo=""
     head_commit="$(git rev-parse HEAD)"
@@ -822,13 +886,19 @@ publish-release version:
         fi
 
         echo "Remote tag $tag already exists at the current commit. Treating publish as idempotent."
-        just release-github-upload "$tag"
+        just release-github-upload "$tag" "" "$release_kind"
         echo "Uploaded local release artifacts/checksums. GitHub Actions can publish or republish the container image separately."
         exit 0
     fi
 
-    just release-github-upload "$tag" "$head_commit"
+    just release-github-upload "$tag" "$head_commit" "$release_kind"
     echo "Created $tag via the GitHub release API, uploaded local release artifacts/checksums, and triggered GitHub Actions to publish the container image."
+
+[doc("Operator path: build, notarize, and publish a GitHub release from a clean main checkout (release_kind: auto|prerelease|release)")]
+[group('release-engineering')]
+[macos]
+release-github version release_kind="auto" container_tag="thane:prepare-release":
+    scripts/releng/release-github.sh "{{version}}" "{{release_kind}}" "{{container_tag}}"
 
 [private]
 macos-sign binary identity=codesign-identity options=codesign-options timestamp=codesign-timestamp:
@@ -865,13 +935,13 @@ release-upload-validate version:
     just release-github-check "{{version}}"
 
 [private]
-release-upload version:
-    just release-github-upload "{{version}}"
+release-upload version release_kind="auto":
+    just release-github-upload "{{version}}" "" "{{release_kind}}"
 
 [private]
 release-breakpoint version container_tag="thane:release-breakpoint":
     just prepare-release "{{version}}" "{{container_tag}}"
 
 [private]
-release version:
-    just publish-release "{{version}}"
+release version release_kind="auto":
+    just publish-release "{{version}}" "{{release_kind}}"

--- a/justfile
+++ b/justfile
@@ -346,10 +346,11 @@ deploy-scp host remote_bin="Thane/bin/thane" target_os=host_os target_arch=host_
         just release-sign-macos "$binary"
         if [ -n "${THANE_NOTARY_PROFILE:-}" ]; then
             if [ -n "$cc" ]; then
-                archive="$(just --quiet release-build-archive "$version" "$target_os" "$target_arch" "$cc" | tail -n 1)"
+                archive="$(just release-build-archive "$version" "$target_os" "$target_arch" "$cc" | tail -n 1)"
             else
-                archive="$(just --quiet release-build-archive "$version" "$target_os" "$target_arch" | tail -n 1)"
+                archive="$(just release-build-archive "$version" "$target_os" "$target_arch" | tail -n 1)"
             fi
+            test -n "$archive" || { echo "release-build-archive did not report an artifact path" >&2; exit 1; }
             echo "Notarized archive ready: $archive"
         fi
     fi
@@ -503,7 +504,8 @@ release-build-archive version target_os=host_os target_arch=host_arch cc="":
             echo "Set THANE_INSTALLER_IDENTITY to a Developer ID Installer certificate before notarizing macOS release packages." >&2
             exit 1
         fi
-        archive="$(just --quiet release-package-macos-pkg "v${version}" "$target_arch" "$binary" | tail -n 1)"
+        archive="$(just release-package-macos-pkg "v${version}" "$target_arch" "$binary" | tail -n 1)"
+        test -n "$archive" || { echo "release-package-macos-pkg did not report an artifact path" >&2; exit 1; }
         if [ -n "${THANE_NOTARY_PROFILE:-}" ]; then
             just release-notarize-macos "$archive"
             just release-staple-macos "$archive"

--- a/justfile
+++ b/justfile
@@ -462,7 +462,7 @@ release-sign-macos binary identity=codesign-identity options=codesign-options ti
 [macos]
 release-notarize-macos archive profile=notary-profile:
     test "{{codesign-identity}}" != "-" || (echo "Notarization requires THANE_CODESIGN_IDENTITY to name a Developer ID Application certificate" && exit 1)
-    test -n "{{installer-identity}}" || (echo "Notarization of macOS installer packages requires THANE_INSTALLER_IDENTITY to name a Developer ID Installer certificate" && exit 1)
+    test -n "{{installer-identity}}" && test "{{installer-identity}}" != "-" || (echo "Notarization of macOS installer packages requires THANE_INSTALLER_IDENTITY to name a Developer ID Installer certificate" && exit 1)
     test -n "{{profile}}" || (echo "Set THANE_NOTARY_PROFILE or pass a notary profile name" && exit 1)
     xcrun notarytool submit "{{archive}}" --keychain-profile "{{profile}}" --wait
 
@@ -786,6 +786,7 @@ prepare-release version container_tag="thane:prepare-release":
     rm -f \
         "{{release-dir}}/thane_${version}_"*.pkg \
         "{{release-dir}}/thane_${version}_"*.tar.gz \
+        "{{release-dir}}/thane_${version}_"*.zip \
         "{{release-dir}}/thane_${version}_checksums.txt" \
         "{{release-dir}}/.thane_${version}_prepared.env"
 

--- a/justfile
+++ b/justfile
@@ -369,11 +369,11 @@ deploy-scp host remote_bin="Thane/bin/thane" target_os=host_os target_arch=host_
 build-macos-pkg version="" target_arch=host_arch output_dir=pkg-dir:
     scripts/releng/build-macos-pkg.sh "{{version}}" "{{target_arch}}" "{{output_dir}}" true
 
-[doc("Operator path: build a signed macOS pkg, install it on a remote Tahoe host via SSH, restart Thane there, and verify the live API version")]
+[doc("Operator path: build a signed macOS pkg, install it on a remote Tahoe host via SSH, and verify the live API version")]
 [group('deploy')]
 [macos]
-deploy-macos-pkg host target_arch=host_arch version="" remote_pkg_dir="/tmp/thane-releng" restart_cmd="" verify_url="http://127.0.0.1:8080/v1/version" verify_timeout_seconds="60":
-    scripts/releng/deploy-macos-pkg.sh "{{host}}" "{{target_arch}}" "{{version}}" "{{remote_pkg_dir}}" "{{restart_cmd}}" "{{verify_url}}" "{{verify_timeout_seconds}}"
+deploy-macos-pkg host target_arch=host_arch version="" remote_pkg_dir="/tmp/thane-releng" verify_url="http://127.0.0.1:8080/v1/version" verify_timeout_seconds="60":
+    scripts/releng/deploy-macos-pkg.sh "{{host}}" "{{target_arch}}" "{{version}}" "{{remote_pkg_dir}}" "{{verify_url}}" "{{verify_timeout_seconds}}"
 
 # Build and run from the local Thane/ working directory (for development)
 [group('operations')]

--- a/justfile
+++ b/justfile
@@ -369,7 +369,7 @@ deploy-scp host remote_bin="Thane/bin/thane" target_os=host_os target_arch=host_
 build-macos-pkg version="" target_arch=host_arch output_dir=pkg-dir:
     scripts/releng/build-macos-pkg.sh "{{version}}" "{{target_arch}}" "{{output_dir}}" true
 
-[doc("Operator path: build a signed macOS pkg, install it on a remote Tahoe host via SSH, and verify the live API version")]
+[doc("Operator path: build, notarize, and deploy a macOS pkg to a remote Tahoe host, then verify the live API version")]
 [group('deploy')]
 [macos]
 deploy-macos-pkg host target_arch=host_arch version="" remote_pkg_dir="/tmp/thane-releng" verify_url="http://127.0.0.1:8080/v1/version" verify_timeout_seconds="60":

--- a/scripts/package-macos-pkg.sh
+++ b/scripts/package-macos-pkg.sh
@@ -58,8 +58,8 @@ cleanup() {
 }
 trap cleanup EXIT
 
-mkdir -p "$payload_root/usr/local/bin" "$localized_resources"
-install -m 755 "$binary_path" "$payload_root/usr/local/bin/thane"
+mkdir -p "$payload_root/Thane/bin" "$localized_resources"
+install -m 755 "$binary_path" "$payload_root/Thane/bin/thane"
 if command -v xattr >/dev/null 2>&1; then
     xattr -cr "$payload_root"
 fi
@@ -76,7 +76,7 @@ cat >"$requirements_plist" <<EOF
         <string>${host_arch}</string>
     </array>
     <key>home</key>
-    <false/>
+    <true/>
 </dict>
 </plist>
 EOF
@@ -84,19 +84,19 @@ EOF
 cat >"$localized_resources/welcome.txt" <<EOF
 Welcome to Thane
 
-This installer places the thane command-line binary in /usr/local/bin so it
-is available to local users from a normal shell.
+This installer places the thane command-line binary in ~/Thane/bin for the
+current macOS account without requiring a machine-wide install.
 EOF
 
 cat >"$localized_resources/readme.txt" <<EOF
 Thane ${version} for ${arch_label}
 
-This package installs thane to /usr/local/bin/thane and is intended for
-local-system installation.
+This package installs thane to ~/Thane/bin/thane for the current macOS
+account.
 
 After installation, run:
 
-  thane version
+  ~/Thane/bin/thane version
 
 to confirm the installed build.
 EOF
@@ -124,22 +124,45 @@ productbuild --synthesize \
     "$distribution_path" >&2
 
 # Add first-party installer metadata so the final product archive is richer to
-# inspect and clearly constrained to the system domain on the intended CPU
-# family.
-distribution_tmp="${distribution_path}.tmp"
-awk '
-    /<installer-gui-script minSpecVersion="1">/ {
-        print
-        print "    <title>Thane Command-Line Agent</title>"
-        print "    <welcome file=\"welcome.txt\" mime-type=\"text/plain\"/>"
-        print "    <readme file=\"readme.txt\" mime-type=\"text/plain\"/>"
-        print "    <license file=\"LICENSE.txt\" mime-type=\"text/plain\"/>"
-        print "    <domains enable_anywhere=\"false\" enable_currentUserHome=\"false\" enable_localSystem=\"true\"/>"
-        next
-    }
-    { print }
-' "$distribution_path" >"$distribution_tmp"
-mv "$distribution_tmp" "$distribution_path"
+# inspect and explicitly models Thane's normal macOS install shape: current
+# user home only, no machine-wide admin install, and one binary under
+# ~/Thane/bin for the chosen account.
+/usr/bin/python3 - "$distribution_path" <<'PY'
+from pathlib import Path
+import sys
+import xml.etree.ElementTree as ET
+
+path = Path(sys.argv[1])
+tree = ET.parse(path)
+root = tree.getroot()
+
+for tag in ("title", "welcome", "readme", "license", "domains"):
+    for node in list(root.findall(tag)):
+        root.remove(node)
+
+metadata = [
+    ET.Element("title"),
+    ET.Element("welcome", {"file": "welcome.txt", "mime-type": "text/plain"}),
+    ET.Element("readme", {"file": "readme.txt", "mime-type": "text/plain"}),
+    ET.Element("license", {"file": "LICENSE.txt", "mime-type": "text/plain"}),
+    ET.Element(
+        "domains",
+        {
+            "enable_anywhere": "false",
+            "enable_currentUserHome": "true",
+            "enable_localSystem": "false",
+        },
+    ),
+]
+metadata[0].text = "Thane Command-Line Agent"
+
+for node in reversed(metadata):
+    root.insert(0, node)
+
+if hasattr(ET, "indent"):
+    ET.indent(tree, space="    ")
+tree.write(path, encoding="utf-8", xml_declaration=True)
+PY
 
 productbuild_args=(
     productbuild

--- a/scripts/package-macos-pkg.sh
+++ b/scripts/package-macos-pkg.sh
@@ -13,11 +13,33 @@ target_arch="$2"
 binary_path="$3"
 output_dir="$4"
 installer_identity="$5"
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "$script_dir/.." && pwd)"
 
 if [ ! -f "$binary_path" ]; then
     echo "binary not found: $binary_path" >&2
     exit 1
 fi
+
+if [ ! -f "$repo_root/LICENSE" ]; then
+    echo "license file not found: $repo_root/LICENSE" >&2
+    exit 1
+fi
+
+case "$target_arch" in
+    amd64)
+        host_arch="x86_64"
+        arch_label="Intel"
+        ;;
+    arm64)
+        host_arch="arm64"
+        arch_label="Apple Silicon"
+        ;;
+    *)
+        echo "unsupported macOS target architecture: $target_arch" >&2
+        exit 1
+        ;;
+esac
 
 mkdir -p "$output_dir"
 
@@ -25,34 +47,115 @@ output_dir="$(cd "$output_dir" && pwd)"
 package_name="thane_${version}_darwin_${target_arch}.pkg"
 stage_dir="$(mktemp -d "${TMPDIR:-/tmp}/thane-pkg.XXXXXX")"
 payload_root="$stage_dir/root"
+component_pkg="$stage_dir/thane-component.pkg"
+distribution_path="$stage_dir/Distribution.xml"
+requirements_plist="$stage_dir/product-requirements.plist"
+resources_root="$stage_dir/Resources"
+localized_resources="$resources_root/English.lproj"
 
 cleanup() {
     rm -rf "$stage_dir"
 }
 trap cleanup EXIT
 
-mkdir -p "$payload_root/usr/local/bin"
+mkdir -p "$payload_root/usr/local/bin" "$localized_resources"
 install -m 755 "$binary_path" "$payload_root/usr/local/bin/thane"
 if command -v xattr >/dev/null 2>&1; then
     xattr -cr "$payload_root"
 fi
 
-args=(
+artifact_path="$output_dir/$package_name"
+
+cat >"$requirements_plist" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>arch</key>
+    <array>
+        <string>${host_arch}</string>
+    </array>
+    <key>home</key>
+    <false/>
+</dict>
+</plist>
+EOF
+
+cat >"$localized_resources/welcome.txt" <<EOF
+Welcome to Thane
+
+This installer places the thane command-line binary in /usr/local/bin so it
+is available to local users from a normal shell.
+EOF
+
+cat >"$localized_resources/readme.txt" <<EOF
+Thane ${version} for ${arch_label}
+
+This package installs thane to /usr/local/bin/thane and is intended for
+local-system installation.
+
+After installation, run:
+
+  thane version
+
+to confirm the installed build.
+EOF
+
+cp "$repo_root/LICENSE" "$localized_resources/LICENSE.txt"
+
+pkgbuild_args=(
     pkgbuild
     --root "$payload_root"
-    --identifier "info.nugget.thane"
+    --identifier "info.nugget.thane.component"
     --version "$version"
     --install-location "/"
+    --ownership recommended
+    --quiet
+    "$component_pkg"
 )
-if [ -n "$installer_identity" ] && [ "$installer_identity" != "-" ]; then
-    args+=(--sign "$installer_identity")
-fi
-artifact_path="$output_dir/$package_name"
-args+=("$artifact_path")
 
 # Keep stdout reserved for the final artifact path so release recipes can
 # safely capture this script's result with command substitution.
-COPYFILE_DISABLE=1 "${args[@]}" >&2
+COPYFILE_DISABLE=1 "${pkgbuild_args[@]}" >&2
+
+productbuild --synthesize \
+    --product "$requirements_plist" \
+    --package "$component_pkg" \
+    "$distribution_path" >&2
+
+# Add first-party installer metadata so the final product archive is richer to
+# inspect and clearly constrained to the system domain on the intended CPU
+# family.
+distribution_tmp="${distribution_path}.tmp"
+awk '
+    /<installer-gui-script minSpecVersion="1">/ {
+        print
+        print "    <title>Thane Command-Line Agent</title>"
+        print "    <welcome file=\"welcome.txt\" mime-type=\"text/plain\"/>"
+        print "    <readme file=\"readme.txt\" mime-type=\"text/plain\"/>"
+        print "    <license file=\"LICENSE.txt\" mime-type=\"text/plain\"/>"
+        print "    <domains enable_anywhere=\"false\" enable_currentUserHome=\"false\" enable_localSystem=\"true\"/>"
+        next
+    }
+    { print }
+' "$distribution_path" >"$distribution_tmp"
+mv "$distribution_tmp" "$distribution_path"
+
+productbuild_args=(
+    productbuild
+    --distribution "$distribution_path"
+    --package-path "$stage_dir"
+    --resources "$resources_root"
+    --identifier "info.nugget.thane"
+    --version "$version"
+    --quiet
+)
+if [ -n "$installer_identity" ] && [ "$installer_identity" != "-" ]; then
+    productbuild_args+=(--sign "$installer_identity")
+fi
+productbuild_args+=("$artifact_path")
+
+COPYFILE_DISABLE=1 "${productbuild_args[@]}" >&2
 
 if [ -n "$installer_identity" ] && [ "$installer_identity" != "-" ]; then
     pkgutil --check-signature "$artifact_path" >&2

--- a/scripts/package-macos-pkg.sh
+++ b/scripts/package-macos-pkg.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+IFS=$'\n\t'
+
+if [ "$#" -ne 5 ]; then
+    echo "usage: $0 <version> <arch> <binary-path> <output-dir> <installer-identity>" >&2
+    exit 1
+fi
+
+version="${1#v}"
+target_arch="$2"
+binary_path="$3"
+output_dir="$4"
+installer_identity="$5"
+
+if [ ! -f "$binary_path" ]; then
+    echo "binary not found: $binary_path" >&2
+    exit 1
+fi
+
+mkdir -p "$output_dir"
+
+output_dir="$(cd "$output_dir" && pwd)"
+package_name="thane_${version}_darwin_${target_arch}.pkg"
+stage_dir="$(mktemp -d "${TMPDIR:-/tmp}/thane-pkg.XXXXXX")"
+payload_root="$stage_dir/root"
+
+cleanup() {
+    rm -rf "$stage_dir"
+}
+trap cleanup EXIT
+
+mkdir -p "$payload_root/usr/local/bin"
+install -m 755 "$binary_path" "$payload_root/usr/local/bin/thane"
+if command -v xattr >/dev/null 2>&1; then
+    xattr -cr "$payload_root"
+fi
+
+args=(
+    pkgbuild
+    --root "$payload_root"
+    --identifier "info.nugget.thane"
+    --version "$version"
+    --install-location "/"
+)
+if [ -n "$installer_identity" ] && [ "$installer_identity" != "-" ]; then
+    args+=(--sign "$installer_identity")
+fi
+artifact_path="$output_dir/$package_name"
+args+=("$artifact_path")
+
+# Keep stdout reserved for the final artifact path so release recipes can
+# safely capture this script's result with command substitution.
+COPYFILE_DISABLE=1 "${args[@]}" >&2
+
+if [ -n "$installer_identity" ] && [ "$installer_identity" != "-" ]; then
+    pkgutil --check-signature "$artifact_path" >&2
+fi
+
+printf '%s\n' "$artifact_path"

--- a/scripts/releng/build-macos-pkg.sh
+++ b/scripts/releng/build-macos-pkg.sh
@@ -26,6 +26,7 @@ case "$target_arch" in
 esac
 
 version="${version_input:-$(git_describe_version)}"
+build_version="v${version#v}"
 
 case "$version" in
     dev) warn "using fallback version label 'dev' because git describe did not find a tag" ;;
@@ -45,13 +46,14 @@ esac
 section "Build macOS installer package"
 step "Branch: $(git rev-parse --abbrev-ref HEAD)"
 step "Version: $version"
+step "Embedded build version: $build_version"
 step "Architecture: $target_arch"
 step "Output directory: $output_dir"
 step "Signing required: $require_signed"
 
 binary="dist/thane-darwin-${target_arch}"
 
-run env THANE_VERSION="$version" just build darwin "$target_arch"
+run env THANE_VERSION="$build_version" just build darwin "$target_arch"
 run just release-sign-macos "$binary"
 
 mkdir -p "$output_dir"

--- a/scripts/releng/build-macos-pkg.sh
+++ b/scripts/releng/build-macos-pkg.sh
@@ -56,7 +56,8 @@ run just release-sign-macos "$binary"
 
 mkdir -p "$output_dir"
 step "Packaging signed installer product"
-pkg_path="$(just --quiet release-package-macos-pkg "$version" "$target_arch" "$binary" "$output_dir" | tail -n 1)"
+pkg_path="$(just release-package-macos-pkg "$version" "$target_arch" "$binary" "$output_dir" | tail -n 1)"
+[[ -n "$pkg_path" ]] || die "release-package-macos-pkg did not report an artifact path"
 
 step "Package ready: $pkg_path"
 printf '%s\n' "$pkg_path"

--- a/scripts/releng/build-macos-pkg.sh
+++ b/scripts/releng/build-macos-pkg.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "$script_dir/../.." && pwd)"
+# shellcheck source=./common.sh
+source "$script_dir/common.sh"
+
+if [[ $# -gt 4 ]]; then
+    die "usage: $0 [version] [target-arch] [output-dir] [require-signed]"
+fi
+
+version_input="${1:-}"
+target_arch="${2:-arm64}"
+output_dir="${3:-dist/pkg}"
+require_signed="${4:-true}"
+
+cd "$repo_root"
+require_macos_host
+require_commands just codesign pkgbuild productbuild pkgutil
+
+case "$target_arch" in
+    amd64|arm64) ;;
+    *) die "unsupported macOS target architecture: $target_arch" ;;
+esac
+
+version="${version_input:-$(git_describe_version)}"
+
+case "$version" in
+    dev) warn "using fallback version label 'dev' because git describe did not find a tag" ;;
+esac
+
+require_clean_worktree "building a macOS pkg from the current checkout"
+
+case "$require_signed" in
+    true)
+        require_real_codesign_identity
+        require_real_installer_identity
+        ;;
+    false) ;;
+    *) die "require-signed must be true or false" ;;
+esac
+
+section "Build macOS installer package"
+step "Branch: $(git rev-parse --abbrev-ref HEAD)"
+step "Version: $version"
+step "Architecture: $target_arch"
+step "Output directory: $output_dir"
+step "Signing required: $require_signed"
+
+binary="dist/thane-darwin-${target_arch}"
+
+run env THANE_VERSION="$version" just build darwin "$target_arch"
+run just release-sign-macos "$binary"
+
+mkdir -p "$output_dir"
+step "Packaging signed installer product"
+pkg_path="$(just --quiet release-package-macos-pkg "$version" "$target_arch" "$binary" "$output_dir" | tail -n 1)"
+
+step "Package ready: $pkg_path"
+printf '%s\n' "$pkg_path"

--- a/scripts/releng/common.sh
+++ b/scripts/releng/common.sh
@@ -80,7 +80,9 @@ worktree_dirty() {
 
 require_clean_worktree() {
     local context="${1:-operation}"
-    worktree_dirty && die "worktree must be clean before ${context}"
+    if worktree_dirty; then
+        die "worktree must be clean before ${context}"
+    fi
 }
 
 warn_if_dirty_worktree() {

--- a/scripts/releng/common.sh
+++ b/scripts/releng/common.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Shared helpers for human-facing release-engineering scripts. Keep the
+# progress output legible and fail early on missing prerequisites so the
+# operator does not have to reconstruct state from half-completed shell output.
+
+if [[ -t 1 ]]; then
+    _RELENG_BOLD=$'\033[1m'
+    _RELENG_BLUE=$'\033[34m'
+    _RELENG_CYAN=$'\033[36m'
+    _RELENG_YELLOW=$'\033[33m'
+    _RELENG_RED=$'\033[31m'
+    _RELENG_RESET=$'\033[0m'
+else
+    _RELENG_BOLD=""
+    _RELENG_BLUE=""
+    _RELENG_CYAN=""
+    _RELENG_YELLOW=""
+    _RELENG_RED=""
+    _RELENG_RESET=""
+fi
+
+section() {
+    printf '\n%s%s==> %s%s\n' "$_RELENG_BOLD" "$_RELENG_BLUE" "$*" "$_RELENG_RESET"
+}
+
+step() {
+    printf '%s%s -> %s%s\n' "$_RELENG_BOLD" "$_RELENG_CYAN" "$*" "$_RELENG_RESET"
+}
+
+warn() {
+    printf '%s%s !! %s%s\n' "$_RELENG_BOLD" "$_RELENG_YELLOW" "$*" "$_RELENG_RESET" >&2
+}
+
+die() {
+    printf '%s%s !! %s%s\n' "$_RELENG_BOLD" "$_RELENG_RED" "$*" "$_RELENG_RESET" >&2
+    exit 1
+}
+
+run() {
+    step "$*"
+    "$@"
+}
+
+require_command() {
+    local cmd="$1"
+    command -v "$cmd" >/dev/null 2>&1 || die "required command not found: $cmd"
+}
+
+require_commands() {
+    local cmd
+    for cmd in "$@"; do
+        require_command "$cmd"
+    done
+}
+
+require_macos_host() {
+    [[ "$(uname -s)" == "Darwin" ]] || die "this workflow must run on a macOS host"
+}
+
+normalize_version() {
+    local version="$1"
+    printf '%s\n' "${version#v}"
+}
+
+validate_release_version() {
+    local version="$1"
+    [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$ ]] || \
+        die "version must look like 0.9.0 or 0.9.0-rc.1"
+}
+
+git_describe_version() {
+    git describe --tags --always --dirty 2>/dev/null || echo dev
+}
+
+worktree_dirty() {
+    [[ -n "$(git status --short)" ]]
+}
+
+require_clean_worktree() {
+    local context="${1:-operation}"
+    worktree_dirty && die "worktree must be clean before ${context}"
+}
+
+warn_if_dirty_worktree() {
+    local context="${1:-operation}"
+    if worktree_dirty; then
+        warn "worktree is dirty; continuing with ${context}"
+        git status --short
+    fi
+}
+
+require_main_branch() {
+    local branch
+    branch="$(git rev-parse --abbrev-ref HEAD)"
+    [[ "$branch" == "main" ]] || die "this workflow must run from main (current branch: $branch)"
+}
+
+require_origin_main_match() {
+    run git fetch origin main --tags
+    local head_commit origin_main
+    head_commit="$(git rev-parse HEAD)"
+    origin_main="$(git rev-parse origin/main)"
+    [[ "$head_commit" == "$origin_main" ]] || die "local main must match origin/main before cutting a release"
+}
+
+require_real_codesign_identity() {
+    local identity="${THANE_CODESIGN_IDENTITY:-}"
+    [[ -n "$identity" && "$identity" != "-" ]] || \
+        die "set THANE_CODESIGN_IDENTITY to a real Developer ID Application certificate"
+}
+
+require_real_installer_identity() {
+    local identity="${THANE_INSTALLER_IDENTITY:-}"
+    [[ -n "$identity" && "$identity" != "-" ]] || \
+        die "set THANE_INSTALLER_IDENTITY to a real Developer ID Installer certificate"
+}
+
+require_notary_profile() {
+    [[ -n "${THANE_NOTARY_PROFILE:-}" ]] || \
+        die "set THANE_NOTARY_PROFILE to a notarytool keychain profile"
+}
+
+require_github_token() {
+    [[ -n "${THANE_GH_TOKEN:-}" ]] || die "set THANE_GH_TOKEN before publishing GitHub releases"
+}
+
+validate_release_kind() {
+    local kind="$1"
+    case "$kind" in
+        auto|prerelease|release) ;;
+        *) die "release_kind must be one of: auto, prerelease, release" ;;
+    esac
+}
+
+resolve_prerelease_bool() {
+    local version="$1"
+    local kind="$2"
+    case "$kind" in
+        prerelease) printf 'true\n' ;;
+        release) printf 'false\n' ;;
+        auto)
+            if [[ "$version" == *-* ]]; then
+                printf 'true\n'
+            else
+                printf 'false\n'
+            fi
+            ;;
+    esac
+}

--- a/scripts/releng/deploy-macos-pkg.sh
+++ b/scripts/releng/deploy-macos-pkg.sh
@@ -24,10 +24,11 @@ fi
 
 cd "$repo_root"
 require_macos_host
-require_commands just ssh scp
+require_commands just ssh scp xcrun
 require_clean_worktree "building and deploying a macOS pkg"
 require_real_codesign_identity
 require_real_installer_identity
+require_notary_profile
 
 version="${version_input:-$(git_describe_version)}"
 expected_version="v${version#v}"
@@ -36,6 +37,11 @@ section "Build macOS installer package"
 pkg_path="$("$script_dir/build-macos-pkg.sh" "$version" "$target_arch" "dist/pkg" true | tail -n 1)"
 pkg_name="$(basename "$pkg_path")"
 remote_pkg_path="${remote_pkg_dir}/${pkg_name}"
+
+section "Notarize macOS installer package"
+step "Submitting $pkg_name with keychain profile: ${THANE_NOTARY_PROFILE}"
+run just release-notarize-macos "$pkg_path" "${THANE_NOTARY_PROFILE}"
+run just release-staple-macos "$pkg_path"
 
 section "Deploy package to remote host"
 step "Remote host: $host"

--- a/scripts/releng/deploy-macos-pkg.sh
+++ b/scripts/releng/deploy-macos-pkg.sh
@@ -67,12 +67,21 @@ while (( SECONDS < deadline )); do
         ssh "$host" /usr/bin/python3 - "$verify_url" <<'PY'
 import json
 import sys
+import urllib.error
 import urllib.request
 
 url = sys.argv[1]
-with urllib.request.urlopen(url, timeout=5) as resp:
-    data = json.load(resp)
-print(data.get("version", ""))
+try:
+    with urllib.request.urlopen(url, timeout=5) as resp:
+        data = json.load(resp)
+except (urllib.error.URLError, TimeoutError, OSError, ValueError, json.JSONDecodeError):
+    raise SystemExit(1)
+
+version = str(data.get("version", "")).strip()
+if not version:
+    raise SystemExit(1)
+
+print(version)
 PY
     )"; then
         remote_version="${remote_version//$'\r'/}"

--- a/scripts/releng/deploy-macos-pkg.sh
+++ b/scripts/releng/deploy-macos-pkg.sh
@@ -15,7 +15,11 @@ host="$1"
 target_arch="${2:-arm64}"
 version_input="${3:-}"
 remote_pkg_dir="${4:-/tmp/thane-releng}"
-restart_cmd="${5:-launchctl kickstart -k gui/\$(id -u)/info.nugget.thane}"
+restart_cmd="${5:-}"
+
+if [[ -z "$restart_cmd" ]]; then
+    restart_cmd='launchctl kickstart -k gui/$(id -u)/info.nugget.thane'
+fi
 
 cd "$repo_root"
 require_macos_host

--- a/scripts/releng/deploy-macos-pkg.sh
+++ b/scripts/releng/deploy-macos-pkg.sh
@@ -7,21 +7,16 @@ repo_root="$(cd "$script_dir/../.." && pwd)"
 # shellcheck source=./common.sh
 source "$script_dir/common.sh"
 
-if [[ $# -lt 1 || $# -gt 7 ]]; then
-    die "usage: $0 <user@host> [target-arch] [version] [remote-pkg-dir] [restart-cmd] [verify-url] [verify-timeout-seconds]"
+if [[ $# -lt 1 || $# -gt 6 ]]; then
+    die "usage: $0 <user@host> [target-arch] [version] [remote-pkg-dir] [verify-url] [verify-timeout-seconds]"
 fi
 
 host="$1"
 target_arch="${2:-arm64}"
 version_input="${3:-}"
 remote_pkg_dir="${4:-/tmp/thane-releng}"
-restart_cmd="${5:-}"
-verify_url="${6:-http://127.0.0.1:8080/v1/version}"
-verify_timeout_seconds="${7:-60}"
-
-if [[ -z "$restart_cmd" ]]; then
-    restart_cmd='launchctl kickstart -k gui/$(id -u)/info.nugget.thane'
-fi
+verify_url="${5:-http://127.0.0.1:8080/v1/version}"
+verify_timeout_seconds="${6:-60}"
 
 if ! [[ "$verify_timeout_seconds" =~ ^[0-9]+$ ]] || [[ "$verify_timeout_seconds" -le 0 ]]; then
     die "verify-timeout-seconds must be a positive integer"
@@ -54,11 +49,6 @@ run scp -p "$pkg_path" "${host}:${remote_pkg_path}"
 run ssh "$host" "pkgutil --check-signature '$remote_pkg_path'"
 
 run ssh "$host" "installer -pkg '$remote_pkg_path' -target CurrentUserHomeDirectory"
-
-if [[ -n "$restart_cmd" ]]; then
-    run ssh "$host" "$restart_cmd"
-fi
-
 run ssh "$host" "rm -f '$remote_pkg_path'"
 
 section "Verify remote live version"

--- a/scripts/releng/deploy-macos-pkg.sh
+++ b/scripts/releng/deploy-macos-pkg.sh
@@ -23,6 +23,10 @@ if [[ -z "$restart_cmd" ]]; then
     restart_cmd='launchctl kickstart -k gui/$(id -u)/info.nugget.thane'
 fi
 
+if ! [[ "$verify_timeout_seconds" =~ ^[0-9]+$ ]] || [[ "$verify_timeout_seconds" -le 0 ]]; then
+    die "verify-timeout-seconds must be a positive integer"
+fi
+
 cd "$repo_root"
 require_macos_host
 require_commands just ssh scp

--- a/scripts/releng/deploy-macos-pkg.sh
+++ b/scripts/releng/deploy-macos-pkg.sh
@@ -7,8 +7,8 @@ repo_root="$(cd "$script_dir/../.." && pwd)"
 # shellcheck source=./common.sh
 source "$script_dir/common.sh"
 
-if [[ $# -lt 1 || $# -gt 5 ]]; then
-    die "usage: $0 <user@host> [target-arch] [version] [remote-pkg-dir] [restart-cmd]"
+if [[ $# -lt 1 || $# -gt 7 ]]; then
+    die "usage: $0 <user@host> [target-arch] [version] [remote-pkg-dir] [restart-cmd] [verify-url] [verify-timeout-seconds]"
 fi
 
 host="$1"
@@ -16,6 +16,8 @@ target_arch="${2:-arm64}"
 version_input="${3:-}"
 remote_pkg_dir="${4:-/tmp/thane-releng}"
 restart_cmd="${5:-}"
+verify_url="${6:-http://127.0.0.1:8080/v1/version}"
+verify_timeout_seconds="${7:-60}"
 
 if [[ -z "$restart_cmd" ]]; then
     restart_cmd='launchctl kickstart -k gui/$(id -u)/info.nugget.thane'
@@ -28,8 +30,11 @@ require_clean_worktree "building and deploying a macOS pkg"
 require_real_codesign_identity
 require_real_installer_identity
 
+version="${version_input:-$(git_describe_version)}"
+expected_version="v${version#v}"
+
 section "Build macOS installer package"
-pkg_path="$("$script_dir/build-macos-pkg.sh" "$version_input" "$target_arch" "dist/pkg" true | tail -n 1)"
+pkg_path="$("$script_dir/build-macos-pkg.sh" "$version" "$target_arch" "dist/pkg" true | tail -n 1)"
 pkg_name="$(basename "$pkg_path")"
 remote_pkg_path="${remote_pkg_dir}/${pkg_name}"
 
@@ -37,6 +42,8 @@ section "Deploy package to remote host"
 step "Remote host: $host"
 step "Remote staging path: $remote_pkg_path"
 step "Remote install domain: CurrentUserHomeDirectory"
+step "Expected live version: $expected_version"
+step "Verify URL: $verify_url"
 
 run ssh "$host" "mkdir -p '$remote_pkg_dir'"
 run scp -p "$pkg_path" "${host}:${remote_pkg_path}"
@@ -49,7 +56,38 @@ if [[ -n "$restart_cmd" ]]; then
 fi
 
 run ssh "$host" "rm -f '$remote_pkg_path'"
-run ssh "$host" "~/Thane/bin/thane version"
 
-section "Deployment complete"
-step "Installed $(basename "$pkg_path") on $host and refreshed the running service"
+section "Verify remote live version"
+step "Waiting up to ${verify_timeout_seconds}s for $verify_url to report $expected_version"
+
+deadline=$((SECONDS + verify_timeout_seconds))
+last_status="remote API not ready yet"
+while (( SECONDS < deadline )); do
+    if remote_version="$(
+        ssh "$host" /usr/bin/python3 - "$verify_url" <<'PY'
+import json
+import sys
+import urllib.request
+
+url = sys.argv[1]
+with urllib.request.urlopen(url, timeout=5) as resp:
+    data = json.load(resp)
+print(data.get("version", ""))
+PY
+    )"; then
+        remote_version="${remote_version//$'\r'/}"
+        remote_version="${remote_version//$'\n'/}"
+        if [[ "$remote_version" == "$expected_version" ]]; then
+            step "Remote API reports version: $remote_version"
+            section "Deployment complete"
+            step "Installed $(basename "$pkg_path") on $host and verified the running Thane API"
+            exit 0
+        fi
+        last_status="remote API reported version '$remote_version'"
+    else
+        last_status="remote API not ready yet"
+    fi
+    sleep 2
+done
+
+die "timed out after ${verify_timeout_seconds}s waiting for $verify_url on $host to report version $expected_version (${last_status})"

--- a/scripts/releng/deploy-macos-pkg.sh
+++ b/scripts/releng/deploy-macos-pkg.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "$script_dir/../.." && pwd)"
+# shellcheck source=./common.sh
+source "$script_dir/common.sh"
+
+if [[ $# -lt 1 || $# -gt 5 ]]; then
+    die "usage: $0 <user@host> [target-arch] [version] [remote-pkg-dir] [restart-cmd]"
+fi
+
+host="$1"
+target_arch="${2:-arm64}"
+version_input="${3:-}"
+remote_pkg_dir="${4:-/tmp/thane-releng}"
+restart_cmd="${5:-launchctl kickstart -k gui/\$(id -u)/info.nugget.thane}"
+
+cd "$repo_root"
+require_macos_host
+require_commands just ssh scp
+require_clean_worktree "building and deploying a macOS pkg"
+require_real_codesign_identity
+require_real_installer_identity
+
+section "Build macOS installer package"
+pkg_path="$("$script_dir/build-macos-pkg.sh" "$version_input" "$target_arch" "dist/pkg" true | tail -n 1)"
+pkg_name="$(basename "$pkg_path")"
+remote_pkg_path="${remote_pkg_dir}/${pkg_name}"
+
+section "Deploy package to remote host"
+step "Remote host: $host"
+step "Remote staging path: $remote_pkg_path"
+step "Remote install domain: CurrentUserHomeDirectory"
+
+run ssh "$host" "mkdir -p '$remote_pkg_dir'"
+run scp -p "$pkg_path" "${host}:${remote_pkg_path}"
+run ssh "$host" "pkgutil --check-signature '$remote_pkg_path'"
+
+run ssh "$host" "installer -pkg '$remote_pkg_path' -target CurrentUserHomeDirectory"
+
+if [[ -n "$restart_cmd" ]]; then
+    run ssh "$host" "$restart_cmd"
+fi
+
+run ssh "$host" "rm -f '$remote_pkg_path'"
+run ssh "$host" "~/Thane/bin/thane version"
+
+section "Deployment complete"
+step "Installed $(basename "$pkg_path") on $host and refreshed the running service"

--- a/scripts/releng/release-github.sh
+++ b/scripts/releng/release-github.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "$script_dir/../.." && pwd)"
+# shellcheck source=./common.sh
+source "$script_dir/common.sh"
+
+if [[ $# -lt 1 || $# -gt 3 ]]; then
+    die "usage: $0 <version> [release-kind] [container-tag]"
+fi
+
+version="$(normalize_version "$1")"
+release_kind="${2:-auto}"
+container_tag="${3:-thane:prepare-release}"
+
+cd "$repo_root"
+require_macos_host
+require_commands just docker gh codesign pkgbuild productbuild xcrun
+
+validate_release_version "$version"
+validate_release_kind "$release_kind"
+require_clean_worktree "cutting a GitHub release"
+require_main_branch
+require_origin_main_match
+require_real_codesign_identity
+require_real_installer_identity
+require_notary_profile
+require_github_token
+
+prerelease="$(resolve_prerelease_bool "$version" "$release_kind")"
+
+section "Cut GitHub release"
+step "Version: v$version"
+step "Release kind: $release_kind (prerelease=${prerelease})"
+step "Container smoke tag: $container_tag"
+
+section "Prepare release artifacts"
+run just prepare-release "v$version" "$container_tag"
+
+section "Publish GitHub release"
+run just publish-release "v$version" "$release_kind"
+
+section "Release complete"
+step "GitHub release v$version is published"


### PR DESCRIPTION
## Summary
- ship Apple-native macOS installer products that align with Thane's home-scoped install model
- add human-facing releng workflows for guarded GitHub releases and pkg-based live-host deploys
- tighten release publication so prerelease vs full release intent is explicit on GitHub

## Why
Issue #709 started as a packaging problem, but the real operator pain was larger than that.

The old macOS path produced notarized `.zip` payloads that could not carry a stapled ticket, so offline inspection still looked second-class. It also left the day-to-day release workflow too fragmented: the right sequence existed, but the comfortable path for the human coordinating releases and live deploys was not yet first-class.

This PR makes the artifact and the workflow tell the same story:
- Thane on macOS installs into `~/Thane/bin`
- release artifacts should be real installer packages that Apple tools can inspect cleanly
- a real GitHub release should be a guarded, one-command path from a clean `main`
- live-host testing should exercise the pkg installer path too, not fall back to copying raw Mach-O binaries around out of convenience

## What changed
### macOS installer artifacts
- switched macOS release artifacts from notarized `.zip` payloads to signed and stapled `.pkg` installer products
- changed the macOS helper from a bare component package to a `productbuild` product archive built from a `pkgbuild` payload
- aligned the installer payload with Thane's real macOS layout:
  - installs `thane` to `~/Thane/bin/thane`
  - advertises `CurrentUserHomeDirectory` as the only install domain
  - avoids a machine-wide admin install path by default
- added richer installer metadata:
  - product title
  - welcome/readme/license resources
  - explicit target CPU family in the synthesized distribution
- kept the installer identity separate via `THANE_INSTALLER_IDENTITY`

### Releng workflows
- added standalone releng helper scripts under `scripts/releng/` so the operator workflows are readable shell, not deeply embedded `justfile` quoting
- added `just build-macos-pkg` for building a signed macOS installer package from the current clean checkout
- added `just deploy-macos-pkg user@host` for pkg-based live-host deploys over SSH, including remote signature inspection, install, restart, and version verification
- added `just release-github <version> [auto|prerelease|release]` as the preferred one-command release path from a clean `main`
- kept `prepare-release` / `publish-release` as lower-level building blocks for intentional breakpoint workflows
- taught GitHub release upload logic about explicit prerelease vs full release state and idempotent behavior against existing mutable/immutable releases

### Docs
- added a dedicated operator guide at `docs/operating/release-engineering.md`
- updated README, deployment docs, docs index, and release checklist to point humans at the new preferred paths

## Design notes
- Kept the release path local-first on a macOS Tahoe workstation, which is where the Apple credentials and tooling already live.
- Kept the installer home-scoped because it matches Thane's real macOS service/account model and avoids inventing an admin-oriented install story the product does not actually want.
- Chose to make the live deploy path pkg-based as well, so development and production exercise the same artifact type.
- Moved the more complicated operator logic into standalone scripts with `set -euo pipefail` and explicit progress markers so the console output stays readable without hiding subprocess output.

## Validation
- `bash -n scripts/releng/*.sh`
- `just ci`
- local smoke test of `scripts/releng/build-macos-pkg.sh` in ad-hoc-signing mode to verify the new script path end to end
- verified `installer -pkg <artifact> -dominfo` reports `CurrentUserHomeDirectory`
- verified the expanded installer distribution still shows:
  - `enable_currentUserHome="true"`
  - `enable_localSystem="false"`
  - the expected `hostArchitectures` value

## Operator prerequisites
### `just release-github ...`
- clean checkout
- `main`
- local `main` matches `origin/main`
- `THANE_CODESIGN_IDENTITY`
- `THANE_INSTALLER_IDENTITY`
- `THANE_NOTARY_PROFILE`
- `THANE_GH_TOKEN`

### `just deploy-macos-pkg ...`
- clean checkout
- `THANE_CODESIGN_IDENTITY`
- `THANE_INSTALLER_IDENTITY`
- remote host running macOS Tahoe with a home-scoped Thane install
