### PR TITLE
fix(tools): propagate tagIndex across FilterByTags shallow copies

### DIFF
--- a/internal/tools/capability_tools_test.go
+++ b/internal/tools/capability_tools_test.go
@@ -484,11 +484,14 @@ func TestRegistryFilterByTags_NoTagIndex(t *testing.T) {
 
 // TestRegistryFilterByTags_PreservesTagIndex pins the convention every
 // shallow-copy method on Registry follows: tagIndex propagates to the
-// returned copy. Without this, a subsequent TaggedToolNames or chained
-// FilterByTags on the result silently returns nothing — a latent bug
-// the v0.9.3 code-path audit caught (FilterByTags was the lone
-// outlier). Two paths matter: the no-filter early return and the
-// active-filter path.
+// returned copy. Without it, tag-aware operations on the result
+// misbehave in two ways — TaggedToolNames returns nil for every tag
+// (the failure exercised below), and a chained FilterByTags call
+// becomes a no-op early return that surfaces the full tool set
+// instead of the narrower subset the caller asked for. The v0.9.3
+// code-path audit caught this; FilterByTags was the lone outlier
+// among the shallow-copy methods. Two paths matter: the no-filter
+// early return and the active-filter path.
 func TestRegistryFilterByTags_PreservesTagIndex(t *testing.T) {
 	reg := NewEmptyRegistry()
 	reg.Register(&Tool{Name: "ha_get_state"})

--- a/internal/tools/capability_tools_test.go
+++ b/internal/tools/capability_tools_test.go
@@ -481,3 +481,40 @@ func TestRegistryFilterByTags_NoTagIndex(t *testing.T) {
 		t.Error("FilterByTags with no tag index should return all tools")
 	}
 }
+
+// TestRegistryFilterByTags_PreservesTagIndex pins the convention every
+// shallow-copy method on Registry follows: tagIndex propagates to the
+// returned copy. Without this, a subsequent TaggedToolNames or chained
+// FilterByTags on the result silently returns nothing — a latent bug
+// the v0.9.3 code-path audit caught (FilterByTags was the lone
+// outlier). Two paths matter: the no-filter early return and the
+// active-filter path.
+func TestRegistryFilterByTags_PreservesTagIndex(t *testing.T) {
+	reg := NewEmptyRegistry()
+	reg.Register(&Tool{Name: "ha_get_state"})
+	reg.Register(&Tool{Name: "web_search"})
+	index := map[string][]string{
+		"ha":  {"ha_get_state"},
+		"web": {"web_search"},
+	}
+	reg.SetTagIndex(index)
+
+	t.Run("active-filter path", func(t *testing.T) {
+		filtered := reg.FilterByTags([]string{"ha"})
+		got := filtered.TaggedToolNames("ha")
+		if len(got) == 0 {
+			t.Fatalf("TaggedToolNames(ha) on filtered registry = %v, want non-empty (tagIndex lost across FilterByTags)", got)
+		}
+		if got[0] != "ha_get_state" {
+			t.Errorf("TaggedToolNames(ha)[0] = %q, want ha_get_state", got[0])
+		}
+	})
+
+	t.Run("no-filter path (empty tags slice)", func(t *testing.T) {
+		filtered := reg.FilterByTags(nil)
+		got := filtered.TaggedToolNames("ha")
+		if len(got) == 0 {
+			t.Fatalf("TaggedToolNames(ha) on no-filter copy = %v, want non-empty (tagIndex lost on no-op path)", got)
+		}
+	})
+}

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -1043,12 +1043,20 @@ func (r *Registry) SetTagIndex(tags map[string][]string) {
 // belong to at least one of the given tags, plus any tools marked as
 // Core. If tags is empty or the tag index is nil, returns a copy of
 // the full registry.
+//
+// Both paths propagate tagIndex to the returned registry, matching
+// the convention of [FilteredCopy], [FilteredCopyExcluding], and
+// [WithRuntimeTools]. Without the propagation, any tag-aware query
+// on the result (e.g. [TaggedToolNames], a subsequent FilterByTags
+// chain) silently returns nothing — a latent bug the convention
+// exists to prevent.
 func (r *Registry) FilterByTags(tags []string) *Registry {
 	if len(tags) == 0 || r.tagIndex == nil {
 		// No filtering — return a shallow copy with all tools.
 		filtered := &Registry{
 			tools:           make(map[string]*Tool, len(r.tools)),
 			contentResolver: r.contentResolver,
+			tagIndex:        r.tagIndex,
 		}
 		for name, t := range r.tools {
 			filtered.tools[name] = t
@@ -1066,6 +1074,7 @@ func (r *Registry) FilterByTags(tags []string) *Registry {
 	filtered := &Registry{
 		tools:           make(map[string]*Tool, len(allowed)),
 		contentResolver: r.contentResolver,
+		tagIndex:        r.tagIndex,
 	}
 	for name, t := range r.tools {
 		if allowed[name] || t.Core {

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -1046,10 +1046,13 @@ func (r *Registry) SetTagIndex(tags map[string][]string) {
 //
 // Both paths propagate tagIndex to the returned registry, matching
 // the convention of [FilteredCopy], [FilteredCopyExcluding], and
-// [WithRuntimeTools]. Without the propagation, any tag-aware query
-// on the result (e.g. [TaggedToolNames], a subsequent FilterByTags
-// chain) silently returns nothing — a latent bug the convention
-// exists to prevent.
+// [WithRuntimeTools]. Without the propagation, tag-aware operations
+// on the result misbehave in two distinct ways: [TaggedToolNames]
+// returns nil for every tag (loses the tag→tool mapping entirely),
+// and a chained FilterByTags call takes the nil-index early-return
+// path so it stops narrowing — returning the full set unfiltered
+// instead of the intended subset. Either failure mode is a latent
+// bug; carrying tagIndex forward prevents both.
 func (r *Registry) FilterByTags(tags []string) *Registry {
 	if len(tags) == 0 || r.tagIndex == nil {
 		// No filtering — return a shallow copy with all tools.


### PR DESCRIPTION
## Summary

Caught by the v0.9.3 code-path audit (Phase 1.1). Every other shallow-copy method on `Registry` — `FilteredCopy`, `FilteredCopyExcluding`, `WithRuntimeTools` — propagates `tagIndex` to the returned copy. `FilterByTags` was the lone outlier: **both** the no-filter early-return path and the active-filter path left `tagIndex` nil on the result.

The bug is latent today (the current callers chain to `FilteredCopyExcluding`, which doesn't depend on `tagIndex`), but the Godoc promises "a copy of the full registry" and the convention every neighboring method follows is to carry the index forward. Without the propagation, any subsequent `TaggedToolNames` or chained `FilterByTags` on the returned copy silently returns nothing — exactly the kind of delete-the-index-then-query-the-index drift the convention exists to prevent.

## Changes

- **`internal/tools/tools.go`** — added `tagIndex: r.tagIndex` to the `Registry` literal in both branches of `FilterByTags`; expanded the Godoc to call out the propagation invariant alongside the sibling methods that follow it.
- **`internal/tools/capability_tools_test.go`** — added `TestRegistryFilterByTags_PreservesTagIndex` covering both the active-filter and no-filter paths. The no-filter sub-test would have failed against the prior code; the active-filter sub-test guards the more subtle case where the source has a tag index but the active-filter literal forgot to carry it.

## Other audit findings from the same Explore-agent pass — declined

The agent surfaced four candidates beyond this one; I acted on this one and declined the others:

- **`explicitTagScope` / `explicitScopeRequested` "redundancy"** — the agent missed the explicit-empty-scope case. `explicitTagScope=true, explicit_tags=[]` is a real and load-bearing call shape (see PR #952's `TestExecute_LoopBackedExplicitEmptyTagsExposeNoTools`). The two values can disagree and carry distinct signal; they aren't redundant.
- **Parallel arg-extraction helpers** (`stringArg`/`intArg`/`boolArg`/`boolArgDefault`/`uint32SliceArg`/`stringSliceArg` in `internal/channels/email/tools.go`) — subjective. The proposed generic replacement still needs per-type coercion logic and would replace six small clear functions with one less-clear one.
- **`delegateToolRegistry` dual return statements** — the agent's drift-risk argument doesn't hold (both returns call the same `delegateToolExclusions()` helper, so changes propagate). Refactoring to a single return is a minor clarity tweak without behavioral payoff.
- **`repairCapabilityToolCall` shim in loop.go** — intentional and documented; the audit flagged it as "skip-and-document" too. Plan a removal in a future major release.

## Test plan

- [x] `just ci` passes (fmt-check, mod-tidy-check, config-generate-check, architecture-check, link-check, lint @ 0 issues, race tests across every package)
- [x] New `TestRegistryFilterByTags_PreservesTagIndex` passes on both sub-tests (active-filter + no-filter)
- [x] Existing `FilterByTags` tests still pass — no behavior change for the call shapes already exercised