### PR TITLE
fix: expose typed launch overrides in loop launch tool schemas

### DIFF
--- a/internal/tools/loop_definition_tool_helpers.go
+++ b/internal/tools/loop_definition_tool_helpers.go
@@ -87,6 +87,64 @@ func validateLoopLaunchOverrides(launch looppkg.Launch) error {
 	return nil
 }
 
+func loopCompletionChannelTargetProperty() map[string]any {
+	return map[string]any{
+		"type":        "object",
+		"description": "Explicit detached channel delivery target when spec.completion=\"channel\". If omitted, the current origin context may infer one automatically.",
+		"properties": map[string]any{
+			"channel": map[string]any{
+				"type":        "string",
+				"description": "Channel integration name such as \"signal\" or \"owu\".",
+			},
+			"recipient": map[string]any{
+				"type":        "string",
+				"description": "Recipient or address for integrations that route by recipient (for example a Signal phone number).",
+			},
+			"conversation_id": map[string]any{
+				"type":        "string",
+				"description": "Channel-native conversation or thread ID for integrations that route by conversation.",
+			},
+		},
+	}
+}
+
+func loopChannelBindingProperty() map[string]any {
+	return map[string]any{
+		"type":        "object",
+		"description": "Typed channel identity bound to the launched loop. If omitted, the current tool-call channel binding is inherited when available.",
+		"properties": map[string]any{
+			"channel": map[string]any{
+				"type":        "string",
+				"description": "Channel integration name (for example \"signal\").",
+			},
+			"address": map[string]any{
+				"type":        "string",
+				"description": "Channel address or sender identity bound to this loop.",
+			},
+			"contact_id": map[string]any{
+				"type":        "string",
+				"description": "Resolved internal contact ID for this channel identity, when known.",
+			},
+			"contact_name": map[string]any{
+				"type":        "string",
+				"description": "Resolved display name for the bound contact, when known.",
+			},
+			"trust_zone": map[string]any{
+				"type":        "string",
+				"description": "Trust classification attached to this channel identity.",
+			},
+			"link_source": map[string]any{
+				"type":        "string",
+				"description": "How this channel binding was established.",
+			},
+			"is_owner": map[string]any{
+				"type":        "boolean",
+				"description": "Whether this bound identity belongs to the owner/self side of the conversation.",
+			},
+		},
+	}
+}
+
 // loopLaunchOverrideProperties returns the JSON-schema property set for
 // the per-launch override fields accepted by both
 // [Registry.handleLoopDefinitionLaunch] and [Registry.handleSpawnLoop].
@@ -103,6 +161,10 @@ func loopLaunchOverrideProperties() map[string]any {
 		"task": map[string]any{
 			"type":        "string",
 			"description": "Override the task text for this launch. Applied only when the stored spec does not already supply a task.",
+		},
+		"parent_id": map[string]any{
+			"type":        "string",
+			"description": "Associate this launch with a parent loop ID for parent/child tracking.",
 		},
 		"allowed_tools": map[string]any{
 			"type":        "array",
@@ -148,14 +210,36 @@ func loopLaunchOverrideProperties() map[string]any {
 			"type":        "string",
 			"description": "Bind this launch to a specific conversation ID instead of deriving one.",
 		},
+		"channel_binding": loopChannelBindingProperty(),
+		"run_timeout": map[string]any{
+			"type":        "string",
+			"description": "For request_reply launches, stop waiting after this wall-clock duration and return a timeout error. Use a Go duration string like \"30s\" or \"2m\".",
+		},
 		"completion_conversation_id": map[string]any{
 			"type":        "string",
 			"description": "When spec.completion=\"conversation\", deliver the final result to this conversation ID.",
 		},
+		"completion_channel": loopCompletionChannelTargetProperty(),
 		"metadata": map[string]any{
 			"type":                 "object",
 			"additionalProperties": map[string]any{"type": "string"},
 			"description":          "Opaque string/string tags attached to the launched loop for correlation or audit. NOT used for routing, tools, budgets, or any runtime behavior. To override the model use top-level \"model\". To override tools use \"allowed_tools\" / \"exclude_tools\". To override budgets use \"max_iterations\" / \"max_output_tokens\".",
+		},
+		"fallback_content": map[string]any{
+			"type":        "string",
+			"description": "Static fallback reply used if the nested agent run produces no content but the launch still needs a last-resort response.",
+		},
+		"tool_timeout": map[string]any{
+			"type":        "string",
+			"description": "Per-tool-call timeout for nested agent tool executions inside this loop. Use a Go duration string like \"30s\" or \"2m\".",
+		},
+		"usage_role": map[string]any{
+			"type":        "string",
+			"description": "Usage attribution role label recorded on model and tool usage for this launch (for example \"delegate\").",
+		},
+		"usage_task_name": map[string]any{
+			"type":        "string",
+			"description": "Usage attribution task label recorded on model and tool usage for this launch (for example \"general\").",
 		},
 	}
 }

--- a/internal/tools/loop_definition_tool_helpers.go
+++ b/internal/tools/loop_definition_tool_helpers.go
@@ -62,7 +62,102 @@ func decodeLoopLaunchArg(args map[string]any, key string) (looppkg.Launch, error
 	if err := json.Unmarshal(data, &launch); err != nil {
 		return looppkg.Launch{}, err
 	}
+	if err := validateLoopLaunchOverrides(launch); err != nil {
+		return looppkg.Launch{}, err
+	}
 	return launch, nil
+}
+
+// validateLoopLaunchOverrides catches common mistakes where a caller
+// placed a routing override inside the opaque metadata map instead of
+// the corresponding top-level Launch field. Metadata is informational
+// tagging only; it does not influence routing, tool selection, or
+// budgets. Returning an actionable error here is preferable to silently
+// ignoring the override and letting the caller misinterpret the run.
+func validateLoopLaunchOverrides(launch looppkg.Launch) error {
+	if len(launch.Metadata) == 0 {
+		return nil
+	}
+	if model, ok := launch.Metadata["model"]; ok && strings.TrimSpace(model) != "" && strings.TrimSpace(launch.Model) == "" {
+		return fmt.Errorf(
+			"launch.metadata.model=%q is opaque tagging and does not override the model; "+
+				"use the top-level launch.model field (e.g. \"launch\": {\"model\": %q})",
+			model, model)
+	}
+	return nil
+}
+
+// loopLaunchOverrideProperties returns the JSON-schema property set for
+// the per-launch override fields accepted by both
+// [Registry.handleLoopDefinitionLaunch] and [Registry.handleSpawnLoop].
+// Exposing a typed schema lets the model see the real field names and
+// their behavior rather than guessing at an opaque object — the
+// disaster mode we most care about is putting a `model` override inside
+// `metadata`, where it has no effect on routing.
+func loopLaunchOverrideProperties() map[string]any {
+	return map[string]any{
+		"model": map[string]any{
+			"type":        "string",
+			"description": "Override the model for this launch (e.g. \"claude-sonnet-4-5\", \"gpt-oss:120b\"). This is the field the router reads. metadata.model is NOT read by the router and does not change the model.",
+		},
+		"task": map[string]any{
+			"type":        "string",
+			"description": "Override the task text for this launch. Applied only when the stored spec does not already supply a task.",
+		},
+		"allowed_tools": map[string]any{
+			"type":        "array",
+			"items":       map[string]any{"type": "string"},
+			"description": "Restrict this launch's effective tool set to the listed tools (intersected with capability gating).",
+		},
+		"exclude_tools": map[string]any{
+			"type":        "array",
+			"items":       map[string]any{"type": "string"},
+			"description": "Remove specific tools from this launch's effective tool set.",
+		},
+		"initial_tags": map[string]any{
+			"type":        "array",
+			"items":       map[string]any{"type": "string"},
+			"description": "Preload these capability tags so the child loop starts with them active.",
+		},
+		"hints": map[string]any{
+			"type":                 "object",
+			"additionalProperties": map[string]any{"type": "string"},
+			"description":          "Free-form string/string routing or context hints. Use named top-level fields (model, allowed_tools, etc.) for well-known behavior overrides; hints are for softer signals.",
+		},
+		"max_iterations": map[string]any{
+			"type":        "integer",
+			"description": "Cap the number of tool-call iterations for this launch.",
+		},
+		"max_output_tokens": map[string]any{
+			"type":        "integer",
+			"description": "Cap the model's output tokens per call for this launch.",
+		},
+		"system_prompt": map[string]any{
+			"type":        "string",
+			"description": "Override the system prompt for this launch.",
+		},
+		"skip_context": map[string]any{
+			"type":        "boolean",
+			"description": "Skip context providers (awareness, archive prewarm, etc.) for this launch.",
+		},
+		"skip_tag_filter": map[string]any{
+			"type":        "boolean",
+			"description": "Disable tag-based tool filtering for this launch. Use with care.",
+		},
+		"conversation_id": map[string]any{
+			"type":        "string",
+			"description": "Bind this launch to a specific conversation ID instead of deriving one.",
+		},
+		"completion_conversation_id": map[string]any{
+			"type":        "string",
+			"description": "When spec.completion=\"conversation\", deliver the final result to this conversation ID.",
+		},
+		"metadata": map[string]any{
+			"type":                 "object",
+			"additionalProperties": map[string]any{"type": "string"},
+			"description":          "Opaque string/string tags attached to the launched loop for correlation or audit. NOT used for routing, tools, budgets, or any runtime behavior. To override the model use top-level \"model\". To override tools use \"allowed_tools\" / \"exclude_tools\". To override budgets use \"max_iterations\" / \"max_output_tokens\".",
+		},
+	}
 }
 
 func findLoopDefinition(snapshot *looppkg.DefinitionRegistrySnapshot, name string) (looppkg.DefinitionSnapshot, bool) {

--- a/internal/tools/loop_definition_tools.go
+++ b/internal/tools/loop_definition_tools.go
@@ -199,7 +199,7 @@ func (r *Registry) registerLoopDefinitionTools() {
 
 	r.Register(&Tool{
 		Name:        "loop_definition_launch",
-		Description: "Launch one stored loop definition by name using its persisted spec plus optional per-launch overrides. Use this instead of resending the full definition for request_reply, background_task, or on-demand service launches. When a launch uses conversation or channel completion and no explicit target is provided, the tool defaults to the current conversation or interactive channel context.",
+		Description: "Launch one stored loop definition by name using its persisted spec plus optional per-launch overrides. Use this instead of resending the full definition for request_reply, background_task, or on-demand service launches. Model routing, tool filtering, and iteration caps go in the top-level launch fields (model, allowed_tools, max_iterations, etc.) — NOT inside launch.metadata, which is opaque tagging only. When a launch uses conversation or channel completion and no explicit target is provided, the tool defaults to the current conversation or interactive channel context.",
 		Parameters: map[string]any{
 			"type": "object",
 			"properties": map[string]any{
@@ -209,7 +209,8 @@ func (r *Registry) registerLoopDefinitionTools() {
 				},
 				"launch": map[string]any{
 					"type":        "object",
-					"description": "Optional per-launch overrides using the loops-ng launch contract. The stored definition spec is used automatically.",
+					"description": "Optional per-launch overrides applied on top of the stored definition spec. The stored spec is used automatically; these fields override selected aspects for this one launch.",
+					"properties":  loopLaunchOverrideProperties(),
 				},
 			},
 			"required": []string{"name"},

--- a/internal/tools/loop_definition_tools_test.go
+++ b/internal/tools/loop_definition_tools_test.go
@@ -3,6 +3,7 @@ package tools
 import (
 	"context"
 	"encoding/json"
+	"strings"
 	"testing"
 	"time"
 
@@ -358,6 +359,44 @@ func TestLoopDefinitionSetPolicyAndLaunch(t *testing.T) {
 	}
 	if launchResp.Result.LoopID != "loop-123" {
 		t.Fatalf("launch loop_id = %q, want loop-123", launchResp.Result.LoopID)
+	}
+}
+
+func TestLoopDefinitionLaunchRoutesTopLevelModelOverride(t *testing.T) {
+	deps := newTestLoopDefinitionDeps(t)
+
+	if _, err := deps.reg.Get("loop_definition_launch").Handler(context.Background(), map[string]any{
+		"name": "metacog_like",
+		"launch": map[string]any{
+			"model": "claude-sonnet-4-5",
+		},
+	}); err != nil {
+		t.Fatalf("loop_definition_launch: %v", err)
+	}
+	if deps.lastLaunch.Model != "claude-sonnet-4-5" {
+		t.Fatalf("lastLaunch.Model = %q, want claude-sonnet-4-5", deps.lastLaunch.Model)
+	}
+}
+
+func TestLoopDefinitionLaunchRejectsModelInsideMetadata(t *testing.T) {
+	deps := newTestLoopDefinitionDeps(t)
+
+	_, err := deps.reg.Get("loop_definition_launch").Handler(context.Background(), map[string]any{
+		"name": "metacog_like",
+		"launch": map[string]any{
+			"metadata": map[string]any{
+				"model": "claude-sonnet-4-5",
+			},
+		},
+	})
+	if err == nil {
+		t.Fatal("expected error for metadata.model override, got nil")
+	}
+	if !strings.Contains(err.Error(), "metadata.model") || !strings.Contains(err.Error(), "launch.model") {
+		t.Fatalf("error = %q, want guidance pointing from metadata.model to launch.model", err.Error())
+	}
+	if deps.lastLaunch.Model != "" {
+		t.Fatalf("lastLaunch.Model = %q, want empty (launch should not have been dispatched)", deps.lastLaunch.Model)
 	}
 }
 

--- a/internal/tools/loop_definition_tools_test.go
+++ b/internal/tools/loop_definition_tools_test.go
@@ -3,6 +3,8 @@ package tools
 import (
 	"context"
 	"encoding/json"
+	"reflect"
+	"sort"
 	"strings"
 	"testing"
 	"time"
@@ -99,6 +101,48 @@ func newTestLoopDefinitionDeps(t *testing.T) *testLoopDefinitionDeps {
 		},
 	})
 	return deps
+}
+
+func sharedLoopLaunchSchemaKeys() []string {
+	typ := reflect.TypeOf(looppkg.Launch{})
+	keys := make([]string, 0, typ.NumField())
+	for i := 0; i < typ.NumField(); i++ {
+		field := typ.Field(i)
+		name, _, _ := strings.Cut(field.Tag.Get("json"), ",")
+		switch name {
+		case "", "-", "spec":
+			continue
+		default:
+			keys = append(keys, name)
+		}
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func schemaProperties(t *testing.T, schema map[string]any) map[string]any {
+	t.Helper()
+
+	props, ok := schema["properties"].(map[string]any)
+	if !ok {
+		t.Fatalf("schema properties = %#v, want map[string]any", schema["properties"])
+	}
+	return props
+}
+
+func schemaObjectProperty(t *testing.T, schema map[string]any, key string) map[string]any {
+	t.Helper()
+
+	props := schemaProperties(t, schema)
+	raw, ok := props[key]
+	if !ok {
+		t.Fatalf("schema missing %q property", key)
+	}
+	child, ok := raw.(map[string]any)
+	if !ok {
+		t.Fatalf("schema property %q = %#v, want map[string]any", key, raw)
+	}
+	return child
 }
 
 func TestConfigureLoopDefinitionTools_RegistersTools(t *testing.T) {
@@ -375,6 +419,45 @@ func TestLoopDefinitionLaunchRoutesTopLevelModelOverride(t *testing.T) {
 	}
 	if deps.lastLaunch.Model != "claude-sonnet-4-5" {
 		t.Fatalf("lastLaunch.Model = %q, want claude-sonnet-4-5", deps.lastLaunch.Model)
+	}
+}
+
+func TestLoopDefinitionLaunchSchemaExposesSharedLaunchFields(t *testing.T) {
+	deps := newTestLoopDefinitionDeps(t)
+
+	tool := deps.reg.Get("loop_definition_launch")
+	if tool == nil {
+		t.Fatal("loop_definition_launch tool not registered")
+	}
+
+	launchSchema := schemaObjectProperty(t, tool.Parameters, "launch")
+	launchProps := schemaProperties(t, launchSchema)
+
+	for _, key := range sharedLoopLaunchSchemaKeys() {
+		if _, ok := launchProps[key]; !ok {
+			t.Errorf("launch schema missing %q", key)
+		}
+	}
+
+	if got := schemaObjectProperty(t, launchSchema, "run_timeout")["type"]; got != "string" {
+		t.Fatalf("run_timeout.type = %#v, want string", got)
+	}
+	if got := schemaObjectProperty(t, launchSchema, "tool_timeout")["type"]; got != "string" {
+		t.Fatalf("tool_timeout.type = %#v, want string", got)
+	}
+
+	completionProps := schemaProperties(t, schemaObjectProperty(t, launchSchema, "completion_channel"))
+	for _, key := range []string{"channel", "recipient", "conversation_id"} {
+		if _, ok := completionProps[key]; !ok {
+			t.Errorf("completion_channel schema missing %q", key)
+		}
+	}
+
+	channelBindingProps := schemaProperties(t, schemaObjectProperty(t, launchSchema, "channel_binding"))
+	for _, key := range []string{"channel", "address", "contact_id", "contact_name", "trust_zone", "link_source", "is_owner"} {
+		if _, ok := channelBindingProps[key]; !ok {
+			t.Errorf("channel_binding schema missing %q", key)
+		}
 	}
 }
 

--- a/internal/tools/loop_runtime_tools.go
+++ b/internal/tools/loop_runtime_tools.go
@@ -113,15 +113,23 @@ func (r *Registry) registerLoopRuntimeTools() {
 		Handler: r.handleSetNextSleep,
 	})
 
+	spawnLoopLaunchProperties := loopLaunchOverrideProperties()
+	spawnLoopLaunchProperties["spec"] = map[string]any{
+		"type":        "object",
+		"description": "Ad-hoc loop spec (name, task, operation, completion, sleep settings, etc.). Required.",
+	}
+
 	r.Register(&Tool{
 		Name:        "spawn_loop",
-		Description: "Launch an ad hoc loop immediately using the loops-ng launch contract without persisting a loop definition. Use this for temporary services, detached background research that should report back later, or one-shot request/reply runs that do not belong in the durable loop-definition registry. For async work, prefer operation=background_task. If completion is omitted there, the runtime infers the most natural detached delivery target from the current origin context.",
+		Description: "Launch an ad hoc loop immediately using the loops-ng launch contract without persisting a loop definition. Use this for temporary services, detached background research that should report back later, or one-shot request/reply runs that do not belong in the durable loop-definition registry. For async work, prefer operation=background_task. If completion is omitted there, the runtime infers the most natural detached delivery target from the current origin context. Model routing and tool filtering go in the top-level launch fields (model, allowed_tools, etc.) — NOT inside launch.metadata.",
 		Parameters: map[string]any{
 			"type": "object",
 			"properties": map[string]any{
 				"launch": map[string]any{
 					"type":        "object",
-					"description": "Loops-ng launch object. Include spec, task, and any per-launch routing or completion overrides. The most common detached shape is a task plus spec.operation=background_task; completion may be omitted when the current conversation or channel context should decide the callback target.",
+					"description": "Loops-ng launch object. Must include spec. The most common detached shape is a task plus spec.operation=background_task; completion may be omitted when the current conversation or channel context should decide the callback target.",
+					"properties":  spawnLoopLaunchProperties,
+					"required":    []string{"spec"},
 				},
 			},
 			"required": []string{"launch"},

--- a/internal/tools/loop_runtime_tools_test.go
+++ b/internal/tools/loop_runtime_tools_test.go
@@ -82,6 +82,26 @@ func TestConfigureLoopRuntimeTools_RegistersTools(t *testing.T) {
 	}
 }
 
+func TestSpawnLoopSchemaExposesSharedLaunchFields(t *testing.T) {
+	deps := newTestLoopRuntimeDeps(t)
+
+	tool := deps.reg.Get("spawn_loop")
+	if tool == nil {
+		t.Fatal("spawn_loop tool not registered")
+	}
+
+	launchSchema := schemaObjectProperty(t, tool.Parameters, "launch")
+	launchProps := schemaProperties(t, launchSchema)
+	if _, ok := launchProps["spec"]; !ok {
+		t.Fatal("spawn_loop launch schema missing spec")
+	}
+	for _, key := range sharedLoopLaunchSchemaKeys() {
+		if _, ok := launchProps[key]; !ok {
+			t.Errorf("spawn_loop launch schema missing %q", key)
+		}
+	}
+}
+
 func TestSetNextSleepForCurrentServiceLoop(t *testing.T) {
 	deps := newTestLoopRuntimeDeps(t)
 	live := deps.live.GetByName("battery_watch")


### PR DESCRIPTION
## Summary

- Replace the opaque `launch` object on `loop_definition_launch` and
  `spawn_loop` with a typed property schema that names the real
  overrides (model, task, allowed_tools, etc.).
- Call out explicitly that `metadata` is opaque and does not affect
  routing — that was the observed failure mode in #729.
- Fail fast with an actionable error when a caller places a `model`
  override inside `metadata`, pointing at the correct top-level field.

## Why

During a personality test on 2026-04-18, Thane placed model overrides
inside `launch.metadata.model`. That field is opaque tagging; the
router ignored it and ran the default model on all four launches.
Thane then narrated the runs as if the override had worked,
fabricating per-model personality differences it never observed.
Surfacing the real fields and trapping the common mistake makes this
class of silent failure loud.

## Test plan

- [x] `just ci` passes locally
- [x] New `TestLoopDefinitionLaunchRoutesTopLevelModelOverride`
      verifies `launch.model` threads through to the dispatched
      `Launch.Model`
- [x] New `TestLoopDefinitionLaunchRejectsModelInsideMetadata`
      verifies the metadata.model trap returns a descriptive error
      and the launch is not dispatched

Closes #729