### PR TITLE
feat: add weather forecast subscriptions

### DIFF
--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -70,6 +70,12 @@ needs a strict fresh tool scope.
 Subscription expiry is reported as `expires_delta`, not a raw timestamp,
 so the model does not need to do clock arithmetic.
 
+For `weather.*` subscriptions, `add_context_entity` accepts
+`forecast: daily`, `forecast: hourly`, or `forecast: twice_daily` to
+fetch Home Assistant forecast response data each turn and include a
+compact forecast in the injected entity context. Use `forecast: none` to
+clear forecast fetching for that subscription.
+
 ## `ha` / `homeassistant` — Home Assistant state and control
 
 | Tool | Description |

--- a/internal/integrations/homeassistant/client.go
+++ b/internal/integrations/homeassistant/client.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/nugget/thane-ai-agent/internal/platform/httpkit"
@@ -188,8 +189,10 @@ func (c *Client) GetWeatherForecasts(ctx context.Context, entityID, forecastType
 	if entityID == "" {
 		return nil, nil
 	}
-	if forecastType == "" {
-		forecastType = "daily"
+	var err error
+	forecastType, err = normalizeWeatherForecastType(forecastType)
+	if err != nil {
+		return nil, err
 	}
 
 	var response struct {
@@ -208,6 +211,20 @@ func (c *Client) GetWeatherForecasts(ctx context.Context, entityID, forecastType
 		return nil, fmt.Errorf("weather forecast response missing entity %q", entityID)
 	}
 	return append([]map[string]any(nil), item.Forecast...), nil
+}
+
+func normalizeWeatherForecastType(value string) (string, error) {
+	value = strings.ToLower(strings.TrimSpace(value))
+	value = strings.ReplaceAll(value, "-", "_")
+	if value == "" {
+		return "daily", nil
+	}
+	switch value {
+	case "daily", "hourly", "twice_daily":
+		return value, nil
+	default:
+		return "", fmt.Errorf("invalid forecast type %q: must be one of daily, hourly, or twice_daily", value)
+	}
 }
 
 // CallService calls a Home Assistant service.

--- a/internal/integrations/homeassistant/client.go
+++ b/internal/integrations/homeassistant/client.go
@@ -81,6 +81,10 @@ type State struct {
 	LastUpdated time.Time      `json:"last_updated"`
 }
 
+type weatherForecastResponse struct {
+	Forecast []map[string]any `json:"forecast"`
+}
+
 // APIStatus represents the HA API status response.
 type APIStatus struct {
 	Message string `json:"message"`
@@ -175,6 +179,35 @@ func (c *Client) GetStateHistory(ctx context.Context, entityID string, startTime
 		}
 	}
 	return states, nil
+}
+
+// GetWeatherForecasts retrieves forecast rows for a weather entity using Home
+// Assistant's weather.get_forecasts response API. forecastType must be daily,
+// hourly, or twice_daily.
+func (c *Client) GetWeatherForecasts(ctx context.Context, entityID, forecastType string) ([]map[string]any, error) {
+	if entityID == "" {
+		return nil, nil
+	}
+	if forecastType == "" {
+		forecastType = "daily"
+	}
+
+	var response struct {
+		ServiceResponse map[string]weatherForecastResponse `json:"service_response"`
+	}
+	body := map[string]any{
+		"entity_id": entityID,
+		"type":      forecastType,
+	}
+	if err := c.post(ctx, "/api/services/weather/get_forecasts?return_response", body, &response); err != nil {
+		return nil, err
+	}
+
+	item, ok := response.ServiceResponse[entityID]
+	if !ok {
+		return nil, fmt.Errorf("weather forecast response missing entity %q", entityID)
+	}
+	return append([]map[string]any(nil), item.Forecast...), nil
 }
 
 // CallService calls a Home Assistant service.

--- a/internal/integrations/homeassistant/client_history_test.go
+++ b/internal/integrations/homeassistant/client_history_test.go
@@ -2,6 +2,8 @@ package homeassistant
 
 import (
 	"context"
+	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -49,5 +51,53 @@ func TestClient_GetStateHistory(t *testing.T) {
 	wantPath := "/api/history/period/2025-01-15T09:00:00Z?end_time=2025-01-15T12%3A00%3A00Z&filter_entity_id=sensor.temp&no_attributes=1&significant_changes_only=0"
 	if capturedPath != wantPath {
 		t.Fatalf("path = %q, want %q", capturedPath, wantPath)
+	}
+}
+
+func TestClient_GetWeatherForecasts(t *testing.T) {
+	var capturedPath string
+	var capturedBody map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedPath = r.URL.RequestURI()
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("read body: %v", err)
+		}
+		if err := json.Unmarshal(body, &capturedBody); err != nil {
+			t.Fatalf("decode request body: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"changed_states": [],
+			"service_response": {
+				"weather.home": {
+					"forecast": [
+						{"datetime":"2026-04-30T18:00:00Z","condition":"rainy","temperature":78}
+					]
+				}
+			}
+		}`))
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "token", nil)
+	forecast, err := client.GetWeatherForecasts(context.Background(), "weather.home", "hourly")
+	if err != nil {
+		t.Fatalf("GetWeatherForecasts: %v", err)
+	}
+	if capturedPath != "/api/services/weather/get_forecasts?return_response" {
+		t.Fatalf("path = %q, want return_response service path", capturedPath)
+	}
+	if capturedBody["entity_id"] != "weather.home" {
+		t.Fatalf("entity_id = %v, want weather.home", capturedBody["entity_id"])
+	}
+	if capturedBody["type"] != "hourly" {
+		t.Fatalf("type = %v, want hourly", capturedBody["type"])
+	}
+	if len(forecast) != 1 {
+		t.Fatalf("len(forecast) = %d, want 1", len(forecast))
+	}
+	if forecast[0]["condition"] != "rainy" {
+		t.Fatalf("forecast condition = %v, want rainy", forecast[0]["condition"])
 	}
 }

--- a/internal/integrations/homeassistant/client_history_test.go
+++ b/internal/integrations/homeassistant/client_history_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 )
@@ -99,5 +100,21 @@ func TestClient_GetWeatherForecasts(t *testing.T) {
 	}
 	if forecast[0]["condition"] != "rainy" {
 		t.Fatalf("forecast condition = %v, want rainy", forecast[0]["condition"])
+	}
+}
+
+func TestClient_GetWeatherForecastsRejectsInvalidType(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("server should not be called for invalid forecast type")
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "token", nil)
+	_, err := client.GetWeatherForecasts(context.Background(), "weather.home", "monthly")
+	if err == nil {
+		t.Fatal("expected invalid forecast type error")
+	}
+	if !strings.Contains(err.Error(), "must be one of daily, hourly, or twice_daily") {
+		t.Fatalf("error = %q, want forecast type guidance", err.Error())
 	}
 }

--- a/internal/integrations/homeassistant/contextfmt/entity_format_weather.go
+++ b/internal/integrations/homeassistant/contextfmt/entity_format_weather.go
@@ -35,15 +35,29 @@ type weatherContext struct {
 	Precipitation any               `json:"precipitation,omitempty"`
 	Since         string            `json:"since"`
 	Updated       string            `json:"updated,omitempty"`
+	ForecastType  string            `json:"forecast_type,omitempty"`
 	Forecast      []weatherForecast `json:"forecast,omitempty"`
 }
 
 // weatherForecast is a single forecast entry.
 type weatherForecast struct {
-	Delta     string `json:"dt"`
-	Condition string `json:"condition,omitempty"`
-	TempHigh  any    `json:"high,omitempty"`
-	TempLow   any    `json:"low,omitempty"`
+	Delta                    string `json:"dt"`
+	Condition                string `json:"condition,omitempty"`
+	ShortDescription         string `json:"short_description,omitempty"`
+	TempHigh                 any    `json:"high,omitempty"`
+	TempLow                  any    `json:"low,omitempty"`
+	ApparentTemp             any    `json:"apparent_temperature,omitempty"`
+	DewPoint                 any    `json:"dew_point,omitempty"`
+	Precipitation            any    `json:"precipitation,omitempty"`
+	PrecipitationProbability any    `json:"precipitation_probability,omitempty"`
+	WindSpeed                any    `json:"wind_speed,omitempty"`
+	WindGustSpeed            any    `json:"wind_gust_speed,omitempty"`
+	WindBearing              any    `json:"wind_bearing,omitempty"`
+	Humidity                 any    `json:"humidity,omitempty"`
+	CloudCoverage            any    `json:"cloud_coverage,omitempty"`
+	Pressure                 any    `json:"pressure,omitempty"`
+	UVIndex                  any    `json:"uv_index,omitempty"`
+	IsDaytime                any    `json:"is_daytime,omitempty"`
 }
 
 func formatWeather(state *homeassistant.State, now time.Time) string {
@@ -71,6 +85,7 @@ func formatWeather(state *homeassistant.State, now time.Time) string {
 	if !state.LastUpdated.IsZero() && state.LastUpdated.Sub(state.LastChanged) > time.Second {
 		wc.Updated = promptfmt.FormatDeltaOnly(state.LastUpdated, now)
 	}
+	wc.ForecastType = attrString(state.Attributes, "forecast_type")
 
 	// Extract forecast entries (HA returns []any of map[string]any).
 	if rawForecast, ok := state.Attributes["forecast"].([]any); ok {
@@ -84,9 +99,22 @@ func formatWeather(state *homeassistant.State, now time.Time) string {
 				continue
 			}
 			fc := weatherForecast{
-				Condition: attrString(entry, "condition"),
-				TempHigh:  measuredFirstAttr(entry, []string{"temperature"}, attrString(state.Attributes, "temperature_unit"), 1),
-				TempLow:   measuredFirstAttr(entry, []string{"templow"}, attrString(state.Attributes, "temperature_unit"), 1),
+				Condition:                attrString(entry, "condition"),
+				ShortDescription:         attrString(entry, "short_description"),
+				TempHigh:                 measuredFirstAttr(entry, []string{"temperature"}, attrString(state.Attributes, "temperature_unit"), 1),
+				TempLow:                  measuredFirstAttr(entry, []string{"templow"}, attrString(state.Attributes, "temperature_unit"), 1),
+				ApparentTemp:             measuredFirstAttr(entry, []string{"apparent_temperature"}, attrString(state.Attributes, "temperature_unit"), 1),
+				DewPoint:                 measuredFirstAttr(entry, []string{"dew_point", "dewpoint"}, attrString(state.Attributes, "temperature_unit"), 1),
+				Precipitation:            measuredFirstAttr(entry, []string{"precipitation"}, attrString(state.Attributes, "precipitation_unit"), 2),
+				PrecipitationProbability: roundAttr(entry["precipitation_probability"], 0),
+				WindSpeed:                measuredFirstAttr(entry, []string{"wind_speed"}, attrString(state.Attributes, "wind_speed_unit"), 1),
+				WindGustSpeed:            measuredFirstAttr(entry, []string{"wind_gust_speed", "wind_gust"}, firstNonEmpty(attrString(state.Attributes, "wind_gust_speed_unit"), attrString(state.Attributes, "wind_speed_unit")), 1),
+				WindBearing:              roundAttr(entry["wind_bearing"], 0),
+				Humidity:                 roundAttr(entry["humidity"], 0),
+				CloudCoverage:            roundAttr(firstAttr(entry, "cloud_coverage", "cloudcover", "clouds"), 0),
+				Pressure:                 measuredFirstAttr(entry, []string{"pressure"}, attrString(state.Attributes, "pressure_unit"), 1),
+				UVIndex:                  roundAttr(firstAttr(entry, "uv_index", "uv"), 1),
+				IsDaytime:                firstAttr(entry, "is_daytime"),
 			}
 			// Delta-annotate forecast time if available. HA may include
 			// fractional seconds, so try RFC3339Nano first.

--- a/internal/state/awareness/watchlist_provider.go
+++ b/internal/state/awareness/watchlist_provider.go
@@ -205,27 +205,34 @@ func (p *WatchlistTagProvider) renderSubscriptionContext(ctx context.Context, su
 }
 
 func (p *WatchlistProvider) stateWithForecast(ctx context.Context, sub WatchedSubscription, state *homeassistant.State) *homeassistant.State {
-	next, err := stateWithWeatherForecast(ctx, p.ha, state, sub.Forecast)
-	if err != nil {
-		p.logger.Warn("failed to fetch watched weather forecast",
-			"entity_id", sub.EntityID,
-			"forecast", sub.Forecast,
-			"error", err,
-		)
-		return state
-	}
-	return next
+	return watchlistStateWithForecast(ctx, p.ha, p.logger, sub, state, "failed to fetch watched weather forecast")
 }
 
 func (p *WatchlistTagProvider) stateWithForecast(ctx context.Context, sub WatchedSubscription, state *homeassistant.State) *homeassistant.State {
-	next, err := stateWithWeatherForecast(ctx, p.ha, state, sub.Forecast)
+	return watchlistStateWithForecast(ctx, p.ha, p.logger, sub, state, "failed to fetch tagged weather forecast", "tag", p.tag)
+}
+
+func watchlistStateWithForecast(
+	ctx context.Context,
+	ha StateGetter,
+	logger *slog.Logger,
+	sub WatchedSubscription,
+	state *homeassistant.State,
+	warnMsg string,
+	extraLogFields ...any,
+) *homeassistant.State {
+	next, err := stateWithWeatherForecast(ctx, ha, state, sub.Forecast)
 	if err != nil {
-		p.logger.Warn("failed to fetch tagged weather forecast",
+		if logger == nil {
+			logger = slog.Default()
+		}
+		fields := []any{
 			"entity_id", sub.EntityID,
-			"tag", p.tag,
 			"forecast", sub.Forecast,
 			"error", err,
-		)
+		}
+		fields = append(fields, extraLogFields...)
+		logger.Warn(warnMsg, fields...)
 		return state
 	}
 	return next

--- a/internal/state/awareness/watchlist_provider.go
+++ b/internal/state/awareness/watchlist_provider.go
@@ -17,6 +17,7 @@ import (
 type StateGetter interface {
 	GetState(ctx context.Context, entityID string) (*homeassistant.State, error)
 	GetStateHistory(ctx context.Context, entityID string, startTime, endTime time.Time) ([]homeassistant.State, error)
+	GetWeatherForecasts(ctx context.Context, entityID, forecastType string) ([]map[string]any, error)
 }
 
 // WatchlistProvider implements [agent.TagContextProvider] by fetching
@@ -142,6 +143,7 @@ func (p *WatchlistProvider) renderSubscriptionContext(ctx context.Context, sub W
 		)
 		return formatFetchError(sub.EntityID)
 	}
+	state = p.stateWithForecast(ctx, sub, state)
 
 	content := formatEntityContext(state, now)
 	content = enrichWithLastKnownGood(ctx, p.ha, content, state, now)
@@ -176,6 +178,7 @@ func (p *WatchlistTagProvider) renderSubscriptionContext(ctx context.Context, su
 		)
 		return formatFetchError(sub.EntityID)
 	}
+	state = p.stateWithForecast(ctx, sub, state)
 
 	content := formatEntityContext(state, now)
 	content = enrichWithLastKnownGood(ctx, p.ha, content, state, now)
@@ -199,4 +202,58 @@ func (p *WatchlistTagProvider) renderSubscriptionContext(ctx context.Context, su
 	}
 
 	return mergeHistoryIntoEntityContext(content, summaries, truncated)
+}
+
+func (p *WatchlistProvider) stateWithForecast(ctx context.Context, sub WatchedSubscription, state *homeassistant.State) *homeassistant.State {
+	next, err := stateWithWeatherForecast(ctx, p.ha, state, sub.Forecast)
+	if err != nil {
+		p.logger.Warn("failed to fetch watched weather forecast",
+			"entity_id", sub.EntityID,
+			"forecast", sub.Forecast,
+			"error", err,
+		)
+		return state
+	}
+	return next
+}
+
+func (p *WatchlistTagProvider) stateWithForecast(ctx context.Context, sub WatchedSubscription, state *homeassistant.State) *homeassistant.State {
+	next, err := stateWithWeatherForecast(ctx, p.ha, state, sub.Forecast)
+	if err != nil {
+		p.logger.Warn("failed to fetch tagged weather forecast",
+			"entity_id", sub.EntityID,
+			"tag", p.tag,
+			"forecast", sub.Forecast,
+			"error", err,
+		)
+		return state
+	}
+	return next
+}
+
+func stateWithWeatherForecast(ctx context.Context, ha StateGetter, state *homeassistant.State, forecastType string) (*homeassistant.State, error) {
+	if state == nil || forecastType == "" || entityDomain(state.EntityID) != "weather" || isSentinelState(state.State) {
+		return state, nil
+	}
+	forecast, err := ha.GetWeatherForecasts(ctx, state.EntityID, forecastType)
+	if err != nil {
+		return state, err
+	}
+	if len(forecast) == 0 {
+		return state, nil
+	}
+
+	next := *state
+	attrs := make(map[string]any, len(state.Attributes)+2)
+	for key, value := range state.Attributes {
+		attrs[key] = value
+	}
+	entries := make([]any, 0, len(forecast))
+	for _, entry := range forecast {
+		entries = append(entries, entry)
+	}
+	attrs["forecast"] = entries
+	attrs["forecast_type"] = forecastType
+	next.Attributes = attrs
+	return &next, nil
 }

--- a/internal/state/awareness/watchlist_provider_test.go
+++ b/internal/state/awareness/watchlist_provider_test.go
@@ -17,10 +17,13 @@ import (
 
 // fakeHA implements StateGetter for testing.
 type fakeHA struct {
-	states  map[string]*homeassistant.State
-	history map[string][]homeassistant.State
-	err     error // returned for any entity not in states
-	histErr error
+	states           map[string]*homeassistant.State
+	history          map[string][]homeassistant.State
+	forecasts        map[string][]map[string]any
+	forecastRequests []string
+	err              error // returned for any entity not in states
+	histErr          error
+	forecastErr      error
 }
 
 func (f *fakeHA) GetState(_ context.Context, entityID string) (*homeassistant.State, error) {
@@ -39,6 +42,14 @@ func (f *fakeHA) GetStateHistory(_ context.Context, entityID string, _ time.Time
 	}
 	history := f.history[entityID]
 	return append([]homeassistant.State(nil), history...), nil
+}
+
+func (f *fakeHA) GetWeatherForecasts(_ context.Context, entityID, forecastType string) ([]map[string]any, error) {
+	f.forecastRequests = append(f.forecastRequests, entityID+":"+forecastType)
+	if f.forecastErr != nil {
+		return nil, f.forecastErr
+	}
+	return append([]map[string]any(nil), f.forecasts[entityID]...), nil
 }
 
 func setupTestProvider(t *testing.T, ha StateGetter) (*WatchlistProvider, *WatchlistStore) {
@@ -255,7 +266,7 @@ func TestProvider_IncludesNumericHistorySummaries(t *testing.T) {
 	}
 
 	p, store := setupTestProvider(t, ha)
-	if err := store.AddWithOptions("sensor.office_temperature", nil, []int{24 * 60 * 60}, 0); err != nil {
+	if err := store.AddWithOptions("sensor.office_temperature", nil, []int{24 * 60 * 60}, 0, ""); err != nil {
 		t.Fatalf("AddWithOptions: %v", err)
 	}
 
@@ -290,6 +301,73 @@ func TestProvider_IncludesNumericHistorySummaries(t *testing.T) {
 	}
 }
 
+func TestProvider_IncludesWeatherForecastWhenSubscribed(t *testing.T) {
+	now := time.Now().UTC().Round(time.Second)
+	ha := &fakeHA{
+		states: map[string]*homeassistant.State{
+			"weather.home": {
+				EntityID:    "weather.home",
+				State:       "cloudy",
+				LastChanged: now.Add(-5 * time.Minute),
+				Attributes: map[string]any{
+					"friendly_name":      "Home Forecast",
+					"temperature":        70.0,
+					"temperature_unit":   "°F",
+					"wind_speed_unit":    "mph",
+					"precipitation_unit": "in",
+				},
+			},
+		},
+		forecasts: map[string][]map[string]any{
+			"weather.home": {
+				{
+					"datetime":                  now.Add(2 * time.Hour).Format(time.RFC3339),
+					"condition":                 "rainy",
+					"temperature":               78.0,
+					"templow":                   64.0,
+					"precipitation_probability": 80.0,
+					"wind_speed":                12.0,
+				},
+			},
+		},
+	}
+
+	p, store := setupTestProvider(t, ha)
+	if err := store.AddWithOptions("weather.home", nil, nil, 0, "hourly"); err != nil {
+		t.Fatalf("AddWithOptions: %v", err)
+	}
+
+	got, err := p.TagContext(context.Background(), agentctx.ContextRequest{UserMessage: ""})
+	if err != nil {
+		t.Fatalf("GetContext: %v", err)
+	}
+
+	if len(ha.forecastRequests) != 1 || ha.forecastRequests[0] != "weather.home:hourly" {
+		t.Fatalf("forecastRequests = %v, want [weather.home:hourly]", ha.forecastRequests)
+	}
+	payload := decodeWatchlistPayload(t, got)
+	if payload["forecast_type"] != "hourly" {
+		t.Fatalf("forecast_type = %#v, want hourly", payload["forecast_type"])
+	}
+	forecast, ok := payload["forecast"].([]any)
+	if !ok || len(forecast) != 1 {
+		t.Fatalf("forecast = %#v, want one entry", payload["forecast"])
+	}
+	entry, ok := forecast[0].(map[string]any)
+	if !ok {
+		t.Fatalf("forecast[0] = %#v, want object", forecast[0])
+	}
+	if entry["condition"] != "rainy" {
+		t.Fatalf("condition = %#v, want rainy", entry["condition"])
+	}
+	if entry["high"] != "78 °F" {
+		t.Fatalf("high = %#v, want 78 °F", entry["high"])
+	}
+	if entry["precipitation_probability"] != float64(80) {
+		t.Fatalf("precipitation_probability = %#v, want 80", entry["precipitation_probability"])
+	}
+}
+
 func TestProvider_IncludesDiscreteHistorySummaries(t *testing.T) {
 	now := time.Now().UTC().Round(time.Second)
 	ha := &fakeHA{
@@ -313,7 +391,7 @@ func TestProvider_IncludesDiscreteHistorySummaries(t *testing.T) {
 	}
 
 	p, store := setupTestProvider(t, ha)
-	if err := store.AddWithOptions("binary_sensor.front_door", nil, []int{24 * 60 * 60}, 0); err != nil {
+	if err := store.AddWithOptions("binary_sensor.front_door", nil, []int{24 * 60 * 60}, 0, ""); err != nil {
 		t.Fatalf("AddWithOptions: %v", err)
 	}
 
@@ -372,7 +450,7 @@ func TestProvider_DiscreteHistoryUsesDeviceClassLabels(t *testing.T) {
 	}
 
 	p, store := setupTestProvider(t, ha)
-	if err := store.AddWithOptions("binary_sensor.front_door", nil, []int{24 * 60 * 60}, 0); err != nil {
+	if err := store.AddWithOptions("binary_sensor.front_door", nil, []int{24 * 60 * 60}, 0, ""); err != nil {
 		t.Fatalf("AddWithOptions: %v", err)
 	}
 

--- a/internal/state/awareness/watchlist_store.go
+++ b/internal/state/awareness/watchlist_store.go
@@ -15,6 +15,7 @@ type WatchedSubscription struct {
 	EntityID  string
 	Scope     string
 	History   []int
+	Forecast  string
 	ExpiresAt *time.Time
 }
 
@@ -59,12 +60,12 @@ func (s *WatchlistStore) Add(entityID string) error {
 }
 
 // AddWithOptions inserts or updates entity subscriptions with tag scopes,
-// historical offsets, and an optional TTL. Empty tags means the entity is
-// always visible in context.
-func (s *WatchlistStore) AddWithOptions(entityID string, tags []string, history []int, ttlSeconds int) error {
+// historical offsets, optional weather forecast type, and an optional TTL.
+// Empty tags means the entity is always visible in context.
+func (s *WatchlistStore) AddWithOptions(entityID string, tags []string, history []int, ttlSeconds int, forecast string) error {
 	scopes := normalizeScopes(tags)
 
-	optsJSON, err := marshalWatchlistOptions(history, ttlSeconds)
+	optsJSON, err := marshalWatchlistOptions(history, ttlSeconds, forecast)
 	if err != nil {
 		return fmt.Errorf("marshal options: %w", err)
 	}
@@ -243,6 +244,7 @@ func (s *WatchlistStore) scanActiveSubscriptions(query string, args ...any) ([]W
 			EntityID:  entityID,
 			Scope:     scope,
 			History:   append([]int(nil), opts.History...),
+			Forecast:  opts.Forecast,
 			ExpiresAt: cloneTimePtr(opts.ExpiresAt),
 		})
 	}
@@ -290,17 +292,24 @@ func (s *WatchlistStore) subscriptionCount() (int, error) {
 
 type watchlistOptions struct {
 	History   []int
+	Forecast  string
 	ExpiresAt *time.Time
 }
 
 type watchlistOptionsWire struct {
 	History   []int  `json:"history,omitempty"`
+	Forecast  string `json:"forecast,omitempty"`
 	ExpiresAt string `json:"expires_at,omitempty"`
 }
 
-func marshalWatchlistOptions(history []int, ttlSeconds int) ([]byte, error) {
+func marshalWatchlistOptions(history []int, ttlSeconds int, forecast string) ([]byte, error) {
+	forecast, err := normalizeForecastType(forecast)
+	if err != nil {
+		return nil, err
+	}
 	wire := watchlistOptionsWire{
-		History: append([]int(nil), history...),
+		History:  append([]int(nil), history...),
+		Forecast: forecast,
 	}
 	if ttlSeconds > 0 {
 		wire.ExpiresAt = time.Now().UTC().Add(time.Duration(ttlSeconds) * time.Second).Format(time.RFC3339)
@@ -318,6 +327,9 @@ func parseWatchlistOptions(optsJSON string) watchlistOptions {
 	}
 	out := watchlistOptions{
 		History: append([]int(nil), wire.History...),
+	}
+	if forecast, err := normalizeForecastType(wire.Forecast); err == nil {
+		out.Forecast = forecast
 	}
 	if wire.ExpiresAt != "" {
 		if ts, err := time.Parse(time.RFC3339, wire.ExpiresAt); err == nil {
@@ -350,6 +362,19 @@ func normalizeScopes(tags []string) []string {
 		return []string{""}
 	}
 	return scopes
+}
+
+func normalizeForecastType(value string) (string, error) {
+	value = strings.ToLower(strings.TrimSpace(value))
+	value = strings.ReplaceAll(value, "-", "_")
+	switch value {
+	case "", "none":
+		return "", nil
+	case "daily", "hourly", "twice_daily":
+		return value, nil
+	default:
+		return "", fmt.Errorf("forecast must be one of daily, hourly, twice_daily, or none")
+	}
 }
 
 func cloneTimePtr(src *time.Time) *time.Time {

--- a/internal/state/awareness/watchlist_store_test.go
+++ b/internal/state/awareness/watchlist_store_test.go
@@ -114,7 +114,7 @@ func TestStore_RemoveNonExistent(t *testing.T) {
 func TestStore_AddWithOptionsScopedSubscriptions(t *testing.T) {
 	store := setupTestStore(t)
 
-	if err := store.AddWithOptions("sensor.battery", []string{"battery_focus", "interactive", "battery_focus"}, []int{600, 3600}, 300, "daily"); err != nil {
+	if err := store.AddWithOptions("weather.home", []string{"weather_focus", "interactive", "weather_focus"}, []int{600, 3600}, 300, "daily"); err != nil {
 		t.Fatalf("AddWithOptions: %v", err)
 	}
 
@@ -122,8 +122,8 @@ func TestStore_AddWithOptionsScopedSubscriptions(t *testing.T) {
 	if err != nil {
 		t.Fatalf("List: %v", err)
 	}
-	if !slices.Equal(ids, []string{"sensor.battery"}) {
-		t.Fatalf("List() = %v, want [sensor.battery]", ids)
+	if !slices.Equal(ids, []string{"weather.home"}) {
+		t.Fatalf("List() = %v, want [weather.home]", ids)
 	}
 
 	untagged, err := store.ListUntagged()
@@ -138,27 +138,27 @@ func TestStore_AddWithOptionsScopedSubscriptions(t *testing.T) {
 	if err != nil {
 		t.Fatalf("DistinctTags: %v", err)
 	}
-	if !slices.Equal(tags, []string{"battery_focus", "interactive"}) {
-		t.Fatalf("DistinctTags() = %v, want [battery_focus interactive]", tags)
+	if !slices.Equal(tags, []string{"interactive", "weather_focus"}) {
+		t.Fatalf("DistinctTags() = %v, want [interactive weather_focus]", tags)
 	}
 
-	batteryFocus, err := store.ListByTag("battery_focus")
+	weatherFocus, err := store.ListByTag("weather_focus")
 	if err != nil {
-		t.Fatalf("ListByTag(battery_focus): %v", err)
+		t.Fatalf("ListByTag(weather_focus): %v", err)
 	}
-	if len(batteryFocus) != 1 {
-		t.Fatalf("ListByTag(battery_focus) len = %d, want 1", len(batteryFocus))
+	if len(weatherFocus) != 1 {
+		t.Fatalf("ListByTag(weather_focus) len = %d, want 1", len(weatherFocus))
 	}
-	if batteryFocus[0].Scope != "battery_focus" {
-		t.Fatalf("scope = %q, want battery_focus", batteryFocus[0].Scope)
+	if weatherFocus[0].Scope != "weather_focus" {
+		t.Fatalf("scope = %q, want weather_focus", weatherFocus[0].Scope)
 	}
-	if !slices.Equal(batteryFocus[0].History, []int{600, 3600}) {
-		t.Fatalf("history = %v, want [600 3600]", batteryFocus[0].History)
+	if !slices.Equal(weatherFocus[0].History, []int{600, 3600}) {
+		t.Fatalf("history = %v, want [600 3600]", weatherFocus[0].History)
 	}
-	if batteryFocus[0].Forecast != "daily" {
-		t.Fatalf("forecast = %q, want daily", batteryFocus[0].Forecast)
+	if weatherFocus[0].Forecast != "daily" {
+		t.Fatalf("forecast = %q, want daily", weatherFocus[0].Forecast)
 	}
-	if batteryFocus[0].ExpiresAt == nil {
+	if weatherFocus[0].ExpiresAt == nil {
 		t.Fatal("expected expiration to be set")
 	}
 }

--- a/internal/state/awareness/watchlist_store_test.go
+++ b/internal/state/awareness/watchlist_store_test.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"slices"
+	"strings"
 	"testing"
 	"time"
 
@@ -113,7 +114,7 @@ func TestStore_RemoveNonExistent(t *testing.T) {
 func TestStore_AddWithOptionsScopedSubscriptions(t *testing.T) {
 	store := setupTestStore(t)
 
-	if err := store.AddWithOptions("sensor.battery", []string{"battery_focus", "interactive", "battery_focus"}, []int{600, 3600}, 300); err != nil {
+	if err := store.AddWithOptions("sensor.battery", []string{"battery_focus", "interactive", "battery_focus"}, []int{600, 3600}, 300, "daily"); err != nil {
 		t.Fatalf("AddWithOptions: %v", err)
 	}
 
@@ -154,8 +155,23 @@ func TestStore_AddWithOptionsScopedSubscriptions(t *testing.T) {
 	if !slices.Equal(batteryFocus[0].History, []int{600, 3600}) {
 		t.Fatalf("history = %v, want [600 3600]", batteryFocus[0].History)
 	}
+	if batteryFocus[0].Forecast != "daily" {
+		t.Fatalf("forecast = %q, want daily", batteryFocus[0].Forecast)
+	}
 	if batteryFocus[0].ExpiresAt == nil {
 		t.Fatal("expected expiration to be set")
+	}
+}
+
+func TestStore_AddWithOptionsRejectsInvalidForecast(t *testing.T) {
+	store := setupTestStore(t)
+
+	err := store.AddWithOptions("weather.home", nil, nil, 0, "monthly")
+	if err == nil {
+		t.Fatal("expected invalid forecast error")
+	}
+	if !strings.Contains(err.Error(), "forecast must be one of") {
+		t.Fatalf("error = %q, want forecast validation", err.Error())
 	}
 }
 
@@ -165,7 +181,7 @@ func TestStore_RemoveWithScopesPreservesOtherSubscriptions(t *testing.T) {
 	if err := store.Add("sensor.battery"); err != nil {
 		t.Fatalf("Add: %v", err)
 	}
-	if err := store.AddWithOptions("sensor.battery", []string{"battery_focus"}, nil, 0); err != nil {
+	if err := store.AddWithOptions("sensor.battery", []string{"battery_focus"}, nil, 0, ""); err != nil {
 		t.Fatalf("AddWithOptions: %v", err)
 	}
 

--- a/internal/state/awareness/watchlist_tool_provider.go
+++ b/internal/state/awareness/watchlist_tool_provider.go
@@ -69,7 +69,8 @@ func (w *WatchlistTools) Tools() []*tools.Tool {
 				"Use tags to scope entity context to specific capabilities or loop-owned focus tags (only visible when that tag is active). " +
 				"Subscriptions are additive: the same entity can appear in multiple scoped contexts. " +
 				"Use ttl_seconds when the watch should expire automatically after a bounded task ends. " +
-				"Use history to include historical state snapshots at specific intervals.",
+				"Use history to include historical state snapshots at specific intervals. " +
+				"Use forecast for weather entities when future weather context is needed.",
 			Parameters: map[string]any{
 				"type": "object",
 				"properties": map[string]any{
@@ -86,6 +87,11 @@ func (w *WatchlistTools) Tools() []*tools.Tool {
 						"type":        "array",
 						"items":       map[string]any{"type": "integer"},
 						"description": "Historical context windows in seconds. When set, watched-entity context includes a compact summary for each window. E.g., [600, 3600, 86400] adds recent summaries for 10min, 1hr, and 1day windows.",
+					},
+					"forecast": map[string]any{
+						"type":        "string",
+						"enum":        []string{"daily", "hourly", "twice_daily", "none"},
+						"description": "For weather.* entities, fetch this Home Assistant weather.get_forecasts type each turn and include the compact forecast in watched-entity context. Use none to clear forecast fetching.",
 					},
 					"ttl_seconds": map[string]any{
 						"type":        "integer",
@@ -160,13 +166,21 @@ func (w *WatchlistTools) handleAddContextEntity(_ context.Context, args map[stri
 	if ttlSeconds < 0 {
 		return "", fmt.Errorf("ttl_seconds must be >= 0")
 	}
+	rawForecast, forecastSet := args["forecast"]
+	forecast, err := parseWatchlistForecastArg(rawForecast)
+	if err != nil {
+		return "", err
+	}
+	if forecast != "" && !strings.HasPrefix(entityID, "weather.") {
+		return "", fmt.Errorf("forecast can only be set for weather.* entities; got %s", entityID)
+	}
 
-	if len(tags) > 0 || len(history) > 0 || ttlSeconds > 0 {
-		if err := w.store.AddWithOptions(entityID, tags, history, ttlSeconds); err != nil {
+	if len(tags) == 0 && len(history) == 0 && ttlSeconds == 0 && forecast == "" && !forecastSet {
+		if err := w.store.Add(entityID); err != nil {
 			return "", fmt.Errorf("add to watchlist: %w", err)
 		}
 	} else {
-		if err := w.store.Add(entityID); err != nil {
+		if err := w.store.AddWithOptions(entityID, tags, history, ttlSeconds, forecast); err != nil {
 			return "", fmt.Errorf("add to watchlist: %w", err)
 		}
 	}
@@ -182,13 +196,18 @@ func (w *WatchlistTools) handleAddContextEntity(_ context.Context, args map[stri
 		}
 		msg += fmt.Sprintf(" (history windows: %s)", strings.Join(parts, ", "))
 	}
+	if forecast != "" {
+		msg += fmt.Sprintf(" (forecast: %s)", forecast)
+	} else if forecastSet {
+		msg += " (forecast: none)"
+	}
 	if ttlSeconds > 0 {
 		msg += fmt.Sprintf(" (expires in %ds)", ttlSeconds)
 	}
 	msg += "."
 
 	w.logger.Info("context entity added",
-		"entity_id", entityID, "tags", tags, "history", history, "ttl_seconds", ttlSeconds)
+		"entity_id", entityID, "tags", tags, "history", history, "forecast", forecast, "ttl_seconds", ttlSeconds)
 	if w.tagRegistrar != nil {
 		for _, tag := range tags {
 			w.tagRegistrar(tag)
@@ -219,6 +238,9 @@ func (w *WatchlistTools) handleListContextEntities(_ context.Context, args map[s
 		}
 		if len(sub.History) > 0 {
 			item["history"] = append([]int(nil), sub.History...)
+		}
+		if sub.Forecast != "" {
+			item["forecast"] = sub.Forecast
 		}
 		if sub.ExpiresAt != nil {
 			item["expires_delta"] = promptfmt.FormatDeltaOnly(*sub.ExpiresAt, now)
@@ -288,6 +310,17 @@ func parseWatchlistTagArgs(raw any) ([]string, error) {
 		}
 	}
 	return tags, nil
+}
+
+func parseWatchlistForecastArg(raw any) (string, error) {
+	if raw == nil {
+		return "", nil
+	}
+	value, ok := raw.(string)
+	if !ok {
+		return "", fmt.Errorf("forecast must be a string")
+	}
+	return normalizeForecastType(value)
 }
 
 func parseWatchlistHistoryArg(raw any) ([]int, error) {

--- a/internal/state/awareness/watchlist_tool_provider_test.go
+++ b/internal/state/awareness/watchlist_tool_provider_test.go
@@ -268,6 +268,25 @@ func TestListContextEntities_ReturnsScopedSubscriptions(t *testing.T) {
 	if payload.Items[0].Forecast != "daily" {
 		t.Fatalf("forecast = %q, want daily", payload.Items[0].Forecast)
 	}
+
+	raw, err = p.handleListContextEntities(context.Background(), map[string]any{
+		"tag": "battery_focus",
+	})
+	if err != nil {
+		t.Fatalf("handleListContextEntities battery_focus: %v", err)
+	}
+	if err := json.Unmarshal([]byte(raw), &payload); err != nil {
+		t.Fatalf("unmarshal battery payload: %v", err)
+	}
+	if payload.Count != 1 {
+		t.Fatalf("battery count = %d, want 1", payload.Count)
+	}
+	if payload.Items[0].EntityID != "sensor.battery" || payload.Items[0].Scope != "battery_focus" {
+		t.Fatalf("battery item = %+v, want sensor.battery/battery_focus", payload.Items[0])
+	}
+	if payload.Items[0].ExpiresDelta == "" {
+		t.Fatal("expected expires_delta for TTL-backed subscription")
+	}
 }
 
 func TestRemoveContextEntity_MissingEntityID(t *testing.T) {

--- a/internal/state/awareness/watchlist_tool_provider_test.go
+++ b/internal/state/awareness/watchlist_tool_provider_test.go
@@ -115,9 +115,10 @@ func TestAddContextEntity_WithScopesTTLAndHistory(t *testing.T) {
 	p, store, registered := setupWatchlistProvider(t)
 
 	result, err := p.handleAddContextEntity(context.Background(), map[string]any{
-		"entity_id":   "sensor.battery",
+		"entity_id":   "weather.home",
 		"tags":        []any{"battery_focus", "battery_focus"},
 		"history":     []any{60, 3600},
+		"forecast":    "hourly",
 		"ttl_seconds": 120,
 	})
 	if err != nil {
@@ -141,8 +142,73 @@ func TestAddContextEntity_WithScopesTTLAndHistory(t *testing.T) {
 	if !slices.Equal(subs[0].History, []int{60, 3600}) {
 		t.Fatalf("history = %v, want [60 3600]", subs[0].History)
 	}
+	if subs[0].Forecast != "hourly" {
+		t.Fatalf("forecast = %q, want hourly", subs[0].Forecast)
+	}
 	if subs[0].ExpiresAt == nil {
 		t.Fatal("expected subscription expiration")
+	}
+}
+
+func TestAddContextEntity_InvalidForecast(t *testing.T) {
+	p, _, _ := setupWatchlistProvider(t)
+
+	_, err := p.handleAddContextEntity(context.Background(), map[string]any{
+		"entity_id": "weather.home",
+		"forecast":  "monthly",
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid forecast")
+	}
+	if !strings.Contains(err.Error(), "forecast must be one of") {
+		t.Fatalf("error = %q, want forecast validation", err.Error())
+	}
+}
+
+func TestAddContextEntity_ForecastRequiresWeatherEntity(t *testing.T) {
+	p, _, _ := setupWatchlistProvider(t)
+
+	_, err := p.handleAddContextEntity(context.Background(), map[string]any{
+		"entity_id": "sensor.outdoor_temperature",
+		"forecast":  "daily",
+	})
+	if err == nil {
+		t.Fatal("expected error for forecast on non-weather entity")
+	}
+	if !strings.Contains(err.Error(), "weather.*") {
+		t.Fatalf("error = %q, want weather entity guidance", err.Error())
+	}
+}
+
+func TestAddContextEntity_ForecastNoneClearsExistingOption(t *testing.T) {
+	p, store, _ := setupWatchlistProvider(t)
+
+	if _, err := p.handleAddContextEntity(context.Background(), map[string]any{
+		"entity_id": "weather.home",
+		"forecast":  "daily",
+	}); err != nil {
+		t.Fatalf("add forecast: %v", err)
+	}
+	result, err := p.handleAddContextEntity(context.Background(), map[string]any{
+		"entity_id": "weather.home",
+		"forecast":  "none",
+	})
+	if err != nil {
+		t.Fatalf("clear forecast: %v", err)
+	}
+	if !strings.Contains(result, "forecast: none") {
+		t.Fatalf("result = %q, want forecast clearing note", result)
+	}
+
+	subs, err := store.ListUntaggedSubscriptions()
+	if err != nil {
+		t.Fatalf("ListUntaggedSubscriptions: %v", err)
+	}
+	if len(subs) != 1 {
+		t.Fatalf("len(subs) = %d, want 1", len(subs))
+	}
+	if subs[0].Forecast != "" {
+		t.Fatalf("forecast = %q, want cleared", subs[0].Forecast)
 	}
 }
 
@@ -163,12 +229,15 @@ func TestListContextEntities_ReturnsScopedSubscriptions(t *testing.T) {
 	if err := store.Add("sensor.always_on"); err != nil {
 		t.Fatalf("Add: %v", err)
 	}
-	if err := store.AddWithOptions("sensor.battery", []string{"battery_focus"}, []int{600}, 300); err != nil {
+	if err := store.AddWithOptions("sensor.battery", []string{"battery_focus"}, []int{600}, 300, ""); err != nil {
 		t.Fatalf("AddWithOptions: %v", err)
+	}
+	if err := store.AddWithOptions("weather.home", []string{"weather_focus"}, nil, 0, "daily"); err != nil {
+		t.Fatalf("AddWithOptions weather: %v", err)
 	}
 
 	raw, err := p.handleListContextEntities(context.Background(), map[string]any{
-		"tag": "battery_focus",
+		"tag": "weather_focus",
 	})
 	if err != nil {
 		t.Fatalf("handleListContextEntities: %v", err)
@@ -180,6 +249,7 @@ func TestListContextEntities_ReturnsScopedSubscriptions(t *testing.T) {
 			EntityID      string `json:"entity_id"`
 			Scope         string `json:"scope"`
 			AlwaysVisible bool   `json:"always_visible"`
+			Forecast      string `json:"forecast"`
 			ExpiresDelta  string `json:"expires_delta"`
 		} `json:"items"`
 	}
@@ -189,14 +259,14 @@ func TestListContextEntities_ReturnsScopedSubscriptions(t *testing.T) {
 	if payload.Count != 1 {
 		t.Fatalf("count = %d, want 1", payload.Count)
 	}
-	if payload.Items[0].EntityID != "sensor.battery" || payload.Items[0].Scope != "battery_focus" {
-		t.Fatalf("item = %+v, want sensor.battery/battery_focus", payload.Items[0])
+	if payload.Items[0].EntityID != "weather.home" || payload.Items[0].Scope != "weather_focus" {
+		t.Fatalf("item = %+v, want weather.home/weather_focus", payload.Items[0])
 	}
 	if payload.Items[0].AlwaysVisible {
 		t.Fatal("tagged subscription should not be always visible")
 	}
-	if payload.Items[0].ExpiresDelta == "" {
-		t.Fatal("expected expires_delta in payload")
+	if payload.Items[0].Forecast != "daily" {
+		t.Fatalf("forecast = %q, want daily", payload.Items[0].Forecast)
 	}
 }
 
@@ -244,7 +314,7 @@ func TestRemoveContextEntity_ScopedRemovalKeepsOtherSubscriptions(t *testing.T) 
 	if err := store.Add("sensor.battery"); err != nil {
 		t.Fatalf("Add: %v", err)
 	}
-	if err := store.AddWithOptions("sensor.battery", []string{"battery_focus"}, nil, 0); err != nil {
+	if err := store.AddWithOptions("sensor.battery", []string{"battery_focus"}, nil, 0, ""); err != nil {
 		t.Fatalf("AddWithOptions: %v", err)
 	}
 


### PR DESCRIPTION
## Summary

Adds an opt-in `forecast` option to watched Home Assistant entity subscriptions so `weather.*` entities can carry future forecast context into loop prompts.

The `add_context_entity` tool now accepts `forecast: daily`, `forecast: hourly`, `forecast: twice_daily`, or `forecast: none`. Forecast fetching is limited to `weather.*` entities and stored in the existing subscription `options` JSON alongside `history` and `expires_at`. When enabled, the watchlist provider calls Home Assistant's `weather.get_forecasts` response API each turn and feeds the returned rows through the existing compact weather formatter.

The weather formatter now preserves additional forecast fields commonly returned by HA weather integrations, including precipitation probability, wind, humidity, pressure, UV index, day/night markers, and NWS-style short descriptions, while continuing to cap forecast entries.

## Operator impact

A loop can now subscribe to a weather entity with forecast context instead of repeatedly calling HA tools. For example, a weather-focused loop can add `weather.nws_msrh_klbx` with a task tag and `forecast: hourly`, then receive current METAR-style conditions plus a compact forecast whenever that tag is active.

## Validation

- `just ci`