### PR TITLE
feat: enforce document root signature policy

### DIFF
--- a/docs/operating/configuration.md
+++ b/docs/operating/configuration.md
@@ -225,6 +225,12 @@ signed git commit. By default the root itself is the repository; set
 otherwise Thane writes a repository-local `.allowed_signers` file from
 the signing key.
 
+`git.verify_signatures` controls read-side enforcement. `none` disables
+checks, `warn` logs and reports verification failures without blocking,
+and `required` blocks managed document reads, indexed browse/search
+results, and tagged context injection unless the content is cleanly
+covered by trusted signed git history.
+
 Good uses for custom roots:
 
 - knowledge bases

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -110,9 +110,12 @@ filesystem access. See
 [Document Roots](../understanding/document-roots.md).
 
 `doc_roots` includes each root's policy summary: indexing status,
-authoring mode, and git/signature expectations. Mutation tools obey that
-policy before writing; for example, `read_only` roots reject managed
-writes and git-backed roots route writes through signed commits.
+authoring mode, git/signature expectations, and current verification
+health. Mutation tools obey that policy before writing; for example,
+`read_only` roots reject managed writes and git-backed roots route
+writes through signed commits. Read/search surfaces also respect
+`verify_signatures: required` by blocking content that is not cleanly
+covered by trusted signed git history.
 
 | Tool | Description |
 |------|-------------|

--- a/docs/understanding/agent-loop.md
+++ b/docs/understanding/agent-loop.md
@@ -123,7 +123,7 @@ The same declaration also feeds context assembly. Each turn receives a
 reference, generated tool name, current content or recent journal tail,
 and any truncation markers. The model should use those generated tools
 instead of generic file tools; the document root owns path safety,
-indexing, provenance, and future signature policy.
+indexing, provenance, and signature policy.
 
 ## Capability Tags
 

--- a/docs/understanding/architecture.md
+++ b/docs/understanding/architecture.md
@@ -118,10 +118,11 @@ managed authoring with optional git backing. Scratchpads can stay
 low-integrity and even opt out of indexing. Same architectural
 primitive, different policy dials.
 
-The current implementation establishes policy-aware managed roots and
-signed git-backed writes. Stricter load-time enforcement, such as
-blocking activation of unsigned high-integrity content, builds on that
-foundation rather than creating another storage lane.
+The current implementation establishes policy-aware managed roots,
+signed git-backed writes, and read-side enforcement for roots that
+require trusted signatures. Unsigned or dirty high-integrity content is
+kept out of managed document reads, indexed results, and tagged context
+injection instead of relying on model behavior.
 
 ## Trust Zones: Safety in Go, Not Prompts
 

--- a/docs/understanding/document-roots.md
+++ b/docs/understanding/document-roots.md
@@ -121,13 +121,16 @@ The current policy fields are:
 - `git.enabled`: records that the root participates in git-backed
   provenance.
 - `git.sign_commits`: signs and commits each managed write/delete.
-- `git.verify_signatures`: records the intended consumer policy:
-  `none`, `warn`, or `required`.
+- `git.verify_signatures`: sets the consumer policy: `none`, `warn`,
+  or `required`.
 
 Signature-required roots are the place for high-integrity authored
-knowledge, such as owner-tagged knowledge articles. Broader enforcement
-for loading or activating signed content builds on this root policy
-rather than inventing a separate trust lane.
+knowledge, such as owner-tagged knowledge articles. When verification
+is `required`, Thane blocks document reads, indexed browse/search
+surfaces, loop-declared output context, and tagged context articles when
+the target content is not cleanly covered by trusted signed git history.
+When verification is `warn`, Thane records and logs verification
+failures but still lets the content load.
 
 ## A Few Practical Guidelines
 
@@ -182,8 +185,8 @@ runtime tools:
 The loop sees a matching context block with the current document content
 or recent journal tail, so the document itself remains the durable source
 of truth. The generated tools still write through document roots. That
-keeps path resolution, indexing, provenance, and future root-level
-integrity policy in one subsystem.
+keeps path resolution, indexing, provenance, and root-level integrity
+policy in one subsystem.
 
 ## Special Case: `core`
 

--- a/examples/config.example.yaml
+++ b/examples/config.example.yaml
@@ -200,10 +200,10 @@ paths:
 #       SignCommits creates a signed git commit for each managed document
 #       mutation. Requires signing_key.
 #       sign_commits: true
-#       VerifySignatures is the desired verification policy for consumers
-#       of this root: "none", "warn", or "required". V1 records the
-#       policy and signs managed writes; policy-aware load/activation
-#       consumers enforce this in follow-up work.
+#       VerifySignatures is the verification policy for consumers of this
+#       root: "none", "warn", or "required". Required roots block managed
+#       reads, indexed results, and tagged context injection when content
+#       is not covered by trusted signed git history.
 #       verify_signatures: warn
 #       RepoPath optionally points at the git repository to use for this
 #       root. Empty means the root directory itself is the repository.
@@ -233,10 +233,10 @@ paths:
 #       SignCommits creates a signed git commit for each managed document
 #       mutation. Requires signing_key.
 #       sign_commits: false
-#       VerifySignatures is the desired verification policy for consumers
-#       of this root: "none", "warn", or "required". V1 records the
-#       policy and signs managed writes; policy-aware load/activation
-#       consumers enforce this in follow-up work.
+#       VerifySignatures is the verification policy for consumers of this
+#       root: "none", "warn", or "required". Required roots block managed
+#       reads, indexed results, and tagged context injection when content
+#       is not covered by trusted signed git history.
 #       verify_signatures: ""
 #       RepoPath optionally points at the git repository to use for this
 #       root. Empty means the root directory itself is the repository.

--- a/internal/app/document_roots.go
+++ b/internal/app/document_roots.go
@@ -21,6 +21,11 @@ type documentRootProvenanceWriter struct {
 	prefix string
 }
 
+type documentRootProvenanceVerifier struct {
+	verifier *provenance.Verifier
+	prefix   string
+}
+
 func (w *documentRootProvenanceWriter) Write(ctx context.Context, filename, content, message string) error {
 	return w.store.Write(ctx, w.storeFilename(filename), content, message)
 }
@@ -38,6 +43,39 @@ func (w *documentRootProvenanceWriter) storeFilename(filename string) string {
 		return clean
 	}
 	return path.Join(w.prefix, clean)
+}
+
+func (v *documentRootProvenanceVerifier) Verify(ctx context.Context, filename string) (documents.SignatureVerification, error) {
+	result, err := v.verifier.VerifyFile(ctx, v.storeFilename(filename))
+	return documentSignatureVerificationFromProvenance(result), err
+}
+
+func (v *documentRootProvenanceVerifier) VerifyRoot(ctx context.Context) (documents.SignatureVerification, error) {
+	result, err := v.verifier.VerifyTree(ctx, v.prefix)
+	return documentSignatureVerificationFromProvenance(result), err
+}
+
+func (v *documentRootProvenanceVerifier) storeFilename(filename string) string {
+	clean := filepath.ToSlash(filepath.Clean(filename))
+	if clean == "." || clean == ".." || strings.HasPrefix(clean, "../") || path.IsAbs(clean) {
+		return clean
+	}
+	if v.prefix == "" || v.prefix == "." {
+		return clean
+	}
+	return path.Join(v.prefix, clean)
+}
+
+func documentSignatureVerificationFromProvenance(result provenance.VerificationResult) documents.SignatureVerification {
+	status := documents.SignatureFailed
+	if result.Status == provenance.VerificationTrusted {
+		status = documents.SignatureTrusted
+	}
+	return documents.SignatureVerification{
+		Status:  status,
+		Commit:  result.Commit,
+		Message: result.Message,
+	}
 }
 
 func buildDocumentRoots(resolver *paths.Resolver) map[string]string {
@@ -76,6 +114,10 @@ func (a *App) buildDocumentStoreOptions(documentRoots map[string]string, resolve
 	if len(a.cfg.DocRoots) == 0 {
 		return opts, nil
 	}
+	logger := a.logger
+	if logger == nil {
+		logger = slog.Default()
+	}
 	for root, rootCfg := range a.cfg.DocRoots {
 		root = strings.TrimSuffix(strings.TrimSpace(root), ":")
 		if root == "" {
@@ -87,6 +129,21 @@ func (a *App) buildDocumentStoreOptions(documentRoots map[string]string, resolve
 		}
 		policy := documentRootPolicyFromConfig(rootCfg)
 		opts.RootPolicies[root] = policy
+		if policy.Git.Enabled && policy.Git.VerifySignatures != documents.VerificationNone {
+			verifier, err := a.newDocumentRootProvenanceVerifier(root, rootPath, rootCfg.Git, resolver)
+			if err != nil {
+				logger.Warn("document root signature verifier unavailable",
+					"root", root,
+					"mode", policy.Git.VerifySignatures,
+					"error", err,
+				)
+			} else {
+				if opts.RootVerifiers == nil {
+					opts.RootVerifiers = make(map[string]documents.RootVerifier)
+				}
+				opts.RootVerifiers[root] = verifier
+			}
+		}
 		if !policy.Git.Enabled || !policy.Git.SignCommits {
 			continue
 		}
@@ -178,6 +235,43 @@ func (a *App) newDocumentRootProvenanceWriter(root, rootPath string, gitCfg conf
 		"allowed_signers", allowedSigners != "",
 	)
 	return &documentRootProvenanceWriter{store: store, prefix: prefix}, nil
+}
+
+func (a *App) newDocumentRootProvenanceVerifier(root, rootPath string, gitCfg config.DocumentRootGitConfig, resolver *paths.Resolver) (*documentRootProvenanceVerifier, error) {
+	repoPath := strings.TrimSpace(gitCfg.RepoPath)
+	if repoPath == "" {
+		repoPath = rootPath
+	} else {
+		repoPath = resolvePath(repoPath, resolver)
+	}
+	absRepoPath, err := filepath.Abs(repoPath)
+	if err != nil {
+		return nil, fmt.Errorf("resolve doc_roots.%s.git.repo_path: %w", root, err)
+	}
+	absRootPath, err := filepath.Abs(rootPath)
+	if err != nil {
+		return nil, fmt.Errorf("resolve document root %s path: %w", root, err)
+	}
+	prefix, err := rootPrefixWithinRepo(absRepoPath, absRootPath)
+	if err != nil {
+		return nil, fmt.Errorf("doc_roots.%s.git.repo_path: %w", root, err)
+	}
+
+	allowedSigners := strings.TrimSpace(gitCfg.AllowedSigners)
+	if allowedSigners != "" {
+		allowedSigners = resolvePath(allowedSigners, resolver)
+	}
+	logger := a.logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+	verifier, err := provenance.NewVerifier(absRepoPath, logger.With("component", "document_root_verifier", "root", root), provenance.Options{
+		AllowedSignersPath: allowedSigners,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("initialize git verifier for document root %s: %w", root, err)
+	}
+	return &documentRootProvenanceVerifier{verifier: verifier, prefix: prefix}, nil
 }
 
 func rootPrefixWithinRepo(repoPath, rootPath string) (string, error) {

--- a/internal/app/finalize_capability_tags.go
+++ b/internal/app/finalize_capability_tags.go
@@ -92,11 +92,19 @@ func (a *App) finalizeCapabilityTags(s *newState) error {
 			kbDir = resolved
 		}
 	}
+	var contextVerifier interface {
+		VerifyRef(ctx context.Context, ref string, consumer string) error
+		VerifyPath(ctx context.Context, path string, consumer string) error
+	}
+	if a.documentStore != nil {
+		contextVerifier = a.documentStore
+	}
 
 	tagCtxAssembler := agent.NewTagContextAssembler(agent.TagContextAssemblerConfig{
 		CapTags:  resolvedCapTags,
 		KBDir:    kbDir,
 		Resolver: s.resolver,
+		Verifier: contextVerifier,
 		HAInject: a.loop.HAInject(),
 		Logger:   logger.With("component", "tag_context"),
 	})

--- a/internal/app/loop_outputs.go
+++ b/internal/app/loop_outputs.go
@@ -151,7 +151,7 @@ func renderLoopOutputContext(ctx context.Context, store *documents.Store, output
 			Ref:       output.Ref,
 			Purpose:   output.Purpose,
 			ToolName:  output.ToolName(),
-			Policy:    "Write only through the generated output tool. The managed document root handles path safety, indexing, and future provenance/signature policy.",
+			Policy:    "Write only through the generated output tool. The managed document root handles path safety, indexing, provenance, and signature policy.",
 			Interface: outputInterfaceDescription(output),
 		}
 		if output.Type == looppkg.OutputTypeJournalDocument {

--- a/internal/platform/config/config.go
+++ b/internal/platform/config/config.go
@@ -786,10 +786,10 @@ type DocumentRootGitConfig struct {
 	// mutation. Requires signing_key.
 	SignCommits bool `yaml:"sign_commits,omitempty"`
 
-	// VerifySignatures is the desired verification policy for consumers
-	// of this root: "none", "warn", or "required". V1 records the
-	// policy and signs managed writes; policy-aware load/activation
-	// consumers enforce this in follow-up work.
+	// VerifySignatures is the verification policy for consumers of this
+	// root: "none", "warn", or "required". Required roots block managed
+	// reads, indexed results, and tagged context injection when content
+	// is not covered by trusted signed git history.
 	VerifySignatures string `yaml:"verify_signatures,omitempty"`
 
 	// RepoPath optionally points at the git repository to use for this

--- a/internal/platform/provenance/git_test.go
+++ b/internal/platform/provenance/git_test.go
@@ -2,7 +2,9 @@ package provenance
 
 import (
 	"bytes"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -94,5 +96,85 @@ func TestCommitHasCorrectMessage(t *testing.T) {
 	got := strings.TrimSpace(msgBuf.String())
 	if got != "loop-metacognitive-42" {
 		t.Errorf("commit message = %q, want %q", got, "loop-metacognitive-42")
+	}
+}
+
+func TestVerifierAcceptsSignedCleanFile(t *testing.T) {
+	s := testStore(t)
+	if err := s.Write(t.Context(), "test.md", "signed content", "test-signed"); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	verifier, err := NewVerifier(s.path, nil, Options{})
+	if err != nil {
+		t.Fatalf("NewVerifier: %v", err)
+	}
+	result, err := verifier.VerifyFile(t.Context(), "test.md")
+	if err != nil {
+		t.Fatalf("VerifyFile: %v", err)
+	}
+	if !result.Trusted() || result.Commit == "" {
+		t.Fatalf("VerifyFile result = %+v, want trusted commit", result)
+	}
+}
+
+func TestVerifierAcceptsRootWithRepoLocalAllowedSigners(t *testing.T) {
+	s := testStore(t)
+	if err := s.Write(t.Context(), "test.md", "signed content", "test-signed"); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	verifier, err := NewVerifier(s.path, nil, Options{})
+	if err != nil {
+		t.Fatalf("NewVerifier: %v", err)
+	}
+	result, err := verifier.VerifyTree(t.Context(), "")
+	if err != nil {
+		t.Fatalf("VerifyTree: %v", err)
+	}
+	if !result.Trusted() || result.Commit == "" {
+		t.Fatalf("VerifyTree result = %+v, want trusted commit", result)
+	}
+}
+
+func TestVerifierRejectsDirtyWorktreeFile(t *testing.T) {
+	s := testStore(t)
+	if err := s.Write(t.Context(), "test.md", "signed content", "test-signed"); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if err := os.WriteFile(s.FilePath("test.md"), []byte("tampered"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	verifier, err := NewVerifier(s.path, nil, Options{})
+	if err != nil {
+		t.Fatalf("NewVerifier: %v", err)
+	}
+	result, err := verifier.VerifyFile(t.Context(), "test.md")
+	if err == nil {
+		t.Fatal("VerifyFile returned nil, want dirty worktree error")
+	}
+	if result.Trusted() || !strings.Contains(err.Error(), "uncommitted changes") {
+		t.Fatalf("VerifyFile result/error = %+v / %v, want dirty failure", result, err)
+	}
+}
+
+func TestVerifierRejectsUntrustedSigner(t *testing.T) {
+	s := testStore(t)
+	if err := s.Write(t.Context(), "test.md", "signed content", "test-signed"); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	wrongSigner := testSigner(t)
+	allowedPath := filepath.Join(t.TempDir(), "allowed_signers")
+	if err := os.WriteFile(allowedPath, []byte("thane@provenance.local "+wrongSigner.PublicKey()+"\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile allowed signers: %v", err)
+	}
+	verifier, err := NewVerifier(s.path, nil, Options{AllowedSignersPath: allowedPath})
+	if err != nil {
+		t.Fatalf("NewVerifier: %v", err)
+	}
+	result, err := verifier.VerifyFile(t.Context(), "test.md")
+	if err == nil {
+		t.Fatal("VerifyFile returned nil, want untrusted signer error")
+	}
+	if result.Trusted() {
+		t.Fatalf("VerifyFile result = %+v, want untrusted", result)
 	}
 }

--- a/internal/platform/provenance/verify.go
+++ b/internal/platform/provenance/verify.go
@@ -1,0 +1,233 @@
+package provenance
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+)
+
+// VerificationStatus describes whether git history currently vouches for
+// the checked path.
+type VerificationStatus string
+
+const (
+	// VerificationTrusted means the worktree path is clean against HEAD
+	// and HEAD carries a trusted SSH signature.
+	VerificationTrusted VerificationStatus = "trusted"
+	// VerificationFailed means the path could not be tied to trusted
+	// signed history.
+	VerificationFailed VerificationStatus = "failed"
+)
+
+// VerificationResult summarizes one provenance verification check.
+type VerificationResult struct {
+	Status  VerificationStatus
+	Commit  string
+	Message string
+}
+
+// Trusted reports whether the verification result is safe to consume.
+func (r VerificationResult) Trusted() bool {
+	return r.Status == VerificationTrusted
+}
+
+// Verifier checks whether files in a git-backed store are clean and
+// covered by a trusted signed commit.
+type Verifier struct {
+	mu                 sync.Mutex
+	path               string
+	allowedSignersPath string
+	logger             *slog.Logger
+}
+
+// NewVerifier creates a verifier for an existing git repository. Unlike
+// [New], it never initializes or mutates the repository.
+func NewVerifier(path string, logger *slog.Logger, opts Options) (*Verifier, error) {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return nil, fmt.Errorf("provenance: resolve verifier path: %w", err)
+	}
+	allowedSignersPath := strings.TrimSpace(opts.AllowedSignersPath)
+	if allowedSignersPath != "" {
+		allowedSignersPath, err = filepath.Abs(allowedSignersPath)
+		if err != nil {
+			return nil, fmt.Errorf("provenance: resolve verifier allowed signers path: %w", err)
+		}
+		if _, err := os.Stat(allowedSignersPath); err != nil {
+			return nil, fmt.Errorf("provenance: stat verifier allowed signers file: %w", err)
+		}
+	} else {
+		repoLocal := filepath.Join(absPath, ".allowed_signers")
+		if _, err := os.Stat(repoLocal); err == nil {
+			allowedSignersPath = repoLocal
+		}
+	}
+	return &Verifier{
+		path:               absPath,
+		allowedSignersPath: allowedSignersPath,
+		logger:             logger,
+	}, nil
+}
+
+// VerifyFile checks one tracked file. The file must be clean against HEAD,
+// present in HEAD, and covered by a trusted signed HEAD commit.
+func (v *Verifier) VerifyFile(ctx context.Context, filename string) (VerificationResult, error) {
+	if err := validateFilename(filename); err != nil {
+		return failedVerification("", err.Error())
+	}
+	filename = filepath.ToSlash(filepath.Clean(filename))
+	return v.verifyPathspec(ctx, filename, true)
+}
+
+// VerifyTree checks the repository, or a subtree when pathspec is non-empty.
+// The pathspec must be clean against HEAD and HEAD must carry a trusted
+// signature.
+func (v *Verifier) VerifyTree(ctx context.Context, pathspec string) (VerificationResult, error) {
+	pathspec = filepath.ToSlash(filepath.Clean(strings.TrimSpace(pathspec)))
+	if pathspec == "." {
+		pathspec = ""
+	}
+	if strings.HasPrefix(pathspec, "../") || pathspec == ".." || filepath.IsAbs(pathspec) {
+		return failedVerification("", fmt.Sprintf("invalid verification path %q", pathspec))
+	}
+	return v.verifyPathspec(ctx, pathspec, false)
+}
+
+func (v *Verifier) verifyPathspec(ctx context.Context, pathspec string, requireTracked bool) (VerificationResult, error) {
+	if v == nil {
+		return failedVerification("", "provenance verifier is not configured")
+	}
+	v.mu.Lock()
+	defer v.mu.Unlock()
+
+	target := pathspec
+	if target == "" {
+		target = "."
+	}
+	statusArgs := []string{"status", "--porcelain", "--", target}
+	if !requireTracked {
+		statusArgs = append(statusArgs, v.statusExclusions(target)...)
+	}
+	if status, err := v.gitOutput(ctx, false, statusArgs...); err != nil {
+		return failedVerification("", fmt.Sprintf("git status failed: %v", err))
+	} else if strings.TrimSpace(status) != "" {
+		return failedVerification("", "worktree has uncommitted changes for "+target)
+	}
+
+	var commit string
+	if out, err := v.gitOutput(ctx, false, "rev-parse", "--verify", "HEAD^{commit}"); err != nil {
+		return failedVerification("", fmt.Sprintf("git HEAD lookup failed: %v", err))
+	} else {
+		commit = strings.TrimSpace(out)
+	}
+	if commit == "" {
+		return failedVerification("", "repository has no HEAD commit")
+	}
+
+	if requireTracked {
+		out, err := v.gitOutput(ctx, false, "ls-tree", "-r", "--name-only", "HEAD", "--", pathspec)
+		if err != nil {
+			return failedVerification(commit, fmt.Sprintf("git tracked-file lookup failed: %v", err))
+		}
+		if !pathspecListed(out, pathspec) {
+			return failedVerification(commit, "file is not tracked in HEAD: "+pathspec)
+		}
+	}
+
+	if out, err := v.gitOutput(ctx, true, "verify-commit", commit); err != nil {
+		msg := strings.TrimSpace(out)
+		if msg == "" {
+			msg = err.Error()
+		}
+		return failedVerification(commit, "commit signature verification failed: "+msg)
+	}
+
+	return VerificationResult{
+		Status:  VerificationTrusted,
+		Commit:  commit,
+		Message: "trusted signed HEAD",
+	}, nil
+}
+
+func pathspecListed(output, pathspec string) bool {
+	for line := range strings.SplitSeq(strings.TrimSpace(output), "\n") {
+		if strings.TrimSpace(line) == pathspec {
+			return true
+		}
+	}
+	return false
+}
+
+func (v *Verifier) statusExclusions(target string) []string {
+	allowedPathspec := v.allowedSignersPathspec()
+	if allowedPathspec == "" || !pathspecIncludes(target, allowedPathspec) {
+		return nil
+	}
+	return []string{":(exclude)" + allowedPathspec}
+}
+
+func (v *Verifier) allowedSignersPathspec() string {
+	if v == nil || v.allowedSignersPath == "" {
+		return ""
+	}
+	rel, err := filepath.Rel(v.path, v.allowedSignersPath)
+	if err != nil {
+		return ""
+	}
+	rel = filepath.ToSlash(filepath.Clean(rel))
+	if rel == "." || rel == ".." || strings.HasPrefix(rel, "../") || filepath.IsAbs(rel) {
+		return ""
+	}
+	return rel
+}
+
+func pathspecIncludes(target, candidate string) bool {
+	target = filepath.ToSlash(filepath.Clean(strings.TrimSpace(target)))
+	candidate = filepath.ToSlash(filepath.Clean(strings.TrimSpace(candidate)))
+	if target == "" || target == "." {
+		return candidate != "" && candidate != "."
+	}
+	return candidate == target || strings.HasPrefix(candidate, target+"/")
+}
+
+func failedVerification(commit string, message string) (VerificationResult, error) {
+	result := VerificationResult{
+		Status:  VerificationFailed,
+		Commit:  commit,
+		Message: strings.TrimSpace(message),
+	}
+	return result, errors.New(result.Message)
+}
+
+func (v *Verifier) gitOutput(ctx context.Context, verify bool, args ...string) (string, error) {
+	cmdArgs := []string{"-C", v.path}
+	if verify && v.allowedSignersPath != "" {
+		cmdArgs = append(cmdArgs, "-c", "gpg.ssh.allowedSignersFile="+v.allowedSignersPath)
+	}
+	cmdArgs = append(cmdArgs, args...)
+	cmd := exec.CommandContext(ctx, "git", cmdArgs...)
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		combined := strings.TrimSpace(strings.Join([]string{stdout.String(), stderr.String()}, "\n"))
+		if combined != "" {
+			return combined, fmt.Errorf("%w: %s", err, combined)
+		}
+		return "", err
+	}
+	combined := strings.TrimSpace(strings.Join([]string{stdout.String(), stderr.String()}, "\n"))
+	return combined, nil
+}

--- a/internal/runtime/agent/tag_context.go
+++ b/internal/runtime/agent/tag_context.go
@@ -30,6 +30,10 @@ type TagContextAssembler struct {
 	capTags  map[string]config.CapabilityTagConfig
 	kbDir    string
 	resolver *paths.Resolver
+	verifier interface {
+		VerifyRef(ctx context.Context, ref string, consumer string) error
+		VerifyPath(ctx context.Context, path string, consumer string) error
+	}
 	haInject homeassistant.StateFetcher // nil-safe — delegates pass nil
 	logger   *slog.Logger
 }
@@ -62,8 +66,14 @@ type KBMenuHint struct {
 // TagContextAssembler.
 type TagContextAssemblerConfig struct {
 	CapTags  map[string]config.CapabilityTagConfig
-	KBDir    string                     // resolved kb: directory; empty skips scanning
-	Resolver *paths.Resolver            // managed document root resolver; nil falls back to KBDir for kb: refs
+	KBDir    string          // resolved kb: directory; empty skips scanning
+	Resolver *paths.Resolver // managed document root resolver; nil falls back to KBDir for kb: refs
+	// Verifier is an optional managed-root verifier for context refs and
+	// tagged articles.
+	Verifier interface {
+		VerifyRef(ctx context.Context, ref string, consumer string) error
+		VerifyPath(ctx context.Context, path string, consumer string) error
+	}
 	HAInject homeassistant.StateFetcher // nil-safe
 	Logger   *slog.Logger
 }
@@ -83,6 +93,7 @@ func NewTagContextAssembler(cfg TagContextAssemblerConfig) *TagContextAssembler 
 		capTags:  cfg.CapTags,
 		kbDir:    cfg.KBDir,
 		resolver: cfg.Resolver,
+		verifier: cfg.Verifier,
 		haInject: cfg.HAInject,
 		logger:   cfg.Logger,
 	}
@@ -133,6 +144,11 @@ func (a *TagContextAssembler) Build(ctx context.Context, activeTags map[string]b
 			continue
 		}
 		seen[article.Path] = true
+		if err := a.verifyPath(ctx, article.Path, "tagged_kb_article"); err != nil {
+			a.logger.Warn("tagged KB article blocked by document root signature policy",
+				"path", article.Path, "error", err)
+			continue
+		}
 		data, err := os.ReadFile(article.Path)
 		if err != nil {
 			a.logger.Warn("failed to read tagged KB article",
@@ -201,6 +217,11 @@ func (a *TagContextAssembler) BuildRefs(ctx context.Context, refs []string) stri
 		if !ok {
 			continue
 		}
+		if err := a.verifyRef(ctx, ref, "session_origin_context_ref"); err != nil {
+			a.logger.Warn("session origin context ref blocked by document root signature policy",
+				"ref", ref, "path", path, "error", err)
+			continue
+		}
 		data, err := os.ReadFile(path)
 		if err != nil {
 			a.logger.Warn("failed to read session origin context ref",
@@ -226,6 +247,20 @@ func (a *TagContextAssembler) BuildRefs(ctx context.Context, refs []string) stri
 		}
 	}
 	return buf.String()
+}
+
+func (a *TagContextAssembler) verifyRef(ctx context.Context, ref string, consumer string) error {
+	if a == nil || a.verifier == nil {
+		return nil
+	}
+	return a.verifier.VerifyRef(ctx, ref, consumer)
+}
+
+func (a *TagContextAssembler) verifyPath(ctx context.Context, path string, consumer string) error {
+	if a == nil || a.verifier == nil {
+		return nil
+	}
+	return a.verifier.VerifyPath(ctx, path, consumer)
 }
 
 func (a *TagContextAssembler) resolveContextRef(ref string) (string, bool) {

--- a/internal/runtime/agent/tag_context_test.go
+++ b/internal/runtime/agent/tag_context_test.go
@@ -449,6 +449,16 @@ func (m *mockTagProvider) TagContext(_ context.Context) (string, error) {
 	return m.content, m.err
 }
 
+type rejectingContextVerifier struct{}
+
+func (rejectingContextVerifier) VerifyRef(_ context.Context, _ string, _ string) error {
+	return fmt.Errorf("blocked by signature policy")
+}
+
+func (rejectingContextVerifier) VerifyPath(_ context.Context, _ string, _ string) error {
+	return fmt.Errorf("blocked by signature policy")
+}
+
 func TestTagContextAssembler_LiveProvider(t *testing.T) {
 	a := NewTagContextAssembler(TagContextAssemblerConfig{
 		CapTags: map[string]config.CapabilityTagConfig{
@@ -517,6 +527,26 @@ func TestTagContextAssembler_TaggedKBArticles(t *testing.T) {
 	// Frontmatter should be stripped.
 	if strings.Contains(result, "tags:") {
 		t.Error("frontmatter should be stripped from KB articles")
+	}
+}
+
+func TestTagContextAssembler_SkipsKBArticleRejectedByVerifier(t *testing.T) {
+	kbDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(kbDir, "forge-guide.md"),
+		[]byte("---\ntags: [forge]\n---\nSIGNED_ONLY_CONTEXT"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	a := NewTagContextAssembler(TagContextAssemblerConfig{
+		CapTags:  map[string]config.CapabilityTagConfig{"forge": {}},
+		KBDir:    kbDir,
+		Verifier: rejectingContextVerifier{},
+		Logger:   slog.Default(),
+	})
+
+	result := a.Build(context.Background(), map[string]bool{"forge": true}, nil)
+	if strings.Contains(result, "SIGNED_ONLY_CONTEXT") {
+		t.Fatalf("rejected KB article leaked into tag context:\n%s", result)
 	}
 }
 

--- a/internal/state/documents/links.go
+++ b/internal/state/documents/links.go
@@ -35,6 +35,9 @@ func (s *Store) Links(ctx context.Context, ref string, mode string, limit int, p
 	if err != nil {
 		return nil, err
 	}
+	if err := s.verifyDocumentForConsumer(ctx, root, relPath, "doc_links"); err != nil {
+		return nil, err
+	}
 	mode, err = normalizeLinkMode(mode)
 	if err != nil {
 		return nil, err
@@ -115,6 +118,11 @@ func (s *Store) loadDocumentIndex(ctx context.Context, includeLinks bool) (*docu
 			}
 		} else if err := rows.Scan(&root, &relPath, &title, &modifiedAt); err != nil {
 			return nil, fmt.Errorf("scan document link index: %w", err)
+		}
+		if err := s.verifyDocumentForConsumer(ctx, root, relPath, "doc_links_index"); err != nil {
+			s.logger.Warn("document links skipped file blocked by signature policy",
+				"root", root, "path", relPath, "error", err)
+			continue
 		}
 		var links []string
 		if includeLinks {

--- a/internal/state/documents/links.go
+++ b/internal/state/documents/links.go
@@ -119,11 +119,6 @@ func (s *Store) loadDocumentIndex(ctx context.Context, includeLinks bool) (*docu
 		} else if err := rows.Scan(&root, &relPath, &title, &modifiedAt); err != nil {
 			return nil, fmt.Errorf("scan document link index: %w", err)
 		}
-		if err := s.verifyDocumentForConsumer(ctx, root, relPath, "doc_links_index"); err != nil {
-			s.logger.Warn("document links skipped file blocked by signature policy",
-				"root", root, "path", relPath, "error", err)
-			continue
-		}
 		var links []string
 		if includeLinks {
 			links, err = decodeDocumentLinks(root, relPath, linksJSON)

--- a/internal/state/documents/mutate.go
+++ b/internal/state/documents/mutate.go
@@ -89,6 +89,9 @@ func (s *Store) Read(ctx context.Context, ref string) (*DocumentRecord, error) {
 	if err != nil {
 		return nil, err
 	}
+	if err := s.verifyDocumentForConsumer(ctx, root, relPath, "doc_read"); err != nil {
+		return nil, err
+	}
 	absPath, err := s.resolveDocumentPath(root, relPath)
 	if err != nil {
 		if os.IsNotExist(err) {

--- a/internal/state/documents/mutate_document_ops.go
+++ b/internal/state/documents/mutate_document_ops.go
@@ -260,11 +260,8 @@ func (s *Store) Copy(ctx context.Context, args CopyArgs) (*CopyResult, error) {
 }
 
 func (s *Store) deleteIndexedDocument(ctx context.Context, root, relPath string) error {
-	if _, err := s.db.ExecContext(ctx, `DELETE FROM indexed_document_sections WHERE root = ? AND rel_path = ?`, root, relPath); err != nil {
-		return fmt.Errorf("delete indexed sections: %w", err)
-	}
-	if _, err := s.db.ExecContext(ctx, `DELETE FROM indexed_documents WHERE root = ? AND rel_path = ?`, root, relPath); err != nil {
-		return fmt.Errorf("delete indexed document: %w", err)
+	if err := s.deleteIndexedDocumentRows(ctx, root, relPath); err != nil {
+		return err
 	}
 	s.touchLastRefresh(time.Now())
 	return nil

--- a/internal/state/documents/policy.go
+++ b/internal/state/documents/policy.go
@@ -28,8 +28,8 @@ type VerificationMode string
 const (
 	// VerificationNone disables signature verification enforcement.
 	VerificationNone VerificationMode = "none"
-	// VerificationWarn records verification expectations but does not
-	// block consumers in V1.
+	// VerificationWarn records verification failures without blocking
+	// consumers.
 	VerificationWarn VerificationMode = "warn"
 	// VerificationRequired marks the root as requiring trusted signed
 	// history before high-integrity consumers should load or activate
@@ -70,6 +70,33 @@ type RootGitPolicySummary struct {
 	VerifySignatures VerificationMode `json:"verify_signatures,omitempty"`
 }
 
+// SignatureStatus describes the last known signature verification state
+// for a root or document.
+type SignatureStatus string
+
+const (
+	// SignatureTrusted means the checked content is clean and covered by
+	// trusted signed git history.
+	SignatureTrusted SignatureStatus = "trusted"
+	// SignatureFailed means signature policy could not verify the checked
+	// content.
+	SignatureFailed SignatureStatus = "failed"
+	// SignatureUnavailable means signature verification was requested but
+	// no verifier could be configured.
+	SignatureUnavailable SignatureStatus = "unavailable"
+)
+
+// SignatureVerification is the document package's verifier-neutral
+// signature status shape.
+type SignatureVerification struct {
+	Status    SignatureStatus  `json:"status"`
+	Mode      VerificationMode `json:"mode,omitempty"`
+	Commit    string           `json:"commit,omitempty"`
+	Message   string           `json:"message,omitempty"`
+	CheckedAt string           `json:"checked_at,omitempty"`
+	Consumer  string           `json:"consumer,omitempty"`
+}
+
 // RootWriter applies a managed document mutation to a root. Git-backed
 // roots use this hook to sign and commit writes without exposing git to
 // the model.
@@ -78,11 +105,19 @@ type RootWriter interface {
 	Delete(ctx context.Context, filename, message string) error
 }
 
+// RootVerifier verifies that a git-backed root or file is clean and
+// trusted before policy-sensitive consumers load it.
+type RootVerifier interface {
+	Verify(ctx context.Context, filename string) (SignatureVerification, error)
+	VerifyRoot(ctx context.Context) (SignatureVerification, error)
+}
+
 // StoreOptions configures optional root policy and backing writers for
 // [Store].
 type StoreOptions struct {
-	RootPolicies map[string]RootPolicy
-	RootWriters  map[string]RootWriter
+	RootPolicies  map[string]RootPolicy
+	RootWriters   map[string]RootWriter
+	RootVerifiers map[string]RootVerifier
 }
 
 func defaultRootPolicy() RootPolicy {
@@ -141,6 +176,24 @@ func normalizeRootWriters(roots map[string]string, writers map[string]RootWriter
 	return out
 }
 
+func normalizeRootVerifiers(roots map[string]string, verifiers map[string]RootVerifier) map[string]RootVerifier {
+	if len(verifiers) == 0 {
+		return nil
+	}
+	out := make(map[string]RootVerifier, len(verifiers))
+	for root, verifier := range verifiers {
+		root = normalizeRootName(root)
+		if root == "" || verifier == nil {
+			continue
+		}
+		if _, ok := roots[root]; !ok {
+			continue
+		}
+		out[root] = verifier
+	}
+	return out
+}
+
 func normalizeRootName(root string) string {
 	return strings.TrimSuffix(strings.TrimSpace(root), ":")
 }
@@ -175,4 +228,12 @@ func (s *Store) rootWriter(root string) RootWriter {
 		return nil
 	}
 	return s.rootWriters[root]
+}
+
+func (s *Store) rootVerifier(root string) RootVerifier {
+	root = normalizeRootName(root)
+	if s == nil || len(s.rootVerifiers) == 0 {
+		return nil
+	}
+	return s.rootVerifiers[root]
 }

--- a/internal/state/documents/policy_test.go
+++ b/internal/state/documents/policy_test.go
@@ -17,6 +17,33 @@ type recordingRootWriter struct {
 	deletes []string
 }
 
+type fakeRootVerifier struct {
+	files map[string]SignatureVerification
+	root  SignatureVerification
+}
+
+func (v fakeRootVerifier) Verify(_ context.Context, filename string) (SignatureVerification, error) {
+	result, ok := v.files[filename]
+	if !ok {
+		result = SignatureVerification{Status: SignatureFailed, Message: "untrusted test document"}
+	}
+	if result.Status == SignatureTrusted {
+		return result, nil
+	}
+	return result, os.ErrPermission
+}
+
+func (v fakeRootVerifier) VerifyRoot(_ context.Context) (SignatureVerification, error) {
+	result := v.root
+	if result.Status == "" {
+		result = SignatureVerification{Status: SignatureTrusted, Message: "trusted test root"}
+	}
+	if result.Status == SignatureTrusted {
+		return result, nil
+	}
+	return result, os.ErrPermission
+}
+
 func (w *recordingRootWriter) Write(_ context.Context, filename, content, message string) error {
 	w.writes = append(w.writes, filename+"|"+message)
 	path := filepath.Join(w.root, filename)
@@ -176,7 +203,90 @@ func TestStorePolicyRootWriterHandlesWriteAndDelete(t *testing.T) {
 	}
 }
 
+func TestStorePolicyRequiredSignatureBlocksReadAndIndex(t *testing.T) {
+	t.Parallel()
+
+	store, kbDir := newPolicyStoreWithOptions(t, map[string]RootPolicy{
+		"kb": {
+			Indexing:  true,
+			Authoring: AuthoringManaged,
+			Git: RootGitPolicy{
+				Enabled:          true,
+				VerifySignatures: VerificationRequired,
+			},
+		},
+	}, nil, map[string]RootVerifier{"kb": fakeRootVerifier{
+		files: map[string]SignatureVerification{
+			"unsafe.md": {Status: SignatureFailed, Message: "unsigned test content"},
+		},
+		root: SignatureVerification{Status: SignatureFailed, Message: "dirty root"},
+	}})
+	writeFile(t, filepath.Join(kbDir, "unsafe.md"), "# Unsafe\n\nShould not load.\n")
+
+	ctx := context.Background()
+	if err := store.Refresh(ctx); err != nil {
+		t.Fatalf("Refresh: %v", err)
+	}
+	results, err := store.Search(ctx, SearchQuery{Root: "kb", Query: "Unsafe", Limit: 10})
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(results) != 0 {
+		t.Fatalf("Search returned %d results, want unsigned document excluded", len(results))
+	}
+	if _, err := store.Read(ctx, "kb:unsafe.md"); err == nil || !strings.Contains(err.Error(), "blocked by signature policy") {
+		t.Fatalf("Read error = %v, want signature policy block", err)
+	}
+	roots, err := store.Roots(ctx)
+	if err != nil {
+		t.Fatalf("Roots: %v", err)
+	}
+	if roots[0].Verification == nil || roots[0].Verification.Status != SignatureFailed {
+		t.Fatalf("Roots verification = %#v, want failed", roots[0].Verification)
+	}
+}
+
+func TestStorePolicyWarnSignatureDoesNotBlockReadOrIndex(t *testing.T) {
+	t.Parallel()
+
+	store, kbDir := newPolicyStoreWithOptions(t, map[string]RootPolicy{
+		"kb": {
+			Indexing:  true,
+			Authoring: AuthoringManaged,
+			Git: RootGitPolicy{
+				Enabled:          true,
+				VerifySignatures: VerificationWarn,
+			},
+		},
+	}, nil, map[string]RootVerifier{"kb": fakeRootVerifier{
+		files: map[string]SignatureVerification{
+			"warning.md": {Status: SignatureFailed, Message: "unsigned but warn-only"},
+		},
+		root: SignatureVerification{Status: SignatureFailed, Message: "dirty root"},
+	}})
+	writeFile(t, filepath.Join(kbDir, "warning.md"), "# Warning\n\nWarn mode still loads.\n")
+
+	ctx := context.Background()
+	if err := store.Refresh(ctx); err != nil {
+		t.Fatalf("Refresh: %v", err)
+	}
+	results, err := store.Search(ctx, SearchQuery{Root: "kb", Query: "Warning", Limit: 10})
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("Search returned %d results, want warn-mode document included", len(results))
+	}
+	if _, err := store.Read(ctx, "kb:warning.md"); err != nil {
+		t.Fatalf("Read warn-mode document: %v", err)
+	}
+}
+
 func newPolicyStore(t *testing.T, policies map[string]RootPolicy, writers map[string]RootWriter) (*Store, string) {
+	return newPolicyStoreWithOptions(t, policies, writers, nil)
+}
+
+func newPolicyStoreWithOptions(t *testing.T, policies map[string]RootPolicy, writers map[string]RootWriter, verifiers map[string]RootVerifier) (*Store, string) {
 	t.Helper()
 
 	rootDir := t.TempDir()
@@ -190,8 +300,9 @@ func newPolicyStore(t *testing.T, policies map[string]RootPolicy, writers map[st
 	}
 	t.Cleanup(func() { db.Close() })
 	store, err := NewStoreWithOptions(db, map[string]string{"kb": kbDir}, nil, StoreOptions{
-		RootPolicies: policies,
-		RootWriters:  writers,
+		RootPolicies:  policies,
+		RootWriters:   writers,
+		RootVerifiers: verifiers,
 	})
 	if err != nil {
 		t.Fatalf("NewStoreWithOptions: %v", err)

--- a/internal/state/documents/policy_test.go
+++ b/internal/state/documents/policy_test.go
@@ -246,6 +246,52 @@ func TestStorePolicyRequiredSignatureBlocksReadAndIndex(t *testing.T) {
 	}
 }
 
+func TestStorePolicyRequiredSignatureRemovesPreviouslyIndexedDocument(t *testing.T) {
+	t.Parallel()
+
+	verifier := fakeRootVerifier{
+		files: map[string]SignatureVerification{
+			"doc.md": {Status: SignatureTrusted, Message: "trusted test content"},
+		},
+	}
+	store, kbDir := newPolicyStoreWithOptions(t, map[string]RootPolicy{
+		"kb": {
+			Indexing:  true,
+			Authoring: AuthoringManaged,
+			Git: RootGitPolicy{
+				Enabled:          true,
+				VerifySignatures: VerificationRequired,
+			},
+		},
+	}, nil, map[string]RootVerifier{"kb": verifier})
+	writeFile(t, filepath.Join(kbDir, "doc.md"), "# Trusted\n\nInitially indexed.\n")
+
+	ctx := context.Background()
+	if err := store.Refresh(ctx); err != nil {
+		t.Fatalf("initial Refresh: %v", err)
+	}
+	results, err := store.Search(ctx, SearchQuery{Root: "kb", Query: "Trusted", Limit: 10})
+	if err != nil {
+		t.Fatalf("initial Search: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("initial Search returned %d results, want 1", len(results))
+	}
+
+	verifier.files["doc.md"] = SignatureVerification{Status: SignatureFailed, Message: "signature revoked"}
+	store.lastRefresh = time.Time{}
+	if err := store.Refresh(ctx); err != nil {
+		t.Fatalf("revoked Refresh: %v", err)
+	}
+	results, err = store.Search(ctx, SearchQuery{Root: "kb", Query: "Trusted", Limit: 10})
+	if err != nil {
+		t.Fatalf("Search after revoked signature: %v", err)
+	}
+	if len(results) != 0 {
+		t.Fatalf("Search after revoked signature returned %d results, want 0", len(results))
+	}
+}
+
 func TestStorePolicyWarnSignatureDoesNotBlockReadOrIndex(t *testing.T) {
 	t.Parallel()
 

--- a/internal/state/documents/query.go
+++ b/internal/state/documents/query.go
@@ -93,11 +93,6 @@ func (s *Store) Browse(ctx context.Context, root, prefix string, limit int) (*Br
 			return nil, fmt.Errorf("scan browse document: %w", err)
 		}
 		rel := doc.Path
-		if err := s.verifyDocumentForConsumer(ctx, doc.Root, doc.Path, "doc_browse"); err != nil {
-			s.logger.Warn("document browse skipped file blocked by signature policy",
-				"root", doc.Root, "path", doc.Path, "error", err)
-			continue
-		}
 		if prefix != "" {
 			if rel != prefix && !strings.HasPrefix(rel, prefix+"/") {
 				continue
@@ -220,11 +215,6 @@ func (s *Store) Search(ctx context.Context, q SearchQuery) ([]DocumentSummary, e
 			continue
 		}
 		if !matchesFrontmatter(doc.Frontmatter, q.Frontmatter) {
-			continue
-		}
-		if err := s.verifyDocumentForConsumer(ctx, doc.Root, doc.Path, "doc_search"); err != nil {
-			s.logger.Warn("document search skipped file blocked by signature policy",
-				"root", doc.Root, "path", doc.Path, "error", err)
 			continue
 		}
 		score := matchScore(doc, q.Query)

--- a/internal/state/documents/query.go
+++ b/internal/state/documents/query.go
@@ -2,8 +2,6 @@ package documents
 
 import (
 	"context"
-	"database/sql"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -22,9 +20,10 @@ func (s *Store) Roots(ctx context.Context) ([]RootSummary, error) {
 	summaries := make([]RootSummary, 0, len(s.roots))
 	for _, root := range s.allRoots() {
 		summary := RootSummary{
-			Root:   root,
-			Path:   s.roots[root],
-			Policy: s.rootPolicySummary(root),
+			Root:         root,
+			Path:         s.roots[root],
+			Policy:       s.rootPolicySummary(root),
+			Verification: s.rootVerificationSummary(ctx, root),
 		}
 		if err := s.db.QueryRowContext(ctx,
 			`SELECT COUNT(*), COALESCE(SUM(size_bytes), 0), COALESCE(SUM(word_count), 0), COALESCE(MAX(modified_at), '')
@@ -94,6 +93,11 @@ func (s *Store) Browse(ctx context.Context, root, prefix string, limit int) (*Br
 			return nil, fmt.Errorf("scan browse document: %w", err)
 		}
 		rel := doc.Path
+		if err := s.verifyDocumentForConsumer(ctx, doc.Root, doc.Path, "doc_browse"); err != nil {
+			s.logger.Warn("document browse skipped file blocked by signature policy",
+				"root", doc.Root, "path", doc.Path, "error", err)
+			continue
+		}
 		if prefix != "" {
 			if rel != prefix && !strings.HasPrefix(rel, prefix+"/") {
 				continue
@@ -218,6 +222,11 @@ func (s *Store) Search(ctx context.Context, q SearchQuery) ([]DocumentSummary, e
 		if !matchesFrontmatter(doc.Frontmatter, q.Frontmatter) {
 			continue
 		}
+		if err := s.verifyDocumentForConsumer(ctx, doc.Root, doc.Path, "doc_search"); err != nil {
+			s.logger.Warn("document search skipped file blocked by signature policy",
+				"root", doc.Root, "path", doc.Path, "error", err)
+			continue
+		}
 		score := matchScore(doc, q.Query)
 		if q.Query != "" && score == 0 {
 			continue
@@ -257,6 +266,9 @@ func (s *Store) Outline(ctx context.Context, ref string) ([]Section, error) {
 	}
 	root, relPath, err := parseRef(ref)
 	if err != nil {
+		return nil, err
+	}
+	if err := s.verifyDocumentForConsumer(ctx, root, relPath, "doc_outline"); err != nil {
 		return nil, err
 	}
 	rows, err := s.db.QueryContext(ctx,
@@ -301,6 +313,9 @@ func (s *Store) Section(ctx context.Context, ref string, selector string) (*Sect
 	if err != nil {
 		return nil, err
 	}
+	if err := s.verifyDocumentForConsumer(ctx, root, relPath, "doc_section"); err != nil {
+		return nil, err
+	}
 	if exists, err := s.documentExists(ctx, root, relPath); err != nil {
 		return nil, err
 	} else if !exists {
@@ -341,73 +356,6 @@ func (s *Store) Section(ctx context.Context, ref string, selector string) (*Sect
 		}
 	}
 	return nil, fmt.Errorf("section %q not found in %s", selector, ref)
-}
-
-// Values returns observed frontmatter values for one key.
-func (s *Store) Values(ctx context.Context, root, key string, limit int) ([]ValueCount, error) {
-	return s.values(ctx, root, key, limit, true)
-}
-
-func (s *Store) values(ctx context.Context, root, key string, limit int, refresh bool) ([]ValueCount, error) {
-	if refresh {
-		if err := s.Refresh(ctx); err != nil {
-			return nil, err
-		}
-	}
-	root = strings.TrimSuffix(strings.TrimSpace(root), ":")
-	key = strings.ToLower(strings.TrimSpace(key))
-	if key == "" {
-		return nil, fmt.Errorf("key is required")
-	}
-	if root != "" && !rootExists(s.roots, root) {
-		return nil, fmt.Errorf("unknown document root %q", root)
-	}
-
-	var (
-		rows *sql.Rows
-		err  error
-	)
-	if root == "" {
-		rows, err = s.db.QueryContext(ctx, `SELECT tags_json, frontmatter_json FROM indexed_documents`)
-	} else {
-		rows, err = s.db.QueryContext(ctx, `SELECT tags_json, frontmatter_json FROM indexed_documents WHERE root = ?`, root)
-	}
-	if err != nil {
-		return nil, fmt.Errorf("query document values: %w", err)
-	}
-	defer rows.Close()
-
-	counts := make(map[string]int)
-	for rows.Next() {
-		var tagsJSON, metaJSON string
-		if err := rows.Scan(&tagsJSON, &metaJSON); err != nil {
-			return nil, fmt.Errorf("scan document values: %w", err)
-		}
-		if key == "tags" {
-			var tags []string
-			if jsonErr := json.Unmarshal([]byte(tagsJSON), &tags); jsonErr == nil {
-				for _, tag := range tags {
-					counts[tag]++
-				}
-			}
-			continue
-		}
-		var meta map[string][]string
-		if jsonErr := json.Unmarshal([]byte(metaJSON), &meta); jsonErr == nil {
-			for _, value := range meta[key] {
-				counts[value]++
-			}
-		}
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	values := asValueCounts(counts)
-	limit = clampLimit(limit, 20, 100)
-	if len(values) > limit {
-		values = values[:limit]
-	}
-	return values, nil
 }
 
 func (s *Store) documentExists(ctx context.Context, root, relPath string) (bool, error) {

--- a/internal/state/documents/refs.go
+++ b/internal/state/documents/refs.go
@@ -1,0 +1,127 @@
+package documents
+
+import (
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+func parseRef(ref string) (root string, relPath string, err error) {
+	ref = strings.TrimSpace(ref)
+	parts := strings.SplitN(ref, ":", 2)
+	if len(parts) != 2 || strings.TrimSpace(parts[0]) == "" || strings.TrimSpace(parts[1]) == "" {
+		return "", "", fmt.Errorf("invalid ref %q; expected root:path.md", ref)
+	}
+	root = strings.TrimSuffix(strings.TrimSpace(parts[0]), ":")
+	relPath = strings.TrimSpace(parts[1])
+	relPath = strings.ReplaceAll(relPath, "\\", "/")
+	relPath = strings.TrimPrefix(path.Clean(strings.TrimPrefix(relPath, "./")), "./")
+	if relPath == "" || relPath == "." || relPath == ".." || strings.HasPrefix(relPath, "../") {
+		return "", "", fmt.Errorf("invalid ref %q; path escapes root", ref)
+	}
+	return root, relPath, nil
+}
+
+func makeRef(root, relPath string) string {
+	return root + ":" + relPath
+}
+
+func scanDocument(rows *sql.Rows, doc *DocumentSummary) error {
+	var tagsJSON string
+	var metaJSON string
+	if err := rows.Scan(&doc.Root, &doc.Path, &doc.Title, &doc.Summary, &tagsJSON, &metaJSON, &doc.ModifiedAt, &doc.WordCount); err != nil {
+		return err
+	}
+	doc.Ref = makeRef(doc.Root, doc.Path)
+	if err := json.Unmarshal([]byte(tagsJSON), &doc.Tags); err != nil {
+		doc.Tags = nil
+	}
+	if err := json.Unmarshal([]byte(metaJSON), &doc.Frontmatter); err != nil {
+		doc.Frontmatter = nil
+	}
+	return nil
+}
+
+func rootExists(roots map[string]string, root string) bool {
+	_, ok := roots[strings.TrimSuffix(strings.TrimSpace(root), ":")]
+	return ok
+}
+
+func asValueCounts(values map[string]int) []ValueCount {
+	out := make([]ValueCount, 0, len(values))
+	for value, count := range values {
+		out = append(out, ValueCount{Value: value, Count: count})
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Count == out[j].Count {
+			return out[i].Value < out[j].Value
+		}
+		return out[i].Count > out[j].Count
+	})
+	return out
+}
+
+func trimPathPrefix(prefix string) string {
+	prefix = filepath.ToSlash(strings.Trim(strings.TrimSpace(prefix), "/"))
+	if prefix == "." {
+		return ""
+	}
+	return prefix
+}
+
+func (s *Store) resolveRootPath(root string) (string, error) {
+	dir, ok := s.roots[strings.TrimSuffix(strings.TrimSpace(root), ":")]
+	if !ok || strings.TrimSpace(dir) == "" {
+		return "", fmt.Errorf("unknown document root %q", root)
+	}
+	absDir, err := filepath.Abs(dir)
+	if err != nil {
+		return "", fmt.Errorf("resolve root %q: %w", root, err)
+	}
+	resolvedDir, err := filepath.EvalSymlinks(absDir)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return "", fmt.Errorf("document root %q does not exist", root)
+		}
+		return "", fmt.Errorf("resolve root %q: %w", root, err)
+	}
+	return filepath.Clean(resolvedDir), nil
+}
+
+func (s *Store) resolveDocumentPath(root, relPath string) (string, error) {
+	rootPath, err := s.resolveRootPath(root)
+	if err != nil {
+		return "", err
+	}
+	candidate := filepath.Clean(filepath.Join(rootPath, filepath.FromSlash(relPath)))
+	if !pathWithinRoot(rootPath, candidate) {
+		return "", fmt.Errorf("document path %q escapes root %q", relPath, root)
+	}
+	resolved, err := filepath.EvalSymlinks(candidate)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return "", os.ErrNotExist
+		}
+		return "", fmt.Errorf("resolve document path %q: %w", relPath, err)
+	}
+	resolved = filepath.Clean(resolved)
+	if !pathWithinRoot(rootPath, resolved) {
+		return "", fmt.Errorf("document path %q resolves outside root %q", relPath, root)
+	}
+	return resolved, nil
+}
+
+func pathWithinRoot(rootPath, targetPath string) bool {
+	rel, err := filepath.Rel(rootPath, targetPath)
+	if err != nil {
+		return false
+	}
+	return rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
+}

--- a/internal/state/documents/store.go
+++ b/internal/state/documents/store.go
@@ -4,12 +4,10 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io/fs"
 	"log/slog"
 	"os"
-	"path"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -19,16 +17,17 @@ import (
 
 // RootSummary describes one indexed document root.
 type RootSummary struct {
-	Root            string             `json:"root"`
-	Path            string             `json:"-"`
-	Policy          RootPolicySummary  `json:"policy"`
-	DocumentCount   int                `json:"document_count"`
-	TotalSizeBytes  int64              `json:"total_size_bytes"`
-	TotalWordCount  int                `json:"total_word_count"`
-	LastModifiedAt  string             `json:"last_modified_at,omitempty"`
-	TopTags         []string           `json:"top_tags,omitempty"`
-	TopDirectories  []BrowseDirectory  `json:"top_directories,omitempty"`
-	RecentDocuments []RootDocumentHint `json:"recent_documents,omitempty"`
+	Root            string                 `json:"root"`
+	Path            string                 `json:"-"`
+	Policy          RootPolicySummary      `json:"policy"`
+	Verification    *SignatureVerification `json:"verification,omitempty"`
+	DocumentCount   int                    `json:"document_count"`
+	TotalSizeBytes  int64                  `json:"total_size_bytes"`
+	TotalWordCount  int                    `json:"total_word_count"`
+	LastModifiedAt  string                 `json:"last_modified_at,omitempty"`
+	TopTags         []string               `json:"top_tags,omitempty"`
+	TopDirectories  []BrowseDirectory      `json:"top_directories,omitempty"`
+	RecentDocuments []RootDocumentHint     `json:"recent_documents,omitempty"`
 }
 
 // RootDocumentHint is a compact example document attached to a root summary.
@@ -79,6 +78,9 @@ type Store struct {
 	roots           map[string]string
 	rootPolicies    map[string]RootPolicy
 	rootWriters     map[string]RootWriter
+	rootVerifiers   map[string]RootVerifier
+	verificationMu  sync.Mutex
+	verification    map[string]SignatureVerification
 	logger          *slog.Logger
 	refreshMu       sync.Mutex
 	lastRefresh     time.Time
@@ -107,6 +109,8 @@ func NewStoreWithOptions(db *sql.DB, roots map[string]string, logger *slog.Logge
 		roots:           normalizedRoots,
 		rootPolicies:    normalizePolicies(normalizedRoots, opts.RootPolicies),
 		rootWriters:     normalizeRootWriters(normalizedRoots, opts.RootWriters),
+		rootVerifiers:   normalizeRootVerifiers(normalizedRoots, opts.RootVerifiers),
+		verification:    make(map[string]SignatureVerification),
 		logger:          logger,
 		refreshInterval: defaultRefreshInterval,
 	}
@@ -245,10 +249,16 @@ func (s *Store) refreshRoot(ctx context.Context, root, dir string) error {
 			return nil
 		}
 		rel = filepath.ToSlash(filepath.Clean(rel))
-		seen[rel] = true
+		if err := s.verifyDocumentForConsumer(ctx, root, rel, "document_index"); err != nil {
+			s.logger.Warn("document index skipped file blocked by signature policy",
+				"root", root, "path", rel, "error", err)
+			return nil
+		}
 		if err := s.upsertFile(ctx, root, rel); err != nil {
 			s.logger.Warn("document index skipped file", "root", root, "path", path, "error", err)
+			return nil
 		}
+		seen[rel] = true
 		return nil
 	})
 	if walkErr != nil {
@@ -383,117 +393,4 @@ func (s *Store) allRoots() []string {
 	}
 	sort.Strings(roots)
 	return roots
-}
-
-func parseRef(ref string) (root string, relPath string, err error) {
-	ref = strings.TrimSpace(ref)
-	parts := strings.SplitN(ref, ":", 2)
-	if len(parts) != 2 || strings.TrimSpace(parts[0]) == "" || strings.TrimSpace(parts[1]) == "" {
-		return "", "", fmt.Errorf("invalid ref %q; expected root:path.md", ref)
-	}
-	root = strings.TrimSuffix(strings.TrimSpace(parts[0]), ":")
-	relPath = strings.TrimSpace(parts[1])
-	relPath = strings.ReplaceAll(relPath, "\\", "/")
-	relPath = strings.TrimPrefix(path.Clean(strings.TrimPrefix(relPath, "./")), "./")
-	if relPath == "" || relPath == "." || relPath == ".." || strings.HasPrefix(relPath, "../") {
-		return "", "", fmt.Errorf("invalid ref %q; path escapes root", ref)
-	}
-	return root, relPath, nil
-}
-
-func makeRef(root, relPath string) string {
-	return root + ":" + relPath
-}
-
-func scanDocument(rows *sql.Rows, doc *DocumentSummary) error {
-	var tagsJSON string
-	var metaJSON string
-	if err := rows.Scan(&doc.Root, &doc.Path, &doc.Title, &doc.Summary, &tagsJSON, &metaJSON, &doc.ModifiedAt, &doc.WordCount); err != nil {
-		return err
-	}
-	doc.Ref = makeRef(doc.Root, doc.Path)
-	if err := json.Unmarshal([]byte(tagsJSON), &doc.Tags); err != nil {
-		doc.Tags = nil
-	}
-	if err := json.Unmarshal([]byte(metaJSON), &doc.Frontmatter); err != nil {
-		doc.Frontmatter = nil
-	}
-	return nil
-}
-
-func rootExists(roots map[string]string, root string) bool {
-	_, ok := roots[strings.TrimSuffix(strings.TrimSpace(root), ":")]
-	return ok
-}
-
-func asValueCounts(values map[string]int) []ValueCount {
-	out := make([]ValueCount, 0, len(values))
-	for value, count := range values {
-		out = append(out, ValueCount{Value: value, Count: count})
-	}
-	sort.Slice(out, func(i, j int) bool {
-		if out[i].Count == out[j].Count {
-			return out[i].Value < out[j].Value
-		}
-		return out[i].Count > out[j].Count
-	})
-	return out
-}
-
-func trimPathPrefix(prefix string) string {
-	prefix = filepath.ToSlash(strings.Trim(strings.TrimSpace(prefix), "/"))
-	if prefix == "." {
-		return ""
-	}
-	return prefix
-}
-
-func (s *Store) resolveRootPath(root string) (string, error) {
-	dir, ok := s.roots[strings.TrimSuffix(strings.TrimSpace(root), ":")]
-	if !ok || strings.TrimSpace(dir) == "" {
-		return "", fmt.Errorf("unknown document root %q", root)
-	}
-	absDir, err := filepath.Abs(dir)
-	if err != nil {
-		return "", fmt.Errorf("resolve root %q: %w", root, err)
-	}
-	resolvedDir, err := filepath.EvalSymlinks(absDir)
-	if err != nil {
-		if errors.Is(err, fs.ErrNotExist) {
-			return "", fmt.Errorf("document root %q does not exist", root)
-		}
-		return "", fmt.Errorf("resolve root %q: %w", root, err)
-	}
-	return filepath.Clean(resolvedDir), nil
-}
-
-func (s *Store) resolveDocumentPath(root, relPath string) (string, error) {
-	rootPath, err := s.resolveRootPath(root)
-	if err != nil {
-		return "", err
-	}
-	candidate := filepath.Clean(filepath.Join(rootPath, filepath.FromSlash(relPath)))
-	if !pathWithinRoot(rootPath, candidate) {
-		return "", fmt.Errorf("document path %q escapes root %q", relPath, root)
-	}
-	resolved, err := filepath.EvalSymlinks(candidate)
-	if err != nil {
-		if errors.Is(err, fs.ErrNotExist) {
-			return "", os.ErrNotExist
-		}
-		return "", fmt.Errorf("resolve document path %q: %w", relPath, err)
-	}
-	resolved = filepath.Clean(resolved)
-	if !pathWithinRoot(rootPath, resolved) {
-		return "", fmt.Errorf("document path %q resolves outside root %q", relPath, root)
-	}
-	return resolved, nil
-}
-
-func pathWithinRoot(rootPath, targetPath string) bool {
-	rel, err := filepath.Rel(rootPath, targetPath)
-	if err != nil {
-		return false
-	}
-	return rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
 }

--- a/internal/state/documents/store.go
+++ b/internal/state/documents/store.go
@@ -249,16 +249,19 @@ func (s *Store) refreshRoot(ctx context.Context, root, dir string) error {
 			return nil
 		}
 		rel = filepath.ToSlash(filepath.Clean(rel))
+		seen[rel] = true
 		if err := s.verifyDocumentForConsumer(ctx, root, rel, "document_index"); err != nil {
 			s.logger.Warn("document index skipped file blocked by signature policy",
 				"root", root, "path", rel, "error", err)
+			if err := s.deleteIndexedDocumentRows(ctx, root, rel); err != nil {
+				return err
+			}
 			return nil
 		}
 		if err := s.upsertFile(ctx, root, rel); err != nil {
 			s.logger.Warn("document index skipped file", "root", root, "path", path, "error", err)
 			return nil
 		}
-		seen[rel] = true
 		return nil
 	})
 	if walkErr != nil {
@@ -279,14 +282,21 @@ func (s *Store) refreshRoot(ctx context.Context, root, dir string) error {
 		if seen[rel] {
 			continue
 		}
-		if _, err := s.db.ExecContext(ctx, `DELETE FROM indexed_document_sections WHERE root = ? AND rel_path = ?`, root, rel); err != nil {
-			return fmt.Errorf("delete stale sections: %w", err)
-		}
-		if _, err := s.db.ExecContext(ctx, `DELETE FROM indexed_documents WHERE root = ? AND rel_path = ?`, root, rel); err != nil {
+		if err := s.deleteIndexedDocumentRows(ctx, root, rel); err != nil {
 			return fmt.Errorf("delete stale document: %w", err)
 		}
 	}
 	return rows.Err()
+}
+
+func (s *Store) deleteIndexedDocumentRows(ctx context.Context, root, relPath string) error {
+	if _, err := s.db.ExecContext(ctx, `DELETE FROM indexed_document_sections WHERE root = ? AND rel_path = ?`, root, relPath); err != nil {
+		return fmt.Errorf("delete indexed sections: %w", err)
+	}
+	if _, err := s.db.ExecContext(ctx, `DELETE FROM indexed_documents WHERE root = ? AND rel_path = ?`, root, relPath); err != nil {
+		return fmt.Errorf("delete indexed document: %w", err)
+	}
+	return nil
 }
 
 func (s *Store) purgeRootIndex(ctx context.Context, root string) error {

--- a/internal/state/documents/values.go
+++ b/internal/state/documents/values.go
@@ -1,0 +1,81 @@
+package documents
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// Values returns observed frontmatter values for one key.
+func (s *Store) Values(ctx context.Context, root, key string, limit int) ([]ValueCount, error) {
+	return s.values(ctx, root, key, limit, true)
+}
+
+func (s *Store) values(ctx context.Context, root, key string, limit int, refresh bool) ([]ValueCount, error) {
+	if refresh {
+		if err := s.Refresh(ctx); err != nil {
+			return nil, err
+		}
+	}
+	root = strings.TrimSuffix(strings.TrimSpace(root), ":")
+	key = strings.ToLower(strings.TrimSpace(key))
+	if key == "" {
+		return nil, fmt.Errorf("key is required")
+	}
+	if root != "" && !rootExists(s.roots, root) {
+		return nil, fmt.Errorf("unknown document root %q", root)
+	}
+
+	var (
+		rows *sql.Rows
+		err  error
+	)
+	if root == "" {
+		rows, err = s.db.QueryContext(ctx, `SELECT root, rel_path, tags_json, frontmatter_json FROM indexed_documents`)
+	} else {
+		rows, err = s.db.QueryContext(ctx, `SELECT root, rel_path, tags_json, frontmatter_json FROM indexed_documents WHERE root = ?`, root)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("query document values: %w", err)
+	}
+	defer rows.Close()
+
+	counts := make(map[string]int)
+	for rows.Next() {
+		var docRoot, relPath, tagsJSON, metaJSON string
+		if err := rows.Scan(&docRoot, &relPath, &tagsJSON, &metaJSON); err != nil {
+			return nil, fmt.Errorf("scan document values: %w", err)
+		}
+		if err := s.verifyDocumentForConsumer(ctx, docRoot, relPath, "doc_values"); err != nil {
+			s.logger.Warn("document values skipped file blocked by signature policy",
+				"root", docRoot, "path", relPath, "error", err)
+			continue
+		}
+		if key == "tags" {
+			var tags []string
+			if jsonErr := json.Unmarshal([]byte(tagsJSON), &tags); jsonErr == nil {
+				for _, tag := range tags {
+					counts[tag]++
+				}
+			}
+			continue
+		}
+		var meta map[string][]string
+		if jsonErr := json.Unmarshal([]byte(metaJSON), &meta); jsonErr == nil {
+			for _, value := range meta[key] {
+				counts[value]++
+			}
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	values := asValueCounts(counts)
+	limit = clampLimit(limit, 20, 100)
+	if len(values) > limit {
+		values = values[:limit]
+	}
+	return values, nil
+}

--- a/internal/state/documents/values.go
+++ b/internal/state/documents/values.go
@@ -33,9 +33,9 @@ func (s *Store) values(ctx context.Context, root, key string, limit int, refresh
 		err  error
 	)
 	if root == "" {
-		rows, err = s.db.QueryContext(ctx, `SELECT root, rel_path, tags_json, frontmatter_json FROM indexed_documents`)
+		rows, err = s.db.QueryContext(ctx, `SELECT tags_json, frontmatter_json FROM indexed_documents`)
 	} else {
-		rows, err = s.db.QueryContext(ctx, `SELECT root, rel_path, tags_json, frontmatter_json FROM indexed_documents WHERE root = ?`, root)
+		rows, err = s.db.QueryContext(ctx, `SELECT tags_json, frontmatter_json FROM indexed_documents WHERE root = ?`, root)
 	}
 	if err != nil {
 		return nil, fmt.Errorf("query document values: %w", err)
@@ -44,14 +44,9 @@ func (s *Store) values(ctx context.Context, root, key string, limit int, refresh
 
 	counts := make(map[string]int)
 	for rows.Next() {
-		var docRoot, relPath, tagsJSON, metaJSON string
-		if err := rows.Scan(&docRoot, &relPath, &tagsJSON, &metaJSON); err != nil {
+		var tagsJSON, metaJSON string
+		if err := rows.Scan(&tagsJSON, &metaJSON); err != nil {
 			return nil, fmt.Errorf("scan document values: %w", err)
-		}
-		if err := s.verifyDocumentForConsumer(ctx, docRoot, relPath, "doc_values"); err != nil {
-			s.logger.Warn("document values skipped file blocked by signature policy",
-				"root", docRoot, "path", relPath, "error", err)
-			continue
 		}
 		if key == "tags" {
 			var tags []string

--- a/internal/state/documents/verification.go
+++ b/internal/state/documents/verification.go
@@ -1,0 +1,189 @@
+package documents
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+func (s *Store) verifyDocumentForConsumer(ctx context.Context, root, relPath, consumer string) error {
+	root = normalizeRootName(root)
+	relPath = filepath.ToSlash(filepath.Clean(relPath))
+	policy := s.rootPolicy(root)
+	if !policy.Git.Enabled || policy.Git.VerifySignatures == VerificationNone {
+		return nil
+	}
+
+	verifier := s.rootVerifier(root)
+	if verifier == nil {
+		result := SignatureVerification{
+			Status:   SignatureUnavailable,
+			Mode:     policy.Git.VerifySignatures,
+			Message:  "signature verification is configured but no verifier is available",
+			Consumer: consumer,
+		}
+		s.recordRootVerification(root, result)
+		return s.handleVerificationFailure(root, relPath, consumer, result)
+	}
+
+	result, err := verifier.Verify(ctx, relPath)
+	if result.Status == "" {
+		result.Status = SignatureFailed
+	}
+	result.Mode = policy.Git.VerifySignatures
+	result.Consumer = consumer
+	result.CheckedAt = time.Now().UTC().Format(time.RFC3339Nano)
+	if err != nil && result.Message == "" {
+		result.Message = err.Error()
+	}
+	s.recordRootVerification(root, result)
+	if err != nil || result.Status != SignatureTrusted {
+		return s.handleVerificationFailure(root, relPath, consumer, result)
+	}
+	return nil
+}
+
+// VerifyRef verifies a managed semantic ref for policy-sensitive consumers.
+func (s *Store) VerifyRef(ctx context.Context, ref string, consumer string) error {
+	if s == nil {
+		return nil
+	}
+	root, relPath, err := parseRef(ref)
+	if err != nil {
+		return err
+	}
+	if !rootExists(s.roots, root) {
+		return fmt.Errorf("unknown document root %q", root)
+	}
+	return s.verifyDocumentForConsumer(ctx, root, relPath, consumer)
+}
+
+// VerifyPath verifies an absolute file path when it belongs to a managed
+// document root. Paths outside configured roots are ignored.
+func (s *Store) VerifyPath(ctx context.Context, path string, consumer string) error {
+	if s == nil || strings.TrimSpace(path) == "" {
+		return nil
+	}
+	root, relPath, ok, err := s.rootRefForPath(path)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return nil
+	}
+	return s.verifyDocumentForConsumer(ctx, root, relPath, consumer)
+}
+
+func (s *Store) rootRefForPath(path string) (root string, relPath string, ok bool, err error) {
+	targetAbs, err := filepath.Abs(path)
+	if err != nil {
+		return "", "", false, fmt.Errorf("resolve document path for verification: %w", err)
+	}
+	targetResolved, err := filepath.EvalSymlinks(targetAbs)
+	if err != nil {
+		return "", "", false, fmt.Errorf("resolve document path for verification: %w", err)
+	}
+
+	type candidate struct {
+		root string
+		path string
+	}
+	var candidates []candidate
+	for root := range s.roots {
+		rootPath, err := s.resolveRootPath(root)
+		if err != nil {
+			continue
+		}
+		if !pathWithinRoot(rootPath, targetResolved) {
+			continue
+		}
+		candidates = append(candidates, candidate{root: root, path: rootPath})
+	}
+	if len(candidates) == 0 {
+		return "", "", false, nil
+	}
+	sort.Slice(candidates, func(i, j int) bool {
+		return len(candidates[i].path) > len(candidates[j].path)
+	})
+	rel, err := filepath.Rel(candidates[0].path, targetResolved)
+	if err != nil {
+		return "", "", false, fmt.Errorf("compute managed document ref: %w", err)
+	}
+	return candidates[0].root, filepath.ToSlash(filepath.Clean(rel)), true, nil
+}
+
+func (s *Store) handleVerificationFailure(root, relPath, consumer string, result SignatureVerification) error {
+	message := strings.TrimSpace(result.Message)
+	if message == "" {
+		message = "signature verification failed"
+	}
+	fields := []any{
+		"root", root,
+		"path", relPath,
+		"mode", result.Mode,
+		"consumer", consumer,
+		"status", result.Status,
+		"message", message,
+	}
+	if result.Commit != "" {
+		fields = append(fields, "commit", result.Commit)
+	}
+	if result.Mode == VerificationWarn {
+		s.logger.Warn("document root signature verification warning", fields...)
+		return nil
+	}
+	return fmt.Errorf("document %s:%s blocked by signature policy for %s: %s", root, relPath, consumer, message)
+}
+
+func (s *Store) recordRootVerification(root string, result SignatureVerification) {
+	if s == nil {
+		return
+	}
+	root = normalizeRootName(root)
+	if root == "" {
+		return
+	}
+	if result.CheckedAt == "" {
+		result.CheckedAt = time.Now().UTC().Format(time.RFC3339Nano)
+	}
+	s.verificationMu.Lock()
+	defer s.verificationMu.Unlock()
+	s.verification[root] = result
+}
+
+func (s *Store) rootVerificationSummary(ctx context.Context, root string) *SignatureVerification {
+	root = normalizeRootName(root)
+	policy := s.rootPolicy(root)
+	if !policy.Git.Enabled || policy.Git.VerifySignatures == VerificationNone {
+		return nil
+	}
+
+	verifier := s.rootVerifier(root)
+	if verifier == nil {
+		result := SignatureVerification{
+			Status:    SignatureUnavailable,
+			Mode:      policy.Git.VerifySignatures,
+			Message:   "signature verification is configured but no verifier is available",
+			CheckedAt: time.Now().UTC().Format(time.RFC3339Nano),
+			Consumer:  "root_summary",
+		}
+		s.recordRootVerification(root, result)
+		return &result
+	}
+
+	result, err := verifier.VerifyRoot(ctx)
+	if result.Status == "" {
+		result.Status = SignatureFailed
+	}
+	result.Mode = policy.Git.VerifySignatures
+	result.Consumer = "root_summary"
+	result.CheckedAt = time.Now().UTC().Format(time.RFC3339Nano)
+	if err != nil && result.Message == "" {
+		result.Message = err.Error()
+	}
+	s.recordRootVerification(root, result)
+	return &result
+}


### PR DESCRIPTION
## Summary

This finishes the document-root signature enforcement layer that was left implicit after the managed document root work. `git.verify_signatures` now has concrete read-side behavior instead of being only recorded in policy metadata.

Required roots now keep unsafe document content out of model-facing paths when the target content is not cleanly covered by trusted signed git state. Warn roots record and log the same verification failure without blocking. Direct content consumers such as `doc_read`, loop output context, tagged KB articles, and session origin context refs verify at consumption time; indexed metadata surfaces such as browse/search/values/links rely on refresh-time verification so large roots do not spawn per-row git checks.

The PR also adds a read-only provenance verifier for existing git repositories, surfaces current verification state in `doc_roots`, and documents the operational behavior. While wiring this in, I split document ref/path and values helpers out of already-large files so the architecture guardrails stay flat rather than expanding the baseline.

Closes #772.
Refs #657.

## Validation

- `env GOCACHE=/tmp/thane-gocache go test ./internal/platform/provenance ./internal/state/documents ./internal/runtime/agent ./internal/app`
- `env GOCACHE=/tmp/thane-gocache GOLANGCI_LINT_CACHE=/tmp/thane-golangci-lint-cache just ci`