### PR TITLE
feat: migrate MQTT-wake to event-driven dispatch (PR-T2b)

### DIFF
--- a/docs/operating/mqtt.md
+++ b/docs/operating/mqtt.md
@@ -57,35 +57,50 @@ persona name).
 
 ## Wake Subscriptions
 
-Thane can subscribe to MQTT topics and wake the agent loop when messages
-arrive:
+Thane can subscribe to MQTT topics and deliver matching messages as
+event-source wakes to an existing loop. Each subscription names a
+`wake_loop` target; matching messages become loop notifications that
+the target loop sees on its next iteration. No fresh loop spawns per
+message — the target loop owns routing via its own
+`Spec.Profile`/`SupervisorProfile`.
 
 ```yaml
 mqtt:
-  wake_subscriptions:
+  subscriptions:
     - topic: frigate/events
-      qos: 1
+      wake_loop:
+        name: home_security
     - topic: custom/alerts/#
+      wake_loop:
+        name: mqtt-default-handler
+        tags:
+          - security
 ```
 
-When a message arrives on a subscribed topic, Thane creates an agent request
-with the message payload as context. This enables reactive behavior —
-Frigate detects a person at the door, publishes an event, and Thane reasons
-about whether to notify you.
+When no custom handler is desired, point `wake_loop` at the built-in
+`mqtt-default-handler` event-driven loop, which is registered
+automatically when MQTT is configured.
 
-### Routing Overrides
+`wake_loop` accepts the following fields:
 
-Wake subscriptions can include routing hints to control which model handles
-the resulting agent request:
+| Field | Purpose |
+|---|---|
+| `loop_id` | Exact live loop ID. Preferred when known. |
+| `name` | Loop name when `loop_id` isn't known (mqtt-default-handler if you don't have a bespoke handler). |
+| `force_supervisor` | Force the target's next iteration into supervisor mode. |
+| `priority` | `low` / `normal` / `urgent`; drives prompt-rendering order on the target loop. |
+| `instructions` | Compact text appended to the rendered wake event. |
+| `tags` | Iteration-scoped capability tags activated on the next turn (e.g. `security`, `device_control`). Fade unless the model explicitly activates them. |
 
-```yaml
-mqtt:
-  wake_subscriptions:
-    - topic: frigate/events
-      routing:
-        local_only: true
-        quality_floor: 3
-```
+Subscriptions without `wake_loop` are ambient-awareness only and are
+not delivered to any loop. Legacy inline-Profile entries (the
+pre-PR-T2b `wake:` field with `local_only` / `quality_floor` / etc.)
+are auto-migrated onto `mqtt-default-handler` at config load with a
+WARN log; remove them from the YAML at your convenience.
+
+Config-defined targets are verified against the live loop registry at
+startup — a typo in `wake_loop.name` fails the app launch loud rather
+than silently dropping the first matching message.
 
 ## Auto-Reconnection
 

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -348,7 +348,7 @@ See [MQTT](../operating/mqtt.md) for the broker-side conventions.
 | Tool | Description |
 |------|-------------|
 | `mqtt_wake_list` | List runtime and config-defined wake subscriptions. |
-| `mqtt_wake_add` | Add a runtime wake subscription with routing config. |
+| `mqtt_wake_add` | Add a runtime wake subscription that delivers matching messages to a `wake_loop` target. Required args: `topic` and `wake_loop` (loop name/ID, optional tags + instructions). The legacy inline routing fields (`mission`, `quality_floor`, etc.) were retired in PR-T2b; point `wake_loop` at the built-in `mqtt-default-handler` for generic triage. |
 | `mqtt_wake_remove` | Remove a runtime wake subscription by ID. |
 
 ## `message_channel` — current message-app conversation

--- a/examples/config.example.yaml
+++ b/examples/config.example.yaml
@@ -507,21 +507,23 @@ talents_dir: ./talents
 #     - # Topic is the MQTT topic filter (e.g., "homeassistant/+/+/state",
 #       "frigate/events"). Supports MQTT wildcard characters.
 #       topic: homeassistant/+/+/state
-#       WakeLoop identifies an existing loop to receive matching MQTT
-#       messages as event-source notifications. Preferred dispatch
-#       route — the target loop's [Spec.Profile] governs routing.
+#       WakeLoop identifies the existing loop that should receive
+#       matching MQTT messages as event-source notifications. When
+#       the target name resolves to a registered loop at startup, this
+#       is how every wake delivers; the target's own Spec.Profile
+#       governs routing. Point this at "mqtt-default-handler" for the
+#       built-in triage loop when you don't have a bespoke handler.
 #       wake_loop:
-#         loopid: ""
+#         loop_id: ""
 #         name: ""
-#         forcesupervisor: false
+#         force_supervisor: false
 #         priority: ""
 #         instructions: ""
 #         tags: []
-#       Wake is the legacy dispatch-via-spawn path: when non-nil and
-#       WakeLoop is unset, messages on this topic spawn a one-shot
-#       agent run using this routing profile. New subscriptions
-#       should use WakeLoop and let the target loop's own Profile
-#       govern routing instead.
+#       Wake is the deprecated inline-routing form. Entries that use
+#       it are auto-migrated onto the default handler at config load
+#       (a one-shot upgrade). New subscriptions should declare
+#       WakeLoop directly instead.
 #       wake:
 #         model: ""
 #         quality_floor: 0
@@ -532,28 +534,31 @@ talents_dir: ./talents
 #         exclude_tools: []
 #         extra_hints: {}
 #         instructions: ""
-#       InitialTags lists capability tags activated at the start of the
-#       spawn-dispatch agent run (legacy path). Only meaningful when
-#       Wake is non-nil and WakeLoop is unset.
+#       InitialTags is the deprecated companion to Wake. Migrated
+#       values flow into the resulting wake_loop target's Tags field
+#       at load time, so per-iteration capability tag activation
+#       continues to work even after the inline-routing form retires.
 #       initial_tags: []
 #     - # Topic is the MQTT topic filter (e.g., "homeassistant/+/+/state",
 #       "frigate/events"). Supports MQTT wildcard characters.
 #       topic: frigate/events
-#       WakeLoop identifies an existing loop to receive matching MQTT
-#       messages as event-source notifications. Preferred dispatch
-#       route — the target loop's [Spec.Profile] governs routing.
+#       WakeLoop identifies the existing loop that should receive
+#       matching MQTT messages as event-source notifications. When
+#       the target name resolves to a registered loop at startup, this
+#       is how every wake delivers; the target's own Spec.Profile
+#       governs routing. Point this at "mqtt-default-handler" for the
+#       built-in triage loop when you don't have a bespoke handler.
 #       wake_loop:
-#         loopid: ""
+#         loop_id: ""
 #         name: ""
-#         forcesupervisor: false
+#         force_supervisor: false
 #         priority: ""
 #         instructions: ""
 #         tags: []
-#       Wake is the legacy dispatch-via-spawn path: when non-nil and
-#       WakeLoop is unset, messages on this topic spawn a one-shot
-#       agent run using this routing profile. New subscriptions
-#       should use WakeLoop and let the target loop's own Profile
-#       govern routing instead.
+#       Wake is the deprecated inline-routing form. Entries that use
+#       it are auto-migrated onto the default handler at config load
+#       (a one-shot upgrade). New subscriptions should declare
+#       WakeLoop directly instead.
 #       wake:
 #         model: ""
 #         quality_floor: 0
@@ -564,28 +569,31 @@ talents_dir: ./talents
 #         exclude_tools: []
 #         extra_hints: {}
 #         instructions: ""
-#       InitialTags lists capability tags activated at the start of the
-#       spawn-dispatch agent run (legacy path). Only meaningful when
-#       Wake is non-nil and WakeLoop is unset.
+#       InitialTags is the deprecated companion to Wake. Migrated
+#       values flow into the resulting wake_loop target's Tags field
+#       at load time, so per-iteration capability tag activation
+#       continues to work even after the inline-routing form retires.
 #       initial_tags: []
 #     - # Topic is the MQTT topic filter (e.g., "homeassistant/+/+/state",
 #       "frigate/events"). Supports MQTT wildcard characters.
 #       topic: automation/wake/security
-#       WakeLoop identifies an existing loop to receive matching MQTT
-#       messages as event-source notifications. Preferred dispatch
-#       route — the target loop's [Spec.Profile] governs routing.
+#       WakeLoop identifies the existing loop that should receive
+#       matching MQTT messages as event-source notifications. When
+#       the target name resolves to a registered loop at startup, this
+#       is how every wake delivers; the target's own Spec.Profile
+#       governs routing. Point this at "mqtt-default-handler" for the
+#       built-in triage loop when you don't have a bespoke handler.
 #       wake_loop:
-#         loopid: ""
+#         loop_id: ""
 #         name: ""
-#         forcesupervisor: false
+#         force_supervisor: false
 #         priority: ""
 #         instructions: ""
 #         tags: []
-#       Wake is the legacy dispatch-via-spawn path: when non-nil and
-#       WakeLoop is unset, messages on this topic spawn a one-shot
-#       agent run using this routing profile. New subscriptions
-#       should use WakeLoop and let the target loop's own Profile
-#       govern routing instead.
+#       Wake is the deprecated inline-routing form. Entries that use
+#       it are auto-migrated onto the default handler at config load
+#       (a one-shot upgrade). New subscriptions should declare
+#       WakeLoop directly instead.
 #       wake:
 #         model: ""
 #         quality_floor: 7
@@ -596,9 +604,10 @@ talents_dir: ./talents
 #         exclude_tools: []
 #         extra_hints: {}
 #         instructions: Evaluate the security event and decide if action is needed.
-#       InitialTags lists capability tags activated at the start of the
-#       spawn-dispatch agent run (legacy path). Only meaningful when
-#       Wake is non-nil and WakeLoop is unset.
+#       InitialTags is the deprecated companion to Wake. Migrated
+#       values flow into the resulting wake_loop target's Tags field
+#       at load time, so per-iteration capability tag activation
+#       continues to work even after the inline-routing form retires.
 #       initial_tags:
 #         - homeassistant
 #   Telemetry configures operational metric publishing. When enabled,

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -135,6 +135,7 @@ type App struct {
 	// MQTT
 	mqttPub        *mqtt.Publisher
 	mqttInstanceID string
+	mqttSubStore   *mqtt.SubscriptionStore
 
 	// Notifications
 	notifSender             *notifications.Sender

--- a/internal/app/loop_definition_builtins.go
+++ b/internal/app/loop_definition_builtins.go
@@ -4,6 +4,8 @@ import (
 	"strings"
 	"time"
 
+	mqtt "github.com/nugget/thane-ai-agent/internal/channels/mqtt"
+	"github.com/nugget/thane-ai-agent/internal/model/router"
 	"github.com/nugget/thane-ai-agent/internal/platform/config"
 	looppkg "github.com/nugget/thane-ai-agent/internal/runtime/loop"
 )
@@ -17,6 +19,11 @@ const (
 	mqttPublisherDefinitionName   = "mqtt"
 	telemetryDefinitionName       = "telemetry"
 )
+
+// mqttDefaultHandlerName is the in-app alias for the mqtt package's
+// built-in default-handler loop name. Aliased here so the builtin
+// spec literal reads cleanly alongside the other naming constants.
+var mqttDefaultHandlerName = mqtt.DefaultHandlerLoopName
 
 func builtInServiceDefinitionSpecs(cfg *config.Config) []looppkg.Spec {
 	if cfg == nil {
@@ -117,6 +124,28 @@ func builtInServiceDefinitionSpecs(cfg *config.Config) []looppkg.Spec {
 	}
 
 	if cfg.MQTT.Configured() {
+		// Default landing zone for mqtt_wake subscriptions that don't
+		// declare a custom wake_loop. Event-driven so the loop sits
+		// idle on wakeCh until an MQTT message arrives, then runs one
+		// agent turn against the rendered notification context. The
+		// model decides what to do based on the topic + payload — no
+		// hardcoded routing, no inline-Profile spawn.
+		specs = append(specs, looppkg.Spec{
+			Name:       mqttDefaultHandlerName,
+			Enabled:    true,
+			Task:       "Triage MQTT wake events: inspect topic and payload, then act or escalate.",
+			Operation:  looppkg.OperationEventDriven,
+			Completion: looppkg.CompletionNone,
+			Profile: router.LoopProfile{
+				Mission:    "mqtt_handler",
+				ExtraHints: map[string]string{"source": "mqtt_wake"},
+			},
+			Metadata: map[string]string{
+				"subsystem": "mqtt",
+				"category":  "default_handler",
+			},
+		})
+
 		mqttInterval := time.Duration(cfg.MQTT.PublishIntervalSec) * time.Second
 		specs = append(specs, looppkg.Spec{
 			Name:         mqttPublisherDefinitionName,

--- a/internal/app/loop_definition_runtime.go
+++ b/internal/app/loop_definition_runtime.go
@@ -23,6 +23,22 @@ type loopDefinitionBootstrapResult struct {
 	SkippedNonService int `json:"skipped_non_service"`
 }
 
+// isDurableDefinitionOperation reports whether a definition's operation
+// kind describes a long-lived loop that the runtime should auto-start
+// at boot and reconcile against eligibility changes. Containers are
+// structural, services run on a periodic timer, and event-driven loops
+// sit idle waiting on notifications — all three are persistent and
+// participate in startup hydration. Request/reply and background-task
+// operations are transient and are explicitly excluded.
+func isDurableDefinitionOperation(op looppkg.Operation) bool {
+	switch op {
+	case looppkg.OperationService, looppkg.OperationContainer, looppkg.OperationEventDriven:
+		return true
+	default:
+		return false
+	}
+}
+
 // loopDefinitionRuntime bridges durable loop definitions into the live
 // loop registry. It intentionally owns only startup/runtime plumbing;
 // the definition registry remains the source of truth for stored specs.
@@ -227,7 +243,7 @@ func (r *loopDefinitionRuntime) nextScheduleTransition(now time.Time) time.Time 
 	}
 	next := time.Time{}
 	for _, def := range snap.Definitions {
-		if def.Spec.Operation != looppkg.OperationService || def.PolicyState != looppkg.DefinitionPolicyStateActive {
+		if !isDurableDefinitionOperation(def.Spec.Operation) || def.PolicyState != looppkg.DefinitionPolicyStateActive {
 			continue
 		}
 		eligibility, _, found := r.definitions.EvaluateConditions(def.Name, now)
@@ -354,7 +370,7 @@ func (r *loopDefinitionRuntime) StartEnabledServices(ctx context.Context) (loopD
 	// here as SkippedNonService for parity with existing callers and
 	// dashboards.
 	for _, def := range snap.Definitions {
-		if def.Spec.Operation != looppkg.OperationService && def.Spec.Operation != looppkg.OperationContainer {
+		if !isDurableDefinitionOperation(def.Spec.Operation) {
 			result.SkippedNonService++
 		}
 	}
@@ -405,10 +421,12 @@ func (r *loopDefinitionRuntime) bootstrapDefinitionSpawn(ctx context.Context, de
 	return nil
 }
 
-// splitContainerSpecs partitions definitions into container and service
-// hydration order. Containers come first, sorted root-first so a
-// parent_name reference resolves to a live loop by the time the child
-// hydrates. Non-container, non-service operations (request_reply,
+// splitContainerSpecs partitions definitions into container and
+// non-container durable hydration order. Containers come first, sorted
+// root-first so a parent_name reference resolves to a live loop by the
+// time the child hydrates. Services and event-driven loops share the
+// second pass — both are persistent and may sit under containers but
+// never the other way around. Non-durable operations (request_reply,
 // background_task) are dropped — they're transient and shouldn't be
 // hydrated at startup at all. nowTime is unused today but threaded
 // through so future condition-driven ordering doesn't reshape the API.
@@ -421,7 +439,7 @@ func splitContainerSpecs(defs []looppkg.DefinitionSnapshot, _ func() time.Time) 
 		switch def.Spec.Operation {
 		case looppkg.OperationContainer:
 			containers = append(containers, def)
-		case looppkg.OperationService:
+		case looppkg.OperationService, looppkg.OperationEventDriven:
 			services = append(services, def)
 		}
 	}
@@ -483,7 +501,7 @@ func (r *loopDefinitionRuntime) ReconcileDefinition(ctx context.Context, name st
 		return nil
 	}
 	eligibility := r.evaluateConditions(def.Name)
-	durable := def.Spec.Operation == looppkg.OperationService || def.Spec.Operation == looppkg.OperationContainer
+	durable := isDurableDefinitionOperation(def.Spec.Operation)
 	if !durable || def.PolicyState != looppkg.DefinitionPolicyStateActive || !eligibility.Eligible {
 		if existing != nil {
 			reason := "not_durable"
@@ -581,7 +599,7 @@ func (r *loopDefinitionRuntime) LaunchDefinition(ctx context.Context, name strin
 	if eligibility := r.evaluateConditions(name); !eligibility.Eligible {
 		return looppkg.LaunchResult{}, &looppkg.IneligibleDefinitionError{Name: name, Reason: eligibility.Reason}
 	}
-	if def.Spec.Operation == looppkg.OperationService || def.Spec.Operation == looppkg.OperationContainer {
+	if isDurableDefinitionOperation(def.Spec.Operation) {
 		if existing := r.loops.GetByName(name); existing != nil {
 			// Loud-fail on caller payload for already-running durable
 			// loops (services and containers). The runtime captures

--- a/internal/app/mqttwake.go
+++ b/internal/app/mqttwake.go
@@ -147,21 +147,35 @@ func dispatchViaWakeTarget(deps mqttWakeDeps, ws mqtt.WakeSubscription, topic st
 
 // sanitizePayload converts raw MQTT bytes to a valid UTF-8 string,
 // replacing invalid sequences and truncating to [maxWakePayloadBytes]
-// on a rune boundary.
+// on a rune boundary. The byte slice is cropped before any string
+// conversion so a multi-megabyte payload from a chatty topic doesn't
+// force an allocation of the full body just to throw most of it away.
+// A small UTF-8 slack (4 bytes — the maximum encoding length for a
+// single rune) is included in the crop so a multi-byte rune
+// straddling the limit can be discarded cleanly by the rune-boundary
+// trim below.
 func sanitizePayload(payload []byte) string {
 	if len(payload) == 0 {
 		return ""
+	}
+	totalBytes := len(payload)
+	truncated := totalBytes > maxWakePayloadBytes
+	if truncated {
+		const utf8Slack = utf8.UTFMax
+		payload = payload[:maxWakePayloadBytes+utf8Slack]
 	}
 	s := string(payload)
 	if !utf8.ValidString(s) {
 		s = strings.ToValidUTF8(s, "�")
 	}
-	if len(s) <= maxWakePayloadBytes {
+	if !truncated {
 		return s
 	}
-	truncated := s[:maxWakePayloadBytes]
-	for len(truncated) > 0 && !utf8.ValidString(truncated) {
-		truncated = truncated[:len(truncated)-1]
+	if len(s) > maxWakePayloadBytes {
+		s = s[:maxWakePayloadBytes]
 	}
-	return truncated + fmt.Sprintf("\n\n[Truncated: %d bytes total, showing first %d bytes]", len(s), maxWakePayloadBytes)
+	for len(s) > 0 && !utf8.ValidString(s) {
+		s = s[:len(s)-1]
+	}
+	return s + fmt.Sprintf("\n\n[Truncated: %d bytes total, showing first %d bytes]", totalBytes, maxWakePayloadBytes)
 }

--- a/internal/app/mqttwake.go
+++ b/internal/app/mqttwake.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"path"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -12,55 +11,46 @@ import (
 
 	"github.com/nugget/thane-ai-agent/internal/channels/messages"
 	mqtt "github.com/nugget/thane-ai-agent/internal/channels/mqtt"
-	"github.com/nugget/thane-ai-agent/internal/model/router"
 	"github.com/nugget/thane-ai-agent/internal/platform/events"
 	looppkg "github.com/nugget/thane-ai-agent/internal/runtime/loop"
 )
 
-// maxWakePayloadBytes is the maximum MQTT payload size included in the
-// user message. Payloads exceeding this are truncated on a valid UTF-8
-// boundary with a marker.
+// maxWakePayloadBytes bounds the MQTT payload size included in the
+// event-source envelope summary. Payloads exceeding this are truncated
+// on a valid UTF-8 boundary with a marker so a chatty topic can't
+// blow up downstream prompt rendering.
 const maxWakePayloadBytes = 32 * 1024
 
-// mqttWakeTimeout bounds how long a single MQTT-triggered agent
-// conversation may run before being cancelled. Applies to the
-// legacy spawn-dispatch path (one-shot loop run).
-const mqttWakeTimeout = 5 * time.Minute
-
-// mqttWakeDeliveryTimeout bounds the bus.Send call for the wake-
-// target dispatch path. Each MQTT message arrives in its own
-// goroutine; without this bound, a stuck downstream route handler
-// could leak goroutines under steady MQTT traffic. The actual
-// agent work happens in the target loop's next iteration on its
-// own clock — this only bounds the envelope-handoff hop.
+// mqttWakeDeliveryTimeout bounds the bus.Send call for envelope
+// delivery. Each MQTT message arrives in its own goroutine; without
+// this bound, a stuck downstream route handler could leak goroutines
+// under steady MQTT traffic. The actual agent work happens in the
+// target loop's next iteration on its own clock — this only bounds
+// the envelope-handoff hop.
 const mqttWakeDeliveryTimeout = 30 * time.Second
 
-// mqttWakeDeps holds optional dependencies for dashboard integration.
-// When registry is non-nil, each wake conversation is spawned as a
-// child loop under parentID so it appears on the dashboard.
-//
-// messageBus, when non-nil, enables the wake-target dispatch path
-// for subscriptions that declare a WakeTarget — MQTT messages
-// produce a [messages.LoopEventPayload] delivered as a loop
-// notification to the target loop, instead of spawning a fresh
-// one-shot loop.
+// mqttWakeDeps wires the wake handler to the message bus and event
+// bus. parentID is unused in the post-retirement dispatch shape but
+// retained so the wiring in new_servers.go stays compatible during
+// the transition.
 type mqttWakeDeps struct {
 	registry   *looppkg.Registry
 	messageBus *messages.Bus
 	eventBus   *events.Bus
-	parentID   *atomic.Value // stores string; populated lazily from the mqtt service loop
+	parentID   *atomic.Value
 }
 
-// mqttWakeHandler returns a MessageHandler that dispatches agent
-// conversations when MQTT messages arrive on wake-configured topics.
-// Messages on topics without a wake subscription are passed through
-// to the fallback handler.
+// mqttWakeHandler returns a MessageHandler that delivers MQTT messages
+// to existing event-driven loops via the message bus. Every active
+// subscription routes through a wake_loop target after the trigger-
+// unification work; legacy inline-Profile subscriptions are migrated
+// onto [mqtt.DefaultHandlerLoopName] at config load / DB hydrate time.
 //
-// When deps.registry is non-nil, each wake conversation is registered
-// as a child loop under the MQTT parent so it appears on the dashboard.
+// Messages on topics without a wake subscription are passed through to
+// the fallback handler. When the message bus is nil (operator
+// configuration error) matching messages are logged and dropped.
 func mqttWakeHandler(
 	store *mqtt.SubscriptionStore,
-	runner looppkg.Runner,
 	fallback mqtt.MessageHandler,
 	logger *slog.Logger,
 	deps mqttWakeDeps,
@@ -77,100 +67,34 @@ func mqttWakeHandler(
 			return
 		}
 
-		if deps.registry == nil {
-			logger.Error("mqtt wake has no loop registry, dropping message",
+		if deps.messageBus == nil {
+			logger.Error("mqtt wake has no message bus, dropping message",
 				"topic", topic,
 				"matches", len(matches),
 			)
 			return
 		}
 
-		// Fan-out: dispatch one agent conversation per matching
-		// subscription. Each gets its own goroutine so the MQTT
-		// message handler does not block the inbound message loop.
-		//
-		// Two dispatch shapes are supported per-subscription:
-		//
-		//   - Wake-target dispatch (preferred): subscription declares
-		//     an existing loop via WakeTarget; the MQTT message
-		//     becomes a [messages.LoopEventPayload] delivered via
-		//     [messages.NewEventSourceEnvelope]. No new loop spawned.
-		//
-		//   - Spawn dispatch (legacy): subscription has no WakeTarget;
-		//     each message spawns a fresh one-shot loop with the
-		//     subscription's Profile/InitialTags.
+		// Fan-out: dispatch one envelope per matching subscription so
+		// multiple subscribers (e.g. owner-attention plus security
+		// monitoring) on the same topic each see the same event in
+		// their own loop's iteration context.
 		for _, ws := range matches {
-			ws := ws // capture loop variable
-			go func() {
-				if ws.HasWakeTarget() {
-					dispatchViaWakeTarget(deps, ws, topic, payload, logger)
-					return
-				}
-				convID := fmt.Sprintf("mqtt-wake-%s-%d", ws.ID, time.Now().UnixMilli())
-				msg := buildWakeMessage(topic, payload, ws.Profile.Instructions)
-
-				req := looppkg.Request{
-					ConversationID: convID,
-					Messages:       []looppkg.Message{{Role: "user", Content: msg}},
-				}
-				applyLoopProfile(&ws.Profile, &req)
-				if len(ws.InitialTags) > 0 {
-					req.InitialTags = append(req.InitialTags, ws.InitialTags...)
-				}
-
-				// Always tag the source so tools and logging can identify
-				// MQTT-triggered conversations.
-				if req.RoutingFactors == nil {
-					req.RoutingFactors = make(map[string]string)
-				}
-				req.RoutingFactors["source"] = "mqtt_wake"
-				req.RoutingFactors["mqtt_topic"] = topic
-				req.RoutingFactors["mqtt_subscription_id"] = ws.ID
-
-				logger.Info("mqtt wake dispatching agent",
-					"conv_id", convID,
-					"subscription_id", ws.ID,
-					"topic", topic,
-					"payload_size", len(payload),
-				)
-
-				// Use a short topic suffix for the loop name (last path segment).
-				loopName := "mqtt/" + path.Base(topic)
-
-				dispatchViaLoop(deps, runner, req, loopName, topic, convID, logger)
-			}()
+			ws := ws
+			go dispatchViaWakeTarget(deps, ws, topic, payload, logger)
 		}
 	}
 }
 
-// dispatchViaWakeTarget delivers an MQTT message to an existing loop
-// as an event-source notification. Mirrors the forge/media-feed
-// pattern: build a [messages.LoopEventPayload] describing the
-// message, wrap it in a [messages.NewEventSourceEnvelope] addressed
-// to the subscription's WakeTarget, and publish via the bus. The
-// target loop's next iteration sees the event in its pending
-// notifications and runs under its own Spec.Profile.
-//
-// No new loop is spawned — the registry stays clean and the
-// container cascade that governs the target loop applies naturally.
-// Failures (bus not configured, target loop not resolvable) are
-// logged at WARN and the message is dropped; the next matching
-// message gets the same treatment.
-//
-// Dispatch runs in a fresh goroutine per matching message (see the
-// fan-out in [mqttWakeHandler]). A bounded context bounds bus
-// delivery so a stuck/slow downstream route handler can't leak
-// goroutines indefinitely under a steady stream of MQTT traffic.
+// dispatchViaWakeTarget delivers an MQTT message to the subscription's
+// wake target as an event-source notification. Builds a
+// [messages.LoopEventPayload], wraps it in a
+// [messages.NewEventSourceEnvelope], and publishes via the bus with a
+// bounded delivery context. No new loop is spawned — the target loop
+// (a custom event-driven loop or the built-in default handler) sees
+// the event in its pending notifications and runs under its own
+// Spec.Profile / container cascade.
 func dispatchViaWakeTarget(deps mqttWakeDeps, ws mqtt.WakeSubscription, topic string, payload []byte, logger *slog.Logger) {
-	if deps.messageBus == nil {
-		logger.Warn("mqtt wake target dispatch unavailable, dropping message",
-			"subscription_id", ws.ID,
-			"topic", topic,
-			"reason", "message_bus_not_configured",
-		)
-		return
-	}
-
 	event := messages.LoopEventPayload{
 		Source:     "mqtt_wake",
 		Type:       "message",
@@ -221,191 +145,23 @@ func dispatchViaWakeTarget(deps mqttWakeDeps, ws mqtt.WakeSubscription, topic st
 	)
 }
 
-// dispatchViaLoop spawns a one-shot child loop under the MQTT parent
-// so the wake conversation appears on the dashboard. The loop manages
-// its own lifecycle via MaxDuration — no external context timeout is
-// needed (SpawnLoop is non-blocking, so the caller must not use a
-// short-lived context that would cancel the child loop).
-func dispatchViaLoop(
-	deps mqttWakeDeps,
-	runner looppkg.Runner,
-	req looppkg.Request,
-	loopName, topic, convID string,
-	logger *slog.Logger,
-) {
-	var parentID string
-	if deps.parentID != nil {
-		if v, ok := deps.parentID.Load().(string); ok {
-			parentID = v
-		}
-	}
-	if parentID == "" && deps.registry != nil {
-		if parent := deps.registry.GetByName(mqttPublisherDefinitionName); parent != nil {
-			parentID = parent.ID()
-			if deps.parentID != nil {
-				deps.parentID.Store(parentID)
-			}
-		}
-	}
-
-	// A wake loop without a parentID would be registered as a top-level
-	// loop, which means it won't be filtered from MQTT telemetry and
-	// could leak conversation content into topic names. Drop the message
-	// rather than create an unparented loop.
-	if parentID == "" {
-		logger.Warn("mqtt wake parent loop not yet registered, dropping message",
-			"conv_id", convID,
-			"topic", topic,
-		)
-		return
-	}
-
-	// Use a background context: SpawnLoop is non-blocking (starts a
-	// goroutine and returns immediately), so a timeout context here
-	// would cancel the child loop as soon as defer fires. The loop's
-	// MaxDuration enforces the wall-clock bound instead.
-	//
-	// Sleep values are set to 1ms so the initial sleep is effectively
-	// zero — this is a one-shot loop that should execute immediately.
-	const immediate = time.Millisecond
-	_, err := deps.registry.SpawnLoop(context.Background(), looppkg.Config{
-		Name:         loopName,
-		MaxIter:      1,
-		MaxDuration:  mqttWakeTimeout,
-		SleepMin:     immediate,
-		SleepMax:     immediate,
-		SleepDefault: immediate,
-		Jitter:       looppkg.Float64Ptr(0),
-		ParentID:     parentID,
-		TurnBuilder: func(context.Context, looppkg.TurnInput) (*looppkg.AgentTurn, error) {
-			return &looppkg.AgentTurn{
-				Request: cloneLoopRequest(req),
-				Summary: map[string]any{
-					"mqtt_topic": topic,
-				},
-			}, nil
-		},
-		PostIterate: func(_ context.Context, result looppkg.IterationResult) error {
-			logger.Info("mqtt wake complete",
-				"conv_id", result.ConvID,
-				"topic", topic,
-				"model", result.Model,
-				"input_tokens", result.InputTokens,
-				"output_tokens", result.OutputTokens,
-			)
-			return nil
-		},
-		Metadata: map[string]string{
-			"subsystem":       "mqtt",
-			"category":        "wake",
-			"mqtt_topic":      topic,
-			"conversation_id": convID,
-		},
-	}, looppkg.Deps{
-		Runner:   runner,
-		Logger:   logger,
-		EventBus: deps.eventBus,
-	})
-	if err != nil {
-		logger.Error("mqtt wake loop spawn failed, message dropped",
-			"conv_id", convID,
-			"topic", topic,
-			"error", err,
-		)
-	}
-}
-
-// buildWakeMessage constructs the user message for an MQTT wake. When
-// instructions are provided, the payload is wrapped with context about
-// the topic and instructions. Otherwise the raw payload is used.
-//
-// Payloads are sanitised to valid UTF-8 and truncated to
-// [maxWakePayloadBytes] to bound prompt size and cost.
-func buildWakeMessage(topic string, payload []byte, instructions string) string {
-	payloadStr := sanitizePayload(payload)
-
-	if instructions == "" {
-		if payloadStr == "" {
-			return fmt.Sprintf("MQTT message received on topic: %s", topic)
-		}
-		return fmt.Sprintf("MQTT message received on topic: %s\n\n%s", topic, payloadStr)
-	}
-
-	if payloadStr == "" {
-		return fmt.Sprintf("Instructions: %s\n\nMQTT topic: %s\n(no payload)", instructions, topic)
-	}
-	return fmt.Sprintf("Instructions: %s\n\nMQTT topic: %s\nPayload:\n%s", instructions, topic, payloadStr)
-}
-
 // sanitizePayload converts raw MQTT bytes to a valid UTF-8 string,
-// replacing invalid sequences and truncating to maxWakePayloadBytes
+// replacing invalid sequences and truncating to [maxWakePayloadBytes]
 // on a rune boundary.
 func sanitizePayload(payload []byte) string {
 	if len(payload) == 0 {
 		return ""
 	}
-
-	// Ensure valid UTF-8 — replace invalid bytes.
 	s := string(payload)
 	if !utf8.ValidString(s) {
-		s = strings.ToValidUTF8(s, "\uFFFD")
+		s = strings.ToValidUTF8(s, "�")
 	}
-
 	if len(s) <= maxWakePayloadBytes {
 		return s
 	}
-
-	// Truncate on a rune boundary.
 	truncated := s[:maxWakePayloadBytes]
 	for len(truncated) > 0 && !utf8.ValidString(truncated) {
 		truncated = truncated[:len(truncated)-1]
 	}
 	return truncated + fmt.Sprintf("\n\n[Truncated: %d bytes total, showing first %d bytes]", len(s), maxWakePayloadBytes)
-}
-
-// applyLoopProfile applies a LoopProfile's routing configuration to a
-// loop request. It sets the model, merges routing hints, and copies tool
-// exclusions. Capability tags are not part of the routing profile and
-// are applied separately by the caller. This function lives in the app
-// package rather than on LoopProfile itself to avoid coupling router
-// profiles to a runtime request type.
-func applyLoopProfile(profile *router.LoopProfile, req *looppkg.Request) {
-	opts := profile.RequestOptions()
-
-	if opts.Model != "" {
-		req.Model = opts.Model
-	}
-
-	if len(opts.RoutingFactors) > 0 {
-		if req.RoutingFactors == nil {
-			req.RoutingFactors = make(map[string]string, len(opts.RoutingFactors))
-		}
-		for k, v := range opts.RoutingFactors {
-			req.RoutingFactors[k] = v
-		}
-	}
-
-	if len(opts.ExcludeTools) > 0 {
-		req.ExcludeTools = append(req.ExcludeTools, opts.ExcludeTools...)
-	}
-
-	if opts.DelegationGating != "" {
-		req.DelegationGating = opts.DelegationGating
-	}
-}
-
-// cloneLoopRequest returns an independent copy of a loop request before
-// it is handed to a TurnBuilder. MQTT wake loops are one-shot today, but
-// cloning keeps request preparation isolated from future retries or
-// accidental caller-side mutation.
-func cloneLoopRequest(req looppkg.Request) looppkg.Request {
-	req.Messages = append([]looppkg.Message(nil), req.Messages...)
-	req.ChannelBinding = req.ChannelBinding.Clone()
-	req.AllowedTools = append([]string(nil), req.AllowedTools...)
-	req.ExcludeTools = append([]string(nil), req.ExcludeTools...)
-	req.RoutingFactors = cloneStringMap(req.RoutingFactors)
-	req.InitialTags = append([]string(nil), req.InitialTags...)
-	req.RuntimeTags = append([]string(nil), req.RuntimeTags...)
-	req.RuntimeTools = append([]looppkg.RuntimeTool(nil), req.RuntimeTools...)
-	return req
 }

--- a/internal/app/mqttwake_test.go
+++ b/internal/app/mqttwake_test.go
@@ -2,14 +2,13 @@ package app
 
 import (
 	"context"
+	"strings"
 	"sync"
-	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/nugget/thane-ai-agent/internal/channels/messages"
 	"github.com/nugget/thane-ai-agent/internal/channels/mqtt"
-	"github.com/nugget/thane-ai-agent/internal/model/router"
 	"github.com/nugget/thane-ai-agent/internal/platform/config"
 	"github.com/nugget/thane-ai-agent/internal/platform/database"
 	"github.com/nugget/thane-ai-agent/internal/platform/events"
@@ -17,35 +16,6 @@ import (
 
 	_ "github.com/mattn/go-sqlite3"
 )
-
-// mqttMockRunner records Run calls for assertion.
-type mqttMockRunner struct {
-	mu   sync.Mutex
-	reqs []looppkg.Request
-}
-
-func (m *mqttMockRunner) Run(_ context.Context, req looppkg.Request, _ looppkg.StreamCallback) (*looppkg.Response, error) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	m.reqs = append(m.reqs, req)
-	return &looppkg.Response{
-		Content:       "ok",
-		Model:         "test-model",
-		InputTokens:   11,
-		OutputTokens:  3,
-		ContextWindow: 4096,
-		RequestID:     "req-mqtt-test",
-		ActiveTags:    append([]string(nil), req.InitialTags...),
-	}, nil
-}
-
-func (m *mqttMockRunner) requests() []looppkg.Request {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	cp := make([]looppkg.Request, len(m.reqs))
-	copy(cp, m.reqs)
-	return cp
-}
 
 func newTestWakeStore(t *testing.T) *mqtt.SubscriptionStore {
 	t.Helper()
@@ -62,74 +32,124 @@ func newTestWakeStore(t *testing.T) *mqtt.SubscriptionStore {
 	return store
 }
 
-func TestMQTTWakeHandlerMatchingTopic(t *testing.T) {
-	store := newTestWakeStore(t)
-	seed := router.LoopProfile{
-		Mission:          "automation",
-		QualityFloor:     7,
-		DelegationGating: "disabled",
-		Instructions:     "handle this",
+// captureBus stands in for a wired message bus during dispatch tests:
+// it records every envelope it accepts so the test can assert on
+// shape without needing a live route handler. Stubs out the loop
+// destination so [messages.Bus.Send] doesn't fail on unrouted loops.
+func captureBus() (*messages.Bus, func() []messages.Envelope) {
+	bus := messages.NewBus(nil)
+	var (
+		mu       sync.Mutex
+		captured []messages.Envelope
+	)
+	bus.AddAuditFunc(func(_ context.Context, env messages.Envelope, _ *messages.DeliveryResult, _ error) {
+		mu.Lock()
+		defer mu.Unlock()
+		captured = append(captured, env)
+	})
+	bus.RegisterRoute(messages.DestinationLoop, func(_ context.Context, env messages.Envelope) (messages.DeliveryResult, error) {
+		return messages.DeliveryResult{Envelope: env, Status: messages.DeliveryDelivered}, nil
+	})
+	return bus, func() []messages.Envelope {
+		mu.Lock()
+		defer mu.Unlock()
+		cp := make([]messages.Envelope, len(captured))
+		copy(cp, captured)
+		return cp
 	}
+}
+
+func waitFor(t *testing.T, snapshot func() []messages.Envelope, n int, timeout time.Duration) []messages.Envelope {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if got := snapshot(); len(got) >= n {
+			return got
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	return snapshot()
+}
+
+func TestMQTTWakeHandlerDispatchesViaWakeTarget(t *testing.T) {
+	store := newTestWakeStore(t)
+
+	target := messages.LoopWakeTarget{Name: "home_security", Priority: messages.PriorityNormal}
 	if err := store.LoadConfig([]config.SubscriptionConfig{
-		{Topic: "test/+/wake", Wake: &seed},
+		{Topic: "frigate/+/events", WakeLoop: &target},
 	}); err != nil {
 		t.Fatalf("LoadConfig: %v", err)
 	}
 
-	runner := &mqttMockRunner{}
-	registry := looppkg.NewRegistry()
-	bus := events.New()
-
-	var parentID atomic.Value
-	parentID.Store("test-mqtt-parent")
-
+	bus, captured := captureBus()
 	deps := mqttWakeDeps{
-		registry: registry,
-		eventBus: bus,
-		parentID: &parentID,
+		registry:   looppkg.NewRegistry(),
+		messageBus: bus,
+		eventBus:   events.New(),
 	}
 
-	handler := mqttWakeHandler(store, runner, nil, nil, deps)
-	handler("test/foo/wake", []byte(`{"event": "motion"}`))
+	handler := mqttWakeHandler(store, nil, nil, deps)
+	handler("frigate/front/events", []byte(`{"event":"motion"}`))
 
-	// Wait for goroutine dispatch.
-	deadline := time.Now().Add(2 * time.Second)
-	for time.Now().Before(deadline) {
-		if reqs := runner.requests(); len(reqs) > 0 {
-			break
-		}
-		time.Sleep(10 * time.Millisecond)
+	got := waitFor(t, captured, 1, 500*time.Millisecond)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 envelope delivered, got %d", len(got))
+	}
+	env := got[0]
+	if env.To.Target != "home_security" {
+		t.Errorf("envelope target = %q, want home_security", env.To.Target)
+	}
+	if env.Type != messages.TypeSignal {
+		t.Errorf("envelope type = %q, want signal", env.Type)
+	}
+	payload, ok := env.Payload.(messages.LoopNotifyPayload)
+	if !ok {
+		t.Fatalf("payload type = %T, want LoopNotifyPayload", env.Payload)
+	}
+	if payload.Kind != "event_source" {
+		t.Errorf("payload.Kind = %q, want event_source", payload.Kind)
+	}
+	if len(payload.Events) != 1 {
+		t.Fatalf("payload.Events len = %d, want 1", len(payload.Events))
+	}
+	event := payload.Events[0]
+	if event.Source != "mqtt_wake" {
+		t.Errorf("event.Source = %q, want mqtt_wake", event.Source)
+	}
+	if event.Title != "frigate/front/events" {
+		t.Errorf("event.Title = %q, want the topic", event.Title)
+	}
+}
+
+func TestMQTTWakeHandlerFanOutDelivers(t *testing.T) {
+	store := newTestWakeStore(t)
+
+	tA := messages.LoopWakeTarget{Name: "handler_a"}
+	tB := messages.LoopWakeTarget{Name: "handler_b"}
+	if err := store.LoadConfig([]config.SubscriptionConfig{
+		{Topic: "sensors/+/reading", WakeLoop: &tA},
+		{Topic: "sensors/+/reading", WakeLoop: &tB},
+	}); err != nil {
+		t.Fatalf("LoadConfig: %v", err)
 	}
 
-	reqs := runner.requests()
-	if len(reqs) != 1 {
-		t.Fatalf("expected 1 request, got %d", len(reqs))
+	bus, captured := captureBus()
+	deps := mqttWakeDeps{
+		registry:   looppkg.NewRegistry(),
+		messageBus: bus,
+		eventBus:   events.New(),
 	}
 
-	req := reqs[0]
-	if req.RoutingFactors["source"] != "mqtt_wake" {
-		t.Errorf("source hint = %q, want %q", req.RoutingFactors["source"], "mqtt_wake")
-	}
-	if req.RoutingFactors["mqtt_topic"] != "test/foo/wake" {
-		t.Errorf("mqtt_topic hint = %q, want %q", req.RoutingFactors["mqtt_topic"], "test/foo/wake")
-	}
-	if req.RoutingFactors[router.FactorMission] != "automation" {
-		t.Errorf("mission hint = %q, want %q", req.RoutingFactors[router.FactorMission], "automation")
-	}
-	if req.RoutingFactors[router.FactorQualityFloor] != "7" {
-		t.Errorf("quality_floor hint = %q, want %q", req.RoutingFactors[router.FactorQualityFloor], "7")
-	}
+	handler := mqttWakeHandler(store, nil, nil, deps)
+	handler("sensors/temp/reading", []byte(`{"value":22}`))
 
-	// Verify message contains instructions and payload.
-	msg := req.Messages[0].Content
-	if msg == "" {
-		t.Fatal("message content is empty")
+	got := waitFor(t, captured, 2, 500*time.Millisecond)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 fan-out envelopes, got %d", len(got))
 	}
-	if !contains(msg, "handle this") {
-		t.Errorf("message should contain instructions, got %q", msg)
-	}
-	if !contains(msg, "motion") {
-		t.Errorf("message should contain payload, got %q", msg)
+	targets := map[string]bool{got[0].To.Target: true, got[1].To.Target: true}
+	if !targets["handler_a"] || !targets["handler_b"] {
+		t.Errorf("envelope targets = %v, want both handler_a and handler_b", targets)
 	}
 }
 
@@ -141,388 +161,47 @@ func TestMQTTWakeHandlerNoMatchFallback(t *testing.T) {
 		fallbackCalled = true
 	}
 
-	runner := &mqttMockRunner{}
-	handler := mqttWakeHandler(store, runner, fallback, nil, mqttWakeDeps{})
+	bus, captured := captureBus()
+	handler := mqttWakeHandler(store, fallback, nil, mqttWakeDeps{messageBus: bus})
 
 	handler("unmatched/topic", []byte("data"))
 
 	if !fallbackCalled {
 		t.Error("expected fallback to be called")
 	}
-	if reqs := runner.requests(); len(reqs) != 0 {
-		t.Errorf("expected 0 requests, got %d", len(reqs))
+	if got := captured(); len(got) != 0 {
+		t.Errorf("expected 0 envelopes for unmatched topic, got %d", len(got))
 	}
 }
 
-func TestMQTTWakeHandlerWithRegistry(t *testing.T) {
+func TestMQTTWakeHandlerNoBusDropsMessage(t *testing.T) {
 	store := newTestWakeStore(t)
-	seed := router.LoopProfile{Instructions: "test instructions"}
+
+	target := messages.LoopWakeTarget{Name: "handler"}
 	if err := store.LoadConfig([]config.SubscriptionConfig{
-		{Topic: "home/sensor/wake", Wake: &seed},
+		{Topic: "test/topic", WakeLoop: &target},
 	}); err != nil {
 		t.Fatalf("LoadConfig: %v", err)
 	}
 
-	runner := &mqttMockRunner{}
-	registry := looppkg.NewRegistry()
-	bus := events.New()
-
-	var parentID atomic.Value
-	parentID.Store("parent-loop-123")
-
-	deps := mqttWakeDeps{
-		registry: registry,
-		eventBus: bus,
-		parentID: &parentID,
-	}
-
-	handler := mqttWakeHandler(store, runner, nil, nil, deps)
-	handler("home/sensor/wake", []byte(`{"temp": 22}`))
-
-	// Wait for the spawned loop to complete.
-	deadline := time.Now().Add(2 * time.Second)
-	for time.Now().Before(deadline) {
-		if reqs := runner.requests(); len(reqs) > 0 {
-			break
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
-
-	reqs := runner.requests()
-	if len(reqs) != 1 {
-		t.Fatalf("expected 1 request via registry dispatch, got %d", len(reqs))
-	}
-
-	req := reqs[0]
-	if req.RoutingFactors["source"] != "mqtt_wake" {
-		t.Errorf("source hint = %q, want %q", req.RoutingFactors["source"], "mqtt_wake")
-	}
-	if req.RoutingFactors["loop_id"] == "" {
-		t.Error("loop_id hint is empty; request did not traverse loop turn preparation")
-	}
-	if req.RoutingFactors["loop_name"] != "mqtt/wake" {
-		t.Errorf("loop_name hint = %q, want %q", req.RoutingFactors["loop_name"], "mqtt/wake")
-	}
-}
-
-func TestMQTTWakeHandlerFanOut(t *testing.T) {
-	store := newTestWakeStore(t)
-	seedA := router.LoopProfile{Mission: "automation", Instructions: "check temperature"}
-	seedB := router.LoopProfile{Mission: "background", Instructions: "log reading"}
-	if err := store.LoadConfig([]config.SubscriptionConfig{
-		{Topic: "sensors/+/reading", Wake: &seedA},
-		{Topic: "sensors/+/reading", Wake: &seedB},
-	}); err != nil {
-		t.Fatalf("LoadConfig: %v", err)
-	}
-
-	runner := &mqttMockRunner{}
-	registry := looppkg.NewRegistry()
-	bus := events.New()
-
-	var parentID atomic.Value
-	parentID.Store("test-mqtt-parent")
-
-	deps := mqttWakeDeps{
-		registry: registry,
-		eventBus: bus,
-		parentID: &parentID,
-	}
-
-	handler := mqttWakeHandler(store, runner, nil, nil, deps)
-	handler("sensors/temp/reading", []byte(`{"value": 22.5}`))
-
-	// Wait for both goroutines to dispatch.
-	deadline := time.Now().Add(2 * time.Second)
-	for time.Now().Before(deadline) {
-		if reqs := runner.requests(); len(reqs) >= 2 {
-			break
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
-
-	reqs := runner.requests()
-	if len(reqs) != 2 {
-		t.Fatalf("expected 2 requests (fan-out), got %d", len(reqs))
-	}
-
-	// Both should have the subscription ID hint set.
-	for i, req := range reqs {
-		if req.RoutingFactors["mqtt_subscription_id"] == "" {
-			t.Errorf("request %d missing mqtt_subscription_id hint", i)
-		}
-	}
-}
-
-func TestMQTTWakeHandlerNoRegistryDropsMessage(t *testing.T) {
-	store := newTestWakeStore(t)
-	seed := router.LoopProfile{Mission: "automation"}
-	if err := store.LoadConfig([]config.SubscriptionConfig{
-		{Topic: "test/topic", Wake: &seed},
-	}); err != nil {
-		t.Fatalf("LoadConfig: %v", err)
-	}
-
-	runner := &mqttMockRunner{}
-	// No registry — message should be dropped, not dispatched directly.
-	handler := mqttWakeHandler(store, runner, nil, nil, mqttWakeDeps{})
+	handler := mqttWakeHandler(store, nil, nil, mqttWakeDeps{})
 	handler("test/topic", []byte("data"))
+	// No bus configured — the handler should log and return without
+	// blocking or panicking. Wait briefly to confirm nothing crashes
+	// asynchronously.
+	time.Sleep(100 * time.Millisecond)
+}
 
-	// Give goroutine time to (not) run.
-	time.Sleep(200 * time.Millisecond)
-
-	if reqs := runner.requests(); len(reqs) != 0 {
-		t.Fatalf("expected 0 requests without registry, got %d", len(reqs))
+func TestSanitizePayloadTruncates(t *testing.T) {
+	big := strings.Repeat("a", maxWakePayloadBytes+10)
+	got := sanitizePayload([]byte(big))
+	if !strings.Contains(got, "[Truncated:") {
+		t.Errorf("expected truncation marker, got %q", got[:60])
 	}
 }
 
-// TestMQTTWakeHandlerDispatchesViaWakeTarget pins the post-PR-T1
-// trigger-unification contract: a subscription with a WakeTarget
-// configured delivers matching messages as event-source envelopes
-// to the target loop, instead of spawning a fresh one-shot loop.
-// The bus audit hook captures the envelope so we can verify shape.
-func TestMQTTWakeHandlerDispatchesViaWakeTarget(t *testing.T) {
-	store := newTestWakeStore(t)
-
-	// Operator declares "messages on frigate/+/events go to the
-	// home_security loop." No spawn-profile fields: the target
-	// loop owns routing.
-	target := messages.LoopWakeTarget{Name: "home_security", Priority: messages.PriorityNormal}
-	if err := store.LoadConfig([]config.SubscriptionConfig{
-		{Topic: "frigate/+/events", WakeLoop: &target},
-	}); err != nil {
-		t.Fatalf("LoadConfig: %v", err)
+func TestSanitizePayloadEmpty(t *testing.T) {
+	if got := sanitizePayload(nil); got != "" {
+		t.Errorf("sanitizePayload(nil) = %q, want empty", got)
 	}
-
-	bus := messages.NewBus(nil)
-	// Capture the envelope the dispatcher sends.
-	var captured []messages.Envelope
-	var capturedMu sync.Mutex
-	bus.AddAuditFunc(func(_ context.Context, env messages.Envelope, _ *messages.DeliveryResult, _ error) {
-		capturedMu.Lock()
-		defer capturedMu.Unlock()
-		captured = append(captured, env)
-	})
-	// Stub the loop destination handler so Send doesn't fail on
-	// the unrouted loop — we don't have a live registry here.
-	bus.RegisterRoute(messages.DestinationLoop, func(_ context.Context, env messages.Envelope) (messages.DeliveryResult, error) {
-		return messages.DeliveryResult{Envelope: env, Status: messages.DeliveryDelivered}, nil
-	})
-
-	runner := &mqttMockRunner{}
-	registry := looppkg.NewRegistry()
-	deps := mqttWakeDeps{
-		registry:   registry,
-		messageBus: bus,
-		eventBus:   events.New(),
-	}
-
-	handler := mqttWakeHandler(store, runner, nil, nil, deps)
-	handler("frigate/front/events", []byte(`{"event":"motion"}`))
-
-	// Give the dispatcher goroutine time to run.
-	deadline := time.Now().Add(500 * time.Millisecond)
-	for time.Now().Before(deadline) {
-		capturedMu.Lock()
-		if len(captured) > 0 {
-			capturedMu.Unlock()
-			break
-		}
-		capturedMu.Unlock()
-		time.Sleep(10 * time.Millisecond)
-	}
-
-	capturedMu.Lock()
-	defer capturedMu.Unlock()
-	if len(captured) != 1 {
-		t.Fatalf("expected 1 envelope delivered, got %d", len(captured))
-	}
-	env := captured[0]
-	if env.To.Target != "home_security" {
-		t.Errorf("envelope target = %q, want %q", env.To.Target, "home_security")
-	}
-	if env.Type != messages.TypeSignal {
-		t.Errorf("envelope type = %q, want %q", env.Type, messages.TypeSignal)
-	}
-	payload, ok := env.Payload.(messages.LoopNotifyPayload)
-	if !ok {
-		t.Fatalf("payload type = %T, want messages.LoopNotifyPayload", env.Payload)
-	}
-	if payload.Kind != "event_source" {
-		t.Errorf("payload.Kind = %q, want %q", payload.Kind, "event_source")
-	}
-	if len(payload.Events) != 1 {
-		t.Fatalf("payload.Events len = %d, want 1", len(payload.Events))
-	}
-	event := payload.Events[0]
-	if event.Source != "mqtt_wake" {
-		t.Errorf("event.Source = %q, want %q", event.Source, "mqtt_wake")
-	}
-	if event.Title != "frigate/front/events" {
-		t.Errorf("event.Title = %q, want the topic", event.Title)
-	}
-
-	// And critically: no agent run happened. The whole point of
-	// the wake-target path is that the existing target loop sees
-	// the event on its next iteration; no new conversation
-	// spawns.
-	if reqs := runner.requests(); len(reqs) != 0 {
-		t.Errorf("expected 0 spawned agent runs, got %d (wake-target dispatch should not spawn)", len(reqs))
-	}
-}
-
-// TestMQTTWakeHandlerFallsBackToSpawnWithoutWakeTarget guards the
-// backwards-compat path: a subscription with no WakeTarget but a
-// legacy Profile still uses the spawn-per-message dispatch.
-func TestMQTTWakeHandlerFallsBackToSpawnWithoutWakeTarget(t *testing.T) {
-	store := newTestWakeStore(t)
-	seed := router.LoopProfile{Mission: "automation"}
-	if err := store.LoadConfig([]config.SubscriptionConfig{
-		{Topic: "legacy/topic", Wake: &seed},
-	}); err != nil {
-		t.Fatalf("LoadConfig: %v", err)
-	}
-
-	bus := messages.NewBus(nil)
-	var capturedMu sync.Mutex
-	var captured []messages.Envelope
-	bus.AddAuditFunc(func(_ context.Context, env messages.Envelope, _ *messages.DeliveryResult, _ error) {
-		capturedMu.Lock()
-		defer capturedMu.Unlock()
-		captured = append(captured, env)
-	})
-
-	runner := &mqttMockRunner{}
-	registry := looppkg.NewRegistry()
-	var parentID atomic.Value
-	parentID.Store("test-parent")
-	deps := mqttWakeDeps{
-		registry:   registry,
-		messageBus: bus,
-		eventBus:   events.New(),
-		parentID:   &parentID,
-	}
-
-	handler := mqttWakeHandler(store, runner, nil, nil, deps)
-	handler("legacy/topic", []byte("data"))
-
-	time.Sleep(200 * time.Millisecond)
-
-	// Spawn path uses SpawnLoop, which won't find the fake
-	// parent_id in the registry — but the important assertion is
-	// that no envelope went through the bus (that's the
-	// wake-target path).
-	capturedMu.Lock()
-	defer capturedMu.Unlock()
-	if len(captured) != 0 {
-		t.Errorf("expected 0 bus envelopes for legacy spawn path, got %d", len(captured))
-	}
-}
-
-func TestBuildWakeMessage(t *testing.T) {
-	tests := []struct {
-		name         string
-		topic        string
-		payload      []byte
-		instructions string
-		wantContains []string
-	}{
-		{
-			name:         "no instructions",
-			topic:        "test/topic",
-			payload:      []byte("hello"),
-			wantContains: []string{"test/topic", "hello"},
-		},
-		{
-			name:         "with instructions",
-			topic:        "test/topic",
-			payload:      []byte("hello"),
-			instructions: "do something",
-			wantContains: []string{"Instructions: do something", "test/topic", "hello"},
-		},
-		{
-			name:         "empty payload no instructions",
-			topic:        "test/topic",
-			payload:      nil,
-			wantContains: []string{"test/topic"},
-		},
-		{
-			name:         "empty payload with instructions",
-			topic:        "test/topic",
-			payload:      nil,
-			instructions: "check status",
-			wantContains: []string{"check status", "test/topic", "no payload"},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			msg := buildWakeMessage(tt.topic, tt.payload, tt.instructions)
-			for _, s := range tt.wantContains {
-				if !contains(msg, s) {
-					t.Errorf("message %q should contain %q", msg, s)
-				}
-			}
-		})
-	}
-}
-
-func TestApplyLoopProfile(t *testing.T) {
-	seed := router.LoopProfile{
-		Model:            "claude-3-opus",
-		QualityFloor:     8,
-		Mission:          "automation",
-		LocalOnly:        "false",
-		DelegationGating: "disabled",
-		ExcludeTools:     []string{"shell_exec"},
-		ExtraHints:       map[string]string{"custom": "value"},
-	}
-
-	req := &looppkg.Request{
-		RoutingFactors: map[string]string{"existing": "hint"},
-		ExcludeTools:   []string{"files_read"},
-		InitialTags:    []string{"baseline"},
-	}
-
-	applyLoopProfile(&seed, req)
-
-	if req.Model != "claude-3-opus" {
-		t.Errorf("Model = %q, want %q", req.Model, "claude-3-opus")
-	}
-	if req.RoutingFactors[router.FactorQualityFloor] != "8" {
-		t.Errorf("quality_floor = %q, want %q", req.RoutingFactors[router.FactorQualityFloor], "8")
-	}
-	if req.RoutingFactors[router.FactorMission] != "automation" {
-		t.Errorf("mission = %q, want %q", req.RoutingFactors[router.FactorMission], "automation")
-	}
-	if req.RoutingFactors["existing"] != "hint" {
-		t.Errorf("existing hint was overwritten")
-	}
-	if req.RoutingFactors["custom"] != "value" {
-		t.Errorf("extra hint not applied")
-	}
-	if len(req.ExcludeTools) != 2 || req.ExcludeTools[0] != "files_read" || req.ExcludeTools[1] != "shell_exec" {
-		t.Errorf("ExcludeTools = %v, want [files_read shell_exec]", req.ExcludeTools)
-	}
-	// applyLoopProfile is purely routing/configuration; capability tags
-	// are no longer part of LoopProfile and are applied separately by
-	// the caller (e.g., from WakeSubscription.InitialTags).
-	if len(req.InitialTags) != 1 || req.InitialTags[0] != "baseline" {
-		t.Errorf("InitialTags = %v, want [baseline] (profile must not touch tags)", req.InitialTags)
-	}
-}
-
-// contains is a test helper for string containment checks.
-func contains(s, substr string) bool {
-	return len(s) >= len(substr) && (s == substr || len(substr) == 0 ||
-		(len(substr) <= len(s) && searchString(s, substr)))
-}
-
-func searchString(s, substr string) bool {
-	for i := 0; i <= len(s)-len(substr); i++ {
-		if s[i:i+len(substr)] == substr {
-			return true
-		}
-	}
-	return false
 }

--- a/internal/app/new_servers.go
+++ b/internal/app/new_servers.go
@@ -291,6 +291,10 @@ func (a *App) initServers(s *newState) error {
 		if err := subStore.LoadConfig(cfg.MQTT.Subscriptions); err != nil {
 			return fmt.Errorf("load mqtt wake subscriptions: %w", err)
 		}
+		// Expose the store so the loop-definition-services deferred
+		// worker can VerifyTargets against the live registry once
+		// every loop has been hydrated.
+		a.mqttSubStore = subStore
 
 		// Wire dynamic topic discovery: on every broker (re-)connect the
 		// publisher merges store topics into the SUBSCRIBE packet.
@@ -595,6 +599,16 @@ func (a *App) initServers(s *newState) error {
 					"skipped_existing", result.SkippedExisting,
 					"skipped_non_service", result.SkippedNonService,
 				)
+			}
+			// Now that the durable definition snapshot is registered,
+			// fail loud on any config-defined MQTT wake subscription
+			// that names a loop nobody actually registered. Runtime
+			// adds already do this at Add() time; this closes the gap
+			// on YAML entries that loaded before any loop existed.
+			if a.mqttSubStore != nil && a.loopRegistry != nil {
+				if err := a.mqttSubStore.VerifyTargets(a.loopRegistry); err != nil {
+					return fmt.Errorf("verify mqtt wake subscription targets: %w", err)
+				}
 			}
 			return nil
 		})

--- a/internal/app/new_servers.go
+++ b/internal/app/new_servers.go
@@ -344,7 +344,6 @@ func (a *App) initServers(s *newState) error {
 		// base handler above.
 		mqttPub.SetMessageHandler(mqttWakeHandler(
 			subStore,
-			&loopAdapter{agentLoop: a.loop, router: a.rtr, capSurface: a.capSurfaceGetter()},
 			baseMsgHandler,
 			logger,
 			wakeDeps,

--- a/internal/channels/messages/event_source.go
+++ b/internal/channels/messages/event_source.go
@@ -31,12 +31,19 @@ type LoopEventPayload struct {
 // LoopWakeTarget identifies an existing loop that should receive an
 // event-source wake. It mirrors thane_wake routing but is embeddable in
 // source-specific subscription records.
+//
+// YAML and JSON tags are kept in lockstep so the same snake_case field
+// names work in operator-edited config files (loaded as YAML by
+// internal/platform/config) and in tool-call JSON arguments from the
+// model. Field names like loop_id and force_supervisor would otherwise
+// silently degrade to lowercase concatenation under default YAML
+// reflection.
 type LoopWakeTarget struct {
-	LoopID          string   `json:"loop_id,omitempty"`
-	Name            string   `json:"name,omitempty"`
-	ForceSupervisor bool     `json:"force_supervisor,omitempty"`
-	Priority        Priority `json:"priority,omitempty"`
-	Instructions    string   `json:"instructions,omitempty"`
+	LoopID          string   `json:"loop_id,omitempty" yaml:"loop_id,omitempty"`
+	Name            string   `json:"name,omitempty" yaml:"name,omitempty"`
+	ForceSupervisor bool     `json:"force_supervisor,omitempty" yaml:"force_supervisor,omitempty"`
+	Priority        Priority `json:"priority,omitempty" yaml:"priority,omitempty"`
+	Instructions    string   `json:"instructions,omitempty" yaml:"instructions,omitempty"`
 	// Tags are iteration-scoped capability tags activated when the
 	// target loop processes this wake. They merge into the
 	// iteration's Request.InitialTags via the loop runtime's
@@ -48,7 +55,7 @@ type LoopWakeTarget struct {
 	// providers without spawning a separate handler loop per
 	// classification. See the trigger-unification design in
 	// issue #902.
-	Tags []string `json:"tags,omitempty"`
+	Tags []string `json:"tags,omitempty" yaml:"tags,omitempty"`
 }
 
 // Empty reports whether the target has no loop selector.

--- a/internal/channels/messages/event_source_test.go
+++ b/internal/channels/messages/event_source_test.go
@@ -3,7 +3,62 @@ package messages
 import (
 	"strings"
 	"testing"
+
+	"gopkg.in/yaml.v3"
 )
+
+// TestLoopWakeTargetYAMLRoundTripSnakeCase pins the Codex P2 fix: the
+// struct's YAML tags match its JSON tags (snake_case) so operator-edited
+// config files can use loop_id / force_supervisor / etc. Pre-fix,
+// only JSON tags were declared and YAML defaulted to lowercase
+// concatenation (loopid / forcesupervisor), silently dropping
+// operator-supplied values that the docs and examples described.
+func TestLoopWakeTargetYAMLRoundTripSnakeCase(t *testing.T) {
+	t.Parallel()
+
+	source := `loop_id: rt-abc
+name: my_handler
+force_supervisor: true
+priority: urgent
+instructions: "act fast"
+tags:
+  - owner
+  - urgent_pickup
+`
+	var got LoopWakeTarget
+	if err := yaml.Unmarshal([]byte(source), &got); err != nil {
+		t.Fatalf("yaml.Unmarshal: %v", err)
+	}
+	if got.LoopID != "rt-abc" {
+		t.Errorf("LoopID = %q, want rt-abc (snake_case loop_id not honored)", got.LoopID)
+	}
+	if got.Name != "my_handler" {
+		t.Errorf("Name = %q, want my_handler", got.Name)
+	}
+	if !got.ForceSupervisor {
+		t.Errorf("ForceSupervisor = false, want true (snake_case force_supervisor not honored)")
+	}
+	if got.Priority != PriorityUrgent {
+		t.Errorf("Priority = %q, want urgent", got.Priority)
+	}
+	if got.Instructions != "act fast" {
+		t.Errorf("Instructions = %q, want %q", got.Instructions, "act fast")
+	}
+	if len(got.Tags) != 2 || got.Tags[0] != "owner" || got.Tags[1] != "urgent_pickup" {
+		t.Errorf("Tags = %v, want [owner urgent_pickup]", got.Tags)
+	}
+
+	// Re-emit and confirm snake_case names survive a round-trip.
+	out, err := yaml.Marshal(got)
+	if err != nil {
+		t.Fatalf("yaml.Marshal: %v", err)
+	}
+	for _, key := range []string{"loop_id", "force_supervisor"} {
+		if !strings.Contains(string(out), key+":") {
+			t.Errorf("re-emitted YAML missing %q field: %s", key, out)
+		}
+	}
+}
 
 func TestNewEventSourceEnvelopeRejectsOversizedBatch(t *testing.T) {
 	t.Parallel()

--- a/internal/channels/mqtt/subscriptions.go
+++ b/internal/channels/mqtt/subscriptions.go
@@ -17,67 +17,47 @@ import (
 	"github.com/nugget/thane-ai-agent/internal/platform/database"
 )
 
-// WakeSubscription pairs an MQTT topic filter with one of two dispatch
-// shapes used to react to messages on the topic:
+// DefaultHandlerLoopName is the name of the built-in event-driven loop
+// that receives MQTT wake events when a subscription does not declare
+// a custom wake_loop target. It is auto-started at boot via the loop
+// definition runtime whenever MQTT is configured, and is the migration
+// landing zone for legacy inline-Profile subscriptions.
+const DefaultHandlerLoopName = "mqtt-default-handler"
+
+// WakeSubscription pairs an MQTT topic filter with a target loop
+// that receives matching messages as event-source notifications.
+// Matching messages produce a [messages.LoopEventPayload] delivered
+// to the target loop's pending notifications via
+// [messages.NewEventSourceEnvelope]; the target loop's next iteration
+// sees the MQTT payload as an event-source wake and runs under its
+// own Spec.Profile / SupervisorProfile / container cascade. No new
+// loop is spawned; the registry stays clean.
 //
-//   - **Wake-target dispatch (preferred):** WakeTarget points at an
-//     existing loop. Matching messages produce a
-//     [messages.LoopEventPayload] delivered to the target loop's
-//     pending notifications via [messages.NewEventSourceEnvelope].
-//     The target loop's next iteration sees the MQTT payload as an
-//     event-source wake and runs under its own Spec.Profile /
-//     SupervisorProfile / container cascade. No new loop is
-//     spawned; the registry stays clean.
-//
-//   - **Spawn dispatch (legacy):** Profile + InitialTags shape a
-//     fresh one-shot loop run when no WakeTarget is configured.
-//     Kept for backwards compatibility with subscriptions written
-//     before the trigger-unification work; new subscriptions
-//     should declare WakeTarget instead.
-//
-// HasWakeTarget reports which path a given subscription uses.
+// Operators that don't declare a custom wake_loop are migrated onto
+// the built-in [DefaultHandlerLoopName] event-driven loop at config
+// load and DB hydrate time.
 type WakeSubscription struct {
 	ID    string `json:"id"`
 	Topic string `json:"topic"`
 
 	// WakeTarget identifies an existing loop to receive matching
-	// MQTT messages as event-source notifications. When non-empty
-	// this is the preferred dispatch route — Profile and InitialTags
-	// are unused on this path because the target loop owns its own
-	// routing via Spec.Profile.
-	WakeTarget messages.LoopWakeTarget `json:"wake_loop,omitempty"`
-
-	// Profile shapes the spawn-dispatch path (legacy). Used only
-	// when WakeTarget is empty.
-	Profile router.LoopProfile `json:"profile"`
-
-	// InitialTags lists capability tags activated at the start of
-	// the spawn-dispatch agent run (legacy path). Only used when
-	// WakeTarget is empty. Modern subscriptions delegate tag
-	// activation to the target loop's Spec.Tags.
-	InitialTags []string `json:"initial_tags,omitempty"`
+	// MQTT messages as event-source notifications. Never empty after
+	// validation: subscriptions without a wake_loop are rejected at
+	// the tool surface and auto-migrated onto the default handler at
+	// load time.
+	WakeTarget messages.LoopWakeTarget `json:"wake_loop"`
 
 	Source    string    `json:"source"` // "config" or "runtime"
 	CreatedAt time.Time `json:"created_at"`
 }
 
-// HasWakeTarget reports whether this subscription routes matching
-// messages to an existing loop via the event-source envelope path
-// (the modern dispatch shape), versus the legacy
-// spawn-a-one-shot-loop path that consumes Profile + InitialTags.
-func (ws WakeSubscription) HasWakeTarget() bool {
-	return !ws.WakeTarget.Empty()
-}
-
-// AddRequest is the parameter struct for [SubscriptionStore.Add]. At
-// least one of WakeTarget or Profile must carry meaningful
-// configuration — a subscription that points at neither would match
-// MQTT messages and then do nothing.
+// AddRequest is the parameter struct for [SubscriptionStore.Add]. A
+// non-empty WakeTarget is required; the inline-Profile spawn path was
+// retired in the trigger-unification work — operators who want bespoke
+// handling create their own event-driven loop and point wake_loop at it.
 type AddRequest struct {
-	Topic       string
-	WakeTarget  messages.LoopWakeTarget
-	Profile     router.LoopProfile
-	InitialTags []string
+	Topic      string
+	WakeTarget messages.LoopWakeTarget
 }
 
 // SubscriptionStore manages wake-enabled MQTT subscriptions with
@@ -139,7 +119,13 @@ func NewSubscriptionStore(db *sql.DB, logger *slog.Logger) (*SubscriptionStore, 
 	return s, nil
 }
 
-// loadRuntime reads persisted runtime subscriptions from SQLite.
+// loadRuntime reads persisted runtime subscriptions from SQLite and
+// auto-migrates legacy inline-Profile rows onto [DefaultHandlerLoopName].
+// Rows that pre-date PR-T1 (no wake_target_json) get rewritten to point
+// at the default handler, preserving any initial_tags as
+// [messages.LoopWakeTarget.Tags] and the profile's Instructions field.
+// Migrated rows are persisted back to SQLite so the migration is a
+// one-shot upgrade rather than a per-boot rewrite.
 func (s *SubscriptionStore) loadRuntime() error {
 	rows, err := s.db.Query(`SELECT id, topic, seed_json, initial_tags_json, wake_target_json, source, created_at FROM mqtt_wake_subscriptions`)
 	if err != nil {
@@ -147,61 +133,56 @@ func (s *SubscriptionStore) loadRuntime() error {
 	}
 	defer rows.Close()
 
+	type loadedRow struct {
+		ws         WakeSubscription
+		needsWrite bool
+		newTarget  messages.LoopWakeTarget
+	}
+	var loaded []loadedRow
+
 	for rows.Next() {
 		var ws WakeSubscription
-		var profileJSON, initialTagsJSON, wakeTargetJSON, createdAt string
-		if err := rows.Scan(&ws.ID, &ws.Topic, &profileJSON, &initialTagsJSON, &wakeTargetJSON, &ws.Source, &createdAt); err != nil {
+		var seedJSON, initialTagsJSON, wakeTargetJSON, createdAt string
+		if err := rows.Scan(&ws.ID, &ws.Topic, &seedJSON, &initialTagsJSON, &wakeTargetJSON, &ws.Source, &createdAt); err != nil {
 			return err
-		}
-		if err := json.Unmarshal([]byte(profileJSON), &ws.Profile); err != nil {
-			s.logger.Warn("skipping subscription with invalid profile JSON",
-				"id", ws.ID, "error", err)
-			continue
-		}
-		if initialTagsJSON != "" {
-			var tags []string
-			if err := json.Unmarshal([]byte(initialTagsJSON), &tags); err != nil {
-				s.logger.Warn("subscription initial_tags_json invalid, ignoring",
-					"id", ws.ID, "error", err)
-			} else if len(tags) > 0 {
-				ws.InitialTags = tags
-			}
-		}
-		// wake_target_json is "{}" for pre-trigger-unification rows
-		// (column default). Unmarshal then Empty() detects "no
-		// target configured" and dispatch falls back to the legacy
-		// Profile-driven spawn path.
-		if wakeTargetJSON != "" && wakeTargetJSON != "{}" {
-			if err := json.Unmarshal([]byte(wakeTargetJSON), &ws.WakeTarget); err != nil {
-				s.logger.Warn("subscription wake_target_json invalid, ignoring",
-					"id", ws.ID, "error", err)
-				ws.WakeTarget = messages.LoopWakeTarget{}
-			}
 		}
 		ts, err := database.ParseTimestamp(createdAt)
 		if err != nil {
-			s.logger.Warn("skipping subscription with invalid timestamp",
+			s.logger.Warn("skipping persisted subscription with invalid timestamp",
 				"id", ws.ID, "error", err)
 			continue
 		}
 		ws.CreatedAt = ts
-
-		// Validate persisted rows against current rules — older rows
-		// may predate the validation added in Add(). Skip invalid
-		// entries rather than letting them cause SUBSCRIBE failures
-		// or unexpected matching at runtime.
 		if err := router.ValidateTopicFilter(ws.Topic); err != nil {
 			s.logger.Warn("skipping persisted subscription with invalid topic",
 				"id", ws.ID, "topic", ws.Topic, "error", err)
 			continue
 		}
-		if err := ws.Profile.Validate(); err != nil {
-			s.logger.Warn("skipping persisted subscription with invalid profile",
-				"id", ws.ID, "topic", ws.Topic, "error", err)
-			continue
-		}
 
-		s.subs = append(s.subs, ws)
+		row := loadedRow{ws: ws}
+		// wake_target_json is "{}" for pre-trigger-unification rows
+		// (the column default added by the PR-T1 migration). Detect
+		// either form and rewrite onto the default handler.
+		hasStoredTarget := wakeTargetJSON != "" && wakeTargetJSON != "{}"
+		if hasStoredTarget {
+			if err := json.Unmarshal([]byte(wakeTargetJSON), &row.ws.WakeTarget); err != nil {
+				s.logger.Warn("subscription wake_target_json invalid, migrating onto default handler",
+					"id", ws.ID, "topic", ws.Topic, "error", err)
+				hasStoredTarget = false
+			}
+		}
+		if !hasStoredTarget || row.ws.WakeTarget.Empty() {
+			row.newTarget = migrateLegacyMQTTSubscription(seedJSON, initialTagsJSON)
+			row.ws.WakeTarget = row.newTarget
+			row.needsWrite = true
+			s.logger.Warn("migrating legacy mqtt wake subscription onto default handler",
+				"id", row.ws.ID,
+				"topic", row.ws.Topic,
+				"default_handler", DefaultHandlerLoopName,
+				"migrated_tags", row.ws.WakeTarget.Tags,
+			)
+		}
+		loaded = append(loaded, row)
 	}
 
 	if err := rows.Err(); err != nil {
@@ -211,15 +192,76 @@ func (s *SubscriptionStore) loadRuntime() error {
 		return err
 	}
 
+	// Persist migrated targets after the query is fully drained — some
+	// drivers won't let us issue UPDATE statements while a SELECT cursor
+	// is still open. Migration failures here are not fatal; the next
+	// boot will retry the same rewrite.
+	for _, row := range loaded {
+		if row.needsWrite {
+			blob, err := json.Marshal(row.ws.WakeTarget)
+			if err != nil {
+				s.logger.Warn("failed to marshal migrated wake target",
+					"id", row.ws.ID, "error", err)
+				continue
+			}
+			if _, err := s.db.Exec(
+				`UPDATE mqtt_wake_subscriptions SET wake_target_json = ?, seed_json = '{}', initial_tags_json = '[]' WHERE id = ?`,
+				string(blob), row.ws.ID,
+			); err != nil {
+				s.logger.Warn("failed to persist migrated wake target — will retry on next boot",
+					"id", row.ws.ID, "error", err)
+			}
+		}
+		s.subs = append(s.subs, row.ws)
+	}
+
 	return nil
 }
 
-// LoadConfig loads config-defined wake subscriptions. Only entries with
-// a non-nil Wake field are loaded. Config subscriptions are not persisted
-// to SQLite and cannot be removed via [SubscriptionStore.Remove].
-// Returns an error if any wake subscription has an invalid topic filter
-// or profile — config-backed triggers should fail at startup rather than
-// silently dropping messages at runtime.
+// migrateLegacyMQTTSubscription constructs a default-handler wake
+// target from a legacy row's stored profile JSON and initial tags JSON.
+// Both blobs are tolerated being invalid or empty — the migration's job
+// is to keep the subscription firing into *something* rather than
+// silently drop it, so we extract whatever signal is salvageable (the
+// operator's Instructions text, their iteration-scoped tags) and
+// otherwise hand the model the bare topic + payload to triage.
+func migrateLegacyMQTTSubscription(seedJSON, initialTagsJSON string) messages.LoopWakeTarget {
+	target := messages.LoopWakeTarget{Name: DefaultHandlerLoopName}
+	if seedJSON != "" {
+		var legacy router.LoopProfile
+		if err := json.Unmarshal([]byte(seedJSON), &legacy); err == nil {
+			if trimmed := strings.TrimSpace(legacy.Instructions); trimmed != "" {
+				target.Instructions = trimmed
+			}
+		}
+	}
+	if initialTagsJSON != "" {
+		var tags []string
+		if err := json.Unmarshal([]byte(initialTagsJSON), &tags); err == nil {
+			cleaned := make([]string, 0, len(tags))
+			for _, tag := range tags {
+				if t := strings.TrimSpace(tag); t != "" {
+					cleaned = append(cleaned, t)
+				}
+			}
+			if len(cleaned) > 0 {
+				target.Tags = cleaned
+			}
+		}
+	}
+	return target
+}
+
+// LoadConfig loads config-defined wake subscriptions. Only entries
+// with a non-nil WakeLoop or legacy Wake field are loaded; entries
+// with neither are ambient-awareness only and skipped. Legacy Wake +
+// InitialTags entries are auto-migrated onto [DefaultHandlerLoopName]
+// with a WARN log so operators see the deprecation. Config
+// subscriptions are not persisted to SQLite and cannot be removed via
+// [SubscriptionStore.Remove]. Returns an error if any wake
+// subscription has an invalid topic filter or wake_loop target —
+// config-backed triggers should fail at startup rather than silently
+// dropping messages at runtime.
 func (s *SubscriptionStore) LoadConfig(subs []config.SubscriptionConfig) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -235,8 +277,6 @@ func (s *SubscriptionStore) LoadConfig(subs []config.SubscriptionConfig) error {
 	s.subs = filtered
 
 	for i, sc := range subs {
-		// A config entry with neither WakeLoop nor Wake is
-		// ambient-awareness only; skip silently like before.
 		if sc.WakeLoop == nil && sc.Wake == nil {
 			continue
 		}
@@ -244,37 +284,79 @@ func (s *SubscriptionStore) LoadConfig(subs []config.SubscriptionConfig) error {
 			return fmt.Errorf("mqtt.subscriptions[%d]: invalid topic %q: %w", i, sc.Topic, err)
 		}
 		ws := WakeSubscription{
-			ID:          fmt.Sprintf("cfg-%s-%d", topicHash(sc.Topic), i),
-			Topic:       sc.Topic,
-			InitialTags: append([]string{}, sc.InitialTags...),
-			Source:      "config",
-			CreatedAt:   time.Now(),
+			ID:        fmt.Sprintf("cfg-%s-%d", topicHash(sc.Topic), i),
+			Topic:     sc.Topic,
+			Source:    "config",
+			CreatedAt: time.Now(),
 		}
-		if sc.WakeLoop != nil {
+		switch {
+		case sc.WakeLoop != nil:
 			if sc.WakeLoop.Empty() {
 				return fmt.Errorf("mqtt.subscriptions[%d] (topic %q): wake_loop requires loop_id or name", i, sc.Topic)
 			}
 			ws.WakeTarget = *sc.WakeLoop
-		}
-		// Profile is the legacy spawn-dispatch shape and is documented
-		// as ignored when WakeLoop is set. Validate it only when
-		// we'll actually use it — an unused-but-invalid Profile
-		// shouldn't fail startup if WakeLoop is the path being
-		// taken. (When neither is set we'd have continued above.)
-		if sc.Wake != nil && sc.WakeLoop == nil {
-			if err := sc.Wake.Validate(); err != nil {
-				return fmt.Errorf("mqtt.subscriptions[%d] (topic %q): invalid wake profile: %w", i, sc.Topic, err)
+			// Config-level initial_tags merge into the iteration-
+			// scoped tag set carried on the wake envelope.
+			if len(sc.InitialTags) > 0 {
+				ws.WakeTarget.Tags = mergeUniqueTags(ws.WakeTarget.Tags, sc.InitialTags)
 			}
-			ws.Profile = *sc.Wake
-		} else if sc.Wake != nil {
-			// WakeLoop wins, but stash the profile data so it
-			// round-trips on the WakeSubscription — operators who
-			// later remove WakeLoop should still see what they had.
-			ws.Profile = *sc.Wake
+		default:
+			// Legacy inline-Profile entry. Migrate onto the default
+			// handler so operators upgrade in place without losing
+			// their subscription firing.
+			ws.WakeTarget = messages.LoopWakeTarget{Name: DefaultHandlerLoopName}
+			if sc.Wake != nil {
+				if instructions := strings.TrimSpace(sc.Wake.Instructions); instructions != "" {
+					ws.WakeTarget.Instructions = instructions
+				}
+			}
+			if len(sc.InitialTags) > 0 {
+				ws.WakeTarget.Tags = mergeUniqueTags(nil, sc.InitialTags)
+			}
+			s.logger.Warn("migrating legacy mqtt subscription config entry onto default handler",
+				"index", i,
+				"topic", sc.Topic,
+				"default_handler", DefaultHandlerLoopName,
+				"migrated_tags", ws.WakeTarget.Tags,
+			)
 		}
 		s.subs = append(s.subs, ws)
 	}
 	return nil
+}
+
+// mergeUniqueTags returns the deduplicated union of two tag slices,
+// preserving the order of the first slice and appending unique tags
+// from the second. Empty strings are dropped.
+func mergeUniqueTags(base, extra []string) []string {
+	seen := make(map[string]struct{}, len(base)+len(extra))
+	out := make([]string, 0, len(base)+len(extra))
+	for _, tag := range base {
+		t := strings.TrimSpace(tag)
+		if t == "" {
+			continue
+		}
+		if _, dup := seen[t]; dup {
+			continue
+		}
+		seen[t] = struct{}{}
+		out = append(out, t)
+	}
+	for _, tag := range extra {
+		t := strings.TrimSpace(tag)
+		if t == "" {
+			continue
+		}
+		if _, dup := seen[t]; dup {
+			continue
+		}
+		seen[t] = struct{}{}
+		out = append(out, t)
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
 }
 
 // SetSubscribeHook registers a callback that is invoked after a runtime
@@ -288,69 +370,40 @@ func (s *SubscriptionStore) SetSubscribeHook(fn func(topics []string)) {
 }
 
 // Add creates a runtime wake subscription, persists it to SQLite, and
-// returns the new subscription. The topic filter and dispatch shape
-// are validated before persistence — invalid values are rejected
-// early rather than stored and retried forever. A subscription that
-// declares neither a WakeTarget nor a meaningful Profile is rejected
-// because it would match messages and do nothing on dispatch.
+// returns the new subscription. A non-empty WakeTarget is required —
+// the inline-Profile spawn path was retired in the trigger-unification
+// work, so a runtime subscription that points at nothing has no
+// dispatch route at all.
 func (s *SubscriptionStore) Add(req AddRequest) (WakeSubscription, error) {
 	topic := strings.TrimSpace(req.Topic)
 	if err := router.ValidateTopicFilter(topic); err != nil {
 		return WakeSubscription{}, fmt.Errorf("invalid topic filter: %w", err)
 	}
-	// Profile validation is conditional on dispatch mode. When
-	// WakeTarget is set, the legacy Profile fields are documented
-	// as ignored — so an irrelevant invalid value (e.g. an
-	// accidental quality_floor=99 left over from copy-paste)
-	// shouldn't block a perfectly valid wake_loop subscription.
-	// Only when we'll actually USE the Profile (spawn dispatch
-	// path) do we require it to be valid.
 	if req.WakeTarget.Empty() {
-		if err := req.Profile.Validate(); err != nil {
-			return WakeSubscription{}, fmt.Errorf("invalid loop profile: %w", err)
-		}
-		// A subscription that points at nothing is almost certainly
-		// an operator/model mistake: matching messages would
-		// dispatch against a zero-value Profile (no model
-		// preference, no instructions) and would still spawn a
-		// one-shot loop. Reject with an actionable error.
-		// LoopProfile contains slice/map fields so we can't
-		// `==`-compare against a zero literal; inspect each field
-		// instead.
-		if isLoopProfileEmpty(req.Profile) {
-			return WakeSubscription{}, fmt.Errorf("subscription must declare either wake_loop (preferred) or a non-empty profile")
-		}
+		return WakeSubscription{}, fmt.Errorf("subscription requires a wake_loop target (loop_id or name)")
 	}
 
 	ws := WakeSubscription{
-		ID:          fmt.Sprintf("rt-%s-%d", topicHash(topic), time.Now().UnixMilli()),
-		Topic:       topic,
-		WakeTarget:  req.WakeTarget,
-		Profile:     req.Profile,
-		InitialTags: append([]string{}, req.InitialTags...),
-		Source:      "runtime",
-		CreatedAt:   time.Now(),
+		ID:         fmt.Sprintf("rt-%s-%d", topicHash(topic), time.Now().UnixMilli()),
+		Topic:      topic,
+		WakeTarget: req.WakeTarget,
+		Source:     "runtime",
+		CreatedAt:  time.Now(),
 	}
 
-	profileJSON, err := json.Marshal(ws.Profile)
-	if err != nil {
-		return WakeSubscription{}, fmt.Errorf("marshal profile: %w", err)
-	}
-	// Marshal from a non-nil slice so the column always stores a JSON
-	// array (matching the column's '[]' default). json.Marshal(nil)
-	// produces "null", which would be inconsistent.
-	initialTagsJSON, err := json.Marshal(ws.InitialTags)
-	if err != nil {
-		return WakeSubscription{}, fmt.Errorf("marshal initial_tags: %w", err)
-	}
 	wakeTargetJSON, err := json.Marshal(ws.WakeTarget)
 	if err != nil {
 		return WakeSubscription{}, fmt.Errorf("marshal wake_target: %w", err)
 	}
 
+	// seed_json and initial_tags_json columns are no-op vestigial
+	// after the legacy spawn path was retired. Insert deterministic
+	// empty-JSON values rather than dropping the columns to keep the
+	// schema compatible with operators who downgrade after upgrading
+	// — they'd still see migrated rows with hollow legacy fields.
 	_, err = s.db.Exec(
 		`INSERT INTO mqtt_wake_subscriptions (id, topic, seed_json, initial_tags_json, wake_target_json, source, created_at) VALUES (?, ?, ?, ?, ?, ?, ?)`,
-		ws.ID, ws.Topic, string(profileJSON), string(initialTagsJSON), string(wakeTargetJSON), ws.Source, ws.CreatedAt.Format(time.RFC3339),
+		ws.ID, ws.Topic, "{}", "[]", string(wakeTargetJSON), ws.Source, ws.CreatedAt.Format(time.RFC3339),
 	)
 	if err != nil {
 		return WakeSubscription{}, fmt.Errorf("insert subscription: %w", err)
@@ -484,21 +537,4 @@ func matchTopicFilter(filter, topic string) bool {
 func topicHash(topic string) string {
 	h := sha256.Sum256([]byte(topic))
 	return hex.EncodeToString(h[:8])
-}
-
-// isLoopProfileEmpty reports whether every field on the profile is
-// zero-valued. Used to detect subscriptions that declare neither a
-// wake target nor a useful spawn-time routing shape (an operator
-// mistake we want to fail loud on, since the subscription would
-// otherwise match and silently produce a no-op spawn).
-func isLoopProfileEmpty(p router.LoopProfile) bool {
-	return p.Model == "" &&
-		p.QualityFloor == 0 &&
-		p.Mission == "" &&
-		p.LocalOnly == "" &&
-		p.DelegationGating == "" &&
-		p.PreferSpeed == "" &&
-		p.Instructions == "" &&
-		len(p.ExcludeTools) == 0 &&
-		len(p.ExtraHints) == 0
 }

--- a/internal/channels/mqtt/subscriptions.go
+++ b/internal/channels/mqtt/subscriptions.go
@@ -131,6 +131,11 @@ func (s *SubscriptionStore) loadRuntime() error {
 	if err != nil {
 		return err
 	}
+	// rows.Close is idempotent so deferring is safe even though the
+	// happy path closes the cursor explicitly below (some drivers
+	// block UPDATEs while a SELECT cursor is open, hence the early
+	// close). The defer is the safety net for the rows.Scan/Err
+	// early-return paths.
 	defer rows.Close()
 
 	type loadedRow struct {
@@ -188,14 +193,17 @@ func (s *SubscriptionStore) loadRuntime() error {
 	if err := rows.Err(); err != nil {
 		return err
 	}
+	// Release the cursor before running UPDATE statements — some
+	// drivers reject DML while a SELECT cursor is still open. The
+	// deferred Close above runs again on return; sql.Rows.Close is
+	// idempotent so the second call is a no-op.
 	if err := rows.Close(); err != nil {
 		return err
 	}
 
-	// Persist migrated targets after the query is fully drained — some
-	// drivers won't let us issue UPDATE statements while a SELECT cursor
-	// is still open. Migration failures here are not fatal; the next
-	// boot will retry the same rewrite.
+	// Persist migrated targets after the query is fully drained.
+	// Migration failures here are not fatal; the next boot will retry
+	// the same rewrite.
 	for _, row := range loaded {
 		if row.needsWrite {
 			blob, err := json.Marshal(row.ws.WakeTarget)
@@ -367,6 +375,34 @@ func (s *SubscriptionStore) SetSubscribeHook(fn func(topics []string)) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.subscribeHook = fn
+}
+
+// VerifyTargets checks that every loaded subscription's wake target
+// resolves against the supplied loop resolver. Intended to run after
+// the live loop registry has finished hydrating (typically right after
+// [loopDefinitionRuntime.StartEnabledServices]) so config-declared
+// targets fail startup loud instead of silently dropping the first
+// matching message at delivery time.
+//
+// Runtime tool adds already verify at the moment of Add — this method
+// closes the gap on config-defined entries, which load before any loop
+// is registered. A nil resolver is a no-op so test wiring without a
+// registry stays simple.
+func (s *SubscriptionStore) VerifyTargets(resolver messages.LoopResolver) error {
+	if resolver == nil {
+		return nil
+	}
+	s.mu.RLock()
+	subs := make([]WakeSubscription, len(s.subs))
+	copy(subs, s.subs)
+	s.mu.RUnlock()
+
+	for _, ws := range subs {
+		if err := messages.VerifyLoopWakeTarget(ws.WakeTarget, resolver); err != nil {
+			return fmt.Errorf("mqtt subscription %q (topic %q, source=%s) wake_loop unresolved: %w", ws.ID, ws.Topic, ws.Source, err)
+		}
+	}
+	return nil
 }
 
 // Add creates a runtime wake subscription, persists it to SQLite, and

--- a/internal/channels/mqtt/subscriptions_test.go
+++ b/internal/channels/mqtt/subscriptions_test.go
@@ -1,6 +1,7 @@
 package mqtt
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/nugget/thane-ai-agent/internal/channels/messages"
@@ -417,6 +418,61 @@ func TestSubscriptionStoreSubscribeHook(t *testing.T) {
 
 	if len(hookedTopics) != 1 || hookedTopics[0] != "hook/test" {
 		t.Errorf("hook received %v, want [hook/test]", hookedTopics)
+	}
+}
+
+// stubResolver implements messages.LoopResolver for VerifyTargets
+// tests. Names listed at construction time resolve; everything else
+// is treated as unregistered.
+type stubResolver struct {
+	known map[string]bool
+}
+
+func (s stubResolver) LoopExistsByID(string) bool        { return false }
+func (s stubResolver) LoopExistsByName(name string) bool { return s.known[name] }
+func (s stubResolver) KnownLoopNames() []string {
+	out := make([]string, 0, len(s.known))
+	for name := range s.known {
+		out = append(out, name)
+	}
+	return out
+}
+
+// TestSubscriptionStoreVerifyTargetsFailsLoudOnUnregistered pins the
+// Codex P2 fix: config-defined subscriptions referencing a loop that
+// nobody registers now error out at the post-StartEnabledServices
+// verification pass, instead of silently dropping the first matching
+// message at delivery time.
+func TestSubscriptionStoreVerifyTargetsFailsLoudOnUnregistered(t *testing.T) {
+	s := newTestStore(t)
+	good := wakeTarget("real_handler")
+	bad := wakeTarget("typo_handler")
+	if err := s.LoadConfig([]config.SubscriptionConfig{
+		{Topic: "ok/topic", WakeLoop: &good},
+		{Topic: "broken/topic", WakeLoop: &bad},
+	}); err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	resolver := stubResolver{known: map[string]bool{"real_handler": true}}
+	err := s.VerifyTargets(resolver)
+	if err == nil {
+		t.Fatal("expected VerifyTargets to fail on unregistered target")
+	}
+	if !strings.Contains(err.Error(), "typo_handler") {
+		t.Fatalf("error = %v, want mention of typo_handler", err)
+	}
+}
+
+func TestSubscriptionStoreVerifyTargetsNilResolverIsNoop(t *testing.T) {
+	s := newTestStore(t)
+	target := wakeTarget("anything")
+	if err := s.LoadConfig([]config.SubscriptionConfig{
+		{Topic: "ok/topic", WakeLoop: &target},
+	}); err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if err := s.VerifyTargets(nil); err != nil {
+		t.Fatalf("VerifyTargets(nil) = %v, want nil", err)
 	}
 }
 

--- a/internal/channels/mqtt/subscriptions_test.go
+++ b/internal/channels/mqtt/subscriptions_test.go
@@ -3,6 +3,7 @@ package mqtt
 import (
 	"testing"
 
+	"github.com/nugget/thane-ai-agent/internal/channels/messages"
 	"github.com/nugget/thane-ai-agent/internal/model/router"
 	"github.com/nugget/thane-ai-agent/internal/platform/config"
 	"github.com/nugget/thane-ai-agent/internal/platform/database"
@@ -75,16 +76,18 @@ func newTestStore(t *testing.T) *SubscriptionStore {
 	return s
 }
 
+func wakeTarget(name string) messages.LoopWakeTarget {
+	return messages.LoopWakeTarget{Name: name}
+}
+
 func TestSubscriptionStoreAddRemoveList(t *testing.T) {
 	s := newTestStore(t)
 
-	// Initially empty.
 	if subs := s.List(); len(subs) != 0 {
 		t.Fatalf("expected empty list, got %d", len(subs))
 	}
 
-	// Add a subscription.
-	ws, err := s.Add(AddRequest{Topic: "test/topic", Profile: router.LoopProfile{Mission: "automation"}, InitialTags: nil})
+	ws, err := s.Add(AddRequest{Topic: "test/topic", WakeTarget: wakeTarget("triage")})
 	if err != nil {
 		t.Fatalf("add: %v", err)
 	}
@@ -94,8 +97,10 @@ func TestSubscriptionStoreAddRemoveList(t *testing.T) {
 	if ws.Source != "runtime" {
 		t.Errorf("source = %q, want %q", ws.Source, "runtime")
 	}
+	if ws.WakeTarget.Name != "triage" {
+		t.Errorf("wake_target name = %q, want triage", ws.WakeTarget.Name)
+	}
 
-	// List shows it.
 	subs := s.List()
 	if len(subs) != 1 {
 		t.Fatalf("list len = %d, want 1", len(subs))
@@ -104,7 +109,6 @@ func TestSubscriptionStoreAddRemoveList(t *testing.T) {
 		t.Errorf("list[0].ID = %q, want %q", subs[0].ID, ws.ID)
 	}
 
-	// Remove it.
 	if err := s.Remove(ws.ID); err != nil {
 		t.Fatalf("remove: %v", err)
 	}
@@ -113,13 +117,23 @@ func TestSubscriptionStoreAddRemoveList(t *testing.T) {
 	}
 }
 
-func TestSubscriptionStoreLoadConfig(t *testing.T) {
+func TestSubscriptionStoreAddRequiresWakeTarget(t *testing.T) {
 	s := newTestStore(t)
 
-	profile := router.LoopProfile{QualityFloor: 7, Mission: "automation"}
+	if _, err := s.Add(AddRequest{Topic: "foo"}); err == nil {
+		t.Fatal("expected error for missing wake_loop target")
+	}
+}
+
+func TestSubscriptionStoreLoadConfigWakeLoop(t *testing.T) {
+	s := newTestStore(t)
+
+	target := wakeTarget("custom_handler")
 	cfgSubs := []config.SubscriptionConfig{
-		{Topic: "homeassistant/+/+/state"},        // no wake
-		{Topic: "frigate/events", Wake: &profile}, // wake-enabled
+		{Topic: "homeassistant/+/+/state"},           // ambient-awareness only
+		{Topic: "frigate/events", WakeLoop: &target}, // wake_loop
+		{Topic: "tagged/topic", WakeLoop: &target,
+			InitialTags: []string{"owner", "security"}},
 	}
 
 	if err := s.LoadConfig(cfgSubs); err != nil {
@@ -127,23 +141,80 @@ func TestSubscriptionStoreLoadConfig(t *testing.T) {
 	}
 
 	subs := s.List()
+	if len(subs) != 2 {
+		t.Fatalf("list len = %d, want 2 (only wake-enabled)", len(subs))
+	}
+	for _, ws := range subs {
+		if ws.Source != "config" {
+			t.Errorf("source = %q, want config", ws.Source)
+		}
+		if ws.WakeTarget.Name != "custom_handler" {
+			t.Errorf("wake_target.Name = %q, want custom_handler", ws.WakeTarget.Name)
+		}
+	}
+	// The tagged entry's InitialTags should merge into wake_target.Tags.
+	taggedFound := false
+	for _, ws := range subs {
+		if ws.Topic == "tagged/topic" {
+			taggedFound = true
+			gotTags := map[string]bool{}
+			for _, t := range ws.WakeTarget.Tags {
+				gotTags[t] = true
+			}
+			if !gotTags["owner"] || !gotTags["security"] {
+				t.Errorf("wake_target.Tags = %v, want owner+security", ws.WakeTarget.Tags)
+			}
+		}
+	}
+	if !taggedFound {
+		t.Fatal("tagged subscription not found")
+	}
+}
+
+func TestSubscriptionStoreLoadConfigMigratesLegacyWake(t *testing.T) {
+	s := newTestStore(t)
+
+	legacyProfile := router.LoopProfile{Mission: "automation", Instructions: "watch hard"}
+	cfgSubs := []config.SubscriptionConfig{
+		{Topic: "legacy/topic", Wake: &legacyProfile, InitialTags: []string{"alpha"}},
+	}
+	if err := s.LoadConfig(cfgSubs); err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+
+	subs := s.List()
 	if len(subs) != 1 {
-		t.Fatalf("list len = %d, want 1 (only wake-enabled)", len(subs))
+		t.Fatalf("list len = %d, want 1", len(subs))
 	}
-	if subs[0].Source != "config" {
-		t.Errorf("source = %q, want %q", subs[0].Source, "config")
+	got := subs[0]
+	if got.WakeTarget.Name != DefaultHandlerLoopName {
+		t.Errorf("migrated wake_target.Name = %q, want %q", got.WakeTarget.Name, DefaultHandlerLoopName)
 	}
-	if subs[0].Profile.QualityFloor != 7 {
-		t.Errorf("profile.QualityFloor = %d, want 7", subs[0].Profile.QualityFloor)
+	if got.WakeTarget.Instructions != "watch hard" {
+		t.Errorf("migrated instructions = %q, want %q", got.WakeTarget.Instructions, "watch hard")
+	}
+	if len(got.WakeTarget.Tags) != 1 || got.WakeTarget.Tags[0] != "alpha" {
+		t.Errorf("migrated tags = %v, want [alpha]", got.WakeTarget.Tags)
+	}
+}
+
+func TestSubscriptionStoreLoadConfigRejectsEmptyWakeLoop(t *testing.T) {
+	s := newTestStore(t)
+	empty := messages.LoopWakeTarget{}
+	err := s.LoadConfig([]config.SubscriptionConfig{
+		{Topic: "broken/topic", WakeLoop: &empty},
+	})
+	if err == nil {
+		t.Fatal("expected error for empty wake_loop selector")
 	}
 }
 
 func TestSubscriptionStoreConfigNotRemovable(t *testing.T) {
 	s := newTestStore(t)
 
-	profile := router.LoopProfile{Mission: "automation"}
+	target := wakeTarget("handler")
 	if err := s.LoadConfig([]config.SubscriptionConfig{
-		{Topic: "test/topic", Wake: &profile},
+		{Topic: "test/topic", WakeLoop: &target},
 	}); err != nil {
 		t.Fatalf("LoadConfig: %v", err)
 	}
@@ -153,8 +224,7 @@ func TestSubscriptionStoreConfigNotRemovable(t *testing.T) {
 		t.Fatalf("expected 1 sub, got %d", len(subs))
 	}
 
-	err := s.Remove(subs[0].ID)
-	if err == nil {
+	if err := s.Remove(subs[0].ID); err == nil {
 		t.Fatal("expected error removing config subscription, got nil")
 	}
 }
@@ -162,14 +232,13 @@ func TestSubscriptionStoreConfigNotRemovable(t *testing.T) {
 func TestSubscriptionStoreMatches(t *testing.T) {
 	s := newTestStore(t)
 
-	profile := router.LoopProfile{Mission: "automation"}
+	target := wakeTarget("handler")
 	if err := s.LoadConfig([]config.SubscriptionConfig{
-		{Topic: "frigate/+/events", Wake: &profile},
+		{Topic: "frigate/+/events", WakeLoop: &target},
 	}); err != nil {
 		t.Fatalf("LoadConfig: %v", err)
 	}
 
-	// Matching topic.
 	matches := s.Matches("frigate/camera1/events")
 	if len(matches) != 1 {
 		t.Fatalf("expected 1 match, got %d", len(matches))
@@ -178,9 +247,7 @@ func TestSubscriptionStoreMatches(t *testing.T) {
 		t.Errorf("matched topic = %q, want %q", matches[0].Topic, "frigate/+/events")
 	}
 
-	// Non-matching topic.
-	matches = s.Matches("homeassistant/sensor/temperature/state")
-	if len(matches) != 0 {
+	if matches := s.Matches("homeassistant/sensor/temperature/state"); len(matches) != 0 {
 		t.Fatalf("expected 0 matches, got %d", len(matches))
 	}
 }
@@ -188,12 +255,11 @@ func TestSubscriptionStoreMatches(t *testing.T) {
 func TestSubscriptionStoreMatchesFanOut(t *testing.T) {
 	s := newTestStore(t)
 
-	// Two subscriptions on the same topic with different profiles.
-	profileA := router.LoopProfile{Mission: "automation", Instructions: "check temperature"}
-	profileB := router.LoopProfile{Mission: "background", Instructions: "log to database"}
+	targetA := messages.LoopWakeTarget{Name: "handler_a"}
+	targetB := messages.LoopWakeTarget{Name: "handler_b"}
 	if err := s.LoadConfig([]config.SubscriptionConfig{
-		{Topic: "sensors/temperature", Wake: &profileA},
-		{Topic: "sensors/temperature", Wake: &profileB},
+		{Topic: "sensors/temperature", WakeLoop: &targetA},
+		{Topic: "sensors/temperature", WakeLoop: &targetB},
 	}); err != nil {
 		t.Fatalf("LoadConfig: %v", err)
 	}
@@ -202,20 +268,15 @@ func TestSubscriptionStoreMatchesFanOut(t *testing.T) {
 	if len(matches) != 2 {
 		t.Fatalf("expected 2 matches for fan-out, got %d", len(matches))
 	}
-
-	// Verify they have distinct IDs.
 	if matches[0].ID == matches[1].ID {
 		t.Errorf("fan-out subscriptions have duplicate IDs: %q", matches[0].ID)
 	}
-
-	// Verify distinct profiles carried through.
-	missions := map[string]bool{
-		matches[0].Profile.Mission: true,
-		matches[1].Profile.Mission: true,
+	names := map[string]bool{
+		matches[0].WakeTarget.Name: true,
+		matches[1].WakeTarget.Name: true,
 	}
-	if !missions["automation"] || !missions["background"] {
-		t.Errorf("expected both missions, got %v and %v",
-			matches[0].Profile.Mission, matches[1].Profile.Mission)
+	if !names["handler_a"] || !names["handler_b"] {
+		t.Errorf("expected both handler names, got %v / %v", matches[0].WakeTarget.Name, matches[1].WakeTarget.Name)
 	}
 }
 
@@ -226,113 +287,105 @@ func TestSubscriptionStorePersistence(t *testing.T) {
 	}
 	defer db.Close()
 
-	// Create store and add a runtime subscription.
 	s1, err := NewSubscriptionStore(db, nil)
 	if err != nil {
 		t.Fatalf("new store 1: %v", err)
 	}
-
-	_, err = s1.Add(AddRequest{Topic: "persist/test", Profile: router.LoopProfile{Mission: "automation", QualityFloor: 5}, InitialTags: nil})
-	if err != nil {
+	if _, err := s1.Add(AddRequest{
+		Topic:      "persist/test",
+		WakeTarget: messages.LoopWakeTarget{Name: "handler", Tags: []string{"persisted"}},
+	}); err != nil {
 		t.Fatalf("add: %v", err)
 	}
 
-	// Create a new store from the same DB — simulates restart.
 	s2, err := NewSubscriptionStore(db, nil)
 	if err != nil {
 		t.Fatalf("new store 2: %v", err)
 	}
-
 	subs := s2.List()
 	if len(subs) != 1 {
 		t.Fatalf("after reload, list len = %d, want 1", len(subs))
 	}
-	if subs[0].Topic != "persist/test" {
-		t.Errorf("topic = %q, want %q", subs[0].Topic, "persist/test")
+	got := subs[0]
+	if got.Topic != "persist/test" {
+		t.Errorf("topic = %q, want %q", got.Topic, "persist/test")
 	}
-	if subs[0].Profile.Mission != "automation" {
-		t.Errorf("profile.Mission = %q, want %q", subs[0].Profile.Mission, "automation")
+	if got.WakeTarget.Name != "handler" {
+		t.Errorf("wake_target.Name = %q, want handler", got.WakeTarget.Name)
+	}
+	if len(got.WakeTarget.Tags) != 1 || got.WakeTarget.Tags[0] != "persisted" {
+		t.Errorf("wake_target.Tags = %v, want [persisted]", got.WakeTarget.Tags)
 	}
 }
 
-func TestSubscriptionStoreInitialTagsPersistence(t *testing.T) {
+func TestSubscriptionStoreLoadRuntimeMigratesLegacyRow(t *testing.T) {
 	db, err := database.OpenMemory()
 	if err != nil {
 		t.Fatalf("open memory db: %v", err)
 	}
 	defer db.Close()
 
-	s1, err := NewSubscriptionStore(db, nil)
+	// Hydrate the schema first so the legacy columns exist.
+	if _, err := NewSubscriptionStore(db, nil); err != nil {
+		t.Fatalf("schema bootstrap: %v", err)
+	}
+
+	// Insert a legacy-shaped row directly: seed_json populated,
+	// wake_target_json defaulted to "{}" by the column default.
+	_, err = db.Exec(
+		`INSERT INTO mqtt_wake_subscriptions (id, topic, seed_json, initial_tags_json, wake_target_json, source, created_at) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		"rt-legacy-1", "legacy/topic",
+		`{"mission":"automation","instructions":"do the thing"}`,
+		`["alpha","beta"]`,
+		`{}`,
+		"runtime",
+		"2026-01-01T00:00:00Z",
+	)
 	if err != nil {
-		t.Fatalf("new store 1: %v", err)
+		t.Fatalf("insert legacy row: %v", err)
 	}
 
-	ws, err := s1.Add(AddRequest{Topic: "tagged/topic", Profile: router.LoopProfile{Mission: "automation"}, InitialTags: []string{"homeassistant", "security"}})
-	if err != nil {
-		t.Fatalf("add: %v", err)
-	}
-
-	var stored string
-	if err := db.QueryRow(`SELECT initial_tags_json FROM mqtt_wake_subscriptions WHERE id = ?`, ws.ID).Scan(&stored); err != nil {
-		t.Fatalf("select persisted tags: %v", err)
-	}
-	if stored != `["homeassistant","security"]` {
-		t.Fatalf("initial_tags_json = %q, want JSON array", stored)
-	}
-
-	s2, err := NewSubscriptionStore(db, nil)
-	if err != nil {
-		t.Fatalf("new store 2: %v", err)
-	}
-	subs := s2.List()
-	if len(subs) != 1 {
-		t.Fatalf("after reload len = %d, want 1", len(subs))
-	}
-	if got := subs[0].InitialTags; len(got) != 2 || got[0] != "homeassistant" || got[1] != "security" {
-		t.Fatalf("reloaded InitialTags = %v, want [homeassistant security]", got)
-	}
-}
-
-// TestSubscriptionStoreAddPersistsEmptyTagsAsArray verifies that a
-// subscription added with no InitialTags writes "[]" rather than
-// "null" — matching the column's default and keeping the on-disk
-// shape consistent.
-func TestSubscriptionStoreAddPersistsEmptyTagsAsArray(t *testing.T) {
-	db, err := database.OpenMemory()
-	if err != nil {
-		t.Fatalf("open memory db: %v", err)
-	}
-	defer db.Close()
-
+	// Reopen — loadRuntime should migrate the row.
 	s, err := NewSubscriptionStore(db, nil)
 	if err != nil {
-		t.Fatalf("new store: %v", err)
+		t.Fatalf("reopen: %v", err)
+	}
+	subs := s.List()
+	if len(subs) != 1 {
+		t.Fatalf("list len = %d, want 1", len(subs))
+	}
+	got := subs[0]
+	if got.WakeTarget.Name != DefaultHandlerLoopName {
+		t.Errorf("migrated wake_target.Name = %q, want %q", got.WakeTarget.Name, DefaultHandlerLoopName)
+	}
+	if got.WakeTarget.Instructions != "do the thing" {
+		t.Errorf("migrated instructions = %q, want %q", got.WakeTarget.Instructions, "do the thing")
+	}
+	if len(got.WakeTarget.Tags) != 2 || got.WakeTarget.Tags[0] != "alpha" || got.WakeTarget.Tags[1] != "beta" {
+		t.Errorf("migrated tags = %v, want [alpha beta]", got.WakeTarget.Tags)
 	}
 
-	ws, err := s.Add(AddRequest{Topic: "empty/tags", Profile: router.LoopProfile{Mission: "automation"}, InitialTags: nil})
-	if err != nil {
-		t.Fatalf("add: %v", err)
+	// Verify the row was persisted with the new wake_target_json,
+	// so the next boot doesn't re-migrate.
+	var storedTarget string
+	if err := db.QueryRow(`SELECT wake_target_json FROM mqtt_wake_subscriptions WHERE id = ?`, "rt-legacy-1").Scan(&storedTarget); err != nil {
+		t.Fatalf("select wake_target_json: %v", err)
 	}
-
-	var stored string
-	if err := db.QueryRow(`SELECT initial_tags_json FROM mqtt_wake_subscriptions WHERE id = ?`, ws.ID).Scan(&stored); err != nil {
-		t.Fatalf("select: %v", err)
-	}
-	if stored != "[]" {
-		t.Fatalf("initial_tags_json = %q, want %q", stored, "[]")
+	if storedTarget == "{}" || storedTarget == "" {
+		t.Fatalf("wake_target_json was not persisted after migration: %q", storedTarget)
 	}
 }
 
 func TestSubscriptionStoreTopics(t *testing.T) {
 	s := newTestStore(t)
 
-	profile := router.LoopProfile{Mission: "automation"}
+	target := wakeTarget("handler")
 	if err := s.LoadConfig([]config.SubscriptionConfig{
-		{Topic: "topic/a", Wake: &profile},
+		{Topic: "topic/a", WakeLoop: &target},
 	}); err != nil {
 		t.Fatalf("LoadConfig: %v", err)
 	}
-	if _, err := s.Add(AddRequest{Topic: "topic/b", Profile: profile}); err != nil {
+	if _, err := s.Add(AddRequest{Topic: "topic/b", WakeTarget: target}); err != nil {
 		t.Fatalf("add: %v", err)
 	}
 
@@ -358,8 +411,7 @@ func TestSubscriptionStoreSubscribeHook(t *testing.T) {
 		hookedTopics = append(hookedTopics, topics...)
 	})
 
-	_, err := s.Add(AddRequest{Topic: "hook/test", Profile: router.LoopProfile{Mission: "automation"}, InitialTags: nil})
-	if err != nil {
+	if _, err := s.Add(AddRequest{Topic: "hook/test", WakeTarget: wakeTarget("handler")}); err != nil {
 		t.Fatalf("add: %v", err)
 	}
 
@@ -368,42 +420,17 @@ func TestSubscriptionStoreSubscribeHook(t *testing.T) {
 	}
 }
 
-func TestSubscriptionStoreSubscribeHookNotCalledWithoutHook(t *testing.T) {
-	s := newTestStore(t)
-
-	// No hook set — Add should not panic. Supply a non-empty
-	// profile so the post-PR-T1 "wake_loop or non-empty profile"
-	// validation passes; the test isn't exercising that surface.
-	_, err := s.Add(AddRequest{Topic: "no-hook/test", Profile: router.LoopProfile{Mission: "automation"}, InitialTags: nil})
-	if err != nil {
-		t.Fatalf("add: %v", err)
-	}
-}
-
 func TestSubscriptionStoreAddValidation(t *testing.T) {
 	s := newTestStore(t)
 
-	// Invalid topic filter.
-	_, err := s.Add(AddRequest{Topic: "", Profile: router.LoopProfile{Mission: "automation"}})
-	if err == nil {
+	target := wakeTarget("handler")
+	if _, err := s.Add(AddRequest{Topic: "", WakeTarget: target}); err == nil {
 		t.Fatal("expected error for empty topic")
 	}
-
-	// Invalid topic with bad wildcard.
-	_, err = s.Add(AddRequest{Topic: "foo/ba#r", Profile: router.LoopProfile{}, InitialTags: nil})
-	if err == nil {
+	if _, err := s.Add(AddRequest{Topic: "foo/ba#r", WakeTarget: target}); err == nil {
 		t.Fatal("expected error for bad wildcard in topic")
 	}
-
-	// Invalid seed.
-	_, err = s.Add(AddRequest{Topic: "valid/topic", Profile: router.LoopProfile{QualityFloor: 99}, InitialTags: nil})
-	if err == nil {
-		t.Fatal("expected error for invalid quality_floor")
-	}
-
-	// Valid — should succeed.
-	_, err = s.Add(AddRequest{Topic: "valid/topic", Profile: router.LoopProfile{Mission: "automation", QualityFloor: 7}, InitialTags: nil})
-	if err != nil {
+	if _, err := s.Add(AddRequest{Topic: "valid/topic", WakeTarget: target}); err != nil {
 		t.Fatalf("expected success, got: %v", err)
 	}
 }

--- a/internal/channels/mqtt/tools.go
+++ b/internal/channels/mqtt/tools.go
@@ -4,11 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"strconv"
 	"strings"
 
 	"github.com/nugget/thane-ai-agent/internal/channels/messages"
-	"github.com/nugget/thane-ai-agent/internal/model/router"
 )
 
 // Tools provides MQTT subscription management tool handlers for the
@@ -28,19 +26,14 @@ func NewTools(store *SubscriptionStore, loopResolver messages.LoopResolver) *Too
 }
 
 // listEntry is the JSON shape emitted by HandleListWakeSubscriptions.
-// One entry per subscription; the WakeLoop field is populated for
-// trigger-style subscriptions, the Profile fields for legacy
-// spawn-style subscriptions, so the model can tell at a glance which
-// dispatch shape each entry uses.
+// One entry per subscription; every active subscription routes through
+// a wake_loop target after the trigger-unification work, so WakeLoop is
+// always populated.
 type listEntry struct {
-	SubscriptionID string                   `json:"subscription_id"`
-	Topic          string                   `json:"topic"`
-	Source         string                   `json:"source"`
-	WakeLoop       *messages.LoopWakeTarget `json:"wake_loop,omitempty"`
-	Mission        string                   `json:"mission,omitempty"`
-	QualityFloor   int                      `json:"quality_floor,omitempty"`
-	Model          string                   `json:"model,omitempty"`
-	Instructions   string                   `json:"instructions,omitempty"`
+	SubscriptionID string                  `json:"subscription_id"`
+	Topic          string                  `json:"topic"`
+	Source         string                  `json:"source"`
+	WakeLoop       messages.LoopWakeTarget `json:"wake_loop"`
 }
 
 // HandleListWakeSubscriptions returns a JSON list of all wake
@@ -49,21 +42,12 @@ func (t *Tools) HandleListWakeSubscriptions(_ context.Context, _ map[string]any)
 	subs := t.store.List()
 	entries := make([]listEntry, 0, len(subs))
 	for _, ws := range subs {
-		entry := listEntry{
+		entries = append(entries, listEntry{
 			SubscriptionID: ws.ID,
 			Topic:          ws.Topic,
 			Source:         ws.Source,
-		}
-		if ws.HasWakeTarget() {
-			target := ws.WakeTarget
-			entry.WakeLoop = &target
-		} else {
-			entry.Mission = ws.Profile.Mission
-			entry.QualityFloor = ws.Profile.QualityFloor
-			entry.Model = ws.Profile.Model
-			entry.Instructions = ws.Profile.Instructions
-		}
-		entries = append(entries, entry)
+			WakeLoop:       ws.WakeTarget,
+		})
 	}
 	data, err := json.MarshalIndent(entries, "", "  ")
 	if err != nil {
@@ -76,17 +60,18 @@ func (t *Tools) HandleListWakeSubscriptions(_ context.Context, _ map[string]any)
 // Uniform success-payload pattern matches forge_repo_follow /
 // media_follow.
 type addResponse struct {
-	Status         string                   `json:"status"`
-	SubscriptionID string                   `json:"subscription_id"`
-	Topic          string                   `json:"topic"`
-	WakeLoop       *messages.LoopWakeTarget `json:"wake_loop,omitempty"`
-	Note           string                   `json:"note,omitempty"`
+	Status         string                  `json:"status"`
+	SubscriptionID string                  `json:"subscription_id"`
+	Topic          string                  `json:"topic"`
+	WakeLoop       messages.LoopWakeTarget `json:"wake_loop"`
+	Note           string                  `json:"note,omitempty"`
 }
 
 // HandleAddWakeSubscription creates a new runtime wake subscription.
-// Required args: "topic" plus one of (a) "wake_loop" naming an
-// existing target loop or (b) any of the legacy spawn-profile fields
-// (mission, model, quality_floor, etc.).
+// Required args: "topic" and "wake_loop" (naming an existing target
+// loop). The legacy inline-Profile spawn path was retired in the
+// trigger-unification work; operators who want bespoke handling
+// create their own event-driven loop and point wake_loop at it.
 func (t *Tools) HandleAddWakeSubscription(_ context.Context, args map[string]any) (string, error) {
 	topic, _ := args["topic"].(string)
 	topic = strings.TrimSpace(topic)
@@ -98,47 +83,16 @@ func (t *Tools) HandleAddWakeSubscription(_ context.Context, args map[string]any
 	if err != nil {
 		return "", err
 	}
-	if wakeConfigured {
-		if err := messages.VerifyLoopWakeTarget(wakeTarget, t.loopResolver); err != nil {
-			return "", err
-		}
-	}
-
-	profile := router.LoopProfile{
-		Model:            stringArg(args, "model"),
-		QualityFloor:     intArg(args, "quality_floor"),
-		Mission:          stringArg(args, "mission"),
-		LocalOnly:        stringArg(args, "local_only"),
-		DelegationGating: stringArg(args, "delegation_gating"),
-		PreferSpeed:      stringArg(args, "prefer_speed"),
-		Instructions:     stringArg(args, "instructions"),
-	}
-
-	if raw, ok := args["exclude_tools"]; ok {
-		profile.ExcludeTools = toStringSlice(raw)
-	}
-
-	var initialTags []string
-	if raw, ok := args["initial_tags"]; ok {
-		initialTags = toStringSlice(raw)
-	}
-
-	// Validate the profile only when we'll actually use it (no
-	// WakeTarget set). With wake_loop dispatch the legacy spawn-
-	// profile fields are documented as ignored — so a stray
-	// invalid quality_floor=99 left over from copy-paste
-	// shouldn't block adding a valid wake_loop subscription.
 	if !wakeConfigured {
-		if err := profile.Validate(); err != nil {
-			return "", fmt.Errorf("invalid profile: %w", err)
-		}
+		return "", fmt.Errorf("wake_loop is required (provide loop_id or name)")
+	}
+	if err := messages.VerifyLoopWakeTarget(wakeTarget, t.loopResolver); err != nil {
+		return "", err
 	}
 
 	ws, err := t.store.Add(AddRequest{
-		Topic:       topic,
-		WakeTarget:  wakeTarget,
-		Profile:     profile,
-		InitialTags: initialTags,
+		Topic:      topic,
+		WakeTarget: wakeTarget,
 	})
 	if err != nil {
 		return "", err
@@ -148,11 +102,8 @@ func (t *Tools) HandleAddWakeSubscription(_ context.Context, args map[string]any
 		Status:         "ok",
 		SubscriptionID: ws.ID,
 		Topic:          ws.Topic,
+		WakeLoop:       ws.WakeTarget,
 		Note:           "Live subscribe attempted; activates on next reconnect if broker is not currently connected.",
-	}
-	if ws.HasWakeTarget() {
-		target := ws.WakeTarget
-		resp.WakeLoop = &target
 	}
 	data, err := json.Marshal(resp)
 	if err != nil {
@@ -189,48 +140,4 @@ func (t *Tools) HandleRemoveWakeSubscription(_ context.Context, args map[string]
 func stringArg(args map[string]any, key string) string {
 	v, _ := args[key].(string)
 	return v
-}
-
-// intArg extracts an int from an args map, accepting both numeric
-// (int, float64 from JSON) and string-of-int forms. Returns 0 when
-// the arg is absent or unparseable — matches the
-// [router.LoopProfile.QualityFloor] "zero means unset" convention.
-func intArg(args map[string]any, key string) int {
-	v, ok := args[key]
-	if !ok {
-		return 0
-	}
-	switch n := v.(type) {
-	case int:
-		return n
-	case int64:
-		return int(n)
-	case float64:
-		return int(n)
-	case string:
-		parsed, err := strconv.Atoi(strings.TrimSpace(n))
-		if err != nil {
-			return 0
-		}
-		return parsed
-	}
-	return 0
-}
-
-// toStringSlice converts an any value to []string. Handles both
-// []any (from JSON tool args) and []string.
-func toStringSlice(v any) []string {
-	switch val := v.(type) {
-	case []string:
-		return val
-	case []any:
-		result := make([]string, 0, len(val))
-		for _, item := range val {
-			if s, ok := item.(string); ok {
-				result = append(result, s)
-			}
-		}
-		return result
-	}
-	return nil
 }

--- a/internal/channels/mqtt/tools_test.go
+++ b/internal/channels/mqtt/tools_test.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/nugget/thane-ai-agent/internal/model/router"
+	"github.com/nugget/thane-ai-agent/internal/channels/messages"
 	"github.com/nugget/thane-ai-agent/internal/platform/config"
 	"github.com/nugget/thane-ai-agent/internal/platform/database"
 
@@ -25,8 +25,7 @@ func newTestTools(t *testing.T) *Tools {
 		t.Fatalf("new subscription store: %v", err)
 	}
 	// Pass a nil resolver so wake_loop verification is skipped in
-	// tests that don't care about it. Tests that DO exercise the
-	// verification path supply their own resolver.
+	// tests that don't care about it.
 	return NewTools(store, nil)
 }
 
@@ -36,10 +35,6 @@ func TestToolsHandleListEmpty(t *testing.T) {
 	if err != nil {
 		t.Fatalf("list: %v", err)
 	}
-	// Empty store now emits the canonical empty JSON array (matches
-	// the cross-family return shape used by forge_repo_subscriptions
-	// and media_feeds); the legacy "No MQTT wake subscriptions
-	// configured." prose was retired in PR-T1.
 	if strings.TrimSpace(result) != "[]" {
 		t.Errorf("expected empty JSON array, got %q", result)
 	}
@@ -49,18 +44,22 @@ func TestToolsHandleAddAndList(t *testing.T) {
 	tools := newTestTools(t)
 
 	args := map[string]any{
-		"topic":         "test/wake",
-		"mission":       "automation",
-		"quality_floor": "7",
-		"instructions":  "handle this event",
+		"topic": "test/wake",
+		"wake_loop": map[string]any{
+			"name":         "triage_handler",
+			"tags":         []any{"owner"},
+			"instructions": "handle this event",
+		},
 	}
-
 	result, err := tools.HandleAddWakeSubscription(context.Background(), args)
 	if err != nil {
 		t.Fatalf("add: %v", err)
 	}
 	if !strings.Contains(result, "test/wake") {
 		t.Errorf("expected topic in result, got %q", result)
+	}
+	if !strings.Contains(result, "triage_handler") {
+		t.Errorf("expected wake_loop target name in result, got %q", result)
 	}
 
 	list, err := tools.HandleListWakeSubscriptions(context.Background(), nil)
@@ -70,41 +69,43 @@ func TestToolsHandleAddAndList(t *testing.T) {
 	if !strings.Contains(list, "test/wake") {
 		t.Errorf("expected topic in list, got %q", list)
 	}
-	if !strings.Contains(list, "automation") {
-		t.Errorf("expected mission in list, got %q", list)
+	if !strings.Contains(list, "triage_handler") {
+		t.Errorf("expected wake_loop target in list, got %q", list)
+	}
+	if !strings.Contains(list, "owner") {
+		t.Errorf("expected wake_loop tags in list, got %q", list)
 	}
 }
 
-func TestToolsHandleAddWithSeedArrays(t *testing.T) {
+func TestToolsHandleAddRejectsMissingWakeLoop(t *testing.T) {
 	tools := newTestTools(t)
 
-	args := map[string]any{
-		"topic":         "arrays/test",
-		"exclude_tools": []any{"shell_exec", "web_fetch"},
-		"initial_tags":  []any{"homeassistant", "security"},
+	args := map[string]any{"topic": "no/handler"}
+	if _, err := tools.HandleAddWakeSubscription(context.Background(), args); err == nil {
+		t.Fatal("expected error for missing wake_loop")
 	}
+}
 
-	_, err := tools.HandleAddWakeSubscription(context.Background(), args)
-	if err != nil {
-		t.Fatalf("add: %v", err)
+func TestToolsHandleAddRejectsBareNameString(t *testing.T) {
+	tools := newTestTools(t)
+
+	// Sanity: the string form still works (it's a name).
+	args := map[string]any{"topic": "string/wake", "wake_loop": "shorthand_handler"}
+	if _, err := tools.HandleAddWakeSubscription(context.Background(), args); err != nil {
+		t.Fatalf("add with string wake_loop: %v", err)
 	}
-
 	subs := tools.store.List()
-	if len(subs) != 1 {
-		t.Fatalf("expected 1 sub, got %d", len(subs))
-	}
-	if len(subs[0].Profile.ExcludeTools) != 2 {
-		t.Errorf("exclude_tools len = %d, want 2", len(subs[0].Profile.ExcludeTools))
-	}
-	if len(subs[0].InitialTags) != 2 {
-		t.Errorf("initial_tags len = %d, want 2", len(subs[0].InitialTags))
+	if len(subs) != 1 || subs[0].WakeTarget.Name != "shorthand_handler" {
+		t.Fatalf("wake_target = %#v, want name=shorthand_handler", subs[0].WakeTarget)
 	}
 }
 
 func TestToolsHandleAddMissingTopic(t *testing.T) {
 	tools := newTestTools(t)
 
-	_, err := tools.HandleAddWakeSubscription(context.Background(), map[string]any{})
+	_, err := tools.HandleAddWakeSubscription(context.Background(), map[string]any{
+		"wake_loop": "handler",
+	})
 	if err == nil {
 		t.Fatal("expected error for missing topic")
 	}
@@ -113,12 +114,8 @@ func TestToolsHandleAddMissingTopic(t *testing.T) {
 func TestToolsHandleRemove(t *testing.T) {
 	tools := newTestTools(t)
 
-	// Add with a non-empty legacy profile so the new "must declare
-	// wake_loop or a non-empty profile" validation passes; the
-	// remove path is what we're exercising here.
-	args := map[string]any{"topic": "remove/test", "mission": "automation"}
-	_, err := tools.HandleAddWakeSubscription(context.Background(), args)
-	if err != nil {
+	args := map[string]any{"topic": "remove/test", "wake_loop": "handler"}
+	if _, err := tools.HandleAddWakeSubscription(context.Background(), args); err != nil {
 		t.Fatalf("add: %v", err)
 	}
 
@@ -127,9 +124,6 @@ func TestToolsHandleRemove(t *testing.T) {
 		t.Fatalf("expected 1 sub, got %d", len(subs))
 	}
 
-	// Canonical parameter name post-PR-T1 is subscription_id; the
-	// `id` alias still works for backwards compat (covered by its
-	// own test below).
 	result, err := tools.HandleRemoveWakeSubscription(context.Background(), map[string]any{"subscription_id": subs[0].ID})
 	if err != nil {
 		t.Fatalf("remove: %v", err)
@@ -146,9 +140,9 @@ func TestToolsHandleRemove(t *testing.T) {
 func TestToolsHandleRemoveConfigProtected(t *testing.T) {
 	tools := newTestTools(t)
 
-	profile := router.LoopProfile{Mission: "automation"}
+	target := messages.LoopWakeTarget{Name: "handler"}
 	if err := tools.store.LoadConfig([]config.SubscriptionConfig{
-		{Topic: "config/test", Wake: &profile},
+		{Topic: "config/test", WakeLoop: &target},
 	}); err != nil {
 		t.Fatalf("LoadConfig: %v", err)
 	}

--- a/internal/channels/mqtt/wake_tool_provider.go
+++ b/internal/channels/mqtt/wake_tool_provider.go
@@ -31,7 +31,7 @@ func (w *WakeTools) Tools() []*tools.Tool {
 	return []*tools.Tool{
 		{
 			Name:        "mqtt_wake_list",
-			Description: "List all MQTT wake subscriptions. Each entry shows the topic filter, the source (config or runtime), and either wake_loop (modern target-dispatch shape — points at an existing loop that receives messages as event-source notifications) or the legacy routing fields (mission, quality_floor, model) for subscriptions that still spawn a one-shot loop per message.",
+			Description: "List all MQTT wake subscriptions. Each entry shows the topic filter, the source (config or runtime), and the wake_loop target that receives matching messages as event-source notifications.",
 			Parameters: map[string]any{
 				"type":       "object",
 				"properties": map[string]any{},
@@ -42,11 +42,7 @@ func (w *WakeTools) Tools() []*tools.Tool {
 		},
 		{
 			Name: "mqtt_wake_add",
-			Description: `Add a runtime MQTT wake subscription. Two dispatch shapes are supported per-subscription:
-
-  - **wake_loop (preferred):** messages on the topic are delivered as event-source notifications to an existing loop. The target loop's next iteration sees the message in its pending notifications and runs under its own Spec.Profile. No new loop is spawned; the registry stays clean. Use this for "topic X → metacog", "topic Y → research_watcher", and similar attention-routing patterns.
-
-  - **Legacy spawn-per-message:** when wake_loop is omitted, the routing fields (model, mission, quality_floor, etc.) shape a fresh one-shot loop that runs on each matching message. Kept for backwards compatibility; new subscriptions should use wake_loop and let the target loop's own profile govern routing.
+			Description: `Add a runtime MQTT wake subscription. Matching messages are delivered as event-source notifications to the loop named in wake_loop; the target loop's next iteration sees the message in its pending notifications and runs under its own Spec.Profile. Use this for "topic X → metacog", "topic Y → research_watcher", and similar attention-routing patterns. If you don't have a custom handler loop in mind, point wake_loop at the built-in mqtt-default-handler.
 
 The subscription is persisted and a live SUBSCRIBE is sent to the broker; if the broker is not currently connected it activates on the next reconnect.
 
@@ -58,47 +54,9 @@ Topic conventions: Use thane/{device_name}/wake/{purpose} for instance-directed 
 						"type":        "string",
 						"description": "MQTT topic filter to subscribe to (supports + and # wildcards).",
 					},
-					"wake_loop": messages.LoopWakeTargetSchema("Preferred dispatch: existing loop to receive matching messages as event-source notifications. Resolves at message-arrival time; verify the target exists via loop_status before persisting."),
-					"model": map[string]any{
-						"type":        "string",
-						"description": "Legacy spawn-dispatch only: explicit model name (bypasses router). Ignored when wake_loop is set.",
-					},
-					"quality_floor": map[string]any{
-						"type":        "integer",
-						"description": "Legacy spawn-dispatch only: minimum model quality rating 1-10. Ignored when wake_loop is set.",
-					},
-					"mission": map[string]any{
-						"type":        "string",
-						"description": "Legacy spawn-dispatch only: task context (conversation, automation, device_control, background). Ignored when wake_loop is set.",
-					},
-					"local_only": map[string]any{
-						"type":        "string",
-						"description": "Legacy spawn-dispatch only: restrict to free/local models (true/false). Ignored when wake_loop is set.",
-					},
-					"delegation_gating": map[string]any{
-						"type":        "string",
-						"description": "Legacy spawn-dispatch only: delegation tool gating (enabled/disabled). Ignored when wake_loop is set.",
-					},
-					"prefer_speed": map[string]any{
-						"type":        "string",
-						"description": "Legacy spawn-dispatch only: favour faster models (true/false). Ignored when wake_loop is set.",
-					},
-					"instructions": map[string]any{
-						"type":        "string",
-						"description": "Legacy spawn-dispatch only: instructions injected into the spawned wake message. For wake_loop dispatch, set wake_loop.instructions instead.",
-					},
-					"exclude_tools": map[string]any{
-						"type":        "array",
-						"items":       map[string]any{"type": "string"},
-						"description": "Legacy spawn-dispatch only: tool names to exclude. Ignored when wake_loop is set (target loop's ExcludeTools governs).",
-					},
-					"initial_tags": map[string]any{
-						"type":        "array",
-						"items":       map[string]any{"type": "string"},
-						"description": "Legacy spawn-dispatch only: capability tags to activate. Ignored when wake_loop is set (target loop's tags govern).",
-					},
+					"wake_loop": messages.LoopWakeTargetSchema("Existing loop to receive matching messages as event-source notifications. Resolves at message-arrival time; verify the target exists via loop_status before persisting."),
 				},
-				"required": []string{"topic"},
+				"required": []string{"topic", "wake_loop"},
 			},
 			Handler: func(ctx context.Context, args map[string]any) (string, error) {
 				return w.tools.HandleAddWakeSubscription(ctx, args)

--- a/internal/platform/config/config.go
+++ b/internal/platform/config/config.go
@@ -1307,42 +1307,41 @@ type MQTTConfig struct {
 // Each entry is subscribed on every broker (re-)connect. Wildcards
 // (+ and #) are supported per the MQTT specification.
 //
-// Two dispatch shapes are supported for matching messages:
+// Every active subscription routes matching messages to a wake_loop
+// target loop, which sees the message in its pending notifications
+// and runs under its own Spec.Profile / SupervisorProfile. No new
+// loop is spawned per message. Subscriptions with neither WakeLoop
+// nor the legacy Wake field are ambient-awareness only.
 //
-//   - **WakeLoop (preferred):** identifies an existing loop to
-//     receive matching MQTT messages as event-source notifications.
-//     The target loop's next iteration sees the message in its
-//     pending notifications and runs under its own Spec.Profile.
-//     No new loop is spawned.
-//
-//   - **Wake (legacy):** matching messages spawn a fresh one-shot
-//     loop using the embedded routing profile. Kept for
-//     backwards compatibility; new subscriptions should declare
-//     WakeLoop instead.
-//
-// When both are set, WakeLoop wins. When neither is set, the
-// subscription is ambient-awareness only (debug-logged, not
-// acted upon).
+// The pre-PR-T2b inline-routing form (Wake + InitialTags) is kept
+// here for backwards compatibility: at config load time entries that
+// declare only Wake are rewritten onto the built-in
+// "mqtt-default-handler" loop with a WARN log, preserving any
+// Instructions and InitialTags as wake target Tags. Remove the
+// legacy fields from your YAML at your convenience.
 type SubscriptionConfig struct {
 	// Topic is the MQTT topic filter (e.g., "homeassistant/+/+/state",
 	// "frigate/events"). Supports MQTT wildcard characters.
 	Topic string `yaml:"topic"`
 
-	// WakeLoop identifies an existing loop to receive matching MQTT
-	// messages as event-source notifications. Preferred dispatch
-	// route — the target loop's [Spec.Profile] governs routing.
+	// WakeLoop identifies the existing loop that should receive
+	// matching MQTT messages as event-source notifications. When
+	// the target name resolves to a registered loop at startup, this
+	// is how every wake delivers; the target's own Spec.Profile
+	// governs routing. Point this at "mqtt-default-handler" for the
+	// built-in triage loop when you don't have a bespoke handler.
 	WakeLoop *messages.LoopWakeTarget `yaml:"wake_loop,omitempty"`
 
-	// Wake is the legacy dispatch-via-spawn path: when non-nil and
-	// WakeLoop is unset, messages on this topic spawn a one-shot
-	// agent run using this routing profile. New subscriptions
-	// should use WakeLoop and let the target loop's own Profile
-	// govern routing instead.
+	// Wake is the deprecated inline-routing form. Entries that use
+	// it are auto-migrated onto the default handler at config load
+	// (a one-shot upgrade). New subscriptions should declare
+	// WakeLoop directly instead.
 	Wake *router.LoopProfile `yaml:"wake,omitempty"`
 
-	// InitialTags lists capability tags activated at the start of the
-	// spawn-dispatch agent run (legacy path). Only meaningful when
-	// Wake is non-nil and WakeLoop is unset.
+	// InitialTags is the deprecated companion to Wake. Migrated
+	// values flow into the resulting wake_loop target's Tags field
+	// at load time, so per-iteration capability tag activation
+	// continues to work even after the inline-routing form retires.
 	InitialTags []string `yaml:"initial_tags,omitempty"`
 }
 


### PR DESCRIPTION
## Summary

**Stacked on [#903](https://github.com/nugget/thane-ai-agent/pull/903) (PR-T2a). Review/merge that first.**

Retires the inline-Profile spawn-per-event path for MQTT-wake subscriptions. Every wake now routes through a `wake_loop` target. Implements the MQTT migration thread from the trigger-unification plan in [#902](https://github.com/nugget/thane-ai-agent/issues/902).

### Threads

- **Default landing zone (`mqtt-default-handler`)** — new built-in event-driven loop registered alongside the other MQTT built-ins when `cfg.MQTT.Configured()` is true. The loop definition runtime now treats `OperationEventDriven` as durable for startup hydration (a new `isDurableDefinitionOperation` helper threads service + container + event_driven through `StartEnabledServices`, `splitContainerSpecs`, `ReconcileDefinition`, `LaunchDefinition`, and `nextScheduleTransition`). Operators who don't declare a custom handler get this one for free.

- **Auto-migration shim** — legacy inline-Profile records get rewritten onto the default handler at first read. SQLite rows with `seed_json` populated but `wake_target_json` empty are updated in place after the SELECT cursor drains, so the migration is a one-shot upgrade rather than a per-boot rewrite. The same migration runs on `SubscriptionConfig.Wake` YAML entries at `LoadConfig` time. Both paths preserve operator intent — `Instructions` text and `InitialTags` carry through to the new `WakeTarget.Instructions` / `WakeTarget.Tags`. Every migrated record gets a one-line WARN with topic + ID so the upgrade is visible in logs.

- **Surface simplification** — `WakeSubscription` drops `Profile` and `InitialTags` fields. `AddRequest` drops them too. The tool surface (`mqtt_wake_add`) shrinks from a 9-field schema to `topic` + `wake_loop` (both required). Tool list/add responses match. The legacy `dispatchViaLoop` / `buildWakeMessage` / `applyLoopProfile` path retires entirely along with the `mqttWakeTimeout` constant. `mqttwake.go` drops from 412 lines to 160.

Schema columns (`seed_json`, `initial_tags_json`) stay in place but go unwritten on the new path — operators who downgrade still see a coherent schema. New INSERTs write `{}` / `[]` placeholders so the NOT NULL constraints stay satisfied without carrying meaning.

### Test plan

- [x] `just ci` green locally
- [x] `mqtt.TestSubscriptionStoreLoadRuntimeMigratesLegacyRow` — DB row migration writes back wake_target_json with default handler + preserved tags
- [x] `mqtt.TestSubscriptionStoreLoadConfigMigratesLegacyWake` — YAML `Wake` entry migrates with preserved instructions + tags
- [x] `mqtt.TestSubscriptionStoreLoadConfigWakeLoop` — wake_loop + `initial_tags` merge into `wake_target.Tags`
- [x] `mqtt.TestSubscriptionStoreAddRequiresWakeTarget` — runtime add rejects missing wake_loop
- [x] `mqtt.TestSubscriptionStoreLoadConfigRejectsEmptyWakeLoop` — config load rejects empty wake_loop selector
- [x] `mqtt.TestToolsHandleAddRejectsMissingWakeLoop` — tool surface rejects missing wake_loop
- [x] `mqtt.TestToolsHandleAddRejectsBareNameString` — string-shorthand `wake_loop: "handler"` works
- [x] `app.TestMQTTWakeHandlerDispatchesViaWakeTarget` — message → envelope → bus, no spawn
- [x] `app.TestMQTTWakeHandlerFanOutDelivers` — two subscriptions on one topic each get their envelope
- [x] `app.TestMQTTWakeHandlerNoMatchFallback` — unmatched topics hit fallback
- [x] `app.TestMQTTWakeHandlerNoBusDropsMessage` — missing bus logs + drops gracefully

Refs [#902](https://github.com/nugget/thane-ai-agent/issues/902)