### PR TITLE
feat: add first-class mission prompt section

### DIFF
--- a/docs/prompt-caching.md
+++ b/docs/prompt-caching.md
@@ -34,8 +34,9 @@ and regression tests.
 |-------------------------|-----------|-----------|
 | `AXIOMS`                | stable    | Highest-level preamble. Changes only when axioms.md is edited. |
 | `PERSONA`               | stable    | Identity. Changes only when persona files are edited. |
+| `MISSION`               | stable    | Durable mission framing. Changes only when mission.md is edited. |
 | `EGO`                   | stable    | Self-reflection file. Stable across long sessions. |
-| `INJECTED CONTEXT`      | stable    | Mission + configured core files. Stable across a session. |
+| `INJECTED CONTEXT`      | stable    | Supplemental configured core files. Stable across a session. |
 | `RUNTIME CONTRACT`      | stable    | Execution semantics. Model-invariant. |
 | `TOOL CALLING CONTRACT` | stable    | Model-family-specific tool-calling guidance. |
 | `TALENTS ALWAYS ON`     | stable    | Behavioral guidance. Stable across a session. |
@@ -61,6 +62,11 @@ other buckets. The tradeoff is an explicit ceiling expansion from one
 64 KB aggregate context block to as much as 256 KB across the four
 volatile buckets, so new buckets should justify both their ordering and
 their prompt-budget impact.
+
+Fixed core prompt files (`axioms.md`, `persona.md`, `mission.md`,
+`ego.md`, and any configured supplemental injected file) share the same
+read/verify/reread/truncate mechanics. Their cache policy follows the
+section they render into, not a separate file-specific path.
 
 ## Adding a New Section
 
@@ -105,8 +111,9 @@ Anthropic exposes explicit prompt-cache breakpoints through
 |-------------------------|---------------|-----------|
 | `AXIOMS`                | 1h            | Highest-level preamble. Changes only when axioms.md is edited. |
 | `PERSONA`               | 1h            | Identity. Changes only when persona files are edited. |
+| `MISSION`               | 1h            | Durable mission framing. Changes only when mission.md is edited. |
 | `EGO`                   | 1h            | Self-reflection file. Stable across long sessions. |
-| `INJECTED CONTEXT`      | 1h            | Mission + configured core files. Stable across a session. |
+| `INJECTED CONTEXT`      | 1h            | Supplemental configured core files. Stable across a session. |
 | `RUNTIME CONTRACT`      | 1h            | Execution semantics. Model-invariant. |
 | `TOOL CALLING CONTRACT` | 1h            | Model-family-specific tool-calling guidance. |
 | `TALENTS ALWAYS ON`     | 1h            | Behavioral guidance. Stable across a session. |

--- a/docs/prompt-tool-pruning-strategy.md
+++ b/docs/prompt-tool-pruning-strategy.md
@@ -35,15 +35,16 @@ Today, prompt assembly in `internal/runtime/agent/loop.go` roughly looks like:
 
 1. axioms, when `core/axioms.md` exists
 2. persona
-3. ego and injected core context files
-4. runtime contract
-5. model-family tool-calling contract
-6. talents
-7. active capability summary
-8. session origin context
-9. typed context buckets: tagged guidance, continuity, related context, live state
-10. current conditions
-11. conversation history and carry-forward context
+3. mission, when `core/mission.md` exists
+4. ego and supplemental injected core context files
+5. runtime contract
+6. model-family tool-calling contract
+7. talents
+8. active capability summary
+9. session origin context
+10. typed context buckets: tagged guidance, continuity, related context, live state
+11. current conditions
+12. conversation history and carry-forward context
 
 This layering is mostly sound. The problem is that the always-on layers
 still carry too much evergreen tool doctrine, and the tagged/contextual
@@ -392,6 +393,12 @@ purpose:
 - `ego.md`: self-reflection and continuity of internal stance
 - `mission.md`: durable mission framing and major operational truths
 - `metacognitive.md`: metacognitive loop state, not general doctrine
+
+All fixed core prompt files should travel through the same mechanics:
+resolve the workspace/core path, verify the managed-root policy, read
+fresh each turn, enforce a prompt budget with an explicit truncation
+marker, and render into the intended semantic slot. The semantic slots
+can differ; the file plumbing should not.
 
 These files should not become a dumping ground for tool encyclopedias.
 

--- a/docs/understanding/architecture.md
+++ b/docs/understanding/architecture.md
@@ -159,9 +159,11 @@ purpose. Mixing concerns across layers degrades agent behavior — this
 was learned empirically, not theorized.
 
 **Axioms** are the highest-level preamble, when `core/axioms.md` exists.
-**Persona** is identity: who the agent is, its voice and values. **Core
-context** publishes curated knowledge and continuity such as
-`core/ego.md` and configured mission files as stable prompt sections.
+**Persona** is identity: who the agent is, its voice and values.
+**Mission** is durable operational framing, when `core/mission.md`
+exists. **Core context** publishes curated knowledge and continuity such
+as `core/ego.md` and supplemental configured files as stable prompt
+sections.
 **Current conditions** are awareness: time, environment, active state.
 **Talents** are behavior: how the agent should act in specific
 situations.

--- a/docs/understanding/context-layers.md
+++ b/docs/understanding/context-layers.md
@@ -12,6 +12,11 @@ specific purpose. Mixing concerns across layers degrades agent behavior.
 The persona defines voice, personality, values, and boundaries. It should
 read like a character description, not an instruction manual.
 
+When `workspace.path` is configured, `core/persona.md` is read fresh
+through the same verified core-prompt file path as the other fixed core
+documents. If it is absent, Thane falls back to the embedded base
+persona.
+
 **Contains:** Name, personality traits, communication style, values, boundaries.
 
 **Does NOT contain:** Tool usage rules, operational procedures, device lists,
@@ -56,10 +61,10 @@ only when those tags are active.
 **Purpose:** Knowledge — what the agent *knows*.
 
 Core context publishes curated reference material such as
-`core/axioms.md`, `core/ego.md`, and configured mission/context files as
-first-class stable prompt sections. These files are read fresh each
-turn, verified when managed-root policy applies, and suppressed for
-task-focused delegate runs.
+`core/mission.md`, `core/ego.md`, and supplemental configured context
+files as stable prompt sections. These files are read fresh each turn,
+verified when managed-root policy applies, capped with explicit
+truncation markers, and suppressed for task-focused delegate runs.
 
 **Contains:** Factual information, user preferences, infrastructure notes,
 memory files, identity documents.
@@ -68,8 +73,12 @@ memory files, identity documents.
 
 **Common core context files:**
 - `axioms.md` — highest-level preamble rendered before persona
-- `ego.md` — self-reflection and continuity notes
+- `persona.md` — identity, voice, values, and boundaries
 - `mission.md` — deployment-specific mission context
+- `ego.md` — self-reflection and continuity notes
+- `metacognitive.md` — metacognitive loop state; only suitable for
+  supplemental injection when that state is intentionally part of the
+  main prompt
 
 See `examples/axioms.example.md` for a reference axioms preamble.
 
@@ -89,14 +98,15 @@ The system prompt is assembled in this order:
 
 1. **Axioms** — highest-level preamble, when `core/axioms.md` exists
 2. **Persona** — identity (who am I)
-3. **Core context** — ego and configured stable context files
-4. **Runtime contract** — execution semantics
-5. **Talents** — behavior (how should I act)
-6. **Active capabilities** — currently loaded tool and context surface
-7. **Session origin context** — generated data about why this run was shaped
-8. **Typed context buckets** — tagged guidance, continuity, related context, live state
-9. **Current conditions** — environment (where/when am I)
-10. **Conversation history** — continuity for full-context runs
+3. **Mission** — durable mission framing, when `core/mission.md` exists
+4. **Core context** — ego and supplemental stable context files
+5. **Runtime contract** — execution semantics
+6. **Talents** — behavior (how should I act)
+7. **Active capabilities** — currently loaded tool and context surface
+8. **Session origin context** — generated data about why this run was shaped
+9. **Typed context buckets** — tagged guidance, continuity, related context, live state
+10. **Current conditions** — environment (where/when am I)
+11. **Conversation history** — continuity for full-context runs
 
 Task-focused delegate runs keep the compact worker persona, runtime
 contract, active capabilities, tagged context, and current conditions,

--- a/internal/app/new_agent.go
+++ b/internal/app/new_agent.go
@@ -61,38 +61,18 @@ func (a *App) initAgentLoop(s *newState) error {
 	}
 	s.resolver = resolver
 
-	// Resolve fixed core context files at startup (tilde expansion,
-	// existence check) but defer reading to the core context provider
-	// each agent turn so edits under workspace/core are visible without
-	// restart.
-	var resolvedInjectFiles []string
-	if injectFiles := cfg.CoreInjectFiles(); len(injectFiles) > 0 {
-		for _, path := range injectFiles {
-			path = resolvePath(path, resolver)
-			if _, err := os.Stat(path); err != nil {
-				if errors.Is(err, fs.ErrNotExist) {
-					logger.Warn("core context file not found", "path", path)
-				} else {
-					logger.Warn("core context file unreadable", "path", path, "error", err)
-				}
-				// Still include the path — the file may appear later.
-			}
-			resolvedInjectFiles = append(resolvedInjectFiles, path)
-			logger.Debug("core context file registered", "path", path)
-		}
-		logger.Info("core context files registered", "files", len(resolvedInjectFiles))
-	}
-	s.resolvedInjectFiles = resolvedInjectFiles
-
 	// Resolve fixed core prompt files if a workspace is configured. The
 	// core context provider reads them fresh on every turn, so paths are
 	// enough at startup.
-	var axiomsFile, egoFile string
+	var axiomsFile, personaFile, missionFile, egoFile string
 	if cfg.Workspace.Path != "" {
 		axiomsFile = resolvePath(coreFilePath(cfg.Workspace.Path, "axioms.md"), nil)
+		personaFile = resolvePath(coreFilePath(cfg.Workspace.Path, "persona.md"), nil)
+		missionFile = resolvePath(coreFilePath(cfg.Workspace.Path, "mission.md"), nil)
 		egoFile = resolvePath(coreFilePath(cfg.Workspace.Path, "ego.md"), nil)
 	}
-	s.resolvedCorePromptFiles = append(corePromptFilesForStartupVerification(logger, axiomsFile, egoFile), resolvedInjectFiles...)
+
+	s.resolvedCorePromptFiles = corePromptFilesForStartupVerification(logger, axiomsFile, personaFile, missionFile, egoFile)
 
 	// --- Agent loop ---
 	// The core conversation engine. Receives messages, manages context,
@@ -116,13 +96,13 @@ func (a *App) initAgentLoop(s *newState) error {
 		LLM:                 a.llmClient,
 		Model:               defaultModel,
 		ContextWindow:       defaultContextWindow,
-		Persona:             s.personaContent,
 		AxiomsFile:          axiomsFile,
+		PersonaFile:         personaFile,
+		MissionFile:         missionFile,
 		ParsedTalents:       s.parsedTalents,
 		Timezone:            cfg.Timezone,
 		RecoveryModel:       recoveryModel,
 		Archiver:            a.archiveAdapter,
-		InjectFiles:         resolvedInjectFiles,
 		EgoFile:             egoFile,
 		HAInject:            haInject,
 		ModelRegistry:       a.modelRegistry,

--- a/internal/app/new_state.go
+++ b/internal/app/new_state.go
@@ -20,13 +20,11 @@ type newState struct {
 
 	// Loaded in initChannels after document-root verification wiring,
 	// consumed by finalizeCapabilityTags.
-	parsedTalents  []talents.Talent
-	personaContent string
+	parsedTalents []talents.Talent
 
 	// Resolved in initAgentLoop, consumed by initChannels for startup
 	// verification once the document store exists.
 	resolvedCorePromptFiles []string
-	resolvedInjectFiles     []string
 
 	// Forward-declared in initStores (for connwatch OnReady closure),
 	// constructed in initAwareness.

--- a/internal/app/new_stores.go
+++ b/internal/app/new_stores.go
@@ -296,22 +296,6 @@ func (a *App) initStores(s *newState) error {
 	archiveAdapter := memory.NewArchiveAdapter(archiveStore, mem, mem, logger)
 	a.archiveAdapter = archiveAdapter
 
-	// --- Persona --- A curated core/persona.md file can replace the
-	// default system prompt, giving the agent a custom identity and
-	// behavioral guidance.
-	var personaContent string
-	if personaPath := resolvePath(cfg.CoreFile("persona.md"), nil); personaPath != "" {
-		data, err := os.ReadFile(personaPath)
-		if err != nil {
-			if !errors.Is(err, os.ErrNotExist) {
-				return fmt.Errorf("load persona %s: %w", personaPath, err)
-			}
-		} else {
-			personaContent = string(data)
-			logger.Info("persona loaded", "path", personaPath, "size", len(personaContent))
-		}
-	}
-	s.personaContent = personaContent
 	// --- Model router ---
 	// Selects the best model for each request based on complexity, cost,
 	// and capability requirements. Falls back to the default model.

--- a/internal/platform/config/config.go
+++ b/internal/platform/config/config.go
@@ -2695,16 +2695,6 @@ func (c *Config) CoreFile(name string) string {
 	return filepath.Join(root, name)
 }
 
-// CoreInjectFiles returns the curated always-on files that should be
-// re-read and injected into the system prompt on every turn.
-func (c *Config) CoreInjectFiles() []string {
-	mission := c.CoreFile("mission.md")
-	if mission == "" {
-		return nil
-	}
-	return []string{mission}
-}
-
 func (c *Config) validateLoops() error {
 	if c.Loops.MaxRunning < 0 {
 		return fmt.Errorf("loops.max_running must be >= 0, got %d", c.Loops.MaxRunning)

--- a/internal/runtime/agent/core_context.go
+++ b/internal/runtime/agent/core_context.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -21,6 +22,8 @@ type CoreContextProvider struct {
 
 	logger             *slog.Logger
 	axiomsFile         string
+	personaFile        string
+	missionFile        string
 	egoFile            string
 	provenanceStore    *provenance.Store
 	injectFiles        []string
@@ -39,6 +42,8 @@ type corePromptSection struct {
 type CoreContextProviderConfig struct {
 	Logger          *slog.Logger
 	AxiomsFile      string
+	PersonaFile     string
+	MissionFile     string
 	EgoFile         string
 	ProvenanceStore *provenance.Store
 	InjectFiles     []string
@@ -56,6 +61,8 @@ func NewCoreContextProvider(cfg CoreContextProviderConfig) *CoreContextProvider 
 	return &CoreContextProvider{
 		logger:          cfg.Logger,
 		axiomsFile:      cfg.AxiomsFile,
+		personaFile:     cfg.PersonaFile,
+		missionFile:     cfg.MissionFile,
 		egoFile:         cfg.EgoFile,
 		provenanceStore: cfg.ProvenanceStore,
 		injectFiles:     append([]string(nil), cfg.InjectFiles...),
@@ -69,6 +76,24 @@ func (p *CoreContextProvider) updateAxiomsFile(path string) {
 	}
 	p.mu.Lock()
 	p.axiomsFile = path
+	p.mu.Unlock()
+}
+
+func (p *CoreContextProvider) updatePersonaFile(path string) {
+	if p == nil {
+		return
+	}
+	p.mu.Lock()
+	p.personaFile = path
+	p.mu.Unlock()
+}
+
+func (p *CoreContextProvider) updateMissionFile(path string) {
+	if p == nil {
+		return
+	}
+	p.mu.Lock()
+	p.missionFile = path
 	p.mu.Unlock()
 }
 
@@ -144,17 +169,34 @@ func (p *CoreContextProvider) preambleSections(ctx context.Context) []corePrompt
 		logger = slog.Default()
 	}
 
-	content := p.readPlainCoreFile(ctx, axiomsFile, verifier, "axioms_file", maxAxiomsBytes, "\n\n[axioms.md truncated — exceeded 16 KB limit]", logger)
-	if content == "" {
-		return nil
+	if section, ok := p.readPlainCoreSection(ctx, corePromptFileSpec{
+		name:     "AXIOMS",
+		title:    "Axioms (axioms.md)",
+		path:     axiomsFile,
+		consumer: "axioms_file",
+		maxBytes: maxAxiomsBytes,
+		marker:   "\n\n[axioms.md truncated — exceeded 16 KB limit]",
+	}, verifier, logger); ok {
+		return []corePromptSection{section}
 	}
-	return []corePromptSection{
-		{
-			name:    "AXIOMS",
-			title:   "Axioms (axioms.md)",
-			content: content,
-		},
+	return nil
+}
+
+func (p *CoreContextProvider) personaContent(ctx context.Context) string {
+	if p == nil {
+		return ""
 	}
+
+	p.mu.RLock()
+	personaFile := p.personaFile
+	verifier := p.injectFileVerifier
+	logger := p.logger
+	p.mu.RUnlock()
+	if logger == nil {
+		logger = slog.Default()
+	}
+
+	return p.readPlainCoreFile(ctx, personaFile, verifier, "persona_file", maxPersonaBytes, "\n\n[persona.md truncated — exceeded 16 KB limit]", logger)
 }
 
 func (p *CoreContextProvider) promptSections(ctx context.Context) []corePromptSection {
@@ -163,6 +205,7 @@ func (p *CoreContextProvider) promptSections(ctx context.Context) []corePromptSe
 	}
 
 	p.mu.RLock()
+	missionFile := p.missionFile
 	egoFile := p.egoFile
 	prov := p.provenanceStore
 	injectFiles := append([]string(nil), p.injectFiles...)
@@ -178,6 +221,16 @@ func (p *CoreContextProvider) promptSections(ctx context.Context) []corePromptSe
 	}
 
 	var sections []corePromptSection
+	if section, ok := p.readPlainCoreSection(ctx, corePromptFileSpec{
+		name:     "MISSION",
+		title:    "Mission (mission.md)",
+		path:     missionFile,
+		consumer: "mission_file",
+		maxBytes: maxMissionBytes,
+		marker:   "\n\n[mission.md truncated — exceeded 16 KB limit]",
+	}, verifier, logger); ok {
+		sections = append(sections, section)
+	}
 	if content := p.readEgo(ctx, egoFile, prov, verifier, now, logger); content != "" {
 		sections = append(sections, corePromptSection{
 			name:    "EGO",
@@ -193,6 +246,27 @@ func (p *CoreContextProvider) promptSections(ctx context.Context) []corePromptSe
 		})
 	}
 	return sections
+}
+
+type corePromptFileSpec struct {
+	name     string
+	title    string
+	path     string
+	consumer string
+	maxBytes int
+	marker   string
+}
+
+func (p *CoreContextProvider) readPlainCoreSection(ctx context.Context, spec corePromptFileSpec, verifier func(context.Context, string, string) error, logger *slog.Logger) (corePromptSection, bool) {
+	content := p.readPlainCoreFile(ctx, spec.path, verifier, spec.consumer, spec.maxBytes, spec.marker, logger)
+	if content == "" {
+		return corePromptSection{}, false
+	}
+	return corePromptSection{
+		name:    spec.name,
+		title:   spec.title,
+		content: content,
+	}, true
 }
 
 func (p *CoreContextProvider) readEgo(ctx context.Context, egoFile string, prov *provenance.Store, verifier func(context.Context, string, string) error, now func() time.Time, logger *slog.Logger) string {
@@ -223,20 +297,15 @@ func (p *CoreContextProvider) readEgoFromProvenance(ctx context.Context, prov *p
 func (p *CoreContextProvider) readInjectFiles(ctx context.Context, injectFiles []string, verifier func(context.Context, string, string) error, logger *slog.Logger) string {
 	var ctxBuf strings.Builder
 	for _, path := range injectFiles {
-		if verifier != nil {
-			if err := verifier(ctx, path, "inject_files"); err != nil {
-				logger.Warn("inject file blocked by verification policy", "path", path, "error", err)
-				continue
-			}
-		}
-		data, err := os.ReadFile(path)
-		if err != nil || len(data) == 0 {
+		content := p.readPlainCoreFile(ctx, path, verifier, "inject_files", maxInjectFileBytes,
+			fmt.Sprintf("\n\n[%s truncated — exceeded 16 KB limit]", filepath.Base(path)), logger)
+		if content == "" {
 			continue
 		}
 		if ctxBuf.Len() > 0 {
 			ctxBuf.WriteString("\n\n---\n\n")
 		}
-		ctxBuf.Write(data)
+		ctxBuf.WriteString(content)
 	}
 	if ctxBuf.Len() == 0 {
 		return ""

--- a/internal/runtime/agent/core_context.go
+++ b/internal/runtime/agent/core_context.go
@@ -317,6 +317,9 @@ func (p *CoreContextProvider) readPlainCoreFile(ctx context.Context, path string
 	if strings.TrimSpace(path) == "" {
 		return ""
 	}
+	if logger == nil {
+		logger = slog.Default()
+	}
 	if verifier != nil {
 		if err := verifier(ctx, path, consumer); err != nil {
 			logger.Warn("core prompt file blocked by verification policy", "path", path, "consumer", consumer, "error", err)
@@ -324,7 +327,13 @@ func (p *CoreContextProvider) readPlainCoreFile(ctx context.Context, path string
 		}
 	}
 	data, err := os.ReadFile(path)
-	if err != nil || len(data) == 0 {
+	if err != nil {
+		if !os.IsNotExist(err) {
+			logger.Warn("core prompt file unreadable", "path", path, "consumer", consumer, "error", err)
+		}
+		return ""
+	}
+	if len(data) == 0 {
 		return ""
 	}
 	return truncateCoreContext(string(data), maxBytes, marker)

--- a/internal/runtime/agent/ego_prompt_test.go
+++ b/internal/runtime/agent/ego_prompt_test.go
@@ -101,6 +101,93 @@ func TestBuildSystemPrompt_AxiomsFileEmpty(t *testing.T) {
 	}
 }
 
+func TestBuildSystemPrompt_PersonaFileIncludedAndReread(t *testing.T) {
+	dir := t.TempDir()
+	personaPath := filepath.Join(dir, "persona.md")
+	if err := os.WriteFile(personaPath, []byte("PERSONA_VERSION_1"), 0o644); err != nil {
+		t.Fatalf("write persona.md: %v", err)
+	}
+
+	l := newMinimalLoop()
+	l.persona = "PERSONA_FALLBACK"
+	l.ensureCoreContextProvider().updatePersonaFile(personaPath)
+
+	prompt1 := l.buildSystemPrompt(context.Background(), "hello", nil)
+	if !strings.Contains(prompt1, "PERSONA_VERSION_1") {
+		t.Fatalf("prompt missing persona file content:\n%s", prompt1)
+	}
+	if strings.Contains(prompt1, "PERSONA_FALLBACK") {
+		t.Fatalf("persona file should override fallback persona:\n%s", prompt1)
+	}
+
+	if err := os.WriteFile(personaPath, []byte("PERSONA_VERSION_2"), 0o644); err != nil {
+		t.Fatalf("rewrite persona.md: %v", err)
+	}
+	prompt2 := l.buildSystemPrompt(context.Background(), "hello", nil)
+	if strings.Contains(prompt2, "PERSONA_VERSION_1") || !strings.Contains(prompt2, "PERSONA_VERSION_2") {
+		t.Fatalf("persona file should be reread each turn:\n%s", prompt2)
+	}
+}
+
+func TestBuildSystemPrompt_PersonaFileMissingUsesFallback(t *testing.T) {
+	l := newMinimalLoop()
+	l.persona = "PERSONA_FALLBACK"
+	l.ensureCoreContextProvider().updatePersonaFile(filepath.Join(t.TempDir(), "missing.md"))
+
+	prompt := l.buildSystemPrompt(context.Background(), "hello", nil)
+
+	if !strings.Contains(prompt, "PERSONA_FALLBACK") {
+		t.Fatalf("missing persona file should use fallback persona:\n%s", prompt)
+	}
+}
+
+func TestBuildSystemPrompt_MissionFileIncluded(t *testing.T) {
+	dir := t.TempDir()
+	missionPath := filepath.Join(dir, "mission.md")
+	content := "# Mission\n\nKeep the household context coherent."
+	if err := os.WriteFile(missionPath, []byte(content), 0o644); err != nil {
+		t.Fatalf("write mission.md: %v", err)
+	}
+
+	l := newMinimalLoop()
+	l.ensureCoreContextProvider().updateMissionFile(missionPath)
+
+	prompt, sections := l.buildSystemPromptWithProfileSections(context.Background(), "hello", nil, llm.DefaultModelInteractionProfile())
+
+	if !strings.Contains(prompt, content) {
+		t.Error("system prompt should contain mission.md content")
+	}
+	if !strings.Contains(prompt, "Mission (mission.md)") {
+		t.Error("system prompt should contain mission section heading")
+	}
+	sectionIndex := promptSectionIndex(t, sections)
+	assertPromptSectionOrder(t, sectionIndex, "PERSONA", "MISSION", "RUNTIME CONTRACT")
+	if got := sections[sectionIndex["MISSION"]].CacheTTL; got != "1h" {
+		t.Fatalf("MISSION CacheTTL = %q, want 1h", got)
+	}
+}
+
+func TestBuildSystemPrompt_MissionFileMissingAndEmpty(t *testing.T) {
+	l := newMinimalLoop()
+	l.ensureCoreContextProvider().updateMissionFile(filepath.Join(t.TempDir(), "missing.md"))
+
+	prompt := l.buildSystemPrompt(context.Background(), "hello", nil)
+	if strings.Contains(prompt, "mission.md") {
+		t.Fatalf("missing mission file should not render section:\n%s", prompt)
+	}
+
+	dir := t.TempDir()
+	missionPath := filepath.Join(dir, "mission.md")
+	if err := os.WriteFile(missionPath, nil, 0o644); err != nil {
+		t.Fatalf("write mission.md: %v", err)
+	}
+	l.ensureCoreContextProvider().updateMissionFile(missionPath)
+	prompt = l.buildSystemPrompt(context.Background(), "hello", nil)
+	if strings.Contains(prompt, "mission.md") {
+		t.Fatalf("empty mission file should not render section:\n%s", prompt)
+	}
+}
+
 func TestBuildSystemPrompt_EgoFileMissing(t *testing.T) {
 	l := newMinimalLoop()
 	l.SetEgoFile(filepath.Join(t.TempDir(), "nonexistent.md"))

--- a/internal/runtime/agent/ego_prompt_test.go
+++ b/internal/runtime/agent/ego_prompt_test.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"log/slog"
@@ -138,6 +139,30 @@ func TestBuildSystemPrompt_PersonaFileMissingUsesFallback(t *testing.T) {
 
 	if !strings.Contains(prompt, "PERSONA_FALLBACK") {
 		t.Fatalf("missing persona file should use fallback persona:\n%s", prompt)
+	}
+}
+
+func TestBuildSystemPrompt_PersonaFileReadErrorLogsWarning(t *testing.T) {
+	var logs bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&logs, nil))
+
+	personaPath := t.TempDir()
+	l := newMinimalLoop()
+	l.logger = logger
+	l.persona = "PERSONA_FALLBACK"
+	l.ensureCoreContextProvider().updatePersonaFile(personaPath)
+
+	prompt := l.buildSystemPrompt(context.Background(), "hello", nil)
+
+	if !strings.Contains(prompt, "PERSONA_FALLBACK") {
+		t.Fatalf("unreadable persona file should use fallback persona:\n%s", prompt)
+	}
+	got := logs.String()
+	if !strings.Contains(got, "core prompt file unreadable") {
+		t.Fatalf("logs = %q, want unreadable warning", got)
+	}
+	if !strings.Contains(got, "consumer=persona_file") {
+		t.Fatalf("logs = %q, want persona_file consumer", got)
 	}
 }
 

--- a/internal/runtime/agent/loop.go
+++ b/internal/runtime/agent/loop.go
@@ -103,9 +103,22 @@ const (
 // with a marker.
 const maxAxiomsBytes = 16 * 1024
 
+// maxPersonaBytes is the maximum size of persona.md content published as the
+// identity section. Content beyond this limit is truncated with a marker.
+const maxPersonaBytes = 16 * 1024
+
 // maxEgoBytes is the maximum size of ego.md content published as a stable
 // core prompt section. Content beyond this limit is truncated with a marker.
 const maxEgoBytes = 16 * 1024
+
+// maxMissionBytes is the maximum size of mission.md content published as a
+// stable core prompt section. Content beyond this limit is truncated with a
+// marker.
+const maxMissionBytes = 16 * 1024
+
+// maxInjectFileBytes is the maximum size of each configured supplemental core
+// prompt file. Content beyond this limit is truncated with a marker.
+const maxInjectFileBytes = 16 * 1024
 
 // maxTagContextBytes is the aggregate size limit for all tag context
 // files injected into the system prompt. Individual files exceeding
@@ -328,6 +341,8 @@ type LoopOptions struct {
 	// Optional, stable at construction.
 	Persona             string
 	AxiomsFile          string
+	PersonaFile         string
+	MissionFile         string
 	ParsedTalents       []talents.Talent
 	Timezone            string
 	RecoveryModel       string
@@ -382,8 +397,10 @@ func NewLoop(opts LoopOptions) (*Loop, error) {
 		requestRecorder:     opts.RequestRecorder,
 		nowFunc:             time.Now,
 	}
-	if opts.AxiomsFile != "" || opts.EgoFile != "" || opts.ProvenanceStore != nil || len(opts.InjectFiles) > 0 {
+	if opts.AxiomsFile != "" || opts.PersonaFile != "" || opts.MissionFile != "" || opts.EgoFile != "" || opts.ProvenanceStore != nil || len(opts.InjectFiles) > 0 {
 		l.ensureCoreContextProvider().updateAxiomsFile(opts.AxiomsFile)
+		l.ensureCoreContextProvider().updatePersonaFile(opts.PersonaFile)
+		l.ensureCoreContextProvider().updateMissionFile(opts.MissionFile)
 		l.ensureCoreContextProvider().updateEgoFile(opts.EgoFile)
 		l.coreContextProvider.updateProvenanceStore(opts.ProvenanceStore)
 		l.coreContextProvider.updateInjectFiles(opts.InjectFiles)
@@ -1009,6 +1026,14 @@ func (l *Loop) buildSystemPromptWithProfileSections(ctx context.Context, userMes
 	appendTracked("PERSONA", func() {
 		if taskPrompt {
 			sb.WriteString(prompts.DelegateSystemPrompt())
+		} else if l.coreContextProvider != nil {
+			if persona := l.coreContextProvider.personaContent(ctx); persona != "" {
+				sb.WriteString(persona)
+			} else if l.persona != "" {
+				sb.WriteString(l.persona)
+			} else {
+				sb.WriteString(prompts.BaseSystemPrompt())
+			}
 		} else if l.persona != "" {
 			sb.WriteString(l.persona)
 		} else {
@@ -1217,7 +1242,7 @@ func promptSectionsFromBoundaries(text string, sections []promptSection) []llm.P
 // instead of amortizing it).
 func promptSectionCacheTTL(name string) string {
 	switch name {
-	case "AXIOMS", "PERSONA", "EGO", "RUNTIME CONTRACT", "INJECTED CONTEXT", "TOOL CALLING CONTRACT", "TALENTS ALWAYS ON":
+	case "AXIOMS", "PERSONA", "MISSION", "EGO", "RUNTIME CONTRACT", "INJECTED CONTEXT", "TOOL CALLING CONTRACT", "TALENTS ALWAYS ON":
 		return "1h"
 	case "TALENTS TAGGED":
 		return "5m"

--- a/internal/runtime/agent/prompt_order_test.go
+++ b/internal/runtime/agent/prompt_order_test.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"strings"
@@ -16,10 +17,14 @@ import (
 func TestBuildSystemPromptSections_FullPromptUsesInvertedPyramidOrder(t *testing.T) {
 	dir := t.TempDir()
 	axiomsPath := filepath.Join(dir, "axioms.md")
+	missionPath := filepath.Join(dir, "mission.md")
 	egoPath := filepath.Join(dir, "ego.md")
-	injectPath := filepath.Join(dir, "mission.md")
+	injectPath := filepath.Join(dir, "metacognitive.md")
 	if err := os.WriteFile(axiomsPath, []byte("AXIOMS_MARKER"), 0o644); err != nil {
 		t.Fatalf("write axioms.md: %v", err)
+	}
+	if err := os.WriteFile(missionPath, []byte("MISSION_MARKER"), 0o644); err != nil {
+		t.Fatalf("write mission.md: %v", err)
 	}
 	if err := os.WriteFile(egoPath, []byte("EGO_MARKER"), 0o644); err != nil {
 		t.Fatalf("write ego.md: %v", err)
@@ -37,6 +42,7 @@ func TestBuildSystemPromptSections_FullPromptUsesInvertedPyramidOrder(t *testing
 	l := newPromptOrderLoop(t, kbDir)
 	l.persona = "PERSONA_MARKER"
 	l.ensureCoreContextProvider().updateAxiomsFile(axiomsPath)
+	l.ensureCoreContextProvider().updateMissionFile(missionPath)
 	l.SetEgoFile(egoPath)
 	l.SetInjectFiles([]string{injectPath})
 	l.RegisterTagContextProvider("forge", &mockTagProvider{
@@ -60,6 +66,7 @@ func TestBuildSystemPromptSections_FullPromptUsesInvertedPyramidOrder(t *testing
 	assertPromptSectionOrder(t, index,
 		"AXIOMS",
 		"PERSONA",
+		"MISSION",
 		"EGO",
 		"INJECTED CONTEXT",
 		"RUNTIME CONTRACT",
@@ -72,6 +79,7 @@ func TestBuildSystemPromptSections_FullPromptUsesInvertedPyramidOrder(t *testing
 		"CURRENT CONDITIONS",
 	)
 	assertPromptSectionContains(t, sections, "AXIOMS", "AXIOMS_MARKER")
+	assertPromptSectionContains(t, sections, "MISSION", "MISSION_MARKER")
 	assertPromptSectionContains(t, sections, "EGO", "EGO_MARKER")
 	assertPromptSectionContains(t, sections, "INJECTED CONTEXT", "INJECT_MARKER")
 	assertPromptSectionContains(t, sections, "TAGGED GUIDANCE", "TAGGED_GUIDANCE_MARKER")
@@ -82,10 +90,14 @@ func TestBuildSystemPromptSections_FullPromptUsesInvertedPyramidOrder(t *testing
 func TestBuildSystemPromptSections_TaskPromptUsesCompactOrder(t *testing.T) {
 	dir := t.TempDir()
 	axiomsPath := filepath.Join(dir, "axioms.md")
+	missionPath := filepath.Join(dir, "mission.md")
 	egoPath := filepath.Join(dir, "ego.md")
-	injectPath := filepath.Join(dir, "mission.md")
+	injectPath := filepath.Join(dir, "metacognitive.md")
 	if err := os.WriteFile(axiomsPath, []byte("AXIOMS_MARKER"), 0o644); err != nil {
 		t.Fatalf("write axioms.md: %v", err)
+	}
+	if err := os.WriteFile(missionPath, []byte("MISSION_MARKER"), 0o644); err != nil {
+		t.Fatalf("write mission.md: %v", err)
 	}
 	if err := os.WriteFile(egoPath, []byte("EGO_MARKER"), 0o644); err != nil {
 		t.Fatalf("write ego.md: %v", err)
@@ -103,6 +115,7 @@ func TestBuildSystemPromptSections_TaskPromptUsesCompactOrder(t *testing.T) {
 	l := newPromptOrderLoop(t, kbDir)
 	l.persona = "PERSONA_MARKER"
 	l.ensureCoreContextProvider().updateAxiomsFile(axiomsPath)
+	l.ensureCoreContextProvider().updateMissionFile(missionPath)
 	l.SetEgoFile(egoPath)
 	l.SetInjectFiles([]string{injectPath})
 	l.RegisterTagContextProvider("forge", &mockTagProvider{
@@ -125,6 +138,7 @@ func TestBuildSystemPromptSections_TaskPromptUsesCompactOrder(t *testing.T) {
 	assertPromptSectionsStartAtContent(t, sections)
 
 	assertPromptSectionAbsent(t, index, "AXIOMS")
+	assertPromptSectionAbsent(t, index, "MISSION")
 	assertPromptSectionAbsent(t, index, "EGO")
 	assertPromptSectionAbsent(t, index, "INJECTED CONTEXT")
 	assertPromptSectionAbsent(t, index, "TALENTS ALWAYS ON")
@@ -140,6 +154,50 @@ func TestBuildSystemPromptSections_TaskPromptUsesCompactOrder(t *testing.T) {
 	)
 	assertPromptSectionContains(t, sections, "TAGGED GUIDANCE", "TAGGED_GUIDANCE_MARKER")
 	assertPromptSectionContains(t, sections, "LIVE STATE", "LIVE_STATE_MARKER")
+}
+
+func TestBuildSystemPromptSections_CoreFileBudgetTruncation(t *testing.T) {
+	dir := t.TempDir()
+	axiomsPath := filepath.Join(dir, "axioms.md")
+	personaPath := filepath.Join(dir, "persona.md")
+	missionPath := filepath.Join(dir, "mission.md")
+	egoPath := filepath.Join(dir, "ego.md")
+	injectPath := filepath.Join(dir, "metacognitive.md")
+	if err := os.WriteFile(axiomsPath, []byte(strings.Repeat("A", maxAxiomsBytes+1024)), 0o644); err != nil {
+		t.Fatalf("write axioms.md: %v", err)
+	}
+	if err := os.WriteFile(personaPath, []byte(strings.Repeat("P", maxPersonaBytes+1024)), 0o644); err != nil {
+		t.Fatalf("write persona.md: %v", err)
+	}
+	if err := os.WriteFile(missionPath, []byte(strings.Repeat("M", maxMissionBytes+1024)), 0o644); err != nil {
+		t.Fatalf("write mission.md: %v", err)
+	}
+	if err := os.WriteFile(egoPath, []byte(strings.Repeat("E", maxEgoBytes+1024)), 0o644); err != nil {
+		t.Fatalf("write ego.md: %v", err)
+	}
+	if err := os.WriteFile(injectPath, []byte(strings.Repeat("I", maxInjectFileBytes+1024)), 0o644); err != nil {
+		t.Fatalf("write inject file: %v", err)
+	}
+
+	l := newMinimalLoop()
+	l.ensureCoreContextProvider().updateAxiomsFile(axiomsPath)
+	l.ensureCoreContextProvider().updatePersonaFile(personaPath)
+	l.ensureCoreContextProvider().updateMissionFile(missionPath)
+	l.SetEgoFile(egoPath)
+	l.SetInjectFiles([]string{injectPath})
+
+	_, sections := l.buildSystemPromptWithProfileSections(
+		context.Background(),
+		"hello",
+		nil,
+		llm.DefaultModelInteractionProfile(),
+	)
+
+	assertPromptSectionContains(t, sections, "AXIOMS", "axioms.md truncated")
+	assertPromptSectionContains(t, sections, "PERSONA", "persona.md truncated")
+	assertPromptSectionContains(t, sections, "MISSION", "mission.md truncated")
+	assertPromptSectionContains(t, sections, "EGO", "ego.md truncated")
+	assertPromptSectionContains(t, sections, "INJECTED CONTEXT", "metacognitive.md truncated")
 }
 
 func newPromptOrderLoop(t *testing.T, kbDir string) *Loop {


### PR DESCRIPTION
## Summary

This PR finishes the first-class core prompt file path started in #876.

- Promotes `core/mission.md` from the old generic `CoreInjectFiles` path into a named `MISSION` section, rendered after `PERSONA` and before `EGO` in full prompt mode.
- Moves `core/persona.md` out of the eager startup read and into the same per-turn `CoreContextProvider` read/verify/truncate flow used by the other core prompt files, preserving fallback behavior when the file is missing or empty.
- Removes `Config.CoreInjectFiles` and the startup `resolvedInjectFiles` plumbing; supplemental `InjectFiles` remain explicit `LoopOptions`/`SetInjectFiles` input and now reuse the same read/verify/truncate helper per file.
- Keeps `metacognitive.md` as metacognitive loop state by default. The tests use it only as an explicit supplemental injected file to prove that path shares core-file mechanics.
- Adds `MISSION` prompt-section cache metadata plus prompt audit coverage for full/task ordering, present/missing/empty mission/persona behavior, and truncation markers across axioms, persona, mission, ego, and injected files.
- Updates prompt caching/context docs to describe mission placement and the shared core-file mechanics.

## Validation

- `just test`
- `just ci`

Closes #870
Closes #874