### PR TITLE
[codex] refactor: route mqtt wakes through turn builder

### DIFF
--- a/internal/app/mqttwake.go
+++ b/internal/app/mqttwake.go
@@ -12,9 +12,7 @@ import (
 
 	mqtt "github.com/nugget/thane-ai-agent/internal/channels/mqtt"
 	"github.com/nugget/thane-ai-agent/internal/model/router"
-	"github.com/nugget/thane-ai-agent/internal/model/toolcatalog"
 	"github.com/nugget/thane-ai-agent/internal/platform/events"
-	"github.com/nugget/thane-ai-agent/internal/runtime/agent"
 	looppkg "github.com/nugget/thane-ai-agent/internal/runtime/loop"
 )
 
@@ -45,7 +43,7 @@ type mqttWakeDeps struct {
 // as a child loop under the MQTT parent so it appears on the dashboard.
 func mqttWakeHandler(
 	store *mqtt.SubscriptionStore,
-	runner agentRunner,
+	runner looppkg.Runner,
 	fallback mqtt.MessageHandler,
 	logger *slog.Logger,
 	deps mqttWakeDeps,
@@ -79,11 +77,11 @@ func mqttWakeHandler(
 				convID := fmt.Sprintf("mqtt-wake-%s-%d", ws.ID, time.Now().UnixMilli())
 				msg := buildWakeMessage(topic, payload, ws.Profile.Instructions)
 
-				req := &agent.Request{
+				req := looppkg.Request{
 					ConversationID: convID,
-					Messages:       []agent.Message{{Role: "user", Content: msg}},
+					Messages:       []looppkg.Message{{Role: "user", Content: msg}},
 				}
-				applyLoopProfile(&ws.Profile, req)
+				applyLoopProfile(&ws.Profile, &req)
 				if len(ws.InitialTags) > 0 {
 					req.InitialTags = append(req.InitialTags, ws.InitialTags...)
 				}
@@ -120,8 +118,8 @@ func mqttWakeHandler(
 // short-lived context that would cancel the child loop).
 func dispatchViaLoop(
 	deps mqttWakeDeps,
-	runner agentRunner,
-	req *agent.Request,
+	runner looppkg.Runner,
+	req looppkg.Request,
 	loopName, topic, convID string,
 	logger *slog.Logger,
 ) {
@@ -169,34 +167,21 @@ func dispatchViaLoop(
 		SleepDefault: immediate,
 		Jitter:       looppkg.Float64Ptr(0),
 		ParentID:     parentID,
-		Handler: func(hCtx context.Context, _ any) error {
-			stream := agent.BuildProgressStream(looppkg.ProgressFunc(hCtx))
-			resp, err := runner.Run(hCtx, req, stream)
-			if err != nil {
-				logger.Error("mqtt wake agent failed",
-					"conv_id", convID,
-					"topic", topic,
-					"error", err,
-				)
-				return fmt.Errorf("mqtt wake %s on %s: %w", convID, topic, err)
-			}
-
-			looppkg.ReportAgentRun(hCtx, looppkg.AgentRunSummary{
-				RequestID:          resp.RequestID,
-				Model:              resp.Model,
-				InputTokens:        resp.InputTokens,
-				OutputTokens:       resp.OutputTokens,
-				ContextWindow:      resp.ContextWindow,
-				ToolsUsed:          resp.ToolsUsed,
-				ActiveTags:         append([]string(nil), resp.ActiveTags...),
-				EffectiveTools:     append([]string(nil), resp.EffectiveTools...),
-				LoadedCapabilities: append([]toolcatalog.LoadedCapabilityEntry(nil), resp.LoadedCapabilities...),
-			})
-
+		TurnBuilder: func(context.Context, looppkg.TurnInput) (*looppkg.AgentTurn, error) {
+			return &looppkg.AgentTurn{
+				Request: cloneLoopRequest(req),
+				Summary: map[string]any{
+					"mqtt_topic": topic,
+				},
+			}, nil
+		},
+		PostIterate: func(_ context.Context, result looppkg.IterationResult) error {
 			logger.Info("mqtt wake complete",
-				"conv_id", convID,
+				"conv_id", result.ConvID,
 				"topic", topic,
-				"result_len", len(resp.Content),
+				"model", result.Model,
+				"input_tokens", result.InputTokens,
+				"output_tokens", result.OutputTokens,
 			)
 			return nil
 		},
@@ -207,6 +192,7 @@ func dispatchViaLoop(
 			"conversation_id": convID,
 		},
 	}, looppkg.Deps{
+		Runner:   runner,
 		Logger:   logger,
 		EventBus: deps.eventBus,
 	})
@@ -267,13 +253,13 @@ func sanitizePayload(payload []byte) string {
 	return truncated + fmt.Sprintf("\n\n[Truncated: %d bytes total, showing first %d bytes]", len(s), maxWakePayloadBytes)
 }
 
-// applyLoopProfile applies a LoopProfile's routing configuration to an
-// agent.Request. It sets the model, merges routing hints, and copies tool
+// applyLoopProfile applies a LoopProfile's routing configuration to a
+// loop request. It sets the model, merges routing hints, and copies tool
 // exclusions. Capability tags are not part of the routing profile and
 // are applied separately by the caller. This function lives in the app
-// package rather than on LoopProfile itself to avoid a circular import
-// between router and agent.
-func applyLoopProfile(profile *router.LoopProfile, req *agent.Request) {
+// package rather than on LoopProfile itself to avoid coupling router
+// profiles to a runtime request type.
+func applyLoopProfile(profile *router.LoopProfile, req *looppkg.Request) {
 	opts := profile.RequestOptions()
 
 	if opts.Model != "" {
@@ -292,4 +278,19 @@ func applyLoopProfile(profile *router.LoopProfile, req *agent.Request) {
 	if len(opts.ExcludeTools) > 0 {
 		req.ExcludeTools = append(req.ExcludeTools, opts.ExcludeTools...)
 	}
+}
+
+// cloneLoopRequest returns an independent copy of a loop request before
+// it is handed to a TurnBuilder. MQTT wake loops are one-shot today, but
+// cloning keeps request preparation isolated from future retries or
+// accidental caller-side mutation.
+func cloneLoopRequest(req looppkg.Request) looppkg.Request {
+	req.Messages = append([]looppkg.Message(nil), req.Messages...)
+	req.ChannelBinding = req.ChannelBinding.Clone()
+	req.AllowedTools = append([]string(nil), req.AllowedTools...)
+	req.ExcludeTools = append([]string(nil), req.ExcludeTools...)
+	req.Hints = cloneStringMap(req.Hints)
+	req.InitialTags = append([]string(nil), req.InitialTags...)
+	req.RuntimeTools = append([]looppkg.RuntimeTool(nil), req.RuntimeTools...)
+	return req
 }

--- a/internal/app/mqttwake_test.go
+++ b/internal/app/mqttwake_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/nugget/thane-ai-agent/internal/platform/config"
 	"github.com/nugget/thane-ai-agent/internal/platform/database"
 	"github.com/nugget/thane-ai-agent/internal/platform/events"
-	"github.com/nugget/thane-ai-agent/internal/runtime/agent"
 	looppkg "github.com/nugget/thane-ai-agent/internal/runtime/loop"
 
 	_ "github.com/mattn/go-sqlite3"
@@ -21,20 +20,28 @@ import (
 // mqttMockRunner records Run calls for assertion.
 type mqttMockRunner struct {
 	mu   sync.Mutex
-	reqs []*agent.Request
+	reqs []looppkg.Request
 }
 
-func (m *mqttMockRunner) Run(_ context.Context, req *agent.Request, _ agent.StreamCallback) (*agent.Response, error) {
+func (m *mqttMockRunner) Run(_ context.Context, req looppkg.Request, _ looppkg.StreamCallback) (*looppkg.Response, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.reqs = append(m.reqs, req)
-	return &agent.Response{Content: "ok"}, nil
+	return &looppkg.Response{
+		Content:       "ok",
+		Model:         "test-model",
+		InputTokens:   11,
+		OutputTokens:  3,
+		ContextWindow: 4096,
+		RequestID:     "req-mqtt-test",
+		ActiveTags:    append([]string(nil), req.InitialTags...),
+	}, nil
 }
 
-func (m *mqttMockRunner) requests() []*agent.Request {
+func (m *mqttMockRunner) requests() []looppkg.Request {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	cp := make([]*agent.Request, len(m.reqs))
+	cp := make([]looppkg.Request, len(m.reqs))
 	copy(cp, m.reqs)
 	return cp
 }
@@ -189,6 +196,12 @@ func TestMQTTWakeHandlerWithRegistry(t *testing.T) {
 	if req.Hints["source"] != "mqtt_wake" {
 		t.Errorf("source hint = %q, want %q", req.Hints["source"], "mqtt_wake")
 	}
+	if req.Hints["loop_id"] == "" {
+		t.Error("loop_id hint is empty; request did not traverse loop turn preparation")
+	}
+	if req.Hints["loop_name"] != "mqtt/wake" {
+		t.Errorf("loop_name hint = %q, want %q", req.Hints["loop_name"], "mqtt/wake")
+	}
 }
 
 func TestMQTTWakeHandlerFanOut(t *testing.T) {
@@ -321,7 +334,7 @@ func TestApplyLoopProfile(t *testing.T) {
 		ExtraHints:       map[string]string{"custom": "value"},
 	}
 
-	req := &agent.Request{
+	req := &looppkg.Request{
 		Hints:        map[string]string{"existing": "hint"},
 		ExcludeTools: []string{"files_read"},
 		InitialTags:  []string{"baseline"},

--- a/internal/app/new_servers.go
+++ b/internal/app/new_servers.go
@@ -333,7 +333,13 @@ func (a *App) initServers(s *newState) error {
 		// Wrap with the wake handler: wake-configured topics dispatch
 		// agent conversations, everything else falls through to the
 		// base handler above.
-		mqttPub.SetMessageHandler(mqttWakeHandler(subStore, a.loop, baseMsgHandler, logger, wakeDeps))
+		mqttPub.SetMessageHandler(mqttWakeHandler(
+			subStore,
+			&loopAdapter{agentLoop: a.loop, router: a.rtr, capSurface: a.capSurfaceGetter()},
+			baseMsgHandler,
+			logger,
+			wakeDeps,
+		))
 
 		// Register MQTT wake subscription tools via the provider.
 		a.loop.Tools().RegisterProvider(mqtt.NewWakeTools(mqtt.NewTools(subStore)))

--- a/internal/app/taskexec.go
+++ b/internal/app/taskexec.go
@@ -10,16 +10,8 @@ import (
 	"github.com/nugget/thane-ai-agent/internal/platform/events"
 	"github.com/nugget/thane-ai-agent/internal/platform/logging"
 	"github.com/nugget/thane-ai-agent/internal/platform/scheduler"
-	"github.com/nugget/thane-ai-agent/internal/runtime/agent"
 	looppkg "github.com/nugget/thane-ai-agent/internal/runtime/loop"
 )
-
-// agentRunner abstracts direct agent dispatch sites that still bypass
-// loops-ng launch semantics (for example, handler-triggered wake paths
-// that create their own conversations).
-type agentRunner interface {
-	Run(ctx context.Context, req *agent.Request, stream agent.StreamCallback) (*agent.Response, error)
-}
 
 // taskExecDeps holds all dependencies needed by the scheduled task
 // executor. Using a struct avoids a growing parameter list as more


### PR DESCRIPTION
## Summary

This migrates MQTT wake dispatch onto the loop runtime's `TurnBuilder` path instead of using a handler that calls the agent runner directly.

## Why

After the loop turn-builder refactor, MQTT was still one of the remaining wake paths that manually built a progress stream, called `runner.Run`, and reported agent-run metrics from inside an app-level handler. That kept a parallel execution path alive for model turns and preserved the kind of plumbing split we are trying to sharpen away.

## What Changed

- MQTT wake requests are now built as `looppkg.Request` values and returned from a `TurnBuilder`.
- The loop runtime now owns runner execution, telemetry, progress wiring, iteration snapshots, token accounting, and request preparation for MQTT wakes.
- Production MQTT wiring passes the standard `loopAdapter` runner used by other loop-backed app paths.
- Removed the now-unused direct `agentRunner` app shim.
- Updated MQTT wake tests to assert the request picked up loop-owned hints like `loop_id` and `loop_name`, proving it traversed common turn preparation.

## Validation

- `just test`
- `just ci`