### PR TITLE
fix: sanitize Anthropic tool schemas

### DIFF
--- a/internal/llm/schema.go
+++ b/internal/llm/schema.go
@@ -20,6 +20,9 @@ func StripTopLevelCompositionKeywords(schema map[string]any) (map[string]any, []
 	if schema == nil {
 		return nil, nil
 	}
+	if !hasTopLevelCompositionKeywords(schema) {
+		return schema, nil
+	}
 
 	cloned := cloneSchemaMap(schema)
 	var removed []string
@@ -125,4 +128,13 @@ func schemaVariants(raw any) []map[string]any {
 func schemaStringValue(raw any) string {
 	value, _ := raw.(string)
 	return value
+}
+
+func hasTopLevelCompositionKeywords(schema map[string]any) bool {
+	for _, keyword := range topLevelCompositionKeywords {
+		if _, ok := schema[keyword]; ok {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/llm/schema.go
+++ b/internal/llm/schema.go
@@ -44,22 +44,25 @@ func StripTopLevelCompositionKeywords(schema map[string]any) (map[string]any, []
 	if properties == nil {
 		properties = make(map[string]any)
 	}
-	objectish := false
 	for _, variant := range variants {
 		if variant == nil {
 			continue
 		}
+		// Hoist the first variant-level title/description when the root
+		// schema doesn't already define one. This preserves some helpful
+		// human-facing metadata without trying to reconcile conflicting
+		// variant descriptions.
 		if desc, ok := variant["description"].(string); ok && strings.TrimSpace(desc) != "" && strings.TrimSpace(schemaStringValue(cloned["description"])) == "" {
 			cloned["description"] = desc
 		}
 		if title, ok := variant["title"].(string); ok && strings.TrimSpace(title) != "" && strings.TrimSpace(schemaStringValue(cloned["title"])) == "" {
 			cloned["title"] = title
 		}
-		if tp, ok := variant["type"].(string); ok && tp == "object" {
-			objectish = true
-		}
 		if variantProps, ok := variant["properties"].(map[string]any); ok {
-			objectish = true
+			// First-wins on duplicate property keys. This keeps the
+			// sanitizer deterministic for the current compatibility use
+			// case, where variants usually share the same property schema
+			// and differ only in required-field groups.
 			for key, value := range variantProps {
 				if _, exists := properties[key]; !exists {
 					properties[key] = value
@@ -69,10 +72,6 @@ func StripTopLevelCompositionKeywords(schema map[string]any) (map[string]any, []
 	}
 	if len(properties) > 0 {
 		cloned["properties"] = properties
-		objectish = true
-	}
-	if _, ok := cloned["type"]; !ok && objectish {
-		cloned["type"] = "object"
 	}
 	if _, ok := cloned["type"]; !ok {
 		cloned["type"] = "object"

--- a/internal/llm/schema.go
+++ b/internal/llm/schema.go
@@ -1,0 +1,128 @@
+package llm
+
+import (
+	"encoding/json"
+	"strings"
+)
+
+var topLevelCompositionKeywords = []string{"oneOf", "allOf", "anyOf"}
+
+// StripTopLevelCompositionKeywords returns a deep-copied schema with
+// unsupported top-level composition keywords removed and their object
+// properties merged into the root when possible.
+//
+// This is a compatibility helper for downstream consumers that accept
+// regular object schemas but reject top-level oneOf/allOf/anyOf. The
+// returned schema is intentionally permissive: root-level required fields
+// are preserved, but composition-derived required constraints are not
+// re-encoded because doing so would often overconstrain the tool contract.
+func StripTopLevelCompositionKeywords(schema map[string]any) (map[string]any, []string) {
+	if schema == nil {
+		return nil, nil
+	}
+
+	cloned := cloneSchemaMap(schema)
+	var removed []string
+	var variants []map[string]any
+	for _, keyword := range topLevelCompositionKeywords {
+		raw, ok := cloned[keyword]
+		if !ok {
+			continue
+		}
+		delete(cloned, keyword)
+		removed = append(removed, keyword)
+		variants = append(variants, schemaVariants(raw)...)
+	}
+	if len(removed) == 0 {
+		return cloned, nil
+	}
+
+	properties, _ := cloned["properties"].(map[string]any)
+	if properties == nil {
+		properties = make(map[string]any)
+	}
+	objectish := false
+	for _, variant := range variants {
+		if variant == nil {
+			continue
+		}
+		if desc, ok := variant["description"].(string); ok && strings.TrimSpace(desc) != "" && strings.TrimSpace(schemaStringValue(cloned["description"])) == "" {
+			cloned["description"] = desc
+		}
+		if title, ok := variant["title"].(string); ok && strings.TrimSpace(title) != "" && strings.TrimSpace(schemaStringValue(cloned["title"])) == "" {
+			cloned["title"] = title
+		}
+		if tp, ok := variant["type"].(string); ok && tp == "object" {
+			objectish = true
+		}
+		if variantProps, ok := variant["properties"].(map[string]any); ok {
+			objectish = true
+			for key, value := range variantProps {
+				if _, exists := properties[key]; !exists {
+					properties[key] = value
+				}
+			}
+		}
+	}
+	if len(properties) > 0 {
+		cloned["properties"] = properties
+		objectish = true
+	}
+	if _, ok := cloned["type"]; !ok && objectish {
+		cloned["type"] = "object"
+	}
+	if _, ok := cloned["type"]; !ok {
+		cloned["type"] = "object"
+	}
+	if tp, _ := cloned["type"].(string); tp == "object" {
+		if _, ok := cloned["properties"]; !ok {
+			cloned["properties"] = map[string]any{}
+		}
+	}
+	return cloned, removed
+}
+
+func cloneSchemaMap(in map[string]any) map[string]any {
+	if in == nil {
+		return nil
+	}
+	data, err := json.Marshal(in)
+	if err != nil {
+		out := make(map[string]any, len(in))
+		for key, value := range in {
+			out[key] = value
+		}
+		return out
+	}
+	var out map[string]any
+	if err := json.Unmarshal(data, &out); err != nil {
+		fallback := make(map[string]any, len(in))
+		for key, value := range in {
+			fallback[key] = value
+		}
+		return fallback
+	}
+	return out
+}
+
+func schemaVariants(raw any) []map[string]any {
+	switch got := raw.(type) {
+	case []any:
+		out := make([]map[string]any, 0, len(got))
+		for _, item := range got {
+			if schema, ok := item.(map[string]any); ok {
+				out = append(out, schema)
+			}
+		}
+		return out
+	case []map[string]any:
+		return got
+	default:
+		return nil
+	}
+}
+
+func schemaStringValue(raw any) string {
+	value, _ := raw.(string)
+	return value
+}

--- a/internal/llm/schema_test.go
+++ b/internal/llm/schema_test.go
@@ -1,0 +1,81 @@
+package llm
+
+import "testing"
+
+func TestStripTopLevelCompositionKeywords_PreservesNestedComposition(t *testing.T) {
+	t.Parallel()
+
+	in := map[string]any{
+		"type": "object",
+		"anyOf": []any{
+			map[string]any{"required": []any{"loop_id"}},
+			map[string]any{"required": []any{"name"}},
+		},
+		"properties": map[string]any{
+			"duration": map[string]any{
+				"anyOf": []any{
+					map[string]any{"type": "string"},
+					map[string]any{"type": "number"},
+				},
+			},
+		},
+	}
+
+	got, removed := StripTopLevelCompositionKeywords(in)
+	if len(removed) != 1 || removed[0] != "anyOf" {
+		t.Fatalf("removed = %#v, want [\"anyOf\"]", removed)
+	}
+	if _, ok := got["anyOf"]; ok {
+		t.Fatalf("top-level anyOf still present: %#v", got)
+	}
+	props, ok := got["properties"].(map[string]any)
+	if !ok {
+		t.Fatalf("properties type = %T, want map[string]any", got["properties"])
+	}
+	duration, ok := props["duration"].(map[string]any)
+	if !ok {
+		t.Fatalf("duration type = %T, want map[string]any", props["duration"])
+	}
+	if _, ok := duration["anyOf"]; !ok {
+		t.Fatalf("nested anyOf missing after sanitize: %#v", duration)
+	}
+}
+
+func TestStripTopLevelCompositionKeywords_MergesVariantProperties(t *testing.T) {
+	t.Parallel()
+
+	in := map[string]any{
+		"oneOf": []any{
+			map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"entity_id": map[string]any{"type": "string"},
+				},
+			},
+			map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"area_id": map[string]any{"type": "string"},
+				},
+			},
+		},
+	}
+
+	got, removed := StripTopLevelCompositionKeywords(in)
+	if len(removed) != 1 || removed[0] != "oneOf" {
+		t.Fatalf("removed = %#v, want [\"oneOf\"]", removed)
+	}
+	if got["type"] != "object" {
+		t.Fatalf("type = %#v, want object", got["type"])
+	}
+	props, ok := got["properties"].(map[string]any)
+	if !ok {
+		t.Fatalf("properties type = %T, want map[string]any", got["properties"])
+	}
+	if _, ok := props["entity_id"]; !ok {
+		t.Fatalf("entity_id missing from merged properties: %#v", props)
+	}
+	if _, ok := props["area_id"]; !ok {
+		t.Fatalf("area_id missing from merged properties: %#v", props)
+	}
+}

--- a/internal/llm/schema_test.go
+++ b/internal/llm/schema_test.go
@@ -41,6 +41,34 @@ func TestStripTopLevelCompositionKeywords_PreservesNestedComposition(t *testing.
 	}
 }
 
+func TestStripTopLevelCompositionKeywords_FastPathReturnsOriginalWhenNoTopLevelComposition(t *testing.T) {
+	t.Parallel()
+
+	in := map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"duration": map[string]any{
+				"anyOf": []any{
+					map[string]any{"type": "string"},
+					map[string]any{"type": "number"},
+				},
+			},
+		},
+	}
+
+	got, removed := StripTopLevelCompositionKeywords(in)
+	if len(removed) != 0 {
+		t.Fatalf("removed = %#v, want nil", removed)
+	}
+	if got["properties"] == nil {
+		t.Fatalf("properties missing from fast-path schema: %#v", got)
+	}
+	got["title"] = "mutated"
+	if _, ok := in["title"]; !ok {
+		t.Fatalf("fast-path should return original schema when no sanitize is needed")
+	}
+}
+
 func TestStripTopLevelCompositionKeywords_MergesVariantProperties(t *testing.T) {
 	t.Parallel()
 

--- a/internal/llm/schema_test.go
+++ b/internal/llm/schema_test.go
@@ -63,9 +63,11 @@ func TestStripTopLevelCompositionKeywords_FastPathReturnsOriginalWhenNoTopLevelC
 	if got["properties"] == nil {
 		t.Fatalf("properties missing from fast-path schema: %#v", got)
 	}
+	// The fast path returns the original map when no top-level
+	// sanitization is required, so mutating got should also mutate in.
 	got["title"] = "mutated"
 	if _, ok := in["title"]; !ok {
-		t.Fatalf("fast-path should return original schema when no sanitize is needed")
+		t.Fatalf("expected fast-path to return the original schema map")
 	}
 }
 

--- a/internal/mcp/bridge.go
+++ b/internal/mcp/bridge.go
@@ -8,6 +8,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/nugget/thane-ai-agent/internal/llm"
 	"github.com/nugget/thane-ai-agent/internal/tools"
 )
 
@@ -64,6 +65,16 @@ func BridgeTools(ctx context.Context, client *Client, serverName string, registr
 			}
 		} else if excludeSet[td.Name] {
 			continue
+		}
+
+		schema, removedKeywords := llm.StripTopLevelCompositionKeywords(td.InputSchema)
+		if len(removedKeywords) > 0 {
+			logger.Info("sanitized MCP tool schema for provider compatibility",
+				"server", serverName,
+				"mcp_name", td.Name,
+				"removed_keywords", removedKeywords,
+			)
+			td.InputSchema = schema
 		}
 
 		name := ToolName(serverName, td.Name)

--- a/internal/mcp/bridge_test.go
+++ b/internal/mcp/bridge_test.go
@@ -260,6 +260,54 @@ func TestBridgeTools_HandlerProxiesCallTool(t *testing.T) {
 	}
 }
 
+func TestBridgeTools_SanitizesTopLevelCompositionKeywords(t *testing.T) {
+	mt := newMockTransport()
+	mt.addResponse("tools/list", toolsListResult{
+		Tools: []ToolDefinition{
+			{
+				Name:        "notify_state",
+				Description: "Notify on state changes",
+				InputSchema: map[string]any{
+					"type": "object",
+					"anyOf": []any{
+						map[string]any{"required": []any{"entity_id"}},
+						map[string]any{"required": []any{"area_id"}},
+					},
+					"properties": map[string]any{
+						"entity_id": map[string]any{"type": "string"},
+						"area_id":   map[string]any{"type": "string"},
+					},
+				},
+			},
+		},
+	})
+
+	client := NewClient("ha", mt, nil)
+	registry := tools.NewEmptyRegistry()
+
+	if _, err := BridgeTools(context.Background(), client, "ha", registry, BridgeOptions{}, slog.Default()); err != nil {
+		t.Fatalf("BridgeTools: %v", err)
+	}
+
+	tool := registry.Get("mcp_ha_notify_state")
+	if tool == nil {
+		t.Fatal("tool not found")
+	}
+	if _, ok := tool.Parameters["anyOf"]; ok {
+		t.Fatalf("top-level anyOf should be removed from bridged schema: %#v", tool.Parameters)
+	}
+	props, ok := tool.Parameters["properties"].(map[string]any)
+	if !ok {
+		t.Fatalf("properties type = %T, want map[string]any", tool.Parameters["properties"])
+	}
+	if _, ok := props["entity_id"]; !ok {
+		t.Fatalf("entity_id missing from sanitized schema: %#v", props)
+	}
+	if _, ok := props["area_id"]; !ok {
+		t.Fatalf("area_id missing from sanitized schema: %#v", props)
+	}
+}
+
 func TestBridgeTools_MetadataOverrides(t *testing.T) {
 	mt := newMockTransport()
 	mt.addResponse("tools/list", toolsListResult{

--- a/internal/models/providers/anthropic.go
+++ b/internal/models/providers/anthropic.go
@@ -607,6 +607,8 @@ func convertToolsToAnthropic(tools []map[string]any) []anthropicTool {
 
 		if params == nil {
 			params = map[string]any{"type": "object", "properties": map[string]any{}}
+		} else if schema, ok := params.(map[string]any); ok {
+			params, _ = llm.StripTopLevelCompositionKeywords(schema)
 		}
 
 		result = append(result, anthropicTool{

--- a/internal/models/providers/anthropic_test.go
+++ b/internal/models/providers/anthropic_test.go
@@ -125,6 +125,61 @@ func TestConvertToolsToAnthropic(t *testing.T) {
 	}
 }
 
+func TestConvertToolsToAnthropic_StripsTopLevelCompositionKeywords(t *testing.T) {
+	tools := []map[string]any{
+		{
+			"type": "function",
+			"function": map[string]any{
+				"name":        "notify_loop",
+				"description": "Notify a loop",
+				"parameters": map[string]any{
+					"type": "object",
+					"anyOf": []any{
+						map[string]any{"required": []any{"loop_id"}},
+						map[string]any{"required": []any{"name"}},
+					},
+					"properties": map[string]any{
+						"loop_id": map[string]any{"type": "string"},
+						"name":    map[string]any{"type": "string"},
+						"duration": map[string]any{
+							"anyOf": []any{
+								map[string]any{"type": "string"},
+								map[string]any{"type": "number"},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	result := convertToolsToAnthropic(tools)
+	if len(result) != 1 {
+		t.Fatalf("expected 1 tool, got %d", len(result))
+	}
+	schema, ok := result[0].InputSchema.(map[string]any)
+	if !ok {
+		t.Fatalf("InputSchema type = %T, want map[string]any", result[0].InputSchema)
+	}
+	if _, ok := schema["anyOf"]; ok {
+		t.Fatalf("top-level anyOf should be removed for Anthropic: %#v", schema)
+	}
+	props, ok := schema["properties"].(map[string]any)
+	if !ok {
+		t.Fatalf("properties type = %T, want map[string]any", schema["properties"])
+	}
+	if _, ok := props["loop_id"]; !ok {
+		t.Fatalf("loop_id missing from sanitized schema: %#v", props)
+	}
+	duration, ok := props["duration"].(map[string]any)
+	if !ok {
+		t.Fatalf("duration type = %T, want map[string]any", props["duration"])
+	}
+	if _, ok := duration["anyOf"]; !ok {
+		t.Fatalf("nested anyOf should be preserved: %#v", duration)
+	}
+}
+
 func TestConvertFromAnthropic(t *testing.T) {
 	resp := &anthropicResponse{
 		Model: "claude-opus-4-20250514",


### PR DESCRIPTION
## Summary

Closes #723.

This fixes the Anthropic 400s caused by tool schemas that use unsupported top-level `oneOf` / `allOf` / `anyOf`.

What changed:
- sanitize tool input schemas at the Anthropic provider boundary before they are serialized into `input_schema`
- sanitize bridged MCP schemas at registration time too, with an operator-visible log when that happens
- add regression coverage for both MCP-style schemas and native-tool schemas like `notify_loop`

## Why

The immediate crash was showing up through MCP-bridged Home Assistant tools, but the underlying incompatibility was broader: Anthropic rejects top-level composition keywords in tool schemas, and we already had at least one native tool schema with the same pattern.

Fixing this only in the MCP bridge would have left the Anthropic path fragile for future native tools. Fixing it only in the provider would have hidden which third-party MCP tools needed compatibility cleanup. This PR does both:
- provider-side sanitization for correctness and safety
- bridge-side sanitization/logging for visibility

## Design notes

- The sanitizer is intentionally permissive. It strips top-level composition keywords, preserves root-level required fields, and merges object properties from composed variants when possible.
- Nested composition keywords are left alone. The Anthropic error is specifically about top-level schema composition, and nested forms are still useful for tolerant local-model guidance.
- No tool handlers were changed. Runtime validation still happens where it already belongs.

## About the high `tools.N` indices

I did not find evidence that `include_tools`-filtered MCP tools were being reintroduced after bridge registration. The existing bridge path still only registers included tools.

The changing Anthropic error index is better explained by the full active tool array for the request, not just the bridged HA tools, plus map-order instability in tool enumeration. In other words: a bad schema can surface at `tools.10`, `tools.41`, or `tools.136` without implying that the full 86-tool HA-MCP catalog leaked into the request.

## Validation

- `just ci`
- added provider tests for top-level composition stripping and nested composition preservation
- added bridge tests for MCP schema sanitization on registration
- added shared schema-helper tests for the flattening behavior
