### PR TITLE
refactor: effective-vs-declared surfaces (PR-B of #889)

### DIFF
--- a/internal/app/loop_definition_runtime.go
+++ b/internal/app/loop_definition_runtime.go
@@ -138,7 +138,11 @@ func (r *loopDefinitionRuntime) Snapshot() *looppkg.DefinitionRegistryView {
 	if r == nil || r.definitions == nil {
 		return nil
 	}
-	return looppkg.BuildDefinitionRegistryView(r.definitions.Snapshot(), r.runtimeStatusByName())
+	return looppkg.BuildDefinitionRegistryView(
+		r.definitions.Snapshot(),
+		r.runtimeStatusByName(),
+		looppkg.WithLiveRegistry(r.loops),
+	)
 }
 
 func (r *loopDefinitionRuntime) nowTime() time.Time {
@@ -581,5 +585,9 @@ func (a *App) loopDefinitionView() *looppkg.DefinitionRegistryView {
 	if a.loopDefinitionRegistry == nil {
 		return nil
 	}
-	return looppkg.BuildDefinitionRegistryView(a.loopDefinitionRegistry.Snapshot(), nil)
+	return looppkg.BuildDefinitionRegistryView(
+		a.loopDefinitionRegistry.Snapshot(),
+		nil,
+		looppkg.WithLiveRegistry(a.loopRegistry),
+	)
 }

--- a/internal/runtime/loop/config.go
+++ b/internal/runtime/loop/config.go
@@ -529,6 +529,16 @@ type Status struct {
 	ActiveTags []string `json:"active_tags,omitempty"`
 	// Tooling captures the resolved loop-level tool/capability state.
 	Tooling ToolingState `json:"tooling,omitempty"`
+	// EffectiveTags is the post-ancestor-merge view of this loop's
+	// capability tags, with provenance on each entry. Computed via
+	// [Registry.EffectiveTags] when the loop is registered; nil for
+	// loops queried in isolation (tests that build a Status manually).
+	EffectiveTags []EffectiveTag `json:"effective_tags,omitempty"`
+	// EffectiveSubscriptions is the post-ancestor-merge view of this
+	// loop's entity subscriptions, with provenance on each entry.
+	// Companion to EffectiveTags; same computed-only-when-registered
+	// semantics.
+	EffectiveSubscriptions []EffectiveSubscription `json:"effective_subscriptions,omitempty"`
 	// Config is a copy of the loop's configuration.
 	Config Config `json:"config"`
 }

--- a/internal/runtime/loop/config.go
+++ b/internal/runtime/loop/config.go
@@ -531,13 +531,17 @@ type Status struct {
 	Tooling ToolingState `json:"tooling,omitempty"`
 	// EffectiveTags is the post-ancestor-merge view of this loop's
 	// capability tags, with provenance on each entry. Computed via
-	// [Registry.EffectiveTags] when the loop is registered; nil for
-	// loops queried in isolation (tests that build a Status manually).
+	// [Registry.EffectiveTags] when the loop is registered. Nil
+	// when the loop is queried in isolation (tests that build a
+	// Status manually) AND when the loop is registered but has no
+	// effective tags to report — readers can't distinguish the two
+	// from this field alone.
 	EffectiveTags []EffectiveTag `json:"effective_tags,omitempty"`
 	// EffectiveSubscriptions is the post-ancestor-merge view of this
 	// loop's entity subscriptions, with provenance on each entry.
-	// Companion to EffectiveTags; same computed-only-when-registered
-	// semantics.
+	// Companion to EffectiveTags with the same nil-conflation: nil
+	// covers both "no registry hook installed" and "registry hook
+	// installed but nothing to report."
 	EffectiveSubscriptions []EffectiveSubscription `json:"effective_subscriptions,omitempty"`
 	// Config is a copy of the loop's configuration.
 	Config Config `json:"config"`

--- a/internal/runtime/loop/definition_view.go
+++ b/internal/runtime/loop/definition_view.go
@@ -37,6 +37,27 @@ type DefinitionView struct {
 	Eligibility        DefinitionEligibilityStatus `yaml:"eligibility,omitempty" json:"eligibility"`
 	Runtime            DefinitionRuntimeStatus     `yaml:"runtime,omitempty" json:"runtime"`
 	Warnings           []DefinitionWarning         `yaml:"warnings,omitempty" json:"warnings,omitempty"`
+	// Effective surfaces the post-ancestor-merge state for inheritable
+	// loop fields. Nil for definitions whose loop isn't currently
+	// running (effective state is computed against the live registry).
+	// Sits alongside Spec rather than inside Runtime so the
+	// declared-vs-effective contrast is at the top of the view and
+	// extends naturally as more fields become inheritable.
+	Effective *DefinitionEffectiveState `yaml:"effective,omitempty" json:"effective,omitempty"`
+}
+
+// DefinitionEffectiveState is the post-ancestor-merge snapshot of
+// inheritable fields for one definition's live loop. Each entry
+// carries provenance so the reader knows which values are this
+// loop's own and which came from a container ancestor.
+type DefinitionEffectiveState struct {
+	// Tags is the deduplicated union of the loop's own Spec.Tags and
+	// every container ancestor's tags, ordered own-first.
+	Tags []EffectiveTag `yaml:"tags,omitempty" json:"tags,omitempty"`
+	// Subscriptions is the deduplicated union of the loop's own
+	// Spec.Subscriptions and every container ancestor's, first-wins
+	// on entity_id (own declarations override inherited options).
+	Subscriptions []EffectiveSubscription `yaml:"subscriptions,omitempty" json:"subscriptions,omitempty"`
 }
 
 // DefinitionRegistryView is the effective combined view of stored loop
@@ -55,16 +76,42 @@ type DefinitionRegistryView struct {
 	Definitions             []DefinitionView `yaml:"definitions,omitempty" json:"definitions,omitempty"`
 }
 
+// DefinitionViewOption tunes [BuildDefinitionRegistryView]. Used today
+// to opt into effective-state population by passing a live registry
+// via [WithLiveRegistry]; older callers that don't supply one continue
+// to get a view without the Effective field, which is the right shape
+// for surfaces that don't have access to a running loop graph.
+type DefinitionViewOption func(*definitionViewOptions)
+
+type definitionViewOptions struct {
+	loops *Registry
+}
+
+// WithLiveRegistry attaches a live loop registry to the view build so
+// each definition's running loop can be inspected for inherited tags
+// and subscriptions. Without it, [DefinitionView.Effective] stays nil
+// — a safe default for snapshots taken outside the running app (e.g.
+// CLI inspection tools or the loop_definition_lint surface).
+func WithLiveRegistry(loops *Registry) DefinitionViewOption {
+	return func(o *definitionViewOptions) {
+		o.loops = loops
+	}
+}
+
 // BuildDefinitionRegistryView combines the durable definition snapshot
 // with an optional runtime-state map to produce the effective loop
 // registry view used by API and tool read surfaces.
-func BuildDefinitionRegistryView(snapshot *DefinitionRegistrySnapshot, runtime map[string]DefinitionRuntimeStatus) *DefinitionRegistryView {
-	return buildDefinitionRegistryViewAt(snapshot, runtime, time.Now())
+func BuildDefinitionRegistryView(snapshot *DefinitionRegistrySnapshot, runtime map[string]DefinitionRuntimeStatus, opts ...DefinitionViewOption) *DefinitionRegistryView {
+	return buildDefinitionRegistryViewAt(snapshot, runtime, time.Now(), opts...)
 }
 
-func buildDefinitionRegistryViewAt(snapshot *DefinitionRegistrySnapshot, runtime map[string]DefinitionRuntimeStatus, now time.Time) *DefinitionRegistryView {
+func buildDefinitionRegistryViewAt(snapshot *DefinitionRegistrySnapshot, runtime map[string]DefinitionRuntimeStatus, now time.Time, opts ...DefinitionViewOption) *DefinitionRegistryView {
 	if snapshot == nil {
 		return nil
+	}
+	options := definitionViewOptions{}
+	for _, opt := range opts {
+		opt(&options)
 	}
 
 	view := &DefinitionRegistryView{
@@ -103,12 +150,23 @@ func buildDefinitionRegistryViewAt(snapshot *DefinitionRegistrySnapshot, runtime
 			view.DefinitionsWithWarnings++
 			view.WarningCount += len(warnings)
 		}
-		view.Definitions = append(view.Definitions, DefinitionView{
+		dv := DefinitionView{
 			DefinitionSnapshot: def,
 			Eligibility:        eligibility,
 			Runtime:            status,
 			Warnings:           warnings,
-		})
+		}
+		if options.loops != nil && status.Running && status.LoopID != "" {
+			tags := options.loops.EffectiveTags(status.LoopID)
+			subs := options.loops.EffectiveSubscriptions(status.LoopID)
+			if len(tags) > 0 || len(subs) > 0 {
+				dv.Effective = &DefinitionEffectiveState{
+					Tags:          tags,
+					Subscriptions: subs,
+				}
+			}
+		}
+		view.Definitions = append(view.Definitions, dv)
 	}
 
 	return view

--- a/internal/runtime/loop/definition_view.go
+++ b/internal/runtime/loop/definition_view.go
@@ -38,8 +38,12 @@ type DefinitionView struct {
 	Runtime            DefinitionRuntimeStatus     `yaml:"runtime,omitempty" json:"runtime"`
 	Warnings           []DefinitionWarning         `yaml:"warnings,omitempty" json:"warnings,omitempty"`
 	// Effective surfaces the post-ancestor-merge state for inheritable
-	// loop fields. Nil for definitions whose loop isn't currently
-	// running (effective state is computed against the live registry).
+	// loop fields. Nil when there is nothing meaningful to report —
+	// the loop isn't running, the view was built without a live
+	// registry (e.g. CLI snapshots), or the loop is running but has
+	// no effective tags and no effective subscriptions. Readers should
+	// not treat nil as a definitive "not running"; pair it with
+	// [DefinitionRuntimeStatus.Running] when that distinction matters.
 	// Sits alongside Spec rather than inside Runtime so the
 	// declared-vs-effective contrast is at the top of the view and
 	// extends naturally as more fields become inheritable.
@@ -157,8 +161,10 @@ func buildDefinitionRegistryViewAt(snapshot *DefinitionRegistrySnapshot, runtime
 			Warnings:           warnings,
 		}
 		if options.loops != nil && status.Running && status.LoopID != "" {
-			tags := options.loops.EffectiveTags(status.LoopID)
-			subs := options.loops.EffectiveSubscriptions(status.LoopID)
+			// One walk per definition: EffectiveTags + EffectiveSubscriptions
+			// would do two ancestor traversals that could observe different
+			// snapshots if SetSubscriptions ran between them.
+			subs, tags := options.loops.effectiveState(status.LoopID)
 			if len(tags) > 0 || len(subs) > 0 {
 				dv.Effective = &DefinitionEffectiveState{
 					Tags:          tags,

--- a/internal/runtime/loop/effective_test.go
+++ b/internal/runtime/loop/effective_test.go
@@ -1,0 +1,360 @@
+package loop
+
+import (
+	"testing"
+	"time"
+)
+
+// TestRegistryEffectiveSubscriptionsCarriesProvenance asserts the
+// provenance contract: the loop's own subscriptions are marked
+// "self"; inherited subscriptions name the originating ancestor
+// container. This is the load-bearing test for PR-B's debugging
+// promise — without provenance the model can't tell which entries
+// it owns and which would persist regardless.
+func TestRegistryEffectiveSubscriptionsCarriesProvenance(t *testing.T) {
+	t.Parallel()
+
+	r := NewRegistry()
+
+	container, err := New(Config{
+		Name:      "home_automation",
+		Operation: OperationContainer,
+		Subscriptions: []EntitySubscription{
+			{EntityID: "weather.home", Forecast: "hourly"},
+			{EntityID: "presence.front_door"},
+		},
+	}, Deps{})
+	if err != nil {
+		t.Fatalf("new container: %v", err)
+	}
+	if err := r.Register(container); err != nil {
+		t.Fatalf("register container: %v", err)
+	}
+
+	leaf, err := New(Config{
+		Name:     "morning_briefing",
+		Task:     "summarize the morning",
+		ParentID: container.ID(),
+		Subscriptions: []EntitySubscription{
+			{EntityID: "calendar.work", History: []int{86400}},
+		},
+	}, Deps{Runner: &noopRunner{}})
+	if err != nil {
+		t.Fatalf("new leaf: %v", err)
+	}
+	if err := r.Register(leaf); err != nil {
+		t.Fatalf("register leaf: %v", err)
+	}
+
+	got := r.EffectiveSubscriptions(leaf.ID())
+	if len(got) != 3 {
+		t.Fatalf("len = %d, want 3 (own + 2 inherited): %+v", len(got), got)
+	}
+
+	// First entry is the loop's own declaration (walk is parent-first
+	// after the starting loop contributes).
+	if got[0].EntityID != "calendar.work" {
+		t.Errorf("got[0].EntityID = %q, want calendar.work", got[0].EntityID)
+	}
+	if got[0].From != EffectiveOriginSelf {
+		t.Errorf("got[0].From = %q, want %q", got[0].From, EffectiveOriginSelf)
+	}
+	// Inherited entries name the container.
+	for _, sub := range got[1:] {
+		if sub.From != "home_automation" {
+			t.Errorf("inherited sub %q has From=%q, want home_automation", sub.EntityID, sub.From)
+		}
+	}
+}
+
+// TestRegistryEffectiveTagsCarriesProvenance mirrors the subscription
+// test for tags — same provenance contract, same walk shape.
+func TestRegistryEffectiveTagsCarriesProvenance(t *testing.T) {
+	t.Parallel()
+
+	r := NewRegistry()
+
+	container, err := New(Config{
+		Name:      "home_automation",
+		Operation: OperationContainer,
+		Tags:      []string{"home", "ambient"},
+	}, Deps{})
+	if err != nil {
+		t.Fatalf("new container: %v", err)
+	}
+	if err := r.Register(container); err != nil {
+		t.Fatalf("register container: %v", err)
+	}
+
+	leaf, err := New(Config{
+		Name:     "leaf",
+		Task:     "t",
+		ParentID: container.ID(),
+		Tags:     []string{"research"},
+	}, Deps{Runner: &noopRunner{}})
+	if err != nil {
+		t.Fatalf("new leaf: %v", err)
+	}
+	if err := r.Register(leaf); err != nil {
+		t.Fatalf("register leaf: %v", err)
+	}
+
+	got := r.EffectiveTags(leaf.ID())
+	if len(got) != 3 {
+		t.Fatalf("len = %d, want 3 (own + 2 inherited): %+v", len(got), got)
+	}
+	if got[0].Tag != "research" || got[0].From != EffectiveOriginSelf {
+		t.Errorf("got[0] = %+v, want {research self}", got[0])
+	}
+	for _, t2 := range got[1:] {
+		if t2.From != "home_automation" {
+			t.Errorf("inherited tag %q has From=%q, want home_automation", t2.Tag, t2.From)
+		}
+	}
+}
+
+// TestRegistryEffectiveSubscriptionsDedupesAcrossLevels covers
+// first-wins precedence when a leaf and an ancestor both declare the
+// same entity: the leaf's options + provenance win, the ancestor's
+// version is silently dropped from the effective view.
+func TestRegistryEffectiveSubscriptionsDedupesAcrossLevels(t *testing.T) {
+	t.Parallel()
+
+	r := NewRegistry()
+	root, err := New(Config{
+		Name:      "root",
+		Operation: OperationContainer,
+		Subscriptions: []EntitySubscription{
+			{EntityID: "sensor.shared", Forecast: "daily"},
+		},
+	}, Deps{})
+	if err != nil {
+		t.Fatalf("new root: %v", err)
+	}
+	if err := r.Register(root); err != nil {
+		t.Fatalf("register root: %v", err)
+	}
+	leaf, err := New(Config{
+		Name:     "leaf",
+		Task:     "t",
+		ParentID: root.ID(),
+		Subscriptions: []EntitySubscription{
+			{EntityID: "sensor.shared", Forecast: "hourly"},
+		},
+	}, Deps{Runner: &noopRunner{}})
+	if err != nil {
+		t.Fatalf("new leaf: %v", err)
+	}
+	if err := r.Register(leaf); err != nil {
+		t.Fatalf("register leaf: %v", err)
+	}
+
+	got := r.EffectiveSubscriptions(leaf.ID())
+	if len(got) != 1 {
+		t.Fatalf("len = %d, want 1 (deduped)", len(got))
+	}
+	if got[0].From != EffectiveOriginSelf {
+		t.Errorf("From = %q, want %q (leaf overrides root)", got[0].From, EffectiveOriginSelf)
+	}
+	if got[0].Forecast != "hourly" {
+		t.Errorf("Forecast = %q, want hourly (leaf's option, not root's daily)", got[0].Forecast)
+	}
+}
+
+// TestLoopStatusReportsEffectiveState covers the Status snapshot
+// surface: a registered loop's Status() includes EffectiveTags and
+// EffectiveSubscriptions populated by the registry-installed hook.
+func TestLoopStatusReportsEffectiveState(t *testing.T) {
+	t.Parallel()
+
+	r := NewRegistry()
+	container, err := New(Config{
+		Name:      "ctx",
+		Operation: OperationContainer,
+		Tags:      []string{"ambient"},
+		Subscriptions: []EntitySubscription{
+			{EntityID: "weather.home"},
+		},
+	}, Deps{})
+	if err != nil {
+		t.Fatalf("new container: %v", err)
+	}
+	if err := r.Register(container); err != nil {
+		t.Fatalf("register container: %v", err)
+	}
+	leaf, err := New(Config{
+		Name:     "reporter",
+		Task:     "t",
+		ParentID: container.ID(),
+		Tags:     []string{"news"},
+		Subscriptions: []EntitySubscription{
+			{EntityID: "calendar.work"},
+		},
+	}, Deps{Runner: &noopRunner{}})
+	if err != nil {
+		t.Fatalf("new leaf: %v", err)
+	}
+	if err := r.Register(leaf); err != nil {
+		t.Fatalf("register leaf: %v", err)
+	}
+
+	st := leaf.Status()
+	if len(st.EffectiveTags) != 2 {
+		t.Fatalf("EffectiveTags len = %d, want 2: %+v", len(st.EffectiveTags), st.EffectiveTags)
+	}
+	if len(st.EffectiveSubscriptions) != 2 {
+		t.Fatalf("EffectiveSubscriptions len = %d, want 2: %+v", len(st.EffectiveSubscriptions), st.EffectiveSubscriptions)
+	}
+	// Status returns the loop's own first, then ancestor's.
+	if st.EffectiveTags[0].Tag != "news" || st.EffectiveTags[0].From != EffectiveOriginSelf {
+		t.Errorf("EffectiveTags[0] = %+v, want {news self}", st.EffectiveTags[0])
+	}
+	if st.EffectiveTags[1].From != "ctx" {
+		t.Errorf("inherited tag From = %q, want ctx", st.EffectiveTags[1].From)
+	}
+}
+
+// TestLoopStatusEffectiveEmptyWithoutRegistry guards against the
+// degraded path: a Loop built with New() outside any registry has
+// no effectiveStateFunc and Status() returns empty effective slices
+// without panicking.
+func TestLoopStatusEffectiveEmptyWithoutRegistry(t *testing.T) {
+	t.Parallel()
+
+	l, err := New(Config{Name: "standalone", Task: "t"}, Deps{Runner: &noopRunner{}})
+	if err != nil {
+		t.Fatalf("new: %v", err)
+	}
+	st := l.Status()
+	if st.EffectiveTags != nil {
+		t.Errorf("EffectiveTags = %v, want nil for unregistered loop", st.EffectiveTags)
+	}
+	if st.EffectiveSubscriptions != nil {
+		t.Errorf("EffectiveSubscriptions = %v, want nil for unregistered loop", st.EffectiveSubscriptions)
+	}
+}
+
+// TestBuildDefinitionRegistryViewPopulatesEffective wires the full
+// path: a running loop plus its container ancestor produce a
+// DefinitionView with Effective populated and carrying provenance.
+func TestBuildDefinitionRegistryViewPopulatesEffective(t *testing.T) {
+	t.Parallel()
+
+	// Build a small definition registry + live registry pairing that
+	// mirrors what the app does in production.
+	defReg, err := NewDefinitionRegistry(nil)
+	if err != nil {
+		t.Fatalf("NewDefinitionRegistry: %v", err)
+	}
+	containerSpec := Spec{
+		Name:      "home_automation",
+		Enabled:   true,
+		Operation: OperationContainer,
+		Tags:      []string{"home"},
+		Subscriptions: []EntitySubscription{
+			{EntityID: "weather.home"},
+		},
+	}
+	now := time.Now()
+	if err := defReg.Upsert(containerSpec, now); err != nil {
+		t.Fatalf("upsert container: %v", err)
+	}
+	leafSpec := Spec{
+		Name:         "morning_brief",
+		Enabled:      true,
+		Task:         "summarize",
+		Operation:    OperationService,
+		SleepMin:     time.Minute,
+		SleepMax:     time.Minute,
+		SleepDefault: time.Minute,
+		Tags:         []string{"news"},
+		ParentName:   "home_automation",
+		Subscriptions: []EntitySubscription{
+			{EntityID: "calendar.work"},
+		},
+	}
+	if err := defReg.Upsert(leafSpec, now); err != nil {
+		t.Fatalf("upsert leaf: %v", err)
+	}
+
+	live := NewRegistry()
+	container, err := New(containerSpec.ToConfig(), Deps{})
+	if err != nil {
+		t.Fatalf("new container loop: %v", err)
+	}
+	if err := live.Register(container); err != nil {
+		t.Fatalf("register container loop: %v", err)
+	}
+	leafCfg := leafSpec.ToConfig()
+	leafCfg.ParentID = container.ID()
+	leaf, err := New(leafCfg, Deps{Runner: &noopRunner{}})
+	if err != nil {
+		t.Fatalf("new leaf loop: %v", err)
+	}
+	if err := live.Register(leaf); err != nil {
+		t.Fatalf("register leaf loop: %v", err)
+	}
+
+	runtimeStatus := map[string]DefinitionRuntimeStatus{
+		"home_automation": {Running: true, LoopID: container.ID()},
+		"morning_brief":   {Running: true, LoopID: leaf.ID()},
+	}
+
+	view := BuildDefinitionRegistryView(defReg.Snapshot(), runtimeStatus, WithLiveRegistry(live))
+	if view == nil {
+		t.Fatal("BuildDefinitionRegistryView returned nil")
+	}
+
+	var leafView *DefinitionView
+	for i := range view.Definitions {
+		if view.Definitions[i].Name == "morning_brief" {
+			leafView = &view.Definitions[i]
+			break
+		}
+	}
+	if leafView == nil {
+		t.Fatal("morning_brief not in view")
+	}
+	if leafView.Effective == nil {
+		t.Fatal("Effective is nil; want populated for running loop")
+	}
+	if len(leafView.Effective.Tags) != 2 {
+		t.Errorf("Effective.Tags len = %d, want 2: %+v", len(leafView.Effective.Tags), leafView.Effective.Tags)
+	}
+	if len(leafView.Effective.Subscriptions) != 2 {
+		t.Errorf("Effective.Subscriptions len = %d, want 2: %+v", len(leafView.Effective.Subscriptions), leafView.Effective.Subscriptions)
+	}
+}
+
+// TestBuildDefinitionRegistryViewEffectiveNilWithoutRegistry covers
+// the safe-default branch: callers that build the view from a
+// snapshot alone (CLI tools, lint surfaces) get no Effective field
+// rather than a misleading empty one.
+func TestBuildDefinitionRegistryViewEffectiveNilWithoutRegistry(t *testing.T) {
+	t.Parallel()
+
+	defReg, err := NewDefinitionRegistry([]Spec{
+		{
+			Name:         "snapshot_only",
+			Enabled:      true,
+			Task:         "t",
+			Operation:    OperationService,
+			SleepMin:     time.Minute,
+			SleepMax:     time.Minute,
+			SleepDefault: time.Minute,
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewDefinitionRegistry: %v", err)
+	}
+
+	view := BuildDefinitionRegistryView(defReg.Snapshot(), nil)
+	if view == nil {
+		t.Fatal("nil view")
+	}
+	for _, dv := range view.Definitions {
+		if dv.Effective != nil {
+			t.Errorf("definition %q has Effective populated without a live registry; want nil", dv.Name)
+		}
+	}
+}

--- a/internal/runtime/loop/loop.go
+++ b/internal/runtime/loop/loop.go
@@ -277,6 +277,13 @@ type Loop struct {
 	// (e.g. unit tests on [New] directly).
 	ancestorTagsFunc func() []string
 
+	// effectiveStateFunc returns the full provenance-annotated
+	// effective tags and subscriptions for this loop. Installed by
+	// [Registry.Register] so [Status] can surface the same view that
+	// loop_definition_get exposes for the running loop. Nil for
+	// loops constructed outside a registry.
+	effectiveStateFunc func() ([]EffectiveTag, []EffectiveSubscription)
+
 	// nextSleep can be set externally (e.g., by a set_next_sleep
 	// tool handler) to override the default sleep for one cycle.
 	nextSleep time.Duration
@@ -500,6 +507,7 @@ func (l *Loop) Status() Status {
 	// Capture the callback reference under the lock; call it after
 	// releasing to avoid holding l.mu while the agent's tagMu is acquired.
 	atFunc := l.activeTagsFunc
+	effFunc := l.effectiveStateFunc
 
 	// Deep copy Config to prevent callers from mutating internal state
 	// via shared slices/maps. Function fields are cleared — they can't
@@ -651,6 +659,10 @@ func (l *Loop) Status() Status {
 	configuredTags := mergeUniqueStrings(cfgCopy.Tags, requestBaseInitialTags, requestOverrideInitialTags)
 	s.Tooling = BuildToolingState(configuredTags, s.ActiveTags, effectiveTools, cfgCopy.ExcludeTools, loadedCaps, lastToolsUsed)
 
+	if effFunc != nil {
+		s.EffectiveTags, s.EffectiveSubscriptions = effFunc()
+	}
+
 	return s
 }
 
@@ -691,6 +703,30 @@ func (l *Loop) Subscriptions() []EntitySubscription {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 	return cloneEntitySubscriptions(l.config.Subscriptions)
+}
+
+// tagsSnapshot returns a copy of the loop's configured tags under the
+// loop lock. Today the underlying field is set once at construction
+// and never changes, but the lock-and-clone shape mirrors
+// [Subscriptions] so future tag mutators can be added without
+// race-detector surprises in the registry walkers.
+func (l *Loop) tagsSnapshot() []string {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if len(l.config.Tags) == 0 {
+		return nil
+	}
+	return append([]string(nil), l.config.Tags...)
+}
+
+// setEffectiveStateFunc installs the provenance-aware walker behind
+// [Status.EffectiveTags] and [Status.EffectiveSubscriptions]. Wired by
+// [Registry.Register] so the loop can report its effective state
+// without a direct registry handle; nil-safe in Status.
+func (l *Loop) setEffectiveStateFunc(fn func() ([]EffectiveTag, []EffectiveSubscription)) {
+	l.mu.Lock()
+	l.effectiveStateFunc = fn
+	l.mu.Unlock()
 }
 
 // setAncestorTagsFunc is package-private because only [Registry.Register]

--- a/internal/runtime/loop/registry.go
+++ b/internal/runtime/loop/registry.go
@@ -80,7 +80,12 @@ func (r *Registry) Register(l *Loop) error {
 		return r.ancestorContainerTags(loopID)
 	})
 	l.setEffectiveStateFunc(func() ([]EffectiveTag, []EffectiveSubscription) {
-		return r.EffectiveTags(loopID), r.EffectiveSubscriptions(loopID)
+		// One walk, atomic snapshot: a second walk could observe a
+		// SetSubscriptions between the two calls and yield tags +
+		// subscriptions from different points in time. Status callers
+		// would have no way to tell.
+		subs, tags := r.effectiveState(loopID)
+		return tags, subs
 	})
 	r.logger.Debug("loop registered",
 		"loop_id", l.id,

--- a/internal/runtime/loop/registry.go
+++ b/internal/runtime/loop/registry.go
@@ -79,6 +79,9 @@ func (r *Registry) Register(l *Loop) error {
 	l.setAncestorTagsFunc(func() []string {
 		return r.ancestorContainerTags(loopID)
 	})
+	l.setEffectiveStateFunc(func() ([]EffectiveTag, []EffectiveSubscription) {
+		return r.EffectiveTags(loopID), r.EffectiveSubscriptions(loopID)
+	})
 	r.logger.Debug("loop registered",
 		"loop_id", l.id,
 		"loop_name", l.config.Name,
@@ -231,28 +234,83 @@ func (r *Registry) Children(loopID string) []*Loop {
 	return children
 }
 
-// AncestorSubscriptions returns the deduplicated effective entity
-// subscriptions for loopID: the union of the loop's own Subscriptions
-// and every container ancestor's, walked parent-first. Dedup is
-// first-wins by EntityID — the loop's own declaration takes precedence
-// over an inherited one, so a child can override a container's default
-// history/forecast settings by listing the same entity locally with
-// different options. Returns nil when the loop is not registered or
+// EffectiveSubscriptions returns the deduplicated effective entity
+// subscriptions for loopID with provenance: the union of the loop's
+// own Subscriptions and every container ancestor's, walked parent-
+// first. Dedup is first-wins by EntityID — the loop's own declaration
+// takes precedence over an inherited one, so a child can override a
+// container's default history/forecast settings by listing the same
+// entity locally with different options.
+//
+// Each [EffectiveSubscription.From] is [EffectiveOriginSelf] for the
+// loop's own declarations or the ancestor container's name for an
+// inherited entry. Returns nil when the loop is not registered or
 // nothing in the chain subscribes to anything.
 //
-// Today only container ancestors contribute; service-loop ancestors
-// (rare, since the loop graph is mostly tree-shaped under containers)
-// are skipped to match the tag-inheritance contract from Phase 1A.
+// Only container ancestors contribute inheritance; service-loop
+// ancestors are skipped to match the tag-inheritance contract from
+// Phase 1A.
+func (r *Registry) EffectiveSubscriptions(loopID string) []EffectiveSubscription {
+	subs, _ := r.effectiveState(loopID)
+	return subs
+}
+
+// EffectiveTags returns the deduplicated effective capability tags
+// for loopID with provenance. Same walk and dedup semantics as
+// [EffectiveSubscriptions]; own declarations carry
+// [EffectiveOriginSelf] in From, inherited tags carry the ancestor
+// container's name.
+func (r *Registry) EffectiveTags(loopID string) []EffectiveTag {
+	_, tags := r.effectiveState(loopID)
+	return tags
+}
+
+// AncestorSubscriptions returns the same union [EffectiveSubscriptions]
+// produces, but stripped of provenance. Kept as the convenient
+// rendering-side projection that the awareness loop subscription
+// provider consumes; the renderer doesn't need to attribute entries.
 func (r *Registry) AncestorSubscriptions(loopID string) []EntitySubscription {
-	// Snapshot the walk under the registry lock — we only need the
-	// parent chain and operation bits, both of which are config-shape
-	// invariants that don't move after construction. ParentID is set
-	// once at construction; Operation is too. The per-loop
-	// Subscriptions slice is the one mutable field [SetSubscriptions]
-	// can change concurrently, so we pull it from each loop via
-	// [Loop.Subscriptions], which clones under l.mu — avoiding the
-	// data race that would arise from reading l.config.Subscriptions
-	// while holding only r.mu.
+	subs := r.EffectiveSubscriptions(loopID)
+	if len(subs) == 0 {
+		return nil
+	}
+	out := make([]EntitySubscription, len(subs))
+	for i, sub := range subs {
+		out[i] = sub.EntitySubscription
+	}
+	return out
+}
+
+// ancestorContainerTags returns the deduplicated capability tags
+// inherited from container ancestors only (excludes the loop's own
+// tags) and drops provenance. Used by [Loop] tag preparation, which
+// already pulls own tags from config separately.
+func (r *Registry) ancestorContainerTags(loopID string) []string {
+	tags := r.EffectiveTags(loopID)
+	if len(tags) == 0 {
+		return nil
+	}
+	var inherited []string
+	for _, t := range tags {
+		if t.From == EffectiveOriginSelf {
+			continue
+		}
+		inherited = append(inherited, t.Tag)
+	}
+	if len(inherited) == 0 {
+		return nil
+	}
+	return inherited
+}
+
+// effectiveState is the shared single-pass walker behind
+// [EffectiveSubscriptions] and [EffectiveTags]. It snapshots the
+// parent chain under the registry lock (parent_id and operation are
+// construction-set invariants), then pulls each loop's subscriptions
+// via [Loop.Subscriptions], which clones under l.mu — preventing the
+// data race that would arise from reading l.config.Subscriptions
+// while holding only r.mu.
+func (r *Registry) effectiveState(loopID string) ([]EffectiveSubscription, []EffectiveTag) {
 	r.mu.RLock()
 	walk := make([]*Loop, 0, 4)
 	current := r.loops[loopID]
@@ -274,11 +332,15 @@ func (r *Registry) AncestorSubscriptions(loopID string) []EntitySubscription {
 	r.mu.RUnlock()
 
 	if len(walk) == 0 {
-		return nil
+		return nil, nil
 	}
 
-	var collected []EntitySubscription
-	seen := make(map[string]struct{})
+	var (
+		subs     []EffectiveSubscription
+		tags     []EffectiveTag
+		seenSubs = make(map[string]struct{})
+		seenTags = make(map[string]struct{})
+	)
 	for i, l := range walk {
 		// The starting loop contributes regardless of operation; only
 		// ancestors are filtered to container nodes (matches the tag-
@@ -286,44 +348,35 @@ func (r *Registry) AncestorSubscriptions(loopID string) []EntitySubscription {
 		if i > 0 && l.Operation() != OperationContainer {
 			continue
 		}
+		origin := EffectiveOriginSelf
+		if i > 0 {
+			origin = l.Name()
+		}
 		for _, sub := range l.Subscriptions() {
 			if sub.EntityID == "" {
 				continue
 			}
-			if _, dup := seen[sub.EntityID]; dup {
+			if _, dup := seenSubs[sub.EntityID]; dup {
 				continue
 			}
-			seen[sub.EntityID] = struct{}{}
-			collected = append(collected, sub)
+			seenSubs[sub.EntityID] = struct{}{}
+			subs = append(subs, EffectiveSubscription{
+				EntitySubscription: sub,
+				From:               origin,
+			})
+		}
+		for _, tag := range l.tagsSnapshot() {
+			if tag == "" {
+				continue
+			}
+			if _, dup := seenTags[tag]; dup {
+				continue
+			}
+			seenTags[tag] = struct{}{}
+			tags = append(tags, EffectiveTag{Tag: tag, From: origin})
 		}
 	}
-	return collected
-}
-
-// ancestorContainerTags collects deduplicated capability tags from each
-// container ancestor of loopID, in walk order (immediate parent first).
-// Non-container ancestors contribute nothing — only container loops are
-// declared as state-inheritance nodes. Used by [Loop] tag preparation to
-// merge inherited tags onto each iteration's request.
-func (r *Registry) ancestorContainerTags(loopID string) []string {
-	ancestors := r.Ancestors(loopID)
-	if len(ancestors) == 0 {
-		return nil
-	}
-	parts := make([][]string, 0, len(ancestors))
-	for _, a := range ancestors {
-		if a.config.Operation != OperationContainer {
-			continue
-		}
-		if len(a.config.Tags) == 0 {
-			continue
-		}
-		parts = append(parts, a.config.Tags)
-	}
-	if len(parts) == 0 {
-		return nil
-	}
-	return mergeUniqueStrings(parts...)
+	return subs, tags
 }
 
 // FindByName returns all live loops with the exact given name.

--- a/internal/runtime/loop/subscription.go
+++ b/internal/runtime/loop/subscription.go
@@ -76,3 +76,38 @@ func cloneEntitySubscriptions(src []EntitySubscription) []EntitySubscription {
 	}
 	return out
 }
+
+// EffectiveOriginSelf is the [EffectiveSubscription.From] /
+// [EffectiveTag.From] value used for entries the loop declared
+// directly. A constant prevents callers from accidentally comparing
+// against a freshly-typed string literal in user-facing surfaces.
+const EffectiveOriginSelf = "self"
+
+// EffectiveSubscription is an entity subscription annotated with its
+// origin in the loop graph. Embeds [EntitySubscription] so JSON
+// encoding stays flat — every field appears alongside `from`.
+// Returned by [Registry.EffectiveSubscriptions] for surfaces that
+// need to render effective state with provenance
+// (loop_definition_get, loop_status).
+type EffectiveSubscription struct {
+	EntitySubscription
+
+	// From is [EffectiveOriginSelf] when this loop declared the
+	// subscription, or the ancestor loop's name when it was
+	// inherited. Operators editing a loop's subscriptions read this
+	// to see which entries are local vs. inherited from a container.
+	From string `yaml:"from" json:"from"`
+}
+
+// EffectiveTag is a capability tag annotated with its origin in the
+// loop graph. Mirror of [EffectiveSubscription] for tags. Returned
+// by [Registry.EffectiveTags].
+type EffectiveTag struct {
+	// Tag is the capability tag name.
+	Tag string `yaml:"tag" json:"tag"`
+
+	// From follows the same contract as
+	// [EffectiveSubscription.From]: [EffectiveOriginSelf] for
+	// directly-declared tags, ancestor loop name otherwise.
+	From string `yaml:"from" json:"from"`
+}


### PR DESCRIPTION
## Summary

PR-B of the [#889](https://github.com/nugget/thane-ai-agent/issues/889) structural-inheritance rollout. Surfaces both "declared on this loop" and "effective after ancestor merge" for tags + subscriptions, with provenance on each inherited entry. Lands the debugging foundation that PR-C will rely on before cascading more inheritable fields.

## What's new

- **Typed effective state.** `EffectiveTag{Tag, From}` and `EffectiveSubscription{EntitySubscription, From}` both carry a provenance string. `From` is `EffectiveOriginSelf` ("self") for entries the loop declared itself, or the ancestor loop's name for inherited entries. `EffectiveSubscription` embeds `EntitySubscription` so JSON stays flat.
- **`Registry.EffectiveTags` / `Registry.EffectiveSubscriptions`.** Single shared walker (`effectiveState`) snapshots the parent chain under r.mu, then pulls each loop's tags/subs via the lock-clone accessors — same shape as the race fix from PR-A. Existing `AncestorSubscriptions` and `ancestorContainerTags` become thin projections so there's one source of truth.
- **`DefinitionView.Effective`.** New optional field carrying the post-merge tags and subscriptions for a running loop. Builder populates it when `WithLiveRegistry` option is supplied; nil otherwise (definitions queried in isolation — CLI, lint surfaces — don't get a misleading empty view).
- **`Status.EffectiveTags` / `Status.EffectiveSubscriptions`.** Same view on the live snapshot. Populated via an `effectiveStateFunc` hook the registry installs at `Register` time, mirroring the existing `ancestorTagsFunc` plumbing.

## Example response shape

For a loop `morning_brief` inside container `home_automation`:

```jsonc
{
  "name": "morning_brief",
  "spec": {
    "tags": ["news"],
    "subscriptions": [{"entity_id": "calendar.work"}]
  },
  "runtime": { "running": true, "loop_id": "..." },
  "effective": {
    "tags": [
      {"tag": "news", "from": "self"},
      {"tag": "home", "from": "home_automation"}
    ],
    "subscriptions": [
      {"entity_id": "calendar.work", "from": "self"},
      {"entity_id": "weather.home", "from": "home_automation"}
    ]
  }
}
```

## Test plan

- [x] `just ci` green locally (race detector clean)
- [x] `internal/runtime/loop/effective_test.go`:
  - Subscription + tag provenance contract (self vs ancestor labeling)
  - Dedup across levels with leaf-overrides-ancestor precedence preserving the leaf's options
  - `Status.Effective*` populated for registered loops
  - `Status.Effective*` empty for loops built outside any registry (no panic)
  - `DefinitionView.Effective` populated end-to-end through `BuildDefinitionRegistryView` with `WithLiveRegistry`
  - `DefinitionView.Effective` nil when no live registry is supplied (snapshot-only callers)
- [ ] After landing: live exercise of `loop_definition_get` to confirm the JSON shape lands as expected

## Followups

Remaining items on [#889](https://github.com/nugget/thane-ai-agent/issues/889):
- **PR-C**: cascade `ExcludeTools`, `RoutingFactors`, `Conditions`, `Profile.DelegationGating` through the same `EffectiveState` shape — each item plugs into the existing struct
- **PR-D**: `operation: core` + gource-style UI variant

🤖 Generated with [Claude Code](https://claude.com/claude-code)