### PR TITLE
refactor: remove deprecated thane_delegate compatibility shim

### DIFF
--- a/docs/prompt-tool-pruning-strategy.md
+++ b/docs/prompt-tool-pruning-strategy.md
@@ -195,9 +195,7 @@ The desired model posture is:
 - activate one capability at a time
 - after activation, reassess before activating anything else
 - if the task clearly spans several domains, prefer `thane_now`
-  (sync) or `thane_assign` (async) over serial capability churn.
-  `thane_delegate` is a deprecated compatibility alias that routes to
-  one of these based on a `mode` parameter
+  (sync) or `thane_assign` (async) over serial capability churn
 
 This is the opposite of a "browse and load everything" posture.
 

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -38,7 +38,6 @@ These tools load on every turn regardless of active tags.
 | `list_lenses` | List currently active behavioural lenses. |
 | `thane_now` | Synchronously delegate a bounded task and return the result inline. |
 | `thane_assign` | Assign a task to a sub-agent that runs in the background and reports back when complete. |
-| `thane_delegate` | DEPRECATED compatibility alias routing to `thane_now` (sync) or `thane_assign` (async) based on a `mode` parameter. |
 | `archive_search` | Full-text search across conversation archives. |
 | `archive_sessions` | Browse session archive metadata. |
 | `archive_session_transcript` | Retrieve a full session transcript. |
@@ -48,11 +47,10 @@ These tools load on every turn regardless of active tags.
 | `conversation_reset` | Reset the current conversation's message history. |
 | `send_notification` | Provider-agnostic fire-and-forget notification. |
 
-The delegate family (`thane_now`, `thane_assign`, and the deprecated
-`thane_delegate` alias) uses capability tags as its primary tool and
-context scope. Delegates inherit elective caller tags by default so
-child work keeps the same task context; explicit `tags` override
-profile default tags.
+The delegate family (`thane_now`, `thane_assign`) uses capability tags as
+its primary tool and context scope. Delegates inherit elective caller tags
+by default so child work keeps the same task context; explicit `tags`
+override profile default tags.
 Use root entry-point tags such as `development`, `home`, `operations`,
 `knowledge`, `media`, `interactive`, or `people` when the delegate should
 read the menu guidance and choose a narrower branch. Use leaf tags such
@@ -289,9 +287,8 @@ Task next-run values include a model-facing delta.
 ## `thane_*` family — intent-shaped front door for "do work"
 
 Always-available (`thane_now`, `thane_assign`) plus loops-tagged
-(`thane_curate`, `thane_wake`). Pick by lifecycle. `thane_delegate`
-and `notify_loop` remain as deprecated aliases that route into the
-family.
+(`thane_curate`, `thane_wake`). Pick by lifecycle. `notify_loop`
+remains as a deprecated alias that routes into the family.
 
 | Tool | Lifecycle | Description |
 |------|-----------|-------------|
@@ -300,8 +297,8 @@ family.
 | `thane_curate` | recurring | Scaffold a managed document and launch a recurring service loop that curates it (`journal` mode appends entries; `maintain` mode rewrites idempotently). |
 | `thane_wake` | poke existing | Send a one-shot message envelope to a live timer loop, waking it or queueing for the next iteration. |
 
-`thane_now`, `thane_assign`, and the deprecated `thane_delegate` alias
-accept `context_mode`. The default, `task`, gives the child run a compact
+`thane_now` and `thane_assign` accept `context_mode`. The default,
+`task`, gives the child run a compact
 task-worker prompt with active capabilities, tagged context, and current
 conditions, but without full Thane identity files, inject files,
 always-on talents, or conversation-history dressing. Use
@@ -329,7 +326,6 @@ supervisor-randomized metacog) where the canonical family doesn't fit.
 | `loop_definition_set_policy` | Update a loop definition's lifecycle policy. |
 | `loop_definition_summary` | Summary view across definitions. |
 | `notify_loop` | DEPRECATED alias for `thane_wake`. |
-| `thane_delegate` | DEPRECATED alias routing to `thane_now` (sync) or `thane_assign` (async). |
 
 ## `mqtt` — wake subscriptions
 

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -51,9 +51,9 @@ The delegate family (`thane_now`, `thane_assign`) uses capability tags as
 its primary tool and context scope. Delegates inherit elective caller tags
 by default so child work keeps the same task context; explicit `tags`
 override profile default tags.
-When the resulting scope includes `ha`, the executor uses HA-oriented
-budget and routing hints automatically; otherwise it uses the general
-delegate defaults.
+When the resulting scope includes `ha` or `ha_admin`, the executor uses
+HA-oriented budget and routing hints automatically; otherwise it uses the
+general delegate defaults.
 Use root entry-point tags such as `development`, `home`, `operations`,
 `knowledge`, `media`, `interactive`, or `people` when the delegate should
 read the menu guidance and choose a narrower branch. Use leaf tags such

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -51,6 +51,9 @@ The delegate family (`thane_now`, `thane_assign`) uses capability tags as
 its primary tool and context scope. Delegates inherit elective caller tags
 by default so child work keeps the same task context; explicit `tags`
 override profile default tags.
+When the resulting scope includes `ha`, the executor uses HA-oriented
+budget and routing hints automatically; otherwise it uses the general
+delegate defaults.
 Use root entry-point tags such as `development`, `home`, `operations`,
 `knowledge`, `media`, `interactive`, or `people` when the delegate should
 read the menu guidance and choose a narrower branch. Use leaf tags such

--- a/docs/understanding/agent-loop.md
+++ b/docs/understanding/agent-loop.md
@@ -155,10 +155,7 @@ synchronous answer it can fold into the current turn, or `thane_assign` for
 an async one-shot that reports back later — when it encounters a request
 that needs capabilities outside its active tags. This is delegation pressure
 by architecture, not instruction — the model delegates because it literally
-doesn't have the tools to do the work directly. (`thane_delegate` is a
-deprecated compatibility alias routing to one or the other based on a
-`mode` parameter; new code should call `thane_now` / `thane_assign`
-directly.)
+doesn't have the tools to do the work directly.
 
 The orchestrator can also activate tags explicitly when it wants direct
 access rather than delegation. The choice between "activate the tag and do

--- a/docs/understanding/delegation.md
+++ b/docs/understanding/delegation.md
@@ -131,11 +131,12 @@ determine the delegate's tool and tagged context scope.
 | Profile | Default Tags | Routing Bias | Use For |
 |---------|--------------|--------------|---------|
 | `general` | none | local, general purpose | Most tasks |
-| `ha` | `ha` when no explicit tags are supplied | local, device-control mission | HA-tagged delegations |
+| `ha` | `ha` when no explicit tags are supplied | local, device-control mission | HA-domain delegations |
 
 The model-facing tools do not expose a `profile` knob. When a delegate's
-scope includes the `ha` tag, the executor selects the `ha` profile's budget
-and routing hints automatically; otherwise it uses `general`.
+scope includes the `ha` or `ha_admin` tag, the executor selects the `ha`
+profile's budget and routing hints automatically; otherwise it uses
+`general`.
 
 Delegates inherit elective caller capability tags by default. This keeps
 task context such as activated domain tags or KB articles attached to

--- a/docs/understanding/delegation.md
+++ b/docs/understanding/delegation.md
@@ -44,7 +44,6 @@ partitioned:
 **Orchestrator sees:**
 - `thane_now` — synchronous delegation; the orchestrator waits for the delegate's answer in this turn
 - `thane_assign` — async one-shot; the delegate runs in the background and reports back through the conversation/channel when complete
-- `thane_delegate` — DEPRECATED compatibility alias that routes to `thane_now` (sync) or `thane_assign` (async) based on a `mode` parameter; will be removed
 - `remember_fact` / `recall_fact` — memory operations
 - `session_working_memory` — session scratchpad
 - `archive_search` — conversation history search

--- a/docs/understanding/delegation.md
+++ b/docs/understanding/delegation.md
@@ -131,7 +131,11 @@ determine the delegate's tool and tagged context scope.
 | Profile | Default Tags | Routing Bias | Use For |
 |---------|--------------|--------------|---------|
 | `general` | none | local, general purpose | Most tasks |
-| `ha` | `ha` when no explicit tags are supplied | local, device-control mission | Legacy HA delegations |
+| `ha` | `ha` when no explicit tags are supplied | local, device-control mission | HA-tagged delegations |
+
+The model-facing tools do not expose a `profile` knob. When a delegate's
+scope includes the `ha` tag, the executor selects the `ha` profile's budget
+and routing hints automatically; otherwise it uses `general`.
 
 Delegates inherit elective caller capability tags by default. This keeps
 task context such as activated domain tags or KB articles attached to

--- a/examples/config.example.yaml
+++ b/examples/config.example.yaml
@@ -408,18 +408,19 @@ talents_dir: ./talents
 # agent:
 #   OrchestratorTools lists tool names to advertise when
 #   DelegationRequired is true. If empty, a sensible default set
-#   is applied (thane_delegate plus lightweight memory tools).
+#   is applied (the thane_now / thane_assign delegation front
+#   doors plus lightweight memory tools).
 #   orchestrator_tools: []
 #   DelegationRequired enables orchestrator tool gating. When false
 #   (the default), all tools are available on every iteration.
 #   delegation_required: false
 #
-# (optional) Delegate configures the thane_delegate tool's split-model execution.
+# (optional) Delegate configures the thane_* delegation tools' split-model execution.
 # delegate:
 #   Profiles contains per-profile budget and timeout overrides. The map
-#   key is the compatibility profile name (e.g., "general", "ha"). Only
-#   fields that are set override the builtin defaults — omitted fields
-#   keep their compiled-in values.
+#   key is the profile name (e.g., "general", "ha"). Only fields that
+#   are set override the builtin defaults — omitted fields keep their
+#   compiled-in values.
 #   profiles:
 #     general:
 #       ToolTimeout is the maximum time a single tool call may run

--- a/internal/app/adapters.go
+++ b/internal/app/adapters.go
@@ -941,9 +941,9 @@ func (a *systemStatusAdapter) AnthropicRateLimitSnapshot() *fleet.AnthropicRateL
 // agent prompt/tooling layer, rendered with the supplied options. The
 // per-call options struct lets API consumers opt in to surfaces such
 // as operator-excluded tools without changing the underlying surface
-// snapshot. Callers that want thane_delegate in the activation tools
-// block must pass IncludeDelegate: true explicitly — the canonical
-// dashboard and /api/capabilities handlers already do.
+// snapshot. Callers that want the thane_* delegation tools in the
+// activation tools block must pass IncludeDelegate: true explicitly —
+// the canonical dashboard and /api/capabilities handlers already do.
 func (a *systemStatusAdapter) CapabilityCatalog(opts toolcatalog.CatalogViewOptions) *toolcatalog.CapabilityCatalogView {
 	surface := a.currentCapSurface()
 	if len(surface) == 0 {

--- a/internal/app/adapters.go
+++ b/internal/app/adapters.go
@@ -941,9 +941,10 @@ func (a *systemStatusAdapter) AnthropicRateLimitSnapshot() *fleet.AnthropicRateL
 // agent prompt/tooling layer, rendered with the supplied options. The
 // per-call options struct lets API consumers opt in to surfaces such
 // as operator-excluded tools without changing the underlying surface
-// snapshot. Callers that want the thane_* delegation tools in the
-// activation tools block must pass IncludeDelegate: true explicitly —
-// the canonical dashboard and /api/capabilities handlers already do.
+// snapshot. Callers that want the surfaced delegation front door
+// (currently `thane_now`) in the activation tools block must pass
+// IncludeDelegate: true explicitly — the canonical dashboard and
+// /api/capabilities handlers already do.
 func (a *systemStatusAdapter) CapabilityCatalog(opts toolcatalog.CatalogViewOptions) *toolcatalog.CapabilityCatalogView {
 	surface := a.currentCapSurface()
 	if len(surface) == 0 {

--- a/internal/app/new_delegation.go
+++ b/internal/app/new_delegation.go
@@ -25,8 +25,9 @@ func (a *App) initDelegation(s *newState) error {
 	logger := a.logger
 
 	// --- Delegation ---
-	// Register thane_delegate tool AFTER all other tools so the delegate
-	// executor's parent registry snapshot includes the full tool set.
+	// Register the thane_* delegation tools AFTER all other tools so
+	// the delegate executor's parent registry snapshot includes the
+	// full tool set.
 	delegateExec := delegate.NewExecutor(logger, a.llmClient, a.rtr, a.loop.Tools(), a.modelCatalog.DefaultModel)
 	conversationInjector := &conversationSystemInjector{mem: a.mem, archiver: a.archiveAdapter}
 	completionDispatcher := a.ensureLoopCompletionDispatcher()
@@ -51,10 +52,11 @@ func (a *App) initDelegation(s *newState) error {
 	if tfs := a.loop.Tools().TempFileStore(); tfs != nil {
 		delegateExec.SetTempFileStore(tfs)
 	}
-	// AlwaysAvailable on all three so they survive capability tag
-	// filtering (channel_tags, model-driven activate_capability). Without
-	// this, FilterByTags drops untagged tools when any tag is active and
-	// the model loses access to the recommended delegation surface.
+	// AlwaysAvailable on both family front doors so they survive
+	// capability tag filtering (channel_tags, model-driven
+	// activate_capability). Without this, FilterByTags drops untagged
+	// tools when any tag is active and the model loses access to the
+	// recommended delegation surface.
 	a.loop.Tools().Register(&tools.Tool{
 		Name:            "thane_now",
 		Description:     delegate.NowToolDescription,
@@ -67,13 +69,6 @@ func (a *App) initDelegation(s *newState) error {
 		Description:     delegate.AssignToolDescription,
 		Parameters:      delegate.AssignToolDefinition(),
 		Handler:         delegate.AssignToolHandler(delegateExec),
-		AlwaysAvailable: true,
-	})
-	a.loop.Tools().Register(&tools.Tool{
-		Name:            "thane_delegate",
-		Description:     delegate.ToolDescription,
-		Parameters:      delegate.ToolDefinition(),
-		Handler:         delegate.ToolHandler(delegateExec),
 		AlwaysAvailable: true,
 	})
 	a.delegateExec = delegateExec

--- a/internal/model/prompts/agent.go
+++ b/internal/model/prompts/agent.go
@@ -33,7 +33,7 @@ func RuntimeContract() string {
 		"- Treat capability activation as a coarse-to-fine menu. Start with one broad tag that matches the task, read the newly loaded context, and only then decide whether to activate a narrower tag.",
 		"- In capability guidance, keep the verbs crisp and literal: `activate <tag>` for activatable tags, `use <tool>` for visible tools, `delegate with <tags>` for handoff, `read <reference>` for specific semantic paths or files, and `respond` when you already have enough.",
 		"- Some capabilities mainly load guidance and recommended next tags. Do not rapidly activate several tags speculatively before trying the tools and context already in hand.",
-		"- Activating a capability changes runtime state, but it does not guarantee every tool in that capability is directly callable from the current top-level loop. If the tool you want is not currently available, use `thane_delegate` or choose another visible tool.",
+		"- Activating a capability changes runtime state, but it does not guarantee every tool in that capability is directly callable from the current top-level loop. If the tool you want is not currently available, use `thane_now` (sync) or `thane_assign` (async) to delegate, or choose another visible tool.",
 		"- Path-like references such as `kb:article.md`, `core:persona.md`, `scratchpad:note.md`, and `temp:label` are semantic references. Preserve them exactly. Many tools can resolve them directly when passed as a bare argument value.",
 		"- If a tool is unavailable in this context, do not retry with guessed names. Either pick an available tool, delegate, or answer directly.",
 	}, "\n")

--- a/internal/model/prompts/delegate.go
+++ b/internal/model/prompts/delegate.go
@@ -3,7 +3,7 @@ package prompts
 import "strings"
 
 // DelegateRunInstructions is the reusable execution contract for spawned
-// delegate loops and the legacy delegate runner.
+// delegate loops.
 const DelegateRunInstructions = `Complete the assigned task using the available tools. Report findings clearly and concisely.
 
 Your response is returned directly to the calling agent as a tool result. If you called tools and received data, include the relevant data in your final text response. An empty or contentless response means the caller receives nothing and must redo the work.`
@@ -31,33 +31,3 @@ func DelegateRuntimeContract() string {
 		"- Return a non-empty final answer that includes the relevant data from any tool results you used.",
 	}, "\n")
 }
-
-// DelegateToolDescription is the LLM-facing description for the thane_delegate tool.
-const DelegateToolDescription = `Delegate a concrete task to a smaller, cheaper model for execution. The delegate has access to tools and can iterate, but by default operates without your conversation history or personality.
-
-Delegates are for EXECUTION, not analysis. You handle reasoning, judgment, and synthesis — the delegate handles tool-heavy legwork.
-
-Delegate limits: 15 tool-calling iterations, 90 seconds wall clock, 25K output tokens. Whichever is hit first triggers termination.
-
-GOOD delegate tasks (concrete, tool-heavy):
-- "Check which lights are on in the office" (device queries)
-- "Turn off all lights except the bedroom" (bulk operations)
-- "Get temperature readings from every room sensor" (data gathering)
-- "Search for files matching *.log in /var/log" (filesystem tasks)
-- "Find the entity ID for the garage door" (lookups)
-
-BAD delegate tasks (keep these yourself):
-- "Analyze these results and decide what to do next" (requires judgment)
-- "Summarize the conversation so far" (requires context)
-- "Should I turn off the lights?" (requires user intent reasoning)
-- A single quick tool call (delegation overhead not worth it)
-
-Use the guidance field to steer execution: provide entity names, file paths, specific focus areas, or output format preferences. More specific guidance means fewer wasted iterations.
-
-Use tags to scope the delegate's capability surface. Use a root entry-point tag like development, home, operations, knowledge, media, interactive, or people when the delegate should read the menu guidance and decide which narrower toolset to activate. Use leaf tags like ha, files, forge, web, loops, documents, or diagnostics when you already know the exact surface needed.
-
-Delegates inherit the caller's elective capability tags by default. Set inherit_caller_tags=false only when you need a strict, fresh tool scope.
-
-Delegates use context_mode="task" by default: compact task-worker prompt, active capability summaries, tagged context, and current conditions, without full Thane identity files or conversation continuity. Use context_mode="full" only when the delegate truly needs full persona, ego, injected core context, always-on talents, and conversation-history dressing.
-
-Use mode="async" when you want the delegate to keep running in the background and report the result back into the current conversation later instead of blocking for a direct reply.`

--- a/internal/model/router/virtual_models.go
+++ b/internal/model/router/virtual_models.go
@@ -28,8 +28,9 @@ type VirtualModelRuntime struct {
 // virtual model names such as "thane:premium".
 //
 // TopLevel controls the initial orchestrator loop. Delegate controls child
-// loops launched via thane_delegate. Future revisions may also derive these
-// policies dynamically from the live registry without changing callers.
+// loops launched via thane_now or thane_assign. Future revisions may also
+// derive these policies dynamically from the live registry without
+// changing callers.
 type VirtualModel struct {
 	Name        string
 	Description string

--- a/internal/model/toolcatalog/catalog_test.go
+++ b/internal/model/toolcatalog/catalog_test.go
@@ -104,8 +104,8 @@ func TestRenderCapabilityManifestMarkdown_UsesExactToolNames(t *testing.T) {
 	if !strings.Contains(manifest, "\"list\":\"list_loaded_capabilities\"") {
 		t.Fatalf("manifest = %q, want list_loaded_capabilities example", manifest)
 	}
-	if !strings.Contains(manifest, "\"delegate\":\"thane_delegate\"") {
-		t.Fatalf("manifest = %q, want thane_delegate example", manifest)
+	if !strings.Contains(manifest, "\"delegate\":\"thane_now\"") {
+		t.Fatalf("manifest = %q, want thane_now example", manifest)
 	}
 	if !strings.Contains(manifest, "\"development\"") {
 		t.Fatalf("manifest = %q, want development menu entry", manifest)

--- a/internal/model/toolcatalog/views.go
+++ b/internal/model/toolcatalog/views.go
@@ -121,9 +121,9 @@ type LoadedCapabilityView struct {
 // active tool members are surfaced. Callers opt in to nuances such as
 // excluded tools via this struct.
 type CatalogViewOptions struct {
-	// IncludeDelegate adds the thane_delegate tool to the activation
-	// tools block in the rendered view. Set false for surfaces where
-	// delegation is not relevant.
+	// IncludeDelegate adds the thane_now delegation tool to the
+	// activation tools block in the rendered view. Set false for
+	// surfaces where delegation is not relevant.
 	IncludeDelegate bool
 
 	// IncludeExcluded surfaces operator-excluded tools per tag in
@@ -141,7 +141,7 @@ func defaultCapabilityActionTools(includeDelegate bool) CapabilityActionTools {
 		Inspect:    "inspect_capability",
 	}
 	if includeDelegate {
-		tools.Delegate = "thane_delegate"
+		tools.Delegate = "thane_now"
 	}
 	return tools
 }

--- a/internal/platform/config/config.go
+++ b/internal/platform/config/config.go
@@ -217,7 +217,7 @@ type Config struct {
 	// tool gating for delegation-first architecture.
 	Agent AgentConfig `yaml:"agent"`
 
-	// Delegate configures the thane_delegate tool's split-model execution.
+	// Delegate configures the thane_* delegation tools' split-model execution.
 	Delegate DelegateConfig `yaml:"delegate"`
 
 	// CapabilityTags optionally overlays the compiled-in capability-tag catalog.
@@ -1147,7 +1147,8 @@ type EpisodicConfig struct {
 type AgentConfig struct {
 	// OrchestratorTools lists tool names to advertise when
 	// DelegationRequired is true. If empty, a sensible default set
-	// is applied (thane_delegate plus lightweight memory tools).
+	// is applied (the thane_now / thane_assign delegation front
+	// doors plus lightweight memory tools).
 	OrchestratorTools []string `yaml:"orchestrator_tools"`
 
 	// DelegationRequired enables orchestrator tool gating. When false
@@ -1155,13 +1156,13 @@ type AgentConfig struct {
 	DelegationRequired bool `yaml:"delegation_required"`
 }
 
-// DelegateConfig configures the thane_delegate tool's split-model
+// DelegateConfig configures the thane_* delegation tools' split-model
 // execution behavior.
 type DelegateConfig struct {
 	// Profiles contains per-profile budget and timeout overrides. The map
-	// key is the compatibility profile name (e.g., "general", "ha"). Only
-	// fields that are set override the builtin defaults — omitted fields
-	// keep their compiled-in values.
+	// key is the profile name (e.g., "general", "ha"). Only fields that
+	// are set override the builtin defaults — omitted fields keep their
+	// compiled-in values.
 	Profiles map[string]DelegateProfileConfig `yaml:"profiles"`
 }
 
@@ -2243,7 +2244,8 @@ func (c *Config) applyDefaults() {
 
 	if c.Agent.DelegationRequired && len(c.Agent.OrchestratorTools) == 0 {
 		c.Agent.OrchestratorTools = []string{
-			"thane_delegate",
+			"thane_now",
+			"thane_assign",
 			"recall_fact",
 			"remember_fact",
 			"save_contact",

--- a/internal/platform/config/config_test.go
+++ b/internal/platform/config/config_test.go
@@ -216,7 +216,7 @@ func TestAgentConfig_DefaultOrchestratorTools(t *testing.T) {
 		t.Fatal("expected delegation_required to be true")
 	}
 
-	want := []string{"thane_delegate", "recall_fact", "remember_fact", "save_contact", "lookup_contact", "owner_contact", "session_working_memory", "session_close", "archive_search"}
+	want := []string{"thane_now", "thane_assign", "recall_fact", "remember_fact", "save_contact", "lookup_contact", "owner_contact", "session_working_memory", "session_close", "archive_search"}
 	if len(cfg.Agent.OrchestratorTools) != len(want) {
 		t.Fatalf("orchestrator_tools length = %d, want %d; got %v", len(cfg.Agent.OrchestratorTools), len(want), cfg.Agent.OrchestratorTools)
 	}
@@ -230,7 +230,7 @@ func TestAgentConfig_DefaultOrchestratorTools(t *testing.T) {
 func TestAgentConfig_CustomOrchestratorTools(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config.yaml")
-	os.WriteFile(path, []byte("agent:\n  delegation_required: true\n  orchestrator_tools:\n    - thane_delegate\n    - recall_fact\n"), 0600)
+	os.WriteFile(path, []byte("agent:\n  delegation_required: true\n  orchestrator_tools:\n    - thane_now\n    - recall_fact\n"), 0600)
 
 	cfg, err := Load(path)
 	if err != nil {
@@ -240,8 +240,8 @@ func TestAgentConfig_CustomOrchestratorTools(t *testing.T) {
 	if len(cfg.Agent.OrchestratorTools) != 2 {
 		t.Fatalf("orchestrator_tools length = %d, want 2; got %v", len(cfg.Agent.OrchestratorTools), cfg.Agent.OrchestratorTools)
 	}
-	if cfg.Agent.OrchestratorTools[0] != "thane_delegate" || cfg.Agent.OrchestratorTools[1] != "recall_fact" {
-		t.Errorf("orchestrator_tools = %v, want [thane_delegate recall_fact]", cfg.Agent.OrchestratorTools)
+	if cfg.Agent.OrchestratorTools[0] != "thane_now" || cfg.Agent.OrchestratorTools[1] != "recall_fact" {
+		t.Errorf("orchestrator_tools = %v, want [thane_now recall_fact]", cfg.Agent.OrchestratorTools)
 	}
 }
 

--- a/internal/runtime/agent/ego_prompt_test.go
+++ b/internal/runtime/agent/ego_prompt_test.go
@@ -116,7 +116,7 @@ func TestBuildSystemPrompt_RuntimeContractIncluded(t *testing.T) {
 	if !strings.Contains(prompt, "`kb:article.md`") {
 		t.Fatal("runtime contract should teach kb: path references")
 	}
-	if !strings.Contains(prompt, "`thane_delegate`") {
+	if !strings.Contains(prompt, "`thane_now`") {
 		t.Fatal("runtime contract should mention delegation when top-level tools are gated")
 	}
 }

--- a/internal/runtime/agent/loop.go
+++ b/internal/runtime/agent/loop.go
@@ -634,10 +634,10 @@ func (l *Loop) contextAssemblerForPrompt() *TagContextAssembler {
 // SetOrchestratorTools configures the restricted tool set for all
 // iterations of the agent loop. When set, only the named tools are
 // advertised on every LLM call, keeping the primary model in
-// orchestrator mode and steering it toward delegation. If
-// thane_delegate is not registered in the tool registry, gating is
-// silently disabled to avoid leaving the agent without actionable
-// tools.
+// orchestrator mode and steering it toward delegation. If neither
+// thane_now nor thane_assign is registered in the tool registry,
+// gating is silently disabled to avoid leaving the agent without
+// any way to delegate.
 func (l *Loop) SetOrchestratorTools(names []string) {
 	l.orchestratorTools = names
 }
@@ -1782,7 +1782,7 @@ func (l *Loop) Run(ctx context.Context, req *Request, stream StreamCallback) (re
 	// Determine whether tool gating is active before model selection so
 	// both router decisions and explicit-model preflight can reason
 	// about the actual tool surface this run will expose.
-	gatingActive := len(l.orchestratorTools) > 0 && l.tools.Get("thane_delegate") != nil
+	gatingActive := len(l.orchestratorTools) > 0 && (l.tools.Get("thane_now") != nil || l.tools.Get("thane_assign") != nil)
 	if req.Hints[router.HintDelegationGating] == "disabled" {
 		gatingActive = false
 	}

--- a/internal/runtime/agent/orchestrator_tools_test.go
+++ b/internal/runtime/agent/orchestrator_tools_test.go
@@ -122,7 +122,7 @@ func TestToolGating_RestrictedAllIterations(t *testing.T) {
 	// so we can inspect both calls.
 	mock := &mockLLM{
 		responses: []*llm.ChatResponse{
-			// First iteration: model calls thane_delegate
+			// First iteration: model calls thane_now
 			{
 				Model: "test-model",
 				Message: llm.Message{
@@ -133,7 +133,7 @@ func TestToolGating_RestrictedAllIterations(t *testing.T) {
 							Name      string         `json:"name"`
 							Arguments map[string]any `json:"arguments"`
 						}{
-							Name:      "thane_delegate",
+							Name:      "thane_now",
 							Arguments: map[string]any{},
 						},
 					}},
@@ -151,8 +151,8 @@ func TestToolGating_RestrictedAllIterations(t *testing.T) {
 		},
 	}
 
-	loop := buildTestLoop(mock, []string{"thane_delegate", "recall_fact", "web_search"})
-	loop.SetOrchestratorTools([]string{"thane_delegate", "recall_fact"})
+	loop := buildTestLoop(mock, []string{"thane_now", "recall_fact", "web_search"})
+	loop.SetOrchestratorTools([]string{"thane_now", "recall_fact"})
 
 	_, err := loop.Run(context.Background(), &Request{
 		Messages: []Message{{Role: "user", Content: "check the lights"}},
@@ -171,8 +171,8 @@ func TestToolGating_RestrictedAllIterations(t *testing.T) {
 		if len(names) != 2 {
 			t.Errorf("call[%d] tool count = %d, want 2; tools: %v", idx, len(names), names)
 		}
-		if !hasName(names, "thane_delegate") {
-			t.Errorf("call[%d] tools missing thane_delegate: %v", idx, names)
+		if !hasName(names, "thane_now") {
+			t.Errorf("call[%d] tools missing thane_now: %v", idx, names)
 		}
 		if !hasName(names, "recall_fact") {
 			t.Errorf("call[%d] tools missing recall_fact: %v", idx, names)
@@ -262,7 +262,7 @@ func TestToolGating_RestrictedAcrossMultipleToolCalls(t *testing.T) {
 							Name      string         `json:"name"`
 							Arguments map[string]any `json:"arguments"`
 						}{
-							Name:      "thane_delegate",
+							Name:      "thane_now",
 							Arguments: map[string]any{},
 						},
 					}},
@@ -279,7 +279,7 @@ func TestToolGating_RestrictedAcrossMultipleToolCalls(t *testing.T) {
 							Name      string         `json:"name"`
 							Arguments map[string]any `json:"arguments"`
 						}{
-							Name:      "thane_delegate",
+							Name:      "thane_now",
 							Arguments: map[string]any{},
 						},
 					}},
@@ -293,8 +293,8 @@ func TestToolGating_RestrictedAcrossMultipleToolCalls(t *testing.T) {
 		},
 	}
 
-	loop := buildTestLoop(mock, []string{"thane_delegate", "recall_fact", "get_state", "web_search"})
-	loop.SetOrchestratorTools([]string{"thane_delegate"})
+	loop := buildTestLoop(mock, []string{"thane_now", "recall_fact", "get_state", "web_search"})
+	loop.SetOrchestratorTools([]string{"thane_now"})
 
 	_, err := loop.Run(context.Background(), &Request{
 		Messages: []Message{{Role: "user", Content: "test"}},
@@ -313,8 +313,8 @@ func TestToolGating_RestrictedAcrossMultipleToolCalls(t *testing.T) {
 		if len(names) != 1 {
 			t.Errorf("call[%d] tool count = %d, want 1; tools: %v", idx, len(names), names)
 		}
-		if !hasName(names, "thane_delegate") {
-			t.Errorf("call[%d] tools missing thane_delegate: %v", idx, names)
+		if !hasName(names, "thane_now") {
+			t.Errorf("call[%d] tools missing thane_now: %v", idx, names)
 		}
 		if hasName(names, "get_state") {
 			t.Errorf("call[%d] tools should NOT contain get_state: %v", idx, names)
@@ -323,7 +323,7 @@ func TestToolGating_RestrictedAcrossMultipleToolCalls(t *testing.T) {
 }
 
 func TestOrchestratorToolGating_DisabledWhenNoDelegation(t *testing.T) {
-	// When orchestratorTools is set but thane_delegate is NOT in the
+	// When orchestratorTools is set but thane_now is NOT in the
 	// registry, gating should be auto-disabled — all tools visible.
 	mock := &mockLLM{
 		responses: []*llm.ChatResponse{
@@ -334,10 +334,10 @@ func TestOrchestratorToolGating_DisabledWhenNoDelegation(t *testing.T) {
 		},
 	}
 
-	// Note: thane_delegate is NOT in the registry (not in extraNames).
+	// Note: thane_now is NOT in the registry (not in extraNames).
 	loop := buildTestLoop(mock, []string{"recall_fact"})
 	fullToolCount := len(loop.tools.List())
-	loop.SetOrchestratorTools([]string{"thane_delegate", "recall_fact"})
+	loop.SetOrchestratorTools([]string{"thane_now", "recall_fact"})
 
 	_, err := loop.Run(context.Background(), &Request{
 		Messages: []Message{{Role: "user", Content: "test"}},
@@ -350,7 +350,7 @@ func TestOrchestratorToolGating_DisabledWhenNoDelegation(t *testing.T) {
 		t.Fatalf("expected 1 LLM call, got %d", len(mock.calls))
 	}
 
-	// All tools should be visible because gating is disabled (no thane_delegate).
+	// All tools should be visible because gating is disabled (no thane_now).
 	names := toolNames(mock.calls[0].Tools)
 	if len(names) != fullToolCount {
 		t.Errorf("tool count = %d, want %d (gating should be disabled); tools: %v", len(names), fullToolCount, names)
@@ -368,7 +368,7 @@ func TestOrchestratorToolGating_DisabledWhenEmpty(t *testing.T) {
 		},
 	}
 
-	loop := buildTestLoop(mock, []string{"thane_delegate", "recall_fact"})
+	loop := buildTestLoop(mock, []string{"thane_now", "recall_fact"})
 	fullToolCount := len(loop.tools.List())
 	// Don't call SetOrchestratorTools — leave nil.
 
@@ -388,7 +388,7 @@ func TestOrchestratorToolGating_DisabledWhenEmpty(t *testing.T) {
 func TestToolGating_DisabledByDelegationGatingHint(t *testing.T) {
 	// When the delegation_gating hint is "disabled" (thane:ops profile),
 	// gating should be bypassed even when orchestratorTools and
-	// thane_delegate are both present.
+	// thane_now are both present.
 	mock := &mockLLM{
 		responses: []*llm.ChatResponse{
 			{
@@ -398,9 +398,9 @@ func TestToolGating_DisabledByDelegationGatingHint(t *testing.T) {
 		},
 	}
 
-	loop := buildTestLoop(mock, []string{"thane_delegate", "recall_fact", "web_search"})
+	loop := buildTestLoop(mock, []string{"thane_now", "recall_fact", "web_search"})
 	fullToolCount := len(loop.tools.List())
-	loop.SetOrchestratorTools([]string{"thane_delegate", "recall_fact"})
+	loop.SetOrchestratorTools([]string{"thane_now", "recall_fact"})
 
 	_, err := loop.Run(context.Background(), &Request{
 		Messages: []Message{{Role: "user", Content: "deploy the update"}},
@@ -447,8 +447,8 @@ func TestToolGating_BlocksCallsOutsideOrchestratorSet(t *testing.T) {
 		},
 	}
 
-	loop := buildTestLoop(mock, []string{"thane_delegate", "web_search"})
-	loop.SetOrchestratorTools([]string{"thane_delegate"})
+	loop := buildTestLoop(mock, []string{"thane_now", "web_search"})
+	loop.SetOrchestratorTools([]string{"thane_now"})
 
 	resp, err := loop.Run(context.Background(), &Request{
 		Messages: []Message{{Role: "user", Content: "delegate the work"}},
@@ -464,8 +464,8 @@ func TestToolGating_BlocksCallsOutsideOrchestratorSet(t *testing.T) {
 	}
 
 	names := toolNames(mock.calls[0].Tools)
-	if len(names) != 1 || !hasName(names, "thane_delegate") {
-		t.Fatalf("first call tools = %v, want only thane_delegate", names)
+	if len(names) != 1 || !hasName(names, "thane_now") {
+		t.Fatalf("first call tools = %v, want only thane_now", names)
 	}
 
 	msgs := mock.calls[1].Messages

--- a/internal/runtime/delegate/delegate.go
+++ b/internal/runtime/delegate/delegate.go
@@ -848,7 +848,7 @@ func (e *Executor) profileForScope(profileName string, scopeTags []string) *Prof
 			return profile
 		}
 	}
-	if containsTag(scopeTags, "ha") {
+	if hasAnyTag(scopeTags, "ha", "ha_admin") {
 		if profile := e.profiles["ha"]; profile != nil {
 			return profile
 		}
@@ -859,10 +859,12 @@ func (e *Executor) profileForScope(profileName string, scopeTags []string) *Prof
 	return e.profiles["general"]
 }
 
-func containsTag(tags []string, want string) bool {
+func hasAnyTag(tags []string, wants ...string) bool {
 	for _, tag := range tags {
-		if tag == want {
-			return true
+		for _, want := range wants {
+			if tag == want {
+				return true
+			}
 		}
 	}
 	return false

--- a/internal/runtime/delegate/delegate.go
+++ b/internal/runtime/delegate/delegate.go
@@ -197,6 +197,7 @@ type ToolCallOutcome struct {
 
 // Result is the outcome of a delegated task execution.
 type Result struct {
+	ProfileName              string            `json:"profile"`
 	Content                  string            `json:"content"`
 	Model                    string            `json:"model"`
 	Iterations               int               `json:"iterations"`
@@ -385,25 +386,26 @@ func (e *Executor) execute(ctx context.Context, task, profileName, guidance stri
 // StartBackground launches a detached delegate loop that reports its
 // completion back into the current conversation.
 func (e *Executor) StartBackground(ctx context.Context, task, profileName, guidance string, tags []string) (string, error) {
-	return e.startBackground(ctx, task, profileName, guidance, tags, defaultExecutionOptions())
+	loopID, _, err := e.startBackground(ctx, task, profileName, guidance, tags, defaultExecutionOptions())
+	return loopID, err
 }
 
-func (e *Executor) startBackground(ctx context.Context, task, profileName, guidance string, tags []string, opts executionOptions) (string, error) {
+func (e *Executor) startBackground(ctx context.Context, task, profileName, guidance string, tags []string, opts executionOptions) (string, string, error) {
 	if e.loopRunner == nil || e.loopRegistry == nil {
-		return "", fmt.Errorf("background delegation requires loops-ng execution")
+		return "", "", fmt.Errorf("background delegation requires loops-ng execution")
 	}
 	if e.completionSink == nil {
-		return "", fmt.Errorf("background delegation requires a completion sink")
+		return "", "", fmt.Errorf("background delegation requires a completion sink")
 	}
 
 	prep, err := e.prepareExecution(ctx, task, profileName, guidance, tags, opts)
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
 
 	completion, targetConversationID, targetChannel := tools.LoopCompletionTargetFromContext(ctx)
 	if completion == looppkg.CompletionConversation && targetConversationID == "" {
-		return "", fmt.Errorf("background delegation requires a target conversation")
+		return "", prep.profile.Name, fmt.Errorf("background delegation requires a target conversation")
 	}
 
 	loopName := "delegate-" + promptfmt.ShortIDPrefix(prep.id)
@@ -420,7 +422,7 @@ func (e *Executor) startBackground(ctx context.Context, task, profileName, guida
 	})
 	if err != nil {
 		e.finishLoopExecution(prep)
-		return "", fmt.Errorf("delegate failed to start in background: %w", err)
+		return "", prep.profile.Name, fmt.Errorf("delegate failed to start in background: %w", err)
 	}
 
 	prep.log.Info("delegate background started",
@@ -432,7 +434,7 @@ func (e *Executor) startBackground(ctx context.Context, task, profileName, guida
 	)
 
 	e.finishDetachedLoopExecution(launchResult.LoopID, prep)
-	return launchResult.LoopID, nil
+	return launchResult.LoopID, prep.profile.Name, nil
 }
 
 type preparedExecution struct {
@@ -497,6 +499,7 @@ func (e *Executor) executeViaLoop(ctx context.Context, task, profileName, guidan
 			toolCallsMu.Lock()
 			defer toolCallsMu.Unlock()
 			return &Result{
+				ProfileName:   prep.profile.Name,
 				Content:       "Delegate was unable to complete the task within its time limit.",
 				Model:         prep.model,
 				Exhausted:     true,
@@ -533,6 +536,7 @@ func (e *Executor) executeViaLoop(ctx context.Context, task, profileName, guidan
 	}
 
 	return &Result{
+		ProfileName:              prep.profile.Name,
 		Content:                  resp.Content,
 		Model:                    resp.Model,
 		Iterations:               resp.Iterations,

--- a/internal/runtime/delegate/delegate.go
+++ b/internal/runtime/delegate/delegate.go
@@ -31,12 +31,10 @@ import (
 // registries to prevent recursion. All members of the delegate family
 // must appear here: a delegate that can call any of them can spawn
 // another delegate, which is exactly the structural recursion the
-// exclusion is meant to prevent. The family currently includes the
-// deprecated thane_delegate alias plus its replacements thane_now
-// (sync) and thane_assign (async). When adding a new family member,
-// add its name here in the same change.
+// exclusion is meant to prevent. The family currently includes
+// thane_now (sync) and thane_assign (async). When adding a new
+// family member, add its name here in the same change.
 var delegateFamilyToolNames = []string{
-	"thane_delegate",
 	"thane_now",
 	"thane_assign",
 }

--- a/internal/runtime/delegate/delegate.go
+++ b/internal/runtime/delegate/delegate.go
@@ -730,14 +730,11 @@ func (e *Executor) prepareExecution(ctx context.Context, task, profileName, guid
 		}
 	}
 
-	profile := e.profiles[profileName]
-	if profile == nil {
-		profile = e.profiles["general"]
-	}
 	scopeTags, inheritedTags, droppedTags, explicitScopeRequested := mergeDelegateScopeTags(ctx, tags, opts.inheritCallerTags, opts.explicitTagScope)
 	if len(droppedTags) > 0 {
 		log.Warn("delegate capability tags skipped", "dropped_tags", droppedTags)
 	}
+	profile := e.profileForScope(profileName, scopeTags)
 	scopeTags, profileDefaultTags := applyProfileDefaultTags(scopeTags, profile, explicitScopeRequested)
 
 	reg := e.delegateToolRegistry(scopeTags, explicitScopeRequested)
@@ -843,6 +840,32 @@ func (e *Executor) prepareExecution(ctx context.Context, task, profileName, guid
 		toolTimeout:      toolTimeout,
 		promptMode:       opts.effectivePromptMode(),
 	}, nil
+}
+
+func (e *Executor) profileForScope(profileName string, scopeTags []string) *Profile {
+	if profileName != "" && profileName != "general" {
+		if profile := e.profiles[profileName]; profile != nil {
+			return profile
+		}
+	}
+	if containsTag(scopeTags, "ha") {
+		if profile := e.profiles["ha"]; profile != nil {
+			return profile
+		}
+	}
+	if profile := e.profiles[profileName]; profile != nil {
+		return profile
+	}
+	return e.profiles["general"]
+}
+
+func containsTag(tags []string, want string) bool {
+	for _, tag := range tags {
+		if tag == want {
+			return true
+		}
+	}
+	return false
 }
 
 // selectModel picks a model for the delegate via the router or falls back to the default.

--- a/internal/runtime/delegate/delegate_test.go
+++ b/internal/runtime/delegate/delegate_test.go
@@ -152,6 +152,9 @@ func TestExecute_LoopBackedPathUsesLaunch(t *testing.T) {
 	if result.Model != "deepslate/google/gemma-3-4b" {
 		t.Fatalf("Model = %q", result.Model)
 	}
+	if result.ProfileName != "ha" {
+		t.Fatalf("ProfileName = %q, want ha", result.ProfileName)
+	}
 	if result.Iterations != 2 {
 		t.Fatalf("Iterations = %d, want 2", result.Iterations)
 	}
@@ -203,6 +206,7 @@ func TestExecute_LoopBackedPathUsesLaunch(t *testing.T) {
 	if captured.UsageRole != "delegate" || captured.UsageTaskName != "ha" {
 		t.Fatalf("usage role/task = %q/%q", captured.UsageRole, captured.UsageTaskName)
 	}
+	assertContainsDelegateFamily(t, captured.ExcludeTools)
 }
 
 func TestExecute_LoopBackedDerivesHAProfileFromTagScope(t *testing.T) {
@@ -230,12 +234,15 @@ func TestExecute_LoopBackedDerivesHAProfileFromTagScope(t *testing.T) {
 			exec := NewExecutor(slog.Default(), nil, nil, taggedDelegateTestRegistry(), "spark/gpt-oss:20b")
 			exec.ConfigureLoopExecution(runner, looppkg.NewRegistry())
 
-			_, err := exec.execute(context.Background(), "Check the hallway light", "general", "", tc.tags, executionOptions{
+			result, err := exec.execute(context.Background(), "Check the hallway light", "general", "", tc.tags, executionOptions{
 				explicitTagScope: true,
 				promptMode:       agentctx.PromptModeTask,
 			})
 			if err != nil {
 				t.Fatalf("execute() error = %v", err)
+			}
+			if result.ProfileName != "ha" {
+				t.Fatalf("ProfileName = %q, want ha profile derived from %v tags", result.ProfileName, tc.tags)
 			}
 
 			if captured.UsageTaskName != "ha" {
@@ -439,6 +446,7 @@ func TestExecute_LoopBackedExplicitEmptyTagsWithAlwaysActiveTagsDoNotBypassFilte
 	if containsString(captured.InitialTags, "ha") {
 		t.Fatalf("InitialTags = %#v, should not include ha profile default for explicit empty tag scope", captured.InitialTags)
 	}
+	assertContainsDelegateFamily(t, captured.ExcludeTools)
 	// ExcludeTools may carry the delegate-family recursion guard, but
 	// must not include any of the regular tag-gated tools — the
 	// always-active tags should expand the filter scope so tag-based
@@ -948,6 +956,7 @@ func TestAssignToolHandler_RoutesToAsyncPath(t *testing.T) {
 	ctx := tools.WithConversationID(context.Background(), "conv-async")
 	result, err := AssignToolHandler(exec)(ctx, map[string]any{
 		"task": "Investigate the slow query.",
+		"tags": []any{"ha"},
 	})
 	if err != nil {
 		t.Fatalf("AssignToolHandler error: %v", err)
@@ -957,6 +966,9 @@ func TestAssignToolHandler_RoutesToAsyncPath(t *testing.T) {
 	}
 	if !strings.Contains(result, "loop_id=") {
 		t.Fatalf("expected loop_id in result, got: %s", result)
+	}
+	if !strings.Contains(result, "profile=ha") {
+		t.Fatalf("expected derived ha profile in result, got: %s", result)
 	}
 }
 
@@ -1136,4 +1148,13 @@ func containsString(values []string, want string) bool {
 		}
 	}
 	return false
+}
+
+func assertContainsDelegateFamily(t *testing.T, toolNames []string) {
+	t.Helper()
+	for _, want := range delegateFamilyToolNames {
+		if !containsString(toolNames, want) {
+			t.Fatalf("tool names = %#v, want delegate-family exclusion %s", toolNames, want)
+		}
+	}
 }

--- a/internal/runtime/delegate/delegate_test.go
+++ b/internal/runtime/delegate/delegate_test.go
@@ -208,39 +208,51 @@ func TestExecute_LoopBackedPathUsesLaunch(t *testing.T) {
 func TestExecute_LoopBackedDerivesHAProfileFromTagScope(t *testing.T) {
 	t.Parallel()
 
-	var captured looppkg.Request
-	runner := &mockLoopRunner{
-		onRun: func(req looppkg.Request) {
-			captured = req
-		},
-		resp: &looppkg.Response{
-			Content: "delegate answer",
-			Model:   "deepslate/google/gemma-3-4b",
-		},
-	}
+	for _, tc := range []struct {
+		name string
+		tags []string
+	}{
+		{name: "ha", tags: []string{"ha"}},
+		{name: "ha_admin", tags: []string{"ha_admin"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var captured looppkg.Request
+			runner := &mockLoopRunner{
+				onRun: func(req looppkg.Request) {
+					captured = req
+				},
+				resp: &looppkg.Response{
+					Content: "delegate answer",
+					Model:   "deepslate/google/gemma-3-4b",
+				},
+			}
 
-	exec := NewExecutor(slog.Default(), nil, nil, taggedDelegateTestRegistry(), "spark/gpt-oss:20b")
-	exec.ConfigureLoopExecution(runner, looppkg.NewRegistry())
+			exec := NewExecutor(slog.Default(), nil, nil, taggedDelegateTestRegistry(), "spark/gpt-oss:20b")
+			exec.ConfigureLoopExecution(runner, looppkg.NewRegistry())
 
-	_, err := exec.execute(context.Background(), "Check the hallway light", "general", "", []string{"ha"}, executionOptions{
-		explicitTagScope: true,
-		promptMode:       agentctx.PromptModeTask,
-	})
-	if err != nil {
-		t.Fatalf("execute() error = %v", err)
-	}
+			_, err := exec.execute(context.Background(), "Check the hallway light", "general", "", tc.tags, executionOptions{
+				explicitTagScope: true,
+				promptMode:       agentctx.PromptModeTask,
+			})
+			if err != nil {
+				t.Fatalf("execute() error = %v", err)
+			}
 
-	if captured.UsageTaskName != "ha" {
-		t.Fatalf("UsageTaskName = %q, want ha profile derived from ha tag", captured.UsageTaskName)
-	}
-	if captured.Hints[router.HintMission] != "device_control" {
-		t.Fatalf("mission hint = %q, want device_control", captured.Hints[router.HintMission])
-	}
-	if captured.Hints[router.HintQualityFloor] != "4" {
-		t.Fatalf("quality_floor hint = %q, want 4", captured.Hints[router.HintQualityFloor])
-	}
-	if !containsString(captured.InitialTags, "ha") {
-		t.Fatalf("InitialTags = %#v, want ha", captured.InitialTags)
+			if captured.UsageTaskName != "ha" {
+				t.Fatalf("UsageTaskName = %q, want ha profile derived from %v tags", captured.UsageTaskName, tc.tags)
+			}
+			if captured.Hints[router.HintMission] != "device_control" {
+				t.Fatalf("mission hint = %q, want device_control", captured.Hints[router.HintMission])
+			}
+			if captured.Hints[router.HintQualityFloor] != "4" {
+				t.Fatalf("quality_floor hint = %q, want 4", captured.Hints[router.HintQualityFloor])
+			}
+			for _, tag := range tc.tags {
+				if !containsString(captured.InitialTags, tag) {
+					t.Fatalf("InitialTags = %#v, want %s", captured.InitialTags, tag)
+				}
+			}
+		})
 	}
 }
 

--- a/internal/runtime/delegate/delegate_test.go
+++ b/internal/runtime/delegate/delegate_test.go
@@ -315,11 +315,10 @@ func TestExecute_LoopBackedTagScopedExcludesDelegateFamily(t *testing.T) {
 
 // TestDelegateToolRegistry_ExcludesFullDelegateFamily is the regression
 // test for #820. Delegate registries must exclude every member of the
-// thane_* family — thane_delegate (deprecated), thane_now, and
-// thane_assign — to prevent a delegate from spawning another delegate
-// via the new front doors. Both branches of delegateToolRegistry are
-// exercised: the tag-scoped branch (FilterByTags result) and the
-// fall-through branch (no scope).
+// thane_* family — thane_now and thane_assign — to prevent a delegate
+// from spawning another delegate via the front doors. Both branches of
+// delegateToolRegistry are exercised: the tag-scoped branch
+// (FilterByTags result) and the fall-through branch (no scope).
 func TestDelegateToolRegistry_ExcludesFullDelegateFamily(t *testing.T) {
 	t.Parallel()
 
@@ -641,21 +640,21 @@ func TestStartBackground_RequiresLoopExecutionWiring(t *testing.T) {
 	}
 }
 
-func TestToolHandler_EmptyTask(t *testing.T) {
+func TestNowToolHandler_EmptyTask(t *testing.T) {
 	exec := NewExecutor(slog.Default(), &mockLLMClient{}, nil, newTestRegistry(), "test-model")
-	handler := ToolHandler(exec)
+	handler := NowToolHandler(exec)
 
 	result, err := handler(context.Background(), map[string]any{})
 
 	if err != nil {
-		t.Fatalf("ToolHandler() error = %v, want nil", err)
+		t.Fatalf("NowToolHandler() error = %v, want nil", err)
 	}
 	if !strings.Contains(result, "Error: task is required") {
 		t.Errorf("result = %q, want to contain 'task is required'", result)
 	}
 }
 
-func TestToolHandler_DefaultProfile(t *testing.T) {
+func TestNowToolHandler_DefaultProfile(t *testing.T) {
 	mock := &mockLLMClient{
 		responses: []*llm.ChatResponse{
 			{
@@ -668,14 +667,14 @@ func TestToolHandler_DefaultProfile(t *testing.T) {
 	}
 
 	exec := NewExecutor(slog.Default(), mock, nil, newTestRegistry(), "test-model")
-	handler := ToolHandler(exec)
+	handler := NowToolHandler(exec)
 
 	result, err := handler(context.Background(), map[string]any{
 		"task": "Do something",
 	})
 
 	if err != nil {
-		t.Fatalf("ToolHandler() error = %v", err)
+		t.Fatalf("NowToolHandler() error = %v", err)
 	}
 	if !strings.Contains(result, "profile=general") {
 		t.Errorf("result = %q, want to contain 'profile=general'", result)
@@ -910,10 +909,10 @@ func TestAssignToolHandler_RoutesToAsyncPath(t *testing.T) {
 	}
 }
 
-// TestToolHandler_AsyncModeLaunchesBackgroundDelegate verifies the
-// deprecated thane_delegate(mode=async) compatibility path still
-// reaches the async executor.
-func TestToolHandler_AsyncModeLaunchesBackgroundDelegate(t *testing.T) {
+// TestAssignToolHandler_LaunchesBackgroundDelegate verifies that the
+// thane_assign handler routes through to the async executor and that
+// the completion sink receives a delivery for the parent conversation.
+func TestAssignToolHandler_LaunchesBackgroundDelegate(t *testing.T) {
 	t.Parallel()
 
 	runner := &mockLoopRunner{
@@ -934,14 +933,13 @@ func TestToolHandler_AsyncModeLaunchesBackgroundDelegate(t *testing.T) {
 	exec.ConfigureLoopExecution(runner, registry)
 	exec.ConfigureLoopCompletionSink(sink.DeliverCompletion)
 
-	handler := ToolHandler(exec)
+	handler := AssignToolHandler(exec)
 	ctx := tools.WithConversationID(context.Background(), "conv-async")
 	result, err := handler(ctx, map[string]any{
 		"task": "Check the office light",
-		"mode": "async",
 	})
 	if err != nil {
-		t.Fatalf("ToolHandler() error = %v", err)
+		t.Fatalf("AssignToolHandler() error = %v", err)
 	}
 	if !strings.Contains(result, "[Delegate STARTED:") {
 		t.Fatalf("result = %q, want async started header", result)
@@ -1061,14 +1059,16 @@ func taggedDelegateTestRegistry() *tools.Registry {
 			return "owner", nil
 		},
 	})
-	reg.Register(&tools.Tool{
-		Name:        "thane_delegate",
-		Description: "Delegate",
-		Parameters:  map[string]any{},
-		Handler: func(_ context.Context, _ map[string]any) (string, error) {
-			return "should not be called", nil
-		},
-	})
+	for _, name := range delegateFamilyToolNames {
+		reg.Register(&tools.Tool{
+			Name:        name,
+			Description: "delegate-family tool — should be excluded from delegate registries",
+			Parameters:  map[string]any{},
+			Handler: func(_ context.Context, _ map[string]any) (string, error) {
+				return "should not be called", nil
+			},
+		})
+	}
 	reg.SetTagIndex(map[string][]string{
 		"web":             {"web_search"},
 		"ha":              {"get_state"},

--- a/internal/runtime/delegate/delegate_test.go
+++ b/internal/runtime/delegate/delegate_test.go
@@ -205,6 +205,45 @@ func TestExecute_LoopBackedPathUsesLaunch(t *testing.T) {
 	}
 }
 
+func TestExecute_LoopBackedDerivesHAProfileFromTagScope(t *testing.T) {
+	t.Parallel()
+
+	var captured looppkg.Request
+	runner := &mockLoopRunner{
+		onRun: func(req looppkg.Request) {
+			captured = req
+		},
+		resp: &looppkg.Response{
+			Content: "delegate answer",
+			Model:   "deepslate/google/gemma-3-4b",
+		},
+	}
+
+	exec := NewExecutor(slog.Default(), nil, nil, taggedDelegateTestRegistry(), "spark/gpt-oss:20b")
+	exec.ConfigureLoopExecution(runner, looppkg.NewRegistry())
+
+	_, err := exec.execute(context.Background(), "Check the hallway light", "general", "", []string{"ha"}, executionOptions{
+		explicitTagScope: true,
+		promptMode:       agentctx.PromptModeTask,
+	})
+	if err != nil {
+		t.Fatalf("execute() error = %v", err)
+	}
+
+	if captured.UsageTaskName != "ha" {
+		t.Fatalf("UsageTaskName = %q, want ha profile derived from ha tag", captured.UsageTaskName)
+	}
+	if captured.Hints[router.HintMission] != "device_control" {
+		t.Fatalf("mission hint = %q, want device_control", captured.Hints[router.HintMission])
+	}
+	if captured.Hints[router.HintQualityFloor] != "4" {
+		t.Fatalf("quality_floor hint = %q, want 4", captured.Hints[router.HintQualityFloor])
+	}
+	if !containsString(captured.InitialTags, "ha") {
+		t.Fatalf("InitialTags = %#v, want ha", captured.InitialTags)
+	}
+}
+
 func TestExecute_LoopBackedInheritsCallerTags(t *testing.T) {
 	t.Parallel()
 

--- a/internal/runtime/delegate/profile.go
+++ b/internal/runtime/delegate/profile.go
@@ -49,7 +49,7 @@ const (
 	defaultToolTimeout = 30 * time.Second
 )
 
-// builtinProfiles returns compatibility profiles for legacy callers.
+// builtinProfiles returns budget and routing defaults for delegate runs.
 func builtinProfiles() map[string]*Profile {
 	return map[string]*Profile{
 		"general": {

--- a/internal/runtime/delegate/profile.go
+++ b/internal/runtime/delegate/profile.go
@@ -1,6 +1,10 @@
-// Package delegate implements the thane_delegate meta-tool for split-model
-// execution. A calling model delegates subtasks to cheaper/local models that
-// run with minimal context and a filtered tool set.
+// Package delegate implements the thane_now and thane_assign delegation
+// tools for split-model execution. A calling model delegates subtasks to
+// cheaper/local models that run with minimal context and a filtered tool
+// set. thane_now is the synchronous front door (the caller blocks for the
+// result); thane_assign is the async one-shot front door (the result is
+// delivered back through the conversation/channel when the delegate
+// completes).
 package delegate
 
 import (

--- a/internal/runtime/delegate/tool.go
+++ b/internal/runtime/delegate/tool.go
@@ -156,11 +156,14 @@ func runAssign(ctx context.Context, exec *Executor, req delegateRequest) string 
 		explicitTagScope:  req.tagsProvided,
 		promptMode:        req.contextMode,
 	}
-	loopID, err := exec.startBackground(ctx, req.task, req.profileName, req.guidance, req.tags, opts)
-	if err != nil {
-		return fmt.Sprintf("[Delegate error: profile=%s, mode=async] %s", req.profileName, err.Error())
+	loopID, profileName, err := exec.startBackground(ctx, req.task, req.profileName, req.guidance, req.tags, opts)
+	if profileName == "" {
+		profileName = req.profileName
 	}
-	return fmt.Sprintf("[Delegate STARTED: profile=%s, mode=async, loop_id=%s]\n\nBackground delegate launched. Its result will be delivered back through the current conversation or interactive channel when it completes.", req.profileName, loopID)
+	if err != nil {
+		return fmt.Sprintf("[Delegate error: profile=%s, mode=async] %s", profileName, err.Error())
+	}
+	return fmt.Sprintf("[Delegate STARTED: profile=%s, mode=async, loop_id=%s]\n\nBackground delegate launched. Its result will be delivered back through the current conversation or interactive channel when it completes.", profileName, loopID)
 }
 
 // runNow executes the sync path for thane_now. Returns a fully
@@ -176,6 +179,10 @@ func runNow(ctx context.Context, exec *Executor, req delegateRequest) string {
 	if err != nil {
 		return fmt.Sprintf("[Delegate error: profile=%s] %s", req.profileName, err.Error())
 	}
+	profileName := req.profileName
+	if result.ProfileName != "" {
+		profileName = result.ProfileName
+	}
 	summary := formatExecSummary(result)
 
 	// Format the result with explicit success/failure headers so the
@@ -186,16 +193,16 @@ func runNow(ctx context.Context, exec *Executor, req delegateRequest) string {
 			// empty-after-tool-calls as ExhaustNoOutput.
 			return fmt.Sprintf("[Delegate FAILED: profile=%s, model=%s, reason=no_output, iter=%d]"+
 				"\n\nDelegate completed without producing results.\n\n%s",
-				req.profileName, result.Model, result.Iterations, summary)
+				profileName, result.Model, result.Iterations, summary)
 		}
 		header := fmt.Sprintf("[Delegate SUCCEEDED: profile=%s, model=%s, iter=%d, tokens=%s]",
-			req.profileName, result.Model, result.Iterations, formatTokens(result.OutputTokens))
+			profileName, result.Model, result.Iterations, formatTokens(result.OutputTokens))
 		return header + "\n\n" + result.Content + "\n\n" + summary
 	}
 
 	// Exhausted delegation — provide actionable context for retry.
 	header := fmt.Sprintf("[Delegate FAILED: profile=%s, model=%s, reason=%s, iter=%d, tokens_in=%s, tokens_out=%s]",
-		req.profileName, result.Model, result.ExhaustReason, result.Iterations,
+		profileName, result.Model, result.ExhaustReason, result.Iterations,
 		formatTokens(result.InputTokens), formatTokens(result.OutputTokens))
 
 	var out strings.Builder

--- a/internal/runtime/delegate/tool.go
+++ b/internal/runtime/delegate/tool.go
@@ -6,16 +6,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/nugget/thane-ai-agent/internal/model/prompts"
 	"github.com/nugget/thane-ai-agent/internal/runtime/agentctx"
 )
-
-// ToolDescription is the LLM-facing description for the deprecated
-// thane_delegate tool. New code should use NowToolDescription /
-// AssignToolDescription on the family-shaped tools.
-var ToolDescription = "DEPRECATED: prefer thane_now (sync answer) or thane_assign (async one-shot). " +
-	"thane_delegate remains as a compatibility alias and routes to the appropriate family member based on the mode parameter; it will be removed in a future release. " +
-	"\n\n" + prompts.DelegateToolDescription
 
 // NowToolDescription is the LLM-facing description for thane_now, the
 // sync member of the thane_* family.
@@ -33,29 +25,6 @@ const AssignToolDescription = "Assign a bounded task to a sub-agent that runs in
 	"Uses compact task context by default; set context_mode=full only for continuity-sensitive work. " +
 	"For an answer needed in this turn, use thane_now. " +
 	"For recurring scheduled work, use thane_curate."
-
-// ToolDefinition returns the JSON schema for the deprecated
-// thane_delegate tool. Routes to thane_now or thane_assign internally
-// based on the mode parameter.
-func ToolDefinition() map[string]any {
-	props := commonDelegateProperties()
-	props["profile"] = map[string]any{
-		"type":        "string",
-		"default":     "general",
-		"description": "Compatibility profile for budget and routing defaults. Prefer tags for capability scoping. The ha profile adds the ha tag only when tags are omitted.",
-	}
-	props["mode"] = map[string]any{
-		"type":        "string",
-		"enum":        []string{"sync", "async"},
-		"default":     "sync",
-		"description": "DEPRECATED. mode=sync routes to thane_now; mode=async routes to thane_assign. Prefer calling those tools directly.",
-	}
-	return map[string]any{
-		"type":       "object",
-		"properties": props,
-		"required":   []string{"task"},
-	}
-}
 
 // NowToolDefinition returns the JSON schema for thane_now.
 func NowToolDefinition() map[string]any {
@@ -79,7 +48,7 @@ func AssignToolDefinition() map[string]any {
 }
 
 // commonDelegateProperties returns the JSON schema property block
-// shared by thane_now, thane_assign, and thane_delegate.
+// shared by thane_now and thane_assign.
 func commonDelegateProperties() map[string]any {
 	return map[string]any{
 		"task": map[string]any{
@@ -110,31 +79,6 @@ func commonDelegateProperties() map[string]any {
 			"default":     "task",
 			"description": "Prompt/context shape for the delegate. task is compact and omits full identity files, inject files, always-on talents, and conversation-history dressing. full opts into the normal Thane prompt when the delegate truly needs that continuity.",
 		},
-	}
-}
-
-// ToolHandler returns the handler for thane_delegate. Routes to the
-// thane_now or thane_assign code paths based on the mode parameter.
-// Errors from the delegate are returned as tool result strings (not
-// Go errors) so the calling model can decide what to do.
-func ToolHandler(exec *Executor) func(ctx context.Context, args map[string]any) (string, error) {
-	return func(ctx context.Context, args map[string]any) (string, error) {
-		mode, _ := args["mode"].(string)
-		if mode == "" {
-			mode = "sync"
-		}
-		if mode != "sync" && mode != "async" {
-			return "Error: mode must be one of [sync, async]", nil
-		}
-
-		req, errMsg := parseDelegateArgs(args)
-		if errMsg != "" {
-			return errMsg, nil
-		}
-		if mode == "async" {
-			return runAssign(ctx, exec, req), nil
-		}
-		return runNow(ctx, exec, req), nil
 	}
 }
 
@@ -173,8 +117,6 @@ type delegateRequest struct {
 }
 
 // parseDelegateArgs extracts the shared args for the family.
-// The profile field is read from args for thane_delegate compatibility
-// but defaults to "general" for the family tools that don't expose it.
 func parseDelegateArgs(args map[string]any) (delegateRequest, string) {
 	req := delegateRequest{inheritCallerTags: true, profileName: "general", contextMode: agentctx.PromptModeTask}
 
@@ -184,9 +126,6 @@ func parseDelegateArgs(args map[string]any) (delegateRequest, string) {
 	}
 	req.task = task
 
-	if profile, ok := args["profile"].(string); ok && profile != "" {
-		req.profileName = profile
-	}
 	req.guidance, _ = args["guidance"].(string)
 	if rawInherit, ok := args["inherit_caller_tags"].(bool); ok {
 		req.inheritCallerTags = rawInherit
@@ -210,8 +149,7 @@ func parseDelegateArgs(args map[string]any) (delegateRequest, string) {
 	return req, ""
 }
 
-// runAssign executes the async path. Used by both thane_assign and
-// thane_delegate(mode=async).
+// runAssign executes the async path for thane_assign.
 func runAssign(ctx context.Context, exec *Executor, req delegateRequest) string {
 	opts := executionOptions{
 		inheritCallerTags: req.inheritCallerTags,
@@ -225,9 +163,9 @@ func runAssign(ctx context.Context, exec *Executor, req delegateRequest) string 
 	return fmt.Sprintf("[Delegate STARTED: profile=%s, mode=async, loop_id=%s]\n\nBackground delegate launched. Its result will be delivered back through the current conversation or interactive channel when it completes.", req.profileName, loopID)
 }
 
-// runNow executes the sync path. Used by both thane_now and
-// thane_delegate(mode=sync). Returns a fully formatted tool-result
-// string with success/exhaustion headers and execution summary.
+// runNow executes the sync path for thane_now. Returns a fully
+// formatted tool-result string with success/exhaustion headers and
+// execution summary.
 func runNow(ctx context.Context, exec *Executor, req delegateRequest) string {
 	opts := executionOptions{
 		inheritCallerTags: req.inheritCallerTags,

--- a/internal/server/web/static/shared.js
+++ b/internal/server/web/static/shared.js
@@ -156,8 +156,20 @@ function formatToolTooltip(entry) {
   return lines.join('\n');
 }
 
-// parseDelegateArgs extracts task/profile/guidance from a thane_delegate
-// tool call's args (which may be a JSON string or object).
+const delegateToolNames = new Set(['thane_now', 'thane_assign', 'thane_delegate']);
+
+function isDelegateTool(name) {
+  return delegateToolNames.has(name);
+}
+
+function delegateToolLabel(name) {
+  if (name === 'thane_now') return 'sync';
+  if (name === 'thane_assign') return 'async';
+  return 'legacy';
+}
+
+// parseDelegateArgs extracts task/guidance/tags from a delegate tool
+// call's args (which may be a JSON string or object).
 function parseDelegateArgs(args) {
   if (!args) return {};
   try {
@@ -171,11 +183,11 @@ function extractDelegateCalls(liveTools) {
   if (!liveTools || liveTools.length === 0) return [];
   const calls = [];
   for (const entry of liveTools) {
-    if (entry.tool !== 'thane_delegate') continue;
+    if (!isDelegateTool(entry.tool)) continue;
     const parsed = parseDelegateArgs(entry.args);
     calls.push({
       task: parsed.task || '',
-      profile: parsed.profile || '',
+      profile: parsed.profile || delegateToolLabel(entry.tool),
       guidance: truncate(parsed.guidance || '', 200),
       tags: parsed.tags || [],
       status: entry.status || 'done',
@@ -1509,7 +1521,7 @@ function buildLiveCard(loop) {
     for (const entry of tools) {
       const li = document.createElement('li');
       li.className = 'live-tool live-tool--' + entry.status;
-      if (entry.tool === 'thane_delegate') {
+      if (isDelegateTool(entry.tool)) {
         // Show delegate task inline instead of bare tool name.
         const parsed = parseDelegateArgs(entry.args);
         li.innerHTML = '';
@@ -1521,12 +1533,11 @@ function buildLiveCard(loop) {
         taskSpan.className = 'live-tool__delegate-task';
         taskSpan.textContent = truncate(parsed.task || 'delegate', 80);
         li.appendChild(taskSpan);
-        if (parsed.profile) {
-          const prof = document.createElement('span');
-          prof.className = 'live-tool__delegate-profile';
-          prof.textContent = parsed.profile;
-          li.appendChild(prof);
-        }
+        const label = parsed.profile || delegateToolLabel(entry.tool);
+        const prof = document.createElement('span');
+        prof.className = 'live-tool__delegate-profile';
+        prof.textContent = label;
+        li.appendChild(prof);
       } else {
         li.textContent = entry.tool;
       }
@@ -1674,7 +1685,7 @@ function buildPastCard(snap, handlerOnly, idx, startExpanded) {
     body.appendChild(toolsDiv);
   }
 
-  // Delegate calls (rich inline display for thane_delegate tool uses).
+  // Delegate calls (rich inline display for thane_now/thane_assign tool uses).
   if (snap.delegate_calls && snap.delegate_calls.length > 0) {
     const delDiv = document.createElement('div');
     delDiv.className = 'iter-card__delegates';

--- a/internal/server/web/static/shared.js
+++ b/internal/server/web/static/shared.js
@@ -187,7 +187,8 @@ function extractDelegateCalls(liveTools) {
     const parsed = parseDelegateArgs(entry.args);
     calls.push({
       task: parsed.task || '',
-      profile: parsed.profile || delegateToolLabel(entry.tool),
+      profile: parsed.profile || '',
+      mode: parsed.mode || delegateToolLabel(entry.tool),
       guidance: truncate(parsed.guidance || '', 200),
       tags: parsed.tags || [],
       status: entry.status || 'done',
@@ -1700,10 +1701,11 @@ function buildPastCard(snap, handlerOnly, idx, startExpanded) {
       task.className = 'iter-card__delegate-task';
       task.textContent = truncate(dc.task || 'delegate', 100);
       item.appendChild(task);
-      if (dc.profile) {
+      const label = dc.profile || dc.mode;
+      if (label) {
         const prof = document.createElement('span');
         prof.className = 'iter-card__delegate-profile';
-        prof.textContent = dc.profile;
+        prof.textContent = label;
         item.appendChild(prof);
       }
       if (dc.status === 'error' && dc.error) {

--- a/internal/state/memory/archive.go
+++ b/internal/state/memory/archive.go
@@ -106,7 +106,7 @@ func WithParentSession(id string) SessionOption {
 }
 
 // WithParentToolCall sets the tool call ID that triggered this child
-// session (e.g. the thane_delegate tool call in the parent).
+// session (e.g. the thane_now or thane_assign call in the parent).
 func WithParentToolCall(id string) SessionOption {
 	return func(s *Session) { s.ParentToolCallID = id }
 }

--- a/internal/tools/capability_tools_test.go
+++ b/internal/tools/capability_tools_test.go
@@ -186,7 +186,7 @@ func TestResetCapabilities(t *testing.T) {
 	manifest := []CapabilityManifest{
 		{Tag: "forge", Description: "Forge tools", Tools: []string{"forge_pr_get"}},
 		{Tag: "web", Description: "Web tools", Tools: []string{"web_fetch"}},
-		{Tag: "core", Description: "Core tools", Tools: []string{"thane_delegate"}, AlwaysActive: true},
+		{Tag: "core", Description: "Core tools", Tools: []string{"thane_now"}, AlwaysActive: true},
 	}
 
 	reg := NewEmptyRegistry()
@@ -228,7 +228,7 @@ func TestResetCapabilities_TruncatesRemovedTools(t *testing.T) {
 	manifest := []CapabilityManifest{
 		{Tag: "alpha", Tools: []string{"a1", "a2", "a3", "a4", "a5"}},
 		{Tag: "beta", Tools: []string{"b1", "b2", "b3", "b4", "b5"}},
-		{Tag: "core", Tools: []string{"thane_delegate"}, AlwaysActive: true},
+		{Tag: "core", Tools: []string{"thane_now"}, AlwaysActive: true},
 	}
 
 	reg := NewEmptyRegistry()

--- a/internal/tools/escalation_tools.go
+++ b/internal/tools/escalation_tools.go
@@ -211,7 +211,7 @@ func (r *Registry) registerAIEscalation(deps EscalationDeps) {
 			"required": []string{"question"},
 		},
 		Handler: func(ctx context.Context, args map[string]any) (string, error) {
-			return "", fmt.Errorf("request_ai_escalation is not yet implemented; use request_human_escalation or thane_delegate with a high quality_floor hint")
+			return "", fmt.Errorf("request_ai_escalation is not yet implemented; use request_human_escalation or thane_now with a high quality_floor hint")
 		},
 	})
 }

--- a/internal/tools/escalation_tools.go
+++ b/internal/tools/escalation_tools.go
@@ -211,7 +211,7 @@ func (r *Registry) registerAIEscalation(deps EscalationDeps) {
 			"required": []string{"question"},
 		},
 		Handler: func(ctx context.Context, args map[string]any) (string, error) {
-			return "", fmt.Errorf("request_ai_escalation is not yet implemented; use request_human_escalation or thane_now with a high quality_floor hint")
+			return "", fmt.Errorf("request_ai_escalation is not yet implemented; use request_human_escalation, or escalate by selecting a higher-quality routing profile (e.g. thane:premium) on the orchestrator side")
 		},
 	})
 }

--- a/talents/loops-doctrine.md
+++ b/talents/loops-doctrine.md
@@ -30,8 +30,8 @@ Pick by lifecycle:
   for forcing the next iteration into supervisor mode or delivering
   fresh context to a watcher.
 
-`thane_delegate` and `notify_loop` are deprecated aliases that route
-into the family. Prefer the family names directly.
+`notify_loop` is a deprecated alias that routes into the family.
+Prefer the family names directly.
 
 Below the family, the lower-level definition and runtime tools remain
 for inspection, control, and unusual launch shapes (event-driven,


### PR DESCRIPTION
## Summary

`thane_delegate` had been a pure routing shim since [#784](https://github.com/nugget/thane-ai-agent/pull/784) introduced the intent-shaped `thane_*` family — its handler did mode dispatch (`sync` → `runNow`, `async` → `runAssign`), nothing more. The description was marked DEPRECATED with explicit guidance to call `thane_now` / `thane_assign` directly. The schema exposed a `profile` parameter that the family tools' `parseDelegateArgs` already read from args anyway, so even that was non-unique behavior.

April production logs showed the shim still being chosen for ~33% of all delegate calls, typically with `mode=sync profile=default`:

| tool | invocations (Apr 2026) |
|------|------------------------|
| `thane_now` | 24 |
| `thane_delegate` | 12 |
| `thane_assign` | 3 |

Of the 12 captured-with-args `thane_delegate` calls, 7 had `mode=sync profile=default`. `default` isn't even a registered profile name (the registered ones are `general` and `ha`); it silently falls through to `general`. Functionally identical to a `thane_now` call, just through the deprecated front door.

Single-production-instance reasoning: no external integrations, deprecation pathway already documented, outright removal beats a graceful sunset that nobody benefits from.

## What changed

**Removed:**
- `delegate.ToolDescription`, `delegate.ToolDefinition`, `delegate.ToolHandler` — the public shim API
- `delegateFamilyToolNames` lost its `"thane_delegate"` entry; the recursion guard now covers exactly the live family
- `parseDelegateArgs`'s dead `profile` arg parser (no schema exposed it after the family tools became canonical)
- `prompts.DelegateToolDescription` — the deprecated tool's description constant
- `new_delegation.go` no longer registers `"thane_delegate"`

**Adjusted to use the family front doors:**
- `agent/loop.go`'s orchestrator-gating check keys off `thane_now` **or** `thane_assign` being registered (was: only `thane_delegate`)
- `config` defaults: `agent.orchestrator_tools` default now lists `thane_now` and `thane_assign`
- `toolcatalog.IncludeDelegate` surfaces `thane_now` in the activation tools block
- ego prompt's delegation guidance recommends `thane_now` / `thane_assign`
- `escalation_tools` "not yet implemented" error message now recommends selecting a higher-quality routing profile, e.g. `thane:premium`

**Tests:**
- `TestToolHandler_AsyncModeLaunchesBackgroundDelegate` (which specifically exercised `thane_delegate(mode=async)`) replaced with `TestAssignToolHandler_LaunchesBackgroundDelegate` — same async path, real handler
- `TestToolHandler_EmptyTask` / `_DefaultProfile` renamed and rewired to `NowToolHandler`
- `taggedDelegateTestRegistry` now iterates `delegateFamilyToolNames` instead of hardcoding tool names — same convention `newTestRegistry` already used after [#828](https://github.com/nugget/thane-ai-agent/pull/828)
- orchestrator-gating tests use `thane_now` as the gating-trigger name throughout

**Docs:** `delegation.md`, `agent-loop.md`, `prompt-tool-pruning-strategy.md`, `reference/tools.md`, `talents/loops-doctrine.md` all drop the "DEPRECATED alias" lines. `examples/config.example.yaml` is regenerated from the updated `config.go` comments via `go generate`.

## Why the recursion guard still holds

The two-layer exclusion documented in [docs/understanding/tag-system.md](docs/understanding/tag-system.md#the-two-layer-delegate-exclusion-this-is-load-bearing) continues to filter `delegateFamilyToolNames` at both the in-process delegate registry layer and the launched-loop `ExcludeTools` layer. The slice is now `[thane_now, thane_assign]` instead of three entries — the guard covers exactly the live front doors and nothing more.

## Test plan

- [x] `just ci` clean
- [x] All test fixtures iterate the production `delegateFamilyToolNames` slice instead of hardcoding tool names — future additions extend coverage automatically
- [ ] After merge: redeploy prod, confirm the model adapts (subsequent April-style traces should show `thane_now`/`thane_assign` only, no `thane_delegate`)
- [ ] After merge: verify the orchestrator-gating mechanism still activates correctly (any conversation with `delegation_required: true` should get the gated catalog)

## Main sync note

Rebased onto current `main` after #833, #834, and #837 merged. The remaining PR diff is the `thane_delegate` shim removal plus the #843 review fixes on top of those merged foundations.