### PR TITLE
debug: log outbound Anthropic cache_control markers

### DIFF
--- a/internal/model/fleet/providers/anthropic.go
+++ b/internal/model/fleet/providers/anthropic.go
@@ -607,16 +607,26 @@ func applyCacheBreakpointGuards(blocks []anthropicContent, tools []anthropicTool
 // A 0% cache-read rate combined with a payload that omits markers points
 // at a different bug than one where markers are present but the prefix
 // isn't matching, so this log is the cheapest way to disambiguate.
+//
+// The function short-circuits when Debug is disabled so the loops and
+// slice allocations don't run on every request in production.
 func logOutboundCacheMarkers(logger *slog.Logger, req *anthropicRequest) {
+	if logger == nil || !logger.Enabled(context.Background(), slog.LevelDebug) {
+		return
+	}
+
+	systemPayloadKind := "none"
 	systemBlocks := 0
 	systemBreakpoints := 0
 	systemTotalChars := 0
 	systemTTLs := make([]string, 0, 4)
 	systemBreakpointPrefixChars := make([]int, 0, 4)
-	if blocks, ok := req.System.([]anthropicContent); ok {
-		systemBlocks = len(blocks)
+	switch system := req.System.(type) {
+	case []anthropicContent:
+		systemPayloadKind = "blocks"
+		systemBlocks = len(system)
 		prefix := 0
-		for _, b := range blocks {
+		for _, b := range system {
 			prefix += len(b.Text)
 			if b.CacheControl != nil {
 				systemBreakpoints++
@@ -629,6 +639,16 @@ func logOutboundCacheMarkers(logger *slog.Logger, req *anthropicRequest) {
 			}
 		}
 		systemTotalChars = prefix
+	case string:
+		// Fallback path from anthropicSystemPayload when no
+		// PromptSections are present. The system content still ships,
+		// just as a single un-cached string — record its size so
+		// operators can correlate prefix length even without blocks.
+		if system != "" {
+			systemPayloadKind = "string"
+			systemBlocks = 1
+			systemTotalChars = len(system)
+		}
 	}
 
 	toolBreakpointTTL := ""
@@ -649,6 +669,7 @@ func logOutboundCacheMarkers(logger *slog.Logger, req *anthropicRequest) {
 
 	logger.Debug("outbound cache markers",
 		"model", req.Model,
+		"system_payload_kind", systemPayloadKind,
 		"system_blocks", systemBlocks,
 		"system_breakpoints", systemBreakpoints,
 		"system_breakpoint_ttls", systemTTLs,

--- a/internal/model/fleet/providers/anthropic.go
+++ b/internal/model/fleet/providers/anthropic.go
@@ -205,6 +205,8 @@ func (c *AnthropicClient) ChatStream(ctx context.Context, model string, messages
 		CacheControl: anthropicPromptCacheControl(systemPrompt, anthropicMsgs, anthropicTools, explicitCaching),
 	}
 
+	logOutboundCacheMarkers(c.logger, &req)
+
 	jsonData, err := json.Marshal(req)
 	if err != nil {
 		return nil, fmt.Errorf("marshal request: %w", err)
@@ -598,6 +600,64 @@ func applyCacheBreakpointGuards(blocks []anthropicContent, tools []anthropicTool
 		blocks[i].CacheControl = nil
 		excess--
 	}
+}
+
+// logOutboundCacheMarkers emits a structured debug line describing every
+// cache_control breakpoint that will land in the outbound request bytes.
+// A 0% cache-read rate combined with a payload that omits markers points
+// at a different bug than one where markers are present but the prefix
+// isn't matching, so this log is the cheapest way to disambiguate.
+func logOutboundCacheMarkers(logger *slog.Logger, req *anthropicRequest) {
+	systemBlocks := 0
+	systemBreakpoints := 0
+	systemTotalChars := 0
+	systemTTLs := make([]string, 0, 4)
+	systemBreakpointPrefixChars := make([]int, 0, 4)
+	if blocks, ok := req.System.([]anthropicContent); ok {
+		systemBlocks = len(blocks)
+		prefix := 0
+		for _, b := range blocks {
+			prefix += len(b.Text)
+			if b.CacheControl != nil {
+				systemBreakpoints++
+				ttl := b.CacheControl.TTL
+				if ttl == "" {
+					ttl = "default"
+				}
+				systemTTLs = append(systemTTLs, ttl)
+				systemBreakpointPrefixChars = append(systemBreakpointPrefixChars, prefix)
+			}
+		}
+		systemTotalChars = prefix
+	}
+
+	toolBreakpointTTL := ""
+	if n := len(req.Tools); n > 0 && req.Tools[n-1].CacheControl != nil {
+		toolBreakpointTTL = req.Tools[n-1].CacheControl.TTL
+		if toolBreakpointTTL == "" {
+			toolBreakpointTTL = "default"
+		}
+	}
+
+	requestLevelTTL := ""
+	if req.CacheControl != nil {
+		requestLevelTTL = req.CacheControl.TTL
+		if requestLevelTTL == "" {
+			requestLevelTTL = "default"
+		}
+	}
+
+	logger.Debug("outbound cache markers",
+		"model", req.Model,
+		"system_blocks", systemBlocks,
+		"system_breakpoints", systemBreakpoints,
+		"system_breakpoint_ttls", systemTTLs,
+		"system_breakpoint_prefix_chars", systemBreakpointPrefixChars,
+		"system_total_chars", systemTotalChars,
+		"tools", len(req.Tools),
+		"tool_breakpoint_ttl", toolBreakpointTTL,
+		"request_cache_control_ttl", requestLevelTTL,
+	)
 }
 
 type promptCacheRun struct {


### PR DESCRIPTION
## Summary

Adds a structured `Debug` log fired on every Anthropic `ChatStream` request, reporting the `cache_control` breakpoints that will land in the outbound JSON: per-block TTL, prefix length at each breakpoint, the tool cache breakpoint, and any request-level `cache_control`.

## Why

Recent burn audit ($115/hour at peak) showed Anthropic reporting `cache_read_input_tokens=0` on opus turns despite our system blocks being structured per the documented caching policy. The `applyCacheBreakpointGuards` logic *appears* correct on inspection, but without visibility into the outbound bytes we can't tell whether:

1. The breakpoints are being written into the JSON correctly,
2. They're being silently dropped by `applyCacheBreakpointGuards` (e.g., under-minimum prefix or 4-breakpoint cap),
3. Or they're landing fine and the server-side prefix isn't matching across turns.

This log disambiguates (1) and (2) from (3) on a single live opus turn. Once we can see what's actually going out, we can stop speculating and start fixing the right thing.

Sample log line shape:

```
outbound cache markers
  model=claude-opus-4-7
  system_blocks=8
  system_breakpoints=3
  system_breakpoint_ttls=[1h, 1h, 1h]
  system_breakpoint_prefix_chars=[1019, 1668, 5083]
  system_total_chars=21340
  tools=64
  tool_breakpoint_ttl=1h
  request_cache_control_ttl=
```

## Scope

- One new helper, `logOutboundCacheMarkers`, next to the existing `applyCacheBreakpointGuards` in [internal/model/fleet/providers/anthropic.go](internal/model/fleet/providers/anthropic.go).
- One call site in `ChatStream`, immediately before `json.Marshal(req)`.
- No behavior change. No new dependencies. Existing tests pass unchanged.

## Test plan

- [x] `just ci` passes locally (build, lint, race tests, link check, architecture check)
- [x] Existing `applyCacheBreakpointGuards` tests still pass — change is additive
- [ ] Verify in production: enable Debug logging on the Anthropic provider, fire one opus turn, confirm the log line shows the expected breakpoint shape
- [ ] Cross-reference the next response's `cache_read_input_tokens` against the outbound markers — this is the diagnostic that should immediately inform the next fix