### PR TITLE
feat: capture Anthropic rate-limit headers and dropped-marker reasons

### DIFF
--- a/internal/model/fleet/providers/anthropic.go
+++ b/internal/model/fleet/providers/anthropic.go
@@ -9,7 +9,9 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/nugget/thane-ai-agent/internal/model/llm"
@@ -26,6 +28,39 @@ type AnthropicClient struct {
 	apiKey     string
 	httpClient *http.Client
 	logger     *slog.Logger
+
+	rateLimitMu       sync.Mutex
+	rateLimitSnapshot *RateLimitSnapshot
+}
+
+// RateLimitSnapshot is the most recent set of rate-limit headers
+// returned by Anthropic. Captured on every response so smarter backoff
+// decisions and dashboards can reason about remaining capacity rather
+// than reacting blindly to 429s. Zero values indicate the header was
+// absent (different deployments expose different subsets).
+type RateLimitSnapshot struct {
+	CapturedAt        time.Time
+	UpstreamRequestID string
+
+	RequestsLimit     int
+	RequestsRemaining int
+	RequestsReset     time.Time
+
+	TokensLimit     int
+	TokensRemaining int
+	TokensReset     time.Time
+
+	InputTokensLimit     int
+	InputTokensRemaining int
+	InputTokensReset     time.Time
+
+	OutputTokensLimit     int
+	OutputTokensRemaining int
+	OutputTokensReset     time.Time
+
+	// RetryAfter is set from the `retry-after` response header,
+	// typically only present on 429 / 5xx responses.
+	RetryAfter time.Duration
 }
 
 // NewAnthropicClient creates a new Anthropic client.
@@ -91,6 +126,90 @@ func (c *AnthropicClient) Logger() *slog.Logger {
 		return nil
 	}
 	return c.logger
+}
+
+// RateLimitSnapshot returns a copy of the most recently captured
+// rate-limit headers, or nil when no response has been received yet.
+// Safe to call concurrently with in-flight requests.
+func (c *AnthropicClient) RateLimitSnapshot() *RateLimitSnapshot {
+	if c == nil {
+		return nil
+	}
+	c.rateLimitMu.Lock()
+	defer c.rateLimitMu.Unlock()
+	if c.rateLimitSnapshot == nil {
+		return nil
+	}
+	cp := *c.rateLimitSnapshot
+	return &cp
+}
+
+func (c *AnthropicClient) storeRateLimitSnapshot(snap *RateLimitSnapshot) {
+	if c == nil || snap == nil {
+		return
+	}
+	c.rateLimitMu.Lock()
+	c.rateLimitSnapshot = snap
+	c.rateLimitMu.Unlock()
+}
+
+// parseRateLimitHeaders extracts Anthropic's documented rate-limit
+// headers into a snapshot. Missing headers leave their fields zero.
+// Reset values come back as RFC3339 timestamps; retry-after is in
+// seconds. UpstreamRequestID is filled from the same response so a
+// snapshot is self-correlating.
+func parseRateLimitHeaders(h http.Header, upstreamRequestID string, capturedAt time.Time) *RateLimitSnapshot {
+	if h == nil {
+		return nil
+	}
+	hasAny := false
+	snap := &RateLimitSnapshot{
+		CapturedAt:        capturedAt,
+		UpstreamRequestID: upstreamRequestID,
+	}
+	parseInt := func(key string) int {
+		v := h.Get(key)
+		if v == "" {
+			return 0
+		}
+		hasAny = true
+		n, _ := strconv.Atoi(v)
+		return n
+	}
+	parseTime := func(key string) time.Time {
+		v := h.Get(key)
+		if v == "" {
+			return time.Time{}
+		}
+		hasAny = true
+		t, err := time.Parse(time.RFC3339, v)
+		if err != nil {
+			return time.Time{}
+		}
+		return t
+	}
+	snap.RequestsLimit = parseInt("anthropic-ratelimit-requests-limit")
+	snap.RequestsRemaining = parseInt("anthropic-ratelimit-requests-remaining")
+	snap.RequestsReset = parseTime("anthropic-ratelimit-requests-reset")
+	snap.TokensLimit = parseInt("anthropic-ratelimit-tokens-limit")
+	snap.TokensRemaining = parseInt("anthropic-ratelimit-tokens-remaining")
+	snap.TokensReset = parseTime("anthropic-ratelimit-tokens-reset")
+	snap.InputTokensLimit = parseInt("anthropic-ratelimit-input-tokens-limit")
+	snap.InputTokensRemaining = parseInt("anthropic-ratelimit-input-tokens-remaining")
+	snap.InputTokensReset = parseTime("anthropic-ratelimit-input-tokens-reset")
+	snap.OutputTokensLimit = parseInt("anthropic-ratelimit-output-tokens-limit")
+	snap.OutputTokensRemaining = parseInt("anthropic-ratelimit-output-tokens-remaining")
+	snap.OutputTokensReset = parseTime("anthropic-ratelimit-output-tokens-reset")
+	if v := h.Get("retry-after"); v != "" {
+		hasAny = true
+		if secs, err := strconv.Atoi(v); err == nil {
+			snap.RetryAfter = time.Duration(secs) * time.Second
+		}
+	}
+	if !hasAny {
+		return nil
+	}
+	return snap
 }
 
 // Anthropic request/response types
@@ -210,8 +329,9 @@ func (c *AnthropicClient) ChatStream(ctx context.Context, model string, messages
 	// minimum cached-prefix length) on the assembled blocks+tools.
 	// Runs below the model minimum and excess breakpoints are silently
 	// ignored by the API, so we drop them here and warn instead.
+	var cacheDrops []CacheBreakpointDrop
 	if blocks, ok := systemPayload.([]anthropicContent); ok {
-		applyCacheBreakpointGuards(blocks, anthropicTools, model, c.logger)
+		cacheDrops = applyCacheBreakpointGuards(blocks, anthropicTools, model, c.logger)
 	}
 	explicitCaching := anthropicUsesExplicitPromptCaching(systemPayload)
 
@@ -234,7 +354,7 @@ func (c *AnthropicClient) ChatStream(ctx context.Context, model string, messages
 		CacheControl: anthropicPromptCacheControl(systemPrompt, anthropicMsgs, anthropicTools, explicitCaching),
 	}
 
-	logOutboundCacheMarkers(c.logger, &req)
+	logOutboundCacheMarkers(c.logger, &req, cacheDrops)
 
 	jsonData, err := json.Marshal(req)
 	if err != nil {
@@ -257,6 +377,14 @@ func (c *AnthropicClient) ChatStream(ctx context.Context, model string, messages
 	}
 	defer resp.Body.Close()
 
+	// Provider-side observability: capture rate-limit headers regardless
+	// of status, so 429s and 5xx still update the snapshot. The headers
+	// are documented per-call invariants, not per-success.
+	if snap := parseRateLimitHeaders(resp.Header, resp.Header.Get("x-request-id"), time.Now()); snap != nil {
+		c.storeRateLimitSnapshot(snap)
+		logRateLimitSnapshot(c.logger, snap)
+	}
+
 	if resp.StatusCode != http.StatusOK {
 		errBody := httpkit.ReadErrorBody(resp.Body, 4096)
 		c.logger.Error("API error", "status", resp.StatusCode, "body", errBody)
@@ -268,6 +396,30 @@ func (c *AnthropicClient) ChatStream(ctx context.Context, model string, messages
 		return c.handleNonStreaming(ctx, resp.Body, upstreamRequestID)
 	}
 	return c.handleStreaming(ctx, resp.Body, callback, upstreamRequestID)
+}
+
+// logRateLimitSnapshot emits a structured Debug line on every response
+// so operators can correlate captured rate-limit state without querying
+// the snapshot accessor. Short-circuits when Debug is off so the field
+// list isn't built per request in production.
+func logRateLimitSnapshot(logger *slog.Logger, snap *RateLimitSnapshot) {
+	if logger == nil || snap == nil || !logger.Enabled(context.Background(), slog.LevelDebug) {
+		return
+	}
+	logger.Debug("anthropic rate limits",
+		"upstream_request_id", snap.UpstreamRequestID,
+		"requests_limit", snap.RequestsLimit,
+		"requests_remaining", snap.RequestsRemaining,
+		"requests_reset", snap.RequestsReset.Format(time.RFC3339),
+		"tokens_limit", snap.TokensLimit,
+		"tokens_remaining", snap.TokensRemaining,
+		"tokens_reset", snap.TokensReset.Format(time.RFC3339),
+		"input_tokens_limit", snap.InputTokensLimit,
+		"input_tokens_remaining", snap.InputTokensRemaining,
+		"output_tokens_limit", snap.OutputTokensLimit,
+		"output_tokens_remaining", snap.OutputTokensRemaining,
+		"retry_after", snap.RetryAfter.String(),
+	)
 }
 
 // Ping checks if the Anthropic API is reachable.
@@ -546,12 +698,37 @@ func minCacheablePrefixTokens(model string) int {
 	}
 }
 
+// CacheBreakpointDrop describes a cache_control marker that was
+// stripped before the request went out. Surfaced both via the Warn
+// logs the guards already emit AND aggregated onto the
+// `outbound cache markers` line so a single log can answer "did we
+// ship the breakpoints we intended?".
+type CacheBreakpointDrop struct {
+	// Reason identifies which guard rule fired. One of:
+	//   "under_minimum_prefix"        — system block, prefix too short
+	//   "over_cap_tool_breakpoint"    — tool cache dropped to fit ≤4
+	//   "over_cap_trailing_system"    — trailing system breakpoint dropped to fit ≤4
+	Reason string
+	// Scope is "system" or "tools".
+	Scope string
+	// BlockIndex is the index within Scope ("system" → block index;
+	// "tools" → last-tool index). -1 when not applicable.
+	BlockIndex int
+	// TTL is the dropped breakpoint's TTL hint, when known.
+	TTL string
+}
+
 // applyCacheBreakpointGuards enforces the Anthropic per-request cache
 // breakpoint cap (≤4) and the per-model minimum cached-prefix length
 // across system blocks and the tool cache. Both are silent-failure
 // modes in the raw API: under-minimum runs are processed uncached
 // without any signal, and over-the-cap breakpoint counts cause a
 // request rejection.
+//
+// Returns the list of drops it performed so callers can fold them
+// into a single observability line; the function also continues to
+// emit Warn logs for each drop so production alerting still fires
+// without depending on aggregated logs.
 //
 // The guard policy:
 //
@@ -567,8 +744,9 @@ func minCacheablePrefixTokens(model string) int {
 //  3. If still over the cap, drop trailing system breakpoints (the
 //     earliest runs typically cover the largest stable prefix, so
 //     dropping from the tail minimizes the loss).
-func applyCacheBreakpointGuards(blocks []anthropicContent, tools []anthropicTool, model string, logger *slog.Logger) {
+func applyCacheBreakpointGuards(blocks []anthropicContent, tools []anthropicTool, model string, logger *slog.Logger) []CacheBreakpointDrop {
 	minTokens := minCacheablePrefixTokens(model)
+	var drops []CacheBreakpointDrop
 
 	// Step 1: strip under-minimum breakpoints from system blocks.
 	prefixChars := 0
@@ -586,6 +764,12 @@ func applyCacheBreakpointGuards(blocks []anthropicContent, tools []anthropicTool
 				"min_tokens", minTokens,
 				"ttl", blocks[i].CacheControl.TTL,
 			)
+			drops = append(drops, CacheBreakpointDrop{
+				Reason:     "under_minimum_prefix",
+				Scope:      "system",
+				BlockIndex: i,
+				TTL:        blocks[i].CacheControl.TTL,
+			})
 			blocks[i].CacheControl = nil
 		}
 	}
@@ -604,20 +788,30 @@ func applyCacheBreakpointGuards(blocks []anthropicContent, tools []anthropicTool
 
 	total := systemBreakpoints + toolBreakpoint
 	if total <= maxAnthropicCacheBreakpoints {
-		return
+		return drops
 	}
 
 	// Step 3: drop the tool breakpoint first.
 	if toolBreakpoint > 0 {
+		ttl := ""
+		if tc := tools[len(tools)-1].CacheControl; tc != nil {
+			ttl = tc.TTL
+		}
 		logger.Warn("dropping tool cache breakpoint to fit Anthropic 4-breakpoint cap",
 			"system_breakpoints", systemBreakpoints,
 			"total_requested", total,
 			"max", maxAnthropicCacheBreakpoints,
 		)
+		drops = append(drops, CacheBreakpointDrop{
+			Reason:     "over_cap_tool_breakpoint",
+			Scope:      "tools",
+			BlockIndex: len(tools) - 1,
+			TTL:        ttl,
+		})
 		tools[len(tools)-1].CacheControl = nil
 		total--
 		if total <= maxAnthropicCacheBreakpoints {
-			return
+			return drops
 		}
 	}
 
@@ -627,13 +821,21 @@ func applyCacheBreakpointGuards(blocks []anthropicContent, tools []anthropicTool
 		if blocks[i].CacheControl == nil {
 			continue
 		}
+		ttl := blocks[i].CacheControl.TTL
 		logger.Warn("dropping trailing system cache breakpoint to fit Anthropic 4-breakpoint cap",
 			"block_index", i,
-			"ttl", blocks[i].CacheControl.TTL,
+			"ttl", ttl,
 		)
+		drops = append(drops, CacheBreakpointDrop{
+			Reason:     "over_cap_trailing_system",
+			Scope:      "system",
+			BlockIndex: i,
+			TTL:        ttl,
+		})
 		blocks[i].CacheControl = nil
 		excess--
 	}
+	return drops
 }
 
 // logOutboundCacheMarkers emits a structured debug line describing every
@@ -642,9 +844,13 @@ func applyCacheBreakpointGuards(blocks []anthropicContent, tools []anthropicTool
 // at a different bug than one where markers are present but the prefix
 // isn't matching, so this log is the cheapest way to disambiguate.
 //
+// drops is the list of breakpoints that applyCacheBreakpointGuards
+// stripped before this call — surfaced on the same line so a single log
+// entry shows both what shipped and what was dropped (and why).
+//
 // The function short-circuits when Debug is disabled so the loops and
 // slice allocations don't run on every request in production.
-func logOutboundCacheMarkers(logger *slog.Logger, req *anthropicRequest) {
+func logOutboundCacheMarkers(logger *slog.Logger, req *anthropicRequest, drops []CacheBreakpointDrop) {
 	if logger == nil || !logger.Enabled(context.Background(), slog.LevelDebug) {
 		return
 	}
@@ -701,6 +907,15 @@ func logOutboundCacheMarkers(logger *slog.Logger, req *anthropicRequest) {
 		}
 	}
 
+	dropReasons := make([]string, 0, len(drops))
+	dropTTLs := make([]string, 0, len(drops))
+	dropScopes := make([]string, 0, len(drops))
+	for _, d := range drops {
+		dropReasons = append(dropReasons, d.Reason)
+		dropTTLs = append(dropTTLs, d.TTL)
+		dropScopes = append(dropScopes, d.Scope)
+	}
+
 	logger.Debug("outbound cache markers",
 		"model", req.Model,
 		"system_payload_kind", systemPayloadKind,
@@ -712,6 +927,10 @@ func logOutboundCacheMarkers(logger *slog.Logger, req *anthropicRequest) {
 		"tools", len(req.Tools),
 		"tool_breakpoint_ttl", toolBreakpointTTL,
 		"request_cache_control_ttl", requestLevelTTL,
+		"dropped_breakpoints", len(drops),
+		"dropped_reasons", dropReasons,
+		"dropped_ttls", dropTTLs,
+		"dropped_scopes", dropScopes,
 	)
 }
 

--- a/internal/model/fleet/providers/anthropic.go
+++ b/internal/model/fleet/providers/anthropic.go
@@ -33,10 +33,10 @@ type AnthropicClient struct {
 	rateLimitSnapshot *RateLimitSnapshot
 }
 
-// RateLimitSnapshot is the most recent set of rate-limit headers
-// returned by Anthropic. Captured on every response so smarter backoff
-// decisions and dashboards can reason about remaining capacity rather
-// than reacting blindly to 429s. Zero values indicate the header was
+// RateLimitSnapshot is the most recent set of rate-limit headers returned by
+// Anthropic. Captured on every response from AnthropicClient request paths so
+// smarter backoff decisions and dashboards can reason about remaining capacity
+// rather than reacting blindly to 429s. Zero values indicate the header was
 // absent (different deployments expose different subsets).
 type RateLimitSnapshot struct {
 	CapturedAt        time.Time
@@ -151,6 +151,16 @@ func (c *AnthropicClient) storeRateLimitSnapshot(snap *RateLimitSnapshot) {
 	c.rateLimitMu.Lock()
 	c.rateLimitSnapshot = snap
 	c.rateLimitMu.Unlock()
+}
+
+func (c *AnthropicClient) captureRateLimitHeaders(h http.Header) {
+	if c == nil {
+		return
+	}
+	if snap := parseRateLimitHeaders(h, h.Get("x-request-id"), time.Now()); snap != nil {
+		c.storeRateLimitSnapshot(snap)
+		logRateLimitSnapshot(c.logger, snap)
+	}
 }
 
 // parseRateLimitHeaders extracts Anthropic's documented rate-limit
@@ -380,10 +390,7 @@ func (c *AnthropicClient) ChatStream(ctx context.Context, model string, messages
 	// Provider-side observability: capture rate-limit headers regardless
 	// of status, so 429s and 5xx still update the snapshot. The headers
 	// are documented per-call invariants, not per-success.
-	if snap := parseRateLimitHeaders(resp.Header, resp.Header.Get("x-request-id"), time.Now()); snap != nil {
-		c.storeRateLimitSnapshot(snap)
-		logRateLimitSnapshot(c.logger, snap)
-	}
+	c.captureRateLimitHeaders(resp.Header)
 
 	if resp.StatusCode != http.StatusOK {
 		errBody := httpkit.ReadErrorBody(resp.Body, 4096)
@@ -406,20 +413,33 @@ func logRateLimitSnapshot(logger *slog.Logger, snap *RateLimitSnapshot) {
 	if logger == nil || snap == nil || !logger.Enabled(context.Background(), slog.LevelDebug) {
 		return
 	}
-	logger.Debug("anthropic rate limits",
+	args := []any{
 		"upstream_request_id", snap.UpstreamRequestID,
 		"requests_limit", snap.RequestsLimit,
 		"requests_remaining", snap.RequestsRemaining,
-		"requests_reset", snap.RequestsReset.Format(time.RFC3339),
 		"tokens_limit", snap.TokensLimit,
 		"tokens_remaining", snap.TokensRemaining,
-		"tokens_reset", snap.TokensReset.Format(time.RFC3339),
 		"input_tokens_limit", snap.InputTokensLimit,
 		"input_tokens_remaining", snap.InputTokensRemaining,
 		"output_tokens_limit", snap.OutputTokensLimit,
 		"output_tokens_remaining", snap.OutputTokensRemaining,
-		"retry_after", snap.RetryAfter.String(),
-	)
+	}
+	if !snap.RequestsReset.IsZero() {
+		args = append(args, "requests_reset", snap.RequestsReset.Format(time.RFC3339))
+	}
+	if !snap.TokensReset.IsZero() {
+		args = append(args, "tokens_reset", snap.TokensReset.Format(time.RFC3339))
+	}
+	if !snap.InputTokensReset.IsZero() {
+		args = append(args, "input_tokens_reset", snap.InputTokensReset.Format(time.RFC3339))
+	}
+	if !snap.OutputTokensReset.IsZero() {
+		args = append(args, "output_tokens_reset", snap.OutputTokensReset.Format(time.RFC3339))
+	}
+	if snap.RetryAfter > 0 {
+		args = append(args, "retry_after", snap.RetryAfter.String())
+	}
+	logger.Debug("anthropic rate limits", args...)
 }
 
 // Ping checks if the Anthropic API is reachable.
@@ -450,6 +470,8 @@ func (c *AnthropicClient) Ping(ctx context.Context) error {
 		return fmt.Errorf("request failed: %w", err)
 	}
 	defer httpResp.Body.Close()
+
+	c.captureRateLimitHeaders(httpResp.Header)
 
 	if httpResp.StatusCode == http.StatusUnauthorized {
 		return fmt.Errorf("invalid API key")

--- a/internal/model/fleet/providers/anthropic_test.go
+++ b/internal/model/fleet/providers/anthropic_test.go
@@ -769,3 +769,64 @@ func TestAnthropicClient_RateLimitSnapshot_StoreReturnsCopy(t *testing.T) {
 		t.Fatal("RateLimitSnapshot returned shared pointer; expected defensive copy")
 	}
 }
+
+func TestAnthropicClient_PingCapturesRateLimitSnapshot(t *testing.T) {
+	c := NewAnthropicClient("k", slog.New(slog.NewTextHandler(io.Discard, nil)))
+	c.httpClient = &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		h := http.Header{}
+		h.Set("x-request-id", "req_ping")
+		h.Set("anthropic-ratelimit-requests-remaining", "123")
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     h,
+			Body:       io.NopCloser(strings.NewReader(`{}`)),
+			Request:    req,
+		}, nil
+	})}
+
+	if err := c.Ping(context.Background()); err != nil {
+		t.Fatalf("Ping returned error: %v", err)
+	}
+	snap := c.RateLimitSnapshot()
+	if snap == nil {
+		t.Fatal("RateLimitSnapshot returned nil after Ping response")
+	}
+	if snap.UpstreamRequestID != "req_ping" {
+		t.Errorf("UpstreamRequestID = %q, want req_ping", snap.UpstreamRequestID)
+	}
+	if snap.RequestsRemaining != 123 {
+		t.Errorf("RequestsRemaining = %d, want 123", snap.RequestsRemaining)
+	}
+}
+
+func TestLogRateLimitSnapshot_OmitsMissingResetFields(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	logRateLimitSnapshot(logger, &RateLimitSnapshot{
+		UpstreamRequestID: "req_missing_resets",
+		RequestsLimit:     5000,
+		RequestsRemaining: 4999,
+	})
+
+	got := buf.String()
+	if strings.Contains(got, "0001-01-01T00:00:00Z") {
+		t.Fatalf("zero time leaked into rate-limit log: %s", got)
+	}
+	for _, absent := range []string{
+		"requests_reset",
+		"tokens_reset",
+		"input_tokens_reset",
+		"output_tokens_reset",
+		"retry_after",
+	} {
+		if strings.Contains(got, absent) {
+			t.Errorf("log should omit %q when missing/zero: %s", absent, got)
+		}
+	}
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}

--- a/internal/model/fleet/providers/anthropic_test.go
+++ b/internal/model/fleet/providers/anthropic_test.go
@@ -6,8 +6,10 @@ import (
 	"encoding/json"
 	"io"
 	"log/slog"
+	"net/http"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/nugget/thane-ai-agent/internal/model/llm"
 )
@@ -620,5 +622,150 @@ func TestAnthropicClient_HandleStreamingCapturesUpstreamRequestID(t *testing.T) 
 	}
 	if resp.UpstreamRequestID != "req_streamed_999" {
 		t.Fatalf("UpstreamRequestID = %q, want %q", resp.UpstreamRequestID, "req_streamed_999")
+	}
+}
+
+func TestApplyCacheBreakpointGuards_ReturnsUnderMinimumDrops(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	// Two short blocks with breakpoints; opus minimum is 4096 tokens
+	// (~16384 chars). Both runs sit well below the threshold.
+	blocks := []anthropicContent{
+		{Type: "text", Text: strings.Repeat("a", 1000), CacheControl: &anthropicCacheControl{Type: "ephemeral", TTL: "1h"}},
+		{Type: "text", Text: strings.Repeat("b", 500), CacheControl: &anthropicCacheControl{Type: "ephemeral", TTL: "5m"}},
+	}
+	tools := []anthropicTool{}
+
+	drops := applyCacheBreakpointGuards(blocks, tools, "claude-opus-4-20250514", logger)
+
+	if len(drops) != 2 {
+		t.Fatalf("drops = %d, want 2", len(drops))
+	}
+	for _, d := range drops {
+		if d.Reason != "under_minimum_prefix" {
+			t.Errorf("drop reason = %q, want under_minimum_prefix", d.Reason)
+		}
+		if d.Scope != "system" {
+			t.Errorf("drop scope = %q, want system", d.Scope)
+		}
+	}
+	if blocks[0].CacheControl != nil || blocks[1].CacheControl != nil {
+		t.Fatalf("expected breakpoints stripped from both blocks: %+v", blocks)
+	}
+}
+
+func TestApplyCacheBreakpointGuards_ReturnsToolCapDrop(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	// Five system breakpoints plus a tool breakpoint = 6 total. Under
+	// the cap policy the tool drop fires first; an additional system
+	// drop brings us to 4. Use opus-sized blocks (>16k chars each) so
+	// the under-minimum guard doesn't pre-drop them.
+	long := strings.Repeat("x", 20000)
+	blocks := []anthropicContent{
+		{Type: "text", Text: long, CacheControl: &anthropicCacheControl{Type: "ephemeral", TTL: "1h"}},
+		{Type: "text", Text: long, CacheControl: &anthropicCacheControl{Type: "ephemeral", TTL: "1h"}},
+		{Type: "text", Text: long, CacheControl: &anthropicCacheControl{Type: "ephemeral", TTL: "1h"}},
+		{Type: "text", Text: long, CacheControl: &anthropicCacheControl{Type: "ephemeral", TTL: "1h"}},
+		{Type: "text", Text: long, CacheControl: &anthropicCacheControl{Type: "ephemeral", TTL: "5m"}},
+	}
+	tools := []anthropicTool{
+		{Name: "first"},
+		{Name: "last", CacheControl: &anthropicCacheControl{Type: "ephemeral", TTL: "1h"}},
+	}
+
+	drops := applyCacheBreakpointGuards(blocks, tools, "claude-opus-4-20250514", logger)
+
+	if len(drops) < 1 {
+		t.Fatalf("drops = %d, want at least 1", len(drops))
+	}
+	// First drop should be the tool breakpoint per the policy.
+	if drops[0].Reason != "over_cap_tool_breakpoint" || drops[0].Scope != "tools" {
+		t.Errorf("first drop = %+v, want over_cap_tool_breakpoint/tools", drops[0])
+	}
+	if tools[1].CacheControl != nil {
+		t.Errorf("tool breakpoint should be stripped: %+v", tools[1].CacheControl)
+	}
+	// Trailing system drops (if any) should follow with the right reason.
+	for _, d := range drops[1:] {
+		if d.Reason != "over_cap_trailing_system" {
+			t.Errorf("subsequent drop reason = %q, want over_cap_trailing_system", d.Reason)
+		}
+	}
+}
+
+func TestParseRateLimitHeaders_AllFieldsPresent(t *testing.T) {
+	h := http.Header{}
+	h.Set("anthropic-ratelimit-requests-limit", "5000")
+	h.Set("anthropic-ratelimit-requests-remaining", "4999")
+	h.Set("anthropic-ratelimit-requests-reset", "2026-04-30T08:00:00Z")
+	h.Set("anthropic-ratelimit-tokens-limit", "1000000")
+	h.Set("anthropic-ratelimit-tokens-remaining", "950000")
+	h.Set("anthropic-ratelimit-input-tokens-limit", "800000")
+	h.Set("anthropic-ratelimit-input-tokens-remaining", "750000")
+	h.Set("anthropic-ratelimit-output-tokens-limit", "200000")
+	h.Set("anthropic-ratelimit-output-tokens-remaining", "199000")
+	h.Set("retry-after", "30")
+
+	now := time.Date(2026, 4, 30, 7, 30, 0, 0, time.UTC)
+	snap := parseRateLimitHeaders(h, "req_xyz", now)
+
+	if snap == nil {
+		t.Fatal("parseRateLimitHeaders returned nil with headers present")
+	}
+	if snap.UpstreamRequestID != "req_xyz" {
+		t.Errorf("UpstreamRequestID = %q, want req_xyz", snap.UpstreamRequestID)
+	}
+	if snap.RequestsRemaining != 4999 {
+		t.Errorf("RequestsRemaining = %d, want 4999", snap.RequestsRemaining)
+	}
+	if snap.TokensLimit != 1000000 {
+		t.Errorf("TokensLimit = %d, want 1000000", snap.TokensLimit)
+	}
+	if snap.InputTokensRemaining != 750000 {
+		t.Errorf("InputTokensRemaining = %d, want 750000", snap.InputTokensRemaining)
+	}
+	if snap.OutputTokensRemaining != 199000 {
+		t.Errorf("OutputTokensRemaining = %d, want 199000", snap.OutputTokensRemaining)
+	}
+	if snap.RetryAfter != 30*time.Second {
+		t.Errorf("RetryAfter = %v, want 30s", snap.RetryAfter)
+	}
+	if !snap.CapturedAt.Equal(now) {
+		t.Errorf("CapturedAt = %v, want %v", snap.CapturedAt, now)
+	}
+}
+
+func TestParseRateLimitHeaders_NoneMeansNil(t *testing.T) {
+	h := http.Header{}
+	h.Set("Content-Type", "application/json")
+	if snap := parseRateLimitHeaders(h, "req_xyz", time.Now()); snap != nil {
+		t.Fatalf("expected nil when no rate-limit headers, got %+v", snap)
+	}
+}
+
+func TestAnthropicClient_RateLimitSnapshot_StoreReturnsCopy(t *testing.T) {
+	c := NewAnthropicClient("k", slog.New(slog.NewTextHandler(io.Discard, nil)))
+	if got := c.RateLimitSnapshot(); got != nil {
+		t.Fatalf("expected nil before any response captured, got %+v", got)
+	}
+
+	original := &RateLimitSnapshot{
+		CapturedAt:        time.Now(),
+		UpstreamRequestID: "req_a",
+		RequestsRemaining: 4000,
+	}
+	c.storeRateLimitSnapshot(original)
+
+	snap := c.RateLimitSnapshot()
+	if snap == nil {
+		t.Fatal("RateLimitSnapshot returned nil after store")
+	}
+	if snap.RequestsRemaining != 4000 {
+		t.Errorf("RequestsRemaining = %d, want 4000", snap.RequestsRemaining)
+	}
+	// Verify we got a copy, not the original pointer — a downstream
+	// mutation must not race with future stores.
+	snap.RequestsRemaining = 0
+	if c.RateLimitSnapshot().RequestsRemaining != 4000 {
+		t.Fatal("RateLimitSnapshot returned shared pointer; expected defensive copy")
 	}
 }


### PR DESCRIPTION
## Summary

Two Phase 2 observability wins from [#744](https://github.com/nugget/thane-ai-agent/issues/744) that share the same provider response path. Independent of [PR #807](https://github.com/nugget/thane-ai-agent/pull/807) (x-request-id capture); the two are designed to merge in either order.

## 1. RateLimitSnapshot

Anthropic returns documented rate-limit headers on every response:

- `anthropic-ratelimit-{requests,tokens,input-tokens,output-tokens}-{limit,remaining,reset}`
- `retry-after` (typically only on 429 / 5xx)

Capture them into a copy-on-read [`RateLimitSnapshot`](internal/model/fleet/providers/anthropic.go) stored on the AnthropicClient, refreshed on every response (including 429s and 5xx — those are when you most need the data). Exposed via `AnthropicClient.RateLimitSnapshot()` for future smarter-backoff and dashboard work, and mirrored to a structured `anthropic rate limits` Debug log on every call so the data is visible in `events/` immediately.

The `/v1/router/stats` integration the issue mentions is a follow-up — capture and storage are the foundation; surfacing them on the API needs a separate (small) PR to thread the AnthropicClient pointer through `systemStatusAdapter`. Doing them together would have made this PR harder to review.

## 2. Cache-marker drop reasons

[`applyCacheBreakpointGuards`](internal/model/fleet/providers/anthropic.go) previously only emitted `Warn` lines per drop, so reconstructing "what shipped vs what was dropped" required correlating multiple log entries. Tonight's cache-hit-rate audit ([#800](https://github.com/nugget/thane-ai-agent/pull/800), [#802](https://github.com/nugget/thane-ai-agent/pull/802), [#804](https://github.com/nugget/thane-ai-agent/pull/804)) had to chase that across files — the issue text calls this out: *"would have shortened the cache-miss diagnosis from hours to minutes."*

The function now also returns `[]CacheBreakpointDrop` describing each dropped breakpoint:

- `under_minimum_prefix` — system block, prefix too short for the model
- `over_cap_tool_breakpoint` — tool cache stripped to fit the ≤4 cap
- `over_cap_trailing_system` — trailing system breakpoint stripped to fit the cap

Those are folded into the existing `outbound cache markers` log line as `dropped_breakpoints`, `dropped_reasons`, `dropped_ttls`, `dropped_scopes`. A single log entry now answers *"did the markers I expected actually go out?"* — the question the 2026-04-29 audit had to chase across multiple log files.

The Warn lines stay in place; they're useful for production alerting that doesn't depend on parsing the aggregated marker log.

## Test plan

- [x] Unit: `applyCacheBreakpointGuards` returns under-minimum drops with the right scope/reason
- [x] Unit: over-cap policy drops the tool breakpoint first, then trailing system breakpoints, with the right reasons in the returned slice
- [x] Unit: `parseRateLimitHeaders` parses every documented field; returns nil when no rate-limit headers present
- [x] Unit: `AnthropicClient.RateLimitSnapshot` returns nil before any response, returns a defensive copy after store (mutating the returned snapshot does not affect future reads)
- [x] `just ci` passes locally (build, lint, race tests, link check, architecture check)
- [ ] Verify in production: rebuild, fire one opus turn, confirm `anthropic rate limits` line appears in events with sensible numbers; confirm `outbound cache markers` line gains `dropped_breakpoints` / `dropped_reasons` columns (likely 0 / empty in steady state)

## Out of scope

- Surfacing rate-limit snapshot via `/v1/router/stats` (follow-up PR)
- Wiring snapshot into a smarter retry policy (separate design)