### PR TITLE
feat: multi-node talent files with declared names

### DIFF
--- a/internal/model/talents/loader.go
+++ b/internal/model/talents/loader.go
@@ -358,33 +358,36 @@ func parseOneBlock(raw string) (Block, string, bool) {
 // node-boundary marker and the remaining input (starting at "---") for
 // the next iteration. When no boundary is found, returns the entire
 // body and an empty remainder.
+//
+// A boundary is a "---" line whose immediately-following line is a
+// recognized frontmatter key ("name:", "tags:", etc.). The "very next
+// line" rule is strict — a blank line between "---" and a later
+// "key:" paragraph means the "---" is a markdown horizontal rule,
+// not a node boundary. The scan also correctly identifies a boundary
+// at the start of body (empty body between consecutive nodes).
 func splitAtNextNodeBoundary(body string) (content, remainder string) {
-	search := body
+	lines := strings.SplitAfter(body, "\n")
 	offset := 0
-	for {
-		idx := strings.Index(search, "\n---")
-		if idx < 0 {
-			return body, ""
+	for i, line := range lines {
+		stripped := strings.TrimRight(line, "\r\n")
+		if stripped != "---" {
+			offset += len(line)
+			continue
 		}
-		// Look at what's on the line after "---" — if it parses as a
-		// frontmatter key, this is a node boundary; otherwise it's a
-		// markdown HR and we keep scanning.
-		afterDashes := search[idx+4:]
-		afterDashes = strings.TrimLeft(afterDashes, " \t")
-		// Skip the rest of the "---" line and look at the next line.
-		if nl := strings.IndexByte(afterDashes, '\n'); nl >= 0 {
-			nextLine := strings.TrimSpace(afterDashes[nl+1:])
-			if firstKey, _, _ := strings.Cut(nextLine, ":"); isFrontmatterKey(strings.TrimSpace(firstKey)) {
-				absolute := offset + idx
-				// Drop the leading newline before "---" from content so
-				// trailing whitespace on the prior block stays clean.
-				return strings.TrimRight(body[:absolute], "\r\n"), body[absolute+1:]
-			}
+		if i+1 >= len(lines) {
+			// Trailing "---" with no following line — not a boundary.
+			offset += len(line)
+			continue
 		}
-		// Not a node boundary — keep scanning past this "---".
-		offset += idx + 4
-		search = search[idx+4:]
+		nextLine := strings.TrimRight(lines[i+1], "\r\n")
+		firstKey, _, found := strings.Cut(nextLine, ":")
+		if !found || !isFrontmatterKey(strings.TrimSpace(firstKey)) {
+			offset += len(line)
+			continue
+		}
+		return strings.TrimRight(body[:offset], "\r\n"), body[offset:]
 	}
+	return body, ""
 }
 
 // isFrontmatterKey reports whether key is one of the recognized

--- a/internal/model/talents/loader.go
+++ b/internal/model/talents/loader.go
@@ -47,12 +47,28 @@ type Talent struct {
 // requires the OR check to pass AND the AND check to pass — useful
 // for articles that should fire for several entry-point tags but only
 // when paired with a runtime-asserted gate (e.g., owner + signal).
+//
+// Name is the explicit per-talent identifier. Required for every node
+// in a multi-node talent file (where there's no filename to fall back
+// to). Optional for single-node files — when omitted, the loader uses
+// the filename (without .md) so existing talents keep working without
+// migration.
 type Frontmatter struct {
+	Name     string
 	Tags     []string
 	TagsAll  []string
 	Kind     string
 	Teaser   string
 	NextTags []string
+}
+
+// Block represents a single parsed frontmatter + content pair from a
+// talent file. A single-node file produces one Block; a multi-node file
+// produces N. Block is the low-level shape under [Talent]; consumers
+// usually want [Loader.Talents] or [ParseFrontmatterMetadata] instead.
+type Block struct {
+	Frontmatter Frontmatter
+	Content     string
 }
 
 // listFiles returns a sorted slice of .md filenames in l.dir.
@@ -90,6 +106,12 @@ func (l *Loader) Talents() ([]Talent, error) {
 // passing each file through verifier. Verification runs immediately
 // before the file read so callers that have a document-root verifier can
 // avoid loading untrusted behavioral guidance into memory.
+//
+// Multi-node talent files (more than one frontmatter block) produce
+// one [Talent] per block, all sharing the same SourcePath. Every node
+// in a multi-node file must declare a unique name: in its frontmatter;
+// single-node files may omit name: and fall back to the filename
+// (without .md) for backward compatibility.
 func (l *Loader) TalentsVerified(ctx context.Context, verifier VerifyPathFunc, consumer string) ([]Talent, error) {
 	if ctx == nil {
 		ctx = context.Background()
@@ -110,19 +132,50 @@ func (l *Loader) TalentsVerified(ctx context.Context, verifier VerifyPathFunc, c
 		if err != nil {
 			return nil, fmt.Errorf("read talent %s: %w", f, err)
 		}
-		name := strings.TrimSuffix(f, ".md")
-		meta, content := ParseFrontmatterMetadata(string(data))
-		ts = append(ts, Talent{
+		filename := strings.TrimSuffix(f, ".md")
+		blocks := ParseFrontmatterBlocks(string(data))
+		fileTalents, err := talentsFromBlocks(blocks, filename, path)
+		if err != nil {
+			return nil, err
+		}
+		ts = append(ts, fileTalents...)
+	}
+	return ts, nil
+}
+
+// talentsFromBlocks materializes parsed Blocks into Talents and enforces
+// the naming contract: multi-node files require declared, unique names;
+// single-node files may fall back to the filename.
+func talentsFromBlocks(blocks []Block, filename, path string) ([]Talent, error) {
+	if len(blocks) == 0 {
+		return nil, nil
+	}
+	out := make([]Talent, 0, len(blocks))
+	seen := make(map[string]bool, len(blocks))
+	multi := len(blocks) > 1
+	for i, block := range blocks {
+		name := strings.TrimSpace(block.Frontmatter.Name)
+		if name == "" {
+			if multi {
+				return nil, fmt.Errorf("talent %s: multi-node file requires name: on every node; block %d is missing one", path, i+1)
+			}
+			name = filename
+		}
+		if seen[name] {
+			return nil, fmt.Errorf("talent %s: duplicate node name %q within file", path, name)
+		}
+		seen[name] = true
+		out = append(out, Talent{
 			Name:       name,
-			Tags:       meta.Tags,
-			Kind:       meta.Kind,
-			Teaser:     meta.Teaser,
-			NextTags:   append([]string(nil), meta.NextTags...),
-			Content:    content,
+			Tags:       block.Frontmatter.Tags,
+			Kind:       block.Frontmatter.Kind,
+			Teaser:     block.Frontmatter.Teaser,
+			NextTags:   append([]string(nil), block.Frontmatter.NextTags...),
+			Content:    block.Content,
 			SourcePath: path,
 		})
 	}
-	return ts, nil
+	return out, nil
 }
 
 // FilterByTags returns the combined content of talents matching the
@@ -220,43 +273,147 @@ func ParseFrontmatter(raw string) ([]string, string) {
 
 // ParseFrontmatterMetadata extracts the supported frontmatter fields and
 // returns both the parsed metadata and the stripped body content. Unknown
-// keys are ignored.
+// keys are ignored. For multi-node files, returns only the first block's
+// metadata + content; use [ParseFrontmatterBlocks] when all blocks matter.
 func ParseFrontmatterMetadata(raw string) (Frontmatter, string) {
-	if !strings.HasPrefix(raw, "---") {
+	blocks := ParseFrontmatterBlocks(raw)
+	if len(blocks) == 0 {
 		return Frontmatter{}, raw
 	}
+	return blocks[0].Frontmatter, blocks[0].Content
+}
 
-	// Find the closing "---" delimiter.
+// ParseFrontmatterBlocks splits a talent file into one or more
+// [Block]s. Each block starts with a YAML frontmatter delimited by
+// "---" lines and is followed by the body content up to the next
+// node boundary (or EOF). A node boundary is a "---" line followed by
+// a recognized frontmatter key (name, tags, tags_all, kind, teaser,
+// next_tags); a "---" followed by anything else stays as body content
+// (a markdown horizontal rule).
+//
+// Single-node files (the historical shape) return a length-1 slice.
+// Multi-node files return one [Block] per node. Returns a length-1
+// slice with the raw input as content when no frontmatter is found at
+// the file start — same fallback as the legacy single-block parser.
+func ParseFrontmatterBlocks(raw string) []Block {
+	if !strings.HasPrefix(raw, "---") {
+		return []Block{{Content: raw}}
+	}
+	var blocks []Block
+	remaining := raw
+	for {
+		block, rest, ok := parseOneBlock(remaining)
+		if !ok {
+			break
+		}
+		blocks = append(blocks, block)
+		if rest == "" {
+			break
+		}
+		remaining = rest
+	}
+	if len(blocks) == 0 {
+		return []Block{{Content: raw}}
+	}
+	return blocks
+}
+
+// parseOneBlock reads a single frontmatter+content pair from raw,
+// returning the parsed Block, any remaining bytes (for the next
+// iteration), and ok=false when raw doesn't start with a frontmatter.
+// The content ends at the next node boundary or EOF.
+func parseOneBlock(raw string) (Block, string, bool) {
+	if !strings.HasPrefix(raw, "---") {
+		return Block{}, "", false
+	}
 	rest := raw[3:]
 	rest = strings.TrimLeft(rest, " \t")
-	if len(rest) > 0 && rest[0] == '\n' {
+	switch {
+	case len(rest) > 0 && rest[0] == '\n':
 		rest = rest[1:]
-	} else if len(rest) > 1 && rest[0] == '\r' && rest[1] == '\n' {
+	case len(rest) > 1 && rest[0] == '\r' && rest[1] == '\n':
 		rest = rest[2:]
-	} else {
-		return Frontmatter{}, raw // No newline after opening ---
+	default:
+		return Block{}, "", false
 	}
-
 	closeIdx := strings.Index(rest, "\n---")
 	if closeIdx < 0 {
-		return Frontmatter{}, raw // No closing ---
+		return Block{}, "", false
 	}
-
 	frontmatter := rest[:closeIdx]
-	content := rest[closeIdx+4:] // Skip "\n---"
-	content = strings.TrimLeft(content, "\r\n")
+	afterClose := rest[closeIdx+4:] // skip "\n---"
+	afterClose = strings.TrimLeft(afterClose, "\r\n")
 
-	meta := parseFrontmatterLines(frontmatter)
-	return meta, content
+	// Scan the body for the next node boundary: a line that is "---"
+	// followed by a recognized frontmatter key. Bare "---" without a
+	// key beneath it stays as content (markdown horizontal rule).
+	content, remaining := splitAtNextNodeBoundary(afterClose)
+	return Block{
+		Frontmatter: parseFrontmatterLines(frontmatter),
+		Content:     content,
+	}, remaining, true
+}
+
+// splitAtNextNodeBoundary returns the body content up to the next
+// node-boundary marker and the remaining input (starting at "---") for
+// the next iteration. When no boundary is found, returns the entire
+// body and an empty remainder.
+func splitAtNextNodeBoundary(body string) (content, remainder string) {
+	search := body
+	offset := 0
+	for {
+		idx := strings.Index(search, "\n---")
+		if idx < 0 {
+			return body, ""
+		}
+		// Look at what's on the line after "---" — if it parses as a
+		// frontmatter key, this is a node boundary; otherwise it's a
+		// markdown HR and we keep scanning.
+		afterDashes := search[idx+4:]
+		afterDashes = strings.TrimLeft(afterDashes, " \t")
+		// Skip the rest of the "---" line and look at the next line.
+		if nl := strings.IndexByte(afterDashes, '\n'); nl >= 0 {
+			nextLine := strings.TrimSpace(afterDashes[nl+1:])
+			if firstKey, _, _ := strings.Cut(nextLine, ":"); isFrontmatterKey(strings.TrimSpace(firstKey)) {
+				absolute := offset + idx
+				// Drop the leading newline before "---" from content so
+				// trailing whitespace on the prior block stays clean.
+				return strings.TrimRight(body[:absolute], "\r\n"), body[absolute+1:]
+			}
+		}
+		// Not a node boundary — keep scanning past this "---".
+		offset += idx + 4
+		search = search[idx+4:]
+	}
+}
+
+// isFrontmatterKey reports whether key is one of the recognized
+// frontmatter field names. Used by [splitAtNextNodeBoundary] to
+// distinguish a node boundary (followed by a known key) from a
+// markdown horizontal rule (followed by prose or a different key).
+func isFrontmatterKey(key string) bool {
+	switch key {
+	case "name", "tags", "tags_all", "kind", "teaser", "next_tags":
+		return true
+	default:
+		return false
+	}
 }
 
 // parseFrontmatterLines extracts the currently supported metadata keys
-// from frontmatter. Unknown keys are ignored.
+// from frontmatter. Unknown keys are ignored. The recognized key set
+// must stay in sync with [isFrontmatterKey], which the multi-block
+// parser uses to distinguish node boundaries from markdown horizontal
+// rules.
 func parseFrontmatterLines(frontmatter string) Frontmatter {
 	var meta Frontmatter
 	for _, line := range strings.Split(frontmatter, "\n") {
 		line = strings.TrimSpace(line)
 		switch {
+		case strings.HasPrefix(line, "name:"):
+			value := strings.TrimSpace(strings.TrimPrefix(line, "name:"))
+			value = strings.Trim(value, `"'`)
+			meta.Name = value
 		case strings.HasPrefix(line, "tags_all:"):
 			meta.TagsAll = parseFrontmatterTagList(strings.TrimPrefix(line, "tags_all:"))
 		case strings.HasPrefix(line, "tags:"):

--- a/internal/model/talents/loader_test.go
+++ b/internal/model/talents/loader_test.go
@@ -668,6 +668,65 @@ curate-specific guidance
 	}
 }
 
+func TestParseFrontmatterBlocks_EmptyBodyBetweenNodes(t *testing.T) {
+	// A node with no body means the next node's frontmatter starts
+	// immediately after the closing "---". The boundary scanner must
+	// detect a boundary at position 0 of the body (no preceding
+	// newline to anchor the search).
+	raw := `---
+name: a
+tags: [x]
+---
+---
+name: b
+tags: [y]
+---
+
+body for b
+`
+	blocks := ParseFrontmatterBlocks(raw)
+	if len(blocks) != 2 {
+		t.Fatalf("blocks = %d, want 2 (empty body between nodes should not collapse them)", len(blocks))
+	}
+	if blocks[0].Frontmatter.Name != "a" || blocks[1].Frontmatter.Name != "b" {
+		t.Fatalf("names = [%q, %q], want [a, b]", blocks[0].Frontmatter.Name, blocks[1].Frontmatter.Name)
+	}
+	if strings.TrimSpace(blocks[0].Content) != "" {
+		t.Errorf("block[0].Content = %q, want empty", blocks[0].Content)
+	}
+	if !strings.Contains(blocks[1].Content, "body for b") {
+		t.Errorf("block[1].Content missing body: %q", blocks[1].Content)
+	}
+}
+
+func TestParseFrontmatterBlocks_HRWithDistantKeyParagraphStaysContent(t *testing.T) {
+	// A "---" line followed by a blank line and then a paragraph that
+	// happens to start with a frontmatter-key word ("name:", "tags:")
+	// must stay as a markdown horizontal rule. Only a "---" whose very
+	// next line is a "key: value" pair counts as a node boundary.
+	raw := `---
+name: only
+tags: [x]
+---
+
+# Heading
+
+paragraph one
+
+---
+
+name: looks like a key but is actually prose
+this paragraph continues
+`
+	blocks := ParseFrontmatterBlocks(raw)
+	if len(blocks) != 1 {
+		t.Fatalf("blocks = %d, want 1 (HR with later key paragraph should not split)", len(blocks))
+	}
+	if !strings.Contains(blocks[0].Content, "name: looks like a key") {
+		t.Errorf("body lost prose after HR: %q", blocks[0].Content)
+	}
+}
+
 func TestParseFrontmatterBlocks_HRInBodyStaysContent(t *testing.T) {
 	// A "---" line followed by prose (not a frontmatter key) is a
 	// markdown horizontal rule and must not split the block.

--- a/internal/model/talents/loader_test.go
+++ b/internal/model/talents/loader_test.go
@@ -603,3 +603,265 @@ func equalStrings(a, b []string) bool {
 	}
 	return true
 }
+
+func TestParseFrontmatterBlocks_SingleBlock(t *testing.T) {
+	raw := `---
+tags: [forge]
+---
+
+# Forge Entry
+
+content
+`
+	blocks := ParseFrontmatterBlocks(raw)
+	if len(blocks) != 1 {
+		t.Fatalf("blocks = %d, want 1", len(blocks))
+	}
+	if got := blocks[0].Frontmatter.Tags; len(got) != 1 || got[0] != "forge" {
+		t.Errorf("tags = %v, want [forge]", got)
+	}
+	if !strings.Contains(blocks[0].Content, "# Forge Entry") {
+		t.Errorf("content missing heading: %q", blocks[0].Content)
+	}
+}
+
+func TestParseFrontmatterBlocks_MultiBlock(t *testing.T) {
+	raw := `---
+name: root
+tags: [loops_examples]
+kind: entry_point
+next_tags: [loops_examples_curate]
+---
+
+# Root
+
+choose your path
+
+---
+name: curate
+tags: [loops_examples_curate]
+kind: entry_point
+---
+
+# Curate
+
+curate-specific guidance
+`
+	blocks := ParseFrontmatterBlocks(raw)
+	if len(blocks) != 2 {
+		t.Fatalf("blocks = %d, want 2", len(blocks))
+	}
+	if blocks[0].Frontmatter.Name != "root" {
+		t.Errorf("block[0].Name = %q, want root", blocks[0].Frontmatter.Name)
+	}
+	if blocks[1].Frontmatter.Name != "curate" {
+		t.Errorf("block[1].Name = %q, want curate", blocks[1].Frontmatter.Name)
+	}
+	if !strings.Contains(blocks[0].Content, "choose your path") {
+		t.Errorf("block[0] content missing root body: %q", blocks[0].Content)
+	}
+	if !strings.Contains(blocks[1].Content, "curate-specific guidance") {
+		t.Errorf("block[1] content missing curate body: %q", blocks[1].Content)
+	}
+	if strings.Contains(blocks[0].Content, "curate-specific guidance") {
+		t.Error("block[0] content leaked into next block's body")
+	}
+}
+
+func TestParseFrontmatterBlocks_HRInBodyStaysContent(t *testing.T) {
+	// A "---" line followed by prose (not a frontmatter key) is a
+	// markdown horizontal rule and must not split the block.
+	raw := `---
+name: only
+tags: [x]
+---
+
+# Heading
+
+paragraph one
+
+---
+
+paragraph two
+`
+	blocks := ParseFrontmatterBlocks(raw)
+	if len(blocks) != 1 {
+		t.Fatalf("blocks = %d, want 1 (HR should not split)", len(blocks))
+	}
+	if !strings.Contains(blocks[0].Content, "paragraph one") || !strings.Contains(blocks[0].Content, "paragraph two") {
+		t.Errorf("HR-separated content lost: %q", blocks[0].Content)
+	}
+}
+
+func TestParseFrontmatterMetadata_DelegatesToFirstBlock(t *testing.T) {
+	raw := `---
+name: first
+tags: [a]
+---
+
+first body
+
+---
+name: second
+tags: [b]
+---
+
+second body
+`
+	meta, content := ParseFrontmatterMetadata(raw)
+	if meta.Name != "first" {
+		t.Errorf("meta.Name = %q, want first (multi-node should return first block's meta)", meta.Name)
+	}
+	if !strings.Contains(content, "first body") {
+		t.Errorf("content missing first body: %q", content)
+	}
+	if strings.Contains(content, "second body") {
+		t.Errorf("content leaked second body: %q", content)
+	}
+}
+
+func TestTalents_MultiNodeFile(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "tree.md"), []byte(`---
+name: tree_root
+tags: [tree]
+kind: entry_point
+teaser: "root teaser"
+next_tags: [tree_branch_a, tree_branch_b]
+---
+
+# Root
+
+choose
+
+---
+name: tree_branch_a
+tags: [tree_branch_a]
+kind: entry_point
+---
+
+# Branch A
+
+---
+name: tree_branch_b
+tags: [tree_branch_b]
+kind: entry_point
+---
+
+# Branch B
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	loader := NewLoader(dir)
+	all, err := loader.Talents()
+	if err != nil {
+		t.Fatalf("Talents: %v", err)
+	}
+	if len(all) != 3 {
+		t.Fatalf("got %d talents, want 3 from one multi-node file", len(all))
+	}
+	wantNames := []string{"tree_root", "tree_branch_a", "tree_branch_b"}
+	for i, talent := range all {
+		if talent.Name != wantNames[i] {
+			t.Errorf("talent[%d].Name = %q, want %q", i, talent.Name, wantNames[i])
+		}
+		if !strings.HasSuffix(talent.SourcePath, "tree.md") {
+			t.Errorf("talent[%d].SourcePath = %q, want tree.md", i, talent.SourcePath)
+		}
+	}
+}
+
+func TestTalents_MultiNodeRequiresName(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "bad.md"), []byte(`---
+tags: [a]
+---
+
+first
+
+---
+tags: [b]
+---
+
+second (missing name)
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, err := NewLoader(dir).Talents()
+	if err == nil {
+		t.Fatal("expected error for multi-node file with missing name, got nil")
+	}
+	if !strings.Contains(err.Error(), "name:") {
+		t.Errorf("error %q should mention the missing name field", err.Error())
+	}
+}
+
+func TestTalents_DuplicateNameWithinFile(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "dupe.md"), []byte(`---
+name: same
+tags: [a]
+---
+
+a
+
+---
+name: same
+tags: [b]
+---
+
+b
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, err := NewLoader(dir).Talents()
+	if err == nil {
+		t.Fatal("expected error for duplicate node name, got nil")
+	}
+	if !strings.Contains(err.Error(), "duplicate") {
+		t.Errorf("error %q should mention duplicate", err.Error())
+	}
+}
+
+func TestTalents_SingleNodeNameOptional(t *testing.T) {
+	// Single-node file without name: falls back to filename for
+	// backward compatibility.
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "legacy.md"), []byte(`---
+tags: [legacy]
+---
+
+# Legacy
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	all, err := NewLoader(dir).Talents()
+	if err != nil {
+		t.Fatalf("Talents: %v", err)
+	}
+	if len(all) != 1 || all[0].Name != "legacy" {
+		t.Fatalf("got %+v, want one talent named legacy (filename fallback)", all)
+	}
+}
+
+func TestTalents_SingleNodeDeclaredNameWinsOverFilename(t *testing.T) {
+	// A single-node file with an explicit name: uses it, not the
+	// filename. Lets authors decouple identity from disk layout.
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "filename.md"), []byte(`---
+name: declared_name
+tags: [x]
+---
+
+body
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	all, err := NewLoader(dir).Talents()
+	if err != nil {
+		t.Fatalf("Talents: %v", err)
+	}
+	if len(all) != 1 || all[0].Name != "declared_name" {
+		t.Fatalf("got %+v, want declared_name", all)
+	}
+}

--- a/talents/loops-doctrine.md
+++ b/talents/loops-doctrine.md
@@ -34,18 +34,18 @@ Choose stream wiring by attention cost:
   immediate iteration. Producer tools such as `forge_repo_follow` and
   `media_follow` own those subscriptions.
 
-Treat running loops as bi-directional. A curate loop can pull the core
-in via `request_core_attention` when something deserves a decision; the
-core can push new focus down by adding entities to a running loop's
-watch set with `update_entity_subscriptions`, or by pointing a
-producer's `wake_loop` target at the loop. Inspect what is already
-running with `loop_status` and `loop_definition_get` before launching
-a parallel loop — a thriving loop is its own data-dense documentation
-and is usually the right thing to extend.
+Treat running loops as bi-directional. A curate loop can pull you in
+via `request_core_attention` when something deserves a decision; you
+can push new focus down by adding entities to a running loop's watch
+set with `update_entity_subscriptions`, or by pointing a producer's
+`wake_loop` target at the loop. Inspect what is already running with
+`loop_status` and `loop_definition_get` before launching a parallel
+loop — a thriving loop is its own data-dense documentation and is
+usually the right thing to extend.
 
-**`request_core_attention` forces a supervisor turn** on the core
-loop's next iteration — costlier than a normal wake. Reserve it for
-concerns that genuinely warrant the extra capacity, not as a routine
+**`request_core_attention` forces a supervisor turn** on your next
+iteration — costlier than a normal wake. Reserve it for concerns
+that genuinely warrant the extra capacity, not as a routine
 notification channel.
 
 Natural-language timing inside a task does not schedule a service loop.

--- a/talents/loops-examples.md
+++ b/talents/loops-examples.md
@@ -71,8 +71,8 @@ document. Two questions decide which sub-shape fits:
      `loops_examples_curate_dashboard`
    - Append a dated entry → activate `loops_examples_curate_journal`
 
-2. **Does the loop need to pull the core's attention or accept new
-   focus from the core?**
+2. **Does the loop need to escalate decisions to you, or accept new
+   focus when you adjust its scope?**
    - Yes (bi-directional) → activate `loops_examples_curate_circle`
      after picking dashboard or journal
 
@@ -173,28 +173,30 @@ and yesterday's state is just noise.
 name: loops_examples_curate_circle
 tags: [loops_examples_curate_circle]
 kind: entry_point
-teaser: "Bi-directional curate loop: pulls the core in for decisions, accepts new focus from the core."
+teaser: "Bi-directional curate loop: escalates decisions to you, accepts new focus when you adjust its scope."
 ---
 
 # Curate: The Circle of Life
 
-A curate loop becomes bi-directional when it (a) pulls the core's
-attention when something deserves a decision and (b) accepts new focus
-from the core when its scope should shift.
+A curate loop becomes bi-directional when it (a) pulls your attention
+when something deserves a decision and (b) accepts new focus from you
+when its scope should shift.
 
 ## Four steps
 
-1. **Core launches the watcher** with `thane_curate` (dashboard or
+1. **You launch the watcher** with `thane_curate` (dashboard or
    journal shape — see those branches).
 
-2. **Watcher runs at its own pace** inside the envelope, tuning via
-   `set_next_sleep` and adjusting its own watch set via `watch_entity`
-   / `unwatch_entity`.
+2. **The watcher runs at its own pace** inside the envelope, tuning
+   via `set_next_sleep` and adjusting its own watch set via
+   `watch_entity` / `unwatch_entity`. You don't interact during this
+   phase.
 
-3. **Watcher pulls the core in when it matters** via
-   `request_core_attention`. This forces a supervisor turn on the
-   core's next iteration — costlier than a normal wake, so reserve it
-   for concerns that genuinely warrant the extra capacity.
+3. **The watcher pulls you in when something matters** via
+   `request_core_attention`. This forces a supervisor turn on your
+   next iteration — costlier than a normal wake, so the watcher
+   should reserve it for concerns that genuinely warrant the extra
+   capacity.
 
    ```json
    {
@@ -204,10 +206,10 @@ from the core when its scope should shift.
    }
    ```
 
-   State the concern as a decision or risk, not as a delivery command.
-   The core decides whether to notify, defer, or absorb.
+   The concern arrives stated as a decision or risk, not as a
+   delivery command. You decide whether to notify, defer, or absorb.
 
-4. **Core pushes new focus down when it matters** via
+4. **You push new focus down when something matters** via
    `update_entity_subscriptions`. Adds or removes entities on the
    running loop's watch set in place.
 
@@ -222,8 +224,8 @@ from the core when its scope should shift.
    ```
 
    The watcher sees the new entities on its next wake. Use
-   `remove: ["entity_id", ...]` to retire watches the core no longer
-   cares about.
+   `remove: ["entity_id", ...]` to retire watches you no longer care
+   about.
 
 For event-driven wakes (a new release on a repo, a new feed entry),
 producer tools like `forge_repo_follow` and `media_follow` take a

--- a/talents/loops-examples.md
+++ b/talents/loops-examples.md
@@ -1,73 +1,118 @@
 ---
-kind: examples
+name: loops_examples
 tags: [loops_examples]
+kind: entry_point
+teaser: "Open when about to launch any loop-shaped work. Walks you to the right thane_* call."
+next_tags: [loops_examples_curate, loops_examples_now, loops_examples_assign, loops_examples_advanced]
 ---
 
 # Loops Examples
 
-Loops are how Thane runs concurrent attention. The default path is a
-**curate loop** — a small subconscious watcher that the core agent
-launches with a watch set and a document to keep current, then leaves
-alone until either side has something to say.
+Loops are how Thane runs concurrent attention. This is the entry point
+for picking the right shape of loop for the work in front of you.
 
-This file walks the full circle of life so the shape is concrete:
-inspect what's already running, launch the watcher, let it self-pace,
-let it pull the core's attention when something matters, push new
-focus down when the core needs it. Then a few specialty shapes for
-work that doesn't fit the curate pattern.
+## First move: look at what's already running
 
-## Look at what's already running first
+Before launching anything new, check what exists. A loop that has run
+hundreds of healthy iterations is a better template than anything
+below.
 
-Each running loop is its own documentation. Before launching anything
-new, check what exists — both for "is there already a loop watching
-this?" and for "what does a healthy spec for this kind of work look
-like?"
+- `loop_status` — live registry with filters for query text, state,
+  operation, and a result cap. Returns iteration counts, last wake,
+  token use, active tags, metadata.
+- `loop_definition_list` — every durable definition (config + overlay).
+- `loop_definition_get(name)` — full spec for one: task, tags, outputs,
+  sleep envelope, profile, supervisor settings, conditions, metadata.
 
-- `loop_status` — live registry, with filters for query text, state,
-  operation, and a result limit. Returns iteration counts, last wake,
-  cumulative and last-turn token use, active tags, metadata, and
-  consecutive error counts for every running loop.
-- `loop_definition_list` — every durable definition, config and
-  overlay together.
-- `loop_definition_get(name)` — the full spec for one: task, tags,
-  outputs, sleep envelope, profile, supervisor settings, conditions,
-  metadata.
+If a peer loop already owns the topic, prefer extending it (via
+`update_entity_subscriptions`) over launching a parallel watcher.
 
-Treat the registry as a library of worked examples. A loop that has
-run hundreds of healthy iterations is a better template than anything
-in this file. If a peer loop already owns the topic, prefer extending
-it (via `update_entity_subscriptions`) over launching a parallel
-watcher.
+## Choose the shape of work
 
-## The default path: curate, self-pace, two-way signal
+Activate the next tag based on what shape this work has:
 
-The bi-directional curate loop is the well-worn path. Two-way comms
-between a subconscious research task and the core's situational
-awareness:
+- **Recurring service work that owns a document** — activate
+  `loops_examples_curate`. The default and most-used path. Maintains a
+  managed document across iterations; the model adapts its own sleep
+  envelope; the document IS the loop's memory.
 
-1. **Core launches the watcher** with `thane_curate`. Hand it an
-   intent, a watch set, a document to own, and an adaptive sleep
-   envelope (see the envelope section below).
-2. **Watcher runs at its own pace.** It writes findings to the
-   document each cycle and tunes its own next wake with
-   `set_next_sleep` (clamped to the envelope it was given).
-3. **Watcher pulls the core in when it matters.** When the watcher
-   sees something the core needs to decide on, it calls
-   `request_core_attention` with a concern and a priority.
-4. **Core pushes new focus down when it matters.** When the core
-   wants the watcher to track something new, it calls
-   `update_entity_subscriptions` to add or remove entities from
-   the watcher's set.
+- **Sync foreground work that must finish before you reply** —
+  activate `loops_examples_now`. Wraps a delegate call (`thane_now`)
+  that blocks this turn.
 
-The watcher never speaks to the operator directly. It speaks to the
-document it owns, and to the core. The core decides what reaches a
-human.
+- **Async one-shot work that should report back when done** — activate
+  `loops_examples_assign`. Detached delegate (`thane_assign`) that
+  picks its own moment to deliver.
 
-### Step 1: Launch the watcher
+- **Custom shapes, lifecycle management, or supervisor turns** —
+  activate `loops_examples_advanced`. Ad-hoc loops via `spawn_loop`,
+  durable definitions you pause/resume, supervisor randomization,
+  linting before save.
+
+The shapes are not exclusive — a curate loop can spawn a one-shot
+research delegate when it needs a side investigation. Pick the
+primary shape first.
+
+---
+name: loops_examples_curate
+tags: [loops_examples_curate]
+kind: entry_point
+teaser: "Recurring service loops that maintain a managed document over time."
+next_tags: [loops_examples_curate_dashboard, loops_examples_curate_journal, loops_examples_curate_circle]
+---
+
+# Curate
+
+`thane_curate` creates a service loop that owns a managed markdown
+document. Two questions decide which sub-shape fits:
+
+1. **Does each cycle replace the document or append to it?**
+   - Replace (idempotent rewrite) → activate
+     `loops_examples_curate_dashboard`
+   - Append a dated entry → activate `loops_examples_curate_journal`
+
+2. **Does the loop need to pull the core's attention or accept new
+   focus from the core?**
+   - Yes (bi-directional) → activate `loops_examples_curate_circle`
+     after picking dashboard or journal
+
+## The sleep envelope is the one judgment call
+
+`thane_curate` requires `sleep_min` and `sleep_max`. The loop
+self-paces inside that envelope via `set_next_sleep`, which is clamped
+to the bounds. Pick bounds to match the topic's metabolism:
+
+- UPS guardian: `[5m, 30m]`
+- Burn-ban monitor: `[1h, 6h]`
+- Daily digest writer: `[12h, 36h]`
+
+`sleep_default` defaults to the midpoint; `jitter` defaults to 0.1.
+Words like "hourly" inside the task text do not schedule the loop —
+only the envelope does.
+
+## Tags scope the loop's tools
+
+The `tags` array activates capability tags for the loop's iterations
+(things like `home`, `ha`, `awareness`, `documents`). Omit to inherit
+the always-active set. A curate loop watching HA entities needs at
+least `home` or `ha` so it has the tools to interpret its watch set.
+
+---
+name: loops_examples_curate_dashboard
+tags: [loops_examples_curate_dashboard]
+kind: entry_point
+teaser: "Maintain a single dashboard document idempotently each cycle."
+---
+
+# Curate: Dashboard (maintain mode)
+
+Use `mode: maintain` when the document should reflect *current state*,
+not history. Each cycle rewrites the body; the generated output tool is
+`replace_output_<loop_name>`.
 
 ```json
 {
-  "name": "server-closet-guardian",
+  "name": "server_closet_guardian",
   "intent": "Watch the server-closet environment and equipment health. Document trends. Surface UPS dropouts, dehumidifier failure, or temperature excursions that need attention.",
   "sleep_min": "10m",
   "sleep_max": "30m",
@@ -87,142 +132,207 @@ human.
 }
 ```
 
-`sleep_min` and `sleep_max` define the envelope the loop self-paces
-inside; `sleep_default` defaults to the midpoint and `jitter` defaults
-to 0.1 (pass them explicitly when you want to override). The watcher
-writes through the generated `replace_output_*` tool (for `mode:
-"maintain"`) or `append_output_*` (for `mode: "journal"`).
+The loop's prompt sees the current document body each turn (truncated
+if oversized — read it with `doc_read` first when so), then the model
+rewrites the body via `replace_output_server_closet_guardian`.
 
-### Step 2: Let the watcher self-pace
+---
+name: loops_examples_curate_journal
+tags: [loops_examples_curate_journal]
+kind: entry_point
+teaser: "Append a dated entry to a journal document each cycle."
+---
 
-Inside its own iteration, the watcher has three steering tools:
+# Curate: Journal (journal mode)
 
-- `set_next_sleep` — tune the next wake within the envelope. Cannot
-  exceed the persisted `sleep_min` / `sleep_max`.
-- `watch_entity` / `unwatch_entity` — adjust its own watch set
-  without needing its name.
-
-Pick the envelope at creation time and trust the loop to find its own
-rhythm inside.
-
-### Step 3: Pull the core in
-
-When the watcher sees something the core should consider:
+Use `mode: journal` when each cycle adds a *new entry* and prior
+entries are preserved. Research notes, decision logs, daily digests.
+The generated output tool is `append_output_<loop_name>` — it writes a
+new dated section without touching prior entries.
 
 ```json
 {
-  "concern": "UPS hor-rack reports 4 minutes battery runtime and 92% load. Brownout protection window is narrowing.",
-  "priority": "urgent",
-  "context": "Last 30m: load climbed from 78% to 92% after closet AC dropped. No recent grid events."
+  "name": "burn_ban_monitor",
+  "intent": "Check the Comal County fire marshal site for the current burn ban status. Note any changes from the prior entry; otherwise note 'no change.'",
+  "sleep_min": "1h",
+  "sleep_max": "6h",
+  "output": {
+    "document": "kb:journals/burn-ban.md",
+    "mode": "journal",
+    "title": "Burn Ban Status Journal"
+  },
+  "tags": ["web"]
 }
 ```
 
-`request_core_attention` does not deliver a message to a human, and
-it is not free: every call forces the core's next iteration into a
-supervisor turn (costlier than a normal wake). Use it for concerns
-that genuinely warrant the extra capacity. State the concern as a
-decision or risk, not as a delivery command — the core decides
-whether to notify, defer, or absorb.
+Journal mode is right when continuity matters — you want to look back
+at the trail. Dashboard mode is right when only "right now" matters
+and yesterday's state is just noise.
 
-### Step 4: Push new focus down
+---
+name: loops_examples_curate_circle
+tags: [loops_examples_curate_circle]
+kind: entry_point
+teaser: "Bi-directional curate loop: pulls the core in for decisions, accepts new focus from the core."
+---
 
-When the core decides the watcher should track something new:
+# Curate: The Circle of Life
 
-```json
-{
-  "name": "server-closet-guardian",
-  "add": [
-    {"entity_id": "sensor.closet_ac_state", "history": [3600]},
-    {"entity_id": "binary_sensor.utility_brownout"}
-  ]
-}
-```
+A curate loop becomes bi-directional when it (a) pulls the core's
+attention when something deserves a decision and (b) accepts new focus
+from the core when its scope should shift.
 
-`update_entity_subscriptions` modifies the running loop's watch
-set in place. The watcher sees the new entities on its next wake. Use
-`remove: ["entity_id", ...]` to retire watches the core no longer
-cares about.
+## Four steps
+
+1. **Core launches the watcher** with `thane_curate` (dashboard or
+   journal shape — see those branches).
+
+2. **Watcher runs at its own pace** inside the envelope, tuning via
+   `set_next_sleep` and adjusting its own watch set via `watch_entity`
+   / `unwatch_entity`.
+
+3. **Watcher pulls the core in when it matters** via
+   `request_core_attention`. This forces a supervisor turn on the
+   core's next iteration — costlier than a normal wake, so reserve it
+   for concerns that genuinely warrant the extra capacity.
+
+   ```json
+   {
+     "concern": "UPS hor-rack reports 4 minutes battery runtime and 92% load. Brownout protection window is narrowing.",
+     "priority": "urgent",
+     "context": "Last 30m: load climbed from 78% to 92% after closet AC dropped. No recent grid events."
+   }
+   ```
+
+   State the concern as a decision or risk, not as a delivery command.
+   The core decides whether to notify, defer, or absorb.
+
+4. **Core pushes new focus down when it matters** via
+   `update_entity_subscriptions`. Adds or removes entities on the
+   running loop's watch set in place.
+
+   ```json
+   {
+     "name": "server_closet_guardian",
+     "add": [
+       {"entity_id": "sensor.closet_ac_state", "history": [3600]},
+       {"entity_id": "binary_sensor.utility_brownout"}
+     ]
+   }
+   ```
+
+   The watcher sees the new entities on its next wake. Use
+   `remove: ["entity_id", ...]` to retire watches the core no longer
+   cares about.
 
 For event-driven wakes (a new release on a repo, a new feed entry),
 producer tools like `forge_repo_follow` and `media_follow` take a
 `wake_loop` target so the curate loop wakes on the event rather than
 its timer.
 
-## Adaptive sleep envelope: pick the bounds, not the tick
+---
+name: loops_examples_now
+tags: [loops_examples_now]
+kind: entry_point
+teaser: "Sync foreground delegate — must finish before this turn replies."
+---
 
-The only real judgment at creation is the sleep envelope. The loop
-self-pacing inside that envelope handles the rest.
+# Now (sync delegate)
 
-- `sleep_min`: how often this topic can deserve attention at its
-  busiest. Tight enough that an urgent change is not missed.
-- `sleep_max`: how rarely this topic can be checked without losing
-  signal. Loose enough that a quiet day costs nothing.
-- `sleep_default`: a sensible mid-point for the first wake.
-- `jitter`: 0.1–0.2 unless several peer loops would otherwise
-  synchronize and stampede.
-
-The watcher uses `set_next_sleep` to tighten when something is
-interesting and loosen when nothing is happening. A burn-ban monitor
-might envelope `[1h, 6h]`; a UPS guardian might envelope `[5m, 30m]`;
-a daily digest writer might envelope `[12h, 36h]`. In all three the
-loop finds its own rhythm.
-
-Words like "hourly" or "every 30 minutes" inside `task` text do not
-schedule the loop. Only the sleep envelope does.
-
-## Specialty shapes
-
-### Lint a durable definition before saving
-
-Use `loop_definition_lint` before `loop_definition_set` when
-authoring or replacing a persisted service. The linter surfaces
-omitted sleep fields, ineffective delegation gating, and task text
-that pretends to schedule itself.
-
-### One-shot research that reports back
-
-When the current turn benefits from a side investigation that returns
-naturally when done, use `spawn_loop` with
-`operation: background_task` and omit completion (the origin context
-infers the callback path).
+`thane_now` runs a bounded delegate that blocks the current turn.
+Returns its result inline. Use this when the work must complete before
+you reply and you don't want to fragment the conversation.
 
 ```json
 {
-  "launch": {
-    "spec": {
-      "name": "research-current-issue",
-      "task": "Investigate the current issue from multiple angles, keep concise notes in a managed document if needed, and report back with the strongest answer once the uncertainty has collapsed.",
-      "operation": "background_task",
-      "profile": {
-        "mission": "background",
-        "initial_tags": ["knowledge", "documents"],
-        "instructions": "Prefer the smallest tool surface that can collapse uncertainty. Use document tools for durable notes."
-      }
-    }
-  }
+  "task": "Look up the current open PRs on nugget/thane-ai-agent assigned to the user, and return their titles and ages.",
+  "profile": "research"
 }
 ```
 
-### Durable service with lifecycle control and supervisor turns
+The delegate runs in a child loop with its own tool surface (chosen by
+profile), executes the task, and returns its content as the tool
+result. Cost is sync model spend on the delegate's iterations.
 
-Use `loop_definition_set` (not `spawn_loop`) when the lifecycle —
-keep, pause, resume, relaunch — matters. Pair with
-`loop_definition_set_policy(state="active" | "paused" | "inactive")`.
-Tagged service loops usually want `profile.delegation_gating:
-"disabled"` so they can use their own tools directly.
+Prefer `thane_assign` (the next tag) when the work can run in the
+background while this turn moves on. Prefer `thane_curate` when the
+work is recurring.
 
-When the loop should mostly run cheap iterations but occasionally
-take a more expensive supervisor pass, layer `supervisor: true` plus
+---
+name: loops_examples_assign
+tags: [loops_examples_assign]
+kind: entry_point
+teaser: "Async one-shot delegate — reports back when done; this turn continues."
+---
+
+# Assign (async one-shot delegate)
+
+`thane_assign` launches a detached delegate that runs in the
+background. Result is delivered later via the current conversation or
+channel context. The launching turn continues immediately.
+
+```json
+{
+  "task": "Investigate why the email-poller loop reported zero new messages in the last 6 hours. Check the email handler logs, the IMAP connection state, and any recent config changes. Report findings.",
+  "profile": "research"
+}
+```
+
+The completion delivery path is inferred from the launch context
+(current Signal conversation, OWU session, etc.). The model that
+receives the completion sees the original task and the delegate's
+final reply.
+
+Use this for side investigations the operator should hear about but
+that don't need to block. Use `thane_now` when the answer is needed
+inline; use `thane_curate` when the work is recurring.
+
+---
+name: loops_examples_advanced
+tags: [loops_examples_advanced]
+kind: entry_point
+teaser: "Custom shapes, lifecycle management, supervisor turns, lint before save."
+---
+
+# Advanced shapes
+
+When none of `thane_curate`, `thane_now`, or `thane_assign` fits the
+work, the lower-level surface is available.
+
+## Lint before saving a durable definition
+
+`loop_definition_lint` surfaces omitted sleep fields, ineffective
+delegation gating, task text that pretends to schedule itself, and
+other authoring mistakes. Run it before `loop_definition_set` when
+authoring or replacing a persisted service by hand.
+
+## Lifecycle: pause, resume, delete
+
+For durable definitions managed by `loop_definition_set`:
+
+- `loop_definition_set_policy(name, state: "paused")` — stops without
+  forgetting; resume by setting state back to `"active"`.
+- `loop_definition_set_policy(name, state: "inactive")` — disables.
+- `loop_definition_delete(name)` — removes from the overlay (config
+  definitions are immutable).
+
+Stored definitions usually want `profile.delegation_gating: "disabled"`
+so tagged service loops can use their own tools directly without
+routing through the orchestrator-delegate gating pattern.
+
+## Supervisor turns on service loops
+
+When a service loop should mostly run cheap iterations but occasionally
+take a more expensive supervisor pass, set `supervisor: true` plus
 `supervisor_prob`, `supervisor_quality_floor`, and a
-`supervisor_context` that prompts the model to step back.
-`thane_curate` does not expose supervisor fields directly — use
-`loop_definition_set` or `spawn_loop` when supervisor turns are
-needed.
+`supervisor_context` that prompts the model to step back. `thane_curate`
+doesn't expose supervisor fields directly — use `loop_definition_set`
+or `spawn_loop` for supervisor-shaped loops.
 
 ```json
 {
   "spec": {
-    "name": "battery-watch",
+    "name": "battery_watch",
     "enabled": true,
     "task": "Maintain a current view of battery health across the property. Notice trends, anomalies, and devices that deserve attention. Keep the state document concise and trustworthy.",
     "operation": "service",
@@ -248,3 +358,29 @@ needed.
 
 Put the main prompt in `spec.task`, not top-level `launch.task`, so
 `supervisor_context` applies cleanly on supervisor turns.
+
+## Ad-hoc and one-shot research
+
+When the work is loop-shaped but shouldn't become a durable
+definition, use `spawn_loop` with `operation: background_task` and
+omit completion (the origin context infers the callback):
+
+```json
+{
+  "launch": {
+    "spec": {
+      "name": "research_current_issue",
+      "task": "Investigate the current issue from multiple angles, keep concise notes in a managed document if needed, and report back with the strongest answer once the uncertainty has collapsed.",
+      "operation": "background_task",
+      "profile": {
+        "mission": "background",
+        "initial_tags": ["knowledge", "documents"],
+        "instructions": "Prefer the smallest tool surface that can collapse uncertainty. Use document tools for durable notes."
+      }
+    }
+  }
+}
+```
+
+For most one-shot work, `thane_assign` is cleaner — `spawn_loop` is
+for the cases where you need to express the spec directly.

--- a/talents/loops-examples.md
+++ b/talents/loops-examples.md
@@ -133,8 +133,8 @@ not history. Each cycle rewrites the body; the generated output tool is
 ```
 
 The loop's prompt sees the current document body each turn (truncated
-if oversized — read it with `doc_read` first when so), then the model
-rewrites the body via `replace_output_server_closet_guardian`.
+if oversized — in that case, read it with `doc_read` first), then the
+model rewrites the body via `replace_output_server_closet_guardian`.
 
 ---
 name: loops_examples_curate_journal


### PR DESCRIPTION
## Summary

Lets multiple talents live in one `.md` file. Each section is a self-contained talent (frontmatter + body); the parser splits on node boundaries and produces N `Talent` entries per file. Downstream consumers (`KBMenuHints`, `FilterByTags`, `SplitByTags`, capability menu) work unchanged — they consume `[]Talent` and don't care whether a talent came from its own file or shared one with siblings.

The "decision tree" behavior was already implicit in the existing format: entry-point talents with `next_tags` form the graph. This change makes it operationally cleaner to author by letting related nodes share a file.

## The contract

- Frontmatter gains a `name:` field — the explicit per-talent identifier.
- Multi-node files (more than one frontmatter block) **require** `name:` on every node. Names must be unique within the file. Parser errors on missing or duplicate names.
- Single-node files (the historical shape) may omit `name:` and fall back to the filename without `.md` — existing talents don't need mass migration.
- Declared name overrides filename even in single-node files, so authors can decouple identity from disk layout when useful.

## Node boundary detection

A node boundary is a `---` line followed by a recognized frontmatter key (`name`, `tags`, `tags_all`, `kind`, `teaser`, `next_tags`). A `---` followed by prose or anything else stays as markdown content (horizontal rule). The known-key set in `isFrontmatterKey` is kept in sync with `parseFrontmatterLines`.

## API shape

- New `Block { Frontmatter, Content }` type.
- New `ParseFrontmatterBlocks(raw) []Block` — the primitive.
- Existing `ParseFrontmatterMetadata` keeps its single-block contract by delegating to the new function and returning the first block. All existing callers (talents loader, tagged KB articles, inject context, durable outputs, context refs) are unchanged.

## Reference implementation: `talents/loops-examples.md`

Converted from a flat reference document to an 8-node decision tree:

```
loops_examples (root)
├── loops_examples_curate
│   ├── loops_examples_curate_dashboard
│   ├── loops_examples_curate_journal
│   └── loops_examples_curate_circle
├── loops_examples_now
├── loops_examples_assign
└── loops_examples_advanced
```

The root walks the model through the choice between `thane_curate`, `thane_now`, `thane_assign`, and the advanced surface. Each leaf carries the concrete JSON the model should produce. The bi-directional curate pattern lives in its own leaf (`loops_examples_curate_circle`) so it can be activated independently.

## Test plan

- [x] `just ci` passes
- [x] `ParseFrontmatterBlocks` covers single-block, multi-block, HR-in-body doesn't split, and `ParseFrontmatterMetadata` delegates to first block
- [x] Loader covers: multi-node file produces N talents with shared `SourcePath`, missing `name:` rejected, duplicate `name:` rejected, single-node files keep filename fallback, single-node declared name wins over filename
- [x] Existing talents tests still pass (no migration of legacy files)
- [x] Sanity-check parse of `loops-examples.md` produces 8 blocks with correct names, tags, kind, next_tags, and teasers

## Open follow-ups (not in this PR)

- Opportunistic consolidation of other related entry-points (e.g., `awareness` + `ha` + `home`) — operator judgment call, not a forcing function.
- Eventually migrate all single-node files to declare `name:` explicitly so the filename fallback can retire — low priority.