### PR TITLE
fix: subscription robustness + hydration footguns (PR-E2)

### DIFF
--- a/internal/app/loop_definition_runtime.go
+++ b/internal/app/loop_definition_runtime.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"strings"
@@ -92,14 +93,30 @@ func (r *loopDefinitionRuntime) runtimeSpec(spec looppkg.Spec) (looppkg.Spec, er
 	// Resolve parent_name → live ParentID late, after every other
 	// hydration has had its say. ParentID survives only as long as the
 	// parent's current launch, so the runtime — not the stored spec —
-	// is the source of truth here. If the named parent isn't yet
-	// registered, ParentID stays empty and the loop lands at the root;
-	// container tag inheritance walks the live registry, so the link
-	// re-establishes naturally if the parent comes up later in the
-	// same startup pass.
+	// is the source of truth here.
+	//
+	// If the named parent isn't yet registered, drop the ParentName
+	// from the spec we hand to [Registry.Register]: post-PR-E1 it
+	// rejects a set ParentName whose ParentID is empty (so direct
+	// API callers can't silently misroute), and aborting the spawn
+	// here would block whole-batch reconciliation on definitions
+	// the operator merely ordered awkwardly. We log instead and let
+	// [Registry.Register] default-parent the loop to the core; if
+	// the operator wants the structural link, fixing the parent
+	// definition and re-reconciling re-establishes it.
 	if r.loops != nil && spec.ParentName != "" && spec.ParentID == "" {
 		if parent := r.loops.GetByName(spec.ParentName); parent != nil {
 			spec.ParentID = parent.ID()
+		} else {
+			logger := r.logger
+			if logger == nil {
+				logger = slog.Default()
+			}
+			logger.Warn("dropping unresolved parent_name during definition hydration; loop will default-parent to core",
+				"loop_name", spec.Name,
+				"parent_name", spec.ParentName,
+			)
+			spec.ParentName = ""
 		}
 	}
 	// Orphan loops attach to the core at registration time —
@@ -391,10 +408,13 @@ func splitContainerSpecs(defs []looppkg.DefinitionSnapshot, _ func() time.Time) 
 		}
 	}
 	// Stable topo sort: containers with no parent first, then those
-	// whose parent has already been emitted. Anything left over (orphan
-	// parent_name) falls back to the original definition order so we
-	// still spawn the container — its tag inheritance will simply
-	// resolve to nil until the operator fixes the missing parent.
+	// whose parent has already been emitted. Anything left over
+	// (orphan parent_name, cycles) falls back to the original
+	// definition order so we still spawn the container — runtimeSpec
+	// drops the unresolved parent_name with a warning, so the
+	// container default-parents to core rather than blocking
+	// reconciliation. Fix the parent definition and re-reconcile to
+	// reattach the structural link.
 	emitted := make(map[string]bool, len(containers))
 	ordered := make([]looppkg.DefinitionSnapshot, 0, len(containers))
 	progressed := true
@@ -440,7 +460,7 @@ func (r *loopDefinitionRuntime) ReconcileDefinition(ctx context.Context, name st
 				"reason", "definition_removed",
 				"loop_id", existing.ID(),
 			)
-			return r.loops.StopLoop(existing.ID())
+			return r.stopLoopForReconcile(log, existing.ID(), "definition_removed")
 		}
 		return nil
 	}
@@ -466,7 +486,7 @@ func (r *loopDefinitionRuntime) ReconcileDefinition(ctx context.Context, name st
 				"eligibility_reason", eligibility.Reason,
 				"loop_id", existing.ID(),
 			)
-			return r.loops.StopLoop(existing.ID())
+			return r.stopLoopForReconcile(log, existing.ID(), reason)
 		}
 		return nil
 	}
@@ -483,6 +503,36 @@ func (r *loopDefinitionRuntime) ReconcileDefinition(ctx context.Context, name st
 		"completion", def.Spec.Completion,
 	)
 	_, err = r.loops.SpawnSpec(r.serviceContext(), runtimeSpec, r.deps())
+	return err
+}
+
+// stopLoopForReconcile wraps [Registry.StopLoop] with handling for
+// the post-PR-E1 [looppkg.ContainerHasChildrenError]. The
+// reconciler is a converging background process; if a container
+// definition is removed but its descendants are still alive,
+// returning the error would make the reconciler retry endlessly
+// and pollute logs. We instead log loudly once (so the operator
+// sees the constraint) and return nil so reconciliation marks the
+// definition handled. The container stays live until its
+// descendants reconcile away on their own passes — at which point
+// the next ReconcileDefinition call lands cleanly. reason mirrors
+// the reason already logged at the caller; we pass it through for
+// correlation rather than re-deriving it here.
+func (r *loopDefinitionRuntime) stopLoopForReconcile(log *slog.Logger, loopID, reason string) error {
+	err := r.loops.StopLoop(loopID)
+	if err == nil {
+		return nil
+	}
+	var childErr *looppkg.ContainerHasChildrenError
+	if errors.As(err, &childErr) {
+		log.Warn("deferring container stop — live descendants remain",
+			"reason", reason,
+			"loop_id", loopID,
+			"container_name", childErr.ContainerName,
+			"children", childErr.ChildNames,
+		)
+		return nil
+	}
 	return err
 }
 

--- a/internal/app/loop_definition_runtime_robustness_test.go
+++ b/internal/app/loop_definition_runtime_robustness_test.go
@@ -1,0 +1,158 @@
+package app
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	looppkg "github.com/nugget/thane-ai-agent/internal/runtime/loop"
+)
+
+// TestRuntimeSpecDropsUnresolvedParentName covers the post-#895
+// boundary: Register now rejects a loop whose ParentName is set
+// but ParentID is empty. runtimeSpec must catch that case for
+// definition-driven spawns and clear ParentName (with a warn log)
+// so the reconciler keeps converging when the operator imports
+// children before their parent — the alternative is fail-loop on
+// bulk imports, which we explicitly didn't want at this layer.
+func TestRuntimeSpecDropsUnresolvedParentName(t *testing.T) {
+	t.Parallel()
+
+	loops := looppkg.NewRegistry()
+	t.Cleanup(func() {
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		loops.ShutdownAll(shutdownCtx)
+	})
+
+	r := &loopDefinitionRuntime{
+		loops:  loops,
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+	spec := looppkg.Spec{
+		Name:       "child",
+		Operation:  looppkg.OperationService,
+		ParentName: "outer_not_yet_registered",
+	}
+	out, err := r.runtimeSpec(spec)
+	if err != nil {
+		t.Fatalf("runtimeSpec: %v", err)
+	}
+	if out.ParentName != "" {
+		t.Errorf("ParentName = %q, want empty (should be dropped with warn log)", out.ParentName)
+	}
+	if out.ParentID != "" {
+		t.Errorf("ParentID = %q, want empty (parent not registered, nothing to set)", out.ParentID)
+	}
+}
+
+// TestRuntimeSpecResolvesRegisteredParent confirms the happy
+// path: a live parent in the loop registry gets its ID stamped
+// onto the child spec at hydration time.
+func TestRuntimeSpecResolvesRegisteredParent(t *testing.T) {
+	t.Parallel()
+
+	loops := looppkg.NewRegistry()
+	t.Cleanup(func() {
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		loops.ShutdownAll(shutdownCtx)
+	})
+
+	core, err := looppkg.New(looppkg.Config{Name: looppkg.CoreLoopName, Operation: looppkg.OperationContainer}, looppkg.Deps{})
+	if err != nil {
+		t.Fatalf("new core: %v", err)
+	}
+	if err := loops.Register(core); err != nil {
+		t.Fatalf("register core: %v", err)
+	}
+	parent, err := looppkg.New(looppkg.Config{Name: "outer", Operation: looppkg.OperationContainer}, looppkg.Deps{})
+	if err != nil {
+		t.Fatalf("new parent: %v", err)
+	}
+	if err := loops.Register(parent); err != nil {
+		t.Fatalf("register parent: %v", err)
+	}
+
+	r := &loopDefinitionRuntime{
+		loops:  loops,
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+	out, err := r.runtimeSpec(looppkg.Spec{
+		Name:       "child",
+		Operation:  looppkg.OperationService,
+		ParentName: "outer",
+	})
+	if err != nil {
+		t.Fatalf("runtimeSpec: %v", err)
+	}
+	if out.ParentID != parent.ID() {
+		t.Errorf("ParentID = %q, want %q", out.ParentID, parent.ID())
+	}
+	if out.ParentName != "outer" {
+		t.Errorf("ParentName = %q, want %q (preserved on resolve)", out.ParentName, "outer")
+	}
+}
+
+// TestStopLoopForReconcileSkipsContainerWithLiveChildren covers
+// the reconciler-side handling of the post-#895
+// [looppkg.ContainerHasChildrenError]: removing a container
+// definition while its descendants are still live must not
+// fail-loop reconciliation. The helper logs and returns nil so
+// the next pass (after descendants stop) lands cleanly.
+func TestStopLoopForReconcileSkipsContainerWithLiveChildren(t *testing.T) {
+	t.Parallel()
+
+	loops := looppkg.NewRegistry()
+	t.Cleanup(func() {
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		loops.ShutdownAll(shutdownCtx)
+	})
+
+	core, err := looppkg.New(looppkg.Config{Name: looppkg.CoreLoopName, Operation: looppkg.OperationContainer}, looppkg.Deps{})
+	if err != nil {
+		t.Fatalf("new core: %v", err)
+	}
+	if err := loops.Register(core); err != nil {
+		t.Fatalf("register core: %v", err)
+	}
+	container, err := looppkg.New(looppkg.Config{Name: "research", Operation: looppkg.OperationContainer}, looppkg.Deps{})
+	if err != nil {
+		t.Fatalf("new container: %v", err)
+	}
+	if err := loops.Register(container); err != nil {
+		t.Fatalf("register container: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err := container.Start(ctx); err != nil {
+		t.Fatalf("start container: %v", err)
+	}
+	child, err := looppkg.New(looppkg.Config{Name: "worker", Task: "t", ParentID: container.ID()}, looppkg.Deps{Runner: testLoopRunner{}})
+	if err != nil {
+		t.Fatalf("new child: %v", err)
+	}
+	if err := loops.Register(child); err != nil {
+		t.Fatalf("register child: %v", err)
+	}
+
+	var buf strings.Builder
+	r := &loopDefinitionRuntime{
+		loops:  loops,
+		logger: slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})),
+	}
+	log := r.definitionLogger("research")
+	if err := r.stopLoopForReconcile(log, container.ID(), "definition_removed"); err != nil {
+		t.Errorf("stopLoopForReconcile returned err = %v; want nil so reconcile converges", err)
+	}
+	if loops.Get(container.ID()) == nil {
+		t.Error("container was deregistered despite the children-live refusal")
+	}
+	if !strings.Contains(buf.String(), "deferring container stop") {
+		t.Errorf("expected warn log about deferral, got: %q", buf.String())
+	}
+}

--- a/internal/app/loop_subscription_migration.go
+++ b/internal/app/loop_subscription_migration.go
@@ -169,6 +169,14 @@ func mergeLegacySubscriptions(existing []looppkg.EntitySubscription, rows []awar
 			continue
 		}
 		seen[sub.EntityID] = struct{}{}
+		// If a partially-upgraded spec carried entries with TTL>0
+		// but missing AddedAt (the documented footgun on the spec
+		// shape), stamp them so the migration doesn't preserve a
+		// permanent watcher. Same boundary invariant the
+		// UnmarshalJSON sweep enforces.
+		if sub.TTLSeconds > 0 && sub.AddedAt.IsZero() {
+			sub.AddedAt = addedAt
+		}
 		out = append(out, sub)
 	}
 	for _, row := range rows {

--- a/internal/app/new_awareness.go
+++ b/internal/app/new_awareness.go
@@ -92,7 +92,7 @@ func (a *App) initAwareness(s *newState) error {
 		// for the current loop. Per-tag watchlist providers are gone —
 		// the structural parent/child binding from container loops
 		// replaces the scope_tag indirection.
-		loopSubProvider := awareness.NewLoopSubscriptionProvider(a.loopRegistry, a.ha, logger)
+		loopSubProvider := awareness.NewLoopSubscriptionProvider(a.loopRegistry, watchlistStore, a.ha, logger)
 		loopSubProvider.SetRegistryClient(a.ha)
 		a.loop.RegisterAlwaysContextProvider(loopSubProvider)
 

--- a/internal/runtime/loop/cascade_correctness_test.go
+++ b/internal/runtime/loop/cascade_correctness_test.go
@@ -102,6 +102,44 @@ func TestEffectiveCascadeReadsProfileDeclarations(t *testing.T) {
 	}
 }
 
+// TestRegisterTrimsParentNameForUnresolvedCheck guards a small
+// consistency gap the audit caught: DefinitionRegistry.
+// AncestorSpecs and the runtimeSpec parent_name resolver both
+// trim ParentName before lookup, but Register's unresolved-name
+// check used the raw value. A spec with incidental whitespace
+// (" outer " from a hand-edited YAML, say) would resolve at one
+// layer and refuse loud at another. Trim everywhere.
+func TestRegisterTrimsParentNameForUnresolvedCheck(t *testing.T) {
+	t.Parallel()
+
+	r := NewRegistry()
+	core, err := New(Config{Name: CoreLoopName, Operation: OperationContainer}, Deps{})
+	if err != nil {
+		t.Fatalf("new core: %v", err)
+	}
+	if err := r.Register(core); err != nil {
+		t.Fatalf("register core: %v", err)
+	}
+
+	// Whitespace-only ParentName should be treated as empty —
+	// loop registers as an orphan and attaches to core, no
+	// UnresolvedParentNameError.
+	orphan, err := New(Config{
+		Name:       "padded",
+		Task:       "t",
+		ParentName: "   ",
+	}, Deps{Runner: &noopRunner{}})
+	if err != nil {
+		t.Fatalf("new orphan: %v", err)
+	}
+	if err := r.Register(orphan); err != nil {
+		t.Fatalf("whitespace-only ParentName treated as set: %v", err)
+	}
+	if got := orphan.ParentID(); got != core.ID() {
+		t.Errorf("ParentID = %q, want core's ID (whitespace ParentName should default-parent)", got)
+	}
+}
+
 // TestStopLoopRefusesContainerWithChildren mirrors the
 // loop_definition_delete refusal pattern. Stopping a container
 // with live descendants would orphan them — their ParentID would

--- a/internal/runtime/loop/cascade_correctness_test.go
+++ b/internal/runtime/loop/cascade_correctness_test.go
@@ -1,0 +1,239 @@
+package loop
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nugget/thane-ai-agent/internal/model/router"
+)
+
+// TestEffectiveCascadeReadsProfileDeclarations is the regression
+// test for the PR-E1 bug: the cascade walker reads from snapshot
+// accessors that previously looked at l.config.* only. In
+// production, containers commonly declare exclude_tools /
+// routing_factors / delegation_gating via the [router.LoopProfile]
+// sub-struct (ego, metacognitive, operator YAML), not the
+// top-level Spec field. The audit caught that those Profile-side
+// declarations weren't reaching descendants or the EffectiveState
+// surface. This test pins both: cascade and effective surface
+// both see Profile values.
+func TestEffectiveCascadeReadsProfileDeclarations(t *testing.T) {
+	t.Parallel()
+
+	r := NewRegistry()
+
+	containerSpec := Spec{
+		Name:      "safety",
+		Operation: OperationContainer,
+		Profile: router.LoopProfile{
+			ExcludeTools:     []string{"shell_exec"},
+			DelegationGating: "disabled",
+			ExtraHints: map[string]string{
+				"cluster": "home",
+			},
+		},
+	}
+	container, err := NewFromSpec(containerSpec, Deps{})
+	if err != nil {
+		t.Fatalf("new container: %v", err)
+	}
+	if err := r.Register(container); err != nil {
+		t.Fatalf("register container: %v", err)
+	}
+
+	leaf, err := New(Config{
+		Name:     "leaf",
+		Task:     "t",
+		ParentID: container.ID(),
+	}, Deps{Runner: &noopRunner{}})
+	if err != nil {
+		t.Fatalf("new leaf: %v", err)
+	}
+	if err := r.Register(leaf); err != nil {
+		t.Fatalf("register leaf: %v", err)
+	}
+
+	// Effective surface should attribute each Profile-declared
+	// value to the container — without the fix these surfaces
+	// returned empty because the walker never read requestBase.
+	excludes := r.EffectiveExcludeTools(leaf.ID())
+	if len(excludes) != 1 || excludes[0].Tool != "shell_exec" || excludes[0].From != "safety" {
+		t.Errorf("EffectiveExcludeTools = %+v, want [{shell_exec safety}]", excludes)
+	}
+	gating := r.EffectiveDelegationGating(leaf.ID())
+	if gating == nil || gating.Value != "disabled" || gating.From != "safety" {
+		t.Errorf("EffectiveDelegationGating = %+v, want {disabled safety}", gating)
+	}
+	factors := r.EffectiveRoutingFactors(leaf.ID())
+	var hasCluster bool
+	for _, f := range factors {
+		if f.Key == "cluster" && f.Value == "home" && f.From == "safety" {
+			hasCluster = true
+		}
+	}
+	if !hasCluster {
+		t.Errorf("EffectiveRoutingFactors = %+v, want one entry {cluster home safety}", factors)
+	}
+
+	// Iteration-time merge should land the inherited exclude in
+	// the prepared Request — descendants now actually get the
+	// safety guarantee the container set out to provide.
+	req, err := leaf.prepareAgentTurnRequest(Request{}, "conv-1", false)
+	if err != nil {
+		t.Fatalf("prepareAgentTurnRequest: %v", err)
+	}
+	var sawShellExec bool
+	for _, tool := range req.ExcludeTools {
+		if tool == "shell_exec" {
+			sawShellExec = true
+		}
+	}
+	if !sawShellExec {
+		t.Errorf("ExcludeTools = %v, want shell_exec inherited from container's Profile", req.ExcludeTools)
+	}
+	if req.RoutingFactors["cluster"] != "home" {
+		t.Errorf("RoutingFactors[cluster] = %q, want home (inherited via Profile)", req.RoutingFactors["cluster"])
+	}
+	if req.DelegationGating != "disabled" {
+		t.Errorf("DelegationGating = %q, want disabled (inherited via Profile)", req.DelegationGating)
+	}
+}
+
+// TestStopLoopRefusesContainerWithChildren mirrors the
+// loop_definition_delete refusal pattern. Stopping a container
+// with live descendants would orphan them — their ParentID would
+// point at a deregistered loop and ancestor walks would silently
+// short-circuit. Refuse with the children named so the caller can
+// re-parent or stop them first.
+func TestStopLoopRefusesContainerWithChildren(t *testing.T) {
+	t.Parallel()
+
+	r := NewRegistry()
+	core, err := New(Config{Name: CoreLoopName, Operation: OperationContainer}, Deps{})
+	if err != nil {
+		t.Fatalf("new core: %v", err)
+	}
+	if err := r.Register(core); err != nil {
+		t.Fatalf("register core: %v", err)
+	}
+
+	parent, err := New(Config{Name: "research", Operation: OperationContainer}, Deps{})
+	if err != nil {
+		t.Fatalf("new parent: %v", err)
+	}
+	if err := r.Register(parent); err != nil {
+		t.Fatalf("register parent: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err := parent.Start(ctx); err != nil {
+		t.Fatalf("start parent: %v", err)
+	}
+
+	child, err := New(Config{Name: "child", Task: "t", ParentID: parent.ID()}, Deps{Runner: &noopRunner{}})
+	if err != nil {
+		t.Fatalf("new child: %v", err)
+	}
+	if err := r.Register(child); err != nil {
+		t.Fatalf("register child: %v", err)
+	}
+
+	err = r.StopLoop(parent.ID())
+	if err == nil {
+		t.Fatal("StopLoop accepted parent with live child; want refusal")
+	}
+	if !strings.Contains(err.Error(), "child") {
+		t.Errorf("err = %v, should name the child loop", err)
+	}
+	if r.Get(parent.ID()) == nil {
+		t.Error("parent was deregistered despite the refusal")
+	}
+
+	// After the child is gone, the parent can stop cleanly.
+	r.Deregister(child.ID())
+	if err := r.StopLoop(parent.ID()); err != nil {
+		t.Errorf("StopLoop after children cleared: %v", err)
+	}
+}
+
+// TestSpecValidateReservesCoreName ensures the well-known core
+// name can't be claimed by a non-container spec. Otherwise a
+// service or request-reply named "core" would shadow
+// Registry.Core() lookups and produce undefined behavior in
+// ensureCoreLoop ("is core already up?" gets confused).
+func TestSpecValidateReservesCoreName(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name      string
+		spec      Spec
+		wantError string
+	}{
+		{
+			name: "container named core is valid",
+			spec: Spec{
+				Name:      CoreLoopName,
+				Operation: OperationContainer,
+			},
+			wantError: "",
+		},
+		{
+			name: "service named core is rejected",
+			spec: Spec{
+				Name:         CoreLoopName,
+				Task:         "t",
+				Operation:    OperationService,
+				Completion:   CompletionNone,
+				SleepMin:     time.Minute,
+				SleepMax:     time.Minute,
+				SleepDefault: time.Minute,
+			},
+			wantError: "reserved for the singleton root container",
+		},
+		{
+			name: "request-reply named core is rejected",
+			spec: Spec{
+				Name:      CoreLoopName,
+				Task:      "t",
+				Operation: OperationRequestReply,
+			},
+			wantError: "reserved for the singleton root container",
+		},
+		{
+			name: "core with parent_name is rejected",
+			spec: Spec{
+				Name:       CoreLoopName,
+				Operation:  OperationContainer,
+				ParentName: "imposter",
+			},
+			wantError: "cannot declare a parent",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.spec.Validate()
+			if tc.wantError == "" {
+				if err != nil {
+					t.Fatalf("Validate: %v, want nil", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("Validate accepted spec %+v; want error containing %q", tc.spec, tc.wantError)
+			}
+			if !strings.Contains(err.Error(), tc.wantError) {
+				t.Errorf("Validate error = %q, want substring %q", err.Error(), tc.wantError)
+			}
+		})
+	}
+}
+
+// errors.As is the recommended way to test the typed errors; this
+// file pulls the standard library import in the cascade test
+// already, so we don't need an explicit assertion line here. The
+// rest of the test files in this package already do it the same
+// way.
+var _ = errors.As

--- a/internal/runtime/loop/cascade_correctness_test.go
+++ b/internal/runtime/loop/cascade_correctness_test.go
@@ -183,6 +183,23 @@ func TestStopLoopRefusesContainerWithChildren(t *testing.T) {
 	if err == nil {
 		t.Fatal("StopLoop accepted parent with live child; want refusal")
 	}
+	// Reconciler / callers depend on the typed error so they can
+	// detect this specific refusal and skip cleanly (see
+	// app.loopDefinitionRuntime.stopLoopForReconcile). Assert the
+	// type rather than the message text so wording can evolve.
+	var childErr *ContainerHasChildrenError
+	if !errors.As(err, &childErr) {
+		t.Fatalf("err = %v (%T), want *ContainerHasChildrenError", err, err)
+	}
+	if childErr.ContainerID != parent.ID() {
+		t.Errorf("ContainerID = %q, want %q", childErr.ContainerID, parent.ID())
+	}
+	if childErr.ContainerName != "research" {
+		t.Errorf("ContainerName = %q, want %q", childErr.ContainerName, "research")
+	}
+	if len(childErr.ChildNames) != 1 || childErr.ChildNames[0] != "child" {
+		t.Errorf("ChildNames = %v, want [child]", childErr.ChildNames)
+	}
 	if !strings.Contains(err.Error(), "child") {
 		t.Errorf("err = %v, should name the child loop", err)
 	}

--- a/internal/runtime/loop/context.go
+++ b/internal/runtime/loop/context.go
@@ -35,6 +35,16 @@ func LoopIDFromContext(ctx context.Context) string {
 	return ""
 }
 
+// WithLoopIDForTest exposes [withLoopID] for tests in other
+// packages that need to drive a context through a function which
+// reads the loop ID (e.g. context-provider tests asserting
+// behavior at iteration time). Production code outside this
+// package should not need this; the loop's own run goroutine
+// stamps the ID before any downstream code runs.
+func WithLoopIDForTest(ctx context.Context, id string) context.Context {
+	return withLoopID(ctx, id)
+}
+
 // FallbackContent returns the loop-configured response fallback from a
 // handler context. Handler-backed interactive loops can pass this through
 // to nested agent.Run calls and use it as a last-resort post-run reply.

--- a/internal/runtime/loop/core_test.go
+++ b/internal/runtime/loop/core_test.go
@@ -253,16 +253,16 @@ func TestRegisterPreservesExplicitParentID(t *testing.T) {
 	}
 }
 
-// TestRegisterLeavesUnresolvedParentNameAlone guards against
-// silently overriding a declared parent reference: a loop with
-// ParentName set but no live parent yet must NOT default-parent
-// to core, because that would lose the intent ("attach to outer
-// when it comes up") permanently. Leaving ParentID empty keeps
-// the option open for a higher-level component to respawn /
-// re-register the loop after the named parent appears — the
-// registry doesn't auto-rebind, but at least the wrong parent
-// hasn't been baked in.
-func TestRegisterLeavesUnresolvedParentNameAlone(t *testing.T) {
+// TestRegisterRejectsUnresolvedParentName guards against silent
+// extra-root creation: a loop with ParentName set but no live
+// parent yet must be REJECTED at Register time. Silent fallback
+// to core would lose the declared intent ("attach to outer when
+// it comes up") permanently because the registry has no late-
+// rebind mechanism; silent parentless (the original PR-D1
+// behavior) would have produced an extra graph root. Loud
+// failure forces the caller to either spawn the parent first or
+// drop the ParentName, both of which are intentional choices.
+func TestRegisterRejectsUnresolvedParentName(t *testing.T) {
 	t.Parallel()
 
 	r := NewRegistry()
@@ -284,12 +284,63 @@ func TestRegisterLeavesUnresolvedParentNameAlone(t *testing.T) {
 	if err != nil {
 		t.Fatalf("new pending: %v", err)
 	}
-	if err := r.Register(pending); err != nil {
-		t.Fatalf("register pending: %v", err)
+	err = r.Register(pending)
+	if err == nil {
+		t.Fatal("Register accepted loop with unresolved ParentName; want loud refusal")
+	}
+	var unresolved *UnresolvedParentNameError
+	if !errors.As(err, &unresolved) {
+		t.Fatalf("err = %v, want *UnresolvedParentNameError", err)
+	}
+	if unresolved.LoopName != "child" {
+		t.Errorf("LoopName = %q, want child", unresolved.LoopName)
+	}
+	if unresolved.ParentName != "outer" {
+		t.Errorf("ParentName = %q, want outer", unresolved.ParentName)
+	}
+	if r.Get(pending.ID()) != nil {
+		t.Error("pending should not be registered after the refusal")
+	}
+}
+
+// TestRegisterAcceptsResolvedParentName covers the happy path:
+// once the named parent is registered, the child registers
+// successfully and inherits ParentID via the runtimeSpec
+// resolution that runs before Register.
+func TestRegisterAcceptsResolvedParentName(t *testing.T) {
+	t.Parallel()
+
+	r := NewRegistry()
+	core, err := New(Config{Name: CoreLoopName, Operation: OperationContainer}, Deps{})
+	if err != nil {
+		t.Fatalf("new core: %v", err)
+	}
+	if err := r.Register(core); err != nil {
+		t.Fatalf("register core: %v", err)
+	}
+	outer, err := New(Config{Name: "outer", Operation: OperationContainer}, Deps{})
+	if err != nil {
+		t.Fatalf("new outer: %v", err)
+	}
+	if err := r.Register(outer); err != nil {
+		t.Fatalf("register outer: %v", err)
 	}
 
-	if got := pending.ParentID(); got != "" {
-		t.Errorf("pending ParentID = %q, want empty (unresolved ParentName should not fall back to core)", got)
+	// Resolved at hydration time (mimicking runtimeSpec): caller
+	// gives Register a Config with ParentID set, ParentName empty.
+	child, err := New(Config{
+		Name:     "child",
+		Task:     "t",
+		ParentID: outer.ID(),
+	}, Deps{Runner: &noopRunner{}})
+	if err != nil {
+		t.Fatalf("new child: %v", err)
+	}
+	if err := r.Register(child); err != nil {
+		t.Fatalf("register child: %v", err)
+	}
+	if got := child.ParentID(); got != outer.ID() {
+		t.Errorf("child ParentID = %q, want outer's id", got)
 	}
 }
 

--- a/internal/runtime/loop/definition_registry.go
+++ b/internal/runtime/loop/definition_registry.go
@@ -287,6 +287,23 @@ func (r *DefinitionRegistry) Upsert(spec Spec, updatedAt time.Time) error {
 	if _, exists := r.base[spec.Name]; exists {
 		return &ImmutableDefinitionError{Name: spec.Name}
 	}
+
+	// Cross-spec invariant: a container's parent_name must point at
+	// another container. Inheritance walks only flow through
+	// container ancestors (PR-A/B/C/C2 contract), so a container
+	// pointing at a service would silently lose the inheritance
+	// chain and produce a confusing graph. Catch it here at
+	// write-time rather than waiting for someone to wonder why
+	// their descendants don't see the expected tags.
+	if spec.Operation == OperationContainer {
+		parentName := strings.TrimSpace(spec.ParentName)
+		if parentName != "" {
+			if parentSpec, ok := r.specByName(parentName); ok && parentSpec.Operation != OperationContainer {
+				return fmt.Errorf("loop: container %q cannot have parent_name %q (operation %q) — container parents must themselves be containers so the inheritance chain stays intact", spec.Name, parentName, parentSpec.Operation)
+			}
+		}
+	}
+
 	r.overlay[spec.Name] = DefinitionRecord{
 		Spec:      spec,
 		UpdatedAt: updatedAt.UTC(),

--- a/internal/runtime/loop/loop.go
+++ b/internal/runtime/loop/loop.go
@@ -402,9 +402,16 @@ func (l *Loop) ID() string { return l.id }
 func (l *Loop) Name() string { return l.config.Name }
 
 // ParentID returns the loop ID of this loop's parent in the registry,
-// or empty for top-level loops. Reads the config snapshot taken at
-// construction time, so callers don't need the registry lock.
-func (l *Loop) ParentID() string { return l.config.ParentID }
+// or empty for top-level loops. Acquires the loop lock to mirror the
+// other snapshot accessors — [setDefaultParentID] mutates this
+// field at Register time, so a lockless read would race the
+// race-detector even though the mutation happens before any
+// goroutine has started reading.
+func (l *Loop) ParentID() string {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.config.ParentID
+}
 
 // Operation returns the loop's runtime operation kind. Set once at
 // construction; safe to read without the loop lock.

--- a/internal/runtime/loop/loop.go
+++ b/internal/runtime/loop/loop.go
@@ -749,41 +749,59 @@ func (l *Loop) tagsSnapshot() []string {
 	return append([]string(nil), l.config.Tags...)
 }
 
-// excludeToolsSnapshot returns a copy of the loop's configured tool
-// exclusions under the loop lock. Same forward-compat shape as
-// [tagsSnapshot].
+// excludeToolsSnapshot returns the union of the loop's
+// Spec.ExcludeTools and Spec.Profile.ExcludeTools under the loop
+// lock. Both sources contribute because production specs split
+// declarations between the two — operator YAML and built-in
+// services commonly set [router.LoopProfile.ExcludeTools] rather
+// than the top-level Spec field, and a cascade that only saw the
+// top-level value would silently drop those declarations for
+// descendants.
 func (l *Loop) excludeToolsSnapshot() []string {
 	l.mu.Lock()
 	defer l.mu.Unlock()
-	if len(l.config.ExcludeTools) == 0 {
+	if len(l.config.ExcludeTools) == 0 && len(l.requestBase.ExcludeTools) == 0 {
 		return nil
 	}
-	return append([]string(nil), l.config.ExcludeTools...)
+	return mergeUniqueStrings(l.config.ExcludeTools, l.requestBase.ExcludeTools)
 }
 
-// routingFactorsSnapshot returns a copy of the loop's configured
-// routing factors under the loop lock. Same forward-compat shape as
-// [tagsSnapshot].
+// routingFactorsSnapshot returns the loop's effective routing
+// factors — Spec.RoutingFactors merged with Spec.Profile's routing
+// hints — under the loop lock. Same Profile-vs-Spec-field reason
+// as [excludeToolsSnapshot]: a container declaring its routing
+// posture via Profile must propagate that to descendants. On key
+// collision Spec.RoutingFactors wins because the top-level field
+// is the more specific declaration; requestBase fills in defaults.
 func (l *Loop) routingFactorsSnapshot() map[string]string {
 	l.mu.Lock()
 	defer l.mu.Unlock()
-	if len(l.config.RoutingFactors) == 0 {
+	if len(l.config.RoutingFactors) == 0 && len(l.requestBase.RoutingFactors) == 0 {
 		return nil
 	}
-	out := make(map[string]string, len(l.config.RoutingFactors))
+	out := make(map[string]string, len(l.config.RoutingFactors)+len(l.requestBase.RoutingFactors))
+	for k, v := range l.requestBase.RoutingFactors {
+		out[k] = v
+	}
 	for k, v := range l.config.RoutingFactors {
 		out[k] = v
 	}
 	return out
 }
 
-// delegationGatingSnapshot returns the loop's configured delegation-
-// gating value under the loop lock. Same forward-compat shape as
-// [tagsSnapshot].
+// delegationGatingSnapshot returns the loop's effective delegation-
+// gating value under the loop lock. Spec.DelegationGating wins
+// when set; otherwise the Profile-side value contributes. Same
+// rationale as [excludeToolsSnapshot] — a container declaring
+// "disabled" via Profile must reach descendants through the
+// cascade.
 func (l *Loop) delegationGatingSnapshot() string {
 	l.mu.Lock()
 	defer l.mu.Unlock()
-	return l.config.DelegationGating
+	if l.config.DelegationGating != "" {
+		return l.config.DelegationGating
+	}
+	return l.requestBase.DelegationGating
 }
 
 // setEffectiveStateFunc installs the provenance-aware walker behind

--- a/internal/runtime/loop/registry.go
+++ b/internal/runtime/loop/registry.go
@@ -69,6 +69,26 @@ func (e *MultipleCoreError) Error() string {
 	return fmt.Sprintf("loop: cannot register a second core; existing core (id=%s) is already the singleton root", e.ExistingID)
 }
 
+// UnresolvedParentNameError reports an attempt to register a loop
+// whose ParentName references a parent that is not currently
+// registered. The registry refuses loud rather than silently
+// default-parenting to core — silent fallback would lose the
+// declared intent ("attach to outer when it comes up") permanently
+// because there is no late-rebind path. Callers either need to
+// ensure the named parent registers first (the bootstrap's
+// topological sort handles this for definition-driven specs) or
+// drop the ParentName and accept attachment to core.
+type UnresolvedParentNameError struct {
+	// LoopName is the loop being registered.
+	LoopName string
+	// ParentName is the unresolved parent reference.
+	ParentName string
+}
+
+func (e *UnresolvedParentNameError) Error() string {
+	return fmt.Sprintf("loop: cannot register %q — parent_name %q is not currently registered; spawn the parent first or drop parent_name to default to core", e.LoopName, e.ParentName)
+}
+
 // Register adds a loop to the registry. Returns an error if the loop's
 // ID is already registered or the concurrency limit would be exceeded.
 // The loop is not started — call [Loop.Start] after registering.
@@ -93,21 +113,38 @@ func (r *Registry) Register(l *Loop) error {
 		}
 	}
 
-	// Default-parent orphan loops to the core so the graph always
-	// has a single root. Only fills in when no parent was declared
-	// at all (both ParentID and ParentName empty): a ParentName
-	// that hasn't yet resolved to a registered loop must stay
-	// unresolved here, otherwise a late reconcile (parent registers
-	// after the child) would have no way to rebind. The core
-	// itself is the exception — it sits above the tree by
-	// definition. Centralizing this in Register means every spawn
-	// path — definition hydration, channel roots via SpawnLoop,
-	// delegate launches, direct tests — gets uniform attachment.
-	if l.config.ParentID == "" && l.config.ParentName == "" && !l.IsCore() {
-		for _, existing := range r.loops {
-			if existing.IsCore() {
-				l.setDefaultParentID(existing.id)
-				break
+	// Three parent-shape outcomes at Register:
+	//
+	//   - ParentID set       → caller wired the parent explicitly. Use it.
+	//   - ParentName set     → caller declared a named parent but it
+	//                          wasn't resolved by the time we reached
+	//                          Register. Refuse loud — silently
+	//                          default-parenting to core would lose
+	//                          the declared intent permanently
+	//                          because the registry has no late-
+	//                          rebind path. Callers must spawn the
+	//                          parent first (the bootstrap's
+	//                          topological sort handles this for
+	//                          definition-driven specs).
+	//   - both empty         → orphan. Attach to core so the graph
+	//                          stays single-rooted.
+	//
+	// Core is the exception — it sits above the tree by definition.
+	if !l.IsCore() {
+		switch {
+		case l.config.ParentID != "":
+			// Explicit parent; leave it alone.
+		case l.config.ParentName != "":
+			return &UnresolvedParentNameError{
+				LoopName:   l.config.Name,
+				ParentName: l.config.ParentName,
+			}
+		default:
+			for _, existing := range r.loops {
+				if existing.IsCore() {
+					l.setDefaultParentID(existing.id)
+					break
+				}
 			}
 		}
 	}
@@ -844,6 +881,23 @@ func (r *Registry) StopLoop(id string) error {
 	}
 	if l.IsCore() {
 		return fmt.Errorf("loop: cannot stop core %q — the structural root has no operator-facing kill switch", l.config.Name)
+	}
+	// Stopping a container with live descendants would orphan them
+	// — their ParentID would point at a deregistered loop, ancestor
+	// walks would short-circuit, and inherited tags/subs/excludes
+	// would silently disappear. Refuse with the children named, the
+	// same pattern loop_definition_delete uses for the persisted
+	// side; the model or operator can re-parent or stop the
+	// children first.
+	if l.config.Operation == OperationContainer {
+		children := r.Children(id)
+		if len(children) > 0 {
+			names := make([]string, 0, len(children))
+			for _, child := range children {
+				names = append(names, child.config.Name)
+			}
+			return fmt.Errorf("loop: cannot stop container %q — it has %d live child loop(s): %v; stop or re-parent them first", l.config.Name, len(children), names)
+		}
 	}
 
 	l.Stop()

--- a/internal/runtime/loop/registry.go
+++ b/internal/runtime/loop/registry.go
@@ -89,6 +89,29 @@ func (e *UnresolvedParentNameError) Error() string {
 	return fmt.Sprintf("loop: cannot register %q — parent_name %q is not currently registered; spawn the parent first or drop parent_name to default to core", e.LoopName, e.ParentName)
 }
 
+// ContainerHasChildrenError reports a [Registry.StopLoop] attempt
+// against a container that still has live descendants. The
+// registry refuses rather than orphaning the children (their
+// ParentID would point at a deregistered loop and ancestor walks
+// would silently lose inherited tags/subscriptions). Callers can
+// inspect [Children] for the names and either stop or re-parent
+// them first; the definition reconciler uses this signal to log
+// loudly and skip rather than fail-loop on a removed container
+// that still has live workers underneath.
+type ContainerHasChildrenError struct {
+	// ContainerID is the loop being asked to stop.
+	ContainerID string
+	// ContainerName is the human-facing name from the loop's config.
+	ContainerName string
+	// ChildNames lists the live descendants by name, sorted for
+	// stable diagnostics.
+	ChildNames []string
+}
+
+func (e *ContainerHasChildrenError) Error() string {
+	return fmt.Sprintf("loop: cannot stop container %q — it has %d live child loop(s): %v; stop or re-parent them first", e.ContainerName, len(e.ChildNames), e.ChildNames)
+}
+
 // Register adds a loop to the registry. Returns an error if the loop's
 // ID is already registered or the concurrency limit would be exceeded.
 // The loop is not started — call [Loop.Start] after registering.
@@ -902,7 +925,12 @@ func (r *Registry) StopLoop(id string) error {
 			for _, child := range children {
 				names = append(names, child.config.Name)
 			}
-			return fmt.Errorf("loop: cannot stop container %q — it has %d live child loop(s): %v; stop or re-parent them first", l.config.Name, len(children), names)
+			sort.Strings(names)
+			return &ContainerHasChildrenError{
+				ContainerID:   id,
+				ContainerName: l.config.Name,
+				ChildNames:    names,
+			}
 		}
 	}
 

--- a/internal/runtime/loop/registry.go
+++ b/internal/runtime/loop/registry.go
@@ -129,15 +129,21 @@ func (r *Registry) Register(l *Loop) error {
 	//   - both empty         → orphan. Attach to core so the graph
 	//                          stays single-rooted.
 	//
+	// Trim ParentName to match the rest of the codebase
+	// ([DefinitionRegistry.AncestorSpecs] and the parent_name
+	// resolution path both trim) so incidental whitespace doesn't
+	// flip a resolvable reference into a loud refusal.
+	//
 	// Core is the exception — it sits above the tree by definition.
 	if !l.IsCore() {
+		parentName := strings.TrimSpace(l.config.ParentName)
 		switch {
 		case l.config.ParentID != "":
 			// Explicit parent; leave it alone.
-		case l.config.ParentName != "":
+		case parentName != "":
 			return &UnresolvedParentNameError{
 				LoopName:   l.config.Name,
-				ParentName: l.config.ParentName,
+				ParentName: parentName,
 			}
 		default:
 			for _, existing := range r.loops {

--- a/internal/runtime/loop/spec.go
+++ b/internal/runtime/loop/spec.go
@@ -260,6 +260,20 @@ func (s *Spec) Validate() error {
 	if !validOperations[s.Operation] {
 		return fmt.Errorf("loop: unsupported operation %q", s.Operation)
 	}
+	// The name "core" is reserved for the singleton structural root.
+	// Anything else with that name would shadow [Registry.Core]'s
+	// lookup and produce a confusing graph. Containers may use it
+	// (they ARE the core when so named); services / request-reply /
+	// background-task definitions may not. A non-empty ParentName on
+	// the core also makes no sense — the core sits above the tree.
+	if s.Name == CoreLoopName {
+		if s.Operation != OperationContainer {
+			return fmt.Errorf("loop: name %q is reserved for the singleton root container; refuse operation=%q", CoreLoopName, s.Operation)
+		}
+		if strings.TrimSpace(s.ParentName) != "" || strings.TrimSpace(s.ParentID) != "" {
+			return fmt.Errorf("loop: core container %q cannot declare a parent — it is the structural root by definition", CoreLoopName)
+		}
+	}
 	if !validCompletions[s.Completion] {
 		return fmt.Errorf("loop: unsupported completion %q", s.Completion)
 	}

--- a/internal/runtime/loop/spec_json.go
+++ b/internal/runtime/loop/spec_json.go
@@ -110,6 +110,20 @@ func (s *Spec) UnmarshalJSON(data []byte) error {
 	if err != nil {
 		return fmt.Errorf("loop: on_retrigger: %w", err)
 	}
+	// Apply the same forecast normalization and AddedAt stamping
+	// the tool-boundary write paths use. Without this, a
+	// hand-edited or externally-pushed Spec with `ttl_seconds > 0`
+	// and missing `added_at` would unmarshal into a permanent
+	// watcher (IsExpired returns false forever, the documented
+	// footgun on EntitySubscription.AddedAt). Stamping at load
+	// time turns "this subscription has never had its TTL clock
+	// started" into "TTL counts from when the spec was loaded" —
+	// which matches operator intent better than "ignored
+	// silently."
+	normalizedSubs, err := normalizeSubscriptionsOnLoad(cloneEntitySubscriptions(wire.Subscriptions), time.Now())
+	if err != nil {
+		return fmt.Errorf("loop: %w", err)
+	}
 	*s = Spec{
 		Name:                   wire.Name,
 		Enabled:                wire.Enabled,
@@ -117,7 +131,7 @@ func (s *Spec) UnmarshalJSON(data []byte) error {
 		Operation:              wire.Operation,
 		Completion:             wire.Completion,
 		Outputs:                cloneOutputs(wire.Outputs),
-		Subscriptions:          cloneEntitySubscriptions(wire.Subscriptions),
+		Subscriptions:          normalizedSubs,
 		Conditions:             cloneConditions(wire.Conditions),
 		Tags:                   append([]string(nil), wire.Tags...),
 		ExcludeTools:           append([]string(nil), wire.ExcludeTools...),

--- a/internal/runtime/loop/subscription.go
+++ b/internal/runtime/loop/subscription.go
@@ -1,6 +1,10 @@
 package loop
 
-import "time"
+import (
+	"fmt"
+	"strings"
+	"time"
+)
 
 // EntitySubscription is one entity that a loop wants to see in context
 // every iteration. It carries everything the awareness renderer needs to
@@ -82,6 +86,63 @@ func cloneEntitySubscriptions(src []EntitySubscription) []EntitySubscription {
 // directly. A constant prevents callers from accidentally comparing
 // against a freshly-typed string literal in user-facing surfaces.
 const EffectiveOriginSelf = "self"
+
+// NormalizeSubscriptionForecast returns the canonical forecast
+// value for persisted subscriptions. "none" and empty collapse to
+// "" (meaning "no forecast fetch"); the three real HA forecast
+// types pass through unchanged; anything else is an actionable
+// error. Lives in the loop package because the forecast string is
+// a property of [EntitySubscription], and centralizing it here
+// lets [Spec.UnmarshalJSON] guard hydration without depending on
+// the tools or awareness packages.
+//
+// Tool-boundary callers (thane_curate, update_entity_subscriptions,
+// watch_entity) and the awareness watchlist store have their own
+// normalizers that match this contract; consolidation is a
+// follow-up.
+func NormalizeSubscriptionForecast(raw string) (string, error) {
+	v := strings.TrimSpace(raw)
+	switch v {
+	case "", "none":
+		return "", nil
+	case "daily", "hourly", "twice_daily":
+		return v, nil
+	default:
+		return "", fmt.Errorf("forecast must be one of [daily, hourly, twice_daily, none], got %q", raw)
+	}
+}
+
+// normalizeSubscriptionsOnLoad sweeps a freshly-hydrated
+// subscription list and applies the boundary invariants the
+// write-side tool handlers enforce: forecast values are
+// canonicalized (or rejected), and TTL-bearing entries that lack
+// an AddedAt stamp get one. The latter closes the documented
+// footgun where `ttl_seconds > 0 && AddedAt.IsZero()` causes
+// [EntitySubscription.IsExpired] to return false forever —
+// hand-edited YAML or externally-pushed specs would otherwise
+// produce "immortal" watchers that ignore their declared TTL.
+//
+// now is threaded through so callers (notably tests) can pin a
+// clock value. The default real-world callsite is
+// [Spec.UnmarshalJSON] which passes time.Now().
+func normalizeSubscriptionsOnLoad(subs []EntitySubscription, now time.Time) ([]EntitySubscription, error) {
+	if len(subs) == 0 {
+		return subs, nil
+	}
+	out := make([]EntitySubscription, len(subs))
+	for i, sub := range subs {
+		forecast, err := NormalizeSubscriptionForecast(sub.Forecast)
+		if err != nil {
+			return nil, fmt.Errorf("subscriptions[%d] (entity_id=%q): %w", i, sub.EntityID, err)
+		}
+		sub.Forecast = forecast
+		if sub.TTLSeconds > 0 && sub.AddedAt.IsZero() {
+			sub.AddedAt = now
+		}
+		out[i] = sub
+	}
+	return out, nil
+}
 
 // EffectiveSubscription is an entity subscription annotated with its
 // origin in the loop graph. Embeds [EntitySubscription] so JSON

--- a/internal/runtime/loop/subscription_robustness_test.go
+++ b/internal/runtime/loop/subscription_robustness_test.go
@@ -1,0 +1,172 @@
+package loop
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestUnmarshalJSONStampsAddedAtForTTL is the regression test for
+// the documented "permanent watcher" footgun. A persisted or
+// API-supplied spec with `ttl_seconds: 60` and missing `added_at`
+// previously deserialized into a subscription whose
+// [EntitySubscription.IsExpired] returned false forever. The
+// UnmarshalJSON sweep now stamps AddedAt = now so the TTL clock
+// actually starts.
+func TestUnmarshalJSONStampsAddedAtForTTL(t *testing.T) {
+	t.Parallel()
+
+	raw := []byte(`{
+		"name": "watcher",
+		"operation": "service",
+		"task": "t",
+		"sleep_min": "1m",
+		"sleep_max": "1m",
+		"sleep_default": "1m",
+		"subscriptions": [
+			{"entity_id": "sensor.foo", "ttl_seconds": 60}
+		]
+	}`)
+
+	var s Spec
+	before := time.Now()
+	if err := json.Unmarshal(raw, &s); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	after := time.Now()
+
+	if len(s.Subscriptions) != 1 {
+		t.Fatalf("Subscriptions len = %d, want 1", len(s.Subscriptions))
+	}
+	sub := s.Subscriptions[0]
+	if sub.TTLSeconds != 60 {
+		t.Errorf("TTLSeconds = %d, want 60", sub.TTLSeconds)
+	}
+	if sub.AddedAt.IsZero() {
+		t.Fatal("AddedAt is zero — UnmarshalJSON should have stamped it for TTL>0")
+	}
+	if sub.AddedAt.Before(before) || sub.AddedAt.After(after) {
+		t.Errorf("AddedAt = %v, want between %v and %v", sub.AddedAt, before, after)
+	}
+}
+
+// TestUnmarshalJSONPreservesExistingAddedAt confirms the stamp
+// only fires when AddedAt is zero — a spec round-tripped through
+// JSON keeps its original timestamp.
+func TestUnmarshalJSONPreservesExistingAddedAt(t *testing.T) {
+	t.Parallel()
+
+	original := time.Date(2025, 1, 15, 10, 30, 0, 0, time.UTC)
+	raw, err := json.Marshal(Spec{
+		Name:         "watcher",
+		Operation:    OperationService,
+		Task:         "t",
+		SleepMin:     time.Minute,
+		SleepMax:     time.Minute,
+		SleepDefault: time.Minute,
+		Subscriptions: []EntitySubscription{
+			{EntityID: "sensor.foo", TTLSeconds: 60, AddedAt: original},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+
+	var s Spec
+	if err := json.Unmarshal(raw, &s); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if !s.Subscriptions[0].AddedAt.Equal(original) {
+		t.Errorf("AddedAt = %v, want %v (existing timestamp should not be overwritten)", s.Subscriptions[0].AddedAt, original)
+	}
+}
+
+// TestUnmarshalJSONNormalizesForecast covers the parallel
+// invariant: "none" maps to "" and unknown values are rejected at
+// the hydration boundary, matching the tool-side normalizer.
+// Without this, a persisted forecast of "none" would reach the
+// renderer as a real forecast type and trigger an invalid HA
+// fetch.
+func TestUnmarshalJSONNormalizesForecast(t *testing.T) {
+	t.Parallel()
+
+	t.Run("none collapses to empty", func(t *testing.T) {
+		raw := []byte(`{
+			"name": "w",
+			"operation": "service",
+			"task": "t",
+			"sleep_min": "1m",
+			"sleep_max": "1m",
+			"sleep_default": "1m",
+			"subscriptions": [{"entity_id": "weather.home", "forecast": "none"}]
+		}`)
+		var s Spec
+		if err := json.Unmarshal(raw, &s); err != nil {
+			t.Fatalf("Unmarshal: %v", err)
+		}
+		if s.Subscriptions[0].Forecast != "" {
+			t.Errorf("Forecast = %q, want empty", s.Subscriptions[0].Forecast)
+		}
+	})
+
+	t.Run("invalid forecast rejected", func(t *testing.T) {
+		raw := []byte(`{
+			"name": "w",
+			"operation": "service",
+			"task": "t",
+			"sleep_min": "1m",
+			"sleep_max": "1m",
+			"sleep_default": "1m",
+			"subscriptions": [{"entity_id": "weather.home", "forecast": "monthly"}]
+		}`)
+		var s Spec
+		err := json.Unmarshal(raw, &s)
+		if err == nil {
+			t.Fatal("Unmarshal accepted invalid forecast; want rejection")
+		}
+		if !strings.Contains(err.Error(), "forecast") {
+			t.Errorf("err = %v, should mention forecast", err)
+		}
+	})
+}
+
+// TestNormalizeSubscriptionForecastTable covers the canonicalizer
+// directly so the boundary contract is pinned independently of
+// the UnmarshalJSON path.
+func TestNormalizeSubscriptionForecastTable(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		raw     string
+		want    string
+		wantErr bool
+	}{
+		{"", "", false},
+		{"none", "", false},
+		{"  ", "", false},
+		{"daily", "daily", false},
+		{"hourly", "hourly", false},
+		{"twice_daily", "twice_daily", false},
+		{"  daily  ", "daily", false},
+		{"monthly", "", true},
+		{"DAILY", "", true}, // strict — case-sensitive at this boundary
+	}
+	for _, tc := range cases {
+		t.Run(tc.raw, func(t *testing.T) {
+			got, err := NormalizeSubscriptionForecast(tc.raw)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("got %q, nil; want error", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/runtime/loop/upsert_parent_validation_test.go
+++ b/internal/runtime/loop/upsert_parent_validation_test.go
@@ -1,0 +1,99 @@
+package loop
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestUpsertRejectsContainerWithServiceParent is the regression
+// test for the LOW finding in the post-#894 audit: a container
+// whose parent_name resolves to a non-container would silently
+// lose its inheritance chain (the cascade walk only flows
+// through container ancestors). Catch it at write time.
+func TestUpsertRejectsContainerWithServiceParent(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	reg, err := NewDefinitionRegistry(nil)
+	if err != nil {
+		t.Fatalf("NewDefinitionRegistry: %v", err)
+	}
+	// Seed a service that some future operator might try to make
+	// a container's parent.
+	parentSvc := Spec{
+		Name:         "background_worker",
+		Operation:    OperationService,
+		Task:         "t",
+		SleepMin:     time.Minute,
+		SleepMax:     time.Minute,
+		SleepDefault: time.Minute,
+	}
+	if err := reg.Upsert(parentSvc, now); err != nil {
+		t.Fatalf("upsert service: %v", err)
+	}
+
+	// Now try to push a container that names the service as its parent.
+	badContainer := Spec{
+		Name:       "home_automation",
+		Operation:  OperationContainer,
+		ParentName: "background_worker",
+	}
+	err = reg.Upsert(badContainer, now)
+	if err == nil {
+		t.Fatal("Upsert accepted container with service parent; want rejection")
+	}
+	if !strings.Contains(err.Error(), "container") || !strings.Contains(err.Error(), "must themselves be containers") {
+		t.Errorf("err = %v, should explain the container-parent constraint", err)
+	}
+}
+
+// TestUpsertAcceptsContainerWithContainerParent covers the happy
+// path — nested containers are valid and stored normally.
+func TestUpsertAcceptsContainerWithContainerParent(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	reg, err := NewDefinitionRegistry(nil)
+	if err != nil {
+		t.Fatalf("NewDefinitionRegistry: %v", err)
+	}
+	if err := reg.Upsert(Spec{Name: "outer", Operation: OperationContainer}, now); err != nil {
+		t.Fatalf("upsert outer: %v", err)
+	}
+	nested := Spec{
+		Name:       "inner",
+		Operation:  OperationContainer,
+		ParentName: "outer",
+	}
+	if err := reg.Upsert(nested, now); err != nil {
+		t.Fatalf("upsert inner: %v", err)
+	}
+}
+
+// TestUpsertAllowsContainerParentNameForwardReference covers an
+// awkward but legal case: a container declares parent_name
+// pointing at a container that hasn't been upserted yet. The
+// cross-spec check uses specByName which returns ok=false for
+// missing parents — we let the upsert through and rely on
+// hydration / topological sort to surface the missing parent at
+// startup. Catching it loudly at write time would block bulk
+// imports where children land before parents.
+func TestUpsertAllowsContainerParentNameForwardReference(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	reg, err := NewDefinitionRegistry(nil)
+	if err != nil {
+		t.Fatalf("NewDefinitionRegistry: %v", err)
+	}
+	// Child upserted first, parent name points at a not-yet-
+	// registered container. Should succeed.
+	if err := reg.Upsert(Spec{
+		Name:       "inner",
+		Operation:  OperationContainer,
+		ParentName: "outer_not_yet_pushed",
+	}, now); err != nil {
+		t.Fatalf("Upsert with forward parent ref: %v", err)
+	}
+}

--- a/internal/state/awareness/loop_subscription_provider.go
+++ b/internal/state/awareness/loop_subscription_provider.go
@@ -85,20 +85,28 @@ func (p *LoopSubscriptionProvider) TagContext(ctx context.Context, _ agentctx.Co
 	// entity that's both always-on and loop-scoped. Each duplicate
 	// would add an HA fetch and a redundant prompt block; the
 	// always-visible rendering wins because it would appear in
-	// every loop's context anyway. Defensive: if the store query
-	// errors, log and continue without the filter (better to
-	// double-render than to break context entirely).
+	// every loop's context anyway. We use
+	// [WatchlistStore.UntaggedEntityIDSet] (bounded IN-clause query,
+	// no TTL cleanup writes) so the dedup check costs one indexed
+	// scan over the loop's own candidate list rather than a full
+	// always-visible scan + cleanup pass — the cleanup is left to
+	// [WatchlistProvider]'s own iteration on the same turn.
+	// Defensive: if the store query errors, log and continue
+	// without the filter (better to double-render than to break
+	// context entirely).
 	alreadyVisible := make(map[string]struct{})
-	if p.store != nil {
-		untagged, err := p.store.ListUntaggedSubscriptions()
+	if p.store != nil && len(subs) > 0 {
+		candidates := make([]string, 0, len(subs))
+		for _, sub := range subs {
+			candidates = append(candidates, sub.EntityID)
+		}
+		set, err := p.store.UntaggedEntityIDSet(candidates)
 		if err != nil {
 			p.logger.Warn("loop subscription provider could not enumerate always-visible store",
 				"error", err,
 			)
 		} else {
-			for _, row := range untagged {
-				alreadyVisible[row.EntityID] = struct{}{}
-			}
+			alreadyVisible = set
 		}
 	}
 

--- a/internal/state/awareness/loop_subscription_provider.go
+++ b/internal/state/awareness/loop_subscription_provider.go
@@ -22,6 +22,7 @@ import (
 // loop- and container-scoped subscriptions.
 type LoopSubscriptionProvider struct {
 	loops      *looppkg.Registry
+	store      *WatchlistStore
 	ha         StateGetter
 	registries HARegistryClient
 	logger     *slog.Logger
@@ -30,11 +31,17 @@ type LoopSubscriptionProvider struct {
 // NewLoopSubscriptionProvider creates a provider bound to the live
 // loop registry. ha is the Home Assistant state getter used for the
 // per-entity render; logger may be nil (defaults to slog.Default()).
-func NewLoopSubscriptionProvider(loops *looppkg.Registry, ha StateGetter, logger *slog.Logger) *LoopSubscriptionProvider {
+// store is the always-visible watchlist store consulted at render
+// time to skip entity_ids already rendered by [WatchlistProvider] —
+// without that filter, an entity subscribed both always-on and
+// loop-scoped would render twice in the prompt and double the HA
+// fetch traffic. Pass nil only in tests that don't care about the
+// double-render guard.
+func NewLoopSubscriptionProvider(loops *looppkg.Registry, store *WatchlistStore, ha StateGetter, logger *slog.Logger) *LoopSubscriptionProvider {
 	if logger == nil {
 		logger = slog.Default()
 	}
-	return &LoopSubscriptionProvider{loops: loops, ha: ha, logger: logger}
+	return &LoopSubscriptionProvider{loops: loops, store: store, ha: ha, logger: logger}
 }
 
 // TagContextBucket places loop-scoped entity snapshots in live state,
@@ -73,6 +80,28 @@ func (p *LoopSubscriptionProvider) TagContext(ctx context.Context, _ agentctx.Co
 	now := time.Now()
 	registries := newRenderRegistries(ctx, p.registries)
 
+	// Build the set of entity_ids already rendered by the always-
+	// visible [WatchlistProvider] so we don't double-render any
+	// entity that's both always-on and loop-scoped. Each duplicate
+	// would add an HA fetch and a redundant prompt block; the
+	// always-visible rendering wins because it would appear in
+	// every loop's context anyway. Defensive: if the store query
+	// errors, log and continue without the filter (better to
+	// double-render than to break context entirely).
+	alreadyVisible := make(map[string]struct{})
+	if p.store != nil {
+		untagged, err := p.store.ListUntaggedSubscriptions()
+		if err != nil {
+			p.logger.Warn("loop subscription provider could not enumerate always-visible store",
+				"error", err,
+			)
+		} else {
+			for _, row := range untagged {
+				alreadyVisible[row.EntityID] = struct{}{}
+			}
+		}
+	}
+
 	// Render the body first so an all-expired list yields no header.
 	// Otherwise a quiescent loop whose TTLs all elapsed would still
 	// add a "### Watched Entities (loop)" line with no entries, which
@@ -80,6 +109,9 @@ func (p *LoopSubscriptionProvider) TagContext(ctx context.Context, _ agentctx.Co
 	var body strings.Builder
 	for _, sub := range subs {
 		if sub.IsExpired(now) {
+			continue
+		}
+		if _, dup := alreadyVisible[sub.EntityID]; dup {
 			continue
 		}
 		body.WriteString(p.renderLoopSubscription(ctx, sub, now, registries))

--- a/internal/state/awareness/loop_subscription_provider_test.go
+++ b/internal/state/awareness/loop_subscription_provider_test.go
@@ -1,0 +1,125 @@
+package awareness
+
+import (
+	"context"
+	"database/sql"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/nugget/thane-ai-agent/internal/integrations/homeassistant"
+	"github.com/nugget/thane-ai-agent/internal/runtime/agentctx"
+	looppkg "github.com/nugget/thane-ai-agent/internal/runtime/loop"
+	_ "modernc.org/sqlite"
+)
+
+// setupLoopSubProvider builds a LoopSubscriptionProvider with an
+// in-memory watchlist store, an in-memory loop registry, and the
+// fakeHA stub used by the rest of the awareness tests.
+func setupLoopSubProvider(t *testing.T) (*LoopSubscriptionProvider, *WatchlistStore, *looppkg.Registry, *fakeHA) {
+	t.Helper()
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+
+	store, err := NewWatchlistStore(db, nil)
+	if err != nil {
+		t.Fatalf("new store: %v", err)
+	}
+
+	ha := &fakeHA{
+		states: map[string]*homeassistant.State{
+			"sensor.shared": {EntityID: "sensor.shared", State: "1"},
+			"sensor.loop":   {EntityID: "sensor.loop", State: "2"},
+		},
+	}
+	reg := looppkg.NewRegistry()
+
+	p := NewLoopSubscriptionProvider(reg, store, ha, slog.Default())
+	return p, store, reg, ha
+}
+
+// TestLoopSubscriptionProviderSkipsAlwaysVisibleEntities is the
+// regression test for the audit's HIGH #5 finding: an entity
+// present in BOTH the always-visible store and the loop's
+// effective subscriptions was being rendered twice (one block by
+// WatchlistProvider, one by LoopSubscriptionProvider) and
+// triggering two HA fetches per turn. The loop-scoped renderer
+// now filters out entity_ids the always-visible store already
+// carries — the always-on rendering wins because it would appear
+// in every loop's context regardless.
+func TestLoopSubscriptionProviderSkipsAlwaysVisibleEntities(t *testing.T) {
+	t.Parallel()
+
+	p, store, reg, ha := setupLoopSubProvider(t)
+
+	// Always-visible subscription via the store (no scope).
+	if err := store.Add("sensor.shared"); err != nil {
+		t.Fatalf("seed always-visible: %v", err)
+	}
+
+	// Loop with two subs: one that overlaps the always-visible
+	// entry, one that's loop-only.
+	leaf, err := looppkg.New(looppkg.Config{
+		Name: "leaf",
+		Task: "t",
+		Subscriptions: []looppkg.EntitySubscription{
+			{EntityID: "sensor.shared"},
+			{EntityID: "sensor.loop"},
+		},
+	}, looppkg.Deps{Runner: noopRunnerForLoopSub{}})
+	if err != nil {
+		t.Fatalf("new leaf: %v", err)
+	}
+	if err := reg.Register(leaf); err != nil {
+		t.Fatalf("register leaf: %v", err)
+	}
+
+	ctx := looppkg.WithLoopIDForTest(context.Background(), leaf.ID())
+	out, err := p.TagContext(ctx, agentctx.ContextRequest{})
+	if err != nil {
+		t.Fatalf("TagContext: %v", err)
+	}
+
+	// The loop-scoped block should mention sensor.loop but NOT
+	// sensor.shared (the always-visible block covers it).
+	if !strings.Contains(out, "sensor.loop") {
+		t.Errorf("loop-scoped render missing sensor.loop: %q", out)
+	}
+	if strings.Contains(out, "sensor.shared") {
+		t.Errorf("loop-scoped render leaked sensor.shared (already always-visible): %q", out)
+	}
+
+	// And only sensor.loop should have hit the HA state getter on
+	// this provider's pass. (sensor.shared is fetched by the
+	// always-visible WatchlistProvider on its own pass; that's
+	// not our concern here.)
+	for _, fetched := range haStateFetches(ha) {
+		if fetched == "sensor.shared" {
+			t.Errorf("provider fetched sensor.shared despite always-visible dedup")
+		}
+	}
+}
+
+// haStateFetches reconstructs the entity IDs the provider asked
+// for via the fakeHA's recorded interactions. fakeHA doesn't
+// track GetState calls directly; we approximate by checking what
+// it WOULD have been able to return.
+func haStateFetches(_ *fakeHA) []string {
+	// fakeHA doesn't have a GetState tracking slice today. The
+	// behavioral check above (output text) is what enforces the
+	// dedup. This helper exists as a clear extension point if
+	// future hardening needs to assert fetch counts.
+	return nil
+}
+
+// noopRunnerForLoopSub satisfies the Runner interface so a loop
+// with a Task can be constructed; never actually called by these
+// tests because we don't invoke the runner.
+type noopRunnerForLoopSub struct{}
+
+func (noopRunnerForLoopSub) Run(_ context.Context, _ looppkg.Request, _ looppkg.StreamCallback) (*looppkg.Response, error) {
+	return &looppkg.Response{}, nil
+}

--- a/internal/state/awareness/loop_subscription_provider_test.go
+++ b/internal/state/awareness/loop_subscription_provider_test.go
@@ -53,7 +53,7 @@ func setupLoopSubProvider(t *testing.T) (*LoopSubscriptionProvider, *WatchlistSt
 func TestLoopSubscriptionProviderSkipsAlwaysVisibleEntities(t *testing.T) {
 	t.Parallel()
 
-	p, store, reg, ha := setupLoopSubProvider(t)
+	p, store, reg, _ := setupLoopSubProvider(t)
 
 	// Always-visible subscription via the store (no scope).
 	if err := store.Add("sensor.shared"); err != nil {
@@ -92,27 +92,13 @@ func TestLoopSubscriptionProviderSkipsAlwaysVisibleEntities(t *testing.T) {
 		t.Errorf("loop-scoped render leaked sensor.shared (already always-visible): %q", out)
 	}
 
-	// And only sensor.loop should have hit the HA state getter on
-	// this provider's pass. (sensor.shared is fetched by the
-	// always-visible WatchlistProvider on its own pass; that's
-	// not our concern here.)
-	for _, fetched := range haStateFetches(ha) {
-		if fetched == "sensor.shared" {
-			t.Errorf("provider fetched sensor.shared despite always-visible dedup")
-		}
-	}
-}
-
-// haStateFetches reconstructs the entity IDs the provider asked
-// for via the fakeHA's recorded interactions. fakeHA doesn't
-// track GetState calls directly; we approximate by checking what
-// it WOULD have been able to return.
-func haStateFetches(_ *fakeHA) []string {
-	// fakeHA doesn't have a GetState tracking slice today. The
-	// behavioral check above (output text) is what enforces the
-	// dedup. This helper exists as a clear extension point if
-	// future hardening needs to assert fetch counts.
-	return nil
+	// The output-text check above is what enforces the dedup;
+	// fakeHA doesn't track GetState call counts, so asserting on
+	// the rendered block is the strongest signal we have without
+	// extending the stub. Promoting that to a fetch-count
+	// assertion (by recording GetState invocations on fakeHA) is
+	// a worthwhile follow-up if the provider's render path ever
+	// grows more side effects.
 }
 
 // noopRunnerForLoopSub satisfies the Runner interface so a loop

--- a/internal/state/awareness/watchlist_store.go
+++ b/internal/state/awareness/watchlist_store.go
@@ -170,6 +170,61 @@ func (s *WatchlistStore) ListUntaggedSubscriptions() ([]WatchedSubscription, err
 	return s.listScopedSubscriptions("")
 }
 
+// UntaggedEntityIDSet returns the subset of candidates that are
+// present in the always-visible watchlist (scope=”). It performs a
+// single bounded IN-clause query and skips the TTL cleanup writes
+// that [ListUntaggedSubscriptions] does — this method is meant to
+// be called by sibling providers (e.g.
+// [LoopSubscriptionProvider]) that only need a dedup check against
+// the always-visible set on every iteration; the cleanup is left
+// to the always-visible [WatchlistProvider]'s own pass so we don't
+// double-write deletes. Returns an empty (non-nil) map when
+// candidates is empty.
+func (s *WatchlistStore) UntaggedEntityIDSet(candidates []string) (map[string]struct{}, error) {
+	out := make(map[string]struct{}, len(candidates))
+	if len(candidates) == 0 {
+		return out, nil
+	}
+	// Deduplicate candidates so the IN list and the param vector
+	// don't bloat for a loop that lists the same entity twice
+	// across cascade levels.
+	seen := make(map[string]struct{}, len(candidates))
+	args := make([]any, 0, len(candidates))
+	for _, id := range candidates {
+		if id == "" {
+			continue
+		}
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		args = append(args, id)
+	}
+	if len(args) == 0 {
+		return out, nil
+	}
+	placeholders := strings.Repeat("?,", len(args))
+	placeholders = placeholders[:len(placeholders)-1]
+	query := `SELECT entity_id FROM watched_entity_subscriptions
+		 WHERE scope = '' AND entity_id IN (` + placeholders + `)`
+	rows, err := s.db.Query(query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		out[id] = struct{}{}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // ListByTag returns watched entity subscriptions for the given capability
 // tag. Used by the tag context assembler to inject entity context only when a
 // tag is active.

--- a/internal/state/awareness/watchlist_store_test.go
+++ b/internal/state/awareness/watchlist_store_test.go
@@ -240,3 +240,60 @@ func TestStore_ListSubscriptionsSkipsExpiredAndCleansUp(t *testing.T) {
 		t.Fatalf("subscriptionCount() = %d, want 0 after cleanup", count)
 	}
 }
+
+// TestStore_UntaggedEntityIDSet covers the narrow dedup lookup
+// used by [LoopSubscriptionProvider]: it must return only the
+// candidates present in the always-visible (scope=”) set,
+// ignore tagged subscriptions for the same entity_id, and skip
+// the TTL cleanup side effect that [ListUntaggedSubscriptions]
+// performs.
+func TestStore_UntaggedEntityIDSet(t *testing.T) {
+	store := setupTestStore(t)
+
+	// Untagged → in the always-visible set.
+	if err := store.Add("sensor.always_on"); err != nil {
+		t.Fatalf("add: %v", err)
+	}
+	// Tagged → NOT in the always-visible set even though the
+	// entity_id matches a candidate.
+	if err := store.AddWithOptions("sensor.tagged_only", []string{"focus"}, nil, 0, ""); err != nil {
+		t.Fatalf("AddWithOptions: %v", err)
+	}
+
+	set, err := store.UntaggedEntityIDSet([]string{
+		"sensor.always_on",
+		"sensor.tagged_only",
+		"sensor.unknown",
+	})
+	if err != nil {
+		t.Fatalf("UntaggedEntityIDSet: %v", err)
+	}
+	if _, ok := set["sensor.always_on"]; !ok {
+		t.Errorf("missing sensor.always_on in result: %v", set)
+	}
+	if _, ok := set["sensor.tagged_only"]; ok {
+		t.Errorf("sensor.tagged_only leaked through despite tagged scope: %v", set)
+	}
+	if _, ok := set["sensor.unknown"]; ok {
+		t.Errorf("sensor.unknown leaked through despite not being subscribed: %v", set)
+	}
+
+	// Empty candidate list returns an empty (non-nil) map.
+	empty, err := store.UntaggedEntityIDSet(nil)
+	if err != nil {
+		t.Fatalf("UntaggedEntityIDSet(nil): %v", err)
+	}
+	if empty == nil || len(empty) != 0 {
+		t.Errorf("want empty non-nil map, got %#v", empty)
+	}
+
+	// Duplicates and empty strings in the candidate list are
+	// tolerated (deduped + filtered before the SQL IN clause).
+	set2, err := store.UntaggedEntityIDSet([]string{"sensor.always_on", "sensor.always_on", ""})
+	if err != nil {
+		t.Fatalf("UntaggedEntityIDSet dedup: %v", err)
+	}
+	if len(set2) != 1 {
+		t.Errorf("want exactly 1 entry after dedup, got %v", set2)
+	}
+}

--- a/internal/tools/loop_intent_tools.go
+++ b/internal/tools/loop_intent_tools.go
@@ -228,7 +228,7 @@ func (r *Registry) registerThaneCurate() {
 			"Future modes will accept a directory ref for tree-shaped collections (multiple files maintained as a structured corpus); the output parameter shape will grow additively. " +
 			"Sleep envelope: pass sleep_min and sleep_max as Go duration strings (\"5m\", \"30m\", \"1h\"). The running loop uses set_next_sleep to self-pace within those bounds — pick them to match the topic's metabolism (tight when busy work deserves quick checks, loose when quiet periods should cost nothing). sleep_default and jitter are optional with sensible defaults. " +
 			"Tags scope the loop's tools; omit to inherit the always-active set. " +
-			"Entities is a list of Home Assistant entity subscriptions the loop should see every iteration; they are persisted under a per-loop scope tag and surfaced into the loop's prompt automatically. " +
+			"Entities is a list of Home Assistant entity subscriptions the loop should see every iteration; they are persisted on the loop's own spec and surfaced into the loop's prompt automatically. Container ancestors' subscriptions also cascade in. " +
 			"Returns the document ref, loop definition name, loop_id, output mode, the generated output tool name (output_tool) the receiving loop writes through, the count of declared entity subscriptions, and the resolved sleep envelope.",
 		ContentResolveExempt: []string{"name", "intent", "sleep_min", "sleep_max", "sleep_default", "jitter", "tags", "instructions", "output", "entities", "replace"},
 		Parameters: map[string]any{
@@ -285,7 +285,7 @@ func (r *Registry) registerThaneCurate() {
 				},
 				"entities": map[string]any{
 					"type":        "array",
-					"description": "Optional Home Assistant entity subscriptions the loop should see in context every iteration. Each item declares an entity_id with optional history windows (seconds, e.g. [3600, 86400] for 1h and 1d summaries), weather forecast type for weather.* entities, and a ttl_seconds expiration. Subscriptions are persisted under a per-loop scope tag; you do not need to spell the tag.",
+					"description": "Optional Home Assistant entity subscriptions the loop should see in context every iteration. Each item declares an entity_id with optional history windows (seconds, e.g. [3600, 86400] for 1h and 1d summaries), weather forecast type for weather.* entities, and a ttl_seconds expiration. Stored on the loop's own spec; if the loop has a container parent, subscriptions declared on ancestor containers also appear at iteration time.",
 					"items": map[string]any{
 						"type": "object",
 						"properties": map[string]any{

--- a/internal/tools/loop_intent_tools.go
+++ b/internal/tools/loop_intent_tools.go
@@ -229,7 +229,7 @@ func (r *Registry) registerThaneCurate() {
 			"Sleep envelope: pass sleep_min and sleep_max as Go duration strings (\"5m\", \"30m\", \"1h\"). The running loop uses set_next_sleep to self-pace within those bounds — pick them to match the topic's metabolism (tight when busy work deserves quick checks, loose when quiet periods should cost nothing). sleep_default and jitter are optional with sensible defaults. " +
 			"Tags scope the loop's tools; omit to inherit the always-active set. " +
 			"Entities is a list of Home Assistant entity subscriptions the loop should see every iteration; they are persisted under a per-loop scope tag and surfaced into the loop's prompt automatically. " +
-			"Returns the document ref, loop definition name, loop_id, output mode, the generated output tool name (output_tool) the receiving loop writes through, the loop's internal scope_tag, and the resolved sleep envelope.",
+			"Returns the document ref, loop definition name, loop_id, output mode, the generated output tool name (output_tool) the receiving loop writes through, the count of declared entity subscriptions, and the resolved sleep envelope.",
 		ContentResolveExempt: []string{"name", "intent", "sleep_min", "sleep_max", "sleep_default", "jitter", "tags", "instructions", "output", "entities", "replace"},
 		Parameters: map[string]any{
 			"type": "object",


### PR DESCRIPTION
## Summary

PR-E2 of the post-#894 audit. Six fixes for HIGH/MEDIUM/LOW findings the suspicious diff review surfaced — none would have failed tests under PR-A through PR-D1, but each was a real runtime risk waiting to bite.

## What changed

1. **`Spec.UnmarshalJSON` sweeps `Subscriptions` on hydration.** New `normalizeSubscriptionsOnLoad` runs every load path through the same boundary invariants the tool-side write paths enforce: `NormalizeSubscriptionForecast` canonicalizes (`"none"` → `""`, strict on the three real types), and any `ttl_seconds > 0` entry with a zero `AddedAt` gets stamped. Closes the documented "permanent watcher" footgun where hand-edited or API-supplied specs would deserialize into subscriptions whose `IsExpired` returned false forever.

2. **`mergeLegacySubscriptions` stamps zero `AddedAt` on existing entries.** Partial-upgrade migrations could carry the footgun forward; the migration now applies the same stamp rule the `UnmarshalJSON` sweep enforces.

3. **Provider double-render fix.** `LoopSubscriptionProvider` now skips entity_ids already in the always-visible `WatchlistStore`. Without this, an entity subscribed both always-on and loop-scoped rendered twice in the prompt and doubled HA fetch traffic every turn. `NewLoopSubscriptionProvider` grew a `store` parameter; the app wires the watchlist store through. Tests that don't care can pass `nil` and get the unfiltered (pre-fix) behavior.

4. **`Loop.ParentID()` now locks.** PR-D1's `setDefaultParentID` mutates `l.config.ParentID` after construction, so the lockless read was a race-detector liability even though the mutation happens before any goroutine starts reading. Mirrors the snapshot-accessor pattern.

5. **Stale `scope_tag` dropped from `thane_curate` description.** PR-A retired the `scope_tag` concept; the model-facing tool description still mentioned it as a return value.

6. **Container `parent_name` must resolve to a container.** `DefinitionRegistry.Upsert` now rejects an attempt to push a container whose `parent_name` resolves to a non-container spec. The cascade walker only flows through container ancestors, so this configuration would silently lose the inheritance chain; catching it at write-time is much friendlier than waiting for the operator to wonder why their descendants don't see expected tags. Forward references (parent not yet upserted) still pass — bulk imports can land children before parents and hydration handles the rest.

## Followups

`NormalizeSubscriptionForecast` deliberately doesn't replace the two existing forecast normalizers (one in `tools/`, one in `awareness/`). They have slightly different lenience rules (case-folding, hyphen-to-underscore) and consolidating could shift behavior. Separate refactor.

`WithLoopIDForTest` exported from the loop package so context-driven provider tests in other packages can stamp a `loop_id` on a context without driving a full loop. Production code outside the loop package shouldn't need it.

## Test plan

- [x] `just ci` passes locally
- [x] New tests: `TestUnmarshalJSONStampsAddedAtForTTL`, `TestUnmarshalJSONPreservesExistingAddedAt`, `TestUnmarshalJSONNormalizesForecast`, `TestNormalizeSubscriptionForecastTable`
- [x] New tests: `TestUpsertRejectsContainerWithServiceParent`, `TestUpsertAcceptsContainerWithContainerParent`, `TestUpsertAllowsContainerParentNameForwardReference`
- [x] New test: `TestLoopSubscriptionProviderSkipsAlwaysVisibleEntities`
- [ ] Manual: confirm no log-spam or double HA fetches after deploy

Refs #889