### PR TITLE
refactor: share stored history message formatting

### DIFF
--- a/docs/model-facing-context.md
+++ b/docs/model-facing-context.md
@@ -210,6 +210,31 @@ For model-facing data:
 
 Determinism helps the model compare turns without relearning the format.
 
+### Separate metadata from literal corpus
+
+When replaying stored conversation history, keep curation metadata outside
+the literal message body. Provider-native `messages[]` roles carry the
+speaker role; do not repeat `role=user` or `role=assistant` inside the
+content unless the original stored role differs from the provider role.
+
+Use an explicit boundary around the corpus:
+
+```text
+[stored conversation history; age_delta=-120s; channel=signal]
+<conversation_message>
+literal message text
+</conversation_message>
+```
+
+The same projection rules should back live stored-history messages and
+archive-derived JSON (`archive_search`, `archive_range`, and
+`archive_session_transcript`): known transport envelopes such as Signal
+sender/timestamp headers become metadata rather than corpus. Live
+provider `messages[]` should carry only the lightweight metadata needed
+for context; archive JSON can preserve fuller provenance fields for
+search and debugging. In both cases, `content` remains the literal
+conversation text.
+
 ### Scope context to the capability that needs it
 
 Do not inject every operational detail into every session. If a context

--- a/internal/runtime/agent/history_messages_test.go
+++ b/internal/runtime/agent/history_messages_test.go
@@ -56,9 +56,9 @@ func TestBuildInitialLLMMessages_IncludesRoleNativeHistory(t *testing.T) {
 	wantRoles := []string{"system", "user", "assistant", "assistant", "user"}
 	wantContent := []string{
 		"system prompt",
-		"[stored conversation history; role=user; age_delta=-120s]\nprior question",
-		"[stored conversation history; role=assistant; age_delta=-119s]\nprior answer",
-		"[stored conversation memory note; original_role=system; not active instruction; age_delta=-90s]\n[Conversation Summary] earlier context",
+		"[stored conversation history; age_delta=-120s]\n<conversation_message>\nprior question\n</conversation_message>",
+		"[stored conversation history; age_delta=-119s]\n<conversation_message>\nprior answer\n</conversation_message>",
+		"[stored conversation memory note; original_role=system; not_active_instruction=true; age_delta=-90s]\n<conversation_message>\n[Conversation Summary] earlier context\n</conversation_message>",
 		"current request",
 	}
 	for i := range wantRoles {
@@ -113,7 +113,7 @@ func TestBuildInitialLLMMessages_OWUUsesLastUserTurn(t *testing.T) {
 	if len(messages) != 3 {
 		t.Fatalf("messages len = %d, want 3: %#v", len(messages), messages)
 	}
-	if messages[1].Content != "[stored conversation history; role=assistant]\nstored previous answer" {
+	if messages[1].Content != "[stored conversation history]\n<conversation_message>\nstored previous answer\n</conversation_message>" {
 		t.Fatalf("history message = %q, want annotated stored previous answer", messages[1].Content)
 	}
 	if messages[2].Role != "user" || messages[2].Content != "client current turn" {
@@ -160,8 +160,8 @@ func TestRun_SendsStoredHistoryAsMessages(t *testing.T) {
 		t.Fatalf("system prompt still embeds conversation history:\n%s", got[0].Content)
 	}
 	want := []llm.Message{
-		{Role: "user", Content: "[stored conversation history; role=user]\nprior question"},
-		{Role: "assistant", Content: "[stored conversation history; role=assistant]\nprior answer"},
+		{Role: "user", Content: "[stored conversation history]\n<conversation_message>\nprior question\n</conversation_message>"},
+		{Role: "assistant", Content: "[stored conversation history]\n<conversation_message>\nprior answer\n</conversation_message>"},
 		{Role: "user", Content: "current request"},
 	}
 	for i, w := range want {
@@ -204,7 +204,50 @@ func TestRun_UsesConfiguredClockForStoredHistoryAgeLabels(t *testing.T) {
 		t.Fatalf("llm calls = %d, want 1", len(mock.calls))
 	}
 	got := mock.calls[0].Messages[1].Content
-	if !strings.HasPrefix(got, "[stored conversation history; role=user; age_delta=-300s]\n") {
+	if !strings.HasPrefix(got, "[stored conversation history; age_delta=-300s]\n") {
 		t.Fatalf("stored history content = %q, want age_delta from loop clock", got)
+	}
+}
+
+func TestBuildInitialLLMMessages_StoredSignalHistorySeparatesMetadataAndCorpus(t *testing.T) {
+	now := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	messages := buildInitialLLMMessages(
+		"system prompt",
+		nil,
+		[]memory.Message{{
+			Role:      "user",
+			Content:   "Signal message from Alice (+15551234567) [ts:1700000000000]:\n\nnew binary, this is a fidelity test",
+			Timestamp: now.Add(-2 * time.Minute),
+		}},
+		[]Message{{Role: "user", Content: "current request"}},
+		"signal-15551234567",
+		now,
+	)
+
+	if len(messages) != 3 {
+		t.Fatalf("messages len = %d, want 3: %#v", len(messages), messages)
+	}
+	history := messages[1]
+	if history.Role != "user" {
+		t.Fatalf("history role = %q, want user", history.Role)
+	}
+	for _, want := range []string{
+		"[stored conversation history; age_delta=-120s; channel=signal]",
+		"<conversation_message>\nnew binary, this is a fidelity test\n</conversation_message>",
+	} {
+		if !strings.Contains(history.Content, want) {
+			t.Fatalf("history content = %q, want %q", history.Content, want)
+		}
+	}
+	for _, unwanted := range []string{
+		"role=user",
+		"Alice (+15551234567)",
+		"Signal message from",
+		"[ts:1700000000000]",
+		"transport_ts=1700000000000",
+	} {
+		if strings.Contains(history.Content, unwanted) {
+			t.Fatalf("history content contains %q:\n%s", unwanted, history.Content)
+		}
 	}
 }

--- a/internal/runtime/agent/loop.go
+++ b/internal/runtime/agent/loop.go
@@ -3248,44 +3248,11 @@ func triggerMessagesForRequest(conversationID string, messages []Message) []Mess
 // compaction summaries and handoffs, not provider-level system prompts, so
 // they are carried as historical assistant notes.
 func historyMessageToLLM(m memory.Message, now time.Time) (llm.Message, bool) {
-	role := strings.TrimSpace(m.Role)
-	content := m.Content
-	if role == "" && strings.TrimSpace(content) == "" {
+	entry, ok := memory.FormatStoredHistoryMessage(m, now)
+	if !ok {
 		return llm.Message{}, false
 	}
-	switch role {
-	case "user", "assistant":
-		return llm.Message{Role: role, Content: historyContentHeader("stored conversation history", role, m.Timestamp, now) + content}, true
-	case "system":
-		return llm.Message{
-			Role:    "assistant",
-			Content: historyContentHeader("stored conversation memory note; original_role=system; not active instruction", "", m.Timestamp, now) + content,
-		}, true
-	case "tool":
-		return llm.Message{
-			Role:    "assistant",
-			Content: historyContentHeader("stored historical tool result; original_role=tool; context only", "", m.Timestamp, now) + content,
-		}, true
-	default:
-		return llm.Message{
-			Role:    "user",
-			Content: historyContentHeader("stored historical message; original_role="+role, "", m.Timestamp, now) + content,
-		}, true
-	}
-}
-
-func historyContentHeader(kind, role string, timestamp, now time.Time) string {
-	var parts []string
-	if kind != "" {
-		parts = append(parts, kind)
-	}
-	if role != "" {
-		parts = append(parts, "role="+role)
-	}
-	if !timestamp.IsZero() && !now.IsZero() {
-		parts = append(parts, "age_delta="+promptfmt.FormatDeltaOnly(timestamp, now))
-	}
-	return "[" + strings.Join(parts, "; ") + "]\n"
+	return llm.Message{Role: entry.Role, Content: entry.Content}, true
 }
 
 func historyGapMarker(previous, next memory.Message) (llm.Message, bool) {

--- a/internal/state/memory/format.go
+++ b/internal/state/memory/format.go
@@ -2,6 +2,8 @@ package memory
 
 import (
 	"encoding/json"
+	"regexp"
+	"strings"
 	"time"
 
 	"github.com/nugget/thane-ai-agent/internal/model/promptfmt"
@@ -88,13 +90,16 @@ const maxMessageContentBytes = 2000
 // T is a signed-second delta via [promptfmt.FormatDeltaOnly]. SessionID
 // is always emitted (empty string when unknown) so the model sees a
 // stable schema across calls. ContentTruncated signals when Content was
-// clipped to [maxMessageContentBytes].
+// clipped to [maxMessageContentBytes]. Metadata carries transport
+// provenance separated from the literal message body when a known channel
+// envelope is detected.
 type MessageView struct {
-	T                string `json:"t"`
-	Role             string `json:"role"`
-	Content          string `json:"content"`
-	ContentTruncated bool   `json:"content_truncated"`
-	SessionID        string `json:"session_id"`
+	T                string            `json:"t"`
+	Role             string            `json:"role"`
+	Content          string            `json:"content"`
+	ContentTruncated bool              `json:"content_truncated"`
+	SessionID        string            `json:"session_id"`
+	Metadata         map[string]string `json:"metadata,omitempty"`
 }
 
 // SearchResultView is the JSON-facing projection of an archive search hit.
@@ -222,7 +227,8 @@ func sessionToView(s *Session, now time.Time) SessionView {
 const archiveAssistantRole = "past you"
 
 func messageToView(m Message, now time.Time) MessageView {
-	content, truncated := clipContent(m.Content, maxMessageContentBytes)
+	body, metadata := splitTransportEnvelope(m.Content)
+	content, truncated := clipContent(body, maxMessageContentBytes)
 	role := m.Role
 	if role == "assistant" {
 		role = archiveAssistantRole
@@ -233,7 +239,136 @@ func messageToView(m Message, now time.Time) MessageView {
 		Content:          content,
 		ContentTruncated: truncated,
 		SessionID:        m.SessionID,
+		Metadata:         metadata,
 	}
+}
+
+// StoredHistoryMessage is a provider-neutral message entry built from
+// stored conversation history. Role is the provider role to use in
+// messages[]. Content is the model-facing body for that role.
+type StoredHistoryMessage struct {
+	Role    string
+	Content string
+}
+
+// FormatStoredHistoryMessage renders one memory row for provider
+// messages[]. It keeps provider-native roles as the primary role signal
+// and separates curation/transport metadata from literal corpus content.
+func FormatStoredHistoryMessage(m Message, now time.Time) (StoredHistoryMessage, bool) {
+	role := strings.TrimSpace(m.Role)
+	if role == "" && strings.TrimSpace(m.Content) == "" {
+		return StoredHistoryMessage{}, false
+	}
+
+	providerRole := role
+	kind := "stored conversation history"
+	var metadata []metadataPart
+	switch role {
+	case "user", "assistant":
+		// Native provider role carries the speaker identity.
+	case "system":
+		providerRole = "assistant"
+		kind = "stored conversation memory note"
+		metadata = append(metadata,
+			metadataPart{key: "original_role", value: "system"},
+			metadataPart{key: "not_active_instruction", value: "true"},
+		)
+	case "tool":
+		providerRole = "assistant"
+		kind = "stored historical tool result"
+		metadata = append(metadata,
+			metadataPart{key: "original_role", value: "tool"},
+			metadataPart{key: "context_only", value: "true"},
+		)
+	default:
+		providerRole = "user"
+		kind = "stored historical message"
+		if role != "" {
+			metadata = append(metadata, metadataPart{key: "original_role", value: role})
+		}
+	}
+	if providerRole == "" {
+		providerRole = "user"
+	}
+
+	body, transportMetadata := splitTransportEnvelope(m.Content)
+	if !m.Timestamp.IsZero() && !now.IsZero() {
+		metadata = append(metadata, metadataPart{key: "age_delta", value: promptfmt.FormatDeltaOnly(m.Timestamp, now)})
+	}
+	metadata = append(metadata, storedHistoryTransportMetadataParts(transportMetadata)...)
+
+	return StoredHistoryMessage{
+		Role:    providerRole,
+		Content: renderStoredHistoryContent(kind, metadata, body),
+	}, true
+}
+
+type metadataPart struct {
+	key   string
+	value string
+}
+
+func renderStoredHistoryContent(kind string, metadata []metadataPart, content string) string {
+	parts := []string{kind}
+	for _, part := range metadata {
+		key := sanitizeMetadataValue(part.key)
+		value := sanitizeMetadataValue(part.value)
+		if key == "" || value == "" {
+			continue
+		}
+		parts = append(parts, key+"="+value)
+	}
+	var sb strings.Builder
+	sb.WriteString("[")
+	sb.WriteString(strings.Join(parts, "; "))
+	sb.WriteString("]\n")
+	sb.WriteString("<conversation_message>\n")
+	sb.WriteString(content)
+	sb.WriteString("\n</conversation_message>")
+	return sb.String()
+}
+
+func sanitizeMetadataValue(value string) string {
+	value = strings.TrimSpace(value)
+	value = strings.ReplaceAll(value, "\n", " ")
+	value = strings.ReplaceAll(value, "\r", " ")
+	value = strings.ReplaceAll(value, ";", ",")
+	return strings.Join(strings.Fields(value), " ")
+}
+
+func storedHistoryTransportMetadataParts(metadata map[string]string) []metadataPart {
+	if len(metadata) == 0 {
+		return nil
+	}
+	parts := make([]metadataPart, 0, 3)
+	if channel := metadata["channel"]; channel != "" {
+		parts = append(parts, metadataPart{key: "channel", value: channel})
+	}
+	if groupID := metadata["group_id"]; groupID != "" {
+		if sender := metadata["sender"]; sender != "" {
+			parts = append(parts, metadataPart{key: "sender", value: sender})
+		}
+		parts = append(parts, metadataPart{key: "group_id", value: groupID})
+	}
+	return parts
+}
+
+var signalMessageEnvelopeRE = regexp.MustCompile(`(?s)^Signal message from (.+?)(?: in group (.+?))? \[ts:([^\]]+)\]:\n\n(.*)$`)
+
+func splitTransportEnvelope(content string) (string, map[string]string) {
+	match := signalMessageEnvelopeRE.FindStringSubmatch(content)
+	if match == nil {
+		return content, nil
+	}
+	metadata := map[string]string{
+		"channel":      "signal",
+		"sender":       strings.TrimSpace(match[1]),
+		"transport_ts": strings.TrimSpace(match[3]),
+	}
+	if group := strings.TrimSpace(match[2]); group != "" {
+		metadata["group_id"] = group
+	}
+	return match[4], metadata
 }
 
 func messagesToViews(messages []Message, now time.Time) []MessageView {

--- a/internal/state/memory/format.go
+++ b/internal/state/memory/format.go
@@ -86,13 +86,23 @@ type SessionView struct {
 // tool's overall byte budget and forcing the handler to drop everything.
 const maxMessageContentBytes = 2000
 
+// maxMessageMetadataValueBytes bounds each transport metadata value in
+// archive-facing JSON and stored-history headers. Metadata is small
+// provenance, not corpus; bounding it prevents unusual channel labels from
+// dominating byte-capped archive tool output.
+const maxMessageMetadataValueBytes = 256
+
+const maxMessageMetadataKeyBytes = 64
+
 // MessageView is the JSON-facing projection of an archived message.
 // T is a signed-second delta via [promptfmt.FormatDeltaOnly]. SessionID
 // is always emitted (empty string when unknown) so the model sees a
 // stable schema across calls. ContentTruncated signals when Content was
 // clipped to [maxMessageContentBytes]. Metadata carries transport
 // provenance separated from the literal message body when a known channel
-// envelope is detected.
+// envelope is detected. Metadata keys and values are individually capped
+// so one malformed envelope cannot force byte-capped tools to drop all
+// messages.
 type MessageView struct {
 	T                string            `json:"t"`
 	Role             string            `json:"role"`
@@ -311,8 +321,8 @@ type metadataPart struct {
 func renderStoredHistoryContent(kind string, metadata []metadataPart, content string) string {
 	parts := []string{kind}
 	for _, part := range metadata {
-		key := sanitizeMetadataValue(part.key)
-		value := sanitizeMetadataValue(part.value)
+		key := sanitizeMetadataToken(part.key, maxMessageMetadataKeyBytes)
+		value := sanitizeMetadataToken(part.value, maxMessageMetadataValueBytes)
 		if key == "" || value == "" {
 			continue
 		}
@@ -334,6 +344,12 @@ func sanitizeMetadataValue(value string) string {
 	value = strings.ReplaceAll(value, "\r", " ")
 	value = strings.ReplaceAll(value, ";", ",")
 	return strings.Join(strings.Fields(value), " ")
+}
+
+func sanitizeMetadataToken(value string, maxBytes int) string {
+	value = sanitizeMetadataValue(value)
+	value, _ = clipContent(value, maxBytes)
+	return value
 }
 
 func storedHistoryTransportMetadataParts(metadata map[string]string) []metadataPart {
@@ -368,7 +384,26 @@ func splitTransportEnvelope(content string) (string, map[string]string) {
 	if group := strings.TrimSpace(match[2]); group != "" {
 		metadata["group_id"] = group
 	}
-	return match[4], metadata
+	return match[4], normalizeMetadata(metadata)
+}
+
+func normalizeMetadata(metadata map[string]string) map[string]string {
+	if len(metadata) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(metadata))
+	for key, value := range metadata {
+		key = sanitizeMetadataToken(key, maxMessageMetadataKeyBytes)
+		value = sanitizeMetadataToken(value, maxMessageMetadataValueBytes)
+		if key == "" || value == "" {
+			continue
+		}
+		out[key] = value
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
 }
 
 func messagesToViews(messages []Message, now time.Time) []MessageView {

--- a/internal/state/memory/format_test.go
+++ b/internal/state/memory/format_test.go
@@ -192,6 +192,101 @@ func TestFormatRecentMessages_ContentTruncation(t *testing.T) {
 	}
 }
 
+func TestFormatRecentMessages_SeparatesSignalEnvelopeMetadata(t *testing.T) {
+	now := time.Date(2026, 4, 25, 12, 0, 0, 0, time.UTC)
+	messages := []Message{{
+		Role:      "user",
+		Content:   "Signal message from Alice (+15551234567) [ts:1700000000000]:\n\nnew binary, this is a fidelity test",
+		Timestamp: now.Add(-30 * time.Minute),
+		SessionID: "s_abc",
+	}}
+
+	data := FormatRecentMessages(messages, now, false)
+
+	var parsed struct {
+		Messages []MessageView `json:"messages"`
+	}
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(parsed.Messages) != 1 {
+		t.Fatalf("messages len = %d, want 1", len(parsed.Messages))
+	}
+	msg := parsed.Messages[0]
+	if msg.Content != "new binary, this is a fidelity test" {
+		t.Fatalf("content = %q, want literal message body only", msg.Content)
+	}
+	if msg.Metadata["channel"] != "signal" {
+		t.Fatalf("metadata[channel] = %q, want signal", msg.Metadata["channel"])
+	}
+	if msg.Metadata["sender"] != "Alice (+15551234567)" {
+		t.Fatalf("metadata[sender] = %q", msg.Metadata["sender"])
+	}
+	if msg.Metadata["transport_ts"] != "1700000000000" {
+		t.Fatalf("metadata[transport_ts] = %q", msg.Metadata["transport_ts"])
+	}
+}
+
+func TestFormatStoredHistoryMessage_SeparatesMetadataAndCorpus(t *testing.T) {
+	now := time.Date(2026, 4, 25, 12, 0, 0, 0, time.UTC)
+	entry, ok := FormatStoredHistoryMessage(Message{
+		Role:      "user",
+		Content:   "Signal message from Alice (+15551234567) [ts:1700000000000]:\n\nnew binary, this is a fidelity test",
+		Timestamp: now.Add(-30 * time.Minute),
+	}, now)
+	if !ok {
+		t.Fatal("FormatStoredHistoryMessage returned ok=false")
+	}
+	if entry.Role != "user" {
+		t.Fatalf("role = %q, want user", entry.Role)
+	}
+	for _, want := range []string{
+		"[stored conversation history; age_delta=-1800s; channel=signal]",
+		"<conversation_message>\nnew binary, this is a fidelity test\n</conversation_message>",
+	} {
+		if !strings.Contains(entry.Content, want) {
+			t.Fatalf("content = %q, want %q", entry.Content, want)
+		}
+	}
+	for _, unwanted := range []string{
+		"role=user",
+		"Alice (+15551234567)",
+		"Signal message from",
+		"[ts:1700000000000]",
+		"transport_ts=1700000000000",
+	} {
+		if strings.Contains(entry.Content, unwanted) {
+			t.Fatalf("content contains %q:\n%s", unwanted, entry.Content)
+		}
+	}
+}
+
+func TestFormatStoredHistoryMessage_SystemRoleAsMemoryNote(t *testing.T) {
+	now := time.Date(2026, 4, 25, 12, 0, 0, 0, time.UTC)
+	entry, ok := FormatStoredHistoryMessage(Message{
+		Role:      "system",
+		Content:   "[Conversation Summary] earlier context",
+		Timestamp: now.Add(-10 * time.Minute),
+	}, now)
+	if !ok {
+		t.Fatal("FormatStoredHistoryMessage returned ok=false")
+	}
+	if entry.Role != "assistant" {
+		t.Fatalf("role = %q, want assistant", entry.Role)
+	}
+	for _, want := range []string{
+		"stored conversation memory note",
+		"original_role=system",
+		"not_active_instruction=true",
+		"age_delta=-600s",
+		"<conversation_message>\n[Conversation Summary] earlier context\n</conversation_message>",
+	} {
+		if !strings.Contains(entry.Content, want) {
+			t.Fatalf("content = %q, want %q", entry.Content, want)
+		}
+	}
+}
+
 func TestFormatSearchResults_StructurePreserved(t *testing.T) {
 	now := time.Date(2026, 4, 25, 12, 0, 0, 0, time.UTC)
 	results := []SearchResult{
@@ -237,6 +332,38 @@ func TestFormatSearchResults_StructurePreserved(t *testing.T) {
 	}
 	if r.Highlight != "freezer alert" {
 		t.Errorf("highlight = %q", r.Highlight)
+	}
+}
+
+func TestFormatSearchResults_SeparatesSignalEnvelopeMetadata(t *testing.T) {
+	now := time.Date(2026, 4, 25, 12, 0, 0, 0, time.UTC)
+	results := []SearchResult{{
+		Match: Message{
+			Role:      "user",
+			Content:   "Signal message from Alice (+15551234567) [ts:1700000000000]:\n\nnew binary, this is a fidelity test",
+			Timestamp: now.Add(-2 * time.Hour),
+			SessionID: "s_xyz",
+		},
+		SessionID: "s_xyz",
+	}}
+
+	data := FormatSearchResults(results, now, false)
+
+	var parsed struct {
+		Results []SearchResultView `json:"results"`
+	}
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(parsed.Results) != 1 {
+		t.Fatalf("results len = %d, want 1", len(parsed.Results))
+	}
+	match := parsed.Results[0].Match
+	if match.Content != "new binary, this is a fidelity test" {
+		t.Fatalf("match content = %q, want literal message body only", match.Content)
+	}
+	if match.Metadata["channel"] != "signal" || match.Metadata["transport_ts"] != "1700000000000" {
+		t.Fatalf("match metadata = %#v, want signal transport metadata", match.Metadata)
 	}
 }
 

--- a/internal/state/memory/format_test.go
+++ b/internal/state/memory/format_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 	"time"
+	"unicode/utf8"
 )
 
 func TestFormatSessionsList_StableSchema(t *testing.T) {
@@ -227,6 +228,46 @@ func TestFormatRecentMessages_SeparatesSignalEnvelopeMetadata(t *testing.T) {
 	}
 }
 
+func TestFormatRecentMessages_ClipsSignalEnvelopeMetadata(t *testing.T) {
+	now := time.Date(2026, 4, 25, 12, 0, 0, 0, time.UTC)
+	hugeSender := strings.Repeat("sender", maxMessageMetadataValueBytes)
+	hugeGroup := strings.Repeat("group", maxMessageMetadataValueBytes)
+	hugeTransportTS := strings.Repeat("1", maxMessageMetadataValueBytes*2)
+	messages := []Message{{
+		Role:      "user",
+		Content:   "Signal message from " + hugeSender + " in group " + hugeGroup + " [ts:" + hugeTransportTS + "]:\n\nbody",
+		Timestamp: now.Add(-30 * time.Minute),
+		SessionID: "s_abc",
+	}}
+
+	data := FormatRecentMessages(messages, now, false)
+
+	var parsed struct {
+		Messages []MessageView `json:"messages"`
+	}
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(parsed.Messages) != 1 {
+		t.Fatalf("messages len = %d, want 1", len(parsed.Messages))
+	}
+	for _, key := range []string{"sender", "group_id", "transport_ts"} {
+		value := parsed.Messages[0].Metadata[key]
+		if value == "" {
+			t.Fatalf("metadata[%s] is empty", key)
+		}
+		if len(value) > maxMessageMetadataValueBytes {
+			t.Fatalf("metadata[%s] len = %d, want <= %d", key, len(value), maxMessageMetadataValueBytes)
+		}
+		if !utf8.ValidString(value) {
+			t.Fatalf("metadata[%s] is not valid UTF-8", key)
+		}
+	}
+	if strings.Contains(string(data), hugeSender) || strings.Contains(string(data), hugeGroup) || strings.Contains(string(data), hugeTransportTS) {
+		t.Fatalf("metadata output contains an unclipped huge field: %s", data)
+	}
+}
+
 func TestFormatStoredHistoryMessage_SeparatesMetadataAndCorpus(t *testing.T) {
 	now := time.Date(2026, 4, 25, 12, 0, 0, 0, time.UTC)
 	entry, ok := FormatStoredHistoryMessage(Message{
@@ -258,6 +299,24 @@ func TestFormatStoredHistoryMessage_SeparatesMetadataAndCorpus(t *testing.T) {
 		if strings.Contains(entry.Content, unwanted) {
 			t.Fatalf("content contains %q:\n%s", unwanted, entry.Content)
 		}
+	}
+}
+
+func TestFormatStoredHistoryMessage_ClipsHeaderMetadata(t *testing.T) {
+	hugeRole := strings.Repeat("historical_role", maxMessageMetadataValueBytes)
+	entry, ok := FormatStoredHistoryMessage(Message{
+		Role:    hugeRole,
+		Content: "body",
+	}, time.Time{})
+	if !ok {
+		t.Fatal("FormatStoredHistoryMessage returned ok=false")
+	}
+	if strings.Contains(entry.Content, hugeRole) {
+		t.Fatalf("stored-history header contains unclipped metadata:\n%s", entry.Content)
+	}
+	want := "original_role=" + hugeRole[:maxMessageMetadataValueBytes]
+	if !strings.Contains(entry.Content, want) {
+		t.Fatalf("stored-history header = %q, want clipped role metadata %q", entry.Content, want)
 	}
 }
 


### PR DESCRIPTION
## Summary

- move stored-history `messages[]` rendering into the shared memory formatting layer used by archive JSON projections
- split known Signal transport envelopes into metadata while keeping `content` as literal conversation corpus for `archive_search`, archive ranges, archive transcripts, and stored-history provider messages
- keep direct-message live history headers lightweight (`channel=signal`) while preserving fuller sender/timestamp provenance in archive JSON metadata
- document the metadata-vs-corpus convention in model-facing context guidance

## Validation

- `just test`
- `just ci`

Closes #854