### PR TITLE
[codex] fix core loop tool visibility

### DIFF
--- a/internal/tools/capability_tools_test.go
+++ b/internal/tools/capability_tools_test.go
@@ -408,6 +408,11 @@ func TestRegistryFilterByTags_AlwaysAvailable(t *testing.T) {
 	// Tagged tools
 	reg.Register(&Tool{Name: "get_state", Description: "HA state"})
 	reg.Register(&Tool{Name: "web_search", Description: "Search"})
+	reg.Register(&Tool{Name: "loop_status", Description: "Inspect running loops"})
+	reg.Register(&Tool{Name: "set_next_sleep", Description: "Adjust service loop sleep"})
+	reg.Register(&Tool{Name: "send_notification", Description: "Send a notification"})
+	reg.Register(&Tool{Name: "request_human_decision", Description: "Request a decision"})
+	reg.Register(&Tool{Name: "macos_calendar_events", Description: "Read macOS calendar events"})
 	// AlwaysAvailable meta-tools (like activate_capability, deactivate_capability,
 	// list_loaded_capabilities, and reset_capabilities)
 	reg.Register(&Tool{Name: "activate_capability", Description: "Activate a tag", AlwaysAvailable: true})
@@ -418,8 +423,12 @@ func TestRegistryFilterByTags_AlwaysAvailable(t *testing.T) {
 	reg.Register(&Tool{Name: "plain_untagged", Description: "Not tagged, not meta"})
 
 	reg.SetTagIndex(map[string][]string{
-		"ha":  {"get_state"},
-		"web": {"web_search"},
+		"ha":            {"get_state"},
+		"web":           {"web_search"},
+		"core":          {"loop_status"},
+		"loops":         {"loop_status", "set_next_sleep"},
+		"notifications": {"send_notification", "request_human_decision"},
+		"platform":      {"macos_calendar_events"},
 	})
 
 	tests := []struct {
@@ -444,12 +453,26 @@ func TestRegistryFilterByTags_AlwaysAvailable(t *testing.T) {
 			name:    "always-available tools survive unknown-tag filter",
 			tags:    []string{"nonexistent"},
 			wantIn:  []string{"activate_capability", "deactivate_capability", "list_loaded_capabilities", "reset_capabilities"},
-			wantOut: []string{"get_state", "web_search", "plain_untagged"},
+			wantOut: []string{"get_state", "web_search", "loop_status", "set_next_sleep", "send_notification", "request_human_decision", "macos_calendar_events", "plain_untagged"},
+		},
+		{
+			name:   "core filter does not leak tagged non-core tools",
+			tags:   []string{"core"},
+			wantIn: []string{"loop_status", "activate_capability", "deactivate_capability", "list_loaded_capabilities", "reset_capabilities"},
+			wantOut: []string{
+				"get_state",
+				"web_search",
+				"set_next_sleep",
+				"send_notification",
+				"request_human_decision",
+				"macos_calendar_events",
+				"plain_untagged",
+			},
 		},
 		{
 			name:   "nil tags returns everything",
 			tags:   nil,
-			wantIn: []string{"get_state", "web_search", "activate_capability", "deactivate_capability", "list_loaded_capabilities", "reset_capabilities", "plain_untagged"},
+			wantIn: []string{"get_state", "web_search", "loop_status", "set_next_sleep", "send_notification", "request_human_decision", "macos_calendar_events", "activate_capability", "deactivate_capability", "list_loaded_capabilities", "reset_capabilities", "plain_untagged"},
 		},
 	}
 
@@ -467,51 +490,6 @@ func TestRegistryFilterByTags_AlwaysAvailable(t *testing.T) {
 				}
 			}
 		})
-	}
-}
-
-func TestRegistryFilterByTags_DoesNotLeakTaggedToolsIntoCore(t *testing.T) {
-	reg := NewEmptyRegistry()
-	reg.Register(&Tool{Name: "activate_capability", Description: "Activate a tag", AlwaysAvailable: true})
-	reg.Register(&Tool{Name: "deactivate_capability", Description: "Deactivate a tag", AlwaysAvailable: true})
-	reg.Register(&Tool{Name: "list_loaded_capabilities", Description: "List loaded tags", AlwaysAvailable: true})
-	reg.Register(&Tool{Name: "reset_capabilities", Description: "Reset capability state", AlwaysAvailable: true})
-	reg.Register(&Tool{Name: "loop_status", Description: "Inspect running loops"})
-	reg.Register(&Tool{Name: "set_next_sleep", Description: "Adjust service loop sleep"})
-	reg.Register(&Tool{Name: "send_notification", Description: "Send a notification"})
-	reg.Register(&Tool{Name: "request_human_decision", Description: "Request a decision"})
-	reg.Register(&Tool{Name: "macos_calendar_events", Description: "Read macOS calendar events"})
-
-	reg.SetTagIndex(map[string][]string{
-		"core":          {"loop_status"},
-		"loops":         {"loop_status", "set_next_sleep"},
-		"notifications": {"send_notification", "request_human_decision"},
-		"platform":      {"macos_calendar_events"},
-	})
-
-	filtered := reg.FilterByTags([]string{"core"})
-
-	for _, name := range []string{
-		"activate_capability",
-		"deactivate_capability",
-		"list_loaded_capabilities",
-		"reset_capabilities",
-		"loop_status",
-	} {
-		if filtered.Get(name) == nil {
-			t.Fatalf("core-filtered registry should contain %q", name)
-		}
-	}
-
-	for _, name := range []string{
-		"set_next_sleep",
-		"send_notification",
-		"request_human_decision",
-		"macos_calendar_events",
-	} {
-		if filtered.Get(name) != nil {
-			t.Fatalf("core-filtered registry should not contain %q", name)
-		}
 	}
 }
 

--- a/internal/tools/capability_tools_test.go
+++ b/internal/tools/capability_tools_test.go
@@ -470,6 +470,51 @@ func TestRegistryFilterByTags_AlwaysAvailable(t *testing.T) {
 	}
 }
 
+func TestRegistryFilterByTags_DoesNotLeakTaggedToolsIntoCore(t *testing.T) {
+	reg := NewEmptyRegistry()
+	reg.Register(&Tool{Name: "activate_capability", Description: "Activate a tag", AlwaysAvailable: true})
+	reg.Register(&Tool{Name: "deactivate_capability", Description: "Deactivate a tag", AlwaysAvailable: true})
+	reg.Register(&Tool{Name: "list_loaded_capabilities", Description: "List loaded tags", AlwaysAvailable: true})
+	reg.Register(&Tool{Name: "reset_capabilities", Description: "Reset capability state", AlwaysAvailable: true})
+	reg.Register(&Tool{Name: "loop_status", Description: "Inspect running loops"})
+	reg.Register(&Tool{Name: "set_next_sleep", Description: "Adjust service loop sleep"})
+	reg.Register(&Tool{Name: "send_notification", Description: "Send a notification"})
+	reg.Register(&Tool{Name: "request_human_decision", Description: "Request a decision"})
+	reg.Register(&Tool{Name: "macos_calendar_events", Description: "Read macOS calendar events"})
+
+	reg.SetTagIndex(map[string][]string{
+		"core":          {"loop_status"},
+		"loops":         {"loop_status", "set_next_sleep"},
+		"notifications": {"send_notification", "request_human_decision"},
+		"platform":      {"macos_calendar_events"},
+	})
+
+	filtered := reg.FilterByTags([]string{"core"})
+
+	for _, name := range []string{
+		"activate_capability",
+		"deactivate_capability",
+		"list_loaded_capabilities",
+		"reset_capabilities",
+		"loop_status",
+	} {
+		if filtered.Get(name) == nil {
+			t.Fatalf("core-filtered registry should contain %q", name)
+		}
+	}
+
+	for _, name := range []string{
+		"set_next_sleep",
+		"send_notification",
+		"request_human_decision",
+		"macos_calendar_events",
+	} {
+		if filtered.Get(name) != nil {
+			t.Fatalf("core-filtered registry should not contain %q", name)
+		}
+	}
+}
+
 func TestRegistryTaggedToolNames(t *testing.T) {
 	reg := NewEmptyRegistry()
 	reg.SetTagIndex(map[string][]string{

--- a/internal/tools/loop_runtime_tools.go
+++ b/internal/tools/loop_runtime_tools.go
@@ -90,9 +90,8 @@ func (r *Registry) registerLoopRuntimeTools() {
 	})
 
 	r.Register(&Tool{
-		Name:            "set_next_sleep",
-		AlwaysAvailable: true,
-		Description:     "Request the next sleep duration for the current running timer-driven service loop. This is the native loops-ng sleep-control tool used by persistent background services such as metacog-style loops. The requested duration is clamped to the loop's configured sleep_min and sleep_max bounds.",
+		Name:        "set_next_sleep",
+		Description: "Request the next sleep duration for the current running timer-driven service loop. This is the native loops-ng sleep-control tool used by persistent background services such as metacog-style loops. The requested duration is clamped to the loop's configured sleep_min and sleep_max bounds.",
 		Parameters: map[string]any{
 			"type": "object",
 			"properties": map[string]any{

--- a/internal/tools/notification_tools.go
+++ b/internal/tools/notification_tools.go
@@ -227,7 +227,6 @@ func (r *Registry) registerGenericNotificationTools() {
 			"future). The system selects the target using the recipient's contact facts. " +
 			"Use this for informing people about events, updates, or anything that needs " +
 			"their attention. This is fire-and-forget — no response tracking.",
-		AlwaysAvailable: true,
 		Parameters: map[string]any{
 			"type": "object",
 			"properties": map[string]any{
@@ -262,7 +261,6 @@ func (r *Registry) registerGenericNotificationTools() {
 			"callback routing — you will receive a callback when they respond or on " +
 			"timeout. The system selects the delivery channel using the recipient's " +
 			"contact facts.",
-		AlwaysAvailable: true,
 		Parameters: map[string]any{
 			"type": "object",
 			"properties": map[string]any{

--- a/internal/tools/notification_tools_test.go
+++ b/internal/tools/notification_tools_test.go
@@ -366,8 +366,8 @@ func TestSendNotification_Registered(t *testing.T) {
 	if tool == nil {
 		t.Fatal("send_notification tool not registered")
 	}
-	if !tool.AlwaysAvailable {
-		t.Error("send_notification should be AlwaysAvailable")
+	if tool.AlwaysAvailable {
+		t.Error("send_notification should rely on capability tags instead of AlwaysAvailable")
 	}
 }
 
@@ -377,8 +377,8 @@ func TestRequestHumanDecision_Registered(t *testing.T) {
 	if tool == nil {
 		t.Fatal("request_human_decision tool not registered")
 	}
-	if !tool.AlwaysAvailable {
-		t.Error("request_human_decision should be AlwaysAvailable")
+	if tool.AlwaysAvailable {
+		t.Error("request_human_decision should rely on capability tags instead of AlwaysAvailable")
 	}
 }
 

--- a/internal/tools/platform_tools.go
+++ b/internal/tools/platform_tools.go
@@ -53,8 +53,7 @@ func (r *Registry) registerPlatformTools() {
 	}
 
 	r.Register(&Tool{
-		Name:            "macos_calendar_events",
-		AlwaysAvailable: true,
+		Name: "macos_calendar_events",
 		Description: "List calendar events from a connected macOS platform host. " +
 			"Use this for upcoming availability, scheduled meetings, and calendar context when a macOS provider is connected to Thane.",
 		Parameters: map[string]any{

--- a/internal/tools/platform_tools_test.go
+++ b/internal/tools/platform_tools_test.go
@@ -46,8 +46,8 @@ func TestSetPlatformCallerRegistersCalendarTool(t *testing.T) {
 	if tool == nil {
 		t.Fatal("expected macos_calendar_events to be registered")
 	}
-	if !tool.AlwaysAvailable {
-		t.Fatal("expected macos_calendar_events to be always available")
+	if tool.AlwaysAvailable {
+		t.Fatal("expected macos_calendar_events to rely on capability tags instead of AlwaysAvailable")
 	}
 
 	output, err := reg.Execute(context.Background(), "macos_calendar_events", `{


### PR DESCRIPTION
## Summary
This fixes a tool-surface leak in fresh core-only conversations.

A Signal conversation loop with only the `core` capability loaded was still showing several tools that do not belong in that default surface:
- `macos_calendar_events`
- `send_notification`
- `request_human_decision`
- `set_next_sleep`

## Root Cause
These tools already had the right semantic catalog tags (`platform`, `notifications`, and `loops`), but their registrations also marked them `AlwaysAvailable`.

`FilterByTags` preserves `AlwaysAvailable` tools even when capability tag filtering is active, so they bypassed the capability menu and leaked into core-only loops.

## What Changed
- Removed `AlwaysAvailable` from `macos_calendar_events`
- Removed `AlwaysAvailable` from `send_notification`
- Removed `AlwaysAvailable` from `request_human_decision`
- Removed `AlwaysAvailable` from `set_next_sleep`
- Updated tool registration tests to assert these tools now rely on capability tags
- Added a regression test proving a `core`-filtered registry does not leak tagged tools from `platform`, `notifications`, or `loops`

## Impact
Fresh owner conversations now present a tighter default tool surface that matches the active capability state more closely.

This keeps service-loop controls out of normal conversations, removes notification tools that do not make sense in a direct owner chat, and keeps macOS calendar access behind the capability that actually advertises it.

## Validation
- `just test`
- `just ci`