### PR TITLE
feat: expose Anthropic rate-limit stats

### DIFF
--- a/internal/app/adapters.go
+++ b/internal/app/adapters.go
@@ -878,6 +878,7 @@ func (q *fallbackContentQuerier) QueryRequestDetail(requestID string) (*logging.
 type systemStatusAdapter struct {
 	connMgr       *connwatch.Manager
 	modelRegistry *fleet.Registry
+	modelRuntime  *fleet.Runtime
 	router        *router.Router
 	capSurface    func() []toolcatalog.CapabilitySurface
 }
@@ -925,6 +926,15 @@ func (a *systemStatusAdapter) RouterStats() *router.Stats {
 	}
 	stats := a.router.GetStats()
 	return &stats
+}
+
+// AnthropicRateLimitSnapshot returns the latest Anthropic rate-limit
+// snapshot captured by the shared model runtime.
+func (a *systemStatusAdapter) AnthropicRateLimitSnapshot() *fleet.AnthropicRateLimitSnapshot {
+	if a.modelRuntime == nil {
+		return nil
+	}
+	return a.modelRuntime.AnthropicRateLimitSnapshot()
 }
 
 // CapabilityCatalog returns the runtime capability catalog used by the

--- a/internal/app/new_servers.go
+++ b/internal/app/new_servers.go
@@ -12,6 +12,7 @@ import (
 	"github.com/nugget/thane-ai-agent/internal/channels/mqtt"
 	"github.com/nugget/thane-ai-agent/internal/connwatch"
 	"github.com/nugget/thane-ai-agent/internal/integrations/companion"
+	"github.com/nugget/thane-ai-agent/internal/model/fleet"
 	"github.com/nugget/thane-ai-agent/internal/platform/checkpoint"
 	"github.com/nugget/thane-ai-agent/internal/platform/config"
 	"github.com/nugget/thane-ai-agent/internal/platform/telemetry"
@@ -73,6 +74,12 @@ func (a *App) initServers(s *newState) error {
 			result[name] = ds
 		}
 		return result
+	})
+	server.ConfigureAnthropicRateLimitSnapshotSource(func() *fleet.AnthropicRateLimitSnapshot {
+		if a.modelRuntime == nil {
+			return nil
+		}
+		return a.modelRuntime.AnthropicRateLimitSnapshot()
 	})
 	a.server = server
 
@@ -498,8 +505,14 @@ func (a *App) initServers(s *newState) error {
 		webCfg := web.Config{
 			LoopRegistry: a.loopRegistry,
 			EventBus:     a.eventBus,
-			SystemStatus: &systemStatusAdapter{connMgr: a.connMgr, modelRegistry: a.modelRegistry, router: a.rtr, capSurface: a.capSurfaceGetter()},
-			Logger:       logger,
+			SystemStatus: &systemStatusAdapter{
+				connMgr:       a.connMgr,
+				modelRegistry: a.modelRegistry,
+				modelRuntime:  a.modelRuntime,
+				router:        a.rtr,
+				capSurface:    a.capSurfaceGetter(),
+			},
+			Logger: logger,
 		}
 		if a.liveRequestStore != nil {
 			webCfg.ContentQuerier = a.liveRequestStore

--- a/internal/model/fleet/runtime.go
+++ b/internal/model/fleet/runtime.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"strings"
 	"sync"
+	"time"
 
 	modelproviders "github.com/nugget/thane-ai-agent/internal/model/fleet/providers"
 	"github.com/nugget/thane-ai-agent/internal/model/llm"
@@ -35,6 +36,27 @@ type Runtime struct {
 	client   *llm.DynamicClient
 
 	refreshMu sync.Mutex
+}
+
+// AnthropicRateLimitSnapshot is a JSON-friendly view of the latest
+// Anthropic rate-limit response headers captured by the shared provider
+// client.
+type AnthropicRateLimitSnapshot struct {
+	CapturedAt        time.Time                 `json:"captured_at"`
+	UpstreamRequestID string                    `json:"upstream_request_id,omitempty"`
+	Requests          *AnthropicRateLimitBucket `json:"requests,omitempty"`
+	Tokens            *AnthropicRateLimitBucket `json:"tokens,omitempty"`
+	InputTokens       *AnthropicRateLimitBucket `json:"input_tokens,omitempty"`
+	OutputTokens      *AnthropicRateLimitBucket `json:"output_tokens,omitempty"`
+	RetryAfterSeconds int64                     `json:"retry_after_seconds,omitempty"`
+}
+
+// AnthropicRateLimitBucket is one Anthropic rate-limit quota family:
+// requests, total tokens, input tokens, or output tokens.
+type AnthropicRateLimitBucket struct {
+	Limit     int        `json:"limit"`
+	Remaining int        `json:"remaining"`
+	Reset     *time.Time `json:"reset,omitempty"`
 }
 
 // NewRuntime builds the initial registry, performs a first inventory
@@ -146,6 +168,49 @@ func (r *Runtime) InventoryClientCount() int {
 		return 0
 	}
 	return len(r.bundle.OllamaClients) + len(r.bundle.LMStudioClients)
+}
+
+// AnthropicRateLimitSnapshot returns the latest captured Anthropic
+// rate-limit snapshot, or nil when the Anthropic provider is not
+// configured or no Anthropic response has been observed yet.
+func (r *Runtime) AnthropicRateLimitSnapshot() *AnthropicRateLimitSnapshot {
+	if r == nil || r.bundle == nil || r.bundle.AnthropicClient == nil {
+		return nil
+	}
+	return anthropicRateLimitSnapshotFromProvider(r.bundle.AnthropicClient.RateLimitSnapshot())
+}
+
+func anthropicRateLimitSnapshotFromProvider(snap *modelproviders.RateLimitSnapshot) *AnthropicRateLimitSnapshot {
+	if snap == nil {
+		return nil
+	}
+	out := &AnthropicRateLimitSnapshot{
+		CapturedAt:        snap.CapturedAt,
+		UpstreamRequestID: snap.UpstreamRequestID,
+		Requests:          anthropicRateLimitBucket(snap.RequestsLimit, snap.RequestsRemaining, snap.RequestsReset),
+		Tokens:            anthropicRateLimitBucket(snap.TokensLimit, snap.TokensRemaining, snap.TokensReset),
+		InputTokens:       anthropicRateLimitBucket(snap.InputTokensLimit, snap.InputTokensRemaining, snap.InputTokensReset),
+		OutputTokens:      anthropicRateLimitBucket(snap.OutputTokensLimit, snap.OutputTokensRemaining, snap.OutputTokensReset),
+	}
+	if snap.RetryAfter > 0 {
+		out.RetryAfterSeconds = int64(snap.RetryAfter / time.Second)
+	}
+	return out
+}
+
+func anthropicRateLimitBucket(limit, remaining int, reset time.Time) *AnthropicRateLimitBucket {
+	if limit == 0 && remaining == 0 && reset.IsZero() {
+		return nil
+	}
+	var resetPtr *time.Time
+	if !reset.IsZero() {
+		resetPtr = &reset
+	}
+	return &AnthropicRateLimitBucket{
+		Limit:     limit,
+		Remaining: remaining,
+		Reset:     resetPtr,
+	}
 }
 
 // Refresh probes provider inventory, updates the registry overlay, and

--- a/internal/model/fleet/runtime_test.go
+++ b/internal/model/fleet/runtime_test.go
@@ -10,11 +10,60 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	modelproviders "github.com/nugget/thane-ai-agent/internal/model/fleet/providers"
 	"github.com/nugget/thane-ai-agent/internal/model/llm"
 	"github.com/nugget/thane-ai-agent/internal/platform/config"
 )
+
+func TestAnthropicRateLimitSnapshotFromProvider(t *testing.T) {
+	t.Parallel()
+
+	capturedAt := time.Date(2026, 4, 30, 12, 0, 0, 0, time.UTC)
+	resetAt := capturedAt.Add(30 * time.Second)
+	snap := anthropicRateLimitSnapshotFromProvider(&modelproviders.RateLimitSnapshot{
+		CapturedAt:        capturedAt,
+		UpstreamRequestID: "req_123",
+		RequestsLimit:     5000,
+		RequestsRemaining: 0,
+		RequestsReset:     resetAt,
+		TokensLimit:       1_000_000,
+		TokensRemaining:   900_000,
+		RetryAfter:        30 * time.Second,
+	})
+
+	if snap == nil {
+		t.Fatal("snapshot is nil")
+	}
+	if !snap.CapturedAt.Equal(capturedAt) {
+		t.Fatalf("CapturedAt = %v, want %v", snap.CapturedAt, capturedAt)
+	}
+	if snap.UpstreamRequestID != "req_123" {
+		t.Fatalf("UpstreamRequestID = %q, want req_123", snap.UpstreamRequestID)
+	}
+	if snap.RetryAfterSeconds != 30 {
+		t.Fatalf("RetryAfterSeconds = %d, want 30", snap.RetryAfterSeconds)
+	}
+	if snap.Requests == nil {
+		t.Fatal("Requests bucket is nil")
+	}
+	if snap.Requests.Limit != 5000 || snap.Requests.Remaining != 0 {
+		t.Fatalf("Requests = %+v, want limit 5000 remaining 0", snap.Requests)
+	}
+	if snap.Requests.Reset == nil || !snap.Requests.Reset.Equal(resetAt) {
+		t.Fatalf("Requests.Reset = %v, want %v", snap.Requests.Reset, resetAt)
+	}
+	if snap.Tokens == nil || snap.Tokens.Limit != 1_000_000 || snap.Tokens.Remaining != 900_000 {
+		t.Fatalf("Tokens = %+v, want limit 1000000 remaining 900000", snap.Tokens)
+	}
+	if snap.InputTokens != nil {
+		t.Fatalf("InputTokens = %+v, want nil", snap.InputTokens)
+	}
+	if snap.OutputTokens != nil {
+		t.Fatalf("OutputTokens = %+v, want nil", snap.OutputTokens)
+	}
+}
 
 func TestRuntimePrepareExplicitModel_LoadsLMStudioContext(t *testing.T) {
 	t.Parallel()

--- a/internal/server/api/server.go
+++ b/internal/server/api/server.go
@@ -91,6 +91,7 @@ type Server struct {
 	deleteLoopDefinitionPolicy         func(string) error
 	reconcileLoopDefinition            func(context.Context, string) error
 	launchLoopDefinition               func(context.Context, string, looppkg.Launch) (looppkg.LaunchResult, error)
+	anthropicRateLimitSnapshot         func() *fleet.AnthropicRateLimitSnapshot
 	logger                             *slog.Logger
 	server                             *http.Server
 	stats                              *SessionStats
@@ -104,6 +105,12 @@ func (s *Server) SetOWUTracker(t *OWUTracker) {
 // SetConnManager sets the dependency health provider for the /health endpoint.
 func (s *Server) SetConnManager(fn HealthStatusFunc) {
 	s.healthDeps = fn
+}
+
+// ConfigureAnthropicRateLimitSnapshotSource configures the provider for the
+// latest Anthropic rate-limit snapshot included in router stats.
+func (s *Server) ConfigureAnthropicRateLimitSnapshotSource(fn func() *fleet.AnthropicRateLimitSnapshot) {
+	s.anthropicRateLimitSnapshot = fn
 }
 
 // SetTokenObserver registers an observer that is notified after each
@@ -883,6 +890,11 @@ func (s *Server) errorResponse(w http.ResponseWriter, code int, message string) 
 
 // Router introspection handlers
 
+type routerStatsResponse struct {
+	router.Stats
+	AnthropicRateLimit *fleet.AnthropicRateLimitSnapshot `json:"anthropic_rate_limit,omitempty"`
+}
+
 func (s *Server) handleRouterStats(w http.ResponseWriter, r *http.Request) {
 	if s.router == nil {
 		s.errorResponse(w, http.StatusServiceUnavailable, "router not configured")
@@ -890,8 +902,12 @@ func (s *Server) handleRouterStats(w http.ResponseWriter, r *http.Request) {
 	}
 
 	stats := s.router.GetStats()
+	response := routerStatsResponse{Stats: stats}
+	if s.anthropicRateLimitSnapshot != nil {
+		response.AnthropicRateLimit = s.anthropicRateLimitSnapshot()
+	}
 	w.Header().Set("Content-Type", "application/json")
-	writeJSON(w, stats, s.logger)
+	writeJSON(w, response, s.logger)
 }
 
 func (s *Server) handleRouterAudit(w http.ResponseWriter, r *http.Request) {

--- a/internal/server/api/server_test.go
+++ b/internal/server/api/server_test.go
@@ -375,6 +375,63 @@ func TestHandleModelRegistry(t *testing.T) {
 	}
 }
 
+func TestHandleRouterStatsIncludesAnthropicRateLimitSnapshot(t *testing.T) {
+	registry := testAPIModelRegistry(t)
+	rtr := router.NewRouter(testAPILogger(), registry.Catalog().RouterConfig(10))
+	server := NewServer("", 0, nil, rtr, nil, registry, nil, nil, nil, nil, nil, testAPILogger())
+
+	capturedAt := time.Date(2026, 4, 30, 12, 0, 0, 0, time.UTC)
+	resetAt := capturedAt.Add(time.Minute)
+	server.ConfigureAnthropicRateLimitSnapshotSource(func() *fleet.AnthropicRateLimitSnapshot {
+		return &fleet.AnthropicRateLimitSnapshot{
+			CapturedAt:        capturedAt,
+			UpstreamRequestID: "req_rate",
+			Requests: &fleet.AnthropicRateLimitBucket{
+				Limit:     5000,
+				Remaining: 0,
+				Reset:     &resetAt,
+			},
+			RetryAfterSeconds: 30,
+		}
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/router/stats", nil)
+	rec := httptest.NewRecorder()
+	server.handleRouterStats(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+
+	var body map[string]any
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if _, ok := body["total_requests"]; !ok {
+		t.Fatal("total_requests missing from router stats response")
+	}
+	limit, ok := body["anthropic_rate_limit"].(map[string]any)
+	if !ok {
+		t.Fatal("anthropic_rate_limit missing or not a map")
+	}
+	if limit["upstream_request_id"] != "req_rate" {
+		t.Fatalf("upstream_request_id = %v, want req_rate", limit["upstream_request_id"])
+	}
+	if limit["retry_after_seconds"] != float64(30) {
+		t.Fatalf("retry_after_seconds = %v, want 30", limit["retry_after_seconds"])
+	}
+	requests, ok := limit["requests"].(map[string]any)
+	if !ok {
+		t.Fatal("requests bucket missing or not a map")
+	}
+	if requests["remaining"] != float64(0) {
+		t.Fatalf("requests.remaining = %v, want 0", requests["remaining"])
+	}
+	if requests["reset"] != resetAt.Format(time.RFC3339) {
+		t.Fatalf("requests.reset = %v, want %s", requests["reset"], resetAt.Format(time.RFC3339))
+	}
+}
+
 func TestHandleModelRegistryPolicySetAndDelete(t *testing.T) {
 	registry := testAPIModelRegistry(t)
 	rtr := router.NewRouter(testAPILogger(), registry.Catalog().RouterConfig(10))

--- a/internal/server/web/handlers.go
+++ b/internal/server/web/handlers.go
@@ -45,6 +45,9 @@ func (s *WebServer) handleSystem(w http.ResponseWriter, r *http.Request) {
 	if stats := s.systemStatus.RouterStats(); stats != nil {
 		body["router_stats"] = stats
 	}
+	if snapshot := s.systemStatus.AnthropicRateLimitSnapshot(); snapshot != nil {
+		body["anthropic_rate_limit"] = snapshot
+	}
 	if catalog := s.systemStatus.CapabilityCatalog(toolcatalog.CatalogViewOptions{IncludeDelegate: true}); catalog != nil {
 		body["capability_catalog"] = catalog
 	}

--- a/internal/server/web/handlers_test.go
+++ b/internal/server/web/handlers_test.go
@@ -70,6 +70,7 @@ type stubSystemStatus struct {
 	version       map[string]string
 	modelRegistry *fleet.RegistrySnapshot
 	routerStats   *router.Stats
+	rateLimit     *fleet.AnthropicRateLimitSnapshot
 	capCatalog    *toolcatalog.CapabilityCatalogView
 }
 
@@ -80,6 +81,9 @@ func (s *stubSystemStatus) ModelRegistry() *fleet.RegistrySnapshot {
 	return s.modelRegistry
 }
 func (s *stubSystemStatus) RouterStats() *router.Stats { return s.routerStats }
+func (s *stubSystemStatus) AnthropicRateLimitSnapshot() *fleet.AnthropicRateLimitSnapshot {
+	return s.rateLimit
+}
 func (s *stubSystemStatus) CapabilityCatalog(_ toolcatalog.CatalogViewOptions) *toolcatalog.CapabilityCatalogView {
 	return s.capCatalog
 }
@@ -335,6 +339,7 @@ func TestHandleLoopEvents_Snapshot(t *testing.T) {
 func TestHandleSystem_Healthy(t *testing.T) {
 	t.Parallel()
 
+	capturedAt := time.Date(2026, 4, 30, 12, 0, 0, 0, time.UTC)
 	sys := &stubSystemStatus{
 		health: map[string]ServiceHealth{
 			"mqtt":          {Name: "MQTT", Ready: true, LastCheck: "2025-01-01T00:00:00Z"},
@@ -357,6 +362,14 @@ func TestHandleSystem_Healthy(t *testing.T) {
 			TotalRequests: 3,
 			DeploymentStats: map[string]router.DeploymentStats{
 				"spark/gpt-oss:20b": {Provider: "ollama", Resource: "spark", UpstreamModel: "gpt-oss:20b", Requests: 3, Successes: 3, AvgLatencyMs: 420, AvgTokensUsed: 1800},
+			},
+		},
+		rateLimit: &fleet.AnthropicRateLimitSnapshot{
+			CapturedAt:        capturedAt,
+			UpstreamRequestID: "req_dashboard",
+			Requests: &fleet.AnthropicRateLimitBucket{
+				Limit:     5000,
+				Remaining: 4999,
 			},
 		},
 		capCatalog: &toolcatalog.CapabilityCatalogView{
@@ -424,6 +437,13 @@ func TestHandleSystem_Healthy(t *testing.T) {
 	}
 	if routerStats["total_requests"] != float64(3) {
 		t.Errorf("total_requests = %v, want 3", routerStats["total_requests"])
+	}
+	rateLimit, ok := body["anthropic_rate_limit"].(map[string]any)
+	if !ok {
+		t.Fatal("anthropic_rate_limit field missing or not a map")
+	}
+	if rateLimit["upstream_request_id"] != "req_dashboard" {
+		t.Errorf("upstream_request_id = %v, want req_dashboard", rateLimit["upstream_request_id"])
 	}
 	capCatalog, ok := body["capability_catalog"].(map[string]any)
 	if !ok {

--- a/internal/server/web/server.go
+++ b/internal/server/web/server.go
@@ -70,6 +70,9 @@ type SystemStatusProvider interface {
 	ModelRegistry() *fleet.RegistrySnapshot
 	// RouterStats returns the current router statistics snapshot.
 	RouterStats() *router.Stats
+	// AnthropicRateLimitSnapshot returns the latest Anthropic
+	// rate-limit snapshot, or nil when Anthropic has not been observed.
+	AnthropicRateLimitSnapshot() *fleet.AnthropicRateLimitSnapshot
 	// CapabilityCatalog returns the resolved runtime capability catalog
 	// rendered with the supplied options.
 	CapabilityCatalog(opts toolcatalog.CatalogViewOptions) *toolcatalog.CapabilityCatalogView


### PR DESCRIPTION
## Summary

Completes the remaining #744 observability gap by surfacing the latest Anthropic rate-limit snapshot anywhere operators already look for routing/runtime status.

The shared Anthropic provider already captures rate-limit response headers. This PR normalizes that provider snapshot into a JSON-friendly runtime view, then exposes it through `/v1/router/stats` and the dashboard `/api/system` payload. The response keeps the existing router stats shape intact and adds `anthropic_rate_limit` only when an Anthropic response has actually been observed.

## Operator impact

When Anthropic capacity gets tight, the dashboard/API can now show the latest captured request, token, input-token, output-token, reset, retry-after, and upstream request ID details instead of leaving that state buried in logs.

## Validation

- `just ci`

Closes #744