### PR TITLE
feat: Anthropic caching polish — retry, guards, 1h pricing, hit rate, docs

### DIFF
--- a/docs/anthropic-caching.md
+++ b/docs/anthropic-caching.md
@@ -1,0 +1,145 @@
+# Anthropic Prompt Caching
+
+How Thane uses Anthropic's prompt-caching feature, what the per-section
+TTL policy is, and how to add a new system-prompt section without
+accidentally breaking the cache.
+
+## Why we cache
+
+Anthropic's prompt-cache charges **0.1× the base input rate** on cache
+reads and reduces time-to-first-token by roughly **85%** for cached
+prefixes. Thane's system prompt runs 30–100 KB per turn (persona, ego,
+mission, talents, context providers, conversation history) plus a full
+tool catalog. Without caching, every turn re-sends that whole prefix
+as paid input tokens. With caching, turn 2 and beyond read almost all
+of it from the cache for 10% of the cost.
+
+The cost win is obvious. The latency win matters more for interactive
+channels: a cached turn answers noticeably faster, especially with
+Opus and 100+ KB prefixes.
+
+## Per-section TTL policy
+
+The system prompt is assembled as a list of named sections, each with
+a `CacheTTL` annotation that controls where (and whether) a cache
+breakpoint gets placed. The policy lives in
+[`internal/agent/loop.go`](../internal/agent/loop.go) in
+`promptSectionCacheTTL`:
+
+| Section                 | TTL | Rationale |
+|-------------------------|-----|-----------|
+| `PERSONA`               | 1h  | Identity. Changes only when persona files are edited.  |
+| `EGO`                   | 1h  | Self-reflection file. Stable across long sessions. |
+| `RUNTIME CONTRACT`      | 1h  | Execution semantics. Model-invariant. |
+| `INJECTED CONTEXT`      | 1h  | Mission + knowledge files. Stable across a session.   |
+| `TOOL CALLING CONTRACT` | 1h  | Model-family-specific tool calling guidance.          |
+| `TALENTS ALWAYS ON`     | 1h  | Behavioural guidance. Stable across a session.        |
+| `TALENTS TAGGED`        | 5m  | Tag-scoped talents. Can change per turn if tags flip. |
+| `ACTIVE CAPABILITIES`   | —   | Derived from active tags; changes per turn.           |
+| `TAG CONTEXT`           | —   | Dynamic capability knowledge; changes per turn.       |
+| `CURRENT CONDITIONS`    | —   | Environment / timezone. Changes every turn by definition. |
+| `DYNAMIC CONTEXT`       | —   | ContextProvider output; per-turn.                     |
+| `CONVERSATION HISTORY`  | —   | Append-only, but uncached so turn N+1 sees turn N.    |
+| `CONTEXT USAGE`         | —   | Per-turn token counts.                                |
+
+Volatile sections (no TTL) sit **after** the cached sections in the
+final prompt so the cache prefix stops at the last stable byte. Tools
+get a blanket `1h` cache on the last tool definition in
+[`internal/models/providers/anthropic.go`](../internal/models/providers/anthropic.go).
+
+## Decision tree for new sections
+
+When adding a new system-prompt section, pick a TTL this way:
+
+1. **Does the content change on every turn?** → `CacheTTL: ""` (no
+   cache). Placing a breakpoint here invalidates every prior cached
+   section. Put it *after* the cached sections so it doesn't break
+   the prefix.
+2. **Does it change per day or by external input (talents pulled
+   from disk, KB articles, user's active tags)?** → `CacheTTL: "5m"`.
+   The shorter TTL matches how often you expect the content to
+   churn; 5-minute writes are 1.25× base input price.
+3. **Is it effectively static across a session (persona, tool
+   contract, compiled-in behavioural guidance)?** → `CacheTTL: "1h"`.
+   1-hour writes are 2.0× base input price but pay off after ~3
+   cache reads inside the hour.
+
+Anything that a human would describe as "this never changes" is a 1h
+candidate. Anything that updates on background heartbeats or config
+reloads is 5m. Anything tied to the current turn's content is
+uncached.
+
+## Minimum cacheable prefix length
+
+Anthropic silently ignores cache breakpoints on prefixes that fall
+below a per-family threshold:
+
+| Family                   | Minimum tokens |
+|--------------------------|----------------|
+| Claude Sonnet 4.x        | 1024           |
+| Claude Opus 4.x          | 4096           |
+| Claude Haiku 4.x         | 4096           |
+
+Thane enforces this in
+[`anthropic.go:applyCacheBreakpointGuards`](../internal/models/providers/anthropic.go):
+under-minimum runs have their `cache_control` stripped at request time
+with a WARN log, so the request doesn't silently miss caching while
+appearing to request it. Unknown model families default to the
+strictest minimum.
+
+## The 4-breakpoint cap
+
+Anthropic rejects requests carrying more than **4 `cache_control`
+markers total** across system blocks, tools, and messages. Today's
+policy emits 2 system breakpoints + 1 tool breakpoint = 3. Any future
+edit to `promptSectionCacheTTL` that introduces another TTL transition
+could push the count over and break every Anthropic turn.
+
+The guard in `applyCacheBreakpointGuards` drops excess breakpoints
+before the request is sent: it drops the blanket tool breakpoint
+first (it's a catch-all policy), then trims trailing system
+breakpoints. Every drop logs a WARN so operators can see why the
+cache didn't apply.
+
+## Validating that caching is working
+
+Three signals, in order of usefulness:
+
+1. **`cache_hit_rate`** on every Anthropic debug log line. Values in
+   [0, 1]; a mature session on a tight task loop should run above 0.9.
+   Cold start shows 0.0 on the first call (nothing to read yet);
+   subsequent calls should climb quickly.
+2. **`cache_hit_rate` in the session stats JSON** served by the API
+   server at `/stats`. Same formula, aggregated across the session.
+   `cache_read_input_tokens` / (`cache_read_input_tokens` +
+   `cache_creation_input_tokens`).
+3. **Raw `cache_creation_input_tokens` and `cache_read_input_tokens`**
+   on debug log lines. Useful for sanity-checking absolute sizes
+   (e.g., tool definitions alone are ~5k tokens, so a cold turn
+   should write at least that).
+
+## Anti-patterns
+
+- **Cache breakpoints on changing content.** Putting a TTL on
+  `CURRENT CONDITIONS` would destroy the cache prefix every turn.
+  `promptSectionCacheTTL` explicitly returns `""` for volatile
+  sections; keep it that way.
+- **Fragmenting into many TTL runs.** Each `promptSectionCacheTTL`
+  transition creates a new breakpoint. Try to order sections so
+  same-TTL runs are contiguous; don't interleave 1h and 5m.
+- **Assuming 4 breakpoints is plenty.** Tools already take one slot,
+  so system has 3 real slots. Adding a third system TTL pushes you to
+  the cap; a fourth transition drops the tool cache (see
+  `applyCacheBreakpointGuards`).
+- **Forgetting the minimum.** A small cached section (say,
+  `CURRENT CONDITIONS` if someone miscategorized it as 5m) attached
+  to a short prefix produces a silent no-op. The guard will warn,
+  but better to not emit the breakpoint in the first place.
+
+## References
+
+- [Anthropic prompt caching docs](https://platform.claude.com/docs/en/docs/build-with-claude/prompt-caching)
+- [`internal/agent/loop.go`](../internal/agent/loop.go) — `promptSectionCacheTTL` (policy)
+- [`internal/models/providers/anthropic.go`](../internal/models/providers/anthropic.go) — `applyCacheBreakpointGuards` (enforcement)
+- [`internal/llm/types.go`](../internal/llm/types.go) — `CacheHitRate` helper
+- [`internal/usage/store.go`](../internal/usage/store.go) — per-TTL cost breakdown

--- a/docs/model-facing-context.md
+++ b/docs/model-facing-context.md
@@ -265,9 +265,15 @@ right track.
 
 Good places to look for existing patterns:
 
-- `internal/awareness/timefmt.go`
+- `internal/promptfmt/timefmt.go`
 - `internal/awareness/entity_format.go`
 - `internal/agent/tag_context.go`
 - `internal/forge/context.go`
 - `internal/notifications/history_provider.go`
 - `internal/agent/channel_provider.go`
+
+## Related
+
+- [`anthropic-caching.md`](anthropic-caching.md) — how the system
+  prompt sections map onto Anthropic cache TTLs, and the decision
+  tree for adding a new section without breaking the cache.

--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -826,6 +826,11 @@ func promptSectionsFromBoundaries(text string, sections []promptSection) []llm.P
 	return result
 }
 
+// promptSectionCacheTTL maps a system-prompt section name to its
+// Anthropic cache TTL. See docs/anthropic-caching.md for the policy,
+// the decision tree for adding new sections, and why volatile
+// sections must return "" rather than a short TTL (they'd churn the
+// cache instead of amortizing it).
 func promptSectionCacheTTL(name string) string {
 	switch name {
 	case "PERSONA", "EGO", "RUNTIME CONTRACT", "INJECTED CONTEXT", "TOOL CALLING CONTRACT", "TALENTS ALWAYS ON":

--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -1281,7 +1281,7 @@ func (l *Loop) Run(ctx context.Context, req *Request, stream StreamCallback) (re
 			"elapsed_ms", time.Since(startTime).Milliseconds(),
 		)
 
-		l.recordUsage(ctx, req, llmResp.Model, llmResp.InputTokens, llmResp.OutputTokens, llmResp.CacheCreationInputTokens, llmResp.CacheReadInputTokens, convID, sessionTag, requestID)
+		l.recordUsage(ctx, req, llmResp.Model, llmResp.InputTokens, llmResp.OutputTokens, llmResp.CacheCreationInputTokens, llmResp.CacheCreation5mInputTokens, llmResp.CacheCreation1hInputTokens, llmResp.CacheReadInputTokens, convID, sessionTag, requestID)
 
 		return &Response{
 			Content:                  llmResp.Message.Content,
@@ -2024,7 +2024,7 @@ func (l *Loop) Run(ctx context.Context, req *Request, stream StreamCallback) (re
 
 	l.recordLiveRequestDetail(ctx, requestID, systemPrompt, userMessage, iterResult)
 
-	l.recordUsage(ctx, req, iterResult.Model, iterResult.InputTokens, iterResult.OutputTokens, iterResult.CacheCreationInputTokens, iterResult.CacheReadInputTokens, convID, sessionTag, requestID)
+	l.recordUsage(ctx, req, iterResult.Model, iterResult.InputTokens, iterResult.OutputTokens, iterResult.CacheCreationInputTokens, iterResult.CacheCreation5mInputTokens, iterResult.CacheCreation1hInputTokens, iterResult.CacheReadInputTokens, convID, sessionTag, requestID)
 	l.archiveIterations(log, convID, iterResult.Iterations)
 
 	// Content retention is fire-and-forget with a short deadline so it
@@ -2840,7 +2840,12 @@ func formatHistoryJSON(messages []memory.Message, tz string) string {
 // recordUsage persists a usage record for a completed LLM interaction.
 // No-op when usage recording is not configured. Errors are logged but
 // do not affect the caller.
-func (l *Loop) recordUsage(ctx context.Context, req *Request, model string, totalIn, totalOut, cacheCreateIn, cacheReadIn int, convID, sessionTag, requestID string) {
+//
+// cacheCreate5m and cacheCreate1h break down cacheCreateIn by TTL when
+// the provider exposes the breakdown (Anthropic). Pass 0/0 when the
+// provider doesn't attribute the writes; pricing falls back to the 5m
+// rate for the unattributed portion.
+func (l *Loop) recordUsage(ctx context.Context, req *Request, model string, totalIn, totalOut, cacheCreateIn, cacheCreate5m, cacheCreate1h, cacheReadIn int, convID, sessionTag, requestID string) {
 	if l.usageStore == nil {
 		return
 	}
@@ -2864,23 +2869,25 @@ func (l *Loop) recordUsage(ctx context.Context, req *Request, model string, tota
 	}
 
 	identity := usage.ResolveModelIdentity(model, l.currentModelCatalog())
-	cost := usage.ComputeDetailedCostForIdentity(identity, totalIn, cacheCreateIn, cacheReadIn, totalOut, l.pricing)
+	cost := usage.ComputeDetailedCostForIdentityWithTTL(identity, totalIn, cacheCreateIn, cacheCreate5m, cacheCreate1h, cacheReadIn, totalOut, l.pricing)
 	rec := usage.Record{
-		Timestamp:                time.Now(),
-		RequestID:                requestID,
-		SessionID:                sessionTag,
-		ConversationID:           convID,
-		Model:                    identity.Model,
-		UpstreamModel:            identity.UpstreamModel,
-		Resource:                 identity.Resource,
-		Provider:                 identity.Provider,
-		InputTokens:              totalIn,
-		OutputTokens:             totalOut,
-		CacheCreationInputTokens: cacheCreateIn,
-		CacheReadInputTokens:     cacheReadIn,
-		CostUSD:                  cost,
-		Role:                     role,
-		TaskName:                 taskName,
+		Timestamp:                  time.Now(),
+		RequestID:                  requestID,
+		SessionID:                  sessionTag,
+		ConversationID:             convID,
+		Model:                      identity.Model,
+		UpstreamModel:              identity.UpstreamModel,
+		Resource:                   identity.Resource,
+		Provider:                   identity.Provider,
+		InputTokens:                totalIn,
+		OutputTokens:               totalOut,
+		CacheCreationInputTokens:   cacheCreateIn,
+		CacheCreation5mInputTokens: cacheCreate5m,
+		CacheCreation1hInputTokens: cacheCreate1h,
+		CacheReadInputTokens:       cacheReadIn,
+		CostUSD:                    cost,
+		Role:                       role,
+		TaskName:                   taskName,
 	}
 
 	if err := l.usageStore.Record(ctx, rec); err != nil {

--- a/internal/delegate/delegate.go
+++ b/internal/delegate/delegate.go
@@ -1216,30 +1216,30 @@ func (e *Executor) selectModel(ctx context.Context, task string, profile *Profil
 // so recordCompletion and archiveSession inherit trace fields (request_id,
 // session_id, conversation_id, subsystem, delegate_id, profile).
 type completionRecord struct {
-	log              *slog.Logger
-	delegateID       string
-	conversationID   string
-	archiveSessionID string
-	task             string
-	guidance         string
-	profileName      string
-	model            string
-	totalIter        int
-	maxIter          int
-	totalInput          int
-	totalOutput         int
-	totalCacheCreate    int
-	totalCacheCreate5m  int
-	totalCacheCreate1h  int
-	totalCacheRead      int
-	exhausted        bool
-	exhaustReason    string
-	startTime        time.Time
-	messages         []llm.Message
-	resultContent    string
-	errMsg           string
-	toolCalls        []ToolCallOutcome
-	iterations       []iterate.IterationRecord
+	log                *slog.Logger
+	delegateID         string
+	conversationID     string
+	archiveSessionID   string
+	task               string
+	guidance           string
+	profileName        string
+	model              string
+	totalIter          int
+	maxIter            int
+	totalInput         int
+	totalOutput        int
+	totalCacheCreate   int
+	totalCacheCreate5m int
+	totalCacheCreate1h int
+	totalCacheRead     int
+	exhausted          bool
+	exhaustReason      string
+	startTime          time.Time
+	messages           []llm.Message
+	resultContent      string
+	errMsg             string
+	toolCalls          []ToolCallOutcome
+	iterations         []iterate.IterationRecord
 }
 
 // retainContent captures request-level content for a delegate execution.

--- a/internal/delegate/delegate.go
+++ b/internal/delegate/delegate.go
@@ -495,7 +495,7 @@ func (e *Executor) executeLegacy(ctx context.Context, task, profileName, guidanc
 	e.seedLiveRequestDetail(ctx, did, messages[0].Content, userMsg.String(), model, 0, messages)
 
 	startTime := time.Now()
-	var totalInput, totalOutput, totalCacheCreate, totalCacheRead int
+	var totalInput, totalOutput, totalCacheCreate, totalCacheCreate5m, totalCacheCreate1h, totalCacheRead int
 	var toolCalls []ToolCallOutcome
 
 	// Publish complete event on all exit paths so the dashboard removes
@@ -591,6 +591,8 @@ func (e *Executor) executeLegacy(ctx context.Context, task, profileName, guidanc
 			totalInput += resp.InputTokens
 			totalOutput += resp.OutputTokens
 			totalCacheCreate += resp.CacheCreationInputTokens
+			totalCacheCreate5m += resp.CacheCreation5mInputTokens
+			totalCacheCreate1h += resp.CacheCreation1hInputTokens
 			totalCacheRead += resp.CacheReadInputTokens
 			iterCount++
 		},
@@ -668,28 +670,30 @@ func (e *Executor) executeLegacy(ctx context.Context, task, profileName, guidanc
 				}
 			}
 			e.recordCompletion(&completionRecord{
-				log:              log,
-				delegateID:       did,
-				conversationID:   convID,
-				archiveSessionID: archiveSessionID,
-				task:             task,
-				guidance:         guidance,
-				profileName:      profile.Name,
-				model:            model,
-				totalIter:        iterCount,
-				maxIter:          maxIter,
-				totalInput:       totalInput,
-				totalOutput:      totalOutput,
-				totalCacheCreate: totalCacheCreate,
-				totalCacheRead:   totalCacheRead,
-				exhausted:        true,
-				exhaustReason:    ExhaustWallClock,
-				startTime:        startTime,
-				messages:         archiveMsgs,
-				resultContent:    "Delegate was unable to complete the task within its time limit.",
-				errMsg:           err.Error(),
-				toolCalls:        toolCalls,
-				iterations:       partialIterations,
+				log:                log,
+				delegateID:         did,
+				conversationID:     convID,
+				archiveSessionID:   archiveSessionID,
+				task:               task,
+				guidance:           guidance,
+				profileName:        profile.Name,
+				model:              model,
+				totalIter:          iterCount,
+				maxIter:            maxIter,
+				totalInput:         totalInput,
+				totalOutput:        totalOutput,
+				totalCacheCreate:   totalCacheCreate,
+				totalCacheCreate5m: totalCacheCreate5m,
+				totalCacheCreate1h: totalCacheCreate1h,
+				totalCacheRead:     totalCacheRead,
+				exhausted:          true,
+				exhaustReason:      ExhaustWallClock,
+				startTime:          startTime,
+				messages:           archiveMsgs,
+				resultContent:      "Delegate was unable to complete the task within its time limit.",
+				errMsg:             err.Error(),
+				toolCalls:          toolCalls,
+				iterations:         partialIterations,
 			})
 			return &Result{
 				Content:                  "Delegate was unable to complete the task within its time limit.",
@@ -728,27 +732,29 @@ func (e *Executor) executeLegacy(ctx context.Context, task, profileName, guidanc
 		e.retainContent(bgCtx, did, messages[0].Content, userMsg.String(), iterResult)
 	}()
 	e.recordCompletion(&completionRecord{
-		log:              log,
-		delegateID:       did,
-		conversationID:   convID,
-		archiveSessionID: archiveSessionID,
-		task:             task,
-		guidance:         guidance,
-		profileName:      profile.Name,
-		model:            iterResult.Model,
-		totalIter:        iterResult.IterationCount,
-		maxIter:          maxIter,
-		totalInput:       iterResult.InputTokens,
-		totalOutput:      iterResult.OutputTokens,
-		totalCacheCreate: iterResult.CacheCreationInputTokens,
-		totalCacheRead:   iterResult.CacheReadInputTokens,
-		exhausted:        exhausted,
-		exhaustReason:    exhaustReason,
-		startTime:        startTime,
-		messages:         iterResult.Messages,
-		resultContent:    iterResult.Content,
-		toolCalls:        toolCalls,
-		iterations:       iterResult.Iterations,
+		log:                log,
+		delegateID:         did,
+		conversationID:     convID,
+		archiveSessionID:   archiveSessionID,
+		task:               task,
+		guidance:           guidance,
+		profileName:        profile.Name,
+		model:              iterResult.Model,
+		totalIter:          iterResult.IterationCount,
+		maxIter:            maxIter,
+		totalInput:         iterResult.InputTokens,
+		totalOutput:        iterResult.OutputTokens,
+		totalCacheCreate:   iterResult.CacheCreationInputTokens,
+		totalCacheCreate5m: iterResult.CacheCreation5mInputTokens,
+		totalCacheCreate1h: iterResult.CacheCreation1hInputTokens,
+		totalCacheRead:     iterResult.CacheReadInputTokens,
+		exhausted:          exhausted,
+		exhaustReason:      exhaustReason,
+		startTime:          startTime,
+		messages:           iterResult.Messages,
+		resultContent:      iterResult.Content,
+		toolCalls:          toolCalls,
+		iterations:         iterResult.Iterations,
 	})
 	return &Result{
 		Content:                  iterResult.Content,
@@ -1220,10 +1226,12 @@ type completionRecord struct {
 	model            string
 	totalIter        int
 	maxIter          int
-	totalInput       int
-	totalOutput      int
-	totalCacheCreate int
-	totalCacheRead   int
+	totalInput          int
+	totalOutput         int
+	totalCacheCreate    int
+	totalCacheCreate5m  int
+	totalCacheCreate1h  int
+	totalCacheRead      int
 	exhausted        bool
 	exhaustReason    string
 	startTime        time.Time
@@ -1294,22 +1302,24 @@ func (e *Executor) recordCompletion(rec *completionRecord) {
 	// the delegate's context may be cancelled (e.g., wall-clock exhaustion).
 	if e.usageStore != nil {
 		identity := usage.ResolveModelIdentity(rec.model, e.currentModelCatalog())
-		cost := usage.ComputeDetailedCostForIdentity(identity, rec.totalInput, rec.totalCacheCreate, rec.totalCacheRead, rec.totalOutput, e.pricing)
+		cost := usage.ComputeDetailedCostForIdentityWithTTL(identity, rec.totalInput, rec.totalCacheCreate, rec.totalCacheCreate5m, rec.totalCacheCreate1h, rec.totalCacheRead, rec.totalOutput, e.pricing)
 		usageRec := usage.Record{
-			Timestamp:                now,
-			RequestID:                rec.delegateID,
-			ConversationID:           rec.conversationID,
-			Model:                    identity.Model,
-			UpstreamModel:            identity.UpstreamModel,
-			Resource:                 identity.Resource,
-			Provider:                 identity.Provider,
-			InputTokens:              rec.totalInput,
-			OutputTokens:             rec.totalOutput,
-			CacheCreationInputTokens: rec.totalCacheCreate,
-			CacheReadInputTokens:     rec.totalCacheRead,
-			CostUSD:                  cost,
-			Role:                     "delegate",
-			TaskName:                 rec.profileName,
+			Timestamp:                  now,
+			RequestID:                  rec.delegateID,
+			ConversationID:             rec.conversationID,
+			Model:                      identity.Model,
+			UpstreamModel:              identity.UpstreamModel,
+			Resource:                   identity.Resource,
+			Provider:                   identity.Provider,
+			InputTokens:                rec.totalInput,
+			OutputTokens:               rec.totalOutput,
+			CacheCreationInputTokens:   rec.totalCacheCreate,
+			CacheCreation5mInputTokens: rec.totalCacheCreate5m,
+			CacheCreation1hInputTokens: rec.totalCacheCreate1h,
+			CacheReadInputTokens:       rec.totalCacheRead,
+			CostUSD:                    cost,
+			Role:                       "delegate",
+			TaskName:                   rec.profileName,
 		}
 		if err := e.usageStore.Record(context.Background(), usageRec); err != nil {
 			rec.log.Warn("failed to record delegate usage", "error", err)

--- a/internal/httpkit/httpkit.go
+++ b/internal/httpkit/httpkit.go
@@ -16,6 +16,7 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
+	"strconv"
 	"syscall"
 	"time"
 
@@ -59,6 +60,7 @@ type clientConfig struct {
 	tlsInsecureSkipVerify bool
 	retryCount            int
 	retryDelay            time.Duration
+	retryStatuses         map[int]bool
 	logger                *slog.Logger
 }
 
@@ -125,6 +127,33 @@ func WithRetry(count int, delay time.Duration) ClientOption {
 	}
 }
 
+// WithRetryOnStatus extends [WithRetry] with HTTP-level retry: if the
+// server returns one of the listed statuses, the transport drains and
+// closes the response body and retries the request. Callers should
+// still set WithRetry to configure the backoff count/delay; this option
+// on its own has no effect.
+//
+// Typical use: cloud API clients opt in with 429 and 5xx to ride out
+// transient rate-limit / upstream hiccups without bubbling them up to
+// the agent loop. Local service clients (Ollama, LMStudio) don't need
+// this and should omit it.
+//
+// The retry honors the Retry-After response header when present; the
+// configured backoff delay is used only when the server doesn't supply
+// one.
+func WithRetryOnStatus(statuses ...int) ClientOption {
+	return func(c *clientConfig) {
+		if len(statuses) == 0 {
+			c.retryStatuses = nil
+			return
+		}
+		c.retryStatuses = make(map[int]bool, len(statuses))
+		for _, s := range statuses {
+			c.retryStatuses[s] = true
+		}
+	}
+}
+
 // WithLogger sets a logger for retry diagnostics.
 func WithLogger(l *slog.Logger) ClientOption {
 	return func(c *clientConfig) { c.logger = l }
@@ -184,10 +213,11 @@ func NewClient(opts ...ClientOption) *http.Client {
 
 	if cfg.retryCount > 0 {
 		rt = &retryTransport{
-			base:   rt,
-			count:  cfg.retryCount,
-			delay:  cfg.retryDelay,
-			logger: cfg.logger,
+			base:          rt,
+			count:         cfg.retryCount,
+			delay:         cfg.retryDelay,
+			retryStatuses: cfg.retryStatuses,
+			logger:        cfg.logger,
 		}
 	}
 
@@ -226,16 +256,59 @@ func DrainAndClose(rc io.ReadCloser, limit int64) {
 // retryTransport wraps a RoundTripper and retries on transient connection
 // errors. It only retries when the request body (if any) supports rewinding
 // via GetBody, ensuring safety for POST/PUT requests.
+//
+// When retryStatuses is non-empty, it additionally retries when the
+// server returns one of the listed HTTP statuses (typically 429 and
+// 5xx). Status-based retries drain and close the prior response body
+// before re-sending; Retry-After is honored when present, otherwise
+// the configured delay is used.
 type retryTransport struct {
-	base   http.RoundTripper
-	count  int
-	delay  time.Duration
-	logger *slog.Logger
+	base          http.RoundTripper
+	count         int
+	delay         time.Duration
+	retryStatuses map[int]bool
+	logger        *slog.Logger
+}
+
+func (t *retryTransport) shouldRetryStatus(resp *http.Response) bool {
+	if resp == nil || len(t.retryStatuses) == 0 {
+		return false
+	}
+	return t.retryStatuses[resp.StatusCode]
+}
+
+// retryAfterDelay extracts a delay from a response's Retry-After header,
+// parsing either a delta-seconds integer or an HTTP-date. Returns a
+// negative duration when the header is absent or unparseable so the
+// caller can distinguish "no header" from "header says wait zero" and
+// fall back to the configured backoff only in the former case.
+func retryAfterDelay(resp *http.Response) time.Duration {
+	if resp == nil {
+		return -1
+	}
+	v := resp.Header.Get("Retry-After")
+	if v == "" {
+		return -1
+	}
+	if secs, err := strconv.Atoi(v); err == nil && secs >= 0 {
+		return time.Duration(secs) * time.Second
+	}
+	if when, err := http.ParseTime(v); err == nil {
+		d := time.Until(when)
+		if d < 0 {
+			return 0
+		}
+		return d
+	}
+	return -1
 }
 
 func (t *retryTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	resp, err := t.base.RoundTrip(req)
-	if err == nil || !isRetryableError(err) {
+	if err == nil && !t.shouldRetryStatus(resp) {
+		return resp, err
+	}
+	if err != nil && !isRetryableError(err) {
 		return resp, err
 	}
 
@@ -247,18 +320,45 @@ func (t *retryTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 
 	for attempt := 1; attempt <= t.count; attempt++ {
 		lastErr := err // capture for success logging
+		statusRetry := err == nil && t.shouldRetryStatus(resp)
+
+		// Determine the backoff for this attempt. Default to the
+		// configured delay; let Retry-After win for HTTP-level retries
+		// when the server supplies one (including "Retry-After: 0").
+		wait := t.delay
+		if statusRetry {
+			if d := retryAfterDelay(resp); d >= 0 {
+				wait = d
+			}
+		}
+
 		if t.logger != nil {
-			t.logger.Debug("retrying request after transient error",
+			attrs := []any{
 				"method", req.Method,
 				"url", req.URL.String(),
 				"attempt", attempt,
 				"maxRetries", t.count,
-				"error", err,
-			)
+				"wait_ms", wait.Milliseconds(),
+			}
+			if statusRetry {
+				attrs = append(attrs, "status", resp.StatusCode)
+				t.logger.Debug("retrying request after transient HTTP status", attrs...)
+			} else {
+				attrs = append(attrs, "error", err)
+				t.logger.Debug("retrying request after transient error", attrs...)
+			}
 		}
 
-		// Wait before retry to allow ARP/route table to settle.
-		timer := time.NewTimer(t.delay)
+		// For status-based retries, drain and close the prior response
+		// body so the connection is returned to the pool before we
+		// re-dial.
+		if statusRetry {
+			DrainAndClose(resp.Body, 64*1024)
+			resp = nil
+		}
+
+		// Wait before retry.
+		timer := time.NewTimer(wait)
 		select {
 		case <-req.Context().Done():
 			timer.Stop()
@@ -277,15 +377,21 @@ func (t *retryTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 		}
 
 		resp, err = t.base.RoundTrip(retryReq)
-		if err == nil || !isRetryableError(err) {
-			if err == nil && t.logger != nil {
-				t.logger.Info("request succeeded after retry",
+		switch {
+		case err == nil && !t.shouldRetryStatus(resp):
+			if t.logger != nil {
+				attrs := []any{
 					"method", req.Method,
 					"url", req.URL.String(),
-					"attempts", attempt+1, // total attempts including original
-					"last_error", lastErr.Error(),
-				)
+					"attempts", attempt + 1, // total attempts including original
+				}
+				if lastErr != nil {
+					attrs = append(attrs, "last_error", lastErr.Error())
+				}
+				t.logger.Info("request succeeded after retry", attrs...)
 			}
+			return resp, nil
+		case err != nil && !isRetryableError(err):
 			return resp, err
 		}
 	}

--- a/internal/httpkit/httpkit_test.go
+++ b/internal/httpkit/httpkit_test.go
@@ -474,10 +474,10 @@ func TestRetryTransport_NoRetryWithoutGetBody(t *testing.T) {
 // After the list is exhausted it returns 200. Used to exercise
 // status-based retry behavior.
 type statusRoundTripper struct {
-	statuses   []int
-	calls      int
-	retryAfter string // if set, included on the first response
-	bodyReadCt *int   // if non-nil, increments on each body read
+	statuses    []int
+	calls       int
+	retryAfter  string // if set, included on the first response
+	bodyCloseCt *int   // if non-nil, increments on each body Close() call
 }
 
 func (s *statusRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
@@ -489,8 +489,8 @@ func (s *statusRoundTripper) RoundTrip(req *http.Request) (*http.Response, error
 	}
 
 	body := io.NopCloser(strings.NewReader("payload"))
-	if s.bodyReadCt != nil {
-		body = &countingReadCloser{r: strings.NewReader("payload"), closed: s.bodyReadCt}
+	if s.bodyCloseCt != nil {
+		body = &countingReadCloser{r: strings.NewReader("payload"), closed: s.bodyCloseCt}
 	}
 
 	resp := &http.Response{
@@ -511,7 +511,7 @@ type countingReadCloser struct {
 
 func (c *countingReadCloser) Read(p []byte) (int, error) { return c.r.Read(p) }
 func (c *countingReadCloser) Close() error {
-	*c.closed++
+	(*c.closed)++
 	return nil
 }
 
@@ -588,8 +588,8 @@ func TestRetryTransport_StatusRetryClosesPriorBody(t *testing.T) {
 	closes := 0
 	rt := &retryTransport{
 		base: &statusRoundTripper{
-			statuses:   []int{http.StatusTooManyRequests},
-			bodyReadCt: &closes,
+			statuses:    []int{http.StatusTooManyRequests},
+			bodyCloseCt: &closes,
 		},
 		count:         2,
 		delay:         1 * time.Millisecond,

--- a/internal/httpkit/httpkit_test.go
+++ b/internal/httpkit/httpkit_test.go
@@ -474,11 +474,10 @@ func TestRetryTransport_NoRetryWithoutGetBody(t *testing.T) {
 // After the list is exhausted it returns 200. Used to exercise
 // status-based retry behavior.
 type statusRoundTripper struct {
-	statuses    []int
-	calls       int
-	retryAfter  string // if set, included on the first response
-	bodyReadCt  *int   // if non-nil, increments on each body read
-	recordCalls bool
+	statuses   []int
+	calls      int
+	retryAfter string // if set, included on the first response
+	bodyReadCt *int   // if non-nil, increments on each body read
 }
 
 func (s *statusRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {

--- a/internal/httpkit/httpkit_test.go
+++ b/internal/httpkit/httpkit_test.go
@@ -469,3 +469,164 @@ func TestRetryTransport_NoRetryWithoutGetBody(t *testing.T) {
 		t.Fatalf("expected 1 call (no retry), got %d", ft.calls)
 	}
 }
+
+// statusRoundTripper returns the given statuses in order across calls.
+// After the list is exhausted it returns 200. Used to exercise
+// status-based retry behavior.
+type statusRoundTripper struct {
+	statuses    []int
+	calls       int
+	retryAfter  string // if set, included on the first response
+	bodyReadCt  *int   // if non-nil, increments on each body read
+	recordCalls bool
+}
+
+func (s *statusRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	idx := s.calls
+	s.calls++
+	status := http.StatusOK
+	if idx < len(s.statuses) {
+		status = s.statuses[idx]
+	}
+
+	body := io.NopCloser(strings.NewReader("payload"))
+	if s.bodyReadCt != nil {
+		body = &countingReadCloser{r: strings.NewReader("payload"), closed: s.bodyReadCt}
+	}
+
+	resp := &http.Response{
+		StatusCode: status,
+		Body:       body,
+		Header:     make(http.Header),
+	}
+	if idx == 0 && s.retryAfter != "" {
+		resp.Header.Set("Retry-After", s.retryAfter)
+	}
+	return resp, nil
+}
+
+type countingReadCloser struct {
+	r      io.Reader
+	closed *int
+}
+
+func (c *countingReadCloser) Read(p []byte) (int, error) { return c.r.Read(p) }
+func (c *countingReadCloser) Close() error {
+	*c.closed++
+	return nil
+}
+
+func TestRetryTransport_RetriesOn429ThenSucceeds(t *testing.T) {
+	rt := &retryTransport{
+		base:          &statusRoundTripper{statuses: []int{http.StatusTooManyRequests}},
+		count:         2,
+		delay:         10 * time.Millisecond,
+		retryStatuses: map[int]bool{http.StatusTooManyRequests: true},
+	}
+
+	req, _ := http.NewRequest("POST", "http://example.com", strings.NewReader("body"))
+	req.GetBody = func() (io.ReadCloser, error) { return io.NopCloser(strings.NewReader("body")), nil }
+
+	resp, err := rt.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	if calls := rt.base.(*statusRoundTripper).calls; calls != 2 {
+		t.Errorf("expected 2 calls (1 throttle + 1 success), got %d", calls)
+	}
+}
+
+func TestRetryTransport_RetriesOn5xxThenSucceeds(t *testing.T) {
+	rt := &retryTransport{
+		base: &statusRoundTripper{
+			statuses: []int{http.StatusBadGateway, http.StatusServiceUnavailable},
+		},
+		count: 3,
+		delay: 10 * time.Millisecond,
+		retryStatuses: map[int]bool{
+			http.StatusBadGateway:         true,
+			http.StatusServiceUnavailable: true,
+		},
+	}
+
+	req, _ := http.NewRequest("POST", "http://example.com", strings.NewReader("body"))
+	req.GetBody = func() (io.ReadCloser, error) { return io.NopCloser(strings.NewReader("body")), nil }
+
+	resp, err := rt.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+}
+
+func TestRetryTransport_DoesNotRetryUnlistedStatus(t *testing.T) {
+	rt := &retryTransport{
+		base:          &statusRoundTripper{statuses: []int{http.StatusBadRequest}},
+		count:         2,
+		delay:         10 * time.Millisecond,
+		retryStatuses: map[int]bool{http.StatusTooManyRequests: true},
+	}
+
+	req, _ := http.NewRequest("GET", "http://example.com", nil)
+	resp, err := rt.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400 (no retry for non-listed status)", resp.StatusCode)
+	}
+	if calls := rt.base.(*statusRoundTripper).calls; calls != 1 {
+		t.Errorf("expected 1 call, got %d", calls)
+	}
+}
+
+func TestRetryTransport_StatusRetryClosesPriorBody(t *testing.T) {
+	closes := 0
+	rt := &retryTransport{
+		base: &statusRoundTripper{
+			statuses:   []int{http.StatusTooManyRequests},
+			bodyReadCt: &closes,
+		},
+		count:         2,
+		delay:         1 * time.Millisecond,
+		retryStatuses: map[int]bool{http.StatusTooManyRequests: true},
+	}
+
+	req, _ := http.NewRequest("GET", "http://example.com", nil)
+	if _, err := rt.RoundTrip(req); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if closes < 1 {
+		t.Errorf("prior response body was never closed (close count = %d)", closes)
+	}
+}
+
+func TestRetryTransport_HonorsRetryAfterSeconds(t *testing.T) {
+	rt := &retryTransport{
+		base: &statusRoundTripper{
+			statuses:   []int{http.StatusTooManyRequests},
+			retryAfter: "0", // zero-second Retry-After, keeps the test fast
+		},
+		count:         2,
+		delay:         1 * time.Hour, // would make the test hang if not overridden
+		retryStatuses: map[int]bool{http.StatusTooManyRequests: true},
+	}
+
+	req, _ := http.NewRequest("GET", "http://example.com", nil)
+	done := make(chan struct{})
+	go func() {
+		_, _ = rt.RoundTrip(req)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("RoundTrip did not honor Retry-After: 0 (waited on configured 1h delay instead)")
+	}
+}

--- a/internal/iterate/engine.go
+++ b/internal/iterate/engine.go
@@ -33,17 +33,19 @@ func (e *Engine) Run(ctx context.Context, cfg Config, messages []llm.Message) (*
 
 	// Per-run tracking.
 	var (
-		iterations       []IterationRecord
-		toolsUsed        = make(map[string]int)
-		toolCallCounts   = make(map[string]int)
-		totalInput       int
-		totalOutput      int
-		totalCacheCreate int
-		totalCacheRead   int
-		illegalStrikes   int
-		emptyRetried     bool
-		deferredText     string
-		breakReason      string
+		iterations          []IterationRecord
+		toolsUsed           = make(map[string]int)
+		toolCallCounts      = make(map[string]int)
+		totalInput          int
+		totalOutput         int
+		totalCacheCreate    int
+		totalCacheCreate5m  int
+		totalCacheCreate1h  int
+		totalCacheRead      int
+		illegalStrikes      int
+		emptyRetried        bool
+		deferredText        string
+		breakReason         string
 	)
 
 	for i := 0; i < cfg.MaxIterations; i++ {
@@ -76,7 +78,9 @@ func (e *Engine) Run(ctx context.Context, cfg Config, messages []llm.Message) (*
 						Model:                    model,
 						InputTokens:              totalInput,
 						OutputTokens:             totalOutput,
-						CacheCreationInputTokens: totalCacheCreate,
+						CacheCreationInputTokens:   totalCacheCreate,
+						CacheCreation5mInputTokens: totalCacheCreate5m,
+						CacheCreation1hInputTokens: totalCacheCreate1h,
 						CacheReadInputTokens:     totalCacheRead,
 						ToolsUsed:                toolsUsed,
 						Exhausted:                true,
@@ -93,7 +97,9 @@ func (e *Engine) Run(ctx context.Context, cfg Config, messages []llm.Message) (*
 					Model:                    model,
 					InputTokens:              totalInput,
 					OutputTokens:             totalOutput,
-					CacheCreationInputTokens: totalCacheCreate,
+					CacheCreationInputTokens:   totalCacheCreate,
+					CacheCreation5mInputTokens: totalCacheCreate5m,
+					CacheCreation1hInputTokens: totalCacheCreate1h,
 					CacheReadInputTokens:     totalCacheRead,
 					ToolsUsed:                toolsUsed,
 					Exhausted:                true,
@@ -108,6 +114,8 @@ func (e *Engine) Run(ctx context.Context, cfg Config, messages []llm.Message) (*
 		totalInput += llmResp.InputTokens
 		totalOutput += llmResp.OutputTokens
 		totalCacheCreate += llmResp.CacheCreationInputTokens
+		totalCacheCreate5m += llmResp.CacheCreation5mInputTokens
+		totalCacheCreate1h += llmResp.CacheCreation1hInputTokens
 		totalCacheRead += llmResp.CacheReadInputTokens
 
 		// --- Callback: LLM response ---
@@ -123,7 +131,9 @@ func (e *Engine) Run(ctx context.Context, cfg Config, messages []llm.Message) (*
 				Model:                    llmResp.Model,
 				InputTokens:              llmResp.InputTokens,
 				OutputTokens:             llmResp.OutputTokens,
-				CacheCreationInputTokens: llmResp.CacheCreationInputTokens,
+				CacheCreationInputTokens:   llmResp.CacheCreationInputTokens,
+				CacheCreation5mInputTokens: llmResp.CacheCreation5mInputTokens,
+				CacheCreation1hInputTokens: llmResp.CacheCreation1hInputTokens,
 				CacheReadInputTokens:     llmResp.CacheReadInputTokens,
 				ToolsOffered:             toolDefsNames(toolDefs),
 				StartedAt:                iterStart,
@@ -136,7 +146,9 @@ func (e *Engine) Run(ctx context.Context, cfg Config, messages []llm.Message) (*
 				Model:                    model,
 				InputTokens:              totalInput,
 				OutputTokens:             totalOutput,
-				CacheCreationInputTokens: totalCacheCreate,
+				CacheCreationInputTokens:   totalCacheCreate,
+				CacheCreation5mInputTokens: totalCacheCreate5m,
+				CacheCreation1hInputTokens: totalCacheCreate1h,
 				CacheReadInputTokens:     totalCacheRead,
 				ToolsUsed:                toolsUsed,
 				Exhausted:                true,
@@ -175,7 +187,9 @@ func (e *Engine) Run(ctx context.Context, cfg Config, messages []llm.Message) (*
 			Model:                    llmResp.Model,
 			InputTokens:              llmResp.InputTokens,
 			OutputTokens:             llmResp.OutputTokens,
-			CacheCreationInputTokens: llmResp.CacheCreationInputTokens,
+			CacheCreationInputTokens:   llmResp.CacheCreationInputTokens,
+			CacheCreation5mInputTokens: llmResp.CacheCreation5mInputTokens,
+			CacheCreation1hInputTokens: llmResp.CacheCreation1hInputTokens,
 			CacheReadInputTokens:     llmResp.CacheReadInputTokens,
 			ToolsOffered:             toolDefsNames(toolDefs),
 			StartedAt:                iterStart,
@@ -407,7 +421,9 @@ func (e *Engine) Run(ctx context.Context, cfg Config, messages []llm.Message) (*
 			Model:                    model,
 			InputTokens:              totalInput,
 			OutputTokens:             totalOutput,
-			CacheCreationInputTokens: totalCacheCreate,
+			CacheCreationInputTokens:   totalCacheCreate,
+			CacheCreation5mInputTokens: totalCacheCreate5m,
+			CacheCreation1hInputTokens: totalCacheCreate1h,
 			CacheReadInputTokens:     totalCacheRead,
 			ToolsUsed:                toolsUsed,
 			Exhausted:                false,
@@ -427,7 +443,9 @@ func (e *Engine) Run(ctx context.Context, cfg Config, messages []llm.Message) (*
 		Model:                    model,
 		InputTokens:              totalInput,
 		OutputTokens:             totalOutput,
-		CacheCreationInputTokens: totalCacheCreate,
+		CacheCreationInputTokens:   totalCacheCreate,
+		CacheCreation5mInputTokens: totalCacheCreate5m,
+		CacheCreation1hInputTokens: totalCacheCreate1h,
 		CacheReadInputTokens:     totalCacheRead,
 		ToolsUsed:                toolsUsed,
 		Exhausted:                true,
@@ -481,7 +499,9 @@ func (e *Engine) forceText(ctx context.Context, cfg Config, model string, messag
 			Model:                    resp.Model,
 			InputTokens:              resp.InputTokens,
 			OutputTokens:             resp.OutputTokens,
-			CacheCreationInputTokens: resp.CacheCreationInputTokens,
+			CacheCreationInputTokens:   resp.CacheCreationInputTokens,
+			CacheCreation5mInputTokens: resp.CacheCreation5mInputTokens,
+			CacheCreation1hInputTokens: resp.CacheCreation1hInputTokens,
 			CacheReadInputTokens:     resp.CacheReadInputTokens,
 			StartedAt:                time.Now(),
 			HasToolCalls:             false,

--- a/internal/iterate/engine.go
+++ b/internal/iterate/engine.go
@@ -33,19 +33,19 @@ func (e *Engine) Run(ctx context.Context, cfg Config, messages []llm.Message) (*
 
 	// Per-run tracking.
 	var (
-		iterations          []IterationRecord
-		toolsUsed           = make(map[string]int)
-		toolCallCounts      = make(map[string]int)
-		totalInput          int
-		totalOutput         int
-		totalCacheCreate    int
-		totalCacheCreate5m  int
-		totalCacheCreate1h  int
-		totalCacheRead      int
-		illegalStrikes      int
-		emptyRetried        bool
-		deferredText        string
-		breakReason         string
+		iterations         []IterationRecord
+		toolsUsed          = make(map[string]int)
+		toolCallCounts     = make(map[string]int)
+		totalInput         int
+		totalOutput        int
+		totalCacheCreate   int
+		totalCacheCreate5m int
+		totalCacheCreate1h int
+		totalCacheRead     int
+		illegalStrikes     int
+		emptyRetried       bool
+		deferredText       string
+		breakReason        string
 	)
 
 	for i := 0; i < cfg.MaxIterations; i++ {
@@ -75,18 +75,18 @@ func (e *Engine) Run(ctx context.Context, cfg Config, messages []llm.Message) (*
 				llmResp, newModel, err = cfg.OnLLMError(iterCtx, err, model, messages, toolDefs, cfg.Stream)
 				if err != nil {
 					return &Result{
-						Model:                    model,
-						InputTokens:              totalInput,
-						OutputTokens:             totalOutput,
+						Model:                      model,
+						InputTokens:                totalInput,
+						OutputTokens:               totalOutput,
 						CacheCreationInputTokens:   totalCacheCreate,
 						CacheCreation5mInputTokens: totalCacheCreate5m,
 						CacheCreation1hInputTokens: totalCacheCreate1h,
-						CacheReadInputTokens:     totalCacheRead,
-						ToolsUsed:                toolsUsed,
-						Exhausted:                true,
-						Iterations:               iterations,
-						Messages:                 messages,
-						IterationCount:           len(iterations),
+						CacheReadInputTokens:       totalCacheRead,
+						ToolsUsed:                  toolsUsed,
+						Exhausted:                  true,
+						Iterations:                 iterations,
+						Messages:                   messages,
+						IterationCount:             len(iterations),
 					}, err
 				}
 				if newModel != "" {
@@ -94,18 +94,18 @@ func (e *Engine) Run(ctx context.Context, cfg Config, messages []llm.Message) (*
 				}
 			} else {
 				return &Result{
-					Model:                    model,
-					InputTokens:              totalInput,
-					OutputTokens:             totalOutput,
+					Model:                      model,
+					InputTokens:                totalInput,
+					OutputTokens:               totalOutput,
 					CacheCreationInputTokens:   totalCacheCreate,
 					CacheCreation5mInputTokens: totalCacheCreate5m,
 					CacheCreation1hInputTokens: totalCacheCreate1h,
-					CacheReadInputTokens:     totalCacheRead,
-					ToolsUsed:                toolsUsed,
-					Exhausted:                true,
-					Iterations:               iterations,
-					Messages:                 messages,
-					IterationCount:           len(iterations),
+					CacheReadInputTokens:       totalCacheRead,
+					ToolsUsed:                  toolsUsed,
+					Exhausted:                  true,
+					Iterations:                 iterations,
+					Messages:                   messages,
+					IterationCount:             len(iterations),
 				}, err
 			}
 		}
@@ -127,34 +127,34 @@ func (e *Engine) Run(ctx context.Context, cfg Config, messages []llm.Message) (*
 		if cfg.CheckBudget != nil && cfg.CheckBudget(totalOutput) {
 			iterLog.Warn("budget exhausted", "total_output", totalOutput)
 			budgetRec := IterationRecord{
-				Index:                    i,
-				Model:                    llmResp.Model,
-				InputTokens:              llmResp.InputTokens,
-				OutputTokens:             llmResp.OutputTokens,
+				Index:                      i,
+				Model:                      llmResp.Model,
+				InputTokens:                llmResp.InputTokens,
+				OutputTokens:               llmResp.OutputTokens,
 				CacheCreationInputTokens:   llmResp.CacheCreationInputTokens,
 				CacheCreation5mInputTokens: llmResp.CacheCreation5mInputTokens,
 				CacheCreation1hInputTokens: llmResp.CacheCreation1hInputTokens,
-				CacheReadInputTokens:     llmResp.CacheReadInputTokens,
-				ToolsOffered:             toolDefsNames(toolDefs),
-				StartedAt:                iterStart,
-				DurationMs:               time.Since(iterStart).Milliseconds(),
-				HasToolCalls:             len(llmResp.Message.ToolCalls) > 0,
-				BreakReason:              ExhaustTokenBudget,
+				CacheReadInputTokens:       llmResp.CacheReadInputTokens,
+				ToolsOffered:               toolDefsNames(toolDefs),
+				StartedAt:                  iterStart,
+				DurationMs:                 time.Since(iterStart).Milliseconds(),
+				HasToolCalls:               len(llmResp.Message.ToolCalls) > 0,
+				BreakReason:                ExhaustTokenBudget,
 			}
 			iterations = append(iterations, budgetRec)
 			partial := &Result{
-				Model:                    model,
-				InputTokens:              totalInput,
-				OutputTokens:             totalOutput,
+				Model:                      model,
+				InputTokens:                totalInput,
+				OutputTokens:               totalOutput,
 				CacheCreationInputTokens:   totalCacheCreate,
 				CacheCreation5mInputTokens: totalCacheCreate5m,
 				CacheCreation1hInputTokens: totalCacheCreate1h,
-				CacheReadInputTokens:     totalCacheRead,
-				ToolsUsed:                toolsUsed,
-				Exhausted:                true,
-				ExhaustReason:            ExhaustTokenBudget,
-				Iterations:               iterations,
-				IterationCount:           i + 1,
+				CacheReadInputTokens:       totalCacheRead,
+				ToolsUsed:                  toolsUsed,
+				Exhausted:                  true,
+				ExhaustReason:              ExhaustTokenBudget,
+				Iterations:                 iterations,
+				IterationCount:             i + 1,
 			}
 			// Text-only response: use content directly.
 			if llmResp.Message.Content != "" && len(llmResp.Message.ToolCalls) == 0 {
@@ -183,17 +183,17 @@ func (e *Engine) Run(ctx context.Context, cfg Config, messages []llm.Message) (*
 
 		// Build iteration record.
 		iterRec := IterationRecord{
-			Index:                    i,
-			Model:                    llmResp.Model,
-			InputTokens:              llmResp.InputTokens,
-			OutputTokens:             llmResp.OutputTokens,
+			Index:                      i,
+			Model:                      llmResp.Model,
+			InputTokens:                llmResp.InputTokens,
+			OutputTokens:               llmResp.OutputTokens,
 			CacheCreationInputTokens:   llmResp.CacheCreationInputTokens,
 			CacheCreation5mInputTokens: llmResp.CacheCreation5mInputTokens,
 			CacheCreation1hInputTokens: llmResp.CacheCreation1hInputTokens,
-			CacheReadInputTokens:     llmResp.CacheReadInputTokens,
-			ToolsOffered:             toolDefsNames(toolDefs),
-			StartedAt:                iterStart,
-			HasToolCalls:             len(llmResp.Message.ToolCalls) > 0,
+			CacheReadInputTokens:       llmResp.CacheReadInputTokens,
+			ToolsOffered:               toolDefsNames(toolDefs),
+			StartedAt:                  iterStart,
+			HasToolCalls:               len(llmResp.Message.ToolCalls) > 0,
 		}
 
 		// =============================================
@@ -417,19 +417,19 @@ func (e *Engine) Run(ctx context.Context, cfg Config, messages []llm.Message) (*
 		}
 
 		return &Result{
-			Content:                  llmResp.Message.Content,
-			Model:                    model,
-			InputTokens:              totalInput,
-			OutputTokens:             totalOutput,
+			Content:                    llmResp.Message.Content,
+			Model:                      model,
+			InputTokens:                totalInput,
+			OutputTokens:               totalOutput,
 			CacheCreationInputTokens:   totalCacheCreate,
 			CacheCreation5mInputTokens: totalCacheCreate5m,
 			CacheCreation1hInputTokens: totalCacheCreate1h,
-			CacheReadInputTokens:     totalCacheRead,
-			ToolsUsed:                toolsUsed,
-			Exhausted:                false,
-			Iterations:               iterations,
-			Messages:                 messages,
-			IterationCount:           i + 1,
+			CacheReadInputTokens:       totalCacheRead,
+			ToolsUsed:                  toolsUsed,
+			Exhausted:                  false,
+			Iterations:                 iterations,
+			Messages:                   messages,
+			IterationCount:             i + 1,
 		}, nil
 	}
 
@@ -440,18 +440,18 @@ func (e *Engine) Run(ctx context.Context, cfg Config, messages []llm.Message) (*
 	log.Warn("iteration loop ended", "reason", breakReason)
 
 	return e.forceText(ctx, cfg, model, messages, &Result{
-		Model:                    model,
-		InputTokens:              totalInput,
-		OutputTokens:             totalOutput,
+		Model:                      model,
+		InputTokens:                totalInput,
+		OutputTokens:               totalOutput,
 		CacheCreationInputTokens:   totalCacheCreate,
 		CacheCreation5mInputTokens: totalCacheCreate5m,
 		CacheCreation1hInputTokens: totalCacheCreate1h,
-		CacheReadInputTokens:     totalCacheRead,
-		ToolsUsed:                toolsUsed,
-		Exhausted:                true,
-		ExhaustReason:            breakReason,
-		Iterations:               iterations,
-		IterationCount:           len(iterations),
+		CacheReadInputTokens:       totalCacheRead,
+		ToolsUsed:                  toolsUsed,
+		Exhausted:                  true,
+		ExhaustReason:              breakReason,
+		Iterations:                 iterations,
+		IterationCount:             len(iterations),
 	})
 }
 
@@ -495,17 +495,17 @@ func (e *Engine) forceText(ctx context.Context, cfg Config, model string, messag
 
 		// Record the recovery call as its own iteration.
 		partial.Iterations = append(partial.Iterations, IterationRecord{
-			Index:                    len(partial.Iterations),
-			Model:                    resp.Model,
-			InputTokens:              resp.InputTokens,
-			OutputTokens:             resp.OutputTokens,
+			Index:                      len(partial.Iterations),
+			Model:                      resp.Model,
+			InputTokens:                resp.InputTokens,
+			OutputTokens:               resp.OutputTokens,
 			CacheCreationInputTokens:   resp.CacheCreationInputTokens,
 			CacheCreation5mInputTokens: resp.CacheCreation5mInputTokens,
 			CacheCreation1hInputTokens: resp.CacheCreation1hInputTokens,
-			CacheReadInputTokens:     resp.CacheReadInputTokens,
-			StartedAt:                time.Now(),
-			HasToolCalls:             false,
-			BreakReason:              partial.ExhaustReason,
+			CacheReadInputTokens:       resp.CacheReadInputTokens,
+			StartedAt:                  time.Now(),
+			HasToolCalls:               false,
+			BreakReason:                partial.ExhaustReason,
 		})
 		partial.IterationCount = len(partial.Iterations)
 

--- a/internal/iterate/types.go
+++ b/internal/iterate/types.go
@@ -27,12 +27,12 @@ type IterationRecord struct {
 	CacheCreation5mInputTokens int
 	CacheCreation1hInputTokens int
 	CacheReadInputTokens       int
-	ToolCallIDs              []string
-	ToolsOffered             []string
-	StartedAt                time.Time
-	DurationMs               int64
-	HasToolCalls             bool
-	BreakReason              string
+	ToolCallIDs                []string
+	ToolsOffered               []string
+	StartedAt                  time.Time
+	DurationMs                 int64
+	HasToolCalls               bool
+	BreakReason                string
 }
 
 // Result is the outcome of an [Engine.Run] execution.

--- a/internal/iterate/types.go
+++ b/internal/iterate/types.go
@@ -19,12 +19,14 @@ const (
 // identical iterationRecord structs that were independently defined in
 // the agent and delegate packages.
 type IterationRecord struct {
-	Index                    int
-	Model                    string
-	InputTokens              int
-	OutputTokens             int
-	CacheCreationInputTokens int
-	CacheReadInputTokens     int
+	Index                      int
+	Model                      string
+	InputTokens                int
+	OutputTokens               int
+	CacheCreationInputTokens   int
+	CacheCreation5mInputTokens int
+	CacheCreation1hInputTokens int
+	CacheReadInputTokens       int
 	ToolCallIDs              []string
 	ToolsOffered             []string
 	StartedAt                time.Time
@@ -52,6 +54,13 @@ type Result struct {
 	// CacheCreationInputTokens is the cumulative prompt-cache write token
 	// count across all iterations when the provider reports it.
 	CacheCreationInputTokens int
+
+	// CacheCreation5mInputTokens and CacheCreation1hInputTokens break
+	// down cache-write tokens by TTL bucket when the provider exposes
+	// the split (Anthropic). The sum is ≤ CacheCreationInputTokens;
+	// any shortfall reflects writes the provider didn't attribute.
+	CacheCreation5mInputTokens int
+	CacheCreation1hInputTokens int
 
 	// CacheReadInputTokens is the cumulative prompt-cache read token
 	// count across all iterations when the provider reports it.

--- a/internal/llm/cache_hit_rate_test.go
+++ b/internal/llm/cache_hit_rate_test.go
@@ -1,0 +1,46 @@
+package llm
+
+import (
+	"math"
+	"testing"
+)
+
+func TestCacheHitRate(t *testing.T) {
+	tests := []struct {
+		name      string
+		reads     int
+		creations int
+		want      float64
+	}{
+		{"cold start: only creations", 0, 1000, 0.0},
+		{"fully warm: only reads", 1000, 0, 1.0},
+		{"half hot", 500, 500, 0.5},
+		{"empty window", 0, 0, 0.0},
+		{"negatives clamp to zero", -5, -10, 0.0},
+		{"typical warm session", 10000, 200, 10000.0 / 10200.0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := CacheHitRate(tt.reads, tt.creations)
+			if math.Abs(got-tt.want) > 1e-9 {
+				t.Errorf("CacheHitRate(%d, %d) = %v, want %v", tt.reads, tt.creations, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestChatResponse_CacheHitRate(t *testing.T) {
+	resp := &ChatResponse{
+		CacheReadInputTokens:     800,
+		CacheCreationInputTokens: 200,
+	}
+	want := 0.8
+	if got := resp.CacheHitRate(); math.Abs(got-want) > 1e-9 {
+		t.Errorf("CacheHitRate() = %v, want %v", got, want)
+	}
+
+	empty := &ChatResponse{}
+	if got := empty.CacheHitRate(); got != 0 {
+		t.Errorf("empty response CacheHitRate() = %v, want 0 (no division by zero)", got)
+	}
+}

--- a/internal/llm/types.go
+++ b/internal/llm/types.go
@@ -74,6 +74,30 @@ type ChatResponse struct {
 	EvalDuration  time.Duration
 }
 
+// CacheHitRate returns the fraction of cache-eligible input tokens on
+// this response that were served from cache, in [0, 1]. Zero when
+// there were no cache-eligible tokens at all. Matches the
+// Anthropic-recommended observability metric:
+// cache_read / (cache_read + cache_creation).
+//
+// Exposed on ChatResponse (and as [CacheHitRate] for bare counts) so
+// providers and loggers can surface the metric without importing the
+// usage package, which would cycle.
+func (r *ChatResponse) CacheHitRate() float64 {
+	return CacheHitRate(r.CacheReadInputTokens, r.CacheCreationInputTokens)
+}
+
+// CacheHitRate returns the cache-read share for a single interaction's
+// token counts, in [0, 1]. Zero when both counts are zero so callers
+// never have to guard against division by zero.
+func CacheHitRate(cacheReadInputTokens, cacheCreationInputTokens int) float64 {
+	denom := cacheReadInputTokens + cacheCreationInputTokens
+	if denom <= 0 {
+		return 0
+	}
+	return float64(cacheReadInputTokens) / float64(denom)
+}
+
 // StreamEvent represents a single event in a streaming response.
 // Consumers switch on Kind to determine what data is available.
 type StreamEvent struct {

--- a/internal/llm/types.go
+++ b/internal/llm/types.go
@@ -59,6 +59,14 @@ type ChatResponse struct {
 	OutputTokens             int
 	CacheCreationInputTokens int
 	CacheReadInputTokens     int
+	// Per-TTL breakdown of cache-write tokens. Populated by providers
+	// that return a structured cache_creation breakdown (Anthropic).
+	// Zero when the provider doesn't expose the breakdown, in which
+	// case callers should fall back to CacheCreationInputTokens and
+	// treat the TTL mix as unknown (typically charged at the 5m rate
+	// for cost estimation, since that's the default).
+	CacheCreation5mInputTokens int
+	CacheCreation1hInputTokens int
 
 	// Timing (populated when available)
 	TotalDuration time.Duration

--- a/internal/models/providers/anthropic.go
+++ b/internal/models/providers/anthropic.go
@@ -129,6 +129,20 @@ type anthropicUsage struct {
 	OutputTokens             int `json:"output_tokens"`
 	CacheCreationInputTokens int `json:"cache_creation_input_tokens,omitempty"`
 	CacheReadInputTokens     int `json:"cache_read_input_tokens,omitempty"`
+	// CacheCreation breaks down cache-write tokens by TTL bucket so
+	// downstream pricing can apply the correct multiplier (5m writes
+	// are 1.25× base input, 1h writes are 2.0×). Older Anthropic
+	// responses omit this object; callers must treat absence as
+	// "unknown TTL mix" and fall back to CacheCreationInputTokens.
+	CacheCreation *anthropicCacheCreation `json:"cache_creation,omitempty"`
+}
+
+// anthropicCacheCreation mirrors the response shape Anthropic returns
+// under usage.cache_creation: a per-TTL breakdown of tokens that were
+// written into the cache on this turn.
+type anthropicCacheCreation struct {
+	Ephemeral5mInputTokens int `json:"ephemeral_5m_input_tokens,omitempty"`
+	Ephemeral1hInputTokens int `json:"ephemeral_1h_input_tokens,omitempty"`
 }
 
 // SSE event types for streaming
@@ -392,6 +406,10 @@ func (c *AnthropicClient) handleStreaming(ctx context.Context, body io.Reader, c
 		OutputTokens:             usage.OutputTokens,
 		CacheCreationInputTokens: usage.CacheCreationInputTokens,
 		CacheReadInputTokens:     usage.CacheReadInputTokens,
+	}
+	if bd := usage.CacheCreation; bd != nil {
+		resp.CacheCreation5mInputTokens = bd.Ephemeral5mInputTokens
+		resp.CacheCreation1hInputTokens = bd.Ephemeral1hInputTokens
 	}
 
 	// stopReason available for future use (end_turn, tool_use, max_tokens, stop_sequence)
@@ -795,7 +813,7 @@ func convertFromAnthropic(resp *anthropicResponse) *llm.ChatResponse {
 		}
 	}
 
-	return &llm.ChatResponse{
+	out := &llm.ChatResponse{
 		Model: resp.Model,
 		Message: llm.Message{
 			Role:      resp.Role,
@@ -808,6 +826,11 @@ func convertFromAnthropic(resp *anthropicResponse) *llm.ChatResponse {
 		CacheCreationInputTokens: resp.Usage.CacheCreationInputTokens,
 		CacheReadInputTokens:     resp.Usage.CacheReadInputTokens,
 	}
+	if bd := resp.Usage.CacheCreation; bd != nil {
+		out.CacheCreation5mInputTokens = bd.Ephemeral5mInputTokens
+		out.CacheCreation1hInputTokens = bd.Ephemeral1hInputTokens
+	}
+	return out
 }
 
 // (toolUseID removed — IDs are now carried on ToolCall.ID directly)

--- a/internal/models/providers/anthropic.go
+++ b/internal/models/providers/anthropic.go
@@ -40,14 +40,26 @@ func NewAnthropicClient(apiKey string, logger *slog.Logger) *AnthropicClient {
 	t := httpkit.NewTransport()
 	t.ResponseHeaderTimeout = 120 * time.Second
 
+	providerLogger := logger.With("provider", "anthropic")
 	return &AnthropicClient{
 		apiKey: apiKey,
-		logger: logger.With("provider", "anthropic"),
+		logger: providerLogger,
 		httpClient: httpkit.NewClient(
 			// No global timeout — streaming responses can be long-lived.
 			// Rely on ctx deadlines/cancellation for timeout control.
 			httpkit.WithTimeout(0),
 			httpkit.WithTransport(t),
+			// Retry transient connection failures (matches the Ollama
+			// and LMStudio clients) plus transient Anthropic-side HTTP
+			// statuses: 429 for rate limiting, 500/502/503/504 for
+			// upstream hiccups. Streaming is safe — retryTransport
+			// only retries while the response body is still unread;
+			// once RoundTrip returns the body to the caller, a
+			// mid-stream failure propagates to the agent loop as a
+			// normal error.
+			httpkit.WithRetry(3, 2*time.Second),
+			httpkit.WithRetryOnStatus(429, 500, 502, 503, 504),
+			httpkit.WithLogger(providerLogger),
 		),
 	}
 }

--- a/internal/models/providers/anthropic.go
+++ b/internal/models/providers/anthropic.go
@@ -289,6 +289,7 @@ func (c *AnthropicClient) handleNonStreaming(ctx context.Context, body io.Reader
 		"output_tokens", result.OutputTokens,
 		"cache_creation_input_tokens", result.CacheCreationInputTokens,
 		"cache_read_input_tokens", result.CacheReadInputTokens,
+		"cache_hit_rate", result.CacheHitRate(),
 		"tool_calls", len(result.Message.ToolCalls),
 	)
 	c.logger.Log(ctx, llm.LevelTrace, "response content", "content", result.Message.Content)
@@ -421,6 +422,7 @@ func (c *AnthropicClient) handleStreaming(ctx context.Context, body io.Reader, c
 		"output_tokens", resp.OutputTokens,
 		"cache_creation_input_tokens", resp.CacheCreationInputTokens,
 		"cache_read_input_tokens", resp.CacheReadInputTokens,
+		"cache_hit_rate", resp.CacheHitRate(),
 		"content_len", len(resp.Message.Content),
 		"tool_calls", len(resp.Message.ToolCalls),
 	)

--- a/internal/models/providers/anthropic.go
+++ b/internal/models/providers/anthropic.go
@@ -162,6 +162,14 @@ func (c *AnthropicClient) ChatStream(ctx context.Context, model string, messages
 	anthropicMsgs, systemPrompt := convertToAnthropic(messages)
 	anthropicTools := convertToolsToAnthropic(tools)
 	systemPayload := anthropicSystemPayload(messages, systemPrompt)
+
+	// Enforce Anthropic cache-breakpoint guards (≤4 total, per-model
+	// minimum cached-prefix length) on the assembled blocks+tools.
+	// Runs below the model minimum and excess breakpoints are silently
+	// ignored by the API, so we drop them here and warn instead.
+	if blocks, ok := systemPayload.([]anthropicContent); ok {
+		applyCacheBreakpointGuards(blocks, anthropicTools, model, c.logger)
+	}
 	explicitCaching := anthropicUsesExplicitPromptCaching(systemPayload)
 
 	c.logger.Debug("preparing request",
@@ -445,6 +453,131 @@ func anthropicSystemBlocks(sections []llm.PromptSection) []anthropicContent {
 		}
 	}
 	return blocks
+}
+
+// maxAnthropicCacheBreakpoints is the Anthropic-enforced per-request
+// limit on cache_control markers across system blocks, tools, and
+// messages. Exceeding it causes the API to reject the request, so
+// [applyCacheBreakpointGuards] silently drops excess breakpoints and
+// warns via slog rather than letting the request fail.
+const maxAnthropicCacheBreakpoints = 4
+
+// estimatedCharsPerToken is the coarse text-to-token ratio Anthropic
+// publishes for English prose. Used to check per-run prefix lengths
+// against the model-specific minimum cacheable tokens.
+const estimatedCharsPerToken = 4
+
+// minCacheablePrefixTokens returns the minimum token count a cached
+// prefix must reach for the Anthropic API to actually cache it. Runs
+// below this threshold are silently processed as uncached, which is
+// indistinguishable from a cache miss in the usage response — hence
+// the guard surfaces them as warnings.
+//
+// Values track the published per-family minimums (Sonnet 1024, Opus
+// 4096, Haiku 4096). Unknown models default to the strictest minimum
+// so we never advertise caching we can't confirm.
+func minCacheablePrefixTokens(model string) int {
+	lower := strings.ToLower(model)
+	switch {
+	case strings.Contains(lower, "opus"):
+		return 4096
+	case strings.Contains(lower, "haiku"):
+		return 4096
+	case strings.Contains(lower, "sonnet"):
+		return 1024
+	default:
+		return 4096
+	}
+}
+
+// applyCacheBreakpointGuards enforces the Anthropic per-request cache
+// breakpoint cap (≤4) and the per-model minimum cached-prefix length
+// across system blocks and the tool cache. Both are silent-failure
+// modes in the raw API: under-minimum runs are processed uncached
+// without any signal, and over-the-cap breakpoint counts cause a
+// request rejection.
+//
+// The guard policy:
+//
+//  1. For each system block that carries a cache_control, compute the
+//     prefix length through that block. If the prefix is below the
+//     model-specific minimum, strip cache_control and warn. The block
+//     itself remains; only the breakpoint is removed.
+//  2. Count surviving system breakpoints plus the one blanket tool
+//     cache (if any). If the total still exceeds 4, drop the tool
+//     cache first — it is an undifferentiated "cache the last tool"
+//     policy, whereas system breakpoints reflect deliberate
+//     per-section TTL choices.
+//  3. If still over the cap, drop trailing system breakpoints (the
+//     earliest runs typically cover the largest stable prefix, so
+//     dropping from the tail minimizes the loss).
+func applyCacheBreakpointGuards(blocks []anthropicContent, tools []anthropicTool, model string, logger *slog.Logger) {
+	minTokens := minCacheablePrefixTokens(model)
+
+	// Step 1: strip under-minimum breakpoints from system blocks.
+	prefixChars := 0
+	for i := range blocks {
+		prefixChars += len(blocks[i].Text)
+		if blocks[i].CacheControl == nil {
+			continue
+		}
+		if prefixChars/estimatedCharsPerToken < minTokens {
+			logger.Warn("dropping under-minimum Anthropic cache breakpoint",
+				"model", model,
+				"block_index", i,
+				"prefix_chars", prefixChars,
+				"prefix_tokens_estimate", prefixChars/estimatedCharsPerToken,
+				"min_tokens", minTokens,
+				"ttl", blocks[i].CacheControl.TTL,
+			)
+			blocks[i].CacheControl = nil
+		}
+	}
+
+	// Step 2: count surviving breakpoints.
+	systemBreakpoints := 0
+	for i := range blocks {
+		if blocks[i].CacheControl != nil {
+			systemBreakpoints++
+		}
+	}
+	toolBreakpoint := 0
+	if n := len(tools); n > 0 && tools[n-1].CacheControl != nil {
+		toolBreakpoint = 1
+	}
+
+	total := systemBreakpoints + toolBreakpoint
+	if total <= maxAnthropicCacheBreakpoints {
+		return
+	}
+
+	// Step 3: drop the tool breakpoint first.
+	if toolBreakpoint > 0 {
+		logger.Warn("dropping tool cache breakpoint to fit Anthropic 4-breakpoint cap",
+			"system_breakpoints", systemBreakpoints,
+			"total_requested", total,
+			"max", maxAnthropicCacheBreakpoints,
+		)
+		tools[len(tools)-1].CacheControl = nil
+		total--
+		if total <= maxAnthropicCacheBreakpoints {
+			return
+		}
+	}
+
+	// Step 4: drop trailing system breakpoints until we fit.
+	excess := total - maxAnthropicCacheBreakpoints
+	for i := len(blocks) - 1; i >= 0 && excess > 0; i-- {
+		if blocks[i].CacheControl == nil {
+			continue
+		}
+		logger.Warn("dropping trailing system cache breakpoint to fit Anthropic 4-breakpoint cap",
+			"block_index", i,
+			"ttl", blocks[i].CacheControl.TTL,
+		)
+		blocks[i].CacheControl = nil
+		excess--
+	}
 }
 
 type promptCacheRun struct {

--- a/internal/models/providers/anthropic_test.go
+++ b/internal/models/providers/anthropic_test.go
@@ -2,6 +2,7 @@ package providers
 
 import (
 	"encoding/json"
+	"log/slog"
 	"strings"
 	"testing"
 
@@ -358,6 +359,130 @@ func TestAnthropicPromptCacheControl_SuppressedBySectionCacheBreakpoints(t *test
 	ctrl := anthropicPromptCacheControl("fallback", []anthropicMessage{{Role: "user", Content: "check"}}, nil, explicit)
 	if ctrl != nil {
 		t.Fatalf("request-level cache_control = %+v, want nil when explicit system block caching is present", ctrl)
+	}
+}
+
+func TestMinCacheablePrefixTokens(t *testing.T) {
+	tests := []struct {
+		model string
+		want  int
+	}{
+		{"claude-sonnet-4-5", 1024},
+		{"claude-sonnet-4-20250514", 1024},
+		{"claude-opus-4-7", 4096},
+		{"claude-haiku-4-5", 4096},
+		{"unknown-model", 4096},
+	}
+	for _, tt := range tests {
+		t.Run(tt.model, func(t *testing.T) {
+			if got := minCacheablePrefixTokens(tt.model); got != tt.want {
+				t.Errorf("minCacheablePrefixTokens(%q) = %d, want %d", tt.model, got, tt.want)
+			}
+		})
+	}
+}
+
+// textBlock is a tiny helper for readable cache-guard test cases.
+func textBlock(text string, ttl string) anthropicContent {
+	b := anthropicContent{Type: "text", Text: text}
+	if ttl != "" {
+		b.CacheControl = &anthropicCacheControl{Type: "ephemeral", TTL: ttl}
+	}
+	return b
+}
+
+func TestApplyCacheBreakpointGuards_UnderMinimumRunsAreDropped(t *testing.T) {
+	// Sonnet minimum is 1024 tokens (≈4096 chars). Build two blocks:
+	// the first is way under; the second pushes the prefix over.
+	blocks := []anthropicContent{
+		textBlock(strings.Repeat("a", 400), "1h"),  // prefix ≈ 100 tokens — below min
+		textBlock(strings.Repeat("b", 4000), "1h"), // prefix ≈ 1100 tokens — above min
+	}
+	applyCacheBreakpointGuards(blocks, nil, "claude-sonnet-4-5", slog.Default())
+
+	if blocks[0].CacheControl != nil {
+		t.Error("under-minimum run should have cache_control stripped")
+	}
+	if blocks[1].CacheControl == nil {
+		t.Error("run above minimum should keep cache_control")
+	}
+}
+
+func TestApplyCacheBreakpointGuards_CapsAtFourBreakpointsDroppingTool(t *testing.T) {
+	// Four system breakpoints each above minimum, plus a tool cache.
+	// Total would be 5; the tool cache should drop.
+	body := strings.Repeat("x", 4100)
+	blocks := []anthropicContent{
+		textBlock(body, "1h"),
+		textBlock(body, "1h"),
+		textBlock(body, "1h"),
+		textBlock(body, "1h"),
+	}
+	tools := []anthropicTool{
+		{Name: "t", CacheControl: &anthropicCacheControl{Type: "ephemeral", TTL: "1h"}},
+	}
+
+	applyCacheBreakpointGuards(blocks, tools, "claude-sonnet-4-5", slog.Default())
+
+	if tools[0].CacheControl != nil {
+		t.Error("tool cache should be dropped when system fills the 4-breakpoint budget")
+	}
+	surviving := 0
+	for _, b := range blocks {
+		if b.CacheControl != nil {
+			surviving++
+		}
+	}
+	if surviving != 4 {
+		t.Errorf("surviving system breakpoints = %d, want 4", surviving)
+	}
+}
+
+func TestApplyCacheBreakpointGuards_DropsTrailingSystemWhenAboveCap(t *testing.T) {
+	// Five system breakpoints all above minimum and no tools. The
+	// trailing breakpoint should drop to fit the cap.
+	body := strings.Repeat("x", 4100)
+	blocks := []anthropicContent{
+		textBlock(body, "1h"),
+		textBlock(body, "1h"),
+		textBlock(body, "1h"),
+		textBlock(body, "1h"),
+		textBlock(body, "1h"),
+	}
+
+	applyCacheBreakpointGuards(blocks, nil, "claude-sonnet-4-5", slog.Default())
+
+	if blocks[4].CacheControl != nil {
+		t.Error("trailing system breakpoint should drop when budget exhausted")
+	}
+	for i := 0; i < 4; i++ {
+		if blocks[i].CacheControl == nil {
+			t.Errorf("leading system breakpoint %d should survive", i)
+		}
+	}
+}
+
+func TestApplyCacheBreakpointGuards_AllowsTypicalThreeBreakpointConfig(t *testing.T) {
+	// Two system runs + one tool is the current policy shape — well
+	// under the cap, all above minimum. The guard should be a no-op.
+	body := strings.Repeat("x", 5000)
+	blocks := []anthropicContent{
+		textBlock(body, "1h"),
+		textBlock(body, "5m"),
+	}
+	tools := []anthropicTool{
+		{Name: "t", CacheControl: &anthropicCacheControl{Type: "ephemeral", TTL: "1h"}},
+	}
+
+	applyCacheBreakpointGuards(blocks, tools, "claude-sonnet-4-5", slog.Default())
+
+	for i, b := range blocks {
+		if b.CacheControl == nil {
+			t.Errorf("system block %d cache_control should remain", i)
+		}
+	}
+	if tools[0].CacheControl == nil {
+		t.Error("tool cache_control should remain when under the 4-breakpoint cap")
 	}
 }
 

--- a/internal/server/api/server.go
+++ b/internal/server/api/server.go
@@ -259,28 +259,28 @@ func (s *SessionStats) SetBalance(balance float64) {
 
 // SessionStatsSnapshot is a copy-safe snapshot of session stats.
 type SessionStatsSnapshot struct {
-	TotalInputTokens              int64                    `json:"total_input_tokens"`
-	TotalOutputTokens             int64                    `json:"total_output_tokens"`
-	TotalCacheCreationInputTokens int64                    `json:"total_cache_creation_input_tokens"`
-	TotalCacheReadInputTokens     int64                    `json:"total_cache_read_input_tokens"`
+	TotalInputTokens              int64 `json:"total_input_tokens"`
+	TotalOutputTokens             int64 `json:"total_output_tokens"`
+	TotalCacheCreationInputTokens int64 `json:"total_cache_creation_input_tokens"`
+	TotalCacheReadInputTokens     int64 `json:"total_cache_read_input_tokens"`
 	// CacheHitRate is cache_read / (cache_read + cache_creation) over
 	// the session so far, expressed as a fraction in [0, 1]. Exposed
 	// to the dashboard so operators can see at a glance whether
 	// prompt caching is actually saving tokens (cold start = near
 	// zero, warm session = high).
-	CacheHitRate                  float64                  `json:"cache_hit_rate"`
-	TotalRequests                 int64                    `json:"total_requests"`
-	EstimatedCostUSD              float64                  `json:"estimated_cost_usd"`
-	ReportedBalance               float64                  `json:"reported_balance_usd,omitempty"`
-	BalanceSetAt                  string                   `json:"balance_set_at,omitempty"`
-	ByModel                       map[string]usage.Summary `json:"by_model,omitempty"`
-	ByUpstreamModel               map[string]usage.Summary `json:"by_upstream_model,omitempty"`
-	ByProvider                    map[string]usage.Summary `json:"by_provider,omitempty"`
-	ByResource                    map[string]usage.Summary `json:"by_resource,omitempty"`
-	ContextTokens                 int                      `json:"context_tokens"`
-	ContextWindow                 int                      `json:"context_window"`
-	MessageCount                  int                      `json:"message_count"`
-	Build                         map[string]string        `json:"build,omitempty"`
+	CacheHitRate     float64                  `json:"cache_hit_rate"`
+	TotalRequests    int64                    `json:"total_requests"`
+	EstimatedCostUSD float64                  `json:"estimated_cost_usd"`
+	ReportedBalance  float64                  `json:"reported_balance_usd,omitempty"`
+	BalanceSetAt     string                   `json:"balance_set_at,omitempty"`
+	ByModel          map[string]usage.Summary `json:"by_model,omitempty"`
+	ByUpstreamModel  map[string]usage.Summary `json:"by_upstream_model,omitempty"`
+	ByProvider       map[string]usage.Summary `json:"by_provider,omitempty"`
+	ByResource       map[string]usage.Summary `json:"by_resource,omitempty"`
+	ContextTokens    int                      `json:"context_tokens"`
+	ContextWindow    int                      `json:"context_window"`
+	MessageCount     int                      `json:"message_count"`
+	Build            map[string]string        `json:"build,omitempty"`
 }
 
 func (s *SessionStats) Snapshot() SessionStatsSnapshot {

--- a/internal/server/api/server.go
+++ b/internal/server/api/server.go
@@ -18,6 +18,7 @@ import (
 	"github.com/nugget/thane-ai-agent/internal/checkpoint"
 	"github.com/nugget/thane-ai-agent/internal/config"
 	"github.com/nugget/thane-ai-agent/internal/events"
+	"github.com/nugget/thane-ai-agent/internal/llm"
 	"github.com/nugget/thane-ai-agent/internal/logging"
 	looppkg "github.com/nugget/thane-ai-agent/internal/loop"
 	"github.com/nugget/thane-ai-agent/internal/memory"
@@ -262,6 +263,12 @@ type SessionStatsSnapshot struct {
 	TotalOutputTokens             int64                    `json:"total_output_tokens"`
 	TotalCacheCreationInputTokens int64                    `json:"total_cache_creation_input_tokens"`
 	TotalCacheReadInputTokens     int64                    `json:"total_cache_read_input_tokens"`
+	// CacheHitRate is cache_read / (cache_read + cache_creation) over
+	// the session so far, expressed as a fraction in [0, 1]. Exposed
+	// to the dashboard so operators can see at a glance whether
+	// prompt caching is actually saving tokens (cold start = near
+	// zero, warm session = high).
+	CacheHitRate                  float64                  `json:"cache_hit_rate"`
 	TotalRequests                 int64                    `json:"total_requests"`
 	EstimatedCostUSD              float64                  `json:"estimated_cost_usd"`
 	ReportedBalance               float64                  `json:"reported_balance_usd,omitempty"`
@@ -284,6 +291,7 @@ func (s *SessionStats) Snapshot() SessionStatsSnapshot {
 		TotalOutputTokens:             s.TotalOutputTokens,
 		TotalCacheCreationInputTokens: s.TotalCacheCreationInputTokens,
 		TotalCacheReadInputTokens:     s.TotalCacheReadInputTokens,
+		CacheHitRate:                  llm.CacheHitRate(int(s.TotalCacheReadInputTokens), int(s.TotalCacheCreationInputTokens)),
 		TotalRequests:                 s.TotalRequests,
 		EstimatedCostUSD:              s.EstimatedCostUSD,
 		ReportedBalance:               s.ReportedBalance,

--- a/internal/usage/store.go
+++ b/internal/usage/store.go
@@ -13,6 +13,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/nugget/thane-ai-agent/internal/config"
 	"github.com/nugget/thane-ai-agent/internal/database"
+	"github.com/nugget/thane-ai-agent/internal/llm"
 	"github.com/nugget/thane-ai-agent/internal/models"
 )
 
@@ -61,6 +62,18 @@ type Summary struct {
 	TotalCacheCreationInputTokens int64   `json:"total_cache_creation_input_tokens"`
 	TotalCacheReadInputTokens     int64   `json:"total_cache_read_input_tokens"`
 	TotalCostUSD                  float64 `json:"total_cost_usd"`
+}
+
+// CacheHitRate returns the fraction of cache-eligible input tokens that
+// were served from cache in this summary, as a value in [0, 1]. Zero
+// when there were no cache-eligible tokens at all (empty window, or
+// caching disabled). Useful for spotting cold-session spikes and
+// validating that prompt-caching policy is actually working.
+//
+// Formula matches the Anthropic-recommended observability metric:
+// cache_read / (cache_read + cache_creation).
+func (s Summary) CacheHitRate() float64 {
+	return llm.CacheHitRate(int(s.TotalCacheReadInputTokens), int(s.TotalCacheCreationInputTokens))
 }
 
 // GroupedSummary pairs a grouping key (model name, role, task name)

--- a/internal/usage/store.go
+++ b/internal/usage/store.go
@@ -30,10 +30,18 @@ type Record struct {
 	InputTokens              int
 	OutputTokens             int
 	CacheCreationInputTokens int
-	CacheReadInputTokens     int
-	CostUSD                  float64
-	Role                     string // "interactive", "delegate", "scheduled", "auxiliary"
-	TaskName                 string // "email_poll", "periodic_reflection", etc. (empty for interactive)
+	// CacheCreation5mInputTokens and CacheCreation1hInputTokens break
+	// down the cache-write bucket by TTL when the provider exposes it
+	// (Anthropic). Their sum is ≤ CacheCreationInputTokens; any
+	// shortfall reflects writes the provider didn't attribute. When
+	// the breakdown is absent (both zero), cost computation treats the
+	// full CacheCreationInputTokens as 5m for the conservative default.
+	CacheCreation5mInputTokens int
+	CacheCreation1hInputTokens int
+	CacheReadInputTokens       int
+	CostUSD                    float64
+	Role                       string // "interactive", "delegate", "scheduled", "auxiliary"
+	TaskName                   string // "email_poll", "periodic_reflection", etc. (empty for interactive)
 }
 
 // ModelIdentity is the normalized usage-facing identity for a selected
@@ -120,6 +128,17 @@ func (s *Store) migrate() error {
 	if err := database.AddColumn(s.db, "usage_records", "cache_read_input_tokens", "INTEGER NOT NULL DEFAULT 0"); err != nil {
 		return err
 	}
+	// Per-TTL cache-write breakdown columns, added for #736. Rows
+	// written before this migration ran have NULL/0 in both buckets;
+	// ComputeDetailedCostForIdentity treats that as "unknown mix" and
+	// falls back to the 5m multiplier on the full total so historical
+	// cost numbers don't spike retroactively.
+	if err := database.AddColumn(s.db, "usage_records", "cache_creation_5m_input_tokens", "INTEGER NOT NULL DEFAULT 0"); err != nil {
+		return err
+	}
+	if err := database.AddColumn(s.db, "usage_records", "cache_creation_1h_input_tokens", "INTEGER NOT NULL DEFAULT 0"); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -140,8 +159,9 @@ func (s *Store) Record(ctx context.Context, rec Record) error {
 	_, err := s.db.ExecContext(ctx,
 		`INSERT INTO usage_records
 			(id, timestamp, request_id, session_id, conversation_id, model, upstream_model, resource, provider,
-			 input_tokens, output_tokens, cache_creation_input_tokens, cache_read_input_tokens, cost_usd, role, task_name)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			 input_tokens, output_tokens, cache_creation_input_tokens, cache_creation_5m_input_tokens,
+			 cache_creation_1h_input_tokens, cache_read_input_tokens, cost_usd, role, task_name)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		rec.ID,
 		rec.Timestamp.UTC().Format(time.RFC3339),
 		rec.RequestID,
@@ -154,6 +174,8 @@ func (s *Store) Record(ctx context.Context, rec Record) error {
 		rec.InputTokens,
 		rec.OutputTokens,
 		rec.CacheCreationInputTokens,
+		rec.CacheCreation5mInputTokens,
+		rec.CacheCreation1hInputTokens,
 		rec.CacheReadInputTokens,
 		rec.CostUSD,
 		rec.Role,
@@ -320,7 +342,15 @@ func ResolveProvider(model string) string {
 }
 
 const (
-	anthropicCacheWriteMultiplier = 1.25
+	// Anthropic cache-write multipliers per TTL bucket (docs:
+	// platform.claude.com). 5m is the default; 1h is an opt-in that
+	// costs more to write in exchange for a longer hot window.
+	anthropicCacheWrite5mMultiplier = 1.25
+	anthropicCacheWrite1hMultiplier = 2.00
+	// Alias retained for legacy callers that haven't been updated to
+	// supply a TTL breakdown. Matches the 5m rate — the conservative
+	// default when the provider doesn't attribute the writes.
+	anthropicCacheWriteMultiplier = anthropicCacheWrite5mMultiplier
 	anthropicCacheReadMultiplier  = 0.10
 )
 
@@ -328,7 +358,22 @@ const (
 // identity using uncached input tokens, cache-write input tokens,
 // cache-read input tokens, and output tokens. Deployment-qualified IDs
 // fall back to upstream-model pricing when needed.
+//
+// Cache-write tokens are charged at the 5m rate (1.25× input) by
+// default. Callers that know the per-TTL split should use
+// [ComputeDetailedCostForIdentityWithTTL] instead to correctly charge
+// 1h writes at 2.0×.
 func ComputeDetailedCostForIdentity(identity ModelIdentity, inputTokens, cacheCreationInputTokens, cacheReadInputTokens, outputTokens int, pricing map[string]config.PricingEntry) float64 {
+	return ComputeDetailedCostForIdentityWithTTL(identity, inputTokens, cacheCreationInputTokens, 0, 0, cacheReadInputTokens, outputTokens, pricing)
+}
+
+// ComputeDetailedCostForIdentityWithTTL is the full-fidelity cost
+// function: callers supply the 5m/1h breakdown when the provider
+// exposes it. The unattributed portion of cacheCreationInputTokens
+// (that is, tokens not accounted for in the 5m or 1h buckets) is
+// charged at the 5m rate to avoid retroactive price spikes on legacy
+// records.
+func ComputeDetailedCostForIdentityWithTTL(identity ModelIdentity, inputTokens, cacheCreationTotal, cacheCreation5m, cacheCreation1h, cacheReadInputTokens, outputTokens int, pricing map[string]config.PricingEntry) float64 {
 	if len(pricing) == 0 {
 		return 0
 	}
@@ -343,7 +388,19 @@ func ComputeDetailedCostForIdentity(identity ModelIdentity, inputTokens, cacheCr
 			continue
 		}
 		cost := float64(inputTokens) / 1_000_000.0 * entry.InputPerMillion
-		cost += float64(cacheCreationInputTokens) / 1_000_000.0 * (entry.InputPerMillion * anthropicCacheWriteMultiplier)
+
+		// Breakdown-aware cache-write pricing. Anything in
+		// cacheCreationTotal not attributed to 5m or 1h is charged at
+		// the 5m rate (conservative default, matches legacy records
+		// written before the breakdown columns existed).
+		attributed := cacheCreation5m + cacheCreation1h
+		unattributed := cacheCreationTotal - attributed
+		if unattributed < 0 {
+			unattributed = 0
+		}
+		cost += float64(cacheCreation5m+unattributed) / 1_000_000.0 * (entry.InputPerMillion * anthropicCacheWrite5mMultiplier)
+		cost += float64(cacheCreation1h) / 1_000_000.0 * (entry.InputPerMillion * anthropicCacheWrite1hMultiplier)
+
 		cost += float64(cacheReadInputTokens) / 1_000_000.0 * (entry.InputPerMillion * anthropicCacheReadMultiplier)
 		cost += float64(outputTokens) / 1_000_000.0 * entry.OutputPerMillion
 		return cost

--- a/internal/usage/store_test.go
+++ b/internal/usage/store_test.go
@@ -474,10 +474,66 @@ func TestComputeDetailedCostForIdentity_AnthropicCacheBuckets(t *testing.T) {
 		Provider:      "anthropic",
 	}
 
+	// Legacy call without TTL breakdown: all cache-writes billed at 5m
+	// rate (1.25×), matching pre-#736 behavior for historical records.
 	got := ComputeDetailedCostForIdentity(identity, 1_000_000, 1_000_000, 1_000_000, 100_000, pricing)
 	want := 15.0 + (15.0 * 1.25) + (15.0 * 0.10) + 7.5
 	if diff := got - want; diff > 0.0001 || diff < -0.0001 {
 		t.Fatalf("ComputeDetailedCostForIdentity(...) = %f, want %f", got, want)
+	}
+}
+
+func TestComputeDetailedCostForIdentityWithTTL_ChargesFiveMinuteAndOneHour(t *testing.T) {
+	pricing := testPricing()
+	identity := ModelIdentity{
+		Model:         "claude-opus-4-20250514",
+		UpstreamModel: "claude-opus-4-20250514",
+		Provider:      "anthropic",
+	}
+
+	// 1M uncached input + 1M 5m writes + 1M 1h writes + 1M reads + 100k output.
+	// Opus pricing: input $15/MTok, output $75/MTok.
+	// 5m write multiplier: 1.25×. 1h: 2.0×. Read: 0.1×.
+	got := ComputeDetailedCostForIdentityWithTTL(identity,
+		1_000_000,   // uncached input
+		2_000_000,   // total cache writes (5m + 1h attributed)
+		1_000_000,   // 5m bucket
+		1_000_000,   // 1h bucket
+		1_000_000,   // cache reads
+		100_000,     // output
+		pricing,
+	)
+	want := 15.0 /* uncached input */ +
+		(15.0 * 1.25) /* 5m write */ +
+		(15.0 * 2.00) /* 1h write */ +
+		(15.0 * 0.10) /* cache read */ +
+		7.5 /* output */
+	if diff := got - want; diff > 0.0001 || diff < -0.0001 {
+		t.Fatalf("cost = %f, want %f", got, want)
+	}
+}
+
+func TestComputeDetailedCostForIdentityWithTTL_UnattributedFallsBackTo5m(t *testing.T) {
+	pricing := testPricing()
+	identity := ModelIdentity{
+		Model:         "claude-opus-4-20250514",
+		UpstreamModel: "claude-opus-4-20250514",
+		Provider:      "anthropic",
+	}
+
+	// Provider reported 1M total writes but attributed 0 to each
+	// bucket. Matches the pre-#736 schema where the breakdown columns
+	// didn't exist. Must fall back to 5m multiplier on the full total.
+	got := ComputeDetailedCostForIdentityWithTTL(identity,
+		0,         // no uncached input
+		1_000_000, // total writes
+		0, 0,      // no attribution
+		0, 0,      // no reads, no output
+		pricing,
+	)
+	want := 15.0 * 1.25
+	if diff := got - want; diff > 0.0001 || diff < -0.0001 {
+		t.Fatalf("unattributed cost = %f, want %f (5m rate)", got, want)
 	}
 }
 

--- a/internal/usage/store_test.go
+++ b/internal/usage/store_test.go
@@ -495,12 +495,12 @@ func TestComputeDetailedCostForIdentityWithTTL_ChargesFiveMinuteAndOneHour(t *te
 	// Opus pricing: input $15/MTok, output $75/MTok.
 	// 5m write multiplier: 1.25×. 1h: 2.0×. Read: 0.1×.
 	got := ComputeDetailedCostForIdentityWithTTL(identity,
-		1_000_000,   // uncached input
-		2_000_000,   // total cache writes (5m + 1h attributed)
-		1_000_000,   // 5m bucket
-		1_000_000,   // 1h bucket
-		1_000_000,   // cache reads
-		100_000,     // output
+		1_000_000, // uncached input
+		2_000_000, // total cache writes (5m + 1h attributed)
+		1_000_000, // 5m bucket
+		1_000_000, // 1h bucket
+		1_000_000, // cache reads
+		100_000,   // output
 		pricing,
 	)
 	want := 15.0 /* uncached input */ +
@@ -528,7 +528,7 @@ func TestComputeDetailedCostForIdentityWithTTL_UnattributedFallsBackTo5m(t *test
 		0,         // no uncached input
 		1_000_000, // total writes
 		0, 0,      // no attribution
-		0, 0,      // no reads, no output
+		0, 0, // no reads, no output
 		pricing,
 	)
 	want := 15.0 * 1.25

--- a/scripts/architecture.baseline
+++ b/scripts/architecture.baseline
@@ -1,5 +1,5 @@
 packages=51
 interfaces=72
-large_files=30
+large_files=31
 set_mutators=103
 database_opens=7


### PR DESCRIPTION
## Summary

Closes all 5 remaining Anthropic caching follow-ups from #640:

- #741 — retry transport with Retry-After on 429/5xx
- #739 — per-request breakpoint count + per-model minimum-prefix guards
- #736 — correct 1h cache-write cost multiplier (was underbilled by ~37%)
- #737 — cache hit rate in debug logs and session-stats snapshot
- #743 — \`docs/anthropic-caching.md\` + cross-links

Five focused commits, one per issue.

## Behavior changes

- **Retries**: Anthropic HTTP 429 and 5xx now retry with backoff (3×,
  2s default, capped by \`Retry-After\` when the server sets it).
  Matches the Ollama/LMStudio pattern; streaming-safe because retries
  only fire before the response body is handed to the caller.
- **Guards**: cache_control markers are stripped from under-minimum
  prefixes (warn + drop) and the 4-breakpoint cap is enforced with
  priority to deliberate system-section TTLs (tool cache drops first
  if over budget).
- **1h cost**: 1-hour cache writes are now charged at 2.0× input
  (docs: platform.claude.com), not the flat 1.25× that had been
  applied to all writes. Per-TTL split is parsed from
  \`usage.cache_creation.ephemeral_{5m,1h}_input_tokens\` and persisted
  on two new \`usage_records\` columns. Historical rows default to the
  5m rate so legacy cost numbers don't spike retroactively.
- **Hit rate**: Anthropic debug log lines include \`cache_hit_rate\`.
  \`SessionStatsSnapshot\` JSON exposes the aggregate under
  \`cache_hit_rate\`. Dashboard HTML/JS doesn't render it yet — that's
  a small follow-up now that the server data exists.

## Net on the PR

- Five commits, all acceptance criteria from the linked issues met.
- Unit coverage: retry on 429 / 5xx / Retry-After / body close,
  breakpoint-guard and min-prefix paths, TTL-aware cost with
  unattributed fallback, \`CacheHitRate\` zero-safe edge cases.
- \`just ci\` green locally. Architecture baselines bumped:
  \`large_files\` 30→31 (server.go crossed 500 lines) and nothing else.
- New doc at \`docs/anthropic-caching.md\` (158 lines); cross-linked
  from \`promptSectionCacheTTL\` and \`docs/model-facing-context.md\`.

## Commits

1. \`feat: retry Anthropic HTTP 429/5xx with Retry-After support\` (#741)
2. \`fix: guard Anthropic cache breakpoints against silent rejection\` (#739)
3. \`fix: charge 1h Anthropic cache writes at 2.0x instead of 1.25x\` (#736)
4. \`feat: surface Anthropic cache hit rate in logs and session snapshot\` (#737)
5. \`docs: explain Anthropic caching policy and add cross-links\` (#743)

## Test plan

- [x] \`just ci\` passes locally on final commit
- [ ] CI green on PR
- [x] Retry tests cover status-based retry, Retry-After, non-matching status
- [x] Guard tests cover under-minimum drop, tool-cache drop, trailing-system drop
- [x] Cost tests cover TTL-aware path and unattributed fallback
- [x] Hit-rate tests cover zero-denominator