### PR TITLE
fix: keep live loop tag forensics in sync

### DIFF
--- a/internal/runtime/loop/loop.go
+++ b/internal/runtime/loop/loop.go
@@ -556,7 +556,7 @@ func (l *Loop) Status() Status {
 	// Call the active tags callback outside the lock to avoid
 	// lock-ordering issues with the agent loop's tagMu.
 	// Deep-copy the result so callers can't mutate internal state.
-	defaultLoadedTags := mergeUniqueStrings(requestBaseInitialTags, requestOverrideInitialTags, activatedTagsCopy)
+	defaultLoadedTags := mergeUniqueStrings(cfgCopy.Tags, requestBaseInitialTags, requestOverrideInitialTags, activatedTagsCopy)
 	if atFunc != nil {
 		if tags := atFunc(); len(tags) > 0 {
 			cp := make([]string, len(tags))
@@ -1336,7 +1336,8 @@ func (l *Loop) iterate(ctx context.Context, isSupervisor bool, convID string, si
 		conversationID = l.requestOverride.ConversationID
 	}
 
-	skipTagFilter := len(l.config.Tags) == 0 || l.requestOverride.SkipTagFilter
+	configuredInitialTags := mergeUniqueStrings(l.config.Tags, l.requestBase.InitialTags, l.requestOverride.InitialTags)
+	skipTagFilter := len(configuredInitialTags) == 0 || l.requestOverride.SkipTagFilter
 
 	req := Request{
 		Model:          firstNonEmpty(l.requestOverride.Model, l.requestBase.Model),
@@ -1351,7 +1352,7 @@ func (l *Loop) iterate(ctx context.Context, isSupervisor bool, convID string, si
 		SkipTagFilter:         skipTagFilter,
 		Hints:                 hints,
 		OnProgress:            composeProgressFuncs(l.makeProgressFunc(), l.requestOverride.OnProgress),
-		InitialTags:           mergeUniqueStrings(l.requestBase.InitialTags, l.requestOverride.InitialTags, l.activatedTags),
+		InitialTags:           mergeUniqueStrings(configuredInitialTags, l.activatedTags),
 		RuntimeTools:          cloneRuntimeTools(l.config.RuntimeTools),
 		FallbackContent:       firstNonEmpty(l.requestOverride.FallbackContent, l.requestBase.FallbackContent, l.config.FallbackContent),
 		MaxIterations:         l.requestOverride.MaxIterations,

--- a/internal/runtime/loop/loop_test.go
+++ b/internal/runtime/loop/loop_test.go
@@ -999,6 +999,84 @@ func TestNewFromSpecAppliesProfileToRequest(t *testing.T) {
 	}
 }
 
+func TestConfigTagsSeedRequestInitialTags(t *testing.T) {
+	t.Parallel()
+
+	var captured Request
+	var mu sync.Mutex
+	runner := &inspectingRunner{
+		onRun: func(req RunRequest) {
+			mu.Lock()
+			defer mu.Unlock()
+			captured = Request{
+				InitialTags:   append([]string(nil), req.InitialTags...),
+				SkipTagFilter: req.SkipTagFilter,
+			}
+		},
+	}
+
+	l, err := New(Config{
+		Name:         "config-tags",
+		Task:         "test",
+		Tags:         []string{"ha", "documents"},
+		SleepMin:     time.Millisecond,
+		SleepMax:     time.Millisecond,
+		SleepDefault: time.Millisecond,
+		Jitter:       Float64Ptr(0),
+		MaxIter:      1,
+	}, Deps{Runner: runner})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	if err := l.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	select {
+	case <-l.Done():
+	case <-time.After(5 * time.Second):
+		t.Fatal("loop did not finish")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if !slices.Contains(captured.InitialTags, "ha") || !slices.Contains(captured.InitialTags, "documents") {
+		t.Fatalf("InitialTags = %v, want ha and documents", captured.InitialTags)
+	}
+	if captured.SkipTagFilter {
+		t.Fatal("SkipTagFilter = true, want false when config tags define loop scope")
+	}
+}
+
+func TestStatusToolingIncludesConfiguredAndLaunchTags(t *testing.T) {
+	t.Parallel()
+
+	l, err := NewFromLaunch(Launch{
+		Spec: Spec{
+			Name:       "status-tags",
+			Task:       "test",
+			Operation:  OperationRequestReply,
+			Completion: CompletionReturn,
+			Tags:       []string{"ha"},
+		},
+		InitialTags: []string{"documents"},
+	}, Deps{Runner: &noopRunner{}})
+	if err != nil {
+		t.Fatalf("NewFromLaunch: %v", err)
+	}
+
+	status := l.Status()
+	if !slices.Contains(status.ActiveTags, "ha") || !slices.Contains(status.ActiveTags, "documents") {
+		t.Fatalf("ActiveTags = %v, want ha and documents before first iteration", status.ActiveTags)
+	}
+	if !slices.Contains(status.Tooling.ConfiguredTags, "ha") || !slices.Contains(status.Tooling.ConfiguredTags, "documents") {
+		t.Fatalf("Tooling.ConfiguredTags = %v, want ha and documents", status.Tooling.ConfiguredTags)
+	}
+	if !slices.Contains(status.Tooling.LoadedTags, "ha") || !slices.Contains(status.Tooling.LoadedTags, "documents") {
+		t.Fatalf("Tooling.LoadedTags = %v, want ha and documents", status.Tooling.LoadedTags)
+	}
+}
+
 func TestCurrentConvID(t *testing.T) {
 	t.Parallel()
 

--- a/internal/server/web/static/detail.js
+++ b/internal/server/web/static/detail.js
@@ -799,9 +799,18 @@ function renderLoopDetail() {
     loadedTags: loopData.active_tags || [],
     excludedTools: (loopData.config && loopData.config.ExcludeTools) || [],
   });
+  const latest = getLatestLoopSnapshot();
+  const latestTooling = normalizeTooling(latest && latest.tooling, {
+    configuredTags: baseTooling.configuredTags,
+    loadedTags: latest && latest.active_tags,
+    effectiveTools: latest && latest.effective_tools,
+    excludedTools: baseTooling.excludedTools,
+  });
   const currentTooling = (liveTooling.loadedTags.length > 0 || liveTooling.effectiveTools.length > 0 || liveTooling.loadedCapabilities.length > 0)
     ? liveTooling
-    : baseTooling;
+    : ((latestTooling.loadedTags.length > 0 || latestTooling.effectiveTools.length > 0 || latestTooling.loadedCapabilities.length > 0)
+      ? latestTooling
+      : baseTooling);
   const tagsSection = $('#detail-tags');
   const tagsList = $('#detail-tags-list');
   const groups = makeIterationScopePanel([


### PR DESCRIPTION
## Summary
- Tighten loop tag seeding so configured tags and launch-time initial tags both feed the request initial-tag set and pre-run status/tooling snapshots.
- Keep tag filtering enabled whenever a loop has a configured initial tag scope, instead of keying only on `Config.Tags`.
- Update the live loop forensics popup to fall back from live LLM tooling to the latest iteration tooling before falling back to base loop config, matching the main dashboard’s tooling model.

## Why
PR #813 made tag ownership clearer (`Spec.Tags`, `Launch.InitialTags`, `WakeSubscription.InitialTags`). This follow-up double-check keeps the WebUI’s live forensics representation aligned with that model, especially for loops whose most recent agent-run tags live on iteration tooling rather than the idle loop status.

## Test plan
- [x] `just ci`