### PR TITLE
feat: container loops with tag inheritance

### DIFF
--- a/examples/config.example.yaml
+++ b/examples/config.example.yaml
@@ -961,6 +961,7 @@ ego:
 #       metadata:
 #         category: observer
 #       parent_id: ""
+#       parent_name: ""
 #
 # (optional) Debug configures diagnostic options for inspecting the assembled
 # debug:

--- a/internal/app/loop_definition_runtime.go
+++ b/internal/app/loop_definition_runtime.go
@@ -79,10 +79,30 @@ func (r *loopDefinitionRuntime) definitionLogger(name string) *slog.Logger {
 }
 
 func (r *loopDefinitionRuntime) runtimeSpec(spec looppkg.Spec) (looppkg.Spec, error) {
-	if r == nil || r.hydrate == nil {
+	if r == nil {
 		return spec, nil
 	}
-	return r.hydrate(spec)
+	if r.hydrate != nil {
+		var err error
+		spec, err = r.hydrate(spec)
+		if err != nil {
+			return spec, err
+		}
+	}
+	// Resolve parent_name → live ParentID late, after every other
+	// hydration has had its say. ParentID survives only as long as the
+	// parent's current launch, so the runtime — not the stored spec —
+	// is the source of truth here. If the named parent isn't yet
+	// registered, ParentID stays empty and the loop lands at the root;
+	// container tag inheritance walks the live registry, so the link
+	// re-establishes naturally if the parent comes up later in the
+	// same startup pass.
+	if r.loops != nil && spec.ParentName != "" && spec.ParentID == "" {
+		if parent := r.loops.GetByName(spec.ParentName); parent != nil {
+			spec.ParentID = parent.ID()
+		}
+	}
+	return spec, nil
 }
 
 func (r *loopDefinitionRuntime) definition(name string) (looppkg.DefinitionSnapshot, bool) {
@@ -263,38 +283,116 @@ func (r *loopDefinitionRuntime) StartEnabledServices(ctx context.Context) (loopD
 	if logger == nil {
 		logger = slog.Default()
 	}
-	for _, def := range snap.Definitions {
-		spec := def.Spec
-		switch {
-		case spec.Operation != looppkg.OperationService && spec.Operation != looppkg.OperationContainer:
-			result.SkippedNonService++
-			continue
-		case def.PolicyState == looppkg.DefinitionPolicyStateInactive:
-			result.SkippedInactive++
-			continue
-		case def.PolicyState == looppkg.DefinitionPolicyStatePaused:
-			result.SkippedPaused++
-			continue
-		case !def.Spec.Conditions.Evaluate(r.nowTime()).Eligible:
-			result.SkippedIneligible++
-			continue
-		case r.loops.GetByName(spec.Name) != nil:
-			result.SkippedExisting++
-			logger.Debug("skipping loop definition bootstrap for existing loop", "name", spec.Name)
-			continue
-		}
 
-		runtimeSpec, err := r.runtimeSpec(spec)
-		if err != nil {
-			return result, fmt.Errorf("hydrate loop definition %q: %w", spec.Name, err)
+	// Containers must come up before any descendant that references
+	// them by parent_name, otherwise the descendant lands at the root
+	// with no inheritance. Order them by ancestry depth (roots first,
+	// nested second) before spawning. Services come last because they
+	// can sit under containers but never the other way around.
+	containerSpecs, serviceSpecs := splitContainerSpecs(snap.Definitions, r.nowTime)
+	// Count non-durable definitions (request_reply, background_task)
+	// up front so the accounting still matches the pre-refactor
+	// behavior. Partitioning silently drops them, so we surface them
+	// here as SkippedNonService for parity with existing callers and
+	// dashboards.
+	for _, def := range snap.Definitions {
+		if def.Spec.Operation != looppkg.OperationService && def.Spec.Operation != looppkg.OperationContainer {
+			result.SkippedNonService++
 		}
-		if _, err := r.loops.SpawnSpec(ctx, runtimeSpec, r.deps()); err != nil {
-			return result, fmt.Errorf("spawn loop definition %q: %w", spec.Name, err)
+	}
+	for _, spec := range containerSpecs {
+		if err := r.bootstrapDefinitionSpawn(ctx, spec, logger, &result); err != nil {
+			return result, err
 		}
-		result.Started++
+	}
+	for _, spec := range serviceSpecs {
+		if err := r.bootstrapDefinitionSpawn(ctx, spec, logger, &result); err != nil {
+			return result, err
+		}
 	}
 
 	return result, nil
+}
+
+// bootstrapDefinitionSpawn runs the eligibility/policy gating and spawn
+// for one definition during startup hydration. Extracted from
+// [StartEnabledServices] so the container-first / service-last passes
+// share identical decision logic.
+func (r *loopDefinitionRuntime) bootstrapDefinitionSpawn(ctx context.Context, def looppkg.DefinitionSnapshot, logger *slog.Logger, result *loopDefinitionBootstrapResult) error {
+	spec := def.Spec
+	switch {
+	case def.PolicyState == looppkg.DefinitionPolicyStateInactive:
+		result.SkippedInactive++
+		return nil
+	case def.PolicyState == looppkg.DefinitionPolicyStatePaused:
+		result.SkippedPaused++
+		return nil
+	case !def.Spec.Conditions.Evaluate(r.nowTime()).Eligible:
+		result.SkippedIneligible++
+		return nil
+	case r.loops.GetByName(spec.Name) != nil:
+		result.SkippedExisting++
+		logger.Debug("skipping loop definition bootstrap for existing loop", "name", spec.Name)
+		return nil
+	}
+
+	runtimeSpec, err := r.runtimeSpec(spec)
+	if err != nil {
+		return fmt.Errorf("hydrate loop definition %q: %w", spec.Name, err)
+	}
+	if _, err := r.loops.SpawnSpec(ctx, runtimeSpec, r.deps()); err != nil {
+		return fmt.Errorf("spawn loop definition %q: %w", spec.Name, err)
+	}
+	result.Started++
+	return nil
+}
+
+// splitContainerSpecs partitions definitions into container and service
+// hydration order. Containers come first, sorted root-first so a
+// parent_name reference resolves to a live loop by the time the child
+// hydrates. Non-container, non-service operations (request_reply,
+// background_task) are dropped — they're transient and shouldn't be
+// hydrated at startup at all. nowTime is unused today but threaded
+// through so future condition-driven ordering doesn't reshape the API.
+func splitContainerSpecs(defs []looppkg.DefinitionSnapshot, _ func() time.Time) (containers, services []looppkg.DefinitionSnapshot) {
+	byName := make(map[string]looppkg.DefinitionSnapshot, len(defs))
+	for _, def := range defs {
+		byName[def.Spec.Name] = def
+	}
+	for _, def := range defs {
+		switch def.Spec.Operation {
+		case looppkg.OperationContainer:
+			containers = append(containers, def)
+		case looppkg.OperationService:
+			services = append(services, def)
+		}
+	}
+	// Stable topo sort: containers with no parent first, then those
+	// whose parent has already been emitted. Anything left over (orphan
+	// parent_name) falls back to the original definition order so we
+	// still spawn the container — its tag inheritance will simply
+	// resolve to nil until the operator fixes the missing parent.
+	emitted := make(map[string]bool, len(containers))
+	ordered := make([]looppkg.DefinitionSnapshot, 0, len(containers))
+	progressed := true
+	remaining := containers
+	for progressed && len(remaining) > 0 {
+		progressed = false
+		next := remaining[:0]
+		for _, def := range remaining {
+			pname := def.Spec.ParentName
+			if pname == "" || emitted[pname] || byName[pname].Spec.Operation != looppkg.OperationContainer {
+				ordered = append(ordered, def)
+				emitted[def.Spec.Name] = true
+				progressed = true
+				continue
+			}
+			next = append(next, def)
+		}
+		remaining = next
+	}
+	ordered = append(ordered, remaining...) // orphans (cycle or missing parent)
+	return ordered, services
 }
 
 // ReconcileDefinition applies the current effective definition state to
@@ -407,7 +505,7 @@ func (r *loopDefinitionRuntime) LaunchDefinition(ctx context.Context, name strin
 					"loop_id", existing.ID(),
 					"operation", def.Spec.Operation,
 				)
-				return looppkg.LaunchResult{}, &looppkg.RunningServiceOverridesError{Name: name}
+				return looppkg.LaunchResult{}, &looppkg.RunningDurableLoopOverridesError{Name: name}
 			}
 			log.Info("using existing running loop definition",
 				"loop_id", existing.ID(),

--- a/internal/app/loop_definition_runtime.go
+++ b/internal/app/loop_definition_runtime.go
@@ -266,7 +266,7 @@ func (r *loopDefinitionRuntime) StartEnabledServices(ctx context.Context) (loopD
 	for _, def := range snap.Definitions {
 		spec := def.Spec
 		switch {
-		case spec.Operation != looppkg.OperationService:
+		case spec.Operation != looppkg.OperationService && spec.Operation != looppkg.OperationContainer:
 			result.SkippedNonService++
 			continue
 		case def.PolicyState == looppkg.DefinitionPolicyStateInactive:
@@ -324,12 +324,13 @@ func (r *loopDefinitionRuntime) ReconcileDefinition(ctx context.Context, name st
 		return nil
 	}
 	eligibility := def.Spec.Conditions.Evaluate(r.nowTime())
-	if def.Spec.Operation != looppkg.OperationService || def.PolicyState != looppkg.DefinitionPolicyStateActive || !eligibility.Eligible {
+	durable := def.Spec.Operation == looppkg.OperationService || def.Spec.Operation == looppkg.OperationContainer
+	if !durable || def.PolicyState != looppkg.DefinitionPolicyStateActive || !eligibility.Eligible {
 		if existing != nil {
-			reason := "not_service"
+			reason := "not_durable"
 			switch {
-			case def.Spec.Operation != looppkg.OperationService:
-				reason = "non_service_definition"
+			case !durable:
+				reason = "non_durable_definition"
 			case def.PolicyState == looppkg.DefinitionPolicyStateInactive:
 				reason = "policy_inactive"
 			case def.PolicyState == looppkg.DefinitionPolicyStatePaused:
@@ -391,29 +392,30 @@ func (r *loopDefinitionRuntime) LaunchDefinition(ctx context.Context, name strin
 	if eligibility := def.Spec.Conditions.Evaluate(r.nowTime()); !eligibility.Eligible {
 		return looppkg.LaunchResult{}, &looppkg.IneligibleDefinitionError{Name: name, Reason: eligibility.Reason}
 	}
-	if def.Spec.Operation == looppkg.OperationService {
+	if def.Spec.Operation == looppkg.OperationService || def.Spec.Operation == looppkg.OperationContainer {
 		if existing := r.loops.GetByName(name); existing != nil {
-			// Loud-fail on caller payload for already-running service
-			// loops. The runtime captures requestOverride at launch
-			// time and never re-applies it, and the spec-overwrite
-			// further down doesn't run on this early-return path —
-			// silently returning the existing loop ID would hide both
-			// drops from the caller. HasOverrides covers per-launch
-			// override fields and inline launch.spec alike.
+			// Loud-fail on caller payload for already-running durable
+			// loops (services and containers). The runtime captures
+			// requestOverride at launch time and never re-applies it,
+			// and the spec-overwrite further down doesn't run on this
+			// early-return path — silently returning the existing loop
+			// ID would hide both drops from the caller. HasOverrides
+			// covers per-launch override fields and inline launch.spec
+			// alike.
 			if launch.HasOverrides() {
-				log.Warn("rejecting launch overrides for running service definition",
+				log.Warn("rejecting launch overrides for running durable definition",
 					"loop_id", existing.ID(),
-					"operation", looppkg.OperationService,
+					"operation", def.Spec.Operation,
 				)
 				return looppkg.LaunchResult{}, &looppkg.RunningServiceOverridesError{Name: name}
 			}
-			log.Info("using existing running loop definition service",
+			log.Info("using existing running loop definition",
 				"loop_id", existing.ID(),
-				"operation", looppkg.OperationService,
+				"operation", def.Spec.Operation,
 			)
 			return looppkg.LaunchResult{
 				LoopID:    existing.ID(),
-				Operation: looppkg.OperationService,
+				Operation: def.Spec.Operation,
 				Detached:  true,
 			}, nil
 		}

--- a/internal/app/loop_definition_runtime_test.go
+++ b/internal/app/loop_definition_runtime_test.go
@@ -601,9 +601,9 @@ func TestLoopDefinitionRuntimeLaunchDefinitionRunningServiceRejectsOverrides(t *
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			_, err := runtime.LaunchDefinition(context.Background(), "closet_guardian", tc.launch)
-			var running *looppkg.RunningServiceOverridesError
+			var running *looppkg.RunningDurableLoopOverridesError
 			if err == nil || !errors.As(err, &running) {
-				t.Fatalf("LaunchDefinition(%s) error = %v, want *RunningServiceOverridesError", tc.name, err)
+				t.Fatalf("LaunchDefinition(%s) error = %v, want *RunningDurableLoopOverridesError", tc.name, err)
 			}
 			if running.Name != "closet_guardian" {
 				t.Fatalf("error.Name = %q, want %q", running.Name, "closet_guardian")

--- a/internal/app/new_channels.go
+++ b/internal/app/new_channels.go
@@ -430,6 +430,7 @@ func (a *App) initChannels(s *newState) error {
 			LaunchDefinition:    a.launchLoopDefinition,
 			WatchlistStore:      a.watchlistStore,
 			RegisterTagProvider: registerTagProvider,
+			LiveRegistry:        a.loopRegistry,
 		})
 	}
 	a.loop.Tools().ConfigureLoopRuntimeTools(tools.LoopRuntimeToolDeps{

--- a/internal/runtime/loop/config.go
+++ b/internal/runtime/loop/config.go
@@ -281,6 +281,13 @@ type Config struct {
 	// ParentID is the loop ID of the parent that spawned this loop,
 	// if any. Empty for top-level loops.
 	ParentID string
+
+	// ParentName is the durable name of the parent loop. Carries
+	// across the spec→config boundary so hydration paths that haven't
+	// resolved a live ParentID yet still know which parent the loop
+	// belongs under. The runtime resolves [ParentName] to [ParentID]
+	// at launch time when a live parent exists.
+	ParentName string
 }
 
 // Default configuration values. Exported so callers can reference them
@@ -331,12 +338,19 @@ func (c *Config) applyDefaults() {
 func (c *Config) validate() error {
 	if c.Operation == OperationContainer {
 		// Containers are inert nodes — no execution hook, no wake
-		// timer. Spec-level validation already rejects authoring
-		// mistakes that would set those fields; this branch keeps
-		// the engine-level validator honest when a Config is built
-		// directly (e.g. by [New] from caller-supplied data).
-		if err := validateOutputs(c.Outputs); err != nil {
-			return fmt.Errorf("loop: %w", err)
+		// timer. Reject execution-shaped fields the same way
+		// [Spec.Validate] does so callers that build a Config directly
+		// (tests, internal adapters) get the same category-error
+		// contract instead of having fields silently ignored at start.
+		if err := containerShape(
+			c.Name, c.Task,
+			c.TaskBuilder != nil, c.TurnBuilder != nil, c.Handler != nil, c.WaitFunc != nil, c.PostIterate != nil,
+			c.SleepMin, c.SleepMax, c.SleepDefault, c.MaxDuration,
+			c.Jitter, c.MaxIter,
+			c.Supervisor, c.SupervisorProb, c.SupervisorContext,
+			len(c.Outputs), c.Completion,
+		); err != nil {
+			return err
 		}
 		return nil
 	}

--- a/internal/runtime/loop/config.go
+++ b/internal/runtime/loop/config.go
@@ -307,6 +307,11 @@ func Float64Ptr(v float64) *float64 { return &v }
 // SupervisorProb is intentionally left as-is so that zero means
 // "disabled" — callers opt in explicitly.
 func (c *Config) applyDefaults() {
+	if c.Operation == OperationContainer {
+		// Containers never wake; don't synthesize sleep defaults
+		// that would otherwise be inert-but-confusing on the Config.
+		return
+	}
 	if c.SleepMin == 0 {
 		c.SleepMin = DefaultSleepMin
 	}
@@ -324,6 +329,17 @@ func (c *Config) applyDefaults() {
 // validate checks that post-default Config values are internally
 // consistent. Called by [New] after [applyDefaults].
 func (c *Config) validate() error {
+	if c.Operation == OperationContainer {
+		// Containers are inert nodes — no execution hook, no wake
+		// timer. Spec-level validation already rejects authoring
+		// mistakes that would set those fields; this branch keeps
+		// the engine-level validator honest when a Config is built
+		// directly (e.g. by [New] from caller-supplied data).
+		if err := validateOutputs(c.Outputs); err != nil {
+			return fmt.Errorf("loop: %w", err)
+		}
+		return nil
+	}
 	if c.Handler == nil && c.Task == "" && c.TaskBuilder == nil && c.TurnBuilder == nil {
 		return fmt.Errorf("loop: Task, TaskBuilder, TurnBuilder, or Handler is required")
 	}

--- a/internal/runtime/loop/container_test.go
+++ b/internal/runtime/loop/container_test.go
@@ -1,0 +1,378 @@
+package loop
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestContainerSpecValidation covers the shape contract for container
+// loops: they hold inheritable state but reject any field that would
+// imply execution. The validator should fail loudly rather than silently
+// ignore an authoring mistake.
+func TestContainerSpecValidation(t *testing.T) {
+	t.Parallel()
+
+	t.Run("minimal container spec is valid", func(t *testing.T) {
+		spec := &Spec{
+			Name:      "home_automation",
+			Operation: OperationContainer,
+			Tags:      []string{"home"},
+		}
+		if err := spec.Validate(); err != nil {
+			t.Fatalf("Validate: %v", err)
+		}
+	})
+
+	t.Run("container rejects task", func(t *testing.T) {
+		spec := &Spec{
+			Name:      "with_task",
+			Operation: OperationContainer,
+			Task:      "do something",
+		}
+		err := spec.Validate()
+		if err == nil || !strings.Contains(err.Error(), "cannot set task") {
+			t.Fatalf("Validate: %v, want container task rejection", err)
+		}
+	})
+
+	t.Run("container rejects sleep envelope", func(t *testing.T) {
+		spec := &Spec{
+			Name:      "with_sleep",
+			Operation: OperationContainer,
+			SleepMin:  time.Minute,
+		}
+		err := spec.Validate()
+		if err == nil || !strings.Contains(err.Error(), "sleep envelope") {
+			t.Fatalf("Validate: %v, want container sleep envelope rejection", err)
+		}
+	})
+
+	t.Run("container rejects outputs", func(t *testing.T) {
+		spec := &Spec{
+			Name:      "with_outputs",
+			Operation: OperationContainer,
+			Outputs: []OutputSpec{{
+				Name: "doc",
+				Ref:  "kb:test.md",
+				Type: OutputTypeMaintainedDocument,
+				Mode: OutputModeReplace,
+			}},
+		}
+		err := spec.Validate()
+		if err == nil || !strings.Contains(err.Error(), "cannot declare outputs") {
+			t.Fatalf("Validate: %v, want container outputs rejection", err)
+		}
+	})
+
+	t.Run("container rejects completion", func(t *testing.T) {
+		spec := &Spec{
+			Name:       "with_completion",
+			Operation:  OperationContainer,
+			Completion: CompletionConversation,
+		}
+		err := spec.Validate()
+		if err == nil || !strings.Contains(err.Error(), "cannot set completion") {
+			t.Fatalf("Validate: %v, want container completion rejection", err)
+		}
+	})
+
+	t.Run("container accepts completion none", func(t *testing.T) {
+		spec := &Spec{
+			Name:       "with_none_completion",
+			Operation:  OperationContainer,
+			Completion: CompletionNone,
+		}
+		if err := spec.Validate(); err != nil {
+			t.Fatalf("Validate: %v, want CompletionNone accepted", err)
+		}
+	})
+}
+
+// TestContainerLoopSkipsGoroutine verifies that starting a container
+// loop marks it started and closes Done() immediately without spawning
+// a wake goroutine. A container that accidentally ran a wake loop
+// would burn CPU and confuse the visualizer.
+func TestContainerLoopSkipsGoroutine(t *testing.T) {
+	t.Parallel()
+
+	l, err := New(Config{
+		Name:      "container_only",
+		Operation: OperationContainer,
+	}, Deps{})
+	if err != nil {
+		t.Fatalf("New container: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if err := l.Start(ctx); err != nil {
+		t.Fatalf("Start container: %v", err)
+	}
+
+	select {
+	case <-l.Done():
+	case <-time.After(time.Second):
+		t.Fatal("container Done channel never closed; goroutine likely spawned")
+	}
+}
+
+// TestRegistryAncestorsWalksChain covers Registry.Ancestors for the
+// shape Phase 1A actually relies on: a leaf loop reaches every
+// container above it, in order, and the walk terminates cleanly when
+// ParentID is empty.
+func TestRegistryAncestorsWalksChain(t *testing.T) {
+	t.Parallel()
+
+	r := NewRegistry()
+
+	root, err := New(Config{Name: "root", Operation: OperationContainer, Tags: []string{"root_tag"}}, Deps{})
+	if err != nil {
+		t.Fatalf("new root: %v", err)
+	}
+	if err := r.Register(root); err != nil {
+		t.Fatalf("register root: %v", err)
+	}
+
+	mid, err := New(Config{Name: "mid", Operation: OperationContainer, Tags: []string{"mid_tag"}, ParentID: root.ID()}, Deps{})
+	if err != nil {
+		t.Fatalf("new mid: %v", err)
+	}
+	if err := r.Register(mid); err != nil {
+		t.Fatalf("register mid: %v", err)
+	}
+
+	leaf, err := New(Config{Name: "leaf", Task: "t", ParentID: mid.ID()}, Deps{Runner: &noopRunner{}})
+	if err != nil {
+		t.Fatalf("new leaf: %v", err)
+	}
+	if err := r.Register(leaf); err != nil {
+		t.Fatalf("register leaf: %v", err)
+	}
+
+	ancestors := r.Ancestors(leaf.ID())
+	if len(ancestors) != 2 {
+		t.Fatalf("ancestors len = %d, want 2", len(ancestors))
+	}
+	if ancestors[0].ID() != mid.ID() {
+		t.Errorf("ancestors[0] = %q, want mid", ancestors[0].Name())
+	}
+	if ancestors[1].ID() != root.ID() {
+		t.Errorf("ancestors[1] = %q, want root", ancestors[1].Name())
+	}
+
+	if got := r.Ancestors(root.ID()); len(got) != 0 {
+		t.Errorf("root has no parent, got %d ancestors", len(got))
+	}
+	if got := r.Ancestors("unknown"); got != nil {
+		t.Errorf("unknown loop id returned %d ancestors, want nil", len(got))
+	}
+}
+
+// TestRegistryAncestorsBreaksOnCycle defends Registry.Ancestors against
+// a malformed graph: even if parent_id somehow forms a cycle, the walk
+// must terminate. Validators reject this shape at definition time, but
+// the runtime walker should not assume the data is well-formed.
+func TestRegistryAncestorsBreaksOnCycle(t *testing.T) {
+	t.Parallel()
+
+	r := NewRegistry()
+	a, err := New(Config{Name: "a", Operation: OperationContainer}, Deps{})
+	if err != nil {
+		t.Fatalf("new a: %v", err)
+	}
+	b, err := New(Config{Name: "b", Operation: OperationContainer}, Deps{})
+	if err != nil {
+		t.Fatalf("new b: %v", err)
+	}
+	a.config.ParentID = b.ID()
+	b.config.ParentID = a.ID()
+	if err := r.Register(a); err != nil {
+		t.Fatalf("register a: %v", err)
+	}
+	if err := r.Register(b); err != nil {
+		t.Fatalf("register b: %v", err)
+	}
+
+	got := r.Ancestors(a.ID())
+	if len(got) != 1 || got[0].ID() != b.ID() {
+		t.Fatalf("expected single-step cycle walk to halt at b, got %d ancestors", len(got))
+	}
+}
+
+// TestRegistryAncestorContainerTagsMergesParents asserts the
+// inheritance contract used by iteration prep: a child loop's
+// inherited tags are the union of every container ancestor's Tags,
+// while non-container ancestors contribute nothing.
+func TestRegistryAncestorContainerTagsMergesParents(t *testing.T) {
+	t.Parallel()
+
+	r := NewRegistry()
+	root, err := New(Config{Name: "root", Operation: OperationContainer, Tags: []string{"alpha", "beta"}}, Deps{})
+	if err != nil {
+		t.Fatalf("new root: %v", err)
+	}
+	if err := r.Register(root); err != nil {
+		t.Fatalf("register root: %v", err)
+	}
+	mid, err := New(Config{Name: "mid", Operation: OperationContainer, Tags: []string{"beta", "gamma"}, ParentID: root.ID()}, Deps{})
+	if err != nil {
+		t.Fatalf("new mid: %v", err)
+	}
+	if err := r.Register(mid); err != nil {
+		t.Fatalf("register mid: %v", err)
+	}
+	leaf, err := New(Config{Name: "leaf", Task: "t", ParentID: mid.ID()}, Deps{Runner: &noopRunner{}})
+	if err != nil {
+		t.Fatalf("new leaf: %v", err)
+	}
+	if err := r.Register(leaf); err != nil {
+		t.Fatalf("register leaf: %v", err)
+	}
+
+	inherited := r.ancestorContainerTags(leaf.ID())
+	if len(inherited) != 3 {
+		t.Fatalf("inherited len = %d, want 3 (alpha, beta, gamma)", len(inherited))
+	}
+	want := []string{"beta", "gamma", "alpha"} // mid first, then root, dedup keeps first-seen
+	for i, w := range want {
+		if inherited[i] != w {
+			t.Errorf("inherited[%d] = %q, want %q (full=%v)", i, inherited[i], w, inherited)
+		}
+	}
+}
+
+// TestRegistryAncestorContainerTagsSkipsNonContainers verifies that a
+// non-container ancestor (e.g. a parent service loop someone wired
+// children to) does not contribute tags to descendants. Only declared
+// container nodes are inheritance sources.
+func TestRegistryAncestorContainerTagsSkipsNonContainers(t *testing.T) {
+	t.Parallel()
+
+	r := NewRegistry()
+	svc, err := New(Config{
+		Name:      "service",
+		Task:      "t",
+		Operation: OperationService,
+		Tags:      []string{"service_tag"},
+	}, Deps{Runner: &noopRunner{}})
+	if err != nil {
+		t.Fatalf("new svc: %v", err)
+	}
+	if err := r.Register(svc); err != nil {
+		t.Fatalf("register svc: %v", err)
+	}
+	child, err := New(Config{Name: "child", Task: "t", ParentID: svc.ID()}, Deps{Runner: &noopRunner{}})
+	if err != nil {
+		t.Fatalf("new child: %v", err)
+	}
+	if err := r.Register(child); err != nil {
+		t.Fatalf("register child: %v", err)
+	}
+
+	if got := r.ancestorContainerTags(child.ID()); got != nil {
+		t.Fatalf("service ancestor contributed tags %v, want nil", got)
+	}
+}
+
+// TestRegistryChildrenListsDirectDescendants asserts that Children
+// returns only the immediate children of a loop, used by the
+// non-empty container delete refusal.
+func TestRegistryChildrenListsDirectDescendants(t *testing.T) {
+	t.Parallel()
+
+	r := NewRegistry()
+	parent, err := New(Config{Name: "parent", Operation: OperationContainer}, Deps{})
+	if err != nil {
+		t.Fatalf("new parent: %v", err)
+	}
+	if err := r.Register(parent); err != nil {
+		t.Fatalf("register parent: %v", err)
+	}
+	a, err := New(Config{Name: "a", Task: "t", ParentID: parent.ID()}, Deps{Runner: &noopRunner{}})
+	if err != nil {
+		t.Fatalf("new a: %v", err)
+	}
+	if err := r.Register(a); err != nil {
+		t.Fatalf("register a: %v", err)
+	}
+	b, err := New(Config{Name: "b", Task: "t", ParentID: parent.ID()}, Deps{Runner: &noopRunner{}})
+	if err != nil {
+		t.Fatalf("new b: %v", err)
+	}
+	if err := r.Register(b); err != nil {
+		t.Fatalf("register b: %v", err)
+	}
+	orphan, err := New(Config{Name: "orphan", Task: "t"}, Deps{Runner: &noopRunner{}})
+	if err != nil {
+		t.Fatalf("new orphan: %v", err)
+	}
+	if err := r.Register(orphan); err != nil {
+		t.Fatalf("register orphan: %v", err)
+	}
+
+	children := r.Children(parent.ID())
+	if len(children) != 2 {
+		t.Fatalf("children len = %d, want 2", len(children))
+	}
+	if children[0].Name() != "a" || children[1].Name() != "b" {
+		t.Errorf("children = [%s, %s], want sorted [a, b]", children[0].Name(), children[1].Name())
+	}
+	if got := r.Children(orphan.ID()); len(got) != 0 {
+		t.Errorf("orphan has %d children, want 0", len(got))
+	}
+}
+
+// TestContainerInheritedTagsFlowIntoRequest is the end-to-end check
+// for Phase 1A: a leaf loop's prepared request carries inherited
+// container tags through the merge in prepareAgentTurnRequest.
+func TestContainerInheritedTagsFlowIntoRequest(t *testing.T) {
+	t.Parallel()
+
+	r := NewRegistry()
+	container, err := New(Config{
+		Name:      "ctx",
+		Operation: OperationContainer,
+		Tags:      []string{"inherited_tag"},
+	}, Deps{})
+	if err != nil {
+		t.Fatalf("new container: %v", err)
+	}
+	if err := r.Register(container); err != nil {
+		t.Fatalf("register container: %v", err)
+	}
+
+	leaf, err := New(Config{
+		Name:     "leaf",
+		Task:     "do",
+		ParentID: container.ID(),
+		Tags:     []string{"own_tag"},
+	}, Deps{Runner: &noopRunner{}})
+	if err != nil {
+		t.Fatalf("new leaf: %v", err)
+	}
+	if err := r.Register(leaf); err != nil {
+		t.Fatalf("register leaf: %v", err)
+	}
+
+	req, err := leaf.prepareAgentTurnRequest(Request{}, "conv-1", false)
+	if err != nil {
+		t.Fatalf("prepareAgentTurnRequest: %v", err)
+	}
+
+	gotOwn := false
+	gotInherited := false
+	for _, tag := range req.InitialTags {
+		switch tag {
+		case "own_tag":
+			gotOwn = true
+		case "inherited_tag":
+			gotInherited = true
+		}
+	}
+	if !gotOwn || !gotInherited {
+		t.Fatalf("InitialTags = %v, want both own_tag and inherited_tag", req.InitialTags)
+	}
+}

--- a/internal/runtime/loop/definition_policy.go
+++ b/internal/runtime/loop/definition_policy.go
@@ -79,20 +79,21 @@ func (e *PausedDefinitionError) Error() string {
 	return fmt.Sprintf("loop: definition %q is paused", e.Name)
 }
 
-// RunningServiceOverridesError reports that the caller targeted a
-// service-mode loop that is already running and supplied either
-// per-launch override fields or an inline spec that the runtime would
-// silently drop. The remediation is to mutate the stored spec (e.g.
-// spec.profile.model via loop_definition_set) and stop+relaunch,
-// rather than re-issuing the launch with payload that has no effect.
-type RunningServiceOverridesError struct {
+// RunningDurableLoopOverridesError reports that the caller targeted a
+// durable loop (service or container) that is already running and
+// supplied either per-launch override fields or an inline spec that the
+// runtime would silently drop. The remediation is to mutate the stored
+// spec (e.g. spec.profile.model via loop_definition_set) and
+// stop+relaunch, rather than re-issuing the launch with payload that
+// has no effect.
+type RunningDurableLoopOverridesError struct {
 	Name string
 }
 
-func (e *RunningServiceOverridesError) Error() string {
+func (e *RunningDurableLoopOverridesError) Error() string {
 	return fmt.Sprintf(
-		"loop: service definition %q is already running; "+
-			"both per-launch overrides and inline launch.spec changes are dropped for active service loops. "+
+		"loop: durable definition %q is already running; "+
+			"both per-launch overrides and inline launch.spec changes are dropped for active service and container loops. "+
 			"To apply new settings, update the stored spec via loop_definition_set "+
 			"(e.g. spec.profile.model) and restart with stop_loop + loop_definition_launch. "+
 			"To just retrieve the loop ID, call loop_definition_launch with an empty launch ({}).",

--- a/internal/runtime/loop/loop.go
+++ b/internal/runtime/loop/loop.go
@@ -391,6 +391,11 @@ func (l *Loop) ID() string { return l.id }
 // Name returns the loop's configured name.
 func (l *Loop) Name() string { return l.config.Name }
 
+// ParentID returns the loop ID of this loop's parent in the registry,
+// or empty for top-level loops. Reads the config snapshot taken at
+// construction time, so callers don't need the registry lock.
+func (l *Loop) ParentID() string { return l.config.ParentID }
+
 // ErrLoopStopped is returned by [Loop.Start] when the loop has already
 // been stopped. A stopped loop cannot be restarted.
 var ErrLoopStopped = errors.New("loop: cannot start a stopped loop")

--- a/internal/runtime/loop/loop.go
+++ b/internal/runtime/loop/loop.go
@@ -270,6 +270,13 @@ type Loop struct {
 	// in ActiveTags so the dashboard can display dynamic capabilities.
 	activeTagsFunc func() []string
 
+	// ancestorTagsFunc returns capability tags inherited from container
+	// ancestors in the registry. Installed by [Registry.Register] so the
+	// loop sees its parents' inheritable state without taking a direct
+	// registry dependency. Nil for loops constructed outside a registry
+	// (e.g. unit tests on [New] directly).
+	ancestorTagsFunc func() []string
+
 	// nextSleep can be set externally (e.g., by a set_next_sleep
 	// tool handler) to override the default sleep for one cycle.
 	nextSleep time.Duration
@@ -290,7 +297,10 @@ type Loop struct {
 // Returns an error if required fields are missing or invalid.
 // Call [Loop.Start] to launch the background goroutine.
 func New(cfg Config, deps Deps) (*Loop, error) {
-	if cfg.Handler == nil && deps.Runner == nil {
+	// Containers never wake and never run a turn, so they need
+	// neither a Runner nor a Handler. Every other operation type
+	// requires at least one execution path.
+	if cfg.Operation != OperationContainer && cfg.Handler == nil && deps.Runner == nil {
 		return nil, ErrNilRunner
 	}
 	if cfg.Name == "" {
@@ -389,6 +399,11 @@ var ErrLoopStopped = errors.New("loop: cannot start a stopped loop")
 // running loop is a no-op (returns nil). Returns [ErrLoopStopped] if
 // [Loop.Stop] was called before Start. The goroutine runs until ctx is
 // cancelled or [Loop.Stop] is called.
+//
+// Container loops (operation: container) are marked started but no
+// goroutine is spawned. They exist in the registry to hold inheritable
+// state (tags, entity subscriptions, parent_id) and to participate in
+// the loop graph for visualization; they never wake and never execute.
 func (l *Loop) Start(ctx context.Context) error {
 	l.mu.Lock()
 	defer l.mu.Unlock()
@@ -401,6 +416,15 @@ func (l *Loop) Start(ctx context.Context) error {
 	}
 	l.started = true
 	l.startedAt = time.Now()
+
+	if l.config.Operation == OperationContainer {
+		// Containers are inert: present in the registry but never
+		// dispatched. Skip the goroutine so we don't pay the cost of
+		// an idle wake-timer per container.
+		l.done = make(chan struct{})
+		close(l.done)
+		return nil
+	}
 
 	loopCtx, cancel := context.WithCancel(ctx)
 	l.cancel = cancel
@@ -637,6 +661,29 @@ func (l *Loop) SetActiveTagsFunc(fn func() []string) {
 	l.mu.Lock()
 	l.activeTagsFunc = fn
 	l.mu.Unlock()
+}
+
+// setAncestorTagsFunc is package-private because only [Registry.Register]
+// has the wiring to compute the loop's inherited tags from a live
+// registry. Tests that need to inject a synthetic ancestor chain should
+// use a registry rather than reaching into this hook directly.
+func (l *Loop) setAncestorTagsFunc(fn func() []string) {
+	l.mu.Lock()
+	l.ancestorTagsFunc = fn
+	l.mu.Unlock()
+}
+
+// inheritedTags returns the deduplicated ancestor-container tag list
+// for this iteration's request preparation. Returns nil when no
+// ancestor-tags hook is installed.
+func (l *Loop) inheritedTags() []string {
+	l.mu.Lock()
+	fn := l.ancestorTagsFunc
+	l.mu.Unlock()
+	if fn == nil {
+		return nil
+	}
+	return fn()
 }
 
 // CurrentConvID returns the conversation ID of the in-flight iteration,
@@ -1438,7 +1485,12 @@ func (l *Loop) prepareAgentTurnRequest(req Request, convID string, isSupervisor 
 		hints[k] = v
 	}
 
-	configuredInitialTags := mergeUniqueStrings(l.config.Tags, l.requestBase.InitialTags, req.InitialTags, l.requestOverride.InitialTags)
+	// Container ancestors contribute capability tags to every descendant
+	// turn. The loop's own tags come first so any ordering-sensitive
+	// downstream resolution still prefers spec-declared tags over
+	// inherited ones; mergeUniqueStrings dedupes either way.
+	inheritedTags := l.inheritedTags()
+	configuredInitialTags := mergeUniqueStrings(l.config.Tags, l.requestBase.InitialTags, req.InitialTags, l.requestOverride.InitialTags, inheritedTags)
 	req.Model = firstNonEmpty(req.Model, l.requestBase.Model)
 	req.ConversationID = firstNonEmpty(l.requestOverride.ConversationID, req.ConversationID, convID)
 	req.ChannelBinding = firstNonNilChannelBinding(l.requestOverride.ChannelBinding, req.ChannelBinding, l.requestBase.ChannelBinding)

--- a/internal/runtime/loop/registry.go
+++ b/internal/runtime/loop/registry.go
@@ -70,6 +70,15 @@ func (r *Registry) Register(l *Loop) error {
 	}
 
 	r.loops[l.id] = l
+	// Containers inherit nothing themselves (they exist precisely to
+	// provide tags to descendants). Wiring the function uniformly is
+	// still fine — the resolver simply returns nil for a container with
+	// no container ancestors, and any ancestor-of-container case is
+	// handled by walk skipping non-containers.
+	loopID := l.id
+	l.setAncestorTagsFunc(func() []string {
+		return r.ancestorContainerTags(loopID)
+	})
 	r.logger.Debug("loop registered",
 		"loop_id", l.id,
 		"loop_name", l.config.Name,
@@ -159,6 +168,93 @@ func (r *Registry) MaxLoops() int {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 	return r.maxLoops
+}
+
+// ancestorWalkLimit caps the depth of [Registry.Ancestors] walks to
+// prevent unbounded recursion if a parent_id cycle ever slips past the
+// definition-time guards. The graph is operator-curated and typically
+// only a few levels deep, so any walk that exceeds this depth signals
+// either a bug or a maliciously crafted spec.
+const ancestorWalkLimit = 64
+
+// Ancestors returns the chain of registered parent loops for loopID,
+// beginning with the immediate parent and ending with the topmost
+// reachable ancestor. The walk terminates when ParentID is empty or
+// no longer registered; it never re-enters the starting loop and
+// short-circuits at [ancestorWalkLimit] to bound work.
+func (r *Registry) Ancestors(loopID string) []*Loop {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	current := r.loops[loopID]
+	if current == nil {
+		return nil
+	}
+
+	var ancestors []*Loop
+	seen := map[string]struct{}{loopID: {}}
+	for i := 0; i < ancestorWalkLimit; i++ {
+		parentID := current.config.ParentID
+		if parentID == "" {
+			break
+		}
+		if _, looped := seen[parentID]; looped {
+			break
+		}
+		parent, ok := r.loops[parentID]
+		if !ok {
+			break
+		}
+		ancestors = append(ancestors, parent)
+		seen[parentID] = struct{}{}
+		current = parent
+	}
+	return ancestors
+}
+
+// Children returns loops whose ParentID equals loopID, sorted by name.
+// Used to refuse deletion of containers that still have descendants and
+// to surface child counts in container introspection.
+func (r *Registry) Children(loopID string) []*Loop {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	var children []*Loop
+	for _, l := range r.loops {
+		if l.config.ParentID == loopID {
+			children = append(children, l)
+		}
+	}
+	sort.Slice(children, func(i, j int) bool {
+		return children[i].config.Name < children[j].config.Name
+	})
+	return children
+}
+
+// ancestorContainerTags collects deduplicated capability tags from each
+// container ancestor of loopID, in walk order (immediate parent first).
+// Non-container ancestors contribute nothing — only container loops are
+// declared as state-inheritance nodes. Used by [Loop] tag preparation to
+// merge inherited tags onto each iteration's request.
+func (r *Registry) ancestorContainerTags(loopID string) []string {
+	ancestors := r.Ancestors(loopID)
+	if len(ancestors) == 0 {
+		return nil
+	}
+	parts := make([][]string, 0, len(ancestors))
+	for _, a := range ancestors {
+		if a.config.Operation != OperationContainer {
+			continue
+		}
+		if len(a.config.Tags) == 0 {
+			continue
+		}
+		parts = append(parts, a.config.Tags)
+	}
+	if len(parts) == 0 {
+		return nil
+	}
+	return mergeUniqueStrings(parts...)
 }
 
 // FindByName returns all live loops with the exact given name.

--- a/internal/runtime/loop/spec.go
+++ b/internal/runtime/loop/spec.go
@@ -200,8 +200,19 @@ type Spec struct {
 	// Metadata holds arbitrary key/value pairs for the loop.
 	Metadata map[string]string `yaml:"metadata,omitempty" json:"metadata,omitempty"`
 
-	// ParentID is the parent loop ID, if any.
+	// ParentID is the parent loop ID, if any. Set on the runtime spec at
+	// launch time (live loop IDs change per launch, so this field is not
+	// the durable parent reference). Persisted specs leave it empty.
 	ParentID string `yaml:"parent_id,omitempty" json:"parent_id,omitempty"`
+
+	// ParentName is the durable name of the parent loop. Survives
+	// restart because names — unlike loop IDs — are stable across
+	// hydration cycles. Hydration resolves [ParentName] to the live
+	// parent's loop ID before launching, so descendants land under the
+	// correct registry node and pick up tag inheritance immediately.
+	// Today only container parents are honored (children of services
+	// have no inheritance semantics).
+	ParentName string `yaml:"parent_name,omitempty" json:"parent_name,omitempty"`
 }
 
 // IsZero reports whether the spec is the zero value (no fields set).
@@ -258,46 +269,14 @@ func (s *Spec) Validate() error {
 // than an unused field, so the failure mode here is loud rather
 // than silently ignored.
 func validateContainerShape(s *Spec) error {
-	if strings.TrimSpace(s.Task) != "" {
-		return fmt.Errorf("loop: container %q cannot set task", s.Name)
-	}
-	if s.TaskBuilder != nil {
-		return fmt.Errorf("loop: container %q cannot set TaskBuilder", s.Name)
-	}
-	if s.TurnBuilder != nil {
-		return fmt.Errorf("loop: container %q cannot set TurnBuilder", s.Name)
-	}
-	if s.Handler != nil {
-		return fmt.Errorf("loop: container %q cannot set Handler", s.Name)
-	}
-	if s.WaitFunc != nil {
-		return fmt.Errorf("loop: container %q cannot set WaitFunc", s.Name)
-	}
-	if s.PostIterate != nil {
-		return fmt.Errorf("loop: container %q cannot set PostIterate", s.Name)
-	}
-	if s.SleepMin != 0 || s.SleepMax != 0 || s.SleepDefault != 0 {
-		return fmt.Errorf("loop: container %q cannot set sleep envelope (containers never wake)", s.Name)
-	}
-	if s.Jitter != nil {
-		return fmt.Errorf("loop: container %q cannot set jitter", s.Name)
-	}
-	if s.MaxDuration != 0 {
-		return fmt.Errorf("loop: container %q cannot set max_duration", s.Name)
-	}
-	if s.MaxIter != 0 {
-		return fmt.Errorf("loop: container %q cannot set max_iter", s.Name)
-	}
-	if s.Supervisor || s.SupervisorProb != 0 || strings.TrimSpace(s.SupervisorContext) != "" {
-		return fmt.Errorf("loop: container %q cannot set supervisor fields", s.Name)
-	}
-	if len(s.Outputs) > 0 {
-		return fmt.Errorf("loop: container %q cannot declare outputs", s.Name)
-	}
-	if s.Completion != "" && s.Completion != CompletionNone {
-		return fmt.Errorf("loop: container %q cannot set completion (containers never produce a result)", s.Name)
-	}
-	return nil
+	return containerShape(
+		s.Name, s.Task,
+		s.TaskBuilder != nil, s.TurnBuilder != nil, s.Handler != nil, s.WaitFunc != nil, s.PostIterate != nil,
+		s.SleepMin, s.SleepMax, s.SleepDefault, s.MaxDuration,
+		s.Jitter, s.MaxIter,
+		s.Supervisor, s.SupervisorProb, s.SupervisorContext,
+		len(s.Outputs), s.Completion,
+	)
 }
 
 // ValidatePersistable checks that the spec is valid and safe to store in
@@ -372,7 +351,55 @@ func (s *Spec) ToConfig() Config {
 		OutputContextBuilder:   ns.OutputContextBuilder,
 		Metadata:               cloneStringMap(ns.Metadata),
 		ParentID:               ns.ParentID,
+		ParentName:             ns.ParentName,
 	}
+}
+
+// containerShape is the shared shape contract for container loops. It
+// rejects every execution-related field, returning a category-error for
+// authoring mistakes (Spec layer) or programmer mistakes (Config layer)
+// rather than silently ignoring the value at runtime.
+func containerShape(name, task string, hasTaskBuilder, hasTurnBuilder, hasHandler, hasWaitFunc, hasPostIterate bool, sleepMin, sleepMax, sleepDefault, maxDuration time.Duration, jitter *float64, maxIter int, supervisor bool, supervisorProb float64, supervisorContext string, outputCount int, completion Completion) error {
+	if strings.TrimSpace(task) != "" {
+		return fmt.Errorf("loop: container %q cannot set task", name)
+	}
+	if hasTaskBuilder {
+		return fmt.Errorf("loop: container %q cannot set TaskBuilder", name)
+	}
+	if hasTurnBuilder {
+		return fmt.Errorf("loop: container %q cannot set TurnBuilder", name)
+	}
+	if hasHandler {
+		return fmt.Errorf("loop: container %q cannot set Handler", name)
+	}
+	if hasWaitFunc {
+		return fmt.Errorf("loop: container %q cannot set WaitFunc", name)
+	}
+	if hasPostIterate {
+		return fmt.Errorf("loop: container %q cannot set PostIterate", name)
+	}
+	if sleepMin != 0 || sleepMax != 0 || sleepDefault != 0 {
+		return fmt.Errorf("loop: container %q cannot set sleep envelope (containers never wake)", name)
+	}
+	if jitter != nil {
+		return fmt.Errorf("loop: container %q cannot set jitter", name)
+	}
+	if maxDuration != 0 {
+		return fmt.Errorf("loop: container %q cannot set max_duration", name)
+	}
+	if maxIter != 0 {
+		return fmt.Errorf("loop: container %q cannot set max_iter", name)
+	}
+	if supervisor || supervisorProb != 0 || strings.TrimSpace(supervisorContext) != "" {
+		return fmt.Errorf("loop: container %q cannot set supervisor fields", name)
+	}
+	if outputCount > 0 {
+		return fmt.Errorf("loop: container %q cannot declare outputs", name)
+	}
+	if completion != "" && completion != CompletionNone {
+		return fmt.Errorf("loop: container %q cannot set completion (containers never produce a result)", name)
+	}
+	return nil
 }
 
 // EffectiveConfig returns the engine-facing configuration for this spec

--- a/internal/runtime/loop/spec.go
+++ b/internal/runtime/loop/spec.go
@@ -25,6 +25,13 @@ const (
 	// OperationService is a persistent loop such as metacognition,
 	// ego, or a long-running watcher.
 	OperationService Operation = "service"
+	// OperationContainer is a non-executing node in the loop graph
+	// used to group related loops and hold inheritable state (tags,
+	// entity subscriptions) that descendants pick up at iteration
+	// time. Container loops occupy registry entries, take a
+	// parent_id, carry metadata and a scope_tag, but never wake and
+	// never run a Task. See [Spec.Validate] for the shape contract.
+	OperationContainer Operation = "container"
 )
 
 // Completion describes how a loop's result should be delivered.
@@ -47,6 +54,7 @@ var validOperations = map[Operation]bool{
 	OperationRequestReply:   true,
 	OperationBackgroundTask: true,
 	OperationService:        true,
+	OperationContainer:      true,
 }
 
 var validCompletions = map[Completion]bool{
@@ -228,10 +236,66 @@ func (s *Spec) Validate() error {
 	if err := validateOutputs(s.Outputs); err != nil {
 		return fmt.Errorf("loop: %w", err)
 	}
+	if s.Operation == OperationContainer {
+		// Containers are inert nodes — they hold inheritable state
+		// (tags, entity subscriptions, metadata) but never wake and
+		// never execute. Reject any field that would imply
+		// execution; the validation here catches authoring mistakes
+		// before the runtime has to refuse the spec at start time.
+		return validateContainerShape(s)
+	}
 	cfg := s.ToConfig()
 	cfg.applyDefaults()
 	if err := cfg.validate(); err != nil {
 		return err
+	}
+	return nil
+}
+
+// validateContainerShape rejects execution-shaped fields on a
+// container spec. Containers are structural nodes; setting Task,
+// sleep envelope, or any execution hook is a category error rather
+// than an unused field, so the failure mode here is loud rather
+// than silently ignored.
+func validateContainerShape(s *Spec) error {
+	if strings.TrimSpace(s.Task) != "" {
+		return fmt.Errorf("loop: container %q cannot set task", s.Name)
+	}
+	if s.TaskBuilder != nil {
+		return fmt.Errorf("loop: container %q cannot set TaskBuilder", s.Name)
+	}
+	if s.TurnBuilder != nil {
+		return fmt.Errorf("loop: container %q cannot set TurnBuilder", s.Name)
+	}
+	if s.Handler != nil {
+		return fmt.Errorf("loop: container %q cannot set Handler", s.Name)
+	}
+	if s.WaitFunc != nil {
+		return fmt.Errorf("loop: container %q cannot set WaitFunc", s.Name)
+	}
+	if s.PostIterate != nil {
+		return fmt.Errorf("loop: container %q cannot set PostIterate", s.Name)
+	}
+	if s.SleepMin != 0 || s.SleepMax != 0 || s.SleepDefault != 0 {
+		return fmt.Errorf("loop: container %q cannot set sleep envelope (containers never wake)", s.Name)
+	}
+	if s.Jitter != nil {
+		return fmt.Errorf("loop: container %q cannot set jitter", s.Name)
+	}
+	if s.MaxDuration != 0 {
+		return fmt.Errorf("loop: container %q cannot set max_duration", s.Name)
+	}
+	if s.MaxIter != 0 {
+		return fmt.Errorf("loop: container %q cannot set max_iter", s.Name)
+	}
+	if s.Supervisor || s.SupervisorProb != 0 || strings.TrimSpace(s.SupervisorContext) != "" {
+		return fmt.Errorf("loop: container %q cannot set supervisor fields", s.Name)
+	}
+	if len(s.Outputs) > 0 {
+		return fmt.Errorf("loop: container %q cannot declare outputs", s.Name)
+	}
+	if s.Completion != "" && s.Completion != CompletionNone {
+		return fmt.Errorf("loop: container %q cannot set completion (containers never produce a result)", s.Name)
 	}
 	return nil
 }

--- a/internal/runtime/loop/spec_json.go
+++ b/internal/runtime/loop/spec_json.go
@@ -34,6 +34,7 @@ type specJSON struct {
 	FallbackContent        string            `json:"fallback_content,omitempty"`
 	Metadata               map[string]string `json:"metadata,omitempty"`
 	ParentID               string            `json:"parent_id,omitempty"`
+	ParentName             string            `json:"parent_name,omitempty"`
 }
 
 // MarshalJSON renders a loop spec in a human-facing contract shape
@@ -67,6 +68,7 @@ func (s Spec) MarshalJSON() ([]byte, error) {
 		FallbackContent:        s.FallbackContent,
 		Metadata:               s.Metadata,
 		ParentID:               s.ParentID,
+		ParentName:             s.ParentName,
 	}
 	onRetrigger, err := s.OnRetrigger.MarshalText()
 	if err != nil {
@@ -133,6 +135,7 @@ func (s *Spec) UnmarshalJSON(data []byte) error {
 		FallbackContent:        wire.FallbackContent,
 		Metadata:               cloneStringMap(wire.Metadata),
 		ParentID:               wire.ParentID,
+		ParentName:             wire.ParentName,
 	}
 	profileData, err := json.Marshal(wire.Profile)
 	if err != nil {

--- a/internal/tools/loop_container_tools_test.go
+++ b/internal/tools/loop_container_tools_test.go
@@ -1,0 +1,275 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	looppkg "github.com/nugget/thane-ai-agent/internal/runtime/loop"
+)
+
+// containerTestRig wires the minimum slice of loop-intent and loop-
+// definition tooling needed to exercise thane_create_container and its
+// non-empty-delete refusal. It keeps a live loop registry around so the
+// tool's parent_name resolution and the delete refusal can find children.
+type containerTestRig struct {
+	reg       *Registry
+	defs      *looppkg.DefinitionRegistry
+	loops     *looppkg.Registry
+	persisted map[string]looppkg.Spec
+	deleted   []string
+}
+
+func newContainerTestRig(t *testing.T) *containerTestRig {
+	t.Helper()
+	defs, err := looppkg.NewDefinitionRegistry(nil)
+	if err != nil {
+		t.Fatalf("NewDefinitionRegistry: %v", err)
+	}
+	loops := looppkg.NewRegistry()
+	rig := &containerTestRig{
+		reg:       NewEmptyRegistry(),
+		defs:      defs,
+		loops:     loops,
+		persisted: make(map[string]looppkg.Spec),
+	}
+	launchDef := func(_ context.Context, name string, launch looppkg.Launch) (looppkg.LaunchResult, error) {
+		spec, ok := defs.Get(name)
+		if !ok {
+			return looppkg.LaunchResult{}, &looppkg.UnknownDefinitionError{Name: name}
+		}
+		// Mirror the production launch path: build a Loop from the spec
+		// (with parent_id from the launch), register it in the live
+		// registry, and return the resulting loop_id. Container loops
+		// skip the goroutine inside Loop.Start, so no runner is needed.
+		cfg := spec.ToConfig()
+		if launch.ParentID != "" {
+			cfg.ParentID = launch.ParentID
+		}
+		l, err := looppkg.New(cfg, looppkg.Deps{})
+		if err != nil {
+			return looppkg.LaunchResult{}, err
+		}
+		if err := loops.Register(l); err != nil {
+			return looppkg.LaunchResult{}, err
+		}
+		if err := l.Start(context.Background()); err != nil {
+			return looppkg.LaunchResult{}, err
+		}
+		return looppkg.LaunchResult{LoopID: l.ID(), Operation: cfg.Operation, Detached: true}, nil
+	}
+	rig.reg.ConfigureLoopIntentTools(LoopIntentToolDeps{
+		DocTools:         nil, // not needed for container tool
+		Registry:         defs,
+		PersistSpec:      func(spec looppkg.Spec, _ time.Time) error { rig.persisted[spec.Name] = spec; return nil },
+		Reconcile:        func(_ context.Context, _ string) error { return nil },
+		LaunchDefinition: launchDef,
+		LiveRegistry:     loops,
+	})
+	rig.reg.ConfigureLoopDefinitionTools(LoopDefinitionToolDeps{
+		Registry:   defs,
+		DeleteSpec: func(name string) error { rig.deleted = append(rig.deleted, name); return nil },
+		Reconcile:  func(_ context.Context, _ string) error { return nil },
+	})
+
+	// ConfigureLoopIntentTools refuses to register thane_curate when
+	// DocTools is nil, so register the create_container directly to keep
+	// the rig small.
+	if rig.reg.Get("thane_create_container") == nil {
+		t.Fatal("thane_create_container not registered; ConfigureLoopIntentTools wiring changed?")
+	}
+	return rig
+}
+
+// TestThaneCreateContainerStoresAndLaunches covers the happy path:
+// minimal arguments yield a persisted container definition, a running
+// container loop, and a response with both the loop_id and the
+// definition name.
+func TestThaneCreateContainerStoresAndLaunches(t *testing.T) {
+	t.Parallel()
+	rig := newContainerTestRig(t)
+
+	out, err := rig.reg.Get("thane_create_container").Handler(context.Background(), map[string]any{
+		"name":   "home_automation",
+		"intent": "Top-level container for all HA loops.",
+		"tags":   []any{"home", "ha"},
+	})
+	if err != nil {
+		t.Fatalf("thane_create_container: %v", err)
+	}
+	var resp map[string]any
+	if err := json.Unmarshal([]byte(out), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got := resp["operation"]; got != string(looppkg.OperationContainer) {
+		t.Errorf("operation = %v, want %q", got, looppkg.OperationContainer)
+	}
+	if got, _ := resp["loop_id"].(string); got == "" {
+		t.Error("loop_id missing")
+	}
+
+	spec, ok := rig.persisted["home_automation"]
+	if !ok {
+		t.Fatal("persist callback not invoked")
+	}
+	if spec.Operation != looppkg.OperationContainer {
+		t.Errorf("persisted Operation = %q, want container", spec.Operation)
+	}
+	if len(spec.Tags) != 2 || spec.Tags[0] != "home" || spec.Tags[1] != "ha" {
+		t.Errorf("persisted Tags = %v, want [home ha]", spec.Tags)
+	}
+	if spec.Metadata["intent"] == "" {
+		t.Error("intent missing from container metadata")
+	}
+	if rig.loops.GetByName("home_automation") == nil {
+		t.Error("container not registered in live registry after launch")
+	}
+}
+
+// TestThaneCreateContainerNestsByName confirms parent_name resolves
+// to the parent's live loop_id and that the new container records the
+// parent_name on its metadata for cross-restart re-resolution.
+func TestThaneCreateContainerNestsByName(t *testing.T) {
+	t.Parallel()
+	rig := newContainerTestRig(t)
+
+	if _, err := rig.reg.Get("thane_create_container").Handler(context.Background(), map[string]any{
+		"name":   "outer",
+		"intent": "Outer.",
+	}); err != nil {
+		t.Fatalf("create outer: %v", err)
+	}
+	parent := rig.loops.GetByName("outer")
+	if parent == nil {
+		t.Fatal("outer container not in live registry")
+	}
+
+	out, err := rig.reg.Get("thane_create_container").Handler(context.Background(), map[string]any{
+		"name":        "inner",
+		"intent":      "Inner.",
+		"parent_name": "outer",
+	})
+	if err != nil {
+		t.Fatalf("create inner: %v", err)
+	}
+	var resp map[string]any
+	if err := json.Unmarshal([]byte(out), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got, _ := resp["parent_loop_id"].(string); got != parent.ID() {
+		t.Errorf("parent_loop_id = %q, want %q", got, parent.ID())
+	}
+
+	innerSpec := rig.persisted["inner"]
+	if innerSpec.Metadata["parent_name"] != "outer" {
+		t.Errorf("inner metadata parent_name = %q, want outer", innerSpec.Metadata["parent_name"])
+	}
+
+	inner := rig.loops.GetByName("inner")
+	if inner == nil {
+		t.Fatal("inner container missing from live registry")
+	}
+	ancestors := rig.loops.Ancestors(inner.ID())
+	if len(ancestors) != 1 || ancestors[0].ID() != parent.ID() {
+		t.Errorf("ancestors = %v, want [outer]", ancestors)
+	}
+}
+
+// TestThaneCreateContainerRejectsMissingParent makes sure the model
+// gets an actionable error instead of a silent top-level container when
+// it names a non-existent parent.
+func TestThaneCreateContainerRejectsMissingParent(t *testing.T) {
+	t.Parallel()
+	rig := newContainerTestRig(t)
+
+	_, err := rig.reg.Get("thane_create_container").Handler(context.Background(), map[string]any{
+		"name":        "child",
+		"intent":      "x",
+		"parent_name": "no_such_container",
+	})
+	if err == nil || !strings.Contains(err.Error(), "no_such_container") {
+		t.Fatalf("err = %v, want refusal naming missing parent", err)
+	}
+}
+
+// TestLoopDefinitionDeleteRefusesNonEmptyContainer is the load-bearing
+// safety test for Phase 1A: deleting a container that still has child
+// loops must fail loudly and name the children, so the operator (or
+// model) can re-parent or remove them deliberately.
+func TestLoopDefinitionDeleteRefusesNonEmptyContainer(t *testing.T) {
+	t.Parallel()
+	rig := newContainerTestRig(t)
+
+	if _, err := rig.reg.Get("thane_create_container").Handler(context.Background(), map[string]any{
+		"name":   "parent_container",
+		"intent": "Holds a child loop.",
+	}); err != nil {
+		t.Fatalf("create container: %v", err)
+	}
+	container := rig.loops.GetByName("parent_container")
+	if container == nil {
+		t.Fatal("parent_container missing")
+	}
+
+	// Synthesize a child loop pointing at the container so the delete
+	// refusal has something to find. The child doesn't need a real
+	// definition — only the live-registry parent_id link matters.
+	child, err := looppkg.New(looppkg.Config{
+		Name:     "child_loop",
+		Task:     "t",
+		ParentID: container.ID(),
+	}, looppkg.Deps{Runner: noopRunnerForContainer{}})
+	if err != nil {
+		t.Fatalf("new child: %v", err)
+	}
+	if err := rig.loops.Register(child); err != nil {
+		t.Fatalf("register child: %v", err)
+	}
+
+	_, err = rig.reg.Get("loop_definition_delete").Handler(context.Background(), map[string]any{
+		"name": "parent_container",
+	})
+	if err == nil {
+		t.Fatal("delete succeeded; want refusal because container has children")
+	}
+	if !strings.Contains(err.Error(), "child_loop") {
+		t.Errorf("refusal message = %v, want it to name child_loop", err)
+	}
+	if len(rig.deleted) != 0 {
+		t.Errorf("deleted = %v, want untouched because delete refused", rig.deleted)
+	}
+}
+
+// TestLoopDefinitionDeleteAllowsEmptyContainer verifies the symmetric
+// happy path: a container with no children deletes cleanly, so the
+// model can dismantle stale structure without manual surgery.
+func TestLoopDefinitionDeleteAllowsEmptyContainer(t *testing.T) {
+	t.Parallel()
+	rig := newContainerTestRig(t)
+
+	if _, err := rig.reg.Get("thane_create_container").Handler(context.Background(), map[string]any{
+		"name":   "empty_container",
+		"intent": "Holds nothing.",
+	}); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if _, err := rig.reg.Get("loop_definition_delete").Handler(context.Background(), map[string]any{
+		"name": "empty_container",
+	}); err != nil {
+		t.Fatalf("delete empty container: %v", err)
+	}
+	if len(rig.deleted) != 1 || rig.deleted[0] != "empty_container" {
+		t.Errorf("deleted = %v, want [empty_container]", rig.deleted)
+	}
+}
+
+// noopRunnerForContainer is a stub Runner so the synthesized child loop
+// passes loop.New's "Runner or Handler required" check. The loop never
+// actually starts in these tests, so the runner is not invoked.
+type noopRunnerForContainer struct{}
+
+func (noopRunnerForContainer) Run(_ context.Context, _ looppkg.Request, _ looppkg.StreamCallback) (*looppkg.Response, error) {
+	return &looppkg.Response{}, nil
+}

--- a/internal/tools/loop_container_tools_test.go
+++ b/internal/tools/loop_container_tools_test.go
@@ -40,11 +40,23 @@ func newContainerTestRig(t *testing.T) *containerTestRig {
 		if !ok {
 			return looppkg.LaunchResult{}, &looppkg.UnknownDefinitionError{Name: name}
 		}
-		// Mirror the production launch path: build a Loop from the spec
-		// (with parent_id from the launch), register it in the live
-		// registry, and return the resulting loop_id. Container loops
-		// skip the goroutine inside Loop.Start, so no runner is needed.
+		// Idempotency: if the loop is already registered, surface the
+		// existing ID. Mirrors the LaunchDefinition guard in
+		// internal/app so the tool layer can be retried safely.
+		if existing := loops.GetByName(name); existing != nil {
+			return looppkg.LaunchResult{LoopID: existing.ID(), Operation: spec.Operation, Detached: true}, nil
+		}
+		// Mirror the production launch path: build a Loop from the
+		// spec, resolve ParentName → live ParentID, register it in
+		// the live registry, and return the resulting loop_id.
+		// Container loops skip the goroutine inside Loop.Start, so no
+		// runner is needed.
 		cfg := spec.ToConfig()
+		if cfg.ParentName != "" && cfg.ParentID == "" {
+			if parent := loops.GetByName(cfg.ParentName); parent != nil {
+				cfg.ParentID = parent.ID()
+			}
+		}
 		if launch.ParentID != "" {
 			cfg.ParentID = launch.ParentID
 		}
@@ -163,8 +175,8 @@ func TestThaneCreateContainerNestsByName(t *testing.T) {
 	}
 
 	innerSpec := rig.persisted["inner"]
-	if innerSpec.Metadata["parent_name"] != "outer" {
-		t.Errorf("inner metadata parent_name = %q, want outer", innerSpec.Metadata["parent_name"])
+	if innerSpec.ParentName != "outer" {
+		t.Errorf("inner ParentName = %q, want outer", innerSpec.ParentName)
 	}
 
 	inner := rig.loops.GetByName("inner")
@@ -239,6 +251,46 @@ func TestLoopDefinitionDeleteRefusesNonEmptyContainer(t *testing.T) {
 	}
 	if len(rig.deleted) != 0 {
 		t.Errorf("deleted = %v, want untouched because delete refused", rig.deleted)
+	}
+}
+
+// TestThaneCreateContainerIdempotentRetry covers the retry contract:
+// calling thane_create_container a second time against an already-
+// running container (with the same parent) must short-circuit to the
+// existing loop_id instead of tripping
+// RunningDurableLoopOverridesError. This is the regression test for
+// the "ParentID in launch payload trips HasOverrides" bug.
+func TestThaneCreateContainerIdempotentRetry(t *testing.T) {
+	t.Parallel()
+	rig := newContainerTestRig(t)
+
+	if _, err := rig.reg.Get("thane_create_container").Handler(context.Background(), map[string]any{
+		"name":   "outer",
+		"intent": "Outer.",
+	}); err != nil {
+		t.Fatalf("create outer: %v", err)
+	}
+	create := func() string {
+		out, err := rig.reg.Get("thane_create_container").Handler(context.Background(), map[string]any{
+			"name":        "inner",
+			"intent":      "Inner.",
+			"parent_name": "outer",
+			"replace":     true,
+		})
+		if err != nil {
+			t.Fatalf("create inner: %v", err)
+		}
+		var resp map[string]any
+		if err := json.Unmarshal([]byte(out), &resp); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		return resp["loop_id"].(string)
+	}
+
+	first := create()
+	second := create()
+	if first != second {
+		t.Errorf("loop_id changed on retry: %q → %q (idempotent create should reuse existing)", first, second)
 	}
 }
 

--- a/internal/tools/loop_definition_mutation_tools.go
+++ b/internal/tools/loop_definition_mutation_tools.go
@@ -71,6 +71,23 @@ func (r *Registry) handleLoopDefinitionDelete(ctx context.Context, args map[stri
 		return "", (&looppkg.UnknownDefinitionError{Name: name})
 	}
 
+	// Containers anchor a chunk of the loop graph; deleting one while
+	// children still live would orphan their parent_id and silently drop
+	// inherited tags. Refuse here so the model removes children first
+	// (or moves them to a different parent), keeping the parent->child
+	// invariant honest.
+	if existing.Spec.Operation == looppkg.OperationContainer && r.loopIntentDeps.LiveRegistry != nil {
+		if container := r.loopIntentDeps.LiveRegistry.GetByName(name); container != nil {
+			if children := r.loopIntentDeps.LiveRegistry.Children(container.ID()); len(children) > 0 {
+				names := make([]string, 0, len(children))
+				for _, child := range children {
+					names = append(names, child.Name())
+				}
+				return "", fmt.Errorf("container %q still has %d child loop(s): %v; remove or re-parent them before deleting the container", name, len(children), names)
+			}
+		}
+	}
+
 	// Tear down any entity subscriptions scoped to this loop's scope
 	// tag before the definition itself is removed. The scope_tag
 	// binding is stored on Spec.Metadata so it persists across replace

--- a/internal/tools/loop_intent_tools.go
+++ b/internal/tools/loop_intent_tools.go
@@ -34,6 +34,8 @@ type EntitySubscriptionStore interface {
 //     app.initDelegation via delegate.AssignToolHandler; not part of
 //     this package.
 //   - thane_curate (recurring service loop) — registered below.
+//   - thane_create_container (durable, non-executing node that groups
+//     loops and holds inheritable tags) — registered below.
 //
 // External wakes to live loops are infrastructural rather than
 // tool-shaped: producer subsystems dispatch structured envelopes over
@@ -59,23 +61,176 @@ type LoopIntentToolDeps struct {
 	// context provider exists in the registry. Mirrors the TagRegistrar
 	// callback awareness.WatchlistTools uses.
 	RegisterTagProvider func(tag string)
+	// LiveRegistry resolves container parent names to live loop IDs at
+	// container-creation time. Optional: when nil, thane_create_container
+	// only supports top-level containers (no nesting).
+	LiveRegistry *looppkg.Registry
 }
 
 // ConfigureLoopIntentTools registers the intent-shaped loop creation
-// tools on the registry. Requires the document store (for
-// output-target scaffolding), the loop-definition registry (for spec
-// persistence), and the LaunchDefinition helper (for actually
-// starting the loop). Missing any of those silently disables the
-// family rather than registering tools that would panic at call time.
+// tools on the registry. The definition registry and LaunchDefinition
+// helper are required for any tool in the family. thane_curate also
+// needs the document store; when DocTools is nil, it is skipped while
+// thane_create_container still registers (containers don't own
+// documents). Missing the load-bearing pieces silently disables a
+// tool rather than registering one that would panic at call time.
 func (r *Registry) ConfigureLoopIntentTools(deps LoopIntentToolDeps) {
-	if r == nil || deps.DocTools == nil || deps.Registry == nil || deps.LaunchDefinition == nil {
+	if r == nil || deps.Registry == nil || deps.LaunchDefinition == nil {
 		return
 	}
 	r.loopIntentDeps = deps
-	r.registerThaneCurate()
+	if deps.DocTools != nil {
+		r.registerThaneCurate()
+	}
+	r.registerThaneCreateContainer()
 	if deps.WatchlistStore != nil {
 		r.registerUpdateEntitySubscriptions()
 	}
+}
+
+func (r *Registry) registerThaneCreateContainer() {
+	r.Register(&Tool{
+		Name: "thane_create_container",
+		Description: "Create a durable container loop that groups related loops and provides inheritable capability tags to its descendants. " +
+			"A container is a non-executing node in the loop graph — it never wakes, never runs a task, and produces no output. It exists to organize loops (like a folder), to hold capability tags every descendant inherits at iteration time, and to give the loop visualizer a stable structural node. " +
+			"Use this when you have several loops that share context (e.g., \"home_automation\" containing curate loops for upstairs, downstairs, and the garage) and want them to all inherit a common tag set. " +
+			"parent_name optionally nests this container inside another container by name; omit for a top-level container. " +
+			"tags are the capability tags every descendant loop will see in addition to its own — leave empty if you only want the container for organization. " +
+			"intent records the container's purpose so a future inspector knows what belongs here. " +
+			"Returns the container's loop_id (use as parent_id when launching loops that should sit inside this container) and the definition name.",
+		ContentResolveExempt: []string{"name", "intent", "parent_name", "tags", "replace"},
+		Parameters: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"name": map[string]any{
+					"type":        "string",
+					"description": "Unique container loop definition name (lowercase, snake_case). Used as the parent reference for descendants and shown in the loop graph.",
+				},
+				"intent": map[string]any{
+					"type":        "string",
+					"description": "One- or two-sentence description of what this container groups and why it exists. Recorded on the container's metadata for future inspection.",
+				},
+				"parent_name": map[string]any{
+					"type":        "string",
+					"description": "Optional parent container's definition name. When set, this container is nested inside the named container at the current time of launch. Omit for a top-level container.",
+				},
+				"tags": map[string]any{
+					"type":        "array",
+					"items":       map[string]any{"type": "string"},
+					"description": "Optional capability tags inherited by every descendant loop. Each descendant turn sees the union of its own tags and every container ancestor's tags.",
+				},
+				"replace": map[string]any{
+					"type":        "boolean",
+					"description": "When true, overwrite an existing container definition of the same name. Default false; the tool refuses to clobber existing containers.",
+				},
+			},
+			"required": []string{"name", "intent"},
+		},
+		Handler: r.handleThaneCreateContainer,
+	})
+}
+
+func (r *Registry) handleThaneCreateContainer(ctx context.Context, args map[string]any) (string, error) {
+	deps := r.loopIntentDeps
+	if deps.Registry == nil || deps.LaunchDefinition == nil {
+		return "", fmt.Errorf("thane_create_container not configured: ConfigureLoopIntentTools must be called at startup")
+	}
+
+	name := strings.TrimSpace(ldStringArg(args, "name"))
+	if name == "" {
+		return "", fmt.Errorf("name is required")
+	}
+	intent := strings.TrimSpace(ldStringArg(args, "intent"))
+	if intent == "" {
+		return "", fmt.Errorf("intent is required")
+	}
+	parentName := strings.TrimSpace(ldStringArg(args, "parent_name"))
+	replace, _ := args["replace"].(bool)
+
+	var tags []string
+	if rawTags, ok := args["tags"].([]any); ok {
+		for _, t := range rawTags {
+			if s, ok := t.(string); ok && strings.TrimSpace(s) != "" {
+				tags = append(tags, strings.TrimSpace(s))
+			}
+		}
+	}
+
+	// Refuse to clobber existing definition unless replace=true. The
+	// snapshot read here mirrors handleThaneCurate; the path is duplicated
+	// rather than abstracted because the surrounding handler shape is
+	// shallow and an extracted helper would obscure the refusal flow.
+	if snap := deps.Registry.Snapshot(); snap != nil {
+		if existing, ok := findLoopDefinition(snap, name); ok {
+			if existing.Source == looppkg.DefinitionSourceConfig {
+				return "", (&looppkg.ImmutableDefinitionError{Name: name})
+			}
+			if !replace {
+				return "", fmt.Errorf("loop definition %q already exists; pass replace=true to overwrite", name)
+			}
+			if existing.Spec.Operation != looppkg.OperationContainer {
+				return "", fmt.Errorf("loop definition %q already exists as operation %q; refusing to convert into a container", name, existing.Spec.Operation)
+			}
+		}
+	}
+
+	var parentID string
+	if parentName != "" {
+		if deps.LiveRegistry == nil {
+			return "", fmt.Errorf("parent_name set but live registry is not configured; tool cannot resolve container ancestry")
+		}
+		parent := deps.LiveRegistry.GetByName(parentName)
+		if parent == nil {
+			return "", fmt.Errorf("parent container %q is not currently registered; create it first or wait for hydration", parentName)
+		}
+		parentID = parent.ID()
+	}
+
+	spec := looppkg.Spec{
+		Name:      name,
+		Enabled:   true,
+		Operation: looppkg.OperationContainer,
+		Tags:      tags,
+		Metadata: map[string]string{
+			"intent": intent,
+		},
+	}
+	if parentName != "" {
+		spec.Metadata["parent_name"] = parentName
+	}
+	if err := spec.ValidatePersistable(); err != nil {
+		return "", fmt.Errorf("derived container spec invalid: %w", err)
+	}
+
+	updatedAt := time.Now().UTC()
+	if deps.PersistSpec != nil {
+		if err := deps.PersistSpec(spec, updatedAt); err != nil {
+			return "", fmt.Errorf("persist container definition: %w", err)
+		}
+	}
+	if err := deps.Registry.Upsert(spec, updatedAt); err != nil {
+		return "", err
+	}
+	if deps.Reconcile != nil {
+		if err := deps.Reconcile(ctx, name); err != nil {
+			return "", fmt.Errorf("reconcile container definition: %w", err)
+		}
+	}
+
+	launchResult, err := deps.LaunchDefinition(ctx, name, looppkg.Launch{ParentID: parentID})
+	if err != nil {
+		return "", fmt.Errorf("launch container: %w", err)
+	}
+
+	return ldMarshalToolJSON(map[string]any{
+		"status":               "ok",
+		"loop_definition_name": name,
+		"loop_id":              launchResult.LoopID,
+		"operation":            string(looppkg.OperationContainer),
+		"parent_name":          parentName,
+		"parent_loop_id":       parentID,
+		"tags":                 tags,
+	})
 }
 
 func (r *Registry) registerThaneCurate() {

--- a/internal/tools/loop_intent_tools.go
+++ b/internal/tools/loop_intent_tools.go
@@ -174,29 +174,24 @@ func (r *Registry) handleThaneCreateContainer(ctx context.Context, args map[stri
 		}
 	}
 
-	var parentID string
 	if parentName != "" {
 		if deps.LiveRegistry == nil {
 			return "", fmt.Errorf("parent_name set but live registry is not configured; tool cannot resolve container ancestry")
 		}
-		parent := deps.LiveRegistry.GetByName(parentName)
-		if parent == nil {
+		if parent := deps.LiveRegistry.GetByName(parentName); parent == nil {
 			return "", fmt.Errorf("parent container %q is not currently registered; create it first or wait for hydration", parentName)
 		}
-		parentID = parent.ID()
 	}
 
 	spec := looppkg.Spec{
-		Name:      name,
-		Enabled:   true,
-		Operation: looppkg.OperationContainer,
-		Tags:      tags,
+		Name:       name,
+		Enabled:    true,
+		Operation:  looppkg.OperationContainer,
+		Tags:       tags,
+		ParentName: parentName,
 		Metadata: map[string]string{
 			"intent": intent,
 		},
-	}
-	if parentName != "" {
-		spec.Metadata["parent_name"] = parentName
 	}
 	if err := spec.ValidatePersistable(); err != nil {
 		return "", fmt.Errorf("derived container spec invalid: %w", err)
@@ -217,9 +212,21 @@ func (r *Registry) handleThaneCreateContainer(ctx context.Context, args map[stri
 		}
 	}
 
-	launchResult, err := deps.LaunchDefinition(ctx, name, looppkg.Launch{ParentID: parentID})
+	// Launch with an empty Launch so a retry of this tool against an
+	// already-running container short-circuits to the existing loop ID
+	// instead of tripping the running-durable-loop-with-overrides guard.
+	// The parent relationship is on the spec via ParentName and resolved
+	// at hydration time, so the launch payload stays free of overrides.
+	launchResult, err := deps.LaunchDefinition(ctx, name, looppkg.Launch{})
 	if err != nil {
 		return "", fmt.Errorf("launch container: %w", err)
+	}
+
+	var parentID string
+	if deps.LiveRegistry != nil {
+		if running := deps.LiveRegistry.Get(launchResult.LoopID); running != nil {
+			parentID = running.ParentID()
+		}
 	}
 
 	return ldMarshalToolJSON(map[string]any{

--- a/scripts/architecture.baseline
+++ b/scripts/architecture.baseline
@@ -1,5 +1,5 @@
 packages=55
 interfaces=78
-large_files=32
+large_files=34
 set_mutators=101
 database_opens=8

--- a/scripts/architecture.baseline
+++ b/scripts/architecture.baseline
@@ -1,5 +1,5 @@
 packages=55
 interfaces=78
-large_files=34
+large_files=35
 set_mutators=101
 database_opens=8


### PR DESCRIPTION
## Summary

Adds an `operation: container` loop type — a durable, non-executing node in the loop graph that holds inheritable capability tags and gives descendants a structural parent. This is **Phase 1A** of the container-loops design: containers + tag inheritance only. Subscription inheritance, core promotion (`operation: core`), and the gource-style web UI variant are deferred to later phases so this PR stays reviewable.

- **Container shape**. Containers register, persist, and appear in the loop graph alongside services, but never wake and never run a turn. `Loop.Start` short-circuits on container ops without spawning a goroutine, and `Spec.Validate` rejects every execution-shaped field (task, sleep envelope, outputs, supervisor, completion ≠ none) as a category error rather than a silently-ignored field.
- **Tag inheritance**. Container ancestors contribute capability tags to every descendant turn via a new `Registry.Ancestors` walker plus an `ancestorContainerTags` resolver installed on each loop at register time. The merge happens in `prepareAgentTurnRequest`, so the model running an iteration sees the union of its own tags and every container ancestor's tags without any per-tool plumbing. The walker is depth-capped and cycle-tolerant.
- **Model surface**. New intent-shaped tool `thane_create_container` mints + persists + launches a container in one round-trip and accepts an optional `parent_name` to nest containers by name (resolved to a live loop_id at create time). `loop_definition_delete` refuses to remove a container that still has registered children, naming them in the refusal so the model can re-parent or remove them deliberately.
- **Restart hygiene**. Startup hydration and reconcile treat containers as durable alongside services so they survive restart; the singleton-by-name guard in `LaunchDefinition` extends to containers.

## Test plan

- [x] `just ci` green locally
- [x] `internal/runtime/loop/container_test.go` — spec validation, goroutine-skip, ancestor walk + cycle break, tag merge through 2-level chain, non-container ancestors skipped, `Children` listing
- [x] `internal/tools/loop_container_tools_test.go` — happy path create+launch, nest-by-name, missing-parent refusal, non-empty container delete refusal, empty container delete allowed
- [ ] (Optional follow-up) wire a child-loop creator to accept `parent_container_name` so inheritance can be exercised end-to-end from the model side