### PR TITLE
feat: finish indexed document navigation

### DIFF
--- a/internal/documents/contracts.go
+++ b/internal/documents/contracts.go
@@ -1,0 +1,43 @@
+package documents
+
+import "time"
+
+// DocumentLink is one outgoing link projected from an indexed document.
+type DocumentLink struct {
+	Target string `json:"target"`
+	Kind   string `json:"kind"`
+	Ref    string `json:"ref,omitempty"`
+	Title  string `json:"title,omitempty"`
+	URL    string `json:"url,omitempty"`
+	Anchor string `json:"anchor,omitempty"`
+}
+
+// Backlink is one indexed document that links to another document.
+type Backlink struct {
+	Ref        string   `json:"ref"`
+	Path       string   `json:"path"`
+	Title      string   `json:"title"`
+	ModifiedAt string   `json:"modified_at"`
+	Targets    []string `json:"targets,omitempty"`
+}
+
+// LinksResult is the outgoing/backlink view for one indexed document.
+type LinksResult struct {
+	Ref       string         `json:"ref"`
+	Mode      string         `json:"mode"`
+	Outgoing  []DocumentLink `json:"outgoing,omitempty"`
+	Backlinks []Backlink     `json:"backlinks,omitempty"`
+}
+
+// SearchQuery filters document search results.
+type SearchQuery struct {
+	Root            string              `json:"root,omitempty"`
+	PathPrefix      string              `json:"path_prefix,omitempty"`
+	Query           string              `json:"query,omitempty"`
+	Tags            []string            `json:"tags,omitempty"`
+	Frontmatter     map[string][]string `json:"frontmatter,omitempty"`
+	FrontmatterKeys []string            `json:"frontmatter_keys,omitempty"`
+	ModifiedAfter   *time.Time          `json:"-"`
+	ModifiedBefore  *time.Time          `json:"-"`
+	Limit           int                 `json:"limit,omitempty"`
+}

--- a/internal/documents/contracts.go
+++ b/internal/documents/contracts.go
@@ -14,19 +14,24 @@ type DocumentLink struct {
 
 // Backlink is one indexed document that links to another document.
 type Backlink struct {
-	Ref        string   `json:"ref"`
-	Path       string   `json:"path"`
-	Title      string   `json:"title"`
-	ModifiedAt string   `json:"modified_at"`
-	Targets    []string `json:"targets,omitempty"`
+	Ref              string   `json:"ref"`
+	Path             string   `json:"path"`
+	Title            string   `json:"title"`
+	ModifiedAt       string   `json:"modified_at"`
+	Targets          []string `json:"targets,omitempty"`
+	TargetsTruncated bool     `json:"targets_truncated,omitempty"`
 }
 
 // LinksResult is the outgoing/backlink view for one indexed document.
 type LinksResult struct {
-	Ref       string         `json:"ref"`
-	Mode      string         `json:"mode"`
-	Outgoing  []DocumentLink `json:"outgoing,omitempty"`
-	Backlinks []Backlink     `json:"backlinks,omitempty"`
+	Ref                string         `json:"ref"`
+	Mode               string         `json:"mode"`
+	Limit              int            `json:"limit,omitempty"`
+	PerBacklinkLimit   int            `json:"per_backlink_limit,omitempty"`
+	Outgoing           []DocumentLink `json:"outgoing,omitempty"`
+	OutgoingTruncated  bool           `json:"outgoing_truncated,omitempty"`
+	Backlinks          []Backlink     `json:"backlinks,omitempty"`
+	BacklinksTruncated bool           `json:"backlinks_truncated,omitempty"`
 }
 
 // SearchQuery filters document search results.

--- a/internal/documents/links.go
+++ b/internal/documents/links.go
@@ -27,7 +27,7 @@ type documentIndex struct {
 }
 
 // Links returns outgoing links, backlinks, or both for one indexed document.
-func (s *Store) Links(ctx context.Context, ref string, mode string) (*LinksResult, error) {
+func (s *Store) Links(ctx context.Context, ref string, mode string, limit int, perBacklinkLimit int) (*LinksResult, error) {
 	if err := s.Refresh(ctx); err != nil {
 		return nil, err
 	}
@@ -39,37 +39,55 @@ func (s *Store) Links(ctx context.Context, ref string, mode string) (*LinksResul
 	if err != nil {
 		return nil, err
 	}
-	index, err := s.loadDocumentIndex(ctx)
+	includeLinks := mode != "outgoing"
+	index, err := s.loadDocumentIndex(ctx, includeLinks)
 	if err != nil {
 		return nil, err
 	}
-	entry, ok := index.byRef[makeRef(root, relPath)]
+	canonicalRef := makeRef(root, relPath)
+	entry, ok := index.byRef[canonicalRef]
 	if !ok {
 		return nil, fmt.Errorf("document not found: %s", ref)
 	}
+	if mode == "outgoing" {
+		links, err := s.loadDocumentLinks(ctx, entry.Root, entry.Path)
+		if err != nil {
+			return nil, err
+		}
+		entry.Links = links
+	}
 
 	result := &LinksResult{
-		Ref:  ref,
-		Mode: mode,
+		Ref:              entry.Ref,
+		Mode:             mode,
+		Limit:            limit,
+		PerBacklinkLimit: perBacklinkLimit,
 	}
 	if mode != "backlinks" {
-		result.Outgoing = make([]DocumentLink, 0, len(entry.Links))
+		outgoing := make([]DocumentLink, 0, len(entry.Links))
 		for _, target := range entry.Links {
-			result.Outgoing = append(result.Outgoing, resolveDocumentLink(index, entry, target))
+			outgoing = append(outgoing, resolveDocumentLink(index, entry, target))
 		}
+		if limit > 0 && len(outgoing) > limit {
+			result.OutgoingTruncated = true
+			outgoing = outgoing[:limit]
+		}
+		result.Outgoing = outgoing
 	}
 	if mode != "outgoing" {
-		result.Backlinks = backlinksForRef(index, entry.Ref)
+		result.Backlinks, result.BacklinksTruncated = backlinksForRef(index, entry.Ref, limit, perBacklinkLimit)
 	}
 	return result, nil
 }
 
-func (s *Store) loadDocumentIndex(ctx context.Context) (*documentIndex, error) {
-	rows, err := s.db.QueryContext(ctx,
-		`SELECT root, rel_path, title, modified_at, links_json
+func (s *Store) loadDocumentIndex(ctx context.Context, includeLinks bool) (*documentIndex, error) {
+	query := `SELECT root, rel_path, title, modified_at FROM indexed_documents ORDER BY root, rel_path`
+	if includeLinks {
+		query = `SELECT root, rel_path, title, modified_at, links_json
 		 FROM indexed_documents
-		 ORDER BY root, rel_path`,
-	)
+		 ORDER BY root, rel_path`
+	}
+	rows, err := s.db.QueryContext(ctx, query)
 	if err != nil {
 		return nil, fmt.Errorf("query document link index: %w", err)
 	}
@@ -91,12 +109,19 @@ func (s *Store) loadDocumentIndex(ctx context.Context) (*documentIndex, error) {
 			modifiedAt string
 			linksJSON  string
 		)
-		if err := rows.Scan(&root, &relPath, &title, &modifiedAt, &linksJSON); err != nil {
+		if includeLinks {
+			if err := rows.Scan(&root, &relPath, &title, &modifiedAt, &linksJSON); err != nil {
+				return nil, fmt.Errorf("scan document link index: %w", err)
+			}
+		} else if err := rows.Scan(&root, &relPath, &title, &modifiedAt); err != nil {
 			return nil, fmt.Errorf("scan document link index: %w", err)
 		}
 		var links []string
-		if err := json.Unmarshal([]byte(linksJSON), &links); err != nil {
-			links = nil
+		if includeLinks {
+			links, err = decodeDocumentLinks(root, relPath, linksJSON)
+			if err != nil {
+				return nil, err
+			}
 		}
 		entry := documentIndexEntry{
 			Root:       root,
@@ -122,9 +147,29 @@ func (s *Store) loadDocumentIndex(ctx context.Context) (*documentIndex, error) {
 	return index, nil
 }
 
-func backlinksForRef(index *documentIndex, targetRef string) []Backlink {
+func (s *Store) loadDocumentLinks(ctx context.Context, root string, relPath string) ([]string, error) {
+	var linksJSON string
+	err := s.db.QueryRowContext(ctx,
+		`SELECT links_json FROM indexed_documents WHERE root = ? AND rel_path = ?`,
+		root, relPath,
+	).Scan(&linksJSON)
+	if err != nil {
+		return nil, fmt.Errorf("query document links for %s/%s: %w", root, relPath, err)
+	}
+	return decodeDocumentLinks(root, relPath, linksJSON)
+}
+
+func decodeDocumentLinks(root string, relPath string, linksJSON string) ([]string, error) {
+	var links []string
+	if err := json.Unmarshal([]byte(linksJSON), &links); err != nil {
+		return nil, fmt.Errorf("unmarshal document links for %s/%s: %w", root, relPath, err)
+	}
+	return links, nil
+}
+
+func backlinksForRef(index *documentIndex, targetRef string, limit int, perBacklinkLimit int) ([]Backlink, bool) {
 	if index == nil {
-		return nil
+		return nil, false
 	}
 	bySource := make(map[string]*Backlink)
 	for _, entry := range index.byRef {
@@ -150,11 +195,15 @@ func backlinksForRef(index *documentIndex, targetRef string) []Backlink {
 		}
 	}
 	if len(bySource) == 0 {
-		return nil
+		return nil, false
 	}
 	out := make([]Backlink, 0, len(bySource))
 	for _, backlink := range bySource {
 		backlink.Targets = dedupeSorted(backlink.Targets)
+		if perBacklinkLimit > 0 && len(backlink.Targets) > perBacklinkLimit {
+			backlink.Targets = backlink.Targets[:perBacklinkLimit]
+			backlink.TargetsTruncated = true
+		}
 		out = append(out, *backlink)
 	}
 	sort.Slice(out, func(i, j int) bool {
@@ -165,7 +214,12 @@ func backlinksForRef(index *documentIndex, targetRef string) []Backlink {
 		}
 		return ti.After(tj)
 	})
-	return out
+	truncated := false
+	if limit > 0 && len(out) > limit {
+		truncated = true
+		out = out[:limit]
+	}
+	return out, truncated
 }
 
 func resolveDocumentLink(index *documentIndex, source documentIndexEntry, rawTarget string) DocumentLink {

--- a/internal/documents/links.go
+++ b/internal/documents/links.go
@@ -1,0 +1,341 @@
+package documents
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"path"
+	"sort"
+	"strings"
+
+	"github.com/nugget/thane-ai-agent/internal/database"
+)
+
+type documentIndexEntry struct {
+	Root       string
+	Path       string
+	Ref        string
+	Title      string
+	ModifiedAt string
+	Links      []string
+}
+
+type documentIndex struct {
+	byRef        map[string]documentIndexEntry
+	byRootTitles map[string]map[string][]documentIndexEntry
+	roots        map[string]bool
+}
+
+// Links returns outgoing links, backlinks, or both for one indexed document.
+func (s *Store) Links(ctx context.Context, ref string, mode string) (*LinksResult, error) {
+	if err := s.Refresh(ctx); err != nil {
+		return nil, err
+	}
+	root, relPath, err := parseRef(ref)
+	if err != nil {
+		return nil, err
+	}
+	mode, err = normalizeLinkMode(mode)
+	if err != nil {
+		return nil, err
+	}
+	index, err := s.loadDocumentIndex(ctx)
+	if err != nil {
+		return nil, err
+	}
+	entry, ok := index.byRef[makeRef(root, relPath)]
+	if !ok {
+		return nil, fmt.Errorf("document not found: %s", ref)
+	}
+
+	result := &LinksResult{
+		Ref:  ref,
+		Mode: mode,
+	}
+	if mode != "backlinks" {
+		result.Outgoing = make([]DocumentLink, 0, len(entry.Links))
+		for _, target := range entry.Links {
+			result.Outgoing = append(result.Outgoing, resolveDocumentLink(index, entry, target))
+		}
+	}
+	if mode != "outgoing" {
+		result.Backlinks = backlinksForRef(index, entry.Ref)
+	}
+	return result, nil
+}
+
+func (s *Store) loadDocumentIndex(ctx context.Context) (*documentIndex, error) {
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT root, rel_path, title, modified_at, links_json
+		 FROM indexed_documents
+		 ORDER BY root, rel_path`,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("query document link index: %w", err)
+	}
+	defer rows.Close()
+
+	index := &documentIndex{
+		byRef:        make(map[string]documentIndexEntry),
+		byRootTitles: make(map[string]map[string][]documentIndexEntry),
+		roots:        make(map[string]bool, len(s.roots)),
+	}
+	for root := range s.roots {
+		index.roots[root] = true
+	}
+	for rows.Next() {
+		var (
+			root       string
+			relPath    string
+			title      string
+			modifiedAt string
+			linksJSON  string
+		)
+		if err := rows.Scan(&root, &relPath, &title, &modifiedAt, &linksJSON); err != nil {
+			return nil, fmt.Errorf("scan document link index: %w", err)
+		}
+		var links []string
+		if err := json.Unmarshal([]byte(linksJSON), &links); err != nil {
+			links = nil
+		}
+		entry := documentIndexEntry{
+			Root:       root,
+			Path:       relPath,
+			Ref:        makeRef(root, relPath),
+			Title:      title,
+			ModifiedAt: modifiedAt,
+			Links:      links,
+		}
+		index.byRef[entry.Ref] = entry
+		titleKey := strings.ToLower(strings.TrimSpace(title))
+		if titleKey == "" {
+			continue
+		}
+		if index.byRootTitles[root] == nil {
+			index.byRootTitles[root] = make(map[string][]documentIndexEntry)
+		}
+		index.byRootTitles[root][titleKey] = append(index.byRootTitles[root][titleKey], entry)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return index, nil
+}
+
+func backlinksForRef(index *documentIndex, targetRef string) []Backlink {
+	if index == nil {
+		return nil
+	}
+	bySource := make(map[string]*Backlink)
+	for _, entry := range index.byRef {
+		if entry.Ref == targetRef {
+			continue
+		}
+		for _, rawTarget := range entry.Links {
+			resolved := resolveDocumentLink(index, entry, rawTarget)
+			if resolved.Ref != targetRef {
+				continue
+			}
+			backlink := bySource[entry.Ref]
+			if backlink == nil {
+				backlink = &Backlink{
+					Ref:        entry.Ref,
+					Path:       entry.Path,
+					Title:      entry.Title,
+					ModifiedAt: entry.ModifiedAt,
+				}
+				bySource[entry.Ref] = backlink
+			}
+			backlink.Targets = append(backlink.Targets, rawTarget)
+		}
+	}
+	if len(bySource) == 0 {
+		return nil
+	}
+	out := make([]Backlink, 0, len(bySource))
+	for _, backlink := range bySource {
+		backlink.Targets = dedupeSorted(backlink.Targets)
+		out = append(out, *backlink)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		ti, _ := database.ParseTimestamp(out[i].ModifiedAt)
+		tj, _ := database.ParseTimestamp(out[j].ModifiedAt)
+		if ti.Equal(tj) {
+			return out[i].Ref < out[j].Ref
+		}
+		return ti.After(tj)
+	})
+	return out
+}
+
+func resolveDocumentLink(index *documentIndex, source documentIndexEntry, rawTarget string) DocumentLink {
+	link := DocumentLink{Target: rawTarget}
+	target, anchor := splitResolvedLinkTarget(rawTarget)
+	if anchor != "" {
+		link.Anchor = anchor
+	}
+	if target == "" {
+		link.Kind = "section"
+		link.Ref = source.Ref
+		link.Title = source.Title
+		return link
+	}
+	if root, _, err := parseRef(target); err == nil && index.roots[root] {
+		if ref, title, ok := resolveIndexedRef(index, source, target); ok {
+			link.Ref = ref
+			link.Title = title
+			if anchor != "" {
+				link.Kind = "section"
+			} else {
+				link.Kind = "document"
+			}
+			return link
+		}
+		link.Kind = "unresolved"
+		return link
+	}
+	if ref, title, ok := resolveIndexedRef(index, source, target); ok {
+		link.Ref = ref
+		link.Title = title
+		if anchor != "" {
+			link.Kind = "section"
+		} else {
+			link.Kind = "document"
+		}
+		return link
+	}
+	if hasExternalLinkScheme(target) {
+		link.Kind = "external"
+		link.URL = rawTarget
+		return link
+	}
+	link.Kind = "unresolved"
+	return link
+}
+
+func resolveIndexedRef(index *documentIndex, source documentIndexEntry, target string) (string, string, bool) {
+	if index == nil {
+		return "", "", false
+	}
+	if root, relPath, err := parseRef(target); err == nil {
+		ref := makeRef(root, relPath)
+		if entry, ok := index.byRef[ref]; ok {
+			return ref, entry.Title, true
+		}
+		return "", "", false
+	}
+
+	for _, candidate := range linkPathCandidates(source.Path, target) {
+		ref := makeRef(source.Root, candidate)
+		if entry, ok := index.byRef[ref]; ok {
+			return ref, entry.Title, true
+		}
+	}
+
+	titleKey := strings.ToLower(strings.TrimSpace(target))
+	if titleKey == "" {
+		return "", "", false
+	}
+	matches := index.byRootTitles[source.Root][titleKey]
+	if len(matches) != 1 {
+		return "", "", false
+	}
+	return matches[0].Ref, matches[0].Title, true
+}
+
+func splitResolvedLinkTarget(raw string) (string, string) {
+	target := strings.TrimSpace(raw)
+	if pipe := strings.Index(target, "|"); pipe >= 0 {
+		target = strings.TrimSpace(target[:pipe])
+	}
+	anchor := ""
+	if cut := strings.Index(target, "#"); cut >= 0 {
+		anchor = strings.TrimSpace(target[cut+1:])
+		target = strings.TrimSpace(target[:cut])
+	}
+	if cut := strings.Index(target, "?"); cut >= 0 {
+		target = strings.TrimSpace(target[:cut])
+	}
+	return target, anchor
+}
+
+func linkPathCandidates(sourcePath, target string) []string {
+	target = strings.TrimSpace(target)
+	if target == "" {
+		return nil
+	}
+	var candidates []string
+	seen := make(map[string]bool)
+	add := func(candidate string) {
+		candidate = strings.TrimSpace(candidate)
+		if candidate == "" {
+			return
+		}
+		candidate = path.Clean(strings.TrimPrefix(candidate, "./"))
+		candidate = strings.TrimPrefix(candidate, "/")
+		if candidate == "" || candidate == "." {
+			return
+		}
+		if seen[candidate] {
+			return
+		}
+		seen[candidate] = true
+		candidates = append(candidates, candidate)
+	}
+
+	if strings.HasPrefix(target, "/") {
+		add(target)
+		if path.Ext(target) == "" {
+			add(target + ".md")
+		}
+		return candidates
+	}
+
+	dir := path.Dir(sourcePath)
+	if dir == "." {
+		dir = ""
+	}
+	if dir == "" {
+		add(target)
+	} else {
+		add(path.Join(dir, target))
+	}
+	if path.Ext(target) == "" {
+		if dir == "" {
+			add(target + ".md")
+		} else {
+			add(path.Join(dir, target+".md"))
+		}
+	}
+	add(target)
+	if path.Ext(target) == "" {
+		add(target + ".md")
+	}
+	return candidates
+}
+
+func hasExternalLinkScheme(target string) bool {
+	lower := strings.ToLower(strings.TrimSpace(target))
+	if strings.HasPrefix(lower, "//") || strings.Contains(lower, "://") {
+		return true
+	}
+	for _, prefix := range []string{"mailto:", "tel:", "sms:", "signal:", "data:", "file:"} {
+		if strings.HasPrefix(lower, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+func normalizeLinkMode(mode string) (string, error) {
+	switch strings.ToLower(strings.TrimSpace(mode)) {
+	case "", "both":
+		return "both", nil
+	case "outgoing":
+		return "outgoing", nil
+	case "backlinks":
+		return "backlinks", nil
+	default:
+		return "", fmt.Errorf("unsupported mode %q; use both, outgoing, or backlinks", mode)
+	}
+}

--- a/internal/documents/query.go
+++ b/internal/documents/query.go
@@ -10,6 +10,8 @@ import (
 	"sort"
 	"strings"
 	"time"
+
+	"github.com/nugget/thane-ai-agent/internal/database"
 )
 
 // Roots returns the current indexed root summaries.
@@ -152,6 +154,11 @@ func (s *Store) Search(ctx context.Context, q SearchQuery) ([]DocumentSummary, e
 	q.PathPrefix = trimPathPrefix(q.PathPrefix)
 	q.Query = strings.TrimSpace(strings.ToLower(q.Query))
 	q.Tags = dedupeSorted(q.Tags)
+	q.Frontmatter = normalizeSearchFrontmatter(q.Frontmatter)
+	q.FrontmatterKeys = dedupeSorted(q.FrontmatterKeys)
+	if q.ModifiedAfter != nil && q.ModifiedBefore != nil && q.ModifiedAfter.After(*q.ModifiedBefore) {
+		return nil, fmt.Errorf("modified_after must be earlier than modified_before")
+	}
 
 	var args []any
 	var where []string
@@ -171,6 +178,14 @@ func (s *Store) Search(ctx context.Context, q SearchQuery) ([]DocumentSummary, e
 		like := "%" + q.Query + "%"
 		where = append(where, `(LOWER(title) LIKE ? OR LOWER(summary) LIKE ? OR LOWER(rel_path) LIKE ? OR LOWER(tags_json) LIKE ?)`)
 		args = append(args, like, like, like, like)
+	}
+	if q.ModifiedAfter != nil {
+		where = append(where, `modified_at >= ?`)
+		args = append(args, q.ModifiedAfter.UTC().Format(time.RFC3339Nano))
+	}
+	if q.ModifiedBefore != nil {
+		where = append(where, `modified_at <= ?`)
+		args = append(args, q.ModifiedBefore.UTC().Format(time.RFC3339Nano))
 	}
 	if len(where) > 0 {
 		query += ` WHERE ` + strings.Join(where, ` AND `)
@@ -196,6 +211,12 @@ func (s *Store) Search(ctx context.Context, q SearchQuery) ([]DocumentSummary, e
 		if !hasAllTags(doc.Tags, q.Tags) {
 			continue
 		}
+		if !hasFrontmatterKeys(doc.Frontmatter, q.FrontmatterKeys) {
+			continue
+		}
+		if !matchesFrontmatter(doc.Frontmatter, q.Frontmatter) {
+			continue
+		}
 		score := matchScore(doc, q.Query)
 		if q.Query != "" && score == 0 {
 			continue
@@ -208,8 +229,8 @@ func (s *Store) Search(ctx context.Context, q SearchQuery) ([]DocumentSummary, e
 
 	sort.Slice(matches, func(i, j int) bool {
 		if matches[i].score == matches[j].score {
-			ti, _ := time.Parse(time.RFC3339Nano, matches[i].doc.ModifiedAt)
-			tj, _ := time.Parse(time.RFC3339Nano, matches[j].doc.ModifiedAt)
+			ti, _ := database.ParseTimestamp(matches[i].doc.ModifiedAt)
+			tj, _ := database.ParseTimestamp(matches[j].doc.ModifiedAt)
 			if ti.Equal(tj) {
 				return matches[i].doc.Ref < matches[j].doc.Ref
 			}

--- a/internal/documents/query_helpers.go
+++ b/internal/documents/query_helpers.go
@@ -1,0 +1,70 @@
+package documents
+
+import "strings"
+
+func hasFrontmatterKeys(frontmatter map[string][]string, keys []string) bool {
+	if len(keys) == 0 {
+		return true
+	}
+	for _, key := range keys {
+		key = strings.ToLower(strings.TrimSpace(key))
+		if key == "" {
+			continue
+		}
+		if len(frontmatter[key]) == 0 {
+			return false
+		}
+	}
+	return true
+}
+
+func matchesFrontmatter(frontmatter map[string][]string, required map[string][]string) bool {
+	if len(required) == 0 {
+		return true
+	}
+	for key, want := range required {
+		have := frontmatter[key]
+		if len(have) == 0 {
+			return false
+		}
+		if !containsAnyFold(have, want) {
+			return false
+		}
+	}
+	return true
+}
+
+func containsAnyFold(have, want []string) bool {
+	if len(want) == 0 {
+		return true
+	}
+	set := make(map[string]bool, len(have))
+	for _, value := range have {
+		set[strings.ToLower(strings.TrimSpace(value))] = true
+	}
+	for _, value := range want {
+		if set[strings.ToLower(strings.TrimSpace(value))] {
+			return true
+		}
+	}
+	return false
+}
+
+func normalizeSearchFrontmatter(in map[string][]string) map[string][]string {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[string][]string, len(in))
+	for key, values := range in {
+		key = strings.ToLower(strings.TrimSpace(key))
+		values = dedupeSorted(values)
+		if key == "" || len(values) == 0 {
+			continue
+		}
+		out[key] = values
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}

--- a/internal/documents/store.go
+++ b/internal/documents/store.go
@@ -71,15 +71,6 @@ type ValueCount struct {
 	Count int    `json:"count"`
 }
 
-// SearchQuery filters document search results.
-type SearchQuery struct {
-	Root       string
-	PathPrefix string
-	Query      string
-	Tags       []string
-	Limit      int
-}
-
 // Store indexes managed markdown roots into the primary Thane SQLite DB.
 type Store struct {
 	db              *sql.DB

--- a/internal/documents/store.go
+++ b/internal/documents/store.go
@@ -9,6 +9,7 @@ import (
 	"io/fs"
 	"log/slog"
 	"os"
+	"path"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -363,7 +364,9 @@ func parseRef(ref string) (root string, relPath string, err error) {
 		return "", "", fmt.Errorf("invalid ref %q; expected root:path.md", ref)
 	}
 	root = strings.TrimSuffix(strings.TrimSpace(parts[0]), ":")
-	relPath = filepath.ToSlash(strings.TrimPrefix(filepath.Clean(strings.TrimSpace(parts[1])), "./"))
+	relPath = strings.TrimSpace(parts[1])
+	relPath = strings.ReplaceAll(relPath, "\\", "/")
+	relPath = strings.TrimPrefix(path.Clean(strings.TrimPrefix(relPath, "./")), "./")
 	if relPath == "" || relPath == "." || relPath == ".." || strings.HasPrefix(relPath, "../") {
 		return "", "", fmt.Errorf("invalid ref %q; path escapes root", ref)
 	}

--- a/internal/documents/store_test.go
+++ b/internal/documents/store_test.go
@@ -60,6 +60,8 @@ area: rack
 
 Rack switch notes.
 
+See [[VLAN Guide]] and [vendor docs](https://example.com/switches).
+
 ## Core Switch
 
 Details about the core switch.
@@ -71,6 +73,8 @@ Notes about the VPN firewall appliance.
 	writeFile(t, filepath.Join(kbDir, "notes", "cameras.md"), `# Camera Notes
 
 Driveway camera notes and maintenance history.
+
+See the [trusted VLAN notes](../network/vlans.md#trusted).
 `)
 	writeFile(t, filepath.Join(scratchDir, "ideas.md"), `---
 tags: [draft]
@@ -96,6 +100,12 @@ Scratch thoughts about future loops.
 	}
 
 	ctx := context.Background()
+	now := time.Now().UTC()
+	setFileModTime(t, filepath.Join(kbDir, "network", "vlans.md"), now.Add(-30*time.Minute))
+	setFileModTime(t, filepath.Join(kbDir, "network", "routers.md"), now.Add(-72*time.Hour))
+	setFileModTime(t, filepath.Join(kbDir, "network", "unifi", "switches.md"), now.Add(-48*time.Hour))
+	setFileModTime(t, filepath.Join(kbDir, "network", "vpn", "firewall.md"), now.Add(-96*time.Hour))
+	setFileModTime(t, filepath.Join(kbDir, "notes", "cameras.md"), now.Add(-2*time.Hour))
 
 	roots, err := store.Roots(ctx)
 	if err != nil {
@@ -163,6 +173,45 @@ Scratch thoughts about future loops.
 		t.Fatalf("len(search(tags)) = %d, want 2", len(tagged))
 	}
 
+	filtered, err := store.Search(ctx, SearchQuery{
+		Root: "kb",
+		Frontmatter: map[string][]string{
+			"status": {"active"},
+		},
+		Limit: 10,
+	})
+	if err != nil {
+		t.Fatalf("Search(frontmatter): %v", err)
+	}
+	if len(filtered) != 1 || filtered[0].Ref != "kb:network/vlans.md" {
+		t.Fatalf("search(frontmatter) = %#v, want vlans doc", filtered)
+	}
+
+	keysOnly, err := store.Search(ctx, SearchQuery{
+		Root:            "kb",
+		FrontmatterKeys: []string{"area"},
+		Limit:           10,
+	})
+	if err != nil {
+		t.Fatalf("Search(frontmatter_keys): %v", err)
+	}
+	if len(keysOnly) != 1 || keysOnly[0].Ref != "kb:network/unifi/switches.md" {
+		t.Fatalf("search(frontmatter_keys) = %#v, want switches doc", keysOnly)
+	}
+
+	modifiedAfter := now.Add(-3 * time.Hour)
+	recent, err := store.Search(ctx, SearchQuery{
+		Root:          "kb",
+		ModifiedAfter: &modifiedAfter,
+		Limit:         10,
+	})
+	if err != nil {
+		t.Fatalf("Search(modified_after): %v", err)
+	}
+	if len(recent) != 2 || recent[0].Ref != "kb:network/vlans.md" || recent[1].Ref != "kb:notes/cameras.md" {
+		t.Fatalf("search(modified_after) = %#v, want vlans then cameras", recent)
+	}
+
 	outline, err := store.Outline(ctx, "kb:network/vlans.md")
 	if err != nil {
 		t.Fatalf("Outline: %v", err)
@@ -191,6 +240,28 @@ Scratch thoughts about future loops.
 	}
 	if len(values) == 0 || values[0].Value != "network" || values[0].Count != 2 {
 		t.Fatalf("values = %#v, want network count 2 first", values)
+	}
+
+	links, err := store.Links(ctx, "kb:network/vlans.md", "both")
+	if err != nil {
+		t.Fatalf("Links: %v", err)
+	}
+	if len(links.Backlinks) != 2 {
+		t.Fatalf("len(links.Backlinks) = %d, want 2", len(links.Backlinks))
+	}
+	if links.Backlinks[0].Ref != "kb:notes/cameras.md" || links.Backlinks[1].Ref != "kb:network/unifi/switches.md" {
+		t.Fatalf("links.Backlinks = %#v, want cameras and switches backlinks", links.Backlinks)
+	}
+
+	outgoing, err := store.Links(ctx, "kb:notes/cameras.md", "outgoing")
+	if err != nil {
+		t.Fatalf("Links(outgoing): %v", err)
+	}
+	if len(outgoing.Outgoing) != 1 {
+		t.Fatalf("len(outgoing.Outgoing) = %d, want 1", len(outgoing.Outgoing))
+	}
+	if outgoing.Outgoing[0].Ref != "kb:network/vlans.md" || outgoing.Outgoing[0].Kind != "section" || outgoing.Outgoing[0].Anchor != "trusted" {
+		t.Fatalf("outgoing.Outgoing[0] = %#v, want trusted VLAN section link", outgoing.Outgoing[0])
 	}
 }
 
@@ -287,6 +358,13 @@ func TestResolveDocumentPathRejectsEscapes(t *testing.T) {
 	}
 	if _, err := store.resolveDocumentPath("kb", "escaped.md"); err == nil || !strings.Contains(err.Error(), "outside root") {
 		t.Fatalf("resolveDocumentPath(escaped.md) error = %v, want outside-root rejection", err)
+	}
+}
+
+func setFileModTime(t *testing.T, path string, mod time.Time) {
+	t.Helper()
+	if err := os.Chtimes(path, mod, mod); err != nil {
+		t.Fatalf("Chtimes(%q): %v", path, err)
 	}
 }
 

--- a/internal/documents/store_test.go
+++ b/internal/documents/store_test.go
@@ -242,7 +242,7 @@ Scratch thoughts about future loops.
 		t.Fatalf("values = %#v, want network count 2 first", values)
 	}
 
-	links, err := store.Links(ctx, "kb:network/vlans.md", "both")
+	links, err := store.Links(ctx, "kb:network/vlans.md", "both", 0, 0)
 	if err != nil {
 		t.Fatalf("Links: %v", err)
 	}
@@ -253,7 +253,7 @@ Scratch thoughts about future loops.
 		t.Fatalf("links.Backlinks = %#v, want cameras and switches backlinks", links.Backlinks)
 	}
 
-	outgoing, err := store.Links(ctx, "kb:notes/cameras.md", "outgoing")
+	outgoing, err := store.Links(ctx, "kb:notes/cameras.md", "outgoing", 0, 0)
 	if err != nil {
 		t.Fatalf("Links(outgoing): %v", err)
 	}
@@ -262,6 +262,76 @@ Scratch thoughts about future loops.
 	}
 	if outgoing.Outgoing[0].Ref != "kb:network/vlans.md" || outgoing.Outgoing[0].Kind != "section" || outgoing.Outgoing[0].Anchor != "trusted" {
 		t.Fatalf("outgoing.Outgoing[0] = %#v, want trusted VLAN section link", outgoing.Outgoing[0])
+	}
+}
+
+func TestDocumentStoreLinksCanonicalizeRefsAndFailFastOnCorruptIndexData(t *testing.T) {
+	t.Parallel()
+
+	rootDir := t.TempDir()
+	kbDir := filepath.Join(rootDir, "kb")
+	for _, dir := range []string{
+		filepath.Join(kbDir, "network", "unifi"),
+		filepath.Join(kbDir, "notes"),
+	} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("MkdirAll(%q): %v", dir, err)
+		}
+	}
+
+	writeFile(t, filepath.Join(kbDir, "network", "vlans.md"), `# VLAN Guide
+
+Reference for the home network VLAN layout.
+`)
+	writeFile(t, filepath.Join(kbDir, "network", "unifi", "switches.md"), `# Switch Inventory
+
+See [[VLAN Guide]].
+`)
+	writeFile(t, filepath.Join(kbDir, "notes", "cameras.md"), `# Camera Notes
+
+See the [trusted VLAN notes](../network/vlans.md#trusted).
+`)
+
+	db, err := database.OpenMemory()
+	if err != nil {
+		t.Fatalf("OpenMemory: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+
+	store, err := NewStore(db, map[string]string{"kb": kbDir}, nil)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+
+	ctx := context.Background()
+	outgoing, err := store.Links(ctx, "  kb:notes\\cameras.md  ", "outgoing", 0, 0)
+	if err != nil {
+		t.Fatalf("Links(canonicalize): %v", err)
+	}
+	if outgoing.Ref != "kb:notes/cameras.md" {
+		t.Fatalf("Links.Ref = %q, want canonical kb:notes/cameras.md", outgoing.Ref)
+	}
+
+	store.refreshInterval = time.Hour
+	if _, err := store.db.ExecContext(ctx,
+		`UPDATE indexed_documents SET links_json = ? WHERE root = ? AND rel_path = ?`,
+		"{bad-json",
+		"kb",
+		"network/unifi/switches.md",
+	); err != nil {
+		t.Fatalf("corrupt links_json: %v", err)
+	}
+
+	outgoing, err = store.Links(ctx, "kb:notes/cameras.md", "outgoing", 0, 0)
+	if err != nil {
+		t.Fatalf("Links(outgoing with unrelated corruption): %v", err)
+	}
+	if len(outgoing.Outgoing) != 1 || outgoing.Outgoing[0].Ref != "kb:network/vlans.md" {
+		t.Fatalf("outgoing = %#v, want resolved VLAN link", outgoing.Outgoing)
+	}
+
+	if _, err := store.Links(ctx, "kb:network/vlans.md", "backlinks", 0, 0); err == nil || !strings.Contains(err.Error(), "unmarshal document links for kb/network/unifi/switches.md") {
+		t.Fatalf("Links(backlinks) err = %v, want corrupt links_json error", err)
 	}
 }
 
@@ -373,6 +443,18 @@ func TestParseRefRejectsPathEscape(t *testing.T) {
 
 	if _, _, err := parseRef("kb:../secret.md"); err == nil || !strings.Contains(err.Error(), "escapes root") {
 		t.Fatalf("parseRef(path escape) error = %v, want escape rejection", err)
+	}
+}
+
+func TestParseRefNormalizesBackslashes(t *testing.T) {
+	t.Parallel()
+
+	root, relPath, err := parseRef(`kb:notes\camera.md`)
+	if err != nil {
+		t.Fatalf("parseRef(backslashes): %v", err)
+	}
+	if root != "kb" || relPath != "notes/camera.md" {
+		t.Fatalf("parseRef(backslashes) = %q %q, want kb notes/camera.md", root, relPath)
 	}
 }
 

--- a/internal/documents/tools.go
+++ b/internal/documents/tools.go
@@ -4,7 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"time"
 	"unicode/utf8"
+
+	"github.com/nugget/thane-ai-agent/internal/awareness"
 )
 
 const (
@@ -22,35 +25,51 @@ func NewTools(store *Store) *Tools {
 	return &Tools{store: store}
 }
 
+// BrowseArgs requests one rooted browse step through an indexed corpus.
 type BrowseArgs struct {
 	Root       string `json:"root"`
 	PathPrefix string `json:"path_prefix,omitempty"`
 	Limit      int    `json:"limit,omitempty"`
 }
 
+// SearchArgs requests structured document search over indexed roots.
 type SearchArgs struct {
-	Root       string   `json:"root,omitempty"`
-	PathPrefix string   `json:"path_prefix,omitempty"`
-	Query      string   `json:"query,omitempty"`
-	Tags       []string `json:"tags,omitempty"`
-	Limit      int      `json:"limit,omitempty"`
+	Root            string              `json:"root,omitempty"`
+	PathPrefix      string              `json:"path_prefix,omitempty"`
+	Query           string              `json:"query,omitempty"`
+	Tags            []string            `json:"tags,omitempty"`
+	Frontmatter     map[string][]string `json:"frontmatter,omitempty"`
+	FrontmatterKeys []string            `json:"frontmatter_keys,omitempty"`
+	ModifiedAfter   string              `json:"modified_after,omitempty"`
+	ModifiedBefore  string              `json:"modified_before,omitempty"`
+	Limit           int                 `json:"limit,omitempty"`
 }
 
+// RefArgs identifies one managed document by canonical semantic ref.
 type RefArgs struct {
 	Ref string `json:"ref"`
 }
 
+// SectionArgs selects one document section by ref and optional heading.
 type SectionArgs struct {
 	Ref     string `json:"ref"`
 	Section string `json:"section,omitempty"`
 }
 
+// ValuesArgs requests observed values for one frontmatter key.
 type ValuesArgs struct {
 	Root  string `json:"root,omitempty"`
 	Key   string `json:"key"`
 	Limit int    `json:"limit,omitempty"`
 }
 
+// LinksArgs requests outgoing links, backlinks, or both for one document.
+type LinksArgs struct {
+	Ref  string `json:"ref"`
+	Mode string `json:"mode,omitempty"`
+}
+
+// Read returns one indexed document payload.
 func (t *Tools) Read(ctx context.Context, args RefArgs) (string, error) {
 	if t == nil || t.store == nil {
 		return "", fmt.Errorf("document index not configured")
@@ -65,6 +84,7 @@ func (t *Tools) Read(ctx context.Context, args RefArgs) (string, error) {
 	return marshalToolResult(doc)
 }
 
+// Roots returns summaries of the indexed document roots.
 func (t *Tools) Roots(ctx context.Context) (string, error) {
 	if t == nil || t.store == nil {
 		return "", fmt.Errorf("document index not configured")
@@ -78,6 +98,7 @@ func (t *Tools) Roots(ctx context.Context) (string, error) {
 	})
 }
 
+// Browse returns one rooted browse step through an indexed corpus.
 func (t *Tools) Browse(ctx context.Context, args BrowseArgs) (string, error) {
 	if t == nil || t.store == nil {
 		return "", fmt.Errorf("document index not configured")
@@ -92,19 +113,59 @@ func (t *Tools) Browse(ctx context.Context, args BrowseArgs) (string, error) {
 	return marshalToolResult(result)
 }
 
+// Search returns compact summaries for documents matching the structured filters.
 func (t *Tools) Search(ctx context.Context, args SearchArgs) (string, error) {
 	if t == nil || t.store == nil {
 		return "", fmt.Errorf("document index not configured")
 	}
-	results, err := t.store.Search(ctx, SearchQuery(args))
+	query := SearchQuery{
+		Root:            args.Root,
+		PathPrefix:      args.PathPrefix,
+		Query:           args.Query,
+		Tags:            args.Tags,
+		Frontmatter:     args.Frontmatter,
+		FrontmatterKeys: args.FrontmatterKeys,
+		Limit:           clampLimit(args.Limit, 20, 100),
+	}
+	now := nowUTC()
+	if args.ModifiedAfter != "" {
+		bound, err := awareness.ParseTimeOrDelta(args.ModifiedAfter, now)
+		if err != nil {
+			return "", fmt.Errorf("modified_after must be RFC3339 or signed delta like -604800s: %w", err)
+		}
+		query.ModifiedAfter = &bound
+	}
+	if args.ModifiedBefore != "" {
+		bound, err := awareness.ParseTimeOrDelta(args.ModifiedBefore, now)
+		if err != nil {
+			return "", fmt.Errorf("modified_before must be RFC3339 or signed delta like -3600s: %w", err)
+		}
+		query.ModifiedBefore = &bound
+	}
+	if query.ModifiedAfter != nil && query.ModifiedBefore != nil && query.ModifiedAfter.After(*query.ModifiedBefore) {
+		return "", fmt.Errorf("modified_after must be earlier than modified_before")
+	}
+	results, err := t.store.Search(ctx, query)
 	if err != nil {
 		return "", err
 	}
 	return marshalToolResult(map[string]any{
+		"filters": map[string]any{
+			"root":             args.Root,
+			"path_prefix":      args.PathPrefix,
+			"query":            args.Query,
+			"tags":             args.Tags,
+			"frontmatter":      args.Frontmatter,
+			"frontmatter_keys": args.FrontmatterKeys,
+			"modified_after":   args.ModifiedAfter,
+			"modified_before":  args.ModifiedBefore,
+			"limit":            query.Limit,
+		},
 		"results": results,
 	})
 }
 
+// Outline returns the heading tree for one indexed document.
 func (t *Tools) Outline(ctx context.Context, args RefArgs) (string, error) {
 	if t == nil || t.store == nil {
 		return "", fmt.Errorf("document index not configured")
@@ -122,6 +183,7 @@ func (t *Tools) Outline(ctx context.Context, args RefArgs) (string, error) {
 	})
 }
 
+// Section returns one named section, or the whole body when no selector is given.
 func (t *Tools) Section(ctx context.Context, args SectionArgs) (string, error) {
 	if t == nil || t.store == nil {
 		return "", fmt.Errorf("document index not configured")
@@ -139,6 +201,7 @@ func (t *Tools) Section(ctx context.Context, args SectionArgs) (string, error) {
 	})
 }
 
+// Values returns observed frontmatter values for one key.
 func (t *Tools) Values(ctx context.Context, args ValuesArgs) (string, error) {
 	if t == nil || t.store == nil {
 		return "", fmt.Errorf("document index not configured")
@@ -154,6 +217,22 @@ func (t *Tools) Values(ctx context.Context, args ValuesArgs) (string, error) {
 	})
 }
 
+// Links returns outgoing links, backlinks, or both for one indexed document.
+func (t *Tools) Links(ctx context.Context, args LinksArgs) (string, error) {
+	if t == nil || t.store == nil {
+		return "", fmt.Errorf("document index not configured")
+	}
+	if args.Ref == "" {
+		return "", fmt.Errorf("ref is required")
+	}
+	links, err := t.store.Links(ctx, args.Ref, args.Mode)
+	if err != nil {
+		return "", err
+	}
+	return marshalToolResult(links)
+}
+
+// Write creates or replaces one managed document.
 func (t *Tools) Write(ctx context.Context, args WriteArgs) (string, error) {
 	if t == nil || t.store == nil {
 		return "", fmt.Errorf("document index not configured")
@@ -168,6 +247,7 @@ func (t *Tools) Write(ctx context.Context, args WriteArgs) (string, error) {
 	return marshalToolResult(result)
 }
 
+// Edit applies one structured edit to a managed document.
 func (t *Tools) Edit(ctx context.Context, args EditArgs) (string, error) {
 	if t == nil || t.store == nil {
 		return "", fmt.Errorf("document index not configured")
@@ -182,6 +262,7 @@ func (t *Tools) Edit(ctx context.Context, args EditArgs) (string, error) {
 	return marshalToolResult(result)
 }
 
+// JournalUpdate appends one journal-window entry to a managed document.
 func (t *Tools) JournalUpdate(ctx context.Context, args JournalUpdateArgs) (string, error) {
 	if t == nil || t.store == nil {
 		return "", fmt.Errorf("document index not configured")
@@ -196,6 +277,7 @@ func (t *Tools) JournalUpdate(ctx context.Context, args JournalUpdateArgs) (stri
 	return marshalToolResult(result)
 }
 
+// Delete removes one managed document.
 func (t *Tools) Delete(ctx context.Context, args DeleteArgs) (string, error) {
 	if t == nil || t.store == nil {
 		return "", fmt.Errorf("document index not configured")
@@ -210,6 +292,7 @@ func (t *Tools) Delete(ctx context.Context, args DeleteArgs) (string, error) {
 	return marshalToolResult(result)
 }
 
+// Move relocates one managed document to a new semantic ref.
 func (t *Tools) Move(ctx context.Context, args MoveArgs) (string, error) {
 	if t == nil || t.store == nil {
 		return "", fmt.Errorf("document index not configured")
@@ -227,6 +310,7 @@ func (t *Tools) Move(ctx context.Context, args MoveArgs) (string, error) {
 	return marshalToolResult(result)
 }
 
+// Copy clones one managed document to a new semantic ref.
 func (t *Tools) Copy(ctx context.Context, args CopyArgs) (string, error) {
 	if t == nil || t.store == nil {
 		return "", fmt.Errorf("document index not configured")
@@ -244,6 +328,7 @@ func (t *Tools) Copy(ctx context.Context, args CopyArgs) (string, error) {
 	return marshalToolResult(result)
 }
 
+// CopySection copies one section into another managed document.
 func (t *Tools) CopySection(ctx context.Context, args SectionTransferArgs) (string, error) {
 	if t == nil || t.store == nil {
 		return "", fmt.Errorf("document index not configured")
@@ -264,6 +349,7 @@ func (t *Tools) CopySection(ctx context.Context, args SectionTransferArgs) (stri
 	return marshalToolResult(result)
 }
 
+// MoveSection moves one section into another managed document.
 func (t *Tools) MoveSection(ctx context.Context, args SectionTransferArgs) (string, error) {
 	if t == nil || t.store == nil {
 		return "", fmt.Errorf("document index not configured")
@@ -314,4 +400,8 @@ func truncateUTF8Bytes(data []byte, maxBytes int) string {
 		truncated = truncated[:len(truncated)-1]
 	}
 	return string(truncated)
+}
+
+func nowUTC() time.Time {
+	return time.Now().UTC()
 }

--- a/internal/documents/tools.go
+++ b/internal/documents/tools.go
@@ -11,8 +11,12 @@ import (
 )
 
 const (
-	maxToolResultBytes      = 16 * 1024
-	toolResultPreviewBudget = maxToolResultBytes - 512
+	maxToolResultBytes         = 16 * 1024
+	toolResultPreviewBudget    = maxToolResultBytes - 512
+	defaultDocLinksLimit       = 20
+	maxDocLinksLimit           = 100
+	defaultBacklinkTargetLimit = 10
+	maxBacklinkTargetLimit     = 50
 )
 
 // Tools exposes model-facing document navigation tools.
@@ -65,8 +69,10 @@ type ValuesArgs struct {
 
 // LinksArgs requests outgoing links, backlinks, or both for one document.
 type LinksArgs struct {
-	Ref  string `json:"ref"`
-	Mode string `json:"mode,omitempty"`
+	Ref              string `json:"ref"`
+	Mode             string `json:"mode,omitempty"`
+	Limit            int    `json:"limit,omitempty"`
+	PerBacklinkLimit int    `json:"per_backlink_limit,omitempty"`
 }
 
 // Read returns one indexed document payload.
@@ -225,7 +231,13 @@ func (t *Tools) Links(ctx context.Context, args LinksArgs) (string, error) {
 	if args.Ref == "" {
 		return "", fmt.Errorf("ref is required")
 	}
-	links, err := t.store.Links(ctx, args.Ref, args.Mode)
+	links, err := t.store.Links(
+		ctx,
+		args.Ref,
+		args.Mode,
+		clampPositiveLimit(args.Limit, defaultDocLinksLimit, maxDocLinksLimit),
+		clampPositiveLimit(args.PerBacklinkLimit, defaultBacklinkTargetLimit, maxBacklinkTargetLimit),
+	)
 	if err != nil {
 		return "", err
 	}
@@ -404,4 +416,14 @@ func truncateUTF8Bytes(data []byte, maxBytes int) string {
 
 func nowUTC() time.Time {
 	return time.Now().UTC()
+}
+
+func clampPositiveLimit(limit int, def int, max int) int {
+	if limit <= 0 {
+		return def
+	}
+	if limit > max {
+		return max
+	}
+	return limit
 }

--- a/internal/toolcatalog/catalog.go
+++ b/internal/toolcatalog/catalog.go
@@ -241,6 +241,7 @@ var builtinToolSpecs = map[string]BuiltinToolSpec{
 	"doc_delete":                  {CanonicalID: "native:doc_delete", Source: NativeToolSource, DefaultTags: []string{"documents"}},
 	"doc_edit":                    {CanonicalID: "native:doc_edit", Source: NativeToolSource, DefaultTags: []string{"documents"}},
 	"doc_journal_update":          {CanonicalID: "native:doc_journal_update", Source: NativeToolSource, DefaultTags: []string{"documents"}},
+	"doc_links":                   {CanonicalID: "native:doc_links", Source: NativeToolSource, DefaultTags: []string{"documents"}},
 	"doc_move":                    {CanonicalID: "native:doc_move", Source: NativeToolSource, DefaultTags: []string{"documents"}},
 	"doc_move_section":            {CanonicalID: "native:doc_move_section", Source: NativeToolSource, DefaultTags: []string{"documents"}},
 	"doc_outline":                 {CanonicalID: "native:doc_outline", Source: NativeToolSource, DefaultTags: []string{"documents"}},

--- a/internal/tools/document_tools.go
+++ b/internal/tools/document_tools.go
@@ -7,6 +7,13 @@ import (
 	"github.com/nugget/thane-ai-agent/internal/documents"
 )
 
+const (
+	defaultDocLinksLimit    = 20
+	maxDocLinksLimit        = 100
+	defaultPerBacklinkLimit = 10
+	maxPerBacklinkLimit     = 50
+)
+
 // RegisterDocumentTools adds indexed document navigation tools to the registry.
 func RegisterDocumentTools(r *Registry, dt *documents.Tools) {
 	if r == nil || dt == nil {
@@ -222,7 +229,7 @@ func RegisterDocumentTools(r *Registry, dt *documents.Tools) {
 
 	r.Register(&Tool{
 		Name:                 "doc_links",
-		Description:          "Return outgoing links, backlinks, or both for one indexed markdown document. Use this when the important question is relationship structure rather than raw content.",
+		Description:          "Return outgoing links, backlinks, or both for one indexed markdown document. Use this when the important question is relationship structure rather than raw content. Results are bounded so the output stays usable; raise `limit` or `per_backlink_limit` when you need a wider graph.",
 		ContentResolveExempt: []string{"ref"},
 		Parameters: map[string]any{
 			"type": "object",
@@ -236,6 +243,14 @@ func RegisterDocumentTools(r *Registry, dt *documents.Tools) {
 					"enum":        []string{"both", "outgoing", "backlinks"},
 					"description": "Which link directions to return. Default: `both`.",
 				},
+				"limit": map[string]any{
+					"type":        "integer",
+					"description": fmt.Sprintf("Maximum outgoing links or backlink source documents to return (default %d, max %d).", defaultDocLinksLimit, maxDocLinksLimit),
+				},
+				"per_backlink_limit": map[string]any{
+					"type":        "integer",
+					"description": fmt.Sprintf("Maximum distinct raw target strings to include per backlink entry (default %d, max %d).", defaultPerBacklinkLimit, maxPerBacklinkLimit),
+				},
 			},
 			"required": []string{"ref"},
 		},
@@ -245,7 +260,14 @@ func RegisterDocumentTools(r *Registry, dt *documents.Tools) {
 				return "", fmt.Errorf("ref is required")
 			}
 			mode, _ := args["mode"].(string)
-			return dt.Links(ctx, documents.LinksArgs{Ref: ref, Mode: mode})
+			limit := numericArg(args["limit"], defaultDocLinksLimit, maxDocLinksLimit)
+			perBacklinkLimit := numericArg(args["per_backlink_limit"], defaultPerBacklinkLimit, maxPerBacklinkLimit)
+			return dt.Links(ctx, documents.LinksArgs{
+				Ref:              ref,
+				Mode:             mode,
+				Limit:            limit,
+				PerBacklinkLimit: perBacklinkLimit,
+			})
 		},
 	})
 

--- a/internal/tools/document_tools.go
+++ b/internal/tools/document_tools.go
@@ -86,7 +86,7 @@ func RegisterDocumentTools(r *Registry, dt *documents.Tools) {
 
 	r.Register(&Tool{
 		Name:        "doc_search",
-		Description: "Search indexed markdown documents by root, path prefix, query, and tags. Returns compact document summaries with canonical refs like `kb:article.md`, not full bodies.",
+		Description: "Search indexed markdown documents by root, path prefix, query text, tags, frontmatter filters, and modified-time bounds. Returns compact document summaries with canonical refs like `kb:article.md`, not full bodies.",
 		Parameters: map[string]any{
 			"type": "object",
 			"properties": map[string]any{
@@ -109,6 +109,36 @@ func RegisterDocumentTools(r *Registry, dt *documents.Tools) {
 						"type": "string",
 					},
 				},
+				"frontmatter": map[string]any{
+					"type":        "object",
+					"description": "Optional frontmatter filters. Each key must match, and each value may be either one required string or an array of acceptable strings for that key.",
+					"additionalProperties": map[string]any{
+						"anyOf": []any{
+							map[string]any{"type": "string"},
+							map[string]any{
+								"type": "array",
+								"items": map[string]any{
+									"type": "string",
+								},
+							},
+						},
+					},
+				},
+				"frontmatter_keys": map[string]any{
+					"type":        "array",
+					"description": "Optional frontmatter keys that must be present on each matching document.",
+					"items": map[string]any{
+						"type": "string",
+					},
+				},
+				"modified_after": map[string]any{
+					"type":        "string",
+					"description": "Optional lower bound on modified time. Accepts RFC3339 timestamps or signed deltas like `-604800s`.",
+				},
+				"modified_before": map[string]any{
+					"type":        "string",
+					"description": "Optional upper bound on modified time. Accepts RFC3339 timestamps or signed deltas like `-3600s`.",
+				},
 				"limit": map[string]any{
 					"type":        "integer",
 					"description": "Maximum number of results to return (default 20, max 100).",
@@ -120,13 +150,21 @@ func RegisterDocumentTools(r *Registry, dt *documents.Tools) {
 			pathPrefix, _ := args["path_prefix"].(string)
 			query, _ := args["query"].(string)
 			tags := documentStringSliceArg(args["tags"])
+			frontmatter := documentFrontmatterArg(args["frontmatter"])
+			frontmatterKeys := documentStringSliceArg(args["frontmatter_keys"])
+			modifiedAfter, _ := args["modified_after"].(string)
+			modifiedBefore, _ := args["modified_before"].(string)
 			limit := numericArg(args["limit"], 20, 100)
 			return dt.Search(ctx, documents.SearchArgs{
-				Root:       root,
-				PathPrefix: pathPrefix,
-				Query:      query,
-				Tags:       tags,
-				Limit:      limit,
+				Root:            root,
+				PathPrefix:      pathPrefix,
+				Query:           query,
+				Tags:            tags,
+				Frontmatter:     frontmatter,
+				FrontmatterKeys: frontmatterKeys,
+				ModifiedAfter:   modifiedAfter,
+				ModifiedBefore:  modifiedBefore,
+				Limit:           limit,
 			})
 		},
 	})
@@ -179,6 +217,35 @@ func RegisterDocumentTools(r *Registry, dt *documents.Tools) {
 			}
 			section, _ := args["section"].(string)
 			return dt.Section(ctx, documents.SectionArgs{Ref: ref, Section: section})
+		},
+	})
+
+	r.Register(&Tool{
+		Name:                 "doc_links",
+		Description:          "Return outgoing links, backlinks, or both for one indexed markdown document. Use this when the important question is relationship structure rather than raw content.",
+		ContentResolveExempt: []string{"ref"},
+		Parameters: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"ref": map[string]any{
+					"type":        "string",
+					"description": "Canonical document ref like `kb:network/vlans.md`.",
+				},
+				"mode": map[string]any{
+					"type":        "string",
+					"enum":        []string{"both", "outgoing", "backlinks"},
+					"description": "Which link directions to return. Default: `both`.",
+				},
+			},
+			"required": []string{"ref"},
+		},
+		Handler: func(ctx context.Context, args map[string]any) (string, error) {
+			ref, _ := args["ref"].(string)
+			if ref == "" {
+				return "", fmt.Errorf("ref is required")
+			}
+			mode, _ := args["mode"].(string)
+			return dt.Links(ctx, documents.LinksArgs{Ref: ref, Mode: mode})
 		},
 	})
 

--- a/internal/tools/document_tools_test.go
+++ b/internal/tools/document_tools_test.go
@@ -200,6 +200,95 @@ func TestDocumentSearchAndLinksHandlersSupportStructuredNavigation(t *testing.T)
 	}
 }
 
+func TestDocumentLinksHandlerSupportsLimitsAndTruncation(t *testing.T) {
+	t.Parallel()
+
+	reg, store := newTestDocumentRegistry(t)
+
+	for _, doc := range []documents.WriteArgs{
+		{
+			Ref:   "kb:network/vlans.md",
+			Title: "VLAN Guide",
+			Body:  stringPtr("# VLAN Guide\n\nReference for the home network VLAN layout.\n"),
+		},
+		{
+			Ref:   "kb:notes/routers.md",
+			Title: "Router Notes",
+			Body:  stringPtr("# Router Notes\n\nSee [[VLAN Guide]].\n"),
+		},
+		{
+			Ref:   "kb:notes/switches.md",
+			Title: "Switch Notes",
+			Body:  stringPtr("# Switch Notes\n\nSee [[VLAN Guide]].\n"),
+		},
+		{
+			Ref:   "kb:notes/cameras.md",
+			Title: "Camera Notes",
+			Body:  stringPtr("# Camera Notes\n\nSee [trusted](../network/vlans.md#trusted), [iot](../network/vlans.md#iot), and [[VLAN Guide]].\n"),
+		},
+	} {
+		if _, err := store.Write(context.Background(), doc); err != nil {
+			t.Fatalf("store.Write(%s): %v", doc.Ref, err)
+		}
+	}
+
+	linksTool := reg.Get("doc_links")
+	if linksTool == nil {
+		t.Fatal("doc_links not registered")
+	}
+
+	backlinksOut, err := linksTool.Handler(context.Background(), map[string]any{
+		"ref":                "kb:network/vlans.md",
+		"mode":               "backlinks",
+		"limit":              2,
+		"per_backlink_limit": 1,
+	})
+	if err != nil {
+		t.Fatalf("doc_links(backlinks): %v", err)
+	}
+
+	var backlinks documents.LinksResult
+	if err := json.Unmarshal([]byte(backlinksOut), &backlinks); err != nil {
+		t.Fatalf("unmarshal backlinks output: %v", err)
+	}
+	if backlinks.Ref != "kb:network/vlans.md" || backlinks.Limit != 2 || backlinks.PerBacklinkLimit != 1 {
+		t.Fatalf("backlinks result = %#v, want canonical ref and echoed limits", backlinks)
+	}
+	if len(backlinks.Backlinks) != 2 || !backlinks.BacklinksTruncated {
+		t.Fatalf("backlinks = %#v, want 2 truncated backlink sources", backlinks.Backlinks)
+	}
+	foundCameras := false
+	for _, backlink := range backlinks.Backlinks {
+		if backlink.Ref != "kb:notes/cameras.md" {
+			continue
+		}
+		foundCameras = true
+		if len(backlink.Targets) != 1 || !backlink.TargetsTruncated {
+			t.Fatalf("camera backlink = %#v, want 1 truncated target", backlink)
+		}
+	}
+	if !foundCameras {
+		t.Fatalf("backlinks = %#v, want cameras backlink present", backlinks.Backlinks)
+	}
+
+	outgoingOut, err := linksTool.Handler(context.Background(), map[string]any{
+		"ref":   "kb:notes/cameras.md",
+		"mode":  "outgoing",
+		"limit": 2,
+	})
+	if err != nil {
+		t.Fatalf("doc_links(outgoing): %v", err)
+	}
+
+	var outgoing documents.LinksResult
+	if err := json.Unmarshal([]byte(outgoingOut), &outgoing); err != nil {
+		t.Fatalf("unmarshal outgoing output: %v", err)
+	}
+	if len(outgoing.Outgoing) != 2 || !outgoing.OutgoingTruncated {
+		t.Fatalf("outgoing = %#v, want 2 truncated outgoing links", outgoing.Outgoing)
+	}
+}
+
 func newTestDocumentRegistry(t *testing.T) (*Registry, *documents.Store) {
 	t.Helper()
 

--- a/internal/tools/document_tools_test.go
+++ b/internal/tools/document_tools_test.go
@@ -143,6 +143,63 @@ func TestDocWriteHandlerAppendsJournalEntry(t *testing.T) {
 	}
 }
 
+func TestDocumentSearchAndLinksHandlersSupportStructuredNavigation(t *testing.T) {
+	t.Parallel()
+
+	reg, store := newTestDocumentRegistry(t)
+
+	if _, err := store.Write(context.Background(), documents.WriteArgs{
+		Ref:   "kb:network/vlans.md",
+		Title: "VLAN Guide",
+		Tags:  []string{"network", "vlans"},
+		Frontmatter: map[string][]string{
+			"status": {"active"},
+		},
+		Body: stringPtr("# VLAN Guide\n\nReference for the home network VLAN layout.\n"),
+	}); err != nil {
+		t.Fatalf("store.Write(vlans): %v", err)
+	}
+	if _, err := store.Write(context.Background(), documents.WriteArgs{
+		Ref:   "kb:notes/cameras.md",
+		Title: "Camera Notes",
+		Body:  stringPtr("# Camera Notes\n\nSee the [trusted VLAN notes](../network/vlans.md#trusted).\n"),
+	}); err != nil {
+		t.Fatalf("store.Write(cameras): %v", err)
+	}
+
+	searchTool := reg.Get("doc_search")
+	if searchTool == nil {
+		t.Fatal("doc_search not registered")
+	}
+	searchOut, err := searchTool.Handler(context.Background(), map[string]any{
+		"root":             "kb",
+		"frontmatter":      map[string]any{"status": "active"},
+		"modified_after":   "-3600s",
+		"frontmatter_keys": []any{},
+	})
+	if err != nil {
+		t.Fatalf("doc_search: %v", err)
+	}
+	if !strings.Contains(searchOut, `"ref": "kb:network/vlans.md"`) {
+		t.Fatalf("doc_search output = %s, want vlans document", searchOut)
+	}
+
+	linksTool := reg.Get("doc_links")
+	if linksTool == nil {
+		t.Fatal("doc_links not registered")
+	}
+	linksOut, err := linksTool.Handler(context.Background(), map[string]any{
+		"ref":  "kb:network/vlans.md",
+		"mode": "backlinks",
+	})
+	if err != nil {
+		t.Fatalf("doc_links: %v", err)
+	}
+	if !strings.Contains(linksOut, `"ref": "kb:notes/cameras.md"`) || !strings.Contains(linksOut, `"targets": [`) {
+		t.Fatalf("doc_links output = %s, want cameras backlink with target list", linksOut)
+	}
+}
+
 func newTestDocumentRegistry(t *testing.T) (*Registry, *documents.Store) {
 	t.Helper()
 
@@ -166,4 +223,8 @@ func newTestDocumentRegistry(t *testing.T) (*Registry, *documents.Store) {
 	reg := NewEmptyRegistry()
 	RegisterDocumentTools(reg, documents.NewTools(store))
 	return reg, store
+}
+
+func stringPtr(s string) *string {
+	return &s
 }

--- a/talents/documents-knowledge.md
+++ b/talents/documents-knowledge.md
@@ -19,7 +19,8 @@ Trust these instincts:
   frontmatter shape, or modified-time window
 - use `doc_links` when the important question is relationship structure:
   what this document points to, what already points here, or whether a
-  concept is already connected elsewhere in the corpus
+  concept is already connected elsewhere in the corpus; add `limit` or
+  `per_backlink_limit` when the graph is broad
 - use `doc_outline` before `doc_section` when the document is known but
   the relevant part is not
 - use `doc_read` when you need the full current state of one managed

--- a/talents/documents-knowledge.md
+++ b/talents/documents-knowledge.md
@@ -15,7 +15,11 @@ Trust these instincts:
   more than free-text search
 - use `doc_values` to discover the local vocabulary before you guess at
   tags or frontmatter filters
-- use `doc_search` to narrow once you know the root, topic, or tag set
+- use `doc_search` to narrow once you know the root, topic, tag set,
+  frontmatter shape, or modified-time window
+- use `doc_links` when the important question is relationship structure:
+  what this document points to, what already points here, or whether a
+  concept is already connected elsewhere in the corpus
 - use `doc_outline` before `doc_section` when the document is known but
   the relevant part is not
 - use `doc_read` when you need the full current state of one managed


### PR DESCRIPTION
## Summary

Closes #628.

This finishes the remaining read-oriented indexed document navigation work for managed markdown roots.

What lands here:
- add `doc_links` for outgoing links, backlinks, or both
- return canonical refs from link traversal and normalize semantic refs consistently
- bound `doc_links` output with `limit` and `per_backlink_limit`, plus explicit truncation flags
- resolve backlinks from the existing indexed link data while avoiding full `links_json` loads for `mode=outgoing`
- extend `doc_search` with structured frontmatter filters, frontmatter key presence, and modified-time bounds
- fail fast on corrupt indexed link JSON instead of silently dropping link data
- update the `documents` capability guidance so the model knows how to use the richer surface and narrow broad link graphs

## Why

The core document index and rooted navigation substrate already existed, but the issue still had three real gaps before the document system felt reference-quality:
- relationship traversal between documents
- backlink discovery
- structured search beyond query/path/tags

Those are exactly the missing pieces that let the model answer questions like:
- what points at this article?
- what docs were updated recently?
- which docs have `status = active` or `area = network`?

The follow-up review fixes in this PR also make the link surface more trustworthy at runtime:
- callers now get canonical refs back instead of raw input echoes
- outgoing-only link reads no longer pay to unmarshal the whole corpus
- corrupt indexed link payloads fail loudly instead of silently producing incomplete graphs
- broad link graphs can be narrowed without relying on tool-result truncation

## Design notes

- `doc_links` stays document-native and model-facing instead of exposing raw stored link blobs.
- Backlinks are resolved from the indexed corpus without introducing a new persistence seam.
- Search filters stay explicit and structured; there is still no mini query language.
- Modified-time filters accept RFC3339 timestamps or signed deltas in the existing model-facing style.
- Link-result limits are additive controls on top of the existing output cap; they do not change canonical link resolution behavior.

## Validation

- [x] `just ci`
- [x] added store-level coverage for frontmatter filters, modified bounds, outgoing links, backlinks, semantic-ref normalization, and corrupt indexed-link handling
- [x] added tool-level coverage for structured `doc_search` and bounded/truncated `doc_links`
