### PR TITLE
[codex] refactor: route owu sessions through turn builder

### DIFF
--- a/internal/app/adapters.go
+++ b/internal/app/adapters.go
@@ -15,6 +15,7 @@ import (
 	"github.com/nugget/thane-ai-agent/internal/channels/notifications"
 	"github.com/nugget/thane-ai-agent/internal/connwatch"
 	"github.com/nugget/thane-ai-agent/internal/model/fleet"
+	"github.com/nugget/thane-ai-agent/internal/model/llm"
 	"github.com/nugget/thane-ai-agent/internal/model/promptfmt"
 	"github.com/nugget/thane-ai-agent/internal/model/router"
 	"github.com/nugget/thane-ai-agent/internal/model/toolcatalog"
@@ -1008,17 +1009,24 @@ func (a *loopAdapter) capSurfaceSnapshot() []toolcatalog.CapabilitySurface {
 const maxToolResultLen = 2000
 
 // Run converts a [looppkg.Request] to [agent.Request], calls the agent
-// loop, and converts the result back to [looppkg.Response].
-func (a *loopAdapter) Run(ctx context.Context, req looppkg.Request, _ looppkg.StreamCallback) (*looppkg.Response, error) {
+// loop, and converts the result back to [looppkg.Response]. The stream
+// callback carries caller-facing events, such as HTTP token streaming;
+// req.OnProgress is translated into loop lifecycle telemetry separately.
+func (a *loopAdapter) Run(ctx context.Context, req looppkg.Request, stream looppkg.StreamCallback) (*looppkg.Response, error) {
 	agentReq := compileLoopAgentRequest(req)
 
-	// Build an agent streaming callback that relays tool and LLM
-	// events through the loop's OnProgress callback.
+	// Build one agent stream that fans out to both the caller-facing
+	// stream and the loop progress callback.
 	capSurface := a.capSurfaceSnapshot()
 
 	var agentStream agent.StreamCallback
-	if req.OnProgress != nil {
+	if stream != nil {
 		agentStream = func(e agent.StreamEvent) {
+			stream(e)
+		}
+	}
+	if req.OnProgress != nil {
+		progressStream := func(e agent.StreamEvent) {
 			switch e.Kind {
 			case agent.KindLLMStart:
 				if e.Response != nil {
@@ -1094,6 +1102,7 @@ func (a *loopAdapter) Run(ctx context.Context, req looppkg.Request, _ looppkg.St
 				}
 			}
 		}
+		agentStream = composeAgentStreams(agentStream, progressStream)
 	}
 
 	resp, err := a.agentLoop.Run(ctx, agentReq, agentStream)
@@ -1135,11 +1144,35 @@ func (a *loopAdapter) Run(ctx context.Context, req looppkg.Request, _ looppkg.St
 	}, nil
 }
 
+// composeAgentStreams returns a callback that preserves both stream
+// consumers. It is used when a loop turn needs caller-facing streaming and
+// loop progress telemetry from the same underlying agent stream.
+func composeAgentStreams(first, second agent.StreamCallback) agent.StreamCallback {
+	if first == nil {
+		return second
+	}
+	if second == nil {
+		return first
+	}
+	return func(e agent.StreamEvent) {
+		first(e)
+		second(e)
+	}
+}
+
+// compileLoopAgentRequest converts the loop-owned request mirror into the
+// agent package's request type. Mutable slices and maps are copied so the
+// loop can keep its per-turn request stable after handing execution to the
+// agent runtime.
 func compileLoopAgentRequest(req looppkg.Request) *agent.Request {
 	// Convert messages.
 	msgs := make([]agent.Message, len(req.Messages))
 	for i, m := range req.Messages {
-		msgs[i] = agent.Message{Role: m.Role, Content: m.Content}
+		msgs[i] = agent.Message{
+			Role:    m.Role,
+			Content: m.Content,
+			Images:  append([]llm.ImageContent(nil), m.Images...),
+		}
 	}
 
 	return &agent.Request{
@@ -1160,6 +1193,7 @@ func compileLoopAgentRequest(req looppkg.Request) *agent.Request {
 		ToolTimeout:           req.ToolTimeout,
 		UsageRole:             req.UsageRole,
 		UsageTaskName:         req.UsageTaskName,
+		FallbackContent:       req.FallbackContent,
 		SystemPrompt:          req.SystemPrompt,
 		PromptMode:            req.PromptMode,
 		SuppressAlwaysContext: req.SuppressAlwaysContext,

--- a/internal/app/adapters_test.go
+++ b/internal/app/adapters_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/nugget/thane-ai-agent/internal/model/llm"
 	"github.com/nugget/thane-ai-agent/internal/runtime/agentctx"
 	looppkg "github.com/nugget/thane-ai-agent/internal/runtime/loop"
 	"github.com/nugget/thane-ai-agent/internal/state/contacts"
@@ -35,7 +36,7 @@ func TestCompileLoopAgentRequest(t *testing.T) {
 			ContactName: "Alice Smith",
 		},
 		Messages: []looppkg.Message{
-			{Role: "system", Content: "stay focused"},
+			{Role: "system", Content: "stay focused", Images: []llm.ImageContent{{MediaType: "image/png", Data: "abc123"}}},
 			{Role: "user", Content: "summarize this"},
 		},
 		SkipContext:     true,
@@ -50,6 +51,7 @@ func TestCompileLoopAgentRequest(t *testing.T) {
 		ToolTimeout:     2 * time.Second,
 		UsageRole:       "delegate",
 		UsageTaskName:   "spec-probe",
+		FallbackContent: "fallback reply",
 		SystemPrompt:    "custom prompt",
 		PromptMode:      agentctx.PromptModeTask,
 	}
@@ -67,6 +69,9 @@ func TestCompileLoopAgentRequest(t *testing.T) {
 	if len(got.Messages) != 2 || got.Messages[0].Role != "system" || got.Messages[1].Content != "summarize this" {
 		t.Fatalf("Messages = %#v", got.Messages)
 	}
+	if len(got.Messages[0].Images) != 1 || got.Messages[0].Images[0].MediaType != "image/png" {
+		t.Fatalf("Images = %#v", got.Messages[0].Images)
+	}
 	if !got.SkipContext || !got.SkipTagFilter {
 		t.Fatalf("Skip flags = %#v", got)
 	}
@@ -82,6 +87,9 @@ func TestCompileLoopAgentRequest(t *testing.T) {
 	if got.SystemPrompt != "custom prompt" {
 		t.Fatalf("SystemPrompt = %q", got.SystemPrompt)
 	}
+	if got.FallbackContent != "fallback reply" {
+		t.Fatalf("FallbackContent = %q", got.FallbackContent)
+	}
 	if got.PromptMode != agentctx.PromptModeTask {
 		t.Fatalf("PromptMode = %q, want task", got.PromptMode)
 	}
@@ -91,6 +99,7 @@ func TestCompileLoopAgentRequest(t *testing.T) {
 	got.Hints["mission"] = "changed"
 	got.InitialTags[0] = "changed"
 	got.RuntimeTags[0] = "changed"
+	got.Messages[0].Images[0].MediaType = "changed"
 	got.ChannelBinding.ContactName = "changed"
 
 	if req.AllowedTools[0] != "alpha" {
@@ -107,6 +116,9 @@ func TestCompileLoopAgentRequest(t *testing.T) {
 	}
 	if req.RuntimeTags[0] != "message_channel" {
 		t.Fatalf("RuntimeTags mutated = %#v", req.RuntimeTags)
+	}
+	if req.Messages[0].Images[0].MediaType != "image/png" {
+		t.Fatalf("Images mutated = %#v", req.Messages[0].Images)
 	}
 	if req.ChannelBinding.ContactName != "Alice Smith" {
 		t.Fatalf("ChannelBinding mutated = %#v", req.ChannelBinding)

--- a/internal/app/new_servers.go
+++ b/internal/app/new_servers.go
@@ -167,7 +167,13 @@ func (a *App) initServers(s *newState) error {
 	// --- OWU tracker ---
 	// Registers a parent "owu" loop and lazily spawns per-conversation
 	// children so that Open WebUI sessions appear on the dashboard.
-	owuTracker, err := api.NewOWUTracker(s.ctx, a.loopRegistry, a.eventBus, a.loop, logger)
+	owuTracker, err := api.NewOWUTracker(
+		s.ctx,
+		a.loopRegistry,
+		a.eventBus,
+		&loopAdapter{agentLoop: a.loop, router: a.rtr, capSurface: a.capSurfaceGetter()},
+		logger,
+	)
 	if err != nil {
 		return fmt.Errorf("create owu tracker: %w", err)
 	}

--- a/internal/runtime/loop/agent_turn.go
+++ b/internal/runtime/loop/agent_turn.go
@@ -26,19 +26,47 @@ type TurnInput struct {
 }
 
 // AgentTurn is an agent request prepared by loop-adjacent code for the
-// loop runtime to execute. The request is not yet final; the runtime
-// still merges loop defaults, launch overrides, progress callbacks,
-// tool filters, and carried capability tags before calling the runner.
+// loop runtime to execute. It is the handoff point between wake-specific
+// adapters and the common runner path: builders describe the work, while
+// the loop still applies defaults, launch overrides, progress callbacks,
+// tool filters, fallback content, and carried capability tags before
+// invoking the runner.
 type AgentTurn struct {
 	// Request is the model-facing request prepared for this wake before
-	// loop-level request defaults are applied.
+	// loop-level defaults and overrides are applied. Builders should set
+	// only the request fields they actually own.
 	Request Request
+
+	// RunContext is an optional caller-owned cancellation context for the
+	// runner invocation. The loop merges it with the iteration context so
+	// request/reply callers, such as HTTP handlers, can cancel model work
+	// on disconnect without owning loop lifecycle or registration.
+	RunContext context.Context
+
+	// Stream receives raw runner stream events for this turn. The loop
+	// still wires its own progress callback separately, so Stream is for
+	// caller-facing delivery such as HTTP token streaming rather than
+	// dashboard telemetry.
+	Stream StreamCallback
+
+	// ResultSink receives the runner response and error when preparation
+	// or execution finishes. It is called synchronously from the loop
+	// goroutine, so implementations should return promptly; a buffered
+	// channel send is the usual pattern for synchronous request/reply
+	// ingress paths.
+	ResultSink TurnResultSink
 
 	// Summary is compact operator context copied onto the iteration
 	// snapshot and completion event. Values should stay small because
 	// they travel through dashboard/event payloads.
 	Summary map[string]any
 }
+
+// TurnResultSink receives the model response and error for a single
+// loop-owned turn. On request-preparation failures the response may be
+// nil; on runner failures it may contain partial metadata returned by
+// the runner.
+type TurnResultSink func(resp *Response, err error)
 
 // TurnBuilder prepares model-facing work from a loop wake. A nil
 // AgentTurn with nil error means the wake produced no work and should

--- a/internal/runtime/loop/doc.go
+++ b/internal/runtime/loop/doc.go
@@ -33,20 +33,27 @@
 //	     └─ Config.Task /
 //	        Config.TaskBuilder    prompt-only convenience path
 //	     ▼
-//	AgentTurn                prepared Request plus compact snapshot summary
+//	AgentTurn                prepared Request, optional stream/result hooks,
+//	                         compact snapshot summary
 //	     │
 //	     │  prepareAgentTurnRequest
 //	     ▼
 //	Request                  loop defaults, launch overrides, progress,
-//	                         tools, tags, fallback content
+//	                         tools, tags, fallback content, cancellation
 //	     │
 //	     │  runAgentTurn
 //	     ▼
-//	Runner.Run              model execution, response capture, telemetry
+//	Runner.Run              model execution, stream fan-out, response capture,
+//	                         telemetry
 //
 // [Config.Handler] is intentionally outside this chain. Use it for
 // infrastructure work that does not need a model turn; use
 // [Config.TurnBuilder] when the wake should result in agent execution.
+// Request/reply integrations may attach [AgentTurn.RunContext],
+// [AgentTurn.Stream], and [AgentTurn.ResultSink] to preserve caller
+// cancellation, streaming, and synchronous result delivery while still
+// letting the loop own request preparation, telemetry, accounting, and
+// runner execution.
 //
 // # Capability tag lifecycle
 //

--- a/internal/runtime/loop/loop.go
+++ b/internal/runtime/loop/loop.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/nugget/thane-ai-agent/internal/model/llm"
 	"github.com/nugget/thane-ai-agent/internal/model/toolcatalog"
 	"github.com/nugget/thane-ai-agent/internal/platform/events"
 	"github.com/nugget/thane-ai-agent/internal/platform/logging"
@@ -18,8 +19,11 @@ import (
 	"github.com/nugget/thane-ai-agent/internal/state/memory"
 )
 
-// Runner abstracts the agent loop for LLM calls. Satisfied by
-// *agent.Loop. Defined here to avoid a circular import.
+// Runner executes one prepared model turn for the loop runtime. The
+// application adapter satisfies this with *agent.Loop while keeping the
+// loop package independent of the agent package. The stream callback is
+// the caller-facing delivery path for raw runner events; loop telemetry is
+// supplied separately through Request.OnProgress.
 type Runner interface {
 	Run(ctx context.Context, req Request, stream StreamCallback) (*Response, error)
 }
@@ -78,10 +82,19 @@ type Request struct {
 // onto Request as the primary loop-facing run descriptor.
 type RunRequest = Request
 
-// Message is a chat message for the runner.
+// Message is a chat message for the runner. It intentionally mirrors
+// the subset of agent.Message that loop-owned request preparation needs.
 type Message struct {
-	Role    string `yaml:"role" json:"role"`
+	// Role is the chat role, such as system, user, assistant, or tool.
+	Role string `yaml:"role" json:"role"`
+
+	// Content is the text body sent to the model.
 	Content string `yaml:"content" json:"content"`
+
+	// Images carries multimodal payloads for this message. It is
+	// runtime-only because persisted loop specs should stay textual and
+	// portable; HTTP ingress paths such as OWU populate it per request.
+	Images []llm.ImageContent `yaml:"-" json:"-"`
 }
 
 // RunMessage is kept as a compatibility alias while loops-ng migrates
@@ -115,7 +128,11 @@ type Response struct {
 // migrates onto Response as the primary loop-facing response type.
 type RunResponse = Response
 
-// StreamCallback receives streaming events. Nil disables streaming.
+// StreamCallback receives raw streaming events from a [Runner]. The event
+// value is intentionally untyped at the loop boundary so the loop package
+// does not import channel-specific or agent-specific event structs.
+// Adapters that know the concrete event type should validate it before
+// forwarding. Nil disables caller-facing streaming for the turn.
 type StreamCallback func(event any)
 
 // RandSource abstracts randomness for deterministic testing.
@@ -958,9 +975,12 @@ func (l *Loop) run(ctx context.Context) {
 			} else if turn == nil {
 				noOp = true
 			} else {
+				var turnResp *Response
+				var turnErr error
 				req, prepareErr := l.prepareAgentTurnRequest(turn.Request, convID, isSupervisor)
 				if prepareErr != nil {
-					err = prepareErr
+					turnErr = prepareErr
+					err = turnErr
 				} else {
 					if req.ConversationID != "" && req.ConversationID != convID {
 						convID = req.ConversationID
@@ -968,10 +988,16 @@ func (l *Loop) run(ctx context.Context) {
 						l.currentConvID = convID
 						l.mu.Unlock()
 					}
-					result, err = l.runAgentTurn(iterCtx, req, iterStart, isSupervisor)
+					runCtx, runCancel := mergeTurnRunContext(iterCtx, turn.RunContext)
+					result, turnResp, turnErr = l.runAgentTurn(runCtx, req, turn.Stream, iterStart, isSupervisor)
+					runCancel()
+					err = turnErr
 					if len(turn.Summary) > 0 {
 						handlerSummary = cloneSummaryMap(turn.Summary)
 					}
+				}
+				if turn.ResultSink != nil {
+					turn.ResultSink(turnResp, turnErr)
 				}
 			}
 			if !noOp {
@@ -1430,8 +1456,11 @@ func (l *Loop) prepareAgentTurnRequest(req Request, convID string, isSupervisor 
 // runAgentTurn is the only loop-owned path that invokes the agent runner.
 // It captures runner response state needed by subsequent iterations and
 // returns the typed iteration result used by snapshots and telemetry.
-func (l *Loop) runAgentTurn(ctx context.Context, req Request, iterStart time.Time, isSupervisor bool) (*IterationResult, error) {
-	resp, err := l.deps.Runner.Run(ctx, req, nil)
+func (l *Loop) runAgentTurn(ctx context.Context, req Request, stream StreamCallback, iterStart time.Time, isSupervisor bool) (*IterationResult, *Response, error) {
+	resp, err := l.deps.Runner.Run(ctx, req, stream)
+	if err == nil && resp == nil {
+		err = fmt.Errorf("runner returned nil response")
+	}
 	// Capture activated tags for next iteration (under lock since
 	// activatedTags is read during Status snapshots). Always update,
 	// even to nil — if all tags were dropped during a run, the next
@@ -1443,7 +1472,7 @@ func (l *Loop) runAgentTurn(ctx context.Context, req Request, iterStart time.Tim
 		l.mu.Unlock()
 	}
 	if err != nil {
-		return nil, fmt.Errorf("loop LLM call: %w", err)
+		return nil, resp, fmt.Errorf("loop LLM call: %w", err)
 	}
 
 	return &IterationResult{
@@ -1459,7 +1488,30 @@ func (l *Loop) runAgentTurn(ctx context.Context, req Request, iterStart time.Tim
 		RequestID:          resp.RequestID,
 		Elapsed:            time.Since(iterStart),
 		Supervisor:         isSupervisor,
-	}, nil
+	}, resp, nil
+}
+
+// mergeTurnRunContext combines the loop iteration context with an optional
+// caller-owned request context. It lets request/reply adapters cancel the
+// runner on client disconnect without making that request context own the
+// child loop's lifetime.
+func mergeTurnRunContext(base context.Context, extra context.Context) (context.Context, context.CancelFunc) {
+	if extra == nil {
+		return base, func() {}
+	}
+	ctx, cancel := context.WithCancel(base)
+	if extra.Err() != nil {
+		cancel()
+		return ctx, cancel
+	}
+	go func() {
+		select {
+		case <-ctx.Done():
+		case <-extra.Done():
+			cancel()
+		}
+	}()
+	return ctx, cancel
 }
 
 func firstNonNilChannelBinding(bindings ...*memory.ChannelBinding) *memory.ChannelBinding {

--- a/internal/runtime/loop/loop_test.go
+++ b/internal/runtime/loop/loop_test.go
@@ -872,6 +872,126 @@ func TestTurnBuilderRunsThroughLoopRunner(t *testing.T) {
 	}
 }
 
+func TestTurnBuilderStreamAndResultSink(t *testing.T) {
+	t.Parallel()
+
+	streamCh := make(chan any, 1)
+	resultCh := make(chan struct {
+		resp *Response
+		err  error
+	}, 1)
+	runner := &turnCallbackRunner{fn: func(_ context.Context, _ RunRequest, stream StreamCallback) (*RunResponse, error) {
+		if stream == nil {
+			return nil, fmt.Errorf("stream callback is nil")
+		}
+		stream("chunk")
+		return &RunResponse{
+			Content:      "ok",
+			Model:        "test-model",
+			InputTokens:  10,
+			OutputTokens: 5,
+		}, nil
+	}}
+
+	l, err := New(Config{
+		Name:         "turn-builder-stream",
+		SleepMin:     1 * time.Millisecond,
+		SleepMax:     2 * time.Millisecond,
+		SleepDefault: 1 * time.Millisecond,
+		Jitter:       Float64Ptr(0),
+		MaxIter:      1,
+		TurnBuilder: func(context.Context, TurnInput) (*AgentTurn, error) {
+			return &AgentTurn{
+				Request: Request{
+					Messages: []Message{{Role: "user", Content: "stream this"}},
+				},
+				Stream: func(event any) {
+					streamCh <- event
+				},
+				ResultSink: func(resp *Response, err error) {
+					resultCh <- struct {
+						resp *Response
+						err  error
+					}{resp: resp, err: err}
+				},
+			}, nil
+		},
+	}, Deps{Runner: runner, EventBus: events.New()})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	_ = l.Start(context.Background())
+	<-l.Done()
+
+	select {
+	case got := <-streamCh:
+		if got != "chunk" {
+			t.Fatalf("stream event = %#v, want chunk", got)
+		}
+	default:
+		t.Fatal("stream callback was not called")
+	}
+	select {
+	case got := <-resultCh:
+		if got.err != nil {
+			t.Fatalf("result sink err = %v", got.err)
+		}
+		if got.resp == nil || got.resp.Content != "ok" {
+			t.Fatalf("result sink resp = %#v", got.resp)
+		}
+	default:
+		t.Fatal("result sink was not called")
+	}
+}
+
+func TestTurnBuilderRunContextCancelsRunner(t *testing.T) {
+	t.Parallel()
+
+	runCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	resultCh := make(chan error, 1)
+	runner := &turnCallbackRunner{fn: func(ctx context.Context, _ RunRequest, _ StreamCallback) (*RunResponse, error) {
+		return nil, ctx.Err()
+	}}
+
+	l, err := New(Config{
+		Name:         "turn-builder-run-context",
+		SleepMin:     1 * time.Millisecond,
+		SleepMax:     2 * time.Millisecond,
+		SleepDefault: 1 * time.Millisecond,
+		Jitter:       Float64Ptr(0),
+		MaxIter:      1,
+		TurnBuilder: func(context.Context, TurnInput) (*AgentTurn, error) {
+			return &AgentTurn{
+				Request: Request{
+					Messages: []Message{{Role: "user", Content: "cancel this"}},
+				},
+				RunContext: runCtx,
+				ResultSink: func(_ *Response, err error) {
+					resultCh <- err
+				},
+			}, nil
+		},
+	}, Deps{Runner: runner, EventBus: events.New()})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	_ = l.Start(context.Background())
+	<-l.Done()
+
+	select {
+	case err := <-resultCh:
+		if err == nil || !strings.Contains(err.Error(), "context canceled") {
+			t.Fatalf("result sink err = %v, want context canceled", err)
+		}
+	default:
+		t.Fatal("result sink was not called")
+	}
+}
+
 func TestTurnBuilderAllowedToolsOverrideIntersects(t *testing.T) {
 	t.Parallel()
 
@@ -1428,6 +1548,16 @@ func (r *inspectingRunner) Run(_ context.Context, req RunRequest, _ StreamCallba
 		InputTokens:  10,
 		OutputTokens: 5,
 	}, nil
+}
+
+// turnCallbackRunner delegates Run to a caller-provided function that can
+// inspect request, context, and stream callback behavior.
+type turnCallbackRunner struct {
+	fn func(context.Context, RunRequest, StreamCallback) (*RunResponse, error)
+}
+
+func (r *turnCallbackRunner) Run(ctx context.Context, req RunRequest, stream StreamCallback) (*RunResponse, error) {
+	return r.fn(ctx, req, stream)
 }
 
 func TestRecentConvIDs(t *testing.T) {

--- a/internal/server/api/owu_tracker.go
+++ b/internal/server/api/owu_tracker.go
@@ -16,28 +16,34 @@ import (
 	"github.com/nugget/thane-ai-agent/internal/state/memory"
 )
 
-// owuWork is a single request dispatched to a per-conversation child loop.
+// owuWork is a single synchronous HTTP request dispatched to a
+// per-conversation child loop.
 type owuWork struct {
-	reqCtx   context.Context // HTTP request context for cancellation
-	req      *agent.Request
-	callback agent.StreamCallback
-	respCh   chan owuResult
+	// reqCtx is the HTTP request context for cancellation.
+	reqCtx context.Context
+	// req is the loop-facing request captured at ingress.
+	req loop.Request
+	// callback is the caller-facing stream sink.
+	callback loop.StreamCallback
+	// respCh is buffered so the loop can finish if the handler returns.
+	respCh chan owuResult
 }
 
 // owuResult carries the agent response (or error) back to the HTTP handler.
 type owuResult struct {
-	resp *agent.Response
+	resp *loop.Response
 	err  error
 }
 
-// OWUTracker registers a parent "owu" loop and lazily spawns
-// per-conversation child loops so that Open WebUI sessions appear on
-// the dashboard with full in-flight event visibility.
+// OWUTracker tracks Open WebUI conversations as loop nodes while keeping
+// the HTTP handler's synchronous request/reply contract. It owns the
+// queueing and type adaptation around OWU sessions; model execution stays
+// on the common loop runner path through [loop.AgentTurn].
 type OWUTracker struct {
 	ctx              context.Context // long-lived context for spawning child loops
 	registry         *loop.Registry
 	eventBus         *events.Bus
-	runner           *agent.Loop
+	runner           loop.Runner
 	logger           *slog.Logger
 	bindConversation func(conversationID string, binding *memory.ChannelBinding) error
 
@@ -46,10 +52,11 @@ type OWUTracker struct {
 	convChs  map[string]chan owuWork // conversation ID → work channel
 }
 
-// NewOWUTracker creates a tracker and spawns the parent "owu" loop.
-// Pass a nil registry to disable loop integration (calls fall through
-// to the agent loop directly).
-func NewOWUTracker(ctx context.Context, registry *loop.Registry, eventBus *events.Bus, runner *agent.Loop, logger *slog.Logger) (*OWUTracker, error) {
+// NewOWUTracker creates an Open WebUI tracker and registers the parent
+// "owu" loop when a registry is available. Pass a nil registry to disable
+// loop visibility while still routing calls through the configured runner.
+// The runner is the loop-facing runner used by child conversation loops.
+func NewOWUTracker(ctx context.Context, registry *loop.Registry, eventBus *events.Bus, runner loop.Runner, logger *slog.Logger) (*OWUTracker, error) {
 	t := &OWUTracker{
 		ctx:      ctx,
 		registry: registry,
@@ -85,27 +92,34 @@ func (t *OWUTracker) UseConversationBindingWriter(bind func(string, *memory.Chan
 	t.bindConversation = bind
 }
 
-// Dispatch routes an agent request through the per-conversation child loop.
-// The supplied streamCallback receives tokens/tool events for HTTP streaming;
-// the loop infrastructure receives the same events for dashboard visibility.
-// displayName is a human-friendly label for the conversation node
-// (e.g., a truncation of the first message).
+// Dispatch routes an agent request through the per-conversation child loop
+// and waits for the loop-owned model result. Auxiliary OWU requests bypass
+// conversation tracking but still use the configured loop runner. The
+// supplied streamCallback is converted to [loop.StreamCallback] for
+// caller-facing HTTP streaming; loop telemetry is emitted independently by
+// the loop runtime. displayName is a human-friendly label for the
+// conversation node, such as a truncation of the first message.
 func (t *OWUTracker) Dispatch(ctx context.Context, req *agent.Request, streamCallback agent.StreamCallback, displayName string) (*agent.Response, error) {
-	convID := req.ConversationID
+	loopReq := loopRequestFromAgent(req)
+	convID := loopReq.ConversationID
 	if convID == "" || convID == "owu-auxiliary" {
 		// Auxiliary requests bypass loop tracking.
-		return t.runner.Run(ctx, req, streamCallback)
+		resp, err := t.run(ctx, loopReq, loopStreamFromAgent(streamCallback))
+		return agentResponseFromLoop(resp), err
 	}
-	if req.ChannelBinding == nil {
-		req.ChannelBinding = (&memory.ChannelBinding{Channel: "owu", IsOwner: true}).Normalize()
+	if loopReq.ChannelBinding == nil {
+		loopReq.ChannelBinding = (&memory.ChannelBinding{Channel: "owu", IsOwner: true}).Normalize()
 	} else {
-		req.ChannelBinding = req.ChannelBinding.Normalize()
-		if req.ChannelBinding != nil && req.ChannelBinding.Channel == "owu" {
-			req.ChannelBinding.IsOwner = true
+		loopReq.ChannelBinding = loopReq.ChannelBinding.Normalize()
+		if loopReq.ChannelBinding != nil && loopReq.ChannelBinding.Channel == "owu" {
+			loopReq.ChannelBinding.IsOwner = true
 		}
 	}
-	if t.bindConversation != nil && req.ChannelBinding != nil {
-		if err := t.bindConversation(convID, req.ChannelBinding); err != nil {
+	if req != nil {
+		req.ChannelBinding = loopReq.ChannelBinding
+	}
+	if t.bindConversation != nil && loopReq.ChannelBinding != nil {
+		if err := t.bindConversation(convID, loopReq.ChannelBinding); err != nil {
 			t.logger.Warn("failed to persist owu conversation binding",
 				"conversation_id", convID,
 				"error", err,
@@ -113,15 +127,16 @@ func (t *OWUTracker) Dispatch(ctx context.Context, req *agent.Request, streamCal
 		}
 	}
 	if t.registry == nil {
-		return t.runner.Run(ctx, req, streamCallback)
+		resp, err := t.run(ctx, loopReq, loopStreamFromAgent(streamCallback))
+		return agentResponseFromLoop(resp), err
 	}
 
-	ch := t.ensureConvLoop(ctx, convID, displayName, req.ChannelBinding != nil && req.ChannelBinding.IsOwner)
+	ch := t.ensureConvLoop(ctx, convID, displayName, loopReq.ChannelBinding != nil && loopReq.ChannelBinding.IsOwner)
 
 	work := owuWork{
 		reqCtx:   ctx,
-		req:      req,
-		callback: streamCallback,
+		req:      loopReq,
+		callback: loopStreamFromAgent(streamCallback),
 		respCh:   make(chan owuResult, 1),
 	}
 
@@ -133,7 +148,7 @@ func (t *OWUTracker) Dispatch(ctx context.Context, req *agent.Request, streamCal
 
 	select {
 	case res := <-work.respCh:
-		return res.resp, res.err
+		return agentResponseFromLoop(res.resp), res.err
 	case <-ctx.Done():
 		return nil, ctx.Err()
 	}
@@ -159,6 +174,7 @@ func (t *OWUTracker) ensureConvLoop(_ context.Context, convID, displayName strin
 
 	loopID, err := t.registry.SpawnLoop(t.ctx, loop.Config{
 		Name: loopName,
+		Tags: []string{"owu"},
 		WaitFunc: func(wCtx context.Context) (any, error) {
 			select {
 			case <-wCtx.Done():
@@ -170,50 +186,23 @@ func (t *OWUTracker) ensureConvLoop(_ context.Context, convID, displayName strin
 				return w, nil
 			}
 		},
-		Handler: func(hCtx context.Context, event any) error {
-			w, ok := event.(owuWork)
+		TurnBuilder: func(_ context.Context, input loop.TurnInput) (*loop.AgentTurn, error) {
+			w, ok := input.Event.(owuWork)
 			if !ok {
-				return nil
+				return nil, nil
 			}
-			// Merge the loop context (lifecycle) with the HTTP request
-			// context (client disconnect) so work cancels on either.
-			runCtx, cancel := context.WithCancel(hCtx)
-			go func() {
-				select {
-				case <-runCtx.Done():
-				case <-w.reqCtx.Done():
-					cancel()
-				}
-			}()
-			defer cancel()
-
-			progressStream := agent.BuildProgressStream(loop.ProgressFunc(hCtx))
-			// Fan-out: forward agent stream events to both the HTTP
-			// streaming callback and the loop progress func.
-			combined := fanOutStream(w.callback, progressStream)
-			fallbackContent := loop.FallbackContent(hCtx)
-			if w.req != nil && w.req.FallbackContent == "" {
-				w.req.FallbackContent = fallbackContent
+			req := cloneLoopRequest(w.req)
+			if req.FallbackContent == "" {
+				req.FallbackContent = prompts.InteractiveEmptyResponseFallback
 			}
-			resp, err := t.runner.Run(runCtx, w.req, combined)
-			if resp != nil && strings.TrimSpace(resp.Content) == "" && fallbackContent != "" {
-				resp.Content = fallbackContent
-			}
-			w.respCh <- owuResult{resp: resp, err: err}
-			if resp != nil {
-				loop.ReportAgentRun(hCtx, loop.AgentRunSummary{
-					RequestID:          resp.RequestID,
-					Model:              resp.Model,
-					InputTokens:        resp.InputTokens,
-					OutputTokens:       resp.OutputTokens,
-					ContextWindow:      resp.ContextWindow,
-					ToolsUsed:          resp.ToolsUsed,
-					ActiveTags:         append([]string(nil), resp.ActiveTags...),
-					EffectiveTools:     append([]string(nil), resp.EffectiveTools...),
-					LoadedCapabilities: append([]toolcatalog.LoadedCapabilityEntry(nil), resp.LoadedCapabilities...),
-				})
-			}
-			return err
+			return &loop.AgentTurn{
+				Request:    req,
+				RunContext: w.reqCtx,
+				Stream:     w.callback,
+				ResultSink: func(resp *loop.Response, err error) {
+					w.respCh <- owuResult{resp: resp, err: err}
+				},
+			}, nil
 		},
 		ParentID:        parentID,
 		FallbackContent: prompts.InteractiveEmptyResponseFallback,
@@ -223,7 +212,7 @@ func (t *OWUTracker) ensureConvLoop(_ context.Context, convID, displayName strin
 			"conversation_id": convID,
 			"is_owner":        strconv.FormatBool(isOwner),
 		},
-	}, loop.Deps{Logger: t.logger, EventBus: t.eventBus})
+	}, loop.Deps{Runner: t.runner, Logger: t.logger, EventBus: t.eventBus})
 	if err != nil {
 		t.logger.Error("failed to spawn owu conversation loop",
 			"conversation_id", convID,
@@ -246,7 +235,9 @@ func (t *OWUTracker) ensureConvLoop(_ context.Context, convID, displayName strin
 					if !ok {
 						return
 					}
-					resp, err := t.runner.Run(t.ctx, w.req, w.callback)
+					runCtx, cancel := mergeOWUContexts(t.ctx, w.reqCtx)
+					resp, err := t.run(runCtx, w.req, w.callback)
+					cancel()
 					w.respCh <- owuResult{resp: resp, err: err}
 				}
 			}
@@ -272,6 +263,185 @@ func (t *OWUTracker) ensureConvLoop(_ context.Context, convID, displayName strin
 	return ch
 }
 
+// run is the direct runner path used for auxiliary requests and fallback
+// paths that intentionally do not create a child conversation loop.
+func (t *OWUTracker) run(ctx context.Context, req loop.Request, stream loop.StreamCallback) (*loop.Response, error) {
+	if t.runner == nil {
+		return nil, fmt.Errorf("owu runner is not configured")
+	}
+	return t.runner.Run(ctx, req, stream)
+}
+
+// loopRequestFromAgent converts the API package's legacy agent.Request
+// boundary into loop.Request while deep-copying mutable request data.
+func loopRequestFromAgent(req *agent.Request) loop.Request {
+	if req == nil {
+		return loop.Request{}
+	}
+	msgs := make([]loop.Message, len(req.Messages))
+	for i, msg := range req.Messages {
+		msgs[i] = loop.Message{
+			Role:    msg.Role,
+			Content: msg.Content,
+			Images:  append(msg.Images[:0:0], msg.Images...),
+		}
+	}
+	runtimeTools := make([]loop.RuntimeTool, 0, len(req.RuntimeTools))
+	for _, tool := range req.RuntimeTools {
+		if tool == nil {
+			continue
+		}
+		runtimeTools = append(runtimeTools, loop.RuntimeTool{
+			Name:                 tool.Name,
+			Description:          tool.Description,
+			Parameters:           cloneAnyMap(tool.Parameters),
+			Handler:              tool.Handler,
+			SkipContentResolve:   tool.SkipContentResolve,
+			ContentResolveExempt: append([]string(nil), tool.ContentResolveExempt...),
+		})
+	}
+	return loop.Request{
+		Model:                 req.Model,
+		ConversationID:        req.ConversationID,
+		ChannelBinding:        req.ChannelBinding.Clone(),
+		Messages:              msgs,
+		SkipContext:           req.SkipContext,
+		AllowedTools:          append([]string(nil), req.AllowedTools...),
+		ExcludeTools:          append([]string(nil), req.ExcludeTools...),
+		SkipTagFilter:         req.SkipTagFilter,
+		Hints:                 cloneStringMap(req.Hints),
+		InitialTags:           append([]string(nil), req.InitialTags...),
+		RuntimeTags:           append([]string(nil), req.RuntimeTags...),
+		RuntimeTools:          runtimeTools,
+		MaxIterations:         req.MaxIterations,
+		MaxOutputTokens:       req.MaxOutputTokens,
+		ToolTimeout:           req.ToolTimeout,
+		UsageRole:             req.UsageRole,
+		UsageTaskName:         req.UsageTaskName,
+		SystemPrompt:          req.SystemPrompt,
+		FallbackContent:       req.FallbackContent,
+		PromptMode:            req.PromptMode,
+		SuppressAlwaysContext: req.SuppressAlwaysContext,
+	}
+}
+
+// cloneLoopRequest copies per-turn request data before a child loop mutates
+// runtime defaults, fallback content, progress callbacks, or tag state.
+func cloneLoopRequest(req loop.Request) loop.Request {
+	cloned := req
+	cloned.ChannelBinding = req.ChannelBinding.Clone()
+	cloned.Messages = append([]loop.Message(nil), req.Messages...)
+	for i := range cloned.Messages {
+		cloned.Messages[i].Images = append(cloned.Messages[i].Images[:0:0], cloned.Messages[i].Images...)
+	}
+	cloned.AllowedTools = append([]string(nil), req.AllowedTools...)
+	cloned.ExcludeTools = append([]string(nil), req.ExcludeTools...)
+	cloned.Hints = cloneStringMap(req.Hints)
+	cloned.InitialTags = append([]string(nil), req.InitialTags...)
+	cloned.RuntimeTags = append([]string(nil), req.RuntimeTags...)
+	cloned.RuntimeTools = append([]loop.RuntimeTool(nil), req.RuntimeTools...)
+	for i := range cloned.RuntimeTools {
+		cloned.RuntimeTools[i].Parameters = cloneAnyMap(req.RuntimeTools[i].Parameters)
+		cloned.RuntimeTools[i].ContentResolveExempt = append([]string(nil), req.RuntimeTools[i].ContentResolveExempt...)
+	}
+	return cloned
+}
+
+// agentResponseFromLoop adapts loop.Response back to the API handler's
+// legacy agent.Response type.
+func agentResponseFromLoop(resp *loop.Response) *agent.Response {
+	if resp == nil {
+		return nil
+	}
+	return &agent.Response{
+		Content:                  resp.Content,
+		Model:                    resp.Model,
+		FinishReason:             resp.FinishReason,
+		InputTokens:              resp.InputTokens,
+		OutputTokens:             resp.OutputTokens,
+		CacheCreationInputTokens: resp.CacheCreationInputTokens,
+		CacheReadInputTokens:     resp.CacheReadInputTokens,
+		ContextWindow:            resp.ContextWindow,
+		ToolsUsed:                cloneToolCounts(resp.ToolsUsed),
+		EffectiveTools:           append([]string(nil), resp.EffectiveTools...),
+		LoadedCapabilities:       append([]toolcatalog.LoadedCapabilityEntry(nil), resp.LoadedCapabilities...),
+		Iterations:               resp.Iterations,
+		Exhausted:                resp.Exhausted,
+		RequestID:                resp.RequestID,
+		ActiveTags:               append([]string(nil), resp.ActiveTags...),
+	}
+}
+
+// loopStreamFromAgent adapts the HTTP handler's stream callback to the
+// loop runner boundary. The application loop adapter sends [agent.StreamEvent]
+// values through this channel.
+func loopStreamFromAgent(cb agent.StreamCallback) loop.StreamCallback {
+	if cb == nil {
+		return nil
+	}
+	return func(event any) {
+		streamEvent, ok := event.(agent.StreamEvent)
+		if !ok {
+			return
+		}
+		cb(streamEvent)
+	}
+}
+
+// mergeOWUContexts combines the long-lived tracker context with an HTTP
+// request context for direct runner fallback paths.
+func mergeOWUContexts(base context.Context, extra context.Context) (context.Context, context.CancelFunc) {
+	if extra == nil {
+		return base, func() {}
+	}
+	ctx, cancel := context.WithCancel(base)
+	if extra.Err() != nil {
+		cancel()
+		return ctx, cancel
+	}
+	go func() {
+		select {
+		case <-ctx.Done():
+		case <-extra.Done():
+			cancel()
+		}
+	}()
+	return ctx, cancel
+}
+
+func cloneStringMap(src map[string]string) map[string]string {
+	if len(src) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(src))
+	for k, v := range src {
+		out[k] = v
+	}
+	return out
+}
+
+func cloneAnyMap(src map[string]any) map[string]any {
+	if len(src) == 0 {
+		return nil
+	}
+	out := make(map[string]any, len(src))
+	for k, v := range src {
+		out[k] = v
+	}
+	return out
+}
+
+func cloneToolCounts(src map[string]int) map[string]int {
+	if len(src) == 0 {
+		return nil
+	}
+	out := make(map[string]int, len(src))
+	for k, v := range src {
+		out[k] = v
+	}
+	return out
+}
+
 // sanitizeOWULoopName strips characters from a display name that could
 // confuse the loop hierarchy ("/") or produce unreadable node labels.
 func sanitizeOWULoopName(name string) string {
@@ -285,19 +455,4 @@ func sanitizeOWULoopName(name string) string {
 		}
 		return r
 	}, name)
-}
-
-// fanOutStream creates a StreamCallback that forwards events to both a and b.
-// Either may be nil.
-func fanOutStream(a, b agent.StreamCallback) agent.StreamCallback {
-	if a == nil {
-		return b
-	}
-	if b == nil {
-		return a
-	}
-	return func(e agent.StreamEvent) {
-		a(e)
-		b(e)
-	}
 }

--- a/internal/server/api/owu_tracker_test.go
+++ b/internal/server/api/owu_tracker_test.go
@@ -1,0 +1,134 @@
+package api
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/nugget/thane-ai-agent/internal/model/llm"
+	"github.com/nugget/thane-ai-agent/internal/platform/events"
+	"github.com/nugget/thane-ai-agent/internal/runtime/agent"
+	"github.com/nugget/thane-ai-agent/internal/runtime/loop"
+	"github.com/nugget/thane-ai-agent/internal/state/memory"
+)
+
+type owuRecordingRunner struct {
+	requests chan loop.Request
+}
+
+func (r *owuRecordingRunner) Run(ctx context.Context, req loop.Request, stream loop.StreamCallback) (*loop.Response, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if stream != nil {
+		stream(agent.StreamEvent{Kind: agent.KindToken, Token: "hello"})
+	}
+	select {
+	case r.requests <- req:
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+	return &loop.Response{
+		Content:       "ok",
+		Model:         "test-model",
+		InputTokens:   10,
+		OutputTokens:  5,
+		ContextWindow: 8192,
+		RequestID:     "req-owu-1",
+		ActiveTags:    []string{"owu"},
+	}, nil
+}
+
+func TestOWUTrackerDispatchRoutesThroughTurnBuilder(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	registry := loop.NewRegistry()
+	t.Cleanup(func() {
+		shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer shutdownCancel()
+		registry.ShutdownAll(shutdownCtx)
+	})
+
+	runner := &owuRecordingRunner{requests: make(chan loop.Request, 1)}
+	tracker, err := NewOWUTracker(ctx, registry, events.New(), runner, slog.Default())
+	if err != nil {
+		t.Fatalf("NewOWUTracker: %v", err)
+	}
+
+	var boundConvID string
+	var bound *memory.ChannelBinding
+	tracker.UseConversationBindingWriter(func(conversationID string, binding *memory.ChannelBinding) error {
+		boundConvID = conversationID
+		bound = binding.Clone()
+		return nil
+	})
+
+	streamed := make(chan agent.StreamEvent, 1)
+	req := &agent.Request{
+		ConversationID: "owu-chat-1",
+		Messages: []agent.Message{{
+			Role:    "user",
+			Content: "what is in this image?",
+			Images:  []llm.ImageContent{{MediaType: "image/png", Data: "abc123"}},
+		}},
+		Hints: map[string]string{
+			"channel": "ollama",
+			"source":  "owu",
+		},
+	}
+
+	resp, err := tracker.Dispatch(ctx, req, func(event agent.StreamEvent) {
+		streamed <- event
+	}, "Home Chat")
+	if err != nil {
+		t.Fatalf("Dispatch: %v", err)
+	}
+	if resp == nil || resp.Content != "ok" || resp.RequestID != "req-owu-1" {
+		t.Fatalf("response = %#v", resp)
+	}
+
+	var gotReq loop.Request
+	select {
+	case gotReq = <-runner.requests:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for runner request")
+	}
+	if gotReq.Hints["loop_id"] == "" {
+		t.Fatal("loop_id hint is empty; request did not traverse OWU child loop turn preparation")
+	}
+	if gotReq.Hints["loop_name"] != "owu/Home Chat" {
+		t.Fatalf("loop_name = %q, want owu/Home Chat", gotReq.Hints["loop_name"])
+	}
+	if gotReq.Hints["source"] != "owu" || gotReq.Hints["channel"] != "ollama" {
+		t.Fatalf("hints = %#v", gotReq.Hints)
+	}
+	if gotReq.SkipTagFilter {
+		t.Fatal("SkipTagFilter = true, want OWU loop tags to keep capability filtering active")
+	}
+	if len(gotReq.InitialTags) != 1 || gotReq.InitialTags[0] != "owu" {
+		t.Fatalf("InitialTags = %#v, want [owu]", gotReq.InitialTags)
+	}
+	if gotReq.ChannelBinding == nil || gotReq.ChannelBinding.Channel != "owu" || !gotReq.ChannelBinding.IsOwner {
+		t.Fatalf("ChannelBinding = %#v", gotReq.ChannelBinding)
+	}
+	if req.ChannelBinding == nil || req.ChannelBinding.Channel != "owu" || !req.ChannelBinding.IsOwner {
+		t.Fatalf("original request ChannelBinding = %#v", req.ChannelBinding)
+	}
+	if boundConvID != "owu-chat-1" || bound == nil || bound.Channel != "owu" || !bound.IsOwner {
+		t.Fatalf("bound conversation = %q %#v", boundConvID, bound)
+	}
+	if len(gotReq.Messages) != 1 || len(gotReq.Messages[0].Images) != 1 || gotReq.Messages[0].Images[0].MediaType != "image/png" {
+		t.Fatalf("Messages = %#v", gotReq.Messages)
+	}
+
+	select {
+	case event := <-streamed:
+		if event.Kind != agent.KindToken || event.Token != "hello" {
+			t.Fatalf("stream event = %#v", event)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for stream event")
+	}
+}


### PR DESCRIPTION
## Summary

This moves Open WebUI per-conversation model work onto the loop runtime `TurnBuilder` path.

## Why

OWU was still the clearest request/reply ingress seam outside the common loop-owned execution path. Its child loops used `Handler`, called the agent runner directly, manually fanned out streaming/progress callbacks, and manually reported agent run metadata back to the loop summary. That kept OWU on the old parallel plumbing even after the MQTT and Signal migrations.

## What Changed

- Added per-turn loop runtime hooks for request/reply ingress:
  - `AgentTurn.Stream` forwards caller stream events to the runner.
  - `AgentTurn.ResultSink` receives the loop-owned runner response/error.
  - `AgentTurn.RunContext` lets HTTP cancellation participate in the runner context without owning loop lifecycle.
- Extended loop messages to preserve image payloads across the loop boundary.
- Updated the app `loopAdapter` to forward stream callbacks into `agent.Loop.Run` while still emitting loop progress telemetry.
- Updated `loopAdapter` conversion to preserve `FallbackContent` and image payloads.
- Refactored `OWUTracker` child loops from handler-owned runner execution to `TurnBuilder` + `loop.Runner` execution.
- Kept OWU capability filtering active by configuring child loops with the `owu` tag.
- Added OWU regression coverage proving requests traverse child loop turn preparation, keep streaming, preserve image payloads, persist owner bindings, and receive loop hints.

## Validation

- `just test`
- `just ci`