### PR TITLE
refactor(memory): archive prewarm uses JSON projection like sibling providers

### DIFF
--- a/internal/state/memory/archive_provider.go
+++ b/internal/state/memory/archive_provider.go
@@ -175,26 +175,43 @@ func stripSubjectPrefix(s string) string {
 // docs/model-facing-context.md.
 const archiveSectionHeading = "### Past Experience\n\n"
 
+// Prewarm-specific projection bounds. These are tighter than
+// FormatSearchResults' defaults because the prewarm block has a much
+// smaller byte budget than archive_search/archive_range tool output
+// (default 4 KB vs. the tool's full byte cap). Without trimming, a
+// single normal hit can carry up to 5 context messages × ~2 KB each
+// and overflow the prewarm budget on its own. With these caps, even
+// the most context-rich hit comfortably fits one or two hits inside
+// the default budget while preserving the JSON schema sibling
+// providers emit.
+const (
+	prewarmContextPerSide    = 2
+	prewarmMessageContentMax = 300
+)
+
 // formatResults renders archive search hits as a heading followed by a
-// JSON projection produced by FormatSearchResults. The hits are trimmed
-// from the tail until the rendered output fits in p.maxBytes; the
-// truncated flag in the JSON tells the model when results were dropped.
-// Returns empty string when there are no hits to render or when not
-// even one hit fits in the byte budget.
+// JSON projection produced by FormatSearchResults. Hits are first
+// trimmed for the prewarm budget (smaller per-message content cap and
+// fewer context messages per side than the archive tools use), then
+// the hit list is shortened from the tail until the rendered output
+// fits in p.maxBytes. The truncated flag in the JSON tells the model
+// when hits were dropped. Returns empty string when there are no hits
+// to render or when not even one trimmed hit fits in the byte budget.
 func (p *ArchiveContextProvider) formatResults(results []SearchResult) string {
 	if len(results) == 0 {
 		return ""
 	}
 	now := time.Now()
+	trimmed := trimResultsForPrewarm(results)
 
-	for n := len(results); n > 0; n-- {
-		body := FormatSearchResults(results[:n], now, n < len(results))
+	for n := len(trimmed); n > 0; n-- {
+		body := FormatSearchResults(trimmed[:n], now, n < len(trimmed))
 		out := archiveSectionHeading + string(body)
 		if len(out) <= p.maxBytes {
-			if n < len(results) {
+			if n < len(trimmed) {
 				p.logger.Debug("archive pre-warm: trimmed to fit byte budget",
 					"included", n,
-					"total", len(results),
+					"total", len(trimmed),
 					"budget", p.maxBytes,
 					"size", len(out),
 				)
@@ -204,10 +221,77 @@ func (p *ArchiveContextProvider) formatResults(results []SearchResult) string {
 	}
 
 	p.logger.Debug("archive pre-warm: not even one hit fits byte budget",
-		"total", len(results),
+		"total", len(trimmed),
 		"budget", p.maxBytes,
 	)
 	return ""
+}
+
+// trimResultsForPrewarm returns a copy of results with each hit's
+// context window narrowed to [prewarmContextPerSide] messages on each
+// side and every message's content clipped to
+// [prewarmMessageContentMax] bytes. This keeps a single hit small
+// enough to fit comfortably under the typical prewarm byte budget;
+// FormatSearchResults applies its own (larger) caps on top, so the
+// tighter prewarm bounds win.
+func trimResultsForPrewarm(results []SearchResult) []SearchResult {
+	out := make([]SearchResult, len(results))
+	for i, r := range results {
+		before := r.ContextBefore
+		if len(before) > prewarmContextPerSide {
+			before = before[len(before)-prewarmContextPerSide:]
+		}
+		after := r.ContextAfter
+		if len(after) > prewarmContextPerSide {
+			after = after[:prewarmContextPerSide]
+		}
+		out[i] = SearchResult{
+			SessionID:     r.SessionID,
+			Match:         clipMessageContent(r.Match, prewarmMessageContentMax),
+			ContextBefore: clipMessageSlice(before, prewarmMessageContentMax),
+			ContextAfter:  clipMessageSlice(after, prewarmMessageContentMax),
+			Highlight:     r.Highlight,
+		}
+	}
+	return out
+}
+
+// clipMessageContent returns m with Content truncated to max bytes on
+// a UTF-8 boundary. The original message is not mutated; the returned
+// value is a shallow copy with the clipped Content.
+func clipMessageContent(m Message, max int) Message {
+	if len(m.Content) <= max {
+		return m
+	}
+	m.Content = clipToRuneBoundary(m.Content, max)
+	return m
+}
+
+// clipMessageSlice applies clipMessageContent to each entry, returning
+// a new slice. Nil input returns nil.
+func clipMessageSlice(msgs []Message, max int) []Message {
+	if msgs == nil {
+		return nil
+	}
+	out := make([]Message, len(msgs))
+	for i, m := range msgs {
+		out[i] = clipMessageContent(m, max)
+	}
+	return out
+}
+
+// clipToRuneBoundary truncates s to at most max bytes, stepping back
+// to the previous UTF-8 boundary if max falls inside a multi-byte
+// rune so the returned string is always valid UTF-8.
+func clipToRuneBoundary(s string, max int) string {
+	if len(s) <= max {
+		return s
+	}
+	cut := max
+	for cut > 0 && (s[cut]&0xC0) == 0x80 {
+		cut--
+	}
+	return s[:cut]
 }
 
 // previewContent shortens message content for debug logging. Output is

--- a/internal/state/memory/archive_provider.go
+++ b/internal/state/memory/archive_provider.go
@@ -2,12 +2,10 @@ package memory
 
 import (
 	"context"
-	"fmt"
 	"log/slog"
 	"strings"
 	"time"
 
-	"github.com/nugget/thane-ai-agent/internal/model/promptfmt"
 	"github.com/nugget/thane-ai-agent/internal/runtime/agentctx"
 	"github.com/nugget/thane-ai-agent/internal/state/knowledge"
 )
@@ -114,7 +112,7 @@ func (p *ArchiveContextProvider) TagContext(ctx context.Context, req agentctx.Co
 			"index", i,
 			"session_id", r.SessionID,
 			"match_role", r.Match.Role,
-			"match_preview", truncateContent(r.Match.Content),
+			"match_preview", previewContent(r.Match.Content),
 			"context_before", len(r.ContextBefore),
 			"context_after", len(r.ContextAfter),
 		)
@@ -171,111 +169,61 @@ func stripSubjectPrefix(s string) string {
 	return s
 }
 
-// maxMessageChars is the per-message content truncation limit for
-// formatted archive results.
-const maxMessageChars = 200
+// archiveSectionHeading is the markdown heading the prewarm block emits
+// above its JSON payload. The heading is markdown framing (a section
+// boundary); the payload below is typed JSON per
+// docs/model-facing-context.md.
+const archiveSectionHeading = "### Past Experience\n\n"
 
-// formatResults renders archive search results as markdown suitable for
-// system prompt injection. Output is capped at p.maxBytes; if results
-// are truncated, a note indicates how many were omitted.
+// formatResults renders archive search hits as a heading followed by a
+// JSON projection produced by FormatSearchResults. The hits are trimmed
+// from the tail until the rendered output fits in p.maxBytes; the
+// truncated flag in the JSON tells the model when results were dropped.
+// Returns empty string when there are no hits to render or when not
+// even one hit fits in the byte budget.
 func (p *ArchiveContextProvider) formatResults(results []SearchResult) string {
-	var sb strings.Builder
-	sb.WriteString("### Past Experience\n\n")
-
-	included := 0
-	for i, r := range results {
-		var block strings.Builder
-		block.WriteString(formatResultBlock(r))
-		if i < len(results)-1 {
-			block.WriteByte('\n')
-		}
-
-		// Check byte budget before adding this block. If it won't fit,
-		// append a truncation notice only if that itself fits.
-		if sb.Len()+block.Len() > p.maxBytes {
-			remaining := len(results) - included
-			p.logger.Debug("archive pre-warm: byte budget truncation",
-				"included", included,
-				"total", len(results),
-				"budget", p.maxBytes,
-				"used", sb.Len(),
-			)
-			truncationMsg := fmt.Sprintf(
-				"*(%d additional result(s) omitted — byte budget reached)*\n",
-				remaining,
-			)
-			if sb.Len()+len(truncationMsg) <= p.maxBytes {
-				sb.WriteString(truncationMsg)
-			}
-			break
-		}
-
-		sb.WriteString(block.String())
-		included++
-	}
-
-	if included == 0 {
+	if len(results) == 0 {
 		return ""
 	}
+	now := time.Now()
 
-	return sb.String()
+	for n := len(results); n > 0; n-- {
+		body := FormatSearchResults(results[:n], now, n < len(results))
+		out := archiveSectionHeading + string(body)
+		if len(out) <= p.maxBytes {
+			if n < len(results) {
+				p.logger.Debug("archive pre-warm: trimmed to fit byte budget",
+					"included", n,
+					"total", len(results),
+					"budget", p.maxBytes,
+					"size", len(out),
+				)
+			}
+			return out
+		}
+	}
+
+	p.logger.Debug("archive pre-warm: not even one hit fits byte budget",
+		"total", len(results),
+		"budget", p.maxBytes,
+	)
+	return ""
 }
 
-// formatResultBlock renders a single search result as a markdown block
-// with session date, matched message (bolded), and surrounding context.
-func formatResultBlock(r SearchResult) string {
-	var sb strings.Builder
-
-	// Header: date and session ID prefix.
-	sessionShort := promptfmt.ShortIDPrefix(r.SessionID)
-	date := r.Match.Timestamp.Format(time.DateOnly)
-	sb.WriteString(fmt.Sprintf("**%s — Session %s:**\n", date, sessionShort))
-
-	// Context before (up to 2 messages for brevity).
-	before := r.ContextBefore
-	if len(before) > 2 {
-		before = before[len(before)-2:]
-	}
-	for _, m := range before {
-		sb.WriteString(fmt.Sprintf("> [%s] %s\n", m.Role, truncateContent(m.Content)))
-	}
-
-	// Matched message — bolded.
-	sb.WriteString(fmt.Sprintf("> **[%s] %s**\n", r.Match.Role, truncateContent(r.Match.Content)))
-
-	// Context after (up to 2 messages for brevity).
-	after := r.ContextAfter
-	if len(after) > 2 {
-		after = after[:2]
-	}
-	for _, m := range after {
-		sb.WriteString(fmt.Sprintf("> [%s] %s\n", m.Role, truncateContent(m.Content)))
-	}
-
-	return sb.String()
-}
-
-// truncateContent shortens message content for display, preserving the
-// first line and trimming at maxMessageChars.
-func truncateContent(s string) string {
+// previewContent shortens message content for debug logging. Output is
+// not model-facing; the model sees the JSON projection from
+// FormatSearchResults instead.
+func previewContent(s string) string {
+	const max = 80
 	s = strings.TrimSpace(s)
 	if s == "" {
 		return "(empty)"
 	}
-
-	// Collapse to first line if multi-line.
 	if idx := strings.IndexByte(s, '\n'); idx >= 0 {
-		s = s[:idx] + "..."
+		s = s[:idx]
 	}
-
-	if len(s) > maxMessageChars {
-		// Respect UTF-8 boundary by truncating at last space before limit.
-		if idx := strings.LastIndexByte(s[:maxMessageChars], ' '); idx > maxMessageChars/2 {
-			s = s[:idx] + "..."
-		} else {
-			s = s[:maxMessageChars] + "..."
-		}
+	if len(s) > max {
+		s = s[:max] + "..."
 	}
-
 	return s
 }

--- a/internal/state/memory/archive_provider_test.go
+++ b/internal/state/memory/archive_provider_test.go
@@ -231,6 +231,60 @@ func TestArchiveContextProvider_GetContext(t *testing.T) {
 		}
 	})
 
+	t.Run("rich_hit_fits_default_4kb_budget", func(t *testing.T) {
+		// Regression coverage for #969 review: a single hit with the full
+		// context window the archive_search tool would return (5 messages
+		// per side, ~2KB content each) must still fit under the prewarm
+		// default budget. Prewarm trimming caps context-per-side and
+		// content size so the projection fits without dropping the hit.
+		big := strings.Repeat("paragraph of content text ", 80) // ~2KB
+		ctxMsgs := make([]Message, 5)
+		for i := range ctxMsgs {
+			ctxMsgs[i] = Message{Role: "user", Content: big, Timestamp: ts.Add(-time.Minute * time.Duration(5-i))}
+		}
+		afterMsgs := make([]Message, 5)
+		for i := range afterMsgs {
+			afterMsgs[i] = Message{Role: "user", Content: big, Timestamp: ts.Add(time.Minute * time.Duration(i+1))}
+		}
+		mock := &mockArchiveSearcher{
+			results: []SearchResult{
+				makeResultWithContext("sess-rich", "assistant", big, ctxMsgs, afterMsgs),
+			},
+		}
+		p := NewArchiveContextProvider(mock, 5, 4000, nil)
+
+		ctx := knowledge.WithSubjects(context.Background(), []string{"entity:meaning.of.life"})
+		got, err := p.TagContext(ctx, agentctx.ContextRequest{UserMessage: ""})
+		if err != nil {
+			t.Fatalf("TagContext: %v", err)
+		}
+		if got == "" {
+			t.Fatalf("expected the trimmed hit to fit under the 4KB prewarm budget")
+		}
+		if len(got) > 4000 {
+			t.Errorf("output length %d exceeds budget 4000", len(got))
+		}
+		payload := parseArchiveBody(t, got)
+		if len(payload.Results) != 1 {
+			t.Fatalf("expected 1 result, got %d", len(payload.Results))
+		}
+		// Match content is clipped to the prewarm cap.
+		match := payload.Results[0]["match"].(map[string]any)
+		matchContent := match["content"].(string)
+		if len(matchContent) > prewarmMessageContentMax {
+			t.Errorf("match.content length %d exceeds prewarm cap %d", len(matchContent), prewarmMessageContentMax)
+		}
+		// Context is narrowed to prewarmContextPerSide on each side.
+		before, _ := payload.Results[0]["context_before"].([]any)
+		after, _ := payload.Results[0]["context_after"].([]any)
+		if len(before) > prewarmContextPerSide {
+			t.Errorf("context_before len %d exceeds prewarm cap %d", len(before), prewarmContextPerSide)
+		}
+		if len(after) > prewarmContextPerSide {
+			t.Errorf("context_after len %d exceeds prewarm cap %d", len(after), prewarmContextPerSide)
+		}
+	})
+
 	t.Run("byte_budget_too_small_returns_empty", func(t *testing.T) {
 		mock := &mockArchiveSearcher{
 			results: []SearchResult{

--- a/internal/state/memory/archive_provider_test.go
+++ b/internal/state/memory/archive_provider_test.go
@@ -2,6 +2,7 @@ package memory
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
 	"testing"
@@ -25,6 +26,29 @@ func (m *mockArchiveSearcher) Search(opts SearchOptions) ([]SearchResult, error)
 	m.lastQuery = opts.Query
 	m.lastLimit = opts.Limit
 	return m.results, m.err
+}
+
+// archivePayload is the projection produced under the "### Past
+// Experience" heading. Mirrors the shape of FormatSearchResults so the
+// tests can decode without depending on json tags directly.
+type archivePayload struct {
+	Results   []map[string]any `json:"results"`
+	Truncated bool             `json:"truncated"`
+}
+
+// parseArchiveBody extracts the JSON body that follows the
+// "### Past Experience" heading and returns it for inspection.
+func parseArchiveBody(t *testing.T, out string) archivePayload {
+	t.Helper()
+	if !strings.HasPrefix(out, archiveSectionHeading) {
+		t.Fatalf("archive output missing heading prefix\nGot:\n%s", out)
+	}
+	body := strings.TrimPrefix(out, archiveSectionHeading)
+	var payload archivePayload
+	if err := json.Unmarshal([]byte(body), &payload); err != nil {
+		t.Fatalf("archive body not valid JSON: %v\nBody: %s", err, body)
+	}
+	return payload
 }
 
 func TestArchiveContextProvider_GetContext(t *testing.T) {
@@ -61,16 +85,21 @@ func TestArchiveContextProvider_GetContext(t *testing.T) {
 		ctx := knowledge.WithSubjects(context.Background(), []string{"entity:switch.pool_heater"})
 		got, err := p.TagContext(ctx, agentctx.ContextRequest{UserMessage: ""})
 		if err != nil {
-			t.Fatalf("GetContext: %v", err)
+			t.Fatalf("TagContext: %v", err)
 		}
-		if !strings.Contains(got, "Past Experience") {
-			t.Error("output should contain 'Past Experience' heading")
+		if !strings.HasPrefix(got, "### Past Experience") {
+			t.Errorf("output should start with '### Past Experience' heading, got:\n%s", got)
 		}
-		if !strings.Contains(got, "pool heater") {
-			t.Error("output should contain matched message content")
+		payload := parseArchiveBody(t, got)
+		if len(payload.Results) != 1 {
+			t.Fatalf("expected 1 result, got %d", len(payload.Results))
 		}
-		if !strings.Contains(got, "sess-abc") {
-			t.Error("output should contain session ID prefix")
+		match := payload.Results[0]["match"].(map[string]any)
+		if !strings.Contains(match["content"].(string), "pool heater") {
+			t.Errorf("match content should mention pool heater, got %q", match["content"])
+		}
+		if got, want := match["session_id"], "sess-abc"; got != want {
+			t.Errorf("session_id = %v, want %v", got, want)
 		}
 		if mock.lastQuery != "switch.pool_heater" {
 			t.Errorf("query = %q, want %q", mock.lastQuery, "switch.pool_heater")
@@ -83,7 +112,7 @@ func TestArchiveContextProvider_GetContext(t *testing.T) {
 
 		got, err := p.TagContext(context.Background(), agentctx.ContextRequest{UserMessage: ""})
 		if err != nil {
-			t.Fatalf("GetContext: %v", err)
+			t.Fatalf("TagContext: %v", err)
 		}
 		if got != "" {
 			t.Errorf("expected empty, got %q", got)
@@ -103,7 +132,7 @@ func TestArchiveContextProvider_GetContext(t *testing.T) {
 
 		got, err := p.TagContext(context.Background(), agentctx.ContextRequest{UserMessage: "pool heater schedule"})
 		if err != nil {
-			t.Fatalf("GetContext: %v", err)
+			t.Fatalf("TagContext: %v", err)
 		}
 		if got == "" {
 			t.Fatal("expected output from message fallback")
@@ -136,7 +165,7 @@ func TestArchiveContextProvider_GetContext(t *testing.T) {
 
 		got, err := p.TagContext(context.Background(), agentctx.ContextRequest{UserMessage: "line one\nline two"})
 		if err != nil {
-			t.Fatalf("GetContext: %v", err)
+			t.Fatalf("TagContext: %v", err)
 		}
 		if got != "" {
 			t.Errorf("expected empty for multiline message, got %q", got)
@@ -150,7 +179,7 @@ func TestArchiveContextProvider_GetContext(t *testing.T) {
 		ctx := knowledge.WithSubjects(context.Background(), []string{"entity:sensor.fake"})
 		got, err := p.TagContext(ctx, agentctx.ContextRequest{UserMessage: ""})
 		if err != nil {
-			t.Fatalf("GetContext: %v", err)
+			t.Fatalf("TagContext: %v", err)
 		}
 		if got != "" {
 			t.Errorf("expected empty for no results, got %q", got)
@@ -171,28 +200,52 @@ func TestArchiveContextProvider_GetContext(t *testing.T) {
 		}
 	})
 
-	t.Run("max_bytes_cap_respected", func(t *testing.T) {
-		// Create results with enough content to exceed a small byte budget.
+	t.Run("byte_budget_trims_and_marks_truncated", func(t *testing.T) {
 		mock := &mockArchiveSearcher{
 			results: []SearchResult{
-				makeResult("sess-001", "assistant", "First result with some content that takes up space."),
-				makeResult("sess-002", "assistant", "Second result with more content."),
-				makeResult("sess-003", "assistant", "Third result that should be omitted."),
+				makeResult("sess-001", "assistant", strings.Repeat("First result content. ", 30)),
+				makeResult("sess-002", "assistant", strings.Repeat("Second result content. ", 30)),
+				makeResult("sess-003", "assistant", strings.Repeat("Third result content. ", 30)),
 			},
 		}
-		// Very tight budget: only room for heading + ~1 result.
-		p := NewArchiveContextProvider(mock, 5, 200, nil)
+		// Tight budget — should fit one or two results, not all three.
+		p := NewArchiveContextProvider(mock, 5, 900, nil)
 
 		ctx := knowledge.WithSubjects(context.Background(), []string{"entity:light.office"})
 		got, err := p.TagContext(ctx, agentctx.ContextRequest{UserMessage: ""})
 		if err != nil {
-			t.Fatalf("GetContext: %v", err)
+			t.Fatalf("TagContext: %v", err)
 		}
-		if len(got) > 300 { // allow some slack for truncation notice
-			t.Errorf("output length %d exceeds expected cap", len(got))
+		if len(got) > 900 {
+			t.Errorf("output length %d exceeds budget 900", len(got))
 		}
-		if !strings.Contains(got, "omitted") {
-			t.Error("expected truncation notice when results are capped")
+		payload := parseArchiveBody(t, got)
+		if len(payload.Results) == 0 {
+			t.Fatal("expected at least one result to fit")
+		}
+		if len(payload.Results) == 3 {
+			t.Error("expected truncation to drop at least one result")
+		}
+		if !payload.Truncated {
+			t.Error("truncated flag should be set when results are dropped")
+		}
+	})
+
+	t.Run("byte_budget_too_small_returns_empty", func(t *testing.T) {
+		mock := &mockArchiveSearcher{
+			results: []SearchResult{
+				makeResult("sess-001", "assistant", strings.Repeat("very large content ", 50)),
+			},
+		}
+		p := NewArchiveContextProvider(mock, 5, 50, nil)
+
+		ctx := knowledge.WithSubjects(context.Background(), []string{"entity:foo"})
+		got, err := p.TagContext(ctx, agentctx.ContextRequest{UserMessage: ""})
+		if err != nil {
+			t.Fatalf("TagContext: %v", err)
+		}
+		if got != "" {
+			t.Errorf("expected empty when nothing fits, got:\n%s", got)
 		}
 	})
 
@@ -256,7 +309,7 @@ func TestArchiveContextProvider_GetContext(t *testing.T) {
 		}
 	})
 
-	t.Run("context_messages_included", func(t *testing.T) {
+	t.Run("context_messages_included_as_metadata", func(t *testing.T) {
 		mock := &mockArchiveSearcher{
 			results: []SearchResult{
 				makeResultWithContext("sess-ctx", "assistant", "The answer is 42.",
@@ -274,31 +327,50 @@ func TestArchiveContextProvider_GetContext(t *testing.T) {
 		ctx := knowledge.WithSubjects(context.Background(), []string{"entity:meaning.of.life"})
 		got, err := p.TagContext(ctx, agentctx.ContextRequest{UserMessage: ""})
 		if err != nil {
-			t.Fatalf("GetContext: %v", err)
+			t.Fatalf("TagContext: %v", err)
 		}
-		if !strings.Contains(got, "What is the answer?") {
-			t.Error("output should contain context before")
+		payload := parseArchiveBody(t, got)
+		if len(payload.Results) != 1 {
+			t.Fatalf("expected 1 result, got %d", len(payload.Results))
 		}
-		if !strings.Contains(got, "The answer is 42.") {
-			t.Error("output should contain matched message")
+		hit := payload.Results[0]
+		before, _ := hit["context_before"].([]any)
+		after, _ := hit["context_after"].([]any)
+		if len(before) != 1 || len(after) != 1 {
+			t.Errorf("expected one context message on each side, got before=%d after=%d", len(before), len(after))
 		}
-		if !strings.Contains(got, "Thanks!") {
-			t.Error("output should contain context after")
+		matchContent := hit["match"].(map[string]any)["content"].(string)
+		if !strings.Contains(matchContent, "The answer is 42.") {
+			t.Errorf("match.content should be the match body, got %q", matchContent)
 		}
 	})
 
-	t.Run("match_is_bolded", func(t *testing.T) {
+	t.Run("delta_timestamps_not_absolute", func(t *testing.T) {
 		mock := &mockArchiveSearcher{
 			results: []SearchResult{
-				makeResult("sess-bold", "assistant", "Important finding."),
+				makeResult("sess-time", "assistant", "Some past observation."),
 			},
 		}
 		p := NewArchiveContextProvider(mock, 3, 4000, nil)
 
 		ctx := knowledge.WithSubjects(context.Background(), []string{"entity:test"})
-		got, _ := p.TagContext(ctx, agentctx.ContextRequest{UserMessage: ""})
-		if !strings.Contains(got, "**[assistant] Important finding.**") {
-			t.Errorf("matched message should be bolded, got:\n%s", got)
+		got, err := p.TagContext(ctx, agentctx.ContextRequest{UserMessage: ""})
+		if err != nil {
+			t.Fatalf("TagContext: %v", err)
+		}
+		// Delta format is "-Ns" or "+Ns"; absolute would contain "T" between date/time.
+		// Make sure no date-only or RFC3339 timestamp shows up in the payload.
+		if strings.Contains(got, ts.Format(time.DateOnly)) {
+			t.Errorf("output should use deltas, not absolute date %q\nGot:\n%s", ts.Format(time.DateOnly), got)
+		}
+		if strings.Contains(got, ts.Format(time.RFC3339)) {
+			t.Errorf("output should use deltas, not RFC3339\nGot:\n%s", got)
+		}
+		payload := parseArchiveBody(t, got)
+		match := payload.Results[0]["match"].(map[string]any)
+		tField, _ := match["t"].(string)
+		if !strings.HasPrefix(tField, "-") {
+			t.Errorf("match.t should be a negative delta like '-Ns', got %q", tField)
 		}
 	})
 }
@@ -381,7 +453,7 @@ func TestStripSubjectPrefix(t *testing.T) {
 	}
 }
 
-func TestTruncateContent(t *testing.T) {
+func TestPreviewContent(t *testing.T) {
 	tests := []struct {
 		name  string
 		input string
@@ -390,26 +462,23 @@ func TestTruncateContent(t *testing.T) {
 		{"short", "hello", "hello"},
 		{"empty", "", "(empty)"},
 		{"whitespace_only", "   ", "(empty)"},
-		{"multiline", "first line\nsecond line", "first line..."},
+		{"multiline", "first line\nsecond line", "first line"},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := truncateContent(tt.input)
+			got := previewContent(tt.input)
 			if got != tt.want {
-				t.Errorf("truncateContent(%q) = %q, want %q", tt.input, got, tt.want)
+				t.Errorf("previewContent(%q) = %q, want %q", tt.input, got, tt.want)
 			}
 		})
 	}
 
 	t.Run("long_content_truncated", func(t *testing.T) {
-		long := strings.Repeat("word ", 60) // 300 chars
-		got := truncateContent(long)
-		if len(got) > maxMessageChars+10 { // allow for "..."
-			t.Errorf("truncated length %d exceeds limit", len(got))
-		}
+		long := strings.Repeat("word ", 60)
+		got := previewContent(long)
 		if !strings.HasSuffix(got, "...") {
-			t.Error("truncated content should end with '...'")
+			t.Errorf("long preview should end with '...', got %q", got)
 		}
 	})
 }


### PR DESCRIPTION
Phase 1.3 model-facing context audit — **Medium #1** finding (full audit summary in #967).

The \`ArchiveContextProvider\` (Layer 2 pre-warm; injected as related context on every wake) was emitting search hits as quoted-markdown blocks with absolute dates and roles glued into the literal message body:

```
### Past Experience

**2026-03-14 — Session abc12345:**
> [user] What is the answer?
> **[assistant] The answer is 42.**
> [user] Thanks!
```

This violates three model-facing conventions at once (per [docs/model-facing-context.md](docs/model-facing-context.md)):

1. **Recency-time anti-pattern.** Absolute \`time.DateOnly\` makes the model do "how long ago was X?" arithmetic. Sibling memory providers (\`MessageChannelProvider\`, \`EpisodicProvider\`, \`WorkingMemoryProvider\`) all use \`promptfmt.FormatDeltaOnly\` for the same data class.
2. **Separate metadata from literal corpus.** \`[user]\` and \`[assistant]\` are transport metadata; baking them into the corpus means they survive forever once these excerpts get archived again.
3. **Structure beats rhetoric.** Generated runtime data defaults to typed JSON, not essay markdown.

## What changed

The provider now delegates to \`FormatSearchResults\` — the same JSON projection used by the \`archive_search\` and \`archive_range\` tools. The heading \`### Past Experience\` remains as section framing; the body below is a compact JSON payload:

```
### Past Experience

{\"results\":[{\"match\":{\"t\":\"-1234s\",\"role\":\"past you\",\"content\":\"The answer is 42.\",\"content_truncated\":false,\"session_id\":\"sess-abc\"},\"context_before\":[...],\"context_after\":[...],\"highlight\":\"...\"}],\"truncated\":false}
```

Delta-only times. Role as a metadata field. Explicit \`truncated\` flag. Same schema as the model already sees from sibling tools.

## Byte-budget handling

Recast as a tail-trim loop: start with all hits, drop the last one at a time until the rendered output fits in \`maxBytes\`, set \`truncated=true\` in the JSON when anything was dropped. When even one hit exceeds the budget, return \"\" — matches the silent-too-big behavior of sibling providers (and avoids emitting just a bare heading).

## Removed

- \`formatResultBlock\`, \`truncateContent\`, \`maxMessageChars\` constants — replaced by \`FormatSearchResults\` from \`format.go\`.
- The omission-notice prose \`*(N additional result(s) omitted ...)*\` — superseded by the JSON \`truncated\` field.

\`previewContent\` is a small new helper for the debug-log preview line (still operator-facing, never reaches the model).

## Test plan

- [x] Updated provider tests parse the JSON body and assert: result count, match content, session_id propagation, delta-time format (no absolute dates or RFC3339), context_before/after presence as JSON arrays, truncated flag set when results are dropped.
- [x] \`just ci\` green locally.
- [ ] Live archive pre-warm produces parseable JSON in production after deploy.

Refs #967.