### PR TITLE
refactor(loop): collapse Spec.Tags / Profile.InitialTags duality

### DIFF
--- a/examples/config.example.yaml
+++ b/examples/config.example.yaml
@@ -518,9 +518,12 @@ talents_dir: ./talents
 #         delegation_gating: ""
 #         prefer_speed: ""
 #         exclude_tools: []
-#         initial_tags: []
 #         extra_hints: {}
 #         instructions: ""
+#       InitialTags lists capability tags activated at the start of the
+#       agent run dispatched for matching messages. Only meaningful when
+#       Wake is non-nil.
+#       initial_tags: []
 #     - # Topic is the MQTT topic filter (e.g., "homeassistant/+/+/state",
 #       "frigate/events"). Supports MQTT wildcard characters.
 #       topic: frigate/events
@@ -536,9 +539,12 @@ talents_dir: ./talents
 #         delegation_gating: ""
 #         prefer_speed: ""
 #         exclude_tools: []
-#         initial_tags: []
 #         extra_hints: {}
 #         instructions: ""
+#       InitialTags lists capability tags activated at the start of the
+#       agent run dispatched for matching messages. Only meaningful when
+#       Wake is non-nil.
+#       initial_tags: []
 #     - # Topic is the MQTT topic filter (e.g., "homeassistant/+/+/state",
 #       "frigate/events"). Supports MQTT wildcard characters.
 #       topic: automation/wake/security
@@ -554,10 +560,13 @@ talents_dir: ./talents
 #         delegation_gating: disabled
 #         prefer_speed: ""
 #         exclude_tools: []
-#         initial_tags:
-#           - homeassistant
 #         extra_hints: {}
 #         instructions: Evaluate the security event and decide if action is needed.
+#       InitialTags lists capability tags activated at the start of the
+#       agent run dispatched for matching messages. Only meaningful when
+#       Wake is non-nil.
+#       initial_tags:
+#         - homeassistant
 #   Telemetry configures operational metric publishing. When enabled,
 #   a separate mqtt-telemetry loop publishes system health, token usage,
 #   loop states, and other operational data as native HA sensors.
@@ -911,8 +920,6 @@ ego:
 #         delegation_gating: disabled
 #         prefer_speed: ""
 #         exclude_tools: []
-#         initial_tags:
-#           - homeassistant
 #         extra_hints: {}
 #         instructions: Be concise and focus on high-signal observations.
 #       operation: service
@@ -930,7 +937,8 @@ ego:
 #                 - fri
 #               start: 08:30
 #               end: 18:00
-#       tags: []
+#       tags:
+#         - homeassistant
 #       exclude_tools: []
 #       sleep_min: 2m
 #       sleep_max: 10m

--- a/internal/app/loop_definition_store.go
+++ b/internal/app/loop_definition_store.go
@@ -80,7 +80,8 @@ func (s *loopDefinitionStore) LoadInto(registry *looppkg.DefinitionRegistry, log
 	records := make(map[string]looppkg.DefinitionRecord, len(entries))
 	for _, key := range keys {
 		var record looppkg.DefinitionRecord
-		if err := json.Unmarshal([]byte(entries[key]), &record); err != nil {
+		raw := []byte(entries[key])
+		if err := json.Unmarshal(raw, &record); err != nil {
 			if logger != nil {
 				logger.Warn("skipping invalid persisted loop definition", "name", key, "error", err)
 			}
@@ -89,12 +90,64 @@ func (s *loopDefinitionStore) LoadInto(registry *looppkg.DefinitionRegistry, log
 		if strings.TrimSpace(record.Spec.Name) == "" {
 			record.Spec.Name = key
 		}
+		// Pre-migration records may have stored capability tags under
+		// spec.profile.initial_tags. The field has since moved to
+		// spec.tags as the single source of truth. Hoist any legacy
+		// value forward so operators don't lose configured tags.
+		if legacy := extractLegacyProfileInitialTags(raw); len(legacy) > 0 {
+			record.Spec.Tags = mergePreservingOrder(record.Spec.Tags, legacy)
+			if logger != nil {
+				logger.Info("migrated legacy spec.profile.initial_tags to spec.tags",
+					"name", key, "tags", legacy)
+			}
+		}
 		records[key] = record
 	}
 	if len(records) == 0 {
 		return nil
 	}
 	return registry.ReplaceOverlay(records)
+}
+
+// extractLegacyProfileInitialTags returns any non-empty
+// spec.profile.initial_tags slice from a persisted definition record's
+// raw JSON. The field moved off LoopProfile, so this is the only path
+// that can recover values written by pre-migration servers.
+func extractLegacyProfileInitialTags(raw []byte) []string {
+	var envelope struct {
+		Spec struct {
+			Profile struct {
+				InitialTags []string `json:"initial_tags"`
+			} `json:"profile"`
+		} `json:"spec"`
+	}
+	if err := json.Unmarshal(raw, &envelope); err != nil {
+		return nil
+	}
+	return envelope.Spec.Profile.InitialTags
+}
+
+// mergePreservingOrder returns a deduplicated slice containing first the
+// existing entries and then any new entries not already present. Order
+// of first appearance is preserved.
+func mergePreservingOrder(existing, additional []string) []string {
+	seen := make(map[string]struct{}, len(existing)+len(additional))
+	out := make([]string, 0, len(existing)+len(additional))
+	for _, v := range existing {
+		if _, dup := seen[v]; dup {
+			continue
+		}
+		seen[v] = struct{}{}
+		out = append(out, v)
+	}
+	for _, v := range additional {
+		if _, dup := seen[v]; dup {
+			continue
+		}
+		seen[v] = struct{}{}
+		out = append(out, v)
+	}
+	return out
 }
 
 func (a *App) persistLoopDefinition(spec looppkg.Spec, updatedAt time.Time) error {

--- a/internal/app/loop_definition_store_test.go
+++ b/internal/app/loop_definition_store_test.go
@@ -53,9 +53,9 @@ func TestLoopDefinitionStoreSaveAndLoadIntoRegistry(t *testing.T) {
 		Task:       "Monitor the front room and surface noteworthy changes.",
 		Operation:  looppkg.OperationService,
 		Completion: looppkg.CompletionConversation,
+		Tags:       []string{"homeassistant"},
 		Profile: router.LoopProfile{
 			Mission:          "background",
-			InitialTags:      []string{"homeassistant"},
 			Instructions:     "Be concise.",
 			DelegationGating: "disabled",
 		},
@@ -86,8 +86,8 @@ func TestLoopDefinitionStoreSaveAndLoadIntoRegistry(t *testing.T) {
 		if !def.UpdatedAt.Equal(updatedAt) {
 			t.Fatalf("UpdatedAt = %v, want %v", def.UpdatedAt, updatedAt)
 		}
-		if def.Spec.Profile.InitialTags[0] != "homeassistant" {
-			t.Fatalf("InitialTags = %v, want homeassistant", def.Spec.Profile.InitialTags)
+		if len(def.Spec.Tags) != 1 || def.Spec.Tags[0] != "homeassistant" {
+			t.Fatalf("Spec.Tags = %v, want [homeassistant]", def.Spec.Tags)
 		}
 	}
 	if !found {

--- a/internal/app/mqttwake.go
+++ b/internal/app/mqttwake.go
@@ -84,6 +84,9 @@ func mqttWakeHandler(
 					Messages:       []agent.Message{{Role: "user", Content: msg}},
 				}
 				applyLoopProfile(&ws.Profile, req)
+				if len(ws.InitialTags) > 0 {
+					req.InitialTags = append(req.InitialTags, ws.InitialTags...)
+				}
 
 				// Always tag the source so tools and logging can identify
 				// MQTT-triggered conversations.
@@ -262,10 +265,12 @@ func sanitizePayload(payload []byte) string {
 	return truncated + fmt.Sprintf("\n\n[Truncated: %d bytes total, showing first %d bytes]", len(s), maxWakePayloadBytes)
 }
 
-// applyLoopProfile applies a LoopProfile's configuration to an agent.Request.
-// It sets the model, merges routing hints, and copies tool exclusions
-// and initial tags. This function lives in the app package rather than on
-// LoopProfile itself to avoid a circular import between router and agent.
+// applyLoopProfile applies a LoopProfile's routing configuration to an
+// agent.Request. It sets the model, merges routing hints, and copies tool
+// exclusions. Capability tags are not part of the routing profile and
+// are applied separately by the caller. This function lives in the app
+// package rather than on LoopProfile itself to avoid a circular import
+// between router and agent.
 func applyLoopProfile(profile *router.LoopProfile, req *agent.Request) {
 	opts := profile.RequestOptions()
 
@@ -284,8 +289,5 @@ func applyLoopProfile(profile *router.LoopProfile, req *agent.Request) {
 
 	if len(opts.ExcludeTools) > 0 {
 		req.ExcludeTools = append(req.ExcludeTools, opts.ExcludeTools...)
-	}
-	if len(opts.InitialTags) > 0 {
-		req.InitialTags = append(req.InitialTags, opts.InitialTags...)
 	}
 }

--- a/internal/app/mqttwake_test.go
+++ b/internal/app/mqttwake_test.go
@@ -318,7 +318,6 @@ func TestApplyLoopProfile(t *testing.T) {
 		LocalOnly:        "false",
 		DelegationGating: "disabled",
 		ExcludeTools:     []string{"shell_exec"},
-		InitialTags:      []string{"homeassistant"},
 		ExtraHints:       map[string]string{"custom": "value"},
 	}
 
@@ -348,8 +347,11 @@ func TestApplyLoopProfile(t *testing.T) {
 	if len(req.ExcludeTools) != 2 || req.ExcludeTools[0] != "files_read" || req.ExcludeTools[1] != "shell_exec" {
 		t.Errorf("ExcludeTools = %v, want [files_read shell_exec]", req.ExcludeTools)
 	}
-	if len(req.InitialTags) != 2 || req.InitialTags[0] != "baseline" || req.InitialTags[1] != "homeassistant" {
-		t.Errorf("InitialTags = %v, want [baseline homeassistant]", req.InitialTags)
+	// applyLoopProfile is purely routing/configuration; capability tags
+	// are no longer part of LoopProfile and are applied separately by
+	// the caller (e.g., from WakeSubscription.InitialTags).
+	if len(req.InitialTags) != 1 || req.InitialTags[0] != "baseline" {
+		t.Errorf("InitialTags = %v, want [baseline] (profile must not touch tags)", req.InitialTags)
 	}
 }
 

--- a/internal/app/taskexec_test.go
+++ b/internal/app/taskexec_test.go
@@ -28,7 +28,6 @@ func (m *mockTaskLauncher) Launch(_ context.Context, launch looppkg.Launch, deps
 	capturedLaunch.Spec.Metadata = cloneTestStringMap(launch.Spec.Metadata)
 	capturedLaunch.Spec.ExcludeTools = append([]string(nil), launch.Spec.ExcludeTools...)
 	capturedLaunch.Spec.Profile.ExcludeTools = append([]string(nil), launch.Spec.Profile.ExcludeTools...)
-	capturedLaunch.Spec.Profile.InitialTags = append([]string(nil), launch.Spec.Profile.InitialTags...)
 	capturedLaunch.Spec.Profile.ExtraHints = cloneTestStringMap(launch.Spec.Profile.ExtraHints)
 	m.launch = &capturedLaunch
 	capturedDeps := deps

--- a/internal/channels/messaging/signal/bridge.go
+++ b/internal/channels/messaging/signal/bridge.go
@@ -571,7 +571,6 @@ func (b *Bridge) handleMessage(ctx context.Context, env *Envelope, progressFn fu
 		Model:           opts.Model,
 		Hints:           opts.Hints,
 		ExcludeTools:    opts.ExcludeTools,
-		InitialTags:     opts.InitialTags,
 		RuntimeTags:     []string{"message_channel"},
 		FallbackContent: fallbackContent,
 	}
@@ -702,7 +701,6 @@ func (b *Bridge) handleReaction(ctx context.Context, env *Envelope) {
 		Model:           opts.Model,
 		Hints:           opts.Hints,
 		ExcludeTools:    opts.ExcludeTools,
-		InitialTags:     opts.InitialTags,
 		RuntimeTags:     []string{"message_channel"},
 		FallbackContent: fallbackContent,
 	}

--- a/internal/channels/mqtt/subscriptions.go
+++ b/internal/channels/mqtt/subscriptions.go
@@ -29,8 +29,10 @@ type WakeSubscription struct {
 	Profile router.LoopProfile `json:"profile"`
 
 	// InitialTags lists capability tags activated at the start of the
-	// dispatched agent run. They merge with whatever tags the
-	// dispatched run would otherwise activate from its loop spec.
+	// dispatched agent run. The dispatcher builds the agent.Request
+	// directly (no loop spec), so these are the only tags on the
+	// request itself; the agent's capability resolver then layers
+	// always-active tags on top.
 	InitialTags []string `json:"initial_tags,omitempty"`
 
 	Source    string    `json:"source"` // "config" or "runtime"
@@ -96,6 +98,17 @@ func (s *SubscriptionStore) loadRuntime() error {
 	}
 	defer rows.Close()
 
+	// Rows whose initial_tags_json is empty/default but whose seed_json
+	// still carries a legacy `initial_tags` key need a one-time write
+	// back so the migration is durable. Collect them and apply after
+	// the read iterator closes — sqlite doesn't love INSERT/UPDATE
+	// against the same connection while a SELECT cursor is open.
+	type pendingMigration struct {
+		id   string
+		tags []string
+	}
+	var pending []pendingMigration
+
 	for rows.Next() {
 		var ws WakeSubscription
 		var profileJSON, initialTagsJSON, createdAt string
@@ -105,12 +118,14 @@ func (s *SubscriptionStore) loadRuntime() error {
 		// Pre-migration rows stored InitialTags inside the profile JSON.
 		// Hoist any legacy value out before unmarshaling so the field
 		// reaches its new home on WakeSubscription.
-		ws.InitialTags = extractLegacyInitialTags(profileJSON)
+		legacyTags := extractLegacyInitialTags(profileJSON)
+		ws.InitialTags = legacyTags
 		if err := json.Unmarshal([]byte(profileJSON), &ws.Profile); err != nil {
 			s.logger.Warn("skipping subscription with invalid profile JSON",
 				"id", ws.ID, "error", err)
 			continue
 		}
+		columnHasTags := false
 		if initialTagsJSON != "" {
 			var tags []string
 			if err := json.Unmarshal([]byte(initialTagsJSON), &tags); err != nil {
@@ -118,7 +133,15 @@ func (s *SubscriptionStore) loadRuntime() error {
 					"id", ws.ID, "error", err)
 			} else if len(tags) > 0 {
 				ws.InitialTags = tags
+				columnHasTags = true
 			}
+		}
+		// Schedule a write-back when we recovered tags from legacy
+		// seed_json but the new column is still at its default. After
+		// this runs once, subsequent loads find tags in the column and
+		// the legacy extraction becomes a no-op for that row.
+		if !columnHasTags && len(legacyTags) > 0 {
+			pending = append(pending, pendingMigration{id: ws.ID, tags: legacyTags})
 		}
 		ts, err := database.ParseTimestamp(createdAt)
 		if err != nil {
@@ -146,7 +169,33 @@ func (s *SubscriptionStore) loadRuntime() error {
 		s.subs = append(s.subs, ws)
 	}
 
-	return rows.Err()
+	if err := rows.Err(); err != nil {
+		return err
+	}
+	if err := rows.Close(); err != nil {
+		return err
+	}
+
+	for _, p := range pending {
+		tagsJSON, err := json.Marshal(p.tags)
+		if err != nil {
+			s.logger.Warn("failed to marshal hoisted initial_tags, leaving row legacy",
+				"id", p.id, "error", err)
+			continue
+		}
+		if _, err := s.db.Exec(
+			`UPDATE mqtt_wake_subscriptions SET initial_tags_json = ? WHERE id = ?`,
+			string(tagsJSON), p.id,
+		); err != nil {
+			s.logger.Warn("failed to persist hoisted initial_tags, will retry next load",
+				"id", p.id, "error", err)
+			continue
+		}
+		s.logger.Info("migrated legacy seed_json initial_tags to initial_tags_json column",
+			"id", p.id, "tags", p.tags)
+	}
+
+	return nil
 }
 
 // LoadConfig loads config-defined wake subscriptions. Only entries with
@@ -183,7 +232,7 @@ func (s *SubscriptionStore) LoadConfig(subs []config.SubscriptionConfig) error {
 			ID:          fmt.Sprintf("cfg-%s-%d", topicHash(sc.Topic), i),
 			Topic:       sc.Topic,
 			Profile:     *sc.Wake,
-			InitialTags: append([]string(nil), sc.InitialTags...),
+			InitialTags: append([]string{}, sc.InitialTags...),
 			Source:      "config",
 			CreatedAt:   time.Now(),
 		})
@@ -241,7 +290,7 @@ func (s *SubscriptionStore) Add(topic string, profile router.LoopProfile, initia
 		ID:          fmt.Sprintf("rt-%s-%d", topicHash(topic), time.Now().UnixMilli()),
 		Topic:       topic,
 		Profile:     profile,
-		InitialTags: append([]string(nil), initialTags...),
+		InitialTags: append([]string{}, initialTags...),
 		Source:      "runtime",
 		CreatedAt:   time.Now(),
 	}
@@ -250,6 +299,9 @@ func (s *SubscriptionStore) Add(topic string, profile router.LoopProfile, initia
 	if err != nil {
 		return WakeSubscription{}, fmt.Errorf("marshal profile: %w", err)
 	}
+	// Marshal from a non-nil slice so the column always stores a JSON
+	// array (matching the column's '[]' default). json.Marshal(nil)
+	// produces "null", which would be inconsistent.
 	initialTagsJSON, err := json.Marshal(ws.InitialTags)
 	if err != nil {
 		return WakeSubscription{}, fmt.Errorf("marshal initial_tags: %w", err)

--- a/internal/channels/mqtt/subscriptions.go
+++ b/internal/channels/mqtt/subscriptions.go
@@ -16,14 +16,25 @@ import (
 	"github.com/nugget/thane-ai-agent/internal/platform/database"
 )
 
-// WakeSubscription pairs an MQTT topic filter with the LoopProfile
-// configuration used to wake the agent when a message arrives.
+// WakeSubscription pairs an MQTT topic filter with the routing profile
+// and capability tag overlay used to wake the agent when a message
+// arrives on the topic.
 type WakeSubscription struct {
-	ID        string             `json:"id"`
-	Topic     string             `json:"topic"`
-	Profile   router.LoopProfile `json:"profile"`
-	Source    string             `json:"source"` // "config" or "runtime"
-	CreatedAt time.Time          `json:"created_at"`
+	ID    string `json:"id"`
+	Topic string `json:"topic"`
+
+	// Profile shapes the agent run dispatched on each matching message
+	// (model selection, mission, hints, exclude_tools, instructions).
+	// Routing/configuration only — capability tags live on InitialTags.
+	Profile router.LoopProfile `json:"profile"`
+
+	// InitialTags lists capability tags activated at the start of the
+	// dispatched agent run. They merge with whatever tags the
+	// dispatched run would otherwise activate from its loop spec.
+	InitialTags []string `json:"initial_tags,omitempty"`
+
+	Source    string    `json:"source"` // "config" or "runtime"
+	CreatedAt time.Time `json:"created_at"`
 }
 
 // SubscriptionStore manages wake-enabled MQTT subscriptions with
@@ -58,6 +69,13 @@ func NewSubscriptionStore(db *sql.DB, logger *slog.Logger) (*SubscriptionStore, 
 		return nil, fmt.Errorf("create mqtt_wake_subscriptions table: %w", err)
 	}
 
+	// Capability tags moved off the embedded LoopProfile onto a
+	// dedicated WakeSubscription field; persist them in their own
+	// column so the seed_json blob stays a pure routing profile.
+	if err := database.AddColumn(db, "mqtt_wake_subscriptions", "initial_tags_json", "TEXT NOT NULL DEFAULT '[]'"); err != nil {
+		return nil, fmt.Errorf("migrate mqtt_wake_subscriptions schema: %w", err)
+	}
+
 	s := &SubscriptionStore{
 		db:     db,
 		logger: logger,
@@ -72,7 +90,7 @@ func NewSubscriptionStore(db *sql.DB, logger *slog.Logger) (*SubscriptionStore, 
 
 // loadRuntime reads persisted runtime subscriptions from SQLite.
 func (s *SubscriptionStore) loadRuntime() error {
-	rows, err := s.db.Query(`SELECT id, topic, seed_json, source, created_at FROM mqtt_wake_subscriptions`)
+	rows, err := s.db.Query(`SELECT id, topic, seed_json, initial_tags_json, source, created_at FROM mqtt_wake_subscriptions`)
 	if err != nil {
 		return err
 	}
@@ -80,14 +98,27 @@ func (s *SubscriptionStore) loadRuntime() error {
 
 	for rows.Next() {
 		var ws WakeSubscription
-		var profileJSON, createdAt string
-		if err := rows.Scan(&ws.ID, &ws.Topic, &profileJSON, &ws.Source, &createdAt); err != nil {
+		var profileJSON, initialTagsJSON, createdAt string
+		if err := rows.Scan(&ws.ID, &ws.Topic, &profileJSON, &initialTagsJSON, &ws.Source, &createdAt); err != nil {
 			return err
 		}
+		// Pre-migration rows stored InitialTags inside the profile JSON.
+		// Hoist any legacy value out before unmarshaling so the field
+		// reaches its new home on WakeSubscription.
+		ws.InitialTags = extractLegacyInitialTags(profileJSON)
 		if err := json.Unmarshal([]byte(profileJSON), &ws.Profile); err != nil {
 			s.logger.Warn("skipping subscription with invalid profile JSON",
 				"id", ws.ID, "error", err)
 			continue
+		}
+		if initialTagsJSON != "" {
+			var tags []string
+			if err := json.Unmarshal([]byte(initialTagsJSON), &tags); err != nil {
+				s.logger.Warn("subscription initial_tags_json invalid, ignoring",
+					"id", ws.ID, "error", err)
+			} else if len(tags) > 0 {
+				ws.InitialTags = tags
+			}
 		}
 		ts, err := database.ParseTimestamp(createdAt)
 		if err != nil {
@@ -149,14 +180,39 @@ func (s *SubscriptionStore) LoadConfig(subs []config.SubscriptionConfig) error {
 			return fmt.Errorf("mqtt.subscriptions[%d] (topic %q): invalid wake profile: %w", i, sc.Topic, err)
 		}
 		s.subs = append(s.subs, WakeSubscription{
-			ID:        fmt.Sprintf("cfg-%s-%d", topicHash(sc.Topic), i),
-			Topic:     sc.Topic,
-			Profile:   *sc.Wake,
-			Source:    "config",
-			CreatedAt: time.Now(),
+			ID:          fmt.Sprintf("cfg-%s-%d", topicHash(sc.Topic), i),
+			Topic:       sc.Topic,
+			Profile:     *sc.Wake,
+			InitialTags: append([]string(nil), sc.InitialTags...),
+			Source:      "config",
+			CreatedAt:   time.Now(),
 		})
 	}
 	return nil
+}
+
+// extractLegacyInitialTags returns any "initial_tags" value embedded in
+// a pre-migration LoopProfile JSON blob. Pre-migration rows stored
+// InitialTags inside the profile object; the field has since moved onto
+// WakeSubscription, so during load we hoist any legacy value here.
+// Returns nil when the JSON is malformed or the field is absent.
+func extractLegacyInitialTags(profileJSON string) []string {
+	if profileJSON == "" {
+		return nil
+	}
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(profileJSON), &raw); err != nil {
+		return nil
+	}
+	tagsRaw, ok := raw["initial_tags"]
+	if !ok {
+		return nil
+	}
+	var tags []string
+	if err := json.Unmarshal(tagsRaw, &tags); err != nil {
+		return nil
+	}
+	return tags
 }
 
 // SetSubscribeHook registers a callback that is invoked after a runtime
@@ -173,7 +229,7 @@ func (s *SubscriptionStore) SetSubscribeHook(fn func(topics []string)) {
 // returns the new subscription. The topic filter and profile are validated
 // before persistence — invalid values are rejected early rather than
 // stored and retried forever.
-func (s *SubscriptionStore) Add(topic string, profile router.LoopProfile) (WakeSubscription, error) {
+func (s *SubscriptionStore) Add(topic string, profile router.LoopProfile, initialTags []string) (WakeSubscription, error) {
 	if err := router.ValidateTopicFilter(topic); err != nil {
 		return WakeSubscription{}, fmt.Errorf("invalid topic filter: %w", err)
 	}
@@ -182,21 +238,26 @@ func (s *SubscriptionStore) Add(topic string, profile router.LoopProfile) (WakeS
 	}
 
 	ws := WakeSubscription{
-		ID:        fmt.Sprintf("rt-%s-%d", topicHash(topic), time.Now().UnixMilli()),
-		Topic:     topic,
-		Profile:   profile,
-		Source:    "runtime",
-		CreatedAt: time.Now(),
+		ID:          fmt.Sprintf("rt-%s-%d", topicHash(topic), time.Now().UnixMilli()),
+		Topic:       topic,
+		Profile:     profile,
+		InitialTags: append([]string(nil), initialTags...),
+		Source:      "runtime",
+		CreatedAt:   time.Now(),
 	}
 
 	profileJSON, err := json.Marshal(ws.Profile)
 	if err != nil {
 		return WakeSubscription{}, fmt.Errorf("marshal profile: %w", err)
 	}
+	initialTagsJSON, err := json.Marshal(ws.InitialTags)
+	if err != nil {
+		return WakeSubscription{}, fmt.Errorf("marshal initial_tags: %w", err)
+	}
 
 	_, err = s.db.Exec(
-		`INSERT INTO mqtt_wake_subscriptions (id, topic, seed_json, source, created_at) VALUES (?, ?, ?, ?, ?)`,
-		ws.ID, ws.Topic, string(profileJSON), ws.Source, ws.CreatedAt.Format(time.RFC3339),
+		`INSERT INTO mqtt_wake_subscriptions (id, topic, seed_json, initial_tags_json, source, created_at) VALUES (?, ?, ?, ?, ?, ?)`,
+		ws.ID, ws.Topic, string(profileJSON), string(initialTagsJSON), ws.Source, ws.CreatedAt.Format(time.RFC3339),
 	)
 	if err != nil {
 		return WakeSubscription{}, fmt.Errorf("insert subscription: %w", err)

--- a/internal/channels/mqtt/subscriptions_test.go
+++ b/internal/channels/mqtt/subscriptions_test.go
@@ -255,6 +255,100 @@ func TestSubscriptionStorePersistence(t *testing.T) {
 	}
 }
 
+// TestSubscriptionStoreLegacyInitialTagsMigration verifies that rows
+// written by a pre-migration server (initial_tags embedded inside the
+// LoopProfile seed_json blob, no initial_tags_json column populated)
+// are hoisted onto WakeSubscription.InitialTags on first load AND
+// written back to the new column so the migration is durable.
+func TestSubscriptionStoreLegacyInitialTagsMigration(t *testing.T) {
+	db, err := database.OpenMemory()
+	if err != nil {
+		t.Fatalf("open memory db: %v", err)
+	}
+	defer db.Close()
+
+	if _, err := NewSubscriptionStore(db, nil); err != nil {
+		t.Fatalf("new store (init schema): %v", err)
+	}
+
+	// Synthesize a pre-migration row: LoopProfile JSON includes the
+	// removed initial_tags field, and initial_tags_json is empty.
+	legacyJSON := `{"mission":"automation","initial_tags":["homeassistant","security"]}`
+	if _, err := db.Exec(
+		`INSERT INTO mqtt_wake_subscriptions (id, topic, seed_json, initial_tags_json, source, created_at) VALUES (?, ?, ?, ?, ?, ?)`,
+		"legacy-row", "legacy/topic", legacyJSON, "[]", "runtime", "2026-04-01T00:00:00Z",
+	); err != nil {
+		t.Fatalf("seed legacy row: %v", err)
+	}
+
+	// First load — hoists from seed_json, writes back to the column.
+	s1, err := NewSubscriptionStore(db, nil)
+	if err != nil {
+		t.Fatalf("first load: %v", err)
+	}
+	subs := s1.List()
+	if len(subs) != 1 {
+		t.Fatalf("first load len = %d, want 1", len(subs))
+	}
+	if got := subs[0].InitialTags; len(got) != 2 || got[0] != "homeassistant" || got[1] != "security" {
+		t.Fatalf("first-load InitialTags = %v, want [homeassistant security]", got)
+	}
+
+	// Verify the write-back actually landed in the column.
+	var stored string
+	if err := db.QueryRow(`SELECT initial_tags_json FROM mqtt_wake_subscriptions WHERE id = ?`, "legacy-row").Scan(&stored); err != nil {
+		t.Fatalf("select after migration: %v", err)
+	}
+	if stored != `["homeassistant","security"]` {
+		t.Fatalf("initial_tags_json after migration = %q, want JSON array", stored)
+	}
+
+	// Second load — should read from the column directly. The legacy
+	// extractor would still fire (seed_json is unchanged), but the
+	// column wins and the result is identical.
+	s2, err := NewSubscriptionStore(db, nil)
+	if err != nil {
+		t.Fatalf("second load: %v", err)
+	}
+	subs = s2.List()
+	if len(subs) != 1 {
+		t.Fatalf("second load len = %d, want 1", len(subs))
+	}
+	if got := subs[0].InitialTags; len(got) != 2 || got[0] != "homeassistant" || got[1] != "security" {
+		t.Fatalf("second-load InitialTags = %v, want [homeassistant security]", got)
+	}
+}
+
+// TestSubscriptionStoreAddPersistsEmptyTagsAsArray verifies that a
+// subscription added with no InitialTags writes "[]" rather than
+// "null" — matching the column's default and keeping the on-disk
+// shape consistent.
+func TestSubscriptionStoreAddPersistsEmptyTagsAsArray(t *testing.T) {
+	db, err := database.OpenMemory()
+	if err != nil {
+		t.Fatalf("open memory db: %v", err)
+	}
+	defer db.Close()
+
+	s, err := NewSubscriptionStore(db, nil)
+	if err != nil {
+		t.Fatalf("new store: %v", err)
+	}
+
+	ws, err := s.Add("empty/tags", router.LoopProfile{Mission: "automation"}, nil)
+	if err != nil {
+		t.Fatalf("add: %v", err)
+	}
+
+	var stored string
+	if err := db.QueryRow(`SELECT initial_tags_json FROM mqtt_wake_subscriptions WHERE id = ?`, ws.ID).Scan(&stored); err != nil {
+		t.Fatalf("select: %v", err)
+	}
+	if stored != "[]" {
+		t.Fatalf("initial_tags_json = %q, want %q", stored, "[]")
+	}
+}
+
 func TestSubscriptionStoreTopics(t *testing.T) {
 	s := newTestStore(t)
 

--- a/internal/channels/mqtt/subscriptions_test.go
+++ b/internal/channels/mqtt/subscriptions_test.go
@@ -84,7 +84,7 @@ func TestSubscriptionStoreAddRemoveList(t *testing.T) {
 	}
 
 	// Add a subscription.
-	ws, err := s.Add("test/topic", router.LoopProfile{Mission: "automation"})
+	ws, err := s.Add("test/topic", router.LoopProfile{Mission: "automation"}, nil)
 	if err != nil {
 		t.Fatalf("add: %v", err)
 	}
@@ -232,7 +232,7 @@ func TestSubscriptionStorePersistence(t *testing.T) {
 		t.Fatalf("new store 1: %v", err)
 	}
 
-	_, err = s1.Add("persist/test", router.LoopProfile{Mission: "automation", QualityFloor: "5"})
+	_, err = s1.Add("persist/test", router.LoopProfile{Mission: "automation", QualityFloor: "5"}, nil)
 	if err != nil {
 		t.Fatalf("add: %v", err)
 	}
@@ -264,7 +264,7 @@ func TestSubscriptionStoreTopics(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("LoadConfig: %v", err)
 	}
-	if _, err := s.Add("topic/b", profile); err != nil {
+	if _, err := s.Add("topic/b", profile, nil); err != nil {
 		t.Fatalf("add: %v", err)
 	}
 
@@ -290,7 +290,7 @@ func TestSubscriptionStoreSubscribeHook(t *testing.T) {
 		hookedTopics = append(hookedTopics, topics...)
 	})
 
-	_, err := s.Add("hook/test", router.LoopProfile{Mission: "automation"})
+	_, err := s.Add("hook/test", router.LoopProfile{Mission: "automation"}, nil)
 	if err != nil {
 		t.Fatalf("add: %v", err)
 	}
@@ -304,7 +304,7 @@ func TestSubscriptionStoreSubscribeHookNotCalledWithoutHook(t *testing.T) {
 	s := newTestStore(t)
 
 	// No hook set — Add should not panic.
-	_, err := s.Add("no-hook/test", router.LoopProfile{})
+	_, err := s.Add("no-hook/test", router.LoopProfile{}, nil)
 	if err != nil {
 		t.Fatalf("add: %v", err)
 	}
@@ -314,25 +314,25 @@ func TestSubscriptionStoreAddValidation(t *testing.T) {
 	s := newTestStore(t)
 
 	// Invalid topic filter.
-	_, err := s.Add("", router.LoopProfile{})
+	_, err := s.Add("", router.LoopProfile{}, nil)
 	if err == nil {
 		t.Fatal("expected error for empty topic")
 	}
 
 	// Invalid topic with bad wildcard.
-	_, err = s.Add("foo/ba#r", router.LoopProfile{})
+	_, err = s.Add("foo/ba#r", router.LoopProfile{}, nil)
 	if err == nil {
 		t.Fatal("expected error for bad wildcard in topic")
 	}
 
 	// Invalid seed.
-	_, err = s.Add("valid/topic", router.LoopProfile{QualityFloor: "99"})
+	_, err = s.Add("valid/topic", router.LoopProfile{QualityFloor: "99"}, nil)
 	if err == nil {
 		t.Fatal("expected error for invalid quality_floor")
 	}
 
 	// Valid — should succeed.
-	_, err = s.Add("valid/topic", router.LoopProfile{Mission: "automation", QualityFloor: "7"})
+	_, err = s.Add("valid/topic", router.LoopProfile{Mission: "automation", QualityFloor: "7"}, nil)
 	if err != nil {
 		t.Fatalf("expected success, got: %v", err)
 	}

--- a/internal/channels/mqtt/tools.go
+++ b/internal/channels/mqtt/tools.go
@@ -81,8 +81,10 @@ func (t *Tools) HandleAddWakeSubscription(_ context.Context, args map[string]any
 	if raw, ok := args["exclude_tools"]; ok {
 		profile.ExcludeTools = toStringSlice(raw)
 	}
+
+	var initialTags []string
 	if raw, ok := args["initial_tags"]; ok {
-		profile.InitialTags = toStringSlice(raw)
+		initialTags = toStringSlice(raw)
 	}
 
 	// Validate the profile before persisting — fail fast with a clear
@@ -91,7 +93,7 @@ func (t *Tools) HandleAddWakeSubscription(_ context.Context, args map[string]any
 		return "", fmt.Errorf("invalid profile: %w", err)
 	}
 
-	ws, err := t.store.Add(topic, profile)
+	ws, err := t.store.Add(topic, profile, initialTags)
 	if err != nil {
 		return "", err
 	}

--- a/internal/channels/mqtt/tools_test.go
+++ b/internal/channels/mqtt/tools_test.go
@@ -89,8 +89,8 @@ func TestToolsHandleAddWithSeedArrays(t *testing.T) {
 	if len(subs[0].Profile.ExcludeTools) != 2 {
 		t.Errorf("exclude_tools len = %d, want 2", len(subs[0].Profile.ExcludeTools))
 	}
-	if len(subs[0].Profile.InitialTags) != 2 {
-		t.Errorf("initial_tags len = %d, want 2", len(subs[0].Profile.InitialTags))
+	if len(subs[0].InitialTags) != 2 {
+		t.Errorf("initial_tags len = %d, want 2", len(subs[0].InitialTags))
 	}
 }
 

--- a/internal/model/router/loopprofile.go
+++ b/internal/model/router/loopprofile.go
@@ -43,10 +43,6 @@ type LoopProfile struct {
 	// ExcludeTools lists tool names to filter out of the agent run.
 	ExcludeTools []string `yaml:"exclude_tools,omitempty" json:"exclude_tools,omitempty"`
 
-	// InitialTags lists capability tags to activate at the start of the
-	// agent run.
-	InitialTags []string `yaml:"initial_tags,omitempty" json:"initial_tags,omitempty"`
-
 	// ExtraHints carries arbitrary key-value routing hints that are
 	// merged last, allowing callers to override or extend the typed
 	// fields above.
@@ -64,7 +60,6 @@ type RequestOptions struct {
 	Model        string
 	Hints        map[string]string
 	ExcludeTools []string
-	InitialTags  []string
 }
 
 // Hints builds a routing hints map from the profile's typed fields.
@@ -185,9 +180,6 @@ func (s *LoopProfile) RequestOptions() RequestOptions {
 
 	if len(s.ExcludeTools) > 0 {
 		opts.ExcludeTools = append([]string(nil), s.ExcludeTools...)
-	}
-	if len(s.InitialTags) > 0 {
-		opts.InitialTags = append([]string(nil), s.InitialTags...)
 	}
 
 	return opts

--- a/internal/model/router/loopprofile_test.go
+++ b/internal/model/router/loopprofile_test.go
@@ -154,7 +154,6 @@ func TestLoopProfileRequestOptions(t *testing.T) {
 		LocalOnly:        "false",
 		DelegationGating: "disabled",
 		ExcludeTools:     []string{"resolve_anticipation", "cancel_anticipation"},
-		InitialTags:      []string{"scheduler", "wake"},
 		ExtraHints: map[string]string{
 			"source": "scheduler",
 		},
@@ -174,17 +173,10 @@ func TestLoopProfileRequestOptions(t *testing.T) {
 	if len(opts.ExcludeTools) != len(seed.ExcludeTools) {
 		t.Fatalf("ExcludeTools len = %d, want %d", len(opts.ExcludeTools), len(seed.ExcludeTools))
 	}
-	if len(opts.InitialTags) != len(seed.InitialTags) {
-		t.Fatalf("InitialTags len = %d, want %d", len(opts.InitialTags), len(seed.InitialTags))
-	}
 
 	opts.ExcludeTools[0] = "changed"
-	opts.InitialTags[0] = "changed"
 	if seed.ExcludeTools[0] != "resolve_anticipation" {
 		t.Fatalf("seed ExcludeTools mutated to %q", seed.ExcludeTools[0])
-	}
-	if seed.InitialTags[0] != "scheduler" {
-		t.Fatalf("seed InitialTags mutated to %q", seed.InitialTags[0])
 	}
 }
 
@@ -227,7 +219,6 @@ func TestLoopProfileJSONRoundTrip(t *testing.T) {
 		DelegationGating: "disabled",
 		PreferSpeed:      "true",
 		ExcludeTools:     []string{"shell_exec", "web_fetch"},
-		InitialTags:      []string{"homeassistant", "security"},
 		ExtraHints:       map[string]string{"source": "frigate"},
 		Instructions:     "Analyse the camera event and decide if action is needed.",
 	}
@@ -269,14 +260,6 @@ func TestLoopProfileJSONRoundTrip(t *testing.T) {
 	for i, v := range original.ExcludeTools {
 		if restored.ExcludeTools[i] != v {
 			t.Errorf("ExcludeTools[%d] = %q, want %q", i, restored.ExcludeTools[i], v)
-		}
-	}
-	if len(restored.InitialTags) != len(original.InitialTags) {
-		t.Fatalf("InitialTags len = %d, want %d", len(restored.InitialTags), len(original.InitialTags))
-	}
-	for i, v := range original.InitialTags {
-		if restored.InitialTags[i] != v {
-			t.Errorf("InitialTags[%d] = %q, want %q", i, restored.InitialTags[i], v)
 		}
 	}
 	if len(restored.ExtraHints) != len(original.ExtraHints) {

--- a/internal/platform/config/config.go
+++ b/internal/platform/config/config.go
@@ -1312,6 +1312,11 @@ type SubscriptionConfig struct {
 	// profile's routing configuration. When nil, messages are received
 	// for ambient awareness only (debug-logged, not acted upon).
 	Wake *router.LoopProfile `yaml:"wake,omitempty"`
+
+	// InitialTags lists capability tags activated at the start of the
+	// agent run dispatched for matching messages. Only meaningful when
+	// Wake is non-nil.
+	InitialTags []string `yaml:"initial_tags,omitempty"`
 }
 
 // TelemetryConfig configures MQTT telemetry publishing. When Enabled
@@ -1569,8 +1574,8 @@ type SignalRoutingConfig struct {
 // LoopProfile representation used by wake-style entrypoints.
 //
 // It intentionally maps only the fields exposed by SignalRoutingConfig.
-// LoopProfile-only fields such as ExcludeTools and InitialTags are omitted
-// until Signal grows explicit config for them.
+// LoopProfile-only fields such as ExcludeTools are omitted until Signal
+// grows explicit config for them.
 func (c SignalRoutingConfig) LoopProfile() router.LoopProfile {
 	return router.LoopProfile{
 		Model:            c.Model,

--- a/internal/platform/config/example.go
+++ b/internal/platform/config/example.go
@@ -189,9 +189,9 @@ func ExampleConfig() *Config {
 						Mission:          "automation",
 						LocalOnly:        "false",
 						DelegationGating: "disabled",
-						InitialTags:      []string{"homeassistant"},
 						Instructions:     "Evaluate the security event and decide if action is needed.",
 					},
+					InitialTags: []string{"homeassistant"},
 				},
 			},
 			Telemetry: TelemetryConfig{
@@ -284,9 +284,9 @@ func ExampleConfig() *Config {
 					Profile: router.LoopProfile{
 						Mission:          "background",
 						DelegationGating: "disabled",
-						InitialTags:      []string{"homeassistant"},
 						Instructions:     "Be concise and focus on high-signal observations.",
 					},
+					Tags:         []string{"homeassistant"},
 					SleepMin:     2 * time.Minute,
 					SleepMax:     10 * time.Minute,
 					SleepDefault: 5 * time.Minute,

--- a/internal/runtime/ego/ego.go
+++ b/internal/runtime/ego/ego.go
@@ -107,10 +107,10 @@ func DefinitionSpec(cfg Config) loop.Spec {
 		SleepDefault: cfg.DefaultSleep,
 		Jitter:       loop.Float64Ptr(cfg.Jitter),
 		ExcludeTools: egoExcludeTools,
+		Tags:         []string{"ego"},
 		Profile: router.LoopProfile{
 			Mission:          "ego",
 			DelegationGating: "disabled",
-			InitialTags:      []string{"ego"},
 			ExtraHints:       map[string]string{"source": "ego"},
 		},
 		Supervisor:             cfg.SupervisorProbability > 0,

--- a/internal/runtime/ego/ego_test.go
+++ b/internal/runtime/ego/ego_test.go
@@ -115,8 +115,8 @@ func TestDefinitionSpec_Outputs(t *testing.T) {
 	if spec.Profile.DelegationGating != "disabled" {
 		t.Errorf("Profile.DelegationGating = %q, want disabled", spec.Profile.DelegationGating)
 	}
-	if len(spec.Profile.InitialTags) != 1 || spec.Profile.InitialTags[0] != "ego" {
-		t.Errorf("Profile.InitialTags = %v, want [ego]", spec.Profile.InitialTags)
+	if len(spec.Tags) != 1 || spec.Tags[0] != "ego" {
+		t.Errorf("Tags = %v, want [ego]", spec.Tags)
 	}
 }
 

--- a/internal/runtime/loop/definition_registry.go
+++ b/internal/runtime/loop/definition_registry.go
@@ -297,7 +297,6 @@ func cloneSpec(s Spec) Spec {
 	clone.Hints = cloneStringMap(s.Hints)
 	clone.Metadata = cloneStringMap(s.Metadata)
 	clone.Profile = s.Profile
-	clone.Profile.InitialTags = append([]string(nil), s.Profile.InitialTags...)
 	clone.Profile.ExcludeTools = append([]string(nil), s.Profile.ExcludeTools...)
 	clone.Profile.ExtraHints = cloneStringMap(s.Profile.ExtraHints)
 	return clone

--- a/internal/runtime/loop/definition_registry_test.go
+++ b/internal/runtime/loop/definition_registry_test.go
@@ -33,9 +33,9 @@ func TestDefinitionRegistrySnapshotIncludesConfigAndOverlay(t *testing.T) {
 		Task:       "Watch the office and report meaningful changes.",
 		Operation:  OperationService,
 		Completion: CompletionConversation,
+		Tags:       []string{"homeassistant"},
 		Profile: router.LoopProfile{
 			Mission:      "background",
-			InitialTags:  []string{"homeassistant"},
 			ExcludeTools: []string{"shell_exec"},
 		},
 	}, updatedAt); err != nil {

--- a/internal/runtime/loop/loop_test.go
+++ b/internal/runtime/loop/loop_test.go
@@ -944,11 +944,11 @@ func TestNewFromSpecAppliesProfileToRequest(t *testing.T) {
 		SleepDefault: 1 * time.Millisecond,
 		Jitter:       Float64Ptr(0),
 		MaxIter:      1,
+		Tags:         []string{"homeassistant"},
 		Profile: router.LoopProfile{
 			Model:        "spark/gpt-oss:20b",
 			Mission:      "automation",
 			ExcludeTools: []string{"shell_exec"},
-			InitialTags:  []string{"homeassistant"},
 			Instructions: "stay concise",
 			PreferSpeed:  "true",
 			LocalOnly:    "false",

--- a/internal/runtime/loop/registry_test.go
+++ b/internal/runtime/loop/registry_test.go
@@ -453,11 +453,11 @@ func TestRegistryLaunchAppliesRequestOverrides(t *testing.T) {
 			Task:       "base task",
 			Operation:  OperationRequestReply,
 			Completion: CompletionReturn,
+			Tags:       []string{"profile_tag"},
 			Profile: router.LoopProfile{
 				Model:        "spark/base",
 				Mission:      "automation",
 				ExcludeTools: []string{"profile_block"},
-				InitialTags:  []string{"profile_tag"},
 				Instructions: "profile guidance",
 			},
 			Hints: map[string]string{

--- a/internal/runtime/loop/spec.go
+++ b/internal/runtime/loop/spec.go
@@ -101,9 +101,12 @@ type Spec struct {
 	// unless blocked by policy.
 	Conditions Conditions `yaml:"conditions,omitempty" json:"conditions,omitempty"`
 
-	// Tags are capability tags for tool scoping. When non-empty,
-	// the loop's tool registry is filtered to tools matching these
-	// tags (plus always-active tags).
+	// Tags are the capability tags scoping this loop. They are
+	// activated at iteration 0 — seeding the active-tag set used for
+	// tool-registry scope filtering, KB article exposure, and any
+	// other tag-driven context surface — and remain active across
+	// iterations unless the model deactivates them. Per-invocation
+	// runtime overrides layer on top via [Launch.InitialTags].
 	Tags []string `yaml:"tags,omitempty" json:"tags,omitempty"`
 
 	// ExcludeTools lists tool names to exclude from the loop's
@@ -302,7 +305,7 @@ func (s *Spec) profileRequest() Request {
 		Model:        opts.Model,
 		Hints:        opts.Hints,
 		ExcludeTools: opts.ExcludeTools,
-		InitialTags:  opts.InitialTags,
+		InitialTags:  append([]string(nil), s.Tags...),
 		RuntimeTools: cloneRuntimeTools(s.RuntimeTools),
 	}
 }

--- a/internal/runtime/loop/spec_test.go
+++ b/internal/runtime/loop/spec_test.go
@@ -141,6 +141,66 @@ func TestSpecToConfigAppliesOneShotOperationDefaults(t *testing.T) {
 	}
 }
 
+func TestSpecProfileRequestSeedsInitialTagsFromSpecTags(t *testing.T) {
+	t.Run("Spec.Tags seeds Request.InitialTags", func(t *testing.T) {
+		spec := &Spec{
+			Name:       "weekend_observer",
+			Task:       "watch the weekend",
+			Operation:  OperationService,
+			Completion: CompletionConversation,
+			Tags:       []string{"ha", "hpde", "documents"},
+			Profile: router.LoopProfile{
+				Mission: "background",
+			},
+		}
+
+		got := spec.profileRequest().InitialTags
+
+		want := []string{"ha", "hpde", "documents"}
+		if len(got) != len(want) {
+			t.Fatalf("InitialTags = %v, want %v", got, want)
+		}
+		for i, tag := range want {
+			if got[i] != tag {
+				t.Fatalf("InitialTags[%d] = %q, want %q", i, got[i], tag)
+			}
+		}
+	})
+
+	t.Run("empty Spec.Tags yields empty InitialTags", func(t *testing.T) {
+		spec := &Spec{
+			Name:       "weekend_observer",
+			Task:       "watch the weekend",
+			Operation:  OperationService,
+			Completion: CompletionConversation,
+			Profile: router.LoopProfile{
+				Mission: "background",
+			},
+		}
+
+		if got := spec.profileRequest().InitialTags; len(got) != 0 {
+			t.Fatalf("InitialTags = %v, want empty", got)
+		}
+	})
+
+	t.Run("seeded slice does not alias Spec.Tags", func(t *testing.T) {
+		spec := &Spec{
+			Name:       "weekend_observer",
+			Task:       "watch the weekend",
+			Operation:  OperationService,
+			Completion: CompletionConversation,
+			Tags:       []string{"ha", "hpde"},
+		}
+
+		req := spec.profileRequest()
+		req.InitialTags[0] = "mutated"
+
+		if spec.Tags[0] != "ha" {
+			t.Fatalf("spec.Tags[0] = %q, want ha (slice was aliased)", spec.Tags[0])
+		}
+	})
+}
+
 func TestSpecValidatePersistableRejectsRuntimeHooks(t *testing.T) {
 	spec := &Spec{
 		Name: "dynamic-loop",
@@ -163,9 +223,9 @@ func TestSpecJSONRoundTripUsesHumanFacingFields(t *testing.T) {
 		Task:       "Watch the office.",
 		Operation:  OperationService,
 		Completion: CompletionConversation,
+		Tags:       []string{"homeassistant"},
 		Profile: router.LoopProfile{
 			Mission:      "background",
-			InitialTags:  []string{"homeassistant"},
 			Instructions: "Be concise.",
 		},
 		Conditions: Conditions{

--- a/internal/runtime/metacognitive/metacognitive.go
+++ b/internal/runtime/metacognitive/metacognitive.go
@@ -175,10 +175,10 @@ func DefinitionSpec(cfg Config) loop.Spec {
 		SleepDefault: cfg.DefaultSleep,
 		Jitter:       loop.Float64Ptr(cfg.Jitter),
 		ExcludeTools: metacogExcludeTools,
+		Tags:         []string{"metacognitive"},
 		Profile: router.LoopProfile{
 			Mission:          "metacognitive",
 			DelegationGating: "disabled",
-			InitialTags:      []string{"metacognitive"},
 			ExtraHints:       map[string]string{"source": "metacognitive"},
 		},
 

--- a/internal/runtime/metacognitive/metacognitive_test.go
+++ b/internal/runtime/metacognitive/metacognitive_test.go
@@ -344,8 +344,8 @@ func TestBuildSpec(t *testing.T) {
 	if spec.Profile.ExtraHints["source"] != "metacognitive" {
 		t.Errorf("Profile.ExtraHints[source] = %q, want metacognitive", spec.Profile.ExtraHints["source"])
 	}
-	if len(spec.Profile.InitialTags) != 1 || spec.Profile.InitialTags[0] != "metacognitive" {
-		t.Errorf("Profile.InitialTags = %v, want [metacognitive]", spec.Profile.InitialTags)
+	if len(spec.Tags) != 1 || spec.Tags[0] != "metacognitive" {
+		t.Errorf("Tags = %v, want [metacognitive]", spec.Tags)
 	}
 	if len(spec.Outputs) != 1 {
 		t.Fatalf("Outputs len = %d, want 1", len(spec.Outputs))

--- a/internal/tools/loop_definition_read_tools.go
+++ b/internal/tools/loop_definition_read_tools.go
@@ -18,7 +18,6 @@ type loopDefinitionLintEffective struct {
 	Mission          string             `json:"mission,omitempty"`
 	DelegationGating string             `json:"delegation_gating,omitempty"`
 	Tags             []string           `json:"tags,omitempty"`
-	InitialTags      []string           `json:"initial_tags,omitempty"`
 }
 
 func (r *Registry) handleLoopDefinitionSummary(_ context.Context, _ map[string]any) (string, error) {
@@ -200,7 +199,6 @@ func (r *Registry) handleLoopDefinitionLint(_ context.Context, args map[string]a
 		Mission:          spec.Profile.Mission,
 		DelegationGating: spec.Profile.DelegationGating,
 		Tags:             append([]string(nil), spec.Tags...),
-		InitialTags:      append([]string(nil), spec.Profile.InitialTags...),
 	}
 
 	resp := map[string]any{


### PR DESCRIPTION
## Summary

Closes #812. Each capability-tag field now has an unambiguous purpose; the redundant `LoopProfile.InitialTags` is gone.

| field | one-line Godoc |
|---|---|
| `Spec.Tags` | declarative spec-level capability scope; activated at iteration 0 |
| `Launch.InitialTags` | per-invocation runtime override (used by delegate) |
| `WakeSubscription.InitialTags` | per-subscription configured tags merged into the dispatched run |

## What changed

**Field removal.** `InitialTags` is removed from `router.LoopProfile` and `router.RequestOptions`. `LoopProfile` is now purely routing/configuration: model, mission, hints, exclude_tools, instructions.

**Spec wiring.** `Spec.profileRequest()` seeds `Request.InitialTags` directly from `Spec.Tags`. `Spec.Tags` becomes the single source of truth at the spec level. The previous behaviour — where the value was read only by `len() > 0` to flip `skipTagFilter`, with the actual filter keyed on a runtime active set that nothing in the spec ever seeded — is gone. The docstring is rewritten to describe what the field actually does.

**MQTT wake gains a first-class field.** `WakeSubscription` carries `InitialTags`; the persistence layer gets a sibling `initial_tags_json` column on `mqtt_wake_subscriptions`. `SubscriptionConfig` gains a top-level `initial_tags` YAML key. The dispatch path applies `ws.InitialTags` to the agent.Request after `applyLoopProfile`; profile application no longer touches tags.

**Migration.** Two paths preserve operator config:
- DB: `extractLegacyInitialTags` hoists pre-migration `initial_tags` out of bare-LoopProfile `seed_json` blobs into the new column on first load.
- Spec store: `extractLegacyProfileInitialTags` merges `spec.profile.initial_tags` from persisted records into `spec.tags` on `LoadInto`, with an info-level log noting the migration.

**Builtin specs migrated.** `ego` and `metacognitive` move their tags from `Profile.InitialTags` to top-level `Spec.Tags`. The example config does the same for the `office_watch` loop and the `automation/wake/security` subscription.

## Test plan

- [x] `just ci` passes locally (fmt-check, lint, tests, mod-tidy-check, link-check, architecture-check, config-generate-check)
- [x] `go generate ./internal/platform/config/...` re-run; `examples/config.example.yaml` regenerated and committed
- [x] Targeted unit tests added/updated:
  - `internal/runtime/loop/spec_test.go::TestSpecProfileRequestSeedsInitialTagsFromSpecTags` — Spec.Tags → Request.InitialTags, empty-tags case, slice-aliasing
  - `internal/app/mqttwake_test.go::TestApplyLoopProfile` — asserts profile no longer touches tags
  - `internal/runtime/ego/ego_test.go`, `internal/runtime/metacognitive/metacognitive_test.go` — assert `Spec.Tags`
  - `internal/channels/mqtt/tools_test.go` — assert `WakeSubscription.InitialTags`
- [ ] After deploy: restart `hpde_weekend_observer` on the live instance and confirm iteration 0's `loop_llm_start.payload.active_tags` contains `[ha, hpde, documents]`
- [ ] Confirm `hpde` KB articles appear in iteration 0 context for that loop
- [ ] Confirm legacy hoist on first server start: any persisted spec or wake subscription with legacy `initial_tags` carries forward (none in current prod, but verify the migration log is silent on clean records)

## Notes

- `Launch.InitialTags` (per-invocation runtime override at the launch level) is unchanged; it remains the right surface for callers like `delegate` that need per-run tag scope distinct from the spec.
- Signal bridge had two `InitialTags: opts.InitialTags` lines that propagated empty values from a `LoopProfile` whose `InitialTags` was never populated by the routing config. Those lines are removed; behaviour is unchanged because the source was already empty.