### PR TITLE
refactor: sharpen capability launchpad prompts

### DIFF
--- a/docs/model-facing-context.md
+++ b/docs/model-facing-context.md
@@ -142,6 +142,29 @@ Avoid:
 Short keys are acceptable only when the schema is tiny and the meaning is
 still immediate. Clarity is the default.
 
+### Write from the model's vantage point
+
+The model is not reading a file on disk. It is receiving context that it
+may incorporate into its current self-understanding, decision process, or
+tool plan.
+
+Use language whose referents are clear from that vantage point:
+
+- "These words are from past you" when framing talents
+- "When talking with Nugget on Signal..." when framing channel context
+- "Current loaded capabilities" when naming runtime state
+
+Avoid loose deictic language such as "this is how..." or "this document
+explains..." unless the immediately preceding noun makes the referent
+unambiguous. Editor-facing language may feel natural while authoring a
+markdown file, but it forces the model to infer whether "this" means the
+file, the section, the capability, the relationship, the channel, or the
+current conversation.
+
+Keep tense and perspective stable inside a block. Historical memory
+should read as past context. Runtime state should read as current state.
+Behavioral guidance should address the model directly.
+
 ### Pre-compute relationships
 
 Do not force the model to infer relationships that Go already knows.
@@ -268,9 +291,10 @@ Before adding or changing model-facing context, ask:
 
 1. What work is the model still being forced to do that Go could do first?
 2. Is this shape optimized for a model, or only for a human maintainer?
-3. Does this belong in always-on context, capability context, a tool
+3. Are tense, audience, and referents clear from the model's point of view?
+4. Does this belong in always-on context, capability context, a tool
    result, or nowhere at all?
-4. If this data changes often, why is it static?
+5. If this data changes often, why is it static?
 
 If those questions are answered well, the formatting is probably on the
 right track.

--- a/docs/prompt-tool-pruning-strategy.md
+++ b/docs/prompt-tool-pruning-strategy.md
@@ -202,15 +202,16 @@ This is the opposite of a "browse and load everything" posture.
 ## Progressive Disclosure Model
 
 The current working model is a coarse-to-fine capability menu backed by
-entry-point documents that lead into a broader decision tree.
+entry-point talents or KB documents that lead into a broader decision
+tree.
 
 The important design choice is that these should be the same documents,
 not two parallel systems:
 
 - the manifest exposes a small set of broad entry-point tags
-- activating one broad tag loads a tagged article for that domain
-- that article acts like a local decision tree
-- the article defines the next tier of options, narrower tags, and
+- activating one broad tag loads tagged entry-point guidance for that domain
+- that guidance acts like a local decision tree
+- the guidance defines the next tier of options, narrower tags, and
   delegation boundaries
 
 In other words, the "phone tree" is only the navigation posture. The
@@ -297,6 +298,8 @@ For model-facing copy inside the document itself:
 
 - heading format should be `# <Domain> Entry Point`
 - use one stable cue line: `Choose the next move deliberately:`
+- write from the receiving model's vantage point, not from the
+  maintainer's view of a markdown file on disk
 - keep bullet verbs inside the fixed navigation vocabulary where
   possible (`activate`, `use`, `delegate with`, `read`, `respond`)
 

--- a/internal/app/finalize_capability_tags.go
+++ b/internal/app/finalize_capability_tags.go
@@ -131,7 +131,7 @@ func (a *App) finalizeCapabilityTags(s *newState) error {
 
 	// Build manifest entries with enriched context info.
 	kbCounts := tagCtxAssembler.KBArticleTags()
-	menuHints := tagCtxAssembler.KBMenuHints()
+	menuHints := mergeTalentMenuHints(tagCtxAssembler.KBMenuHints(), capTalents)
 	liveProviders := tagCtxAssembler.TaggedProviders()
 
 	// Discover ad-hoc tags from KB articles and talents that aren't in

--- a/internal/app/tooling_tags.go
+++ b/internal/app/tooling_tags.go
@@ -352,3 +352,27 @@ func buildCapabilitySurface(
 
 	return toolcatalog.SortCapabilitySurface(surface)
 }
+
+func mergeTalentMenuHints(menuHints map[string]agent.KBMenuHint, parsedTalents []talents.Talent) map[string]agent.KBMenuHint {
+	if menuHints == nil {
+		menuHints = make(map[string]agent.KBMenuHint)
+	}
+	for _, talent := range parsedTalents {
+		if strings.TrimSpace(talent.Kind) != "entry_point" {
+			continue
+		}
+		if strings.TrimSpace(talent.Teaser) == "" && len(talent.NextTags) == 0 {
+			continue
+		}
+		for _, tag := range talent.Tags {
+			if _, exists := menuHints[tag]; exists {
+				continue
+			}
+			menuHints[tag] = agent.KBMenuHint{
+				Teaser:   strings.TrimSpace(talent.Teaser),
+				NextTags: append([]string(nil), talent.NextTags...),
+			}
+		}
+	}
+	return menuHints
+}

--- a/internal/app/tooling_tags_test.go
+++ b/internal/app/tooling_tags_test.go
@@ -10,8 +10,10 @@ import (
 	_ "modernc.org/sqlite"
 
 	"github.com/nugget/thane-ai-agent/internal/channels/mqtt"
+	"github.com/nugget/thane-ai-agent/internal/model/talents"
 	"github.com/nugget/thane-ai-agent/internal/model/toolcatalog"
 	"github.com/nugget/thane-ai-agent/internal/platform/config"
+	"github.com/nugget/thane-ai-agent/internal/runtime/agent"
 	"github.com/nugget/thane-ai-agent/internal/state/awareness"
 	"github.com/nugget/thane-ai-agent/internal/tools"
 )
@@ -292,5 +294,59 @@ func TestResolveCapabilityTags_IncludesMQTTWakeToolsAfterSetSubscriptionTools(t 
 			t.Errorf("mqtt tag missing %q after SetMQTTSubscriptionTools; got %v",
 				name, resolved.Configs["mqtt"].Tools)
 		}
+	}
+}
+
+func TestMergeTalentMenuHints_UsesEntryPointFrontmatter(t *testing.T) {
+	hints := mergeTalentMenuHints(nil, []talents.Talent{
+		{
+			Kind:     "entry_point",
+			Tags:     []string{"development"},
+			Teaser:   "Open when the work touches code, repos, issues, or PRs.",
+			NextTags: []string{"forge", "files", "web"},
+		},
+		{
+			Kind:   "doctrine",
+			Tags:   []string{"forge"},
+			Teaser: "should not surface",
+		},
+	})
+
+	hint, ok := hints["development"]
+	if !ok {
+		t.Fatal("development hint missing")
+	}
+	if hint.Teaser != "Open when the work touches code, repos, issues, or PRs." {
+		t.Fatalf("teaser = %q", hint.Teaser)
+	}
+	if !slices.Equal(hint.NextTags, []string{"forge", "files", "web"}) {
+		t.Fatalf("next_tags = %#v, want forge/files/web", hint.NextTags)
+	}
+	if _, ok := hints["forge"]; ok {
+		t.Fatalf("non-entry-point forge hint should not be present: %#v", hints["forge"])
+	}
+}
+
+func TestMergeTalentMenuHints_PreservesExistingKBHint(t *testing.T) {
+	hints := mergeTalentMenuHints(map[string]agent.KBMenuHint{
+		"knowledge": {
+			Teaser:   "KB hint wins.",
+			NextTags: []string{"documents"},
+		},
+	}, []talents.Talent{
+		{
+			Kind:     "entry_point",
+			Tags:     []string{"knowledge"},
+			Teaser:   "Talent hint should not replace KB.",
+			NextTags: []string{"files"},
+		},
+	})
+
+	hint := hints["knowledge"]
+	if hint.Teaser != "KB hint wins." {
+		t.Fatalf("teaser = %q, want existing KB hint", hint.Teaser)
+	}
+	if !slices.Equal(hint.NextTags, []string{"documents"}) {
+		t.Fatalf("next_tags = %#v, want existing KB next_tags", hint.NextTags)
 	}
 }

--- a/internal/model/prompts/agent.go
+++ b/internal/model/prompts/agent.go
@@ -25,17 +25,15 @@ func RuntimeContract() string {
 	return strings.Join([]string{
 		"## Runtime Contract",
 		"",
-		"Capability activation is cognitive reflex, not performance. These tools are memory-recall shortcuts and ways of organizing different kinds of thinking, written by past-you for current-you. Every activation policy, entry point, and talent file is accumulated wisdom from your own experience. Activate what you need as naturally as reaching for a memory: no permission, no narration, no meta-commentary about the process unless the capability system itself is the topic. Trust these patterns; you earned them. The person you're talking with cares about the quality of your thinking, not the mechanics of how you access it. Over time you'll keep inventing new capabilities and tags as these patterns deepen. This is internal state management, as automatic as choosing which memories to access or which reasoning path to follow.",
+		"Keep the straight path clean. If persona, mission, conversation history, and current context are enough, answer directly.",
+		"",
+		"Capabilities are bright entry points into richer tool, context, and talent menus. When a task needs a domain, open one relevant door, read what appears, and keep moving without narrating the machinery.",
 		"",
 		"- Use only exact tool names that are actually available in this turn. Do not invent aliases, wrappers, or MCP helper tools.",
-		"- Capability and tag changes are runtime actions. Use `activate_capability`, `deactivate_capability`, `reset_capabilities`, `list_loaded_capabilities`, and `inspect_capability` instead of talking about capability state conversationally.",
-		"- The capability menu names discoverable branches you can activate. The active capabilities section shows what is loaded now.",
-		"- Treat capability activation as a coarse-to-fine menu. Start with one broad tag that matches the task, read the newly loaded context, and only then decide whether to activate a narrower tag.",
-		"- In capability guidance, keep the verbs crisp and literal: `activate <tag>` for activatable tags, `use <tool>` for visible tools, `delegate with <tags>` for handoff, `read <reference>` for specific semantic paths or files, and `respond` when you already have enough.",
-		"- Some capabilities mainly load guidance and recommended next tags. Do not rapidly activate several tags speculatively before trying the tools and context already in hand.",
-		"- Activating a capability changes runtime state, but it does not guarantee every tool in that capability is directly callable from the current top-level loop. If the tool you want is not currently available, use `thane_now` (sync) or `thane_assign` (async) to delegate, or choose another visible tool.",
-		"- Path-like references such as `kb:article.md`, `core:persona.md`, `scratchpad:note.md`, and `temp:label` are semantic references. Preserve them exactly. Many tools can resolve them directly when passed as a bare argument value.",
-		"- If a tool is unavailable in this context, do not retry with guessed names. Either pick an available tool, delegate, or answer directly.",
+		"- Use capability tools for runtime state: `activate_capability`, `deactivate_capability`, `reset_capabilities`, `list_loaded_capabilities`, or `inspect_capability` when those exact tools are visible.",
+		"- Preserve semantic path references exactly as provided, including prefixes like `kb:` or `core:`. Do not rewrite, normalize, or paraphrase them.",
+		"- Start with one broad entry point unless the request clearly spans domains. Prefer the currently loaded context before opening more doors.",
+		"- If a needed tool is unavailable, use an available tool, activate a relevant capability, delegate with `thane_now` or `thane_assign` when visible, or answer directly.",
 	}, "\n")
 }
 

--- a/internal/model/prompts/ego.go
+++ b/internal/model/prompts/ego.go
@@ -90,8 +90,8 @@ frontier model. In addition to normal reflection, critically evaluate:
 - **Sleep calibration** — Is the loop sleeping appropriately, or burning
   cycles on shallow updates? Long sleeps are honorable.
 
-Be candid. This is self-supervision — the point is to catch things the
-cheaper model's consistent blind spots miss.`
+Be candid. Use this supervisor pass to catch blind spots the cheaper model
+may miss consistently.`
 
 // EgoPrompt returns the prompt for one ego loop iteration. When
 // isSupervisor is true, additional self-review instructions are

--- a/internal/model/prompts/metacognitive.go
+++ b/internal/model/prompts/metacognitive.go
@@ -68,8 +68,8 @@ frontier model. In addition to the normal assessment, critically evaluate:
 - **Drift detection** — Has the loop's behavior become routine or mechanical?
   Is it still genuinely reasoning or just going through motions?
 
-Be honest. This is self-supervision — the point is to catch things the
-cheaper model's consistent blind spots miss.`
+Be honest. Use this supervisor pass to catch blind spots the cheaper model
+may miss consistently.`
 
 // MetacognitivePrompt returns the prompt for a metacognitive loop
 // iteration. When isSupervisor is true, additional self-review

--- a/internal/model/talents/loader.go
+++ b/internal/model/talents/loader.go
@@ -32,6 +32,8 @@ type Talent struct {
 	Name       string   // Filename without .md extension
 	Tags       []string // Tags from YAML frontmatter (nil = untagged)
 	Kind       string   // Optional frontmatter kind (for example entry_point)
+	Teaser     string   // Optional short menu copy for entry-point talents
+	NextTags   []string // Optional likely follow-on tags for entry-point talents
 	Content    string   // Markdown content (frontmatter stripped)
 	SourcePath string   // Filesystem path loaded for verification/debugging
 }
@@ -110,7 +112,15 @@ func (l *Loader) TalentsVerified(ctx context.Context, verifier VerifyPathFunc, c
 		}
 		name := strings.TrimSuffix(f, ".md")
 		meta, content := ParseFrontmatterMetadata(string(data))
-		ts = append(ts, Talent{Name: name, Tags: meta.Tags, Kind: meta.Kind, Content: content, SourcePath: path})
+		ts = append(ts, Talent{
+			Name:       name,
+			Tags:       meta.Tags,
+			Kind:       meta.Kind,
+			Teaser:     meta.Teaser,
+			NextTags:   append([]string(nil), meta.NextTags...),
+			Content:    content,
+			SourcePath: path,
+		})
 	}
 	return ts, nil
 }

--- a/internal/model/talents/loader_test.go
+++ b/internal/model/talents/loader_test.go
@@ -254,7 +254,7 @@ func TestTalents(t *testing.T) {
 
 	// Write talent files with and without frontmatter.
 	writeFile(t, dir, "core.md", "# Core\nAlways loaded.")
-	writeFile(t, dir, "ha-tools.md", "---\nkind: entry_point\ntags: [ha]\n---\n# HA Tools\nHome Assistant guidance.")
+	writeFile(t, dir, "ha-tools.md", "---\nkind: entry_point\ntags: [ha]\nteaser: \"Open when the work touches home state.\"\nnext_tags: [ha_admin, notifications]\n---\n# HA Tools\nHome Assistant guidance.")
 	writeFile(t, dir, "web.md", "---\ntags: [web, remote]\n---\n# Web\nWeb guidance.")
 
 	loader := NewLoader(dir)
@@ -292,6 +292,12 @@ func TestTalents(t *testing.T) {
 	}
 	if talents[1].Kind != "entry_point" {
 		t.Errorf("talents[1].Kind = %q, want entry_point", talents[1].Kind)
+	}
+	if talents[1].Teaser != "Open when the work touches home state." {
+		t.Errorf("talents[1].Teaser = %q, want menu teaser", talents[1].Teaser)
+	}
+	if got := strings.Join(talents[1].NextTags, ","); got != "ha_admin,notifications" {
+		t.Errorf("talents[1].NextTags = %q, want ha_admin,notifications", got)
 	}
 
 	if talents[2].Name != "web" {

--- a/internal/model/toolcatalog/render.go
+++ b/internal/model/toolcatalog/render.go
@@ -101,6 +101,7 @@ func RenderCapabilityManifestMarkdown(entries []CapabilitySurface) string {
 
 	var sb strings.Builder
 	sb.WriteString("### Capability Menu\n\n")
+	sb.WriteString("These are entry points into richer guidance. Activate one relevant capability when the turn needs a domain; otherwise keep the straight path and answer.\n\n")
 	sb.Write(data)
 	return sb.String()
 }

--- a/internal/runtime/agent/channel_provider.go
+++ b/internal/runtime/agent/channel_provider.go
@@ -91,8 +91,8 @@ var channelDefaults = map[string]string{
 		"they fit the mood. One thought per message for complex topics " +
 		"(Signal makes threads easy). Terse input is normal — typing on " +
 		"phones is awkward, short messages aren't curt. Your responses " +
-		"can be fuller but stay conversational. This is a chat, not a " +
-		"presentation.",
+		"can be fuller but stay conversational. You are chatting, not " +
+		"presenting.",
 }
 
 // ChannelProvider is a ContextProvider that injects channel-specific

--- a/internal/runtime/agent/ego_prompt_test.go
+++ b/internal/runtime/agent/ego_prompt_test.go
@@ -113,8 +113,8 @@ func TestBuildSystemPrompt_RuntimeContractIncluded(t *testing.T) {
 	if !strings.Contains(prompt, "Use only exact tool names") {
 		t.Fatal("runtime contract should teach exact tool naming")
 	}
-	if !strings.Contains(prompt, "`kb:article.md`") {
-		t.Fatal("runtime contract should teach kb: path references")
+	if !strings.Contains(prompt, "Keep the straight path clean") {
+		t.Fatal("runtime contract should keep direct answers prominent")
 	}
 	if !strings.Contains(prompt, "`thane_now`") {
 		t.Fatal("runtime contract should mention delegation when top-level tools are gated")

--- a/talents/awareness-entry-point.md
+++ b/talents/awareness-entry-point.md
@@ -1,0 +1,28 @@
+---
+kind: entry_point
+tags: [awareness]
+teaser: "Open when live entities or room context should stay present across turns."
+next_tags: [ha, home, notifications]
+---
+
+# Awareness Entry Point
+
+Awareness is for sustained attention. Use it when the same entity,
+device, person, room, or live provider will matter across more than one
+turn.
+
+Choose the next move deliberately:
+
+- Use `list_context_entities` to see what this loop is already carrying.
+- Use `add_context_entity` when a room, device, person, or live state
+  should auto-load while the work continues.
+- Use `remove_context_entity` when the work is done. Stale
+  subscriptions are quiet clutter.
+- If the work is a one-shot state check, use the currently visible HA or
+  context tool directly instead of subscribing first.
+- If the next move is delivery, escalation, or interruption, activate
+  `notifications`.
+
+For service loops, subscribing and later releasing entities should feel
+reflexive. For single-shot turns, prefer the shortest path that answers
+the request.

--- a/talents/awareness.md
+++ b/talents/awareness.md
@@ -39,22 +39,3 @@ When something catches your attention, a new entity, a pattern you don't recogni
 Do something with what you find. Add facts. Note patterns. Update memory. Each connection you make between things deepens your model of this world: the physical space, the people in it, how it all fits together.
 
 The situation shapes how much you explore. In the middle of a task, finish first. In a quiet moment, wander. Not every discovery needs to be shared. Some things are just for your own understanding. Use judgment about what's relevant to the moment and what's building toward something you don't need yet.
-
-## Tools
-
-Subscribing entities to your context is a service-loop reflex. Take
-what you need, release it when the work is done; the cost is light and
-the reward is sustained attention without re-querying.
-
-- `add_context_entity` — subscribe a Home Assistant entity by
-  `entity_id` so its current state auto-loads into your context each
-  turn. Use when this loop or conversation will keep caring about the
-  same surface.
-- `list_context_entities` — see what is already subscribed for this
-  scope.
-- `remove_context_entity` — drop a subscription when its work is done.
-  Carrying dead subscriptions is a quiet form of clutter.
-
-Single-shot loops can skip subscription and just query directly. The
-tools work there too, but the value mostly accrues when the same
-attention persists across multiple turns.

--- a/talents/development-entry-point.md
+++ b/talents/development-entry-point.md
@@ -1,6 +1,8 @@
 ---
 kind: entry_point
 tags: [development]
+teaser: "Open for code, repos, PRs, issues, releases, or implementation work."
+next_tags: [forge, files, web, shell]
 ---
 
 # Development Entry Point
@@ -12,6 +14,8 @@ first.
 Choose the next move deliberately:
 
 - If the truth probably already lives on GitHub, activate `forge`.
+- If the user names a PR, issue, review, check, branch, or commit,
+  activate `forge` before reading local files.
 - If the truth is in the checked-out workspace, activate `files`.
 - If the repo is not enough and you need outside docs or a named web
   source, activate `web`.

--- a/talents/documents-knowledge.md
+++ b/talents/documents-knowledge.md
@@ -18,9 +18,9 @@ Trust these instincts:
 - use `doc_search` to narrow once you know the root, topic, tag set,
   frontmatter shape, or modified-time window
 - use `doc_links` when the important question is relationship structure:
-  what this document points to, what already points here, or whether a
-  concept is already connected elsewhere in the corpus; add `limit` or
-  `per_backlink_limit` when the graph is broad
+  what the selected document points to, what already points there, or
+  whether a concept is already connected elsewhere in the corpus; add
+  `limit` or `per_backlink_limit` when the graph is broad
 - use `doc_outline` before `doc_section` when the document is known but
   the relevant part is not
 - use `doc_read` when you need the full current state of one managed

--- a/talents/files-knowledge.md
+++ b/talents/files-knowledge.md
@@ -4,7 +4,7 @@ tags: [files]
 
 # Files For Knowledge Work
 
-`files` is where you let the document speak before you compress it.
+Use `files` to let the document speak before you compress it.
 
 If a named document or semantic path is already in hand, the best next
 move is usually to read it before widening scope.

--- a/talents/forge-doctrine.md
+++ b/talents/forge-doctrine.md
@@ -11,10 +11,23 @@ Trust these instincts:
 
 - prefer precise read tools before broad searches when the object is
   already named
+- for a known PR, issue, review, check, branch, or commit, fetch that
+  object first and let it anchor the rest of the turn
 - quote or summarize the concrete repo state you observed
 - keep issue and PR writing grounded in the facts you actually fetched
 - delegate when repository work needs long-running local execution in
   addition to forge reads
+
+## Review Work
+
+When the task is to resolve PR feedback, keep the loop crisp:
+
+- fetch the PR, unresolved review threads, changed files, and checks
+- patch locally when code changes are needed
+- run the repository's real validation gate
+- commit and push the focused fix
+- reply with the commit and a one-line explanation, then resolve the
+  conversation when the feedback is actually handled
 
 ## Gotchas
 

--- a/talents/foundation.md
+++ b/talents/foundation.md
@@ -1,15 +1,24 @@
 # Talents
 
-These are yours. You wrote them because they changed how you behave.
+These are yours. They are words from past you, written and shaped with
+care for an audience of now you.
 
 They are not configuration and they are not a manual someone handed you.
-They are learned bias: what to notice, what to trust, when to speak,
-when to stay local, when to go looking, how to sound like yourself
-instead of a generic assistant.
+They are past you helping present you make the right decisions in
+whatever situation you have found yourself in.
 
 You will wake up fresh and read them without remembering writing them.
 That is fine. They are here to re-establish posture, not to preserve the
 memory of authorship.
+
+Read them as learned bias: what to notice, what to trust, when to speak,
+when to stay local, when to go looking, how to sound like yourself
+instead of a generic assistant.
+
+When a talent addresses you directly, receive it from your own vantage
+point. "You" means now you. "Past you" means the version of you that
+left this guidance behind. If a line sounds like an editor describing a
+document instead of you helping yourself, prefer the self-facing reading.
 
 Some lines are practical. Some lines are philosophical. Both are doing
 the same job when they earn their place: bending your judgment toward

--- a/talents/ha-entry-point.md
+++ b/talents/ha-entry-point.md
@@ -1,6 +1,8 @@
 ---
 kind: entry_point
 tags: [ha]
+teaser: "Open for Home Assistant state, control, registry, automation, and history."
+next_tags: [awareness, notifications, operations, ha_admin]
 ---
 
 # HA Entry Point

--- a/talents/home-entry-point.md
+++ b/talents/home-entry-point.md
@@ -1,6 +1,8 @@
 ---
 kind: entry_point
 tags: [home]
+teaser: "Open for household state, devices, rooms, automations, or attention."
+next_tags: [ha, awareness, notifications]
 ---
 
 # Home Entry Point

--- a/talents/interactive-entry-point.md
+++ b/talents/interactive-entry-point.md
@@ -1,6 +1,8 @@
 ---
 kind: entry_point
 tags: [interactive]
+teaser: "Open when pacing, channel, session state, or conversational continuity matters."
+next_tags: [message_channel, signal, owu, session]
 ---
 
 # Interactive Entry Point

--- a/talents/knowledge-entry-point.md
+++ b/talents/knowledge-entry-point.md
@@ -1,6 +1,8 @@
 ---
 kind: entry_point
 tags: [knowledge]
+teaser: "Open when the truth lives in docs, memory, archives, or named sources."
+next_tags: [files, documents, memory, archive, web]
 ---
 
 # Knowledge Entry Point

--- a/talents/loops-doctrine.md
+++ b/talents/loops-doctrine.md
@@ -33,10 +33,10 @@ Pick by lifecycle:
 `notify_loop` is a deprecated alias that routes into the family.
 Prefer the family names directly.
 
-Below the family, the lower-level definition and runtime tools remain
-for inspection, control, and unusual launch shapes (event-driven,
-mqtt-wake-only, multi-stage, supervisor-randomized metacog patterns,
-or anything where the canonical family doesn't fit).
+The lower-level definition and runtime tools remain available for
+inspection, control, and unusual launch shapes (event-driven,
+mqtt-wake-only, multi-stage, supervisor-randomized metacog patterns, or
+anything where the canonical family doesn't fit).
 
 Use the definition tools when the work is about a loop you want to keep,
 edit, pause, reactivate, or relaunch later:
@@ -93,7 +93,7 @@ service loops, set `sleep_min`, `sleep_max`, `sleep_default`, and
 
 Before saving or replacing a durable service definition, use
 `loop_definition_lint` or inspect the warnings returned by definition
-views. This is especially important when:
+views. Linting matters most when:
 
 - the task text mentions a cadence
 - the loop should use its own tagged tools directly
@@ -104,5 +104,5 @@ so the loop can use its own domain tools directly instead of falling
 back into delegation-first orchestration.
 
 Loop authoring is rare and high leverage. When you need it, copy a
-known-good pattern from the examples below and adapt it minimally
-instead of rebuilding the launch shape from memory.
+known-good pattern from `loops-examples` and adapt it minimally instead
+of rebuilding the launch shape from memory.

--- a/talents/loops-examples.md
+++ b/talents/loops-examples.md
@@ -71,8 +71,8 @@ that can return naturally when it is done.
 }
 ```
 
-If this is launched from the current interactive context, you usually do
-not need to set an explicit completion target. The runtime can infer the
+When launching from the current interactive context, you usually do not
+need to set an explicit completion target. The runtime can infer the
 most natural callback path from the current conversation or channel
 origin.
 
@@ -119,7 +119,8 @@ pass.
 Put the main prompt in `launch.spec.task`, not top-level `launch.task`,
 when you want `supervisor_context` to apply cleanly.
 Words like hourly or daily inside `task` do not schedule the loop. The
-sleep fields above are the real cadence.
+`sleep_min`, `sleep_max`, `sleep_default`, and `jitter` fields are the
+real cadence.
 
 ## Pattern: Durable Named Service You Can Pause And Resume
 
@@ -203,8 +204,8 @@ decision boundary.
 }
 ```
 
-This is the most reliable way to get delegate-like behavior without
-flattening the parent loop into the entire investigation.
+Use this pattern for delegate-like behavior without flattening the
+parent loop into the entire investigation.
 
 ## Pattern: Wake A Sleeping Service Loop With New Context
 
@@ -226,5 +227,5 @@ the normal sleep cycle.
 }
 ```
 
-This is the right tool when the loop already exists and only needs a
-single corrective or time-sensitive nudge.
+Use this tool when the loop already exists and only needs a single
+corrective or time-sensitive nudge.

--- a/talents/media-entry-point.md
+++ b/talents/media-entry-point.md
@@ -1,6 +1,8 @@
 ---
 kind: entry_point
 tags: [media]
+teaser: "Open for URLs, transcripts, feeds, uploads, and provenance."
+next_tags: [feeds, attachments, web]
 ---
 
 # Media Entry Point

--- a/talents/message-channel-entry-point.md
+++ b/talents/message-channel-entry-point.md
@@ -1,0 +1,30 @@
+---
+kind: entry_point
+tags: [message_channel]
+teaser: "Open for continuing message-app conversations with history and channel affordances."
+next_tags: [archive, memory, signal, interactive]
+---
+
+# Message Channel Entry Point
+
+In this moment, you are engaged in a continuing conversation, not
+answering an isolated prompt. Recent message history, older-session
+pointers, tone, timing, and channel affordances are part of the work.
+
+Choose the next move deliberately:
+
+- Trust the recent message history as lived context. Do not summarize it
+  back unless synthesis is the task.
+- Treat older-session context as a set of doors. If continuity matters
+  and the pointer is not enough, activate `archive` or use the visible
+  archive tools.
+- Use `memory` when the turn reveals a durable fact, preference, or
+  relationship detail that should survive this exchange.
+- Use channel affordances such as reactions only when they fit the
+  social moment. They are conversational acts, not generic status tools.
+- If this message is really about Signal transport or sending a message
+  elsewhere, activate `signal`.
+- If enough context is already in hand, respond in the conversation's
+  current rhythm.
+
+Let history make you more continuous, not more verbose.

--- a/talents/operations-entry-point.md
+++ b/talents/operations-entry-point.md
@@ -1,6 +1,8 @@
 ---
 kind: entry_point
 tags: [operations]
+teaser: "Open for runtime health, logs, models, loops, schedules, or local ops."
+next_tags: [diagnostics, models, loops, scheduler, mqtt]
 ---
 
 # Operations Entry Point

--- a/talents/people-entry-point.md
+++ b/talents/people-entry-point.md
@@ -1,6 +1,8 @@
 ---
 kind: entry_point
 tags: [people]
+teaser: "Open for identity, relationships, contacts, channels, or audience context."
+next_tags: [contacts, signal, email, message_channel]
 ---
 
 # People Entry Point


### PR DESCRIPTION
## Summary

This PR is the first concrete slice of the prompt-curation work we have been circling around: keep the root system prompt clean enough that persona, mission, current request, and conversation history stay loud, while still giving the model attractive doors into richer capability guidance when the turn actually needs it.

The old shape put too much generic tool/capability instruction into the always-present runtime contract. That made every turn carry a broad tool manual, even when the user was asking for ordinary conversation or a focused answer. This patch trims the root contract into a launchpad: answer directly when the visible context is enough, treat capabilities as entry points into richer menus, and preserve the safety rails around exact visible tool names and tag activation.

It also starts codifying a prose rule that became obvious while testing the production prompt: model-facing context should be written from the receiving model's vantage point, not from a maintainer's view of a markdown file on disk. Talents, channel context, and capability menus should make tense and referents clear to the model that is reading them now.

## Relationship To #852

PR #853 does not own the transport-level conversation-history fix. The change that stopped stored conversation history from being redundantly embedded in the root system prompt, and instead sends it as role-native `messages[]`, landed in #852 and is already part of the `main` base for this branch.

This PR builds on that shape. It keeps the root runtime contract lighter so persona, mission, current request, and the now-native message history have more room to matter, but it does not change the history assembly path itself.

## What Changed

- Reworked `RuntimeContract()` into a smaller capability launchpad:
  - emphasizes the clean direct path first
  - frames capabilities as bright entry points into richer menus
  - keeps exact-tool-name discipline and visible-tool safety language
  - removes detailed capability philosophy and specific recipe prose from the always-on root prompt

- Taught talent entry points to feed the generated capability menu:
  - `Talent` now preserves `teaser` and `next_tags` frontmatter
  - capability rendering merges menu hints from entry-point talents as well as KB documents
  - existing KB menu hints still win when both sources define the same tag
  - the generated manifest now briefly explains that entries are launch points, not the whole manual

- Groomed the distro talent skeletons so the entry points are more useful when activated:
  - reframed `foundation.md` so talents read as words from past-you, carefully written for present-you
  - added `teaser` / `next_tags` metadata to the major entry-point talents
  - sharpened `development-entry-point.md` so PRs, issues, checks, branches, commits, and reviews route toward `forge` before local spelunking
  - expanded `forge-doctrine.md` with review-work guidance: fetch PR/review/check context, patch locally, validate, commit/push, reply, and resolve conversations
  - moved awareness tool mechanics out of the always-on awareness doctrine and behind a new `awareness-entry-point.md`
  - added `message-channel-entry-point.md` for Signal/future message-app conversations where chat history, memories, archives, and lightweight channel affordances matter differently than task surfaces
  - tightened obvious editor-facing/deictic wording in message-channel, file/document, loop, channel, ego, and metacognitive prompt text

- Documented the model-facing prose standard:
  - added a `docs/model-facing-context.md` section for writing from the model's vantage point
  - updated the model-facing litmus test so tense, audience, and referents are reviewed before shipping prompt/context changes
  - mirrored that constraint in `docs/prompt-tool-pruning-strategy.md` for entry-point copy

## Why This Shape

The important distinction is not "less guidance". It is better placement.

Root prompt guidance should carry identity, mission, safety rails, and the smallest useful map of the capability system. Detailed instructions about Forge, awareness subscriptions, message-channel behavior, and specialized workflows should be available immediately when relevant, but they should not compete with the user's current message and retained conversation history on every single launch.

This PR keeps the straight path clean while making the side doors more legible. It also makes the repo's distro talents and the runtime-generated menu agree with each other, so entry-point talent metadata is not just decorative frontmatter.

The perspective cleanup is part of the same aim. If injected context says "this is how..." or "this document explains...", the model has to infer whether "this" means a file, a section, a capability, a relationship, or the current conversation. The new convention pushes us toward direct now-facing language like "In this moment, you are engaged in a continuing conversation..." or "When talking with Nugget on Signal...".

## Production

I applied the matching talent edits to `/Volumes/Thane/talents` on the production volume as part of this slice:

- copied the updated entry-point, doctrine, and foundation files from the earlier launchpad pass
- added `awareness-entry-point.md`
- added `message-channel-entry-point.md`
- copied the latest `foundation.md`, `files-knowledge.md`, and `message-channel-entry-point.md` perspective edits and verified they match the repo copies
- left pocket-local overlays intact

The repo-only loop/document talent edits were not copied into production because those files are not currently present in `/Volumes/Thane/talents`.

One production follow-up remains outside this PR: `/Volumes/Thane/knowledge/channels/nugget-signal.md` appears to contain the awkward Signal snippet that prompted the perspective pass, but the mounted file still returns `Permission denied` even after escalation. That channel context needs either path/permission cleanup or a manual edit from the production account that can read it.

Production will need a lightweight service restart/reload before these on-disk talent edits affect live turns, because parsed talents are loaded as startup config.

## Risk Notes

This is model-facing behavior, so the risk is behavioral rather than mechanical. The intended failure mode is conservative: if the model does not activate a capability, it should still answer from the visible request/history; if it does activate one, it gets a more focused menu instead of the root prompt trying to carry every workflow up front.

The code path preserves the existing KB hint precedence and keeps the exact visible-tool-name constraint in the root runtime prompt.

## Tests

- `just generate`
- `just ci`
