### PR TITLE
[codex] docs: recommend thane-agent-macos for macOS deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ Point Home Assistant's Ollama integration at `http://thane-host:11434`, select m
 
 **[Your First Thane](docs/operating/guide.md)** — Complete onboarding guide with hardware, models, and deployment.
 
+On macOS, we recommend the
+[thane-agent-macos](https://github.com/nugget/thane-agent-macos) companion app
+for a native, integrated way to run Thane on a Mac.
+
 ## Releases
 
 Tagged releases publish locally prepared release artifacts on GitHub plus a

--- a/docs/operating/guide.md
+++ b/docs/operating/guide.md
@@ -75,6 +75,12 @@ cloud model provides the intelligence for orchestration and conversation.
 
 ## Deployment
 
+If you're running Thane on a macOS host, start with the
+[thane-agent-macos](https://github.com/nugget/thane-agent-macos) companion
+app. It gives you a native, integrated Mac experience for installing and
+running Thane. The manual steps below remain useful for source-based setups,
+Linux hosts, and operators who want the raw binary and service path.
+
 ### Step 1: Build and Install
 
 ```bash


### PR DESCRIPTION
## Summary
- add a README note directing macOS users to `thane-agent-macos`
- add the same recommendation to the operating guide before the manual deployment steps
- present `thane-agent-macos` as the native, integrated way to run Thane on a Mac while keeping the existing manual path documented

## Why
macOS operators currently land in the generic deployment docs first. Pointing them to `thane-agent-macos` gives them a clearer, more welcoming recommendation for running Thane on a Mac.

## Impact
This is a docs-only change. It makes the macOS deployment story clearer without changing the existing source/manual deployment instructions.

## Validation
- `just ci`