### PR TITLE
fix: parallel-audit findings on post-#894 diff (PR-E3)

### DIFF
--- a/internal/app/loop_definition_runtime.go
+++ b/internal/app/loop_definition_runtime.go
@@ -197,11 +197,23 @@ func (r *loopDefinitionRuntime) serviceContext() context.Context {
 // permanently-eligible status when the definitions registry is
 // unwired (test paths) so the check sites that gate on Eligible
 // don't accidentally block when the registry is mocked away.
+//
+// When the definition is not found in the registry — e.g., a
+// reconcile racing with a delete — the returned status reports
+// ineligible with a "definition_not_found" reason rather than the
+// pre-#896 silent eligible=true fallback. Spawn-time gate sites
+// shouldn't treat a missing-from-registry as "safe to spawn."
 func (r *loopDefinitionRuntime) evaluateConditions(loopName string) looppkg.DefinitionEligibilityStatus {
 	if r == nil || r.definitions == nil {
 		return looppkg.DefinitionEligibilityStatus{Eligible: true}
 	}
-	status, _ := r.definitions.EvaluateConditions(loopName, r.nowTime())
+	status, _, found := r.definitions.EvaluateConditions(loopName, r.nowTime())
+	if !found {
+		return looppkg.DefinitionEligibilityStatus{
+			Eligible: false,
+			Reason:   "definition_not_found",
+		}
+	}
 	return status
 }
 
@@ -218,7 +230,13 @@ func (r *loopDefinitionRuntime) nextScheduleTransition(now time.Time) time.Time 
 		if def.Spec.Operation != looppkg.OperationService || def.PolicyState != looppkg.DefinitionPolicyStateActive {
 			continue
 		}
-		eligibility, _ := r.definitions.EvaluateConditions(def.Name, now)
+		eligibility, _, found := r.definitions.EvaluateConditions(def.Name, now)
+		if !found {
+			// Concurrent delete between Snapshot() and the
+			// per-name lookup. Skip — the next iteration will
+			// see the same (now-fully-removed) state.
+			continue
+		}
 		if eligibility.NextTransitionAt.IsZero() {
 			continue
 		}

--- a/internal/app/loop_focus_tools.go
+++ b/internal/app/loop_focus_tools.go
@@ -180,6 +180,14 @@ func (a *App) mutateLoopSubscriptions(ctx context.Context, loopName string, muta
 	newSpec := existing.Spec
 	newSpec.Subscriptions = next
 	updatedAt := time.Now().UTC()
+	// Persist BEFORE patching live state. The dual-walker model
+	// (live [Registry.effectiveState] vs persisted
+	// [EvaluateEffectiveConditions]) only agrees as long as the
+	// persisted store is at-or-ahead of the live snapshot — if a
+	// process crashes between the live patch and the persist, the
+	// next startup hydrates the loop without the change and the
+	// live and persisted views diverge. This ordering is
+	// load-bearing for any future mutator on this path.
 	if err := a.persistLoopDefinition(newSpec, updatedAt); err != nil {
 		return nil, fmt.Errorf("persist loop definition: %w", err)
 	}
@@ -190,6 +198,17 @@ func (a *App) mutateLoopSubscriptions(ctx context.Context, loopName string, muta
 		if live := a.loopRegistry.GetByName(loopName); live != nil {
 			live.SetSubscriptions(next)
 		}
+	}
+	// Signal the schedule watcher so the invariant "any spec write
+	// refires the schedule watcher" survives this mutator. Today
+	// Subscriptions don't affect schedules, so the signal is
+	// strictly conservative — but the architectural property
+	// matters: a future mutator on this path (Conditions, sleep
+	// envelope) that forgot to signal would silently break wake-up
+	// timing. Fanning out from every spec-mutation point keeps the
+	// reconciler's reactive model honest.
+	if a.loopDefinitionRuntime != nil {
+		a.loopDefinitionRuntime.signalScheduleChange()
 	}
 	_ = ctx
 	return next, nil

--- a/internal/app/loop_focus_tools_test.go
+++ b/internal/app/loop_focus_tools_test.go
@@ -2,11 +2,14 @@ package app
 
 import (
 	"context"
+	"database/sql"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/nugget/thane-ai-agent/internal/platform/opstate"
 	looppkg "github.com/nugget/thane-ai-agent/internal/runtime/loop"
+	_ "modernc.org/sqlite"
 )
 
 // fakeMutator is a thin in-memory implementation of subscriptionMutator
@@ -225,25 +228,27 @@ func TestMutateLoopSubscriptionsSignalsScheduleWatcher(t *testing.T) {
 	}
 }
 
-// TestMutateLoopSubscriptionsPersistsBeforeLivePatch is the
+// TestMutateLoopSubscriptionsWritesPersistedAndLive is the
 // regression test for the post-#896 audit's LOW #4: the dual-
 // walker model (live effectiveState vs. persisted
-// EvaluateEffectiveConditions) only agrees as long as mutators
-// persist before patching live state. We can't directly observe
-// "persist before patch" in a single in-process run; instead we
-// pin the post-state both surfaces should see and assert they
-// agree, which proves the call path doesn't drop the persist
-// step.
-func TestMutateLoopSubscriptionsPersistsBeforeLivePatch(t *testing.T) {
+// EvaluateEffectiveConditions) only agrees when both surfaces
+// reflect the mutation. This test wires a real
+// opstate-backed loopDefinitionStore (in-memory SQLite) so the
+// persistLoopDefinition call is exercised and observable —
+// removing or reordering the persist step would leave the
+// store empty, failing the disk-side assertion. The strict
+// "persist BEFORE live patch" ordering can't be observed
+// from a single in-process run (no crash-injection here), but
+// asserting that BOTH writes occurred catches the most likely
+// regression: a future refactor that drops persistence and
+// only patches live state.
+func TestMutateLoopSubscriptionsWritesPersistedAndLive(t *testing.T) {
 	t.Parallel()
 
 	reg, err := looppkg.NewDefinitionRegistry(nil)
 	if err != nil {
 		t.Fatalf("NewDefinitionRegistry: %v", err)
 	}
-	// Upsert (not seed via constructor) so the definition lands
-	// as runtime-source — config-source specs are immutable and
-	// mutateLoopSubscriptions rejects them.
 	if err := reg.Upsert(looppkg.Spec{
 		Name:         "leaf",
 		Task:         "t",
@@ -254,6 +259,7 @@ func TestMutateLoopSubscriptionsPersistsBeforeLivePatch(t *testing.T) {
 	}, time.Now()); err != nil {
 		t.Fatalf("Upsert: %v", err)
 	}
+
 	loops := looppkg.NewRegistry()
 	t.Cleanup(func() {
 		shutdownCtx, cancel := context.WithTimeout(context.Background(), time.Second)
@@ -275,6 +281,21 @@ func TestMutateLoopSubscriptionsPersistsBeforeLivePatch(t *testing.T) {
 		t.Fatalf("register leaf: %v", err)
 	}
 
+	// Real opstate-backed store on an in-memory SQLite — so
+	// persistLoopDefinition is not a no-op and a future
+	// refactor that drops the persist call would leave the
+	// disk-side assertion below empty.
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	opStore, err := opstate.NewStore(db, nil)
+	if err != nil {
+		t.Fatalf("opstate.NewStore: %v", err)
+	}
+	store := newLoopDefinitionStore(opStore)
+
 	runtime := &loopDefinitionRuntime{
 		definitions: reg,
 		scheduleCh:  make(chan struct{}, 1),
@@ -283,6 +304,7 @@ func TestMutateLoopSubscriptionsPersistsBeforeLivePatch(t *testing.T) {
 		loopDefinitionRegistry: reg,
 		loopDefinitionRuntime:  runtime,
 		loopRegistry:           loops,
+		loopDefinitionStore:    store,
 	}
 
 	_, err = a.mutateLoopSubscriptions(context.Background(), "leaf",
@@ -294,8 +316,24 @@ func TestMutateLoopSubscriptionsPersistsBeforeLivePatch(t *testing.T) {
 		t.Fatalf("mutateLoopSubscriptions: %v", err)
 	}
 
-	// Persisted view: the definition registry should hold the
-	// new subscription.
+	// Disk-side assertion: read the store directly. Failing here
+	// means persistLoopDefinition was skipped or didn't actually
+	// reach the backing opstate — the in-memory DefinitionRegistry
+	// would still show the change, so the previous version of
+	// this test would have passed and missed the regression.
+	persisted, err := opStore.Get(loopDefinitionRegistryNamespace, "leaf")
+	if err != nil {
+		t.Fatalf("opStore.Get: %v", err)
+	}
+	if persisted == "" {
+		t.Fatal("opStore has no row for leaf — persistLoopDefinition was skipped")
+	}
+	if !strings.Contains(persisted, "sensor.foo") {
+		t.Errorf("persisted payload missing sensor.foo: %s", persisted)
+	}
+
+	// In-memory definition-registry view: same content via the
+	// snapshot path most callers use.
 	snap := reg.Snapshot()
 	if snap == nil {
 		t.Fatal("definition registry Snapshot returned nil")
@@ -307,7 +345,7 @@ func TestMutateLoopSubscriptionsPersistsBeforeLivePatch(t *testing.T) {
 		}
 		found = true
 		if len(def.Spec.Subscriptions) != 1 || def.Spec.Subscriptions[0].EntityID != "sensor.foo" {
-			t.Errorf("persisted Subscriptions = %v, want [sensor.foo]", def.Spec.Subscriptions)
+			t.Errorf("registry-snapshot Subscriptions = %v, want [sensor.foo]", def.Spec.Subscriptions)
 		}
 	}
 	if !found {
@@ -315,7 +353,9 @@ func TestMutateLoopSubscriptionsPersistsBeforeLivePatch(t *testing.T) {
 	}
 
 	// Live view: same change should be visible on the running
-	// loop. Equivalent state on both walkers is the invariant.
+	// loop. All three surfaces (disk, registry-snapshot, live
+	// loop) agreeing is the invariant the dual-walker model
+	// relies on.
 	liveSubs := live.Subscriptions()
 	if len(liveSubs) != 1 || liveSubs[0].EntityID != "sensor.foo" {
 		t.Errorf("live Subscriptions = %v, want [sensor.foo]", liveSubs)

--- a/internal/app/loop_focus_tools_test.go
+++ b/internal/app/loop_focus_tools_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"strings"
 	"testing"
+	"time"
 
 	looppkg "github.com/nugget/thane-ai-agent/internal/runtime/loop"
 )
@@ -163,6 +164,161 @@ func TestBuildLoopFocusTools_EmptyEntityID(t *testing.T) {
 		if err == nil {
 			t.Errorf("%s should reject empty entity_id", rt.Name)
 		}
+	}
+}
+
+// TestMutateLoopSubscriptionsSignalsScheduleWatcher is the
+// regression test for the post-#896 audit's MED #3: any spec-
+// mutation path must refire the schedule watcher so a future
+// mutator that touches Conditions through this code path
+// doesn't silently break wake-up timing. Today subscriptions
+// don't drive schedules, so the signal is conservative; the
+// architectural invariant is what's load-bearing.
+func TestMutateLoopSubscriptionsSignalsScheduleWatcher(t *testing.T) {
+	t.Parallel()
+
+	reg, err := looppkg.NewDefinitionRegistry(nil)
+	if err != nil {
+		t.Fatalf("NewDefinitionRegistry: %v", err)
+	}
+	// Upsert (not seed via constructor) so the definition lands
+	// as runtime-source — config-source specs are immutable and
+	// mutateLoopSubscriptions rejects them.
+	if err := reg.Upsert(looppkg.Spec{
+		Name:         "leaf",
+		Task:         "t",
+		Operation:    looppkg.OperationService,
+		SleepMin:     time.Minute,
+		SleepMax:     time.Minute,
+		SleepDefault: time.Minute,
+	}, time.Now()); err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+
+	scheduleCh := make(chan struct{}, 1)
+	runtime := &loopDefinitionRuntime{
+		definitions: reg,
+		scheduleCh:  scheduleCh,
+	}
+	a := &App{
+		loopDefinitionRegistry: reg,
+		loopDefinitionRuntime:  runtime,
+	}
+
+	_, err = a.mutateLoopSubscriptions(context.Background(), "leaf",
+		func(_ []looppkg.EntitySubscription) ([]looppkg.EntitySubscription, error) {
+			return []looppkg.EntitySubscription{{EntityID: "sensor.foo"}}, nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("mutateLoopSubscriptions: %v", err)
+	}
+
+	// Coalesced signal channel: at least one value must have
+	// landed. We use a non-blocking receive so a missing signal
+	// fails fast rather than hanging the test.
+	select {
+	case <-scheduleCh:
+		// good
+	default:
+		t.Fatal("schedule watcher was not signaled after spec mutation; the 'any spec write refires the schedule watcher' invariant is broken")
+	}
+}
+
+// TestMutateLoopSubscriptionsPersistsBeforeLivePatch is the
+// regression test for the post-#896 audit's LOW #4: the dual-
+// walker model (live effectiveState vs. persisted
+// EvaluateEffectiveConditions) only agrees as long as mutators
+// persist before patching live state. We can't directly observe
+// "persist before patch" in a single in-process run; instead we
+// pin the post-state both surfaces should see and assert they
+// agree, which proves the call path doesn't drop the persist
+// step.
+func TestMutateLoopSubscriptionsPersistsBeforeLivePatch(t *testing.T) {
+	t.Parallel()
+
+	reg, err := looppkg.NewDefinitionRegistry(nil)
+	if err != nil {
+		t.Fatalf("NewDefinitionRegistry: %v", err)
+	}
+	// Upsert (not seed via constructor) so the definition lands
+	// as runtime-source — config-source specs are immutable and
+	// mutateLoopSubscriptions rejects them.
+	if err := reg.Upsert(looppkg.Spec{
+		Name:         "leaf",
+		Task:         "t",
+		Operation:    looppkg.OperationService,
+		SleepMin:     time.Minute,
+		SleepMax:     time.Minute,
+		SleepDefault: time.Minute,
+	}, time.Now()); err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+	loops := looppkg.NewRegistry()
+	t.Cleanup(func() {
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		loops.ShutdownAll(shutdownCtx)
+	})
+	core, err := looppkg.New(looppkg.Config{Name: looppkg.CoreLoopName, Operation: looppkg.OperationContainer}, looppkg.Deps{})
+	if err != nil {
+		t.Fatalf("new core: %v", err)
+	}
+	if err := loops.Register(core); err != nil {
+		t.Fatalf("register core: %v", err)
+	}
+	live, err := looppkg.New(looppkg.Config{Name: "leaf", Task: "t"}, looppkg.Deps{Runner: testLoopRunner{}})
+	if err != nil {
+		t.Fatalf("new leaf: %v", err)
+	}
+	if err := loops.Register(live); err != nil {
+		t.Fatalf("register leaf: %v", err)
+	}
+
+	runtime := &loopDefinitionRuntime{
+		definitions: reg,
+		scheduleCh:  make(chan struct{}, 1),
+	}
+	a := &App{
+		loopDefinitionRegistry: reg,
+		loopDefinitionRuntime:  runtime,
+		loopRegistry:           loops,
+	}
+
+	_, err = a.mutateLoopSubscriptions(context.Background(), "leaf",
+		func(_ []looppkg.EntitySubscription) ([]looppkg.EntitySubscription, error) {
+			return []looppkg.EntitySubscription{{EntityID: "sensor.foo"}}, nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("mutateLoopSubscriptions: %v", err)
+	}
+
+	// Persisted view: the definition registry should hold the
+	// new subscription.
+	snap := reg.Snapshot()
+	if snap == nil {
+		t.Fatal("definition registry Snapshot returned nil")
+	}
+	var found bool
+	for _, def := range snap.Definitions {
+		if def.Name != "leaf" {
+			continue
+		}
+		found = true
+		if len(def.Spec.Subscriptions) != 1 || def.Spec.Subscriptions[0].EntityID != "sensor.foo" {
+			t.Errorf("persisted Subscriptions = %v, want [sensor.foo]", def.Spec.Subscriptions)
+		}
+	}
+	if !found {
+		t.Fatal("leaf definition missing from snapshot after mutation")
+	}
+
+	// Live view: same change should be visible on the running
+	// loop. Equivalent state on both walkers is the invariant.
+	liveSubs := live.Subscriptions()
+	if len(liveSubs) != 1 || liveSubs[0].EntityID != "sensor.foo" {
+		t.Errorf("live Subscriptions = %v, want [sensor.foo]", liveSubs)
 	}
 }
 

--- a/internal/app/new_servers.go
+++ b/internal/app/new_servers.go
@@ -553,7 +553,25 @@ func (a *App) initServers(s *newState) error {
 	if a.loopDefinitionRuntime != nil {
 		a.deferWorker("loop-definition-services", func(ctx context.Context) error {
 			if err := a.migrateLegacyScopeTagSubscriptions(); err != nil {
-				logger.Warn("legacy scope_tag migration encountered errors", "error", err)
+				// Promoted from Warn to hard error: a failed
+				// migration leaves subscription state partial —
+				// spec.Subscriptions populated, legacy
+				// scope_tag metadata still present, watchlist
+				// rows un-wiped. The next startup re-runs the
+				// migration. If an operator edits subscriptions
+				// between failed-migration restarts (via
+				// watch_entity / update_entity_subscriptions),
+				// mergeLegacySubscriptions re-adds the entities
+				// they removed because step 1 unions
+				// def.Spec.Subscriptions with the legacy rows
+				// that are still in the watchlist. Failing the
+				// startup loud forces operator attention while
+				// the migration is still a one-shot upgrade
+				// path; the migration is idempotent in the
+				// happy case, so a clean restart after fixing
+				// the underlying issue (DB connectivity,
+				// permissions, schema drift) resumes cleanly.
+				return fmt.Errorf("legacy scope_tag migration failed — subscription state may be partial; fix underlying error and restart: %w", err)
 			}
 			// Core is auto-created synchronously during initStores —
 			// before any deferred worker runs — so default-parenting

--- a/internal/runtime/loop/conditions.go
+++ b/internal/runtime/loop/conditions.go
@@ -89,6 +89,16 @@ type EffectiveConditionEvaluation struct {
 // gating the loop. The per-level evaluations are returned alongside
 // so the effective surface can show provenance.
 //
+// This is the PERSISTED walker (chain comes from
+// [DefinitionRegistry.AncestorSpecs] — spec-level reads). Its
+// live counterpart is [Registry.effectiveState]. The two walkers
+// only agree as long as mutators persist BEFORE patching live
+// state — see the load-bearing ordering at
+// [app.App.mutateLoopSubscriptions]. A future mutator that
+// patches live state without persisting first would let the
+// persisted walker stay stale while the live walker shows the
+// new value, until reconcile catches up.
+//
 // Only the leaf itself (chain[0]) and container ancestors
 // contribute. Non-container ancestors are walked past silently —
 // matches the inheritance contract established in PR-A/B/C, where

--- a/internal/runtime/loop/conditions_cascade_test.go
+++ b/internal/runtime/loop/conditions_cascade_test.go
@@ -298,7 +298,10 @@ func TestDefinitionRegistryEvaluateConditionsCascades(t *testing.T) {
 		t.Fatalf("upsert leaf: %v", err)
 	}
 
-	status, evals := reg.EvaluateConditions("leaf", now)
+	status, evals, found := reg.EvaluateConditions("leaf", now)
+	if !found {
+		t.Fatal("EvaluateConditions reported leaf as not found")
+	}
 	if status.Eligible {
 		t.Errorf("leaf should be ineligible due to ancestor schedule, got %+v", status)
 	}

--- a/internal/runtime/loop/definition_registry.go
+++ b/internal/runtime/loop/definition_registry.go
@@ -179,19 +179,22 @@ const definitionAncestorWalkLimit = 64
 // loop as eligible. Distinguishing the cases here pushes the
 // not-found handling back where it belongs — the call site that
 // looked the definition up in the first place.
+//
+// Input is trimmed before lookup so " leaf " resolves the same
+// definition as "leaf" — matches the trim that [AncestorSpecs]
+// and [Upsert] already apply elsewhere.
 func (r *DefinitionRegistry) EvaluateConditions(name string, now time.Time) (DefinitionEligibilityStatus, []EffectiveConditionEvaluation, bool) {
-	r.mu.RLock()
-	_, exists := r.specByName(name)
-	r.mu.RUnlock()
-	if !exists {
+	if r == nil {
 		return DefinitionEligibilityStatus{}, nil, false
 	}
+	// AncestorSpecs trims internally and returns an empty chain
+	// when the leaf isn't in the registry — that's our found
+	// signal. No separate specByName precheck needed (and the
+	// precheck would have used the raw, un-trimmed name and
+	// reported false for " leaf " when AncestorSpecs would have
+	// resolved it normally).
 	chain := r.AncestorSpecs(name)
 	if len(chain) == 0 {
-		// specByName saw the definition but AncestorSpecs walked
-		// nothing — would require a concurrent delete between the
-		// two reads. Treat as not-found rather than synthesizing
-		// an eligible status from no chain.
 		return DefinitionEligibilityStatus{}, nil, false
 	}
 	status, evals := EvaluateEffectiveConditions(chain, now)

--- a/internal/runtime/loop/definition_registry.go
+++ b/internal/runtime/loop/definition_registry.go
@@ -166,16 +166,36 @@ const definitionAncestorWalkLimit = 64
 // definition and evaluates Conditions across every ancestor with
 // AND semantics. Convenience wrapper around [AncestorSpecs] +
 // [EvaluateEffectiveConditions] for the common eligibility-check
-// surfaces. Returns (eligible=true, nil) when the definition is
-// not found — letting check sites stick with their existing
-// not-found handling rather than conflate "missing" with
-// "ineligible."
-func (r *DefinitionRegistry) EvaluateConditions(name string, now time.Time) (DefinitionEligibilityStatus, []EffectiveConditionEvaluation) {
+// surfaces.
+//
+// Returns (status, evals, found). When the definition is not in
+// the registry the returned status is the zero
+// [DefinitionEligibilityStatus] (NOT eligible=true) and found is
+// false — callers MUST check found before treating Eligible as
+// "safe to spawn." Previously the missing case collapsed into
+// eligible=true; a stale snapshot lookup that happened to
+// observe a registry gap would have let the gated check sites
+// (bootstrap, LaunchDefinition, ReconcileDefinition) spawn the
+// loop as eligible. Distinguishing the cases here pushes the
+// not-found handling back where it belongs — the call site that
+// looked the definition up in the first place.
+func (r *DefinitionRegistry) EvaluateConditions(name string, now time.Time) (DefinitionEligibilityStatus, []EffectiveConditionEvaluation, bool) {
+	r.mu.RLock()
+	_, exists := r.specByName(name)
+	r.mu.RUnlock()
+	if !exists {
+		return DefinitionEligibilityStatus{}, nil, false
+	}
 	chain := r.AncestorSpecs(name)
 	if len(chain) == 0 {
-		return DefinitionEligibilityStatus{Eligible: true}, nil
+		// specByName saw the definition but AncestorSpecs walked
+		// nothing — would require a concurrent delete between the
+		// two reads. Treat as not-found rather than synthesizing
+		// an eligible status from no chain.
+		return DefinitionEligibilityStatus{}, nil, false
 	}
-	return EvaluateEffectiveConditions(chain, now)
+	status, evals := EvaluateEffectiveConditions(chain, now)
+	return status, evals, true
 }
 
 // specByName reads the effective spec by name (overlay first, base

--- a/internal/runtime/loop/definition_registry_evaluate_test.go
+++ b/internal/runtime/loop/definition_registry_evaluate_test.go
@@ -35,6 +35,59 @@ func TestEvaluateConditionsReturnsFoundFalseForMissingDefinition(t *testing.T) {
 	}
 }
 
+// TestEvaluateConditionsTrimsName covers the input-normalization
+// invariant: callers passing " leaf " (whitespace around the
+// name) should resolve the same definition as "leaf". Upsert,
+// AncestorSpecs, and the rest of the registry trim, so
+// EvaluateConditions should match. Otherwise a copy-pasted
+// definition name with trailing whitespace would silently
+// register as "not found" and the new found-bool contract would
+// produce a confusing false negative.
+func TestEvaluateConditionsTrimsName(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	reg, err := NewDefinitionRegistry(nil)
+	if err != nil {
+		t.Fatalf("NewDefinitionRegistry: %v", err)
+	}
+	if err := reg.Upsert(Spec{
+		Name:         "leaf",
+		Task:         "t",
+		Operation:    OperationService,
+		SleepMin:     time.Minute,
+		SleepMax:     time.Minute,
+		SleepDefault: time.Minute,
+	}, now); err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+
+	_, _, found := reg.EvaluateConditions("  leaf  ", now)
+	if !found {
+		t.Errorf("EvaluateConditions(\"  leaf  \") returned found=false; should trim and resolve")
+	}
+}
+
+// TestEvaluateConditionsNilReceiver guards the nil-receiver
+// contract: callers holding an optional registry handle should
+// safely get (zero, nil, false) without panicking. Pairs with
+// the nil-tolerance pattern on [AncestorSpecs] and [Get].
+func TestEvaluateConditionsNilReceiver(t *testing.T) {
+	t.Parallel()
+
+	var reg *DefinitionRegistry
+	status, evals, found := reg.EvaluateConditions("anything", time.Now())
+	if found {
+		t.Error("nil receiver returned found=true")
+	}
+	if status.Eligible || status.Reason != "" || !status.NextTransitionAt.IsZero() {
+		t.Errorf("nil receiver returned non-zero status: %+v", status)
+	}
+	if evals != nil {
+		t.Errorf("nil receiver returned non-nil evals: %v", evals)
+	}
+}
+
 // TestEvaluateConditionsReturnsFoundTrueForRegisteredDefinition
 // covers the happy path: a registered definition returns found=true
 // with the live cascade result. Pairs with the not-found case

--- a/internal/runtime/loop/definition_registry_evaluate_test.go
+++ b/internal/runtime/loop/definition_registry_evaluate_test.go
@@ -1,0 +1,68 @@
+package loop
+
+import (
+	"testing"
+	"time"
+)
+
+// TestEvaluateConditionsReturnsFoundFalseForMissingDefinition is
+// the regression test for the post-#896 audit's MED finding:
+// previously EvaluateConditions collapsed "definition not found"
+// into Eligible:true, which let gated call sites (bootstrap,
+// LaunchDefinition, ReconcileDefinition) treat a stale snapshot
+// or registry race as "safe to spawn." Callers now MUST check the
+// returned found bool before reading .Eligible.
+func TestEvaluateConditionsReturnsFoundFalseForMissingDefinition(t *testing.T) {
+	t.Parallel()
+
+	reg, err := NewDefinitionRegistry(nil)
+	if err != nil {
+		t.Fatalf("NewDefinitionRegistry: %v", err)
+	}
+
+	status, evals, found := reg.EvaluateConditions("ghost", time.Now())
+	if found {
+		t.Fatal("found = true for a name that was never registered")
+	}
+	if status.Eligible {
+		t.Errorf("Eligible = true for missing definition; must be the zero status")
+	}
+	if status.Reason != "" || !status.NextTransitionAt.IsZero() {
+		t.Errorf("status = %+v, want zero status when found=false", status)
+	}
+	if evals != nil {
+		t.Errorf("evals = %v, want nil when found=false", evals)
+	}
+}
+
+// TestEvaluateConditionsReturnsFoundTrueForRegisteredDefinition
+// covers the happy path: a registered definition returns found=true
+// with the live cascade result. Pairs with the not-found case
+// above to pin the two-state contract.
+func TestEvaluateConditionsReturnsFoundTrueForRegisteredDefinition(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	reg, err := NewDefinitionRegistry(nil)
+	if err != nil {
+		t.Fatalf("NewDefinitionRegistry: %v", err)
+	}
+	if err := reg.Upsert(Spec{
+		Name:         "leaf",
+		Task:         "t",
+		Operation:    OperationService,
+		SleepMin:     time.Minute,
+		SleepMax:     time.Minute,
+		SleepDefault: time.Minute,
+	}, now); err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+
+	status, _, found := reg.EvaluateConditions("leaf", now)
+	if !found {
+		t.Fatal("found = false for a registered definition")
+	}
+	if !status.Eligible {
+		t.Errorf("Eligible = false for an unconditional spec; got %+v", status)
+	}
+}

--- a/internal/runtime/loop/loop.go
+++ b/internal/runtime/loop/loop.go
@@ -226,6 +226,23 @@ type Loop struct {
 	// requestInstructions is extra guidance derived from a [Spec]'s
 	// [router.LoopProfile]. It is prepended to each iteration task
 	// when present.
+	//
+	// SCOPE: self-only — does NOT cascade through container
+	// ancestors, unlike the five fields handled by
+	// [Registry.effectiveState] (Subscriptions, Tags, ExcludeTools,
+	// RoutingFactors, DelegationGating) and Conditions. The
+	// reasoning: Instructions describe what THIS loop's task is —
+	// it's task-shape guidance ("always emit JSON", "be terse",
+	// "follow this output template"), not capability-shape. A
+	// parent container with task-specific instructions doesn't
+	// naturally apply to a child whose own task is different.
+	// If a future use case wants inherited instructions
+	// (e.g., a research container demanding all descendant
+	// researchers append citations), promote it to a new
+	// EffectiveState field with explicit merge semantics —
+	// silent cascade through this field would break loops that
+	// declared their own instructions and didn't expect parent
+	// noise prepended.
 	requestInstructions string
 
 	// lastResponse is the most recent successful runner response for

--- a/internal/runtime/loop/registry.go
+++ b/internal/runtime/loop/registry.go
@@ -462,6 +462,18 @@ func (r *Registry) ancestorContainerTags(loopID string) []string {
 // would arise from reading l.config.* directly while holding only
 // r.mu.
 //
+// This is the LIVE walker. Its persisted-side counterpart is
+// [EvaluateEffectiveConditions] (and the per-field
+// [DefinitionRegistry.AncestorSpecs] consumers). The two walkers
+// agree only as long as mutators persist BEFORE patching live
+// state — see the load-bearing ordering at
+// [app.App.mutateLoopSubscriptions]. A mutator that updates live
+// state without persisting (or persists after patching) would let
+// the dual-walk model silently disagree: ConfigureLoop callers
+// reading the live snapshot would see the change, while
+// definition-snapshot consumers (the API surface, eligibility
+// checks, view rendering) would not, until the next persist.
+//
 // Each cascading field uses its own merge semantics:
 //
 //   - Subscriptions / Tags / ExcludeTools — union, first-wins on


### PR DESCRIPTION
## Summary

PR-E3 of the post-#894 audit, picking up five findings from a parallel audit that neither PR-E1 nor PR-E2 caught. Scoped to runtime-correctness items; cosmetic findings (Registry.Core perf, ShutdownAll noop, splitContainerSpecs lint, MultipleCoreError naming, stale scope_tag in spec.go) deferred to backlog.

## What changed

1. **[HIGH] Migration failure is no longer swallowed.** `internal/app/new_servers.go` previously wrapped `migrateLegacyScopeTagSubscriptions` in `logger.Warn(...); continue`. A failed `RemoveAllForScope` in step 2 of the two-step persist leaves stale watchlist rows + populated `Subscriptions` + legacy `Metadata["scope_tag"]` coexisting. On next startup, `mergeLegacySubscriptions` unions `def.Spec.Subscriptions` with the still-present watchlist rows — silently re-adding any entity the operator removed via `watch_entity` / `update_entity_subscriptions` between failed-migration restarts. Promoted to a hard startup error; the migration is idempotent in the happy case, so a clean restart after fixing the underlying issue resumes cleanly.

2. **[MED] `EvaluateConditions` returns a `found bool`.** Previously returned `Eligible:true` when `AncestorSpecs(name)` was empty, conflating "missing" with "eligible." Gated call sites (`bootstrapDefinitionSpawn`, `LaunchDefinition`, the eligibility guard in `ReconcileDefinition`) treat `.Eligible` as "safe to spawn" — a stale snapshot or registry race could have let a not-found loop spawn. Signature now `(DefinitionEligibilityStatus, []EffectiveConditionEvaluation, bool)`. App-side `evaluateConditions` synthesizes ineligible with `Reason="definition_not_found"`; `nextScheduleTransition` skips not-found entries explicitly.

3. **[MED] `mutateLoopSubscriptions` signals the schedule watcher.** `signalScheduleChange` only fired from `ReconcileDefinition`. The newer `mutateLoopSubscriptions` path wrote directly through persist + Upsert + SetSubscriptions without signaling. Correct today (subscriptions don't drive schedules) but the architectural invariant "any spec write refires the schedule watcher" was silently violated — a future mutator on this path touching `Conditions` would break wake-up timing with no warning. Added the signal after successful persist/patch.

4. **[LOW] Persist-before-patch invariant documented in both dual walkers.** `Registry.effectiveState` (live walker) and `EvaluateEffectiveConditions` (persisted walker) only agree as long as mutators persist before patching live state. Comments added to both walkers and to `mutateLoopSubscriptions` naming the ordering as load-bearing.

5. **[LOW] `Profile.Instructions` cascade defined as self-only.** `Spec.profileRequest` flows `Profile.Instructions` into the loop's own task prompt but there's no path to descendants. Documented the choice on the `requestInstructions` field: instructions are task-shape guidance, not capability-shape; cascading silently would surprise loops with their own. If a future use case wants inheritance, promote to a new `EffectiveState` field with explicit merge semantics.

## Test plan

- [x] `just ci` passes locally
- [x] New tests:
  - `TestEvaluateConditionsReturnsFoundFalseForMissingDefinition`
  - `TestEvaluateConditionsReturnsFoundTrueForRegisteredDefinition`
  - `TestMutateLoopSubscriptionsSignalsScheduleWatcher`
  - `TestMutateLoopSubscriptionsPersistsBeforeLivePatch`
- [x] Updated `TestDefinitionRegistryEvaluateConditionsCascades` for the new signature
- [ ] Manual: confirm a deliberately failed migration aborts startup with the new error message
- [ ] Manual: confirm reconcile keeps converging when a definition is concurrently deleted

## Stacked on

Built on top of `codex/subscription-robustness` (PR #896). Once #895 and #896 merge, this PR's diff collapses to the five fixes above.

Refs #889