### PR TITLE
feat: unify roots: config + deferred Copilot fixes for #791

### DIFF
--- a/examples/config.example.yaml
+++ b/examples/config.example.yaml
@@ -155,99 +155,152 @@ workspace:
   # must remain outside Thane's writable authority, such as a legacy
   # workspace or an external vault mirror.
   read_only_dirs: []
-# Paths maps named prefixes to directory paths for file resolution.
-# Each entry creates a prefix (e.g., "kb" → kb:path resolves to
-# the configured directory). Supports ~ expansion at resolver
-# construction time.
+# Roots is the unified document-root config. Each entry names one
+# managed root and combines its path with optional per-root policy
+# (indexing, authoring, git-backed provenance, signing, signature
+# verification). See docs/understanding/document-roots.md for the
+# operator-facing contract.
 # 
-# These prefixes also define the managed local document roots used by
-# the documents capability. Any configured root that exists on disk is
-# eligible for indexed browse/search/section retrieval via doc_* tools,
-# so users can add their own custom corpora here without code changes.
-# See docs/understanding/document-roots.md for the operator-facing
-# contract; keep that document in sync with changes here.
+# Each entry accepts either a bare-string shorthand (path only,
+# default policy) or a full mapping form. Both forms are valid in
+# the same block:
 # 
-# Typical prefixes are:
-#   - kb:         curated knowledge / indexed documents
-#   - generated:  model-produced durable outputs (reports, dailies)
-#   - scratchpad: low-integrity writable work area
-#   - dossiers:   private dossiers or long-form reference material
+#   roots:
+#     kb: ~/Sync/Vault                  # bare string, defaults
+#     scratchpad:
+#       path: ~/Thane/scratchpad
+#       authoring: managed
+#     secure:
+#       path: ~/secure/notes
+#       git:
+#         enabled: true
+#         sign_commits: true
+#         verify_signatures: required
+#         signing_key: ~/Thane/core/identity/signing_ed25519
 # 
-# The core: prefix is reserved and always derived from
-# {workspace.path}/core; it is not configured here.
-paths:
-  generated: ./generated
-  kb: ./knowledge
-  scratchpad: ./scratchpad
+# Typical names: kb (curated knowledge), generated (model-produced
+# durable outputs), scratchpad (low-integrity work area), dossiers.
+# The core: name is reserved and always derived from
+# {workspace.path}/core; declaring it under roots: lets you set
+# policy for it but the path is ignored.
+roots:
+  generated:
+    # Path is the directory the root resolves to. Supports ~
+    # expansion at resolver construction time. For the reserved
+    # core: name this is ignored; the path is always derived from
+    # workspace.path.
+    path: ./generated
+    # Indexing controls whether markdown files in this root are
+    # scanned into the document index. Omit to keep indexing enabled.
+    indexing: false
+    # Authoring controls whether managed document mutation tools may
+    # write this root. Empty defaults to "managed". Supported values:
+    # "managed", "read_only", "restricted".
+    authoring: ""
+    # Git configures optional git-backed write provenance for this
+    # root. Same fields as the legacy doc_roots[name].git block.
+    git:
+      # Enabled controls whether this root participates in git-backed
+      # provenance. When false, git settings are ignored.
+      enabled: false
+      # SignCommits creates a signed git commit for each managed document
+      # mutation. Requires signing_key.
+      sign_commits: false
+      # VerifySignatures is the verification policy for consumers of this
+      # root: "none", "warn", or "required". Required roots block managed
+      # reads, indexed results, and tagged context injection when content
+      # is not covered by trusted signed git history.
+      verify_signatures: ""
+      # RepoPath optionally points at the git repository to use for this
+      # root. Empty means the root directory itself is the repository.
+      repo_path: ""
+      # SigningKey is the SSH private key used to sign managed commits.
+      # Supports ~ expansion at startup.
+      signing_key: ""
+      # AllowedSigners is the OpenSSH allowed signers file to use when
+      # verifying this root. Empty uses the repository-local
+      # .allowed_signers written from signing_key.
+      allowed_signers: ""
+  kb:
+    # Path is the directory the root resolves to. Supports ~
+    # expansion at resolver construction time. For the reserved
+    # core: name this is ignored; the path is always derived from
+    # workspace.path.
+    path: ./knowledge
+    # Indexing controls whether markdown files in this root are
+    # scanned into the document index. Omit to keep indexing enabled.
+    indexing: true
+    # Authoring controls whether managed document mutation tools may
+    # write this root. Empty defaults to "managed". Supported values:
+    # "managed", "read_only", "restricted".
+    authoring: managed
+    # Git configures optional git-backed write provenance for this
+    # root. Same fields as the legacy doc_roots[name].git block.
+    git:
+      # Enabled controls whether this root participates in git-backed
+      # provenance. When false, git settings are ignored.
+      enabled: true
+      # SignCommits creates a signed git commit for each managed document
+      # mutation. Requires signing_key.
+      sign_commits: true
+      # VerifySignatures is the verification policy for consumers of this
+      # root: "none", "warn", or "required". Required roots block managed
+      # reads, indexed results, and tagged context injection when content
+      # is not covered by trusted signed git history.
+      verify_signatures: warn
+      # RepoPath optionally points at the git repository to use for this
+      # root. Empty means the root directory itself is the repository.
+      repo_path: ""
+      # SigningKey is the SSH private key used to sign managed commits.
+      # Supports ~ expansion at startup.
+      signing_key: ~/.ssh/id_ed25519
+      # AllowedSigners is the OpenSSH allowed signers file to use when
+      # verifying this root. Empty uses the repository-local
+      # .allowed_signers written from signing_key.
+      allowed_signers: ""
+  scratchpad:
+    # Path is the directory the root resolves to. Supports ~
+    # expansion at resolver construction time. For the reserved
+    # core: name this is ignored; the path is always derived from
+    # workspace.path.
+    path: ./scratchpad
+    # Indexing controls whether markdown files in this root are
+    # scanned into the document index. Omit to keep indexing enabled.
+    indexing: false
+    # Authoring controls whether managed document mutation tools may
+    # write this root. Empty defaults to "managed". Supported values:
+    # "managed", "read_only", "restricted".
+    authoring: managed
+    # Git configures optional git-backed write provenance for this
+    # root. Same fields as the legacy doc_roots[name].git block.
+    git:
+      # Enabled controls whether this root participates in git-backed
+      # provenance. When false, git settings are ignored.
+      enabled: false
+      # SignCommits creates a signed git commit for each managed document
+      # mutation. Requires signing_key.
+      sign_commits: false
+      # VerifySignatures is the verification policy for consumers of this
+      # root: "none", "warn", or "required". Required roots block managed
+      # reads, indexed results, and tagged context injection when content
+      # is not covered by trusted signed git history.
+      verify_signatures: ""
+      # RepoPath optionally points at the git repository to use for this
+      # root. Empty means the root directory itself is the repository.
+      repo_path: ""
+      # SigningKey is the SSH private key used to sign managed commits.
+      # Supports ~ expansion at startup.
+      signing_key: ""
+      # AllowedSigners is the OpenSSH allowed signers file to use when
+      # verifying this root. Empty uses the repository-local
+      # .allowed_signers written from signing_key.
+      allowed_signers: ""
 #
-# (optional) DocRoots configures per-root document policy keyed by paths root name.
-# doc_roots:
-#   kb:
-#     Indexing controls whether markdown files in this root are scanned
-#     into the document index. Omit to keep indexing enabled.
-#     indexing: true
-#     Authoring controls whether managed document mutation tools may
-#     write this root. Empty defaults to "managed". Supported values:
-#     "managed", "read_only", and "restricted". Restricted is intended
-#     for high-integrity roots whose writes must come from narrower
-#     future flows.
-#     authoring: managed
-#     Git configures optional git-backed write provenance for this root.
-#     git:
-#       Enabled controls whether this root participates in git-backed
-#       provenance. When false, git settings are ignored.
-#       enabled: true
-#       SignCommits creates a signed git commit for each managed document
-#       mutation. Requires signing_key.
-#       sign_commits: true
-#       VerifySignatures is the verification policy for consumers of this
-#       root: "none", "warn", or "required". Required roots block managed
-#       reads, indexed results, and tagged context injection when content
-#       is not covered by trusted signed git history.
-#       verify_signatures: warn
-#       RepoPath optionally points at the git repository to use for this
-#       root. Empty means the root directory itself is the repository.
-#       repo_path: ""
-#       SigningKey is the SSH private key used to sign managed commits.
-#       Supports ~ expansion at startup.
-#       signing_key: ~/.ssh/id_ed25519
-#       AllowedSigners is the OpenSSH allowed signers file to use when
-#       verifying this root. Empty uses the repository-local
-#       .allowed_signers written from signing_key.
-#       allowed_signers: ""
-#   scratchpad:
-#     Indexing controls whether markdown files in this root are scanned
-#     into the document index. Omit to keep indexing enabled.
-#     indexing: false
-#     Authoring controls whether managed document mutation tools may
-#     write this root. Empty defaults to "managed". Supported values:
-#     "managed", "read_only", and "restricted". Restricted is intended
-#     for high-integrity roots whose writes must come from narrower
-#     future flows.
-#     authoring: managed
-#     Git configures optional git-backed write provenance for this root.
-#     git:
-#       Enabled controls whether this root participates in git-backed
-#       provenance. When false, git settings are ignored.
-#       enabled: false
-#       SignCommits creates a signed git commit for each managed document
-#       mutation. Requires signing_key.
-#       sign_commits: false
-#       VerifySignatures is the verification policy for consumers of this
-#       root: "none", "warn", or "required". Required roots block managed
-#       reads, indexed results, and tagged context injection when content
-#       is not covered by trusted signed git history.
-#       verify_signatures: ""
-#       RepoPath optionally points at the git repository to use for this
-#       root. Empty means the root directory itself is the repository.
-#       repo_path: ""
-#       SigningKey is the SSH private key used to sign managed commits.
-#       Supports ~ expansion at startup.
-#       signing_key: ""
-#       AllowedSigners is the OpenSSH allowed signers file to use when
-#       verifying this root. Empty uses the repository-local
-#       .allowed_signers written from signing_key.
-#       allowed_signers: ""
+# (optional) Paths is the legacy directory-mapping block. Replaced by roots:.
+# paths: {}
+#
+# (optional) DocRoots is the legacy per-root policy overlay. Replaced by
+# doc_roots: {}
 #
 # (optional) ExtraPath lists additional directories to prepend to the process
 # extra_path:

--- a/internal/app/document_roots.go
+++ b/internal/app/document_roots.go
@@ -17,6 +17,12 @@ import (
 	"github.com/nugget/thane-ai-agent/internal/state/documents"
 )
 
+// docRootBootstrapTimeout bounds the per-root birth-commit work
+// (stat/write .gitignore, stage, sign commit). Matches the
+// 30s ceiling provenance uses for its own startup git operations
+// so the budget stays consistent across the boot path.
+const docRootBootstrapTimeout = 30 * time.Second
+
 type documentRootProvenanceWriter struct {
 	store  *provenance.Store
 	prefix string
@@ -296,7 +302,7 @@ func (a *App) newDocumentRootProvenanceWriter(root, rootPath string, gitCfg conf
 	// commits a templated .gitignore plus the repo-local
 	// .allowed_signers (when present) so verification has signed
 	// history to verify against.
-	bootstrapCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	bootstrapCtx, cancel := context.WithTimeout(context.Background(), docRootBootstrapTimeout)
 	defer cancel()
 	if err := store.BootstrapBirthCommit(bootstrapCtx); err != nil {
 		return nil, fmt.Errorf("doc_roots.%s bootstrap birth commit: %w", root, err)

--- a/internal/app/document_roots_test.go
+++ b/internal/app/document_roots_test.go
@@ -1,7 +1,6 @@
 package app
 
 import (
-	"context"
 	"log/slog"
 	"os"
 	"os/exec"
@@ -16,8 +15,9 @@ import (
 )
 
 // writeTestSigningKey generates a fresh ed25519 SSH signing key,
-// writes it to a temp path, and returns the path. The matching public
-// key is also written for tests that need .allowed_signers.
+// writes the private key to a temp path, and returns the path along
+// with the matching public key as a string. Callers that need
+// .allowed_signers should write the returned public key themselves.
 func writeTestSigningKey(t *testing.T) (privPath, pub string) {
 	t.Helper()
 	if _, err := exec.LookPath("git"); err != nil {
@@ -161,7 +161,7 @@ func TestBuildDocumentStoreOptionsBootstrapsMissingDirectory(t *testing.T) {
 		t.Fatalf("bootstrap should have run git init: %v", err)
 	}
 	// HEAD should exist (birth commit).
-	cmd := exec.CommandContext(context.Background(), "git", "-C", targetPath, "rev-parse", "--verify", "HEAD^{commit}")
+	cmd := exec.CommandContext(t.Context(), "git", "-C", targetPath, "rev-parse", "--verify", "HEAD^{commit}")
 	if err := cmd.Run(); err != nil {
 		t.Fatalf("birth commit not found: %v", err)
 	}

--- a/internal/platform/config/config.go
+++ b/internal/platform/config/config.go
@@ -137,37 +137,47 @@ type Config struct {
 	// mission.md, and metacognitive.md.
 	Workspace WorkspaceConfig `yaml:"workspace"`
 
-	// Paths maps named prefixes to directory paths for file resolution.
-	// Each entry creates a prefix (e.g., "kb" → kb:path resolves to
-	// the configured directory). Supports ~ expansion at resolver
-	// construction time.
+	// Roots is the unified document-root config. Each entry names one
+	// managed root and combines its path with optional per-root policy
+	// (indexing, authoring, git-backed provenance, signing, signature
+	// verification). See docs/understanding/document-roots.md for the
+	// operator-facing contract.
 	//
-	// These prefixes also define the managed local document roots used by
-	// the documents capability. Any configured root that exists on disk is
-	// eligible for indexed browse/search/section retrieval via doc_* tools,
-	// so users can add their own custom corpora here without code changes.
-	// See docs/understanding/document-roots.md for the operator-facing
-	// contract; keep that document in sync with changes here.
+	// Each entry accepts either a bare-string shorthand (path only,
+	// default policy) or a full mapping form. Both forms are valid in
+	// the same block:
 	//
-	// Typical prefixes are:
-	//   - kb:         curated knowledge / indexed documents
-	//   - generated:  model-produced durable outputs (reports, dailies)
-	//   - scratchpad: low-integrity writable work area
-	//   - dossiers:   private dossiers or long-form reference material
+	//   roots:
+	//     kb: ~/Sync/Vault                  # bare string, defaults
+	//     scratchpad:
+	//       path: ~/Thane/scratchpad
+	//       authoring: managed
+	//     secure:
+	//       path: ~/secure/notes
+	//       git:
+	//         enabled: true
+	//         sign_commits: true
+	//         verify_signatures: required
+	//         signing_key: ~/Thane/core/identity/signing_ed25519
 	//
-	// The core: prefix is reserved and always derived from
-	// {workspace.path}/core; it is not configured here.
-	Paths map[string]string `yaml:"paths"`
+	// Typical names: kb (curated knowledge), generated (model-produced
+	// durable outputs), scratchpad (low-integrity work area), dossiers.
+	// The core: name is reserved and always derived from
+	// {workspace.path}/core; declaring it under roots: lets you set
+	// policy for it but the path is ignored.
+	Roots map[string]RootEntry `yaml:"roots,omitempty"`
 
-	// DocRoots configures per-root document policy keyed by paths root name.
-	// Keys match roots defined in paths plus the derived core root.
-	// Omitted roots use the default policy: indexed, managed-authorable,
-	// and not git-backed.
-	//
-	// This is a policy overlay, not a replacement for paths:. Use
-	// paths: to name the root and doc_roots: to say whether it is
-	// indexed, model-authorable, git-backed, signed, or verified.
-	DocRoots map[string]DocumentRootConfig `yaml:"doc_roots"`
+	// Paths is the legacy directory-mapping block. Replaced by roots:.
+	// Still parsed for backwards compatibility with a deprecation
+	// warning. Cannot be used in the same config as roots:. New
+	// configs should use roots: instead.
+	Paths map[string]string `yaml:"paths,omitempty"`
+
+	// DocRoots is the legacy per-root policy overlay. Replaced by
+	// roots: (where path and policy live in the same entry). Still
+	// parsed for backwards compatibility with a deprecation warning.
+	// Cannot be used in the same config as roots:.
+	DocRoots map[string]DocumentRootConfig `yaml:"doc_roots,omitempty"`
 
 	// ExtraPath lists additional directories to prepend to the process
 	// PATH at startup, ensuring exec.LookPath finds binaries installed
@@ -740,6 +750,53 @@ type ProvenanceConfig struct {
 // signing key set.
 func (c ProvenanceConfig) Configured() bool {
 	return c.Path != "" && c.SigningKey != ""
+}
+
+// RootEntry combines a managed root's path with its per-root policy
+// in the unified roots: block. Accepts either a bare-string shorthand
+// (the entire entry is the path, all policy fields default) or a
+// mapping with explicit path: and policy fields.
+type RootEntry struct {
+	// Path is the directory the root resolves to. Supports ~
+	// expansion at resolver construction time. For the reserved
+	// core: name this is ignored; the path is always derived from
+	// workspace.path.
+	Path string `yaml:"path"`
+
+	// Indexing controls whether markdown files in this root are
+	// scanned into the document index. Omit to keep indexing enabled.
+	Indexing *bool `yaml:"indexing,omitempty"`
+
+	// Authoring controls whether managed document mutation tools may
+	// write this root. Empty defaults to "managed". Supported values:
+	// "managed", "read_only", "restricted".
+	Authoring string `yaml:"authoring,omitempty"`
+
+	// Git configures optional git-backed write provenance for this
+	// root. Same fields as the legacy doc_roots[name].git block.
+	Git DocumentRootGitConfig `yaml:"git,omitempty"`
+}
+
+// UnmarshalYAML accepts either the bare-string shorthand or the full
+// mapping form for a root entry. Bare strings populate Path with all
+// policy fields defaulted; mappings decode normally.
+func (r *RootEntry) UnmarshalYAML(node *yaml.Node) error {
+	switch node.Kind {
+	case yaml.ScalarNode:
+		r.Path = node.Value
+		return nil
+	case yaml.MappingNode:
+		// Use a type alias to avoid recursing into this method.
+		type rawRootEntry RootEntry
+		var raw rawRootEntry
+		if err := node.Decode(&raw); err != nil {
+			return err
+		}
+		*r = RootEntry(raw)
+		return nil
+	default:
+		return fmt.Errorf("roots entry must be a string path or a mapping, got node kind %d", node.Kind)
+	}
 }
 
 // DocumentRootConfig configures policy for one managed document root.
@@ -1705,8 +1762,11 @@ type StateWindowConfig struct {
 //  1. Read the file.
 //  2. Expand environment variables (e.g., ${HOME}, ${ANTHROPIC_API_KEY}).
 //  3. Unmarshal YAML into a [Config].
-//  4. Apply defaults via [Config.applyDefaults].
-//  5. Validate via [Config.Validate].
+//  4. Normalize via [Config.normalizeRoots] (desugar roots: into
+//     legacy paths/doc_roots; emit deprecation warning for legacy
+//     shape).
+//  5. Apply defaults via [Config.applyDefaults].
+//  6. Validate via [Config.Validate].
 func Load(path string) (*Config, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
@@ -1721,6 +1781,10 @@ func Load(path string) (*Config, error) {
 
 	cfg := &Config{}
 	if err := yaml.Unmarshal([]byte(expanded), cfg); err != nil {
+		return nil, err
+	}
+
+	if err := cfg.normalizeRoots(); err != nil {
 		return nil, err
 	}
 
@@ -1761,6 +1825,73 @@ func rejectRetiredTopLevelKeys(data []byte) error {
 		}
 	}
 	return nil
+}
+
+// normalizeRoots desugars the unified roots: block into the legacy
+// Paths and DocRoots maps so downstream consumers (resolver
+// construction, doc-store options) keep working unchanged. It also
+// rejects configs that declare both shapes simultaneously, and emits
+// a deprecation warning for the legacy shape.
+//
+// Called from [Load] between yaml.Unmarshal and applyDefaults.
+// Programmatic constructions that bypass Load can call this directly
+// after populating Roots.
+func (c *Config) normalizeRoots() error {
+	if len(c.Roots) > 0 {
+		if len(c.Paths) > 0 || len(c.DocRoots) > 0 {
+			return fmt.Errorf("config: cannot declare both roots: and the legacy paths:/doc_roots: blocks; pick one (roots: is preferred)")
+		}
+		if c.Paths == nil {
+			c.Paths = make(map[string]string, len(c.Roots))
+		}
+		if c.DocRoots == nil {
+			c.DocRoots = make(map[string]DocumentRootConfig, len(c.Roots))
+		}
+		for name, entry := range c.Roots {
+			trimmed := strings.TrimSuffix(strings.TrimSpace(name), ":")
+			if trimmed == "" {
+				return fmt.Errorf("config: roots: contains an empty entry name")
+			}
+			// core: is reserved — its path is always derived from
+			// workspace.path. Allow declaring it in roots: solely
+			// to set policy; ignore any path that was provided.
+			if trimmed != "core" && entry.Path != "" {
+				c.Paths[trimmed] = entry.Path
+			}
+			if entryHasPolicy(entry) {
+				c.DocRoots[trimmed] = DocumentRootConfig{
+					Indexing:  entry.Indexing,
+					Authoring: entry.Authoring,
+					Git:       entry.Git,
+				}
+			}
+		}
+		// Clear Roots after desugaring so there is exactly one
+		// canonical representation downstream and no risk of drift.
+		c.Roots = nil
+		return nil
+	}
+
+	if len(c.Paths) > 0 || len(c.DocRoots) > 0 {
+		slog.Default().Warn("config: paths: and doc_roots: are deprecated in favor of the unified roots: block; see docs/understanding/document-roots.md for the new shape")
+	}
+	return nil
+}
+
+// entryHasPolicy reports whether a root entry has any policy fields
+// set beyond its path. Used to decide whether to emit a DocRoots
+// entry during normalization (entries with only a path get default
+// policy and need no DocRoots row).
+func entryHasPolicy(entry RootEntry) bool {
+	if entry.Indexing != nil {
+		return true
+	}
+	if strings.TrimSpace(entry.Authoring) != "" {
+		return true
+	}
+	g := entry.Git
+	return g.Enabled || g.SignCommits || g.VerifySignatures != "" ||
+		g.RepoPath != "" || g.SigningKey != "" || g.AllowedSigners != ""
 }
 
 // applyDefaults fills zero-value fields with sensible defaults. It is

--- a/internal/platform/config/config.go
+++ b/internal/platform/config/config.go
@@ -780,9 +780,19 @@ type RootEntry struct {
 // UnmarshalYAML accepts either the bare-string shorthand or the full
 // mapping form for a root entry. Bare strings populate Path with all
 // policy fields defaulted; mappings decode normally.
+//
+// Scalar shorthand requires a non-empty string. Null (e.g. `kb:` with
+// no value) and non-string scalars (numbers, bools) are rejected so a
+// typo can't silently become a path.
 func (r *RootEntry) UnmarshalYAML(node *yaml.Node) error {
 	switch node.Kind {
 	case yaml.ScalarNode:
+		if node.Tag != "" && node.Tag != "!!str" {
+			return fmt.Errorf("roots entry shorthand must be a string path, got %s", node.Tag)
+		}
+		if strings.TrimSpace(node.Value) == "" {
+			return fmt.Errorf("roots entry shorthand path must not be empty")
+		}
 		r.Path = node.Value
 		return nil
 	case yaml.MappingNode:
@@ -1847,15 +1857,29 @@ func (c *Config) normalizeRoots() error {
 		if c.DocRoots == nil {
 			c.DocRoots = make(map[string]DocumentRootConfig, len(c.Roots))
 		}
+		seen := make(map[string]string, len(c.Roots))
 		for name, entry := range c.Roots {
 			trimmed := strings.TrimSuffix(strings.TrimSpace(name), ":")
 			if trimmed == "" {
 				return fmt.Errorf("config: roots: contains an empty entry name")
 			}
+			if prev, ok := seen[trimmed]; ok {
+				return fmt.Errorf("config: roots: keys %q and %q both canonicalize to %q", prev, name, trimmed)
+			}
+			seen[trimmed] = name
+			pathValue := strings.TrimSpace(entry.Path)
 			// core: is reserved — its path is always derived from
 			// workspace.path. Allow declaring it in roots: solely
 			// to set policy; ignore any path that was provided.
-			if trimmed != "core" && entry.Path != "" {
+			if trimmed == "core" {
+				if pathValue != "" && !entryHasPolicy(entry) {
+					slog.Default().Warn("config: roots.core path is ignored (core derives from workspace.path); declare core: only when setting policy",
+						"path", entry.Path)
+				}
+			} else {
+				if pathValue == "" {
+					return fmt.Errorf("config: roots.%s.path must be set for non-core roots", trimmed)
+				}
 				c.Paths[trimmed] = entry.Path
 			}
 			if entryHasPolicy(entry) {

--- a/internal/platform/config/config_test.go
+++ b/internal/platform/config/config_test.go
@@ -1050,3 +1050,126 @@ func TestNormalizeRoots_Programmatic(t *testing.T) {
 		t.Errorf("Roots should be cleared after normalize")
 	}
 }
+
+// TestLoad_RootsBlockRejectsNullShorthand guards against `kb:` (null
+// scalar) silently becoming an empty path. yaml.v3 doesn't invoke
+// UnmarshalYAML for a null map value, so the null is caught by the
+// normalize-time empty-path check rather than the scalar guard.
+func TestLoad_RootsBlockRejectsNullShorthand(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(path, []byte(`
+roots:
+  kb:
+`), 0600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	_, err := Load(path)
+	if err == nil {
+		t.Fatal("Load should error on null roots entry")
+	}
+	if !strings.Contains(err.Error(), "roots.kb.path") {
+		t.Fatalf("error = %v, want empty-path or scalar-tag message", err)
+	}
+}
+
+// TestLoad_RootsBlockRejectsNonStringScalar guards against typos like
+// `kb: 42` or `kb: true` that would otherwise become path strings.
+func TestLoad_RootsBlockRejectsNonStringScalar(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(path, []byte(`
+roots:
+  kb: 42
+`), 0600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	_, err := Load(path)
+	if err == nil {
+		t.Fatal("Load should error on non-string scalar shorthand")
+	}
+	if !strings.Contains(err.Error(), "must be a string") {
+		t.Fatalf("error = %v, want non-string scalar message", err)
+	}
+}
+
+// TestLoad_RootsBlockRejectsMappingWithoutPath guards against a
+// non-core entry whose mapping omits path: — easy to do when
+// templating policy without a path.
+func TestLoad_RootsBlockRejectsMappingWithoutPath(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(path, []byte(`
+roots:
+  kb:
+    authoring: managed
+`), 0600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	_, err := Load(path)
+	if err == nil {
+		t.Fatal("Load should error when a non-core root mapping has no path")
+	}
+	if !strings.Contains(err.Error(), "roots.kb.path") {
+		t.Fatalf("error = %v, want roots.kb.path message", err)
+	}
+}
+
+// TestNormalizeRoots_RejectsEmptyPathProgrammatic mirrors the
+// mapping-without-path case for callers that bypass YAML.
+func TestNormalizeRoots_RejectsEmptyPathProgrammatic(t *testing.T) {
+	t.Parallel()
+	cfg := &Config{
+		Roots: map[string]RootEntry{
+			"kb": {Authoring: "managed"},
+		},
+	}
+	err := cfg.normalizeRoots()
+	if err == nil {
+		t.Fatal("normalizeRoots should error on empty path for non-core root")
+	}
+	if !strings.Contains(err.Error(), "roots.kb.path") {
+		t.Fatalf("error = %v, want roots.kb.path message", err)
+	}
+}
+
+// TestNormalizeRoots_DetectsCanonicalCollision verifies that two keys
+// that canonicalize to the same trimmed name (e.g. `kb` and `kb:`)
+// are rejected rather than silently overwriting each other.
+func TestNormalizeRoots_DetectsCanonicalCollision(t *testing.T) {
+	t.Parallel()
+	cfg := &Config{
+		Roots: map[string]RootEntry{
+			"kb":  {Path: "/a"},
+			"kb:": {Path: "/b"},
+		},
+	}
+	err := cfg.normalizeRoots()
+	if err == nil {
+		t.Fatal("normalizeRoots should error on canonical-name collision")
+	}
+	if !strings.Contains(err.Error(), "canonicalize") {
+		t.Fatalf("error = %v, want canonicalize collision message", err)
+	}
+}
+
+// TestNormalizeRoots_CoreReservedAcceptsPolicyOnly confirms that
+// declaring core: with policy fields and no path is the supported
+// shape (no warning, no error).
+func TestNormalizeRoots_CoreReservedAcceptsPolicyOnly(t *testing.T) {
+	t.Parallel()
+	cfg := &Config{
+		Roots: map[string]RootEntry{
+			"core": {Authoring: "managed"},
+		},
+	}
+	if err := cfg.normalizeRoots(); err != nil {
+		t.Fatalf("normalizeRoots: %v", err)
+	}
+	if _, ok := cfg.Paths["core"]; ok {
+		t.Errorf("core path must not be populated; Paths = %#v", cfg.Paths)
+	}
+	if cfg.DocRoots["core"].Authoring != "managed" {
+		t.Errorf("core policy not applied: %#v", cfg.DocRoots["core"])
+	}
+}

--- a/internal/platform/config/config_test.go
+++ b/internal/platform/config/config_test.go
@@ -866,3 +866,187 @@ func TestValidate_DocumentRootConfig(t *testing.T) {
 }
 
 func strPtr(s string) *string { return &s }
+
+// TestLoad_RootsBlockBareString covers the bare-string shorthand:
+// `name: ~/path` desugars into Paths with default policy.
+func TestLoad_RootsBlockBareString(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(path, []byte(`
+roots:
+  kb: ./knowledge
+  scratchpad: ./scratch
+`), 0600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load error: %v", err)
+	}
+	if cfg.Paths["kb"] != "./knowledge" {
+		t.Errorf("Paths[kb] = %q, want ./knowledge", cfg.Paths["kb"])
+	}
+	if cfg.Paths["scratchpad"] != "./scratch" {
+		t.Errorf("Paths[scratchpad] = %q, want ./scratch", cfg.Paths["scratchpad"])
+	}
+	// Bare-string entries should not produce DocRoots rows
+	// because they have no policy fields.
+	if _, ok := cfg.DocRoots["kb"]; ok {
+		t.Errorf("bare-string entry should not produce a DocRoots row: %#v", cfg.DocRoots)
+	}
+	// Roots is cleared after normalize.
+	if cfg.Roots != nil {
+		t.Errorf("Roots should be cleared after normalize, got %#v", cfg.Roots)
+	}
+}
+
+// TestLoad_RootsBlockMixedForms verifies that bare-string and full
+// mapping forms can coexist in the same roots: block.
+func TestLoad_RootsBlockMixedForms(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(path, []byte(`
+roots:
+  kb: ./knowledge
+  scratchpad:
+    path: ./scratch
+    authoring: managed
+  secure:
+    path: ./secure
+    indexing: false
+    git:
+      enabled: true
+      sign_commits: true
+      verify_signatures: required
+      signing_key: ./id_ed25519
+`), 0600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load error: %v", err)
+	}
+	if cfg.Paths["kb"] != "./knowledge" || cfg.Paths["scratchpad"] != "./scratch" || cfg.Paths["secure"] != "./secure" {
+		t.Errorf("Paths = %#v, want all three roots", cfg.Paths)
+	}
+	if _, ok := cfg.DocRoots["kb"]; ok {
+		t.Errorf("kb (bare string) should not have DocRoots entry")
+	}
+	if cfg.DocRoots["scratchpad"].Authoring != "managed" {
+		t.Errorf("scratchpad authoring = %q, want managed", cfg.DocRoots["scratchpad"].Authoring)
+	}
+	secure := cfg.DocRoots["secure"]
+	if secure.Indexing == nil || *secure.Indexing {
+		t.Errorf("secure indexing = %v, want false pointer", secure.Indexing)
+	}
+	if !secure.Git.Enabled || !secure.Git.SignCommits || secure.Git.VerifySignatures != "required" || secure.Git.SigningKey != "./id_ed25519" {
+		t.Errorf("secure.Git = %#v, want enabled+signed+required", secure.Git)
+	}
+}
+
+// TestLoad_RootsBlockRejectsLegacyMix guards against silently
+// accepting both shapes — the operator must pick one.
+func TestLoad_RootsBlockRejectsLegacyMix(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(path, []byte(`
+roots:
+  kb: ./knowledge
+paths:
+  scratchpad: ./scratch
+`), 0600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	_, err := Load(path)
+	if err == nil {
+		t.Fatal("Load should error when both roots: and paths: are present")
+	}
+	if !strings.Contains(err.Error(), "roots:") || !strings.Contains(err.Error(), "paths:") {
+		t.Fatalf("error = %v, want explanation that the two shapes can't coexist", err)
+	}
+}
+
+// TestLoad_RootsBlockReservedCoreNamePolicyOnly verifies that core:
+// can be declared in roots: solely to set policy; the path is
+// ignored (the runtime always derives core from workspace.path).
+func TestLoad_RootsBlockReservedCoreNamePolicyOnly(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(path, []byte(`
+roots:
+  core:
+    path: /should/be/ignored
+    authoring: managed
+    git:
+      enabled: true
+`), 0600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load error: %v", err)
+	}
+	if _, ok := cfg.Paths["core"]; ok {
+		t.Errorf("core path should not be set from roots: (it's reserved); Paths = %#v", cfg.Paths)
+	}
+	if !cfg.DocRoots["core"].Git.Enabled {
+		t.Errorf("core policy should still apply even when path is ignored: %#v", cfg.DocRoots["core"])
+	}
+}
+
+// TestLoad_LegacyShapeStillWorks verifies the legacy paths:+doc_roots:
+// shape continues to load successfully (with a deprecation warning
+// emitted to slog.Default — not asserted here, since tests don't
+// capture default slog).
+func TestLoad_LegacyShapeStillWorks(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(path, []byte(`
+paths:
+  kb: ./knowledge
+doc_roots:
+  kb:
+    authoring: read_only
+`), 0600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load error: %v", err)
+	}
+	if cfg.Paths["kb"] != "./knowledge" {
+		t.Errorf("legacy Paths still expected; got %#v", cfg.Paths)
+	}
+	if cfg.DocRoots["kb"].Authoring != "read_only" {
+		t.Errorf("legacy DocRoots still expected; got %#v", cfg.DocRoots)
+	}
+}
+
+// TestNormalizeRoots_Programmatic exercises the normalize step on a
+// hand-built Config (the Default+populate path some callers use).
+func TestNormalizeRoots_Programmatic(t *testing.T) {
+	t.Parallel()
+	cfg := &Config{
+		Roots: map[string]RootEntry{
+			"kb": {Path: "/k"},
+			"sp": {Path: "/s", Authoring: "managed"},
+		},
+	}
+	if err := cfg.normalizeRoots(); err != nil {
+		t.Fatalf("normalizeRoots: %v", err)
+	}
+	if cfg.Paths["kb"] != "/k" || cfg.Paths["sp"] != "/s" {
+		t.Errorf("Paths = %#v", cfg.Paths)
+	}
+	if _, ok := cfg.DocRoots["kb"]; ok {
+		t.Errorf("kb has no policy, should not produce DocRoots row")
+	}
+	if cfg.DocRoots["sp"].Authoring != "managed" {
+		t.Errorf("sp.Authoring = %q, want managed", cfg.DocRoots["sp"].Authoring)
+	}
+	if cfg.Roots != nil {
+		t.Errorf("Roots should be cleared after normalize")
+	}
+}

--- a/internal/platform/config/example.go
+++ b/internal/platform/config/example.go
@@ -103,14 +103,10 @@ func ExampleConfig() *Config {
 		DataDir:    "./db",
 		TalentsDir: "./talents",
 
-		Paths: map[string]string{
-			"generated":  "./generated",
-			"kb":         "./knowledge",
-			"scratchpad": "./scratchpad",
-		},
-
-		DocRoots: map[string]DocumentRootConfig{
+		Roots: map[string]RootEntry{
+			"generated": {Path: "./generated"},
 			"kb": {
+				Path:      "./knowledge",
 				Indexing:  &docRootIndexing,
 				Authoring: "managed",
 				Git: DocumentRootGitConfig{
@@ -121,6 +117,7 @@ func ExampleConfig() *Config {
 				},
 			},
 			"scratchpad": {
+				Path:      "./scratchpad",
 				Authoring: "managed",
 			},
 		},

--- a/internal/platform/config/gen/gencfg/main.go
+++ b/internal/platform/config/gen/gencfg/main.go
@@ -66,6 +66,7 @@ var optionalKeys = map[string]bool{
 	"extra_path":      true,
 	"pricing":         true,
 	"debug":           true,
+	"paths":           true,
 	"doc_roots":       true,
 	"log_level":       true,
 	"log_format":      true,

--- a/internal/platform/provenance/git.go
+++ b/internal/platform/provenance/git.go
@@ -43,7 +43,10 @@ func (s *Store) BootstrapBirthCommit(ctx context.Context) error {
 	}
 
 	gitignorePath := filepath.Join(s.path, ".gitignore")
-	if _, err := os.Stat(gitignorePath); os.IsNotExist(err) {
+	if _, err := os.Stat(gitignorePath); err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("stat .gitignore: %w", err)
+		}
 		if err := os.WriteFile(gitignorePath, []byte(defaultBirthGitignore), 0o644); err != nil {
 			return fmt.Errorf("write default .gitignore: %w", err)
 		}
@@ -52,6 +55,8 @@ func (s *Store) BootstrapBirthCommit(ctx context.Context) error {
 	bootstrapFiles := []string{".gitignore"}
 	if _, err := os.Stat(filepath.Join(s.path, ".allowed_signers")); err == nil {
 		bootstrapFiles = append(bootstrapFiles, ".allowed_signers")
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("stat .allowed_signers: %w", err)
 	}
 
 	committed, err := s.commitFiles(ctx, bootstrapFiles, "bootstrap document root")


### PR DESCRIPTION
## Summary

Closes #790. Also lands the four Copilot review fixes for #791 that didn't make it onto the merged PR (the SSH agent was failing during the review window).

### #790 — unify `paths:` + `doc_roots:` into `roots:`

`paths:` and `doc_roots:` were two YAML keys describing one logical thing — every entry in `paths:` was implicitly a doc root with default policy. The split caused real misconfiguration risk: easy to set `paths.kb` and forget `doc_roots.kb`, leaving an unhardened root.

New shape, with shorthand and full forms supported in the same block:

```yaml
roots:
  kb: ~/Sync/Vault                  # bare-string shorthand, defaults
  scratchpad:
    path: ~/Thane/scratchpad
    authoring: managed
  secure:
    path: ~/secure/notes
    git:
      enabled: true
      sign_commits: true
      verify_signatures: required
      signing_key: ~/Thane/core/identity/signing_ed25519
```

**Implementation**: a `normalizeRoots()` step runs in `Load()` between `yaml.Unmarshal` and `applyDefaults`. It desugars `Roots` into the existing `Paths`/`DocRoots` maps so downstream consumers (resolver construction, doc-store options) keep working unchanged. `Roots` is cleared after normalize so there's exactly one canonical representation downstream.

**Behavior**:
- New `roots:` shape is canonical.
- Legacy `paths:` + `doc_roots:` still loads with a deprecation warning (`slog.Default().Warn`).
- A config that declares both shapes returns a fatal error with a clear pick-one message.
- Reserved `core:` name is allowed in `roots:` solely to set policy; any path is ignored.
- Custom `RootEntry.UnmarshalYAML` handles the bare-string vs mapping fork.

**Generator/example**: `ExampleConfig` and `examples/config.example.yaml` regenerated to use the new shape. Legacy `paths:` and `doc_roots:` now appear as commented-out optional blocks in the example.

### #791 deferred Copilot fixes

The four review-feedback fixes that were stranded as local commit `8cd3d77` (push blocked by SSH agent failure) — cherry-picked here:

- `BootstrapBirthCommit` distinguishes `os.ErrNotExist` from other stat errors so permission/IO failures surface as `stat .gitignore:` / `stat .allowed_signers:` instead of being swallowed and turning into a confusing `git add` failure.
- `writeTestSigningKey` docstring corrected (private key written, public key returned as a string; no `.pub` file written).
- `t.Context()` for the `git rev-parse` subprocess in `TestBuildDocumentStoreOptionsBootstrapsMissingDirectory` so a hung git can't stall the test.
- `docRootBootstrapTimeout` named constant in `document_roots.go` instead of a bare `30 * time.Second`.

These were referenced in resolved Copilot threads on PR #791 as "Fixed in 8cd3d77," but that commit never reached origin. This PR carries them forward.

## Test plan

- [x] `just ci` passes locally (fmt, generate, architecture baseline, lint, tests)
- [x] New tests cover: bare-string `roots:`, mixed-form `roots:`, both-shapes-rejected, reserved-core-policy-only, legacy-shape-still-loads, programmatic normalize
- [x] Existing legacy-shape tests still pass (deprecation warning is logged but not asserted)
- [ ] Production smoke: load an existing legacy config with `paths:`/`doc_roots:`, verify deprecation warning fires and behavior is unchanged
- [ ] Production smoke: rewrite that config to `roots:` and confirm equivalence