### PR TITLE
fix: surface archived assistant messages as "past you" in archive JSON

### DIFF
--- a/internal/state/memory/format.go
+++ b/internal/state/memory/format.go
@@ -211,11 +211,25 @@ func sessionToView(s *Session, now time.Time) SessionView {
 	return view
 }
 
+// archiveAssistantRole is the display label used for assistant
+// messages in archive-derived JSON the model reads. The neutral
+// "assistant" role is anodyne and reads as a third party — but
+// archived assistant messages are *the model's own past output*.
+// Surfacing them as "past you" gives the model a personal hook into
+// its own history. This is a cosmetic label only: stored roles, live
+// conversation history, API responses, and tool wire formats are
+// unaffected.
+const archiveAssistantRole = "past you"
+
 func messageToView(m Message, now time.Time) MessageView {
 	content, truncated := clipContent(m.Content, maxMessageContentBytes)
+	role := m.Role
+	if role == "assistant" {
+		role = archiveAssistantRole
+	}
 	return MessageView{
 		T:                promptfmt.FormatDeltaOnly(m.Timestamp, now),
-		Role:             m.Role,
+		Role:             role,
 		Content:          content,
 		ContentTruncated: truncated,
 		SessionID:        m.SessionID,

--- a/internal/state/memory/format_test.go
+++ b/internal/state/memory/format_test.go
@@ -286,3 +286,65 @@ func TestFormatSearchResults_BoundsContextPerSide(t *testing.T) {
 		t.Errorf("context_after len = %d, want %d", len(r.ContextAfter), maxSearchContextPerSide)
 	}
 }
+
+func TestMessageToView_AssistantRoleRelabeled(t *testing.T) {
+	// Archive-derived JSON should surface the model's own past output
+	// as "past you" rather than the third-party-feeling "assistant".
+	// User and other roles pass through unchanged.
+	now := time.Now()
+	cases := []struct {
+		input string
+		want  string
+	}{
+		{"assistant", "past you"},
+		{"user", "user"},
+		{"system", "system"},
+		{"tool", "tool"},
+		{"", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.input, func(t *testing.T) {
+			view := messageToView(Message{Role: tc.input, Content: "x", Timestamp: now}, now)
+			if view.Role != tc.want {
+				t.Errorf("role = %q, want %q", view.Role, tc.want)
+			}
+		})
+	}
+}
+
+func TestFormatSearchResults_AssistantContextRelabeled(t *testing.T) {
+	// Substitution applies to context_before / context_after too —
+	// any assistant message in archive output reads as "past you".
+	now := time.Now()
+	results := []SearchResult{{
+		Match: Message{Role: "user", Content: "freezer alert", Timestamp: now.Add(-1 * time.Hour), SessionID: "s1"},
+		ContextBefore: []Message{
+			{Role: "assistant", Content: "earlier reply", Timestamp: now.Add(-1*time.Hour - time.Minute)},
+		},
+		ContextAfter: []Message{
+			{Role: "assistant", Content: "later reply", Timestamp: now.Add(-1*time.Hour + time.Minute)},
+		},
+		SessionID: "s1",
+	}}
+	data := FormatSearchResults(results, now, false)
+
+	var parsed struct {
+		Results []SearchResultView `json:"results"`
+	}
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(parsed.Results) != 1 {
+		t.Fatalf("results len = %d", len(parsed.Results))
+	}
+	r := parsed.Results[0]
+	if len(r.ContextBefore) != 1 || r.ContextBefore[0].Role != "past you" {
+		t.Errorf("context_before role = %q, want past you", r.ContextBefore[0].Role)
+	}
+	if len(r.ContextAfter) != 1 || r.ContextAfter[0].Role != "past you" {
+		t.Errorf("context_after role = %q, want past you", r.ContextAfter[0].Role)
+	}
+	if r.Match.Role != "user" {
+		t.Errorf("match role = %q, want user (unchanged)", r.Match.Role)
+	}
+}

--- a/internal/tools/archive_tools_test.go
+++ b/internal/tools/archive_tools_test.go
@@ -273,7 +273,10 @@ func TestArchiveSessionTranscriptTool_JSONOutput(t *testing.T) {
 	if len(parsed.Messages) != 2 {
 		t.Fatalf("messages len = %d, want 2", len(parsed.Messages))
 	}
-	if parsed.Messages[0].Role != "user" || parsed.Messages[1].Role != "assistant" {
+	// Assistant role is relabeled to "past you" in archive-derived
+	// JSON so the model reads its own historical output as personal,
+	// not as a third party. User role is unchanged.
+	if parsed.Messages[0].Role != "user" || parsed.Messages[1].Role != "past you" {
 		t.Errorf("roles = %q,%q", parsed.Messages[0].Role, parsed.Messages[1].Role)
 	}
 }


### PR DESCRIPTION
## What this is for

The archive tools (`archive_search`, `archive_session_transcript`, `archive_range`) and the `message_channel` verbatim-tail context provider all serialize archived messages as JSON for the model to read. The role field went out as the raw `"assistant"` string — neutral, anodyne, and phrased like a third party. But these are the model's own past outputs being reflected back at it. Surfacing them as `"past you"` gives the model a personal hook into its own history, which is the whole point of feeding archived assistant turns into context in the first place.

## What changed

A single substitution at the JSON-formatter layer: `messageToView` now maps `assistant` → `past you` for archived messages. Other roles (`user`, `system`, `tool`) pass through unchanged — they're not the model's own output.

```diff
 func messageToView(m Message, now time.Time) MessageView {
   content, truncated := clipContent(m.Content, maxMessageContentBytes)
+  role := m.Role
+  if role == "assistant" {
+    role = archiveAssistantRole // "past you"
+  }
   return MessageView{
     T:                promptfmt.FormatDeltaOnly(m.Timestamp, now),
-    Role:             m.Role,
+    Role:             role,
     ...
```

Because the substitution lives in `messageToView`, every archived-message rendering path picks it up uniformly: match messages on a search hit, the surrounding `context_before` / `context_after` window, transcript output, range output, and the verbatim tail block emitted by the message_channel provider.

## Scope: this is a cosmetic label only

Explicitly **not** touched:

- Stored `Role` values in the messages table
- Live conversation history serialization (different code path in `loop.go`)
- API server responses
- The tool wire format / model→tool input round trip
- LLM provider role enums (`anthropic.user`, `anthropic.assistant` etc.)

The relabel happens at the formatter for archive-derived JSON the model reads in context, and nowhere else.

## Tests

- **`TestMessageToView_AssistantRoleRelabeled`** — table test pinning the substitution: `assistant` → `past you`, all other roles pass through.
- **`TestFormatSearchResults_AssistantContextRelabeled`** — confirms the substitution applies to `context_before` and `context_after` around search hits, not just the match itself.
- **`TestArchiveSessionTranscriptTool_JSONOutput`** — updated; the assertion that previously pinned `Role == "assistant"` now expects `past you`, with an inline comment explaining why.

`just ci` green locally — fmt, mod-tidy, config-generate-check, architecture, link-check, lint, full test suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)