### PR TITLE
[codex] refactor: route signal wakes through turn builder

### DIFF
--- a/internal/app/adapters.go
+++ b/internal/app/adapters.go
@@ -1153,6 +1153,7 @@ func compileLoopAgentRequest(req looppkg.Request) *agent.Request {
 		SkipTagFilter:         req.SkipTagFilter,
 		Hints:                 cloneStringMap(req.Hints),
 		InitialTags:           append([]string(nil), req.InitialTags...),
+		RuntimeTags:           append([]string(nil), req.RuntimeTags...),
 		RuntimeTools:          compileLoopRuntimeTools(req.RuntimeTools),
 		MaxIterations:         req.MaxIterations,
 		MaxOutputTokens:       req.MaxOutputTokens,

--- a/internal/app/adapters_test.go
+++ b/internal/app/adapters_test.go
@@ -44,6 +44,7 @@ func TestCompileLoopAgentRequest(t *testing.T) {
 		SkipTagFilter:   true,
 		Hints:           map[string]string{"mission": "automation"},
 		InitialTags:     []string{"monitoring"},
+		RuntimeTags:     []string{"message_channel"},
 		MaxIterations:   7,
 		MaxOutputTokens: 321,
 		ToolTimeout:     2 * time.Second,
@@ -89,6 +90,7 @@ func TestCompileLoopAgentRequest(t *testing.T) {
 	got.ExcludeTools[0] = "changed"
 	got.Hints["mission"] = "changed"
 	got.InitialTags[0] = "changed"
+	got.RuntimeTags[0] = "changed"
 	got.ChannelBinding.ContactName = "changed"
 
 	if req.AllowedTools[0] != "alpha" {
@@ -102,6 +104,9 @@ func TestCompileLoopAgentRequest(t *testing.T) {
 	}
 	if req.InitialTags[0] != "monitoring" {
 		t.Fatalf("InitialTags mutated = %#v", req.InitialTags)
+	}
+	if req.RuntimeTags[0] != "message_channel" {
+		t.Fatalf("RuntimeTags mutated = %#v", req.RuntimeTags)
 	}
 	if req.ChannelBinding.ContactName != "Alice Smith" {
 		t.Fatalf("ChannelBinding mutated = %#v", req.ChannelBinding)

--- a/internal/app/mqttwake.go
+++ b/internal/app/mqttwake.go
@@ -291,6 +291,7 @@ func cloneLoopRequest(req looppkg.Request) looppkg.Request {
 	req.ExcludeTools = append([]string(nil), req.ExcludeTools...)
 	req.Hints = cloneStringMap(req.Hints)
 	req.InitialTags = append([]string(nil), req.InitialTags...)
+	req.RuntimeTags = append([]string(nil), req.RuntimeTags...)
 	req.RuntimeTools = append([]looppkg.RuntimeTool(nil), req.RuntimeTools...)
 	return req
 }

--- a/internal/app/new_channels.go
+++ b/internal/app/new_channels.go
@@ -708,7 +708,7 @@ func (a *App) initChannels(s *newState) error {
 
 			bridge := sigcli.NewBridge(sigcli.BridgeConfig{
 				Client:        signalClient,
-				Runner:        a.loop,
+				Runner:        &loopAdapter{agentLoop: a.loop, router: a.rtr, capSurface: a.capSurfaceGetter()},
 				Logger:        a.logger,
 				RateLimit:     a.cfg.Signal.RateLimitPerMinute,
 				HandleTimeout: a.cfg.Signal.HandleTimeout,

--- a/internal/channels/messages/activity.go
+++ b/internal/channels/messages/activity.go
@@ -1,0 +1,122 @@
+package messages
+
+import (
+	"context"
+	"log/slog"
+	"time"
+)
+
+const defaultActivityIndicatorInterval = 10 * time.Second
+
+// ActivityIndicator manages a short-lived channel activity marker, such as
+// a typing indicator. It sends one marker immediately, refreshes it on an
+// interval, and lets callers send a final stop marker with a fresh context.
+type ActivityIndicator struct {
+	// Name is included in debug logs so transport-specific failures can be
+	// identified without making this helper depend on a particular channel.
+	Name string
+
+	// Interval controls how often Refresh is called after the initial
+	// marker. Zero uses the default interval.
+	Interval time.Duration
+
+	// Start sends the first activity marker. When nil, Refresh is used.
+	Start func(context.Context) error
+
+	// Refresh renews the marker while work is still in progress. When nil,
+	// Start is used for refreshes too.
+	Refresh func(context.Context) error
+
+	// Stop clears the marker after work is complete. Nil means there is no
+	// explicit stop action for this transport.
+	Stop func(context.Context) error
+
+	// Logger receives debug-level start, refresh, and stop failures.
+	Logger *slog.Logger
+}
+
+// Begin starts the activity marker and returns a cancel function that stops
+// future refreshes. It does not call Stop; callers should use End with a
+// context appropriate for cleanup after cancelling refreshes.
+func (i ActivityIndicator) Begin(ctx context.Context) context.CancelFunc {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	logger := i.logger()
+	refreshCtx, cancel := context.WithCancel(ctx)
+
+	start := i.Start
+	if start == nil {
+		start = i.Refresh
+	}
+	if start != nil {
+		if err := start(refreshCtx); err != nil {
+			logger.Debug("activity indicator start failed",
+				"indicator", i.name(),
+				"error", err,
+			)
+		}
+	}
+
+	refresh := i.Refresh
+	if refresh == nil {
+		refresh = i.Start
+	}
+	if refresh == nil {
+		return cancel
+	}
+
+	interval := i.Interval
+	if interval <= 0 {
+		interval = defaultActivityIndicatorInterval
+	}
+	go func() {
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-refreshCtx.Done():
+				return
+			case <-ticker.C:
+				if err := refresh(refreshCtx); err != nil {
+					logger.Debug("activity indicator refresh failed",
+						"indicator", i.name(),
+						"error", err,
+					)
+				}
+			}
+		}
+	}()
+
+	return cancel
+}
+
+// End sends the final stop marker when the transport supports one.
+func (i ActivityIndicator) End(ctx context.Context) {
+	if i.Stop == nil {
+		return
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := i.Stop(ctx); err != nil {
+		i.logger().Debug("activity indicator stop failed",
+			"indicator", i.name(),
+			"error", err,
+		)
+	}
+}
+
+func (i ActivityIndicator) logger() *slog.Logger {
+	if i.Logger != nil {
+		return i.Logger
+	}
+	return slog.Default()
+}
+
+func (i ActivityIndicator) name() string {
+	if i.Name != "" {
+		return i.Name
+	}
+	return "activity_indicator"
+}

--- a/internal/channels/messages/activity_test.go
+++ b/internal/channels/messages/activity_test.go
@@ -1,0 +1,55 @@
+package messages
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestActivityIndicatorBeginEnd(t *testing.T) {
+	var starts atomic.Int32
+	var refreshes atomic.Int32
+	var stops atomic.Int32
+	refreshed := make(chan struct{}, 1)
+
+	indicator := ActivityIndicator{
+		Name:     "test",
+		Interval: time.Millisecond,
+		Start: func(context.Context) error {
+			starts.Add(1)
+			return nil
+		},
+		Refresh: func(context.Context) error {
+			refreshes.Add(1)
+			select {
+			case refreshed <- struct{}{}:
+			default:
+			}
+			return nil
+		},
+		Stop: func(context.Context) error {
+			stops.Add(1)
+			return nil
+		},
+	}
+
+	cancel := indicator.Begin(context.Background())
+	select {
+	case <-refreshed:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for refresh")
+	}
+	cancel()
+	indicator.End(context.Background())
+
+	if starts.Load() != 1 {
+		t.Fatalf("starts = %d, want 1", starts.Load())
+	}
+	if refreshes.Load() == 0 {
+		t.Fatal("expected at least one refresh")
+	}
+	if stops.Load() != 1 {
+		t.Fatalf("stops = %d, want 1", stops.Load())
+	}
+}

--- a/internal/channels/messages/reaction.go
+++ b/internal/channels/messages/reaction.go
@@ -1,0 +1,70 @@
+package messages
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ReactionEvent is a channel-neutral description of a reaction observed on
+// an interactive message transport.
+type ReactionEvent struct {
+	// ChannelName is the human-facing channel label used in model context.
+	ChannelName string
+	// SenderID is the stable channel address that produced the reaction.
+	SenderID string
+	// SenderName is the optional display name supplied by the channel.
+	SenderName string
+	// Emoji is the reaction content.
+	Emoji string
+	// TargetAuthor identifies the author of the message being reacted to.
+	TargetAuthor string
+	// TargetTimestamp is the channel-native timestamp of the target message.
+	TargetTimestamp int64
+	// Removed reports that this event removed a prior reaction.
+	Removed bool
+}
+
+// SenderLabel returns the display name and stable address in a compact form
+// suitable for model-facing context.
+func (e ReactionEvent) SenderLabel() string {
+	name := strings.TrimSpace(e.SenderName)
+	id := strings.TrimSpace(e.SenderID)
+	if name != "" && id != "" {
+		return fmt.Sprintf("%s (%s)", name, id)
+	}
+	if name != "" {
+		return name
+	}
+	if id == "" {
+		return "unknown sender"
+	}
+	return id
+}
+
+// Prompt renders the reaction as a concise model-facing message.
+func (e ReactionEvent) Prompt() string {
+	channel := strings.TrimSpace(e.ChannelName)
+	if channel == "" {
+		channel = "Message"
+	}
+	return fmt.Sprintf("%s reaction from %s: %s on message [ts:%d] from %s",
+		channel,
+		e.SenderLabel(),
+		e.Emoji,
+		e.TargetTimestamp,
+		e.TargetAuthor,
+	)
+}
+
+// Hints returns routing hints common to reaction-triggered model turns.
+func (e ReactionEvent) Hints() map[string]string {
+	eventType := "reaction"
+	if e.Removed {
+		eventType = "reaction_removed"
+	}
+	return map[string]string{
+		"event_type":            eventType,
+		"reaction_emoji":        e.Emoji,
+		"target_sent_timestamp": fmt.Sprintf("%d", e.TargetTimestamp),
+	}
+}

--- a/internal/channels/messages/reaction_test.go
+++ b/internal/channels/messages/reaction_test.go
@@ -1,0 +1,48 @@
+package messages
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestReactionEventPrompt(t *testing.T) {
+	event := ReactionEvent{
+		ChannelName:     "Signal",
+		SenderID:        "+15551234567",
+		SenderName:      "Alice",
+		Emoji:           "❤️",
+		TargetAuthor:    "+15559999999",
+		TargetTimestamp: 1700000099000,
+	}
+
+	got := event.Prompt()
+	for _, want := range []string{
+		"Signal reaction from Alice (+15551234567)",
+		"❤️",
+		"[ts:1700000099000]",
+		"+15559999999",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("Prompt() = %q, missing %q", got, want)
+		}
+	}
+}
+
+func TestReactionEventHints(t *testing.T) {
+	event := ReactionEvent{
+		Emoji:           "👍",
+		TargetTimestamp: 12345,
+		Removed:         true,
+	}
+
+	hints := event.Hints()
+	if hints["event_type"] != "reaction_removed" {
+		t.Fatalf("event_type = %q, want reaction_removed", hints["event_type"])
+	}
+	if hints["reaction_emoji"] != "👍" {
+		t.Fatalf("reaction_emoji = %q, want 👍", hints["reaction_emoji"])
+	}
+	if hints["target_sent_timestamp"] != "12345" {
+		t.Fatalf("target_sent_timestamp = %q, want 12345", hints["target_sent_timestamp"])
+	}
+}

--- a/internal/channels/messaging/signal/bridge.go
+++ b/internal/channels/messaging/signal/bridge.go
@@ -11,22 +11,22 @@ import (
 	"sync"
 	"time"
 
+	"github.com/nugget/thane-ai-agent/internal/channels/messages"
 	"github.com/nugget/thane-ai-agent/internal/model/prompts"
 	"github.com/nugget/thane-ai-agent/internal/model/router"
-	"github.com/nugget/thane-ai-agent/internal/model/toolcatalog"
 	"github.com/nugget/thane-ai-agent/internal/platform/config"
 	"github.com/nugget/thane-ai-agent/internal/platform/events"
 	"github.com/nugget/thane-ai-agent/internal/platform/logging"
-	"github.com/nugget/thane-ai-agent/internal/runtime/agent"
 	"github.com/nugget/thane-ai-agent/internal/runtime/loop"
 	"github.com/nugget/thane-ai-agent/internal/state/attachments"
 	"github.com/nugget/thane-ai-agent/internal/state/memory"
 )
 
-// AgentRunner abstracts the agent loop for testability. The real
-// implementation is *agent.Loop.
+// AgentRunner abstracts the loop-owned agent runner for testability.
+// Production passes the app loop adapter so Signal requests share the
+// same execution path as other loop turns.
 type AgentRunner interface {
-	Run(ctx context.Context, req *agent.Request, stream agent.StreamCallback) (*agent.Response, error)
+	Run(ctx context.Context, req loop.Request, stream loop.StreamCallback) (*loop.Response, error)
 }
 
 // ContactResolver resolves a channel/address pair to a typed channel
@@ -273,6 +273,15 @@ func (b *Bridge) dispatch(ctx context.Context, event any) error {
 	// Reactions are carried inside dataMessage but have no
 	// text. Intercept them before the content filter.
 	if env.DataMessage != nil && env.DataMessage.Reaction != nil {
+		if env.DataMessage.Reaction.IsRemove {
+			b.handleReaction(ctx, env)
+			if summary != nil {
+				summary["action"] = "reaction_removed"
+				summary["sender"] = env.Source
+				summary["emoji"] = env.DataMessage.Reaction.Emoji
+			}
+			return nil
+		}
 		if !b.allowSender(env.Source) {
 			b.logger.Warn("signal reaction rate-limited",
 				"sender", env.Source,
@@ -283,7 +292,9 @@ func (b *Bridge) dispatch(ctx context.Context, event any) error {
 			}
 			return nil
 		}
-		b.handleReaction(ctx, env)
+		if !b.enqueueSenderEnvelope(ctx, env) {
+			return nil
+		}
 		if summary != nil {
 			summary["action"] = "reaction"
 			summary["sender"] = env.Source
@@ -294,9 +305,8 @@ func (b *Bridge) dispatch(ctx context.Context, event any) error {
 
 	// For DataMessages with neither text nor attachments,
 	// track the signal timestamp so the reaction tool's
-	// "latest" resolution still works. Messages with content
-	// update lastInboundTS inside handleMessage (after the
-	// idle rotation check).
+	// "latest" resolution still works. Messages with content update
+	// lastInboundTS during turn preparation.
 	hasContent := env.DataMessage != nil &&
 		(env.DataMessage.Message != "" || len(env.DataMessage.Attachments) > 0)
 	if env.DataMessage != nil && !hasContent {
@@ -335,26 +345,7 @@ func (b *Bridge) dispatch(ctx context.Context, event any) error {
 	}
 
 	// Fan out to per-sender child loop.
-	b.ensureSenderLoop(ctx, env.Source)
-
-	b.mu.Lock()
-	ch, ok := b.senderChans[env.Source]
-	b.mu.Unlock()
-
-	enqueued := false
-	if ok {
-		select {
-		case ch <- env:
-			enqueued = true
-		case <-ctx.Done():
-			b.logger.Warn("signal context cancelled before enqueue, dropping message",
-				"sender", env.Source,
-				"error", ctx.Err(),
-			)
-		}
-	}
-
-	if !enqueued {
+	if !b.enqueueSenderEnvelope(ctx, env) {
 		// Don't send a read receipt for messages we failed to enqueue.
 		return nil
 	}
@@ -381,9 +372,34 @@ func (b *Bridge) dispatch(ctx context.Context, event any) error {
 	return nil
 }
 
+func (b *Bridge) enqueueSenderEnvelope(ctx context.Context, env *Envelope) bool {
+	if env == nil {
+		return false
+	}
+	b.ensureSenderLoop(ctx, env.Source)
+
+	b.mu.Lock()
+	ch, ok := b.senderChans[env.Source]
+	b.mu.Unlock()
+	if !ok {
+		return false
+	}
+
+	select {
+	case ch <- env:
+		return true
+	case <-ctx.Done():
+		b.logger.Warn("signal context cancelled before enqueue, dropping message",
+			"sender", env.Source,
+			"error", ctx.Err(),
+		)
+		return false
+	}
+}
+
 // ensureSenderLoop creates a per-sender child loop if one does not
 // already exist. The child loop blocks on a per-sender channel and
-// processes messages sequentially via handleMessage.
+// processes envelopes sequentially via TurnBuilder.
 func (b *Bridge) ensureSenderLoop(ctx context.Context, sender string) {
 	b.mu.Lock()
 	if _, exists := b.senderChans[sender]; exists {
@@ -419,7 +435,7 @@ func (b *Bridge) ensureSenderLoop(ctx context.Context, sender string) {
 					if !ok {
 						return
 					}
-					b.handleMessage(ctx, env, nil)
+					b.handleEnvelope(ctx, env, nil)
 				}
 			}
 		}()
@@ -439,14 +455,12 @@ func (b *Bridge) ensureSenderLoop(ctx context.Context, sender string) {
 				return env, nil
 			}
 		},
-		Handler: func(hCtx context.Context, event any) error {
-			env, ok := event.(*Envelope)
+		TurnBuilder: func(tCtx context.Context, input loop.TurnInput) (*loop.AgentTurn, error) {
+			env, ok := input.Event.(*Envelope)
 			if !ok {
-				return nil
+				return nil, nil
 			}
-			progressFn := loop.ProgressFunc(hCtx)
-			b.handleMessage(hCtx, env, progressFn)
-			return nil
+			return b.prepareSignalTurn(tCtx, env)
 		},
 		ParentID:        parentID,
 		FallbackContent: prompts.InteractiveEmptyResponseFallback,
@@ -464,7 +478,11 @@ func (b *Bridge) ensureSenderLoop(ctx context.Context, sender string) {
 				return b.LinkSource
 			}),
 		},
-	}, loop.Deps{Logger: b.logger, EventBus: b.eventBus})
+	}, loop.Deps{
+		Runner:   signalResponseRunner{bridge: b, runner: b.runner},
+		Logger:   b.logger,
+		EventBus: b.eventBus,
+	})
 	if err != nil {
 		b.logger.Error("failed to spawn sender loop",
 			"sender", sender,
@@ -480,42 +498,87 @@ func (b *Bridge) ensureSenderLoop(ctx context.Context, sender string) {
 					if !ok {
 						return
 					}
-					b.handleMessage(ctx, env, nil)
+					b.handleEnvelope(ctx, env, nil)
 				}
 			}
 		}()
 	}
 }
 
-// handleMessage processes a single inbound Signal message: runs it
-// through the agent loop and sends the response back to the sender.
-// The progressFn, if non-nil, is used to forward in-flight events
-// to the loop infrastructure for dashboard visibility.
+// handleMessage processes a single inbound Signal message through the
+// loop-facing request path. The progressFn, if non-nil, is used by the
+// legacy no-registry path to forward in-flight events to loop telemetry.
 func (b *Bridge) handleMessage(ctx context.Context, env *Envelope, progressFn func(string, map[string]any)) {
-	ctx, cancel := context.WithTimeout(ctx, b.handleTimeout)
-	defer cancel()
+	b.handleEnvelope(ctx, env, progressFn)
+}
 
+// handleReaction processes an inbound emoji reaction. Reaction
+// removals are logged but do not wake the agent. Non-removal
+// reactions are forwarded to the agent loop with contextual hints.
+func (b *Bridge) handleReaction(ctx context.Context, env *Envelope) {
+	sender := env.Source
+	reaction := signalReactionEvent(env)
+
+	if reaction.Removed {
+		b.logger.Info("signal reaction removed",
+			"sender", sender,
+			"emoji", reaction.Emoji,
+			"target_author", reaction.TargetAuthor,
+			"target_timestamp", reaction.TargetTimestamp,
+		)
+		return
+	}
+
+	b.handleEnvelope(ctx, env, nil)
+}
+
+func (b *Bridge) handleEnvelope(ctx context.Context, env *Envelope, progressFn func(string, map[string]any)) {
+	turn, err := b.prepareSignalTurn(ctx, env)
+	if err != nil {
+		b.logger.Error("signal turn preparation failed", "error", err)
+		return
+	}
+	if turn == nil {
+		return
+	}
+	req := turn.Request
+	if progressFn != nil {
+		req.OnProgress = progressFn
+	}
+	_, _ = signalResponseRunner{bridge: b, runner: b.runner}.Run(ctx, req, nil)
+}
+
+func (b *Bridge) prepareSignalTurn(ctx context.Context, env *Envelope) (*loop.AgentTurn, error) {
+	if env == nil || env.DataMessage == nil {
+		return nil, nil
+	}
+	if env.DataMessage.Reaction != nil {
+		if env.DataMessage.Reaction.IsRemove {
+			b.handleReaction(ctx, env)
+			return nil, nil
+		}
+		return b.prepareReactionTurn(ctx, env)
+	}
+	if env.DataMessage.Message == "" && len(env.DataMessage.Attachments) == 0 {
+		return nil, nil
+	}
+	return b.prepareMessageTurn(ctx, env)
+}
+
+func (b *Bridge) prepareMessageTurn(ctx context.Context, env *Envelope) (*loop.AgentTurn, error) {
 	sender := env.Source
 	convID := fmt.Sprintf("signal-%s", sanitizePhone(sender))
-
-	// Inject a context logger with Signal-specific trace fields so all
-	// downstream code (agent loop, tools, delegate) inherits them.
 	log := b.logger.With(
 		"subsystem", logging.SubsystemSignal,
 		"conversation_id", convID,
 		"sender", sender,
 	)
-	ctx = logging.WithLogger(ctx, log)
 
-	// Process attachments before formatting the message.
 	var attachmentDescs []string
 	if len(env.DataMessage.Attachments) > 0 {
 		if env.DataMessage.ViewOnce {
 			attachmentDescs = []string{"[View-once attachment — not available]"}
 		} else {
-			// Use the Signal message timestamp for provenance rather than
-			// wall-clock time, so records remain accurate across processing
-			// delays and downtime replays.
 			msgTS := env.Timestamp
 			if env.DataMessage.Timestamp != 0 {
 				msgTS = env.DataMessage.Timestamp
@@ -537,13 +600,8 @@ func (b *Bridge) handleMessage(ctx context.Context, env *Envelope, progressFn fu
 		"attachments", len(env.DataMessage.Attachments),
 	)
 
-	// Update lastInboundTS so the reaction tool's "latest" resolution
-	// has a fresh anchor. Idle-session rotation is no longer triggered
-	// here — the summarizer worker is the sole owner of idle close,
-	// and continuity is delivered via the message_channel context
-	// provider's verbatim tail rather than an LLM-driven carry-forward.
 	ts := env.Timestamp
-	if env.DataMessage != nil && env.DataMessage.Timestamp != 0 {
+	if env.DataMessage.Timestamp != 0 {
 		ts = env.DataMessage.Timestamp
 	}
 	b.mu.Lock()
@@ -553,133 +611,32 @@ func (b *Bridge) handleMessage(ctx context.Context, env *Envelope, progressFn fu
 	}
 	b.mu.Unlock()
 
-	// Start typing indicator refresh loop. The goroutine sends an
-	// initial indicator and then re-sends every 10s to keep it
-	// visible during long agent processing.
-	stopTyping := b.startTypingRefresh(ctx, sender)
-
 	opts := b.requestOptions(sender, map[string]string{
 		"source": "signal",
 		"sender": sender,
 	})
-	fallbackContent := loop.FallbackContent(ctx)
 
-	req := &agent.Request{
-		ConversationID:  convID,
-		ChannelBinding:  channelBinding,
-		Messages:        []agent.Message{{Role: "user", Content: content}},
-		Model:           opts.Model,
-		Hints:           opts.Hints,
-		ExcludeTools:    opts.ExcludeTools,
-		RuntimeTags:     []string{"message_channel"},
-		FallbackContent: fallbackContent,
-	}
-
-	stream := agent.BuildProgressStream(progressFn)
-	resp, err := b.runner.Run(ctx, req, stream)
-
-	// Stop the typing refresh goroutine, then send a definitive
-	// typing stop. Use a fresh background context so this
-	// best-effort cleanup runs even if the handler context has
-	// timed out or been cancelled.
-	stopTyping()
-	stopCtx, stopCancel := context.WithTimeout(context.Background(), 2*time.Second)
-	defer stopCancel()
-	if typErr := b.client.SendTyping(stopCtx, sender, true); typErr != nil {
-		b.logger.Debug("signal typing stop failed", "error", typErr)
-	}
-
-	// Enrich the logger with session/request IDs from the agent loop
-	// so post-run log lines correlate with the agent's context.
-	if resp != nil {
-		log = log.With("session_id", resp.SessionID, "request_id", resp.RequestID)
-	}
-
-	if err != nil {
-		log.Error("signal agent run failed", "error", err)
-		return
-	}
-	if resp != nil && strings.TrimSpace(resp.Content) == "" && fallbackContent != "" {
-		resp.Content = fallbackContent
-	}
-
-	// Report iteration stats for the loop dashboard.
-	if summary := loop.ReportAgentRun(ctx, loop.AgentRunSummary{
-		RequestID:          resp.RequestID,
-		Model:              resp.Model,
-		InputTokens:        resp.InputTokens,
-		OutputTokens:       resp.OutputTokens,
-		ContextWindow:      resp.ContextWindow,
-		ToolsUsed:          resp.ToolsUsed,
-		ActiveTags:         append([]string(nil), resp.ActiveTags...),
-		EffectiveTools:     append([]string(nil), resp.EffectiveTools...),
-		LoadedCapabilities: append([]toolcatalog.LoadedCapabilityEntry(nil), resp.LoadedCapabilities...),
-	}); summary != nil {
-		summary["message_len"] = len(content)
-		summary["response_len"] = len(resp.Content)
-		summary["sender"] = sender
-	}
-
-	log.Info("signal agent run completed",
-		"response_len", len(resp.Content),
-		"model", resp.Model,
-	)
-
-	// If the agent already called signal_send_message during its tool
-	// loop, skip the bridge-level send to avoid duplicate messages.
-	if agentAlreadySent(resp.ToolsUsed) {
-		log.Info("signal reply already sent by agent tool call")
-		return
-	}
-
-	if resp.Content == "" {
-		return
-	}
-
-	log.Info("signal sending reply",
-		"response_len", len(resp.Content),
-	)
-
-	if _, err := b.client.Send(ctx, sender, resp.Content); err != nil {
-		log.Error("signal reply send failed", "error", err)
-		return
-	}
-
-	log.Info("signal reply sent")
+	return b.agentTurn(convID, channelBinding, content, opts, map[string]any{
+		"message_len": len(content),
+		"sender":      sender,
+		"attachments": len(env.DataMessage.Attachments),
+	}), nil
 }
 
-// handleReaction processes an inbound emoji reaction. Reaction
-// removals are logged but do not wake the agent. Non-removal
-// reactions are forwarded to the agent loop with contextual hints.
-func (b *Bridge) handleReaction(ctx context.Context, env *Envelope) {
-	ctx, cancel := context.WithTimeout(ctx, b.handleTimeout)
-	defer cancel()
-
+func (b *Bridge) prepareReactionTurn(_ context.Context, env *Envelope) (*loop.AgentTurn, error) {
 	sender := env.Source
-	reaction := env.DataMessage.Reaction
+	reaction := signalReactionEvent(env)
 	convID := fmt.Sprintf("signal-%s", sanitizePhone(sender))
-
-	if reaction.IsRemove {
-		b.logger.Info("signal reaction removed",
-			"sender", sender,
-			"emoji", reaction.Emoji,
-			"target_author", reaction.TargetAuthor,
-			"target_timestamp", reaction.TargetSentTimestamp,
-		)
-		return
-	}
 
 	b.logger.Info("signal reaction received",
 		"sender", sender,
 		"emoji", reaction.Emoji,
 		"target_author", reaction.TargetAuthor,
-		"target_timestamp", reaction.TargetSentTimestamp,
+		"target_timestamp", reaction.TargetTimestamp,
 		"conversation_id", convID,
 	)
 
-	stopTyping := b.startTypingRefresh(ctx, sender)
-
-	content := formatReaction(env)
+	content := reaction.Prompt()
 	channelBinding := b.resolveBinding(sender)
 	if b.bindConversation != nil && channelBinding != nil {
 		if err := b.bindConversation(convID, channelBinding); err != nil {
@@ -687,89 +644,133 @@ func (b *Bridge) handleReaction(ctx context.Context, env *Envelope) {
 		}
 	}
 
-	opts := b.requestOptions(sender, map[string]string{
-		"source":                "signal",
-		"sender":                sender,
+	hints := reaction.Hints()
+	hints["source"] = "signal"
+	hints["sender"] = sender
+	opts := b.requestOptions(sender, hints)
+
+	return b.agentTurn(convID, channelBinding, content, opts, map[string]any{
 		"event_type":            "reaction",
+		"sender":                sender,
 		"reaction_emoji":        reaction.Emoji,
-		"target_sent_timestamp": fmt.Sprintf("%d", reaction.TargetSentTimestamp),
-	})
-	fallbackContent := loop.FallbackContent(ctx)
-
-	req := &agent.Request{
-		ConversationID:  convID,
-		ChannelBinding:  channelBinding,
-		Messages:        []agent.Message{{Role: "user", Content: content}},
-		Model:           opts.Model,
-		Hints:           opts.Hints,
-		ExcludeTools:    opts.ExcludeTools,
-		RuntimeTags:     []string{"message_channel"},
-		FallbackContent: fallbackContent,
-	}
-
-	resp, err := b.runner.Run(ctx, req, nil)
-
-	// Build a logger with correlation IDs for post-run log lines.
-	rlog := b.logger.With("sender", sender, "conversation_id", convID)
-	if resp != nil {
-		rlog = rlog.With("session_id", resp.SessionID, "request_id", resp.RequestID)
-	}
-
-	stopTyping()
-	stopCtx, stopCancel := context.WithTimeout(context.Background(), 2*time.Second)
-	defer stopCancel()
-	if typErr := b.client.SendTyping(stopCtx, sender, true); typErr != nil {
-		b.logger.Debug("signal typing stop failed", "error", typErr)
-	}
-
-	if err != nil {
-		rlog.Error("signal agent run failed (reaction)", "error", err)
-		return
-	}
-	if resp != nil && strings.TrimSpace(resp.Content) == "" && fallbackContent != "" {
-		resp.Content = fallbackContent
-	}
-
-	if agentAlreadySent(resp.ToolsUsed) || resp.Content == "" {
-		return
-	}
-
-	if _, err := b.client.Send(ctx, sender, resp.Content); err != nil {
-		rlog.Error("signal reply send failed (reaction)", "error", err)
-		return
-	}
-
-	rlog.Info("signal reply sent (reaction)")
+		"target_sent_timestamp": reaction.TargetTimestamp,
+	}), nil
 }
 
-// startTypingRefresh sends a typing indicator immediately, then
-// refreshes it on a ticker until the returned cancel function is
-// called. The caller must call the cancel function when processing
-// is complete.
-func (b *Bridge) startTypingRefresh(ctx context.Context, recipient string) context.CancelFunc {
-	refreshCtx, cancel := context.WithCancel(ctx)
+func (b *Bridge) agentTurn(convID string, binding *memory.ChannelBinding, content string, opts router.RequestOptions, summary map[string]any) *loop.AgentTurn {
+	fallbackContent := prompts.InteractiveEmptyResponseFallback
+	return &loop.AgentTurn{
+		Request: loop.Request{
+			ConversationID:  convID,
+			ChannelBinding:  binding,
+			Messages:        []loop.Message{{Role: "user", Content: content}},
+			Model:           opts.Model,
+			Hints:           opts.Hints,
+			ExcludeTools:    opts.ExcludeTools,
+			InitialTags:     []string{"signal"},
+			RuntimeTags:     []string{"message_channel"},
+			FallbackContent: fallbackContent,
+		},
+		Summary: summary,
+	}
+}
 
-	// Send initial typing indicator.
-	if err := b.client.SendTyping(refreshCtx, recipient, false); err != nil {
-		b.logger.Debug("signal typing indicator failed", "error", err)
+type signalResponseRunner struct {
+	bridge *Bridge
+	runner AgentRunner
+}
+
+func (r signalResponseRunner) Run(ctx context.Context, req loop.Request, stream loop.StreamCallback) (*loop.Response, error) {
+	if r.runner == nil {
+		return nil, fmt.Errorf("signal runner is not configured")
+	}
+	b := r.bridge
+	if b == nil {
+		return r.runner.Run(ctx, req, stream)
 	}
 
-	go func() {
-		ticker := time.NewTicker(typingRefreshInterval)
-		defer ticker.Stop()
-		for {
-			select {
-			case <-refreshCtx.Done():
-				return
-			case <-ticker.C:
-				if err := b.client.SendTyping(refreshCtx, recipient, false); err != nil {
-					b.logger.Debug("signal typing refresh failed", "error", err)
-				}
-			}
-		}
-	}()
+	sender := req.Hints["sender"]
+	log := b.logger.With(
+		"subsystem", logging.SubsystemSignal,
+		"conversation_id", req.ConversationID,
+		"sender", sender,
+	)
+	runCtx, cancel := context.WithTimeout(ctx, b.handleTimeout)
+	defer cancel()
+	runCtx = logging.WithLogger(runCtx, log)
 
-	return cancel
+	indicator := b.activityIndicator(sender)
+	stopActivity := indicator.Begin(runCtx)
+	resp, err := r.runner.Run(runCtx, req, stream)
+	stopActivity()
+	stopCtx, stopCancel := context.WithTimeout(context.Background(), 2*time.Second)
+	indicator.End(stopCtx)
+	stopCancel()
+
+	if resp == nil {
+		resp = &loop.Response{}
+	}
+	if resp.RequestID != "" {
+		log = log.With("request_id", resp.RequestID)
+	}
+	if err != nil {
+		log.Error("signal agent run failed", "error", err)
+		return resp, err
+	}
+	if strings.TrimSpace(resp.Content) == "" && req.FallbackContent != "" {
+		resp.Content = req.FallbackContent
+	}
+
+	log.Info("signal agent run completed",
+		"response_len", len(resp.Content),
+		"model", resp.Model,
+	)
+
+	if agentAlreadySent(resp.ToolsUsed) {
+		log.Info("signal reply already sent by agent tool call")
+		return resp, nil
+	}
+	if resp.Content == "" || sender == "" {
+		return resp, nil
+	}
+
+	log.Info("signal sending reply",
+		"response_len", len(resp.Content),
+	)
+	if b.client == nil {
+		log.Warn("signal reply send skipped because client is not configured")
+		return resp, nil
+	}
+	if _, err := b.client.Send(runCtx, sender, resp.Content); err != nil {
+		log.Error("signal reply send failed", "error", err)
+		return resp, fmt.Errorf("send signal reply: %w", err)
+	}
+
+	log.Info("signal reply sent")
+	return resp, nil
+}
+
+func (b *Bridge) activityIndicator(recipient string) messages.ActivityIndicator {
+	sendTyping := func(ctx context.Context, stop bool) error {
+		if b.client == nil || recipient == "" {
+			return nil
+		}
+		return b.client.SendTyping(ctx, recipient, stop)
+	}
+	return messages.ActivityIndicator{
+		Name:     "signal_typing",
+		Interval: typingRefreshInterval,
+		Start: func(ctx context.Context) error {
+			return sendTyping(ctx, false)
+		},
+		Refresh: func(ctx context.Context) error {
+			return sendTyping(ctx, false)
+		},
+		Stop: func(ctx context.Context) error {
+			return sendTyping(ctx, true)
+		},
+		Logger: b.logger,
+	}
 }
 
 func (b *Bridge) requestOptions(sender string, extraHints map[string]string) router.RequestOptions {
@@ -955,18 +956,23 @@ func formatMessage(env *Envelope, attachmentDescs []string) string {
 // reaction envelope. The output identifies the sender, the emoji,
 // and the target message timestamp.
 func formatReaction(env *Envelope) string {
-	var sb strings.Builder
-	sender := env.Source
-	if env.SourceName != "" {
-		sender = fmt.Sprintf("%s (%s)", env.SourceName, env.Source)
+	return signalReactionEvent(env).Prompt()
+}
+
+func signalReactionEvent(env *Envelope) messages.ReactionEvent {
+	if env == nil || env.DataMessage == nil || env.DataMessage.Reaction == nil {
+		return messages.ReactionEvent{ChannelName: "Signal"}
 	}
-	fmt.Fprintf(&sb, "Signal reaction from %s: %s on message [ts:%d] from %s",
-		sender,
-		env.DataMessage.Reaction.Emoji,
-		env.DataMessage.Reaction.TargetSentTimestamp,
-		env.DataMessage.Reaction.TargetAuthor,
-	)
-	return sb.String()
+	reaction := env.DataMessage.Reaction
+	return messages.ReactionEvent{
+		ChannelName:     "Signal",
+		SenderID:        env.Source,
+		SenderName:      env.SourceName,
+		Emoji:           reaction.Emoji,
+		TargetAuthor:    reaction.TargetAuthor,
+		TargetTimestamp: reaction.TargetSentTimestamp,
+		Removed:         reaction.IsRemove,
+	}
 }
 
 // processAttachments stores received attachments and returns a

--- a/internal/channels/messaging/signal/bridge_test.go
+++ b/internal/channels/messaging/signal/bridge_test.go
@@ -18,7 +18,7 @@ import (
 
 	"github.com/nugget/thane-ai-agent/internal/model/router"
 	"github.com/nugget/thane-ai-agent/internal/platform/config"
-	"github.com/nugget/thane-ai-agent/internal/runtime/agent"
+	"github.com/nugget/thane-ai-agent/internal/runtime/loop"
 	"github.com/nugget/thane-ai-agent/internal/state/attachments"
 	"github.com/nugget/thane-ai-agent/internal/state/memory"
 )
@@ -27,19 +27,19 @@ import (
 // response. Thread-safe for use from handleMessage goroutines.
 type testRunner struct {
 	mu      sync.Mutex
-	lastReq *agent.Request
-	resp    *agent.Response
+	lastReq *loop.Request
+	resp    *loop.Response
 	err     error
 }
 
-func (r *testRunner) Run(_ context.Context, req *agent.Request, _ agent.StreamCallback) (*agent.Response, error) {
+func (r *testRunner) Run(_ context.Context, req loop.Request, _ loop.StreamCallback) (*loop.Response, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	r.lastReq = req
+	r.lastReq = &req
 	return r.resp, r.err
 }
 
-func (r *testRunner) getLastReq() *agent.Request {
+func (r *testRunner) getLastReq() *loop.Request {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	return r.lastReq
@@ -68,7 +68,7 @@ func bridgeHelper(t *testing.T, opts ...bridgeOption) (*Bridge, io.Writer, io.Re
 	t.Helper()
 	client, stdout, stdin := pipeClient(t)
 	runner := &testRunner{
-		resp: &agent.Response{Content: "ok"},
+		resp: &loop.Response{Content: "ok"},
 	}
 
 	cfg := BridgeConfig{
@@ -161,6 +161,51 @@ func TestBridge_MessageRoutesToAgent(t *testing.T) {
 	}
 	if !strings.Contains(req.Messages[0].Content, "What's the weather?") {
 		t.Errorf("message content missing user text: %q", req.Messages[0].Content)
+	}
+}
+
+func TestBridge_MessageRoutesThroughSenderTurnBuilder(t *testing.T) {
+	bridge, stdout, stdin, runner := bridgeHelper(t, func(cfg *BridgeConfig) {
+		cfg.Registry = loop.NewRegistry()
+	})
+	go drainRPCRequests(t, stdin, stdout)
+
+	bridge.mu.Lock()
+	bridge.parentID = "signal-parent"
+	bridge.mu.Unlock()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	env := &Envelope{
+		Source:       "+15551234567",
+		SourceNumber: "+15551234567",
+		SourceName:   "Alice",
+		Timestamp:    1700000000000,
+		DataMessage:  &DataMessage{Message: "What's the weather?"},
+	}
+
+	if err := bridge.dispatch(ctx, env); err != nil {
+		t.Fatalf("dispatch: %v", err)
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if runner.getLastReq() != nil {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	req := runner.getLastReq()
+	if req == nil {
+		t.Fatal("runner.Run was not called")
+	}
+	if req.Hints["loop_id"] == "" {
+		t.Fatal("loop_id hint is empty; request did not traverse sender loop turn preparation")
+	}
+	if req.Hints["loop_name"] != "signal/15551234567" {
+		t.Fatalf("loop_name = %q, want signal/15551234567", req.Hints["loop_name"])
 	}
 }
 
@@ -293,7 +338,7 @@ func TestBridge_EmptyResponseNoReply(t *testing.T) {
 		}
 	}()
 
-	runner.resp = &agent.Response{Content: ""}
+	runner.resp = &loop.Response{Content: ""}
 
 	env := &Envelope{
 		Source:      "+15551234567",
@@ -409,7 +454,7 @@ func TestBridge_AgentAlreadySentSkipsDuplicateReply(t *testing.T) {
 		}
 	}()
 
-	runner.resp = &agent.Response{
+	runner.resp = &loop.Response{
 		Content: "Already sent via tool",
 		ToolsUsed: map[string]int{
 			"signal_send_message": 1,
@@ -535,6 +580,52 @@ func TestAgentAlreadySent(t *testing.T) {
 				t.Errorf("agentAlreadySent(%v) = %v, want %v", tt.toolsUsed, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestSignalResponseRunner_ReturnsReplySendError(t *testing.T) {
+	bridge, stdout, stdin, runner := bridgeHelper(t)
+	go func() {
+		reader := bufio.NewReader(stdin)
+		for {
+			line, err := reader.ReadBytes('\n')
+			if err != nil {
+				return
+			}
+			var req rpcRequest
+			if err := json.Unmarshal(line, &req); err != nil {
+				continue
+			}
+
+			var resp string
+			if req.Method == "send" {
+				resp = fmt.Sprintf(`{"jsonrpc":"2.0","id":%d,"error":{"code":-32000,"message":"delivery failed"}}`+"\n", req.ID)
+			} else {
+				resp = fmt.Sprintf(`{"jsonrpc":"2.0","id":%d,"result":{}}`+"\n", req.ID)
+			}
+			if _, err := io.WriteString(stdout, resp); err != nil {
+				return
+			}
+		}
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	resp, err := signalResponseRunner{bridge: bridge, runner: runner}.Run(ctx, loop.Request{
+		ConversationID: "signal-15551234567",
+		Hints: map[string]string{
+			"sender": "+15551234567",
+		},
+	}, nil)
+	if err == nil {
+		t.Fatal("Run returned nil error for failed Signal send")
+	}
+	if !strings.Contains(err.Error(), "send signal reply") {
+		t.Fatalf("Run error = %q, want send signal reply context", err)
+	}
+	if resp == nil || resp.Content != "ok" {
+		t.Fatalf("response = %#v, want original runner response", resp)
 	}
 }
 
@@ -735,9 +826,9 @@ func TestBridge_ContactResolution_NilResolver(t *testing.T) {
 	}
 }
 
-// --- Issue #357: Typing Indicator Refresh ---
+// --- Issue #357: Activity Indicator Refresh ---
 
-func TestStartTypingRefresh_CancelsCleanly(t *testing.T) {
+func TestBridgeActivityIndicator_CancelsCleanly(t *testing.T) {
 	bridge, _, stdin, _ := bridgeHelper(t)
 
 	// Drain RPC requests so the client doesn't block on pipe writes.
@@ -753,7 +844,7 @@ func TestStartTypingRefresh_CancelsCleanly(t *testing.T) {
 	ctx, ctxCancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer ctxCancel()
 
-	cancel := bridge.startTypingRefresh(ctx, "+15551234567")
+	cancel := bridge.activityIndicator("+15551234567").Begin(ctx)
 
 	// Let the goroutine start and potentially fire.
 	time.Sleep(50 * time.Millisecond)

--- a/internal/runtime/loop/doc.go
+++ b/internal/runtime/loop/doc.go
@@ -105,13 +105,13 @@
 //     loop/agent boundary and becomes the capability scope's seed.
 //     Lives in the [agent] package, not here.
 //
-//   - agent.Request.RuntimeTags is distinct from InitialTags despite
-//     the similar shape. RuntimeTags are trusted runtime-asserted
-//     tags the model cannot deactivate within the run; they're
-//     pinned via scope.PinChannelTags rather than scope.Request.
-//     Set by trusted callers (the Signal bridge pins
-//     "message_channel"). Use when a tag must remain active
-//     regardless of model behavior.
+//   - [Request.RuntimeTags] is distinct from InitialTags despite the
+//     similar shape. RuntimeTags are trusted runtime-asserted tags the
+//     model cannot deactivate within the run; the app adapter copies
+//     them to agent.Request.RuntimeTags, where they are pinned via
+//     scope.PinChannelTags rather than scope.Request. Set by trusted
+//     callers (the Signal bridge pins "message_channel"). Use when a
+//     tag must remain active regardless of model behavior.
 //
 //   - agent.Response.ActiveTags is the end-of-run snapshot. The loop
 //     captures it into activatedTags for the next iteration's merge,

--- a/internal/runtime/loop/loop.go
+++ b/internal/runtime/loop/loop.go
@@ -40,6 +40,11 @@ type Request struct {
 	// in addition to always-active and channel-pinned tags. Used by loops
 	// to carry forward tags activated in previous iterations.
 	InitialTags []string `yaml:"initial_tags,omitempty" json:"initial_tags,omitempty"`
+	// RuntimeTags are trusted runtime-asserted tags pinned for this runner
+	// invocation only. Unlike InitialTags, the model cannot deactivate them
+	// during the run. They are runtime-only so persisted specs and external
+	// launch JSON cannot assert trust.
+	RuntimeTags []string `yaml:"-" json:"-"`
 	// RuntimeTools are request-scoped tools visible only to this run.
 	RuntimeTools []RuntimeTool `yaml:"-" json:"-"`
 


### PR DESCRIPTION
## Summary

This moves Signal sender-loop model work onto the loop runtime `TurnBuilder` path, matching the MQTT wake migration.

## Why

Signal was still doing model execution inside channel handlers: building `loop.Request` values, constructing progress streams, calling the channel runner directly, and reporting loop summaries manually. That kept one of the main interactive ingress paths on the old parallel plumbing.

## What Changed

- Signal per-sender child loops now use `TurnBuilder` to prepare `loop.AgentTurn` values.
- Signal production wiring now passes the standard app `loopAdapter` runner.
- Signal message and reaction model turns now execute via the loop runtime runner path.
- Signal reply delivery and activity indicators are handled by a small runner decorator around the standard runner, preserving channel side effects while keeping model execution loop-owned.
- `loop.Request` now carries runtime-only `RuntimeTags` so Signal can keep pinning `message_channel` through the loop boundary.
- Added reusable channel helpers:
  - `messages.ActivityIndicator` for start/refresh/stop activity markers like typing.
  - `messages.ReactionEvent` for channel-neutral reaction prompts and routing hints.
- Added a registry-path Signal regression test asserting `loop_id`/`loop_name` are present on the runner request.

## Validation

- `just test`
- `just ci`