### PR TITLE
feat: expose API management surfaces

### DIFF
--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -4,31 +4,88 @@ Thane serves three network listeners simultaneously from a single binary.
 
 ## Port 8080 — Native API
 
-OpenAI-compatible `/v1/chat/completions` endpoint. This is the primary
-interface for direct integration, development, and the built-in web
-experience.
+Port 8080 serves the OpenAI-compatible native API and the embedded Cognition
+Engine dashboard. The dashboard has no build step and fetches JSON/SSE
+endpoints from the same listener.
 
-**Chat API:** Accepts standard OpenAI chat completion requests with
-streaming support. The `model` field selects a
-[routing profile](../operating/routing-profiles.md) (e.g., `thane:latest`,
-`thane:premium`).
+### Chat and Models
 
-**Web Dashboard:** Served on the same port at the root path. Includes:
-- **Overview** — runtime stats, dependency health, model router info
-- **Chat** — interactive web chat interface with streaming
-- **Contacts** — browse and inspect the contact directory
-- **Facts** — search the semantic knowledge store
-- **Sessions** — list sessions with full transcripts and timeline view
-- **Tasks** — view scheduled tasks with execution history
+| Method | Path | Purpose |
+| --- | --- | --- |
+| `POST` | `/v1/chat/completions` | OpenAI-compatible chat completions with streaming support. The `model` field selects a [routing profile](../operating/routing-profiles.md), such as `thane:latest` or `thane:premium`. |
+| `POST` | `/v1/chat` | Minimal JSON chat endpoint for simple testing. |
+| `GET` | `/v1/models` | OpenAI-compatible model list. |
 
-The dashboard uses embedded HTML templates and htmx for lightweight
-interactivity. No build step, no JavaScript framework.
+### Runtime and Web Dashboard
 
-**Health endpoint:** Available for service monitoring.
+| Method | Path | Purpose |
+| --- | --- | --- |
+| `GET` | `/` | Embedded Cognition Engine dashboard. |
+| `GET` | `/health` | Dependency health for service monitoring. |
+| `GET` | `/v1/version` | Build and runtime metadata. |
+| `GET` | `/api/system` | Dashboard aggregate: health, uptime, version, model registry, router stats, Anthropic rate limits, loop definitions, and capability catalog. |
+| `GET` | `/api/system/logs` | Structured log tail across the runtime, excluding API/web feedback noise. |
+| `GET` | `/api/loops` | Live loop status snapshots, including recent iterations, active tags, tooling, and config. |
+| `GET` | `/api/loops/events` | SSE stream. Sends an initial loop snapshot, then loop and delegate events. |
+| `GET` | `/api/loops/{id}/logs` | Structured logs scoped to a loop's recent conversation IDs. |
+| `GET` | `/api/loop-definitions` | Effective durable loop-definition registry view, including runtime state. |
+| `GET` | `/api/capabilities` | Resolved capability catalog. Pass `include=excluded` to include operator-excluded tools. |
+| `GET` | `/api/capabilities/{tag}` | Single capability entry. |
+| `GET` | `/api/request-detail/_probe` | Request-detail availability probe. |
+| `GET` | `/api/requests/{id}` | Live or retained request detail: prompt, messages, tool calls, results, and token metadata. |
 
-**Companion WebSocket:** Native companion apps connect at
-`/v1/companion/ws` to register local host capabilities. The older
-`/v1/platform/ws` route remains as a compatibility alias.
+### Router, Registry, and History
+
+| Method | Path | Purpose |
+| --- | --- | --- |
+| `GET` | `/v1/router/stats` | Router statistics, including Anthropic rate-limit snapshot when available. |
+| `GET` | `/v1/router/audit` | Recent routing decisions. |
+| `GET` | `/v1/router/explain/{requestId}` | Routing decision for one request ID. |
+| `GET` | `/v1/model-registry` | Effective model registry snapshot. |
+| `POST` | `/v1/model-registry/policy` | Set a deployment policy. |
+| `DELETE` | `/v1/model-registry/policy?deployment=...` | Clear a deployment policy. |
+| `POST` | `/v1/model-registry/resource-policy` | Set a resource policy. |
+| `DELETE` | `/v1/model-registry/resource-policy?resource=...` | Clear a resource policy. |
+| `GET` | `/v1/contacts` | List or search contacts. Supports `query`, `kind`, `trust_zone`, `property`, `value`, `exact=true`, and `limit` (default 100, max 500). |
+| `GET` | `/v1/contacts/{id}` | Get one contact with structured properties. |
+| `POST` | `/v1/contacts` | Create a contact with optional vCard-style `properties`. |
+| `PUT` | `/v1/contacts/{id}` | Replace a contact and its structured properties. |
+| `DELETE` | `/v1/contacts/{id}` | Soft-delete a contact. |
+| `GET` | `/v1/loop-definitions` | Effective durable loop-definition registry view. |
+| `GET` | `/v1/loop-definitions/{name}` | One loop definition. |
+| `POST` | `/v1/loop-definitions` | Upsert a mutable overlay loop definition. |
+| `DELETE` | `/v1/loop-definitions/{name}` | Delete a mutable overlay loop definition. |
+| `POST` | `/v1/loop-definitions/policy` | Set a loop-definition policy. |
+| `DELETE` | `/v1/loop-definitions/policy?name=...` | Clear a loop-definition policy. |
+| `POST` | `/v1/loop-definitions/{name}/launch` | Launch a stored loop definition. |
+| `GET` | `/v1/conversations` | Conversation summaries. |
+| `GET` | `/v1/conversations/{id}` | Conversation detail. |
+| `GET` | `/v1/tools/calls` | Tool-call history. |
+| `GET` | `/v1/tools/stats` | Tool usage stats. |
+| `GET` | `/v1/session/stats` | Current session usage and context stats. |
+| `GET` | `/v1/usage/summary` | Usage summary over a time window. |
+| `POST` | `/v1/session/balance` | Set reported balance for session cost tracking. |
+| `POST` | `/v1/session/reset` | Reset current session stats. |
+| `POST` | `/v1/session/compact` | Compact current session history. |
+| `GET` | `/v1/session/history` | Current session history. |
+| `GET` | `/v1/archive/sessions` | Archived session list. |
+| `GET` | `/v1/archive/sessions/{id}` | Archived session detail. |
+| `GET` | `/v1/archive/sessions/{id}/export` | Export one archived session. |
+| `GET` | `/v1/archive/search` | Full-text archive search. |
+| `GET` | `/v1/archive/messages` | Archived message query. |
+| `GET` | `/v1/archive/stats` | Archive statistics. |
+
+### Checkpoints and Companion Apps
+
+| Method | Path | Purpose |
+| --- | --- | --- |
+| `POST` | `/v1/checkpoint` | Create a checkpoint. |
+| `GET` | `/v1/checkpoints` | List checkpoints. |
+| `GET` | `/v1/checkpoint/{id}` | Get checkpoint metadata/detail. |
+| `DELETE` | `/v1/checkpoint/{id}` | Delete a checkpoint. |
+| `POST` | `/v1/checkpoint/{id}/restore` | Restore from a checkpoint. |
+| `GET` | `/v1/companion/ws` | Native companion app WebSocket. |
+| `GET` | `/v1/platform/ws` | Legacy companion WebSocket alias. |
 
 ## Port 11434 — Ollama-Compatible API
 

--- a/internal/app/adapters.go
+++ b/internal/app/adapters.go
@@ -882,6 +882,7 @@ type systemStatusAdapter struct {
 	modelRuntime  *fleet.Runtime
 	router        *router.Router
 	capSurface    func() []toolcatalog.CapabilitySurface
+	definitions   func() *looppkg.DefinitionRegistryView
 }
 
 // Health returns the health state of all watched services.
@@ -936,6 +937,15 @@ func (a *systemStatusAdapter) AnthropicRateLimitSnapshot() *fleet.AnthropicRateL
 		return nil
 	}
 	return a.modelRuntime.AnthropicRateLimitSnapshot()
+}
+
+// LoopDefinitions returns the effective durable loop-definition view,
+// including live runtime state when the loop-definition runtime is enabled.
+func (a *systemStatusAdapter) LoopDefinitions() *looppkg.DefinitionRegistryView {
+	if a.definitions == nil {
+		return nil
+	}
+	return a.definitions()
 }
 
 // CapabilityCatalog returns the runtime capability catalog used by the

--- a/internal/app/new_servers.go
+++ b/internal/app/new_servers.go
@@ -49,6 +49,7 @@ func (a *App) initServers(s *newState) error {
 	)
 	server.SetMemoryStore(a.mem)
 	server.SetArchiveStore(a.archiveStore)
+	server.UseContactStore(a.contactStore)
 	server.UseLoopDefinitionRegistry(a.loopDefinitionRegistry)
 	server.ConfigureLoopDefinitionView(a.loopDefinitionView)
 	server.ConfigureLoopDefinitionPersistence(a.persistLoopDefinition, a.deletePersistedLoopDefinition)
@@ -524,6 +525,7 @@ func (a *App) initServers(s *newState) error {
 				modelRuntime:  a.modelRuntime,
 				router:        a.rtr,
 				capSurface:    a.capSurfaceGetter(),
+				definitions:   a.loopDefinitionView,
 			},
 			Logger: logger,
 		}

--- a/internal/server/api/contacts.go
+++ b/internal/server/api/contacts.go
@@ -1,0 +1,365 @@
+package api
+
+import (
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/google/uuid"
+	sqlite3 "github.com/mattn/go-sqlite3"
+	"github.com/nugget/thane-ai-agent/internal/state/contacts"
+)
+
+const (
+	defaultContactsAPILimit = 100
+	maxContactsAPILimit     = 500
+)
+
+type contactsListResponse struct {
+	Status   string              `json:"status"`
+	Count    int                 `json:"count"`
+	Contacts []*contacts.Contact `json:"contacts"`
+}
+
+type contactResponse struct {
+	Status  string            `json:"status"`
+	Contact *contacts.Contact `json:"contact"`
+}
+
+type contactDeleteResponse struct {
+	Status string `json:"status"`
+	ID     string `json:"id"`
+}
+
+func (s *Server) handleContactsList(w http.ResponseWriter, r *http.Request) {
+	if s.contactStore == nil {
+		s.errorResponse(w, http.StatusServiceUnavailable, "contact store not configured")
+		return
+	}
+
+	query := strings.TrimSpace(r.URL.Query().Get("query"))
+	kind := strings.ToLower(strings.TrimSpace(r.URL.Query().Get("kind")))
+	trustZone := strings.ToLower(strings.TrimSpace(r.URL.Query().Get("trust_zone")))
+	property := strings.ToUpper(strings.TrimSpace(r.URL.Query().Get("property")))
+	value := strings.TrimSpace(r.URL.Query().Get("value"))
+	exact := strings.EqualFold(strings.TrimSpace(r.URL.Query().Get("exact")), "true")
+	limit, ok := parseContactsLimit(r)
+	if !ok {
+		s.errorResponse(w, http.StatusBadRequest, "limit must be a positive integer")
+		return
+	}
+
+	var (
+		list []*contacts.Contact
+		err  error
+	)
+	switch {
+	case property != "":
+		if value == "" {
+			s.errorResponse(w, http.StatusBadRequest, "value is required when property is set")
+			return
+		}
+		if exact {
+			list, err = s.contactStore.FindByPropertyExact(property, value)
+		} else {
+			list, err = s.contactStore.FindByProperty(property, value)
+		}
+	case query != "":
+		list, err = s.contactStore.Search(query)
+	case kind != "":
+		if !contacts.ValidKinds[kind] {
+			s.errorResponse(w, http.StatusBadRequest, fmt.Sprintf("invalid kind %q", kind))
+			return
+		}
+		list, err = s.contactStore.ListByKind(kind)
+	case trustZone != "":
+		if !contacts.ValidTrustZones[trustZone] {
+			s.errorResponse(w, http.StatusBadRequest, fmt.Sprintf("invalid trust zone %q", trustZone))
+			return
+		}
+		list, err = s.contactStore.FindByTrustZoneLimit(trustZone, limit)
+	default:
+		list, err = s.contactStore.ListAllLimit(limit)
+	}
+	if err != nil {
+		s.logger.Error("list contacts failed", "error", err)
+		s.errorResponse(w, http.StatusInternalServerError, "failed to list contacts")
+		return
+	}
+
+	if len(list) > limit {
+		list = list[:limit]
+	}
+	if err := s.hydrateContactProperties(list); err != nil {
+		s.logger.Error("hydrate contacts failed", "error", err)
+		s.errorResponse(w, http.StatusInternalServerError, "failed to load contact properties")
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	writeJSON(w, contactsListResponse{
+		Status:   "ok",
+		Count:    len(list),
+		Contacts: list,
+	}, s.logger)
+}
+
+func (s *Server) handleContactGet(w http.ResponseWriter, r *http.Request) {
+	if s.contactStore == nil {
+		s.errorResponse(w, http.StatusServiceUnavailable, "contact store not configured")
+		return
+	}
+	id, ok := parseContactID(s, w, r)
+	if !ok {
+		return
+	}
+
+	c, err := s.contactStore.GetWithProperties(id)
+	if err != nil {
+		s.writeContactStoreError(w, err, "failed to load contact")
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	writeJSON(w, contactResponse{Status: "ok", Contact: c}, s.logger)
+}
+
+func (s *Server) handleContactCreate(w http.ResponseWriter, r *http.Request) {
+	if s.contactStore == nil {
+		s.errorResponse(w, http.StatusServiceUnavailable, "contact store not configured")
+		return
+	}
+	c, props, ok := decodeAPIContact(s, w, r, uuid.Nil)
+	if !ok {
+		return
+	}
+	c.ID = uuid.Nil
+
+	saved, err := s.contactStore.UpsertWithProperties(c, props)
+	if err != nil {
+		s.writeContactStoreError(w, err, "failed to create contact")
+		return
+	}
+	final, err := s.contactStore.GetWithProperties(saved.ID)
+	if err != nil {
+		s.writeContactStoreError(w, err, "failed to load created contact")
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusCreated)
+	writeJSON(w, contactResponse{Status: "ok", Contact: final}, s.logger)
+}
+
+func (s *Server) handleContactUpdate(w http.ResponseWriter, r *http.Request) {
+	if s.contactStore == nil {
+		s.errorResponse(w, http.StatusServiceUnavailable, "contact store not configured")
+		return
+	}
+	id, ok := parseContactID(s, w, r)
+	if !ok {
+		return
+	}
+	c, props, ok := decodeAPIContact(s, w, r, id)
+	if !ok {
+		return
+	}
+	c.ID = id
+
+	saved, err := s.contactStore.UpsertWithProperties(c, props)
+	if err != nil {
+		s.writeContactStoreError(w, err, "failed to update contact")
+		return
+	}
+	final, err := s.contactStore.GetWithProperties(saved.ID)
+	if err != nil {
+		s.writeContactStoreError(w, err, "failed to load updated contact")
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	writeJSON(w, contactResponse{Status: "ok", Contact: final}, s.logger)
+}
+
+func (s *Server) handleContactDelete(w http.ResponseWriter, r *http.Request) {
+	if s.contactStore == nil {
+		s.errorResponse(w, http.StatusServiceUnavailable, "contact store not configured")
+		return
+	}
+	id, ok := parseContactID(s, w, r)
+	if !ok {
+		return
+	}
+	if _, err := s.contactStore.Get(id); err != nil {
+		s.writeContactStoreError(w, err, "failed to load contact")
+		return
+	}
+	if err := s.contactStore.Delete(id); err != nil {
+		s.writeContactStoreError(w, err, "failed to delete contact")
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	writeJSON(w, contactDeleteResponse{Status: "ok", ID: id.String()}, s.logger)
+}
+
+func parseContactID(s *Server, w http.ResponseWriter, r *http.Request) (uuid.UUID, bool) {
+	raw := strings.TrimSpace(r.PathValue("id"))
+	if raw == "" {
+		s.errorResponse(w, http.StatusBadRequest, "contact id is required")
+		return uuid.Nil, false
+	}
+	id, err := uuid.Parse(raw)
+	if err != nil {
+		s.errorResponse(w, http.StatusBadRequest, "contact id must be a UUID")
+		return uuid.Nil, false
+	}
+	return id, true
+}
+
+func parseContactsLimit(r *http.Request) (int, bool) {
+	raw := strings.TrimSpace(r.URL.Query().Get("limit"))
+	if raw == "" {
+		return defaultContactsAPILimit, true
+	}
+	limit, err := strconv.Atoi(raw)
+	if err != nil || limit <= 0 {
+		return 0, false
+	}
+	if limit > maxContactsAPILimit {
+		limit = maxContactsAPILimit
+	}
+	return limit, true
+}
+
+func decodeAPIContact(s *Server, w http.ResponseWriter, r *http.Request, id uuid.UUID) (*contacts.Contact, []contacts.Property, bool) {
+	var c contacts.Contact
+	if err := json.NewDecoder(r.Body).Decode(&c); err != nil {
+		s.errorResponse(w, http.StatusBadRequest, "invalid JSON")
+		return nil, nil, false
+	}
+	if id != uuid.Nil && c.ID != uuid.Nil && c.ID != id {
+		s.errorResponse(w, http.StatusBadRequest, "body id must match path id")
+		return nil, nil, false
+	}
+	normalizeAPIContact(&c)
+	if c.FormattedName == "" {
+		s.errorResponse(w, http.StatusBadRequest, "formatted_name is required")
+		return nil, nil, false
+	}
+	props, err := normalizeAPIContactProperties(c.Properties)
+	if err != nil {
+		s.errorResponse(w, http.StatusBadRequest, err.Error())
+		return nil, nil, false
+	}
+	c.Properties = nil
+	return &c, props, true
+}
+
+func normalizeAPIContact(c *contacts.Contact) {
+	if c == nil {
+		return
+	}
+	c.Kind = strings.ToLower(strings.TrimSpace(c.Kind))
+	c.FormattedName = strings.TrimSpace(c.FormattedName)
+	c.FamilyName = strings.TrimSpace(c.FamilyName)
+	c.GivenName = strings.TrimSpace(c.GivenName)
+	c.AdditionalNames = strings.TrimSpace(c.AdditionalNames)
+	c.NamePrefix = strings.TrimSpace(c.NamePrefix)
+	c.NameSuffix = strings.TrimSpace(c.NameSuffix)
+	c.Nickname = strings.TrimSpace(c.Nickname)
+	c.Birthday = strings.TrimSpace(c.Birthday)
+	c.Anniversary = strings.TrimSpace(c.Anniversary)
+	c.Gender = strings.TrimSpace(c.Gender)
+	c.Org = strings.TrimSpace(c.Org)
+	c.Title = strings.TrimSpace(c.Title)
+	c.Role = strings.TrimSpace(c.Role)
+	c.Note = strings.TrimSpace(c.Note)
+	c.PhotoURI = strings.TrimSpace(c.PhotoURI)
+	c.TrustZone = strings.ToLower(strings.TrimSpace(c.TrustZone))
+	c.AISummary = strings.TrimSpace(c.AISummary)
+}
+
+func normalizeAPIContactProperties(props []contacts.Property) ([]contacts.Property, error) {
+	out := make([]contacts.Property, 0, len(props))
+	for i, prop := range props {
+		prop.Property = strings.ToUpper(strings.TrimSpace(prop.Property))
+		prop.Value = strings.TrimSpace(prop.Value)
+		prop.Type = strings.TrimSpace(prop.Type)
+		prop.Label = strings.TrimSpace(prop.Label)
+		prop.MediaType = strings.TrimSpace(prop.MediaType)
+		if prop.Property == "" {
+			return nil, fmt.Errorf("properties[%d].property is required", i)
+		}
+		if prop.Value == "" {
+			return nil, fmt.Errorf("properties[%d].value is required", i)
+		}
+		out = append(out, prop)
+	}
+	return out, nil
+}
+
+func (s *Server) hydrateContactProperties(list []*contacts.Contact) error {
+	ids := make([]uuid.UUID, 0, len(list))
+	for _, c := range list {
+		if c == nil {
+			continue
+		}
+		ids = append(ids, c.ID)
+	}
+	propsByContact, err := s.contactStore.GetPropertiesForContacts(ids)
+	if err != nil {
+		return fmt.Errorf("get contact properties: %w", err)
+	}
+	for _, c := range list {
+		if c == nil {
+			continue
+		}
+		c.Properties = propsByContact[c.ID]
+	}
+	return nil
+}
+
+func (s *Server) writeContactStoreError(w http.ResponseWriter, err error, fallback string) {
+	lower := strings.ToLower(err.Error())
+	switch {
+	case errors.Is(err, sql.ErrNoRows):
+		s.errorResponse(w, http.StatusNotFound, "contact not found")
+	case isSQLiteConstraint(err):
+		s.errorResponse(w, http.StatusConflict, contactConstraintMessage(err))
+	case strings.Contains(lower, "not found"):
+		s.errorResponse(w, http.StatusNotFound, "contact not found")
+	case strings.Contains(err.Error(), "invalid kind"), strings.Contains(err.Error(), "invalid trust zone"):
+		s.errorResponse(w, http.StatusBadRequest, err.Error())
+	default:
+		s.logger.Error("contact store operation failed", "error", err)
+		s.errorResponse(w, http.StatusInternalServerError, fallback)
+	}
+}
+
+func isSQLiteConstraint(err error) bool {
+	var sqliteErr sqlite3.Error
+	if errors.As(err, &sqliteErr) && sqliteErr.Code == sqlite3.ErrConstraint {
+		return true
+	}
+	lower := strings.ToLower(err.Error())
+	return strings.Contains(lower, "constraint") || strings.Contains(lower, "unique")
+}
+
+func contactConstraintMessage(err error) string {
+	var sqliteErr sqlite3.Error
+	if errors.As(err, &sqliteErr) {
+		if sqliteErr.ExtendedCode == sqlite3.ErrConstraintUnique {
+			return "formatted_name must be unique"
+		}
+	}
+	lower := strings.ToLower(err.Error())
+	if strings.Contains(lower, "idx_contacts_fn_active") || strings.Contains(lower, "unique") {
+		return "formatted_name must be unique"
+	}
+	return "contact violates a database constraint"
+}

--- a/internal/server/api/server.go
+++ b/internal/server/api/server.go
@@ -24,6 +24,7 @@ import (
 	"github.com/nugget/thane-ai-agent/internal/platform/usage"
 	"github.com/nugget/thane-ai-agent/internal/runtime/agent"
 	looppkg "github.com/nugget/thane-ai-agent/internal/runtime/loop"
+	"github.com/nugget/thane-ai-agent/internal/state/contacts"
 	"github.com/nugget/thane-ai-agent/internal/state/memory"
 )
 
@@ -78,6 +79,7 @@ type Server struct {
 	webServer                          WebServerRegistrar
 	companionHandler                   http.Handler
 	modelRegistry                      *fleet.Registry
+	contactStore                       *contacts.Store
 	loopDefinitionRegistry             *looppkg.DefinitionRegistry
 	loopDefinitionView                 func() *looppkg.DefinitionRegistryView
 	usageStore                         *usage.Store
@@ -136,6 +138,11 @@ func (s *Server) SetWebServer(ws WebServerRegistrar) {
 // companion app connections.
 func (s *Server) SetCompanionHandler(h http.Handler) {
 	s.companionHandler = h
+}
+
+// UseContactStore configures the native contact-directory API.
+func (s *Server) UseContactStore(store *contacts.Store) {
+	s.contactStore = store
 }
 
 // UseLoopDefinitionRegistry configures the persistent loops-ng definition
@@ -431,6 +438,13 @@ func (s *Server) Start(ctx context.Context) error {
 	mux.HandleFunc("DELETE /v1/model-registry/policy", s.handleModelRegistryPolicyDelete)
 	mux.HandleFunc("POST /v1/model-registry/resource-policy", s.handleModelRegistryResourcePolicySet)
 	mux.HandleFunc("DELETE /v1/model-registry/resource-policy", s.handleModelRegistryResourcePolicyDelete)
+
+	// Contact directory endpoints
+	mux.HandleFunc("GET /v1/contacts", s.handleContactsList)
+	mux.HandleFunc("GET /v1/contacts/{id}", s.handleContactGet)
+	mux.HandleFunc("POST /v1/contacts", s.handleContactCreate)
+	mux.HandleFunc("PUT /v1/contacts/{id}", s.handleContactUpdate)
+	mux.HandleFunc("DELETE /v1/contacts/{id}", s.handleContactDelete)
 
 	// Loop definition registry endpoints
 	mux.HandleFunc("GET /v1/loop-definitions", s.handleLoopDefinitions)

--- a/internal/server/api/server_test.go
+++ b/internal/server/api/server_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/nugget/thane-ai-agent/internal/platform/usage"
 	"github.com/nugget/thane-ai-agent/internal/runtime/agent"
 	looppkg "github.com/nugget/thane-ai-agent/internal/runtime/loop"
+	"github.com/nugget/thane-ai-agent/internal/state/contacts"
 )
 
 func testAPILogger() *slog.Logger {
@@ -104,6 +105,17 @@ func testAPILoopDefinitionRegistry(t *testing.T) *looppkg.DefinitionRegistry {
 		t.Fatalf("NewDefinitionRegistry: %v", err)
 	}
 	return registry
+}
+
+func testAPIContactStore(t *testing.T) *contacts.Store {
+	t.Helper()
+
+	store, err := contacts.NewStore(t.TempDir()+"/contacts.db", testAPILogger())
+	if err != nil {
+		t.Fatalf("contacts.NewStore: %v", err)
+	}
+	t.Cleanup(func() { store.Close() })
+	return store
 }
 
 func TestSimpleChatRequest_Parsing(t *testing.T) {
@@ -927,6 +939,236 @@ func TestHandleModelRegistryResourcePolicySet_PersistenceFailure(t *testing.T) {
 	}
 	if res.snapshot.PolicySource != fleet.DeploymentPolicySourceDefault {
 		t.Fatalf("PolicySource = %q, want %q after persistence failure", res.snapshot.PolicySource, fleet.DeploymentPolicySourceDefault)
+	}
+}
+
+func TestHandleContactsCreateListGetUpdateDelete(t *testing.T) {
+	store := testAPIContactStore(t)
+	server := NewServer("", 0, nil, nil, nil, nil, nil, nil, nil, nil, nil, testAPILogger())
+	server.UseContactStore(store)
+
+	createBody := bytes.NewBufferString(`{
+		"formatted_name":"Alice Smith",
+		"kind":"individual",
+		"trust_zone":"trusted",
+		"properties":[
+			{"property":"email","value":"alice@example.com","type":"home","verified":true},
+			{"property":"tel","value":"+15551234567","type":"cell"}
+		]
+	}`)
+	createReq := httptest.NewRequest(http.MethodPost, "/v1/contacts", createBody)
+	createRec := httptest.NewRecorder()
+	server.handleContactCreate(createRec, createReq)
+
+	if createRec.Code != http.StatusCreated {
+		t.Fatalf("create status = %d, want 201; body=%s", createRec.Code, createRec.Body.String())
+	}
+
+	var created contactResponse
+	if err := json.NewDecoder(createRec.Body).Decode(&created); err != nil {
+		t.Fatalf("decode create response: %v", err)
+	}
+	if created.Contact == nil || created.Contact.ID.String() == "" {
+		t.Fatalf("created contact = %#v, want populated id", created.Contact)
+	}
+	if created.Contact.FormattedName != "Alice Smith" {
+		t.Fatalf("FormattedName = %q, want Alice Smith", created.Contact.FormattedName)
+	}
+	if len(created.Contact.Properties) != 2 {
+		t.Fatalf("properties len = %d, want 2", len(created.Contact.Properties))
+	}
+	if created.Contact.Properties[0].Property != "EMAIL" || !created.Contact.Properties[0].Verified {
+		t.Fatalf("first property = %+v, want verified EMAIL", created.Contact.Properties[0])
+	}
+
+	listReq := httptest.NewRequest(http.MethodGet, "/v1/contacts?query=Alice", nil)
+	listRec := httptest.NewRecorder()
+	server.handleContactsList(listRec, listReq)
+
+	if listRec.Code != http.StatusOK {
+		t.Fatalf("list status = %d, want 200", listRec.Code)
+	}
+	var listResp contactsListResponse
+	if err := json.NewDecoder(listRec.Body).Decode(&listResp); err != nil {
+		t.Fatalf("decode list response: %v", err)
+	}
+	if listResp.Count != 1 || listResp.Contacts[0].FormattedName != "Alice Smith" {
+		t.Fatalf("list response = %#v, want Alice Smith", listResp)
+	}
+	if len(listResp.Contacts[0].Properties) != 2 {
+		t.Fatalf("list properties len = %d, want 2", len(listResp.Contacts[0].Properties))
+	}
+
+	getReq := httptest.NewRequest(http.MethodGet, "/v1/contacts/"+created.Contact.ID.String(), nil)
+	getReq.SetPathValue("id", created.Contact.ID.String())
+	getRec := httptest.NewRecorder()
+	server.handleContactGet(getRec, getReq)
+
+	if getRec.Code != http.StatusOK {
+		t.Fatalf("get status = %d, want 200", getRec.Code)
+	}
+
+	updateBody := bytes.NewBufferString(`{
+		"formatted_name":"Alice Jones",
+		"kind":"individual",
+		"trust_zone":"household",
+		"properties":[{"property":"email","value":"alice@home.example","type":"work"}]
+	}`)
+	updateReq := httptest.NewRequest(http.MethodPut, "/v1/contacts/"+created.Contact.ID.String(), updateBody)
+	updateReq.SetPathValue("id", created.Contact.ID.String())
+	updateRec := httptest.NewRecorder()
+	server.handleContactUpdate(updateRec, updateReq)
+
+	if updateRec.Code != http.StatusOK {
+		t.Fatalf("update status = %d, want 200; body=%s", updateRec.Code, updateRec.Body.String())
+	}
+	var updated contactResponse
+	if err := json.NewDecoder(updateRec.Body).Decode(&updated); err != nil {
+		t.Fatalf("decode update response: %v", err)
+	}
+	if updated.Contact.FormattedName != "Alice Jones" || updated.Contact.TrustZone != contacts.ZoneHousehold {
+		t.Fatalf("updated contact = %+v, want Alice Jones household", updated.Contact)
+	}
+	if len(updated.Contact.Properties) != 1 || updated.Contact.Properties[0].Value != "alice@home.example" {
+		t.Fatalf("updated properties = %+v, want replacement email", updated.Contact.Properties)
+	}
+
+	deleteReq := httptest.NewRequest(http.MethodDelete, "/v1/contacts/"+created.Contact.ID.String(), nil)
+	deleteReq.SetPathValue("id", created.Contact.ID.String())
+	deleteRec := httptest.NewRecorder()
+	server.handleContactDelete(deleteRec, deleteReq)
+
+	if deleteRec.Code != http.StatusOK {
+		t.Fatalf("delete status = %d, want 200", deleteRec.Code)
+	}
+
+	getDeletedReq := httptest.NewRequest(http.MethodGet, "/v1/contacts/"+created.Contact.ID.String(), nil)
+	getDeletedReq.SetPathValue("id", created.Contact.ID.String())
+	getDeletedRec := httptest.NewRecorder()
+	server.handleContactGet(getDeletedRec, getDeletedReq)
+	if getDeletedRec.Code != http.StatusNotFound {
+		t.Fatalf("deleted get status = %d, want 404", getDeletedRec.Code)
+	}
+}
+
+func TestHandleContactsListFilters(t *testing.T) {
+	store := testAPIContactStore(t)
+	server := NewServer("", 0, nil, nil, nil, nil, nil, nil, nil, nil, nil, testAPILogger())
+	server.UseContactStore(store)
+
+	alice, err := store.UpsertWithProperties(&contacts.Contact{
+		FormattedName: "Alice Smith",
+		Kind:          "individual",
+		TrustZone:     contacts.ZoneTrusted,
+	}, []contacts.Property{{Property: "EMAIL", Value: "alice@example.com"}})
+	if err != nil {
+		t.Fatalf("upsert Alice: %v", err)
+	}
+	if _, err := store.UpsertWithProperties(&contacts.Contact{
+		FormattedName: "Acme Org",
+		Kind:          "org",
+		TrustZone:     contacts.ZoneKnown,
+	}, []contacts.Property{{Property: "EMAIL", Value: "ops@acme.example"}}); err != nil {
+		t.Fatalf("upsert Acme: %v", err)
+	}
+
+	tests := []struct {
+		name      string
+		target    string
+		wantCount int
+		wantName  string
+	}{
+		{name: "kind", target: "/v1/contacts?kind=org", wantCount: 1, wantName: "Acme Org"},
+		{name: "trust zone", target: "/v1/contacts?trust_zone=trusted", wantCount: 1, wantName: alice.FormattedName},
+		{name: "property exact", target: "/v1/contacts?property=email&value=alice@example.com&exact=true", wantCount: 1, wantName: alice.FormattedName},
+		{name: "limit", target: "/v1/contacts?limit=1", wantCount: 1, wantName: "Acme Org"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, tt.target, nil)
+			rec := httptest.NewRecorder()
+			server.handleContactsList(rec, req)
+
+			if rec.Code != http.StatusOK {
+				t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+			}
+			var resp contactsListResponse
+			if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+				t.Fatalf("decode response: %v", err)
+			}
+			if resp.Count != tt.wantCount {
+				t.Fatalf("Count = %d, want %d", resp.Count, tt.wantCount)
+			}
+			if resp.Contacts[0].FormattedName != tt.wantName {
+				t.Fatalf("contact = %q, want %q", resp.Contacts[0].FormattedName, tt.wantName)
+			}
+			if len(resp.Contacts[0].Properties) == 0 {
+				t.Fatalf("contact properties are empty, want hydrated properties")
+			}
+		})
+	}
+}
+
+func TestHandleContactsValidationErrors(t *testing.T) {
+	store := testAPIContactStore(t)
+	server := NewServer("", 0, nil, nil, nil, nil, nil, nil, nil, nil, nil, testAPILogger())
+	server.UseContactStore(store)
+
+	createReq := httptest.NewRequest(http.MethodPost, "/v1/contacts", bytes.NewBufferString(`{"kind":"individual"}`))
+	createRec := httptest.NewRecorder()
+	server.handleContactCreate(createRec, createReq)
+	if createRec.Code != http.StatusBadRequest {
+		t.Fatalf("missing name status = %d, want 400", createRec.Code)
+	}
+
+	getReq := httptest.NewRequest(http.MethodGet, "/v1/contacts/not-a-uuid", nil)
+	getReq.SetPathValue("id", "not-a-uuid")
+	getRec := httptest.NewRecorder()
+	server.handleContactGet(getRec, getReq)
+	if getRec.Code != http.StatusBadRequest {
+		t.Fatalf("bad id status = %d, want 400", getRec.Code)
+	}
+
+	listReq := httptest.NewRequest(http.MethodGet, "/v1/contacts?kind=bogus", nil)
+	listRec := httptest.NewRecorder()
+	server.handleContactsList(listRec, listReq)
+	if listRec.Code != http.StatusBadRequest {
+		t.Fatalf("bad kind status = %d, want 400", listRec.Code)
+	}
+
+	if _, err := store.Upsert(&contacts.Contact{
+		FormattedName: "Duplicate Name",
+		Kind:          "individual",
+	}); err != nil {
+		t.Fatalf("seed duplicate contact: %v", err)
+	}
+	dupReq := httptest.NewRequest(http.MethodPost, "/v1/contacts", bytes.NewBufferString(`{
+		"formatted_name":"duplicate name",
+		"kind":"individual"
+	}`))
+	dupRec := httptest.NewRecorder()
+	server.handleContactCreate(dupRec, dupReq)
+	if dupRec.Code != http.StatusConflict {
+		t.Fatalf("duplicate status = %d, want 409", dupRec.Code)
+	}
+	var dupBody map[string]map[string]any
+	if err := json.NewDecoder(dupRec.Body).Decode(&dupBody); err != nil {
+		t.Fatalf("decode duplicate response: %v", err)
+	}
+	if got := dupBody["error"]["message"]; got != "formatted_name must be unique" {
+		t.Fatalf("duplicate message = %v, want stable uniqueness message", got)
+	}
+}
+
+func TestHandleContactsUnavailable(t *testing.T) {
+	server := NewServer("", 0, nil, nil, nil, nil, nil, nil, nil, nil, nil, testAPILogger())
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/contacts", nil)
+	rec := httptest.NewRecorder()
+	server.handleContactsList(rec, req)
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503", rec.Code)
 	}
 }
 

--- a/internal/server/web/handlers.go
+++ b/internal/server/web/handlers.go
@@ -48,10 +48,28 @@ func (s *WebServer) handleSystem(w http.ResponseWriter, r *http.Request) {
 	if snapshot := s.systemStatus.AnthropicRateLimitSnapshot(); snapshot != nil {
 		body["anthropic_rate_limit"] = snapshot
 	}
+	if definitions := s.systemStatus.LoopDefinitions(); definitions != nil {
+		body["loop_definitions"] = definitions
+	}
 	if catalog := s.systemStatus.CapabilityCatalog(toolcatalog.CatalogViewOptions{IncludeDelegate: true}); catalog != nil {
 		body["capability_catalog"] = catalog
 	}
 	s.writeJSON(w, body)
+}
+
+// handleLoopDefinitions returns the current effective durable
+// loop-definition registry view for dashboard clients.
+func (s *WebServer) handleLoopDefinitions(w http.ResponseWriter, _ *http.Request) {
+	if s.systemStatus == nil {
+		s.writeJSONError(w, "loop definitions unavailable", http.StatusServiceUnavailable)
+		return
+	}
+	definitions := s.systemStatus.LoopDefinitions()
+	if definitions == nil {
+		s.writeJSONError(w, "loop definitions unavailable", http.StatusServiceUnavailable)
+		return
+	}
+	s.writeJSON(w, definitions)
 }
 
 // handleCapabilities returns the resolved capability catalog as a

--- a/internal/server/web/handlers_test.go
+++ b/internal/server/web/handlers_test.go
@@ -71,6 +71,7 @@ type stubSystemStatus struct {
 	modelRegistry *fleet.RegistrySnapshot
 	routerStats   *router.Stats
 	rateLimit     *fleet.AnthropicRateLimitSnapshot
+	definitions   *loop.DefinitionRegistryView
 	capCatalog    *toolcatalog.CapabilityCatalogView
 }
 
@@ -83,6 +84,9 @@ func (s *stubSystemStatus) ModelRegistry() *fleet.RegistrySnapshot {
 func (s *stubSystemStatus) RouterStats() *router.Stats { return s.routerStats }
 func (s *stubSystemStatus) AnthropicRateLimitSnapshot() *fleet.AnthropicRateLimitSnapshot {
 	return s.rateLimit
+}
+func (s *stubSystemStatus) LoopDefinitions() *loop.DefinitionRegistryView {
+	return s.definitions
 }
 func (s *stubSystemStatus) CapabilityCatalog(_ toolcatalog.CatalogViewOptions) *toolcatalog.CapabilityCatalogView {
 	return s.capCatalog
@@ -372,6 +376,26 @@ func TestHandleSystem_Healthy(t *testing.T) {
 				Remaining: 4999,
 			},
 		},
+		definitions: &loop.DefinitionRegistryView{
+			Generation:         7,
+			ConfigDefinitions:  1,
+			RunningDefinitions: 1,
+			ByRuntimeState:     map[string]int{"sleeping": 1},
+			Definitions: []loop.DefinitionView{
+				{
+					DefinitionSnapshot: loop.DefinitionSnapshot{
+						Name:        "metacog",
+						Source:      loop.DefinitionSourceConfig,
+						PolicyState: loop.DefinitionPolicyStateActive,
+					},
+					Runtime: loop.DefinitionRuntimeStatus{
+						Running: true,
+						LoopID:  "loop-metacog",
+						State:   loop.StateSleeping,
+					},
+				},
+			},
+		},
 		capCatalog: &toolcatalog.CapabilityCatalogView{
 			Kind: "capability_catalog",
 			ActivationTools: toolcatalog.CapabilityActionTools{
@@ -445,6 +469,16 @@ func TestHandleSystem_Healthy(t *testing.T) {
 	if rateLimit["upstream_request_id"] != "req_dashboard" {
 		t.Errorf("upstream_request_id = %v, want req_dashboard", rateLimit["upstream_request_id"])
 	}
+	definitions, ok := body["loop_definitions"].(map[string]any)
+	if !ok {
+		t.Fatal("loop_definitions field missing or not a map")
+	}
+	if definitions["generation"] != float64(7) {
+		t.Errorf("loop definition generation = %v, want 7", definitions["generation"])
+	}
+	if definitions["running_definitions"] != float64(1) {
+		t.Errorf("running_definitions = %v, want 1", definitions["running_definitions"])
+	}
 	capCatalog, ok := body["capability_catalog"].(map[string]any)
 	if !ok {
 		t.Fatal("capability_catalog field missing or not a map")
@@ -502,6 +536,81 @@ func TestHandleSystem_Nil(t *testing.T) {
 
 	if w.Code != http.StatusNotFound {
 		t.Errorf("status = %d, want 404 when SystemStatus is nil", w.Code)
+	}
+}
+
+func TestHandleLoopDefinitions_ReturnsView(t *testing.T) {
+	t.Parallel()
+
+	sys := &stubSystemStatus{
+		definitions: &loop.DefinitionRegistryView{
+			Generation:         11,
+			ConfigDefinitions:  1,
+			OverlayDefinitions: 1,
+			RunningDefinitions: 1,
+			ByPolicyState:      map[string]int{"active": 2},
+			ByRuntimeState:     map[string]int{"sleeping": 1, "not_running": 1},
+			Definitions: []loop.DefinitionView{
+				{
+					DefinitionSnapshot: loop.DefinitionSnapshot{
+						Name:        "metacog",
+						Source:      loop.DefinitionSourceConfig,
+						PolicyState: loop.DefinitionPolicyStateActive,
+					},
+					Runtime: loop.DefinitionRuntimeStatus{
+						Running: true,
+						LoopID:  "loop-metacog",
+						State:   loop.StateSleeping,
+					},
+				},
+			},
+		},
+	}
+
+	srv := NewWebServer(Config{
+		LoopRegistry: &stubRegistry{},
+		EventBus:     events.New(),
+		SystemStatus: sys,
+	})
+	mux := http.NewServeMux()
+	srv.RegisterRoutes(mux)
+
+	req := httptest.NewRequest("GET", "/api/loop-definitions", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	var view loop.DefinitionRegistryView
+	if err := json.NewDecoder(w.Body).Decode(&view); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if view.Generation != 11 || view.RunningDefinitions != 1 {
+		t.Fatalf("view = %+v, want generation 11 with one running definition", view)
+	}
+	if len(view.Definitions) != 1 || view.Definitions[0].Runtime.LoopID != "loop-metacog" {
+		t.Fatalf("definitions = %+v, want metacog runtime loop", view.Definitions)
+	}
+}
+
+func TestHandleLoopDefinitions_Unavailable(t *testing.T) {
+	t.Parallel()
+
+	srv := NewWebServer(Config{
+		LoopRegistry: &stubRegistry{},
+		EventBus:     events.New(),
+		SystemStatus: &stubSystemStatus{},
+	})
+	mux := http.NewServeMux()
+	srv.RegisterRoutes(mux)
+
+	req := httptest.NewRequest("GET", "/api/loop-definitions", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503", w.Code)
 	}
 }
 

--- a/internal/server/web/server.go
+++ b/internal/server/web/server.go
@@ -73,6 +73,9 @@ type SystemStatusProvider interface {
 	// AnthropicRateLimitSnapshot returns the latest Anthropic
 	// rate-limit snapshot, or nil when Anthropic has not been observed.
 	AnthropicRateLimitSnapshot() *fleet.AnthropicRateLimitSnapshot
+	// LoopDefinitions returns the current effective loop-definition
+	// registry view, including live runtime state when available.
+	LoopDefinitions() *loop.DefinitionRegistryView
 	// CapabilityCatalog returns the resolved runtime capability catalog
 	// rendered with the supplied options.
 	CapabilityCatalog(opts toolcatalog.CatalogViewOptions) *toolcatalog.CapabilityCatalogView
@@ -146,6 +149,7 @@ func (s *WebServer) RegisterRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("GET /api/capabilities", s.handleCapabilities)
 	mux.HandleFunc("GET /api/capabilities/{tag}", s.handleCapability)
 	mux.HandleFunc("GET /api/loops", s.handleLoops)
+	mux.HandleFunc("GET /api/loop-definitions", s.handleLoopDefinitions)
 	mux.HandleFunc("GET /api/loops/events", s.handleLoopEvents)
 	mux.HandleFunc("GET /api/loops/{id}/logs", s.handleLoopLogs)
 	mux.HandleFunc("GET /api/request-detail/_probe", s.handleRequestDetailProbe)

--- a/internal/state/contacts/store.go
+++ b/internal/state/contacts/store.go
@@ -467,8 +467,18 @@ func (s *Store) ListByKind(kind string) ([]*Contact, error) {
 
 // ListAll returns all active contacts.
 func (s *Store) ListAll() ([]*Contact, error) {
+	return s.ListAllLimit(100)
+}
+
+// ListAllLimit returns up to limit active contacts. Values less than
+// one use the same 100-contact cap as [Store.ListAll].
+func (s *Store) ListAllLimit(limit int) ([]*Contact, error) {
+	if limit <= 0 {
+		limit = 100
+	}
 	rows, err := s.db.Query(
-		`SELECT ` + contactColumns + ` FROM contacts WHERE ` + activeFilter + ` ORDER BY formatted_name LIMIT 100`)
+		`SELECT `+contactColumns+` FROM contacts WHERE `+activeFilter+` ORDER BY formatted_name LIMIT ?`,
+		limit)
 	if err != nil {
 		return nil, fmt.Errorf("query: %w", err)
 	}
@@ -656,10 +666,10 @@ func (s *Store) UpsertWithProperties(c *Contact, props []Property) (*Contact, er
 		propNow := now.Format(time.RFC3339)
 		if _, err := tx.Exec(`
 			INSERT INTO contact_properties (contact_id, property, value, type, pref, label, mediatype, verified, created_at, updated_at)
-			VALUES (?, ?, ?, ?, ?, ?, ?, 0, ?, ?)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		`, c.ID.String(), p.Property, p.Value,
 			nullStr(p.Type), nullInt(p.Pref), nullStr(p.Label), nullStr(p.MediaType),
-			propNow, propNow); err != nil {
+			boolToInt(p.Verified), propNow, propNow); err != nil {
 			return nil, fmt.Errorf("add property %s: %w", p.Property, err)
 		}
 	}
@@ -794,6 +804,42 @@ func (s *Store) GetProperties(contactID uuid.UUID) ([]Property, error) {
 	return props, rows.Err()
 }
 
+// GetPropertiesForContacts returns all properties for the supplied
+// contact IDs, grouped by contact ID.
+func (s *Store) GetPropertiesForContacts(contactIDs []uuid.UUID) (map[uuid.UUID][]Property, error) {
+	result := make(map[uuid.UUID][]Property, len(contactIDs))
+	if len(contactIDs) == 0 {
+		return result, nil
+	}
+
+	placeholders := strings.TrimRight(strings.Repeat("?,", len(contactIDs)), ",")
+	args := make([]any, len(contactIDs))
+	for i, id := range contactIDs {
+		result[id] = nil
+		args[i] = id.String()
+	}
+
+	rows, err := s.db.Query(`
+		SELECT id, contact_id, property, value, type, pref, label, mediatype, verified, created_at, updated_at
+		FROM contact_properties
+		WHERE contact_id IN (`+placeholders+`)
+		ORDER BY contact_id, property, pref NULLS LAST, id
+	`, args...)
+	if err != nil {
+		return nil, fmt.Errorf("query: %w", err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		p, err := scanProperty(rows)
+		if err != nil {
+			return nil, err
+		}
+		result[p.ContactID] = append(result[p.ContactID], p)
+	}
+	return result, rows.Err()
+}
+
 // GetPropertiesMap returns all properties for a contact grouped by
 // property name as a map of name→values. This is a convenience view
 // for callers that don't need the full Property metadata.
@@ -890,6 +936,23 @@ func (s *Store) FindByTrustZone(zone string) ([]*Contact, error) {
 	rows, err := s.db.Query(
 		`SELECT `+contactColumns+` FROM contacts WHERE `+activeFilter+` AND trust_zone = ? ORDER BY formatted_name`,
 		zone)
+	if err != nil {
+		return nil, fmt.Errorf("query: %w", err)
+	}
+	defer rows.Close()
+
+	return s.scanContacts(rows)
+}
+
+// FindByTrustZoneLimit returns up to limit active contacts in the given
+// trust zone. Values less than one return all active contacts in that zone.
+func (s *Store) FindByTrustZoneLimit(zone string, limit int) ([]*Contact, error) {
+	if limit <= 0 {
+		return s.FindByTrustZone(zone)
+	}
+	rows, err := s.db.Query(
+		`SELECT `+contactColumns+` FROM contacts WHERE `+activeFilter+` AND trust_zone = ? ORDER BY formatted_name LIMIT ?`,
+		zone, limit)
 	if err != nil {
 		return nil, fmt.Errorf("query: %w", err)
 	}

--- a/internal/state/contacts/store_test.go
+++ b/internal/state/contacts/store_test.go
@@ -469,6 +469,17 @@ func TestListAll(t *testing.T) {
 	if results[0].FormattedName != "Adam" {
 		t.Errorf("first contact = %q, want %q", results[0].FormattedName, "Adam")
 	}
+
+	limited, err := store.ListAllLimit(2)
+	if err != nil {
+		t.Fatalf("ListAllLimit() error = %v", err)
+	}
+	if len(limited) != 2 {
+		t.Fatalf("ListAllLimit() returned %d, want 2", len(limited))
+	}
+	if limited[0].FormattedName != "Adam" || limited[1].FormattedName != "Mid Corp" {
+		t.Fatalf("limited contacts = %q, %q; want Adam, Mid Corp", limited[0].FormattedName, limited[1].FormattedName)
+	}
 }
 
 func TestResurrectSoftDeleted(t *testing.T) {
@@ -823,6 +834,14 @@ func TestFindByTrustZone(t *testing.T) {
 			}
 		})
 	}
+
+	limited, err := store.FindByTrustZoneLimit("trusted", 1)
+	if err != nil {
+		t.Fatalf("FindByTrustZoneLimit() error = %v", err)
+	}
+	if len(limited) != 1 || limited[0].FormattedName != "Trusted C" {
+		t.Fatalf("FindByTrustZoneLimit() = %+v, want Trusted C only", limited)
+	}
 }
 
 func TestFindByPropertyExact_HACompanionApp(t *testing.T) {
@@ -1038,6 +1057,14 @@ func TestAddProperty_GetProperties(t *testing.T) {
 	tel := props[1]
 	if tel.Property != "TEL" || tel.Value != "+15551234567" || tel.Type != "cell" {
 		t.Errorf("TEL prop = %+v", tel)
+	}
+
+	propsByContact, err := store.GetPropertiesForContacts([]uuid.UUID{created.ID})
+	if err != nil {
+		t.Fatalf("GetPropertiesForContacts() error = %v", err)
+	}
+	if got := propsByContact[created.ID]; len(got) != 2 {
+		t.Fatalf("GetPropertiesForContacts()[created] len = %d, want 2", len(got))
 	}
 }
 


### PR DESCRIPTION
## Summary
- expose loop definitions in the web API aggregate and add a direct dashboard endpoint
- add native JSON contact-directory CRUD endpoints backed by the existing contacts store
- refresh the API reference route inventory and preserve contact property verification on full-contact writes

## Why
The WebUI overhaul needs first-class API surfaces for runtime management instead of depending on CardDAV-only contact access or incomplete dashboard aggregates.

## Validation
- just ci