### PR TITLE
fix: clarify logs_query pattern vs attribute filters

### DIFF
--- a/internal/tools/log_tools.go
+++ b/internal/tools/log_tools.go
@@ -294,7 +294,7 @@ func zeroResultPatternHint(params logging.QueryParams, returned int) string {
 		return ""
 	}
 	if params.SessionID != "" || params.ConversationID != "" || params.RequestID != "" ||
-		params.Tool != "" || params.Model != "" ||
+		params.Subsystem != "" || params.Tool != "" || params.Model != "" ||
 		params.LoopID != "" || params.LoopName != "" {
 		// Caller already combined pattern with an attribute filter, so
 		// the empty result is legitimately empty — do not second-guess.

--- a/internal/tools/log_tools.go
+++ b/internal/tools/log_tools.go
@@ -29,9 +29,15 @@ func (r *Registry) registerLogsQuery() {
 	r.Register(&Tool{
 		Name: "logs_query",
 		Description: "Query the structured log index for debugging and forensics. " +
-			"Filter by session, conversation, request ID, subsystem, tool, model, " +
-			"log level (minimum severity), time range, and message pattern. " +
-			"Returns matching entries as JSON.",
+			"Returns matching entries as JSON. " +
+			"Prefer attribute filters over `pattern` whenever you can name the target: " +
+			"use `loop_name` or `loop_id` for a specific loop, " +
+			"`session_id` / `conversation_id` / `request_id` for a correlation ID, " +
+			"`tool` for a tool name, `model` for a model name, " +
+			"`subsystem` to scope by subsystem. " +
+			"`pattern` is a substring search on the log message text only — " +
+			"it does NOT search attribute fields, so `pattern=\"my-loop\"` will miss every entry " +
+			"whose loop_name is \"my-loop\" unless that literal string appears in the message text.",
 		AlwaysAvailable: true,
 		Parameters: map[string]any{
 			"type": "object",
@@ -67,7 +73,7 @@ func (r *Registry) registerLogsQuery() {
 				},
 				"loop_name": map[string]any{
 					"type":        "string",
-					"description": "Filter by loop name (e.g., \"metacognitive\", \"signal-parent\", \"email-poller\").",
+					"description": "Filter by loop name (e.g., \"metacognitive\", \"signal-parent\", \"email-poller\"). Use this — not `pattern` — to find all entries for a named loop.",
 				},
 				"level": map[string]any{
 					"type":        "string",
@@ -84,7 +90,7 @@ func (r *Registry) registerLogsQuery() {
 				},
 				"pattern": map[string]any{
 					"type":        "string",
-					"description": "Text search in log message (substring match).",
+					"description": "Substring match against the log message text only. Does NOT search attribute fields like loop_name, loop_id, session_id, request_id, conversation_id, tool, model, or subsystem — those have dedicated filter parameters. Use `pattern` for phrases that actually appear in the human-readable message (e.g. \"illegal tool call\", \"connection refused\"), not for IDs or names.",
 				},
 				"limit": map[string]any{
 					"type":        "integer",
@@ -219,6 +225,13 @@ func (r *Registry) handleLogsQuery(_ context.Context, args map[string]any) (stri
 		included++
 	}
 
+	// hint is emitted when a pattern-only search returns zero rows. That
+	// pattern almost always means the caller reached for `pattern` when
+	// they should have used one of the dedicated attribute filters — a
+	// common failure mode for models that do not realize `pattern`
+	// matches message text only.
+	hint := zeroResultPatternHint(params, returned)
+
 	// Build final JSON with a hard cap enforcement. The entry
 	// collection above uses an estimated budget; this final pass
 	// guarantees the output never exceeds maxLogsResultBytes.
@@ -233,6 +246,9 @@ func (r *Registry) handleLogsQuery(_ context.Context, args map[string]any) (stri
 	sb.WriteString("]")
 	if truncated {
 		fmt.Fprintf(&sb, `,"truncated":true,"note":"showing %d of %d returned entries (byte limit). Narrow filters for more targeted results."`, included, returned)
+	}
+	if hint != "" {
+		writeJSONStringField(&sb, "hint", hint)
 	}
 	sb.WriteString("}")
 
@@ -256,12 +272,56 @@ func (r *Registry) handleLogsQuery(_ context.Context, args map[string]any) (stri
 			}
 			rebuild.WriteString("]")
 			fmt.Fprintf(&rebuild, `,"truncated":true,"note":"showing %d of %d returned entries (byte limit). Narrow filters for more targeted results."`, included, returned)
+			if hint != "" {
+				writeJSONStringField(&rebuild, "hint", hint)
+			}
 			rebuild.WriteString("}")
 			out = rebuild.String()
 		}
 	}
 
 	return out, nil
+}
+
+// zeroResultPatternHint returns a short hint when a query that relied
+// on `pattern` alone returned zero rows. Models frequently use
+// `pattern=\"<loop-name>\"` or `pattern=\"<request-id>\"` and get an
+// empty result because `pattern` matches the log message text only,
+// not attribute columns. Pointing them at the dedicated attribute
+// filters is the recovery path.
+func zeroResultPatternHint(params logging.QueryParams, returned int) string {
+	if returned > 0 || strings.TrimSpace(params.Pattern) == "" {
+		return ""
+	}
+	if params.SessionID != "" || params.ConversationID != "" || params.RequestID != "" ||
+		params.Tool != "" || params.Model != "" ||
+		params.LoopID != "" || params.LoopName != "" {
+		// Caller already combined pattern with an attribute filter, so
+		// the empty result is legitimately empty — do not second-guess.
+		return ""
+	}
+	return "pattern matches log message text only and returned no rows. " +
+		"If you are searching for a loop, session, request, or conversation, " +
+		"use the matching attribute filter instead: " +
+		"loop_name / loop_id / session_id / conversation_id / request_id / tool / model / subsystem."
+}
+
+// writeJSONStringField appends a JSON string field to an existing
+// object body. The caller is responsible for the surrounding braces
+// and any leading comma separator concerns are handled internally.
+func writeJSONStringField(sb *strings.Builder, key, value string) {
+	sb.WriteByte(',')
+	enc, err := json.Marshal(key)
+	if err != nil {
+		return
+	}
+	sb.Write(enc)
+	sb.WriteByte(':')
+	valEnc, err := json.Marshal(value)
+	if err != nil {
+		return
+	}
+	sb.Write(valEnc)
 }
 
 // stringArg extracts a string value from the args map.

--- a/internal/tools/log_tools_test.go
+++ b/internal/tools/log_tools_test.go
@@ -243,6 +243,88 @@ func TestLogsQuery_ResultTruncation(t *testing.T) {
 	}
 }
 
+func TestLogsQuery_ZeroResultPatternHint(t *testing.T) {
+	db := openLogTestDB(t)
+	now := time.Now()
+
+	// Seed an entry whose loop_name is "personality-test" but whose
+	// message text does not contain that string. pattern="personality-test"
+	// must return zero rows; the loop_name filter must return one.
+	insertTestLogEntry(t, db, now.Add(-5*time.Second), "INFO", "loop started", "loop-aaa", "personality-test", "loop")
+
+	r := NewEmptyRegistry()
+	r.SetLogIndexDB(db)
+	tool := r.Get("logs_query")
+
+	t.Run("pattern-only zero-result emits hint", func(t *testing.T) {
+		result, err := tool.Handler(nil, map[string]any{
+			"pattern": "personality-test",
+			"since":   "1h",
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !strings.Contains(result, `"returned":0`) {
+			t.Fatalf("expected returned:0 for pattern matching no message text, got: %s", result)
+		}
+		if !strings.Contains(result, `"hint"`) {
+			t.Errorf("expected hint field steering toward attribute filters, got: %s", result)
+		}
+		if !strings.Contains(result, "loop_name") {
+			t.Errorf("hint should mention loop_name as an alternative, got: %s", result)
+		}
+	})
+
+	t.Run("loop_name filter returns the row", func(t *testing.T) {
+		result, err := tool.Handler(nil, map[string]any{
+			"loop_name": "personality-test",
+			"since":     "1h",
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !strings.Contains(result, `"returned":1`) {
+			t.Errorf("expected returned:1 via loop_name, got: %s", result)
+		}
+	})
+
+	t.Run("pattern with attribute filter omits hint even when empty", func(t *testing.T) {
+		// Attribute filter combined with pattern may legitimately
+		// return zero rows — the caller clearly knew which attribute
+		// they wanted, so do not second-guess.
+		result, err := tool.Handler(nil, map[string]any{
+			"pattern":   "does-not-match",
+			"loop_name": "personality-test",
+			"since":     "1h",
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !strings.Contains(result, `"returned":0`) {
+			t.Fatalf("expected returned:0, got: %s", result)
+		}
+		if strings.Contains(result, `"hint"`) {
+			t.Errorf("hint should not appear when an attribute filter is already combined, got: %s", result)
+		}
+	})
+
+	t.Run("non-empty result has no hint", func(t *testing.T) {
+		result, err := tool.Handler(nil, map[string]any{
+			"pattern": "loop started",
+			"since":   "1h",
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !strings.Contains(result, `"returned":1`) {
+			t.Fatalf("expected returned:1 when pattern actually matches message text, got: %s", result)
+		}
+		if strings.Contains(result, `"hint"`) {
+			t.Errorf("hint should not appear when rows were returned, got: %s", result)
+		}
+	})
+}
+
 func TestParseTimeOrDuration(t *testing.T) {
 	tests := []struct {
 		name  string

--- a/internal/tools/log_tools_test.go
+++ b/internal/tools/log_tools_test.go
@@ -308,6 +308,23 @@ func TestLogsQuery_ZeroResultPatternHint(t *testing.T) {
 		}
 	})
 
+	t.Run("pattern with subsystem filter also omits hint", func(t *testing.T) {
+		result, err := tool.Handler(nil, map[string]any{
+			"pattern":   "does-not-match",
+			"subsystem": "loop",
+			"since":     "1h",
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !strings.Contains(result, `"returned":0`) {
+			t.Fatalf("expected returned:0, got: %s", result)
+		}
+		if strings.Contains(result, `"hint"`) {
+			t.Errorf("hint should not appear when subsystem is already filtered, got: %s", result)
+		}
+	})
+
 	t.Run("non-empty result has no hint", func(t *testing.T) {
 		result, err := tool.Handler(nil, map[string]any{
 			"pattern": "loop started",


### PR DESCRIPTION
## Summary

- Rewrite the `pattern` parameter description (and the tool-level
  description) to make it unambiguous that `pattern` only searches
  log *message* text, not attribute columns.
- Steer callers at the right filter by name — `loop_name`,
  `loop_id`, `session_id`, `conversation_id`, `request_id`, `tool`,
  `model`, `subsystem` — for those lookups.
- When a pattern-only query returns zero rows, include a structured
  `hint` field naming the attribute filters that would likely have
  worked. The common failure mode is the model using
  `pattern="<loop-name>"` and interpreting the empty result as
  "doesn't exist" rather than "wrong filter"; the hint breaks that
  cycle in one retry.

## Why

Context from #730: on 2026-04-18 Thane needed to surface loop IDs
for four recent personality-test launches and ran five variations
of `pattern=...`, all returning zero rows. Every one of them would
have succeeded as `loop_name="personality-test"`. Thane then told
the operator "the loop IDs don't appear in the logs I can access" —
which was wrong, but consistent with the empty responses it had
seen. Making the contract explicit in the description and emitting
a recovery hint on the observed failure shape should prevent that
class of miss.

## Test plan

- [x] `just ci` passes locally
- [x] `TestLogsQuery_ZeroResultPatternHint` covers:
  - pattern-only zero-result query emits a hint that mentions
    `loop_name`
  - the matching attribute filter actually returns the row
  - combining pattern with an attribute filter suppresses the hint
    (caller already knew what they were doing)
  - a pattern that genuinely matches message text returns rows
    without a hint

Closes #730