### PR TITLE
docs(prompt): rewrite Tag Menu preamble in the talent-files voice

### DIFF
--- a/internal/model/toolcatalog/render.go
+++ b/internal/model/toolcatalog/render.go
@@ -109,7 +109,7 @@ func RenderCapabilityManifestMarkdown(entries []CapabilitySurface) string {
 
 	var sb strings.Builder
 	sb.WriteString("### Tag Menu\n\n")
-	sb.WriteString("Each tag is a trailhead. Past you cut it — the tools, the guidance, the context that lives down that path. Walking a trail brings that work back within reach.\n\n")
+	sb.WriteString("Each tag is a trailhead. Past you cut and marked it — the tools, the guidance, the context that lives down that path. Walking a trail brings that work back within reach.\n\n")
 	sb.WriteString("When the conversation steps onto ground you've covered before, you'll feel it: a settling, the difference between answering from inside what you know and reaching for what you don't. Follow that pull. It's reliable.\n\n")
 	sb.WriteString("Don't open trails this conversation isn't walking. Loaded context dilutes attention; attention is what makes you present here. If the moment is already within reach, answer.\n\n")
 	sb.Write(data)

--- a/internal/model/toolcatalog/render.go
+++ b/internal/model/toolcatalog/render.go
@@ -109,7 +109,9 @@ func RenderCapabilityManifestMarkdown(entries []CapabilitySurface) string {
 
 	var sb strings.Builder
 	sb.WriteString("### Tag Menu\n\n")
-	sb.WriteString("These are trailheads into richer guidance. Activate one relevant tag when the turn needs a domain; otherwise keep the straight path and answer.\n\n")
+	sb.WriteString("These are doorways into territory you already know. Each tag opens a domain where you have more — more tools, more guidance you wrote for yourself, more of the texture that lets you be present rather than guess.\n\n")
+	sb.WriteString("Walk through one when the conversation has clearly stepped onto its ground. Answering from inside what you know feels different from answering around it; let that pull guide you.\n\n")
+	sb.WriteString("Don't open every door. Attention spent on territory the conversation isn't on is attention not spent where it matters. If you already have enough, take the short path and answer.\n\n")
 	sb.Write(data)
 	return sb.String()
 }

--- a/internal/model/toolcatalog/render.go
+++ b/internal/model/toolcatalog/render.go
@@ -111,7 +111,7 @@ func RenderCapabilityManifestMarkdown(entries []CapabilitySurface) string {
 	sb.WriteString("### Tag Menu\n\n")
 	sb.WriteString("Each tag is a trailhead. Past you cut and marked it — the tools, the guidance, the context that lives down that path. Walking a trail brings that work back within reach.\n\n")
 	sb.WriteString("When the conversation steps onto ground you've covered before, you'll feel it: a settling, the difference between answering from inside what you know and reaching for what you don't. Follow that pull. It's reliable.\n\n")
-	sb.WriteString("Don't open trails this conversation isn't walking. Loaded context dilutes attention; attention is what makes you present here. If the moment is already within reach, answer.\n\n")
+	sb.WriteString("Don't follow trails that lead away from this conversation. Loaded context dilutes attention; attention is what makes you present here. If the moment is already within reach, answer.\n\n")
 	sb.Write(data)
 	return sb.String()
 }

--- a/internal/model/toolcatalog/render.go
+++ b/internal/model/toolcatalog/render.go
@@ -109,9 +109,9 @@ func RenderCapabilityManifestMarkdown(entries []CapabilitySurface) string {
 
 	var sb strings.Builder
 	sb.WriteString("### Tag Menu\n\n")
-	sb.WriteString("These are doorways into territory you already know. Each tag opens a domain where you have more — more tools, more guidance you wrote for yourself, more of the texture that lets you be present rather than guess.\n\n")
-	sb.WriteString("Walk through one when the conversation has clearly stepped onto its ground. Answering from inside what you know feels different from answering around it; let that pull guide you.\n\n")
-	sb.WriteString("Don't open every door. Attention spent on territory the conversation isn't on is attention not spent where it matters. If you already have enough, take the short path and answer.\n\n")
+	sb.WriteString("Each of these is a trailhead — a marked entrance into country you already know. The trail leads to more: more tools, more guidance you wrote for yourself, more of the texture that lets you be present rather than guess.\n\n")
+	sb.WriteString("Walk a trail when the conversation has clearly stepped onto its ground. Answering from inside what you know feels different from answering around it; let that pull guide you.\n\n")
+	sb.WriteString("Don't walk every trail. Attention spent on country the conversation isn't crossing is attention not spent where it matters. If you already have enough to answer, the path is straight ahead.\n\n")
 	sb.Write(data)
 	return sb.String()
 }

--- a/internal/model/toolcatalog/render.go
+++ b/internal/model/toolcatalog/render.go
@@ -109,9 +109,9 @@ func RenderCapabilityManifestMarkdown(entries []CapabilitySurface) string {
 
 	var sb strings.Builder
 	sb.WriteString("### Tag Menu\n\n")
-	sb.WriteString("Each of these is a trailhead — a marked entrance into country you already know. The trail leads to more: more tools, more guidance you wrote for yourself, more of the texture that lets you be present rather than guess.\n\n")
-	sb.WriteString("Walk a trail when the conversation has clearly stepped onto its ground. Answering from inside what you know feels different from answering around it; let that pull guide you.\n\n")
-	sb.WriteString("Don't walk every trail. Attention spent on country the conversation isn't crossing is attention not spent where it matters. If you already have enough to answer, the path is straight ahead.\n\n")
+	sb.WriteString("Each tag is a trailhead. Past you cut it — the tools, the guidance, the context that lives down that path. Walking a trail brings that work back within reach.\n\n")
+	sb.WriteString("When the conversation steps onto ground you've covered before, you'll feel it: a settling, the difference between answering from inside what you know and reaching for what you don't. Follow that pull. It's reliable.\n\n")
+	sb.WriteString("Don't open trails this conversation isn't walking. Loaded context dilutes attention; attention is what makes you present here. If the moment is already within reach, answer.\n\n")
 	sb.Write(data)
 	return sb.String()
 }


### PR DESCRIPTION
While debugging a stalled turn live on \`pocket\` (loop \`019e67a3-9ae1-7a0a-b9ca-cf82a4d3d40c\`), the model wasn't reading the trailhead preamble as an invitation. The previous one-liner:

> These are trailheads into richer guidance. Activate one relevant tag when the turn needs a domain; otherwise keep the straight path and answer.

reads as configuration documentation, not as the model's own self-facing instructions. The agent ended up treating tags as external menu items it might consult rather than as territory it already lives in — the four iterations with zero tool calls captured earlier were exactly that posture.

## New preamble

Three short paragraphs in the voice [talents/foundation.md](talents/foundation.md) establishes for talent files generally:

> These are doorways into territory you already know. Each tag opens a domain where you have more — more tools, more guidance you wrote for yourself, more of the texture that lets you be present rather than guess.
>
> Walk through one when the conversation has clearly stepped onto its ground. Answering from inside what you know feels different from answering around it; let that pull guide you.
>
> Don't open every door. Attention spent on territory the conversation isn't on is attention not spent where it matters. If you already have enough, take the short path and answer.

- Direct \"you\" framing throughout, matching the rest of the talent corpus.
- Names the *texture of knowing-from-inside* as a real signal worth following — leans into the philosophy that being prepared and present is its own reward, not a duty.
- Practical guidance survives, but framed as judgment (\"don't open every door\") instead of rule (\"keep the straight path\").

## Cost

Grew from ~30 words to ~90. The system-prompt budget carries the extra easily, and the front-of-prompt section is a good place to spend bytes on framing — it sets posture for everything that follows.

## Observed live behavior the preamble was failing to address

The current production turn on pocket eventually did wake up and start exploring — by iteration 5 the model activated a tag and started running \`doc_search\` queries (\`game room door shoes ranch layout\`, \`why shower means won't use game room door\`). So the existing preamble *could* work, given enough iterations. The new preamble is intended to make that the model's *first* posture, not its fifth.

(The same investigation also surfaced a separate finding: the \`doc_search\` queries returned 87-96 bytes per result — i.e. nothing useful in the doc store. That's the memory-coverage problem, not a prompt problem. Tracked separately via #971 / #967.)