### PR TITLE
refactor: convert LoopProfile.QualityFloor from string to int (PR-Q1)

### DIFF
--- a/examples/config.example.yaml
+++ b/examples/config.example.yaml
@@ -513,7 +513,7 @@ talents_dir: ./talents
 #       for ambient awareness only (debug-logged, not acted upon).
 #       wake:
 #         model: ""
-#         quality_floor: ""
+#         quality_floor: 0
 #         mission: ""
 #         local_only: ""
 #         delegation_gating: ""
@@ -534,7 +534,7 @@ talents_dir: ./talents
 #       for ambient awareness only (debug-logged, not acted upon).
 #       wake:
 #         model: ""
-#         quality_floor: ""
+#         quality_floor: 0
 #         mission: ""
 #         local_only: ""
 #         delegation_gating: ""
@@ -555,7 +555,7 @@ talents_dir: ./talents
 #       for ambient awareness only (debug-logged, not acted upon).
 #       wake:
 #         model: ""
-#         quality_floor: "7"
+#         quality_floor: 7
 #         mission: automation
 #         local_only: "false"
 #         delegation_gating: disabled
@@ -925,7 +925,7 @@ ego:
 #       task: Watch the office and report noteworthy changes or trends.
 #       profile:
 #         model: ""
-#         quality_floor: ""
+#         quality_floor: 0
 #         mission: background
 #         local_only: ""
 #         delegation_gating: disabled
@@ -962,7 +962,7 @@ ego:
 #       supervisor_prob: 0.0
 #       supervisor_profile:
 #         model: ""
-#         quality_floor: ""
+#         quality_floor: 0
 #         mission: ""
 #         local_only: ""
 #         delegation_gating: ""

--- a/examples/config.example.yaml
+++ b/examples/config.example.yaml
@@ -852,21 +852,25 @@ talents_dir: ./talents
 #   0.2 means the actual sleep varies by ±20% of the computed
 #   duration. Default: 0.2. Set to 0.0 for deterministic timing.
 #   jitter: 0.2
-#   SupervisorProbability is the chance (0.0–1.0) that each wake
-#   uses a frontier model with supervisor-augmented prompt.
-#   Default: 0.1. Set to 0.0 to disable supervisor turns.
+#   SupervisorProbability is the per-wake chance (0.0–1.0) that
+#   this iteration runs as a supervisor turn — a more capable
+#   model with the augmented prompt produced by
+#   [prompts.MetacognitivePrompt]. Default: 0.1. Set to 0.0 to
+#   disable supervisor turns entirely.
 #   supervisor_probability: 0.1
 #   Router configures model routing for normal (non-supervisor)
 #   iterations.
 #   router:
 #     QualityFloor is the minimum quality rating (1–10) for model
-#     selection. Default: 3 for normal iterations, 8 for supervisor.
+#     selection. Built-in service defaults: metacognitive uses 3
+#     (normal) / 8 (supervisor); ego uses 5 (normal) / 8 (supervisor).
 #     quality_floor: 3
 #   SupervisorRouter configures model routing for supervisor
 #   turns (frontier model with augmented prompt).
 #   supervisor_router:
 #     QualityFloor is the minimum quality rating (1–10) for model
-#     selection. Default: 3 for normal iterations, 8 for supervisor.
+#     selection. Built-in service defaults: metacognitive uses 3
+#     (normal) / 8 (supervisor); ego uses 5 (normal) / 8 (supervisor).
 #     quality_floor: 8
 #
 # Ego configures the self-reflection loop. When enabled, a long-cycle
@@ -887,20 +891,24 @@ ego:
   # Jitter is the sleep randomization factor (0.0–1.0). Default: 0.2.
   # Set to 0.0 for deterministic timing.
   jitter: 0.2
-  # SupervisorProbability is the chance (0.0–1.0) that each wake
-  # uses a frontier model with supervisor-augmented prompt.
-  # Default: 0.2. Set to 0.0 to disable supervisor turns.
+  # SupervisorProbability is the per-wake chance (0.0–1.0) that
+  # this iteration runs as a supervisor turn — a more capable
+  # model with the augmented prompt produced by
+  # [prompts.EgoPrompt]. Default: 0.2. Set to 0.0 to disable
+  # supervisor turns entirely.
   supervisor_probability: 0.2
   # Router configures model routing for normal iterations.
   router:
     # QualityFloor is the minimum quality rating (1–10) for model
-    # selection. Default: 5 for normal iterations, 8 for supervisor.
+    # selection. Built-in service defaults: metacognitive uses 3
+    # (normal) / 8 (supervisor); ego uses 5 (normal) / 8 (supervisor).
     quality_floor: 5
   # SupervisorRouter configures model routing for supervisor
   # turns (frontier model with augmented prompt).
   supervisor_router:
     # QualityFloor is the minimum quality rating (1–10) for model
-    # selection. Default: 5 for normal iterations, 8 for supervisor.
+    # selection. Built-in service defaults: metacognitive uses 3
+    # (normal) / 8 (supervisor); ego uses 5 (normal) / 8 (supervisor).
     quality_floor: 8
 #
 # (optional) Loops configures immutable loop definitions loaded from the config
@@ -952,9 +960,16 @@ ego:
 #       max_iter: 0
 #       supervisor: false
 #       supervisor_prob: 0.0
-#       quality_floor: 0
-#       supervisor_context: ""
-#       supervisor_quality_floor: 0
+#       supervisor_profile:
+#         model: ""
+#         quality_floor: ""
+#         mission: ""
+#         local_only: ""
+#         delegation_gating: ""
+#         prefer_speed: ""
+#         exclude_tools: []
+#         extra_hints: {}
+#         instructions: ""
 #       on_retrigger: 0
 #       routing_factors: {}
 #       delegation_gating: ""

--- a/internal/app/mqttwake_test.go
+++ b/internal/app/mqttwake_test.go
@@ -65,7 +65,7 @@ func TestMQTTWakeHandlerMatchingTopic(t *testing.T) {
 	store := newTestWakeStore(t)
 	seed := router.LoopProfile{
 		Mission:          "automation",
-		QualityFloor:     "7",
+		QualityFloor:     7,
 		DelegationGating: "disabled",
 		Instructions:     "handle this",
 	}
@@ -326,7 +326,7 @@ func TestBuildWakeMessage(t *testing.T) {
 func TestApplyLoopProfile(t *testing.T) {
 	seed := router.LoopProfile{
 		Model:            "claude-3-opus",
-		QualityFloor:     "8",
+		QualityFloor:     8,
 		Mission:          "automation",
 		LocalOnly:        "false",
 		DelegationGating: "disabled",

--- a/internal/app/taskexec.go
+++ b/internal/app/taskexec.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/nugget/thane-ai-agent/internal/model/router"
@@ -126,9 +128,20 @@ func buildScheduledTaskLoopProfile(task *scheduler.Task) router.LoopProfile {
 		localOnly = lo
 	}
 
-	qualityFloor := "1"
-	if qf, ok := task.Payload.Data["quality_floor"].(string); ok {
-		qualityFloor = qf
+	qualityFloor := 1
+	if raw, ok := task.Payload.Data["quality_floor"]; ok {
+		switch v := raw.(type) {
+		case int:
+			qualityFloor = v
+		case int64:
+			qualityFloor = int(v)
+		case float64:
+			qualityFloor = int(v)
+		case string:
+			if parsed, err := strconv.Atoi(strings.TrimSpace(v)); err == nil {
+				qualityFloor = parsed
+			}
+		}
 	}
 
 	return router.LoopProfile{

--- a/internal/app/taskexec_test.go
+++ b/internal/app/taskexec_test.go
@@ -105,7 +105,7 @@ func TestRunScheduledTask_WakePayload(t *testing.T) {
 		t.Errorf("hint local_only = %q, want %q", launcher.launch.Spec.Profile.LocalOnly, "true")
 	}
 	if launcher.launch.Spec.Profile.QualityFloor != 1 {
-		t.Errorf("hint quality_floor = %q, want %q", launcher.launch.Spec.Profile.QualityFloor, 1)
+		t.Errorf("hint quality_floor = %d, want %d", launcher.launch.Spec.Profile.QualityFloor, 1)
 	}
 	if launcher.launch.Spec.Profile.Mission != "automation" {
 		t.Errorf("hint mission = %q, want %q", launcher.launch.Spec.Profile.Mission, "automation")
@@ -281,7 +281,7 @@ func TestRunScheduledTask_PayloadModelOverride(t *testing.T) {
 		t.Errorf("hint local_only = %q, want %q", launcher.launch.Spec.Profile.LocalOnly, "false")
 	}
 	if launcher.launch.Spec.Profile.QualityFloor != 7 {
-		t.Errorf("hint quality_floor = %q, want %q", launcher.launch.Spec.Profile.QualityFloor, 7)
+		t.Errorf("hint quality_floor = %d, want %d", launcher.launch.Spec.Profile.QualityFloor, 7)
 	}
 }
 
@@ -323,7 +323,7 @@ func TestRunScheduledTask_PayloadPartialOverride(t *testing.T) {
 	}
 	// quality_floor should use the override.
 	if launcher.launch.Spec.Profile.QualityFloor != 5 {
-		t.Errorf("hint quality_floor = %q, want %q", launcher.launch.Spec.Profile.QualityFloor, 5)
+		t.Errorf("hint quality_floor = %d, want %d", launcher.launch.Spec.Profile.QualityFloor, 5)
 	}
 }
 

--- a/internal/app/taskexec_test.go
+++ b/internal/app/taskexec_test.go
@@ -104,8 +104,8 @@ func TestRunScheduledTask_WakePayload(t *testing.T) {
 	if launcher.launch.Spec.Profile.LocalOnly != "true" {
 		t.Errorf("hint local_only = %q, want %q", launcher.launch.Spec.Profile.LocalOnly, "true")
 	}
-	if launcher.launch.Spec.Profile.QualityFloor != "1" {
-		t.Errorf("hint quality_floor = %q, want %q", launcher.launch.Spec.Profile.QualityFloor, "1")
+	if launcher.launch.Spec.Profile.QualityFloor != 1 {
+		t.Errorf("hint quality_floor = %q, want %q", launcher.launch.Spec.Profile.QualityFloor, 1)
 	}
 	if launcher.launch.Spec.Profile.Mission != "automation" {
 		t.Errorf("hint mission = %q, want %q", launcher.launch.Spec.Profile.Mission, "automation")
@@ -280,8 +280,8 @@ func TestRunScheduledTask_PayloadModelOverride(t *testing.T) {
 	if launcher.launch.Spec.Profile.LocalOnly != "false" {
 		t.Errorf("hint local_only = %q, want %q", launcher.launch.Spec.Profile.LocalOnly, "false")
 	}
-	if launcher.launch.Spec.Profile.QualityFloor != "7" {
-		t.Errorf("hint quality_floor = %q, want %q", launcher.launch.Spec.Profile.QualityFloor, "7")
+	if launcher.launch.Spec.Profile.QualityFloor != 7 {
+		t.Errorf("hint quality_floor = %q, want %q", launcher.launch.Spec.Profile.QualityFloor, 7)
 	}
 }
 
@@ -322,8 +322,8 @@ func TestRunScheduledTask_PayloadPartialOverride(t *testing.T) {
 		t.Errorf("hint local_only = %q, want %q", launcher.launch.Spec.Profile.LocalOnly, "true")
 	}
 	// quality_floor should use the override.
-	if launcher.launch.Spec.Profile.QualityFloor != "5" {
-		t.Errorf("hint quality_floor = %q, want %q", launcher.launch.Spec.Profile.QualityFloor, "5")
+	if launcher.launch.Spec.Profile.QualityFloor != 5 {
+		t.Errorf("hint quality_floor = %q, want %q", launcher.launch.Spec.Profile.QualityFloor, 5)
 	}
 }
 
@@ -380,7 +380,7 @@ func TestBuildScheduledTaskLoopProfile(t *testing.T) {
 			},
 			want: router.LoopProfile{
 				LocalOnly:        "true",
-				QualityFloor:     "1",
+				QualityFloor:     1,
 				Mission:          "automation",
 				DelegationGating: "disabled",
 				ExtraHints: map[string]string{
@@ -405,7 +405,7 @@ func TestBuildScheduledTaskLoopProfile(t *testing.T) {
 			want: router.LoopProfile{
 				Model:            "claude-sonnet-4-20250514",
 				LocalOnly:        "false",
-				QualityFloor:     "7",
+				QualityFloor:     7,
 				Mission:          "automation",
 				DelegationGating: "disabled",
 				ExtraHints: map[string]string{

--- a/internal/channels/mqtt/subscriptions_test.go
+++ b/internal/channels/mqtt/subscriptions_test.go
@@ -134,7 +134,7 @@ func TestSubscriptionStoreLoadConfig(t *testing.T) {
 		t.Errorf("source = %q, want %q", subs[0].Source, "config")
 	}
 	if subs[0].Profile.QualityFloor != 7 {
-		t.Errorf("profile.QualityFloor = %q, want %q", subs[0].Profile.QualityFloor, "7")
+		t.Errorf("profile.QualityFloor = %d, want 7", subs[0].Profile.QualityFloor)
 	}
 }
 

--- a/internal/channels/mqtt/subscriptions_test.go
+++ b/internal/channels/mqtt/subscriptions_test.go
@@ -116,7 +116,7 @@ func TestSubscriptionStoreAddRemoveList(t *testing.T) {
 func TestSubscriptionStoreLoadConfig(t *testing.T) {
 	s := newTestStore(t)
 
-	profile := router.LoopProfile{QualityFloor: "7", Mission: "automation"}
+	profile := router.LoopProfile{QualityFloor: 7, Mission: "automation"}
 	cfgSubs := []config.SubscriptionConfig{
 		{Topic: "homeassistant/+/+/state"},        // no wake
 		{Topic: "frigate/events", Wake: &profile}, // wake-enabled
@@ -133,7 +133,7 @@ func TestSubscriptionStoreLoadConfig(t *testing.T) {
 	if subs[0].Source != "config" {
 		t.Errorf("source = %q, want %q", subs[0].Source, "config")
 	}
-	if subs[0].Profile.QualityFloor != "7" {
+	if subs[0].Profile.QualityFloor != 7 {
 		t.Errorf("profile.QualityFloor = %q, want %q", subs[0].Profile.QualityFloor, "7")
 	}
 }
@@ -232,7 +232,7 @@ func TestSubscriptionStorePersistence(t *testing.T) {
 		t.Fatalf("new store 1: %v", err)
 	}
 
-	_, err = s1.Add("persist/test", router.LoopProfile{Mission: "automation", QualityFloor: "5"}, nil)
+	_, err = s1.Add("persist/test", router.LoopProfile{Mission: "automation", QualityFloor: 5}, nil)
 	if err != nil {
 		t.Fatalf("add: %v", err)
 	}
@@ -394,13 +394,13 @@ func TestSubscriptionStoreAddValidation(t *testing.T) {
 	}
 
 	// Invalid seed.
-	_, err = s.Add("valid/topic", router.LoopProfile{QualityFloor: "99"}, nil)
+	_, err = s.Add("valid/topic", router.LoopProfile{QualityFloor: 99}, nil)
 	if err == nil {
 		t.Fatal("expected error for invalid quality_floor")
 	}
 
 	// Valid — should succeed.
-	_, err = s.Add("valid/topic", router.LoopProfile{Mission: "automation", QualityFloor: "7"}, nil)
+	_, err = s.Add("valid/topic", router.LoopProfile{Mission: "automation", QualityFloor: 7}, nil)
 	if err != nil {
 		t.Fatalf("expected success, got: %v", err)
 	}

--- a/internal/channels/mqtt/tools.go
+++ b/internal/channels/mqtt/tools.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/nugget/thane-ai-agent/internal/model/router"
@@ -34,7 +35,7 @@ func (t *Tools) HandleListWakeSubscriptions(_ context.Context, _ map[string]any)
 		Topic        string `json:"topic"`
 		Source       string `json:"source"`
 		Mission      string `json:"mission,omitempty"`
-		QualityFloor string `json:"quality_floor,omitempty"`
+		QualityFloor int    `json:"quality_floor,omitempty"`
 		Model        string `json:"model,omitempty"`
 		Instructions string `json:"instructions,omitempty"`
 	}
@@ -70,7 +71,7 @@ func (t *Tools) HandleAddWakeSubscription(_ context.Context, args map[string]any
 
 	profile := router.LoopProfile{
 		Model:            stringArg(args, "model"),
-		QualityFloor:     stringArg(args, "quality_floor"),
+		QualityFloor:     intArg(args, "quality_floor"),
 		Mission:          stringArg(args, "mission"),
 		LocalOnly:        stringArg(args, "local_only"),
 		DelegationGating: stringArg(args, "delegation_gating"),
@@ -122,6 +123,32 @@ func (t *Tools) HandleRemoveWakeSubscription(_ context.Context, args map[string]
 func stringArg(args map[string]any, key string) string {
 	v, _ := args[key].(string)
 	return v
+}
+
+// intArg extracts an int from an args map, accepting both numeric
+// (int, float64 from JSON) and string-of-int forms. Returns 0 when
+// the arg is absent or unparseable — matches the
+// [router.LoopProfile.QualityFloor] "zero means unset" convention.
+func intArg(args map[string]any, key string) int {
+	v, ok := args[key]
+	if !ok {
+		return 0
+	}
+	switch n := v.(type) {
+	case int:
+		return n
+	case int64:
+		return int(n)
+	case float64:
+		return int(n)
+	case string:
+		parsed, err := strconv.Atoi(strings.TrimSpace(n))
+		if err != nil {
+			return 0
+		}
+		return parsed
+	}
+	return 0
 }
 
 // toStringSlice converts an any value to []string. Handles both

--- a/internal/integrations/media/feed_wake.go
+++ b/internal/integrations/media/feed_wake.go
@@ -111,7 +111,7 @@ func feedWakeTargetDefinition() map[string]any {
 			},
 			"force_supervisor": map[string]any{
 				"type":        "boolean",
-				"description": "When true, force the target loop's next iteration to use supervisor routing.",
+				"description": "When true, force the target loop's next iteration to run as a supervisor turn (the more capable model with the augmented prompt). Costlier than a normal wake — reserve for signals that genuinely warrant the extra capacity.",
 			},
 			"priority": map[string]any{
 				"type":        "string",

--- a/internal/model/router/loopprofile.go
+++ b/internal/model/router/loopprofile.go
@@ -105,8 +105,11 @@ func (s *LoopProfile) UnmarshalJSON(data []byte) error {
 	if len(w.QualityFloor) == 0 || string(w.QualityFloor) == "null" {
 		return nil
 	}
-	// Try the canonical int form first — succeeds on `5`,
-	// `5.0` (json decodes float-to-int truncating), etc.
+	// Try the canonical int form first — succeeds on plain
+	// integer JSON numbers like `5`. encoding/json rejects
+	// non-integer numbers like `5.0` when targeting int, so we
+	// don't pretend to accept them; if a config source produces
+	// `5.0` we'd rather fail loud than silently truncate.
 	var n int
 	if err := json.Unmarshal(w.QualityFloor, &n); err == nil {
 		s.QualityFloor = n

--- a/internal/model/router/loopprofile.go
+++ b/internal/model/router/loopprofile.go
@@ -1,6 +1,7 @@
 package router
 
 import (
+	"encoding/json"
 	"fmt"
 	"regexp"
 	"strconv"
@@ -19,9 +20,15 @@ type LoopProfile struct {
 	// the router selects based on the other hint fields.
 	Model string `yaml:"model,omitempty" json:"model,omitempty"`
 
-	// QualityFloor is the minimum model quality rating (1–10). Maps
-	// to [FactorQualityFloor].
-	QualityFloor string `yaml:"quality_floor,omitempty" json:"quality_floor,omitempty"`
+	// QualityFloor is the minimum model quality rating (1–10).
+	// Maps to [FactorQualityFloor]. Zero means "unset" — let the
+	// router pick its own default.
+	//
+	// JSON/YAML accept both the canonical int form (`5`) and the
+	// legacy stringified form (`"5"`) for backwards compatibility
+	// with persisted overlay specs and operator YAML written
+	// before the int conversion; see [LoopProfile.UnmarshalJSON].
+	QualityFloor int `yaml:"quality_floor,omitempty" json:"quality_floor,omitempty"`
 
 	// Mission describes the task context for routing. Maps to
 	// [FactorMission]. Common values: "conversation", "automation",
@@ -56,6 +63,73 @@ type LoopProfile struct {
 	Instructions string `yaml:"instructions,omitempty" json:"instructions,omitempty"`
 }
 
+// loopProfileWire is the JSON wire representation used by
+// [LoopProfile.UnmarshalJSON]. QualityFloor is decoded as
+// [json.RawMessage] so both the canonical int form (`5`) and the
+// legacy stringified form (`"5"`) survive the round-trip — needed
+// for persisted overlay specs written before the int conversion.
+type loopProfileWire struct {
+	Model            string            `json:"model,omitempty"`
+	QualityFloor     json.RawMessage   `json:"quality_floor,omitempty"`
+	Mission          string            `json:"mission,omitempty"`
+	LocalOnly        string            `json:"local_only,omitempty"`
+	DelegationGating string            `json:"delegation_gating,omitempty"`
+	PreferSpeed      string            `json:"prefer_speed,omitempty"`
+	ExcludeTools     []string          `json:"exclude_tools,omitempty"`
+	ExtraHints       map[string]string `json:"extra_hints,omitempty"`
+	Instructions     string            `json:"instructions,omitempty"`
+}
+
+// UnmarshalJSON accepts the canonical int form for QualityFloor
+// AND the legacy stringified form for backwards compatibility
+// with persisted overlay specs / config blocks written before
+// the field type changed. A missing or null QualityFloor decodes
+// to 0 ("unset"). An empty string also decodes to 0. Anything
+// else fails fast so a malformed value is loud rather than
+// silently treated as zero.
+func (s *LoopProfile) UnmarshalJSON(data []byte) error {
+	var w loopProfileWire
+	if err := json.Unmarshal(data, &w); err != nil {
+		return err
+	}
+	*s = LoopProfile{
+		Model:            w.Model,
+		Mission:          w.Mission,
+		LocalOnly:        w.LocalOnly,
+		DelegationGating: w.DelegationGating,
+		PreferSpeed:      w.PreferSpeed,
+		ExcludeTools:     w.ExcludeTools,
+		ExtraHints:       w.ExtraHints,
+		Instructions:     w.Instructions,
+	}
+	if len(w.QualityFloor) == 0 || string(w.QualityFloor) == "null" {
+		return nil
+	}
+	// Try the canonical int form first — succeeds on `5`,
+	// `5.0` (json decodes float-to-int truncating), etc.
+	var n int
+	if err := json.Unmarshal(w.QualityFloor, &n); err == nil {
+		s.QualityFloor = n
+		return nil
+	}
+	// Fall back to the legacy stringified form. Empty string is
+	// treated as unset (matches the pre-conversion behavior).
+	var raw string
+	if err := json.Unmarshal(w.QualityFloor, &raw); err != nil {
+		return fmt.Errorf("quality_floor: must be an integer or string-of-integer, got %s", w.QualityFloor)
+	}
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil
+	}
+	parsed, err := strconv.Atoi(raw)
+	if err != nil {
+		return fmt.Errorf("quality_floor: %q is not a valid integer", raw)
+	}
+	s.QualityFloor = parsed
+	return nil
+}
+
 // RequestOptions contains the agent request fields derived from a
 // LoopProfile. Callers can merge additional channel- or trigger-specific
 // factors on top of these shared routing defaults.
@@ -66,14 +140,17 @@ type RequestOptions struct {
 	DelegationGating string
 }
 
-// RoutingFactors builds the routing-factor map from the profile's typed
-// fields. Only non-empty fields are included. ExtraHints are merged
-// last and can override typed fields.
+// RoutingFactors builds the routing-factor map from the profile's
+// typed fields. Only non-empty fields are included. ExtraHints
+// are merged last and can override typed fields. QualityFloor is
+// the only typed numeric field today; it's string-ified at this
+// boundary so the wire format (`map[string]string`) the router
+// consumes stays uniform.
 func (s *LoopProfile) RoutingFactors() map[string]string {
 	h := make(map[string]string)
 
-	if s.QualityFloor != "" {
-		h[FactorQualityFloor] = s.QualityFloor
+	if s.QualityFloor > 0 {
+		h[FactorQualityFloor] = strconv.Itoa(s.QualityFloor)
 	}
 	if s.Mission != "" {
 		h[FactorMission] = s.Mission
@@ -118,10 +195,9 @@ var validDelegationGating = map[string]bool{
 // valid values. It does not require any field to be set — an empty
 // LoopProfile is valid. Returns nil on success.
 func (s *LoopProfile) Validate() error {
-	if s.QualityFloor != "" {
-		n, err := strconv.Atoi(s.QualityFloor)
-		if err != nil || n < 1 || n > 10 {
-			return fmt.Errorf("quality_floor must be an integer 1–10, got %q", s.QualityFloor)
+	if s.QualityFloor != 0 {
+		if s.QualityFloor < 1 || s.QualityFloor > 10 {
+			return fmt.Errorf("quality_floor must be an integer 1–10, got %d", s.QualityFloor)
 		}
 	}
 	if s.Mission != "" && !missionPattern.MatchString(s.Mission) {

--- a/internal/model/router/loopprofile_int_compat_test.go
+++ b/internal/model/router/loopprofile_int_compat_test.go
@@ -1,0 +1,118 @@
+package router
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// TestLoopProfileUnmarshalQualityFloorAcceptsInt covers the
+// canonical post-PR-Q1 wire form for `quality_floor`: a JSON
+// integer decodes directly onto the int field.
+func TestLoopProfileUnmarshalQualityFloorAcceptsInt(t *testing.T) {
+	t.Parallel()
+
+	var p LoopProfile
+	if err := json.Unmarshal([]byte(`{"quality_floor": 7}`), &p); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if p.QualityFloor != 7 {
+		t.Errorf("QualityFloor = %d, want 7", p.QualityFloor)
+	}
+}
+
+// TestLoopProfileUnmarshalQualityFloorAcceptsLegacyString covers
+// the backwards-compatibility path for persisted overlay specs
+// and operator config files written with the pre-PR-Q1 string
+// form. Without this, an upgrade from a pre-PR-Q1 deployment
+// would silently drop the operator's configured quality floor
+// (or fail the load entirely) on first restart.
+func TestLoopProfileUnmarshalQualityFloorAcceptsLegacyString(t *testing.T) {
+	t.Parallel()
+
+	var p LoopProfile
+	if err := json.Unmarshal([]byte(`{"quality_floor": "7"}`), &p); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if p.QualityFloor != 7 {
+		t.Errorf("QualityFloor = %d, want 7 (legacy string form)", p.QualityFloor)
+	}
+}
+
+// TestLoopProfileUnmarshalQualityFloorEmptyOrMissingIsZero pins
+// the "unset" contract: missing key, null value, and empty
+// string all decode to zero (the canonical "let the router
+// pick" sentinel).
+func TestLoopProfileUnmarshalQualityFloorEmptyOrMissingIsZero(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		raw  string
+	}{
+		{"missing", `{}`},
+		{"null", `{"quality_floor": null}`},
+		{"empty string", `{"quality_floor": ""}`},
+		{"whitespace string", `{"quality_floor": "   "}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var p LoopProfile
+			if err := json.Unmarshal([]byte(tc.raw), &p); err != nil {
+				t.Fatalf("Unmarshal: %v", err)
+			}
+			if p.QualityFloor != 0 {
+				t.Errorf("QualityFloor = %d, want 0 (unset)", p.QualityFloor)
+			}
+		})
+	}
+}
+
+// TestLoopProfileUnmarshalQualityFloorMalformedFails ensures
+// garbage is loud rather than silently treated as zero. A
+// malformed value should fail the Unmarshal so the caller
+// notices.
+func TestLoopProfileUnmarshalQualityFloorMalformedFails(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		raw  string
+	}{
+		{"non-numeric string", `{"quality_floor": "high"}`},
+		{"bool", `{"quality_floor": true}`},
+		{"array", `{"quality_floor": [7]}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var p LoopProfile
+			err := json.Unmarshal([]byte(tc.raw), &p)
+			if err == nil {
+				t.Fatalf("Unmarshal accepted garbage: %s", tc.raw)
+			}
+			if !strings.Contains(err.Error(), "quality_floor") {
+				t.Errorf("error %q should mention quality_floor", err)
+			}
+		})
+	}
+}
+
+// TestLoopProfileMarshalEmitsIntQualityFloor confirms the
+// canonical wire shape is int — a marshal round-trip never
+// regresses to the legacy string form.
+func TestLoopProfileMarshalEmitsIntQualityFloor(t *testing.T) {
+	t.Parallel()
+
+	p := LoopProfile{QualityFloor: 5}
+	out, err := json.Marshal(p)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	js := string(out)
+	if !strings.Contains(js, `"quality_floor":5`) {
+		t.Errorf("Marshal didn't emit int quality_floor: %s", js)
+	}
+	if strings.Contains(js, `"quality_floor":"5"`) {
+		t.Errorf("Marshal regressed to legacy string form: %s", js)
+	}
+}

--- a/internal/model/router/loopprofile_test.go
+++ b/internal/model/router/loopprofile_test.go
@@ -19,7 +19,7 @@ func TestLoopProfileHints(t *testing.T) {
 		{
 			name: "all typed fields populated",
 			seed: LoopProfile{
-				QualityFloor:     "7",
+				QualityFloor:     7,
 				Mission:          "automation",
 				LocalOnly:        "false",
 				DelegationGating: "disabled",
@@ -35,7 +35,7 @@ func TestLoopProfileHints(t *testing.T) {
 		{
 			name: "only populated fields appear",
 			seed: LoopProfile{
-				QualityFloor: "5",
+				QualityFloor: 5,
 				Mission:      "conversation",
 			},
 			want: map[string]string{
@@ -74,7 +74,7 @@ func TestLoopProfileHints(t *testing.T) {
 			name: "model not in hints",
 			seed: LoopProfile{
 				Model:        "claude-3-opus",
-				QualityFloor: "10",
+				QualityFloor: 10,
 			},
 			want: map[string]string{
 				FactorQualityFloor: "10",
@@ -107,18 +107,16 @@ func TestLoopProfileValidate(t *testing.T) {
 	}{
 		{name: "empty seed is valid", seed: LoopProfile{}},
 		{name: "fully populated valid seed", seed: LoopProfile{
-			QualityFloor:     "7",
+			QualityFloor:     7,
 			Mission:          "automation",
 			LocalOnly:        "false",
 			DelegationGating: "disabled",
 			PreferSpeed:      "true",
 		}},
-		{name: "quality_floor boundary low", seed: LoopProfile{QualityFloor: "1"}},
-		{name: "quality_floor boundary high", seed: LoopProfile{QualityFloor: "10"}},
-		{name: "quality_floor zero", seed: LoopProfile{QualityFloor: "0"}, wantErr: true},
-		{name: "quality_floor eleven", seed: LoopProfile{QualityFloor: "11"}, wantErr: true},
-		{name: "quality_floor non-numeric", seed: LoopProfile{QualityFloor: "high"}, wantErr: true},
-		{name: "quality_floor negative", seed: LoopProfile{QualityFloor: "-1"}, wantErr: true},
+		{name: "quality_floor boundary low", seed: LoopProfile{QualityFloor: 1}},
+		{name: "quality_floor boundary high", seed: LoopProfile{QualityFloor: 10}},
+		{name: "quality_floor eleven", seed: LoopProfile{QualityFloor: 11}, wantErr: true},
+		{name: "quality_floor negative", seed: LoopProfile{QualityFloor: -1}, wantErr: true},
 		{name: "mission conversation", seed: LoopProfile{Mission: "conversation"}},
 		{name: "mission device_control", seed: LoopProfile{Mission: "device_control"}},
 		{name: "mission background", seed: LoopProfile{Mission: "background"}},
@@ -148,7 +146,7 @@ func TestLoopProfileValidate(t *testing.T) {
 func TestLoopProfileRequestOptions(t *testing.T) {
 	seed := LoopProfile{
 		Model:            "claude-sonnet-4-20250514",
-		QualityFloor:     "7",
+		QualityFloor:     7,
 		Mission:          "automation",
 		LocalOnly:        "false",
 		DelegationGating: "disabled",
@@ -212,7 +210,7 @@ func TestValidateTopicFilter(t *testing.T) {
 func TestLoopProfileJSONRoundTrip(t *testing.T) {
 	original := LoopProfile{
 		Model:            "gpt-4o",
-		QualityFloor:     "8",
+		QualityFloor:     8,
 		Mission:          "automation",
 		LocalOnly:        "false",
 		DelegationGating: "disabled",

--- a/internal/model/router/virtual_models.go
+++ b/internal/model/router/virtual_models.go
@@ -21,7 +21,10 @@ const delegateHintPrefix = "delegate_"
 // model expansion. The shape is intentionally small today but is designed to
 // grow as the live model registry contributes more dynamic overlay state.
 type VirtualModelRuntime struct {
-	PremiumQualityFloor string
+	// PremiumQualityFloor is the QualityFloor stamped on premium /
+	// ops virtual models when expanded. Zero means "fall back to
+	// the package default of 10."
+	PremiumQualityFloor int
 }
 
 // VirtualModel describes an end-to-end execution policy exposed through
@@ -176,9 +179,9 @@ func ResolveVirtualModelSelection(rawModel string, baseHints map[string]string, 
 }
 
 func builtinVirtualModels(runtime VirtualModelRuntime) []VirtualModel {
-	premiumFloor := strings.TrimSpace(runtime.PremiumQualityFloor)
-	if premiumFloor == "" {
-		premiumFloor = "10"
+	premiumFloor := runtime.PremiumQualityFloor
+	if premiumFloor <= 0 {
+		premiumFloor = 10
 	}
 
 	return []VirtualModel{
@@ -222,13 +225,13 @@ func builtinVirtualModels(runtime VirtualModelRuntime) []VirtualModel {
 			Aliases:     []string{"thane:command", "thane:homeassistant", "thane:fast"},
 			TopLevel: LoopProfile{
 				Mission:      "device_control",
-				QualityFloor: "4",
+				QualityFloor: 4,
 				LocalOnly:    "true",
 				PreferSpeed:  "true",
 			},
 			Delegate: LoopProfile{
 				Mission:      "device_control",
-				QualityFloor: "4",
+				QualityFloor: 4,
 				LocalOnly:    "true",
 				PreferSpeed:  "true",
 			},
@@ -238,12 +241,12 @@ func builtinVirtualModels(runtime VirtualModelRuntime) []VirtualModel {
 			Description: "strictly local-only mode",
 			Exposed:     true,
 			TopLevel: LoopProfile{
-				QualityFloor: "1",
+				QualityFloor: 1,
 				LocalOnly:    "true",
 				PreferSpeed:  "true",
 			},
 			Delegate: LoopProfile{
-				QualityFloor: "1",
+				QualityFloor: 1,
 				LocalOnly:    "true",
 				PreferSpeed:  "true",
 			},
@@ -254,13 +257,13 @@ func builtinVirtualModels(runtime VirtualModelRuntime) []VirtualModel {
 			Aliases:     []string{"thane:trigger"},
 			TopLevel: LoopProfile{
 				Mission:      "automation",
-				QualityFloor: "1",
+				QualityFloor: 1,
 				LocalOnly:    "true",
 				PreferSpeed:  "true",
 			},
 			Delegate: LoopProfile{
 				Mission:      "automation",
-				QualityFloor: "1",
+				QualityFloor: 1,
 				LocalOnly:    "true",
 				PreferSpeed:  "true",
 			},

--- a/internal/model/router/virtual_models_test.go
+++ b/internal/model/router/virtual_models_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestExposedVirtualModels(t *testing.T) {
-	models := ExposedVirtualModels(VirtualModelRuntime{PremiumQualityFloor: "9"})
+	models := ExposedVirtualModels(VirtualModelRuntime{PremiumQualityFloor: 9})
 	var names []string
 	for _, model := range models {
 		names = append(names, model.Name)
@@ -30,7 +30,7 @@ func TestExposedVirtualModels(t *testing.T) {
 
 func TestResolveVirtualModelSelection_PremiumKeepsDelegatePolicyAdaptive(t *testing.T) {
 	selection := ResolveVirtualModelSelection("thane:premium", map[string]string{"channel": "api"}, VirtualModelRuntime{
-		PremiumQualityFloor: "9",
+		PremiumQualityFloor: 9,
 	}, slog.Default())
 
 	if !selection.Known {
@@ -60,7 +60,7 @@ func TestResolveVirtualModelSelection_PremiumKeepsDelegatePolicyAdaptive(t *test
 
 func TestResolveVirtualModelSelection_OpsAddsDelegatePolicy(t *testing.T) {
 	selection := ResolveVirtualModelSelection("thane:ops", map[string]string{"channel": "api"}, VirtualModelRuntime{
-		PremiumQualityFloor: "9",
+		PremiumQualityFloor: 9,
 	}, slog.Default())
 
 	if !selection.Known {

--- a/internal/platform/config/config.go
+++ b/internal/platform/config/config.go
@@ -1729,25 +1729,20 @@ type MetacognitiveConfig struct {
 	// duration. Default: 0.2. Set to 0.0 for deterministic timing.
 	Jitter *float64 `yaml:"jitter,omitempty"`
 
-	// SupervisorProbability is the chance (0.0–1.0) that each wake
-	// uses a frontier model with supervisor-augmented prompt.
-	// Default: 0.1. Set to 0.0 to disable supervisor turns.
+	// SupervisorProbability is the per-wake chance (0.0–1.0) that
+	// this iteration runs as a supervisor turn — a more capable
+	// model with the augmented prompt produced by
+	// [prompts.MetacognitivePrompt]. Default: 0.1. Set to 0.0 to
+	// disable supervisor turns entirely.
 	SupervisorProbability *float64 `yaml:"supervisor_probability,omitempty"`
 
 	// Router configures model routing for normal (non-supervisor)
 	// iterations.
-	Router MetacognitiveRouterConfig `yaml:"router"`
+	Router RouterConfig `yaml:"router"`
 
 	// SupervisorRouter configures model routing for supervisor
 	// turns (frontier model with augmented prompt).
-	SupervisorRouter MetacognitiveRouterConfig `yaml:"supervisor_router"`
-}
-
-// MetacognitiveRouterConfig holds routing hints for metacognitive iterations.
-type MetacognitiveRouterConfig struct {
-	// QualityFloor is the minimum quality rating (1–10) for model
-	// selection. Default: 3 for normal iterations, 8 for supervisor.
-	QualityFloor int `yaml:"quality_floor"`
+	SupervisorRouter RouterConfig `yaml:"supervisor_router"`
 }
 
 // EgoConfig configures the self-reflection ego loop. The loop runs as a
@@ -1774,23 +1769,33 @@ type EgoConfig struct {
 	// Set to 0.0 for deterministic timing.
 	Jitter *float64 `yaml:"jitter,omitempty"`
 
-	// SupervisorProbability is the chance (0.0–1.0) that each wake
-	// uses a frontier model with supervisor-augmented prompt.
-	// Default: 0.2. Set to 0.0 to disable supervisor turns.
+	// SupervisorProbability is the per-wake chance (0.0–1.0) that
+	// this iteration runs as a supervisor turn — a more capable
+	// model with the augmented prompt produced by
+	// [prompts.EgoPrompt]. Default: 0.2. Set to 0.0 to disable
+	// supervisor turns entirely.
 	SupervisorProbability *float64 `yaml:"supervisor_probability,omitempty"`
 
 	// Router configures model routing for normal iterations.
-	Router EgoRouterConfig `yaml:"router"`
+	Router RouterConfig `yaml:"router"`
 
 	// SupervisorRouter configures model routing for supervisor
 	// turns (frontier model with augmented prompt).
-	SupervisorRouter EgoRouterConfig `yaml:"supervisor_router"`
+	SupervisorRouter RouterConfig `yaml:"supervisor_router"`
 }
 
-// EgoRouterConfig holds routing hints for ego iterations.
-type EgoRouterConfig struct {
+// RouterConfig holds routing hints used by the built-in services
+// (metacognitive, ego) for both normal and supervisor turns. It is
+// deliberately narrow — operator-tunable knobs only — and gets
+// translated into the spec-level [router.LoopProfile] /
+// [router.LoopProfile.QualityFloor] at hydration time. Replaces
+// the previously-duplicated `MetacognitiveRouterConfig` and
+// `EgoRouterConfig` types which were byte-identical apart from
+// their default floors.
+type RouterConfig struct {
 	// QualityFloor is the minimum quality rating (1–10) for model
-	// selection. Default: 5 for normal iterations, 8 for supervisor.
+	// selection. Built-in service defaults: metacognitive uses 3
+	// (normal) / 8 (supervisor); ego uses 5 (normal) / 8 (supervisor).
 	QualityFloor int `yaml:"quality_floor"`
 }
 

--- a/internal/platform/config/config.go
+++ b/internal/platform/config/config.go
@@ -32,6 +32,7 @@ import (
 	"path"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -1579,9 +1580,17 @@ type SignalRoutingConfig struct {
 // LoopProfile-only fields such as ExcludeTools are omitted until Signal
 // grows explicit config for them.
 func (c SignalRoutingConfig) LoopProfile() router.LoopProfile {
+	// SignalRoutingConfig.QualityFloor stays string-shaped in its
+	// own YAML schema for now — converting it is a separate
+	// operator-config cleanup. Atoi here at the boundary so the
+	// downstream [router.LoopProfile.QualityFloor] (int) is
+	// happy. An unparseable value gets silently dropped to zero
+	// ("unset"); validation belongs at config load time, not at
+	// every conversion call.
+	floor, _ := strconv.Atoi(strings.TrimSpace(c.QualityFloor))
 	return router.LoopProfile{
 		Model:            c.Model,
-		QualityFloor:     c.QualityFloor,
+		QualityFloor:     floor,
 		Mission:          c.Mission,
 		DelegationGating: c.DelegationGating,
 	}

--- a/internal/platform/config/config.go
+++ b/internal/platform/config/config.go
@@ -1583,10 +1583,11 @@ func (c SignalRoutingConfig) LoopProfile() router.LoopProfile {
 	// SignalRoutingConfig.QualityFloor stays string-shaped in its
 	// own YAML schema for now — converting it is a separate
 	// operator-config cleanup. Atoi here at the boundary so the
-	// downstream [router.LoopProfile.QualityFloor] (int) is
-	// happy. An unparseable value gets silently dropped to zero
-	// ("unset"); validation belongs at config load time, not at
-	// every conversion call.
+	// downstream [router.LoopProfile.QualityFloor] (int) is happy.
+	// Unparseable values drop to zero ("unset") here;
+	// [Config.validateSignal] enforces parseability at config-load
+	// time so this conversion never sees a "high"-shaped string in
+	// a validated config.
 	floor, _ := strconv.Atoi(strings.TrimSpace(c.QualityFloor))
 	return router.LoopProfile{
 		Model:            c.Model,
@@ -2816,6 +2817,17 @@ func (c *Config) validateSignal() error {
 	}
 	if c.Signal.HandleTimeout < 0 {
 		return fmt.Errorf("signal.handle_timeout %s must be non-negative", c.Signal.HandleTimeout)
+	}
+	// SignalRoutingConfig keeps QualityFloor as a string for now
+	// (its own YAML cleanup is deferred). SignalRoutingConfig.LoopProfile()
+	// silently drops unparseable values to 0, which Profile.Validate()
+	// then accepts as "unset" — so a typo like `quality_floor: "high"`
+	// would slip past Validate entirely. Parse explicitly here so the
+	// operator sees a loud failure at config-load time.
+	if raw := strings.TrimSpace(c.Signal.Routing.QualityFloor); raw != "" {
+		if _, err := strconv.Atoi(raw); err != nil {
+			return fmt.Errorf("signal.routing.quality_floor %q is not a valid integer", c.Signal.Routing.QualityFloor)
+		}
 	}
 	profile := c.Signal.Routing.LoopProfile()
 	if err := profile.Validate(); err != nil {

--- a/internal/platform/config/config_test.go
+++ b/internal/platform/config/config_test.go
@@ -454,6 +454,36 @@ func TestValidate_SignalInvalidRouting(t *testing.T) {
 	}
 }
 
+// TestValidate_SignalRoutingQualityFloorNonNumeric pins the
+// post-PR-Q1 explicit-parse check: an operator-supplied
+// non-numeric quality_floor like "high" used to silently drop
+// to 0 (treated as "unset") through SignalRoutingConfig.LoopProfile()
+// → LoopProfile.Validate() and pass validation. validateSignal
+// now parses the raw string first so a typo is caught loud at
+// config-load time.
+func TestValidate_SignalRoutingQualityFloorNonNumeric(t *testing.T) {
+	cfg := Default()
+	cfg.Signal = SignalConfig{
+		Enabled: true,
+		Command: "signal-cli",
+		Account: "+15551234567",
+		Routing: SignalRoutingConfig{
+			QualityFloor: "high",
+		},
+	}
+
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("expected validation error for non-numeric signal.routing.quality_floor")
+	}
+	if !strings.Contains(err.Error(), "signal.routing.quality_floor") {
+		t.Errorf("error should mention signal.routing.quality_floor, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "valid integer") {
+		t.Errorf("error should explain the failure (not a valid integer), got: %v", err)
+	}
+}
+
 func TestValidate_SignalEnabledMissingCommand(t *testing.T) {
 	cfg := Default()
 	cfg.Signal = SignalConfig{

--- a/internal/platform/config/example.go
+++ b/internal/platform/config/example.go
@@ -381,8 +381,8 @@ func ExampleConfig() *Config {
 			DefaultSleep:          "10m",
 			Jitter:                floatPtr(0.2),
 			SupervisorProbability: floatPtr(0.1),
-			Router:                MetacognitiveRouterConfig{QualityFloor: 3},
-			SupervisorRouter:      MetacognitiveRouterConfig{QualityFloor: 8},
+			Router:                RouterConfig{QualityFloor: 3},
+			SupervisorRouter:      RouterConfig{QualityFloor: 8},
 		},
 
 		Ego: EgoConfig{
@@ -392,8 +392,8 @@ func ExampleConfig() *Config {
 			DefaultSleep:          "6h",
 			Jitter:                floatPtr(0.2),
 			SupervisorProbability: floatPtr(0.2),
-			Router:                EgoRouterConfig{QualityFloor: 5},
-			SupervisorRouter:      EgoRouterConfig{QualityFloor: 8},
+			Router:                RouterConfig{QualityFloor: 5},
+			SupervisorRouter:      RouterConfig{QualityFloor: 8},
 		},
 
 		Agent: AgentConfig{

--- a/internal/platform/config/example.go
+++ b/internal/platform/config/example.go
@@ -185,7 +185,7 @@ func ExampleConfig() *Config {
 				{
 					Topic: "automation/wake/security",
 					Wake: &router.LoopProfile{
-						QualityFloor:     "7",
+						QualityFloor:     7,
 						Mission:          "automation",
 						LocalOnly:        "false",
 						DelegationGating: "disabled",

--- a/internal/platform/events/bus.go
+++ b/internal/platform/events/bus.go
@@ -97,7 +97,8 @@ const (
 	// Data: loop_id, loop_name, iterations, attempts.
 	KindLoopStopped = "loop_stopped"
 	// KindLoopIterationStart signals the beginning of a loop iteration.
-	// Data: loop_id, loop_name, conversation_id, supervisor, attempt.
+	// Data: loop_id, loop_name, conversation_id, supervisor,
+	// supervisor_trigger, attempt, signal_envelopes.
 	KindLoopIterationStart = "loop_iteration_start"
 	// KindLoopIterationComplete signals the end of a loop iteration.
 	// Data: loop_id, loop_name, model, input_tokens, output_tokens,

--- a/internal/runtime/ego/ego.go
+++ b/internal/runtime/ego/ego.go
@@ -112,7 +112,7 @@ func DefinitionSpec(cfg Config) loop.Spec {
 		Profile: router.LoopProfile{
 			Mission:          "ego",
 			DelegationGating: "disabled",
-			QualityFloor:     fmt.Sprintf("%d", cfg.QualityFloor),
+			QualityFloor:     cfg.QualityFloor,
 			ExtraHints:       map[string]string{"source": "ego"},
 		},
 		SupervisorProfile: supervisorProfile(cfg.SupervisorQualityFloor),
@@ -134,7 +134,7 @@ func supervisorProfile(qualityFloor int) *router.LoopProfile {
 		return nil
 	}
 	return &router.LoopProfile{
-		QualityFloor: fmt.Sprintf("%d", qualityFloor),
+		QualityFloor: qualityFloor,
 	}
 }
 

--- a/internal/runtime/ego/ego.go
+++ b/internal/runtime/ego/ego.go
@@ -112,16 +112,29 @@ func DefinitionSpec(cfg Config) loop.Spec {
 		Profile: router.LoopProfile{
 			Mission:          "ego",
 			DelegationGating: "disabled",
+			QualityFloor:     fmt.Sprintf("%d", cfg.QualityFloor),
 			ExtraHints:       map[string]string{"source": "ego"},
 		},
-		Supervisor:             cfg.SupervisorProbability > 0,
-		SupervisorProb:         cfg.SupervisorProbability,
-		QualityFloor:           cfg.QualityFloor,
-		SupervisorQualityFloor: cfg.SupervisorQualityFloor,
+		SupervisorProfile: supervisorProfile(cfg.SupervisorQualityFloor),
+		Supervisor:        cfg.SupervisorProbability > 0,
+		SupervisorProb:    cfg.SupervisorProbability,
 		Metadata: map[string]string{
 			"subsystem": "ego",
 			"category":  "service",
 		},
+	}
+}
+
+// supervisorProfile builds the ego service's per-turn-mode
+// overrides from the supervisor router config. Returns nil when
+// no overrides are declared, signaling the loop runtime to reuse
+// the normal Profile during supervisor turns.
+func supervisorProfile(qualityFloor int) *router.LoopProfile {
+	if qualityFloor <= 0 {
+		return nil
+	}
+	return &router.LoopProfile{
+		QualityFloor: fmt.Sprintf("%d", qualityFloor),
 	}
 }
 
@@ -139,11 +152,11 @@ func HydrateSpec(spec loop.Spec, cfg Config) loop.Spec {
 
 // BuildSpec returns a [loop.Spec] that implements the ego loop as a
 // service loop. The returned spec declares the durable output document
-// and uses runtime hooks to build prompts.
+// and uses runtime hooks to build prompts. The supervisor prompt prefix
+// is produced by [prompts.EgoPrompt] inside the TaskBuilder, not via
+// the spec-level [SupervisorProfile.Instructions] hook.
 func BuildSpec(cfg Config) loop.Spec {
-	spec := DefinitionSpec(cfg)
-	spec.SupervisorContext = ""
-	return HydrateSpec(spec, cfg)
+	return HydrateSpec(DefinitionSpec(cfg), cfg)
 }
 
 // BuildLoopConfig returns the engine-facing [loop.Config] view of the

--- a/internal/runtime/ego/ego_test.go
+++ b/internal/runtime/ego/ego_test.go
@@ -18,8 +18,8 @@ func TestParseConfig_Valid(t *testing.T) {
 		DefaultSleep:          "6h",
 		Jitter:                &jitter,
 		SupervisorProbability: &supervisor,
-		Router:                config.EgoRouterConfig{QualityFloor: 5},
-		SupervisorRouter:      config.EgoRouterConfig{QualityFloor: 8},
+		Router:                config.RouterConfig{QualityFloor: 5},
+		SupervisorRouter:      config.RouterConfig{QualityFloor: 8},
 	}
 
 	cfg, err := ParseConfig(raw)

--- a/internal/runtime/loop/config.go
+++ b/internal/runtime/loop/config.go
@@ -46,6 +46,36 @@ const (
 	StateStopped State = "stopped"
 )
 
+// SupervisorTrigger names the cause that put an iteration into
+// supervisor-turn mode. Reported on [IterationResult],
+// [IterationSnapshot], and [Status.LastSupervisorTrigger] so
+// retrospection and analytics can distinguish a Bernoulli win
+// from a force_supervisor notification. Future routing-strategy
+// experiments (alternation, cooldowns, slot-based selectors)
+// will widen the value space; consumers should treat unknown
+// values as "this iteration was a supervisor turn for some
+// reason," not as an error.
+type SupervisorTrigger string
+
+const (
+	// SupervisorTriggerNone is the zero value, used when the
+	// iteration ran as a normal turn. Encodes as the empty
+	// string in JSON so it's omitted from the wire format by
+	// the standard `omitempty` tag.
+	SupervisorTriggerNone SupervisorTrigger = ""
+	// SupervisorTriggerRandom indicates the supervisor turn
+	// fired because the per-wake Bernoulli trial (driven by
+	// [Config.SupervisorProb]) won — the steady-state cause for
+	// loops with Supervisor=true.
+	SupervisorTriggerRandom SupervisorTrigger = "random"
+	// SupervisorTriggerForced indicates the supervisor turn
+	// fired because an external signal asked for it via the
+	// `force_supervisor` notification field (mqtt, message_tools,
+	// feed_wake, etc.). Costlier than a normal wake; reserve for
+	// signals that genuinely warrant the extra capacity.
+	SupervisorTriggerForced SupervisorTrigger = "forced"
+)
+
 // RetriggerMode determines what happens when a loop's start condition
 // fires again while the loop is already running.
 type RetriggerMode int
@@ -408,8 +438,17 @@ type IterationResult struct {
 	LoadedCapabilities []toolcatalog.LoadedCapabilityEntry
 	// Elapsed is the wall-clock duration of the iteration.
 	Elapsed time.Duration
-	// Supervisor indicates whether this iteration ran a supervisor turn.
+	// Supervisor indicates whether this iteration ran a supervisor
+	// turn. Derived from SupervisorTrigger; preserved for
+	// backwards-compatible consumers that just want the bool.
 	Supervisor bool
+	// SupervisorTrigger names why a supervisor turn fired (or
+	// reports the empty string when this iteration ran as a normal
+	// turn). Lets retrospection and routing-strategy experiments
+	// distinguish "the dice came up" from "an external signal asked
+	// for it" without re-deriving the cause from notification
+	// history.
+	SupervisorTrigger SupervisorTrigger
 	// Sleep is the computed sleep duration before the next iteration.
 	Sleep time.Duration
 }
@@ -446,8 +485,16 @@ type IterationSnapshot struct {
 	// value is directly usable by the client without nanosecond
 	// conversion.
 	ElapsedMs int64 `json:"elapsed_ms"`
-	// Supervisor indicates whether this iteration ran a supervisor turn.
+	// Supervisor indicates whether this iteration ran a supervisor
+	// turn. Derived from SupervisorTrigger; the JSON wire format
+	// keeps the bool so existing dashboard clients render correctly.
 	Supervisor bool `json:"supervisor,omitempty"`
+	// SupervisorTrigger names why a supervisor turn fired. Empty
+	// string for normal turns. Emitted alongside the bool so
+	// retrospection and analytics tooling can distinguish
+	// "random" (Bernoulli win) from "forced" (notification-driven)
+	// without re-deriving the cause from event logs.
+	SupervisorTrigger SupervisorTrigger `json:"supervisor_trigger,omitempty"`
 	// Error holds the error message if the iteration failed.
 	Error string `json:"error,omitempty"`
 	// StartedAt is when the iteration began.
@@ -516,6 +563,13 @@ type Status struct {
 	// iteration that ran a successful supervisor turn. Zero means
 	// no supervisor turn has completed yet.
 	LastSupervisorIter int `json:"last_supervisor_iter,omitempty"`
+	// LastSupervisorTrigger is the cause of the most recent
+	// supervisor turn (empty when LastSupervisorIter == 0). Lets
+	// the running loop see "my last review was a random pass 14
+	// turns ago" vs "my last review was forced by mqtt 3 turns
+	// ago" without scanning event logs. Drives self-pacing
+	// decisions.
+	LastSupervisorTrigger SupervisorTrigger `json:"last_supervisor_trigger,omitempty"`
 	// LLMContext holds enrichment data from the most recent
 	// loop_llm_start event (model, est_tokens, messages, tools,
 	// complexity, intent, reasoning). Only populated while the loop

--- a/internal/runtime/loop/config.go
+++ b/internal/runtime/loop/config.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/nugget/thane-ai-agent/internal/model/router"
 	"github.com/nugget/thane-ai-agent/internal/model/toolcatalog"
 )
 
@@ -181,30 +182,25 @@ type Config struct {
 	// may make (including failures). Zero means unlimited.
 	MaxIter int
 
-	// Supervisor enables frontier model dice rolls. When true, a
-	// fraction of iterations (controlled by SupervisorProb) use a
-	// more capable model for oversight.
+	// Supervisor enables periodic supervisor turns: a Bernoulli trial
+	// at each wake decides whether the iteration uses the elevated
+	// SupervisorProfile overrides. Mirrors [Spec.Supervisor].
 	Supervisor bool
 
 	// SupervisorProb is the probability [0.0, 1.0] that a given
-	// iteration uses the supervisor model. Only meaningful when
-	// Supervisor is true. Zero means never (use DefaultSupervisorProb
-	// for the recommended default).
+	// iteration is a supervisor turn. Only meaningful when
+	// Supervisor is true. Zero means never. Mirrors
+	// [Spec.SupervisorProb].
 	SupervisorProb float64
 
-	// QualityFloor is the minimum model quality rating for normal
-	// iterations. Zero uses the router default.
-	QualityFloor int
-
-	// SupervisorContext is an optional prompt prepended to the Task
-	// during supervisor turns. Use it to give the frontier model
-	// review instructions, recent iteration summaries, or oversight
-	// criteria. Empty means supervisor runs the same Task as normal.
-	SupervisorContext string
-
-	// SupervisorQualityFloor is the minimum model quality rating
-	// for supervisor turns. Zero uses the router default.
-	SupervisorQualityFloor int
+	// SupervisorProfile carries the per-turn-mode overrides applied
+	// during supervisor turns. Overlay on the loop's normal routing
+	// shape (built from Profile-derived [requestBase]): any field
+	// set here wins, any field left empty falls back to the normal
+	// shape. Nil means "no overrides; supervisor turns use the same
+	// routing shape as normal turns." Mirrors
+	// [Spec.SupervisorProfile].
+	SupervisorProfile *router.LoopProfile
 
 	// OnRetrigger determines behavior when the loop's start
 	// condition fires again while running. Default: RetriggerSingle.
@@ -355,7 +351,7 @@ func (c *Config) validate() error {
 			c.TaskBuilder != nil, c.TurnBuilder != nil, c.Handler != nil, c.WaitFunc != nil, c.PostIterate != nil,
 			c.SleepMin, c.SleepMax, c.SleepDefault, c.MaxDuration,
 			c.Jitter, c.MaxIter,
-			c.Supervisor, c.SupervisorProb, c.SupervisorContext,
+			c.Supervisor, c.SupervisorProb,
 			len(c.Outputs), c.Completion,
 		); err != nil {
 			return err

--- a/internal/runtime/loop/loop.go
+++ b/internal/runtime/loop/loop.go
@@ -275,6 +275,14 @@ type Loop struct {
 	// none yet.
 	lastSupervisorIter int
 
+	// lastSupervisorTrigger names the cause of the most recent
+	// successful supervisor turn — empty when lastSupervisorIter
+	// is zero. Surfaced through [Status.LastSupervisorTrigger] so
+	// the loop and dashboard can distinguish "random" Bernoulli
+	// hits from "forced" external signals when interpreting the
+	// recent-supervisor recency value.
+	lastSupervisorTrigger SupervisorTrigger
+
 	// llmContext holds enrichment data from the most recent
 	// loop_llm_start progress event (model, est_tokens, messages,
 	// tools, complexity, intent, reasoning). Set by makeProgressFunc
@@ -433,6 +441,26 @@ func (l *Loop) ParentID() string {
 // Operation returns the loop's runtime operation kind. Set once at
 // construction; safe to read without the loop lock.
 func (l *Loop) Operation() Operation { return l.config.Operation }
+
+// shouldRunSupervisor decides whether the next iteration runs as
+// a supervisor turn and reports the cause. Forced is the boolean
+// from [consumePendingNotifies] — true when at least one pending
+// notification carried `force_supervisor: true`. Random is the
+// per-wake Bernoulli trial driven by [Config.SupervisorProb].
+// Returns the trigger alongside the bool so callers don't have to
+// re-derive the cause when stamping the iteration record / events.
+// Forced wins over random — if both conditions are true, the
+// trigger reports "forced" because the external signal expresses
+// stronger operator intent than the dice.
+func (l *Loop) shouldRunSupervisor(forced bool) (bool, SupervisorTrigger) {
+	if forced {
+		return true, SupervisorTriggerForced
+	}
+	if l.config.Supervisor && l.config.SupervisorProb > 0 && l.deps.Rand.Float64() < l.config.SupervisorProb {
+		return true, SupervisorTriggerRandom
+	}
+	return false, SupervisorTriggerNone
+}
 
 // IsCore reports whether this loop is the singleton structural root
 // — the container with the well-known name [CoreLoopName]. Core is
@@ -642,28 +670,29 @@ func (l *Loop) Status() Status {
 	}
 
 	s := Status{
-		ID:                 l.id,
-		Name:               l.config.Name,
-		State:              l.state,
-		ParentID:           l.config.ParentID,
-		StartedAt:          l.startedAt,
-		LastWakeAt:         l.lastWakeAt,
-		Iterations:         l.iterations,
-		Attempts:           l.attempts,
-		TotalInputTokens:   l.totalInputTokens,
-		TotalOutputTokens:  l.totalOutputTokens,
-		LastInputTokens:    l.lastInputTokens,
-		LastOutputTokens:   l.lastOutputTokens,
-		ContextWindow:      l.contextWindow,
-		LastError:          l.lastError,
-		ConsecutiveErrors:  l.consecutiveErrors,
-		RecentConvIDs:      convIDsCopy,
-		RecentIterations:   iterCopy,
-		LLMContext:         llmCtxCopy,
-		LastSupervisorIter: l.lastSupervisorIter,
-		HandlerOnly:        l.config.Handler != nil,
-		EventDriven:        l.config.WaitFunc != nil,
-		Config:             cfgCopy,
+		ID:                    l.id,
+		Name:                  l.config.Name,
+		State:                 l.state,
+		ParentID:              l.config.ParentID,
+		StartedAt:             l.startedAt,
+		LastWakeAt:            l.lastWakeAt,
+		Iterations:            l.iterations,
+		Attempts:              l.attempts,
+		TotalInputTokens:      l.totalInputTokens,
+		TotalOutputTokens:     l.totalOutputTokens,
+		LastInputTokens:       l.lastInputTokens,
+		LastOutputTokens:      l.lastOutputTokens,
+		ContextWindow:         l.contextWindow,
+		LastError:             l.lastError,
+		ConsecutiveErrors:     l.consecutiveErrors,
+		RecentConvIDs:         convIDsCopy,
+		RecentIterations:      iterCopy,
+		LLMContext:            llmCtxCopy,
+		LastSupervisorIter:    l.lastSupervisorIter,
+		LastSupervisorTrigger: l.lastSupervisorTrigger,
+		HandlerOnly:           l.config.Handler != nil,
+		EventDriven:           l.config.WaitFunc != nil,
+		Config:                cfgCopy,
 	}
 	l.mu.Unlock()
 
@@ -1147,12 +1176,15 @@ func (l *Loop) run(ctx context.Context) {
 		l.currentConvID = convID
 		l.mu.Unlock()
 
-		// Determine if this iteration runs a supervisor turn.
-		isSupervisor := forceSupervisor || (l.config.Supervisor && l.config.SupervisorProb > 0 && l.deps.Rand.Float64() < l.config.SupervisorProb)
+		// Determine if this iteration runs a supervisor turn and
+		// stamp the cause once so downstream surfaces (events,
+		// iteration record, status) all see the same value.
+		isSupervisor, supervisorTrigger := l.shouldRunSupervisor(forceSupervisor)
 
 		iterLog := logger.With(
 			"conversation_id", convID,
 			"supervisor", isSupervisor,
+			"supervisor_trigger", string(supervisorTrigger),
 			"attempt", attemptCount+1,
 		)
 		iterCtx := logging.WithLogger(ctx, iterLog)
@@ -1173,12 +1205,13 @@ func (l *Loop) run(ctx context.Context) {
 			Source:    events.SourceLoop,
 			Kind:      events.KindLoopIterationStart,
 			Data: map[string]any{
-				"loop_id":          l.id,
-				"loop_name":        l.config.Name,
-				"conversation_id":  convID,
-				"supervisor":       isSupervisor,
-				"attempt":          attemptCount + 1,
-				"signal_envelopes": len(signals),
+				"loop_id":            l.id,
+				"loop_name":          l.config.Name,
+				"conversation_id":    convID,
+				"supervisor":         isSupervisor,
+				"supervisor_trigger": string(supervisorTrigger),
+				"attempt":            attemptCount + 1,
+				"signal_envelopes":   len(signals),
 			},
 		})
 		iterLog.Debug("loop iteration starting")
@@ -1199,9 +1232,10 @@ func (l *Loop) run(ctx context.Context) {
 				}
 			} else {
 				result = &IterationResult{
-					ConvID:     convID,
-					Supervisor: isSupervisor,
-					Elapsed:    time.Since(iterStart),
+					ConvID:            convID,
+					Supervisor:        isSupervisor,
+					SupervisorTrigger: supervisorTrigger,
+					Elapsed:           time.Since(iterStart),
 				}
 			}
 			if model, ok := summary["model"].(string); ok && model != "" && result != nil {
@@ -1301,7 +1335,7 @@ func (l *Loop) run(ctx context.Context) {
 						l.mu.Unlock()
 					}
 					runCtx, runCancel := mergeTurnRunContext(iterCtx, turn.RunContext)
-					result, turnResp, turnErr = l.runAgentTurn(runCtx, req, turn.Stream, iterStart, isSupervisor)
+					result, turnResp, turnErr = l.runAgentTurn(runCtx, req, turn.Stream, iterStart, isSupervisor, supervisorTrigger)
 					runCancel()
 					err = turnErr
 					if len(turn.Summary) > 0 {
@@ -1360,6 +1394,7 @@ func (l *Loop) run(ctx context.Context) {
 			snap.ConvID = convID
 			snap.StartedAt = iterStartTime
 			snap.Supervisor = isSupervisor
+			snap.SupervisorTrigger = supervisorTrigger
 
 			if err != nil {
 				if ctx.Err() != nil {
@@ -1406,6 +1441,7 @@ func (l *Loop) run(ctx context.Context) {
 				l.consecutiveErrors = 0
 				if isSupervisor {
 					l.lastSupervisorIter = l.iterations
+					l.lastSupervisorTrigger = supervisorTrigger
 				}
 				snap.Number = l.iterations
 				l.mu.Unlock()
@@ -1815,7 +1851,7 @@ func (l *Loop) prepareAgentTurnRequest(req Request, convID string, isSupervisor 
 // runAgentTurn is the only loop-owned path that invokes the agent runner.
 // It captures runner response state needed by subsequent iterations and
 // returns the typed iteration result used by snapshots and telemetry.
-func (l *Loop) runAgentTurn(ctx context.Context, req Request, stream StreamCallback, iterStart time.Time, isSupervisor bool) (*IterationResult, *Response, error) {
+func (l *Loop) runAgentTurn(ctx context.Context, req Request, stream StreamCallback, iterStart time.Time, isSupervisor bool, supervisorTrigger SupervisorTrigger) (*IterationResult, *Response, error) {
 	resp, err := l.deps.Runner.Run(ctx, req, stream)
 	if err == nil && resp == nil {
 		err = fmt.Errorf("runner returned nil response")
@@ -1847,6 +1883,7 @@ func (l *Loop) runAgentTurn(ctx context.Context, req Request, stream StreamCallb
 		RequestID:          resp.RequestID,
 		Elapsed:            time.Since(iterStart),
 		Supervisor:         isSupervisor,
+		SupervisorTrigger:  supervisorTrigger,
 	}, resp, nil
 }
 

--- a/internal/runtime/loop/loop.go
+++ b/internal/runtime/loop/loop.go
@@ -813,6 +813,22 @@ func (l *Loop) routingFactorsSnapshot() map[string]string {
 	return out
 }
 
+// supervisorRoutingFactorsSnapshot returns the loop's leaf-level
+// SupervisorProfile-derived routing factors under the loop lock,
+// for use by the cascade walker. Mirrors [routingFactorsSnapshot]
+// but reads from [Config.SupervisorProfile] and contributes only
+// to the SupervisorRoutingFactors cascade — the normal-turn
+// cascade is unaffected. Returns nil when no SupervisorProfile is
+// declared on this loop.
+func (l *Loop) supervisorRoutingFactorsSnapshot() map[string]string {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.config.SupervisorProfile == nil {
+		return nil
+	}
+	return l.config.SupervisorProfile.RoutingFactors()
+}
+
 // delegationGatingSnapshot returns the loop's effective delegation-
 // gating value under the loop lock. Spec.DelegationGating wins
 // when set; otherwise the Profile-side value contributes. Same
@@ -869,9 +885,10 @@ func (l *Loop) inheritedTags() []string {
 // [prepareAgentTurnRequest] to fold inherited values into the
 // existing merge chain without double-counting the loop's own.
 type inheritedCascade struct {
-	ExcludeTools     []string
-	RoutingFactors   map[string]string
-	DelegationGating string
+	ExcludeTools             []string
+	RoutingFactors           map[string]string
+	SupervisorRoutingFactors map[string]string
+	DelegationGating         string
 }
 
 func (l *Loop) inheritedCascade() inheritedCascade {
@@ -903,6 +920,18 @@ func (l *Loop) inheritedCascade() inheritedCascade {
 			continue
 		}
 		out.RoutingFactors[f.Key] = f.Value
+	}
+	for _, f := range eff.SupervisorRoutingFactors {
+		if f.From == EffectiveOriginSelf {
+			continue
+		}
+		if out.SupervisorRoutingFactors == nil {
+			out.SupervisorRoutingFactors = make(map[string]string)
+		}
+		if _, dup := out.SupervisorRoutingFactors[f.Key]; dup {
+			continue
+		}
+		out.SupervisorRoutingFactors[f.Key] = f.Value
 	}
 	if eff.DelegationGating != nil && eff.DelegationGating.From != EffectiveOriginSelf {
 		out.DelegationGating = eff.DelegationGating.Value
@@ -1643,8 +1672,14 @@ func (l *Loop) buildTaskTurn(ctx context.Context, input TurnInput) (*AgentTurn, 
 		}
 	} else {
 		task = l.config.Task
-		if input.Supervisor && l.config.SupervisorContext != "" {
-			task = l.config.SupervisorContext + "\n\n" + task
+		// SupervisorProfile.Instructions is the post-PR-R1 home
+		// for the prompt-prefix that used to live in SupervisorContext.
+		// Self-only by design (matches Profile.Instructions cascade
+		// semantics from PR-E3) — supervisor instructions describe
+		// what to do on this loop's review turn, not "all my
+		// descendants get this prefix."
+		if input.Supervisor && l.config.SupervisorProfile != nil && l.config.SupervisorProfile.Instructions != "" {
+			task = l.config.SupervisorProfile.Instructions + "\n\n" + task
 		}
 	}
 	if l.taskOverride != "" {
@@ -1686,14 +1721,12 @@ func (l *Loop) prepareAgentTurnRequest(req Request, convID string, isSupervisor 
 	}
 	if isSupervisor {
 		hints["supervisor"] = "true"
-		if l.config.SupervisorQualityFloor > 0 {
-			hints["quality_floor"] = fmt.Sprintf("%d", l.config.SupervisorQualityFloor)
-		}
+		// Default a supervisor turn to cloud-eligible and let the
+		// SupervisorProfile overlay refine. Operators or containers
+		// can flip local_only back to "true" via SupervisorProfile if
+		// they really want a local-only supervisor pass.
 		hints["local_only"] = "false"
 	} else {
-		if l.config.QualityFloor > 0 {
-			hints["quality_floor"] = fmt.Sprintf("%d", l.config.QualityFloor)
-		}
 		hints["local_only"] = "true"
 	}
 	// Container ancestors fold into the merge chain alongside
@@ -1715,6 +1748,28 @@ func (l *Loop) prepareAgentTurnRequest(req Request, convID string, isSupervisor 
 	}
 	for k, v := range req.RoutingFactors {
 		hints[k] = v
+	}
+	// SupervisorProfile overlay: when this is a supervisor turn,
+	// merge the loop's leaf-level SupervisorProfile routing factors
+	// AND any cascaded supervisor-profile factors from container
+	// ancestors. Higher priority than the normal Profile-derived
+	// factors above (supervisor overrides win over leaf Profile),
+	// lower than per-launch overrides (operator intent still wins
+	// last). Field-by-field merge; an empty key falls back to the
+	// pre-overlay value already in hints.
+	if isSupervisor {
+		for k, v := range cascade.SupervisorRoutingFactors {
+			if v != "" {
+				hints[k] = v
+			}
+		}
+		if l.config.SupervisorProfile != nil {
+			for k, v := range l.config.SupervisorProfile.RoutingFactors() {
+				if v != "" {
+					hints[k] = v
+				}
+			}
+		}
 	}
 	for k, v := range l.requestOverride.RoutingFactors {
 		hints[k] = v

--- a/internal/runtime/loop/loop_test.go
+++ b/internal/runtime/loop/loop_test.go
@@ -1410,7 +1410,7 @@ func TestNewFromSpecAppliesProfileToRequest(t *testing.T) {
 			Instructions: "stay concise",
 			PreferSpeed:  "true",
 			LocalOnly:    "false",
-			QualityFloor: "7",
+			QualityFloor: 7,
 			ExtraHints:   map[string]string{"source": "profile"},
 		},
 		ExcludeTools: []string{"dangerous_tool"},

--- a/internal/runtime/loop/registry.go
+++ b/internal/runtime/loop/registry.go
@@ -357,6 +357,13 @@ type effectiveStateResult struct {
 	ExcludeTools     []EffectiveExcludeTool
 	RoutingFactors   []EffectiveRoutingFactor
 	DelegationGating *EffectiveDelegationGating
+	// SupervisorRoutingFactors is the parallel cascade for the
+	// per-turn-mode overrides declared on [Spec.SupervisorProfile].
+	// Same closest-wins semantics as RoutingFactors, walked over the
+	// same container ancestor chain — but populated from each loop's
+	// SupervisorProfile rather than Profile. Loop runtime consumes
+	// this only during supervisor turns; normal turns ignore it.
+	SupervisorRoutingFactors []EffectiveRoutingFactor
 }
 
 // EffectiveSubscriptions returns the deduplicated effective entity
@@ -404,6 +411,18 @@ func (r *Registry) EffectiveExcludeTools(loopID string) []EffectiveExcludeTool {
 // declares any factors.
 func (r *Registry) EffectiveRoutingFactors(loopID string) []EffectiveRoutingFactor {
 	return r.effectiveState(loopID).RoutingFactors
+}
+
+// EffectiveSupervisorRoutingFactors returns the per-turn-mode
+// override cascade derived from [Spec.SupervisorProfile] across
+// the loop and its container ancestors. Walked parent-first with
+// child-wins on key collision, identical to
+// [EffectiveRoutingFactors] but sourced from SupervisorProfile
+// rather than Profile. The loop runtime overlays these on top of
+// the normal-turn routing factors only when the iteration is a
+// supervisor turn; normal turns ignore this surface entirely.
+func (r *Registry) EffectiveSupervisorRoutingFactors(loopID string) []EffectiveRoutingFactor {
+	return r.effectiveState(loopID).SupervisorRoutingFactors
 }
 
 // EffectiveDelegationGating returns the resolved delegation-gating
@@ -513,6 +532,7 @@ func (r *Registry) effectiveState(loopID string) effectiveStateResult {
 	seenTags := make(map[string]struct{})
 	seenExcludes := make(map[string]struct{})
 	seenFactors := make(map[string]struct{})
+	seenSupervisorFactors := make(map[string]struct{})
 
 	for i, l := range walk {
 		// The starting loop contributes regardless of operation; only
@@ -572,6 +592,24 @@ func (r *Registry) effectiveState(loopID string) effectiveStateResult {
 			}
 			seenFactors[key] = struct{}{}
 			result.RoutingFactors = append(result.RoutingFactors, EffectiveRoutingFactor{
+				Key:   key,
+				Value: value,
+				From:  origin,
+			})
+		}
+		// SupervisorRoutingFactors: parallel cascade fed by each
+		// loop's SupervisorProfile. Same closest-wins semantics —
+		// the leaf's SupervisorProfile beats ancestors', and once a
+		// key is set it sticks for the rest of the walk.
+		for key, value := range l.supervisorRoutingFactorsSnapshot() {
+			if key == "" {
+				continue
+			}
+			if _, dup := seenSupervisorFactors[key]; dup {
+				continue
+			}
+			seenSupervisorFactors[key] = struct{}{}
+			result.SupervisorRoutingFactors = append(result.SupervisorRoutingFactors, EffectiveRoutingFactor{
 				Key:   key,
 				Value: value,
 				From:  origin,

--- a/internal/runtime/loop/routing_unification_test.go
+++ b/internal/runtime/loop/routing_unification_test.go
@@ -34,7 +34,7 @@ func TestUnmarshalJSONMigratesLegacyQualityFloor(t *testing.T) {
 		t.Fatalf("Unmarshal: %v", err)
 	}
 	if s.Profile.QualityFloor != 7 {
-		t.Errorf("Profile.QualityFloor = %q, want %q (legacy migration)", s.Profile.QualityFloor, "7")
+		t.Errorf("Profile.QualityFloor = %d, want 7 (legacy migration)", s.Profile.QualityFloor)
 	}
 }
 
@@ -68,7 +68,7 @@ func TestUnmarshalJSONMigratesLegacySupervisorFields(t *testing.T) {
 			t.Fatal("SupervisorProfile is nil; expected allocation when legacy supervisor fields are present")
 		}
 		if s.SupervisorProfile.QualityFloor != 9 {
-			t.Errorf("SupervisorProfile.QualityFloor = %q, want %q", s.SupervisorProfile.QualityFloor, "9")
+			t.Errorf("SupervisorProfile.QualityFloor = %d, want 9", s.SupervisorProfile.QualityFloor)
 		}
 		if !strings.Contains(s.SupervisorProfile.Instructions, "Review this turn") {
 			t.Errorf("SupervisorProfile.Instructions = %q, want the legacy supervisor_context content", s.SupervisorProfile.Instructions)
@@ -120,10 +120,10 @@ func TestUnmarshalJSONPrefersNewShapeOverLegacy(t *testing.T) {
 		t.Fatalf("Unmarshal: %v", err)
 	}
 	if s.Profile.QualityFloor != 8 {
-		t.Errorf("Profile.QualityFloor = %q, want %q (new shape should win)", s.Profile.QualityFloor, "8")
+		t.Errorf("Profile.QualityFloor = %d, want 8 (new shape should win)", s.Profile.QualityFloor)
 	}
 	if s.SupervisorProfile == nil || s.SupervisorProfile.QualityFloor != 10 {
-		t.Errorf("SupervisorProfile.QualityFloor = %v, want %q (new shape should win)", s.SupervisorProfile, "10")
+		t.Errorf("SupervisorProfile.QualityFloor = %+v, want 10 (new shape should win)", s.SupervisorProfile)
 	}
 }
 

--- a/internal/runtime/loop/routing_unification_test.go
+++ b/internal/runtime/loop/routing_unification_test.go
@@ -33,7 +33,7 @@ func TestUnmarshalJSONMigratesLegacyQualityFloor(t *testing.T) {
 	if err := json.Unmarshal(raw, &s); err != nil {
 		t.Fatalf("Unmarshal: %v", err)
 	}
-	if s.Profile.QualityFloor != "7" {
+	if s.Profile.QualityFloor != 7 {
 		t.Errorf("Profile.QualityFloor = %q, want %q (legacy migration)", s.Profile.QualityFloor, "7")
 	}
 }
@@ -67,7 +67,7 @@ func TestUnmarshalJSONMigratesLegacySupervisorFields(t *testing.T) {
 		if s.SupervisorProfile == nil {
 			t.Fatal("SupervisorProfile is nil; expected allocation when legacy supervisor fields are present")
 		}
-		if s.SupervisorProfile.QualityFloor != "9" {
+		if s.SupervisorProfile.QualityFloor != 9 {
 			t.Errorf("SupervisorProfile.QualityFloor = %q, want %q", s.SupervisorProfile.QualityFloor, "9")
 		}
 		if !strings.Contains(s.SupervisorProfile.Instructions, "Review this turn") {
@@ -119,10 +119,10 @@ func TestUnmarshalJSONPrefersNewShapeOverLegacy(t *testing.T) {
 	if err := json.Unmarshal(raw, &s); err != nil {
 		t.Fatalf("Unmarshal: %v", err)
 	}
-	if s.Profile.QualityFloor != "8" {
+	if s.Profile.QualityFloor != 8 {
 		t.Errorf("Profile.QualityFloor = %q, want %q (new shape should win)", s.Profile.QualityFloor, "8")
 	}
-	if s.SupervisorProfile == nil || s.SupervisorProfile.QualityFloor != "10" {
+	if s.SupervisorProfile == nil || s.SupervisorProfile.QualityFloor != 10 {
 		t.Errorf("SupervisorProfile.QualityFloor = %v, want %q (new shape should win)", s.SupervisorProfile, "10")
 	}
 }
@@ -142,10 +142,10 @@ func TestMarshalJSONOmitsLegacyFields(t *testing.T) {
 		SleepMax:     time.Minute,
 		SleepDefault: time.Minute,
 		Profile: router.LoopProfile{
-			QualityFloor: "4",
+			QualityFloor: 4,
 		},
 		SupervisorProfile: &router.LoopProfile{
-			QualityFloor: "9",
+			QualityFloor: 9,
 			Instructions: "Periodic review.",
 		},
 	}
@@ -154,23 +154,28 @@ func TestMarshalJSONOmitsLegacyFields(t *testing.T) {
 		t.Fatalf("Marshal: %v", err)
 	}
 	js := string(out)
+	// The retired top-level fields must not appear on the wire.
+	// Note: `quality_floor` IS the canonical Profile field name,
+	// so we can't just grep for the key — we check that it never
+	// appears at the spec root, only nested inside profile and
+	// supervisor_profile objects.
 	for _, legacy := range []string{
-		`"quality_floor":4`,
-		`"quality_floor":9`,
 		`"supervisor_quality_floor"`,
 		`"supervisor_context"`,
 	} {
 		if strings.Contains(js, legacy) {
-			t.Errorf("Marshal emitted legacy field %q in: %s", legacy, js)
+			t.Errorf("Marshal emitted retired field %q in: %s", legacy, js)
 		}
 	}
-	// The canonical fields must appear so a downstream consumer
-	// sees the real configuration.
-	if !strings.Contains(js, `"quality_floor":"4"`) {
-		t.Errorf("Marshal didn't emit Profile.quality_floor as %q: %s", "4", js)
+	// The canonical Profile / SupervisorProfile blocks must
+	// carry quality_floor as an int (not the legacy string
+	// form). A pre-PR-Q1 marshal would have emitted "4" /
+	// "9"; the int wire format pins the conversion.
+	if !strings.Contains(js, `"profile":{"quality_floor":4}`) {
+		t.Errorf("Marshal didn't emit profile.quality_floor as int 4: %s", js)
 	}
-	if !strings.Contains(js, `"supervisor_profile"`) {
-		t.Errorf("Marshal didn't emit supervisor_profile block: %s", js)
+	if !strings.Contains(js, `"supervisor_profile":{"quality_floor":9`) {
+		t.Errorf("Marshal didn't emit supervisor_profile.quality_floor as int 9: %s", js)
 	}
 }
 
@@ -199,7 +204,7 @@ func TestEffectiveSupervisorRoutingFactorsCascadesFromContainers(t *testing.T) {
 		Name:      "research",
 		Operation: OperationContainer,
 		SupervisorProfile: &router.LoopProfile{
-			QualityFloor: "9",
+			QualityFloor: 9,
 			LocalOnly:    "false",
 		},
 	}, Deps{})
@@ -217,7 +222,7 @@ func TestEffectiveSupervisorRoutingFactorsCascadesFromContainers(t *testing.T) {
 		Task:     "research things",
 		ParentID: parent.ID(),
 		SupervisorProfile: &router.LoopProfile{
-			QualityFloor: "10",
+			QualityFloor: 10,
 		},
 	}, Deps{Runner: &noopRunner{}})
 	if err != nil {

--- a/internal/runtime/loop/routing_unification_test.go
+++ b/internal/runtime/loop/routing_unification_test.go
@@ -1,0 +1,297 @@
+package loop
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nugget/thane-ai-agent/internal/model/router"
+)
+
+// TestUnmarshalJSONMigratesLegacyQualityFloor is the regression
+// test for the post-PR-R1 routing-surface unification: a
+// persisted overlay spec written before PR-R1 with the top-level
+// `quality_floor` field must hydrate cleanly, with the value
+// translated onto Profile.QualityFloor. Without this, an upgrade
+// from a pre-PR-R1 deployment would silently lose the operator's
+// configured quality floor on first restart.
+func TestUnmarshalJSONMigratesLegacyQualityFloor(t *testing.T) {
+	t.Parallel()
+
+	raw := []byte(`{
+		"name": "legacy",
+		"operation": "service",
+		"task": "t",
+		"sleep_min": "1m",
+		"sleep_max": "1m",
+		"sleep_default": "1m",
+		"quality_floor": 7
+	}`)
+
+	var s Spec
+	if err := json.Unmarshal(raw, &s); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if s.Profile.QualityFloor != "7" {
+		t.Errorf("Profile.QualityFloor = %q, want %q (legacy migration)", s.Profile.QualityFloor, "7")
+	}
+}
+
+// TestUnmarshalJSONMigratesLegacySupervisorFields covers the
+// parallel migration for supervisor turns: the legacy
+// `supervisor_quality_floor` and `supervisor_context` fields
+// translate onto SupervisorProfile.QualityFloor and
+// SupervisorProfile.Instructions respectively. Allocates a
+// SupervisorProfile only when at least one legacy supervisor
+// field is set, so a spec with no supervisor overrides at all
+// still hydrates with nil SupervisorProfile.
+func TestUnmarshalJSONMigratesLegacySupervisorFields(t *testing.T) {
+	t.Parallel()
+
+	t.Run("both supervisor fields populate SupervisorProfile", func(t *testing.T) {
+		raw := []byte(`{
+			"name": "legacy",
+			"operation": "service",
+			"task": "t",
+			"sleep_min": "1m",
+			"sleep_max": "1m",
+			"sleep_default": "1m",
+			"supervisor_quality_floor": 9,
+			"supervisor_context": "Review this turn's outputs against past patterns."
+		}`)
+		var s Spec
+		if err := json.Unmarshal(raw, &s); err != nil {
+			t.Fatalf("Unmarshal: %v", err)
+		}
+		if s.SupervisorProfile == nil {
+			t.Fatal("SupervisorProfile is nil; expected allocation when legacy supervisor fields are present")
+		}
+		if s.SupervisorProfile.QualityFloor != "9" {
+			t.Errorf("SupervisorProfile.QualityFloor = %q, want %q", s.SupervisorProfile.QualityFloor, "9")
+		}
+		if !strings.Contains(s.SupervisorProfile.Instructions, "Review this turn") {
+			t.Errorf("SupervisorProfile.Instructions = %q, want the legacy supervisor_context content", s.SupervisorProfile.Instructions)
+		}
+	})
+
+	t.Run("no supervisor fields leaves SupervisorProfile nil", func(t *testing.T) {
+		raw := []byte(`{
+			"name": "leaf",
+			"operation": "service",
+			"task": "t",
+			"sleep_min": "1m",
+			"sleep_max": "1m",
+			"sleep_default": "1m"
+		}`)
+		var s Spec
+		if err := json.Unmarshal(raw, &s); err != nil {
+			t.Fatalf("Unmarshal: %v", err)
+		}
+		if s.SupervisorProfile != nil {
+			t.Errorf("SupervisorProfile = %+v, want nil for a spec with no overrides", s.SupervisorProfile)
+		}
+	})
+}
+
+// TestUnmarshalJSONPrefersNewShapeOverLegacy guards the
+// collision rule: when both the legacy top-level fields AND the
+// new Profile/SupervisorProfile fields are present in the JSON
+// (unlikely in practice but possible during a partial upgrade),
+// the new shape wins. Legacy values do NOT clobber explicit new
+// fields.
+func TestUnmarshalJSONPrefersNewShapeOverLegacy(t *testing.T) {
+	t.Parallel()
+
+	raw := []byte(`{
+		"name": "mixed",
+		"operation": "service",
+		"task": "t",
+		"sleep_min": "1m",
+		"sleep_max": "1m",
+		"sleep_default": "1m",
+		"quality_floor": 3,
+		"profile": {"quality_floor": "8"},
+		"supervisor_quality_floor": 5,
+		"supervisor_profile": {"quality_floor": "10"}
+	}`)
+	var s Spec
+	if err := json.Unmarshal(raw, &s); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if s.Profile.QualityFloor != "8" {
+		t.Errorf("Profile.QualityFloor = %q, want %q (new shape should win)", s.Profile.QualityFloor, "8")
+	}
+	if s.SupervisorProfile == nil || s.SupervisorProfile.QualityFloor != "10" {
+		t.Errorf("SupervisorProfile.QualityFloor = %v, want %q (new shape should win)", s.SupervisorProfile, "10")
+	}
+}
+
+// TestMarshalJSONOmitsLegacyFields confirms a freshly-built spec
+// never emits the legacy top-level fields on its way back to
+// disk — the canonical shape moves forward and the migration
+// shim cleans up old persisted state in one direction only.
+func TestMarshalJSONOmitsLegacyFields(t *testing.T) {
+	t.Parallel()
+
+	s := Spec{
+		Name:         "fresh",
+		Operation:    OperationService,
+		Task:         "t",
+		SleepMin:     time.Minute,
+		SleepMax:     time.Minute,
+		SleepDefault: time.Minute,
+		Profile: router.LoopProfile{
+			QualityFloor: "4",
+		},
+		SupervisorProfile: &router.LoopProfile{
+			QualityFloor: "9",
+			Instructions: "Periodic review.",
+		},
+	}
+	out, err := json.Marshal(s)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	js := string(out)
+	for _, legacy := range []string{
+		`"quality_floor":4`,
+		`"quality_floor":9`,
+		`"supervisor_quality_floor"`,
+		`"supervisor_context"`,
+	} {
+		if strings.Contains(js, legacy) {
+			t.Errorf("Marshal emitted legacy field %q in: %s", legacy, js)
+		}
+	}
+	// The canonical fields must appear so a downstream consumer
+	// sees the real configuration.
+	if !strings.Contains(js, `"quality_floor":"4"`) {
+		t.Errorf("Marshal didn't emit Profile.quality_floor as %q: %s", "4", js)
+	}
+	if !strings.Contains(js, `"supervisor_profile"`) {
+		t.Errorf("Marshal didn't emit supervisor_profile block: %s", js)
+	}
+}
+
+// TestEffectiveSupervisorRoutingFactorsCascadesFromContainers
+// pins the parallel cascade for SupervisorProfile: a container
+// ancestor's SupervisorProfile.QualityFloor reaches the
+// descendant via [Registry.EffectiveSupervisorRoutingFactors],
+// with the leaf's own SupervisorProfile winning on collision.
+// Normal-turn routing factors (Profile cascade) are unaffected.
+func TestEffectiveSupervisorRoutingFactorsCascadesFromContainers(t *testing.T) {
+	t.Parallel()
+
+	r := NewRegistry()
+	core, err := New(Config{Name: CoreLoopName, Operation: OperationContainer}, Deps{})
+	if err != nil {
+		t.Fatalf("new core: %v", err)
+	}
+	if err := r.Register(core); err != nil {
+		t.Fatalf("register core: %v", err)
+	}
+
+	// Container ancestor declares a SupervisorProfile override.
+	// (Mission cascades because it's a routing factor; only
+	// SupervisorProfile fields go into the supervisor cascade.)
+	parent, err := New(Config{
+		Name:      "research",
+		Operation: OperationContainer,
+		SupervisorProfile: &router.LoopProfile{
+			QualityFloor: "9",
+			LocalOnly:    "false",
+		},
+	}, Deps{})
+	if err != nil {
+		t.Fatalf("new parent: %v", err)
+	}
+	if err := r.Register(parent); err != nil {
+		t.Fatalf("register parent: %v", err)
+	}
+
+	// Leaf has its own SupervisorProfile that overrides one
+	// field but leaves the other to inherit.
+	leaf, err := New(Config{
+		Name:     "researcher",
+		Task:     "research things",
+		ParentID: parent.ID(),
+		SupervisorProfile: &router.LoopProfile{
+			QualityFloor: "10",
+		},
+	}, Deps{Runner: &noopRunner{}})
+	if err != nil {
+		t.Fatalf("new leaf: %v", err)
+	}
+	if err := r.Register(leaf); err != nil {
+		t.Fatalf("register leaf: %v", err)
+	}
+
+	factors := r.EffectiveSupervisorRoutingFactors(leaf.ID())
+	got := make(map[string]EffectiveRoutingFactor, len(factors))
+	for _, f := range factors {
+		got[f.Key] = f
+	}
+
+	// quality_floor: leaf wins.
+	if f, ok := got["quality_floor"]; !ok {
+		t.Error("quality_floor missing from cascade")
+	} else {
+		if f.Value != "10" {
+			t.Errorf("quality_floor.Value = %q, want %q (leaf wins)", f.Value, "10")
+		}
+		if f.From != EffectiveOriginSelf {
+			t.Errorf("quality_floor.From = %q, want %q (leaf own decl)", f.From, EffectiveOriginSelf)
+		}
+	}
+	// local_only: only declared on parent — inherits.
+	if f, ok := got["local_only"]; !ok {
+		t.Error("local_only missing from cascade (should inherit from parent)")
+	} else {
+		if f.Value != "false" {
+			t.Errorf("local_only.Value = %q, want %q (inherited from parent)", f.Value, "false")
+		}
+		if f.From != "research" {
+			t.Errorf("local_only.From = %q, want %q (parent name)", f.From, "research")
+		}
+	}
+
+	// And the normal-turn cascade should be empty — none of the
+	// fields on either spec went into Profile.
+	if normal := r.EffectiveRoutingFactors(leaf.ID()); len(normal) != 0 {
+		t.Errorf("EffectiveRoutingFactors (normal) = %v, want empty (SupervisorProfile shouldn't leak into Profile cascade)", normal)
+	}
+}
+
+// TestSupervisorProfileNilLeavesNormalRoutingUntouched guards
+// the no-overrides case: a loop with Supervisor=true and
+// SupervisorProb>0 but SupervisorProfile=nil should run
+// supervisor turns with the same routing factors as normal
+// turns. The supervisor flag still flips on the iteration
+// record; just no overrides apply.
+func TestSupervisorProfileNilLeavesNormalRoutingUntouched(t *testing.T) {
+	t.Parallel()
+
+	r := NewRegistry()
+	core, err := New(Config{Name: CoreLoopName, Operation: OperationContainer}, Deps{})
+	if err != nil {
+		t.Fatalf("new core: %v", err)
+	}
+	if err := r.Register(core); err != nil {
+		t.Fatalf("register core: %v", err)
+	}
+	leaf, err := New(Config{
+		Name: "service",
+		Task: "do",
+	}, Deps{Runner: &noopRunner{}})
+	if err != nil {
+		t.Fatalf("new leaf: %v", err)
+	}
+	if err := r.Register(leaf); err != nil {
+		t.Fatalf("register leaf: %v", err)
+	}
+
+	if got := r.EffectiveSupervisorRoutingFactors(leaf.ID()); len(got) != 0 {
+		t.Errorf("EffectiveSupervisorRoutingFactors = %v, want empty (no SupervisorProfile declared)", got)
+	}
+}

--- a/internal/runtime/loop/spec.go
+++ b/internal/runtime/loop/spec.go
@@ -160,18 +160,27 @@ type Spec struct {
 	// may make.
 	MaxIter int `yaml:"max_iter,omitempty" json:"max_iter,omitempty"`
 
-	// Supervisor enables frontier model dice rolls.
+	// Supervisor enables periodic supervisor turns: a Bernoulli trial
+	// at each wake decides whether this iteration uses the more
+	// capable model and the SupervisorProfile overrides defined below.
 	Supervisor bool `yaml:"supervisor,omitempty" json:"supervisor,omitempty"`
-	// SupervisorProb is the probability of using the supervisor model.
+	// SupervisorProb is the per-wake probability [0.0, 1.0] of a
+	// supervisor turn when Supervisor is true.
 	SupervisorProb float64 `yaml:"supervisor_prob,omitempty" json:"supervisor_prob,omitempty"`
-	// QualityFloor is the minimum model quality rating for normal
-	// iterations.
-	QualityFloor int `yaml:"quality_floor,omitempty" json:"quality_floor,omitempty"`
-	// SupervisorContext is prepended during supervisor turns.
-	SupervisorContext string `yaml:"supervisor_context,omitempty" json:"supervisor_context,omitempty"`
-	// SupervisorQualityFloor is the quality floor for supervisor
-	// turns.
-	SupervisorQualityFloor int `yaml:"supervisor_quality_floor,omitempty" json:"supervisor_quality_floor,omitempty"`
+	// SupervisorProfile carries the per-turn-mode overrides applied
+	// during supervisor turns. It is an OVERLAY on Profile: any field
+	// set here wins, any field left empty falls back to Profile.
+	// Notably, SupervisorProfile.QualityFloor lets a loop demand a
+	// higher rating during review turns, and
+	// SupervisorProfile.Instructions replaces the (now-retired)
+	// SupervisorContext as the prompt-prefix path. Like
+	// [Profile.Instructions], SupervisorProfile.Instructions is
+	// self-only — it does not cascade through container ancestors.
+	//
+	// Nil means "supervisor turns use Profile as-is" — i.e. the
+	// supervisor flag still flips on the iteration record but no
+	// routing-shape overrides apply.
+	SupervisorProfile *router.LoopProfile `yaml:"supervisor_profile,omitempty" json:"supervisor_profile,omitempty"`
 
 	// OnRetrigger determines behavior when the loop is triggered again
 	// while already running.
@@ -308,12 +317,18 @@ func (s *Spec) Validate() error {
 // than an unused field, so the failure mode here is loud rather
 // than silently ignored.
 func validateContainerShape(s *Spec) error {
+	// Containers can declare a SupervisorProfile for cascade to
+	// descendants, but the supervisor-turn Bernoulli trial itself
+	// never fires on a container (containers don't execute), so
+	// Supervisor and SupervisorProb must remain off.
+	// SupervisorProfile-only is OK — that's the inheritance vector
+	// the cascade walker uses.
 	return containerShape(
 		s.Name, s.Task,
 		s.TaskBuilder != nil, s.TurnBuilder != nil, s.Handler != nil, s.WaitFunc != nil, s.PostIterate != nil,
 		s.SleepMin, s.SleepMax, s.SleepDefault, s.MaxDuration,
 		s.Jitter, s.MaxIter,
-		s.Supervisor, s.SupervisorProb, s.SupervisorContext,
+		s.Supervisor, s.SupervisorProb,
 		len(s.Outputs), s.Completion,
 	)
 }
@@ -358,40 +373,38 @@ func (s *Spec) ToConfig() Config {
 	}
 	ns := s.normalized()
 	return Config{
-		Name:                   ns.Name,
-		Task:                   ns.Task,
-		Operation:              ns.Operation,
-		Completion:             ns.Completion,
-		Outputs:                cloneOutputs(ns.Outputs),
-		Subscriptions:          cloneEntitySubscriptions(ns.Subscriptions),
-		Tags:                   append([]string(nil), ns.Tags...),
-		ExcludeTools:           append([]string(nil), ns.ExcludeTools...),
-		SleepMin:               ns.SleepMin,
-		SleepMax:               ns.SleepMax,
-		SleepDefault:           ns.SleepDefault,
-		Jitter:                 cloneFloat64Ptr(ns.Jitter),
-		MaxDuration:            ns.MaxDuration,
-		MaxIter:                ns.MaxIter,
-		Supervisor:             ns.Supervisor,
-		SupervisorProb:         ns.SupervisorProb,
-		QualityFloor:           ns.QualityFloor,
-		SupervisorContext:      ns.SupervisorContext,
-		SupervisorQualityFloor: ns.SupervisorQualityFloor,
-		OnRetrigger:            ns.OnRetrigger,
-		TaskBuilder:            ns.TaskBuilder,
-		TurnBuilder:            ns.TurnBuilder,
-		PostIterate:            ns.PostIterate,
-		WaitFunc:               ns.WaitFunc,
-		Handler:                ns.Handler,
-		RoutingFactors:         cloneStringMap(ns.RoutingFactors),
-		DelegationGating:       ns.DelegationGating,
-		FallbackContent:        ns.FallbackContent,
-		Setup:                  ns.Setup,
-		RuntimeTools:           cloneRuntimeTools(ns.RuntimeTools),
-		OutputContextBuilder:   ns.OutputContextBuilder,
-		Metadata:               cloneStringMap(ns.Metadata),
-		ParentID:               ns.ParentID,
-		ParentName:             ns.ParentName,
+		Name:                 ns.Name,
+		Task:                 ns.Task,
+		Operation:            ns.Operation,
+		Completion:           ns.Completion,
+		Outputs:              cloneOutputs(ns.Outputs),
+		Subscriptions:        cloneEntitySubscriptions(ns.Subscriptions),
+		Tags:                 append([]string(nil), ns.Tags...),
+		ExcludeTools:         append([]string(nil), ns.ExcludeTools...),
+		SleepMin:             ns.SleepMin,
+		SleepMax:             ns.SleepMax,
+		SleepDefault:         ns.SleepDefault,
+		Jitter:               cloneFloat64Ptr(ns.Jitter),
+		MaxDuration:          ns.MaxDuration,
+		MaxIter:              ns.MaxIter,
+		Supervisor:           ns.Supervisor,
+		SupervisorProb:       ns.SupervisorProb,
+		SupervisorProfile:    cloneLoopProfilePtr(ns.SupervisorProfile),
+		OnRetrigger:          ns.OnRetrigger,
+		TaskBuilder:          ns.TaskBuilder,
+		TurnBuilder:          ns.TurnBuilder,
+		PostIterate:          ns.PostIterate,
+		WaitFunc:             ns.WaitFunc,
+		Handler:              ns.Handler,
+		RoutingFactors:       cloneStringMap(ns.RoutingFactors),
+		DelegationGating:     ns.DelegationGating,
+		FallbackContent:      ns.FallbackContent,
+		Setup:                ns.Setup,
+		RuntimeTools:         cloneRuntimeTools(ns.RuntimeTools),
+		OutputContextBuilder: ns.OutputContextBuilder,
+		Metadata:             cloneStringMap(ns.Metadata),
+		ParentID:             ns.ParentID,
+		ParentName:           ns.ParentName,
 	}
 }
 
@@ -399,7 +412,7 @@ func (s *Spec) ToConfig() Config {
 // rejects every execution-related field, returning a category-error for
 // authoring mistakes (Spec layer) or programmer mistakes (Config layer)
 // rather than silently ignoring the value at runtime.
-func containerShape(name, task string, hasTaskBuilder, hasTurnBuilder, hasHandler, hasWaitFunc, hasPostIterate bool, sleepMin, sleepMax, sleepDefault, maxDuration time.Duration, jitter *float64, maxIter int, supervisor bool, supervisorProb float64, supervisorContext string, outputCount int, completion Completion) error {
+func containerShape(name, task string, hasTaskBuilder, hasTurnBuilder, hasHandler, hasWaitFunc, hasPostIterate bool, sleepMin, sleepMax, sleepDefault, maxDuration time.Duration, jitter *float64, maxIter int, supervisor bool, supervisorProb float64, outputCount int, completion Completion) error {
 	if strings.TrimSpace(task) != "" {
 		return fmt.Errorf("loop: container %q cannot set task", name)
 	}
@@ -430,7 +443,7 @@ func containerShape(name, task string, hasTaskBuilder, hasTurnBuilder, hasHandle
 	if maxIter != 0 {
 		return fmt.Errorf("loop: container %q cannot set max_iter", name)
 	}
-	if supervisor || supervisorProb != 0 || strings.TrimSpace(supervisorContext) != "" {
+	if supervisor || supervisorProb != 0 {
 		return fmt.Errorf("loop: container %q cannot set supervisor fields", name)
 	}
 	if outputCount > 0 {
@@ -512,4 +525,22 @@ func cloneFloat64Ptr(src *float64) *float64 {
 	}
 	v := *src
 	return &v
+}
+
+// cloneLoopProfilePtr deep-copies an optional [router.LoopProfile]
+// pointer so callers can mutate the result without affecting the
+// underlying spec. Used to thread SupervisorProfile through
+// [Spec.ToConfig] without aliasing the spec's overlay struct.
+func cloneLoopProfilePtr(src *router.LoopProfile) *router.LoopProfile {
+	if src == nil {
+		return nil
+	}
+	c := *src
+	if len(src.ExcludeTools) > 0 {
+		c.ExcludeTools = append([]string(nil), src.ExcludeTools...)
+	}
+	if len(src.ExtraHints) > 0 {
+		c.ExtraHints = cloneStringMap(src.ExtraHints)
+	}
+	return &c
 }

--- a/internal/runtime/loop/spec_json.go
+++ b/internal/runtime/loop/spec_json.go
@@ -206,16 +206,16 @@ func migrateLegacyRoutingFields(s *Spec, wire specJSON, logger *slog.Logger) {
 		return
 	}
 	migrated := false
-	if wire.LegacyQualityFloor > 0 && s.Profile.QualityFloor == "" {
-		s.Profile.QualityFloor = fmt.Sprintf("%d", wire.LegacyQualityFloor)
+	if wire.LegacyQualityFloor > 0 && s.Profile.QualityFloor == 0 {
+		s.Profile.QualityFloor = wire.LegacyQualityFloor
 		migrated = true
 	}
 	if wire.LegacySupervisorQualityFloor > 0 {
 		if s.SupervisorProfile == nil {
 			s.SupervisorProfile = &router.LoopProfile{}
 		}
-		if s.SupervisorProfile.QualityFloor == "" {
-			s.SupervisorProfile.QualityFloor = fmt.Sprintf("%d", wire.LegacySupervisorQualityFloor)
+		if s.SupervisorProfile.QualityFloor == 0 {
+			s.SupervisorProfile.QualityFloor = wire.LegacySupervisorQualityFloor
 			migrated = true
 		}
 	}

--- a/internal/runtime/loop/spec_json.go
+++ b/internal/runtime/loop/spec_json.go
@@ -3,74 +3,87 @@ package loop
 import (
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"time"
+
+	"github.com/nugget/thane-ai-agent/internal/model/router"
 )
 
 type specJSON struct {
-	Name                   string               `json:"name,omitempty"`
-	Enabled                bool                 `json:"enabled"`
-	Task                   string               `json:"task,omitempty"`
-	Profile                any                  `json:"profile,omitempty"`
-	Operation              Operation            `json:"operation,omitempty"`
-	Completion             Completion           `json:"completion,omitempty"`
-	Outputs                []OutputSpec         `json:"outputs,omitempty"`
-	Subscriptions          []EntitySubscription `json:"subscriptions,omitempty"`
-	Conditions             Conditions           `json:"conditions,omitempty"`
-	Tags                   []string             `json:"tags,omitempty"`
-	ExcludeTools           []string             `json:"exclude_tools,omitempty"`
-	SleepMin               string               `json:"sleep_min,omitempty"`
-	SleepMax               string               `json:"sleep_max,omitempty"`
-	SleepDefault           string               `json:"sleep_default,omitempty"`
-	Jitter                 *float64             `json:"jitter,omitempty"`
-	MaxDuration            string               `json:"max_duration,omitempty"`
-	MaxIter                int                  `json:"max_iter,omitempty"`
-	Supervisor             bool                 `json:"supervisor,omitempty"`
-	SupervisorProb         float64              `json:"supervisor_prob,omitempty"`
-	QualityFloor           int                  `json:"quality_floor,omitempty"`
-	SupervisorContext      string               `json:"supervisor_context,omitempty"`
-	SupervisorQualityFloor int                  `json:"supervisor_quality_floor,omitempty"`
-	OnRetrigger            string               `json:"on_retrigger,omitempty"`
-	RoutingFactors         map[string]string    `json:"routing_factors,omitempty"`
-	DelegationGating       string               `json:"delegation_gating,omitempty"`
-	FallbackContent        string               `json:"fallback_content,omitempty"`
-	Metadata               map[string]string    `json:"metadata,omitempty"`
-	ParentID               string               `json:"parent_id,omitempty"`
-	ParentName             string               `json:"parent_name,omitempty"`
+	Name              string               `json:"name,omitempty"`
+	Enabled           bool                 `json:"enabled"`
+	Task              string               `json:"task,omitempty"`
+	Profile           any                  `json:"profile,omitempty"`
+	Operation         Operation            `json:"operation,omitempty"`
+	Completion        Completion           `json:"completion,omitempty"`
+	Outputs           []OutputSpec         `json:"outputs,omitempty"`
+	Subscriptions     []EntitySubscription `json:"subscriptions,omitempty"`
+	Conditions        Conditions           `json:"conditions,omitempty"`
+	Tags              []string             `json:"tags,omitempty"`
+	ExcludeTools      []string             `json:"exclude_tools,omitempty"`
+	SleepMin          string               `json:"sleep_min,omitempty"`
+	SleepMax          string               `json:"sleep_max,omitempty"`
+	SleepDefault      string               `json:"sleep_default,omitempty"`
+	Jitter            *float64             `json:"jitter,omitempty"`
+	MaxDuration       string               `json:"max_duration,omitempty"`
+	MaxIter           int                  `json:"max_iter,omitempty"`
+	Supervisor        bool                 `json:"supervisor,omitempty"`
+	SupervisorProb    float64              `json:"supervisor_prob,omitempty"`
+	SupervisorProfile any                  `json:"supervisor_profile,omitempty"`
+	OnRetrigger       string               `json:"on_retrigger,omitempty"`
+	RoutingFactors    map[string]string    `json:"routing_factors,omitempty"`
+	DelegationGating  string               `json:"delegation_gating,omitempty"`
+	FallbackContent   string               `json:"fallback_content,omitempty"`
+	Metadata          map[string]string    `json:"metadata,omitempty"`
+	ParentID          string               `json:"parent_id,omitempty"`
+	ParentName        string               `json:"parent_name,omitempty"`
+
+	// Legacy top-level fields, accepted on UnmarshalJSON for backwards
+	// compatibility with persisted overlay specs written before the
+	// PR-R1 routing-surface unification. Translated into Profile /
+	// SupervisorProfile on load with a one-shot WARN log. Never
+	// emitted by MarshalJSON — new persists use the canonical shape.
+	LegacyQualityFloor           int    `json:"quality_floor,omitempty"`
+	LegacySupervisorContext      string `json:"supervisor_context,omitempty"`
+	LegacySupervisorQualityFloor int    `json:"supervisor_quality_floor,omitempty"`
 }
 
 // MarshalJSON renders a loop spec in a human-facing contract shape
-// suitable for APIs and tools: durations are strings and retrigger mode is
-// named instead of using the engine's integer form.
+// suitable for APIs and tools: durations are strings and retrigger
+// mode is named instead of using the engine's integer form.
+// Supervisor routing overrides emit as `supervisor_profile` (nil
+// omits the field); the legacy top-level `quality_floor`,
+// `supervisor_quality_floor`, and `supervisor_context` fields are
+// no longer emitted — they only round-trip through UnmarshalJSON
+// for backwards compatibility with pre-PR-R1 persisted specs.
 func (s Spec) MarshalJSON() ([]byte, error) {
 	wire := specJSON{
-		Name:                   s.Name,
-		Enabled:                s.Enabled,
-		Task:                   s.Task,
-		Profile:                s.Profile,
-		Operation:              s.Operation,
-		Completion:             s.Completion,
-		Outputs:                cloneOutputs(s.Outputs),
-		Subscriptions:          cloneEntitySubscriptions(s.Subscriptions),
-		Conditions:             s.Conditions,
-		Tags:                   s.Tags,
-		ExcludeTools:           s.ExcludeTools,
-		SleepMin:               durationString(s.SleepMin),
-		SleepMax:               durationString(s.SleepMax),
-		SleepDefault:           durationString(s.SleepDefault),
-		Jitter:                 s.Jitter,
-		MaxDuration:            durationString(s.MaxDuration),
-		MaxIter:                s.MaxIter,
-		Supervisor:             s.Supervisor,
-		SupervisorProb:         s.SupervisorProb,
-		QualityFloor:           s.QualityFloor,
-		SupervisorContext:      s.SupervisorContext,
-		SupervisorQualityFloor: s.SupervisorQualityFloor,
-		RoutingFactors:         s.RoutingFactors,
-		DelegationGating:       s.DelegationGating,
-		FallbackContent:        s.FallbackContent,
-		Metadata:               s.Metadata,
-		ParentID:               s.ParentID,
-		ParentName:             s.ParentName,
+		Name:              s.Name,
+		Enabled:           s.Enabled,
+		Task:              s.Task,
+		Profile:           s.Profile,
+		Operation:         s.Operation,
+		Completion:        s.Completion,
+		Outputs:           cloneOutputs(s.Outputs),
+		Subscriptions:     cloneEntitySubscriptions(s.Subscriptions),
+		Conditions:        s.Conditions,
+		Tags:              s.Tags,
+		ExcludeTools:      s.ExcludeTools,
+		SleepMin:          durationString(s.SleepMin),
+		SleepMax:          durationString(s.SleepMax),
+		SleepDefault:      durationString(s.SleepDefault),
+		Jitter:            s.Jitter,
+		MaxDuration:       durationString(s.MaxDuration),
+		MaxIter:           s.MaxIter,
+		Supervisor:        s.Supervisor,
+		SupervisorProb:    s.SupervisorProb,
+		SupervisorProfile: s.SupervisorProfile,
+		RoutingFactors:    s.RoutingFactors,
+		DelegationGating:  s.DelegationGating,
+		FallbackContent:   s.FallbackContent,
+		Metadata:          s.Metadata,
+		ParentID:          s.ParentID,
+		ParentName:        s.ParentName,
 	}
 	onRetrigger, err := s.OnRetrigger.MarshalText()
 	if err != nil {
@@ -125,34 +138,31 @@ func (s *Spec) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("loop: %w", err)
 	}
 	*s = Spec{
-		Name:                   wire.Name,
-		Enabled:                wire.Enabled,
-		Task:                   wire.Task,
-		Operation:              wire.Operation,
-		Completion:             wire.Completion,
-		Outputs:                cloneOutputs(wire.Outputs),
-		Subscriptions:          normalizedSubs,
-		Conditions:             cloneConditions(wire.Conditions),
-		Tags:                   append([]string(nil), wire.Tags...),
-		ExcludeTools:           append([]string(nil), wire.ExcludeTools...),
-		SleepMin:               sleepMin,
-		SleepMax:               sleepMax,
-		SleepDefault:           sleepDefault,
-		Jitter:                 cloneFloat64Ptr(wire.Jitter),
-		MaxDuration:            maxDuration,
-		MaxIter:                wire.MaxIter,
-		Supervisor:             wire.Supervisor,
-		SupervisorProb:         wire.SupervisorProb,
-		QualityFloor:           wire.QualityFloor,
-		SupervisorContext:      wire.SupervisorContext,
-		SupervisorQualityFloor: wire.SupervisorQualityFloor,
-		OnRetrigger:            onRetrigger,
-		RoutingFactors:         cloneStringMap(wire.RoutingFactors),
-		DelegationGating:       wire.DelegationGating,
-		FallbackContent:        wire.FallbackContent,
-		Metadata:               cloneStringMap(wire.Metadata),
-		ParentID:               wire.ParentID,
-		ParentName:             wire.ParentName,
+		Name:             wire.Name,
+		Enabled:          wire.Enabled,
+		Task:             wire.Task,
+		Operation:        wire.Operation,
+		Completion:       wire.Completion,
+		Outputs:          cloneOutputs(wire.Outputs),
+		Subscriptions:    normalizedSubs,
+		Conditions:       cloneConditions(wire.Conditions),
+		Tags:             append([]string(nil), wire.Tags...),
+		ExcludeTools:     append([]string(nil), wire.ExcludeTools...),
+		SleepMin:         sleepMin,
+		SleepMax:         sleepMax,
+		SleepDefault:     sleepDefault,
+		Jitter:           cloneFloat64Ptr(wire.Jitter),
+		MaxDuration:      maxDuration,
+		MaxIter:          wire.MaxIter,
+		Supervisor:       wire.Supervisor,
+		SupervisorProb:   wire.SupervisorProb,
+		OnRetrigger:      onRetrigger,
+		RoutingFactors:   cloneStringMap(wire.RoutingFactors),
+		DelegationGating: wire.DelegationGating,
+		FallbackContent:  wire.FallbackContent,
+		Metadata:         cloneStringMap(wire.Metadata),
+		ParentID:         wire.ParentID,
+		ParentName:       wire.ParentName,
 	}
 	profileData, err := json.Marshal(wire.Profile)
 	if err != nil {
@@ -163,7 +173,69 @@ func (s *Spec) UnmarshalJSON(data []byte) error {
 			return fmt.Errorf("loop: profile: %w", err)
 		}
 	}
+	supervisorProfileData, err := json.Marshal(wire.SupervisorProfile)
+	if err != nil {
+		return err
+	}
+	if len(supervisorProfileData) != 0 && string(supervisorProfileData) != "null" {
+		var sp router.LoopProfile
+		if err := json.Unmarshal(supervisorProfileData, &sp); err != nil {
+			return fmt.Errorf("loop: supervisor_profile: %w", err)
+		}
+		s.SupervisorProfile = &sp
+	}
+	// Migration shim for pre-PR-R1 persisted specs: translate the
+	// legacy top-level quality_floor / supervisor_quality_floor /
+	// supervisor_context fields into the canonical Profile /
+	// SupervisorProfile shape. New fields win on collision —
+	// callers writing the new shape don't get clobbered by
+	// stragglers left in the JSON. Log once per migrated spec at
+	// WARN so operators can audit what's being upgraded.
+	migrateLegacyRoutingFields(s, wire, slog.Default())
 	return nil
+}
+
+// migrateLegacyRoutingFields rewrites legacy top-level routing
+// fields onto the spec's [Profile] / [SupervisorProfile] surfaces.
+// Idempotent: a fully-migrated spec carries empty legacy fields
+// and the function is a no-op. Exposed at package scope so the
+// regression tests can drive it directly without round-tripping
+// JSON.
+func migrateLegacyRoutingFields(s *Spec, wire specJSON, logger *slog.Logger) {
+	if s == nil {
+		return
+	}
+	migrated := false
+	if wire.LegacyQualityFloor > 0 && s.Profile.QualityFloor == "" {
+		s.Profile.QualityFloor = fmt.Sprintf("%d", wire.LegacyQualityFloor)
+		migrated = true
+	}
+	if wire.LegacySupervisorQualityFloor > 0 {
+		if s.SupervisorProfile == nil {
+			s.SupervisorProfile = &router.LoopProfile{}
+		}
+		if s.SupervisorProfile.QualityFloor == "" {
+			s.SupervisorProfile.QualityFloor = fmt.Sprintf("%d", wire.LegacySupervisorQualityFloor)
+			migrated = true
+		}
+	}
+	if wire.LegacySupervisorContext != "" {
+		if s.SupervisorProfile == nil {
+			s.SupervisorProfile = &router.LoopProfile{}
+		}
+		if s.SupervisorProfile.Instructions == "" {
+			s.SupervisorProfile.Instructions = wire.LegacySupervisorContext
+			migrated = true
+		}
+	}
+	if migrated && logger != nil {
+		logger.Warn("migrated pre-PR-R1 routing fields onto Profile/SupervisorProfile during spec hydration",
+			"loop_name", s.Name,
+			"legacy_quality_floor", wire.LegacyQualityFloor,
+			"legacy_supervisor_quality_floor", wire.LegacySupervisorQualityFloor,
+			"legacy_supervisor_context_set", wire.LegacySupervisorContext != "",
+		)
+	}
 }
 
 func durationString(d time.Duration) string {

--- a/internal/runtime/loop/spec_test.go
+++ b/internal/runtime/loop/spec_test.go
@@ -55,7 +55,7 @@ func TestSpecValidate(t *testing.T) {
 			Name: "bad-profile",
 			Task: "Do something.",
 			Profile: router.LoopProfile{
-				QualityFloor: "99",
+				QualityFloor: 99,
 			},
 		}
 		err := spec.Validate()

--- a/internal/runtime/loop/supervisor_trigger_test.go
+++ b/internal/runtime/loop/supervisor_trigger_test.go
@@ -1,0 +1,185 @@
+package loop
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// TestShouldRunSupervisor pins the three-way contract of the
+// post-PR-F2 supervisor decision: forced beats random beats none.
+// Tests the predicate directly so it can be exercised without
+// driving a full loop.
+func TestShouldRunSupervisor(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name           string
+		supervisor     bool
+		supervisorProb float64
+		randValue      float64
+		forced         bool
+		wantBool       bool
+		wantTrigger    SupervisorTrigger
+	}{
+		{
+			name:        "forced wins over disabled supervisor",
+			supervisor:  false,
+			forced:      true,
+			wantBool:    true,
+			wantTrigger: SupervisorTriggerForced,
+		},
+		{
+			name:           "forced wins over random",
+			supervisor:     true,
+			supervisorProb: 1.0,
+			randValue:      0.5,
+			forced:         true,
+			wantBool:       true,
+			wantTrigger:    SupervisorTriggerForced,
+		},
+		{
+			name:           "random fires when supervisor enabled and dice come up",
+			supervisor:     true,
+			supervisorProb: 0.5,
+			randValue:      0.4,
+			forced:         false,
+			wantBool:       true,
+			wantTrigger:    SupervisorTriggerRandom,
+		},
+		{
+			name:           "random does not fire when dice exceed prob",
+			supervisor:     true,
+			supervisorProb: 0.5,
+			randValue:      0.6,
+			forced:         false,
+			wantBool:       false,
+			wantTrigger:    SupervisorTriggerNone,
+		},
+		{
+			name:           "random does not fire when supervisor disabled",
+			supervisor:     false,
+			supervisorProb: 1.0,
+			randValue:      0.0,
+			forced:         false,
+			wantBool:       false,
+			wantTrigger:    SupervisorTriggerNone,
+		},
+		{
+			name:           "random does not fire when prob is zero",
+			supervisor:     true,
+			supervisorProb: 0.0,
+			randValue:      0.0,
+			forced:         false,
+			wantBool:       false,
+			wantTrigger:    SupervisorTriggerNone,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			l := &Loop{
+				config: Config{
+					Supervisor:     tc.supervisor,
+					SupervisorProb: tc.supervisorProb,
+				},
+				deps: Deps{Rand: fixedRand{tc.randValue}},
+			}
+			gotBool, gotTrigger := l.shouldRunSupervisor(tc.forced)
+			if gotBool != tc.wantBool {
+				t.Errorf("isSupervisor = %v, want %v", gotBool, tc.wantBool)
+			}
+			if gotTrigger != tc.wantTrigger {
+				t.Errorf("trigger = %q, want %q", gotTrigger, tc.wantTrigger)
+			}
+		})
+	}
+}
+
+// TestSupervisorTriggerStampedOnIterationRecord exercises the
+// end-to-end plumbing: a loop with SupervisorProb=1.0 should
+// produce iteration records carrying SupervisorTrigger="random",
+// and the loop's Status() should report the same value on
+// LastSupervisorTrigger. Without this, retrospection on
+// supervisor cadence would see "this iteration was a supervisor
+// turn" but lose the cause.
+func TestSupervisorTriggerStampedOnIterationRecord(t *testing.T) {
+	t.Parallel()
+
+	var iterSnapshots atomic.Int32
+	var lastTrigger atomic.Value // SupervisorTrigger
+	runner := &inspectingRunner{
+		onRun: func(req RunRequest) {
+			iterSnapshots.Add(1)
+		},
+	}
+	l, err := New(Config{
+		Name:           "trigger-test",
+		Task:           "t",
+		SleepMin:       time.Millisecond,
+		SleepMax:       2 * time.Millisecond,
+		SleepDefault:   time.Millisecond,
+		Jitter:         Float64Ptr(0),
+		MaxIter:        2,
+		Supervisor:     true,
+		SupervisorProb: 1.0, // every iteration is supervisor
+	}, Deps{Runner: runner, Rand: fixedRand{0.5}})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	_ = l.Start(context.Background())
+	<-l.Done()
+
+	status := l.Status()
+	if status.LastSupervisorIter == 0 {
+		t.Fatal("LastSupervisorIter is zero — no supervisor turn ran")
+	}
+	if status.LastSupervisorTrigger != SupervisorTriggerRandom {
+		t.Errorf("LastSupervisorTrigger = %q, want %q (Bernoulli at prob=1.0)",
+			status.LastSupervisorTrigger, SupervisorTriggerRandom)
+	}
+	if len(status.RecentIterations) == 0 {
+		t.Fatal("no iteration snapshots recorded")
+	}
+	for i, snap := range status.RecentIterations {
+		if !snap.Supervisor {
+			t.Errorf("snap[%d].Supervisor = false; want true (prob=1.0)", i)
+		}
+		if snap.SupervisorTrigger != SupervisorTriggerRandom {
+			t.Errorf("snap[%d].SupervisorTrigger = %q, want %q",
+				i, snap.SupervisorTrigger, SupervisorTriggerRandom)
+			lastTrigger.Store(snap.SupervisorTrigger)
+		}
+	}
+}
+
+// TestSupervisorTriggerForcedFromNotification covers the
+// alternate plumbing: a notification with force_supervisor=true
+// must produce SupervisorTrigger="forced" on the iteration
+// record. We can't easily drive a real notification through
+// here, so we exercise shouldRunSupervisor with forced=true to
+// validate the contract — the upstream caller's
+// consumePendingNotifies path is tested elsewhere.
+func TestSupervisorTriggerForcedFromNotification(t *testing.T) {
+	t.Parallel()
+
+	// Construct a loop whose normal random path would also pick
+	// supervisor (prob=1.0). Forced should still produce
+	// "forced", not "random" — the typed cause distinguishes
+	// the two even when both are "true."
+	l := &Loop{
+		config: Config{
+			Supervisor:     true,
+			SupervisorProb: 1.0,
+		},
+		deps: Deps{Rand: fixedRand{0.0}},
+	}
+	isSup, trigger := l.shouldRunSupervisor(true)
+	if !isSup {
+		t.Fatal("forced=true didn't produce supervisor turn")
+	}
+	if trigger != SupervisorTriggerForced {
+		t.Errorf("trigger = %q, want %q (forced beats random)", trigger, SupervisorTriggerForced)
+	}
+}

--- a/internal/runtime/metacognitive/metacognitive.go
+++ b/internal/runtime/metacognitive/metacognitive.go
@@ -183,7 +183,7 @@ func DefinitionSpec(cfg Config) loop.Spec {
 		Profile: router.LoopProfile{
 			Mission:          "metacognitive",
 			DelegationGating: "disabled",
-			QualityFloor:     fmt.Sprintf("%d", cfg.QualityFloor),
+			QualityFloor:     cfg.QualityFloor,
 			ExtraHints:       map[string]string{"source": "metacognitive"},
 		},
 		SupervisorProfile: supervisorProfile(cfg.SupervisorQualityFloor),
@@ -206,7 +206,7 @@ func supervisorProfile(qualityFloor int) *router.LoopProfile {
 		return nil
 	}
 	return &router.LoopProfile{
-		QualityFloor: fmt.Sprintf("%d", qualityFloor),
+		QualityFloor: qualityFloor,
 	}
 }
 

--- a/internal/runtime/metacognitive/metacognitive.go
+++ b/internal/runtime/metacognitive/metacognitive.go
@@ -6,9 +6,12 @@
 // via a markdown file (metacognitive.md by default). The loop's cost is
 // self-limiting: quiet periods produce long sleeps and few iterations.
 //
-// "Dice" randomly select a frontier model for supervisor turns that
-// review the loop's own behavior, catching blind spots that the cheaper
-// local model's consistent reasoning patterns miss.
+// Supervisor turns randomly select a frontier model to review the
+// loop's own behavior, catching blind spots that the cheaper local
+// model's consistent reasoning patterns miss. The per-wake
+// probability is driven by [Config.SupervisorProbability]; when a
+// supervisor turn fires, the loop overlays
+// [Spec.SupervisorProfile] on its normal routing.
 //
 // The loop lifecycle is managed by the [loop] package. This package
 // provides [BuildLoopConfig] to assemble a [loop.Config] with the
@@ -180,17 +183,30 @@ func DefinitionSpec(cfg Config) loop.Spec {
 		Profile: router.LoopProfile{
 			Mission:          "metacognitive",
 			DelegationGating: "disabled",
+			QualityFloor:     fmt.Sprintf("%d", cfg.QualityFloor),
 			ExtraHints:       map[string]string{"source": "metacognitive"},
 		},
+		SupervisorProfile: supervisorProfile(cfg.SupervisorQualityFloor),
 
-		Supervisor:             cfg.SupervisorProbability > 0,
-		SupervisorProb:         cfg.SupervisorProbability,
-		QualityFloor:           cfg.QualityFloor,
-		SupervisorQualityFloor: cfg.SupervisorQualityFloor,
+		Supervisor:     cfg.SupervisorProbability > 0,
+		SupervisorProb: cfg.SupervisorProbability,
 		Metadata: map[string]string{
 			"subsystem": "metacognitive",
 			"category":  "service",
 		},
+	}
+}
+
+// supervisorProfile builds the metacognitive service's per-turn-
+// mode overrides from the supervisor router config. Returns nil
+// when no overrides are declared, signaling the loop runtime to
+// reuse the normal Profile during supervisor turns.
+func supervisorProfile(qualityFloor int) *router.LoopProfile {
+	if qualityFloor <= 0 {
+		return nil
+	}
+	return &router.LoopProfile{
+		QualityFloor: fmt.Sprintf("%d", qualityFloor),
 	}
 }
 
@@ -217,11 +233,11 @@ func HydrateSpec(spec loop.Spec, cfg Config, opts Opts) loop.Spec {
 // output document and uses runtime hooks to build prompts and
 // append iteration logs.
 func BuildSpec(cfg Config, opts Opts) loop.Spec {
-	spec := DefinitionSpec(cfg)
 	// TaskBuilder handles supervisor augmentation itself via
-	// prompts.MetacognitivePrompt, so SupervisorContext is empty.
-	spec.SupervisorContext = ""
-	return HydrateSpec(spec, cfg, opts)
+	// prompts.MetacognitivePrompt, so SupervisorProfile.Instructions
+	// is left unset; the per-turn prompt prefix comes from the
+	// prompts package rather than the spec-level overlay.
+	return HydrateSpec(DefinitionSpec(cfg), cfg, opts)
 }
 
 // BuildLoopConfig returns the engine-facing [loop.Config] view of the

--- a/internal/runtime/metacognitive/metacognitive_test.go
+++ b/internal/runtime/metacognitive/metacognitive_test.go
@@ -41,8 +41,8 @@ func TestParseConfig_Valid(t *testing.T) {
 		DefaultSleep:          "10m",
 		Jitter:                &jitter,
 		SupervisorProbability: &supervisor,
-		Router:                config.MetacognitiveRouterConfig{QualityFloor: 3},
-		SupervisorRouter:      config.MetacognitiveRouterConfig{QualityFloor: 8},
+		Router:                config.RouterConfig{QualityFloor: 3},
+		SupervisorRouter:      config.RouterConfig{QualityFloor: 8},
 	}
 
 	cfg, err := ParseConfig(raw)

--- a/internal/server/api/model_profiles.go
+++ b/internal/server/api/model_profiles.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"fmt"
 	"log/slog"
 
 	"github.com/nugget/thane-ai-agent/internal/model/router"
@@ -12,16 +11,19 @@ import (
 // prompt. The systemPrompt return is reserved for future virtual
 // models that want to inject prompt scaffolding; today it is always
 // empty.
-func normalizeModelSelection(rawModel string, hints map[string]string, premiumFloor string, logger *slog.Logger) (model string, factors map[string]string, delegationGating string, systemPrompt string) {
+func normalizeModelSelection(rawModel string, hints map[string]string, premiumFloor int, logger *slog.Logger) (model string, factors map[string]string, delegationGating string, systemPrompt string) {
 	selection := router.ResolveVirtualModelSelection(rawModel, hints, router.VirtualModelRuntime{
 		PremiumQualityFloor: premiumFloor,
 	}, logger)
 	return selection.Model, selection.RoutingFactors, selection.DelegationGating, ""
 }
 
-func premiumQualityFloor(rtr *router.Router) string {
+// premiumQualityFloor returns the QualityFloor stamped on premium /
+// ops virtual models. Falls back to 10 when no router is wired
+// (test paths), so the result is always a usable int.
+func premiumQualityFloor(rtr *router.Router) int {
 	if rtr == nil {
-		return "10"
+		return 10
 	}
-	return fmt.Sprintf("%d", rtr.MaxQuality())
+	return rtr.MaxQuality()
 }

--- a/internal/server/api/model_profiles_test.go
+++ b/internal/server/api/model_profiles_test.go
@@ -11,7 +11,7 @@ func TestNormalizeModelSelection(t *testing.T) {
 		name                 string
 		rawModel             string
 		hints                map[string]string
-		premiumFloor         string
+		premiumFloor         int
 		wantModel            string
 		wantSystemPrompt     bool
 		wantHintKey          string
@@ -22,14 +22,14 @@ func TestNormalizeModelSelection(t *testing.T) {
 			name:         "default latest profile",
 			rawModel:     "thane:latest",
 			hints:        map[string]string{"channel": "api"},
-			premiumFloor: "8",
+			premiumFloor: 8,
 			wantModel:    "",
 		},
 		{
 			name:          "premium profile",
 			rawModel:      "thane:premium",
 			hints:         map[string]string{"channel": "api"},
-			premiumFloor:  "8",
+			premiumFloor:  8,
 			wantModel:     "",
 			wantHintKey:   router.FactorQualityFloor,
 			wantHintValue: "8",
@@ -38,7 +38,7 @@ func TestNormalizeModelSelection(t *testing.T) {
 			name:          "assist alias profile",
 			rawModel:      "thane:command",
 			hints:         map[string]string{"channel": "api"},
-			premiumFloor:  "8",
+			premiumFloor:  8,
 			wantModel:     "",
 			wantHintKey:   router.FactorMission,
 			wantHintValue: "device_control",
@@ -47,7 +47,7 @@ func TestNormalizeModelSelection(t *testing.T) {
 			name:                 "ops profile",
 			rawModel:             "thane:ops",
 			hints:                map[string]string{"channel": "api"},
-			premiumFloor:         "8",
+			premiumFloor:         8,
 			wantModel:            "",
 			wantDelegationGating: "disabled",
 		},
@@ -55,14 +55,14 @@ func TestNormalizeModelSelection(t *testing.T) {
 			name:         "explicit deployment preserved",
 			rawModel:     "spark/gpt-oss:20b",
 			hints:        map[string]string{"channel": "api"},
-			premiumFloor: "8",
+			premiumFloor: 8,
 			wantModel:    "spark/gpt-oss:20b",
 		},
 		{
 			name:         "unknown thane profile falls back",
 			rawModel:     "thane:unknown",
 			hints:        map[string]string{"channel": "api"},
-			premiumFloor: "8",
+			premiumFloor: 8,
 			wantModel:    "",
 		},
 	}

--- a/internal/tools/forge_subscription_tools.go
+++ b/internal/tools/forge_subscription_tools.go
@@ -93,7 +93,7 @@ func forgeWakeLoopDefinition() map[string]any {
 			},
 			"force_supervisor": map[string]any{
 				"type":        "boolean",
-				"description": "When true, force the target loop's next iteration to use supervisor routing.",
+				"description": "When true, force the target loop's next iteration to run as a supervisor turn (the more capable model with the augmented prompt). Costlier than a normal wake — reserve for signals that genuinely warrant the extra capacity.",
 			},
 			"priority": map[string]any{
 				"type":        "string",

--- a/internal/tools/loop_runtime_tools.go
+++ b/internal/tools/loop_runtime_tools.go
@@ -17,27 +17,28 @@ const (
 )
 
 type loopStatusView struct {
-	ID                 string             `json:"id"`
-	Name               string             `json:"name"`
-	State              looppkg.State      `json:"state"`
-	Operation          looppkg.Operation  `json:"operation,omitempty"`
-	Completion         looppkg.Completion `json:"completion,omitempty"`
-	ParentID           string             `json:"parent_id,omitempty"`
-	StartedAt          time.Time          `json:"started_at"`
-	LastWakeAt         time.Time          `json:"last_wake_at,omitempty"`
-	Iterations         int                `json:"iterations"`
-	Attempts           int                `json:"attempts"`
-	TotalInputTokens   int                `json:"total_input_tokens"`
-	TotalOutputTokens  int                `json:"total_output_tokens"`
-	LastInputTokens    int                `json:"last_input_tokens,omitempty"`
-	LastOutputTokens   int                `json:"last_output_tokens,omitempty"`
-	LastError          string             `json:"last_error,omitempty"`
-	ConsecutiveErrors  int                `json:"consecutive_errors,omitempty"`
-	HandlerOnly        bool               `json:"handler_only,omitempty"`
-	EventDriven        bool               `json:"event_driven,omitempty"`
-	LastSupervisorIter int                `json:"last_supervisor_iter,omitempty"`
-	ActiveTags         []string           `json:"active_tags,omitempty"`
-	Metadata           map[string]string  `json:"metadata,omitempty"`
+	ID                    string             `json:"id"`
+	Name                  string             `json:"name"`
+	State                 looppkg.State      `json:"state"`
+	Operation             looppkg.Operation  `json:"operation,omitempty"`
+	Completion            looppkg.Completion `json:"completion,omitempty"`
+	ParentID              string             `json:"parent_id,omitempty"`
+	StartedAt             time.Time          `json:"started_at"`
+	LastWakeAt            time.Time          `json:"last_wake_at,omitempty"`
+	Iterations            int                `json:"iterations"`
+	Attempts              int                `json:"attempts"`
+	TotalInputTokens      int                `json:"total_input_tokens"`
+	TotalOutputTokens     int                `json:"total_output_tokens"`
+	LastInputTokens       int                `json:"last_input_tokens,omitempty"`
+	LastOutputTokens      int                `json:"last_output_tokens,omitempty"`
+	LastError             string             `json:"last_error,omitempty"`
+	ConsecutiveErrors     int                `json:"consecutive_errors,omitempty"`
+	HandlerOnly           bool               `json:"handler_only,omitempty"`
+	EventDriven           bool               `json:"event_driven,omitempty"`
+	LastSupervisorIter    int                `json:"last_supervisor_iter,omitempty"`
+	LastSupervisorTrigger string             `json:"last_supervisor_trigger,omitempty"`
+	ActiveTags            []string           `json:"active_tags,omitempty"`
+	Metadata              map[string]string  `json:"metadata,omitempty"`
 }
 
 // LoopRuntimeToolDeps wires the live loop registry and ad hoc launch path
@@ -398,27 +399,28 @@ func matchLoopStatus(status looppkg.Status, query, state string, operation loopp
 
 func summarizeLoopStatus(status looppkg.Status) loopStatusView {
 	return loopStatusView{
-		ID:                 status.ID,
-		Name:               status.Name,
-		State:              status.State,
-		Operation:          status.Config.Operation,
-		Completion:         status.Config.Completion,
-		ParentID:           status.ParentID,
-		StartedAt:          status.StartedAt,
-		LastWakeAt:         status.LastWakeAt,
-		Iterations:         status.Iterations,
-		Attempts:           status.Attempts,
-		TotalInputTokens:   status.TotalInputTokens,
-		TotalOutputTokens:  status.TotalOutputTokens,
-		LastInputTokens:    status.LastInputTokens,
-		LastOutputTokens:   status.LastOutputTokens,
-		LastError:          status.LastError,
-		ConsecutiveErrors:  status.ConsecutiveErrors,
-		HandlerOnly:        status.HandlerOnly,
-		EventDriven:        status.EventDriven,
-		LastSupervisorIter: status.LastSupervisorIter,
-		ActiveTags:         append([]string(nil), status.ActiveTags...),
-		Metadata:           cloneLoopMetadata(status.Config.Metadata),
+		ID:                    status.ID,
+		Name:                  status.Name,
+		State:                 status.State,
+		Operation:             status.Config.Operation,
+		Completion:            status.Config.Completion,
+		ParentID:              status.ParentID,
+		StartedAt:             status.StartedAt,
+		LastWakeAt:            status.LastWakeAt,
+		Iterations:            status.Iterations,
+		Attempts:              status.Attempts,
+		TotalInputTokens:      status.TotalInputTokens,
+		TotalOutputTokens:     status.TotalOutputTokens,
+		LastInputTokens:       status.LastInputTokens,
+		LastOutputTokens:      status.LastOutputTokens,
+		LastError:             status.LastError,
+		ConsecutiveErrors:     status.ConsecutiveErrors,
+		HandlerOnly:           status.HandlerOnly,
+		EventDriven:           status.EventDriven,
+		LastSupervisorIter:    status.LastSupervisorIter,
+		LastSupervisorTrigger: string(status.LastSupervisorTrigger),
+		ActiveTags:            append([]string(nil), status.ActiveTags...),
+		Metadata:              cloneLoopMetadata(status.Config.Metadata),
 	}
 }
 


### PR DESCRIPTION
## Summary

`LoopProfile.QualityFloor` was awkwardly string-typed even though every validator clamped it to integers 1–10. YAML configs read `quality_floor: "5"` (quoted), Go literals read `QualityFloor: "5"` (string-of-int) — both fighting the underlying semantics. This PR completes the type cleanup the routing-surface unification (PR-R1) deferred.

## What changed

- **`router.LoopProfile.QualityFloor` is now `int`.** `Validate()` operates on the int directly. `RoutingFactors()` does the int→string conversion at the map boundary so the flat `map[string]string` wire format the model router consumes is unchanged.

- **~30 call sites** updated to use int literals across the codebase: built-in services (metacog, ego), config example, tools (mqtt, taskexec), tests, etc.

- **`router.VirtualModelRuntime.PremiumQualityFloor`** also becomes int; same cleanup for the chained `api.normalizeModelSelection` / `api.premiumQualityFloor` helpers.

- **`mqtt.Tools`** now emits int in `HandleListWakeSubscriptions`. `HandleAddWakeSubscription` accepts both int and string-of-int from tool arguments via a new `intArg` helper.

## Backwards compatibility — no migration needed

Persisted overlay specs and operator YAML configs written before this change still load cleanly. `LoopProfile` got a custom `UnmarshalJSON` that accepts both forms:

| Input | Result |
|---|---|
| `{"quality_floor": 5}` | canonical int form → `5` |
| `{"quality_floor": "5"}` | legacy string form → `5` |
| missing / null / `""` / whitespace string | zero ("unset") |
| `"high"`, bool, array, etc. | loud `UnmarshalJSON` failure |

No migration step needed — the next persist writes the int form, and old YAML configs keep working until the operator chooses to clean them up.

## SignalRoutingConfig untouched

`config.SignalRoutingConfig.QualityFloor` stays string-shaped in its own YAML schema for now. Atoi at the boundary in `SignalRoutingConfig.LoopProfile()`. Converting Signal's operator-facing config is a separate cleanup — out of scope for this routing-surface PR.

## Test plan

- [x] `just ci` passes locally
- [x] New `internal/model/router/loopprofile_int_compat_test.go` — 5 sub-suites:
  - `TestLoopProfileUnmarshalQualityFloorAcceptsInt` (canonical)
  - `TestLoopProfileUnmarshalQualityFloorAcceptsLegacyString` (backwards-compat)
  - `TestLoopProfileUnmarshalQualityFloorEmptyOrMissingIsZero` (missing/null/empty/whitespace → 0)
  - `TestLoopProfileUnmarshalQualityFloorMalformedFails` (garbage values are loud)
  - `TestLoopProfileMarshalEmitsIntQualityFloor` (marshal never regresses to string)
- [x] All existing test suites still pass with int literals
- [ ] Manual: confirm a pre-PR-Q1 persisted overlay spec hydrates with the right `QualityFloor` after deploy

## Stacked on

Built on top of `codex/supervisor-decision-provenance` (PR #899) which is on top of `codex/routing-surface-unification` (PR #898). Once those merge in order, this PR's diff collapses to just the int-conversion work above.

Refs #889