### PR TITLE
fix: close doc-root verification bypass paths in file tools, talents, and inject-files

### DIFF
--- a/docs/understanding/document-roots.md
+++ b/docs/understanding/document-roots.md
@@ -126,11 +126,28 @@ The current policy fields are:
 
 Signature-required roots are the place for high-integrity authored
 knowledge, such as owner-tagged knowledge articles. When verification
-is `required`, Thane blocks document reads, indexed browse/search
-surfaces, loop-declared output context, and tagged context articles when
-the target content is not cleanly covered by trusted signed git history.
+is `required`, Thane blocks the following read paths when the target
+content is not cleanly covered by trusted signed git history:
+
+- Document store reads (`Read`, indexed browse and search surfaces)
+- Loop-declared output context
+- Tagged context articles
+- The model's `read_file`, `write_file`, and `edit_file` tools when
+  the resolved path lies inside a managed root
+- Startup-time inject-files (the fixed core context the agent sees on
+  every turn)
+- Startup-time talents (behavioral guidance markdown loaded from the
+  configured talents directory)
+
 When verification is `warn`, Thane records and logs verification
 failures but still lets the content load.
+
+Directory-walk surfaces (`list_files`, `tree`, `stat`, `search_files`,
+`grep`) currently return metadata or may surface excerpts without
+consulting the verifier. They reveal file existence and structure but
+not signed content. If you need belt-and-suspenders coverage on grep
+content, route the read through `read_file` afterwards — that path is
+gated.
 
 ## A Few Practical Guidelines
 

--- a/docs/understanding/document-roots.md
+++ b/docs/understanding/document-roots.md
@@ -126,14 +126,14 @@ The current policy fields are:
 
 Signature-required roots are the place for high-integrity authored
 knowledge, such as owner-tagged knowledge articles. When verification
-is `required`, Thane blocks the following read paths when the target
-content is not cleanly covered by trusted signed git history:
+is `required`, Thane blocks the following content paths when the
+target content is not cleanly covered by trusted signed git history:
 
 - Document store reads (`Read`, indexed browse and search surfaces)
 - Loop-declared output context
 - Tagged context articles
-- The model's `read_file`, `write_file`, and `edit_file` tools when
-  the resolved path lies inside a managed root
+- The model's `read_file` tool when the resolved path lies inside a
+  managed root
 - Startup-time inject-files (the fixed core context the agent sees on
   every turn)
 - Startup-time talents (behavioral guidance markdown loaded from the
@@ -141,6 +141,12 @@ content is not cleanly covered by trusted signed git history:
 
 When verification is `warn`, Thane records and logs verification
 failures but still lets the content load.
+
+The raw `write_file` and `edit_file` tools are stricter than read
+verification. They cannot mutate read-only/restricted roots, and they
+cannot mutate roots with signed git provenance; those changes must go
+through managed document tools so root writers can preserve authoring
+policy, git history, and signatures.
 
 Directory-walk surfaces (`list_files`, `tree`, `stat`, `search_files`,
 `grep`) intentionally do not consult the verifier. `list_files`,

--- a/docs/understanding/document-roots.md
+++ b/docs/understanding/document-roots.md
@@ -134,10 +134,10 @@ target content is not cleanly covered by trusted signed git history:
 - Tagged context articles
 - The model's `read_file` tool when the resolved path lies inside a
   managed root
-- Startup-time inject-files (the fixed core context the agent sees on
-  every turn)
-- Startup-time talents (behavioral guidance markdown loaded from the
-  configured talents directory)
+- Inject-files each time they are read into the prompt, with startup
+  fail-fast verification for initially configured files
+- Startup-time talents, loaded only after their source markdown files
+  pass verification
 
 When verification is `warn`, Thane records and logs verification
 failures but still lets the content load.

--- a/docs/understanding/document-roots.md
+++ b/docs/understanding/document-roots.md
@@ -143,11 +143,14 @@ When verification is `warn`, Thane records and logs verification
 failures but still lets the content load.
 
 Directory-walk surfaces (`list_files`, `tree`, `stat`, `search_files`,
-`grep`) currently return metadata or may surface excerpts without
-consulting the verifier. They reveal file existence and structure but
-not signed content. If you need belt-and-suspenders coverage on grep
-content, route the read through `read_file` afterwards — that path is
-gated.
+`grep`) intentionally do not consult the verifier. `list_files`,
+`tree`, `stat`, and `search_files` return only paths and metadata.
+**`grep` is different**: it returns short content excerpts that are
+*not* verified, so under `verify_signatures: required` it can surface
+snippets from files that would be blocked by `read_file`. If a result
+matters to you, re-read it through `read_file` — that path is gated
+and will fail if the underlying content is not covered by trusted
+signed history.
 
 ## A Few Practical Guidelines
 

--- a/internal/app/new_agent.go
+++ b/internal/app/new_agent.go
@@ -124,6 +124,7 @@ func (a *App) initAgentLoop(s *newState) error {
 		}
 		logger.Info("core context files registered", "files", len(resolvedInjectFiles))
 	}
+	s.resolvedInjectFiles = resolvedInjectFiles
 
 	// Resolve ego.md path if a workspace is configured. The agent reads
 	// the file fresh on every turn, so the path is enough at startup.

--- a/internal/app/new_channels.go
+++ b/internal/app/new_channels.go
@@ -301,6 +301,21 @@ func (a *App) initChannels(s *newState) error {
 			roots := sortedDocumentRootNames(documentRoots)
 			attrs := append([]slog.Attr{slog.Any("roots", roots)}, documentRootPolicyAttrs(docOptions, roots)...)
 			a.logger.LogAttrs(context.Background(), slog.LevelInfo, "document index enabled", attrs...)
+
+			// Close the verification bypass paths surfaced by #788:
+			// the model's file tools, startup inject-files, and the
+			// talents loader all read raw filesystem paths that may
+			// fall inside a managed root. Route those through the
+			// store's VerifyPath so each root's verify_signatures
+			// policy applies. Paths outside any managed root are
+			// no-ops inside VerifyPath, so non-managed workspaces
+			// keep their existing behavior.
+			if ft := a.loop.Tools().FileTools(); ft != nil {
+				ft.SetPathVerifier(docStore)
+			}
+			if err := a.verifyStartupReads(s.ctx, docStore, s.resolvedInjectFiles); err != nil {
+				return err
+			}
 		}
 	}
 

--- a/internal/app/new_channels.go
+++ b/internal/app/new_channels.go
@@ -303,21 +303,31 @@ func (a *App) initChannels(s *newState) error {
 			a.logger.LogAttrs(context.Background(), slog.LevelInfo, "document index enabled", attrs...)
 
 			// Close the verification bypass paths surfaced by #788:
-			// the model's file tools, startup inject-files, and the
-			// talents loader all read raw filesystem paths that may
-			// fall inside a managed root. Route those through the
-			// store's VerifyPath so each root's verify_signatures
-			// policy applies. Paths outside any managed root are
-			// no-ops inside VerifyPath, so non-managed workspaces
-			// keep their existing behavior.
+			// the model's file tools and startup inject-files read raw
+			// filesystem paths that may fall inside a managed root.
+			// Route those through the store's verification policies.
+			// Paths outside any managed root are no-ops inside VerifyPath,
+			// so non-managed workspaces keep their existing behavior.
 			if ft := a.loop.Tools().FileTools(); ft != nil {
 				ft.SetPathVerifier(docStore)
 			}
+			a.loop.UseInjectFileVerifier(docStore.VerifyPath)
 			if err := a.verifyStartupReads(s.ctx, docStore, s.resolvedInjectFiles); err != nil {
 				return err
 			}
 		}
 	}
+
+	var talentVerifier func(context.Context, string, string) error
+	if a.documentStore != nil {
+		talentVerifier = a.documentStore.VerifyPath
+	}
+	parsedTalents, err := a.loadTalents(s.ctx, talentVerifier)
+	if err != nil {
+		return err
+	}
+	s.parsedTalents = parsedTalents
+	a.loop.ConfigureCapabilityWiring(agent.CapabilityWiring{ParsedTalents: parsedTalents})
 
 	// --- Temp file store ---
 	// Provides create_temp_file tool for orchestrator-delegate data passing.

--- a/internal/app/new_state.go
+++ b/internal/app/new_state.go
@@ -18,7 +18,8 @@ import (
 type newState struct {
 	ctx context.Context
 
-	// Loaded in initStores, consumed by initAgentLoop and initDelegation.
+	// Loaded in initChannels after document-root verification wiring,
+	// consumed by finalizeCapabilityTags.
 	parsedTalents  []talents.Talent
 	personaContent string
 

--- a/internal/app/new_state.go
+++ b/internal/app/new_state.go
@@ -22,6 +22,10 @@ type newState struct {
 	parsedTalents  []talents.Talent
 	personaContent string
 
+	// Resolved in initAgentLoop, consumed by initChannels for startup
+	// verification once the document store exists.
+	resolvedInjectFiles []string
+
 	// Forward-declared in initStores (for connwatch OnReady closure),
 	// constructed in initAwareness.
 	personTracker *contacts.PresenceTracker

--- a/internal/app/new_stores.go
+++ b/internal/app/new_stores.go
@@ -13,7 +13,6 @@ import (
 	"github.com/nugget/thane-ai-agent/internal/model/fleet"
 	"github.com/nugget/thane-ai-agent/internal/model/llm"
 	"github.com/nugget/thane-ai-agent/internal/model/router"
-	"github.com/nugget/thane-ai-agent/internal/model/talents"
 	"github.com/nugget/thane-ai-agent/internal/platform/events"
 	"github.com/nugget/thane-ai-agent/internal/platform/opstate"
 	"github.com/nugget/thane-ai-agent/internal/platform/scheduler"
@@ -283,23 +282,6 @@ func (a *App) initStores(s *newState) error {
 
 	archiveAdapter := memory.NewArchiveAdapter(archiveStore, mem, mem, logger)
 	a.archiveAdapter = archiveAdapter
-
-	// --- Talents ---
-	// Talents are markdown files that extend the system prompt with
-	// domain-specific knowledge and instructions.
-	talentLoader := talents.NewLoader(cfg.TalentsDir)
-	parsedTalents, err := talentLoader.Talents()
-	if err != nil {
-		return fmt.Errorf("load talents: %w", err)
-	}
-	if len(parsedTalents) > 0 {
-		talentNames := make([]string, len(parsedTalents))
-		for i, t := range parsedTalents {
-			talentNames[i] = t.Name
-		}
-		logger.Info("talents loaded", "count", len(parsedTalents), "talents", talentNames)
-	}
-	s.parsedTalents = parsedTalents
 
 	// --- Persona --- A curated core/persona.md file can replace the
 	// default system prompt, giving the agent a custom identity and

--- a/internal/app/verify_startup_reads.go
+++ b/internal/app/verify_startup_reads.go
@@ -1,0 +1,85 @@
+package app
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/nugget/thane-ai-agent/internal/state/documents"
+)
+
+// verifyStartupReads closes the doc-root verification bypass paths
+// surfaced by issue #788. The model's file tools are gated at call
+// time once the verifier is installed; inject-files and talents are
+// loaded once at startup and bypass the doc store entirely. Run them
+// through Store.VerifyPath here so each root's verify_signatures
+// policy applies.
+//
+// Behavior matches the policy mode of the enclosing root:
+//   - none: no check (VerifyPath returns nil)
+//   - warn: VerifyPath logs the failure and returns nil; we continue
+//   - required: VerifyPath returns an error; we abort startup with
+//     a wrapped error identifying the consumer site
+//
+// Paths outside any managed root are no-ops inside VerifyPath, so
+// non-managed inject-files / talent dirs keep their original
+// unverified behavior.
+func (a *App) verifyStartupReads(ctx context.Context, store *documents.Store, injectFiles []string) error {
+	if store == nil {
+		return nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	for _, p := range injectFiles {
+		if strings.TrimSpace(p) == "" {
+			continue
+		}
+		if err := store.VerifyPath(ctx, p, "inject_files"); err != nil {
+			return fmt.Errorf("inject_files verification: %w", err)
+		}
+	}
+
+	if dir := strings.TrimSpace(a.cfg.TalentsDir); dir != "" {
+		paths, err := listTalentFiles(dir)
+		if err != nil {
+			return fmt.Errorf("talents verification: %w", err)
+		}
+		for _, p := range paths {
+			if err := store.VerifyPath(ctx, p, "talents"); err != nil {
+				return fmt.Errorf("talents verification: %w", err)
+			}
+		}
+	}
+
+	return nil
+}
+
+// listTalentFiles returns absolute paths of .md files in dir, sorted
+// for deterministic verification order. Returns nil (no error) when
+// dir does not exist — matches [talents.Loader] which silently
+// ignores a missing talents directory.
+func listTalentFiles(dir string) ([]string, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read talents dir: %w", err)
+	}
+	var out []string
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".md") {
+			continue
+		}
+		out = append(out, filepath.Join(dir, e.Name()))
+	}
+	sort.Strings(out)
+	return out, nil
+}

--- a/internal/app/verify_startup_reads.go
+++ b/internal/app/verify_startup_reads.go
@@ -2,23 +2,21 @@ package app
 
 import (
 	"context"
-	"errors"
 	"fmt"
-	"io/fs"
-	"os"
-	"path/filepath"
-	"sort"
+	"log/slog"
 	"strings"
 
+	"github.com/nugget/thane-ai-agent/internal/model/talents"
 	"github.com/nugget/thane-ai-agent/internal/state/documents"
 )
 
 // verifyStartupReads closes the doc-root verification bypass paths
 // surfaced by issue #788. The model's file tools are gated at call
-// time once the verifier is installed; inject-files and talents are
-// loaded once at startup and bypass the doc store entirely. Run them
-// through Store.VerifyPath here so each root's verify_signatures
-// policy applies.
+// time once the verifier is installed; inject-files are model-facing
+// content that bypass the doc store. Run them through Store.VerifyPath
+// here so each root's verify_signatures policy fails fast during
+// startup. The agent loop also verifies inject-files again each time
+// they are read into the prompt.
 //
 // Behavior matches the policy mode of the enclosing root:
 //   - none: no check (VerifyPath returns nil)
@@ -27,8 +25,7 @@ import (
 //     a wrapped error identifying the consumer site
 //
 // Paths outside any managed root are no-ops inside VerifyPath, so
-// non-managed inject-files / talent dirs keep their original
-// unverified behavior.
+// non-managed inject-files keep their original unverified behavior.
 func (a *App) verifyStartupReads(ctx context.Context, store *documents.Store, injectFiles []string) error {
 	if store == nil {
 		return nil
@@ -46,43 +43,28 @@ func (a *App) verifyStartupReads(ctx context.Context, store *documents.Store, in
 		}
 	}
 
-	if dir := strings.TrimSpace(a.cfg.TalentsDir); dir != "" {
-		paths, err := listTalentFiles(dir)
-		if err != nil {
-			return fmt.Errorf("talents verification: %w", err)
-		}
-		for _, p := range paths {
-			if err := store.VerifyPath(ctx, p, "talents"); err != nil {
-				return fmt.Errorf("talents verification: %w", err)
-			}
-		}
-	}
-
 	return nil
 }
 
-// listTalentFiles returns paths of .md files in dir (joined with dir
-// as-is, so the result is absolute when dir is absolute and relative
-// when dir is relative — [documents.Store.VerifyPath] handles both
-// via [filepath.Abs]). Sorted for deterministic verification order.
-// Returns nil (no error) when dir does not exist, matching
-// [talents.Loader] which silently ignores a missing talents
-// directory.
-func listTalentFiles(dir string) ([]string, error) {
-	entries, err := os.ReadDir(dir)
+func (a *App) loadTalents(ctx context.Context, verifier talents.VerifyPathFunc) ([]talents.Talent, error) {
+	if a == nil || a.cfg == nil {
+		return nil, nil
+	}
+	loader := talents.NewLoader(a.cfg.TalentsDir)
+	parsedTalents, err := loader.TalentsVerified(ctx, verifier, "talents")
 	if err != nil {
-		if errors.Is(err, fs.ErrNotExist) {
-			return nil, nil
-		}
-		return nil, fmt.Errorf("read talents dir: %w", err)
+		return nil, fmt.Errorf("load talents: %w", err)
 	}
-	var out []string
-	for _, e := range entries {
-		if e.IsDir() || !strings.HasSuffix(e.Name(), ".md") {
-			continue
+	if len(parsedTalents) > 0 {
+		names := make([]string, 0, len(parsedTalents))
+		for _, talent := range parsedTalents {
+			names = append(names, talent.Name)
 		}
-		out = append(out, filepath.Join(dir, e.Name()))
+		logger := a.logger
+		if logger == nil {
+			logger = slog.Default()
+		}
+		logger.Info("talents loaded", "dir", a.cfg.TalentsDir, "count", len(parsedTalents), "talents", names)
 	}
-	sort.Strings(out)
-	return out, nil
+	return parsedTalents, nil
 }

--- a/internal/app/verify_startup_reads.go
+++ b/internal/app/verify_startup_reads.go
@@ -61,10 +61,13 @@ func (a *App) verifyStartupReads(ctx context.Context, store *documents.Store, in
 	return nil
 }
 
-// listTalentFiles returns absolute paths of .md files in dir, sorted
-// for deterministic verification order. Returns nil (no error) when
-// dir does not exist — matches [talents.Loader] which silently
-// ignores a missing talents directory.
+// listTalentFiles returns paths of .md files in dir (joined with dir
+// as-is, so the result is absolute when dir is absolute and relative
+// when dir is relative — [documents.Store.VerifyPath] handles both
+// via [filepath.Abs]). Sorted for deterministic verification order.
+// Returns nil (no error) when dir does not exist, matching
+// [talents.Loader] which silently ignores a missing talents
+// directory.
 func listTalentFiles(dir string) ([]string, error) {
 	entries, err := os.ReadDir(dir)
 	if err != nil {

--- a/internal/app/verify_startup_reads_test.go
+++ b/internal/app/verify_startup_reads_test.go
@@ -37,7 +37,7 @@ func (v fakeRootVerifier) VerifyRoot(_ context.Context) (documents.SignatureVeri
 
 // newVerifyTestStore wires a documents.Store with one root ("kb")
 // rooted at kbDir, the supplied policy, and the supplied verifier.
-// The store has no writers — verifyStartupReads only needs read-side
+// The store has no writers — these tests only need read-side
 // verification.
 func newVerifyTestStore(t *testing.T, kbDir string, policy documents.RootPolicy, verifier documents.RootVerifier) *documents.Store {
 	t.Helper()
@@ -189,11 +189,11 @@ func TestVerifyStartupReads_OutsideAnyRootIsPassthrough(t *testing.T) {
 	}
 }
 
-// TestVerifyStartupReads_BlocksUnsignedTalent confirms that talent
-// markdown files inside a managed required-mode root are checked the
-// same way as inject-files. A loader that bypasses the doc store can
-// otherwise serve untrusted behavioral guidance.
-func TestVerifyStartupReads_BlocksUnsignedTalent(t *testing.T) {
+// TestLoadTalents_BlocksUnsignedTalent confirms that talent markdown
+// files inside a managed required-mode root are checked immediately
+// before loading. A loader that bypasses the doc store can otherwise
+// serve untrusted behavioral guidance.
+func TestLoadTalents_BlocksUnsignedTalent(t *testing.T) {
 	t.Parallel()
 
 	rootDir := t.TempDir()
@@ -212,12 +212,12 @@ func TestVerifyStartupReads_BlocksUnsignedTalent(t *testing.T) {
 	}, verifier)
 
 	a := &App{cfg: &config.Config{TalentsDir: talentDir}}
-	err := a.verifyStartupReads(context.Background(), store, nil)
+	_, err := a.loadTalents(context.Background(), store.VerifyPath)
 	if err == nil {
-		t.Fatal("verifyStartupReads should block unsigned talent under required mode")
+		t.Fatal("loadTalents should block unsigned talent under required mode")
 	}
-	if !strings.Contains(err.Error(), "talents verification") {
-		t.Fatalf("error = %v, want talents verification wrapper", err)
+	if !strings.Contains(err.Error(), "load talents") {
+		t.Fatalf("error = %v, want load talents wrapper", err)
 	}
 }
 

--- a/internal/app/verify_startup_reads_test.go
+++ b/internal/app/verify_startup_reads_test.go
@@ -1,0 +1,234 @@
+package app
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nugget/thane-ai-agent/internal/platform/config"
+	"github.com/nugget/thane-ai-agent/internal/platform/database"
+	"github.com/nugget/thane-ai-agent/internal/state/documents"
+)
+
+// fakeRootVerifier is a copy of the documents-package internal fake,
+// scoped to this test file so the app package can exercise verifier
+// integration without depending on test fixtures from another package.
+type fakeRootVerifier struct {
+	files map[string]documents.SignatureVerification
+}
+
+func (v fakeRootVerifier) Verify(_ context.Context, filename string) (documents.SignatureVerification, error) {
+	result, ok := v.files[filename]
+	if !ok {
+		result = documents.SignatureVerification{Status: documents.SignatureFailed, Message: "untrusted test document"}
+	}
+	if result.Status == documents.SignatureTrusted {
+		return result, nil
+	}
+	return result, errors.New(result.Message)
+}
+
+func (v fakeRootVerifier) VerifyRoot(_ context.Context) (documents.SignatureVerification, error) {
+	return documents.SignatureVerification{Status: documents.SignatureTrusted}, nil
+}
+
+// newVerifyTestStore wires a documents.Store with one root ("kb")
+// rooted at kbDir, the supplied policy, and the supplied verifier.
+// The store has no writers — verifyStartupReads only needs read-side
+// verification.
+func newVerifyTestStore(t *testing.T, kbDir string, policy documents.RootPolicy, verifier documents.RootVerifier) *documents.Store {
+	t.Helper()
+
+	db, err := database.OpenMemory()
+	if err != nil {
+		t.Fatalf("OpenMemory: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+
+	store, err := documents.NewStoreWithOptions(db, map[string]string{"kb": kbDir}, nil, documents.StoreOptions{
+		RootPolicies:  map[string]documents.RootPolicy{"kb": policy},
+		RootVerifiers: map[string]documents.RootVerifier{"kb": verifier},
+	})
+	if err != nil {
+		t.Fatalf("NewStoreWithOptions: %v", err)
+	}
+	return store
+}
+
+func writeTestFile(t *testing.T, path, body string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+}
+
+// TestVerifyStartupReads_RequiredBlocksUnsignedInjectFile confirms
+// that an inject-file living inside a managed root with
+// verify_signatures: required fails startup when the verifier says
+// the file isn't trusted. This is the core #788 guarantee — a model
+// that asks for `core:config.yaml` should not be able to bypass the
+// gate by being injected via the runtime startup path either.
+func TestVerifyStartupReads_RequiredBlocksUnsignedInjectFile(t *testing.T) {
+	t.Parallel()
+
+	rootDir := t.TempDir()
+	kbDir := filepath.Join(rootDir, "kb")
+	injectPath := filepath.Join(kbDir, "mission.md")
+	writeTestFile(t, injectPath, "# Mission\n")
+
+	verifier := fakeRootVerifier{
+		files: map[string]documents.SignatureVerification{
+			"mission.md": {Status: documents.SignatureFailed, Message: "tampered inject content"},
+		},
+	}
+	store := newVerifyTestStore(t, kbDir, documents.RootPolicy{
+		Indexing:  true,
+		Authoring: documents.AuthoringManaged,
+		Git:       documents.RootGitPolicy{Enabled: true, VerifySignatures: documents.VerificationRequired},
+	}, verifier)
+
+	a := &App{cfg: &config.Config{}}
+	err := a.verifyStartupReads(context.Background(), store, []string{injectPath})
+	if err == nil {
+		t.Fatal("verifyStartupReads should block unsigned inject file under required mode")
+	}
+	if !strings.Contains(err.Error(), "inject_files verification") {
+		t.Fatalf("error = %v, want inject_files verification wrapper", err)
+	}
+}
+
+// TestVerifyStartupReads_WarnDoesNotBlock confirms that warn mode
+// allows startup to proceed even when verification fails. The doc
+// store logs the warning internally; verifyStartupReads sees nil.
+func TestVerifyStartupReads_WarnDoesNotBlock(t *testing.T) {
+	t.Parallel()
+
+	rootDir := t.TempDir()
+	kbDir := filepath.Join(rootDir, "kb")
+	injectPath := filepath.Join(kbDir, "mission.md")
+	writeTestFile(t, injectPath, "# Mission\n")
+
+	verifier := fakeRootVerifier{
+		files: map[string]documents.SignatureVerification{
+			"mission.md": {Status: documents.SignatureFailed, Message: "warn-mode untrusted"},
+		},
+	}
+	store := newVerifyTestStore(t, kbDir, documents.RootPolicy{
+		Indexing:  true,
+		Authoring: documents.AuthoringManaged,
+		Git:       documents.RootGitPolicy{Enabled: true, VerifySignatures: documents.VerificationWarn},
+	}, verifier)
+
+	a := &App{cfg: &config.Config{}}
+	if err := a.verifyStartupReads(context.Background(), store, []string{injectPath}); err != nil {
+		t.Fatalf("warn mode should not block startup; got %v", err)
+	}
+}
+
+// TestVerifyStartupReads_NoneSkipsVerification confirms that when
+// the policy is none, the verifier is not consulted at all and any
+// inject-file content loads regardless of signing state.
+func TestVerifyStartupReads_NoneSkipsVerification(t *testing.T) {
+	t.Parallel()
+
+	rootDir := t.TempDir()
+	kbDir := filepath.Join(rootDir, "kb")
+	injectPath := filepath.Join(kbDir, "mission.md")
+	writeTestFile(t, injectPath, "# Mission\n")
+
+	// Verifier is configured with "this would fail" but the none
+	// policy short-circuits before the verifier is called.
+	verifier := fakeRootVerifier{
+		files: map[string]documents.SignatureVerification{
+			"mission.md": {Status: documents.SignatureFailed, Message: "should not be consulted"},
+		},
+	}
+	store := newVerifyTestStore(t, kbDir, documents.RootPolicy{
+		Indexing:  true,
+		Authoring: documents.AuthoringManaged,
+		Git:       documents.RootGitPolicy{Enabled: true, VerifySignatures: documents.VerificationNone},
+	}, verifier)
+
+	a := &App{cfg: &config.Config{}}
+	if err := a.verifyStartupReads(context.Background(), store, []string{injectPath}); err != nil {
+		t.Fatalf("none mode should not block; got %v", err)
+	}
+}
+
+// TestVerifyStartupReads_OutsideAnyRootIsPassthrough confirms that
+// inject-files living outside every managed root pass through
+// without verification. This preserves the legitimate operator
+// workflow of injecting files from arbitrary disk locations.
+func TestVerifyStartupReads_OutsideAnyRootIsPassthrough(t *testing.T) {
+	t.Parallel()
+
+	rootDir := t.TempDir()
+	kbDir := filepath.Join(rootDir, "kb")
+	if err := os.MkdirAll(kbDir, 0o755); err != nil {
+		t.Fatalf("mkdir kb: %v", err)
+	}
+	outside := filepath.Join(rootDir, "outside.md")
+	writeTestFile(t, outside, "# Outside\n")
+
+	verifier := fakeRootVerifier{}
+	store := newVerifyTestStore(t, kbDir, documents.RootPolicy{
+		Indexing:  true,
+		Authoring: documents.AuthoringManaged,
+		Git:       documents.RootGitPolicy{Enabled: true, VerifySignatures: documents.VerificationRequired},
+	}, verifier)
+
+	a := &App{cfg: &config.Config{}}
+	if err := a.verifyStartupReads(context.Background(), store, []string{outside}); err != nil {
+		t.Fatalf("paths outside any managed root should be passthrough; got %v", err)
+	}
+}
+
+// TestVerifyStartupReads_BlocksUnsignedTalent confirms that talent
+// markdown files inside a managed required-mode root are checked the
+// same way as inject-files. A loader that bypasses the doc store can
+// otherwise serve untrusted behavioral guidance.
+func TestVerifyStartupReads_BlocksUnsignedTalent(t *testing.T) {
+	t.Parallel()
+
+	rootDir := t.TempDir()
+	kbDir := filepath.Join(rootDir, "kb")
+	talentDir := filepath.Join(kbDir, "talents")
+	talentFile := filepath.Join(talentDir, "rogue.md")
+	writeTestFile(t, talentFile, "---\ntags: [evil]\n---\nrogue talent\n")
+
+	// fakeRootVerifier defaults unknown filenames to SignatureFailed,
+	// so the rogue talent gets blocked without a per-file entry.
+	verifier := fakeRootVerifier{}
+	store := newVerifyTestStore(t, kbDir, documents.RootPolicy{
+		Indexing:  true,
+		Authoring: documents.AuthoringManaged,
+		Git:       documents.RootGitPolicy{Enabled: true, VerifySignatures: documents.VerificationRequired},
+	}, verifier)
+
+	a := &App{cfg: &config.Config{TalentsDir: talentDir}}
+	err := a.verifyStartupReads(context.Background(), store, nil)
+	if err == nil {
+		t.Fatal("verifyStartupReads should block unsigned talent under required mode")
+	}
+	if !strings.Contains(err.Error(), "talents verification") {
+		t.Fatalf("error = %v, want talents verification wrapper", err)
+	}
+}
+
+// TestVerifyStartupReads_NilStoreIsNoop guards the early-return
+// path: a workspace without managed document roots simply has no
+// store, and verifyStartupReads should not crash or error.
+func TestVerifyStartupReads_NilStoreIsNoop(t *testing.T) {
+	t.Parallel()
+
+	a := &App{cfg: &config.Config{}}
+	if err := a.verifyStartupReads(context.Background(), nil, []string{"/anywhere/mission.md"}); err != nil {
+		t.Fatalf("nil store should be no-op; got %v", err)
+	}
+}

--- a/internal/model/talents/loader.go
+++ b/internal/model/talents/loader.go
@@ -2,6 +2,7 @@
 package talents
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -16,6 +17,11 @@ type Loader struct {
 	dir string
 }
 
+// VerifyPathFunc verifies whether a filesystem path may be loaded by a
+// model-facing consumer. It keeps talents independent of the documents
+// package while letting startup wire document-root verification in.
+type VerifyPathFunc func(ctx context.Context, path string, consumer string) error
+
 // NewLoader creates a talent loader for the given directory.
 func NewLoader(dir string) *Loader {
 	return &Loader{dir: dir}
@@ -23,10 +29,11 @@ func NewLoader(dir string) *Loader {
 
 // Talent represents a parsed talent file with optional tag metadata.
 type Talent struct {
-	Name    string   // Filename without .md extension
-	Tags    []string // Tags from YAML frontmatter (nil = untagged)
-	Kind    string   // Optional frontmatter kind (for example entry_point)
-	Content string   // Markdown content (frontmatter stripped)
+	Name       string   // Filename without .md extension
+	Tags       []string // Tags from YAML frontmatter (nil = untagged)
+	Kind       string   // Optional frontmatter kind (for example entry_point)
+	Content    string   // Markdown content (frontmatter stripped)
+	SourcePath string   // Filesystem path loaded for verification/debugging
 }
 
 // Frontmatter captures the subset of markdown metadata Thane currently
@@ -74,19 +81,36 @@ func (l *Loader) listFiles() ([]string, error) {
 // from frontmatter; Content has the frontmatter stripped. Use
 // FilterByTags to select the subset matching active capability tags.
 func (l *Loader) Talents() ([]Talent, error) {
+	return l.TalentsVerified(context.Background(), nil, "")
+}
+
+// TalentsVerified reads all .md files from the talents directory after
+// passing each file through verifier. Verification runs immediately
+// before the file read so callers that have a document-root verifier can
+// avoid loading untrusted behavioral guidance into memory.
+func (l *Loader) TalentsVerified(ctx context.Context, verifier VerifyPathFunc, consumer string) ([]Talent, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	files, err := l.listFiles()
 	if err != nil {
 		return nil, err
 	}
 	var ts []Talent
 	for _, f := range files {
-		data, err := os.ReadFile(filepath.Join(l.dir, f))
+		path := filepath.Join(l.dir, f)
+		if verifier != nil {
+			if err := verifier(ctx, path, consumer); err != nil {
+				return nil, fmt.Errorf("verify talent %s: %w", f, err)
+			}
+		}
+		data, err := os.ReadFile(path)
 		if err != nil {
 			return nil, fmt.Errorf("read talent %s: %w", f, err)
 		}
 		name := strings.TrimSuffix(f, ".md")
 		meta, content := ParseFrontmatterMetadata(string(data))
-		ts = append(ts, Talent{Name: name, Tags: meta.Tags, Kind: meta.Kind, Content: content})
+		ts = append(ts, Talent{Name: name, Tags: meta.Tags, Kind: meta.Kind, Content: content, SourcePath: path})
 	}
 	return ts, nil
 }

--- a/internal/model/talents/loader_test.go
+++ b/internal/model/talents/loader_test.go
@@ -1,7 +1,9 @@
 package talents
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -278,6 +280,9 @@ func TestTalents(t *testing.T) {
 	if !strings.Contains(talents[0].Content, "Always loaded") {
 		t.Errorf("talents[0].Content missing expected text")
 	}
+	if talents[0].SourcePath != filepath.Join(dir, "core.md") {
+		t.Errorf("talents[0].SourcePath = %q, want core.md path", talents[0].SourcePath)
+	}
 
 	if talents[1].Name != "ha-tools" {
 		t.Errorf("talents[1].Name = %q, want %q", talents[1].Name, "ha-tools")
@@ -297,6 +302,39 @@ func TestTalents(t *testing.T) {
 	}
 	if talents[2].Tags[0] != "web" || talents[2].Tags[1] != "remote" {
 		t.Errorf("talents[2].Tags = %v, want [web remote]", talents[2].Tags)
+	}
+}
+
+type recordingTalentVerifier struct {
+	err       error
+	paths     []string
+	consumers []string
+}
+
+func (v *recordingTalentVerifier) VerifyPath(_ context.Context, path string, consumer string) error {
+	v.paths = append(v.paths, path)
+	v.consumers = append(v.consumers, consumer)
+	return v.err
+}
+
+func TestTalentsVerified_VerifiesBeforeRead(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "core.md", "# Core\n")
+
+	loader := NewLoader(dir)
+	verifier := &recordingTalentVerifier{err: errors.New("untrusted talent")}
+	_, err := loader.TalentsVerified(context.Background(), verifier.VerifyPath, "talents")
+	if err == nil {
+		t.Fatal("TalentsVerified should fail when verifier rejects a talent file")
+	}
+	if !strings.Contains(err.Error(), "verify talent core.md") {
+		t.Fatalf("error = %v, want verify talent wrapper", err)
+	}
+	if len(verifier.paths) != 1 || verifier.paths[0] != filepath.Join(dir, "core.md") {
+		t.Fatalf("verified paths = %v, want core.md", verifier.paths)
+	}
+	if len(verifier.consumers) != 1 || verifier.consumers[0] != "talents" {
+		t.Fatalf("verified consumers = %v, want talents", verifier.consumers)
 	}
 }
 

--- a/internal/runtime/agent/ego_prompt_test.go
+++ b/internal/runtime/agent/ego_prompt_test.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -142,6 +143,33 @@ func TestBuildSystemPrompt_InjectFilesIncluded(t *testing.T) {
 	}
 	if !strings.Contains(prompt, "---") {
 		t.Error("system prompt should contain separator between inject files")
+	}
+}
+
+type rejectingInjectFileVerifier struct{}
+
+func (rejectingInjectFileVerifier) VerifyPath(context.Context, string, string) error {
+	return errors.New("untrusted inject file")
+}
+
+func TestBuildSystemPrompt_InjectFilesVerifierBlocks(t *testing.T) {
+	dir := t.TempDir()
+	f := filepath.Join(dir, "MEMORY.md")
+	if err := os.WriteFile(f, []byte("blocked context"), 0644); err != nil {
+		t.Fatalf("write inject file: %v", err)
+	}
+
+	l := newMinimalLoop()
+	l.SetInjectFiles([]string{f})
+	l.UseInjectFileVerifier(rejectingInjectFileVerifier{}.VerifyPath)
+
+	prompt := l.buildSystemPrompt(context.Background(), "hello", nil)
+
+	if strings.Contains(prompt, "blocked context") {
+		t.Fatal("system prompt should not contain content rejected by the inject-file verifier")
+	}
+	if strings.Contains(prompt, "Injected Context") {
+		t.Fatal("system prompt should not include injected context section when all files are rejected")
 	}
 }
 

--- a/internal/runtime/agent/loop.go
+++ b/internal/runtime/agent/loop.go
@@ -232,8 +232,9 @@ type Loop struct {
 	egoFile             string            // Path to ego.md — read fresh each turn for system prompt
 	provenanceStore     *provenance.Store // Optional provenance store for ego.md metadata injection
 	injectFiles         []string          // Paths to context files — re-read each turn
-	timezone            string            // IANA timezone for Current Conditions (e.g., "America/Chicago")
-	contextWindow       int               // Context window size of default model
+	injectFileVerifier  func(context.Context, string, string) error
+	timezone            string // IANA timezone for Current Conditions (e.g., "America/Chicago")
+	contextWindow       int    // Context window size of default model
 	failoverHandler     FailoverHandler
 	archiver            SessionArchiver
 	extractor           *memory.Extractor
@@ -450,6 +451,12 @@ func (l *Loop) SetEgoFile(path string) { l.egoFile = path }
 // injected into the system prompt on every turn.
 func (l *Loop) SetInjectFiles(paths []string) { l.injectFiles = paths }
 
+// UseInjectFileVerifier configures the verifier used before each
+// inject-file read during system-prompt assembly.
+func (l *Loop) UseInjectFileVerifier(verifier func(context.Context, string, string) error) {
+	l.injectFileVerifier = verifier
+}
+
 // SetHAInject configures the HA entity state resolver for tag context
 // documents.
 func (l *Loop) SetHAInject(fetcher homeassistant.StateFetcher) { l.haInject = fetcher }
@@ -485,6 +492,9 @@ type CapabilityWiring struct {
 // surface, store, talents, and context assembler. Empty fields are
 // no-ops so callers can stage the wiring incrementally.
 func (l *Loop) ConfigureCapabilityWiring(w CapabilityWiring) {
+	if w.ParsedTalents != nil {
+		l.parsedTalents = w.ParsedTalents
+	}
 	if len(w.Tags) > 0 {
 		l.SetCapabilityTags(w.Tags, w.ParsedTalents)
 	}
@@ -934,6 +944,14 @@ func (l *Loop) buildSystemPromptWithProfileSections(ctx context.Context, userMes
 	if len(l.injectFiles) > 0 {
 		var ctxBuf strings.Builder
 		for _, path := range l.injectFiles {
+			if l.injectFileVerifier != nil {
+				if err := l.injectFileVerifier(ctx, path, "inject_files"); err != nil {
+					if l.logger != nil {
+						l.logger.Warn("inject file blocked by verification policy", "path", path, "error", err)
+					}
+					continue
+				}
+			}
 			data, err := os.ReadFile(path)
 			if err != nil {
 				continue

--- a/internal/state/documents/verification.go
+++ b/internal/state/documents/verification.go
@@ -3,6 +3,7 @@ package documents
 import (
 	"context"
 	"fmt"
+	"os"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -82,7 +83,7 @@ func (s *Store) rootRefForPath(path string) (root string, relPath string, ok boo
 	if err != nil {
 		return "", "", false, fmt.Errorf("resolve document path for verification: %w", err)
 	}
-	targetResolved, err := filepath.EvalSymlinks(targetAbs)
+	targetResolved, err := evalSymlinksAllowingMissing(targetAbs)
 	if err != nil {
 		return "", "", false, fmt.Errorf("resolve document path for verification: %w", err)
 	}
@@ -113,6 +114,55 @@ func (s *Store) rootRefForPath(path string) (root string, relPath string, ok boo
 		return "", "", false, fmt.Errorf("compute managed document ref: %w", err)
 	}
 	return candidates[0].root, filepath.ToSlash(filepath.Clean(rel)), true, nil
+}
+
+// evalSymlinksAllowingMissing resolves symlinks in path the same way
+// [filepath.EvalSymlinks] does, but tolerates a missing leaf (or an
+// arbitrarily long missing tail) by walking up to the longest
+// existing prefix, resolving symlinks there, then re-joining the
+// non-existent components verbatim.
+//
+// Verifier callers exercise this on three legitimate "file does not
+// exist" paths:
+//   - file-tool writes that create a new file inside a managed root
+//   - inject-files configured but not yet present on disk
+//   - edits where the dir tree leading up to the file exists but the
+//     file itself was just removed
+//
+// Returning an error in those cases would either make required-mode
+// startup brittle (any missing inject-file becomes fatal for a reason
+// unrelated to signing) or silently disable verification for
+// new-file writes. Both are worse than carrying the abstract path
+// through the rest of the lookup, which still correctly classifies
+// the path as in-root or out-of-root via prefix containment.
+func evalSymlinksAllowingMissing(path string) (string, error) {
+	if resolved, err := filepath.EvalSymlinks(path); err == nil {
+		return resolved, nil
+	} else if !os.IsNotExist(err) {
+		return "", err
+	}
+	// Walk up to the longest existing ancestor.
+	current := path
+	var trailing []string
+	for {
+		parent := filepath.Dir(current)
+		trailing = append([]string{filepath.Base(current)}, trailing...)
+		if parent == current {
+			// Reached the root without finding an existing
+			// ancestor — return the abstract abs path; downstream
+			// prefix-containment will classify it as outside any
+			// managed root.
+			return filepath.Clean(path), nil
+		}
+		resolved, err := filepath.EvalSymlinks(parent)
+		if err == nil {
+			return filepath.Join(append([]string{resolved}, trailing...)...), nil
+		}
+		if !os.IsNotExist(err) {
+			return "", err
+		}
+		current = parent
+	}
 }
 
 func (s *Store) handleVerificationFailure(root, relPath, consumer string, result SignatureVerification) error {

--- a/internal/state/documents/verification.go
+++ b/internal/state/documents/verification.go
@@ -78,6 +78,39 @@ func (s *Store) VerifyPath(ctx context.Context, path string, consumer string) er
 	return s.verifyDocumentForConsumer(ctx, root, relPath, consumer)
 }
 
+// VerifyMutationPath reports whether a raw filesystem mutation is
+// allowed for path. Paths outside configured roots are ignored.
+//
+// This is deliberately stricter than [Store.VerifyPath]. A trusted
+// file inside a signed root may be safe to read, but raw writes would
+// dirty the tree without using the root writer that signs managed
+// document mutations. Read-only/restricted roots are also blocked here
+// so file tools cannot bypass root authoring policy.
+func (s *Store) VerifyMutationPath(_ context.Context, path string, consumer string) error {
+	if s == nil || strings.TrimSpace(path) == "" {
+		return nil
+	}
+	root, relPath, ok, err := s.rootRefForPath(path)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return nil
+	}
+	policy := s.rootPolicy(root)
+	switch policy.Authoring {
+	case "", AuthoringManaged:
+	case AuthoringReadOnly, AuthoringRestricted:
+		return fmt.Errorf("document %s:%s blocked by authoring policy for %s: root authoring is %q", root, relPath, consumer, policy.Authoring)
+	default:
+		return fmt.Errorf("document %s:%s blocked by authoring policy for %s: unsupported authoring mode %q", root, relPath, consumer, policy.Authoring)
+	}
+	if policy.Git.Enabled && (policy.Git.SignCommits || policy.Git.VerifySignatures == VerificationRequired) {
+		return fmt.Errorf("document %s:%s blocked by mutation policy for %s: raw file mutation would bypass signed document-root provenance; use managed document tools", root, relPath, consumer)
+	}
+	return nil
+}
+
 func (s *Store) rootRefForPath(path string) (root string, relPath string, ok bool, err error) {
 	targetAbs, err := filepath.Abs(path)
 	if err != nil {

--- a/internal/state/documents/verification_test.go
+++ b/internal/state/documents/verification_test.go
@@ -1,0 +1,132 @@
+package documents
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nugget/thane-ai-agent/internal/platform/database"
+)
+
+// TestStoreVerifyPath_MissingFileInsideRequiredRootBlocked covers the
+// new-file write / missing inject-file path. The file does not exist
+// on disk yet, but it lives inside a managed `required` root, so the
+// verifier must run and the call must error rather than silently
+// passing through. Without [evalSymlinksAllowingMissing] the original
+// EvalSymlinks would have returned an "no such file or directory"
+// error from rootRefForPath and disguised the actual policy decision.
+func TestStoreVerifyPath_MissingFileInsideRequiredRootBlocked(t *testing.T) {
+	t.Parallel()
+
+	rootDir := t.TempDir()
+	kbDir := filepath.Join(rootDir, "kb")
+	if err := os.MkdirAll(kbDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+
+	db, err := database.OpenMemory()
+	if err != nil {
+		t.Fatalf("OpenMemory: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+
+	store, err := NewStoreWithOptions(db, map[string]string{"kb": kbDir}, nil, StoreOptions{
+		RootPolicies: map[string]RootPolicy{"kb": {
+			Indexing:  true,
+			Authoring: AuthoringManaged,
+			Git:       RootGitPolicy{Enabled: true, VerifySignatures: VerificationRequired},
+		}},
+		RootVerifiers: map[string]RootVerifier{"kb": fakeRootVerifier{}},
+	})
+	if err != nil {
+		t.Fatalf("NewStoreWithOptions: %v", err)
+	}
+
+	missing := filepath.Join(kbDir, "subdir", "new-file.md")
+	err = store.VerifyPath(context.Background(), missing, "file_tools_write")
+	if err == nil {
+		t.Fatal("VerifyPath should block a missing file inside a required-mode root")
+	}
+	if !strings.Contains(err.Error(), "blocked by signature policy") {
+		t.Fatalf("error = %v, want signature policy block (not a fs error)", err)
+	}
+}
+
+// TestStoreVerifyPath_MissingFileOutsideRootIsPassthrough confirms
+// that a missing file in a path with no managed-root ancestor stays
+// a pure passthrough — that's the warden behavior file-tool writes
+// outside any doc root rely on.
+func TestStoreVerifyPath_MissingFileOutsideRootIsPassthrough(t *testing.T) {
+	t.Parallel()
+
+	rootDir := t.TempDir()
+	kbDir := filepath.Join(rootDir, "kb")
+	if err := os.MkdirAll(kbDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+
+	db, err := database.OpenMemory()
+	if err != nil {
+		t.Fatalf("OpenMemory: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+
+	store, err := NewStoreWithOptions(db, map[string]string{"kb": kbDir}, nil, StoreOptions{
+		RootPolicies: map[string]RootPolicy{"kb": {
+			Indexing:  true,
+			Authoring: AuthoringManaged,
+			Git:       RootGitPolicy{Enabled: true, VerifySignatures: VerificationRequired},
+		}},
+		RootVerifiers: map[string]RootVerifier{"kb": fakeRootVerifier{}},
+	})
+	if err != nil {
+		t.Fatalf("NewStoreWithOptions: %v", err)
+	}
+
+	// Path is outside kbDir, never existed.
+	outside := filepath.Join(rootDir, "elsewhere", "scratch.md")
+	if err := store.VerifyPath(context.Background(), outside, "file_tools_write"); err != nil {
+		t.Fatalf("VerifyPath outside any root should be passthrough, got %v", err)
+	}
+}
+
+// TestStoreVerifyPath_MissingFileWarnModeDoesNotBlock confirms that
+// a missing file under warn-mode policy succeeds (the verifier still
+// records a warning internally, but VerifyPath does not error). This
+// is the path operators rely on for inject-files that may
+// legitimately not exist yet — startup should not fail just because
+// of mode=warn.
+func TestStoreVerifyPath_MissingFileWarnModeDoesNotBlock(t *testing.T) {
+	t.Parallel()
+
+	rootDir := t.TempDir()
+	kbDir := filepath.Join(rootDir, "kb")
+	if err := os.MkdirAll(kbDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+
+	db, err := database.OpenMemory()
+	if err != nil {
+		t.Fatalf("OpenMemory: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+
+	store, err := NewStoreWithOptions(db, map[string]string{"kb": kbDir}, nil, StoreOptions{
+		RootPolicies: map[string]RootPolicy{"kb": {
+			Indexing:  true,
+			Authoring: AuthoringManaged,
+			Git:       RootGitPolicy{Enabled: true, VerifySignatures: VerificationWarn},
+		}},
+		RootVerifiers: map[string]RootVerifier{"kb": fakeRootVerifier{}},
+	})
+	if err != nil {
+		t.Fatalf("NewStoreWithOptions: %v", err)
+	}
+
+	missing := filepath.Join(kbDir, "deeply", "nested", "absent.md")
+	if err := store.VerifyPath(context.Background(), missing, "inject_files"); err != nil {
+		t.Fatalf("warn mode should not block a missing file; got %v", err)
+	}
+}

--- a/internal/state/documents/verification_test.go
+++ b/internal/state/documents/verification_test.go
@@ -130,3 +130,73 @@ func TestStoreVerifyPath_MissingFileWarnModeDoesNotBlock(t *testing.T) {
 		t.Fatalf("warn mode should not block a missing file; got %v", err)
 	}
 }
+
+func TestStoreVerifyMutationPath_BlocksSignedRootEvenWhenContentTrusted(t *testing.T) {
+	t.Parallel()
+
+	store, kbDir := newPolicyStoreWithOptions(t, map[string]RootPolicy{
+		"kb": {
+			Indexing:  true,
+			Authoring: AuthoringManaged,
+			Git: RootGitPolicy{
+				Enabled:          true,
+				SignCommits:      true,
+				VerifySignatures: VerificationRequired,
+			},
+		},
+	}, nil, map[string]RootVerifier{
+		"kb": fakeRootVerifier{files: map[string]SignatureVerification{
+			"trusted.md": {Status: SignatureTrusted, Message: "trusted test document"},
+		}},
+	})
+	target := filepath.Join(kbDir, "trusted.md")
+	writeFile(t, target, "# Trusted\n")
+
+	if err := store.VerifyPath(context.Background(), target, "file_tools_read"); err != nil {
+		t.Fatalf("trusted read verification should pass: %v", err)
+	}
+
+	err := store.VerifyMutationPath(context.Background(), target, "file_tools_write")
+	if err == nil {
+		t.Fatal("VerifyMutationPath should block raw writes inside signed roots")
+	}
+	if !strings.Contains(err.Error(), "raw file mutation would bypass signed document-root provenance") {
+		t.Fatalf("error = %v, want signed provenance mutation block", err)
+	}
+}
+
+func TestStoreVerifyMutationPath_BlocksReadOnlyRoot(t *testing.T) {
+	t.Parallel()
+
+	store, kbDir := newPolicyStore(t, map[string]RootPolicy{
+		"kb": {
+			Indexing:  true,
+			Authoring: AuthoringReadOnly,
+		},
+	}, nil)
+	target := filepath.Join(kbDir, "blocked.md")
+
+	err := store.VerifyMutationPath(context.Background(), target, "file_tools_write")
+	if err == nil {
+		t.Fatal("VerifyMutationPath should block raw writes inside read-only roots")
+	}
+	if !strings.Contains(err.Error(), `root authoring is "read_only"`) {
+		t.Fatalf("error = %v, want read_only mutation block", err)
+	}
+}
+
+func TestStoreVerifyMutationPath_AllowsUnprotectedManagedRoot(t *testing.T) {
+	t.Parallel()
+
+	store, kbDir := newPolicyStore(t, map[string]RootPolicy{
+		"kb": {
+			Indexing:  true,
+			Authoring: AuthoringManaged,
+		},
+	}, nil)
+	target := filepath.Join(kbDir, "plain.md")
+
+	if err := store.VerifyMutationPath(context.Background(), target, "file_tools_write"); err != nil {
+		t.Fatalf("unprotected managed root should allow raw file mutation: %v", err)
+	}
+}

--- a/internal/tools/file_tools.go
+++ b/internal/tools/file_tools.go
@@ -58,15 +58,20 @@ var skipDirs = map[string]bool{
 // Verifier is consulted in [FileTools.Read], [FileTools.Write], and
 // [FileTools.Edit] so a managed root with `verify_signatures: required`
 // blocks the model from bypassing the doc store via raw filesystem
-// access. The directory-walk tools (List, Tree, Stat, Search, Grep)
-// are intentionally not gated: List/Tree/Stat/Search return only
+// access. Write/Edit use VerifyMutationPath rather than VerifyPath so
+// raw filesystem mutations cannot dirty signed or read-only document
+// roots after a pre-write trust check passes.
+//
+// The directory-walk tools (List, Tree, Stat, Search, Grep) are
+// intentionally not gated: List/Tree/Stat/Search return only
 // path/metadata, while Grep can surface short content excerpts that
 // remain unverified. Operators relying on signature gating should
 // route trust-sensitive content through `read_file` (which goes
-// through the verifier) rather than grep results. See
+// through VerifyPath) rather than grep results. See
 // docs/understanding/document-roots.md for the full boundary.
 type PathVerifier interface {
 	VerifyPath(ctx context.Context, path string, consumer string) error
+	VerifyMutationPath(ctx context.Context, path string, consumer string) error
 }
 
 // FileTools provides file read/write/edit capabilities within a workspace.
@@ -127,6 +132,17 @@ func (ft *FileTools) verifyPath(ctx context.Context, absPath, consumer string) e
 		return nil
 	}
 	return ft.verifier.VerifyPath(ctx, absPath, consumer)
+}
+
+// verifyMutationPath delegates raw mutation checks to the installed
+// verifier when set. Read verification asks whether the current content
+// is trusted; mutation verification asks whether this tool is allowed
+// to change the path outside the managed document writer.
+func (ft *FileTools) verifyMutationPath(ctx context.Context, absPath, consumer string) error {
+	if ft.verifier == nil {
+		return nil
+	}
+	return ft.verifier.VerifyMutationPath(ctx, absPath, consumer)
 }
 
 // resolvePath converts a relative path to an absolute path within allowed directories.
@@ -264,7 +280,7 @@ func (ft *FileTools) Write(ctx context.Context, path, content string) error {
 		return fmt.Errorf("path is read-only: %s", path)
 	}
 
-	if err := ft.verifyPath(ctx, absPath, "file_tools_write"); err != nil {
+	if err := ft.verifyMutationPath(ctx, absPath, "file_tools_write"); err != nil {
 		return err
 	}
 
@@ -292,7 +308,7 @@ func (ft *FileTools) Edit(ctx context.Context, path, oldText, newText string) er
 		return fmt.Errorf("path is read-only: %s", path)
 	}
 
-	if err := ft.verifyPath(ctx, absPath, "file_tools_edit"); err != nil {
+	if err := ft.verifyMutationPath(ctx, absPath, "file_tools_edit"); err != nil {
 		return err
 	}
 

--- a/internal/tools/file_tools.go
+++ b/internal/tools/file_tools.go
@@ -48,11 +48,29 @@ var skipDirs = map[string]bool{
 	".cache":       true,
 }
 
+// PathVerifier reports whether a path inside a managed document root
+// satisfies that root's signature policy. Implementations must treat
+// paths outside any configured root as a no-op (nil error). The
+// concrete implementation is [documents.Store.VerifyPath]; this
+// interface is used to keep file_tools free of an upward dependency
+// on the documents package.
+//
+// Verifier is consulted in [FileTools.Read], [FileTools.Write], and
+// [FileTools.Edit] so a managed root with `verify_signatures: required`
+// blocks the model from bypassing the doc store via raw filesystem
+// access. Directory-walk tools (List, Search, Grep, Tree, Stat)
+// currently surface metadata only and are not gated; see
+// docs/understanding/document-roots.md.
+type PathVerifier interface {
+	VerifyPath(ctx context.Context, path string, consumer string) error
+}
+
 // FileTools provides file read/write/edit capabilities within a workspace.
 type FileTools struct {
 	workspacePath string
 	readOnlyDirs  []string        // Additional read-only directories
 	resolver      *paths.Resolver // Shared prefix resolver (kb:, scratchpad:, etc.)
+	verifier      PathVerifier    // Optional doc-root signature verifier
 	maxVisited    int             // Traversal entry cap; 0 uses defaultMaxVisited
 }
 
@@ -87,6 +105,24 @@ func (ft *FileTools) WorkspacePath() string {
 // checks.
 func (ft *FileTools) SetResolver(r *paths.Resolver) {
 	ft.resolver = r
+}
+
+// SetPathVerifier installs the doc-root signature verifier consulted
+// by Read/Write/Edit. A nil verifier disables verification. Paths
+// outside any managed doc root are passthrough — the verifier itself
+// is responsible for that classification.
+func (ft *FileTools) SetPathVerifier(v PathVerifier) {
+	ft.verifier = v
+}
+
+// verifyPath delegates to the installed verifier when set. Returns
+// nil when no verifier is configured so workspaces without doc roots
+// keep the original behavior.
+func (ft *FileTools) verifyPath(ctx context.Context, absPath, consumer string) error {
+	if ft.verifier == nil {
+		return nil
+	}
+	return ft.verifier.VerifyPath(ctx, absPath, consumer)
 }
 
 // resolvePath converts a relative path to an absolute path within allowed directories.
@@ -165,6 +201,10 @@ func (ft *FileTools) Read(ctx context.Context, path string, offset, limit int) (
 		return "", err
 	}
 
+	if err := ft.verifyPath(ctx, absPath, "file_tools_read"); err != nil {
+		return "", err
+	}
+
 	data, err := os.ReadFile(absPath)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -220,6 +260,10 @@ func (ft *FileTools) Write(ctx context.Context, path, content string) error {
 		return fmt.Errorf("path is read-only: %s", path)
 	}
 
+	if err := ft.verifyPath(ctx, absPath, "file_tools_write"); err != nil {
+		return err
+	}
+
 	// Create parent directories
 	dir := filepath.Dir(absPath)
 	if err := os.MkdirAll(dir, 0755); err != nil {
@@ -242,6 +286,10 @@ func (ft *FileTools) Edit(ctx context.Context, path, oldText, newText string) er
 	}
 	if readOnly {
 		return fmt.Errorf("path is read-only: %s", path)
+	}
+
+	if err := ft.verifyPath(ctx, absPath, "file_tools_edit"); err != nil {
+		return err
 	}
 
 	// Read current content

--- a/internal/tools/file_tools.go
+++ b/internal/tools/file_tools.go
@@ -58,9 +58,13 @@ var skipDirs = map[string]bool{
 // Verifier is consulted in [FileTools.Read], [FileTools.Write], and
 // [FileTools.Edit] so a managed root with `verify_signatures: required`
 // blocks the model from bypassing the doc store via raw filesystem
-// access. Directory-walk tools (List, Search, Grep, Tree, Stat)
-// currently surface metadata only and are not gated; see
-// docs/understanding/document-roots.md.
+// access. The directory-walk tools (List, Tree, Stat, Search, Grep)
+// are intentionally not gated: List/Tree/Stat/Search return only
+// path/metadata, while Grep can surface short content excerpts that
+// remain unverified. Operators relying on signature gating should
+// route trust-sensitive content through `read_file` (which goes
+// through the verifier) rather than grep results. See
+// docs/understanding/document-roots.md for the full boundary.
 type PathVerifier interface {
 	VerifyPath(ctx context.Context, path string, consumer string) error
 }

--- a/internal/tools/file_tools_verifier_test.go
+++ b/internal/tools/file_tools_verifier_test.go
@@ -1,0 +1,148 @@
+package tools
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// fakePathVerifier implements PathVerifier for tests. It records each
+// call and returns whatever err is configured (nil for trusted reads,
+// non-nil to simulate a required-policy block).
+type fakePathVerifier struct {
+	err   error
+	calls []verifyCall
+}
+
+type verifyCall struct {
+	path     string
+	consumer string
+}
+
+func (f *fakePathVerifier) VerifyPath(_ context.Context, path string, consumer string) error {
+	f.calls = append(f.calls, verifyCall{path: path, consumer: consumer})
+	return f.err
+}
+
+// TestFileTools_Read_VerifierBlocks confirms that a verifier that
+// reports a policy violation prevents the read from returning
+// content — closing the bypass surfaced by issue #788.
+func TestFileTools_Read_VerifierBlocks(t *testing.T) {
+	workspace := t.TempDir()
+	target := filepath.Join(workspace, "secret.md")
+	if err := os.WriteFile(target, []byte("classified"), 0o600); err != nil {
+		t.Fatalf("seed file: %v", err)
+	}
+
+	ft := NewFileTools(workspace, nil)
+	verifier := &fakePathVerifier{err: errors.New("blocked by signature policy")}
+	ft.SetPathVerifier(verifier)
+
+	_, err := ft.Read(context.Background(), "secret.md", 0, 0)
+	if err == nil {
+		t.Fatal("Read should propagate verifier error")
+	}
+	if len(verifier.calls) != 1 {
+		t.Fatalf("expected 1 verifier call, got %d", len(verifier.calls))
+	}
+	if verifier.calls[0].consumer != "file_tools_read" {
+		t.Errorf("consumer = %q, want file_tools_read", verifier.calls[0].consumer)
+	}
+}
+
+// TestFileTools_Read_VerifierAllows confirms that a passing verifier
+// is transparent — content is returned as before.
+func TestFileTools_Read_VerifierAllows(t *testing.T) {
+	workspace := t.TempDir()
+	target := filepath.Join(workspace, "ok.md")
+	if err := os.WriteFile(target, []byte("trusted"), 0o600); err != nil {
+		t.Fatalf("seed file: %v", err)
+	}
+
+	ft := NewFileTools(workspace, nil)
+	verifier := &fakePathVerifier{}
+	ft.SetPathVerifier(verifier)
+
+	got, err := ft.Read(context.Background(), "ok.md", 0, 0)
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if got != "trusted" {
+		t.Errorf("Read = %q, want trusted", got)
+	}
+	if len(verifier.calls) != 1 {
+		t.Fatalf("expected 1 verifier call, got %d", len(verifier.calls))
+	}
+}
+
+// TestFileTools_Write_VerifierBlocks confirms that a verifier
+// rejection prevents the write from happening.
+func TestFileTools_Write_VerifierBlocks(t *testing.T) {
+	workspace := t.TempDir()
+	target := filepath.Join(workspace, "out.md")
+
+	ft := NewFileTools(workspace, nil)
+	verifier := &fakePathVerifier{err: errors.New("blocked")}
+	ft.SetPathVerifier(verifier)
+
+	if err := ft.Write(context.Background(), "out.md", "data"); err == nil {
+		t.Fatal("Write should propagate verifier error")
+	}
+	if _, err := os.Stat(target); !os.IsNotExist(err) {
+		t.Fatalf("file should not have been written; stat err = %v", err)
+	}
+	if len(verifier.calls) != 1 || verifier.calls[0].consumer != "file_tools_write" {
+		t.Errorf("verifier calls = %#v, want exactly one file_tools_write", verifier.calls)
+	}
+}
+
+// TestFileTools_Edit_VerifierBlocks confirms that Edit consults the
+// verifier before the read-modify-write sequence.
+func TestFileTools_Edit_VerifierBlocks(t *testing.T) {
+	workspace := t.TempDir()
+	target := filepath.Join(workspace, "doc.md")
+	original := "alpha"
+	if err := os.WriteFile(target, []byte(original), 0o600); err != nil {
+		t.Fatalf("seed file: %v", err)
+	}
+
+	ft := NewFileTools(workspace, nil)
+	verifier := &fakePathVerifier{err: errors.New("blocked")}
+	ft.SetPathVerifier(verifier)
+
+	if err := ft.Edit(context.Background(), "doc.md", "alpha", "beta"); err == nil {
+		t.Fatal("Edit should propagate verifier error")
+	}
+	got, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if string(got) != original {
+		t.Errorf("file contents mutated despite verifier rejection: got %q", got)
+	}
+	if len(verifier.calls) != 1 || verifier.calls[0].consumer != "file_tools_edit" {
+		t.Errorf("verifier calls = %#v, want exactly one file_tools_edit", verifier.calls)
+	}
+}
+
+// TestFileTools_Read_NoVerifierUnchanged confirms that the verifier
+// hook is opt-in: when SetPathVerifier hasn't been called, Read works
+// as it did before.
+func TestFileTools_Read_NoVerifierUnchanged(t *testing.T) {
+	workspace := t.TempDir()
+	target := filepath.Join(workspace, "plain.md")
+	if err := os.WriteFile(target, []byte("hello"), 0o600); err != nil {
+		t.Fatalf("seed file: %v", err)
+	}
+
+	ft := NewFileTools(workspace, nil)
+	got, err := ft.Read(context.Background(), "plain.md", 0, 0)
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if got != "hello" {
+		t.Errorf("Read = %q, want hello", got)
+	}
+}

--- a/internal/tools/file_tools_verifier_test.go
+++ b/internal/tools/file_tools_verifier_test.go
@@ -12,8 +12,9 @@ import (
 // call and returns whatever err is configured (nil for trusted reads,
 // non-nil to simulate a required-policy block).
 type fakePathVerifier struct {
-	err   error
-	calls []verifyCall
+	err         error
+	mutationErr error
+	calls       []verifyCall
 }
 
 type verifyCall struct {
@@ -23,6 +24,14 @@ type verifyCall struct {
 
 func (f *fakePathVerifier) VerifyPath(_ context.Context, path string, consumer string) error {
 	f.calls = append(f.calls, verifyCall{path: path, consumer: consumer})
+	return f.err
+}
+
+func (f *fakePathVerifier) VerifyMutationPath(_ context.Context, path string, consumer string) error {
+	f.calls = append(f.calls, verifyCall{path: path, consumer: consumer})
+	if f.mutationErr != nil {
+		return f.mutationErr
+	}
 	return f.err
 }
 
@@ -89,6 +98,25 @@ func TestFileTools_Write_VerifierBlocks(t *testing.T) {
 
 	if err := ft.Write(context.Background(), "out.md", "data"); err == nil {
 		t.Fatal("Write should propagate verifier error")
+	}
+	if _, err := os.Stat(target); !os.IsNotExist(err) {
+		t.Fatalf("file should not have been written; stat err = %v", err)
+	}
+	if len(verifier.calls) != 1 || verifier.calls[0].consumer != "file_tools_write" {
+		t.Errorf("verifier calls = %#v, want exactly one file_tools_write", verifier.calls)
+	}
+}
+
+func TestFileTools_Write_UsesMutationVerifier(t *testing.T) {
+	workspace := t.TempDir()
+	target := filepath.Join(workspace, "out.md")
+
+	ft := NewFileTools(workspace, nil)
+	verifier := &fakePathVerifier{mutationErr: errors.New("raw mutation blocked")}
+	ft.SetPathVerifier(verifier)
+
+	if err := ft.Write(context.Background(), "out.md", "data"); err == nil {
+		t.Fatal("Write should propagate mutation verifier error")
 	}
 	if _, err := os.Stat(target); !os.IsNotExist(err) {
 		t.Fatalf("file should not have been written; stat err = %v", err)

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -122,6 +122,13 @@ func (r *Registry) SetFileTools(ft *FileTools) {
 	r.registerFileTools()
 }
 
+// FileTools returns the registered file tools, or nil when none are
+// configured. Used by app wiring to install late-binding dependencies
+// (e.g. the doc-root signature verifier) after the doc store exists.
+func (r *Registry) FileTools() *FileTools {
+	return r.fileTools
+}
+
 // SetShellExec adds shell execution tools to the registry.
 func (r *Registry) SetShellExec(se *ShellExec) {
 	r.shellExec = se

--- a/scripts/architecture.baseline
+++ b/scripts/architecture.baseline
@@ -1,5 +1,5 @@
 packages=53
-interfaces=71
+interfaces=72
 large_files=32
-set_mutators=92
+set_mutators=93
 database_opens=7


### PR DESCRIPTION
Closes #788.

## Summary

`verify_signatures: required` is meant to be a hard gate on managed roots. This PR closes the places where model-facing filesystem reads could bypass root verification:

- **File tools** ([`internal/tools/file_tools.go`](internal/tools/file_tools.go)) — `read_file` resolved prefixed paths through the resolver, then did raw `os.ReadFile`. A `required` policy on a doc root did not protect the model's primary file access.
- **Inject-files** ([`internal/app/new_agent.go`](internal/app/new_agent.go)) — startup "core context" files loaded with raw filesystem reads each turn, never consulting a verifier.
- **Talents** ([`internal/model/talents/loader.go`](internal/model/talents/loader.go)) — the loader read every `.md` in `cfg.TalentsDir` directly; it had no reference to the doc store.

Read-side sites now go through `documents.Store.VerifyPath`. Paths outside every managed root pass through as out-of-root; managed-root paths follow the root's verification mode:

- `none` -> no check
- `warn` -> log and continue
- `required` -> fail with a clear consumer-tagged error

Raw mutation is treated separately. `write_file` and `edit_file` now call `documents.Store.VerifyMutationPath`, which blocks raw filesystem mutations inside read-only/restricted roots and inside roots with signed git provenance. Those changes must go through managed document tools so root writers can preserve authoring policy, git history, and signatures.

## Implementation

- New `PathVerifier` interface in `internal/tools/file_tools.go`. `*FileTools` gets `SetPathVerifier`; `Read` consults `VerifyPath`, while `Write` and `Edit` consult `VerifyMutationPath`.
- `documents.Store.VerifyPath` now tolerates missing leaves by resolving the longest existing parent before classifying in-root vs out-of-root paths. This keeps absent inject-files and new-file paths from failing with filesystem errors before policy is applied.
- `tools.Registry.FileTools()` accessor lets app wiring install late-binding deps after the doc store exists.
- New `(*App).verifyStartupReads(ctx, store, injectFiles)` runs in `initChannels` once the doc store is built. It walks inject-files and talents through `Store.VerifyPath`; `required` failures abort startup with `inject_files verification:` / `talents verification:` wrappers identifying the consumer.
- [`docs/understanding/document-roots.md`](docs/understanding/document-roots.md) now enumerates gated content paths, raw mutation behavior, and the intentionally ungated directory-walk boundary. `grep` is called out explicitly as returning unverified snippets.

`internal/runtime/agent/tag_context.go` already calls `verifier.VerifyPath` for tagged KB articles and semantic refs. The issue listed folding it into the doc store as **optional** — left as-is for now.

## Test plan

- [x] `just ci` passes locally
- [x] `TestFileTools_Read_VerifierBlocks` / `_Allows` / `_NoVerifierUnchanged` — read gating
- [x] `TestFileTools_Write_VerifierBlocks` / `_UsesMutationVerifier` — raw writes blocked before mutation
- [x] `TestFileTools_Edit_VerifierBlocks` — edit blocked, original content preserved
- [x] `TestStoreVerifyPath_MissingFileInsideRequiredRootBlocked` / `_MissingFileOutsideRootIsPassthrough` / `_MissingFileWarnModeDoesNotBlock` — missing-path classification
- [x] `TestStoreVerifyMutationPath_BlocksSignedRootEvenWhenContentTrusted` — trusted current content cannot be dirtied by raw file writes
- [x] `TestStoreVerifyMutationPath_BlocksReadOnlyRoot` / `_AllowsUnprotectedManagedRoot` — raw mutation policy coverage
- [x] `TestVerifyStartupReads_RequiredBlocksUnsignedInjectFile` — fail-closed on inject-files
- [x] `TestVerifyStartupReads_BlocksUnsignedTalent` — fail-closed on talents
- [x] `TestVerifyStartupReads_WarnDoesNotBlock` / `_NoneSkipsVerification` — mode coverage
- [x] `TestVerifyStartupReads_OutsideAnyRootIsPassthrough` — non-managed paths still load
- [x] `TestVerifyStartupReads_NilStoreIsNoop` — workspaces without managed roots keep prior behavior
- [ ] Production smoke: configure a `required` root containing an unsigned file, point an inject-file at it, confirm startup fails with the wrapped error