### PR TITLE
feat: add corpus-aware document intake

### DIFF
--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -127,6 +127,8 @@ covered by trusted signed git history.
 | `doc_search` | Full-text and tagged search across roots. |
 | `doc_links` | List inbound/outbound links for a document. |
 | `doc_values` | List frontmatter values (tags, statuses, etc.) across a root. |
+| `doc_intake` | Analyze proposed knowledge against the existing corpus before writing it. |
+| `doc_commit` | Commit an approved `doc_intake` result through managed mutations. |
 | `doc_write` | Write or replace a document. |
 | `doc_edit` | Targeted edit within a document. |
 | `doc_copy` | Copy a document to another location. |

--- a/docs/understanding/architecture.md
+++ b/docs/understanding/architecture.md
@@ -122,7 +122,10 @@ The current implementation establishes policy-aware managed roots,
 signed git-backed writes, and read-side enforcement for roots that
 require trusted signatures. Unsigned or dirty high-integrity content is
 kept out of managed document reads, indexed results, and tagged context
-injection instead of relying on model behavior.
+injection instead of relying on model behavior. New durable knowledge
+can also enter through a corpus-aware intake flow that checks nearby
+documents, observed tags, path conventions, and root policy before any
+managed write is committed.
 
 ## Trust Zones: Safety in Go, Not Prompts
 

--- a/docs/understanding/document-roots.md
+++ b/docs/understanding/document-roots.md
@@ -109,8 +109,8 @@ doc_roots:
 ```
 
 Policy is deliberately attached to the root, not to individual tools or
-prompts. A loop-declared output, a document write tool, and a future
-specialized authoring flow should all meet the same root contract.
+prompts. A loop-declared output, a direct document write, and the
+corpus-aware intake flow should all meet the same root contract.
 
 The current policy fields are:
 
@@ -141,6 +141,31 @@ failures but still lets the content load.
   give it a root instead of leaving it buried in a generic folder.
 - If a root is very high integrity or operationally sensitive, be
   deliberate about how you want it managed and edited.
+
+## Corpus-Aware Intake
+
+When Thane is about to create durable knowledge, the safest first step
+is `doc_intake`, not guessing a new filename. Intake looks at the target
+root, searches related documents, checks observed tag vocabulary and
+path patterns, and returns a proposed destination with a recommended
+action:
+
+- `create_new` when the corpus does not appear to contain the idea yet
+- `update_existing` when a related document looks like the better home
+- `append_existing` when the request sounds like a journal or running
+  note
+- `draft_for_review` when root policy or ambiguity makes a write
+  inappropriate
+
+The result includes an `intake_id`, normalized title/tags/frontmatter,
+related documents with similarity scores, and a `commit_plan`. The
+model then calls `doc_commit` with that `intake_id` and the approved
+body. If intake reports a caution, such as a high-overlap existing
+document, `doc_commit` requires `confirm=true` before writing.
+
+This keeps taxonomy decisions anchored in the existing corpus. The raw
+mutation tools still exist for deliberate exact-path work, but intake is
+the normal authoring flow for new knowledge.
 
 ## Generated Documents
 

--- a/internal/state/documents/intake_paths.go
+++ b/internal/state/documents/intake_paths.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path"
 	"strings"
+	"unicode"
 )
 
 func normalizeIntakeTitle(args IntakeArgs) string {
@@ -32,7 +33,9 @@ func normalizeIntakeTags(tags []string, observed []ValueCount) []string {
 			continue
 		}
 		observedByFold[strings.ToLower(clean)] = clean
-		observedBySlug[slugify(clean)] = clean
+		if slug := slugifyIntakeValue(clean); slug != "" {
+			observedBySlug[slug] = clean
+		}
 	}
 	out := make([]string, 0, len(tags))
 	for _, tag := range tags {
@@ -44,7 +47,10 @@ func normalizeIntakeTags(tags []string, observed []ValueCount) []string {
 			out = append(out, observed)
 			continue
 		}
-		slug := slugify(tag)
+		slug := slugifyIntakeValue(tag)
+		if slug == "" {
+			continue
+		}
 		if observed := observedBySlug[slug]; observed != "" {
 			out = append(out, observed)
 			continue
@@ -52,6 +58,15 @@ func normalizeIntakeTags(tags []string, observed []ValueCount) []string {
 		out = append(out, slug)
 	}
 	return dedupeSorted(out)
+}
+
+func slugifyIntakeValue(raw string) string {
+	for _, r := range raw {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) {
+			return slugify(raw)
+		}
+	}
+	return ""
 }
 
 func (s *Store) proposeIntakeRef(ctx context.Context, root string, args IntakeArgs, title string, tags []string, related []IntakeRelatedDocument) (string, string, error) {

--- a/internal/state/documents/intake_paths.go
+++ b/internal/state/documents/intake_paths.go
@@ -1,0 +1,185 @@
+package documents
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path"
+	"strings"
+)
+
+func normalizeIntakeTitle(args IntakeArgs) string {
+	for _, candidate := range []string{
+		args.DesiredTitle,
+		firstMarkdownHeading(args.BodySnippet),
+		firstSentence(args.Summary),
+		firstSentence(args.ContentDigest),
+	} {
+		candidate = strings.TrimSpace(candidate)
+		if candidate != "" {
+			return candidate
+		}
+	}
+	return "Untitled Note"
+}
+
+func normalizeIntakeTags(tags []string, observed []ValueCount) []string {
+	observedByFold := make(map[string]string, len(observed))
+	observedBySlug := make(map[string]string, len(observed))
+	for _, value := range observed {
+		clean := strings.TrimSpace(value.Value)
+		if clean == "" {
+			continue
+		}
+		observedByFold[strings.ToLower(clean)] = clean
+		observedBySlug[slugify(clean)] = clean
+	}
+	out := make([]string, 0, len(tags))
+	for _, tag := range tags {
+		tag = strings.TrimSpace(tag)
+		if tag == "" {
+			continue
+		}
+		if observed := observedByFold[strings.ToLower(tag)]; observed != "" {
+			out = append(out, observed)
+			continue
+		}
+		slug := slugify(tag)
+		if observed := observedBySlug[slug]; observed != "" {
+			out = append(out, observed)
+			continue
+		}
+		out = append(out, slug)
+	}
+	return dedupeSorted(out)
+}
+
+func (s *Store) proposeIntakeRef(ctx context.Context, root string, args IntakeArgs, title string, tags []string, related []IntakeRelatedDocument) (string, string, error) {
+	if strings.TrimSpace(args.DesiredRef) != "" {
+		desiredRoot, relPath, err := parseRef(args.DesiredRef)
+		if err != nil {
+			return "", "", fmt.Errorf("desired_ref: %w", err)
+		}
+		if normalizeRootName(desiredRoot) != root {
+			return "", "", fmt.Errorf("desired_ref root %q does not match intake root %q", desiredRoot, root)
+		}
+		return makeRef(root, relPath), relPath, nil
+	}
+
+	dir := trimPathPrefix(args.PathPrefix)
+	if dir == "" {
+		if top := topRelated(related); top != nil && top.Score >= intakeMaybeOverlapScore {
+			dir = path.Dir(top.Path)
+			if dir == "." {
+				dir = ""
+			}
+		}
+	}
+	if dir == "" && len(tags) > 0 {
+		dir = slugify(tags[0])
+	}
+	if dir == "" {
+		dir = "notes"
+	}
+	slug := slugify(title)
+	relPath, err := s.uniqueIntakePath(ctx, root, dir, slug)
+	if err != nil {
+		return "", "", err
+	}
+	return makeRef(root, relPath), relPath, nil
+}
+
+func (s *Store) uniqueIntakePath(ctx context.Context, root, dir, slug string) (string, error) {
+	dir = trimPathPrefix(dir)
+	slug = slugify(slug)
+	if slug == "" {
+		slug = "note"
+	}
+	for i := 0; i < 100; i++ {
+		name := slug
+		if i > 0 {
+			name = fmt.Sprintf("%s-%d", slug, i+1)
+		}
+		relPath := name + ".md"
+		if dir != "" {
+			relPath = path.Join(dir, relPath)
+		}
+		if !s.refExists(ctx, root, relPath) {
+			return relPath, nil
+		}
+	}
+	return "", fmt.Errorf("could not allocate a unique path for %q in root %q", slug, root)
+}
+
+func (s *Store) refExists(ctx context.Context, root, relPath string) bool {
+	if exists, err := s.documentExists(ctx, root, relPath); err == nil && exists {
+		return true
+	}
+	absPath, err := s.resolveDocumentWritePath(root, relPath)
+	if err != nil {
+		return false
+	}
+	if _, err := os.Stat(absPath); err == nil {
+		return true
+	}
+	return false
+}
+
+func topRelated(related []IntakeRelatedDocument) *IntakeRelatedDocument {
+	if len(related) == 0 {
+		return nil
+	}
+	return &related[0]
+}
+
+func firstMarkdownHeading(raw string) string {
+	for _, line := range strings.Split(raw, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if !strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		heading := strings.TrimSpace(strings.TrimLeft(trimmed, "#"))
+		if heading != "" {
+			return heading
+		}
+	}
+	return ""
+}
+
+func firstSentence(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return ""
+	}
+	for _, sep := range []string{".", "\n"} {
+		if idx := strings.Index(raw, sep); idx > 0 {
+			raw = raw[:idx]
+			break
+		}
+	}
+	words := strings.Fields(raw)
+	if len(words) > 10 {
+		words = words[:10]
+	}
+	return strings.Join(words, " ")
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func intakeLooksAppendOrJournal(intent string) bool {
+	intent = strings.ToLower(intent)
+	for _, word := range []string{"append", "journal", "log", "entry", "note"} {
+		if strings.Contains(intent, word) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/state/documents/intake_similarity.go
+++ b/internal/state/documents/intake_similarity.go
@@ -1,0 +1,123 @@
+package documents
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"sort"
+	"strings"
+	"unicode"
+)
+
+func (s *Store) relatedIntakeDocuments(ctx context.Context, root string, args IntakeArgs, title string, tags []string) ([]IntakeRelatedDocument, error) {
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT root, rel_path, title, summary, tags_json, frontmatter_json, modified_at, word_count
+		 FROM indexed_documents
+		 WHERE root = ?
+		 ORDER BY modified_at DESC, rel_path
+		 LIMIT ?`,
+		root, intakeCandidateScanCap)
+	if err != nil {
+		return nil, fmt.Errorf("query intake candidates: %w", err)
+	}
+	defer rows.Close()
+
+	queryTokens := tokenSet(strings.Join([]string{
+		title,
+		args.Intent,
+		args.Summary,
+		args.BodySnippet,
+		args.ContentDigest,
+		strings.Join(tags, " "),
+	}, " "))
+	var related []IntakeRelatedDocument
+	for rows.Next() {
+		var doc DocumentSummary
+		if err := scanDocument(rows, &doc); err != nil {
+			return nil, fmt.Errorf("scan intake candidate: %w", err)
+		}
+		score := intakeSimilarity(queryTokens, doc)
+		if score < 0.08 {
+			continue
+		}
+		related = append(related, IntakeRelatedDocument{
+			Ref:       doc.Ref,
+			Title:     doc.Title,
+			Path:      doc.Path,
+			Tags:      append([]string(nil), doc.Tags...),
+			Score:     score,
+			Rationale: intakeSimilarityRationale(score),
+		})
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	sort.SliceStable(related, func(i, j int) bool {
+		if related[i].Score == related[j].Score {
+			return related[i].Ref < related[j].Ref
+		}
+		return related[i].Score > related[j].Score
+	})
+	if len(related) > intakeSimilarLimit {
+		related = related[:intakeSimilarLimit]
+	}
+	return related, nil
+}
+
+func intakeSimilarity(queryTokens map[string]bool, doc DocumentSummary) float64 {
+	if len(queryTokens) == 0 {
+		return 0
+	}
+	docTokens := tokenSet(strings.Join([]string{
+		doc.Title,
+		doc.Summary,
+		doc.Path,
+		strings.Join(doc.Tags, " "),
+	}, " "))
+	if len(docTokens) == 0 {
+		return 0
+	}
+	overlap := 0
+	for token := range queryTokens {
+		if docTokens[token] {
+			overlap++
+		}
+	}
+	score := float64(overlap) / math.Sqrt(float64(len(queryTokens)*len(docTokens)))
+	if score > 1 {
+		score = 1
+	}
+	return math.Round(score*100) / 100
+}
+
+func tokenSet(raw string) map[string]bool {
+	tokens := make(map[string]bool)
+	var b strings.Builder
+	flush := func() {
+		token := b.String()
+		b.Reset()
+		if len(token) >= 3 {
+			tokens[token] = true
+		}
+	}
+	for _, r := range strings.ToLower(raw) {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) {
+			b.WriteRune(r)
+			continue
+		}
+		flush()
+	}
+	flush()
+	return tokens
+}
+
+func intakeSimilarityRationale(score float64) string {
+	switch {
+	case score >= intakeHighOverlapScore:
+		return "high token overlap with title/path/summary/tags"
+	case score >= intakeMaybeOverlapScore:
+		return "moderate token overlap; inspect before creating a new document"
+	default:
+		return "low but nonzero token overlap"
+	}
+}

--- a/internal/state/documents/intake_store.go
+++ b/internal/state/documents/intake_store.go
@@ -24,7 +24,7 @@ func (s *Store) Intake(ctx context.Context, args IntakeArgs) (*IntakeResult, err
 	}
 
 	policy := s.rootPolicy(root)
-	observedTags, err := s.Values(ctx, root, "tags", 40)
+	observedTags, err := s.values(ctx, root, "tags", 40, false)
 	if err != nil {
 		return nil, fmt.Errorf("load observed tags: %w", err)
 	}

--- a/internal/state/documents/intake_store.go
+++ b/internal/state/documents/intake_store.go
@@ -1,0 +1,151 @@
+package documents
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+// Intake analyzes a proposed document contribution against existing
+// corpus structure.
+func (s *Store) Intake(ctx context.Context, args IntakeArgs) (*IntakeResult, error) {
+	if s == nil {
+		return nil, fmt.Errorf("document index not configured")
+	}
+	root, err := s.resolveIntakeRoot(args.Root)
+	if err != nil {
+		return nil, err
+	}
+	if strings.TrimSpace(args.Summary) == "" && strings.TrimSpace(args.BodySnippet) == "" && strings.TrimSpace(args.ContentDigest) == "" {
+		return nil, fmt.Errorf("summary, body_snippet, or content_digest is required")
+	}
+	if err := s.Refresh(ctx); err != nil {
+		return nil, err
+	}
+
+	policy := s.rootPolicy(root)
+	observedTags, err := s.Values(ctx, root, "tags", 40)
+	if err != nil {
+		return nil, fmt.Errorf("load observed tags: %w", err)
+	}
+	normalizedTags := normalizeIntakeTags(args.Tags, observedTags)
+	title := normalizeIntakeTitle(args)
+	frontmatter := map[string][]string{
+		"title":       {title},
+		"description": {firstNonEmpty(args.Summary, args.ContentDigest)},
+	}
+	if len(normalizedTags) > 0 {
+		frontmatter["tags"] = normalizedTags
+	}
+	related, err := s.relatedIntakeDocuments(ctx, root, args, title, normalizedTags)
+	if err != nil {
+		return nil, err
+	}
+
+	proposedRef, proposedRel, err := s.proposeIntakeRef(ctx, root, args, title, normalizedTags, related)
+	if err != nil {
+		return nil, err
+	}
+	top := topRelated(related)
+	proposedExists := s.refExists(ctx, root, proposedRel)
+	appendPreferred := intakeLooksAppendOrJournal(args.Intent)
+
+	status := IntakeReady
+	reason := ""
+	action := IntakeActionCreateNew
+	targetRef := ""
+	rationale := []string{
+		"normalized title, tags, and proposed path from current corpus state",
+	}
+
+	switch policy.Authoring {
+	case AuthoringReadOnly:
+		status = IntakeRefused
+		reason = "target root is read_only"
+		action = IntakeActionDraftForReview
+		rationale = append(rationale, "root authoring policy refuses managed writes")
+	case AuthoringRestricted:
+		status = IntakeDraftForReview
+		reason = "target root is restricted"
+		action = IntakeActionDraftForReview
+		rationale = append(rationale, "root authoring policy requires a narrower review path")
+	case "", AuthoringManaged:
+		switch {
+		case proposedExists:
+			status = IntakeConfirmUpdate
+			reason = "proposed_ref_already_exists"
+			action = IntakeActionUpdateExisting
+			targetRef = proposedRef
+			rationale = append(rationale, "proposed path already exists; update is safer than overwrite")
+		case top != nil && top.Score >= intakeHighOverlapScore:
+			status = IntakeConfirmUpdate
+			reason = "high_similarity_existing_document"
+			action = IntakeActionUpdateExisting
+			if appendPreferred {
+				action = IntakeActionAppendExisting
+			}
+			targetRef = top.Ref
+			rationale = append(rationale, fmt.Sprintf("top related document score %.2f suggests reuse", top.Score))
+		case top != nil && top.Score >= intakeMaybeOverlapScore:
+			status = IntakeConfirmCreate
+			reason = "similar_documents_found"
+			action = IntakeActionUpdateExisting
+			targetRef = top.Ref
+			rationale = append(rationale, fmt.Sprintf("top related document score %.2f makes create_new a confirmation decision", top.Score))
+		default:
+			rationale = append(rationale, "no high-overlap document found; create_new is safe")
+		}
+	default:
+		status = IntakeRefused
+		reason = "unsupported_authoring_policy"
+		action = IntakeActionDraftForReview
+		rationale = append(rationale, "root authoring policy is unsupported")
+	}
+
+	requiresConfirmation := status == IntakeConfirmCreate || status == IntakeConfirmUpdate || status == IntakeDraftForReview
+	confirmationReason := reason
+	if requiresConfirmation && confirmationReason == "" {
+		confirmationReason = string(status)
+	}
+	result := &IntakeResult{
+		Status:                status,
+		Reason:                reason,
+		Root:                  root,
+		RootPolicy:            s.rootPolicySummary(root),
+		RecommendedAction:     action,
+		ProposedRef:           proposedRef,
+		TargetRef:             targetRef,
+		NormalizedTitle:       title,
+		NormalizedTags:        normalizedTags,
+		NormalizedFrontmatter: frontmatter,
+		ObservedTags:          observedTags,
+		RelatedDocuments:      related,
+		Rationale:             rationale,
+	}
+	result.CommitPlan = IntakeCommitPlan{
+		RecommendedAction:     action,
+		ProposedRef:           proposedRef,
+		TargetRef:             targetRef,
+		NormalizedTitle:       title,
+		NormalizedTags:        normalizedTags,
+		NormalizedFrontmatter: frontmatter,
+		RequiresConfirmation:  requiresConfirmation,
+		ConfirmationReason:    confirmationReason,
+	}
+	return result, nil
+}
+
+func (s *Store) resolveIntakeRoot(root string) (string, error) {
+	root = normalizeRootName(root)
+	if root != "" {
+		if !rootExists(s.roots, root) {
+			return "", fmt.Errorf("unknown document root %q; use doc_roots to choose one of %v", root, s.allRoots())
+		}
+		return root, nil
+	}
+	roots := s.allRoots()
+	if len(roots) == 1 {
+		return roots[0], nil
+	}
+	return "", fmt.Errorf("root is required; choose one of %v", roots)
+}

--- a/internal/state/documents/intake_test.go
+++ b/internal/state/documents/intake_test.go
@@ -3,10 +3,12 @@ package documents
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/nugget/thane-ai-agent/internal/platform/database"
 )
@@ -178,6 +180,82 @@ func TestDocumentCommitRejectsUnknownAction(t *testing.T) {
 		Body:     "# Action Validation\n",
 	}); err == nil || !strings.Contains(err.Error(), "unsupported action") {
 		t.Fatalf("Commit unknown action error = %v, want unsupported action", err)
+	}
+}
+
+func TestDocumentCommitDraftForReviewForgetsIntake(t *testing.T) {
+	t.Parallel()
+
+	tools, _ := newIntakeTools(t, nil)
+	out, err := tools.Intake(context.Background(), IntakeArgs{
+		Root:         "kb",
+		Summary:      "A draft-only intake should not stay resident.",
+		DesiredTitle: "Draft Intake",
+	})
+	if err != nil {
+		t.Fatalf("Intake: %v", err)
+	}
+	var intake IntakeResult
+	if err := json.Unmarshal([]byte(out), &intake); err != nil {
+		t.Fatalf("unmarshal intake: %v", err)
+	}
+	if _, err := tools.Commit(context.Background(), CommitArgs{
+		IntakeID: intake.IntakeID,
+		Action:   IntakeActionDraftForReview,
+	}); err != nil {
+		t.Fatalf("Commit draft_for_review: %v", err)
+	}
+	if _, err := tools.Commit(context.Background(), CommitArgs{
+		IntakeID: intake.IntakeID,
+		Body:     "# Draft Intake\n",
+	}); err == nil || !strings.Contains(err.Error(), "unknown intake_id") {
+		t.Fatalf("Commit reused draft intake error = %v, want unknown intake_id", err)
+	}
+}
+
+func TestDocumentIntakeCacheIsBoundedAndExpires(t *testing.T) {
+	t.Parallel()
+
+	tools, _ := newIntakeTools(t, nil)
+	for i := 0; i < maxIntakeEntries+10; i++ {
+		result := &IntakeResult{
+			Status:            IntakeReady,
+			RecommendedAction: IntakeActionCreateNew,
+			ProposedRef:       fmt.Sprintf("kb:notes/intake-%d.md", i),
+		}
+		tools.rememberIntake(result)
+	}
+	tools.intakeMu.Lock()
+	got := len(tools.intakes)
+	tools.intakeMu.Unlock()
+	if got != maxIntakeEntries {
+		t.Fatalf("intake cache size = %d, want %d", got, maxIntakeEntries)
+	}
+
+	tools.intakeMu.Lock()
+	tools.intakes["old"] = intakeEntry{
+		result: IntakeResult{
+			IntakeID:          "old",
+			Status:            IntakeReady,
+			RecommendedAction: IntakeActionCreateNew,
+		},
+		createdAt: time.Now().Add(-intakeEntryTTL - time.Second),
+	}
+	tools.intakeMu.Unlock()
+
+	if _, ok := tools.lookupIntake("old"); ok {
+		t.Fatal("expired intake was still available")
+	}
+}
+
+func TestNormalizeIntakeTagsDropsPunctuationOnlyTags(t *testing.T) {
+	t.Parallel()
+
+	got := normalizeIntakeTags([]string{"...", "--", "Home Assistant"}, []ValueCount{
+		{Value: "home-assistant", Count: 2},
+	})
+	if len(got) != 1 || got[0] != "home-assistant" {
+		t.Fatalf("normalizeIntakeTags = %#v, want only observed home-assistant tag", got)
 	}
 }
 

--- a/internal/state/documents/intake_test.go
+++ b/internal/state/documents/intake_test.go
@@ -1,0 +1,214 @@
+package documents
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nugget/thane-ai-agent/internal/platform/database"
+)
+
+func TestDocumentIntakeProposesCreateAndCommit(t *testing.T) {
+	t.Parallel()
+
+	tools, _ := newIntakeTools(t, nil)
+	ctx := context.Background()
+
+	out, err := tools.Intake(ctx, IntakeArgs{
+		Root:         "kb",
+		Intent:       "create a durable note",
+		Summary:      "Driveway gate maintenance observations and reset procedure.",
+		DesiredTitle: "Driveway Gate Notes",
+		Tags:         []string{"Home Assistant"},
+		BodySnippet:  "# Driveway Gate Notes\n\nThe driveway gate sometimes needs a controller reset.",
+	})
+	if err != nil {
+		t.Fatalf("Intake: %v", err)
+	}
+	var intake IntakeResult
+	if err := json.Unmarshal([]byte(out), &intake); err != nil {
+		t.Fatalf("unmarshal intake: %v", err)
+	}
+	if intake.Status != IntakeReady || intake.RecommendedAction != IntakeActionCreateNew {
+		t.Fatalf("intake status/action = %s/%s, want ready/create_new", intake.Status, intake.RecommendedAction)
+	}
+	if intake.IntakeID == "" || intake.ProposedRef != "kb:home-assistant/driveway-gate-notes.md" {
+		t.Fatalf("intake id/ref = %q/%q, want id and canonical ref", intake.IntakeID, intake.ProposedRef)
+	}
+
+	commitOut, err := tools.Commit(ctx, CommitArgs{
+		IntakeID: intake.IntakeID,
+		Body:     "# Driveway Gate Notes\n\nThe reset process lives here.",
+	})
+	if err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+	var commit CommitResult
+	if err := json.Unmarshal([]byte(commitOut), &commit); err != nil {
+		t.Fatalf("unmarshal commit: %v", err)
+	}
+	if commit.Ref != intake.ProposedRef || commit.Action != IntakeActionCreateNew {
+		t.Fatalf("commit = %#v, want create at %s", commit, intake.ProposedRef)
+	}
+	doc, err := tools.store.Read(ctx, intake.ProposedRef)
+	if err != nil {
+		t.Fatalf("Read committed doc: %v", err)
+	}
+	if doc.Title != "Driveway Gate Notes" || !containsString(doc.Tags, "home-assistant") {
+		t.Fatalf("doc title/tags = %q/%v, want normalized metadata", doc.Title, doc.Tags)
+	}
+}
+
+func TestDocumentIntakeRequiresConfirmationForSimilarCorpus(t *testing.T) {
+	t.Parallel()
+
+	tools, _ := newIntakeTools(t, nil)
+	ctx := context.Background()
+	body := "# VLAN Guide\n\nHome network VLAN layout for trusted, IoT, and camera segments."
+	if _, err := tools.store.Write(ctx, WriteArgs{
+		Ref:   "kb:network/vlans.md",
+		Title: "VLAN Guide",
+		Tags:  []string{"network", "vlans"},
+		Body:  &body,
+	}); err != nil {
+		t.Fatalf("seed Write: %v", err)
+	}
+
+	out, err := tools.Intake(ctx, IntakeArgs{
+		Root:         "kb",
+		Intent:       "create a new note about the home network VLAN layout",
+		Summary:      "Home network VLAN layout for trusted IoT and camera segments.",
+		DesiredTitle: "VLAN Guide",
+		Tags:         []string{"network", "vlans"},
+		BodySnippet:  body,
+	})
+	if err != nil {
+		t.Fatalf("Intake: %v", err)
+	}
+	var intake IntakeResult
+	if err := json.Unmarshal([]byte(out), &intake); err != nil {
+		t.Fatalf("unmarshal intake: %v", err)
+	}
+	if intake.Status != IntakeConfirmUpdate || intake.TargetRef != "kb:network/vlans.md" {
+		t.Fatalf("intake status/target = %s/%q, want confirm_update existing VLAN doc", intake.Status, intake.TargetRef)
+	}
+
+	if _, err := tools.Commit(ctx, CommitArgs{
+		IntakeID: intake.IntakeID,
+		Action:   IntakeActionCreateNew,
+		Body:     "# VLAN Follow-up\n\nA separate copy should require confirmation.",
+	}); err == nil || !strings.Contains(err.Error(), "confirm=true") {
+		t.Fatalf("Commit without confirm error = %v, want confirmation requirement", err)
+	}
+
+	if _, err := tools.Commit(ctx, CommitArgs{
+		IntakeID: intake.IntakeID,
+		Action:   IntakeActionUpdateExisting,
+		Body:     "Additional VLAN operational detail.",
+		Confirm:  true,
+	}); err != nil {
+		t.Fatalf("Commit update_existing: %v", err)
+	}
+	doc, err := tools.store.Read(ctx, "kb:network/vlans.md")
+	if err != nil {
+		t.Fatalf("Read updated doc: %v", err)
+	}
+	if !strings.Contains(doc.Body, "Additional VLAN operational detail.") {
+		t.Fatalf("updated body = %q, want appended intake body", doc.Body)
+	}
+}
+
+func TestDocumentIntakeRefusesReadOnlyRoot(t *testing.T) {
+	t.Parallel()
+
+	tools, _ := newIntakeTools(t, map[string]RootPolicy{
+		"kb": {
+			Indexing:  true,
+			Authoring: AuthoringReadOnly,
+		},
+	})
+	out, err := tools.Intake(context.Background(), IntakeArgs{
+		Root:         "kb",
+		Summary:      "Read-only root should not accept managed intake writes.",
+		DesiredTitle: "Read Only Intake",
+	})
+	if err != nil {
+		t.Fatalf("Intake: %v", err)
+	}
+	var intake IntakeResult
+	if err := json.Unmarshal([]byte(out), &intake); err != nil {
+		t.Fatalf("unmarshal intake: %v", err)
+	}
+	if intake.Status != IntakeRefused || intake.RecommendedAction != IntakeActionDraftForReview {
+		t.Fatalf("intake status/action = %s/%s, want refused/draft_for_review", intake.Status, intake.RecommendedAction)
+	}
+	if _, err := tools.Commit(context.Background(), CommitArgs{
+		IntakeID: intake.IntakeID,
+		Action:   IntakeActionCreateNew,
+		Body:     "# Should Not Write\n",
+		Confirm:  true,
+	}); err == nil || !strings.Contains(err.Error(), "cannot be committed") {
+		t.Fatalf("Commit read-only error = %v, want refusal", err)
+	}
+}
+
+func TestDocumentCommitRejectsUnknownAction(t *testing.T) {
+	t.Parallel()
+
+	tools, _ := newIntakeTools(t, nil)
+	out, err := tools.Intake(context.Background(), IntakeArgs{
+		Root:         "kb",
+		Summary:      "A small note for action validation.",
+		DesiredTitle: "Action Validation",
+	})
+	if err != nil {
+		t.Fatalf("Intake: %v", err)
+	}
+	var intake IntakeResult
+	if err := json.Unmarshal([]byte(out), &intake); err != nil {
+		t.Fatalf("unmarshal intake: %v", err)
+	}
+
+	if _, err := tools.Commit(context.Background(), CommitArgs{
+		IntakeID: intake.IntakeID,
+		Action:   IntakeAction("creat_new"),
+		Body:     "# Action Validation\n",
+	}); err == nil || !strings.Contains(err.Error(), "unsupported action") {
+		t.Fatalf("Commit unknown action error = %v, want unsupported action", err)
+	}
+}
+
+func newIntakeTools(t *testing.T, policies map[string]RootPolicy) (*Tools, string) {
+	t.Helper()
+
+	rootDir := t.TempDir()
+	kbDir := filepath.Join(rootDir, "kb")
+	if err := os.MkdirAll(kbDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	db, err := database.OpenMemory()
+	if err != nil {
+		t.Fatalf("OpenMemory: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	store, err := NewStoreWithOptions(db, map[string]string{"kb": kbDir}, nil, StoreOptions{
+		RootPolicies: policies,
+	})
+	if err != nil {
+		t.Fatalf("NewStoreWithOptions: %v", err)
+	}
+	return NewTools(store), kbDir
+}
+
+func containsString(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/state/documents/intake_tools.go
+++ b/internal/state/documents/intake_tools.go
@@ -143,9 +143,7 @@ func (t *Tools) Commit(ctx context.Context, args CommitArgs) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	if action != IntakeActionDraftForReview {
-		t.forgetIntake(args.IntakeID)
-	}
+	t.forgetIntake(args.IntakeID)
 	return marshalToolResult(CommitResult{
 		IntakeID: args.IntakeID,
 		Action:   action,
@@ -165,22 +163,50 @@ func (t *Tools) rememberIntake(result *IntakeResult) {
 	t.intakeMu.Lock()
 	defer t.intakeMu.Unlock()
 	if t.intakes == nil {
-		t.intakes = make(map[string]IntakeResult)
+		t.intakes = make(map[string]intakeEntry)
 	}
-	t.intakes[id] = *result
+	now := time.Now()
+	t.pruneIntakesLocked(now)
+	if len(t.intakes) >= maxIntakeEntries {
+		t.evictOldestIntakeLocked()
+	}
+	t.intakes[id] = intakeEntry{result: *result, createdAt: now}
 }
 
 func (t *Tools) lookupIntake(id string) (IntakeResult, bool) {
 	t.intakeMu.Lock()
 	defer t.intakeMu.Unlock()
-	result, ok := t.intakes[id]
-	return result, ok
+	t.pruneIntakesLocked(time.Now())
+	entry, ok := t.intakes[id]
+	return entry.result, ok
 }
 
 func (t *Tools) forgetIntake(id string) {
 	t.intakeMu.Lock()
 	defer t.intakeMu.Unlock()
 	delete(t.intakes, id)
+}
+
+func (t *Tools) pruneIntakesLocked(now time.Time) {
+	for id, entry := range t.intakes {
+		if entry.createdAt.IsZero() || now.Sub(entry.createdAt) > intakeEntryTTL {
+			delete(t.intakes, id)
+		}
+	}
+}
+
+func (t *Tools) evictOldestIntakeLocked() {
+	oldestID := ""
+	var oldest time.Time
+	for id, entry := range t.intakes {
+		if oldestID == "" || entry.createdAt.Before(oldest) {
+			oldestID = id
+			oldest = entry.createdAt
+		}
+	}
+	if oldestID != "" {
+		delete(t.intakes, oldestID)
+	}
 }
 
 func newIntakeID() string {

--- a/internal/state/documents/intake_tools.go
+++ b/internal/state/documents/intake_tools.go
@@ -1,0 +1,201 @@
+package documents
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// Intake analyzes where new knowledge should land in a managed corpus.
+func (t *Tools) Intake(ctx context.Context, args IntakeArgs) (string, error) {
+	if t == nil || t.store == nil {
+		return "", fmt.Errorf("document index not configured")
+	}
+	result, err := t.store.Intake(ctx, args)
+	if err != nil {
+		return "", err
+	}
+	t.rememberIntake(result)
+	return marshalToolResult(result)
+}
+
+// Commit applies a previously returned intake plan through managed
+// document mutation paths.
+func (t *Tools) Commit(ctx context.Context, args CommitArgs) (string, error) {
+	if t == nil || t.store == nil {
+		return "", fmt.Errorf("document index not configured")
+	}
+	args.IntakeID = strings.TrimSpace(args.IntakeID)
+	if args.IntakeID == "" {
+		return "", fmt.Errorf("intake_id is required; call doc_intake first")
+	}
+	result, ok := t.lookupIntake(args.IntakeID)
+	if !ok {
+		return "", fmt.Errorf("unknown intake_id %q; call doc_intake again before doc_commit", args.IntakeID)
+	}
+
+	action := normalizeIntakeAction(args.Action)
+	if args.Action != "" && action == "" {
+		return "", fmt.Errorf("unsupported action %q; expected create_new, update_existing, append_existing, or draft_for_review", args.Action)
+	}
+	if action == "" {
+		action = result.RecommendedAction
+	}
+	if action == "" {
+		action = result.CommitPlan.RecommendedAction
+	}
+	if action == "" {
+		return "", fmt.Errorf("action is required for intake_id %q", args.IntakeID)
+	}
+	if result.Status == IntakeRefused {
+		return "", fmt.Errorf("intake_id %q cannot be committed: %s", args.IntakeID, result.Reason)
+	}
+	if action != IntakeActionDraftForReview && (result.CommitPlan.RequiresConfirmation || action != result.RecommendedAction) && !args.Confirm {
+		return "", fmt.Errorf("intake_id %q requires confirm=true before %s; recommended_action=%s reason=%s",
+			args.IntakeID, action, result.RecommendedAction, result.CommitPlan.ConfirmationReason)
+	}
+
+	body := strings.TrimSpace(args.Body)
+	status := "committed"
+	var (
+		ref string
+		out any
+		err error
+	)
+	switch action {
+	case IntakeActionCreateNew:
+		ref = result.ProposedRef
+		if ref == "" {
+			return "", fmt.Errorf("intake_id %q has no proposed_ref for create_new", args.IntakeID)
+		}
+		if body == "" {
+			return "", fmt.Errorf("body is required for create_new")
+		}
+		root, relPath, parseErr := parseRef(ref)
+		if parseErr != nil {
+			return "", parseErr
+		}
+		if t.store.refExists(ctx, root, relPath) {
+			return "", fmt.Errorf("proposed_ref %q already exists; rerun doc_intake or choose update_existing", ref)
+		}
+		out, err = t.store.Write(ctx, WriteArgs{
+			Ref:         ref,
+			Title:       result.NormalizedTitle,
+			Description: firstValue(result.NormalizedFrontmatter, "description"),
+			Tags:        result.NormalizedTags,
+			Frontmatter: result.NormalizedFrontmatter,
+			Body:        &body,
+		})
+	case IntakeActionUpdateExisting:
+		ref = result.TargetRef
+		if ref == "" {
+			return "", fmt.Errorf("intake_id %q has no target_ref for update_existing", args.IntakeID)
+		}
+		if body == "" {
+			return "", fmt.Errorf("body is required for update_existing")
+		}
+		mode := "append_body"
+		section := strings.TrimSpace(args.Section)
+		heading := strings.TrimSpace(args.Heading)
+		if section != "" || heading != "" {
+			mode = "upsert_section"
+			if section == "" {
+				section = heading
+			}
+		}
+		out, err = t.store.Edit(ctx, EditArgs{
+			Ref:     ref,
+			Mode:    mode,
+			Content: body,
+			Section: section,
+			Heading: heading,
+		})
+	case IntakeActionAppendExisting:
+		ref = result.TargetRef
+		if ref == "" {
+			return "", fmt.Errorf("intake_id %q has no target_ref for append_existing", args.IntakeID)
+		}
+		if body == "" {
+			return "", fmt.Errorf("body is required for append_existing")
+		}
+		out, err = t.store.JournalUpdate(ctx, JournalUpdateArgs{
+			Ref:    ref,
+			Entry:  body,
+			Window: args.Window,
+		})
+	case IntakeActionDraftForReview:
+		status = "draft_for_review"
+		ref = result.ProposedRef
+		out = map[string]any{
+			"proposed_ref":      result.ProposedRef,
+			"target_ref":        result.TargetRef,
+			"normalized_title":  result.NormalizedTitle,
+			"normalized_tags":   result.NormalizedTags,
+			"related_documents": result.RelatedDocuments,
+			"review_suggestion": "No document was written. Ask the user which destination/action to use, then rerun doc_intake if needed.",
+		}
+	default:
+		return "", fmt.Errorf("unsupported action %q; expected create_new, update_existing, append_existing, or draft_for_review", action)
+	}
+	if err != nil {
+		return "", err
+	}
+	if action != IntakeActionDraftForReview {
+		t.forgetIntake(args.IntakeID)
+	}
+	return marshalToolResult(CommitResult{
+		IntakeID: args.IntakeID,
+		Action:   action,
+		Ref:      ref,
+		Status:   status,
+		Result:   out,
+	})
+}
+
+func (t *Tools) rememberIntake(result *IntakeResult) {
+	if t == nil || result == nil {
+		return
+	}
+	id := newIntakeID()
+	result.IntakeID = id
+	result.CommitPlan.IntakeID = id
+	t.intakeMu.Lock()
+	defer t.intakeMu.Unlock()
+	if t.intakes == nil {
+		t.intakes = make(map[string]IntakeResult)
+	}
+	t.intakes[id] = *result
+}
+
+func (t *Tools) lookupIntake(id string) (IntakeResult, bool) {
+	t.intakeMu.Lock()
+	defer t.intakeMu.Unlock()
+	result, ok := t.intakes[id]
+	return result, ok
+}
+
+func (t *Tools) forgetIntake(id string) {
+	t.intakeMu.Lock()
+	defer t.intakeMu.Unlock()
+	delete(t.intakes, id)
+}
+
+func newIntakeID() string {
+	var b [8]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return fmt.Sprintf("intake_%d", time.Now().UnixNano())
+	}
+	return "intake_" + hex.EncodeToString(b[:])
+}
+
+func normalizeIntakeAction(action IntakeAction) IntakeAction {
+	switch action {
+	case IntakeActionCreateNew, IntakeActionUpdateExisting, IntakeActionAppendExisting, IntakeActionDraftForReview:
+		return action
+	default:
+		return ""
+	}
+}

--- a/internal/state/documents/intake_types.go
+++ b/internal/state/documents/intake_types.go
@@ -1,0 +1,123 @@
+package documents
+
+const (
+	intakeSimilarLimit      = 5
+	intakeCandidateScanCap  = 500
+	intakeHighOverlapScore  = 0.82
+	intakeMaybeOverlapScore = 0.55
+)
+
+// IntakeStatus describes whether an intake can be committed directly or
+// needs a second explicit decision.
+type IntakeStatus string
+
+const (
+	// IntakeReady means the proposed commit can proceed without extra
+	// confirmation.
+	IntakeReady IntakeStatus = "ready"
+	// IntakeConfirmCreate means a new document is possible, but similar
+	// documents make an update the safer default.
+	IntakeConfirmCreate IntakeStatus = "confirm_create"
+	// IntakeConfirmUpdate means the intake is likely an update or append
+	// to an existing document and should be confirmed before committing.
+	IntakeConfirmUpdate IntakeStatus = "confirm_update"
+	// IntakeDraftForReview means root policy or corpus ambiguity suggests
+	// leaving the content as a draft instead of committing it.
+	IntakeDraftForReview IntakeStatus = "draft_for_review"
+	// IntakeRefused means the target root cannot accept managed commits.
+	IntakeRefused IntakeStatus = "refused"
+)
+
+// IntakeAction is the document mutation shape recommended by intake.
+type IntakeAction string
+
+const (
+	// IntakeActionCreateNew creates a new managed document at proposed_ref.
+	IntakeActionCreateNew IntakeAction = "create_new"
+	// IntakeActionUpdateExisting updates an existing related document.
+	IntakeActionUpdateExisting IntakeAction = "update_existing"
+	// IntakeActionAppendExisting appends a journal-style note to an
+	// existing related document.
+	IntakeActionAppendExisting IntakeAction = "append_existing"
+	// IntakeActionDraftForReview declines mutation and returns a draft
+	// plan for human or later review.
+	IntakeActionDraftForReview IntakeAction = "draft_for_review"
+)
+
+// IntakeArgs describes a proposed managed-document addition before it is
+// assigned to a final corpus destination.
+type IntakeArgs struct {
+	Root          string   `json:"root,omitempty"`
+	Intent        string   `json:"intent,omitempty"`
+	Summary       string   `json:"summary,omitempty"`
+	BodySnippet   string   `json:"body_snippet,omitempty"`
+	ContentDigest string   `json:"content_digest,omitempty"`
+	DesiredTitle  string   `json:"desired_title,omitempty"`
+	DesiredRef    string   `json:"desired_ref,omitempty"`
+	Tags          []string `json:"tags,omitempty"`
+	PathPrefix    string   `json:"path_prefix,omitempty"`
+}
+
+// IntakeRelatedDocument describes a corpus document that overlaps with
+// the proposed intake.
+type IntakeRelatedDocument struct {
+	Ref       string   `json:"ref"`
+	Title     string   `json:"title"`
+	Path      string   `json:"path"`
+	Tags      []string `json:"tags,omitempty"`
+	Score     float64  `json:"score"`
+	Rationale string   `json:"rationale,omitempty"`
+}
+
+// IntakeCommitPlan is the exact structured handoff expected by
+// doc_commit.
+type IntakeCommitPlan struct {
+	IntakeID              string              `json:"intake_id,omitempty"`
+	RecommendedAction     IntakeAction        `json:"recommended_action"`
+	ProposedRef           string              `json:"proposed_ref,omitempty"`
+	TargetRef             string              `json:"target_ref,omitempty"`
+	NormalizedTitle       string              `json:"normalized_title,omitempty"`
+	NormalizedTags        []string            `json:"normalized_tags,omitempty"`
+	NormalizedFrontmatter map[string][]string `json:"normalized_frontmatter,omitempty"`
+	RequiresConfirmation  bool                `json:"requires_confirmation,omitempty"`
+	ConfirmationReason    string              `json:"confirmation_reason,omitempty"`
+}
+
+// IntakeResult is the model-facing corpus-aware placement analysis.
+type IntakeResult struct {
+	IntakeID              string                  `json:"intake_id,omitempty"`
+	Status                IntakeStatus            `json:"status"`
+	Reason                string                  `json:"reason,omitempty"`
+	Root                  string                  `json:"root"`
+	RootPolicy            RootPolicySummary       `json:"root_policy"`
+	RecommendedAction     IntakeAction            `json:"recommended_action"`
+	ProposedRef           string                  `json:"proposed_ref,omitempty"`
+	TargetRef             string                  `json:"target_ref,omitempty"`
+	NormalizedTitle       string                  `json:"normalized_title,omitempty"`
+	NormalizedTags        []string                `json:"normalized_tags,omitempty"`
+	NormalizedFrontmatter map[string][]string     `json:"normalized_frontmatter,omitempty"`
+	ObservedTags          []ValueCount            `json:"observed_tags,omitempty"`
+	RelatedDocuments      []IntakeRelatedDocument `json:"related_documents,omitempty"`
+	Rationale             []string                `json:"rationale,omitempty"`
+	CommitPlan            IntakeCommitPlan        `json:"commit_plan"`
+}
+
+// CommitArgs commits an approved document intake plan.
+type CommitArgs struct {
+	IntakeID string       `json:"intake_id"`
+	Action   IntakeAction `json:"action,omitempty"`
+	Body     string       `json:"body,omitempty"`
+	Section  string       `json:"section,omitempty"`
+	Heading  string       `json:"heading,omitempty"`
+	Window   string       `json:"window,omitempty"`
+	Confirm  bool         `json:"confirm,omitempty"`
+}
+
+// CommitResult describes the mutation, or draft, created from an intake.
+type CommitResult struct {
+	IntakeID string       `json:"intake_id"`
+	Action   IntakeAction `json:"action"`
+	Ref      string       `json:"ref,omitempty"`
+	Status   string       `json:"status"`
+	Result   any          `json:"result,omitempty"`
+}

--- a/internal/state/documents/tools.go
+++ b/internal/state/documents/tools.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sync"
 	"time"
 	"unicode/utf8"
 
@@ -21,12 +22,14 @@ const (
 
 // Tools exposes model-facing document navigation tools.
 type Tools struct {
-	store *Store
+	store    *Store
+	intakeMu sync.Mutex
+	intakes  map[string]IntakeResult
 }
 
 // NewTools creates a document tool surface.
 func NewTools(store *Store) *Tools {
-	return &Tools{store: store}
+	return &Tools{store: store, intakes: make(map[string]IntakeResult)}
 }
 
 // BrowseArgs requests one rooted browse step through an indexed corpus.

--- a/internal/state/documents/tools.go
+++ b/internal/state/documents/tools.go
@@ -18,18 +18,25 @@ const (
 	maxDocLinksLimit           = 100
 	defaultBacklinkTargetLimit = 10
 	maxBacklinkTargetLimit     = 50
+	maxIntakeEntries           = 128
+	intakeEntryTTL             = 6 * time.Hour
 )
 
 // Tools exposes model-facing document navigation tools.
 type Tools struct {
 	store    *Store
 	intakeMu sync.Mutex
-	intakes  map[string]IntakeResult
+	intakes  map[string]intakeEntry
 }
 
 // NewTools creates a document tool surface.
 func NewTools(store *Store) *Tools {
-	return &Tools{store: store, intakes: make(map[string]IntakeResult)}
+	return &Tools{store: store, intakes: make(map[string]intakeEntry)}
+}
+
+type intakeEntry struct {
+	result    IntakeResult
+	createdAt time.Time
 }
 
 // BrowseArgs requests one rooted browse step through an indexed corpus.

--- a/internal/tools/document_intake_tools.go
+++ b/internal/tools/document_intake_tools.go
@@ -1,0 +1,142 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/nugget/thane-ai-agent/internal/state/documents"
+)
+
+func registerDocumentIntakeTools(r *Registry, dt *documents.Tools) {
+	r.Register(&Tool{
+		Name:                 "doc_intake",
+		Description:          "Analyze where proposed new knowledge belongs in a managed markdown corpus before writing it. Use this before creating new knowledge documents: it searches related documents, normalizes title/tags/path, checks root policy, and returns an intake_id plus a commit_plan for doc_commit.",
+		ContentResolveExempt: []string{"root", "desired_title", "desired_ref", "tags", "path_prefix"},
+		Parameters: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"root": map[string]any{
+					"type":        "string",
+					"description": "Target managed root without trailing colon, such as `kb` or `scratchpad`. Required unless only one document root exists.",
+				},
+				"intent": map[string]any{
+					"type":        "string",
+					"description": "What the knowledge is for and whether you expect to create, update, append, or journal it.",
+				},
+				"summary": map[string]any{
+					"type":        "string",
+					"description": "Short semantic summary of the proposed knowledge. Required when body_snippet and content_digest are absent.",
+				},
+				"body_snippet": map[string]any{
+					"type":        "string",
+					"description": "Representative markdown snippet or full draft content for similarity and title/path inference.",
+				},
+				"content_digest": map[string]any{
+					"type":        "string",
+					"description": "Optional compact digest when the full body is too large for intake.",
+				},
+				"desired_title": map[string]any{
+					"type":        "string",
+					"description": "Optional title hint. The tool may normalize it but will not invent a path solely from the model's hint.",
+				},
+				"desired_ref": map[string]any{
+					"type":        "string",
+					"description": "Optional explicit document ref such as `kb:network/unifi/vlans.md`. Use only when the destination is already intentional.",
+				},
+				"tags": map[string]any{
+					"type":        "array",
+					"description": "Optional desired tags. Intake normalizes them against observed corpus vocabulary.",
+					"items":       map[string]any{"type": "string"},
+				},
+				"path_prefix": map[string]any{
+					"type":        "string",
+					"description": "Optional directory hint inside the root, such as `network/unifi`.",
+				},
+			},
+		},
+		Handler: func(ctx context.Context, args map[string]any) (string, error) {
+			root, _ := args["root"].(string)
+			intent, _ := args["intent"].(string)
+			summary, _ := args["summary"].(string)
+			bodySnippet, _ := args["body_snippet"].(string)
+			contentDigest, _ := args["content_digest"].(string)
+			desiredTitle, _ := args["desired_title"].(string)
+			desiredRef, _ := args["desired_ref"].(string)
+			pathPrefix, _ := args["path_prefix"].(string)
+			return dt.Intake(ctx, documents.IntakeArgs{
+				Root:          root,
+				Intent:        intent,
+				Summary:       summary,
+				BodySnippet:   bodySnippet,
+				ContentDigest: contentDigest,
+				DesiredTitle:  desiredTitle,
+				DesiredRef:    desiredRef,
+				Tags:          documentStringSliceArg(args["tags"]),
+				PathPrefix:    pathPrefix,
+			})
+		},
+	})
+
+	r.Register(&Tool{
+		Name:                 "doc_commit",
+		Description:          "Commit a prior doc_intake result through managed document mutations. Pass the intake_id from doc_intake, choose the approved action, and set confirm=true when doc_intake returned a caution or when overriding its recommendation.",
+		ContentResolveExempt: []string{"intake_id", "action", "section", "heading", "window", "confirm"},
+		Parameters: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"intake_id": map[string]any{
+					"type":        "string",
+					"description": "The intake_id returned by doc_intake.",
+				},
+				"action": map[string]any{
+					"type":        "string",
+					"enum":        []string{"create_new", "update_existing", "append_existing", "draft_for_review"},
+					"description": "Approved action. Omit only when accepting a ready doc_intake recommendation.",
+				},
+				"body": map[string]any{
+					"type":        "string",
+					"description": "Full markdown body, section content, or journal entry to commit. Required for create_new, update_existing, and append_existing.",
+				},
+				"section": map[string]any{
+					"type":        "string",
+					"description": "For update_existing, upsert this section instead of appending to the body.",
+				},
+				"heading": map[string]any{
+					"type":        "string",
+					"description": "Optional heading for an upserted update_existing section.",
+				},
+				"window": map[string]any{
+					"type":        "string",
+					"enum":        []string{"day", "week", "month"},
+					"description": "For append_existing, journal window grouping. Default: day.",
+				},
+				"confirm": map[string]any{
+					"type":        "boolean",
+					"description": "Set true only after reconsidering a caution from doc_intake or intentionally overriding its recommendation.",
+				},
+			},
+			"required": []string{"intake_id"},
+		},
+		Handler: func(ctx context.Context, args map[string]any) (string, error) {
+			intakeID, _ := args["intake_id"].(string)
+			if intakeID == "" {
+				return "", fmt.Errorf("intake_id is required")
+			}
+			action, _ := args["action"].(string)
+			body, _ := args["body"].(string)
+			section, _ := args["section"].(string)
+			heading, _ := args["heading"].(string)
+			window, _ := args["window"].(string)
+			confirm, _ := args["confirm"].(bool)
+			return dt.Commit(ctx, documents.CommitArgs{
+				IntakeID: intakeID,
+				Action:   documents.IntakeAction(action),
+				Body:     body,
+				Section:  section,
+				Heading:  heading,
+				Window:   window,
+				Confirm:  confirm,
+			})
+		},
+	})
+}

--- a/internal/tools/document_tools.go
+++ b/internal/tools/document_tools.go
@@ -302,5 +302,6 @@ func RegisterDocumentTools(r *Registry, dt *documents.Tools) {
 			return dt.Values(ctx, documents.ValuesArgs{Root: root, Key: key, Limit: limit})
 		},
 	})
+	registerDocumentIntakeTools(r, dt)
 	registerDocumentMutationTools(r, dt)
 }

--- a/internal/tools/document_tools_test.go
+++ b/internal/tools/document_tools_test.go
@@ -289,6 +289,52 @@ func TestDocumentLinksHandlerSupportsLimitsAndTruncation(t *testing.T) {
 	}
 }
 
+func TestDocumentIntakeAndCommitHandlersCreateManagedDocument(t *testing.T) {
+	t.Parallel()
+
+	reg, store := newTestDocumentRegistry(t)
+	intakeTool := reg.Get("doc_intake")
+	if intakeTool == nil {
+		t.Fatal("doc_intake not registered")
+	}
+	commitTool := reg.Get("doc_commit")
+	if commitTool == nil {
+		t.Fatal("doc_commit not registered")
+	}
+
+	intakeOut, err := intakeTool.Handler(context.Background(), map[string]any{
+		"root":          "kb",
+		"intent":        "create a durable operating note",
+		"summary":       "Garage door opener reset notes.",
+		"desired_title": "Garage Door Reset",
+		"tags":          []any{"home"},
+	})
+	if err != nil {
+		t.Fatalf("doc_intake: %v", err)
+	}
+	var intake documents.IntakeResult
+	if err := json.Unmarshal([]byte(intakeOut), &intake); err != nil {
+		t.Fatalf("unmarshal doc_intake: %v", err)
+	}
+	if intake.IntakeID == "" || intake.ProposedRef == "" {
+		t.Fatalf("intake = %#v, want id and proposed ref", intake)
+	}
+
+	if _, err := commitTool.Handler(context.Background(), map[string]any{
+		"intake_id": intake.IntakeID,
+		"body":      "# Garage Door Reset\n\nHold the wall button until the opener resets.",
+	}); err != nil {
+		t.Fatalf("doc_commit: %v", err)
+	}
+	record, err := store.Read(context.Background(), intake.ProposedRef)
+	if err != nil {
+		t.Fatalf("Read committed intake document: %v", err)
+	}
+	if record.Title != "Garage Door Reset" {
+		t.Fatalf("record title = %q, want Garage Door Reset", record.Title)
+	}
+}
+
 func newTestDocumentRegistry(t *testing.T) (*Registry, *documents.Store) {
 	t.Helper()
 


### PR DESCRIPTION
## Summary

Adds a corpus-aware document intake flow for managed document roots. `doc_intake` now gives the model a deliberate first step before it creates durable knowledge: choose a root, summarize the intent/body, inspect nearby documents and observed tag vocabulary, then receive a normalized title, tags, proposed ref, related-document scores, and a commit plan.

`doc_commit` takes the resulting `intake_id` and performs the approved mutation through the existing managed document write/edit/journal paths. It requires explicit confirmation when intake finds meaningful overlap or when the caller overrides the recommendation, so the happy path nudges the agent toward updating existing corpus structure instead of spraying near-duplicate files across the root.

This keeps the raw mutation tools available for exact-path work, but makes intake the normal model-facing doorway for new knowledge. The docs now describe that flow alongside document-root policy, and the tool reference lists the new authoring pair.

Closes #653

## Test Plan

- [x] `just ci` passes locally
- [x] New/changed behavior has test coverage
- [x] Manual verification: reviewed intake statuses for create, high-overlap confirmation, read-only refusal, unknown commit action rejection, and registry handler wiring

## Checklist

- [x] Commits are signed
- [x] Commit messages use conventional format (`feat:`, `fix:`, etc.)
- [x] Related issue referenced (`Refs #NNN` or `Closes #NNN`)
- [x] Impacted documentation updated (`docs/`, `AGENTS.md`, config examples, CLI help)
- [x] No new third-party dependencies without discussion