### PR TITLE
feat: tags_all frontmatter for intersection-gated KB articles

### DIFF
--- a/internal/model/talents/loader.go
+++ b/internal/model/talents/loader.go
@@ -31,8 +31,16 @@ type Talent struct {
 
 // Frontmatter captures the subset of markdown metadata Thane currently
 // understands for talents and tagged KB articles.
+//
+// Tags and TagsAll compose with different semantics in the article
+// matcher: any tag in Tags activates the article (OR), every tag in
+// TagsAll must be active (AND). When both are non-empty the matcher
+// requires the OR check to pass AND the AND check to pass — useful
+// for articles that should fire for several entry-point tags but only
+// when paired with a runtime-asserted gate (e.g., owner + signal).
 type Frontmatter struct {
 	Tags     []string
+	TagsAll  []string
 	Kind     string
 	Teaser   string
 	NextTags []string
@@ -215,22 +223,10 @@ func parseFrontmatterLines(frontmatter string) Frontmatter {
 	for _, line := range strings.Split(frontmatter, "\n") {
 		line = strings.TrimSpace(line)
 		switch {
+		case strings.HasPrefix(line, "tags_all:"):
+			meta.TagsAll = parseFrontmatterTagList(strings.TrimPrefix(line, "tags_all:"))
 		case strings.HasPrefix(line, "tags:"):
-			value := strings.TrimPrefix(line, "tags:")
-			value = strings.TrimSpace(value)
-
-			// Handle [a, b, c] format.
-			value = strings.TrimPrefix(value, "[")
-			value = strings.TrimSuffix(value, "]")
-
-			var tags []string
-			for _, part := range strings.Split(value, ",") {
-				tag := strings.Trim(strings.TrimSpace(part), `"'`)
-				if tag != "" {
-					tags = append(tags, tag)
-				}
-			}
-			meta.Tags = tags
+			meta.Tags = parseFrontmatterTagList(strings.TrimPrefix(line, "tags:"))
 		case strings.HasPrefix(line, "kind:"):
 			value := strings.TrimSpace(strings.TrimPrefix(line, "kind:"))
 			value = strings.Trim(value, `"'`)
@@ -240,22 +236,30 @@ func parseFrontmatterLines(frontmatter string) Frontmatter {
 			value = strings.Trim(value, `"'`)
 			meta.Teaser = value
 		case strings.HasPrefix(line, "next_tags:"):
-			value := strings.TrimSpace(strings.TrimPrefix(line, "next_tags:"))
-			value = strings.TrimPrefix(value, "[")
-			value = strings.TrimSuffix(value, "]")
-			var tags []string
-			for _, part := range strings.Split(value, ",") {
-				tag := strings.Trim(strings.TrimSpace(part), `"'`)
-				if tag != "" {
-					tags = append(tags, tag)
-				}
-			}
-			meta.NextTags = tags
+			meta.NextTags = parseFrontmatterTagList(strings.TrimPrefix(line, "next_tags:"))
 		default:
 			continue
 		}
 	}
 	return meta
+}
+
+// parseFrontmatterTagList parses a YAML inline list of tag-like strings
+// from the value side of a frontmatter line. Accepts the bracket form
+// `[a, b, "c"]` and an unbracketed comma-separated form. Empty entries
+// are skipped and quotes are trimmed.
+func parseFrontmatterTagList(value string) []string {
+	value = strings.TrimSpace(value)
+	value = strings.TrimPrefix(value, "[")
+	value = strings.TrimSuffix(value, "]")
+	var tags []string
+	for _, part := range strings.Split(value, ",") {
+		tag := strings.Trim(strings.TrimSpace(part), `"'`)
+		if tag != "" {
+			tags = append(tags, tag)
+		}
+	}
+	return tags
 }
 
 // ManifestEntry describes a capability tag for the auto-generated manifest.

--- a/internal/model/talents/loader_test.go
+++ b/internal/model/talents/loader_test.go
@@ -492,3 +492,70 @@ func writeFile(t *testing.T, dir, name, content string) {
 		t.Fatalf("write %s: %v", name, err)
 	}
 }
+
+func TestParseFrontmatterMetadata_TagsAll(t *testing.T) {
+	cases := []struct {
+		name        string
+		raw         string
+		wantTags    []string
+		wantTagsAll []string
+	}{
+		{
+			name: "tags_all alone",
+			raw: `---
+tags_all: [owner, message_channel]
+---
+body`,
+			wantTagsAll: []string{"owner", "message_channel"},
+		},
+		{
+			name: "tags and tags_all together",
+			raw: `---
+tags: [forge, ha]
+tags_all: [owner]
+---
+body`,
+			wantTags:    []string{"forge", "ha"},
+			wantTagsAll: []string{"owner"},
+		},
+		{
+			name: "tags_all with quoted entries",
+			raw: `---
+tags_all: ["a", 'b']
+---
+body`,
+			wantTagsAll: []string{"a", "b"},
+		},
+		{
+			name: "tags_all empty list",
+			raw: `---
+tags_all: []
+---
+body`,
+			wantTagsAll: nil,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			meta, _ := ParseFrontmatterMetadata(tc.raw)
+			if !equalStrings(meta.Tags, tc.wantTags) {
+				t.Errorf("Tags = %v, want %v", meta.Tags, tc.wantTags)
+			}
+			if !equalStrings(meta.TagsAll, tc.wantTagsAll) {
+				t.Errorf("TagsAll = %v, want %v", meta.TagsAll, tc.wantTagsAll)
+			}
+		})
+	}
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/platform/config/config.go
+++ b/internal/platform/config/config.go
@@ -1105,15 +1105,16 @@ type CapabilityTagConfig struct {
 }
 
 // Validate checks that the capability tag configuration is internally
-// consistent. It ensures a description is present and the tools list is
-// non-empty. Tag names are validated by the caller since they are map
-// keys in the parent Config struct.
+// consistent. A description is required for non-builtin tags so the
+// operator-defined intent is documented in the capability menu. Tools
+// are optional — capability tags also gate talents, KB articles
+// (via `tags:` and `tags_all:` frontmatter), and tag-context providers,
+// so a content-only tag with no tool membership is a legitimate shape.
+// Tag names are validated by the caller since they are map keys in the
+// parent Config struct.
 func (c CapabilityTagConfig) Validate(tagName string, builtin bool) error {
 	if strings.TrimSpace(c.Description) == "" && !builtin {
 		return fmt.Errorf("capability_tags.%s.description must not be empty", tagName)
-	}
-	if len(c.Tools) == 0 && !builtin {
-		return fmt.Errorf("capability_tags.%s.tools must not be empty", tagName)
 	}
 	return nil
 }

--- a/internal/platform/config/config_test.go
+++ b/internal/platform/config/config_test.go
@@ -493,18 +493,17 @@ func TestValidate_CapabilityTagEmptyDescription(t *testing.T) {
 	}
 }
 
-func TestValidate_CapabilityTagEmptyTools(t *testing.T) {
+func TestValidate_CapabilityTagEmptyToolsAllowed(t *testing.T) {
+	// Tags can exist purely to gate content (talents, KB articles via
+	// tags_all/tags frontmatter, tag-context providers) without owning
+	// any tools. Validation must allow that shape.
 	cfg := Default()
 	cfg.CapabilityTags = map[string]CapabilityTagConfig{
-		"custom": {Description: "Web search", Tools: nil},
+		"signal_channel": {Description: "Runtime gate for Signal-channel context.", Tools: nil},
 	}
 
-	err := cfg.Validate()
-	if err == nil {
-		t.Fatal("expected validation error for empty tools")
-	}
-	if !strings.Contains(err.Error(), "capability_tags.custom.tools") {
-		t.Errorf("error should mention capability_tags.custom.tools, got: %v", err)
+	if err := cfg.Validate(); err != nil {
+		t.Errorf("content-only tag rejected: %v", err)
 	}
 }
 
@@ -532,21 +531,21 @@ func TestValidate_CapabilityTagValid(t *testing.T) {
 	}
 }
 
-func TestValidate_CapabilityTagNoTools(t *testing.T) {
+func TestValidate_CapabilityTagContentOnlyValid(t *testing.T) {
+	// Companion of TestValidate_CapabilityTagEmptyToolsAllowed — a
+	// purely content-gating tag (no tools, just a description) is a
+	// valid first-class shape after the empty-tools requirement was
+	// dropped.
 	cfg := Default()
 	cfg.CapabilityTags = map[string]CapabilityTagConfig{
 		"docs": {
 			Description: "Documentation context",
-			Tools:       nil, // tools are required
+			Tools:       nil,
 		},
 	}
 
-	err := cfg.Validate()
-	if err == nil {
-		t.Fatal("expected validation error for tag with no tools")
-	}
-	if !strings.Contains(err.Error(), "capability_tags.docs.tools") {
-		t.Errorf("error should mention capability_tags.docs.tools, got: %v", err)
+	if err := cfg.Validate(); err != nil {
+		t.Errorf("content-only tag rejected: %v", err)
 	}
 }
 

--- a/internal/runtime/agent/tag_context.go
+++ b/internal/runtime/agent/tag_context.go
@@ -27,12 +27,11 @@ import (
 // to avoid duplicating the assembly logic. The assembler is safe for
 // concurrent use after construction.
 type TagContextAssembler struct {
-	capTags    map[string]config.CapabilityTagConfig
-	kbDir      string
-	resolver   *paths.Resolver
-	kbArticles []kbArticle                // pre-scanned, sorted
-	haInject   homeassistant.StateFetcher // nil-safe — delegates pass nil
-	logger     *slog.Logger
+	capTags  map[string]config.CapabilityTagConfig
+	kbDir    string
+	resolver *paths.Resolver
+	haInject homeassistant.StateFetcher // nil-safe — delegates pass nil
+	logger   *slog.Logger
 }
 
 // kbArticle is a knowledge base file with tag affinity parsed from
@@ -69,32 +68,42 @@ type TagContextAssemblerConfig struct {
 	Logger   *slog.Logger
 }
 
-// NewTagContextAssembler creates an assembler, scanning the KB directory
-// for tagged articles at construction time. KB scan errors are logged
-// but do not prevent construction.
+// NewTagContextAssembler creates an assembler. The KB directory is
+// scanned lazily — the article list (paths and tag affinity) is
+// re-read from disk on every consumer call (Build, KBArticleTags,
+// KBMenuHints), so frontmatter edits, additions, and deletions
+// propagate without a process restart. Scans are cheap (a directory
+// walk plus a frontmatter parse per .md file) and run once per
+// consumer call, not once per article.
 func NewTagContextAssembler(cfg TagContextAssemblerConfig) *TagContextAssembler {
 	if cfg.Logger == nil {
 		cfg.Logger = slog.Default()
 	}
-
-	var articles []kbArticle
-	if cfg.KBDir != "" {
-		var err error
-		articles, err = scanKBArticles(cfg.KBDir)
-		if err != nil {
-			cfg.Logger.Warn("failed to scan KB directory for tagged articles",
-				"dir", cfg.KBDir, "error", err)
-		}
-	}
-
 	return &TagContextAssembler{
-		capTags:    cfg.CapTags,
-		kbDir:      cfg.KBDir,
-		resolver:   cfg.Resolver,
-		kbArticles: articles,
-		haInject:   cfg.HAInject,
-		logger:     cfg.Logger,
+		capTags:  cfg.CapTags,
+		kbDir:    cfg.KBDir,
+		resolver: cfg.Resolver,
+		haInject: cfg.HAInject,
+		logger:   cfg.Logger,
 	}
+}
+
+// loadKBArticles returns the current list of tag-aware KB articles by
+// scanning kbDir fresh. Scan errors are logged and the call returns an
+// empty slice, matching the prior constructor behavior. Callers that
+// need a stable snapshot within a single operation (e.g., Build) call
+// this once and iterate the result locally.
+func (a *TagContextAssembler) loadKBArticles() []kbArticle {
+	if a.kbDir == "" {
+		return nil
+	}
+	articles, err := scanKBArticles(a.kbDir)
+	if err != nil {
+		a.logger.Warn("failed to scan KB directory for tagged articles",
+			"dir", a.kbDir, "error", err)
+		return nil
+	}
+	return articles
 }
 
 // Build assembles tag context for the given active tags. Providers
@@ -110,11 +119,13 @@ func (a *TagContextAssembler) Build(ctx context.Context, activeTags map[string]b
 	seen := make(map[string]bool)
 	var buf strings.Builder
 
-	// Phase 1: Tagged KB articles (re-read each turn for freshness).
-	// KB articles declare tag affinity via frontmatter — `tags:` for
-	// any-of activation and `tags_all:` for all-of (intersection)
-	// activation. Both compose; see [articleMatchesTags].
-	for _, article := range a.kbArticles {
+	// Phase 1: Tagged KB articles (re-scanned and re-read each turn
+	// for freshness — frontmatter edits, additions, and deletions all
+	// propagate without a restart). Articles declare tag affinity via
+	// frontmatter: `tags:` for any-of activation, `tags_all:` for
+	// all-of activation. Both compose; see [articleMatchesTags].
+	articles := a.loadKBArticles()
+	for _, article := range articles {
 		if !articleMatchesTags(article, activeTags) {
 			continue
 		}
@@ -299,15 +310,29 @@ func (a *TagContextAssembler) appendContent(buf *strings.Builder, data []byte) {
 }
 
 // KBArticleTags returns the tag→article count index, useful for
-// enriching the capability manifest with KB article counts.
+// enriching the capability manifest with KB article counts. Both
+// `tags:` (any-of) and `tags_all:` (all-of) memberships count — a
+// `tags_all`-only article would otherwise be invisible to the menu
+// surface despite gating real content. Tags appearing in both lists
+// of the same article count once.
 func (a *TagContextAssembler) KBArticleTags() map[string]int {
 	if a == nil {
 		return nil
 	}
 	counts := make(map[string]int)
-	for _, article := range a.kbArticles {
+	for _, article := range a.loadKBArticles() {
+		seen := make(map[string]bool, len(article.Tags)+len(article.TagsAll))
 		for _, tag := range article.Tags {
-			counts[tag]++
+			if !seen[tag] {
+				seen[tag] = true
+				counts[tag]++
+			}
+		}
+		for _, tag := range article.TagsAll {
+			if !seen[tag] {
+				seen[tag] = true
+				counts[tag]++
+			}
 		}
 	}
 	return counts
@@ -321,7 +346,7 @@ func (a *TagContextAssembler) KBMenuHints() map[string]KBMenuHint {
 		return nil
 	}
 	hints := make(map[string]KBMenuHint)
-	for _, article := range a.kbArticles {
+	for _, article := range a.loadKBArticles() {
 		if !isEntryPointKind(article.Kind) {
 			continue
 		}

--- a/internal/runtime/agent/tag_context.go
+++ b/internal/runtime/agent/tag_context.go
@@ -17,8 +17,9 @@ import (
 // TagContextAssembler builds the Capability Context section from two
 // sources for each active tag:
 //
-//  1. Tagged KB articles — markdown files with tags: frontmatter in the
-//     knowledge base directory (same pattern as talents)
+//  1. Tagged KB articles — markdown files in the knowledge base
+//     directory with `tags:` (any-of) and/or `tags_all:` (all-of)
+//     frontmatter, same pattern as talents.
 //  2. Live providers — [TagContextProvider] implementations producing
 //     fresh context each turn
 //
@@ -35,10 +36,16 @@ type TagContextAssembler struct {
 }
 
 // kbArticle is a knowledge base file with tag affinity parsed from
-// frontmatter. Reuses the talent frontmatter format: tags: [a, b].
+// frontmatter. Reuses the talent frontmatter format: `tags: [a, b]`
+// activates on any (OR), `tags_all: [a, b]` requires all (AND).
+// When both are set, the article injects only when the OR check on
+// Tags AND the AND check on TagsAll both pass — useful for articles
+// that should fire for several entry-point tags but only when paired
+// with a runtime-asserted gate (e.g., owner + signal).
 type kbArticle struct {
 	Path     string   // absolute file path
-	Tags     []string // from frontmatter
+	Tags     []string // any-of activation set, from frontmatter `tags:`
+	TagsAll  []string // all-of activation set, from frontmatter `tags_all:`
 	Kind     string   // frontmatter kind: entry_point or empty/article
 	Teaser   string   // short menu teaser for entry-point docs
 	NextTags []string // suggested next tags from an entry point
@@ -104,8 +111,9 @@ func (a *TagContextAssembler) Build(ctx context.Context, activeTags map[string]b
 	var buf strings.Builder
 
 	// Phase 1: Tagged KB articles (re-read each turn for freshness).
-	// KB articles declare their tag affinity via frontmatter
-	// (tags: [forge, ha]) and auto-load when matching tags are active.
+	// KB articles declare tag affinity via frontmatter — `tags:` for
+	// any-of activation and `tags_all:` for all-of (intersection)
+	// activation. Both compose; see [articleMatchesTags].
 	for _, article := range a.kbArticles {
 		if !articleMatchesTags(article, activeTags) {
 			continue
@@ -365,13 +373,14 @@ func scanKBArticles(dir string) ([]kbArticle, error) {
 		}
 
 		meta, _ := talents.ParseFrontmatterMetadata(string(data))
-		if len(meta.Tags) == 0 {
+		if len(meta.Tags) == 0 && len(meta.TagsAll) == 0 {
 			return nil // untagged KB articles are not auto-loaded
 		}
 
 		articles = append(articles, kbArticle{
 			Path:     path,
 			Tags:     meta.Tags,
+			TagsAll:  append([]string(nil), meta.TagsAll...),
 			Kind:     strings.TrimSpace(meta.Kind),
 			Teaser:   strings.TrimSpace(meta.Teaser),
 			NextTags: append([]string(nil), meta.NextTags...),
@@ -397,9 +406,28 @@ func scanKBArticles(dir string) ([]kbArticle, error) {
 	return articles, nil
 }
 
-// articleMatchesTags returns true if any of the article's tags are in
-// the active set.
+// articleMatchesTags reports whether an article should inject given
+// the currently active tag set. Semantics:
+//
+//   - When TagsAll is non-empty, every tag in TagsAll must be active.
+//     This is the AND gate for narrowly-scoped articles.
+//   - When Tags is non-empty, at least one tag must be active. This
+//     is the OR activation set.
+//   - When both are set, the article injects only when both checks
+//     pass — `(any of Tags) AND (all of TagsAll)`.
+//   - When only TagsAll is set (no Tags), the AND check alone gates
+//     the article.
 func articleMatchesTags(a kbArticle, activeTags map[string]bool) bool {
+	if len(a.TagsAll) > 0 {
+		for _, tag := range a.TagsAll {
+			if !activeTags[tag] {
+				return false
+			}
+		}
+		if len(a.Tags) == 0 {
+			return true
+		}
+	}
 	for _, tag := range a.Tags {
 		if activeTags[tag] {
 			return true

--- a/internal/runtime/agent/tag_context_test.go
+++ b/internal/runtime/agent/tag_context_test.go
@@ -618,3 +618,92 @@ func TestBuildSystemPrompt_TagContextViaProvider(t *testing.T) {
 		t.Error("system prompt should contain capability context heading")
 	}
 }
+
+func TestArticleMatchesTags_OrSemantics(t *testing.T) {
+	a := kbArticle{Tags: []string{"forge", "ha"}}
+
+	if !articleMatchesTags(a, map[string]bool{"forge": true}) {
+		t.Error("expected match when forge is active")
+	}
+	if !articleMatchesTags(a, map[string]bool{"ha": true}) {
+		t.Error("expected match when ha is active")
+	}
+	if !articleMatchesTags(a, map[string]bool{"forge": true, "ha": true}) {
+		t.Error("expected match when both are active")
+	}
+	if articleMatchesTags(a, map[string]bool{"unrelated": true}) {
+		t.Error("expected no match when only an unlisted tag is active")
+	}
+}
+
+func TestArticleMatchesTags_AndSemantics(t *testing.T) {
+	// tags_all only: every tag must be active.
+	a := kbArticle{TagsAll: []string{"owner", "message_channel"}}
+
+	if articleMatchesTags(a, map[string]bool{"owner": true}) {
+		t.Error("expected no match when only owner is active")
+	}
+	if articleMatchesTags(a, map[string]bool{"message_channel": true}) {
+		t.Error("expected no match when only message_channel is active")
+	}
+	if !articleMatchesTags(a, map[string]bool{"owner": true, "message_channel": true}) {
+		t.Error("expected match when both required tags are active")
+	}
+	if !articleMatchesTags(a, map[string]bool{"owner": true, "message_channel": true, "extra": true}) {
+		t.Error("expected match with extra tags active too")
+	}
+}
+
+func TestArticleMatchesTags_OrAndCombined(t *testing.T) {
+	// (any of Tags) AND (all of TagsAll). Useful for "fires for several
+	// entry-point tags, but only when paired with a runtime gate."
+	a := kbArticle{
+		Tags:    []string{"forge", "ha"},
+		TagsAll: []string{"owner"},
+	}
+
+	cases := []struct {
+		name   string
+		active map[string]bool
+		want   bool
+	}{
+		{"or-only", map[string]bool{"forge": true}, false},
+		{"and-only", map[string]bool{"owner": true}, false},
+		{"both-via-forge", map[string]bool{"forge": true, "owner": true}, true},
+		{"both-via-ha", map[string]bool{"ha": true, "owner": true}, true},
+		{"neither", map[string]bool{"unrelated": true}, false},
+		{"all-three", map[string]bool{"forge": true, "ha": true, "owner": true}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := articleMatchesTags(a, tc.active); got != tc.want {
+				t.Errorf("active=%v: got %v, want %v", tc.active, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestTagContextAssembler_TagsAllArticleInjects(t *testing.T) {
+	kbDir := t.TempDir()
+	os.WriteFile(filepath.Join(kbDir, "owner-signal-bundle.md"),
+		[]byte("---\ntags_all: [owner, message_channel]\n---\n# Owner-Signal Bundle"), 0o644)
+
+	a := NewTagContextAssembler(TagContextAssemblerConfig{
+		CapTags: map[string]config.CapabilityTagConfig{"owner": {}, "message_channel": {}},
+		KBDir:   kbDir,
+	})
+
+	// Either tag alone: silent.
+	if got := a.Build(context.Background(), map[string]bool{"owner": true}, nil); strings.Contains(got, "Owner-Signal Bundle") {
+		t.Errorf("article injected with only owner active:\n%s", got)
+	}
+	if got := a.Build(context.Background(), map[string]bool{"message_channel": true}, nil); strings.Contains(got, "Owner-Signal Bundle") {
+		t.Errorf("article injected with only message_channel active:\n%s", got)
+	}
+
+	// Intersection: injects.
+	got := a.Build(context.Background(), map[string]bool{"owner": true, "message_channel": true}, nil)
+	if !strings.Contains(got, "Owner-Signal Bundle") {
+		t.Errorf("article missing when both required tags active:\n%s", got)
+	}
+}

--- a/internal/runtime/agent/tag_context_test.go
+++ b/internal/runtime/agent/tag_context_test.go
@@ -707,3 +707,105 @@ func TestTagContextAssembler_TagsAllArticleInjects(t *testing.T) {
 		t.Errorf("article missing when both required tags active:\n%s", got)
 	}
 }
+
+func TestTagContextAssembler_LiveFrontmatterPickup(t *testing.T) {
+	// Frontmatter edits, additions, and deletions all propagate on the
+	// next Build call — no process restart required. Each Build
+	// re-scans the KB directory.
+	kbDir := t.TempDir()
+
+	a := NewTagContextAssembler(TagContextAssemblerConfig{
+		CapTags: map[string]config.CapabilityTagConfig{"forge": {}, "ha": {}},
+		KBDir:   kbDir,
+	})
+
+	// First Build: empty dir, nothing injects.
+	if got := a.Build(context.Background(), map[string]bool{"forge": true}, nil); got != "" {
+		t.Errorf("expected empty output before any articles exist, got: %s", got)
+	}
+
+	// Add an article tagged forge — next Build should pick it up
+	// without reconstruction.
+	articlePath := filepath.Join(kbDir, "forge.md")
+	if err := os.WriteFile(articlePath,
+		[]byte("---\ntags: [forge]\n---\nFORGE_V1"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got := a.Build(context.Background(), map[string]bool{"forge": true}, nil)
+	if !strings.Contains(got, "FORGE_V1") {
+		t.Errorf("new article not picked up:\n%s", got)
+	}
+
+	// Edit the article body — next Build should see the new content.
+	if err := os.WriteFile(articlePath,
+		[]byte("---\ntags: [forge]\n---\nFORGE_V2"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got = a.Build(context.Background(), map[string]bool{"forge": true}, nil)
+	if !strings.Contains(got, "FORGE_V2") {
+		t.Errorf("body edit not picked up:\n%s", got)
+	}
+	if strings.Contains(got, "FORGE_V1") {
+		t.Errorf("stale content from first Build leaked through:\n%s", got)
+	}
+
+	// Change the frontmatter to retag the article — must propagate
+	// without restart. Activate `ha` instead and confirm.
+	if err := os.WriteFile(articlePath,
+		[]byte("---\ntags: [ha]\n---\nFORGE_V2"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got := a.Build(context.Background(), map[string]bool{"forge": true}, nil); strings.Contains(got, "FORGE_V2") {
+		t.Errorf("retagged article still firing for forge:\n%s", got)
+	}
+	got = a.Build(context.Background(), map[string]bool{"ha": true}, nil)
+	if !strings.Contains(got, "FORGE_V2") {
+		t.Errorf("retagged article not firing for ha:\n%s", got)
+	}
+
+	// Delete the article — next Build should be silent.
+	if err := os.Remove(articlePath); err != nil {
+		t.Fatal(err)
+	}
+	if got := a.Build(context.Background(), map[string]bool{"ha": true}, nil); got != "" {
+		t.Errorf("deleted article still appearing:\n%s", got)
+	}
+}
+
+func TestKBArticleTags_CountsTagsAll(t *testing.T) {
+	// Regression for PR #763 review: KBArticleTags previously counted
+	// only article.Tags, so tags_all-only articles were invisible to
+	// the capability surface. Both lists must contribute, with within-
+	// article dedup so tags appearing in both lists count once.
+	kbDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(kbDir, "or.md"),
+		[]byte("---\ntags: [forge, ha]\n---\nbody"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(kbDir, "and-only.md"),
+		[]byte("---\ntags_all: [owner, signal_channel]\n---\nbody"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(kbDir, "mixed.md"),
+		[]byte("---\ntags: [forge]\ntags_all: [forge, owner]\n---\nbody"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	a := NewTagContextAssembler(TagContextAssemblerConfig{KBDir: kbDir})
+	counts := a.KBArticleTags()
+
+	expect := map[string]int{
+		"forge":          2, // or.md + mixed.md (mixed has forge in both lists, dedup → 1)
+		"ha":             1, // or.md
+		"owner":          2, // and-only.md + mixed.md
+		"signal_channel": 1, // and-only.md
+	}
+	for tag, want := range expect {
+		if counts[tag] != want {
+			t.Errorf("counts[%q] = %d, want %d (full counts: %v)", tag, counts[tag], want, counts)
+		}
+	}
+	if len(counts) != len(expect) {
+		t.Errorf("unexpected extra tags in counts: %v", counts)
+	}
+}


### PR DESCRIPTION
## What this is for

Today, KB articles in the knowledge-base directory activate via OR semantics: any of the article's `tags:` being in the active capability set causes the article to auto-inject. That's the right default for "fires when this entry-point becomes active" — and most articles want exactly that.

It's exactly wrong when the activation condition is the *intersection* of two runtime facts.

## The motivating case

A Signal operator has a knowledge-base article that should be loaded for every conversation that's both with the owner *and* on a message channel — Signal first, but Matrix and iMessage when those land. The two conditions are independently asserted by different parts of the runtime: `owner` by the trusted channel-binding path on the contact's trust zone, `message_channel` by whichever messaging bridge produced the inbound. Each is the right thing to fire on, but the article only makes sense when *both* are true.

With only `tags:`:

- `tags: [owner]` over-fires — the article also injects on email-as-owner, MQTT-as-owner, every other path that gets the owner runtime tag.
- `tags: [message_channel]` over-fires the other way — every Signal conversation gets it, including ones with non-owner contacts.
- `tags: [owner, message_channel]` reads like an intersection in English but evaluates as a union in code: the article injects whenever *either* tag is active.

There was no way to express "AND" as a content-level tag affinity. The closest workaround was a code-level [TagContextProvider](internal/runtime/agent/tag_context.go), which is heavy machinery for what should be a frontmatter line.

## What changed

### `tags_all:` frontmatter (commit 1)

A new `tags_all:` frontmatter field on tagged KB articles. It's a list of tags, all of which must be active in the current capability set for the article to inject. It composes with the existing `tags:` field; together they express "any of these entry points, but only when paired with all of these runtime gates."

```yaml
---
tags: [forge, ha]
tags_all: [owner]
---
```

That article injects when:
- (`forge` is active OR `ha` is active) — the OR check on `tags`
- AND `owner` is active — the AND check on `tags_all`

For the motivating Signal case, the article frontmatter is just:

```yaml
---
tags_all: [owner, message_channel]
---
```

When only `tags_all:` is set, the AND check alone gates the article. The scanner now treats either field as enough to mark the article tag-aware, so an "AND-only" article isn't silently filtered out by the legacy "must have at least one `tags:` entry" gate.

### Drop the "tools must not be empty" validation on capability_tags (commit 2)

While dogfooding the `tags_all:` change, the operator wanted a custom `signal_channel` tag — pinned via `channel_tags: { signal: [signal_channel] }` and used as one half of a `tags_all: [owner, signal_channel]` article gate. Validation rejected that config because non-builtin `capability_tags` entries were required to declare a `tools:` list.

That requirement predates the broader role capability tags now play: they also gate talents, KB articles (via `tags:` and `tags_all:` frontmatter), and tag-context providers. A tag that exists purely to flip content into the system prompt — no tool membership at all — is a legitimate, increasingly common shape, especially with this PR's intersection-gated pattern. Forcing such a tag to claim a tool just to satisfy the validator is paperwork without benefit.

The fix drops only the empty-tools check. Description is still required for non-builtin tags so the operator's intent is documented in the capability menu. Builtin overlays remain free of both checks. The two tests that pinned the old rejection behavior flip to assert that content-only tags are now accepted.

## Backwards compatibility

Articles using only `tags:` keep their current OR behavior, unchanged. The `tags`/`tags_all` composition rule is purely additive: missing `tags_all` means the AND gate is a no-op, missing `tags:` means the OR gate is a no-op, and the existing matcher logic is preserved when both are absent (which can't happen for a tag-aware article — the scanner rejects it).

The validation change is strictly a relaxation — every config that was previously valid stays valid; some configs that were previously rejected now pass.

## Drive-by cleanup

`parseFrontmatterLines` had three near-identical inline-list parsers — one for `tags`, one for `next_tags`, and the third would have been for `tags_all`. Pulled the shared logic into [parseFrontmatterTagList](internal/model/talents/loader.go) so all three call the same helper. Same behavior, less surface.

## Test plan

- [x] Parser: `tags_all` alone, `tags` and `tags_all` together, quoted entries, empty list
- [x] Matcher OR semantics unchanged for `tags`-only articles
- [x] Matcher AND semantics for `tags_all`-only articles (requires all listed tags)
- [x] Matcher composition: `(any of tags) AND (all of tags_all)`
- [x] Assembler integration: AND-only article stays silent when only one of the required tags is active, injects when both are
- [x] Validation: content-only `capability_tags` entries (description set, `tools` empty) now pass; existing positive tests (builtin-overlay, normal tag with tools, channel_tags reference check) continue to pass
- [x] `just ci` green locally — fmt, mod-tidy, config-generate-check, architecture, link-check, lint, full test suite

## How to use it

Drop a frontmatter block on the article in your KB directory. For "owner on any message channel":

```yaml
---
tags_all: [owner, message_channel]
---

# Bot Operating Notes for the Owner on Signal
…
```

For "owner on Signal specifically" with a custom channel-pinned tag:

```yaml
# config.yaml
channel_tags:
  signal: [signal_channel]
capability_tags:
  signal_channel:
    description: "Runtime gate for Signal-channel context."
    # tools list intentionally omitted — content-only tag.
```

```yaml
# article frontmatter
---
tags_all: [owner, signal_channel]
---
```

Restart Thane (or reload — the assembler scans the KB directory at startup, then re-reads matching articles every turn). The article will appear in the **Capability Context** section of the system prompt for any turn where every required tag is in the active set. Verify by tailing a Signal turn's request log — you'll see the article content under the dynamic tag-context block. If it's not appearing, the most common cause is malformed YAML — `tags_all: [owner, message_channel]` must be a list, not a comma-separated string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)