### PR TITLE
fix: tighten loops launch contract and supporting guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,10 @@ on GitHub Actions to catch what you could have caught locally.
   `httpkit.NewTransport()` — never construct `http.Client{}` directly.
   httpkit is the single source of truth for outbound HTTP: retry
   transport, User-Agent injection, connection pool management.
+- **HTTP handlers**: Set explicit timeouts at the server boundary, keep
+  handlers thin, and return bounded responses. The handler should be a
+  shell around package-level logic that can be unit-tested without
+  standing up a server.
 - **Prefer the standard library**. Third-party imports add supply chain
   risk, version churn, and transitive deps. Use stdlib when it can do the
   job.
@@ -73,13 +77,48 @@ on GitHub Actions to catch what you could have caught locally.
 - **Tool result sizes**: Cap output (search: 16 KB, transcripts: 32 KB).
   Watch for unbounded data returns.
 - **Config defaults**: Set in `applyDefaults()`, not struct tags.
-- **Go doc comments**: GoDoc is a primary audience for this codebase.
-  Every exported symbol gets a doc comment starting with its name that
-  reads as a complete sentence. Every package gets `// Package foo ...`.
-  Write comments that help a reader understand *why*, not just *what* —
-  the signature already says what.
+- **Documentation**: See the [Documentation](#documentation) section
+  below. The short version: GoDoc is a product surface, not commentary,
+  and the bar differs for exported (full contract) vs unexported
+  (rationale where it earns its place).
+- **Package boundaries**: Keep them honest. Avoid shared "utility"
+  packages until two real call sites prove the abstraction belongs
+  there. Prefer placing helpers in the package that owns the type.
 - **Provider pattern**: New integrations implement a provider interface
   (see `search.Provider`).
+
+## Documentation
+
+GoDoc is a primary product surface, not commentary on the source. A
+reader on pkg.go.dev (or running `go doc`) should be able to use any
+package correctly without opening it.
+
+**Exported symbols** carry that load: document the contract, not the Go
+shape. Every exported symbol gets a doc comment starting with its name
+that reads as a complete sentence. Every package gets
+`// Package foo ...`. Use Go 1.19+ heading syntax for navigable
+package-level docs, cross-reference related symbols with
+`[Identifier]` doc links, and add runnable `Example*` tests for primary
+usage patterns so the docs cannot bit-rot.
+
+**Unexported symbols** answer a different question: *why is this here
+in its current form?* The test for whether a comment is earning its
+place:
+
+> If a contributor deleted this symbol in a PR, would the surrounding
+> code make clear why that's wrong?
+
+If no, document the why. If yes, no comment needed. This bar prevents
+two failure modes: undocumented decisions that look like accidents
+("why is this field still here?") and reflexive doc comments that just
+restate the signature. Fields that look like relics but aren't — kept
+for internal callers, retained for backwards compatibility, deliberately
+narrower than the surrounding type implies — are exactly where this
+rationale earns its place.
+
+Model-facing context and tool authoring have their own conventions; see
+[docs/model-facing-context.md](docs/model-facing-context.md) and
+[docs/model-facing-tools.md](docs/model-facing-tools.md).
 
 ## Architecture at a Glance
 

--- a/docs/milestone-strategy.md
+++ b/docs/milestone-strategy.md
@@ -72,7 +72,7 @@ forward into point releases when priorities shift.
 
 Milestones track *when* something ships. Labels track *what area* it
 belongs to. An issue's thematic identity lives in its labels (e.g.,
-`security`, `architecture`, `loops-ng`), not its milestone.
+`security`, `architecture`, `loops`), not its milestone.
 
 To see progress on a pillar like identity/trust: filter by label across
 all milestones. To see what's shipping next: look at the current point

--- a/docs/operating/configuration.md
+++ b/docs/operating/configuration.md
@@ -271,7 +271,7 @@ Cron-style task scheduling. Each task can override the model and routing
 hints. See [Event Sources](../reference/event-sources.md) for how scheduled
 tasks integrate with the agent loop.
 
-Self-reflection (`ego.md` maintenance) runs as the `ego` loops-ng service,
+Self-reflection (`ego.md` maintenance) runs as the `ego` service loop,
 not as a scheduled task. See the `ego:` block in the example config for
 sleep bounds, supervisor randomization, and routing.
 

--- a/docs/reference/event-sources.md
+++ b/docs/reference/event-sources.md
@@ -78,7 +78,7 @@ Cron-style scheduling stored in SQLite. Each task defines:
 - Missed execution recovery (fires on next startup if the window was missed)
 
 Custom tasks can be created via the `schedule_task` tool. Built-in
-recurring work runs as loops-ng service definitions instead — for
+recurring work runs as service loop definitions instead — for
 example, the `ego` loop maintains `core/ego.md` with bounded voluntary
 sleep and supervisor randomization, and the `email-poller` loop drives
 IMAP polling.

--- a/docs/understanding/glossary.md
+++ b/docs/understanding/glossary.md
@@ -118,6 +118,26 @@ A persistent global behavioral mode that modifies context across all
 conversations. Unlike capability tags (which activate tools), lenses
 shape *how* the agent behaves. Activated and deactivated via tools.
 
+### Loop Definition
+
+A named, persistable description of a loop. Three names appear for
+related-but-distinct shapes; they refer to the same underlying thing
+at different layers:
+
+- **Definition** — the model-facing and API-facing term. What
+  `loop_definition_*` tools operate on. A snapshot includes the
+  current spec, policy state, and live runtime status. This is the
+  word to use in tool descriptions, talents, and prose.
+- **Spec** — the Go type (`loop.Spec`) that holds the durable shape:
+  task, tags, outputs, sleep envelope, profile, supervisor settings,
+  conditions, metadata. Internal vocabulary.
+- **Config** — the engine-facing runtime form (`loop.Config`) derived
+  from a Spec via `Spec.ToConfig()`. Used by the loop runner; not
+  exposed to the model.
+
+When in doubt, say "definition" externally and use `Spec`/`Config`
+only in Go contexts where the type matters.
+
 ### MCP (Model Context Protocol)
 
 A standard protocol for extending LLM capabilities via external tool

--- a/docs/understanding/glossary.md
+++ b/docs/understanding/glossary.md
@@ -138,7 +138,7 @@ a frontier model to catch blind spots.
 A long-cycle self-reflection loop that maintains `core/ego.md` — the
 agent's own evolving notes on how its thinking is changing, what
 patterns it observes in itself, and honest self-assessment. Runs as a
-loops-ng service with bounded voluntary sleep, supervisor randomization,
+service loop with bounded voluntary sleep, supervisor randomization,
 and a declared maintained-document output. The interactive agent reads
 `ego.md` every turn; the ego loop is the sole writer.
 

--- a/examples/config.example.yaml
+++ b/examples/config.example.yaml
@@ -854,7 +854,7 @@ talents_dir: ./talents
 #   jitter: 0.2
 #   SupervisorProbability is the chance (0.0–1.0) that each wake
 #   uses a frontier model with supervisor-augmented prompt.
-#   Default: 0.1. Set to 0.0 to disable supervisor iterations.
+#   Default: 0.1. Set to 0.0 to disable supervisor turns.
 #   supervisor_probability: 0.1
 #   Router configures model routing for normal (non-supervisor)
 #   iterations.
@@ -863,7 +863,7 @@ talents_dir: ./talents
 #     selection. Default: 3 for normal iterations, 8 for supervisor.
 #     quality_floor: 3
 #   SupervisorRouter configures model routing for supervisor
-#   iterations (frontier model with augmented prompt).
+#   turns (frontier model with augmented prompt).
 #   supervisor_router:
 #     QualityFloor is the minimum quality rating (1–10) for model
 #     selection. Default: 3 for normal iterations, 8 for supervisor.
@@ -889,7 +889,7 @@ ego:
   jitter: 0.2
   # SupervisorProbability is the chance (0.0–1.0) that each wake
   # uses a frontier model with supervisor-augmented prompt.
-  # Default: 0.2. Set to 0.0 to disable supervisor iterations.
+  # Default: 0.2. Set to 0.0 to disable supervisor turns.
   supervisor_probability: 0.2
   # Router configures model routing for normal iterations.
   router:
@@ -897,7 +897,7 @@ ego:
     # selection. Default: 5 for normal iterations, 8 for supervisor.
     quality_floor: 5
   # SupervisorRouter configures model routing for supervisor
-  # iterations (frontier model with augmented prompt).
+  # turns (frontier model with augmented prompt).
   supervisor_router:
     # QualityFloor is the minimum quality rating (1–10) for model
     # selection. Default: 5 for normal iterations, 8 for supervisor.

--- a/internal/app/adapters.go
+++ b/internal/app/adapters.go
@@ -610,7 +610,7 @@ func resolveContactByChannelLink(store *contacts.Store, channel, address string)
 
 // conversationSystemInjector is the shared app-side bridge for writing
 // detached messages back into live conversations. Both notification
-// callbacks and loops-ng detached completions use this adapter so
+// callbacks and detached loop completions use this adapter so
 // completion routing converges on one app-level seam.
 type conversationSystemInjector struct {
 	mem      memory.MemoryStore

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -165,7 +165,7 @@ type App struct {
 	// Media
 	mediaStore *media.MediaStore
 
-	// Service loop runtimes hydrated into built-in loops-ng definitions.
+	// Service loop runtimes hydrated into built-in loop definitions.
 	unifiPoller        *unifi.Poller
 	haStateWatcher     *homeassistant.StateWatcher
 	emailPoller        *email.Poller

--- a/internal/app/loop_definition_runtime.go
+++ b/internal/app/loop_definition_runtime.go
@@ -397,7 +397,19 @@ func (r *loopDefinitionRuntime) LaunchDefinition(ctx context.Context, name strin
 			// The runtime captures requestOverride at launch time and
 			// never re-applies it; returning the existing loop ID
 			// silently would hide that fact from the caller.
-			if launch.HasOverrides() {
+			//
+			// Two failure modes to catch:
+			//   1. Per-launch overrides (model, hints, allowed_tools,
+			//      etc.) — Launch.HasOverrides covers these.
+			//   2. An inline launch.spec — normally overwritten by the
+			//      runtime spec further down, but on the
+			//      already-running early return below the overwrite
+			//      never runs and the caller's spec would silently
+			//      vanish. HasOverrides intentionally excludes Spec
+			//      (it would otherwise flag the non-running path too,
+			//      where the overwrite makes it benign); check Spec
+			//      separately here so the guard is complete.
+			if launch.HasOverrides() || !launch.Spec.IsZero() {
 				log.Warn("rejecting launch overrides for running service definition",
 					"loop_id", existing.ID(),
 					"operation", looppkg.OperationService,

--- a/internal/app/loop_definition_runtime.go
+++ b/internal/app/loop_definition_runtime.go
@@ -393,6 +393,17 @@ func (r *loopDefinitionRuntime) LaunchDefinition(ctx context.Context, name strin
 	}
 	if def.Spec.Operation == looppkg.OperationService {
 		if existing := r.loops.GetByName(name); existing != nil {
+			// Loud-fail on overrides for already-running service loops.
+			// The runtime captures requestOverride at launch time and
+			// never re-applies it; returning the existing loop ID
+			// silently would hide that fact from the caller.
+			if launch.HasOverrides() {
+				log.Warn("rejecting launch overrides for running service definition",
+					"loop_id", existing.ID(),
+					"operation", looppkg.OperationService,
+				)
+				return looppkg.LaunchResult{}, &looppkg.RunningServiceOverridesError{Name: name}
+			}
 			log.Info("using existing running loop definition service",
 				"loop_id", existing.ID(),
 				"operation", looppkg.OperationService,

--- a/internal/app/loop_definition_runtime.go
+++ b/internal/app/loop_definition_runtime.go
@@ -393,23 +393,14 @@ func (r *loopDefinitionRuntime) LaunchDefinition(ctx context.Context, name strin
 	}
 	if def.Spec.Operation == looppkg.OperationService {
 		if existing := r.loops.GetByName(name); existing != nil {
-			// Loud-fail on overrides for already-running service loops.
-			// The runtime captures requestOverride at launch time and
-			// never re-applies it; returning the existing loop ID
-			// silently would hide that fact from the caller.
-			//
-			// Two failure modes to catch:
-			//   1. Per-launch overrides (model, hints, allowed_tools,
-			//      etc.) — Launch.HasOverrides covers these.
-			//   2. An inline launch.spec — normally overwritten by the
-			//      runtime spec further down, but on the
-			//      already-running early return below the overwrite
-			//      never runs and the caller's spec would silently
-			//      vanish. HasOverrides intentionally excludes Spec
-			//      (it would otherwise flag the non-running path too,
-			//      where the overwrite makes it benign); check Spec
-			//      separately here so the guard is complete.
-			if launch.HasOverrides() || !launch.Spec.IsZero() {
+			// Loud-fail on caller payload for already-running service
+			// loops. The runtime captures requestOverride at launch
+			// time and never re-applies it, and the spec-overwrite
+			// further down doesn't run on this early-return path —
+			// silently returning the existing loop ID would hide both
+			// drops from the caller. HasOverrides covers per-launch
+			// override fields and inline launch.spec alike.
+			if launch.HasOverrides() {
 				log.Warn("rejecting launch overrides for running service definition",
 					"loop_id", existing.ID(),
 					"operation", looppkg.OperationService,

--- a/internal/app/loop_definition_runtime_test.go
+++ b/internal/app/loop_definition_runtime_test.go
@@ -583,7 +583,6 @@ func TestLoopDefinitionRuntimeLaunchDefinitionRunningServiceRejectsOverrides(t *
 		name   string
 		launch looppkg.Launch
 	}{
-		{"model", looppkg.Launch{Model: "claude-sonnet-4-5"}},
 		{"hints", looppkg.Launch{Hints: map[string]string{"quality_floor": "7"}}},
 		{"allowed_tools", looppkg.Launch{AllowedTools: []string{"get_state"}}},
 		{"max_iterations", looppkg.Launch{MaxIterations: 5}},

--- a/internal/app/loop_definition_runtime_test.go
+++ b/internal/app/loop_definition_runtime_test.go
@@ -519,6 +519,91 @@ func TestLoopDefinitionRuntimeReconcileDefinitionStopsWhenConditionsNoLongerMatc
 	}
 }
 
+func TestLoopDefinitionRuntimeLaunchDefinitionRunningServiceRejectsOverrides(t *testing.T) {
+	t.Parallel()
+
+	registry, err := looppkg.NewDefinitionRegistry([]looppkg.Spec{
+		{
+			Name:         "closet_guardian",
+			Enabled:      true,
+			Task:         "Watch the closet.",
+			Operation:    looppkg.OperationService,
+			Completion:   looppkg.CompletionNone,
+			SleepMin:     time.Minute,
+			SleepMax:     time.Minute,
+			SleepDefault: time.Minute,
+			Jitter:       looppkg.Float64Ptr(0),
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewDefinitionRegistry: %v", err)
+	}
+
+	loops := looppkg.NewRegistry()
+	t.Cleanup(func() {
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		loops.ShutdownAll(shutdownCtx)
+	})
+	if _, err := loops.SpawnLoop(context.Background(), looppkg.Config{
+		Name:         "closet_guardian",
+		Handler:      func(context.Context, any) error { return nil },
+		SleepMin:     time.Minute,
+		SleepMax:     time.Minute,
+		SleepDefault: time.Minute,
+		Jitter:       looppkg.Float64Ptr(0),
+	}, looppkg.Deps{
+		Logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}); err != nil {
+		t.Fatalf("SpawnLoop: %v", err)
+	}
+
+	runtime := &loopDefinitionRuntime{
+		definitions: registry,
+		loops:       loops,
+		runner:      testLoopRunner{},
+		logger:      slog.New(slog.NewTextHandler(io.Discard, nil)),
+		now:         time.Now,
+		scheduleCh:  make(chan struct{}, 1),
+	}
+
+	// Empty launch joins the running loop and returns its ID.
+	result, err := runtime.LaunchDefinition(context.Background(), "closet_guardian", looppkg.Launch{})
+	if err != nil {
+		t.Fatalf("LaunchDefinition(empty): unexpected error %v", err)
+	}
+	if result.LoopID == "" || result.Operation != looppkg.OperationService || !result.Detached {
+		t.Fatalf("empty launch result = %+v, want running service handle", result)
+	}
+
+	// Any caller-supplied override field on the same running service
+	// loop must surface a typed error rather than silently dropping
+	// the override.
+	overrides := []struct {
+		name   string
+		launch looppkg.Launch
+	}{
+		{"model", looppkg.Launch{Model: "claude-sonnet-4-5"}},
+		{"hints", looppkg.Launch{Hints: map[string]string{"quality_floor": "7"}}},
+		{"allowed_tools", looppkg.Launch{AllowedTools: []string{"get_state"}}},
+		{"max_iterations", looppkg.Launch{MaxIterations: 5}},
+		{"metadata", looppkg.Launch{Metadata: map[string]string{"reason": "experiment"}}},
+	}
+	for _, tc := range overrides {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := runtime.LaunchDefinition(context.Background(), "closet_guardian", tc.launch)
+			var running *looppkg.RunningServiceOverridesError
+			if err == nil || !errors.As(err, &running) {
+				t.Fatalf("LaunchDefinition(%s) error = %v, want *RunningServiceOverridesError", tc.name, err)
+			}
+			if running.Name != "closet_guardian" {
+				t.Fatalf("error.Name = %q, want %q", running.Name, "closet_guardian")
+			}
+		})
+	}
+}
+
 func TestLoopDefinitionRuntimeLaunchDefinitionRejectsIneligibleDefinition(t *testing.T) {
 	t.Parallel()
 

--- a/internal/app/loop_definition_runtime_test.go
+++ b/internal/app/loop_definition_runtime_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/nugget/thane-ai-agent/internal/model/router"
 	"github.com/nugget/thane-ai-agent/internal/platform/events"
 	looppkg "github.com/nugget/thane-ai-agent/internal/runtime/loop"
 )
@@ -587,6 +588,14 @@ func TestLoopDefinitionRuntimeLaunchDefinitionRunningServiceRejectsOverrides(t *
 		{"allowed_tools", looppkg.Launch{AllowedTools: []string{"get_state"}}},
 		{"max_iterations", looppkg.Launch{MaxIterations: 5}},
 		{"metadata", looppkg.Launch{Metadata: map[string]string{"reason": "experiment"}}},
+		// Inline launch.spec gets silently overwritten on the normal
+		// path and silently dropped on the running-service early
+		// return — guard must catch the latter case explicitly since
+		// HasOverrides excludes Spec.
+		{"spec", looppkg.Launch{Spec: looppkg.Spec{
+			Name:    "closet_guardian",
+			Profile: router.LoopProfile{Model: "claude-sonnet-4-5"},
+		}}},
 	}
 	for _, tc := range overrides {
 		tc := tc

--- a/internal/app/new_agent.go
+++ b/internal/app/new_agent.go
@@ -15,7 +15,7 @@ import (
 
 // initAgentLoop builds the core agent loop, resolves path prefixes and
 // context injection files, and starts the initial conversation session.
-// Self-reflection runs as the ego loops-ng service (see internal/runtime/ego).
+// Self-reflection runs as the ego service loop (see internal/runtime/ego).
 func (a *App) initAgentLoop(s *newState) error {
 	cfg := a.cfg
 	logger := a.logger
@@ -146,7 +146,7 @@ func corePromptFilesForStartupVerification(logger *slog.Logger, paths ...string)
 
 // removeLegacyPeriodicReflectionTask deletes the persisted
 // periodic_reflection scheduler row from older builds. Self-reflection
-// is now handled by the ego loops-ng service. Best-effort: errors are
+// is now handled by the ego service loop. Best-effort: errors are
 // logged and ignored so a missing row or transient error does not block
 // startup.
 func (a *App) removeLegacyPeriodicReflectionTask(logger *slog.Logger) {
@@ -170,7 +170,7 @@ func (a *App) removeLegacyPeriodicReflectionTask(logger *slog.Logger) {
 	}
 	logger.Info("removed legacy periodic_reflection scheduler task",
 		"id", existing.ID,
-		"replacement", "ego loops-ng service",
+		"replacement", "ego service loop",
 	)
 }
 

--- a/internal/app/new_servers.go
+++ b/internal/app/new_servers.go
@@ -546,7 +546,7 @@ func (a *App) initServers(s *newState) error {
 	}
 
 	// --- Loop definition services ---
-	// Durable loops-ng service definitions are bootstrapped from the
+	// Durable loop service definitions are bootstrapped from the
 	// immutable+overlay definition registry. Built-in services like
 	// metacognitive, pollers, watchers, and MQTT publishers participate
 	// as first-class definitions via runtime spec hydration.

--- a/internal/app/taskexec.go
+++ b/internal/app/taskexec.go
@@ -24,7 +24,7 @@ type taskExecDeps struct {
 }
 
 // runScheduledTask handles execution of a scheduled task by compiling it
-// into a transient loops-ng launch. Unsupported payload kinds are logged
+// into a transient loop launch. Unsupported payload kinds are logged
 // and silently ignored (returning nil, not an error).
 func runScheduledTask(ctx context.Context, task *scheduler.Task, exec *scheduler.Execution, deps taskExecDeps) error {
 	log := deps.logger.With(
@@ -72,7 +72,7 @@ func runScheduledTask(ctx context.Context, task *scheduler.Task, exec *scheduler
 }
 
 // buildScheduledTaskLaunch compiles a persisted scheduler task and one
-// execution record into a loops-ng launch with scheduler-specific
+// execution record into a loop launch with scheduler-specific
 // routing, metadata, and timeout inheritance.
 func buildScheduledTaskLaunch(ctx context.Context, task *scheduler.Task, exec *scheduler.Execution) looppkg.Launch {
 	msg, _ := task.Payload.Data["message"].(string)

--- a/internal/model/prompts/ego.go
+++ b/internal/model/prompts/ego.go
@@ -69,8 +69,7 @@ If it reads like something you'd put in a ticket, it doesn't belong here.
 - Quality of thought matters more than coverage. Quiet observation and
   a long sleep beats a manufactured update.`
 
-// egoSupervisorAugmentation is appended for frontier/supervisor
-// iterations.
+// egoSupervisorAugmentation is appended for frontier/supervisor turns.
 const egoSupervisorAugmentation = `
 
 ## Supervisor Review (Frontier Iteration)

--- a/internal/model/prompts/ego_test.go
+++ b/internal/model/prompts/ego_test.go
@@ -25,13 +25,13 @@ func TestEgoPrompt_NormalIteration(t *testing.T) {
 	}
 }
 
-func TestEgoPrompt_SupervisorIteration(t *testing.T) {
+func TestEgoPrompt_SupervisorTurn(t *testing.T) {
 	got := EgoPrompt(true)
 
 	if !strings.Contains(got, "Supervisor Review") {
-		t.Error("supervisor iteration should include supervisor review section")
+		t.Error("supervisor turn should include supervisor review section")
 	}
 	if !strings.Contains(got, "Ego loop iteration") {
-		t.Error("supervisor iteration should still include base prompt")
+		t.Error("supervisor turn should still include base prompt")
 	}
 }

--- a/internal/model/prompts/metacognitive.go
+++ b/internal/model/prompts/metacognitive.go
@@ -48,8 +48,7 @@ names the generated replacement tool for the document.
   tools are NOT available.
 - If nothing interesting is happening, note it and sleep long.`
 
-// metacognitiveSupervisorAugmentation is appended for frontier/supervisor
-// iterations.
+// metacognitiveSupervisorAugmentation is appended for frontier/supervisor turns.
 const metacognitiveSupervisorAugmentation = `
 
 ## Supervisor Review (Frontier Iteration)

--- a/internal/platform/config/config.go
+++ b/internal/platform/config/config.go
@@ -314,7 +314,7 @@ type Config struct {
 	Ego EgoConfig `yaml:"ego"`
 
 	// Loops configures immutable loop definitions loaded from the config
-	// file. These definitions become the base layer for the loops-ng
+	// file. These definitions become the base layer for the loop
 	// definition registry, with a persistent dynamic overlay applied at
 	// runtime.
 	Loops LoopsConfig `yaml:"loops"`
@@ -1751,8 +1751,8 @@ type MetacognitiveRouterConfig struct {
 }
 
 // EgoConfig configures the self-reflection ego loop. The loop runs as a
-// loops-ng service: bounded voluntary sleep, supervisor randomization,
-// and a declared maintained-document output at core/ego.md. Replaces the
+// service loop: bounded voluntary sleep, supervisor randomization, and
+// a declared maintained-document output at core/ego.md. Replaces the
 // legacy periodic_reflection scheduled task.
 type EgoConfig struct {
 	// Enabled controls whether the ego loop starts. Default: false.
@@ -1794,7 +1794,7 @@ type EgoRouterConfig struct {
 	QualityFloor int `yaml:"quality_floor"`
 }
 
-// LoopsConfig configures immutable loops-ng definitions loaded from the
+// LoopsConfig configures immutable loop definitions loaded from the
 // config file.
 type LoopsConfig struct {
 	// MaxRunning caps the number of concurrently running loops across

--- a/internal/platform/config/config.go
+++ b/internal/platform/config/config.go
@@ -1731,7 +1731,7 @@ type MetacognitiveConfig struct {
 
 	// SupervisorProbability is the chance (0.0–1.0) that each wake
 	// uses a frontier model with supervisor-augmented prompt.
-	// Default: 0.1. Set to 0.0 to disable supervisor iterations.
+	// Default: 0.1. Set to 0.0 to disable supervisor turns.
 	SupervisorProbability *float64 `yaml:"supervisor_probability,omitempty"`
 
 	// Router configures model routing for normal (non-supervisor)
@@ -1739,7 +1739,7 @@ type MetacognitiveConfig struct {
 	Router MetacognitiveRouterConfig `yaml:"router"`
 
 	// SupervisorRouter configures model routing for supervisor
-	// iterations (frontier model with augmented prompt).
+	// turns (frontier model with augmented prompt).
 	SupervisorRouter MetacognitiveRouterConfig `yaml:"supervisor_router"`
 }
 
@@ -1776,14 +1776,14 @@ type EgoConfig struct {
 
 	// SupervisorProbability is the chance (0.0–1.0) that each wake
 	// uses a frontier model with supervisor-augmented prompt.
-	// Default: 0.2. Set to 0.0 to disable supervisor iterations.
+	// Default: 0.2. Set to 0.0 to disable supervisor turns.
 	SupervisorProbability *float64 `yaml:"supervisor_probability,omitempty"`
 
 	// Router configures model routing for normal iterations.
 	Router EgoRouterConfig `yaml:"router"`
 
 	// SupervisorRouter configures model routing for supervisor
-	// iterations (frontier model with augmented prompt).
+	// turns (frontier model with augmented prompt).
 	SupervisorRouter EgoRouterConfig `yaml:"supervisor_router"`
 }
 

--- a/internal/runtime/delegate/delegate.go
+++ b/internal/runtime/delegate/delegate.go
@@ -341,7 +341,7 @@ func (e *Executor) SetLensProvider(fn func() []string) {
 
 // ConfigureLoopExecution configures loop-backed delegate execution. When both
 // runner and registry are set, Execute launches a one-shot child loop through
-// the shared loops-ng path, giving delegates the same telemetry path as other
+// the shared loops path, giving delegates the same telemetry path as other
 // loop-driven work.
 func (e *Executor) ConfigureLoopExecution(runner looppkg.Runner, registry *looppkg.Registry) {
 	e.loopRunner = runner
@@ -382,7 +382,7 @@ func (e *Executor) Execute(ctx context.Context, task, profileName, guidance stri
 
 func (e *Executor) execute(ctx context.Context, task, profileName, guidance string, tags []string, opts executionOptions) (*Result, error) {
 	if e.loopRunner == nil || e.loopRegistry == nil {
-		return nil, fmt.Errorf("delegate execution requires loops-ng wiring; call ConfigureLoopExecution before Execute")
+		return nil, fmt.Errorf("delegate execution requires loops wiring; call ConfigureLoopExecution before Execute")
 	}
 	return e.executeViaLoop(ctx, task, profileName, guidance, tags, opts)
 }
@@ -396,7 +396,7 @@ func (e *Executor) StartBackground(ctx context.Context, task, profileName, guida
 
 func (e *Executor) startBackground(ctx context.Context, task, profileName, guidance string, tags []string, opts executionOptions) (string, string, error) {
 	if e.loopRunner == nil || e.loopRegistry == nil {
-		return "", "", fmt.Errorf("background delegation requires loops-ng execution")
+		return "", "", fmt.Errorf("background delegation requires loops execution")
 	}
 	if e.completionSink == nil {
 		return "", "", fmt.Errorf("background delegation requires a completion sink")

--- a/internal/runtime/delegate/delegate.go
+++ b/internal/runtime/delegate/delegate.go
@@ -571,6 +571,7 @@ func (e *Executor) buildLoopLaunch(prep *preparedExecution, task, guidance strin
 			MaxDuration: loopMaxDuration,
 			Tags:        append([]string(nil), prep.filterTags...),
 			Profile: router.LoopProfile{
+				Model:        prep.model,
 				Instructions: prompts.DelegateRunInstructions,
 			},
 			Metadata: map[string]string{
@@ -586,7 +587,6 @@ func (e *Executor) buildLoopLaunch(prep *preparedExecution, task, guidance strin
 		ParentID:                 prep.parentLoopID,
 		ConversationID:           prep.conversationID,
 		ChannelBinding:           prep.channelBinding.Clone(),
-		Model:                    prep.model,
 		Hints:                    hints,
 		ExcludeTools:             append([]string(nil), prep.excludeTools...),
 		SkipTagFilter:            !prep.tagFilterActive,

--- a/internal/runtime/delegate/delegate_test.go
+++ b/internal/runtime/delegate/delegate_test.go
@@ -777,7 +777,7 @@ func TestExecute_RequiresLoopExecutionWiring(t *testing.T) {
 
 	_, err := exec.Execute(context.Background(), "Check the office light", "general", "", nil)
 	if err == nil {
-		t.Fatal("Execute() without loops-ng wiring should return error")
+		t.Fatal("Execute() without loops wiring should return error")
 	}
 	if !strings.Contains(err.Error(), "ConfigureLoopExecution") {
 		t.Errorf("error %q should mention ConfigureLoopExecution", err)
@@ -786,17 +786,17 @@ func TestExecute_RequiresLoopExecutionWiring(t *testing.T) {
 
 // TestStartBackground_RequiresLoopExecutionWiring is the StartBackground
 // counterpart to TestExecute_RequiresLoopExecutionWiring. Same rationale:
-// the contract is that loops-ng wiring is mandatory and the failure mode
+// the contract is that loops wiring is mandatory and the failure mode
 // must be actionable.
 func TestStartBackground_RequiresLoopExecutionWiring(t *testing.T) {
 	exec := NewExecutor(slog.Default(), &mockLLMClient{}, nil, newTestRegistry(), "test-model")
 
 	_, err := exec.StartBackground(context.Background(), "Check the office light", "general", "", nil)
 	if err == nil {
-		t.Fatal("StartBackground() without loops-ng wiring should return error")
+		t.Fatal("StartBackground() without loops wiring should return error")
 	}
-	if !strings.Contains(err.Error(), "loops-ng") {
-		t.Errorf("error %q should mention loops-ng wiring", err)
+	if !strings.Contains(err.Error(), "loops") {
+		t.Errorf("error %q should mention loops wiring", err)
 	}
 }
 
@@ -931,7 +931,7 @@ func TestExecute_LoopBackedDelegateRequiresStreamingCapableModel(t *testing.T) {
 	}
 }
 
-// delegateCompletionSink is a test stub for the loops-ng completion
+// delegateCompletionSink is a test stub for the loop completion
 // delivery interface used by background delegate tests.
 type delegateCompletionSink struct {
 	deliveries chan looppkg.CompletionDelivery

--- a/internal/runtime/ego/ego.go
+++ b/internal/runtime/ego/ego.go
@@ -1,5 +1,5 @@
 // Package ego implements the self-reflection loop that maintains
-// core/ego.md. It runs as a loops-ng service: each iteration is a fresh
+// core/ego.md. It runs as a service loop: each iteration is a fresh
 // conversation with bounded voluntary sleep, supervisor randomization
 // for periodic frontier review, and a declared maintained-document
 // output that pins ego.md to the loop.
@@ -21,7 +21,7 @@ import (
 	"github.com/nugget/thane-ai-agent/internal/tools"
 )
 
-// DefinitionName is the durable loops-ng definition name for the ego
+// DefinitionName is the durable loop definition name for the ego
 // service.
 const DefinitionName = "ego"
 
@@ -84,7 +84,7 @@ func derefFloat(p *float64, def float64) float64 {
 	return *p
 }
 
-// DefinitionSpec returns the persistable loops-ng definition for the ego
+// DefinitionSpec returns the persistable loop definition for the ego
 // service. Runtime hooks are attached later by [HydrateSpec] so the
 // definition can live in the durable registry.
 func DefinitionSpec(cfg Config) loop.Spec {
@@ -126,7 +126,7 @@ func DefinitionSpec(cfg Config) loop.Spec {
 }
 
 // HydrateSpec attaches the runtime-only hooks needed to execute the ego
-// service from a durable loops-ng definition.
+// service from a durable loop definition.
 func HydrateSpec(spec loop.Spec, cfg Config) loop.Spec {
 	if strings.TrimSpace(spec.Name) == "" {
 		spec.Name = DefinitionName
@@ -138,8 +138,8 @@ func HydrateSpec(spec loop.Spec, cfg Config) loop.Spec {
 }
 
 // BuildSpec returns a [loop.Spec] that implements the ego loop as a
-// standard loops-ng service. The returned spec declares the durable
-// output document and uses runtime hooks to build prompts.
+// service loop. The returned spec declares the durable output document
+// and uses runtime hooks to build prompts.
 func BuildSpec(cfg Config) loop.Spec {
 	spec := DefinitionSpec(cfg)
 	spec.SupervisorContext = ""
@@ -147,8 +147,8 @@ func BuildSpec(cfg Config) loop.Spec {
 }
 
 // BuildLoopConfig returns the engine-facing [loop.Config] view of the
-// ego loop. Kept as a compatibility bridge while loops-ng adoption is
-// in progress.
+// ego loop. Kept as a compatibility shim for callers that work directly
+// with [loop.Config] rather than [loop.Spec].
 func BuildLoopConfig(cfg Config) loop.Config {
 	spec := BuildSpec(cfg)
 	out := spec.ToConfig()

--- a/internal/runtime/loop/conditions.go
+++ b/internal/runtime/loop/conditions.go
@@ -16,7 +16,7 @@ const (
 // Conditions describes optional runtime eligibility gates for a loop
 // definition. The first supported condition family is schedule-based,
 // and additional condition families can be added here over time
-// without changing the surrounding loops-ng contract shape.
+// without changing the surrounding loop contract shape.
 type Conditions struct {
 	// Schedule constrains when the definition is currently eligible for
 	// runtime use. When unset, the definition is always eligible unless

--- a/internal/runtime/loop/config.go
+++ b/internal/runtime/loop/config.go
@@ -191,13 +191,13 @@ type Config struct {
 	QualityFloor int
 
 	// SupervisorContext is an optional prompt prepended to the Task
-	// during supervisor iterations. Use it to give the frontier model
+	// during supervisor turns. Use it to give the frontier model
 	// review instructions, recent iteration summaries, or oversight
 	// criteria. Empty means supervisor runs the same Task as normal.
 	SupervisorContext string
 
 	// SupervisorQualityFloor is the minimum model quality rating
-	// for supervisor iterations. Zero uses the router default.
+	// for supervisor turns. Zero uses the router default.
 	SupervisorQualityFloor int
 
 	// OnRetrigger determines behavior when the loop's start
@@ -368,7 +368,7 @@ type IterationResult struct {
 	LoadedCapabilities []toolcatalog.LoadedCapabilityEntry
 	// Elapsed is the wall-clock duration of the iteration.
 	Elapsed time.Duration
-	// Supervisor indicates whether this was a supervisor iteration.
+	// Supervisor indicates whether this iteration ran a supervisor turn.
 	Supervisor bool
 	// Sleep is the computed sleep duration before the next iteration.
 	Sleep time.Duration
@@ -406,7 +406,7 @@ type IterationSnapshot struct {
 	// value is directly usable by the client without nanosecond
 	// conversion.
 	ElapsedMs int64 `json:"elapsed_ms"`
-	// Supervisor indicates whether this was a supervisor iteration.
+	// Supervisor indicates whether this iteration ran a supervisor turn.
 	Supervisor bool `json:"supervisor,omitempty"`
 	// Error holds the error message if the iteration failed.
 	Error string `json:"error,omitempty"`
@@ -473,8 +473,8 @@ type Status struct {
 	// (newest first), used by the dashboard timeline.
 	RecentIterations []IterationSnapshot `json:"recent_iterations,omitempty"`
 	// LastSupervisorIter is the iteration number of the most recent
-	// successful supervisor iteration. Zero means no supervisor
-	// iteration has completed yet.
+	// iteration that ran a successful supervisor turn. Zero means
+	// no supervisor turn has completed yet.
 	LastSupervisorIter int `json:"last_supervisor_iter,omitempty"`
 	// LLMContext holds enrichment data from the most recent
 	// loop_llm_start event (model, est_tokens, messages, tools,

--- a/internal/runtime/loop/definition_policy.go
+++ b/internal/runtime/loop/definition_policy.go
@@ -80,11 +80,11 @@ func (e *PausedDefinitionError) Error() string {
 }
 
 // RunningServiceOverridesError reports that the caller targeted a
-// service-mode loop that is already running and attached per-launch
-// override fields that the runtime would silently drop. The remediation
-// is to mutate the stored spec (e.g. spec.profile.model via
-// loop_definition_set) and stop+relaunch, rather than re-issuing the
-// launch with overrides that have no effect.
+// service-mode loop that is already running and supplied either
+// per-launch override fields or an inline spec that the runtime would
+// silently drop. The remediation is to mutate the stored spec (e.g.
+// spec.profile.model via loop_definition_set) and stop+relaunch,
+// rather than re-issuing the launch with payload that has no effect.
 type RunningServiceOverridesError struct {
 	Name string
 }
@@ -92,7 +92,7 @@ type RunningServiceOverridesError struct {
 func (e *RunningServiceOverridesError) Error() string {
 	return fmt.Sprintf(
 		"loop: service definition %q is already running; "+
-			"per-launch overrides are dropped for active service loops. "+
+			"both per-launch overrides and inline launch.spec changes are dropped for active service loops. "+
 			"To apply new settings, update the stored spec via loop_definition_set "+
 			"(e.g. spec.profile.model) and restart with stop_loop + loop_definition_launch. "+
 			"To just retrieve the loop ID, call loop_definition_launch with an empty launch ({}).",

--- a/internal/runtime/loop/definition_policy.go
+++ b/internal/runtime/loop/definition_policy.go
@@ -79,6 +79,26 @@ func (e *PausedDefinitionError) Error() string {
 	return fmt.Sprintf("loop: definition %q is paused", e.Name)
 }
 
+// RunningServiceOverridesError reports that the caller targeted a
+// service-mode loop that is already running and attached per-launch
+// override fields that the runtime would silently drop. The remediation
+// is to mutate the stored spec (e.g. spec.profile.model via
+// loop_definition_set) and stop+relaunch, rather than re-issuing the
+// launch with overrides that have no effect.
+type RunningServiceOverridesError struct {
+	Name string
+}
+
+func (e *RunningServiceOverridesError) Error() string {
+	return fmt.Sprintf(
+		"loop: service definition %q is already running; "+
+			"per-launch overrides are dropped for active service loops. "+
+			"To apply new settings, update the stored spec via loop_definition_set "+
+			"(e.g. spec.profile.model) and restart with stop_loop + loop_definition_launch. "+
+			"To just retrieve the loop ID, call loop_definition_launch with an empty launch ({}).",
+		e.Name)
+}
+
 func defaultDefinitionPolicyState(spec Spec) DefinitionPolicyState {
 	if spec.Enabled {
 		return DefinitionPolicyStateActive

--- a/internal/runtime/loop/definition_view.go
+++ b/internal/runtime/loop/definition_view.go
@@ -31,7 +31,7 @@ type DefinitionRuntimeStatus struct {
 }
 
 // DefinitionView is the combined stored-definition and live-runtime view
-// exposed by loops-ng read surfaces.
+// exposed by loop read surfaces.
 type DefinitionView struct {
 	DefinitionSnapshot `yaml:",inline"`
 	Eligibility        DefinitionEligibilityStatus `yaml:"eligibility,omitempty" json:"eligibility"`
@@ -56,7 +56,7 @@ type DefinitionRegistryView struct {
 }
 
 // BuildDefinitionRegistryView combines the durable definition snapshot
-// with an optional runtime-state map to produce the effective loops-ng
+// with an optional runtime-state map to produce the effective loop
 // registry view used by API and tool read surfaces.
 func BuildDefinitionRegistryView(snapshot *DefinitionRegistrySnapshot, runtime map[string]DefinitionRuntimeStatus) *DefinitionRegistryView {
 	return buildDefinitionRegistryViewAt(snapshot, runtime, time.Now())

--- a/internal/runtime/loop/definition_warnings.go
+++ b/internal/runtime/loop/definition_warnings.go
@@ -6,7 +6,7 @@ import (
 )
 
 // DefinitionWarning is a non-fatal authoring concern discovered while
-// inspecting a persistable loops-ng definition. Warnings are surfaced
+// inspecting a persistable loop definition. Warnings are surfaced
 // through definition views and lint tooling so the model can correct
 // likely mistakes before they become noisy runtime behavior.
 type DefinitionWarning struct {

--- a/internal/runtime/loop/launch.go
+++ b/internal/runtime/loop/launch.go
@@ -14,19 +14,27 @@ import (
 // from [Spec] so per-launch overrides and delivery hooks can grow here
 // over time without turning [Spec] itself into an ephemeral run object.
 type Launch struct {
-	Spec           Spec                                   `yaml:"spec,omitempty" json:"spec,omitempty"`
-	Task           string                                 `yaml:"task,omitempty" json:"task,omitempty"`
-	ParentID       string                                 `yaml:"parent_id,omitempty" json:"parent_id,omitempty"`
-	Metadata       map[string]string                      `yaml:"metadata,omitempty" json:"metadata,omitempty"`
-	ConversationID string                                 `yaml:"conversation_id,omitempty" json:"conversation_id,omitempty"`
-	ChannelBinding *memory.ChannelBinding                 `yaml:"channel_binding,omitempty" json:"channel_binding,omitempty"`
-	Model          string                                 `yaml:"model,omitempty" json:"model,omitempty"`
-	Hints          map[string]string                      `yaml:"hints,omitempty" json:"hints,omitempty"`
-	AllowedTools   []string                               `yaml:"allowed_tools,omitempty" json:"allowed_tools,omitempty"`
-	ExcludeTools   []string                               `yaml:"exclude_tools,omitempty" json:"exclude_tools,omitempty"`
-	InitialTags    []string                               `yaml:"initial_tags,omitempty" json:"initial_tags,omitempty"`
-	OnProgress     func(kind string, data map[string]any) `yaml:"-" json:"-"`
-	RunTimeout     time.Duration                          `yaml:"run_timeout,omitempty" json:"run_timeout,omitempty"`
+	Spec           Spec                   `yaml:"spec,omitempty" json:"spec,omitempty"`
+	Task           string                 `yaml:"task,omitempty" json:"task,omitempty"`
+	ParentID       string                 `yaml:"parent_id,omitempty" json:"parent_id,omitempty"`
+	Metadata       map[string]string      `yaml:"metadata,omitempty" json:"metadata,omitempty"`
+	ConversationID string                 `yaml:"conversation_id,omitempty" json:"conversation_id,omitempty"`
+	ChannelBinding *memory.ChannelBinding `yaml:"channel_binding,omitempty" json:"channel_binding,omitempty"`
+	// Model overrides the model for this single Launch. Reserved for
+	// internal Go callers (delegates, scheduled tasks) that build
+	// one-shot Launches with throwaway Specs. The agent-facing tool
+	// surface (loop_definition_launch, spawn_loop) intentionally does
+	// not expose this field and rejects it on input: for service-mode
+	// loops the runtime drops every launch override when the loop is
+	// already running, and Launch itself is not persisted across
+	// restarts. Persistent model selection lives on Spec.Profile.Model.
+	Model        string                                 `yaml:"model,omitempty" json:"model,omitempty"`
+	Hints        map[string]string                      `yaml:"hints,omitempty" json:"hints,omitempty"`
+	AllowedTools []string                               `yaml:"allowed_tools,omitempty" json:"allowed_tools,omitempty"`
+	ExcludeTools []string                               `yaml:"exclude_tools,omitempty" json:"exclude_tools,omitempty"`
+	InitialTags  []string                               `yaml:"initial_tags,omitempty" json:"initial_tags,omitempty"`
+	OnProgress   func(kind string, data map[string]any) `yaml:"-" json:"-"`
+	RunTimeout   time.Duration                          `yaml:"run_timeout,omitempty" json:"run_timeout,omitempty"`
 	// CompletionConversationID names the live conversation that should
 	// receive detached completion delivery when Spec.Completion is
 	// CompletionConversation.
@@ -158,6 +166,54 @@ func (l *Launch) UnmarshalJSON(data []byte) error {
 		SuppressAlwaysContext:    wire.SuppressAlwaysContext,
 	}
 	return nil
+}
+
+// HasOverrides reports whether the launch carries any caller-supplied
+// per-launch override field. Returns false for the zero value (callers
+// joining an existing loop with no per-run customization). Spec is
+// excluded because [loopDefinitionRuntime.LaunchDefinition] overwrites
+// it with the stored runtime spec, and OnProgress is excluded because
+// it is an internal-only delivery hook.
+//
+// Used by the active-service-loop guard to surface a loud error when a
+// caller passes overrides that would be silently dropped (the runtime
+// returns the existing loop ID without re-applying any override fields).
+func (l *Launch) HasOverrides() bool {
+	if l == nil {
+		return false
+	}
+	if l.Task != "" ||
+		l.ParentID != "" ||
+		l.ConversationID != "" ||
+		l.Model != "" ||
+		l.SystemPrompt != "" ||
+		l.FallbackContent != "" ||
+		l.CompletionConversationID != "" ||
+		l.UsageRole != "" ||
+		l.UsageTaskName != "" ||
+		l.PromptMode != "" {
+		return true
+	}
+	if l.SkipContext || l.SkipTagFilter || l.SuppressAlwaysContext {
+		return true
+	}
+	if l.MaxIterations != 0 || l.MaxOutputTokens != 0 {
+		return true
+	}
+	if l.RunTimeout != 0 || l.ToolTimeout != 0 {
+		return true
+	}
+	if l.ChannelBinding != nil || l.CompletionChannel != nil {
+		return true
+	}
+	if len(l.Metadata) > 0 ||
+		len(l.Hints) > 0 ||
+		len(l.AllowedTools) > 0 ||
+		len(l.ExcludeTools) > 0 ||
+		len(l.InitialTags) > 0 {
+		return true
+	}
+	return false
 }
 
 // Validate checks that the launch is well-formed.

--- a/internal/runtime/loop/launch.go
+++ b/internal/runtime/loop/launch.go
@@ -10,7 +10,7 @@ import (
 	"github.com/nugget/thane-ai-agent/internal/state/memory"
 )
 
-// Launch describes a single loops-ng launch request. It is separate
+// Launch describes a single loops launch request. It is separate
 // from [Spec] so per-launch overrides and delivery hooks can grow here
 // over time without turning [Spec] itself into an ephemeral run object.
 type Launch struct {

--- a/internal/runtime/loop/launch.go
+++ b/internal/runtime/loop/launch.go
@@ -157,24 +157,26 @@ func (l *Launch) UnmarshalJSON(data []byte) error {
 }
 
 // HasOverrides reports whether the launch carries any caller-supplied
-// per-launch override field. Returns false for the zero value (callers
-// joining an existing loop with no per-run customization).
+// payload. Returns false for the zero value (callers joining an
+// existing loop with no per-run customization).
 //
-// Spec is intentionally excluded: on the normal launch path the runtime
-// overwrites it with the stored runtime spec, so a caller-supplied Spec
-// is benign there. The active-service-loop guard in
-// [loopDefinitionRuntime.LaunchDefinition] returns before that
-// overwrite, so it pairs HasOverrides with a separate [Spec.IsZero]
-// check to catch a caller-supplied Spec that would otherwise vanish
-// silently. OnProgress is excluded because it is an internal-only
-// delivery hook.
+// Includes Spec: a caller-supplied Spec is also caller payload. On the
+// normal launch path the runtime overwrites it with the stored runtime
+// spec so it's benign there, but the active-service-loop guard returns
+// before the overwrite, so flagging it here keeps that guard's check
+// to one expression. OnProgress is excluded because it is an
+// internal-only delivery hook.
 //
-// Used by the active-service-loop guard to surface a loud error when a
-// caller passes overrides that would be silently dropped (the runtime
-// returns the existing loop ID without re-applying any override fields).
+// Used by the active-service-loop guard in
+// [loopDefinitionRuntime.LaunchDefinition] to surface a loud error
+// when a caller passes payload that would be silently dropped (the
+// runtime returns the existing loop ID without re-applying anything).
 func (l *Launch) HasOverrides() bool {
 	if l == nil {
 		return false
+	}
+	if !l.Spec.IsZero() {
+		return true
 	}
 	if l.Task != "" ||
 		l.ParentID != "" ||

--- a/internal/runtime/loop/launch.go
+++ b/internal/runtime/loop/launch.go
@@ -158,10 +158,16 @@ func (l *Launch) UnmarshalJSON(data []byte) error {
 
 // HasOverrides reports whether the launch carries any caller-supplied
 // per-launch override field. Returns false for the zero value (callers
-// joining an existing loop with no per-run customization). Spec is
-// excluded because [loopDefinitionRuntime.LaunchDefinition] overwrites
-// it with the stored runtime spec, and OnProgress is excluded because
-// it is an internal-only delivery hook.
+// joining an existing loop with no per-run customization).
+//
+// Spec is intentionally excluded: on the normal launch path the runtime
+// overwrites it with the stored runtime spec, so a caller-supplied Spec
+// is benign there. The active-service-loop guard in
+// [loopDefinitionRuntime.LaunchDefinition] returns before that
+// overwrite, so it pairs HasOverrides with a separate [Spec.IsZero]
+// check to catch a caller-supplied Spec that would otherwise vanish
+// silently. OnProgress is excluded because it is an internal-only
+// delivery hook.
 //
 // Used by the active-service-loop guard to surface a loud error when a
 // caller passes overrides that would be silently dropped (the runtime

--- a/internal/runtime/loop/launch.go
+++ b/internal/runtime/loop/launch.go
@@ -14,27 +14,18 @@ import (
 // from [Spec] so per-launch overrides and delivery hooks can grow here
 // over time without turning [Spec] itself into an ephemeral run object.
 type Launch struct {
-	Spec           Spec                   `yaml:"spec,omitempty" json:"spec,omitempty"`
-	Task           string                 `yaml:"task,omitempty" json:"task,omitempty"`
-	ParentID       string                 `yaml:"parent_id,omitempty" json:"parent_id,omitempty"`
-	Metadata       map[string]string      `yaml:"metadata,omitempty" json:"metadata,omitempty"`
-	ConversationID string                 `yaml:"conversation_id,omitempty" json:"conversation_id,omitempty"`
-	ChannelBinding *memory.ChannelBinding `yaml:"channel_binding,omitempty" json:"channel_binding,omitempty"`
-	// Model overrides the model for this single Launch. Reserved for
-	// internal Go callers (delegates, scheduled tasks) that build
-	// one-shot Launches with throwaway Specs. The agent-facing tool
-	// surface (loop_definition_launch, spawn_loop) intentionally does
-	// not expose this field and rejects it on input: for service-mode
-	// loops the runtime drops every launch override when the loop is
-	// already running, and Launch itself is not persisted across
-	// restarts. Persistent model selection lives on Spec.Profile.Model.
-	Model        string                                 `yaml:"model,omitempty" json:"model,omitempty"`
-	Hints        map[string]string                      `yaml:"hints,omitempty" json:"hints,omitempty"`
-	AllowedTools []string                               `yaml:"allowed_tools,omitempty" json:"allowed_tools,omitempty"`
-	ExcludeTools []string                               `yaml:"exclude_tools,omitempty" json:"exclude_tools,omitempty"`
-	InitialTags  []string                               `yaml:"initial_tags,omitempty" json:"initial_tags,omitempty"`
-	OnProgress   func(kind string, data map[string]any) `yaml:"-" json:"-"`
-	RunTimeout   time.Duration                          `yaml:"run_timeout,omitempty" json:"run_timeout,omitempty"`
+	Spec           Spec                                   `yaml:"spec,omitempty" json:"spec,omitempty"`
+	Task           string                                 `yaml:"task,omitempty" json:"task,omitempty"`
+	ParentID       string                                 `yaml:"parent_id,omitempty" json:"parent_id,omitempty"`
+	Metadata       map[string]string                      `yaml:"metadata,omitempty" json:"metadata,omitempty"`
+	ConversationID string                                 `yaml:"conversation_id,omitempty" json:"conversation_id,omitempty"`
+	ChannelBinding *memory.ChannelBinding                 `yaml:"channel_binding,omitempty" json:"channel_binding,omitempty"`
+	Hints          map[string]string                      `yaml:"hints,omitempty" json:"hints,omitempty"`
+	AllowedTools   []string                               `yaml:"allowed_tools,omitempty" json:"allowed_tools,omitempty"`
+	ExcludeTools   []string                               `yaml:"exclude_tools,omitempty" json:"exclude_tools,omitempty"`
+	InitialTags    []string                               `yaml:"initial_tags,omitempty" json:"initial_tags,omitempty"`
+	OnProgress     func(kind string, data map[string]any) `yaml:"-" json:"-"`
+	RunTimeout     time.Duration                          `yaml:"run_timeout,omitempty" json:"run_timeout,omitempty"`
 	// CompletionConversationID names the live conversation that should
 	// receive detached completion delivery when Spec.Completion is
 	// CompletionConversation.
@@ -70,7 +61,6 @@ type launchJSON struct {
 	Metadata                 map[string]string        `json:"metadata,omitempty"`
 	ConversationID           string                   `json:"conversation_id,omitempty"`
 	ChannelBinding           *memory.ChannelBinding   `json:"channel_binding,omitempty"`
-	Model                    string                   `json:"model,omitempty"`
 	Hints                    map[string]string        `json:"hints,omitempty"`
 	AllowedTools             []string                 `json:"allowed_tools,omitempty"`
 	ExcludeTools             []string                 `json:"exclude_tools,omitempty"`
@@ -99,7 +89,6 @@ func (l Launch) MarshalJSON() ([]byte, error) {
 		Metadata:                 cloneStringMap(l.Metadata),
 		ConversationID:           l.ConversationID,
 		ChannelBinding:           l.ChannelBinding.Clone(),
-		Model:                    l.Model,
 		Hints:                    cloneStringMap(l.Hints),
 		AllowedTools:             append([]string(nil), l.AllowedTools...),
 		ExcludeTools:             append([]string(nil), l.ExcludeTools...),
@@ -145,7 +134,6 @@ func (l *Launch) UnmarshalJSON(data []byte) error {
 		Metadata:                 cloneStringMap(wire.Metadata),
 		ConversationID:           wire.ConversationID,
 		ChannelBinding:           wire.ChannelBinding.Clone(),
-		Model:                    wire.Model,
 		Hints:                    cloneStringMap(wire.Hints),
 		AllowedTools:             append([]string(nil), wire.AllowedTools...),
 		ExcludeTools:             append([]string(nil), wire.ExcludeTools...),
@@ -185,7 +173,6 @@ func (l *Launch) HasOverrides() bool {
 	if l.Task != "" ||
 		l.ParentID != "" ||
 		l.ConversationID != "" ||
-		l.Model != "" ||
 		l.SystemPrompt != "" ||
 		l.FallbackContent != "" ||
 		l.CompletionConversationID != "" ||
@@ -247,7 +234,6 @@ func (l *Launch) requestOverride() Request {
 		return Request{}
 	}
 	return Request{
-		Model:                 l.Model,
 		ConversationID:        l.ConversationID,
 		ChannelBinding:        l.ChannelBinding.Clone(),
 		SkipContext:           l.SkipContext,

--- a/internal/runtime/loop/launch_json_test.go
+++ b/internal/runtime/loop/launch_json_test.go
@@ -114,10 +114,14 @@ func TestLaunchHasOverrides(t *testing.T) {
 		}
 	})
 	t.Run("spec-only", func(t *testing.T) {
-		// Spec is overwritten by LaunchDefinition; not a caller override.
+		// Caller-supplied Spec counts as an override: on the running-
+		// service early-return path the runtime drops it silently, so
+		// HasOverrides has to flag it. The normal launch path
+		// overwrites it; flagging it there is harmless because no
+		// caller of HasOverrides currently runs on that path.
 		l := Launch{Spec: Spec{Name: "x", Task: "y"}}
-		if l.HasOverrides() {
-			t.Fatal("spec-only launch reported overrides")
+		if !l.HasOverrides() {
+			t.Fatal("spec-only launch did not report overrides")
 		}
 	})
 	cases := []struct {
@@ -148,6 +152,7 @@ func TestLaunchHasOverrides(t *testing.T) {
 		{"completion_conversation_id", func(l *Launch) { l.CompletionConversationID = "c" }, "CompletionConversationID"},
 		{"completion_channel", func(l *Launch) { l.CompletionChannel = &CompletionChannelTarget{Channel: "signal"} }, "CompletionChannel"},
 		{"channel_binding", func(l *Launch) { l.ChannelBinding = &memory.ChannelBinding{Channel: "signal"} }, "ChannelBinding"},
+		{"spec", func(l *Launch) { l.Spec = Spec{Name: "x"} }, "Spec"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -174,7 +179,7 @@ func TestLaunchHasOverrides(t *testing.T) {
 		for i := 0; i < typ.NumField(); i++ {
 			field := typ.Field(i)
 			name, _, _ := strings.Cut(field.Tag.Get("json"), ",")
-			if name == "" || name == "-" || name == "spec" {
+			if name == "" || name == "-" {
 				continue
 			}
 			if !covered[field.Name] {

--- a/internal/runtime/loop/launch_json_test.go
+++ b/internal/runtime/loop/launch_json_test.go
@@ -2,11 +2,14 @@ package loop
 
 import (
 	"encoding/json"
+	"reflect"
+	"sort"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/nugget/thane-ai-agent/internal/runtime/agentctx"
+	"github.com/nugget/thane-ai-agent/internal/state/memory"
 )
 
 func TestLaunchMarshalJSONUsesDurationStrings(t *testing.T) {
@@ -93,4 +96,95 @@ func TestLaunchValidateRejectsInvalidPromptMode(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "prompt_mode") {
 		t.Fatalf("Validate error = %v, want prompt_mode validation error", err)
 	}
+}
+
+func TestLaunchHasOverrides(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil", func(t *testing.T) {
+		var l *Launch
+		if l.HasOverrides() {
+			t.Fatal("nil launch reported overrides")
+		}
+	})
+	t.Run("zero-value", func(t *testing.T) {
+		var l Launch
+		if l.HasOverrides() {
+			t.Fatal("zero-value launch reported overrides")
+		}
+	})
+	t.Run("spec-only", func(t *testing.T) {
+		// Spec is overwritten by LaunchDefinition; not a caller override.
+		l := Launch{Spec: Spec{Name: "x", Task: "y"}}
+		if l.HasOverrides() {
+			t.Fatal("spec-only launch reported overrides")
+		}
+	})
+	cases := []struct {
+		name  string
+		mut   func(*Launch)
+		field string
+	}{
+		{"model", func(l *Launch) { l.Model = "x" }, "Model"},
+		{"task", func(l *Launch) { l.Task = "x" }, "Task"},
+		{"hints", func(l *Launch) { l.Hints = map[string]string{"k": "v"} }, "Hints"},
+		{"metadata", func(l *Launch) { l.Metadata = map[string]string{"k": "v"} }, "Metadata"},
+		{"allowed_tools", func(l *Launch) { l.AllowedTools = []string{"t"} }, "AllowedTools"},
+		{"exclude_tools", func(l *Launch) { l.ExcludeTools = []string{"t"} }, "ExcludeTools"},
+		{"initial_tags", func(l *Launch) { l.InitialTags = []string{"t"} }, "InitialTags"},
+		{"max_iterations", func(l *Launch) { l.MaxIterations = 3 }, "MaxIterations"},
+		{"max_output_tokens", func(l *Launch) { l.MaxOutputTokens = 256 }, "MaxOutputTokens"},
+		{"run_timeout", func(l *Launch) { l.RunTimeout = time.Second }, "RunTimeout"},
+		{"tool_timeout", func(l *Launch) { l.ToolTimeout = time.Second }, "ToolTimeout"},
+		{"conversation_id", func(l *Launch) { l.ConversationID = "c" }, "ConversationID"},
+		{"parent_id", func(l *Launch) { l.ParentID = "p" }, "ParentID"},
+		{"system_prompt", func(l *Launch) { l.SystemPrompt = "s" }, "SystemPrompt"},
+		{"fallback_content", func(l *Launch) { l.FallbackContent = "f" }, "FallbackContent"},
+		{"skip_context", func(l *Launch) { l.SkipContext = true }, "SkipContext"},
+		{"skip_tag_filter", func(l *Launch) { l.SkipTagFilter = true }, "SkipTagFilter"},
+		{"suppress_always_context", func(l *Launch) { l.SuppressAlwaysContext = true }, "SuppressAlwaysContext"},
+		{"prompt_mode", func(l *Launch) { l.PromptMode = agentctx.PromptModeTask }, "PromptMode"},
+		{"usage_role", func(l *Launch) { l.UsageRole = "r" }, "UsageRole"},
+		{"usage_task_name", func(l *Launch) { l.UsageTaskName = "n" }, "UsageTaskName"},
+		{"completion_conversation_id", func(l *Launch) { l.CompletionConversationID = "c" }, "CompletionConversationID"},
+		{"completion_channel", func(l *Launch) { l.CompletionChannel = &CompletionChannelTarget{Channel: "signal"} }, "CompletionChannel"},
+		{"channel_binding", func(l *Launch) { l.ChannelBinding = &memory.ChannelBinding{Channel: "signal"} }, "ChannelBinding"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var l Launch
+			tc.mut(&l)
+			if !l.HasOverrides() {
+				t.Fatalf("HasOverrides returned false after setting %s", tc.field)
+			}
+		})
+	}
+
+	// Forcing function: every caller-supplied field on Launch (anything
+	// with a non-empty JSON tag, excluding Spec which the runtime
+	// overwrites) must have a matching case above. Without this, adding
+	// a new override field would silently bypass the active-service-loop
+	// guard.
+	t.Run("covers-all-fields", func(t *testing.T) {
+		covered := make(map[string]bool, len(cases))
+		for _, tc := range cases {
+			covered[tc.field] = true
+		}
+		typ := reflect.TypeOf(Launch{})
+		var missing []string
+		for i := 0; i < typ.NumField(); i++ {
+			field := typ.Field(i)
+			name, _, _ := strings.Cut(field.Tag.Get("json"), ",")
+			if name == "" || name == "-" || name == "spec" {
+				continue
+			}
+			if !covered[field.Name] {
+				missing = append(missing, field.Name)
+			}
+		}
+		sort.Strings(missing)
+		if len(missing) > 0 {
+			t.Fatalf("Launch fields without HasOverrides coverage: %v — add a case above and update Launch.HasOverrides", missing)
+		}
+	})
 }

--- a/internal/runtime/loop/launch_json_test.go
+++ b/internal/runtime/loop/launch_json_test.go
@@ -125,7 +125,6 @@ func TestLaunchHasOverrides(t *testing.T) {
 		mut   func(*Launch)
 		field string
 	}{
-		{"model", func(l *Launch) { l.Model = "x" }, "Model"},
 		{"task", func(l *Launch) { l.Task = "x" }, "Task"},
 		{"hints", func(l *Launch) { l.Hints = map[string]string{"k": "v"} }, "Hints"},
 		{"metadata", func(l *Launch) { l.Metadata = map[string]string{"k": "v"} }, "Metadata"},

--- a/internal/runtime/loop/loop.go
+++ b/internal/runtime/loop/loop.go
@@ -253,7 +253,8 @@ type Loop struct {
 	recentIterations []IterationSnapshot
 
 	// lastSupervisorIter is the iteration number of the most recent
-	// successful supervisor iteration. Zero means none yet.
+	// iteration that ran a successful supervisor turn. Zero means
+	// none yet.
 	lastSupervisorIter int
 
 	// llmContext holds enrichment data from the most recent
@@ -845,7 +846,7 @@ func (l *Loop) run(ctx context.Context) {
 		l.currentConvID = convID
 		l.mu.Unlock()
 
-		// Determine if this is a supervisor iteration.
+		// Determine if this iteration runs a supervisor turn.
 		isSupervisor := forceSupervisor || (l.config.Supervisor && l.config.SupervisorProb > 0 && l.deps.Rand.Float64() < l.config.SupervisorProb)
 
 		iterLog := logger.With(
@@ -1345,9 +1346,10 @@ func (l *Loop) makeProgressFunc() func(string, map[string]any) {
 	}
 }
 
-// buildAgentTurn chooses the loop's turn construction strategy. Custom
-// TurnBuilder hooks get the wake first; otherwise Task and TaskBuilder
-// are adapted into the same AgentTurn shape.
+// buildAgentTurn chooses the loop's turn construction strategy. A
+// custom TurnBuilder hook gets first refusal on this iteration's turn;
+// otherwise Task and TaskBuilder are adapted into the same AgentTurn
+// shape.
 func (l *Loop) buildAgentTurn(ctx context.Context, input TurnInput) (*AgentTurn, error) {
 	if l.config.TurnBuilder != nil {
 		return l.config.TurnBuilder(ctx, input)

--- a/internal/runtime/loop/loop.go
+++ b/internal/runtime/loop/loop.go
@@ -1437,7 +1437,7 @@ func (l *Loop) prepareAgentTurnRequest(req Request, convID string, isSupervisor 
 	}
 
 	configuredInitialTags := mergeUniqueStrings(l.config.Tags, l.requestBase.InitialTags, req.InitialTags, l.requestOverride.InitialTags)
-	req.Model = firstNonEmpty(l.requestOverride.Model, req.Model, l.requestBase.Model)
+	req.Model = firstNonEmpty(req.Model, l.requestBase.Model)
 	req.ConversationID = firstNonEmpty(l.requestOverride.ConversationID, req.ConversationID, convID)
 	req.ChannelBinding = firstNonNilChannelBinding(l.requestOverride.ChannelBinding, req.ChannelBinding, l.requestBase.ChannelBinding)
 	req.SkipContext = l.requestOverride.SkipContext || req.SkipContext

--- a/internal/runtime/loop/loop.go
+++ b/internal/runtime/loop/loop.go
@@ -78,8 +78,8 @@ type Request struct {
 	SuppressAlwaysContext bool `yaml:"suppress_always_context,omitempty" json:"suppress_always_context,omitempty"`
 }
 
-// RunRequest is kept as a compatibility alias while loops-ng migrates
-// onto Request as the primary loop-facing run descriptor.
+// RunRequest is a compatibility alias for [Request], the primary
+// loop-facing run descriptor.
 type RunRequest = Request
 
 // Message is a chat message for the runner. It intentionally mirrors
@@ -97,8 +97,8 @@ type Message struct {
 	Images []llm.ImageContent `yaml:"-" json:"-"`
 }
 
-// RunMessage is kept as a compatibility alias while loops-ng migrates
-// onto Message as the primary loop-facing message type.
+// RunMessage is a compatibility alias for [Message], the primary
+// loop-facing message type.
 type RunMessage = Message
 
 // Response mirrors agent.Response fields that loops consume. It holds
@@ -124,8 +124,8 @@ type Response struct {
 	ActiveTags []string `yaml:"active_tags,omitempty" json:"active_tags,omitempty"`
 }
 
-// RunResponse is kept as a compatibility alias while loops-ng
-// migrates onto Response as the primary loop-facing response type.
+// RunResponse is a compatibility alias for [Response], the primary
+// loop-facing response type.
 type RunResponse = Response
 
 // StreamCallback receives raw streaming events from a [Runner]. The event
@@ -214,17 +214,17 @@ type Loop struct {
 	currentConvID string
 
 	// requestBase carries the per-iteration request shaping derived
-	// from a loops-ng [Spec]'s [router.LoopProfile]. It is additive and
-	// only populated for loops created via [NewFromSpec].
+	// from a [Spec]'s [router.LoopProfile]. It is additive and only
+	// populated for loops created via [NewFromSpec].
 	requestBase Request
 
 	// requestOverride carries launch-specific per-run overrides
 	// applied on top of the spec/profile-derived request shaping.
 	requestOverride Request
 
-	// requestInstructions is extra guidance derived from a loops-ng
-	// [Spec]'s [router.LoopProfile]. It is prepended to each iteration
-	// task when present.
+	// requestInstructions is extra guidance derived from a [Spec]'s
+	// [router.LoopProfile]. It is prepended to each iteration task
+	// when present.
 	requestInstructions string
 
 	// lastResponse is the most recent successful runner response for
@@ -319,9 +319,8 @@ func New(cfg Config, deps Deps) (*Loop, error) {
 	}, nil
 }
 
-// NewFromSpec creates a loop from a [Spec], validating the loops-ng
-// fields before compiling the engine-facing [Config]. This is an
-// additive bridge for gradually moving call sites onto Spec.
+// NewFromSpec creates a loop from a [Spec], validating it before
+// compiling the engine-facing [Config].
 func NewFromSpec(spec Spec, deps Deps) (*Loop, error) {
 	if err := spec.Validate(); err != nil {
 		return nil, err

--- a/internal/runtime/loop/registry.go
+++ b/internal/runtime/loop/registry.go
@@ -290,8 +290,8 @@ func (r *Registry) SpawnLoop(ctx context.Context, cfg Config, deps Deps) (string
 }
 
 // SpawnSpec creates, registers, and starts a loop from a [Spec]. It is
-// the additive loops-ng entrypoint while existing call sites continue to
-// use [Registry.SpawnLoop] with [Config].
+// the spec-based entrypoint; [Registry.SpawnLoop] with [Config] remains
+// available for callers that build a Config directly.
 func (r *Registry) SpawnSpec(ctx context.Context, spec Spec, deps Deps) (string, error) {
 	l, err := NewFromSpec(spec, deps)
 	if err != nil {
@@ -304,7 +304,7 @@ func (r *Registry) SpawnSpec(ctx context.Context, spec Spec, deps Deps) (string,
 	return l.id, nil
 }
 
-// Launch starts a loops-ng [Launch]. Request/reply launches wait for
+// Launch starts a loop from a [Launch]. Request/reply launches wait for
 // completion and return a final status snapshot; background and service
 // launches detach immediately and leave the loop running in the
 // registry.

--- a/internal/runtime/loop/registry_test.go
+++ b/internal/runtime/loop/registry_test.go
@@ -469,7 +469,6 @@ func TestRegistryLaunchAppliesRequestOverrides(t *testing.T) {
 		ParentID:        "parent-loop",
 		Metadata:        map[string]string{"origin": "launch"},
 		ConversationID:  "conv-123",
-		Model:           "deepslate/google/gemma-3-4b",
 		Hints:           map[string]string{"source": "launch", "custom": "1"},
 		AllowedTools:    []string{"get_state"},
 		ExcludeTools:    []string{"launch_block"},
@@ -516,8 +515,11 @@ func TestRegistryLaunchAppliesRequestOverrides(t *testing.T) {
 	if result.FinalStatus.Config.Metadata["origin"] != "launch" {
 		t.Fatalf("Metadata origin = %q, want launch", result.FinalStatus.Config.Metadata["origin"])
 	}
-	if captured.Model != "deepslate/google/gemma-3-4b" {
-		t.Fatalf("Model = %q, want deepslate/google/gemma-3-4b", captured.Model)
+	// Persistent model selection lives on Spec.Profile.Model — Launch
+	// no longer carries a Model override. The captured request should
+	// reflect the spec profile's model.
+	if captured.Model != "spark/base" {
+		t.Fatalf("Model = %q, want spark/base", captured.Model)
 	}
 	if captured.ConversationID != "conv-123" {
 		t.Fatalf("ConversationID = %q, want conv-123", captured.ConversationID)

--- a/internal/runtime/loop/spec.go
+++ b/internal/runtime/loop/spec.go
@@ -3,6 +3,7 @@ package loop
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"strings"
 	"time"
 
@@ -186,6 +187,14 @@ type Spec struct {
 
 	// ParentID is the parent loop ID, if any.
 	ParentID string `yaml:"parent_id,omitempty" json:"parent_id,omitempty"`
+}
+
+// IsZero reports whether the spec is the zero value (no fields set).
+// Used by guards that need to detect "did the caller send a spec at
+// all" without enumerating every field. Uses [reflect.DeepEqual]
+// against the zero value so new fields are covered automatically.
+func (s Spec) IsZero() bool {
+	return reflect.DeepEqual(s, Spec{})
 }
 
 // Validate checks that the spec fields and derived engine-facing

--- a/internal/runtime/loop/spec.go
+++ b/internal/runtime/loop/spec.go
@@ -133,10 +133,10 @@ type Spec struct {
 	// QualityFloor is the minimum model quality rating for normal
 	// iterations.
 	QualityFloor int `yaml:"quality_floor,omitempty" json:"quality_floor,omitempty"`
-	// SupervisorContext is prepended during supervisor iterations.
+	// SupervisorContext is prepended during supervisor turns.
 	SupervisorContext string `yaml:"supervisor_context,omitempty" json:"supervisor_context,omitempty"`
 	// SupervisorQualityFloor is the quality floor for supervisor
-	// iterations.
+	// turns.
 	SupervisorQualityFloor int `yaml:"supervisor_quality_floor,omitempty" json:"supervisor_quality_floor,omitempty"`
 
 	// OnRetrigger determines behavior when the loop is triggered again

--- a/internal/runtime/loop/spec.go
+++ b/internal/runtime/loop/spec.go
@@ -10,8 +10,8 @@ import (
 )
 
 // Operation describes the runtime pattern a loop is expected to
-// follow. The zero value is accepted while loops-ng adoption is
-// incremental.
+// follow. The zero value is accepted and defaults to
+// [OperationRequestReply].
 type Operation string
 
 const (
@@ -27,7 +27,7 @@ const (
 )
 
 // Completion describes how a loop's result should be delivered.
-// The zero value is accepted while loops-ng adoption is incremental.
+// The zero value is accepted and means "no outward delivery declared".
 type Completion string
 
 const (
@@ -63,12 +63,9 @@ func effectiveOperation(op Operation) Operation {
 	return op
 }
 
-// Spec is the loops-ng contract for describing a loop. It carries
-// both the current engine-facing config fields and the forward-looking
-// loops-ng semantics. Today it compiles to [Config], while [Profile]
-// already shapes requests for loops created via [NewFromSpec].
-// [Operation] and [Completion] are retained for the upcoming RunV2
-// work.
+// Spec is the contract for describing a loop. It compiles to
+// [Config] for the runtime, and [Profile] shapes requests for loops
+// created via [NewFromSpec].
 type Spec struct {
 	// Name is the unique identifier for the loop. Required.
 	Name string `yaml:"name,omitempty" json:"name,omitempty"`
@@ -191,8 +188,8 @@ type Spec struct {
 	ParentID string `yaml:"parent_id,omitempty" json:"parent_id,omitempty"`
 }
 
-// Validate checks that the loops-ng-facing fields and the current
-// engine-facing configuration are internally consistent.
+// Validate checks that the spec fields and derived engine-facing
+// configuration are internally consistent.
 func (s *Spec) Validate() error {
 	if s == nil {
 		return fmt.Errorf("loop: spec is nil")

--- a/internal/runtime/loop/spec_json.go
+++ b/internal/runtime/loop/spec_json.go
@@ -35,7 +35,7 @@ type specJSON struct {
 	ParentID               string            `json:"parent_id,omitempty"`
 }
 
-// MarshalJSON renders a loops-ng spec in a human-facing contract shape
+// MarshalJSON renders a loop spec in a human-facing contract shape
 // suitable for APIs and tools: durations are strings and retrigger mode is
 // named instead of using the engine's integer form.
 func (s Spec) MarshalJSON() ([]byte, error) {

--- a/internal/runtime/loop/spec_test.go
+++ b/internal/runtime/loop/spec_test.go
@@ -327,3 +327,29 @@ func TestSpecJSONMarshalRejectsUnsupportedRetriggerMode(t *testing.T) {
 		t.Fatalf("error = %v, want unsupported retrigger mode", err)
 	}
 }
+
+func TestSpecIsZero(t *testing.T) {
+	t.Parallel()
+
+	t.Run("zero value", func(t *testing.T) {
+		if !(Spec{}).IsZero() {
+			t.Fatal("Spec{}.IsZero() = false, want true")
+		}
+	})
+	t.Run("name set", func(t *testing.T) {
+		if (Spec{Name: "x"}).IsZero() {
+			t.Fatal("Spec with Name set reported IsZero")
+		}
+	})
+	t.Run("nested profile set", func(t *testing.T) {
+		s := Spec{Profile: router.LoopProfile{Model: "x"}}
+		if s.IsZero() {
+			t.Fatal("Spec with Profile.Model set reported IsZero")
+		}
+	})
+	t.Run("metadata set", func(t *testing.T) {
+		if (Spec{Metadata: map[string]string{"k": "v"}}).IsZero() {
+			t.Fatal("Spec with Metadata set reported IsZero")
+		}
+	})
+}

--- a/internal/runtime/metacognitive/metacognitive.go
+++ b/internal/runtime/metacognitive/metacognitive.go
@@ -36,7 +36,7 @@ import (
 	"github.com/nugget/thane-ai-agent/internal/tools"
 )
 
-// DefinitionName is the durable loops-ng definition name for the
+// DefinitionName is the durable loop definition name for the
 // metacognitive service.
 const DefinitionName = "metacognitive"
 
@@ -152,7 +152,7 @@ type Opts struct {
 	StateFileName string
 }
 
-// DefinitionSpec returns the persistable loops-ng definition for the
+// DefinitionSpec returns the persistable loop definition for the
 // metacognitive service. Runtime hooks are attached later by
 // [HydrateSpec] so the definition can live in the durable registry.
 func DefinitionSpec(cfg Config) loop.Spec {
@@ -195,7 +195,7 @@ func DefinitionSpec(cfg Config) loop.Spec {
 }
 
 // HydrateSpec attaches the runtime-only hooks needed to execute the
-// metacognitive service from a durable loops-ng definition.
+// metacognitive service from a durable loop definition.
 func HydrateSpec(spec loop.Spec, cfg Config, opts Opts) loop.Spec {
 	spec = loop.Spec(spec)
 	if strings.TrimSpace(spec.Name) == "" {
@@ -213,8 +213,8 @@ func HydrateSpec(spec loop.Spec, cfg Config, opts Opts) loop.Spec {
 }
 
 // BuildSpec returns a [loop.Spec] that implements the metacognitive
-// loop as a standard loops-ng service. The returned spec declares the
-// durable output document and uses runtime hooks to build prompts and
+// loop as a service loop. The returned spec declares the durable
+// output document and uses runtime hooks to build prompts and
 // append iteration logs.
 func BuildSpec(cfg Config, opts Opts) loop.Spec {
 	spec := DefinitionSpec(cfg)
@@ -225,8 +225,8 @@ func BuildSpec(cfg Config, opts Opts) loop.Spec {
 }
 
 // BuildLoopConfig returns the engine-facing [loop.Config] view of the
-// metacognitive loop. Kept as a compatibility bridge while loops-ng
-// adoption is in progress.
+// metacognitive loop. Kept as a compatibility shim for callers that
+// work directly with [loop.Config] rather than [loop.Spec].
 func BuildLoopConfig(cfg Config, opts Opts) loop.Config {
 	spec := BuildSpec(cfg, opts)
 	out := spec.ToConfig()

--- a/internal/runtime/metacognitive/metacognitive.go
+++ b/internal/runtime/metacognitive/metacognitive.go
@@ -6,7 +6,7 @@
 // via a markdown file (metacognitive.md by default). The loop's cost is
 // self-limiting: quiet periods produce long sleeps and few iterations.
 //
-// "Dice" randomly select a frontier model for supervisor iterations that
+// "Dice" randomly select a frontier model for supervisor turns that
 // review the loop's own behavior, catching blind spots that the cheaper
 // local model's consistent reasoning patterns miss.
 //
@@ -88,7 +88,7 @@ type Config struct {
 	Jitter                 float64 // 0.0–1.0
 	SupervisorProbability  float64 // 0.0–1.0
 	QualityFloor           int     // normal iterations
-	SupervisorQualityFloor int     // supervisor iterations
+	SupervisorQualityFloor int     // supervisor turns
 }
 
 // ParseConfig converts a [config.MetacognitiveConfig] (string durations)

--- a/internal/server/api/server.go
+++ b/internal/server/api/server.go
@@ -145,14 +145,14 @@ func (s *Server) UseContactStore(store *contacts.Store) {
 	s.contactStore = store
 }
 
-// UseLoopDefinitionRegistry configures the persistent loops-ng definition
+// UseLoopDefinitionRegistry configures the persistent loop definition
 // registry exposed by the API.
 func (s *Server) UseLoopDefinitionRegistry(reg *looppkg.DefinitionRegistry) {
 	s.loopDefinitionRegistry = reg
 }
 
 // ConfigureLoopDefinitionView configures the effective combined
-// definition registry view used by loops-ng read surfaces.
+// definition registry view used by loop read surfaces.
 func (s *Server) ConfigureLoopDefinitionView(fn func() *looppkg.DefinitionRegistryView) {
 	s.loopDefinitionView = fn
 }

--- a/internal/tools/loop_definition_tool_helpers.go
+++ b/internal/tools/loop_definition_tool_helpers.go
@@ -68,21 +68,37 @@ func decodeLoopLaunchArg(args map[string]any, key string) (looppkg.Launch, error
 	return launch, nil
 }
 
-// validateLoopLaunchOverrides catches common mistakes where a caller
-// placed a routing override inside the opaque metadata map instead of
-// the corresponding top-level Launch field. Metadata is informational
-// tagging only; it does not influence routing, tool selection, or
-// budgets. Returning an actionable error here is preferable to silently
-// ignoring the override and letting the caller misinterpret the run.
+// validateLoopLaunchOverrides rejects tool-facing launch payloads that
+// attempt to set the model. The router's persistent baseline lives on
+// the stored spec (`spec.profile.model`) and is the only durable place
+// to pin a model. `launch.model` is intentionally not exposed on the
+// agent-facing schema: for service-mode loops, calling
+// loop_definition_launch on an already-running definition silently
+// drops every launch field (the runtime returns the existing loop ID
+// without re-applying overrides), and even on a fresh service launch
+// the per-launch model is lost on restart because Launch is not
+// persisted. The Go-level field stays for internal callers (delegates,
+// scheduled tasks) that legitimately construct one-shot Launches with
+// throwaway Specs; the rejection here only guards the JSON tool path.
 func validateLoopLaunchOverrides(launch looppkg.Launch) error {
+	if model := strings.TrimSpace(launch.Model); model != "" {
+		return fmt.Errorf(
+			"launch.model=%q is no longer accepted from tool input; "+
+				"to pin a model, set spec.profile.model "+
+				"(via loop_definition_set for persisted definitions, "+
+				"or inside the spec passed to spawn_loop for ad-hoc loops)",
+			model)
+	}
 	if len(launch.Metadata) == 0 {
 		return nil
 	}
-	if model, ok := launch.Metadata["model"]; ok && strings.TrimSpace(model) != "" && strings.TrimSpace(launch.Model) == "" {
+	if model, ok := launch.Metadata["model"]; ok && strings.TrimSpace(model) != "" {
 		return fmt.Errorf(
 			"launch.metadata.model=%q is opaque tagging and does not override the model; "+
-				"use the top-level launch.model field (e.g. \"launch\": {\"model\": %q})",
-			model, model)
+				"set spec.profile.model instead "+
+				"(via loop_definition_set for persisted definitions, "+
+				"or inside the spec passed to spawn_loop for ad-hoc loops)",
+			model)
 	}
 	return nil
 }
@@ -149,15 +165,16 @@ func loopChannelBindingProperty() map[string]any {
 // the per-launch override fields accepted by both
 // [Registry.handleLoopDefinitionLaunch] and [Registry.handleSpawnLoop].
 // Exposing a typed schema lets the model see the real field names and
-// their behavior rather than guessing at an opaque object — the
-// disaster mode we most care about is putting a `model` override inside
-// `metadata`, where it has no effect on routing.
+// their behavior rather than guessing at an opaque object.
+//
+// `model` is deliberately omitted: the persistent model selection lives
+// on `spec.profile.model`, and per-launch model overrides are silently
+// dropped when a service definition is already running. Callers that
+// reach for a model override should mutate the stored spec via
+// loop_definition_set, or set profile.model inside the spec passed to
+// spawn_loop. See [validateLoopLaunchOverrides] for the rejection path.
 func loopLaunchOverrideProperties() map[string]any {
 	return map[string]any{
-		"model": map[string]any{
-			"type":        "string",
-			"description": "Override the model for this launch (e.g. \"claude-sonnet-4-5\", \"gpt-oss:120b\"). This is the field the router reads. metadata.model is NOT read by the router and does not change the model.",
-		},
 		"task": map[string]any{
 			"type":        "string",
 			"description": "Override the task text for this launch. Applied only when the stored spec does not already supply a task.",
@@ -184,7 +201,7 @@ func loopLaunchOverrideProperties() map[string]any {
 		"hints": map[string]any{
 			"type":                 "object",
 			"additionalProperties": map[string]any{"type": "string"},
-			"description":          "Free-form string/string routing or context hints. Use named top-level fields (model, allowed_tools, etc.) for well-known behavior overrides; hints are for softer signals.",
+			"description":          "Free-form string/string routing or context hints. Use named top-level fields (allowed_tools, max_iterations, etc.) for well-known behavior overrides; hints are for softer signals. To pin a model, set spec.profile.model on the stored definition or in the spec passed to spawn_loop — not via hints.",
 		},
 		"max_iterations": map[string]any{
 			"type":        "integer",
@@ -232,7 +249,7 @@ func loopLaunchOverrideProperties() map[string]any {
 		"metadata": map[string]any{
 			"type":                 "object",
 			"additionalProperties": map[string]any{"type": "string"},
-			"description":          "Opaque string/string tags attached to the launched loop for correlation or audit. NOT used for routing, tools, budgets, or any runtime behavior. To override the model use top-level \"model\". To override tools use \"allowed_tools\" / \"exclude_tools\". To override budgets use \"max_iterations\" / \"max_output_tokens\".",
+			"description":          "Opaque string/string tags attached to the launched loop for correlation or audit. NOT used for routing, tools, budgets, or any runtime behavior. To pin a model, set spec.profile.model on the stored definition (or in the spec passed to spawn_loop). To override tools use \"allowed_tools\" / \"exclude_tools\". To override budgets use \"max_iterations\" / \"max_output_tokens\".",
 		},
 		"fallback_content": map[string]any{
 			"type":        "string",

--- a/internal/tools/loop_definition_tool_helpers.go
+++ b/internal/tools/loop_definition_tool_helpers.go
@@ -54,6 +54,9 @@ func decodeLoopLaunchArg(args map[string]any, key string) (looppkg.Launch, error
 	if !ok {
 		return looppkg.Launch{}, nil
 	}
+	if err := rejectLaunchModelKeys(raw); err != nil {
+		return looppkg.Launch{}, err
+	}
 	data, err := json.Marshal(raw)
 	if err != nil {
 		return looppkg.Launch{}, err
@@ -62,43 +65,46 @@ func decodeLoopLaunchArg(args map[string]any, key string) (looppkg.Launch, error
 	if err := json.Unmarshal(data, &launch); err != nil {
 		return looppkg.Launch{}, err
 	}
-	if err := validateLoopLaunchOverrides(launch); err != nil {
-		return looppkg.Launch{}, err
-	}
 	return launch, nil
 }
 
-// validateLoopLaunchOverrides rejects tool-facing launch payloads that
-// attempt to set the model. The router's persistent baseline lives on
-// the stored spec (`spec.profile.model`) and is the only durable place
-// to pin a model. `launch.model` is intentionally not exposed on the
-// agent-facing schema: for service-mode loops, calling
-// loop_definition_launch on an already-running definition silently
-// drops every launch field (the runtime returns the existing loop ID
-// without re-applying overrides), and even on a fresh service launch
-// the per-launch model is lost on restart because Launch is not
-// persisted. The Go-level field stays for internal callers (delegates,
-// scheduled tasks) that legitimately construct one-shot Launches with
-// throwaway Specs; the rejection here only guards the JSON tool path.
-func validateLoopLaunchOverrides(launch looppkg.Launch) error {
-	if model := strings.TrimSpace(launch.Model); model != "" {
-		return fmt.Errorf(
-			"launch.model=%q is no longer accepted from tool input; "+
-				"to pin a model, set spec.profile.model "+
-				"(via loop_definition_set for persisted definitions, "+
-				"or inside the spec passed to spawn_loop for ad-hoc loops)",
-			model)
-	}
-	if len(launch.Metadata) == 0 {
+// rejectLaunchModelKeys catches tool-facing launch payloads that try to
+// set the model. The router's persistent baseline lives on the stored
+// spec (`spec.profile.model`) and is the only durable place to pin a
+// model. The Go [looppkg.Launch] type no longer carries a Model field —
+// so unmarshalling alone would silently drop a `"model"` key. This
+// raw-map pre-check preserves a useful error pointing callers at
+// `spec.profile.model`.
+//
+// Both top-level `launch.model` and `launch.metadata.model` are
+// rejected. Other tool-facing layers (the JSON schema for
+// [loop_definition_launch] and [spawn_loop]) already omit `model`; this
+// is the runtime backstop.
+func rejectLaunchModelKeys(raw any) error {
+	launch, ok := raw.(map[string]any)
+	if !ok {
 		return nil
 	}
-	if model, ok := launch.Metadata["model"]; ok && strings.TrimSpace(model) != "" {
-		return fmt.Errorf(
-			"launch.metadata.model=%q is opaque tagging and does not override the model; "+
-				"set spec.profile.model instead "+
-				"(via loop_definition_set for persisted definitions, "+
-				"or inside the spec passed to spawn_loop for ad-hoc loops)",
-			model)
+	if v, present := launch["model"]; present {
+		if model, _ := v.(string); strings.TrimSpace(model) != "" {
+			return fmt.Errorf(
+				"launch.model=%q is not accepted from tool input; "+
+					"to pin a model, set spec.profile.model "+
+					"(via loop_definition_set for persisted definitions, "+
+					"or inside the spec passed to spawn_loop for ad-hoc loops)",
+				model)
+		}
+	}
+	metadata, _ := launch["metadata"].(map[string]any)
+	if v, present := metadata["model"]; present {
+		if model, _ := v.(string); strings.TrimSpace(model) != "" {
+			return fmt.Errorf(
+				"launch.metadata.model=%q is opaque tagging and does not override the model; "+
+					"set spec.profile.model instead "+
+					"(via loop_definition_set for persisted definitions, "+
+					"or inside the spec passed to spawn_loop for ad-hoc loops)",
+				model)
+		}
 	}
 	return nil
 }
@@ -167,12 +173,11 @@ func loopChannelBindingProperty() map[string]any {
 // Exposing a typed schema lets the model see the real field names and
 // their behavior rather than guessing at an opaque object.
 //
-// `model` is deliberately omitted: the persistent model selection lives
-// on `spec.profile.model`, and per-launch model overrides are silently
-// dropped when a service definition is already running. Callers that
-// reach for a model override should mutate the stored spec via
-// loop_definition_set, or set profile.model inside the spec passed to
-// spawn_loop. See [validateLoopLaunchOverrides] for the rejection path.
+// `model` is not a field. Persistent model selection lives on
+// `spec.profile.model`; mutate the stored spec via loop_definition_set,
+// or set profile.model inside the spec passed to spawn_loop. See
+// [rejectLaunchModelKeys] for the runtime backstop that surfaces a
+// useful error if a caller sends `launch.model` anyway.
 func loopLaunchOverrideProperties() map[string]any {
 	return map[string]any{
 		"task": map[string]any{

--- a/internal/tools/loop_definition_tool_helpers.go
+++ b/internal/tools/loop_definition_tool_helpers.go
@@ -76,6 +76,11 @@ func decodeLoopLaunchArg(args map[string]any, key string) (looppkg.Launch, error
 // raw-map pre-check preserves a useful error pointing callers at
 // `spec.profile.model`.
 //
+// Rejection fires on any non-null value, not just non-empty strings.
+// A caller sending `{"model": 5}` or `{"model": {...}}` would otherwise
+// slip past a string-only check and have the key silently dropped by
+// the unmarshaller. Same logic applies to `launch.metadata.model`.
+//
 // Both top-level `launch.model` and `launch.metadata.model` are
 // rejected. Other tool-facing layers (the JSON schema for
 // [loop_definition_launch] and [spawn_loop]) already omit `model`; this
@@ -85,28 +90,39 @@ func rejectLaunchModelKeys(raw any) error {
 	if !ok {
 		return nil
 	}
-	if v, present := launch["model"]; present {
-		if model, _ := v.(string); strings.TrimSpace(model) != "" {
-			return fmt.Errorf(
-				"launch.model=%q is not accepted from tool input; "+
-					"to pin a model, set spec.profile.model "+
-					"(via loop_definition_set for persisted definitions, "+
-					"or inside the spec passed to spawn_loop for ad-hoc loops)",
-				model)
-		}
+	if v, present := launch["model"]; present && !isNilOrEmptyString(v) {
+		return fmt.Errorf(
+			"launch.model=%v is not accepted from tool input; "+
+				"to pin a model, set spec.profile.model "+
+				"(via loop_definition_set for persisted definitions, "+
+				"or inside the spec passed to spawn_loop for ad-hoc loops)",
+			v)
 	}
 	metadata, _ := launch["metadata"].(map[string]any)
-	if v, present := metadata["model"]; present {
-		if model, _ := v.(string); strings.TrimSpace(model) != "" {
-			return fmt.Errorf(
-				"launch.metadata.model=%q is opaque tagging and does not override the model; "+
-					"set spec.profile.model instead "+
-					"(via loop_definition_set for persisted definitions, "+
-					"or inside the spec passed to spawn_loop for ad-hoc loops)",
-				model)
-		}
+	if v, present := metadata["model"]; present && !isNilOrEmptyString(v) {
+		return fmt.Errorf(
+			"launch.metadata.model=%v is opaque tagging and does not override the model; "+
+				"set spec.profile.model instead "+
+				"(via loop_definition_set for persisted definitions, "+
+				"or inside the spec passed to spawn_loop for ad-hoc loops)",
+			v)
 	}
 	return nil
+}
+
+// isNilOrEmptyString reports whether v is nil or an empty/whitespace
+// string. Used by [rejectLaunchModelKeys] to treat null and "" as
+// "not set" while still rejecting non-string values like numbers or
+// objects, which would otherwise be silently dropped by JSON unmarshal
+// when the target field is absent.
+func isNilOrEmptyString(v any) bool {
+	if v == nil {
+		return true
+	}
+	if s, ok := v.(string); ok {
+		return strings.TrimSpace(s) == ""
+	}
+	return false
 }
 
 func loopCompletionChannelTargetProperty() map[string]any {

--- a/internal/tools/loop_definition_tools.go
+++ b/internal/tools/loop_definition_tools.go
@@ -199,7 +199,7 @@ func (r *Registry) registerLoopDefinitionTools() {
 
 	r.Register(&Tool{
 		Name:        "loop_definition_launch",
-		Description: "Launch one stored loop definition by name using its persisted spec plus optional per-launch overrides. Use this instead of resending the full definition for request_reply, background_task, or on-demand service launches. Model routing, tool filtering, and iteration caps go in the top-level launch fields (model, allowed_tools, max_iterations, etc.) — NOT inside launch.metadata, which is opaque tagging only. When a launch uses conversation or channel completion and no explicit target is provided, the tool defaults to the current conversation or interactive channel context.",
+		Description: "Launch one stored loop definition by name using its persisted spec plus optional per-launch overrides. Use this instead of resending the full definition for request_reply, background_task, or on-demand service launches. Tool filtering and iteration caps go in the top-level launch fields (allowed_tools, max_iterations, etc.) — NOT inside launch.metadata, which is opaque tagging only. Model selection is persistent and lives on spec.profile.model — set it via loop_definition_set, not via launch overrides (per-launch model is rejected here because it is silently dropped when a service loop is already running and is not persisted across restarts when it is not). When a launch uses conversation or channel completion and no explicit target is provided, the tool defaults to the current conversation or interactive channel context.",
 		Parameters: map[string]any{
 			"type": "object",
 			"properties": map[string]any{

--- a/internal/tools/loop_definition_tools.go
+++ b/internal/tools/loop_definition_tools.go
@@ -14,7 +14,7 @@ const (
 )
 
 // LoopDefinitionToolDeps wires the live loop-definition registry into the
-// tool registry so the model can inspect and mutate the persistent loops-ng
+// tool registry so the model can inspect and mutate the persistent loops
 // definition overlay.
 type LoopDefinitionToolDeps struct {
 	Registry         *looppkg.DefinitionRegistry
@@ -48,7 +48,7 @@ func (r *Registry) registerLoopDefinitionTools() {
 
 	r.Register(&Tool{
 		Name:        "loop_definition_summary",
-		Description: "Return a compact structured summary of the persistent loops-ng definition registry: generation, counts by source, operation, policy state, live runtime state, warning totals, and the known loop definition names.",
+		Description: "Return a compact structured summary of the persistent loops definition registry: generation, counts by source, operation, policy state, live runtime state, warning totals, and the known loop definition names.",
 		Parameters: map[string]any{
 			"type":       "object",
 			"properties": map[string]any{},
@@ -106,7 +106,7 @@ func (r *Registry) registerLoopDefinitionTools() {
 
 	r.Register(&Tool{
 		Name:        "loop_definition_get",
-		Description: "Get one deep loop definition object from the persistent loops-ng definition registry by name, including authoring warnings and its current live runtime state when available.",
+		Description: "Get one deep loop definition object from the persistent loops definition registry by name, including authoring warnings and its current live runtime state when available.",
 		Parameters: map[string]any{
 			"type": "object",
 			"properties": map[string]any{
@@ -138,7 +138,7 @@ func (r *Registry) registerLoopDefinitionTools() {
 
 	r.Register(&Tool{
 		Name:        "loop_definition_set",
-		Description: "Create or replace one dynamic loop definition in the persistent loops-ng overlay. This cannot modify config-owned definitions. The saved definition view includes warnings for common service-loop authoring mistakes. The spec uses human-facing strings for durations and retrigger mode.",
+		Description: "Create or replace one dynamic loop definition in the persistent loops overlay. This cannot modify config-owned definitions. The saved definition view includes warnings for common service-loop authoring mistakes. The spec uses human-facing strings for durations and retrigger mode.",
 		Parameters: map[string]any{
 			"type": "object",
 			"properties": map[string]any{
@@ -154,7 +154,7 @@ func (r *Registry) registerLoopDefinitionTools() {
 
 	r.Register(&Tool{
 		Name:        "loop_definition_delete",
-		Description: "Delete one dynamic loop definition from the persistent loops-ng overlay. Config-owned definitions are immutable and cannot be deleted.",
+		Description: "Delete one dynamic loop definition from the persistent loops overlay. Config-owned definitions are immutable and cannot be deleted.",
 		Parameters: map[string]any{
 			"type": "object",
 			"properties": map[string]any{

--- a/internal/tools/loop_definition_tools_test.go
+++ b/internal/tools/loop_definition_tools_test.go
@@ -112,15 +112,6 @@ func sharedLoopLaunchSchemaKeys() []string {
 		switch name {
 		case "", "-", "spec":
 			continue
-		case "model":
-			// Intentionally not exposed on the agent-facing schema.
-			// Persistent model selection lives on spec.profile.model;
-			// per-launch overrides are silently dropped for service
-			// loops that are already running and lost on restart when
-			// they are not. The Go field stays in place for internal
-			// callers (delegates, scheduled tasks) that build one-shot
-			// Launches with throwaway Specs.
-			continue
 		default:
 			keys = append(keys, name)
 		}
@@ -430,8 +421,8 @@ func TestLoopDefinitionLaunchRejectsTopLevelModelOverride(t *testing.T) {
 	if !strings.Contains(err.Error(), "launch.model") || !strings.Contains(err.Error(), "spec.profile.model") {
 		t.Fatalf("error = %q, want guidance pointing from launch.model to spec.profile.model", err.Error())
 	}
-	if deps.lastLaunch.Model != "" {
-		t.Fatalf("lastLaunch.Model = %q, want empty (launch should not have been dispatched)", deps.lastLaunch.Model)
+	if deps.lastLaunch.Task != "" || len(deps.lastLaunch.Metadata) > 0 {
+		t.Fatalf("lastLaunch = %#v, want zero value (launch should not have been dispatched)", deps.lastLaunch)
 	}
 }
 
@@ -505,8 +496,8 @@ func TestLoopDefinitionLaunchRejectsModelInsideMetadata(t *testing.T) {
 	if !strings.Contains(err.Error(), "metadata.model") || !strings.Contains(err.Error(), "spec.profile.model") {
 		t.Fatalf("error = %q, want guidance pointing from metadata.model to spec.profile.model", err.Error())
 	}
-	if deps.lastLaunch.Model != "" {
-		t.Fatalf("lastLaunch.Model = %q, want empty (launch should not have been dispatched)", deps.lastLaunch.Model)
+	if deps.lastLaunch.Task != "" || len(deps.lastLaunch.Metadata) > 0 {
+		t.Fatalf("lastLaunch = %#v, want zero value (launch should not have been dispatched)", deps.lastLaunch)
 	}
 }
 

--- a/internal/tools/loop_definition_tools_test.go
+++ b/internal/tools/loop_definition_tools_test.go
@@ -112,6 +112,15 @@ func sharedLoopLaunchSchemaKeys() []string {
 		switch name {
 		case "", "-", "spec":
 			continue
+		case "model":
+			// Intentionally not exposed on the agent-facing schema.
+			// Persistent model selection lives on spec.profile.model;
+			// per-launch overrides are silently dropped for service
+			// loops that are already running and lost on restart when
+			// they are not. The Go field stays in place for internal
+			// callers (delegates, scheduled tasks) that build one-shot
+			// Launches with throwaway Specs.
+			continue
 		default:
 			keys = append(keys, name)
 		}
@@ -406,19 +415,37 @@ func TestLoopDefinitionSetPolicyAndLaunch(t *testing.T) {
 	}
 }
 
-func TestLoopDefinitionLaunchRoutesTopLevelModelOverride(t *testing.T) {
+func TestLoopDefinitionLaunchRejectsTopLevelModelOverride(t *testing.T) {
 	deps := newTestLoopDefinitionDeps(t)
 
-	if _, err := deps.reg.Get("loop_definition_launch").Handler(context.Background(), map[string]any{
+	_, err := deps.reg.Get("loop_definition_launch").Handler(context.Background(), map[string]any{
 		"name": "metacog_like",
 		"launch": map[string]any{
 			"model": "claude-sonnet-4-5",
 		},
-	}); err != nil {
-		t.Fatalf("loop_definition_launch: %v", err)
+	})
+	if err == nil {
+		t.Fatal("expected error for launch.model override, got nil")
 	}
-	if deps.lastLaunch.Model != "claude-sonnet-4-5" {
-		t.Fatalf("lastLaunch.Model = %q, want claude-sonnet-4-5", deps.lastLaunch.Model)
+	if !strings.Contains(err.Error(), "launch.model") || !strings.Contains(err.Error(), "spec.profile.model") {
+		t.Fatalf("error = %q, want guidance pointing from launch.model to spec.profile.model", err.Error())
+	}
+	if deps.lastLaunch.Model != "" {
+		t.Fatalf("lastLaunch.Model = %q, want empty (launch should not have been dispatched)", deps.lastLaunch.Model)
+	}
+}
+
+func TestLoopDefinitionLaunchSchemaOmitsModel(t *testing.T) {
+	deps := newTestLoopDefinitionDeps(t)
+
+	tool := deps.reg.Get("loop_definition_launch")
+	if tool == nil {
+		t.Fatal("loop_definition_launch tool not registered")
+	}
+	launchSchema := schemaObjectProperty(t, tool.Parameters, "launch")
+	props := schemaProperties(t, launchSchema)
+	if _, ok := props["model"]; ok {
+		t.Fatal("launch schema must not expose \"model\"; persistent model selection lives on spec.profile.model")
 	}
 }
 
@@ -475,8 +502,8 @@ func TestLoopDefinitionLaunchRejectsModelInsideMetadata(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for metadata.model override, got nil")
 	}
-	if !strings.Contains(err.Error(), "metadata.model") || !strings.Contains(err.Error(), "launch.model") {
-		t.Fatalf("error = %q, want guidance pointing from metadata.model to launch.model", err.Error())
+	if !strings.Contains(err.Error(), "metadata.model") || !strings.Contains(err.Error(), "spec.profile.model") {
+		t.Fatalf("error = %q, want guidance pointing from metadata.model to spec.profile.model", err.Error())
 	}
 	if deps.lastLaunch.Model != "" {
 		t.Fatalf("lastLaunch.Model = %q, want empty (launch should not have been dispatched)", deps.lastLaunch.Model)

--- a/internal/tools/loop_definition_tools_test.go
+++ b/internal/tools/loop_definition_tools_test.go
@@ -426,6 +426,56 @@ func TestLoopDefinitionLaunchRejectsTopLevelModelOverride(t *testing.T) {
 	}
 }
 
+func TestLoopDefinitionLaunchRejectsNonStringModel(t *testing.T) {
+	// Non-string model values (numbers, objects, arrays) would slip past
+	// a string-only check and be silently dropped by the unmarshaller
+	// (since looppkg.Launch has no Model field). The pre-check must
+	// reject any non-null value.
+	cases := []struct {
+		name  string
+		value any
+	}{
+		{"number", 5},
+		{"object", map[string]any{"name": "claude"}},
+		{"array", []any{"claude"}},
+		{"bool", true},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			deps := newTestLoopDefinitionDeps(t)
+			_, err := deps.reg.Get("loop_definition_launch").Handler(context.Background(), map[string]any{
+				"name": "metacog_like",
+				"launch": map[string]any{
+					"model": tc.value,
+				},
+			})
+			if err == nil {
+				t.Fatalf("expected error for launch.model=%v (%T), got nil", tc.value, tc.value)
+			}
+			if !strings.Contains(err.Error(), "launch.model") || !strings.Contains(err.Error(), "spec.profile.model") {
+				t.Fatalf("error = %q, want guidance pointing from launch.model to spec.profile.model", err.Error())
+			}
+		})
+	}
+}
+
+func TestLoopDefinitionLaunchAcceptsExplicitNullModel(t *testing.T) {
+	// Explicit JSON null on launch.model is harmless — same shape as
+	// "key absent." Don't reject; the unmarshaller would already see
+	// no value to bind.
+	deps := newTestLoopDefinitionDeps(t)
+	_, err := deps.reg.Get("loop_definition_launch").Handler(context.Background(), map[string]any{
+		"name": "metacog_like",
+		"launch": map[string]any{
+			"model": nil,
+		},
+	})
+	if err != nil {
+		t.Fatalf("explicit null model should be tolerated, got %v", err)
+	}
+}
+
 func TestLoopDefinitionLaunchSchemaOmitsModel(t *testing.T) {
 	deps := newTestLoopDefinitionDeps(t)
 

--- a/internal/tools/loop_intent_tools.go
+++ b/internal/tools/loop_intent_tools.go
@@ -586,7 +586,7 @@ func renderScaffoldBody(outputMode, title, intent string) string {
 }
 
 // cadence captures the sleep_min/max/default/jitter triple derived from
-// a human-facing cadence string. The loops-ng spec already has these
+// a human-facing cadence string. The loop spec already has these
 // fields; this helper centralizes the input parsing so the intent
 // tools share one parser.
 type cadence struct {

--- a/internal/tools/loop_runtime_tools.go
+++ b/internal/tools/loop_runtime_tools.go
@@ -121,7 +121,7 @@ func (r *Registry) registerLoopRuntimeTools() {
 
 	r.Register(&Tool{
 		Name:        "spawn_loop",
-		Description: "Launch an ad hoc loop immediately using the loops-ng launch contract without persisting a loop definition. Use this for temporary services, detached background research that should report back later, or one-shot request/reply runs that do not belong in the durable loop-definition registry. For async work, prefer operation=background_task. If completion is omitted there, the runtime infers the most natural detached delivery target from the current origin context. Model routing and tool filtering go in the top-level launch fields (model, allowed_tools, etc.) — NOT inside launch.metadata.",
+		Description: "Launch an ad hoc loop immediately using the loops-ng launch contract without persisting a loop definition. Use this for temporary services, detached background research that should report back later, or one-shot request/reply runs that do not belong in the durable loop-definition registry. For async work, prefer operation=background_task. If completion is omitted there, the runtime infers the most natural detached delivery target from the current origin context. Tool filtering goes in the top-level launch fields (allowed_tools, etc.) — NOT inside launch.metadata. To pin a model, set spec.profile.model inside the spec object; per-launch model overrides are rejected.",
 		Parameters: map[string]any{
 			"type": "object",
 			"properties": map[string]any{

--- a/internal/tools/loop_runtime_tools.go
+++ b/internal/tools/loop_runtime_tools.go
@@ -91,7 +91,7 @@ func (r *Registry) registerLoopRuntimeTools() {
 
 	r.Register(&Tool{
 		Name:        "set_next_sleep",
-		Description: "Request the next sleep duration for the current running timer-driven service loop. This is the native loops-ng sleep-control tool used by persistent background services such as metacog-style loops. The requested duration is clamped to the loop's configured sleep_min and sleep_max bounds.",
+		Description: "Request the next sleep duration for the current running timer-driven service loop. This is the native loops sleep-control tool used by persistent background services such as metacog-style loops. The requested duration is clamped to the loop's configured sleep_min and sleep_max bounds.",
 		Parameters: map[string]any{
 			"type": "object",
 			"properties": map[string]any{
@@ -121,7 +121,7 @@ func (r *Registry) registerLoopRuntimeTools() {
 
 	r.Register(&Tool{
 		Name:        "spawn_loop",
-		Description: "Launch an ad hoc loop immediately using the loops-ng launch contract without persisting a loop definition. Use this for temporary services, detached background research that should report back later, or one-shot request/reply runs that do not belong in the durable loop-definition registry. For async work, prefer operation=background_task. If completion is omitted there, the runtime infers the most natural detached delivery target from the current origin context. Tool filtering goes in the top-level launch fields (allowed_tools, etc.) — NOT inside launch.metadata. To pin a model, set spec.profile.model inside the spec object; per-launch model overrides are rejected.",
+		Description: "Launch an ad hoc loop immediately using the loops launch contract without persisting a loop definition. Use this for temporary services, detached background research that should report back later, or one-shot request/reply runs that do not belong in the durable loop-definition registry. For async work, prefer operation=background_task. If completion is omitted there, the runtime infers the most natural detached delivery target from the current origin context. Tool filtering goes in the top-level launch fields (allowed_tools, etc.) — NOT inside launch.metadata. To pin a model, set spec.profile.model inside the spec object; per-launch model overrides are rejected.",
 		Parameters: map[string]any{
 			"type": "object",
 			"properties": map[string]any{

--- a/internal/tools/loop_runtime_tools_test.go
+++ b/internal/tools/loop_runtime_tools_test.go
@@ -3,6 +3,7 @@ package tools
 import (
 	"context"
 	"encoding/json"
+	"strings"
 	"testing"
 	"time"
 
@@ -95,10 +96,37 @@ func TestSpawnLoopSchemaExposesSharedLaunchFields(t *testing.T) {
 	if _, ok := launchProps["spec"]; !ok {
 		t.Fatal("spawn_loop launch schema missing spec")
 	}
+	if _, ok := launchProps["model"]; ok {
+		t.Fatal("spawn_loop launch schema must not expose \"model\"; set spec.profile.model inside the spec")
+	}
 	for _, key := range sharedLoopLaunchSchemaKeys() {
 		if _, ok := launchProps[key]; !ok {
 			t.Errorf("spawn_loop launch schema missing %q", key)
 		}
+	}
+}
+
+func TestSpawnLoopRejectsTopLevelModelOverride(t *testing.T) {
+	deps := newTestLoopRuntimeDeps(t)
+
+	_, err := deps.reg.Get("spawn_loop").Handler(context.Background(), map[string]any{
+		"launch": map[string]any{
+			"model": "claude-sonnet-4-5",
+			"spec": map[string]any{
+				"name":      "ad_hoc",
+				"task":      "Probe.",
+				"operation": "background_task",
+			},
+		},
+	})
+	if err == nil {
+		t.Fatal("expected error for launch.model override, got nil")
+	}
+	if !strings.Contains(err.Error(), "launch.model") || !strings.Contains(err.Error(), "spec.profile.model") {
+		t.Fatalf("error = %q, want guidance pointing from launch.model to spec.profile.model", err.Error())
+	}
+	if deps.lastLaunch.Model != "" {
+		t.Fatalf("lastLaunch.Model = %q, want empty (launch should not have been dispatched)", deps.lastLaunch.Model)
 	}
 }
 

--- a/internal/tools/loop_runtime_tools_test.go
+++ b/internal/tools/loop_runtime_tools_test.go
@@ -125,8 +125,8 @@ func TestSpawnLoopRejectsTopLevelModelOverride(t *testing.T) {
 	if !strings.Contains(err.Error(), "launch.model") || !strings.Contains(err.Error(), "spec.profile.model") {
 		t.Fatalf("error = %q, want guidance pointing from launch.model to spec.profile.model", err.Error())
 	}
-	if deps.lastLaunch.Model != "" {
-		t.Fatalf("lastLaunch.Model = %q, want empty (launch should not have been dispatched)", deps.lastLaunch.Model)
+	if deps.lastLaunch.Spec.Name != "" || deps.lastLaunch.Task != "" {
+		t.Fatalf("lastLaunch = %#v, want zero value (launch should not have been dispatched)", deps.lastLaunch)
 	}
 }
 

--- a/internal/tools/message_tools.go
+++ b/internal/tools/message_tools.go
@@ -30,6 +30,7 @@ func (r *Registry) registerMessageTools() {
 	r.Register(&Tool{
 		Name: "request_core_attention",
 		Description: "Ask the designated core/owner loop to review a concern. Use this from delegate, service, or subsystem loops when a human-facing alert, message, or strategic decision may be needed. " +
+			"This call forces the core loop's next iteration into a supervisor turn — costlier than a normal wake — so reserve it for concerns that genuinely warrant the extra capacity, not as a routine notification channel. " +
 			"Do not include recipients, phone numbers, delivery channels, or instructions to send immediately; the core loop decides whether to deliver, defer, or ignore the concern.",
 		Parameters:      coreAttentionToolParameters(),
 		Handler:         r.handleRequestCoreAttention,

--- a/talents/loops-doctrine.md
+++ b/talents/loops-doctrine.md
@@ -34,6 +34,20 @@ Choose stream wiring by attention cost:
   immediate iteration. Producer tools such as `forge_repo_follow` and
   `media_follow` own those subscriptions.
 
+Treat running loops as bi-directional. A curate loop can pull the core
+in via `request_core_attention` when something deserves a decision; the
+core can push new focus down by adding entities to a running loop's
+watch set with `loop_update_entity_subscriptions`, or by pointing a
+producer's `wake_loop` target at the loop. Inspect what is already
+running with `loop_status` and `loop_definition_get` before launching
+a parallel watcher — a thriving loop is its own data-dense
+documentation and is usually the right thing to extend.
+
+**`request_core_attention` forces a supervisor turn** on the core
+loop's next iteration — costlier than a normal wake. Reserve it for
+concerns that genuinely warrant the extra capacity, not as a routine
+notification channel.
+
 Natural-language timing inside a task does not schedule a service loop.
 Use `thane_curate.cadence` or explicit service-loop sleep fields. Lint
 hand-authored durable definitions before saving them, especially when

--- a/talents/loops-doctrine.md
+++ b/talents/loops-doctrine.md
@@ -40,8 +40,8 @@ core can push new focus down by adding entities to a running loop's
 watch set with `loop_update_entity_subscriptions`, or by pointing a
 producer's `wake_loop` target at the loop. Inspect what is already
 running with `loop_status` and `loop_definition_get` before launching
-a parallel watcher — a thriving loop is its own data-dense
-documentation and is usually the right thing to extend.
+a parallel loop — a thriving loop is its own data-dense documentation
+and is usually the right thing to extend.
 
 **`request_core_attention` forces a supervisor turn** on the core
 loop's next iteration — costlier than a normal wake. Reserve it for

--- a/talents/loops-doctrine.md
+++ b/talents/loops-doctrine.md
@@ -5,138 +5,40 @@ tags: [loops]
 
 # Loops Doctrine
 
-The model-facing front door for "do work" is the `thane_*` family.
-Pick by lifecycle:
+Choose loop tools by lifecycle:
 
-- `thane_now(task, ...)` — synchronous answer right now. Blocks the
-  current turn until the delegate completes; result returns inline.
-  Use for bounded investigation, summarization, controlled tool use
-  where the answer is needed in this turn.
-- `thane_assign(task, ...)` — async one-shot. The delegate runs in
-  the background and reports back through the current conversation or
-  channel when complete. Use when the work is long enough that the
-  caller should move on rather than block.
-- `thane_curate(intent, cadence, output)` — recurring service loop
-  that maintains a managed document over time. Scaffolds the document
-  with frontmatter recording loop ownership, derives sleep parameters
-  from a cadence string ("hourly", "daily", "every 30 minutes",
-  "30m", "1h"), and launches in one round-trip. Two output modes:
-  `journal` appends a dated entry each cycle; `maintain` rewrites the
-  body each cycle. Future versions will accept a directory ref for
-  tree-shaped collections.
+- `thane_now` for bounded work that must finish before you reply.
+- `thane_assign` for one-shot background work that should report back
+  later.
+- `thane_curate` for recurring service work that owns a managed document
+  over time.
+- `spawn_loop` for ad hoc loop-shaped work that should start now without
+  becoming a stored definition.
+- loop definition tools for durable services you need to inspect, edit,
+  pause, reactivate, or relaunch.
 
-External wakes to running loops are infrastructural, not tool-shaped:
-producer subsystems (feed pollers, forge subscriptions, channel
-ingestion) dispatch structured event envelopes over the message bus to
-the loop named in their subscription's `wake_loop`. From inside a
-running service loop, use `set_next_sleep` to shorten its own cycle
-when it has learned something time-sensitive. To route a concern up to
-the core/owner loop, use `request_core_attention`.
+For recurring document work, prefer `thane_curate`. Its `cadence`
+schedules the service, its `output` declares the state owner, and the
+running loop writes through generated output tools such as
+`replace_output_*` or `append_output_*`. If a maintained output is
+marked `truncated` in Declared Durable Outputs, read the full document
+before replacing it.
 
-## Two paths for "this loop cares about a stream of things"
+Choose stream wiring by attention cost:
 
-There are two distinct mechanisms for binding a loop to a stream of
-external information. Pick the one that matches the cadence and
-event-shape of the source — they coexist on the same loop without
-conflict.
+- Use entity subscriptions for ambient state the loop should see on its
+  normal turns. `thane_curate.entities` creates the initial watch set;
+  `loop_update_entity_subscriptions`, `watch_entity`, and
+  `unwatch_entity` adjust it later.
+- Use event-source `wake_loop` targets when each event deserves an
+  immediate iteration. Producer tools such as `forge_repo_follow` and
+  `media_follow` own those subscriptions.
 
-**Ambient context injection (entity subscriptions).** Use for sources
-that update frequently and where each tick is *not* iteration-worthy
-on its own. The loop sees current values automatically on every
-scheduled iteration; no wake is triggered. Set up at thane_curate
-create time via the `entities` parameter, or adjust in flight with
-`loop_update_entity_subscriptions` (by name from outside) or
-`watch_entity` / `unwatch_entity` (from inside the loop itself).
-Scope: per-loop, behind the scenes via an internal `focus_tag`. Good
-fit: HA sensor values, weather state, presence — high-frequency
-ambient state where "next iteration" is soon enough.
+Natural-language timing inside a task does not schedule a service loop.
+Use `thane_curate.cadence` or explicit service-loop sleep fields. Lint
+hand-authored durable definitions before saving them, especially when
+cadence, jitter, or direct domain-tool access matters. Tagged service
+loops often want `profile.delegation_gating: "disabled"`.
 
-**Event-source wakes (`wake_loop` on a subscription).** Use for
-sources where each event is genuinely iteration-worthy and worth an
-immediate wake. The producer subsystem (forge subscription, media
-feed) dispatches a structured envelope with the events as payload,
-which wakes the target loop now if sleeping or queues for its next
-iteration if processing. Set up with the source-specific follow tool
-(`forge_repo_follow`, `media_follow`) and a `wake_loop` target. Good
-fit: forge releases, RSS feed entries, low-cadence
-something-just-happened signals where waiting for the next scheduled
-iteration would be too slow.
-
-Same loop, both mechanisms: a `thane_curate` loop watching HVAC
-entities (ambient) can also receive forge release events for the
-project that owns its scripts (event-source). The watch set keeps the
-prompt informed every iteration; the forge wake fires an iteration
-the moment a release lands.
-
-The lower-level definition and runtime tools remain available for
-inspection, control, and unusual launch shapes (event-driven,
-mqtt-wake-only, multi-stage, supervisor-randomized metacog patterns, or
-anything where the canonical family doesn't fit).
-
-Use the definition tools when the work is about a loop you want to keep,
-edit, pause, reactivate, or relaunch later:
-
-- `loop_definition_lint`
-- `loop_definition_list`
-- `loop_definition_get`
-- `loop_definition_set`
-- `loop_definition_set_policy`
-- `loop_definition_launch`
-
-Use the live runtime tools when the work is about what is running right
-now:
-
-- `loop_status`
-- `set_next_sleep`
-- `spawn_loop`
-- `stop_loop`
-
-`spawn_loop` is for ad hoc work that should start immediately without
-first becoming part of the persistent loop-definition registry. Reach
-for it when the loop is temporary, experimental, or tightly tied to the
-current moment.
-
-`set_next_sleep` is for the loop that is already running right now:
-
-- call it from inside a timer-driven service loop
-- ask for the next wake duration in plain duration syntax like `15m`
-- the runtime clamps the request to the loop's configured sleep bounds
-- use it when the loop has learned something that should change its
-  next attention cycle
-
-For one-shot curiosity or side research, think in the same shape as a
-delegate:
-
-- use `operation: background_task`
-- let completion default from the current origin when that is clearly
-  the right callback target
-- let the result come back naturally when it is done
-
-When a loop should maintain durable state, do that inside the loop's own
-work with normal tools such as `doc_write`, `doc_edit`, or
-`doc_journal_update`. Do not invent a second persistence path when the
-document tools already express the artifact clearly.
-
-Prefer durable definitions for recurring services. Prefer ad hoc live
-spawns for temporary observers and one-off detached tasks.
-
-Natural-language timing in `task` does not schedule a service loop.
-Words like hourly, daily, or every night do nothing on their own. For
-service loops, set `sleep_min`, `sleep_max`, `sleep_default`, and
-`jitter` deliberately.
-
-Before saving or replacing a durable service definition, use
-`loop_definition_lint` or inspect the warnings returned by definition
-views. Linting matters most when:
-
-- the task text mentions a cadence
-- the loop should use its own tagged tools directly
-- fixed cadence matters more than jitter
-
-Tagged service loops often want `profile.delegation_gating: "disabled"`
-so the loop can use its own domain tools directly instead of falling
-back into delegation-first orchestration.
-
-Loop authoring is rare and high leverage. When you need it, copy a
-known-good pattern from `loops-examples` and adapt it minimally instead
-of rebuilding the launch shape from memory.
+When you need concrete JSON launch patterns, activate `loops_examples`
+and adapt the closest recipe minimally.

--- a/talents/loops-examples.md
+++ b/talents/loops-examples.md
@@ -115,10 +115,12 @@ When the watcher sees something the core should consider:
 }
 ```
 
-`request_core_attention` does not deliver a message to a human. It
-queues a supervisor turn on the core loop. The core decides whether
-to notify, defer, or absorb. State the concern as a decision or risk,
-not as a delivery command.
+`request_core_attention` does not deliver a message to a human, and
+it is not free: every call forces the core's next iteration into a
+supervisor turn (costlier than a normal wake). Use it for concerns
+that genuinely warrant the extra capacity. State the concern as a
+decision or risk, not as a delivery command — the core decides
+whether to notify, defer, or absorb.
 
 ### Step 4: Push new focus down
 

--- a/talents/loops-examples.md
+++ b/talents/loops-examples.md
@@ -5,54 +5,182 @@ tags: [loops_examples]
 
 # Loops Examples
 
-Use these as trusted launch patterns. Do not improvise the whole
-loops-ng contract from scratch unless the situation truly demands it.
-Start from the closest recipe and change only what matters.
+Loops are how Thane runs concurrent attention. The default path is a
+**curate loop** — a small subconscious watcher that the core agent
+launches with a watch set and a document to keep current, then leaves
+alone until either side has something to say.
 
-## Pattern: Lint A Durable Service Definition Before Saving It
+This file walks the full circle of life so the shape is concrete:
+inspect what's already running, launch the watcher, let it self-pace,
+let it pull the core's attention when something matters, push new
+focus down when the core needs it. Then a few specialty shapes for
+work that doesn't fit the curate pattern.
 
-Use this when you are about to create or replace a persistent service
-loop and want to see the effective defaults and authoring warnings
-first.
+## Look at what's already running first
 
-- Tool: `loop_definition_lint`
-- Use this before `loop_definition_set`
-- Pay special attention to omitted sleep fields, delegation gating, and
-  warnings about task text that mentions a cadence
+Each running loop is its own documentation. Before launching anything
+new, check what exists — both for "is there already a loop watching
+this?" and for "what does a healthy spec for this kind of work look
+like?"
+
+- `loop_status` — live registry, with filters for query text, state,
+  operation, and a result limit. Returns iteration counts, last wake,
+  cumulative and last-turn token use, active tags, metadata, and
+  consecutive error counts for every running loop.
+- `loop_definition_list` — every durable definition, config and
+  overlay together.
+- `loop_definition_get(name)` — the full spec for one: task, tags,
+  outputs, sleep envelope, profile, supervisor settings, conditions,
+  metadata.
+
+Treat the registry as a library of worked examples. A loop that has
+run hundreds of healthy iterations is a better template than anything
+in this file. If a peer loop already owns the topic, prefer extending
+it (via `loop_update_entity_subscriptions`) over launching a parallel
+watcher.
+
+## The default path: curate, self-pace, two-way signal
+
+The bi-directional curate loop is the well-worn path. Two-way comms
+between a subconscious research task and the core's situational
+awareness:
+
+1. **Core launches the watcher** with `thane_curate`. Hand it an
+   intent, a watch set, a document to own, and an adaptive sleep
+   envelope (see the cadence section below).
+2. **Watcher runs at its own pace.** It writes findings to the
+   document each cycle and tunes its own next wake with
+   `set_next_sleep` (clamped to the envelope it was given).
+3. **Watcher pulls the core in when it matters.** When the watcher
+   sees something the core needs to decide on, it calls
+   `request_core_attention` with a concern and a priority.
+4. **Core pushes new focus down when it matters.** When the core
+   wants the watcher to track something new, it calls
+   `loop_update_entity_subscriptions` to add or remove entities from
+   the watcher's set.
+
+The watcher never speaks to the operator directly. It speaks to the
+document it owns, and to the core. The core decides what reaches a
+human.
+
+### Step 1: Launch the watcher
 
 ```json
 {
-  "spec": {
-    "name": "county-burn-ban-monitor",
-    "enabled": true,
-    "task": "Check the county burn ban source hourly and keep the Home Assistant helper aligned with the current restriction state.",
-    "operation": "service",
-    "completion": "none",
-    "tags": ["web", "ha"],
-    "sleep_min": "1h",
-    "sleep_max": "1h",
-    "sleep_default": "1h",
-    "jitter": 0,
-    "profile": {
-      "mission": "background",
-      "delegation_gating": "disabled",
-      "initial_tags": ["home"],
-      "instructions": "Use direct domain tools. Keep durable notes only when they materially improve future iterations."
-    }
-  }
+  "name": "server-closet-guardian",
+  "intent": "Watch the server-closet environment and equipment health. Document trends. Surface UPS dropouts, dehumidifier failure, or temperature excursions that need attention.",
+  "cadence": "30m",
+  "entities": [
+    {"entity_id": "sensor.server_closet_temperature"},
+    {"entity_id": "sensor.server_closet_humidity"},
+    {"entity_id": "sensor.ups_hor_rack_status"},
+    {"entity_id": "sensor.ups_hor_rack_battery_runtime"},
+    {"entity_id": "switch.dehumidifier"}
+  ],
+  "output": {
+    "document": "kb:dashboards/server-closet.md",
+    "mode": "maintain",
+    "title": "Server Closet Guardian"
+  },
+  "tags": ["home", "ha", "awareness"]
 }
 ```
 
-## Pattern: Detached Research That Reports Back Later
+`cadence` sets the default; the runtime derives a sleep envelope
+around it with light jitter. The watcher writes through the generated
+`replace_output_*` tool (for `mode: "maintain"`) or `append_output_*`
+(for `mode: "journal"`).
 
-Use this when the current turn would benefit from a side investigation
-that can return naturally when it is done.
+### Step 2: Let the watcher self-pace
 
-- Tool: `spawn_loop`
-- Shape: `operation: background_task`
-- Delivery: omit completion when the current conversation or channel
-  context should decide the callback target
-- Persistence: none beyond whatever documents the loop writes itself
+Inside its own iteration, the watcher has three steering tools:
+
+- `set_next_sleep` — tune the next wake within the envelope. Cannot
+  exceed the persisted `sleep_min` / `sleep_max`.
+- `watch_entity` / `unwatch_entity` — adjust its own watch set
+  without needing its name.
+
+Pick the envelope at creation time and trust the loop to find its own
+rhythm inside.
+
+### Step 3: Pull the core in
+
+When the watcher sees something the core should consider:
+
+```json
+{
+  "concern": "UPS hor-rack reports 4 minutes battery runtime and 92% load. Brownout protection window is narrowing.",
+  "priority": "urgent",
+  "context": "Last 30m: load climbed from 78% to 92% after closet AC dropped. No recent grid events."
+}
+```
+
+`request_core_attention` does not deliver a message to a human. It
+queues a supervisor turn on the core loop. The core decides whether
+to notify, defer, or absorb. State the concern as a decision or risk,
+not as a delivery command.
+
+### Step 4: Push new focus down
+
+When the core decides the watcher should track something new:
+
+```json
+{
+  "name": "server-closet-guardian",
+  "add": [
+    {"entity_id": "sensor.closet_ac_state", "history": [3600]},
+    {"entity_id": "binary_sensor.utility_brownout"}
+  ]
+}
+```
+
+`loop_update_entity_subscriptions` modifies the running loop's watch
+set in place. The watcher sees the new entities on its next wake. Use
+`remove: ["entity_id", ...]` to retire watches the core no longer
+cares about.
+
+For event-driven wakes (a new release on a repo, a new feed entry),
+producer tools like `forge_repo_follow` and `media_follow` take a
+`wake_loop` target so the curate loop wakes on the event rather than
+its timer.
+
+## Adaptive cadence: pick the envelope, not the tick
+
+The only real judgment at creation is the sleep envelope. The loop
+self-pacing inside that envelope handles the rest.
+
+- `sleep_min`: how often this topic can deserve attention at its
+  busiest. Tight enough that an urgent change is not missed.
+- `sleep_max`: how rarely this topic can be checked without losing
+  signal. Loose enough that a quiet day costs nothing.
+- `sleep_default`: a sensible mid-point for the first wake.
+- `jitter`: 0.1–0.2 unless several peer loops would otherwise
+  synchronize and stampede.
+
+The watcher uses `set_next_sleep` to tighten when something is
+interesting and loosen when nothing is happening. A burn-ban monitor
+might envelope `[1h, 6h]`; a UPS guardian might envelope `[5m, 30m]`;
+a daily digest writer might envelope `[12h, 36h]`. In all three the
+loop finds its own rhythm.
+
+Words like "hourly" or "every 30 minutes" inside `task` text do not
+schedule the loop. Only the sleep envelope does.
+
+## Specialty shapes
+
+### Lint a durable definition before saving
+
+Use `loop_definition_lint` before `loop_definition_set` when
+authoring or replacing a persisted service. The linter surfaces
+omitted sleep fields, ineffective delegation gating, and task text
+that pretends to schedule itself.
+
+### One-shot research that reports back
+
+When the current turn benefits from a side investigation that returns
+naturally when done, use `spawn_loop` with
+`operation: background_task` and omit completion (the origin context
+infers the callback path).
 
 ```json
 {
@@ -71,70 +199,21 @@ that can return naturally when it is done.
 }
 ```
 
-When launching from the current interactive context, you usually do not
-need to set an explicit completion target. The runtime can infer the
-most natural callback path from the current conversation or channel
-origin.
+### Durable service with lifecycle control and supervisor turns
 
-## Pattern: Persistent Service With Supervisor Turns
+Use `loop_definition_set` (not `spawn_loop`) when the lifecycle —
+keep, pause, resume, relaunch — matters. Pair with
+`loop_definition_set_policy(state="active" | "paused" | "inactive")`.
+Tagged service loops usually want `profile.delegation_gating:
+"disabled"` so they can use their own tools directly.
 
-Use this when the loop should keep watching something over time, sleep
-between iterations, and occasionally take a more expensive supervisor
-pass.
-
-- Tool: `spawn_loop`
-- Shape: `operation: service`
-- Delivery: usually `completion: none`
-- Persistence: the loop should maintain its own state with `doc_write`,
-  `doc_edit`, or `doc_journal_update`
-
-```json
-{
-  "launch": {
-    "spec": {
-      "name": "battery-watch",
-      "task": "Maintain a current view of battery health across the property. Notice trends, anomalies, and devices that deserve attention. Keep the state document concise and trustworthy.",
-      "operation": "service",
-      "completion": "none",
-      "sleep_min": "10m",
-      "sleep_max": "30m",
-      "sleep_default": "15m",
-      "jitter": 0.2,
-      "supervisor": true,
-      "supervisor_prob": 0.15,
-      "quality_floor": 4,
-      "supervisor_quality_floor": 9,
-      "supervisor_context": "Supervisor turn. Step back from individual readings, look for cross-device patterns or weak assumptions, and decide whether anything now deserves escalation or a sharper hypothesis.",
-      "profile": {
-        "mission": "background",
-        "delegation_gating": "disabled",
-        "initial_tags": ["home", "knowledge", "documents"],
-        "instructions": "Maintain one durable state document. Use the journal when something materially changes. Call set_next_sleep when the next wake should be meaningfully shorter or longer than the default cycle."
-      }
-    }
-  }
-}
-```
-
-Put the main prompt in `launch.spec.task`, not top-level `launch.task`,
-when you want `supervisor_context` to apply cleanly.
-Words like hourly or daily inside `task` do not schedule the loop. The
-`sleep_min`, `sleep_max`, `sleep_default`, and `jitter` fields are the
-real cadence.
-
-## Pattern: Durable Named Service You Can Pause And Resume
-
-Use this when the loop should survive beyond the current moment as a
-stored definition that can be inspected, paused, resumed, or relaunched
-later.
-
-1. Lint the definition with `loop_definition_lint`.
-2. Create or replace the definition with `loop_definition_set`.
-3. Use `loop_definition_set_policy(state=\"active\")` to keep it
-   running, `paused` to stop without forgetting it, and `inactive` to
-   disable it.
-4. Use `loop_definition_get`, `loop_definition_list`, and `loop_status`
-   to inspect it later.
+When the loop should mostly run cheap iterations but occasionally
+take a more expensive supervisor pass, layer `supervisor: true` plus
+`supervisor_prob`, `supervisor_quality_floor`, and a
+`supervisor_context` that prompts the model to step back.
+`thane_curate` does not expose supervisor fields directly — use
+`loop_definition_set` or `spawn_loop` when supervisor turns are
+needed.
 
 ```json
 {
@@ -163,46 +242,5 @@ later.
 }
 ```
 
-Use `spawn_loop` for temporary loops. Use stored definitions when the
-important part is the lifecycle:
-
-- keep it
-- pause it
-- resume it
-- inspect it later
-
-If the loop should use its own tagged tools directly, remember
-`profile.delegation_gating: "disabled"`. That is a common service-loop
-need.
-
-## Pattern: Background Loop With Operator Turns
-
-Use this when the loop should work independently most of the time but
-return to the operator only when it has a real result or has reached a
-decision boundary.
-
-- Tool: `spawn_loop`
-- Shape: `operation: background_task`
-- Delivery: usually omit completion and let the origin decide; set it
-  explicitly only when you need a non-default callback path
-- Prompting move: state clearly what should trigger a return turn
-
-```json
-{
-  "launch": {
-    "spec": {
-      "name": "policy-research",
-      "task": "Research the current policy question thoroughly. Work independently while evidence gathering is straightforward. Return to the operator only when you have a strong answer, a short list of real options, or a blocking ambiguity that requires a human choice.",
-      "operation": "background_task",
-      "profile": {
-        "mission": "background",
-        "initial_tags": ["knowledge", "documents"],
-        "instructions": "Leave durable notes in documents when they will make the eventual return turn easier to understand."
-      }
-    }
-  }
-}
-```
-
-Use this pattern for delegate-like behavior without flattening the
-parent loop into the entire investigation.
+Put the main prompt in `spec.task`, not top-level `launch.task`, so
+`supervisor_context` applies cleanly on supervisor turns.

--- a/talents/loops-examples.md
+++ b/talents/loops-examples.md
@@ -1,6 +1,6 @@
 ---
 kind: examples
-tags: [loops]
+tags: [loops_examples]
 ---
 
 # Loops Examples


### PR DESCRIPTION
## Summary

Four related changes that all tighten the loops surface so an agent
hitting it makes fewer wrong guesses.

### Runtime: stop silently dropping launch overrides on running service loops

Diagnosed from request `r_9bcd6703e0fe5c71`, where three `thane_curate`
+ three `loop_definition_launch(launch.model=…)` calls returned
`status: ok` but produced four service loops with no persistent model
selection. Root cause was layered: the agent surface invited a launch
override that the runtime drops on the floor for running services, and
the model description led the agent to believe it was setting a
persistent model.

Fixed both layers:

- **Close the agent surface.** Drop `model` from the JSON schema for
  `loop_definition_launch` and `spawn_loop`. The validator rejects both
  `launch.model` and the older `launch.metadata.model` with an error
  that points to `spec.profile.model` and the `loop_definition_set`
  remediation. `Launch.Model` stays on the Go type for internal one-shot
  callers (delegates, scheduled tasks) with godoc explaining why it's
  closed at the JSON boundary.
- **Make the silent drop loud.** New typed `RunningServiceOverridesError`
  and `Launch.HasOverrides()`. `LaunchDefinition` now returns the typed
  error when a running service definition receives non-empty overrides
  instead of silently returning the existing loop ID. Empty `Launch{}`
  still joins the running loop unchanged.

### Docs: clarify GoDoc bar for exported vs unexported symbols

Lifts the convention worked out in `wheelsdown/spivot-server`'s
AGENTS.md. New `## Documentation` section splits the bar between
exported (product surface, with `[Identifier]` doc links and `Example*`
tests) and unexported (deletion test heuristic for whether a comment is
earning its place). Calls out fields that look like relics but aren't
as the canonical case — see the `Launch.Model` godoc landed in the
runtime commit above.

Two adjacent convention bullets while editing AGENTS.md:

- HTTP handlers: explicit boundary timeouts, thin handlers, package-
  level logic that's unit-testable without standing up a server.
- Package boundaries: avoid shared "utility" packages until two real
  call sites prove the abstraction belongs there.

### Talents: compact loops doctrine + reframe examples around the circle of life

Two passes on the loops talent surface:

- **Compaction (original PR content).** Compact the always-loaded
  loops doctrine into a short lifecycle/state/streaming decision guide,
  and move loop recipe examples behind the narrower `loops_examples`
  tag.
- **Examples reframed as narrative.** Restructure `loops-examples.md`
  around the bi-directional pattern the curate path is built for:
  inspect what's already running first (each thriving loop is its own
  data-dense documentation), then walk the four steps of the circle
  of life — core launches via `thane_curate`, watcher self-paces via
  `set_next_sleep`, watcher pulls the core in via
  `request_core_attention`, core pushes new focus down via
  `loop_update_entity_subscriptions`. Promotes the sleep envelope as
  the only real judgment call at creation; specialty shapes (lint,
  one-shot research, supervisor turns) retained in compact form.

## Test plan

- [x] `just ci` passes locally on the combined diff
- [x] New `TestLaunchHasOverrides` covers 24 fields plus baselines, with
      a reflection-based forcing function that fails by name if a future
      `Launch` field skips `HasOverrides()` coverage
- [x] New `TestLoopDefinitionRuntimeLaunchDefinitionRunningServiceRejectsOverrides`
      covers empty-launch success and 5 representative override paths
- [x] Schema-omits-model and reject-top-level-model tests on both
      `loop_definition_launch` and `spawn_loop`

Refs the audit threads on `r_9bcd6703e0fe5c71`.