### PR TITLE
catalog: formalize tag hierarchy with Kind/Parents/Aliases (PR-G of #910)

### DIFF
--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -94,7 +94,12 @@ fetch Home Assistant forecast response data each turn and include a
 compact forecast in the injected entity context. Use `forecast: none` to
 clear forecast fetching for that subscription.
 
-## `ha` / `homeassistant` — Home Assistant state and control
+## `ha` — Home Assistant state and control
+
+`homeassistant` is an alias that resolves to `ha`. Either name works at
+`activate_capability`; the canonical name `ha` is what flows through the
+scope and prompt rendering.
+
 
 | Tool | Description |
 |------|-------------|

--- a/docs/understanding/tag-system.md
+++ b/docs/understanding/tag-system.md
@@ -45,6 +45,10 @@ boundaries, that's a smell.
 | **Scope** / **capabilityScope** | The runtime tag-set object for one `agent.Run()`. | [`capability_scope.go:51`][scope]. | Lives in context; mutated by tools; not directly persisted. |
 | **Core tool** | A boolean flag on a `Tool`. | [`tools.Tool.Core`][core-tool]. | Tool-level, not tag-level. Survives all tag filters. Used for meta-tools (`activate_capability` itself, etc.) and for `RuntimeTools`. |
 | **Core tag** | Tags pinned in every scope by config. | [`Executor.SetCoreTags`][exec-core], config `capability_tags.*.core`. | Tag-level, not tool-level. Re-seeded each run. |
+| **Tag kind** | Tag's surface role: leaf (carries tools) vs. menu (coarse trailhead routing to leaves). | [`BuiltinTagSpec.Kind`][tag-spec]. | Orthogonal to Protected. Menus surface as routing entries in the activation prompt; leaves carry tool surface. |
+| **Tag parents** | Menu(s) a leaf appears under in the hierarchical menu. Multi-valued. | [`BuiltinTagSpec.Parents`][tag-spec]. | Data, not prose. Replaces the "usually leads to X, Y, Z" sentences that were the only menu→leaf mapping before PR-G. |
+| **Tag aliases** | Alternate names that resolve to a canonical tag at every system boundary (activate_capability, channel binding, config). | [`BuiltinTagSpec.Aliases`][tag-spec], [`CanonicalTagName`][tag-canonical]. | Internally only canonical names exist; aliases funnel in at boundaries via reverse-lookup map populated at init. `homeassistant` resolves to `ha`. |
+| **Protected tag** | Runtime-asserted; can't be model-toggled. | [`BuiltinTagSpec.Protected`][tag-spec]. | Orthogonal to Kind. A leaf can be protected (`message_channel`, `owner`) without being a menu. |
 | **Delegate profile** (`delegate.Profile`) | Operational bundle for a delegated task: max iterations, max duration, token budget, tool timeout, default tags, router hints. | [`delegate/profile.go`][delegate-profile]. | Operational *constraints*. No relation to tool gating beyond `DefaultTags`. |
 | **Loop profile** (`router.LoopProfile`) | Routing/behavior bundle: model selection, mission, quality floor, instructions. | [`router/loopprofile.go`][loop-profile]. | Routing and prompt-shaping. No relation to tool gating except via `ExcludeTools`. |
 | **Routing profile** | A user-facing model name (`thane:premium`, `thane:ops`). | [Routing Profiles](../operating/routing-profiles.md). | Selected by Ollama-API model name; resolves to a `LoopProfile`. |
@@ -57,6 +61,8 @@ boundaries, that's a smell.
 [delegate-profile]: ../../internal/runtime/delegate/profile.go
 [loop-profile]: ../../internal/model/router/loopprofile.go
 [configured-tags]: ../../internal/runtime/loop/tooling.go
+[tag-spec]: ../../internal/model/toolcatalog/catalog.go
+[tag-canonical]: ../../internal/model/toolcatalog/catalog.go
 [pr-813]: https://github.com/nugget/thane-ai-agent/pull/813
 
 The glossary in [docs/understanding/glossary.md](glossary.md) covers

--- a/internal/app/tooling_tags.go
+++ b/internal/app/tooling_tags.go
@@ -262,7 +262,7 @@ func overlayExcludeReason(tag string) string {
 }
 
 func shouldSeedBuiltinTag(tag string, spec toolcatalog.BuiltinTagSpec) bool {
-	if spec.Protected || spec.Menu {
+	if spec.Protected || spec.Kind.IsMenu() {
 		return true
 	}
 	switch tag {

--- a/internal/model/toolcatalog/catalog.go
+++ b/internal/model/toolcatalog/catalog.go
@@ -24,12 +24,82 @@ type BuiltinToolSpec struct {
 	Tags        []string
 }
 
-// BuiltinTagSpec captures compiled-in metadata for a tag/toolset.
+// TagKind describes a tag's surface role in the capability menu.
+//
+//   - [TagKindLeaf] is the default: an ordinary capability tag that
+//     carries tools, talents, and KB articles. When the model activates
+//     a leaf tag, those resources load into scope.
+//   - [TagKindMenu] is a coarse trailhead that routes the model toward
+//     leaf tags. Menus typically carry few or no tools of their own;
+//     their value is the per-branch teaser surfaced in the capability
+//     menu prompt.
+//
+// Tag kind is orthogonal to [BuiltinTagSpec.Protected] — a leaf can be
+// protected (e.g. `message_channel`, `owner`) without becoming a menu.
+type TagKind string
+
+const (
+	// TagKindLeaf is the default kind. Empty string normalizes to this.
+	TagKindLeaf TagKind = "leaf"
+	// TagKindMenu marks a coarse trailhead — see [TagKind] for the
+	// distinction from leaves.
+	TagKindMenu TagKind = "menu"
+)
+
+// IsMenu reports whether the kind is a menu. The empty string
+// (zero-value) is treated as [TagKindLeaf].
+func (k TagKind) IsMenu() bool {
+	return k == TagKindMenu
+}
+
+// BuiltinTagSpec captures compiled-in metadata for a tag/toolset. The
+// shape grew incrementally and was formalized in PR-G as part of the
+// #910 talent corpus overhaul to make tag-grouping data instead of
+// prose: leaf tags now point at the menu(s) they belong under via
+// [Parents], and alternate names funnel through [Aliases] at activation
+// time instead of being separately-declared spec entries.
 type BuiltinTagSpec struct {
+	// Description is the short, model-facing summary rendered into
+	// the capability menu and inspect_capability output.
 	Description string
-	Core        bool
-	Menu        bool
-	Protected   bool
+
+	// Core tags are pinned in every scope by operator configuration.
+	// Survives capability-tag filtering; cannot be deactivated by the
+	// model. Re-seeded each run from config — not a property of
+	// individual built-in tags, but operators can set it via the
+	// capability_tags YAML overlay.
+	Core bool
+
+	// Kind classifies the tag's surface role. Zero value is treated
+	// as [TagKindLeaf]; menu trailheads explicitly set
+	// [TagKindMenu]. See [TagKind] for the orthogonality with
+	// Protected.
+	Kind TagKind
+
+	// Protected tags cannot be toggled via activate_capability /
+	// deactivate_capability — they're reserved for runtime trust
+	// assertions (e.g. owner-authenticated conversations, channel
+	// affordance tags asserted by the integration). Orthogonal to
+	// Kind: a tag can be a protected leaf (`message_channel`,
+	// `owner`) without being a menu.
+	Protected bool
+
+	// Parents lists the menu tag(s) this leaf appears under in the
+	// hierarchical capability menu. Multi-valued because some leaves
+	// legitimately serve more than one menu (e.g. `files` is
+	// reachable from both development and knowledge). Omitted for
+	// menus themselves and for tags that don't fit any menu — those
+	// surface as top-level entries in the menu rendering.
+	Parents []string
+
+	// Aliases lists alternate names that resolve to this canonical
+	// tag. Most relevant for backward-compatible renames or
+	// operator-friendly synonyms (e.g. `homeassistant` resolves to
+	// `ha`). Resolution happens at every boundary the tag enters the
+	// system: activate_capability / inspect_capability calls,
+	// channel-tag binding, operator YAML. Internally only canonical
+	// names exist.
+	Aliases []string
 }
 
 // CapabilitySurface captures the resolved model-facing view of a
@@ -52,12 +122,15 @@ type CapabilitySurface struct {
 	ToolEntries   []CapabilityToolEntry
 	ExcludedTools []CapabilityToolEntry
 	Core          bool
-	Menu          bool
-	Protected     bool
-	Loaded        bool
-	KBArticles    int
-	LiveContext   bool
-	AdHoc         bool
+	// Kind mirrors [BuiltinTagSpec.Kind]. Use Kind.IsMenu() to test
+	// menu-ness; the zero value normalizes to [TagKindLeaf].
+	Kind        TagKind
+	Parents     []string
+	Protected   bool
+	Loaded      bool
+	KBArticles  int
+	LiveContext bool
+	AdHoc       bool
 }
 
 var builtinToolSpecs = map[string]BuiltinToolSpec{
@@ -70,9 +143,9 @@ var builtinToolSpecs = map[string]BuiltinToolSpec{
 	"attachment_describe":         {CanonicalID: "native:attachment_describe", Source: NativeToolSource, Tags: []string{"attachments"}},
 	"attachment_list":             {CanonicalID: "native:attachment_list", Source: NativeToolSource, Tags: []string{"attachments"}},
 	"attachment_search":           {CanonicalID: "native:attachment_search", Source: NativeToolSource, Tags: []string{"attachments"}},
-	"call_service":                {CanonicalID: "native:call_service", Source: NativeToolSource, Tags: []string{"ha", "homeassistant"}},
+	"call_service":                {CanonicalID: "native:call_service", Source: NativeToolSource, Tags: []string{"ha"}},
 	"cancel_task":                 {CanonicalID: "native:cancel_task", Source: NativeToolSource, Tags: []string{"scheduler"}},
-	"control_device":              {CanonicalID: "native:control_device", Source: NativeToolSource, Tags: []string{"ha", "homeassistant"}},
+	"control_device":              {CanonicalID: "native:control_device", Source: NativeToolSource, Tags: []string{"ha"}},
 	"conversation_reset":          {CanonicalID: "native:conversation_reset", Source: NativeToolSource, Tags: []string{"session"}},
 	"cost_summary":                {CanonicalID: "native:cost_summary", Source: NativeToolSource, Tags: []string{"diagnostics"}},
 	"create_temp_file":            {CanonicalID: "native:create_temp_file", Source: NativeToolSource, Tags: []string{"files"}},
@@ -116,7 +189,7 @@ var builtinToolSpecs = map[string]BuiltinToolSpec{
 	"file_stat":                   {CanonicalID: "native:file_stat", Source: NativeToolSource, Tags: []string{"files"}},
 	"file_tree":                   {CanonicalID: "native:file_tree", Source: NativeToolSource, Tags: []string{"files"}},
 	"file_write":                  {CanonicalID: "native:file_write", Source: NativeToolSource, Tags: []string{"files"}},
-	"find_entity":                 {CanonicalID: "native:find_entity", Source: NativeToolSource, Tags: []string{"ha", "homeassistant"}},
+	"find_entity":                 {CanonicalID: "native:find_entity", Source: NativeToolSource, Tags: []string{"ha"}},
 	"forget_contact":              {CanonicalID: "native:forget_contact", Source: NativeToolSource, Tags: []string{"contacts"}},
 	"forget_fact":                 {CanonicalID: "native:forget_fact", Source: NativeToolSource, Tags: []string{"memory"}},
 	"forge_issue_comment":         {CanonicalID: "native:forge_issue_comment", Source: NativeToolSource, Tags: []string{"forge"}},
@@ -140,18 +213,18 @@ var builtinToolSpecs = map[string]BuiltinToolSpec{
 	"forge_repo_subscriptions":    {CanonicalID: "native:forge_repo_subscriptions", Source: NativeToolSource, Tags: []string{"forge"}},
 	"forge_repo_unfollow":         {CanonicalID: "native:forge_repo_unfollow", Source: NativeToolSource, Tags: []string{"forge"}},
 	"forge_search":                {CanonicalID: "native:forge_search", Source: NativeToolSource, Tags: []string{"forge"}},
-	"get_state":                   {CanonicalID: "native:get_state", Source: NativeToolSource, Tags: []string{"ha", "homeassistant"}},
+	"get_state":                   {CanonicalID: "native:get_state", Source: NativeToolSource, Tags: []string{"ha"}},
 	"get_version":                 {CanonicalID: "native:get_version", Source: NativeToolSource, Tags: []string{"diagnostics"}},
-	"ha_automation_create":        {CanonicalID: "native:ha_automation_create", Source: NativeToolSource, Tags: []string{"ha", "homeassistant"}},
-	"ha_automation_delete":        {CanonicalID: "native:ha_automation_delete", Source: NativeToolSource, Tags: []string{"ha", "homeassistant"}},
-	"ha_automation_get":           {CanonicalID: "native:ha_automation_get", Source: NativeToolSource, Tags: []string{"ha", "homeassistant"}},
-	"ha_automation_list":          {CanonicalID: "native:ha_automation_list", Source: NativeToolSource, Tags: []string{"ha", "homeassistant"}},
-	"ha_automation_update":        {CanonicalID: "native:ha_automation_update", Source: NativeToolSource, Tags: []string{"ha", "homeassistant"}},
+	"ha_automation_create":        {CanonicalID: "native:ha_automation_create", Source: NativeToolSource, Tags: []string{"ha"}},
+	"ha_automation_delete":        {CanonicalID: "native:ha_automation_delete", Source: NativeToolSource, Tags: []string{"ha"}},
+	"ha_automation_get":           {CanonicalID: "native:ha_automation_get", Source: NativeToolSource, Tags: []string{"ha"}},
+	"ha_automation_list":          {CanonicalID: "native:ha_automation_list", Source: NativeToolSource, Tags: []string{"ha"}},
+	"ha_automation_update":        {CanonicalID: "native:ha_automation_update", Source: NativeToolSource, Tags: []string{"ha"}},
 	"ha_notify":                   {CanonicalID: "native:ha_notify", Source: NativeToolSource, Tags: []string{"notifications"}},
-	"ha_registry_search":          {CanonicalID: "native:ha_registry_search", Source: NativeToolSource, Tags: []string{"ha", "homeassistant"}},
+	"ha_registry_search":          {CanonicalID: "native:ha_registry_search", Source: NativeToolSource, Tags: []string{"ha"}},
 	"import_vcf":                  {CanonicalID: "native:import_vcf", Source: NativeToolSource, Tags: []string{"contacts"}},
 	"list_contacts":               {CanonicalID: "native:list_contacts", Source: NativeToolSource, Tags: []string{"contacts"}},
-	"list_entities":               {CanonicalID: "native:list_entities", Source: NativeToolSource, Tags: []string{"ha", "homeassistant"}},
+	"list_entities":               {CanonicalID: "native:list_entities", Source: NativeToolSource, Tags: []string{"ha"}},
 	"list_lenses":                 {CanonicalID: "native:list_lenses", Source: NativeToolSource},
 	"inspect_capability":          {CanonicalID: "native:inspect_capability", Source: NativeToolSource},
 	"reset_capabilities":          {CanonicalID: "native:reset_capabilities", Source: NativeToolSource},
@@ -244,10 +317,52 @@ func BuiltinTagSpecs() map[string]BuiltinTagSpec {
 	return maps.Clone(builtinTagSpecs)
 }
 
-// HasBuiltinTag reports whether the name is a compiled-in tag.
+// HasBuiltinTag reports whether the name is a compiled-in tag,
+// resolving aliases. So `HasBuiltinTag("homeassistant")` returns true
+// because `ha` declares it as an alias.
 func HasBuiltinTag(name string) bool {
-	_, ok := builtinTagSpecs[name]
+	if _, ok := builtinTagSpecs[name]; ok {
+		return true
+	}
+	_, ok := builtinTagAliases[name]
 	return ok
+}
+
+// CanonicalTagName returns the canonical tag name for value, resolving
+// aliases. If value is already a canonical tag (or an unknown name), it
+// is returned unchanged.
+func CanonicalTagName(value string) string {
+	if canonical, ok := builtinTagAliases[value]; ok {
+		return canonical
+	}
+	return value
+}
+
+// LookupBuiltinTagSpec returns the spec for name, resolving aliases.
+// Returns the zero value and false for unknown names.
+func LookupBuiltinTagSpec(name string) (BuiltinTagSpec, bool) {
+	if spec, ok := builtinTagSpecs[name]; ok {
+		return spec, true
+	}
+	if canonical, ok := builtinTagAliases[name]; ok {
+		spec, found := builtinTagSpecs[canonical]
+		return spec, found
+	}
+	return BuiltinTagSpec{}, false
+}
+
+// builtinTagAliases is the reverse-lookup map populated from each
+// canonical spec's Aliases field at package init. Lookups are
+// alias → canonical name; resolving an unknown name returns ("", false).
+var builtinTagAliases map[string]string
+
+func init() {
+	builtinTagAliases = make(map[string]string)
+	for canonical, spec := range builtinTagSpecs {
+		for _, alias := range spec.Aliases {
+			builtinTagAliases[alias] = canonical
+		}
+	}
 }
 
 // BuildCapabilitySurface builds a sorted capability surface from
@@ -263,7 +378,8 @@ func BuildCapabilitySurface(tags map[string][]string, descriptions map[string]st
 			Description: descriptions[tag],
 			Tools:       copiedTools,
 			Core:        core[tag],
-			Menu:        spec.Menu,
+			Kind:        spec.Kind,
+			Parents:     append([]string(nil), spec.Parents...),
 			Protected:   protected[tag],
 		})
 	}

--- a/internal/model/toolcatalog/catalog.go
+++ b/internal/model/toolcatalog/catalog.go
@@ -5,7 +5,7 @@ package toolcatalog
 
 import (
 	"encoding/json"
-	"maps"
+	"fmt"
 	"sort"
 )
 
@@ -143,9 +143,9 @@ var builtinToolSpecs = map[string]BuiltinToolSpec{
 	"attachment_describe":         {CanonicalID: "native:attachment_describe", Source: NativeToolSource, Tags: []string{"attachments"}},
 	"attachment_list":             {CanonicalID: "native:attachment_list", Source: NativeToolSource, Tags: []string{"attachments"}},
 	"attachment_search":           {CanonicalID: "native:attachment_search", Source: NativeToolSource, Tags: []string{"attachments"}},
-	"call_service":                {CanonicalID: "native:call_service", Source: NativeToolSource, Tags: []string{"ha"}},
+	"call_service":                {CanonicalID: "native:call_service", Source: NativeToolSource, Tags: []string{"ha", "homeassistant"}},
 	"cancel_task":                 {CanonicalID: "native:cancel_task", Source: NativeToolSource, Tags: []string{"scheduler"}},
-	"control_device":              {CanonicalID: "native:control_device", Source: NativeToolSource, Tags: []string{"ha"}},
+	"control_device":              {CanonicalID: "native:control_device", Source: NativeToolSource, Tags: []string{"ha", "homeassistant"}},
 	"conversation_reset":          {CanonicalID: "native:conversation_reset", Source: NativeToolSource, Tags: []string{"session"}},
 	"cost_summary":                {CanonicalID: "native:cost_summary", Source: NativeToolSource, Tags: []string{"diagnostics"}},
 	"create_temp_file":            {CanonicalID: "native:create_temp_file", Source: NativeToolSource, Tags: []string{"files"}},
@@ -189,7 +189,7 @@ var builtinToolSpecs = map[string]BuiltinToolSpec{
 	"file_stat":                   {CanonicalID: "native:file_stat", Source: NativeToolSource, Tags: []string{"files"}},
 	"file_tree":                   {CanonicalID: "native:file_tree", Source: NativeToolSource, Tags: []string{"files"}},
 	"file_write":                  {CanonicalID: "native:file_write", Source: NativeToolSource, Tags: []string{"files"}},
-	"find_entity":                 {CanonicalID: "native:find_entity", Source: NativeToolSource, Tags: []string{"ha"}},
+	"find_entity":                 {CanonicalID: "native:find_entity", Source: NativeToolSource, Tags: []string{"ha", "homeassistant"}},
 	"forget_contact":              {CanonicalID: "native:forget_contact", Source: NativeToolSource, Tags: []string{"contacts"}},
 	"forget_fact":                 {CanonicalID: "native:forget_fact", Source: NativeToolSource, Tags: []string{"memory"}},
 	"forge_issue_comment":         {CanonicalID: "native:forge_issue_comment", Source: NativeToolSource, Tags: []string{"forge"}},
@@ -213,18 +213,18 @@ var builtinToolSpecs = map[string]BuiltinToolSpec{
 	"forge_repo_subscriptions":    {CanonicalID: "native:forge_repo_subscriptions", Source: NativeToolSource, Tags: []string{"forge"}},
 	"forge_repo_unfollow":         {CanonicalID: "native:forge_repo_unfollow", Source: NativeToolSource, Tags: []string{"forge"}},
 	"forge_search":                {CanonicalID: "native:forge_search", Source: NativeToolSource, Tags: []string{"forge"}},
-	"get_state":                   {CanonicalID: "native:get_state", Source: NativeToolSource, Tags: []string{"ha"}},
+	"get_state":                   {CanonicalID: "native:get_state", Source: NativeToolSource, Tags: []string{"ha", "homeassistant"}},
 	"get_version":                 {CanonicalID: "native:get_version", Source: NativeToolSource, Tags: []string{"diagnostics"}},
-	"ha_automation_create":        {CanonicalID: "native:ha_automation_create", Source: NativeToolSource, Tags: []string{"ha"}},
-	"ha_automation_delete":        {CanonicalID: "native:ha_automation_delete", Source: NativeToolSource, Tags: []string{"ha"}},
-	"ha_automation_get":           {CanonicalID: "native:ha_automation_get", Source: NativeToolSource, Tags: []string{"ha"}},
-	"ha_automation_list":          {CanonicalID: "native:ha_automation_list", Source: NativeToolSource, Tags: []string{"ha"}},
-	"ha_automation_update":        {CanonicalID: "native:ha_automation_update", Source: NativeToolSource, Tags: []string{"ha"}},
+	"ha_automation_create":        {CanonicalID: "native:ha_automation_create", Source: NativeToolSource, Tags: []string{"ha", "homeassistant"}},
+	"ha_automation_delete":        {CanonicalID: "native:ha_automation_delete", Source: NativeToolSource, Tags: []string{"ha", "homeassistant"}},
+	"ha_automation_get":           {CanonicalID: "native:ha_automation_get", Source: NativeToolSource, Tags: []string{"ha", "homeassistant"}},
+	"ha_automation_list":          {CanonicalID: "native:ha_automation_list", Source: NativeToolSource, Tags: []string{"ha", "homeassistant"}},
+	"ha_automation_update":        {CanonicalID: "native:ha_automation_update", Source: NativeToolSource, Tags: []string{"ha", "homeassistant"}},
 	"ha_notify":                   {CanonicalID: "native:ha_notify", Source: NativeToolSource, Tags: []string{"notifications"}},
-	"ha_registry_search":          {CanonicalID: "native:ha_registry_search", Source: NativeToolSource, Tags: []string{"ha"}},
+	"ha_registry_search":          {CanonicalID: "native:ha_registry_search", Source: NativeToolSource, Tags: []string{"ha", "homeassistant"}},
 	"import_vcf":                  {CanonicalID: "native:import_vcf", Source: NativeToolSource, Tags: []string{"contacts"}},
 	"list_contacts":               {CanonicalID: "native:list_contacts", Source: NativeToolSource, Tags: []string{"contacts"}},
-	"list_entities":               {CanonicalID: "native:list_entities", Source: NativeToolSource, Tags: []string{"ha"}},
+	"list_entities":               {CanonicalID: "native:list_entities", Source: NativeToolSource, Tags: []string{"ha", "homeassistant"}},
 	"list_lenses":                 {CanonicalID: "native:list_lenses", Source: NativeToolSource},
 	"inspect_capability":          {CanonicalID: "native:inspect_capability", Source: NativeToolSource},
 	"reset_capabilities":          {CanonicalID: "native:reset_capabilities", Source: NativeToolSource},
@@ -312,9 +312,18 @@ func BuiltinToolSpecs() map[string]BuiltinToolSpec {
 	return out
 }
 
-// BuiltinTagSpecs returns a copy of the compiled-in tag catalog.
+// BuiltinTagSpecs returns a deep copy of the compiled-in tag catalog.
+// The returned map and the slice fields on each spec (Parents,
+// Aliases) are independent copies — mutating them does not affect the
+// global catalog. Parallels [BuiltinToolSpecs] for the tool half.
 func BuiltinTagSpecs() map[string]BuiltinTagSpec {
-	return maps.Clone(builtinTagSpecs)
+	out := make(map[string]BuiltinTagSpec, len(builtinTagSpecs))
+	for name, spec := range builtinTagSpecs {
+		spec.Parents = append([]string(nil), spec.Parents...)
+		spec.Aliases = append([]string(nil), spec.Aliases...)
+		out[name] = spec
+	}
+	return out
 }
 
 // HasBuiltinTag reports whether the name is a compiled-in tag,
@@ -354,12 +363,30 @@ func LookupBuiltinTagSpec(name string) (BuiltinTagSpec, bool) {
 // builtinTagAliases is the reverse-lookup map populated from each
 // canonical spec's Aliases field at package init. Lookups are
 // alias → canonical name; resolving an unknown name returns ("", false).
+//
+// Until alias resolution propagates to every tag ingress point (config
+// validation, channel-tag binding, loop spec, persisted scope), tools
+// belonging to a canonical tag with aliases should *also* carry the
+// alias names in their Tags slice — see the `ha` / `homeassistant`
+// pattern in builtinToolSpecs. The CanonicalTagName helper is the
+// model-facing resolution boundary; the double-tagging is the
+// tag-index bridge until that resolution covers every ingress.
 var builtinTagAliases map[string]string
 
 func init() {
 	builtinTagAliases = make(map[string]string)
 	for canonical, spec := range builtinTagSpecs {
 		for _, alias := range spec.Aliases {
+			if _, collides := builtinTagSpecs[alias]; collides {
+				panic(fmt.Sprintf(
+					"toolcatalog: alias %q on canonical tag %q collides with an existing canonical tag of the same name",
+					alias, canonical))
+			}
+			if existing, dup := builtinTagAliases[alias]; dup {
+				panic(fmt.Sprintf(
+					"toolcatalog: alias %q declared by both %q and %q",
+					alias, existing, canonical))
+			}
 			builtinTagAliases[alias] = canonical
 		}
 	}

--- a/internal/model/toolcatalog/catalog_tags.go
+++ b/internal/model/toolcatalog/catalog_tags.go
@@ -1,37 +1,160 @@
 package toolcatalog
 
+// builtinTagSpecs is the compiled-in tag catalog. PR-G formalized the
+// hierarchy: every leaf declares its Parents (the menu trailheads it
+// appears under), aliases funnel into canonical names via Aliases, and
+// coarse trailheads are explicitly marked Kind: TagKindMenu. Some
+// leaves legitimately serve more than one menu (files spans development
+// and knowledge; web spans development, knowledge, and media) and
+// declare multi-valued Parents.
+//
+// Adding a new tag: pick a Kind, write a Description that fits the
+// model-facing menu, and assign Parents from the existing menus when
+// the tag clearly belongs under one. A new top-level menu is a bigger
+// move — make sure the leaves grouped under it warrant a coarse
+// trailhead before adding one.
 var builtinTagSpecs = map[string]BuiltinTagSpec{
-	"archive":         {Description: "Archive search and transcript retrieval across past conversations."},
-	"attachments":     {Description: "Attachment listing, search, and vision description tools."},
-	"awareness":       {Description: "Subscribe entities and live providers to a loop or conversation's auto-injected context. Reflexive for service loops, optional for single-shots."},
-	"contacts":        {Description: "Structured contact-directory records and vCard administration tools."},
-	"development":     {Description: "Coarse trailhead for software, repository, and code-change work. Usually leads to forge, files, web, or shell.", Menu: true},
-	"diagnostics":     {Description: "Logs, usage, version, and operational debugging tools."},
-	"documents":       {Description: "Indexed document-root browsing, search, and section retrieval tools."},
-	"email":           {Description: "Email inbox reading, search, and sending tools."},
-	"feeds":           {Description: "Media feed following and feed management tools."},
-	"files":           {Description: "Workspace file read, write, edit, and search tools."},
-	"forge":           {Description: "Forge and code-collaboration tools for issues, pull requests, checks, and reviews."},
-	"ha":              {Description: "Home Assistant state, control, registry, and automation tools."},
-	"home":            {Description: "Coarse trailhead for home, device, room, and automation work. Usually leads to ha or notifications.", Menu: true},
-	"homeassistant":   {Description: "Alias for ha: Home Assistant state, control, registry, and automation tools."},
-	"interactive":     {Description: "Coarse trailhead for interactive loop behavior and channel guidance. Usually leads to signal, owu, or owner context.", Menu: true},
-	"knowledge":       {Description: "Coarse trailhead for kb articles, memory, dossiers, and document understanding. Usually leads to documents, memory, files, or web.", Menu: true},
-	"loops":           {Description: "Live loop status, sleep control, notifications, ad hoc spawn, and durable loop-definition authoring tools."},
-	"media":           {Description: "Coarse trailhead for transcripts, feeds, and media analysis. Usually leads to media, feeds, attachments, or web.", Menu: true},
-	"memory":          {Description: "Persistent fact memory and working-memory tools."},
-	"message_channel": {Description: "Current message-app conversation affordances, such as reactions, normalized across Signal, Matrix, iMessage, and similar providers.", Protected: true},
-	"models":          {Description: "Model registry inspection, routing, and policy tools."},
-	"mqtt":            {Description: "MQTT wake subscription management tools."},
-	"notifications":   {Description: "Notification delivery, escalation, and actionable response tools."},
-	"operations":      {Description: "Coarse trailhead for routing, scheduling, logs, runtime state, and operational debugging. Usually leads to diagnostics, models, scheduler, loops, or companion.", Menu: true},
-	"owner":           {Description: "Trusted owner/operator context set by runtime identity. When present, treat it as true; it can unlock owner-specific guidance and tools.", Menu: true, Protected: true},
-	"owu":             {Description: "Open WebUI interactive chat loop context and guidance."},
-	"people":          {Description: "Coarse trailhead for identity, relationship context, and communication channels. Usually leads to person-record context, signal, email, or owner context.", Menu: true},
-	"companion":       {Description: "Native companion app integration tools."},
-	"scheduler":       {Description: "Scheduling and task management tools."},
-	"web":             {Description: "Web page retrieval and wider-web discovery tools."},
-	"session":         {Description: "Conversation/session lifecycle and checkpoint tools."},
-	"shell":           {Description: "Shell execution tools for local command work."},
-	"signal":          {Description: "Signal messaging tools."},
+	// --- Menus (coarse trailheads) ---
+
+	"development": {
+		Description: "Coarse trailhead for software, repository, and code-change work. Usually leads to forge, files, web, or shell.",
+		Kind:        TagKindMenu,
+	},
+	"home": {
+		Description: "Coarse trailhead for home, device, room, and automation work. Usually leads to ha, awareness, or notifications.",
+		Kind:        TagKindMenu,
+	},
+	"interactive": {
+		Description: "Coarse trailhead for interactive loop behavior and channel guidance. Usually leads to signal, owu, or owner context.",
+		Kind:        TagKindMenu,
+	},
+	"knowledge": {
+		Description: "Coarse trailhead for kb articles, memory, dossiers, and document understanding. Usually leads to documents, memory, files, archive, or web.",
+		Kind:        TagKindMenu,
+	},
+	"media": {
+		Description: "Coarse trailhead for transcripts, feeds, and media analysis. Usually leads to feeds, attachments, or web.",
+		Kind:        TagKindMenu,
+	},
+	"operations": {
+		Description: "Coarse trailhead for routing, scheduling, logs, runtime state, and operational debugging. Usually leads to diagnostics, models, scheduler, loops, mqtt, session, or companion.",
+		Kind:        TagKindMenu,
+	},
+	"people": {
+		Description: "Coarse trailhead for identity, relationship context, and communication channels. Usually leads to contacts, signal, email, or owner context.",
+		Kind:        TagKindMenu,
+	},
+
+	// --- Leaves ---
+	// Each leaf declares the menu(s) it appears under via Parents. Some
+	// leaves are reachable from multiple menus — those carry multiple
+	// entries in Parents.
+
+	"archive": {
+		Description: "Archive search and transcript retrieval across past conversations.",
+		Parents:     []string{"knowledge"},
+	},
+	"attachments": {
+		Description: "Attachment listing, search, and vision description tools.",
+		Parents:     []string{"media"},
+	},
+	"awareness": {
+		Description: "Subscribe entities and live providers to a loop or conversation's auto-injected context. Reflexive for service loops, optional for single-shots.",
+		Parents:     []string{"home"},
+	},
+	"companion": {
+		Description: "Native macOS companion app integration tools (calendar, contacts, AppleScript bridges).",
+		Parents:     []string{"operations"},
+	},
+	"contacts": {
+		Description: "Structured contact-directory records and vCard administration tools.",
+		Parents:     []string{"people"},
+	},
+	"diagnostics": {
+		Description: "Logs, usage, version, and operational debugging tools.",
+		Parents:     []string{"operations"},
+	},
+	"documents": {
+		Description: "Indexed document-root browsing, search, and section retrieval tools.",
+		Parents:     []string{"knowledge"},
+	},
+	"email": {
+		Description: "Email inbox reading, search, and sending tools.",
+		Parents:     []string{"people"},
+	},
+	"feeds": {
+		Description: "Media feed following and feed management tools.",
+		Parents:     []string{"media"},
+	},
+	"files": {
+		Description: "Workspace file read, write, edit, and search tools.",
+		Parents:     []string{"development", "knowledge"},
+	},
+	"forge": {
+		Description: "Forge and code-collaboration tools for issues, pull requests, checks, and reviews.",
+		Parents:     []string{"development"},
+	},
+	"ha": {
+		Description: "Home Assistant state, control, registry, and automation tools.",
+		Parents:     []string{"home"},
+		Aliases:     []string{"homeassistant"},
+	},
+	"loops": {
+		Description: "Live loop status, sleep control, notifications, ad hoc spawn, and durable loop-definition authoring tools.",
+		Parents:     []string{"operations"},
+	},
+	"memory": {
+		Description: "Persistent fact memory and working-memory tools.",
+		Parents:     []string{"knowledge"},
+	},
+	"models": {
+		Description: "Model registry inspection, routing, and policy tools.",
+		Parents:     []string{"operations"},
+	},
+	"mqtt": {
+		Description: "MQTT wake subscription management tools.",
+		Parents:     []string{"operations"},
+	},
+	"notifications": {
+		Description: "Notification delivery, escalation, and actionable response tools.",
+		Parents:     []string{"home"},
+	},
+	"owu": {
+		Description: "Open WebUI interactive chat loop context and guidance.",
+		Parents:     []string{"interactive"},
+	},
+	"scheduler": {
+		Description: "Scheduling and task management tools.",
+		Parents:     []string{"operations"},
+	},
+	"session": {
+		Description: "Conversation/session lifecycle and checkpoint tools.",
+		Parents:     []string{"operations"},
+	},
+	"shell": {
+		Description: "Shell execution tools for local command work.",
+		Parents:     []string{"development"},
+	},
+	"signal": {
+		Description: "Signal messaging tools.",
+		Parents:     []string{"interactive", "people"},
+	},
+	"web": {
+		Description: "Web page retrieval and wider-web discovery tools.",
+		Parents:     []string{"development", "knowledge", "media"},
+	},
+
+	// --- Protected leaves ---
+	// Runtime-asserted, can't be model-toggled. Surface in the menu for
+	// situational awareness, but they're not navigation trailheads.
+
+	"message_channel": {
+		Description: "Current message-app conversation affordances, such as reactions, normalized across Signal, Matrix, iMessage, and similar providers.",
+		Protected:   true,
+	},
+	"owner": {
+		Description: "Trusted owner/operator context set by runtime identity. When present, treat it as true; it can unlock owner-specific guidance and tools.",
+		Protected:   true,
+		Parents:     []string{"interactive", "people"},
+	},
 }

--- a/internal/model/toolcatalog/catalog_test.go
+++ b/internal/model/toolcatalog/catalog_test.go
@@ -1,9 +1,117 @@
 package toolcatalog
 
 import (
+	"sort"
 	"strings"
 	"testing"
 )
+
+// TestBuiltinTagSpecs_ParentsResolveToMenuTags pins the invariant that
+// every Parent value points at a real menu tag. Catches the dangling
+// reference that the loose prose "Usually leads to X, Y, Z" descriptions
+// were prone to — a leaf claiming Parents: []string{"typo"} or pointing
+// at a tag whose Kind isn't TagKindMenu would slip past code review
+// without this guard.
+func TestBuiltinTagSpecs_ParentsResolveToMenuTags(t *testing.T) {
+	specs := BuiltinTagSpecs()
+	var problems []string
+	for name, spec := range specs {
+		for _, parent := range spec.Parents {
+			parentSpec, ok := specs[parent]
+			if !ok {
+				problems = append(problems, name+": parent "+parent+" is not a registered tag")
+				continue
+			}
+			if !parentSpec.Kind.IsMenu() {
+				problems = append(problems, name+": parent "+parent+" is registered but not a menu (Kind="+string(parentSpec.Kind)+")")
+			}
+		}
+	}
+	if len(problems) > 0 {
+		sort.Strings(problems)
+		t.Fatalf("BuiltinTagSpecs Parents reference non-menu tags:\n  - %s",
+			strings.Join(problems, "\n  - "))
+	}
+}
+
+// TestBuiltinTagSpecs_AliasesResolveToCanonicals pins that every Alias
+// is unique across the catalog (no two canonical tags claim the same
+// alias) and doesn't collide with an existing canonical name. Without
+// this, a future addition like Aliases: []string{"ha"} on a sibling tag
+// would silently override the canonical ha entry in the reverse-alias
+// map.
+func TestBuiltinTagSpecs_AliasesResolveToCanonicals(t *testing.T) {
+	specs := BuiltinTagSpecs()
+	seenAliases := make(map[string]string)
+	var problems []string
+	for name, spec := range specs {
+		for _, alias := range spec.Aliases {
+			if _, ok := specs[alias]; ok {
+				problems = append(problems, name+": alias "+alias+" collides with an existing canonical tag")
+				continue
+			}
+			if owner, dup := seenAliases[alias]; dup {
+				problems = append(problems, name+": alias "+alias+" already declared by "+owner)
+				continue
+			}
+			seenAliases[alias] = name
+		}
+	}
+	if len(problems) > 0 {
+		sort.Strings(problems)
+		t.Fatalf("BuiltinTagSpecs Aliases are not unique:\n  - %s",
+			strings.Join(problems, "\n  - "))
+	}
+}
+
+// TestCanonicalTagName_ResolvesHomeAssistantAlias is the worked example
+// for alias resolution: the reverse-alias map populated at init must
+// resolve homeassistant → ha, and the canonical name must round-trip
+// unchanged.
+func TestCanonicalTagName_ResolvesHomeAssistantAlias(t *testing.T) {
+	if got := CanonicalTagName("homeassistant"); got != "ha" {
+		t.Fatalf("CanonicalTagName(homeassistant) = %q, want ha", got)
+	}
+	if got := CanonicalTagName("ha"); got != "ha" {
+		t.Fatalf("CanonicalTagName(ha) = %q, want ha (canonical round-trip)", got)
+	}
+	if got := CanonicalTagName("nonexistent"); got != "nonexistent" {
+		t.Fatalf("CanonicalTagName(nonexistent) = %q, want nonexistent (unchanged for unknown)", got)
+	}
+}
+
+// TestHasBuiltinTag_AcceptsAliases checks that aliases register as
+// known tags. The runtime relies on this so validation against
+// unknown-tag references (channel_tags pointing at homeassistant, KB
+// articles tagged homeassistant) keeps working through the alias.
+func TestHasBuiltinTag_AcceptsAliases(t *testing.T) {
+	if !HasBuiltinTag("homeassistant") {
+		t.Fatal("HasBuiltinTag(homeassistant) = false, want true via ha's alias")
+	}
+	if !HasBuiltinTag("ha") {
+		t.Fatal("HasBuiltinTag(ha) = false, want true (canonical)")
+	}
+	if HasBuiltinTag("definitely_not_a_tag") {
+		t.Fatal("HasBuiltinTag(definitely_not_a_tag) = true, want false")
+	}
+}
+
+// TestLookupBuiltinTagSpec_ResolvesAliases confirms that fetching the
+// spec for an alias returns the canonical spec.
+func TestLookupBuiltinTagSpec_ResolvesAliases(t *testing.T) {
+	viaCanonical, ok := LookupBuiltinTagSpec("ha")
+	if !ok {
+		t.Fatal("LookupBuiltinTagSpec(ha) not found")
+	}
+	viaAlias, ok := LookupBuiltinTagSpec("homeassistant")
+	if !ok {
+		t.Fatal("LookupBuiltinTagSpec(homeassistant) not found via alias")
+	}
+	if viaAlias.Description != viaCanonical.Description {
+		t.Fatalf("alias resolution returned different spec: alias=%+v canonical=%+v",
+			viaAlias, viaCanonical)
+	}
+}
 
 func TestBuildCapabilitySurface_SortsTagsAndTools(t *testing.T) {
 	surface := BuildCapabilitySurface(
@@ -34,7 +142,7 @@ func TestBuildCapabilitySurface_SortsTagsAndTools(t *testing.T) {
 	if !surface[0].Core {
 		t.Fatal("forge should be core")
 	}
-	if !surface[1].Menu {
+	if !surface[1].Kind.IsMenu() {
 		t.Fatal("interactive should be a menu tag")
 	}
 	if !surface[2].Protected {
@@ -142,7 +250,7 @@ func TestRenderLoadedCapabilitySummary_EmptyStateExplainsAvailability(t *testing
 
 func TestRenderCapabilityManifestMarkdown_UsesExactToolNames(t *testing.T) {
 	manifest := RenderCapabilityManifestMarkdown([]CapabilitySurface{
-		{Tag: "development", Description: "Development trailhead.", Teaser: "Activate when the next move is about code or repos.", NextTags: []string{"forge", "files", "web"}, Menu: true},
+		{Tag: "development", Description: "Development trailhead.", Teaser: "Activate when the next move is about code or repos.", NextTags: []string{"forge", "files", "web"}, Kind: TagKindMenu},
 		{Tag: "forge", Description: "Forge tools.", Tools: []string{"forge_pr_get"}},
 	})
 	if !strings.Contains(manifest, "\"kind\":\"capability_menu\"") {
@@ -179,9 +287,9 @@ func TestRenderCapabilityManifestMarkdown_UsesExactToolNames(t *testing.T) {
 
 func TestRenderCapabilityActivationDescription_ShowsMenuTags(t *testing.T) {
 	desc := RenderCapabilityActivationDescription([]CapabilitySurface{
-		{Tag: "development", Description: "Development trailhead.", Teaser: "Activate when the next move is about code or repos.", NextTags: []string{"forge", "files", "web"}, Menu: true},
+		{Tag: "development", Description: "Development trailhead.", Teaser: "Activate when the next move is about code or repos.", NextTags: []string{"forge", "files", "web"}, Kind: TagKindMenu},
 		{Tag: "forge", Description: "Forge tools.", Tools: []string{"forge_pr_get"}},
-		{Tag: "owner", Description: "Owner guidance.", Menu: true, Protected: true},
+		{Tag: "owner", Description: "Owner guidance.", Protected: true},
 	})
 
 	if !strings.Contains(desc, "coarse-to-fine menu") {

--- a/internal/model/toolcatalog/render.go
+++ b/internal/model/toolcatalog/render.go
@@ -14,8 +14,9 @@ import (
 // pre-config edge case where the catalog hasn't classified anything
 // yet.
 func selectCapabilityMenuEntries(entries []CapabilitySurface) []CapabilitySurface {
-	menu := make([]CapabilitySurface, 0, len(entries))
-	for _, entry := range SortCapabilitySurface(entries) {
+	sorted := SortCapabilitySurface(entries)
+	menu := make([]CapabilitySurface, 0, len(sorted))
+	for _, entry := range sorted {
 		if entry.Kind.IsMenu() || entry.Protected {
 			menu = append(menu, entry)
 		}
@@ -23,7 +24,7 @@ func selectCapabilityMenuEntries(entries []CapabilitySurface) []CapabilitySurfac
 	if len(menu) > 0 {
 		return menu
 	}
-	return SortCapabilitySurface(entries)
+	return sorted
 }
 
 // RenderCapabilityActivationDescription renders the activate_capability

--- a/internal/model/toolcatalog/render.go
+++ b/internal/model/toolcatalog/render.go
@@ -6,10 +6,17 @@ import (
 	"strings"
 )
 
+// selectCapabilityMenuEntries returns the entries that should appear
+// in the capability menu surface: every menu trailhead plus any
+// protected leaf (those are runtime-asserted gates worth surfacing for
+// situational awareness, even though the model can't activate them).
+// Falls back to all entries if no entry qualifies — covers the
+// pre-config edge case where the catalog hasn't classified anything
+// yet.
 func selectCapabilityMenuEntries(entries []CapabilitySurface) []CapabilitySurface {
 	menu := make([]CapabilitySurface, 0, len(entries))
 	for _, entry := range SortCapabilitySurface(entries) {
-		if entry.Menu {
+		if entry.Kind.IsMenu() || entry.Protected {
 			menu = append(menu, entry)
 		}
 	}

--- a/internal/tools/capability_tools.go
+++ b/internal/tools/capability_tools.go
@@ -131,17 +131,25 @@ func (r *Registry) registerActivateCapability(mgr CapabilityManager, manifest []
 			"required": []string{"tag"},
 		},
 		Handler: func(ctx context.Context, args map[string]any) (string, error) {
-			tag := extractTag(args)
-			if tag == "" {
+			rawTag := extractTag(args)
+			if rawTag == "" {
 				return "", fmt.Errorf("tag is required (e.g., activate_capability(tag: \"forge\"))")
 			}
+			// Resolve aliases before activation so the canonical name is
+			// what flows through the scope, the prompt's ## Active
+			// Capabilities section, and the persistence layer.
+			tag := toolcatalog.CanonicalTagName(rawTag)
 
 			if err := mgr.RequestCapability(ctx, tag); err != nil {
 				return "", err
 			}
 
 			var result strings.Builder
-			fmt.Fprintf(&result, "Capability **%s** activated.", tag)
+			if tag != rawTag {
+				fmt.Fprintf(&result, "Capability **%s** activated (alias for **%s**).", rawTag, tag)
+			} else {
+				fmt.Fprintf(&result, "Capability **%s** activated.", tag)
+			}
 			if m, ok := tagManifest[tag]; ok {
 				if len(m.Tools) > 0 {
 					fmt.Fprintf(&result, " %d tools now available.", len(m.Tools))
@@ -178,17 +186,24 @@ func (r *Registry) registerDeactivateCapability(mgr CapabilityManager, tagManife
 			"required": []string{"tag"},
 		},
 		Handler: func(ctx context.Context, args map[string]any) (string, error) {
-			tag := extractTag(args)
-			if tag == "" {
+			rawTag := extractTag(args)
+			if rawTag == "" {
 				return "", fmt.Errorf("tag is required (e.g., deactivate_capability(tag: \"forge\"))")
 			}
+			// Resolve aliases so deactivating by an alternate name
+			// (e.g. `homeassistant`) hits the canonical tag in scope.
+			tag := toolcatalog.CanonicalTagName(rawTag)
 
 			if err := mgr.DropCapability(ctx, tag); err != nil {
 				return "", err
 			}
 
 			var result strings.Builder
-			fmt.Fprintf(&result, "Capability **%s** deactivated.", tag)
+			if tag != rawTag {
+				fmt.Fprintf(&result, "Capability **%s** deactivated (alias for **%s**).", rawTag, tag)
+			} else {
+				fmt.Fprintf(&result, "Capability **%s** deactivated.", tag)
+			}
 			if m, ok := tagManifest[tag]; ok && len(m.Tools) > 0 {
 				fmt.Fprintf(&result, " %d tools removed.", len(m.Tools))
 			}
@@ -288,13 +303,16 @@ func (r *Registry) registerInspectCapability(tagManifest map[string]CapabilityMa
 			"required": []string{"tag"},
 		},
 		Handler: func(ctx context.Context, args map[string]any) (string, error) {
-			tag := extractTag(args)
-			if tag == "" {
+			rawTag := extractTag(args)
+			if rawTag == "" {
 				return "", fmt.Errorf("tag is required (e.g., inspect_capability(tag: \"ha\"))")
 			}
+			// Resolve aliases so inspect_capability("homeassistant")
+			// returns ha's breakdown.
+			tag := toolcatalog.CanonicalTagName(rawTag)
 			manifest, ok := tagManifest[tag]
 			if !ok {
-				return "", fmt.Errorf("unknown capability tag %q; read the ## Active Capabilities section of your prompt to see what's already loaded, or use activate_capability to discover available tags", tag)
+				return "", fmt.Errorf("unknown capability tag %q; read the ## Active Capabilities section of your prompt to see what's already loaded, or use activate_capability to discover available tags", rawTag)
 			}
 			includeExcluded, _ := args["include_excluded"].(bool)
 			entry := toolcatalog.RenderCapabilityCatalogEntry(manifest, toolcatalog.CatalogViewOptions{


### PR DESCRIPTION
Closes #910 (the talent corpus overhaul). Stacked on #921.

Treats #910's stretch goal as a redesign opportunity rather than a strict formalization — per user direction, nothing sacred. The existing tag taxonomy grew organically; this PR makes the hierarchy data-driven and cleans up the accumulated ambiguities along the way.

## What changed

### Structural

| Surface | Change |
|---|---|
| \`BuiltinTagSpec\` | New: \`Kind\` (TagKindLeaf / TagKindMenu — replaces Menu bool), \`Parents []string\` (menu(s) a leaf belongs under), \`Aliases []string\` (alternate names resolving to this canonical tag). Protected stays orthogonal. |
| \`CapabilitySurface\` | Mirrors Kind + Parents; drops Menu. |
| Tool catalog | All 20+ tools previously double-tagged \`["ha", "homeassistant"]\` now carry just \`["ha"]\`; alias machinery handles the rest. |

### Alias machinery

- \`CanonicalTagName(name)\` resolves aliases via a reverse-lookup map built at package init
- \`HasBuiltinTag\` and \`LookupBuiltinTagSpec\` both accept aliases
- \`activate_capability\` / \`deactivate_capability\` / \`inspect_capability\` handlers call \`CanonicalTagName\` before passing through; response text acknowledges the resolution (\"Capability **homeassistant** activated (alias for **ha**).\")
- Internally only canonical names exist

### Tag landscape redesign

| Concern from #910 | Resolution |
|---|---|
| \`homeassistant\` alias convention | No longer a separate spec entry. \`Aliases: ["homeassistant"]\` on \`ha\`. |
| \`companion\` menuless | \`Parents: ["operations"]\`. Promoted in operations trailhead description. |
| \`shell\` lonely leaf | \`Parents: ["development"]\`. Already mentioned in trailhead; now formalized. |
| \`ha_admin\` declared-but-unused | (Resolved earlier in PR-E.) |
| \`owner\` overloaded Menu+Protected | Split. owner is now Kind: leaf (default), Protected: true, Parents: [interactive, people]. Menu rendering filter changed to Kind.IsMenu() OR Protected so owner still surfaces for situational awareness without the overload. |

Plus opportunistic cleanup:
- **Every leaf gets Parents formalized** from the existing "Usually leads to X, Y, Z" trailhead descriptions
- **Multi-parent leaves** documented as data: \`files\` [development, knowledge], \`signal\` [interactive, people], \`web\` [development, knowledge, media]
- **Orphans rehomed**: \`archive\` → knowledge, \`awareness\` → home, \`mqtt\` → operations, \`session\` → operations. Trailhead descriptions updated to list the new children.

## Regression tests (new)

- \`TestBuiltinTagSpecs_ParentsResolveToMenuTags\` — every Parent value must point at a real tag whose Kind is TagKindMenu
- \`TestBuiltinTagSpecs_AliasesResolveToCanonicals\` — every Alias is unique and doesn't collide with a canonical name
- \`TestCanonicalTagName_ResolvesHomeAssistantAlias\` — worked example
- \`TestHasBuiltinTag_AcceptsAliases\` + \`TestLookupBuiltinTagSpec_ResolvesAliases\` — pin the alias-resolution code paths

## Consumer updates

- \`selectCapabilityMenuEntries\` filter is now \`Kind.IsMenu() OR Protected\` (was \`Menu==true\`). Both menu trailheads and protected leaves surface in the prompt menu.
- \`shouldSeedBuiltinTag\` uses \`Kind.IsMenu()\`.
- \`BuildCapabilitySurface\` propagates Kind + Parents from BuiltinTagSpec.

## Docs

- \`docs/understanding/tag-system.md\` concept matrix gains rows for Tag kind / Tag parents / Tag aliases / Protected tag (with orthogonality call-out)
- \`docs/reference/tools.md\` ha section drops the "\`ha\` / \`homeassistant\`" slash-header in favor of an explicit alias-as-resolution-mechanism note

## Scope

**8 files, +456/-73.** Mechanical rename surface is small (Menu → Kind on a handful of consumers); the bulk is the redesigned \`catalog_tags.go\` (hand-written Parents declarations across 29 tags) and the new regression tests.

Stacked on PR #921 — when that lands, rebase will be a no-op.

Refs #910 #917 #921

## Test plan
- [x] \`just ci\` clean (lint 0 issues, race tests pass, lychee 0 errors, architecture baseline unchanged)
- [x] All 5 new regression tests pass
- [x] activate_capability(tag: "homeassistant") resolves to ha; response mentions the alias
- [x] inspect_capability(tag: "homeassistant") returns ha's tool breakdown
- [x] Tools previously double-tagged \`["ha", "homeassistant"]\` now carry just \`["ha"]\`; filter still finds them via the canonical
- [ ] Spot-check the capability menu rendering shows the protected owner tag as a menu entry post-Kind-split