### PR TITLE
talents: loop-tagging doctrine + Godoc on the 12 always-available tools (PR-F of #910)

### DIFF
--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -345,9 +345,9 @@ The delegate family (`thane_now`, `thane_assign`) uses capability tags as
 its primary tool and context scope. Delegates inherit elective caller tags
 by default so child work keeps the same task context; explicit `tags`
 override profile default tags.
-When the resulting scope includes `ha` or `ha_admin`, the executor uses
-HA-oriented budget and routing hints automatically; otherwise it uses the
-general delegate defaults.
+When the resulting scope includes `ha`, the executor uses HA-oriented
+budget and routing hints automatically; otherwise it uses the general
+delegate defaults.
 Use root trailhead tags such as `development`, `home`, `operations`,
 `knowledge`, `media`, `interactive`, or `people` when the delegate should
 read the menu guidance and choose a narrower branch. Use leaf tags such

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -50,7 +50,6 @@ These tools load on every turn regardless of active tags.
 | `activate_capability` | Activate a capability tag for the current conversation. |
 | `deactivate_capability` | Deactivate a capability tag for the current conversation. |
 | `reset_capabilities` | Return the current conversation to its baseline capability state. |
-| `list_loaded_capabilities` | List capability tags currently loaded in this conversation. |
 | `inspect_capability` | Inspect one capability tag's active and excluded tool surface. |
 | `activate_lens` | Activate a persistent global behavioral lens. |
 | `deactivate_lens` | Deactivate a global behavioral lens. |

--- a/docs/talent-authoring.md
+++ b/docs/talent-authoring.md
@@ -331,6 +331,50 @@ paragraph of posture — it's not a trailhead, it's doctrine that
 should drop the `kind: trailhead` declaration. The discriminator: a
 trailhead points somewhere else. Doctrine stands alone.
 
+### Developer-doc co-mingling
+
+The audience for a talent is the model's decision moment. Background
+about *why* a thing exists, *how* it gets configured at deploy time,
+*what* runtime mechanism drives it, or *who* owns the
+implementation does not belong in talent prose. Those facts don't
+change what the model should do; they only explain it to a human
+reader. Different audience, different page (Godoc, `docs/`, the
+catalog source).
+
+Signal you're co-mingling: you find yourself writing "site-specific,"
+"the operator configures...", "this depends on the deployment," or
+"each deployment's set isn't another's." A model reading those lines
+gets context-heavier without getting decision-clearer. PR #917's
+review cut ~20 lines from `loops-tagging.md` that explained operator
+config and site variation around always-active tags — the model only
+needed "some tags are immutably present; look at `## Active
+Capabilities` for the list."
+
+The same line tells you whether to delete or relocate: if the line
+helps a *contributor* understand the system, move it to Godoc or
+`docs/`; if it doesn't help anyone, delete it.
+
+### Architecture-stale advice
+
+A talent that captures how a system used to work can route the model
+*around* the boundary that exists now. PR #917's `loops-tagging.md`
+example bullet originally said "add `notifications` if the loop
+should be able to escalate" — true in the pre-#696 world where any
+loop called `send_notification` directly. After #696 built the
+core-mediated attention boundary, escalation goes through
+`request_core_attention` (a core tool, free to every loop) and the
+`notifications` tag now holds the human-egress tools that **only the
+core loop** should reach. The stale bullet pointed non-core loops at
+the exact surface the boundary exists to gate.
+
+The regression test catches dead tool names, not dead architectures.
+Whenever you write routing advice, grep the catalog for the tool
+family you're describing and verify the *current* invariants —
+especially around security, attention, and trust boundaries — before
+naming a path. If the talent's framing predates a known refactor or
+issue, treat that as a smell: the current code is the source of
+truth, not the previous talent.
+
 ## Verification
 
 Two regression tests in

--- a/docs/understanding/delegation.md
+++ b/docs/understanding/delegation.md
@@ -134,9 +134,8 @@ determine the delegate's tool and tagged context scope.
 | `ha` | `ha` when no explicit tags are supplied | local, device-control mission | HA-domain delegations |
 
 The model-facing tools do not expose a `profile` knob. When a delegate's
-scope includes the `ha` or `ha_admin` tag, the executor selects the `ha`
-profile's budget and routing hints automatically; otherwise it uses
-`general`.
+scope includes the `ha` tag, the executor selects the `ha` profile's
+budget and routing hints automatically; otherwise it uses `general`.
 
 Delegates inherit elective caller capability tags by default. This keeps
 task context such as activated domain tags or KB articles attached to

--- a/internal/app/new_delegation.go
+++ b/internal/app/new_delegation.go
@@ -52,11 +52,17 @@ func (a *App) initDelegation(s *newState) error {
 	if tfs := a.loop.Tools().TempFileStore(); tfs != nil {
 		delegateExec.SetTempFileStore(tfs)
 	}
-	// AlwaysAvailable on both family front doors so they survive
-	// capability tag filtering (channel_tags, model-driven
-	// activate_capability). Without this, FilterByTags drops untagged
-	// tools when any tag is active and the model loses access to the
-	// recommended delegation surface.
+	// thane_now and thane_assign are AlwaysAvailable: delegation is a
+	// primitive operation, not a capability. A loop with a narrow tag
+	// scope (forge only, ha only) still needs to be able to spawn a
+	// sub-loop for a side investigation or background task — restricting
+	// delegate spawning to a tag would create cases where the model
+	// wanted to delegate but couldn't see the spawn primitive.
+	//
+	// Mechanically: without AlwaysAvailable, FilterByTags would drop
+	// these untagged tools when any tag is active (via channel_tags or
+	// model-driven activate_capability), and the model would lose access
+	// to the recommended delegation surface mid-conversation.
 	a.loop.Tools().Register(&tools.Tool{
 		Name:            "thane_now",
 		Description:     delegate.NowToolDescription,

--- a/internal/model/prompts/agent.go
+++ b/internal/model/prompts/agent.go
@@ -42,7 +42,7 @@ func RuntimeContract() string {
 		"Capabilities are bright trailheads into richer tool, context, and talent menus. When a task needs a domain, open one relevant door, read what appears, and keep moving without narrating the machinery.",
 		"",
 		"- Use only exact tool names that are actually available in this turn. Do not invent aliases, wrappers, or MCP helper tools.",
-		"- Use capability tools for runtime state: `activate_capability`, `deactivate_capability`, `reset_capabilities`, `list_loaded_capabilities`, or `inspect_capability` when those exact tools are visible.",
+		"- Use capability tools for runtime state: `activate_capability`, `deactivate_capability`, `reset_capabilities`, or `inspect_capability` when those exact tools are visible. To see what's currently loaded, read the `## Active Capabilities` section already in this prompt — no tool call needed.",
 		"- Preserve semantic path references exactly as provided, including prefixes like `kb:` or `core:`. Do not rewrite, normalize, or paraphrase them.",
 		"- Start with one broad trailhead unless the request clearly spans domains. Prefer the currently loaded context before opening more doors.",
 		"- If a needed tool is unavailable, use an available tool, activate a relevant capability, delegate with `thane_now` or `thane_assign` when visible, or answer directly.",
@@ -54,7 +54,7 @@ func RuntimeContract() string {
 // pushes the model back toward the exact runtime contract instead of
 // encouraging speculative delegation or invented tool names. It is a
 // format string accepting the tool name as its single argument.
-const IllegalToolMessage = "Error: tool %q is not available in this context. Use an available tool by its exact name. Do not invent tool names. For capability state, prefer activate_capability, deactivate_capability, reset_capabilities, list_loaded_capabilities, or inspect_capability when those exact tools are available in this turn. Otherwise choose another available tool or respond directly."
+const IllegalToolMessage = "Error: tool %q is not available in this context. Use an available tool by its exact name. Do not invent tool names. For capability state, prefer activate_capability, deactivate_capability, reset_capabilities, or inspect_capability when those exact tools are available in this turn. To see what is currently loaded, read the ## Active Capabilities section of this prompt — no tool call needed. Otherwise choose another available tool or respond directly."
 
 // TimeoutRecoverySystem is the system prompt for the recovery model
 // when the primary model times out after completing tool calls.

--- a/internal/model/talents/loader_test.go
+++ b/internal/model/talents/loader_test.go
@@ -254,7 +254,7 @@ func TestTalents(t *testing.T) {
 
 	// Write talent files with and without frontmatter.
 	writeFile(t, dir, "core.md", "# Core\nAlways loaded.")
-	writeFile(t, dir, "ha-tools.md", "---\nkind: trailhead\ntags: [ha]\nteaser: \"Open when the work touches home state.\"\nnext_tags: [ha_admin, notifications]\n---\n# HA Tools\nHome Assistant guidance.")
+	writeFile(t, dir, "ha-tools.md", "---\nkind: trailhead\ntags: [ha]\nteaser: \"Open when the work touches home state.\"\nnext_tags: [awareness, notifications]\n---\n# HA Tools\nHome Assistant guidance.")
 	writeFile(t, dir, "web.md", "---\ntags: [web, remote]\n---\n# Web\nWeb guidance.")
 
 	loader := NewLoader(dir)
@@ -296,8 +296,8 @@ func TestTalents(t *testing.T) {
 	if talents[1].Teaser != "Open when the work touches home state." {
 		t.Errorf("talents[1].Teaser = %q, want menu teaser", talents[1].Teaser)
 	}
-	if got := strings.Join(talents[1].NextTags, ","); got != "ha_admin,notifications" {
-		t.Errorf("talents[1].NextTags = %q, want ha_admin,notifications", got)
+	if got := strings.Join(talents[1].NextTags, ","); got != "awareness,notifications" {
+		t.Errorf("talents[1].NextTags = %q, want awareness,notifications", got)
 	}
 
 	if talents[2].Name != "web" {

--- a/internal/model/talents/repo_corpus_test.go
+++ b/internal/model/talents/repo_corpus_test.go
@@ -60,8 +60,9 @@ func loadRepoTalents(t *testing.T) []Talent {
 // block per deployment) are intentionally rejected here: they're not
 // portable across configurations and shouldn't appear in the bundled
 // talent corpus. If a concept genuinely deserves a trailhead pointer,
-// promote it to a real [toolcatalog.BuiltinTagSpec] entry — see
-// ha_admin's addition alongside this test as the worked example.
+// promote it to a real [toolcatalog.BuiltinTagSpec] entry (and back it
+// with an in-repo talent tagged to match), or declare the tag on
+// another loaded talent's `tags:` field for intra-talent navigation.
 func TestRepoTrailheadNextTagsResolve(t *testing.T) {
 	talents := loadRepoTalents(t)
 	known := buildResolvableTagSet(talents)

--- a/internal/model/toolcatalog/catalog_tags.go
+++ b/internal/model/toolcatalog/catalog_tags.go
@@ -13,7 +13,6 @@ var builtinTagSpecs = map[string]BuiltinTagSpec{
 	"files":           {Description: "Workspace file read, write, edit, and search tools."},
 	"forge":           {Description: "Forge and code-collaboration tools for issues, pull requests, checks, and reviews."},
 	"ha":              {Description: "Home Assistant state, control, registry, and automation tools."},
-	"ha_admin":        {Description: "Additive routing hint for admin-shaped Home Assistant work — system-wide control, registry mutation, sweeping automation edits. ha_admin in scope tells the delegate executor to apply the ha profile's higher-trust routing and budgets, but ha_admin carries no tools of its own — pair it with `ha` so the HA tool surface actually loads. Setting ha_admin alone results in a scope with no HA tools."},
 	"home":            {Description: "Coarse trailhead for home, device, room, and automation work. Usually leads to ha or notifications.", Menu: true},
 	"homeassistant":   {Description: "Alias for ha: Home Assistant state, control, registry, and automation tools."},
 	"interactive":     {Description: "Coarse trailhead for interactive loop behavior and channel guidance. Usually leads to signal, owu, or owner context.", Menu: true},

--- a/internal/model/toolcatalog/catalog_test.go
+++ b/internal/model/toolcatalog/catalog_test.go
@@ -46,11 +46,16 @@ func TestBuildCapabilitySurface_SortsTagsAndTools(t *testing.T) {
 }
 
 func TestBuiltinToolCatalogIncludesAlwaysAvailableTools(t *testing.T) {
+	// The canonical always-available set: 11 tools that survive
+	// capability-tag filtering regardless of scope. list_loaded_capabilities
+	// was previously a 12th member but was demoted because its output is
+	// a strict subset of the "## Active Capabilities" section already
+	// rendered into every prompt (see capability_tools.go's
+	// registerListLoadedCapabilities Godoc for the full rationale).
 	names := []string{
 		"activate_capability",
 		"deactivate_capability",
 		"reset_capabilities",
-		"list_loaded_capabilities",
 		"inspect_capability",
 		"activate_lens",
 		"deactivate_lens",

--- a/internal/runtime/agent/capability_activation_test.go
+++ b/internal/runtime/agent/capability_activation_test.go
@@ -191,7 +191,10 @@ func TestRunResponseSurfacesEffectiveToolsAndLoadedCapabilities(t *testing.T) {
 	if !slices.Contains(resp.EffectiveTools, "get_state") {
 		t.Fatalf("EffectiveTools = %#v, want get_state", resp.EffectiveTools)
 	}
-	for _, toolName := range []string{"activate_capability", "deactivate_capability", "reset_capabilities", "list_loaded_capabilities"} {
+	// list_loaded_capabilities was demoted from always-available (see #918)
+	// because its output is a strict subset of the ## Active Capabilities
+	// prompt section. The remaining four still earn the always-on slot.
+	for _, toolName := range []string{"activate_capability", "deactivate_capability", "reset_capabilities", "inspect_capability"} {
 		if !slices.Contains(resp.EffectiveTools, toolName) {
 			t.Fatalf("EffectiveTools = %#v, missing %q", resp.EffectiveTools, toolName)
 		}

--- a/internal/runtime/agent/capability_tool_repair_test.go
+++ b/internal/runtime/agent/capability_tool_repair_test.go
@@ -106,6 +106,11 @@ func TestRepairToolCall_RepairsInventedCapabilityToolName(t *testing.T) {
 }
 
 func TestRepairToolCall_RepairsListCapabilitiesAlias(t *testing.T) {
+	t.Skip("list_loaded_capabilities was demoted from always-available; the " +
+		"repair shim still rewrites the alias but the tool now surfaces as " +
+		"'not available'. Both the tool and the shim are scheduled for " +
+		"retirement (#918) — delete this test along with the shim block " +
+		"in loop.go:1302 when that lands.")
 	mock := &mockLLM{
 		responses: []*llm.ChatResponse{
 			{

--- a/internal/runtime/agent/gpt_oss_toolcall_test.go
+++ b/internal/runtime/agent/gpt_oss_toolcall_test.go
@@ -205,6 +205,11 @@ func TestGptOSSProviderProfile_RecoversCapabilityActivationFromRawText(t *testin
 }
 
 func TestGptOSSProviderProfile_RecoversListLoadedCapabilitiesAliasFromRawText(t *testing.T) {
+	t.Skip("list_loaded_capabilities was demoted from always-available; the " +
+		"gpt-oss raw-text recovery path still parses the alias but the tool " +
+		"now surfaces as 'not available'. Both the tool and the shim are " +
+		"scheduled for retirement (#918) — delete this test along with the " +
+		"shim block in loop.go:1302 when that lands.")
 	mock := &rawTextMockLLM{
 		textProfile: llm.DefaultToolCallTextProfile(),
 		responses: []*llm.ChatResponse{

--- a/internal/runtime/delegate/delegate.go
+++ b/internal/runtime/delegate/delegate.go
@@ -855,7 +855,7 @@ func (e *Executor) profileForScope(profileName string, scopeTags []string) *Prof
 			return profile
 		}
 	}
-	if hasAnyTag(scopeTags, "ha", "ha_admin") {
+	if hasAnyTag(scopeTags, "ha") {
 		if profile := e.profiles["ha"]; profile != nil {
 			return profile
 		}

--- a/internal/runtime/delegate/delegate_test.go
+++ b/internal/runtime/delegate/delegate_test.go
@@ -233,7 +233,6 @@ func TestExecute_LoopBackedDerivesHAProfileFromTagScope(t *testing.T) {
 		tags []string
 	}{
 		{name: "ha", tags: []string{"ha"}},
-		{name: "ha_admin", tags: []string{"ha_admin"}},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			var captured looppkg.Request

--- a/internal/tools/capability_tools.go
+++ b/internal/tools/capability_tools.go
@@ -258,16 +258,31 @@ func (r *Registry) registerResetCapabilities(mgr CapabilityManager, tagManifest 
 
 // registerListLoadedCapabilities registers the list_loaded_capabilities tool.
 //
-// Always-available rationale: self-introspection. The model needs to
-// be able to ask "what's currently loaded" without that answer
-// depending on what's loaded. Especially important for delegates and
-// service loops that inherit a narrowed surface and need to discover
-// whether a tag they want is already in scope.
+// NOT always-available. This tool returns a strict subset of the data
+// already rendered into every prompt under "## Active Capabilities"
+// (see loop.go:1090 → toolcatalog.RenderLoadedCapabilitySummary). The
+// prompt section carries tag, description, tool_count, always_active,
+// protected, ad_hoc, and context per loaded tag; this tool returns
+// just tag, always_active, protected, ad_hoc — so every call burns a
+// tool turn to retrieve less than the model already has in its
+// context.
+//
+// The five-way repair shim at loop.go:1302 (list_capabilities,
+// loaded_capabilities, active_capabilities, get_loaded_capabilities,
+// list_loaded_capabilities) is the smoking gun: the model has been
+// reaching for this tool repeatedly under different names because it
+// looked like the canonical handle for capability introspection. The
+// fix is the prompt section, not a more findable tool.
+//
+// Demoted out of always-available as a stepping stone toward full
+// removal. Keep the registration in place until the repair shim
+// aliases retire too, so the tool still loads when an unfiltered
+// scope happens to include it. The model-facing answer to "what's
+// loaded?" is the prompt section.
 func (r *Registry) registerListLoadedCapabilities(mgr CapabilityManager, tagManifest map[string]CapabilityManifest) {
 	r.Register(&Tool{
-		Name:            "list_loaded_capabilities",
-		AlwaysAvailable: true,
-		Description:     "List the capability tags currently loaded in YOUR current conversation runtime. Use when asked which capabilities or tags are active right now.",
+		Name:        "list_loaded_capabilities",
+		Description: "List the capability tags currently loaded in YOUR current conversation runtime. Use when asked which capabilities or tags are active right now.",
 		Parameters: map[string]any{
 			"type":       "object",
 			"properties": map[string]any{},

--- a/internal/tools/capability_tools.go
+++ b/internal/tools/capability_tools.go
@@ -108,6 +108,12 @@ func summarizeRemovedTools(tags []string, tagManifest map[string]CapabilityManif
 }
 
 // registerActivateCapability registers the activate_capability tool.
+//
+// Always-available rationale: this is the bootstrap primitive for
+// opening capability scopes. If it required a tag to be loaded first,
+// there would be no way to widen the model's surface from any
+// starting state — a chicken-and-egg that would leave a tightly
+// scoped loop unable to ever ask for more.
 func (r *Registry) registerActivateCapability(mgr CapabilityManager, manifest []CapabilityManifest, tagManifest map[string]CapabilityManifest) {
 	r.Register(&Tool{
 		Name:            "activate_capability",
@@ -148,6 +154,12 @@ func (r *Registry) registerActivateCapability(mgr CapabilityManager, manifest []
 }
 
 // registerDeactivateCapability registers the deactivate_capability tool.
+//
+// Always-available rationale: symmetric counterpart to
+// activate_capability. A loop that widened its surface for one phase
+// of work needs to be able to narrow back without keeping a tag
+// loaded just for the release primitive. Locking this behind a tag
+// would create stuck-wide states.
 func (r *Registry) registerDeactivateCapability(mgr CapabilityManager, tagManifest map[string]CapabilityManifest) {
 	r.Register(&Tool{
 		Name:            "deactivate_capability",
@@ -193,6 +205,12 @@ func (r *Registry) registerDeactivateCapability(mgr CapabilityManager, tagManife
 }
 
 // registerResetCapabilities registers the reset_capabilities tool.
+//
+// Always-available rationale: the emergency hatch for returning to
+// baseline when the loop has accumulated voluntary tags it no longer
+// needs. Same bootstrap argument as activate/deactivate — must work
+// from any state, including states where the model intentionally
+// dropped most of its surface.
 func (r *Registry) registerResetCapabilities(mgr CapabilityManager, tagManifest map[string]CapabilityManifest) {
 	r.Register(&Tool{
 		Name:            "reset_capabilities",
@@ -239,6 +257,12 @@ func (r *Registry) registerResetCapabilities(mgr CapabilityManager, tagManifest 
 }
 
 // registerListLoadedCapabilities registers the list_loaded_capabilities tool.
+//
+// Always-available rationale: self-introspection. The model needs to
+// be able to ask "what's currently loaded" without that answer
+// depending on what's loaded. Especially important for delegates and
+// service loops that inherit a narrowed surface and need to discover
+// whether a tag they want is already in scope.
 func (r *Registry) registerListLoadedCapabilities(mgr CapabilityManager, tagManifest map[string]CapabilityManifest) {
 	r.Register(&Tool{
 		Name:            "list_loaded_capabilities",
@@ -293,6 +317,11 @@ func (r *Registry) registerListLoadedCapabilities(mgr CapabilityManager, tagMani
 // attribution (native / mcp / overlay), and optionally
 // operator-excluded tools. Use this to audit "where did this tool
 // come from" or "what's actually in the ha tag at this site".
+//
+// Always-available rationale: auditing a tag must work *before* the
+// tag is activated. The whole point of inspection is to decide
+// whether opening the tag is worth the surface cost, which means the
+// answer can't depend on the tag already being in scope.
 func (r *Registry) registerInspectCapability(tagManifest map[string]CapabilityManifest) {
 	r.Register(&Tool{
 		Name:            "inspect_capability",

--- a/internal/tools/capability_tools.go
+++ b/internal/tools/capability_tools.go
@@ -363,7 +363,7 @@ func (r *Registry) registerInspectCapability(tagManifest map[string]CapabilityMa
 			}
 			manifest, ok := tagManifest[tag]
 			if !ok {
-				return "", fmt.Errorf("unknown capability tag %q; use list_loaded_capabilities or activate_capability to discover available tags", tag)
+				return "", fmt.Errorf("unknown capability tag %q; read the ## Active Capabilities section of your prompt to see what's already loaded, or use activate_capability to discover available tags", tag)
 			}
 			includeExcluded, _ := args["include_excluded"].(bool)
 			entry := toolcatalog.RenderCapabilityCatalogEntry(manifest, toolcatalog.CatalogViewOptions{

--- a/internal/tools/lens_tools.go
+++ b/internal/tools/lens_tools.go
@@ -100,6 +100,14 @@ func (s *LensStore) Remove(lens string) error {
 // across all conversations. Lenses use the same tag system as
 // capabilities — when a lens is active, KB articles and talents tagged
 // with that lens name are loaded into every conversation.
+//
+// All three are AlwaysAvailable. Rationale: lens management is the
+// meta-operation that adjusts which lens is in effect. Locking it
+// behind a lens would be a chicken-and-egg — you can't activate a
+// lens if activate_lens itself depends on a lens being active. Same
+// argument applies to deactivate_lens (must work to release a lens
+// the loop no longer needs) and list_lenses (self-introspection
+// can't depend on what's currently active).
 func (r *Registry) SetLensTools(store *LensStore) {
 	if store == nil {
 		return

--- a/internal/tools/log_tools.go
+++ b/internal/tools/log_tools.go
@@ -22,6 +22,15 @@ func (r *Registry) SetLogIndexDB(db *sql.DB) {
 }
 
 // registerLogsQuery registers the logs_query tool.
+//
+// Always-available rationale: forensics primitive. Debugging a
+// loop's own behavior shouldn't depend on the tag set the loop runs
+// with — a tightly scoped service loop hitting an anomaly still needs
+// to be able to look at what happened on prior iterations, even
+// though it doesn't carry the `diagnostics` tag in its surface. The
+// alternative — requiring the model to widen its capabilities before
+// it can investigate — adds an extra round trip at exactly the
+// moment the loop wants to converge on a cause.
 func (r *Registry) registerLogsQuery() {
 	if r.logIndexDB == nil {
 		return

--- a/internal/tools/message_tools.go
+++ b/internal/tools/message_tools.go
@@ -23,6 +23,16 @@ func (r *Registry) ConfigureMessageTools(deps MessageToolDeps) {
 	r.registerMessageTools()
 }
 
+// registerMessageTools registers request_core_attention.
+//
+// Always-available rationale: escalation primitive. Any tightly
+// scoped service or delegate loop must be able to reach back to the
+// core loop when something deserves the operator's attention. Hiding
+// this behind a tag would orphan loops that already filtered down to
+// their domain — they'd be unable to surface a concern *because* they
+// did the right thing and scoped narrowly. The cost of an over-eager
+// escalation is a wasted supervisor turn; the cost of a missing
+// escalation primitive is a silent service loop.
 func (r *Registry) registerMessageTools() {
 	if r.messageBus == nil {
 		return

--- a/talents/ha-trailhead.md
+++ b/talents/ha-trailhead.md
@@ -2,7 +2,7 @@
 kind: trailhead
 tags: [ha]
 teaser: "Open for Home Assistant state, control, registry, automation, and history."
-next_tags: [awareness, notifications, operations, ha_admin]
+next_tags: [awareness, notifications, operations]
 ---
 
 # HA Trailhead

--- a/talents/loops-tagging.md
+++ b/talents/loops-tagging.md
@@ -45,8 +45,12 @@ job:
 - **Forge curator** (release digest, PR queue dashboard) — `forge`
   plus `documents` for the output doc.
 - **Email triage loop** — `email`. Add `contacts` if the loop should
-  ground claims in person records; `notifications` if it should be
-  able to escalate.
+  ground claims in person records. Escalation is not a tag-add
+  decision: every loop already has `request_core_attention` from the
+  core tool set, and that is the path. The `notifications` tag holds
+  the human-egress tools the core loop calls *after* it decides to
+  escalate; granting it to a non-core service or delegate loop
+  bypasses that boundary, not strengthens it.
 
 Whether omitting `tags:` differs from passing `tags: []` depends on
 which loop family is doing the launching:

--- a/talents/loops-tagging.md
+++ b/talents/loops-tagging.md
@@ -31,9 +31,21 @@ There are two always-X concepts and they're often confused:
   escape primitives — every loop, however tightly scoped, has them.
   Their Godoc explains why each one earns the slot.
 
-A loop with `tags: []` is NOT empty — it still has the operator's
-always-active tags plus the 12 always-available tools. It's missing
-*scoped* tools, not all tools.
+A loop with `tags: []` is deployment-dependent, and the trap is that
+the empty case isn't a single behavior:
+
+- **Operator has always-active tags** → tag filtering kicks in. The
+  loop sees the always-active tools plus the 12 always-available
+  primitives. Scoped, predictable.
+- **No always-active tags at this deployment** → `tags: []` falls
+  through to "no filtering at all," and the loop sees the *entire*
+  tool registry (every native + MCP tool, ~150+ tools at a typical
+  site). This is almost never what a focused service loop wants;
+  it's a context-blow-up disguised as a config minimum.
+
+Treat `tags: []` as "the default makes a judgment call I haven't
+verified." Pass an explicit narrow set instead, even if it's just
+`["awareness"]` for an ambient watcher.
 
 ## Picking the right tag set
 
@@ -51,18 +63,30 @@ job:
   ground claims in person records; `notifications` if it should be
   able to escalate.
 
-Omitting `tags:` is *not* the same as `tags: []`. An omitted field
-inherits the parent context's tags (channel + currently-activated
-capabilities), which is usually wider than the loop needs. For
-service loops, name the tags explicitly so the surface is stable
-across the loop's lifetime.
+Whether omitting `tags:` differs from passing `tags: []` depends on
+which loop family is doing the launching:
+
+- **`thane_now` / `thane_assign`** — `inherit_caller_tags` defaults to
+  true, so omitting `tags:` inherits the caller's capability scope
+  (the operator's always-active set plus whatever the caller had
+  activated). Pass `inherit_caller_tags: false` along with an
+  explicit `tags` array when you need a clean scope that doesn't
+  carry over caller context.
+- **`thane_curate` / `spawn_loop` / `loop_definition_launch`** — no
+  caller-tag inheritance. Omitting `tags:` is the same as passing
+  `tags: []`, with the deployment-dependent behavior above. Name
+  the tags explicitly for service loops so the surface is stable
+  across the loop's lifetime.
 
 ## Anti-patterns
 
 - **Tag-as-label.** Tags are not free-form metadata. Each tag binds
-  to a real tool surface. Adding `tags: ["server-room"]` does
-  nothing useful — `server-room` isn't a registered tag, so it
-  resolves to no tools (and contributes to ad-hoc-tag confusion).
+  to a real tool surface. Adding `tags: ["server-room"]` doesn't
+  pull in any scoped tools — `server-room` isn't a registered tag,
+  so the filter resolves to just the 12 always-available primitives
+  (no `ha`, no `awareness`, no actual server-watching capability).
+  The loop still runs, but it runs blind. Use a real tag name; the
+  catalog is the source of truth.
 
 - **Over-tagging "just in case."** Every tag you add pulls in its
   full tool surface, its trailhead/doctrine talents, and any KB
@@ -72,10 +96,10 @@ across the loop's lifetime.
   use. Start with the minimum; expand only when the loop demonstrably
   needs more.
 
-- **Empty tags expecting "everything."** `tags: []` means "just the
-  baseline" — operator always-active set plus the 12 always-available
-  primitives. If you wanted a kitchen-sink surface, you wanted
-  something else; `tags` doesn't have a wildcard.
+- **Empty tags expecting "baseline."** `tags: []` is not a portable
+  "just the basics" knob — see the deployment-dependent split above.
+  At a site with operator always-active tags it narrows; at a site
+  without, it explodes. Pass an explicit narrow set instead.
 
 - **Adding `ha_admin` without `ha`.** `ha_admin` is an additive
   routing hint, not a self-contained surface — pair it with `ha` or

--- a/talents/loops-tagging.md
+++ b/talents/loops-tagging.md
@@ -86,11 +86,6 @@ which loop family is doing the launching:
   "just the basics" knob — see above. Pass an explicit narrow set
   instead.
 
-- **Adding `ha_admin` without `ha`.** `ha_admin` is an additive
-  routing hint, not a self-contained surface — pair it with `ha` or
-  the loop ends up with no HA tools at all. The catalog tag
-  description spells this out.
-
 ## Discovering what's loaded vs. what a tag would open
 
 These are two different questions with two different answers.

--- a/talents/loops-tagging.md
+++ b/talents/loops-tagging.md
@@ -11,42 +11,25 @@ relevant tools) or distracted it with menus it doesn't need. Tagging
 is the single most consequential field on a loop launch after the
 sleep envelope.
 
-## "Always" means two different things
+## What's always there
 
-There are two always-X concepts and they're often confused:
+Two things load regardless of your `tags` array:
 
-- **Always-active tags** are capability tags the operator has marked
-  always-active in their site config. They load into every
-  conversation and every loop iteration by default, *in addition to*
-  whatever the loop's own `tags` array specifies. Site-specific —
-  one deployment's always-active set isn't another's. The `##
-  Active Capabilities` section of your system prompt lists what's
-  currently loaded with `always_active: true` flagged per entry; no
-  tool call needed to see it.
+- **A small set of always-on tools**: `activate_capability`,
+  `deactivate_capability`, `reset_capabilities`, `inspect_capability`,
+  `activate_lens`, `deactivate_lens`, `list_lenses`, `thane_now`,
+  `thane_assign`, `request_core_attention`, `logs_query`. Every loop
+  has these regardless of scope.
 
-- **Always-available tools** are a small set of tools that survive
-  capability-tag filtering regardless of the loop's tag scope:
-  `activate_capability`, `deactivate_capability`, `reset_capabilities`,
-  `inspect_capability`, `activate_lens`, `deactivate_lens`,
-  `list_lenses`, `thane_now`, `thane_assign`, `request_core_attention`,
-  `logs_query`. These eleven are bootstrap and escape primitives —
-  every loop, however tightly scoped, has them. Their Godoc explains
-  why each one earns the slot.
+- **Capability tags that are immutably present.** Some tags load
+  automatically and stay loaded — you can't deactivate them. Your
+  system prompt's `## Active Capabilities` section lists what's
+  loaded with `always_active: true` flagged per entry; trust that as
+  ground truth for "what's already in scope."
 
-A loop with `tags: []` is deployment-dependent, and the trap is that
-the empty case isn't a single behavior:
-
-- **Operator has always-active tags** → tag filtering kicks in. The
-  loop sees the always-active tools plus the 11 always-available
-  primitives. Scoped, predictable.
-- **No always-active tags at this deployment** → `tags: []` falls
-  through to "no filtering at all," and the loop sees the *entire*
-  tool registry (every native + MCP tool, ~150+ tools at a typical
-  site). This is almost never what a focused service loop wants;
-  it's a context-blow-up disguised as a config minimum.
-
-Treat `tags: []` as "the default makes a judgment call I haven't
-verified." Pass an explicit narrow set instead, even if it's just
+A loop with `tags: []` is unreliable — depending on what's already
+loaded, you may end up with a narrow surface or with the entire tool
+registry. Pass an explicit narrow set instead, even just
 `["awareness"]` for an ambient watcher.
 
 ## Picking the right tag set
@@ -69,26 +52,23 @@ Whether omitting `tags:` differs from passing `tags: []` depends on
 which loop family is doing the launching:
 
 - **`thane_now` / `thane_assign`** — `inherit_caller_tags` defaults to
-  true, so omitting `tags:` inherits the caller's capability scope
-  (the operator's always-active set plus whatever the caller had
-  activated). Pass `inherit_caller_tags: false` along with an
-  explicit `tags` array when you need a clean scope that doesn't
-  carry over caller context.
+  true, so omitting `tags:` inherits the caller's currently-loaded
+  capabilities. Pass `inherit_caller_tags: false` along with an
+  explicit `tags` array when you need a clean scope.
 - **`thane_curate` / `spawn_loop` / `loop_definition_launch`** — no
-  caller-tag inheritance. Omitting `tags:` is the same as passing
-  `tags: []`, with the deployment-dependent behavior above. Name
-  the tags explicitly for service loops so the surface is stable
-  across the loop's lifetime.
+  caller-tag inheritance. Omitting `tags:` behaves the same as `tags:
+  []` (unreliable, see above). Name the tags explicitly for service
+  loops so the surface is stable across the loop's lifetime.
 
 ## Anti-patterns
 
 - **Tag-as-label.** Tags are not free-form metadata. Each tag binds
   to a real tool surface. Adding `tags: ["server-room"]` doesn't
   pull in any scoped tools — `server-room` isn't a registered tag,
-  so the filter resolves to just the 12 always-available primitives
-  (no `ha`, no `awareness`, no actual server-watching capability).
-  The loop still runs, but it runs blind. Use a real tag name; the
-  catalog is the source of truth.
+  so the filter resolves to just the always-on primitives (no `ha`,
+  no `awareness`, no actual server-watching capability). The loop
+  still runs, but it runs blind. Use a real tag name; the catalog is
+  the source of truth.
 
 - **Over-tagging "just in case."** Every tag you add pulls in its
   full tool surface, its trailhead/doctrine talents, and any KB
@@ -99,9 +79,8 @@ which loop family is doing the launching:
   needs more.
 
 - **Empty tags expecting "baseline."** `tags: []` is not a portable
-  "just the basics" knob — see the deployment-dependent split above.
-  At a site with operator always-active tags it narrows; at a site
-  without, it explodes. Pass an explicit narrow set instead.
+  "just the basics" knob — see above. Pass an explicit narrow set
+  instead.
 
 - **Adding `ha_admin` without `ha`.** `ha_admin` is an additive
   routing hint, not a self-contained surface — pair it with `ha` or
@@ -113,17 +92,17 @@ which loop family is doing the launching:
 These are two different questions with two different answers.
 
 **What's loaded right now?** Read your own system prompt. The `##
-Active Capabilities` section is rendered into every prompt (top-loop
-and delegate) with each loaded tag's `description`, `tool_count`,
-`always_active`, `protected`, and `ad_hoc` flags. No tool call
-needed — the answer is already in your context. Reaching for a tool
-to retrieve information you already have just burns a turn.
+Active Capabilities` section is rendered into every prompt with each
+loaded tag's `description`, `tool_count`, `always_active`,
+`protected`, and `ad_hoc` flags. No tool call needed — the answer is
+already in your context. Reaching for a tool to retrieve information
+you already have just burns a turn.
 
 **What would adding a new tag pull in?** Call `inspect_capability(tag:
 "<tag>")`. Returns the per-tool breakdown with source attribution
-(native, mcp, overlay) and whether the operator overlay has excluded
-any tools. Use this before adding an unfamiliar tag — the catalog is
-the source of truth on what's actually behind that name.
+(native, mcp, overlay). Use this before adding an unfamiliar tag —
+the catalog is the source of truth on what's actually behind that
+name.
 
 When in doubt, the empirical answer beats the remembered one — a
 running loop that worked before is better evidence than your model of

--- a/talents/loops-tagging.md
+++ b/talents/loops-tagging.md
@@ -19,23 +19,25 @@ There are two always-X concepts and they're often confused:
   always-active in their site config. They load into every
   conversation and every loop iteration by default, *in addition to*
   whatever the loop's own `tags` array specifies. Site-specific —
-  one deployment's always-active set isn't another's. Inspect with
-  `list_loaded_capabilities` (entries with `always_active: true`).
+  one deployment's always-active set isn't another's. The `##
+  Active Capabilities` section of your system prompt lists what's
+  currently loaded with `always_active: true` flagged per entry; no
+  tool call needed to see it.
 
 - **Always-available tools** are a small set of tools that survive
   capability-tag filtering regardless of the loop's tag scope:
   `activate_capability`, `deactivate_capability`, `reset_capabilities`,
-  `list_loaded_capabilities`, `inspect_capability`, `activate_lens`,
-  `deactivate_lens`, `list_lenses`, `thane_now`, `thane_assign`,
-  `request_core_attention`, `logs_query`. These are bootstrap and
-  escape primitives — every loop, however tightly scoped, has them.
-  Their Godoc explains why each one earns the slot.
+  `inspect_capability`, `activate_lens`, `deactivate_lens`,
+  `list_lenses`, `thane_now`, `thane_assign`, `request_core_attention`,
+  `logs_query`. These eleven are bootstrap and escape primitives —
+  every loop, however tightly scoped, has them. Their Godoc explains
+  why each one earns the slot.
 
 A loop with `tags: []` is deployment-dependent, and the trap is that
 the empty case isn't a single behavior:
 
 - **Operator has always-active tags** → tag filtering kicks in. The
-  loop sees the always-active tools plus the 12 always-available
+  loop sees the always-active tools plus the 11 always-available
   primitives. Scoped, predictable.
 - **No always-active tags at this deployment** → `tags: []` falls
   through to "no filtering at all," and the loop sees the *entire*
@@ -106,19 +108,22 @@ which loop family is doing the launching:
   the loop ends up with no HA tools at all. The catalog tag
   description spells this out.
 
-## Discovering what a tag opens
+## Discovering what's loaded vs. what a tag would open
 
-Before adding a tag you haven't used before, inspect it:
+These are two different questions with two different answers.
 
-- `inspect_capability(tag: "<tag>")` — returns the per-tool breakdown
-  with source attribution (native, mcp, overlay) and whether the
-  operator overlay has excluded any tools. Use this to answer "what
-  does adding `forge` actually surface?" without guessing.
+**What's loaded right now?** Read your own system prompt. The `##
+Active Capabilities` section is rendered into every prompt (top-loop
+and delegate) with each loaded tag's `description`, `tool_count`,
+`always_active`, `protected`, and `ad_hoc` flags. No tool call
+needed — the answer is already in your context. Reaching for a tool
+to retrieve information you already have just burns a turn.
 
-- `list_loaded_capabilities` — shows what's already loaded in your
-  current scope, including which entries are always-active. Useful
-  for telling "this is already covered" from "I need to add this
-  tag."
+**What would adding a new tag pull in?** Call `inspect_capability(tag:
+"<tag>")`. Returns the per-tool breakdown with source attribution
+(native, mcp, overlay) and whether the operator overlay has excluded
+any tools. Use this before adding an unfamiliar tag — the catalog is
+the source of truth on what's actually behind that name.
 
 When in doubt, the empirical answer beats the remembered one — a
 running loop that worked before is better evidence than your model of

--- a/talents/loops-tagging.md
+++ b/talents/loops-tagging.md
@@ -1,0 +1,101 @@
+---
+tags: [loops]
+---
+
+# Loop tagging
+
+When you launch a loop, the `tags` array decides what tools its
+iterations can reach. Get the tag set right and the loop has exactly
+what it needs; get it wrong and you've either starved the loop (no
+relevant tools) or distracted it with menus it doesn't need. Tagging
+is the single most consequential field on a loop launch after the
+sleep envelope.
+
+## "Always" means two different things
+
+There are two always-X concepts and they're often confused:
+
+- **Always-active tags** are capability tags the operator has marked
+  always-active in their site config. They load into every
+  conversation and every loop iteration by default, *in addition to*
+  whatever the loop's own `tags` array specifies. Site-specific —
+  one deployment's always-active set isn't another's. Inspect with
+  `list_loaded_capabilities` (entries with `always_active: true`).
+
+- **Always-available tools** are a small set of tools that survive
+  capability-tag filtering regardless of the loop's tag scope:
+  `activate_capability`, `deactivate_capability`, `reset_capabilities`,
+  `list_loaded_capabilities`, `inspect_capability`, `activate_lens`,
+  `deactivate_lens`, `list_lenses`, `thane_now`, `thane_assign`,
+  `request_core_attention`, `logs_query`. These are bootstrap and
+  escape primitives — every loop, however tightly scoped, has them.
+  Their Godoc explains why each one earns the slot.
+
+A loop with `tags: []` is NOT empty — it still has the operator's
+always-active tags plus the 12 always-available tools. It's missing
+*scoped* tools, not all tools.
+
+## Picking the right tag set
+
+Match the tags to the smallest tool surface that lets the loop do its
+job:
+
+- **Curate loop watching HA entities** — needs `home` or `ha` so the
+  state/control tools resolve. `awareness` if the loop should see
+  ambient context. `documents` if its output goes into a managed doc.
+- **Research delegate** — `documents` and `web` cover most one-shot
+  investigations. Add `forge` only if the question is repo-shaped.
+- **Forge curator** (release digest, PR queue dashboard) — `forge`
+  plus `documents` for the output doc.
+- **Email triage loop** — `email`. Add `contacts` if the loop should
+  ground claims in person records; `notifications` if it should be
+  able to escalate.
+
+Omitting `tags:` is *not* the same as `tags: []`. An omitted field
+inherits the parent context's tags (channel + currently-activated
+capabilities), which is usually wider than the loop needs. For
+service loops, name the tags explicitly so the surface is stable
+across the loop's lifetime.
+
+## Anti-patterns
+
+- **Tag-as-label.** Tags are not free-form metadata. Each tag binds
+  to a real tool surface. Adding `tags: ["server-room"]` does
+  nothing useful — `server-room` isn't a registered tag, so it
+  resolves to no tools (and contributes to ad-hoc-tag confusion).
+
+- **Over-tagging "just in case."** Every tag you add pulls in its
+  full tool surface, its trailhead/doctrine talents, and any KB
+  articles tagged with it. A research delegate with
+  `["documents", "web", "ha", "forge", "email", "memory"]` is
+  burning context on every iteration for tools 95% of cycles won't
+  use. Start with the minimum; expand only when the loop demonstrably
+  needs more.
+
+- **Empty tags expecting "everything."** `tags: []` means "just the
+  baseline" — operator always-active set plus the 12 always-available
+  primitives. If you wanted a kitchen-sink surface, you wanted
+  something else; `tags` doesn't have a wildcard.
+
+- **Adding `ha_admin` without `ha`.** `ha_admin` is an additive
+  routing hint, not a self-contained surface — pair it with `ha` or
+  the loop ends up with no HA tools at all. The catalog tag
+  description spells this out.
+
+## Discovering what a tag opens
+
+Before adding a tag you haven't used before, inspect it:
+
+- `inspect_capability(tag: "<tag>")` — returns the per-tool breakdown
+  with source attribution (native, mcp, overlay) and whether the
+  operator overlay has excluded any tools. Use this to answer "what
+  does adding `forge` actually surface?" without guessing.
+
+- `list_loaded_capabilities` — shows what's already loaded in your
+  current scope, including which entries are always-active. Useful
+  for telling "this is already covered" from "I need to add this
+  tag."
+
+When in doubt, the empirical answer beats the remembered one — a
+running loop that worked before is better evidence than your model of
+what each tag includes.


### PR DESCRIPTION
## Summary

Started as "loops-tagging doctrine + Godoc on the 12 always-available tools." Grew during review into a tighter audit of the always-X surface and one architectural cleanup. Net scope landed here:

- New talent `talents/loops-tagging.md` covering tag selection nuance for loop launches.
- Godoc rationale on each always-available tool registration explaining why it earns the slot.
- **`list_loaded_capabilities` demoted out of always-available** (12 → 11). Its output is a strict subset of the `## Active Capabilities` section already rendered into every prompt; the model has been reaching for it under five different names via a repair shim. Full retirement of the tool + shim tracked in #918.
- **`ha_admin` removed from the in-repo concept surface.** It was a pocket-specific tag that leaked into BuiltinTagSpecs, `delegate.go`'s profile selector, the `ha-trailhead.md` next_tags, and the loops-tagging anti-pattern bullet. No in-repo talent was tagged `[ha_admin]`, so the trailhead pointed at a dead destination for any non-pocket deployment. Pocket can use just `ha` or build a config-driven profile selector later.
- Two new anti-patterns in `docs/talent-authoring.md` ("Developer-doc co-mingling" and "Architecture-stale advice") capturing meta-lessons from the review.

## Functional changes operators should know about

| Change | Impact | Migration |
|---|---|---|
| `list_loaded_capabilities` no longer `AlwaysAvailable` | Tag-scoped loops can no longer call it; runtime contract + IllegalToolMessage point at the `## Active Capabilities` prompt section instead | None — the tool still loads when no tags are active; otherwise the prompt section carries the same data and more |
| `ha_admin` removed from BuiltinTagSpecs | The catalog no longer renders a description for the tag if operator YAML still references it | Operators using `ha_admin` should rename to `ha` in their CapabilityTags YAML. The `ha` profile selection still works for `ha`-tagged scopes |
| Delegate executor's profile selector drops the `ha_admin` branch | `delegate.profileForScope` now only checks `ha` | Same migration as above |

## Always-available set (post-demotion: 11 tools)

`activate_capability`, `deactivate_capability`, `reset_capabilities`, `inspect_capability`, `activate_lens`, `deactivate_lens`, `list_lenses`, `thane_now`, `thane_assign`, `request_core_attention`, `logs_query`.

Each one carries a Godoc rationale comment explaining the always-on slot. The 5 families: capability management (5), lens management (3), delegation front doors (2), escalation (1), forensics (1).

Refs #910 #696 (escalation boundary the talent now points at correctly)

## Follow-ups stacked off this PR's tip

- **#918** — full retirement of `list_loaded_capabilities` + its 5-way repair shim + the two t.Skip'd tests + remaining doc references
- **#919** — rename always-available/always-active → `core` (Tool.Core, BuiltinTagSpec.Core, JSON keys, talents, docs); accept-both-keys transition for operator YAML
- **#916** — native forge tools for the PR creation + review-cycle workflows (surfaced when PR-E's review_loop leaf had to fall back to raw `gh` calls)

## Test plan
- [x] `just ci` clean (lint, race tests, lychee, architecture baseline unchanged at 55/76/40/102/8)
- [x] `TestBuiltinToolCatalogIncludesAlwaysAvailableTools` updated to the 11-tool list
- [x] `TestRepoTrailheadNextTagsResolve` + `TestRepoTalentToolReferences` pass with `loops-tagging.md` + `ha-trailhead.md` changes
- [x] 3 runtime tests handled: 1 trimmed (still exercises effective-tools surface), 2 t.Skip'd with comments pointing at #918
- [x] `inspect_capability`'s unknown-tag error message points at the prompt section, not the demoted tool
- [x] `docs/reference/tools.md` "Always-active" table reflects 11 tools