### PR TITLE
fix(memory): phrase-first FTS5 search + drop anticipations by default

### DIFF
--- a/internal/state/memory/archive.go
+++ b/internal/state/memory/archive.go
@@ -1330,13 +1330,12 @@ type matchWithHighlight struct {
 // literal query as a phrase (precision); when phrase hits are
 // fewer than opts.Limit, the backfill pass adds OR-of-terms hits
 // (recall headroom) without disturbing the phrase-anchored
-// ordering. The two passes share the same anticipation /
-// conversation-ID filters via ftsConditions.
+// ordering. Both passes share the same anticipation and
+// conversation-ID filters because they both go through runFTSQuery.
 //
-// Single-word queries collapse cleanly: the phrase form
-// `"word"` is identical to the OR form `"word"` so the backfill
-// produces no new rows. The cost is one extra prepared-statement
-// execution, microseconds.
+// Single-word queries skip the backfill entirely: the OR form
+// `"word"` is identical to the phrase form, so a second query
+// would only produce duplicates.
 func (s *ArchiveStore) searchFTS(opts SearchOptions) ([]matchWithHighlight, error) {
 	phrase := phraseFTS5Query(opts.Query)
 	if phrase == "" {

--- a/internal/state/memory/archive.go
+++ b/internal/state/memory/archive.go
@@ -269,6 +269,16 @@ type SearchOptions struct {
 	MaxDuration      time.Duration // time-based cap per direction
 	Limit            int           // max results
 	NoContext        bool          // if true, return matches only (no surrounding context)
+
+	// IncludeAnticipations controls whether wake-bridge synthetic
+	// "Anticipation matched: …" rows can appear in results. The
+	// default (false) drops them because their dense-keyword shape
+	// dominates BM25 ranking for any household-vocabulary query
+	// (the entity name often repeats 5-10 times in one event),
+	// drowning out the conversational hits the model is actually
+	// reaching for. Set this true when an operator or diagnostic
+	// caller explicitly wants to inspect wake events.
+	IncludeAnticipations bool
 }
 
 // NewArchiveStore creates a new archive store at the given database path.
@@ -1269,70 +1279,178 @@ func (s *ArchiveStore) Search(opts SearchOptions) ([]SearchResult, error) {
 		opts.MaxDuration = s.defaultMaxDuration
 	}
 
-	// Build query — use FTS5 if available, fall back to LIKE
-	var query string
-	var args []any
+	// Run the search. FTS5 path uses phrase-first + OR-of-terms
+	// backfill so multi-word queries get phrase-anchored precision
+	// at the top with recall headroom when the phrase is sparse.
+	// LIKE path is the FTS5-unavailable fallback.
+	var matches []matchWithHighlight
+	var err error
+	if s.ftsEnabled {
+		matches, err = s.searchFTS(opts)
+	} else {
+		matches, err = s.searchLIKE(opts)
+	}
+	if err != nil {
+		return nil, err
+	}
 
+	// Now expand context for each match (safe to query again)
+	var results []SearchResult
+	for _, mh := range matches {
+		var before, after []Message
+		if !opts.NoContext {
+			before = s.expandContext(mh.msg.ConversationID, mh.msg.Timestamp, true, opts)
+			after = s.expandContext(mh.msg.ConversationID, mh.msg.Timestamp, false, opts)
+		}
+
+		results = append(results, SearchResult{
+			Match:         mh.msg,
+			SessionID:     mh.msg.SessionID,
+			ContextBefore: before,
+			ContextAfter:  after,
+			Highlight:     mh.highlight,
+		})
+	}
+
+	return results, nil
+}
+
+// matchWithHighlight is the per-row shape both searchFTS and
+// searchLIKE produce. It carries the full archived message plus
+// the FTS5 snippet highlight (or empty string for the LIKE
+// fallback), and lets [Search] do context expansion separately
+// from the candidate-collection phase.
+type matchWithHighlight struct {
+	msg       Message
+	highlight string
+}
+
+// searchFTS runs the phrase-first + OR-of-terms backfill against
+// the FTS5 index. The phrase pass scores rows that contain the
+// literal query as a phrase (precision); when phrase hits are
+// fewer than opts.Limit, the backfill pass adds OR-of-terms hits
+// (recall headroom) without disturbing the phrase-anchored
+// ordering. The two passes share the same anticipation /
+// conversation-ID filters via ftsConditions.
+//
+// Single-word queries collapse cleanly: the phrase form
+// `"word"` is identical to the OR form `"word"` so the backfill
+// produces no new rows. The cost is one extra prepared-statement
+// execution, microseconds.
+func (s *ArchiveStore) searchFTS(opts SearchOptions) ([]matchWithHighlight, error) {
+	phrase := phraseFTS5Query(opts.Query)
+	if phrase == "" {
+		return nil, fmt.Errorf("query is required")
+	}
+
+	phraseHits, err := s.runFTSQuery(phrase, opts, opts.Limit)
+	if err != nil {
+		return nil, err
+	}
+	if len(phraseHits) >= opts.Limit {
+		return phraseHits, nil
+	}
+
+	// Backfill with the broader OR-of-terms shape. Over-fetch a bit
+	// so that dedup against the phrase hits still leaves headroom
+	// to reach opts.Limit.
+	orExpr := orFTS5Query(opts.Query)
+	if orExpr == "" || orExpr == phrase {
+		// Single-word query — backfill would be identical, skip it.
+		return phraseHits, nil
+	}
+	backfill, err := s.runFTSQuery(orExpr, opts, opts.Limit*2)
+	if err != nil {
+		return nil, err
+	}
+	return mergeFTSMatches(phraseHits, backfill, opts.Limit), nil
+}
+
+// runFTSQuery executes one FTS5 expression against messages_fts
+// and returns the matching rows in BM25 rank order. Filters
+// (conversation_id, anticipation exclusion) live in the SQL WHERE
+// clause so they participate in BM25 scoring rather than being
+// applied post-hoc.
+func (s *ArchiveStore) runFTSQuery(ftsExpr string, opts SearchOptions, limit int) ([]matchWithHighlight, error) {
 	ftsTable := s.msgFTSName
 	msgTable := s.msgTableName
-	cols := s.msgSelectCols()
 
-	if s.ftsEnabled {
-		query = fmt.Sprintf(`
-			SELECT %s,
-			       snippet(%s, 0, '**', '**', '...', 64) as highlight
-			FROM %s
-			JOIN %s am ON %s.rowid = am.rowid
-		`, "am.id, am.conversation_id, COALESCE(am.session_id, '') as session_id, am.role, am.content, am.timestamp, am.token_count, am.tool_calls, am.tool_call_id, COALESCE(am.archived_at, '') as archived_at, COALESCE(am.archive_reason, '') as archive_reason",
-			ftsTable, ftsTable, msgTable, ftsTable)
-		// Sanitize query for FTS5: wrap each term in double quotes to prevent
-		// syntax errors from special characters (periods, colons, etc.)
-		sanitized := sanitizeFTS5Query(opts.Query)
-		args = []any{sanitized}
-		conditions := []string{ftsTable + " MATCH ?"}
+	query := fmt.Sprintf(`
+		SELECT %s,
+		       snippet(%s, 0, '**', '**', '...', 64) as highlight
+		FROM %s
+		JOIN %s am ON %s.rowid = am.rowid
+	`, "am.id, am.conversation_id, COALESCE(am.session_id, '') as session_id, am.role, am.content, am.timestamp, am.token_count, am.tool_calls, am.tool_call_id, COALESCE(am.archived_at, '') as archived_at, COALESCE(am.archive_reason, '') as archive_reason",
+		ftsTable, ftsTable, msgTable, ftsTable)
 
-		if opts.ConversationID != "" {
-			conditions = append(conditions, "am.conversation_id = ?")
-			args = append(args, opts.ConversationID)
-		}
+	args := []any{ftsExpr}
+	conditions := []string{ftsTable + " MATCH ?"}
 
-		query += " WHERE " + strings.Join(conditions, " AND ")
-		query += " ORDER BY rank LIMIT ?"
-		args = append(args, opts.Limit)
-	} else {
-		// LIKE fallback — less precise but functional
-		query = fmt.Sprintf(`
-			SELECT %s,
-			       '' as highlight
-			FROM %s
-		`, cols, msgTable)
-		args = []any{"%" + opts.Query + "%"}
-		conditions := []string{"content LIKE ?"}
-
-		if opts.ConversationID != "" {
-			conditions = append(conditions, "conversation_id = ?")
-			args = append(args, opts.ConversationID)
-		}
-
-		query += " WHERE " + strings.Join(conditions, " AND ")
-		query += " ORDER BY timestamp DESC LIMIT ?"
-		args = append(args, opts.Limit)
+	if opts.ConversationID != "" {
+		conditions = append(conditions, "am.conversation_id = ?")
+		args = append(args, opts.ConversationID)
 	}
+	if !opts.IncludeAnticipations {
+		// Wake-bridge synthetic content has its own retrieval paths
+		// (watchlist / event tools); semantic search shouldn't
+		// compete with itself. Filter at the storage layer so BM25
+		// scoring sees only the candidate set we care about.
+		conditions = append(conditions, "am.content NOT LIKE 'Anticipation matched:%'")
+	}
+
+	query += " WHERE " + strings.Join(conditions, " AND ")
+	query += " ORDER BY rank LIMIT ?"
+	args = append(args, limit)
 
 	rows, err := s.msgDB().Query(query, args...)
 	if err != nil {
 		return nil, fmt.Errorf("search: %w", err)
 	}
 	defer rows.Close()
+	return scanFTSMatches(rows)
+}
 
-	// Collect all matches first (must close rows before doing context expansion
-	// queries, since SQLite may not support concurrent readers on same connection)
-	type matchWithHighlight struct {
-		msg       Message
-		highlight string
+// searchLIKE runs the FTS5-unavailable fallback path. Less
+// precise (substring match, no BM25 ranking) but functional. The
+// anticipation filter applies here too — same rationale as the
+// FTS path, just enforced with a NOT LIKE clause.
+func (s *ArchiveStore) searchLIKE(opts SearchOptions) ([]matchWithHighlight, error) {
+	msgTable := s.msgTableName
+	cols := s.msgSelectCols()
+
+	query := fmt.Sprintf(`
+		SELECT %s,
+		       '' as highlight
+		FROM %s
+	`, cols, msgTable)
+	args := []any{"%" + opts.Query + "%"}
+	conditions := []string{"content LIKE ?"}
+
+	if opts.ConversationID != "" {
+		conditions = append(conditions, "conversation_id = ?")
+		args = append(args, opts.ConversationID)
 	}
-	var matches []matchWithHighlight
+	if !opts.IncludeAnticipations {
+		conditions = append(conditions, "content NOT LIKE 'Anticipation matched:%'")
+	}
 
+	query += " WHERE " + strings.Join(conditions, " AND ")
+	query += " ORDER BY timestamp DESC LIMIT ?"
+	args = append(args, opts.Limit)
+
+	rows, err := s.msgDB().Query(query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("search: %w", err)
+	}
+	defer rows.Close()
+	return scanFTSMatches(rows)
+}
+
+// scanFTSMatches reads the shared match-with-highlight projection
+// out of either the FTS5 or LIKE query path. Both queries select
+// the same column list so a single scanner serves both.
+func scanFTSMatches(rows *sql.Rows) ([]matchWithHighlight, error) {
+	var matches []matchWithHighlight
 	for rows.Next() {
 		var m Message
 		var highlight string
@@ -1368,27 +1486,33 @@ func (s *ArchiveStore) Search(opts SearchOptions) ([]SearchResult, error) {
 	if err := rows.Err(); err != nil {
 		return nil, fmt.Errorf("iterate results: %w", err)
 	}
-	rows.Close()
+	return matches, nil
+}
 
-	// Now expand context for each match (safe to query again)
-	var results []SearchResult
-	for _, mh := range matches {
-		var before, after []Message
-		if !opts.NoContext {
-			before = s.expandContext(mh.msg.ConversationID, mh.msg.Timestamp, true, opts)
-			after = s.expandContext(mh.msg.ConversationID, mh.msg.Timestamp, false, opts)
-		}
-
-		results = append(results, SearchResult{
-			Match:         mh.msg,
-			SessionID:     mh.msg.SessionID,
-			ContextBefore: before,
-			ContextAfter:  after,
-			Highlight:     mh.highlight,
-		})
+// mergeFTSMatches appends backfill rows after the phrase-anchored
+// rows, dropping duplicates by message ID and capping at limit.
+// Phrase ordering is preserved at the head; backfill ordering
+// (BM25 over OR-of-terms) fills the tail.
+func mergeFTSMatches(phrase, backfill []matchWithHighlight, limit int) []matchWithHighlight {
+	if len(phrase) >= limit {
+		return phrase[:limit]
 	}
-
-	return results, nil
+	seen := make(map[string]struct{}, len(phrase)+len(backfill))
+	for _, m := range phrase {
+		seen[m.msg.ID] = struct{}{}
+	}
+	out := make([]matchWithHighlight, 0, limit)
+	out = append(out, phrase...)
+	for _, m := range backfill {
+		if _, dup := seen[m.msg.ID]; dup {
+			continue
+		}
+		out = append(out, m)
+		if len(out) >= limit {
+			break
+		}
+	}
+	return out
 }
 
 // expandContext walks messages outward from a timestamp, stopping at silence gaps.
@@ -2584,13 +2708,34 @@ func nullString(s string) any {
 	return s
 }
 
-// sanitizeFTS5Query wraps each search term in double quotes to prevent FTS5
-// syntax errors from special characters like periods, colons, and parentheses,
-// then joins terms with OR so that broader recall is possible. BM25 ranking
-// ensures messages matching more terms score higher.
+// phraseFTS5Query wraps the whole query in a single double-quoted
+// phrase so FTS5 matches only rows containing the literal sequence
+// of terms. Embedded double-quotes are escaped per FTS5 string-
+// literal rules. Returns "" for an empty input.
 //
-// E.g., "consciousness hard problem" becomes `"consciousness" OR "hard" OR "problem"`.
-func sanitizeFTS5Query(query string) string {
+// Used as the precision-first leg of Search's phrase-first +
+// OR-of-terms backfill: phrase hits rank by BM25 against rows that
+// actually contain the phrase, instead of being drowned out by
+// dense-keyword rows that happen to match individual tokens.
+func phraseFTS5Query(query string) string {
+	q := strings.TrimSpace(query)
+	if q == "" {
+		return ""
+	}
+	q = strings.ReplaceAll(q, `"`, `""`)
+	return `"` + q + `"`
+}
+
+// orFTS5Query wraps each whitespace-separated term in double quotes
+// and joins with OR. Broader recall than [phraseFTS5Query] — used
+// as the backfill leg of Search's phrase-first + OR-of-terms
+// strategy when the phrase pass returns fewer hits than the limit
+// (or for single-word queries, where the two shapes are
+// equivalent).
+//
+// E.g., "consciousness hard problem" becomes
+// `"consciousness" OR "hard" OR "problem"`.
+func orFTS5Query(query string) string {
 	words := strings.Fields(query)
 	if len(words) == 0 {
 		return ""

--- a/internal/state/memory/archive_test.go
+++ b/internal/state/memory/archive_test.go
@@ -1934,3 +1934,179 @@ func TestGetMessagesInRange_ExcludeSessionIDPreservesNullRows(t *testing.T) {
 		t.Error("NULL session_id row dropped — exclusion should preserve NULLs")
 	}
 }
+
+// TestSearch_PhraseFirstPreferred verifies the phrase-first +
+// OR-of-terms backfill: when a multi-word phrase has dedicated
+// matches, those rank higher than rows where the individual words
+// happen to co-occur densely. The fixture includes a "noise" row
+// that repeats individual query tokens many times — it should not
+// rank above the row that contains the phrase verbatim.
+func TestSearch_PhraseFirstPreferred(t *testing.T) {
+	store := newTestArchiveStore(t)
+
+	base := time.Date(2026, 2, 12, 10, 0, 0, 0, time.UTC)
+	msgs := []Message{
+		// Dense-keyword noise: lots of "office", "door", "state" but
+		// never the phrase "office door state" in that order.
+		{
+			ID: "noise", ConversationID: "conv-1", SessionID: "sess-1",
+			Role:          "tool",
+			Content:       "office occupancy. office camera. office lock. door open. door close. door open. door state changed. state available. state on. state off. state error.",
+			Timestamp:     base,
+			ArchiveReason: string(ArchiveReasonReset),
+		},
+		// Phrase-anchored row: contains the exact "office door state" once.
+		{
+			ID: "phrase", ConversationID: "conv-1", SessionID: "sess-1",
+			Role:          "user",
+			Content:       "What is the office door state right now?",
+			Timestamp:     base.Add(time.Minute),
+			ArchiveReason: string(ArchiveReasonReset),
+		},
+	}
+	if err := store.ArchiveMessages(msgs); err != nil {
+		t.Fatal(err)
+	}
+
+	results, err := store.Search(SearchOptions{
+		Query:     "office door state",
+		Limit:     5,
+		NoContext: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) == 0 {
+		t.Fatal("expected at least one result")
+	}
+	if results[0].Match.ID != "phrase" {
+		t.Errorf("expected phrase-anchored row to rank first, got %q with content %q",
+			results[0].Match.ID, results[0].Match.Content)
+	}
+}
+
+// TestSearch_AnticipationsFilteredByDefault verifies that
+// wake-bridge synthetic "Anticipation matched: …" rows are
+// excluded from search results by default and only appear when
+// IncludeAnticipations is set true.
+func TestSearch_AnticipationsFilteredByDefault(t *testing.T) {
+	store := newTestArchiveStore(t)
+
+	base := time.Date(2026, 2, 12, 10, 0, 0, 0, time.UTC)
+	msgs := []Message{
+		{
+			ID: "anticipation", ConversationID: "wake-ant_999", SessionID: "sess-w",
+			Role:          "user",
+			Content:       "Anticipation matched: \"check the pool heater after 5 minutes\"\n\nEntity sensor.pool_heater changed from off to on.",
+			Timestamp:     base,
+			ArchiveReason: string(ArchiveReasonReset),
+		},
+		{
+			ID: "conversational", ConversationID: "conv-1", SessionID: "sess-1",
+			Role:          "user",
+			Content:       "Is the pool heater on?",
+			Timestamp:     base.Add(time.Minute),
+			ArchiveReason: string(ArchiveReasonReset),
+		},
+	}
+	if err := store.ArchiveMessages(msgs); err != nil {
+		t.Fatal(err)
+	}
+
+	// Default: anticipations excluded.
+	res, err := store.Search(SearchOptions{Query: "pool heater", Limit: 5, NoContext: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, r := range res {
+		if r.Match.ID == "anticipation" {
+			t.Errorf("anticipation row should not appear in default results, got %q", r.Match.Content)
+		}
+	}
+	if len(res) == 0 {
+		t.Fatal("conversational hit should still be returned with default filter")
+	}
+
+	// Opt-in: anticipations included.
+	res, err = store.Search(SearchOptions{Query: "pool heater", Limit: 5, NoContext: true, IncludeAnticipations: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var sawAnticipation bool
+	for _, r := range res {
+		if r.Match.ID == "anticipation" {
+			sawAnticipation = true
+			break
+		}
+	}
+	if !sawAnticipation {
+		t.Error("anticipation row should appear when IncludeAnticipations=true")
+	}
+}
+
+// TestSearch_OrBackfillFillsThinPhrase verifies that when a
+// phrase pass returns fewer hits than the limit, the OR-of-terms
+// backfill tops it up — without duplicating the phrase hits.
+// The backfill path is FTS5-only; the LIKE fallback runs one
+// substring pass and has no equivalent.
+func TestSearch_OrBackfillFillsThinPhrase(t *testing.T) {
+	store := newTestArchiveStore(t)
+	if !store.FTSEnabled() {
+		t.Skip("FTS5 not available; OR-backfill path requires FTS5")
+	}
+
+	base := time.Date(2026, 2, 12, 10, 0, 0, 0, time.UTC)
+	msgs := []Message{
+		// One phrase match.
+		{
+			ID: "phrase-only", ConversationID: "conv-1", SessionID: "sess-1",
+			Role:          "user",
+			Content:       "I lost my keys at the pool patio yesterday.",
+			Timestamp:     base,
+			ArchiveReason: string(ArchiveReasonReset),
+		},
+		// Several rows matching individual terms.
+		{
+			ID: "patio-only", ConversationID: "conv-1", SessionID: "sess-1",
+			Role:          "user",
+			Content:       "The back patio needs sweeping.",
+			Timestamp:     base.Add(time.Minute),
+			ArchiveReason: string(ArchiveReasonReset),
+		},
+		{
+			ID: "pool-only", ConversationID: "conv-1", SessionID: "sess-1",
+			Role:          "user",
+			Content:       "Is the swimming pool open?",
+			Timestamp:     base.Add(2 * time.Minute),
+			ArchiveReason: string(ArchiveReasonReset),
+		},
+	}
+	if err := store.ArchiveMessages(msgs); err != nil {
+		t.Fatal(err)
+	}
+
+	results, err := store.Search(SearchOptions{
+		Query:     "pool patio",
+		Limit:     5,
+		NoContext: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(results) < 2 {
+		t.Fatalf("expected backfill to add to single phrase hit, got %d results", len(results))
+	}
+	// Phrase match should be at rank 1.
+	if results[0].Match.ID != "phrase-only" {
+		t.Errorf("expected phrase row at rank 1, got %q", results[0].Match.ID)
+	}
+	// No duplicates — every result is unique.
+	seen := map[string]bool{}
+	for _, r := range results {
+		if seen[r.Match.ID] {
+			t.Errorf("duplicate result %q in merged set", r.Match.ID)
+		}
+		seen[r.Match.ID] = true
+	}
+}


### PR DESCRIPTION
## Summary

Addresses **#977 Finding 1** — archive_search precision.

`archive_search` was tokenizing multi-word queries into a bag of OR-of-terms, so dense-keyword noise outranked literal phrase matches. Two changes:

- **Phrase-first then OR-of-terms backfill.** The phrase pass quotes the entire query as one FTS5 phrase token; BM25 then rewards rows that contain the literal phrase. When the phrase pass returns fewer hits than the limit, an OR-of-terms pass tops up the tail. Single-word queries collapse cleanly to one pass.
- **Filter `Anticipation matched: …` wake-bridge rows by default.** Those have dedicated retrieval surfaces (watchlist/event tools) and only compete with conversational hits in BM25. Opt back in via `SearchOptions.IncludeAnticipations` if an internal caller needs them.

Originally surfaced via the `prewarm-replay compare` harness (PR #972), where the phrase-first sanitizer took "office door state" from 0/6 phrase-in-content hits to 6/6, and the anticipation filter took "game room door" from 0/6 to 6/6 conversational hits.

## Changes

- `internal/state/memory/archive.go`:
  - Add `IncludeAnticipations bool` to `SearchOptions` (default false).
  - Split `Search` into `searchFTS` (phrase + OR backfill) and `searchLIKE` (substring fallback).
  - New helpers `phraseFTS5Query`, `orFTS5Query`, `runFTSQuery`, `scanFTSMatches`, `mergeFTSMatches`.
  - Both paths filter `content NOT LIKE 'Anticipation matched:%'` unless opt-in.
- `internal/state/memory/archive_test.go`: three new tests covering phrase-first ordering, default-off anticipations + opt-in, and OR-backfill topping up a thin phrase result.

## Test plan

- [x] `go test -tags=sqlite_fts5 ./internal/state/memory/` — all three new tests pass
- [x] `just ci` — full gate green
- [x] OR-backfill test skips cleanly when FTS5 isn't compiled in (LIKE fallback has no equivalent path)

Refs #977