### PR TITLE
fix(delegate): close recursion leak and surface child errors on joined launch

### DIFF
--- a/internal/runtime/delegate/delegate.go
+++ b/internal/runtime/delegate/delegate.go
@@ -520,7 +520,7 @@ func (e *Executor) executeViaLoop(ctx context.Context, task, profileName, guidan
 	e.finishLoopExecution(prep)
 	resp := launchResult.Response
 	if resp == nil {
-		return nil, fmt.Errorf("delegate failed: joined launch completed without response")
+		return nil, emptyResponseError(launchResult)
 	}
 
 	toolCallsMu.Lock()
@@ -747,8 +747,15 @@ func (e *Executor) prepareExecution(ctx context.Context, task, profileName, guid
 	var excludeTools []string
 	if explicitScopeRequested && len(filterTags) == 0 {
 		excludeTools = e.parentReg.AllToolNames()
-		sort.Strings(excludeTools)
 	}
+	// The delegate-family recursion guard must hold on every code
+	// path, not only the explicit-empty-scope branch above. The
+	// loop-backed launch rebuilds the catalog from the parent registry
+	// filtered by the launched loop's request, so the family has to be
+	// expressed as a request-level exclusion to survive that rebuild —
+	// the in-process delegateToolRegistry filter alone is not enough.
+	excludeTools = append(excludeTools, delegateFamilyToolNames...)
+	sort.Strings(excludeTools)
 	tagFilterActive := len(scopeTags) > 0 || explicitScopeRequested
 
 	log = log.With("profile", profile.Name)
@@ -889,4 +896,20 @@ func truncate(s string, maxLen int) string {
 		return s
 	}
 	return s[:maxLen] + "..."
+}
+
+// emptyResponseError builds the error returned to the parent when a
+// joined launch finishes without producing a Response. The naive form
+// — "joined launch completed without response" — is opaque: it doesn't
+// distinguish a transient timeout from a deterministic LLM-API
+// failure, so a parent retrying blind burns tokens for no diagnostic
+// gain. When the child loop captured a terminal error in its final
+// status (e.g. tool-call parse failures from local models, LLM-API
+// 5xx, exhausted retries), surface that string verbatim so the parent
+// can decide whether to retry, change strategy, or escalate.
+func emptyResponseError(launchResult looppkg.LaunchResult) error {
+	if launchResult.FinalStatus != nil && launchResult.FinalStatus.LastError != "" {
+		return fmt.Errorf("delegate failed: %s", launchResult.FinalStatus.LastError)
+	}
+	return fmt.Errorf("delegate failed: joined launch completed without response")
 }

--- a/internal/runtime/delegate/delegate.go
+++ b/internal/runtime/delegate/delegate.go
@@ -744,18 +744,21 @@ func (e *Executor) prepareExecution(ctx context.Context, task, profileName, guid
 	reg := e.delegateToolRegistry(scopeTags, explicitScopeRequested)
 	toolDefs := reg.List()
 	filterTags := mergeTagLists(scopeTags, e.alwaysActiveTags)
+	// The delegate-family recursion guard must hold on every code
+	// path. The loop-backed launch rebuilds the catalog from the
+	// parent registry filtered by the launched loop's request, so the
+	// family has to be expressed as a request-level exclusion to
+	// survive that rebuild — the in-process delegateToolRegistry
+	// filter alone is not enough.
+	//
+	// The explicit-empty-scope branch (AllToolNames) already includes
+	// the family names, so dedup before sorting to avoid duplicate
+	// entries when both sources contribute.
 	var excludeTools []string
 	if explicitScopeRequested && len(filterTags) == 0 {
 		excludeTools = e.parentReg.AllToolNames()
 	}
-	// The delegate-family recursion guard must hold on every code
-	// path, not only the explicit-empty-scope branch above. The
-	// loop-backed launch rebuilds the catalog from the parent registry
-	// filtered by the launched loop's request, so the family has to be
-	// expressed as a request-level exclusion to survive that rebuild —
-	// the in-process delegateToolRegistry filter alone is not enough.
-	excludeTools = append(excludeTools, delegateFamilyToolNames...)
-	sort.Strings(excludeTools)
+	excludeTools = mergeExcludeToolNames(excludeTools, delegateFamilyToolNames)
 	tagFilterActive := len(scopeTags) > 0 || explicitScopeRequested
 
 	log = log.With("profile", profile.Name)
@@ -898,6 +901,16 @@ func truncate(s string, maxLen int) string {
 	return s[:maxLen] + "..."
 }
 
+// childLastErrorMaxLen caps the size of a child loop's LastError
+// string when it's surfaced through emptyResponseError. The child
+// stores LastError as a raw err.Error() with no truncation, so a
+// runaway error (a full stack trace, an LLM body dump) could
+// otherwise inflate the parent's tool result and burn parent tokens.
+// 1024 is comfortably enough for the error shapes we've actually seen
+// in production (tool-call parse failures, API-5xx bodies) while
+// keeping a hard ceiling on pathological cases.
+const childLastErrorMaxLen = 1024
+
 // emptyResponseError builds the error returned to the parent when a
 // joined launch finishes without producing a Response. The naive form
 // — "joined launch completed without response" — is opaque: it doesn't
@@ -905,11 +918,41 @@ func truncate(s string, maxLen int) string {
 // failure, so a parent retrying blind burns tokens for no diagnostic
 // gain. When the child loop captured a terminal error in its final
 // status (e.g. tool-call parse failures from local models, LLM-API
-// 5xx, exhausted retries), surface that string verbatim so the parent
-// can decide whether to retry, change strategy, or escalate.
+// 5xx, exhausted retries), surface that string (truncated to
+// childLastErrorMaxLen) so the parent can decide whether to retry,
+// change strategy, or escalate.
 func emptyResponseError(launchResult looppkg.LaunchResult) error {
 	if launchResult.FinalStatus != nil && launchResult.FinalStatus.LastError != "" {
-		return fmt.Errorf("delegate failed: %s", launchResult.FinalStatus.LastError)
+		return fmt.Errorf("delegate failed: %s", truncate(launchResult.FinalStatus.LastError, childLastErrorMaxLen))
 	}
 	return fmt.Errorf("delegate failed: joined launch completed without response")
+}
+
+// mergeExcludeToolNames combines two tool-name slices into a sorted,
+// deduplicated slice. Used by the delegate launch path so the
+// AllToolNames-based wholesale exclusion (from the explicit-empty-
+// scope branch) and the always-applied delegateFamilyToolNames guard
+// don't produce duplicate entries when both contribute.
+func mergeExcludeToolNames(groups ...[]string) []string {
+	if len(groups) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{})
+	for _, group := range groups {
+		for _, name := range group {
+			if name == "" {
+				continue
+			}
+			seen[name] = struct{}{}
+		}
+	}
+	if len(seen) == 0 {
+		return nil
+	}
+	merged := make([]string, 0, len(seen))
+	for name := range seen {
+		merged = append(merged, name)
+	}
+	sort.Strings(merged)
+	return merged
 }

--- a/internal/runtime/delegate/delegate.go
+++ b/internal/runtime/delegate/delegate.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unicode/utf8"
 
 	"github.com/google/uuid"
 	"github.com/nugget/thane-ai-agent/internal/model/llm"
@@ -893,10 +894,14 @@ func formatTokens(n int) string {
 	return fmt.Sprintf("%.1fK", math.Round(float64(n)/100)/10)
 }
 
-// truncate shortens a string to maxLen characters, adding "..." if truncated.
+// truncate shortens a string to maxLen bytes without splitting a UTF-8
+// sequence, adding "..." if truncated.
 func truncate(s string, maxLen int) string {
 	if len(s) <= maxLen {
 		return s
+	}
+	for maxLen > 0 && !utf8.RuneStart(s[maxLen]) {
+		maxLen--
 	}
 	return s[:maxLen] + "..."
 }

--- a/internal/runtime/delegate/delegate_test.go
+++ b/internal/runtime/delegate/delegate_test.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	"github.com/nugget/thane-ai-agent/internal/model/llm"
 	"github.com/nugget/thane-ai-agent/internal/model/router"
@@ -459,26 +460,48 @@ func TestEmptyResponseError_PropagatesChildLastError(t *testing.T) {
 func TestEmptyResponseError_TruncatesOversizedLastError(t *testing.T) {
 	t.Parallel()
 
-	huge := strings.Repeat("x", childLastErrorMaxLen*4)
-	err := emptyResponseError(looppkg.LaunchResult{
-		FinalStatus: &looppkg.Status{LastError: huge},
-	})
-	if err == nil {
-		t.Fatal("emptyResponseError() = nil, want truncated error")
+	cases := []struct {
+		name string
+		huge string
+	}{
+		{
+			name: "ascii",
+			huge: strings.Repeat("x", childLastErrorMaxLen*4),
+		},
+		{
+			name: "utf8 boundary",
+			huge: strings.Repeat("€", childLastErrorMaxLen),
+		},
 	}
-	const prefix = "delegate failed: "
-	got := err.Error()
-	if !strings.HasPrefix(got, prefix) {
-		t.Fatalf("error = %q, want prefix %q", got, prefix)
-	}
-	// The body after the prefix is the truncated LastError, possibly
-	// with a "..." marker appended by truncate().
-	body := got[len(prefix):]
-	if len(body) > childLastErrorMaxLen+len("...") {
-		t.Fatalf("body length = %d, want <= %d (cap %d + ellipsis)", len(body), childLastErrorMaxLen+len("..."), childLastErrorMaxLen)
-	}
-	if !strings.HasSuffix(body, "...") {
-		t.Fatalf("body = %q, want truncation marker", body)
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := emptyResponseError(looppkg.LaunchResult{
+				FinalStatus: &looppkg.Status{LastError: tc.huge},
+			})
+			if err == nil {
+				t.Fatal("emptyResponseError() = nil, want truncated error")
+			}
+			const prefix = "delegate failed: "
+			got := err.Error()
+			if !strings.HasPrefix(got, prefix) {
+				t.Fatalf("error = %q, want prefix %q", got, prefix)
+			}
+			// The body after the prefix is the truncated LastError, possibly
+			// with a "..." marker appended by truncate().
+			body := got[len(prefix):]
+			if len(body) > childLastErrorMaxLen+len("...") {
+				t.Fatalf("body length = %d, want <= %d (cap %d + ellipsis)", len(body), childLastErrorMaxLen+len("..."), childLastErrorMaxLen)
+			}
+			if !utf8.ValidString(body) {
+				t.Fatalf("body is not valid UTF-8: %q", body)
+			}
+			if !strings.HasSuffix(body, "...") {
+				t.Fatalf("body = %q, want truncation marker", body)
+			}
+		})
 	}
 }
 

--- a/internal/runtime/delegate/delegate_test.go
+++ b/internal/runtime/delegate/delegate_test.go
@@ -450,6 +450,130 @@ func TestEmptyResponseError_PropagatesChildLastError(t *testing.T) {
 	}
 }
 
+// TestEmptyResponseError_TruncatesOversizedLastError ensures a child
+// loop's runaway LastError (e.g. a stack trace, a multi-KB response
+// body dump) is truncated before it becomes the parent's tool-call
+// result. Without this, a single misbehaving error could inflate
+// every subsequent parent prompt by however much the loop runtime
+// happened to capture.
+func TestEmptyResponseError_TruncatesOversizedLastError(t *testing.T) {
+	t.Parallel()
+
+	huge := strings.Repeat("x", childLastErrorMaxLen*4)
+	err := emptyResponseError(looppkg.LaunchResult{
+		FinalStatus: &looppkg.Status{LastError: huge},
+	})
+	if err == nil {
+		t.Fatal("emptyResponseError() = nil, want truncated error")
+	}
+	const prefix = "delegate failed: "
+	got := err.Error()
+	if !strings.HasPrefix(got, prefix) {
+		t.Fatalf("error = %q, want prefix %q", got, prefix)
+	}
+	// The body after the prefix is the truncated LastError, possibly
+	// with a "..." marker appended by truncate().
+	body := got[len(prefix):]
+	if len(body) > childLastErrorMaxLen+len("...") {
+		t.Fatalf("body length = %d, want <= %d (cap %d + ellipsis)", len(body), childLastErrorMaxLen+len("..."), childLastErrorMaxLen)
+	}
+	if !strings.HasSuffix(body, "...") {
+		t.Fatalf("body = %q, want truncation marker", body)
+	}
+}
+
+// TestMergeExcludeToolNames pins the dedup invariant for the
+// composed exclusion list. The launched-loop path always appends
+// delegateFamilyToolNames, and the explicit-empty-scope branch
+// independently sources AllToolNames (which already contains the
+// family). Both contributing without dedup produces noise; the
+// merge helper must collapse to a single sorted set.
+func TestMergeExcludeToolNames(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name   string
+		groups [][]string
+		want   []string
+	}{
+		{
+			name:   "empty input returns nil",
+			groups: nil,
+			want:   nil,
+		},
+		{
+			name:   "single group sorted and deduped",
+			groups: [][]string{{"b", "a", "b", ""}},
+			want:   []string{"a", "b"},
+		},
+		{
+			name: "overlapping groups dedup to a single sorted slice",
+			groups: [][]string{
+				{"get_state", "thane_now", "thane_assign"},
+				{"thane_delegate", "thane_now", "thane_assign"},
+			},
+			want: []string{"get_state", "thane_assign", "thane_delegate", "thane_now"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := mergeExcludeToolNames(tc.groups...)
+			if len(got) != len(tc.want) {
+				t.Fatalf("mergeExcludeToolNames() = %#v, want %#v", got, tc.want)
+			}
+			for i, name := range tc.want {
+				if got[i] != name {
+					t.Fatalf("mergeExcludeToolNames()[%d] = %q, want %q (got=%#v)", i, got[i], name, got)
+				}
+			}
+		})
+	}
+}
+
+// TestExecute_LoopBackedExplicitEmptyScopeNoDuplicateExcludes pins the
+// dedup contract through the actual launch path. When AllToolNames
+// (which contains the family) and delegateFamilyToolNames both
+// contribute, ExcludeTools must contain each family name exactly once.
+func TestExecute_LoopBackedExplicitEmptyScopeNoDuplicateExcludes(t *testing.T) {
+	t.Parallel()
+
+	var captured looppkg.Request
+	runner := &mockLoopRunner{
+		onRun: func(req looppkg.Request) {
+			captured = req
+		},
+		resp: &looppkg.Response{
+			Content: "delegate answer",
+			Model:   "deepslate/google/gemma-3-4b",
+		},
+	}
+
+	exec := NewExecutor(slog.Default(), nil, nil, newTestRegistry(), "spark/gpt-oss:20b")
+	exec.ConfigureLoopExecution(runner, looppkg.NewRegistry())
+
+	_, err := exec.execute(context.Background(), "No tools needed", "ha", "", []string{}, executionOptions{
+		inheritCallerTags: false,
+		explicitTagScope:  true,
+	})
+	if err != nil {
+		t.Fatalf("execute() error = %v", err)
+	}
+
+	for _, name := range delegateFamilyToolNames {
+		count := 0
+		for _, got := range captured.ExcludeTools {
+			if got == name {
+				count++
+			}
+		}
+		if count != 1 {
+			t.Fatalf("ExcludeTools = %#v contains %q %d times, want exactly 1 (recursion guard must dedup against AllToolNames)", captured.ExcludeTools, name, count)
+		}
+	}
+}
+
 func TestExecute_EmptyTask(t *testing.T) {
 	exec := NewExecutor(slog.Default(), &mockLLMClient{}, nil, newTestRegistry(), "test-model")
 	exec.ConfigureLoopExecution(&mockLoopRunner{}, looppkg.NewRegistry())

--- a/internal/runtime/delegate/delegate_test.go
+++ b/internal/runtime/delegate/delegate_test.go
@@ -273,6 +273,45 @@ func TestExecute_LoopBackedExplicitEmptyTagsExposeNoTools(t *testing.T) {
 	}
 }
 
+// TestExecute_LoopBackedTagScopedExcludesDelegateFamily exercises the
+// common delegate-launch path: caller specifies non-empty tags, so the
+// AllToolNames-based wholesale exclusion at the explicit-empty-scope
+// branch does not apply. This is the path the production failures
+// from 2026-04-30 traversed — three consecutive delegates whose
+// effective_tools log payloads still contained thane_now, thane_assign,
+// and thane_delegate. The recursion guard must extend through this
+// branch as well, not only the explicit-empty-scope one.
+func TestExecute_LoopBackedTagScopedExcludesDelegateFamily(t *testing.T) {
+	t.Parallel()
+
+	var captured looppkg.Request
+	runner := &mockLoopRunner{
+		onRun: func(req looppkg.Request) {
+			captured = req
+		},
+		resp: &looppkg.Response{
+			Content: "delegate answer",
+			Model:   "deepslate/google/gemma-3-4b",
+		},
+	}
+
+	exec := NewExecutor(slog.Default(), nil, nil, newTestRegistry(), "spark/gpt-oss:20b")
+	exec.ConfigureLoopExecution(runner, looppkg.NewRegistry())
+
+	_, err := exec.execute(context.Background(), "task", "ha", "", []string{"web"}, executionOptions{
+		explicitTagScope: true,
+	})
+	if err != nil {
+		t.Fatalf("execute() error = %v", err)
+	}
+
+	for _, want := range delegateFamilyToolNames {
+		if !containsString(captured.ExcludeTools, want) {
+			t.Fatalf("ExcludeTools = %#v, want %s — delegate-family recursion guard must hold on the tag-scoped path too", captured.ExcludeTools, want)
+		}
+	}
+}
+
 // TestDelegateToolRegistry_ExcludesFullDelegateFamily is the regression
 // test for #820. Delegate registries must exclude every member of the
 // thane_* family — thane_delegate (deprecated), thane_now, and
@@ -349,8 +388,65 @@ func TestExecute_LoopBackedExplicitEmptyTagsWithAlwaysActiveTagsDoNotBypassFilte
 	if containsString(captured.InitialTags, "ha") {
 		t.Fatalf("InitialTags = %#v, should not include ha profile default for explicit empty tag scope", captured.InitialTags)
 	}
-	if len(captured.ExcludeTools) != 0 {
-		t.Fatalf("ExcludeTools = %#v, want tag filtering through always-active tags", captured.ExcludeTools)
+	// ExcludeTools may carry the delegate-family recursion guard, but
+	// must not include any of the regular tag-gated tools — the
+	// always-active tags should expand the filter scope so tag-based
+	// filtering does the work via InitialTags, not via wholesale
+	// AllToolNames exclusion.
+	for _, got := range captured.ExcludeTools {
+		if !containsString(delegateFamilyToolNames, got) {
+			t.Fatalf("ExcludeTools = %#v, includes non-family tool %q — tag filtering should route through InitialTags", captured.ExcludeTools, got)
+		}
+	}
+}
+
+// TestEmptyResponseError_PropagatesChildLastError pins the error
+// surface for the case where a delegate's joined launch finishes
+// without a Response. Production failures on 2026-04-30 surfaced as
+// "delegate failed: joined launch completed without response" — a
+// generic message that hid the child loop's underlying tool-call
+// parse error from gpt-oss:120b. The parent had no way to decide
+// whether to retry or change strategy. With FinalStatus populated,
+// the helper must surface the child's LastError verbatim.
+func TestEmptyResponseError_PropagatesChildLastError(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name   string
+		result looppkg.LaunchResult
+		want   string
+	}{
+		{
+			name:   "no final status falls back to opaque message",
+			result: looppkg.LaunchResult{},
+			want:   "delegate failed: joined launch completed without response",
+		},
+		{
+			name: "final status with empty last error falls back to opaque message",
+			result: looppkg.LaunchResult{
+				FinalStatus: &looppkg.Status{LastError: ""},
+			},
+			want: "delegate failed: joined launch completed without response",
+		},
+		{
+			name: "final status with last error surfaces the child error verbatim",
+			result: looppkg.LaunchResult{
+				FinalStatus: &looppkg.Status{
+					LastError: `loop LLM call: API error 500: error parsing tool call: raw='{"account":"github":"primary"}'`,
+				},
+			},
+			want: `delegate failed: loop LLM call: API error 500: error parsing tool call: raw='{"account":"github":"primary"}'`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := emptyResponseError(tc.result)
+			if got == nil || got.Error() != tc.want {
+				t.Fatalf("emptyResponseError() = %v, want %q", got, tc.want)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

Two related delegate-runtime bugs that surfaced together in production on **2026-04-30 19:52–19:56 UTC**, when a signal-conversation parent fired three back-to-back `thane_now` delegates that each produced malformed JSON for `forge_pr_get` and died opaquely.

### Bug 1 — recursion guard missed the launched-loop catalog path

[#828](https://github.com/nugget/thane-ai-agent/pull/828) (`a0fb993`) patched `delegateToolRegistry` to exclude the full `delegateFamilyToolNames` slice, but the value that function returns is only used for model-routing sizing now that [`eebdf2c`](https://github.com/nugget/thane-ai-agent/commit/eebdf2c) retired `executeLegacy`. The catalog the launched loop actually runs with is built from `prep.excludeTools`, populated at [delegate.go:747-752](internal/runtime/delegate/delegate.go) **only** when `explicitTagScope` is true and `filterTags` is empty. In the common case (caller passes specific tags like `[\"development\"]`), `excludeTools` stays empty and `thane_now` / `thane_assign` / `thane_delegate` survive into the delegate's `effective_tools` — exactly what the production `loop_llm_start` payloads showed:

```
active_tags: [core, development, forge, owner]
effective_tools (count=35):
  ... forge_pr_get ...
  thane_assign
  thane_delegate
  thane_now
```

Fix: append `delegateFamilyToolNames` to `prep.excludeTools` on every code path. The recursion guard is now expressed as a request-level exclusion that survives the loop-side catalog rebuild. The existing `delegateToolRegistry` filter still applies to the in-process registry view used for routing; the new request-level filter handles the launched loop.

### Bug 2 — joined launches without a Response failed opaquely

When a child loop terminated without producing a `Response`, the parent saw only `delegate failed: joined launch completed without response` — indistinguishable from a transient timeout. Each retry burned parent tokens for an identical failure with no way to course-correct. `LaunchResult.FinalStatus` already carries the child loop's `LastError` (the actual `loop LLM call: API error 500: error parsing tool call: raw='...'` message in this case); surfacing it verbatim lets the parent decide whether to retry, change strategy, or escalate.

Extracted into `emptyResponseError()` so the dispatch logic is unit-testable.

## Tests

- `TestExecute_LoopBackedTagScopedExcludesDelegateFamily` — exercises the common path (non-empty tags) and asserts the family is in `Launch.ExcludeTools`. Fails on the unfixed code with `ExcludeTools = []string(nil)`.
- `TestExecute_LoopBackedExplicitEmptyTagsWithAlwaysActiveTagsDoNotBypassFiltering` — tightened to allow the family guard while still preventing wholesale exclusion of regular tools through `AllToolNames`.
- `TestEmptyResponseError_PropagatesChildLastError` — table test covering nil `FinalStatus`, empty `LastError`, and populated `LastError`.

## Test plan

- [x] `just ci` clean locally
- [x] Sandbox-validated: in a fresh dev workspace under `Sync/Projects/AI/Claude/dev-workspace`, three delegates spawned with `tags=[development]` all logged `effective_tools (count=9)` with **zero** family members present
- [ ] Production deploy — confirm next round of forge-tagged delegate work shows tighter catalogs in `loop_llm_start` payloads
- [ ] Production deploy — confirm any future delegate failure surfaces the underlying error string instead of the generic message

Closes #820 in full.