### PR TITLE
docs: post-v0.9.3 audit fixes — archive layout, new subcommands, delegate config key

### DIFF
--- a/docs/operating/configuration.md
+++ b/docs/operating/configuration.md
@@ -297,7 +297,7 @@ is blocked by default.
 
 ```yaml
 logging:
-  root: ~/Thane/logs
+  root: ~/Thane/archive
   level: info
   stdout:
     enabled: true
@@ -307,7 +307,7 @@ logging:
       enabled: true
     requests:
       enabled: true
-    access:
+    http_access:
       enabled: false
     loops:
       enabled: true
@@ -315,6 +315,8 @@ logging:
       enabled: true
     envelopes:
       enabled: true
+    conversations:
+      enabled: false
 ```
 
 Thane writes append-only JSONL datasets under `logging.root`, partitioned by
@@ -347,14 +349,14 @@ See [Delegation & MCP](../understanding/delegation.md).
 ## Delegation
 
 ```yaml
-delegation:
+delegate:
   profiles:
     general:
-      quality_floor: 5
-      prefer_speed: true
+      tool_timeout: 8m
+      max_duration: 15m
     ha:
-      quality_floor: 4
-      prefer_speed: true
+      tool_timeout: 3m
+      max_duration: 5m
 ```
 
 Controls how delegated tasks are routed.

--- a/docs/operating/deployment.md
+++ b/docs/operating/deployment.md
@@ -17,7 +17,7 @@ that user's home directory — Finder-visible, easy to inspect and back up.
 just install                  # -> ~/Thane/bin/thane
 just service-install          # -> ~/Library/LaunchAgents/info.nugget.thane.plist
 launchctl load ~/Library/LaunchAgents/info.nugget.thane.plist
-just logs                     # Tail the latest ~/Thane/logs/events/... JSONL segment
+just logs                     # Tail the latest ~/Thane/archive/sources/thane/events/... JSONL segment
 ```
 
 ### macOS Local Network Permission

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1,6 +1,6 @@
 # CLI Reference
 
-Thane ships as a single binary with four commands.
+Thane ships as a single binary with seven commands.
 
 ```
 $ thane --help
@@ -9,10 +9,13 @@ Thane - Autonomous Home Assistant Agent
 Usage: thane [flags] <command> [args]
 
 Commands:
-  serve    Start the API server
-  ask      Ask a single question (for testing)
-  ingest   Import markdown docs into fact store
-  version  Show version information
+  serve        Start the API server
+  init [dir]   Initialize working directory with defaults (default: .)
+  validate     Parse and validate the config without starting services
+  ask          Ask a single question (for testing)
+  ingest       Import markdown docs into fact store
+  caps         Show resolved capability tags from a running daemon
+  version      Show version information
 
 Flags:
   -config <path>    Path to config file (default: auto-discover)
@@ -32,6 +35,41 @@ Starts three listeners:
 - **Port 11434** — Ollama-compatible API (for Home Assistant)
 - **Port 8843** — CardDAV server (for contact sync)
 
+### `thane init [dir]`
+
+Initialize a Thane working directory with bundled defaults. Creates the
+directory structure (`db/`, `talents/`, `archive/`), writes a default
+`config.yaml` (0600 permissions, contains placeholders for secrets) and a
+default `persona.md`, deploys the embedded talent corpus, bootstraps the
+core identity (signing key, channel CA) and the archive skeleton
+(orientation READMEs + the `interactions/` schema stub). Existing files
+are never overwritten — re-runs report `(exists, skipping)` per file, so
+it's safe to run against an established workspace to fill in anything
+missing.
+
+`dir` defaults to the current directory.
+
+```bash
+thane init ~/Thane
+```
+
+### `thane validate`
+
+Parse and validate the config file without starting any services or
+opening any sockets. Useful as a pre-deploy gate (`thane validate &&
+thane serve`) or in CI.
+
+```bash
+thane validate                            # auto-discovered config
+thane -config /etc/thane/config.yaml validate
+thane -o json validate | jq .             # structured report for scripting
+```
+
+Text mode prints a one-line confirmation plus a short structural summary
+(default model, resource/model/root counts, MCP server count, which
+optional integrations are configured). JSON mode emits `{path, valid,
+error, summary}` and exits non-zero on failure.
+
 ### `thane ask`
 
 One-shot question for testing. Runs a single request through the agent loop
@@ -48,6 +86,19 @@ content into categorized facts with optional embeddings.
 
 ```bash
 thane ingest ~/notes/home-layout.md
+```
+
+### `thane caps`
+
+Show resolved capability tags from a running daemon — useful for
+inspecting which tags resolved on the running config and what tools each
+tag carries. Reads from the live `serve` process via its API; requires
+the daemon to be running.
+
+```bash
+thane caps
+thane caps -x          # include tags the operator overlay excluded
+thane -o json caps     # structured output
 ```
 
 ### `thane version`

--- a/justfile
+++ b/justfile
@@ -213,7 +213,7 @@ service-install: install
     THANE_HOME="{{thane-home}}"
     # Create directory structure
     mkdir -p "$THANE_HOME/db"
-    mkdir -p "$THANE_HOME/logs"
+    mkdir -p "$THANE_HOME/archive"
     # Generate plist with absolute paths for this user
     mkdir -p ~/Library/LaunchAgents
     sed -e "s|/usr/local/bin/thane|$THANE_HOME/bin/thane|g" \
@@ -225,8 +225,8 @@ service-install: install
     echo "  Binary:  $THANE_HOME/bin/thane"
     echo "  Config:  $THANE_HOME/config.yaml"
     echo "  Data:    $THANE_HOME/db/"
-    echo "  Logs:    $THANE_HOME/logs/{events,requests,access,loops,delegates,envelopes}/YYYY-MM-DD/HH.jsonl"
-    echo "           $THANE_HOME/logs/logs.db"
+    echo "  Archive: $THANE_HOME/archive/sources/thane/{events,requests,http_access,loops,delegates,envelopes,conversations}/YYYY/MM/DD/<dataset>-YYYY-MM-DD-HH.jsonl"
+    echo "  Index:   $THANE_HOME/archive/logs.db"
     echo "  Crashes: $THANE_HOME/crash.log       (pre-init errors only)"
     echo ""
     echo "Next steps:"
@@ -393,7 +393,7 @@ serve: build
 logs workdir="./Thane":
     #!/usr/bin/env bash
     set -euo pipefail
-    events_dir="{{workdir}}/logs/events"
+    events_dir="{{workdir}}/archive/sources/thane/events"
     echo "Tailing events dataset under $events_dir (Ctrl-C to stop)..."
     current=""
     while true; do


### PR DESCRIPTION
## Summary

Phase 1 (Pre-release audits) — documentation audit pass against the v0.9.3 deltas. Small, surgical fixes across the justfile and three doc files where the post-#952/#954 reality contradicted what was written.

## What was stale

- **Archive layout migration (#952)** left `logs/` references in:
  - `justfile`'s `service-install` recipe (created `~/Thane/logs/`, printed help saying logs go there with the pre-rename `access` dataset name and no `conversations`)
  - `justfile`'s `just logs` tail recipe (searched `workdir/logs/events` — silently found nothing on a current install)
  - `docs/operating/deployment.md` (inline `just logs` description)
  - `docs/operating/configuration.md` logging example (root + dataset names)
- **New subcommands (#954, plus older `init`/`caps`)** missing from `docs/reference/cli.md`, which still claimed "four commands"
- **`delegation:` → `delegate:`** YAML key mismatch in `docs/operating/configuration.md` (also fixed the override fields it listed — they belonged on `LoopProfile`, not `DelegateProfileConfig`)

## What got fixed

- `justfile`:
  - `service-install`: `mkdir -p` → `archive/` instead of `logs/`
  - Post-install help: new path, full dataset list with renamed/new entries (`http_access`, `conversations`)
  - `just logs`: tail path → `archive/sources/thane/events`
- `docs/operating/deployment.md`: matching inline path update
- `docs/operating/configuration.md`:
  - Logging example: `root: ~/Thane/archive`, `http_access` (was `access`), added `conversations`
  - Delegation example: `delegation:` → `delegate:`, override fields swapped to ones that actually exist (`tool_timeout`, `max_duration`)
- `docs/reference/cli.md`: full seven-command listing with bodies for `init`, `validate`, `caps`

## What the audit flagged that I declined

- `examples/config.example.yaml`'s comment referencing `archive/README.md` — the file IS created by `thane init` (embedded as `archive_readme.md` per `cmd/thane/init.go:37`), so the comment is correct
- "Delegation Profiles" operator-facing vocabulary in `docs/understanding/delegation.md` — intentionally preserved per the RunPolicy-rename compat clause (the YAML key, log key, and JSON wire field all still say "profile")

## Test plan

- [x] `just ci` passes (fmt-check, mod-tidy-check, config-generate-check, architecture-check, link-check, lint @ 0 issues, race tests)
- [x] `just logs` recipe path matches what `archive-migration` produces and what fresh `thane init` workspaces look like
- [x] `cli.md` command list matches `cmd/thane/main.go` switch statement (`serve` / `init` / `validate` / `ask` / `ingest` / `version` / `caps`)
- [x] `delegate:` config key matches `internal/platform/config/config.go:223` (`Delegate DelegateConfig \`yaml:"delegate"\``)