### PR TITLE
[codex] fix: use promptfmt for model-facing outputs

### DIFF
--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -67,6 +67,9 @@ needs a strict fresh tool scope.
 | `list_context_entities` | List current watchlist subscriptions (scoped and always-visible). |
 | `remove_context_entity` | Remove a watched entity or a scoped subscription. |
 
+Subscription expiry is reported as `expires_delta`, not a raw timestamp,
+so the model does not need to do clock arithmetic.
+
 ## `ha` / `homeassistant` — Home Assistant state and control
 
 | Tool | Description |
@@ -183,6 +186,9 @@ being reimplemented in each loop prompt.
 |------|-------------|
 | `owner_contact` | Return the runtime owner identity. Protected tag. |
 
+Owner channel activity recency is reported with delta fields such as
+`last_active_delta`.
+
 ## `files` — workspace filesystem access
 
 | Tool | Description |
@@ -196,6 +202,8 @@ being reimplemented in each loop prompt.
 | `file_stat` | Get file metadata. |
 | `file_tree` | Render a directory tree. |
 | `create_temp_file` | Create a temp file with a labelled path. |
+
+`file_stat` reports modification recency as `modified_delta`.
 
 ## `shell` — host command execution
 
@@ -233,6 +241,9 @@ being reimplemented in each loop prompt.
 | `attachment_search` | Semantic or tag search over attachment descriptions. |
 | `attachment_describe` | Produce/refresh a vision description for an attachment. |
 
+Attachment list and search results report arrival recency as
+`received_delta`.
+
 ## `forge` — GitHub/code collaboration
 
 | Tool | Description |
@@ -262,6 +273,8 @@ being reimplemented in each loop prompt.
 | `schedule_task` | Schedule a future task. |
 | `list_tasks` | List scheduled tasks. |
 | `cancel_task` | Cancel a scheduled task. |
+
+Task next-run values include a model-facing delta.
 
 ## `thane_*` family — intent-shaped front door for "do work"
 

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -117,6 +117,11 @@ writes through signed commits. Read/search surfaces also respect
 `verify_signatures: required` by blocking content that is not cleanly
 covered by trusted signed git history.
 
+Document tool results use model-facing time deltas such as
+`modified_delta`, `created_delta`, and `checked_delta` instead of raw
+absolute timestamps. Timestamp filter inputs still accept RFC3339 values
+or signed deltas like `-604800s`.
+
 | Tool | Description |
 |------|-------------|
 | `doc_roots` | List configured document roots with policy, health, and counts. |

--- a/internal/app/adapters.go
+++ b/internal/app/adapters.go
@@ -15,6 +15,7 @@ import (
 	"github.com/nugget/thane-ai-agent/internal/channels/notifications"
 	"github.com/nugget/thane-ai-agent/internal/connwatch"
 	"github.com/nugget/thane-ai-agent/internal/model/fleet"
+	"github.com/nugget/thane-ai-agent/internal/model/promptfmt"
 	"github.com/nugget/thane-ai-agent/internal/model/router"
 	"github.com/nugget/thane-ai-agent/internal/model/toolcatalog"
 	"github.com/nugget/thane-ai-agent/internal/platform/buildinfo"
@@ -349,7 +350,7 @@ func buildContactContext(c *contacts.Contact, props []contacts.Property, policy 
 	// Interaction history (trusted+).
 	if !c.LastInteraction.IsZero() {
 		ref := &agent.InteractionRef{
-			AgoSeconds: int64(c.LastInteraction.Sub(now).Truncate(time.Second).Seconds()),
+			Ago: promptfmt.FormatDeltaOnly(c.LastInteraction, now),
 		}
 		if c.LastInteractionMeta != nil {
 			ref.Channel = c.LastInteractionMeta.Channel

--- a/internal/runtime/agent/channel_provider.go
+++ b/internal/runtime/agent/channel_provider.go
@@ -51,12 +51,12 @@ type RelatedContact struct {
 }
 
 // InteractionRef summarizes the contact's most recent interaction for
-// temporal context. AgoSeconds is negative for past interactions.
+// temporal context. Ago is a signed-second delta such as "-3600s".
 type InteractionRef struct {
-	AgoSeconds int64    `json:"ago_seconds"`
-	Channel    string   `json:"channel,omitempty"`
-	SessionID  string   `json:"session_id,omitempty"`
-	Topics     []string `json:"topics,omitempty"`
+	Ago       string   `json:"ago"`
+	Channel   string   `json:"channel,omitempty"`
+	SessionID string   `json:"session_id,omitempty"`
+	Topics    []string `json:"topics,omitempty"`
 }
 
 // ContactLookup resolves contact identity into trust-gated profile and

--- a/internal/runtime/agent/channel_provider_test.go
+++ b/internal/runtime/agent/channel_provider_test.go
@@ -282,10 +282,10 @@ func TestChannelProvider_AdminFullContext(t *testing.T) {
 					"email":  []string{"admin@example.com"},
 				},
 				LastInteraction: &InteractionRef{
-					AgoSeconds: -3600,
-					Channel:    "signal",
-					SessionID:  "sess-abc",
-					Topics:     []string{"HVAC", "cameras"},
+					Ago:       "-3600s",
+					Channel:   "signal",
+					SessionID: "sess-abc",
+					Topics:    []string{"HVAC", "cameras"},
 				},
 			},
 		},
@@ -326,8 +326,8 @@ func TestChannelProvider_AdminFullContext(t *testing.T) {
 	if contact.LastInteraction == nil {
 		t.Fatal("expected last_interaction")
 	}
-	if contact.LastInteraction.AgoSeconds != -3600 {
-		t.Errorf("ago_seconds: got %d", contact.LastInteraction.AgoSeconds)
+	if contact.LastInteraction.Ago != "-3600s" {
+		t.Errorf("ago: got %q", contact.LastInteraction.Ago)
 	}
 	if contact.LastInteraction.Channel != "signal" {
 		t.Errorf("interaction channel: got %q", contact.LastInteraction.Channel)
@@ -542,10 +542,10 @@ func TestChannelProvider_InteractionRef(t *testing.T) {
 					SendGating:        "confirmation",
 				},
 				LastInteraction: &InteractionRef{
-					AgoSeconds: -7200,
-					Channel:    "signal",
-					SessionID:  "sess-xyz",
-					Topics:     []string{"weather", "schedule"},
+					Ago:       "-7200s",
+					Channel:   "signal",
+					SessionID: "sess-xyz",
+					Topics:    []string{"weather", "schedule"},
 				},
 			},
 		},
@@ -565,8 +565,8 @@ func TestChannelProvider_InteractionRef(t *testing.T) {
 	if contact.LastInteraction == nil {
 		t.Fatal("expected last_interaction")
 	}
-	if contact.LastInteraction.AgoSeconds != -7200 {
-		t.Errorf("ago_seconds: got %d, want -7200", contact.LastInteraction.AgoSeconds)
+	if contact.LastInteraction.Ago != "-7200s" {
+		t.Errorf("ago: got %q, want -7200s", contact.LastInteraction.Ago)
 	}
 	if len(contact.LastInteraction.Topics) != 2 {
 		t.Errorf("topics: got %v", contact.LastInteraction.Topics)

--- a/internal/runtime/agent/loop.go
+++ b/internal/runtime/agent/loop.go
@@ -1376,9 +1376,8 @@ func (l *Loop) injectEgoFromProvenance(ctx context.Context, sb *strings.Builder,
 
 	// Inject delta-relative metadata from git history.
 	if hist, err := l.provenanceStore.History(ctx, "ego.md"); err == nil && hist.RevisionCount > 0 {
-		ago := time.Since(hist.LastModified).Truncate(time.Second)
-		sb.WriteString(fmt.Sprintf("(updated %s ago by %s, revision %d)\n",
-			formatDeltaDuration(ago), hist.LastMessage, hist.RevisionCount))
+		sb.WriteString(fmt.Sprintf("(updated %s by %s, revision %d)\n",
+			promptfmt.FormatDeltaOnly(hist.LastModified, time.Now()), hist.LastMessage, hist.RevisionCount))
 	}
 
 	sb.WriteString("\n")
@@ -1389,27 +1388,6 @@ func (l *Loop) injectEgoFromProvenance(ctx context.Context, sb *strings.Builder,
 		sb.WriteString(content)
 	}
 	seal()
-}
-
-// formatDeltaDuration formats a duration as a human-readable delta
-// string (e.g., "3h", "2d", "45m"). Uses the largest natural unit.
-func formatDeltaDuration(d time.Duration) string {
-	switch {
-	case d < time.Minute:
-		return fmt.Sprintf("%ds", max(int(d.Seconds()), 1))
-	case d < time.Hour:
-		return fmt.Sprintf("%dm", int(d.Minutes()))
-	case d < 24*time.Hour:
-		h := int(d.Hours())
-		m := int(d.Minutes()) % 60
-		if m == 0 {
-			return fmt.Sprintf("%dh", h)
-		}
-		return fmt.Sprintf("%dh%dm", h, m)
-	default:
-		days := int(d.Hours()) / 24
-		return fmt.Sprintf("%dd", days)
-	}
 }
 
 // generateRequestID returns a human-scannable identifier for a single

--- a/internal/runtime/delegate/delegate.go
+++ b/internal/runtime/delegate/delegate.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/nugget/thane-ai-agent/internal/model/llm"
+	"github.com/nugget/thane-ai-agent/internal/model/promptfmt"
 	"github.com/nugget/thane-ai-agent/internal/model/prompts"
 	"github.com/nugget/thane-ai-agent/internal/model/router"
 	"github.com/nugget/thane-ai-agent/internal/platform/events"
@@ -383,7 +384,7 @@ func (e *Executor) startBackground(ctx context.Context, task, profileName, guida
 		return "", fmt.Errorf("background delegation requires a target conversation")
 	}
 
-	loopName := "delegate-" + prep.id[:8]
+	loopName := "delegate-" + promptfmt.ShortIDPrefix(prep.id)
 	loopMaxDuration := prep.maxDuration + 5*time.Second
 	if loopMaxDuration <= 0 {
 		loopMaxDuration = prep.maxDuration
@@ -440,7 +441,7 @@ func (e *Executor) executeViaLoop(ctx context.Context, task, profileName, guidan
 		return nil, err
 	}
 
-	loopName := "delegate-" + prep.id[:8]
+	loopName := "delegate-" + promptfmt.ShortIDPrefix(prep.id)
 	loopMaxDuration := prep.maxDuration + 5*time.Second
 	if loopMaxDuration <= 0 {
 		loopMaxDuration = prep.maxDuration
@@ -671,7 +672,7 @@ func (e *Executor) prepareExecution(ctx context.Context, task, profileName, guid
 
 	delegateID, _ := uuid.NewV7()
 	did := delegateID.String()
-	conversationID := "delegate-" + did[:8]
+	conversationID := "delegate-" + promptfmt.ShortIDPrefix(did)
 
 	log := logging.Logger(ctx).With(
 		"subsystem", logging.SubsystemDelegate,

--- a/internal/state/attachments/tools.go
+++ b/internal/state/attachments/tools.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"time"
 	"unicode/utf8"
+
+	"github.com/nugget/thane-ai-agent/internal/model/promptfmt"
 )
 
 // maxToolResultBytes caps JSON tool output to prevent context flooding.
@@ -30,17 +32,17 @@ func NewTools(store *Store, analyzer *Analyzer) *Tools {
 // attachmentSummary is the JSON-serializable summary returned by list
 // and search operations.
 type attachmentSummary struct {
-	ID          string `json:"id"`
-	Name        string `json:"name,omitempty"`
-	ContentType string `json:"content_type"`
-	Size        int64  `json:"size"`
-	Channel     string `json:"channel,omitempty"`
-	Sender      string `json:"sender,omitempty"`
-	ReceivedAt  string `json:"received_at"`
-	Description string `json:"description,omitempty"`
+	ID            string `json:"id"`
+	Name          string `json:"name,omitempty"`
+	ContentType   string `json:"content_type"`
+	Size          int64  `json:"size"`
+	Channel       string `json:"channel,omitempty"`
+	Sender        string `json:"sender,omitempty"`
+	ReceivedDelta string `json:"received_delta"`
+	Description   string `json:"description,omitempty"`
 }
 
-func summarizeRecord(rec *Record) attachmentSummary {
+func summarizeRecord(rec *Record, now time.Time) attachmentSummary {
 	desc := rec.Description
 	// Truncate long descriptions in list view on rune boundaries
 	// to avoid splitting multi-byte UTF-8 characters.
@@ -49,14 +51,14 @@ func summarizeRecord(rec *Record) attachmentSummary {
 		desc = string(runes[:197]) + "..."
 	}
 	return attachmentSummary{
-		ID:          rec.ID,
-		Name:        rec.OriginalName,
-		ContentType: rec.ContentType,
-		Size:        rec.Size,
-		Channel:     rec.Channel,
-		Sender:      rec.Sender,
-		ReceivedAt:  rec.ReceivedAt.UTC().Format(time.RFC3339),
-		Description: desc,
+		ID:            rec.ID,
+		Name:          rec.OriginalName,
+		ContentType:   rec.ContentType,
+		Size:          rec.Size,
+		Channel:       rec.Channel,
+		Sender:        rec.Sender,
+		ReceivedDelta: promptfmt.FormatDeltaOnly(rec.ReceivedAt, now),
+		Description:   desc,
 	}
 }
 
@@ -103,9 +105,10 @@ func (t *Tools) List(ctx context.Context, args map[string]any) (string, error) {
 		return "No attachments found matching the given filters.", nil
 	}
 
+	now := time.Now()
 	summaries := make([]attachmentSummary, len(records))
 	for i, rec := range records {
-		summaries[i] = summarizeRecord(rec)
+		summaries[i] = summarizeRecord(rec, now)
 	}
 
 	data, err := json.Marshal(summaries)
@@ -206,9 +209,10 @@ func (t *Tools) Search(ctx context.Context, args map[string]any) (string, error)
 		return "No attachments found matching the query.", nil
 	}
 
+	now := time.Now()
 	summaries := make([]attachmentSummary, len(records))
 	for i, rec := range records {
-		summaries[i] = summarizeRecord(rec)
+		summaries[i] = summarizeRecord(rec, now)
 	}
 
 	data, err := json.Marshal(summaries)

--- a/internal/state/attachments/tools_test.go
+++ b/internal/state/attachments/tools_test.go
@@ -153,6 +153,9 @@ func TestToolsList_Basic(t *testing.T) {
 	if summaries[0].Name != "photo.jpg" {
 		t.Errorf("name = %q, want photo.jpg", summaries[0].Name)
 	}
+	if summaries[0].ReceivedDelta == "" {
+		t.Error("expected received_delta")
+	}
 }
 
 func TestToolsList_Empty(t *testing.T) {
@@ -298,6 +301,9 @@ func TestToolsSearch_Basic(t *testing.T) {
 	}
 	if summaries[0].Name != "landscape.jpg" {
 		t.Errorf("name = %q, want landscape.jpg", summaries[0].Name)
+	}
+	if summaries[0].ReceivedDelta == "" {
+		t.Error("expected received_delta")
 	}
 }
 

--- a/internal/state/awareness/watchlist_tool_provider.go
+++ b/internal/state/awareness/watchlist_tool_provider.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/nugget/thane-ai-agent/internal/model/promptfmt"
 	"github.com/nugget/thane-ai-agent/internal/tools"
 )
 
@@ -205,6 +206,7 @@ func (w *WatchlistTools) handleListContextEntities(_ context.Context, args map[s
 		return "", fmt.Errorf("list watchlist subscriptions: %w", err)
 	}
 
+	now := time.Now()
 	items := make([]map[string]any, 0, len(subs))
 	for _, sub := range subs {
 		if entityID != "" && sub.EntityID != entityID {
@@ -219,7 +221,7 @@ func (w *WatchlistTools) handleListContextEntities(_ context.Context, args map[s
 			item["history"] = append([]int(nil), sub.History...)
 		}
 		if sub.ExpiresAt != nil {
-			item["expires_at"] = sub.ExpiresAt.Format(time.RFC3339)
+			item["expires_delta"] = promptfmt.FormatDeltaOnly(*sub.ExpiresAt, now)
 		}
 		items = append(items, item)
 	}

--- a/internal/state/awareness/watchlist_tool_provider_test.go
+++ b/internal/state/awareness/watchlist_tool_provider_test.go
@@ -180,7 +180,7 @@ func TestListContextEntities_ReturnsScopedSubscriptions(t *testing.T) {
 			EntityID      string `json:"entity_id"`
 			Scope         string `json:"scope"`
 			AlwaysVisible bool   `json:"always_visible"`
-			ExpiresAt     string `json:"expires_at"`
+			ExpiresDelta  string `json:"expires_delta"`
 		} `json:"items"`
 	}
 	if err := json.Unmarshal([]byte(raw), &payload); err != nil {
@@ -195,8 +195,8 @@ func TestListContextEntities_ReturnsScopedSubscriptions(t *testing.T) {
 	if payload.Items[0].AlwaysVisible {
 		t.Fatal("tagged subscription should not be always visible")
 	}
-	if payload.Items[0].ExpiresAt == "" {
-		t.Fatal("expected expires_at in payload")
+	if payload.Items[0].ExpiresDelta == "" {
+		t.Fatal("expected expires_delta in payload")
 	}
 }
 

--- a/internal/state/contacts/tools.go
+++ b/internal/state/contacts/tools.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/emersion/go-vcard"
 	"github.com/google/uuid"
+	"github.com/nugget/thane-ai-agent/internal/model/promptfmt"
 )
 
 // EmbeddingClient generates embeddings for semantic search.
@@ -1026,7 +1027,7 @@ func (t *Tools) formatOwnerActivitySummary() string {
 		ConversationID string `json:"conversation_id,omitempty"`
 		ContactName    string `json:"contact_name,omitempty"`
 		State          string `json:"state,omitempty"`
-		LastActive     string `json:"last_active,omitempty"`
+		LastActive     string `json:"last_active_delta,omitempty"`
 	}
 	payload := struct {
 		ActiveOwnerChannels []activityView `json:"active_owner_channels"`
@@ -1034,7 +1035,7 @@ func (t *Tools) formatOwnerActivitySummary() string {
 		Total               int            `json:"total"`
 		Displayed           int            `json:"displayed,omitempty"`
 		Omitted             int            `json:"omitted,omitempty"`
-		MostRecentActive    string         `json:"most_recent_active,omitempty"`
+		MostRecentActive    string         `json:"most_recent_active_delta,omitempty"`
 	}{
 		ActiveOwnerChannels: make([]activityView, 0, min(len(channels), ownerActivitySummaryLimit)),
 		ByChannel:           make(map[string]int),
@@ -1051,6 +1052,7 @@ func (t *Tools) formatOwnerActivitySummary() string {
 	}
 	payload.Displayed = len(visible)
 
+	now := time.Now()
 	for _, ch := range visible {
 		view := activityView{
 			Channel:        ch.Channel,
@@ -1061,7 +1063,7 @@ func (t *Tools) formatOwnerActivitySummary() string {
 			State:          ch.State,
 		}
 		if !ch.LastActive.IsZero() {
-			view.LastActive = ch.LastActive.UTC().Format(time.RFC3339)
+			view.LastActive = promptfmt.FormatDeltaOnly(ch.LastActive, now)
 			if payload.MostRecentActive == "" {
 				payload.MostRecentActive = view.LastActive
 			}

--- a/internal/state/contacts/tools_test.go
+++ b/internal/state/contacts/tools_test.go
@@ -995,6 +995,9 @@ func TestOwnerContact_IncludesActiveOwnerChannels(t *testing.T) {
 	if !strings.Contains(result, "\"owu\"") || !strings.Contains(result, "\"signal\"") {
 		t.Fatalf("OwnerContact() = %q, want both owner channels", result)
 	}
+	if !strings.Contains(result, "last_active_delta") || strings.Contains(result, "last_active\"") {
+		t.Fatalf("OwnerContact() = %q, want delta-oriented owner channel activity", result)
+	}
 }
 
 func TestOwnerContact_AmbiguousAdminRequiresConfig(t *testing.T) {

--- a/internal/state/documents/intake_tools.go
+++ b/internal/state/documents/intake_tools.go
@@ -144,13 +144,13 @@ func (t *Tools) Commit(ctx context.Context, args CommitArgs) (string, error) {
 		return "", err
 	}
 	t.forgetIntake(args.IntakeID)
-	return marshalToolResult(CommitResult{
+	return marshalToolResult(toModelCommitResult(CommitResult{
 		IntakeID: args.IntakeID,
 		Action:   action,
 		Ref:      ref,
 		Status:   status,
 		Result:   out,
-	})
+	}, nowUTC()))
 }
 
 func (t *Tools) rememberIntake(result *IntakeResult) {

--- a/internal/state/documents/model_tool_mutation_results.go
+++ b/internal/state/documents/model_tool_mutation_results.go
@@ -1,0 +1,249 @@
+package documents
+
+import "time"
+
+type modelMutationResult struct {
+	Action        string   `json:"action"`
+	Ref           string   `json:"ref"`
+	Root          string   `json:"root"`
+	Path          string   `json:"path"`
+	Existed       bool     `json:"existed"`
+	Title         string   `json:"title"`
+	Description   string   `json:"description,omitempty"`
+	Tags          []string `json:"tags,omitempty"`
+	CreatedDelta  string   `json:"created_delta,omitempty"`
+	UpdatedDelta  string   `json:"updated_delta,omitempty"`
+	ModifiedDelta string   `json:"modified_delta,omitempty"`
+	WordCount     int      `json:"word_count"`
+	SizeBytes     int64    `json:"size_bytes"`
+	Section       string   `json:"section,omitempty"`
+	Window        string   `json:"window,omitempty"`
+}
+
+type modelDeleteResult struct {
+	Action        string   `json:"action"`
+	DeletedRef    string   `json:"deleted_ref"`
+	Root          string   `json:"root"`
+	Path          string   `json:"path"`
+	Title         string   `json:"title"`
+	Description   string   `json:"description,omitempty"`
+	Tags          []string `json:"tags,omitempty"`
+	CreatedDelta  string   `json:"created_delta,omitempty"`
+	UpdatedDelta  string   `json:"updated_delta,omitempty"`
+	ModifiedDelta string   `json:"modified_delta,omitempty"`
+	WordCount     int      `json:"word_count"`
+	SizeBytes     int64    `json:"size_bytes"`
+}
+
+type modelMoveResult struct {
+	Action        string   `json:"action"`
+	FromRef       string   `json:"from_ref"`
+	ToRef         string   `json:"to_ref"`
+	FromRoot      string   `json:"from_root"`
+	FromPath      string   `json:"from_path"`
+	ToRoot        string   `json:"to_root"`
+	ToPath        string   `json:"to_path"`
+	Overwrote     bool     `json:"overwrote,omitempty"`
+	Title         string   `json:"title"`
+	Description   string   `json:"description,omitempty"`
+	Tags          []string `json:"tags,omitempty"`
+	CreatedDelta  string   `json:"created_delta,omitempty"`
+	UpdatedDelta  string   `json:"updated_delta,omitempty"`
+	ModifiedDelta string   `json:"modified_delta,omitempty"`
+	WordCount     int      `json:"word_count"`
+	SizeBytes     int64    `json:"size_bytes"`
+}
+
+type modelCopyResult struct {
+	Action        string   `json:"action"`
+	FromRef       string   `json:"from_ref"`
+	ToRef         string   `json:"to_ref"`
+	FromRoot      string   `json:"from_root"`
+	FromPath      string   `json:"from_path"`
+	ToRoot        string   `json:"to_root"`
+	ToPath        string   `json:"to_path"`
+	Overwrote     bool     `json:"overwrote,omitempty"`
+	Title         string   `json:"title"`
+	Description   string   `json:"description,omitempty"`
+	Tags          []string `json:"tags,omitempty"`
+	CreatedDelta  string   `json:"created_delta,omitempty"`
+	UpdatedDelta  string   `json:"updated_delta,omitempty"`
+	ModifiedDelta string   `json:"modified_delta,omitempty"`
+	WordCount     int      `json:"word_count"`
+	SizeBytes     int64    `json:"size_bytes"`
+}
+
+type modelSectionTransferResult struct {
+	Action             string   `json:"action"`
+	SourceRef          string   `json:"source_ref"`
+	SourceRoot         string   `json:"source_root"`
+	SourcePath         string   `json:"source_path"`
+	SourceSection      string   `json:"source_section"`
+	DestinationRef     string   `json:"destination_ref"`
+	DestinationRoot    string   `json:"destination_root"`
+	DestinationPath    string   `json:"destination_path"`
+	DestinationSection string   `json:"destination_section"`
+	DestinationLevel   int      `json:"destination_level"`
+	DestinationExisted bool     `json:"destination_existed"`
+	Title              string   `json:"title"`
+	Description        string   `json:"description,omitempty"`
+	Tags               []string `json:"tags,omitempty"`
+	CreatedDelta       string   `json:"created_delta,omitempty"`
+	UpdatedDelta       string   `json:"updated_delta,omitempty"`
+	ModifiedDelta      string   `json:"modified_delta,omitempty"`
+	WordCount          int      `json:"word_count"`
+	SizeBytes          int64    `json:"size_bytes"`
+}
+
+type modelCommitResult struct {
+	IntakeID string       `json:"intake_id"`
+	Action   IntakeAction `json:"action"`
+	Ref      string       `json:"ref,omitempty"`
+	Status   string       `json:"status"`
+	Result   any          `json:"result,omitempty"`
+}
+
+func toModelMutationResult(result *MutationResult, now time.Time) *modelMutationResult {
+	if result == nil {
+		return nil
+	}
+	return &modelMutationResult{
+		Action:        result.Action,
+		Ref:           result.Ref,
+		Root:          result.Root,
+		Path:          result.Path,
+		Existed:       result.Existed,
+		Title:         result.Title,
+		Description:   result.Description,
+		Tags:          append([]string(nil), result.Tags...),
+		CreatedDelta:  modelDelta(result.CreatedAt, now),
+		UpdatedDelta:  modelDelta(result.UpdatedAt, now),
+		ModifiedDelta: modelDelta(result.ModifiedAt, now),
+		WordCount:     result.WordCount,
+		SizeBytes:     result.SizeBytes,
+		Section:       result.Section,
+		Window:        result.Window,
+	}
+}
+
+func toModelDeleteResult(result *DeleteResult, now time.Time) *modelDeleteResult {
+	if result == nil {
+		return nil
+	}
+	return &modelDeleteResult{
+		Action:        result.Action,
+		DeletedRef:    result.DeletedRef,
+		Root:          result.Root,
+		Path:          result.Path,
+		Title:         result.Title,
+		Description:   result.Description,
+		Tags:          append([]string(nil), result.Tags...),
+		CreatedDelta:  modelDelta(result.CreatedAt, now),
+		UpdatedDelta:  modelDelta(result.UpdatedAt, now),
+		ModifiedDelta: modelDelta(result.ModifiedAt, now),
+		WordCount:     result.WordCount,
+		SizeBytes:     result.SizeBytes,
+	}
+}
+
+func toModelMoveResult(result *MoveResult, now time.Time) *modelMoveResult {
+	if result == nil {
+		return nil
+	}
+	return &modelMoveResult{
+		Action:        result.Action,
+		FromRef:       result.FromRef,
+		ToRef:         result.ToRef,
+		FromRoot:      result.FromRoot,
+		FromPath:      result.FromPath,
+		ToRoot:        result.ToRoot,
+		ToPath:        result.ToPath,
+		Overwrote:     result.Overwrote,
+		Title:         result.Title,
+		Description:   result.Description,
+		Tags:          append([]string(nil), result.Tags...),
+		CreatedDelta:  modelDelta(result.CreatedAt, now),
+		UpdatedDelta:  modelDelta(result.UpdatedAt, now),
+		ModifiedDelta: modelDelta(result.ModifiedAt, now),
+		WordCount:     result.WordCount,
+		SizeBytes:     result.SizeBytes,
+	}
+}
+
+func toModelCopyResult(result *CopyResult, now time.Time) *modelCopyResult {
+	if result == nil {
+		return nil
+	}
+	return &modelCopyResult{
+		Action:        result.Action,
+		FromRef:       result.FromRef,
+		ToRef:         result.ToRef,
+		FromRoot:      result.FromRoot,
+		FromPath:      result.FromPath,
+		ToRoot:        result.ToRoot,
+		ToPath:        result.ToPath,
+		Overwrote:     result.Overwrote,
+		Title:         result.Title,
+		Description:   result.Description,
+		Tags:          append([]string(nil), result.Tags...),
+		CreatedDelta:  modelDelta(result.CreatedAt, now),
+		UpdatedDelta:  modelDelta(result.UpdatedAt, now),
+		ModifiedDelta: modelDelta(result.ModifiedAt, now),
+		WordCount:     result.WordCount,
+		SizeBytes:     result.SizeBytes,
+	}
+}
+
+func toModelSectionTransferResult(result *SectionTransferResult, now time.Time) *modelSectionTransferResult {
+	if result == nil {
+		return nil
+	}
+	return &modelSectionTransferResult{
+		Action:             result.Action,
+		SourceRef:          result.SourceRef,
+		SourceRoot:         result.SourceRoot,
+		SourcePath:         result.SourcePath,
+		SourceSection:      result.SourceSection,
+		DestinationRef:     result.DestinationRef,
+		DestinationRoot:    result.DestinationRoot,
+		DestinationPath:    result.DestinationPath,
+		DestinationSection: result.DestinationSection,
+		DestinationLevel:   result.DestinationLevel,
+		DestinationExisted: result.DestinationExisted,
+		Title:              result.Title,
+		Description:        result.Description,
+		Tags:               append([]string(nil), result.Tags...),
+		CreatedDelta:       modelDelta(result.CreatedAt, now),
+		UpdatedDelta:       modelDelta(result.UpdatedAt, now),
+		ModifiedDelta:      modelDelta(result.ModifiedAt, now),
+		WordCount:          result.WordCount,
+		SizeBytes:          result.SizeBytes,
+	}
+}
+
+func toModelCommitResult(result CommitResult, now time.Time) modelCommitResult {
+	return modelCommitResult{
+		IntakeID: result.IntakeID,
+		Action:   result.Action,
+		Ref:      result.Ref,
+		Status:   result.Status,
+		Result:   modelCommitPayload(result.Result, now),
+	}
+}
+
+func modelCommitPayload(v any, now time.Time) any {
+	switch typed := v.(type) {
+	case *MutationResult:
+		return toModelMutationResult(typed, now)
+	case *DeleteResult:
+		return toModelDeleteResult(typed, now)
+	case *MoveResult:
+		return toModelMoveResult(typed, now)
+	case *CopyResult:
+		return toModelCopyResult(typed, now)
+	case *SectionTransferResult:
+		return toModelSectionTransferResult(typed, now)
+	default:
+		return v
+	}
+}

--- a/internal/state/documents/model_tool_results.go
+++ b/internal/state/documents/model_tool_results.go
@@ -276,7 +276,7 @@ func modelDeltaValueCounts(values []ValueCount, now time.Time) []ValueCount {
 	for _, value := range values {
 		delta := modelDelta(value.Value, now)
 		if delta == "" {
-			delta = "unparseable_timestamp"
+			continue
 		}
 		counts[delta] += value.Count
 	}
@@ -294,9 +294,12 @@ func modelFrontmatter(frontmatter map[string][]string, now time.Time) map[string
 			for _, value := range values {
 				delta := modelDelta(value, now)
 				if delta == "" {
-					delta = "unparseable_timestamp"
+					continue
 				}
 				deltas = append(deltas, delta)
+			}
+			if len(deltas) == 0 {
+				continue
 			}
 			out[deltaKey] = deltas
 			continue

--- a/internal/state/documents/model_tool_results.go
+++ b/internal/state/documents/model_tool_results.go
@@ -1,0 +1,357 @@
+package documents
+
+import (
+	"strings"
+	"time"
+
+	"github.com/nugget/thane-ai-agent/internal/model/promptfmt"
+	"github.com/nugget/thane-ai-agent/internal/platform/database"
+)
+
+type modelRootSummary struct {
+	Root              string                      `json:"root"`
+	Policy            RootPolicySummary           `json:"policy"`
+	Verification      *modelSignatureVerification `json:"verification,omitempty"`
+	DocumentCount     int                         `json:"document_count"`
+	TotalSizeBytes    int64                       `json:"total_size_bytes"`
+	TotalWordCount    int                         `json:"total_word_count"`
+	LastModifiedDelta string                      `json:"last_modified_delta,omitempty"`
+	TopTags           []string                    `json:"top_tags,omitempty"`
+	TopDirectories    []BrowseDirectory           `json:"top_directories,omitempty"`
+	RecentDocuments   []modelRootDocumentHint     `json:"recent_documents,omitempty"`
+}
+
+type modelSignatureVerification struct {
+	Status       SignatureStatus  `json:"status"`
+	Mode         VerificationMode `json:"mode,omitempty"`
+	Commit       string           `json:"commit,omitempty"`
+	Message      string           `json:"message,omitempty"`
+	CheckedDelta string           `json:"checked_delta,omitempty"`
+	Consumer     string           `json:"consumer,omitempty"`
+}
+
+type modelRootDocumentHint struct {
+	Ref           string `json:"ref"`
+	Path          string `json:"path"`
+	Title         string `json:"title"`
+	ModifiedDelta string `json:"modified_delta,omitempty"`
+}
+
+type modelDocumentSummary struct {
+	Root          string              `json:"root"`
+	Ref           string              `json:"ref"`
+	Path          string              `json:"path"`
+	Title         string              `json:"title"`
+	Summary       string              `json:"summary,omitempty"`
+	Tags          []string            `json:"tags,omitempty"`
+	Frontmatter   map[string][]string `json:"frontmatter,omitempty"`
+	ModifiedDelta string              `json:"modified_delta,omitempty"`
+	WordCount     int                 `json:"word_count"`
+}
+
+type modelSearchResult struct {
+	Filters modelSearchFilters     `json:"filters"`
+	Results []modelDocumentSummary `json:"results,omitempty"`
+}
+
+type modelSearchFilters struct {
+	Root                string              `json:"root,omitempty"`
+	PathPrefix          string              `json:"path_prefix,omitempty"`
+	Query               string              `json:"query,omitempty"`
+	Tags                []string            `json:"tags,omitempty"`
+	Frontmatter         map[string][]string `json:"frontmatter,omitempty"`
+	FrontmatterKeys     []string            `json:"frontmatter_keys,omitempty"`
+	ModifiedAfterDelta  string              `json:"modified_after_delta,omitempty"`
+	ModifiedBeforeDelta string              `json:"modified_before_delta,omitempty"`
+	Limit               int                 `json:"limit"`
+}
+
+type modelBrowseResult struct {
+	Root        string                 `json:"root"`
+	PathPrefix  string                 `json:"path_prefix,omitempty"`
+	Directories []BrowseDirectory      `json:"directories,omitempty"`
+	Documents   []modelDocumentSummary `json:"documents,omitempty"`
+}
+
+type modelDocumentRecord struct {
+	Root          string              `json:"root"`
+	Ref           string              `json:"ref"`
+	Path          string              `json:"path"`
+	Title         string              `json:"title"`
+	Description   string              `json:"description,omitempty"`
+	Tags          []string            `json:"tags,omitempty"`
+	Frontmatter   map[string][]string `json:"frontmatter,omitempty"`
+	Body          string              `json:"body"`
+	Outline       []Section           `json:"outline,omitempty"`
+	ModifiedDelta string              `json:"modified_delta,omitempty"`
+	WordCount     int                 `json:"word_count"`
+	SizeBytes     int64               `json:"size_bytes"`
+}
+
+type modelBacklink struct {
+	Ref              string   `json:"ref"`
+	Path             string   `json:"path"`
+	Title            string   `json:"title"`
+	ModifiedDelta    string   `json:"modified_delta,omitempty"`
+	Targets          []string `json:"targets,omitempty"`
+	TargetsTruncated bool     `json:"targets_truncated,omitempty"`
+}
+
+type modelLinksResult struct {
+	Ref                string          `json:"ref"`
+	Mode               string          `json:"mode"`
+	Limit              int             `json:"limit,omitempty"`
+	PerBacklinkLimit   int             `json:"per_backlink_limit,omitempty"`
+	Outgoing           []DocumentLink  `json:"outgoing,omitempty"`
+	OutgoingTruncated  bool            `json:"outgoing_truncated,omitempty"`
+	Backlinks          []modelBacklink `json:"backlinks,omitempty"`
+	BacklinksTruncated bool            `json:"backlinks_truncated,omitempty"`
+}
+
+type modelValuesResult struct {
+	Root   string       `json:"root,omitempty"`
+	Key    string       `json:"key"`
+	Values []ValueCount `json:"values,omitempty"`
+}
+
+func modelRootSummaries(roots []RootSummary, now time.Time) []modelRootSummary {
+	out := make([]modelRootSummary, 0, len(roots))
+	for _, root := range roots {
+		out = append(out, modelRootSummary{
+			Root:              root.Root,
+			Policy:            root.Policy,
+			Verification:      modelVerification(root.Verification, now),
+			DocumentCount:     root.DocumentCount,
+			TotalSizeBytes:    root.TotalSizeBytes,
+			TotalWordCount:    root.TotalWordCount,
+			LastModifiedDelta: modelDelta(root.LastModifiedAt, now),
+			TopTags:           append([]string(nil), root.TopTags...),
+			TopDirectories:    append([]BrowseDirectory(nil), root.TopDirectories...),
+			RecentDocuments:   modelRootDocumentHints(root.RecentDocuments, now),
+		})
+	}
+	return out
+}
+
+func modelVerification(v *SignatureVerification, now time.Time) *modelSignatureVerification {
+	if v == nil {
+		return nil
+	}
+	return &modelSignatureVerification{
+		Status:       v.Status,
+		Mode:         v.Mode,
+		Commit:       v.Commit,
+		Message:      v.Message,
+		CheckedDelta: modelDelta(v.CheckedAt, now),
+		Consumer:     v.Consumer,
+	}
+}
+
+func modelRootDocumentHints(docs []RootDocumentHint, now time.Time) []modelRootDocumentHint {
+	out := make([]modelRootDocumentHint, 0, len(docs))
+	for _, doc := range docs {
+		out = append(out, modelRootDocumentHint{
+			Ref:           doc.Ref,
+			Path:          doc.Path,
+			Title:         doc.Title,
+			ModifiedDelta: modelDelta(doc.ModifiedAt, now),
+		})
+	}
+	return out
+}
+
+func modelDocumentSummaries(docs []DocumentSummary, now time.Time) []modelDocumentSummary {
+	out := make([]modelDocumentSummary, 0, len(docs))
+	for _, doc := range docs {
+		out = append(out, toModelDocumentSummary(doc, now))
+	}
+	return out
+}
+
+func toModelDocumentSummary(doc DocumentSummary, now time.Time) modelDocumentSummary {
+	return modelDocumentSummary{
+		Root:          doc.Root,
+		Ref:           doc.Ref,
+		Path:          doc.Path,
+		Title:         doc.Title,
+		Summary:       doc.Summary,
+		Tags:          append([]string(nil), doc.Tags...),
+		Frontmatter:   modelFrontmatter(doc.Frontmatter, now),
+		ModifiedDelta: modelDelta(doc.ModifiedAt, now),
+		WordCount:     doc.WordCount,
+	}
+}
+
+func toModelSearchResult(args SearchArgs, query SearchQuery, results []DocumentSummary, now time.Time) modelSearchResult {
+	return modelSearchResult{
+		Filters: modelSearchFilters{
+			Root:                query.Root,
+			PathPrefix:          query.PathPrefix,
+			Query:               query.Query,
+			Tags:                append([]string(nil), query.Tags...),
+			Frontmatter:         modelFrontmatter(query.Frontmatter, now),
+			FrontmatterKeys:     modelFrontmatterKeys(query.FrontmatterKeys),
+			ModifiedAfterDelta:  modelInputDelta(args.ModifiedAfter, now),
+			ModifiedBeforeDelta: modelInputDelta(args.ModifiedBefore, now),
+			Limit:               query.Limit,
+		},
+		Results: modelDocumentSummaries(results, now),
+	}
+}
+
+func toModelBrowseResult(result *BrowseResult, now time.Time) *modelBrowseResult {
+	if result == nil {
+		return nil
+	}
+	return &modelBrowseResult{
+		Root:        result.Root,
+		PathPrefix:  result.PathPrefix,
+		Directories: append([]BrowseDirectory(nil), result.Directories...),
+		Documents:   modelDocumentSummaries(result.Documents, now),
+	}
+}
+
+func toModelDocumentRecord(record *DocumentRecord, now time.Time) *modelDocumentRecord {
+	if record == nil {
+		return nil
+	}
+	return &modelDocumentRecord{
+		Root:          record.Root,
+		Ref:           record.Ref,
+		Path:          record.Path,
+		Title:         record.Title,
+		Description:   record.Description,
+		Tags:          append([]string(nil), record.Tags...),
+		Frontmatter:   modelFrontmatter(record.Frontmatter, now),
+		Body:          record.Body,
+		Outline:       append([]Section(nil), record.Outline...),
+		ModifiedDelta: modelDelta(record.ModifiedAt, now),
+		WordCount:     record.WordCount,
+		SizeBytes:     record.SizeBytes,
+	}
+}
+
+func toModelLinksResult(result *LinksResult, now time.Time) *modelLinksResult {
+	if result == nil {
+		return nil
+	}
+	backlinks := make([]modelBacklink, 0, len(result.Backlinks))
+	for _, backlink := range result.Backlinks {
+		backlinks = append(backlinks, modelBacklink{
+			Ref:              backlink.Ref,
+			Path:             backlink.Path,
+			Title:            backlink.Title,
+			ModifiedDelta:    modelDelta(backlink.ModifiedAt, now),
+			Targets:          append([]string(nil), backlink.Targets...),
+			TargetsTruncated: backlink.TargetsTruncated,
+		})
+	}
+	return &modelLinksResult{
+		Ref:                result.Ref,
+		Mode:               result.Mode,
+		Limit:              result.Limit,
+		PerBacklinkLimit:   result.PerBacklinkLimit,
+		Outgoing:           append([]DocumentLink(nil), result.Outgoing...),
+		OutgoingTruncated:  result.OutgoingTruncated,
+		Backlinks:          backlinks,
+		BacklinksTruncated: result.BacklinksTruncated,
+	}
+}
+
+func toModelValuesResult(root string, key string, values []ValueCount, now time.Time) modelValuesResult {
+	out := append([]ValueCount(nil), values...)
+	if deltaKey, ok := frontmatterDeltaFieldName(key); ok {
+		key = deltaKey
+		out = modelDeltaValueCounts(values, now)
+	}
+	return modelValuesResult{
+		Root:   root,
+		Key:    key,
+		Values: out,
+	}
+}
+
+func modelDeltaValueCounts(values []ValueCount, now time.Time) []ValueCount {
+	counts := make(map[string]int, len(values))
+	for _, value := range values {
+		delta := modelDelta(value.Value, now)
+		if delta == "" {
+			delta = "unparseable_timestamp"
+		}
+		counts[delta] += value.Count
+	}
+	return asValueCounts(counts)
+}
+
+func modelFrontmatter(frontmatter map[string][]string, now time.Time) map[string][]string {
+	if len(frontmatter) == 0 {
+		return nil
+	}
+	out := make(map[string][]string, len(frontmatter))
+	for key, values := range frontmatter {
+		if deltaKey, ok := frontmatterDeltaFieldName(key); ok {
+			deltas := make([]string, 0, len(values))
+			for _, value := range values {
+				delta := modelDelta(value, now)
+				if delta == "" {
+					delta = "unparseable_timestamp"
+				}
+				deltas = append(deltas, delta)
+			}
+			out[deltaKey] = deltas
+			continue
+		}
+		out[key] = append([]string(nil), values...)
+	}
+	return out
+}
+
+func frontmatterDeltaFieldName(key string) (string, bool) {
+	switch strings.ToLower(strings.TrimSpace(key)) {
+	case "created":
+		return "created_delta", true
+	case "updated":
+		return "updated_delta", true
+	case GeneratedFieldAt:
+		return "generated_delta", true
+	default:
+		return "", false
+	}
+}
+
+func modelFrontmatterKeys(keys []string) []string {
+	if len(keys) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(keys))
+	for _, key := range keys {
+		if deltaKey, ok := frontmatterDeltaFieldName(key); ok {
+			out = append(out, deltaKey)
+			continue
+		}
+		out = append(out, key)
+	}
+	return out
+}
+
+func modelInputDelta(value string, now time.Time) string {
+	if value == "" {
+		return ""
+	}
+	ts, err := promptfmt.ParseTimeOrDelta(value, now)
+	if err != nil {
+		return ""
+	}
+	return promptfmt.FormatDeltaOnly(ts, now)
+}
+
+func modelDelta(value string, now time.Time) string {
+	if value == "" {
+		return ""
+	}
+	ts, err := database.ParseTimestamp(value)
+	if err != nil {
+		return ""
+	}
+	return promptfmt.FormatDeltaOnly(ts, now)
+}

--- a/internal/state/documents/tools.go
+++ b/internal/state/documents/tools.go
@@ -97,7 +97,7 @@ func (t *Tools) Read(ctx context.Context, args RefArgs) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return marshalToolResult(doc)
+	return marshalToolResult(toModelDocumentRecord(doc, nowUTC()))
 }
 
 // Roots returns summaries of the indexed document roots.
@@ -109,8 +109,9 @@ func (t *Tools) Roots(ctx context.Context) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	now := nowUTC()
 	return marshalToolResult(map[string]any{
-		"roots": roots,
+		"roots": modelRootSummaries(roots, now),
 	})
 }
 
@@ -126,7 +127,7 @@ func (t *Tools) Browse(ctx context.Context, args BrowseArgs) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return marshalToolResult(result)
+	return marshalToolResult(toModelBrowseResult(result, nowUTC()))
 }
 
 // Search returns compact summaries for documents matching the structured filters.
@@ -165,20 +166,7 @@ func (t *Tools) Search(ctx context.Context, args SearchArgs) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return marshalToolResult(map[string]any{
-		"filters": map[string]any{
-			"root":             args.Root,
-			"path_prefix":      args.PathPrefix,
-			"query":            args.Query,
-			"tags":             args.Tags,
-			"frontmatter":      args.Frontmatter,
-			"frontmatter_keys": args.FrontmatterKeys,
-			"modified_after":   args.ModifiedAfter,
-			"modified_before":  args.ModifiedBefore,
-			"limit":            query.Limit,
-		},
-		"results": results,
-	})
+	return marshalToolResult(toModelSearchResult(args, query, results, now))
 }
 
 // Outline returns the heading tree for one indexed document.
@@ -226,11 +214,7 @@ func (t *Tools) Values(ctx context.Context, args ValuesArgs) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return marshalToolResult(map[string]any{
-		"root":   args.Root,
-		"key":    args.Key,
-		"values": values,
-	})
+	return marshalToolResult(toModelValuesResult(args.Root, args.Key, values, nowUTC()))
 }
 
 // Links returns outgoing links, backlinks, or both for one indexed document.
@@ -251,7 +235,7 @@ func (t *Tools) Links(ctx context.Context, args LinksArgs) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return marshalToolResult(links)
+	return marshalToolResult(toModelLinksResult(links, nowUTC()))
 }
 
 // Write creates or replaces one managed document.
@@ -266,7 +250,7 @@ func (t *Tools) Write(ctx context.Context, args WriteArgs) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return marshalToolResult(result)
+	return marshalToolResult(toModelMutationResult(result, nowUTC()))
 }
 
 // Edit applies one structured edit to a managed document.
@@ -281,7 +265,7 @@ func (t *Tools) Edit(ctx context.Context, args EditArgs) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return marshalToolResult(result)
+	return marshalToolResult(toModelMutationResult(result, nowUTC()))
 }
 
 // JournalUpdate appends one journal-window entry to a managed document.
@@ -296,7 +280,7 @@ func (t *Tools) JournalUpdate(ctx context.Context, args JournalUpdateArgs) (stri
 	if err != nil {
 		return "", err
 	}
-	return marshalToolResult(result)
+	return marshalToolResult(toModelMutationResult(result, nowUTC()))
 }
 
 // Delete removes one managed document.
@@ -311,7 +295,7 @@ func (t *Tools) Delete(ctx context.Context, args DeleteArgs) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return marshalToolResult(result)
+	return marshalToolResult(toModelDeleteResult(result, nowUTC()))
 }
 
 // Move relocates one managed document to a new semantic ref.
@@ -329,7 +313,7 @@ func (t *Tools) Move(ctx context.Context, args MoveArgs) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return marshalToolResult(result)
+	return marshalToolResult(toModelMoveResult(result, nowUTC()))
 }
 
 // Copy clones one managed document to a new semantic ref.
@@ -347,7 +331,7 @@ func (t *Tools) Copy(ctx context.Context, args CopyArgs) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return marshalToolResult(result)
+	return marshalToolResult(toModelCopyResult(result, nowUTC()))
 }
 
 // CopySection copies one section into another managed document.
@@ -368,7 +352,7 @@ func (t *Tools) CopySection(ctx context.Context, args SectionTransferArgs) (stri
 	if err != nil {
 		return "", err
 	}
-	return marshalToolResult(result)
+	return marshalToolResult(toModelSectionTransferResult(result, nowUTC()))
 }
 
 // MoveSection moves one section into another managed document.
@@ -389,7 +373,7 @@ func (t *Tools) MoveSection(ctx context.Context, args SectionTransferArgs) (stri
 	if err != nil {
 		return "", err
 	}
-	return marshalToolResult(result)
+	return marshalToolResult(toModelSectionTransferResult(result, nowUTC()))
 }
 
 func marshalToolResult(v any) (string, error) {

--- a/internal/state/documents/tools_test.go
+++ b/internal/state/documents/tools_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	_ "github.com/mattn/go-sqlite3"
 	"github.com/nugget/thane-ai-agent/internal/platform/database"
@@ -91,22 +92,138 @@ func TestDocumentToolsUseDeltaTimeFields(t *testing.T) {
 	}
 
 	for name, got := range outputs {
-		if strings.Contains(got, `"modified_at"`) ||
-			strings.Contains(got, `"last_modified_at"`) ||
-			strings.Contains(got, `"created_at"`) ||
-			strings.Contains(got, `"updated_at"`) ||
-			strings.Contains(got, `"checked_at"`) ||
-			strings.Contains(got, `"modified_after":`) ||
-			strings.Contains(got, `"modified_before":`) ||
-			strings.Contains(got, `"created":`) ||
-			strings.Contains(got, `"updated":`) ||
-			strings.Contains(got, `"generated_at":`) {
-			t.Fatalf("%s output exposes raw timestamp field: %s", name, got)
+		assertModelOutputDeltaContract(t, name, got)
+	}
+}
+
+func TestModelDeltaValueCountsSkipsUnparseableTimestamps(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 4, 29, 12, 0, 0, 0, time.UTC)
+	got := modelDeltaValueCounts([]ValueCount{
+		{Value: now.Add(-time.Hour).Format(time.RFC3339), Count: 2},
+		{Value: "not-a-timestamp", Count: 3},
+	}, now)
+
+	if len(got) != 1 {
+		t.Fatalf("modelDeltaValueCounts() = %#v, want one parsed delta", got)
+	}
+	if got[0].Value != "-3600s" || got[0].Count != 2 {
+		t.Fatalf("modelDeltaValueCounts()[0] = %#v, want -3600s count 2", got[0])
+	}
+}
+
+func TestModelFrontmatterSkipsUnparseableTimestampValues(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 4, 29, 12, 0, 0, 0, time.UTC)
+	got := modelFrontmatter(map[string][]string{
+		"created": {"not-a-timestamp"},
+		"updated": {now.Add(-2 * time.Hour).Format(time.RFC3339)},
+		"status":  {"open"},
+	}, now)
+
+	if _, ok := got["created_delta"]; ok {
+		t.Fatalf("modelFrontmatter() = %#v, should omit unparseable created_delta", got)
+	}
+	if values := got["updated_delta"]; len(values) != 1 || values[0] != "-7200s" {
+		t.Fatalf("updated_delta = %#v, want [-7200s]", values)
+	}
+	if values := got["status"]; len(values) != 1 || values[0] != "open" {
+		t.Fatalf("status = %#v, want [open]", values)
+	}
+}
+
+func assertModelOutputDeltaContract(t *testing.T, name, got string) {
+	t.Helper()
+
+	var payload any
+	if err := json.Unmarshal([]byte(got), &payload); err != nil {
+		t.Fatalf("%s output is not JSON: %v\n%s", name, err, got)
+	}
+
+	forbidden := map[string]struct{}{
+		"modified_at":      {},
+		"last_modified_at": {},
+		"created_at":       {},
+		"updated_at":       {},
+		"checked_at":       {},
+		"modified_after":   {},
+		"modified_before":  {},
+		"created":          {},
+		"updated":          {},
+		GeneratedFieldAt:   {},
+	}
+	if key, ok := firstForbiddenJSONKey(payload, forbidden); ok {
+		t.Fatalf("%s output exposes raw timestamp key %q: %s", name, key, got)
+	}
+	if !hasModelDeltaSignal(payload) {
+		t.Fatalf("%s output = %s, want at least one model-facing delta field", name, got)
+	}
+}
+
+func firstForbiddenJSONKey(value any, forbidden map[string]struct{}) (string, bool) {
+	switch typed := value.(type) {
+	case map[string]any:
+		for key, child := range typed {
+			if _, ok := forbidden[key]; ok {
+				return key, true
+			}
+			if found, ok := firstForbiddenJSONKey(child, forbidden); ok {
+				return found, true
+			}
 		}
-		if !strings.Contains(got, `_delta"`) {
-			t.Fatalf("%s output = %s, want at least one delta time field", name, got)
+	case []any:
+		for _, child := range typed {
+			if found, ok := firstForbiddenJSONKey(child, forbidden); ok {
+				return found, true
+			}
 		}
 	}
+	return "", false
+}
+
+func hasModelDeltaSignal(value any) bool {
+	switch typed := value.(type) {
+	case map[string]any:
+		for key, child := range typed {
+			if strings.HasSuffix(key, "_delta") {
+				return true
+			}
+			if key == "key" {
+				if text, ok := child.(string); ok && strings.HasSuffix(text, "_delta") {
+					return true
+				}
+			}
+			if key == "frontmatter_keys" && stringSliceHasDeltaSignal(child) {
+				return true
+			}
+			if hasModelDeltaSignal(child) {
+				return true
+			}
+		}
+	case []any:
+		for _, child := range typed {
+			if hasModelDeltaSignal(child) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func stringSliceHasDeltaSignal(value any) bool {
+	items, ok := value.([]any)
+	if !ok {
+		return false
+	}
+	for _, item := range items {
+		text, ok := item.(string)
+		if ok && strings.HasSuffix(text, "_delta") {
+			return true
+		}
+	}
+	return false
 }
 
 func TestToolsSectionFailsWhenResultTooLarge(t *testing.T) {

--- a/internal/state/documents/tools_test.go
+++ b/internal/state/documents/tools_test.go
@@ -32,9 +32,79 @@ func TestToolsRootsOmitAbsolutePath(t *testing.T) {
 	if _, ok := payload.Roots[0]["path"]; ok {
 		t.Fatalf("Roots() leaked root filesystem path: %s", got)
 	}
-	for _, want := range []string{`"total_size_bytes"`, `"last_modified_at"`, `"top_directories"`, `"recent_documents"`} {
+	for _, want := range []string{`"total_size_bytes"`, `"last_modified_delta"`, `"top_directories"`, `"recent_documents"`} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("Roots() = %s, want field %s", got, want)
+		}
+	}
+	for _, rawTimeField := range []string{`"last_modified_at"`, `"modified_at"`} {
+		if strings.Contains(got, rawTimeField) {
+			t.Fatalf("Roots() = %s, should not expose raw timestamp field %s", got, rawTimeField)
+		}
+	}
+}
+
+func TestDocumentToolsUseDeltaTimeFields(t *testing.T) {
+	t.Parallel()
+
+	tools := newDocumentToolsTestFixture(t)
+	ctx := context.Background()
+
+	outputs := map[string]string{}
+	var err error
+	outputs["roots"], err = tools.Roots(ctx)
+	if err != nil {
+		t.Fatalf("Roots: %v", err)
+	}
+	outputs["browse"], err = tools.Browse(ctx, BrowseArgs{Root: "kb"})
+	if err != nil {
+		t.Fatalf("Browse: %v", err)
+	}
+	outputs["search"], err = tools.Search(ctx, SearchArgs{
+		Root:            "kb",
+		Query:           "note",
+		FrontmatterKeys: []string{"created"},
+		ModifiedAfter:   "-3600s",
+	})
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	outputs["read"], err = tools.Read(ctx, RefArgs{Ref: "kb:note.md"})
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	outputs["write"], err = tools.Write(ctx, WriteArgs{
+		Ref:   "kb:written.md",
+		Title: "Written",
+		Body:  stringPtr("# Written\n\nBody."),
+	})
+	if err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	outputs["read_written"], err = tools.Read(ctx, RefArgs{Ref: "kb:written.md"})
+	if err != nil {
+		t.Fatalf("Read written: %v", err)
+	}
+	outputs["values_created"], err = tools.Values(ctx, ValuesArgs{Root: "kb", Key: "created"})
+	if err != nil {
+		t.Fatalf("Values created: %v", err)
+	}
+
+	for name, got := range outputs {
+		if strings.Contains(got, `"modified_at"`) ||
+			strings.Contains(got, `"last_modified_at"`) ||
+			strings.Contains(got, `"created_at"`) ||
+			strings.Contains(got, `"updated_at"`) ||
+			strings.Contains(got, `"checked_at"`) ||
+			strings.Contains(got, `"modified_after":`) ||
+			strings.Contains(got, `"modified_before":`) ||
+			strings.Contains(got, `"created":`) ||
+			strings.Contains(got, `"updated":`) ||
+			strings.Contains(got, `"generated_at":`) {
+			t.Fatalf("%s output exposes raw timestamp field: %s", name, got)
+		}
+		if !strings.Contains(got, `_delta"`) {
+			t.Fatalf("%s output = %s, want at least one delta time field", name, got)
 		}
 	}
 }

--- a/internal/state/memory/archive.go
+++ b/internal/state/memory/archive.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/nugget/thane-ai-agent/internal/model/promptfmt"
 	"github.com/nugget/thane-ai-agent/internal/platform/database"
 )
 
@@ -2573,10 +2574,7 @@ func (s *ArchiveStore) PurgeImported(sourceType string) (int, error) {
 // ShortID safely truncates an ID to 8 characters for display.
 // Returns the full string if shorter than 8 characters.
 func ShortID(id string) string {
-	if len(id) <= 8 {
-		return id
-	}
-	return id[:8]
+	return promptfmt.ShortIDPrefix(id)
 }
 
 func nullString(s string) any {

--- a/internal/state/memory/archive_provider.go
+++ b/internal/state/memory/archive_provider.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/nugget/thane-ai-agent/internal/model/promptfmt"
 	"github.com/nugget/thane-ai-agent/internal/runtime/agentctx"
 	"github.com/nugget/thane-ai-agent/internal/state/knowledge"
 )
@@ -219,10 +220,7 @@ func formatResultBlock(r SearchResult) string {
 	var sb strings.Builder
 
 	// Header: date and session ID prefix.
-	sessionShort := r.SessionID
-	if len(sessionShort) > 8 {
-		sessionShort = sessionShort[:8]
-	}
+	sessionShort := promptfmt.ShortIDPrefix(r.SessionID)
 	date := r.Match.Timestamp.Format(time.DateOnly)
 	sb.WriteString(fmt.Sprintf("**%s — Session %s:**\n", date, sessionShort))
 

--- a/internal/state/memory/working_provider.go
+++ b/internal/state/memory/working_provider.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/nugget/thane-ai-agent/internal/model/promptfmt"
 	"github.com/nugget/thane-ai-agent/internal/runtime/agentctx"
 )
 
@@ -50,7 +51,7 @@ func (p *WorkingMemoryProvider) TagContext(ctx context.Context, _ agentctx.Conte
 	var sb strings.Builder
 	sb.WriteString("### Working Memory\n\n")
 	if !updatedAt.IsZero() {
-		sb.WriteString(fmt.Sprintf("*Last updated: %s*\n\n", updatedAt.Format(time.RFC3339)))
+		sb.WriteString(fmt.Sprintf("*Last updated: %s*\n\n", promptfmt.FormatDeltaOnly(updatedAt, time.Now())))
 	}
 	sb.WriteString(content)
 

--- a/internal/tools/document_tools.go
+++ b/internal/tools/document_tools.go
@@ -45,7 +45,7 @@ func RegisterDocumentTools(r *Registry, dt *documents.Tools) {
 
 	r.Register(&Tool{
 		Name:        "doc_roots",
-		Description: "List indexed markdown roots with helpful corpus summaries such as document counts, total size, last modification, top tags, top directories, and recent example documents. Use first when the answer probably lives in a managed document corpus but you do not yet know which root to browse.",
+		Description: "List indexed markdown roots with helpful corpus summaries such as document counts, total size, last modification delta, top tags, top directories, and recent example documents. Use first when the answer probably lives in a managed document corpus but you do not yet know which root to browse.",
 		Parameters: map[string]any{
 			"type":       "object",
 			"properties": map[string]any{},
@@ -93,7 +93,7 @@ func RegisterDocumentTools(r *Registry, dt *documents.Tools) {
 
 	r.Register(&Tool{
 		Name:        "doc_search",
-		Description: "Search indexed markdown documents by root, path prefix, query text, tags, frontmatter filters, and modified-time bounds. Returns compact document summaries with canonical refs like `kb:article.md`, not full bodies.",
+		Description: "Search indexed markdown documents by root, path prefix, query text, tags, frontmatter filters, and modified-time bounds. Returns compact document summaries with canonical refs and modified-time deltas like `kb:article.md`, not full bodies.",
 		Parameters: map[string]any{
 			"type": "object",
 			"properties": map[string]any{
@@ -273,7 +273,7 @@ func RegisterDocumentTools(r *Registry, dt *documents.Tools) {
 
 	r.Register(&Tool{
 		Name:        "doc_values",
-		Description: "List observed values for one frontmatter key across indexed roots, especially keys like `tags`, `status`, or `area`. Use this to discover the corpus vocabulary before narrowing a search.",
+		Description: "List observed values for one frontmatter key across indexed roots, especially keys like `tags`, `status`, or `area`. Timestamp-valued keys are returned as deltas. Use this to discover the corpus vocabulary before narrowing a search.",
 		Parameters: map[string]any{
 			"type": "object",
 			"properties": map[string]any{

--- a/internal/tools/document_tools.go
+++ b/internal/tools/document_tools.go
@@ -93,7 +93,7 @@ func RegisterDocumentTools(r *Registry, dt *documents.Tools) {
 
 	r.Register(&Tool{
 		Name:        "doc_search",
-		Description: "Search indexed markdown documents by root, path prefix, query text, tags, frontmatter filters, and modified-time bounds. Returns compact document summaries with canonical refs and modified-time deltas like `kb:article.md`, not full bodies.",
+		Description: "Search indexed markdown documents by root, path prefix, query text, tags, frontmatter filters, and modified-time bounds. Returns compact document summaries with canonical refs like `kb:article.md` and modified-time delta fields like `-3600s`, not full bodies.",
 		Parameters: map[string]any{
 			"type": "object",
 			"properties": map[string]any{

--- a/internal/tools/file_tools.go
+++ b/internal/tools/file_tools.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/nugget/thane-ai-agent/internal/model/promptfmt"
 	"github.com/nugget/thane-ai-agent/internal/platform/paths"
 )
 
@@ -635,6 +636,7 @@ func (ft *FileTools) Stat(ctx context.Context, paths string) (string, error) {
 	pathList := strings.Split(paths, ",")
 
 	var results []string
+	now := time.Now()
 	for _, p := range pathList {
 		p = strings.TrimSpace(p)
 		if p == "" {
@@ -665,8 +667,8 @@ func (ft *FileTools) Stat(ctx context.Context, paths string) (string, error) {
 		}
 
 		results = append(results, fmt.Sprintf(
-			"%s: type=%s size=%s permissions=%s modified=%s",
-			p, kind, humanSize(info.Size()), info.Mode().Perm(), info.ModTime().Format(time.RFC3339),
+			"%s: type=%s size=%s permissions=%s modified_delta=%s",
+			p, kind, humanSize(info.Size()), info.Mode().Perm(), promptfmt.FormatDeltaOnly(info.ModTime(), now),
 		))
 	}
 

--- a/internal/tools/file_tools_test.go
+++ b/internal/tools/file_tools_test.go
@@ -597,6 +597,9 @@ func TestFileTools_Stat(t *testing.T) {
 			if !strings.Contains(result, tt.wantMatch) {
 				t.Errorf("Stat() result missing %q:\n%s", tt.wantMatch, result)
 			}
+			if strings.Contains(result, "type=") && !strings.Contains(result, "modified_delta=") {
+				t.Errorf("Stat() result missing modified_delta:\n%s", result)
+			}
 		})
 	}
 

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -17,6 +17,7 @@ import (
 	"github.com/nugget/thane-ai-agent/internal/integrations/media"
 	"github.com/nugget/thane-ai-agent/internal/integrations/search"
 	"github.com/nugget/thane-ai-agent/internal/model/fleet"
+	"github.com/nugget/thane-ai-agent/internal/model/promptfmt"
 	routepkg "github.com/nugget/thane-ai-agent/internal/model/router"
 	"github.com/nugget/thane-ai-agent/internal/model/toolcatalog"
 	"github.com/nugget/thane-ai-agent/internal/platform/buildinfo"
@@ -1423,8 +1424,13 @@ func (r *Registry) handleScheduleTask(ctx context.Context, args map[string]any) 
 		return "", err
 	}
 
-	nextRun, _ := task.NextRun(time.Now())
-	return fmt.Sprintf("Task '%s' scheduled (ID: %s). Next run: %s", name, task.ID, nextRun.Format(time.RFC3339)), nil
+	now := time.Now()
+	nextRun, hasNext := task.NextRun(now)
+	next := "(none)"
+	if hasNext {
+		next = promptfmt.FormatDelta(nextRun, now)
+	}
+	return fmt.Sprintf("Task '%s' scheduled (ID: %s). Next run: %s", name, task.ID, next), nil
 }
 
 func (r *Registry) handleListTasks(ctx context.Context, args map[string]any) (string, error) {
@@ -1449,16 +1455,17 @@ func (r *Registry) handleListTasks(ctx context.Context, args map[string]any) (st
 	var result strings.Builder
 	result.WriteString(fmt.Sprintf("Found %d task(s):\n", len(tasks)))
 
+	now := time.Now()
 	for _, t := range tasks {
-		next, hasNext := t.NextRun(time.Now())
+		next, hasNext := t.NextRun(now)
 		status := "enabled"
 		if !t.Enabled {
 			status = "disabled"
 		}
 
-		result.WriteString(fmt.Sprintf("- %s (%s): %s", t.Name, t.ID[:8], status))
+		result.WriteString(fmt.Sprintf("- %s (%s): %s", t.Name, promptfmt.ShortIDPrefix(t.ID), status))
 		if hasNext {
-			result.WriteString(fmt.Sprintf(", next: %s", next.Format("2006-01-02 15:04")))
+			result.WriteString(fmt.Sprintf(", next: %s", promptfmt.FormatDelta(next, now)))
 		}
 		result.WriteString("\n")
 	}


### PR DESCRIPTION
## Summary

This PR brings model-facing tool and context output into closer alignment with `docs/model-facing-context.md`. It removes raw timestamp fields from document tool results, then extends the same cleanup to nearby model-facing surfaces that were hand-rolling timestamp deltas or short IDs instead of using `promptfmt`.

Storage and internal contracts still keep absolute timestamps where that belongs. The PR adds projection at the model boundary so tools can return exact-second delta fields without reshaping persistent records, document indexes, or backend APIs.

## What changed

- Added explicit model-facing projection structs for document read/search/browse/link/value/root outputs.
- Added matching projections for managed mutation results and `doc_commit` payloads.
- Converted document result timestamps such as `modified_at`, `last_modified_at`, `created_at`, `updated_at`, and `checked_at` into delta fields such as `modified_delta`, `last_modified_delta`, `created_delta`, `updated_delta`, and `checked_delta`.
- Converted known timestamp frontmatter keys (`created`, `updated`, `generated_at`) to delta-shaped fields in document tool output.
- Converted `doc_search` filter echoes and `doc_values` timestamp values to delta-oriented model-facing output.
- Reused `promptfmt` for other model-facing recency and compact-ID output: working memory, provenance ego context, channel contact context, owner channel activity, attachment summaries, watchlist subscriptions, file stat metadata, scheduler task listings, archive result short IDs, and delegate loop names.
- Updated reference docs to describe the delta-time output contract for affected tool families.
- Added regression coverage for document outputs plus the changed attachment, watchlist, owner-contact, and file stat surfaces.

## Why

The model-facing context guidance is clear: models should not do timestamp arithmetic when Go can provide the useful relation directly. The previous tool outputs leaked raw timestamps in several places, including `doc_roots`, compact document results, mutation summaries, backlink metadata, attachment summaries, watchlist expiry, owner channel activity, and file metadata.

This keeps model input cognitively lighter and makes the formatting policy less fragmented by routing the obvious cases through the shared `promptfmt` helpers.

## Validation

- `just ci`