### PR TITLE
feat: attach entity subscriptions to thane_curate loops

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -46,6 +46,7 @@ import (
 	"github.com/nugget/thane-ai-agent/internal/server/api"
 	cdav "github.com/nugget/thane-ai-agent/internal/server/carddav"
 	"github.com/nugget/thane-ai-agent/internal/state/attachments"
+	"github.com/nugget/thane-ai-agent/internal/state/awareness"
 	"github.com/nugget/thane-ai-agent/internal/state/contacts"
 	"github.com/nugget/thane-ai-agent/internal/state/documents"
 	"github.com/nugget/thane-ai-agent/internal/state/knowledge"
@@ -92,6 +93,7 @@ type App struct {
 	documentStore             *documents.Store
 	documentTools             *documents.Tools
 	contactStore              *contacts.Store
+	watchlistStore            *awareness.WatchlistStore
 	opStore                   *opstate.Store
 	modelPolicyStore          *modelPolicyStore
 	modelResourcePolicyStore  *modelResourcePolicyStore

--- a/internal/app/new_awareness.go
+++ b/internal/app/new_awareness.go
@@ -2,7 +2,6 @@ package app
 
 import (
 	"context"
-	"fmt"
 	"strings"
 	"time"
 
@@ -77,11 +76,11 @@ func (a *App) initAwareness(s *newState) error {
 	// --- Entity watchlist ---
 	// Allows the agent to dynamically add HA entities to a watched list
 	// whose live state is injected into context each turn. Persisted in
-	// SQLite so the watchlist survives restarts. Shares thane.db.
-	watchlistStore, err := awareness.NewWatchlistStore(a.mem.DB(), logger)
-	if err != nil {
-		return fmt.Errorf("watchlist store: %w", err)
-	}
+	// SQLite so the watchlist survives restarts. Shares thane.db. The
+	// store itself is constructed earlier in initStores so initChannels
+	// can wire it into thane_curate; here we register the runtime
+	// context providers that surface its rows into prompts.
+	watchlistStore := a.watchlistStore
 
 	if a.ha != nil {
 		watchlistProvider := awareness.NewWatchlistProvider(watchlistStore, a.ha, logger)

--- a/internal/app/new_channels.go
+++ b/internal/app/new_channels.go
@@ -24,6 +24,7 @@ import (
 	"github.com/nugget/thane-ai-agent/internal/platform/config"
 	"github.com/nugget/thane-ai-agent/internal/platform/database"
 	"github.com/nugget/thane-ai-agent/internal/runtime/agent"
+	"github.com/nugget/thane-ai-agent/internal/state/awareness"
 	"github.com/nugget/thane-ai-agent/internal/state/contacts"
 	"github.com/nugget/thane-ai-agent/internal/state/documents"
 	"github.com/nugget/thane-ai-agent/internal/state/knowledge"
@@ -398,12 +399,27 @@ func (a *App) initChannels(s *newState) error {
 		LaunchDefinition: a.launchLoopDefinition,
 	})
 	if a.documentTools != nil {
+		// RegisterTagProvider mirrors the TagRegistrar callback wired into
+		// awareness.WatchlistTools (see initAwareness): when thane_curate
+		// mints a new focus tag for a loop's entity subscriptions, this
+		// callback registers the matching tag-scoped context provider so
+		// the loop's iterations actually see those entities in prompt.
+		registerTagProvider := func(tag string) {
+			if a.ha == nil || strings.TrimSpace(tag) == "" {
+				return
+			}
+			tagProvider := awareness.NewWatchlistTagProvider(tag, a.watchlistStore, a.ha, a.logger)
+			tagProvider.SetRegistryClient(a.ha)
+			a.loop.RegisterTagContextProvider(tag, tagProvider)
+		}
 		a.loop.Tools().ConfigureLoopIntentTools(tools.LoopIntentToolDeps{
-			DocTools:         a.documentTools,
-			Registry:         a.loopDefinitionRegistry,
-			PersistSpec:      a.persistLoopDefinition,
-			Reconcile:        a.reconcileLoopDefinition,
-			LaunchDefinition: a.launchLoopDefinition,
+			DocTools:            a.documentTools,
+			Registry:            a.loopDefinitionRegistry,
+			PersistSpec:         a.persistLoopDefinition,
+			Reconcile:           a.reconcileLoopDefinition,
+			LaunchDefinition:    a.launchLoopDefinition,
+			WatchlistStore:      a.watchlistStore,
+			RegisterTagProvider: registerTagProvider,
 		})
 	}
 	a.loop.Tools().ConfigureLoopRuntimeTools(tools.LoopRuntimeToolDeps{

--- a/internal/app/new_stores.go
+++ b/internal/app/new_stores.go
@@ -18,6 +18,7 @@ import (
 	"github.com/nugget/thane-ai-agent/internal/platform/opstate"
 	"github.com/nugget/thane-ai-agent/internal/platform/scheduler"
 	looppkg "github.com/nugget/thane-ai-agent/internal/runtime/loop"
+	"github.com/nugget/thane-ai-agent/internal/state/awareness"
 	"github.com/nugget/thane-ai-agent/internal/state/memory"
 )
 
@@ -92,6 +93,17 @@ func (a *App) initStores(s *newState) error {
 	a.mem = mem
 	a.onCloseErr("memory", mem.Close)
 	logger.Info("memory database opened", "path", dbPath)
+
+	// --- Entity watchlist store ---
+	// Constructed early so later init phases (initChannels →
+	// ConfigureLoopIntentTools) can wire it into thane_curate for
+	// loop-owned entity subscriptions. The associated tag/always context
+	// providers are registered in initAwareness, which uses a.watchlistStore.
+	watchlistStore, err := awareness.NewWatchlistStore(a.mem.DB(), logger)
+	if err != nil {
+		return fmt.Errorf("watchlist store: %w", err)
+	}
+	a.watchlistStore = watchlistStore
 
 	// --- Home Assistant client ---
 	// Optional but central. Without it, HA-related tools are unavailable

--- a/internal/state/awareness/watchlist_store.go
+++ b/internal/state/awareness/watchlist_store.go
@@ -114,6 +114,21 @@ func (s *WatchlistStore) RemoveWithScopes(entityID string, scopes []string) erro
 	return tx.Commit()
 }
 
+// RemoveAllForScope deletes every subscription whose scope matches the given
+// tag. Used to tear down loop-owned entity subscriptions when the owning loop
+// is deleted or when a replace-mode launch re-seeds its watch set.
+func (s *WatchlistStore) RemoveAllForScope(scope string) error {
+	scope = strings.TrimSpace(scope)
+	if scope == "" {
+		return fmt.Errorf("scope is required")
+	}
+	_, err := s.db.Exec(
+		`DELETE FROM watched_entity_subscriptions WHERE scope = ?`,
+		scope,
+	)
+	return err
+}
+
 // List returns all watched entity IDs in insertion order, deduplicated across
 // scoped subscriptions.
 func (s *WatchlistStore) List() ([]string, error) {

--- a/internal/tools/loop_definition_mutation_tools.go
+++ b/internal/tools/loop_definition_mutation_tools.go
@@ -3,6 +3,7 @@ package tools
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	looppkg "github.com/nugget/thane-ai-agent/internal/runtime/loop"
@@ -64,11 +65,29 @@ func (r *Registry) handleLoopDefinitionDelete(ctx context.Context, args map[stri
 	if err != nil {
 		return "", err
 	}
-	if existing, ok := findLoopDefinition(snapshot, name); ok && existing.Source == looppkg.DefinitionSourceConfig {
+	existing, ok := findLoopDefinition(snapshot, name)
+	if ok && existing.Source == looppkg.DefinitionSourceConfig {
 		return "", (&looppkg.ImmutableDefinitionError{Name: name})
 	} else if !ok {
 		return "", (&looppkg.UnknownDefinitionError{Name: name})
 	}
+
+	// Tear down any entity subscriptions scoped to this loop's focus tag
+	// before the definition itself is removed. The focus_tag binding is
+	// stored on Spec.Metadata so it persists across replace cycles; only
+	// delete crosses the threshold where the subscriptions become orphans.
+	// Cleanup is best-effort: a store error is reported, but the
+	// definition delete still proceeds so the caller isn't left with a
+	// half-deleted loop. Skip when the watchlist store isn't wired
+	// (test harnesses, alternate registries).
+	if r.loopIntentDeps.WatchlistStore != nil {
+		if focusTag := strings.TrimSpace(existing.Spec.Metadata["focus_tag"]); focusTag != "" {
+			if err := r.loopIntentDeps.WatchlistStore.RemoveAllForScope(focusTag); err != nil {
+				return "", fmt.Errorf("wipe loop entity subscriptions for %q: %w", focusTag, err)
+			}
+		}
+	}
+
 	if r.deletePersistedLoopDefinition != nil {
 		if err := r.deletePersistedLoopDefinition(name); err != nil {
 			return "", fmt.Errorf("delete persisted loop definition: %w", err)

--- a/internal/tools/loop_definition_mutation_tools.go
+++ b/internal/tools/loop_definition_mutation_tools.go
@@ -76,10 +76,12 @@ func (r *Registry) handleLoopDefinitionDelete(ctx context.Context, args map[stri
 	// before the definition itself is removed. The focus_tag binding is
 	// stored on Spec.Metadata so it persists across replace cycles; only
 	// delete crosses the threshold where the subscriptions become orphans.
-	// Cleanup is best-effort: a store error is reported, but the
-	// definition delete still proceeds so the caller isn't left with a
-	// half-deleted loop. Skip when the watchlist store isn't wired
-	// (test harnesses, alternate registries).
+	// A wipe failure aborts the whole delete: the alternative (proceed
+	// anyway) would leave watchlist rows scoped to a focus_tag whose
+	// owning loop no longer exists, with no later operation that could
+	// reach them. Hard-fail keeps state consistent and lets the caller
+	// retry once the underlying issue clears. Skip when the watchlist
+	// store isn't wired (test harnesses, alternate registries).
 	if r.loopIntentDeps.WatchlistStore != nil {
 		if focusTag := strings.TrimSpace(existing.Spec.Metadata["focus_tag"]); focusTag != "" {
 			if err := r.loopIntentDeps.WatchlistStore.RemoveAllForScope(focusTag); err != nil {

--- a/internal/tools/loop_intent_tools.go
+++ b/internal/tools/loop_intent_tools.go
@@ -2,6 +2,8 @@ package tools
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"fmt"
 	"regexp"
 	"strconv"
@@ -12,6 +14,15 @@ import (
 	looppkg "github.com/nugget/thane-ai-agent/internal/runtime/loop"
 	"github.com/nugget/thane-ai-agent/internal/state/documents"
 )
+
+// EntitySubscriptionStore is the narrow contract loop-intent tools need
+// from the entity-watchlist store. Defined here rather than imported
+// from state/awareness because that package transitively imports this
+// one (area_activity_tool.go); the interface inverts the dependency.
+type EntitySubscriptionStore interface {
+	AddWithOptions(entityID string, tags []string, history []int, ttlSeconds int, forecast string) error
+	RemoveAllForScope(scope string) error
+}
 
 // LoopIntentToolDeps wires the loop-definition registry, document
 // store, and launch helper into the intent-shaped loop creation tools.
@@ -40,6 +51,15 @@ type LoopIntentToolDeps struct {
 	PersistSpec      func(looppkg.Spec, time.Time) error
 	Reconcile        func(context.Context, string) error
 	LaunchDefinition func(context.Context, string, looppkg.Launch) (looppkg.LaunchResult, error)
+	// WatchlistStore wires entity-subscription writes into thane_curate's
+	// entities parameter. Optional: when nil, the entities parameter is
+	// rejected and only the document/output side of the loop is set up.
+	WatchlistStore EntitySubscriptionStore
+	// RegisterTagProvider, if set, is invoked once after thane_curate
+	// adds entity subscriptions under a new focus tag so the tag-scoped
+	// context provider exists in the registry. Mirrors the TagRegistrar
+	// callback awareness.WatchlistTools uses.
+	RegisterTagProvider func(tag string)
 }
 
 // ConfigureLoopIntentTools registers the intent-shaped loop creation
@@ -65,8 +85,9 @@ func (r *Registry) registerThaneCurate() {
 			"Future modes will accept a directory ref for tree-shaped collections (multiple files maintained as a structured corpus); the output parameter shape will grow additively. " +
 			"Cadence accepts \"hourly\", \"daily\", \"every 30 minutes\", \"5m\", or \"1h\". Sleep_min/max/jitter are derived automatically. " +
 			"Tags scope the loop's tools; omit to inherit the always-active set. " +
-			"Returns the document ref, loop definition name, loop_id, output mode, the generated output tool name (output_tool) the receiving loop writes through, and the derived sleep_min/max/default cadence triple.",
-		ContentResolveExempt: []string{"name", "intent", "cadence", "tags", "guidance", "output", "replace"},
+			"Entities is a list of Home Assistant entity subscriptions the loop should see every iteration; they are persisted under a per-loop focus tag and surfaced into the loop's prompt automatically. " +
+			"Returns the document ref, loop definition name, loop_id, output mode, the generated output tool name (output_tool) the receiving loop writes through, the loop's internal focus_tag, and the derived sleep_min/max/default cadence triple.",
+		ContentResolveExempt: []string{"name", "intent", "cadence", "tags", "guidance", "output", "entities", "replace"},
 		Parameters: map[string]any{
 			"type": "object",
 			"properties": map[string]any{
@@ -106,6 +127,34 @@ func (r *Registry) registerThaneCurate() {
 					"type":        "array",
 					"items":       map[string]any{"type": "string"},
 					"description": "Optional capability tags scoping the loop's tool surface. Omit to use only always-active tags.",
+				},
+				"entities": map[string]any{
+					"type":        "array",
+					"description": "Optional Home Assistant entity subscriptions the loop should see in context every iteration. Each item declares an entity_id with optional history windows (seconds, e.g. [3600, 86400] for 1h and 1d summaries), weather forecast type for weather.* entities, and a ttl_seconds expiration. Subscriptions are persisted under a per-loop focus tag; you do not need to spell the tag.",
+					"items": map[string]any{
+						"type": "object",
+						"properties": map[string]any{
+							"entity_id": map[string]any{
+								"type":        "string",
+								"description": "The Home Assistant entity ID to watch (e.g., sensor.upstairs_temperature, weather.home).",
+							},
+							"history": map[string]any{
+								"type":        "array",
+								"items":       map[string]any{"type": "integer"},
+								"description": "Optional historical context windows in seconds. Each window adds a compact summary of past state to context (e.g., [600, 3600, 86400] for 10min/1hr/1day).",
+							},
+							"forecast": map[string]any{
+								"type":        "string",
+								"enum":        []string{"daily", "hourly", "twice_daily", "none"},
+								"description": "For weather.* entities, fetch this HA forecast type each turn and include the compact forecast in context.",
+							},
+							"ttl_seconds": map[string]any{
+								"type":        "integer",
+								"description": "Optional expiration in seconds. After this TTL elapses, the subscription is auto-removed from future context injection.",
+							},
+						},
+						"required": []string{"entity_id"},
+					},
 				},
 				"guidance": map[string]any{
 					"type":        "string",
@@ -169,6 +218,14 @@ func (r *Registry) handleThaneCurate(ctx context.Context, args map[string]any) (
 	guidance, _ := args["guidance"].(string)
 	replace, _ := args["replace"].(bool)
 
+	entities, err := parseCurateEntities(args["entities"])
+	if err != nil {
+		return "", err
+	}
+	if len(entities) > 0 && deps.WatchlistStore == nil {
+		return "", fmt.Errorf("entities provided but watchlist store is not configured")
+	}
+
 	cad, err := parseCadence(cadenceInput)
 	if err != nil {
 		return "", err
@@ -179,6 +236,11 @@ func (r *Registry) handleThaneCurate(ctx context.Context, args map[string]any) (
 	// currentLoopDefinitionSnapshot, because the latter checks
 	// r.loopDefinitionRegistry (set by ConfigureLoopDefinitionTools)
 	// rather than the registry handle this tool was configured with.
+	//
+	// When replace=true and the prior spec has a focus_tag, reuse it
+	// so existing subscriptions are renormalized under a stable tag
+	// rather than orphaned under a stale one.
+	var existingFocusTag string
 	if snap := deps.Registry.Snapshot(); snap != nil {
 		if existing, ok := findLoopDefinition(snap, name); ok {
 			if existing.Source == looppkg.DefinitionSourceConfig {
@@ -187,10 +249,24 @@ func (r *Registry) handleThaneCurate(ctx context.Context, args map[string]any) (
 			if !replace {
 				return "", fmt.Errorf("loop definition %q already exists; pass replace=true to overwrite", name)
 			}
+			existingFocusTag = strings.TrimSpace(existing.Spec.Metadata["focus_tag"])
+		}
+	}
+
+	focusTag := existingFocusTag
+	if focusTag == "" {
+		focusTag, err = newFocusTag()
+		if err != nil {
+			return "", fmt.Errorf("generate focus tag: %w", err)
 		}
 	}
 
 	outputSpec := buildCurateOutputSpec(name, documentRef, outputMode, intent)
+
+	// The focus tag is prepended to Spec.Tags so each iteration activates
+	// the loop-scoped watchlist provider without the caller having to
+	// repeat it. Caller-supplied tags follow.
+	finalTags := append([]string{focusTag}, tags...)
 
 	jitterRatio := 0.1
 	spec := looppkg.Spec{
@@ -202,8 +278,11 @@ func (r *Registry) handleThaneCurate(ctx context.Context, args map[string]any) (
 		SleepMax:     cad.sleepMax,
 		SleepDefault: cad.sleepDefault,
 		Jitter:       &jitterRatio,
-		Tags:         tags,
+		Tags:         finalTags,
 		Outputs:      []looppkg.OutputSpec{outputSpec},
+		Metadata: map[string]string{
+			"focus_tag": focusTag,
+		},
 		Profile: router.LoopProfile{
 			DelegationGating: "disabled",
 		},
@@ -243,6 +322,27 @@ func (r *Registry) handleThaneCurate(ctx context.Context, args map[string]any) (
 	}
 	_ = docResult // discard structured result; we surface the ref directly
 
+	// Entity subscriptions: wipe-and-re-add under the focus tag. On a
+	// fresh create existingFocusTag is empty and wipe is a no-op; on
+	// replace=true we wipe the prior watch set before adding the new
+	// one so the loop never sees stale entities. Wipe runs even when
+	// the new entities list is empty (an explicit clear).
+	if deps.WatchlistStore != nil && (existingFocusTag != "" || len(entities) > 0) {
+		if existingFocusTag != "" {
+			if err := deps.WatchlistStore.RemoveAllForScope(focusTag); err != nil {
+				return "", fmt.Errorf("wipe prior entity subscriptions: %w", err)
+			}
+		}
+		for _, e := range entities {
+			if err := deps.WatchlistStore.AddWithOptions(e.EntityID, []string{focusTag}, e.History, e.TTLSeconds, e.Forecast); err != nil {
+				return "", fmt.Errorf("add entity subscription %q: %w", e.EntityID, err)
+			}
+		}
+		if deps.RegisterTagProvider != nil && len(entities) > 0 {
+			deps.RegisterTagProvider(focusTag)
+		}
+	}
+
 	// Persist + reconcile + launch. Mirrors handleLoopDefinitionSet +
 	// handleLoopDefinitionLaunch; collapsed here so the model only sees
 	// one round-trip for the intent.
@@ -273,6 +373,8 @@ func (r *Registry) handleThaneCurate(ctx context.Context, args map[string]any) (
 		"loop_id":              launchResult.LoopID,
 		"output_mode":          outputMode,
 		"output_tool":          outputSpec.ToolName(),
+		"focus_tag":            focusTag,
+		"entity_subscriptions": len(entities),
 		"cadence": map[string]any{
 			"input":         cadenceInput,
 			"sleep_default": cad.sleepDefault.String(),
@@ -281,6 +383,103 @@ func (r *Registry) handleThaneCurate(ctx context.Context, args map[string]any) (
 		},
 		"warnings": warnings,
 	})
+}
+
+// curateEntity is the parsed shape of one element from the thane_curate
+// "entities" parameter. Fields mirror the watchlist subscription options.
+type curateEntity struct {
+	EntityID   string
+	History    []int
+	Forecast   string
+	TTLSeconds int
+}
+
+// parseCurateEntities decodes the "entities" parameter of thane_curate
+// into a typed list. Empty/missing returns nil. Invalid shapes return
+// an actionable error per the model-facing-tools doctrine.
+func parseCurateEntities(raw any) ([]curateEntity, error) {
+	if raw == nil {
+		return nil, nil
+	}
+	list, ok := raw.([]any)
+	if !ok {
+		return nil, fmt.Errorf("entities must be an array of objects")
+	}
+	if len(list) == 0 {
+		return nil, nil
+	}
+	out := make([]curateEntity, 0, len(list))
+	seen := make(map[string]bool, len(list))
+	for i, item := range list {
+		obj, ok := item.(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf("entities[%d] must be an object with at least an entity_id", i)
+		}
+		entityID, _ := obj["entity_id"].(string)
+		entityID = strings.TrimSpace(entityID)
+		if entityID == "" {
+			return nil, fmt.Errorf("entities[%d].entity_id is required", i)
+		}
+		if seen[entityID] {
+			return nil, fmt.Errorf("entities[%d] duplicates entity_id %q; each entity may appear at most once", i, entityID)
+		}
+		seen[entityID] = true
+
+		ent := curateEntity{EntityID: entityID}
+		if rawHistory, ok := obj["history"].([]any); ok {
+			for j, h := range rawHistory {
+				n, err := coerceInt(h)
+				if err != nil {
+					return nil, fmt.Errorf("entities[%d].history[%d]: %w", i, j, err)
+				}
+				if n <= 0 {
+					return nil, fmt.Errorf("entities[%d].history[%d]: window seconds must be > 0", i, j)
+				}
+				ent.History = append(ent.History, n)
+			}
+		}
+		if forecast, ok := obj["forecast"].(string); ok {
+			ent.Forecast = strings.TrimSpace(forecast)
+		}
+		if rawTTL, present := obj["ttl_seconds"]; present {
+			ttl, err := coerceInt(rawTTL)
+			if err != nil {
+				return nil, fmt.Errorf("entities[%d].ttl_seconds: %w", i, err)
+			}
+			if ttl < 0 {
+				return nil, fmt.Errorf("entities[%d].ttl_seconds: must be >= 0", i)
+			}
+			ent.TTLSeconds = ttl
+		}
+		out = append(out, ent)
+	}
+	return out, nil
+}
+
+func coerceInt(v any) (int, error) {
+	switch n := v.(type) {
+	case int:
+		return n, nil
+	case int64:
+		return int(n), nil
+	case float64:
+		return int(n), nil
+	default:
+		return 0, fmt.Errorf("must be an integer, got %T", v)
+	}
+}
+
+// newFocusTag mints a fresh per-loop watchlist scope. The "loop:" prefix
+// is the load-bearing convention: API/UI layers filter for it to find
+// loop-owned subscriptions, capability-tag collisions are impossible
+// (no built-in tag contains a colon), and a human reading
+// list_context_entities knows at a glance which rows belong to a loop.
+func newFocusTag() (string, error) {
+	var buf [3]byte
+	if _, err := rand.Read(buf[:]); err != nil {
+		return "", err
+	}
+	return "loop:" + hex.EncodeToString(buf[:]), nil
 }
 
 // buildCurateOutputSpec converts the intent-shaped output argument into

--- a/internal/tools/loop_intent_tools.go
+++ b/internal/tools/loop_intent_tools.go
@@ -463,6 +463,12 @@ func coerceInt(v any) (int, error) {
 	case int64:
 		return int(n), nil
 	case float64:
+		// JSON decoders deliver every number as float64; reject any
+		// fractional value so callers see an actionable error instead
+		// of a silent truncation (e.g. 3600.5 quietly becoming 3600).
+		if n != float64(int64(n)) {
+			return 0, fmt.Errorf("must be an integer, got fractional value %v", n)
+		}
 		return int(n), nil
 	default:
 		return 0, fmt.Errorf("must be an integer, got %T", v)

--- a/internal/tools/loop_intent_tools_test.go
+++ b/internal/tools/loop_intent_tools_test.go
@@ -213,8 +213,24 @@ func TestThaneCurate_EndToEnd(t *testing.T) {
 	if found.Spec.Profile.DelegationGating != "disabled" {
 		t.Errorf("DelegationGating = %q, want disabled", found.Spec.Profile.DelegationGating)
 	}
-	if len(found.Spec.Tags) != 1 || found.Spec.Tags[0] != "forge" {
-		t.Errorf("Tags = %v, want [forge]", found.Spec.Tags)
+	// The focus tag is generated internally and prepended to Spec.Tags;
+	// caller-supplied tags follow.
+	if len(found.Spec.Tags) != 2 {
+		t.Fatalf("Tags = %v, want [loop:<id>, forge]", found.Spec.Tags)
+	}
+	if !strings.HasPrefix(found.Spec.Tags[0], "loop:") {
+		t.Errorf("Tags[0] = %q, want loop:<id> prefix", found.Spec.Tags[0])
+	}
+	if found.Spec.Tags[1] != "forge" {
+		t.Errorf("Tags[1] = %q, want forge", found.Spec.Tags[1])
+	}
+	// The focus tag is also stored in Spec.Metadata so it survives
+	// persistence and is discoverable by management tools.
+	if got := found.Spec.Metadata["focus_tag"]; got != found.Spec.Tags[0] {
+		t.Errorf("Metadata[focus_tag] = %q, want %q (same as Tags[0])", got, found.Spec.Tags[0])
+	}
+	if resp["focus_tag"] != found.Spec.Tags[0] {
+		t.Errorf("response focus_tag = %v, want %q", resp["focus_tag"], found.Spec.Tags[0])
 	}
 
 	// Verify the declared output rides on the spec so the hydration
@@ -522,5 +538,345 @@ func TestThaneCurate_JournalDeclaresAppendOutput(t *testing.T) {
 	// warning — appending doesn't need the full history.
 	if strings.Contains(found.Spec.Task, "truncated") {
 		t.Errorf("journal-mode task prompt should not carry maintain-mode truncation warning, got: %s", found.Spec.Task)
+	}
+}
+
+// fakeSubscriptionStore captures AddWithOptions / RemoveAllForScope
+// calls so tests can assert on the per-loop watchlist plumbing without
+// standing up a real SQLite database.
+type fakeSubscriptionStore struct {
+	added   []fakeSubAdd
+	wiped   []string
+	failAdd error
+}
+
+type fakeSubAdd struct {
+	EntityID   string
+	Tags       []string
+	History    []int
+	TTLSeconds int
+	Forecast   string
+}
+
+func (f *fakeSubscriptionStore) AddWithOptions(entityID string, tags []string, history []int, ttlSeconds int, forecast string) error {
+	if f.failAdd != nil {
+		return f.failAdd
+	}
+	f.added = append(f.added, fakeSubAdd{
+		EntityID:   entityID,
+		Tags:       append([]string(nil), tags...),
+		History:    append([]int(nil), history...),
+		TTLSeconds: ttlSeconds,
+		Forecast:   forecast,
+	})
+	return nil
+}
+
+func (f *fakeSubscriptionStore) RemoveAllForScope(scope string) error {
+	f.wiped = append(f.wiped, scope)
+	return nil
+}
+
+// newCurateTestRig builds the minimum machinery needed for
+// thane_curate-handler tests: in-memory document store, empty
+// definition registry, fake subscription store, stub launch + reconcile,
+// and a registered-tag recorder. Returned values let each test inspect
+// post-call state without re-running the setup boilerplate.
+type curateTestRig struct {
+	reg            *Registry
+	tool           *Tool
+	defRegistry    *looppkg.DefinitionRegistry
+	subStore       *fakeSubscriptionStore
+	registeredTags []string
+	docTools       *documents.Tools
+}
+
+func newCurateTestRig(t *testing.T) *curateTestRig {
+	t.Helper()
+	tempDir := t.TempDir()
+	kbDir := filepath.Join(tempDir, "kb")
+	if err := mkdirAllForTest(kbDir); err != nil {
+		t.Fatalf("mkdir kb: %v", err)
+	}
+	db, err := database.OpenMemory()
+	if err != nil {
+		t.Fatalf("open memory db: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	docStore, err := documents.NewStore(db, map[string]string{"kb": kbDir}, nil)
+	if err != nil {
+		t.Fatalf("documents.NewStore: %v", err)
+	}
+	docTools := documents.NewTools(docStore)
+	defRegistry, err := looppkg.NewDefinitionRegistry(nil)
+	if err != nil {
+		t.Fatalf("NewDefinitionRegistry: %v", err)
+	}
+	subStore := &fakeSubscriptionStore{}
+	rig := &curateTestRig{
+		defRegistry: defRegistry,
+		subStore:    subStore,
+		docTools:    docTools,
+	}
+	rig.reg = NewEmptyRegistry()
+	rig.reg.ConfigureLoopIntentTools(LoopIntentToolDeps{
+		DocTools:    docTools,
+		Registry:    defRegistry,
+		PersistSpec: func(_ looppkg.Spec, _ time.Time) error { return nil },
+		Reconcile:   func(_ context.Context, _ string) error { return nil },
+		LaunchDefinition: func(_ context.Context, name string, _ looppkg.Launch) (looppkg.LaunchResult, error) {
+			return looppkg.LaunchResult{LoopID: "loop-test-" + name}, nil
+		},
+		WatchlistStore: subStore,
+		RegisterTagProvider: func(tag string) {
+			rig.registeredTags = append(rig.registeredTags, tag)
+		},
+	})
+	rig.tool = rig.reg.Get("thane_curate")
+	if rig.tool == nil {
+		t.Fatal("thane_curate not registered")
+	}
+	return rig
+}
+
+// findCurateSpec is a small helper for asserting on a definition's spec.
+func (rig *curateTestRig) findCurateSpec(t *testing.T, name string) looppkg.Spec {
+	t.Helper()
+	snap := rig.defRegistry.Snapshot()
+	for i := range snap.Definitions {
+		if snap.Definitions[i].Spec.Name == name {
+			return snap.Definitions[i].Spec
+		}
+	}
+	t.Fatalf("definition %q not in registry", name)
+	return looppkg.Spec{}
+}
+
+// TestThaneCurate_PersistsEntitySubscriptions covers the create-time
+// path: entities are written to the watchlist store under the generated
+// focus tag, and the tag-provider registrar is invoked once so the
+// loop's iterations see those entities in context.
+func TestThaneCurate_PersistsEntitySubscriptions(t *testing.T) {
+	t.Parallel()
+	rig := newCurateTestRig(t)
+
+	result, err := rig.tool.Handler(context.Background(), map[string]any{
+		"name":    "thermostat_journal",
+		"intent":  "Daily HVAC summary.",
+		"cadence": "daily",
+		"output": map[string]any{
+			"mode":     "journal",
+			"document": "kb:home/hvac.md",
+		},
+		"entities": []any{
+			map[string]any{
+				"entity_id": "climate.upstairs",
+				"history":   []any{3600, 86400},
+			},
+			map[string]any{
+				"entity_id":   "weather.home",
+				"forecast":    "hourly",
+				"ttl_seconds": 86400,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("thane_curate: %v", err)
+	}
+
+	var resp map[string]any
+	if err := json.Unmarshal([]byte(result), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	focusTag, _ := resp["focus_tag"].(string)
+	if !strings.HasPrefix(focusTag, "loop:") || len(focusTag) <= len("loop:") {
+		t.Fatalf("focus_tag = %q, want loop:<hex> shape", focusTag)
+	}
+	if got := resp["entity_subscriptions"]; got != float64(2) {
+		t.Errorf("entity_subscriptions = %v, want 2", got)
+	}
+
+	if len(rig.subStore.added) != 2 {
+		t.Fatalf("added subs = %d, want 2: %+v", len(rig.subStore.added), rig.subStore.added)
+	}
+	for i, sub := range rig.subStore.added {
+		if len(sub.Tags) != 1 || sub.Tags[0] != focusTag {
+			t.Errorf("added[%d].Tags = %v, want [%q]", i, sub.Tags, focusTag)
+		}
+	}
+	if rig.subStore.added[0].EntityID != "climate.upstairs" {
+		t.Errorf("added[0].EntityID = %q, want climate.upstairs", rig.subStore.added[0].EntityID)
+	}
+	if h := rig.subStore.added[0].History; len(h) != 2 || h[0] != 3600 || h[1] != 86400 {
+		t.Errorf("added[0].History = %v, want [3600 86400]", h)
+	}
+	if rig.subStore.added[1].Forecast != "hourly" {
+		t.Errorf("added[1].Forecast = %q, want hourly", rig.subStore.added[1].Forecast)
+	}
+	if rig.subStore.added[1].TTLSeconds != 86400 {
+		t.Errorf("added[1].TTLSeconds = %d, want 86400", rig.subStore.added[1].TTLSeconds)
+	}
+
+	// The RegisterTagProvider callback fires exactly once per create, so
+	// the loop's tag-scoped context provider is wired before the first
+	// iteration runs.
+	if len(rig.registeredTags) != 1 || rig.registeredTags[0] != focusTag {
+		t.Errorf("registeredTags = %v, want [%q]", rig.registeredTags, focusTag)
+	}
+
+	// The spec carries the focus tag in both Metadata (canonical binding)
+	// and Tags[0] (active during every iteration).
+	spec := rig.findCurateSpec(t, "thermostat_journal")
+	if got := spec.Metadata["focus_tag"]; got != focusTag {
+		t.Errorf("Metadata[focus_tag] = %q, want %q", got, focusTag)
+	}
+	if len(spec.Tags) == 0 || spec.Tags[0] != focusTag {
+		t.Errorf("Tags[0] = %q, want %q", spec.Tags, focusTag)
+	}
+}
+
+// TestThaneCurate_ReplacePreservesFocusTag verifies the replace=true
+// branch: the focus tag from the prior spec is reused (not minted
+// anew), the watchlist scope is wiped, and the new entities are added
+// under the same stable tag.
+func TestThaneCurate_ReplacePreservesFocusTag(t *testing.T) {
+	t.Parallel()
+	rig := newCurateTestRig(t)
+
+	create := func(extra map[string]any) string {
+		args := map[string]any{
+			"name":    "hvac_curate",
+			"intent":  "HVAC summary.",
+			"cadence": "daily",
+			"output": map[string]any{
+				"mode":     "journal",
+				"document": "kb:home/hvac.md",
+			},
+		}
+		for k, v := range extra {
+			args[k] = v
+		}
+		result, err := rig.tool.Handler(context.Background(), args)
+		if err != nil {
+			t.Fatalf("thane_curate: %v", err)
+		}
+		var resp map[string]any
+		if err := json.Unmarshal([]byte(result), &resp); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		return resp["focus_tag"].(string)
+	}
+
+	firstTag := create(map[string]any{
+		"entities": []any{
+			map[string]any{"entity_id": "climate.upstairs"},
+		},
+	})
+	if len(rig.subStore.added) != 1 || rig.subStore.added[0].EntityID != "climate.upstairs" {
+		t.Fatalf("first create added = %+v", rig.subStore.added)
+	}
+	if len(rig.subStore.wiped) != 0 {
+		t.Fatalf("first create should not wipe anything, got %v", rig.subStore.wiped)
+	}
+
+	secondTag := create(map[string]any{
+		"replace": true,
+		"entities": []any{
+			map[string]any{"entity_id": "sensor.upstairs_temp"},
+			map[string]any{"entity_id": "weather.home", "forecast": "daily"},
+		},
+	})
+	if secondTag != firstTag {
+		t.Errorf("focus_tag changed across replace: %q → %q (should be stable)", firstTag, secondTag)
+	}
+	if len(rig.subStore.wiped) != 1 || rig.subStore.wiped[0] != firstTag {
+		t.Errorf("expected exactly one wipe of %q, got %v", firstTag, rig.subStore.wiped)
+	}
+	// Three adds total: 1 from first create + 2 from replace.
+	if len(rig.subStore.added) != 3 {
+		t.Fatalf("total added = %d, want 3", len(rig.subStore.added))
+	}
+	if rig.subStore.added[1].EntityID != "sensor.upstairs_temp" || rig.subStore.added[2].EntityID != "weather.home" {
+		t.Errorf("replace-side adds = %+v %+v", rig.subStore.added[1], rig.subStore.added[2])
+	}
+}
+
+// TestLoopDefinitionDelete_WipesEntitySubscriptions covers the
+// teardown path: deleting a curate loop cleans up its scoped entity
+// subscriptions so they don't linger as orphans in the watchlist.
+func TestLoopDefinitionDelete_WipesEntitySubscriptions(t *testing.T) {
+	t.Parallel()
+	rig := newCurateTestRig(t)
+
+	// Configure loop-definition tools against the same registry the
+	// intent tool wrote into. View is omitted so the delete handler
+	// falls through to building one from the registry directly.
+	rig.reg.ConfigureLoopDefinitionTools(LoopDefinitionToolDeps{
+		Registry:   rig.defRegistry,
+		DeleteSpec: func(_ string) error { return nil },
+		Reconcile:  func(_ context.Context, _ string) error { return nil },
+	})
+
+	if _, err := rig.tool.Handler(context.Background(), map[string]any{
+		"name":    "curate_to_delete",
+		"intent":  "Short-lived watcher.",
+		"cadence": "hourly",
+		"output": map[string]any{
+			"mode":     "journal",
+			"document": "kb:scratch/short.md",
+		},
+		"entities": []any{
+			map[string]any{"entity_id": "binary_sensor.door"},
+		},
+	}); err != nil {
+		t.Fatalf("thane_curate: %v", err)
+	}
+
+	spec := rig.findCurateSpec(t, "curate_to_delete")
+	focusTag := spec.Metadata["focus_tag"]
+	if focusTag == "" {
+		t.Fatal("focus_tag missing on spec")
+	}
+	// Reset wiped log so we can isolate the delete's contribution.
+	rig.subStore.wiped = nil
+
+	delTool := rig.reg.Get("loop_definition_delete")
+	if delTool == nil {
+		t.Fatal("loop_definition_delete not registered")
+	}
+	if _, err := delTool.Handler(context.Background(), map[string]any{"name": "curate_to_delete"}); err != nil {
+		t.Fatalf("loop_definition_delete: %v", err)
+	}
+	if len(rig.subStore.wiped) != 1 || rig.subStore.wiped[0] != focusTag {
+		t.Errorf("delete should wipe focus_tag %q exactly once, got %v", focusTag, rig.subStore.wiped)
+	}
+}
+
+// TestThaneCurate_RejectsDuplicateEntityID guards parseCurateEntities's
+// duplicate detection — a model that lists the same entity twice
+// should see an actionable error rather than have the second write
+// silently no-op via the store's ON CONFLICT clause.
+func TestThaneCurate_RejectsDuplicateEntityID(t *testing.T) {
+	t.Parallel()
+	rig := newCurateTestRig(t)
+
+	_, err := rig.tool.Handler(context.Background(), map[string]any{
+		"name":    "dup_test",
+		"intent":  "x",
+		"cadence": "hourly",
+		"output": map[string]any{
+			"mode":     "journal",
+			"document": "kb:dup.md",
+		},
+		"entities": []any{
+			map[string]any{"entity_id": "sensor.foo"},
+			map[string]any{"entity_id": "sensor.foo"},
+		},
+	})
+	if err == nil {
+		t.Fatal("expected duplicate entity_id to be rejected")
+	}
+	if !strings.Contains(err.Error(), "duplicate") {
+		t.Errorf("error %q should mention duplicate", err)
 	}
 }

--- a/internal/tools/loop_intent_tools_test.go
+++ b/internal/tools/loop_intent_tools_test.go
@@ -880,3 +880,58 @@ func TestThaneCurate_RejectsDuplicateEntityID(t *testing.T) {
 		t.Errorf("error %q should mention duplicate", err)
 	}
 }
+
+// TestThaneCurate_RejectsFractionalInteger guards coerceInt's
+// integer-not-float guard. JSON decoders deliver every number as
+// float64, so a model that types `"ttl_seconds": 3600.5` would be
+// silently truncated to 3600 without this check. Whole-number
+// floats (3600.0) must still be accepted since that's the realistic
+// post-decode shape of an integer literal.
+func TestThaneCurate_RejectsFractionalInteger(t *testing.T) {
+	t.Parallel()
+	rig := newCurateTestRig(t)
+
+	_, err := rig.tool.Handler(context.Background(), map[string]any{
+		"name":    "frac_test",
+		"intent":  "x",
+		"cadence": "hourly",
+		"output": map[string]any{
+			"mode":     "journal",
+			"document": "kb:frac.md",
+		},
+		"entities": []any{
+			map[string]any{
+				"entity_id":   "sensor.foo",
+				"ttl_seconds": 3600.5,
+			},
+		},
+	})
+	if err == nil {
+		t.Fatal("expected fractional ttl_seconds to be rejected")
+	}
+	if !strings.Contains(err.Error(), "fractional") {
+		t.Errorf("error %q should mention fractional", err)
+	}
+
+	// Whole-number float (post-JSON-decode shape of an integer literal)
+	// must still pass — coerceInt accepts float64 when n == int64(n).
+	_, err = rig.tool.Handler(context.Background(), map[string]any{
+		"name":    "whole_float_test",
+		"intent":  "x",
+		"cadence": "hourly",
+		"output": map[string]any{
+			"mode":     "journal",
+			"document": "kb:whole.md",
+		},
+		"entities": []any{
+			map[string]any{
+				"entity_id":   "sensor.foo",
+				"ttl_seconds": 3600.0,
+				"history":     []any{3600.0, 86400.0},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("whole-number floats should be accepted: %v", err)
+	}
+}

--- a/scripts/architecture.baseline
+++ b/scripts/architecture.baseline
@@ -1,5 +1,5 @@
 packages=55
-interfaces=74
-large_files=31
+interfaces=75
+large_files=32
 set_mutators=99
 database_opens=8


### PR DESCRIPTION
## Summary

`thane_curate` gains an `entities` parameter that lets the model declare the Home Assistant entity subscriptions a loop should see in context every iteration — in **one call**, instead of the prior friction of `thane_curate` + N × `add_context_entity` + manually-shared tag string.

The synthetic focus tag is internal-only: `loop:<6-hex>`, stored on `Spec.Metadata[\"focus_tag\"]` and prepended to `Spec.Tags`. The model never sees, types, or thinks about it. The `loop:` prefix is the load-bearing convention — it gives API/UI surfaces a filter (`scope LIKE 'loop:%'` finds all loop-managed subscriptions) and is collision-proof against capability tags (none contain a colon).

## Why

Before this change, attaching a watchlist to a thane_curate loop required the model to keep three strings in sync across multiple tool calls:

1. Pass `tags: [\"focus_thing\"]` to `thane_curate`.
2. Call `add_context_entity({entity_id: \"...\", tags: [\"focus_thing\"]})` N times with the same string.
3. Hope nothing got misspelled.

This change folds all of that into one declarative call where the system owns the tag generation and consistency, and the model owns the *intent* — which entities it wants the loop to see.

## Design decisions

1. **Tag = `loop:<6-hex>`, stored in `Spec.Metadata[\"focus_tag\"]`, never user-facing.**
2. **Synthetic tag prepended to `Spec.Tags` alongside caller-passed tags.**
3. **`replace=true` preserves the focus tag**, wipes-and-re-adds subscriptions under it (stable identifier across recreations).
4. **`loop_definition_delete` reads `focus_tag` and wipes scoped subscriptions** so deleted loops don't leave orphaned watchlist rows.
5. **CRUD shape for in-flight loops** — deferred to a follow-on PR (`loop_update_entity_subscriptions` external, `watch_entity` / `unwatch_entity` internal).

## Surgery

- [`internal/state/awareness/watchlist_store.go`](internal/state/awareness/watchlist_store.go) — new `RemoveAllForScope` method.
- [`internal/tools/loop_intent_tools.go`](internal/tools/loop_intent_tools.go) — new `EntitySubscriptionStore` interface (defined in `tools` rather than imported from `awareness` to invert what would have been an import cycle). `LoopIntentToolDeps` gains `WatchlistStore` + `RegisterTagProvider`. Handler grows `parseCurateEntities` and `newFocusTag` helpers, weaves entity persistence into the replace/create flow, surfaces `focus_tag` + `entity_subscriptions` in the response JSON.
- [`internal/tools/loop_definition_mutation_tools.go`](internal/tools/loop_definition_mutation_tools.go) — `handleLoopDefinitionDelete` reads `Spec.Metadata[\"focus_tag\"]` and wipes scoped subscriptions before deletion.
- [`internal/app/app.go`](internal/app/app.go) + [`new_stores.go`](internal/app/new_stores.go) + [`new_awareness.go`](internal/app/new_awareness.go) — `watchlistStore` moves from a local in `initAwareness` to `App.watchlistStore` constructed in `initStores` so it's available to `initChannels` for thane_curate wiring. Context-provider registration in `initAwareness` unchanged in behavior.
- [`internal/app/new_channels.go`](internal/app/new_channels.go) — pass `watchlistStore` + a `RegisterTagProvider` closure (mirroring `awareness.WatchlistTools`'s `TagRegistrar` shape) into `ConfigureLoopIntentTools` so new focus tags get their context provider wired immediately at create time.

## Tests

- [`internal/tools/loop_intent_tools_test.go`](internal/tools/loop_intent_tools_test.go):
  - Existing `TestThaneCurate_EndToEnd` adjusted for the new `Spec.Tags` shape (focus_tag prepended) and asserts `focus_tag` is present in response + `Spec.Metadata`.
  - `TestThaneCurate_PersistsEntitySubscriptions` — entity persistence with history/forecast/ttl pass-through, RegisterTagProvider invoked once.
  - `TestThaneCurate_ReplacePreservesFocusTag` — replace reuses the existing focus tag, wipes once, re-adds new entities.
  - `TestLoopDefinitionDelete_WipesEntitySubscriptions` — deletion wipes the loop's scoped subscriptions.
  - `TestThaneCurate_RejectsDuplicateEntityID` — actionable error on duplicates.
  - Shared `curateTestRig` + `fakeSubscriptionStore` factor out boilerplate.

## Architecture baseline

Bumped `interfaces` (74→75) for the new `EntitySubscriptionStore` interface, and `large_files` (31→32) for the test file's growth. Both deliberate.

## Validation

- [x] `just ci` clean locally (golangci-lint 0 issues, `go test -race ./...` green, architecture check 0 issues)