### PR TITLE
refactor: cascade Conditions through definition ancestors (PR-C2 of #889)

### DIFF
--- a/internal/app/loop_definition_runtime.go
+++ b/internal/app/loop_definition_runtime.go
@@ -169,6 +169,19 @@ func (r *loopDefinitionRuntime) serviceContext() context.Context {
 	return context.Background()
 }
 
+// evaluateConditions runs the cascade-aware eligibility check for
+// loopName at the runtime's current clock. Falls back to a
+// permanently-eligible status when the definitions registry is
+// unwired (test paths) so the check sites that gate on Eligible
+// don't accidentally block when the registry is mocked away.
+func (r *loopDefinitionRuntime) evaluateConditions(loopName string) looppkg.DefinitionEligibilityStatus {
+	if r == nil || r.definitions == nil {
+		return looppkg.DefinitionEligibilityStatus{Eligible: true}
+	}
+	status, _ := r.definitions.EvaluateConditions(loopName, r.nowTime())
+	return status
+}
+
 func (r *loopDefinitionRuntime) nextScheduleTransition(now time.Time) time.Time {
 	if r == nil || r.definitions == nil {
 		return time.Time{}
@@ -182,7 +195,7 @@ func (r *loopDefinitionRuntime) nextScheduleTransition(now time.Time) time.Time 
 		if def.Spec.Operation != looppkg.OperationService || def.PolicyState != looppkg.DefinitionPolicyStateActive {
 			continue
 		}
-		eligibility := def.Spec.Conditions.Evaluate(now)
+		eligibility, _ := r.definitions.EvaluateConditions(def.Name, now)
 		if eligibility.NextTransitionAt.IsZero() {
 			continue
 		}
@@ -331,7 +344,7 @@ func (r *loopDefinitionRuntime) bootstrapDefinitionSpawn(ctx context.Context, de
 	case def.PolicyState == looppkg.DefinitionPolicyStatePaused:
 		result.SkippedPaused++
 		return nil
-	case !def.Spec.Conditions.Evaluate(r.nowTime()).Eligible:
+	case !r.evaluateConditions(def.Name).Eligible:
 		result.SkippedIneligible++
 		return nil
 	case r.loops.GetByName(spec.Name) != nil:
@@ -425,7 +438,7 @@ func (r *loopDefinitionRuntime) ReconcileDefinition(ctx context.Context, name st
 		}
 		return nil
 	}
-	eligibility := def.Spec.Conditions.Evaluate(r.nowTime())
+	eligibility := r.evaluateConditions(def.Name)
 	durable := def.Spec.Operation == looppkg.OperationService || def.Spec.Operation == looppkg.OperationContainer
 	if !durable || def.PolicyState != looppkg.DefinitionPolicyStateActive || !eligibility.Eligible {
 		if existing != nil {
@@ -491,7 +504,7 @@ func (r *loopDefinitionRuntime) LaunchDefinition(ctx context.Context, name strin
 	case looppkg.DefinitionPolicyStatePaused:
 		return looppkg.LaunchResult{}, &looppkg.PausedDefinitionError{Name: name}
 	}
-	if eligibility := def.Spec.Conditions.Evaluate(r.nowTime()); !eligibility.Eligible {
+	if eligibility := r.evaluateConditions(name); !eligibility.Eligible {
 		return looppkg.LaunchResult{}, &looppkg.IneligibleDefinitionError{Name: name, Reason: eligibility.Reason}
 	}
 	if def.Spec.Operation == looppkg.OperationService || def.Spec.Operation == looppkg.OperationContainer {

--- a/internal/runtime/loop/conditions.go
+++ b/internal/runtime/loop/conditions.go
@@ -67,11 +67,12 @@ type DefinitionEligibilityStatus struct {
 // EffectiveConditionEvaluation pairs one definition's eligibility
 // status with the loop that owns it, used by the effective-
 // eligibility surface to attribute which ancestor blocks the chain.
-// "self" is the owning definition; otherwise the ancestor's name.
+// Only the leaf and its container ancestors appear here — non-
+// container ancestors don't contribute and are silently walked past
+// (see [EvaluateEffectiveConditions]).
 type EffectiveConditionEvaluation struct {
 	// From is [EffectiveOriginSelf] for the loop's own conditions,
-	// or the ancestor's name when the entry came from a container
-	// ancestor.
+	// or the container ancestor's name when inherited.
 	From string `yaml:"from" json:"from"`
 	// Status is the result of [Conditions.Evaluate] for the owning
 	// loop, computed at the evaluation time supplied to
@@ -81,18 +82,25 @@ type EffectiveConditionEvaluation struct {
 
 // EvaluateEffectiveConditions aggregates one definition's
 // eligibility with its container ancestors' eligibility. Every
-// ancestor must independently report eligible for the result to be
-// eligible — AND across the chain. When ineligible, the returned
-// status's Reason names the closest blocking ancestor so the
-// operator (or model) sees which level of the tree is gating the
-// loop. The per-level evaluations are returned alongside so the
-// effective surface can show provenance.
+// container ancestor must independently report eligible for the
+// result to be eligible — AND across the chain. When ineligible,
+// the returned status's Reason names the closest blocking ancestor
+// so the operator (or model) sees which level of the tree is
+// gating the loop. The per-level evaluations are returned alongside
+// so the effective surface can show provenance.
 //
-// chain is expected to be parent-first (own definition at index 0,
-// immediate parent at 1, etc.) — the shape
-// [DefinitionRegistry.AncestorSpecs] returns when called with the
-// loop's name prepended. now is the evaluation time, threaded
-// through so callers can substitute a fixed clock in tests.
+// Only the leaf itself (chain[0]) and container ancestors
+// contribute. Non-container ancestors are walked past silently —
+// matches the inheritance contract established in PR-A/B/C, where
+// only [OperationContainer] nodes pass scope down to descendants.
+// A service-loop ancestor with ineligible Conditions does not
+// block its descendant.
+//
+// chain is leaf-first: index 0 is the loop's own spec, index 1 is
+// its immediate parent, and so on — the shape
+// [DefinitionRegistry.AncestorSpecs] returns. now is the
+// evaluation time, threaded through so callers can substitute a
+// fixed clock in tests.
 func EvaluateEffectiveConditions(chain []Spec, now time.Time) (DefinitionEligibilityStatus, []EffectiveConditionEvaluation) {
 	if len(chain) == 0 {
 		return DefinitionEligibilityStatus{Eligible: true}, nil
@@ -103,6 +111,14 @@ func EvaluateEffectiveConditions(chain []Spec, now time.Time) (DefinitionEligibi
 	var blockingFrom string
 
 	for i, spec := range chain {
+		// Leaf contributes regardless of operation; ancestors must be
+		// containers to participate in the cascade. Skip silently —
+		// non-container nodes don't appear in the per-level
+		// evaluations because they didn't contribute.
+		if i > 0 && spec.Operation != OperationContainer {
+			continue
+		}
+
 		status := spec.Conditions.Evaluate(now)
 		from := EffectiveOriginSelf
 		if i > 0 {
@@ -116,7 +132,7 @@ func EvaluateEffectiveConditions(chain []Spec, now time.Time) (DefinitionEligibi
 		if !status.Eligible {
 			if aggregate.Eligible {
 				// First ineligible we encounter wins attribution.
-				// Walking parent-first means this is the closest
+				// Walking leaf-first means this is the closest
 				// blocking ancestor (or self), which is the most
 				// actionable thing to surface.
 				aggregate.Eligible = false

--- a/internal/runtime/loop/conditions.go
+++ b/internal/runtime/loop/conditions.go
@@ -64,6 +64,94 @@ type DefinitionEligibilityStatus struct {
 	NextTransitionAt time.Time `yaml:"next_transition_at,omitempty" json:"next_transition_at,omitempty"`
 }
 
+// EffectiveConditionEvaluation pairs one definition's eligibility
+// status with the loop that owns it, used by the effective-
+// eligibility surface to attribute which ancestor blocks the chain.
+// "self" is the owning definition; otherwise the ancestor's name.
+type EffectiveConditionEvaluation struct {
+	// From is [EffectiveOriginSelf] for the loop's own conditions,
+	// or the ancestor's name when the entry came from a container
+	// ancestor.
+	From string `yaml:"from" json:"from"`
+	// Status is the result of [Conditions.Evaluate] for the owning
+	// loop, computed at the evaluation time supplied to
+	// [EvaluateEffectiveConditions].
+	Status DefinitionEligibilityStatus `yaml:"status" json:"status"`
+}
+
+// EvaluateEffectiveConditions aggregates one definition's
+// eligibility with its container ancestors' eligibility. Every
+// ancestor must independently report eligible for the result to be
+// eligible — AND across the chain. When ineligible, the returned
+// status's Reason names the closest blocking ancestor so the
+// operator (or model) sees which level of the tree is gating the
+// loop. The per-level evaluations are returned alongside so the
+// effective surface can show provenance.
+//
+// chain is expected to be parent-first (own definition at index 0,
+// immediate parent at 1, etc.) — the shape
+// [DefinitionRegistry.AncestorSpecs] returns when called with the
+// loop's name prepended. now is the evaluation time, threaded
+// through so callers can substitute a fixed clock in tests.
+func EvaluateEffectiveConditions(chain []Spec, now time.Time) (DefinitionEligibilityStatus, []EffectiveConditionEvaluation) {
+	if len(chain) == 0 {
+		return DefinitionEligibilityStatus{Eligible: true}, nil
+	}
+
+	evaluations := make([]EffectiveConditionEvaluation, 0, len(chain))
+	aggregate := DefinitionEligibilityStatus{Eligible: true}
+	var blockingFrom string
+
+	for i, spec := range chain {
+		status := spec.Conditions.Evaluate(now)
+		from := EffectiveOriginSelf
+		if i > 0 {
+			from = spec.Name
+		}
+		evaluations = append(evaluations, EffectiveConditionEvaluation{
+			From:   from,
+			Status: status,
+		})
+
+		if !status.Eligible {
+			if aggregate.Eligible {
+				// First ineligible we encounter wins attribution.
+				// Walking parent-first means this is the closest
+				// blocking ancestor (or self), which is the most
+				// actionable thing to surface.
+				aggregate.Eligible = false
+				aggregate.Reason = status.Reason
+				blockingFrom = from
+			}
+		}
+
+		// NextTransitionAt rolls up to the earliest transition across
+		// the chain — eligibility could change because this level's
+		// schedule advances OR because some ancestor's schedule
+		// advances. The earliest wins as the meaningful "watch this
+		// time" value for schedulers.
+		if !status.NextTransitionAt.IsZero() {
+			if aggregate.NextTransitionAt.IsZero() || status.NextTransitionAt.Before(aggregate.NextTransitionAt) {
+				aggregate.NextTransitionAt = status.NextTransitionAt
+			}
+		}
+	}
+
+	if !aggregate.Eligible && blockingFrom != "" && blockingFrom != EffectiveOriginSelf {
+		// Suffix the attribution to the reason so callers reading
+		// just the reason string still see which ancestor blocked
+		// them. Keep the underlying reason in place so existing
+		// matchers (tests, log greps) still work.
+		if strings.TrimSpace(aggregate.Reason) == "" {
+			aggregate.Reason = fmt.Sprintf("blocked by container %q", blockingFrom)
+		} else {
+			aggregate.Reason = fmt.Sprintf("%s (blocked by container %q)", aggregate.Reason, blockingFrom)
+		}
+	}
+
+	return aggregate, evaluations
+}
+
 // IneligibleDefinitionError reports that a loop definition exists and
 // is active by policy, but its runtime conditions do not currently
 // permit launch.

--- a/internal/runtime/loop/conditions_cascade_test.go
+++ b/internal/runtime/loop/conditions_cascade_test.go
@@ -15,7 +15,7 @@ func TestEvaluateEffectiveConditionsAllEligible(t *testing.T) {
 	now := time.Date(2026, 5, 25, 14, 0, 0, 0, time.UTC) // Monday afternoon
 	chain := []Spec{
 		{Name: "leaf"}, // no conditions = always eligible
-		{Name: "parent"},
+		{Name: "parent", Operation: OperationContainer},
 	}
 
 	agg, evals := EvaluateEffectiveConditions(chain, now)
@@ -33,6 +33,46 @@ func TestEvaluateEffectiveConditionsAllEligible(t *testing.T) {
 	}
 }
 
+// TestEvaluateEffectiveConditionsSkipsNonContainerAncestors guards
+// the inheritance contract: only container ancestors gate
+// descendants. A service-loop ancestor with ineligible Conditions
+// must NOT block its descendant, since service loops don't pass
+// scope down the way containers do. This is the regression test
+// for the bug where the cascade evaluated every ancestor
+// indiscriminately.
+func TestEvaluateEffectiveConditionsSkipsNonContainerAncestors(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 5, 24, 14, 0, 0, 0, time.UTC) // Sunday
+	weekdays := &ScheduleCondition{
+		Timezone: "UTC",
+		Windows: []ScheduleWindow{
+			{Days: []string{"mon", "tue", "wed", "thu", "fri"}, Start: "09:00", End: "17:00"},
+		},
+	}
+	chain := []Spec{
+		{Name: "leaf"},
+		{
+			Name:       "service_parent",
+			Operation:  OperationService,
+			Conditions: Conditions{Schedule: weekdays},
+		},
+	}
+
+	agg, evals := EvaluateEffectiveConditions(chain, now)
+	if !agg.Eligible {
+		t.Errorf("aggregate should be eligible; non-container ancestor must not gate descendant, got %+v", agg)
+	}
+	// The non-container ancestor is walked past silently, so the per-
+	// level evaluations include only the leaf.
+	if len(evals) != 1 {
+		t.Fatalf("evals len = %d, want 1 (only self contributes)", len(evals))
+	}
+	if evals[0].From != EffectiveOriginSelf {
+		t.Errorf("evals[0].From = %q, want self", evals[0].From)
+	}
+}
+
 // TestEvaluateEffectiveConditionsAncestorBlocks is the load-bearing
 // test for PR-C2: a leaf with no conditions still becomes ineligible
 // when an ancestor container's schedule is outside its window. The
@@ -46,7 +86,8 @@ func TestEvaluateEffectiveConditionsAncestorBlocks(t *testing.T) {
 	chain := []Spec{
 		{Name: "leaf"},
 		{
-			Name: "work_hours",
+			Name:      "work_hours",
+			Operation: OperationContainer,
 			Conditions: Conditions{
 				Schedule: &ScheduleCondition{
 					Timezone: "UTC",
@@ -91,8 +132,8 @@ func TestEvaluateEffectiveConditionsClosestBlockingWins(t *testing.T) {
 	}
 	chain := []Spec{
 		{Name: "leaf"},
-		{Name: "near_block", Conditions: Conditions{Schedule: schedule}},
-		{Name: "far_block", Conditions: Conditions{Schedule: schedule}},
+		{Name: "near_block", Operation: OperationContainer, Conditions: Conditions{Schedule: schedule}},
+		{Name: "far_block", Operation: OperationContainer, Conditions: Conditions{Schedule: schedule}},
 	}
 
 	agg, _ := EvaluateEffectiveConditions(chain, now)
@@ -160,7 +201,8 @@ func TestEvaluateEffectiveConditionsNextTransitionEarliest(t *testing.T) {
 			}},
 		},
 		{
-			Name: "ancestor",
+			Name:      "ancestor",
+			Operation: OperationContainer,
 			Conditions: Conditions{Schedule: &ScheduleCondition{
 				Timezone: "UTC",
 				Windows: []ScheduleWindow{

--- a/internal/runtime/loop/conditions_cascade_test.go
+++ b/internal/runtime/loop/conditions_cascade_test.go
@@ -1,0 +1,362 @@
+package loop
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestEvaluateEffectiveConditionsAllEligible covers the happy path:
+// when every ancestor and the leaf are eligible, the aggregate is
+// eligible and each per-level evaluation reports the same.
+func TestEvaluateEffectiveConditionsAllEligible(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 5, 25, 14, 0, 0, 0, time.UTC) // Monday afternoon
+	chain := []Spec{
+		{Name: "leaf"}, // no conditions = always eligible
+		{Name: "parent"},
+	}
+
+	agg, evals := EvaluateEffectiveConditions(chain, now)
+	if !agg.Eligible {
+		t.Errorf("aggregate Eligible = false, want true: %+v", agg)
+	}
+	if len(evals) != 2 {
+		t.Fatalf("evals len = %d, want 2", len(evals))
+	}
+	if evals[0].From != EffectiveOriginSelf {
+		t.Errorf("evals[0].From = %q, want self", evals[0].From)
+	}
+	if evals[1].From != "parent" {
+		t.Errorf("evals[1].From = %q, want parent", evals[1].From)
+	}
+}
+
+// TestEvaluateEffectiveConditionsAncestorBlocks is the load-bearing
+// test for PR-C2: a leaf with no conditions still becomes ineligible
+// when an ancestor container's schedule is outside its window. The
+// reason names the blocking ancestor.
+func TestEvaluateEffectiveConditionsAncestorBlocks(t *testing.T) {
+	t.Parallel()
+
+	// Set "now" to a Sunday so the work_hours window (mon-fri) is
+	// outside. Use UTC for deterministic comparison.
+	now := time.Date(2026, 5, 24, 14, 0, 0, 0, time.UTC) // Sunday
+	chain := []Spec{
+		{Name: "leaf"},
+		{
+			Name: "work_hours",
+			Conditions: Conditions{
+				Schedule: &ScheduleCondition{
+					Timezone: "UTC",
+					Windows: []ScheduleWindow{
+						{Days: []string{"mon", "tue", "wed", "thu", "fri"}, Start: "09:00", End: "17:00"},
+					},
+				},
+			},
+		},
+	}
+
+	agg, evals := EvaluateEffectiveConditions(chain, now)
+	if agg.Eligible {
+		t.Errorf("aggregate Eligible = true, want false (ancestor blocks)")
+	}
+	if !strings.Contains(agg.Reason, "work_hours") {
+		t.Errorf("Reason = %q, should name the blocking ancestor work_hours", agg.Reason)
+	}
+	if len(evals) != 2 {
+		t.Fatalf("evals len = %d, want 2", len(evals))
+	}
+	if !evals[0].Status.Eligible {
+		t.Error("leaf's own evaluation should still report eligible")
+	}
+	if evals[1].Status.Eligible {
+		t.Error("work_hours ancestor should report ineligible")
+	}
+}
+
+// TestEvaluateEffectiveConditionsClosestBlockingWins covers
+// attribution when multiple ancestors would block: the closest one
+// (parent-first walk) wins the Reason field. Surfaces the most
+// actionable bit — fix this level, not the most distant one.
+func TestEvaluateEffectiveConditionsClosestBlockingWins(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 5, 24, 14, 0, 0, 0, time.UTC) // Sunday
+	weekdays := []string{"mon", "tue", "wed", "thu", "fri"}
+	schedule := &ScheduleCondition{
+		Timezone: "UTC",
+		Windows:  []ScheduleWindow{{Days: weekdays, Start: "09:00", End: "17:00"}},
+	}
+	chain := []Spec{
+		{Name: "leaf"},
+		{Name: "near_block", Conditions: Conditions{Schedule: schedule}},
+		{Name: "far_block", Conditions: Conditions{Schedule: schedule}},
+	}
+
+	agg, _ := EvaluateEffectiveConditions(chain, now)
+	if agg.Eligible {
+		t.Fatal("aggregate should be ineligible")
+	}
+	if !strings.Contains(agg.Reason, "near_block") {
+		t.Errorf("Reason = %q, should name the closest blocking ancestor near_block", agg.Reason)
+	}
+	if strings.Contains(agg.Reason, "far_block") {
+		t.Errorf("Reason = %q, should not name the far ancestor — only the closest blocker is actionable", agg.Reason)
+	}
+}
+
+// TestEvaluateEffectiveConditionsOwnBlockSkipsAttribution covers
+// the "self blocks self" path: when the leaf's own conditions are
+// ineligible, the reason carries the underlying condition message
+// without a misleading "blocked by container" suffix.
+func TestEvaluateEffectiveConditionsOwnBlockSkipsAttribution(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 5, 24, 14, 0, 0, 0, time.UTC)
+	chain := []Spec{
+		{
+			Name: "leaf",
+			Conditions: Conditions{
+				Schedule: &ScheduleCondition{
+					Timezone: "UTC",
+					Windows: []ScheduleWindow{
+						{Days: []string{"mon"}, Start: "09:00", End: "17:00"},
+					},
+				},
+			},
+		},
+	}
+
+	agg, _ := EvaluateEffectiveConditions(chain, now)
+	if agg.Eligible {
+		t.Fatal("leaf with off-schedule condition should be ineligible")
+	}
+	if strings.Contains(agg.Reason, "blocked by container") {
+		t.Errorf("Reason = %q, should not blame a container when self blocks", agg.Reason)
+	}
+}
+
+// TestEvaluateEffectiveConditionsNextTransitionEarliest verifies
+// that NextTransitionAt rolls up to the earliest transition across
+// the chain. Schedulers need the soonest meaningful tick, not just
+// the leaf's own.
+func TestEvaluateEffectiveConditionsNextTransitionEarliest(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 5, 25, 14, 0, 0, 0, time.UTC) // Monday afternoon
+
+	// Leaf: window 13:00-23:00 → transitions at 23:00 today.
+	// Ancestor: window 10:00-15:00 → transitions at 15:00 today (earlier).
+	chain := []Spec{
+		{
+			Name: "leaf",
+			Conditions: Conditions{Schedule: &ScheduleCondition{
+				Timezone: "UTC",
+				Windows: []ScheduleWindow{
+					{Days: []string{"mon"}, Start: "13:00", End: "23:00"},
+				},
+			}},
+		},
+		{
+			Name: "ancestor",
+			Conditions: Conditions{Schedule: &ScheduleCondition{
+				Timezone: "UTC",
+				Windows: []ScheduleWindow{
+					{Days: []string{"mon"}, Start: "10:00", End: "15:00"},
+				},
+			}},
+		},
+	}
+
+	agg, _ := EvaluateEffectiveConditions(chain, now)
+	if !agg.Eligible {
+		t.Fatal("both windows include 14:00 Monday — aggregate should be eligible")
+	}
+	expected := time.Date(2026, 5, 25, 15, 0, 0, 0, time.UTC)
+	if !agg.NextTransitionAt.Equal(expected) {
+		t.Errorf("NextTransitionAt = %v, want %v (earliest across chain)", agg.NextTransitionAt, expected)
+	}
+}
+
+// TestDefinitionRegistryAncestorSpecs covers the walk shape: the
+// returned chain is leaf-first, terminates at root, and ignores
+// loops in the parent_name graph.
+func TestDefinitionRegistryAncestorSpecs(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	reg, err := NewDefinitionRegistry(nil)
+	if err != nil {
+		t.Fatalf("NewDefinitionRegistry: %v", err)
+	}
+
+	root := Spec{Name: "root", Operation: OperationContainer}
+	mid := Spec{Name: "mid", Operation: OperationContainer, ParentName: "root"}
+	leaf := Spec{
+		Name:         "leaf",
+		Task:         "t",
+		Operation:    OperationService,
+		SleepMin:     time.Minute,
+		SleepMax:     time.Minute,
+		SleepDefault: time.Minute,
+		ParentName:   "mid",
+	}
+	for _, s := range []Spec{root, mid, leaf} {
+		if err := reg.Upsert(s, now); err != nil {
+			t.Fatalf("upsert %s: %v", s.Name, err)
+		}
+	}
+
+	chain := reg.AncestorSpecs("leaf")
+	if len(chain) != 3 {
+		t.Fatalf("chain len = %d, want 3 (leaf, mid, root)", len(chain))
+	}
+	if chain[0].Name != "leaf" || chain[1].Name != "mid" || chain[2].Name != "root" {
+		t.Errorf("walk order = [%s %s %s], want [leaf mid root]", chain[0].Name, chain[1].Name, chain[2].Name)
+	}
+
+	if chain := reg.AncestorSpecs("nonexistent"); chain != nil {
+		t.Errorf("unknown name returned %v, want nil", chain)
+	}
+}
+
+// TestDefinitionRegistryEvaluateConditionsCascades verifies the
+// convenience wrapper actually walks the chain — a leaf with no
+// own conditions becomes ineligible when an ancestor's schedule
+// is closed.
+func TestDefinitionRegistryEvaluateConditionsCascades(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 5, 24, 14, 0, 0, 0, time.UTC) // Sunday
+	reg, err := NewDefinitionRegistry(nil)
+	if err != nil {
+		t.Fatalf("NewDefinitionRegistry: %v", err)
+	}
+
+	weekday := &ScheduleCondition{
+		Timezone: "UTC",
+		Windows: []ScheduleWindow{
+			{Days: []string{"mon", "tue", "wed", "thu", "fri"}, Start: "09:00", End: "17:00"},
+		},
+	}
+	if err := reg.Upsert(Spec{Name: "weekdays", Operation: OperationContainer, Conditions: Conditions{Schedule: weekday}}, now); err != nil {
+		t.Fatalf("upsert ancestor: %v", err)
+	}
+	if err := reg.Upsert(Spec{
+		Name:         "leaf",
+		Task:         "t",
+		Operation:    OperationService,
+		SleepMin:     time.Minute,
+		SleepMax:     time.Minute,
+		SleepDefault: time.Minute,
+		ParentName:   "weekdays",
+	}, now); err != nil {
+		t.Fatalf("upsert leaf: %v", err)
+	}
+
+	status, evals := reg.EvaluateConditions("leaf", now)
+	if status.Eligible {
+		t.Errorf("leaf should be ineligible due to ancestor schedule, got %+v", status)
+	}
+	if !strings.Contains(status.Reason, "weekdays") {
+		t.Errorf("Reason = %q, should name the weekdays ancestor", status.Reason)
+	}
+	if len(evals) != 2 {
+		t.Fatalf("evals len = %d, want 2 (leaf + ancestor)", len(evals))
+	}
+}
+
+// TestBuildDefinitionRegistryViewSurfacesEffectiveConditions
+// is the end-to-end test: a leaf blocked by an ancestor's schedule
+// surfaces as ineligible on its DefinitionView, with the per-level
+// EffectiveConditions slice populated for the cascade.
+func TestBuildDefinitionRegistryViewSurfacesEffectiveConditions(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 5, 24, 14, 0, 0, 0, time.UTC) // Sunday
+	reg, err := NewDefinitionRegistry(nil)
+	if err != nil {
+		t.Fatalf("NewDefinitionRegistry: %v", err)
+	}
+	weekday := &ScheduleCondition{
+		Timezone: "UTC",
+		Windows: []ScheduleWindow{
+			{Days: []string{"mon", "tue", "wed", "thu", "fri"}, Start: "09:00", End: "17:00"},
+		},
+	}
+	if err := reg.Upsert(Spec{Name: "weekdays", Operation: OperationContainer, Conditions: Conditions{Schedule: weekday}}, now); err != nil {
+		t.Fatalf("upsert ancestor: %v", err)
+	}
+	if err := reg.Upsert(Spec{
+		Name:         "leaf",
+		Task:         "t",
+		Operation:    OperationService,
+		SleepMin:     time.Minute,
+		SleepMax:     time.Minute,
+		SleepDefault: time.Minute,
+		ParentName:   "weekdays",
+	}, now); err != nil {
+		t.Fatalf("upsert leaf: %v", err)
+	}
+
+	view := buildDefinitionRegistryViewAt(reg.Snapshot(), nil, now)
+	if view == nil {
+		t.Fatal("nil view")
+	}
+
+	var leaf *DefinitionView
+	for i := range view.Definitions {
+		if view.Definitions[i].Name == "leaf" {
+			leaf = &view.Definitions[i]
+			break
+		}
+	}
+	if leaf == nil {
+		t.Fatal("leaf not in view")
+	}
+	if leaf.Eligibility.Eligible {
+		t.Errorf("leaf Eligibility = %+v, want ineligible due to ancestor", leaf.Eligibility)
+	}
+	if len(leaf.EffectiveConditions) != 2 {
+		t.Fatalf("EffectiveConditions len = %d, want 2: %+v", len(leaf.EffectiveConditions), leaf.EffectiveConditions)
+	}
+	if leaf.EffectiveConditions[0].From != EffectiveOriginSelf {
+		t.Errorf("EffectiveConditions[0].From = %q, want self", leaf.EffectiveConditions[0].From)
+	}
+	if leaf.EffectiveConditions[1].From != "weekdays" {
+		t.Errorf("EffectiveConditions[1].From = %q, want weekdays", leaf.EffectiveConditions[1].From)
+	}
+}
+
+// TestBuildDefinitionRegistryViewOmitsEffectiveConditionsForOrphans
+// keeps the view tidy: a definition without container ancestors
+// already carries its eligibility in DefinitionView.Eligibility, so
+// adding a single-entry EffectiveConditions list would be noise.
+func TestBuildDefinitionRegistryViewOmitsEffectiveConditionsForOrphans(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 5, 25, 14, 0, 0, 0, time.UTC)
+	reg, err := NewDefinitionRegistry([]Spec{
+		{
+			Name:         "loner",
+			Enabled:      true,
+			Task:         "t",
+			Operation:    OperationService,
+			SleepMin:     time.Minute,
+			SleepMax:     time.Minute,
+			SleepDefault: time.Minute,
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewDefinitionRegistry: %v", err)
+	}
+	view := buildDefinitionRegistryViewAt(reg.Snapshot(), nil, now)
+	if view == nil {
+		t.Fatal("nil view")
+	}
+	if got := view.Definitions[0].EffectiveConditions; got != nil {
+		t.Errorf("EffectiveConditions = %+v, want nil for single-level definitions", got)
+	}
+}

--- a/internal/runtime/loop/definition_registry.go
+++ b/internal/runtime/loop/definition_registry.go
@@ -104,6 +104,90 @@ func NewDefinitionRegistry(base []Spec) (*DefinitionRegistry, error) {
 	}, nil
 }
 
+// AncestorSpecs walks the parent_name chain from the named
+// definition up to the topmost reachable ancestor and returns the
+// chain in walk order: index 0 is the loop's own spec, index 1 is
+// its immediate parent, and so on. Returns nil when the loop is
+// not found. The walk terminates when parent_name is empty or no
+// longer resolvable; short-circuits at [definitionAncestorWalkLimit]
+// to bound work against malformed graphs.
+//
+// Mirror of [Registry.Ancestors] but operating on the persisted
+// spec graph rather than the live loop graph. Used by
+// [EvaluateEffectiveConditions] and other definition-eligibility-
+// time surfaces that need to consult ancestor specs without
+// requiring the loop to be running.
+func (r *DefinitionRegistry) AncestorSpecs(name string) []Spec {
+	if r == nil {
+		return nil
+	}
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return nil
+	}
+
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	first, ok := r.specByName(name)
+	if !ok {
+		return nil
+	}
+
+	chain := []Spec{cloneSpec(first)}
+	seen := map[string]struct{}{name: {}}
+	current := first
+	for i := 0; i < definitionAncestorWalkLimit; i++ {
+		parentName := strings.TrimSpace(current.ParentName)
+		if parentName == "" {
+			break
+		}
+		if _, dup := seen[parentName]; dup {
+			break
+		}
+		parent, ok := r.specByName(parentName)
+		if !ok {
+			break
+		}
+		chain = append(chain, cloneSpec(parent))
+		seen[parentName] = struct{}{}
+		current = parent
+	}
+	return chain
+}
+
+// definitionAncestorWalkLimit caps the depth of [AncestorSpecs] in
+// the same spirit as [ancestorWalkLimit] for the live registry —
+// well above realistic graph depth but tight enough that a
+// malformed parent_name cycle terminates fast.
+const definitionAncestorWalkLimit = 64
+
+// EvaluateConditions walks the parent_name chain for the named
+// definition and evaluates Conditions across every ancestor with
+// AND semantics. Convenience wrapper around [AncestorSpecs] +
+// [EvaluateEffectiveConditions] for the common eligibility-check
+// surfaces. Returns (eligible=true, nil) when the definition is
+// not found — letting check sites stick with their existing
+// not-found handling rather than conflate "missing" with
+// "ineligible."
+func (r *DefinitionRegistry) EvaluateConditions(name string, now time.Time) (DefinitionEligibilityStatus, []EffectiveConditionEvaluation) {
+	chain := r.AncestorSpecs(name)
+	if len(chain) == 0 {
+		return DefinitionEligibilityStatus{Eligible: true}, nil
+	}
+	return EvaluateEffectiveConditions(chain, now)
+}
+
+// specByName reads the effective spec by name (overlay first, base
+// fallback). Caller must hold r.mu.RLock.
+func (r *DefinitionRegistry) specByName(name string) (Spec, bool) {
+	if record, ok := r.overlay[name]; ok {
+		return record.Spec, true
+	}
+	spec, ok := r.base[name]
+	return spec, ok
+}
+
 // Get returns the effective definition with the given name.
 func (r *DefinitionRegistry) Get(name string) (Spec, bool) {
 	if r == nil {

--- a/internal/runtime/loop/definition_view.go
+++ b/internal/runtime/loop/definition_view.go
@@ -1,6 +1,9 @@
 package loop
 
-import "time"
+import (
+	"strings"
+	"time"
+)
 
 const definitionRuntimeStateNotRunning = "not_running"
 
@@ -37,6 +40,13 @@ type DefinitionView struct {
 	Eligibility        DefinitionEligibilityStatus `yaml:"eligibility,omitempty" json:"eligibility"`
 	Runtime            DefinitionRuntimeStatus     `yaml:"runtime,omitempty" json:"runtime"`
 	Warnings           []DefinitionWarning         `yaml:"warnings,omitempty" json:"warnings,omitempty"`
+	// EffectiveConditions lists each ancestor's Conditions
+	// evaluation with provenance. Surfaces the cascade behind
+	// [Eligibility]: a leaf reading [Eligibility].Eligible=false
+	// can see *which* ancestor blocked it without re-walking the
+	// graph. Empty when the leaf has no container ancestors —
+	// [Eligibility] already carries the single-level result.
+	EffectiveConditions []EffectiveConditionEvaluation `yaml:"effective_conditions,omitempty" json:"effective_conditions,omitempty"`
 	// Effective surfaces the post-ancestor-merge state for inheritable
 	// loop fields. Nil when there is nothing meaningful to report —
 	// the loop isn't running, the view was built without a live
@@ -140,8 +150,19 @@ func buildDefinitionRegistryViewAt(snapshot *DefinitionRegistrySnapshot, runtime
 		Definitions:        make([]DefinitionView, 0, len(snapshot.Definitions)),
 	}
 
+	// Index the snapshot by name once so the eligibility cascade
+	// walks parent_name through the same snapshot we're rendering —
+	// avoids both per-definition registry lock acquisition and the
+	// risk of observing a different definition state between
+	// snapshot and ancestor lookup.
+	byName := make(map[string]Spec, len(snapshot.Definitions))
 	for _, def := range snapshot.Definitions {
-		eligibility := def.Spec.Conditions.Evaluate(now)
+		byName[def.Name] = def.Spec
+	}
+
+	for _, def := range snapshot.Definitions {
+		chain := ancestorChainFromSnapshot(byName, def.Name)
+		eligibility, conditionEvals := EvaluateEffectiveConditions(chain, now)
 		warnings := BuildDefinitionWarnings(def.Spec)
 		status, ok := runtime[def.Name]
 		if ok && status.Running {
@@ -171,6 +192,14 @@ func buildDefinitionRegistryViewAt(snapshot *DefinitionRegistrySnapshot, runtime
 			Runtime:            status,
 			Warnings:           warnings,
 		}
+		// Surface the per-ancestor evaluations only when the cascade
+		// actually went through more than one level — for a leaf with
+		// no container parent, the single self-evaluation is already
+		// what [Eligibility] reports and adding a single-entry list
+		// would be noise.
+		if len(conditionEvals) > 1 {
+			dv.EffectiveConditions = conditionEvals
+		}
 		if options.loops != nil && status.Running && status.LoopID != "" {
 			// One walk per definition: per-field Effective* calls
 			// would do separate ancestor traversals that could observe
@@ -192,4 +221,37 @@ func buildDefinitionRegistryViewAt(snapshot *DefinitionRegistrySnapshot, runtime
 	}
 
 	return view
+}
+
+// ancestorChainFromSnapshot walks parent_name through a name-indexed
+// snapshot map and returns the chain in parent-first walk order
+// (index 0 is the leaf). Pure function over the snapshot — no
+// registry lock required — so the view builder can compute one
+// chain per definition without re-acquiring locks. Bounded by
+// [definitionAncestorWalkLimit] like [DefinitionRegistry.AncestorSpecs].
+func ancestorChainFromSnapshot(byName map[string]Spec, name string) []Spec {
+	spec, ok := byName[name]
+	if !ok {
+		return nil
+	}
+	chain := []Spec{spec}
+	seen := map[string]struct{}{name: {}}
+	current := spec
+	for i := 0; i < definitionAncestorWalkLimit; i++ {
+		parentName := strings.TrimSpace(current.ParentName)
+		if parentName == "" {
+			break
+		}
+		if _, dup := seen[parentName]; dup {
+			break
+		}
+		parent, ok := byName[parentName]
+		if !ok {
+			break
+		}
+		chain = append(chain, parent)
+		seen[parentName] = struct{}{}
+		current = parent
+	}
+	return chain
 }

--- a/scripts/architecture.baseline
+++ b/scripts/architecture.baseline
@@ -1,5 +1,5 @@
 packages=55
 interfaces=76
-large_files=35
+large_files=36
 set_mutators=102
 database_opens=8


### PR DESCRIPTION
## Summary

PR-C2 of the [#889](https://github.com/nugget/thane-ai-agent/issues/889) structural-inheritance rollout. Closes out the remaining inheritable field — `Conditions` — which sits on a different timeline than the iteration-time fields PR-C handled: Conditions are evaluated at definition-eligibility time against persisted specs, not at iteration time against the live registry. The cascade is the same ancestor-walk shape but operates on `DefinitionRegistry` instead of `Registry`.

## Merge semantics

**AND across the chain**. Every ancestor must independently report eligible for the leaf to be eligible. Three rollup rules:

- **Closest blocker wins attribution**: when ineligible, the closest blocking ancestor surfaces in `Reason` (`"blocked by container \"work_hours\""`). The most actionable thing to surface, not the most distant.
- **Earliest transition wins schedule rollup**: `NextTransitionAt` is the soonest tick across the chain so the scheduler picks the right wake time.
- **Own block bypasses container attribution**: when the leaf's own conditions block, the reason carries the underlying condition message without a misleading "blocked by container" suffix.

## What's new

- `DefinitionRegistry.AncestorSpecs(name)` — parent_name walk through the persisted spec graph; mirror of `Registry.Ancestors` for the durable side. Cycle-tolerant.
- `EvaluateEffectiveConditions(chain, now)` — pure aggregate evaluator: AND eligibility, closest-blocker attribution, earliest-transition rollup. Per-level evaluations returned alongside for the effective surface.
- `DefinitionRegistry.EvaluateConditions(name, now)` — convenience wrapper for the common call site shape.
- `DefinitionView.EffectiveConditions` — per-level cascade evaluations with provenance. Surfaced only when the chain has more than one level (single-level definitions already carry the result in `Eligibility`).
- `ancestorChainFromSnapshot` — pure-function chain walker over a name-indexed snapshot. Lets the view builder compute one chain per definition without re-acquiring the registry lock or risking snapshot/ancestor inconsistency.

## Where it's wired

Every definition-eligibility check site routes through the cascade now:
- `loopDefinitionRuntime.nextScheduleTransition` — schedule-watcher pickup
- `bootstrapDefinitionSpawn` — startup hydration gate
- `ReconcileDefinition` — runtime reconcile gate
- `LaunchDefinition` — `IneligibleDefinitionError` carries cascade-aware reason
- `buildDefinitionRegistryViewAt` — view eligibility + `EffectiveConditions` surface

A new `loopDefinitionRuntime.evaluateConditions` helper collapses the standard \"now + name\" call so each site reads the same way.

## Example response shape

For a leaf `morning_brief` inside container `work_hours` (which has a Mon-Fri 9-17 schedule), queried on a Sunday afternoon:

```jsonc
{
  \"name\": \"morning_brief\",
  \"eligibility\": {
    \"eligible\": false,
    \"reason\": \"outside scheduled windows (blocked by container \\\"work_hours\\\")\",
    \"next_transition_at\": \"2026-05-25T09:00:00Z\"
  },
  \"effective_conditions\": [
    {\"from\": \"self\", \"status\": {\"eligible\": true}},
    {\"from\": \"work_hours\", \"status\": {\"eligible\": false, \"reason\": \"outside scheduled windows\", \"next_transition_at\": \"2026-05-25T09:00:00Z\"}}
  ]
}
```

## Test plan

- [x] `just ci` green locally (race detector clean)
- [x] `internal/runtime/loop/conditions_cascade_test.go`:
  - Happy path: all-eligible chain → eligible aggregate, per-level evaluations
  - Ancestor blocks leaf with no own conditions → ineligible, ancestor named
  - Multiple blocking ancestors → closest wins attribution
  - Own conditions block → no \"blocked by container\" suffix
  - `NextTransitionAt` rolls up to earliest across chain
  - `DefinitionRegistry.AncestorSpecs` walks leaf-first to root, returns nil for unknown names
  - `DefinitionRegistry.EvaluateConditions` end-to-end through the registry
  - `buildDefinitionRegistryViewAt` populates `EffectiveConditions` only when chain has >1 level
  - Single-level definitions have nil `EffectiveConditions` (no noise)
- [ ] After landing: live exercise of `loop_definition_get` for a leaf inside a container with a schedule, verify the JSON shape matches

## Followups

[#889](https://github.com/nugget/thane-ai-agent/issues/889) status after this lands:
- All four inheritable cascades complete (Tags, Subscriptions, ExcludeTools, RoutingFactors, DelegationGating, Conditions)
- **PR-D** remains: `operation: core` + gource-style UI variant

🤖 Generated with [Claude Code](https://claude.com/claude-code)