### PR TITLE
refactor(delegate): single-return shape for delegateToolRegistry

### DIFF
--- a/internal/runtime/delegate/delegate.go
+++ b/internal/runtime/delegate/delegate.go
@@ -160,18 +160,32 @@ func applyRunPolicyDefaultTags(scopeTags []string, policy *RunPolicy, explicitSc
 	return mergedTags, appliedDefaults
 }
 
+// delegateToolRegistry builds the catalog a delegate's executor sees
+// during its in-process setup phase (e.g. model-routing sizing in
+// selectModel). Two phases:
+//
+//  1. Optional tag narrowing. When the caller requested an explicit
+//     scope or supplied non-empty scope tags, narrow the parent
+//     registry by the union of scope tags and operator core tags.
+//     If that union is empty (explicit-empty-scope), FilteredCopy(nil)
+//     yields a registry with zero non-core tools.
+//
+//  2. Recursion guard. Strip the delegate family
+//     ([delegateToolExclusions]) so a delegate can't spawn another
+//     delegate. This step runs unconditionally — both the narrowed
+//     and unnarrowed paths funnel through it, single source of truth
+//     for the exclusion set.
 func (e *Executor) delegateToolRegistry(scopeTags []string, explicitScopeRequested bool) *tools.Registry {
+	reg := e.parentReg
 	if len(scopeTags) > 0 || explicitScopeRequested {
 		merged := mergeTagLists(scopeTags, e.coreTags)
-		var reg *tools.Registry
 		if len(merged) > 0 {
-			reg = e.parentReg.FilterByTags(merged)
+			reg = reg.FilterByTags(merged)
 		} else {
-			reg = e.parentReg.FilteredCopy(nil)
+			reg = reg.FilteredCopy(nil)
 		}
-		return reg.FilteredCopyExcluding(delegateToolExclusions())
 	}
-	return e.parentReg.FilteredCopyExcluding(delegateToolExclusions())
+	return reg.FilteredCopyExcluding(delegateToolExclusions())
 }
 
 func mergeTagLists(tagGroups ...[]string) []string {

--- a/internal/runtime/delegate/delegate.go
+++ b/internal/runtime/delegate/delegate.go
@@ -167,8 +167,13 @@ func applyRunPolicyDefaultTags(scopeTags []string, policy *RunPolicy, explicitSc
 //  1. Optional tag narrowing. When the caller requested an explicit
 //     scope or supplied non-empty scope tags, narrow the parent
 //     registry by the union of scope tags and operator core tags.
-//     If that union is empty (explicit-empty-scope), FilteredCopy(nil)
-//     yields a registry with zero non-core tools.
+//     FilterByTags preserves Tool.Core members so the tag-navigation
+//     surface stays reachable. When the union is empty
+//     (explicit-empty-scope with no core tags configured),
+//     FilteredCopy(nil) yields a zero-tool registry — FilteredCopy
+//     does not preserve Tool.Core, so the explicit-empty-scope
+//     delegate sees no tools at all. That's the documented contract
+//     covered by TestExecute_LoopBackedExplicitEmptyTagsExposeNoTools.
 //
 //  2. Recursion guard. Strip the delegate family
 //     ([delegateToolExclusions]) so a delegate can't spawn another


### PR DESCRIPTION
## Summary

Re-acted on a previously-declined code-path audit finding (PR #963 declined this; on reflection it was worth doing).

The two `FilteredCopyExcluding` return statements in `delegateToolRegistry` weren't a drift risk — both called the same `delegateToolExclusions` helper, so the exclusion set stays a single source of truth — but the duplication itself obscured the function's actual shape, which is **"optionally narrow, then always exclude the family."**

Hoist the parent registry into a local, do the optional narrow in-place, and return the unconditional exclusion once. Same behavior; the function is now a literal description of its two phases. Added a Godoc that names both phases explicitly so the next reader doesn't have to reverse-engineer the structure from the if/else.

## Why I re-evaluated

The original audit-decline reasoning ("minor clarity tweak without behavioral payoff") was weak. Clarity *is* a payoff. The next reviewer touching this function will ask the same question Copilot asked on PR #963 — preempting that by writing the function in its honest shape is a small, durable win.

Other declined audit findings remain declined:
- **`explicitTagScope` / `explicitScopeRequested`** — agent's "redundancy" claim is wrong (they carry distinct signal for the explicit-empty-scope case); the naming similarity is a smaller readability concern worth a rename pass next time someone touches the code, not blocking.
- **Parallel arg-extraction helpers across email / loop-definition / model-registry packages** — the agent's proposed "generic helper" fix was wrong but the underlying smell is real and *bigger* than the agent surfaced (three packages have prefixed copies, 167+ inline `args[].(type)` sites). Filing as a follow-up issue rather than rolling into v0.9.3.

## Test plan

- [x] `just ci` passes (fmt-check, mod-tidy-check, config-generate-check, architecture-check, link-check, lint @ 0 issues, race tests across every package)
- [x] All existing delegate tests pass unchanged
- [x] Branch coverage from PR #958 still exercises the three paths: tag-narrow, explicit-empty-scope, fall-through