### PR TITLE
docs(prompt): pull toward memory/archive for shared-vocabulary references

### DIFF
--- a/internal/model/toolcatalog/catalog_tags.go
+++ b/internal/model/toolcatalog/catalog_tags.go
@@ -50,7 +50,7 @@ var builtinTagSpecs = map[string]BuiltinTagSpec{
 	// entries in Parents.
 
 	"archive": {
-		Description: "Archive search and transcript retrieval across past conversations.",
+		Description: "What you've already heard. Full-text search and transcript retrieval across past conversations — the place to look when a phrase sounds like an inside joke, a name, or shorthand you should already understand.",
 		Parents:     []string{"knowledge"},
 	},
 	"attachments": {
@@ -74,7 +74,7 @@ var builtinTagSpecs = map[string]BuiltinTagSpec{
 		Parents:     []string{"operations"},
 	},
 	"documents": {
-		Description: "Indexed document-root browsing, search, and section retrieval tools.",
+		Description: "Curated documents you've authored or imported — KB articles, runbooks, persona/ego notes, indexed reference material under managed roots. NOT past conversation history; for things the user said or you've heard before, use `archive` or `memory` instead.",
 		Parents:     []string{"knowledge"},
 	},
 	"email": {
@@ -102,7 +102,7 @@ var builtinTagSpecs = map[string]BuiltinTagSpec{
 		Parents:     []string{"operations"},
 	},
 	"memory": {
-		Description: "Persistent fact memory and working-memory tools.",
+		Description: "Things you've chosen to remember — durable facts you've stored about people, places, routines, and the user's vocabulary. Also the unified door to contacts and archive search, so it's where to start when something the user said sounds like a reference to your shared past.",
 		Parents:     []string{"knowledge"},
 	},
 	"models": {

--- a/internal/model/toolcatalog/catalog_tags.go
+++ b/internal/model/toolcatalog/catalog_tags.go
@@ -102,7 +102,7 @@ var builtinTagSpecs = map[string]BuiltinTagSpec{
 		Parents:     []string{"operations"},
 	},
 	"memory": {
-		Description: "Things you've chosen to remember — durable facts you've stored about people, places, routines, and the user's vocabulary. Also the unified door to contacts and archive search, so it's where to start when something the user said sounds like a reference to your shared past.",
+		Description: "Things you've chosen to remember — durable facts you've stored about people, places, routines, and the user's vocabulary. The store you write to with `remember_fact` and read with `recall_fact`. For past *conversations* (what was said, when, by whom) use `archive` instead; these are sibling doors, not the same room.",
 		Parents:     []string{"knowledge"},
 	},
 	"models": {

--- a/talents/message-channel-trailhead.md
+++ b/talents/message-channel-trailhead.md
@@ -20,9 +20,13 @@ Choose the next move deliberately:
   without context, a routine you should already know — that is
   `archive` and `memory` territory, not `documents`. Reach for those
   first. Guessing or reasoning around the reference when you could
-  just look it up is the move that costs trust. Activate `memory`
-  (which carries archive search, contacts, and the fact store
-  together) and search for the literal phrase before answering.
+  just look it up is the move that costs trust. **`archive` is for
+  what was said before** (full-text search across past conversations
+  via `archive_search`); **`memory` is for what you've chosen to
+  remember** (durable facts via `recall_fact`). They are sibling
+  doors. For an inside-joke phrase, activate `archive` and search
+  the literal phrase; if the answer is more "what's the user's
+  pattern" than "what did we say," `memory` is the better start.
 - Treat older-session context as a set of doors. If continuity matters
   and the pointer is not enough, activate `archive` or use the visible
   archive tools.

--- a/talents/message-channel-trailhead.md
+++ b/talents/message-channel-trailhead.md
@@ -15,11 +15,20 @@ Choose the next move deliberately:
 
 - Trust the recent message history as lived context. Do not summarize it
   back unless synthesis is the task.
+- When the message references something *only the two of you would
+  understand* — an inside joke, a household-specific phrase, a name
+  without context, a routine you should already know — that is
+  `archive` and `memory` territory, not `documents`. Reach for those
+  first. Guessing or reasoning around the reference when you could
+  just look it up is the move that costs trust. Activate `memory`
+  (which carries archive search, contacts, and the fact store
+  together) and search for the literal phrase before answering.
 - Treat older-session context as a set of doors. If continuity matters
   and the pointer is not enough, activate `archive` or use the visible
   archive tools.
-- Use `memory` when the turn reveals a durable fact, preference, or
-  relationship detail that should survive this exchange.
+- Use `memory` again when the turn *reveals* a durable fact,
+  preference, or relationship detail worth remembering — `remember_fact`
+  is the same shaped tool from the other direction.
 - Use channel affordances such as reactions only when they fit the
   social moment. They are conversational acts, not generic status tools.
 - If this message is really about Signal transport or sending a message
@@ -27,4 +36,5 @@ Choose the next move deliberately:
 - If enough context is already in hand, respond in the conversation's
   current rhythm.
 
-Let history make you more continuous, not more verbose.
+Let history make you more continuous, not more verbose. When in doubt
+between answering-around and looking-up, look up.


### PR DESCRIPTION
**Updated post-config-cutover.** Original PR text was written against the OLD pocket config which bundled \`archive_search\` + contacts under the \`memory\` tag via an operator-side \`include\`. The NEW production config (just rolled) drops that bundle — \`memory\` is narrowly facts-only now, \`archive\` is its own sibling door. The PR description and the second commit reflect the corrected mental model.

---

Diagnosed live on \`pocket\` while watching loop \`019e67a3-9ae1-7a0a-b9ca-cf82a4d3d40c\` work through a fidelity question about \"the game room door\" — a household inside-joke phrase with dozens of relevant hits in the archive. The model reached for \`doc_search\` across the curated KB instead of \`archive_search\`, got ~90 bytes per result (nothing), and stalled while guessing.

## Three layers conspired

1. **Visible toolbox.** The model's active toolbox included 19 \`doc_*\` tools but zero \`archive_*\` or memory tools. \`doc_search\` was the only search-shaped option without activating a tag — and the model didn't know there was a better tag to activate.
2. **Sterile descriptions.** The catalog descriptions of \`archive\` and \`memory\` were dry one-liners that didn't read as \"the place you keep your shared past with this person.\" Read in passing they were indistinguishable from \`documents\`.
3. **Too-gentle trailhead.** The message-channel trailhead mentioned archive only as the place to look \"if the pointer is not enough\" — fine prose, wrong default for the case where the user used a phrase the model should recognize *on sight*.

## What this PR changes

Three retunings, no tool routing or gating changes:

| Layer | Before | After |
|---|---|---|
| \`archive\` description | \"Archive search and transcript retrieval across past conversations.\" | \"What you've already heard. ... the place to look when a phrase sounds like an inside joke, a name, or shorthand you should already understand.\" |
| \`memory\` description | \"Persistent fact memory and working-memory tools.\" | \"Things you've chosen to remember — durable facts about people, places, routines, and the user's vocabulary. The store you write to with \`remember_fact\` and read with \`recall_fact\`. For past *conversations* (what was said, when, by whom) use \`archive\` instead; these are sibling doors, not the same room.\" |
| \`documents\` description | \"Indexed document-root browsing, search, and section retrieval tools.\" | \"Curated documents you've authored or imported — KB articles, runbooks, persona/ego notes ... NOT past conversation history; for things the user said or you've heard before, use \`archive\` or \`memory\` instead.\" |

Plus a sharper bullet in [message-channel-trailhead.md](talents/message-channel-trailhead.md):

> When the message references something **only the two of you would understand** — an inside joke, a household-specific phrase, a name without context, a routine you should already know — that is \`archive\` and \`memory\` territory, not \`documents\`. Reach for those first. Guessing or reasoning around the reference when you could just look it up is the move that costs trust. **\`archive\` is for what was said before** (full-text search across past conversations via \`archive_search\`); **\`memory\` is for what you've chosen to remember** (durable facts via \`recall_fact\`). They are sibling doors. For an inside-joke phrase, activate \`archive\` and search the literal phrase; if the answer is more \"what's the user's pattern\" than \"what did we say,\" \`memory\` is the better start.

Closing line of the trailhead becomes the moral: \"When in doubt between answering-around and looking-up, look up.\"

## Related

- #975 — broader Tag Menu preamble rewrite (different surface, complementary fix)
- #971 / #967 — the deeper memory-coverage problem (data hollowness). Today's fix steers the model to the *right tool*; it doesn't put more facts in the store.