### PR TITLE
fix(delegate): exclude the full thane_* family from delegate registries

### DIFF
--- a/internal/runtime/delegate/delegate.go
+++ b/internal/runtime/delegate/delegate.go
@@ -26,8 +26,19 @@ import (
 	"github.com/nugget/thane-ai-agent/internal/tools"
 )
 
-// delegateToolName is the tool name excluded from delegate registries to prevent recursion.
-const delegateToolName = "thane_delegate"
+// delegateFamilyToolNames are the tool names excluded from delegate
+// registries to prevent recursion. All members of the delegate family
+// must appear here: a delegate that can call any of them can spawn
+// another delegate, which is exactly the structural recursion the
+// exclusion is meant to prevent. The family currently includes the
+// deprecated thane_delegate alias plus its replacements thane_now
+// (sync) and thane_assign (async). When adding a new family member,
+// add its name here in the same change.
+var delegateFamilyToolNames = []string{
+	"thane_delegate",
+	"thane_now",
+	"thane_assign",
+}
 
 // Exhaustion reason constants are defined in the [iterate] package.
 // These aliases preserve backward compatibility for consumers that
@@ -155,9 +166,9 @@ func (e *Executor) delegateToolRegistry(scopeTags []string, explicitScopeRequest
 		} else {
 			reg = e.parentReg.FilteredCopy(nil)
 		}
-		return reg.FilteredCopyExcluding([]string{delegateToolName})
+		return reg.FilteredCopyExcluding(delegateFamilyToolNames)
 	}
-	return e.parentReg.FilteredCopyExcluding([]string{delegateToolName})
+	return e.parentReg.FilteredCopyExcluding(delegateFamilyToolNames)
 }
 
 func mergeTagLists(tagGroups ...[]string) []string {

--- a/internal/runtime/delegate/delegate_test.go
+++ b/internal/runtime/delegate/delegate_test.go
@@ -77,14 +77,20 @@ func newTestRegistry() *tools.Registry {
 			return "search results", nil
 		},
 	})
-	r.Register(&tools.Tool{
-		Name:        "thane_delegate",
-		Description: "Should be excluded",
-		Parameters:  map[string]any{},
-		Handler: func(_ context.Context, _ map[string]any) (string, error) {
-			return "this should never be called by a delegate", nil
-		},
-	})
+	// All three delegate-family tools are registered so tests can
+	// verify the full recursion guard, not just the deprecated alias.
+	// See #820 — thane_now and thane_assign were originally missed by
+	// the exclusion list.
+	for _, name := range []string{"thane_delegate", "thane_now", "thane_assign"} {
+		r.Register(&tools.Tool{
+			Name:        name,
+			Description: "delegate-family tool — should be excluded from delegate registries",
+			Parameters:  map[string]any{},
+			Handler: func(_ context.Context, _ map[string]any) (string, error) {
+				return "this should never be called by a delegate", nil
+			},
+		})
+	}
 	r.SetTagIndex(map[string][]string{
 		"ha":  {"get_state"},
 		"web": {"web_search"},
@@ -256,11 +262,54 @@ func TestExecute_LoopBackedExplicitEmptyTagsExposeNoTools(t *testing.T) {
 		t.Fatalf("execute() error = %v", err)
 	}
 
-	for _, want := range []string{"get_state", "web_search", "thane_delegate"} {
+	for _, want := range []string{"get_state", "web_search", "thane_delegate", "thane_now", "thane_assign"} {
 		if !containsString(captured.ExcludeTools, want) {
 			t.Fatalf("ExcludeTools = %#v, want %s", captured.ExcludeTools, want)
 		}
 	}
+}
+
+// TestDelegateToolRegistry_ExcludesFullDelegateFamily is the regression
+// test for #820. Delegate registries must exclude every member of the
+// thane_* family — thane_delegate (deprecated), thane_now, and
+// thane_assign — to prevent a delegate from spawning another delegate
+// via the new front doors. Both branches of delegateToolRegistry are
+// exercised: the tag-scoped branch (FilterByTags result) and the
+// fall-through branch (no scope).
+func TestDelegateToolRegistry_ExcludesFullDelegateFamily(t *testing.T) {
+	t.Parallel()
+
+	exec := NewExecutor(slog.Default(), nil, nil, newTestRegistry(), "spark/gpt-oss:20b")
+
+	familyNames := []string{"thane_delegate", "thane_now", "thane_assign"}
+
+	t.Run("tag-scoped branch", func(t *testing.T) {
+		reg := exec.delegateToolRegistry([]string{"web"}, false)
+		names := reg.AllToolNames()
+		for _, want := range familyNames {
+			if containsString(names, want) {
+				t.Errorf("tag-scoped delegate registry contains %q; full family must be excluded (registry: %v)", want, names)
+			}
+		}
+		// Sanity: the tag-matching tool should still be present.
+		if !containsString(names, "web_search") {
+			t.Errorf("tag-scoped delegate registry missing tag-matching tool web_search (registry: %v)", names)
+		}
+	})
+
+	t.Run("fall-through branch", func(t *testing.T) {
+		reg := exec.delegateToolRegistry(nil, false)
+		names := reg.AllToolNames()
+		for _, want := range familyNames {
+			if containsString(names, want) {
+				t.Errorf("fall-through delegate registry contains %q; full family must be excluded (registry: %v)", want, names)
+			}
+		}
+		// Sanity: non-family tools survive.
+		if !containsString(names, "get_state") {
+			t.Errorf("fall-through delegate registry missing non-family tool get_state (registry: %v)", names)
+		}
+	})
 }
 
 func TestExecute_LoopBackedExplicitEmptyTagsWithAlwaysActiveTagsDoNotBypassFiltering(t *testing.T) {

--- a/internal/runtime/delegate/delegate_test.go
+++ b/internal/runtime/delegate/delegate_test.go
@@ -77,11 +77,14 @@ func newTestRegistry() *tools.Registry {
 			return "search results", nil
 		},
 	})
-	// All three delegate-family tools are registered so tests can
-	// verify the full recursion guard, not just the deprecated alias.
-	// See #820 — thane_now and thane_assign were originally missed by
-	// the exclusion list.
-	for _, name := range []string{"thane_delegate", "thane_now", "thane_assign"} {
+	// All delegate-family tools are registered so tests can verify
+	// the full recursion guard, not just the deprecated alias. See
+	// #820 — thane_now and thane_assign were originally missed by
+	// the exclusion list. Iterating over the production
+	// delegateFamilyToolNames slice keeps fixture coverage in lock-step
+	// with the real exclusion list, so a future family addition
+	// automatically extends the test surface.
+	for _, name := range delegateFamilyToolNames {
 		r.Register(&tools.Tool{
 			Name:        name,
 			Description: "delegate-family tool — should be excluded from delegate registries",
@@ -262,7 +265,8 @@ func TestExecute_LoopBackedExplicitEmptyTagsExposeNoTools(t *testing.T) {
 		t.Fatalf("execute() error = %v", err)
 	}
 
-	for _, want := range []string{"get_state", "web_search", "thane_delegate", "thane_now", "thane_assign"} {
+	wantExcluded := append([]string{"get_state", "web_search"}, delegateFamilyToolNames...)
+	for _, want := range wantExcluded {
 		if !containsString(captured.ExcludeTools, want) {
 			t.Fatalf("ExcludeTools = %#v, want %s", captured.ExcludeTools, want)
 		}
@@ -281,12 +285,10 @@ func TestDelegateToolRegistry_ExcludesFullDelegateFamily(t *testing.T) {
 
 	exec := NewExecutor(slog.Default(), nil, nil, newTestRegistry(), "spark/gpt-oss:20b")
 
-	familyNames := []string{"thane_delegate", "thane_now", "thane_assign"}
-
 	t.Run("tag-scoped branch", func(t *testing.T) {
 		reg := exec.delegateToolRegistry([]string{"web"}, false)
 		names := reg.AllToolNames()
-		for _, want := range familyNames {
+		for _, want := range delegateFamilyToolNames {
 			if containsString(names, want) {
 				t.Errorf("tag-scoped delegate registry contains %q; full family must be excluded (registry: %v)", want, names)
 			}
@@ -300,7 +302,7 @@ func TestDelegateToolRegistry_ExcludesFullDelegateFamily(t *testing.T) {
 	t.Run("fall-through branch", func(t *testing.T) {
 		reg := exec.delegateToolRegistry(nil, false)
 		names := reg.AllToolNames()
-		for _, want := range familyNames {
+		for _, want := range delegateFamilyToolNames {
 			if containsString(names, want) {
 				t.Errorf("fall-through delegate registry contains %q; full family must be excluded (registry: %v)", want, names)
 			}


### PR DESCRIPTION
## Summary

Closes [#820](https://github.com/nugget/thane-ai-agent/issues/820). Delegate registries excluded only `thane_delegate`, the deprecated alias. Its successors `thane_now` (sync) and `thane_assign` (async) are registered `AlwaysAvailable` and so survived into delegate scope, leaving the recursion guard in name only — a delegate could spawn another delegate via either of the new front doors.

## What changed

Replaces the single-string const `delegateToolName` with the slice `delegateFamilyToolNames` covering all three names. Both branches of `delegateToolRegistry` now exclude the whole family:

```go
var delegateFamilyToolNames = []string{
    "thane_delegate",
    "thane_now",
    "thane_assign",
}
```

The slice's Godoc explicitly tells future contributors that any new family member must be added here in the same change — so the next time someone introduces (say) `thane_schedule`, the recursion guard doesn't silently regress.

## Tests

- **`newTestRegistry`** now registers all three family tools instead of only `thane_delegate`, so the existing fixture exercises the full guard.
- **`TestExecute_LoopBackedExplicitEmptyTagsExposeNoTools`** assertion extended: now asserts all three names appear in the request's `ExcludeTools` when an explicit empty tag scope is requested.
- **New `TestDelegateToolRegistry_ExcludesFullDelegateFamily`** exercises `delegateToolRegistry` directly with subtests for both its tag-scoped and fall-through branches. Asserts every family name is excluded and that non-family tools survive.

## Test plan

- [x] `just ci` — full gate green
- [x] Focused tests pass with the new invariant
- [ ] Spot-check on a live build that delegate runs no longer surface the family in their tool list (operator-side verification at deploy)

## Notes

This was the second of the two release-gating items on milestone v0.9.2. The other ([#816](https://github.com/nugget/thane-ai-agent/issues/816)) is independently in-flight as [#827](https://github.com/nugget/thane-ai-agent/pull/827); both can land in any order.