### PR TITLE
refactor: route api chat through turn builder

### DIFF
--- a/internal/app/new_servers.go
+++ b/internal/app/new_servers.go
@@ -58,6 +58,7 @@ func (a *App) initServers(s *newState) error {
 		a.reconcileLoopDefinition,
 		a.launchLoopDefinition,
 	)
+	server.ConfigureChatLoopLauncher(a.launchLoop)
 	server.SetEventBus(a.eventBus)
 	server.SetConnManager(func() map[string]api.DependencyStatus {
 		status := a.connMgr.Status()

--- a/internal/server/api/agent_loop_bridge.go
+++ b/internal/server/api/agent_loop_bridge.go
@@ -1,0 +1,156 @@
+package api
+
+import (
+	"github.com/nugget/thane-ai-agent/internal/model/toolcatalog"
+	"github.com/nugget/thane-ai-agent/internal/runtime/agent"
+	"github.com/nugget/thane-ai-agent/internal/runtime/loop"
+)
+
+// loopRequestFromAgent converts the API package's legacy agent.Request
+// boundary into loop.Request while deep-copying mutable request data.
+func loopRequestFromAgent(req *agent.Request) loop.Request {
+	if req == nil {
+		return loop.Request{}
+	}
+	msgs := make([]loop.Message, len(req.Messages))
+	for i, msg := range req.Messages {
+		msgs[i] = loop.Message{
+			Role:    msg.Role,
+			Content: msg.Content,
+			Images:  append(msg.Images[:0:0], msg.Images...),
+		}
+	}
+	runtimeTools := make([]loop.RuntimeTool, 0, len(req.RuntimeTools))
+	for _, tool := range req.RuntimeTools {
+		if tool == nil {
+			continue
+		}
+		runtimeTools = append(runtimeTools, loop.RuntimeTool{
+			Name:                 tool.Name,
+			Description:          tool.Description,
+			Parameters:           cloneAnyMap(tool.Parameters),
+			Handler:              tool.Handler,
+			SkipContentResolve:   tool.SkipContentResolve,
+			ContentResolveExempt: append([]string(nil), tool.ContentResolveExempt...),
+		})
+	}
+	return loop.Request{
+		Model:                 req.Model,
+		ConversationID:        req.ConversationID,
+		ChannelBinding:        req.ChannelBinding.Clone(),
+		Messages:              msgs,
+		SkipContext:           req.SkipContext,
+		AllowedTools:          append([]string(nil), req.AllowedTools...),
+		ExcludeTools:          append([]string(nil), req.ExcludeTools...),
+		SkipTagFilter:         req.SkipTagFilter,
+		Hints:                 cloneStringMap(req.Hints),
+		InitialTags:           append([]string(nil), req.InitialTags...),
+		RuntimeTags:           append([]string(nil), req.RuntimeTags...),
+		RuntimeTools:          runtimeTools,
+		MaxIterations:         req.MaxIterations,
+		MaxOutputTokens:       req.MaxOutputTokens,
+		ToolTimeout:           req.ToolTimeout,
+		UsageRole:             req.UsageRole,
+		UsageTaskName:         req.UsageTaskName,
+		SystemPrompt:          req.SystemPrompt,
+		FallbackContent:       req.FallbackContent,
+		PromptMode:            req.PromptMode,
+		SuppressAlwaysContext: req.SuppressAlwaysContext,
+	}
+}
+
+// cloneLoopRequest copies per-turn request data before a loop mutates
+// runtime defaults, fallback content, progress callbacks, or tag state.
+func cloneLoopRequest(req loop.Request) loop.Request {
+	cloned := req
+	cloned.ChannelBinding = req.ChannelBinding.Clone()
+	cloned.Messages = append([]loop.Message(nil), req.Messages...)
+	for i := range cloned.Messages {
+		cloned.Messages[i].Images = append(cloned.Messages[i].Images[:0:0], cloned.Messages[i].Images...)
+	}
+	cloned.AllowedTools = append([]string(nil), req.AllowedTools...)
+	cloned.ExcludeTools = append([]string(nil), req.ExcludeTools...)
+	cloned.Hints = cloneStringMap(req.Hints)
+	cloned.InitialTags = append([]string(nil), req.InitialTags...)
+	cloned.RuntimeTags = append([]string(nil), req.RuntimeTags...)
+	cloned.RuntimeTools = append([]loop.RuntimeTool(nil), req.RuntimeTools...)
+	for i := range cloned.RuntimeTools {
+		cloned.RuntimeTools[i].Parameters = cloneAnyMap(req.RuntimeTools[i].Parameters)
+		cloned.RuntimeTools[i].ContentResolveExempt = append([]string(nil), req.RuntimeTools[i].ContentResolveExempt...)
+	}
+	return cloned
+}
+
+// agentResponseFromLoop adapts loop.Response back to the API handler's
+// legacy agent.Response type.
+func agentResponseFromLoop(resp *loop.Response) *agent.Response {
+	if resp == nil {
+		return nil
+	}
+	return &agent.Response{
+		Content:                  resp.Content,
+		Model:                    resp.Model,
+		FinishReason:             resp.FinishReason,
+		InputTokens:              resp.InputTokens,
+		OutputTokens:             resp.OutputTokens,
+		CacheCreationInputTokens: resp.CacheCreationInputTokens,
+		CacheReadInputTokens:     resp.CacheReadInputTokens,
+		ContextWindow:            resp.ContextWindow,
+		ToolsUsed:                cloneToolCounts(resp.ToolsUsed),
+		EffectiveTools:           append([]string(nil), resp.EffectiveTools...),
+		LoadedCapabilities:       append([]toolcatalog.LoadedCapabilityEntry(nil), resp.LoadedCapabilities...),
+		Iterations:               resp.Iterations,
+		Exhausted:                resp.Exhausted,
+		RequestID:                resp.RequestID,
+		ActiveTags:               append([]string(nil), resp.ActiveTags...),
+	}
+}
+
+// loopStreamFromAgent adapts an API stream callback to the loop runner
+// boundary. The application loop adapter sends [agent.StreamEvent] values
+// through this channel.
+func loopStreamFromAgent(cb agent.StreamCallback) loop.StreamCallback {
+	if cb == nil {
+		return nil
+	}
+	return func(event any) {
+		streamEvent, ok := event.(agent.StreamEvent)
+		if !ok {
+			return
+		}
+		cb(streamEvent)
+	}
+}
+
+func cloneStringMap(src map[string]string) map[string]string {
+	if len(src) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(src))
+	for k, v := range src {
+		out[k] = v
+	}
+	return out
+}
+
+func cloneAnyMap(src map[string]any) map[string]any {
+	if len(src) == 0 {
+		return nil
+	}
+	out := make(map[string]any, len(src))
+	for k, v := range src {
+		out[k] = v
+	}
+	return out
+}
+
+func cloneToolCounts(src map[string]int) map[string]int {
+	if len(src) == 0 {
+		return nil
+	}
+	out := make(map[string]int, len(src))
+	for k, v := range src {
+		out[k] = v
+	}
+	return out
+}

--- a/internal/server/api/owu_tracker.go
+++ b/internal/server/api/owu_tracker.go
@@ -9,7 +9,6 @@ import (
 	"sync"
 
 	"github.com/nugget/thane-ai-agent/internal/model/prompts"
-	"github.com/nugget/thane-ai-agent/internal/model/toolcatalog"
 	"github.com/nugget/thane-ai-agent/internal/platform/events"
 	"github.com/nugget/thane-ai-agent/internal/runtime/agent"
 	"github.com/nugget/thane-ai-agent/internal/runtime/loop"
@@ -272,122 +271,6 @@ func (t *OWUTracker) run(ctx context.Context, req loop.Request, stream loop.Stre
 	return t.runner.Run(ctx, req, stream)
 }
 
-// loopRequestFromAgent converts the API package's legacy agent.Request
-// boundary into loop.Request while deep-copying mutable request data.
-func loopRequestFromAgent(req *agent.Request) loop.Request {
-	if req == nil {
-		return loop.Request{}
-	}
-	msgs := make([]loop.Message, len(req.Messages))
-	for i, msg := range req.Messages {
-		msgs[i] = loop.Message{
-			Role:    msg.Role,
-			Content: msg.Content,
-			Images:  append(msg.Images[:0:0], msg.Images...),
-		}
-	}
-	runtimeTools := make([]loop.RuntimeTool, 0, len(req.RuntimeTools))
-	for _, tool := range req.RuntimeTools {
-		if tool == nil {
-			continue
-		}
-		runtimeTools = append(runtimeTools, loop.RuntimeTool{
-			Name:                 tool.Name,
-			Description:          tool.Description,
-			Parameters:           cloneAnyMap(tool.Parameters),
-			Handler:              tool.Handler,
-			SkipContentResolve:   tool.SkipContentResolve,
-			ContentResolveExempt: append([]string(nil), tool.ContentResolveExempt...),
-		})
-	}
-	return loop.Request{
-		Model:                 req.Model,
-		ConversationID:        req.ConversationID,
-		ChannelBinding:        req.ChannelBinding.Clone(),
-		Messages:              msgs,
-		SkipContext:           req.SkipContext,
-		AllowedTools:          append([]string(nil), req.AllowedTools...),
-		ExcludeTools:          append([]string(nil), req.ExcludeTools...),
-		SkipTagFilter:         req.SkipTagFilter,
-		Hints:                 cloneStringMap(req.Hints),
-		InitialTags:           append([]string(nil), req.InitialTags...),
-		RuntimeTags:           append([]string(nil), req.RuntimeTags...),
-		RuntimeTools:          runtimeTools,
-		MaxIterations:         req.MaxIterations,
-		MaxOutputTokens:       req.MaxOutputTokens,
-		ToolTimeout:           req.ToolTimeout,
-		UsageRole:             req.UsageRole,
-		UsageTaskName:         req.UsageTaskName,
-		SystemPrompt:          req.SystemPrompt,
-		FallbackContent:       req.FallbackContent,
-		PromptMode:            req.PromptMode,
-		SuppressAlwaysContext: req.SuppressAlwaysContext,
-	}
-}
-
-// cloneLoopRequest copies per-turn request data before a child loop mutates
-// runtime defaults, fallback content, progress callbacks, or tag state.
-func cloneLoopRequest(req loop.Request) loop.Request {
-	cloned := req
-	cloned.ChannelBinding = req.ChannelBinding.Clone()
-	cloned.Messages = append([]loop.Message(nil), req.Messages...)
-	for i := range cloned.Messages {
-		cloned.Messages[i].Images = append(cloned.Messages[i].Images[:0:0], cloned.Messages[i].Images...)
-	}
-	cloned.AllowedTools = append([]string(nil), req.AllowedTools...)
-	cloned.ExcludeTools = append([]string(nil), req.ExcludeTools...)
-	cloned.Hints = cloneStringMap(req.Hints)
-	cloned.InitialTags = append([]string(nil), req.InitialTags...)
-	cloned.RuntimeTags = append([]string(nil), req.RuntimeTags...)
-	cloned.RuntimeTools = append([]loop.RuntimeTool(nil), req.RuntimeTools...)
-	for i := range cloned.RuntimeTools {
-		cloned.RuntimeTools[i].Parameters = cloneAnyMap(req.RuntimeTools[i].Parameters)
-		cloned.RuntimeTools[i].ContentResolveExempt = append([]string(nil), req.RuntimeTools[i].ContentResolveExempt...)
-	}
-	return cloned
-}
-
-// agentResponseFromLoop adapts loop.Response back to the API handler's
-// legacy agent.Response type.
-func agentResponseFromLoop(resp *loop.Response) *agent.Response {
-	if resp == nil {
-		return nil
-	}
-	return &agent.Response{
-		Content:                  resp.Content,
-		Model:                    resp.Model,
-		FinishReason:             resp.FinishReason,
-		InputTokens:              resp.InputTokens,
-		OutputTokens:             resp.OutputTokens,
-		CacheCreationInputTokens: resp.CacheCreationInputTokens,
-		CacheReadInputTokens:     resp.CacheReadInputTokens,
-		ContextWindow:            resp.ContextWindow,
-		ToolsUsed:                cloneToolCounts(resp.ToolsUsed),
-		EffectiveTools:           append([]string(nil), resp.EffectiveTools...),
-		LoadedCapabilities:       append([]toolcatalog.LoadedCapabilityEntry(nil), resp.LoadedCapabilities...),
-		Iterations:               resp.Iterations,
-		Exhausted:                resp.Exhausted,
-		RequestID:                resp.RequestID,
-		ActiveTags:               append([]string(nil), resp.ActiveTags...),
-	}
-}
-
-// loopStreamFromAgent adapts the HTTP handler's stream callback to the
-// loop runner boundary. The application loop adapter sends [agent.StreamEvent]
-// values through this channel.
-func loopStreamFromAgent(cb agent.StreamCallback) loop.StreamCallback {
-	if cb == nil {
-		return nil
-	}
-	return func(event any) {
-		streamEvent, ok := event.(agent.StreamEvent)
-		if !ok {
-			return
-		}
-		cb(streamEvent)
-	}
-}
-
 // mergeOWUContexts combines the long-lived tracker context with an HTTP
 // request context for direct runner fallback paths.
 func mergeOWUContexts(base context.Context, extra context.Context) (context.Context, context.CancelFunc) {
@@ -407,39 +290,6 @@ func mergeOWUContexts(base context.Context, extra context.Context) (context.Cont
 		}
 	}()
 	return ctx, cancel
-}
-
-func cloneStringMap(src map[string]string) map[string]string {
-	if len(src) == 0 {
-		return nil
-	}
-	out := make(map[string]string, len(src))
-	for k, v := range src {
-		out[k] = v
-	}
-	return out
-}
-
-func cloneAnyMap(src map[string]any) map[string]any {
-	if len(src) == 0 {
-		return nil
-	}
-	out := make(map[string]any, len(src))
-	for k, v := range src {
-		out[k] = v
-	}
-	return out
-}
-
-func cloneToolCounts(src map[string]int) map[string]int {
-	if len(src) == 0 {
-		return nil
-	}
-	out := make(map[string]int, len(src))
-	for k, v := range src {
-		out[k] = v
-	}
-	return out
 }
 
 // sanitizeOWULoopName strips characters from a display name that could

--- a/internal/server/api/server.go
+++ b/internal/server/api/server.go
@@ -91,6 +91,7 @@ type Server struct {
 	deleteLoopDefinitionPolicy         func(string) error
 	reconcileLoopDefinition            func(context.Context, string) error
 	launchLoopDefinition               func(context.Context, string, looppkg.Launch) (looppkg.LaunchResult, error)
+	launchChatLoop                     func(context.Context, looppkg.Launch) (looppkg.LaunchResult, error)
 	anthropicRateLimitSnapshot         func() *fleet.AnthropicRateLimitSnapshot
 	logger                             *slog.Logger
 	server                             *http.Server
@@ -172,6 +173,12 @@ func (s *Server) ConfigureLoopDefinitionLifecycle(
 	s.deleteLoopDefinitionPolicy = deletePolicy
 	s.reconcileLoopDefinition = reconcile
 	s.launchLoopDefinition = launch
+}
+
+// ConfigureChatLoopLauncher configures the request/reply loop launcher used
+// by the native OpenAI-compatible chat endpoints.
+func (s *Server) ConfigureChatLoopLauncher(launch func(context.Context, looppkg.Launch) (looppkg.LaunchResult, error)) {
+	s.launchChatLoop = launch
 }
 
 // DashboardSnapshot returns a copy of the current session stats
@@ -601,6 +608,55 @@ type Usage struct {
 	TotalTokens      int `json:"total_tokens"`
 }
 
+// runChatLoop routes a native API request through the loop runtime's
+// request/reply path. The API layer still owns OpenAI wire formatting,
+// while the loop owns request preparation, telemetry, accounting, and
+// runner execution.
+func (s *Server) runChatLoop(ctx context.Context, req *agent.Request, streamCallback agent.StreamCallback, loopName string) (*agent.Response, error) {
+	if s.launchChatLoop == nil {
+		return nil, fmt.Errorf("api chat loop launcher is not configured")
+	}
+
+	loopReq := loopRequestFromAgent(req)
+	if loopReq.Hints == nil {
+		loopReq.Hints = make(map[string]string, 2)
+	}
+	if _, ok := loopReq.Hints["source"]; !ok {
+		loopReq.Hints["source"] = "api"
+	}
+	if _, ok := loopReq.Hints["channel"]; !ok {
+		loopReq.Hints["channel"] = "api"
+	}
+	stream := loopStreamFromAgent(streamCallback)
+
+	result, err := s.launchChatLoop(ctx, looppkg.Launch{
+		Spec: looppkg.Spec{
+			Name:       loopName,
+			Operation:  looppkg.OperationRequestReply,
+			Completion: looppkg.CompletionReturn,
+			Tags:       []string{"api"},
+			TurnBuilder: func(context.Context, looppkg.TurnInput) (*looppkg.AgentTurn, error) {
+				return &looppkg.AgentTurn{
+					Request:    cloneLoopRequest(loopReq),
+					RunContext: ctx,
+					Stream:     stream,
+				}, nil
+			},
+			Metadata: map[string]string{
+				"subsystem": "api",
+				"category":  "chat",
+			},
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+	if result.Response == nil {
+		return nil, fmt.Errorf("api chat loop returned no response")
+	}
+	return agentResponseFromLoop(result.Response), nil
+}
+
 func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 	var req ChatCompletionRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
@@ -635,7 +691,7 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Non-streaming: run and return complete response
-	resp, err := s.loop.Run(ctx, agentReq, nil)
+	resp, err := s.runChatLoop(ctx, agentReq, nil, "api/chat-completions")
 	if err != nil {
 		log.Error("agent loop failed", "error", err)
 		code, message := agentErrorDetails(err)
@@ -719,7 +775,7 @@ func (s *Server) handleSimpleChat(w http.ResponseWriter, r *http.Request) {
 		},
 	}
 
-	resp, err := s.loop.Run(ctx, agentReq, nil)
+	resp, err := s.runChatLoop(ctx, agentReq, nil, "api/simple-chat")
 	if err != nil {
 		log.Error("agent loop failed", "error", err)
 		s.errorResponse(w, http.StatusInternalServerError, "agent error: "+err.Error())
@@ -774,6 +830,7 @@ func (s *Server) handleStreamingCompletion(w http.ResponseWriter, r *http.Reques
 	completionID := fmt.Sprintf("chatcmpl-%d", time.Now().UnixNano())
 	created := time.Now().Unix()
 	modelName := "thane" // Will be updated when we get the response
+	var writeMu sync.Mutex
 
 	// Send initial chunk with role
 	initialChunk := StreamChunk{
@@ -786,8 +843,10 @@ func (s *Server) handleStreamingCompletion(w http.ResponseWriter, r *http.Reques
 			Delta: StreamDelta{Role: "assistant"},
 		}},
 	}
+	writeMu.Lock()
 	s.writeSSE(w, initialChunk)
 	flusher.Flush()
+	writeMu.Unlock()
 
 	// Track if any tokens were streamed (greeting fast-path skips streaming)
 	streamed := false
@@ -810,25 +869,31 @@ func (s *Server) handleStreamingCompletion(w http.ResponseWriter, r *http.Reques
 					Delta: StreamDelta{Content: event.Token},
 				}},
 			}
+			writeMu.Lock()
 			s.writeSSE(w, chunk)
 			flusher.Flush()
+			writeMu.Unlock()
 
 		case agent.KindToolCallStart, agent.KindToolCallDone:
 			// Send SSE comment as keepalive to prevent write timeout
+			writeMu.Lock()
 			fmt.Fprintf(w, ": keepalive\n\n")
 			flusher.Flush()
+			writeMu.Unlock()
 		}
 
 		// Reset write deadline after every event to prevent timeout
 		// during multi-iteration tool loops
+		writeMu.Lock()
 		if err := rc.SetWriteDeadline(time.Now().Add(120 * time.Second)); err != nil {
 			s.logger.Debug("failed to reset write deadline", "error", err)
 		}
+		writeMu.Unlock()
 	}
 
 	// Run agent with streaming — context carries the subsystem logger
-	// injected by the calling handler (handleChatCompletions or Ollama).
-	resp, err := s.loop.Run(r.Context(), agentReq, streamCallback)
+	// injected by the calling OpenAI-compatible handler.
+	resp, err := s.runChatLoop(r.Context(), agentReq, streamCallback, "api/chat-completions")
 	if err != nil {
 		s.logger.Error("agent loop failed", "error", err)
 		// Can't change status code after streaming started, just close
@@ -857,12 +922,14 @@ func (s *Server) handleStreamingCompletion(w http.ResponseWriter, r *http.Reques
 			FinishReason: &finishReason,
 		}},
 	}
+	writeMu.Lock()
 	s.writeSSE(w, finalChunk)
 	flusher.Flush()
 
 	// Send [DONE] marker
 	fmt.Fprintf(w, "data: [DONE]\n\n")
 	flusher.Flush()
+	writeMu.Unlock()
 }
 
 func (s *Server) writeSSE(w http.ResponseWriter, chunk StreamChunk) {

--- a/internal/server/api/server_test.go
+++ b/internal/server/api/server_test.go
@@ -9,6 +9,8 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"slices"
+	"strings"
 	"testing"
 	"time"
 
@@ -17,6 +19,7 @@ import (
 	"github.com/nugget/thane-ai-agent/internal/platform/config"
 	"github.com/nugget/thane-ai-agent/internal/platform/database"
 	"github.com/nugget/thane-ai-agent/internal/platform/usage"
+	"github.com/nugget/thane-ai-agent/internal/runtime/agent"
 	looppkg "github.com/nugget/thane-ai-agent/internal/runtime/loop"
 )
 
@@ -209,6 +212,134 @@ func TestSimpleChatResponse_OmitEmptyToolCalls(t *testing.T) {
 	// tool_calls should be omitted when empty
 	if bytes.Contains(data, []byte(`"tool_calls":[]`)) {
 		t.Error("empty tool_calls should be omitted")
+	}
+}
+
+type capturingAPILoopRunner struct {
+	response *looppkg.Response
+	onRun    func(req looppkg.Request, stream looppkg.StreamCallback)
+}
+
+func (r *capturingAPILoopRunner) Run(_ context.Context, req looppkg.Request, stream looppkg.StreamCallback) (*looppkg.Response, error) {
+	if r.onRun != nil {
+		r.onRun(req, stream)
+	}
+	if r.response != nil {
+		return r.response, nil
+	}
+	return &looppkg.Response{Content: "ok", Model: "test-model", FinishReason: "stop"}, nil
+}
+
+func TestRunChatLoopRoutesThroughLoopRuntime(t *testing.T) {
+	t.Parallel()
+
+	var capturedReq looppkg.Request
+	var capturedLaunch looppkg.Launch
+	runner := &capturingAPILoopRunner{
+		response: &looppkg.Response{
+			Content:      "looped",
+			Model:        "test-model",
+			FinishReason: "stop",
+			InputTokens:  12,
+			OutputTokens: 3,
+			ActiveTags:   []string{"api"},
+		},
+		onRun: func(req looppkg.Request, _ looppkg.StreamCallback) {
+			capturedReq = req
+		},
+	}
+
+	server := NewServer("", 0, nil, nil, nil, nil, nil, nil, nil, nil, nil, testAPILogger())
+	server.ConfigureChatLoopLauncher(func(ctx context.Context, launch looppkg.Launch) (looppkg.LaunchResult, error) {
+		capturedLaunch = launch
+		return looppkg.NewRegistry().Launch(ctx, launch, looppkg.Deps{
+			Runner: runner,
+			Logger: testAPILogger(),
+		})
+	})
+
+	resp, err := server.runChatLoop(context.Background(), &agent.Request{
+		Model:          "thane",
+		ConversationID: "conv-api",
+		Messages: []agent.Message{
+			{Role: "user", Content: "hello"},
+		},
+		Hints: map[string]string{
+			"channel": "api",
+		},
+	}, nil, "api/test")
+	if err != nil {
+		t.Fatalf("runChatLoop: %v", err)
+	}
+	if resp == nil || resp.Content != "looped" || resp.Model != "test-model" {
+		t.Fatalf("response = %#v, want looped test-model", resp)
+	}
+	if capturedLaunch.Spec.Operation != looppkg.OperationRequestReply {
+		t.Fatalf("Operation = %q, want %q", capturedLaunch.Spec.Operation, looppkg.OperationRequestReply)
+	}
+	if !slices.Equal(capturedLaunch.Spec.Tags, []string{"api"}) {
+		t.Fatalf("Tags = %v, want [api]", capturedLaunch.Spec.Tags)
+	}
+	if capturedReq.ConversationID != "conv-api" {
+		t.Fatalf("ConversationID = %q, want conv-api", capturedReq.ConversationID)
+	}
+	if capturedReq.SkipTagFilter {
+		t.Fatal("SkipTagFilter = true, want false for native API capability scoping")
+	}
+	if !slices.Equal(capturedReq.InitialTags, []string{"api"}) {
+		t.Fatalf("InitialTags = %v, want [api]", capturedReq.InitialTags)
+	}
+	if capturedReq.Hints["source"] != "api" || capturedReq.Hints["channel"] != "api" {
+		t.Fatalf("Hints = %#v, want source/channel api", capturedReq.Hints)
+	}
+	if capturedReq.Hints["loop_id"] == "" || capturedReq.Hints["loop_name"] != "api/test" {
+		t.Fatalf("loop hints = %#v, want loop_id and loop_name api/test", capturedReq.Hints)
+	}
+	if len(capturedReq.Messages) != 1 || capturedReq.Messages[0].Content != "hello" {
+		t.Fatalf("Messages = %#v, want user hello", capturedReq.Messages)
+	}
+}
+
+func TestHandleStreamingCompletionUsesChatLoopStream(t *testing.T) {
+	t.Parallel()
+
+	runner := &capturingAPILoopRunner{
+		response: &looppkg.Response{
+			Content:      "streamed",
+			Model:        "test-model",
+			FinishReason: "stop",
+		},
+		onRun: func(_ looppkg.Request, stream looppkg.StreamCallback) {
+			if stream != nil {
+				stream(agent.StreamEvent{Kind: agent.KindToken, Token: "streamed"})
+			}
+		},
+	}
+
+	server := NewServer("", 0, nil, nil, nil, nil, nil, nil, nil, nil, nil, testAPILogger())
+	server.ConfigureChatLoopLauncher(func(ctx context.Context, launch looppkg.Launch) (looppkg.LaunchResult, error) {
+		return looppkg.NewRegistry().Launch(ctx, launch, looppkg.Deps{
+			Runner: runner,
+			Logger: testAPILogger(),
+		})
+	})
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+	server.handleStreamingCompletion(rec, req, &agent.Request{
+		Messages: []agent.Message{{Role: "user", Content: "hello"}},
+		Hints:    map[string]string{"channel": "api"},
+	})
+
+	body := rec.Body.String()
+	if !strings.Contains(body, `"content":"streamed"`) {
+		t.Fatalf("stream body = %q, want streamed token", body)
+	}
+	if !strings.Contains(body, "data: [DONE]") {
+		t.Fatalf("stream body = %q, want DONE marker", body)
+	}
+	if rec.Header().Get("Content-Type") != "text/event-stream" {
+		t.Fatalf("Content-Type = %q, want text/event-stream", rec.Header().Get("Content-Type"))
 	}
 }
 


### PR DESCRIPTION
## Summary

Routes the native OpenAI-compatible API chat surfaces through the loop request/reply runtime instead of calling `agent.Loop.Run` directly from the HTTP handlers.

This adds a chat loop launcher callback to the API server and wires production to `App.launchLoop`, so `/v1/chat/completions`, streaming completions, and `/v1/chat` now enter the same `TurnBuilder` -> `AgentTurn` -> loop runner path as the recently migrated channel integrations. Native API requests keep their OpenAI wire handling in `server/api`, but loop-owned request prep, telemetry, accounting, cancellation, and runner execution now happen in one place.

The shared agent/loop request conversion helpers moved out of `owu_tracker.go` into `agent_loop_bridge.go` because OWU and the native API now both use that bridge.

## Validation

- `just test`
- `just ci`