### PR TITLE
fix(agent): inject subjects from channel binding so prewarm has signal

### DIFF
--- a/internal/runtime/agent/loop.go
+++ b/internal/runtime/agent/loop.go
@@ -1462,6 +1462,7 @@ func (l *Loop) Run(ctx context.Context, req *Request, stream StreamCallback) (re
 		"conversation_id", convID,
 	)
 	ctx = logging.WithLogger(ctx, log)
+	ctx = withRequestSubjects(ctx, req)
 	runStarted := time.Now()
 	defer func() {
 		attrs := []any{

--- a/internal/runtime/agent/loop.go
+++ b/internal/runtime/agent/loop.go
@@ -1462,7 +1462,6 @@ func (l *Loop) Run(ctx context.Context, req *Request, stream StreamCallback) (re
 		"conversation_id", convID,
 	)
 	ctx = logging.WithLogger(ctx, log)
-	ctx = withRequestSubjects(ctx, req)
 	runStarted := time.Now()
 	defer func() {
 		attrs := []any{
@@ -1640,6 +1639,12 @@ func (l *Loop) Run(ctx context.Context, req *Request, stream StreamCallback) (re
 	if channelBinding == nil {
 		channelBinding = l.conversationChannelBinding(convID)
 	}
+	// Inject subjects from the effective channel binding (request first,
+	// persisted conversation binding as fallback) so subject-aware
+	// context providers find relevant stored facts. Must run after the
+	// persisted-binding fallback above; otherwise API turns that supply
+	// only conversation_id would miss the injection entirely.
+	ctx = withChannelSubjects(ctx, channelBinding)
 	origin := newSessionOrigin(req.RoutingFactors, channelBinding)
 	originResult := SessionOriginPolicyResult{Origin: origin}
 	if contactPolicy := l.contactOriginPolicy(origin); contactPolicy != nil {

--- a/internal/runtime/agent/subjects.go
+++ b/internal/runtime/agent/subjects.go
@@ -4,15 +4,20 @@ import (
 	"context"
 
 	"github.com/nugget/thane-ai-agent/internal/state/knowledge"
+	"github.com/nugget/thane-ai-agent/internal/state/memory"
 )
 
-// withRequestSubjects extends ctx with subject keys derived from req's
-// channel binding so that subject-aware context providers (the
+// withChannelSubjects extends ctx with subject keys derived from a
+// resolved channel binding so subject-aware context providers (the
 // archive prewarm and the subject-keyed knowledge provider) can find
-// stored facts relevant to the current wake without needing the
-// user's message itself to mention them. Existing subjects already on
+// stored facts relevant to the current wake. Existing subjects on
 // ctx (e.g. from an outer wake bridge that knows about
-// entity:/area:/space: subjects) are preserved.
+// entity:/area:/space: subjects) are preserved and deduplicated.
+//
+// The caller is responsible for resolving the effective binding
+// before invoking — passing req.ChannelBinding directly would miss
+// the persisted-binding fallback that Loop.Run uses for API turns
+// supplying only conversation_id.
 //
 // Currently injects:
 //
@@ -28,16 +33,16 @@ import (
 // Loops and channels that want richer subjects (entity:, area:,
 // space:) can call [knowledge.WithSubjects] before invoking the agent
 // loop; this helper preserves what they set.
-func withRequestSubjects(ctx context.Context, req *Request) context.Context {
+func withChannelSubjects(ctx context.Context, binding *memory.ChannelBinding) context.Context {
 	existing := knowledge.SubjectsFromContext(ctx)
 	subjects := append([]string{}, existing...)
 
-	if cb := req.ChannelBinding; cb != nil {
-		if cb.ContactID != "" {
-			subjects = appendUniqueSubject(subjects, "contact:"+cb.ContactID)
+	if binding != nil {
+		if binding.ContactID != "" {
+			subjects = appendUniqueSubject(subjects, "contact:"+binding.ContactID)
 		}
-		if cb.Address != "" {
-			subjects = appendUniqueSubject(subjects, "contact:"+cb.Address)
+		if binding.Address != "" {
+			subjects = appendUniqueSubject(subjects, "contact:"+binding.Address)
 		}
 	}
 

--- a/internal/runtime/agent/subjects.go
+++ b/internal/runtime/agent/subjects.go
@@ -1,0 +1,57 @@
+package agent
+
+import (
+	"context"
+
+	"github.com/nugget/thane-ai-agent/internal/state/knowledge"
+)
+
+// withRequestSubjects extends ctx with subject keys derived from req's
+// channel binding so that subject-aware context providers (the
+// archive prewarm and the subject-keyed knowledge provider) can find
+// stored facts relevant to the current wake without needing the
+// user's message itself to mention them. Existing subjects already on
+// ctx (e.g. from an outer wake bridge that knows about
+// entity:/area:/space: subjects) are preserved.
+//
+// Currently injects:
+//
+//   - "contact:<ContactID>" when the channel binding resolved to a
+//     known contact UUID. This is the stable subject; prefer it over
+//     "contact:<Address>" which can shift when phone numbers move
+//     between accounts.
+//   - "contact:<Address>" when the channel binding carries a raw
+//     address (E.164 phone for Signal, SMTP for email). Useful even
+//     without a resolved contact — the address itself is a stable
+//     handle for retrieval.
+//
+// Loops and channels that want richer subjects (entity:, area:,
+// space:) can call [knowledge.WithSubjects] before invoking the agent
+// loop; this helper preserves what they set.
+func withRequestSubjects(ctx context.Context, req *Request) context.Context {
+	existing := knowledge.SubjectsFromContext(ctx)
+	subjects := append([]string{}, existing...)
+
+	if cb := req.ChannelBinding; cb != nil {
+		if cb.ContactID != "" {
+			subjects = appendUniqueSubject(subjects, "contact:"+cb.ContactID)
+		}
+		if cb.Address != "" {
+			subjects = appendUniqueSubject(subjects, "contact:"+cb.Address)
+		}
+	}
+
+	if len(subjects) == len(existing) {
+		return ctx
+	}
+	return knowledge.WithSubjects(ctx, subjects)
+}
+
+func appendUniqueSubject(subjects []string, s string) []string {
+	for _, existing := range subjects {
+		if existing == s {
+			return subjects
+		}
+	}
+	return append(subjects, s)
+}

--- a/internal/runtime/agent/subjects_test.go
+++ b/internal/runtime/agent/subjects_test.go
@@ -8,14 +8,12 @@ import (
 	"github.com/nugget/thane-ai-agent/internal/state/memory"
 )
 
-func TestWithRequestSubjects_InjectsBoth(t *testing.T) {
-	req := &Request{
-		ChannelBinding: &memory.ChannelBinding{
-			ContactID: "c-abc",
-			Address:   "+15551234567",
-		},
+func TestWithChannelSubjects_InjectsBoth(t *testing.T) {
+	binding := &memory.ChannelBinding{
+		ContactID: "c-abc",
+		Address:   "+15551234567",
 	}
-	ctx := withRequestSubjects(context.Background(), req)
+	ctx := withChannelSubjects(context.Background(), binding)
 
 	got := knowledge.SubjectsFromContext(ctx)
 	want := []string{"contact:c-abc", "contact:+15551234567"}
@@ -29,18 +27,16 @@ func TestWithRequestSubjects_InjectsBoth(t *testing.T) {
 	}
 }
 
-func TestWithRequestSubjects_PreservesExistingThenAppends(t *testing.T) {
+func TestWithChannelSubjects_PreservesExistingThenAppends(t *testing.T) {
 	base := knowledge.WithSubjects(context.Background(), []string{
 		"entity:binary_sensor.driveway",
 		"contact:c-abc", // duplicate of what binding would add — should not duplicate
 	})
-	req := &Request{
-		ChannelBinding: &memory.ChannelBinding{
-			ContactID: "c-abc",
-			Address:   "+15551234567",
-		},
+	binding := &memory.ChannelBinding{
+		ContactID: "c-abc",
+		Address:   "+15551234567",
 	}
-	ctx := withRequestSubjects(base, req)
+	ctx := withChannelSubjects(base, binding)
 
 	got := knowledge.SubjectsFromContext(ctx)
 	want := []string{"entity:binary_sensor.driveway", "contact:c-abc", "contact:+15551234567"}
@@ -54,31 +50,25 @@ func TestWithRequestSubjects_PreservesExistingThenAppends(t *testing.T) {
 	}
 }
 
-func TestWithRequestSubjects_NilBindingIsNoop(t *testing.T) {
-	req := &Request{}
-	ctx := withRequestSubjects(context.Background(), req)
+func TestWithChannelSubjects_NilBindingIsNoop(t *testing.T) {
+	ctx := withChannelSubjects(context.Background(), nil)
 	if got := knowledge.SubjectsFromContext(ctx); got != nil {
 		t.Errorf("expected nil subjects, got %v", got)
 	}
 }
 
-func TestWithRequestSubjects_NilBindingPreservesExisting(t *testing.T) {
+func TestWithChannelSubjects_NilBindingPreservesExisting(t *testing.T) {
 	base := knowledge.WithSubjects(context.Background(), []string{"entity:light.office"})
-	req := &Request{}
-	ctx := withRequestSubjects(base, req)
+	ctx := withChannelSubjects(base, nil)
 	got := knowledge.SubjectsFromContext(ctx)
 	if len(got) != 1 || got[0] != "entity:light.office" {
 		t.Errorf("subjects = %v, want [entity:light.office]", got)
 	}
 }
 
-func TestWithRequestSubjects_EmptyBindingFieldsAreSkipped(t *testing.T) {
-	req := &Request{
-		ChannelBinding: &memory.ChannelBinding{
-			Channel: "signal", // present but no ContactID or Address
-		},
-	}
-	ctx := withRequestSubjects(context.Background(), req)
+func TestWithChannelSubjects_EmptyBindingFieldsAreSkipped(t *testing.T) {
+	binding := &memory.ChannelBinding{Channel: "signal"} // no ContactID, no Address
+	ctx := withChannelSubjects(context.Background(), binding)
 	if got := knowledge.SubjectsFromContext(ctx); got != nil {
 		t.Errorf("expected nil subjects when binding has no id/address, got %v", got)
 	}

--- a/internal/runtime/agent/subjects_test.go
+++ b/internal/runtime/agent/subjects_test.go
@@ -1,0 +1,96 @@
+package agent
+
+import (
+	"context"
+	"testing"
+
+	"github.com/nugget/thane-ai-agent/internal/state/knowledge"
+	"github.com/nugget/thane-ai-agent/internal/state/memory"
+)
+
+func TestWithRequestSubjects_InjectsBoth(t *testing.T) {
+	req := &Request{
+		ChannelBinding: &memory.ChannelBinding{
+			ContactID: "c-abc",
+			Address:   "+15551234567",
+		},
+	}
+	ctx := withRequestSubjects(context.Background(), req)
+
+	got := knowledge.SubjectsFromContext(ctx)
+	want := []string{"contact:c-abc", "contact:+15551234567"}
+	if len(got) != len(want) {
+		t.Fatalf("subjects = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("subjects[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestWithRequestSubjects_PreservesExistingThenAppends(t *testing.T) {
+	base := knowledge.WithSubjects(context.Background(), []string{
+		"entity:binary_sensor.driveway",
+		"contact:c-abc", // duplicate of what binding would add — should not duplicate
+	})
+	req := &Request{
+		ChannelBinding: &memory.ChannelBinding{
+			ContactID: "c-abc",
+			Address:   "+15551234567",
+		},
+	}
+	ctx := withRequestSubjects(base, req)
+
+	got := knowledge.SubjectsFromContext(ctx)
+	want := []string{"entity:binary_sensor.driveway", "contact:c-abc", "contact:+15551234567"}
+	if len(got) != len(want) {
+		t.Fatalf("subjects = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("subjects[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestWithRequestSubjects_NilBindingIsNoop(t *testing.T) {
+	req := &Request{}
+	ctx := withRequestSubjects(context.Background(), req)
+	if got := knowledge.SubjectsFromContext(ctx); got != nil {
+		t.Errorf("expected nil subjects, got %v", got)
+	}
+}
+
+func TestWithRequestSubjects_NilBindingPreservesExisting(t *testing.T) {
+	base := knowledge.WithSubjects(context.Background(), []string{"entity:light.office"})
+	req := &Request{}
+	ctx := withRequestSubjects(base, req)
+	got := knowledge.SubjectsFromContext(ctx)
+	if len(got) != 1 || got[0] != "entity:light.office" {
+		t.Errorf("subjects = %v, want [entity:light.office]", got)
+	}
+}
+
+func TestWithRequestSubjects_EmptyBindingFieldsAreSkipped(t *testing.T) {
+	req := &Request{
+		ChannelBinding: &memory.ChannelBinding{
+			Channel: "signal", // present but no ContactID or Address
+		},
+	}
+	ctx := withRequestSubjects(context.Background(), req)
+	if got := knowledge.SubjectsFromContext(ctx); got != nil {
+		t.Errorf("expected nil subjects when binding has no id/address, got %v", got)
+	}
+}
+
+func TestAppendUniqueSubject(t *testing.T) {
+	got := appendUniqueSubject([]string{"a", "b"}, "a")
+	if len(got) != 2 {
+		t.Errorf("expected 'a' to be deduplicated, got %v", got)
+	}
+	got = appendUniqueSubject([]string{"a", "b"}, "c")
+	if len(got) != 3 || got[2] != "c" {
+		t.Errorf("expected 'c' appended, got %v", got)
+	}
+}


### PR DESCRIPTION
Found during the v0.9.3 cutover validation on \`pocket.hollowoak.net\`. The Signal turn 019e67a3-9ae1-7a0a-b9ca-cf82a4d3d40c failed a fidelity test by making layout assumptions about \"the game room door\" instead of consulting memory.

## Root cause

\`knowledge.WithSubjects\` has been defined since the prewarm work in #404 but has **zero callers in production code** (verified by grep of the whole tree). The two memory layers that depend on it both silently degrade:

- \`SubjectContextProvider.TagContext\` sees empty subjects → returns \"\" → no subject-keyed facts injected
- \`ArchiveContextProvider.buildQuery\` falls through to the user-message branch → for terse messages like \"You failed the fidelity test.\" the search has no useful keywords → no \`### Past Experience\` block

The Signal bridge, email poller, and HA state-watcher all *know* useful subjects (sender phone, contact ID, entity ID, area) at wake time, but none of them call \`WithSubjects\`. The prewarm pipeline is wired but never fed.

## Fix

The agent \`Loop.Run\` already sees \`Request.ChannelBinding\`, which every channel populates today (\`Channel\`, \`Address\`, \`ContactID\`, \`ContactName\`, \`TrustZone\`). Add a small helper that derives subjects from the binding at the top of \`Run\`, preserving any subjects already on \`ctx\`:

- \`contact:<ContactID>\` — stable UUID; primary
- \`contact:<Address>\` — phone (Signal) or SMTP (email); secondary stable handle

Loops and channels with richer wake metadata (HA \`entity:<id>\`, MQTT \`topic:<topic>\`) can call \`knowledge.WithSubjects\` on \`ctx\` *before* invoking the agent loop and \`withRequestSubjects\` will stack on top.

## What this does NOT cover

- HA state-watcher → entity subject injection (separate follow-up; the wake-bus dispatch path needs a hook)
- Email poller → from-address subject injection (same wake-bus path)
- MQTT/RSS/Forge wake sources (same)

Filed as scope for v0.9.4 — the structural insight (subjects live on ChannelBinding *or* on ctx-before-Run) carries forward.

## Test plan

- [x] New unit tests cover: both subjects injected, existing ctx subjects preserved+deduped, nil binding is a no-op, nil binding preserves existing, binding with only \`Channel\` and no ID/Address is a no-op.
- [x] \`just ci\` green locally.
- [ ] Live verification on \`pocket\` after merge: next Signal turn with a known contact should show \`contact:<id>\` in archive_provider debug logs as the query subject, and \`### Past Experience\` should appear in the system prompt when relevant past archive content exists.