### PR TITLE
docs(release): reorder checklist around actual release flow

### DIFF
--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -4,20 +4,185 @@ Use this for real release work, not just version bumps. The goal is to
 ship a build that is technically sound, operationally inspectable, and
 easy to roll back.
 
-## Repo Preflight
+The phases are time-ordered: audits land first, while a fix is still
+cheap; assets get cut once the tree is clean; validation and
+communication happen against the live build. Skipping forward is fine,
+working backward is the smell.
+
+## 1. Pre-release audits
+
+Done before any artifacts are cut. This is where structural problems
+get fixed cheaply — a redundant field collapsed here is one PR; the
+same fix after a release ships is migration work.
+
+- [ ] **Code-path audit** — sweep recent surfaces for redundant fields,
+      parallel implementations, and dead code paths. The Godoc
+      compliance audit below is the main lens for spotting these;
+      apply it ruthlessly.
+- [ ] **Godoc compliance audit**
+
+  Godoc is a design check, not a documentation chore. Best-in-class
+  Godoc forces every exported type, field, and function to justify
+  its existence at the narrative level — what role it plays, why the
+  abstraction exists, when callers should reach for it. Code that
+  produces correct output but cannot explain its place in the system
+  is incomplete.
+
+  Two practical tests:
+
+  - [ ] **Stand-alone test.** Each field's Godoc reads cleanly without
+        referencing sibling fields for disambiguation. If `FieldA`
+        needs "but if `FieldB` is also set, this is ignored" or
+        "spec-defined consumers should use `FieldB` instead," the
+        design is wrong — collapse, rename, or split until each
+        field's purpose is independently statable.
+        [#812](https://github.com/nugget/thane-ai-agent/issues/812) /
+        [#813](https://github.com/nugget/thane-ai-agent/pull/813) is
+        the canonical example: two tag fields whose honest Godocs
+        could not be written without referencing each other, which
+        was the smell that prompted the structural fix.
+  - [ ] **Why-it-exists test.** Each Godoc answers not just *what*
+        but *why*. "X is the user's display name" is not enough; "X
+        is the operator-configured display name; the UI renders this
+        and falls back to the email local-part when unset" is. If
+        you can only describe the *what*, the abstraction has no
+        narrative reason to exist as a distinct thing — fold it into
+        whatever does have a reason.
+
+  What to audit:
+
+  - [ ] **Exported types** — what they represent, what role they
+        play in the system, who constructs them, who consumes them
+  - [ ] **Exported fields** — what they contain, when they are set,
+        when they are consumed, what an empty/zero value means
+  - [ ] **Exported functions/methods** — what they do, when callers
+        should reach for them versus alternatives, what guarantees
+        they make
+  - [ ] **Recently added/changed surfaces especially** — fresh code
+        is where narrative drift sneaks in before review is cold
+  - [ ] **Cross-type lifecycle narratives** — when a field's role
+        only makes sense alongside fields on other types (a value
+        carried through Spec → Launch → Request, an override layered
+        across packages), per-field Godoc breaks down. The right
+        place is a `doc.go` or package comment that explains the
+        whole lifecycle in one place; per-field comments then
+        anchor to it instead of re-explaining the chain. The first
+        audit run flagged the tag layering across `Spec.Tags`,
+        `Launch.InitialTags`, `Request.InitialTags`, and
+        `Request.RuntimeTags` as the canonical example.
+
+  What this is *not*:
+
+  - Not a comment-density gate. Internal symbols and self-evident
+    getters need no commentary.
+  - Not "explain WHAT the code does" — well-named identifiers do
+    that. Explain WHY this exists and HOW it fits.
+  - Not a place to log historical decisions ("added for issue X",
+    "used by handler Y") — that belongs in PR descriptions and git
+    history, not in the source.
+- [ ] **Model-facing context audit**
+
+  Every output that becomes system prompt content, capability context,
+  delegate bootstrap context, tool output, summary scaffolding, or any
+  other loop input has a model as its audience. Audit new and altered
+  context-injection points against
+  [docs/model-facing-context.md](model-facing-context.md). Cognitive
+  clarity is expensive; typing is free.
+
+  Run the litmus questions on each new/altered surface:
+
+  - [ ] **What work is the model still being forced to do that Go
+        could do first?** Timestamp arithmetic, unit conversion,
+        schema inference, hidden-default recovery, scope inference
+        from vague names — none of these belong in the model's path
+        if Go can derive them. Pre-compute relationships, normalize
+        values, pre-join related fields.
+  - [ ] **Is this shape optimized for a model, or only for a human
+        maintainer?** Generated runtime state defaults to typed JSON,
+        not narrative prose. Markdown is for section boundaries,
+        brief framing notes, and normative instructions; structured
+        data is data.
+  - [ ] **Does this belong in always-on context, capability context,
+        a tool result, or nowhere at all?** Tag-scoped providers exist
+        for a reason — every block that lives in always-on context
+        thins what's left for the conversation.
+  - [ ] **If this data changes often, why is it static?** Live config,
+        active capabilities, recent tool activity, and external state
+        belong in dynamic providers, not in markdown files frozen at
+        build time.
+
+  Anti-patterns to grep for explicitly:
+
+  - [ ] Raw absolute timestamps in recency-sensitive context — use
+        the delta helpers in
+        [`internal/model/promptfmt/timefmt.go`](../internal/model/promptfmt/timefmt.go).
+  - [ ] Essay-style markdown rendering data that should be a compact
+        JSON projection.
+  - [ ] Field names, section names, or ordering drifting between calls
+        when stability would help the model compare turns; silent
+        truncation rather than an explicit truncation marker.
+  - [ ] Dumping raw upstream payloads where a smaller projection
+        would do.
+  - [ ] The same fact rendered in conflicting shapes across two
+        injection points.
+  - [ ] Instructions hiding inside what claims to be data, or runtime
+        data baked into prompt prose that should be a context provider.
+
+  Placement check:
+
+  - [ ] Assembly and section ordering live in `internal/runtime/agent`.
+  - [ ] Cross-domain time and recency helpers live in
+        `internal/state/awareness` and `internal/model/promptfmt`.
+  - [ ] Domain-to-view projection lives in the domain package as a
+        co-located `contextfmt` subpackage with clean exported entry
+        points. The canonical shape is
+        [`internal/integrations/homeassistant/contextfmt/`](../internal/integrations/homeassistant/contextfmt/) —
+        a small, domain-owned package whose exports (`Format`,
+        `SemanticState`, normalizers, etc.) are the only formatter
+        surface providers need to call. New formatters should look
+        like that, not be inlined into providers, runtime tools, or
+        ad-hoc helpers scattered across the consumer side.
+  - [ ] If formatter logic is being reimplemented inline at the
+        provider level — or duplicated across domain packages —
+        consolidate it into the domain's `contextfmt` package (or
+        promote a shared helper if it's genuinely cross-domain).
+- [ ] **Documentation audit**
+  - [ ] [README.md](../README.md) — accurate description of current capabilities
+  - [ ] [docs/understanding/](understanding/) — architecture, philosophy, design docs reflect actual implementation
+  - [ ] [docs/operating/](operating/) — getting started, integration, deployment guides reflect current reality
+  - [ ] [docs/reference/](reference/) — tools, CLI, API docs accurate
+  - [ ] [CONTRIBUTING.md](../CONTRIBUTING.md) — accurate for current development workflow
+- [ ] **Config review**
+  - [ ] [`examples/config.example.yaml`](../examples/config.example.yaml) regenerated and committed (`go generate ./internal/platform/config/...`)
+  - [ ] Stale config-owned tool lists removed where compiled defaults or MCP `default_tags` can own membership
+  - [ ] Document roots reviewed intentionally:
+    - [ ] `paths.core` for persona/ego/metacognitive and other high-integrity docs
+    - [ ] `paths.kb` for curated knowledge
+    - [ ] `paths.generated` for model-produced durable artifacts
+    - [ ] `paths.scratchpad` for low-integrity writable work
+  - [ ] `data_dir` kept separate from document roots
+- [ ] **Model and tooling review**
+  - [ ] Premium/ops/assist semantics still match operator expectations
+  - [ ] Dynamic model-registry overlays reviewed for any temporary canary-only policy changes
+  - [ ] MCP server configuration verifies the right tools will land in the intended tags/toolboxes
+- [ ] **Code surface hygiene**
+  - [ ] New code paths use inherited/component loggers, not ad-hoc `slog.Default()` where request or subsystem context matters
+
+## 2. Build readiness
+
+Tree is clean — verify it builds.
 
 - [ ] `just ci`
 - [ ] `just build`
 - [ ] `just release-build-snapshot <version>` for at least the primary operator target
-- [ ] Preferred operator path chosen up front:
+
+## 3. Cut artifacts
+
+Decide the operator path first; the rest follows from that choice.
+
+- [ ] Operator path chosen:
   - [ ] `just release-github <version> [auto|prerelease|release]` for a real published release
   - [ ] `just deploy-macos-pkg user@host` for live-host pkg testing without cutting a release
-- [ ] Generated files are committed, especially [`examples/config.example.yaml`](../examples/config.example.yaml)
-- [ ] New exported Go types/functions read cleanly in Go Doc form
-- [ ] Logs for new code paths use inherited/component loggers instead of ad hoc `slog.Default()` where request or subsystem context matters
-
-## Artifact Publication
-
 - [ ] `just release-github <version>` completes on the macOS Tahoe release workstation
 - [ ] Prepared release metadata matches the commit being published
 - [ ] Release tag created from a clean, up-to-date `main`
@@ -31,61 +196,52 @@ easy to roll back.
 - [ ] macOS installer packages inspect cleanly (`pkgutil --check-signature`, distribution metadata, current-user-home install domain, and architecture gating all match the intended release)
 - [ ] If a manual breakpoint was needed, `just prepare-release <version>` and `just publish-release <version> [auto|prerelease|release]` were used intentionally instead of by habit
 
-## Documentation Audit
+## 4. Post-deploy validation
 
-- [ ] **README.md** — Accurate description of current capabilities
-- [ ] **docs/understanding/** — Architecture, philosophy, and design docs reflect actual implementation
-- [ ] **docs/operating/** — Getting started, integration, and deployment guides reflect current reality
-- [ ] **docs/reference/** — Tools, CLI, and API docs accurate
-- [ ] **config.example.yaml** — Includes all current config options with documentation
-- [ ] **CONTRIBUTING.md** — Still accurate for current development workflow
+After the build lands on its target host. Verifies the release in situ
+and confirms rollback is real.
 
-## Config and Migration Review
+- [ ] **Pre-deploy operator hygiene**
+  - [ ] Existing production config backed up before swap
+  - [ ] Previous binary kept locally on the host so rollback is one move
+- [ ] **Live-build sanity**
+  - [ ] `/v1/version` reports the intended commit after restart
+  - [ ] `11434` exposes only the intended virtual model suite
+  - [ ] MCP servers needed in production start successfully and their tools land in the intended tags/toolboxes
+- [ ] **Canary smoke tests**
+  - [ ] One plain `8080` chat request succeeds
+  - [ ] One `11434` `thane:premium` request succeeds
+  - [ ] One tool-using request succeeds on the route operators actually use
+  - [ ] One Home Assistant request succeeds if HA is production-critical
+  - [ ] One scheduler/background loop completes after restart
+  - [ ] Dashboard, request viewer, and registry windows load cleanly enough for incident response
+  - [ ] If a live host was used for pkg validation, `just deploy-macos-pkg user@host` completed and the target Thane API reported the intended build version after restart
+- [ ] **Log review**
+  - [ ] Check recent `WARN`/`ERROR` output after restart
+  - [ ] Distinguish startup burst noise from steady-state regressions
+  - [ ] Remove or explain stale config warnings instead of normalizing them away
+  - [ ] Confirm request, loop, tool, and model fields are present on new operational log lines
+- [ ] **Rollback readiness**
+  - [ ] Restart path uses the real supervisor in production, not vestigial install-time service scripts
+  - [ ] Rollback steps are short enough to execute under pressure
 
-- [ ] Start from the repo example config instead of editing an old production file in place
-- [ ] Remove stale config-owned tool lists when compiled defaults or MCP `default_tags` can own membership instead
-- [ ] Review document roots intentionally:
-  - [ ] `paths.core` for persona/ego/metacognitive and other high-integrity docs
-  - [ ] `paths.kb` for curated knowledge
-  - [ ] `paths.generated` for model-produced durable artifacts
-  - [ ] `paths.scratchpad` for low-integrity writable work
-- [ ] Keep `data_dir` separate from document roots
-- [ ] Back up the existing production config and binary before swapping anything
-
-## Model and Tooling Sanity
-
-- [ ] `/v1/version` reports the intended commit after restart
-- [ ] `11434` exposes only the intended virtual model suite
-- [ ] The intended premium/ops/assist semantics still match operator expectations
-- [ ] Dynamic model-registry overlays are reviewed for any temporary canary-only policy changes
-- [ ] MCP servers needed in production start successfully and their tools land in the intended tags/toolboxes
-
-## Canary Smoke Tests
-
-- [ ] One plain `8080` chat request succeeds
-- [ ] One `11434` `thane:premium` request succeeds
-- [ ] One tool-using request succeeds on the route you actually expect operators to use
-- [ ] One Home Assistant request succeeds if HA is production-critical
-- [ ] One scheduler/background loop completes after restart
-- [ ] Dashboard, request viewer, and registry windows load cleanly enough for incident response
-- [ ] If a live host was used for pkg validation, `just deploy-macos-pkg user@host` completed and the target Thane API reported the intended build version after restart
-
-## Log Review
-
-- [ ] Check recent `WARN`/`ERROR` output after restart
-- [ ] Distinguish startup burst noise from steady-state regressions
-- [ ] Remove or explain stale config warnings instead of normalizing them away
-- [ ] Confirm request, loop, tool, and model fields are present on new operational log lines
-
-## Rollback Readiness
-
-- [ ] Previous binary is still available locally on the host
-- [ ] Previous config is backed up and easy to restore
-- [ ] Restart path uses the real supervisor in production, not vestigial install-time service scripts
-- [ ] Rollback steps are short enough to execute under pressure
-
-## Release Notes
+## 5. Communication
 
 - [ ] PR description summarizes the user-visible changes and operational implications
 - [ ] Known alpha/canary risks are written down explicitly
 - [ ] Follow-up cleanup items are split from release-blocking fixes
+- [ ] **GitHub release notes drafted on the release object itself**, not in a repo document.
+
+  Thane release notes are narrative. Pattern them after recent releases — [v0.9.1 — The Operational Hardening Release](https://github.com/nugget/thane-ai-agent/releases/tag/v0.9.1) is the current canonical example. The notes make a story out of the release and are explicit about the *whys* behind the features. They draw heavily from constituent PR descriptions and issue comments, because that's where the why actually got written down. They are *not* an autogenerated changelog with a marketing intro.
+
+  - [ ] **Title and theme.** Pick a center of gravity and name it: `vX.Y.Z — The {Theme} Release` (e.g. *Operational Hardening*, *Convergence*). State the theme in the title and reinforce it in the opening paragraph. If the release lacks a thematic backbone, that itself is signal — call it a maintenance bump and keep it short rather than inflating it.
+  - [ ] **Opening framing paragraph.** One to three sentences placing this release in the larger arc of the project. "v0.9.1 is the first release after the convergence work of v0.9.0; the architecture is no longer trying to become one thing — now it starts getting sharper, safer, and easier to operate as that one thing." sets context that a flat changelog cannot. Lift framing language from the PR descriptions and issue comments where the writers captured *why* in the moment.
+  - [ ] **Walk the merged PRs as source material.** Enumerate everything that landed since the previous tag — `git log --merges <prev_tag>..HEAD --oneline` or `gh pr list --base main --state merged --search "merged:>YYYY-MM-DD"`. For each non-trivial PR, read the description and any thoughtful comments. The release notes are a synthesis of that material, not a transcript. Linked issues often carry the *why* better than the PR title; follow those links and pull what's useful.
+  - [ ] **Group by operational story, not by code area.** Sections should be themes the operator will recognize (*Document Substrate*, *Anthropic Provider Hardening*, *Tool and Context Assembly*, *Scoped Awareness*) — not *Bug fixes* or *Internal refactors*. A bullet's home is wherever the user-facing implication makes most sense. Each section gets a short bolded lead phrase and a why-driven sentence or two.
+  - [ ] **Write each bullet around the why.** *"The tool suite assembles before capability tags are finalized"* is incomplete on its own. *"The tool suite now assembles before capability tags are finalized. `tools.Provider` gives subsystems a common declaration contract, while async runtimes such as Signal can declare tools early and bind handlers later. This fixes the `add_context_entity` missing-from-`awareness` bug and removes a whole class of startup-order drift."* is the bar. The reader should finish each bullet knowing both what changed and why it mattered enough to ship.
+  - [ ] **Cite inline.** Put `(#NNN)` at the end of each bullet, not as a separate "PRs included" footer. Use issue numbers when an issue captures the why better than the PR; use the PR number when the PR description carries the narrative; multiple references on one bullet are fine and common.
+  - [ ] **Diff stats line.** Include the diff stats for the release range — `git diff --shortstat <prev_tag>..<this_tag>` produces the wording. *"183 files changed, 18,265 insertions, 2,577 deletions."* The number doesn't justify the release on its own, but it gives operators a rough scale anchor.
+  - [ ] **Upgrade Notes section** when operators need to do or expect anything — config migration, schema change, behavior shift, deprecated path. Keep it short, concrete, numbered. This is the part operators read most carefully; it earns its space by being practical, not aspirational.
+  - [ ] **Known alpha/canary risks** that survived into the release belong here too, named plainly. If a feature is hardened-but-still-evolving, say so — operators trust the notes more when the notes admit limits.
+  - [ ] **Footer with full changelog link.** `**Full Changelog**: https://github.com/nugget/thane-ai-agent/compare/<prev_tag>...<this_tag>`.
+  - [ ] **Read it cold before publishing.** Notes written in PR-by-PR order while walking the log read that way. Close the source tabs, read the assembled notes start to finish, and ask: does the story hold? If a section is adjacent bullets without a thematic point, it needs an opener — or the bullets need to merge into one. If the framing paragraph promises a theme the bullets don't deliver, fix one of them.


### PR DESCRIPTION
## Summary

Reorganize [`docs/release-checklist.md`](docs/release-checklist.md) into five time-ordered phases that match how releases actually happen, and add three phase-1 audits — code-path, Godoc compliance, and model-facing context — that operationalize hard-earned lessons.

**This PR also serves as the first run of the new audit, with a parallel Codex crosscheck.** Findings, refinements, and amendments below.

## Why the reorder

The previous layout sandwiched the documentation audit, config review, and model/tooling sanity check **between** artifact publication and validation. That implied those were post-cut concerns. They aren't — fixing a stale doc or a redundant field after a binary ships is migration work; doing it before the cut is one PR.

The new order makes the dependency explicit: audits land first, while a fix is still cheap; assets get cut once the tree is clean; validation and communication happen against the live build.

## Phases

1. **Pre-release audits** — code-path, Godoc compliance, model-facing context, documentation, config, model/tooling
2. **Build readiness** — `just ci`, `just build`, snapshot
3. **Cut artifacts** — operator path, signing, notarization, publish
4. **Post-deploy validation** — pre-deploy hygiene, sanity, smoke, logs, rollback
5. **Communication** — release PR description, **expanded GitHub release-notes guidance** patterned after [v0.9.1](https://github.com/nugget/thane-ai-agent/releases/tag/v0.9.1) (narrative tone, story-shaped sections, why-driven bullets, inline citations, upgrade notes)

## The three new phase-1 audits

- **Code-path audit** — sweeps recent surfaces for redundant fields, parallel implementations, dead code paths.
- **Godoc compliance audit** — Godoc as a design check. Stand-alone test (each field's Godoc reads cleanly without sibling cross-references), why-it-exists test (Godoc explains *why*, not just *what*), and cross-type lifecycle narratives (when a field's role spans types, the right place is a `doc.go`, not per-field comments).
- **Model-facing context audit** — runs the four litmus questions from [`docs/model-facing-context.md`](docs/model-facing-context.md), greps for anti-patterns, and pins placement to the `internal/integrations/homeassistant/contextfmt/` convention.

## First-run audit findings (initial + Codex crosscheck)

All filed against milestone **v0.9.2**. Categorized by Codex's release-priority recommendation.

### Release-gating

| # | Finding |
|---|---|
| [#820](https://github.com/nugget/thane-ai-agent/issues/820) | **Delegate recursion leak.** Delegate registries exclude only `thane_delegate`, but `thane_now` and `thane_assign` are registered `AlwaysAvailable: true` and survive into delegate scope. A delegate can spawn another delegate via the new front doors. The recursion guard exists in name only. |
| [#816](https://github.com/nugget/thane-ai-agent/issues/816) | **Conversation history uses absolute RFC3339 timestamps in recency-sensitive context.** Should use `promptfmt.FormatDelta(Only)`. Direct hit on the model-facing audit's first litmus question. (Refined: rename the field to `age_delta`/`timestamp_delta`, not just change the value.) |

### Strongly recommended before release

| # | Finding |
|---|---|
| [#821](https://github.com/nugget/thane-ai-agent/issues/821) | **Weather forecast formatter silently caps entries at 3** with no `forecast_truncated` / `forecast_total_count` marker. Anti-pattern from the model-facing audit. |
| [#822](https://github.com/nugget/thane-ai-agent/issues/822) | **Weather forecast fetch failures are invisible to the model** — error is logged operator-side and the original state returned, so the model can't tell that requested forecast context just vanished. |

### Polish / can follow

| # | Finding |
|---|---|
| [#817](https://github.com/nugget/thane-ai-agent/issues/817) | Tag layering across `Spec.Tags` / `Launch.InitialTags` / `Request.InitialTags` / `Request.RuntimeTags` lacks a package-level narrative doc — the canonical example for the new "cross-type lifecycle narratives" Godoc bullet. |
| [#818](https://github.com/nugget/thane-ai-agent/issues/818) | MQTT wake legacy `initial_tags` migration code (post-#813) has no documented sunset criterion. (Refined: if kept, use a concrete version, not a vague TODO.) |
| [#819](https://github.com/nugget/thane-ai-agent/issues/819) | `channel_provider.TagContext` mixes markdown bullets with JSON for the same fact-type. (Refined: target shape is one markdown header + single JSON envelope holding `source`, `note`, `contact`.) |
| [#823](https://github.com/nugget/thane-ai-agent/issues/823) | `thane_curate` writes `created_at` frontmatter that bypasses `frontmatterDeltaFieldName` normalization (which only knows about `created` / `updated` / `generated_at`). Same family as #816. |
| [#824](https://github.com/nugget/thane-ai-agent/issues/824) | Delegation docs still lead with `thane_delegate` (deprecated) instead of `thane_now` / `thane_assign`. Affects `delegation.md`, `agent-loop.md`, `prompt-tool-pruning-strategy.md`, partial in `reference/tools.md`. |

Other audit results, kept brief:

- **Documentation audit**: clean for the recent collapse work — no stale references to removed fields. Stale delegation framing surfaced separately as [#824](https://github.com/nugget/thane-ai-agent/issues/824).
- **Config audit**: `examples/config.example.yaml` regenerates with no drift.
- **Code surface hygiene** (`slog.Default()` audit): all sites are constructor-level defensive defaults or `.With(subsystem=...)` wrappers — no bare-default calls in hot paths.
- **Code-path audit nitpicks** (not filed): single-callsite adapters (`composeProgressFuncs`, `Launch.requestOverride()`); `ExcludeTools`/`AllowedTools` merge asymmetry undocumented; `skipTagFilter` boolean derivation could be clearer. Worth flagging but below the bar for issues.

## Checklist amendments from the audit

The Godoc compliance section gained one bullet under "What to audit": **Cross-type lifecycle narratives** — when a field's role only makes sense alongside fields on other types, the right place to document is a `doc.go` or package comment, not per-field Godoc that recapitulates the chain. The tag-layering case ([#817](https://github.com/nugget/thane-ai-agent/issues/817)) is cited as the canonical example.

This was the audit's most valuable signal: not every Godoc finding wants a per-field rewrite — sometimes the lifecycle is the abstraction and needs documenting at that level.

The Codex crosscheck also validated that **a second audit pass catches things a single pass misses**. Five out of nine findings came from the parallel review. Worth considering whether the checklist should mention dual-audit as a practice for the larger releases, or whether that stays informal.

## Two judgment calls baked in (open to redirection)

- **Operator path choice** sits at the top of phase 3 rather than phase 1 — I think it's the trigger for cutting, not a planning step. Move it earlier if you'd rather treat it as a planning checkpoint.
- **Documentation audit stays on the release checklist** rather than moving to a separate dev-hygiene doc. Operators reaching for this checklist want the prompts even when the audit happened weeks earlier.

## Test plan

- [x] `just link-check` — internal markdown links valid
- [x] `just ci` — full gate green
- [x] First-run audit completed; substantive findings filed as #816–#819
- [x] Codex crosscheck applied; additional findings filed as #820–#824; all nine tagged for milestone **v0.9.2**
- [x] Refinement comments posted on #816, #818, #819 per crosscheck
- [x] Branch rebased on current main before audit (per the audit's own first step)
- [ ] Use this checklist on the v0.9.2 release and revise based on what actually happened