### PR TITLE
refactor: drop MQTT legacy initial tags migration

### DIFF
--- a/internal/channels/mqtt/subscriptions.go
+++ b/internal/channels/mqtt/subscriptions.go
@@ -98,34 +98,17 @@ func (s *SubscriptionStore) loadRuntime() error {
 	}
 	defer rows.Close()
 
-	// Rows whose initial_tags_json is empty/default but whose seed_json
-	// still carries a legacy `initial_tags` key need a one-time write
-	// back so the migration is durable. Collect them and apply after
-	// the read iterator closes — sqlite doesn't love INSERT/UPDATE
-	// against the same connection while a SELECT cursor is open.
-	type pendingMigration struct {
-		id   string
-		tags []string
-	}
-	var pending []pendingMigration
-
 	for rows.Next() {
 		var ws WakeSubscription
 		var profileJSON, initialTagsJSON, createdAt string
 		if err := rows.Scan(&ws.ID, &ws.Topic, &profileJSON, &initialTagsJSON, &ws.Source, &createdAt); err != nil {
 			return err
 		}
-		// Pre-migration rows stored InitialTags inside the profile JSON.
-		// Hoist any legacy value out before unmarshaling so the field
-		// reaches its new home on WakeSubscription.
-		legacyTags := extractLegacyInitialTags(profileJSON)
-		ws.InitialTags = legacyTags
 		if err := json.Unmarshal([]byte(profileJSON), &ws.Profile); err != nil {
 			s.logger.Warn("skipping subscription with invalid profile JSON",
 				"id", ws.ID, "error", err)
 			continue
 		}
-		columnHasTags := false
 		if initialTagsJSON != "" {
 			var tags []string
 			if err := json.Unmarshal([]byte(initialTagsJSON), &tags); err != nil {
@@ -133,15 +116,7 @@ func (s *SubscriptionStore) loadRuntime() error {
 					"id", ws.ID, "error", err)
 			} else if len(tags) > 0 {
 				ws.InitialTags = tags
-				columnHasTags = true
 			}
-		}
-		// Schedule a write-back when we recovered tags from legacy
-		// seed_json but the new column is still at its default. After
-		// this runs once, subsequent loads find tags in the column and
-		// the legacy extraction becomes a no-op for that row.
-		if !columnHasTags && len(legacyTags) > 0 {
-			pending = append(pending, pendingMigration{id: ws.ID, tags: legacyTags})
 		}
 		ts, err := database.ParseTimestamp(createdAt)
 		if err != nil {
@@ -174,25 +149,6 @@ func (s *SubscriptionStore) loadRuntime() error {
 	}
 	if err := rows.Close(); err != nil {
 		return err
-	}
-
-	for _, p := range pending {
-		tagsJSON, err := json.Marshal(p.tags)
-		if err != nil {
-			s.logger.Warn("failed to marshal hoisted initial_tags, leaving row legacy",
-				"id", p.id, "error", err)
-			continue
-		}
-		if _, err := s.db.Exec(
-			`UPDATE mqtt_wake_subscriptions SET initial_tags_json = ? WHERE id = ?`,
-			string(tagsJSON), p.id,
-		); err != nil {
-			s.logger.Warn("failed to persist hoisted initial_tags, will retry next load",
-				"id", p.id, "error", err)
-			continue
-		}
-		s.logger.Info("migrated legacy seed_json initial_tags to initial_tags_json column",
-			"id", p.id, "tags", p.tags)
 	}
 
 	return nil
@@ -238,30 +194,6 @@ func (s *SubscriptionStore) LoadConfig(subs []config.SubscriptionConfig) error {
 		})
 	}
 	return nil
-}
-
-// extractLegacyInitialTags returns any "initial_tags" value embedded in
-// a pre-migration LoopProfile JSON blob. Pre-migration rows stored
-// InitialTags inside the profile object; the field has since moved onto
-// WakeSubscription, so during load we hoist any legacy value here.
-// Returns nil when the JSON is malformed or the field is absent.
-func extractLegacyInitialTags(profileJSON string) []string {
-	if profileJSON == "" {
-		return nil
-	}
-	var raw map[string]json.RawMessage
-	if err := json.Unmarshal([]byte(profileJSON), &raw); err != nil {
-		return nil
-	}
-	tagsRaw, ok := raw["initial_tags"]
-	if !ok {
-		return nil
-	}
-	var tags []string
-	if err := json.Unmarshal(tagsRaw, &tags); err != nil {
-		return nil
-	}
-	return tags
 }
 
 // SetSubscribeHook registers a callback that is invoked after a runtime

--- a/internal/channels/mqtt/subscriptions_test.go
+++ b/internal/channels/mqtt/subscriptions_test.go
@@ -255,67 +255,41 @@ func TestSubscriptionStorePersistence(t *testing.T) {
 	}
 }
 
-// TestSubscriptionStoreLegacyInitialTagsMigration verifies that rows
-// written by a pre-migration server (initial_tags embedded inside the
-// LoopProfile seed_json blob, no initial_tags_json column populated)
-// are hoisted onto WakeSubscription.InitialTags on first load AND
-// written back to the new column so the migration is durable.
-func TestSubscriptionStoreLegacyInitialTagsMigration(t *testing.T) {
+func TestSubscriptionStoreInitialTagsPersistence(t *testing.T) {
 	db, err := database.OpenMemory()
 	if err != nil {
 		t.Fatalf("open memory db: %v", err)
 	}
 	defer db.Close()
 
-	if _, err := NewSubscriptionStore(db, nil); err != nil {
-		t.Fatalf("new store (init schema): %v", err)
-	}
-
-	// Synthesize a pre-migration row: LoopProfile JSON includes the
-	// removed initial_tags field, and initial_tags_json is empty.
-	legacyJSON := `{"mission":"automation","initial_tags":["homeassistant","security"]}`
-	if _, err := db.Exec(
-		`INSERT INTO mqtt_wake_subscriptions (id, topic, seed_json, initial_tags_json, source, created_at) VALUES (?, ?, ?, ?, ?, ?)`,
-		"legacy-row", "legacy/topic", legacyJSON, "[]", "runtime", "2026-04-01T00:00:00Z",
-	); err != nil {
-		t.Fatalf("seed legacy row: %v", err)
-	}
-
-	// First load — hoists from seed_json, writes back to the column.
 	s1, err := NewSubscriptionStore(db, nil)
 	if err != nil {
-		t.Fatalf("first load: %v", err)
-	}
-	subs := s1.List()
-	if len(subs) != 1 {
-		t.Fatalf("first load len = %d, want 1", len(subs))
-	}
-	if got := subs[0].InitialTags; len(got) != 2 || got[0] != "homeassistant" || got[1] != "security" {
-		t.Fatalf("first-load InitialTags = %v, want [homeassistant security]", got)
+		t.Fatalf("new store 1: %v", err)
 	}
 
-	// Verify the write-back actually landed in the column.
+	ws, err := s1.Add("tagged/topic", router.LoopProfile{Mission: "automation"}, []string{"homeassistant", "security"})
+	if err != nil {
+		t.Fatalf("add: %v", err)
+	}
+
 	var stored string
-	if err := db.QueryRow(`SELECT initial_tags_json FROM mqtt_wake_subscriptions WHERE id = ?`, "legacy-row").Scan(&stored); err != nil {
-		t.Fatalf("select after migration: %v", err)
+	if err := db.QueryRow(`SELECT initial_tags_json FROM mqtt_wake_subscriptions WHERE id = ?`, ws.ID).Scan(&stored); err != nil {
+		t.Fatalf("select persisted tags: %v", err)
 	}
 	if stored != `["homeassistant","security"]` {
-		t.Fatalf("initial_tags_json after migration = %q, want JSON array", stored)
+		t.Fatalf("initial_tags_json = %q, want JSON array", stored)
 	}
 
-	// Second load — should read from the column directly. The legacy
-	// extractor would still fire (seed_json is unchanged), but the
-	// column wins and the result is identical.
 	s2, err := NewSubscriptionStore(db, nil)
 	if err != nil {
-		t.Fatalf("second load: %v", err)
+		t.Fatalf("new store 2: %v", err)
 	}
-	subs = s2.List()
+	subs := s2.List()
 	if len(subs) != 1 {
-		t.Fatalf("second load len = %d, want 1", len(subs))
+		t.Fatalf("after reload len = %d, want 1", len(subs))
 	}
 	if got := subs[0].InitialTags; len(got) != 2 || got[0] != "homeassistant" || got[1] != "security" {
-		t.Fatalf("second-load InitialTags = %v, want [homeassistant security]", got)
+		t.Fatalf("reloaded InitialTags = %v, want [homeassistant security]", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

Removes the one-time MQTT wake subscription migration that hoisted legacy `initial_tags` values from the embedded `seed_json` routing profile into the dedicated `initial_tags_json` column.

The production shape now treats `initial_tags_json` as the only persisted source of wake subscription capability tags. This keeps the loader simpler and removes a vestigial code path that had already served its purpose.

## Changes

- Deleted the legacy `seed_json` extraction and write-back path from runtime subscription loading.
- Removed the dedicated legacy migration helper.
- Replaced the legacy migration test with a current-shape persistence test that verifies runtime `InitialTags` are stored in `initial_tags_json` and reload correctly.

Closes #818.

## Validation

- `just ci`