### PR TITLE
fix: preserve loop agent telemetry

### DIFF
--- a/internal/app/adapters.go
+++ b/internal/app/adapters.go
@@ -1106,13 +1106,14 @@ func (a *loopAdapter) Run(ctx context.Context, req looppkg.Request, _ looppkg.St
 		loadedCapabilities = toolcatalog.BuildLoadedCapabilityEntries(capSurface, resp.ActiveTags)
 	}
 
-	// Use the routed model's context window if available, otherwise
-	// fall back to the agent loop's default.
-	ctxWindow := a.agentLoop.GetContextWindow()
-	if a.router != nil && resp.Model != "" {
+	ctxWindow := resp.ContextWindow
+	if ctxWindow <= 0 && a.router != nil && resp.Model != "" {
 		if mw := a.router.ContextWindowForModel(resp.Model); mw > 0 {
 			ctxWindow = mw
 		}
+	}
+	if ctxWindow <= 0 {
+		ctxWindow = a.agentLoop.GetContextWindow()
 	}
 
 	return &looppkg.Response{

--- a/internal/app/mqttwake.go
+++ b/internal/app/mqttwake.go
@@ -186,6 +186,8 @@ func dispatchViaLoop(
 				Model:              resp.Model,
 				InputTokens:        resp.InputTokens,
 				OutputTokens:       resp.OutputTokens,
+				ContextWindow:      resp.ContextWindow,
+				ToolsUsed:          resp.ToolsUsed,
 				ActiveTags:         append([]string(nil), resp.ActiveTags...),
 				EffectiveTools:     append([]string(nil), resp.EffectiveTools...),
 				LoadedCapabilities: append([]toolcatalog.LoadedCapabilityEntry(nil), resp.LoadedCapabilities...),

--- a/internal/channels/messaging/signal/bridge.go
+++ b/internal/channels/messaging/signal/bridge.go
@@ -609,6 +609,8 @@ func (b *Bridge) handleMessage(ctx context.Context, env *Envelope, progressFn fu
 		Model:              resp.Model,
 		InputTokens:        resp.InputTokens,
 		OutputTokens:       resp.OutputTokens,
+		ContextWindow:      resp.ContextWindow,
+		ToolsUsed:          resp.ToolsUsed,
 		ActiveTags:         append([]string(nil), resp.ActiveTags...),
 		EffectiveTools:     append([]string(nil), resp.EffectiveTools...),
 		LoadedCapabilities: append([]toolcatalog.LoadedCapabilityEntry(nil), resp.LoadedCapabilities...),

--- a/internal/platform/events/bus.go
+++ b/internal/platform/events/bus.go
@@ -100,7 +100,8 @@ const (
 	// Data: loop_id, loop_name, conversation_id, supervisor, attempt.
 	KindLoopIterationStart = "loop_iteration_start"
 	// KindLoopIterationComplete signals the end of a loop iteration.
-	// Data: loop_id, loop_name, model, input_tokens, output_tokens, elapsed_ms.
+	// Data: loop_id, loop_name, model, input_tokens, output_tokens,
+	// context_window, elapsed_ms, tools_used.
 	KindLoopIterationComplete = "loop_iteration_complete"
 	// KindLoopSleepStart signals a loop has entered its sleep phase.
 	// Data: loop_id, loop_name, sleep_duration, initial (bool, true

--- a/internal/runtime/agent/loop.go
+++ b/internal/runtime/agent/loop.go
@@ -119,6 +119,7 @@ type Response struct {
 	OutputTokens             int                                 `json:"output_tokens,omitempty"`
 	CacheCreationInputTokens int                                 `json:"cache_creation_input_tokens,omitempty"`
 	CacheReadInputTokens     int                                 `json:"cache_read_input_tokens,omitempty"`
+	ContextWindow            int                                 `json:"context_window,omitempty"`
 	ToolsUsed                map[string]int                      `json:"tools_used,omitempty"` // tool name → call count
 	EffectiveTools           []string                            `json:"effective_tools,omitempty"`
 	LoadedCapabilities       []toolcatalog.LoadedCapabilityEntry `json:"loaded_capabilities,omitempty"`
@@ -2363,6 +2364,7 @@ func (l *Loop) Run(ctx context.Context, req *Request, stream StreamCallback) (re
 		OutputTokens:             iterResult.OutputTokens,
 		CacheCreationInputTokens: iterResult.CacheCreationInputTokens,
 		CacheReadInputTokens:     iterResult.CacheReadInputTokens,
+		ContextWindow:            usageInfo.ContextWindow,
 		ToolsUsed:                iterResult.ToolsUsed,
 		EffectiveTools:           effectiveToolNames(),
 		Iterations:               iterResult.IterationCount,

--- a/internal/runtime/loop/loop.go
+++ b/internal/runtime/loop/loop.go
@@ -880,6 +880,14 @@ func (l *Loop) run(ctx context.Context) {
 				result.OutputTokens = outputTokens
 				delete(summary, "output_tokens")
 			}
+			if contextWindow, ok := summary["context_window"].(int); ok && contextWindow > 0 && result != nil {
+				result.ContextWindow = contextWindow
+				delete(summary, "context_window")
+			}
+			if toolsUsed, ok := summary["tools_used"].(map[string]int); ok && result != nil {
+				result.ToolsUsed = cloneToolCounts(toolsUsed)
+				delete(summary, "tools_used")
+			}
 			if activeTags, ok := summary["active_tags"].([]string); ok && result != nil {
 				result.ActiveTags = append([]string(nil), activeTags...)
 				delete(summary, "active_tags")

--- a/internal/runtime/loop/loop_test.go
+++ b/internal/runtime/loop/loop_test.go
@@ -2086,6 +2086,9 @@ func TestHandlerReportedToolingStaysInRecentIterationsOnly(t *testing.T) {
 	t.Parallel()
 
 	bus := events.New()
+	ch := bus.Subscribe(16)
+	defer bus.Unsubscribe(ch)
+
 	l, err := New(Config{
 		Name: "handler-tooling-test",
 		Handler: func(ctx context.Context, _ any) error {
@@ -2094,6 +2097,8 @@ func TestHandlerReportedToolingStaysInRecentIterationsOnly(t *testing.T) {
 				Model:          "test-model",
 				InputTokens:    42,
 				OutputTokens:   9,
+				ContextWindow:  200000,
+				ToolsUsed:      map[string]int{"archive_search": 2, "remember_fact": 1},
 				ActiveTags:     []string{"forge", "ha"},
 				EffectiveTools: []string{"forge_issue_list", "get_state"},
 				LoadedCapabilities: []toolcatalog.LoadedCapabilityEntry{
@@ -2136,6 +2141,15 @@ func TestHandlerReportedToolingStaysInRecentIterationsOnly(t *testing.T) {
 	if !slices.Equal(snap.EffectiveTools, []string{"forge_issue_list", "get_state"}) {
 		t.Fatalf("snap.EffectiveTools = %v, want [forge_issue_list get_state]", snap.EffectiveTools)
 	}
+	if snap.ToolsUsed["archive_search"] != 2 || snap.ToolsUsed["remember_fact"] != 1 {
+		t.Fatalf("snap.ToolsUsed = %v, want archive_search=2 remember_fact=1", snap.ToolsUsed)
+	}
+	if snap.ContextWindow != 200000 {
+		t.Fatalf("snap.ContextWindow = %d, want 200000", snap.ContextWindow)
+	}
+	if snap.Tooling.ToolsUsed["archive_search"] != 2 || snap.Tooling.ToolsUsed["remember_fact"] != 1 {
+		t.Fatalf("snap.Tooling.ToolsUsed = %v, want archive_search=2 remember_fact=1", snap.Tooling.ToolsUsed)
+	}
 	if len(snap.Tooling.LoadedCapabilities) != 2 {
 		t.Fatalf("snap.Tooling.LoadedCapabilities = %v, want 2 entries", snap.Tooling.LoadedCapabilities)
 	}
@@ -2147,6 +2161,33 @@ func TestHandlerReportedToolingStaysInRecentIterationsOnly(t *testing.T) {
 	}
 	if len(status.Tooling.LoadedCapabilities) != 0 {
 		t.Fatalf("status.Tooling.LoadedCapabilities = %v, want empty for idle handler loop", status.Tooling.LoadedCapabilities)
+	}
+
+	var complete *events.Event
+	for {
+		select {
+		case evt := <-ch:
+			if evt.Kind == events.KindLoopIterationComplete && evt.Source == events.SourceLoop {
+				evtCopy := evt
+				complete = &evtCopy
+			}
+		default:
+			goto drained
+		}
+	}
+drained:
+	if complete == nil {
+		t.Fatal("missing loop_iteration_complete event")
+	}
+	toolsUsed, ok := complete.Data["tools_used"].(map[string]int)
+	if !ok {
+		t.Fatalf("event tools_used = %#v, want map[string]int", complete.Data["tools_used"])
+	}
+	if toolsUsed["archive_search"] != 2 || toolsUsed["remember_fact"] != 1 {
+		t.Fatalf("event tools_used = %v, want archive_search=2 remember_fact=1", toolsUsed)
+	}
+	if complete.Data["context_window"] != 200000 {
+		t.Fatalf("event context_window = %v, want 200000", complete.Data["context_window"])
 	}
 }
 

--- a/internal/runtime/loop/summary.go
+++ b/internal/runtime/loop/summary.go
@@ -11,8 +11,8 @@ type iterSummaryKey struct{}
 // IterationSummary returns the summary map for the current iteration
 // from the handler context, or nil if not available. Handler
 // implementations call this to report per-iteration metrics to the
-// dashboard timeline. Values should be small scalars (int, string,
-// bool) to keep SSE payloads compact.
+// dashboard timeline. Values should be small scalars or compact
+// structured metadata to keep SSE payloads readable.
 func IterationSummary(ctx context.Context) map[string]any {
 	if m, ok := ctx.Value(iterSummaryKey{}).(map[string]any); ok {
 		return m
@@ -30,6 +30,8 @@ type AgentRunSummary struct {
 	Model              string
 	InputTokens        int
 	OutputTokens       int
+	ContextWindow      int
+	ToolsUsed          map[string]int
 	ActiveTags         []string
 	EffectiveTools     []string
 	LoadedCapabilities []toolcatalog.LoadedCapabilityEntry
@@ -37,8 +39,8 @@ type AgentRunSummary struct {
 
 // ReportAgentRun writes standard agent-run metrics into the current
 // iteration's summary map. It is the canonical way for handler-only
-// loops that call runner.Run() to surface request_id, model, and
-// token counts on the dashboard.
+// loops that call runner.Run() to surface request_id, model, token
+// counts, and tool usage on the dashboard.
 //
 // Callers may add additional custom fields to the summary map after
 // this call (e.g., sender, message_len).
@@ -54,6 +56,12 @@ func ReportAgentRun(ctx context.Context, s AgentRunSummary) map[string]any {
 	summary["model"] = s.Model
 	summary["input_tokens"] = s.InputTokens
 	summary["output_tokens"] = s.OutputTokens
+	if s.ContextWindow > 0 {
+		summary["context_window"] = s.ContextWindow
+	}
+	if len(s.ToolsUsed) > 0 {
+		summary["tools_used"] = cloneToolCounts(s.ToolsUsed)
+	}
 	if len(s.ActiveTags) > 0 {
 		summary["active_tags"] = append([]string(nil), s.ActiveTags...)
 	}
@@ -64,6 +72,17 @@ func ReportAgentRun(ctx context.Context, s AgentRunSummary) map[string]any {
 		summary["loaded_capabilities"] = append([]toolcatalog.LoadedCapabilityEntry(nil), s.LoadedCapabilities...)
 	}
 	return summary
+}
+
+func cloneToolCounts(tools map[string]int) map[string]int {
+	if len(tools) == 0 {
+		return nil
+	}
+	clone := make(map[string]int, len(tools))
+	for name, count := range tools {
+		clone[name] = count
+	}
+	return clone
 }
 
 // ReportConversationID overrides the loop-visible conversation ID for the

--- a/internal/runtime/loop/summary_test.go
+++ b/internal/runtime/loop/summary_test.go
@@ -38,6 +38,8 @@ func TestReportAgentRun_PopulatesSummary(t *testing.T) {
 		Model:          "claude-3-opus",
 		InputTokens:    500,
 		OutputTokens:   200,
+		ContextWindow:  200000,
+		ToolsUsed:      map[string]int{"archive_search": 2, "remember_fact": 1},
 		ActiveTags:     []string{"forge", "ha"},
 		EffectiveTools: []string{"get_state", "forge_issue_list"},
 		LoadedCapabilities: []toolcatalog.LoadedCapabilityEntry{
@@ -58,6 +60,12 @@ func TestReportAgentRun_PopulatesSummary(t *testing.T) {
 	}
 	if got["output_tokens"] != 200 {
 		t.Errorf("output_tokens = %v, want 200", got["output_tokens"])
+	}
+	if got["context_window"] != 200000 {
+		t.Errorf("context_window = %v, want 200000", got["context_window"])
+	}
+	if tools, ok := got["tools_used"].(map[string]int); !ok || len(tools) != 2 || tools["archive_search"] != 2 || tools["remember_fact"] != 1 {
+		t.Errorf("tools_used = %#v, want archive_search=2 remember_fact=1", got["tools_used"])
 	}
 	if active, ok := got["active_tags"].([]string); !ok || len(active) != 2 || active[0] != "forge" || active[1] != "ha" {
 		t.Errorf("active_tags = %#v, want [forge ha]", got["active_tags"])

--- a/internal/server/api/owu_tracker.go
+++ b/internal/server/api/owu_tracker.go
@@ -206,6 +206,8 @@ func (t *OWUTracker) ensureConvLoop(_ context.Context, convID, displayName strin
 					Model:              resp.Model,
 					InputTokens:        resp.InputTokens,
 					OutputTokens:       resp.OutputTokens,
+					ContextWindow:      resp.ContextWindow,
+					ToolsUsed:          resp.ToolsUsed,
 					ActiveTags:         append([]string(nil), resp.ActiveTags...),
 					EffectiveTools:     append([]string(nil), resp.EffectiveTools...),
 					LoadedCapabilities: append([]toolcatalog.LoadedCapabilityEntry(nil), resp.LoadedCapabilities...),


### PR DESCRIPTION
## Summary

- carry routed `context_window` on `agent.Response` so loop adapters and handler-only loops can report the actual model window
- include `tools_used` and `context_window` in `ReportAgentRun` summaries, then extract them into loop iteration snapshots/events
- wire Signal, MQTT wake, and OWU handler loops through the richer summary shape

## Context

Production request content showed successful `archive_search` / `remember_fact` calls for loop `019de102-0652-7710-b0c4-379945d65dc8`, but the corresponding loop iteration logs still had `tools_used:null` and `context_window:0`. The nested agent run had the data; the handler-loop telemetry adapter was only copying the older subset of response fields.

## Test Plan

- `just test`
- `just ci`