### PR TITLE
[codex] fix: use repo-local allowed signers for document roots

### DIFF
--- a/docs/operating/configuration.md
+++ b/docs/operating/configuration.md
@@ -220,10 +220,11 @@ reserves the root for narrower future flows.
 
 `git.sign_commits` turns each managed document write/delete into a
 signed git commit. By default the root itself is the repository; set
-`git.repo_path` when several roots live under one larger repo. Set
-`git.allowed_signers` to use an existing OpenSSH allowed signers file;
-otherwise Thane writes a repository-local `.allowed_signers` file from
-the signing key.
+`git.repo_path` when several roots live under one larger repo. Thane
+uses the repository-local `.allowed_signers` file for SSH signature
+verification. For signer-backed roots, Thane creates that file from the
+configured signing key when it is missing; after that, the file itself is
+the trust configuration surface.
 
 `git.verify_signatures` controls read-side enforcement. `none` disables
 checks, `warn` logs and reports verification failures without blocking,

--- a/docs/understanding/document-roots.md
+++ b/docs/understanding/document-roots.md
@@ -124,6 +124,13 @@ The current policy fields are:
 - `git.verify_signatures`: sets the consumer policy: `none`, `warn`,
   or `required`.
 
+Signature verification always uses the repository-local
+`.allowed_signers` file. For signer-backed roots, Thane creates that
+file from the configured signing key when it is missing; after that, the
+file itself is the trust configuration surface. Adding additional
+signers should be done by editing and committing `.allowed_signers`
+through trusted history.
+
 Signature-required roots are the place for high-integrity authored
 knowledge, such as owner-tagged knowledge articles. When verification
 is `required`, Thane blocks the following content paths when the

--- a/examples/config.example.yaml
+++ b/examples/config.example.yaml
@@ -217,10 +217,6 @@ roots:
       # SigningKey is the SSH private key used to sign managed commits.
       # Supports ~ expansion at startup.
       signing_key: ""
-      # AllowedSigners is the OpenSSH allowed signers file to use when
-      # verifying this root. Empty uses the repository-local
-      # .allowed_signers written from signing_key.
-      allowed_signers: ""
   kb:
     # Path is the directory the root resolves to. Supports ~
     # expansion at resolver construction time. For the reserved
@@ -254,10 +250,6 @@ roots:
       # SigningKey is the SSH private key used to sign managed commits.
       # Supports ~ expansion at startup.
       signing_key: ~/.ssh/id_ed25519
-      # AllowedSigners is the OpenSSH allowed signers file to use when
-      # verifying this root. Empty uses the repository-local
-      # .allowed_signers written from signing_key.
-      allowed_signers: ""
   scratchpad:
     # Path is the directory the root resolves to. Supports ~
     # expansion at resolver construction time. For the reserved
@@ -291,10 +283,6 @@ roots:
       # SigningKey is the SSH private key used to sign managed commits.
       # Supports ~ expansion at startup.
       signing_key: ""
-      # AllowedSigners is the OpenSSH allowed signers file to use when
-      # verifying this root. Empty uses the repository-local
-      # .allowed_signers written from signing_key.
-      allowed_signers: ""
 #
 # (optional) Paths is the legacy directory-mapping block. Replaced by roots:.
 # paths: {}

--- a/internal/app/document_roots.go
+++ b/internal/app/document_roots.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"os/exec"
 	"path"
 	"path/filepath"
 	"sort"
@@ -248,7 +249,6 @@ func documentRootPolicyFromConfig(rootCfg config.DocumentRootConfig) documents.R
 		policy.Git.VerifySignatures = documents.VerificationMode(verify)
 	}
 	policy.Git.RepoPath = strings.TrimSpace(gitCfg.RepoPath)
-	policy.Git.AllowedSigners = strings.TrimSpace(gitCfg.AllowedSigners)
 	return policy
 }
 
@@ -278,10 +278,6 @@ func (a *App) newDocumentRootProvenanceWriter(root, rootPath string, gitCfg conf
 		return nil, fmt.Errorf("doc_roots.%s.git.repo_path: %w", root, err)
 	}
 
-	allowedSigners := strings.TrimSpace(gitCfg.AllowedSigners)
-	if allowedSigners != "" {
-		allowedSigners = resolvePath(allowedSigners, resolver)
-	}
 	signer, err := provenance.NewSSHFileSigner(signingKey)
 	if err != nil {
 		return nil, fmt.Errorf("doc_roots.%s.git.signing_key: %w", root, err)
@@ -290,9 +286,7 @@ func (a *App) newDocumentRootProvenanceWriter(root, rootPath string, gitCfg conf
 	if logger == nil {
 		logger = slog.Default()
 	}
-	store, err := provenance.NewWithOptions(absRepoPath, signer, logger.With("component", "document_root_provenance", "root", root), provenance.Options{
-		AllowedSignersPath: allowedSigners,
-	})
+	store, err := provenance.New(absRepoPath, signer, logger.With("component", "document_root_provenance", "root", root))
 	if err != nil {
 		return nil, fmt.Errorf("initialize git provenance for document root %s: %w", root, err)
 	}
@@ -312,7 +306,6 @@ func (a *App) newDocumentRootProvenanceWriter(root, rootPath string, gitCfg conf
 		"root", root,
 		"repo", store.Path(),
 		"prefix", prefix,
-		"allowed_signers", allowedSigners != "",
 	)
 	return &documentRootProvenanceWriter{store: store, prefix: prefix}, nil
 }
@@ -337,21 +330,35 @@ func (a *App) newDocumentRootProvenanceVerifier(root, rootPath string, gitCfg co
 		return nil, fmt.Errorf("doc_roots.%s.git.repo_path: %w", root, err)
 	}
 
-	allowedSigners := strings.TrimSpace(gitCfg.AllowedSigners)
-	if allowedSigners != "" {
-		allowedSigners = resolvePath(allowedSigners, resolver)
-	}
 	logger := a.logger
 	if logger == nil {
 		logger = slog.Default()
 	}
-	verifier, err := provenance.NewVerifier(absRepoPath, logger.With("component", "document_root_verifier", "root", root), provenance.Options{
-		AllowedSignersPath: allowedSigners,
-	})
+	if err := configureRepoLocalAllowedSigners(root, absRepoPath); err != nil {
+		return nil, err
+	}
+	verifier, err := provenance.NewVerifier(absRepoPath, logger.With("component", "document_root_verifier", "root", root), provenance.Options{})
 	if err != nil {
 		return nil, fmt.Errorf("initialize git verifier for document root %s: %w", root, err)
 	}
 	return &documentRootProvenanceVerifier{verifier: verifier, prefix: prefix}, nil
+}
+
+func configureRepoLocalAllowedSigners(root, repoPath string) error {
+	allowedSignersPath := filepath.Join(repoPath, ".allowed_signers")
+	if _, err := os.Stat(allowedSignersPath); err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("doc_roots.%s.git requires repo-local .allowed_signers at %s", root, allowedSignersPath)
+		}
+		return fmt.Errorf("doc_roots.%s.git stat .allowed_signers: %w", root, err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), docRootBootstrapTimeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "git", "-C", repoPath, "config", "gpg.ssh.allowedSignersFile", allowedSignersPath)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("doc_roots.%s.git config allowedSignersFile: %w: %s", root, err, strings.TrimSpace(string(out)))
+	}
+	return nil
 }
 
 func rootPrefixWithinRepo(repoPath, rootPath string) (string, error) {

--- a/internal/app/document_roots.go
+++ b/internal/app/document_roots.go
@@ -334,7 +334,7 @@ func (a *App) newDocumentRootProvenanceVerifier(root, rootPath string, gitCfg co
 	if logger == nil {
 		logger = slog.Default()
 	}
-	if err := configureRepoLocalAllowedSigners(root, absRepoPath); err != nil {
+	if err := configureRepoLocalAllowedSigners(root, absRepoPath, logger); err != nil {
 		return nil, err
 	}
 	verifier, err := provenance.NewVerifier(absRepoPath, logger.With("component", "document_root_verifier", "root", root), provenance.Options{})
@@ -344,19 +344,28 @@ func (a *App) newDocumentRootProvenanceVerifier(root, rootPath string, gitCfg co
 	return &documentRootProvenanceVerifier{verifier: verifier, prefix: prefix}, nil
 }
 
-func configureRepoLocalAllowedSigners(root, repoPath string) error {
+func configureRepoLocalAllowedSigners(root, repoPath string, logger *slog.Logger) error {
 	allowedSignersPath := filepath.Join(repoPath, ".allowed_signers")
-	if _, err := os.Stat(allowedSignersPath); err != nil {
+	if info, err := os.Lstat(allowedSignersPath); err != nil {
 		if os.IsNotExist(err) {
 			return fmt.Errorf("doc_roots.%s.git requires repo-local .allowed_signers at %s", root, allowedSignersPath)
 		}
 		return fmt.Errorf("doc_roots.%s.git stat .allowed_signers: %w", root, err)
+	} else if info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("doc_roots.%s.git .allowed_signers must be a regular file, not a symlink: %s", root, allowedSignersPath)
+	} else if !info.Mode().IsRegular() {
+		return fmt.Errorf("doc_roots.%s.git .allowed_signers must be a regular file: %s", root, allowedSignersPath)
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), docRootBootstrapTimeout)
 	defer cancel()
 	cmd := exec.CommandContext(ctx, "git", "-C", repoPath, "config", "gpg.ssh.allowedSignersFile", allowedSignersPath)
 	if out, err := cmd.CombinedOutput(); err != nil {
-		return fmt.Errorf("doc_roots.%s.git config allowedSignersFile: %w: %s", root, err, strings.TrimSpace(string(out)))
+		logger.Warn("document root git config allowedSignersFile failed; verification will still use per-command configuration",
+			"root", root,
+			"repo", repoPath,
+			"allowed_signers", allowedSignersPath,
+			"error", strings.TrimSpace(fmt.Sprintf("%v: %s", err, out)),
+		)
 	}
 	return nil
 }

--- a/internal/app/document_roots_test.go
+++ b/internal/app/document_roots_test.go
@@ -16,8 +16,7 @@ import (
 
 // writeTestSigningKey generates a fresh ed25519 SSH signing key,
 // writes the private key to a temp path, and returns the path along
-// with the matching public key as a string. Callers that need
-// .allowed_signers should write the returned public key themselves.
+// with the matching public key as a string.
 func writeTestSigningKey(t *testing.T) (privPath, pub string) {
 	t.Helper()
 	if _, err := exec.LookPath("git"); err != nil {
@@ -78,7 +77,6 @@ func TestBuildDocumentStoreOptionsMapsConfigPolicy(t *testing.T) {
 					Enabled:          true,
 					VerifySignatures: "warn",
 					RepoPath:         "~/repo",
-					AllowedSigners:   "~/allowed_signers",
 				},
 			},
 		},
@@ -160,6 +158,9 @@ func TestBuildDocumentStoreOptionsBootstrapsMissingDirectory(t *testing.T) {
 	if _, err := os.Stat(filepath.Join(targetPath, ".git")); err != nil {
 		t.Fatalf("bootstrap should have run git init: %v", err)
 	}
+	if _, err := os.Stat(filepath.Join(targetPath, ".allowed_signers")); err != nil {
+		t.Fatalf("bootstrap should have written repo-local .allowed_signers: %v", err)
+	}
 	// HEAD should exist (birth commit).
 	cmd := exec.CommandContext(t.Context(), "git", "-C", targetPath, "rev-parse", "--verify", "HEAD^{commit}")
 	if err := cmd.Run(); err != nil {
@@ -211,6 +212,9 @@ func TestBuildDocumentStoreOptionsBootstrapsEmptyDirectory(t *testing.T) {
 	if _, err := os.Stat(filepath.Join(targetPath, ".gitignore")); err != nil {
 		t.Fatalf("birth commit should have written .gitignore: %v", err)
 	}
+	if _, err := os.Stat(filepath.Join(targetPath, ".allowed_signers")); err != nil {
+		t.Fatalf("provenance init should have written .allowed_signers: %v", err)
+	}
 	if opts.RootVerifiers["kb"] == nil {
 		t.Fatal("verifier missing on freshly bootstrapped root")
 	}
@@ -225,7 +229,6 @@ func TestBuildDocumentStoreOptionsRequiredVerifierUnavailableIsFatal(t *testing.
 
 	targetPath := t.TempDir()
 	resolver := paths.New(map[string]string{"kb": targetPath})
-	missingAllowedSigners := filepath.Join(t.TempDir(), "does-not-exist")
 
 	app := &App{
 		logger: slog.Default(),
@@ -236,7 +239,6 @@ func TestBuildDocumentStoreOptionsRequiredVerifierUnavailableIsFatal(t *testing.
 						Enabled:          true,
 						SignCommits:      false, // verifier-only path
 						VerifySignatures: "required",
-						AllowedSigners:   missingAllowedSigners,
 					},
 				},
 			},
@@ -249,6 +251,67 @@ func TestBuildDocumentStoreOptionsRequiredVerifierUnavailableIsFatal(t *testing.
 	}
 	if !strings.Contains(err.Error(), "verify_signatures=required but verifier unavailable") {
 		t.Fatalf("error = %v, want required-but-unavailable message", err)
+	}
+}
+
+func TestBuildDocumentStoreOptionsVerifierUsesRepoLocalAllowedSigners(t *testing.T) {
+	targetPath := t.TempDir()
+	signingKey, publicKey := writeTestSigningKey(t)
+
+	app := &App{
+		logger: slog.Default(),
+		cfg: &config.Config{
+			DocRoots: map[string]config.DocumentRootConfig{
+				"kb": {
+					Git: config.DocumentRootGitConfig{
+						Enabled:          true,
+						SignCommits:      true,
+						VerifySignatures: "required",
+						SigningKey:       signingKey,
+					},
+				},
+			},
+		},
+	}
+	resolver := paths.New(map[string]string{"kb": targetPath})
+	opts, err := app.buildDocumentStoreOptions(buildDocumentRoots(resolver), resolver)
+	if err != nil {
+		t.Fatalf("initial buildDocumentStoreOptions: %v", err)
+	}
+	if opts.RootVerifiers["kb"] == nil {
+		t.Fatal("initial verifier missing")
+	}
+
+	allowedPath := filepath.Join(targetPath, ".allowed_signers")
+	data, err := os.ReadFile(allowedPath)
+	if err != nil {
+		t.Fatalf("ReadFile .allowed_signers: %v", err)
+	}
+	if !strings.Contains(string(data), publicKey) {
+		t.Fatalf(".allowed_signers = %q, want generated public key", data)
+	}
+
+	cfgOut, err := exec.CommandContext(t.Context(), "git", "-C", targetPath, "config", "gpg.ssh.allowedSignersFile").Output()
+	if err != nil {
+		t.Fatalf("git config allowedSignersFile: %v", err)
+	}
+	if got := strings.TrimSpace(string(cfgOut)); got != allowedPath {
+		t.Fatalf("allowedSignersFile = %q, want %q", got, allowedPath)
+	}
+
+	app.cfg.DocRoots["kb"] = config.DocumentRootConfig{
+		Git: config.DocumentRootGitConfig{
+			Enabled:          true,
+			SignCommits:      false,
+			VerifySignatures: "required",
+		},
+	}
+	opts, err = app.buildDocumentStoreOptions(buildDocumentRoots(resolver), resolver)
+	if err != nil {
+		t.Fatalf("verifier-only buildDocumentStoreOptions: %v", err)
+	}
+	if opts.RootVerifiers["kb"] == nil {
+		t.Fatal("verifier-only root should use repo-local .allowed_signers")
 	}
 }
 

--- a/internal/app/document_roots_test.go
+++ b/internal/app/document_roots_test.go
@@ -315,6 +315,33 @@ func TestBuildDocumentStoreOptionsVerifierUsesRepoLocalAllowedSigners(t *testing
 	}
 }
 
+func TestConfigureRepoLocalAllowedSignersBestEffortGitConfig(t *testing.T) {
+	targetPath := t.TempDir()
+	allowedPath := filepath.Join(targetPath, ".allowed_signers")
+	if err := os.WriteFile(allowedPath, []byte("thane@example.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFakeKeyForConfigOnly\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile .allowed_signers: %v", err)
+	}
+
+	if err := configureRepoLocalAllowedSigners("kb", targetPath, slog.Default()); err != nil {
+		t.Fatalf("configureRepoLocalAllowedSigners() = %v, want nil despite non-git dir", err)
+	}
+}
+
+func TestConfigureRepoLocalAllowedSignersRejectsNonRegularFile(t *testing.T) {
+	targetPath := t.TempDir()
+	if err := os.Mkdir(filepath.Join(targetPath, ".allowed_signers"), 0o755); err != nil {
+		t.Fatalf("Mkdir .allowed_signers: %v", err)
+	}
+
+	err := configureRepoLocalAllowedSigners("kb", targetPath, slog.Default())
+	if err == nil {
+		t.Fatal("configureRepoLocalAllowedSigners() returned nil, want non-regular file error")
+	}
+	if !strings.Contains(err.Error(), "must be a regular file") {
+		t.Fatalf("error = %v, want regular-file message", err)
+	}
+}
+
 // TestBuildDocumentStoreOptionsNonBootstrapMissingDirStillErrors
 // preserves the original behavior for non-bootstrap configs: a
 // missing directory without git+sign_commits stays an error, since

--- a/internal/platform/config/config.go
+++ b/internal/platform/config/config.go
@@ -852,11 +852,6 @@ type DocumentRootGitConfig struct {
 	// SigningKey is the SSH private key used to sign managed commits.
 	// Supports ~ expansion at startup.
 	SigningKey string `yaml:"signing_key,omitempty"`
-
-	// AllowedSigners is the OpenSSH allowed signers file to use when
-	// verifying this root. Empty uses the repository-local
-	// .allowed_signers written from signing_key.
-	AllowedSigners string `yaml:"allowed_signers,omitempty"`
 }
 
 // HomeAssistantConfig configures the connection to a Home Assistant
@@ -1915,7 +1910,7 @@ func entryHasPolicy(entry RootEntry) bool {
 	}
 	g := entry.Git
 	return g.Enabled || g.SignCommits || g.VerifySignatures != "" ||
-		g.RepoPath != "" || g.SigningKey != "" || g.AllowedSigners != ""
+		g.RepoPath != "" || g.SigningKey != ""
 }
 
 // applyDefaults fills zero-value fields with sensible defaults. It is

--- a/internal/platform/config/config_test.go
+++ b/internal/platform/config/config_test.go
@@ -800,7 +800,6 @@ doc_roots:
       sign_commits: false
       verify_signatures: required
       repo_path: ./knowledge
-      allowed_signers: ./allowed_signers
 `), 0600); err != nil {
 		t.Fatalf("WriteFile: %v", err)
 	}
@@ -816,7 +815,7 @@ doc_roots:
 	if root.Authoring != "read_only" {
 		t.Fatalf("DocRoots[kb].Authoring = %q, want read_only", root.Authoring)
 	}
-	if !root.Git.Enabled || root.Git.VerifySignatures != "required" || root.Git.AllowedSigners != "./allowed_signers" {
+	if !root.Git.Enabled || root.Git.VerifySignatures != "required" {
 		t.Fatalf("DocRoots[kb].Git = %#v, want enabled required verification", root.Git)
 	}
 }

--- a/internal/platform/provenance/git.go
+++ b/internal/platform/provenance/git.go
@@ -103,11 +103,18 @@ func (s *Store) ensureRepo() error {
 
 	allowedPath := s.allowedSignersPath
 	if allowedPath == "" {
-		// Write .allowed_signers with the signer's public key.
-		allowedSigners := fmt.Sprintf("thane@provenance.local %s\n", s.signer.PublicKey())
 		allowedPath = filepath.Join(s.path, ".allowed_signers")
-		if err := os.WriteFile(allowedPath, []byte(allowedSigners), 0o644); err != nil {
-			return fmt.Errorf("write .allowed_signers: %w", err)
+		if _, err := os.Stat(allowedPath); err != nil {
+			if !errors.Is(err, os.ErrNotExist) {
+				return fmt.Errorf("stat .allowed_signers: %w", err)
+			}
+			// Bootstrap .allowed_signers with the signer's public
+			// key when this repository does not already define its
+			// own trust surface.
+			allowedSigners := fmt.Sprintf("thane@provenance.local %s\n", s.signer.PublicKey())
+			if err := os.WriteFile(allowedPath, []byte(allowedSigners), 0o644); err != nil {
+				return fmt.Errorf("write .allowed_signers: %w", err)
+			}
 		}
 	} else if _, err := os.Stat(allowedPath); err != nil {
 		return fmt.Errorf("stat allowed signers file: %w", err)

--- a/internal/platform/provenance/git.go
+++ b/internal/platform/provenance/git.go
@@ -104,9 +104,9 @@ func (s *Store) ensureRepo() error {
 	allowedPath := s.allowedSignersPath
 	if allowedPath == "" {
 		allowedPath = filepath.Join(s.path, ".allowed_signers")
-		if _, err := os.Stat(allowedPath); err != nil {
+		if err := validateAllowedSignersFile(allowedPath); err != nil {
 			if !errors.Is(err, os.ErrNotExist) {
-				return fmt.Errorf("stat .allowed_signers: %w", err)
+				return err
 			}
 			// Bootstrap .allowed_signers with the signer's public
 			// key when this repository does not already define its
@@ -116,8 +116,8 @@ func (s *Store) ensureRepo() error {
 				return fmt.Errorf("write .allowed_signers: %w", err)
 			}
 		}
-	} else if _, err := os.Stat(allowedPath); err != nil {
-		return fmt.Errorf("stat allowed signers file: %w", err)
+	} else if err := validateAllowedSignersFile(allowedPath); err != nil {
+		return err
 	}
 
 	// Tell git where to find allowed signers for verification.

--- a/internal/platform/provenance/provenance_test.go
+++ b/internal/platform/provenance/provenance_test.go
@@ -176,6 +176,37 @@ func TestStoreNewPreservesExistingRepoLocalAllowedSigners(t *testing.T) {
 	}
 }
 
+func TestStoreNewRejectsNonRegularRepoLocalAllowedSigners(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+
+	storePath := t.TempDir()
+	if err := os.Mkdir(filepath.Join(storePath, ".allowed_signers"), 0o755); err != nil {
+		t.Fatalf("Mkdir .allowed_signers: %v", err)
+	}
+
+	_, err := New(storePath, testSigner(t), slog.Default())
+	if err == nil {
+		t.Fatal("New returned nil, want non-regular .allowed_signers error")
+	}
+	if !strings.Contains(err.Error(), "must be a regular file") {
+		t.Fatalf("error = %v, want regular-file message", err)
+	}
+}
+
+func TestVerifierMissingRepoLocalAllowedSignersIncludesPath(t *testing.T) {
+	repoPath := t.TempDir()
+	_, err := NewVerifier(repoPath, nil, Options{})
+	if err == nil {
+		t.Fatal("NewVerifier returned nil, want missing .allowed_signers error")
+	}
+	want := filepath.Join(repoPath, ".allowed_signers")
+	if !strings.Contains(err.Error(), want) || !strings.Contains(err.Error(), repoPath) {
+		t.Fatalf("error = %v, want repo and allowed signers paths", err)
+	}
+}
+
 func TestStoreWriteCreatesSubdirectories(t *testing.T) {
 	s := testStore(t)
 

--- a/internal/platform/provenance/provenance_test.go
+++ b/internal/platform/provenance/provenance_test.go
@@ -152,6 +152,30 @@ func TestStoreNewWithOptionsUsesExternalAllowedSigners(t *testing.T) {
 	}
 }
 
+func TestStoreNewPreservesExistingRepoLocalAllowedSigners(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+
+	storePath := t.TempDir()
+	existing := "trusted@example.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFakeKeyForPreservationOnly\n"
+	if err := os.WriteFile(filepath.Join(storePath, ".allowed_signers"), []byte(existing), 0o644); err != nil {
+		t.Fatalf("WriteFile .allowed_signers: %v", err)
+	}
+
+	if _, err := New(storePath, testSigner(t), slog.Default()); err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	got, err := os.ReadFile(filepath.Join(storePath, ".allowed_signers"))
+	if err != nil {
+		t.Fatalf("ReadFile .allowed_signers: %v", err)
+	}
+	if string(got) != existing {
+		t.Fatalf(".allowed_signers was overwritten:\n got %q\nwant %q", got, existing)
+	}
+}
+
 func TestStoreWriteCreatesSubdirectories(t *testing.T) {
 	s := testStore(t)
 

--- a/internal/platform/provenance/verify.go
+++ b/internal/platform/provenance/verify.go
@@ -70,6 +70,10 @@ func NewVerifier(path string, logger *slog.Logger, opts Options) (*Verifier, err
 		repoLocal := filepath.Join(absPath, ".allowed_signers")
 		if _, err := os.Stat(repoLocal); err == nil {
 			allowedSignersPath = repoLocal
+		} else if errors.Is(err, os.ErrNotExist) {
+			return nil, fmt.Errorf("provenance: repo-local .allowed_signers file is required")
+		} else {
+			return nil, fmt.Errorf("provenance: stat repo-local .allowed_signers file: %w", err)
 		}
 	}
 	return &Verifier{

--- a/internal/platform/provenance/verify.go
+++ b/internal/platform/provenance/verify.go
@@ -63,17 +63,17 @@ func NewVerifier(path string, logger *slog.Logger, opts Options) (*Verifier, err
 		if err != nil {
 			return nil, fmt.Errorf("provenance: resolve verifier allowed signers path: %w", err)
 		}
-		if _, err := os.Stat(allowedSignersPath); err != nil {
-			return nil, fmt.Errorf("provenance: stat verifier allowed signers file: %w", err)
+		if err := validateAllowedSignersFile(allowedSignersPath); err != nil {
+			return nil, err
 		}
 	} else {
 		repoLocal := filepath.Join(absPath, ".allowed_signers")
-		if _, err := os.Stat(repoLocal); err == nil {
+		if err := validateAllowedSignersFile(repoLocal); err == nil {
 			allowedSignersPath = repoLocal
 		} else if errors.Is(err, os.ErrNotExist) {
-			return nil, fmt.Errorf("provenance: repo-local .allowed_signers file is required")
+			return nil, fmt.Errorf("provenance: repo-local .allowed_signers file is required at %s for repository %s", repoLocal, absPath)
 		} else {
-			return nil, fmt.Errorf("provenance: stat repo-local .allowed_signers file: %w", err)
+			return nil, err
 		}
 	}
 	return &Verifier{
@@ -81,6 +81,20 @@ func NewVerifier(path string, logger *slog.Logger, opts Options) (*Verifier, err
 		allowedSignersPath: allowedSignersPath,
 		logger:             logger,
 	}, nil
+}
+
+func validateAllowedSignersFile(path string) error {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return fmt.Errorf("provenance: stat allowed signers file %s: %w", path, err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("provenance: allowed signers file %s must be a regular file, not a symlink", path)
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("provenance: allowed signers file %s must be a regular file", path)
+	}
+	return nil
 }
 
 // VerifyFile checks one tracked file. The file must be clean against HEAD,

--- a/internal/state/documents/policy.go
+++ b/internal/state/documents/policy.go
@@ -52,7 +52,6 @@ type RootGitPolicy struct {
 	SignCommits      bool             `json:"sign_commits,omitempty"`
 	VerifySignatures VerificationMode `json:"verify_signatures,omitempty"`
 	RepoPath         string           `json:"-"`
-	AllowedSigners   string           `json:"-"`
 }
 
 // RootPolicySummary is the model-facing form of [RootPolicy]. It omits


### PR DESCRIPTION
## Summary

This PR makes repository-local `.allowed_signers` the document-root trust surface and removes the document-root `git.allowed_signers` config knob.

Signature-verifying document roots now always use `<repo>/.allowed_signers`. Signer-backed roots still bootstrap that file from the configured `signing_key` when it is missing, but existing `.allowed_signers` files are preserved instead of overwritten. Verifier setup also configures the repository's `gpg.ssh.allowedSignersFile`, so local Git commands such as `git log --show-signature` use the same in-repo trust file Thane uses.

## What changed

- Removed `allowed_signers` from document-root config and regenerated the example config.
- Removed the corresponding document-root policy plumbing.
- Made provenance initialization preserve an existing repo-local `.allowed_signers` file.
- Made verifier construction require a repo-local `.allowed_signers` when no explicit internal override is supplied.
- Configured document-root repositories to point Git at their repo-local `.allowed_signers` file during verifier setup.
- Added coverage for signer bootstrap, verifier-only reuse of repo-local `.allowed_signers`, and preservation of existing trust files.
- Updated docs to describe `.allowed_signers` as the trust configuration surface and call out the remaining signer-addition path as editing and committing that file through trusted history.

## Why

A signature-required root should not depend on an out-of-band config pointer for trust policy. The production `projects` root exposed the gap: Git was configured to use a repo-local `.allowed_signers` file, but the file was absent, so `git log --show-signature` reported a good SSH signature and then failed principal matching because the trust file could not be opened.

Making `.allowed_signers` canonical keeps the trust decision auditable inside the root's git history and removes a confusing second configuration surface.

## Validation

- `just test`
- `just lint`
- `just ci`