### PR TITLE
fix(weather): make the forecast surface honest about truncation and failures

### DIFF
--- a/internal/integrations/homeassistant/contextfmt/entity_format_weather.go
+++ b/internal/integrations/homeassistant/contextfmt/entity_format_weather.go
@@ -113,6 +113,17 @@ func formatWeather(state *homeassistant.State, now time.Time) string {
 		wc.ForecastUnavailable = true
 	}
 
+	// Short-circuit forecast rendering when the state is marked
+	// unavailable. Defense in depth alongside the source-side scrub
+	// in stateMarkedForecastUnavailable: even if an upstream path
+	// were to leave a forecast attribute next to the unavailable
+	// marker, the rendered JSON stays self-consistent — the model
+	// either gets a forecast array, or gets the unavailability
+	// marker, never both.
+	if wc.ForecastUnavailable {
+		return promptfmt.MarshalCompact(wc)
+	}
+
 	// Extract forecast entries (HA returns []any of map[string]any).
 	if rawForecast, ok := state.Attributes["forecast"].([]any); ok {
 		wc.ForecastTotalCount = len(rawForecast)

--- a/internal/integrations/homeassistant/contextfmt/entity_format_weather.go
+++ b/internal/integrations/homeassistant/contextfmt/entity_format_weather.go
@@ -47,6 +47,13 @@ type weatherContext struct {
 	// Pairs with ForecastTotalCount; the model can compute how many
 	// entries were dropped.
 	ForecastTruncated bool `json:"forecast_truncated,omitempty"`
+	// ForecastUnavailable is true when a forecast was requested for
+	// this entity but could not be retrieved (fetch error, empty
+	// result). Pairs with ForecastType: the model knows which
+	// forecast type was asked for and that it was not delivered, so
+	// it can avoid acting as though current conditions are the full
+	// picture.
+	ForecastUnavailable bool `json:"forecast_unavailable,omitempty"`
 }
 
 // weatherForecastRenderLimit caps the number of forecast entries
@@ -102,6 +109,9 @@ func formatWeather(state *homeassistant.State, now time.Time) string {
 		wc.Updated = promptfmt.FormatDeltaOnly(state.LastUpdated, now)
 	}
 	wc.ForecastType = attrString(state.Attributes, "forecast_type")
+	if unavailable, _ := state.Attributes["forecast_unavailable"].(bool); unavailable {
+		wc.ForecastUnavailable = true
+	}
 
 	// Extract forecast entries (HA returns []any of map[string]any).
 	if rawForecast, ok := state.Attributes["forecast"].([]any); ok {

--- a/internal/integrations/homeassistant/contextfmt/entity_format_weather.go
+++ b/internal/integrations/homeassistant/contextfmt/entity_format_weather.go
@@ -37,7 +37,23 @@ type weatherContext struct {
 	Updated       string            `json:"updated,omitempty"`
 	ForecastType  string            `json:"forecast_type,omitempty"`
 	Forecast      []weatherForecast `json:"forecast,omitempty"`
+	// ForecastTotalCount is the total number of forecast entries the
+	// upstream provider returned, before this formatter capped the
+	// rendered list. Surfaced so the model can tell a short forecast
+	// apart from a truncated long one. Zero is omitted.
+	ForecastTotalCount int `json:"forecast_total_count,omitempty"`
+	// ForecastTruncated is true when the rendered Forecast slice
+	// contains fewer entries than the upstream provider returned.
+	// Pairs with ForecastTotalCount; the model can compute how many
+	// entries were dropped.
+	ForecastTruncated bool `json:"forecast_truncated,omitempty"`
 }
+
+// weatherForecastRenderLimit caps the number of forecast entries
+// rendered into model-facing context. Forecasts longer than this are
+// truncated and the truncation is signaled via ForecastTruncated /
+// ForecastTotalCount; never silently dropped.
+const weatherForecastRenderLimit = 3
 
 // weatherForecast is a single forecast entry.
 type weatherForecast struct {
@@ -89,8 +105,11 @@ func formatWeather(state *homeassistant.State, now time.Time) string {
 
 	// Extract forecast entries (HA returns []any of map[string]any).
 	if rawForecast, ok := state.Attributes["forecast"].([]any); ok {
-		limit := 3
-		if len(rawForecast) < limit {
+		wc.ForecastTotalCount = len(rawForecast)
+		limit := weatherForecastRenderLimit
+		if len(rawForecast) > limit {
+			wc.ForecastTruncated = true
+		} else {
 			limit = len(rawForecast)
 		}
 		for i := 0; i < limit; i++ {

--- a/internal/state/awareness/entity_format_test.go
+++ b/internal/state/awareness/entity_format_test.go
@@ -159,6 +159,39 @@ func TestFormatWeather_TruncatedForecastSurfacesMarker(t *testing.T) {
 	}
 }
 
+func TestFormatWeather_ForecastUnavailableSurfacesMarker(t *testing.T) {
+	// State carrying the forecast_unavailable marker — set upstream by
+	// stateMarkedForecastUnavailable when fetch fails — should render
+	// the marker into model-facing JSON alongside the requested type.
+	state := &homeassistant.State{
+		EntityID:    "weather.home",
+		State:       "sunny",
+		LastChanged: testNow.Add(-60 * time.Second),
+		Attributes: map[string]any{
+			"temperature":          72.0,
+			"forecast_type":        "daily",
+			"forecast_unavailable": true,
+		},
+	}
+
+	result := formatEntityContext(state, testNow)
+
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(result), &parsed); err != nil {
+		t.Fatalf("invalid JSON: %v\nGot: %s", err, result)
+	}
+
+	if got := parsed["forecast_type"]; got != "daily" {
+		t.Errorf("forecast_type = %v, want daily", got)
+	}
+	if got := parsed["forecast_unavailable"]; got != true {
+		t.Errorf("forecast_unavailable = %v, want true", got)
+	}
+	if _, present := parsed["forecast"]; present {
+		t.Errorf("forecast array should be absent when forecast is unavailable, got %v", parsed["forecast"])
+	}
+}
+
 func TestFormatWeather_OpportunisticOptionalAttributes(t *testing.T) {
 	state := &homeassistant.State{
 		EntityID:    "weather.rooftop",

--- a/internal/state/awareness/entity_format_test.go
+++ b/internal/state/awareness/entity_format_test.go
@@ -106,6 +106,57 @@ func TestFormatWeather(t *testing.T) {
 	if dt, ok := fc0["dt"].(string); !ok || !strings.HasPrefix(dt, "+") {
 		t.Errorf("forecast dt should be positive delta, got %v", fc0["dt"])
 	}
+
+	// Forecast within the render limit: total count surfaced, truncated
+	// flag absent (omitempty for the false case).
+	if got := parsed["forecast_total_count"]; got != float64(2) {
+		t.Errorf("forecast_total_count = %v, want 2", got)
+	}
+	if _, present := parsed["forecast_truncated"]; present {
+		t.Errorf("forecast_truncated should be omitted when forecast fits the render limit, got %v", parsed["forecast_truncated"])
+	}
+}
+
+func TestFormatWeather_TruncatedForecastSurfacesMarker(t *testing.T) {
+	// Build a 7-entry forecast — well past the 3-entry render cap.
+	rawForecast := make([]any, 0, 7)
+	for i := 0; i < 7; i++ {
+		rawForecast = append(rawForecast, map[string]any{
+			"datetime":  testNow.Add(time.Duration(i+1) * 6 * time.Hour).Format(time.RFC3339),
+			"condition": "cloudy",
+		})
+	}
+
+	state := &homeassistant.State{
+		EntityID:    "weather.home",
+		State:       "sunny",
+		LastChanged: testNow.Add(-60 * time.Second),
+		Attributes: map[string]any{
+			"temperature": 72.0,
+			"forecast":    rawForecast,
+		},
+	}
+
+	result := formatEntityContext(state, testNow)
+
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(result), &parsed); err != nil {
+		t.Fatalf("invalid JSON: %v\nGot: %s", err, result)
+	}
+
+	forecast, ok := parsed["forecast"].([]any)
+	if !ok {
+		t.Fatal("missing forecast array")
+	}
+	if len(forecast) != 3 {
+		t.Errorf("rendered forecast len = %d, want 3 (cap)", len(forecast))
+	}
+	if got := parsed["forecast_total_count"]; got != float64(7) {
+		t.Errorf("forecast_total_count = %v, want 7", got)
+	}
+	if got := parsed["forecast_truncated"]; got != true {
+		t.Errorf("forecast_truncated = %v, want true", got)
+	}
 }
 
 func TestFormatWeather_OpportunisticOptionalAttributes(t *testing.T) {

--- a/internal/state/awareness/entity_format_test.go
+++ b/internal/state/awareness/entity_format_test.go
@@ -192,6 +192,53 @@ func TestFormatWeather_ForecastUnavailableSurfacesMarker(t *testing.T) {
 	}
 }
 
+func TestFormatWeather_ForecastUnavailableShortCircuitsRenderingEvenWithStaleForecastAttr(t *testing.T) {
+	// Defensive case: even if an upstream path were to leave a
+	// forecast array next to the unavailable marker (HA component
+	// quirks, race in state mutation, etc.), the formatter must keep
+	// the rendered JSON internally consistent — never report
+	// forecast_unavailable: true *and* a forecast array. This is the
+	// short-circuit defense that pairs with
+	// stateMarkedForecastUnavailable's source-side scrub.
+	state := &homeassistant.State{
+		EntityID:    "weather.home",
+		State:       "sunny",
+		LastChanged: testNow.Add(-60 * time.Second),
+		Attributes: map[string]any{
+			"temperature":          72.0,
+			"forecast_type":        "daily",
+			"forecast_unavailable": true,
+			"forecast": []any{
+				map[string]any{
+					"datetime":    testNow.Add(6 * time.Hour).Format(time.RFC3339),
+					"condition":   "stale",
+					"temperature": 99.0,
+				},
+			},
+		},
+	}
+
+	result := formatEntityContext(state, testNow)
+
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(result), &parsed); err != nil {
+		t.Fatalf("invalid JSON: %v\nGot: %s", err, result)
+	}
+
+	if got := parsed["forecast_unavailable"]; got != true {
+		t.Errorf("forecast_unavailable = %v, want true", got)
+	}
+	if _, present := parsed["forecast"]; present {
+		t.Errorf("forecast array must be absent when forecast_unavailable: true, got %v", parsed["forecast"])
+	}
+	if _, present := parsed["forecast_total_count"]; present {
+		t.Errorf("forecast_total_count must be absent when forecast_unavailable: true, got %v", parsed["forecast_total_count"])
+	}
+	if _, present := parsed["forecast_truncated"]; present {
+		t.Errorf("forecast_truncated must be absent when forecast_unavailable: true, got %v", parsed["forecast_truncated"])
+	}
+}
+
 func TestFormatWeather_OpportunisticOptionalAttributes(t *testing.T) {
 	state := &homeassistant.State{
 		EntityID:    "weather.rooftop",

--- a/internal/state/awareness/watchlist_provider.go
+++ b/internal/state/awareness/watchlist_provider.go
@@ -286,10 +286,19 @@ func stateWithWeatherForecast(ctx context.Context, ha StateGetter, state *homeas
 // forecast_type and forecast_unavailable attributes set so the
 // formatter can render an explicit unavailability marker for a
 // forecast that was requested but could not be returned.
+//
+// Any pre-existing "forecast" attribute on the source state is
+// dropped on the clone. Some HA components include a forecast array
+// on /api/states; without this scrub, the rendered context could
+// claim forecast_unavailable: true while still carrying a (probably
+// stale) forecast array, which would mislead the model.
 func stateMarkedForecastUnavailable(state *homeassistant.State, forecastType string) *homeassistant.State {
 	next := *state
 	attrs := make(map[string]any, len(state.Attributes)+2)
 	for key, value := range state.Attributes {
+		if key == "forecast" {
+			continue
+		}
 		attrs[key] = value
 	}
 	attrs["forecast_type"] = forecastType

--- a/internal/state/awareness/watchlist_provider.go
+++ b/internal/state/awareness/watchlist_provider.go
@@ -233,21 +233,38 @@ func watchlistStateWithForecast(
 		}
 		fields = append(fields, extraLogFields...)
 		logger.Warn(warnMsg, fields...)
-		return state
 	}
+	// next carries the unavailability marker on failure; the original
+	// behavior of "return state silently on error" hid the requested
+	// forecast from the model entirely. Always thread the marker-bearing
+	// state through so the formatter can surface the gap.
 	return next
 }
 
+// stateWithWeatherForecast returns a state with forecast attributes
+// reflecting the outcome of fetching forecastType from Home Assistant.
+//
+// Three cases:
+//
+//   - The request is not applicable (no forecast requested, non-weather
+//     entity, sentinel state): the original state is returned unchanged.
+//   - The fetch succeeds: a clone is returned with attrs["forecast"]
+//     and attrs["forecast_type"] set.
+//   - The fetch fails (non-nil err) or returns no entries: a clone is
+//     returned with attrs["forecast_type"] and
+//     attrs["forecast_unavailable"] set so the model-facing formatter
+//     can render an explicit "asked but missing" marker rather than
+//     silently presenting state without forecast.
 func stateWithWeatherForecast(ctx context.Context, ha StateGetter, state *homeassistant.State, forecastType string) (*homeassistant.State, error) {
 	if state == nil || forecastType == "" || entityDomain(state.EntityID) != "weather" || isSentinelState(state.State) {
 		return state, nil
 	}
 	forecast, err := ha.GetWeatherForecasts(ctx, state.EntityID, forecastType)
 	if err != nil {
-		return state, err
+		return stateMarkedForecastUnavailable(state, forecastType), err
 	}
 	if len(forecast) == 0 {
-		return state, nil
+		return stateMarkedForecastUnavailable(state, forecastType), nil
 	}
 
 	next := *state
@@ -263,4 +280,20 @@ func stateWithWeatherForecast(ctx context.Context, ha StateGetter, state *homeas
 	attrs["forecast_type"] = forecastType
 	next.Attributes = attrs
 	return &next, nil
+}
+
+// stateMarkedForecastUnavailable returns a clone of state with
+// forecast_type and forecast_unavailable attributes set so the
+// formatter can render an explicit unavailability marker for a
+// forecast that was requested but could not be returned.
+func stateMarkedForecastUnavailable(state *homeassistant.State, forecastType string) *homeassistant.State {
+	next := *state
+	attrs := make(map[string]any, len(state.Attributes)+2)
+	for key, value := range state.Attributes {
+		attrs[key] = value
+	}
+	attrs["forecast_type"] = forecastType
+	attrs["forecast_unavailable"] = true
+	next.Attributes = attrs
+	return &next
 }

--- a/internal/state/awareness/watchlist_provider_test.go
+++ b/internal/state/awareness/watchlist_provider_test.go
@@ -368,6 +368,60 @@ func TestProvider_IncludesWeatherForecastWhenSubscribed(t *testing.T) {
 	}
 }
 
+func TestProvider_ForecastFetchFailureSurfacesUnavailableMarker(t *testing.T) {
+	// When the forecast fetch errors, the model must see an explicit
+	// "asked but unavailable" marker — not silently fall back to current
+	// conditions only. Pre-fix, the failure was logged operator-side and
+	// the original state was returned, so the model couldn't tell the
+	// difference between an unsubscribed entity and one whose forecast
+	// just failed to load.
+	now := time.Now().UTC().Round(time.Second)
+	ha := &fakeHA{
+		states: map[string]*homeassistant.State{
+			"weather.home": {
+				EntityID:    "weather.home",
+				State:       "cloudy",
+				LastChanged: now.Add(-5 * time.Minute),
+				Attributes: map[string]any{
+					"friendly_name":    "Home Forecast",
+					"temperature":      70.0,
+					"temperature_unit": "°F",
+				},
+			},
+		},
+		forecastErr: errors.New("upstream 503"),
+	}
+
+	p, store := setupTestProvider(t, ha)
+	if err := store.AddWithOptions("weather.home", nil, nil, 0, "daily"); err != nil {
+		t.Fatalf("AddWithOptions: %v", err)
+	}
+
+	got, err := p.TagContext(context.Background(), agentctx.ContextRequest{UserMessage: ""})
+	if err != nil {
+		t.Fatalf("TagContext: %v", err)
+	}
+
+	if len(ha.forecastRequests) != 1 || ha.forecastRequests[0] != "weather.home:daily" {
+		t.Fatalf("forecastRequests = %v, want [weather.home:daily]", ha.forecastRequests)
+	}
+
+	payload := decodeWatchlistPayload(t, got)
+	if payload["forecast_type"] != "daily" {
+		t.Errorf("forecast_type = %#v, want daily (the requested type must remain visible to the model)", payload["forecast_type"])
+	}
+	if payload["forecast_unavailable"] != true {
+		t.Errorf("forecast_unavailable = %#v, want true", payload["forecast_unavailable"])
+	}
+	if _, present := payload["forecast"]; present {
+		t.Errorf("forecast array should be absent on fetch failure, got %v", payload["forecast"])
+	}
+	// Sanity: current-conditions data still passes through.
+	if payload["temperature"] != "70 °F" {
+		t.Errorf("temperature = %#v, want 70 °F (current conditions should still render)", payload["temperature"])
+	}
+}
+
 func TestProvider_IncludesDiscreteHistorySummaries(t *testing.T) {
 	now := time.Now().UTC().Round(time.Second)
 	ha := &fakeHA{

--- a/internal/state/awareness/watchlist_provider_test.go
+++ b/internal/state/awareness/watchlist_provider_test.go
@@ -422,6 +422,41 @@ func TestProvider_ForecastFetchFailureSurfacesUnavailableMarker(t *testing.T) {
 	}
 }
 
+func TestStateMarkedForecastUnavailable_ScrubsExistingForecastAttr(t *testing.T) {
+	// Some HA components emit a forecast array on /api/states even
+	// when a follow-up fetch fails. stateMarkedForecastUnavailable
+	// must drop that stale array on the marked clone so downstream
+	// formatters don't end up rendering both forecast_unavailable: true
+	// and a forecast list (the contradiction Copilot flagged on #830).
+	stale := []any{
+		map[string]any{"datetime": "2026-04-30T18:00:00Z", "condition": "stale"},
+	}
+	state := &homeassistant.State{
+		EntityID: "weather.home",
+		State:    "sunny",
+		Attributes: map[string]any{
+			"temperature": 72.0,
+			"forecast":    stale,
+		},
+	}
+
+	marked := stateMarkedForecastUnavailable(state, "daily")
+
+	if _, present := marked.Attributes["forecast"]; present {
+		t.Errorf("marked.Attributes still contains forecast = %#v; expected scrub", marked.Attributes["forecast"])
+	}
+	if got := marked.Attributes["forecast_type"]; got != "daily" {
+		t.Errorf("forecast_type = %#v, want daily", got)
+	}
+	if got := marked.Attributes["forecast_unavailable"]; got != true {
+		t.Errorf("forecast_unavailable = %#v, want true", got)
+	}
+	// Source state must remain untouched — the scrub is on the clone.
+	if _, present := state.Attributes["forecast"]; !present {
+		t.Errorf("source state.Attributes[\"forecast\"] should not be modified by the helper")
+	}
+}
+
 func TestProvider_IncludesDiscreteHistorySummaries(t *testing.T) {
 	now := time.Now().UTC().Round(time.Second)
 	ha := &fakeHA{


### PR DESCRIPTION
## Summary

Closes the two weather-forecast items on milestone v0.9.2 with one focused commit each. Both make the forecast context honest with the model rather than silently presenting partial information.

- **[#821](https://github.com/nugget/thane-ai-agent/issues/821)** — Forecast formatter silently caps entries at 3.
- **[#822](https://github.com/nugget/thane-ai-agent/issues/822)** — Forecast fetch failures invisible to the model.

## Commits

### `3713521 fix(weather): surface forecast truncation explicitly`

The 3-entry render cap stays — it's the right context-budget choice — but it's now signaled explicitly. `weatherContext` gains:

- `forecast_total_count` — total upstream entries before the cap.
- `forecast_truncated` — true when the rendered forecast contains fewer entries than upstream returned.

A loop subscribed to a daily forecast can now tell a 3-entry forecast apart from a 14-entry-truncated-to-3 one. The cap value moves into the named constant `weatherForecastRenderLimit` so future tuning touches one place. `omitempty` on both fields means the no-forecast case is unchanged in shape.

Direct hit on `docs/model-facing-context.md` — *"mark truncation explicitly instead of silently dropping context."*

### `beda399 fix(weather): surface forecast fetch failures to the model`

When `stateWithWeatherForecast` couldn't retrieve a requested forecast (upstream 5xx, transient HA outage, schema mismatch), the failure was logged operator-side and the original forecast-less state was returned. The model saw a normal weather entity with no indication that forecast had even been requested.

Threading the failure through:

- `stateWithWeatherForecast` on error or empty result returns a state clone with `attrs["forecast_type"]` (so the model knows which forecast was asked for) and `attrs["forecast_unavailable"] = true`. The error still propagates so callers keep logging.
- `watchlistStateWithForecast` no longer drops back to the original state on error; the marker-bearing state flows through to the formatter.
- New helper `stateMarkedForecastUnavailable` builds the marked clone in one place so both the error and empty-result paths stay consistent.
- `weatherContext.ForecastUnavailable` (json `"forecast_unavailable"`) renders the marker. Pairs with the existing `forecast_type`.

## Tests

- `TestFormatWeather` extended to assert `forecast_total_count = 2` and absence of `forecast_truncated` when forecast fits the cap.
- `TestFormatWeather_TruncatedForecastSurfacesMarker` (#821) — 7-entry input, asserts rendered length = 3, count = 7, truncated = true.
- `TestFormatWeather_ForecastUnavailableSurfacesMarker` (#822) — state with `forecast_unavailable: true` renders the marker plus forecast_type, no forecast array.
- `TestProvider_ForecastFetchFailureSurfacesUnavailableMarker` (#822) — end-to-end regression. fakeHA whose `GetWeatherForecasts` errors, exercised through the real watchlist provider; payload must contain `forecast_type`, `forecast_unavailable: true`, no forecast array, with current-conditions data still rendering normally.

## Test plan

- [x] `just ci` — full gate green
- [x] All `TestFormatWeather*` and `TestProvider_*Forecast*` tests pass
- [ ] Spot-check on a live build with a real HA instance: trigger a forecast fetch error (e.g. wrong forecast type) and confirm the rendered context shows `forecast_unavailable: true` rather than disappearing