### PR TITLE
refactor: unify MQTT wake dispatch with forge/media event-source pattern (PR-T1)

### DIFF
--- a/examples/config.example.yaml
+++ b/examples/config.example.yaml
@@ -507,10 +507,20 @@ talents_dir: ./talents
 #     - # Topic is the MQTT topic filter (e.g., "homeassistant/+/+/state",
 #       "frigate/events"). Supports MQTT wildcard characters.
 #       topic: homeassistant/+/+/state
-#       Wake, when non-nil, enables agent wake on this topic. Messages
-#       arriving on the topic trigger an agent conversation using the
-#       profile's routing configuration. When nil, messages are received
-#       for ambient awareness only (debug-logged, not acted upon).
+#       WakeLoop identifies an existing loop to receive matching MQTT
+#       messages as event-source notifications. Preferred dispatch
+#       route — the target loop's [Spec.Profile] governs routing.
+#       wake_loop:
+#         loopid: ""
+#         name: ""
+#         forcesupervisor: false
+#         priority: ""
+#         instructions: ""
+#       Wake is the legacy dispatch-via-spawn path: when non-nil and
+#       WakeLoop is unset, messages on this topic spawn a one-shot
+#       agent run using this routing profile. New subscriptions
+#       should use WakeLoop and let the target loop's own Profile
+#       govern routing instead.
 #       wake:
 #         model: ""
 #         quality_floor: 0
@@ -522,16 +532,26 @@ talents_dir: ./talents
 #         extra_hints: {}
 #         instructions: ""
 #       InitialTags lists capability tags activated at the start of the
-#       agent run dispatched for matching messages. Only meaningful when
-#       Wake is non-nil.
+#       spawn-dispatch agent run (legacy path). Only meaningful when
+#       Wake is non-nil and WakeLoop is unset.
 #       initial_tags: []
 #     - # Topic is the MQTT topic filter (e.g., "homeassistant/+/+/state",
 #       "frigate/events"). Supports MQTT wildcard characters.
 #       topic: frigate/events
-#       Wake, when non-nil, enables agent wake on this topic. Messages
-#       arriving on the topic trigger an agent conversation using the
-#       profile's routing configuration. When nil, messages are received
-#       for ambient awareness only (debug-logged, not acted upon).
+#       WakeLoop identifies an existing loop to receive matching MQTT
+#       messages as event-source notifications. Preferred dispatch
+#       route — the target loop's [Spec.Profile] governs routing.
+#       wake_loop:
+#         loopid: ""
+#         name: ""
+#         forcesupervisor: false
+#         priority: ""
+#         instructions: ""
+#       Wake is the legacy dispatch-via-spawn path: when non-nil and
+#       WakeLoop is unset, messages on this topic spawn a one-shot
+#       agent run using this routing profile. New subscriptions
+#       should use WakeLoop and let the target loop's own Profile
+#       govern routing instead.
 #       wake:
 #         model: ""
 #         quality_floor: 0
@@ -543,16 +563,26 @@ talents_dir: ./talents
 #         extra_hints: {}
 #         instructions: ""
 #       InitialTags lists capability tags activated at the start of the
-#       agent run dispatched for matching messages. Only meaningful when
-#       Wake is non-nil.
+#       spawn-dispatch agent run (legacy path). Only meaningful when
+#       Wake is non-nil and WakeLoop is unset.
 #       initial_tags: []
 #     - # Topic is the MQTT topic filter (e.g., "homeassistant/+/+/state",
 #       "frigate/events"). Supports MQTT wildcard characters.
 #       topic: automation/wake/security
-#       Wake, when non-nil, enables agent wake on this topic. Messages
-#       arriving on the topic trigger an agent conversation using the
-#       profile's routing configuration. When nil, messages are received
-#       for ambient awareness only (debug-logged, not acted upon).
+#       WakeLoop identifies an existing loop to receive matching MQTT
+#       messages as event-source notifications. Preferred dispatch
+#       route — the target loop's [Spec.Profile] governs routing.
+#       wake_loop:
+#         loopid: ""
+#         name: ""
+#         forcesupervisor: false
+#         priority: ""
+#         instructions: ""
+#       Wake is the legacy dispatch-via-spawn path: when non-nil and
+#       WakeLoop is unset, messages on this topic spawn a one-shot
+#       agent run using this routing profile. New subscriptions
+#       should use WakeLoop and let the target loop's own Profile
+#       govern routing instead.
 #       wake:
 #         model: ""
 #         quality_floor: 7
@@ -564,8 +594,8 @@ talents_dir: ./talents
 #         extra_hints: {}
 #         instructions: Evaluate the security event and decide if action is needed.
 #       InitialTags lists capability tags activated at the start of the
-#       agent run dispatched for matching messages. Only meaningful when
-#       Wake is non-nil.
+#       spawn-dispatch agent run (legacy path). Only meaningful when
+#       Wake is non-nil and WakeLoop is unset.
 #       initial_tags:
 #         - homeassistant
 #   Telemetry configures operational metric publishing. When enabled,

--- a/internal/app/mqttwake.go
+++ b/internal/app/mqttwake.go
@@ -23,8 +23,17 @@ import (
 const maxWakePayloadBytes = 32 * 1024
 
 // mqttWakeTimeout bounds how long a single MQTT-triggered agent
-// conversation may run before being cancelled.
+// conversation may run before being cancelled. Applies to the
+// legacy spawn-dispatch path (one-shot loop run).
 const mqttWakeTimeout = 5 * time.Minute
+
+// mqttWakeDeliveryTimeout bounds the bus.Send call for the wake-
+// target dispatch path. Each MQTT message arrives in its own
+// goroutine; without this bound, a stuck downstream route handler
+// could leak goroutines under steady MQTT traffic. The actual
+// agent work happens in the target loop's next iteration on its
+// own clock — this only bounds the envelope-handoff hop.
+const mqttWakeDeliveryTimeout = 30 * time.Second
 
 // mqttWakeDeps holds optional dependencies for dashboard integration.
 // When registry is non-nil, each wake conversation is spawned as a
@@ -147,6 +156,11 @@ func mqttWakeHandler(
 // Failures (bus not configured, target loop not resolvable) are
 // logged at WARN and the message is dropped; the next matching
 // message gets the same treatment.
+//
+// Dispatch runs in a fresh goroutine per matching message (see the
+// fan-out in [mqttWakeHandler]). A bounded context bounds bus
+// delivery so a stuck/slow downstream route handler can't leak
+// goroutines indefinitely under a steady stream of MQTT traffic.
 func dispatchViaWakeTarget(deps mqttWakeDeps, ws mqtt.WakeSubscription, topic string, payload []byte, logger *slog.Logger) {
 	if deps.messageBus == nil {
 		logger.Warn("mqtt wake target dispatch unavailable, dropping message",
@@ -185,7 +199,9 @@ func dispatchViaWakeTarget(deps mqttWakeDeps, ws mqtt.WakeSubscription, topic st
 		return
 	}
 
-	if _, err := deps.messageBus.Send(context.Background(), env); err != nil {
+	deliveryCtx, cancel := context.WithTimeout(context.Background(), mqttWakeDeliveryTimeout)
+	defer cancel()
+	if _, err := deps.messageBus.Send(deliveryCtx, env); err != nil {
 		logger.Warn("mqtt wake envelope delivery failed, dropping message",
 			"subscription_id", ws.ID,
 			"topic", topic,

--- a/internal/app/mqttwake.go
+++ b/internal/app/mqttwake.go
@@ -10,6 +10,7 @@ import (
 	"time"
 	"unicode/utf8"
 
+	"github.com/nugget/thane-ai-agent/internal/channels/messages"
 	mqtt "github.com/nugget/thane-ai-agent/internal/channels/mqtt"
 	"github.com/nugget/thane-ai-agent/internal/model/router"
 	"github.com/nugget/thane-ai-agent/internal/platform/events"
@@ -28,10 +29,17 @@ const mqttWakeTimeout = 5 * time.Minute
 // mqttWakeDeps holds optional dependencies for dashboard integration.
 // When registry is non-nil, each wake conversation is spawned as a
 // child loop under parentID so it appears on the dashboard.
+//
+// messageBus, when non-nil, enables the wake-target dispatch path
+// for subscriptions that declare a WakeTarget — MQTT messages
+// produce a [messages.LoopEventPayload] delivered as a loop
+// notification to the target loop, instead of spawning a fresh
+// one-shot loop.
 type mqttWakeDeps struct {
-	registry *looppkg.Registry
-	eventBus *events.Bus
-	parentID *atomic.Value // stores string; populated lazily from the mqtt service loop
+	registry   *looppkg.Registry
+	messageBus *messages.Bus
+	eventBus   *events.Bus
+	parentID   *atomic.Value // stores string; populated lazily from the mqtt service loop
 }
 
 // mqttWakeHandler returns a MessageHandler that dispatches agent
@@ -71,9 +79,24 @@ func mqttWakeHandler(
 		// Fan-out: dispatch one agent conversation per matching
 		// subscription. Each gets its own goroutine so the MQTT
 		// message handler does not block the inbound message loop.
+		//
+		// Two dispatch shapes are supported per-subscription:
+		//
+		//   - Wake-target dispatch (preferred): subscription declares
+		//     an existing loop via WakeTarget; the MQTT message
+		//     becomes a [messages.LoopEventPayload] delivered via
+		//     [messages.NewEventSourceEnvelope]. No new loop spawned.
+		//
+		//   - Spawn dispatch (legacy): subscription has no WakeTarget;
+		//     each message spawns a fresh one-shot loop with the
+		//     subscription's Profile/InitialTags.
 		for _, ws := range matches {
 			ws := ws // capture loop variable
 			go func() {
+				if ws.HasWakeTarget() {
+					dispatchViaWakeTarget(deps, ws, topic, payload, logger)
+					return
+				}
 				convID := fmt.Sprintf("mqtt-wake-%s-%d", ws.ID, time.Now().UnixMilli())
 				msg := buildWakeMessage(topic, payload, ws.Profile.Instructions)
 
@@ -109,6 +132,77 @@ func mqttWakeHandler(
 			}()
 		}
 	}
+}
+
+// dispatchViaWakeTarget delivers an MQTT message to an existing loop
+// as an event-source notification. Mirrors the forge/media-feed
+// pattern: build a [messages.LoopEventPayload] describing the
+// message, wrap it in a [messages.NewEventSourceEnvelope] addressed
+// to the subscription's WakeTarget, and publish via the bus. The
+// target loop's next iteration sees the event in its pending
+// notifications and runs under its own Spec.Profile.
+//
+// No new loop is spawned — the registry stays clean and the
+// container cascade that governs the target loop applies naturally.
+// Failures (bus not configured, target loop not resolvable) are
+// logged at WARN and the message is dropped; the next matching
+// message gets the same treatment.
+func dispatchViaWakeTarget(deps mqttWakeDeps, ws mqtt.WakeSubscription, topic string, payload []byte, logger *slog.Logger) {
+	if deps.messageBus == nil {
+		logger.Warn("mqtt wake target dispatch unavailable, dropping message",
+			"subscription_id", ws.ID,
+			"topic", topic,
+			"reason", "message_bus_not_configured",
+		)
+		return
+	}
+
+	event := messages.LoopEventPayload{
+		Source:     "mqtt_wake",
+		Type:       "message",
+		ID:         fmt.Sprintf("mqtt-%s-%d", ws.ID, time.Now().UnixMilli()),
+		Title:      topic,
+		Summary:    sanitizePayload(payload),
+		ObservedAt: time.Now(),
+		Metadata: map[string]string{
+			"topic":           topic,
+			"subscription_id": ws.ID,
+		},
+	}
+
+	env, err := messages.NewEventSourceEnvelope(
+		messages.Identity{Kind: messages.IdentitySystem, Name: "mqtt_wake"},
+		ws.WakeTarget,
+		"mqtt_wake",
+		[]messages.LoopEventPayload{event},
+	)
+	if err != nil {
+		logger.Warn("mqtt wake envelope construction failed, dropping message",
+			"subscription_id", ws.ID,
+			"topic", topic,
+			"error", err,
+		)
+		return
+	}
+
+	if _, err := deps.messageBus.Send(context.Background(), env); err != nil {
+		logger.Warn("mqtt wake envelope delivery failed, dropping message",
+			"subscription_id", ws.ID,
+			"topic", topic,
+			"target_loop_id", ws.WakeTarget.LoopID,
+			"target_loop_name", ws.WakeTarget.Name,
+			"error", err,
+		)
+		return
+	}
+
+	logger.Info("mqtt wake delivered to target loop",
+		"subscription_id", ws.ID,
+		"topic", topic,
+		"target_loop_id", ws.WakeTarget.LoopID,
+		"target_loop_name", ws.WakeTarget.Name,
+		"payload_size", len(payload),
+	)
 }
 
 // dispatchViaLoop spawns a one-shot child loop under the MQTT parent

--- a/internal/app/mqttwake_test.go
+++ b/internal/app/mqttwake_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/nugget/thane-ai-agent/internal/channels/messages"
 	"github.com/nugget/thane-ai-agent/internal/channels/mqtt"
 	"github.com/nugget/thane-ai-agent/internal/model/router"
 	"github.com/nugget/thane-ai-agent/internal/platform/config"
@@ -272,6 +273,149 @@ func TestMQTTWakeHandlerNoRegistryDropsMessage(t *testing.T) {
 
 	if reqs := runner.requests(); len(reqs) != 0 {
 		t.Fatalf("expected 0 requests without registry, got %d", len(reqs))
+	}
+}
+
+// TestMQTTWakeHandlerDispatchesViaWakeTarget pins the post-PR-T1
+// trigger-unification contract: a subscription with a WakeTarget
+// configured delivers matching messages as event-source envelopes
+// to the target loop, instead of spawning a fresh one-shot loop.
+// The bus audit hook captures the envelope so we can verify shape.
+func TestMQTTWakeHandlerDispatchesViaWakeTarget(t *testing.T) {
+	store := newTestWakeStore(t)
+
+	// Operator declares "messages on frigate/+/events go to the
+	// home_security loop." No spawn-profile fields: the target
+	// loop owns routing.
+	target := messages.LoopWakeTarget{Name: "home_security", Priority: messages.PriorityNormal}
+	if err := store.LoadConfig([]config.SubscriptionConfig{
+		{Topic: "frigate/+/events", WakeLoop: &target},
+	}); err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+
+	bus := messages.NewBus(nil)
+	// Capture the envelope the dispatcher sends.
+	var captured []messages.Envelope
+	var capturedMu sync.Mutex
+	bus.AddAuditFunc(func(_ context.Context, env messages.Envelope, _ *messages.DeliveryResult, _ error) {
+		capturedMu.Lock()
+		defer capturedMu.Unlock()
+		captured = append(captured, env)
+	})
+	// Stub the loop destination handler so Send doesn't fail on
+	// the unrouted loop — we don't have a live registry here.
+	bus.RegisterRoute(messages.DestinationLoop, func(_ context.Context, env messages.Envelope) (messages.DeliveryResult, error) {
+		return messages.DeliveryResult{Envelope: env, Status: messages.DeliveryDelivered}, nil
+	})
+
+	runner := &mqttMockRunner{}
+	registry := looppkg.NewRegistry()
+	deps := mqttWakeDeps{
+		registry:   registry,
+		messageBus: bus,
+		eventBus:   events.New(),
+	}
+
+	handler := mqttWakeHandler(store, runner, nil, nil, deps)
+	handler("frigate/front/events", []byte(`{"event":"motion"}`))
+
+	// Give the dispatcher goroutine time to run.
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		capturedMu.Lock()
+		if len(captured) > 0 {
+			capturedMu.Unlock()
+			break
+		}
+		capturedMu.Unlock()
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	capturedMu.Lock()
+	defer capturedMu.Unlock()
+	if len(captured) != 1 {
+		t.Fatalf("expected 1 envelope delivered, got %d", len(captured))
+	}
+	env := captured[0]
+	if env.To.Target != "home_security" {
+		t.Errorf("envelope target = %q, want %q", env.To.Target, "home_security")
+	}
+	if env.Type != messages.TypeSignal {
+		t.Errorf("envelope type = %q, want %q", env.Type, messages.TypeSignal)
+	}
+	payload, ok := env.Payload.(messages.LoopNotifyPayload)
+	if !ok {
+		t.Fatalf("payload type = %T, want messages.LoopNotifyPayload", env.Payload)
+	}
+	if payload.Kind != "event_source" {
+		t.Errorf("payload.Kind = %q, want %q", payload.Kind, "event_source")
+	}
+	if len(payload.Events) != 1 {
+		t.Fatalf("payload.Events len = %d, want 1", len(payload.Events))
+	}
+	event := payload.Events[0]
+	if event.Source != "mqtt_wake" {
+		t.Errorf("event.Source = %q, want %q", event.Source, "mqtt_wake")
+	}
+	if event.Title != "frigate/front/events" {
+		t.Errorf("event.Title = %q, want the topic", event.Title)
+	}
+
+	// And critically: no agent run happened. The whole point of
+	// the wake-target path is that the existing target loop sees
+	// the event on its next iteration; no new conversation
+	// spawns.
+	if reqs := runner.requests(); len(reqs) != 0 {
+		t.Errorf("expected 0 spawned agent runs, got %d (wake-target dispatch should not spawn)", len(reqs))
+	}
+}
+
+// TestMQTTWakeHandlerFallsBackToSpawnWithoutWakeTarget guards the
+// backwards-compat path: a subscription with no WakeTarget but a
+// legacy Profile still uses the spawn-per-message dispatch.
+func TestMQTTWakeHandlerFallsBackToSpawnWithoutWakeTarget(t *testing.T) {
+	store := newTestWakeStore(t)
+	seed := router.LoopProfile{Mission: "automation"}
+	if err := store.LoadConfig([]config.SubscriptionConfig{
+		{Topic: "legacy/topic", Wake: &seed},
+	}); err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+
+	bus := messages.NewBus(nil)
+	var capturedMu sync.Mutex
+	var captured []messages.Envelope
+	bus.AddAuditFunc(func(_ context.Context, env messages.Envelope, _ *messages.DeliveryResult, _ error) {
+		capturedMu.Lock()
+		defer capturedMu.Unlock()
+		captured = append(captured, env)
+	})
+
+	runner := &mqttMockRunner{}
+	registry := looppkg.NewRegistry()
+	var parentID atomic.Value
+	parentID.Store("test-parent")
+	deps := mqttWakeDeps{
+		registry:   registry,
+		messageBus: bus,
+		eventBus:   events.New(),
+		parentID:   &parentID,
+	}
+
+	handler := mqttWakeHandler(store, runner, nil, nil, deps)
+	handler("legacy/topic", []byte("data"))
+
+	time.Sleep(200 * time.Millisecond)
+
+	// Spawn path uses SpawnLoop, which won't find the fake
+	// parent_id in the registry — but the important assertion is
+	// that no envelope went through the bus (that's the
+	// wake-target path).
+	capturedMu.Lock()
+	defer capturedMu.Unlock()
+	if len(captured) != 0 {
+		t.Errorf("expected 0 bus envelopes for legacy spawn path, got %d", len(captured))
 	}
 }
 

--- a/internal/app/new_servers.go
+++ b/internal/app/new_servers.go
@@ -333,9 +333,10 @@ func (a *App) initServers(s *newState) error {
 		var mqttParentID atomic.Value
 		mqttParentID.Store("") // initialize with zero-value string
 		wakeDeps := mqttWakeDeps{
-			registry: a.loopRegistry,
-			eventBus: a.eventBus,
-			parentID: &mqttParentID,
+			registry:   a.loopRegistry,
+			messageBus: a.messageBus,
+			eventBus:   a.eventBus,
+			parentID:   &mqttParentID,
 		}
 
 		// Wrap with the wake handler: wake-configured topics dispatch
@@ -350,7 +351,9 @@ func (a *App) initServers(s *newState) error {
 		))
 
 		// Register MQTT wake subscription tools via the provider.
-		a.loop.Tools().RegisterProvider(mqtt.NewWakeTools(mqtt.NewTools(subStore)))
+		// loopRegistry doubles as the LoopResolver so wake_loop
+		// arguments are verified against live loops at add time.
+		a.loop.Tools().RegisterProvider(mqtt.NewWakeTools(mqtt.NewTools(subStore, a.loopRegistry)))
 
 		// Defer MQTT connection to StartWorkers. The publisher object,
 		// tooling, and message handler are already wired above; this just

--- a/internal/app/tooling_tags_test.go
+++ b/internal/app/tooling_tags_test.go
@@ -285,7 +285,7 @@ func TestResolveCapabilityTags_IncludesMQTTWakeToolsAfterSetSubscriptionTools(t 
 	if err != nil {
 		t.Fatalf("new mqtt subscription store: %v", err)
 	}
-	reg.RegisterProvider(mqtt.NewWakeTools(mqtt.NewTools(subStore)))
+	reg.RegisterProvider(mqtt.NewWakeTools(mqtt.NewTools(subStore, nil)))
 
 	resolved := resolveCapabilityTags(reg, nil)
 	wantTools := []string{"mqtt_wake_add", "mqtt_wake_list", "mqtt_wake_remove"}

--- a/internal/channels/messages/wake_schema.go
+++ b/internal/channels/messages/wake_schema.go
@@ -1,0 +1,44 @@
+package messages
+
+// LoopWakeTargetSchema returns the canonical JSON-schema description
+// of the [LoopWakeTarget] wire shape, used by every source-specific
+// subscription tool that lets the model declare an existing loop to
+// receive event-source wakes (forge_repo_follow, media_follow,
+// mqtt_wake_add, etc.). One definition site, one description style.
+//
+// description is the per-source phrasing that introduces the field;
+// the rest of the schema (property names, enum values, priority
+// description) is fixed so the model sees the same shape regardless
+// of the source. Pass an empty string to use a generic fallback.
+func LoopWakeTargetSchema(description string) map[string]any {
+	if description == "" {
+		description = "Existing loop to wake when this subscription fires. The target loop's next iteration sees the event in its pending notifications; no new loop is spawned."
+	}
+	return map[string]any{
+		"type":        "object",
+		"description": description,
+		"properties": map[string]any{
+			"loop_id": map[string]any{
+				"type":        "string",
+				"description": "Exact live loop ID to signal. Preferred when available from loop_status.",
+			},
+			"name": map[string]any{
+				"type":        "string",
+				"description": "Exact live loop name to signal when loop_id is not known.",
+			},
+			"force_supervisor": map[string]any{
+				"type":        "boolean",
+				"description": "When true, force the target loop's next iteration to run as a supervisor turn (the more capable model with the augmented prompt). Costlier than a normal wake — reserve for signals that genuinely warrant the extra capacity.",
+			},
+			"priority": map[string]any{
+				"type":        "string",
+				"enum":        []string{"low", "normal", "urgent"},
+				"description": "Delivery priority recorded on the loop notification. Default: normal.",
+			},
+			"instructions": map[string]any{
+				"type":        "string",
+				"description": "Compact source-specific instructions included with the wake event.",
+			},
+		},
+	}
+}

--- a/internal/channels/mqtt/subscriptions.go
+++ b/internal/channels/mqtt/subscriptions.go
@@ -11,32 +11,73 @@ import (
 	"sync"
 	"time"
 
+	"github.com/nugget/thane-ai-agent/internal/channels/messages"
 	"github.com/nugget/thane-ai-agent/internal/model/router"
 	"github.com/nugget/thane-ai-agent/internal/platform/config"
 	"github.com/nugget/thane-ai-agent/internal/platform/database"
 )
 
-// WakeSubscription pairs an MQTT topic filter with the routing profile
-// and capability tag overlay used to wake the agent when a message
-// arrives on the topic.
+// WakeSubscription pairs an MQTT topic filter with one of two dispatch
+// shapes used to react to messages on the topic:
+//
+//   - **Wake-target dispatch (preferred):** WakeTarget points at an
+//     existing loop. Matching messages produce a
+//     [messages.LoopEventPayload] delivered to the target loop's
+//     pending notifications via [messages.NewEventSourceEnvelope].
+//     The target loop's next iteration sees the MQTT payload as an
+//     event-source wake and runs under its own Spec.Profile /
+//     SupervisorProfile / container cascade. No new loop is
+//     spawned; the registry stays clean.
+//
+//   - **Spawn dispatch (legacy):** Profile + InitialTags shape a
+//     fresh one-shot loop run when no WakeTarget is configured.
+//     Kept for backwards compatibility with subscriptions written
+//     before the trigger-unification work; new subscriptions
+//     should declare WakeTarget instead.
+//
+// HasWakeTarget reports which path a given subscription uses.
 type WakeSubscription struct {
 	ID    string `json:"id"`
 	Topic string `json:"topic"`
 
-	// Profile shapes the agent run dispatched on each matching message
-	// (model selection, mission, hints, exclude_tools, instructions).
-	// Routing/configuration only — capability tags live on InitialTags.
+	// WakeTarget identifies an existing loop to receive matching
+	// MQTT messages as event-source notifications. When non-empty
+	// this is the preferred dispatch route — Profile and InitialTags
+	// are unused on this path because the target loop owns its own
+	// routing via Spec.Profile.
+	WakeTarget messages.LoopWakeTarget `json:"wake_loop,omitempty"`
+
+	// Profile shapes the spawn-dispatch path (legacy). Used only
+	// when WakeTarget is empty.
 	Profile router.LoopProfile `json:"profile"`
 
-	// InitialTags lists capability tags activated at the start of the
-	// dispatched agent run. The dispatcher builds the agent.Request
-	// directly (no loop spec), so these are the only tags on the
-	// request itself; the agent's capability resolver then layers
-	// always-active tags on top.
+	// InitialTags lists capability tags activated at the start of
+	// the spawn-dispatch agent run (legacy path). Only used when
+	// WakeTarget is empty. Modern subscriptions delegate tag
+	// activation to the target loop's Spec.Tags.
 	InitialTags []string `json:"initial_tags,omitempty"`
 
 	Source    string    `json:"source"` // "config" or "runtime"
 	CreatedAt time.Time `json:"created_at"`
+}
+
+// HasWakeTarget reports whether this subscription routes matching
+// messages to an existing loop via the event-source envelope path
+// (the modern dispatch shape), versus the legacy
+// spawn-a-one-shot-loop path that consumes Profile + InitialTags.
+func (ws WakeSubscription) HasWakeTarget() bool {
+	return !ws.WakeTarget.Empty()
+}
+
+// AddRequest is the parameter struct for [SubscriptionStore.Add]. At
+// least one of WakeTarget or Profile must carry meaningful
+// configuration — a subscription that points at neither would match
+// MQTT messages and then do nothing.
+type AddRequest struct {
+	Topic       string
+	WakeTarget  messages.LoopWakeTarget
+	Profile     router.LoopProfile
+	InitialTags []string
 }
 
 // SubscriptionStore manages wake-enabled MQTT subscriptions with
@@ -77,6 +118,14 @@ func NewSubscriptionStore(db *sql.DB, logger *slog.Logger) (*SubscriptionStore, 
 	if err := database.AddColumn(db, "mqtt_wake_subscriptions", "initial_tags_json", "TEXT NOT NULL DEFAULT '[]'"); err != nil {
 		return nil, fmt.Errorf("migrate mqtt_wake_subscriptions schema: %w", err)
 	}
+	// Wake-target dispatch added in the trigger-unification work:
+	// subscriptions can declare an existing loop to receive matching
+	// MQTT messages instead of spawning a fresh one-shot loop.
+	// Default '{}' lets older rows hydrate cleanly with an empty
+	// target (falling through to the legacy spawn path).
+	if err := database.AddColumn(db, "mqtt_wake_subscriptions", "wake_target_json", "TEXT NOT NULL DEFAULT '{}'"); err != nil {
+		return nil, fmt.Errorf("migrate mqtt_wake_subscriptions schema: %w", err)
+	}
 
 	s := &SubscriptionStore{
 		db:     db,
@@ -92,7 +141,7 @@ func NewSubscriptionStore(db *sql.DB, logger *slog.Logger) (*SubscriptionStore, 
 
 // loadRuntime reads persisted runtime subscriptions from SQLite.
 func (s *SubscriptionStore) loadRuntime() error {
-	rows, err := s.db.Query(`SELECT id, topic, seed_json, initial_tags_json, source, created_at FROM mqtt_wake_subscriptions`)
+	rows, err := s.db.Query(`SELECT id, topic, seed_json, initial_tags_json, wake_target_json, source, created_at FROM mqtt_wake_subscriptions`)
 	if err != nil {
 		return err
 	}
@@ -100,8 +149,8 @@ func (s *SubscriptionStore) loadRuntime() error {
 
 	for rows.Next() {
 		var ws WakeSubscription
-		var profileJSON, initialTagsJSON, createdAt string
-		if err := rows.Scan(&ws.ID, &ws.Topic, &profileJSON, &initialTagsJSON, &ws.Source, &createdAt); err != nil {
+		var profileJSON, initialTagsJSON, wakeTargetJSON, createdAt string
+		if err := rows.Scan(&ws.ID, &ws.Topic, &profileJSON, &initialTagsJSON, &wakeTargetJSON, &ws.Source, &createdAt); err != nil {
 			return err
 		}
 		if err := json.Unmarshal([]byte(profileJSON), &ws.Profile); err != nil {
@@ -116,6 +165,17 @@ func (s *SubscriptionStore) loadRuntime() error {
 					"id", ws.ID, "error", err)
 			} else if len(tags) > 0 {
 				ws.InitialTags = tags
+			}
+		}
+		// wake_target_json is "{}" for pre-trigger-unification rows
+		// (column default). Unmarshal then Empty() detects "no
+		// target configured" and dispatch falls back to the legacy
+		// Profile-driven spawn path.
+		if wakeTargetJSON != "" && wakeTargetJSON != "{}" {
+			if err := json.Unmarshal([]byte(wakeTargetJSON), &ws.WakeTarget); err != nil {
+				s.logger.Warn("subscription wake_target_json invalid, ignoring",
+					"id", ws.ID, "error", err)
+				ws.WakeTarget = messages.LoopWakeTarget{}
 			}
 		}
 		ts, err := database.ParseTimestamp(createdAt)
@@ -175,23 +235,34 @@ func (s *SubscriptionStore) LoadConfig(subs []config.SubscriptionConfig) error {
 	s.subs = filtered
 
 	for i, sc := range subs {
-		if sc.Wake == nil {
+		// A config entry with neither WakeLoop nor Wake is
+		// ambient-awareness only; skip silently like before.
+		if sc.WakeLoop == nil && sc.Wake == nil {
 			continue
 		}
 		if err := router.ValidateTopicFilter(sc.Topic); err != nil {
 			return fmt.Errorf("mqtt.subscriptions[%d]: invalid topic %q: %w", i, sc.Topic, err)
 		}
-		if err := sc.Wake.Validate(); err != nil {
-			return fmt.Errorf("mqtt.subscriptions[%d] (topic %q): invalid wake profile: %w", i, sc.Topic, err)
-		}
-		s.subs = append(s.subs, WakeSubscription{
+		ws := WakeSubscription{
 			ID:          fmt.Sprintf("cfg-%s-%d", topicHash(sc.Topic), i),
 			Topic:       sc.Topic,
-			Profile:     *sc.Wake,
 			InitialTags: append([]string{}, sc.InitialTags...),
 			Source:      "config",
 			CreatedAt:   time.Now(),
-		})
+		}
+		if sc.WakeLoop != nil {
+			if sc.WakeLoop.Empty() {
+				return fmt.Errorf("mqtt.subscriptions[%d] (topic %q): wake_loop requires loop_id or name", i, sc.Topic)
+			}
+			ws.WakeTarget = *sc.WakeLoop
+		}
+		if sc.Wake != nil {
+			if err := sc.Wake.Validate(); err != nil {
+				return fmt.Errorf("mqtt.subscriptions[%d] (topic %q): invalid wake profile: %w", i, sc.Topic, err)
+			}
+			ws.Profile = *sc.Wake
+		}
+		s.subs = append(s.subs, ws)
 	}
 	return nil
 }
@@ -207,22 +278,36 @@ func (s *SubscriptionStore) SetSubscribeHook(fn func(topics []string)) {
 }
 
 // Add creates a runtime wake subscription, persists it to SQLite, and
-// returns the new subscription. The topic filter and profile are validated
-// before persistence — invalid values are rejected early rather than
-// stored and retried forever.
-func (s *SubscriptionStore) Add(topic string, profile router.LoopProfile, initialTags []string) (WakeSubscription, error) {
+// returns the new subscription. The topic filter and dispatch shape
+// are validated before persistence — invalid values are rejected
+// early rather than stored and retried forever. A subscription that
+// declares neither a WakeTarget nor a meaningful Profile is rejected
+// because it would match messages and do nothing on dispatch.
+func (s *SubscriptionStore) Add(req AddRequest) (WakeSubscription, error) {
+	topic := strings.TrimSpace(req.Topic)
 	if err := router.ValidateTopicFilter(topic); err != nil {
 		return WakeSubscription{}, fmt.Errorf("invalid topic filter: %w", err)
 	}
-	if err := profile.Validate(); err != nil {
+	if err := req.Profile.Validate(); err != nil {
 		return WakeSubscription{}, fmt.Errorf("invalid loop profile: %w", err)
+	}
+	// A subscription that points at nothing is almost certainly an
+	// operator/model mistake: matching messages would dispatch
+	// against a zero-value Profile (no model preference, no
+	// instructions) and would still spawn a one-shot loop. Reject
+	// with an actionable error. LoopProfile contains slice/map
+	// fields so we can't `==`-compare against a zero literal;
+	// inspect each field instead.
+	if req.WakeTarget.Empty() && isLoopProfileEmpty(req.Profile) {
+		return WakeSubscription{}, fmt.Errorf("subscription must declare either wake_loop (preferred) or a non-empty profile")
 	}
 
 	ws := WakeSubscription{
 		ID:          fmt.Sprintf("rt-%s-%d", topicHash(topic), time.Now().UnixMilli()),
 		Topic:       topic,
-		Profile:     profile,
-		InitialTags: append([]string{}, initialTags...),
+		WakeTarget:  req.WakeTarget,
+		Profile:     req.Profile,
+		InitialTags: append([]string{}, req.InitialTags...),
 		Source:      "runtime",
 		CreatedAt:   time.Now(),
 	}
@@ -238,10 +323,14 @@ func (s *SubscriptionStore) Add(topic string, profile router.LoopProfile, initia
 	if err != nil {
 		return WakeSubscription{}, fmt.Errorf("marshal initial_tags: %w", err)
 	}
+	wakeTargetJSON, err := json.Marshal(ws.WakeTarget)
+	if err != nil {
+		return WakeSubscription{}, fmt.Errorf("marshal wake_target: %w", err)
+	}
 
 	_, err = s.db.Exec(
-		`INSERT INTO mqtt_wake_subscriptions (id, topic, seed_json, initial_tags_json, source, created_at) VALUES (?, ?, ?, ?, ?, ?)`,
-		ws.ID, ws.Topic, string(profileJSON), string(initialTagsJSON), ws.Source, ws.CreatedAt.Format(time.RFC3339),
+		`INSERT INTO mqtt_wake_subscriptions (id, topic, seed_json, initial_tags_json, wake_target_json, source, created_at) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		ws.ID, ws.Topic, string(profileJSON), string(initialTagsJSON), string(wakeTargetJSON), ws.Source, ws.CreatedAt.Format(time.RFC3339),
 	)
 	if err != nil {
 		return WakeSubscription{}, fmt.Errorf("insert subscription: %w", err)
@@ -375,4 +464,21 @@ func matchTopicFilter(filter, topic string) bool {
 func topicHash(topic string) string {
 	h := sha256.Sum256([]byte(topic))
 	return hex.EncodeToString(h[:8])
+}
+
+// isLoopProfileEmpty reports whether every field on the profile is
+// zero-valued. Used to detect subscriptions that declare neither a
+// wake target nor a useful spawn-time routing shape (an operator
+// mistake we want to fail loud on, since the subscription would
+// otherwise match and silently produce a no-op spawn).
+func isLoopProfileEmpty(p router.LoopProfile) bool {
+	return p.Model == "" &&
+		p.QualityFloor == 0 &&
+		p.Mission == "" &&
+		p.LocalOnly == "" &&
+		p.DelegationGating == "" &&
+		p.PreferSpeed == "" &&
+		p.Instructions == "" &&
+		len(p.ExcludeTools) == 0 &&
+		len(p.ExtraHints) == 0
 }

--- a/internal/channels/mqtt/subscriptions.go
+++ b/internal/channels/mqtt/subscriptions.go
@@ -256,10 +256,20 @@ func (s *SubscriptionStore) LoadConfig(subs []config.SubscriptionConfig) error {
 			}
 			ws.WakeTarget = *sc.WakeLoop
 		}
-		if sc.Wake != nil {
+		// Profile is the legacy spawn-dispatch shape and is documented
+		// as ignored when WakeLoop is set. Validate it only when
+		// we'll actually use it — an unused-but-invalid Profile
+		// shouldn't fail startup if WakeLoop is the path being
+		// taken. (When neither is set we'd have continued above.)
+		if sc.Wake != nil && sc.WakeLoop == nil {
 			if err := sc.Wake.Validate(); err != nil {
 				return fmt.Errorf("mqtt.subscriptions[%d] (topic %q): invalid wake profile: %w", i, sc.Topic, err)
 			}
+			ws.Profile = *sc.Wake
+		} else if sc.Wake != nil {
+			// WakeLoop wins, but stash the profile data so it
+			// round-trips on the WakeSubscription — operators who
+			// later remove WakeLoop should still see what they had.
 			ws.Profile = *sc.Wake
 		}
 		s.subs = append(s.subs, ws)
@@ -288,18 +298,28 @@ func (s *SubscriptionStore) Add(req AddRequest) (WakeSubscription, error) {
 	if err := router.ValidateTopicFilter(topic); err != nil {
 		return WakeSubscription{}, fmt.Errorf("invalid topic filter: %w", err)
 	}
-	if err := req.Profile.Validate(); err != nil {
-		return WakeSubscription{}, fmt.Errorf("invalid loop profile: %w", err)
-	}
-	// A subscription that points at nothing is almost certainly an
-	// operator/model mistake: matching messages would dispatch
-	// against a zero-value Profile (no model preference, no
-	// instructions) and would still spawn a one-shot loop. Reject
-	// with an actionable error. LoopProfile contains slice/map
-	// fields so we can't `==`-compare against a zero literal;
-	// inspect each field instead.
-	if req.WakeTarget.Empty() && isLoopProfileEmpty(req.Profile) {
-		return WakeSubscription{}, fmt.Errorf("subscription must declare either wake_loop (preferred) or a non-empty profile")
+	// Profile validation is conditional on dispatch mode. When
+	// WakeTarget is set, the legacy Profile fields are documented
+	// as ignored — so an irrelevant invalid value (e.g. an
+	// accidental quality_floor=99 left over from copy-paste)
+	// shouldn't block a perfectly valid wake_loop subscription.
+	// Only when we'll actually USE the Profile (spawn dispatch
+	// path) do we require it to be valid.
+	if req.WakeTarget.Empty() {
+		if err := req.Profile.Validate(); err != nil {
+			return WakeSubscription{}, fmt.Errorf("invalid loop profile: %w", err)
+		}
+		// A subscription that points at nothing is almost certainly
+		// an operator/model mistake: matching messages would
+		// dispatch against a zero-value Profile (no model
+		// preference, no instructions) and would still spawn a
+		// one-shot loop. Reject with an actionable error.
+		// LoopProfile contains slice/map fields so we can't
+		// `==`-compare against a zero literal; inspect each field
+		// instead.
+		if isLoopProfileEmpty(req.Profile) {
+			return WakeSubscription{}, fmt.Errorf("subscription must declare either wake_loop (preferred) or a non-empty profile")
+		}
 	}
 
 	ws := WakeSubscription{

--- a/internal/channels/mqtt/subscriptions_test.go
+++ b/internal/channels/mqtt/subscriptions_test.go
@@ -84,7 +84,7 @@ func TestSubscriptionStoreAddRemoveList(t *testing.T) {
 	}
 
 	// Add a subscription.
-	ws, err := s.Add("test/topic", router.LoopProfile{Mission: "automation"}, nil)
+	ws, err := s.Add(AddRequest{Topic: "test/topic", Profile: router.LoopProfile{Mission: "automation"}, InitialTags: nil})
 	if err != nil {
 		t.Fatalf("add: %v", err)
 	}
@@ -232,7 +232,7 @@ func TestSubscriptionStorePersistence(t *testing.T) {
 		t.Fatalf("new store 1: %v", err)
 	}
 
-	_, err = s1.Add("persist/test", router.LoopProfile{Mission: "automation", QualityFloor: 5}, nil)
+	_, err = s1.Add(AddRequest{Topic: "persist/test", Profile: router.LoopProfile{Mission: "automation", QualityFloor: 5}, InitialTags: nil})
 	if err != nil {
 		t.Fatalf("add: %v", err)
 	}
@@ -267,7 +267,7 @@ func TestSubscriptionStoreInitialTagsPersistence(t *testing.T) {
 		t.Fatalf("new store 1: %v", err)
 	}
 
-	ws, err := s1.Add("tagged/topic", router.LoopProfile{Mission: "automation"}, []string{"homeassistant", "security"})
+	ws, err := s1.Add(AddRequest{Topic: "tagged/topic", Profile: router.LoopProfile{Mission: "automation"}, InitialTags: []string{"homeassistant", "security"}})
 	if err != nil {
 		t.Fatalf("add: %v", err)
 	}
@@ -309,7 +309,7 @@ func TestSubscriptionStoreAddPersistsEmptyTagsAsArray(t *testing.T) {
 		t.Fatalf("new store: %v", err)
 	}
 
-	ws, err := s.Add("empty/tags", router.LoopProfile{Mission: "automation"}, nil)
+	ws, err := s.Add(AddRequest{Topic: "empty/tags", Profile: router.LoopProfile{Mission: "automation"}, InitialTags: nil})
 	if err != nil {
 		t.Fatalf("add: %v", err)
 	}
@@ -332,7 +332,7 @@ func TestSubscriptionStoreTopics(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("LoadConfig: %v", err)
 	}
-	if _, err := s.Add("topic/b", profile, nil); err != nil {
+	if _, err := s.Add(AddRequest{Topic: "topic/b", Profile: profile}); err != nil {
 		t.Fatalf("add: %v", err)
 	}
 
@@ -358,7 +358,7 @@ func TestSubscriptionStoreSubscribeHook(t *testing.T) {
 		hookedTopics = append(hookedTopics, topics...)
 	})
 
-	_, err := s.Add("hook/test", router.LoopProfile{Mission: "automation"}, nil)
+	_, err := s.Add(AddRequest{Topic: "hook/test", Profile: router.LoopProfile{Mission: "automation"}, InitialTags: nil})
 	if err != nil {
 		t.Fatalf("add: %v", err)
 	}
@@ -371,8 +371,10 @@ func TestSubscriptionStoreSubscribeHook(t *testing.T) {
 func TestSubscriptionStoreSubscribeHookNotCalledWithoutHook(t *testing.T) {
 	s := newTestStore(t)
 
-	// No hook set — Add should not panic.
-	_, err := s.Add("no-hook/test", router.LoopProfile{}, nil)
+	// No hook set — Add should not panic. Supply a non-empty
+	// profile so the post-PR-T1 "wake_loop or non-empty profile"
+	// validation passes; the test isn't exercising that surface.
+	_, err := s.Add(AddRequest{Topic: "no-hook/test", Profile: router.LoopProfile{Mission: "automation"}, InitialTags: nil})
 	if err != nil {
 		t.Fatalf("add: %v", err)
 	}
@@ -382,25 +384,25 @@ func TestSubscriptionStoreAddValidation(t *testing.T) {
 	s := newTestStore(t)
 
 	// Invalid topic filter.
-	_, err := s.Add("", router.LoopProfile{}, nil)
+	_, err := s.Add(AddRequest{Topic: "", Profile: router.LoopProfile{Mission: "automation"}})
 	if err == nil {
 		t.Fatal("expected error for empty topic")
 	}
 
 	// Invalid topic with bad wildcard.
-	_, err = s.Add("foo/ba#r", router.LoopProfile{}, nil)
+	_, err = s.Add(AddRequest{Topic: "foo/ba#r", Profile: router.LoopProfile{}, InitialTags: nil})
 	if err == nil {
 		t.Fatal("expected error for bad wildcard in topic")
 	}
 
 	// Invalid seed.
-	_, err = s.Add("valid/topic", router.LoopProfile{QualityFloor: 99}, nil)
+	_, err = s.Add(AddRequest{Topic: "valid/topic", Profile: router.LoopProfile{QualityFloor: 99}, InitialTags: nil})
 	if err == nil {
 		t.Fatal("expected error for invalid quality_floor")
 	}
 
 	// Valid — should succeed.
-	_, err = s.Add("valid/topic", router.LoopProfile{Mission: "automation", QualityFloor: 7}, nil)
+	_, err = s.Add(AddRequest{Topic: "valid/topic", Profile: router.LoopProfile{Mission: "automation", QualityFloor: 7}, InitialTags: nil})
 	if err != nil {
 		t.Fatalf("expected success, got: %v", err)
 	}

--- a/internal/channels/mqtt/tools.go
+++ b/internal/channels/mqtt/tools.go
@@ -123,10 +123,15 @@ func (t *Tools) HandleAddWakeSubscription(_ context.Context, args map[string]any
 		initialTags = toStringSlice(raw)
 	}
 
-	// Validate the profile before persisting — fail fast with a clear
-	// error rather than storing an invalid subscription.
-	if err := profile.Validate(); err != nil {
-		return "", fmt.Errorf("invalid profile: %w", err)
+	// Validate the profile only when we'll actually use it (no
+	// WakeTarget set). With wake_loop dispatch the legacy spawn-
+	// profile fields are documented as ignored — so a stray
+	// invalid quality_floor=99 left over from copy-paste
+	// shouldn't block adding a valid wake_loop subscription.
+	if !wakeConfigured {
+		if err := profile.Validate(); err != nil {
+			return "", fmt.Errorf("invalid profile: %w", err)
+		}
 	}
 
 	ws, err := t.store.Add(AddRequest{
@@ -157,14 +162,10 @@ func (t *Tools) HandleAddWakeSubscription(_ context.Context, args map[string]any
 }
 
 // HandleRemoveWakeSubscription removes a runtime subscription by ID.
-// Accepts either "subscription_id" (preferred, matching the forge /
-// media tool surface) or the legacy "id" alias for backwards
-// compatibility with operator scripts.
+// `subscription_id` is the cross-family canonical parameter name,
+// matching forge_repo_unfollow and media_unfollow.
 func (t *Tools) HandleRemoveWakeSubscription(_ context.Context, args map[string]any) (string, error) {
 	id := strings.TrimSpace(stringArg(args, "subscription_id"))
-	if id == "" {
-		id = strings.TrimSpace(stringArg(args, "id"))
-	}
 	if id == "" {
 		return "", fmt.Errorf("subscription_id is required")
 	}

--- a/internal/channels/mqtt/tools.go
+++ b/internal/channels/mqtt/tools.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/nugget/thane-ai-agent/internal/channels/messages"
 	"github.com/nugget/thane-ai-agent/internal/model/router"
 )
 
@@ -14,45 +15,56 @@ import (
 // agent's tool registry. Each handler follows the standard tool
 // signature: func(ctx, args) (string, error).
 type Tools struct {
-	store *SubscriptionStore
+	store        *SubscriptionStore
+	loopResolver messages.LoopResolver
 }
 
 // NewTools creates MQTT tools backed by the given subscription store.
-func NewTools(store *SubscriptionStore) *Tools {
-	return &Tools{store: store}
+// loopResolver, when non-nil, is used to verify wake_loop targets at
+// subscription-add time so a typo'd loop name fails loud rather than
+// producing a permanent silent-drop on every matching message.
+func NewTools(store *SubscriptionStore, loopResolver messages.LoopResolver) *Tools {
+	return &Tools{store: store, loopResolver: loopResolver}
+}
+
+// listEntry is the JSON shape emitted by HandleListWakeSubscriptions.
+// One entry per subscription; the WakeLoop field is populated for
+// trigger-style subscriptions, the Profile fields for legacy
+// spawn-style subscriptions, so the model can tell at a glance which
+// dispatch shape each entry uses.
+type listEntry struct {
+	SubscriptionID string                   `json:"subscription_id"`
+	Topic          string                   `json:"topic"`
+	Source         string                   `json:"source"`
+	WakeLoop       *messages.LoopWakeTarget `json:"wake_loop,omitempty"`
+	Mission        string                   `json:"mission,omitempty"`
+	QualityFloor   int                      `json:"quality_floor,omitempty"`
+	Model          string                   `json:"model,omitempty"`
+	Instructions   string                   `json:"instructions,omitempty"`
 }
 
 // HandleListWakeSubscriptions returns a JSON list of all wake
 // subscriptions (config + runtime).
 func (t *Tools) HandleListWakeSubscriptions(_ context.Context, _ map[string]any) (string, error) {
 	subs := t.store.List()
-	if len(subs) == 0 {
-		return "No MQTT wake subscriptions configured.", nil
-	}
-
-	type entry struct {
-		ID           string `json:"id"`
-		Topic        string `json:"topic"`
-		Source       string `json:"source"`
-		Mission      string `json:"mission,omitempty"`
-		QualityFloor int    `json:"quality_floor,omitempty"`
-		Model        string `json:"model,omitempty"`
-		Instructions string `json:"instructions,omitempty"`
-	}
-
-	entries := make([]entry, len(subs))
-	for i, ws := range subs {
-		entries[i] = entry{
-			ID:           ws.ID,
-			Topic:        ws.Topic,
-			Source:       ws.Source,
-			Mission:      ws.Profile.Mission,
-			QualityFloor: ws.Profile.QualityFloor,
-			Model:        ws.Profile.Model,
-			Instructions: ws.Profile.Instructions,
+	entries := make([]listEntry, 0, len(subs))
+	for _, ws := range subs {
+		entry := listEntry{
+			SubscriptionID: ws.ID,
+			Topic:          ws.Topic,
+			Source:         ws.Source,
 		}
+		if ws.HasWakeTarget() {
+			target := ws.WakeTarget
+			entry.WakeLoop = &target
+		} else {
+			entry.Mission = ws.Profile.Mission
+			entry.QualityFloor = ws.Profile.QualityFloor
+			entry.Model = ws.Profile.Model
+			entry.Instructions = ws.Profile.Instructions
+		}
+		entries = append(entries, entry)
 	}
-
 	data, err := json.MarshalIndent(entries, "", "  ")
 	if err != nil {
 		return "", fmt.Errorf("marshal subscriptions: %w", err)
@@ -60,13 +72,36 @@ func (t *Tools) HandleListWakeSubscriptions(_ context.Context, _ map[string]any)
 	return string(data), nil
 }
 
+// addResponse is the JSON shape returned by HandleAddWakeSubscription.
+// Uniform success-payload pattern matches forge_repo_follow /
+// media_follow.
+type addResponse struct {
+	Status         string                   `json:"status"`
+	SubscriptionID string                   `json:"subscription_id"`
+	Topic          string                   `json:"topic"`
+	WakeLoop       *messages.LoopWakeTarget `json:"wake_loop,omitempty"`
+	Note           string                   `json:"note,omitempty"`
+}
+
 // HandleAddWakeSubscription creates a new runtime wake subscription.
-// Required args: "topic". Optional: all LoopProfile fields.
+// Required args: "topic" plus one of (a) "wake_loop" naming an
+// existing target loop or (b) any of the legacy spawn-profile fields
+// (mission, model, quality_floor, etc.).
 func (t *Tools) HandleAddWakeSubscription(_ context.Context, args map[string]any) (string, error) {
 	topic, _ := args["topic"].(string)
 	topic = strings.TrimSpace(topic)
 	if topic == "" {
 		return "", fmt.Errorf("topic is required")
+	}
+
+	wakeTarget, wakeConfigured, err := messages.ParseLoopWakeTarget(args["wake_loop"])
+	if err != nil {
+		return "", err
+	}
+	if wakeConfigured {
+		if err := messages.VerifyLoopWakeTarget(wakeTarget, t.loopResolver); err != nil {
+			return "", err
+		}
 	}
 
 	profile := router.LoopProfile{
@@ -94,28 +129,58 @@ func (t *Tools) HandleAddWakeSubscription(_ context.Context, args map[string]any
 		return "", fmt.Errorf("invalid profile: %w", err)
 	}
 
-	ws, err := t.store.Add(topic, profile, initialTags)
+	ws, err := t.store.Add(AddRequest{
+		Topic:       topic,
+		WakeTarget:  wakeTarget,
+		Profile:     profile,
+		InitialTags: initialTags,
+	})
 	if err != nil {
 		return "", err
 	}
 
-	return fmt.Sprintf("Wake subscription added (id=%s, topic=%s). Live subscribe attempted; activates on next reconnect if broker is not currently connected.", ws.ID, ws.Topic), nil
+	resp := addResponse{
+		Status:         "ok",
+		SubscriptionID: ws.ID,
+		Topic:          ws.Topic,
+		Note:           "Live subscribe attempted; activates on next reconnect if broker is not currently connected.",
+	}
+	if ws.HasWakeTarget() {
+		target := ws.WakeTarget
+		resp.WakeLoop = &target
+	}
+	data, err := json.Marshal(resp)
+	if err != nil {
+		return "", fmt.Errorf("marshal response: %w", err)
+	}
+	return string(data), nil
 }
 
 // HandleRemoveWakeSubscription removes a runtime subscription by ID.
-// Required args: "id".
+// Accepts either "subscription_id" (preferred, matching the forge /
+// media tool surface) or the legacy "id" alias for backwards
+// compatibility with operator scripts.
 func (t *Tools) HandleRemoveWakeSubscription(_ context.Context, args map[string]any) (string, error) {
-	id, _ := args["id"].(string)
-	id = strings.TrimSpace(id)
+	id := strings.TrimSpace(stringArg(args, "subscription_id"))
 	if id == "" {
-		return "", fmt.Errorf("id is required")
+		id = strings.TrimSpace(stringArg(args, "id"))
+	}
+	if id == "" {
+		return "", fmt.Errorf("subscription_id is required")
 	}
 
 	if err := t.store.Remove(id); err != nil {
 		return "", err
 	}
 
-	return fmt.Sprintf("Wake subscription %q removed.", id), nil
+	data, err := json.Marshal(map[string]string{
+		"status":          "ok",
+		"subscription_id": id,
+	})
+	if err != nil {
+		return "", fmt.Errorf("marshal response: %w", err)
+	}
+	return string(data), nil
 }
 
 // stringArg extracts a string from an args map, returning "" if absent

--- a/internal/channels/mqtt/tools_test.go
+++ b/internal/channels/mqtt/tools_test.go
@@ -24,7 +24,10 @@ func newTestTools(t *testing.T) *Tools {
 	if err != nil {
 		t.Fatalf("new subscription store: %v", err)
 	}
-	return NewTools(store)
+	// Pass a nil resolver so wake_loop verification is skipped in
+	// tests that don't care about it. Tests that DO exercise the
+	// verification path supply their own resolver.
+	return NewTools(store, nil)
 }
 
 func TestToolsHandleListEmpty(t *testing.T) {
@@ -33,8 +36,12 @@ func TestToolsHandleListEmpty(t *testing.T) {
 	if err != nil {
 		t.Fatalf("list: %v", err)
 	}
-	if !strings.Contains(result, "No MQTT wake") {
-		t.Errorf("expected empty message, got %q", result)
+	// Empty store now emits the canonical empty JSON array (matches
+	// the cross-family return shape used by forge_repo_subscriptions
+	// and media_feeds); the legacy "No MQTT wake subscriptions
+	// configured." prose was retired in PR-T1.
+	if strings.TrimSpace(result) != "[]" {
+		t.Errorf("expected empty JSON array, got %q", result)
 	}
 }
 
@@ -106,8 +113,10 @@ func TestToolsHandleAddMissingTopic(t *testing.T) {
 func TestToolsHandleRemove(t *testing.T) {
 	tools := newTestTools(t)
 
-	// Add then remove.
-	args := map[string]any{"topic": "remove/test"}
+	// Add with a non-empty legacy profile so the new "must declare
+	// wake_loop or a non-empty profile" validation passes; the
+	// remove path is what we're exercising here.
+	args := map[string]any{"topic": "remove/test", "mission": "automation"}
 	_, err := tools.HandleAddWakeSubscription(context.Background(), args)
 	if err != nil {
 		t.Fatalf("add: %v", err)
@@ -118,12 +127,15 @@ func TestToolsHandleRemove(t *testing.T) {
 		t.Fatalf("expected 1 sub, got %d", len(subs))
 	}
 
-	result, err := tools.HandleRemoveWakeSubscription(context.Background(), map[string]any{"id": subs[0].ID})
+	// Canonical parameter name post-PR-T1 is subscription_id; the
+	// `id` alias still works for backwards compat (covered by its
+	// own test below).
+	result, err := tools.HandleRemoveWakeSubscription(context.Background(), map[string]any{"subscription_id": subs[0].ID})
 	if err != nil {
 		t.Fatalf("remove: %v", err)
 	}
-	if !strings.Contains(result, "removed") {
-		t.Errorf("expected removed message, got %q", result)
+	if !strings.Contains(result, `"status":"ok"`) {
+		t.Errorf("expected JSON ok response, got %q", result)
 	}
 
 	if subs := tools.store.List(); len(subs) != 0 {
@@ -146,7 +158,7 @@ func TestToolsHandleRemoveConfigProtected(t *testing.T) {
 		t.Fatalf("expected 1 sub, got %d", len(subs))
 	}
 
-	_, err := tools.HandleRemoveWakeSubscription(context.Background(), map[string]any{"id": subs[0].ID})
+	_, err := tools.HandleRemoveWakeSubscription(context.Background(), map[string]any{"subscription_id": subs[0].ID})
 	if err == nil {
 		t.Fatal("expected error removing config subscription")
 	}

--- a/internal/channels/mqtt/wake_tool_provider.go
+++ b/internal/channels/mqtt/wake_tool_provider.go
@@ -3,6 +3,7 @@ package mqtt
 import (
 	"context"
 
+	"github.com/nugget/thane-ai-agent/internal/channels/messages"
 	"github.com/nugget/thane-ai-agent/internal/tools"
 )
 
@@ -30,7 +31,7 @@ func (w *WakeTools) Tools() []*tools.Tool {
 	return []*tools.Tool{
 		{
 			Name:        "mqtt_wake_list",
-			Description: "List all MQTT wake subscriptions. Shows topic filters that trigger agent conversations when messages arrive, along with their routing configuration (mission, quality floor, model) and source (config or runtime).",
+			Description: "List all MQTT wake subscriptions. Each entry shows the topic filter, the source (config or runtime), and either wake_loop (modern target-dispatch shape — points at an existing loop that receives messages as event-source notifications) or the legacy routing fields (mission, quality_floor, model) for subscriptions that still spawn a one-shot loop per message.",
 			Parameters: map[string]any{
 				"type":       "object",
 				"properties": map[string]any{},
@@ -41,53 +42,60 @@ func (w *WakeTools) Tools() []*tools.Tool {
 		},
 		{
 			Name: "mqtt_wake_add",
-			Description: `Add a runtime MQTT wake subscription. When a message arrives on the given topic, the agent wakes with the specified routing configuration. The subscription is persisted and a live SUBSCRIBE is sent to the broker; if the broker is not currently connected it activates on the next reconnect. Persists across restarts.
+			Description: `Add a runtime MQTT wake subscription. Two dispatch shapes are supported per-subscription:
 
-Topic conventions: Use thane/{device_name}/wake/{purpose} for instance-directed wakes. Subscribe to external topics directly for shared events (e.g., frigate/+/events). MQTT wildcards: + matches one level, # matches remaining levels (must be last segment). Each wake creates a fresh conversation — no state accumulates across messages. The MQTT payload becomes the user message, optionally wrapped with the instructions field.`,
+  - **wake_loop (preferred):** messages on the topic are delivered as event-source notifications to an existing loop. The target loop's next iteration sees the message in its pending notifications and runs under its own Spec.Profile. No new loop is spawned; the registry stays clean. Use this for "topic X → metacog", "topic Y → research_watcher", and similar attention-routing patterns.
+
+  - **Legacy spawn-per-message:** when wake_loop is omitted, the routing fields (model, mission, quality_floor, etc.) shape a fresh one-shot loop that runs on each matching message. Kept for backwards compatibility; new subscriptions should use wake_loop and let the target loop's own profile govern routing.
+
+The subscription is persisted and a live SUBSCRIBE is sent to the broker; if the broker is not currently connected it activates on the next reconnect.
+
+Topic conventions: Use thane/{device_name}/wake/{purpose} for instance-directed wakes. Subscribe to external topics directly for shared events (e.g., frigate/+/events). MQTT wildcards: + matches one level, # matches remaining levels (must be last segment).`,
 			Parameters: map[string]any{
 				"type": "object",
 				"properties": map[string]any{
 					"topic": map[string]any{
 						"type":        "string",
-						"description": "MQTT topic filter to subscribe to (supports + and # wildcards)",
+						"description": "MQTT topic filter to subscribe to (supports + and # wildcards).",
 					},
+					"wake_loop": messages.LoopWakeTargetSchema("Preferred dispatch: existing loop to receive matching messages as event-source notifications. Resolves at message-arrival time; verify the target exists via loop_status before persisting."),
 					"model": map[string]any{
 						"type":        "string",
-						"description": "Explicit model name (bypasses router). Leave empty for router-based selection.",
+						"description": "Legacy spawn-dispatch only: explicit model name (bypasses router). Ignored when wake_loop is set.",
 					},
 					"quality_floor": map[string]any{
-						"type":        "string",
-						"description": "Minimum model quality rating 1-10 (default: router decides)",
+						"type":        "integer",
+						"description": "Legacy spawn-dispatch only: minimum model quality rating 1-10. Ignored when wake_loop is set.",
 					},
 					"mission": map[string]any{
 						"type":        "string",
-						"description": "Task context for routing: conversation, automation, device_control, background",
+						"description": "Legacy spawn-dispatch only: task context (conversation, automation, device_control, background). Ignored when wake_loop is set.",
 					},
 					"local_only": map[string]any{
 						"type":        "string",
-						"description": "Restrict to free/local models: true or false",
+						"description": "Legacy spawn-dispatch only: restrict to free/local models (true/false). Ignored when wake_loop is set.",
 					},
 					"delegation_gating": map[string]any{
 						"type":        "string",
-						"description": "Delegation tool gating: enabled or disabled",
+						"description": "Legacy spawn-dispatch only: delegation tool gating (enabled/disabled). Ignored when wake_loop is set.",
 					},
 					"prefer_speed": map[string]any{
 						"type":        "string",
-						"description": "Favour faster models: true or false",
+						"description": "Legacy spawn-dispatch only: favour faster models (true/false). Ignored when wake_loop is set.",
 					},
 					"instructions": map[string]any{
 						"type":        "string",
-						"description": "Instructions injected into the wake message to guide the agent's behaviour",
+						"description": "Legacy spawn-dispatch only: instructions injected into the spawned wake message. For wake_loop dispatch, set wake_loop.instructions instead.",
 					},
 					"exclude_tools": map[string]any{
 						"type":        "array",
 						"items":       map[string]any{"type": "string"},
-						"description": "Tool names to exclude from the wake conversation",
+						"description": "Legacy spawn-dispatch only: tool names to exclude. Ignored when wake_loop is set (target loop's ExcludeTools governs).",
 					},
 					"initial_tags": map[string]any{
 						"type":        "array",
 						"items":       map[string]any{"type": "string"},
-						"description": "Capability tags to activate at wake start",
+						"description": "Legacy spawn-dispatch only: capability tags to activate. Ignored when wake_loop is set (target loop's tags govern).",
 					},
 				},
 				"required": []string{"topic"},
@@ -102,12 +110,12 @@ Topic conventions: Use thane/{device_name}/wake/{purpose} for instance-directed 
 			Parameters: map[string]any{
 				"type": "object",
 				"properties": map[string]any{
-					"id": map[string]any{
+					"subscription_id": map[string]any{
 						"type":        "string",
-						"description": "Subscription ID to remove (from mqtt_wake_list)",
+						"description": "Subscription ID to remove (from mqtt_wake_list's subscription_id field).",
 					},
 				},
-				"required": []string{"id"},
+				"required": []string{"subscription_id"},
 			},
 			Handler: func(ctx context.Context, args map[string]any) (string, error) {
 				return w.tools.HandleRemoveWakeSubscription(ctx, args)

--- a/internal/integrations/media/feed_wake.go
+++ b/internal/integrations/media/feed_wake.go
@@ -97,33 +97,7 @@ func loadFeedWakeTarget(state *opstate.Store, feedID string) (messages.LoopWakeT
 }
 
 func feedWakeTargetDefinition() map[string]any {
-	return map[string]any{
-		"type":        "object",
-		"description": "Optional existing loop to wake when this feed has new entries. Use this to feed a thane_curate-managed document instead of starting the default media-analysis conversation.",
-		"properties": map[string]any{
-			"loop_id": map[string]any{
-				"type":        "string",
-				"description": "Exact live loop ID to signal. Preferred when available from loop_status.",
-			},
-			"name": map[string]any{
-				"type":        "string",
-				"description": "Exact live loop name to signal when loop_id is not known.",
-			},
-			"force_supervisor": map[string]any{
-				"type":        "boolean",
-				"description": "When true, force the target loop's next iteration to run as a supervisor turn (the more capable model with the augmented prompt). Costlier than a normal wake — reserve for signals that genuinely warrant the extra capacity.",
-			},
-			"priority": map[string]any{
-				"type":        "string",
-				"enum":        []string{"low", "normal", "urgent"},
-				"description": "Delivery priority recorded on the loop notification. Default: normal.",
-			},
-			"instructions": map[string]any{
-				"type":        "string",
-				"description": "Compact source-specific instructions included with the wake event.",
-			},
-		},
-	}
+	return messages.LoopWakeTargetSchema("Optional existing loop to wake when this feed has new entries. Use this to feed a thane_curate-managed document instead of starting the default media-analysis conversation.")
 }
 
 func feedWakeTargetJSON(target messages.LoopWakeTarget, ok bool) map[string]any {

--- a/internal/integrations/media/tools_feed.go
+++ b/internal/integrations/media/tools_feed.go
@@ -194,11 +194,11 @@ func (ft *FeedTools) FollowHandler() func(ctx context.Context, args map[string]a
 		)
 
 		result := map[string]any{
-			"feed_id":      id,
-			"name":         name,
-			"url":          feedURL,
-			"trust_zone":   trustZone,
-			"latest_entry": latestTitle,
+			"subscription_id": id,
+			"name":            name,
+			"url":             feedURL,
+			"trust_zone":      trustZone,
+			"latest_entry":    latestTitle,
 		}
 		if outputPath != "" {
 			result["output_path"] = outputPath
@@ -212,17 +212,13 @@ func (ft *FeedTools) FollowHandler() func(ctx context.Context, args map[string]a
 }
 
 // UnfollowHandler returns the tool handler for media_unfollow.
-// Accepts either subscription_id (cross-family canonical, matches
-// forge_repo_unfollow / mqtt_wake_remove) or the historical feed_id
-// alias.
+// `subscription_id` is the cross-family canonical parameter name,
+// matching forge_repo_unfollow and mqtt_wake_remove.
 func (ft *FeedTools) UnfollowHandler() func(ctx context.Context, args map[string]any) (string, error) {
 	return func(_ context.Context, args map[string]any) (string, error) {
 		id, _ := args["subscription_id"].(string)
 		if id == "" {
-			id, _ = args["feed_id"].(string)
-		}
-		if id == "" {
-			return "", fmt.Errorf("media_unfollow: subscription_id (or feed_id) is required")
+			return "", fmt.Errorf("media_unfollow: subscription_id is required")
 		}
 
 		// Verify feed exists.
@@ -303,7 +299,6 @@ func (ft *FeedTools) FeedsHandler() func(ctx context.Context, args map[string]an
 
 		type feedInfo struct {
 			SubscriptionID string         `json:"subscription_id"`
-			FeedID         string         `json:"feed_id"` // deprecated alias of subscription_id; kept for compat
 			Name           string         `json:"name"`
 			URL            string         `json:"url"`
 			TrustZone      string         `json:"trust_zone"`
@@ -354,7 +349,6 @@ func (ft *FeedTools) FeedsHandler() func(ctx context.Context, args map[string]an
 
 			feeds = append(feeds, feedInfo{
 				SubscriptionID: id,
-				FeedID:         id,
 				Name:           name,
 				URL:            feedURL,
 				TrustZone:      trustZone,
@@ -412,11 +406,8 @@ func UnfollowDefinition() map[string]any {
 				"type":        "string",
 				"description": "The feed identifier returned by media_follow or media_feeds (the subscription_id field). Cross-family canonical name matching forge_repo_unfollow and mqtt_wake_remove.",
 			},
-			"feed_id": map[string]any{
-				"type":        "string",
-				"description": "Deprecated alias for subscription_id; kept for backwards compatibility with operator scripts.",
-			},
 		},
+		"required": []string{"subscription_id"},
 	}
 }
 

--- a/internal/integrations/media/tools_feed.go
+++ b/internal/integrations/media/tools_feed.go
@@ -212,11 +212,17 @@ func (ft *FeedTools) FollowHandler() func(ctx context.Context, args map[string]a
 }
 
 // UnfollowHandler returns the tool handler for media_unfollow.
+// Accepts either subscription_id (cross-family canonical, matches
+// forge_repo_unfollow / mqtt_wake_remove) or the historical feed_id
+// alias.
 func (ft *FeedTools) UnfollowHandler() func(ctx context.Context, args map[string]any) (string, error) {
 	return func(_ context.Context, args map[string]any) (string, error) {
-		id, _ := args["feed_id"].(string)
+		id, _ := args["subscription_id"].(string)
 		if id == "" {
-			return "", fmt.Errorf("media_unfollow: feed_id is required")
+			id, _ = args["feed_id"].(string)
+		}
+		if id == "" {
+			return "", fmt.Errorf("media_unfollow: subscription_id (or feed_id) is required")
 		}
 
 		// Verify feed exists.
@@ -271,7 +277,19 @@ func (ft *FeedTools) UnfollowHandler() func(ctx context.Context, args map[string
 
 		ft.logger.Info("feed unfollowed", "feed_id", id, "name", name)
 
-		return fmt.Sprintf("Unfollowed %q (id: %s)", name, id), nil
+		// Match the JSON-response shape used by forge_repo_unfollow
+		// and the new mqtt_wake_remove — every subscription tool
+		// family returns structured JSON for mutations now, not
+		// prose.
+		out, err := json.Marshal(map[string]string{
+			"status":          "ok",
+			"subscription_id": id,
+			"name":            name,
+		})
+		if err != nil {
+			return "", fmt.Errorf("marshal response: %w", err)
+		}
+		return string(out), nil
 	}
 }
 
@@ -284,15 +302,16 @@ func (ft *FeedTools) FeedsHandler() func(ctx context.Context, args map[string]an
 		}
 
 		type feedInfo struct {
-			FeedID      string         `json:"feed_id"`
-			Name        string         `json:"name"`
-			URL         string         `json:"url"`
-			TrustZone   string         `json:"trust_zone"`
-			OutputPath  string         `json:"output_path,omitempty"`
-			LastChecked string         `json:"last_checked,omitempty"`
-			LatestEntry string         `json:"latest_entry,omitempty"`
-			Notify      bool           `json:"notify"`
-			WakeLoop    map[string]any `json:"wake_loop,omitempty"`
+			SubscriptionID string         `json:"subscription_id"`
+			FeedID         string         `json:"feed_id"` // deprecated alias of subscription_id; kept for compat
+			Name           string         `json:"name"`
+			URL            string         `json:"url"`
+			TrustZone      string         `json:"trust_zone"`
+			OutputPath     string         `json:"output_path,omitempty"`
+			LastChecked    string         `json:"last_checked,omitempty"`
+			LatestEntry    string         `json:"latest_entry,omitempty"`
+			Notify         bool           `json:"notify"`
+			WakeLoop       map[string]any `json:"wake_loop,omitempty"`
 		}
 
 		feeds := make([]feedInfo, 0, len(ids))
@@ -334,15 +353,16 @@ func (ft *FeedTools) FeedsHandler() func(ctx context.Context, args map[string]an
 			}
 
 			feeds = append(feeds, feedInfo{
-				FeedID:      id,
-				Name:        name,
-				URL:         feedURL,
-				TrustZone:   trustZone,
-				OutputPath:  outputPath,
-				LastChecked: lastChecked,
-				LatestEntry: latestTitle,
-				Notify:      notifyStr != "false",
-				WakeLoop:    feedWakeTargetJSON(wakeTarget, wakeConfigured),
+				SubscriptionID: id,
+				FeedID:         id,
+				Name:           name,
+				URL:            feedURL,
+				TrustZone:      trustZone,
+				OutputPath:     outputPath,
+				LastChecked:    lastChecked,
+				LatestEntry:    latestTitle,
+				Notify:         notifyStr != "false",
+				WakeLoop:       feedWakeTargetJSON(wakeTarget, wakeConfigured),
 			})
 		}
 
@@ -388,12 +408,15 @@ func UnfollowDefinition() map[string]any {
 	return map[string]any{
 		"type": "object",
 		"properties": map[string]any{
+			"subscription_id": map[string]any{
+				"type":        "string",
+				"description": "The feed identifier returned by media_follow or media_feeds (the subscription_id field). Cross-family canonical name matching forge_repo_unfollow and mqtt_wake_remove.",
+			},
 			"feed_id": map[string]any{
 				"type":        "string",
-				"description": "The feed identifier returned by media_follow or media_feeds.",
+				"description": "Deprecated alias for subscription_id; kept for backwards compatibility with operator scripts.",
 			},
 		},
-		"required": []string{"feed_id"},
 	}
 }
 

--- a/internal/integrations/media/tools_feed_test.go
+++ b/internal/integrations/media/tools_feed_test.go
@@ -39,7 +39,7 @@ func TestFollowHandler_TrustZoneDefault(t *testing.T) {
 	}
 
 	// Verify stored in opstate.
-	id := out["feed_id"]
+	id := out["subscription_id"]
 	stored, _ := store.Get(feedNamespace, feedKeyTrustZone(id))
 	if stored != "unknown" {
 		t.Errorf("stored trust_zone = %q, want %q", stored, "unknown")
@@ -80,7 +80,7 @@ func TestFollowHandler_TrustZoneExplicit(t *testing.T) {
 	}
 
 	// Verify stored in opstate.
-	id := out["feed_id"]
+	id := out["subscription_id"]
 	stored, _ := store.Get(feedNamespace, feedKeyTrustZone(id))
 	if stored != "trusted" {
 		t.Errorf("stored trust_zone = %q, want %q", stored, "trusted")
@@ -148,7 +148,7 @@ func TestUnfollowHandler_CleansTrustZone(t *testing.T) {
 	ft := NewFeedTools(store, nil, 10)
 	handler := ft.UnfollowHandler()
 
-	_, err := handler(context.Background(), map[string]any{"feed_id": id})
+	_, err := handler(context.Background(), map[string]any{"subscription_id": id})
 	if err != nil {
 		t.Fatalf("UnfollowHandler() error: %v", err)
 	}
@@ -183,9 +183,9 @@ func TestFeedsHandler_IncludesTrustZone(t *testing.T) {
 	}
 
 	type feedInfo struct {
-		FeedID    string `json:"feed_id"`
-		Name      string `json:"name"`
-		TrustZone string `json:"trust_zone"`
+		SubscriptionID string `json:"subscription_id"`
+		Name           string `json:"name"`
+		TrustZone      string `json:"trust_zone"`
 	}
 	var feeds []feedInfo
 	if err := json.Unmarshal([]byte(result), &feeds); err != nil {
@@ -199,7 +199,7 @@ func TestFeedsHandler_IncludesTrustZone(t *testing.T) {
 	// Find each feed by ID.
 	zones := map[string]string{}
 	for _, f := range feeds {
-		zones[f.FeedID] = f.TrustZone
+		zones[f.SubscriptionID] = f.TrustZone
 	}
 	if zones["f1"] != "trusted" {
 		t.Errorf("f1 trust_zone = %q, want %q", zones["f1"], "trusted")

--- a/internal/platform/config/config.go
+++ b/internal/platform/config/config.go
@@ -37,6 +37,7 @@ import (
 	"time"
 
 	"github.com/nugget/thane-ai-agent/internal/channels/email"
+	"github.com/nugget/thane-ai-agent/internal/channels/messages"
 	"github.com/nugget/thane-ai-agent/internal/integrations/forge"
 	"github.com/nugget/thane-ai-agent/internal/integrations/search"
 	"github.com/nugget/thane-ai-agent/internal/model/router"
@@ -1305,20 +1306,43 @@ type MQTTConfig struct {
 // SubscriptionConfig describes a single MQTT topic subscription.
 // Each entry is subscribed on every broker (re-)connect. Wildcards
 // (+ and #) are supported per the MQTT specification.
+//
+// Two dispatch shapes are supported for matching messages:
+//
+//   - **WakeLoop (preferred):** identifies an existing loop to
+//     receive matching MQTT messages as event-source notifications.
+//     The target loop's next iteration sees the message in its
+//     pending notifications and runs under its own Spec.Profile.
+//     No new loop is spawned.
+//
+//   - **Wake (legacy):** matching messages spawn a fresh one-shot
+//     loop using the embedded routing profile. Kept for
+//     backwards compatibility; new subscriptions should declare
+//     WakeLoop instead.
+//
+// When both are set, WakeLoop wins. When neither is set, the
+// subscription is ambient-awareness only (debug-logged, not
+// acted upon).
 type SubscriptionConfig struct {
 	// Topic is the MQTT topic filter (e.g., "homeassistant/+/+/state",
 	// "frigate/events"). Supports MQTT wildcard characters.
 	Topic string `yaml:"topic"`
 
-	// Wake, when non-nil, enables agent wake on this topic. Messages
-	// arriving on the topic trigger an agent conversation using the
-	// profile's routing configuration. When nil, messages are received
-	// for ambient awareness only (debug-logged, not acted upon).
+	// WakeLoop identifies an existing loop to receive matching MQTT
+	// messages as event-source notifications. Preferred dispatch
+	// route — the target loop's [Spec.Profile] governs routing.
+	WakeLoop *messages.LoopWakeTarget `yaml:"wake_loop,omitempty"`
+
+	// Wake is the legacy dispatch-via-spawn path: when non-nil and
+	// WakeLoop is unset, messages on this topic spawn a one-shot
+	// agent run using this routing profile. New subscriptions
+	// should use WakeLoop and let the target loop's own Profile
+	// govern routing instead.
 	Wake *router.LoopProfile `yaml:"wake,omitempty"`
 
 	// InitialTags lists capability tags activated at the start of the
-	// agent run dispatched for matching messages. Only meaningful when
-	// Wake is non-nil.
+	// spawn-dispatch agent run (legacy path). Only meaningful when
+	// Wake is non-nil and WakeLoop is unset.
 	InitialTags []string `yaml:"initial_tags,omitempty"`
 }
 

--- a/internal/tools/forge_subscription_tools.go
+++ b/internal/tools/forge_subscription_tools.go
@@ -1,6 +1,10 @@
 package tools
 
-import "context"
+import (
+	"context"
+
+	"github.com/nugget/thane-ai-agent/internal/channels/messages"
+)
 
 func (r *Registry) registerForgeSubscriptionTools() {
 	if r.forgeTools == nil {
@@ -79,31 +83,5 @@ func (r *Registry) registerForgeSubscriptionTools() {
 }
 
 func forgeWakeLoopDefinition() map[string]any {
-	return map[string]any{
-		"type":        "object",
-		"description": "Existing loop to wake when repository events are detected. Usually a thane_curate loop that owns the managed document and tagging strategy.",
-		"properties": map[string]any{
-			"loop_id": map[string]any{
-				"type":        "string",
-				"description": "Exact live loop ID to signal. Preferred when available from loop_status.",
-			},
-			"name": map[string]any{
-				"type":        "string",
-				"description": "Exact live loop name to signal when loop_id is not known.",
-			},
-			"force_supervisor": map[string]any{
-				"type":        "boolean",
-				"description": "When true, force the target loop's next iteration to run as a supervisor turn (the more capable model with the augmented prompt). Costlier than a normal wake — reserve for signals that genuinely warrant the extra capacity.",
-			},
-			"priority": map[string]any{
-				"type":        "string",
-				"enum":        []string{"low", "normal", "urgent"},
-				"description": "Delivery priority recorded on the loop notification. Default: normal.",
-			},
-			"instructions": map[string]any{
-				"type":        "string",
-				"description": "Compact source-specific instructions included with the wake event.",
-			},
-		},
-	}
+	return messages.LoopWakeTargetSchema("Existing loop to wake when repository events are detected. Usually a thane_curate loop that owns the managed document and tagging strategy.")
 }

--- a/scripts/architecture.baseline
+++ b/scripts/architecture.baseline
@@ -1,5 +1,5 @@
 packages=55
 interfaces=76
-large_files=37
+large_files=38
 set_mutators=102
 database_opens=8


### PR DESCRIPTION
## Summary

The pseudo-loop audit (post-PRs #898/#899/#900) flagged MQTT-wake as the only "Tier 0" pseudo-loop that spawned a fresh one-shot loop per matching message, completely bypassing the Spec/cascade/SupervisorProfile system. Forge and media-feed already deliver to existing loops via `messages.NewEventSourceEnvelope`; this PR brings MQTT into the same pattern.

The framing: external events should *wake* existing loops with new context, not spawn bespoke per-event loops. An operator should be able to say *"frigate topics → metacog"* and have metacog's next iteration see the events in its pending notifications, running under its own Profile/SupervisorProfile/container cascade.

## What changed

### MQTT wake-target dispatch

`mqtt.WakeSubscription` grows a `WakeTarget` field (`messages.LoopWakeTarget`, the canonical type forge and media already use). When set, matching MQTT messages become `LoopEventPayload`s delivered to the target loop via the message bus — no new loop is spawned, the registry stays clean, and the target loop's cascade governs everything.

Subscriptions without a WakeTarget keep the legacy spawn-per-message behavior driven by the per-subscription `Profile` + `InitialTags`. The MQTT tool descriptions now point operators at `wake_loop` as the preferred path; the legacy fields remain documented for backwards compat but are marked as ignored when `wake_loop` is set.

### Cross-family tool surface alignment

| Concern | Before | After |
|---|---|---|
| `wake_loop` JSON schema | Three byte-identical duplicates (forge, media, the envelope itself) | One `messages.LoopWakeTargetSchema(description)` helper |
| Subscription identifier param | `id` (mqtt) / `feed_id` (media) / `subscription_id` (forge) | `subscription_id` canonical everywhere; `id` and `feed_id` kept as aliases |
| Return shapes | `mqtt_wake_*` and `media_unfollow` returned prose; forge returned JSON | All three families return JSON |
| `quality_floor` type | mqtt_wake_add declared as string | Integer everywhere, matching PR-Q1's LoopProfile conversion |
| Empty-list response | mqtt_wake_list returned "No MQTT wake subscriptions configured." | `[]` (canonical JSON empty array) |

### Persistence

New `wake_target_json` column on `mqtt_wake_subscriptions`, defaulted to `'{}'`. Pre-PR-T1 rows hydrate cleanly with an empty target, falling through to the legacy Profile-driven spawn path. No migration step needed.

### YAML config

`MQTT.subscriptions[]` grows an optional `wake_loop` field parallel to the existing `wake`. When both are set, `wake_loop` wins. When neither is set, the subscription is ambient-awareness only (debug-logged, not acted upon).

## What didn't move

- **Signal** and **OWU** stay session-shaped: per-sender / per-conversation loops are doing a different job (conversation continuity, not trigger dispatch). They keep the SpawnLoop pattern. This is the deliberate split between "triggers" (this PR) and "sessions" (deferred).

- **Email-poller** still self-handles new mail via TurnBuilder. Whether email becomes a trigger (deliver to metacog) or stays a session is a separate design conversation flagged in the audit.

## Test plan

- [x] `just ci` passes locally
- [x] `TestMQTTWakeHandlerDispatchesViaWakeTarget` — end-to-end: subscription with WakeTarget produces an event-source envelope on the bus, addressed correctly, with the MQTT topic + payload threaded through. Verifies NO agent spawn happens.
- [x] `TestMQTTWakeHandlerFallsBackToSpawnWithoutWakeTarget` — backwards-compat path: subscription with only legacy Profile uses spawn-per-message, never touches the bus.
- [x] Existing MQTT tests updated for the new `Add(AddRequest{...})` signature and JSON return shapes.
- [ ] Manual: deploy with a `wake_loop` config-defined subscription pointing at metacog; verify MQTT message → metacog's next iteration sees it as an event-source notification.

## Followups

- Email-poller trigger semantics (deferred per audit conversation)
- Storage shape unification for wake subscriptions (forge JSON-blob vs media flat-keys vs mqtt dedicated table — different patterns for the same concept)
- Bidirectional discoverability: "what triggers does loop X receive?" — natural after dispatch is unified

Refs #889