### PR TITLE
feat: declare durable output on thane_curate loops

### DIFF
--- a/internal/tools/loop_intent_tools.go
+++ b/internal/tools/loop_intent_tools.go
@@ -54,7 +54,7 @@ func (r *Registry) registerThaneCurate() {
 			"Future modes will accept a directory ref for tree-shaped collections (multiple files maintained as a structured corpus); the output parameter shape will grow additively. " +
 			"Cadence accepts \"hourly\", \"daily\", \"every 30 minutes\", \"5m\", or \"1h\". Sleep_min/max/jitter are derived automatically. " +
 			"Tags scope the loop's tools; omit to inherit the always-active set. " +
-			"Returns the document ref, loop definition name, loop_id, output mode, and the derived sleep_min/max/default cadence triple.",
+			"Returns the document ref, loop definition name, loop_id, output mode, the generated output tool name (output_tool) the receiving loop writes through, and the derived sleep_min/max/default cadence triple.",
 		ContentResolveExempt: []string{"name", "intent", "cadence", "tags", "guidance", "output", "replace"},
 		Parameters: map[string]any{
 			"type": "object",
@@ -318,7 +318,22 @@ func buildCurateTask(intent, docRef, outputMode, outputToolName, guidance string
 	sb.WriteString(docRef)
 	sb.WriteString(" with the current state. Write through the declared output tool ")
 	sb.WriteString(outputToolName)
-	sb.WriteString("; the document's current contents are surfaced in the Declared Durable Outputs context block above, so no separate read is needed.")
+	sb.WriteString(". ")
+	switch outputMode {
+	case "journal":
+		// Append-only: the recent tail in the context block is enough; the
+		// model never needs the full history to write a new entry.
+		sb.WriteString("Recent entries are surfaced in the Declared Durable Outputs context block above; no separate read is needed before appending.")
+	case "maintain":
+		// Complete-replacement: the context block shows the document head,
+		// possibly truncated at 16 KiB (see loopOutputContentBytes in
+		// app.loop_outputs). The model MUST notice the `truncated` flag and
+		// read the full document before replacing, or it will silently drop
+		// everything past the truncation boundary.
+		sb.WriteString("The current document body is shown in the Declared Durable Outputs context block above. If that entry is marked `truncated: true`, read the full document with doc_read before replacing — the output tool overwrites the entire body.")
+	default:
+		sb.WriteString("The document's current contents are surfaced in the Declared Durable Outputs context block above.")
+	}
 	if strings.TrimSpace(guidance) != "" {
 		sb.WriteString("\n\nGuidance: ")
 		sb.WriteString(guidance)

--- a/internal/tools/loop_intent_tools.go
+++ b/internal/tools/loop_intent_tools.go
@@ -179,17 +179,20 @@ func (r *Registry) handleThaneCurate(ctx context.Context, args map[string]any) (
 		}
 	}
 
+	outputSpec := buildCurateOutputSpec(name, documentRef, outputMode, intent)
+
 	jitterRatio := 0.1
 	spec := looppkg.Spec{
 		Name:         name,
 		Enabled:      true,
-		Task:         buildCurateTask(intent, documentRef, outputMode, guidance),
+		Task:         buildCurateTask(intent, documentRef, outputMode, outputSpec.ToolName(), guidance),
 		Operation:    looppkg.OperationService,
 		SleepMin:     cad.sleepMin,
 		SleepMax:     cad.sleepMax,
 		SleepDefault: cad.sleepDefault,
 		Jitter:       &jitterRatio,
 		Tags:         tags,
+		Outputs:      []looppkg.OutputSpec{outputSpec},
 		Profile: router.LoopProfile{
 			DelegationGating: "disabled",
 		},
@@ -258,6 +261,7 @@ func (r *Registry) handleThaneCurate(ctx context.Context, args map[string]any) (
 		"loop_definition_name": name,
 		"loop_id":              launchResult.LoopID,
 		"output_mode":          outputMode,
+		"output_tool":          outputSpec.ToolName(),
 		"cadence": map[string]any{
 			"input":         cadenceInput,
 			"sleep_default": cad.sleepDefault.String(),
@@ -268,12 +272,35 @@ func (r *Registry) handleThaneCurate(ctx context.Context, args map[string]any) (
 	})
 }
 
+// buildCurateOutputSpec converts the intent-shaped output argument into
+// a declared OutputSpec on the loop. Once declared, the hydration layer
+// generates a scoped mutation tool (replace_output_* / append_output_*)
+// and injects current-document context into each iteration prompt — so
+// the model gets a typed write surface and "what's already there?"
+// answered without re-reading the doc itself.
+func buildCurateOutputSpec(name, docRef, outputMode, intent string) looppkg.OutputSpec {
+	out := looppkg.OutputSpec{
+		Name:    name,
+		Ref:     docRef,
+		Purpose: intent,
+	}
+	switch outputMode {
+	case "journal":
+		out.Type = looppkg.OutputTypeJournalDocument
+		out.Mode = looppkg.OutputModeAppend
+	case "maintain":
+		out.Type = looppkg.OutputTypeMaintainedDocument
+		out.Mode = looppkg.OutputModeReplace
+	}
+	return out
+}
+
 // buildCurateTask renders the per-iteration task prompt for a
 // thane_curate-created loop. The model running each iteration sees the
-// intent, the document target, and the output mode, plus any caller
-// guidance. Kept short and shape-clear so the model can act without
-// re-reading the loop's own definition.
-func buildCurateTask(intent, docRef, outputMode, guidance string) string {
+// intent, the document target, the output mode, the scoped output tool
+// name, plus any caller guidance. Kept short and shape-clear so the
+// model can act without re-reading the loop's own definition.
+func buildCurateTask(intent, docRef, outputMode, outputToolName, guidance string) string {
 	var verb string
 	switch outputMode {
 	case "journal":
@@ -289,13 +316,9 @@ func buildCurateTask(intent, docRef, outputMode, guidance string) string {
 	sb.WriteString(verb)
 	sb.WriteString(" ")
 	sb.WriteString(docRef)
-	sb.WriteString(" with the current state. Use document mutation tools (")
-	if outputMode == "journal" {
-		sb.WriteString("doc_journal_update for the dated entry, doc_read to inspect existing entries")
-	} else {
-		sb.WriteString("doc_write to replace the body, doc_read to inspect the prior snapshot before rewriting")
-	}
-	sb.WriteString(").")
+	sb.WriteString(" with the current state. Write through the declared output tool ")
+	sb.WriteString(outputToolName)
+	sb.WriteString("; the document's current contents are surfaced in the Declared Durable Outputs context block above, so no separate read is needed.")
 	if strings.TrimSpace(guidance) != "" {
 		sb.WriteString("\n\nGuidance: ")
 		sb.WriteString(guidance)

--- a/internal/tools/loop_intent_tools_test.go
+++ b/internal/tools/loop_intent_tools_test.go
@@ -186,6 +186,9 @@ func TestThaneCurate_EndToEnd(t *testing.T) {
 	if resp["output_mode"] != "maintain" {
 		t.Errorf("output_mode = %v, want maintain", resp["output_mode"])
 	}
+	if resp["output_tool"] != "replace_output_test_pr_watchlist" {
+		t.Errorf("output_tool = %v, want replace_output_test_pr_watchlist", resp["output_tool"])
+	}
 
 	// Verify the launch fired against the right name.
 	if launchedName != "test_pr_watchlist" {
@@ -212,6 +215,37 @@ func TestThaneCurate_EndToEnd(t *testing.T) {
 	}
 	if len(found.Spec.Tags) != 1 || found.Spec.Tags[0] != "forge" {
 		t.Errorf("Tags = %v, want [forge]", found.Spec.Tags)
+	}
+
+	// Verify the declared output rides on the spec so the hydration
+	// layer can generate the scoped output tool and inject document
+	// context on each iteration.
+	if len(found.Spec.Outputs) != 1 {
+		t.Fatalf("Outputs len = %d, want 1: %+v", len(found.Spec.Outputs), found.Spec.Outputs)
+	}
+	out := found.Spec.Outputs[0]
+	if out.Name != "test_pr_watchlist" {
+		t.Errorf("Outputs[0].Name = %q, want test_pr_watchlist", out.Name)
+	}
+	if out.Type != looppkg.OutputTypeMaintainedDocument {
+		t.Errorf("Outputs[0].Type = %q, want maintained_document", out.Type)
+	}
+	if out.Mode != looppkg.OutputModeReplace {
+		t.Errorf("Outputs[0].Mode = %q, want replace", out.Mode)
+	}
+	if out.Ref != "kb:dashboards/pr-watchlist.md" {
+		t.Errorf("Outputs[0].Ref = %q, want kb:dashboards/pr-watchlist.md", out.Ref)
+	}
+	if out.Purpose == "" {
+		t.Errorf("Outputs[0].Purpose should carry the intent, got empty")
+	}
+	if got, want := out.ToolName(), "replace_output_test_pr_watchlist"; got != want {
+		t.Errorf("Outputs[0].ToolName = %q, want %q", got, want)
+	}
+	// The task prompt should point the model at the scoped tool rather
+	// than the generic doc_write / doc_journal_update pair.
+	if !strings.Contains(found.Spec.Task, "replace_output_test_pr_watchlist") {
+		t.Errorf("task prompt should reference scoped output tool, got: %s", found.Spec.Task)
 	}
 
 	// Verify the scaffold document was written with loop-ownership frontmatter.
@@ -387,5 +421,86 @@ func TestThaneCurate_RefusesToClobberDocument(t *testing.T) {
 	}
 	if !strings.Contains(doc, "Do not overwrite") {
 		t.Errorf("pre-existing document was modified despite refusal:\n%s", doc)
+	}
+}
+
+// TestThaneCurate_JournalDeclaresAppendOutput verifies that journal-mode
+// loops carry a journal_document OutputSpec with append mode, so the
+// hydration layer generates an append_output_* scoped tool instead of
+// the replace_output_* tool used by maintain-mode loops.
+func TestThaneCurate_JournalDeclaresAppendOutput(t *testing.T) {
+	t.Parallel()
+
+	tempDir := t.TempDir()
+	kbDir := filepath.Join(tempDir, "kb")
+	if err := mkdirAllForTest(kbDir); err != nil {
+		t.Fatalf("mkdir kb: %v", err)
+	}
+	db, err := database.OpenMemory()
+	if err != nil {
+		t.Fatalf("open memory db: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	docStore, err := documents.NewStore(db, map[string]string{"kb": kbDir}, nil)
+	if err != nil {
+		t.Fatalf("documents.NewStore: %v", err)
+	}
+	docTools := documents.NewTools(docStore)
+
+	defRegistry, err := looppkg.NewDefinitionRegistry(nil)
+	if err != nil {
+		t.Fatalf("NewDefinitionRegistry: %v", err)
+	}
+	reg := NewEmptyRegistry()
+	reg.ConfigureLoopIntentTools(LoopIntentToolDeps{
+		DocTools:    docTools,
+		Registry:    defRegistry,
+		PersistSpec: func(_ looppkg.Spec, _ time.Time) error { return nil },
+		Reconcile:   func(_ context.Context, _ string) error { return nil },
+		LaunchDefinition: func(_ context.Context, _ string, _ looppkg.Launch) (looppkg.LaunchResult, error) {
+			return looppkg.LaunchResult{LoopID: "loop-journal-1"}, nil
+		},
+	})
+
+	tool := reg.Get("thane_curate")
+	if _, err := tool.Handler(context.Background(), map[string]any{
+		"name":    "release_journal",
+		"intent":  "Capture forge releases as a dated log.",
+		"cadence": "hourly",
+		"output": map[string]any{
+			"mode":     "journal",
+			"document": "kb:journal/releases.md",
+		},
+	}); err != nil {
+		t.Fatalf("thane_curate handler: %v", err)
+	}
+
+	snap := defRegistry.Snapshot()
+	var found *looppkg.DefinitionSnapshot
+	for i := range snap.Definitions {
+		if snap.Definitions[i].Spec.Name == "release_journal" {
+			found = &snap.Definitions[i]
+			break
+		}
+	}
+	if found == nil {
+		t.Fatal("definition not registered")
+	}
+	if len(found.Spec.Outputs) != 1 {
+		t.Fatalf("Outputs len = %d, want 1", len(found.Spec.Outputs))
+	}
+	out := found.Spec.Outputs[0]
+	if out.Type != looppkg.OutputTypeJournalDocument {
+		t.Errorf("Type = %q, want journal_document", out.Type)
+	}
+	if out.Mode != looppkg.OutputModeAppend {
+		t.Errorf("Mode = %q, want append", out.Mode)
+	}
+	if got, want := out.ToolName(), "append_output_release_journal"; got != want {
+		t.Errorf("ToolName = %q, want %q", got, want)
+	}
+	if !strings.Contains(found.Spec.Task, "append_output_release_journal") {
+		t.Errorf("task prompt should reference scoped output tool, got: %s", found.Spec.Task)
 	}
 }

--- a/internal/tools/loop_intent_tools_test.go
+++ b/internal/tools/loop_intent_tools_test.go
@@ -247,6 +247,15 @@ func TestThaneCurate_EndToEnd(t *testing.T) {
 	if !strings.Contains(found.Spec.Task, "replace_output_test_pr_watchlist") {
 		t.Errorf("task prompt should reference scoped output tool, got: %s", found.Spec.Task)
 	}
+	// Maintain mode must warn the model about the 16 KiB head truncation
+	// applied by renderLoopOutputContext, or it will rewrite only the
+	// visible prefix and silently drop everything past the boundary.
+	if !strings.Contains(found.Spec.Task, "truncated") {
+		t.Errorf("maintain-mode task prompt must warn about truncation, got: %s", found.Spec.Task)
+	}
+	if !strings.Contains(found.Spec.Task, "doc_read") {
+		t.Errorf("maintain-mode task prompt must instruct doc_read on truncation, got: %s", found.Spec.Task)
+	}
 
 	// Verify the scaffold document was written with loop-ownership frontmatter.
 	doc, err := docTools.Read(context.Background(), documents.RefArgs{Ref: "kb:dashboards/pr-watchlist.md"})
@@ -502,5 +511,16 @@ func TestThaneCurate_JournalDeclaresAppendOutput(t *testing.T) {
 	}
 	if !strings.Contains(found.Spec.Task, "append_output_release_journal") {
 		t.Errorf("task prompt should reference scoped output tool, got: %s", found.Spec.Task)
+	}
+	// Journal mode is append-only: the recent tail in the context block
+	// is enough, so the prompt should explicitly say no separate read is
+	// needed before appending.
+	if !strings.Contains(found.Spec.Task, "no separate read") {
+		t.Errorf("journal-mode task prompt should reassure no read needed, got: %s", found.Spec.Task)
+	}
+	// Conversely, journal mode must NOT carry the maintain-mode truncation
+	// warning — appending doesn't need the full history.
+	if strings.Contains(found.Spec.Task, "truncated") {
+		t.Errorf("journal-mode task prompt should not carry maintain-mode truncation warning, got: %s", found.Spec.Task)
 	}
 }


### PR DESCRIPTION
## Summary

- `thane_curate` now populates `Spec.Outputs` with a single `OutputSpec` derived from its `output.mode` / `output.document` args, so the loop's data contract is explicit.
- The hydration layer (`app.hydrateLoopOutputs`) generates a scoped mutation tool — `replace_output_<name>` for maintain mode, `append_output_<name>` for journal mode — that writes through the document store with the right policy.
- The per-iteration task prompt references the scoped tool by name, and the `thane_curate` response JSON gains an `output_tool` field so the calling model can see what the new loop writes through.

## Why

Before this change, `thane_curate`-created loops scaffolded a managed document and wrote ownership frontmatter — but never declared the document as a `Spec.Outputs` entry. As a result:

- The loop ran without the auto-generated `replace_output_*` / `append_output_*` tool — the model had to fall back to generic `doc_write` / `doc_journal_update`, which aren't guaranteed to be in the loop's tool surface depending on tag configuration.
- The loop ran without the auto-injected "## Declared Durable Outputs" context block, so each iteration the model had to re-read the document itself to know what was already there.
- No spec-level invariant tied the loop to the document; only the task prompt and the frontmatter made the link.

This change brings `thane_curate` in line with the canonical pattern set by `metacognitive` and `ego`, which both declare a single `OutputSpec` and rely on the hydration layer to do the rest.

## Downstream value

This is the handshake that lets event-source consumers — the forge subscriptions added in [#863](https://github.com/nugget/thane-ai-agent/pull/863), the media feed `wake_loop` path, and future producers — land in a loop whose write surface is typed (the scoped output tool) and whose current-state context is auto-injected (the OutputContextBuilder). Without this, a forge release wake into a `thane_curate` journal loop still meant the receiving model had to construct a write path by hand.

Refs #377, #402.

## Test plan

- [x] `just ci` (golangci-lint clean, `go test -race ./...` green)
- [x] `TestThaneCurate_EndToEnd` now asserts the spec carries an `OutputSpec` with the right type/mode/ref/purpose and that the task prompt references the scoped tool
- [x] New `TestThaneCurate_JournalDeclaresAppendOutput` covers journal mode (`OutputTypeJournalDocument` + `OutputModeAppend` → `append_output_*`)
- [x] Existing clobber-refusal tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)