### PR TITLE
docs: tag lifecycle narrative + delegate-family doc cleanup

### DIFF
--- a/docs/prompt-tool-pruning-strategy.md
+++ b/docs/prompt-tool-pruning-strategy.md
@@ -194,8 +194,10 @@ The desired model posture is:
 - activate narrowly when blocked
 - activate one capability at a time
 - after activation, reassess before activating anything else
-- if the task clearly spans several domains, prefer `thane_delegate`
-  over serial capability churn
+- if the task clearly spans several domains, prefer `thane_now`
+  (sync) or `thane_assign` (async) over serial capability churn.
+  `thane_delegate` is a deprecated compatibility alias that routes to
+  one of these based on a `mode` parameter
 
 This is the opposite of a "browse and load everything" posture.
 

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -36,7 +36,9 @@ These tools load on every turn regardless of active tags.
 | `activate_lens` | Activate a persistent global behavioural lens. |
 | `deactivate_lens` | Deactivate a global behavioural lens. |
 | `list_lenses` | List currently active behavioural lenses. |
-| `thane_delegate` | Delegate a task to a cheaper/faster model via the delegate executor. |
+| `thane_now` | Synchronously delegate a bounded task and return the result inline. |
+| `thane_assign` | Assign a task to a sub-agent that runs in the background and reports back when complete. |
+| `thane_delegate` | DEPRECATED compatibility alias routing to `thane_now` (sync) or `thane_assign` (async) based on a `mode` parameter. |
 | `archive_search` | Full-text search across conversation archives. |
 | `archive_sessions` | Browse session archive metadata. |
 | `archive_session_transcript` | Retrieve a full session transcript. |
@@ -46,9 +48,11 @@ These tools load on every turn regardless of active tags.
 | `conversation_reset` | Reset the current conversation's message history. |
 | `send_notification` | Provider-agnostic fire-and-forget notification. |
 
-`thane_delegate` uses capability tags as its primary tool and context
-scope. It inherits elective caller tags by default so child work keeps
-the same task context; explicit `tags` override profile default tags.
+The delegate family (`thane_now`, `thane_assign`, and the deprecated
+`thane_delegate` alias) uses capability tags as its primary tool and
+context scope. Delegates inherit elective caller tags by default so
+child work keeps the same task context; explicit `tags` override
+profile default tags.
 Use root entry-point tags such as `development`, `home`, `operations`,
 `knowledge`, `media`, `interactive`, or `people` when the delegate should
 read the menu guidance and choose a narrower branch. Use leaf tags such

--- a/docs/understanding/agent-loop.md
+++ b/docs/understanding/agent-loop.md
@@ -150,10 +150,15 @@ capability_tags:
 ### Delegation Pressure
 
 When the orchestrator model starts with only ~15-20 tools (the always-active
-set), it naturally reaches for `thane_delegate` when it encounters a request
+set), it naturally reaches for the delegate family — `thane_now` for a
+synchronous answer it can fold into the current turn, or `thane_assign` for
+an async one-shot that reports back later — when it encounters a request
 that needs capabilities outside its active tags. This is delegation pressure
 by architecture, not instruction — the model delegates because it literally
-doesn't have the tools to do the work directly.
+doesn't have the tools to do the work directly. (`thane_delegate` is a
+deprecated compatibility alias routing to one or the other based on a
+`mode` parameter; new code should call `thane_now` / `thane_assign`
+directly.)
 
 The orchestrator can also activate tags explicitly when it wants direct
 access rather than delegation. The choice between "activate the tag and do

--- a/docs/understanding/delegation.md
+++ b/docs/understanding/delegation.md
@@ -42,10 +42,14 @@ When delegation is enabled (`delegation_required: true`), tools are
 partitioned:
 
 **Orchestrator sees:**
-- `thane_delegate` — delegate tasks to local models
+- `thane_now` — synchronous delegation; the orchestrator waits for the delegate's answer in this turn
+- `thane_assign` — async one-shot; the delegate runs in the background and reports back through the conversation/channel when complete
+- `thane_delegate` — DEPRECATED compatibility alias that routes to `thane_now` (sync) or `thane_assign` (async) based on a `mode` parameter; will be removed
 - `remember_fact` / `recall_fact` — memory operations
 - `session_working_memory` — session scratchpad
 - `archive_search` — conversation history search
+
+Pick by lifecycle: reach for `thane_now` when the orchestrator needs the result inline to continue reasoning, `thane_assign` when the work is fire-and-forget and a later message is acceptable.
 
 **Delegates see tools** through their capability tags:
 - HA-tagged native and MCP tools for device control or entity queries

--- a/internal/runtime/loop/doc.go
+++ b/internal/runtime/loop/doc.go
@@ -15,4 +15,87 @@
 // limits and coordinates graceful shutdown.
 //
 // See issue #509 for the full design.
+//
+// # Capability tag lifecycle
+//
+// Capability tags scope the tool surface, KB articles, talents, and
+// other context a loop iteration sees. The same conceptual value
+// flows through several fields at different stages of a loop's life.
+// They are not redundant — each represents a distinct point on the
+// lifecycle — but in isolation any one of them looks like it does
+// the same job as the others. This map exists so per-field Godoc can
+// stay short and reference here rather than re-explaining the chain.
+//
+//	Spec.Tags                    declarative, persisted with the spec
+//	     │
+//	     │  Spec.profileRequest()
+//	     ▼
+//	requestBase.InitialTags      base iteration tags
+//	     │
+//	     │  + Launch.InitialTags    per-invocation runtime override
+//	     │  + activatedTags         carried from prior iterations'
+//	     │                          Response.ActiveTags
+//	     ▼
+//	loop.Request.InitialTags     merged set per iteration
+//	     │
+//	     │  loopAdapter translates to agent.Request
+//	     ▼
+//	agent.Request.InitialTags    seed for the capability scope
+//	     │
+//	     │  scope.Request(tag) per tag
+//	     ▼
+//	scope.Snapshot()             active tags during the run
+//	     │
+//	     │  end-of-run capture
+//	     ▼
+//	agent.Response.ActiveTags    fed back into activatedTags
+//
+// Each layer in plain English:
+//
+//   - [Spec.Tags] is the spec-level declaration. Operators editing a
+//     loop definition set this field; it persists with the spec.
+//     Activated at iteration 0 of any run from this spec, and
+//     remains active through the loop's lifetime unless the model
+//     deactivates a tag mid-run.
+//
+//   - [Launch.InitialTags] is a per-invocation runtime override.
+//     Launchers that scope a particular run differently from the
+//     spec — the delegate executor, MQTT wake dispatch, programmatic
+//     spawners — set it here. Does not persist with the spec.
+//
+//   - [Request.InitialTags] (this package's [Request]) is the merged
+//     set the loop hands to its runner each iteration. The merge
+//     happens in the loop's request-build path and combines
+//     requestBase.InitialTags, requestOverride.InitialTags, and the
+//     loop's running activatedTags state.
+//
+//   - agent.Request.InitialTags receives the merged set across the
+//     loop/agent boundary and becomes the capability scope's seed.
+//     Lives in the [agent] package, not here.
+//
+//   - agent.Request.RuntimeTags is distinct from InitialTags despite
+//     the similar shape. RuntimeTags are trusted runtime-asserted
+//     tags the model cannot deactivate within the run; they're
+//     pinned via scope.PinChannelTags rather than scope.Request.
+//     Set by trusted callers (the Signal bridge pins
+//     "message_channel"). Use when a tag must remain active
+//     regardless of model behavior.
+//
+//   - agent.Response.ActiveTags is the end-of-run snapshot. The loop
+//     captures it into activatedTags for the next iteration's merge,
+//     which is how a tag activated mid-run by the model survives
+//     into iteration N+1.
+//
+//   - [Request.SkipTagFilter] (and the matching agent.Request field)
+//     bypass the scope filter entirely. Used by self-scoping
+//     contexts like the metacognitive loop. Empty Spec.Tags + a
+//     SkipTagFilter request together signal "this loop does not
+//     participate in tag filtering."
+//
+// When adding or modifying tag-related fields, anchor your work
+// against this map rather than re-explaining the chain in each
+// field's Godoc. If you find yourself writing "but if FieldB is also
+// set, this is ignored" or "see FieldC for the related case" in a
+// field comment, that's a sign the field belongs in this lifecycle
+// document instead.
 package loop


### PR DESCRIPTION
## Summary

Closes the two pure-docs items on milestone v0.9.2 with one focused commit each:

- **[#817](https://github.com/nugget/thane-ai-agent/issues/817)** — Tag lifecycle across `Spec.Tags` / `Launch.InitialTags` / `Request.InitialTags` / `Request.RuntimeTags` lacked a package-level narrative doc. Adds it to [`internal/runtime/loop/doc.go`](internal/runtime/loop/doc.go).
- **[#824](https://github.com/nugget/thane-ai-agent/issues/824)** — Several docs still led with `thane_delegate` as the canonical delegation tool, even though it's been deprecated in favor of `thane_now` / `thane_assign`. Four docs updated to lead with the family the orchestrator should actually call.

## Commits

### `488a46b docs(loop): document the capability tag lifecycle in the loop package doc`

Adds a "Capability tag lifecycle" section to the `loop` package doc that walks the same conceptual value through every layer it traverses:

```
Spec.Tags → requestBase.InitialTags → +Launch.InitialTags
   → +activatedTags → loop.Request.InitialTags
   → agent.Request.InitialTags → scope → Response.ActiveTags
   → activatedTags (next iter)
```

Each layer gets a one-paragraph explanation distinguishing its role: declarative spec scope, per-invocation override, per-iteration merge, agent-boundary seed, runtime-pinned tags (vs. user-asserted), end-of-run snapshot, and the `SkipTagFilter` bypass for self-scoping contexts like the metacognitive loop.

The closing note tells future contributors that "but if `FieldB` is also set, this is ignored" comments are a smell that belongs in this lifecycle doc instead of in per-field Godoc — directly operationalizing the "cross-type lifecycle narratives" bullet from the new release-checklist Godoc audit ([#815](https://github.com/nugget/thane-ai-agent/pull/815)).

### `fc67c5e docs(delegation): lead with thane_now and thane_assign, frame thane_delegate as deprecated`

Four docs updated to lead with the new delegate family, with `thane_delegate` consistently framed as the deprecated compatibility alias:

- [`docs/understanding/delegation.md`](docs/understanding/delegation.md) — orchestrator tool list now leads with `thane_now` (sync) and `thane_assign` (async one-shot), with a one-liner on how to pick by lifecycle. `thane_delegate` is explicitly marked DEPRECATED.
- [`docs/understanding/agent-loop.md`](docs/understanding/agent-loop.md) — the "Delegation Pressure" narrative no longer says the orchestrator "naturally reaches for `thane_delegate`"; it reaches for the family, with the deprecated alias mentioned in passing.
- [`docs/prompt-tool-pruning-strategy.md`](docs/prompt-tool-pruning-strategy.md) — cross-domain task recommendation now points at `thane_now` / `thane_assign` with the deprecated alias noted.
- [`docs/reference/tools.md`](docs/reference/tools.md) — always-available tool table now lists all three side-by-side; the trailing prose paragraph reconciled to match.

## Test plan

- [x] `just ci` — full gate green (no code changed)
- [x] `just link-check` — internal markdown links valid
- [x] One commit per issue with `Closes #NNN` trailer so each auto-closes on merge