### PR TITLE
refactor: route loop turns through common builder

### DIFF
--- a/internal/app/emailhandler.go
+++ b/internal/app/emailhandler.go
@@ -9,56 +9,45 @@ import (
 	"github.com/nugget/thane-ai-agent/internal/channels/email"
 	"github.com/nugget/thane-ai-agent/internal/model/prompts"
 	"github.com/nugget/thane-ai-agent/internal/model/router"
-	"github.com/nugget/thane-ai-agent/internal/runtime/agent"
 	looppkg "github.com/nugget/thane-ai-agent/internal/runtime/loop"
 )
 
-// emailPollHandler returns a loop handler that checks IMAP accounts for
-// new messages and dispatches an agent conversation when new mail is
-// found. When no new messages are detected, the handler returns nil
-// without invoking the LLM, avoiding unnecessary token spend.
-func emailPollHandler(poller *email.Poller, runner agentRunner, logger *slog.Logger) func(context.Context, any) error {
-	return func(ctx context.Context, _ any) error {
+// emailPollTurnBuilder checks IMAP accounts for new messages and prepares
+// an agent turn when new mail is found. When no new messages are detected,
+// it returns nil so the loop runtime treats the wake as a no-op.
+func emailPollTurnBuilder(poller *email.Poller, logger *slog.Logger) looppkg.TurnBuilder {
+	return func(ctx context.Context, _ looppkg.TurnInput) (*looppkg.AgentTurn, error) {
 		wakeMsg, err := poller.CheckNewMessages(ctx)
 		if err != nil {
-			return fmt.Errorf("check new messages: %w", err)
+			return nil, fmt.Errorf("check new messages: %w", err)
 		}
 		if wakeMsg == "" {
-			return nil // nothing new — no LLM call
+			return nil, nil // nothing new — no LLM call
 		}
 
-		// Dispatch agent conversation for the new mail.
 		msg := prompts.EmailPollWakePrompt(wakeMsg)
 		convID := fmt.Sprintf("email-poll-%d", time.Now().UnixMilli())
 
-		logger.Info("new email detected, dispatching agent",
+		logger.Info("new email detected, preparing agent turn",
 			"conv_id", convID,
 			"wake_msg_len", len(wakeMsg),
 		)
 
-		resp, err := runner.Run(ctx, &agent.Request{
-			ConversationID: convID,
-			Messages:       []agent.Message{{Role: "user", Content: msg}},
-			Hints: map[string]string{
-				"source":                    "email_poll",
-				router.HintLocalOnly:        "false",
-				router.HintQualityFloor:     "5",
-				router.HintMission:          "automation",
-				router.HintDelegationGating: "disabled",
+		return &looppkg.AgentTurn{
+			Request: looppkg.Request{
+				ConversationID: convID,
+				Messages:       []looppkg.Message{{Role: "user", Content: msg}},
+				Hints: map[string]string{
+					"source":                    "email_poll",
+					router.HintLocalOnly:        "false",
+					router.HintQualityFloor:     "5",
+					router.HintMission:          "automation",
+					router.HintDelegationGating: "disabled",
+				},
 			},
-		}, nil)
-		if err != nil {
-			return fmt.Errorf("agent dispatch: %w", err)
-		}
-
-		if summary := looppkg.IterationSummary(ctx); summary != nil && resp != nil {
-			summary["request_id"] = resp.RequestID
-		}
-
-		logger.Info("email triage complete",
-			"conv_id", convID,
-			"result_len", len(resp.Content),
-		)
-		return nil
+			Summary: map[string]any{
+				"wake_msg_len": len(wakeMsg),
+			},
+		}, nil
 	}
 }

--- a/internal/app/feedhandler.go
+++ b/internal/app/feedhandler.go
@@ -9,56 +9,45 @@ import (
 	"github.com/nugget/thane-ai-agent/internal/integrations/media"
 	"github.com/nugget/thane-ai-agent/internal/model/prompts"
 	"github.com/nugget/thane-ai-agent/internal/model/router"
-	"github.com/nugget/thane-ai-agent/internal/runtime/agent"
 	looppkg "github.com/nugget/thane-ai-agent/internal/runtime/loop"
 )
 
-// mediaFeedHandler returns a loop handler that checks RSS/Atom feeds
-// for new entries and dispatches an agent conversation when new content
-// is found. When no new content is detected, the handler returns nil
-// without invoking the LLM, avoiding unnecessary token spend.
-func mediaFeedHandler(poller *media.FeedPoller, runner agentRunner, logger *slog.Logger) func(context.Context, any) error {
-	return func(ctx context.Context, _ any) error {
+// mediaFeedTurnBuilder checks RSS/Atom feeds for new entries and prepares
+// an agent turn when new content is found. When no new content is detected,
+// it returns nil so the loop runtime treats the wake as a no-op.
+func mediaFeedTurnBuilder(poller *media.FeedPoller, logger *slog.Logger) looppkg.TurnBuilder {
+	return func(ctx context.Context, _ looppkg.TurnInput) (*looppkg.AgentTurn, error) {
 		wakeMsg, err := poller.CheckFeeds(ctx)
 		if err != nil {
-			return fmt.Errorf("check feeds: %w", err)
+			return nil, fmt.Errorf("check feeds: %w", err)
 		}
 		if wakeMsg == "" {
-			return nil // nothing new — no LLM call
+			return nil, nil // nothing new — no LLM call
 		}
 
-		// Dispatch agent conversation for the new content.
 		msg := prompts.MediaFeedPollWakePrompt(wakeMsg)
 		convID := fmt.Sprintf("media-feed-%d", time.Now().UnixMilli())
 
-		logger.Info("new feed content detected, dispatching agent",
+		logger.Info("new feed content detected, preparing agent turn",
 			"conv_id", convID,
 			"wake_msg_len", len(wakeMsg),
 		)
 
-		resp, err := runner.Run(ctx, &agent.Request{
-			ConversationID: convID,
-			Messages:       []agent.Message{{Role: "user", Content: msg}},
-			Hints: map[string]string{
-				"source":                    "media_feed_poll",
-				router.HintLocalOnly:        "false",
-				router.HintQualityFloor:     "5",
-				router.HintMission:          "automation",
-				router.HintDelegationGating: "disabled",
+		return &looppkg.AgentTurn{
+			Request: looppkg.Request{
+				ConversationID: convID,
+				Messages:       []looppkg.Message{{Role: "user", Content: msg}},
+				Hints: map[string]string{
+					"source":                    "media_feed_poll",
+					router.HintLocalOnly:        "false",
+					router.HintQualityFloor:     "5",
+					router.HintMission:          "automation",
+					router.HintDelegationGating: "disabled",
+				},
 			},
-		}, nil)
-		if err != nil {
-			return fmt.Errorf("agent dispatch: %w", err)
-		}
-
-		if summary := looppkg.IterationSummary(ctx); summary != nil && resp != nil {
-			summary["request_id"] = resp.RequestID
-		}
-
-		logger.Info("media feed analysis complete",
-			"conv_id", convID,
-			"result_len", len(resp.Content),
-		)
-		return nil
+			Summary: map[string]any{
+				"wake_msg_len": len(wakeMsg),
+			},
+		}, nil
 	}
 }

--- a/internal/app/loop_definition_hydration.go
+++ b/internal/app/loop_definition_hydration.go
@@ -86,13 +86,13 @@ func (a *App) hydrateLoopDefinitionSpec(spec looppkg.Spec) (looppkg.Spec, error)
 		if a.emailPoller == nil {
 			return looppkg.Spec{}, fmt.Errorf("%s definition requires email poller runtime", emailPollerDefinitionName)
 		}
-		spec.Handler = emailPollHandler(a.emailPoller, a.loop, a.logger)
+		spec.TurnBuilder = emailPollTurnBuilder(a.emailPoller, a.logger)
 		return a.hydrateLoopOutputs(spec)
 	case mediaFeedPollerDefinitionName:
 		if a.mediaFeedPoller == nil {
 			return looppkg.Spec{}, fmt.Errorf("%s definition requires media feed poller runtime", mediaFeedPollerDefinitionName)
 		}
-		spec.Handler = mediaFeedHandler(a.mediaFeedPoller, a.loop, a.logger)
+		spec.TurnBuilder = mediaFeedTurnBuilder(a.mediaFeedPoller, a.logger)
 		return a.hydrateLoopOutputs(spec)
 	case mqttPublisherDefinitionName:
 		if a.mqttPub == nil {

--- a/internal/runtime/loop/agent_turn.go
+++ b/internal/runtime/loop/agent_turn.go
@@ -1,0 +1,47 @@
+package loop
+
+import (
+	"context"
+
+	"github.com/nugget/thane-ai-agent/internal/channels/messages"
+)
+
+// TurnInput is the loop wake context passed to a [TurnBuilder]. It is
+// intentionally about the wake, not about the final agent request: the
+// loop still applies routing, tool, progress, and accounting defaults
+// after the builder returns.
+type TurnInput struct {
+	// Event is the payload returned by Config.WaitFunc for this wake,
+	// or nil for timer-driven loops.
+	Event any
+
+	// Supervisor reports whether this wake should use supervisor
+	// routing defaults.
+	Supervisor bool
+
+	// NotifyEnvelopes are one-shot notification envelopes queued for
+	// this wake. Task-based turns render them into the prompt; custom
+	// builders may inspect or ignore them.
+	NotifyEnvelopes []messages.Envelope
+}
+
+// AgentTurn is an agent request prepared by loop-adjacent code for the
+// loop runtime to execute. The request is not yet final; the runtime
+// still merges loop defaults, launch overrides, progress callbacks,
+// tool filters, and carried capability tags before calling the runner.
+type AgentTurn struct {
+	// Request is the model-facing request prepared for this wake before
+	// loop-level request defaults are applied.
+	Request Request
+
+	// Summary is compact operator context copied onto the iteration
+	// snapshot and completion event. Values should stay small because
+	// they travel through dashboard/event payloads.
+	Summary map[string]any
+}
+
+// TurnBuilder prepares model-facing work from a loop wake. A nil
+// AgentTurn with nil error means the wake produced no work and should
+// be treated as [ErrNoOp]. Builders should observe and prepare; the
+// loop runtime owns execution, telemetry, snapshots, and completion.
+type TurnBuilder func(ctx context.Context, input TurnInput) (*AgentTurn, error)

--- a/internal/runtime/loop/config.go
+++ b/internal/runtime/loop/config.go
@@ -125,7 +125,8 @@ type Config struct {
 	Name string
 
 	// Task is the LLM prompt for each iteration. It describes what
-	// the loop should observe, check, or do on each wake.
+	// the loop should observe, check, or do on each wake. Ignored when
+	// TaskBuilder or TurnBuilder is set.
 	Task string
 
 	// Operation describes the runtime pattern expected for the loop.
@@ -204,9 +205,18 @@ type Config struct {
 	OnRetrigger RetriggerMode
 
 	// TaskBuilder is called per-iteration to generate a dynamic prompt.
-	// When set, the static Task field is ignored. The isSupervisor
-	// argument indicates whether this is a supervisor iteration.
+	// When set, the static Task field is ignored. The returned prompt
+	// is wrapped as an [AgentTurn] so task-based loops use the same
+	// request preparation and runner path as [TurnBuilder].
 	TaskBuilder func(ctx context.Context, isSupervisor bool) (string, error) `json:"-"`
+
+	// TurnBuilder prepares a full agent request for each wake while
+	// leaving model execution, telemetry, snapshots, and completion
+	// handling in the loop runtime. Return nil, nil when the wake
+	// produced no model-facing work. If unset, Task/TaskBuilder are
+	// adapted into this shape. Use Handler instead for work that should
+	// not run a model turn.
+	TurnBuilder TurnBuilder `json:"-"`
 
 	// PostIterate is called after each successful iteration. Use it
 	// for side effects like appending iteration logs. Errors are
@@ -308,8 +318,8 @@ func (c *Config) applyDefaults() {
 // validate checks that post-default Config values are internally
 // consistent. Called by [New] after [applyDefaults].
 func (c *Config) validate() error {
-	if c.Handler == nil && c.Task == "" && c.TaskBuilder == nil {
-		return fmt.Errorf("loop: Task, TaskBuilder, or Handler is required")
+	if c.Handler == nil && c.Task == "" && c.TaskBuilder == nil && c.TurnBuilder == nil {
+		return fmt.Errorf("loop: Task, TaskBuilder, TurnBuilder, or Handler is required")
 	}
 	if c.SleepMin <= 0 {
 		return fmt.Errorf("loop: SleepMin must be positive, got %v", c.SleepMin)

--- a/internal/runtime/loop/doc.go
+++ b/internal/runtime/loop/doc.go
@@ -16,6 +16,38 @@
 //
 // See issue #509 for the full design.
 //
+// # Turn construction lifecycle
+//
+// Model-facing loop work is built in two phases so wake-specific code
+// can prepare useful context without owning model execution. First,
+// a wake is converted into an [AgentTurn]. Then the loop applies its
+// common request environment and runs the agent.
+//
+//	WaitFunc / timer wake
+//	     │
+//	     ▼
+//	TurnInput                 event payload, supervisor flag, notify envelopes
+//	     │
+//	     ├─ Config.TurnBuilder    custom request-producing wake logic
+//	     │
+//	     └─ Config.Task /
+//	        Config.TaskBuilder    prompt-only convenience path
+//	     ▼
+//	AgentTurn                prepared Request plus compact snapshot summary
+//	     │
+//	     │  prepareAgentTurnRequest
+//	     ▼
+//	Request                  loop defaults, launch overrides, progress,
+//	                         tools, tags, fallback content
+//	     │
+//	     │  runAgentTurn
+//	     ▼
+//	Runner.Run              model execution, response capture, telemetry
+//
+// [Config.Handler] is intentionally outside this chain. Use it for
+// infrastructure work that does not need a model turn; use
+// [Config.TurnBuilder] when the wake should result in agent execution.
+//
 // # Capability tag lifecycle
 //
 // Capability tags scope the tool surface, KB articles, talents, and

--- a/internal/runtime/loop/launch.go
+++ b/internal/runtime/loop/launch.go
@@ -180,7 +180,7 @@ func (l *Launch) Validate() error {
 		}
 	}
 	spec := l.Spec
-	if l.Task != "" && spec.Task == "" && spec.TaskBuilder == nil && spec.Handler == nil {
+	if l.Task != "" && spec.Task == "" && spec.TaskBuilder == nil && spec.TurnBuilder == nil && spec.Handler == nil {
 		spec.Task = l.Task
 	}
 	return spec.Validate()

--- a/internal/runtime/loop/loop.go
+++ b/internal/runtime/loop/loop.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/nugget/thane-ai-agent/internal/channels/messages"
 	"github.com/nugget/thane-ai-agent/internal/model/toolcatalog"
 	"github.com/nugget/thane-ai-agent/internal/platform/events"
 	"github.com/nugget/thane-ai-agent/internal/platform/logging"
@@ -154,7 +153,8 @@ type Deps struct {
 
 // Loop is a persistent background goroutine that iterates on a timer
 // or in response to external events. Each iteration runs an LLM call
-// via the agent runner, or a direct [Config.Handler] function for
+// via the agent runner, prepares an agent turn via [Config.TurnBuilder],
+// or calls a direct [Config.Handler] for
 // infrastructure loops that don't need an LLM. Create with [New],
 // start with [Start], stop with [Stop].
 type Loop struct {
@@ -323,7 +323,7 @@ func NewFromLaunch(launch Launch, deps Deps) (*Loop, error) {
 	}
 
 	spec := launch.Spec
-	if launch.Task != "" && spec.Task == "" && spec.TaskBuilder == nil && spec.Handler == nil {
+	if launch.Task != "" && spec.Task == "" && spec.TaskBuilder == nil && spec.TurnBuilder == nil && spec.Handler == nil {
 		spec.Task = launch.Task
 	}
 	cfg := spec.ToConfig()
@@ -450,6 +450,7 @@ func (l *Loop) Status() Status {
 	// be serialized and shouldn't leak to callers.
 	cfgCopy := l.config
 	cfgCopy.TaskBuilder = nil
+	cfgCopy.TurnBuilder = nil
 	cfgCopy.PostIterate = nil
 	cfgCopy.WaitFunc = nil
 	cfgCopy.Handler = nil
@@ -824,7 +825,8 @@ func (l *Loop) run(ctx context.Context) {
 
 		iterStartTime := time.Now()
 
-		// Dispatch: Handler runs directly; otherwise use LLM via iterate().
+		// Dispatch: Handler runs directly; otherwise build an agent
+		// turn and let the loop runtime execute it.
 		var result *IterationResult
 		var err error
 		var handlerSummary map[string]any
@@ -933,16 +935,50 @@ func (l *Loop) run(ctx context.Context) {
 				l.mu.Unlock()
 			}
 		} else {
-			// LLM-based loops always do meaningful work.
-			l.mu.Lock()
-			l.lastWakeAt = iterStartTime
-			l.attempts++
-			l.recentConvIDs = append([]string{convID}, l.recentConvIDs...)
-			if len(l.recentConvIDs) > recentConvIDsCap {
-				l.recentConvIDs = l.recentConvIDs[:recentConvIDsCap]
+			iterStart := time.Now()
+			turnCtx := withLoopID(iterCtx, l.id)
+			turnCtx = withFallbackContent(turnCtx, l.config.FallbackContent)
+			turnCtx = withNotifyEnvelopes(turnCtx, signals)
+			turn, buildErr := l.buildAgentTurn(turnCtx, TurnInput{
+				Event:           event,
+				Supervisor:      isSupervisor,
+				NotifyEnvelopes: signals,
+			})
+			if buildErr != nil {
+				if errors.Is(buildErr, ErrNoOp) {
+					noOp = true
+				} else {
+					err = fmt.Errorf("turn builder: %w", buildErr)
+				}
+			} else if turn == nil {
+				noOp = true
+			} else {
+				req, prepareErr := l.prepareAgentTurnRequest(turn.Request, convID, isSupervisor)
+				if prepareErr != nil {
+					err = prepareErr
+				} else {
+					if req.ConversationID != "" && req.ConversationID != convID {
+						convID = req.ConversationID
+						l.mu.Lock()
+						l.currentConvID = convID
+						l.mu.Unlock()
+					}
+					result, err = l.runAgentTurn(iterCtx, req, iterStart, isSupervisor)
+					if len(turn.Summary) > 0 {
+						handlerSummary = cloneSummaryMap(turn.Summary)
+					}
+				}
 			}
-			l.mu.Unlock()
-			result, err = l.iterate(iterCtx, isSupervisor, convID, signals)
+			if !noOp {
+				l.mu.Lock()
+				l.lastWakeAt = iterStartTime
+				l.attempts++
+				l.recentConvIDs = append([]string{convID}, l.recentConvIDs...)
+				if len(l.recentConvIDs) > recentConvIDsCap {
+					l.recentConvIDs = l.recentConvIDs[:recentConvIDsCap]
+				}
+				l.mu.Unlock()
+			}
 		}
 
 		// Clear in-flight state after iteration completes.
@@ -1268,41 +1304,31 @@ func (l *Loop) makeProgressFunc() func(string, map[string]any) {
 	}
 }
 
-// iterate performs a single loop iteration: build prompt and run the
-// LLM via the agent runner.
-func (l *Loop) iterate(ctx context.Context, isSupervisor bool, convID string, signals []messages.Envelope) (*IterationResult, error) {
-	iterStart := time.Now()
-
-	// Build routing hints.
-	hints := map[string]string{
-		"source":    "loop",
-		"loop_id":   l.id,
-		"loop_name": l.config.Name,
+// buildAgentTurn chooses the loop's turn construction strategy. Custom
+// TurnBuilder hooks get the wake first; otherwise Task and TaskBuilder
+// are adapted into the same AgentTurn shape.
+func (l *Loop) buildAgentTurn(ctx context.Context, input TurnInput) (*AgentTurn, error) {
+	if l.config.TurnBuilder != nil {
+		return l.config.TurnBuilder(ctx, input)
 	}
-	if isSupervisor {
-		hints["supervisor"] = "true"
-		if l.config.SupervisorQualityFloor > 0 {
-			hints["quality_floor"] = fmt.Sprintf("%d", l.config.SupervisorQualityFloor)
-		}
-		hints["local_only"] = "false"
-	} else {
-		if l.config.QualityFloor > 0 {
-			hints["quality_floor"] = fmt.Sprintf("%d", l.config.QualityFloor)
-		}
-		hints["local_only"] = "true"
-	}
+	return l.buildTaskTurn(ctx, input)
+}
 
-	// Build the task prompt. TaskBuilder takes priority over static Task.
+// buildTaskTurn adapts Config.Task and Config.TaskBuilder into the common
+// AgentTurn representation. Prompt-only concerns live here; request-level
+// routing, tool, progress, and accounting concerns stay in
+// prepareAgentTurnRequest and runAgentTurn.
+func (l *Loop) buildTaskTurn(ctx context.Context, input TurnInput) (*AgentTurn, error) {
 	var task string
 	if l.config.TaskBuilder != nil {
 		var buildErr error
-		task, buildErr = l.config.TaskBuilder(ctx, isSupervisor)
+		task, buildErr = l.config.TaskBuilder(ctx, input.Supervisor)
 		if buildErr != nil {
 			return nil, fmt.Errorf("TaskBuilder: %w", buildErr)
 		}
 	} else {
 		task = l.config.Task
-		if isSupervisor && l.config.SupervisorContext != "" {
+		if input.Supervisor && l.config.SupervisorContext != "" {
 			task = l.config.SupervisorContext + "\n\n" + task
 		}
 	}
@@ -1322,57 +1348,84 @@ func (l *Loop) iterate(ctx context.Context, isSupervisor bool, convID string, si
 			task = outputContext + "\n\n" + task
 		}
 	}
-	if signalSummary := summarizeNotifyEnvelopes(signals); signalSummary != "" {
+	if signalSummary := summarizeNotifyEnvelopes(input.NotifyEnvelopes); signalSummary != "" {
 		task = signalSummary + "\n\n" + task
 	}
 
-	// Merge loops-ng profile hints over loop-generated defaults.
+	return &AgentTurn{
+		Request: Request{
+			Messages: []Message{{Role: "user", Content: task}},
+		},
+	}, nil
+}
+
+// prepareAgentTurnRequest applies the loop request environment to a
+// prepared turn request. This is the shared boundary where task turns,
+// custom TurnBuilder turns, launch overrides, and carried capability
+// state become the final runner request.
+func (l *Loop) prepareAgentTurnRequest(req Request, convID string, isSupervisor bool) (Request, error) {
+	hints := map[string]string{
+		"source":    "loop",
+		"loop_id":   l.id,
+		"loop_name": l.config.Name,
+	}
+	if isSupervisor {
+		hints["supervisor"] = "true"
+		if l.config.SupervisorQualityFloor > 0 {
+			hints["quality_floor"] = fmt.Sprintf("%d", l.config.SupervisorQualityFloor)
+		}
+		hints["local_only"] = "false"
+	} else {
+		if l.config.QualityFloor > 0 {
+			hints["quality_floor"] = fmt.Sprintf("%d", l.config.QualityFloor)
+		}
+		hints["local_only"] = "true"
+	}
 	for k, v := range l.requestBase.Hints {
 		hints[k] = v
 	}
-
-	// Merge config hints over loop-generated defaults.
 	for k, v := range l.config.Hints {
+		hints[k] = v
+	}
+	for k, v := range req.Hints {
 		hints[k] = v
 	}
 	for k, v := range l.requestOverride.Hints {
 		hints[k] = v
 	}
 
-	conversationID := convID
-	if l.requestOverride.ConversationID != "" {
-		conversationID = l.requestOverride.ConversationID
+	configuredInitialTags := mergeUniqueStrings(l.config.Tags, l.requestBase.InitialTags, req.InitialTags, l.requestOverride.InitialTags)
+	req.Model = firstNonEmpty(l.requestOverride.Model, req.Model, l.requestBase.Model)
+	req.ConversationID = firstNonEmpty(l.requestOverride.ConversationID, req.ConversationID, convID)
+	req.ChannelBinding = firstNonNilChannelBinding(l.requestOverride.ChannelBinding, req.ChannelBinding, l.requestBase.ChannelBinding)
+	req.SkipContext = l.requestOverride.SkipContext || req.SkipContext
+	allowedTools, err := applyAllowedToolsOverride(req.AllowedTools, l.requestOverride.AllowedTools)
+	if err != nil {
+		return Request{}, err
 	}
+	req.AllowedTools = allowedTools
+	req.ExcludeTools = mergeUniqueStrings(l.requestBase.ExcludeTools, l.config.ExcludeTools, req.ExcludeTools, l.requestOverride.ExcludeTools)
+	req.SkipTagFilter = len(configuredInitialTags) == 0 || req.SkipTagFilter || l.requestOverride.SkipTagFilter
+	req.Hints = hints
+	req.OnProgress = composeProgressFuncs(l.makeProgressFunc(), req.OnProgress, l.requestOverride.OnProgress)
+	req.InitialTags = mergeUniqueStrings(configuredInitialTags, l.activatedTags)
+	req.RuntimeTools = mergeRuntimeTools(l.config.RuntimeTools, req.RuntimeTools)
+	req.FallbackContent = firstNonEmpty(l.requestOverride.FallbackContent, req.FallbackContent, l.requestBase.FallbackContent, l.config.FallbackContent)
+	req.MaxIterations = firstPositiveInt(l.requestOverride.MaxIterations, req.MaxIterations)
+	req.MaxOutputTokens = firstPositiveInt(l.requestOverride.MaxOutputTokens, req.MaxOutputTokens)
+	req.ToolTimeout = firstPositiveDuration(l.requestOverride.ToolTimeout, req.ToolTimeout)
+	req.UsageRole = firstNonEmpty(l.requestOverride.UsageRole, req.UsageRole)
+	req.UsageTaskName = firstNonEmpty(l.requestOverride.UsageTaskName, req.UsageTaskName)
+	req.SystemPrompt = firstNonEmpty(l.requestOverride.SystemPrompt, req.SystemPrompt)
+	req.PromptMode = firstPromptMode(l.requestOverride.PromptMode, req.PromptMode)
+	req.SuppressAlwaysContext = l.requestOverride.SuppressAlwaysContext || req.SuppressAlwaysContext
+	return req, nil
+}
 
-	configuredInitialTags := mergeUniqueStrings(l.config.Tags, l.requestBase.InitialTags, l.requestOverride.InitialTags)
-	skipTagFilter := len(configuredInitialTags) == 0 || l.requestOverride.SkipTagFilter
-
-	req := Request{
-		Model:          firstNonEmpty(l.requestOverride.Model, l.requestBase.Model),
-		ConversationID: conversationID,
-		ChannelBinding: firstNonNilChannelBinding(l.requestOverride.ChannelBinding, l.requestBase.ChannelBinding),
-		Messages: []Message{
-			{Role: "user", Content: task},
-		},
-		SkipContext:           l.requestOverride.SkipContext,
-		AllowedTools:          append([]string(nil), l.requestOverride.AllowedTools...),
-		ExcludeTools:          mergeUniqueStrings(l.requestBase.ExcludeTools, l.config.ExcludeTools, l.requestOverride.ExcludeTools),
-		SkipTagFilter:         skipTagFilter,
-		Hints:                 hints,
-		OnProgress:            composeProgressFuncs(l.makeProgressFunc(), l.requestOverride.OnProgress),
-		InitialTags:           mergeUniqueStrings(configuredInitialTags, l.activatedTags),
-		RuntimeTools:          cloneRuntimeTools(l.config.RuntimeTools),
-		FallbackContent:       firstNonEmpty(l.requestOverride.FallbackContent, l.requestBase.FallbackContent, l.config.FallbackContent),
-		MaxIterations:         l.requestOverride.MaxIterations,
-		MaxOutputTokens:       l.requestOverride.MaxOutputTokens,
-		ToolTimeout:           l.requestOverride.ToolTimeout,
-		UsageRole:             l.requestOverride.UsageRole,
-		UsageTaskName:         l.requestOverride.UsageTaskName,
-		SystemPrompt:          l.requestOverride.SystemPrompt,
-		PromptMode:            l.requestOverride.PromptMode,
-		SuppressAlwaysContext: l.requestOverride.SuppressAlwaysContext,
-	}
-
+// runAgentTurn is the only loop-owned path that invokes the agent runner.
+// It captures runner response state needed by subsequent iterations and
+// returns the typed iteration result used by snapshots and telemetry.
+func (l *Loop) runAgentTurn(ctx context.Context, req Request, iterStart time.Time, isSupervisor bool) (*IterationResult, error) {
 	resp, err := l.deps.Runner.Run(ctx, req, nil)
 	// Capture activated tags for next iteration (under lock since
 	// activatedTags is read during Status snapshots). Always update,
@@ -1389,16 +1442,18 @@ func (l *Loop) iterate(ctx context.Context, isSupervisor bool, convID string, si
 	}
 
 	return &IterationResult{
-		Model:          resp.Model,
-		InputTokens:    resp.InputTokens,
-		OutputTokens:   resp.OutputTokens,
-		ContextWindow:  resp.ContextWindow,
-		ToolsUsed:      resp.ToolsUsed,
-		EffectiveTools: append([]string(nil), resp.EffectiveTools...),
-		ActiveTags:     append([]string(nil), resp.ActiveTags...),
-		RequestID:      resp.RequestID,
-		Elapsed:        time.Since(iterStart),
-		Supervisor:     isSupervisor,
+		ConvID:             req.ConversationID,
+		Model:              resp.Model,
+		InputTokens:        resp.InputTokens,
+		OutputTokens:       resp.OutputTokens,
+		ContextWindow:      resp.ContextWindow,
+		ToolsUsed:          resp.ToolsUsed,
+		EffectiveTools:     append([]string(nil), resp.EffectiveTools...),
+		ActiveTags:         append([]string(nil), resp.ActiveTags...),
+		LoadedCapabilities: append([]toolcatalog.LoadedCapabilityEntry(nil), resp.LoadedCapabilities...),
+		RequestID:          resp.RequestID,
+		Elapsed:            time.Since(iterStart),
+		Supervisor:         isSupervisor,
 	}, nil
 }
 
@@ -1430,6 +1485,32 @@ func mergeUniqueStrings(parts ...[]string) []string {
 		return nil
 	}
 	return merged
+}
+
+func applyAllowedToolsOverride(base, override []string) ([]string, error) {
+	base = mergeUniqueStrings(base)
+	override = mergeUniqueStrings(override)
+	if len(override) == 0 {
+		return base, nil
+	}
+	if len(base) == 0 {
+		return override, nil
+	}
+
+	baseSet := make(map[string]struct{}, len(base))
+	for _, name := range base {
+		baseSet[name] = struct{}{}
+	}
+	result := make([]string, 0, len(override))
+	for _, name := range override {
+		if _, ok := baseSet[name]; ok {
+			result = append(result, name)
+		}
+	}
+	if len(result) == 0 {
+		return nil, fmt.Errorf("agent turn allowed_tools override has no overlap with prepared request allowed_tools")
+	}
+	return result, nil
 }
 
 func composeProgressFuncs(callbacks ...func(kind string, data map[string]any)) func(kind string, data map[string]any) {
@@ -1482,6 +1563,55 @@ func firstNonEmpty(values ...string) string {
 		}
 	}
 	return ""
+}
+
+func firstPositiveInt(values ...int) int {
+	for _, v := range values {
+		if v > 0 {
+			return v
+		}
+	}
+	return 0
+}
+
+func firstPositiveDuration(values ...time.Duration) time.Duration {
+	for _, v := range values {
+		if v > 0 {
+			return v
+		}
+	}
+	return 0
+}
+
+func firstPromptMode(values ...agentctx.PromptMode) agentctx.PromptMode {
+	for _, v := range values {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+func mergeRuntimeTools(parts ...[]RuntimeTool) []RuntimeTool {
+	var merged []RuntimeTool
+	for _, part := range parts {
+		if len(part) == 0 {
+			continue
+		}
+		merged = append(merged, cloneRuntimeTools(part)...)
+	}
+	return merged
+}
+
+func cloneSummaryMap(src map[string]any) map[string]any {
+	if len(src) == 0 {
+		return nil
+	}
+	dst := make(map[string]any, len(src))
+	for k, v := range src {
+		dst[k] = v
+	}
+	return dst
 }
 
 // computeSleep returns the sleep duration for the next cycle. If

--- a/internal/runtime/loop/loop_test.go
+++ b/internal/runtime/loop/loop_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"slices"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -773,13 +774,223 @@ func TestTaskBuilderValidation(t *testing.T) {
 		}
 	})
 
-	t.Run("neither Task nor TaskBuilder nor Handler fails", func(t *testing.T) {
+	t.Run("TurnBuilder accepted without Task", func(t *testing.T) {
+		t.Parallel()
+		_, err := New(Config{
+			Name: "turn-builder-only",
+			TurnBuilder: func(context.Context, TurnInput) (*AgentTurn, error) {
+				return &AgentTurn{
+					Request: Request{
+						Messages: []Message{{Role: "user", Content: "dynamic"}},
+					},
+				}, nil
+			},
+		}, Deps{Runner: runner})
+		if err != nil {
+			t.Errorf("expected no error with TurnBuilder, got: %v", err)
+		}
+	})
+
+	t.Run("neither Task nor builder nor Handler fails", func(t *testing.T) {
 		t.Parallel()
 		_, err := New(Config{Name: "neither"}, Deps{Runner: runner})
 		if err == nil {
-			t.Error("expected error when neither Task, TaskBuilder, nor Handler set")
+			t.Error("expected error when neither Task, builder, nor Handler set")
 		}
 	})
+}
+
+func TestTurnBuilderRunsThroughLoopRunner(t *testing.T) {
+	t.Parallel()
+
+	var gotReq RunRequest
+	runner := &inspectingRunner{onRun: func(req RunRequest) {
+		gotReq = req
+	}}
+
+	l, err := New(Config{
+		Name:         "turn-builder",
+		SleepMin:     1 * time.Millisecond,
+		SleepMax:     2 * time.Millisecond,
+		SleepDefault: 1 * time.Millisecond,
+		Jitter:       Float64Ptr(0),
+		MaxIter:      1,
+		Tags:         []string{"email"},
+		TurnBuilder: func(context.Context, TurnInput) (*AgentTurn, error) {
+			return &AgentTurn{
+				Request: Request{
+					ConversationID: "email-poll-123",
+					Messages:       []Message{{Role: "user", Content: "triage this mail"}},
+					Hints:          map[string]string{"source": "email_poll"},
+				},
+				Summary: map[string]any{"wake_msg_len": 42},
+			}, nil
+		},
+	}, Deps{Runner: runner, EventBus: events.New()})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	_ = l.Start(context.Background())
+	<-l.Done()
+
+	if gotReq.ConversationID != "email-poll-123" {
+		t.Fatalf("ConversationID = %q, want email-poll-123", gotReq.ConversationID)
+	}
+	if len(gotReq.Messages) != 1 || gotReq.Messages[0].Content != "triage this mail" {
+		t.Fatalf("Messages = %#v, want triage prompt", gotReq.Messages)
+	}
+	if gotReq.Hints["source"] != "email_poll" {
+		t.Fatalf("source hint = %q, want email_poll", gotReq.Hints["source"])
+	}
+	if gotReq.Hints["loop_name"] != "turn-builder" {
+		t.Fatalf("loop_name hint = %q, want turn-builder", gotReq.Hints["loop_name"])
+	}
+	if !slices.Equal(gotReq.InitialTags, []string{"email"}) {
+		t.Fatalf("InitialTags = %v, want [email]", gotReq.InitialTags)
+	}
+	if gotReq.OnProgress == nil {
+		t.Fatal("OnProgress is nil, want loop progress wiring")
+	}
+
+	status := l.Status()
+	if status.HandlerOnly {
+		t.Fatal("HandlerOnly = true, want false for turn builder")
+	}
+	if status.Iterations != 1 || status.Attempts != 1 {
+		t.Fatalf("Iterations/Attempts = %d/%d, want 1/1", status.Iterations, status.Attempts)
+	}
+	if len(status.RecentIterations) != 1 {
+		t.Fatalf("RecentIterations = %d, want 1", len(status.RecentIterations))
+	}
+	snap := status.RecentIterations[0]
+	if snap.ConvID != "email-poll-123" {
+		t.Fatalf("snapshot ConvID = %q, want email-poll-123", snap.ConvID)
+	}
+	if snap.Summary["wake_msg_len"] != 42 {
+		t.Fatalf("snapshot wake_msg_len = %v, want 42", snap.Summary["wake_msg_len"])
+	}
+}
+
+func TestTurnBuilderAllowedToolsOverrideIntersects(t *testing.T) {
+	t.Parallel()
+
+	var gotReq RunRequest
+	runner := &inspectingRunner{onRun: func(req RunRequest) {
+		gotReq = req
+	}}
+
+	l, err := New(Config{
+		Name:         "agent-turn-allowed-tools",
+		SleepMin:     1 * time.Millisecond,
+		SleepMax:     2 * time.Millisecond,
+		SleepDefault: 1 * time.Millisecond,
+		Jitter:       Float64Ptr(0),
+		MaxIter:      1,
+		TurnBuilder: func(context.Context, TurnInput) (*AgentTurn, error) {
+			return &AgentTurn{
+				Request: Request{
+					ConversationID: "allowed-tools-123",
+					Messages:       []Message{{Role: "user", Content: "use scoped tools"}},
+					AllowedTools:   []string{"email_search", "email_archive"},
+				},
+			}, nil
+		},
+	}, Deps{Runner: runner})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	l.requestOverride = Request{AllowedTools: []string{"email_search", "shell_exec"}}
+
+	_ = l.Start(context.Background())
+	<-l.Done()
+
+	if !slices.Equal(gotReq.AllowedTools, []string{"email_search"}) {
+		t.Fatalf("AllowedTools = %#v, want intersection [email_search]", gotReq.AllowedTools)
+	}
+}
+
+func TestTurnBuilderAllowedToolsOverrideFailsClosed(t *testing.T) {
+	t.Parallel()
+
+	var runnerCalls atomic.Int32
+	l, err := New(Config{
+		Name:         "agent-turn-allowed-tools-empty",
+		SleepMin:     1 * time.Millisecond,
+		SleepMax:     2 * time.Millisecond,
+		SleepDefault: 1 * time.Millisecond,
+		Jitter:       Float64Ptr(0),
+		MaxIter:      1,
+		TurnBuilder: func(context.Context, TurnInput) (*AgentTurn, error) {
+			return &AgentTurn{
+				Request: Request{
+					ConversationID: "allowed-tools-empty-123",
+					Messages:       []Message{{Role: "user", Content: "use scoped tools"}},
+					AllowedTools:   []string{"email_search"},
+				},
+			}, nil
+		},
+	}, Deps{Runner: &countingRunner{count: &runnerCalls}})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	l.requestOverride = Request{AllowedTools: []string{"shell_exec"}}
+
+	_ = l.Start(context.Background())
+	<-l.Done()
+
+	status := l.Status()
+	if runnerCalls.Load() != 0 {
+		t.Fatalf("runner calls = %d, want 0", runnerCalls.Load())
+	}
+	if status.Iterations != 0 || status.Attempts != 1 {
+		t.Fatalf("Iterations/Attempts = %d/%d, want 0/1", status.Iterations, status.Attempts)
+	}
+	if !strings.Contains(status.LastError, "allowed_tools override has no overlap") {
+		t.Fatalf("LastError = %q, want allowed_tools overlap error", status.LastError)
+	}
+}
+
+func TestTurnBuilderNilTurnIsNoOp(t *testing.T) {
+	t.Parallel()
+
+	var runnerCalls atomic.Int32
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	l, err := New(Config{
+		Name:         "turn-noop",
+		SleepMin:     1 * time.Millisecond,
+		SleepMax:     2 * time.Millisecond,
+		SleepDefault: 1 * time.Millisecond,
+		Jitter:       Float64Ptr(0),
+		MaxIter:      100,
+		TurnBuilder: func(context.Context, TurnInput) (*AgentTurn, error) {
+			cancel()
+			return nil, nil
+		},
+	}, Deps{Runner: &countingRunner{count: &runnerCalls}})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	_ = l.Start(ctx)
+	select {
+	case <-l.Done():
+	case <-time.After(5 * time.Second):
+		t.Fatal("loop did not finish")
+	}
+
+	status := l.Status()
+	if runnerCalls.Load() != 0 {
+		t.Fatalf("runner calls = %d, want 0", runnerCalls.Load())
+	}
+	if status.Iterations != 0 || status.Attempts != 0 {
+		t.Fatalf("Iterations/Attempts = %d/%d, want 0/0", status.Iterations, status.Attempts)
+	}
+	if status.ConsecutiveErrors != 0 || status.LastError != "" {
+		t.Fatalf("error state = %d/%q, want empty", status.ConsecutiveErrors, status.LastError)
+	}
 }
 
 func TestPostIterate(t *testing.T) {

--- a/internal/runtime/loop/spec.go
+++ b/internal/runtime/loop/spec.go
@@ -78,7 +78,7 @@ type Spec struct {
 	Enabled bool `yaml:"enabled" json:"enabled"`
 
 	// Task is the static prompt for each iteration. Ignored when
-	// TaskBuilder is set.
+	// TaskBuilder or TurnBuilder is set.
 	Task string `yaml:"task,omitempty" json:"task,omitempty"`
 
 	// Profile shapes loop execution: routing hints, context-injection
@@ -146,8 +146,16 @@ type Spec struct {
 	// while already running.
 	OnRetrigger RetriggerMode `yaml:"on_retrigger,omitempty" json:"on_retrigger,omitempty"`
 
-	// TaskBuilder generates a prompt per-iteration.
+	// TaskBuilder generates a prompt per-iteration. The loop adapts
+	// the prompt into the common TurnBuilder execution path so task
+	// loops and custom turn builders share request preparation and
+	// runner execution.
 	TaskBuilder func(ctx context.Context, isSupervisor bool) (string, error) `yaml:"-" json:"-"`
+
+	// TurnBuilder prepares an agent request per wake while leaving
+	// execution in the loop runtime. It is runtime-only because it
+	// captures Go dependencies and cannot be persisted.
+	TurnBuilder TurnBuilder `yaml:"-" json:"-"`
 
 	// PostIterate runs after each successful iteration.
 	PostIterate func(ctx context.Context, result IterationResult) error `yaml:"-" json:"-"`
@@ -225,6 +233,8 @@ func (s *Spec) ValidatePersistable() error {
 	switch {
 	case s.TaskBuilder != nil:
 		return fmt.Errorf("loop: persistable spec %q cannot set TaskBuilder", s.Name)
+	case s.TurnBuilder != nil:
+		return fmt.Errorf("loop: persistable spec %q cannot set TurnBuilder", s.Name)
 	case s.PostIterate != nil:
 		return fmt.Errorf("loop: persistable spec %q cannot set PostIterate", s.Name)
 	case s.WaitFunc != nil:
@@ -273,6 +283,7 @@ func (s *Spec) ToConfig() Config {
 		SupervisorQualityFloor: ns.SupervisorQualityFloor,
 		OnRetrigger:            ns.OnRetrigger,
 		TaskBuilder:            ns.TaskBuilder,
+		TurnBuilder:            ns.TurnBuilder,
 		PostIterate:            ns.PostIterate,
 		WaitFunc:               ns.WaitFunc,
 		Handler:                ns.Handler,

--- a/internal/runtime/loop/spec_test.go
+++ b/internal/runtime/loop/spec_test.go
@@ -202,17 +202,44 @@ func TestSpecProfileRequestSeedsInitialTagsFromSpecTags(t *testing.T) {
 }
 
 func TestSpecValidatePersistableRejectsRuntimeHooks(t *testing.T) {
-	spec := &Spec{
-		Name: "dynamic-loop",
-		Task: "Do useful background work.",
-		TaskBuilder: func(_ context.Context, _ bool) (string, error) {
-			return "dynamic", nil
+	tests := []struct {
+		name    string
+		mutate  func(*Spec)
+		wantErr string
+	}{
+		{
+			name: "task builder",
+			mutate: func(spec *Spec) {
+				spec.TaskBuilder = func(_ context.Context, _ bool) (string, error) {
+					return "dynamic", nil
+				}
+			},
+			wantErr: "cannot set TaskBuilder",
+		},
+		{
+			name: "turn builder",
+			mutate: func(spec *Spec) {
+				spec.TurnBuilder = func(context.Context, TurnInput) (*AgentTurn, error) {
+					return nil, nil
+				}
+			},
+			wantErr: "cannot set TurnBuilder",
 		},
 	}
 
-	err := spec.ValidatePersistable()
-	if err == nil || !strings.Contains(err.Error(), "cannot set TaskBuilder") {
-		t.Fatalf("ValidatePersistable() error = %v, want TaskBuilder rejection", err)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			spec := &Spec{
+				Name: "dynamic-loop",
+				Task: "Do useful background work.",
+			}
+			tt.mutate(spec)
+
+			err := spec.ValidatePersistable()
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("ValidatePersistable() error = %v, want %q", err, tt.wantErr)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Background

This PR is the first small slice of the loop-plumbing cleanup we discussed: moving toward a codebase where loop-owned model work goes through the same runtime path, while wake handlers stay focused on observing the outside world and deciding whether there is work to do.

The concrete smell was the email and media feed pollers. They were registered as loop handlers, but when they found new work they called the agent runner directly from inside the handler. The loop still knew a handler ran, but the actual model turn took a side path: request construction, progress wiring, response capture, activated tags, telemetry, and iteration snapshots were not owned by the same code that handles ordinary loop model turns. That is the class of bug we have been bumping into lately: two paths between the same conceptual points in the flow, with slightly different plumbing on each path.

## What Changed

This adds a runtime-only `loop.TurnBuilder` hook. A `TurnBuilder` receives a loop wake context and either:

- returns `nil, nil` / `ErrNoOp` when the wake produced no model-facing work, or
- returns a prepared `AgentTurn` with a `loop.Request` plus an optional compact summary map for the iteration snapshot.

The loop runtime then applies the common request environment and owns the actual runner call through `prepareAgentTurnRequest` and `runAgentTurn`. That keeps model execution, progress callbacks, activated capability tags, last response capture, request IDs, token accounting, and dashboard events in loop-owned code.

`Task` and `TaskBuilder` now adapt into this same shape internally: they build the task prompt, wrap it as an `AgentTurn`, then flow through the same request-prep and runner path as custom turn builders. Email polling and media feed polling now use `TurnBuilder` directly, so they still check external sources and build domain-specific prompts, but no longer invoke the agent runner themselves.

## Why This Shape

This is deliberately narrower than a broad loop rewrite. It gives event/poller code a clean place to prepare model-facing work without forcing every wake into a static prompt string, and without letting model execution escape the loop runtime.

The distinction is now clearer:

- `Task` / `TaskBuilder` are prompt-level conveniences that adapt into `TurnBuilder`.
- `TurnBuilder` is the common model-work construction shape for a loop wake.
- `Handler` remains for infrastructure work that does not need a model turn.

`TurnBuilder` is rejected from persistable specs, like the other runtime hooks, because it captures live Go dependencies.

## Guardrails

The common request-prep path preserves request overrides and tool filtering semantics. In particular, `allowed_tools` from a prepared turn and `allowed_tools` from launch/request overrides are intersected when both are present, so an override can restrict the visible tool surface but cannot broaden it. If both allowlists are present and disjoint, the turn fails closed before runner execution.

## Out Of Scope

This does not try to convert every remaining handler that can run an agent. Signal, OWU, MQTT, and other loop-adjacent paths should be looked at separately once this smaller pattern has reviewer confidence. The intent is to sharpen one edge of the system without turning this PR into another sweeping architecture pass.

## Test Plan

- `go test -race ./internal/runtime/loop`
- `just test`
- `just ci`