### PR TITLE
refactor: cascade runtime settings through ancestors (PR-C of #889)

### DIFF
--- a/internal/runtime/loop/cascade_test.go
+++ b/internal/runtime/loop/cascade_test.go
@@ -1,0 +1,341 @@
+package loop
+
+import (
+	"testing"
+)
+
+// TestEffectiveExcludeToolsUnion covers the union semantics: every
+// ancestor's ExcludeTools contributes and a descendant cannot
+// un-exclude an ancestor's restriction. Provenance reports the
+// closest declaration when the same tool appears at multiple
+// levels.
+func TestEffectiveExcludeToolsUnion(t *testing.T) {
+	t.Parallel()
+
+	r := NewRegistry()
+	root, err := New(Config{
+		Name:         "root",
+		Operation:    OperationContainer,
+		ExcludeTools: []string{"shell_exec", "doc_write"},
+	}, Deps{})
+	if err != nil {
+		t.Fatalf("new root: %v", err)
+	}
+	if err := r.Register(root); err != nil {
+		t.Fatalf("register root: %v", err)
+	}
+
+	leaf, err := New(Config{
+		Name:         "leaf",
+		Task:         "t",
+		ParentID:     root.ID(),
+		ExcludeTools: []string{"shell_exec", "schedule_task"},
+	}, Deps{Runner: &noopRunner{}})
+	if err != nil {
+		t.Fatalf("new leaf: %v", err)
+	}
+	if err := r.Register(leaf); err != nil {
+		t.Fatalf("register leaf: %v", err)
+	}
+
+	got := r.EffectiveExcludeTools(leaf.ID())
+	if len(got) != 3 {
+		t.Fatalf("len = %d, want 3 (shell_exec, schedule_task, doc_write): %+v", len(got), got)
+	}
+
+	byTool := make(map[string]string, len(got))
+	for _, e := range got {
+		byTool[e.Tool] = e.From
+	}
+	// shell_exec appears at both levels — closest declaration wins on dedup.
+	if byTool["shell_exec"] != EffectiveOriginSelf {
+		t.Errorf("shell_exec From = %q, want self (closest wins on collision)", byTool["shell_exec"])
+	}
+	if byTool["schedule_task"] != EffectiveOriginSelf {
+		t.Errorf("schedule_task From = %q, want self", byTool["schedule_task"])
+	}
+	if byTool["doc_write"] != "root" {
+		t.Errorf("doc_write From = %q, want root (only the ancestor declared it)", byTool["doc_write"])
+	}
+}
+
+// TestEffectiveRoutingFactorsChildWins covers the child-wins
+// semantics on key collision: when a leaf and an ancestor both
+// declare the same key, the leaf's value+provenance survive.
+func TestEffectiveRoutingFactorsChildWins(t *testing.T) {
+	t.Parallel()
+
+	r := NewRegistry()
+	root, err := New(Config{
+		Name:      "root",
+		Operation: OperationContainer,
+		RoutingFactors: map[string]string{
+			"cluster":     "home",
+			"environment": "production",
+		},
+	}, Deps{})
+	if err != nil {
+		t.Fatalf("new root: %v", err)
+	}
+	if err := r.Register(root); err != nil {
+		t.Fatalf("register root: %v", err)
+	}
+
+	leaf, err := New(Config{
+		Name:     "leaf",
+		Task:     "t",
+		ParentID: root.ID(),
+		RoutingFactors: map[string]string{
+			"cluster":    "home", // same as root — leaf's "self" wins on dedup
+			"complexity": "low",  // leaf-only
+		},
+	}, Deps{Runner: &noopRunner{}})
+	if err != nil {
+		t.Fatalf("new leaf: %v", err)
+	}
+	if err := r.Register(leaf); err != nil {
+		t.Fatalf("register leaf: %v", err)
+	}
+
+	got := r.EffectiveRoutingFactors(leaf.ID())
+	if len(got) != 3 {
+		t.Fatalf("len = %d, want 3: %+v", len(got), got)
+	}
+	byKey := make(map[string]EffectiveRoutingFactor, len(got))
+	for _, f := range got {
+		byKey[f.Key] = f
+	}
+	if byKey["cluster"].From != EffectiveOriginSelf {
+		t.Errorf("cluster From = %q, want self (child wins on collision)", byKey["cluster"].From)
+	}
+	if byKey["complexity"].From != EffectiveOriginSelf {
+		t.Errorf("complexity From = %q, want self", byKey["complexity"].From)
+	}
+	if byKey["environment"].From != "root" {
+		t.Errorf("environment From = %q, want root", byKey["environment"].From)
+	}
+	if byKey["environment"].Value != "production" {
+		t.Errorf("environment Value = %q, want production", byKey["environment"].Value)
+	}
+}
+
+// TestEffectiveDelegationGatingClosestNonEmpty covers the closest-
+// non-empty walk: a leaf with no declaration inherits from the
+// closest ancestor that declared a value, skipping intermediate
+// ancestors with no declaration.
+func TestEffectiveDelegationGatingClosestNonEmpty(t *testing.T) {
+	t.Parallel()
+
+	r := NewRegistry()
+	grandparent, err := New(Config{
+		Name:             "grandparent",
+		Operation:        OperationContainer,
+		DelegationGating: "permissive",
+	}, Deps{})
+	if err != nil {
+		t.Fatalf("new grandparent: %v", err)
+	}
+	if err := r.Register(grandparent); err != nil {
+		t.Fatalf("register grandparent: %v", err)
+	}
+	parent, err := New(Config{
+		Name:             "parent",
+		Operation:        OperationContainer,
+		ParentID:         grandparent.ID(),
+		DelegationGating: "disabled",
+	}, Deps{})
+	if err != nil {
+		t.Fatalf("new parent: %v", err)
+	}
+	if err := r.Register(parent); err != nil {
+		t.Fatalf("register parent: %v", err)
+	}
+	leaf, err := New(Config{
+		Name:     "leaf",
+		Task:     "t",
+		ParentID: parent.ID(),
+		// No DelegationGating declared.
+	}, Deps{Runner: &noopRunner{}})
+	if err != nil {
+		t.Fatalf("new leaf: %v", err)
+	}
+	if err := r.Register(leaf); err != nil {
+		t.Fatalf("register leaf: %v", err)
+	}
+
+	got := r.EffectiveDelegationGating(leaf.ID())
+	if got == nil {
+		t.Fatal("EffectiveDelegationGating = nil, want closest ancestor's value")
+	}
+	if got.Value != "disabled" {
+		t.Errorf("Value = %q, want disabled (parent wins over grandparent — closest non-empty)", got.Value)
+	}
+	if got.From != "parent" {
+		t.Errorf("From = %q, want parent", got.From)
+	}
+
+	// Sanity: a loop with its own non-empty value should report self.
+	override, err := New(Config{
+		Name:             "override",
+		Task:             "t",
+		ParentID:         parent.ID(),
+		DelegationGating: "strict",
+	}, Deps{Runner: &noopRunner{}})
+	if err != nil {
+		t.Fatalf("new override: %v", err)
+	}
+	if err := r.Register(override); err != nil {
+		t.Fatalf("register override: %v", err)
+	}
+	got = r.EffectiveDelegationGating(override.ID())
+	if got == nil || got.From != EffectiveOriginSelf || got.Value != "strict" {
+		t.Errorf("override leaf got = %+v, want {strict self}", got)
+	}
+}
+
+// TestEffectiveDelegationGatingNoDeclarationAnywhere asserts the
+// nil-when-empty contract: if no loop in the chain set a non-empty
+// gating value, the result is nil so the caller falls back to the
+// agent default.
+func TestEffectiveDelegationGatingNoDeclarationAnywhere(t *testing.T) {
+	t.Parallel()
+
+	r := NewRegistry()
+	root, err := New(Config{
+		Name:      "root",
+		Operation: OperationContainer,
+	}, Deps{})
+	if err != nil {
+		t.Fatalf("new root: %v", err)
+	}
+	if err := r.Register(root); err != nil {
+		t.Fatalf("register root: %v", err)
+	}
+	leaf, err := New(Config{Name: "leaf", Task: "t", ParentID: root.ID()}, Deps{Runner: &noopRunner{}})
+	if err != nil {
+		t.Fatalf("new leaf: %v", err)
+	}
+	if err := r.Register(leaf); err != nil {
+		t.Fatalf("register leaf: %v", err)
+	}
+	if got := r.EffectiveDelegationGating(leaf.ID()); got != nil {
+		t.Errorf("got %+v, want nil (no declaration in chain)", got)
+	}
+}
+
+// TestPrepareAgentTurnRequestAppliesCascade is the load-bearing
+// end-to-end test for PR-C: it confirms each cascading field
+// actually lands in the prepared Request that goes to the runner.
+func TestPrepareAgentTurnRequestAppliesCascade(t *testing.T) {
+	t.Parallel()
+
+	r := NewRegistry()
+	container, err := New(Config{
+		Name:         "ctx",
+		Operation:    OperationContainer,
+		ExcludeTools: []string{"shell_exec"},
+		RoutingFactors: map[string]string{
+			"cluster":     "home",
+			"environment": "production",
+		},
+		DelegationGating: "disabled",
+	}, Deps{})
+	if err != nil {
+		t.Fatalf("new container: %v", err)
+	}
+	if err := r.Register(container); err != nil {
+		t.Fatalf("register container: %v", err)
+	}
+	leaf, err := New(Config{
+		Name:         "leaf",
+		Task:         "t",
+		ParentID:     container.ID(),
+		ExcludeTools: []string{"doc_write"},
+		RoutingFactors: map[string]string{
+			"cluster":    "edge", // overrides container's "home"
+			"complexity": "low",
+		},
+		// No DelegationGating — should inherit "disabled".
+	}, Deps{Runner: &noopRunner{}})
+	if err != nil {
+		t.Fatalf("new leaf: %v", err)
+	}
+	if err := r.Register(leaf); err != nil {
+		t.Fatalf("register leaf: %v", err)
+	}
+
+	got, err := leaf.prepareAgentTurnRequest(Request{}, "conv-1", false)
+	if err != nil {
+		t.Fatalf("prepareAgentTurnRequest: %v", err)
+	}
+
+	// ExcludeTools union — both shell_exec (from container) and doc_write (own).
+	excludes := make(map[string]bool, len(got.ExcludeTools))
+	for _, e := range got.ExcludeTools {
+		excludes[e] = true
+	}
+	if !excludes["shell_exec"] || !excludes["doc_write"] {
+		t.Errorf("ExcludeTools = %v, want both shell_exec (inherited) and doc_write (own)", got.ExcludeTools)
+	}
+
+	// RoutingFactors child-wins — cluster=edge (leaf), environment=production (inherited).
+	if got.RoutingFactors["cluster"] != "edge" {
+		t.Errorf("cluster = %q, want edge (leaf overrides container)", got.RoutingFactors["cluster"])
+	}
+	if got.RoutingFactors["environment"] != "production" {
+		t.Errorf("environment = %q, want production (inherited)", got.RoutingFactors["environment"])
+	}
+	if got.RoutingFactors["complexity"] != "low" {
+		t.Errorf("complexity = %q, want low (leaf-only)", got.RoutingFactors["complexity"])
+	}
+
+	// DelegationGating closest-non-empty — leaf has nothing, inherits from container.
+	if got.DelegationGating != "disabled" {
+		t.Errorf("DelegationGating = %q, want disabled (inherited from ctx)", got.DelegationGating)
+	}
+}
+
+// TestLoopStatusReportsCascadeFields confirms the Status surface
+// includes the three new effective fields populated by the
+// registry-installed hook.
+func TestLoopStatusReportsCascadeFields(t *testing.T) {
+	t.Parallel()
+
+	r := NewRegistry()
+	container, err := New(Config{
+		Name:             "ctx",
+		Operation:        OperationContainer,
+		ExcludeTools:     []string{"shell_exec"},
+		RoutingFactors:   map[string]string{"env": "prod"},
+		DelegationGating: "disabled",
+	}, Deps{})
+	if err != nil {
+		t.Fatalf("new container: %v", err)
+	}
+	if err := r.Register(container); err != nil {
+		t.Fatalf("register container: %v", err)
+	}
+	leaf, err := New(Config{
+		Name:         "reporter",
+		Task:         "t",
+		ParentID:     container.ID(),
+		ExcludeTools: []string{"doc_write"},
+	}, Deps{Runner: &noopRunner{}})
+	if err != nil {
+		t.Fatalf("new leaf: %v", err)
+	}
+	if err := r.Register(leaf); err != nil {
+		t.Fatalf("register leaf: %v", err)
+	}
+
+	st := leaf.Status()
+	if len(st.EffectiveExcludeTools) != 2 {
+		t.Errorf("EffectiveExcludeTools len = %d, want 2: %+v", len(st.EffectiveExcludeTools), st.EffectiveExcludeTools)
+	}
+	if len(st.EffectiveRoutingFactors) != 1 || st.EffectiveRoutingFactors[0].Key != "env" {
+		t.Errorf("EffectiveRoutingFactors = %+v, want one entry for env", st.EffectiveRoutingFactors)
+	}
+	if st.EffectiveDelegationGating == nil || st.EffectiveDelegationGating.Value != "disabled" {
+		t.Errorf("EffectiveDelegationGating = %+v, want {disabled ctx}", st.EffectiveDelegationGating)
+	}
+}

--- a/internal/runtime/loop/config.go
+++ b/internal/runtime/loop/config.go
@@ -543,6 +543,18 @@ type Status struct {
 	// covers both "no registry hook installed" and "registry hook
 	// installed but nothing to report."
 	EffectiveSubscriptions []EffectiveSubscription `json:"effective_subscriptions,omitempty"`
+	// EffectiveExcludeTools is the post-ancestor-merge view of this
+	// loop's tool exclusions, with provenance on each entry. Same
+	// nil-conflation as EffectiveTags.
+	EffectiveExcludeTools []EffectiveExcludeTool `json:"effective_exclude_tools,omitempty"`
+	// EffectiveRoutingFactors is the post-ancestor-merge view of this
+	// loop's routing factors, child-wins on key collision. Same
+	// nil-conflation as EffectiveTags.
+	EffectiveRoutingFactors []EffectiveRoutingFactor `json:"effective_routing_factors,omitempty"`
+	// EffectiveDelegationGating is the resolved delegation-gating
+	// value plus its origin. Nil when no loop in the chain declared
+	// a non-empty value (the agent default applies).
+	EffectiveDelegationGating *EffectiveDelegationGating `json:"effective_delegation_gating,omitempty"`
 	// Config is a copy of the loop's configuration.
 	Config Config `json:"config"`
 }

--- a/internal/runtime/loop/definition_view.go
+++ b/internal/runtime/loop/definition_view.go
@@ -62,6 +62,17 @@ type DefinitionEffectiveState struct {
 	// Spec.Subscriptions and every container ancestor's, first-wins
 	// on entity_id (own declarations override inherited options).
 	Subscriptions []EffectiveSubscription `yaml:"subscriptions,omitempty" json:"subscriptions,omitempty"`
+	// ExcludeTools is the union of the loop's own ExcludeTools and
+	// every container ancestor's. Union semantics — a descendant
+	// cannot un-exclude an ancestor's restriction.
+	ExcludeTools []EffectiveExcludeTool `yaml:"exclude_tools,omitempty" json:"exclude_tools,omitempty"`
+	// RoutingFactors is the merged routing-factor map, child-wins on
+	// key collision. Each entry names its origin loop.
+	RoutingFactors []EffectiveRoutingFactor `yaml:"routing_factors,omitempty" json:"routing_factors,omitempty"`
+	// DelegationGating is the resolved gating value plus its origin.
+	// Nil when no loop in the chain declared a non-empty value (the
+	// agent default applies).
+	DelegationGating *EffectiveDelegationGating `yaml:"delegation_gating,omitempty" json:"delegation_gating,omitempty"`
 }
 
 // DefinitionRegistryView is the effective combined view of stored loop
@@ -161,14 +172,19 @@ func buildDefinitionRegistryViewAt(snapshot *DefinitionRegistrySnapshot, runtime
 			Warnings:           warnings,
 		}
 		if options.loops != nil && status.Running && status.LoopID != "" {
-			// One walk per definition: EffectiveTags + EffectiveSubscriptions
-			// would do two ancestor traversals that could observe different
-			// snapshots if SetSubscriptions ran between them.
-			subs, tags := options.loops.effectiveState(status.LoopID)
-			if len(tags) > 0 || len(subs) > 0 {
+			// One walk per definition: per-field Effective* calls
+			// would do separate ancestor traversals that could observe
+			// different snapshots if SetSubscriptions ran between them.
+			eff := options.loops.effectiveState(status.LoopID)
+			if len(eff.Tags) > 0 || len(eff.Subscriptions) > 0 ||
+				len(eff.ExcludeTools) > 0 || len(eff.RoutingFactors) > 0 ||
+				eff.DelegationGating != nil {
 				dv.Effective = &DefinitionEffectiveState{
-					Tags:          tags,
-					Subscriptions: subs,
+					Tags:             eff.Tags,
+					Subscriptions:    eff.Subscriptions,
+					ExcludeTools:     eff.ExcludeTools,
+					RoutingFactors:   eff.RoutingFactors,
+					DelegationGating: eff.DelegationGating,
 				}
 			}
 		}

--- a/internal/runtime/loop/loop.go
+++ b/internal/runtime/loop/loop.go
@@ -278,11 +278,13 @@ type Loop struct {
 	ancestorTagsFunc func() []string
 
 	// effectiveStateFunc returns the full provenance-annotated
-	// effective tags and subscriptions for this loop. Installed by
-	// [Registry.Register] so [Status] can surface the same view that
-	// loop_definition_get exposes for the running loop. Nil for
-	// loops constructed outside a registry.
-	effectiveStateFunc func() ([]EffectiveTag, []EffectiveSubscription)
+	// effective state for this loop — every cascading field (tags,
+	// subscriptions, exclude tools, routing factors, delegation
+	// gating) in one atomic snapshot. Installed by
+	// [Registry.Register] so [Status] and the iteration-time merge
+	// in [prepareAgentTurnRequest] share one ancestor walk per call.
+	// Nil for loops constructed outside a registry.
+	effectiveStateFunc func() effectiveStateResult
 
 	// nextSleep can be set externally (e.g., by a set_next_sleep
 	// tool handler) to override the default sleep for one cycle.
@@ -660,7 +662,12 @@ func (l *Loop) Status() Status {
 	s.Tooling = BuildToolingState(configuredTags, s.ActiveTags, effectiveTools, cfgCopy.ExcludeTools, loadedCaps, lastToolsUsed)
 
 	if effFunc != nil {
-		s.EffectiveTags, s.EffectiveSubscriptions = effFunc()
+		eff := effFunc()
+		s.EffectiveTags = eff.Tags
+		s.EffectiveSubscriptions = eff.Subscriptions
+		s.EffectiveExcludeTools = eff.ExcludeTools
+		s.EffectiveRoutingFactors = eff.RoutingFactors
+		s.EffectiveDelegationGating = eff.DelegationGating
 	}
 
 	return s
@@ -719,11 +726,49 @@ func (l *Loop) tagsSnapshot() []string {
 	return append([]string(nil), l.config.Tags...)
 }
 
+// excludeToolsSnapshot returns a copy of the loop's configured tool
+// exclusions under the loop lock. Same forward-compat shape as
+// [tagsSnapshot].
+func (l *Loop) excludeToolsSnapshot() []string {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if len(l.config.ExcludeTools) == 0 {
+		return nil
+	}
+	return append([]string(nil), l.config.ExcludeTools...)
+}
+
+// routingFactorsSnapshot returns a copy of the loop's configured
+// routing factors under the loop lock. Same forward-compat shape as
+// [tagsSnapshot].
+func (l *Loop) routingFactorsSnapshot() map[string]string {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if len(l.config.RoutingFactors) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(l.config.RoutingFactors))
+	for k, v := range l.config.RoutingFactors {
+		out[k] = v
+	}
+	return out
+}
+
+// delegationGatingSnapshot returns the loop's configured delegation-
+// gating value under the loop lock. Same forward-compat shape as
+// [tagsSnapshot].
+func (l *Loop) delegationGatingSnapshot() string {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.config.DelegationGating
+}
+
 // setEffectiveStateFunc installs the provenance-aware walker behind
-// [Status.EffectiveTags] and [Status.EffectiveSubscriptions]. Wired by
-// [Registry.Register] so the loop can report its effective state
-// without a direct registry handle; nil-safe in Status.
-func (l *Loop) setEffectiveStateFunc(fn func() ([]EffectiveTag, []EffectiveSubscription)) {
+// [Status]'s Effective* fields and the iteration-time cascade merge.
+// Wired by [Registry.Register] so the loop reports its effective
+// state without a direct registry handle; nil-safe everywhere it's
+// consulted.
+func (l *Loop) setEffectiveStateFunc(fn func() effectiveStateResult) {
 	l.mu.Lock()
 	l.effectiveStateFunc = fn
 	l.mu.Unlock()
@@ -750,6 +795,54 @@ func (l *Loop) inheritedTags() []string {
 		return nil
 	}
 	return fn()
+}
+
+// inheritedCascade is the per-iteration projection of effective
+// state that drops the loop's own contributions (those flow through
+// the existing l.config.* / l.requestBase.* / etc. merges) and
+// keeps only what ancestor containers contributed. Used by
+// [prepareAgentTurnRequest] to fold inherited values into the
+// existing merge chain without double-counting the loop's own.
+type inheritedCascade struct {
+	ExcludeTools     []string
+	RoutingFactors   map[string]string
+	DelegationGating string
+}
+
+func (l *Loop) inheritedCascade() inheritedCascade {
+	l.mu.Lock()
+	fn := l.effectiveStateFunc
+	l.mu.Unlock()
+	if fn == nil {
+		return inheritedCascade{}
+	}
+	eff := fn()
+
+	var out inheritedCascade
+	for _, e := range eff.ExcludeTools {
+		if e.From == EffectiveOriginSelf {
+			continue
+		}
+		out.ExcludeTools = append(out.ExcludeTools, e.Tool)
+	}
+	for _, f := range eff.RoutingFactors {
+		if f.From == EffectiveOriginSelf {
+			continue
+		}
+		if out.RoutingFactors == nil {
+			out.RoutingFactors = make(map[string]string)
+		}
+		// EffectiveRoutingFactors is already deduped closest-first,
+		// so the first ancestor entry for any key is the winner.
+		if _, dup := out.RoutingFactors[f.Key]; dup {
+			continue
+		}
+		out.RoutingFactors[f.Key] = f.Value
+	}
+	if eff.DelegationGating != nil && eff.DelegationGating.From != EffectiveOriginSelf {
+		out.DelegationGating = eff.DelegationGating.Value
+	}
+	return out
 }
 
 // CurrentConvID returns the conversation ID of the in-flight iteration,
@@ -1538,6 +1631,17 @@ func (l *Loop) prepareAgentTurnRequest(req Request, convID string, isSupervisor 
 		}
 		hints["local_only"] = "true"
 	}
+	// Container ancestors fold into the merge chain alongside
+	// capability tags. The cascade snapshot is taken once so every
+	// inheritable field (routing factors, exclude tools, delegation
+	// gating) shares one ancestor walk per iteration. Inherited
+	// values sit at the weakest priority — own config / per-turn
+	// overrides / per-launch overrides all win on collision — so
+	// ancestors set defaults that descendants can refine.
+	cascade := l.inheritedCascade()
+	for k, v := range cascade.RoutingFactors {
+		hints[k] = v
+	}
 	for k, v := range l.requestBase.RoutingFactors {
 		hints[k] = v
 	}
@@ -1551,10 +1655,6 @@ func (l *Loop) prepareAgentTurnRequest(req Request, convID string, isSupervisor 
 		hints[k] = v
 	}
 
-	// Container ancestors contribute capability tags to every descendant
-	// turn. The loop's own tags come first so any ordering-sensitive
-	// downstream resolution still prefers spec-declared tags over
-	// inherited ones; mergeUniqueStrings dedupes either way.
 	inheritedTags := l.inheritedTags()
 	configuredInitialTags := mergeUniqueStrings(l.config.Tags, l.requestBase.InitialTags, req.InitialTags, l.requestOverride.InitialTags, inheritedTags)
 	req.Model = firstNonEmpty(req.Model, l.requestBase.Model)
@@ -1566,10 +1666,17 @@ func (l *Loop) prepareAgentTurnRequest(req Request, convID string, isSupervisor 
 		return Request{}, err
 	}
 	req.AllowedTools = allowedTools
-	req.ExcludeTools = mergeUniqueStrings(l.requestBase.ExcludeTools, l.config.ExcludeTools, req.ExcludeTools, l.requestOverride.ExcludeTools)
+	// Ancestor-container excludes union into the merge so a "no
+	// shell_exec under home_automation" restriction reaches every
+	// descendant regardless of what they declare locally.
+	req.ExcludeTools = mergeUniqueStrings(l.requestBase.ExcludeTools, l.config.ExcludeTools, req.ExcludeTools, l.requestOverride.ExcludeTools, cascade.ExcludeTools)
 	req.SkipTagFilter = len(configuredInitialTags) == 0 || req.SkipTagFilter || l.requestOverride.SkipTagFilter
 	req.RoutingFactors = hints
-	req.DelegationGating = firstNonEmpty(l.requestOverride.DelegationGating, req.DelegationGating, l.config.DelegationGating, l.requestBase.DelegationGating)
+	// Inherited gating is the weakest priority — own config and
+	// runtime overrides take precedence, but a container's
+	// "disabled" default reaches descendants when nothing closer
+	// declares a value.
+	req.DelegationGating = firstNonEmpty(l.requestOverride.DelegationGating, req.DelegationGating, l.config.DelegationGating, l.requestBase.DelegationGating, cascade.DelegationGating)
 	req.OnProgress = composeProgressFuncs(l.makeProgressFunc(), req.OnProgress, l.requestOverride.OnProgress)
 	req.InitialTags = mergeUniqueStrings(configuredInitialTags, l.activatedTags)
 	req.RuntimeTools = mergeRuntimeTools(l.config.RuntimeTools, req.RuntimeTools)

--- a/internal/runtime/loop/registry.go
+++ b/internal/runtime/loop/registry.go
@@ -79,13 +79,12 @@ func (r *Registry) Register(l *Loop) error {
 	l.setAncestorTagsFunc(func() []string {
 		return r.ancestorContainerTags(loopID)
 	})
-	l.setEffectiveStateFunc(func() ([]EffectiveTag, []EffectiveSubscription) {
+	l.setEffectiveStateFunc(func() effectiveStateResult {
 		// One walk, atomic snapshot: a second walk could observe a
 		// SetSubscriptions between the two calls and yield tags +
 		// subscriptions from different points in time. Status callers
 		// would have no way to tell.
-		subs, tags := r.effectiveState(loopID)
-		return tags, subs
+		return r.effectiveState(loopID)
 	})
 	r.logger.Debug("loop registered",
 		"loop_id", l.id,
@@ -239,6 +238,18 @@ func (r *Registry) Children(loopID string) []*Loop {
 	return children
 }
 
+// effectiveStateResult is the bundle returned by the shared internal
+// walker. Surfaced through dedicated Effective* methods rather than
+// directly so each public field can carry its own GoDoc and so the
+// internal shape can grow without changing every caller signature.
+type effectiveStateResult struct {
+	Subscriptions    []EffectiveSubscription
+	Tags             []EffectiveTag
+	ExcludeTools     []EffectiveExcludeTool
+	RoutingFactors   []EffectiveRoutingFactor
+	DelegationGating *EffectiveDelegationGating
+}
+
 // EffectiveSubscriptions returns the deduplicated effective entity
 // subscriptions for loopID with provenance: the union of the loop's
 // own Subscriptions and every container ancestor's, walked parent-
@@ -256,8 +267,7 @@ func (r *Registry) Children(loopID string) []*Loop {
 // ancestors are skipped to match the tag-inheritance contract from
 // Phase 1A.
 func (r *Registry) EffectiveSubscriptions(loopID string) []EffectiveSubscription {
-	subs, _ := r.effectiveState(loopID)
-	return subs
+	return r.effectiveState(loopID).Subscriptions
 }
 
 // EffectiveTags returns the deduplicated effective capability tags
@@ -266,8 +276,35 @@ func (r *Registry) EffectiveSubscriptions(loopID string) []EffectiveSubscription
 // [EffectiveOriginSelf] in From, inherited tags carry the ancestor
 // container's name.
 func (r *Registry) EffectiveTags(loopID string) []EffectiveTag {
-	_, tags := r.effectiveState(loopID)
-	return tags
+	return r.effectiveState(loopID).Tags
+}
+
+// EffectiveExcludeTools returns the deduplicated union of the loop's
+// own ExcludeTools and every container ancestor's, walked parent-
+// first. Union semantics mean a descendant cannot un-exclude a tool
+// the ancestor restricted; provenance on each entry tells the
+// operator (or model) where the exclusion came from.
+func (r *Registry) EffectiveExcludeTools(loopID string) []EffectiveExcludeTool {
+	return r.effectiveState(loopID).ExcludeTools
+}
+
+// EffectiveRoutingFactors returns the resolved routing-factor map
+// for loopID, walked parent-first with child-wins on key collision.
+// Each entry carries the origin loop name; collisions silently keep
+// the closest declaration. Returns nil when nothing in the chain
+// declares any factors.
+func (r *Registry) EffectiveRoutingFactors(loopID string) []EffectiveRoutingFactor {
+	return r.effectiveState(loopID).RoutingFactors
+}
+
+// EffectiveDelegationGating returns the resolved delegation-gating
+// value for loopID using closest-non-empty semantics: the loop's
+// own value wins if set; otherwise the nearest ancestor that
+// declares a non-empty value wins. Returns nil when no loop in the
+// chain declared a non-empty value (i.e. the agent default
+// applies).
+func (r *Registry) EffectiveDelegationGating(loopID string) *EffectiveDelegationGating {
+	return r.effectiveState(loopID).DelegationGating
 }
 
 // AncestorSubscriptions returns the same union [EffectiveSubscriptions]
@@ -308,14 +345,24 @@ func (r *Registry) ancestorContainerTags(loopID string) []string {
 	return inherited
 }
 
-// effectiveState is the shared single-pass walker behind
-// [EffectiveSubscriptions] and [EffectiveTags]. It snapshots the
-// parent chain under the registry lock (parent_id and operation are
-// construction-set invariants), then pulls each loop's subscriptions
-// via [Loop.Subscriptions], which clones under l.mu — preventing the
-// data race that would arise from reading l.config.Subscriptions
-// while holding only r.mu.
-func (r *Registry) effectiveState(loopID string) ([]EffectiveSubscription, []EffectiveTag) {
+// effectiveState is the shared single-pass walker behind every
+// Registry.Effective* method. It snapshots the parent chain under
+// the registry lock (parent_id and operation are construction-set
+// invariants), then pulls each loop's mutable state via the locked
+// snapshot accessors on [Loop] — preventing the data races that
+// would arise from reading l.config.* directly while holding only
+// r.mu.
+//
+// Each cascading field uses its own merge semantics:
+//
+//   - Subscriptions / Tags / ExcludeTools — union, first-wins on
+//     key (entity_id / tag / tool name). Closest declaration in
+//     the chain takes priority on collision.
+//   - RoutingFactors — map merge, child-wins on key collision.
+//     Same closest-declaration-wins behavior, just expressed over
+//     map[string]string instead of a slice.
+//   - DelegationGating — single scalar, closest non-empty wins.
+func (r *Registry) effectiveState(loopID string) effectiveStateResult {
 	r.mu.RLock()
 	walk := make([]*Loop, 0, 4)
 	current := r.loops[loopID]
@@ -337,15 +384,15 @@ func (r *Registry) effectiveState(loopID string) ([]EffectiveSubscription, []Eff
 	r.mu.RUnlock()
 
 	if len(walk) == 0 {
-		return nil, nil
+		return effectiveStateResult{}
 	}
 
-	var (
-		subs     []EffectiveSubscription
-		tags     []EffectiveTag
-		seenSubs = make(map[string]struct{})
-		seenTags = make(map[string]struct{})
-	)
+	result := effectiveStateResult{}
+	seenSubs := make(map[string]struct{})
+	seenTags := make(map[string]struct{})
+	seenExcludes := make(map[string]struct{})
+	seenFactors := make(map[string]struct{})
+
 	for i, l := range walk {
 		// The starting loop contributes regardless of operation; only
 		// ancestors are filtered to container nodes (matches the tag-
@@ -357,6 +404,7 @@ func (r *Registry) effectiveState(loopID string) ([]EffectiveSubscription, []Eff
 		if i > 0 {
 			origin = l.Name()
 		}
+
 		for _, sub := range l.Subscriptions() {
 			if sub.EntityID == "" {
 				continue
@@ -365,7 +413,7 @@ func (r *Registry) effectiveState(loopID string) ([]EffectiveSubscription, []Eff
 				continue
 			}
 			seenSubs[sub.EntityID] = struct{}{}
-			subs = append(subs, EffectiveSubscription{
+			result.Subscriptions = append(result.Subscriptions, EffectiveSubscription{
 				EntitySubscription: sub,
 				From:               origin,
 			})
@@ -378,10 +426,45 @@ func (r *Registry) effectiveState(loopID string) ([]EffectiveSubscription, []Eff
 				continue
 			}
 			seenTags[tag] = struct{}{}
-			tags = append(tags, EffectiveTag{Tag: tag, From: origin})
+			result.Tags = append(result.Tags, EffectiveTag{Tag: tag, From: origin})
+		}
+		for _, tool := range l.excludeToolsSnapshot() {
+			if tool == "" {
+				continue
+			}
+			if _, dup := seenExcludes[tool]; dup {
+				continue
+			}
+			seenExcludes[tool] = struct{}{}
+			result.ExcludeTools = append(result.ExcludeTools, EffectiveExcludeTool{
+				Tool: tool,
+				From: origin,
+			})
+		}
+		for key, value := range l.routingFactorsSnapshot() {
+			if key == "" {
+				continue
+			}
+			if _, dup := seenFactors[key]; dup {
+				continue
+			}
+			seenFactors[key] = struct{}{}
+			result.RoutingFactors = append(result.RoutingFactors, EffectiveRoutingFactor{
+				Key:   key,
+				Value: value,
+				From:  origin,
+			})
+		}
+		if result.DelegationGating == nil {
+			if gating := l.delegationGatingSnapshot(); gating != "" {
+				result.DelegationGating = &EffectiveDelegationGating{
+					Value: gating,
+					From:  origin,
+				}
+			}
 		}
 	}
-	return subs, tags
+	return result
 }
 
 // FindByName returns all live loops with the exact given name.

--- a/internal/runtime/loop/subscription.go
+++ b/internal/runtime/loop/subscription.go
@@ -111,3 +111,47 @@ type EffectiveTag struct {
 	// directly-declared tags, ancestor loop name otherwise.
 	From string `yaml:"from" json:"from"`
 }
+
+// EffectiveExcludeTool is a tool-exclusion entry annotated with its
+// origin in the loop graph. ExcludeTools cascades by union — every
+// ancestor's excludes contribute and a child cannot un-exclude a
+// container's restriction. This makes "no shell_exec in this
+// subtree" a structural safety guarantee. Returned by
+// [Registry.EffectiveExcludeTools].
+type EffectiveExcludeTool struct {
+	// Tool is the tool name that is excluded.
+	Tool string `yaml:"tool" json:"tool"`
+	// From follows the same provenance contract as [EffectiveTag.From].
+	From string `yaml:"from" json:"from"`
+}
+
+// EffectiveRoutingFactor is one routing-factor entry annotated with
+// its origin in the loop graph. RoutingFactors cascade with
+// child-wins semantics on key collision — a descendant's value
+// overrides the ancestor's. Returned by
+// [Registry.EffectiveRoutingFactors].
+type EffectiveRoutingFactor struct {
+	// Key is the routing-factor name.
+	Key string `yaml:"key" json:"key"`
+	// Value is the routing-factor value at this level of the graph.
+	Value string `yaml:"value" json:"value"`
+	// From is [EffectiveOriginSelf] when this loop declared the
+	// value, or the ancestor loop's name when it was inherited.
+	From string `yaml:"from" json:"from"`
+}
+
+// EffectiveDelegationGating is the resolved delegation-gating
+// directive plus its origin. DelegationGating cascades with
+// closest-non-empty semantics — the loop's own value wins if set;
+// otherwise the closest ancestor that declares a non-empty value
+// wins; otherwise the result is "". Returned by
+// [Registry.EffectiveDelegationGating] as a pointer so the absence
+// of a declaration anywhere in the chain is distinguishable from
+// the empty-string value (today empty means "no override" so the
+// distinction doesn't load-bear, but it leaves room).
+type EffectiveDelegationGating struct {
+	// Value is the resolved gating string (e.g. "disabled").
+	Value string `yaml:"value" json:"value"`
+	// From follows the same provenance contract as [EffectiveTag.From].
+	From string `yaml:"from" json:"from"`
+}


### PR DESCRIPTION
## Summary

PR-C of the [#889](https://github.com/nugget/thane-ai-agent/issues/889) structural-inheritance rollout. Three iteration-time fields cascade through ancestor containers via the EffectiveState machinery from PR-B, each with its own merge semantics:

- **`ExcludeTools`** — union. Every ancestor that excludes a tool contributes; a child cannot un-exclude an ancestor's restriction. "No `shell_exec` under `home_automation`" becomes a structural safety guarantee.
- **`RoutingFactors`** — child-wins on key collision. Ancestors set defaults (`cluster=home`); descendants can override locally.
- **`Profile.DelegationGating`** — closest-non-empty. A container can default the subtree to `\"disabled\"` without forcing every descendant to repeat it; descendants with their own value win.

Each field plugs into the existing `DefinitionEffectiveState` struct alongside `Tags` / `Subscriptions`, with provenance on every entry so `loop_definition_get` and `loop_status` remain debuggable.

## Scope note

PR-C's plan in [#889](https://github.com/nugget/thane-ai-agent/issues/889) also listed `Conditions` cascade. That's split into a focused follow-up — `Conditions` are evaluated at definition-eligibility time against persisted specs, not at iteration time, and need a separate `DefinitionRegistry`-side ancestor walk. Keeping this PR focused on the three iteration-time fields that share the existing `EffectiveState` machinery.

## What changed

- **Effective types**: `EffectiveExcludeTool{Tool, From}`, `EffectiveRoutingFactor{Key, Value, From}`, `EffectiveDelegationGating{Value, From}` mirror the `EffectiveTag` / `EffectiveSubscription` shape from PR-B.
- **`effectiveState` walker**: extended to compute all five cascading fields in one ancestor walk. Returns a single `effectiveStateResult` struct (replaces the prior pair return). Per-field merge semantics live in the walker; surface and iteration-time consumers see ready-to-use values.
- **`Registry.EffectiveExcludeTools` / `EffectiveRoutingFactors` / `EffectiveDelegationGating`** — public methods backed by the shared walker.
- **`DefinitionEffectiveState`** grows `ExcludeTools`, `RoutingFactors`, `DelegationGating` fields for `loop_definition_get`.
- **`Status`** grows `EffectiveExcludeTools`, `EffectiveRoutingFactors`, `EffectiveDelegationGating` for `loop_status`.
- **`prepareAgentTurnRequest`** — new `inheritedCascade` helper projects out the inherited-only portion of effective state and folds it into the existing merge chain at the weakest priority. Loop's own config / per-turn / per-launch values all win on collision; inherited values set defaults.

## Example response shape

For a leaf `morning_brief` inside container `home_automation`:

```jsonc
{
  \"effective\": {
    \"tags\": [{\"tag\": \"news\", \"from\": \"self\"}, {\"tag\": \"home\", \"from\": \"home_automation\"}],
    \"subscriptions\": [...],
    \"exclude_tools\": [
      {\"tool\": \"shell_exec\", \"from\": \"home_automation\"}
    ],
    \"routing_factors\": [
      {\"key\": \"cluster\", \"value\": \"edge\", \"from\": \"self\"},
      {\"key\": \"environment\", \"value\": \"production\", \"from\": \"home_automation\"}
    ],
    \"delegation_gating\": {\"value\": \"disabled\", \"from\": \"home_automation\"}
  }
}
```

## Test plan

- [x] \`just ci\` green locally (race detector clean)
- [x] \`internal/runtime/loop/cascade_test.go\`:
  - ExcludeTools union — both levels' entries appear, closest-wins provenance on collision
  - RoutingFactors child-wins on key collision, ancestor-only keys preserved with origin
  - DelegationGating closest-non-empty walk skips intermediate empty ancestors
  - DelegationGating nil when nothing in chain declares
  - `prepareAgentTurnRequest` end-to-end: cascade lands on the prepared `Request`
  - `Status` surface includes all three new effective fields populated by the registry hook
- [ ] After landing: live exercise of `loop_definition_get` for a container+child pair to confirm JSON shape

## Followups

Remaining on [#889](https://github.com/nugget/thane-ai-agent/issues/889):
- **PR-C2** (new): `Conditions` cascade — needs DefinitionRegistry-side ancestor walk; AND semantics across ancestors
- **PR-D**: `operation: core` + gource-style UI variant

🤖 Generated with [Claude Code](https://claude.com/claude-code)