### PR TITLE
feat: bootstrap core identity during init

### DIFF
--- a/cmd/thane/init.go
+++ b/cmd/thane/init.go
@@ -1,16 +1,19 @@
 package main
 
 import (
+	"context"
 	_ "embed"
 	"errors"
 	"fmt"
 	"io"
 	"io/fs"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
 
 	"github.com/nugget/thane-ai-agent/internal/model/talents"
+	"github.com/nugget/thane-ai-agent/internal/platform/identity"
 )
 
 //go:generate sh -c "cp ../../examples/config.example.yaml . && cp ../../examples/persona.example.md ."
@@ -73,6 +76,16 @@ func runInit(w io.Writer, dir string) error {
 	})
 	if err != nil {
 		return fmt.Errorf("deploy talents: %w", err)
+	}
+
+	result, err := identity.BootstrapCore(context.Background(), filepath.Join(absDir, "core"), filepath.Base(absDir), slog.Default())
+	if err != nil {
+		return fmt.Errorf("bootstrap core identity: %w", err)
+	}
+	if result.Created {
+		fmt.Fprintf(w, "  ✓ %s (core identity, signing %s)\n", result.CoreDir, result.SigningKeyFingerprint)
+	} else {
+		fmt.Fprintf(w, "  · %s (core identity exists, skipping)\n", result.CoreDir)
 	}
 
 	fmt.Fprintln(w)

--- a/cmd/thane/init_test.go
+++ b/cmd/thane/init_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"syscall"
@@ -17,7 +18,15 @@ func clearUmask(t *testing.T) {
 	t.Cleanup(func() { syscall.Umask(old) })
 }
 
+func requireGit(t *testing.T) {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+}
+
 func TestRunInit_FreshDirectory(t *testing.T) {
+	requireGit(t)
 	clearUmask(t)
 	dir := t.TempDir()
 	var buf bytes.Buffer
@@ -29,7 +38,7 @@ func TestRunInit_FreshDirectory(t *testing.T) {
 	out := buf.String()
 
 	// Verify directory structure.
-	for _, sub := range []string{"db", "talents"} {
+	for _, sub := range []string{"core", "db", "talents"} {
 		info, err := os.Stat(filepath.Join(dir, sub))
 		if err != nil {
 			t.Errorf("expected directory %s: %v", sub, err)
@@ -88,9 +97,35 @@ func TestRunInit_FreshDirectory(t *testing.T) {
 	if !strings.Contains(out, "persona.md") {
 		t.Error("output missing persona.md")
 	}
+	if !strings.Contains(out, "core identity") {
+		t.Error("output missing core identity")
+	}
+
+	for _, rel := range []string{
+		"core/config.yaml",
+		"core/identity/signing_ed25519",
+		"core/identity/signing_ed25519.pub",
+		"core/ca/channel_root.key",
+		"core/ca/channel_root.crt",
+	} {
+		if _, err := os.Stat(filepath.Join(dir, rel)); err != nil {
+			t.Fatalf("%s not created: %v", rel, err)
+		}
+	}
+
+	for _, rel := range []string{"core/identity/signing_ed25519", "core/ca/channel_root.key"} {
+		info, err := os.Stat(filepath.Join(dir, rel))
+		if err != nil {
+			t.Fatalf("stat %s: %v", rel, err)
+		}
+		if got := info.Mode().Perm(); got != 0o600 {
+			t.Errorf("%s permissions = %o, want 0600", rel, got)
+		}
+	}
 }
 
 func TestRunInit_SkipsExistingFiles(t *testing.T) {
+	requireGit(t)
 	dir := t.TempDir()
 	var buf bytes.Buffer
 

--- a/docs/operating/getting-started.md
+++ b/docs/operating/getting-started.md
@@ -32,14 +32,18 @@ This builds a platform-specific binary into `dist/`. Cross-compile with
 
 ## Initialize
 
-Set up the `~/Thane` directory with config, talents, and persona:
+Set up the `~/Thane` directory with config, talents, persona, and a local
+cryptographic identity:
 
 ```bash
 just init
 ```
 
-This creates `~/Thane/config.yaml`, copies talent files, and sets up the
-persona. Edit `~/Thane/config.yaml` for your setup.
+This creates `~/Thane/config.yaml`, copies talent files, sets up the
+persona, and bootstraps `~/Thane/core` as the instance trust root. The core
+root contains a generated Ed25519 signing key, an internal channel CA, and a
+signed git birth commit containing the public identity material and
+`core/config.yaml`. Edit `~/Thane/config.yaml` for your setup.
 
 **Required settings:**
 

--- a/docs/understanding/trust-architecture.md
+++ b/docs/understanding/trust-architecture.md
@@ -21,6 +21,22 @@ prompt compliance, we acknowledge the gap and plan structural replacements.
 
 ## Current Structural Enforcement
 
+### Core Identity Bootstrap
+
+**Status: Implemented**
+
+`thane init` creates `core/` as the instance trust root. It generates an
+Ed25519 SSH signing key, an internal Ed25519 X.509 channel CA, and
+`core/config.yaml` with the initial identity declaration and default trust
+policy. Private keys remain local under `core/` with `0600` permissions and
+are ignored by git. Public identity material and policy are committed
+together as one SSH-signed birth commit, giving the instance a verifiable
+cryptographic birthday.
+
+This is a foundation, not the full peer-trust system. Peer CA exchange,
+delegation certificates, inherited-trust policy enforcement, and transport
+mTLS still need dedicated runtime paths.
+
 ### Trust Zones
 
 **Status: Implemented**

--- a/internal/platform/identity/bootstrap.go
+++ b/internal/platform/identity/bootstrap.go
@@ -64,6 +64,13 @@ func BootstrapCore(ctx context.Context, coreDir, instanceName string, logger *sl
 		return nil, fmt.Errorf("core identity appears partially initialized in %s", absCoreDir)
 	}
 
+	created := false
+	defer func() {
+		if !created {
+			cleanupBootstrapArtifacts(absCoreDir, logger)
+		}
+	}()
+
 	if err := os.MkdirAll(filepath.Join(absCoreDir, "identity"), 0o755); err != nil {
 		return nil, fmt.Errorf("create identity directory: %w", err)
 	}
@@ -112,12 +119,41 @@ func BootstrapCore(ctx context.Context, coreDir, instanceName string, logger *sl
 		return nil, err
 	}
 
+	created = true
 	return &BootstrapResult{
 		Created:               true,
 		CoreDir:               absCoreDir,
 		SigningKeyFingerprint: signing.Fingerprint,
 		ChannelCAFingerprint:  channelCA.Fingerprint,
 	}, nil
+}
+
+func cleanupBootstrapArtifacts(coreDir string, logger *slog.Logger) {
+	for _, rel := range []string{
+		CoreConfigFile,
+		SigningPrivateKeyFile,
+		SigningPublicKeyFile,
+		ChannelCAKeyFile,
+		ChannelCACertFile,
+		".gitignore",
+		".allowed_signers",
+	} {
+		path := filepath.Join(coreDir, rel)
+		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+			logger.Warn("failed to clean up core identity bootstrap artifact", "path", path, "error", err)
+		}
+	}
+
+	if err := os.RemoveAll(filepath.Join(coreDir, ".git")); err != nil {
+		logger.Warn("failed to clean up core identity git repository", "path", filepath.Join(coreDir, ".git"), "error", err)
+	}
+
+	for _, rel := range []string{"identity", "ca", ""} {
+		path := filepath.Join(coreDir, rel)
+		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+			logger.Debug("core identity bootstrap directory not removed", "path", path, "error", err)
+		}
+	}
 }
 
 type coreIdentityState struct {

--- a/internal/platform/identity/bootstrap.go
+++ b/internal/platform/identity/bootstrap.go
@@ -1,0 +1,271 @@
+package identity
+
+import (
+	"context"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/nugget/thane-ai-agent/internal/platform/provenance"
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	// CoreConfigFile is the policy document committed into the core root.
+	CoreConfigFile = "config.yaml"
+	// SigningPrivateKeyFile is the private Ed25519 signing key path.
+	SigningPrivateKeyFile = "identity/signing_ed25519"
+	// SigningPublicKeyFile is the public Ed25519 signing key path.
+	SigningPublicKeyFile = "identity/signing_ed25519.pub"
+	// ChannelCAKeyFile is the private channel CA key path.
+	ChannelCAKeyFile = "ca/channel_root.key"
+	// ChannelCACertFile is the public channel CA certificate path.
+	ChannelCACertFile = "ca/channel_root.crt"
+)
+
+const coreGitIgnore = `identity/signing_ed25519
+ca/channel_root.key
+`
+
+// BootstrapResult describes the outcome of a core identity bootstrap.
+type BootstrapResult struct {
+	Created               bool
+	CoreDir               string
+	SigningKeyFingerprint string
+	ChannelCAFingerprint  string
+}
+
+// BootstrapCore initializes the core trust root for a Thane instance.
+// Private key material is written under core/ with 0600 permissions and
+// ignored by git. Public key material, the channel CA certificate, and
+// core/config.yaml are committed together as the signed birth commit.
+func BootstrapCore(ctx context.Context, coreDir, instanceName string, logger *slog.Logger) (*BootstrapResult, error) {
+	absCoreDir, err := filepath.Abs(coreDir)
+	if err != nil {
+		return nil, fmt.Errorf("resolve core dir: %w", err)
+	}
+	if logger == nil {
+		logger = slog.Default()
+	}
+	if instanceName = strings.TrimSpace(instanceName); instanceName == "" {
+		instanceName = "thane"
+	}
+
+	if state, err := existingCoreIdentity(absCoreDir); err != nil {
+		return nil, err
+	} else if state.complete {
+		return &BootstrapResult{Created: false, CoreDir: absCoreDir}, nil
+	} else if state.partial {
+		return nil, fmt.Errorf("core identity appears partially initialized in %s", absCoreDir)
+	}
+
+	if err := os.MkdirAll(filepath.Join(absCoreDir, "identity"), 0o755); err != nil {
+		return nil, fmt.Errorf("create identity directory: %w", err)
+	}
+	if err := os.MkdirAll(filepath.Join(absCoreDir, "ca"), 0o755); err != nil {
+		return nil, fmt.Errorf("create CA directory: %w", err)
+	}
+
+	now := time.Now().UTC().Truncate(time.Second)
+	signing, err := GenerateSigningKeyPair(instanceName)
+	if err != nil {
+		return nil, err
+	}
+	channelCA, err := GenerateCertificateAuthority(instanceName+" Thane Channel CA", now)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := writePrivateFile(filepath.Join(absCoreDir, SigningPrivateKeyFile), signing.PrivatePEM); err != nil {
+		return nil, err
+	}
+	if err := writePrivateFile(filepath.Join(absCoreDir, ChannelCAKeyFile), channelCA.PrivatePEM); err != nil {
+		return nil, err
+	}
+
+	signer, err := provenance.NewSSHSignerFromKey(signing.PrivateKey)
+	if err != nil {
+		return nil, err
+	}
+	store, err := provenance.New(absCoreDir, signer, logger)
+	if err != nil {
+		return nil, err
+	}
+
+	policy, err := renderCoreConfig(instanceName, now, signing, channelCA)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := store.WriteFiles(ctx, map[string]string{
+		".gitignore":         coreGitIgnore,
+		".allowed_signers":   fmt.Sprintf("thane@provenance.local %s\n", strings.TrimSpace(signing.Public)),
+		SigningPublicKeyFile: signing.Public,
+		ChannelCACertFile:    string(channelCA.Certificate),
+		CoreConfigFile:       string(policy),
+	}, "bootstrap core identity"); err != nil {
+		return nil, err
+	}
+
+	return &BootstrapResult{
+		Created:               true,
+		CoreDir:               absCoreDir,
+		SigningKeyFingerprint: signing.Fingerprint,
+		ChannelCAFingerprint:  channelCA.Fingerprint,
+	}, nil
+}
+
+type coreIdentityState struct {
+	complete bool
+	partial  bool
+}
+
+func existingCoreIdentity(coreDir string) (coreIdentityState, error) {
+	paths := []string{
+		".git",
+		".gitignore",
+		".allowed_signers",
+		CoreConfigFile,
+		SigningPrivateKeyFile,
+		SigningPublicKeyFile,
+		ChannelCAKeyFile,
+		ChannelCACertFile,
+	}
+
+	found := 0
+	for _, rel := range paths {
+		_, err := os.Stat(filepath.Join(coreDir, rel))
+		switch {
+		case err == nil:
+			found++
+		case os.IsNotExist(err):
+		default:
+			return coreIdentityState{}, fmt.Errorf("stat core identity file %s: %w", rel, err)
+		}
+	}
+	return coreIdentityState{
+		complete: found == len(paths),
+		partial:  found > 0 && found < len(paths),
+	}, nil
+}
+
+func writePrivateFile(path string, data []byte) error {
+	file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+	if err != nil {
+		return fmt.Errorf("create private file %s: %w", path, err)
+	}
+	_, writeErr := file.Write(data)
+	closeErr := file.Close()
+	if writeErr != nil {
+		return fmt.Errorf("write private file %s: %w", path, writeErr)
+	}
+	if closeErr != nil {
+		return fmt.Errorf("close private file %s: %w", path, closeErr)
+	}
+	return nil
+}
+
+type coreConfig struct {
+	Version     int              `yaml:"version"`
+	GeneratedAt string           `yaml:"generated_at"`
+	Identity    identityPolicy   `yaml:"identity"`
+	Trust       trustPolicy      `yaml:"trust"`
+	Delegation  delegationPolicy `yaml:"delegation"`
+	Channels    channelPolicy    `yaml:"channels"`
+}
+
+type identityPolicy struct {
+	InstanceName string         `yaml:"instance_name"`
+	SigningKey   signingKeyRef  `yaml:"signing_key"`
+	ChannelCA    certificateRef `yaml:"channel_ca"`
+}
+
+type signingKeyRef struct {
+	PublicKeyPath string `yaml:"public_key_path"`
+	Fingerprint   string `yaml:"fingerprint"`
+}
+
+type certificateRef struct {
+	CertPath    string `yaml:"cert_path"`
+	Fingerprint string `yaml:"fingerprint"`
+	NotBefore   string `yaml:"not_before"`
+	NotAfter    string `yaml:"not_after"`
+}
+
+type trustPolicy struct {
+	TrustedPeerCAs []string `yaml:"trusted_peer_ca_fingerprints"`
+	Revocations    []string `yaml:"revocations"`
+}
+
+type delegationPolicy struct {
+	IssueDelegationCerts bool     `yaml:"issue_delegation_certs"`
+	MaxDepth             int      `yaml:"max_depth"`
+	DefaultLifetime      string   `yaml:"default_lifetime"`
+	Profiles             []string `yaml:"profiles"`
+}
+
+type channelPolicy struct {
+	InboundAuth     string   `yaml:"inbound_auth"`
+	AcceptTOFU      bool     `yaml:"accept_tofu"`
+	AllowedKeyTypes []string `yaml:"allowed_key_types"`
+}
+
+func renderCoreConfig(instanceName string, generatedAt time.Time, signing *SigningKeyPair, ca *CertificateAuthority) ([]byte, error) {
+	cfg := coreConfig{
+		Version:     1,
+		GeneratedAt: generatedAt.Format(time.RFC3339),
+		Identity: identityPolicy{
+			InstanceName: instanceName,
+			SigningKey: signingKeyRef{
+				PublicKeyPath: SigningPublicKeyFile,
+				Fingerprint:   signing.Fingerprint,
+			},
+			ChannelCA: certificateRef{
+				CertPath:    ChannelCACertFile,
+				Fingerprint: ca.Fingerprint,
+				NotBefore:   ca.NotBefore.Format(time.RFC3339),
+				NotAfter:    ca.NotAfter.Format(time.RFC3339),
+			},
+		},
+		Trust: trustPolicy{
+			TrustedPeerCAs: []string{},
+			Revocations:    []string{},
+		},
+		Delegation: delegationPolicy{
+			IssueDelegationCerts: true,
+			MaxDepth:             1,
+			DefaultLifetime:      "1h",
+			Profiles:             []string{"read_only_peer", "task_scoped_delegate"},
+		},
+		Channels: channelPolicy{
+			InboundAuth:     "mtls_required",
+			AcceptTOFU:      false,
+			AllowedKeyTypes: []string{"ed25519"},
+		},
+	}
+
+	data, err := yaml.Marshal(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("marshal core config: %w", err)
+	}
+	return data, nil
+}
+
+// ParseCACertificate decodes a generated CA certificate from PEM. It is
+// exported for tests and future identity loaders.
+func ParseCACertificate(data []byte) (*x509.Certificate, error) {
+	block, _ := pem.Decode(data)
+	if block == nil || block.Type != "CERTIFICATE" {
+		return nil, fmt.Errorf("missing certificate PEM block")
+	}
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("parse certificate: %w", err)
+	}
+	return cert, nil
+}

--- a/internal/platform/identity/bootstrap_test.go
+++ b/internal/platform/identity/bootstrap_test.go
@@ -2,6 +2,7 @@ package identity
 
 import (
 	"bytes"
+	"context"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -138,6 +139,36 @@ func TestBootstrapCoreRejectsPartialIdentity(t *testing.T) {
 
 	if _, err := BootstrapCore(t.Context(), coreDir, "pocket", nil); err == nil {
 		t.Fatal("BootstrapCore partial identity returned nil, want error")
+	}
+}
+
+func TestBootstrapCoreRollsBackFailedBirthCommit(t *testing.T) {
+	requireGit(t)
+
+	coreDir := filepath.Join(t.TempDir(), "core")
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	if _, err := BootstrapCore(ctx, coreDir, "pocket", nil); err == nil {
+		t.Fatal("BootstrapCore with canceled context returned nil, want error")
+	}
+
+	for _, rel := range []string{
+		CoreConfigFile,
+		SigningPrivateKeyFile,
+		SigningPublicKeyFile,
+		ChannelCAKeyFile,
+		ChannelCACertFile,
+		".gitignore",
+		".allowed_signers",
+		".git",
+	} {
+		if _, err := os.Stat(filepath.Join(coreDir, rel)); !os.IsNotExist(err) {
+			t.Fatalf("%s exists after failed bootstrap; stat err=%v", rel, err)
+		}
+	}
+
+	if _, err := BootstrapCore(t.Context(), coreDir, "pocket", nil); err != nil {
+		t.Fatalf("BootstrapCore after rollback: %v", err)
 	}
 }
 

--- a/internal/platform/identity/bootstrap_test.go
+++ b/internal/platform/identity/bootstrap_test.go
@@ -1,0 +1,186 @@
+package identity
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func clearUmask(t *testing.T) {
+	t.Helper()
+	old := syscall.Umask(0)
+	t.Cleanup(func() { syscall.Umask(old) })
+}
+
+func requireGit(t *testing.T) {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+}
+
+func TestBootstrapCoreCreatesSignedBirthCommit(t *testing.T) {
+	requireGit(t)
+	clearUmask(t)
+
+	coreDir := filepath.Join(t.TempDir(), "core")
+	result, err := BootstrapCore(t.Context(), coreDir, "pocket", nil)
+	if err != nil {
+		t.Fatalf("BootstrapCore: %v", err)
+	}
+	if !result.Created {
+		t.Fatal("Created = false, want true")
+	}
+	if result.SigningKeyFingerprint == "" || result.ChannelCAFingerprint == "" {
+		t.Fatalf("missing fingerprints: %+v", result)
+	}
+
+	for _, rel := range []string{
+		CoreConfigFile,
+		SigningPrivateKeyFile,
+		SigningPublicKeyFile,
+		ChannelCAKeyFile,
+		ChannelCACertFile,
+		".gitignore",
+		".allowed_signers",
+	} {
+		if _, err := os.Stat(filepath.Join(coreDir, rel)); err != nil {
+			t.Fatalf("expected %s: %v", rel, err)
+		}
+	}
+
+	assertMode(t, filepath.Join(coreDir, SigningPrivateKeyFile), 0o600)
+	assertMode(t, filepath.Join(coreDir, ChannelCAKeyFile), 0o600)
+	assertMode(t, filepath.Join(coreDir, SigningPublicKeyFile), 0o644)
+	assertMode(t, filepath.Join(coreDir, ChannelCACertFile), 0o644)
+
+	certPEM, err := os.ReadFile(filepath.Join(coreDir, ChannelCACertFile))
+	if err != nil {
+		t.Fatalf("read CA cert: %v", err)
+	}
+	if _, err := ParseCACertificate(certPEM); err != nil {
+		t.Fatalf("CA cert is not parseable: %v", err)
+	}
+
+	var cfg coreConfig
+	cfgData, err := os.ReadFile(filepath.Join(coreDir, CoreConfigFile))
+	if err != nil {
+		t.Fatalf("read core config: %v", err)
+	}
+	if err := yaml.Unmarshal(cfgData, &cfg); err != nil {
+		t.Fatalf("unmarshal core config: %v", err)
+	}
+	if cfg.Identity.InstanceName != "pocket" {
+		t.Fatalf("instance_name = %q, want pocket", cfg.Identity.InstanceName)
+	}
+	if cfg.Identity.SigningKey.Fingerprint != result.SigningKeyFingerprint {
+		t.Fatalf("signing fingerprint = %q, want %q", cfg.Identity.SigningKey.Fingerprint, result.SigningKeyFingerprint)
+	}
+	if cfg.Identity.ChannelCA.Fingerprint != result.ChannelCAFingerprint {
+		t.Fatalf("CA fingerprint = %q, want %q", cfg.Identity.ChannelCA.Fingerprint, result.ChannelCAFingerprint)
+	}
+
+	tracked := gitOutput(t, coreDir, "ls-files")
+	trackedFiles := strings.Split(strings.TrimSpace(tracked), "\n")
+	for _, want := range []string{CoreConfigFile, SigningPublicKeyFile, ChannelCACertFile, ".gitignore", ".allowed_signers"} {
+		if !containsString(trackedFiles, want) {
+			t.Fatalf("tracked files missing %s:\n%s", want, tracked)
+		}
+	}
+	for _, private := range []string{SigningPrivateKeyFile, ChannelCAKeyFile} {
+		if containsString(trackedFiles, private) {
+			t.Fatalf("private key %s was committed:\n%s", private, tracked)
+		}
+	}
+
+	if got := strings.TrimSpace(gitOutput(t, coreDir, "rev-list", "--count", "HEAD")); got != "1" {
+		t.Fatalf("commit count = %s, want 1", got)
+	}
+	if status := strings.TrimSpace(gitOutput(t, coreDir, "status", "--short", "--untracked-files=all")); status != "" {
+		t.Fatalf("core git status = %q, want clean", status)
+	}
+	verifyGitCommit(t, coreDir)
+}
+
+func TestBootstrapCoreSkipsCompleteIdentity(t *testing.T) {
+	requireGit(t)
+
+	coreDir := filepath.Join(t.TempDir(), "core")
+	if _, err := BootstrapCore(t.Context(), coreDir, "pocket", nil); err != nil {
+		t.Fatalf("first BootstrapCore: %v", err)
+	}
+	result, err := BootstrapCore(t.Context(), coreDir, "pocket", nil)
+	if err != nil {
+		t.Fatalf("second BootstrapCore: %v", err)
+	}
+	if result.Created {
+		t.Fatal("Created = true, want false for existing identity")
+	}
+	if got := strings.TrimSpace(gitOutput(t, coreDir, "rev-list", "--count", "HEAD")); got != "1" {
+		t.Fatalf("commit count = %s, want 1", got)
+	}
+}
+
+func TestBootstrapCoreRejectsPartialIdentity(t *testing.T) {
+	coreDir := filepath.Join(t.TempDir(), "core")
+	if err := os.MkdirAll(filepath.Join(coreDir, "identity"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(coreDir, SigningPublicKeyFile), []byte("ssh-ed25519 test"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := BootstrapCore(t.Context(), coreDir, "pocket", nil); err == nil {
+		t.Fatal("BootstrapCore partial identity returned nil, want error")
+	}
+}
+
+func assertMode(t *testing.T, path string, want os.FileMode) {
+	t.Helper()
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat %s: %v", path, err)
+	}
+	if got := info.Mode().Perm(); got != want {
+		t.Fatalf("%s permissions = %o, want %o", path, got, want)
+	}
+}
+
+func containsString(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}
+
+func gitOutput(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %s failed: %v\n%s", strings.Join(args, " "), err, out)
+	}
+	return string(out)
+}
+
+func verifyGitCommit(t *testing.T, dir string) {
+	t.Helper()
+	cmd := exec.Command("git", "-C", dir, "verify-commit", "HEAD")
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("git verify-commit failed: %v\nstdout: %s\nstderr: %s", err, stdout.String(), stderr.String())
+	}
+	if combined := stdout.String() + stderr.String(); !strings.Contains(combined, "Good") {
+		t.Fatalf("verify-commit output missing Good signature:\n%s", combined)
+	}
+}

--- a/internal/platform/identity/keys.go
+++ b/internal/platform/identity/keys.go
@@ -1,0 +1,124 @@
+// Package identity bootstraps Thane instance identity material.
+package identity
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/base64"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"time"
+
+	"golang.org/x/crypto/ssh"
+)
+
+// SigningKeyPair contains a generated Ed25519 SSH signing key pair.
+type SigningKeyPair struct {
+	PrivateKey  ed25519.PrivateKey
+	PrivatePEM  []byte
+	Public      string
+	Fingerprint string
+}
+
+// CertificateAuthority contains a generated self-signed X.509 CA.
+type CertificateAuthority struct {
+	PrivateKey  ed25519.PrivateKey
+	PrivatePEM  []byte
+	Certificate []byte
+	Fingerprint string
+	NotBefore   time.Time
+	NotAfter    time.Time
+}
+
+// GenerateSigningKeyPair creates a new Ed25519 SSH signing key pair.
+func GenerateSigningKeyPair(comment string) (*SigningKeyPair, error) {
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		return nil, fmt.Errorf("generate signing key: %w", err)
+	}
+
+	sshPub, err := ssh.NewPublicKey(pub)
+	if err != nil {
+		return nil, fmt.Errorf("encode signing public key: %w", err)
+	}
+	block, err := ssh.MarshalPrivateKey(priv, comment)
+	if err != nil {
+		return nil, fmt.Errorf("marshal signing private key: %w", err)
+	}
+
+	return &SigningKeyPair{
+		PrivateKey:  priv,
+		PrivatePEM:  pem.EncodeToMemory(block),
+		Public:      string(ssh.MarshalAuthorizedKey(sshPub)),
+		Fingerprint: ssh.FingerprintSHA256(sshPub),
+	}, nil
+}
+
+// GenerateCertificateAuthority creates a self-signed Ed25519 root CA.
+func GenerateCertificateAuthority(commonName string, now time.Time) (*CertificateAuthority, error) {
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		return nil, fmt.Errorf("generate CA key: %w", err)
+	}
+
+	serialLimit := new(big.Int).Lsh(big.NewInt(1), 128)
+	serial, err := rand.Int(rand.Reader, serialLimit)
+	if err != nil {
+		return nil, fmt.Errorf("generate CA serial: %w", err)
+	}
+	if serial.Sign() == 0 {
+		serial = big.NewInt(1)
+	}
+
+	notBefore := now.UTC().Truncate(time.Second)
+	notAfter := notBefore.AddDate(10, 0, 0)
+	template := &x509.Certificate{
+		SerialNumber: serial,
+		Subject: pkix.Name{
+			CommonName: commonName,
+		},
+		NotBefore:             notBefore,
+		NotAfter:              notAfter,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign | x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+		MaxPathLen:            2,
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, template, template, pub, priv)
+	if err != nil {
+		return nil, fmt.Errorf("create CA certificate: %w", err)
+	}
+	keyDER, err := x509.MarshalPKCS8PrivateKey(priv)
+	if err != nil {
+		return nil, fmt.Errorf("marshal CA private key: %w", err)
+	}
+	cert, err := x509.ParseCertificate(der)
+	if err != nil {
+		return nil, fmt.Errorf("parse generated CA certificate: %w", err)
+	}
+
+	return &CertificateAuthority{
+		PrivateKey: priv,
+		PrivatePEM: pem.EncodeToMemory(&pem.Block{
+			Type:  "PRIVATE KEY",
+			Bytes: keyDER,
+		}),
+		Certificate: pem.EncodeToMemory(&pem.Block{
+			Type:  "CERTIFICATE",
+			Bytes: der,
+		}),
+		Fingerprint: certificateFingerprint(cert),
+		NotBefore:   notBefore,
+		NotAfter:    notAfter,
+	}, nil
+}
+
+func certificateFingerprint(cert *x509.Certificate) string {
+	sum := sha256.Sum256(cert.Raw)
+	return "SHA256:" + base64.RawStdEncoding.EncodeToString(sum[:])
+}

--- a/internal/platform/identity/keys_test.go
+++ b/internal/platform/identity/keys_test.go
@@ -1,0 +1,59 @@
+package identity
+
+import (
+	"crypto/x509"
+	"encoding/pem"
+	"testing"
+	"time"
+
+	"golang.org/x/crypto/ssh"
+)
+
+func TestGenerateSigningKeyPair(t *testing.T) {
+	key, err := GenerateSigningKeyPair("test-thane")
+	if err != nil {
+		t.Fatalf("GenerateSigningKeyPair: %v", err)
+	}
+	if len(key.PrivatePEM) == 0 {
+		t.Fatal("PrivatePEM is empty")
+	}
+	if _, err := ssh.ParsePrivateKey(key.PrivatePEM); err != nil {
+		t.Fatalf("generated private key is not parseable: %v", err)
+	}
+	pub, _, _, _, err := ssh.ParseAuthorizedKey([]byte(key.Public))
+	if err != nil {
+		t.Fatalf("generated public key is not parseable: %v", err)
+	}
+	if got := ssh.FingerprintSHA256(pub); got != key.Fingerprint {
+		t.Fatalf("fingerprint = %q, want %q", key.Fingerprint, got)
+	}
+}
+
+func TestGenerateCertificateAuthority(t *testing.T) {
+	now := time.Date(2026, 4, 25, 12, 0, 0, 0, time.UTC)
+	ca, err := GenerateCertificateAuthority("test CA", now)
+	if err != nil {
+		t.Fatalf("GenerateCertificateAuthority: %v", err)
+	}
+	cert, err := ParseCACertificate(ca.Certificate)
+	if err != nil {
+		t.Fatalf("ParseCACertificate: %v", err)
+	}
+	if !cert.IsCA {
+		t.Fatal("generated certificate is not a CA")
+	}
+	if cert.Subject.CommonName != "test CA" {
+		t.Fatalf("CommonName = %q, want test CA", cert.Subject.CommonName)
+	}
+	if got := certificateFingerprint(cert); got != ca.Fingerprint {
+		t.Fatalf("fingerprint = %q, want %q", ca.Fingerprint, got)
+	}
+
+	keyBlock, _ := pem.Decode(ca.PrivatePEM)
+	if keyBlock == nil {
+		t.Fatal("generated CA private key missing PEM block")
+	}
+	if _, err := x509.ParsePKCS8PrivateKey(keyBlock.Bytes); err != nil {
+		t.Fatalf("generated CA private key is not parseable: %v", err)
+	}
+}

--- a/internal/platform/provenance/git.go
+++ b/internal/platform/provenance/git.go
@@ -68,10 +68,20 @@ func (s *Store) ensureRepo() error {
 
 // commitFile stages a file and creates a signed commit.
 func (s *Store) commitFile(ctx context.Context, filename, message string) error {
+	return s.commitFiles(ctx, []string{filename}, message)
+}
 
-	// Stage the file.
-	if err := s.git(ctx, nil, nil, "add", filename); err != nil {
-		return fmt.Errorf("git add %s: %w", filename, err)
+// commitFiles stages files and creates one signed commit containing all
+// staged changes.
+func (s *Store) commitFiles(ctx context.Context, filenames []string, message string) error {
+	if len(filenames) == 0 {
+		return fmt.Errorf("no files to commit")
+	}
+
+	// Stage the files.
+	args := append([]string{"add", "--"}, filenames...)
+	if err := s.git(ctx, nil, nil, args...); err != nil {
+		return fmt.Errorf("git add: %w", err)
 	}
 
 	// Check if there are staged changes — skip commit if nothing changed.
@@ -80,7 +90,7 @@ func (s *Store) commitFile(ctx context.Context, filename, message string) error 
 	diffErr := s.git(ctx, nil, nil, "diff", "--cached", "--quiet")
 	if diffErr == nil {
 		// Exit code 0 means no differences — nothing to commit.
-		s.logger.Debug("no changes to commit", "file", filename)
+		s.logger.Debug("no changes to commit", "files", filenames)
 		return nil
 	}
 	var exitErr *exec.ExitError

--- a/internal/platform/provenance/git.go
+++ b/internal/platform/provenance/git.go
@@ -67,21 +67,21 @@ func (s *Store) ensureRepo() error {
 }
 
 // commitFile stages a file and creates a signed commit.
-func (s *Store) commitFile(ctx context.Context, filename, message string) error {
+func (s *Store) commitFile(ctx context.Context, filename, message string) (bool, error) {
 	return s.commitFiles(ctx, []string{filename}, message)
 }
 
 // commitFiles stages files and creates one signed commit containing all
-// staged changes.
-func (s *Store) commitFiles(ctx context.Context, filenames []string, message string) error {
+// staged changes. It reports whether a commit was created.
+func (s *Store) commitFiles(ctx context.Context, filenames []string, message string) (bool, error) {
 	if len(filenames) == 0 {
-		return fmt.Errorf("no files to commit")
+		return false, fmt.Errorf("no files to commit")
 	}
 
 	// Stage the files.
 	args := append([]string{"add", "--"}, filenames...)
 	if err := s.git(ctx, nil, nil, args...); err != nil {
-		return fmt.Errorf("git add: %w", err)
+		return false, fmt.Errorf("git add: %w", err)
 	}
 
 	// Check if there are staged changes — skip commit if nothing changed.
@@ -91,17 +91,17 @@ func (s *Store) commitFiles(ctx context.Context, filenames []string, message str
 	if diffErr == nil {
 		// Exit code 0 means no differences — nothing to commit.
 		s.logger.Debug("no changes to commit", "files", filenames)
-		return nil
+		return false, nil
 	}
 	var exitErr *exec.ExitError
 	if errors.As(diffErr, &exitErr) && exitErr.ExitCode() != 1 {
-		return fmt.Errorf("git diff --cached: %w", diffErr)
+		return false, fmt.Errorf("git diff --cached: %w", diffErr)
 	}
 
 	// Get the tree hash.
 	var treeBuf bytes.Buffer
 	if err := s.git(ctx, nil, &treeBuf, "write-tree"); err != nil {
-		return fmt.Errorf("git write-tree: %w", err)
+		return false, fmt.Errorf("git write-tree: %w", err)
 	}
 	tree := strings.TrimSpace(treeBuf.String())
 
@@ -139,7 +139,7 @@ func (s *Store) commitFiles(ctx context.Context, filenames []string, message str
 	commitForSigning := commitObj.String() + "\n" + message + "\n"
 	armoredSig, err := s.signer.Sign([]byte(commitForSigning))
 	if err != nil {
-		return fmt.Errorf("sign commit: %w", err)
+		return false, fmt.Errorf("sign commit: %w", err)
 	}
 
 	// Insert the gpgsig header between the last header line and the
@@ -157,23 +157,23 @@ func (s *Store) commitFiles(ctx context.Context, filenames []string, message str
 	commitBytes := []byte(commitObj.String())
 	if err := s.git(ctx, bytes.NewReader(commitBytes), &hashBuf,
 		"hash-object", "-t", "commit", "-w", "--stdin"); err != nil {
-		return fmt.Errorf("git hash-object: %w", err)
+		return false, fmt.Errorf("git hash-object: %w", err)
 	}
 	commitHash := strings.TrimSpace(hashBuf.String())
 
 	// Update HEAD to point to the new commit.
 	if err := s.git(ctx, nil, nil,
 		"update-ref", "HEAD", commitHash); err != nil {
-		return fmt.Errorf("git update-ref: %w", err)
+		return false, fmt.Errorf("git update-ref: %w", err)
 	}
 
 	// Reset the index to match HEAD so subsequent operations see a
 	// clean working tree.
 	if err := s.git(ctx, nil, nil, "reset", "--mixed", "HEAD"); err != nil {
-		return fmt.Errorf("git reset: %w", err)
+		return false, fmt.Errorf("git reset: %w", err)
 	}
 
-	return nil
+	return true, nil
 }
 
 // fileHistory reads git log for a file and returns structured metadata.

--- a/internal/platform/provenance/provenance.go
+++ b/internal/platform/provenance/provenance.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -211,6 +212,50 @@ func (s *Store) Write(ctx context.Context, filename, content, message string) er
 	s.logger.Info("provenance file committed",
 		"file", filename,
 		"bytes", len(content),
+		"message", message,
+	)
+
+	return nil
+}
+
+// WriteFiles writes multiple files within the store and creates one
+// signed git commit containing all resulting changes. Filenames are
+// relative to the store root. Parent directories are created
+// automatically. If all target files already contain the requested
+// content, no commit is created.
+func (s *Store) WriteFiles(ctx context.Context, files map[string]string, message string) error {
+	if len(files) == 0 {
+		return fmt.Errorf("provenance: no files to write")
+	}
+
+	filenames := make([]string, 0, len(files))
+	for filename := range files {
+		if err := validateFilename(filename); err != nil {
+			return fmt.Errorf("provenance: %w", err)
+		}
+		filenames = append(filenames, filename)
+	}
+	sort.Strings(filenames)
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	for _, filename := range filenames {
+		absPath := filepath.Join(s.path, filename)
+		if err := os.MkdirAll(filepath.Dir(absPath), 0o755); err != nil {
+			return fmt.Errorf("provenance: create directory for %s: %w", filename, err)
+		}
+		if err := os.WriteFile(absPath, []byte(files[filename]), 0o644); err != nil {
+			return fmt.Errorf("provenance: write %s: %w", filename, err)
+		}
+	}
+
+	if err := s.commitFiles(ctx, filenames, message); err != nil {
+		return fmt.Errorf("provenance: commit files: %w", err)
+	}
+
+	s.logger.Info("provenance files committed",
+		"files", filenames,
 		"message", message,
 	)
 

--- a/internal/platform/provenance/provenance.go
+++ b/internal/platform/provenance/provenance.go
@@ -205,15 +205,18 @@ func (s *Store) Write(ctx context.Context, filename, content, message string) er
 		return fmt.Errorf("provenance: write %s: %w", filename, err)
 	}
 
-	if err := s.commitFile(ctx, filename, message); err != nil {
+	committed, err := s.commitFile(ctx, filename, message)
+	if err != nil {
 		return fmt.Errorf("provenance: commit %s: %w", filename, err)
 	}
 
-	s.logger.Info("provenance file committed",
-		"file", filename,
-		"bytes", len(content),
-		"message", message,
-	)
+	if committed {
+		s.logger.Info("provenance file committed",
+			"file", filename,
+			"bytes", len(content),
+			"message", message,
+		)
+	}
 
 	return nil
 }
@@ -250,14 +253,17 @@ func (s *Store) WriteFiles(ctx context.Context, files map[string]string, message
 		}
 	}
 
-	if err := s.commitFiles(ctx, filenames, message); err != nil {
+	committed, err := s.commitFiles(ctx, filenames, message)
+	if err != nil {
 		return fmt.Errorf("provenance: commit files: %w", err)
 	}
 
-	s.logger.Info("provenance files committed",
-		"files", filenames,
-		"message", message,
-	)
+	if committed {
+		s.logger.Info("provenance files committed",
+			"files", filenames,
+			"message", message,
+		)
+	}
 
 	return nil
 }
@@ -265,10 +271,16 @@ func (s *Store) WriteFiles(ctx context.Context, files map[string]string, message
 // validateFilename rejects filenames that could escape the store root
 // via path traversal or absolute paths.
 func validateFilename(filename string) error {
+	if filename == "" {
+		return fmt.Errorf("empty filename not allowed")
+	}
 	if filepath.IsAbs(filename) {
 		return fmt.Errorf("absolute path not allowed: %s", filename)
 	}
 	cleaned := filepath.Clean(filename)
+	if cleaned == "." {
+		return fmt.Errorf("current directory filename not allowed: %s", filename)
+	}
 	if cleaned == ".." || strings.HasPrefix(cleaned, ".."+string(filepath.Separator)) {
 		return fmt.Errorf("path traversal not allowed: %s", filename)
 	}

--- a/internal/platform/provenance/provenance_test.go
+++ b/internal/platform/provenance/provenance_test.go
@@ -97,6 +97,45 @@ func TestStoreWriteCreatesSubdirectories(t *testing.T) {
 	}
 }
 
+func TestStoreWriteFilesCreatesSingleCommit(t *testing.T) {
+	s := testStore(t)
+
+	if err := s.WriteFiles(t.Context(), map[string]string{
+		"alpha.txt":      "alpha",
+		"nested/beta.md": "beta",
+	}, "bootstrap"); err != nil {
+		t.Fatalf("WriteFiles: %v", err)
+	}
+
+	for name, want := range map[string]string{
+		"alpha.txt":      "alpha",
+		"nested/beta.md": "beta",
+	} {
+		got, err := s.Read(name)
+		if err != nil {
+			t.Fatalf("Read %s: %v", name, err)
+		}
+		if got != want {
+			t.Fatalf("Read %s = %q, want %q", name, got, want)
+		}
+		hist, err := s.History(t.Context(), name)
+		if err != nil {
+			t.Fatalf("History %s: %v", name, err)
+		}
+		if hist.RevisionCount != 1 || hist.LastMessage != "bootstrap" {
+			t.Fatalf("History %s = %+v, want one bootstrap commit", name, hist)
+		}
+	}
+}
+
+func TestStoreWriteFilesRejectsEmptySet(t *testing.T) {
+	s := testStore(t)
+
+	if err := s.WriteFiles(t.Context(), map[string]string{}, "empty"); err == nil {
+		t.Fatal("WriteFiles empty set returned nil, want error")
+	}
+}
+
 func TestStoreWriteNoChangeSkipsCommit(t *testing.T) {
 	s := testStore(t)
 

--- a/internal/platform/provenance/provenance_test.go
+++ b/internal/platform/provenance/provenance_test.go
@@ -136,6 +136,28 @@ func TestStoreWriteFilesRejectsEmptySet(t *testing.T) {
 	}
 }
 
+func TestStoreWriteRejectsEmptyOrDotFilename(t *testing.T) {
+	s := testStore(t)
+
+	for _, tc := range []struct {
+		name     string
+		filename string
+	}{
+		{name: "empty", filename: ""},
+		{name: "dot", filename: "."},
+		{name: "dot-slash", filename: "./"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := s.Write(t.Context(), tc.filename, "content", "bad"); err == nil {
+				t.Fatal("Write returned nil, want error")
+			}
+			if err := s.WriteFiles(t.Context(), map[string]string{tc.filename: "content"}, "bad"); err == nil {
+				t.Fatal("WriteFiles returned nil, want error")
+			}
+		})
+	}
+}
+
 func TestStoreWriteNoChangeSkipsCommit(t *testing.T) {
 	s := testStore(t)
 
@@ -155,6 +177,31 @@ func TestStoreWriteNoChangeSkipsCommit(t *testing.T) {
 
 	if hist.RevisionCount != 1 {
 		t.Errorf("RevisionCount = %d, want 1 (no-change write should not create commit)", hist.RevisionCount)
+	}
+}
+
+func TestStoreWriteFilesNoChangeSkipsCommit(t *testing.T) {
+	s := testStore(t)
+
+	files := map[string]string{
+		"alpha.txt":      "alpha",
+		"nested/beta.md": "beta",
+	}
+	if err := s.WriteFiles(t.Context(), files, "first"); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.WriteFiles(t.Context(), files, "second"); err != nil {
+		t.Fatal(err)
+	}
+
+	for filename := range files {
+		hist, err := s.History(t.Context(), filename)
+		if err != nil {
+			t.Fatalf("History %s: %v", filename, err)
+		}
+		if hist.RevisionCount != 1 || hist.LastMessage != "first" {
+			t.Fatalf("History %s = %+v, want one first commit", filename, hist)
+		}
 	}
 }
 

--- a/scripts/architecture.baseline
+++ b/scripts/architecture.baseline
@@ -1,4 +1,4 @@
-packages=51
+packages=52
 interfaces=72
 large_files=31
 set_mutators=103


### PR DESCRIPTION
## Summary

Closes #695.

This teaches `thane init` to establish a local core identity root the first time an instance is initialized. The bootstrap creates `core/` and generates two separate pieces of Ed25519 key material:

- an SSH signing key at `core/identity/signing_ed25519` with its public key at `core/identity/signing_ed25519.pub`, used for git/provenance signatures
- an X.509 channel CA private key at `core/ca/channel_root.key` with its self-signed CA certificate at `core/ca/channel_root.crt`, intended as the future trust anchor for secure Thane-to-Thane channel work

Private keys are written with `0600` permissions and kept out of git. Public identity artifacts, `.allowed_signers`, `.gitignore`, the channel CA certificate, and `core/config.yaml` are committed together as one SSH-signed birth commit so the instance starts with an auditable cryptographic origin.

The PR also adds a small `internal/platform/identity` package for key generation and bootstrap policy rendering, plus a multi-file signed write path in provenance so related bootstrap artifacts share one commit. The trust architecture docs call this out as foundation work; peer CA exchange, delegation certificates, inherited-trust enforcement, leaf channel certificate issuance, and transport mTLS remain runtime follow-ups rather than being smuggled into init.

## Test Plan

- [x] `just ci` passes locally
- [x] New/changed behavior has test coverage
- [x] Manual verification: checked the created commit signature with `git log -1 --show-signature --pretty=fuller`

## Checklist

- [x] Commits are signed
- [x] Commit messages use conventional format (`feat:`, `fix:`, etc.)
- [x] Related issue referenced (`Refs #NNN` or `Closes #NNN`)
- [x] Impacted documentation updated (`docs/`, `AGENTS.md`, config examples, CLI help)
- [x] No new third-party dependencies without discussion