### PR TITLE
fix(loop): stamp own LoopID onto run context so delegates parent correctly

### DIFF
--- a/internal/runtime/loop/context.go
+++ b/internal/runtime/loop/context.go
@@ -23,9 +23,11 @@ func withFallbackContent(ctx context.Context, content string) context.Context {
 	return context.WithValue(ctx, fallbackContentKey{}, content)
 }
 
-// LoopIDFromContext extracts the originating loop ID from a handler
-// context. Returns an empty string if the context was not created by
-// a loop handler dispatch.
+// LoopIDFromContext extracts the originating loop ID from any context
+// derived from a loop's run goroutine — handler, turn builder, agent
+// runner, tool call, or delegate launch contexts all qualify. Returns
+// an empty string when called from a context that did not originate
+// inside a loop.
 func LoopIDFromContext(ctx context.Context) string {
 	if id, ok := ctx.Value(loopIDKey{}).(string); ok {
 		return id

--- a/internal/runtime/loop/context.go
+++ b/internal/runtime/loop/context.go
@@ -5,9 +5,13 @@ import "context"
 type loopIDKey struct{}
 type fallbackContentKey struct{}
 
-// withLoopID injects the loop ID into the handler context so downstream
-// code (e.g. agent loop → delegate executor) can discover which loop
-// triggered the current execution.
+// withLoopID injects the loop ID into the run context so downstream
+// code (e.g. handlers, turn builders, the agent runner, tool calls,
+// and delegate launches) can discover which loop triggered the current
+// execution. The loop's own run() applies this at the top of its
+// goroutine so the loop's identity dominates over anything inherited
+// from the spawning context — important when a loop is spawned from
+// inside another loop's handler context.
 func withLoopID(ctx context.Context, id string) context.Context {
 	return context.WithValue(ctx, loopIDKey{}, id)
 }

--- a/internal/runtime/loop/loop.go
+++ b/internal/runtime/loop/loop.go
@@ -658,6 +658,17 @@ func (l *Loop) run(ctx context.Context) {
 		"loop_name", l.config.Name,
 	)
 	ctx = logging.WithLogger(ctx, logger)
+	// Stamp this loop's ID onto the run context so every descendant
+	// context — iterCtx, handlerCtx, turnCtx, the agent runner's ctx,
+	// tool calls, and any delegates those tools launch — sees this
+	// loop as the LoopID origin rather than inheriting whatever ID
+	// the spawner's context happened to carry. Without this, a child
+	// loop spawned from a parent's handler context (where withLoopID
+	// is set to the parent's ID) silently inherits the parent's ID
+	// through every downstream context, and any delegate launched
+	// from within the child loop's run is mis-parented onto the
+	// parent loop in the topology.
+	ctx = withLoopID(ctx, l.id)
 
 	// Initial state depends on whether the loop waits for events or
 	// sleeps on a timer. WaitFunc loops enter StateWaiting immediately

--- a/internal/runtime/loop/loop_test.go
+++ b/internal/runtime/loop/loop_test.go
@@ -1193,10 +1193,9 @@ func TestRunContextHasOwnLoopID(t *testing.T) {
 		const parentID = "parent-loop-id-should-not-leak"
 
 		var (
-			mu              sync.Mutex
-			handlerLoopID   string
-			handlerInvoked  bool
-			handlerLoopName string
+			mu             sync.Mutex
+			handlerLoopID  string
+			handlerInvoked bool
 		)
 
 		l, err := New(Config{
@@ -1211,7 +1210,6 @@ func TestRunContextHasOwnLoopID(t *testing.T) {
 				mu.Lock()
 				handlerInvoked = true
 				handlerLoopID = LoopIDFromContext(ctx)
-				handlerLoopName = "run-ctx-loop-id-handler"
 				mu.Unlock()
 				return nil
 			},
@@ -1231,7 +1229,6 @@ func TestRunContextHasOwnLoopID(t *testing.T) {
 		if !handlerInvoked {
 			t.Fatalf("handler was not invoked")
 		}
-		_ = handlerLoopName
 		if handlerLoopID != l.ID() {
 			t.Errorf("Handler ctx LoopID = %q, want loop's own ID %q (parent was %q)",
 				handlerLoopID, l.ID(), parentID)

--- a/internal/runtime/loop/loop_test.go
+++ b/internal/runtime/loop/loop_test.go
@@ -1113,6 +1113,136 @@ func TestTurnBuilderNilTurnIsNoOp(t *testing.T) {
 	}
 }
 
+// TestRunContextHasOwnLoopID verifies that a loop's run context carries
+// its own ID — not whatever LoopID may have been set on the spawning
+// context. Regression guard for the topology bug where delegates
+// launched from a per-contact channel loop ended up parented onto the
+// channel-level loop because the per-contact loop's run context still
+// carried the channel loop's LoopID inherited from its Start ctx.
+func TestRunContextHasOwnLoopID(t *testing.T) {
+	t.Parallel()
+
+	t.Run("turn builder and runner see own loop id", func(t *testing.T) {
+		t.Parallel()
+
+		const parentID = "parent-loop-id-should-not-leak"
+
+		var (
+			mu                sync.Mutex
+			turnBuilderLoopID string
+			runnerLoopID      string
+		)
+
+		runner := &turnCallbackRunner{fn: func(ctx context.Context, _ RunRequest, _ StreamCallback) (*RunResponse, error) {
+			mu.Lock()
+			runnerLoopID = LoopIDFromContext(ctx)
+			mu.Unlock()
+			return &RunResponse{Content: "ok", Model: "test-model"}, nil
+		}}
+
+		l, err := New(Config{
+			Name:         "run-ctx-loop-id-turn",
+			SleepMin:     1 * time.Millisecond,
+			SleepMax:     2 * time.Millisecond,
+			SleepDefault: 1 * time.Millisecond,
+			Jitter:       Float64Ptr(0),
+			MaxIter:      1,
+			TurnBuilder: func(ctx context.Context, _ TurnInput) (*AgentTurn, error) {
+				mu.Lock()
+				turnBuilderLoopID = LoopIDFromContext(ctx)
+				mu.Unlock()
+				return &AgentTurn{
+					Request: Request{
+						Messages: []Message{{Role: "user", Content: "go"}},
+					},
+				}, nil
+			},
+		}, Deps{Runner: runner})
+		if err != nil {
+			t.Fatalf("New: %v", err)
+		}
+
+		// Start with a parent context that carries a DIFFERENT loop ID,
+		// the way ensureSenderLoop spawns a per-contact loop from the
+		// channel-level loop's handler context.
+		parentCtx := withLoopID(context.Background(), parentID)
+		if err := l.Start(parentCtx); err != nil {
+			t.Fatalf("Start: %v", err)
+		}
+		<-l.Done()
+
+		mu.Lock()
+		defer mu.Unlock()
+		if turnBuilderLoopID != l.ID() {
+			t.Errorf("TurnBuilder ctx LoopID = %q, want loop's own ID %q (parent was %q)",
+				turnBuilderLoopID, l.ID(), parentID)
+		}
+		if runnerLoopID != l.ID() {
+			t.Errorf("Runner ctx LoopID = %q, want loop's own ID %q (parent was %q)",
+				runnerLoopID, l.ID(), parentID)
+		}
+		if turnBuilderLoopID == parentID || runnerLoopID == parentID {
+			t.Errorf("parent LoopID %q leaked into loop run context — delegates would be mis-parented",
+				parentID)
+		}
+	})
+
+	t.Run("handler sees own loop id", func(t *testing.T) {
+		t.Parallel()
+
+		const parentID = "parent-loop-id-should-not-leak"
+
+		var (
+			mu              sync.Mutex
+			handlerLoopID   string
+			handlerInvoked  bool
+			handlerLoopName string
+		)
+
+		l, err := New(Config{
+			Name:         "run-ctx-loop-id-handler",
+			SleepMin:     1 * time.Millisecond,
+			SleepMax:     2 * time.Millisecond,
+			SleepDefault: 1 * time.Millisecond,
+			Jitter:       Float64Ptr(0),
+			MaxIter:      1,
+			Task:         "handler-only",
+			Handler: func(ctx context.Context, _ any) error {
+				mu.Lock()
+				handlerInvoked = true
+				handlerLoopID = LoopIDFromContext(ctx)
+				handlerLoopName = "run-ctx-loop-id-handler"
+				mu.Unlock()
+				return nil
+			},
+		}, Deps{Runner: &noopRunner{}})
+		if err != nil {
+			t.Fatalf("New: %v", err)
+		}
+
+		parentCtx := withLoopID(context.Background(), parentID)
+		if err := l.Start(parentCtx); err != nil {
+			t.Fatalf("Start: %v", err)
+		}
+		<-l.Done()
+
+		mu.Lock()
+		defer mu.Unlock()
+		if !handlerInvoked {
+			t.Fatalf("handler was not invoked")
+		}
+		_ = handlerLoopName
+		if handlerLoopID != l.ID() {
+			t.Errorf("Handler ctx LoopID = %q, want loop's own ID %q (parent was %q)",
+				handlerLoopID, l.ID(), parentID)
+		}
+		if handlerLoopID == parentID {
+			t.Errorf("parent LoopID %q leaked into handler context — delegates would be mis-parented",
+				parentID)
+		}
+	})
+}
+
 func TestPostIterate(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- Stamp `withLoopID(ctx, l.id)` at the top of `(*Loop).run()` so the loop's own ID dominates over anything inherited from the spawning context, fixing a delegate-mis-parenting topology bug introduced in `40b0ccc` (refactor: route signal wakes through turn builder, 2026-05-01).
- Add a regression test that exercises both the TurnBuilder/runner and Handler paths from a parent context that carries a sentinel LoopID, asserting the loop's own ID wins.

## What was broken

When the channel-level `signal` loop's handler dispatches to a per-contact loop via `ensureSenderLoop`, it calls `b.registry.SpawnLoop(ctx, …)` with the channel loop's handler context — which has `withLoopID(_, channelLoopID)` already injected. The per-contact loop's `run()` derived its `loopCtx` from that ctx and never overrode the LoopID at the run-context level. It only re-stamped `withLoopID` on local `handlerCtx` (loop.go:879) and `turnCtx` (loop.go:961).

The Handler path was fine — handlers are called with `handlerCtx` so descendants saw the right ID. But the TurnBuilder path builds the agent's run context via `mergeTurnRunContext(iterCtx, turn.RunContext)` — derived from `iterCtx`, not `turnCtx` — so the per-contact loop's override never reached the agent runner. The agent then read the leaked channel-loop ID via `loop.LoopIDFromContext`, propagated it into tool contexts at agent/loop.go:2156-2159, and `delegate.go:832` recorded that ID as the new delegate's `ParentID`. The topology graph drew every delegate spawned from a Signal turn under the generic `signal` node instead of the specific `signal/David McNett` node.

Observed in production logs (`loop_id 019e1d38-…`, request `r_882ce4146f90ace3`):

| loop_id | name | role |
|---|---|---|
| `019e1d36-2718-7849-…` | `signal` | channel-level handler |
| `019e1d37-48ac-77cc-…` | `signal/David McNett` | per-contact (ran the agent) |
| `019e1d38-8464-720b-…` | `delegate-019e1d38` | registered with `parent_id: 019e1d36-…` ❌ |

The parent agent's request `r_b19bb7ce8ba2b2b6` showed `loop_id = ""` on every log line — the per-contact loop's ID never made it into the agent runtime's logger/context.

## Why this is the right fix

The cleanest invariant is "a loop owns its identity on its run context, set once." Stamping the LoopID at the top of `run()` makes every descendant context — iter, handler, turn, run, tool, delegate — inherit it correctly by default. The per-handler and per-turn `withLoopID` calls inside the iteration are kept as harmless re-asserts that document intent at those boundaries; they're no-ops once the run-level stamp is in place.

## Regression test

`TestRunContextHasOwnLoopID` (loop_test.go) starts a loop from `parentCtx := withLoopID(context.Background(), "parent-loop-id-should-not-leak")` and asserts:

1. TurnBuilder ctx sees the loop's own ID
2. The Runner's ctx sees the loop's own ID (this is the assertion that fails without the fix)
3. Handler ctx sees the loop's own ID (was already correct; pinned as belt-and-suspenders)

Without the run-level stamp, the Runner-ctx assertion fails with `Runner ctx LoopID = "parent-loop-id-should-not-leak"`, matching the production symptom exactly. With the fix, both subtests pass.

## Validation

- `go test -run TestRunContextHasOwnLoopID -count=1 ./internal/runtime/loop/` — passes with fix, fails without it (verified by stash-pop on the prod files while keeping the test).
- `just ci` — clean.

## Test plan

- [x] New regression test passes
- [x] New regression test fails without the production fix (verified by stash)
- [x] `just ci` passes locally
- [ ] Production verification: after deploy, spawn a `thane_now` delegate from a Signal turn and confirm the topology graph parents it under `signal/<contact>` rather than the channel-level `signal` node