### PR TITLE
fix: render channel context as JSON envelope

### DIFF
--- a/internal/runtime/agent/channel_provider.go
+++ b/internal/runtime/agent/channel_provider.go
@@ -2,10 +2,8 @@ package agent
 
 import (
 	"context"
-	"encoding/json"
-	"fmt"
-	"strings"
 
+	"github.com/nugget/thane-ai-agent/internal/model/promptfmt"
 	"github.com/nugget/thane-ai-agent/internal/runtime/agentctx"
 	"github.com/nugget/thane-ai-agent/internal/state/contacts"
 	"github.com/nugget/thane-ai-agent/internal/state/memory"
@@ -32,6 +30,12 @@ type ContactContext struct {
 	Channels        map[string]any   `json:"channels,omitempty"`
 	LastInteraction *InteractionRef  `json:"last_interaction,omitempty"`
 	ContactSince    string           `json:"contact_since,omitempty"`
+}
+
+type channelContextEnvelope struct {
+	Source  string          `json:"source"`
+	Note    string          `json:"note,omitempty"`
+	Contact *ContactContext `json:"contact"`
 }
 
 // TrustPolicyView is the JSON-serializable view of a trust zone's
@@ -174,27 +178,18 @@ func (p *ChannelProvider) TagContext(ctx context.Context, _ agentctx.ContextRequ
 		}
 	}
 
-	// Build output: markdown header + channel note + JSON contact block.
-	var sb strings.Builder
-	sb.WriteString("### Channel Context\n")
-	fmt.Fprintf(&sb, "- **Source:** %s\n", formatSourceName(source))
-	if channelNote != "" {
-		fmt.Fprintf(&sb, "- **Note:** %s\n", channelNote)
+	envelope := channelContextEnvelope{
+		Source:  source,
+		Note:    channelNote,
+		Contact: contactCtx,
+	}
+	payload := promptfmt.MarshalCompact(envelope)
+	if promptfmt.HasMarshalError(payload) {
+		envelope.Contact = contactContextWithoutChannels(contactCtx)
+		payload = promptfmt.MarshalCompact(envelope)
 	}
 
-	envelope := map[string]*ContactContext{"contact": contactCtx}
-	jsonBytes, err := json.Marshal(envelope)
-	if err != nil {
-		// Fall back to name-only if JSON fails (shouldn't happen).
-		fmt.Fprintf(&sb, "- **Participant:** %s\n", contactCtx.Name)
-		return sb.String(), nil
-	}
-
-	sb.WriteString("```json\n")
-	sb.Write(jsonBytes)
-	sb.WriteString("\n```\n")
-
-	return sb.String(), nil
+	return "### Channel Context\n\n" + payload + "\n", nil
 }
 
 func contactContextFromBinding(binding *memory.ChannelBinding, source string) *ContactContext {
@@ -237,16 +232,11 @@ func contactContextFromBinding(binding *memory.ChannelBinding, source string) *C
 	return ctx
 }
 
-// formatSourceName returns a human-readable channel name.
-func formatSourceName(source string) string {
-	switch source {
-	case "signal":
-		return "Signal"
-	case "matrix":
-		return "Matrix"
-	case "email":
-		return "Email"
-	default:
-		return source
+func contactContextWithoutChannels(contactCtx *ContactContext) *ContactContext {
+	if contactCtx == nil {
+		return nil
 	}
+	clone := *contactCtx
+	clone.Channels = nil
+	return &clone
 }

--- a/internal/runtime/agent/channel_provider_test.go
+++ b/internal/runtime/agent/channel_provider_test.go
@@ -44,26 +44,34 @@ func (m *mockContactLookup) LookupContactOriginPolicy(id, name, _ string) *Conta
 	return m.policies[name]
 }
 
-// parseContactJSON extracts the ContactContext from a channel context
-// output string by finding and parsing the JSON block.
-func parseContactJSON(t *testing.T, output string) *ContactContext {
-	t.Helper()
-	start := strings.Index(output, "```json\n")
-	if start < 0 {
-		t.Fatalf("no JSON block found in output:\n%s", output)
-	}
-	start += len("```json\n")
-	end := strings.Index(output[start:], "\n```")
-	if end < 0 {
-		t.Fatalf("unterminated JSON block in output:\n%s", output)
-	}
-	jsonStr := output[start : start+end]
+type parsedChannelContext struct {
+	Source  string          `json:"source"`
+	Note    string          `json:"note,omitempty"`
+	Contact *ContactContext `json:"contact"`
+}
 
-	var envelope struct {
-		Contact *ContactContext `json:"contact"`
+// parseChannelJSON extracts the channel context JSON envelope from output.
+func parseChannelJSON(t *testing.T, output string) parsedChannelContext {
+	t.Helper()
+	const header = "### Channel Context"
+	if !strings.HasPrefix(output, header) {
+		t.Fatalf("missing channel context header:\n%s", output)
 	}
+	jsonStr := strings.TrimSpace(strings.TrimPrefix(output, header))
+
+	var envelope parsedChannelContext
 	if err := json.Unmarshal([]byte(jsonStr), &envelope); err != nil {
 		t.Fatalf("failed to parse JSON: %v\n%s", err, jsonStr)
+	}
+	return envelope
+}
+
+// parseContactJSON extracts the ContactContext from a channel context output string.
+func parseContactJSON(t *testing.T, output string) *ContactContext {
+	t.Helper()
+	envelope := parseChannelJSON(t, output)
+	if envelope.Contact == nil {
+		t.Fatalf("contact missing from channel context:\n%s", output)
 	}
 	return envelope.Contact
 }
@@ -104,24 +112,34 @@ func TestChannelProvider_SignalKnownContact(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Check markdown framing.
+	// Check markdown framing and JSON envelope.
 	checks := []struct {
 		label string
 		want  string
 	}{
 		{"header", "### Channel Context"},
-		{"source", "Signal"},
 		{"channel note", "Terse input is normal"},
-		{"json block", "```json"},
 	}
 	for _, tt := range checks {
 		if !strings.Contains(got, tt.want) {
 			t.Errorf("%s: expected %q in output:\n%s", tt.label, tt.want, got)
 		}
 	}
+	for _, stale := range []string{"- **Source:**", "- **Note:**", "```json"} {
+		if strings.Contains(got, stale) {
+			t.Errorf("stale mixed-format marker %q in output:\n%s", stale, got)
+		}
+	}
 
 	// Check JSON content.
-	contact := parseContactJSON(t, got)
+	envelope := parseChannelJSON(t, got)
+	if envelope.Source != "signal" {
+		t.Errorf("source: got %q, want %q", envelope.Source, "signal")
+	}
+	if !strings.Contains(envelope.Note, "Terse input is normal") {
+		t.Errorf("note: got %q", envelope.Note)
+	}
+	contact := envelope.Contact
 	if contact.Name != "Nugget (David McNett)" {
 		t.Errorf("name: got %q, want %q", contact.Name, "Nugget (David McNett)")
 	}
@@ -525,6 +543,44 @@ func TestChannelProvider_JSONStructure(t *testing.T) {
 	}
 	if len(contact.Groups) != 1 || contact.Groups[0] != "family" {
 		t.Errorf("groups: got %v", contact.Groups)
+	}
+}
+
+func TestChannelProvider_JSONFallbackDropsUnmarshalableChannels(t *testing.T) {
+	lookup := &mockContactLookup{
+		contacts: map[string]*ContactContext{
+			"BadChannel": {
+				Name:      "Bad Channel",
+				TrustZone: "known",
+				TrustPolicy: &TrustPolicyView{
+					ToolAccess: "readonly",
+					SendGating: "blocked",
+				},
+				Channels: map[string]any{
+					"signal": func() {},
+				},
+			},
+		},
+	}
+	p := NewChannelProvider(lookup)
+	ctx := tools.WithHints(context.Background(), map[string]string{
+		"source":      "signal",
+		"sender_name": "BadChannel",
+	})
+
+	got, err := p.TagContext(ctx, agentctx.ContextRequest{UserMessage: "hello"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(got, "[json-marshal-error") {
+		t.Fatalf("channel context should recover to JSON envelope, got:\n%s", got)
+	}
+	contact := parseContactJSON(t, got)
+	if contact.Name != "Bad Channel" {
+		t.Fatalf("name = %q, want Bad Channel", contact.Name)
+	}
+	if contact.Channels != nil {
+		t.Fatalf("channels = %#v, want dropped fallback channels", contact.Channels)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Render channel context as one stable JSON envelope after the `### Channel Context` heading.
- Move `source`, channel `note`, and `contact` into that envelope instead of mixing markdown bullets with fenced JSON.
- Use the existing `promptfmt.MarshalCompact` helper, with a fallback that drops unmarshalable dynamic channel data while preserving the JSON envelope shape.

Closes #819

## Test plan
- [x] `just ci`