### PR TITLE
fix: clickable request chip + copy JSON feedback on failed turns

### DIFF
--- a/internal/server/web/static/app.js
+++ b/internal/server/web/static/app.js
@@ -1552,7 +1552,7 @@ function renderLoopCurrentTurnCard(loop, entity, conversationSummary) {
   briefGrid.className = 'loop-turn-brief__grid';
   const briefFacts = [
     { label: 'Thread', value: threadLabel },
-    { label: 'Request', value: entity.latestRequestID ? shortID(entity.latestRequestID) : 'pending' },
+    { label: 'Request', value: entity.latestRequestID ? makeRequestChip(entity.latestRequestID) : 'pending' },
     { label: 'Model', value: latestModelLabel },
     { label: 'State', value: formatSchemaToken(entity.stateLabel) },
     { label: 'Context', value: contextLabel || 'pending' },
@@ -1565,7 +1565,11 @@ function renderLoopCurrentTurnCard(loop, entity, conversationSummary) {
     cell.className = 'loop-turn-brief__metric';
     const value = document.createElement('div');
     value.className = 'loop-turn-brief__metric-value';
-    value.textContent = item.value;
+    if (item.value instanceof Node) {
+      value.appendChild(item.value);
+    } else {
+      value.textContent = item.value;
+    }
     cell.appendChild(value);
     const label = document.createElement('div');
     label.className = 'loop-turn-brief__metric-label';
@@ -4309,7 +4313,7 @@ function renderLoopEntityDetail(loop) {
     latestGrid.className = 'loop-turn-brief__grid';
     const latestFacts = [
       { label: 'Iteration', value: '#' + formatNumber(entity.latestSnapshot.number || entity.iterations || 0) },
-      { label: 'Request', value: entity.latestSnapshot.request_id ? shortID(entity.latestSnapshot.request_id) : 'pending' },
+      { label: 'Request', value: entity.latestSnapshot.request_id ? makeRequestChip(entity.latestSnapshot.request_id) : 'pending' },
       { label: 'Model', value: entity.latestSnapshot.model ? shortModelName(entity.latestSnapshot.model) : latestModelLabel },
       { label: 'Duration', value: entity.latestSnapshot.elapsed_ms ? formatDuration(entity.latestSnapshot.elapsed_ms) : 'pending' },
       { label: 'Input', value: entity.latestSnapshot.input_tokens ? formatTokens(entity.latestSnapshot.input_tokens) : '0' },
@@ -4320,7 +4324,11 @@ function renderLoopEntityDetail(loop) {
       cell.className = 'loop-turn-brief__metric';
       const value = document.createElement('div');
       value.className = 'loop-turn-brief__metric-value';
-      value.textContent = item.value;
+      if (item.value instanceof Node) {
+        value.appendChild(item.value);
+      } else {
+        value.textContent = item.value;
+      }
       cell.appendChild(value);
       const label = document.createElement('div');
       label.className = 'loop-turn-brief__metric-label';
@@ -5160,15 +5168,26 @@ function closeRequestDetail() {
 
 $('#request-detail-close').addEventListener('click', closeRequestDetail);
 $('#request-detail-copy').addEventListener('click', () => {
-  if (!activeRequestJSON) return;
   const btn = $('#request-detail-copy');
-  navigator.clipboard.writeText(activeRequestJSON).then(() => {
-    btn.textContent = 'Copied';
+  const flash = (label, ms = 1200) => {
+    btn.textContent = label;
+    setTimeout(() => { btn.textContent = 'JSON'; btn.classList.remove('copy-btn--copied'); }, ms);
+  };
+  // Fall back to a minimal envelope when full detail is unavailable
+  // (404, 503, content retention off) so the button always copies
+  // something identifiable rather than silently no-opping.
+  const payload = activeRequestJSON
+    || (activeRequestID ? JSON.stringify({ request_id: activeRequestID, error: 'detail unavailable' }, null, 2) : '');
+  if (!payload) {
+    flash('No request');
+    return;
+  }
+  navigator.clipboard.writeText(payload).then(() => {
     btn.classList.add('copy-btn--copied');
-    setTimeout(() => {
-      btn.textContent = 'JSON';
-      btn.classList.remove('copy-btn--copied');
-    }, 1200);
+    flash(activeRequestJSON ? 'Copied' : 'Copied ID only');
+  }).catch((err) => {
+    console.warn('Failed to copy request detail JSON:', err);
+    flash('Copy failed');
   });
 });
 


### PR DESCRIPTION
Stacked on top of #868. Targets `codex/live-trace-forensics-ui`.

## Summary

Two related web UI bugs surfaced while triaging a Signal/David McNett handler-timeout incident in prod (request `r_a137554bc78b4338`, 2026-05-22 23:11:45 UTC). The failed turn was unrecoverable from the UI because:

1. The activity card's brief-grid Request cell rendered as plain text — the summary above promised "Use the request chip below" but the chip wasn't actually a chip. No click, no copy. Now rendered via `makeRequestChip(request_id)`. Same fix applied to the loop current-turn brief grid which shared the bug.

2. `#request-detail-copy` (the JSON button on the inline request detail panel) silently bailed when `activeRequestJSON` was null — which happens on 404/503 from `/api/requests/:id`, or whenever the panel was closed mid-fetch. Now flashes user-visible feedback (`No request` / `Copy failed`) and falls back to copying a minimal `{request_id, error: "detail unavailable"}` envelope so the user can at least get the ID when full detail is gone.

The fix keeps the rendering data-driven (string or `Node` in `item.value`) so future fields can also supply DOM nodes without a wider refactor.

## Test plan

- [ ] Manual: load a loop with a failed latest turn — confirm the brief grid's Request cell is now a clickable/shift-clickable chip
- [ ] Manual: click the chip on a failed turn — confirm the inline detail panel opens, JSON copy works
- [ ] Manual: simulate `/api/requests/:id` returning 404 — confirm JSON button shows `No request` instead of silent no-op
- [ ] Manual: with content retention off (503), confirm fallback to `request.html` window still works, and that any leftover inline-panel JSON button click shows feedback
- [ ] `just ci` passes locally (verified)

## Out of scope (worth follow-ups)

- The runtime `llm_timeout_retrying_same_model` retry path inherits the already-cancelled outer Signal handler context, so the retry can never run. Currently logged as if retry is meaningful — misleading in both logs and UI. Worth a separate fix on the runner side.
- Backend doesn't seem to index failed-turn request detail consistently (some 404s on otherwise-known request IDs). Out of scope for this UI change.