### PR TITLE
fix: late-bind dataset logger into model provider clients

### DIFF
--- a/internal/app/new.go
+++ b/internal/app/new.go
@@ -91,6 +91,15 @@ func New(ctx context.Context, cfg *config.Config, logger *slog.Logger, stdout io
 		return nil, err
 	}
 
+	// Late-bind the configured logger into provider clients that were
+	// built during bootstrap with the Info-level stdout logger. Without
+	// this, every Debug log inside the model providers (preparing
+	// request, response received, outbound cache markers, etc.) is
+	// suppressed because the bootstrap logger's handler short-circuits
+	// at LevelInfo. Anything else constructed before initLogging that
+	// emits Debug logs needs a similar rebind hook.
+	a.modelRuntime.SetLogger(a.logger)
+
 	s := &newState{ctx: ctx}
 
 	if err := a.initStores(s); err != nil {

--- a/internal/model/fleet/client_bundle.go
+++ b/internal/model/fleet/client_bundle.go
@@ -20,6 +20,11 @@ type ClientBundle struct {
 	HealthClients   map[string]ResourceHealthClient
 	OllamaClients   map[string]*modelproviders.OllamaClient
 	LMStudioClients map[string]*modelproviders.LMStudioClient
+	// AnthropicClient is the singleton Anthropic provider shared across
+	// all anthropic-backed resources, retained here so late-bind
+	// machinery (e.g., Runtime.SetLogger) can find it without scanning
+	// ResourceClients for the *AnthropicClient type.
+	AnthropicClient *modelproviders.AnthropicClient
 }
 
 // ResourceHealthClient is the minimal health/watch surface that app
@@ -85,6 +90,7 @@ func BuildClients(cat *Catalog, cfg *config.Config, logger *slog.Logger) (*Clien
 		HealthClients:   healthClients,
 		OllamaClients:   ollamaClients,
 		LMStudioClients: lmstudioClients,
+		AnthropicClient: anthropicClient,
 	}
 	client, err := bundle.BuildRoutedClient(cat)
 	if err != nil {

--- a/internal/model/fleet/providers/anthropic.go
+++ b/internal/model/fleet/providers/anthropic.go
@@ -44,6 +44,11 @@ func NewAnthropicClient(apiKey string, logger *slog.Logger) *AnthropicClient {
 	return &AnthropicClient{
 		apiKey: apiKey,
 		logger: providerLogger,
+		// httpClient retains its own copy of providerLogger for retry
+		// diagnostics; SetLogger only refreshes c.logger because httpkit
+		// has no setter and rebuilding the client would drop the
+		// connection pool. Retry logs from the bootstrap logger may be
+		// suppressed; request-level Debug/Info/Warn flow through c.logger.
 		httpClient: httpkit.NewClient(
 			// No global timeout — streaming responses can be long-lived.
 			// Rely on ctx deadlines/cancellation for timeout control.
@@ -62,6 +67,30 @@ func NewAnthropicClient(apiKey string, logger *slog.Logger) *AnthropicClient {
 			httpkit.WithLogger(providerLogger),
 		),
 	}
+}
+
+// SetLogger rebinds the request-level logger. Late binding lets the
+// app pass the dataset-routed, debug-level logger into clients that
+// were constructed during bootstrap with an Info-only stdout logger.
+// See [internal/app/new_logging.go] for the wider lifecycle.
+//
+// Not safe to call concurrently with in-flight requests; intended to
+// be invoked once during init, before the runtime starts servicing
+// traffic.
+func (c *AnthropicClient) SetLogger(logger *slog.Logger) {
+	if c == nil || logger == nil {
+		return
+	}
+	c.logger = logger.With("provider", "anthropic")
+}
+
+// Logger returns the request-level logger. Exposed for tests and
+// late-bind verification — production callers should not depend on it.
+func (c *AnthropicClient) Logger() *slog.Logger {
+	if c == nil {
+		return nil
+	}
+	return c.logger
 }
 
 // Anthropic request/response types

--- a/internal/model/fleet/providers/anthropic_test.go
+++ b/internal/model/fleet/providers/anthropic_test.go
@@ -1,6 +1,8 @@
 package providers
 
 import (
+	"bytes"
+	"context"
 	"encoding/json"
 	"log/slog"
 	"strings"
@@ -532,5 +534,47 @@ func TestShouldUseAnthropicPromptCaching(t *testing.T) {
 				t.Fatalf("shouldUseAnthropicPromptCaching() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestAnthropicClient_SetLogger_ReboundLoggerEmitsDebug(t *testing.T) {
+	bootBuf := &bytes.Buffer{}
+	bootLogger := slog.New(slog.NewJSONHandler(bootBuf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+
+	c := NewAnthropicClient("k", bootLogger)
+
+	if c.logger.Enabled(context.Background(), slog.LevelDebug) {
+		t.Fatal("bootstrap logger unexpectedly enabled at Debug")
+	}
+	c.logger.Debug("preflight", "stage", "boot")
+	if bootBuf.Len() != 0 {
+		t.Fatalf("bootstrap Info-level logger should drop Debug, got: %s", bootBuf.String())
+	}
+
+	prodBuf := &bytes.Buffer{}
+	prodLogger := slog.New(slog.NewJSONHandler(prodBuf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	c.SetLogger(prodLogger)
+
+	if !c.logger.Enabled(context.Background(), slog.LevelDebug) {
+		t.Fatal("rebound logger should be Debug-enabled")
+	}
+	c.logger.Debug("after rebind", "stage", "prod")
+	if !strings.Contains(prodBuf.String(), `"msg":"after rebind"`) {
+		t.Fatalf("expected Debug line after rebind, got: %s", prodBuf.String())
+	}
+	if !strings.Contains(prodBuf.String(), `"provider":"anthropic"`) {
+		t.Fatalf("rebound logger lost provider attribute, got: %s", prodBuf.String())
+	}
+}
+
+func TestAnthropicClient_SetLogger_NilGuards(t *testing.T) {
+	var c *AnthropicClient
+	c.SetLogger(slog.Default()) // must not panic on nil receiver
+
+	c = NewAnthropicClient("k", slog.Default())
+	before := c.logger
+	c.SetLogger(nil)
+	if c.logger != before {
+		t.Fatal("nil logger argument must not replace existing logger")
 	}
 }

--- a/internal/model/fleet/providers/lmstudio.go
+++ b/internal/model/fleet/providers/lmstudio.go
@@ -60,6 +60,27 @@ func NewLMStudioClientWithTTL(baseURL, apiKey string, logger *slog.Logger, idleT
 	}
 }
 
+// SetLogger rebinds the request-level logger. See AnthropicClient.SetLogger
+// for the late-bind rationale; the same caveat about httpkit retries applies.
+//
+// Not safe to call concurrently with in-flight requests; intended to be
+// invoked once during init.
+func (c *LMStudioClient) SetLogger(logger *slog.Logger) {
+	if c == nil || logger == nil {
+		return
+	}
+	c.logger = logger.With("provider", "lmstudio")
+}
+
+// Logger returns the request-level logger. Exposed for tests and
+// late-bind verification — production callers should not depend on it.
+func (c *LMStudioClient) Logger() *slog.Logger {
+	if c == nil {
+		return nil
+	}
+	return c.logger
+}
+
 // AttachWatcher sets the connection watcher for health status queries.
 func (c *LMStudioClient) AttachWatcher(w llm.ReadyWatcher) {
 	c.watcher = w

--- a/internal/model/fleet/providers/ollama.go
+++ b/internal/model/fleet/providers/ollama.go
@@ -63,6 +63,27 @@ func NewOllamaClient(baseURL string, logger *slog.Logger) *OllamaClient {
 	}
 }
 
+// SetLogger rebinds the request-level logger. See AnthropicClient.SetLogger
+// for the late-bind rationale; the same caveat about httpkit retries applies.
+//
+// Not safe to call concurrently with in-flight requests; intended to be
+// invoked once during init.
+func (c *OllamaClient) SetLogger(logger *slog.Logger) {
+	if c == nil || logger == nil {
+		return
+	}
+	c.logger = logger.With("provider", "ollama")
+}
+
+// Logger returns the request-level logger. Exposed for tests and
+// late-bind verification — production callers should not depend on it.
+func (c *OllamaClient) Logger() *slog.Logger {
+	if c == nil {
+		return nil
+	}
+	return c.logger
+}
+
 // ChatRequest is the request format for Ollama chat API.
 type ChatRequest struct {
 	Model    string           `json:"model"`

--- a/internal/model/fleet/runtime.go
+++ b/internal/model/fleet/runtime.go
@@ -72,12 +72,12 @@ func NewRuntime(ctx context.Context, base *Catalog, cfg *config.Config, logger *
 }
 
 // SetLogger rebinds the logger on every provider client owned by this
-// runtime. The intended caller is [internal/app.App.New], which needs
-// to swap clients off the bootstrap Info-level logger and onto the
-// dataset-routed handler once initLogging has finished. Each provider
-// re-applies its own "provider" attribute and the per-resource clients
-// receive a logger pre-decorated with the resource ID, so attributes
-// match what BuildClients originally produced.
+// runtime. The intended caller is app.New, after initLogging has
+// finished, to swap clients off the bootstrap Info-level logger and
+// onto the dataset-routed handler. Each provider re-applies its own
+// "provider" attribute and the per-resource clients receive a logger
+// pre-decorated with the resource ID, so attributes match what
+// BuildClients originally produced.
 //
 // Not safe to call concurrently with in-flight requests; intended to
 // be invoked once during init, before the runtime services traffic.

--- a/internal/model/fleet/runtime.go
+++ b/internal/model/fleet/runtime.go
@@ -71,6 +71,31 @@ func NewRuntime(ctx context.Context, base *Catalog, cfg *config.Config, logger *
 	return rt, nil
 }
 
+// SetLogger rebinds the logger on every provider client owned by this
+// runtime. The intended caller is [internal/app.App.New], which needs
+// to swap clients off the bootstrap Info-level logger and onto the
+// dataset-routed handler once initLogging has finished. Each provider
+// re-applies its own "provider" attribute and the per-resource clients
+// receive a logger pre-decorated with the resource ID, so attributes
+// match what BuildClients originally produced.
+//
+// Not safe to call concurrently with in-flight requests; intended to
+// be invoked once during init, before the runtime services traffic.
+func (r *Runtime) SetLogger(logger *slog.Logger) {
+	if r == nil || r.bundle == nil || logger == nil {
+		return
+	}
+	for id, oc := range r.bundle.OllamaClients {
+		oc.SetLogger(logger.With("resource", id))
+	}
+	for id, lc := range r.bundle.LMStudioClients {
+		lc.SetLogger(logger.With("resource", id))
+	}
+	if r.bundle.AnthropicClient != nil {
+		r.bundle.AnthropicClient.SetLogger(logger)
+	}
+}
+
 // Client returns the swappable llm.Client.
 func (r *Runtime) Client() llm.Client {
 	if r == nil {

--- a/internal/model/fleet/runtime_test.go
+++ b/internal/model/fleet/runtime_test.go
@@ -1,10 +1,13 @@
 package fleet
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync"
 	"testing"
 
@@ -129,4 +132,63 @@ func TestRuntimePrepareExplicitModel_LoadsLMStudioContext(t *testing.T) {
 	if _, ok := client.(*llm.DynamicClient); !ok {
 		t.Fatalf("runtime.Client() = %T, want *llm.DynamicClient", client)
 	}
+}
+
+func TestRuntime_SetLogger_RebindsAllProviderClients(t *testing.T) {
+	t.Parallel()
+
+	bootBuf := &bytes.Buffer{}
+	bootLogger := slog.New(slog.NewJSONHandler(bootBuf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+
+	bundle := &ClientBundle{
+		OllamaClients: map[string]*modelproviders.OllamaClient{
+			"hearth": modelproviders.NewOllamaClient("http://127.0.0.1:11434", bootLogger.With("resource", "hearth")),
+		},
+		LMStudioClients: map[string]*modelproviders.LMStudioClient{
+			"deepslate": modelproviders.NewLMStudioClient("http://127.0.0.1:1234", "", bootLogger.With("resource", "deepslate")),
+		},
+		AnthropicClient: modelproviders.NewAnthropicClient("k", bootLogger),
+	}
+	rt := &Runtime{bundle: bundle}
+
+	prodBuf := &bytes.Buffer{}
+	prodLogger := slog.New(slog.NewJSONHandler(prodBuf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	rt.SetLogger(prodLogger)
+
+	// Each rebound logger should reach the prod buffer at Debug, with
+	// the resource attribute restored for per-resource clients and the
+	// provider attribute restored on every client.
+	bundle.OllamaClients["hearth"].Logger().Debug("ollama probe")
+	bundle.LMStudioClients["deepslate"].Logger().Debug("lmstudio probe")
+	bundle.AnthropicClient.Logger().Debug("anthropic probe")
+
+	out := prodBuf.String()
+	for _, want := range []string{
+		`"msg":"ollama probe"`, `"resource":"hearth"`, `"provider":"ollama"`,
+		`"msg":"lmstudio probe"`, `"resource":"deepslate"`, `"provider":"lmstudio"`,
+		`"msg":"anthropic probe"`, `"provider":"anthropic"`,
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("rebound output missing %q\n--- output ---\n%s", want, out)
+		}
+	}
+
+	// Bootstrap logger must not have received any of the Debug lines —
+	// SetLogger should fully replace the reference, not tee.
+	if bootBuf.Len() != 0 {
+		t.Fatalf("bootstrap logger still receiving messages after rebind: %s", bootBuf.String())
+	}
+}
+
+func TestRuntime_SetLogger_NilGuards(t *testing.T) {
+	t.Parallel()
+
+	var rt *Runtime
+	rt.SetLogger(slog.Default()) // nil receiver
+
+	rt = &Runtime{}
+	rt.SetLogger(slog.Default()) // nil bundle
+
+	rt = &Runtime{bundle: &ClientBundle{}}
+	rt.SetLogger(nil) // nil logger
 }

--- a/scripts/architecture.baseline
+++ b/scripts/architecture.baseline
@@ -1,5 +1,5 @@
 packages=54
 interfaces=74
 large_files=32
-set_mutators=95
+set_mutators=99
 database_opens=7


### PR DESCRIPTION
## Summary

Provider clients are constructed in [createLLMSetup](cmd/thane/main.go:450) **before** [App.initLogging](internal/app/new_logging.go:22) reconfigures the logger to the dataset-routed Debug-level handler. They keep a permanent reference to the bootstrap Info-only stdout logger, so every `c.logger.Debug(...)` call inside the providers short-circuits via `Enabled()` and silently disappears in production.

This wires a `SetLogger` pathway down through `Runtime` to each provider, and `app.New` rebinds immediately after `initLogging`. Future components constructed before logging is configured can adopt the same pattern.

## Why this matters right now

[#800](https://github.com/nugget/thane-ai-agent/pull/800) added `outbound cache markers` specifically to disambiguate "markers missing from outbound JSON" vs. "markers present, server-side prefix not matching." It's gated by `logger.Enabled(ctx, slog.LevelDebug)` — which has been returning false on every call since the binary booted, because the bootstrap logger is Info-only. The diagnostic log has never emitted.

Today's `requests` dataset confirms the burn pattern is still active:

| model | calls | input_tokens | cache_read | cache_creation |
|---|---|---|---|---|
| claude-opus-4-20250514 | 42 | 2.58M | **0** | 3.01M |
| claude-sonnet-4-20250514 | 3 | 54.7k | **0** | 390k |

Calls with `cache_read > 0`: **0/45**. Cache creation exceeds input on every turn — we pay the 1.25× write tax and read nothing back. With this fix, the next opus turn will produce the diagnostic line PR #800 was supposed to surface.

## Scope

- New `SetLogger(*slog.Logger)` and `Logger() *slog.Logger` on each provider client (`AnthropicClient`, `OllamaClient`, `LMStudioClient`). Each rebinds with its own `provider` attribute restored.
- `ClientBundle` now exposes `AnthropicClient` directly so the runtime can find the singleton without scanning the typed `ResourceClients` map.
- `Runtime.SetLogger` walks the bundle, restores the per-resource `resource` attribute on Ollama and LM Studio clients, and rebinds the singleton Anthropic client.
- One call from [app.New](internal/app/new.go:90) right after `initLogging`.
- Architecture baseline bumped from 95 → 99 set-mutators (the four new `SetLogger` methods).

## Known follow-up (out of scope)

The `httpkit` retry logger is set at provider construction time and isn't refreshed by `SetLogger` — `httpkit` has no setter, and rebuilding the http client would drop the connection pool. Retry-path Warn logs from the bootstrap logger may still be suppressed; that's a smaller, separable fix.

## Test plan

- [x] Three new `SetLogger` unit tests across `internal/model/fleet/providers/anthropic_test.go` and `internal/model/fleet/runtime_test.go` — verify Debug-level rebound logger emits, attributes are restored, bootstrap buffer stays empty post-rebind, and nil receivers/args are guarded
- [x] `just ci` passes locally (build, lint, race tests, link check, architecture check)
- [ ] Verify in production: rebuild the agent, fire one opus turn, confirm `outbound cache markers` lands in `events/<date>/<hour>.jsonl`
- [ ] Cross-reference the next response's `cache_read_input_tokens` against the outbound markers — the diagnostic that should immediately inform the next fix