### PR TITLE
docs(godoc): post-v0.9.3 narrative pass — tag lifecycle, override semantics, alias removal

### DIFF
--- a/internal/channels/email/tools.go
+++ b/internal/channels/email/tools.go
@@ -531,10 +531,17 @@ func boolArg(args map[string]any, key string) bool {
 	return false
 }
 
-// boolArgDefault is the same as boolArg but returns fallback (rather
-// than false) when key is absent or wrong-typed. Use it when the tool
-// schema documents a true-default; reaching for it is a signal that
-// the docs and code agree on the absent-key behavior.
+// boolArgDefault resolves the omitted-bool ambiguity that bit
+// email_mark in #930: when a tool schema documents `default: true`
+// for a boolean argument, the calling model often omits the field
+// entirely rather than sending `true` explicitly — and Go's zero
+// value for the missing key is `false`, the opposite of what the
+// schema promised. boolArgDefault returns the documented fallback
+// when the key is absent or wrong-typed, so runtime behavior matches
+// the schema regardless of how the model encodes the call. Use it
+// for any tool argument whose schema documents a non-false default;
+// use boolArg directly when false-when-omitted is the intended
+// semantic.
 func boolArgDefault(args map[string]any, key string, fallback bool) bool {
 	if v, ok := args[key].(bool); ok {
 		return v

--- a/internal/model/toolcatalog/catalog.go
+++ b/internal/model/toolcatalog/catalog.go
@@ -6,11 +6,12 @@
 // external surface (operator config, channel bindings, loop specs,
 // persisted scope, talents, knowledge frontmatter) spells each
 // built-in tag with its compiled-in name; the v0.9.3 retirement of
-// the alias machinery (#925) removed [CanonicalTagName] and the
-// `Aliases` field on [BuiltinTagSpec], so any pre-v0.9.3 reference to
-// `homeassistant` (the one alias that ever existed) needs to be
-// rewritten as `ha`. Operators may still define ad-hoc tags via the
-// `capability_tags:` YAML overlay; those names pass through verbatim.
+// the alias machinery (#925) removed the `CanonicalTagName` resolver
+// and the `Aliases` field on [BuiltinTagSpec], so any pre-v0.9.3
+// reference to `homeassistant` (the one alias that ever existed)
+// needs to be rewritten as `ha`. Operators may still define ad-hoc
+// tags via the `capability_tags:` YAML overlay; those names pass
+// through verbatim.
 package toolcatalog
 
 import (

--- a/internal/model/toolcatalog/catalog.go
+++ b/internal/model/toolcatalog/catalog.go
@@ -1,6 +1,16 @@
 // Package toolcatalog provides compiled-in metadata for tools and capability
 // tags, and renders capability surface descriptions for model-facing context
 // and the web dashboard.
+//
+// Tag names are first-class — there is no alias mechanism. Every
+// external surface (operator config, channel bindings, loop specs,
+// persisted scope, talents, knowledge frontmatter) spells each
+// built-in tag with its compiled-in name; the v0.9.3 retirement of
+// the alias machinery (#925) removed [CanonicalTagName] and the
+// `Aliases` field on [BuiltinTagSpec], so any pre-v0.9.3 reference to
+// `homeassistant` (the one alias that ever existed) needs to be
+// rewritten as `ha`. Operators may still define ad-hoc tags via the
+// `capability_tags:` YAML overlay; those names pass through verbatim.
 package toolcatalog
 
 import (

--- a/internal/runtime/delegate/delegate.go
+++ b/internal/runtime/delegate/delegate.go
@@ -201,9 +201,18 @@ type ToolCallOutcome struct {
 
 // Result is the outcome of a delegated task execution.
 type Result struct {
-	// RunPolicyName is the [RunPolicy.Name] used to route this run.
-	// The wire JSON field stays "profile" for log/dashboard compat.
-	RunPolicyName            string            `json:"profile"`
+	// RunPolicyName is the [RunPolicy.Name] selected for this run.
+	// The JSON tag stays "profile" because the operator-facing
+	// vocabulary, dashboards, and log-parsing scripts predate the
+	// internal Profile→RunPolicy rename; changing the wire field
+	// would break those surfaces without delivering value.
+	RunPolicyName string `json:"profile"`
+	// Content is the assistant text the delegate produced. Empty when
+	// the delegate exhausted without producing output (Exhausted is
+	// true and ExhaustReason names which budget ran out), or when the
+	// delegate completed but produced only tool calls with no final
+	// answer (Exhausted=true, ExhaustReason=ExhaustNoOutput). Check
+	// Exhausted before treating an empty Content as success.
 	Content                  string            `json:"content"`
 	Model                    string            `json:"model"`
 	Iterations               int               `json:"iterations"`
@@ -287,14 +296,28 @@ func (e *Executor) ApplyRunPolicyOverrides(overrides map[string]RunPolicyOverrid
 	}
 }
 
-// RunPolicyOverride holds optional operator overrides for a builtin
-// run policy. Only positive values are applied; zero and negative
-// fields are ignored.
+// RunPolicyOverride is the partial-update shape operators use to
+// adjust one or more budgets on a builtin run policy without having
+// to restate the whole policy. The struct is intentionally
+// all-zero-valued by default — operators only fill the fields they
+// want to override, and [Executor.ApplyRunPolicyOverrides] leaves
+// builtin values in place wherever the override is zero.
 type RunPolicyOverride struct {
+	// ToolTimeout, when positive, replaces the builtin policy's
+	// per-tool-call timeout. Zero leaves the builtin unchanged.
 	ToolTimeout time.Duration
+	// MaxDuration, when positive, replaces the builtin policy's
+	// wall-clock cap on the whole delegate loop. Zero leaves the
+	// builtin unchanged.
 	MaxDuration time.Duration
-	MaxIter     int
-	MaxTokens   int
+	// MaxIter, when positive, replaces the builtin policy's maximum
+	// tool-calling iteration count. Zero leaves the builtin
+	// unchanged.
+	MaxIter int
+	// MaxTokens, when positive, replaces the builtin policy's
+	// cumulative output-token budget. Zero leaves the builtin
+	// unchanged.
+	MaxTokens int
 }
 
 // SetTimezone configures the IANA timezone used in delegate logging and

--- a/internal/runtime/delegate/profile.go
+++ b/internal/runtime/delegate/profile.go
@@ -5,6 +5,48 @@
 // result); thane_assign is the async one-shot front door (the result is
 // delivered back through the conversation/channel when the delegate
 // completes).
+//
+// # Tag scope and inheritance
+//
+// A delegate's tag scope is composed from three sources, in priority
+// order:
+//
+//  1. Explicit tags passed to thane_now / thane_assign. When the
+//     caller names tags, those tags define the scope and the run
+//     policy's DefaultTags are NOT applied — the explicit list is
+//     authoritative. This is the "I know exactly what tools this
+//     subtask needs" path.
+//
+//  2. Elective tags inherited from the caller's context when the
+//     caller did not provide explicit tags. Inheritance is the
+//     default — a delegate working on the same conversation thread
+//     should see the same tag-loaded knowledge as the orchestrator.
+//
+//  3. The run policy's DefaultTags, merged in only when neither
+//     explicit nor inherited tags are present. These exist to give a
+//     bare invocation (no caller context, no explicit tags) a
+//     sensible default tool surface — e.g., the `ha` policy adds
+//     `[ha]` so a `thane_now` aimed at HA work gets HA tools without
+//     the caller having to say so.
+//
+// Tags that never propagate to delegates: `message_channel` and
+// `owner`. These are runtime-asserted trust tags meaningful only in
+// the context they were set; they must be re-asserted (or not) by
+// the delegate's own runtime context, not inherited.
+//
+// Core tags (those operator-pinned via config) always load regardless
+// of which path above contributed the scope.
+//
+// # Vocabulary
+//
+// "Profile" appears in operator-facing surfaces (YAML key
+// `delegate.profiles.<name>`, log keys, JSON wire field `profile`,
+// model-facing result strings `profile=...`) and refers to the
+// operator-named entry. Internally that entry is a [RunPolicy] —
+// the rename in #959 disambiguated three concepts that previously
+// shared the word "profile": delegate run policies (this type),
+// [router.LoopProfile] (loop/wake routing shape), and user-facing
+// `thane:*` virtual model names.
 package delegate
 
 import (
@@ -36,8 +78,13 @@ type RunPolicy struct {
 	// Description is a human-readable summary for logging.
 	Description string
 
-	// DefaultTags are compatibility capability tags applied when the
-	// caller does not request an explicit tag scope.
+	// DefaultTags are the policy's fallback tag scope, merged in only
+	// when the caller did not provide explicit tags AND no context
+	// tags were inherited. The motivating example is the `ha` policy:
+	// a bare `thane_now` aimed at HA work gets `[ha]` so HA tools
+	// load even when the caller didn't name them. See the package
+	// "Tag scope and inheritance" comment for the full composition
+	// rule.
 	DefaultTags []string
 
 	// RouterHints are passed to the router for model selection.

--- a/internal/runtime/delegate/profile.go
+++ b/internal/runtime/delegate/profile.go
@@ -8,34 +8,39 @@
 //
 // # Tag scope and inheritance
 //
-// A delegate's tag scope is composed from three sources, in priority
-// order:
+// A delegate's tag scope is a union of up to three contributors:
 //
-//  1. Explicit tags passed to thane_now / thane_assign. When the
-//     caller names tags, those tags define the scope and the run
-//     policy's DefaultTags are NOT applied — the explicit list is
-//     authoritative. This is the "I know exactly what tools this
-//     subtask needs" path.
+//  1. Inherited tags from the caller's context, when the caller
+//     enabled inherit_caller_tags. Every elective tag the caller
+//     carried is folded in, minus the never-propagate set below.
+//     Inheritance is the default for thane_now / thane_assign so a
+//     delegate working on the same conversation thread sees the
+//     same tag-loaded knowledge as the orchestrator.
 //
-//  2. Elective tags inherited from the caller's context when the
-//     caller did not provide explicit tags. Inheritance is the
-//     default — a delegate working on the same conversation thread
-//     should see the same tag-loaded knowledge as the orchestrator.
+//  2. Explicit tags passed to thane_now / thane_assign. These are
+//     added to the scope (alongside any inherited tags, not in
+//     place of them) and they flip an "explicit scope requested"
+//     flag that the next contributor checks. The flag — not the
+//     tags themselves — is what suppresses RunPolicy.DefaultTags.
 //
-//  3. The run policy's DefaultTags, merged in only when neither
-//     explicit nor inherited tags are present. These exist to give a
-//     bare invocation (no caller context, no explicit tags) a
-//     sensible default tool surface — e.g., the `ha` policy adds
-//     `[ha]` so a `thane_now` aimed at HA work gets HA tools without
-//     the caller having to say so.
+//  3. RunPolicy.DefaultTags, merged in whenever the scope was NOT
+//     explicitly requested. This is the gate operators use when a
+//     bare invocation should still get a sensible tool surface —
+//     e.g., the `ha` policy adds `[ha]` so a `thane_now` aimed at
+//     HA work gets HA tools without the caller having to say so.
+//     Note the asymmetry: explicit tags suppress DefaultTags, but
+//     inherited tags do not. A delegate with no explicit tags and
+//     non-empty inherited tags gets BOTH the inherited set AND the
+//     policy defaults.
 //
 // Tags that never propagate to delegates: `message_channel` and
 // `owner`. These are runtime-asserted trust tags meaningful only in
 // the context they were set; they must be re-asserted (or not) by
 // the delegate's own runtime context, not inherited.
 //
-// Core tags (those operator-pinned via config) always load regardless
-// of which path above contributed the scope.
+// Core tags (those operator-pinned via config) always load
+// regardless of which of the three contributors above produced the
+// scope.
 //
 // # Vocabulary
 //
@@ -78,13 +83,15 @@ type RunPolicy struct {
 	// Description is a human-readable summary for logging.
 	Description string
 
-	// DefaultTags are the policy's fallback tag scope, merged in only
-	// when the caller did not provide explicit tags AND no context
-	// tags were inherited. The motivating example is the `ha` policy:
-	// a bare `thane_now` aimed at HA work gets `[ha]` so HA tools
-	// load even when the caller didn't name them. See the package
-	// "Tag scope and inheritance" comment for the full composition
-	// rule.
+	// DefaultTags merge into the delegate's scope whenever the caller
+	// did NOT pass explicit tags — regardless of whether inherited
+	// tags also contributed. The gate is the "explicit scope
+	// requested" flag, not the absence of inherited tags. The
+	// motivating example is the `ha` policy: a `thane_now` aimed at
+	// HA work gets `[ha]` so HA tools load even when the caller
+	// didn't name them, even if it also inherited unrelated tags
+	// from the caller's context. See the package "Tag scope and
+	// inheritance" comment for the full composition rule.
 	DefaultTags []string
 
 	// RouterHints are passed to the router for model selection.


### PR DESCRIPTION
## Summary

Phase 1 (Pre-release audits) — Godoc compliance audit pass. The release checklist's two practical tests applied to v0.9.3-touched surfaces:

- **Stand-alone test**: each Godoc reads cleanly without requiring cross-references to sibling fields.
- **Why-it-exists test**: each Godoc answers *why* this surface exists, not just *what* it does.

Behavior unchanged across this PR — every edit is a documentation rewrite.

## Findings addressed

### Cross-type narrative
- **`delegate` package comment** ([profile.go](internal/runtime/delegate/profile.go)) — added "Tag scope and inheritance" section explaining the three-source composition rule (explicit → inherited → policy defaults), the never-propagate tags (`message_channel`, `owner`), and a "Vocabulary" subsection naming why operator-facing surfaces still say "profile" while the internal type is `RunPolicy`. The audit specifically flagged that the `DefaultTags` / `explicitScopeRequested` interaction couldn't be statable at the per-field level — this is the lifecycle home for it.

### Field-level rewrites
- **`RunPolicy.DefaultTags`** — re-anchored to the package narrative with a motivating example (the `ha` policy auto-loading `[ha]` when nothing else contributed) rather than the half-true "applied when the caller does not request an explicit tag scope."
- **`Result.RunPolicyName`** — explained WHY the JSON tag stays `"profile"` instead of leaving "log/dashboard compat" as a hand-wave.
- **`Result.Content`** — was un-Godoc'd. Added a comment naming the empty-string semantics (exhausted vs. tool-calls-only vs. real failure) and pointing at the `Exhausted` check the consumer must do.
- **`RunPolicyOverride` per-field Godocs** — replacing the parent-only comment. Each of the four fields now states what it overrides on the builtin policy and what its zero value means.

### Helper-level rewrites
- **`boolArgDefault`** — explained the LLM-omitted-bool problem this helper solves (the #930 regression), with explicit guidance on when to reach for `boolArgDefault` vs. `boolArg`.

### Package-level breadcrumb
- **`toolcatalog` package comment** — documented the v0.9.3 alias retirement so a maintainer landing on the package learns that the `homeassistant → ha` rewrite is real and no `CanonicalTagName` / `Aliases` machinery exists to paper over it.

## Declined from the audit

Four findings flagged by the audit agent that I left alone:

- **`parseMarkAction`** — current Godoc accurately names the extraction reason; the suggested rewrite added length without clarity.
- **`FindConfig`** — the function name and the algorithm describe themselves; the audit's suggested "rationale" rewrite was verbose without delivering new information.
- **`runValidate`** — current Godoc already explains the pre-flight gate role; the audit's expansion was operator-guide material that belongs in the CLI reference (where it already is).
- **`NewConversationsRecorder` / `DatasetRecordFromRequestContent`** — the cleanup in #953 already addressed the relevant clarity; further expansion would have been the agent's voice, not load-bearing documentation.

## Test plan

- [x] `just ci` passes (fmt-check, mod-tidy-check, config-generate-check, architecture-check, link-check, lint @ 0 issues, race tests across every package)
- [x] `go doc github.com/nugget/thane-ai-agent/internal/runtime/delegate` renders the new package-level narrative cleanly
- [x] `go doc github.com/nugget/thane-ai-agent/internal/runtime/delegate RunPolicy` shows the field-level documentation as standalone-readable
- [x] No behavior change — same tests, same shape