### PR TITLE
refactor(awareness): emit Current Conditions as JSON, not bold-markdown prose

### DIFF
--- a/internal/state/awareness/conditions.go
+++ b/internal/state/awareness/conditions.go
@@ -15,19 +15,37 @@ import (
 	"strings"
 	"time"
 
+	"github.com/nugget/thane-ai-agent/internal/model/promptfmt"
 	"github.com/nugget/thane-ai-agent/internal/platform/buildinfo"
 )
 
+// conditionsPayload is the JSON projection emitted under the
+// "# Current Conditions" heading. Field names are stable across turns so
+// the model can compare snapshots; pre-computed fields (weekday,
+// uptime_seconds, environment) remove arithmetic the model would
+// otherwise have to do itself.
+type conditionsPayload struct {
+	Time           string `json:"time"`
+	TimeZone       string `json:"time_zone,omitempty"`
+	TimeZoneAbbrev string `json:"time_zone_abbrev"`
+	Weekday        string `json:"weekday"`
+	Host           string `json:"host"`
+	OS             string `json:"os"`
+	Arch           string `json:"arch"`
+	Environment    string `json:"environment"`
+	Version        string `json:"version"`
+	Commit         string `json:"commit"`
+	Branch         string `json:"branch"`
+	UptimeSeconds  int64  `json:"uptime_seconds"`
+}
+
 // CurrentConditions returns a formatted "# Current Conditions" section
-// for injection into the system prompt. The timezone parameter should be
-// an IANA timezone name (e.g., "America/Chicago"). If empty or invalid,
-// the system's local timezone is used.
+// for injection into the system prompt. The body is a compact JSON object
+// (typed runtime state per docs/model-facing-context.md). The timezone
+// parameter should be an IANA timezone name (e.g., "America/Chicago"). If
+// empty or invalid, the system's local timezone is used and the IANA name
+// is omitted from the output.
 func CurrentConditions(timezone string) string {
-	var sb strings.Builder
-
-	sb.WriteString("# Current Conditions\n\n")
-
-	// Time — use configured timezone, fall back to system local.
 	loc := time.Now().Location()
 	tzResolved := false
 	if timezone != "" {
@@ -37,35 +55,33 @@ func CurrentConditions(timezone string) string {
 		}
 	}
 	now := time.Now().In(loc)
-	zoneName, _ := now.Zone()
+	zoneAbbrev, _ := now.Zone()
 
-	// Format: Saturday, February 14, 2026 at 15:45 CST (America/Chicago)
-	sb.WriteString("**Time:** ")
-	sb.WriteString(now.Format("Monday, January 2, 2006 at 15:04 "))
-	sb.WriteString(zoneName)
-	// Include IANA name when we successfully resolved a configured timezone.
-	if tzResolved && timezone != zoneName {
-		sb.WriteString(" (")
-		sb.WriteString(timezone)
-		sb.WriteString(")")
-	}
-	sb.WriteString("\n")
-
-	// Host — hostname, OS/arch, bare metal vs container.
 	hostname, _ := os.Hostname()
 	if hostname == "" {
 		hostname = "unknown"
 	}
-	env := detectEnvironment()
-	fmt.Fprintf(&sb, "**Host:** %s (%s/%s, %s)\n", hostname, runtime.GOOS, runtime.GOARCH, env)
 
-	// Thane — version and commit.
-	fmt.Fprintf(&sb, "**Thane:** %s (%s@%s)\n", buildinfo.Version, buildinfo.GitCommit, buildinfo.GitBranch)
+	payload := conditionsPayload{
+		Time:           now.Format(time.RFC3339),
+		TimeZoneAbbrev: zoneAbbrev,
+		Weekday:        now.Weekday().String(),
+		Host:           hostname,
+		OS:             runtime.GOOS,
+		Arch:           runtime.GOARCH,
+		Environment:    detectEnvironment(),
+		Version:        buildinfo.Version,
+		Commit:         buildinfo.GitCommit,
+		Branch:         buildinfo.GitBranch,
+		UptimeSeconds:  int64(buildinfo.Uptime().Truncate(time.Second).Seconds()),
+	}
+	if tzResolved {
+		payload.TimeZone = timezone
+	}
 
-	// Uptime.
-	uptime := buildinfo.Uptime()
-	fmt.Fprintf(&sb, "**Uptime:** %s", formatUptime(uptime))
-
+	var sb strings.Builder
+	sb.WriteString("# Current Conditions\n\n")
+	sb.WriteString(promptfmt.MarshalCompact(payload))
 	return sb.String()
 }
 
@@ -96,7 +112,10 @@ func detectEnvironment() string {
 }
 
 // formatUptime formats a duration as a human-readable uptime string.
-// Examples: "4h 23m", "2d 5h", "45m", "30s".
+// Examples: "4h 23m", "2d 5h", "45m", "30s". Used only by
+// FormatContextUsage for the operator-facing context line, where a
+// compact human-readable string is preferred over a delta. CurrentConditions
+// emits uptime as a raw seconds integer inside the JSON payload.
 func formatUptime(d time.Duration) string {
 	if d < time.Minute {
 		return fmt.Sprintf("%ds", int(d.Seconds()))

--- a/internal/state/awareness/conditions.go
+++ b/internal/state/awareness/conditions.go
@@ -73,7 +73,7 @@ func CurrentConditions(timezone string) string {
 		Version:        buildinfo.Version,
 		Commit:         buildinfo.GitCommit,
 		Branch:         buildinfo.GitBranch,
-		UptimeSeconds:  int64(buildinfo.Uptime().Truncate(time.Second).Seconds()),
+		UptimeSeconds:  int64(buildinfo.Uptime() / time.Second),
 	}
 	if tzResolved {
 		payload.TimeZone = timezone

--- a/internal/state/awareness/conditions_test.go
+++ b/internal/state/awareness/conditions_test.go
@@ -1,60 +1,78 @@
 package awareness
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 	"time"
 )
 
-func TestCurrentConditions_ContainsRequiredSections(t *testing.T) {
-	result := CurrentConditions("")
+// parseConditionsBody extracts the JSON payload that follows the
+// "# Current Conditions\n\n" heading and unmarshals it for assertion.
+func parseConditionsBody(t *testing.T, out string) map[string]any {
+	t.Helper()
+
+	const heading = "# Current Conditions\n\n"
+	if !strings.HasPrefix(out, heading) {
+		t.Fatalf("CurrentConditions output missing heading prefix\nGot:\n%s", out)
+	}
+	body := strings.TrimPrefix(out, heading)
+
+	var got map[string]any
+	if err := json.Unmarshal([]byte(body), &got); err != nil {
+		t.Fatalf("CurrentConditions body not valid JSON: %v\nBody: %s", err, body)
+	}
+	return got
+}
+
+func TestCurrentConditions_JSONPayloadHasRequiredFields(t *testing.T) {
+	got := parseConditionsBody(t, CurrentConditions(""))
 
 	required := []string{
-		"# Current Conditions",
-		"**Time:**",
-		"**Host:**",
-		"**Thane:**",
-		"**Uptime:**",
+		"time", "time_zone_abbrev", "weekday",
+		"host", "os", "arch", "environment",
+		"version", "commit", "branch", "uptime_seconds",
 	}
-
-	for _, section := range required {
-		if !strings.Contains(result, section) {
-			t.Errorf("CurrentConditions() missing %q\nGot:\n%s", section, result)
+	for _, field := range required {
+		if _, ok := got[field]; !ok {
+			t.Errorf("conditions JSON missing %q field\nGot: %v", field, got)
 		}
 	}
-}
 
-func TestCurrentConditions_WithTimezone(t *testing.T) {
-	result := CurrentConditions("America/Chicago")
-
-	if !strings.Contains(result, "America/Chicago") {
-		t.Errorf("CurrentConditions(America/Chicago) should include timezone name\nGot:\n%s", result)
+	if _, err := time.Parse(time.RFC3339, got["time"].(string)); err != nil {
+		t.Errorf("conditions.time not RFC3339: %v", err)
 	}
 }
 
-func TestCurrentConditions_InvalidTimezone(t *testing.T) {
-	// Use a timezone name that time.LoadLocation rejects on all platforms.
+func TestCurrentConditions_WithTimezoneSetsIANAName(t *testing.T) {
+	got := parseConditionsBody(t, CurrentConditions("America/Chicago"))
+
+	if tz, _ := got["time_zone"].(string); tz != "America/Chicago" {
+		t.Errorf("conditions.time_zone = %q; want America/Chicago", tz)
+	}
+}
+
+func TestCurrentConditions_InvalidTimezoneOmitsIANA(t *testing.T) {
 	const bogus = "Bogus/ZZZZZ_Not_Real_12345"
 	if _, err := time.LoadLocation(bogus); err == nil {
 		t.Skip("platform resolved bogus timezone; cannot test fallback")
 	}
 
-	result := CurrentConditions(bogus)
+	got := parseConditionsBody(t, CurrentConditions(bogus))
 
-	if !strings.Contains(result, "**Time:**") {
-		t.Errorf("CurrentConditions with invalid timezone should still include time\nGot:\n%s", result)
+	if _, ok := got["time_zone"]; ok {
+		t.Errorf("conditions.time_zone should be omitted for invalid timezone\nGot: %v", got["time_zone"])
 	}
-	// Should NOT contain the invalid timezone name.
-	if strings.Contains(result, bogus) {
-		t.Errorf("CurrentConditions with invalid timezone should not include invalid name\nGot:\n%s", result)
+	if tz, _ := got["time_zone_abbrev"].(string); tz == "" {
+		t.Errorf("conditions.time_zone_abbrev should still be present")
 	}
 }
 
-func TestCurrentConditions_EmptyTimezone(t *testing.T) {
-	// Should use local timezone.
-	result := CurrentConditions("")
-	if !strings.Contains(result, "**Time:**") {
-		t.Errorf("CurrentConditions('') should still include time\nGot:\n%s", result)
+func TestCurrentConditions_EmptyTimezoneOmitsIANA(t *testing.T) {
+	got := parseConditionsBody(t, CurrentConditions(""))
+
+	if _, ok := got["time_zone"]; ok {
+		t.Errorf("conditions.time_zone should be omitted when no timezone is configured")
 	}
 }
 

--- a/internal/state/awareness/conditions_test.go
+++ b/internal/state/awareness/conditions_test.go
@@ -39,7 +39,11 @@ func TestCurrentConditions_JSONPayloadHasRequiredFields(t *testing.T) {
 		}
 	}
 
-	if _, err := time.Parse(time.RFC3339, got["time"].(string)); err != nil {
+	timeStr, ok := got["time"].(string)
+	if !ok {
+		t.Fatalf("conditions.time should be a string, got %T: %v", got["time"], got["time"])
+	}
+	if _, err := time.Parse(time.RFC3339, timeStr); err != nil {
 		t.Errorf("conditions.time not RFC3339: %v", err)
 	}
 }


### PR DESCRIPTION
Phase 1.3 model-facing context audit — **High #1** finding (full audit summary in #967).

The always-on \`# Current Conditions\` block at the top of every system prompt was emitting bold-markdown labels for what is generated runtime state:

```
**Time:** Saturday, May 26, 2026 at 14:23 CDT (America/Chicago)
**Host:** pocket (darwin/arm64, bare metal)
**Thane:** v0.9.2-79 (abc123@main)
**Uptime:** 4h 23m
```

Per [docs/model-facing-context.md](docs/model-facing-context.md), typed JSON is the default shape for generated runtime data — markdown is for section boundaries and behavioral instructions, not data fields. The block now reads:

```
# Current Conditions

{"time":"2026-05-26T14:23:00-05:00","time_zone":"America/Chicago","time_zone_abbrev":"CDT","weekday":"Saturday","host":"pocket","os":"darwin","arch":"arm64","environment":"bare metal","version":"v0.9.2-79","commit":"abc123","branch":"main","uptime_seconds":15780}
```

## What changed

- Body of \`CurrentConditions\` is a compact JSON object marshaled with \`promptfmt.MarshalCompact\`.
- Two pre-computed fields save the model arithmetic it's unreliable at:
  - \`weekday\` — derived from the resolved time.
  - \`uptime_seconds\` — integer duration replacing the inline-assembled \"Xd Yh Zm\" string.
- \`time\` keeps absolute RFC3339 + timezone abbreviation. Wall-clock anchoring is the section's literal purpose — explicit spec exemption.
- \`time_zone\` (IANA name) uses \`omitempty\`; absent when no timezone is configured or it failed to resolve.

## What didn't change

- The heading (\`# Current Conditions\`) and its placement in prompt assembly.
- The local \`formatUptime\` helper stays in the package — still consumed by \`FormatContextUsage\` for the operator-facing \"Context:\" line further down in the prompt. That block is bold-prose for separate reasons; rewriting it isn't in this scope.

## Test plan

- [x] Updated \`conditions_test.go\` parses the JSON body and asserts field presence, RFC3339 shape, IANA-name presence/absence based on input.
- [x] \`just ci\` green locally.
- [ ] Live prompt assembly produces parseable JSON on \`pocket\` after deploy.

Refs #967.