### PR TITLE
fix: harden cascade correctness post-#894 audit (PR-E1)

### DIFF
--- a/internal/runtime/loop/cascade_correctness_test.go
+++ b/internal/runtime/loop/cascade_correctness_test.go
@@ -102,6 +102,44 @@ func TestEffectiveCascadeReadsProfileDeclarations(t *testing.T) {
 	}
 }
 
+// TestRegisterTrimsParentNameForUnresolvedCheck guards a small
+// consistency gap the audit caught: DefinitionRegistry.
+// AncestorSpecs and the runtimeSpec parent_name resolver both
+// trim ParentName before lookup, but Register's unresolved-name
+// check used the raw value. A spec with incidental whitespace
+// (" outer " from a hand-edited YAML, say) would resolve at one
+// layer and refuse loud at another. Trim everywhere.
+func TestRegisterTrimsParentNameForUnresolvedCheck(t *testing.T) {
+	t.Parallel()
+
+	r := NewRegistry()
+	core, err := New(Config{Name: CoreLoopName, Operation: OperationContainer}, Deps{})
+	if err != nil {
+		t.Fatalf("new core: %v", err)
+	}
+	if err := r.Register(core); err != nil {
+		t.Fatalf("register core: %v", err)
+	}
+
+	// Whitespace-only ParentName should be treated as empty —
+	// loop registers as an orphan and attaches to core, no
+	// UnresolvedParentNameError.
+	orphan, err := New(Config{
+		Name:       "padded",
+		Task:       "t",
+		ParentName: "   ",
+	}, Deps{Runner: &noopRunner{}})
+	if err != nil {
+		t.Fatalf("new orphan: %v", err)
+	}
+	if err := r.Register(orphan); err != nil {
+		t.Fatalf("whitespace-only ParentName treated as set: %v", err)
+	}
+	if got := orphan.ParentID(); got != core.ID() {
+		t.Errorf("ParentID = %q, want core's ID (whitespace ParentName should default-parent)", got)
+	}
+}
+
 // TestStopLoopRefusesContainerWithChildren mirrors the
 // loop_definition_delete refusal pattern. Stopping a container
 // with live descendants would orphan them — their ParentID would

--- a/internal/runtime/loop/cascade_correctness_test.go
+++ b/internal/runtime/loop/cascade_correctness_test.go
@@ -1,0 +1,239 @@
+package loop
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nugget/thane-ai-agent/internal/model/router"
+)
+
+// TestEffectiveCascadeReadsProfileDeclarations is the regression
+// test for the PR-E1 bug: the cascade walker reads from snapshot
+// accessors that previously looked at l.config.* only. In
+// production, containers commonly declare exclude_tools /
+// routing_factors / delegation_gating via the [router.LoopProfile]
+// sub-struct (ego, metacognitive, operator YAML), not the
+// top-level Spec field. The audit caught that those Profile-side
+// declarations weren't reaching descendants or the EffectiveState
+// surface. This test pins both: cascade and effective surface
+// both see Profile values.
+func TestEffectiveCascadeReadsProfileDeclarations(t *testing.T) {
+	t.Parallel()
+
+	r := NewRegistry()
+
+	containerSpec := Spec{
+		Name:      "safety",
+		Operation: OperationContainer,
+		Profile: router.LoopProfile{
+			ExcludeTools:     []string{"shell_exec"},
+			DelegationGating: "disabled",
+			ExtraHints: map[string]string{
+				"cluster": "home",
+			},
+		},
+	}
+	container, err := NewFromSpec(containerSpec, Deps{})
+	if err != nil {
+		t.Fatalf("new container: %v", err)
+	}
+	if err := r.Register(container); err != nil {
+		t.Fatalf("register container: %v", err)
+	}
+
+	leaf, err := New(Config{
+		Name:     "leaf",
+		Task:     "t",
+		ParentID: container.ID(),
+	}, Deps{Runner: &noopRunner{}})
+	if err != nil {
+		t.Fatalf("new leaf: %v", err)
+	}
+	if err := r.Register(leaf); err != nil {
+		t.Fatalf("register leaf: %v", err)
+	}
+
+	// Effective surface should attribute each Profile-declared
+	// value to the container — without the fix these surfaces
+	// returned empty because the walker never read requestBase.
+	excludes := r.EffectiveExcludeTools(leaf.ID())
+	if len(excludes) != 1 || excludes[0].Tool != "shell_exec" || excludes[0].From != "safety" {
+		t.Errorf("EffectiveExcludeTools = %+v, want [{shell_exec safety}]", excludes)
+	}
+	gating := r.EffectiveDelegationGating(leaf.ID())
+	if gating == nil || gating.Value != "disabled" || gating.From != "safety" {
+		t.Errorf("EffectiveDelegationGating = %+v, want {disabled safety}", gating)
+	}
+	factors := r.EffectiveRoutingFactors(leaf.ID())
+	var hasCluster bool
+	for _, f := range factors {
+		if f.Key == "cluster" && f.Value == "home" && f.From == "safety" {
+			hasCluster = true
+		}
+	}
+	if !hasCluster {
+		t.Errorf("EffectiveRoutingFactors = %+v, want one entry {cluster home safety}", factors)
+	}
+
+	// Iteration-time merge should land the inherited exclude in
+	// the prepared Request — descendants now actually get the
+	// safety guarantee the container set out to provide.
+	req, err := leaf.prepareAgentTurnRequest(Request{}, "conv-1", false)
+	if err != nil {
+		t.Fatalf("prepareAgentTurnRequest: %v", err)
+	}
+	var sawShellExec bool
+	for _, tool := range req.ExcludeTools {
+		if tool == "shell_exec" {
+			sawShellExec = true
+		}
+	}
+	if !sawShellExec {
+		t.Errorf("ExcludeTools = %v, want shell_exec inherited from container's Profile", req.ExcludeTools)
+	}
+	if req.RoutingFactors["cluster"] != "home" {
+		t.Errorf("RoutingFactors[cluster] = %q, want home (inherited via Profile)", req.RoutingFactors["cluster"])
+	}
+	if req.DelegationGating != "disabled" {
+		t.Errorf("DelegationGating = %q, want disabled (inherited via Profile)", req.DelegationGating)
+	}
+}
+
+// TestStopLoopRefusesContainerWithChildren mirrors the
+// loop_definition_delete refusal pattern. Stopping a container
+// with live descendants would orphan them — their ParentID would
+// point at a deregistered loop and ancestor walks would silently
+// short-circuit. Refuse with the children named so the caller can
+// re-parent or stop them first.
+func TestStopLoopRefusesContainerWithChildren(t *testing.T) {
+	t.Parallel()
+
+	r := NewRegistry()
+	core, err := New(Config{Name: CoreLoopName, Operation: OperationContainer}, Deps{})
+	if err != nil {
+		t.Fatalf("new core: %v", err)
+	}
+	if err := r.Register(core); err != nil {
+		t.Fatalf("register core: %v", err)
+	}
+
+	parent, err := New(Config{Name: "research", Operation: OperationContainer}, Deps{})
+	if err != nil {
+		t.Fatalf("new parent: %v", err)
+	}
+	if err := r.Register(parent); err != nil {
+		t.Fatalf("register parent: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err := parent.Start(ctx); err != nil {
+		t.Fatalf("start parent: %v", err)
+	}
+
+	child, err := New(Config{Name: "child", Task: "t", ParentID: parent.ID()}, Deps{Runner: &noopRunner{}})
+	if err != nil {
+		t.Fatalf("new child: %v", err)
+	}
+	if err := r.Register(child); err != nil {
+		t.Fatalf("register child: %v", err)
+	}
+
+	err = r.StopLoop(parent.ID())
+	if err == nil {
+		t.Fatal("StopLoop accepted parent with live child; want refusal")
+	}
+	if !strings.Contains(err.Error(), "child") {
+		t.Errorf("err = %v, should name the child loop", err)
+	}
+	if r.Get(parent.ID()) == nil {
+		t.Error("parent was deregistered despite the refusal")
+	}
+
+	// After the child is gone, the parent can stop cleanly.
+	r.Deregister(child.ID())
+	if err := r.StopLoop(parent.ID()); err != nil {
+		t.Errorf("StopLoop after children cleared: %v", err)
+	}
+}
+
+// TestSpecValidateReservesCoreName ensures the well-known core
+// name can't be claimed by a non-container spec. Otherwise a
+// service or request-reply named "core" would shadow
+// Registry.Core() lookups and produce undefined behavior in
+// ensureCoreLoop ("is core already up?" gets confused).
+func TestSpecValidateReservesCoreName(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name      string
+		spec      Spec
+		wantError string
+	}{
+		{
+			name: "container named core is valid",
+			spec: Spec{
+				Name:      CoreLoopName,
+				Operation: OperationContainer,
+			},
+			wantError: "",
+		},
+		{
+			name: "service named core is rejected",
+			spec: Spec{
+				Name:         CoreLoopName,
+				Task:         "t",
+				Operation:    OperationService,
+				Completion:   CompletionNone,
+				SleepMin:     time.Minute,
+				SleepMax:     time.Minute,
+				SleepDefault: time.Minute,
+			},
+			wantError: "reserved for the singleton root container",
+		},
+		{
+			name: "request-reply named core is rejected",
+			spec: Spec{
+				Name:      CoreLoopName,
+				Task:      "t",
+				Operation: OperationRequestReply,
+			},
+			wantError: "reserved for the singleton root container",
+		},
+		{
+			name: "core with parent_name is rejected",
+			spec: Spec{
+				Name:       CoreLoopName,
+				Operation:  OperationContainer,
+				ParentName: "imposter",
+			},
+			wantError: "cannot declare a parent",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.spec.Validate()
+			if tc.wantError == "" {
+				if err != nil {
+					t.Fatalf("Validate: %v, want nil", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("Validate accepted spec %+v; want error containing %q", tc.spec, tc.wantError)
+			}
+			if !strings.Contains(err.Error(), tc.wantError) {
+				t.Errorf("Validate error = %q, want substring %q", err.Error(), tc.wantError)
+			}
+		})
+	}
+}
+
+// errors.As is the recommended way to test the typed errors; this
+// file pulls the standard library import in the cascade test
+// already, so we don't need an explicit assertion line here. The
+// rest of the test files in this package already do it the same
+// way.
+var _ = errors.As

--- a/internal/runtime/loop/core_test.go
+++ b/internal/runtime/loop/core_test.go
@@ -253,16 +253,16 @@ func TestRegisterPreservesExplicitParentID(t *testing.T) {
 	}
 }
 
-// TestRegisterLeavesUnresolvedParentNameAlone guards against
-// silently overriding a declared parent reference: a loop with
-// ParentName set but no live parent yet must NOT default-parent
-// to core, because that would lose the intent ("attach to outer
-// when it comes up") permanently. Leaving ParentID empty keeps
-// the option open for a higher-level component to respawn /
-// re-register the loop after the named parent appears — the
-// registry doesn't auto-rebind, but at least the wrong parent
-// hasn't been baked in.
-func TestRegisterLeavesUnresolvedParentNameAlone(t *testing.T) {
+// TestRegisterRejectsUnresolvedParentName guards against silent
+// extra-root creation: a loop with ParentName set but no live
+// parent yet must be REJECTED at Register time. Silent fallback
+// to core would lose the declared intent ("attach to outer when
+// it comes up") permanently because the registry has no late-
+// rebind mechanism; silent parentless (the original PR-D1
+// behavior) would have produced an extra graph root. Loud
+// failure forces the caller to either spawn the parent first or
+// drop the ParentName, both of which are intentional choices.
+func TestRegisterRejectsUnresolvedParentName(t *testing.T) {
 	t.Parallel()
 
 	r := NewRegistry()
@@ -284,12 +284,63 @@ func TestRegisterLeavesUnresolvedParentNameAlone(t *testing.T) {
 	if err != nil {
 		t.Fatalf("new pending: %v", err)
 	}
-	if err := r.Register(pending); err != nil {
-		t.Fatalf("register pending: %v", err)
+	err = r.Register(pending)
+	if err == nil {
+		t.Fatal("Register accepted loop with unresolved ParentName; want loud refusal")
+	}
+	var unresolved *UnresolvedParentNameError
+	if !errors.As(err, &unresolved) {
+		t.Fatalf("err = %v, want *UnresolvedParentNameError", err)
+	}
+	if unresolved.LoopName != "child" {
+		t.Errorf("LoopName = %q, want child", unresolved.LoopName)
+	}
+	if unresolved.ParentName != "outer" {
+		t.Errorf("ParentName = %q, want outer", unresolved.ParentName)
+	}
+	if r.Get(pending.ID()) != nil {
+		t.Error("pending should not be registered after the refusal")
+	}
+}
+
+// TestRegisterAcceptsResolvedParentName covers the happy path:
+// once the named parent is registered, the child registers
+// successfully and inherits ParentID via the runtimeSpec
+// resolution that runs before Register.
+func TestRegisterAcceptsResolvedParentName(t *testing.T) {
+	t.Parallel()
+
+	r := NewRegistry()
+	core, err := New(Config{Name: CoreLoopName, Operation: OperationContainer}, Deps{})
+	if err != nil {
+		t.Fatalf("new core: %v", err)
+	}
+	if err := r.Register(core); err != nil {
+		t.Fatalf("register core: %v", err)
+	}
+	outer, err := New(Config{Name: "outer", Operation: OperationContainer}, Deps{})
+	if err != nil {
+		t.Fatalf("new outer: %v", err)
+	}
+	if err := r.Register(outer); err != nil {
+		t.Fatalf("register outer: %v", err)
 	}
 
-	if got := pending.ParentID(); got != "" {
-		t.Errorf("pending ParentID = %q, want empty (unresolved ParentName should not fall back to core)", got)
+	// Resolved at hydration time (mimicking runtimeSpec): caller
+	// gives Register a Config with ParentID set, ParentName empty.
+	child, err := New(Config{
+		Name:     "child",
+		Task:     "t",
+		ParentID: outer.ID(),
+	}, Deps{Runner: &noopRunner{}})
+	if err != nil {
+		t.Fatalf("new child: %v", err)
+	}
+	if err := r.Register(child); err != nil {
+		t.Fatalf("register child: %v", err)
+	}
+	if got := child.ParentID(); got != outer.ID() {
+		t.Errorf("child ParentID = %q, want outer's id", got)
 	}
 }
 

--- a/internal/runtime/loop/loop.go
+++ b/internal/runtime/loop/loop.go
@@ -749,41 +749,59 @@ func (l *Loop) tagsSnapshot() []string {
 	return append([]string(nil), l.config.Tags...)
 }
 
-// excludeToolsSnapshot returns a copy of the loop's configured tool
-// exclusions under the loop lock. Same forward-compat shape as
-// [tagsSnapshot].
+// excludeToolsSnapshot returns the union of the loop's
+// Spec.ExcludeTools and Spec.Profile.ExcludeTools under the loop
+// lock. Both sources contribute because production specs split
+// declarations between the two — operator YAML and built-in
+// services commonly set [router.LoopProfile.ExcludeTools] rather
+// than the top-level Spec field, and a cascade that only saw the
+// top-level value would silently drop those declarations for
+// descendants.
 func (l *Loop) excludeToolsSnapshot() []string {
 	l.mu.Lock()
 	defer l.mu.Unlock()
-	if len(l.config.ExcludeTools) == 0 {
+	if len(l.config.ExcludeTools) == 0 && len(l.requestBase.ExcludeTools) == 0 {
 		return nil
 	}
-	return append([]string(nil), l.config.ExcludeTools...)
+	return mergeUniqueStrings(l.config.ExcludeTools, l.requestBase.ExcludeTools)
 }
 
-// routingFactorsSnapshot returns a copy of the loop's configured
-// routing factors under the loop lock. Same forward-compat shape as
-// [tagsSnapshot].
+// routingFactorsSnapshot returns the loop's effective routing
+// factors — Spec.RoutingFactors merged with Spec.Profile's routing
+// hints — under the loop lock. Same Profile-vs-Spec-field reason
+// as [excludeToolsSnapshot]: a container declaring its routing
+// posture via Profile must propagate that to descendants. On key
+// collision Spec.RoutingFactors wins because the top-level field
+// is the more specific declaration; requestBase fills in defaults.
 func (l *Loop) routingFactorsSnapshot() map[string]string {
 	l.mu.Lock()
 	defer l.mu.Unlock()
-	if len(l.config.RoutingFactors) == 0 {
+	if len(l.config.RoutingFactors) == 0 && len(l.requestBase.RoutingFactors) == 0 {
 		return nil
 	}
-	out := make(map[string]string, len(l.config.RoutingFactors))
+	out := make(map[string]string, len(l.config.RoutingFactors)+len(l.requestBase.RoutingFactors))
+	for k, v := range l.requestBase.RoutingFactors {
+		out[k] = v
+	}
 	for k, v := range l.config.RoutingFactors {
 		out[k] = v
 	}
 	return out
 }
 
-// delegationGatingSnapshot returns the loop's configured delegation-
-// gating value under the loop lock. Same forward-compat shape as
-// [tagsSnapshot].
+// delegationGatingSnapshot returns the loop's effective delegation-
+// gating value under the loop lock. Spec.DelegationGating wins
+// when set; otherwise the Profile-side value contributes. Same
+// rationale as [excludeToolsSnapshot] — a container declaring
+// "disabled" via Profile must reach descendants through the
+// cascade.
 func (l *Loop) delegationGatingSnapshot() string {
 	l.mu.Lock()
 	defer l.mu.Unlock()
-	return l.config.DelegationGating
+	if l.config.DelegationGating != "" {
+		return l.config.DelegationGating
+	}
+	return l.requestBase.DelegationGating
 }
 
 // setEffectiveStateFunc installs the provenance-aware walker behind

--- a/internal/runtime/loop/registry.go
+++ b/internal/runtime/loop/registry.go
@@ -69,6 +69,26 @@ func (e *MultipleCoreError) Error() string {
 	return fmt.Sprintf("loop: cannot register a second core; existing core (id=%s) is already the singleton root", e.ExistingID)
 }
 
+// UnresolvedParentNameError reports an attempt to register a loop
+// whose ParentName references a parent that is not currently
+// registered. The registry refuses loud rather than silently
+// default-parenting to core — silent fallback would lose the
+// declared intent ("attach to outer when it comes up") permanently
+// because there is no late-rebind path. Callers either need to
+// ensure the named parent registers first (the bootstrap's
+// topological sort handles this for definition-driven specs) or
+// drop the ParentName and accept attachment to core.
+type UnresolvedParentNameError struct {
+	// LoopName is the loop being registered.
+	LoopName string
+	// ParentName is the unresolved parent reference.
+	ParentName string
+}
+
+func (e *UnresolvedParentNameError) Error() string {
+	return fmt.Sprintf("loop: cannot register %q — parent_name %q is not currently registered; spawn the parent first or drop parent_name to default to core", e.LoopName, e.ParentName)
+}
+
 // Register adds a loop to the registry. Returns an error if the loop's
 // ID is already registered or the concurrency limit would be exceeded.
 // The loop is not started — call [Loop.Start] after registering.
@@ -93,21 +113,38 @@ func (r *Registry) Register(l *Loop) error {
 		}
 	}
 
-	// Default-parent orphan loops to the core so the graph always
-	// has a single root. Only fills in when no parent was declared
-	// at all (both ParentID and ParentName empty): a ParentName
-	// that hasn't yet resolved to a registered loop must stay
-	// unresolved here, otherwise a late reconcile (parent registers
-	// after the child) would have no way to rebind. The core
-	// itself is the exception — it sits above the tree by
-	// definition. Centralizing this in Register means every spawn
-	// path — definition hydration, channel roots via SpawnLoop,
-	// delegate launches, direct tests — gets uniform attachment.
-	if l.config.ParentID == "" && l.config.ParentName == "" && !l.IsCore() {
-		for _, existing := range r.loops {
-			if existing.IsCore() {
-				l.setDefaultParentID(existing.id)
-				break
+	// Three parent-shape outcomes at Register:
+	//
+	//   - ParentID set       → caller wired the parent explicitly. Use it.
+	//   - ParentName set     → caller declared a named parent but it
+	//                          wasn't resolved by the time we reached
+	//                          Register. Refuse loud — silently
+	//                          default-parenting to core would lose
+	//                          the declared intent permanently
+	//                          because the registry has no late-
+	//                          rebind path. Callers must spawn the
+	//                          parent first (the bootstrap's
+	//                          topological sort handles this for
+	//                          definition-driven specs).
+	//   - both empty         → orphan. Attach to core so the graph
+	//                          stays single-rooted.
+	//
+	// Core is the exception — it sits above the tree by definition.
+	if !l.IsCore() {
+		switch {
+		case l.config.ParentID != "":
+			// Explicit parent; leave it alone.
+		case l.config.ParentName != "":
+			return &UnresolvedParentNameError{
+				LoopName:   l.config.Name,
+				ParentName: l.config.ParentName,
+			}
+		default:
+			for _, existing := range r.loops {
+				if existing.IsCore() {
+					l.setDefaultParentID(existing.id)
+					break
+				}
 			}
 		}
 	}
@@ -844,6 +881,23 @@ func (r *Registry) StopLoop(id string) error {
 	}
 	if l.IsCore() {
 		return fmt.Errorf("loop: cannot stop core %q — the structural root has no operator-facing kill switch", l.config.Name)
+	}
+	// Stopping a container with live descendants would orphan them
+	// — their ParentID would point at a deregistered loop, ancestor
+	// walks would short-circuit, and inherited tags/subs/excludes
+	// would silently disappear. Refuse with the children named, the
+	// same pattern loop_definition_delete uses for the persisted
+	// side; the model or operator can re-parent or stop the
+	// children first.
+	if l.config.Operation == OperationContainer {
+		children := r.Children(id)
+		if len(children) > 0 {
+			names := make([]string, 0, len(children))
+			for _, child := range children {
+				names = append(names, child.config.Name)
+			}
+			return fmt.Errorf("loop: cannot stop container %q — it has %d live child loop(s): %v; stop or re-parent them first", l.config.Name, len(children), names)
+		}
 	}
 
 	l.Stop()

--- a/internal/runtime/loop/registry.go
+++ b/internal/runtime/loop/registry.go
@@ -129,15 +129,21 @@ func (r *Registry) Register(l *Loop) error {
 	//   - both empty         → orphan. Attach to core so the graph
 	//                          stays single-rooted.
 	//
+	// Trim ParentName to match the rest of the codebase
+	// ([DefinitionRegistry.AncestorSpecs] and the parent_name
+	// resolution path both trim) so incidental whitespace doesn't
+	// flip a resolvable reference into a loud refusal.
+	//
 	// Core is the exception — it sits above the tree by definition.
 	if !l.IsCore() {
+		parentName := strings.TrimSpace(l.config.ParentName)
 		switch {
 		case l.config.ParentID != "":
 			// Explicit parent; leave it alone.
-		case l.config.ParentName != "":
+		case parentName != "":
 			return &UnresolvedParentNameError{
 				LoopName:   l.config.Name,
-				ParentName: l.config.ParentName,
+				ParentName: parentName,
 			}
 		default:
 			for _, existing := range r.loops {

--- a/internal/runtime/loop/spec.go
+++ b/internal/runtime/loop/spec.go
@@ -260,6 +260,20 @@ func (s *Spec) Validate() error {
 	if !validOperations[s.Operation] {
 		return fmt.Errorf("loop: unsupported operation %q", s.Operation)
 	}
+	// The name "core" is reserved for the singleton structural root.
+	// Anything else with that name would shadow [Registry.Core]'s
+	// lookup and produce a confusing graph. Containers may use it
+	// (they ARE the core when so named); services / request-reply /
+	// background-task definitions may not. A non-empty ParentName on
+	// the core also makes no sense — the core sits above the tree.
+	if s.Name == CoreLoopName {
+		if s.Operation != OperationContainer {
+			return fmt.Errorf("loop: name %q is reserved for the singleton root container; refuse operation=%q", CoreLoopName, s.Operation)
+		}
+		if strings.TrimSpace(s.ParentName) != "" || strings.TrimSpace(s.ParentID) != "" {
+			return fmt.Errorf("loop: core container %q cannot declare a parent — it is the structural root by definition", CoreLoopName)
+		}
+	}
 	if !validCompletions[s.Completion] {
 		return fmt.Errorf("loop: unsupported completion %q", s.Completion)
 	}


### PR DESCRIPTION
## Summary

PR-E1 of a post-merge audit on the [#889](https://github.com/nugget/thane-ai-agent/issues/889) structural-inheritance rollout. Four correctness fixes for issues a sub-agent diff review caught that the test suite missed. All four are in the same theme: **declarations that should propagate through the cascade weren't, and silent failure modes should be loud**.

The audit was suspicious-by-default — \"none of this code has actually run yet, look for what tests don't cover.\" These are the high-confidence findings.

## Fixes

**1. `Profile.*` declarations now propagate through the cascade.** This is the load-bearing one. Snapshot accessors (`excludeToolsSnapshot`, `routingFactorsSnapshot`, `delegationGatingSnapshot`) read only `l.config.*`. In production, containers commonly declare these via the `router.LoopProfile` sub-struct (ego, metacognitive, operator YAML), and the audit caught that Profile-side declarations were invisible to both the inheritance walker AND the `EffectiveState` surfaces. A container declaring `profile.delegation_gating: disabled` applied it to itself (via `requestBase`) but descendants never saw it, and `Status.EffectiveDelegationGating` falsely reported it absent. Now the accessors union `config + requestBase`, so containers and descendants see the same effective state.

**2. Unresolved `ParentName` is loud at Register.** PR-D1 left loops with `ParentName` set but unresolvable parents as silent parentless entries — would have produced extra graph roots with no recovery path. New typed `UnresolvedParentNameError` forces the caller to either spawn the parent first or drop `ParentName`. The bootstrap's topological sort already handles definition-driven specs; this protects against the edge cases the audit flagged (manual launches, channel roots, delegate launches that set `ParentName`).

**3. Name \"core\" is reserved for the singleton container.** `Spec.Validate` now rejects non-container specs named \"core\" and refuses any core spec that declares a parent. Without this guard a service named \"core\" would shadow `Registry.Core()` lookups and confuse `ensureCoreLoop`'s \"is core already up?\" check.

**4. `StopLoop` refuses non-empty containers.** Same children-aware refusal pattern `loop_definition_delete` uses. Stopping a container with live descendants would orphan them silently — their `ParentID` points at a deregistered loop and ancestor walks short-circuit.

## Test plan

- [x] `just ci` green locally (race detector clean)
- [x] `internal/runtime/loop/cascade_correctness_test.go`:
  - `TestEffectiveCascadeReadsProfileDeclarations` — regression test for finding #1; would have failed against PR-A through PR-D1
  - `TestStopLoopRefusesContainerWithChildren` — covers refusal + names children + still works after children clear
  - `TestSpecValidateReservesCoreName` — table-driven coverage of the core-name reservation
- [x] `internal/runtime/loop/core_test.go`:
  - `TestRegisterLeavesUnresolvedParentNameAlone` renamed and flipped to `TestRegisterRejectsUnresolvedParentName`
  - New `TestRegisterAcceptsResolvedParentName` for the happy path

## Followups in the audit queue

The audit also surfaced these for a follow-up PR-E2:

- HIGH: `Spec.UnmarshalJSON` skips `AddedAt` stamping + forecast normalization (persisted JSON footgun)
- HIGH: `mergeLegacySubscriptions` carries existing zero-`AddedAt` subs through unchanged
- HIGH: Watchlist + LoopSubscription providers double-render shared entities
- MEDIUM: `Loop.ParentID()` lockless read + stale doc comment
- LOW: Stale \"scope_tag\" mention in thane_curate description

Refs #889

🤖 Generated with [Claude Code](https://claude.com/claude-code)