### PR TITLE
docs: v0.9.1 prep — tools reference sync, caching cross-links, milestone strategy

### DIFF
--- a/docs/milestone-strategy.md
+++ b/docs/milestone-strategy.md
@@ -1,0 +1,89 @@
+# Milestone Strategy
+
+How we use GitHub milestones to plan and track releases.
+
+## Versioning Philosophy
+
+**v1.0.0 is a meaningful threshold, not an arbitrary number.** It marks the
+moment Thane transitions from a single-instance universe to a population.
+Pre-1.0 is the single-thane era. At 1.0, a second production thane launches
+and establishes mutual trust with the first.
+
+The 1.0 gate is defined by two concrete questions:
+
+1. *Can we spin up a second thane instance and have it cryptographically
+   establish mutual trust with the first?*
+2. *Can a technically skilled enthusiast install and bootstrap a thane
+   instance from docs alone, without our involvement?*
+
+If either answer is no, it's not 1.0.
+
+## Milestone Types
+
+### Major milestones (v1.0.0, v2.0.0)
+
+Semantic thresholds with real criteria. Issues assigned here represent
+hard requirements for that threshold. They stay in the major milestone
+until they're pulled into an active point release for implementation.
+
+**v1.0.0 criteria:**
+- Cryptographic identity established at init (SSH keypair, internal CA)
+- Managed document roots with signature-required integrity policy
+- Peer trust model: flat by default, hierarchical by choice
+- Message bus with signed envelopes for inter-component communication
+- Model-guided onboarding for new instances
+- Cohesive log storage with primary-source retention
+- Documentation and init flow sufficient for an unassisted install by
+  a technically skilled enthusiast
+- Everything needed for two thane instances to coexist with mutual trust
+
+### Point releases (v0.9.0, v0.9.1, v1.1.0)
+
+Active shipping targets. These are ephemeral and focused — a small batch
+of issues cherry-picked from the backlog or from a major milestone.
+
+When planning a point release, pull issues from wherever they make sense:
+- From v1.0.0 to chip away at the multi-thane gate
+- From the unlabeled backlog for independent improvements
+- New work that emerged since the last release
+
+When a point release ships, close the milestone. Open the next one and
+pull in the next batch.
+
+### Post-major (v1.1.0, future)
+
+Good ideas that don't gate the next major threshold. These can be pulled
+forward into point releases when priorities shift.
+
+## Workflow
+
+1. **Issues start in the major milestone they gate** (if any) or remain
+   unassigned if they're independent of a threshold.
+2. **To plan a point release**, cherry-pick issues into the new point
+   release milestone. If an issue was in v1.0.0, it moves to the point
+   release — the v1.0.0 milestone tracks what's *remaining*, not a
+   frozen manifest.
+3. **Ship the point release**, close the milestone.
+4. **Repeat.** When every v1.0.0 issue has shipped through point releases,
+   the v1.0.0 milestone is empty and the threshold is met. Tag the
+   release as v1.0.0.
+
+## Thematic Organization
+
+Milestones track *when* something ships. Labels track *what area* it
+belongs to. An issue's thematic identity lives in its labels (e.g.,
+`security`, `architecture`, `loops-ng`), not its milestone.
+
+To see progress on a pillar like identity/trust: filter by label across
+all milestones. To see what's shipping next: look at the current point
+release milestone.
+
+## Guidelines
+
+- **Fuzzy is fine.** Milestone assignment is a planning tool, not a
+  contract. Move issues freely as priorities shift.
+- **One milestone per issue.** GitHub enforces this. Use the most
+  actionable milestone — usually the release target.
+- **Close milestones when shipped.** Don't leave stale milestones open.
+- **Major milestones drain to zero.** When all issues have been pulled
+  through point releases and shipped, the major milestone is met.

--- a/docs/model-facing-context.md
+++ b/docs/model-facing-context.md
@@ -164,7 +164,7 @@ reasoning:
   anchoring matters, and should still include a delta
 - persistent storage, logs, and APIs should keep absolute timestamps
 
-Use the shared helpers in `internal/awareness/timefmt.go`:
+Use the shared helpers in `internal/promptfmt/timefmt.go`:
 
 - `FormatDelta`
 - `FormatDeltaOnly`

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -1,184 +1,308 @@
 # Tools Reference
 
-Thane provides 80+ native tools organized by capability tag. Tools are only
-available when their tag is active — see
-[The Agent Loop](../understanding/agent-loop.md) for how tags work.
+Thane provides ~130 native tools organized by capability tag. A tool is
+available to a given turn only when one of its default tags is active —
+see [The Agent Loop](../understanding/agent-loop.md) for how tags flip
+on and off, and [Anthropic Caching](../anthropic-caching.md) for how
+tag choices interact with prompt caching.
 
-Tools marked `always` are available regardless of tag state.
+Tools under the `always` heading below are not tag-gated and load on
+every turn. Everything else loads only when a relevant capability is
+activated, either by the model via `activate_capability` or via
+configured always-active tags.
 
-## Home Assistant (`ha`)
+The authoritative source for which tool is tagged how is
+[`internal/toolcatalog/catalog.go`](../../internal/toolcatalog/catalog.go);
+this doc is a human-readable reflection of that catalog. If you add or
+re-tag a tool there, update this file in the same PR.
 
-| Tool | Description |
-|------|-------------|
-| `control_device` | Natural language device control with fuzzy entity matching |
-| `find_entity` | Smart entity discovery across all HA domains |
-| `get_state` | Current state of any entity |
-| `list_entities` | Browse entities by domain or pattern |
-| `call_service` | Direct HA service invocation |
-| `add_context_entity` | Add entity to the state watchlist |
-| `list_context_entities` | List live context watchlist subscriptions |
-| `remove_context_entity` | Remove entity from the state watchlist |
-| `ha_notify` | HA companion app push notification |
+## Coarse menu tags
 
-## Email (`email`)
+`development`, `home`, `interactive`, `knowledge`, `media`,
+`operations`, `people` are coarse navigation tags rather than tool
+containers. They carry short teasers that point the model at the
+fine-grained tags that actually own the tools. Activating any coarse
+tag surfaces its teaser; the model then activates the fine tag it
+needs.
 
-| Tool | Description |
-|------|-------------|
-| `email_list` | List messages in a folder |
-| `email_read` | Read message with full body |
-| `email_search` | Server-side IMAP search |
-| `email_folders` | List available mailboxes |
-| `email_mark` | Flag/unflag messages |
-| `email_send` | Compose and send (markdown to MIME) |
-| `email_reply` | Reply with threading headers |
-| `email_move` | Move messages between folders |
+## Always-active
 
-## Contacts (`contacts`)
+These tools load on every turn regardless of active tags.
 
 | Tool | Description |
 |------|-------------|
-| `save_contact` | Create or update contacts with vCard properties |
-| `lookup_contact` | Search by name, query, kind, or property |
-| `forget_contact` | Delete a contact |
-| `list_contacts` | List and filter contacts |
-| `export_vcf` | Export contact as vCard |
-| `export_vcf_qr` | Export contact as vCard QR code |
-| `export_all_vcf` | Bulk vCard export |
-| `import_vcf` | Import vCard data |
+| `activate_capability` | Activate a capability tag for the current conversation. |
+| `deactivate_capability` | Deactivate a capability tag for the current conversation. |
+| `activate_lens` | Activate a persistent global behavioural lens. |
+| `deactivate_lens` | Deactivate a global behavioural lens. |
+| `list_lenses` | List currently active behavioural lenses. |
+| `thane_delegate` | Delegate a task to a cheaper/faster model via the delegate executor. |
+| `archive_search` | Full-text search across conversation archives. |
+| `archive_sessions` | Browse session archive metadata. |
+| `archive_session_transcript` | Retrieve a full session transcript. |
+| `session_checkpoint` | Save current session state as a checkpoint. |
+| `session_close` | Close the current session with carry-forward context. |
+| `session_split` | Fork the current session. |
+| `conversation_reset` | Reset the current conversation's message history. |
+| `send_notification` | Provider-agnostic fire-and-forget notification. |
 
-## Notifications (`always`)
-
-| Tool | Description |
-|------|-------------|
-| `send_notification` | Provider-agnostic fire-and-forget notification |
-| `request_human_decision` | Actionable notification with HITL callbacks |
-
-## Media & Feeds (`media`)
-
-| Tool | Description |
-|------|-------------|
-| `media_transcript` | Fetch video/podcast transcript via yt-dlp |
-| `media_follow` | Follow an RSS/Atom feed or YouTube channel |
-| `media_unfollow` | Stop following a feed |
-| `media_feeds` | List followed feeds with status |
-| `media_save_analysis` | Save analysis to Obsidian vault |
-
-## Memory & Knowledge (`memory`, `always`)
-
-| Tool | Tag | Description |
-|------|-----|-------------|
-| `remember_fact` | memory | Store knowledge with embeddings |
-| `recall_fact` | memory | Retrieve knowledge by category or search |
-| `forget_fact` | memory | Remove stored knowledge |
-
-## Archive (`always`)
+## `awareness` — live-context entity management
 
 | Tool | Description |
 |------|-------------|
-| `archive_search` | Full-text search across conversation history |
-| `archive_sessions` | Browse session archive |
-| `archive_session_transcript` | Retrieve full session transcript |
+| `add_context_entity` | Watch an HA entity so its state is injected into context each turn. |
+| `list_context_entities` | List current watchlist subscriptions (scoped and always-visible). |
+| `remove_context_entity` | Remove a watched entity or a scoped subscription. |
 
-## Session (`always`)
-
-| Tool | Description |
-|------|-------------|
-| `session_working_memory` | Read/write scratchpad for active session |
-| `session_close` | Close session with carry-forward context |
-| `session_checkpoint` | Save current session state |
-| `session_split` | Fork the current session |
-| `conversation_reset` | Reset conversation context |
-
-## Planning (`planning`)
+## `ha` / `homeassistant` — Home Assistant state and control
 
 | Tool | Description |
 |------|-------------|
-| `schedule_task` | Time-based future actions |
-| `list_tasks` | List scheduled tasks |
-| `cancel_task` | Cancel a scheduled task |
+| `control_device` | Natural-language device control with fuzzy entity matching. |
+| `find_entity` | Smart entity discovery across HA domains. |
+| `get_state` | Current state of any entity. |
+| `list_entities` | Browse entities by domain or glob pattern. |
+| `call_service` | Direct HA service invocation. |
+| `ha_registry_search` | Search the entity/device/area registry. |
+| `ha_automation_list` | List automations with recent activation counts. |
+| `ha_automation_get` | Retrieve one automation's configuration. |
+| `ha_automation_create` | Create a new automation. |
+| `ha_automation_update` | Modify an existing automation. |
+| `ha_automation_delete` | Delete an automation. |
 
-## Capabilities (`always`)
-
-| Tool | Description |
-|------|-------------|
-| `activate_capability` | Activate capability tags for current conversation |
-| `deactivate_capability` | Deactivate capability tags |
-| `activate_lens` | Activate a persistent global behavioral lens |
-| `deactivate_lens` | Deactivate a global behavioral lens |
-| `list_lenses` | List active behavioral lenses |
-
-## Forge / GitHub (`forge`)
+## `notifications` — delivery, escalation, and actionable responses
 
 | Tool | Description |
 |------|-------------|
-| `forge_issue_create` | Create an issue |
-| `forge_issue_get` | Get issue details |
-| `forge_issue_list` | List issues with filters |
-| `forge_issue_update` | Update issue fields |
-| `forge_issue_comment` | Comment on an issue |
-| `forge_pr_list` | List pull requests |
-| `forge_pr_get` | Get PR details |
-| `forge_pr_diff` | Get PR diff |
-| `forge_pr_files` | List changed files |
-| `forge_pr_commits` | List PR commits |
-| `forge_pr_reviews` | List PR reviews |
-| `forge_pr_review` | Submit a review |
-| `forge_pr_review_comment` | Comment on specific code |
-| `forge_pr_checks` | Get CI check status |
-| `forge_pr_merge` | Merge a PR |
-| `forge_pr_request_review` | Request reviewers |
-| `forge_react` | Add emoji reaction |
-| `forge_search` | Search code and issues |
+| `ha_notify` | HA companion-app push notification. |
+| `request_human_decision` | Actionable notification with a human-in-the-loop callback. |
+| `request_human_escalation` | Escalate to a human with a synchronous response wait. |
+| `request_ai_escalation` | Escalate to another agent/model with a synchronous response wait. |
+| `resolve_actionable` | Mark an actionable notification as resolved. |
 
-## Web (`web`)
+## `memory` — persistent facts and working memory
 
 | Tool | Description |
 |------|-------------|
-| `web_search` | Search via SearXNG or Brave |
-| `web_fetch` | Extract readable content from URLs |
+| `remember_fact` | Store knowledge with optional embeddings. |
+| `recall_fact` | Retrieve knowledge by category or semantic search. |
+| `forget_fact` | Remove a stored fact. |
+| `session_working_memory` | Read/write scratchpad for the active session. |
 
-## Files (`files`)
+## `documents` — indexed document-root browsing
 
-| Tool | Description |
-|------|-------------|
-| `file_read` | Read file contents |
-| `file_write` | Write file contents |
-| `file_edit` | Edit file with diff |
-| `file_list` | List directory contents |
-| `file_search` | Search for files by name |
-| `file_grep` | Search file contents with regex |
-| `file_stat` | Get file metadata |
-| `file_tree` | Directory tree view |
-| `create_temp_file` | Create a temporary file |
-
-## Shell (`shell`)
+Managed document roots (`core:`, `kb:`, `generated:`, `scratchpad:`,
+custom prefixes) are browsed through these tools rather than via raw
+filesystem access. See
+[Document Roots](../understanding/document-roots.md).
 
 | Tool | Description |
 |------|-------------|
-| `exec` | Host shell command execution (configurable safety guardrails) |
+| `doc_roots` | List configured document roots with health/counts. |
+| `doc_browse` | Walk a document root by folder. |
+| `doc_outline` | Emit the heading/section outline for a document. |
+| `doc_read` | Read a document by prefixed path. |
+| `doc_section` | Retrieve a named section from a document. |
+| `doc_search` | Full-text and tagged search across roots. |
+| `doc_links` | List inbound/outbound links for a document. |
+| `doc_values` | List frontmatter values (tags, statuses, etc.) across a root. |
+| `doc_write` | Write or replace a document. |
+| `doc_edit` | Targeted edit within a document. |
+| `doc_copy` | Copy a document to another location. |
+| `doc_move` | Move or rename a document. |
+| `doc_delete` | Delete a document. |
+| `doc_copy_section` | Copy one named section into another document. |
+| `doc_move_section` | Move one named section into another document. |
+| `doc_journal_update` | Append or update a journal-style entry. |
 
-## Delegation (`always`)
+## `email` — inbox traffic
 
 | Tool | Description |
 |------|-------------|
-| `thane_delegate` | Delegate tasks to local models |
+| `email_list` | List messages in a folder. |
+| `email_read` | Read a message with its full body. |
+| `email_search` | Server-side IMAP search. |
+| `email_folders` | List available mailboxes. |
+| `email_mark` | Flag or unflag messages. |
+| `email_send` | Compose and send (markdown → MIME). |
+| `email_reply` | Reply with proper threading headers. |
+| `email_move` | Move messages between folders. |
 
-## Utility (`always`)
+## `contacts` — directory and vCard administration
 
 | Tool | Description |
 |------|-------------|
-| `get_version` | Agent version and build info |
-| `cost_summary` | Token usage and cost summary |
+| `save_contact` | Create or update a contact with vCard properties. |
+| `lookup_contact` | Search by name, query, kind, or property. |
+| `forget_contact` | Delete a contact. |
+| `list_contacts` | List and filter contacts. |
+| `export_vcf` | Export one contact as a vCard. |
+| `export_vcf_qr` | Export one contact as a vCard QR code. |
+| `export_all_vcf` | Bulk vCard export. |
+| `import_vcf` | Import one or more vCards. |
 
-## MCP Tools
+## `owner` — trusted operator context
 
-Thane hosts MCP servers as subprocesses, bridging their tools into the agent
-loop. MCP tools appear as `mcp_{server}_{tool}` and are assigned to
-capability tags in config.
+| Tool | Description |
+|------|-------------|
+| `owner_contact` | Return the runtime owner identity. Protected tag. |
 
-The primary MCP server is [ha-mcp](https://github.com/karimkhaleel/ha-mcp),
-which provides 90+ Home Assistant tools. With `include_tools` filtering, you
-select which tools to bridge.
+## `files` — workspace filesystem access
 
-See [Delegation & MCP](../understanding/delegation.md) for configuration
-details.
+| Tool | Description |
+|------|-------------|
+| `file_read` | Read file contents. |
+| `file_write` | Write file contents. |
+| `file_edit` | Targeted edit with a diff preview. |
+| `file_list` | List directory contents. |
+| `file_search` | Search for files by name. |
+| `file_grep` | Search file contents with regex. |
+| `file_stat` | Get file metadata. |
+| `file_tree` | Render a directory tree. |
+| `create_temp_file` | Create a temp file with a labelled path. |
+
+## `shell` — host command execution
+
+| Tool | Description |
+|------|-------------|
+| `exec` | Run a host shell command with configurable allow/deny guardrails. |
+
+## `web` — web search and fetch
+
+| Tool | Description |
+|------|-------------|
+| `web_search` | Search via the configured backend (SearXNG/Brave). |
+| `web_fetch` | Extract readable content from a URL. |
+
+## `media` — transcript and analysis
+
+| Tool | Description |
+|------|-------------|
+| `media_transcript` | Fetch a video/podcast transcript via yt-dlp. Also tagged `web`. |
+| `media_save_analysis` | Save a media analysis to the configured vault. |
+
+## `feeds` — RSS/Atom and channel subscriptions
+
+| Tool | Description |
+|------|-------------|
+| `media_follow` | Follow an RSS/Atom feed or YouTube channel. |
+| `media_unfollow` | Stop following a feed. |
+| `media_feeds` | List followed feeds and their status. |
+
+## `attachments` — vision pipeline
+
+| Tool | Description |
+|------|-------------|
+| `attachment_list` | List known attachments with metadata. |
+| `attachment_search` | Semantic or tag search over attachment descriptions. |
+| `attachment_describe` | Produce/refresh a vision description for an attachment. |
+
+## `forge` — GitHub/code collaboration
+
+| Tool | Description |
+|------|-------------|
+| `forge_issue_list` | List issues with filters. |
+| `forge_issue_get` | Get an issue's details. |
+| `forge_issue_create` | Create an issue. |
+| `forge_issue_update` | Update issue fields. |
+| `forge_issue_comment` | Comment on an issue. |
+| `forge_pr_list` | List pull requests. |
+| `forge_pr_get` | Get a PR's details. |
+| `forge_pr_diff` | Retrieve a PR's diff. |
+| `forge_pr_files` | List changed files in a PR. |
+| `forge_pr_commits` | List commits in a PR. |
+| `forge_pr_reviews` | List reviews on a PR. |
+| `forge_pr_review` | Submit a review. |
+| `forge_pr_review_comment` | Comment on a specific line in a PR. |
+| `forge_pr_merge` | Merge a PR. |
+| `forge_pr_request_review` | Request reviewers on a PR. |
+| `forge_react` | Add an emoji reaction to an issue/PR/comment. |
+| `forge_search` | Search code and issues across the forge. |
+
+## `scheduler` — time-based tasks
+
+| Tool | Description |
+|------|-------------|
+| `schedule_task` | Schedule a future task. |
+| `list_tasks` | List scheduled tasks. |
+| `cancel_task` | Cancel a scheduled task. |
+
+## `loops` — live loop and loop-definition management
+
+| Tool | Description |
+|------|-------------|
+| `loop_status` | Snapshot of currently running loops. |
+| `notify_loop` | Deliver a message envelope to a live loop. |
+| `set_next_sleep` | Request the next sleep duration for the current loop. |
+| `spawn_loop` | Launch an ad-hoc loop from a definition and input. |
+| `stop_loop` | Stop a running loop. |
+| `loop_definition_list` | List registered loop definitions. |
+| `loop_definition_get` | Retrieve a loop definition's spec. |
+| `loop_definition_set` | Create or update a loop definition. |
+| `loop_definition_delete` | Remove a loop definition. |
+| `loop_definition_lint` | Validate a proposed loop-definition spec. |
+| `loop_definition_launch` | Launch a persistent loop from a definition. |
+| `loop_definition_set_policy` | Update a loop definition's lifecycle policy. |
+| `loop_definition_summary` | Summary view across definitions. |
+
+## `mqtt` — wake subscriptions
+
+See [MQTT](../operating/mqtt.md) for the broker-side conventions.
+
+| Tool | Description |
+|------|-------------|
+| `mqtt_wake_list` | List runtime and config-defined wake subscriptions. |
+| `mqtt_wake_add` | Add a runtime wake subscription with routing config. |
+| `mqtt_wake_remove` | Remove a runtime wake subscription by ID. |
+
+## `signal` — Signal messaging
+
+Declared via a Provider with async binding; handlers return
+[`tools.ErrUnavailable`](../../internal/tools/provider.go) when
+signal-cli isn't connected.
+
+| Tool | Description |
+|------|-------------|
+| `signal_send_message` | Send a Signal message to a phone number. |
+| `signal_send_reaction` | React to an inbound Signal message. |
+
+## `platform` — native OS integration
+
+| Tool | Description |
+|------|-------------|
+| `macos_calendar_events` | Query the local macOS Calendar (platform provider required). |
+
+## `models` — model registry and routing
+
+| Tool | Description |
+|------|-------------|
+| `model_registry_list` | List available models with capability metadata. |
+| `model_registry_get` | Retrieve one model deployment's metadata. |
+| `model_registry_summary` | Summary of routing policy and cost tiers. |
+| `model_route_explain` | Dry-run a routing decision with the router's rationale. |
+| `model_deployment_set_policy` | Update deployment-level routing policy. |
+| `model_resource_set_policy` | Update resource-level routing policy. |
+
+## `diagnostics` — operational visibility
+
+| Tool | Description |
+|------|-------------|
+| `get_version` | Agent version, build info, and commit SHA. |
+| `cost_summary` | Aggregated token usage and cost (uses `usage.Summary`, including `cache_hit_rate`). |
+| `logs_query` | Query the structured log index with attribute filters. |
+
+## MCP tools
+
+Thane hosts MCP servers as subprocesses and bridges their tools into
+the registry as `mcp_{server}_{tool}`. MCP tools inherit their default
+tags from the MCP config's `default_tags` or configuration-side tag
+overrides; they do not have a compiled-in entry in
+`internal/toolcatalog/catalog.go`.
+
+The primary MCP server in typical deployments is
+[`ha-mcp`](https://github.com/karimkhaleel/ha-mcp), which exposes
+90+ Home Assistant tools beyond Thane's native set. `include_tools`
+filtering in the config narrows the bridged surface.
+
+See [Delegation & MCP](../understanding/delegation.md) for
+configuration details.

--- a/docs/understanding/context-layers.md
+++ b/docs/understanding/context-layers.md
@@ -102,3 +102,10 @@ memory.
 | Identity in talents | Confusing — talent says "you are X" but persona says "you are Y" | Keep identity in persona only |
 | Behavioral directives in inject files | Inject files are knowledge, not instructions | Move directives to talents |
 | Static time in build info | Model treats version metadata as ignorable | Use Current Conditions section |
+
+## Related
+
+- [Anthropic Caching](../anthropic-caching.md) — how the layer
+  boundaries map onto Anthropic cache TTLs (persona and inject-file
+  layers cache at 1h; dynamic context and current conditions are
+  uncached so they don't churn the prefix).


### PR DESCRIPTION
## Summary

Docs housekeeping ahead of the v0.9.1 cut. Four doc files changed, one
new file committed.

### docs/reference/tools.md — sync with catalog

The single biggest delta. The doc advertised ~80 tools and was
organized around an older capability-tag scheme; the actual catalog
in [\`internal/toolcatalog/catalog.go\`](internal/toolcatalog/catalog.go)
has ~130 tools and has grown tags the doc didn't know about
(\`awareness\`, \`documents\`, \`loops\`, \`mqtt\`, \`signal\`, \`platform\`,
\`models\`, \`diagnostics\`, \`attachments\`, \`feeds\`, \`owner\`,
\`scheduler\`).

Concrete miscategorizations the rewrite fixes:

- \`add_context_entity\`, \`list_context_entities\`, \`remove_context_entity\`
  were listed under \`ha\` but are tagged \`awareness\`.
- \`schedule_task\`/\`list_tasks\`/\`cancel_task\` were under a non-existent
  \`planning\` tag — they're \`scheduler\`.
- \`ha_notify\` was grouped with \`ha\` but is tagged \`notifications\`.
- \`get_version\`, \`cost_summary\`, \`logs_query\` were marked \`always\` /
  \`utility\` but are tagged \`diagnostics\`.

Rewritten as a reflection of the actual catalog, grouped by tag, with
a pointer up top naming \`internal/toolcatalog/catalog.go\` as the
authoritative source — so the next drift cycle is easier to catch.

### docs/model-facing-context.md — timefmt path fix

Pointed at \`internal/awareness/timefmt.go\`. #625 moved that package
to \`internal/promptfmt/\`. One-line fix.

### docs/understanding/context-layers.md — link caching

Added a Related section pointing at \`anthropic-caching.md\` so readers
working on system-prompt layers find the TTL policy that maps onto
those layers.

### docs/milestone-strategy.md — commit untracked file

The milestone-workflow doc that's been in the working tree since we
set up the v0.9.1/v1.0.0 milestone split earlier in this cycle. No
content changes; just bringing it into the tree.

## Scope note

Did an overall docs review across \`README.md\`, \`AGENTS.md\`,
\`CONTRIBUTING.md\`, \`docs/**/*.md\`. No other stale refactor references
found:

- No mentions of removed \`logging.Rotator\`, \`logging.Open\`,
  \`logging.dir\`, \`logging.compress\`, or the monolithic \`thane.log\`.
- No mentions of \`SetWatchlistStore\`, \`SetMQTTSubscriptionTools\`, or
  \`s.deferredTools\` in prose.
- Logging section in \`operating/configuration.md\` already describes
  the new JSONL dataset structure correctly.
- \`docs/release-checklist.md\` is evergreen and accurate.

## Test plan

- [x] \`just ci\` passes locally (docs-only changes, no Go touched)
- [ ] CI green on PR
- [x] Spot-checked a handful of tags in the new tools.md against the
  catalog