### PR TITLE
refactor(contacts,knowledge): add contextfmt subpackages, emit JSON projections

### DIFF
--- a/internal/state/contacts/context.go
+++ b/internal/state/contacts/context.go
@@ -3,9 +3,9 @@ package contacts
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/nugget/thane-ai-agent/internal/runtime/agentctx"
+	"github.com/nugget/thane-ai-agent/internal/state/contacts/contextfmt"
 )
 
 // ContextProvider provides relevant contacts as context for the system prompt.
@@ -49,7 +49,8 @@ func (p *ContextProvider) SetMinScore(score float32) {
 
 // TagContext returns relevant contacts formatted for the system prompt.
 // Implements [agent.TagContextProvider]; registered via
-// RegisterAlwaysContextProvider.
+// RegisterAlwaysContextProvider. The body is rendered by
+// [contextfmt.Format] as compact JSON under a markdown heading.
 func (p *ContextProvider) TagContext(ctx context.Context, req agentctx.ContextRequest) (string, error) {
 	userMessage := req.UserMessage
 	if userMessage == "" || p.embeddings == nil {
@@ -61,55 +62,36 @@ func (p *ContextProvider) TagContext(ctx context.Context, req agentctx.ContextRe
 		return "", fmt.Errorf("embed query: %w", err)
 	}
 
-	contacts, scores, err := p.store.SemanticSearch(embedding, p.maxContacts)
+	contactsList, scores, err := p.store.SemanticSearch(embedding, p.maxContacts)
 	if err != nil {
 		return "", fmt.Errorf("semantic search: %w", err)
 	}
 
-	if len(contacts) == 0 {
-		return "", nil
-	}
-
-	var sb strings.Builder
-	included := 0
-	for i, c := range contacts {
+	matches := make([]contextfmt.Match, 0, len(contactsList))
+	for i, c := range contactsList {
 		if scores[i] < p.minScore {
 			continue
 		}
 
-		// Load properties for this contact.
 		props, _ := p.store.GetProperties(c.ID)
-
-		if included > 0 {
-			sb.WriteString("\n")
-		}
-
-		sb.WriteString(fmt.Sprintf("**%s**", c.FormattedName))
-		if c.Org != "" {
-			sb.WriteString(fmt.Sprintf(" (%s)", c.Org))
-		}
-		if c.AISummary != "" {
-			sb.WriteString(fmt.Sprintf(" — %s", c.AISummary))
-		}
-		if c.TrustZone != "" {
-			sb.WriteString(fmt.Sprintf(" [%s]", c.TrustZone))
-		}
-		sb.WriteString("\n")
-
+		viewProps := make([]contextfmt.Property, 0, len(props))
 		for _, prop := range props {
-			label := prop.Property
-			if prop.Type != "" {
-				label += " (" + prop.Type + ")"
-			}
-			sb.WriteString(fmt.Sprintf("  %s: %s\n", label, prop.Value))
+			viewProps = append(viewProps, contextfmt.Property{
+				Label: prop.Property,
+				Type:  prop.Type,
+				Value: prop.Value,
+			})
 		}
 
-		included++
+		matches = append(matches, contextfmt.Match{
+			Name:       c.FormattedName,
+			Org:        c.Org,
+			Summary:    c.AISummary,
+			TrustZone:  c.TrustZone,
+			Score:      scores[i],
+			Properties: viewProps,
+		})
 	}
 
-	if included == 0 {
-		return "", nil
-	}
-
-	return sb.String(), nil
+	return contextfmt.Format(matches), nil
 }

--- a/internal/state/contacts/context_test.go
+++ b/internal/state/contacts/context_test.go
@@ -2,11 +2,31 @@ package contacts
 
 import (
 	"context"
+	"encoding/json"
 	"strings"
 	"testing"
 
 	"github.com/nugget/thane-ai-agent/internal/runtime/agentctx"
+	"github.com/nugget/thane-ai-agent/internal/state/contacts/contextfmt"
 )
+
+// parseContactsBody extracts the JSON payload that follows the
+// "### Relevant Contacts" heading and unmarshals it for assertion.
+func parseContactsBody(t *testing.T, out string) []contextfmt.Match {
+	t.Helper()
+	const heading = "### Relevant Contacts\n\n"
+	if !strings.HasPrefix(out, heading) {
+		t.Fatalf("output missing heading prefix\nGot:\n%s", out)
+	}
+	body := strings.TrimPrefix(out, heading)
+	var env struct {
+		Contacts []contextfmt.Match `json:"contacts"`
+	}
+	if err := json.Unmarshal([]byte(body), &env); err != nil {
+		t.Fatalf("body not parseable JSON: %v\nBody: %s", err, body)
+	}
+	return env.Contacts
+}
 
 func TestContextProvider_NilEmbedder(t *testing.T) {
 	store := newTestStore(t)
@@ -14,7 +34,7 @@ func TestContextProvider_NilEmbedder(t *testing.T) {
 
 	result, err := cp.TagContext(context.Background(), agentctx.ContextRequest{UserMessage: "hello"})
 	if err != nil {
-		t.Fatalf("GetContext() error = %v", err)
+		t.Fatalf("TagContext() error = %v", err)
 	}
 	if result != "" {
 		t.Errorf("expected empty result with nil embedder, got %q", result)
@@ -28,7 +48,7 @@ func TestContextProvider_EmptyMessage(t *testing.T) {
 
 	result, err := cp.TagContext(context.Background(), agentctx.ContextRequest{UserMessage: ""})
 	if err != nil {
-		t.Fatalf("GetContext() error = %v", err)
+		t.Fatalf("TagContext() error = %v", err)
 	}
 	if result != "" {
 		t.Errorf("expected empty result for empty message, got %q", result)
@@ -42,7 +62,7 @@ func TestContextProvider_NoContacts(t *testing.T) {
 
 	result, err := cp.TagContext(context.Background(), agentctx.ContextRequest{UserMessage: "hello"})
 	if err != nil {
-		t.Fatalf("GetContext() error = %v", err)
+		t.Fatalf("TagContext() error = %v", err)
 	}
 	if result != "" {
 		t.Errorf("expected empty result with no contacts, got %q", result)
@@ -68,26 +88,29 @@ func TestContextProvider_ReturnsRelevant(t *testing.T) {
 
 	result, err := cp.TagContext(context.Background(), agentctx.ContextRequest{UserMessage: "tell me about Alice"})
 	if err != nil {
-		t.Fatalf("GetContext() error = %v", err)
+		t.Fatalf("TagContext() error = %v", err)
 	}
+	matches := parseContactsBody(t, result)
 
-	if !strings.Contains(result, "Alice Relevant") {
-		t.Errorf("result should contain 'Alice Relevant', got %q", result)
+	if len(matches) != 1 {
+		t.Fatalf("expected 1 match (Alice only), got %d", len(matches))
 	}
-	if !strings.Contains(result, "Works at TechCo") {
-		t.Errorf("result should contain 'Works at TechCo', got %q", result)
+	m := matches[0]
+	if m.Name != "Alice Relevant" {
+		t.Errorf("name = %q, want %q", m.Name, "Alice Relevant")
 	}
-	if !strings.Contains(result, "EMAIL") {
-		t.Errorf("result should contain property 'EMAIL', got %q", result)
+	if m.Summary != "Works at TechCo" {
+		t.Errorf("summary = %q, want %q", m.Summary, "Works at TechCo")
 	}
-	if !strings.Contains(result, "timezone") {
-		t.Errorf("result should contain property 'timezone', got %q", result)
+	if m.TrustZone != "known" {
+		t.Errorf("trust_zone = %q, want %q", m.TrustZone, "known")
 	}
-	if !strings.Contains(result, "[known]") {
-		t.Errorf("result should contain trust zone tag '[known]', got %q", result)
+	props := propsByLabel(m.Properties)
+	if _, ok := props["EMAIL"]; !ok {
+		t.Errorf("expected EMAIL property, got %+v", m.Properties)
 	}
-	if strings.Contains(result, "Bob Irrelevant") {
-		t.Errorf("result should not contain 'Bob Irrelevant'")
+	if _, ok := props["timezone"]; !ok {
+		t.Errorf("expected timezone property, got %+v", m.Properties)
 	}
 }
 
@@ -129,16 +152,9 @@ func TestContextProvider_MaxContacts(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	lines := strings.Split(strings.TrimSpace(result), "\n")
-	boldCount := 0
-	for _, line := range lines {
-		if strings.HasPrefix(line, "**") {
-			boldCount++
-		}
-	}
-	if boldCount != 2 {
-		t.Errorf("expected 2 contacts in output, got %d (result: %q)", boldCount, result)
+	matches := parseContactsBody(t, result)
+	if len(matches) != 2 {
+		t.Errorf("expected 2 matches under SetMaxContacts(2), got %d", len(matches))
 	}
 }
 
@@ -155,10 +171,14 @@ func TestContextProvider_TrustZoneTag(t *testing.T) {
 
 	result, err := cp.TagContext(context.Background(), agentctx.ContextRequest{UserMessage: "Alice"})
 	if err != nil {
-		t.Fatalf("GetContext() error = %v", err)
+		t.Fatalf("TagContext() error = %v", err)
 	}
-	if !strings.Contains(result, "[trusted]") {
-		t.Errorf("result should contain '[trusted]' tag, got %q", result)
+	matches := parseContactsBody(t, result)
+	if len(matches) != 1 {
+		t.Fatalf("expected 1 match, got %d", len(matches))
+	}
+	if matches[0].TrustZone != "trusted" {
+		t.Errorf("trust_zone = %q, want %q", matches[0].TrustZone, "trusted")
 	}
 }
 
@@ -180,4 +200,12 @@ func TestSetMaxContacts_ClampsToMin(t *testing.T) {
 	if cp.maxContacts != 10 {
 		t.Errorf("SetMaxContacts(10) = %d, want 10", cp.maxContacts)
 	}
+}
+
+func propsByLabel(props []contextfmt.Property) map[string]contextfmt.Property {
+	m := make(map[string]contextfmt.Property, len(props))
+	for _, p := range props {
+		m[p.Label] = p
+	}
+	return m
 }

--- a/internal/state/contacts/contextfmt/contacts.go
+++ b/internal/state/contacts/contextfmt/contacts.go
@@ -1,0 +1,60 @@
+// Package contextfmt renders contact records into compact, model-facing
+// context. Callers build a [Match] slice from domain types (Contact,
+// Property, similarity score) and call [Format] — the JSON projection is
+// schema-stable across turns so the model can compare snapshots, sort by
+// score, and key off trust zone without parsing prose.
+//
+// The package mirrors the shape of
+// internal/integrations/homeassistant/contextfmt: the parent package
+// (contacts) imports this subpackage to render, but this subpackage
+// does not import its parent — Match is a value type built at the call
+// site to avoid the cycle and keep the formatter trivially testable.
+package contextfmt
+
+import (
+	"strings"
+
+	"github.com/nugget/thane-ai-agent/internal/model/promptfmt"
+)
+
+// Match is one contact ready for rendering: contact-card fields plus the
+// similarity score that selected it and any structured properties to
+// surface. Score is a similarity in [0, 1]; the renderer emits it as a
+// float so the model can sort or threshold without re-deriving it from
+// prose.
+type Match struct {
+	Name       string     `json:"name"`
+	Org        string     `json:"org,omitempty"`
+	Summary    string     `json:"summary,omitempty"`
+	TrustZone  string     `json:"trust_zone,omitempty"`
+	Score      float32    `json:"score"`
+	Properties []Property `json:"properties,omitempty"`
+}
+
+// Property is one vCard-style property of a contact (email, phone,
+// timezone, etc.). Type carries the vCard subtype when present
+// (e.g., "INTERNET", "HOME").
+type Property struct {
+	Label string `json:"label"`
+	Type  string `json:"type,omitempty"`
+	Value string `json:"value"`
+}
+
+// Format renders matches as a heading-framed compact JSON projection
+// suitable for the system prompt. Returns "" when no matches are given,
+// so callers can decide whether to emit anything without parsing the
+// JSON envelope. The heading is markdown (a section boundary); the
+// payload is JSON (typed runtime data).
+func Format(matches []Match) string {
+	if len(matches) == 0 {
+		return ""
+	}
+	envelope := struct {
+		Contacts []Match `json:"contacts"`
+	}{Contacts: matches}
+
+	var sb strings.Builder
+	sb.WriteString("### Relevant Contacts\n\n")
+	sb.WriteString(promptfmt.MarshalCompact(envelope))
+	return sb.String()
+}

--- a/internal/state/contacts/contextfmt/contacts_test.go
+++ b/internal/state/contacts/contextfmt/contacts_test.go
@@ -1,0 +1,90 @@
+package contextfmt
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestFormat_EmptyReturnsEmpty(t *testing.T) {
+	if got := Format(nil); got != "" {
+		t.Errorf("Format(nil) = %q, want empty", got)
+	}
+	if got := Format([]Match{}); got != "" {
+		t.Errorf("Format([]) = %q, want empty", got)
+	}
+}
+
+func TestFormat_HeadingPrecedesJSON(t *testing.T) {
+	got := Format([]Match{
+		{Name: "Alice", Score: 0.9},
+	})
+	if !strings.HasPrefix(got, "### Relevant Contacts\n\n") {
+		t.Fatalf("output missing heading prefix\nGot:\n%s", got)
+	}
+}
+
+func TestFormat_JSONIsParseable(t *testing.T) {
+	got := Format([]Match{
+		{
+			Name:      "Alice Relevant",
+			Org:       "TechCo",
+			Summary:   "Works at TechCo",
+			TrustZone: "trusted",
+			Score:     0.92,
+			Properties: []Property{
+				{Label: "EMAIL", Type: "INTERNET", Value: "alice@techco.com"},
+				{Label: "timezone", Value: "America/Chicago"},
+			},
+		},
+	})
+	body := strings.TrimPrefix(got, "### Relevant Contacts\n\n")
+
+	var env struct {
+		Contacts []Match `json:"contacts"`
+	}
+	if err := json.Unmarshal([]byte(body), &env); err != nil {
+		t.Fatalf("body not parseable JSON: %v\nBody: %s", err, body)
+	}
+	if len(env.Contacts) != 1 {
+		t.Fatalf("expected 1 contact, got %d", len(env.Contacts))
+	}
+	c := env.Contacts[0]
+	if c.Name != "Alice Relevant" {
+		t.Errorf("name = %q", c.Name)
+	}
+	if c.TrustZone != "trusted" {
+		t.Errorf("trust_zone = %q", c.TrustZone)
+	}
+	if c.Score != 0.92 {
+		t.Errorf("score = %f", c.Score)
+	}
+	if len(c.Properties) != 2 {
+		t.Fatalf("properties len = %d", len(c.Properties))
+	}
+	if c.Properties[0].Type != "INTERNET" {
+		t.Errorf("property[0].type = %q", c.Properties[0].Type)
+	}
+	if c.Properties[1].Type != "" {
+		t.Errorf("property[1].type should omit when empty, got %q", c.Properties[1].Type)
+	}
+}
+
+func TestFormat_OmitsEmptyOptionalFields(t *testing.T) {
+	got := Format([]Match{
+		{Name: "Minimal", Score: 0.5},
+	})
+	body := strings.TrimPrefix(got, "### Relevant Contacts\n\n")
+	// Schema stability: required fields stay; optional empties drop.
+	if !strings.Contains(body, `"name":"Minimal"`) {
+		t.Errorf("name field missing\nBody: %s", body)
+	}
+	if !strings.Contains(body, `"score":0.5`) {
+		t.Errorf("score field missing\nBody: %s", body)
+	}
+	for _, f := range []string{`"org":`, `"summary":`, `"trust_zone":`, `"properties":`} {
+		if strings.Contains(body, f) {
+			t.Errorf("expected %s to be omitted when empty\nBody: %s", f, body)
+		}
+	}
+}

--- a/internal/state/knowledge/context.go
+++ b/internal/state/knowledge/context.go
@@ -3,9 +3,9 @@ package knowledge
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/nugget/thane-ai-agent/internal/runtime/agentctx"
+	"github.com/nugget/thane-ai-agent/internal/state/knowledge/contextfmt"
 )
 
 // ContextProvider provides relevant facts as context for the system prompt.
@@ -44,47 +44,36 @@ func (p *ContextProvider) SetMinScore(score float32) {
 
 // TagContext returns relevant facts formatted for the system prompt.
 // Implements [agent.TagContextProvider]; registered via
-// RegisterAlwaysContextProvider.
+// RegisterAlwaysContextProvider. The body is rendered by
+// [contextfmt.FormatSimilarity] as compact JSON under a markdown heading.
 func (p *ContextProvider) TagContext(ctx context.Context, req agentctx.ContextRequest) (string, error) {
 	userMessage := req.UserMessage
 	if userMessage == "" {
 		return "", nil
 	}
 
-	// Generate embedding for user message
 	embedding, err := p.embedder.Generate(ctx, userMessage)
 	if err != nil {
 		return "", fmt.Errorf("embed query: %w", err)
 	}
 
-	// Search for similar facts
 	facts, scores, err := p.store.SemanticSearch(embedding, p.maxFacts)
 	if err != nil {
 		return "", fmt.Errorf("semantic search: %w", err)
 	}
 
-	if len(facts) == 0 {
-		return "", nil
-	}
-
-	// Filter by minimum score and format
-	var sb strings.Builder
-	included := 0
+	views := make([]contextfmt.SimilarityFact, 0, len(facts))
 	for i, f := range facts {
 		if scores[i] < p.minScore {
 			continue
 		}
-		if included > 0 {
-			sb.WriteString("\n\n")
-		}
-		sb.WriteString(fmt.Sprintf("**%s/%s** (%.0f%% relevant)\n%s",
-			f.Category, f.Key, scores[i]*100, f.Value))
-		included++
+		views = append(views, contextfmt.SimilarityFact{
+			Category: string(f.Category),
+			Key:      f.Key,
+			Value:    f.Value,
+			Score:    scores[i],
+		})
 	}
 
-	if included == 0 {
-		return "", nil
-	}
-
-	return sb.String(), nil
+	return contextfmt.FormatSimilarity(views), nil
 }

--- a/internal/state/knowledge/contextfmt/facts.go
+++ b/internal/state/knowledge/contextfmt/facts.go
@@ -1,0 +1,75 @@
+// Package contextfmt renders knowledge facts into compact, model-facing
+// context. Callers convert their domain Fact values into one of the
+// view types here (SimilarityFact or SubjectFact) and call the matching
+// Format function — the JSON projection is schema-stable across turns
+// so the model can sort by score, filter by subjects, or chase a Ref
+// into the KB without parsing prose.
+//
+// The package mirrors the shape of
+// internal/integrations/homeassistant/contextfmt: the parent package
+// (knowledge) imports this subpackage to render, but this subpackage
+// does not import its parent — view types are values built at the call
+// site to avoid the cycle and keep the formatter trivially testable.
+package contextfmt
+
+import (
+	"strings"
+
+	"github.com/nugget/thane-ai-agent/internal/model/promptfmt"
+)
+
+// SimilarityFact is one fact selected by semantic similarity search.
+// Score is the cosine similarity in [0, 1]; the model can read it as a
+// sortable number rather than the "(60% relevant)" prose the older
+// renderer produced.
+type SimilarityFact struct {
+	Category string  `json:"category"`
+	Key      string  `json:"key"`
+	Value    string  `json:"value"`
+	Score    float32 `json:"score"`
+}
+
+// SubjectFact is one fact retrieved by subject-key match. Subjects
+// lists the keys this fact was indexed by (entity:foo, zone:bar,
+// contact:dan@example.com). Ref is the canonical KB-document reference
+// when present; the model can chase it for full details instead of
+// relying on the short Value text.
+type SubjectFact struct {
+	Category string   `json:"category"`
+	Key      string   `json:"key"`
+	Value    string   `json:"value"`
+	Subjects []string `json:"subjects,omitempty"`
+	Ref      string   `json:"ref,omitempty"`
+}
+
+// FormatSimilarity renders similarity-matched facts as a heading-framed
+// compact JSON projection. Returns "" when no facts are given.
+func FormatSimilarity(facts []SimilarityFact) string {
+	if len(facts) == 0 {
+		return ""
+	}
+	envelope := struct {
+		Facts []SimilarityFact `json:"facts"`
+	}{Facts: facts}
+
+	var sb strings.Builder
+	sb.WriteString("### Relevant Facts\n\n")
+	sb.WriteString(promptfmt.MarshalCompact(envelope))
+	return sb.String()
+}
+
+// FormatSubjectKeyed renders subject-keyed facts as a heading-framed
+// compact JSON projection. Returns "" when no facts are given.
+func FormatSubjectKeyed(facts []SubjectFact) string {
+	if len(facts) == 0 {
+		return ""
+	}
+	envelope := struct {
+		Facts []SubjectFact `json:"facts"`
+	}{Facts: facts}
+
+	var sb strings.Builder
+	sb.WriteString("### Subject-Keyed Facts\n\n")
+	sb.WriteString(promptfmt.MarshalCompact(envelope))
+	return sb.String()
+}

--- a/internal/state/knowledge/contextfmt/facts_test.go
+++ b/internal/state/knowledge/contextfmt/facts_test.go
@@ -1,0 +1,87 @@
+package contextfmt
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestFormatSimilarity_EmptyReturnsEmpty(t *testing.T) {
+	if got := FormatSimilarity(nil); got != "" {
+		t.Errorf("FormatSimilarity(nil) = %q, want empty", got)
+	}
+	if got := FormatSimilarity([]SimilarityFact{}); got != "" {
+		t.Errorf("FormatSimilarity([]) = %q, want empty", got)
+	}
+}
+
+func TestFormatSimilarity_HeadingPrecedesJSON(t *testing.T) {
+	got := FormatSimilarity([]SimilarityFact{
+		{Category: "device", Key: "office_light", Value: "Hue desk lamp", Score: 0.85},
+	})
+	if !strings.HasPrefix(got, "### Relevant Facts\n\n") {
+		t.Fatalf("output missing heading prefix\nGot:\n%s", got)
+	}
+	body := strings.TrimPrefix(got, "### Relevant Facts\n\n")
+	var env struct {
+		Facts []SimilarityFact `json:"facts"`
+	}
+	if err := json.Unmarshal([]byte(body), &env); err != nil {
+		t.Fatalf("body not parseable JSON: %v\nBody: %s", err, body)
+	}
+	if len(env.Facts) != 1 {
+		t.Fatalf("expected 1 fact, got %d", len(env.Facts))
+	}
+	if env.Facts[0].Score != 0.85 {
+		t.Errorf("score = %f, want 0.85", env.Facts[0].Score)
+	}
+}
+
+func TestFormatSubjectKeyed_EmptyReturnsEmpty(t *testing.T) {
+	if got := FormatSubjectKeyed(nil); got != "" {
+		t.Errorf("FormatSubjectKeyed(nil) = %q, want empty", got)
+	}
+	if got := FormatSubjectKeyed([]SubjectFact{}); got != "" {
+		t.Errorf("FormatSubjectKeyed([]) = %q, want empty", got)
+	}
+}
+
+func TestFormatSubjectKeyed_RendersFields(t *testing.T) {
+	got := FormatSubjectKeyed([]SubjectFact{
+		{
+			Category: "device",
+			Key:      "office_light",
+			Value:    "Hue desk lamp",
+			Subjects: []string{"entity:light.office", "zone:office"},
+			Ref:      "devices/office_light.md",
+		},
+		{
+			Category: "home",
+			Key:      "house_layout",
+			Value:    "Two-story craftsman",
+		},
+	})
+	if !strings.HasPrefix(got, "### Subject-Keyed Facts\n\n") {
+		t.Fatalf("output missing heading prefix\nGot:\n%s", got)
+	}
+	body := strings.TrimPrefix(got, "### Subject-Keyed Facts\n\n")
+	var env struct {
+		Facts []SubjectFact `json:"facts"`
+	}
+	if err := json.Unmarshal([]byte(body), &env); err != nil {
+		t.Fatalf("body not parseable JSON: %v\nBody: %s", err, body)
+	}
+	if len(env.Facts) != 2 {
+		t.Fatalf("expected 2 facts, got %d", len(env.Facts))
+	}
+	if env.Facts[0].Ref != "devices/office_light.md" {
+		t.Errorf("fact[0].ref = %q", env.Facts[0].Ref)
+	}
+	// Schema stability: a fact without Subjects/Ref drops those fields.
+	if !strings.Contains(body, `"category":"home"`) {
+		t.Errorf("home fact missing category\nBody: %s", body)
+	}
+	if strings.Contains(body, `"subjects":null`) || strings.Contains(body, `"subjects":[]`) {
+		t.Errorf("empty subjects should be omitted, not present as null/empty\nBody: %s", body)
+	}
+}

--- a/internal/state/knowledge/subject_context.go
+++ b/internal/state/knowledge/subject_context.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"strings"
 
 	"github.com/nugget/thane-ai-agent/internal/runtime/agentctx"
+	"github.com/nugget/thane-ai-agent/internal/state/knowledge/contextfmt"
 )
 
 // subjectCtxKey is the context key for subject-keyed fact injection.
@@ -67,7 +67,9 @@ func (p *SubjectContextProvider) SetMaxFacts(n int) {
 
 // TagContext returns subject-keyed facts formatted for the system
 // prompt. Implements [agent.TagContextProvider]; registered via
-// RegisterAlwaysContextProvider.
+// RegisterAlwaysContextProvider. The body is rendered by
+// [contextfmt.FormatSubjectKeyed] as compact JSON under a markdown
+// heading.
 //
 // Subjects are extracted from the context via [SubjectsFromContext].
 // If no subjects are present, returns empty. The request is unused —
@@ -87,26 +89,22 @@ func (p *SubjectContextProvider) TagContext(ctx context.Context, _ agentctx.Cont
 		return "", nil
 	}
 
-	// Cap at maxFacts.
 	if len(facts) > p.maxFacts {
 		facts = facts[:p.maxFacts]
 	}
 
-	var sb strings.Builder
-	sb.WriteString("### Subject-Keyed Facts\n\n")
-	for i, f := range facts {
-		if i > 0 {
-			sb.WriteString("\n\n")
+	views := make([]contextfmt.SubjectFact, 0, len(facts))
+	for _, f := range facts {
+		view := contextfmt.SubjectFact{
+			Category: string(f.Category),
+			Key:      f.Key,
+			Value:    f.Value,
+			Ref:      f.Ref,
 		}
-		sb.WriteString(fmt.Sprintf("**%s/%s**", f.Category, f.Key))
 		if len(f.Subjects) > 0 {
-			sb.WriteString(fmt.Sprintf(" [%s]", strings.Join(f.Subjects, ", ")))
+			view.Subjects = append([]string{}, f.Subjects...)
 		}
-		sb.WriteString("\n")
-		sb.WriteString(f.Value)
-		if f.Ref != "" {
-			sb.WriteString(fmt.Sprintf("\n📎 Full details: kb:%s", f.Ref))
-		}
+		views = append(views, view)
 	}
 
 	p.logger.Debug("subject context injected",
@@ -114,5 +112,5 @@ func (p *SubjectContextProvider) TagContext(ctx context.Context, _ agentctx.Cont
 		"facts_matched", len(facts),
 	)
 
-	return sb.String(), nil
+	return contextfmt.FormatSubjectKeyed(views), nil
 }

--- a/internal/state/knowledge/subject_context_test.go
+++ b/internal/state/knowledge/subject_context_test.go
@@ -340,11 +340,8 @@ func TestGetContext_WithRef(t *testing.T) {
 		t.Fatalf("GetContext: %v", err)
 	}
 
-	if !strings.Contains(got, "kb:devices/office_light.md") {
-		t.Errorf("expected ref annotation in context output, got:\n%s", got)
-	}
-	if !strings.Contains(got, "📎 Full details:") {
-		t.Errorf("expected '📎 Full details:' prefix in context output, got:\n%s", got)
+	if !strings.Contains(got, `"ref":"devices/office_light.md"`) {
+		t.Errorf("expected ref field in context output, got:\n%s", got)
 	}
 }
 
@@ -365,7 +362,7 @@ func TestGetContext_WithoutRef_NoAnnotation(t *testing.T) {
 		t.Fatalf("GetContext: %v", err)
 	}
 
-	if strings.Contains(got, "📎") {
-		t.Errorf("expected no ref annotation for fact without ref, got:\n%s", got)
+	if strings.Contains(got, `"ref":`) {
+		t.Errorf("expected ref field to be omitted when empty, got:\n%s", got)
 	}
 }

--- a/scripts/architecture.baseline
+++ b/scripts/architecture.baseline
@@ -1,4 +1,4 @@
-packages=55
+packages=57
 interfaces=76
 large_files=40
 set_mutators=102


### PR DESCRIPTION
Phase 1.3 model-facing context audit — **High #2** finding (full audit summary in #967).

Two related-context providers — semantic contact matches and similarity/subject-keyed facts — were emitting structured records as prose-bold markdown:

```
**Alice Relevant** (TechCo) — Works at TechCo [trusted]
  EMAIL (INTERNET): alice@techco.com
  timezone: America/Chicago

**device/office_light** (85% relevant)
Hue desk lamp
```

The same \`contacts\` package already proves the JSON-projection pattern on the same domain via \`FormatPersonPresence\` ([presence.go:21](internal/state/contacts/presence.go#L21)) — one shape for presence, another for related context. This PR brings the related-context paths into parity.

## Approach

Factor each domain's projection into a \`contextfmt\` subpackage (the canonical shape from [internal/integrations/homeassistant/contextfmt/](internal/integrations/homeassistant/contextfmt/)) and switch the providers to call it.

### \`internal/state/contacts/contextfmt\`
- \`Match\` (one contact + score + properties) and \`Property\` value types
- \`Format\` renders a heading-framed compact JSON envelope under \`### Relevant Contacts\`
- No import cycle: \`contacts → contextfmt → promptfmt\` only

### \`internal/state/knowledge/contextfmt\`
- \`SimilarityFact\` (score in [0, 1]) and \`SubjectFact\` (subjects, ref) value types
- \`FormatSimilarity\` → \`### Relevant Facts\`
- \`FormatSubjectKeyed\` → \`### Subject-Keyed Facts\`

Each provider builds the view slice at the call site and delegates rendering. The view types are intentionally value-only (string fields) — keeping the formatter trivially testable without pulling in DB types.

## Model-facing wins

| Before | After |
|--------|-------|
| \`(60% relevant)\` parenthetical | \`\"score\": 0.6\` (sortable float) |
| \`📎 Full details: kb:devices/office_light.md\` | \`\"ref\": \"devices/office_light.md\"\` |
| \`EMAIL (INTERNET): alice@techco.com\` | \`{\"label\":\"EMAIL\",\"type\":\"INTERNET\",\"value\":\"alice@techco.com\"}\` |
| \`[trusted]\` trailing tag | \`\"trust_zone\": \"trusted\"\` |
| Variable indentation by record kind | Stable JSON schema across turns |

## Architecture baseline

\`scripts/architecture.baseline\` bumps \`packages\` 55 → 57 for the two new contextfmt subpackages. This is the intended growth flagged by the audit's placement check (\"Domain-to-view projection lives in the domain package as a co-located \`contextfmt\` subpackage\").

## Test plan

- [x] New tests for each \`contextfmt\` package cover: empty input → empty output, heading prefix, JSON parseability, omitempty schema stability.
- [x] Provider tests rewritten to parse the JSON body and assert structured field presence (no longer probing for bold-markdown substrings).
- [x] \`just ci\` green locally (including refreshed architecture baseline).
- [ ] Live related-context bucket renders parseable JSON on \`pocket\` after deploy.

Refs #967.