### PR TITLE
fix: remove AppleDouble files from macOS pkg payloads

### DIFF
--- a/justfile
+++ b/justfile
@@ -21,6 +21,11 @@ notary-profile := env("THANE_NOTARY_PROFILE", "")
 
 # List available recipes
 default:
+    @echo "Common workflows:"
+    @echo "  just release-github <version> [auto|prerelease|release]  # normal production release path"
+    @echo "  just deploy-macos-pkg <user@host>                         # live-host pkg validation without a GitHub release"
+    @echo "  just ci                                                   # full local validation gate"
+    @echo ""
     @just --list
 
 # --- Build ---

--- a/scripts/package-macos-pkg.sh
+++ b/scripts/package-macos-pkg.sh
@@ -48,6 +48,9 @@ package_name="thane_${version}_darwin_${target_arch}.pkg"
 stage_dir="$(mktemp -d "${TMPDIR:-/tmp}/thane-pkg.XXXXXX")"
 payload_root="$stage_dir/root"
 component_pkg="$stage_dir/thane-component.pkg"
+component_expanded="$stage_dir/thane-component-expanded"
+clean_component_pkg="$stage_dir/thane-component-clean.pkg"
+clean_bom_list="$stage_dir/clean-bom.txt"
 distribution_path="$stage_dir/Distribution.xml"
 requirements_plist="$stage_dir/product-requirements.plist"
 resources_root="$stage_dir/Resources"
@@ -63,6 +66,7 @@ install -m 755 "$binary_path" "$payload_root/Thane/bin/thane"
 if command -v xattr >/dev/null 2>&1; then
     xattr -cr "$payload_root"
 fi
+find "$payload_root" \( -name '.DS_Store' -o -name '._*' \) -delete
 
 artifact_path="$output_dir/$package_name"
 
@@ -110,6 +114,10 @@ pkgbuild_args=(
     --version "$version"
     --install-location "/"
     --ownership recommended
+    --filter '(^|/)\.DS_Store$'
+    --filter '(^|/)\.svn(/|$)'
+    --filter '(^|/)CVS(/|$)'
+    --filter '(^|/)\._[^/]*$'
     --quiet
     "$component_pkg"
 )
@@ -117,6 +125,21 @@ pkgbuild_args=(
 # Keep stdout reserved for the final artifact path so release recipes can
 # safely capture this script's result with command substitution.
 COPYFILE_DISABLE=1 "${pkgbuild_args[@]}" >&2
+
+# pkgbuild preserves protected macOS provenance metadata as AppleDouble `._*`
+# entries in the component payload/BOM. Rebuild both from the clean staging
+# root so published packages contain only the files operators should inspect.
+pkgutil --expand "$component_pkg" "$component_expanded" >&2
+lsbom "$component_expanded/Bom" \
+    | awk '$1 !~ /(^|\/)\._/ && $1 !~ /(^|\/)\.DS_Store$/ { print }' \
+    > "$clean_bom_list"
+mkbom -i "$clean_bom_list" "$component_expanded/Bom" >&2
+(
+    cd "$payload_root"
+    find . | LC_ALL=C sort | cpio -o --format odc --owner 0:0 2>/dev/null
+) | gzip -c > "$component_expanded/Payload"
+pkgutil --flatten "$component_expanded" "$clean_component_pkg" >&2
+mv "$clean_component_pkg" "$component_pkg"
 
 productbuild --synthesize \
     --product "$requirements_plist" \

--- a/scripts/package-macos-pkg.sh
+++ b/scripts/package-macos-pkg.sh
@@ -66,7 +66,11 @@ install -m 755 "$binary_path" "$payload_root/Thane/bin/thane"
 if command -v xattr >/dev/null 2>&1; then
     xattr -cr "$payload_root"
 fi
-find "$payload_root" \( -name '.DS_Store' -o -name '._*' \) -delete
+# Keep the staging root aligned with the pkgbuild filter set so the
+# post-processing payload rebuild cannot reintroduce metadata debris.
+find "$payload_root" \
+    \( -name '.DS_Store' -o -name '._*' -o -name '.svn' -o -name 'CVS' \) \
+    -exec rm -rf {} +
 
 artifact_path="$output_dir/$package_name"
 

--- a/scripts/releng/build-macos-pkg.sh
+++ b/scripts/releng/build-macos-pkg.sh
@@ -18,7 +18,7 @@ require_signed="${4:-true}"
 
 cd "$repo_root"
 require_macos_host
-require_commands just codesign pkgbuild productbuild pkgutil
+require_commands just codesign pkgbuild productbuild pkgutil lsbom mkbom cpio gzip
 
 case "$target_arch" in
     amd64|arm64) ;;

--- a/scripts/releng/release-github.sh
+++ b/scripts/releng/release-github.sh
@@ -17,7 +17,7 @@ container_tag="${3:-thane:prepare-release}"
 
 cd "$repo_root"
 require_macos_host
-require_commands just docker gh codesign pkgbuild productbuild xcrun
+require_commands just docker gh codesign pkgbuild productbuild pkgutil lsbom mkbom cpio gzip xcrun
 
 validate_release_version "$version"
 validate_release_kind "$release_kind"


### PR DESCRIPTION
## Summary
- Rebuild the macOS component package BOM and payload from the clean staging root so `pkgutil --payload-files` no longer reports synthetic `._*` AppleDouble entries.
- Keep explicit pkgbuild filters for source-level metadata debris.
- Add the extra standard macOS packaging tools to release wrapper prerequisite checks.

## Validation
- Built a local arm64 macOS package and verified `pkgutil --payload-files` only reports `.`, `./Thane`, `./Thane/bin`, and `./Thane/bin/thane`.
- `just ci`