### PR TITLE
talents: ghost-tool fixes + corpus regression tests (PR-A of #910)

### DIFF
--- a/internal/model/talents/repo_corpus_test.go
+++ b/internal/model/talents/repo_corpus_test.go
@@ -1,0 +1,218 @@
+package talents
+
+import (
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/nugget/thane-ai-agent/internal/model/toolcatalog"
+)
+
+// repoTalentsDir returns the in-tree talents/ directory, located
+// relative to this test file's path so the test is portable across
+// developer checkouts and CI sandboxes.
+func repoTalentsDir(t *testing.T) string {
+	t.Helper()
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed; cannot locate repo talents dir")
+	}
+	// Walk from internal/model/talents/*_test.go to the repo root.
+	return filepath.Join(filepath.Dir(thisFile), "..", "..", "..", "talents")
+}
+
+func loadRepoTalents(t *testing.T) []Talent {
+	t.Helper()
+	loader := NewLoader(repoTalentsDir(t))
+	talents, err := loader.Talents()
+	if err != nil {
+		t.Fatalf("loading repo talents: %v", err)
+	}
+	if len(talents) == 0 {
+		t.Fatal("no talents loaded from repo dir; the corpus regression tests would be meaningless")
+	}
+	return talents
+}
+
+// TestRepoTrailheadNextTagsResolve pins every in-tree trailhead's
+// next_tags references against the union of (a) compiled built-in tags
+// and (b) tags declared by any other loaded talent. A trailhead that
+// points at a tag that no longer exists (or never existed) silently
+// breaks the model's decision trail — activating the suggested tag
+// loads nothing. Without this guard, a tag rename or deprecation can
+// rot the trails it touches without any test surfacing it.
+//
+// Two valid references:
+//
+//   - **Built-in tag** — declared in [toolcatalog.BuiltinTagSpecs].
+//     Activating it loads the tools the catalog binds to that tag.
+//   - **Talent-declared tag** — any other loaded talent's `tags:`
+//     field. Used for multi-node trailhead navigation: a sibling node
+//     in the same file (or a related node in another file) declares
+//     `tags: [self_name]` so trailheads can chain to it without
+//     polluting the global tool-tag catalog. `loops-examples.md` is
+//     the canonical example.
+//
+// Operator-defined catalog tags (declared via the CapabilityTags: YAML
+// block per deployment) are intentionally rejected here: they're not
+// portable across configurations and shouldn't appear in the bundled
+// talent corpus. If a concept genuinely deserves a trailhead pointer,
+// promote it to a real [toolcatalog.BuiltinTagSpec] entry — see
+// ha_admin's addition alongside this test as the worked example.
+func TestRepoTrailheadNextTagsResolve(t *testing.T) {
+	talents := loadRepoTalents(t)
+	known := buildResolvableTagSet(talents)
+
+	var problems []string
+	trailheads := 0
+	for _, talent := range talents {
+		if talent.Kind != KindTrailhead {
+			continue
+		}
+		trailheads++
+		for _, tag := range talent.NextTags {
+			if _, ok := known[tag]; !ok {
+				problems = append(problems, talent.Name+": next_tags references unresolvable tag "+tag)
+			}
+		}
+	}
+	if trailheads == 0 {
+		t.Fatal("no trailhead talents loaded; the in-repo corpus should contain several")
+	}
+	if len(problems) > 0 {
+		sort.Strings(problems)
+		t.Fatalf("trailhead next_tags reference tags neither in BuiltinTagSpecs nor declared by another talent:\n  - %s",
+			strings.Join(problems, "\n  - "))
+	}
+}
+
+// buildResolvableTagSet returns the union of built-in catalog tags
+// and tags declared on the Tags field of any loaded talent. A talent
+// next_tags reference is considered resolvable when its target is in
+// this set.
+func buildResolvableTagSet(talents []Talent) map[string]struct{} {
+	known := make(map[string]struct{})
+	for tag := range toolcatalog.BuiltinTagSpecs() {
+		known[tag] = struct{}{}
+	}
+	for _, talent := range talents {
+		for _, tag := range talent.Tags {
+			known[tag] = struct{}{}
+		}
+	}
+	return known
+}
+
+// toolReferenceRe matches `backticked_snake_case_tokens` in talent
+// markdown bodies. The token must look like a Go-style identifier
+// (lowercase + underscores + digits) and contain at least one
+// underscore — single-word backticked terms like `INBOX` or `maintain`
+// are intentionally not flagged, since the false-positive rate would
+// drown the signal.
+var toolReferenceRe = regexp.MustCompile("`([a-z][a-z0-9_]*_[a-z0-9_]*[a-z0-9])`")
+
+// nonToolTokens are backticked snake_case identifiers that look
+// tool-shaped to [TestRepoTalentToolReferences] but are actually
+// configuration fields, frontmatter keys, or other non-tool concepts.
+// Each entry documents a deliberate "this isn't a tool" decision so a
+// future reader knows it was reviewed, not missed. Keep this list
+// short and curate it consciously — every addition should be a real
+// non-tool concept that legitimately appears in talent prose.
+var nonToolTokens = map[string]struct{}{
+	// LoopWakeTarget field name (also the field name on producer
+	// tools like forge_repo_follow / media_follow / mqtt_wake_add).
+	// Appears in talent prose describing routing, not as a tool call.
+	"wake_loop": {},
+}
+
+// TestRepoTalentToolReferences pins backticked tool-name references in
+// talent prose against the compiled tool catalog. A reference like
+// `email_compose` or `watch_entity` is a hallucination magnet — the
+// model reads the talent, learns "use email_compose for this," then
+// hits a tool-not-found error when it tries. This is the analogue of
+// the docs-side drift test PR-907 introduced for docs/reference/tools.md.
+//
+// A token is treated as "claiming to be a tool" when it's backticked,
+// snake_case, contains at least one underscore, and either:
+//
+//   - Its first segment matches a real tool family's prefix (catches
+//     `email_compose`, `forge_yolo`, etc. — known family, wrong name).
+//   - Its second segment matches a real tool family's second segment
+//     (catches `watch_entity`, `unwatch_entity`, etc. — verb-noun
+//     shape where the noun is one a real tool actually uses).
+//
+// Either match flags the token as a candidate; the test fails when
+// any flagged token isn't itself a registered tool. Templates with
+// non-identifier characters (`replace_output_<loop_name>`, `email_*`)
+// are skipped by the regex.
+//
+// When a new tool is added to the catalog its segments automatically
+// expand both gates, so future hallucinations in the same families
+// get caught without changes here.
+func TestRepoTalentToolReferences(t *testing.T) {
+	talents := loadRepoTalents(t)
+	knownTools, knownPrefixes, knownSecondSegments := buildToolReferenceSets()
+
+	var problems []string
+	for _, talent := range talents {
+		seen := make(map[string]struct{})
+		for _, match := range toolReferenceRe.FindAllStringSubmatch(talent.Content, -1) {
+			token := match[1]
+			if _, dup := seen[token]; dup {
+				continue
+			}
+			seen[token] = struct{}{}
+			if _, ok := knownTools[token]; ok {
+				continue
+			}
+			if _, ok := nonToolTokens[token]; ok {
+				continue
+			}
+			segments := strings.Split(token, "_")
+			prefixMatch := false
+			if len(segments) > 0 {
+				_, prefixMatch = knownPrefixes[segments[0]]
+			}
+			secondMatch := false
+			if len(segments) > 1 {
+				_, secondMatch = knownSecondSegments[segments[1]]
+			}
+			if !prefixMatch && !secondMatch {
+				continue
+			}
+			problems = append(problems, talent.Name+": references `"+token+"` (shape matches a real tool family but no such tool is registered)")
+		}
+	}
+	if len(problems) > 0 {
+		sort.Strings(problems)
+		t.Fatalf("talent prose references tool names missing from the catalog:\n  - %s",
+			strings.Join(problems, "\n  - "))
+	}
+}
+
+// buildToolReferenceSets returns (a) the set of fully-qualified tool
+// names from the compiled catalog, (b) the set of first-segment
+// prefixes (the "family" — email, forge, doc, etc.), and (c) the set
+// of second-segment terms (the verb's object — entity, fact, file,
+// etc.). The prose drift check fires when a token matches the
+// catalog's shape in either dimension but doesn't exist as a tool.
+func buildToolReferenceSets() (map[string]struct{}, map[string]struct{}, map[string]struct{}) {
+	specs := toolcatalog.BuiltinToolSpecs()
+	known := make(map[string]struct{}, len(specs))
+	prefixes := make(map[string]struct{})
+	seconds := make(map[string]struct{})
+	for name := range specs {
+		known[name] = struct{}{}
+		segments := strings.Split(name, "_")
+		if len(segments) > 0 && segments[0] != "" {
+			prefixes[segments[0]] = struct{}{}
+		}
+		if len(segments) > 1 && segments[1] != "" {
+			seconds[segments[1]] = struct{}{}
+		}
+	}
+	return known, prefixes, seconds
+}

--- a/internal/model/toolcatalog/catalog.go
+++ b/internal/model/toolcatalog/catalog.go
@@ -226,6 +226,20 @@ func LookupBuiltinToolSpec(name string) (BuiltinToolSpec, bool) {
 	return spec, true
 }
 
+// BuiltinToolSpecs returns a deep copy of the compiled-in tool catalog
+// keyed by tool wire name. Parallels [BuiltinTagSpecs] for the
+// tag-catalog half. Used by drift tests that need to iterate every
+// known tool — e.g., the talent corpus regression test that catches
+// hallucinated tool references in talent prose.
+func BuiltinToolSpecs() map[string]BuiltinToolSpec {
+	out := make(map[string]BuiltinToolSpec, len(builtinToolSpecs))
+	for name, spec := range builtinToolSpecs {
+		spec.Tags = append([]string(nil), spec.Tags...)
+		out[name] = spec
+	}
+	return out
+}
+
 // BuiltinTagSpecs returns a copy of the compiled-in tag catalog.
 func BuiltinTagSpecs() map[string]BuiltinTagSpec {
 	return maps.Clone(builtinTagSpecs)

--- a/internal/model/toolcatalog/catalog_tags.go
+++ b/internal/model/toolcatalog/catalog_tags.go
@@ -13,7 +13,7 @@ var builtinTagSpecs = map[string]BuiltinTagSpec{
 	"files":           {Description: "Workspace file read, write, edit, and search tools."},
 	"forge":           {Description: "Forge and code-collaboration tools for issues, pull requests, checks, and reviews."},
 	"ha":              {Description: "Home Assistant state, control, registry, and automation tools."},
-	"ha_admin":        {Description: "Elevated Home Assistant scope hint. The delegate executor pairs it with the ha profile and routing budgets so admin-shaped HA work (system-wide control, registry mutation, sweeping automation edits) gets the same tool surface as ha while signalling the higher trust requirement to routing."},
+	"ha_admin":        {Description: "Additive routing hint for admin-shaped Home Assistant work — system-wide control, registry mutation, sweeping automation edits. ha_admin in scope tells the delegate executor to apply the ha profile's higher-trust routing and budgets, but ha_admin carries no tools of its own — pair it with `ha` so the HA tool surface actually loads. Setting ha_admin alone results in a scope with no HA tools."},
 	"home":            {Description: "Coarse trailhead for home, device, room, and automation work. Usually leads to ha or notifications.", Menu: true},
 	"homeassistant":   {Description: "Alias for ha: Home Assistant state, control, registry, and automation tools."},
 	"interactive":     {Description: "Coarse trailhead for interactive loop behavior and channel guidance. Usually leads to signal, owu, or owner context.", Menu: true},

--- a/internal/model/toolcatalog/catalog_tags.go
+++ b/internal/model/toolcatalog/catalog_tags.go
@@ -13,6 +13,7 @@ var builtinTagSpecs = map[string]BuiltinTagSpec{
 	"files":           {Description: "Workspace file read, write, edit, and search tools."},
 	"forge":           {Description: "Forge and code-collaboration tools for issues, pull requests, checks, and reviews."},
 	"ha":              {Description: "Home Assistant state, control, registry, and automation tools."},
+	"ha_admin":        {Description: "Elevated Home Assistant scope hint. The delegate executor pairs it with the ha profile and routing budgets so admin-shaped HA work (system-wide control, registry mutation, sweeping automation edits) gets the same tool surface as ha while signalling the higher trust requirement to routing."},
 	"home":            {Description: "Coarse trailhead for home, device, room, and automation work. Usually leads to ha or notifications.", Menu: true},
 	"homeassistant":   {Description: "Alias for ha: Home Assistant state, control, registry, and automation tools."},
 	"interactive":     {Description: "Coarse trailhead for interactive loop behavior and channel guidance. Usually leads to signal, owu, or owner context.", Menu: true},

--- a/talents/loops-doctrine.md
+++ b/talents/loops-doctrine.md
@@ -28,8 +28,8 @@ Choose stream wiring by attention cost:
 
 - Use entity subscriptions for ambient state the loop should see on its
   normal turns. `thane_curate.entities` creates the initial watch set;
-  `update_entity_subscriptions`, `watch_entity`, and
-  `unwatch_entity` adjust it later.
+  `update_entity_subscriptions`, `add_entity_subscription`, and
+  `remove_entity_subscription` adjust it later.
 - Use event-source `wake_loop` targets when each event deserves an
   immediate iteration. Producer tools such as `forge_repo_follow` and
   `media_follow` own those subscriptions.

--- a/talents/loops-doctrine.md
+++ b/talents/loops-doctrine.md
@@ -28,8 +28,11 @@ Choose stream wiring by attention cost:
 
 - Use entity subscriptions for ambient state the loop should see on its
   normal turns. `thane_curate.entities` creates the initial watch set;
-  `update_entity_subscriptions`, `add_entity_subscription`, and
-  `remove_entity_subscription` adjust it later.
+  `update_entity_subscriptions` adjusts it later — that's the
+  loop-scoped store. Don't reach for `add_entity_subscription` /
+  `remove_entity_subscription` here; those mutate the
+  conversation-wide always-visible subscription set, a different
+  store, and using them on a loop's scope mutates the wrong thing.
 - Use event-source `wake_loop` targets when each event deserves an
   immediate iteration. Producer tools such as `forge_repo_follow` and
   `media_follow` own those subscriptions.

--- a/talents/loops-examples.md
+++ b/talents/loops-examples.md
@@ -189,8 +189,9 @@ when its scope should shift.
 
 2. **The watcher runs at its own pace** inside the envelope, tuning
    via `set_next_sleep` and adjusting its own watch set via
-   `add_entity_subscription` / `remove_entity_subscription`. You don't
-   interact during this phase.
+   `update_entity_subscriptions` (same loop-scoped tool the operator
+   uses in step 4 to push focus down, just called by the watcher
+   against its own name). You don't interact during this phase.
 
 3. **The watcher pulls you in when something matters** via
    `request_core_attention`. This forces a supervisor turn on your

--- a/talents/loops-examples.md
+++ b/talents/loops-examples.md
@@ -189,8 +189,8 @@ when its scope should shift.
 
 2. **The watcher runs at its own pace** inside the envelope, tuning
    via `set_next_sleep` and adjusting its own watch set via
-   `watch_entity` / `unwatch_entity`. You don't interact during this
-   phase.
+   `add_entity_subscription` / `remove_entity_subscription`. You don't
+   interact during this phase.
 
 3. **The watcher pulls you in when something matters** via
    `request_core_attention`. This forces a supervisor turn on your


### PR DESCRIPTION
First PR in the trailhead/decision-trail overhaul tracked in [#910](https://github.com/nugget/thane-ai-agent/issues/910). Pure correctness — no structural changes to the corpus yet. The regression-test infrastructure added here prevents the bugs being fixed from re-appearing during the structural work that follows.

## Three fixes

1. **Ghost `watch_entity` / `unwatch_entity` references** in `loops-doctrine.md` and `loops-examples.md` — both told the model to adjust watch sets via tools that don't exist. Real names: `add_entity_subscription` / `remove_entity_subscription`. Same shape Codex caught for `email_compose` on PR-T2d.

2. **`ha_admin` referenced but undeclared** — used in `delegate.go` for elevated HA scope routing and documented in `docs/delegation.md` + `docs/reference/tools.md`, but `BuiltinTagSpecs` didn't carry it. The `ha-trailhead.md` `next_tags` entry was a dangling pointer. Declared with a description that documents its role as a scope hint.

3. **New `BuiltinToolSpecs()` accessor** in `internal/model/toolcatalog/catalog.go`, parallel to `BuiltinTagSpecs()`. Needed by the new tests; useful generally for drift checks.

## Two new regression tests

In `internal/model/talents/repo_corpus_test.go`:

- **`TestRepoTrailheadNextTagsResolve`** — walks every loaded trailhead, verifies each `next_tags` entry is either a builtin catalog tag OR a tag declared by another loaded talent. The "OR" case covers the intra-file navigation pattern multi-node trailheads use (e.g., `loops_examples_curate` is declared by a sibling node in `loops-examples.md`).
- **`TestRepoTalentToolReferences`** — scans every talent body for backticked snake_case tokens, flags any that look tool-shaped (first-segment matches a real tool family prefix OR second-segment matches a real tool family second-segment) but aren't registered. Catches both:
  - `email_compose`-class ghosts (known family `email_`, wrong full name)
  - `watch_entity`-class ghosts (verb-noun shape where the noun matches a real tool's noun like `_entity`)

A tight `nonToolTokens` allowlist documents legitimate non-tool concepts that appear in prose (currently just `wake_loop` — the `LoopWakeTarget` field name, not a tool). Each addition is a conscious "this isn't a tool" decision.

## Verification

- [x] `just ci` green locally
- [x] Reverting the `watch_entity` fix triggers `TestRepoTalentToolReferences` (confirmed catches the bug being fixed)
- [x] Without the `ha_admin` declaration, `TestRepoTrailheadNextTagsResolve` fails on the `ha-trailhead.md` reference (confirmed catches the dangling pointer)

Refs [#910](https://github.com/nugget/thane-ai-agent/issues/910)