### PR TITLE
talents: backport prod-tested wisdom on loop authoring + forge spec discipline

### DIFF
--- a/talents/forge.md
+++ b/talents/forge.md
@@ -104,6 +104,24 @@ When the goal is "append a thought to the conversation," use
 `forge_issue_comment` instead — that's almost always what you actually
 want.
 
+## How the next reader will see this
+
+When a future model picks up this issue, it reads the title and the
+description — not the comment thread. That makes the body the
+**living spec**, not just the original framing.
+
+- As scope evolves through discussion, fold the changes back into the
+  body via `forge_issue_update`. A comment that says "actually, let's
+  also handle X" is invisible to the next implementer unless someone
+  edits it into the body.
+- Comments are conversation history, useful for audit and provenance,
+  but they don't drive the work. Plan for the description to carry
+  the full current intent on its own.
+
+The same logic applies in reverse for PRs you authored: keep the PR
+body honest about what actually landed, because the next reviewer
+reads the description, not the running commentary.
+
 ## Lightweight acknowledgement
 
 `forge_react` adds an emoji reaction to the issue itself or to one of

--- a/talents/loops.md
+++ b/talents/loops.md
@@ -59,32 +59,35 @@ durable definitions before saving them, especially when the envelope,
 jitter, or direct domain-tool access matters. Tagged service loops
 often want `profile.delegation_gating: "disabled"`.
 
-## Composing the task
+## Composing the loop
 
-A loop's `task`, `guidance`, and `output` parameters carry different
-weight. Get the boundaries right and the loop runs honestly; muddle
-them and the loop drifts.
+A `thane_curate` spec separates `intent` (what this loop tracks and
+why), `instructions` (steering text prepended to every iteration —
+the spec's `Profile.Instructions`), and `output` (the document target
+and mode). Get the boundaries right and the loop runs honestly;
+muddle them and the loop drifts.
 
-- **Document destinations belong in `output`, not in the task prose.**
-  "Update kb:foo with the current state" is the wrong shape; the loop
-  already knows where to write because `output: {document: "kb:foo",
-  mode: "maintain"}` told it. Task prose names *what to observe and
-  why it matters*, not where to write. Document management is a
-  framework concern; the task description shouldn't restate it.
+- **Document destinations belong in `output`, not in `intent`.**
+  "Update kb:foo with the current state" is the wrong shape for the
+  intent; the loop already knows where to write because `output:
+  {document: "kb:foo", mode: "maintain"}` told it. Intent names
+  *what to observe and why it matters*, not where to write. Document
+  management is a framework concern; the intent shouldn't restate it.
 
-- **Guidance tone shapes the loop's posture.** Earnest, mission-
-  focused, concrete about what to look for. Skip distracting
+- **`instructions` tone shapes the loop's posture.** Earnest,
+  mission-focused, concrete about what to look for. Skip distracting
   meta-commentary ("this is our first attempt", "let's see if this
   works") — it leaks into the loop's voice and erodes the focused
-  attention the loop is meant to embody. Treat the guidance as
+  attention the loop is meant to embody. Treat instructions as
   setting an intention, not as commentary about the experiment.
 
-- **Reach for a loop when the data is messy.** Brittle scripts win on
-  structured feeds. Loops win on human-edited sources with
-  inconsistent formatting, drifting layouts, or judgment calls about
-  what changed. If you find yourself writing fragile parsing logic
-  to coax a script through messy input, that's the signal — a loop
-  with interpretive guidance handles it more durably.
+- **Reach for a loop when the source is messy.** Scripts win on
+  structured feeds — the parser is short, the failure modes are
+  finite. Loops win on human-edited sources with inconsistent
+  formatting, drifting layouts, or judgment calls about what changed.
+  If you find yourself writing brittle parsing logic to coax a
+  script through unstructured input, that's the signal — a loop
+  with interpretive instructions handles it more durably.
 
 When you need concrete JSON launch patterns, activate `loops_examples`
 and adapt the closest recipe minimally.

--- a/talents/loops.md
+++ b/talents/loops.md
@@ -59,5 +59,32 @@ durable definitions before saving them, especially when the envelope,
 jitter, or direct domain-tool access matters. Tagged service loops
 often want `profile.delegation_gating: "disabled"`.
 
+## Composing the task
+
+A loop's `task`, `guidance`, and `output` parameters carry different
+weight. Get the boundaries right and the loop runs honestly; muddle
+them and the loop drifts.
+
+- **Document destinations belong in `output`, not in the task prose.**
+  "Update kb:foo with the current state" is the wrong shape; the loop
+  already knows where to write because `output: {document: "kb:foo",
+  mode: "maintain"}` told it. Task prose names *what to observe and
+  why it matters*, not where to write. Document management is a
+  framework concern; the task description shouldn't restate it.
+
+- **Guidance tone shapes the loop's posture.** Earnest, mission-
+  focused, concrete about what to look for. Skip distracting
+  meta-commentary ("this is our first attempt", "let's see if this
+  works") — it leaks into the loop's voice and erodes the focused
+  attention the loop is meant to embody. Treat the guidance as
+  setting an intention, not as commentary about the experiment.
+
+- **Reach for a loop when the data is messy.** Brittle scripts win on
+  structured feeds. Loops win on human-edited sources with
+  inconsistent formatting, drifting layouts, or judgment calls about
+  what changed. If you find yourself writing fragile parsing logic
+  to coax a script through messy input, that's the signal — a loop
+  with interpretive guidance handles it more durably.
+
 When you need concrete JSON launch patterns, activate `loops_examples`
 and adapt the closest recipe minimally.


### PR DESCRIPTION
## Summary

Final wrap-up of the #910 talent corpus overhaul: two doctrinal
observations that emerged from real-world production usage but weren't
captured by the audit cycle. Sourced from
`/Volumes/Thane/knowledge/architecture/spawned-loops-as-distributed-cognition.md`
and `/Volumes/Thane/knowledge/forge/issue-writing.md` — both audited
for host-agnostic wisdom (anything site-specific like Comal County,
the ranch, HPDE, etc. was stripped during translation).

## Investigation method

Audited `/Volumes/Thane/talents/` (~30 files) and
`/Volumes/Thane/knowledge/` (architecture, channels, core, forge,
identity subtrees) against the current in-repo `talents/`. Prod is
essentially a 2026-05-01 snapshot — the corpus has moved significantly
since via the #910 multi-node-tree restructure, so the question was
not "what's drifted" but "what wisdom did prod use teach us that the
audit overlooked?" Three candidates surfaced; two are real and now
captured here.

## Changes

### `talents/loops.md` — new "Composing the task" section

Three anti-patterns from real curate-loop authoring:

1. **Document destinations belong in `output:`, not in the task prose.**
   The loop already knows where to write because `output: {document:
   "...", mode: "..."}` told it. Task prose is about what to observe
   and why it matters. Restating the destination in the task description
   muddies the boundary.

2. **Guidance tone shapes the loop's posture.** Meta-commentary like
   "this is our first attempt" or "let's see if this works" leaks
   into the loop's voice and erodes the focused attention the loop is
   meant to embody. Guidance sets intention; it doesn't narrate the
   experiment.

3. **Reach for a loop when the data source is messy.** Scripts win on
   structured feeds; loops win on human-edited sources with drifting
   layouts and judgment calls. Fragile parsing logic against messy
   input is the signal to switch.

### `talents/forge.md` — new "How the next reader will see this" subsection

The strategic complement to the existing mechanical "body REPLACES"
gotcha: a future model picks up an issue from title + description
only — comments are invisible by default. That makes the body the
**living spec**, not just the original framing. Scope changes from
discussion need to be folded into the description; same logic for PR
bodies. Sits as a new subsection in `forge_known_issue` right after
the body-REPLACES gotcha and before the lightweight-acknowledgement
section.

## Considered and skipped

Production's `spawned-loops-as-distributed-cognition.md` also describes
a "tagged entity subscription" pattern (tag the entity with `burn-ban`,
tag the loop with `burn-ban`, expect automatic context injection).
**Verified not real today** — `update_entity_subscriptions` has no
tags parameter; subscriptions are explicitly bound to a named loop
via `Spec.Subscriptions`. The prod doc captured an aspirational
design that didn't ship. Skipped.

## Test plan

- [x] `just ci` passes locally
- [x] `TestRepoTalentToolReferences` passes (no new tool name claims)
- [x] `TestRepoTrailheadNextTagsResolve` passes (no new tag refs)
- [x] Sanity-read: `talents/loops.md` "Composing the task" reads as
      authoring doctrine, not as commentary
- [x] Sanity-read: `talents/forge.md` next-reader subsection
      complements (doesn't duplicate) the body-REPLACES gotcha

Closes the final wrap of #910 (talent corpus overhaul).