### PR TITLE
docs: tighten awareness capability description

### DIFF
--- a/internal/model/toolcatalog/catalog_tags.go
+++ b/internal/model/toolcatalog/catalog_tags.go
@@ -3,7 +3,7 @@ package toolcatalog
 var builtinTagSpecs = map[string]BuiltinTagSpec{
 	"archive":         {Description: "Archive search and transcript retrieval across past conversations."},
 	"attachments":     {Description: "Attachment listing, search, and vision description tools."},
-	"awareness":       {Description: "Watchlist and live-context entity management tools."},
+	"awareness":       {Description: "Subscribe entities and live providers to a loop or conversation's auto-injected context. Reflexive for service loops, optional for single-shots."},
 	"contacts":        {Description: "Structured contact-directory records and vCard administration tools."},
 	"development":     {Description: "Coarse entry point for software, repository, and code-change work. Usually leads to forge, files, web, or shell.", Menu: true},
 	"diagnostics":     {Description: "Logs, usage, version, and operational debugging tools."},


### PR DESCRIPTION
## Summary

Refresh the catalog description for the \`awareness\` tag. The previous
text ("Watchlist and live-context entity management tools") undersold
the tag's actual job and gave the model nothing concrete to match
against when deciding whether to activate.

The new wording names the load-bearing concept — auto-injecting
subscribed entity state into a loop or conversation's context — and
signals when activation is worth it (sustained service work) vs not
(single-shots). It aligns with the new awareness talent doctrine
shipped in /Volumes/Thane/talents/awareness.md and the menu pointers
recently added from \`operations\`, \`home\`, and \`ha\`.

## Test plan

- [x] \`just ci\` passes locally.
- [ ] After merge: confirm \`thane caps awareness\` (or
  \`/api/capabilities/awareness\`) shows the new description.