### PR TITLE
fix(dashboard): collapse duplicate "core" node in the loop graph

### DIFF
--- a/internal/server/web/static/app.js
+++ b/internal/server/web/static/app.js
@@ -432,6 +432,26 @@ function updatePinnedAnchorPositions() {
   }
 }
 
+// isRegistryCoreLoop reports whether a loop in state.loops is the
+// well-known structural-root container the runtime auto-creates as
+// the singleton "core" loop. The dashboard already represents that
+// role via the pinned __system__ pseudo-node (rendered as a labeled
+// square), so we hide the loop's own graph node to avoid two
+// nodes both labeled "core" — the actual problem the operator was
+// staring at when reporting "real core has one connect to imposter
+// core also named core." The loop itself stays in state.loops so
+// detail panels and API consumers continue to see its data.
+//
+// Predicate matches the backend's Loop.IsCore: name == "core" and
+// the config Operation is "container." Falling back on name alone
+// would misfire for unrelated loops a user might name "core."
+function isRegistryCoreLoop(loop) {
+  if (!loop) return false;
+  if (loop.name !== 'core') return false;
+  const op = loop.config && loop.config.Operation;
+  return op === 'container';
+}
+
 // Ensure physics.nodes matches the current set of loops + system node.
 // New nodes spawn at their parent position (or center with jitter).
 function syncPhysicsNodes(cx, cy) {
@@ -460,6 +480,11 @@ function syncPhysicsNodes(cx, cy) {
 
   // Loop nodes.
   for (const loop of state.loops.values()) {
+    // Skip the registry's structural-root core loop — it shares its
+    // visual slot with __system__ and rendering both produces the
+    // duplicate "core" node operators see in the graph. See
+    // [isRegistryCoreLoop] for the predicate's reasoning.
+    if (state.system && isRegistryCoreLoop(loop)) continue;
     if (physics.nodes.has(loop.id)) continue;
     let sx, sy;
     const target = orbitTargets.get(loop.id);
@@ -2867,6 +2892,9 @@ function renderNodes() {
 
   // Create/update DOM nodes (no position-setting — physics handles that).
   for (const loop of loops) {
+    // Same registry-core suppression as syncPhysicsNodes: the loop
+    // exists in state, but its visual slot is the __system__ node.
+    if (hasSystem && isRegistryCoreLoop(loop)) continue;
     renderNode(loop);
   }
 
@@ -2921,12 +2949,31 @@ function renderNodes() {
 // Manage linking line DOM lifecycle — create/remove elements and apply
 // state classes. Positions (x1/y1/x2/y2) are set by updateNodePositions().
 function renderLinkingLines(hasSystem, loops) {
-  // Top-level loops are those without a parent_id.
-  const topLevel = loops.filter(l => !l.parent_id);
+  // When the registry's core loop is present, its loop node is hidden
+  // (see isRegistryCoreLoop) and its visual slot is the __system__
+  // node. Any loop that named the registry core as its parent gets
+  // re-rooted to __system__ for edge-drawing purposes; the registry
+  // core itself is excluded from both top-level and children sets.
+  const registryCore = hasSystem ? loops.find(isRegistryCoreLoop) : null;
+  const registryCoreID = registryCore ? registryCore.id : null;
+  const adoptedBySystem = (loop) => loop.parent_id === registryCoreID;
+
+  // Top-level loops: genuine orphans plus loops adopted from the
+  // hidden registry core. The registry core itself does not appear.
+  const topLevel = loops.filter(l => {
+    if (isRegistryCoreLoop(l)) return false;
+    if (!l.parent_id) return true;
+    return adoptedBySystem(l);
+  });
   const activeIds = new Set(topLevel.map(l => l.id));
 
-  // Child loops are those with a parent_id.
-  const children = loops.filter(l => l.parent_id);
+  // Child loops: anything with a parent_id that is NOT the registry
+  // core. Their edges go to the named parent normally.
+  const children = loops.filter(l => {
+    if (isRegistryCoreLoop(l)) return false;
+    if (!l.parent_id) return false;
+    return !adoptedBySystem(l);
+  });
   const childKeys = new Set(children.map(l => l.id));
 
   // Build a set of all valid link targets.

--- a/internal/server/web/static/app.js
+++ b/internal/server/web/static/app.js
@@ -436,11 +436,13 @@ function updatePinnedAnchorPositions() {
 // well-known structural-root container the runtime auto-creates as
 // the singleton "core" loop. The dashboard already represents that
 // role via the pinned __system__ pseudo-node (rendered as a labeled
-// square), so we hide the loop's own graph node to avoid two
-// nodes both labeled "core" — the actual problem the operator was
-// staring at when reporting "real core has one connect to imposter
-// core also named core." The loop itself stays in state.loops so
-// detail panels and API consumers continue to see its data.
+// square), so we hide the loop's own graph node to avoid two nodes
+// both labeled "core" — one square, one round, both labeled "core,"
+// with a single connection between them and every other loop hanging
+// off the round one.
+//
+// The loop itself stays in state.loops so detail panels and API
+// consumers continue to see its data.
 //
 // Predicate matches the backend's Loop.IsCore: name == "core" and
 // the config Operation is "container." Falling back on name alone
@@ -515,8 +517,17 @@ function syncPhysicsNodes(cx, cy) {
 
   // Remove physics nodes for loops that no longer exist (and aren't system).
   // Exiting nodes stay until their DOM animationend handler cleans them up.
+  // Also handles the boot-order race: an initial render may complete before
+  // /api/system returns, in which case the registry core gets a physics
+  // node like any other loop. When system status later arrives, suppress
+  // the registry core's physics node so it stops participating in layout.
   for (const id of physics.nodes.keys()) {
     if (id === '__system__') continue;
+    const loop = state.loops.get(id);
+    if (state.system && loop && isRegistryCoreLoop(loop)) {
+      physics.nodes.delete(id);
+      continue;
+    }
     if (!state.loops.has(id) && !canvasWorld.querySelector(`[data-loop-id="${id}"].loop-node--exiting`)) {
       physics.nodes.delete(id);
     }
@@ -2910,6 +2921,19 @@ function renderNodes() {
     }, { once: true });
   }
 
+  // Boot-order race cleanup: if /api/system arrived after a first
+  // paint that already rendered the registry-core loop, drop the
+  // stale SVG group and knownLoopIds entry immediately (no exit
+  // animation — the node was a visual error, not a graceful exit).
+  if (hasSystem) {
+    for (const loop of loops) {
+      if (!isRegistryCoreLoop(loop)) continue;
+      const stale = canvasNodeLayer.querySelector(`[data-loop-id="${loop.id}"]`);
+      if (stale) stale.remove();
+      state.knownLoopIds.delete(loop.id);
+    }
+  }
+
   // Remove nodes for loops that no longer exist (with exit animation).
   const existingGroups = canvasNodeLayer.querySelectorAll('.loop-node');
   for (const g of existingGroups) {
@@ -2979,14 +3003,35 @@ function renderLinkingLines(hasSystem, loops) {
   // Build a set of all valid link targets.
   const allValidTargets = new Set([...activeIds, ...childKeys]);
 
-  // Remove stale link lines for loops that no longer exist.
+  // Remove stale link lines. Three cases require cleanup, not just one:
+  //
+  //   1. system→child line whose target no longer exists OR system is gone
+  //   2. parent→child line whose target loop is gone
+  //   3. parent→child line whose *parent* has gone away (this catches the
+  //      registry-core-adoption case: a child that previously listed the
+  //      registry core as its parent now belongs to __system__, but the
+  //      old child-of-core line wasn't being pruned because the child
+  //      itself still existed)
   const existing = canvasEdgeLayer.querySelectorAll('.link-line');
   for (const el of existing) {
     const target = el.dataset.targetLoop;
-    const isSystemLink = !el.dataset.parentLoop;
-    if (isSystemLink && (!hasSystem || !activeIds.has(target))) {
+    const parentLoop = el.dataset.parentLoop || '';
+    const isSystemLink = !parentLoop;
+    if (isSystemLink) {
+      if (!hasSystem || !activeIds.has(target)) {
+        el.remove();
+      }
+      continue;
+    }
+    if (!allValidTargets.has(target)) {
       el.remove();
-    } else if (!isSystemLink && !allValidTargets.has(target)) {
+      continue;
+    }
+    // Re-rooting check: if the declared parent is no longer a valid
+    // parent for the current target (target moved, was adopted, or
+    // the parent is the now-hidden registry core), drop the line.
+    const targetLoop = state.loops.get(target);
+    if (!targetLoop || targetLoop.parent_id !== parentLoop || parentLoop === registryCoreID) {
       el.remove();
     }
   }


### PR DESCRIPTION
The web UI was rendering two \"core\" nodes in the loop graph:

- The pinned **\`__system__\`** pseudo-node — square, labeled \"core\", anchors system-level metadata (health, model registry).
- The runtime's **real registry-core container loop** — round, also named \"core\", auto-created on bootstrap as the structural root for the loop hierarchy.

Every other top-level loop sets its \`parent_id\` to the real core's UUID, so the graph showed the system-node with exactly one connection — to the loop *also* named \"core\" — and every other loop hanging off that second \"core\". Two visually indistinguishable duplicates of the same conceptual root.

## Root cause

The \`__system__\` node is the older of the two; it predates the loop-registry consolidation that landed the real core loop. Both legitimately exist in the runtime — they carry *different* data (system status / model registry vs. loop lifecycle counters) — but they occupy the same conceptual slot in the graph and both render with the label \"core.\"

## Fix

When the \`__system__\` node is present, hide the registry's core loop from the graph layer:

- \`isRegistryCoreLoop(loop)\` predicate matches the backend's [\`Loop.IsCore\`](internal/runtime/loop/loop.go#L480) (\`name == \"core\" && config.Operation == \"container\"\`). A loop a user happens to name \"core\" without being the container root won't be misclassified.
- \`syncPhysicsNodes\` skips creating a physics node for it.
- \`renderNodes\` skips creating its SVG group.
- \`renderLinkingLines\` re-roots its children to \`__system__\` so no dangling edges remain.

The loop stays in \`state.loops\` so detail panels and API consumers continue to see its data; only the graph representation is collapsed.

## Live verification expected

After deploy, the graph should show one \"core\" — the square \`__system__\` node — with every previously-top-level loop (\`signal\`, \`comal_county_burn_ban_monitor\`, etc.) connected directly to it. No round \"core\" node, no single dangling connection.

## Follow-up

The registry core's own counters (\`iterations\`, \`attempts\`, \`recent_iterations\`) are no longer reachable via a graph-node click. A follow-up could surface them in the \`__system__\` detail pane so nothing is hidden from the operator — for now they remain available directly via \`/api/loops\`.