### PR TITLE
feat: drop cadence from thane_curate; require explicit sleep envelope

### DIFF
--- a/internal/runtime/loop/definition_warnings.go
+++ b/internal/runtime/loop/definition_warnings.go
@@ -26,7 +26,7 @@ func BuildDefinitionWarnings(spec Spec) []DefinitionWarning {
 	switch len(missingSleep) {
 	case 4:
 		warnings = append(warnings, DefinitionWarning{
-			Code: "service_default_cadence",
+			Code: "service_default_sleep_envelope",
 			Message: fmt.Sprintf(
 				"Service loop omits sleep_min, sleep_max, sleep_default, and jitter. It will use engine defaults of sleep_min=%s, sleep_max=%s, sleep_default=%s, jitter=%.1f. Natural-language timing in task text does not schedule the loop.",
 				DefaultSleepMin.String(),
@@ -37,7 +37,7 @@ func BuildDefinitionWarnings(spec Spec) []DefinitionWarning {
 		})
 	case 1, 2, 3:
 		warnings = append(warnings, DefinitionWarning{
-			Code: "service_partial_cadence_defaults",
+			Code: "service_partial_sleep_defaults",
 			Message: fmt.Sprintf(
 				"Service loop leaves %s implicit. Omitted timing fields fall back to sleep_min=%s, sleep_max=%s, sleep_default=%s, jitter=%.1f.",
 				quotedFieldList(missingSleep),
@@ -49,10 +49,10 @@ func BuildDefinitionWarnings(spec Spec) []DefinitionWarning {
 		})
 	}
 
-	if taskSuggestsCadence(spec.Task) && len(missingSleep) > 0 {
+	if taskSuggestsTiming(spec.Task) && len(missingSleep) > 0 {
 		warnings = append(warnings, DefinitionWarning{
-			Code:    "task_mentions_cadence_without_explicit_sleep",
-			Message: "Task text suggests a cadence such as hourly or daily, but service-loop timing comes only from sleep_min, sleep_max, sleep_default, and jitter.",
+			Code:    "task_mentions_timing_without_explicit_sleep",
+			Message: "Task text suggests a recurring schedule such as hourly or daily, but service-loop timing comes only from sleep_min, sleep_max, sleep_default, and jitter.",
 		})
 	}
 
@@ -78,8 +78,8 @@ func BuildDefinitionWarnings(spec Spec) []DefinitionWarning {
 	}
 	if cfg.SleepMin == cfg.SleepMax && cfg.SleepDefault == cfg.SleepMin && jitter > 0 {
 		warnings = append(warnings, DefinitionWarning{
-			Code:    "fixed_cadence_with_jitter",
-			Message: "Fixed cadence is implied because sleep_min == sleep_max == sleep_default, but jitter is still non-zero. Set jitter to 0 if the loop should wake on a stable interval.",
+			Code:    "fixed_interval_with_jitter",
+			Message: "Fixed interval is implied because sleep_min == sleep_max == sleep_default, but jitter is still non-zero. Set jitter to 0 if the loop should wake on a stable interval.",
 		})
 	}
 
@@ -117,7 +117,7 @@ func quotedFieldList(fields []string) string {
 	return strings.Join(quoted[:len(quoted)-1], ", ") + ", and " + quoted[len(quoted)-1]
 }
 
-func taskSuggestsCadence(task string) bool {
+func taskSuggestsTiming(task string) bool {
 	task = strings.ToLower(strings.TrimSpace(task))
 	if task == "" {
 		return false

--- a/internal/runtime/loop/definition_warnings_test.go
+++ b/internal/runtime/loop/definition_warnings_test.go
@@ -5,7 +5,7 @@ import (
 	"time"
 )
 
-func TestBuildDefinitionWarnings_DefaultCadenceAndDelegation(t *testing.T) {
+func TestBuildDefinitionWarnings_DefaultSleepAndDelegation(t *testing.T) {
 	spec := Spec{
 		Name:      "comal_burn_ban_monitor",
 		Task:      "Check the county burn ban source hourly and update Home Assistant.",
@@ -22,8 +22,8 @@ func TestBuildDefinitionWarnings_DefaultCadenceAndDelegation(t *testing.T) {
 		codes[warning.Code] = true
 	}
 	for _, code := range []string{
-		"service_default_cadence",
-		"task_mentions_cadence_without_explicit_sleep",
+		"service_default_sleep_envelope",
+		"task_mentions_timing_without_explicit_sleep",
 		"service_delegation_gating_enabled",
 	} {
 		if !codes[code] {
@@ -32,7 +32,7 @@ func TestBuildDefinitionWarnings_DefaultCadenceAndDelegation(t *testing.T) {
 	}
 }
 
-func TestBuildDefinitionWarnings_FixedCadenceJitterAndCompletion(t *testing.T) {
+func TestBuildDefinitionWarnings_FixedIntervalJitterAndCompletion(t *testing.T) {
 	spec := Spec{
 		Name:         "battery_watch",
 		Task:         "Watch batteries.",
@@ -51,7 +51,7 @@ func TestBuildDefinitionWarnings_FixedCadenceJitterAndCompletion(t *testing.T) {
 	if !codes["service_completion_not_periodic"] {
 		t.Fatalf("warning codes = %#v, want service_completion_not_periodic", codes)
 	}
-	if !codes["fixed_cadence_with_jitter"] {
-		t.Fatalf("warning codes = %#v, want fixed_cadence_with_jitter", codes)
+	if !codes["fixed_interval_with_jitter"] {
+		t.Fatalf("warning codes = %#v, want fixed_interval_with_jitter", codes)
 	}
 }

--- a/internal/tools/loop_definition_tools.go
+++ b/internal/tools/loop_definition_tools.go
@@ -122,7 +122,7 @@ func (r *Registry) registerLoopDefinitionTools() {
 
 	r.Register(&Tool{
 		Name:        "loop_definition_lint",
-		Description: "Lint one candidate persistent loop definition without saving it. Returns whether the spec is persistable, the effective runtime defaults that would apply, and non-fatal warnings for common service-loop authoring mistakes such as omitted cadence fields or delegation-first gating.",
+		Description: "Lint one candidate persistent loop definition without saving it. Returns whether the spec is persistable, the effective runtime defaults that would apply, and non-fatal warnings for common service-loop authoring mistakes such as omitted sleep envelope fields or delegation-first gating.",
 		Parameters: map[string]any{
 			"type": "object",
 			"properties": map[string]any{

--- a/internal/tools/loop_definition_tools_test.go
+++ b/internal/tools/loop_definition_tools_test.go
@@ -186,8 +186,8 @@ func TestLoopDefinitionGetIncludesWarnings(t *testing.T) {
 	if len(got.Definition.Warnings) == 0 {
 		t.Fatal("expected authoring warnings on metacog_like definition")
 	}
-	if got.Definition.Warnings[0].Code != "service_default_cadence" {
-		t.Fatalf("warning code = %q, want service_default_cadence", got.Definition.Warnings[0].Code)
+	if got.Definition.Warnings[0].Code != "service_default_sleep_envelope" {
+		t.Fatalf("warning code = %q, want service_default_sleep_envelope", got.Definition.Warnings[0].Code)
 	}
 }
 
@@ -236,15 +236,15 @@ func TestLoopDefinitionLintReportsServiceWarnings(t *testing.T) {
 		t.Fatalf("effective jitter = %v, want %v", got.Effective.Jitter, looppkg.DefaultJitter)
 	}
 	if len(got.Warnings) < 3 {
-		t.Fatalf("warnings = %#v, want at least cadence/task/delegation warnings", got.Warnings)
+		t.Fatalf("warnings = %#v, want at least sleep/task/delegation warnings", got.Warnings)
 	}
 	codes := make(map[string]bool, len(got.Warnings))
 	for _, warning := range got.Warnings {
 		codes[warning.Code] = true
 	}
 	for _, code := range []string{
-		"service_default_cadence",
-		"task_mentions_cadence_without_explicit_sleep",
+		"service_default_sleep_envelope",
+		"task_mentions_timing_without_explicit_sleep",
 		"service_delegation_gating_enabled",
 	} {
 		if !codes[code] {

--- a/internal/tools/loop_intent_tools.go
+++ b/internal/tools/loop_intent_tools.go
@@ -5,8 +5,6 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"fmt"
-	"regexp"
-	"strconv"
 	"strings"
 	"time"
 
@@ -87,11 +85,11 @@ func (r *Registry) registerThaneCurate() {
 			"Output-first: the target document (kb:, core:, scratchpad:, generated:) is scaffolded with frontmatter recording loop ownership before the loop is registered, so the loop's identity and intent are self-describing on disk. " +
 			"Two output modes today: \"journal\" appends a dated entry each cycle (research notes, decision logs, daily digests); \"maintain\" rewrites the document idempotently each cycle (dashboards, current-state snapshots). " +
 			"Future modes will accept a directory ref for tree-shaped collections (multiple files maintained as a structured corpus); the output parameter shape will grow additively. " +
-			"Cadence accepts \"hourly\", \"daily\", \"every 30 minutes\", \"5m\", or \"1h\". Sleep_min/max/jitter are derived automatically. " +
+			"Sleep envelope: pass sleep_min and sleep_max as Go duration strings (\"5m\", \"30m\", \"1h\"). The running loop uses set_next_sleep to self-pace within those bounds — pick them to match the topic's metabolism (tight when busy work deserves quick checks, loose when quiet periods should cost nothing). sleep_default and jitter are optional with sensible defaults. " +
 			"Tags scope the loop's tools; omit to inherit the always-active set. " +
 			"Entities is a list of Home Assistant entity subscriptions the loop should see every iteration; they are persisted under a per-loop focus tag and surfaced into the loop's prompt automatically. " +
-			"Returns the document ref, loop definition name, loop_id, output mode, the generated output tool name (output_tool) the receiving loop writes through, the loop's internal focus_tag, and the derived sleep_min/max/default cadence triple.",
-		ContentResolveExempt: []string{"name", "intent", "cadence", "tags", "guidance", "output", "entities", "replace"},
+			"Returns the document ref, loop definition name, loop_id, output mode, the generated output tool name (output_tool) the receiving loop writes through, the loop's internal focus_tag, and the resolved sleep envelope.",
+		ContentResolveExempt: []string{"name", "intent", "sleep_min", "sleep_max", "sleep_default", "jitter", "tags", "guidance", "output", "entities", "replace"},
 		Parameters: map[string]any{
 			"type": "object",
 			"properties": map[string]any{
@@ -103,9 +101,21 @@ func (r *Registry) registerThaneCurate() {
 					"type":        "string",
 					"description": "One- or two-sentence description of what the loop tracks, why it exists, and what the document should contain. The model running each iteration sees this in its task prompt.",
 				},
-				"cadence": map[string]any{
+				"sleep_min": map[string]any{
 					"type":        "string",
-					"description": "How often the loop wakes. Accepts \"hourly\", \"daily\", \"every 30 minutes\", \"30m\", \"1h\", or any time.Duration string. Below 1 minute is rejected.",
+					"description": "Tightest interval between iterations (Go duration: \"5m\", \"30m\", \"1h\"). Floor at 1 minute. The loop's set_next_sleep can never wake sooner than this.",
+				},
+				"sleep_max": map[string]any{
+					"type":        "string",
+					"description": "Loosest interval between iterations (Go duration: \"30m\", \"6h\"). The loop's set_next_sleep can never sleep longer than this. Must be >= sleep_min; equal values pin a fixed interval.",
+				},
+				"sleep_default": map[string]any{
+					"type":        "string",
+					"description": "Optional initial sleep duration for the first wake. Defaults to the midpoint of sleep_min and sleep_max. Must lie within the envelope.",
+				},
+				"jitter": map[string]any{
+					"type":        "number",
+					"description": "Optional sleep randomization factor in [0, 1]. Defaults to 0.1. Set to 0 for deterministic timing.",
 				},
 				"output": map[string]any{
 					"type":        "object",
@@ -169,7 +179,7 @@ func (r *Registry) registerThaneCurate() {
 					"description": "When true, overwrite an existing definition or document of the same name/ref. Default false; the tool refuses to clobber existing artifacts.",
 				},
 			},
-			"required": []string{"name", "intent", "cadence", "output"},
+			"required": []string{"name", "intent", "sleep_min", "sleep_max", "output"},
 		},
 		Handler: r.handleThaneCurate,
 	})
@@ -183,15 +193,16 @@ func (r *Registry) handleThaneCurate(ctx context.Context, args map[string]any) (
 
 	name, _ := args["name"].(string)
 	intent, _ := args["intent"].(string)
-	cadenceInput, _ := args["cadence"].(string)
 	if strings.TrimSpace(name) == "" {
 		return "", fmt.Errorf("name is required")
 	}
 	if strings.TrimSpace(intent) == "" {
 		return "", fmt.Errorf("intent is required")
 	}
-	if strings.TrimSpace(cadenceInput) == "" {
-		return "", fmt.Errorf("cadence is required")
+
+	envelope, err := parseSleepEnvelope(args)
+	if err != nil {
+		return "", err
 	}
 
 	output, _ := args["output"].(map[string]any)
@@ -228,11 +239,6 @@ func (r *Registry) handleThaneCurate(ctx context.Context, args map[string]any) (
 	}
 	if len(entities) > 0 && deps.WatchlistStore == nil {
 		return "", fmt.Errorf("entities provided but watchlist store is not configured")
-	}
-
-	cad, err := parseCadence(cadenceInput)
-	if err != nil {
-		return "", err
 	}
 
 	// Refuse to clobber an existing definition unless replace=true.
@@ -272,15 +278,15 @@ func (r *Registry) handleThaneCurate(ctx context.Context, args map[string]any) (
 	// repeat it. Caller-supplied tags follow.
 	finalTags := append([]string{focusTag}, tags...)
 
-	jitterRatio := 0.1
+	jitterRatio := envelope.jitter
 	spec := looppkg.Spec{
 		Name:         name,
 		Enabled:      true,
 		Task:         buildCurateTask(intent, documentRef, outputMode, outputSpec.ToolName(), guidance),
 		Operation:    looppkg.OperationService,
-		SleepMin:     cad.sleepMin,
-		SleepMax:     cad.sleepMax,
-		SleepDefault: cad.sleepDefault,
+		SleepMin:     envelope.sleepMin,
+		SleepMax:     envelope.sleepMax,
+		SleepDefault: envelope.sleepDefault,
 		Jitter:       &jitterRatio,
 		Tags:         finalTags,
 		Outputs:      []looppkg.OutputSpec{outputSpec},
@@ -312,7 +318,8 @@ func (r *Registry) handleThaneCurate(ctx context.Context, args map[string]any) (
 		"loop_definition_name": {name},
 		"loop_intent":          {intent},
 		"output_mode":          {outputMode},
-		"cadence":              {cadenceInput},
+		"sleep_min":            {envelope.sleepMin.String()},
+		"sleep_max":            {envelope.sleepMax.String()},
 		"created":              {time.Now().UTC().Format(time.RFC3339)},
 	}
 	docResult, err := deps.DocTools.Write(ctx, documents.WriteArgs{
@@ -379,11 +386,11 @@ func (r *Registry) handleThaneCurate(ctx context.Context, args map[string]any) (
 		"output_tool":          outputSpec.ToolName(),
 		"focus_tag":            focusTag,
 		"entity_subscriptions": len(entities),
-		"cadence": map[string]any{
-			"input":         cadenceInput,
-			"sleep_default": cad.sleepDefault.String(),
-			"sleep_min":     cad.sleepMin.String(),
-			"sleep_max":     cad.sleepMax.String(),
+		"sleep_envelope": map[string]any{
+			"sleep_min":     envelope.sleepMin.String(),
+			"sleep_max":     envelope.sleepMax.String(),
+			"sleep_default": envelope.sleepDefault.String(),
+			"jitter":        envelope.jitter,
 		},
 		"warnings": warnings,
 	})
@@ -585,96 +592,79 @@ func renderScaffoldBody(outputMode, title, intent string) string {
 	return sb.String()
 }
 
-// cadence captures the sleep_min/max/default/jitter triple derived from
-// a human-facing cadence string. The loop spec already has these
-// fields; this helper centralizes the input parsing so the intent
-// tools share one parser.
-type cadence struct {
+// sleepEnvelope captures the sleep_min/max/default/jitter quartet that
+// shapes a service loop's sleep behavior. The fields mirror the
+// corresponding [looppkg.Spec] fields; this struct centralizes the
+// validation/defaulting that turns raw tool input into a known-good
+// envelope.
+type sleepEnvelope struct {
 	sleepMin     time.Duration
 	sleepMax     time.Duration
 	sleepDefault time.Duration
+	jitter       float64
 }
 
-var cadenceUnitPattern = regexp.MustCompile(`(\d+)\s*(minutes?|mins?|m|hours?|hrs?|h|days?|d)\b`)
-
-// parseCadence accepts canonical cadence strings ("hourly", "daily",
-// "5m", "1h") and natural-language equivalents ("every 30 minutes",
-// "every 2 hours"). Returns sleep_min, sleep_max, and a sleep_default
-// derived from a symmetric ~10% jitter window. Floor 1 minute.
-func parseCadence(input string) (cadence, error) {
-	s := strings.ToLower(strings.TrimSpace(input))
-	if s == "" {
-		return cadence{}, fmt.Errorf("cadence is required")
+// parseSleepEnvelope reads sleep_min, sleep_max, sleep_default, and
+// jitter from the tool args and returns a validated envelope. sleep_min
+// and sleep_max are required Go duration strings (>= 1 minute, with
+// sleep_min <= sleep_max). sleep_default defaults to the midpoint of
+// the envelope; jitter defaults to 0.1. Returns a single error per
+// failure, so the caller surfaces the first problem to the model
+// without piling on cascading complaints.
+func parseSleepEnvelope(args map[string]any) (sleepEnvelope, error) {
+	minStr, _ := args["sleep_min"].(string)
+	maxStr, _ := args["sleep_max"].(string)
+	if strings.TrimSpace(minStr) == "" {
+		return sleepEnvelope{}, fmt.Errorf("sleep_min is required (Go duration string, e.g. \"5m\")")
 	}
-
-	switch s {
-	case "hourly":
-		return cadenceFromInterval(time.Hour), nil
-	case "daily":
-		return cadenceFromInterval(24 * time.Hour), nil
+	if strings.TrimSpace(maxStr) == "" {
+		return sleepEnvelope{}, fmt.Errorf("sleep_max is required (Go duration string, e.g. \"30m\")")
 	}
-
-	// Strip leading "every " — "every 30 minutes" reads to "30 minutes".
-	s = strings.TrimPrefix(s, "every ")
-	s = strings.TrimSpace(s)
-
-	// Normalize natural-language units to time.Duration form. "30 minutes"
-	// → "30m", "2 hours" → "2h", "1 day" → "24h".
-	if normalized, ok := normalizeCadenceUnits(s); ok {
-		s = normalized
-	}
-
-	d, err := time.ParseDuration(s)
+	sleepMin, err := time.ParseDuration(strings.TrimSpace(minStr))
 	if err != nil {
-		return cadence{}, fmt.Errorf("unsupported cadence %q: try \"hourly\", \"daily\", \"30m\", or \"1h\"", input)
+		return sleepEnvelope{}, fmt.Errorf("sleep_min %q: %w", minStr, err)
 	}
-	if d < time.Minute {
-		return cadence{}, fmt.Errorf("cadence %q is below the 1 minute floor", input)
+	sleepMax, err := time.ParseDuration(strings.TrimSpace(maxStr))
+	if err != nil {
+		return sleepEnvelope{}, fmt.Errorf("sleep_max %q: %w", maxStr, err)
 	}
-	return cadenceFromInterval(d), nil
-}
-
-func cadenceFromInterval(d time.Duration) cadence {
-	jit := d / 10
-	if jit < 30*time.Second {
-		jit = 30 * time.Second
-	}
-	sleepMin := d - jit
-	// Clamp sleepMin to the same 1-minute floor parseCadence enforces
-	// on the input interval. Without this clamp a 1m cadence with the
-	// 30s minimum jitter would yield sleepMin=30s, breaching the floor.
 	if sleepMin < time.Minute {
-		sleepMin = time.Minute
+		return sleepEnvelope{}, fmt.Errorf("sleep_min %q is below the 1 minute floor", minStr)
 	}
-	return cadence{
-		sleepMin:     sleepMin,
-		sleepMax:     d + jit,
-		sleepDefault: d,
+	if sleepMax < sleepMin {
+		return sleepEnvelope{}, fmt.Errorf("sleep_max %q must be >= sleep_min %q", maxStr, minStr)
 	}
-}
 
-// normalizeCadenceUnits replaces natural-language unit suffixes with
-// time.Duration-compatible single-letter units. Returns (normalized,
-// true) on a successful match anywhere in the input; otherwise
-// (input, false) so the caller can try time.ParseDuration directly.
-func normalizeCadenceUnits(input string) (string, bool) {
-	matched := false
-	out := cadenceUnitPattern.ReplaceAllStringFunc(input, func(match string) string {
-		parts := cadenceUnitPattern.FindStringSubmatch(match)
-		if len(parts) < 3 {
-			return match
+	sleepDefault := (sleepMin + sleepMax) / 2
+	if defStr, ok := args["sleep_default"].(string); ok && strings.TrimSpace(defStr) != "" {
+		sleepDefault, err = time.ParseDuration(strings.TrimSpace(defStr))
+		if err != nil {
+			return sleepEnvelope{}, fmt.Errorf("sleep_default %q: %w", defStr, err)
 		}
-		matched = true
-		n, _ := strconv.Atoi(parts[1])
-		switch parts[2] {
-		case "minute", "minutes", "min", "mins", "m":
-			return fmt.Sprintf("%dm", n)
-		case "hour", "hours", "hr", "hrs", "h":
-			return fmt.Sprintf("%dh", n)
-		case "day", "days", "d":
-			return fmt.Sprintf("%dh", n*24)
+		if sleepDefault < sleepMin || sleepDefault > sleepMax {
+			return sleepEnvelope{}, fmt.Errorf("sleep_default %q must lie in [%s, %s]", defStr, sleepMin, sleepMax)
 		}
-		return match
-	})
-	return strings.ReplaceAll(out, " ", ""), matched
+	}
+
+	jitter := 0.1
+	if v, present := args["jitter"]; present && v != nil {
+		switch j := v.(type) {
+		case float64:
+			jitter = j
+		case int:
+			jitter = float64(j)
+		default:
+			return sleepEnvelope{}, fmt.Errorf("jitter must be a number in [0, 1], got %T", v)
+		}
+		if jitter < 0 || jitter > 1 {
+			return sleepEnvelope{}, fmt.Errorf("jitter %v must be in [0, 1]", jitter)
+		}
+	}
+
+	return sleepEnvelope{
+		sleepMin:     sleepMin,
+		sleepMax:     sleepMax,
+		sleepDefault: sleepDefault,
+		jitter:       jitter,
+	}, nil
 }

--- a/internal/tools/loop_intent_tools.go
+++ b/internal/tools/loop_intent_tools.go
@@ -612,38 +612,35 @@ type sleepEnvelope struct {
 // failure, so the caller surfaces the first problem to the model
 // without piling on cascading complaints.
 func parseSleepEnvelope(args map[string]any) (sleepEnvelope, error) {
-	minStr, _ := args["sleep_min"].(string)
-	maxStr, _ := args["sleep_max"].(string)
-	if strings.TrimSpace(minStr) == "" {
+	sleepMin, presentMin, err := parseDurationArg(args, "sleep_min")
+	if err != nil {
+		return sleepEnvelope{}, err
+	}
+	if !presentMin {
 		return sleepEnvelope{}, fmt.Errorf("sleep_min is required (Go duration string, e.g. \"5m\")")
 	}
-	if strings.TrimSpace(maxStr) == "" {
+	sleepMax, presentMax, err := parseDurationArg(args, "sleep_max")
+	if err != nil {
+		return sleepEnvelope{}, err
+	}
+	if !presentMax {
 		return sleepEnvelope{}, fmt.Errorf("sleep_max is required (Go duration string, e.g. \"30m\")")
 	}
-	sleepMin, err := time.ParseDuration(strings.TrimSpace(minStr))
-	if err != nil {
-		return sleepEnvelope{}, fmt.Errorf("sleep_min %q: %w", minStr, err)
-	}
-	sleepMax, err := time.ParseDuration(strings.TrimSpace(maxStr))
-	if err != nil {
-		return sleepEnvelope{}, fmt.Errorf("sleep_max %q: %w", maxStr, err)
-	}
 	if sleepMin < time.Minute {
-		return sleepEnvelope{}, fmt.Errorf("sleep_min %q is below the 1 minute floor", minStr)
+		return sleepEnvelope{}, fmt.Errorf("sleep_min %s is below the 1 minute floor", sleepMin)
 	}
 	if sleepMax < sleepMin {
-		return sleepEnvelope{}, fmt.Errorf("sleep_max %q must be >= sleep_min %q", maxStr, minStr)
+		return sleepEnvelope{}, fmt.Errorf("sleep_max %s must be >= sleep_min %s", sleepMax, sleepMin)
 	}
 
-	sleepDefault := (sleepMin + sleepMax) / 2
-	if defStr, ok := args["sleep_default"].(string); ok && strings.TrimSpace(defStr) != "" {
-		sleepDefault, err = time.ParseDuration(strings.TrimSpace(defStr))
-		if err != nil {
-			return sleepEnvelope{}, fmt.Errorf("sleep_default %q: %w", defStr, err)
-		}
-		if sleepDefault < sleepMin || sleepDefault > sleepMax {
-			return sleepEnvelope{}, fmt.Errorf("sleep_default %q must lie in [%s, %s]", defStr, sleepMin, sleepMax)
-		}
+	sleepDefault, presentDefault, err := parseDurationArg(args, "sleep_default")
+	if err != nil {
+		return sleepEnvelope{}, err
+	}
+	if !presentDefault {
+		sleepDefault = (sleepMin + sleepMax) / 2
+	} else if sleepDefault < sleepMin || sleepDefault > sleepMax {
+		return sleepEnvelope{}, fmt.Errorf("sleep_default %s must lie in [%s, %s]", sleepDefault, sleepMin, sleepMax)
 	}
 
 	jitter := 0.1
@@ -667,4 +664,33 @@ func parseSleepEnvelope(args map[string]any) (sleepEnvelope, error) {
 		sleepDefault: sleepDefault,
 		jitter:       jitter,
 	}, nil
+}
+
+// parseDurationArg returns the parsed duration from args[key]. present
+// is false when the key is absent, JSON null, or an empty/whitespace
+// string — all "caller didn't set this" shapes. Returns an error when
+// the key is present with a non-string type or a string that does not
+// parse as a Go duration. Distinguishing "wrong type present" from
+// "absent" matters because the JSON schema isn't enforced at handler
+// entry; a caller sending `{"sleep_default": 300}` would otherwise
+// have the value silently ignored and the loop launched with an
+// unexpected default.
+func parseDurationArg(args map[string]any, key string) (d time.Duration, present bool, err error) {
+	v, found := args[key]
+	if !found || v == nil {
+		return 0, false, nil
+	}
+	s, ok := v.(string)
+	if !ok {
+		return 0, true, fmt.Errorf("%s must be a Go duration string (e.g. \"5m\"), got %T", key, v)
+	}
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return 0, false, nil
+	}
+	d, err = time.ParseDuration(s)
+	if err != nil {
+		return 0, true, fmt.Errorf("%s %q: %w", key, s, err)
+	}
+	return d, true, nil
 }

--- a/internal/tools/loop_intent_tools_test.go
+++ b/internal/tools/loop_intent_tools_test.go
@@ -106,6 +106,16 @@ func TestParseSleepEnvelope_Rejections(t *testing.T) {
 		{"max less than min", map[string]any{"sleep_min": "30m", "sleep_max": "5m"}, "must be >= sleep_min"},
 		{"sleep_default outside envelope", map[string]any{"sleep_min": "5m", "sleep_max": "30m", "sleep_default": "1h"}, "must lie in"},
 		{"unparseable sleep_default", map[string]any{"sleep_min": "5m", "sleep_max": "30m", "sleep_default": "bad"}, "sleep_default"},
+		// Non-string types for duration args must surface a typed
+		// error, not be silently dropped. The JSON schema isn't
+		// enforced at handler entry, so a caller sending
+		// {sleep_default: 300} would otherwise have the value
+		// ignored and the loop launched with the midpoint instead
+		// of what they requested.
+		{"sleep_default as number", map[string]any{"sleep_min": "5m", "sleep_max": "30m", "sleep_default": 300}, "sleep_default must be a Go duration string"},
+		{"sleep_default as object", map[string]any{"sleep_min": "5m", "sleep_max": "30m", "sleep_default": map[string]any{"x": 1}}, "sleep_default must be a Go duration string"},
+		{"sleep_min as number", map[string]any{"sleep_min": 300, "sleep_max": "30m"}, "sleep_min must be a Go duration string"},
+		{"sleep_max as bool", map[string]any{"sleep_min": "5m", "sleep_max": true}, "sleep_max must be a Go duration string"},
 		{"jitter out of range high", map[string]any{"sleep_min": "5m", "sleep_max": "30m", "jitter": 1.5}, "must be in [0, 1]"},
 		{"jitter out of range low", map[string]any{"sleep_min": "5m", "sleep_max": "30m", "jitter": -0.1}, "must be in [0, 1]"},
 		{"jitter non-numeric", map[string]any{"sleep_min": "5m", "sleep_max": "30m", "jitter": "fast"}, "must be a number"},

--- a/internal/tools/loop_intent_tools_test.go
+++ b/internal/tools/loop_intent_tools_test.go
@@ -23,76 +23,101 @@ func mkdirAllForTest(dir string) error {
 	return os.MkdirAll(dir, 0o755)
 }
 
-func TestParseCadence_AcceptedForms(t *testing.T) {
+func TestParseSleepEnvelope_HappyPath(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {
-		input               string
-		wantSleepDefault    time.Duration
-		wantSleepMinAtMost  time.Duration
-		wantSleepMaxAtLeast time.Duration
+		name             string
+		args             map[string]any
+		wantSleepMin     time.Duration
+		wantSleepMax     time.Duration
+		wantSleepDefault time.Duration
+		wantJitter       float64
 	}{
-		{"hourly", time.Hour, 55 * time.Minute, 65 * time.Minute},
-		{"daily", 24 * time.Hour, 23*time.Hour - time.Second, 25 * time.Hour},
-		{"every 30 minutes", 30 * time.Minute, 28 * time.Minute, 32 * time.Minute},
-		{"30m", 30 * time.Minute, 28 * time.Minute, 32 * time.Minute},
-		{"1h", time.Hour, 55 * time.Minute, 65 * time.Minute},
-		{"every 2 hours", 2 * time.Hour, time.Hour + 50*time.Minute, 2*time.Hour + 10*time.Minute},
-		{"1 day", 24 * time.Hour, 23*time.Hour - time.Second, 25 * time.Hour},
+		{
+			name:             "minimal asymmetric",
+			args:             map[string]any{"sleep_min": "5m", "sleep_max": "30m"},
+			wantSleepMin:     5 * time.Minute,
+			wantSleepMax:     30 * time.Minute,
+			wantSleepDefault: 17*time.Minute + 30*time.Second, // midpoint
+			wantJitter:       0.1,
+		},
+		{
+			name:             "fixed cadence (min == max)",
+			args:             map[string]any{"sleep_min": "30m", "sleep_max": "30m"},
+			wantSleepMin:     30 * time.Minute,
+			wantSleepMax:     30 * time.Minute,
+			wantSleepDefault: 30 * time.Minute,
+			wantJitter:       0.1,
+		},
+		{
+			name:             "explicit default and jitter",
+			args:             map[string]any{"sleep_min": "5m", "sleep_max": "30m", "sleep_default": "10m", "jitter": 0.0},
+			wantSleepMin:     5 * time.Minute,
+			wantSleepMax:     30 * time.Minute,
+			wantSleepDefault: 10 * time.Minute,
+			wantJitter:       0.0,
+		},
+		{
+			name:             "jitter as int",
+			args:             map[string]any{"sleep_min": "5m", "sleep_max": "30m", "jitter": 0},
+			wantSleepMin:     5 * time.Minute,
+			wantSleepMax:     30 * time.Minute,
+			wantSleepDefault: 17*time.Minute + 30*time.Second,
+			wantJitter:       0,
+		},
 	}
 	for _, tc := range cases {
-		t.Run(tc.input, func(t *testing.T) {
-			c, err := parseCadence(tc.input)
+		t.Run(tc.name, func(t *testing.T) {
+			env, err := parseSleepEnvelope(tc.args)
 			if err != nil {
-				t.Fatalf("parseCadence(%q): %v", tc.input, err)
+				t.Fatalf("parseSleepEnvelope: %v", err)
 			}
-			if c.sleepDefault != tc.wantSleepDefault {
-				t.Errorf("sleepDefault = %v, want %v", c.sleepDefault, tc.wantSleepDefault)
+			if env.sleepMin != tc.wantSleepMin {
+				t.Errorf("sleepMin = %v, want %v", env.sleepMin, tc.wantSleepMin)
 			}
-			if c.sleepMin > tc.wantSleepMinAtMost {
-				t.Errorf("sleepMin = %v, want ≤ %v", c.sleepMin, tc.wantSleepMinAtMost)
+			if env.sleepMax != tc.wantSleepMax {
+				t.Errorf("sleepMax = %v, want %v", env.sleepMax, tc.wantSleepMax)
 			}
-			if c.sleepMax < tc.wantSleepMaxAtLeast {
-				t.Errorf("sleepMax = %v, want ≥ %v", c.sleepMax, tc.wantSleepMaxAtLeast)
+			if env.sleepDefault != tc.wantSleepDefault {
+				t.Errorf("sleepDefault = %v, want %v", env.sleepDefault, tc.wantSleepDefault)
+			}
+			if env.jitter != tc.wantJitter {
+				t.Errorf("jitter = %v, want %v", env.jitter, tc.wantJitter)
 			}
 		})
 	}
 }
 
-func TestParseCadence_RejectsTooFast(t *testing.T) {
+func TestParseSleepEnvelope_Rejections(t *testing.T) {
 	t.Parallel()
-	if _, err := parseCadence("30s"); err == nil {
-		t.Fatal("expected error for sub-minute cadence")
-	}
-}
 
-func TestParseCadence_RejectsGarbage(t *testing.T) {
-	t.Parallel()
-	if _, err := parseCadence("when the cows come home"); err == nil {
-		t.Fatal("expected error for unparseable cadence")
+	cases := []struct {
+		name    string
+		args    map[string]any
+		wantMsg string
+	}{
+		{"missing sleep_min", map[string]any{"sleep_max": "30m"}, "sleep_min is required"},
+		{"missing sleep_max", map[string]any{"sleep_min": "5m"}, "sleep_max is required"},
+		{"empty sleep_min", map[string]any{"sleep_min": "  ", "sleep_max": "30m"}, "sleep_min is required"},
+		{"unparseable sleep_min", map[string]any{"sleep_min": "when the cows come home", "sleep_max": "30m"}, "sleep_min"},
+		{"unparseable sleep_max", map[string]any{"sleep_min": "5m", "sleep_max": "garbage"}, "sleep_max"},
+		{"below 1m floor", map[string]any{"sleep_min": "30s", "sleep_max": "30m"}, "below the 1 minute floor"},
+		{"max less than min", map[string]any{"sleep_min": "30m", "sleep_max": "5m"}, "must be >= sleep_min"},
+		{"sleep_default outside envelope", map[string]any{"sleep_min": "5m", "sleep_max": "30m", "sleep_default": "1h"}, "must lie in"},
+		{"unparseable sleep_default", map[string]any{"sleep_min": "5m", "sleep_max": "30m", "sleep_default": "bad"}, "sleep_default"},
+		{"jitter out of range high", map[string]any{"sleep_min": "5m", "sleep_max": "30m", "jitter": 1.5}, "must be in [0, 1]"},
+		{"jitter out of range low", map[string]any{"sleep_min": "5m", "sleep_max": "30m", "jitter": -0.1}, "must be in [0, 1]"},
+		{"jitter non-numeric", map[string]any{"sleep_min": "5m", "sleep_max": "30m", "jitter": "fast"}, "must be a number"},
 	}
-}
-
-func TestParseCadence_RejectsEmpty(t *testing.T) {
-	t.Parallel()
-	if _, err := parseCadence("   "); err == nil {
-		t.Fatal("expected error for empty cadence")
-	}
-}
-
-// TestParseCadence_SleepMinNeverDropsBelowMinute guards the floor
-// against a regression where the 30s minimum jitter could push
-// sleep_min below the documented 1-minute floor for short cadences.
-func TestParseCadence_SleepMinNeverDropsBelowMinute(t *testing.T) {
-	t.Parallel()
-	for _, input := range []string{"1m", "60s", "every 1 minute"} {
-		t.Run(input, func(t *testing.T) {
-			c, err := parseCadence(input)
-			if err != nil {
-				t.Fatalf("parseCadence(%q): %v", input, err)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := parseSleepEnvelope(tc.args)
+			if err == nil {
+				t.Fatalf("expected error for %s, got nil", tc.name)
 			}
-			if c.sleepMin < time.Minute {
-				t.Errorf("sleepMin = %v, want >= 1m (floor)", c.sleepMin)
+			if !strings.Contains(err.Error(), tc.wantMsg) {
+				t.Errorf("error = %q, want substring %q", err.Error(), tc.wantMsg)
 			}
 		})
 	}
@@ -155,9 +180,10 @@ func TestThaneCurate_EndToEnd(t *testing.T) {
 	}
 
 	result, err := tool.Handler(context.Background(), map[string]any{
-		"name":    "test_pr_watchlist",
-		"intent":  "Track v1.0 PR activity for the upcoming release.",
-		"cadence": "hourly",
+		"name":      "test_pr_watchlist",
+		"intent":    "Track v1.0 PR activity for the upcoming release.",
+		"sleep_min": "54m",
+		"sleep_max": "66m",
 		"output": map[string]any{
 			"mode":     "maintain",
 			"document": "kb:dashboards/pr-watchlist.md",
@@ -354,9 +380,10 @@ func TestThaneCurate_RefusesToClobber(t *testing.T) {
 
 	tool := reg.Get("thane_curate")
 	_, err = tool.Handler(context.Background(), map[string]any{
-		"name":    "existing_loop",
-		"intent":  "Replace the prior loop without permission.",
-		"cadence": "hourly",
+		"name":      "existing_loop",
+		"intent":    "Replace the prior loop without permission.",
+		"sleep_min": "54m",
+		"sleep_max": "66m",
 		"output": map[string]any{
 			"mode":     "journal",
 			"document": "kb:journal/existing.md",
@@ -424,9 +451,10 @@ func TestThaneCurate_RefusesToClobberDocument(t *testing.T) {
 
 	tool := reg.Get("thane_curate")
 	_, err = tool.Handler(context.Background(), map[string]any{
-		"name":    "fresh_loop",
-		"intent":  "Track something the doc already covers.",
-		"cadence": "hourly",
+		"name":      "fresh_loop",
+		"intent":    "Track something the doc already covers.",
+		"sleep_min": "54m",
+		"sleep_max": "66m",
 		"output": map[string]any{
 			"mode":     "maintain",
 			"document": "kb:notes/existing.md",
@@ -490,9 +518,10 @@ func TestThaneCurate_JournalDeclaresAppendOutput(t *testing.T) {
 
 	tool := reg.Get("thane_curate")
 	if _, err := tool.Handler(context.Background(), map[string]any{
-		"name":    "release_journal",
-		"intent":  "Capture forge releases as a dated log.",
-		"cadence": "hourly",
+		"name":      "release_journal",
+		"intent":    "Capture forge releases as a dated log.",
+		"sleep_min": "54m",
+		"sleep_max": "66m",
 		"output": map[string]any{
 			"mode":     "journal",
 			"document": "kb:journal/releases.md",
@@ -675,9 +704,10 @@ func TestThaneCurate_PersistsEntitySubscriptions(t *testing.T) {
 	rig := newCurateTestRig(t)
 
 	result, err := rig.tool.Handler(context.Background(), map[string]any{
-		"name":    "thermostat_journal",
-		"intent":  "Daily HVAC summary.",
-		"cadence": "daily",
+		"name":      "thermostat_journal",
+		"intent":    "Daily HVAC summary.",
+		"sleep_min": "21h",
+		"sleep_max": "27h",
 		"output": map[string]any{
 			"mode":     "journal",
 			"document": "kb:home/hvac.md",
@@ -759,9 +789,10 @@ func TestThaneCurate_ReplacePreservesFocusTag(t *testing.T) {
 
 	create := func(extra map[string]any) string {
 		args := map[string]any{
-			"name":    "hvac_curate",
-			"intent":  "HVAC summary.",
-			"cadence": "daily",
+			"name":      "hvac_curate",
+			"intent":    "HVAC summary.",
+			"sleep_min": "21h",
+			"sleep_max": "27h",
 			"output": map[string]any{
 				"mode":     "journal",
 				"document": "kb:home/hvac.md",
@@ -832,9 +863,10 @@ func TestLoopDefinitionDelete_WipesEntitySubscriptions(t *testing.T) {
 	})
 
 	if _, err := rig.tool.Handler(context.Background(), map[string]any{
-		"name":    "curate_to_delete",
-		"intent":  "Short-lived watcher.",
-		"cadence": "hourly",
+		"name":      "curate_to_delete",
+		"intent":    "Short-lived watcher.",
+		"sleep_min": "54m",
+		"sleep_max": "66m",
 		"output": map[string]any{
 			"mode":     "journal",
 			"document": "kb:scratch/short.md",
@@ -875,9 +907,10 @@ func TestThaneCurate_RejectsDuplicateEntityID(t *testing.T) {
 	rig := newCurateTestRig(t)
 
 	_, err := rig.tool.Handler(context.Background(), map[string]any{
-		"name":    "dup_test",
-		"intent":  "x",
-		"cadence": "hourly",
+		"name":      "dup_test",
+		"intent":    "x",
+		"sleep_min": "54m",
+		"sleep_max": "66m",
 		"output": map[string]any{
 			"mode":     "journal",
 			"document": "kb:dup.md",
@@ -906,9 +939,10 @@ func TestThaneCurate_RejectsFractionalInteger(t *testing.T) {
 	rig := newCurateTestRig(t)
 
 	_, err := rig.tool.Handler(context.Background(), map[string]any{
-		"name":    "frac_test",
-		"intent":  "x",
-		"cadence": "hourly",
+		"name":      "frac_test",
+		"intent":    "x",
+		"sleep_min": "54m",
+		"sleep_max": "66m",
 		"output": map[string]any{
 			"mode":     "journal",
 			"document": "kb:frac.md",
@@ -930,9 +964,10 @@ func TestThaneCurate_RejectsFractionalInteger(t *testing.T) {
 	// Whole-number float (post-JSON-decode shape of an integer literal)
 	// must still pass — coerceInt accepts float64 when n == int64(n).
 	_, err = rig.tool.Handler(context.Background(), map[string]any{
-		"name":    "whole_float_test",
-		"intent":  "x",
-		"cadence": "hourly",
+		"name":      "whole_float_test",
+		"intent":    "x",
+		"sleep_min": "54m",
+		"sleep_max": "66m",
 		"output": map[string]any{
 			"mode":     "journal",
 			"document": "kb:whole.md",

--- a/internal/tools/loop_subscription_tools_test.go
+++ b/internal/tools/loop_subscription_tools_test.go
@@ -20,9 +20,10 @@ func TestLoopUpdateEntitySubscriptions_AddRemove(t *testing.T) {
 
 	// Seed a curate loop with one entity so we have something to remove.
 	if _, err := rig.tool.Handler(context.Background(), map[string]any{
-		"name":    "watcher",
-		"intent":  "watch things",
-		"cadence": "hourly",
+		"name":      "watcher",
+		"intent":    "watch things",
+		"sleep_min": "54m",
+		"sleep_max": "66m",
 		"output": map[string]any{
 			"mode":     "journal",
 			"document": "kb:watch/log.md",
@@ -169,9 +170,10 @@ func TestLoopUpdateEntitySubscriptions_RequiresAddOrRemove(t *testing.T) {
 	rig := newCurateTestRig(t)
 
 	if _, err := rig.tool.Handler(context.Background(), map[string]any{
-		"name":    "loop_one",
-		"intent":  "x",
-		"cadence": "hourly",
+		"name":      "loop_one",
+		"intent":    "x",
+		"sleep_min": "54m",
+		"sleep_max": "66m",
 		"output": map[string]any{
 			"mode":     "journal",
 			"document": "kb:none.md",
@@ -203,9 +205,10 @@ func TestLoopUpdateEntitySubscriptions_AddErrorsScopedCorrectly(t *testing.T) {
 	rig := newCurateTestRig(t)
 
 	if _, err := rig.tool.Handler(context.Background(), map[string]any{
-		"name":    "scope_test",
-		"intent":  "x",
-		"cadence": "hourly",
+		"name":      "scope_test",
+		"intent":    "x",
+		"sleep_min": "54m",
+		"sleep_max": "66m",
 		"output": map[string]any{
 			"mode":     "journal",
 			"document": "kb:scope.md",

--- a/talents/loops-doctrine.md
+++ b/talents/loops-doctrine.md
@@ -17,12 +17,12 @@ Choose loop tools by lifecycle:
 - loop definition tools for durable services you need to inspect, edit,
   pause, reactivate, or relaunch.
 
-For recurring document work, prefer `thane_curate`. Its `cadence`
-schedules the service, its `output` declares the state owner, and the
-running loop writes through generated output tools such as
-`replace_output_*` or `append_output_*`. If a maintained output is
-marked `truncated` in Declared Durable Outputs, read the full document
-before replacing it.
+For recurring document work, prefer `thane_curate`. Its `sleep_min`
+and `sleep_max` set the envelope the running loop self-paces inside,
+its `output` declares the state owner, and the running loop writes
+through generated output tools such as `replace_output_*` or
+`append_output_*`. If a maintained output is marked `truncated` in
+Declared Durable Outputs, read the full document before replacing it.
 
 Choose stream wiring by attention cost:
 
@@ -49,10 +49,12 @@ concerns that genuinely warrant the extra capacity, not as a routine
 notification channel.
 
 Natural-language timing inside a task does not schedule a service loop.
-Use `thane_curate.cadence` or explicit service-loop sleep fields. Lint
-hand-authored durable definitions before saving them, especially when
-cadence, jitter, or direct domain-tool access matters. Tagged service
-loops often want `profile.delegation_gating: "disabled"`.
+Pick a sleep envelope (sleep_min, sleep_max) tight enough to catch what
+matters and loose enough to cost nothing when quiet; the running loop
+uses `set_next_sleep` to self-pace inside it. Lint hand-authored
+durable definitions before saving them, especially when the envelope,
+jitter, or direct domain-tool access matters. Tagged service loops
+often want `profile.delegation_gating: "disabled"`.
 
 When you need concrete JSON launch patterns, activate `loops_examples`
 and adapt the closest recipe minimally.

--- a/talents/loops-examples.md
+++ b/talents/loops-examples.md
@@ -47,7 +47,7 @@ awareness:
 
 1. **Core launches the watcher** with `thane_curate`. Hand it an
    intent, a watch set, a document to own, and an adaptive sleep
-   envelope (see the cadence section below).
+   envelope (see the envelope section below).
 2. **Watcher runs at its own pace.** It writes findings to the
    document each cycle and tunes its own next wake with
    `set_next_sleep` (clamped to the envelope it was given).
@@ -69,7 +69,8 @@ human.
 {
   "name": "server-closet-guardian",
   "intent": "Watch the server-closet environment and equipment health. Document trends. Surface UPS dropouts, dehumidifier failure, or temperature excursions that need attention.",
-  "cadence": "30m",
+  "sleep_min": "10m",
+  "sleep_max": "30m",
   "entities": [
     {"entity_id": "sensor.server_closet_temperature"},
     {"entity_id": "sensor.server_closet_humidity"},
@@ -86,10 +87,11 @@ human.
 }
 ```
 
-`cadence` sets the default; the runtime derives a sleep envelope
-around it with light jitter. The watcher writes through the generated
-`replace_output_*` tool (for `mode: "maintain"`) or `append_output_*`
-(for `mode: "journal"`).
+`sleep_min` and `sleep_max` define the envelope the loop self-paces
+inside; `sleep_default` defaults to the midpoint and `jitter` defaults
+to 0.1 (pass them explicitly when you want to override). The watcher
+writes through the generated `replace_output_*` tool (for `mode:
+"maintain"`) or `append_output_*` (for `mode: "journal"`).
 
 ### Step 2: Let the watcher self-pace
 
@@ -146,7 +148,7 @@ producer tools like `forge_repo_follow` and `media_follow` take a
 `wake_loop` target so the curate loop wakes on the event rather than
 its timer.
 
-## Adaptive cadence: pick the envelope, not the tick
+## Adaptive sleep envelope: pick the bounds, not the tick
 
 The only real judgment at creation is the sleep envelope. The loop
 self-pacing inside that envelope handles the rest.


### PR DESCRIPTION
## Summary

`thane_curate.cadence` hid the only decision worth making at creation time. It accepted natural-language strings like `"hourly"` and auto-synthesized a symmetric ±10% sleep envelope — invisible to the caller at call time, and useless for any asymmetric pacing (which is most interesting cases: UPS guardian `[5m, 30m]`, burn-ban monitor `[1h, 6h]`, daily digest `[12h, 36h]`).

Drop it. Take `sleep_min` and `sleep_max` as required Go duration strings. `sleep_default` defaults to the midpoint; `jitter` defaults to `0.1`. The doctrine's framing — "pick the envelope, not the tick" — is now what the schema actually rewards.

This is the first PR in a five-item loops-vocabulary cleanup queue.

## Surface changes

- **`thane_curate` schema**: removed `cadence`; added `sleep_min`, `sleep_max` (required), `sleep_default`, `jitter` (optional).
- **`thane_curate` response**: `cadence` block replaced with a `sleep_envelope` object that echoes the resolved sleep_min/max/default/jitter.
- **Output document frontmatter**: `cadence: <input>` replaced with `sleep_min` and `sleep_max` entries.
- **`loop_definition_lint` description**: "omitted cadence fields" → "omitted sleep envelope fields".
- **Warning code renames** in `[looppkg.BuildDefinitionWarnings]`:
  - `service_default_cadence` → `service_default_sleep_envelope`
  - `service_partial_cadence_defaults` → `service_partial_sleep_defaults`
  - `task_mentions_cadence_without_explicit_sleep` → `task_mentions_timing_without_explicit_sleep`
  - `fixed_cadence_with_jitter` → `fixed_interval_with_jitter`
- **Internal helpers**: `parseCadence` / `cadenceFromInterval` / `normalizeCadenceUnits` / `cadenceUnitPattern` (~50 LOC) collapsed to one `parseSleepEnvelope` (~60 LOC, but more thorough validation — per-field unparseable errors, max-less-than-min, sleep_default-out-of-envelope, jitter range).
- **Doctrine**: rewrites the "use `thane_curate.cadence`" guidance around envelope thinking.
- **Examples**: Step 1 JSON uses `sleep_min`/`sleep_max`; the "Adaptive cadence" section becomes "Adaptive sleep envelope: pick the bounds, not the tick."

## Why no migration headache

Existing persisted loops keep their stored `sleep_min`/`sleep_max` and run unchanged. The change is to the tool input shape only. Old client calls using `cadence` get a clear `"sleep_min is required"` error pointing at the new contract.

## Test plan

- [x] `just ci` passes locally
- [x] `TestParseSleepEnvelope_HappyPath` covers asymmetric, fixed (min == max), explicit overrides, int-typed jitter
- [x] `TestParseSleepEnvelope_Rejections` covers 12 failure modes (missing, unparseable, floor, range, jitter type)
- [x] All `TestThaneCurate_*` and `TestLoopUpdateEntitySubscriptions_*` call sites updated to `sleep_min`/`sleep_max`
- [x] Warning-code tests reflect the new identifiers
- [x] Doctrine and examples reflect the new vocabulary