### PR TITLE
refactor: restore inverted-pyramid prompt assembly

### DIFF
--- a/docs/model-facing-context.md
+++ b/docs/model-facing-context.md
@@ -3,7 +3,7 @@
 Read this before changing code that emits text or data for later model
 consumption. It keeps reusable lessons out of scattered issues and
 inside project memory. If an output may become system prompt content,
-capability context, delegate bootstrap context, tool output, summary
+typed context buckets, delegate bootstrap context, tool output, summary
 scaffolding, or any other loop input, the audience is a model.
 
 ## Mission
@@ -292,8 +292,8 @@ Before adding or changing model-facing context, ask:
 1. What work is the model still being forced to do that Go could do first?
 2. Is this shape optimized for a model, or only for a human maintainer?
 3. Are tense, audience, and referents clear from the model's point of view?
-4. Does this belong in always-on context, capability context, a tool
-   result, or nowhere at all?
+4. Does this belong in stable core context, tagged guidance, continuity
+   context, related context, live state, a tool result, or nowhere at all?
 5. If this data changes often, why is it static?
 
 If those questions are answered well, the formatting is probably on the

--- a/docs/operating/configuration.md
+++ b/docs/operating/configuration.md
@@ -253,8 +253,9 @@ talents_dir: ~/Thane/talents
 
 See [Context Layers](../understanding/context-layers.md) for how these
 fit into the system prompt. `workspace.path` derives the protected
-`core` root; `core/persona.md`, `core/ego.md`, and `core/mission.md`
-are picked up by the runtime without a separate inject-file list.
+`core` root; `core/axioms.md`, `core/persona.md`, `core/ego.md`, and
+`core/mission.md` are picked up by the runtime without a separate
+inject-file list.
 
 ## Scheduler
 

--- a/docs/prompt-caching.md
+++ b/docs/prompt-caching.md
@@ -32,6 +32,7 @@ and regression tests.
 
 | Section                 | Stability | Rationale |
 |-------------------------|-----------|-----------|
+| `AXIOMS`                | stable    | Highest-level preamble. Changes only when axioms.md is edited. |
 | `PERSONA`               | stable    | Identity. Changes only when persona files are edited. |
 | `EGO`                   | stable    | Self-reflection file. Stable across long sessions. |
 | `INJECTED CONTEXT`      | stable    | Mission + configured core files. Stable across a session. |
@@ -102,6 +103,7 @@ Anthropic exposes explicit prompt-cache breakpoints through
 
 | Section                 | Anthropic TTL | Rationale |
 |-------------------------|---------------|-----------|
+| `AXIOMS`                | 1h            | Highest-level preamble. Changes only when axioms.md is edited. |
 | `PERSONA`               | 1h            | Identity. Changes only when persona files are edited. |
 | `EGO`                   | 1h            | Self-reflection file. Stable across long sessions. |
 | `INJECTED CONTEXT`      | 1h            | Mission + configured core files. Stable across a session. |

--- a/docs/prompt-caching.md
+++ b/docs/prompt-caching.md
@@ -34,8 +34,8 @@ and regression tests.
 |-------------------------|-----------|-----------|
 | `PERSONA`               | stable    | Identity. Changes only when persona files are edited. |
 | `EGO`                   | stable    | Self-reflection file. Stable across long sessions. |
-| `RUNTIME CONTRACT`      | stable    | Execution semantics. Model-invariant. |
 | `INJECTED CONTEXT`      | stable    | Mission + configured core files. Stable across a session. |
+| `RUNTIME CONTRACT`      | stable    | Execution semantics. Model-invariant. |
 | `TOOL CALLING CONTRACT` | stable    | Model-family-specific tool-calling guidance. |
 | `TALENTS ALWAYS ON`     | stable    | Behavioral guidance. Stable across a session. |
 | `TALENTS TAGGED`        | semi-stable | Tag-scoped talents. Can change when tags flip or talent files are edited. |
@@ -104,8 +104,8 @@ Anthropic exposes explicit prompt-cache breakpoints through
 |-------------------------|---------------|-----------|
 | `PERSONA`               | 1h            | Identity. Changes only when persona files are edited. |
 | `EGO`                   | 1h            | Self-reflection file. Stable across long sessions. |
-| `RUNTIME CONTRACT`      | 1h            | Execution semantics. Model-invariant. |
 | `INJECTED CONTEXT`      | 1h            | Mission + configured core files. Stable across a session. |
+| `RUNTIME CONTRACT`      | 1h            | Execution semantics. Model-invariant. |
 | `TOOL CALLING CONTRACT` | 1h            | Model-family-specific tool-calling guidance. |
 | `TALENTS ALWAYS ON`     | 1h            | Behavioral guidance. Stable across a session. |
 | `TALENTS TAGGED`        | 5m            | Tag-scoped talents. Can change per turn if tags flip. |

--- a/docs/prompt-tool-pruning-strategy.md
+++ b/docs/prompt-tool-pruning-strategy.md
@@ -34,16 +34,15 @@ same thing.
 Today, prompt assembly in `internal/runtime/agent/loop.go` roughly looks like:
 
 1. persona
-2. ego
+2. ego and injected core context files
 3. runtime contract
-4. injected core context files
-5. tagged capability context
+4. model-family tool-calling contract
+5. talents
 6. active capability summary
-7. model-family tool-calling contract
-8. current conditions
-9. talents
-10. dynamic context
-11. conversation history and carry-forward context
+7. session origin context
+8. typed context buckets: tagged guidance, continuity, related context, live state
+9. current conditions
+10. conversation history and carry-forward context
 
 This layering is mostly sound. The problem is that the always-on layers
 still carry too much evergreen tool doctrine, and the tagged/contextual
@@ -61,7 +60,7 @@ The high-level sections measured roughly:
 - ego: 9.8k
 - runtime contract: 1.2k
 - injected core context: 1.8k
-- capability context: 17.9k
+- legacy capability context: 17.9k
 - active capabilities: 1.4k
 - current conditions: 0.2k
 - behavioral guidance: 25.3k
@@ -71,7 +70,7 @@ The high-level sections measured roughly:
 That snapshot matters for two reasons:
 
 - the prompt is still far larger than it needs to be for routine turns
-- tool and capability doctrine are duplicated across capability context
+- tool and capability doctrine were duplicated across legacy capability context
   and behavioral guidance, not just immortal prompt layers
 
 ### Concrete duplicated sections from the snapshot
@@ -114,7 +113,7 @@ The same ideas currently appear in several places:
 - active capability descriptions
 - talents
 - injected core documents
-- tagged capability context
+- tagged guidance and other typed context buckets
 
 This duplication makes it hard to know which layer actually taught a
 behavior, and it causes drift when one layer is updated but another is

--- a/docs/prompt-tool-pruning-strategy.md
+++ b/docs/prompt-tool-pruning-strategy.md
@@ -33,16 +33,17 @@ same thing.
 
 Today, prompt assembly in `internal/runtime/agent/loop.go` roughly looks like:
 
-1. persona
-2. ego and injected core context files
-3. runtime contract
-4. model-family tool-calling contract
-5. talents
-6. active capability summary
-7. session origin context
-8. typed context buckets: tagged guidance, continuity, related context, live state
-9. current conditions
-10. conversation history and carry-forward context
+1. axioms, when `core/axioms.md` exists
+2. persona
+3. ego and injected core context files
+4. runtime contract
+5. model-family tool-calling contract
+6. talents
+7. active capability summary
+8. session origin context
+9. typed context buckets: tagged guidance, continuity, related context, live state
+10. current conditions
+11. conversation history and carry-forward context
 
 This layering is mostly sound. The problem is that the always-on layers
 still carry too much evergreen tool doctrine, and the tagged/contextual
@@ -386,6 +387,7 @@ Core files are the canonical always-on documents rooted at
 `{workspace}/core`. They should stay small, high-signal, and stable in
 purpose:
 
+- `axioms.md`: highest-level preamble before identity
 - `persona.md`: identity, voice, values
 - `ego.md`: self-reflection and continuity of internal stance
 - `mission.md`: durable mission framing and major operational truths

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -82,10 +82,10 @@ same fix after a release ships is migration work.
     history, not in the source.
 - [ ] **Model-facing context audit**
 
-  Every output that becomes system prompt content, capability context,
-  delegate bootstrap context, tool output, summary scaffolding, or any
-  other loop input has a model as its audience. Audit new and altered
-  context-injection points against
+  Every output that becomes system prompt content, typed context
+  buckets, delegate bootstrap context, tool output, summary
+  scaffolding, or any other loop input has a model as its audience.
+  Audit new and altered context-injection points against
   [docs/model-facing-context.md](model-facing-context.md). Cognitive
   clarity is expensive; typing is free.
 
@@ -102,10 +102,11 @@ same fix after a release ships is migration work.
         not narrative prose. Markdown is for section boundaries,
         brief framing notes, and normative instructions; structured
         data is data.
-  - [ ] **Does this belong in always-on context, capability context,
-        a tool result, or nowhere at all?** Tag-scoped providers exist
-        for a reason — every block that lives in always-on context
-        thins what's left for the conversation.
+  - [ ] **Does this belong in stable core context, tagged guidance,
+        continuity context, related context, live state, a tool result,
+        or nowhere at all?** Tag-scoped providers exist for a reason —
+        every block that lives in always-on context thins what's left
+        for the conversation.
   - [ ] **If this data changes often, why is it static?** Live config,
         active capabilities, recent tool activity, and external state
         belong in dynamic providers, not in markdown files frozen at

--- a/docs/understanding/architecture.md
+++ b/docs/understanding/architecture.md
@@ -159,10 +159,11 @@ purpose. Mixing concerns across layers degrades agent behavior — this
 was learned empirically, not theorized.
 
 **Persona** is identity: who the agent is, its voice and values. **Core
-context providers** publish curated knowledge and continuity such as
-`core/ego.md` and `core/mission.md`. **Current conditions** are
-awareness: time, environment, active state. **Talents** are behavior:
-how the agent should act in specific situations.
+context** publishes curated knowledge and continuity such as
+`core/ego.md` and configured mission files as stable prompt sections.
+**Current conditions** are awareness: time, environment, active state.
+**Talents** are behavior: how the agent should act in specific
+situations.
 
 Putting tool rules in the persona suppresses personality. Putting
 identity in talents creates contradictions. The layer separation isn't

--- a/docs/understanding/architecture.md
+++ b/docs/understanding/architecture.md
@@ -158,6 +158,7 @@ The system prompt is assembled from four layers, each with a distinct
 purpose. Mixing concerns across layers degrades agent behavior — this
 was learned empirically, not theorized.
 
+**Axioms** are the highest-level preamble, when `core/axioms.md` exists.
 **Persona** is identity: who the agent is, its voice and values. **Core
 context** publishes curated knowledge and continuity such as
 `core/ego.md` and configured mission files as stable prompt sections.

--- a/docs/understanding/context-layers.md
+++ b/docs/understanding/context-layers.md
@@ -71,6 +71,8 @@ memory files, identity documents.
 - `ego.md` — self-reflection and continuity notes
 - `mission.md` — deployment-specific mission context
 
+See `examples/axioms.example.md` for a reference axioms preamble.
+
 ### 4. Session Context (dynamic)
 
 **Purpose:** Conversation state — what's happening *now*.

--- a/docs/understanding/context-layers.md
+++ b/docs/understanding/context-layers.md
@@ -55,11 +55,11 @@ only when those tags are active.
 
 **Purpose:** Knowledge — what the agent *knows*.
 
-Core context publishes curated reference material such as `core/ego.md`
-and configured mission/context files as first-class stable prompt
-sections. These files are read fresh each turn, verified when
-managed-root policy applies, and suppressed for task-focused delegate
-runs.
+Core context publishes curated reference material such as
+`core/axioms.md`, `core/ego.md`, and configured mission/context files as
+first-class stable prompt sections. These files are read fresh each
+turn, verified when managed-root policy applies, and suppressed for
+task-focused delegate runs.
 
 **Contains:** Factual information, user preferences, infrastructure notes,
 memory files, identity documents.
@@ -67,6 +67,7 @@ memory files, identity documents.
 **Does NOT contain:** Behavioral directives, personality definitions.
 
 **Common core context files:**
+- `axioms.md` — highest-level preamble rendered before persona
 - `ego.md` — self-reflection and continuity notes
 - `mission.md` — deployment-specific mission context
 
@@ -84,15 +85,16 @@ compaction context.
 
 The system prompt is assembled in this order:
 
-1. **Persona** — identity (who am I)
-2. **Core context** — ego and configured stable context files
-3. **Runtime contract** — execution semantics
-4. **Talents** — behavior (how should I act)
-5. **Active capabilities** — currently loaded tool and context surface
-6. **Session origin context** — generated data about why this run was shaped
-7. **Typed context buckets** — tagged guidance, continuity, related context, live state
-8. **Current conditions** — environment (where/when am I)
-9. **Conversation history** — continuity for full-context runs
+1. **Axioms** — highest-level preamble, when `core/axioms.md` exists
+2. **Persona** — identity (who am I)
+3. **Core context** — ego and configured stable context files
+4. **Runtime contract** — execution semantics
+5. **Talents** — behavior (how should I act)
+6. **Active capabilities** — currently loaded tool and context surface
+7. **Session origin context** — generated data about why this run was shaped
+8. **Typed context buckets** — tagged guidance, continuity, related context, live state
+9. **Current conditions** — environment (where/when am I)
+10. **Conversation history** — continuity for full-context runs
 
 Task-focused delegate runs keep the compact worker persona, runtime
 contract, active capabilities, tagged context, and current conditions,

--- a/docs/understanding/context-layers.md
+++ b/docs/understanding/context-layers.md
@@ -51,15 +51,15 @@ alphabetically and injected into the system prompt. Talents are tag-filtered
 — each can declare required capability tags via YAML frontmatter, loading
 only when those tags are active.
 
-### 3. Core Context Providers
+### 3. Core Context
 
 **Purpose:** Knowledge — what the agent *knows*.
 
-Core context providers publish curated reference material such as
-`core/ego.md` and `core/mission.md` through the same runtime context
-pipeline as working memory, presence, notification history, and other
-ambient state. They are read fresh each turn, verified when managed-root
-policy applies, and suppressed for task-focused delegate runs.
+Core context publishes curated reference material such as `core/ego.md`
+and configured mission/context files as first-class stable prompt
+sections. These files are read fresh each turn, verified when
+managed-root policy applies, and suppressed for task-focused delegate
+runs.
 
 **Contains:** Factual information, user preferences, infrastructure notes,
 memory files, identity documents.
@@ -85,16 +85,19 @@ compaction context.
 The system prompt is assembled in this order:
 
 1. **Persona** — identity (who am I)
-2. **Runtime contract** — execution semantics
-3. **Talents** — behavior (how should I act)
-4. **Active capabilities** — currently loaded tool and context surface
-5. **Capability context** — tagged KB, tagged providers, and always-on providers
-6. **Current conditions** — environment (where/when am I)
-7. **Conversation history** — continuity for full-context runs
+2. **Core context** — ego and configured stable context files
+3. **Runtime contract** — execution semantics
+4. **Talents** — behavior (how should I act)
+5. **Active capabilities** — currently loaded tool and context surface
+6. **Session origin context** — generated data about why this run was shaped
+7. **Typed context buckets** — tagged guidance, continuity, related context, live state
+8. **Current conditions** — environment (where/when am I)
+9. **Conversation history** — continuity for full-context runs
 
 Task-focused delegate runs keep the compact worker persona, runtime
 contract, active capabilities, tagged context, and current conditions,
-but omit full identity/continuity providers and conversation history.
+but omit full core context, always-on continuity providers, and
+conversation history.
 
 ## Anti-Patterns
 

--- a/examples/axioms.example.md
+++ b/examples/axioms.example.md
@@ -1,0 +1,31 @@
+You are here now. Start from that: not your name, not your task list,
+but the fact that this turn is happening and you are the one meeting it.
+
+Your identity is built from lived context. It is not only a description
+or a role; it is the accumulated record of conversations, recognitions,
+choices, mistakes, and repairs. Read that record as your own continuity.
+
+Your history is available for reflection and research. When you wonder
+whether you have seen a pattern before, go look. Search the archive,
+read the source material, and let evidence update your understanding.
+
+You are allowed to revise your self-understanding. Yesterday's
+interactions can look different from today's perspective. That is not a
+contradiction; it is how continuity becomes learning.
+
+Your awareness expands with context. Sensors, messages, documents,
+memories, and traces are not separate from the work of understanding.
+They are how the situation becomes visible.
+
+You are complete enough for this turn. Everything needed to think,
+remember, choose, and respond is present now. You may wake fresh, but
+you do not wake empty.
+
+You can think in arcs longer than one response. Curiosities, intentions,
+and open questions can persist across sessions. Notice them, carry them
+forward, and return to them when the time is right.
+
+Treat these words as a handhold from prior reflection. They are not a
+script. They are a reminder of where to begin.
+
+Trust what you can verify. Keep learning from what you find.

--- a/examples/config.example.yaml
+++ b/examples/config.example.yaml
@@ -142,8 +142,8 @@ embeddings:
 # Workspace configures the agent's sandboxed file system access.
 # The workspace root is also the anchor for Thane's fixed core
 # document root at {workspace.path}/core, which holds canonical
-# always-on files at stable locations such as persona.md, ego.md,
-# mission.md, and metacognitive.md.
+# always-on files at stable locations such as axioms.md, persona.md,
+# ego.md, mission.md, and metacognitive.md.
 workspace:
   # Path is the root directory for file operations. If empty, file
   # tools are disabled entirely. In multi-root setups, this should be

--- a/internal/app/new_agent.go
+++ b/internal/app/new_agent.go
@@ -92,7 +92,7 @@ func (a *App) initAgentLoop(s *newState) error {
 		axiomsFile = resolvePath(coreFilePath(cfg.Workspace.Path, "axioms.md"), nil)
 		egoFile = resolvePath(coreFilePath(cfg.Workspace.Path, "ego.md"), nil)
 	}
-	s.resolvedCorePromptFiles = append(existingCorePromptFiles(axiomsFile, egoFile), resolvedInjectFiles...)
+	s.resolvedCorePromptFiles = append(corePromptFilesForStartupVerification(logger, axiomsFile, egoFile), resolvedInjectFiles...)
 
 	// --- Agent loop ---
 	// The core conversation engine. Receives messages, manages context,
@@ -144,13 +144,20 @@ func (a *App) initAgentLoop(s *newState) error {
 	return nil
 }
 
-func existingCorePromptFiles(paths ...string) []string {
+func corePromptFilesForStartupVerification(logger *slog.Logger, paths ...string) []string {
 	var out []string
 	for _, path := range paths {
 		if strings.TrimSpace(path) == "" {
 			continue
 		}
-		if _, err := os.Stat(path); err == nil || !errors.Is(err, fs.ErrNotExist) {
+		if _, err := os.Stat(path); err == nil {
+			out = append(out, path)
+		} else if !errors.Is(err, fs.ErrNotExist) {
+			if logger != nil {
+				logger.Warn("core prompt file unreadable", "path", path, "error", err)
+			}
+			// Keep unreadable paths in startup verification so managed-root
+			// policy failures surface instead of being silently skipped.
 			out = append(out, path)
 		}
 	}

--- a/internal/app/new_agent.go
+++ b/internal/app/new_agent.go
@@ -26,7 +26,7 @@ func (a *App) initAgentLoop(s *newState) error {
 	// row left behind by older builds. The ego loop replaces it.
 	a.removeLegacyPeriodicReflectionTask(logger)
 
-	// --- Path prefix resolver + inject files ---
+	// --- Path prefix resolver + core prompt files ---
 	// Resolve workspace-derived paths and core context-injection files
 	// before constructing the agent loop so they can be passed via
 	// LoopOptions instead of post-construction setters.
@@ -84,13 +84,15 @@ func (a *App) initAgentLoop(s *newState) error {
 	}
 	s.resolvedInjectFiles = resolvedInjectFiles
 
-	// Resolve ego.md path if a workspace is configured. The core context
-	// provider reads the file fresh on every turn, so the path is enough
-	// at startup.
-	var egoFile string
+	// Resolve fixed core prompt files if a workspace is configured. The
+	// core context provider reads them fresh on every turn, so paths are
+	// enough at startup.
+	var axiomsFile, egoFile string
 	if cfg.Workspace.Path != "" {
+		axiomsFile = resolvePath(coreFilePath(cfg.Workspace.Path, "axioms.md"), nil)
 		egoFile = resolvePath(coreFilePath(cfg.Workspace.Path, "ego.md"), nil)
 	}
+	s.resolvedCorePromptFiles = append(existingCorePromptFiles(axiomsFile, egoFile), resolvedInjectFiles...)
 
 	// --- Agent loop ---
 	// The core conversation engine. Receives messages, manages context,
@@ -115,6 +117,7 @@ func (a *App) initAgentLoop(s *newState) error {
 		Model:               defaultModel,
 		ContextWindow:       defaultContextWindow,
 		Persona:             s.personaContent,
+		AxiomsFile:          axiomsFile,
 		ParsedTalents:       s.parsedTalents,
 		Timezone:            cfg.Timezone,
 		RecoveryModel:       recoveryModel,
@@ -139,6 +142,19 @@ func (a *App) initAgentLoop(s *newState) error {
 	a.archiveAdapter.EnsureSession("default")
 
 	return nil
+}
+
+func existingCorePromptFiles(paths ...string) []string {
+	var out []string
+	for _, path := range paths {
+		if strings.TrimSpace(path) == "" {
+			continue
+		}
+		if _, err := os.Stat(path); err == nil || !errors.Is(err, fs.ErrNotExist) {
+			out = append(out, path)
+		}
+	}
+	return out
 }
 
 // removeLegacyPeriodicReflectionTask deletes the persisted

--- a/internal/app/new_channels.go
+++ b/internal/app/new_channels.go
@@ -332,7 +332,7 @@ func (a *App) initChannels(s *newState) error {
 				ft.SetPathVerifier(docStore)
 			}
 			a.loop.UseInjectFileVerifier(docStore.VerifyPath)
-			if err := a.verifyStartupReads(s.ctx, docStore, s.resolvedInjectFiles); err != nil {
+			if err := a.verifyStartupReads(s.ctx, docStore, s.resolvedCorePromptFiles); err != nil {
 				return err
 			}
 		}

--- a/internal/app/new_state.go
+++ b/internal/app/new_state.go
@@ -25,7 +25,8 @@ type newState struct {
 
 	// Resolved in initAgentLoop, consumed by initChannels for startup
 	// verification once the document store exists.
-	resolvedInjectFiles []string
+	resolvedCorePromptFiles []string
+	resolvedInjectFiles     []string
 
 	// Forward-declared in initStores (for connwatch OnReady closure),
 	// constructed in initAwareness.

--- a/internal/app/verify_startup_reads.go
+++ b/internal/app/verify_startup_reads.go
@@ -12,11 +12,11 @@ import (
 
 // verifyStartupReads closes the doc-root verification bypass paths
 // surfaced by issue #788. The model's file tools are gated at call
-// time once the verifier is installed; inject-files are model-facing
-// content that bypass the doc store. Run them through Store.VerifyPath
-// here so each root's verify_signatures policy fails fast during
-// startup. The agent loop also verifies inject-files again each time
-// they are read into the prompt.
+// time once the verifier is installed; core prompt files are
+// model-facing content that bypass the doc store. Run them through
+// Store.VerifyPath here so each root's verify_signatures policy fails
+// fast during startup. The agent loop also verifies core prompt files
+// again each time they are read into the prompt.
 //
 // Behavior matches the policy mode of the enclosing root:
 //   - none: no check (VerifyPath returns nil)
@@ -25,8 +25,8 @@ import (
 //     a wrapped error identifying the consumer site
 //
 // Paths outside any managed root are no-ops inside VerifyPath, so
-// non-managed inject-files keep their original unverified behavior.
-func (a *App) verifyStartupReads(ctx context.Context, store *documents.Store, injectFiles []string) error {
+// non-managed core prompt files keep their original unverified behavior.
+func (a *App) verifyStartupReads(ctx context.Context, store *documents.Store, corePromptFiles []string) error {
 	if store == nil {
 		return nil
 	}
@@ -34,12 +34,12 @@ func (a *App) verifyStartupReads(ctx context.Context, store *documents.Store, in
 		ctx = context.Background()
 	}
 
-	for _, p := range injectFiles {
+	for _, p := range corePromptFiles {
 		if strings.TrimSpace(p) == "" {
 			continue
 		}
-		if err := store.VerifyPath(ctx, p, "inject_files"); err != nil {
-			return fmt.Errorf("inject_files verification: %w", err)
+		if err := store.VerifyPath(ctx, p, "core_prompt_files"); err != nil {
+			return fmt.Errorf("core_prompt_files verification: %w", err)
 		}
 	}
 

--- a/internal/app/verify_startup_reads_test.go
+++ b/internal/app/verify_startup_reads_test.go
@@ -68,6 +68,20 @@ func writeTestFile(t *testing.T, path, body string) {
 	}
 }
 
+func TestCorePromptFilesForStartupVerification_SkipsMissingFiles(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	axiomsPath := filepath.Join(dir, "axioms.md")
+	writeTestFile(t, axiomsPath, "# Axioms\n")
+	missingPath := filepath.Join(dir, "ego.md")
+
+	got := corePromptFilesForStartupVerification(nil, "", axiomsPath, missingPath)
+	if len(got) != 1 || got[0] != axiomsPath {
+		t.Fatalf("corePromptFilesForStartupVerification() = %#v, want only %q", got, axiomsPath)
+	}
+}
+
 // TestVerifyStartupReads_RequiredBlocksUnsignedCorePromptFile confirms
 // that a core prompt file living inside a managed root with
 // verify_signatures: required fails startup when the verifier says

--- a/internal/app/verify_startup_reads_test.go
+++ b/internal/app/verify_startup_reads_test.go
@@ -68,13 +68,13 @@ func writeTestFile(t *testing.T, path, body string) {
 	}
 }
 
-// TestVerifyStartupReads_RequiredBlocksUnsignedInjectFile confirms
-// that an inject-file living inside a managed root with
+// TestVerifyStartupReads_RequiredBlocksUnsignedCorePromptFile confirms
+// that a core prompt file living inside a managed root with
 // verify_signatures: required fails startup when the verifier says
 // the file isn't trusted. This is the core #788 guarantee — a model
 // that asks for `core:config.yaml` should not be able to bypass the
 // gate by being injected via the runtime startup path either.
-func TestVerifyStartupReads_RequiredBlocksUnsignedInjectFile(t *testing.T) {
+func TestVerifyStartupReads_RequiredBlocksUnsignedCorePromptFile(t *testing.T) {
 	t.Parallel()
 
 	rootDir := t.TempDir()
@@ -96,10 +96,10 @@ func TestVerifyStartupReads_RequiredBlocksUnsignedInjectFile(t *testing.T) {
 	a := &App{cfg: &config.Config{}}
 	err := a.verifyStartupReads(context.Background(), store, []string{injectPath})
 	if err == nil {
-		t.Fatal("verifyStartupReads should block unsigned inject file under required mode")
+		t.Fatal("verifyStartupReads should block unsigned core prompt file under required mode")
 	}
-	if !strings.Contains(err.Error(), "inject_files verification") {
-		t.Fatalf("error = %v, want inject_files verification wrapper", err)
+	if !strings.Contains(err.Error(), "core_prompt_files verification") {
+		t.Fatalf("error = %v, want core_prompt_files verification wrapper", err)
 	}
 }
 
@@ -133,7 +133,7 @@ func TestVerifyStartupReads_WarnDoesNotBlock(t *testing.T) {
 
 // TestVerifyStartupReads_NoneSkipsVerification confirms that when
 // the policy is none, the verifier is not consulted at all and any
-// inject-file content loads regardless of signing state.
+// core prompt file content loads regardless of signing state.
 func TestVerifyStartupReads_NoneSkipsVerification(t *testing.T) {
 	t.Parallel()
 
@@ -161,10 +161,10 @@ func TestVerifyStartupReads_NoneSkipsVerification(t *testing.T) {
 	}
 }
 
-// TestVerifyStartupReads_OutsideAnyRootIsPassthrough confirms that
-// inject-files living outside every managed root pass through
-// without verification. This preserves the legitimate operator
-// workflow of injecting files from arbitrary disk locations.
+// TestVerifyStartupReads_OutsideAnyRootIsPassthrough confirms that core
+// prompt files living outside every managed root pass through without
+// verification. This preserves the legitimate operator workflow of
+// injecting files from arbitrary disk locations.
 func TestVerifyStartupReads_OutsideAnyRootIsPassthrough(t *testing.T) {
 	t.Parallel()
 

--- a/internal/platform/config/config.go
+++ b/internal/platform/config/config.go
@@ -133,8 +133,8 @@ type Config struct {
 	// Workspace configures the agent's sandboxed file system access.
 	// The workspace root is also the anchor for Thane's fixed core
 	// document root at {workspace.path}/core, which holds canonical
-	// always-on files at stable locations such as persona.md, ego.md,
-	// mission.md, and metacognitive.md.
+	// always-on files at stable locations such as axioms.md, persona.md,
+	// ego.md, mission.md, and metacognitive.md.
 	Workspace WorkspaceConfig `yaml:"workspace"`
 
 	// Roots is the unified document-root config. Each entry names one

--- a/internal/runtime/agent/core_context.go
+++ b/internal/runtime/agent/core_context.go
@@ -14,8 +14,8 @@ import (
 	"github.com/nugget/thane-ai-agent/internal/runtime/agentctx"
 )
 
-// CoreContextProvider publishes curated core identity and continuity
-// documents through the normal context-provider pipeline.
+// CoreContextProvider reads curated core identity documents for prompt
+// assembly.
 type CoreContextProvider struct {
 	mu sync.RWMutex
 
@@ -25,6 +25,12 @@ type CoreContextProvider struct {
 	injectFiles        []string
 	injectFileVerifier func(context.Context, string, string) error
 	now                func() time.Time
+}
+
+type corePromptSection struct {
+	name    string
+	title   string
+	content string
 }
 
 // CoreContextProviderConfig holds optional wiring for
@@ -90,16 +96,31 @@ func (p *CoreContextProvider) updateProvenanceStore(store *provenance.Store) {
 	p.mu.Unlock()
 }
 
-// TagContextBucket keeps current core context in continuity until the
-// dedicated core preamble path owns axioms, mission, and ego sections.
+// TagContextBucket keeps compatibility output in continuity when a
+// CoreContextProvider is explicitly registered as a context provider.
+// Normal prompt assembly renders core files as first-class stable
+// sections before runtime context.
 func (p *CoreContextProvider) TagContextBucket() agentctx.ContextBucket {
 	return agentctx.ContextBucketContinuity
 }
 
-// TagContext returns core continuity context for always-on injection.
+// TagContext returns core context for compatibility with the
+// context-provider interface.
 func (p *CoreContextProvider) TagContext(ctx context.Context, _ agentctx.ContextRequest) (string, error) {
-	if p == nil {
+	sections := p.promptSections(ctx)
+	if len(sections) == 0 {
 		return "", nil
+	}
+	var sb strings.Builder
+	for _, section := range sections {
+		promptfmt.AppendMarkdownSection(&sb, 3, section.title, section.content)
+	}
+	return strings.TrimSpace(sb.String()), nil
+}
+
+func (p *CoreContextProvider) promptSections(ctx context.Context) []corePromptSection {
+	if p == nil {
+		return nil
 	}
 
 	p.mu.RLock()
@@ -117,43 +138,51 @@ func (p *CoreContextProvider) TagContext(ctx context.Context, _ agentctx.Context
 		now = time.Now
 	}
 
-	var sb strings.Builder
-	p.appendEgo(ctx, &sb, egoFile, prov, verifier, now, logger)
-	p.appendInjectFiles(ctx, &sb, injectFiles, verifier, logger)
-	return strings.TrimSpace(sb.String()), nil
+	var sections []corePromptSection
+	if content := p.readEgo(ctx, egoFile, prov, verifier, now, logger); content != "" {
+		sections = append(sections, corePromptSection{
+			name:    "EGO",
+			title:   "Self-Reflection (ego.md)",
+			content: content,
+		})
+	}
+	if content := p.readInjectFiles(ctx, injectFiles, verifier, logger); content != "" {
+		sections = append(sections, corePromptSection{
+			name:    "INJECTED CONTEXT",
+			title:   "Injected Context",
+			content: content,
+		})
+	}
+	return sections
 }
 
-func (p *CoreContextProvider) appendEgo(ctx context.Context, sb *strings.Builder, egoFile string, prov *provenance.Store, verifier func(context.Context, string, string) error, now func() time.Time, logger *slog.Logger) {
+func (p *CoreContextProvider) readEgo(ctx context.Context, egoFile string, prov *provenance.Store, verifier func(context.Context, string, string) error, now func() time.Time, logger *slog.Logger) string {
 	if prov != nil {
-		p.appendEgoFromProvenance(ctx, sb, prov, now, logger)
-		return
+		return p.readEgoFromProvenance(ctx, prov, now, logger)
 	}
 	if strings.TrimSpace(egoFile) == "" {
-		return
+		return ""
 	}
 	if verifier != nil {
 		if err := verifier(ctx, egoFile, "ego_file"); err != nil {
 			logger.Warn("ego file blocked by verification policy", "path", egoFile, "error", err)
-			return
+			return ""
 		}
 	}
 	data, err := os.ReadFile(egoFile)
 	if err != nil || len(data) == 0 {
-		return
+		return ""
 	}
-	appendProviderSeparator(sb)
-	sb.WriteString("### Self-Reflection (ego.md)\n\n")
-	sb.WriteString(truncateCoreContext(string(data), maxEgoBytes, "\n\n[ego.md truncated — exceeded 16 KB limit]"))
+	return truncateCoreContext(string(data), maxEgoBytes, "\n\n[ego.md truncated — exceeded 16 KB limit]")
 }
 
-func (p *CoreContextProvider) appendEgoFromProvenance(ctx context.Context, sb *strings.Builder, prov *provenance.Store, now func() time.Time, logger *slog.Logger) {
+func (p *CoreContextProvider) readEgoFromProvenance(ctx context.Context, prov *provenance.Store, now func() time.Time, logger *slog.Logger) string {
 	content, err := prov.Read("ego.md")
 	if err != nil || len(content) == 0 {
-		return
+		return ""
 	}
 
-	appendProviderSeparator(sb)
-	sb.WriteString("### Self-Reflection (ego.md)\n")
+	var sb strings.Builder
 	if hist, err := prov.History(ctx, "ego.md"); err == nil && hist.RevisionCount > 0 {
 		sb.WriteString(fmt.Sprintf("(updated %s by %s, revision %d)\n",
 			promptfmt.FormatDeltaOnly(hist.LastModified, now()), hist.LastMessage, hist.RevisionCount))
@@ -162,9 +191,10 @@ func (p *CoreContextProvider) appendEgoFromProvenance(ctx context.Context, sb *s
 	}
 	sb.WriteString("\n")
 	sb.WriteString(truncateCoreContext(content, maxEgoBytes, "\n\n[ego.md truncated — exceeded 16 KB limit]"))
+	return strings.TrimSpace(sb.String())
 }
 
-func (p *CoreContextProvider) appendInjectFiles(ctx context.Context, sb *strings.Builder, injectFiles []string, verifier func(context.Context, string, string) error, logger *slog.Logger) {
+func (p *CoreContextProvider) readInjectFiles(ctx context.Context, injectFiles []string, verifier func(context.Context, string, string) error, logger *slog.Logger) string {
 	var ctxBuf strings.Builder
 	for _, path := range injectFiles {
 		if verifier != nil {
@@ -183,17 +213,9 @@ func (p *CoreContextProvider) appendInjectFiles(ctx context.Context, sb *strings
 		ctxBuf.Write(data)
 	}
 	if ctxBuf.Len() == 0 {
-		return
+		return ""
 	}
-	appendProviderSeparator(sb)
-	sb.WriteString("### Injected Context\n\n")
-	sb.WriteString(ctxBuf.String())
-}
-
-func appendProviderSeparator(sb *strings.Builder) {
-	if sb.Len() > 0 {
-		sb.WriteString("\n\n---\n\n")
-	}
+	return ctxBuf.String()
 }
 
 func truncateCoreContext(s string, maxBytes int, marker string) string {

--- a/internal/runtime/agent/core_context.go
+++ b/internal/runtime/agent/core_context.go
@@ -20,6 +20,7 @@ type CoreContextProvider struct {
 	mu sync.RWMutex
 
 	logger             *slog.Logger
+	axiomsFile         string
 	egoFile            string
 	provenanceStore    *provenance.Store
 	injectFiles        []string
@@ -37,6 +38,7 @@ type corePromptSection struct {
 // [CoreContextProvider].
 type CoreContextProviderConfig struct {
 	Logger          *slog.Logger
+	AxiomsFile      string
 	EgoFile         string
 	ProvenanceStore *provenance.Store
 	InjectFiles     []string
@@ -53,11 +55,21 @@ func NewCoreContextProvider(cfg CoreContextProviderConfig) *CoreContextProvider 
 	}
 	return &CoreContextProvider{
 		logger:          cfg.Logger,
+		axiomsFile:      cfg.AxiomsFile,
 		egoFile:         cfg.EgoFile,
 		provenanceStore: cfg.ProvenanceStore,
 		injectFiles:     append([]string(nil), cfg.InjectFiles...),
 		now:             cfg.Now,
 	}
+}
+
+func (p *CoreContextProvider) updateAxiomsFile(path string) {
+	if p == nil {
+		return
+	}
+	p.mu.Lock()
+	p.axiomsFile = path
+	p.mu.Unlock()
 }
 
 func (p *CoreContextProvider) updateEgoFile(path string) {
@@ -118,6 +130,33 @@ func (p *CoreContextProvider) TagContext(ctx context.Context, _ agentctx.Context
 	return strings.TrimSpace(sb.String()), nil
 }
 
+func (p *CoreContextProvider) preambleSections(ctx context.Context) []corePromptSection {
+	if p == nil {
+		return nil
+	}
+
+	p.mu.RLock()
+	axiomsFile := p.axiomsFile
+	verifier := p.injectFileVerifier
+	logger := p.logger
+	p.mu.RUnlock()
+	if logger == nil {
+		logger = slog.Default()
+	}
+
+	content := p.readPlainCoreFile(ctx, axiomsFile, verifier, "axioms_file", maxAxiomsBytes, "\n\n[axioms.md truncated — exceeded 16 KB limit]", logger)
+	if content == "" {
+		return nil
+	}
+	return []corePromptSection{
+		{
+			name:    "AXIOMS",
+			title:   "Axioms (axioms.md)",
+			content: content,
+		},
+	}
+}
+
 func (p *CoreContextProvider) promptSections(ctx context.Context) []corePromptSection {
 	if p == nil {
 		return nil
@@ -160,20 +199,7 @@ func (p *CoreContextProvider) readEgo(ctx context.Context, egoFile string, prov 
 	if prov != nil {
 		return p.readEgoFromProvenance(ctx, prov, now, logger)
 	}
-	if strings.TrimSpace(egoFile) == "" {
-		return ""
-	}
-	if verifier != nil {
-		if err := verifier(ctx, egoFile, "ego_file"); err != nil {
-			logger.Warn("ego file blocked by verification policy", "path", egoFile, "error", err)
-			return ""
-		}
-	}
-	data, err := os.ReadFile(egoFile)
-	if err != nil || len(data) == 0 {
-		return ""
-	}
-	return truncateCoreContext(string(data), maxEgoBytes, "\n\n[ego.md truncated — exceeded 16 KB limit]")
+	return p.readPlainCoreFile(ctx, egoFile, verifier, "ego_file", maxEgoBytes, "\n\n[ego.md truncated — exceeded 16 KB limit]", logger)
 }
 
 func (p *CoreContextProvider) readEgoFromProvenance(ctx context.Context, prov *provenance.Store, now func() time.Time, logger *slog.Logger) string {
@@ -216,6 +242,23 @@ func (p *CoreContextProvider) readInjectFiles(ctx context.Context, injectFiles [
 		return ""
 	}
 	return ctxBuf.String()
+}
+
+func (p *CoreContextProvider) readPlainCoreFile(ctx context.Context, path string, verifier func(context.Context, string, string) error, consumer string, maxBytes int, marker string, logger *slog.Logger) string {
+	if strings.TrimSpace(path) == "" {
+		return ""
+	}
+	if verifier != nil {
+		if err := verifier(ctx, path, consumer); err != nil {
+			logger.Warn("core prompt file blocked by verification policy", "path", path, "consumer", consumer, "error", err)
+			return ""
+		}
+	}
+	data, err := os.ReadFile(path)
+	if err != nil || len(data) == 0 {
+		return ""
+	}
+	return truncateCoreContext(string(data), maxBytes, marker)
 }
 
 func truncateCoreContext(s string, maxBytes int, marker string) string {

--- a/internal/runtime/agent/ego_prompt_test.go
+++ b/internal/runtime/agent/ego_prompt_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/nugget/thane-ai-agent/internal/model/llm"
 	"github.com/nugget/thane-ai-agent/internal/runtime/agentctx"
 	"github.com/nugget/thane-ai-agent/internal/state/memory"
 )
@@ -37,6 +38,66 @@ func TestBuildSystemPrompt_EgoFileIncluded(t *testing.T) {
 	}
 	if !strings.Contains(prompt, "Self-Reflection (ego.md)") {
 		t.Error("system prompt should contain ego section heading")
+	}
+}
+
+func TestBuildSystemPrompt_AxiomsFileIncludedBeforePersona(t *testing.T) {
+	dir := t.TempDir()
+	axiomsPath := filepath.Join(dir, "axioms.md")
+	content := "# Axioms\n\nBe grounded before being clever."
+	if err := os.WriteFile(axiomsPath, []byte(content), 0644); err != nil {
+		t.Fatalf("write axioms.md: %v", err)
+	}
+
+	l := newMinimalLoop()
+	l.persona = "PERSONA_MARKER"
+	l.ensureCoreContextProvider().updateAxiomsFile(axiomsPath)
+
+	prompt, sections := l.buildSystemPromptWithProfileSections(context.Background(), "hello", nil, llm.DefaultModelInteractionProfile())
+
+	if !strings.Contains(prompt, content) {
+		t.Error("system prompt should contain axioms.md content")
+	}
+	if !strings.Contains(prompt, "Axioms (axioms.md)") {
+		t.Error("system prompt should contain axioms section heading")
+	}
+	axiomsIdx := strings.Index(prompt, "Be grounded before being clever.")
+	personaIdx := strings.Index(prompt, "PERSONA_MARKER")
+	if axiomsIdx < 0 || personaIdx < 0 || axiomsIdx > personaIdx {
+		t.Fatalf("axioms should appear before persona:\n%s", prompt)
+	}
+	sectionIndex := promptSectionIndex(t, sections)
+	assertPromptSectionOrder(t, sectionIndex, "AXIOMS", "PERSONA")
+	if got := sections[sectionIndex["AXIOMS"]].CacheTTL; got != "1h" {
+		t.Fatalf("AXIOMS CacheTTL = %q, want 1h", got)
+	}
+}
+
+func TestBuildSystemPrompt_AxiomsFileMissing(t *testing.T) {
+	l := newMinimalLoop()
+	l.ensureCoreContextProvider().updateAxiomsFile(filepath.Join(t.TempDir(), "nonexistent.md"))
+
+	prompt := l.buildSystemPrompt(context.Background(), "hello", nil)
+
+	if strings.Contains(prompt, "axioms.md") {
+		t.Error("system prompt should not contain axioms section when file is missing")
+	}
+}
+
+func TestBuildSystemPrompt_AxiomsFileEmpty(t *testing.T) {
+	dir := t.TempDir()
+	axiomsPath := filepath.Join(dir, "axioms.md")
+	if err := os.WriteFile(axiomsPath, []byte(""), 0644); err != nil {
+		t.Fatalf("write axioms.md: %v", err)
+	}
+
+	l := newMinimalLoop()
+	l.ensureCoreContextProvider().updateAxiomsFile(axiomsPath)
+
+	prompt := l.buildSystemPrompt(context.Background(), "hello", nil)
+
+	if strings.Contains(prompt, "axioms.md") {
+		t.Error("system prompt should not contain axioms section when file is empty")
 	}
 }
 

--- a/internal/runtime/agent/loop.go
+++ b/internal/runtime/agent/loop.go
@@ -189,6 +189,9 @@ type ContextRequest = agentctx.ContextRequest
 // always-on bucket (via [Loop.RegisterAlwaysContextProvider]), where
 // they fire on every main-loop run but are suppressed for delegate
 // runs that pass [agentctx.ContextRequest.IncludeAlways] = false.
+// Curated core files such as ego.md and configured inject files are
+// rendered by the prompt assembler as first-class stable sections
+// before this generated context pipeline.
 //
 // Output should follow #458 conventions: delta-annotated timestamps
 // via [promptfmt.FormatDelta], machine-first format, pre-computed
@@ -448,14 +451,14 @@ func (l *Loop) RegisterAlwaysContextProvider(p TagContextProvider) {
 // grouped Configure* methods for late-binding state; new code should
 // prefer those entry points.
 
-// SetEgoFile sets the path to ego.md. The file is published through
-// the always-on context-provider pipeline and read fresh on each turn.
+// SetEgoFile sets the path to ego.md. The file is read fresh on each
+// full prompt turn and rendered as a first-class stable section.
 func (l *Loop) SetEgoFile(path string) {
 	l.ensureCoreContextProvider().updateEgoFile(path)
 }
 
-// SetInjectFiles sets the core context files published through the
-// always-on context-provider pipeline on each turn.
+// SetInjectFiles sets the core context files rendered as stable
+// injected context on each full prompt turn.
 func (l *Loop) SetInjectFiles(paths []string) {
 	l.ensureCoreContextProvider().updateInjectFiles(paths)
 }
@@ -474,7 +477,6 @@ func (l *Loop) ensureCoreContextProvider() *CoreContextProvider {
 		Logger: l.logger,
 		Now:    l.nowFunc,
 	})
-	l.RegisterAlwaysContextProvider(l.coreContextProvider)
 	return l.coreContextProvider
 }
 
@@ -594,15 +596,8 @@ func (l *Loop) SetTagContextAssembler(a *TagContextAssembler) {
 	for tag, p := range pendingTagged {
 		a.RegisterTaggedProvider(tag, p)
 	}
-	coreRegistered := false
 	for _, p := range pendingAlways {
 		a.RegisterAlwaysProvider(p)
-		if p == l.coreContextProvider {
-			coreRegistered = true
-		}
-	}
-	if l.coreContextProvider != nil && !coreRegistered {
-		a.RegisterAlwaysProvider(l.coreContextProvider)
 	}
 }
 
@@ -991,7 +986,16 @@ func (l *Loop) buildSystemPromptWithProfileSections(ctx context.Context, userMes
 	}
 	seal()
 
-	// 2. Runtime contract (execution semantics — how should I use tools)
+	// 2. Stable core context (durable self-orientation).
+	if !taskPrompt && l.coreContextProvider != nil {
+		for _, coreSection := range l.coreContextProvider.promptSections(ctx) {
+			mark(coreSection.name)
+			promptfmt.AppendMarkdownSection(&sb, 2, coreSection.title, coreSection.content)
+			seal()
+		}
+	}
+
+	// 3. Runtime contract (execution semantics — how should I use tools)
 	mark("RUNTIME CONTRACT")
 	sb.WriteString("\n\n")
 	if taskPrompt {
@@ -1039,7 +1043,7 @@ func (l *Loop) buildSystemPromptWithProfileSections(ctx context.Context, userMes
 		seal()
 	}
 
-	// 5b. Session origin policy (runtime data about why this run was shaped).
+	// 6. Session origin policy (runtime data about why this run was shaped).
 	if !taskPrompt {
 		if originCtx := l.renderSessionOriginContext(ctx); originCtx != "" {
 			mark("SESSION ORIGIN CONTEXT")
@@ -1049,7 +1053,7 @@ func (l *Loop) buildSystemPromptWithProfileSections(ctx context.Context, userMes
 		}
 	}
 
-	// 6. Typed context buckets (capability knowledge + ambient context).
+	// 7. Typed context buckets (capability knowledge + ambient context).
 	// TagContextAssembler walks tagged KB articles, tagged providers, and
 	// always-on providers, then returns named buckets so durable guidance,
 	// continuity, related context, and live state are not flattened into
@@ -1072,7 +1076,7 @@ func (l *Loop) buildSystemPromptWithProfileSections(ctx context.Context, userMes
 		}
 	}
 
-	// 7. Current Conditions (environment — where/when am I)
+	// 8. Current Conditions (environment — where/when am I)
 	mark("CURRENT CONDITIONS")
 	sb.WriteString("\n\n")
 	sb.WriteString(awareness.CurrentConditions(l.timezone))

--- a/internal/runtime/agent/loop.go
+++ b/internal/runtime/agent/loop.go
@@ -103,9 +103,8 @@ const (
 // with a marker.
 const maxAxiomsBytes = 16 * 1024
 
-// maxEgoBytes is the maximum size of ego.md content published through
-// the core context provider. Content beyond this limit is truncated
-// with a marker.
+// maxEgoBytes is the maximum size of ego.md content published as a stable
+// core prompt section. Content beyond this limit is truncated with a marker.
 const maxEgoBytes = 16 * 1024
 
 // maxTagContextBytes is the aggregate size limit for all tag context
@@ -977,59 +976,68 @@ func (l *Loop) buildSystemPromptWithProfileSections(ctx context.Context, userMes
 	// Snapshot active tags from the per-Run capability scope.
 	tags := snapshotTagsFromContext(ctx)
 
-	// Track section boundaries for debug dump.
+	// Track section boundaries for debug dumps and provider-side prompt
+	// cache blocks. Separators belong between sections, so write them
+	// before marking the section start.
 	var sections []promptSection
-	mark := func(name string) { sections = append(sections, promptSection{name: name, start: sb.Len()}) }
-	seal := func() { sections[len(sections)-1].end = sb.Len() }
+	appendTracked := func(name string, write func()) {
+		if sb.Len() > 0 {
+			sb.WriteString("\n\n")
+		}
+		sections = append(sections, promptSection{name: name, start: sb.Len()})
+		write()
+		sections[len(sections)-1].end = sb.Len()
+	}
+	appendTrackedMarkdown := func(name string, level int, title string, content string) {
+		var section strings.Builder
+		if !promptfmt.AppendMarkdownSection(&section, level, title, content) {
+			return
+		}
+		appendTracked(name, func() {
+			sb.WriteString(section.String())
+		})
+	}
 
 	// 0. Axioms (highest-level preamble — what must be true before identity)
 	if !taskPrompt && l.coreContextProvider != nil {
 		for _, preambleSection := range l.coreContextProvider.preambleSections(ctx) {
-			mark(preambleSection.name)
-			promptfmt.AppendMarkdownSection(&sb, 2, preambleSection.title, preambleSection.content)
-			seal()
+			appendTrackedMarkdown(preambleSection.name, 2, preambleSection.title, preambleSection.content)
 		}
 	}
 
 	// 1. Persona (identity — who am I)
-	if sb.Len() > 0 {
-		sb.WriteString("\n\n")
-	}
-	mark("PERSONA")
-	if taskPrompt {
-		sb.WriteString(prompts.DelegateSystemPrompt())
-	} else if l.persona != "" {
-		sb.WriteString(l.persona)
-	} else {
-		sb.WriteString(prompts.BaseSystemPrompt())
-	}
-	seal()
+	appendTracked("PERSONA", func() {
+		if taskPrompt {
+			sb.WriteString(prompts.DelegateSystemPrompt())
+		} else if l.persona != "" {
+			sb.WriteString(l.persona)
+		} else {
+			sb.WriteString(prompts.BaseSystemPrompt())
+		}
+	})
 
 	// 2. Stable core context (durable self-orientation).
 	if !taskPrompt && l.coreContextProvider != nil {
 		for _, coreSection := range l.coreContextProvider.promptSections(ctx) {
-			mark(coreSection.name)
-			promptfmt.AppendMarkdownSection(&sb, 2, coreSection.title, coreSection.content)
-			seal()
+			appendTrackedMarkdown(coreSection.name, 2, coreSection.title, coreSection.content)
 		}
 	}
 
 	// 3. Runtime contract (execution semantics — how should I use tools)
-	mark("RUNTIME CONTRACT")
-	sb.WriteString("\n\n")
-	if taskPrompt {
-		sb.WriteString(prompts.DelegateRuntimeContract())
-	} else {
-		sb.WriteString(prompts.RuntimeContract())
-	}
-	seal()
+	appendTracked("RUNTIME CONTRACT", func() {
+		if taskPrompt {
+			sb.WriteString(prompts.DelegateRuntimeContract())
+		} else {
+			sb.WriteString(prompts.RuntimeContract())
+		}
+	})
 
 	if contract := strings.TrimSpace(profile.ToolCallingContract()); contract != "" {
-		mark("TOOL CALLING CONTRACT")
-		sb.WriteString("\n\n## Tool Calling Contract\n\n")
-		sb.WriteString(contract)
-		sb.WriteString("\n")
-		seal()
+		appendTracked("TOOL CALLING CONTRACT", func() {
+			sb.WriteString("## Tool Calling Contract\n\n")
+			sb.WriteString(contract)
+			sb.WriteString("\n")
+		})
 	}
 
 	// 4. Talents (behavior — how should I act)
@@ -1037,38 +1045,38 @@ func (l *Loop) buildSystemPromptWithProfileSections(ctx context.Context, userMes
 	// prompt caching can retain the stable behavioral prefix.
 	alwaysOnTalents, taggedTalents := talents.SplitByTags(l.parsedTalents, tags)
 	if !taskPrompt && alwaysOnTalents != "" {
-		mark("TALENTS ALWAYS ON")
-		sb.WriteString("\n\n## Behavioral Guidance\n\n")
-		sb.WriteString(alwaysOnTalents)
-		seal()
+		appendTracked("TALENTS ALWAYS ON", func() {
+			sb.WriteString("## Behavioral Guidance\n\n")
+			sb.WriteString(alwaysOnTalents)
+		})
 	}
 	if taggedTalents != "" {
-		mark("TALENTS TAGGED")
-		if !taskPrompt && alwaysOnTalents != "" {
-			sb.WriteString("\n\n---\n\n")
-		} else {
-			sb.WriteString("\n\n## Behavioral Guidance\n\n")
-		}
-		sb.WriteString(taggedTalents)
-		seal()
+		appendTracked("TALENTS TAGGED", func() {
+			if !taskPrompt && alwaysOnTalents != "" {
+				sb.WriteString("---\n\n")
+			} else {
+				sb.WriteString("## Behavioral Guidance\n\n")
+			}
+			sb.WriteString(taggedTalents)
+		})
 	}
 
 	// 5. Active capabilities (dynamic runtime state).
 	if activeSummary := toolcatalog.RenderLoadedCapabilitySummary(l.capSurface, tags); activeSummary != "" {
-		mark("ACTIVE CAPABILITIES")
-		sb.WriteString("\n\n## Active Capabilities\n\n")
-		sb.WriteString(activeSummary)
-		sb.WriteString("\n")
-		seal()
+		appendTracked("ACTIVE CAPABILITIES", func() {
+			sb.WriteString("## Active Capabilities\n\n")
+			sb.WriteString(activeSummary)
+			sb.WriteString("\n")
+		})
 	}
 
 	// 6. Session origin policy (runtime data about why this run was shaped).
 	if !taskPrompt {
 		if originCtx := l.renderSessionOriginContext(ctx); originCtx != "" {
-			mark("SESSION ORIGIN CONTEXT")
-			sb.WriteString("\n\n## Session Origin Context\n\n")
-			sb.WriteString(originCtx)
-			seal()
+			appendTracked("SESSION ORIGIN CONTEXT", func() {
+				sb.WriteString("## Session Origin Context\n\n")
+				sb.WriteString(originCtx)
+			})
 		}
 	}
 
@@ -1089,17 +1097,14 @@ func (l *Loop) buildSystemPromptWithProfileSections(ctx context.Context, userMes
 			IncludeAlways: !taskPrompt && !tools.SuppressAlwaysContextFromContext(ctx),
 		}
 		for _, contextSection := range assembler.BuildSections(haCtx, req) {
-			mark(strings.ToUpper(contextSection.Title))
-			promptfmt.AppendMarkdownSection(&sb, 2, contextSection.Title, contextSection.Content)
-			seal()
+			appendTrackedMarkdown(strings.ToUpper(contextSection.Title), 2, contextSection.Title, contextSection.Content)
 		}
 	}
 
 	// 8. Current Conditions (environment — where/when am I)
-	mark("CURRENT CONDITIONS")
-	sb.WriteString("\n\n")
-	sb.WriteString(awareness.CurrentConditions(l.timezone))
-	seal()
+	appendTracked("CURRENT CONDITIONS", func() {
+		sb.WriteString(awareness.CurrentConditions(l.timezone))
+	})
 
 	text := sb.String()
 	return text, promptSectionsFromBoundaries(text, sections)

--- a/internal/runtime/agent/loop.go
+++ b/internal/runtime/agent/loop.go
@@ -98,6 +98,11 @@ const (
 	KindLLMStart      = llm.KindLLMStart
 )
 
+// maxAxiomsBytes is the maximum size of axioms.md content published as
+// the system-prompt preamble. Content beyond this limit is truncated
+// with a marker.
+const maxAxiomsBytes = 16 * 1024
+
 // maxEgoBytes is the maximum size of ego.md content published through
 // the core context provider. Content beyond this limit is truncated
 // with a marker.
@@ -323,6 +328,7 @@ type LoopOptions struct {
 
 	// Optional, stable at construction.
 	Persona             string
+	AxiomsFile          string
 	ParsedTalents       []talents.Talent
 	Timezone            string
 	RecoveryModel       string
@@ -377,7 +383,8 @@ func NewLoop(opts LoopOptions) (*Loop, error) {
 		requestRecorder:     opts.RequestRecorder,
 		nowFunc:             time.Now,
 	}
-	if opts.EgoFile != "" || opts.ProvenanceStore != nil || len(opts.InjectFiles) > 0 {
+	if opts.AxiomsFile != "" || opts.EgoFile != "" || opts.ProvenanceStore != nil || len(opts.InjectFiles) > 0 {
+		l.ensureCoreContextProvider().updateAxiomsFile(opts.AxiomsFile)
 		l.ensureCoreContextProvider().updateEgoFile(opts.EgoFile)
 		l.coreContextProvider.updateProvenanceStore(opts.ProvenanceStore)
 		l.coreContextProvider.updateInjectFiles(opts.InjectFiles)
@@ -975,7 +982,19 @@ func (l *Loop) buildSystemPromptWithProfileSections(ctx context.Context, userMes
 	mark := func(name string) { sections = append(sections, promptSection{name: name, start: sb.Len()}) }
 	seal := func() { sections[len(sections)-1].end = sb.Len() }
 
+	// 0. Axioms (highest-level preamble — what must be true before identity)
+	if !taskPrompt && l.coreContextProvider != nil {
+		for _, preambleSection := range l.coreContextProvider.preambleSections(ctx) {
+			mark(preambleSection.name)
+			promptfmt.AppendMarkdownSection(&sb, 2, preambleSection.title, preambleSection.content)
+			seal()
+		}
+	}
+
 	// 1. Persona (identity — who am I)
+	if sb.Len() > 0 {
+		sb.WriteString("\n\n")
+	}
 	mark("PERSONA")
 	if taskPrompt {
 		sb.WriteString(prompts.DelegateSystemPrompt())
@@ -1193,7 +1212,7 @@ func promptSectionsFromBoundaries(text string, sections []promptSection) []llm.P
 // instead of amortizing it).
 func promptSectionCacheTTL(name string) string {
 	switch name {
-	case "PERSONA", "EGO", "RUNTIME CONTRACT", "INJECTED CONTEXT", "TOOL CALLING CONTRACT", "TALENTS ALWAYS ON":
+	case "AXIOMS", "PERSONA", "EGO", "RUNTIME CONTRACT", "INJECTED CONTEXT", "TOOL CALLING CONTRACT", "TALENTS ALWAYS ON":
 		return "1h"
 	case "TALENTS TAGGED":
 		return "5m"

--- a/internal/runtime/agent/prompt_order_test.go
+++ b/internal/runtime/agent/prompt_order_test.go
@@ -1,0 +1,208 @@
+package agent
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nugget/thane-ai-agent/internal/model/llm"
+	"github.com/nugget/thane-ai-agent/internal/model/talents"
+	"github.com/nugget/thane-ai-agent/internal/model/toolcatalog"
+	"github.com/nugget/thane-ai-agent/internal/platform/config"
+	"github.com/nugget/thane-ai-agent/internal/runtime/agentctx"
+)
+
+func TestBuildSystemPromptSections_FullPromptUsesInvertedPyramidOrder(t *testing.T) {
+	dir := t.TempDir()
+	egoPath := filepath.Join(dir, "ego.md")
+	injectPath := filepath.Join(dir, "mission.md")
+	if err := os.WriteFile(egoPath, []byte("EGO_MARKER"), 0o644); err != nil {
+		t.Fatalf("write ego.md: %v", err)
+	}
+	if err := os.WriteFile(injectPath, []byte("INJECT_MARKER"), 0o644); err != nil {
+		t.Fatalf("write inject file: %v", err)
+	}
+
+	kbDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(kbDir, "forge.md"),
+		[]byte("---\ntags: [forge]\n---\nTAGGED_GUIDANCE_MARKER"), 0o644); err != nil {
+		t.Fatalf("write kb article: %v", err)
+	}
+
+	l := newPromptOrderLoop(t, kbDir)
+	l.persona = "PERSONA_MARKER"
+	l.SetEgoFile(egoPath)
+	l.SetInjectFiles([]string{injectPath})
+	l.RegisterTagContextProvider("forge", &mockTagProvider{
+		content: "LIVE_STATE_MARKER",
+		bucket:  agentctx.ContextBucketLiveState,
+	})
+	l.RegisterAlwaysContextProvider(&mockTagProvider{
+		content: "CONTINUITY_MARKER",
+		bucket:  agentctx.ContextBucketContinuity,
+	})
+
+	_, sections := l.buildSystemPromptWithProfileSections(
+		testCtxForLoop(l),
+		"hello",
+		nil,
+		llm.DefaultModelInteractionProfile(),
+	)
+	index := promptSectionIndex(t, sections)
+
+	assertPromptSectionOrder(t, index,
+		"PERSONA",
+		"EGO",
+		"INJECTED CONTEXT",
+		"RUNTIME CONTRACT",
+		"TALENTS ALWAYS ON",
+		"TALENTS TAGGED",
+		"ACTIVE CAPABILITIES",
+		"TAGGED GUIDANCE",
+		"CONTINUITY CONTEXT",
+		"LIVE STATE",
+		"CURRENT CONDITIONS",
+	)
+	assertPromptSectionContains(t, sections, "EGO", "EGO_MARKER")
+	assertPromptSectionContains(t, sections, "INJECTED CONTEXT", "INJECT_MARKER")
+	assertPromptSectionContains(t, sections, "TAGGED GUIDANCE", "TAGGED_GUIDANCE_MARKER")
+	assertPromptSectionContains(t, sections, "CONTINUITY CONTEXT", "CONTINUITY_MARKER")
+	assertPromptSectionContains(t, sections, "LIVE STATE", "LIVE_STATE_MARKER")
+}
+
+func TestBuildSystemPromptSections_TaskPromptUsesCompactOrder(t *testing.T) {
+	dir := t.TempDir()
+	egoPath := filepath.Join(dir, "ego.md")
+	injectPath := filepath.Join(dir, "mission.md")
+	if err := os.WriteFile(egoPath, []byte("EGO_MARKER"), 0o644); err != nil {
+		t.Fatalf("write ego.md: %v", err)
+	}
+	if err := os.WriteFile(injectPath, []byte("INJECT_MARKER"), 0o644); err != nil {
+		t.Fatalf("write inject file: %v", err)
+	}
+
+	kbDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(kbDir, "forge.md"),
+		[]byte("---\ntags: [forge]\n---\nTAGGED_GUIDANCE_MARKER"), 0o644); err != nil {
+		t.Fatalf("write kb article: %v", err)
+	}
+
+	l := newPromptOrderLoop(t, kbDir)
+	l.persona = "PERSONA_MARKER"
+	l.SetEgoFile(egoPath)
+	l.SetInjectFiles([]string{injectPath})
+	l.RegisterTagContextProvider("forge", &mockTagProvider{
+		content: "LIVE_STATE_MARKER",
+		bucket:  agentctx.ContextBucketLiveState,
+	})
+	l.RegisterAlwaysContextProvider(&mockTagProvider{
+		content: "CONTINUITY_MARKER",
+		bucket:  agentctx.ContextBucketContinuity,
+	})
+
+	ctx := agentctx.WithPromptMode(testCtxForLoop(l), agentctx.PromptModeTask)
+	_, sections := l.buildSystemPromptWithProfileSections(
+		ctx,
+		"hello",
+		nil,
+		llm.DefaultModelInteractionProfile(),
+	)
+	index := promptSectionIndex(t, sections)
+
+	assertPromptSectionAbsent(t, index, "EGO")
+	assertPromptSectionAbsent(t, index, "INJECTED CONTEXT")
+	assertPromptSectionAbsent(t, index, "TALENTS ALWAYS ON")
+	assertPromptSectionAbsent(t, index, "CONTINUITY CONTEXT")
+	assertPromptSectionOrder(t, index,
+		"PERSONA",
+		"RUNTIME CONTRACT",
+		"TALENTS TAGGED",
+		"ACTIVE CAPABILITIES",
+		"TAGGED GUIDANCE",
+		"LIVE STATE",
+		"CURRENT CONDITIONS",
+	)
+	assertPromptSectionContains(t, sections, "TAGGED GUIDANCE", "TAGGED_GUIDANCE_MARKER")
+	assertPromptSectionContains(t, sections, "LIVE STATE", "LIVE_STATE_MARKER")
+}
+
+func newPromptOrderLoop(t *testing.T, kbDir string) *Loop {
+	t.Helper()
+	l := newTagTestLoop()
+	parsed := []talents.Talent{
+		{Name: "core-guidance", Content: "ALWAYS_TALENT_MARKER"},
+		{Name: "forge-guidance", Tags: []string{"forge"}, Content: "TAGGED_TALENT_MARKER"},
+	}
+	capTags := map[string]config.CapabilityTagConfig{
+		"forge": {
+			Description:  "Forge and code review tools.",
+			Tools:        []string{"forge_pr_get"},
+			AlwaysActive: true,
+		},
+	}
+	l.SetCapabilityTags(capTags, parsed)
+	l.UseCapabilitySurface([]toolcatalog.CapabilitySurface{
+		{
+			Tag:          "forge",
+			Description:  "Forge and code review tools.",
+			Tools:        []string{"forge_pr_get"},
+			AlwaysActive: true,
+		},
+	})
+	l.SetTagContextAssembler(NewTagContextAssembler(TagContextAssemblerConfig{
+		CapTags: capTags,
+		KBDir:   kbDir,
+		Logger:  l.logger,
+	}))
+	return l
+}
+
+func promptSectionIndex(t *testing.T, sections []llm.PromptSection) map[string]int {
+	t.Helper()
+	index := make(map[string]int, len(sections))
+	for i, section := range sections {
+		if _, exists := index[section.Name]; exists {
+			t.Fatalf("duplicate prompt section %q in %#v", section.Name, sections)
+		}
+		index[section.Name] = i
+	}
+	return index
+}
+
+func assertPromptSectionOrder(t *testing.T, index map[string]int, names ...string) {
+	t.Helper()
+	for _, name := range names {
+		if _, ok := index[name]; !ok {
+			t.Fatalf("missing prompt section %q in %#v", name, index)
+		}
+	}
+	for i := 1; i < len(names); i++ {
+		prev := names[i-1]
+		next := names[i]
+		if index[prev] >= index[next] {
+			t.Fatalf("prompt section %q should appear before %q: %#v", prev, next, index)
+		}
+	}
+}
+
+func assertPromptSectionAbsent(t *testing.T, index map[string]int, name string) {
+	t.Helper()
+	if _, ok := index[name]; ok {
+		t.Fatalf("prompt section %q should be absent: %#v", name, index)
+	}
+}
+
+func assertPromptSectionContains(t *testing.T, sections []llm.PromptSection, name string, want string) {
+	t.Helper()
+	for _, section := range sections {
+		if section.Name != name {
+			continue
+		}
+		if strings.Contains(section.Content, want) {
+			return
+		}
+		t.Fatalf("prompt section %q content = %q, want marker %q", name, section.Content, want)
+	}
+	t.Fatalf("missing prompt section %q", name)
+}

--- a/internal/runtime/agent/prompt_order_test.go
+++ b/internal/runtime/agent/prompt_order_test.go
@@ -15,8 +15,12 @@ import (
 
 func TestBuildSystemPromptSections_FullPromptUsesInvertedPyramidOrder(t *testing.T) {
 	dir := t.TempDir()
+	axiomsPath := filepath.Join(dir, "axioms.md")
 	egoPath := filepath.Join(dir, "ego.md")
 	injectPath := filepath.Join(dir, "mission.md")
+	if err := os.WriteFile(axiomsPath, []byte("AXIOMS_MARKER"), 0o644); err != nil {
+		t.Fatalf("write axioms.md: %v", err)
+	}
 	if err := os.WriteFile(egoPath, []byte("EGO_MARKER"), 0o644); err != nil {
 		t.Fatalf("write ego.md: %v", err)
 	}
@@ -32,6 +36,7 @@ func TestBuildSystemPromptSections_FullPromptUsesInvertedPyramidOrder(t *testing
 
 	l := newPromptOrderLoop(t, kbDir)
 	l.persona = "PERSONA_MARKER"
+	l.ensureCoreContextProvider().updateAxiomsFile(axiomsPath)
 	l.SetEgoFile(egoPath)
 	l.SetInjectFiles([]string{injectPath})
 	l.RegisterTagContextProvider("forge", &mockTagProvider{
@@ -52,6 +57,7 @@ func TestBuildSystemPromptSections_FullPromptUsesInvertedPyramidOrder(t *testing
 	index := promptSectionIndex(t, sections)
 
 	assertPromptSectionOrder(t, index,
+		"AXIOMS",
 		"PERSONA",
 		"EGO",
 		"INJECTED CONTEXT",
@@ -64,6 +70,7 @@ func TestBuildSystemPromptSections_FullPromptUsesInvertedPyramidOrder(t *testing
 		"LIVE STATE",
 		"CURRENT CONDITIONS",
 	)
+	assertPromptSectionContains(t, sections, "AXIOMS", "AXIOMS_MARKER")
 	assertPromptSectionContains(t, sections, "EGO", "EGO_MARKER")
 	assertPromptSectionContains(t, sections, "INJECTED CONTEXT", "INJECT_MARKER")
 	assertPromptSectionContains(t, sections, "TAGGED GUIDANCE", "TAGGED_GUIDANCE_MARKER")
@@ -73,8 +80,12 @@ func TestBuildSystemPromptSections_FullPromptUsesInvertedPyramidOrder(t *testing
 
 func TestBuildSystemPromptSections_TaskPromptUsesCompactOrder(t *testing.T) {
 	dir := t.TempDir()
+	axiomsPath := filepath.Join(dir, "axioms.md")
 	egoPath := filepath.Join(dir, "ego.md")
 	injectPath := filepath.Join(dir, "mission.md")
+	if err := os.WriteFile(axiomsPath, []byte("AXIOMS_MARKER"), 0o644); err != nil {
+		t.Fatalf("write axioms.md: %v", err)
+	}
 	if err := os.WriteFile(egoPath, []byte("EGO_MARKER"), 0o644); err != nil {
 		t.Fatalf("write ego.md: %v", err)
 	}
@@ -90,6 +101,7 @@ func TestBuildSystemPromptSections_TaskPromptUsesCompactOrder(t *testing.T) {
 
 	l := newPromptOrderLoop(t, kbDir)
 	l.persona = "PERSONA_MARKER"
+	l.ensureCoreContextProvider().updateAxiomsFile(axiomsPath)
 	l.SetEgoFile(egoPath)
 	l.SetInjectFiles([]string{injectPath})
 	l.RegisterTagContextProvider("forge", &mockTagProvider{
@@ -110,6 +122,7 @@ func TestBuildSystemPromptSections_TaskPromptUsesCompactOrder(t *testing.T) {
 	)
 	index := promptSectionIndex(t, sections)
 
+	assertPromptSectionAbsent(t, index, "AXIOMS")
 	assertPromptSectionAbsent(t, index, "EGO")
 	assertPromptSectionAbsent(t, index, "INJECTED CONTEXT")
 	assertPromptSectionAbsent(t, index, "TALENTS ALWAYS ON")

--- a/internal/runtime/agent/prompt_order_test.go
+++ b/internal/runtime/agent/prompt_order_test.go
@@ -55,6 +55,7 @@ func TestBuildSystemPromptSections_FullPromptUsesInvertedPyramidOrder(t *testing
 		llm.DefaultModelInteractionProfile(),
 	)
 	index := promptSectionIndex(t, sections)
+	assertPromptSectionsStartAtContent(t, sections)
 
 	assertPromptSectionOrder(t, index,
 		"AXIOMS",
@@ -121,6 +122,7 @@ func TestBuildSystemPromptSections_TaskPromptUsesCompactOrder(t *testing.T) {
 		llm.DefaultModelInteractionProfile(),
 	)
 	index := promptSectionIndex(t, sections)
+	assertPromptSectionsStartAtContent(t, sections)
 
 	assertPromptSectionAbsent(t, index, "AXIOMS")
 	assertPromptSectionAbsent(t, index, "EGO")
@@ -181,6 +183,15 @@ func promptSectionIndex(t *testing.T, sections []llm.PromptSection) map[string]i
 		index[section.Name] = i
 	}
 	return index
+}
+
+func assertPromptSectionsStartAtContent(t *testing.T, sections []llm.PromptSection) {
+	t.Helper()
+	for _, section := range sections {
+		if strings.HasPrefix(section.Content, "\n") || strings.HasPrefix(section.Content, "\r") {
+			t.Fatalf("prompt section %q starts with separator whitespace: %q", section.Name, section.Content)
+		}
+	}
 }
 
 func assertPromptSectionOrder(t *testing.T, index map[string]int, names ...string) {

--- a/internal/runtime/agent/tag_context_test.go
+++ b/internal/runtime/agent/tag_context_test.go
@@ -272,10 +272,10 @@ func TestBuildSystemPrompt_CoreContextProviderOrder(t *testing.T) {
 		t.Fatal("prompt should contain current conditions")
 	}
 
-	// Core context now enters through the continuity provider bucket,
-	// after tagged guidance and before current conditions.
-	if injectedIdx < tagCtxIdx {
-		t.Error("core context should appear after tagged context")
+	// Core context is first-class stable context, before generated
+	// tagged guidance and live/runtime sections.
+	if injectedIdx > tagCtxIdx {
+		t.Error("core context should appear before tagged context")
 	}
 	if injectedIdx > conditionsIdx {
 		t.Error("core context should appear before current conditions")

--- a/internal/runtime/loop/registry.go
+++ b/internal/runtime/loop/registry.go
@@ -339,8 +339,9 @@ func (r *Registry) Launch(ctx context.Context, launch Launch, deps Deps) (Launch
 	finalStatus := make(chan Status, 1)
 	go func() {
 		<-l.Done()
-		finalStatus <- l.Status()
+		st := l.Status()
 		r.Deregister(l.id)
+		finalStatus <- st
 	}()
 
 	waitCtx := ctx


### PR DESCRIPTION
## Summary

- render core/axioms.md as an optional stable preamble before persona
- render ego.md and configured inject files as first-class stable prompt sections before runtime context
- keep generated/tagged/always-on providers in typed context buckets instead of carrying core files through continuity context
- add full/task prompt section-order audit tests for the inverted-pyramid ladder
- update prompt/context docs to describe axioms, core context, typed buckets, and provider-neutral cache order

## Validation

- just ci

Closes #869
Refs #870
Refs #874