### PR TITLE
feat: add generated document provenance metadata

### DIFF
--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -192,7 +192,7 @@ filesystem access. See
 | Tool | Description |
 |------|-------------|
 | `media_transcript` | Fetch a video/podcast transcript via yt-dlp. Also tagged `web`. |
-| `media_save_analysis` | Save a media analysis to the configured vault. |
+| `media_save_analysis` | Save a media analysis to the configured vault with generated-document provenance. |
 
 ## `feeds` — RSS/Atom and channel subscriptions
 

--- a/docs/understanding/document-roots.md
+++ b/docs/understanding/document-roots.md
@@ -92,6 +92,35 @@ time.
 - If a root is very high integrity or operationally sensitive, be
   deliberate about how you want it managed and edited.
 
+## Generated Documents
+
+Generated markdown should be legible to both people and the document
+index. When Thane intentionally writes an artifact into a managed root,
+the file should include document-local provenance in frontmatter:
+
+```yaml
+generated_by: "media_save_analysis"
+generated_at: "2026-04-26T18:14:15Z"
+document_kind: "media_analysis"
+refresh_strategy: "immutable"
+source_refs:
+  - "url:https://example.test/watch?v=abc123"
+  - "feed:security-news"
+managed_root: "generated"
+```
+
+These fields answer a different question than git history. Frontmatter
+tells Thane what kind of generated artifact it is, what source material
+it came from, and how future refreshes should treat it. Root-level git
+history and signature policy can still answer who changed a file and
+whether that change is trusted.
+
+Use `source_refs` for compact, typed references such as URLs,
+conversation IDs, Home Assistant entity IDs, attachment hashes, or feed
+IDs. Use `refresh_strategy` to distinguish one-shot immutable artifacts
+from generated files that are replaced, appended to, or maintained as a
+rolling window.
+
 ## Special Case: `core`
 
 The `core:` root is reserved.

--- a/internal/integrations/media/tools_analysis.go
+++ b/internal/integrations/media/tools_analysis.go
@@ -167,6 +167,7 @@ func (at *AnalysisTools) SaveHandler() func(ctx context.Context, args map[string
 			Title:        title,
 			Channel:      channel,
 			URL:          entryURL,
+			FeedID:       feedIDParam,
 			Published:    published,
 			Topics:       topics,
 			TrustZone:    trustZone,

--- a/internal/integrations/media/vault.go
+++ b/internal/integrations/media/vault.go
@@ -11,6 +11,8 @@ import (
 	"sort"
 	"strings"
 	"time"
+
+	"github.com/nugget/thane-ai-agent/internal/state/documents"
 )
 
 // AnalysisPage holds the data for a single media analysis markdown file.
@@ -20,11 +22,13 @@ type AnalysisPage struct {
 	Title        string
 	Channel      string
 	URL          string
+	FeedID       string
 	Published    string // YYYY-MM-DD or empty (falls back to today)
 	Topics       []string
 	TrustZone    string
 	QualityScore float64
 	AnalyzedAt   time.Time
+	ManagedRoot  string
 	Content      string // Markdown body written by the agent
 }
 
@@ -152,6 +156,22 @@ func (w *VaultWriter) buildMarkdown(page *AnalysisPage) string {
 		analyzedAt = time.Now().UTC()
 	}
 	sb.WriteString(fmt.Sprintf("analyzed: %s\n", analyzedAt.Format(time.RFC3339)))
+	if generatedRaw, err := documents.RenderGeneratedFrontmatter(documents.GeneratedMetadata{
+		GeneratedBy:     "media_save_analysis",
+		GeneratedAt:     analyzedAt,
+		SourceRefs:      mediaAnalysisSourceRefs(page),
+		DocumentKind:    documents.DocumentKindMediaAnalysis,
+		RefreshStrategy: documents.RefreshStrategyImmutable,
+		ManagedRoot:     page.ManagedRoot,
+	}); err == nil {
+		sb.WriteString(generatedRaw)
+		sb.WriteString("\n")
+	} else {
+		w.logger.Warn("failed to render generated document metadata",
+			"title", page.Title,
+			"error", err,
+		)
+	}
 
 	sb.WriteString("---\n\n")
 
@@ -203,12 +223,28 @@ func (w *VaultWriter) updateChannelIndex(channelDir, channelName, trustZone stri
 	})
 
 	var sb strings.Builder
+	updatedAt := time.Now().UTC()
 	sb.WriteString("---\n")
 	sb.WriteString(fmt.Sprintf("channel: %q\n", channelName))
 	if trustZone != "" {
 		sb.WriteString(fmt.Sprintf("trust_zone: %q\n", trustZone))
 	}
-	sb.WriteString(fmt.Sprintf("updated: %s\n", time.Now().UTC().Format(time.RFC3339)))
+	sb.WriteString(fmt.Sprintf("updated: %s\n", updatedAt.Format(time.RFC3339)))
+	if generatedRaw, err := documents.RenderGeneratedFrontmatter(documents.GeneratedMetadata{
+		GeneratedBy:     "media_vault_writer",
+		GeneratedAt:     updatedAt,
+		SourceRefs:      []string{"channel:" + channelName},
+		DocumentKind:    documents.DocumentKindMediaChannelIndex,
+		RefreshStrategy: documents.RefreshStrategyReplace,
+	}); err == nil {
+		sb.WriteString(generatedRaw)
+		sb.WriteString("\n")
+	} else {
+		w.logger.Warn("failed to render generated channel index metadata",
+			"channel", channelName,
+			"error", err,
+		)
+	}
 	sb.WriteString("---\n\n")
 	sb.WriteString(fmt.Sprintf("# %s\n\n", channelName))
 	sb.WriteString("## Analyses\n\n")
@@ -219,6 +255,17 @@ func (w *VaultWriter) updateChannelIndex(channelDir, channelName, trustZone stri
 
 	indexPath := filepath.Join(channelDir, "_channel.md")
 	return os.WriteFile(indexPath, []byte(sb.String()), 0o644)
+}
+
+func mediaAnalysisSourceRefs(page *AnalysisPage) []string {
+	refs := make([]string, 0, 2)
+	if page.URL != "" {
+		refs = append(refs, "url:"+page.URL)
+	}
+	if page.FeedID != "" {
+		refs = append(refs, "feed:"+page.FeedID)
+	}
+	return refs
 }
 
 // extractTitle reads the first markdown heading from a file.

--- a/internal/integrations/media/vault.go
+++ b/internal/integrations/media/vault.go
@@ -102,7 +102,10 @@ func (w *VaultWriter) WriteAnalysis(outputPath string, page *AnalysisPage) (stri
 	filePath := filepath.Join(channelDir, filename)
 
 	// Build the markdown content.
-	content := w.buildMarkdown(page)
+	content, err := w.buildMarkdown(page)
+	if err != nil {
+		return "", fmt.Errorf("build analysis markdown: %w", err)
+	}
 
 	if err := os.WriteFile(filePath, []byte(content), 0o644); err != nil {
 		return "", fmt.Errorf("write analysis file: %w", err)
@@ -126,7 +129,7 @@ func (w *VaultWriter) WriteAnalysis(outputPath string, page *AnalysisPage) (stri
 }
 
 // buildMarkdown assembles the YAML frontmatter and body.
-func (w *VaultWriter) buildMarkdown(page *AnalysisPage) string {
+func (w *VaultWriter) buildMarkdown(page *AnalysisPage) (string, error) {
 	var sb strings.Builder
 
 	sb.WriteString("---\n")
@@ -156,22 +159,19 @@ func (w *VaultWriter) buildMarkdown(page *AnalysisPage) string {
 		analyzedAt = time.Now().UTC()
 	}
 	sb.WriteString(fmt.Sprintf("analyzed: %s\n", analyzedAt.Format(time.RFC3339)))
-	if generatedRaw, err := documents.RenderGeneratedFrontmatter(documents.GeneratedMetadata{
+	generatedRaw, err := documents.RenderGeneratedFrontmatter(documents.GeneratedMetadata{
 		GeneratedBy:     "media_save_analysis",
 		GeneratedAt:     analyzedAt,
 		SourceRefs:      mediaAnalysisSourceRefs(page),
 		DocumentKind:    documents.DocumentKindMediaAnalysis,
 		RefreshStrategy: documents.RefreshStrategyImmutable,
 		ManagedRoot:     page.ManagedRoot,
-	}); err == nil {
-		sb.WriteString(generatedRaw)
-		sb.WriteString("\n")
-	} else {
-		w.logger.Warn("failed to render generated document metadata",
-			"title", page.Title,
-			"error", err,
-		)
+	})
+	if err != nil {
+		return "", fmt.Errorf("render generated document metadata: %w", err)
 	}
+	sb.WriteString(generatedRaw)
+	sb.WriteString("\n")
 
 	sb.WriteString("---\n\n")
 
@@ -183,7 +183,7 @@ func (w *VaultWriter) buildMarkdown(page *AnalysisPage) string {
 		sb.WriteString("\n")
 	}
 
-	return sb.String()
+	return sb.String(), nil
 }
 
 // updateChannelIndex rebuilds the _channel.md index file by scanning
@@ -230,21 +230,18 @@ func (w *VaultWriter) updateChannelIndex(channelDir, channelName, trustZone stri
 		sb.WriteString(fmt.Sprintf("trust_zone: %q\n", trustZone))
 	}
 	sb.WriteString(fmt.Sprintf("updated: %s\n", updatedAt.Format(time.RFC3339)))
-	if generatedRaw, err := documents.RenderGeneratedFrontmatter(documents.GeneratedMetadata{
+	generatedRaw, err := documents.RenderGeneratedFrontmatter(documents.GeneratedMetadata{
 		GeneratedBy:     "media_vault_writer",
 		GeneratedAt:     updatedAt,
 		SourceRefs:      []string{"channel:" + channelName},
 		DocumentKind:    documents.DocumentKindMediaChannelIndex,
 		RefreshStrategy: documents.RefreshStrategyReplace,
-	}); err == nil {
-		sb.WriteString(generatedRaw)
-		sb.WriteString("\n")
-	} else {
-		w.logger.Warn("failed to render generated channel index metadata",
-			"channel", channelName,
-			"error", err,
-		)
+	})
+	if err != nil {
+		return fmt.Errorf("render generated channel index metadata: %w", err)
 	}
+	sb.WriteString(generatedRaw)
+	sb.WriteString("\n")
 	sb.WriteString("---\n\n")
 	sb.WriteString(fmt.Sprintf("# %s\n\n", channelName))
 	sb.WriteString("## Analyses\n\n")

--- a/internal/integrations/media/vault_test.go
+++ b/internal/integrations/media/vault_test.go
@@ -64,6 +64,7 @@ func TestWriteAnalysis(t *testing.T) {
 		Title:        "Annie Jacobsen: Nuclear War & Area 51",
 		Channel:      "Lex Fridman Podcast",
 		URL:          "https://youtube.com/watch?v=test123",
+		FeedID:       "lex-fridman",
 		Published:    "2026-03-15",
 		Topics:       []string{"nuclear-war", "area-51", "existential-risk"},
 		TrustZone:    "known",
@@ -116,6 +117,21 @@ func TestWriteAnalysis(t *testing.T) {
 	}
 	if !strings.Contains(content, `- "nuclear-war"`) {
 		t.Error("missing topic in frontmatter")
+	}
+	if !strings.Contains(content, `generated_by: "media_save_analysis"`) {
+		t.Error("missing generated_by provenance field")
+	}
+	if !strings.Contains(content, `generated_at: "2026-03-15T14:30:00Z"`) {
+		t.Error("missing generated_at provenance field")
+	}
+	if !strings.Contains(content, `document_kind: "media_analysis"`) {
+		t.Error("missing document_kind provenance field")
+	}
+	if !strings.Contains(content, `refresh_strategy: "immutable"`) {
+		t.Error("missing refresh_strategy provenance field")
+	}
+	if !strings.Contains(content, `"feed:lex-fridman"`) || !strings.Contains(content, `"url:https://youtube.com/watch?v=test123"`) {
+		t.Error("missing source_refs provenance values")
 	}
 
 	// Check body.
@@ -214,6 +230,18 @@ func TestWriteAnalysis_ChannelIndex(t *testing.T) {
 	// Check frontmatter.
 	if !strings.Contains(index, `channel: "Index Test"`) {
 		t.Error("channel index missing channel name")
+	}
+	if !strings.Contains(index, `generated_by: "media_vault_writer"`) {
+		t.Error("channel index missing generated_by provenance field")
+	}
+	if !strings.Contains(index, `document_kind: "media_channel_index"`) {
+		t.Error("channel index missing document_kind provenance field")
+	}
+	if !strings.Contains(index, `refresh_strategy: "replace"`) {
+		t.Error("channel index missing refresh_strategy provenance field")
+	}
+	if !strings.Contains(index, "source_refs:") || !strings.Contains(index, `"channel:Index Test"`) {
+		t.Error("channel index missing source_refs provenance field")
 	}
 
 	// Check both entries are listed.

--- a/internal/state/documents/generated.go
+++ b/internal/state/documents/generated.go
@@ -1,0 +1,140 @@
+package documents
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	// GeneratedFieldBy is the frontmatter field naming the subsystem or
+	// loop that produced a generated document.
+	GeneratedFieldBy = "generated_by"
+	// GeneratedFieldAt is the frontmatter field recording when a generated
+	// document was produced.
+	GeneratedFieldAt = "generated_at"
+	// GeneratedFieldSourceRefs is the frontmatter field listing source
+	// references used to produce a generated document.
+	GeneratedFieldSourceRefs = "source_refs"
+	// GeneratedFieldDocumentKind is the frontmatter field describing the
+	// semantic kind of generated document.
+	GeneratedFieldDocumentKind = "document_kind"
+	// GeneratedFieldRefreshStrategy is the frontmatter field describing how
+	// repeated generation should treat the document.
+	GeneratedFieldRefreshStrategy = "refresh_strategy"
+	// GeneratedFieldManagedRoot is the optional frontmatter field naming the
+	// managed root prefix when the writer knows it.
+	GeneratedFieldManagedRoot = "managed_root"
+)
+
+const (
+	// RefreshStrategyImmutable marks generated documents that should be
+	// written once and left unchanged.
+	RefreshStrategyImmutable = "immutable"
+	// RefreshStrategyReplace marks generated documents that are replaced in
+	// full on refresh.
+	RefreshStrategyReplace = "replace"
+	// RefreshStrategyAppend marks generated documents that grow by appending
+	// new entries.
+	RefreshStrategyAppend = "append"
+	// RefreshStrategyRollingWindow marks generated documents that keep a
+	// bounded recent window.
+	RefreshStrategyRollingWindow = "rolling-window"
+)
+
+const (
+	// DocumentKindMediaAnalysis identifies a generated media analysis page.
+	DocumentKindMediaAnalysis = "media_analysis"
+	// DocumentKindMediaChannelIndex identifies an automatically maintained
+	// media channel index page.
+	DocumentKindMediaChannelIndex = "media_channel_index"
+)
+
+// GeneratedMetadata is the document-local provenance contract for generated
+// markdown artifacts in managed document roots. It intentionally uses only
+// flat frontmatter fields so the document index can filter and expose it
+// without nested YAML support.
+type GeneratedMetadata struct {
+	GeneratedBy     string    `json:"generated_by" yaml:"generated_by"`
+	GeneratedAt     time.Time `json:"generated_at" yaml:"generated_at"`
+	SourceRefs      []string  `json:"source_refs,omitempty" yaml:"source_refs,omitempty"`
+	DocumentKind    string    `json:"document_kind" yaml:"document_kind"`
+	RefreshStrategy string    `json:"refresh_strategy" yaml:"refresh_strategy"`
+	ManagedRoot     string    `json:"managed_root,omitempty" yaml:"managed_root,omitempty"`
+}
+
+// Validate reports whether metadata has the minimum fields required for a
+// generated document to be machine-legible.
+func (m GeneratedMetadata) Validate() error {
+	if strings.TrimSpace(m.GeneratedBy) == "" {
+		return fmt.Errorf("%s is required", GeneratedFieldBy)
+	}
+	if m.GeneratedAt.IsZero() {
+		return fmt.Errorf("%s is required", GeneratedFieldAt)
+	}
+	if strings.TrimSpace(m.DocumentKind) == "" {
+		return fmt.Errorf("%s is required", GeneratedFieldDocumentKind)
+	}
+	if strings.TrimSpace(m.RefreshStrategy) == "" {
+		return fmt.Errorf("%s is required", GeneratedFieldRefreshStrategy)
+	}
+	return nil
+}
+
+// Frontmatter returns the generated-document metadata as index-compatible
+// frontmatter values. Empty optional fields are omitted.
+func (m GeneratedMetadata) Frontmatter() map[string][]string {
+	meta := make(map[string][]string, 6)
+	if value := strings.TrimSpace(m.GeneratedBy); value != "" {
+		meta[GeneratedFieldBy] = []string{value}
+	}
+	if !m.GeneratedAt.IsZero() {
+		meta[GeneratedFieldAt] = []string{m.GeneratedAt.UTC().Format(time.RFC3339)}
+	}
+	if values := normalizeFrontmatterValues(m.SourceRefs); len(values) > 0 {
+		meta[GeneratedFieldSourceRefs] = values
+	}
+	if value := strings.TrimSpace(m.DocumentKind); value != "" {
+		meta[GeneratedFieldDocumentKind] = []string{value}
+	}
+	if value := strings.TrimSpace(m.RefreshStrategy); value != "" {
+		meta[GeneratedFieldRefreshStrategy] = []string{value}
+	}
+	if value := strings.TrimSpace(m.ManagedRoot); value != "" {
+		meta[GeneratedFieldManagedRoot] = []string{value}
+	}
+	return meta
+}
+
+// RenderGeneratedFrontmatter renders generated-document metadata as YAML
+// frontmatter lines suitable for insertion into a larger frontmatter block.
+func RenderGeneratedFrontmatter(m GeneratedMetadata) (string, error) {
+	if err := m.Validate(); err != nil {
+		return "", err
+	}
+	meta := m.Frontmatter()
+	lines := make([]string, 0, len(meta)+len(meta[GeneratedFieldSourceRefs]))
+	for _, key := range []string{
+		GeneratedFieldBy,
+		GeneratedFieldAt,
+		GeneratedFieldDocumentKind,
+		GeneratedFieldRefreshStrategy,
+		GeneratedFieldSourceRefs,
+		GeneratedFieldManagedRoot,
+	} {
+		values := meta[key]
+		if len(values) == 0 {
+			continue
+		}
+		if key == GeneratedFieldSourceRefs {
+			lines = append(lines, key+":")
+			for _, value := range values {
+				lines = append(lines, "  - "+strconv.Quote(value))
+			}
+			continue
+		}
+		lines = append(lines, fmt.Sprintf("%s: %s", key, strconv.Quote(values[0])))
+	}
+	return strings.Join(lines, "\n"), nil
+}

--- a/internal/state/documents/generated.go
+++ b/internal/state/documents/generated.go
@@ -128,10 +128,7 @@ func RenderGeneratedFrontmatter(m GeneratedMetadata) (string, error) {
 			continue
 		}
 		if key == GeneratedFieldSourceRefs {
-			lines = append(lines, key+":")
-			for _, value := range values {
-				lines = append(lines, "  - "+strconv.Quote(value))
-			}
+			lines = appendBlockListFrontmatter(lines, key, values)
 			continue
 		}
 		lines = append(lines, fmt.Sprintf("%s: %s", key, strconv.Quote(values[0])))

--- a/internal/state/documents/generated_test.go
+++ b/internal/state/documents/generated_test.go
@@ -74,6 +74,25 @@ func TestRenderGeneratedFrontmatter(t *testing.T) {
 	}
 }
 
+func TestRenderFrontmatterUsesBlockListForSourceRefs(t *testing.T) {
+	t.Parallel()
+
+	raw := renderFrontmatter(map[string][]string{
+		GeneratedFieldSourceRefs: {"url:https://example.test/watch?v=a,b", "feed:security-news"},
+	})
+
+	if !strings.Contains(raw, "source_refs:\n") {
+		t.Fatalf("rendered frontmatter = %q, want source_refs block list", raw)
+	}
+	if strings.Contains(raw, `source_refs: ["`) {
+		t.Fatalf("rendered frontmatter = %q, should not use flow sequence for source_refs", raw)
+	}
+	parsed := parseFrontmatterMap(raw)
+	if got := parsed[GeneratedFieldSourceRefs]; len(got) != 2 || got[0] != "feed:security-news" || got[1] != "url:https://example.test/watch?v=a,b" {
+		t.Fatalf("parsed %s = %#v, want comma-bearing URL preserved", GeneratedFieldSourceRefs, got)
+	}
+}
+
 func TestRenderGeneratedFrontmatterRequiresCoreFields(t *testing.T) {
 	t.Parallel()
 
@@ -121,6 +140,7 @@ func TestRenderGeneratedFrontmatterRequiresCoreFields(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/state/documents/generated_test.go
+++ b/internal/state/documents/generated_test.go
@@ -1,0 +1,133 @@
+package documents
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestGeneratedMetadataFrontmatter(t *testing.T) {
+	t.Parallel()
+
+	generatedAt := time.Date(2026, 4, 26, 13, 14, 15, 0, time.FixedZone("test", -5*60*60))
+	meta := GeneratedMetadata{
+		GeneratedBy:     "media_save_analysis",
+		GeneratedAt:     generatedAt,
+		SourceRefs:      []string{" url:https://example.test/a ", "", "feed:alpha", "feed:alpha"},
+		DocumentKind:    DocumentKindMediaAnalysis,
+		RefreshStrategy: RefreshStrategyImmutable,
+		ManagedRoot:     "generated",
+	}.Frontmatter()
+
+	if got := firstValue(meta, GeneratedFieldBy); got != "media_save_analysis" {
+		t.Fatalf("%s = %q, want media_save_analysis", GeneratedFieldBy, got)
+	}
+	if got := firstValue(meta, GeneratedFieldAt); got != "2026-04-26T18:14:15Z" {
+		t.Fatalf("%s = %q, want UTC RFC3339 timestamp", GeneratedFieldAt, got)
+	}
+	if got := meta[GeneratedFieldSourceRefs]; len(got) != 2 || got[0] != "feed:alpha" || got[1] != "url:https://example.test/a" {
+		t.Fatalf("%s = %#v, want normalized unique source refs", GeneratedFieldSourceRefs, got)
+	}
+	if got := firstValue(meta, GeneratedFieldDocumentKind); got != DocumentKindMediaAnalysis {
+		t.Fatalf("%s = %q, want %q", GeneratedFieldDocumentKind, got, DocumentKindMediaAnalysis)
+	}
+	if got := firstValue(meta, GeneratedFieldRefreshStrategy); got != RefreshStrategyImmutable {
+		t.Fatalf("%s = %q, want %q", GeneratedFieldRefreshStrategy, got, RefreshStrategyImmutable)
+	}
+	if got := firstValue(meta, GeneratedFieldManagedRoot); got != "generated" {
+		t.Fatalf("%s = %q, want generated", GeneratedFieldManagedRoot, got)
+	}
+}
+
+func TestRenderGeneratedFrontmatter(t *testing.T) {
+	t.Parallel()
+
+	raw, err := RenderGeneratedFrontmatter(GeneratedMetadata{
+		GeneratedBy:     "perception_loop",
+		GeneratedAt:     time.Date(2026, 4, 26, 18, 14, 15, 0, time.UTC),
+		SourceRefs:      []string{"ha:camera.front_door"},
+		DocumentKind:    "rolling_summary",
+		RefreshStrategy: RefreshStrategyRollingWindow,
+	})
+	if err != nil {
+		t.Fatalf("RenderGeneratedFrontmatter: %v", err)
+	}
+
+	for _, want := range []string{
+		`generated_by: "perception_loop"`,
+		`generated_at: "2026-04-26T18:14:15Z"`,
+		`document_kind: "rolling_summary"`,
+		`refresh_strategy: "rolling-window"`,
+		"source_refs:\n  - \"ha:camera.front_door\"",
+	} {
+		if !strings.Contains(raw, want) {
+			t.Fatalf("rendered frontmatter = %q, want %q", raw, want)
+		}
+	}
+
+	parsed := parseFrontmatterMap(raw)
+	if got := firstValue(parsed, GeneratedFieldDocumentKind); got != "rolling_summary" {
+		t.Fatalf("parsed %s = %q, want rolling_summary", GeneratedFieldDocumentKind, got)
+	}
+	if got := parsed[GeneratedFieldSourceRefs]; len(got) != 1 || got[0] != "ha:camera.front_door" {
+		t.Fatalf("parsed %s = %#v, want source ref", GeneratedFieldSourceRefs, got)
+	}
+}
+
+func TestRenderGeneratedFrontmatterRequiresCoreFields(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		meta GeneratedMetadata
+		want string
+	}{
+		{
+			name: "missing generator",
+			meta: GeneratedMetadata{
+				GeneratedAt:     time.Now(),
+				DocumentKind:    DocumentKindMediaAnalysis,
+				RefreshStrategy: RefreshStrategyImmutable,
+			},
+			want: GeneratedFieldBy,
+		},
+		{
+			name: "missing timestamp",
+			meta: GeneratedMetadata{
+				GeneratedBy:     "media_save_analysis",
+				DocumentKind:    DocumentKindMediaAnalysis,
+				RefreshStrategy: RefreshStrategyImmutable,
+			},
+			want: GeneratedFieldAt,
+		},
+		{
+			name: "missing kind",
+			meta: GeneratedMetadata{
+				GeneratedBy:     "media_save_analysis",
+				GeneratedAt:     time.Now(),
+				RefreshStrategy: RefreshStrategyImmutable,
+			},
+			want: GeneratedFieldDocumentKind,
+		},
+		{
+			name: "missing refresh strategy",
+			meta: GeneratedMetadata{
+				GeneratedBy:  "media_save_analysis",
+				GeneratedAt:  time.Now(),
+				DocumentKind: DocumentKindMediaAnalysis,
+			},
+			want: GeneratedFieldRefreshStrategy,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := RenderGeneratedFrontmatter(tt.meta)
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("RenderGeneratedFrontmatter error = %v, want field %q", err, tt.want)
+			}
+		})
+	}
+}

--- a/internal/state/documents/mutate_helpers.go
+++ b/internal/state/documents/mutate_helpers.go
@@ -94,6 +94,10 @@ func renderFrontmatter(meta map[string][]string) string {
 	lines := make([]string, 0, len(keys))
 	for _, key := range keys {
 		values := meta[key]
+		if key == GeneratedFieldSourceRefs {
+			lines = appendBlockListFrontmatter(lines, key, values)
+			continue
+		}
 		switch {
 		case len(values) == 1:
 			lines = append(lines, fmt.Sprintf("%s: %s", key, strconv.Quote(values[0])))
@@ -106,6 +110,17 @@ func renderFrontmatter(meta map[string][]string) string {
 		}
 	}
 	return strings.Join(lines, "\n")
+}
+
+func appendBlockListFrontmatter(lines []string, key string, values []string) []string {
+	if len(values) == 0 {
+		return lines
+	}
+	lines = append(lines, key+":")
+	for _, value := range values {
+		lines = append(lines, "  - "+strconv.Quote(value))
+	}
+	return lines
 }
 
 func touchDocumentFrontmatter(frontmatterRaw string, record *DocumentRecord, now time.Time) string {

--- a/internal/state/documents/mutate_helpers.go
+++ b/internal/state/documents/mutate_helpers.go
@@ -58,11 +58,17 @@ func renderFrontmatter(meta map[string][]string) string {
 		return ""
 	}
 	priority := map[string]int{
-		"title":       0,
-		"description": 1,
-		"tags":        2,
-		"created":     3,
-		"updated":     4,
+		"title":                       0,
+		"description":                 1,
+		"tags":                        2,
+		GeneratedFieldBy:              3,
+		GeneratedFieldAt:              4,
+		GeneratedFieldDocumentKind:    5,
+		GeneratedFieldRefreshStrategy: 6,
+		GeneratedFieldSourceRefs:      7,
+		GeneratedFieldManagedRoot:     8,
+		"created":                     9,
+		"updated":                     10,
 	}
 	keys := make([]string, 0, len(meta))
 	for key, values := range meta {


### PR DESCRIPTION
## Summary

Adds the V1 document-local provenance contract for generated markdown artifacts in managed document roots, and adopts it in the existing media analysis vault writer.

Generated documents now have a small, stable frontmatter surface that the document index can already parse and filter:

- `generated_by`
- `generated_at`
- `document_kind`
- `refresh_strategy`
- `source_refs`
- optional `managed_root`

This intentionally stays separate from the root-level git/signature provenance work planned in #657. Frontmatter describes what the generated artifact is and what sources it came from; root policy can later describe who changed it and whether that change is trusted.

## What Changed

- Added `documents.GeneratedMetadata` plus validation/rendering helpers for generated-document frontmatter.
- Renders `source_refs` as a YAML block list so URLs and other typed refs remain compatible with the current document-root parser.
- Prioritized generated-document fields in the shared frontmatter renderer for stable ordering when future writers merge this metadata through document mutation helpers.
- Updated media analysis output to include generated-document provenance on saved analysis pages.
- Updated generated media channel index pages with provenance metadata and `replace` refresh strategy.
- Passed feed IDs into media analysis pages so saved artifacts can record both URL and feed source refs.
- Documented the generated document frontmatter contract in the document roots guide and updated the media tool reference.

## Validation

- `GOCACHE=/tmp/thane-go-build-cache just ci`

Closes #656