### PR TITLE
refactor: modernize delegate profile scoping

### DIFF
--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -49,6 +49,11 @@ These tools load on every turn regardless of active tags.
 `thane_delegate` uses capability tags as its primary tool and context
 scope. It inherits elective caller tags by default so child work keeps
 the same task context; explicit `tags` override profile default tags.
+Use root entry-point tags such as `development`, `home`, `operations`,
+`knowledge`, `media`, `interactive`, or `people` when the delegate should
+read the menu guidance and choose a narrower branch. Use leaf tags such
+as `ha`, `files`, `forge`, `web`, `loops`, `documents`, or `diagnostics`
+when the caller already knows the needed toolset.
 Runtime and channel affordance tags such as `owner` and `message_channel`
 are re-asserted only from trusted runtime context; they are not inherited
 as model-requested tags. Use `inherit_caller_tags: false` when a delegate

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -46,12 +46,13 @@ These tools load on every turn regardless of active tags.
 | `conversation_reset` | Reset the current conversation's message history. |
 | `send_notification` | Provider-agnostic fire-and-forget notification. |
 
-`thane_delegate` inherits elective caller capability tags by default so
-child work keeps the same task context. Runtime and channel affordance
-tags such as `owner` and `message_channel` are re-asserted only from
-trusted runtime context; they are not inherited as model-requested tags.
-Use `inherit_caller_tags: false` when a delegate needs a strict fresh
-tool scope.
+`thane_delegate` uses capability tags as its primary tool and context
+scope. It inherits elective caller tags by default so child work keeps
+the same task context; explicit `tags` override profile default tags.
+Runtime and channel affordance tags such as `owner` and `message_channel`
+are re-asserted only from trusted runtime context; they are not inherited
+as model-requested tags. Use `inherit_caller_tags: false` when a delegate
+needs a strict fresh tool scope.
 
 ## `awareness` — live-context entity management
 

--- a/docs/understanding/delegation.md
+++ b/docs/understanding/delegation.md
@@ -129,10 +129,18 @@ Delegates inherit elective caller capability tags by default. This keeps
 task context such as activated domain tags or KB articles attached to
 the child work without making the orchestrator restate it on every
 handoff. If explicit tags are provided, they take precedence over profile
-default tags. Runtime/channel affordance tags such as `message_channel`
-and trust tags such as `owner` are not inherited as model-requested tags;
-they must be asserted again by trusted runtime context. Use
-`inherit_caller_tags=false` for a strict fresh scope.
+default tags.
+
+Use root entry-point tags when the delegate should read the menu guidance
+and choose the next branch itself: `development`, `home`, `operations`,
+`knowledge`, `media`, `interactive`, or `people`. Use leaf tags when the
+caller already knows the needed toolset: `ha`, `files`, `forge`, `web`,
+`loops`, `documents`, `diagnostics`, and similar focused tags.
+
+Runtime/channel affordance tags such as `message_channel` and trust tags
+such as `owner` are not inherited as model-requested tags; they must be
+asserted again by trusted runtime context. Use `inherit_caller_tags=false`
+for a strict fresh scope.
 
 ## Writing Good Delegation Prompts
 

--- a/docs/understanding/delegation.md
+++ b/docs/understanding/delegation.md
@@ -20,7 +20,7 @@ tool-heavy execution to a smaller, faster local model.
 User: "Set the office Hue Go to teal"
 
 Orchestrator (Opus):
-  -> "Delegate to ha profile: search for 'hue go' entities in office,
+  -> "Delegate with the ha capability tag: search for 'hue go' entities in office,
      call light.turn_on with rgb_color [0,200,180], verify with get_state"
 
 Delegate (local 20B model):
@@ -47,10 +47,10 @@ partitioned:
 - `session_working_memory` — session scratchpad
 - `archive_search` — conversation history search
 
-**Delegates see all tools** for their profile:
-- Native HA tools (`get_state`, `find_entity`, `call_service`, etc.)
-- MCP tools (`mcp_home_assistant_ha_*`)
-- File operations, shell exec, web search/fetch
+**Delegates see tools** through their capability tags:
+- HA-tagged native and MCP tools for device control or entity queries
+- Web, file, shell, document, and other tool families when those tags are active
+- Always-active tools configured for the instance
 
 The `thane:ops` [routing profile](../operating/routing-profiles.md) disables
 orchestrator gating — the primary model sees everything directly. Use it when
@@ -64,7 +64,7 @@ Instead, **talent files** teach it what's available and how to write effective
 delegation prompts.
 
 `delegate-hints.md` contains:
-- Which tools exist for each delegation profile
+- Which capability tags and tool families exist
 - Patterns to follow (search, act, verify for HA)
 - Anti-patterns to avoid (multi-entity delegations, `list_entities` abuse)
 - Known quirks (ha-mcp `return_response` errors, silent `call_service` failures)
@@ -116,19 +116,21 @@ if a server exists, Thane can host it.
 
 ## Delegation Profiles
 
-When delegating, the orchestrator specifies a **profile** that determines
-which model and tools the delegate gets:
+Delegation profiles are compatibility hints for budget and routing defaults.
+They do not own a separate system prompt or fixed tool allowlist. Capability
+tags determine the delegate's tool and context scope.
 
-| Profile | Model | Tools | Use For |
-|---------|-------|-------|---------|
-| `general` | Default local | All (native + MCP) | Most tasks |
-| `ha` | Default local | Native HA tools only | Device control, entity queries |
+| Profile | Default Tags | Routing Bias | Use For |
+|---------|--------------|--------------|---------|
+| `general` | none | local, general purpose | Most tasks |
+| `ha` | `ha` when no explicit tags are supplied | local, device-control mission | Legacy HA delegations |
 
 Delegates inherit elective caller capability tags by default. This keeps
 task context such as activated domain tags or KB articles attached to
 the child work without making the orchestrator restate it on every
-handoff. Runtime/channel affordance tags such as `message_channel` and
-trust tags such as `owner` are not inherited as model-requested tags;
+handoff. If explicit tags are provided, they take precedence over profile
+default tags. Runtime/channel affordance tags such as `message_channel`
+and trust tags such as `owner` are not inherited as model-requested tags;
 they must be asserted again by trusted runtime context. Use
 `inherit_caller_tags=false` for a strict fresh scope.
 

--- a/examples/config.example.yaml
+++ b/examples/config.example.yaml
@@ -306,10 +306,10 @@ talents_dir: ./talents
 #
 # (optional) Delegate configures the thane_delegate tool's split-model execution.
 # delegate:
-#   Profiles contains per-profile overrides. The map key is the
-#   profile name (e.g., "general", "ha"). Only fields that are set
-#   override the builtin defaults — omitted fields keep their
-#   compiled-in values.
+#   Profiles contains per-profile budget and timeout overrides. The map
+#   key is the compatibility profile name (e.g., "general", "ha"). Only
+#   fields that are set override the builtin defaults — omitted fields
+#   keep their compiled-in values.
 #   profiles:
 #     general:
 #       ToolTimeout is the maximum time a single tool call may run

--- a/internal/model/prompts/delegate.go
+++ b/internal/model/prompts/delegate.go
@@ -28,6 +28,8 @@ BAD delegate tasks (keep these yourself):
 
 Use the guidance field to steer execution: provide entity names, file paths, specific focus areas, or output format preferences. More specific guidance means fewer wasted iterations.
 
-Use tags to scope the delegate's capability surface. Delegates inherit the caller's elective capability tags by default. Set inherit_caller_tags=false only when you need a strict, fresh tool scope.
+Use tags to scope the delegate's capability surface. Use a root entry-point tag like development, home, operations, knowledge, media, interactive, or people when the delegate should read the menu guidance and decide which narrower toolset to activate. Use leaf tags like ha, files, forge, web, loops, documents, or diagnostics when you already know the exact surface needed.
+
+Delegates inherit the caller's elective capability tags by default. Set inherit_caller_tags=false only when you need a strict, fresh tool scope.
 
 Use mode="async" when you want the delegate to keep running in the background and report the result back into the current conversation later instead of blocking for a direct reply.`

--- a/internal/model/prompts/delegate.go
+++ b/internal/model/prompts/delegate.go
@@ -1,5 +1,11 @@
 package prompts
 
+// DelegateRunInstructions is the reusable execution contract for spawned
+// delegate loops and the legacy delegate runner.
+const DelegateRunInstructions = `Complete the assigned task using the available tools. Report findings clearly and concisely.
+
+Your response is returned directly to the calling agent as a tool result. If you called tools and received data, include the relevant data in your final text response. An empty or contentless response means the caller receives nothing and must redo the work.`
+
 // DelegateToolDescription is the LLM-facing description for the thane_delegate tool.
 const DelegateToolDescription = `Delegate a concrete task to a smaller, cheaper model for execution. The delegate has access to tools and can iterate, but operates without your conversation history or personality.
 
@@ -22,6 +28,6 @@ BAD delegate tasks (keep these yourself):
 
 Use the guidance field to steer execution: provide entity names, file paths, specific focus areas, or output format preferences. More specific guidance means fewer wasted iterations.
 
-Delegates inherit the caller's elective capability tags by default. Set inherit_caller_tags=false only when you need a strict, fresh tool scope.
+Use tags to scope the delegate's capability surface. Delegates inherit the caller's elective capability tags by default. Set inherit_caller_tags=false only when you need a strict, fresh tool scope.
 
 Use mode="async" when you want the delegate to keep running in the background and report the result back into the current conversation later instead of blocking for a direct reply.`

--- a/internal/platform/config/config.go
+++ b/internal/platform/config/config.go
@@ -1044,10 +1044,10 @@ type AgentConfig struct {
 // DelegateConfig configures the thane_delegate tool's split-model
 // execution behavior.
 type DelegateConfig struct {
-	// Profiles contains per-profile overrides. The map key is the
-	// profile name (e.g., "general", "ha"). Only fields that are set
-	// override the builtin defaults — omitted fields keep their
-	// compiled-in values.
+	// Profiles contains per-profile budget and timeout overrides. The map
+	// key is the compatibility profile name (e.g., "general", "ha"). Only
+	// fields that are set override the builtin defaults — omitted fields
+	// keep their compiled-in values.
 	Profiles map[string]DelegateProfileConfig `yaml:"profiles"`
 }
 

--- a/internal/runtime/delegate/delegate.go
+++ b/internal/runtime/delegate/delegate.go
@@ -15,6 +15,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/nugget/thane-ai-agent/internal/model/fleet"
 	"github.com/nugget/thane-ai-agent/internal/model/llm"
+	"github.com/nugget/thane-ai-agent/internal/model/prompts"
 	"github.com/nugget/thane-ai-agent/internal/model/router"
 	"github.com/nugget/thane-ai-agent/internal/platform/config"
 	"github.com/nugget/thane-ai-agent/internal/platform/events"
@@ -44,16 +45,18 @@ const (
 
 type executionOptions struct {
 	inheritCallerTags bool
+	explicitTagScope  bool
 }
 
 func defaultExecutionOptions() executionOptions {
 	return executionOptions{inheritCallerTags: true}
 }
 
-func mergeDelegateScopeTags(ctx context.Context, explicitTags []string, inheritCallerTags bool) (scopeTags []string, inheritedTags []string, droppedTags []string, explicitScopeRequested bool) {
+func mergeDelegateScopeTags(ctx context.Context, explicitTags []string, inheritCallerTags bool, explicitTagScope bool) (scopeTags []string, inheritedTags []string, droppedTags []string, explicitScopeRequested bool) {
 	scope := make(map[string]bool)
 	inherited := make(map[string]bool)
 	dropped := make(map[string]bool)
+	explicitScopeRequested = explicitTagScope
 
 	if inheritCallerTags {
 		for _, tag := range tools.InheritableCapabilityTagsFromContext(ctx) {
@@ -109,6 +112,70 @@ func nonDelegableCapabilityTag(tag string) bool {
 	default:
 		return false
 	}
+}
+
+func applyProfileDefaultTags(scopeTags []string, profile *Profile, explicitScopeRequested bool) (mergedTags []string, appliedDefaults []string) {
+	mergedTags = append([]string(nil), scopeTags...)
+	if explicitScopeRequested || profile == nil || len(profile.DefaultTags) == 0 {
+		return mergedTags, nil
+	}
+
+	seen := make(map[string]bool, len(mergedTags)+len(profile.DefaultTags))
+	for _, tag := range mergedTags {
+		seen[tag] = true
+	}
+	for _, tag := range profile.DefaultTags {
+		tag = strings.TrimSpace(tag)
+		if tag == "" || seen[tag] || nonDelegableCapabilityTag(tag) {
+			continue
+		}
+		seen[tag] = true
+		mergedTags = append(mergedTags, tag)
+		appliedDefaults = append(appliedDefaults, tag)
+	}
+	sort.Strings(mergedTags)
+	sort.Strings(appliedDefaults)
+	return mergedTags, appliedDefaults
+}
+
+func (e *Executor) delegateToolRegistry(scopeTags []string, explicitScopeRequested bool) *tools.Registry {
+	if len(scopeTags) > 0 || explicitScopeRequested {
+		merged := append([]string(nil), scopeTags...)
+		merged = append(merged, e.alwaysActiveTags...)
+		var reg *tools.Registry
+		if len(merged) > 0 {
+			reg = e.parentReg.FilterByTags(merged)
+		} else {
+			reg = e.parentReg.FilteredCopy(nil)
+		}
+		return reg.FilteredCopyExcluding([]string{delegateToolName})
+	}
+	return e.parentReg.FilteredCopyExcluding([]string{delegateToolName})
+}
+
+func (e *Executor) buildLegacySystemPrompt(ctx context.Context, effectiveTags map[string]bool, pathPrefixes map[string]string) string {
+	var sb strings.Builder
+	sb.WriteString(prompts.BaseSystemPrompt())
+	sb.WriteString("\n\n## Delegate Execution Contract\n\n")
+	sb.WriteString(prompts.DelegateRunInstructions)
+	sb.WriteString("\n\n")
+	sb.WriteString(awareness.CurrentConditions(e.timezone))
+
+	if e.tagCtxFunc != nil && len(effectiveTags) > 0 {
+		if tagCtx := e.tagCtxFunc(ctx, effectiveTags); tagCtx != "" {
+			sb.WriteString("\n\n## Capability Context\n\n")
+			sb.WriteString(tagCtx)
+		}
+	} else if e.forgeContext != "" {
+		sb.WriteString("\n\n")
+		sb.WriteString(e.forgeContext)
+	}
+
+	if prefixPrompt := formatPrefixPrompt(pathPrefixes, time.Now()); prefixPrompt != "" {
+		sb.WriteString("\n\n")
+		sb.WriteString(prefixPrompt)
+	}
+	return sb.String()
 }
 
 // ToolCallOutcome records the name and success/failure of a single tool
@@ -220,8 +287,8 @@ type ProfileOverride struct {
 	MaxTokens   int
 }
 
-// SetTimezone configures the IANA timezone for Current Conditions
-// in the delegate system prompt.
+// SetTimezone configures the IANA timezone for Current Conditions in
+// legacy delegate prompt assembly.
 func (e *Executor) SetTimezone(tz string) {
 	e.timezone = tz
 }
@@ -266,10 +333,9 @@ func (e *Executor) SetEventBus(bus *events.Bus) {
 	e.eventBus = bus
 }
 
-// SetForgeContext configures the forge account context block that is
-// appended to delegate system prompts. This gives delegates immediate
-// knowledge of configured forge accounts so they don't waste iterations
-// guessing account names.
+// SetForgeContext configures the forge account context block used by
+// legacy delegate prompt assembly. Loop-backed delegates receive this
+// kind of context through the normal loop context providers.
 func (e *Executor) SetForgeContext(ctx string) {
 	e.forgeContext = ctx
 }
@@ -289,10 +355,9 @@ func (e *Executor) SetLensProvider(fn func() []string) {
 	e.lensProvider = fn
 }
 
-// SetTagContextFunc configures the tag context builder function for
-// injecting capability context (static files, tagged KB articles,
-// and live providers) into delegate system prompts. When set, this
-// replaces the ad-hoc forge context injection.
+// SetTagContextFunc configures the legacy tag context builder function
+// for injecting capability context. Loop-backed delegates use the normal
+// loop prompt assembly path.
 func (e *Executor) SetTagContextFunc(fn tagContextFunc) {
 	e.tagCtxFunc = fn
 }
@@ -343,11 +408,9 @@ func (e *Executor) ProfileNames() []string {
 }
 
 // Execute runs a delegated task with the given profile and guidance.
-// When tags is non-empty, the delegate's tool registry is scoped to
-// only tools belonging to the given capability tags (plus any
-// always-active tags). Elective caller tags are inherited by default;
-// when the resulting scope has no tags, the profile's AllowedTools
-// controls tool selection.
+// Capability tags define the delegate's tool and context scope. Elective
+// caller tags are inherited by default; compatibility profiles may add
+// default tags only when the caller did not request an explicit scope.
 func (e *Executor) Execute(ctx context.Context, task, profileName, guidance string, tags []string, pathPrefixes map[string]string) (*Result, error) {
 	return e.execute(ctx, task, profileName, guidance, tags, pathPrefixes, defaultExecutionOptions())
 }
@@ -463,28 +526,13 @@ func (e *Executor) executeLegacy(ctx context.Context, task, profileName, guidanc
 	if profile == nil {
 		profile = e.profiles["general"]
 	}
-	scopeTags, inheritedTags, droppedTags, explicitScopeRequested := mergeDelegateScopeTags(ctx, tags, opts.inheritCallerTags)
+	scopeTags, inheritedTags, droppedTags, explicitScopeRequested := mergeDelegateScopeTags(ctx, tags, opts.inheritCallerTags, opts.explicitTagScope)
 	if len(droppedTags) > 0 {
 		log.Warn("delegate capability tags skipped", "dropped_tags", droppedTags)
 	}
+	scopeTags, profileDefaultTags := applyProfileDefaultTags(scopeTags, profile, explicitScopeRequested)
 
-	// Build filtered tool registry. Tag-scoped delegations take
-	// precedence over the profile's AllowedTools list.
-	var reg *tools.Registry
-	if len(scopeTags) > 0 || explicitScopeRequested {
-		merged := append([]string(nil), scopeTags...)
-		merged = append(merged, e.alwaysActiveTags...)
-		if len(merged) > 0 {
-			reg = e.parentReg.FilterByTags(merged)
-		} else {
-			reg = e.parentReg.FilteredCopy(nil)
-		}
-		reg = reg.FilteredCopyExcluding([]string{delegateToolName})
-	} else if len(profile.AllowedTools) > 0 {
-		reg = e.parentReg.FilteredCopy(profile.AllowedTools)
-	} else {
-		reg = e.parentReg.FilteredCopyExcluding([]string{delegateToolName})
-	}
+	reg := e.delegateToolRegistry(scopeTags, explicitScopeRequested)
 
 	toolDefs := reg.List()
 	toolNames := reg.AllToolNames()
@@ -498,6 +546,7 @@ func (e *Executor) executeLegacy(ctx context.Context, task, profileName, guidanc
 		"guidance", truncate(guidance, 200),
 		"tags", scopeTags,
 		"inherited_tags", inheritedTags,
+		"profile_default_tags", profileDefaultTags,
 		"tools_available", len(toolDefs),
 	)
 
@@ -518,15 +567,6 @@ func (e *Executor) executeLegacy(ctx context.Context, task, profileName, guidanc
 		},
 	})
 
-	// Build system prompt.
-	var sb strings.Builder
-	sb.WriteString(profile.SystemPrompt)
-	sb.WriteString("\n\n")
-	sb.WriteString(awareness.CurrentConditions(e.timezone))
-
-	// Inject tag context (static files, KB articles, live providers).
-	// Falls back to the legacy forge-only injection when the tag
-	// context function is not configured.
 	// Build effective tag set: scoped tags + always-active + global lenses.
 	merged := make(map[string]bool, len(scopeTags)+len(e.alwaysActiveTags))
 	for _, t := range scopeTags {
@@ -540,21 +580,7 @@ func (e *Executor) executeLegacy(ctx context.Context, task, profileName, guidanc
 			merged[lens] = true
 		}
 	}
-	if e.tagCtxFunc != nil && len(merged) > 0 {
-		if tagCtx := e.tagCtxFunc(ctx, merged); tagCtx != "" {
-			sb.WriteString("\n\n## Capability Context\n\n")
-			sb.WriteString(tagCtx)
-		}
-	} else if e.forgeContext != "" {
-		sb.WriteString("\n\n")
-		sb.WriteString(e.forgeContext)
-	}
-
-	// Inject path prefix documentation so the delegate knows the shortcuts.
-	if prefixPrompt := formatPrefixPrompt(pathPrefixes, time.Now()); prefixPrompt != "" {
-		sb.WriteString("\n\n")
-		sb.WriteString(prefixPrompt)
-	}
+	systemPrompt := e.buildLegacySystemPrompt(ctx, merged, pathPrefixes)
 
 	// Expand temp file labels so the delegate sees real paths.
 	if e.tempFiles != nil {
@@ -574,7 +600,7 @@ func (e *Executor) executeLegacy(ctx context.Context, task, profileName, guidanc
 	}
 
 	messages := []llm.Message{
-		{Role: "system", Content: sb.String()},
+		{Role: "system", Content: systemPrompt},
 		{Role: "user", Content: userMsg.String()},
 	}
 
@@ -868,11 +894,11 @@ type preparedExecution struct {
 	profile          *Profile
 	routeHints       map[string]string
 	log              *slog.Logger
-	systemPrompt     string
 	userMessage      string
 	model            string
-	toolNames        []string
-	explicitTags     []string
+	scopeTags        []string
+	excludeTools     []string
+	tagFilterActive  bool
 	effectiveTags    []string
 	maxIterations    int
 	maxOutputTokens  int
@@ -983,7 +1009,10 @@ func (e *Executor) buildLoopLaunch(prep *preparedExecution, task, guidance strin
 			Operation:   operation,
 			Completion:  completion,
 			MaxDuration: loopMaxDuration,
-			Tags:        append([]string(nil), prep.explicitTags...),
+			Tags:        append([]string(nil), prep.scopeTags...),
+			Profile: router.LoopProfile{
+				Instructions: prompts.DelegateRunInstructions,
+			},
 			Metadata: map[string]string{
 				"category":          "delegate",
 				"delegate_id":       prep.id,
@@ -998,10 +1027,9 @@ func (e *Executor) buildLoopLaunch(prep *preparedExecution, task, guidance strin
 		ChannelBinding:           prep.channelBinding.Clone(),
 		Model:                    prep.model,
 		Hints:                    hints,
-		AllowedTools:             append([]string(nil), prep.toolNames...),
-		SkipTagFilter:            len(prep.explicitTags) == 0,
+		ExcludeTools:             append([]string(nil), prep.excludeTools...),
+		SkipTagFilter:            !prep.tagFilterActive,
 		InitialTags:              append([]string(nil), prep.effectiveTags...),
-		SystemPrompt:             prep.systemPrompt,
 		MaxIterations:            prep.maxIterations,
 		MaxOutputTokens:          prep.maxOutputTokens,
 		ToolTimeout:              prep.toolTimeout,
@@ -1145,29 +1173,20 @@ func (e *Executor) prepareExecution(ctx context.Context, task, profileName, guid
 	if profile == nil {
 		profile = e.profiles["general"]
 	}
-	scopeTags, inheritedTags, droppedTags, explicitScopeRequested := mergeDelegateScopeTags(ctx, tags, opts.inheritCallerTags)
+	scopeTags, inheritedTags, droppedTags, explicitScopeRequested := mergeDelegateScopeTags(ctx, tags, opts.inheritCallerTags, opts.explicitTagScope)
 	if len(droppedTags) > 0 {
 		log.Warn("delegate capability tags skipped", "dropped_tags", droppedTags)
 	}
+	scopeTags, profileDefaultTags := applyProfileDefaultTags(scopeTags, profile, explicitScopeRequested)
 
-	var reg *tools.Registry
-	if len(scopeTags) > 0 || explicitScopeRequested {
-		merged := append([]string(nil), scopeTags...)
-		merged = append(merged, e.alwaysActiveTags...)
-		if len(merged) > 0 {
-			reg = e.parentReg.FilterByTags(merged)
-		} else {
-			reg = e.parentReg.FilteredCopy(nil)
-		}
-		reg = reg.FilteredCopyExcluding([]string{delegateToolName})
-	} else if len(profile.AllowedTools) > 0 {
-		reg = e.parentReg.FilteredCopy(profile.AllowedTools)
-	} else {
-		reg = e.parentReg.FilteredCopyExcluding([]string{delegateToolName})
-	}
+	reg := e.delegateToolRegistry(scopeTags, explicitScopeRequested)
 	toolDefs := reg.List()
-	toolNames := reg.AllToolNames()
-	sort.Strings(toolNames)
+	var excludeTools []string
+	if explicitScopeRequested && len(scopeTags) == 0 && len(e.alwaysActiveTags) == 0 {
+		excludeTools = e.parentReg.AllToolNames()
+		sort.Strings(excludeTools)
+	}
+	tagFilterActive := len(scopeTags) > 0 || explicitScopeRequested
 
 	log = log.With("profile", profile.Name)
 	ctx = logging.WithLogger(ctx, log)
@@ -1176,6 +1195,7 @@ func (e *Executor) prepareExecution(ctx context.Context, task, profileName, guid
 		"guidance", truncate(guidance, 200),
 		"tags", scopeTags,
 		"inherited_tags", inheritedTags,
+		"profile_default_tags", profileDefaultTags,
 		"tools_available", len(toolDefs),
 	)
 
@@ -1196,24 +1216,6 @@ func (e *Executor) prepareExecution(ctx context.Context, task, profileName, guid
 		effectiveTags = append(effectiveTags, tag)
 	}
 	sort.Strings(effectiveTags)
-
-	var sb strings.Builder
-	sb.WriteString(profile.SystemPrompt)
-	sb.WriteString("\n\n")
-	sb.WriteString(awareness.CurrentConditions(e.timezone))
-	if e.tagCtxFunc != nil && len(effectiveTagsMap) > 0 {
-		if tagCtx := e.tagCtxFunc(ctx, effectiveTagsMap); tagCtx != "" {
-			sb.WriteString("\n\n## Capability Context\n\n")
-			sb.WriteString(tagCtx)
-		}
-	} else if e.forgeContext != "" {
-		sb.WriteString("\n\n")
-		sb.WriteString(e.forgeContext)
-	}
-	if prefixPrompt := formatPrefixPrompt(pathPrefixes, time.Now()); prefixPrompt != "" {
-		sb.WriteString("\n\n")
-		sb.WriteString(prefixPrompt)
-	}
 
 	if e.tempFiles != nil {
 		parentConvID := tools.ConversationIDFromContext(ctx)
@@ -1256,11 +1258,11 @@ func (e *Executor) prepareExecution(ctx context.Context, task, profileName, guid
 		profile:          profile,
 		routeHints:       e.effectiveDelegateRouterHints(ctx, profile),
 		log:              log,
-		systemPrompt:     sb.String(),
 		userMessage:      userMsg.String(),
 		model:            e.selectModel(ctx, task, profile, len(toolDefs)),
-		toolNames:        toolNames,
-		explicitTags:     append([]string(nil), scopeTags...),
+		scopeTags:        append([]string(nil), scopeTags...),
+		excludeTools:     excludeTools,
+		tagFilterActive:  tagFilterActive,
 		effectiveTags:    effectiveTags,
 		maxIterations:    maxIterations,
 		maxOutputTokens:  maxOutputTokens,

--- a/internal/runtime/delegate/delegate.go
+++ b/internal/runtime/delegate/delegate.go
@@ -140,8 +140,7 @@ func applyProfileDefaultTags(scopeTags []string, profile *Profile, explicitScope
 
 func (e *Executor) delegateToolRegistry(scopeTags []string, explicitScopeRequested bool) *tools.Registry {
 	if len(scopeTags) > 0 || explicitScopeRequested {
-		merged := append([]string(nil), scopeTags...)
-		merged = append(merged, e.alwaysActiveTags...)
+		merged := mergeTagLists(scopeTags, e.alwaysActiveTags)
 		var reg *tools.Registry
 		if len(merged) > 0 {
 			reg = e.parentReg.FilterByTags(merged)
@@ -151,6 +150,24 @@ func (e *Executor) delegateToolRegistry(scopeTags []string, explicitScopeRequest
 		return reg.FilteredCopyExcluding([]string{delegateToolName})
 	}
 	return e.parentReg.FilteredCopyExcluding([]string{delegateToolName})
+}
+
+func mergeTagLists(tagGroups ...[]string) []string {
+	seen := make(map[string]bool)
+	for _, tags := range tagGroups {
+		for _, tag := range tags {
+			tag = strings.TrimSpace(tag)
+			if tag != "" {
+				seen[tag] = true
+			}
+		}
+	}
+	merged := make([]string, 0, len(seen))
+	for tag := range seen {
+		merged = append(merged, tag)
+	}
+	sort.Strings(merged)
+	return merged
 }
 
 func (e *Executor) buildLegacySystemPrompt(ctx context.Context, effectiveTags map[string]bool, pathPrefixes map[string]string) string {
@@ -897,6 +914,7 @@ type preparedExecution struct {
 	userMessage      string
 	model            string
 	scopeTags        []string
+	filterTags       []string
 	excludeTools     []string
 	tagFilterActive  bool
 	effectiveTags    []string
@@ -1009,7 +1027,7 @@ func (e *Executor) buildLoopLaunch(prep *preparedExecution, task, guidance strin
 			Operation:   operation,
 			Completion:  completion,
 			MaxDuration: loopMaxDuration,
-			Tags:        append([]string(nil), prep.scopeTags...),
+			Tags:        append([]string(nil), prep.filterTags...),
 			Profile: router.LoopProfile{
 				Instructions: prompts.DelegateRunInstructions,
 			},
@@ -1181,8 +1199,9 @@ func (e *Executor) prepareExecution(ctx context.Context, task, profileName, guid
 
 	reg := e.delegateToolRegistry(scopeTags, explicitScopeRequested)
 	toolDefs := reg.List()
+	filterTags := mergeTagLists(scopeTags, e.alwaysActiveTags)
 	var excludeTools []string
-	if explicitScopeRequested && len(scopeTags) == 0 && len(e.alwaysActiveTags) == 0 {
+	if explicitScopeRequested && len(filterTags) == 0 {
 		excludeTools = e.parentReg.AllToolNames()
 		sort.Strings(excludeTools)
 	}
@@ -1261,6 +1280,7 @@ func (e *Executor) prepareExecution(ctx context.Context, task, profileName, guid
 		userMessage:      userMsg.String(),
 		model:            e.selectModel(ctx, task, profile, len(toolDefs)),
 		scopeTags:        append([]string(nil), scopeTags...),
+		filterTags:       filterTags,
 		excludeTools:     excludeTools,
 		tagFilterActive:  tagFilterActive,
 		effectiveTags:    effectiveTags,

--- a/internal/runtime/delegate/delegate_test.go
+++ b/internal/runtime/delegate/delegate_test.go
@@ -88,6 +88,10 @@ func newTestRegistry() *tools.Registry {
 			return "this should never be called by a delegate", nil
 		},
 	})
+	r.SetTagIndex(map[string][]string{
+		"ha":  {"get_state"},
+		"web": {"web_search"},
+	})
 	return r
 }
 
@@ -235,7 +239,7 @@ func TestExecute_LoopBackedPathUsesLaunch(t *testing.T) {
 	exec := NewExecutor(slog.Default(), nil, nil, newTestRegistry(), "spark/gpt-oss:20b")
 	exec.ConfigureLoopExecution(runner, looppkg.NewRegistry())
 
-	result, err := exec.Execute(context.Background(), "Check the office light", "ha", "Be concise", []string{"homeassistant"}, nil)
+	result, err := exec.Execute(context.Background(), "Check the office light", "ha", "Be concise", nil, nil)
 	if err != nil {
 		t.Fatalf("Execute() error = %v", err)
 	}
@@ -266,8 +270,8 @@ func TestExecute_LoopBackedPathUsesLaunch(t *testing.T) {
 	if captured.Model != "spark/gpt-oss:20b" {
 		t.Fatalf("captured Model = %q, want spark/gpt-oss:20b", captured.Model)
 	}
-	if captured.SystemPrompt == "" {
-		t.Fatal("SystemPrompt = empty, want delegate prompt")
+	if captured.SystemPrompt != "" {
+		t.Fatalf("SystemPrompt = %q, want loop-built prompt", captured.SystemPrompt)
 	}
 	if len(captured.Messages) != 1 || !strings.Contains(captured.Messages[0].Content, "Check the office light") || !strings.Contains(captured.Messages[0].Content, "Be concise") {
 		t.Fatalf("Messages = %#v", captured.Messages)
@@ -279,7 +283,13 @@ func TestExecute_LoopBackedPathUsesLaunch(t *testing.T) {
 		t.Fatalf("delegation gating hint = %q, want disabled", captured.Hints[router.HintDelegationGating])
 	}
 	if captured.SkipTagFilter {
-		t.Fatal("SkipTagFilter = true, want false for explicit tag-scoped delegate")
+		t.Fatal("SkipTagFilter = true, want false for ha profile default tag")
+	}
+	if !containsString(captured.InitialTags, "ha") {
+		t.Fatalf("InitialTags = %#v, want ha", captured.InitialTags)
+	}
+	if len(captured.AllowedTools) != 0 {
+		t.Fatalf("AllowedTools = %#v, want loop tag filtering", captured.AllowedTools)
 	}
 	if captured.UsageRole != "delegate" || captured.UsageTaskName != "ha" {
 		t.Fatalf("usage role/task = %q/%q", captured.UsageRole, captured.UsageTaskName)
@@ -317,11 +327,40 @@ func TestExecute_LoopBackedInheritsCallerTags(t *testing.T) {
 	if containsString(captured.InitialTags, "message_channel") {
 		t.Fatalf("InitialTags = %#v, should not inherit message_channel", captured.InitialTags)
 	}
-	if !containsString(captured.AllowedTools, "web_search") {
-		t.Fatalf("AllowedTools = %#v, want web_search", captured.AllowedTools)
+	if len(captured.AllowedTools) != 0 {
+		t.Fatalf("AllowedTools = %#v, want loop tag filtering", captured.AllowedTools)
 	}
-	if containsString(captured.AllowedTools, "send_reaction") {
-		t.Fatalf("AllowedTools = %#v, should not include send_reaction", captured.AllowedTools)
+}
+
+func TestExecute_LoopBackedExplicitEmptyTagsExposeNoTools(t *testing.T) {
+	t.Parallel()
+
+	var captured looppkg.Request
+	runner := &mockLoopRunner{
+		onRun: func(req looppkg.Request) {
+			captured = req
+		},
+		resp: &looppkg.Response{
+			Content: "delegate answer",
+			Model:   "deepslate/google/gemma-3-4b",
+		},
+	}
+
+	exec := NewExecutor(slog.Default(), nil, nil, newTestRegistry(), "spark/gpt-oss:20b")
+	exec.ConfigureLoopExecution(runner, looppkg.NewRegistry())
+
+	_, err := exec.execute(context.Background(), "No tools needed", "ha", "", []string{}, nil, executionOptions{
+		inheritCallerTags: false,
+		explicitTagScope:  true,
+	})
+	if err != nil {
+		t.Fatalf("execute() error = %v", err)
+	}
+
+	for _, want := range []string{"get_state", "web_search", "thane_delegate"} {
+		if !containsString(captured.ExcludeTools, want) {
+			t.Fatalf("ExcludeTools = %#v, want %s", captured.ExcludeTools, want)
+		}
 	}
 }
 
@@ -545,7 +584,7 @@ func TestExecute_ContextCancellation(t *testing.T) {
 }
 
 func TestExecute_HAProfileExcludesNonHATools(t *testing.T) {
-	// The HA profile should not have web_search or thane_delegate.
+	// The HA compatibility profile scopes through the ha capability tag.
 	mock := &mockLLMClient{
 		responses: []*llm.ChatResponse{
 			{
@@ -583,7 +622,7 @@ func TestExecute_HAProfileExcludesNonHATools(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Execute() error = %v", err)
 	}
-	// The tool call should fail because web_search is not in the HA profile.
+	// The tool call should fail because web_search is not in the ha tag scope.
 	// The delegate should still complete with the error in the tool result.
 	if result.Content != "Failed to search." {
 		t.Errorf("Content = %q, want %q", result.Content, "Failed to search.")
@@ -709,6 +748,9 @@ func TestBuiltinProfiles_HAForcesLocalOnly(t *testing.T) {
 	if ha.RouterHints[router.HintPreferSpeed] != "true" {
 		t.Errorf("ha profile HintPreferSpeed = %q, want %q",
 			ha.RouterHints[router.HintPreferSpeed], "true")
+	}
+	if len(ha.DefaultTags) != 1 || ha.DefaultTags[0] != "ha" {
+		t.Fatalf("ha profile DefaultTags = %#v, want [ha]", ha.DefaultTags)
 	}
 }
 
@@ -1853,6 +1895,34 @@ func TestExecute_CanDisableCallerTagInheritance(t *testing.T) {
 	}
 }
 
+func TestExecute_ExplicitTagsOverrideProfileDefaultTags(t *testing.T) {
+	mock := &mockLLMClient{
+		responses: []*llm.ChatResponse{
+			{
+				Model:        "test-model",
+				Message:      llm.Message{Role: "assistant", Content: "Web only."},
+				InputTokens:  100,
+				OutputTokens: 20,
+			},
+		},
+	}
+	reg := taggedDelegateTestRegistry()
+	exec := NewExecutor(slog.Default(), mock, nil, reg, "test-model")
+
+	_, err := exec.Execute(context.Background(), "Search only", "ha", "", []string{"web"}, nil)
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	toolNames := toolNameSet(mock.calls[0].Tools)
+	if !toolNames["web_search"] {
+		t.Fatalf("web_search should be available with explicit web scope: %v", toolNames)
+	}
+	if toolNames["get_state"] {
+		t.Fatalf("get_state should not be added from ha profile when explicit tags are provided: %v", toolNames)
+	}
+}
+
 func TestExecute_NonDelegableExplicitTagsDoNotFallBackToProfile(t *testing.T) {
 	mock := &mockLLMClient{
 		responses: []*llm.ChatResponse{
@@ -1867,7 +1937,7 @@ func TestExecute_NonDelegableExplicitTagsDoNotFallBackToProfile(t *testing.T) {
 	reg := taggedDelegateTestRegistry()
 	exec := NewExecutor(slog.Default(), mock, nil, reg, "test-model")
 
-	_, err := exec.Execute(context.Background(), "React from a delegate", "general", "", []string{"message_channel"}, nil)
+	_, err := exec.Execute(context.Background(), "React from a delegate", "ha", "", []string{"message_channel"}, nil)
 	if err != nil {
 		t.Fatalf("Execute() error = %v", err)
 	}
@@ -1955,8 +2025,8 @@ func containsString(values []string, want string) bool {
 	return false
 }
 
-func TestExecute_TagScoping_NilPreservesProfile(t *testing.T) {
-	// When tags is nil, profile-based filtering should apply (existing behavior).
+func TestExecute_TagScoping_NilUsesProfileDefaultTags(t *testing.T) {
+	// When tags is nil, the ha compatibility profile applies its default tag.
 	mock := &mockLLMClient{
 		responses: []*llm.ChatResponse{
 			{
@@ -1977,7 +2047,7 @@ func TestExecute_TagScoping_NilPreservesProfile(t *testing.T) {
 		t.Errorf("Content = %q, want %q", result.Content, "HA result.")
 	}
 
-	// The HA profile has a fixed AllowedTools list. Verify only those appear.
+	// The ha default tag scopes the visible tool surface.
 	if len(mock.calls) < 1 {
 		t.Fatal("expected at least 1 LLM call")
 	}
@@ -1991,14 +2061,14 @@ func TestExecute_TagScoping_NilPreservesProfile(t *testing.T) {
 		}
 	}
 
-	// web_search and thane_delegate should NOT be in HA profile.
+	// web_search and thane_delegate should NOT be in the ha scope.
 	if toolNames["web_search"] {
 		t.Error("web_search should not appear in HA profile tool definitions")
 	}
 	if toolNames["thane_delegate"] {
 		t.Error("thane_delegate should not appear in HA profile tool definitions")
 	}
-	// get_state should be in HA profile.
+	// get_state should be in the ha scope.
 	if !toolNames["get_state"] {
 		t.Error("get_state should appear in HA profile tool definitions")
 	}

--- a/internal/runtime/delegate/delegate_test.go
+++ b/internal/runtime/delegate/delegate_test.go
@@ -364,6 +364,46 @@ func TestExecute_LoopBackedExplicitEmptyTagsExposeNoTools(t *testing.T) {
 	}
 }
 
+func TestExecute_LoopBackedExplicitEmptyTagsWithAlwaysActiveTagsDoNotBypassFiltering(t *testing.T) {
+	t.Parallel()
+
+	var captured looppkg.Request
+	runner := &mockLoopRunner{
+		onRun: func(req looppkg.Request) {
+			captured = req
+		},
+		resp: &looppkg.Response{
+			Content: "delegate answer",
+			Model:   "deepslate/google/gemma-3-4b",
+		},
+	}
+
+	exec := NewExecutor(slog.Default(), nil, nil, newTestRegistry(), "spark/gpt-oss:20b")
+	exec.ConfigureLoopExecution(runner, looppkg.NewRegistry())
+	exec.SetAlwaysActiveTags([]string{"web"})
+
+	_, err := exec.execute(context.Background(), "No tools needed", "ha", "", []string{}, nil, executionOptions{
+		inheritCallerTags: false,
+		explicitTagScope:  true,
+	})
+	if err != nil {
+		t.Fatalf("execute() error = %v", err)
+	}
+
+	if captured.SkipTagFilter {
+		t.Fatal("SkipTagFilter = true, want false for explicit empty tag scope with always-active tags")
+	}
+	if !containsString(captured.InitialTags, "web") {
+		t.Fatalf("InitialTags = %#v, want always-active web tag", captured.InitialTags)
+	}
+	if containsString(captured.InitialTags, "ha") {
+		t.Fatalf("InitialTags = %#v, should not include ha profile default for explicit empty tag scope", captured.InitialTags)
+	}
+	if len(captured.ExcludeTools) != 0 {
+		t.Fatalf("ExcludeTools = %#v, want tag filtering through always-active tags", captured.ExcludeTools)
+	}
+}
+
 func TestRecordCompletion_UsesLiveModelRegistryForUsageIdentity(t *testing.T) {
 	db, err := database.OpenMemory()
 	if err != nil {

--- a/internal/runtime/delegate/profile.go
+++ b/internal/runtime/delegate/profile.go
@@ -17,12 +17,9 @@ type Profile struct {
 	// Description is a human-readable summary for logging.
 	Description string
 
-	// AllowedTools lists the tool names available to the delegate.
-	// An empty list means all tools (minus thane_delegate).
-	AllowedTools []string
-
-	// SystemPrompt is the profile-specific system prompt for the delegate.
-	SystemPrompt string
+	// DefaultTags are compatibility capability tags applied when the
+	// caller does not request an explicit tag scope.
+	DefaultTags []string
 
 	// RouterHints are passed to the router for model selection.
 	RouterHints map[string]string
@@ -48,14 +45,12 @@ const (
 	defaultToolTimeout = 30 * time.Second
 )
 
-// builtinProfiles returns the MVP delegation profiles.
+// builtinProfiles returns compatibility profiles for legacy callers.
 func builtinProfiles() map[string]*Profile {
 	return map[string]*Profile{
 		"general": {
-			Name:         "general",
-			Description:  "General-purpose delegation with all tools",
-			AllowedTools: nil, // all tools minus thane_delegate
-			SystemPrompt: generalSystemPrompt,
+			Name:        "general",
+			Description: "General-purpose delegation defaults",
 			RouterHints: map[string]string{
 				router.HintLocalOnly:    "true",
 				router.HintQualityFloor: "5",
@@ -68,15 +63,8 @@ func builtinProfiles() map[string]*Profile {
 		},
 		"ha": {
 			Name:        "ha",
-			Description: "Home Assistant device queries and control",
-			AllowedTools: []string{
-				"get_state",
-				"list_entities",
-				"control_device",
-				"call_service",
-				"find_entity",
-			},
-			SystemPrompt: haSystemPrompt,
+			Description: "Home Assistant budget and routing defaults",
+			DefaultTags: []string{"ha"},
 			RouterHints: map[string]string{
 				router.HintLocalOnly:    "true",
 				router.HintMission:      "device_control",
@@ -90,39 +78,3 @@ func builtinProfiles() map[string]*Profile {
 		},
 	}
 }
-
-const generalSystemPrompt = `You are a task executor. Complete the assigned task using the available tools.
-Report your findings clearly and concisely. Do not engage in conversation.
-Focus on completing the task and returning results.
-
-Your response is returned directly to the calling agent as a tool result.
-If you called tools and received data, you MUST include that data in your
-final text response. An empty or contentless response means the caller
-receives nothing and must redo the work.
-
-## Tool usage notes
-
-- File tool paths must be literal filesystem paths. The only expansion supported is a leading ~/ to your home directory; other shell expansions ($HOME, $(whoami), ~user) do NOT work in file tools. Use absolute paths like /path/to/project or ~/Documents.
-- If a task names a managed document ref like kb:article.md or core:mission.md, keep that semantic ref and prefer document tools over file tools when they are available. Do not rewrite managed refs into workspace-relative paths like kb/article.md.
-- For shell operations that need pipes, globs, or environment variable expansion, use the exec tool. The exec tool runs commands through a real shell where expansion works normally.
-- On macOS (Darwin), common CLI tools differ from GNU/Linux. In particular: sed requires sed -i '' (empty string argument), date flags differ from GNU coreutils, and stat output format is different. Check the platform in Current Conditions before writing platform-specific commands.
-- When a task involves finding files, prefer using the exec tool with find or ls rather than guessing paths with file tools.`
-
-const haSystemPrompt = `You are a Home Assistant task executor. Use the available tools to query or control Home Assistant devices.
-
-Entity IDs follow the pattern: domain.name (e.g., light.living_room, sensor.outdoor_temperature).
-Use find_entity when the user describes a device by name rather than entity_id.
-
-Report your findings clearly. Include entity states, values, and any relevant attributes.
-
-Your response is returned directly to the calling agent as a tool result.
-If you called tools and received data, you MUST include that data in your
-final text response. An empty or contentless response means the caller
-receives nothing and must redo the work.
-
-## Tool usage notes
-
-- Always use find_entity to look up the correct entity ID before calling get_state or control_device. Do not guess entity IDs — naming conventions vary across installations.
-- Entity state values are strings. Compare with string values like "on", "off", "unavailable" — not booleans or numbers.
-- When controlling devices, verify the entity exists and check its current state before sending commands. This avoids errors from typos or unavailable devices.
-- Some entities expose useful data in their attributes (e.g., brightness, temperature, battery level). Include relevant attributes in your response when they add context.`

--- a/internal/runtime/delegate/tool.go
+++ b/internal/runtime/delegate/tool.go
@@ -39,6 +39,7 @@ func ToolDefinition() map[string]any {
 				"description": "Optional capability tags to scope the delegate's tools. " +
 					"When provided, the delegate only sees tools from these tags " +
 					"(plus inherited elective caller tags and always-active tags). " +
+					"Use root entry-point tags when the delegate should choose a narrower branch; use leaf tags when you already know the needed toolset. " +
 					"Omit to inherit the caller's elective task context and any compatibility profile default tags.",
 			},
 			"inherit_caller_tags": map[string]any{

--- a/internal/runtime/delegate/tool.go
+++ b/internal/runtime/delegate/tool.go
@@ -20,9 +20,8 @@ func ToolDefinition() map[string]any {
 			},
 			"profile": map[string]any{
 				"type":        "string",
-				"enum":        []string{"general", "ha"},
 				"default":     "general",
-				"description": "Delegation profile — controls which tools and context the delegate receives",
+				"description": "Compatibility profile for budget and routing defaults. Prefer tags for capability scoping. The ha profile adds the ha tag only when tags are omitted.",
 			},
 			"mode": map[string]any{
 				"type":        "string",
@@ -40,7 +39,7 @@ func ToolDefinition() map[string]any {
 				"description": "Optional capability tags to scope the delegate's tools. " +
 					"When provided, the delegate only sees tools from these tags " +
 					"(plus inherited elective caller tags and always-active tags). " +
-					"Omit to inherit the caller's elective task context or use the profile's default toolset.",
+					"Omit to inherit the caller's elective task context and any compatibility profile default tags.",
 			},
 			"inherit_caller_tags": map[string]any{
 				"type":        "boolean",
@@ -91,7 +90,10 @@ func ToolHandler(exec *Executor) func(ctx context.Context, args map[string]any) 
 		}
 
 		var tags []string
+		tagsProvided := false
 		if rawTags, ok := args["tags"].([]any); ok {
+			tagsProvided = true
+			tags = make([]string, 0, len(rawTags))
 			for _, rt := range rawTags {
 				if s, ok := rt.(string); ok {
 					tags = append(tags, s)
@@ -109,7 +111,10 @@ func ToolHandler(exec *Executor) func(ctx context.Context, args map[string]any) 
 			}
 		}
 
-		opts := executionOptions{inheritCallerTags: inheritCallerTags}
+		opts := executionOptions{
+			inheritCallerTags: inheritCallerTags,
+			explicitTagScope:  tagsProvided,
+		}
 		if mode == "async" {
 			loopID, err := exec.startBackground(ctx, task, profileName, guidance, tags, pathPrefixes, opts)
 			if err != nil {


### PR DESCRIPTION
## Summary

Modernizes delegate profiles so they act as compatibility defaults instead of owning a parallel prompt and tool-surface system.

This moves delegate scoping toward the same capability-tag model used by the rest of Thane. The `ha` profile now preserves legacy caller behavior by supplying a default `ha` tag when the caller does not provide explicit tags, while explicit tags remain the primary way to shape delegate tools and context.

## What changed

- Removed profile-owned hardcoded system prompts and fixed `AllowedTools` lists from delegate profiles.
- Added profile default tags, with `ha` mapping to the `ha` capability tag only when no explicit tag scope is requested.
- Stopped loop-backed delegates from passing a custom `SystemPrompt` or synthetic `AllowedTools`; spawned delegate loops now use the normal loop prompt assembly path.
- Preserved strict explicit-empty tag behavior by excluding the available tool surface when the caller deliberately requests an empty scope.
- Updated the `thane_delegate` model-facing schema to present tags as the primary scoping mechanism and profiles as compatibility budget/routing hints.
- Clarified that parent loops should delegate with root entry-point tags when the delegate should follow the capability menu tree, and leaf tags when the needed toolset is already known.
- Refreshed docs and generated config comments so they describe profiles as budget/timeout/routing compatibility, not tool partitions.

## Validation

- `GOCACHE=/tmp/thane-go-build-cache just test`
- `GOCACHE=/tmp/thane-go-build-cache just ci`

Refs #753