### PR TITLE
feat(thane): add `thane validate` subcommand for config pre-flight

### DIFF
--- a/cmd/thane/main.go
+++ b/cmd/thane/main.go
@@ -127,6 +127,8 @@ func run(ctx context.Context, stdout io.Writer, stderr io.Writer, args []string)
 			dir = cmdArgs[0]
 		}
 		return runInit(stdout, dir)
+	case "validate":
+		return runValidate(stdout, configPath, outputFmt)
 	case "ask":
 		if len(cmdArgs) == 0 {
 			return fmt.Errorf("usage: thane ask <question>")
@@ -176,6 +178,7 @@ func printUsage(w io.Writer) error {
 	fmt.Fprintln(w, "Commands:")
 	fmt.Fprintln(w, "  serve        Start the API server")
 	fmt.Fprintln(w, "  init [dir]   Initialize working directory with defaults (default: .)")
+	fmt.Fprintln(w, "  validate     Parse and validate the config without starting services")
 	fmt.Fprintln(w, "  ask          Ask a single question (for testing)")
 	fmt.Fprintln(w, "  ingest       Import markdown docs into fact store")
 	fmt.Fprintln(w, "  caps         Show resolved capability tags from a running daemon")

--- a/cmd/thane/validate.go
+++ b/cmd/thane/validate.go
@@ -24,6 +24,13 @@ import (
 // piping into jq.
 func runValidate(w io.Writer, configPath, outputFmt string) error {
 	cfg, cfgPath, loadErr := loadConfig(configPath)
+	// When discovery fails before a path is resolved, fall back to
+	// the operator's explicit -config value so the JSON report still
+	// names the file that was at fault. Stays empty when neither
+	// resolution nor an explicit flag was provided.
+	if cfgPath == "" {
+		cfgPath = configPath
+	}
 	if outputFmt == "json" {
 		// Always emit JSON to stdout, even on failure — scripts may
 		// want the structured error. The error is still returned so
@@ -64,8 +71,11 @@ func writeValidateText(w io.Writer, cfg *config.Config) {
 // writeValidateJSON emits the structured validation report. cfg may be
 // nil when load failed; loadErr is non-nil when validation failed.
 func writeValidateJSON(w io.Writer, cfgPath string, cfg *config.Config, loadErr error) error {
+	// Path always emits (no omitempty) so the JSON schema is stable
+	// for scripts piping into jq — even discovery-failure cases get
+	// a path field, possibly empty.
 	result := struct {
-		Path    string         `json:"path,omitempty"`
+		Path    string         `json:"path"`
 		Valid   bool           `json:"valid"`
 		Error   string         `json:"error,omitempty"`
 		Summary map[string]any `json:"summary,omitempty"`

--- a/cmd/thane/validate.go
+++ b/cmd/thane/validate.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"github.com/nugget/thane-ai-agent/internal/platform/config"
+)
+
+// runValidate parses and validates the config that would be loaded by
+// `thane serve`. It does not start any services or open any sockets —
+// this is purely a pre-flight gate for scripts and operators.
+//
+// The configPath argument follows the same convention as other
+// subcommands: when empty, [config.FindConfig] walks the standard
+// search order; when set, that exact path is used. The returned error
+// signals "config is invalid" so the binary exits non-zero, which
+// makes `thane validate && thane serve` a usable deploy guard.
+//
+// Output mode "text" prints a one-line confirmation followed by a
+// short structural summary. Mode "json" emits a single object with
+// path, valid, error (if any), and summary fields, suitable for
+// piping into jq.
+func runValidate(w io.Writer, configPath, outputFmt string) error {
+	cfg, cfgPath, loadErr := loadConfig(configPath)
+	if outputFmt == "json" {
+		// Always emit JSON to stdout, even on failure — scripts may
+		// want the structured error. The error is still returned so
+		// the exit code reflects validity.
+		if err := writeValidateJSON(w, cfgPath, cfg, loadErr); err != nil {
+			return err
+		}
+		return loadErr
+	}
+	if loadErr != nil {
+		return loadErr
+	}
+	fmt.Fprintf(w, "✓ Config valid: %s\n\n", cfgPath)
+	writeValidateText(w, cfg)
+	return nil
+}
+
+// writeValidateText prints the per-section structural summary used by
+// the default text output mode. Counts and presence checks are enough
+// to confirm "is the config I edited really the one that loaded?"
+// without dumping the parsed struct.
+func writeValidateText(w io.Writer, cfg *config.Config) {
+	fmt.Fprintf(w, "  Default model:        %s\n", cfg.Models.Default)
+	fmt.Fprintf(w, "  Model resources:      %d\n", len(cfg.Models.Resources))
+	fmt.Fprintf(w, "  Models available:     %d\n", len(cfg.Models.Available))
+	// cfg.Roots is normalized into cfg.Paths during Load; count there.
+	fmt.Fprintf(w, "  Document roots:       %d\n", len(cfg.Paths))
+	fmt.Fprintf(w, "  Capability tags:      %d\n", len(cfg.CapabilityTags))
+	fmt.Fprintf(w, "  Channel→tag binds:    %d\n", len(cfg.ChannelTags))
+	fmt.Fprintf(w, "  MCP servers:          %d\n", len(cfg.MCP.Servers))
+	fmt.Fprintf(w, "  Home Assistant:       %v\n", cfg.HomeAssistant.Configured())
+	fmt.Fprintf(w, "  Signal bridge:        %v\n", cfg.Signal.Enabled)
+	fmt.Fprintf(w, "  Embeddings:           %v\n", cfg.Embeddings.Enabled)
+	fmt.Fprintf(w, "  Metacognitive loop:   %v\n", cfg.Metacognitive.Enabled)
+	fmt.Fprintf(w, "  Ego loop:             %v\n", cfg.Ego.Enabled)
+}
+
+// writeValidateJSON emits the structured validation report. cfg may be
+// nil when load failed; loadErr is non-nil when validation failed.
+func writeValidateJSON(w io.Writer, cfgPath string, cfg *config.Config, loadErr error) error {
+	result := struct {
+		Path    string         `json:"path,omitempty"`
+		Valid   bool           `json:"valid"`
+		Error   string         `json:"error,omitempty"`
+		Summary map[string]any `json:"summary,omitempty"`
+	}{
+		Path:  cfgPath,
+		Valid: loadErr == nil,
+	}
+	if loadErr != nil {
+		result.Error = loadErr.Error()
+	} else if cfg != nil {
+		result.Summary = map[string]any{
+			"default_model":            cfg.Models.Default,
+			"model_resources":          len(cfg.Models.Resources),
+			"models_available":         len(cfg.Models.Available),
+			"roots":                    len(cfg.Paths),
+			"capability_tags":          len(cfg.CapabilityTags),
+			"channel_tags":             len(cfg.ChannelTags),
+			"mcp_servers":              len(cfg.MCP.Servers),
+			"homeassistant_configured": cfg.HomeAssistant.Configured(),
+			"signal_enabled":           cfg.Signal.Enabled,
+			"embeddings_enabled":       cfg.Embeddings.Enabled,
+			"metacognitive_enabled":    cfg.Metacognitive.Enabled,
+			"ego_enabled":              cfg.Ego.Enabled,
+		}
+	}
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(result)
+}

--- a/cmd/thane/validate_test.go
+++ b/cmd/thane/validate_test.go
@@ -1,0 +1,164 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// minimalValidConfig returns the smallest config.yaml body that parses
+// and survives semantic validation. Tests use it as a known-good base
+// to layer breakages on top of.
+const minimalValidConfig = `
+listen:
+  port: 8080
+models:
+  default: test-model
+  available:
+    - name: test-model
+      provider: ollama
+      supports_tools: true
+      context_window: 4096
+      speed: 5
+      quality: 5
+`
+
+func writeConfig(t *testing.T, body string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	return path
+}
+
+func TestRunValidate_HappyPath(t *testing.T) {
+	path := writeConfig(t, minimalValidConfig)
+	var buf bytes.Buffer
+
+	if err := runValidate(&buf, path, "text"); err != nil {
+		t.Fatalf("runValidate: %v", err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "✓ Config valid") {
+		t.Errorf("expected success marker, got:\n%s", out)
+	}
+	if !strings.Contains(out, path) {
+		t.Errorf("expected output to mention config path, got:\n%s", out)
+	}
+	if !strings.Contains(out, "Default model:") {
+		t.Errorf("expected summary section, got:\n%s", out)
+	}
+}
+
+func TestRunValidate_MissingFile(t *testing.T) {
+	var buf bytes.Buffer
+	err := runValidate(&buf, "/nonexistent/path/config.yaml", "text")
+	if err == nil {
+		t.Fatal("expected error for missing file, got nil")
+	}
+	// loadConfig is the call that fails; the error path should mention
+	// what was tried so the operator knows what to fix.
+	if buf.Len() != 0 {
+		t.Errorf("expected no stdout on failure (text mode), got:\n%s", buf.String())
+	}
+}
+
+func TestRunValidate_ParseError(t *testing.T) {
+	path := writeConfig(t, "models:\n  default: [this isn't a string\n")
+	var buf bytes.Buffer
+
+	err := runValidate(&buf, path, "text")
+	if err == nil {
+		t.Fatal("expected parse error, got nil")
+	}
+}
+
+// TestRunValidate_SemanticError exercises the cross-key validation hook
+// that catches dangling references between channel_tags and the union
+// of canonical + operator-defined capability tags. The same hook is
+// what caught the signal_channel orphan in the v0.9.3 deploy draft.
+func TestRunValidate_SemanticError(t *testing.T) {
+	body := minimalValidConfig + `
+channel_tags:
+  signal:
+    - definitely_not_a_real_tag
+`
+	path := writeConfig(t, body)
+	var buf bytes.Buffer
+
+	err := runValidate(&buf, path, "text")
+	if err == nil {
+		t.Fatal("expected semantic error for undefined tag reference, got nil")
+	}
+	if !strings.Contains(err.Error(), "definitely_not_a_real_tag") {
+		t.Errorf("error should mention the offending tag name, got: %v", err)
+	}
+}
+
+func TestRunValidate_JSONHappyPath(t *testing.T) {
+	path := writeConfig(t, minimalValidConfig)
+	var buf bytes.Buffer
+
+	if err := runValidate(&buf, path, "json"); err != nil {
+		t.Fatalf("runValidate: %v", err)
+	}
+
+	var got struct {
+		Path    string         `json:"path"`
+		Valid   bool           `json:"valid"`
+		Error   string         `json:"error"`
+		Summary map[string]any `json:"summary"`
+	}
+	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+		t.Fatalf("json output is not valid JSON: %v\nbody:\n%s", err, buf.String())
+	}
+	if !got.Valid {
+		t.Errorf("expected valid=true, got false (error=%q)", got.Error)
+	}
+	if got.Path != path {
+		t.Errorf("path = %q, want %q", got.Path, path)
+	}
+	if got.Summary == nil {
+		t.Error("expected summary on success")
+	}
+	if model, _ := got.Summary["default_model"].(string); model != "test-model" {
+		t.Errorf("default_model in summary = %q, want %q", model, "test-model")
+	}
+}
+
+func TestRunValidate_JSONFailure(t *testing.T) {
+	body := minimalValidConfig + `
+channel_tags:
+  signal:
+    - definitely_not_a_real_tag
+`
+	path := writeConfig(t, body)
+	var buf bytes.Buffer
+
+	err := runValidate(&buf, path, "json")
+	if err == nil {
+		t.Fatal("expected error from runValidate, got nil")
+	}
+
+	// JSON should be emitted to the writer even on failure — the
+	// structured report is the whole point of -o json.
+	var got struct {
+		Valid bool   `json:"valid"`
+		Error string `json:"error"`
+	}
+	if jerr := json.Unmarshal(buf.Bytes(), &got); jerr != nil {
+		t.Fatalf("json output is not valid JSON: %v\nbody:\n%s", jerr, buf.String())
+	}
+	if got.Valid {
+		t.Error("expected valid=false on semantic error")
+	}
+	if !strings.Contains(got.Error, "definitely_not_a_real_tag") {
+		t.Errorf("json error field should name the offending tag, got: %q", got.Error)
+	}
+}

--- a/cmd/thane/validate_test.go
+++ b/cmd/thane/validate_test.go
@@ -132,6 +132,44 @@ func TestRunValidate_JSONHappyPath(t *testing.T) {
 	}
 }
 
+// TestRunValidate_JSONDiscoveryFailure guards the stable-schema
+// promise: even when config discovery fails before a path is
+// resolved, the JSON report still includes the path field (populated
+// from the operator's explicit -config value) so scripts piping into
+// jq don't have to handle two schema shapes.
+func TestRunValidate_JSONDiscoveryFailure(t *testing.T) {
+	const explicit = "/nonexistent/never-going-to-exist.yaml"
+	var buf bytes.Buffer
+
+	err := runValidate(&buf, explicit, "json")
+	if err == nil {
+		t.Fatal("expected error for missing file, got nil")
+	}
+
+	var got map[string]any
+	if jerr := json.Unmarshal(buf.Bytes(), &got); jerr != nil {
+		t.Fatalf("json output is not valid JSON: %v\nbody:\n%s", jerr, buf.String())
+	}
+	pathField, present := got["path"]
+	if !present {
+		t.Errorf("path field must be present in JSON output even on discovery failure; got keys: %v", keysOf(got))
+	}
+	if got, _ := pathField.(string); got != explicit {
+		t.Errorf("path = %q, want %q (operator's -config value)", got, explicit)
+	}
+	if v, _ := got["valid"].(bool); v {
+		t.Error("valid should be false on discovery failure")
+	}
+}
+
+func keysOf(m map[string]any) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}
+
 func TestRunValidate_JSONFailure(t *testing.T) {
 	body := minimalValidConfig + `
 channel_tags:


### PR DESCRIPTION
## Summary

Adds a top-level `thane validate` subcommand that parses and semantically validates the config a `thane serve` would load — without starting any services or opening any sockets. Designed as a pre-deploy gate.

```sh
thane validate && thane serve     # exits non-zero on bad config
thane -o json validate | jq .     # structured report for scripting
```

The validation logic is `config.Load()` itself, so YAML parse errors AND cross-key semantic checks (dangling `channel_tags` references, `prewarm.archive` bounds, model resource references, etc.) flow through the same path the server uses on startup. No new validation surface to keep in sync.

## Output

**Text mode (default)** — one-line confirmation + structural summary:

```
✓ Config valid: /Users/aimee/Thane/config.yaml

  Default model:        claude-opus-4-7
  Model resources:      4
  Models available:     3
  Document roots:       7
  Capability tags:      1
  Channel→tag binds:    2
  MCP servers:          1
  Home Assistant:       true
  Signal bridge:        true
  Embeddings:           false
  Metacognitive loop:   true
  Ego loop:             true
```

**JSON mode (`-o json`)** — single structured object:

```json
{
  "path": "/Users/aimee/Thane/config.yaml",
  "valid": false,
  "error": "load config ...: channel_tags.signal references undefined capability tag \"signal_channel\"",
}
```

## Why now

Came out of the v0.9.3 production upgrade work — I was hand-rolling a one-shot Go program to validate the new config draft against `config.Load()`. The user (rightly) pointed out this is a durable utility that belongs in the CLI alongside `thane init`. First use already caught a real config drift (a dangling `channel_tags` reference in the upgrade draft).

## Implementation notes

- New file `cmd/thane/validate.go` (~100 lines). Same `loadConfig()` helper that `serve` uses.
- One-line addition to `cmd/thane/main.go`'s switch + a line in the usage text.
- `cfg.Roots` is normalized into `cfg.Paths` by `config.Load()` (the unified `roots:` → legacy `paths:` shim). The summary reads from `cfg.Paths` to get the operator-intent count.
- Both text and JSON modes return non-zero on failure; JSON mode also writes the report to stdout before the non-zero exit, matching the structured-output expectations of `-o json` scripts.

## Test plan

- [x] `just ci` passes locally (fmt-check, mod-tidy-check, config-generate-check, architecture-check, link-check, lint @ 0 issues, race tests)
- [x] `TestRunValidate_HappyPath` against a minimal valid config
- [x] `TestRunValidate_MissingFile` — error + no stdout
- [x] `TestRunValidate_ParseError` — invalid YAML
- [x] `TestRunValidate_SemanticError` — dangling `channel_tags` ref (this is the case that prompted the work)
- [x] `TestRunValidate_JSONHappyPath` — JSON shape + summary populated
- [x] `TestRunValidate_JSONFailure` — JSON emitted with `valid: false` on failure
- [x] Smoke-tested against `examples/config.example.yaml` (passes) and the v0.9.3 prod-upgrade draft (now passes after fixing the `signal_channel` orphan)