### PR TITLE
fix: sort tools by name to unblock Anthropic prompt caching

### DIFF
--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -895,10 +895,19 @@ func (r *Registry) Get(name string) *Tool {
 	return r.tools[name]
 }
 
-// List returns all tools for the LLM.
+// List returns all tools for the LLM, sorted by name. Deterministic
+// order is required for Anthropic prompt caching: tools land first in
+// the cache key, so a randomized order (Go map iteration) makes every
+// turn miss the prefix even when the tool set is unchanged.
 func (r *Registry) List() []map[string]any {
-	var result []map[string]any
-	for _, t := range r.tools {
+	names := make([]string, 0, len(r.tools))
+	for name := range r.tools {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	result := make([]map[string]any, 0, len(names))
+	for _, name := range names {
+		t := r.tools[name]
 		result = append(result, map[string]any{
 			"type": "function",
 			"function": map[string]any{
@@ -911,12 +920,13 @@ func (r *Registry) List() []map[string]any {
 	return result
 }
 
-// AllToolNames returns the names of all registered tools.
+// AllToolNames returns the names of all registered tools, sorted.
 func (r *Registry) AllToolNames() []string {
 	names := make([]string, 0, len(r.tools))
 	for name := range r.tools {
 		names = append(names, name)
 	}
+	sort.Strings(names)
 	return names
 }
 

--- a/internal/tools/tools_test.go
+++ b/internal/tools/tools_test.go
@@ -174,3 +174,71 @@ func TestFormatEntityState(t *testing.T) {
 		})
 	}
 }
+
+// TestRegistry_List_SortedByName guards Anthropic prompt caching: the
+// outbound tools block lands first in the cache key, so a non-deterministic
+// order makes every turn miss the cached prefix even when the tool set is
+// unchanged. See PR comments diagnosing 0% cache_read on opus turns.
+func TestRegistry_List_SortedByName(t *testing.T) {
+	// Insert in reverse-alphabetical order so any reliance on insertion
+	// order would also fail this test.
+	names := []string{"zeta", "yankee", "mike", "delta", "bravo", "alpha"}
+	reg := &Registry{tools: make(map[string]*Tool)}
+	for _, n := range names {
+		reg.Register(&Tool{Name: n, Description: "desc " + n, Handler: func(context.Context, map[string]any) (string, error) { return "", nil }})
+	}
+
+	want := []string{"alpha", "bravo", "delta", "mike", "yankee", "zeta"}
+
+	// Run List() repeatedly; if Go map iteration leaks through, one of
+	// these calls eventually returns a different order. 32 iterations
+	// is overkill for a 6-element map but cheap.
+	for i := 0; i < 32; i++ {
+		got := reg.List()
+		if len(got) != len(want) {
+			t.Fatalf("iter %d: List() len=%d, want %d", i, len(got), len(want))
+		}
+		for j, def := range got {
+			fn, _ := def["function"].(map[string]any)
+			gotName, _ := fn["name"].(string)
+			if gotName != want[j] {
+				t.Fatalf("iter %d: List()[%d].name = %q, want %q (full order: %v)", i, j, gotName, want[j], extractListNames(got))
+			}
+		}
+	}
+}
+
+// TestRegistry_AllToolNames_Sorted protects external callers (debug
+// tooling, telemetry) that already assume a stable order from the
+// previously-undocumented map iteration randomness.
+func TestRegistry_AllToolNames_Sorted(t *testing.T) {
+	names := []string{"zeta", "delta", "bravo", "alpha", "yankee"}
+	reg := &Registry{tools: make(map[string]*Tool)}
+	for _, n := range names {
+		reg.Register(&Tool{Name: n, Description: "x", Handler: func(context.Context, map[string]any) (string, error) { return "", nil }})
+	}
+
+	want := []string{"alpha", "bravo", "delta", "yankee", "zeta"}
+
+	for i := 0; i < 32; i++ {
+		got := reg.AllToolNames()
+		if len(got) != len(want) {
+			t.Fatalf("iter %d: AllToolNames() len=%d, want %d", i, len(got), len(want))
+		}
+		for j := range got {
+			if got[j] != want[j] {
+				t.Fatalf("iter %d: AllToolNames()[%d] = %q, want %q (full: %v)", i, j, got[j], want[j], got)
+			}
+		}
+	}
+}
+
+func extractListNames(defs []map[string]any) []string {
+	out := make([]string, 0, len(defs))
+	for _, def := range defs {
+		fn, _ := def["function"].(map[string]any)
+		name, _ := fn["name"].(string)
+		out = append(out, name)
+	}
+	return out
+}


### PR DESCRIPTION
## Summary

Anthropic prompt caching keys on `tools → system → messages`. Tools land first in the cache key, so any byte difference in the tools block invalidates the entire downstream prefix. `Registry.List()` was iterating a `map[string]*Tool` directly — Go intentionally randomizes map iteration — so every turn shipped a differently-ordered tools array, and **no opus turn could ever match a prior cached prefix.**

Sort the tool slice by name before returning. Same treatment for `AllToolNames()` for the handful of debug/telemetry callers that already assumed a stable order.

## How we got here

[#800](https://github.com/nugget/thane-ai-agent/pull/800) added the `outbound cache markers` debug log. [#802](https://github.com/nugget/thane-ai-agent/pull/802) wired the production logger so the line could actually emit. With both deployed, the diagnostic output exonerated the system blocks and pointed at tools.

**18 outbound markers post-deploy, every one identical:**

```
system_blocks=10
system_breakpoint_prefix_chars=[20358, 25241]
system_breakpoint_ttls=["1h", "5m"]
tool_breakpoint_ttl=1h
tools=61–65
```

System breakpoints are stable, prefix lengths don't drift. PR #800 worked. Yet:

| time | input | cache_creation | cache_read |
|---|---|---|---|
| 06:17 | 329k | 431k | **0** |
| 06:43 | 140k | 194k | **0** |
| 06:45 | 19k | 28k | **0** |
| 06:46 | 100k | 140k | **0** |
| 07:07 | 20k | 28k | **0** |
| 07:07 | 20k | 28k | **0** |
| 07:08 | 21k | 28k | **0** |
| 07:10 | 21k | 28k | **0** |

Four turns from 07:07–07:10 are within three minutes on the same conversation. Identical `cache_creation=27974`, `cache_read=0` on all four. With stable system blocks and stable cache positions, the only remaining variable is tool order — which Go map iteration was scrambling on every call to [`Registry.List()`](internal/tools/tools.go:898).

## Scope

- [`Registry.List()`](internal/tools/tools.go:898) — collect names, `sort.Strings`, then materialize the `[]map[string]any` in sorted order.
- [`Registry.AllToolNames()`](internal/tools/tools.go:914) — sort before returning.
- Two new tests — both register tools in reverse-alphabetical order and call the function 32 times, asserting alphabetical output every iteration. If Go map iteration leaks through, even one of the 32 will catch it.
- No change to filtered-registry code paths: `FilteredCopy`, `FilteredCopyExcluding`, and `WithRuntimeTools` still produce a `map[string]*Tool`, but the determinism is enforced at the `List`/`AllToolNames` boundary, not at construction.

## Test plan

- [x] New unit tests pass under `-race`, 32 iterations each
- [x] `just ci` passes locally (build, lint, race tests, link check, architecture check)
- [ ] Verify in production: rebuild the agent, fire two opus turns in the same conversation, confirm the second turn's `cache_read_input_tokens` is non-zero and roughly matches the first turn's `cache_creation_input_tokens`
- [ ] Spot-check the marker logs to confirm the `tool_breakpoint_ttl=1h` is now landing on a deterministic last tool (alphabetically last name)