### PR TITLE
fix: normalize curated document timestamps

### DIFF
--- a/internal/state/documents/model_tool_results.go
+++ b/internal/state/documents/model_tool_results.go
@@ -1,6 +1,7 @@
 package documents
 
 import (
+	"sort"
 	"strings"
 	"time"
 
@@ -288,8 +289,18 @@ func modelFrontmatter(frontmatter map[string][]string, now time.Time) map[string
 		return nil
 	}
 	out := make(map[string][]string, len(frontmatter))
-	for key, values := range frontmatter {
+	keys := make([]string, 0, len(frontmatter))
+	for key := range frontmatter {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	for _, key := range keys {
+		values := frontmatter[key]
 		if deltaKey, ok := frontmatterDeltaFieldName(key); ok {
+			if _, exists := out[deltaKey]; exists {
+				continue
+			}
 			deltas := make([]string, 0, len(values))
 			for _, value := range values {
 				delta := modelDelta(value, now)
@@ -311,9 +322,9 @@ func modelFrontmatter(frontmatter map[string][]string, now time.Time) map[string
 
 func frontmatterDeltaFieldName(key string) (string, bool) {
 	switch strings.ToLower(strings.TrimSpace(key)) {
-	case "created":
+	case "created", "created_at":
 		return "created_delta", true
-	case "updated":
+	case "updated", "updated_at":
 		return "updated_delta", true
 	case GeneratedFieldAt:
 		return "generated_delta", true

--- a/internal/state/documents/tools_test.go
+++ b/internal/state/documents/tools_test.go
@@ -134,6 +134,67 @@ func TestModelFrontmatterSkipsUnparseableTimestampValues(t *testing.T) {
 	}
 }
 
+func TestModelFrontmatterNormalizesTimestampAliases(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 4, 29, 12, 0, 0, 0, time.UTC)
+	got := modelFrontmatter(map[string][]string{
+		"created_at":     {now.Add(-1 * time.Hour).Format(time.RFC3339)},
+		"updated_at":     {now.Add(-2 * time.Hour).Format(time.RFC3339)},
+		GeneratedFieldAt: {now.Add(-3 * time.Hour).Format(time.RFC3339)},
+	}, now)
+
+	tests := map[string]string{
+		"created_delta":   "-3600s",
+		"updated_delta":   "-7200s",
+		"generated_delta": "-10800s",
+	}
+	for key, want := range tests {
+		if values := got[key]; len(values) != 1 || values[0] != want {
+			t.Fatalf("%s = %#v, want [%s]", key, values, want)
+		}
+	}
+}
+
+func TestModelFrontmatterCanonicalTimestampWinsOverAlias(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 4, 29, 12, 0, 0, 0, time.UTC)
+	got := modelFrontmatter(map[string][]string{
+		"created":    {now.Add(-1 * time.Hour).Format(time.RFC3339)},
+		"created_at": {now.Add(-2 * time.Hour).Format(time.RFC3339)},
+	}, now)
+
+	if values := got["created_delta"]; len(values) != 1 || values[0] != "-3600s" {
+		t.Fatalf("created_delta = %#v, want canonical created value [-3600s]", values)
+	}
+}
+
+func TestFrontmatterDeltaFieldName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		key  string
+		want string
+		ok   bool
+	}{
+		{key: "created", want: "created_delta", ok: true},
+		{key: "created_at", want: "created_delta", ok: true},
+		{key: "updated", want: "updated_delta", ok: true},
+		{key: "updated_at", want: "updated_delta", ok: true},
+		{key: GeneratedFieldAt, want: "generated_delta", ok: true},
+		{key: "status", ok: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.key, func(t *testing.T) {
+			got, ok := frontmatterDeltaFieldName(tt.key)
+			if ok != tt.ok || got != tt.want {
+				t.Fatalf("frontmatterDeltaFieldName(%q) = %q, %v; want %q, %v", tt.key, got, ok, tt.want, tt.ok)
+			}
+		})
+	}
+}
+
 func assertModelOutputDeltaContract(t *testing.T, name, got string) {
 	t.Helper()
 

--- a/internal/tools/loop_intent_tools.go
+++ b/internal/tools/loop_intent_tools.go
@@ -216,7 +216,7 @@ func (r *Registry) handleThaneCurate(ctx context.Context, args map[string]any) (
 		"loop_intent":          {intent},
 		"output_mode":          {outputMode},
 		"cadence":              {cadenceInput},
-		"created_at":           {time.Now().UTC().Format(time.RFC3339)},
+		"created":              {time.Now().UTC().Format(time.RFC3339)},
 	}
 	docResult, err := deps.DocTools.Write(ctx, documents.WriteArgs{
 		Ref:         documentRef,

--- a/internal/tools/loop_intent_tools_test.go
+++ b/internal/tools/loop_intent_tools_test.go
@@ -228,6 +228,16 @@ func TestThaneCurate_EndToEnd(t *testing.T) {
 	if !strings.Contains(doc, "output_mode") {
 		t.Errorf("scaffold missing output_mode frontmatter:\n%s", doc)
 	}
+	rawDoc, err := os.ReadFile(filepath.Join(kbDir, "dashboards", "pr-watchlist.md"))
+	if err != nil {
+		t.Fatalf("read raw scaffold doc: %v", err)
+	}
+	if strings.Contains(string(rawDoc), "created_at:") {
+		t.Errorf("scaffold should use canonical created frontmatter, got created_at:\n%s", rawDoc)
+	}
+	if !strings.Contains(string(rawDoc), "created:") {
+		t.Errorf("scaffold missing canonical created frontmatter:\n%s", rawDoc)
+	}
 	if !strings.Contains(doc, "Current State") {
 		t.Errorf("maintain scaffold should include Current State heading:\n%s", doc)
 	}


### PR DESCRIPTION
## Summary

Fixes the `thane_curate` scaffold path so curated documents use the document subsystem's canonical `created` frontmatter key instead of adding a parallel `created_at` timestamp.

The document model projection also now treats legacy `created_at` and `updated_at` frontmatter as timestamp aliases, converting them to `created_delta` and `updated_delta` rather than surfacing raw RFC3339 values to the model. When both canonical and alias forms are present, the canonical field wins.

## Changes

- Updated `thane_curate` scaffold frontmatter to write `created`.
- Extended document model frontmatter normalization to cover `created_at` / `updated_at` aliases.
- Made timestamp alias handling deterministic so canonical keys win over legacy aliases.
- Added tests for alias normalization, canonical precedence, direct field-name mapping, and raw scaffold frontmatter.

Closes #823.

## Validation

- `just ci`