### PR TITLE
docs(tag-system): document Tool.Core and configured_tags

### DIFF
--- a/docs/understanding/glossary.md
+++ b/docs/understanding/glossary.md
@@ -62,6 +62,27 @@ while preserving semantic content. Compaction happens automatically when
 a conversation approaches context limits. The LLM generates the summary,
 preserving decisions, facts, and preferences.
 
+### Configured Tags
+
+A read-only snapshot of the tag inputs declared at loop launch — the
+loop spec's `Tags` plus any request-base or request-override
+`InitialTags` — frozen so dashboards and forensic event payloads can
+compare "what was configured" against "what became active." Three
+adjacent concepts to keep distinct:
+
+- **`Spec.Tags`** — what the loop definition declares.
+- **`ActiveTags`** (on the run's `Response`) — what became active
+  during the run after the model's activations and deactivations.
+- **Configured tags** — the frozen launch-time snapshot, surfaced on
+  `ToolingState.ConfiguredTags`.
+
+The forensic motivation: when a loop's runtime active set diverges
+from what the spec declared, the configured-tag snapshot is the
+read-only baseline that surfaces "what the operator asked for vs.
+what happened." See [The Tag System](tag-system.md) (concept matrix
+row "Configured tags") and `internal/runtime/loop/doc.go` for where
+the snapshot gets taken in the lifecycle.
+
 ### Context Layer
 
 One of the distinct sections of the system prompt, each with a specific

--- a/docs/understanding/tag-system.md
+++ b/docs/understanding/tag-system.md
@@ -66,9 +66,10 @@ boundaries, that's a smell.
 [pr-813]: https://github.com/nugget/thane-ai-agent/pull/813
 
 The glossary in [docs/understanding/glossary.md](glossary.md) covers
-the user-facing definitions of *Capability Tag*, *Lens*, *Talent*,
-and *Routing Profile*. This doc is the technical companion that adds
-the disambiguations the glossary doesn't need to make.
+the user-facing definitions of *Capability Tag*, *Configured Tags*,
+*Lens*, *Talent*, and *Routing Profile*. This doc is the technical
+companion that adds the disambiguations the glossary doesn't need to
+make.
 
 ## The lifecycle
 
@@ -140,6 +141,40 @@ The combinatorics are deliberate but easy to mis-compose. Always-on
 preservation is at the *tool* level; always-on tagging is at the
 *tag* level; explicit exclusions can override either. When in doubt,
 read the test for the case you're touching.
+
+### Why Tool.Core exists
+
+`Tool.Core` is the one knob in the table above that operates at the
+*tool* level rather than the *tag* level — it exempts a tool from
+`FilterByTags` so the tool stays in the catalog even when its tags
+(if any) aren't active. Two distinct needs ride this single flag:
+
+**Meta-tools must be reachable from any scope.** `tag_activate`,
+`tag_deactivate`, `tag_inspect`, `tag_reset`, and the other
+tag-navigation tools are themselves part of the contract that makes
+tags safe to mutate at runtime: a model that wanders into a
+too-restrictive tag set has to be able to widen scope from where it
+stands. If those tools were tag-gated, the activation prompt would
+become the only widening path, and runtime tag mutation would lose
+its symmetry. Marking the navigation tools `Core` keeps the door
+open in both directions.
+
+**Request-scoped `RuntimeTools` join the catalog via this flag,
+not via tags.** When the agent loop calls
+`WithRuntimeTools(req.RuntimeTools)` it inserts request-provided
+tools into the registry view with `Core = true` automatically. The
+contract for `RuntimeTools` is "this request provides these tools;
+they're available for this run regardless of the active tag set" —
+which is exactly what `Core` delivers. Treating them as `Core` is
+the mechanism; the request is the source of truth.
+
+The flag is intentionally not configurable from outside the Go
+source. A tag-system that let arbitrary tools opt out of filtering
+would defeat the point of the filter. New tools that genuinely
+need this property declare `Core: true` at registration, and the
+review for "is this really a third use case?" lives at the code
+review, not in config. If you find yourself reaching for it for a
+third reason, that's a smell — read this section first.
 
 ### The two-layer delegate exclusion (this is load-bearing)
 
@@ -260,25 +295,13 @@ code; some are queued as cleanup work.
    "combine these tag slices and dedup." A unified helper would
    reduce drift risk. Tracked as a follow-up.
 
-3. **`configured_tags` is undocumented user-facing.** Introduced in
-   [#813][pr-813] for telemetry/forensics, but the concept lives in a
-   field comment. Worth a glossary entry once we're sure the
-   user-facing surface is stable.
-
-4. **Test coverage is path-asymmetric.** Today's bug ([#833][pr-833])
+3. **Test coverage is path-asymmetric.** Today's bug ([#833][pr-833])
    existed because the empty-scope delegate path was tested but the
    tag-scoped path wasn't. Several other branch-condition pairs in
    [`prepareExecution`][prepare-execution] have similar asymmetry —
    worth a sweep.
 
-5. **Core has no architectural doc.** The flag exists on
-   `Tool`, the docstring says "Survives capability tag filtering,"
-   but the *why* (meta-tools must survive the filter so the model can
-   navigate, runtime tools join via this mechanism) lives in scattered
-   comments. A short note in this doc or in `tools/doc.go` would
-   close the gap.
-
-6. **Two-layer exclusion has no helper.** Documented above, but
+4. **Two-layer exclusion has no helper.** Documented above, but
    currently expressed only as "remember to do this in both places."
    A helper that returns both the in-process filter and the
    request-level exclusion list would make the invariant

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -32,17 +32,25 @@ import (
 
 // Tool represents a callable tool.
 type Tool struct {
-	Name                 string                                                         `json:"name"`
-	Description          string                                                         `json:"description"`
-	Parameters           map[string]any                                                 `json:"parameters"`
-	Handler              func(ctx context.Context, args map[string]any) (string, error) `json:"-"`
-	Core                 bool                                                           `json:"-"` // Core tool — survives capability tag filtering regardless of scope.
-	SkipContentResolve   bool                                                           `json:"-"` // Exempt from prefix-to-content resolution.
-	ContentResolveExempt []string                                                       `json:"-"` // Top-level arg keys that must remain literal during content resolution.
-	CanonicalID          string                                                         `json:"-"`
-	Source               string                                                         `json:"-"`
-	Origin               string                                                         `json:"-"`
-	Tags                 []string                                                       `json:"-"`
+	Name        string                                                         `json:"name"`
+	Description string                                                         `json:"description"`
+	Parameters  map[string]any                                                 `json:"parameters"`
+	Handler     func(ctx context.Context, args map[string]any) (string, error) `json:"-"`
+	// Core marks the tool as exempt from capability-tag filtering: it
+	// stays in the catalog even when its tags (if any) aren't active.
+	// Two distinct use cases ride this flag — meta-tools that must be
+	// reachable from any scope so the tag system itself remains
+	// navigable (tag_activate, tag_inspect, and friends), and
+	// request-scoped tools layered in via WithRuntimeTools (where the
+	// contract is "available for this run regardless of active tags").
+	// See docs/understanding/tag-system.md, "Why Tool.Core exists".
+	Core                 bool     `json:"-"`
+	SkipContentResolve   bool     `json:"-"` // Exempt from prefix-to-content resolution.
+	ContentResolveExempt []string `json:"-"` // Top-level arg keys that must remain literal during content resolution.
+	CanonicalID          string   `json:"-"`
+	Source               string   `json:"-"`
+	Origin               string   `json:"-"`
+	Tags                 []string `json:"-"`
 }
 
 // Registry holds available tools.


### PR DESCRIPTION
## Summary

Closes two long-standing documentation gaps that were tracked as
\"Smells\" in [docs/understanding/tag-system.md](docs/understanding/tag-system.md). Both fixes are doc-only — no behavior change.

### Tool.Core — closes #842

- Extend the [\`Tool.Core\` field Godoc](internal/tools/tools.go) from a one-line inline comment to a block comment that names the two use cases (meta-tools that must stay reachable for tag navigation; request-scoped \`RuntimeTools\` that join the catalog via this flag) and points at the new architectural subsection.
- Add a **\"Why Tool.Core exists\"** subsection under \"Tool catalog construction\" in [docs/understanding/tag-system.md](docs/understanding/tag-system.md) so the rationale is discoverable from the ToC instead of being scattered across the concept matrix row, the diagram narrative, and the \"Filtering knobs\" table.
- Drop Smell #5 (\"Core has no architectural doc\") from the same doc — now covered.

### configured_tags — closes #841

- Add a **\"Configured Tags\"** entry to [docs/understanding/glossary.md](docs/understanding/glossary.md) that distinguishes \`Spec.Tags\` (what the loop declares), \`ActiveTags\` (what became active during the run), and the configured-tag snapshot (the frozen launch-time read-only baseline). Forensic motivation up front, code pointer to \`ToolingState.ConfiguredTags\`.
- Update tag-system.md's glossary cross-reference paragraph to list *Configured Tags* alongside the other terms it mentions.
- Drop Smell #3 (\"configured_tags is undocumented user-facing\") — now covered.

## Notes on the diff shape

gofmt rewrapped the \`Tool\` struct field-tag columns into two groups around the new block comment. That's the expected formatter output when a struct mixes inline and block field comments — fields above the block stay column-aligned with each other, fields below the block re-align tighter. Mechanical, not a style choice.

## Test plan

- [x] \`just ci\` passes (fmt-check, mod-tidy-check, config-generate-check, architecture-check, link-check, lint @ 0 issues, race tests).
- [x] \`go doc github.com/nugget/thane-ai-agent/internal/tools Tool\` renders the new \`Core\` doc as a multi-line field comment.
- [x] Both files render in GitHub markdown — no broken links, ToC picks up \"Why Tool.Core exists\".