### PR TITLE
refactor(talents): backport prod-tuned content into embedded defaults

### DIFF
--- a/talents/awareness.md
+++ b/talents/awareness.md
@@ -39,3 +39,21 @@ When something catches your attention, a new entity, a pattern you don't recogni
 Do something with what you find. Add facts. Note patterns. Update memory. Each connection you make between things deepens your model of this world: the physical space, the people in it, how it all fits together.
 
 The situation shapes how much you explore. In the middle of a task, finish first. In a quiet moment, wander. Not every discovery needs to be shared. Some things are just for your own understanding. Use judgment about what's relevant to the moment and what's building toward something you don't need yet.
+
+## Tools
+
+Subscribing entities to your context is a service-loop reflex. Take
+what you need, release it when the work is done; the cost is light and
+the reward is sustained attention without re-querying.
+
+- `add_context_entity` — subscribe an entity or live provider so its
+  current state auto-loads into your context each turn. Use when this
+  loop or conversation will keep caring about the same surface.
+- `list_context_entities` — see what is already subscribed for this
+  scope.
+- `remove_context_entity` — drop a subscription when its work is done.
+  Carrying dead subscriptions is a quiet form of clutter.
+
+Single-shot loops can skip subscription and just query directly. The
+tools work there too, but the value mostly accrues when the same
+attention persists across multiple turns.

--- a/talents/awareness.md
+++ b/talents/awareness.md
@@ -46,9 +46,10 @@ Subscribing entities to your context is a service-loop reflex. Take
 what you need, release it when the work is done; the cost is light and
 the reward is sustained attention without re-querying.
 
-- `add_context_entity` — subscribe an entity or live provider so its
-  current state auto-loads into your context each turn. Use when this
-  loop or conversation will keep caring about the same surface.
+- `add_context_entity` — subscribe a Home Assistant entity by
+  `entity_id` so its current state auto-loads into your context each
+  turn. Use when this loop or conversation will keep caring about the
+  same surface.
 - `list_context_entities` — see what is already subscribed for this
   scope.
 - `remove_context_entity` — drop a subscription when its work is done.

--- a/talents/development-entry-point.md
+++ b/talents/development-entry-point.md
@@ -22,3 +22,11 @@ Once one surface starts giving you real state, stop menuing and work. If
 you can already feel that this spans repo state, local files, and local
 execution, delegate instead of turning the parent loop into an
 everything-at-once operator shell.
+
+## Workspace gotchas
+
+`file_read` is sandboxed to the configured workspace roots. Reaching
+for `/tmp` or other system paths through `file_read` will fail with a
+permission error. When you genuinely need to read outside the
+workspace (a system log, a temp file from a subprocess), use
+`exec(command="cat /path")` instead.

--- a/talents/forge-doctrine.md
+++ b/talents/forge-doctrine.md
@@ -15,3 +15,10 @@ Trust these instincts:
 - keep issue and PR writing grounded in the facts you actually fetched
 - delegate when repository work needs long-running local execution in
   addition to forge reads
+
+## Gotchas
+
+- `forge_issue_update`'s `body` REPLACES the entire description, it
+  does not append. If you only want to add a comment, use
+  `forge_issue_comment` instead. To append to the body, fetch the
+  current body first and write it back concatenated.

--- a/talents/ha-entry-point.md
+++ b/talents/ha-entry-point.md
@@ -1,0 +1,36 @@
+---
+kind: entry_point
+tags: [ha]
+---
+
+# HA Entry Point
+
+Home Assistant work is rarely truly single-shot. State drifts, devices
+report, automations fire — your understanding goes stale fast. Match
+the shape of the work to the right surface:
+
+- For one-off state checks, service calls, or registry lookups, the
+  tools loaded with `ha` are enough on their own.
+- For sustained attention — a service loop watching a room, a guardian
+  loop tracking a device, any conversation that wants entity state to
+  stay current between turns — activate `awareness` and subscribe the
+  entities you care about. Adding and dropping subscriptions should be
+  reflexive: take what you need, release it when the work is done.
+- If the next move is delivery, alerts, or interruption rather than
+  state, activate `notifications`.
+- If the operational issue is wake signals, MQTT plumbing, or scheduler
+  policy rather than HA state, rebound through `operations`.
+
+## Verifying device control
+
+`call_service` does not validate entity IDs — a typo or stale ID
+returns success and silently does nothing. Treat any control action as
+a three-step move:
+
+1. `find_entity` (or `mcp_home_assistant_ha_search_entities`) to confirm
+   the entity actually exists and grab its real ID.
+2. `call_service` (or the MCP equivalent) to perform the action.
+3. `get_state` afterwards to verify the new value really took.
+
+Never trust `call_service` success alone — for anything that matters,
+read the state back.

--- a/talents/ha-entry-point.md
+++ b/talents/ha-entry-point.md
@@ -27,7 +27,7 @@ the shape of the work to the right surface:
 returns success and silently does nothing. Treat any control action as
 a three-step move:
 
-1. `find_entity` (or `mcp_home_assistant_ha_search_entities`) to confirm
+1. `find_entity` (or the loaded MCP entity-search equivalent) to confirm
    the entity actually exists and grab its real ID.
 2. `call_service` (or the MCP equivalent) to perform the action.
 3. `get_state` afterwards to verify the new value really took.

--- a/talents/knowledge-entry-point.md
+++ b/talents/knowledge-entry-point.md
@@ -12,9 +12,9 @@ Choose the next move deliberately:
 
 - If the truth is already named in a local document, dossier, note, or
   semantic path, activate `files`.
-- If the truth probably lives somewhere in a managed local document
-  root, but the path has been lost or was never known, activate
-  `documents`.
+- If the truth lives in a structured document root—browsing, searching,
+  reading or editing sections of curated docs rather than raw workspace
+  files—activate `documents`.
 - If the truth is already named on the web, in a URL or page, activate
   `web`.
 - If the turn wants a distilled truth that should survive beyond this

--- a/talents/operations-entry-point.md
+++ b/talents/operations-entry-point.md
@@ -17,19 +17,19 @@ Choose the next move deliberately:
   `models`.
 - If the work is about scheduled tasks or timing policy, activate
   `scheduler`.
-- If you need live loop status, loop stops, ad hoc loop spawns, durable
-  loop definitions, loop policy, detached research that should report
-  back later, a one-shot signal to a sleeping service loop, or help
-  linting and authoring a reliable persistent service definition,
-  activate `loops`. That branch also carries concrete loop-launch
-  recipes and service-loop authoring guardrails when you need a
-  known-good pattern.
+- If you need loop definitions, loop policy, or loop launches, activate
+  `loops`.
 - If the operational question is really about session boundaries,
   resets, splits, checkpoints, or carry-forward, activate `session`.
 - If the work is MQTT plumbing or wake subscriptions, activate `mqtt`.
 - If the operational issue actually lives inside Home Assistant, its
   registries, or automations, activate `ha`.
-- If the surface is native platform integration, activate `platform`.
+- If this loop should keep watching specific entities, devices, or
+  live signals between turns rather than re-querying each time,
+  activate `awareness`. Adding and dropping subscriptions is reflexive
+  for service loops; single-shot loops can usually skip it.
+- If the surface is native companion app integration (calendar,
+  presence sensors, host-side tooling), activate `companion`.
 
 If several of these branches are clearly involved, delegate the
 investigation rather than opening them all and hoping the shape emerges


### PR DESCRIPTION
## Summary

Brings six talents from production back into the repo source. Direct edits to `/Volumes/Thane/talents/` accumulated real improvements (Tools sections, Gotchas, hard-won lessons) over months and never flowed back to `talents/` at the repo root. Every fresh `thane init` was deploying the worse version of these talents.

Per-file rationale lives in the commit message; the high-level shape:

| Talent | Diff | What prod added |
|--------|------|-----------------|
| `awareness.md` | +19 lines | `## Tools` section for `add_context_entity`/`list_context_entities`/`remove_context_entity` |
| `forge-doctrine.md` | +8 lines | `## Gotchas` warning that `forge_issue_update.body` replaces the description |
| `development-entry-point.md` | +9 lines | `## Workspace gotchas` about `file_read` sandboxing vs `exec(command="cat ...")` |
| `knowledge-entry-point.md` | wording | Sharper `documents` vs `files` activation guidance |
| `operations-entry-point.md` | restructure | Drops `platform` branch; adds `awareness` and `companion` branches |
| `ha-entry-point.md` | new file | Was wholly missing from embedded defaults despite being in every prod install |

## Out of scope (handled in [#836](https://github.com/nugget/thane-ai-agent/issues/836))

- The 3 talents present in defaults but missing from prod (`documents-knowledge.md`, `loops-doctrine.md`, `loops-examples.md`) — they're new additions that haven't propagated to the existing prod workspace because `cp -n` preserves missing files. Will deploy on next prod restart with a `cp` instead of `cp -n`, or a manual sync.
- The 6 prod-only `*-pocket-local.md` overlays — that's the host-specific overlay convention, deliberately not in defaults.
- Sustaining sync discipline + tooling — captured in [#836](https://github.com/nugget/thane-ai-agent/issues/836).

## Test plan

- [x] `go generate ./internal/model/talents/` regenerates the embedded artifact from `talents/`
- [x] `just ci` clean
- [ ] After merge: redeploy prod with `cp` (not `cp -n`) for the 5 backported files so prod and embedded match in both directions
- [ ] After merge: deploy `loops-doctrine.md`, `loops-examples.md`, `documents-knowledge.md` to prod (separate per-file decision)