### PR TITLE
fix: reserve runtime-only origin tags

### DIFF
--- a/docs/operating/configuration.md
+++ b/docs/operating/configuration.md
@@ -166,7 +166,9 @@ channel_tags: {}
 `channel_tags` pins broad optional capability families for requests from
 a source. Use it for coarse source defaults only. Runtime facts such as
 current message-channel affordances and owner identity are asserted by
-the integrations that know them, not configured here.
+the integrations that know them, not configured here. Do not put
+`message_channel` or `owner` in `channel_tags`; Thane skips those
+runtime-only tags from source defaults.
 
 ## Memory & Storage
 

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -273,7 +273,7 @@ See [MQTT](../operating/mqtt.md) for the broker-side conventions.
 Normalized tools for the active message-app channel. Providers such as
 Signal adapt these calls to their native APIs. Inbound message-app
 bridges assert this capability as a runtime fact; it does not need to be
-listed in `channel_tags`.
+listed in `channel_tags` or contact `origin_tags`.
 
 | Tool | Description |
 |------|-------------|

--- a/internal/model/toolcatalog/catalog_tags.go
+++ b/internal/model/toolcatalog/catalog_tags.go
@@ -20,7 +20,7 @@ var builtinTagSpecs = map[string]BuiltinTagSpec{
 	"loops":           {Description: "Live loop status, sleep control, notifications, ad hoc spawn, and durable loop-definition authoring tools."},
 	"media":           {Description: "Coarse entry point for transcripts, feeds, and media analysis. Usually leads to media, feeds, attachments, or web.", Menu: true},
 	"memory":          {Description: "Persistent fact memory and working-memory tools."},
-	"message_channel": {Description: "Current message-app conversation affordances, such as reactions, normalized across Signal, Matrix, iMessage, and similar providers."},
+	"message_channel": {Description: "Current message-app conversation affordances, such as reactions, normalized across Signal, Matrix, iMessage, and similar providers.", Protected: true},
 	"models":          {Description: "Model registry inspection, routing, and policy tools."},
 	"mqtt":            {Description: "MQTT wake subscription management tools."},
 	"notifications":   {Description: "Notification delivery, escalation, and actionable response tools."},

--- a/internal/platform/config/config.go
+++ b/internal/platform/config/config.go
@@ -210,10 +210,11 @@ type Config struct {
 
 	// ChannelTags maps source channels to broad optional capability tags.
 	// Use this for coarse source defaults, not runtime facts such as owner
-	// identity or current message-channel affordances. This is additive to
+	// identity or current message-channel affordances. Runtime-only tags
+	// such as owner and message_channel are skipped here; they must be
+	// asserted by trusted current-run evidence. This is additive to
 	// always-active tags and any tags the agent requests at runtime. Tag
-	// names must reference either compiled-in tags or entries in
-	// [CapabilityTags].
+	// names must reference either compiled-in tags or entries in [CapabilityTags].
 	ChannelTags map[string][]string `yaml:"channel_tags"`
 
 	// MCP configures external MCP (Model Context Protocol) server
@@ -1077,7 +1078,10 @@ type DelegateProfileConfig struct {
 // Description and Tools act as "keep the built-in defaults". Tags
 // marked AlwaysActive are included in every session unconditionally.
 // Tags marked Protected are runtime-asserted and cannot be manually
-// activated or deactivated by the model.
+// activated or deactivated by the model. Runtime-only tags such as
+// owner and message_channel should be asserted by the integration or
+// trusted channel binding that has current-run evidence, not by
+// channel_tags or contact origin policy.
 type CapabilityTagConfig struct {
 	// Description is a human-readable summary shown in the capability
 	// manifest so the agent knows what activating this tag provides. For

--- a/internal/runtime/agent/capability_activation_test.go
+++ b/internal/runtime/agent/capability_activation_test.go
@@ -298,6 +298,7 @@ func TestRuntimeTags_PinForRunWithoutPersistence(t *testing.T) {
 		"message_channel": {
 			Description: "Current message channel",
 			Tools:       []string{"send_reaction"},
+			Protected:   true,
 		},
 	}
 

--- a/internal/runtime/agent/channel_tags_test.go
+++ b/internal/runtime/agent/channel_tags_test.go
@@ -640,7 +640,7 @@ func TestSessionOrigin_RuntimeOnlyTagsRequireTrustedRuntimeSource(t *testing.T) 
 		},
 	}
 
-	loop := buildTestLoop(mock, []string{"owner_tool", "send_reaction", "signal_tool", "project_tool"})
+	loop := buildTestLoop(mock, []string{"owner_tool", "send_reaction", "signal_tool", "project_tool", "protected_tool"})
 	loop.SetCapabilityTags(map[string]config.CapabilityTagConfig{
 		"owner": {
 			Description: "Owner-scoped privileged tools.",
@@ -660,14 +660,19 @@ func TestSessionOrigin_RuntimeOnlyTagsRequireTrustedRuntimeSource(t *testing.T) 
 			Description: "Project context.",
 			Tools:       []string{"project_tool"},
 		},
+		"protected_custom": {
+			Description: "Future protected runtime surface.",
+			Tools:       []string{"protected_tool"},
+			Protected:   true,
+		},
 	}, nil)
 	loop.SetChannelTags(map[string][]string{
-		"signal": {"signal", "message_channel", "owner"},
+		"signal": {"signal", "message_channel", "owner", "protected_custom"},
 	})
 	loop.UseContactLookup(&mockContactLookup{
 		policies: map[string]*ContactOriginPolicy{
 			"David": {
-				Tags: []string{"projects", "message_channel", "owner"},
+				Tags: []string{"projects", "message_channel", "owner", "protected_custom"},
 			},
 		},
 	})
@@ -690,26 +695,26 @@ func TestSessionOrigin_RuntimeOnlyTagsRequireTrustedRuntimeSource(t *testing.T) 
 			t.Fatalf("%s should be available from source/contact policy: %v", want, names)
 		}
 	}
-	for _, unwanted := range []string{"send_reaction", "owner_tool"} {
+	for _, unwanted := range []string{"send_reaction", "owner_tool", "protected_tool"} {
 		if hasName(names, unwanted) {
 			t.Fatalf("%s should not be available from source/contact policy: %v", unwanted, names)
 		}
 	}
 
 	originCtx := parseSessionOriginContext(t, mock.calls[0].Messages[0].Content)
-	for _, unwanted := range []string{"message_channel", "owner"} {
+	for _, unwanted := range []string{"message_channel", "owner", "protected_custom"} {
 		if containsString(originCtx.Tags, unwanted) {
 			t.Fatalf("origin tags = %#v, should not include runtime-only %s", originCtx.Tags, unwanted)
 		}
 	}
 	if rule, ok := appliedRuleBySource(originCtx.Applied, "channel_tags"); !ok {
 		t.Fatalf("origin applied rules missing channel_tags: %#v", originCtx.Applied)
-	} else if !containsString(rule.Tags, "signal") || containsString(rule.Tags, "message_channel") || containsString(rule.Tags, "owner") {
+	} else if !containsString(rule.Tags, "signal") || containsString(rule.Tags, "message_channel") || containsString(rule.Tags, "owner") || containsString(rule.Tags, "protected_custom") {
 		t.Fatalf("channel_tags rule = %#v, want only broad source tags", rule)
 	}
 	if rule, ok := appliedRuleBySource(originCtx.Applied, "contacts"); !ok {
 		t.Fatalf("origin applied rules missing contacts: %#v", originCtx.Applied)
-	} else if !containsString(rule.Tags, "projects") || containsString(rule.Tags, "message_channel") || containsString(rule.Tags, "owner") {
+	} else if !containsString(rule.Tags, "projects") || containsString(rule.Tags, "message_channel") || containsString(rule.Tags, "owner") || containsString(rule.Tags, "protected_custom") {
 		t.Fatalf("contacts rule = %#v, want only contact-origin optional tags", rule)
 	}
 }

--- a/internal/runtime/agent/channel_tags_test.go
+++ b/internal/runtime/agent/channel_tags_test.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -11,6 +12,45 @@ import (
 	"github.com/nugget/thane-ai-agent/internal/platform/config"
 	"github.com/nugget/thane-ai-agent/internal/state/memory"
 )
+
+type sessionOriginContextView struct {
+	Origin      SessionOrigin              `json:"origin"`
+	Applied     []SessionOriginAppliedRule `json:"applied_rules,omitempty"`
+	Tags        []string                   `json:"tags,omitempty"`
+	ContextRefs []string                   `json:"context_refs,omitempty"`
+}
+
+func parseSessionOriginContext(t *testing.T, prompt string) sessionOriginContextView {
+	t.Helper()
+	sectionStart := strings.Index(prompt, "## Session Origin Context")
+	if sectionStart < 0 {
+		t.Fatalf("prompt missing Session Origin Context:\n%s", prompt)
+	}
+	blockStart := strings.Index(prompt[sectionStart:], "```json\n")
+	if blockStart < 0 {
+		t.Fatalf("session origin context missing JSON block:\n%s", prompt[sectionStart:])
+	}
+	blockStart = sectionStart + blockStart + len("```json\n")
+	blockEnd := strings.Index(prompt[blockStart:], "\n```")
+	if blockEnd < 0 {
+		t.Fatalf("session origin context has unterminated JSON block:\n%s", prompt[blockStart:])
+	}
+
+	var payload sessionOriginContextView
+	if err := json.Unmarshal([]byte(prompt[blockStart:blockStart+blockEnd]), &payload); err != nil {
+		t.Fatalf("parse session origin context: %v\n%s", err, prompt[blockStart:blockStart+blockEnd])
+	}
+	return payload
+}
+
+func appliedRuleBySource(rules []SessionOriginAppliedRule, source string) (SessionOriginAppliedRule, bool) {
+	for _, rule := range rules {
+		if rule.Source == source {
+			return rule, true
+		}
+	}
+	return SessionOriginAppliedRule{}, false
+}
 
 func TestChannelTags_ActivatedBySource(t *testing.T) {
 	// When a request has hints["source"]="signal" and channel_tags maps
@@ -348,14 +388,20 @@ func TestProtectedTags_CannotBeActivatedManually(t *testing.T) {
 			Description: "Owner-scoped privileged tools.",
 			Protected:   true,
 		},
+		"message_channel": {
+			Description: "Current message channel.",
+			Protected:   true,
+		},
 	}, nil)
 
-	err := scope.Request("owner")
-	if err == nil {
-		t.Fatal("expected protected tag activation to fail")
-	}
-	if !strings.Contains(err.Error(), "protected tag") {
-		t.Fatalf("error = %v, want protected-tag message", err)
+	for _, tag := range []string{"owner", "message_channel"} {
+		err := scope.Request(tag)
+		if err == nil {
+			t.Fatalf("expected protected tag %q activation to fail", tag)
+		}
+		if !strings.Contains(err.Error(), "protected tag") {
+			t.Fatalf("error = %v, want protected-tag message", err)
+		}
 	}
 }
 
@@ -579,6 +625,194 @@ func TestContactOrigin_ProtectedTagsRequireTrustedBinding(t *testing.T) {
 	}
 	if !hasName(names, "signal_tool") {
 		t.Fatalf("signal_tool should still be available: %v", names)
+	}
+}
+
+func TestSessionOrigin_RuntimeOnlyTagsRequireTrustedRuntimeSource(t *testing.T) {
+	mock := &mockLLM{
+		responses: []*llm.ChatResponse{
+			{
+				Model:        "test-model",
+				Message:      llm.Message{Role: "assistant", Content: "Done."},
+				InputTokens:  100,
+				OutputTokens: 10,
+			},
+		},
+	}
+
+	loop := buildTestLoop(mock, []string{"owner_tool", "send_reaction", "signal_tool", "project_tool"})
+	loop.SetCapabilityTags(map[string]config.CapabilityTagConfig{
+		"owner": {
+			Description: "Owner-scoped privileged tools.",
+			Tools:       []string{"owner_tool"},
+			Protected:   true,
+		},
+		"message_channel": {
+			Description: "Current message channel.",
+			Tools:       []string{"send_reaction"},
+			Protected:   true,
+		},
+		"signal": {
+			Description: "Signal messaging.",
+			Tools:       []string{"signal_tool"},
+		},
+		"projects": {
+			Description: "Project context.",
+			Tools:       []string{"project_tool"},
+		},
+	}, nil)
+	loop.SetChannelTags(map[string][]string{
+		"signal": {"signal", "message_channel", "owner"},
+	})
+	loop.UseContactLookup(&mockContactLookup{
+		policies: map[string]*ContactOriginPolicy{
+			"David": {
+				Tags: []string{"projects", "message_channel", "owner"},
+			},
+		},
+	})
+
+	_, err := loop.Run(context.Background(), &Request{
+		Messages: []Message{{Role: "user", Content: "check available surfaces"}},
+		Hints:    map[string]string{"source": "signal"},
+		ChannelBinding: &memory.ChannelBinding{
+			Channel:     "signal",
+			ContactName: "David",
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("Run() error: %v", err)
+	}
+
+	names := toolNames(mock.calls[0].Tools)
+	for _, want := range []string{"signal_tool", "project_tool"} {
+		if !hasName(names, want) {
+			t.Fatalf("%s should be available from source/contact policy: %v", want, names)
+		}
+	}
+	for _, unwanted := range []string{"send_reaction", "owner_tool"} {
+		if hasName(names, unwanted) {
+			t.Fatalf("%s should not be available from source/contact policy: %v", unwanted, names)
+		}
+	}
+
+	originCtx := parseSessionOriginContext(t, mock.calls[0].Messages[0].Content)
+	for _, unwanted := range []string{"message_channel", "owner"} {
+		if containsString(originCtx.Tags, unwanted) {
+			t.Fatalf("origin tags = %#v, should not include runtime-only %s", originCtx.Tags, unwanted)
+		}
+	}
+	if rule, ok := appliedRuleBySource(originCtx.Applied, "channel_tags"); !ok {
+		t.Fatalf("origin applied rules missing channel_tags: %#v", originCtx.Applied)
+	} else if !containsString(rule.Tags, "signal") || containsString(rule.Tags, "message_channel") || containsString(rule.Tags, "owner") {
+		t.Fatalf("channel_tags rule = %#v, want only broad source tags", rule)
+	}
+	if rule, ok := appliedRuleBySource(originCtx.Applied, "contacts"); !ok {
+		t.Fatalf("origin applied rules missing contacts: %#v", originCtx.Applied)
+	} else if !containsString(rule.Tags, "projects") || containsString(rule.Tags, "message_channel") || containsString(rule.Tags, "owner") {
+		t.Fatalf("contacts rule = %#v, want only contact-origin optional tags", rule)
+	}
+}
+
+func TestSessionOrigin_CombinesRuntimeContactSourceAndOwnerBinding(t *testing.T) {
+	mock := &mockLLM{
+		responses: []*llm.ChatResponse{
+			{
+				Model:        "test-model",
+				Message:      llm.Message{Role: "assistant", Content: "Done."},
+				InputTokens:  100,
+				OutputTokens: 10,
+			},
+		},
+	}
+
+	loop := buildTestLoop(mock, []string{"owner_tool", "send_reaction", "signal_tool", "project_tool"})
+	loop.SetCapabilityTags(map[string]config.CapabilityTagConfig{
+		"owner": {
+			Description: "Owner-scoped privileged tools.",
+			Tools:       []string{"owner_tool"},
+			Protected:   true,
+		},
+		"message_channel": {
+			Description: "Current message channel.",
+			Tools:       []string{"send_reaction"},
+			Protected:   true,
+		},
+		"signal": {
+			Description: "Signal messaging.",
+			Tools:       []string{"signal_tool"},
+		},
+		"projects": {
+			Description: "Project context.",
+			Tools:       []string{"project_tool"},
+		},
+	}, nil)
+	loop.SetChannelTags(map[string][]string{
+		"signal": {"signal", "message_channel"},
+	})
+	loop.UseContactLookup(&mockContactLookup{
+		byID: map[string]*ContactContext{
+			"contact-1": {
+				ID:        "contact-1",
+				Name:      "David",
+				TrustZone: "admin",
+			},
+		},
+		policies: map[string]*ContactOriginPolicy{
+			"contact-1": {
+				Tags:        []string{"projects", "message_channel", "owner"},
+				ContextRefs: []string{"kb:projects/current.md"},
+			},
+		},
+	})
+
+	_, err := loop.Run(context.Background(), &Request{
+		Messages:    []Message{{Role: "user", Content: "check all origin layers"}},
+		Hints:       map[string]string{"source": "signal"},
+		RuntimeTags: []string{"message_channel"},
+		ChannelBinding: &memory.ChannelBinding{
+			Channel:     "signal",
+			ContactID:   "contact-1",
+			ContactName: "David",
+			IsOwner:     true,
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("Run() error: %v", err)
+	}
+
+	names := toolNames(mock.calls[0].Tools)
+	for _, want := range []string{"owner_tool", "send_reaction", "signal_tool", "project_tool"} {
+		if !hasName(names, want) {
+			t.Fatalf("%s should be available from the combined production origin shape: %v", want, names)
+		}
+	}
+
+	originCtx := parseSessionOriginContext(t, mock.calls[0].Messages[0].Content)
+	if !containsString(originCtx.Tags, "message_channel") || !containsString(originCtx.Tags, "owner") ||
+		!containsString(originCtx.Tags, "signal") || !containsString(originCtx.Tags, "projects") {
+		t.Fatalf("origin tags = %#v, want runtime, owner binding, source, and contact tags", originCtx.Tags)
+	}
+	if !containsString(originCtx.ContextRefs, "kb:projects/current.md") {
+		t.Fatalf("origin context refs = %#v, want exact contact ref", originCtx.ContextRefs)
+	}
+	if rule, ok := appliedRuleBySource(originCtx.Applied, "runtime"); !ok || !containsString(rule.Tags, "message_channel") {
+		t.Fatalf("runtime rule = %#v, ok=%v, want message_channel", rule, ok)
+	}
+	if rule, ok := appliedRuleBySource(originCtx.Applied, "channel_tags"); !ok {
+		t.Fatalf("origin applied rules missing channel_tags: %#v", originCtx.Applied)
+	} else if !containsString(rule.Tags, "signal") || containsString(rule.Tags, "message_channel") {
+		t.Fatalf("channel_tags rule = %#v, want signal without runtime-only tags", rule)
+	}
+	if rule, ok := appliedRuleBySource(originCtx.Applied, "contacts"); !ok {
+		t.Fatalf("origin applied rules missing contacts: %#v", originCtx.Applied)
+	} else if !containsString(rule.Tags, "projects") || containsString(rule.Tags, "message_channel") || containsString(rule.Tags, "owner") {
+		t.Fatalf("contacts rule = %#v, want projects without runtime-only tags", rule)
+	} else if !containsString(rule.ContextRefs, "kb:projects/current.md") {
+		t.Fatalf("contacts rule = %#v, want exact context ref", rule)
+	}
+	if rule, ok := appliedRuleBySource(originCtx.Applied, "channel_binding"); !ok || !containsString(rule.Tags, "owner") {
+		t.Fatalf("owner binding rule = %#v, ok=%v, want owner", rule, ok)
 	}
 }
 

--- a/internal/runtime/agent/loop.go
+++ b/internal/runtime/agent/loop.go
@@ -478,6 +478,14 @@ func (l *Loop) UseContactLookup(lookup ContactLookup) {
 }
 
 func (l *Loop) filterOriginPinnedTags(origin SessionOrigin, tags []string) []string {
+	return l.filterOriginPinnedTagsForSource(origin, tags, "origin_policy")
+}
+
+func (l *Loop) filterRuntimePinnedTags(origin SessionOrigin, tags []string) []string {
+	return l.filterOriginPinnedTagsForSource(origin, tags, "runtime")
+}
+
+func (l *Loop) filterOriginPinnedTagsForSource(origin SessionOrigin, tags []string, source string) []string {
 	if len(tags) == 0 || l.capTags == nil {
 		return nil
 	}
@@ -490,7 +498,18 @@ func (l *Loop) filterOriginPinnedTags(origin SessionOrigin, tags []string) []str
 			}
 			continue
 		}
-		if cfg.Protected && (tag != "owner" || !origin.IsOwner) {
+		if source != "runtime" && runtimeOnlyOriginTag(tag) {
+			if l.logger != nil {
+				l.logger.Warn("session origin policy skipped runtime-only tag",
+					"tag", tag,
+					"source", origin.Source,
+					"channel", origin.Channel,
+					"contact_name", origin.ContactName,
+				)
+			}
+			continue
+		}
+		if cfg.Protected && tag == "owner" && !origin.IsOwner {
 			if l.logger != nil {
 				l.logger.Warn("session origin policy skipped protected tag",
 					"tag", tag,
@@ -504,6 +523,15 @@ func (l *Loop) filterOriginPinnedTags(origin SessionOrigin, tags []string) []str
 		filtered = append(filtered, tag)
 	}
 	return filtered
+}
+
+func runtimeOnlyOriginTag(tag string) bool {
+	switch tag {
+	case "message_channel", "owner":
+		return true
+	default:
+		return false
+	}
 }
 
 // SetLensProvider configures a function that returns the currently
@@ -1459,7 +1487,7 @@ func (l *Loop) Run(ctx context.Context, req *Request, stream StreamCallback) (re
 		for _, tag := range req.InitialTags {
 			_ = scope.Request(tag)
 		}
-		if runtimeTags := l.filterOriginPinnedTags(origin, req.RuntimeTags); len(runtimeTags) > 0 {
+		if runtimeTags := l.filterRuntimePinnedTags(origin, req.RuntimeTags); len(runtimeTags) > 0 {
 			scope.PinChannelTags(runtimeTags)
 			originResult.addApplied(SessionOriginAppliedRule{
 				Name:   "runtime_tags",

--- a/internal/runtime/agent/loop.go
+++ b/internal/runtime/agent/loop.go
@@ -485,7 +485,7 @@ func (l *Loop) filterRuntimePinnedTags(origin SessionOrigin, tags []string) []st
 	return l.filterOriginPinnedTagsForSource(origin, tags, "runtime")
 }
 
-func (l *Loop) filterOriginPinnedTagsForSource(origin SessionOrigin, tags []string, source string) []string {
+func (l *Loop) filterOriginPinnedTagsForSource(origin SessionOrigin, tags []string, policySource string) []string {
 	if len(tags) == 0 || l.capTags == nil {
 		return nil
 	}
@@ -498,11 +498,24 @@ func (l *Loop) filterOriginPinnedTagsForSource(origin SessionOrigin, tags []stri
 			}
 			continue
 		}
-		if source != "runtime" && runtimeOnlyOriginTag(tag) {
+		if policySource != "runtime" && runtimeOnlyOriginTag(tag) {
 			if l.logger != nil {
 				l.logger.Warn("session origin policy skipped runtime-only tag",
 					"tag", tag,
-					"source", origin.Source,
+					"policy_source", policySource,
+					"origin_source", origin.Source,
+					"channel", origin.Channel,
+					"contact_name", origin.ContactName,
+				)
+			}
+			continue
+		}
+		if policySource != "runtime" && cfg.Protected {
+			if l.logger != nil {
+				l.logger.Warn("session origin policy skipped protected tag",
+					"tag", tag,
+					"policy_source", policySource,
+					"origin_source", origin.Source,
 					"channel", origin.Channel,
 					"contact_name", origin.ContactName,
 				)
@@ -513,7 +526,8 @@ func (l *Loop) filterOriginPinnedTagsForSource(origin SessionOrigin, tags []stri
 			if l.logger != nil {
 				l.logger.Warn("session origin policy skipped protected tag",
 					"tag", tag,
-					"source", origin.Source,
+					"policy_source", policySource,
+					"origin_source", origin.Source,
 					"channel", origin.Channel,
 					"contact_name", origin.ContactName,
 				)

--- a/internal/tools/contact_tools.go
+++ b/internal/tools/contact_tools.go
@@ -74,7 +74,7 @@ func (r *Registry) registerContactTools() {
 				"origin_tags": map[string]any{
 					"type":        "array",
 					"items":       map[string]any{"type": "string"},
-					"description": "Capability tags to pin automatically when this contact is the session origin. Do not use this for owner; owner is asserted from trusted runtime identity.",
+					"description": "Capability tags to pin automatically when this contact is the session origin. Do not use this for owner or message_channel; those are asserted from trusted runtime identity.",
 				},
 				"origin_context_refs": map[string]any{
 					"type":        "array",

--- a/internal/tools/contact_tools.go
+++ b/internal/tools/contact_tools.go
@@ -74,7 +74,7 @@ func (r *Registry) registerContactTools() {
 				"origin_tags": map[string]any{
 					"type":        "array",
 					"items":       map[string]any{"type": "string"},
-					"description": "Capability tags to pin automatically when this contact is the session origin. Do not use this for owner or message_channel; those are asserted from trusted runtime identity.",
+					"description": "Capability tags to pin automatically when this contact is the session origin. Do not use this for owner or message_channel; owner is asserted from trusted runtime identity, and message_channel is asserted by trusted current-run evidence.",
 				},
 				"origin_context_refs": map[string]any{
 					"type":        "array",


### PR DESCRIPTION
## Summary

Closes #46.

This is the closeout pass for the session-origin policy work. #754 gave Thane the core origin contract, and #767 cleaned up the delegate side. This PR tightens the remaining boundary: runtime-only facts must come from trusted current-run evidence, not from broad source defaults or contact policy.

`message_channel` now behaves like the runtime fact it was designed to be. It is a protected capability tag, so the model cannot activate it manually, and origin policy filters skip it when it appears in `channel_tags` or contact `origin_tags`. Trusted integrations can still assert it through `Request.RuntimeTags`, which preserves the Signal bridge behavior and gives future Matrix/iMessage-style providers the same path.

`owner` is also treated as runtime-only for source/contact policy. It remains available through the trusted channel binding path, which keeps owner access tied to the Go-validated identity signal instead of duplicated YAML or contact-directory convention.

## What Changed

- Marked the built-in `message_channel` capability as protected.
- Split origin tag filtering so trusted runtime tags are handled separately from source/contact policy tags.
- Skipped runtime-only tags (`message_channel`, `owner`) when they appear in `channel_tags` or contact `origin_tags`.
- Preserved trusted runtime assertion for `message_channel` and trusted channel binding assertion for `owner`.
- Updated operator docs and `save_contact` tool schema text to steer operators away from configuring runtime-only facts manually.
- Added regression coverage for forged source/contact runtime tags and the combined production shape: source defaults, contact tags/context refs, runtime `message_channel`, trusted owner binding, and Session Origin Context reporting.

## Validation

- `GOCACHE=/tmp/thane-go-build-cache just test`
- `GOCACHE=/tmp/thane-go-build-cache just ci`

Note: `golangci-lint` emitted sandbox cache-write warnings under `~/Library/Caches/golangci-lint`, but completed with `0 issues`.