### PR TITLE
fix: archive_search returns empty results when context windows blow byte cap

### DIFF
--- a/internal/state/memory/format.go
+++ b/internal/state/memory/format.go
@@ -148,11 +148,27 @@ func FormatRecentMessages(messages []Message, now time.Time, truncated bool) []b
 	return data
 }
 
+// maxSearchContextPerSide caps the number of context messages emitted
+// on each side of a search match. The archive's context-expansion
+// query bounds context by silence-gap and a generous per-direction
+// max (default 50), which made each search result potentially huge:
+// 1 match + up to 100 context × maxMessageContentBytes can blow well
+// past the tool's overall byte cap. With unbounded per-result size,
+// the byte-cap fitter could not seat even a single hit and would
+// return `{"results":[],"truncated":true}` — empty output, signal
+// lost. This per-side cap keeps each rendered result bounded so the
+// fitter can always fit at least one hit; the model can pull the
+// fuller window via archive_session_transcript when it wants more.
+const maxSearchContextPerSide = 5
+
 // FormatSearchResults renders archive search hits as JSON. Each result
 // carries the matched message plus the surrounding context window in
 // chronological order. SessionID is emitted on every message; context
 // messages may belong to a different session than the match because
 // context expansion is bounded by silence gaps, not session edges.
+// Context lists are trimmed to the [maxSearchContextPerSide] messages
+// closest to the match on each side — for context_before that's the
+// last N, for context_after the first N.
 func FormatSearchResults(results []SearchResult, now time.Time, truncated bool) []byte {
 	views := make([]SearchResultView, 0, len(results))
 	for _, r := range results {
@@ -162,8 +178,8 @@ func FormatSearchResults(results []SearchResult, now time.Time, truncated bool) 
 		}
 		views = append(views, SearchResultView{
 			Match:         match,
-			ContextBefore: messagesToViews(r.ContextBefore, now),
-			ContextAfter:  messagesToViews(r.ContextAfter, now),
+			ContextBefore: messagesToViews(tailMessages(r.ContextBefore, maxSearchContextPerSide), now),
+			ContextAfter:  messagesToViews(headMessages(r.ContextAfter, maxSearchContextPerSide), now),
 			Highlight:     r.Highlight,
 		})
 	}
@@ -212,6 +228,27 @@ func messagesToViews(messages []Message, now time.Time) []MessageView {
 		views = append(views, messageToView(m, now))
 	}
 	return views
+}
+
+// tailMessages returns the last n messages from msgs, or all of them
+// when the slice is shorter than n. Used to keep the context window
+// closest to the match (search result before-context is in
+// chronological order, so the closest message is at the tail).
+func tailMessages(msgs []Message, n int) []Message {
+	if n <= 0 || len(msgs) <= n {
+		return msgs
+	}
+	return msgs[len(msgs)-n:]
+}
+
+// headMessages returns the first n messages from msgs, or all of them
+// when the slice is shorter than n. Used for after-context, where the
+// chronologically-nearest message is at the head.
+func headMessages(msgs []Message, n int) []Message {
+	if n <= 0 || len(msgs) <= n {
+		return msgs
+	}
+	return msgs[:n]
 }
 
 // clipContent clips s to at most maxBytes, returning the clipped

--- a/internal/state/memory/format_test.go
+++ b/internal/state/memory/format_test.go
@@ -239,3 +239,50 @@ func TestFormatSearchResults_StructurePreserved(t *testing.T) {
 		t.Errorf("highlight = %q", r.Highlight)
 	}
 }
+
+func TestFormatSearchResults_BoundsContextPerSide(t *testing.T) {
+	// Production hotfix: per-message content was already capped at
+	// maxMessageContentBytes, but the per-side context list was not.
+	// With the archive's default 50-message-per-direction context
+	// expansion, a single search result's serialized form could blow
+	// well past the tool's overall byte cap, causing FitPrefix to
+	// clip to zero and emit an empty results array. Cap context
+	// list length per side so each rendered result is bounded.
+	now := time.Now()
+	makeMsgs := func(prefix string, n int) []Message {
+		out := make([]Message, n)
+		for i := range out {
+			out[i] = Message{
+				Role:      "user",
+				Content:   prefix,
+				Timestamp: now.Add(-time.Duration(n-i) * time.Minute),
+				SessionID: "s1",
+			}
+		}
+		return out
+	}
+	results := []SearchResult{{
+		Match:         Message{Role: "user", Content: "match", Timestamp: now, SessionID: "s1"},
+		SessionID:     "s1",
+		ContextBefore: makeMsgs("before", 50),
+		ContextAfter:  makeMsgs("after", 50),
+	}}
+
+	data := FormatSearchResults(results, now, false)
+	var parsed struct {
+		Results []SearchResultView `json:"results"`
+	}
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(parsed.Results) != 1 {
+		t.Fatalf("results len = %d, want 1", len(parsed.Results))
+	}
+	r := parsed.Results[0]
+	if len(r.ContextBefore) != maxSearchContextPerSide {
+		t.Errorf("context_before len = %d, want %d", len(r.ContextBefore), maxSearchContextPerSide)
+	}
+	if len(r.ContextAfter) != maxSearchContextPerSide {
+		t.Errorf("context_after len = %d, want %d", len(r.ContextAfter), maxSearchContextPerSide)
+	}
+}

--- a/internal/tools/archive_tools.go
+++ b/internal/tools/archive_tools.go
@@ -2,6 +2,7 @@ package tools
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
 	"time"
@@ -9,6 +10,20 @@ import (
 	"github.com/nugget/thane-ai-agent/internal/model/promptfmt"
 	"github.com/nugget/thane-ai-agent/internal/state/memory"
 )
+
+// countSearchResults parses an archive_search JSON envelope and
+// returns the length of its `results` array, or 0 on parse failure
+// or absent field. Used by the search handler's defensive guard
+// against the empty-with-truncated degenerate state.
+func countSearchResults(data []byte) int {
+	var env struct {
+		Results []json.RawMessage `json:"results"`
+	}
+	if err := json.Unmarshal(data, &env); err != nil {
+		return 0
+	}
+	return len(env.Results)
+}
 
 // archiveResultByteCap is the per-tool byte ceiling on JSON output.
 // The cap protects the model's context budget when an archive query
@@ -98,9 +113,20 @@ func (r *Registry) registerArchiveSearch(store *memory.ArchiveStore) {
 			// Fit to byte cap by dropping from the tail (lowest-relevance
 			// hits go first). Binary search avoids O(n^2) re-marshaling.
 			now := time.Now()
-			data := memory.FitPrefix(len(results), archiveResultByteCap, func(k int) []byte {
+			render := func(k int) []byte {
 				return memory.FormatSearchResults(results[:k], now, k < len(results))
-			})
+			}
+			data := memory.FitPrefix(len(results), archiveResultByteCap, render)
+
+			// Defensive: if the fitter clipped to zero results despite
+			// having raw matches, force the top-relevance hit through
+			// even if it overshoots the byte cap. Returning empty with
+			// truncated=true would silently swallow useful signal — far
+			// worse than going slightly over budget on one oversized
+			// result.
+			if len(results) > 0 && countSearchResults(data) == 0 {
+				data = render(1)
+			}
 			return string(data), nil
 		},
 	})

--- a/internal/tools/archive_tools_test.go
+++ b/internal/tools/archive_tools_test.go
@@ -328,3 +328,43 @@ func TestArchiveRangeTool_ExcludeSessionID(t *testing.T) {
 		t.Errorf("session_id = %q, want archived", parsed.Messages[0].SessionID)
 	}
 }
+
+func TestArchiveSearchTool_NeverEmptyWhenResultsExist(t *testing.T) {
+	// Regression: production hotfix for an archive_search that returned
+	// `{"results":[],"truncated":true}` because each individual result
+	// (match + up to 100 context messages × per-message content cap)
+	// blew past archiveResultByteCap, so FitPrefix degenerated to 0
+	// and silently swallowed every match.
+	r, _, insert := newArchiveTestRegistry(t)
+	now := time.Now()
+
+	// Seed a session with the matched term plus enough surrounding
+	// chatter that a real search expansion would balloon the result.
+	insert("conv-1", "sess-1", "user", "looking for the freezer alarm details", now.Add(-30*time.Minute))
+	for i := range 30 {
+		ts := now.Add(-time.Duration(29-i) * time.Minute)
+		role := "user"
+		if i%2 == 0 {
+			role = "assistant"
+		}
+		insert("conv-1", "sess-1", role, strings.Repeat("filler text ", 100), ts)
+	}
+
+	tool := r.Get("archive_search")
+	out, err := tool.Handler(context.Background(), map[string]any{
+		"query": "freezer",
+	})
+	if err != nil {
+		t.Fatalf("handler: %v", err)
+	}
+	var parsed struct {
+		Results   []memory.SearchResultView `json:"results"`
+		Truncated bool                      `json:"truncated"`
+	}
+	if err := json.Unmarshal([]byte(out), &parsed); err != nil {
+		t.Fatalf("unmarshal: %v\noutput: %s", err, out)
+	}
+	if len(parsed.Results) == 0 {
+		t.Fatalf("results empty despite real matches existing — regression of the production bug:\n%s", out)
+	}
+}


### PR DESCRIPTION
## Production symptom

Deploy of v0.9.1-28-gc2239de surfaced this in the request logs for nearly every `archive_search` call:

```json
{"results":[],"truncated":true}
```

Empty results with `truncated=true` is the worst possible failure mode: the tool implies there were matches, but the model has nothing to look at. Search felt completely broken.

## Root cause

This is the exact failure mode #761 round-2 review warned about, just arriving through a slightly different path than the one we addressed at the time.

Each `archive_search` result is the matched message plus a context window expanded by the archive store. The store's default [`MaxContextMessages`](internal/state/memory/archive.go) is **50 per direction** — so a single result can carry the match plus up to ~100 surrounding messages. We already cap per-message content at `maxMessageContentBytes` (2 KB), but that ceiling against ~100 context messages still puts a worst-case rendered result at ~200 KB. The tool's `archiveResultByteCap` is 16 KB.

Net: every individual hit overshoots the cap. `FitPrefix`'s binary search converges at `k=0`. The handler emits the envelope with the `truncated=true` flag (because k < len(results)) and an empty results array (because k=0). The model sees nothing useful.

The per-message content truncation we landed in #761 was necessary but insufficient — bounded individual messages don't help when an unbounded number of them get packed into a single result.

## Fix

Two changes, complementary:

### 1. Cap context messages per side in `FormatSearchResults`

`maxSearchContextPerSide = 5`. `context_before` keeps the last N (closest to the match in chronological order); `context_after` keeps the first N (also closest). Each rendered result now bounds at roughly 1 + 10 messages × 2 KB content cap = ~22 KB worst case, but realistic content sizes put typical results well under 16 KB. The fitter actually has work to do — and degeneracy at `k=0` becomes the rare edge instead of the common case.

The model still has the option to pull the fuller window via `archive_session_transcript` when something in the trimmed context catches its eye. That's already the documented "dive deeper" path; this just makes the trimmed-context default explicit.

### 2. Defensive guard in the `archive_search` handler

If `FitPrefix` emits an envelope with zero results despite `len(results) > 0`, the handler now forces `render(1)` and accepts a single oversized hit going slightly past the byte cap. Returning empty silently swallows useful signal — that's worse than emitting one chunky result.

`countSearchResults` parses the envelope to detect the empty case without assuming a specific JSON shape from the formatter.

## Tests

- **`TestFormatSearchResults_BoundsContextPerSide`** — synthesizes 50 context messages on each side and asserts the rendered result keeps only the nearest 5 on each side.
- **`TestArchiveSearchTool_NeverEmptyWhenResultsExist`** — seeds a session with a matched term plus 30 surrounding chatter messages sized to reproduce the production blowup, then asserts the handler returns at least one result. Pinned regression for the deployed bug.

`just ci` green locally — fmt, mod-tidy, config-generate-check, architecture, link-check, lint, full test suite.

## Follow-up worth doing later

Per-message content truncation is uniform across match and context messages today: 2 KB everywhere. Context messages are supplementary "color around the match" and almost certainly don't need the full 2 KB allowance. A smaller cap on context-only messages would let us widen `maxSearchContextPerSide` back to a more generous default without re-exposing the same blow-past-cap risk. Not in scope for the hotfix — clean up later when search ergonomics get another pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)