### PR TITLE
fix: neutralize quote chars in build changelog injection

### DIFF
--- a/justfile
+++ b/justfile
@@ -3,7 +3,7 @@ version := env("THANE_VERSION", `git describe --tags --always --dirty 2>/dev/nul
 git_commit := `git rev-parse --short HEAD 2>/dev/null || echo "unknown"`
 git_branch := `git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown"`
 build_time := `date -u '+%Y-%m-%dT%H:%M:%SZ'`
-changelog := `git log --oneline $(git describe --tags --abbrev=0 2>/dev/null || echo HEAD)..HEAD --no-merges 2>/dev/null | head -5 | sed 's/^[a-f0-9]* //' | tr "'" "_" | tr '\n' ';' | sed 's/;$//' | sed 's/;/; /g' || echo ""`
+changelog := `git log --oneline $(git describe --tags --abbrev=0 2>/dev/null || echo HEAD)..HEAD --no-merges 2>/dev/null | head -5 | sed 's/^[a-f0-9]* //' | tr "'" "_" | tr '"' "_" | tr '\\' "_" | tr '\n' ';' | sed 's/;$//' | sed 's/;/; /g' || echo ""`
 
 ldflags := "-X " + pkg + ".Version=" + version + " -X " + pkg + ".GitCommit=" + git_commit + " -X " + pkg + ".GitBranch=" + git_branch + " -X " + pkg + ".BuildTime=" + build_time + " -X '" + pkg + ".Changelog=" + changelog + "'"
 


### PR DESCRIPTION
## Symptom

Local \`just build\` fails when HEAD is a commit whose subject contains a literal double quote:

\`\`\`
invalid value \"-X ... -X 'github.com/nugget/.../buildinfo.Changelog=fix: surface archived assistant messages as past\" for flag -ldflags: unterminated ' string
\`\`\`

The shell parser hits the inner \`\"\` from the commit subject, treats it as a string terminator for the outer \`-ldflags \"...\"\`, and panics on the leftover unbalanced quote.

## Root cause

The justfile builds a \`changelog\` variable from \`git log --oneline\` of recent commits, then concatenates it into the \`ldflags\` expression for \`-X buildinfo.Changelog=...\`. The pipeline ran one \`tr \"'\" \"_\"\` pass to neutralize single quotes, but it never handled double quotes or backslashes. As soon as a commit subject with a literal \`\"\` landed on main, the next local build broke.

## Fix

Two more \`tr\` passes in the changelog pipeline — one for double quotes, one for backslashes — both with clean shell quoting:

\`\`\`diff
- | tr \"'\" \"_\" | tr '\\n' ';' ...
+ | tr \"'\" \"_\" | tr '\"' \"_\" | tr '\\\\' \"_\" | tr '\\n' ';' ...
\`\`\`

Each \`tr\` invocation has its own simple quoting context — single quotes around chars that need to be literal, double quotes around chars that don't survive single-quoting. Combined character-class approaches (\`tr \"'\\\"\\\\\\\\\" \"_\"\`) are fragile across shells and across just's own backtick-substitution layer; chained \`tr\`s sidestep the problem.

## Out of scope

Backticks (\`\\\`\`) in commit subjects would still break the build — escaping a literal backtick inside a justfile backtick-substitution block requires bigger restructuring (\`shell()\` function or extracting the pipeline to its own script). Backticks in commit subjects are rare enough that the cost/benefit isn't there yet. If a backtick subject ever lands and breaks the build the same way, the right move is factoring the changelog pipeline out of the justfile entirely.

## Verification

Tested locally with the offending HEAD (commit subject \"fix: surface archived assistant messages as 'past you' in archive JSON\" with literal double quotes). Before this change: \`just build\` errors as shown above. After: build completes cleanly through to the signed binary.

\`just ci\` green locally — fmt, mod-tidy, config-generate-check, architecture, link-check, lint, full test suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)