### PR TITLE
feat: trigger unification foundation (PR-T2a)

### DIFF
--- a/examples/config.example.yaml
+++ b/examples/config.example.yaml
@@ -516,6 +516,7 @@ talents_dir: ./talents
 #         forcesupervisor: false
 #         priority: ""
 #         instructions: ""
+#         tags: []
 #       Wake is the legacy dispatch-via-spawn path: when non-nil and
 #       WakeLoop is unset, messages on this topic spawn a one-shot
 #       agent run using this routing profile. New subscriptions
@@ -547,6 +548,7 @@ talents_dir: ./talents
 #         forcesupervisor: false
 #         priority: ""
 #         instructions: ""
+#         tags: []
 #       Wake is the legacy dispatch-via-spawn path: when non-nil and
 #       WakeLoop is unset, messages on this topic spawn a one-shot
 #       agent run using this routing profile. New subscriptions
@@ -578,6 +580,7 @@ talents_dir: ./talents
 #         forcesupervisor: false
 #         priority: ""
 #         instructions: ""
+#         tags: []
 #       Wake is the legacy dispatch-via-spawn path: when non-nil and
 #       WakeLoop is unset, messages on this topic spawn a one-shot
 #       agent run using this routing profile. New subscriptions

--- a/internal/channels/messages/envelope.go
+++ b/internal/channels/messages/envelope.go
@@ -205,4 +205,10 @@ type LoopNotifyPayload struct {
 	Context         string             `json:"context,omitempty"`
 	ForceSupervisor bool               `json:"force_supervisor,omitempty"`
 	Events          []LoopEventPayload `json:"events,omitempty"`
+	// Tags are iteration-scoped capability tags activated when the
+	// receiving loop processes this wake. They merge into the
+	// iteration's Request.InitialTags during pendingNotifies drain
+	// and fade unless the model explicitly activates them via tool.
+	// Sourced from [LoopWakeTarget.Tags] on the wake target.
+	Tags []string `json:"tags,omitempty"`
 }

--- a/internal/channels/messages/event_source.go
+++ b/internal/channels/messages/event_source.go
@@ -37,6 +37,18 @@ type LoopWakeTarget struct {
 	ForceSupervisor bool     `json:"force_supervisor,omitempty"`
 	Priority        Priority `json:"priority,omitempty"`
 	Instructions    string   `json:"instructions,omitempty"`
+	// Tags are iteration-scoped capability tags activated when the
+	// target loop processes this wake. They merge into the
+	// iteration's Request.InitialTags via the loop runtime's
+	// notification drain, then fade unless the model explicitly
+	// activates them via tool. Use this to route source-side
+	// classification outcomes (contacts → "owner" / "untrusted",
+	// MQTT topic patterns → "security" / "device_control") into
+	// the target loop's per-iteration tool surface and context
+	// providers without spawning a separate handler loop per
+	// classification. See the trigger-unification design in
+	// issue #902.
+	Tags []string `json:"tags,omitempty"`
 }
 
 // Empty reports whether the target has no loop selector.
@@ -81,6 +93,7 @@ func ParseLoopWakeTarget(raw any) (LoopWakeTarget, bool, error) {
 			Name:            stringMapValue(v, "name"),
 			ForceSupervisor: boolMapValue(v, "force_supervisor"),
 			Instructions:    stringMapValue(v, "instructions"),
+			Tags:            stringSliceMapValue(v, "tags"),
 		}
 		if priority := stringMapValue(v, "priority"); priority != "" {
 			target.Priority = Priority(priority)
@@ -165,6 +178,7 @@ func NewEventSourceEnvelope(from Identity, target LoopWakeTarget, source string,
 		Context:         strings.TrimSpace(target.Instructions),
 		ForceSupervisor: target.ForceSupervisor,
 		Events:          payloadEvents,
+		Tags:            append([]string(nil), target.Tags...),
 	}
 	scope := []string{"event_source"}
 	if source != "event_source" {
@@ -236,6 +250,45 @@ func stringMapValue(values map[string]any, key string) string {
 func boolMapValue(values map[string]any, key string) bool {
 	v, _ := values[key].(bool)
 	return v
+}
+
+// stringSliceMapValue extracts a []string from an args map,
+// accepting both []string (passed through Go-side) and []any
+// (tool-call args after JSON decode). Non-string elements are
+// silently filtered. Empty / missing returns nil so the field
+// stays omitempty-friendly.
+func stringSliceMapValue(values map[string]any, key string) []string {
+	v, ok := values[key]
+	if !ok {
+		return nil
+	}
+	switch s := v.(type) {
+	case []string:
+		out := make([]string, 0, len(s))
+		for _, item := range s {
+			if t := strings.TrimSpace(item); t != "" {
+				out = append(out, t)
+			}
+		}
+		if len(out) == 0 {
+			return nil
+		}
+		return out
+	case []any:
+		out := make([]string, 0, len(s))
+		for _, item := range s {
+			if str, ok := item.(string); ok {
+				if t := strings.TrimSpace(str); t != "" {
+					out = append(out, t)
+				}
+			}
+		}
+		if len(out) == 0 {
+			return nil
+		}
+		return out
+	}
+	return nil
 }
 
 func cloneLoopEventPayloads(events []LoopEventPayload) []LoopEventPayload {

--- a/internal/channels/messages/event_source_test.go
+++ b/internal/channels/messages/event_source_test.go
@@ -52,3 +52,73 @@ func TestNewEventSourceEnvelopeAllowsMaxBatch(t *testing.T) {
 		t.Fatalf("events len = %d, want %d", len(payload.Events), MaxLoopEventsPerWake)
 	}
 }
+
+func TestNewEventSourceEnvelopeCarriesWakeTags(t *testing.T) {
+	t.Parallel()
+
+	env, err := NewEventSourceEnvelope(
+		Identity{Kind: IdentitySystem, Name: "contacts"},
+		LoopWakeTarget{Name: "email-triage", Tags: []string{"owner", "high_trust"}},
+		"contacts",
+		[]LoopEventPayload{{Source: "contacts", Type: "match", ID: "1"}},
+	)
+	if err != nil {
+		t.Fatalf("NewEventSourceEnvelope: %v", err)
+	}
+	payload, ok := env.Payload.(LoopNotifyPayload)
+	if !ok {
+		t.Fatalf("payload type = %T, want LoopNotifyPayload", env.Payload)
+	}
+	if len(payload.Tags) != 2 || payload.Tags[0] != "owner" || payload.Tags[1] != "high_trust" {
+		t.Fatalf("payload.Tags = %v, want [owner high_trust]", payload.Tags)
+	}
+}
+
+func TestParseLoopWakeTargetExtractsTags(t *testing.T) {
+	t.Parallel()
+
+	t.Run("string slice", func(t *testing.T) {
+		raw := map[string]any{
+			"name": "triage",
+			"tags": []string{"owner", "", " untrusted "},
+		}
+		target, ok, err := ParseLoopWakeTarget(raw)
+		if err != nil {
+			t.Fatalf("ParseLoopWakeTarget: %v", err)
+		}
+		if !ok {
+			t.Fatal("ok = false, want true")
+		}
+		if len(target.Tags) != 2 || target.Tags[0] != "owner" || target.Tags[1] != "untrusted" {
+			t.Fatalf("Tags = %v, want [owner untrusted]", target.Tags)
+		}
+	})
+
+	t.Run("any slice (post-JSON decode)", func(t *testing.T) {
+		raw := map[string]any{
+			"name": "triage",
+			"tags": []any{"owner", 42, "device_control"},
+		}
+		target, ok, err := ParseLoopWakeTarget(raw)
+		if err != nil {
+			t.Fatalf("ParseLoopWakeTarget: %v", err)
+		}
+		if !ok {
+			t.Fatal("ok = false, want true")
+		}
+		if len(target.Tags) != 2 || target.Tags[0] != "owner" || target.Tags[1] != "device_control" {
+			t.Fatalf("Tags = %v, want [owner device_control]", target.Tags)
+		}
+	})
+
+	t.Run("absent tags", func(t *testing.T) {
+		raw := map[string]any{"name": "triage"}
+		target, _, err := ParseLoopWakeTarget(raw)
+		if err != nil {
+			t.Fatalf("ParseLoopWakeTarget: %v", err)
+		}
+		if target.Tags != nil {
+			t.Fatalf("Tags = %v, want nil", target.Tags)
+		}
+	})
+}

--- a/internal/channels/messages/wake_schema.go
+++ b/internal/channels/messages/wake_schema.go
@@ -39,6 +39,11 @@ func LoopWakeTargetSchema(description string) map[string]any {
 				"type":        "string",
 				"description": "Compact source-specific instructions included with the wake event.",
 			},
+			"tags": map[string]any{
+				"type":        "array",
+				"items":       map[string]any{"type": "string"},
+				"description": "Iteration-scoped capability tags activated when the target loop processes this wake. Use this to route source-side classification outcomes (contacts → \"owner\" / \"untrusted\", MQTT topic patterns → \"security\" / \"device_control\") into the target loop's per-iteration tool surface. Tags fade after the iteration unless the model explicitly activates them via tool.",
+			},
 		},
 	}
 }

--- a/internal/integrations/media/feed_wake.go
+++ b/internal/integrations/media/feed_wake.go
@@ -1,6 +1,7 @@
 package media
 
 import (
+	"encoding/json"
 	"fmt"
 
 	"github.com/nugget/thane-ai-agent/internal/channels/messages"
@@ -12,6 +13,7 @@ func feedKeyWakeLoopName(id string) string        { return "feed:" + id + ":wake
 func feedKeyWakeForceSupervisor(id string) string { return "feed:" + id + ":wake_force_supervisor" }
 func feedKeyWakePriority(id string) string        { return "feed:" + id + ":wake_priority" }
 func feedKeyWakeInstructions(id string) string    { return "feed:" + id + ":wake_instructions" }
+func feedKeyWakeTags(id string) string            { return "feed:" + id + ":wake_tags" }
 
 func feedWakeKeys(id string) []string {
 	return []string{
@@ -20,6 +22,7 @@ func feedWakeKeys(id string) []string {
 		feedKeyWakeForceSupervisor(id),
 		feedKeyWakePriority(id),
 		feedKeyWakeInstructions(id),
+		feedKeyWakeTags(id),
 	}
 }
 
@@ -46,12 +49,21 @@ func storeFeedWakeTarget(state *opstate.Store, feedID string, target messages.Lo
 	if !configured {
 		return nil
 	}
+	tagsJSON := ""
+	if len(target.Tags) > 0 {
+		blob, err := json.Marshal(target.Tags)
+		if err != nil {
+			return fmt.Errorf("marshal wake tags: %w", err)
+		}
+		tagsJSON = string(blob)
+	}
 	values := map[string]string{
 		feedKeyWakeLoopID(feedID):          target.LoopID,
 		feedKeyWakeLoopName(feedID):        target.Name,
 		feedKeyWakeForceSupervisor(feedID): fmt.Sprintf("%t", target.ForceSupervisor),
 		feedKeyWakePriority(feedID):        string(target.Priority),
 		feedKeyWakeInstructions(feedID):    target.Instructions,
+		feedKeyWakeTags(feedID):            tagsJSON,
 	}
 	for key, value := range values {
 		if err := state.Set(feedNamespace, key, value); err != nil {
@@ -85,6 +97,16 @@ func loadFeedWakeTarget(state *opstate.Store, feedID string) (messages.LoopWakeT
 	if err != nil {
 		return messages.LoopWakeTarget{}, false, err
 	}
+	tagsRaw, err := state.Get(feedNamespace, feedKeyWakeTags(feedID))
+	if err != nil {
+		return messages.LoopWakeTarget{}, false, err
+	}
+	var tags []string
+	if tagsRaw != "" {
+		if err := json.Unmarshal([]byte(tagsRaw), &tags); err != nil {
+			return messages.LoopWakeTarget{}, false, fmt.Errorf("decode wake tags: %w", err)
+		}
+	}
 
 	target, ok, err := messages.ParseLoopWakeTarget(map[string]any{
 		"loop_id":          loopID,
@@ -92,6 +114,7 @@ func loadFeedWakeTarget(state *opstate.Store, feedID string) (messages.LoopWakeT
 		"force_supervisor": forceRaw == "true",
 		"priority":         priorityRaw,
 		"instructions":     instructions,
+		"tags":             tags,
 	})
 	return target, ok, err
 }
@@ -116,6 +139,9 @@ func feedWakeTargetJSON(target messages.LoopWakeTarget, ok bool) map[string]any 
 	}
 	if target.Instructions != "" {
 		out["instructions"] = target.Instructions
+	}
+	if len(target.Tags) > 0 {
+		out["tags"] = append([]string(nil), target.Tags...)
 	}
 	return out
 }

--- a/internal/integrations/media/poller_test.go
+++ b/internal/integrations/media/poller_test.go
@@ -380,6 +380,44 @@ func TestCheckFeeds_WakeLoopDeliveryFailureKeepsHighWater(t *testing.T) {
 	}
 }
 
+// TestStoreFeedWakeTargetRoundTripsTags pins the P3 fix: Tags on a
+// feed's wake target persist alongside the other fields and round-trip
+// through loadFeedWakeTarget. Pre-fix, feed_wake.go's storage helpers
+// ignored target.Tags entirely.
+func TestStoreFeedWakeTargetRoundTripsTags(t *testing.T) {
+	store := newTestStore(t)
+
+	target := messages.LoopWakeTarget{
+		Name: "feed_curator",
+		Tags: []string{"owner", "research"},
+	}
+	if err := storeFeedWakeTarget(store, "cf1", target, true); err != nil {
+		t.Fatalf("storeFeedWakeTarget: %v", err)
+	}
+	got, ok, err := loadFeedWakeTarget(store, "cf1")
+	if err != nil || !ok {
+		t.Fatalf("loadFeedWakeTarget ok=%v err=%v", ok, err)
+	}
+	if len(got.Tags) != 2 || got.Tags[0] != "owner" || got.Tags[1] != "research" {
+		t.Fatalf("round-tripped Tags = %v, want [owner research]", got.Tags)
+	}
+
+	// JSON projection also surfaces Tags so list-style tool responses
+	// show what the operator configured.
+	jsonProj := feedWakeTargetJSON(got, true)
+	tagsRaw, ok := jsonProj["tags"]
+	if !ok {
+		t.Fatal("feedWakeTargetJSON dropped tags")
+	}
+	tags, ok := tagsRaw.([]string)
+	if !ok {
+		t.Fatalf("feedWakeTargetJSON tags type = %T, want []string", tagsRaw)
+	}
+	if len(tags) != 2 || tags[0] != "owner" || tags[1] != "research" {
+		t.Fatalf("feedWakeTargetJSON tags = %v, want [owner research]", tags)
+	}
+}
+
 func TestStoreFeedWakeTargetClearsWhenOmitted(t *testing.T) {
 	store := newTestStore(t)
 

--- a/internal/runtime/loop/agent_turn.go
+++ b/internal/runtime/loop/agent_turn.go
@@ -23,6 +23,15 @@ type TurnInput struct {
 	// this wake. Task-based turns render them into the prompt; custom
 	// builders may inspect or ignore them.
 	NotifyEnvelopes []messages.Envelope
+
+	// WakeTags are iteration-scoped capability tags carried on the
+	// envelopes that woke this iteration (see [messages.LoopWakeTarget.Tags]).
+	// They fade after this iteration unless the model explicitly
+	// activates them via tool. The loop runtime folds them into the
+	// final Request.InitialTags merge automatically for task-built
+	// turns; custom builders can inspect them when shaping their own
+	// request.
+	WakeTags []string
 }
 
 // AgentTurn is an agent request prepared by loop-adjacent code for the

--- a/internal/runtime/loop/config.go
+++ b/internal/runtime/loop/config.go
@@ -360,6 +360,13 @@ func (c *Config) applyDefaults() {
 		// this contract by being a container.
 		return
 	}
+	if c.Operation == OperationEventDriven {
+		// Event-driven loops wake only on notifications or
+		// [Config.WaitFunc] channel reads — they have no periodic
+		// timer. Synthesizing sleep defaults would just write
+		// inert-but-misleading values on the Config.
+		return
+	}
 	if c.SleepMin == 0 {
 		c.SleepMin = DefaultSleepMin
 	}
@@ -398,11 +405,17 @@ func (c *Config) validate() error {
 	if c.Handler == nil && c.Task == "" && c.TaskBuilder == nil && c.TurnBuilder == nil {
 		return fmt.Errorf("loop: Task, TaskBuilder, TurnBuilder, or Handler is required")
 	}
-	if c.SleepMin <= 0 {
-		return fmt.Errorf("loop: SleepMin must be positive, got %v", c.SleepMin)
-	}
-	if c.SleepMax < c.SleepMin {
-		return fmt.Errorf("loop: SleepMax (%v) must be >= SleepMin (%v)", c.SleepMax, c.SleepMin)
+	if c.Operation != OperationEventDriven {
+		// Timer-driven loops require a positive sleep envelope.
+		// Event-driven loops are deliberately timer-less (sleep is
+		// zero) — they wake only on notifications or WaitFunc, so
+		// these checks would be incorrect for them.
+		if c.SleepMin <= 0 {
+			return fmt.Errorf("loop: SleepMin must be positive, got %v", c.SleepMin)
+		}
+		if c.SleepMax < c.SleepMin {
+			return fmt.Errorf("loop: SleepMax (%v) must be >= SleepMin (%v)", c.SleepMax, c.SleepMin)
+		}
 	}
 	if c.Jitter != nil && (*c.Jitter < 0 || *c.Jitter > 1) {
 		return fmt.Errorf("loop: Jitter must be in [0, 1], got %v", *c.Jitter)

--- a/internal/runtime/loop/config.go
+++ b/internal/runtime/loop/config.go
@@ -337,6 +337,14 @@ const (
 	DefaultSleepDefault   = 1 * time.Minute
 	DefaultJitter         = 0.2
 	DefaultSupervisorProb = 0.1
+
+	// eventDrivenErrorBackoff is the floor applied to wait-error
+	// backoffs on event-driven loops. Event-driven specs intentionally
+	// carry no sleep envelope, so [Loop.computeSleep] returns zero and
+	// a chronically failing WaitFunc would otherwise tight-loop. Keep
+	// this short enough that healthy upstream recovery is observed
+	// quickly and long enough that the broken case doesn't burn CPU.
+	eventDrivenErrorBackoff = 5 * time.Second
 )
 
 // Float64Ptr returns a pointer to v. Use it to set optional *float64
@@ -573,8 +581,11 @@ type Status struct {
 	// HandlerOnly is true when the loop uses a Handler instead of LLM
 	// iterations. Handler-only loops have no token metrics.
 	HandlerOnly bool `json:"handler_only,omitempty"`
-	// EventDriven is true when the loop uses a WaitFunc instead of
-	// timer-based sleeping.
+	// EventDriven is true when the loop's run shape is event-driven
+	// rather than timer-based — either it has a [Config.WaitFunc]
+	// channel reader, or its operation kind is [OperationEventDriven]
+	// (the persistable form that blocks on notification arrivals
+	// instead of a periodic sleep).
 	EventDriven bool `json:"event_driven,omitempty"`
 	// RecentIterations holds up to 10 completed iteration snapshots
 	// (newest first), used by the dashboard timeline.

--- a/internal/runtime/loop/loop.go
+++ b/internal/runtime/loop/loop.go
@@ -1042,7 +1042,11 @@ func (l *Loop) run(ctx context.Context) {
 	// iteration instead of firing immediately. The delay is jittered
 	// from SleepDefault to stagger loop starts and avoid a thundering
 	// herd of simultaneous iterations after a restart.
-	if l.config.WaitFunc == nil {
+	//
+	// Event-driven loops (WaitFunc-based or OperationEventDriven)
+	// have no periodic timer; they skip initial sleep and proceed
+	// directly to the wait phase at the top of the iteration loop.
+	if l.config.WaitFunc == nil && l.config.Operation != OperationEventDriven {
 		initialSleep := l.applyJitter(l.config.SleepDefault)
 		initialSleep = l.clamp(initialSleep)
 
@@ -1086,10 +1090,22 @@ func (l *Loop) run(ctx context.Context) {
 			break
 		}
 
-		// --- WAIT PHASE (top of loop, WaitFunc loops only) ---
-		// Event-driven loops block here until an external event
-		// arrives. This runs before the first iteration — no event
-		// has occurred yet, so there is nothing to process.
+		// --- WAIT PHASE (top of loop, event-driven loops only) ---
+		// Loops that don't iterate on a timer block here until the
+		// next wake. Two flavors:
+		//
+		//   - WaitFunc-based (legacy, runtime-only): reads from a
+		//     caller-supplied channel via [Config.WaitFunc]. The
+		//     payload becomes the iteration's `event` input.
+		//
+		//   - OperationEventDriven (modern, persistable): blocks
+		//     on the loop's notification channel via
+		//     [Loop.waitForWake]. The next iteration drains
+		//     pendingNotifies for the events; there's no separate
+		//     `event` payload from a user channel.
+		//
+		// This runs before the first iteration — no event has
+		// occurred yet, so there is nothing to process.
 		if l.config.WaitFunc != nil {
 			l.setState(StateWaiting)
 			l.publishEvent(events.Event{
@@ -1164,9 +1180,34 @@ func (l *Loop) run(ctx context.Context) {
 			if event == nil {
 				continue
 			}
+		} else if l.config.Operation == OperationEventDriven {
+			// OperationEventDriven without a WaitFunc: block on
+			// the notification channel until something asks this
+			// loop to run. The wake-source (forge poller, MQTT
+			// dispatcher, request_core_attention, etc.) pushes
+			// envelopes via [Loop.Notify], which signals wakeCh.
+			// The next iteration drains pendingNotifies for the
+			// actual event content.
+			l.setState(StateWaiting)
+			l.publishEvent(events.Event{
+				Timestamp: time.Now(),
+				Source:    events.SourceLoop,
+				Kind:      events.KindLoopWaitStart,
+				Data: map[string]any{
+					"loop_id":   l.id,
+					"loop_name": l.config.Name,
+				},
+			})
+			logger.Debug("event-driven loop waiting for notification")
+			if !l.waitForWake(ctx) {
+				logger.Debug("loop stopped while waiting for notification",
+					"phase", "wait",
+				)
+				break
+			}
 		}
 
-		signals, forceSupervisor := l.consumePendingNotifies()
+		signals, forceSupervisor, wakeTags := l.consumePendingNotifies()
 
 		// --- PROCESSING PHASE ---
 		// Reset tool-provided sleep override and set current conversation ID.
@@ -1224,6 +1265,7 @@ func (l *Loop) run(ctx context.Context) {
 			handlerCtx = withLoopID(handlerCtx, l.id)
 			handlerCtx = withFallbackContent(handlerCtx, l.config.FallbackContent)
 			handlerCtx = withNotifyEnvelopes(handlerCtx, signals)
+			handlerCtx = withWakeTags(handlerCtx, wakeTags)
 			if handlerErr := l.config.Handler(handlerCtx, event); handlerErr != nil {
 				if errors.Is(handlerErr, ErrNoOp) {
 					noOp = true
@@ -1307,10 +1349,12 @@ func (l *Loop) run(ctx context.Context) {
 			turnCtx := withLoopID(iterCtx, l.id)
 			turnCtx = withFallbackContent(turnCtx, l.config.FallbackContent)
 			turnCtx = withNotifyEnvelopes(turnCtx, signals)
+			turnCtx = withWakeTags(turnCtx, wakeTags)
 			turn, buildErr := l.buildAgentTurn(turnCtx, TurnInput{
 				Event:           event,
 				Supervisor:      isSupervisor,
 				NotifyEnvelopes: signals,
+				WakeTags:        wakeTags,
 			})
 			if buildErr != nil {
 				if errors.Is(buildErr, ErrNoOp) {
@@ -1559,9 +1603,10 @@ func (l *Loop) run(ctx context.Context) {
 		}
 
 		// --- SLEEP PHASE (bottom of loop, timer-driven loops only) ---
-		// WaitFunc loops skip sleep and flow back to the top to wait
-		// for the next event.
-		if l.config.WaitFunc == nil {
+		// Event-driven loops (WaitFunc-based and OperationEventDriven)
+		// skip the sleep phase and flow back to the top to wait for
+		// the next event/notification.
+		if l.config.WaitFunc == nil && l.config.Operation != OperationEventDriven {
 			l.setState(StateSleeping)
 			l.publishEvent(events.Event{
 				Timestamp: time.Now(),
@@ -1740,7 +1785,8 @@ func (l *Loop) buildTaskTurn(ctx context.Context, input TurnInput) (*AgentTurn, 
 
 	return &AgentTurn{
 		Request: Request{
-			Messages: []Message{{Role: "user", Content: task}},
+			Messages:    []Message{{Role: "user", Content: task}},
+			InitialTags: append([]string(nil), input.WakeTags...),
 		},
 	}, nil
 }

--- a/internal/runtime/loop/loop.go
+++ b/internal/runtime/loop/loop.go
@@ -442,6 +442,16 @@ func (l *Loop) ParentID() string {
 // construction; safe to read without the loop lock.
 func (l *Loop) Operation() Operation { return l.config.Operation }
 
+// isEventDriven reports whether the loop's run shape is event-driven —
+// either via a [Config.WaitFunc] channel reader (the legacy runtime-only
+// form) or via [OperationEventDriven] (the persistable form added in
+// PR-T2a). Status, logs, iteration snapshots, and stop telemetry use
+// this to surface a single truthful flag instead of forking on
+// WaitFunc != nil at every site.
+func (l *Loop) isEventDriven() bool {
+	return l.config.WaitFunc != nil || l.config.Operation == OperationEventDriven
+}
+
 // shouldRunSupervisor decides whether the next iteration runs as
 // a supervisor turn and reports the cause. Forced is the boolean
 // from [consumePendingNotifies] — true when at least one pending
@@ -691,7 +701,7 @@ func (l *Loop) Status() Status {
 		LastSupervisorIter:    l.lastSupervisorIter,
 		LastSupervisorTrigger: l.lastSupervisorTrigger,
 		HandlerOnly:           l.config.Handler != nil,
-		EventDriven:           l.config.WaitFunc != nil,
+		EventDriven:           l.isEventDriven(),
 		Config:                cfgCopy,
 	}
 	l.mu.Unlock()
@@ -1027,7 +1037,7 @@ func (l *Loop) run(ctx context.Context) {
 		"max_iter", l.config.MaxIter,
 		"supervisor", l.config.Supervisor,
 		"handler_only", l.config.Handler != nil,
-		"event_driven", l.config.WaitFunc != nil,
+		"event_driven", l.isEventDriven(),
 	)
 
 	// Apply max duration as a context deadline if configured.
@@ -1150,6 +1160,17 @@ func (l *Loop) run(ctx context.Context) {
 					},
 				})
 				backoff := l.computeSleep()
+				// Event-driven loops (OperationEventDriven, or any spec
+				// that left the sleep envelope at zero) would tight-loop
+				// here on a chronically failing WaitFunc — computeSleep
+				// returns 0, sleep returns immediately, the error fires
+				// again. Floor the wait-error backoff at
+				// eventDrivenErrorBackoff so the upstream source has
+				// breathing room without forcing operators to declare a
+				// sleep envelope they otherwise don't need.
+				if backoff <= 0 {
+					backoff = eventDrivenErrorBackoff
+				}
 				logger.Warn("loop wait failed",
 					"error", waitErr,
 					"consecutive_errors", consecutiveErrors,
@@ -1561,7 +1582,7 @@ func (l *Loop) run(ctx context.Context) {
 			sleep = l.computeSleep()
 
 			// Record sleep/wait info on the snapshot before buffering.
-			if l.config.WaitFunc != nil {
+			if l.isEventDriven() {
 				snap.WaitAfter = true
 			} else {
 				snap.SleepAfterMs = sleep.Milliseconds()
@@ -1643,7 +1664,7 @@ func (l *Loop) emitStopped() {
 	consecutiveErrors := l.consecutiveErrors
 	startedAt := l.startedAt
 	handlerOnly := l.config.Handler != nil
-	eventDriven := l.config.WaitFunc != nil
+	eventDriven := l.isEventDriven()
 	l.mu.Unlock()
 
 	logger := l.deps.Logger

--- a/internal/runtime/loop/signals.go
+++ b/internal/runtime/loop/signals.go
@@ -5,11 +5,27 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"sort"
 	"strings"
 	"time"
 
 	"github.com/nugget/thane-ai-agent/internal/channels/messages"
 )
+
+// priorityRank maps a message priority to a sort key. Higher rank
+// renders first in summarizeNotifyEnvelopes, so urgent notifications
+// lead the prompt and the model sees the most important wake content
+// before any normal- or low-priority companions.
+func priorityRank(p messages.Priority) int {
+	switch p {
+	case messages.PriorityUrgent:
+		return 2
+	case messages.PriorityLow:
+		return 0
+	default:
+		return 1
+	}
+}
 
 // maxPendingNotifications bounds how many one-shot inter-loop notifications a
 // live loop may queue while it is busy or sleeping. enqueueNotify rejects new
@@ -42,6 +58,8 @@ type NotifyReceipt struct {
 
 type notifyContextKey struct{}
 
+type wakeTagsContextKey struct{}
+
 // NotifyEnvelopesFromContext returns one-shot message envelopes delivered to
 // the current loop iteration, if any.
 func NotifyEnvelopesFromContext(ctx context.Context) []messages.Envelope {
@@ -54,6 +72,22 @@ func NotifyEnvelopesFromContext(ctx context.Context) []messages.Envelope {
 	return out
 }
 
+// WakeTagsFromContext returns the iteration-scoped capability tags
+// carried on the envelopes that woke the current loop iteration, if any.
+// Handler-based loops can use this to observe source-classified tags
+// (for example contacts → "owner", MQTT topic → "security") that the
+// loop runtime has already folded into the iteration's Request.InitialTags
+// for task-built turns.
+func WakeTagsFromContext(ctx context.Context) []string {
+	tags, _ := ctx.Value(wakeTagsContextKey{}).([]string)
+	if len(tags) == 0 {
+		return nil
+	}
+	out := make([]string, len(tags))
+	copy(out, tags)
+	return out
+}
+
 func withNotifyEnvelopes(ctx context.Context, envs []messages.Envelope) context.Context {
 	if len(envs) == 0 {
 		return ctx
@@ -61,6 +95,15 @@ func withNotifyEnvelopes(ctx context.Context, envs []messages.Envelope) context.
 	cp := make([]messages.Envelope, len(envs))
 	copy(cp, envs)
 	return context.WithValue(ctx, notifyContextKey{}, cp)
+}
+
+func withWakeTags(ctx context.Context, tags []string) context.Context {
+	if len(tags) == 0 {
+		return ctx
+	}
+	cp := make([]string, len(tags))
+	copy(cp, tags)
+	return context.WithValue(ctx, wakeTagsContextKey{}, cp)
 }
 
 func decodeLoopNotifyPayload(raw any) (messages.LoopNotifyPayload, error) {
@@ -94,6 +137,16 @@ func summarizeNotifyEnvelopes(envs []messages.Envelope) string {
 	if len(envs) == 0 {
 		return ""
 	}
+	// Sort by priority descending so urgent wake notifications lead the
+	// prompt. Use a stable sort so envelopes that share a priority keep
+	// their arrival order, preserving the producer's intent for batches
+	// from the same source (e.g. ordered event-source events delivered
+	// together).
+	ordered := make([]messages.Envelope, len(envs))
+	copy(ordered, envs)
+	sort.SliceStable(ordered, func(i, j int) bool {
+		return priorityRank(ordered[i].Priority) > priorityRank(ordered[j].Priority)
+	})
 	type notifyView struct {
 		ID       string            `json:"id"`
 		From     messages.Identity `json:"from"`
@@ -101,8 +154,8 @@ func summarizeNotifyEnvelopes(envs []messages.Envelope) string {
 		Scope    []string          `json:"scope,omitempty"`
 		Payload  map[string]any    `json:"payload,omitempty"`
 	}
-	views := make([]notifyView, 0, len(envs))
-	for _, env := range envs {
+	views := make([]notifyView, 0, len(ordered))
+	for _, env := range ordered {
 		payload, _ := decodeLoopNotifyPayload(env.Payload)
 		view := notifyView{
 			ID:       env.ID,
@@ -218,7 +271,25 @@ func (l *Loop) enqueueNotify(env messages.Envelope) (NotifyReceipt, error) {
 	return receipt, nil
 }
 
-func (l *Loop) consumePendingNotifies() ([]messages.Envelope, bool) {
+// consumePendingNotifies drains the loop's pending notification
+// queue and returns the envelopes alongside the aggregated
+// per-iteration directives derived from them:
+//
+//   - forceSupervisor — true when ANY envelope carried
+//     [LoopNotifyPayload.ForceSupervisor]. The supervisor-turn
+//     decision OR's across all draining notifications.
+//   - tags — the deduplicated union of
+//     [LoopNotifyPayload.Tags] across all envelopes. These are
+//     iteration-scoped capability tags that the trigger source
+//     (forge, MQTT, contacts classifier in email, etc.) wants
+//     activated for the upcoming iteration's tool surface and
+//     context providers. Empty slice when no envelopes carry tags.
+//
+// Tags are returned as a separate value (not embedded in the
+// envelope return) so callers can merge them into
+// [Request.InitialTags] before [prepareAgentTurnRequest] runs the
+// final tag aggregation.
+func (l *Loop) consumePendingNotifies() ([]messages.Envelope, bool, []string) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 	if len(l.pendingNotifies) == 0 {
@@ -229,20 +300,34 @@ func (l *Loop) consumePendingNotifies() ([]messages.Envelope, bool) {
 		case <-l.wakeCh:
 		default:
 		}
-		return nil, false
+		return nil, false, nil
 	}
 	envs := make([]messages.Envelope, 0, len(l.pendingNotifies))
 	forceSupervisor := false
+	seenTags := make(map[string]struct{})
+	var tags []string
 	for _, sig := range l.pendingNotifies {
 		envs = append(envs, sig.Envelope)
 		forceSupervisor = forceSupervisor || sig.ForceSupervisor
+		if payload, ok := sig.Envelope.Payload.(messages.LoopNotifyPayload); ok {
+			for _, tag := range payload.Tags {
+				if tag == "" {
+					continue
+				}
+				if _, dup := seenTags[tag]; dup {
+					continue
+				}
+				seenTags[tag] = struct{}{}
+				tags = append(tags, tag)
+			}
+		}
 	}
 	l.pendingNotifies = nil
 	select {
 	case <-l.wakeCh:
 	default:
 	}
-	return envs, forceSupervisor
+	return envs, forceSupervisor, tags
 }
 
 func (l *Loop) waitForEvent(ctx context.Context) (any, error) {
@@ -282,6 +367,25 @@ func (l *Loop) sleep(ctx context.Context, d time.Duration) bool {
 		return false
 	case <-timer.C:
 		return true
+	case <-l.wakeCh:
+		return true
+	}
+}
+
+// waitForWake blocks until a notification arrives or the context is
+// cancelled. The notification path used by event-driven loops
+// (operation=event_driven without a [Config.WaitFunc]) — these loops
+// have no periodic timer to wake on, so they wait indefinitely on
+// the notification channel that [Loop.Notify] writes into.
+//
+// Returns true on wake (a notification arrived; the caller should
+// continue to the iteration phase, where consumePendingNotifies
+// drains the envelopes), false on context cancellation (the loop
+// should exit).
+func (l *Loop) waitForWake(ctx context.Context) bool {
+	select {
+	case <-ctx.Done():
+		return false
 	case <-l.wakeCh:
 		return true
 	}

--- a/internal/runtime/loop/signals.go
+++ b/internal/runtime/loop/signals.go
@@ -43,6 +43,7 @@ const maxNotifyEventsInSummary = messages.MaxLoopEventsPerWake
 type pendingNotify struct {
 	Envelope        messages.Envelope
 	ForceSupervisor bool
+	Tags            []string
 }
 
 // NotifyReceipt summarizes the effect of notifying a live loop.
@@ -248,9 +249,11 @@ func (l *Loop) enqueueNotify(env messages.Envelope) (NotifyReceipt, error) {
 		return NotifyReceipt{}, fmt.Errorf("loop %q notify queue full (%d pending)", l.config.Name, len(l.pendingNotifies))
 	}
 
+	tags := cleanNotifyTags(payload.Tags)
 	l.pendingNotifies = append(l.pendingNotifies, pendingNotify{
 		Envelope:        env,
 		ForceSupervisor: payload.ForceSupervisor,
+		Tags:            tags,
 	})
 	receipt := NotifyReceipt{
 		LoopID:               l.id,
@@ -259,16 +262,52 @@ func (l *Loop) enqueueNotify(env messages.Envelope) (NotifyReceipt, error) {
 		ForceSupervisor:      payload.ForceSupervisor,
 		PendingNotifications: len(l.pendingNotifies),
 	}
+	// Signal wakeCh unconditionally. A notification arriving while the
+	// loop is in StateProcessing must still poke the channel so the
+	// next waitForWake (event-driven loops with no periodic timer) or
+	// next sleep (timer-driven loops, which become 0-duration on
+	// signal) sees it and drains pendingNotifies. Without this, an
+	// event-driven loop that is busy when a notification arrives can
+	// strand the message until some later unrelated wake repokes the
+	// channel. Spurious wakes are absorbed harmlessly:
+	// consumePendingNotifies drains wakeCh when no items are queued.
+	select {
+	case l.wakeCh <- struct{}{}:
+	default:
+	}
 	if l.state == StateSleeping || l.state == StateWaiting {
-		select {
-		case l.wakeCh <- struct{}{}:
-		default:
-		}
 		receipt.WokeImmediately = true
 	} else {
 		receipt.QueuedForNextWake = true
 	}
 	return receipt, nil
+}
+
+// cleanNotifyTags returns a deduplicated, whitespace-trimmed copy of
+// the tag slice, dropping empties. The caller hands ownership of the
+// returned slice to pendingNotify; mutation of the source after the
+// call does not affect the stored tags.
+func cleanNotifyTags(in []string) []string {
+	if len(in) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(in))
+	out := make([]string, 0, len(in))
+	for _, tag := range in {
+		t := strings.TrimSpace(tag)
+		if t == "" {
+			continue
+		}
+		if _, dup := seen[t]; dup {
+			continue
+		}
+		seen[t] = struct{}{}
+		out = append(out, t)
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
 }
 
 // consumePendingNotifies drains the loop's pending notification
@@ -309,17 +348,17 @@ func (l *Loop) consumePendingNotifies() ([]messages.Envelope, bool, []string) {
 	for _, sig := range l.pendingNotifies {
 		envs = append(envs, sig.Envelope)
 		forceSupervisor = forceSupervisor || sig.ForceSupervisor
-		if payload, ok := sig.Envelope.Payload.(messages.LoopNotifyPayload); ok {
-			for _, tag := range payload.Tags {
-				if tag == "" {
-					continue
-				}
-				if _, dup := seenTags[tag]; dup {
-					continue
-				}
-				seenTags[tag] = struct{}{}
-				tags = append(tags, tag)
+		// Tags are pre-decoded at enqueue time, so all valid payload
+		// shapes (LoopNotifyPayload value, *LoopNotifyPayload pointer,
+		// map[string]any from a JSON-decoded bus envelope) contribute
+		// uniformly. The previous Envelope.Payload type-assert would
+		// silently drop tags from the pointer and map forms.
+		for _, tag := range sig.Tags {
+			if _, dup := seenTags[tag]; dup {
+				continue
 			}
+			seenTags[tag] = struct{}{}
+			tags = append(tags, tag)
 		}
 	}
 	l.pendingNotifies = nil

--- a/internal/runtime/loop/signals_test.go
+++ b/internal/runtime/loop/signals_test.go
@@ -266,6 +266,135 @@ func TestLoopNotifyQueueBounded(t *testing.T) {
 	}
 }
 
+// TestOperationEventDrivenReportsEventDrivenStatus pins the P2 fix:
+// status, logs, and snapshots all key off [Loop.isEventDriven], which
+// returns true for both WaitFunc-based loops AND OperationEventDriven
+// specs. Pre-fix, a persisted operation: event_driven loop showed up
+// as timed/non-event-driven in /api/loops and the dashboard.
+func TestOperationEventDrivenReportsEventDrivenStatus(t *testing.T) {
+	t.Parallel()
+
+	l, err := New(Config{
+		Name:      "declared-event-driven",
+		Task:      "watch",
+		Operation: OperationEventDriven,
+	}, Deps{Runner: &noopRunner{}})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	status := l.Status()
+	if !status.EventDriven {
+		t.Errorf("Status.EventDriven = false, want true for OperationEventDriven")
+	}
+}
+
+// TestLoopNotifyPokesWakeChWhileProcessing pins the P1 fix: a
+// notification arriving while an event-driven loop is in StateProcessing
+// must still poke wakeCh so the next waitForWake doesn't strand the
+// pendingNotify. Pre-fix, enqueueNotify skipped the channel signal when
+// state != Sleeping/Waiting, leaving the queued item until some later
+// unrelated wake repoked the channel.
+func TestLoopNotifyPokesWakeChWhileProcessing(t *testing.T) {
+	t.Parallel()
+
+	l, err := New(Config{
+		Name: "busy-event-driven",
+		Task: "watch",
+	}, Deps{Runner: &noopRunner{}})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	l.mu.Lock()
+	l.started = true
+	l.state = StateProcessing
+	l.mu.Unlock()
+
+	env, err := (messages.Envelope{
+		From: messages.Identity{Kind: messages.IdentityCore},
+		To: messages.Destination{
+			Kind:     messages.DestinationLoop,
+			Target:   l.Name(),
+			Selector: messages.SelectorName,
+		},
+		Type: messages.TypeSignal,
+	}).Normalize(time.Now())
+	if err != nil {
+		t.Fatalf("Normalize: %v", err)
+	}
+	receipt, err := l.enqueueNotify(env)
+	if err != nil {
+		t.Fatalf("enqueueNotify: %v", err)
+	}
+	if receipt.WokeImmediately {
+		t.Errorf("WokeImmediately = true, want false (state was Processing)")
+	}
+	if !receipt.QueuedForNextWake {
+		t.Errorf("QueuedForNextWake = false, want true")
+	}
+	// The channel must be non-empty so the next waitForWake returns
+	// instead of blocking.
+	select {
+	case <-l.wakeCh:
+	default:
+		t.Fatal("wakeCh was not signaled while loop in StateProcessing — next waitForWake would block and strand the queued notification")
+	}
+}
+
+// TestConsumePendingNotifiesDecodesPointerAndMapPayloads exercises the
+// P2/Copilot tag-aggregation fix: tags arriving on *LoopNotifyPayload
+// and map[string]any payloads now contribute to the iteration's
+// returned tag set. Pre-fix, only the concrete LoopNotifyPayload type
+// assertion fired, silently dropping the others.
+func TestConsumePendingNotifiesDecodesPointerAndMapPayloads(t *testing.T) {
+	t.Parallel()
+
+	l, err := New(Config{
+		Name: "tag-decode",
+		Task: "watch",
+	}, Deps{Runner: &noopRunner{}})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	l.mu.Lock()
+	l.started = true
+	l.state = StateProcessing
+	l.mu.Unlock()
+
+	dest := messages.Destination{Kind: messages.DestinationLoop, Target: l.Name(), Selector: messages.SelectorName}
+
+	pointerEnv, err := (messages.Envelope{
+		From: messages.Identity{Kind: messages.IdentityCore}, To: dest, Type: messages.TypeSignal,
+		Payload: &messages.LoopNotifyPayload{Tags: []string{"pointer_tag"}},
+	}).Normalize(time.Now())
+	if err != nil {
+		t.Fatalf("Normalize pointer: %v", err)
+	}
+	mapEnv, err := (messages.Envelope{
+		From: messages.Identity{Kind: messages.IdentityCore}, To: dest, Type: messages.TypeSignal,
+		Payload: map[string]any{"tags": []any{"map_tag", "pointer_tag"}},
+	}).Normalize(time.Now())
+	if err != nil {
+		t.Fatalf("Normalize map: %v", err)
+	}
+	for _, env := range []messages.Envelope{pointerEnv, mapEnv} {
+		if _, err := l.enqueueNotify(env); err != nil {
+			t.Fatalf("enqueueNotify: %v", err)
+		}
+	}
+
+	_, _, tags := l.consumePendingNotifies()
+	got := map[string]bool{}
+	for _, tag := range tags {
+		got[tag] = true
+	}
+	if !got["pointer_tag"] || !got["map_tag"] {
+		t.Fatalf("tags = %v, want both pointer_tag and map_tag", tags)
+	}
+	if len(tags) != 2 {
+		t.Fatalf("tags = %v, want exactly 2 unique", tags)
+	}
+}
+
 func TestLoopNotifyTagsFlowIntoInitialTags(t *testing.T) {
 	t.Parallel()
 

--- a/internal/runtime/loop/signals_test.go
+++ b/internal/runtime/loop/signals_test.go
@@ -266,6 +266,183 @@ func TestLoopNotifyQueueBounded(t *testing.T) {
 	}
 }
 
+func TestLoopNotifyTagsFlowIntoInitialTags(t *testing.T) {
+	t.Parallel()
+
+	reqs := make(chan RunRequest, 1)
+	runner := &inspectingRunner{
+		onRun: func(req RunRequest) {
+			reqs <- req
+		},
+	}
+	l, err := New(Config{
+		Name:         "tag-wake",
+		Task:         "Triage incoming notifications.",
+		SleepMin:     time.Hour,
+		SleepMax:     time.Hour,
+		SleepDefault: time.Hour,
+		Jitter:       Float64Ptr(0),
+		MaxIter:      1,
+	}, Deps{Runner: runner, Rand: fixedRand{0}})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := l.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	waitForLoopState(t, l, StateSleeping)
+
+	env, err := (messages.Envelope{
+		From: messages.Identity{Kind: messages.IdentityCore, Name: "core"},
+		To: messages.Destination{
+			Kind:     messages.DestinationLoop,
+			Target:   l.Name(),
+			Selector: messages.SelectorName,
+		},
+		Type: messages.TypeSignal,
+		Payload: messages.LoopNotifyPayload{
+			Message: "Triage triggered by classifier.",
+			Tags:    []string{"owner", "untrusted"},
+		},
+	}).Normalize(time.Now())
+	if err != nil {
+		t.Fatalf("Normalize: %v", err)
+	}
+	if _, err := l.enqueueNotify(env); err != nil {
+		t.Fatalf("enqueueNotify: %v", err)
+	}
+
+	select {
+	case req := <-reqs:
+		got := map[string]bool{}
+		for _, tag := range req.InitialTags {
+			got[tag] = true
+		}
+		if !got["owner"] || !got["untrusted"] {
+			t.Fatalf("InitialTags = %v, want owner+untrusted", req.InitialTags)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("loop did not wake after tag-carrying signal")
+	}
+	l.Stop()
+	select {
+	case <-l.Done():
+	case <-time.After(2 * time.Second):
+		t.Fatal("loop did not finish")
+	}
+}
+
+func TestConsumePendingNotifiesAggregatesWakeTags(t *testing.T) {
+	t.Parallel()
+
+	l, err := New(Config{
+		Name: "tag-aggregator",
+		Task: "watch",
+	}, Deps{Runner: &noopRunner{}})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	l.mu.Lock()
+	l.started = true
+	l.state = StateProcessing
+	l.mu.Unlock()
+
+	mkEnv := func(tags []string) messages.Envelope {
+		env, err := (messages.Envelope{
+			From: messages.Identity{Kind: messages.IdentityCore},
+			To: messages.Destination{
+				Kind:     messages.DestinationLoop,
+				Target:   l.Name(),
+				Selector: messages.SelectorName,
+			},
+			Type: messages.TypeSignal,
+			Payload: messages.LoopNotifyPayload{
+				Tags: tags,
+			},
+		}).Normalize(time.Now())
+		if err != nil {
+			t.Fatalf("Normalize: %v", err)
+		}
+		return env
+	}
+
+	if _, err := l.enqueueNotify(mkEnv([]string{"owner", "security"})); err != nil {
+		t.Fatalf("enqueueNotify: %v", err)
+	}
+	if _, err := l.enqueueNotify(mkEnv([]string{"owner", "device_control", ""})); err != nil {
+		t.Fatalf("enqueueNotify: %v", err)
+	}
+	if _, err := l.enqueueNotify(mkEnv(nil)); err != nil {
+		t.Fatalf("enqueueNotify: %v", err)
+	}
+
+	envs, force, tags := l.consumePendingNotifies()
+	if len(envs) != 3 {
+		t.Fatalf("envelopes len = %d, want 3", len(envs))
+	}
+	if force {
+		t.Fatalf("forceSupervisor = true, want false")
+	}
+	wantTags := map[string]bool{"owner": true, "security": true, "device_control": true}
+	if len(tags) != len(wantTags) {
+		t.Fatalf("tags = %v, want %d unique", tags, len(wantTags))
+	}
+	for _, tag := range tags {
+		if !wantTags[tag] {
+			t.Fatalf("unexpected tag %q in %v", tag, tags)
+		}
+	}
+}
+
+func TestSummarizeNotifyEnvelopesOrdersUrgentFirst(t *testing.T) {
+	t.Parallel()
+
+	mkEnv := func(id string, priority messages.Priority, message string) messages.Envelope {
+		return messages.Envelope{
+			ID:       id,
+			From:     messages.Identity{Kind: messages.IdentitySystem, Name: "tester"},
+			Priority: priority,
+			Payload: messages.LoopNotifyPayload{
+				Kind:    "test",
+				Message: message,
+			},
+		}
+	}
+
+	envs := []messages.Envelope{
+		mkEnv("low-1", messages.PriorityLow, "low signal"),
+		mkEnv("normal-1", messages.PriorityNormal, "normal one"),
+		mkEnv("urgent-1", messages.PriorityUrgent, "urgent one"),
+		mkEnv("normal-2", messages.PriorityNormal, "normal two"),
+		mkEnv("urgent-2", messages.PriorityUrgent, "urgent two"),
+	}
+
+	summary := summarizeNotifyEnvelopes(envs)
+	idxUrgent1 := strings.Index(summary, `"urgent-1"`)
+	idxUrgent2 := strings.Index(summary, `"urgent-2"`)
+	idxNormal1 := strings.Index(summary, `"normal-1"`)
+	idxNormal2 := strings.Index(summary, `"normal-2"`)
+	idxLow := strings.Index(summary, `"low-1"`)
+	if idxUrgent1 < 0 || idxUrgent2 < 0 || idxNormal1 < 0 || idxNormal2 < 0 || idxLow < 0 {
+		t.Fatalf("missing id in summary: %s", summary)
+	}
+	// Urgent must precede normal which must precede low.
+	if idxUrgent1 >= idxNormal1 || idxUrgent2 >= idxNormal1 {
+		t.Fatalf("urgent envelopes not rendered before normal: %s", summary)
+	}
+	if idxNormal1 >= idxLow || idxNormal2 >= idxLow {
+		t.Fatalf("normal envelopes not rendered before low: %s", summary)
+	}
+	// Within urgent bucket, arrival order is preserved.
+	if idxUrgent1 >= idxUrgent2 {
+		t.Fatalf("urgent ordering not stable: %s", summary)
+	}
+	if idxNormal1 >= idxNormal2 {
+		t.Fatalf("normal ordering not stable: %s", summary)
+	}
+}
+
 func waitForLoopState(t *testing.T, l *Loop, want State) {
 	t.Helper()
 	deadline := time.Now().Add(2 * time.Second)

--- a/internal/runtime/loop/spec.go
+++ b/internal/runtime/loop/spec.go
@@ -39,6 +39,34 @@ const (
 	// auto-created on startup, refused for delete, default parent
 	// for orphan loops). See [Loop.IsCore].
 	OperationContainer Operation = "container"
+	// OperationEventDriven is a persistent loop that wakes only on
+	// external triggers — inter-loop notifications (the message bus
+	// + pendingNotifies machinery) or a runtime [Config.WaitFunc]
+	// channel. Unlike [OperationService], it carries no periodic
+	// sleep envelope; it sits quiescent until something asks it to
+	// run.
+	//
+	// Use it for trigger handlers: a loop that does nothing until
+	// an MQTT message / feed entry / event-source envelope arrives,
+	// then handles the event, then returns to quiescent. Validation
+	// rejects [Spec.SleepMin] / [Spec.SleepMax] / [Spec.SleepDefault]
+	// on this operation — those fields only make sense for
+	// timer-driven service loops.
+	//
+	// Otherwise event-driven loops participate fully in the
+	// Spec/cascade/SupervisorProfile system. Profile, Tags,
+	// Subscriptions, ParentName, Conditions all apply. Per-iteration
+	// behavior is identical to service loops: each wake gets a
+	// fresh conversation ID and runs one iteration of the Task /
+	// TaskBuilder / TurnBuilder.
+	//
+	// The runtime substrate already exists — [Config.WaitFunc] +
+	// [Config.Handler] service loops (ha-state-watcher, etc.) have
+	// done this shape for ages. OperationEventDriven exposes it
+	// declaratively so persisted overlay specs and YAML-defined
+	// loops can opt into the "no timer, wake only on notification"
+	// shape without needing runtime hooks.
+	OperationEventDriven Operation = "event_driven"
 )
 
 // CoreLoopName is the well-known name reserved for the singleton
@@ -70,6 +98,7 @@ var validOperations = map[Operation]bool{
 	OperationBackgroundTask: true,
 	OperationService:        true,
 	OperationContainer:      true,
+	OperationEventDriven:    true,
 }
 
 var validCompletions = map[Completion]bool{
@@ -316,10 +345,37 @@ func (s *Spec) Validate() error {
 		// before the runtime has to refuse the spec at start time.
 		return validateContainerShape(s)
 	}
+	if s.Operation == OperationEventDriven {
+		if err := validateEventDrivenShape(s); err != nil {
+			return err
+		}
+	}
 	cfg := s.ToConfig()
 	cfg.applyDefaults()
 	if err := cfg.validate(); err != nil {
 		return err
+	}
+	return nil
+}
+
+// validateEventDrivenShape rejects timer-shaped fields on
+// event-driven specs. These loops have no periodic wake — the only
+// reasons they iterate are notification arrivals and explicit
+// runtime [Config.WaitFunc] channel reads. A sleep envelope would
+// just be dead config; catching it at spec-validation time keeps
+// authoring mistakes loud rather than silently ignored at start.
+//
+// What IS legal on an event-driven spec: Task / TaskBuilder /
+// TurnBuilder / Handler, all of which still describe what to do on
+// each wake. Profile, Tags, Subscriptions, ParentName, Conditions,
+// Outputs, Supervisor + SupervisorProfile — all participate
+// normally. The only constraint is "no periodic timer."
+func validateEventDrivenShape(s *Spec) error {
+	if s.SleepMin != 0 || s.SleepMax != 0 || s.SleepDefault != 0 {
+		return fmt.Errorf("loop: event-driven %q cannot set sleep envelope (event-driven loops have no periodic timer; remove sleep_min / sleep_max / sleep_default)", s.Name)
+	}
+	if s.Jitter != nil {
+		return fmt.Errorf("loop: event-driven %q cannot set jitter (no periodic timer to randomize)", s.Name)
 	}
 	return nil
 }

--- a/internal/runtime/loop/spec_test.go
+++ b/internal/runtime/loop/spec_test.go
@@ -75,6 +75,44 @@ func TestSpecValidate(t *testing.T) {
 			t.Fatalf("Validate() error = %v, want missing name rejection", err)
 		}
 	})
+
+	t.Run("event_driven spec without timer fields is valid", func(t *testing.T) {
+		spec := &Spec{
+			Name:      "event-driven-ok",
+			Task:      "Process events.",
+			Operation: OperationEventDriven,
+		}
+		if err := spec.Validate(); err != nil {
+			t.Fatalf("Validate() error = %v, want nil", err)
+		}
+	})
+
+	t.Run("event_driven rejects sleep envelope", func(t *testing.T) {
+		spec := &Spec{
+			Name:         "event-driven-bad-sleep",
+			Task:         "Process events.",
+			Operation:    OperationEventDriven,
+			SleepDefault: time.Minute,
+		}
+		err := spec.Validate()
+		if err == nil || !strings.Contains(err.Error(), "sleep envelope") {
+			t.Fatalf("Validate() error = %v, want sleep-envelope rejection", err)
+		}
+	})
+
+	t.Run("event_driven rejects jitter", func(t *testing.T) {
+		jitter := 0.1
+		spec := &Spec{
+			Name:      "event-driven-bad-jitter",
+			Task:      "Process events.",
+			Operation: OperationEventDriven,
+			Jitter:    &jitter,
+		}
+		err := spec.Validate()
+		if err == nil || !strings.Contains(err.Error(), "jitter") {
+			t.Fatalf("Validate() error = %v, want jitter rejection", err)
+		}
+	})
 }
 
 func TestSpecToConfigCopiesMutableFields(t *testing.T) {


### PR DESCRIPTION
## Summary

Foundation pieces for the trigger unification work tracked in #902. All additive — no callers migrated yet, no behavior change for existing loops. The next PRs (T2b/T2c/T2d) migrate MQTT/media/email onto this surface.

Three threads in this PR:

- **`OperationEventDriven`** — new persistable operation that says "wake only on notifications, never on a timer." The runtime substrate existed already via `WaitFunc` loops; this promotes the shape so YAML specs and tool-spawned loops can declare it directly. Spec validation rejects sleep envelope / jitter (dead config). `Config.applyDefaults` / `Config.validate` skip sleep machinery for it. The runtime grew `waitForWake` and three guards so event-driven loops without a `WaitFunc` block on `wakeCh` instead of spinning a no-op timer.

- **`LoopWakeTarget.Tags`** — wake envelopes carry iteration-scoped capability tags. Source-side classifiers (contacts → `owner`, MQTT topic patterns → `security`) set these on the wake target; the loop runtime drains them in `consumePendingNotifies` and folds them into the iteration's `Request.InitialTags` before the final tag merge runs. They fade after the iteration unless the model explicitly activates them via tool — same lifecycle as any other iteration-scoped tag. Handler-based loops can observe them via `WakeTagsFromContext`.

- **Priority-aware notify rendering** — `summarizeNotifyEnvelopes` now sorts by priority descending (`urgent > normal > low`) with a stable sort within each bucket. Urgent wake content leads the prompt so the model sees it before normal- or low-priority companions; producers that send a batch from one source keep their intended order.

## Test plan

- [x] `just ci` green locally
- [x] `TestSpecValidate` — event-driven happy path + sleep-envelope / jitter rejection
- [x] `TestConsumePendingNotifiesAggregatesWakeTags` — dedup across envelopes, empty-string filter
- [x] `TestLoopNotifyTagsFlowIntoInitialTags` — tags reach the model-facing `Request.InitialTags`
- [x] `TestSummarizeNotifyEnvelopesOrdersUrgentFirst` — urgent before normal before low; stable in-bucket
- [x] `TestNewEventSourceEnvelopeCarriesWakeTags`
- [x] `TestParseLoopWakeTargetExtractsTags` — `[]string` and `[]any` (post-JSON-decode) inputs

Refs #902