### PR TITLE
refactor(toolcatalog): remove the tag alias mechanism

### DIFF
--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -96,11 +96,6 @@ clear forecast fetching for that subscription.
 
 ## `ha` — Home Assistant state and control
 
-`homeassistant` is an alias that resolves to `ha`. Either name works at
-`tag_activate`; the canonical name `ha` is what flows through the
-scope and prompt rendering.
-
-
 | Tool | Description |
 |------|-------------|
 | `ha_control_device` | Natural-language device control with fuzzy entity matching. |

--- a/docs/tool-and-talent-audit.md
+++ b/docs/tool-and-talent-audit.md
@@ -43,7 +43,7 @@ A full audit should be triggered by:
   integration, future Notion integration)
 - **A new tool family is added** (3+ new tools that share a domain,
   e.g., `doc_intake` / `doc_commit` added a curate pipeline)
-- **A capability tag is renamed or repurposed** (the alias/parent
+- **A capability tag is renamed or repurposed** (the parent
   machinery may need updating)
 - **A taxonomy reshape lands** (PR-G's hierarchy formalization was
   the last one)

--- a/docs/understanding/tag-system.md
+++ b/docs/understanding/tag-system.md
@@ -47,7 +47,6 @@ boundaries, that's a smell.
 | **Core tag** | Tags pinned in every scope by config. | [`Executor.SetCoreTags`][exec-core], config `capability_tags.*.core`. | Tag-level, not tool-level. Re-seeded each run. |
 | **Tag kind** | Tag's surface role: leaf (carries tools) vs. menu (coarse trailhead routing to leaves). | [`BuiltinTagSpec.Kind`][tag-spec]. | Orthogonal to Protected. Menus surface as routing entries in the activation prompt; leaves carry tool surface. |
 | **Tag parents** | Menu(s) a leaf appears under in the hierarchical menu. Multi-valued. | [`BuiltinTagSpec.Parents`][tag-spec]. | Data, not prose. Replaces the "usually leads to X, Y, Z" sentences that were the only menu→leaf mapping before PR-G. |
-| **Tag aliases** | Alternate names that resolve to a canonical tag at every system boundary (tag_activate, channel binding, config). | [`BuiltinTagSpec.Aliases`][tag-spec], [`CanonicalTagName`][tag-canonical]. | Internally only canonical names exist; aliases funnel in at boundaries via reverse-lookup map populated at init. `homeassistant` resolves to `ha`. |
 | **Protected tag** | Runtime-asserted; can't be model-toggled. | [`BuiltinTagSpec.Protected`][tag-spec]. | Orthogonal to Kind. A leaf can be protected (`message_channel`, `owner`) without being a menu. |
 | **Delegate profile** (`delegate.Profile`) | Operational bundle for a delegated task: max iterations, max duration, token budget, tool timeout, default tags, router hints. | [`delegate/profile.go`][delegate-profile]. | Operational *constraints*. No relation to tool gating beyond `DefaultTags`. |
 | **Loop profile** (`router.LoopProfile`) | Routing/behavior bundle: model selection, mission, quality floor, instructions. | [`router/loopprofile.go`][loop-profile]. | Routing and prompt-shaping. No relation to tool gating except via `ExcludeTools`. |
@@ -62,7 +61,6 @@ boundaries, that's a smell.
 [loop-profile]: ../../internal/model/router/loopprofile.go
 [configured-tags]: ../../internal/runtime/loop/tooling.go
 [tag-spec]: ../../internal/model/toolcatalog/catalog.go
-[tag-canonical]: ../../internal/model/toolcatalog/catalog.go
 [pr-813]: https://github.com/nugget/thane-ai-agent/pull/813
 
 The glossary in [docs/understanding/glossary.md](glossary.md) covers

--- a/examples/config.example.yaml
+++ b/examples/config.example.yaml
@@ -609,7 +609,7 @@ talents_dir: ./talents
 #       at load time, so per-iteration capability tag activation
 #       continues to work even after the inline-routing form retires.
 #       initial_tags:
-#         - homeassistant
+#         - ha
 #   Telemetry configures operational metric publishing. When enabled,
 #   a separate mqtt-telemetry loop publishes system health, token usage,
 #   loop states, and other operational data as native HA sensors.
@@ -992,7 +992,7 @@ ego:
 #               start: 08:30
 #               end: 18:00
 #       tags:
-#         - homeassistant
+#         - ha
 #       exclude_tools: []
 #       sleep_min: 2m
 #       sleep_max: 10m

--- a/internal/model/toolcatalog/catalog.go
+++ b/internal/model/toolcatalog/catalog.go
@@ -55,10 +55,12 @@ func (k TagKind) IsMenu() bool {
 // shape grew incrementally and was formalized in PR-G as part of the
 // #910 talent corpus overhaul to make tag-grouping data instead of
 // prose: leaf tags point at the menu(s) they belong under via
-// [Parents]. Tag names are first-class — there is no alias mechanism;
-// every external surface (operator config, channel bindings, loop
-// specs, persisted scope, talents, knowledge frontmatter) must spell
-// each tag with its canonical name.
+// [Parents]. Built-in tag names have no aliases — every external
+// surface (operator config, channel bindings, loop specs, persisted
+// scope, talents, knowledge frontmatter) must spell each built-in
+// tag with its compiled-in name. Operators may still define their
+// own ad-hoc tags via the capability_tags YAML overlay; those names
+// pass through verbatim.
 type BuiltinTagSpec struct {
 	// Description is the short, model-facing summary rendered into
 	// the tag menu and tag_inspect output.

--- a/internal/model/toolcatalog/catalog.go
+++ b/internal/model/toolcatalog/catalog.go
@@ -5,7 +5,6 @@ package toolcatalog
 
 import (
 	"encoding/json"
-	"fmt"
 	"sort"
 )
 
@@ -55,9 +54,11 @@ func (k TagKind) IsMenu() bool {
 // BuiltinTagSpec captures compiled-in metadata for a tag/toolset. The
 // shape grew incrementally and was formalized in PR-G as part of the
 // #910 talent corpus overhaul to make tag-grouping data instead of
-// prose: leaf tags now point at the menu(s) they belong under via
-// [Parents], and alternate names funnel through [Aliases] at activation
-// time instead of being separately-declared spec entries.
+// prose: leaf tags point at the menu(s) they belong under via
+// [Parents]. Tag names are first-class — there is no alias mechanism;
+// every external surface (operator config, channel bindings, loop
+// specs, persisted scope, talents, knowledge frontmatter) must spell
+// each tag with its canonical name.
 type BuiltinTagSpec struct {
 	// Description is the short, model-facing summary rendered into
 	// the tag menu and tag_inspect output.
@@ -91,14 +92,6 @@ type BuiltinTagSpec struct {
 	// menus themselves and for tags that don't fit any menu — those
 	// surface as top-level entries in the menu rendering.
 	Parents []string
-
-	// Aliases lists alternate names that resolve to this canonical
-	// tag. Most relevant for backward-compatible renames or
-	// operator-friendly synonyms (e.g. `homeassistant` resolves to
-	// `ha`). Resolution happens at every boundary the tag enters the
-	// system: tag_activate / tag_inspect calls, channel-tag binding,
-	// operator YAML. Internally only canonical names exist.
-	Aliases []string
 }
 
 // CapabilitySurface captures the resolved model-facing view of a
@@ -142,9 +135,9 @@ var builtinToolSpecs = map[string]BuiltinToolSpec{
 	"attachment_describe":         {CanonicalID: "native:attachment_describe", Source: NativeToolSource, Tags: []string{"attachments"}},
 	"attachment_list":             {CanonicalID: "native:attachment_list", Source: NativeToolSource, Tags: []string{"attachments"}},
 	"attachment_search":           {CanonicalID: "native:attachment_search", Source: NativeToolSource, Tags: []string{"attachments"}},
-	"ha_call_service":             {CanonicalID: "native:ha_call_service", Source: NativeToolSource, Tags: []string{"ha", "homeassistant"}},
+	"ha_call_service":             {CanonicalID: "native:ha_call_service", Source: NativeToolSource, Tags: []string{"ha"}},
 	"task_cancel":                 {CanonicalID: "native:task_cancel", Source: NativeToolSource, Tags: []string{"scheduler"}},
-	"ha_control_device":           {CanonicalID: "native:ha_control_device", Source: NativeToolSource, Tags: []string{"ha", "homeassistant"}},
+	"ha_control_device":           {CanonicalID: "native:ha_control_device", Source: NativeToolSource, Tags: []string{"ha"}},
 	"conversation_reset":          {CanonicalID: "native:conversation_reset", Source: NativeToolSource, Tags: []string{"session"}},
 	"cost_summary":                {CanonicalID: "native:cost_summary", Source: NativeToolSource, Tags: []string{"diagnostics"}},
 	"create_temp_file":            {CanonicalID: "native:create_temp_file", Source: NativeToolSource, Tags: []string{"files"}},
@@ -188,7 +181,7 @@ var builtinToolSpecs = map[string]BuiltinToolSpec{
 	"file_stat":                   {CanonicalID: "native:file_stat", Source: NativeToolSource, Tags: []string{"files"}},
 	"file_tree":                   {CanonicalID: "native:file_tree", Source: NativeToolSource, Tags: []string{"files"}},
 	"file_write":                  {CanonicalID: "native:file_write", Source: NativeToolSource, Tags: []string{"files"}},
-	"ha_find_entity":              {CanonicalID: "native:ha_find_entity", Source: NativeToolSource, Tags: []string{"ha", "homeassistant"}},
+	"ha_find_entity":              {CanonicalID: "native:ha_find_entity", Source: NativeToolSource, Tags: []string{"ha"}},
 	"contact_forget":              {CanonicalID: "native:contact_forget", Source: NativeToolSource, Tags: []string{"contacts"}},
 	"forget_fact":                 {CanonicalID: "native:forget_fact", Source: NativeToolSource, Tags: []string{"memory"}},
 	"forge_issue_comment":         {CanonicalID: "native:forge_issue_comment", Source: NativeToolSource, Tags: []string{"forge"}},
@@ -212,18 +205,18 @@ var builtinToolSpecs = map[string]BuiltinToolSpec{
 	"forge_repo_subscriptions":    {CanonicalID: "native:forge_repo_subscriptions", Source: NativeToolSource, Tags: []string{"forge"}},
 	"forge_repo_unfollow":         {CanonicalID: "native:forge_repo_unfollow", Source: NativeToolSource, Tags: []string{"forge"}},
 	"forge_search":                {CanonicalID: "native:forge_search", Source: NativeToolSource, Tags: []string{"forge"}},
-	"ha_get_state":                {CanonicalID: "native:ha_get_state", Source: NativeToolSource, Tags: []string{"ha", "homeassistant"}},
+	"ha_get_state":                {CanonicalID: "native:ha_get_state", Source: NativeToolSource, Tags: []string{"ha"}},
 	"get_version":                 {CanonicalID: "native:get_version", Source: NativeToolSource, Tags: []string{"diagnostics"}},
-	"ha_automation_create":        {CanonicalID: "native:ha_automation_create", Source: NativeToolSource, Tags: []string{"ha", "homeassistant"}},
-	"ha_automation_delete":        {CanonicalID: "native:ha_automation_delete", Source: NativeToolSource, Tags: []string{"ha", "homeassistant"}},
-	"ha_automation_get":           {CanonicalID: "native:ha_automation_get", Source: NativeToolSource, Tags: []string{"ha", "homeassistant"}},
-	"ha_automation_list":          {CanonicalID: "native:ha_automation_list", Source: NativeToolSource, Tags: []string{"ha", "homeassistant"}},
-	"ha_automation_update":        {CanonicalID: "native:ha_automation_update", Source: NativeToolSource, Tags: []string{"ha", "homeassistant"}},
+	"ha_automation_create":        {CanonicalID: "native:ha_automation_create", Source: NativeToolSource, Tags: []string{"ha"}},
+	"ha_automation_delete":        {CanonicalID: "native:ha_automation_delete", Source: NativeToolSource, Tags: []string{"ha"}},
+	"ha_automation_get":           {CanonicalID: "native:ha_automation_get", Source: NativeToolSource, Tags: []string{"ha"}},
+	"ha_automation_list":          {CanonicalID: "native:ha_automation_list", Source: NativeToolSource, Tags: []string{"ha"}},
+	"ha_automation_update":        {CanonicalID: "native:ha_automation_update", Source: NativeToolSource, Tags: []string{"ha"}},
 	"ha_notify":                   {CanonicalID: "native:ha_notify", Source: NativeToolSource, Tags: []string{"notifications"}},
-	"ha_registry_search":          {CanonicalID: "native:ha_registry_search", Source: NativeToolSource, Tags: []string{"ha", "homeassistant"}},
+	"ha_registry_search":          {CanonicalID: "native:ha_registry_search", Source: NativeToolSource, Tags: []string{"ha"}},
 	"contact_import_vcf":          {CanonicalID: "native:contact_import_vcf", Source: NativeToolSource, Tags: []string{"contacts"}},
 	"contact_list":                {CanonicalID: "native:contact_list", Source: NativeToolSource, Tags: []string{"contacts"}},
-	"ha_list_entities":            {CanonicalID: "native:ha_list_entities", Source: NativeToolSource, Tags: []string{"ha", "homeassistant"}},
+	"ha_list_entities":            {CanonicalID: "native:ha_list_entities", Source: NativeToolSource, Tags: []string{"ha"}},
 	"lens_list":                   {CanonicalID: "native:lens_list", Source: NativeToolSource},
 	"tag_inspect":                 {CanonicalID: "native:tag_inspect", Source: NativeToolSource},
 	"tag_reset":                   {CanonicalID: "native:tag_reset", Source: NativeToolSource},
@@ -312,83 +305,30 @@ func BuiltinToolSpecs() map[string]BuiltinToolSpec {
 }
 
 // BuiltinTagSpecs returns a deep copy of the compiled-in tag catalog.
-// The returned map and the slice fields on each spec (Parents,
-// Aliases) are independent copies — mutating them does not affect the
-// global catalog. Parallels [BuiltinToolSpecs] for the tool half.
+// The returned map and the Parents slice on each spec are independent
+// copies — mutating them does not affect the global catalog. Parallels
+// [BuiltinToolSpecs] for the tool half.
 func BuiltinTagSpecs() map[string]BuiltinTagSpec {
 	out := make(map[string]BuiltinTagSpec, len(builtinTagSpecs))
 	for name, spec := range builtinTagSpecs {
 		spec.Parents = append([]string(nil), spec.Parents...)
-		spec.Aliases = append([]string(nil), spec.Aliases...)
 		out[name] = spec
 	}
 	return out
 }
 
-// HasBuiltinTag reports whether the name is a compiled-in tag,
-// resolving aliases. So `HasBuiltinTag("homeassistant")` returns true
-// because `ha` declares it as an alias.
+// HasBuiltinTag reports whether the name is a compiled-in tag. Tag
+// names are first-class; there are no aliases.
 func HasBuiltinTag(name string) bool {
-	if _, ok := builtinTagSpecs[name]; ok {
-		return true
-	}
-	_, ok := builtinTagAliases[name]
+	_, ok := builtinTagSpecs[name]
 	return ok
 }
 
-// CanonicalTagName returns the canonical tag name for value, resolving
-// aliases. If value is already a canonical tag (or an unknown name), it
-// is returned unchanged.
-func CanonicalTagName(value string) string {
-	if canonical, ok := builtinTagAliases[value]; ok {
-		return canonical
-	}
-	return value
-}
-
-// LookupBuiltinTagSpec returns the spec for name, resolving aliases.
-// Returns the zero value and false for unknown names.
+// LookupBuiltinTagSpec returns the spec for name. Returns the zero
+// value and false for unknown names.
 func LookupBuiltinTagSpec(name string) (BuiltinTagSpec, bool) {
-	if spec, ok := builtinTagSpecs[name]; ok {
-		return spec, true
-	}
-	if canonical, ok := builtinTagAliases[name]; ok {
-		spec, found := builtinTagSpecs[canonical]
-		return spec, found
-	}
-	return BuiltinTagSpec{}, false
-}
-
-// builtinTagAliases is the reverse-lookup map populated from each
-// canonical spec's Aliases field at package init. Lookups are
-// alias → canonical name; resolving an unknown name returns ("", false).
-//
-// Until alias resolution propagates to every tag ingress point (config
-// validation, channel-tag binding, loop spec, persisted scope), tools
-// belonging to a canonical tag with aliases should *also* carry the
-// alias names in their Tags slice — see the `ha` / `homeassistant`
-// pattern in builtinToolSpecs. The CanonicalTagName helper is the
-// model-facing resolution boundary; the double-tagging is the
-// tag-index bridge until that resolution covers every ingress.
-var builtinTagAliases map[string]string
-
-func init() {
-	builtinTagAliases = make(map[string]string)
-	for canonical, spec := range builtinTagSpecs {
-		for _, alias := range spec.Aliases {
-			if _, collides := builtinTagSpecs[alias]; collides {
-				panic(fmt.Sprintf(
-					"toolcatalog: alias %q on canonical tag %q collides with an existing canonical tag of the same name",
-					alias, canonical))
-			}
-			if existing, dup := builtinTagAliases[alias]; dup {
-				panic(fmt.Sprintf(
-					"toolcatalog: alias %q declared by both %q and %q",
-					alias, existing, canonical))
-			}
-			builtinTagAliases[alias] = canonical
-		}
-	}
+	spec, ok := builtinTagSpecs[name]
+	return spec, ok
 }
 
 // BuildCapabilitySurface builds a sorted capability surface from

--- a/internal/model/toolcatalog/catalog_tags.go
+++ b/internal/model/toolcatalog/catalog_tags.go
@@ -2,11 +2,10 @@ package toolcatalog
 
 // builtinTagSpecs is the compiled-in tag catalog. PR-G formalized the
 // hierarchy: every leaf declares its Parents (the menu trailheads it
-// appears under), aliases funnel into canonical names via Aliases, and
-// coarse trailheads are explicitly marked Kind: TagKindMenu. Some
-// leaves legitimately serve more than one menu (files spans development
-// and knowledge; web spans development, knowledge, and media) and
-// declare multi-valued Parents.
+// appears under), and coarse trailheads are explicitly marked
+// Kind: TagKindMenu. Some leaves legitimately serve more than one
+// menu (files spans development and knowledge; web spans development,
+// knowledge, and media) and declare multi-valued Parents.
 //
 // Adding a new tag: pick a Kind, write a Description that fits the
 // model-facing menu, and assign Parents from the existing menus when

--- a/internal/model/toolcatalog/catalog_tags.go
+++ b/internal/model/toolcatalog/catalog_tags.go
@@ -97,7 +97,6 @@ var builtinTagSpecs = map[string]BuiltinTagSpec{
 	"ha": {
 		Description: "Home Assistant state, control, registry, and automation tools.",
 		Parents:     []string{"home"},
-		Aliases:     []string{"homeassistant"},
 	},
 	"loops": {
 		Description: "Live loop status, sleep control, notifications, ad hoc spawn, and durable loop-definition authoring tools.",

--- a/internal/model/toolcatalog/catalog_test.go
+++ b/internal/model/toolcatalog/catalog_test.go
@@ -34,82 +34,32 @@ func TestBuiltinTagSpecs_ParentsResolveToMenuTags(t *testing.T) {
 	}
 }
 
-// TestBuiltinTagSpecs_AliasesResolveToCanonicals pins that every Alias
-// is unique across the catalog (no two canonical tags claim the same
-// alias) and doesn't collide with an existing canonical name. Without
-// this, a future addition like Aliases: []string{"ha"} on a sibling tag
-// would silently override the canonical ha entry in the reverse-alias
-// map.
-func TestBuiltinTagSpecs_AliasesResolveToCanonicals(t *testing.T) {
-	specs := BuiltinTagSpecs()
-	seenAliases := make(map[string]string)
-	var problems []string
-	for name, spec := range specs {
-		for _, alias := range spec.Aliases {
-			if _, ok := specs[alias]; ok {
-				problems = append(problems, name+": alias "+alias+" collides with an existing canonical tag")
-				continue
-			}
-			if owner, dup := seenAliases[alias]; dup {
-				problems = append(problems, name+": alias "+alias+" already declared by "+owner)
-				continue
-			}
-			seenAliases[alias] = name
-		}
-	}
-	if len(problems) > 0 {
-		sort.Strings(problems)
-		t.Fatalf("BuiltinTagSpecs Aliases are not unique:\n  - %s",
-			strings.Join(problems, "\n  - "))
-	}
-}
-
-// TestCanonicalTagName_ResolvesHomeAssistantAlias is the worked example
-// for alias resolution: the reverse-alias map populated at init must
-// resolve homeassistant → ha, and the canonical name must round-trip
-// unchanged.
-func TestCanonicalTagName_ResolvesHomeAssistantAlias(t *testing.T) {
-	if got := CanonicalTagName("homeassistant"); got != "ha" {
-		t.Fatalf("CanonicalTagName(homeassistant) = %q, want ha", got)
-	}
-	if got := CanonicalTagName("ha"); got != "ha" {
-		t.Fatalf("CanonicalTagName(ha) = %q, want ha (canonical round-trip)", got)
-	}
-	if got := CanonicalTagName("nonexistent"); got != "nonexistent" {
-		t.Fatalf("CanonicalTagName(nonexistent) = %q, want nonexistent (unchanged for unknown)", got)
-	}
-}
-
-// TestHasBuiltinTag_AcceptsAliases checks that aliases register as
-// known tags. The runtime relies on this so validation against
-// unknown-tag references (channel_tags pointing at homeassistant, KB
-// articles tagged homeassistant) keeps working through the alias.
-func TestHasBuiltinTag_AcceptsAliases(t *testing.T) {
-	if !HasBuiltinTag("homeassistant") {
-		t.Fatal("HasBuiltinTag(homeassistant) = false, want true via ha's alias")
-	}
+// TestHasBuiltinTag covers the canonical-tag membership check. Tag
+// names are first-class — there is no alias resolution; the historical
+// homeassistant→ha alias was retired in #925.
+func TestHasBuiltinTag(t *testing.T) {
 	if !HasBuiltinTag("ha") {
 		t.Fatal("HasBuiltinTag(ha) = false, want true (canonical)")
+	}
+	if HasBuiltinTag("homeassistant") {
+		t.Fatal("HasBuiltinTag(homeassistant) = true, want false (retired alias)")
 	}
 	if HasBuiltinTag("definitely_not_a_tag") {
 		t.Fatal("HasBuiltinTag(definitely_not_a_tag) = true, want false")
 	}
 }
 
-// TestLookupBuiltinTagSpec_ResolvesAliases confirms that fetching the
-// spec for an alias returns the canonical spec.
-func TestLookupBuiltinTagSpec_ResolvesAliases(t *testing.T) {
-	viaCanonical, ok := LookupBuiltinTagSpec("ha")
-	if !ok {
+// TestLookupBuiltinTagSpec confirms canonical-only lookup behavior.
+// The pre-#925 alias path is gone; only canonical names resolve.
+func TestLookupBuiltinTagSpec(t *testing.T) {
+	if _, ok := LookupBuiltinTagSpec("ha"); !ok {
 		t.Fatal("LookupBuiltinTagSpec(ha) not found")
 	}
-	viaAlias, ok := LookupBuiltinTagSpec("homeassistant")
-	if !ok {
-		t.Fatal("LookupBuiltinTagSpec(homeassistant) not found via alias")
+	if _, ok := LookupBuiltinTagSpec("homeassistant"); ok {
+		t.Fatal("LookupBuiltinTagSpec(homeassistant) found; the alias was retired")
 	}
-	if viaAlias.Description != viaCanonical.Description {
-		t.Fatalf("alias resolution returned different spec: alias=%+v canonical=%+v",
-			viaAlias, viaCanonical)
+	if _, ok := LookupBuiltinTagSpec("definitely_not_a_tag"); ok {
+		t.Fatal("LookupBuiltinTagSpec(definitely_not_a_tag) found")
 	}
 }
 

--- a/internal/platform/config/example.go
+++ b/internal/platform/config/example.go
@@ -191,7 +191,7 @@ func ExampleConfig() *Config {
 						DelegationGating: "disabled",
 						Instructions:     "Evaluate the security event and decide if action is needed.",
 					},
-					InitialTags: []string{"homeassistant"},
+					InitialTags: []string{"ha"},
 				},
 			},
 			Telemetry: TelemetryConfig{
@@ -286,7 +286,7 @@ func ExampleConfig() *Config {
 						DelegationGating: "disabled",
 						Instructions:     "Be concise and focus on high-signal observations.",
 					},
-					Tags:         []string{"homeassistant"},
+					Tags:         []string{"ha"},
 					SleepMin:     2 * time.Minute,
 					SleepMax:     10 * time.Minute,
 					SleepDefault: 5 * time.Minute,

--- a/internal/tools/capability_tools.go
+++ b/internal/tools/capability_tools.go
@@ -138,25 +138,17 @@ func (r *Registry) registerActivateTag(mgr CapabilityManager, manifest []Capabil
 			"required": []string{"tag"},
 		},
 		Handler: func(ctx context.Context, args map[string]any) (string, error) {
-			rawTag := extractTag(args)
-			if rawTag == "" {
+			tag := extractTag(args)
+			if tag == "" {
 				return "", fmt.Errorf("tag is required (e.g., tag_activate(tag: \"forge\"))")
 			}
-			// Resolve aliases before activation so the canonical name is
-			// what flows through the scope, the prompt's ## Active Tags
-			// section, and the persistence layer.
-			tag := toolcatalog.CanonicalTagName(rawTag)
 
 			if err := mgr.RequestCapability(ctx, tag); err != nil {
 				return "", err
 			}
 
 			var result strings.Builder
-			if tag != rawTag {
-				fmt.Fprintf(&result, "Tag **%s** activated (alias for **%s**).", rawTag, tag)
-			} else {
-				fmt.Fprintf(&result, "Tag **%s** activated.", tag)
-			}
+			fmt.Fprintf(&result, "Tag **%s** activated.", tag)
 			if m, ok := tagManifest[tag]; ok {
 				if len(m.Tools) > 0 {
 					fmt.Fprintf(&result, " %d tools now available.", len(m.Tools))
@@ -193,24 +185,17 @@ func (r *Registry) registerDeactivateTag(mgr CapabilityManager, tagManifest map[
 			"required": []string{"tag"},
 		},
 		Handler: func(ctx context.Context, args map[string]any) (string, error) {
-			rawTag := extractTag(args)
-			if rawTag == "" {
+			tag := extractTag(args)
+			if tag == "" {
 				return "", fmt.Errorf("tag is required (e.g., tag_deactivate(tag: \"forge\"))")
 			}
-			// Resolve aliases so deactivating by an alternate name
-			// (e.g. `homeassistant`) hits the canonical tag in scope.
-			tag := toolcatalog.CanonicalTagName(rawTag)
 
 			if err := mgr.DropCapability(ctx, tag); err != nil {
 				return "", err
 			}
 
 			var result strings.Builder
-			if tag != rawTag {
-				fmt.Fprintf(&result, "Tag **%s** deactivated (alias for **%s**).", rawTag, tag)
-			} else {
-				fmt.Fprintf(&result, "Tag **%s** deactivated.", tag)
-			}
+			fmt.Fprintf(&result, "Tag **%s** deactivated.", tag)
 			if m, ok := tagManifest[tag]; ok && len(m.Tools) > 0 {
 				fmt.Fprintf(&result, " %d tools removed.", len(m.Tools))
 			}
@@ -310,16 +295,13 @@ func (r *Registry) registerInspectTag(tagManifest map[string]CapabilityManifest)
 			"required": []string{"tag"},
 		},
 		Handler: func(ctx context.Context, args map[string]any) (string, error) {
-			rawTag := extractTag(args)
-			if rawTag == "" {
+			tag := extractTag(args)
+			if tag == "" {
 				return "", fmt.Errorf("tag is required (e.g., tag_inspect(tag: \"ha\"))")
 			}
-			// Resolve aliases so tag_inspect("homeassistant") returns
-			// ha's breakdown.
-			tag := toolcatalog.CanonicalTagName(rawTag)
 			manifest, ok := tagManifest[tag]
 			if !ok {
-				return "", fmt.Errorf("unknown tag %q; read the ## Active Tags section of your prompt to see what's already loaded, or use tag_activate to discover available tags", rawTag)
+				return "", fmt.Errorf("unknown tag %q; read the ## Active Tags section of your prompt to see what's already loaded, or use tag_activate to discover available tags", tag)
 			}
 			includeExcluded, _ := args["include_excluded"].(bool)
 			entry := toolcatalog.RenderCapabilityCatalogEntry(manifest, toolcatalog.CatalogViewOptions{


### PR DESCRIPTION
## Summary

Closes #925.

Tag aliases were a bad idea, won't ever use one again. The whole machinery — one alias entry (`homeassistant → ha`), one resolver function, ten double-tagged HA tools, three model-facing canonicalization sites — comes out in favor of canonical-only tag names everywhere.

The issue originally proposed propagating `CanonicalTagName` to every ingress point and then dropping the double-tagging. The direction shifted during the v0.9.3 production-config cutover: rather than spread alias resolution across five more sites (and grow the maintenance surface every time a new alias landed), retire the mechanism entirely. Net is -131 lines and a simpler shape.

## What got removed

- `BuiltinTagSpec.Aliases` field
- `builtinTagAliases` reverse-lookup map and the package `init()` that populated it
- `CanonicalTagName` function
- Alias-resolution branches in `HasBuiltinTag` and `LookupBuiltinTagSpec`
- `Aliases: []string{\"homeassistant\"}` on the `ha` tag in `catalog_tags.go`
- `Tags: []string{\"ha\", \"homeassistant\"}` double-tagging on 10 HA tools — back to `[\"ha\"]`
- `toolcatalog.CanonicalTagName` calls in `capability_tools.go`'s `tag_activate` / `tag_deactivate` / `tag_inspect` handlers, plus the now-unreachable \"alias for X\" output branches
- \"Tag aliases\" row in `docs/understanding/tag-system.md` concept matrix; the `tag-canonical` link reference goes with it
- Alias-specific tests (4 tests + an Aliases-uniqueness invariant check)
- `homeassistant` → `ha` in two example-config `InitialTags`/`Tags` values (regenerated `examples/config.example.yaml` + `cmd/thane/config.example.yaml`)

## What got added

- `TestHasBuiltinTag` and `TestLookupBuiltinTagSpec` that explicitly assert `homeassistant` is now an unknown tag — regression guards against the alias mechanism creeping back in
- `BuiltinTagSpec` Godoc updated: \"Tag names are first-class — there is no alias mechanism\"

## Behavior change

Any persisted scope state, talent frontmatter, or operator config that still spells a tag with a retired alias (only `homeassistant` ever existed) becomes an inert reference — no auto-canonicalization. The v0.9.3 production config draft was audited for this; no production-config refs remain.

## Test plan

- [x] `just ci` passes locally (fmt-check, mod-tidy-check, config-generate-check, architecture-check, link-check, lint @ 0 issues, race tests)
- [x] `TestHasBuiltinTag` asserts `homeassistant` is unknown (regression guard)
- [x] `TestLookupBuiltinTagSpec` asserts the same via the lookup path
- [x] All `tag_*` tool tests still pass — the handlers now treat the raw input as canonical
- [x] `go generate ./internal/platform/config/... && go generate ./cmd/thane/...` produces no diff (the regenerated examples are already committed)