### PR TITLE
feat: bootstrap missing or empty doc roots with signed birth commit

### DIFF
--- a/internal/app/document_roots.go
+++ b/internal/app/document_roots.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/nugget/thane-ai-agent/internal/platform/config"
 	"github.com/nugget/thane-ai-agent/internal/platform/paths"
@@ -105,7 +106,7 @@ func buildDocumentRoots(resolver *paths.Resolver) map[string]string {
 }
 
 func (a *App) buildDocumentStoreOptions(documentRoots map[string]string, resolver *paths.Resolver) (documents.StoreOptions, error) {
-	if len(documentRoots) == 0 || a == nil || a.cfg == nil {
+	if a == nil || a.cfg == nil {
 		return documents.StoreOptions{}, nil
 	}
 	opts := documents.StoreOptions{
@@ -113,6 +114,12 @@ func (a *App) buildDocumentStoreOptions(documentRoots map[string]string, resolve
 	}
 	if len(a.cfg.DocRoots) == 0 {
 		return opts, nil
+	}
+	if documentRoots == nil {
+		// The loop below mutates this map when bootstrapping a
+		// missing directory; ensure it is non-nil so we don't
+		// panic on assignment.
+		documentRoots = make(map[string]string)
 	}
 	logger := a.logger
 	if logger == nil {
@@ -123,15 +130,49 @@ func (a *App) buildDocumentStoreOptions(documentRoots map[string]string, resolve
 		if root == "" {
 			continue
 		}
+		policy := documentRootPolicyFromConfig(rootCfg)
+
 		rootPath, ok := documentRoots[root]
 		if !ok {
-			return documents.StoreOptions{}, fmt.Errorf("doc_roots.%s references a document root that is not configured in paths or does not exist on disk", root)
+			// A git-managed signing root is allowed to bootstrap
+			// from a missing directory — we will mkdir, git init,
+			// and birth-commit below. Non-bootstrap configs still
+			// require the directory to already exist.
+			if !policy.Git.Enabled || !policy.Git.SignCommits {
+				return documents.StoreOptions{}, fmt.Errorf("doc_roots.%s references a document root that is not configured in paths or does not exist on disk", root)
+			}
+			created, err := bootstrapMissingRootDirectory(root, resolver, logger)
+			if err != nil {
+				return documents.StoreOptions{}, err
+			}
+			documentRoots[root] = created
+			rootPath = created
 		}
-		policy := documentRootPolicyFromConfig(rootCfg)
+
 		opts.RootPolicies[root] = policy
+
+		// Construct the writer first when this root signs commits.
+		// provenance.NewWithOptions runs ensureRepo (mkdir + git
+		// init + .allowed_signers); BootstrapBirthCommit then makes
+		// HEAD exist if the repo was empty. Doing this before the
+		// verifier means the verifier always sees a fully prepared
+		// repo and never silently no-ops because the repo wasn't
+		// ready yet.
+		var writer *documentRootProvenanceWriter
+		if policy.Git.Enabled && policy.Git.SignCommits {
+			w, err := a.newDocumentRootProvenanceWriter(root, rootPath, rootCfg.Git, resolver)
+			if err != nil {
+				return documents.StoreOptions{}, err
+			}
+			writer = w
+		}
+
 		if policy.Git.Enabled && policy.Git.VerifySignatures != documents.VerificationNone {
 			verifier, err := a.newDocumentRootProvenanceVerifier(root, rootPath, rootCfg.Git, resolver)
 			if err != nil {
+				if policy.Git.VerifySignatures == documents.VerificationRequired {
+					return documents.StoreOptions{}, fmt.Errorf("doc_roots.%s verify_signatures=required but verifier unavailable: %w", root, err)
+				}
 				logger.Warn("document root signature verifier unavailable",
 					"root", root,
 					"mode", policy.Git.VerifySignatures,
@@ -144,19 +185,40 @@ func (a *App) buildDocumentStoreOptions(documentRoots map[string]string, resolve
 				opts.RootVerifiers[root] = verifier
 			}
 		}
-		if !policy.Git.Enabled || !policy.Git.SignCommits {
-			continue
+
+		if writer != nil {
+			if opts.RootWriters == nil {
+				opts.RootWriters = make(map[string]documents.RootWriter)
+			}
+			opts.RootWriters[root] = writer
 		}
-		writer, err := a.newDocumentRootProvenanceWriter(root, rootPath, rootCfg.Git, resolver)
-		if err != nil {
-			return documents.StoreOptions{}, err
-		}
-		if opts.RootWriters == nil {
-			opts.RootWriters = make(map[string]documents.RootWriter)
-		}
-		opts.RootWriters[root] = writer
 	}
 	return opts, nil
+}
+
+// bootstrapMissingRootDirectory creates the directory for a git-managed
+// document root that was declared in doc_roots: but has no entry in
+// paths or does not exist on disk. Returns the absolute path. Only
+// callers that are about to construct a signing writer should use this
+// — for non-bootstrap roots the existing "does not exist on disk" error
+// is preserved.
+func bootstrapMissingRootDirectory(root string, resolver *paths.Resolver, logger *slog.Logger) (string, error) {
+	if resolver == nil {
+		return "", fmt.Errorf("doc_roots.%s has no path configured (paths: missing entry for %q)", root, root)
+	}
+	resolved, err := resolver.Resolve(root + ":")
+	if err != nil {
+		return "", fmt.Errorf("doc_roots.%s: %w", root, err)
+	}
+	if err := os.MkdirAll(resolved, 0o755); err != nil {
+		return "", fmt.Errorf("doc_roots.%s create directory: %w", root, err)
+	}
+	absPath, err := filepath.Abs(resolved)
+	if err != nil {
+		return "", fmt.Errorf("doc_roots.%s resolve absolute path: %w", root, err)
+	}
+	logger.Info("bootstrapping new document root", "root", root, "path", absPath)
+	return absPath, nil
 }
 
 func documentRootPolicyFromConfig(rootCfg config.DocumentRootConfig) documents.RootPolicy {
@@ -228,6 +290,18 @@ func (a *App) newDocumentRootProvenanceWriter(root, rootPath string, gitCfg conf
 	if err != nil {
 		return nil, fmt.Errorf("initialize git provenance for document root %s: %w", root, err)
 	}
+
+	// Make sure HEAD exists before any verifier construction. No-op
+	// when the repo already has commits; for a fresh repo this
+	// commits a templated .gitignore plus the repo-local
+	// .allowed_signers (when present) so verification has signed
+	// history to verify against.
+	bootstrapCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	if err := store.BootstrapBirthCommit(bootstrapCtx); err != nil {
+		return nil, fmt.Errorf("doc_roots.%s bootstrap birth commit: %w", root, err)
+	}
+
 	logger.Info("document root provenance enabled",
 		"root", root,
 		"repo", store.Path(),

--- a/internal/app/document_roots_test.go
+++ b/internal/app/document_roots_test.go
@@ -1,15 +1,39 @@
 package app
 
 import (
+	"context"
+	"log/slog"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/nugget/thane-ai-agent/internal/platform/config"
+	"github.com/nugget/thane-ai-agent/internal/platform/identity"
 	"github.com/nugget/thane-ai-agent/internal/platform/paths"
 	"github.com/nugget/thane-ai-agent/internal/state/documents"
 )
+
+// writeTestSigningKey generates a fresh ed25519 SSH signing key,
+// writes it to a temp path, and returns the path. The matching public
+// key is also written for tests that need .allowed_signers.
+func writeTestSigningKey(t *testing.T) (privPath, pub string) {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	pair, err := identity.GenerateSigningKeyPair("doc-roots-test")
+	if err != nil {
+		t.Fatalf("GenerateSigningKeyPair: %v", err)
+	}
+	dir := t.TempDir()
+	privPath = filepath.Join(dir, "id_ed25519")
+	if err := os.WriteFile(privPath, pair.PrivatePEM, 0o600); err != nil {
+		t.Fatalf("write signing key: %v", err)
+	}
+	return privPath, strings.TrimSpace(pair.Public)
+}
 
 func TestBuildDocumentRootsOnlyIncludesExistingDirectories(t *testing.T) {
 	t.Parallel()
@@ -39,6 +63,11 @@ func TestBuildDocumentRootsOnlyIncludesExistingDirectories(t *testing.T) {
 func TestBuildDocumentStoreOptionsMapsConfigPolicy(t *testing.T) {
 	t.Parallel()
 
+	// Use warn rather than required so a bogus repo path (which is
+	// what the original config-policy mapping test uses to keep the
+	// test hermetic) doesn't trigger the new "required-but-
+	// unavailable verifier is fatal" guard. This test cares about
+	// policy mapping, not verifier wiring.
 	indexing := false
 	app := &App{cfg: &config.Config{
 		DocRoots: map[string]config.DocumentRootConfig{
@@ -47,7 +76,7 @@ func TestBuildDocumentStoreOptionsMapsConfigPolicy(t *testing.T) {
 				Authoring: "read_only",
 				Git: config.DocumentRootGitConfig{
 					Enabled:          true,
-					VerifySignatures: "required",
+					VerifySignatures: "warn",
 					RepoPath:         "~/repo",
 					AllowedSigners:   "~/allowed_signers",
 				},
@@ -62,8 +91,8 @@ func TestBuildDocumentStoreOptionsMapsConfigPolicy(t *testing.T) {
 	if policy.Indexing || policy.Authoring != documents.AuthoringReadOnly {
 		t.Fatalf("policy = %#v, want non-indexed read_only", policy)
 	}
-	if !policy.Git.Enabled || policy.Git.VerifySignatures != documents.VerificationRequired {
-		t.Fatalf("policy.Git = %#v, want enabled required verification", policy.Git)
+	if !policy.Git.Enabled || policy.Git.VerifySignatures != documents.VerificationWarn {
+		t.Fatalf("policy.Git = %#v, want enabled warn verification", policy.Git)
 	}
 	if len(opts.RootWriters) != 0 {
 		t.Fatalf("RootWriters = %#v, want none without sign_commits", opts.RootWriters)
@@ -84,6 +113,167 @@ func TestBuildDocumentStoreOptionsRejectsUnknownPolicyRoot(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "doc_roots.ghost references a document root") {
 		t.Fatalf("error = %v, want unknown root message", err)
+	}
+}
+
+// TestBuildDocumentStoreOptionsBootstrapsMissingDirectory covers issue
+// #789: a doc_roots entry that signs commits should bootstrap a
+// missing directory (mkdir + git init + signed birth commit) so
+// verification has a baseline. Without this, the operator would have
+// to mkdir+git init+commit by hand before pointing config at it.
+func TestBuildDocumentStoreOptionsBootstrapsMissingDirectory(t *testing.T) {
+	rootDir := t.TempDir()
+	// Note: targetPath does NOT exist before the bootstrap call —
+	// we want the doc-root layer to create it.
+	targetPath := filepath.Join(rootDir, "kb")
+
+	signingKey, _ := writeTestSigningKey(t)
+
+	resolver := paths.New(map[string]string{"kb": targetPath})
+	app := &App{
+		logger: slog.Default(),
+		cfg: &config.Config{
+			DocRoots: map[string]config.DocumentRootConfig{
+				"kb": {
+					Authoring: "managed",
+					Git: config.DocumentRootGitConfig{
+						Enabled:          true,
+						SignCommits:      true,
+						VerifySignatures: "required",
+						SigningKey:       signingKey,
+					},
+				},
+			},
+		},
+	}
+
+	opts, err := app.buildDocumentStoreOptions(buildDocumentRoots(resolver), resolver)
+	if err != nil {
+		t.Fatalf("buildDocumentStoreOptions: %v", err)
+	}
+
+	// Directory should now exist.
+	if info, err := os.Stat(targetPath); err != nil || !info.IsDir() {
+		t.Fatalf("bootstrap should have created %s as a directory: err=%v", targetPath, err)
+	}
+	// Git repo should exist.
+	if _, err := os.Stat(filepath.Join(targetPath, ".git")); err != nil {
+		t.Fatalf("bootstrap should have run git init: %v", err)
+	}
+	// HEAD should exist (birth commit).
+	cmd := exec.CommandContext(context.Background(), "git", "-C", targetPath, "rev-parse", "--verify", "HEAD^{commit}")
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("birth commit not found: %v", err)
+	}
+
+	// Both writer and verifier should be wired.
+	if _, ok := opts.RootWriters["kb"]; !ok {
+		t.Errorf("RootWriters[kb] missing")
+	}
+	if _, ok := opts.RootVerifiers["kb"]; !ok {
+		t.Errorf("RootVerifiers[kb] missing — would mean required verification was silently disabled")
+	}
+}
+
+// TestBuildDocumentStoreOptionsBootstrapsEmptyDirectory covers the
+// case where the directory already exists but is empty. This is the
+// most common "I just made this directory and added it to config"
+// shape. Bootstrap should run identically to the missing-dir case.
+func TestBuildDocumentStoreOptionsBootstrapsEmptyDirectory(t *testing.T) {
+	targetPath := t.TempDir() // exists but empty
+
+	signingKey, _ := writeTestSigningKey(t)
+
+	resolver := paths.New(map[string]string{"kb": targetPath})
+	app := &App{
+		logger: slog.Default(),
+		cfg: &config.Config{
+			DocRoots: map[string]config.DocumentRootConfig{
+				"kb": {
+					Git: config.DocumentRootGitConfig{
+						Enabled:          true,
+						SignCommits:      true,
+						VerifySignatures: "required",
+						SigningKey:       signingKey,
+					},
+				},
+			},
+		},
+	}
+
+	opts, err := app.buildDocumentStoreOptions(buildDocumentRoots(resolver), resolver)
+	if err != nil {
+		t.Fatalf("buildDocumentStoreOptions: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(targetPath, ".git")); err != nil {
+		t.Fatalf("git init did not run on empty directory: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(targetPath, ".gitignore")); err != nil {
+		t.Fatalf("birth commit should have written .gitignore: %v", err)
+	}
+	if opts.RootVerifiers["kb"] == nil {
+		t.Fatal("verifier missing on freshly bootstrapped root")
+	}
+}
+
+// TestBuildDocumentStoreOptionsRequiredVerifierUnavailableIsFatal
+// covers the "no silent disable" guarantee. If verify_signatures is
+// required but the verifier can't be constructed, startup must fail
+// rather than silently downgrade to no-verification.
+func TestBuildDocumentStoreOptionsRequiredVerifierUnavailableIsFatal(t *testing.T) {
+	t.Parallel()
+
+	targetPath := t.TempDir()
+	resolver := paths.New(map[string]string{"kb": targetPath})
+	missingAllowedSigners := filepath.Join(t.TempDir(), "does-not-exist")
+
+	app := &App{
+		logger: slog.Default(),
+		cfg: &config.Config{
+			DocRoots: map[string]config.DocumentRootConfig{
+				"kb": {
+					Git: config.DocumentRootGitConfig{
+						Enabled:          true,
+						SignCommits:      false, // verifier-only path
+						VerifySignatures: "required",
+						AllowedSigners:   missingAllowedSigners,
+					},
+				},
+			},
+		},
+	}
+
+	_, err := app.buildDocumentStoreOptions(buildDocumentRoots(resolver), resolver)
+	if err == nil {
+		t.Fatal("expected fatal error for required-but-unavailable verifier")
+	}
+	if !strings.Contains(err.Error(), "verify_signatures=required but verifier unavailable") {
+		t.Fatalf("error = %v, want required-but-unavailable message", err)
+	}
+}
+
+// TestBuildDocumentStoreOptionsNonBootstrapMissingDirStillErrors
+// preserves the original behavior for non-bootstrap configs: a
+// missing directory without git+sign_commits stays an error, since
+// we have no way to know whether the operator wants it created.
+func TestBuildDocumentStoreOptionsNonBootstrapMissingDirStillErrors(t *testing.T) {
+	t.Parallel()
+
+	resolver := paths.New(map[string]string{"kb": filepath.Join(t.TempDir(), "missing")})
+	app := &App{
+		logger: slog.Default(),
+		cfg: &config.Config{
+			DocRoots: map[string]config.DocumentRootConfig{
+				"kb": {Authoring: "read_only"},
+			},
+		},
+	}
+	_, err := app.buildDocumentStoreOptions(buildDocumentRoots(resolver), resolver)
+	if err == nil {
+		t.Fatal("expected error for missing dir without bootstrap policy")
+	}
+	if !strings.Contains(err.Error(), "does not exist on disk") {
+		t.Fatalf("error = %v, want does-not-exist message", err)
 	}
 }
 

--- a/internal/platform/provenance/git.go
+++ b/internal/platform/provenance/git.go
@@ -21,6 +21,52 @@ const recentEditsCap = 10
 // receive a caller-provided context (e.g., repository initialization).
 const gitTimeout = 30 * time.Second
 
+// defaultBirthGitignore is written by [Store.BootstrapBirthCommit] when
+// the repository has no .gitignore yet. Kept minimal — broader patterns
+// belong to the operator's own .gitignore.
+const defaultBirthGitignore = `.DS_Store
+*~
+.tmp/
+`
+
+// BootstrapBirthCommit creates an initial signed commit on an empty
+// repository so verification has a baseline to verify against. No-op
+// when HEAD already exists. Stages only the bootstrap files
+// (.gitignore and the repo-local .allowed_signers if present);
+// existing user content stays untracked and must be added explicitly.
+func (s *Store) BootstrapBirthCommit(ctx context.Context) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if err := s.git(ctx, nil, nil, "rev-parse", "--verify", "HEAD^{commit}"); err == nil {
+		return nil
+	}
+
+	gitignorePath := filepath.Join(s.path, ".gitignore")
+	if _, err := os.Stat(gitignorePath); os.IsNotExist(err) {
+		if err := os.WriteFile(gitignorePath, []byte(defaultBirthGitignore), 0o644); err != nil {
+			return fmt.Errorf("write default .gitignore: %w", err)
+		}
+	}
+
+	bootstrapFiles := []string{".gitignore"}
+	if _, err := os.Stat(filepath.Join(s.path, ".allowed_signers")); err == nil {
+		bootstrapFiles = append(bootstrapFiles, ".allowed_signers")
+	}
+
+	committed, err := s.commitFiles(ctx, bootstrapFiles, "bootstrap document root")
+	if err != nil {
+		return fmt.Errorf("birth commit: %w", err)
+	}
+	if committed {
+		s.logger.Info("created document root birth commit",
+			"path", s.path,
+			"files", bootstrapFiles,
+		)
+	}
+	return nil
+}
+
 // ensureRepo initializes the git repository if it doesn't already
 // exist, configures the committer identity, and writes the
 // .allowed_signers file.

--- a/internal/platform/provenance/git_test.go
+++ b/internal/platform/provenance/git_test.go
@@ -178,3 +178,112 @@ func TestVerifierRejectsUntrustedSigner(t *testing.T) {
 		t.Fatalf("VerifyFile result = %+v, want untrusted", result)
 	}
 }
+
+// TestBootstrapBirthCommitCreatesHEAD covers the case where a managed
+// doc root is first wired up: ensureRepo has run (git init,
+// .allowed_signers present), but no commit exists yet. After
+// BootstrapBirthCommit, HEAD should exist and verify cleanly.
+func TestBootstrapBirthCommitCreatesHEAD(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+
+	dir := t.TempDir()
+	s, err := New(dir, testSigner(t), nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	// Sanity: ensureRepo wrote .allowed_signers and ran git init,
+	// but no HEAD yet.
+	if err := s.git(t.Context(), nil, nil, "rev-parse", "--verify", "HEAD^{commit}"); err == nil {
+		t.Fatal("expected fresh repo to have no HEAD yet")
+	}
+
+	if err := s.BootstrapBirthCommit(t.Context()); err != nil {
+		t.Fatalf("BootstrapBirthCommit: %v", err)
+	}
+
+	// HEAD should now exist and verify cleanly.
+	verifier, err := NewVerifier(s.path, nil, Options{})
+	if err != nil {
+		t.Fatalf("NewVerifier: %v", err)
+	}
+	result, err := verifier.VerifyTree(t.Context(), "")
+	if err != nil {
+		t.Fatalf("VerifyTree on bootstrapped repo: %v", err)
+	}
+	if !result.Trusted() {
+		t.Fatalf("VerifyTree result = %+v, want trusted", result)
+	}
+	if _, err := os.Stat(filepath.Join(dir, ".gitignore")); err != nil {
+		t.Errorf("expected .gitignore from birth commit: %v", err)
+	}
+}
+
+// TestBootstrapBirthCommitIsIdempotent verifies the call is a no-op
+// once HEAD exists, so callers can invoke it on every startup.
+func TestBootstrapBirthCommitIsIdempotent(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+
+	s := testStore(t)
+	if err := s.Write(t.Context(), "test.md", "first", "first commit"); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	var beforeBuf bytes.Buffer
+	if err := s.git(t.Context(), nil, &beforeBuf, "rev-parse", "HEAD"); err != nil {
+		t.Fatalf("rev-parse HEAD: %v", err)
+	}
+	beforeHEAD := strings.TrimSpace(beforeBuf.String())
+
+	if err := s.BootstrapBirthCommit(t.Context()); err != nil {
+		t.Fatalf("BootstrapBirthCommit: %v", err)
+	}
+
+	var afterBuf bytes.Buffer
+	if err := s.git(t.Context(), nil, &afterBuf, "rev-parse", "HEAD"); err != nil {
+		t.Fatalf("rev-parse HEAD after: %v", err)
+	}
+	if got := strings.TrimSpace(afterBuf.String()); got != beforeHEAD {
+		t.Fatalf("HEAD changed after bootstrap idempotent call: before=%s after=%s", beforeHEAD, got)
+	}
+}
+
+// TestBootstrapBirthCommitLeavesExistingContentUntracked guards the
+// "no auto-import" rule from issue #789. If the operator drops a
+// directory full of pre-existing files in front of us, bootstrap
+// commits only the bootstrap files; the rest stay untracked so the
+// operator must explicitly bring them under signed history.
+func TestBootstrapBirthCommitLeavesExistingContentUntracked(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "user-content.md"), []byte("operator data"), 0o644); err != nil {
+		t.Fatalf("seed user content: %v", err)
+	}
+
+	s, err := New(dir, testSigner(t), nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := s.BootstrapBirthCommit(t.Context()); err != nil {
+		t.Fatalf("BootstrapBirthCommit: %v", err)
+	}
+
+	var lsBuf bytes.Buffer
+	if err := s.git(t.Context(), nil, &lsBuf, "ls-files"); err != nil {
+		t.Fatalf("ls-files: %v", err)
+	}
+	tracked := strings.TrimSpace(lsBuf.String())
+	if strings.Contains(tracked, "user-content.md") {
+		t.Errorf("user-content.md was auto-tracked; want untracked. tracked=%q", tracked)
+	}
+	if !strings.Contains(tracked, ".gitignore") {
+		t.Errorf(".gitignore should be tracked after bootstrap. tracked=%q", tracked)
+	}
+}


### PR DESCRIPTION
## Summary

Closes #789. A `doc_roots:` entry pointing to a missing or empty directory used to boot in three different broken ways. This makes the bootstrap path symmetric with the core identity bootstrap (#757).

- **Silent skip on missing directory** — `buildDocumentRoots()` skipped the dir, then `buildDocumentStoreOptions` errored with `"does not exist on disk"` for any `doc_roots:` entry referencing it.
- **No birth commit** — the writer's `provenance.NewWithOptions` → `ensureRepo` ran `git init` + wrote `.allowed_signers` but made no commit. HEAD never existed.
- **Verifier silently disabled on first start** — verifier was constructed before the writer; on a fresh empty repo the verifier failed to construct and was logged as a warning. `required` mode effectively became `none` until the next startup.

### Behavior changes

- New `provenance.Store.BootstrapBirthCommit(ctx)` — idempotent. On an empty repo, writes a templated `.gitignore` (if absent) and stages `.gitignore` plus the repo-local `.allowed_signers` (when present). Existing user content stays untracked so we never auto-import unsigned content into signed history (per the issue's out-of-scope clause).
- `buildDocumentStoreOptions` now `mkdir`s missing directories for `git.enabled && sign_commits` roots, then constructs the writer (which triggers `ensureRepo` + `BootstrapBirthCommit`) before constructing the verifier. Non-bootstrap configs still get the original "does not exist on disk" error.
- `verify_signatures: required` with an unavailable verifier is now a **fatal startup error** rather than a silent downgrade to no-verification. `warn` mode keeps the existing warn-and-continue behavior.

### Diff highlights

- [internal/platform/provenance/git.go](internal/platform/provenance/git.go) — new `BootstrapBirthCommit` method and `defaultBirthGitignore` template.
- [internal/app/document_roots.go](internal/app/document_roots.go) — refactored per-root loop: writer-before-verifier construction order, `bootstrapMissingRootDirectory` helper, fatal error on `required + unavailable`.
- [internal/app/document_roots_test.go](internal/app/document_roots_test.go) — new tests for missing-dir bootstrap, empty-dir bootstrap, required-but-unavailable verifier fatal, non-bootstrap missing-dir error preserved. Existing `TestBuildDocumentStoreOptionsMapsConfigPolicy` switched from `required` → `warn` since it was relying on the silent-disable bug to keep its bogus `RepoPath` test hermetic.
- [internal/platform/provenance/git_test.go](internal/platform/provenance/git_test.go) — `BootstrapBirthCommit` tests: creates HEAD on fresh repo, idempotent on populated repo, leaves existing content untracked.

## Test plan

- [x] `just ci` passes locally
- [x] New tests cover the missing-dir, empty-dir, idempotent, no-auto-import, and required-but-unavailable cases
- [ ] Production smoke: add a hardened doc_roots entry pointing to a brand-new empty path; confirm Thane boots cleanly, the directory is created with git history and a signed birth commit, and `verify_signatures: required` works on subsequent reads