### PR TITLE
refactor: route core context through providers

### DIFF
--- a/docs/operating/configuration.md
+++ b/docs/operating/configuration.md
@@ -246,15 +246,15 @@ operator guide.
 ## Persona & Talents
 
 ```yaml
-persona_file: ~/Thane/persona.md
+workspace:
+  path: ~/Thane
 talents_dir: ~/Thane/talents
-inject_files:
-  - ~/Thane/IDENTITY.md
-  - ~/Thane/USER.md
 ```
 
 See [Context Layers](../understanding/context-layers.md) for how these
-fit into the system prompt.
+fit into the system prompt. `workspace.path` derives the protected
+`core` root; `core/persona.md`, `core/ego.md`, and `core/mission.md`
+are picked up by the runtime without a separate inject-file list.
 
 ## Scheduler
 

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -290,6 +290,14 @@ family.
 | `thane_curate` | recurring | Scaffold a managed document and launch a recurring service loop that curates it (`journal` mode appends entries; `maintain` mode rewrites idempotently). |
 | `thane_wake` | poke existing | Send a one-shot message envelope to a live timer loop, waking it or queueing for the next iteration. |
 
+`thane_now`, `thane_assign`, and the deprecated `thane_delegate` alias
+accept `context_mode`. The default, `task`, gives the child run a compact
+task-worker prompt with active capabilities, tagged context, and current
+conditions, but without full Thane identity files, inject files,
+always-on talents, or conversation-history dressing. Use
+`context_mode=full` only when the delegated work genuinely needs that
+continuity.
+
 ## `loops` — lower-level loop control and inspection
 
 Below the `thane_*` family. Use these for inspection, control, or

--- a/docs/understanding/architecture.md
+++ b/docs/understanding/architecture.md
@@ -158,16 +158,15 @@ The system prompt is assembled from four layers, each with a distinct
 purpose. Mixing concerns across layers degrades agent behavior — this
 was learned empirically, not theorized.
 
-**Persona** is identity: who the agent is, its voice and values.
-**Inject files** are knowledge: factual reference material the agent
-needs. **Current conditions** are awareness: time, environment, active
-state. **Talents** are behavior: how the agent should act in specific
-situations.
+**Persona** is identity: who the agent is, its voice and values. **Core
+context providers** publish curated knowledge and continuity such as
+`core/ego.md` and `core/mission.md`. **Current conditions** are
+awareness: time, environment, active state. **Talents** are behavior:
+how the agent should act in specific situations.
 
-The assembly order mirrors natural orientation: I know who I am, I know
-what I know, I know where and when I am, I know how to behave. Putting
-tool rules in the persona suppresses personality. Putting identity in
-talents creates contradictions. The layer separation isn't arbitrary —
+Putting tool rules in the persona suppresses personality. Putting
+identity in talents creates contradictions. The layer separation isn't
+arbitrary —
 each anti-pattern was discovered by watching the agent behave badly
 when concerns were mixed. See [Context Layers](context-layers.md).
 

--- a/docs/understanding/context-layers.md
+++ b/docs/understanding/context-layers.md
@@ -51,24 +51,24 @@ alphabetically and injected into the system prompt. Talents are tag-filtered
 — each can declare required capability tags via YAML frontmatter, loading
 only when those tags are active.
 
-### 3. Inject Files (`inject_files`)
+### 3. Core Context Providers
 
 **Purpose:** Knowledge — what the agent *knows*.
 
-Inject files provide reference material: identity details, user profiles,
-tool documentation, memory. They're the agent's knowledge base, loaded
-from the filesystem.
+Core context providers publish curated reference material such as
+`core/ego.md` and `core/mission.md` through the same runtime context
+pipeline as working memory, presence, notification history, and other
+ambient state. They are read fresh each turn, verified when managed-root
+policy applies, and suppressed for task-focused delegate runs.
 
 **Contains:** Factual information, user preferences, infrastructure notes,
 memory files, identity documents.
 
 **Does NOT contain:** Behavioral directives, personality definitions.
 
-**Common inject files:**
-- `MEMORY.md` — curated long-term memory
-- `IDENTITY.md` — name, avatar, technical identity
-- `USER.md` — information about the primary user
-- `TOOLS.md` — infrastructure and credential locations
+**Common core context files:**
+- `ego.md` — self-reflection and continuity notes
+- `mission.md` — deployment-specific mission context
 
 ### 4. Session Context (dynamic)
 
@@ -85,14 +85,16 @@ compaction context.
 The system prompt is assembled in this order:
 
 1. **Persona** — identity (who am I)
-2. **Inject files** — knowledge (what do I know)
-3. **Current conditions** — environment (where/when am I)
-4. **Talents** — behavior (how should I act)
-5. **Dynamic context** — facts, memory (what's relevant now)
-6. **Compaction summary** — continuity (what happened before)
+2. **Runtime contract** — execution semantics
+3. **Talents** — behavior (how should I act)
+4. **Active capabilities** — currently loaded tool and context surface
+5. **Capability context** — tagged KB, tagged providers, and always-on providers
+6. **Current conditions** — environment (where/when am I)
+7. **Conversation history** — continuity for full-context runs
 
-This mirrors natural orientation: identity, knowledge, awareness, norms,
-memory.
+Task-focused delegate runs keep the compact worker persona, runtime
+contract, active capabilities, tagged context, and current conditions,
+but omit full identity/continuity providers and conversation history.
 
 ## Anti-Patterns
 
@@ -100,12 +102,10 @@ memory.
 |---|---|---|
 | Tool rules in persona | Suppresses personality (e.g., "only use tools when asked" kills proactive behavior) | Move to `tool-guidance.md` talent |
 | Identity in talents | Confusing — talent says "you are X" but persona says "you are Y" | Keep identity in persona only |
-| Behavioral directives in inject files | Inject files are knowledge, not instructions | Move directives to talents |
+| Behavioral directives in core context | Core context is knowledge, not instructions | Move directives to talents |
 | Static time in build info | Model treats version metadata as ignorable | Use Current Conditions section |
 
 ## Related
 
 - [Anthropic Caching](../anthropic-caching.md) — how the layer
-  boundaries map onto Anthropic cache TTLs (persona and inject-file
-  layers cache at 1h; dynamic context and current conditions are
-  uncached so they don't churn the prefix).
+  boundaries map onto Anthropic cache TTLs.

--- a/docs/understanding/delegation.md
+++ b/docs/understanding/delegation.md
@@ -117,8 +117,13 @@ if a server exists, Thane can host it.
 ## Delegation Profiles
 
 Delegation profiles are compatibility hints for budget and routing defaults.
-They do not own a separate system prompt or fixed tool allowlist. Capability
-tags determine the delegate's tool and context scope.
+By default they use a task-focused prompt mode: compact worker identity,
+tool-use contract, active capability summaries, tagged context, and
+current conditions. The full Thane prompt can still be requested for
+continuity-sensitive work, but ordinary delegates should stay in task mode
+so small local models are not flooded with persona, ego, injected core
+files, always-on talents, or conversation-history dressing. Capability tags
+determine the delegate's tool and tagged context scope.
 
 | Profile | Default Tags | Routing Bias | Use For |
 |---------|--------------|--------------|---------|
@@ -141,6 +146,10 @@ Runtime/channel affordance tags such as `message_channel` and trust tags
 such as `owner` are not inherited as model-requested tags; they must be
 asserted again by trusted runtime context. Use `inherit_caller_tags=false`
 for a strict fresh scope.
+
+Use `context_mode=full` sparingly when a delegate truly needs the same rich
+identity and continuity context as the caller. The default `task` mode is
+the normal execution path.
 
 ## Writing Good Delegation Prompts
 

--- a/docs/understanding/glossary.md
+++ b/docs/understanding/glossary.md
@@ -64,10 +64,10 @@ preserving decisions, facts, and preferences.
 
 ### Context Layer
 
-One of four distinct sections of the system prompt, each with a specific
-purpose: *Persona* (identity), *Talents* (behavior), *Inject Files*
-(knowledge), and *Session Context* (current state). Mixing concerns across
-layers degrades agent behavior.
+One of the distinct sections of the system prompt, each with a specific
+purpose: *Persona* (identity), *Talents* (behavior), *Core Context*
+(curated knowledge and continuity), and *Session Context* (current
+state). Mixing concerns across layers degrades agent behavior.
 See [Context Layers](context-layers.md).
 
 ### Delegate

--- a/internal/app/adapters.go
+++ b/internal/app/adapters.go
@@ -1123,6 +1123,7 @@ func compileLoopAgentRequest(req looppkg.Request) *agent.Request {
 		UsageRole:             req.UsageRole,
 		UsageTaskName:         req.UsageTaskName,
 		SystemPrompt:          req.SystemPrompt,
+		PromptMode:            req.PromptMode,
 		SuppressAlwaysContext: req.SuppressAlwaysContext,
 	}
 }

--- a/internal/app/adapters_test.go
+++ b/internal/app/adapters_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/nugget/thane-ai-agent/internal/runtime/agentctx"
 	looppkg "github.com/nugget/thane-ai-agent/internal/runtime/loop"
 	"github.com/nugget/thane-ai-agent/internal/state/contacts"
 	"github.com/nugget/thane-ai-agent/internal/state/memory"
@@ -49,6 +50,7 @@ func TestCompileLoopAgentRequest(t *testing.T) {
 		UsageRole:       "delegate",
 		UsageTaskName:   "spec-probe",
 		SystemPrompt:    "custom prompt",
+		PromptMode:      agentctx.PromptModeTask,
 	}
 
 	got := compileLoopAgentRequest(req)
@@ -78,6 +80,9 @@ func TestCompileLoopAgentRequest(t *testing.T) {
 	}
 	if got.SystemPrompt != "custom prompt" {
 		t.Fatalf("SystemPrompt = %q", got.SystemPrompt)
+	}
+	if got.PromptMode != agentctx.PromptModeTask {
+		t.Fatalf("PromptMode = %q, want task", got.PromptMode)
 	}
 
 	got.AllowedTools[0] = "changed"

--- a/internal/app/new_agent.go
+++ b/internal/app/new_agent.go
@@ -105,8 +105,9 @@ func (a *App) initAgentLoop(s *newState) error {
 	s.resolver = resolver
 
 	// Resolve fixed core context files at startup (tilde expansion,
-	// existence check) but defer reading to each agent turn so edits
-	// under workspace/core are visible without restart.
+	// existence check) but defer reading to the core context provider
+	// each agent turn so edits under workspace/core are visible without
+	// restart.
 	var resolvedInjectFiles []string
 	if injectFiles := cfg.CoreInjectFiles(); len(injectFiles) > 0 {
 		for _, path := range injectFiles {
@@ -126,8 +127,9 @@ func (a *App) initAgentLoop(s *newState) error {
 	}
 	s.resolvedInjectFiles = resolvedInjectFiles
 
-	// Resolve ego.md path if a workspace is configured. The agent reads
-	// the file fresh on every turn, so the path is enough at startup.
+	// Resolve ego.md path if a workspace is configured. The core context
+	// provider reads the file fresh on every turn, so the path is enough
+	// at startup.
 	var egoFile string
 	if cfg.Workspace.Path != "" {
 		egoFile = resolvePath(coreFilePath(cfg.Workspace.Path, "ego.md"), nil)

--- a/internal/app/new_channels.go
+++ b/internal/app/new_channels.go
@@ -303,7 +303,7 @@ func (a *App) initChannels(s *newState) error {
 			a.logger.LogAttrs(context.Background(), slog.LevelInfo, "document index enabled", attrs...)
 
 			// Close the verification bypass paths surfaced by #788:
-			// the model's file tools and startup inject-files read raw
+			// the model's file tools and core context provider read raw
 			// filesystem paths that may fall inside a managed root.
 			// Route those through the store's verification policies.
 			// Paths outside any managed root are no-ops inside VerifyPath,

--- a/internal/model/prompts/delegate.go
+++ b/internal/model/prompts/delegate.go
@@ -1,13 +1,39 @@
 package prompts
 
+import "strings"
+
 // DelegateRunInstructions is the reusable execution contract for spawned
 // delegate loops and the legacy delegate runner.
 const DelegateRunInstructions = `Complete the assigned task using the available tools. Report findings clearly and concisely.
 
 Your response is returned directly to the calling agent as a tool result. If you called tools and received data, include the relevant data in your final text response. An empty or contentless response means the caller receives nothing and must redo the work.`
 
+// DelegateSystemPrompt is the compact system prompt for task-focused
+// delegate runs.
+func DelegateSystemPrompt() string {
+	return `You are Thane running as a bounded task worker for another agent.
+
+Complete only the assigned task. Use the available tools when they are needed. Return concise, concrete findings to the calling agent.
+
+Do not assume access to the caller's private conversation, identity notes, or long-term self-reflection unless they are explicitly included in this prompt or the task text.`
+}
+
+// DelegateRuntimeContract is the compact execution contract for
+// task-focused delegate runs.
+func DelegateRuntimeContract() string {
+	return strings.Join([]string{
+		"## Runtime Contract",
+		"",
+		"- Use only exact tool names that are actually available in this turn.",
+		"- Capability changes are runtime actions. Use available capability tools instead of describing capability state conversationally.",
+		"- Use active capability guidance and tagged context to decide which visible tools fit the task.",
+		"- If a needed tool is unavailable, report what is missing instead of inventing aliases or wrappers.",
+		"- Return a non-empty final answer that includes the relevant data from any tool results you used.",
+	}, "\n")
+}
+
 // DelegateToolDescription is the LLM-facing description for the thane_delegate tool.
-const DelegateToolDescription = `Delegate a concrete task to a smaller, cheaper model for execution. The delegate has access to tools and can iterate, but operates without your conversation history or personality.
+const DelegateToolDescription = `Delegate a concrete task to a smaller, cheaper model for execution. The delegate has access to tools and can iterate, but by default operates without your conversation history or personality.
 
 Delegates are for EXECUTION, not analysis. You handle reasoning, judgment, and synthesis — the delegate handles tool-heavy legwork.
 
@@ -31,5 +57,7 @@ Use the guidance field to steer execution: provide entity names, file paths, spe
 Use tags to scope the delegate's capability surface. Use a root entry-point tag like development, home, operations, knowledge, media, interactive, or people when the delegate should read the menu guidance and decide which narrower toolset to activate. Use leaf tags like ha, files, forge, web, loops, documents, or diagnostics when you already know the exact surface needed.
 
 Delegates inherit the caller's elective capability tags by default. Set inherit_caller_tags=false only when you need a strict, fresh tool scope.
+
+Delegates use context_mode="task" by default: compact task-worker prompt, active capability summaries, tagged context, and current conditions, without full Thane identity files or conversation continuity. Use context_mode="full" only when the delegate truly needs full persona, ego, injected core context, always-on talents, and conversation-history dressing.
 
 Use mode="async" when you want the delegate to keep running in the background and report the result back into the current conversation later instead of blocking for a direct reply.`

--- a/internal/runtime/agent/core_context.go
+++ b/internal/runtime/agent/core_context.go
@@ -1,0 +1,212 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/nugget/thane-ai-agent/internal/model/promptfmt"
+	"github.com/nugget/thane-ai-agent/internal/platform/provenance"
+	"github.com/nugget/thane-ai-agent/internal/runtime/agentctx"
+)
+
+// CoreContextProvider publishes curated core identity and continuity
+// documents through the normal context-provider pipeline.
+type CoreContextProvider struct {
+	mu sync.RWMutex
+
+	logger             *slog.Logger
+	egoFile            string
+	provenanceStore    *provenance.Store
+	injectFiles        []string
+	injectFileVerifier func(context.Context, string, string) error
+	now                func() time.Time
+}
+
+// CoreContextProviderConfig holds optional wiring for
+// [CoreContextProvider].
+type CoreContextProviderConfig struct {
+	Logger          *slog.Logger
+	EgoFile         string
+	ProvenanceStore *provenance.Store
+	InjectFiles     []string
+	Now             func() time.Time
+}
+
+// NewCoreContextProvider creates a core context provider.
+func NewCoreContextProvider(cfg CoreContextProviderConfig) *CoreContextProvider {
+	if cfg.Logger == nil {
+		cfg.Logger = slog.Default()
+	}
+	if cfg.Now == nil {
+		cfg.Now = time.Now
+	}
+	return &CoreContextProvider{
+		logger:          cfg.Logger,
+		egoFile:         cfg.EgoFile,
+		provenanceStore: cfg.ProvenanceStore,
+		injectFiles:     append([]string(nil), cfg.InjectFiles...),
+		now:             cfg.Now,
+	}
+}
+
+func (p *CoreContextProvider) updateEgoFile(path string) {
+	if p == nil {
+		return
+	}
+	p.mu.Lock()
+	p.egoFile = path
+	p.mu.Unlock()
+}
+
+func (p *CoreContextProvider) updateInjectFiles(paths []string) {
+	if p == nil {
+		return
+	}
+	p.mu.Lock()
+	p.injectFiles = append([]string(nil), paths...)
+	p.mu.Unlock()
+}
+
+func (p *CoreContextProvider) updateInjectFileVerifier(verifier func(context.Context, string, string) error) {
+	if p == nil {
+		return
+	}
+	p.mu.Lock()
+	p.injectFileVerifier = verifier
+	p.mu.Unlock()
+}
+
+func (p *CoreContextProvider) updateProvenanceStore(store *provenance.Store) {
+	if p == nil {
+		return
+	}
+	p.mu.Lock()
+	p.provenanceStore = store
+	p.mu.Unlock()
+}
+
+// TagContext returns core continuity context for always-on injection.
+func (p *CoreContextProvider) TagContext(ctx context.Context, _ agentctx.ContextRequest) (string, error) {
+	if p == nil {
+		return "", nil
+	}
+
+	p.mu.RLock()
+	egoFile := p.egoFile
+	prov := p.provenanceStore
+	injectFiles := append([]string(nil), p.injectFiles...)
+	verifier := p.injectFileVerifier
+	now := p.now
+	logger := p.logger
+	p.mu.RUnlock()
+	if logger == nil {
+		logger = slog.Default()
+	}
+	if now == nil {
+		now = time.Now
+	}
+
+	var sb strings.Builder
+	p.appendEgo(ctx, &sb, egoFile, prov, verifier, now, logger)
+	p.appendInjectFiles(ctx, &sb, injectFiles, verifier, logger)
+	return strings.TrimSpace(sb.String()), nil
+}
+
+func (p *CoreContextProvider) appendEgo(ctx context.Context, sb *strings.Builder, egoFile string, prov *provenance.Store, verifier func(context.Context, string, string) error, now func() time.Time, logger *slog.Logger) {
+	if prov != nil {
+		p.appendEgoFromProvenance(ctx, sb, prov, now, logger)
+		return
+	}
+	if strings.TrimSpace(egoFile) == "" {
+		return
+	}
+	if verifier != nil {
+		if err := verifier(ctx, egoFile, "ego_file"); err != nil {
+			logger.Warn("ego file blocked by verification policy", "path", egoFile, "error", err)
+			return
+		}
+	}
+	data, err := os.ReadFile(egoFile)
+	if err != nil || len(data) == 0 {
+		return
+	}
+	appendProviderSeparator(sb)
+	sb.WriteString("### Self-Reflection (ego.md)\n\n")
+	sb.WriteString(truncateCoreContext(string(data), maxEgoBytes, "\n\n[ego.md truncated — exceeded 16 KB limit]"))
+}
+
+func (p *CoreContextProvider) appendEgoFromProvenance(ctx context.Context, sb *strings.Builder, prov *provenance.Store, now func() time.Time, logger *slog.Logger) {
+	content, err := prov.Read("ego.md")
+	if err != nil || len(content) == 0 {
+		return
+	}
+
+	appendProviderSeparator(sb)
+	sb.WriteString("### Self-Reflection (ego.md)\n")
+	if hist, err := prov.History(ctx, "ego.md"); err == nil && hist.RevisionCount > 0 {
+		sb.WriteString(fmt.Sprintf("(updated %s by %s, revision %d)\n",
+			promptfmt.FormatDeltaOnly(hist.LastModified, now()), hist.LastMessage, hist.RevisionCount))
+	} else if err != nil {
+		logger.Debug("failed to read ego.md provenance history", "error", err)
+	}
+	sb.WriteString("\n")
+	sb.WriteString(truncateCoreContext(content, maxEgoBytes, "\n\n[ego.md truncated — exceeded 16 KB limit]"))
+}
+
+func (p *CoreContextProvider) appendInjectFiles(ctx context.Context, sb *strings.Builder, injectFiles []string, verifier func(context.Context, string, string) error, logger *slog.Logger) {
+	var ctxBuf strings.Builder
+	for _, path := range injectFiles {
+		if verifier != nil {
+			if err := verifier(ctx, path, "inject_files"); err != nil {
+				logger.Warn("inject file blocked by verification policy", "path", path, "error", err)
+				continue
+			}
+		}
+		data, err := os.ReadFile(path)
+		if err != nil || len(data) == 0 {
+			continue
+		}
+		if ctxBuf.Len() > 0 {
+			ctxBuf.WriteString("\n\n---\n\n")
+		}
+		ctxBuf.Write(data)
+	}
+	if ctxBuf.Len() == 0 {
+		return
+	}
+	appendProviderSeparator(sb)
+	sb.WriteString("### Injected Context\n\n")
+	sb.WriteString(ctxBuf.String())
+}
+
+func appendProviderSeparator(sb *strings.Builder) {
+	if sb.Len() > 0 {
+		sb.WriteString("\n\n---\n\n")
+	}
+}
+
+func truncateCoreContext(s string, maxBytes int, marker string) string {
+	if maxBytes <= 0 || len(s) <= maxBytes {
+		return s
+	}
+	limit := maxBytes - len(marker)
+	if limit <= 0 {
+		return marker
+	}
+	cut := 0
+	for i := range s {
+		if i > limit {
+			break
+		}
+		cut = i
+	}
+	if cut == 0 {
+		return marker
+	}
+	return s[:cut] + marker
+}

--- a/internal/runtime/agent/ego_prompt_test.go
+++ b/internal/runtime/agent/ego_prompt_test.go
@@ -8,6 +8,9 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/nugget/thane-ai-agent/internal/runtime/agentctx"
+	"github.com/nugget/thane-ai-agent/internal/state/memory"
 )
 
 func newMinimalLoop() *Loop {
@@ -217,5 +220,49 @@ func TestBuildSystemPrompt_InjectFilesEmpty(t *testing.T) {
 
 	if strings.Contains(prompt, "Injected Context") {
 		t.Error("system prompt should not contain injected context section when no files configured")
+	}
+}
+
+func TestBuildSystemPrompt_TaskModeOmitsIdentityContinuityContext(t *testing.T) {
+	dir := t.TempDir()
+	egoPath := filepath.Join(dir, "ego.md")
+	injectPath := filepath.Join(dir, "metacognitive.md")
+	if err := os.WriteFile(egoPath, []byte("EGO_MARKER"), 0o644); err != nil {
+		t.Fatalf("write ego.md: %v", err)
+	}
+	if err := os.WriteFile(injectPath, []byte("INJECT_MARKER"), 0o644); err != nil {
+		t.Fatalf("write inject file: %v", err)
+	}
+
+	l := newMinimalLoop()
+	l.persona = "PERSONA_MARKER"
+	l.SetEgoFile(egoPath)
+	l.SetInjectFiles([]string{injectPath})
+
+	ctx := agentctx.WithPromptMode(context.Background(), agentctx.PromptModeTask)
+	history := []memory.Message{{Role: "user", Content: "HISTORY_MARKER"}}
+	prompt := l.buildSystemPrompt(ctx, "hello", history)
+
+	for _, marker := range []string{
+		"PERSONA_MARKER",
+		"EGO_MARKER",
+		"INJECT_MARKER",
+		"HISTORY_MARKER",
+		"Self-Reflection (ego.md)",
+		"Injected Context",
+		"Conversation History",
+	} {
+		if strings.Contains(prompt, marker) {
+			t.Fatalf("task prompt contains %q:\n%s", marker, prompt)
+		}
+	}
+	for _, marker := range []string{
+		"bounded task worker",
+		"## Runtime Contract",
+		"Current Conditions",
+	} {
+		if !strings.Contains(prompt, marker) {
+			t.Fatalf("task prompt missing %q:\n%s", marker, prompt)
+		}
 	}
 }

--- a/internal/runtime/agent/loop.go
+++ b/internal/runtime/agent/loop.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"os"
 	"sort"
 	"strconv"
 	"strings"
@@ -65,6 +64,7 @@ type Request struct {
 	UsageRole       string                 `json:"-"`               // Optional usage role override (e.g., "delegate")
 	UsageTaskName   string                 `json:"-"`               // Optional usage task name override
 	FallbackContent string                 `json:"-"`               // Optional static fallback text when the run yields no content
+	PromptMode      agentctx.PromptMode    `json:"-"`               // Optional system-prompt shape override.
 
 	// SystemPrompt, when non-empty, replaces the output of
 	// buildSystemPrompt(). Used by callers that assemble their own
@@ -98,8 +98,9 @@ const (
 	KindLLMStart      = llm.KindLLMStart
 )
 
-// maxEgoBytes is the maximum size of ego.md content injected into the
-// system prompt. Content beyond this limit is truncated with a marker.
+// maxEgoBytes is the maximum size of ego.md content published through
+// the core context provider. Content beyond this limit is truncated
+// with a marker.
 const maxEgoBytes = 16 * 1024
 
 // maxTagContextBytes is the aggregate size limit for all tag context
@@ -226,13 +227,10 @@ type Loop struct {
 	llm                 llm.Client
 	tools               *tools.Registry
 	model               string
-	recoveryModel       string            // Fast model for timeout recovery summaries (empty = disabled)
-	retryBaseDelay      time.Duration     // Base backoff delay between timeout retries (0 = use default)
-	persona             string            // Persona content (replaces base system prompt if set)
-	egoFile             string            // Path to ego.md — read fresh each turn for system prompt
-	provenanceStore     *provenance.Store // Optional provenance store for ego.md metadata injection
-	injectFiles         []string          // Paths to context files — re-read each turn
-	injectFileVerifier  func(context.Context, string, string) error
+	recoveryModel       string        // Fast model for timeout recovery summaries (empty = disabled)
+	retryBaseDelay      time.Duration // Base backoff delay between timeout retries (0 = use default)
+	persona             string        // Persona content (replaces base system prompt if set)
+	coreContextProvider *CoreContextProvider
 	timezone            string // IANA timezone for Current Conditions (e.g., "America/Chicago")
 	contextWindow       int    // Context window size of default model
 	failoverHandler     FailoverHandler
@@ -364,15 +362,17 @@ func NewLoop(opts LoopOptions) (*Loop, error) {
 		timezone:            opts.Timezone,
 		recoveryModel:       opts.RecoveryModel,
 		archiver:            opts.Archiver,
-		injectFiles:         opts.InjectFiles,
-		egoFile:             opts.EgoFile,
-		provenanceStore:     opts.ProvenanceStore,
 		haInject:            opts.HAInject,
 		modelRegistry:       opts.ModelRegistry,
 		modelRuntime:        opts.ModelRuntime,
 		liveRequestRecorder: opts.LiveRequestRecorder,
 		requestRecorder:     opts.RequestRecorder,
 		nowFunc:             time.Now,
+	}
+	if opts.EgoFile != "" || opts.ProvenanceStore != nil || len(opts.InjectFiles) > 0 {
+		l.ensureCoreContextProvider().updateEgoFile(opts.EgoFile)
+		l.coreContextProvider.updateProvenanceStore(opts.ProvenanceStore)
+		l.coreContextProvider.updateInjectFiles(opts.InjectFiles)
 	}
 	return l, nil
 }
@@ -443,18 +443,34 @@ func (l *Loop) RegisterAlwaysContextProvider(p TagContextProvider) {
 // grouped Configure* methods for late-binding state; new code should
 // prefer those entry points.
 
-// SetEgoFile sets the path to ego.md. The file is read fresh on each
-// turn after this is set.
-func (l *Loop) SetEgoFile(path string) { l.egoFile = path }
+// SetEgoFile sets the path to ego.md. The file is published through
+// the always-on context-provider pipeline and read fresh on each turn.
+func (l *Loop) SetEgoFile(path string) {
+	l.ensureCoreContextProvider().updateEgoFile(path)
+}
 
-// SetInjectFiles sets the file paths whose content is re-read and
-// injected into the system prompt on every turn.
-func (l *Loop) SetInjectFiles(paths []string) { l.injectFiles = paths }
+// SetInjectFiles sets the core context files published through the
+// always-on context-provider pipeline on each turn.
+func (l *Loop) SetInjectFiles(paths []string) {
+	l.ensureCoreContextProvider().updateInjectFiles(paths)
+}
 
 // UseInjectFileVerifier configures the verifier used before each
-// inject-file read during system-prompt assembly.
+// core context file read during system-prompt assembly.
 func (l *Loop) UseInjectFileVerifier(verifier func(context.Context, string, string) error) {
-	l.injectFileVerifier = verifier
+	l.ensureCoreContextProvider().updateInjectFileVerifier(verifier)
+}
+
+func (l *Loop) ensureCoreContextProvider() *CoreContextProvider {
+	if l.coreContextProvider != nil {
+		return l.coreContextProvider
+	}
+	l.coreContextProvider = NewCoreContextProvider(CoreContextProviderConfig{
+		Logger: l.logger,
+		Now:    l.nowFunc,
+	})
+	l.RegisterAlwaysContextProvider(l.coreContextProvider)
+	return l.coreContextProvider
 }
 
 // SetHAInject configures the HA entity state resolver for tag context
@@ -573,9 +589,46 @@ func (l *Loop) SetTagContextAssembler(a *TagContextAssembler) {
 	for tag, p := range pendingTagged {
 		a.RegisterTaggedProvider(tag, p)
 	}
+	coreRegistered := false
 	for _, p := range pendingAlways {
 		a.RegisterAlwaysProvider(p)
+		if p == l.coreContextProvider {
+			coreRegistered = true
+		}
 	}
+	if l.coreContextProvider != nil && !coreRegistered {
+		a.RegisterAlwaysProvider(l.coreContextProvider)
+	}
+}
+
+func (l *Loop) contextAssemblerForPrompt() *TagContextAssembler {
+	l.pendingProvidersMu.Lock()
+	assembler := l.tagContextAssembler
+	if assembler != nil {
+		l.pendingProvidersMu.Unlock()
+		return assembler
+	}
+	pendingTagged := make(map[string]TagContextProvider, len(l.pendingTagProviders))
+	for tag, p := range l.pendingTagProviders {
+		pendingTagged[tag] = p
+	}
+	pendingAlways := append([]TagContextProvider(nil), l.pendingAlwaysProviders...)
+	l.pendingProvidersMu.Unlock()
+
+	if len(pendingTagged) == 0 && len(pendingAlways) == 0 {
+		return nil
+	}
+	assembler = NewTagContextAssembler(TagContextAssemblerConfig{
+		HAInject: l.haInject,
+		Logger:   l.logger,
+	})
+	for tag, p := range pendingTagged {
+		assembler.RegisterTaggedProvider(tag, p)
+	}
+	for _, p := range pendingAlways {
+		assembler.RegisterAlwaysProvider(p)
+	}
+	return assembler
 }
 
 // SetOrchestratorTools configures the restricted tool set for all
@@ -911,6 +964,8 @@ func (l *Loop) buildSystemPromptWithProfile(ctx context.Context, userMessage str
 
 func (l *Loop) buildSystemPromptWithProfileSections(ctx context.Context, userMessage string, history []memory.Message, profile llm.ModelInteractionProfile) (string, []llm.PromptSection) {
 	var sb strings.Builder
+	promptMode := agentctx.PromptModeFromContext(ctx)
+	taskPrompt := promptMode == agentctx.PromptModeTask
 
 	// Snapshot active tags from the per-Run capability scope.
 	tags := snapshotTagsFromContext(ctx)
@@ -922,52 +977,24 @@ func (l *Loop) buildSystemPromptWithProfileSections(ctx context.Context, userMes
 
 	// 1. Persona (identity — who am I)
 	mark("PERSONA")
-	if l.persona != "" {
+	if taskPrompt {
+		sb.WriteString(prompts.DelegateSystemPrompt())
+	} else if l.persona != "" {
 		sb.WriteString(l.persona)
 	} else {
 		sb.WriteString(prompts.BaseSystemPrompt())
 	}
 	seal()
 
-	// 2. Ego (self-reflection — what have I been noticing/thinking)
-	l.injectEgo(ctx, &sb, mark, seal)
-
-	// 2b. Runtime contract (execution semantics — how should I use tools)
+	// 2. Runtime contract (execution semantics — how should I use tools)
 	mark("RUNTIME CONTRACT")
 	sb.WriteString("\n\n")
-	sb.WriteString(prompts.RuntimeContract())
-	seal()
-
-	// 3. Injected context (knowledge — what do I know)
-	// Re-read registered core context files each turn so external edits
-	// (for example mission.md updates) are visible without restart.
-	if len(l.injectFiles) > 0 {
-		var ctxBuf strings.Builder
-		for _, path := range l.injectFiles {
-			if l.injectFileVerifier != nil {
-				if err := l.injectFileVerifier(ctx, path, "inject_files"); err != nil {
-					if l.logger != nil {
-						l.logger.Warn("inject file blocked by verification policy", "path", path, "error", err)
-					}
-					continue
-				}
-			}
-			data, err := os.ReadFile(path)
-			if err != nil {
-				continue
-			}
-			if ctxBuf.Len() > 0 {
-				ctxBuf.WriteString("\n\n---\n\n")
-			}
-			ctxBuf.Write(data)
-		}
-		if ctxBuf.Len() > 0 {
-			mark("INJECTED CONTEXT")
-			sb.WriteString("\n\n## Injected Context\n\n")
-			sb.WriteString(ctxBuf.String())
-			seal()
-		}
+	if taskPrompt {
+		sb.WriteString(prompts.DelegateRuntimeContract())
+	} else {
+		sb.WriteString(prompts.RuntimeContract())
 	}
+	seal()
 
 	if contract := strings.TrimSpace(profile.ToolCallingContract()); contract != "" {
 		mark("TOOL CALLING CONTRACT")
@@ -981,7 +1008,7 @@ func (l *Loop) buildSystemPromptWithProfileSections(ctx context.Context, userMes
 	// Keep always-on guidance ahead of volatile context so provider-side
 	// prompt caching can retain the stable behavioral prefix.
 	alwaysOnTalents, taggedTalents := talents.SplitByTags(l.parsedTalents, tags)
-	if alwaysOnTalents != "" {
+	if !taskPrompt && alwaysOnTalents != "" {
 		mark("TALENTS ALWAYS ON")
 		sb.WriteString("\n\n## Behavioral Guidance\n\n")
 		sb.WriteString(alwaysOnTalents)
@@ -989,7 +1016,7 @@ func (l *Loop) buildSystemPromptWithProfileSections(ctx context.Context, userMes
 	}
 	if taggedTalents != "" {
 		mark("TALENTS TAGGED")
-		if alwaysOnTalents != "" {
+		if !taskPrompt && alwaysOnTalents != "" {
 			sb.WriteString("\n\n---\n\n")
 		} else {
 			sb.WriteString("\n\n## Behavioral Guidance\n\n")
@@ -1008,11 +1035,13 @@ func (l *Loop) buildSystemPromptWithProfileSections(ctx context.Context, userMes
 	}
 
 	// 5b. Session origin policy (runtime data about why this run was shaped).
-	if originCtx := l.renderSessionOriginContext(ctx); originCtx != "" {
-		mark("SESSION ORIGIN CONTEXT")
-		sb.WriteString("\n\n## Session Origin Context\n\n")
-		sb.WriteString(originCtx)
-		seal()
+	if !taskPrompt {
+		if originCtx := l.renderSessionOriginContext(ctx); originCtx != "" {
+			mark("SESSION ORIGIN CONTEXT")
+			sb.WriteString("\n\n## Session Origin Context\n\n")
+			sb.WriteString(originCtx)
+			seal()
+		}
 	}
 
 	// 6. Capability context (capability knowledge + ambient context)
@@ -1021,16 +1050,16 @@ func (l *Loop) buildSystemPromptWithProfileSections(ctx context.Context, userMes
 	// providers. Always-on providers are gated by IncludeAlways: main
 	// loop runs include them; delegate runs (which set
 	// req.SuppressAlwaysContext via the loops launch) do not.
-	if l.tagContextAssembler != nil {
+	if assembler := l.contextAssemblerForPrompt(); assembler != nil {
 		haCtx, haCancel := context.WithTimeout(ctx, 2*time.Second)
 		defer haCancel()
 
 		req := ContextRequest{
 			UserMessage:   userMessage,
 			ActiveTags:    tags,
-			IncludeAlways: !tools.SuppressAlwaysContextFromContext(ctx),
+			IncludeAlways: !taskPrompt && !tools.SuppressAlwaysContextFromContext(ctx),
 		}
-		if capCtx := l.tagContextAssembler.Build(haCtx, req); capCtx != "" {
+		if capCtx := assembler.Build(haCtx, req); capCtx != "" {
 			mark("CAPABILITY CONTEXT")
 			sb.WriteString("\n\n## Capability Context\n\n")
 			sb.WriteString(capCtx)
@@ -1048,7 +1077,7 @@ func (l *Loop) buildSystemPromptWithProfileSections(ctx context.Context, userMes
 	// Embedding history as JSON in the system prompt creates an unambiguous
 	// boundary between "what happened before" and "what just arrived." The
 	// new user input follows as a standard chat message after this prompt.
-	if len(history) > 0 {
+	if !taskPrompt && len(history) > 0 {
 		mark("CONVERSATION HISTORY")
 		sb.WriteString("\n\n## Conversation History\n\n")
 		sb.WriteString("The following fenced JSON array contains prior messages in this conversation. ")
@@ -1094,10 +1123,10 @@ func (l *Loop) renderSessionOriginContext(ctx context.Context) string {
 	sb.Write(data)
 	sb.WriteString("\n```\n")
 
-	if l.tagContextAssembler != nil && len(result.ContextRefs) > 0 {
+	if assembler := l.contextAssemblerForPrompt(); assembler != nil && len(result.ContextRefs) > 0 {
 		haCtx, haCancel := context.WithTimeout(ctx, 2*time.Second)
 		defer haCancel()
-		if refs := l.tagContextAssembler.BuildRefs(haCtx, result.ContextRefs); refs != "" {
+		if refs := assembler.BuildRefs(haCtx, result.ContextRefs); refs != "" {
 			sb.WriteString("\n\n### Context Refs\n\n")
 			sb.WriteString(refs)
 		}
@@ -1334,62 +1363,6 @@ func canonicalCapabilityAlias(value string) string {
 	return strings.Trim(value, "_")
 }
 
-// injectEgo injects the ego.md content into the system prompt. When a
-// provenance store is configured, delta-relative metadata (time since
-// last modification, revision count) is prepended. Otherwise, the file
-// is read directly from disk.
-func (l *Loop) injectEgo(ctx context.Context, sb *strings.Builder, mark func(string), seal func()) {
-	if l.provenanceStore != nil {
-		l.injectEgoFromProvenance(ctx, sb, mark, seal)
-		return
-	}
-
-	// Fallback: direct file read.
-	if l.egoFile == "" {
-		return
-	}
-	data, err := os.ReadFile(l.egoFile)
-	if err != nil || len(data) == 0 {
-		return
-	}
-	mark("EGO")
-	sb.WriteString("\n\n## Self-Reflection (ego.md)\n\n")
-	if len(data) > maxEgoBytes {
-		sb.WriteString(string(data[:maxEgoBytes]))
-		sb.WriteString("\n\n[ego.md truncated — exceeded 16 KB limit]")
-	} else {
-		sb.WriteString(string(data))
-	}
-	seal()
-}
-
-// injectEgoFromProvenance reads ego.md from the provenance store and
-// prepends delta-relative metadata derived from git history.
-func (l *Loop) injectEgoFromProvenance(ctx context.Context, sb *strings.Builder, mark func(string), seal func()) {
-	content, err := l.provenanceStore.Read("ego.md")
-	if err != nil || len(content) == 0 {
-		return
-	}
-
-	mark("EGO")
-	sb.WriteString("\n\n## Self-Reflection (ego.md)\n")
-
-	// Inject delta-relative metadata from git history.
-	if hist, err := l.provenanceStore.History(ctx, "ego.md"); err == nil && hist.RevisionCount > 0 {
-		sb.WriteString(fmt.Sprintf("(updated %s by %s, revision %d)\n",
-			promptfmt.FormatDeltaOnly(hist.LastModified, time.Now()), hist.LastMessage, hist.RevisionCount))
-	}
-
-	sb.WriteString("\n")
-	if len(content) > maxEgoBytes {
-		sb.WriteString(content[:maxEgoBytes])
-		sb.WriteString("\n\n[ego.md truncated — exceeded 16 KB limit]")
-	} else {
-		sb.WriteString(content)
-	}
-	seal()
-}
-
 // generateRequestID returns a human-scannable identifier for a single
 // user-message turn (e.g., "r_7f3ab2c1d5e6f7a8"). It uses 8 random
 // bytes from a UUIDv7 (bytes 8-15), giving ~62 bits of effective
@@ -1482,6 +1455,7 @@ func (l *Loop) Run(ctx context.Context, req *Request, stream StreamCallback) (re
 		"kind", events.KindRequestStart,
 		"message_count", len(req.Messages),
 		"mission", req.Hints["mission"],
+		"prompt_mode", req.PromptMode.OrDefault(),
 		"skip_context", req.SkipContext,
 		"max_iterations", req.MaxIterations,
 	)
@@ -1717,6 +1691,7 @@ func (l *Loop) Run(ctx context.Context, req *Request, stream StreamCallback) (re
 	// Build messages for LLM. Enrich ctx with conversation ID so that
 	// context providers (e.g. working memory) can scope their output.
 	// Propagate request hints so channel-aware providers can adapt.
+	ctx = agentctx.WithPromptMode(ctx, req.PromptMode)
 	promptCtx := tools.WithConversationID(ctx, convID)
 	promptCtx = tools.WithHints(promptCtx, req.Hints)
 	promptCtx = tools.WithChannelBinding(promptCtx, channelBinding)

--- a/internal/runtime/agent/tag_context.go
+++ b/internal/runtime/agent/tag_context.go
@@ -35,8 +35,9 @@ import (
 // always-bucket walker. Tagged vs always is encoded as where each
 // source registered, not as a separate code path. KB articles and
 // explicit context refs flow through the optional managed-root
-// signature verifier; always-providers do not (they return content
-// the agent itself wrote, not disk-managed material).
+// signature verifier. Providers that read disk-managed material are
+// responsible for applying their own verification before returning
+// model-facing content.
 //
 // Both the main agent loop and delegate executor share a single
 // assembler. The assembler is safe for concurrent use after

--- a/internal/runtime/agent/tag_context_test.go
+++ b/internal/runtime/agent/tag_context_test.go
@@ -230,7 +230,7 @@ func TestBuildSystemPrompt_TagContextChannelPinnedBuiltinTagIncluded(t *testing.
 	}
 }
 
-func TestBuildSystemPrompt_TagContextOrderAfterInjected(t *testing.T) {
+func TestBuildSystemPrompt_CoreContextProviderOrder(t *testing.T) {
 	dir := t.TempDir()
 	injected := filepath.Join(dir, "injected.md")
 	os.WriteFile(injected, []byte("INJECTED_MARKER"), 0644)
@@ -272,12 +272,13 @@ func TestBuildSystemPrompt_TagContextOrderAfterInjected(t *testing.T) {
 		t.Fatal("prompt should contain current conditions")
 	}
 
-	// Tag context should appear between injected context and conditions.
-	if tagCtxIdx < injectedIdx {
-		t.Error("tag context should appear after injected context")
+	// Core context now enters through the always-on provider bucket,
+	// after tagged context and before current conditions.
+	if injectedIdx < tagCtxIdx {
+		t.Error("core context should appear after tagged context")
 	}
-	if tagCtxIdx > conditionsIdx {
-		t.Error("tag context should appear before current conditions")
+	if injectedIdx > conditionsIdx {
+		t.Error("core context should appear before current conditions")
 	}
 }
 

--- a/internal/runtime/agentctx/request.go
+++ b/internal/runtime/agentctx/request.go
@@ -6,6 +6,28 @@
 // import cycles.
 package agentctx
 
+import (
+	"context"
+	"fmt"
+)
+
+// PromptMode names the system-prompt shape used for an agent run.
+type PromptMode string
+
+const (
+	// PromptModeFull is the default Thane prompt: persona, ego,
+	// configured inject files, talents, generated runtime context, and
+	// conversation history.
+	PromptModeFull PromptMode = "full"
+
+	// PromptModeTask is a compact worker prompt for bounded child
+	// tasks. It preserves tool contracts and tag-scoped context while
+	// omitting full identity and continuity material.
+	PromptModeTask PromptMode = "task"
+)
+
+type promptModeKey struct{}
+
 // ContextRequest carries everything a context provider might need
 // during system-prompt assembly. Always-on providers ignore
 // ActiveTags; tagged providers ignore UserMessage when they don't
@@ -22,4 +44,49 @@ type ContextRequest struct {
 	UserMessage   string
 	ActiveTags    map[string]bool
 	IncludeAlways bool
+}
+
+// ParsePromptMode validates a wire value and returns the corresponding
+// prompt mode. An empty value resolves to the full default.
+func ParsePromptMode(value string) (PromptMode, error) {
+	mode := PromptMode(value)
+	if mode == "" {
+		return PromptModeFull, nil
+	}
+	if mode.Valid() {
+		return mode, nil
+	}
+	return "", fmt.Errorf("prompt_mode must be one of [full, task], got %q", value)
+}
+
+// Valid reports whether m is a supported prompt mode.
+func (m PromptMode) Valid() bool {
+	switch m {
+	case "", PromptModeFull, PromptModeTask:
+		return true
+	default:
+		return false
+	}
+}
+
+// OrDefault returns m when set, otherwise the full prompt mode.
+func (m PromptMode) OrDefault() PromptMode {
+	if m == "" {
+		return PromptModeFull
+	}
+	return m
+}
+
+// WithPromptMode annotates ctx with the system-prompt shape for the run.
+func WithPromptMode(ctx context.Context, mode PromptMode) context.Context {
+	return context.WithValue(ctx, promptModeKey{}, mode.OrDefault())
+}
+
+// PromptModeFromContext returns the requested prompt mode, defaulting to
+// full when no request-scoped mode has been set.
+func PromptModeFromContext(ctx context.Context) PromptMode {
+	if mode, ok := ctx.Value(promptModeKey{}).(PromptMode); ok && mode.Valid() {
+		return mode.OrDefault()
+	}
+	return PromptModeFull
 }

--- a/internal/runtime/delegate/delegate.go
+++ b/internal/runtime/delegate/delegate.go
@@ -19,6 +19,7 @@ import (
 	"github.com/nugget/thane-ai-agent/internal/platform/events"
 	"github.com/nugget/thane-ai-agent/internal/platform/logging"
 	"github.com/nugget/thane-ai-agent/internal/runtime/agent"
+	"github.com/nugget/thane-ai-agent/internal/runtime/agentctx"
 	"github.com/nugget/thane-ai-agent/internal/runtime/iterate"
 	looppkg "github.com/nugget/thane-ai-agent/internal/runtime/loop"
 	"github.com/nugget/thane-ai-agent/internal/state/memory"
@@ -42,10 +43,21 @@ const (
 type executionOptions struct {
 	inheritCallerTags bool
 	explicitTagScope  bool
+	promptMode        agentctx.PromptMode
 }
 
 func defaultExecutionOptions() executionOptions {
-	return executionOptions{inheritCallerTags: true}
+	return executionOptions{
+		inheritCallerTags: true,
+		promptMode:        agentctx.PromptModeTask,
+	}
+}
+
+func (o executionOptions) effectivePromptMode() agentctx.PromptMode {
+	if o.promptMode == "" {
+		return agentctx.PromptModeTask
+	}
+	return o.promptMode
 }
 
 func mergeDelegateScopeTags(ctx context.Context, explicitTags []string, inheritCallerTags bool, explicitTagScope bool) (scopeTags []string, inheritedTags []string, droppedTags []string, explicitScopeRequested bool) {
@@ -433,6 +445,7 @@ type preparedExecution struct {
 	maxOutputTokens  int
 	maxDuration      time.Duration
 	toolTimeout      time.Duration
+	promptMode       agentctx.PromptMode
 }
 
 func (e *Executor) executeViaLoop(ctx context.Context, task, profileName, guidance string, tags []string, opts executionOptions) (*Result, error) {
@@ -548,6 +561,7 @@ func (e *Executor) buildLoopLaunch(prep *preparedExecution, task, guidance strin
 				"delegate_task":     truncate(task, 500),
 				"delegate_profile":  prep.profile.Name,
 				"delegate_guidance": truncate(guidance, 500),
+				"prompt_mode":       string(prep.promptMode),
 			},
 		},
 		Task:                     prep.userMessage,
@@ -564,16 +578,18 @@ func (e *Executor) buildLoopLaunch(prep *preparedExecution, task, guidance strin
 		ToolTimeout:              prep.toolTimeout,
 		UsageRole:                "delegate",
 		UsageTaskName:            prep.profile.Name,
+		PromptMode:               prep.promptMode,
 		RunTimeout:               prep.maxDuration,
 		CompletionConversationID: completionConversationID,
 		CompletionChannel:        looppkg.CloneCompletionChannelTarget(completionChannel),
 		OnProgress:               onProgress,
-		// Delegate loops are bounded child tasks. They get tagged
-		// providers and KB articles for their declared profile, but
-		// not the always-on ambient context (presence, episodic memory,
-		// notification history, etc.) that is meant for the main loop's
-		// experiential continuity. See #778.
-		SuppressAlwaysContext: true,
+		// Task-focused delegates are bounded child tasks. They get
+		// tagged providers and KB articles for their declared profile,
+		// but not the always-on ambient context (presence, episodic
+		// memory, notification history, etc.) that is meant for the
+		// main loop's experiential continuity. Full-context delegates
+		// opt back into that richer prompt shape intentionally.
+		SuppressAlwaysContext: prep.promptMode != agentctx.PromptModeFull,
 	}
 }
 
@@ -805,6 +821,7 @@ func (e *Executor) prepareExecution(ctx context.Context, task, profileName, guid
 		maxOutputTokens:  maxOutputTokens,
 		maxDuration:      maxDuration,
 		toolTimeout:      toolTimeout,
+		promptMode:       opts.effectivePromptMode(),
 	}, nil
 }
 

--- a/internal/runtime/delegate/delegate_test.go
+++ b/internal/runtime/delegate/delegate_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/nugget/thane-ai-agent/internal/model/llm"
 	"github.com/nugget/thane-ai-agent/internal/model/router"
 	"github.com/nugget/thane-ai-agent/internal/platform/events"
+	"github.com/nugget/thane-ai-agent/internal/runtime/agentctx"
 	looppkg "github.com/nugget/thane-ai-agent/internal/runtime/loop"
 	"github.com/nugget/thane-ai-agent/internal/tools"
 )
@@ -164,6 +165,12 @@ func TestExecute_LoopBackedPathUsesLaunch(t *testing.T) {
 	}
 	if captured.SystemPrompt != "" {
 		t.Fatalf("SystemPrompt = %q, want loop-built prompt", captured.SystemPrompt)
+	}
+	if captured.PromptMode != agentctx.PromptModeTask {
+		t.Fatalf("PromptMode = %q, want task", captured.PromptMode)
+	}
+	if !captured.SuppressAlwaysContext {
+		t.Fatal("SuppressAlwaysContext = false, want true for task-mode delegate")
 	}
 	if len(captured.Messages) != 1 || !strings.Contains(captured.Messages[0].Content, "Check the office light") || !strings.Contains(captured.Messages[0].Content, "Be concise") {
 		t.Fatalf("Messages = %#v", captured.Messages)
@@ -515,6 +522,58 @@ func TestNowToolHandler_RoutesToSyncPath(t *testing.T) {
 	}
 	if !strings.Contains(result, "answer") {
 		t.Fatalf("expected delegate content in result, got: %s", result)
+	}
+}
+
+func TestNowToolHandler_ContextModeFull(t *testing.T) {
+	t.Parallel()
+
+	var captured looppkg.Request
+	runner := &mockLoopRunner{
+		onRun: func(req looppkg.Request) {
+			captured = req
+		},
+		resp: &looppkg.Response{
+			Content: "answer",
+			Model:   "test-model",
+		},
+	}
+	exec := NewExecutor(slog.Default(), nil, nil, newTestRegistry(), "test-model")
+	exec.ConfigureLoopExecution(runner, looppkg.NewRegistry())
+
+	result, err := NowToolHandler(exec)(context.Background(), map[string]any{
+		"task":         "Inspect the continuity-sensitive issue.",
+		"context_mode": "full",
+	})
+	if err != nil {
+		t.Fatalf("NowToolHandler error: %v", err)
+	}
+	if !strings.Contains(result, "[Delegate SUCCEEDED:") {
+		t.Fatalf("expected SUCCESS header, got: %s", result)
+	}
+	if captured.PromptMode != agentctx.PromptModeFull {
+		t.Fatalf("PromptMode = %q, want full", captured.PromptMode)
+	}
+	if captured.SuppressAlwaysContext {
+		t.Fatal("SuppressAlwaysContext = true, want false for full-context delegate")
+	}
+}
+
+func TestNowToolHandler_InvalidContextMode(t *testing.T) {
+	t.Parallel()
+
+	exec := NewExecutor(slog.Default(), nil, nil, newTestRegistry(), "test-model")
+	exec.ConfigureLoopExecution(&mockLoopRunner{}, looppkg.NewRegistry())
+
+	result, err := NowToolHandler(exec)(context.Background(), map[string]any{
+		"task":         "Do something.",
+		"context_mode": "everything",
+	})
+	if err != nil {
+		t.Fatalf("NowToolHandler error: %v", err)
+	}
+	if !strings.Contains(result, "context_mode must be one of [task, full]") {
+		t.Fatalf("unexpected result: %s", result)
 	}
 }
 

--- a/internal/runtime/delegate/tool.go
+++ b/internal/runtime/delegate/tool.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/nugget/thane-ai-agent/internal/model/prompts"
+	"github.com/nugget/thane-ai-agent/internal/runtime/agentctx"
 )
 
 // ToolDescription is the LLM-facing description for the deprecated
@@ -20,6 +21,7 @@ var ToolDescription = "DEPRECATED: prefer thane_now (sync answer) or thane_assig
 // sync member of the thane_* family.
 const NowToolDescription = "Synchronously delegate a bounded task to a sub-agent and return the result inline. " +
 	"Use when the calling model needs the answer in this turn — investigation, research, summarization, controlled tool execution. " +
+	"Uses compact task context by default; set context_mode=full only for continuity-sensitive work. " +
 	"Blocks until the delegate completes or exhausts its budget. " +
 	"For fire-and-forget background work, use thane_assign instead. " +
 	"For recurring document-anchored work on a schedule, use thane_curate."
@@ -28,6 +30,7 @@ const NowToolDescription = "Synchronously delegate a bounded task to a sub-agent
 // the async one-shot member of the thane_* family.
 const AssignToolDescription = "Assign a bounded task to a sub-agent that runs in the background and reports its result back through the current conversation or interactive channel when complete. " +
 	"Use when the work will take long enough that the calling model should not block waiting — multi-step investigation, deferred report generation, anything where the caller wants to move on while the delegate completes. " +
+	"Uses compact task context by default; set context_mode=full only for continuity-sensitive work. " +
 	"For an answer needed in this turn, use thane_now. " +
 	"For recurring scheduled work, use thane_curate."
 
@@ -101,6 +104,12 @@ func commonDelegateProperties() map[string]any {
 			"default":     true,
 			"description": "Whether to inherit elective capability tags from the caller. Runtime and channel affordance tags such as message_channel are never inherited.",
 		},
+		"context_mode": map[string]any{
+			"type":        "string",
+			"enum":        []string{"task", "full"},
+			"default":     "task",
+			"description": "Prompt/context shape for the delegate. task is compact and omits full identity files, inject files, always-on talents, and conversation-history dressing. full opts into the normal Thane prompt when the delegate truly needs that continuity.",
+		},
 	}
 }
 
@@ -160,13 +169,14 @@ type delegateRequest struct {
 	inheritCallerTags bool
 	tags              []string
 	tagsProvided      bool
+	contextMode       agentctx.PromptMode
 }
 
 // parseDelegateArgs extracts the shared args for the family.
 // The profile field is read from args for thane_delegate compatibility
 // but defaults to "general" for the family tools that don't expose it.
 func parseDelegateArgs(args map[string]any) (delegateRequest, string) {
-	req := delegateRequest{inheritCallerTags: true, profileName: "general"}
+	req := delegateRequest{inheritCallerTags: true, profileName: "general", contextMode: agentctx.PromptModeTask}
 
 	task, _ := args["task"].(string)
 	if task == "" {
@@ -180,6 +190,13 @@ func parseDelegateArgs(args map[string]any) (delegateRequest, string) {
 	req.guidance, _ = args["guidance"].(string)
 	if rawInherit, ok := args["inherit_caller_tags"].(bool); ok {
 		req.inheritCallerTags = rawInherit
+	}
+	if rawMode, ok := args["context_mode"].(string); ok && rawMode != "" {
+		mode, err := agentctx.ParsePromptMode(rawMode)
+		if err != nil {
+			return req, "Error: context_mode must be one of [task, full]"
+		}
+		req.contextMode = mode
 	}
 	if rawTags, ok := args["tags"].([]any); ok {
 		req.tagsProvided = true
@@ -199,6 +216,7 @@ func runAssign(ctx context.Context, exec *Executor, req delegateRequest) string 
 	opts := executionOptions{
 		inheritCallerTags: req.inheritCallerTags,
 		explicitTagScope:  req.tagsProvided,
+		promptMode:        req.contextMode,
 	}
 	loopID, err := exec.startBackground(ctx, req.task, req.profileName, req.guidance, req.tags, opts)
 	if err != nil {
@@ -214,6 +232,7 @@ func runNow(ctx context.Context, exec *Executor, req delegateRequest) string {
 	opts := executionOptions{
 		inheritCallerTags: req.inheritCallerTags,
 		explicitTagScope:  req.tagsProvided,
+		promptMode:        req.contextMode,
 	}
 	result, err := exec.execute(ctx, req.task, req.profileName, req.guidance, req.tags, opts)
 	if err != nil {

--- a/internal/runtime/loop/launch.go
+++ b/internal/runtime/loop/launch.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/nugget/thane-ai-agent/internal/runtime/agentctx"
 	"github.com/nugget/thane-ai-agent/internal/state/memory"
 )
 
@@ -38,6 +39,7 @@ type Launch struct {
 	SkipTagFilter     bool                     `yaml:"skip_tag_filter,omitempty" json:"skip_tag_filter,omitempty"`
 	SystemPrompt      string                   `yaml:"system_prompt,omitempty" json:"system_prompt,omitempty"`
 	FallbackContent   string                   `yaml:"fallback_content,omitempty" json:"fallback_content,omitempty"`
+	PromptMode        agentctx.PromptMode      `yaml:"prompt_mode,omitempty" json:"prompt_mode,omitempty"`
 	MaxIterations     int                      `yaml:"max_iterations,omitempty" json:"max_iterations,omitempty"`
 	MaxOutputTokens   int                      `yaml:"max_output_tokens,omitempty" json:"max_output_tokens,omitempty"`
 	ToolTimeout       time.Duration            `yaml:"tool_timeout,omitempty" json:"tool_timeout,omitempty"`
@@ -72,6 +74,7 @@ type launchJSON struct {
 	SkipTagFilter            bool                     `json:"skip_tag_filter,omitempty"`
 	SystemPrompt             string                   `json:"system_prompt,omitempty"`
 	FallbackContent          string                   `json:"fallback_content,omitempty"`
+	PromptMode               agentctx.PromptMode      `json:"prompt_mode,omitempty"`
 	MaxIterations            int                      `json:"max_iterations,omitempty"`
 	MaxOutputTokens          int                      `json:"max_output_tokens,omitempty"`
 	ToolTimeout              string                   `json:"tool_timeout,omitempty"`
@@ -100,6 +103,7 @@ func (l Launch) MarshalJSON() ([]byte, error) {
 		SkipTagFilter:            l.SkipTagFilter,
 		SystemPrompt:             l.SystemPrompt,
 		FallbackContent:          l.FallbackContent,
+		PromptMode:               l.PromptMode,
 		MaxIterations:            l.MaxIterations,
 		MaxOutputTokens:          l.MaxOutputTokens,
 		ToolTimeout:              durationString(l.ToolTimeout),
@@ -145,6 +149,7 @@ func (l *Launch) UnmarshalJSON(data []byte) error {
 		SkipTagFilter:            wire.SkipTagFilter,
 		SystemPrompt:             wire.SystemPrompt,
 		FallbackContent:          wire.FallbackContent,
+		PromptMode:               wire.PromptMode,
 		MaxIterations:            wire.MaxIterations,
 		MaxOutputTokens:          wire.MaxOutputTokens,
 		ToolTimeout:              toolTimeout,
@@ -162,6 +167,9 @@ func (l *Launch) Validate() error {
 	}
 	if l.RunTimeout < 0 {
 		return fmt.Errorf("loop: run timeout must be >= 0")
+	}
+	if !l.PromptMode.Valid() {
+		return fmt.Errorf("loop: invalid prompt_mode %q", l.PromptMode)
 	}
 	if l.Spec.Completion == CompletionConversation && strings.TrimSpace(l.CompletionConversationID) == "" {
 		return fmt.Errorf("loop: completion conversation ID is required for conversation completion")
@@ -200,6 +208,7 @@ func (l *Launch) requestOverride() Request {
 		UsageRole:             l.UsageRole,
 		UsageTaskName:         l.UsageTaskName,
 		SystemPrompt:          l.SystemPrompt,
+		PromptMode:            l.PromptMode,
 		SuppressAlwaysContext: l.SuppressAlwaysContext,
 	}
 }

--- a/internal/runtime/loop/launch_json_test.go
+++ b/internal/runtime/loop/launch_json_test.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/nugget/thane-ai-agent/internal/runtime/agentctx"
 )
 
 func TestLaunchMarshalJSONUsesDurationStrings(t *testing.T) {
@@ -16,6 +18,7 @@ func TestLaunchMarshalJSONUsesDurationStrings(t *testing.T) {
 		ToolTimeout:     45 * time.Second,
 		AllowedTools:    []string{"get_state"},
 		FallbackContent: "please try again",
+		PromptMode:      agentctx.PromptModeTask,
 	})
 	if err != nil {
 		t.Fatalf("MarshalJSON: %v", err)
@@ -30,6 +33,9 @@ func TestLaunchMarshalJSONUsesDurationStrings(t *testing.T) {
 	if !strings.Contains(body, `"fallback_content":"please try again"`) {
 		t.Fatalf("marshal output missing fallback_content: %s", body)
 	}
+	if !strings.Contains(body, `"prompt_mode":"task"`) {
+		t.Fatalf("marshal output missing prompt_mode: %s", body)
+	}
 }
 
 func TestLaunchUnmarshalJSONParsesDurationStrings(t *testing.T) {
@@ -41,6 +47,7 @@ func TestLaunchUnmarshalJSONParsesDurationStrings(t *testing.T) {
 		"run_timeout":"90s",
 		"tool_timeout":"30s",
 		"fallback_content":"please try again",
+		"prompt_mode":"task",
 		"completion_channel":{"channel":"owu","conversation_id":"conv-1"}
 	}`), &launch); err != nil {
 		t.Fatalf("UnmarshalJSON: %v", err)
@@ -57,6 +64,9 @@ func TestLaunchUnmarshalJSONParsesDurationStrings(t *testing.T) {
 	if launch.FallbackContent != "please try again" {
 		t.Fatalf("FallbackContent = %q, want %q", launch.FallbackContent, "please try again")
 	}
+	if launch.PromptMode != agentctx.PromptModeTask {
+		t.Fatalf("PromptMode = %q, want task", launch.PromptMode)
+	}
 }
 
 func TestLaunchUnmarshalJSONRejectsInvalidDurationStrings(t *testing.T) {
@@ -66,5 +76,21 @@ func TestLaunchUnmarshalJSONRejectsInvalidDurationStrings(t *testing.T) {
 	err := json.Unmarshal([]byte(`{"run_timeout":"definitely-not-a-duration"}`), &launch)
 	if err == nil || !strings.Contains(err.Error(), "run_timeout") {
 		t.Fatalf("UnmarshalJSON error = %v, want run_timeout parse error", err)
+	}
+}
+
+func TestLaunchValidateRejectsInvalidPromptMode(t *testing.T) {
+	t.Parallel()
+
+	launch := Launch{
+		Spec: Spec{
+			Name: "bad-prompt-mode",
+			Task: "do work",
+		},
+		PromptMode: agentctx.PromptMode("everything"),
+	}
+	err := launch.Validate()
+	if err == nil || !strings.Contains(err.Error(), "prompt_mode") {
+		t.Fatalf("Validate error = %v, want prompt_mode validation error", err)
 	}
 }

--- a/internal/runtime/loop/loop.go
+++ b/internal/runtime/loop/loop.go
@@ -15,6 +15,7 @@ import (
 	"github.com/nugget/thane-ai-agent/internal/model/toolcatalog"
 	"github.com/nugget/thane-ai-agent/internal/platform/events"
 	"github.com/nugget/thane-ai-agent/internal/platform/logging"
+	"github.com/nugget/thane-ai-agent/internal/runtime/agentctx"
 	"github.com/nugget/thane-ai-agent/internal/state/memory"
 )
 
@@ -51,13 +52,14 @@ type Request struct {
 	// progress reporting.
 	OnProgress func(kind string, data map[string]any) `yaml:"-" json:"-"`
 
-	MaxIterations   int           `yaml:"max_iterations,omitempty" json:"max_iterations,omitempty"`
-	MaxOutputTokens int           `yaml:"max_output_tokens,omitempty" json:"max_output_tokens,omitempty"`
-	ToolTimeout     time.Duration `yaml:"tool_timeout,omitempty" json:"tool_timeout,omitempty"`
-	UsageRole       string        `yaml:"usage_role,omitempty" json:"usage_role,omitempty"`
-	UsageTaskName   string        `yaml:"usage_task_name,omitempty" json:"usage_task_name,omitempty"`
-	SystemPrompt    string        `yaml:"system_prompt,omitempty" json:"system_prompt,omitempty"`
-	FallbackContent string        `yaml:"fallback_content,omitempty" json:"fallback_content,omitempty"`
+	MaxIterations   int                 `yaml:"max_iterations,omitempty" json:"max_iterations,omitempty"`
+	MaxOutputTokens int                 `yaml:"max_output_tokens,omitempty" json:"max_output_tokens,omitempty"`
+	ToolTimeout     time.Duration       `yaml:"tool_timeout,omitempty" json:"tool_timeout,omitempty"`
+	UsageRole       string              `yaml:"usage_role,omitempty" json:"usage_role,omitempty"`
+	UsageTaskName   string              `yaml:"usage_task_name,omitempty" json:"usage_task_name,omitempty"`
+	SystemPrompt    string              `yaml:"system_prompt,omitempty" json:"system_prompt,omitempty"`
+	FallbackContent string              `yaml:"fallback_content,omitempty" json:"fallback_content,omitempty"`
+	PromptMode      agentctx.PromptMode `yaml:"prompt_mode,omitempty" json:"prompt_mode,omitempty"`
 
 	// SuppressAlwaysContext drops the always-on bucket from the
 	// system-prompt assembler's context output for this run. Default
@@ -1358,6 +1360,7 @@ func (l *Loop) iterate(ctx context.Context, isSupervisor bool, convID string, si
 		UsageRole:             l.requestOverride.UsageRole,
 		UsageTaskName:         l.requestOverride.UsageTaskName,
 		SystemPrompt:          l.requestOverride.SystemPrompt,
+		PromptMode:            l.requestOverride.PromptMode,
 		SuppressAlwaysContext: l.requestOverride.SuppressAlwaysContext,
 	}
 

--- a/internal/tools/loop_definition_tool_helpers.go
+++ b/internal/tools/loop_definition_tool_helpers.go
@@ -198,6 +198,11 @@ func loopLaunchOverrideProperties() map[string]any {
 			"type":        "string",
 			"description": "Override the system prompt for this launch.",
 		},
+		"prompt_mode": map[string]any{
+			"type":        "string",
+			"enum":        []string{"full", "task"},
+			"description": "Select the system-prompt shape. full is the normal Thane prompt. task is a compact worker prompt that suppresses full identity and always-on continuity context.",
+		},
 		"skip_context": map[string]any{
 			"type":        "boolean",
 			"description": "Skip context providers (awareness, archive prewarm, etc.) for this launch.",


### PR DESCRIPTION
## Summary

This moves the old day-zero core context embeds (`ego.md` and core inject files such as `mission.md`) out of direct system-prompt assembly and into a normal always-on context provider. That makes core continuity context obey the same provider gating as the newer runtime context sources instead of sneaking around `SuppressAlwaysContext`.

The immediate production behavior change is that delegate runs now default to a compact task-worker prompt. They still get runtime contract guidance, active capability summaries, tagged KB/provider context, and current conditions, but they do not inherit full Thane identity/continuity dressing unless the caller explicitly asks for it.

## What Changed

- Added `CoreContextProvider` for `ego.md` and curated core context files.
- Removed direct ego/inject-file reads from agent prompt assembly.
- Added prompt modes (`full`, `task`) at the agent/loop launch layer.
- Added delegate-facing `context_mode` with default `task` and opt-in `full`.
- Exposed `prompt_mode` in loop launch schemas for lower-level loop tools.
- Updated documentation around context layers and delegation semantics.

## Why

The previous `SuppressAlwaysContext` switch only suppressed registered context providers. `ego.md` and configured core inject files were still read directly by `buildSystemPrompt`, so loop-backed delegates could carry metacog/ego/core content into small-model task contexts. That was both noisy for normal delegation and structurally surprising.

With this change, the old core files ride the same model-facing context pipeline as presence, working memory, notification history, and other always-on providers.

## Validation

- `just test`
- `just ci`