### PR TITLE
feat: capture Anthropic x-request-id into usage_records

### DIFF
--- a/internal/model/fleet/providers/anthropic.go
+++ b/internal/model/fleet/providers/anthropic.go
@@ -263,10 +263,11 @@ func (c *AnthropicClient) ChatStream(ctx context.Context, model string, messages
 		return nil, fmt.Errorf("anthropic API error %d: %s", resp.StatusCode, errBody)
 	}
 
+	upstreamRequestID := resp.Header.Get("x-request-id")
 	if !stream {
-		return c.handleNonStreaming(ctx, resp.Body)
+		return c.handleNonStreaming(ctx, resp.Body, upstreamRequestID)
 	}
-	return c.handleStreaming(ctx, resp.Body, callback)
+	return c.handleStreaming(ctx, resp.Body, callback, upstreamRequestID)
 }
 
 // Ping checks if the Anthropic API is reachable.
@@ -307,12 +308,13 @@ func (c *AnthropicClient) Ping(ctx context.Context) error {
 	return nil
 }
 
-func (c *AnthropicClient) handleNonStreaming(ctx context.Context, body io.Reader) (*llm.ChatResponse, error) {
+func (c *AnthropicClient) handleNonStreaming(ctx context.Context, body io.Reader, upstreamRequestID string) (*llm.ChatResponse, error) {
 	var resp anthropicResponse
 	if err := json.NewDecoder(body).Decode(&resp); err != nil {
 		return nil, fmt.Errorf("decode response: %w", err)
 	}
 	result := convertFromAnthropic(&resp)
+	result.UpstreamRequestID = upstreamRequestID
 
 	c.logger.Debug("response received",
 		"model", result.Model,
@@ -322,13 +324,14 @@ func (c *AnthropicClient) handleNonStreaming(ctx context.Context, body io.Reader
 		"cache_read_input_tokens", result.CacheReadInputTokens,
 		"cache_hit_rate", result.CacheHitRate(),
 		"tool_calls", len(result.Message.ToolCalls),
+		"upstream_request_id", upstreamRequestID,
 	)
 	c.logger.Log(ctx, llm.LevelTrace, "response content", "content", result.Message.Content)
 
 	return result, nil
 }
 
-func (c *AnthropicClient) handleStreaming(ctx context.Context, body io.Reader, callback llm.StreamCallback) (*llm.ChatResponse, error) {
+func (c *AnthropicClient) handleStreaming(ctx context.Context, body io.Reader, callback llm.StreamCallback, upstreamRequestID string) (*llm.ChatResponse, error) {
 	scanner := bufio.NewScanner(body)
 	// Increase scanner buffer for large responses
 	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
@@ -434,6 +437,7 @@ func (c *AnthropicClient) handleStreaming(ctx context.Context, body io.Reader, c
 			ToolCalls: toolCalls,
 		},
 		Done:                     true,
+		UpstreamRequestID:        upstreamRequestID,
 		InputTokens:              usage.InputTokens,
 		OutputTokens:             usage.OutputTokens,
 		CacheCreationInputTokens: usage.CacheCreationInputTokens,
@@ -456,6 +460,7 @@ func (c *AnthropicClient) handleStreaming(ctx context.Context, body io.Reader, c
 		"cache_hit_rate", resp.CacheHitRate(),
 		"content_len", len(resp.Message.Content),
 		"tool_calls", len(resp.Message.ToolCalls),
+		"upstream_request_id", upstreamRequestID,
 	)
 	c.logger.Log(ctx, llm.LevelTrace, "stream final content", "content", resp.Message.Content)
 

--- a/internal/model/fleet/providers/anthropic_test.go
+++ b/internal/model/fleet/providers/anthropic_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"io"
 	"log/slog"
 	"strings"
 	"testing"
@@ -576,5 +577,48 @@ func TestAnthropicClient_SetLogger_NilGuards(t *testing.T) {
 	c.SetLogger(nil)
 	if c.logger != before {
 		t.Fatal("nil logger argument must not replace existing logger")
+	}
+}
+
+func TestAnthropicClient_HandleNonStreamingCapturesUpstreamRequestID(t *testing.T) {
+	body := strings.NewReader(`{
+		"id":"msg_01",
+		"type":"message",
+		"role":"assistant",
+		"content":[{"type":"text","text":"hi"}],
+		"model":"claude-opus-4-20250514",
+		"stop_reason":"end_turn",
+		"usage":{"input_tokens":10,"output_tokens":5}
+	}`)
+	c := NewAnthropicClient("k", slog.New(slog.NewTextHandler(io.Discard, nil)))
+
+	resp, err := c.handleNonStreaming(context.Background(), body, "req_xyz789")
+	if err != nil {
+		t.Fatalf("handleNonStreaming: %v", err)
+	}
+	if resp.UpstreamRequestID != "req_xyz789" {
+		t.Fatalf("UpstreamRequestID = %q, want %q", resp.UpstreamRequestID, "req_xyz789")
+	}
+}
+
+func TestAnthropicClient_HandleStreamingCapturesUpstreamRequestID(t *testing.T) {
+	// Minimal SSE stream: message_start with usage, then message_stop.
+	stream := strings.Join([]string{
+		`event: message_start`,
+		`data: {"type":"message_start","message":{"id":"msg_x","model":"claude-opus-4-20250514","usage":{"input_tokens":10,"output_tokens":0}}}`,
+		``,
+		`event: message_stop`,
+		`data: {"type":"message_stop"}`,
+		``,
+		``,
+	}, "\n")
+
+	c := NewAnthropicClient("k", slog.New(slog.NewTextHandler(io.Discard, nil)))
+	resp, err := c.handleStreaming(context.Background(), strings.NewReader(stream), nil, "req_streamed_999")
+	if err != nil {
+		t.Fatalf("handleStreaming: %v", err)
+	}
+	if resp.UpstreamRequestID != "req_streamed_999" {
+		t.Fatalf("UpstreamRequestID = %q, want %q", resp.UpstreamRequestID, "req_streamed_999")
 	}
 }

--- a/internal/model/llm/types.go
+++ b/internal/model/llm/types.go
@@ -54,6 +54,13 @@ type ChatResponse struct {
 	Message   Message
 	Done      bool
 
+	// UpstreamRequestID is the provider-side request identifier when the
+	// provider exposes one (e.g. Anthropic's `x-request-id` response
+	// header). Empty when the provider does not return one. Captured
+	// for support escalation, billing reconciliation, and correlating
+	// our local r_* request IDs to upstream invoice line items.
+	UpstreamRequestID string
+
 	// Token usage (provider-neutral)
 	InputTokens              int
 	OutputTokens             int

--- a/internal/platform/usage/store.go
+++ b/internal/platform/usage/store.go
@@ -19,11 +19,17 @@ import (
 
 // Record represents a single LLM interaction's token usage and cost.
 type Record struct {
-	ID                       string
-	Timestamp                time.Time
-	RequestID                string
-	SessionID                string
-	ConversationID           string
+	ID             string
+	Timestamp      time.Time
+	RequestID      string
+	SessionID      string
+	ConversationID string
+	// UpstreamRequestID is the provider-side request identifier when
+	// available (e.g. Anthropic's `x-request-id` response header).
+	// Empty when the provider does not return one or the call failed
+	// before headers arrived. Captured for support escalation and to
+	// correlate our local r_* IDs with upstream invoice line items.
+	UpstreamRequestID        string
 	Model                    string // Selected deployment ID when known
 	UpstreamModel            string
 	Resource                 string
@@ -152,6 +158,13 @@ func (s *Store) migrate() error {
 	if err := database.AddColumn(s.db, "usage_records", "cache_creation_1h_input_tokens", "INTEGER NOT NULL DEFAULT 0"); err != nil {
 		return err
 	}
+	// upstream_request_id captures Anthropic's `x-request-id` response
+	// header (and any equivalent from future providers) for billing
+	// correlation. Rows from before this migration have "" — fine,
+	// the column is informational and never participates in joins.
+	if err := database.AddColumn(s.db, "usage_records", "upstream_request_id", "TEXT NOT NULL DEFAULT ''"); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -171,13 +184,14 @@ func (s *Store) Record(ctx context.Context, rec Record) error {
 
 	_, err := s.db.ExecContext(ctx,
 		`INSERT INTO usage_records
-			(id, timestamp, request_id, session_id, conversation_id, model, upstream_model, resource, provider,
+			(id, timestamp, request_id, upstream_request_id, session_id, conversation_id, model, upstream_model, resource, provider,
 			 input_tokens, output_tokens, cache_creation_input_tokens, cache_creation_5m_input_tokens,
 			 cache_creation_1h_input_tokens, cache_read_input_tokens, cost_usd, role, task_name)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		rec.ID,
 		rec.Timestamp.UTC().Format(time.RFC3339),
 		rec.RequestID,
+		rec.UpstreamRequestID,
 		rec.SessionID,
 		rec.ConversationID,
 		rec.Model,

--- a/internal/platform/usage/store_test.go
+++ b/internal/platform/usage/store_test.go
@@ -734,3 +734,47 @@ func TestMigrate_AddsDeploymentMetadataColumns(t *testing.T) {
 		t.Fatal("expected cache_read_input_tokens column after migration")
 	}
 }
+
+func TestRecord_PersistsUpstreamRequestID(t *testing.T) {
+	s := testStore(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	rec := Record{
+		Timestamp:         now,
+		RequestID:         "r_local_001",
+		UpstreamRequestID: "req_anthropic_xyz",
+		Model:             "claude-opus-4-20250514",
+		Provider:          "anthropic",
+		InputTokens:       100,
+		OutputTokens:      50,
+		Role:              "interactive",
+	}
+	if err := s.Record(ctx, rec); err != nil {
+		t.Fatalf("Record: %v", err)
+	}
+
+	row := s.db.QueryRow(`SELECT upstream_request_id FROM usage_records WHERE request_id = ?`, "r_local_001")
+	var got string
+	if err := row.Scan(&got); err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if got != "req_anthropic_xyz" {
+		t.Errorf("upstream_request_id = %q, want %q", got, "req_anthropic_xyz")
+	}
+}
+
+func TestMigrate_AddsUpstreamRequestIDColumn(t *testing.T) {
+	db, err := database.OpenMemory()
+	if err != nil {
+		t.Fatalf("OpenMemory: %v", err)
+	}
+	defer db.Close()
+
+	if _, err := NewStore(db); err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	if !database.HasColumn(db, "usage_records", "upstream_request_id") {
+		t.Fatal("expected upstream_request_id column after migration")
+	}
+}

--- a/internal/runtime/agent/loop.go
+++ b/internal/runtime/agent/loop.go
@@ -1576,7 +1576,7 @@ func (l *Loop) Run(ctx context.Context, req *Request, stream StreamCallback) (re
 			"elapsed_ms", time.Since(startTime).Milliseconds(),
 		)
 
-		l.recordUsage(ctx, req, llmResp.Model, llmResp.InputTokens, llmResp.OutputTokens, llmResp.CacheCreationInputTokens, llmResp.CacheCreation5mInputTokens, llmResp.CacheCreation1hInputTokens, llmResp.CacheReadInputTokens, convID, sessionTag, requestID)
+		l.recordUsage(ctx, req, llmResp.Model, llmResp.InputTokens, llmResp.OutputTokens, llmResp.CacheCreationInputTokens, llmResp.CacheCreation5mInputTokens, llmResp.CacheCreation1hInputTokens, llmResp.CacheReadInputTokens, convID, sessionTag, requestID, llmResp.UpstreamRequestID)
 
 		return &Response{
 			Content:                  llmResp.Message.Content,
@@ -2375,7 +2375,7 @@ func (l *Loop) Run(ctx context.Context, req *Request, stream StreamCallback) (re
 
 	l.recordLiveRequestDetail(ctx, requestID, systemPrompt, userMessage, iterResult)
 
-	l.recordUsage(ctx, req, iterResult.Model, iterResult.InputTokens, iterResult.OutputTokens, iterResult.CacheCreationInputTokens, iterResult.CacheCreation5mInputTokens, iterResult.CacheCreation1hInputTokens, iterResult.CacheReadInputTokens, convID, sessionTag, requestID)
+	l.recordUsage(ctx, req, iterResult.Model, iterResult.InputTokens, iterResult.OutputTokens, iterResult.CacheCreationInputTokens, iterResult.CacheCreation5mInputTokens, iterResult.CacheCreation1hInputTokens, iterResult.CacheReadInputTokens, convID, sessionTag, requestID, iterResult.UpstreamRequestID)
 	l.archiveIterations(log, convID, iterResult.Iterations)
 
 	// Content retention is fire-and-forget with a short deadline so it
@@ -3196,7 +3196,11 @@ func formatHistoryJSON(messages []memory.Message, tz string) string {
 // the provider exposes the breakdown (Anthropic). Pass 0/0 when the
 // provider doesn't attribute the writes; pricing falls back to the 5m
 // rate for the unattributed portion.
-func (l *Loop) recordUsage(ctx context.Context, req *Request, model string, totalIn, totalOut, cacheCreateIn, cacheCreate5m, cacheCreate1h, cacheReadIn int, convID, sessionTag, requestID string) {
+//
+// upstreamRequestID is the provider-side request ID (e.g. Anthropic's
+// `x-request-id` response header) when the provider exposes one. Pass
+// "" when no upstream ID is available; the column accepts empty.
+func (l *Loop) recordUsage(ctx context.Context, req *Request, model string, totalIn, totalOut, cacheCreateIn, cacheCreate5m, cacheCreate1h, cacheReadIn int, convID, sessionTag, requestID, upstreamRequestID string) {
 	if l.usageStore == nil {
 		return
 	}
@@ -3224,6 +3228,7 @@ func (l *Loop) recordUsage(ctx context.Context, req *Request, model string, tota
 	rec := usage.Record{
 		Timestamp:                  time.Now(),
 		RequestID:                  requestID,
+		UpstreamRequestID:          upstreamRequestID,
 		SessionID:                  sessionTag,
 		ConversationID:             convID,
 		Model:                      identity.Model,

--- a/internal/runtime/iterate/engine.go
+++ b/internal/runtime/iterate/engine.go
@@ -76,6 +76,7 @@ func (e *Engine) Run(ctx context.Context, cfg Config, messages []llm.Message) (*
 				if err != nil {
 					return &Result{
 						Model:                      model,
+						UpstreamRequestID:          latestUpstreamRequestID(iterations),
 						InputTokens:                totalInput,
 						OutputTokens:               totalOutput,
 						CacheCreationInputTokens:   totalCacheCreate,
@@ -95,6 +96,7 @@ func (e *Engine) Run(ctx context.Context, cfg Config, messages []llm.Message) (*
 			} else {
 				return &Result{
 					Model:                      model,
+					UpstreamRequestID:          latestUpstreamRequestID(iterations),
 					InputTokens:                totalInput,
 					OutputTokens:               totalOutput,
 					CacheCreationInputTokens:   totalCacheCreate,
@@ -129,6 +131,7 @@ func (e *Engine) Run(ctx context.Context, cfg Config, messages []llm.Message) (*
 			budgetRec := IterationRecord{
 				Index:                      i,
 				Model:                      llmResp.Model,
+				UpstreamRequestID:          llmResp.UpstreamRequestID,
 				InputTokens:                llmResp.InputTokens,
 				OutputTokens:               llmResp.OutputTokens,
 				CacheCreationInputTokens:   llmResp.CacheCreationInputTokens,
@@ -144,6 +147,7 @@ func (e *Engine) Run(ctx context.Context, cfg Config, messages []llm.Message) (*
 			iterations = append(iterations, budgetRec)
 			partial := &Result{
 				Model:                      model,
+				UpstreamRequestID:          latestUpstreamRequestID(iterations),
 				InputTokens:                totalInput,
 				OutputTokens:               totalOutput,
 				CacheCreationInputTokens:   totalCacheCreate,
@@ -185,6 +189,7 @@ func (e *Engine) Run(ctx context.Context, cfg Config, messages []llm.Message) (*
 		iterRec := IterationRecord{
 			Index:                      i,
 			Model:                      llmResp.Model,
+			UpstreamRequestID:          llmResp.UpstreamRequestID,
 			InputTokens:                llmResp.InputTokens,
 			OutputTokens:               llmResp.OutputTokens,
 			CacheCreationInputTokens:   llmResp.CacheCreationInputTokens,
@@ -419,6 +424,7 @@ func (e *Engine) Run(ctx context.Context, cfg Config, messages []llm.Message) (*
 		return &Result{
 			Content:                    llmResp.Message.Content,
 			Model:                      model,
+			UpstreamRequestID:          latestUpstreamRequestID(iterations),
 			InputTokens:                totalInput,
 			OutputTokens:               totalOutput,
 			CacheCreationInputTokens:   totalCacheCreate,
@@ -441,6 +447,7 @@ func (e *Engine) Run(ctx context.Context, cfg Config, messages []llm.Message) (*
 
 	return e.forceText(ctx, cfg, model, messages, &Result{
 		Model:                      model,
+		UpstreamRequestID:          latestUpstreamRequestID(iterations),
 		InputTokens:                totalInput,
 		OutputTokens:               totalOutput,
 		CacheCreationInputTokens:   totalCacheCreate,
@@ -497,6 +504,7 @@ func (e *Engine) forceText(ctx context.Context, cfg Config, model string, messag
 		partial.Iterations = append(partial.Iterations, IterationRecord{
 			Index:                      len(partial.Iterations),
 			Model:                      resp.Model,
+			UpstreamRequestID:          resp.UpstreamRequestID,
 			InputTokens:                resp.InputTokens,
 			OutputTokens:               resp.OutputTokens,
 			CacheCreationInputTokens:   resp.CacheCreationInputTokens,
@@ -512,6 +520,20 @@ func (e *Engine) forceText(ctx context.Context, cfg Config, model string, messag
 		partial.Content = content
 	}
 
+	partial.UpstreamRequestID = latestUpstreamRequestID(partial.Iterations)
 	partial.Messages = messages
 	return partial, nil
+}
+
+// latestUpstreamRequestID returns the most recent non-empty upstream
+// request ID across iterations, or "" when none captured one. Used to
+// surface the final iteration's provider-side ID on Result without
+// forcing every Result construction site to dig into Iterations.
+func latestUpstreamRequestID(iters []IterationRecord) string {
+	for i := len(iters) - 1; i >= 0; i-- {
+		if iters[i].UpstreamRequestID != "" {
+			return iters[i].UpstreamRequestID
+		}
+	}
+	return ""
 }

--- a/internal/runtime/iterate/engine_test.go
+++ b/internal/runtime/iterate/engine_test.go
@@ -840,3 +840,75 @@ func TestEngine_ToolDefsNamesEmpty(t *testing.T) {
 		t.Errorf("names = %v, want nil", names)
 	}
 }
+
+func TestEngine_PropagatesUpstreamRequestID(t *testing.T) {
+	first := textResponse("Hello back!")
+	first.UpstreamRequestID = "req_anthropic_abc123"
+	mock := &mockLLM{responses: []*llm.ChatResponse{first}}
+	exec := &mockExecutor{results: map[string]string{}}
+	cfg := baseCfg(mock, exec)
+
+	engine := &Engine{}
+	result, err := engine.Run(context.Background(), cfg, baseMessages())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.UpstreamRequestID != "req_anthropic_abc123" {
+		t.Errorf("Result.UpstreamRequestID = %q, want %q", result.UpstreamRequestID, "req_anthropic_abc123")
+	}
+	if len(result.Iterations) != 1 {
+		t.Fatalf("iterations = %d, want 1", len(result.Iterations))
+	}
+	if result.Iterations[0].UpstreamRequestID != "req_anthropic_abc123" {
+		t.Errorf("Iterations[0].UpstreamRequestID = %q, want %q", result.Iterations[0].UpstreamRequestID, "req_anthropic_abc123")
+	}
+}
+
+func TestEngine_UpstreamRequestID_LatestNonEmptyWins(t *testing.T) {
+	// Multi-iteration: tool call then text. The final text response carries
+	// the upstream ID; an empty middle ID must not blank out the result.
+	tc := toolCallResponse(makeToolCall("search", map[string]any{"q": "x"}))
+	tc.UpstreamRequestID = "req_first"
+	final := textResponse("done")
+	final.UpstreamRequestID = "req_final"
+	mock := &mockLLM{responses: []*llm.ChatResponse{tc, final}}
+	exec := &mockExecutor{results: map[string]string{"search": "ok"}}
+	cfg := baseCfg(mock, exec)
+
+	engine := &Engine{}
+	result, err := engine.Run(context.Background(), cfg, baseMessages())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.UpstreamRequestID != "req_final" {
+		t.Errorf("Result.UpstreamRequestID = %q, want %q (most recent iteration wins)", result.UpstreamRequestID, "req_final")
+	}
+	if len(result.Iterations) != 2 {
+		t.Fatalf("iterations = %d, want 2", len(result.Iterations))
+	}
+	if result.Iterations[0].UpstreamRequestID != "req_first" || result.Iterations[1].UpstreamRequestID != "req_final" {
+		t.Errorf("per-iteration IDs lost: %q, %q", result.Iterations[0].UpstreamRequestID, result.Iterations[1].UpstreamRequestID)
+	}
+}
+
+func TestLatestUpstreamRequestID(t *testing.T) {
+	tests := []struct {
+		name string
+		in   []IterationRecord
+		want string
+	}{
+		{name: "empty", in: nil, want: ""},
+		{name: "all empty", in: []IterationRecord{{}, {}, {}}, want: ""},
+		{name: "single id", in: []IterationRecord{{UpstreamRequestID: "abc"}}, want: "abc"},
+		{name: "later wins", in: []IterationRecord{{UpstreamRequestID: "first"}, {UpstreamRequestID: "second"}}, want: "second"},
+		{name: "skips trailing empty", in: []IterationRecord{{UpstreamRequestID: "kept"}, {}}, want: "kept"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := latestUpstreamRequestID(tt.in)
+			if got != tt.want {
+				t.Errorf("latestUpstreamRequestID(%+v) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/runtime/iterate/types.go
+++ b/internal/runtime/iterate/types.go
@@ -21,6 +21,7 @@ const (
 type IterationRecord struct {
 	Index                      int
 	Model                      string
+	UpstreamRequestID          string
 	InputTokens                int
 	OutputTokens               int
 	CacheCreationInputTokens   int
@@ -44,6 +45,14 @@ type Result struct {
 	// differ from the initially configured model if error recovery
 	// or failover changed it.
 	Model string
+
+	// UpstreamRequestID is the provider-side request ID of the final
+	// iteration when the provider returned one (e.g. Anthropic's
+	// `x-request-id` header). Empty when the provider doesn't expose
+	// one or the run had no successful iterations. Per-iteration IDs
+	// remain available on Iterations[i].UpstreamRequestID for cases
+	// where billing escalation or correlation needs the full chain.
+	UpstreamRequestID string
 
 	// InputTokens is the cumulative input token count across all iterations.
 	InputTokens int


### PR DESCRIPTION
## Summary

Anthropic returns a unique `x-request-id` per response. Capture it into `usage_records.upstream_request_id` (new column) so future billing escalations and reconciliations can correlate our local `r_*` IDs against upstream invoice line items. **Phase 2 of [#744](https://github.com/nugget/thane-ai-agent/issues/744).**

## Why now

Tonight's cache-hit-rate audit ([#800](https://github.com/nugget/thane-ai-agent/pull/800), [#802](https://github.com/nugget/thane-ai-agent/pull/802), [#804](https://github.com/nugget/thane-ai-agent/pull/804)) flagged the gap explicitly: the burn pattern was visible in our logs but couldn't be cross-referenced with Anthropic's side without filing a manual support ticket. Capturing the header is the smallest possible fix — one line of stdlib in the provider, one column in the schema — and unlocks every future incident.

## Plumbing

```
http resp.Header.Get("x-request-id")
  → llm.ChatResponse.UpstreamRequestID
  → iterate.IterationRecord.UpstreamRequestID
  → iterate.Result.UpstreamRequestID    (latest non-empty wins)
  → usage.Record.UpstreamRequestID
  → usage_records.upstream_request_id
```

The ID is captured on every iteration; `iterate.Result.UpstreamRequestID` surfaces the most recent non-empty one via a small `latestUpstreamRequestID` helper, so multi-iteration tool runs land the *final* upstream ID in `usage_records` (the one that actually completed billing). Per-iteration IDs remain on `Iterations[i]` for cases where the full chain matters.

## Schema migration

```sql
ALTER TABLE usage_records ADD COLUMN upstream_request_id TEXT NOT NULL DEFAULT '';
```

Empty default means historical rows coexist; the column is informational and never participates in joins. No backfill needed.

## Provider observability

The pre-existing `c.logger.Debug("response received", ...)` and `c.logger.Debug("stream complete", ...)` lines now include `upstream_request_id`, so the value is visible in `events/` without querying the DB.

## Out of scope (separate PRs in this Phase 2 chain)

- Rate-limit headers (`anthropic-ratelimit-*`)
- Extending the cache-marker log with dropped-breakpoint reasons
- Surfacing `stop_reason` (especially `pause_turn`) in `IterationRecord`

## Test plan

- [x] Unit: `handleNonStreaming` and `handleStreaming` propagate the param onto `ChatResponse.UpstreamRequestID`
- [x] Unit: `iterate.Engine.Run` propagates `ChatResponse.UpstreamRequestID` onto every `IterationRecord` and onto `Result`; multi-iteration runs surface the final iteration's ID
- [x] Unit: `latestUpstreamRequestID` helper covers empty, all-empty, single, multi, and trailing-empty cases
- [x] Unit: `usage.Store.Record` persists the column; migration adds the column on existing DBs
- [x] `just ci` passes locally (build, lint, race tests, link check, architecture check)
- [ ] Verify in production: rebuild, fire one opus turn, query `usage_records.upstream_request_id` to confirm the column is populated; cross-reference one ID with Anthropic's response logs