### PR TITLE
refactor: unify guidance and instructions onto Profile.Instructions

### DIFF
--- a/internal/tools/loop_intent_tools.go
+++ b/internal/tools/loop_intent_tools.go
@@ -89,7 +89,7 @@ func (r *Registry) registerThaneCurate() {
 			"Tags scope the loop's tools; omit to inherit the always-active set. " +
 			"Entities is a list of Home Assistant entity subscriptions the loop should see every iteration; they are persisted under a per-loop focus tag and surfaced into the loop's prompt automatically. " +
 			"Returns the document ref, loop definition name, loop_id, output mode, the generated output tool name (output_tool) the receiving loop writes through, the loop's internal focus_tag, and the resolved sleep envelope.",
-		ContentResolveExempt: []string{"name", "intent", "sleep_min", "sleep_max", "sleep_default", "jitter", "tags", "guidance", "output", "entities", "replace"},
+		ContentResolveExempt: []string{"name", "intent", "sleep_min", "sleep_max", "sleep_default", "jitter", "tags", "instructions", "output", "entities", "replace"},
 		Parameters: map[string]any{
 			"type": "object",
 			"properties": map[string]any{
@@ -170,9 +170,9 @@ func (r *Registry) registerThaneCurate() {
 						"required": []string{"entity_id"},
 					},
 				},
-				"guidance": map[string]any{
+				"instructions": map[string]any{
 					"type":        "string",
-					"description": "Optional extra steering injected into each iteration's task prompt (output format hints, what to focus on, what to skip).",
+					"description": "Optional steering text prepended to every iteration's task (output format guidance, what to focus on, what to skip). Persists on the spec's Profile and shows up in loop_definition_get.",
 				},
 				"replace": map[string]any{
 					"type":        "boolean",
@@ -230,7 +230,7 @@ func (r *Registry) handleThaneCurate(ctx context.Context, args map[string]any) (
 			}
 		}
 	}
-	guidance, _ := args["guidance"].(string)
+	instructions, _ := args["instructions"].(string)
 	replace, _ := args["replace"].(bool)
 
 	entities, err := parseEntityList("entities", args["entities"])
@@ -282,7 +282,7 @@ func (r *Registry) handleThaneCurate(ctx context.Context, args map[string]any) (
 	spec := looppkg.Spec{
 		Name:         name,
 		Enabled:      true,
-		Task:         buildCurateTask(intent, documentRef, outputMode, outputSpec.ToolName(), guidance),
+		Task:         buildCurateTask(intent, documentRef, outputMode, outputSpec.ToolName()),
 		Operation:    looppkg.OperationService,
 		SleepMin:     envelope.sleepMin,
 		SleepMax:     envelope.sleepMax,
@@ -295,6 +295,7 @@ func (r *Registry) handleThaneCurate(ctx context.Context, args map[string]any) (
 		},
 		Profile: router.LoopProfile{
 			DelegationGating: "disabled",
+			Instructions:     strings.TrimSpace(instructions),
 		},
 	}
 	if err := spec.ValidatePersistable(); err != nil {
@@ -528,10 +529,13 @@ func buildCurateOutputSpec(name, docRef, outputMode, intent string) looppkg.Outp
 
 // buildCurateTask renders the per-iteration task prompt for a
 // thane_curate-created loop. The model running each iteration sees the
-// intent, the document target, the output mode, the scoped output tool
-// name, plus any caller guidance. Kept short and shape-clear so the
-// model can act without re-reading the loop's own definition.
-func buildCurateTask(intent, docRef, outputMode, outputToolName, guidance string) string {
+// intent, the document target, the output mode, and the scoped output
+// tool name. Caller-supplied steering text lives on
+// [router.LoopProfile.Instructions] and is prepended at iteration time
+// by [loop.Loop.prepareAgentTurnRequest], so it doesn't appear here.
+// Kept short and shape-clear so the model can act without re-reading
+// the loop's own definition.
+func buildCurateTask(intent, docRef, outputMode, outputToolName string) string {
 	var verb string
 	switch outputMode {
 	case "journal":
@@ -564,10 +568,6 @@ func buildCurateTask(intent, docRef, outputMode, outputToolName, guidance string
 		sb.WriteString("The current document body is shown in the Declared Durable Outputs context block above. If that entry is marked `truncated: true`, read the full document with doc_read before replacing — the output tool overwrites the entire body.")
 	default:
 		sb.WriteString("The document's current contents are surfaced in the Declared Durable Outputs context block above.")
-	}
-	if strings.TrimSpace(guidance) != "" {
-		sb.WriteString("\n\nGuidance: ")
-		sb.WriteString(guidance)
 	}
 	return sb.String()
 }

--- a/internal/tools/loop_intent_tools.go
+++ b/internal/tools/loop_intent_tools.go
@@ -531,10 +531,10 @@ func buildCurateOutputSpec(name, docRef, outputMode, intent string) looppkg.Outp
 // thane_curate-created loop. The model running each iteration sees the
 // intent, the document target, the output mode, and the scoped output
 // tool name. Caller-supplied steering text lives on
-// [router.LoopProfile.Instructions] and is prepended at iteration time
-// by [loop.Loop.prepareAgentTurnRequest], so it doesn't appear here.
-// Kept short and shape-clear so the model can act without re-reading
-// the loop's own definition.
+// [router.LoopProfile.Instructions] and is prepended during task-turn
+// construction (see [loop.Loop.buildTaskTurn]), so it doesn't appear
+// here. Kept short and shape-clear so the model can act without
+// re-reading the loop's own definition.
 func buildCurateTask(intent, docRef, outputMode, outputToolName string) string {
 	var verb string
 	switch outputMode {

--- a/internal/tools/loop_intent_tools_test.go
+++ b/internal/tools/loop_intent_tools_test.go
@@ -570,6 +570,155 @@ func TestThaneCurate_JournalDeclaresAppendOutput(t *testing.T) {
 	}
 }
 
+// TestThaneCurate_InstructionsFlowToProfile verifies that the
+// `instructions` tool arg lands on Spec.Profile.Instructions (the
+// canonical iteration-prepend surface) and NOT on the Spec.Task via
+// the older "Guidance: ..." fold. Two failure modes to guard against:
+// (1) the arg silently dropped, (2) the arg still being concatenated
+// into Task — both would mean a caller's steering text shows up in
+// the wrong place or twice if anything restores the old code path.
+func TestThaneCurate_InstructionsFlowToProfile(t *testing.T) {
+	t.Parallel()
+
+	tempDir := t.TempDir()
+	kbDir := filepath.Join(tempDir, "kb")
+	if err := mkdirAllForTest(kbDir); err != nil {
+		t.Fatalf("mkdir kb: %v", err)
+	}
+	db, err := database.OpenMemory()
+	if err != nil {
+		t.Fatalf("open memory db: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	docStore, err := documents.NewStore(db, map[string]string{"kb": kbDir}, nil)
+	if err != nil {
+		t.Fatalf("documents.NewStore: %v", err)
+	}
+	docTools := documents.NewTools(docStore)
+
+	defRegistry, err := looppkg.NewDefinitionRegistry(nil)
+	if err != nil {
+		t.Fatalf("NewDefinitionRegistry: %v", err)
+	}
+	reg := NewEmptyRegistry()
+	reg.ConfigureLoopIntentTools(LoopIntentToolDeps{
+		DocTools:    docTools,
+		Registry:    defRegistry,
+		PersistSpec: func(_ looppkg.Spec, _ time.Time) error { return nil },
+		Reconcile:   func(_ context.Context, _ string) error { return nil },
+		LaunchDefinition: func(_ context.Context, _ string, _ looppkg.Launch) (looppkg.LaunchResult, error) {
+			return looppkg.LaunchResult{LoopID: "loop-inst-1"}, nil
+		},
+	})
+
+	const steering = "Focus on UPS load trends; ignore brief transients under 5 seconds."
+	tool := reg.Get("thane_curate")
+	if _, err := tool.Handler(context.Background(), map[string]any{
+		"name":         "instructions_test",
+		"intent":       "Watch the rack.",
+		"sleep_min":    "5m",
+		"sleep_max":    "30m",
+		"instructions": "  " + steering + "  ", // whitespace trimmed
+		"output": map[string]any{
+			"mode":     "maintain",
+			"document": "kb:dashboards/rack.md",
+		},
+	}); err != nil {
+		t.Fatalf("thane_curate handler: %v", err)
+	}
+
+	snap := defRegistry.Snapshot()
+	var found *looppkg.DefinitionSnapshot
+	for i := range snap.Definitions {
+		if snap.Definitions[i].Spec.Name == "instructions_test" {
+			found = &snap.Definitions[i]
+			break
+		}
+	}
+	if found == nil {
+		t.Fatal("definition not registered")
+	}
+	if found.Spec.Profile.Instructions != steering {
+		t.Errorf("Profile.Instructions = %q, want %q (whitespace trimmed)", found.Spec.Profile.Instructions, steering)
+	}
+	if strings.Contains(found.Spec.Task, "Guidance:") {
+		t.Errorf("Spec.Task should not carry legacy \"Guidance:\" fold, got: %s", found.Spec.Task)
+	}
+	if strings.Contains(found.Spec.Task, steering) {
+		t.Errorf("Spec.Task should not carry the steering text directly; it belongs on Profile.Instructions. Task: %s", found.Spec.Task)
+	}
+}
+
+// TestThaneCurate_InstructionsOmitted verifies that omitting
+// `instructions` results in an empty Profile.Instructions (not nil-vs-
+// empty-string weirdness, not a default value), and the Task text
+// stays minimal.
+func TestThaneCurate_InstructionsOmitted(t *testing.T) {
+	t.Parallel()
+
+	tempDir := t.TempDir()
+	kbDir := filepath.Join(tempDir, "kb")
+	if err := mkdirAllForTest(kbDir); err != nil {
+		t.Fatalf("mkdir kb: %v", err)
+	}
+	db, err := database.OpenMemory()
+	if err != nil {
+		t.Fatalf("open memory db: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	docStore, err := documents.NewStore(db, map[string]string{"kb": kbDir}, nil)
+	if err != nil {
+		t.Fatalf("documents.NewStore: %v", err)
+	}
+	docTools := documents.NewTools(docStore)
+
+	defRegistry, err := looppkg.NewDefinitionRegistry(nil)
+	if err != nil {
+		t.Fatalf("NewDefinitionRegistry: %v", err)
+	}
+	reg := NewEmptyRegistry()
+	reg.ConfigureLoopIntentTools(LoopIntentToolDeps{
+		DocTools:    docTools,
+		Registry:    defRegistry,
+		PersistSpec: func(_ looppkg.Spec, _ time.Time) error { return nil },
+		Reconcile:   func(_ context.Context, _ string) error { return nil },
+		LaunchDefinition: func(_ context.Context, _ string, _ looppkg.Launch) (looppkg.LaunchResult, error) {
+			return looppkg.LaunchResult{LoopID: "loop-inst-2"}, nil
+		},
+	})
+
+	tool := reg.Get("thane_curate")
+	if _, err := tool.Handler(context.Background(), map[string]any{
+		"name":      "no_instructions",
+		"intent":    "Watch.",
+		"sleep_min": "5m",
+		"sleep_max": "30m",
+		"output": map[string]any{
+			"mode":     "maintain",
+			"document": "kb:dashboards/no-inst.md",
+		},
+	}); err != nil {
+		t.Fatalf("thane_curate handler: %v", err)
+	}
+
+	snap := defRegistry.Snapshot()
+	var found *looppkg.DefinitionSnapshot
+	for i := range snap.Definitions {
+		if snap.Definitions[i].Spec.Name == "no_instructions" {
+			found = &snap.Definitions[i]
+			break
+		}
+	}
+	if found == nil {
+		t.Fatal("definition not registered")
+	}
+	if found.Spec.Profile.Instructions != "" {
+		t.Errorf("Profile.Instructions = %q, want empty when omitted", found.Spec.Profile.Instructions)
+	}
+}
+
 // fakeSubscriptionStore captures the interface-method calls so tests
 // can assert on the per-loop watchlist plumbing without standing up
 // a real SQLite database.

--- a/internal/tools/loop_intent_tools_test.go
+++ b/internal/tools/loop_intent_tools_test.go
@@ -614,6 +614,9 @@ func TestThaneCurate_InstructionsFlowToProfile(t *testing.T) {
 
 	const steering = "Focus on UPS load trends; ignore brief transients under 5 seconds."
 	tool := reg.Get("thane_curate")
+	if tool == nil {
+		t.Fatal("thane_curate tool not registered after ConfigureLoopIntentTools")
+	}
 	if _, err := tool.Handler(context.Background(), map[string]any{
 		"name":         "instructions_test",
 		"intent":       "Watch the rack.",


### PR DESCRIPTION
## Summary

Two competing surfaces for caller-supplied steering text on `thane_curate`:

| | guidance (old) | instructions (Profile field) |
|---|---|---|
| Set by | `thane_curate.guidance` arg | `Profile.Instructions` Go field |
| Stored on | folded into `Spec.Task` by `buildCurateTask()` | lives on `Profile`, prepended each iteration |
| Renders as | `...task...\n\nGuidance: <text>` | `Instructions: <text>\n\n...task...` |
| Visible in `loop_definition_get` | inside Task string | under `spec.profile.instructions` |

From the model's perspective both produced extra steering at roughly the same place. The difference was implementation history, not user-meaningful semantics.

Collapse to one:

- Rename tool arg `guidance` → `instructions`. The name matches the persistent destination field.
- Route into `Spec.Profile.Instructions` instead of folding into `Spec.Task`.
- Drop `buildCurateTask`'s guidance arg and the trailing `\n\nGuidance: ...` concatenation. Function signature shrinks from 5 args to 4.

The iteration prompt still receives the steering text — but now via the canonical pre-task `Instructions:` slot, which is where `loop_definition_set` callers and internal Go callers (e.g. delegate's `DelegateRunInstructions`) already put theirs. One slot, one rendering path, one name.

## Net code change

- Production: **−13 LOC** (handler simplified, buildCurateTask shrinks, no guidance-fold path)
- Tests: **+149 LOC** (two new tests lock the new behavior)

## Tests

- `TestThaneCurate_InstructionsFlowToProfile` — sets `instructions` (with whitespace), verifies it lands trimmed on `Profile.Instructions`, and verifies `Spec.Task` no longer contains either "Guidance:" or the steering text directly. Guards against regression to the old fold path.
- `TestThaneCurate_InstructionsOmitted` — omitting the arg yields an empty `Profile.Instructions`. No surprise default.

## Stacking

Stacked on top of PR #882 (cadence drop). Once #882 merges to main, this PR's base auto-shifts to main and the rebase is clean.

Second in the loops-cleanup queue. Next up: focus_tag → scope_tag.

## Test plan

- [x] `just ci` passes locally
- [x] New tests cover the flow-through path and the omitted path
- [x] No other thane_curate test exercises the old `guidance` arg, so no migration of existing test data needed