### PR TITLE
fix(memory): drop identity-shaped subjects from archive prewarm FTS query

### DIFF
--- a/internal/state/memory/archive_provider.go
+++ b/internal/state/memory/archive_provider.go
@@ -126,8 +126,13 @@ func (p *ArchiveContextProvider) TagContext(ctx context.Context, req agentctx.Co
 const maxUserMessageLen = 100
 
 // buildQuery constructs a search query from subjects and/or the user
-// message. Subject prefixes (entity:, zone:, etc.) are stripped to
-// leave raw identifiers that match conversational references.
+// message. Content-shaped subject prefixes (entity:, zone:, area:,
+// space:) are stripped to leave raw identifiers that match
+// conversational references. Identity-shaped subjects (contact:) are
+// dropped from the query because their values are stable handles
+// (UUIDs, phone numbers, email addresses) that either match nothing
+// or match every message from that handle — neither produces a
+// useful FTS ranking.
 //
 // Returns the query string and a source label ("subjects" or
 // "message_fallback") for logging.
@@ -136,6 +141,9 @@ func (p *ArchiveContextProvider) buildQuery(subjects []string, userMessage strin
 	var terms []string
 
 	for _, s := range subjects {
+		if isIdentitySubject(s) {
+			continue
+		}
 		term := stripSubjectPrefix(s)
 		if term != "" && !seen[term] {
 			seen[term] = true
@@ -147,9 +155,12 @@ func (p *ArchiveContextProvider) buildQuery(subjects []string, userMessage strin
 		return strings.Join(terms, " "), "subjects"
 	}
 
-	// Fall back to user message when no subjects are available.
-	// Only use short, single-line messages — long content produces
-	// noisy queries.
+	// Fall back to user message when no content-shaped subjects are
+	// available. Only use short, single-line messages — long content
+	// produces noisy queries. This branch handles two cases that look
+	// the same from here: no subjects at all, and only identity-shaped
+	// subjects (e.g. Signal contact handles) that we filtered out
+	// above.
 	if userMessage != "" {
 		msg := strings.TrimSpace(userMessage)
 		if len(msg) <= maxUserMessageLen && !strings.ContainsAny(msg, "\n\r") {
@@ -158,6 +169,28 @@ func (p *ArchiveContextProvider) buildQuery(subjects []string, userMessage strin
 	}
 
 	return "", ""
+}
+
+// identitySubjectPrefixes lists the subject kinds whose values are
+// stable identity handles, not content terms. Stripping the prefix
+// leaves a UUID, phone, or address that the FTS index treats as a
+// generic token — typically matching every message from that
+// participant and ranking the shortest of those highest. Useful for
+// scoping (conversation_id filters, knowledge subject keys) but a
+// pollutant in a full-text query.
+var identitySubjectPrefixes = map[string]struct{}{
+	"contact": {},
+}
+
+// isIdentitySubject reports whether a subject's prefix marks it as
+// an identity handle rather than a content term.
+func isIdentitySubject(s string) bool {
+	idx := strings.IndexByte(s, ':')
+	if idx < 0 {
+		return false
+	}
+	_, ok := identitySubjectPrefixes[s[:idx]]
+	return ok
 }
 
 // stripSubjectPrefix removes the type prefix from a subject string.

--- a/internal/state/memory/archive_provider_test.go
+++ b/internal/state/memory/archive_provider_test.go
@@ -314,7 +314,10 @@ func TestArchiveContextProvider_GetContext(t *testing.T) {
 		})
 		_, _ = p.TagContext(ctx, agentctx.ContextRequest{UserMessage: ""})
 
-		// Verify all prefixes are stripped.
+		// Content-shaped prefixes are stripped and their values
+		// become query terms. Identity-shaped prefixes (contact:)
+		// are dropped entirely — their values are stable handles
+		// that pollute the FTS query (see #979).
 		q := mock.lastQuery
 		if strings.Contains(q, "entity:") {
 			t.Errorf("query %q should not contain 'entity:' prefix", q)
@@ -331,8 +334,8 @@ func TestArchiveContextProvider_GetContext(t *testing.T) {
 		if !strings.Contains(q, "kitchen") {
 			t.Errorf("query %q should contain 'kitchen'", q)
 		}
-		if !strings.Contains(q, "dan@example.com") {
-			t.Errorf("query %q should contain 'dan@example.com'", q)
+		if strings.Contains(q, "dan@example.com") {
+			t.Errorf("query %q should NOT contain 'dan@example.com' — contact subjects are identity-shaped, dropped from FTS", q)
 		}
 	})
 
@@ -468,6 +471,38 @@ func TestBuildQuery(t *testing.T) {
 			subjects:   []string{"bare_subject"},
 			wantQuery:  "bare_subject",
 			wantSource: "subjects",
+		},
+		{
+			// Channel-binding subjects (sender handle + contact UUID)
+			// must not become the FTS query — they either match
+			// nothing or match every message from that sender. With
+			// only identity subjects and a user message present, the
+			// provider must fall through to message_fallback.
+			name:       "contact_subjects_dropped_falls_through_to_message",
+			subjects:   []string{"contact:019c76e4-2ff1-7918-8d6f-6c2488f5098d", "contact:+15124232707"},
+			message:    "why don't you use the game room door after a shower",
+			wantQuery:  "why don't you use the game room door after a shower",
+			wantSource: "message_fallback",
+		},
+		{
+			// Identity subjects coexisting with a content subject:
+			// the content subject still drives the query; identity
+			// values are dropped silently.
+			name:       "contact_subjects_dropped_alongside_content",
+			subjects:   []string{"contact:+15124232707", "entity:binary_sensor.game_room_door"},
+			message:    "fallback that should not be used",
+			wantQuery:  "binary_sensor.game_room_door",
+			wantSource: "subjects",
+		},
+		{
+			// Identity-only subjects with no user message → no query.
+			// The "" / "" return tells the caller to skip the prewarm
+			// pass entirely; emitting an FTS-poisoning query would
+			// be worse.
+			name:       "contact_subjects_only_no_message",
+			subjects:   []string{"contact:+15124232707"},
+			wantQuery:  "",
+			wantSource: "",
 		},
 	}
 


### PR DESCRIPTION
Closes #979.

## Summary

Channel-binding subjects (`contact:<UUID>`, `contact:<Address>`) were flowing into the archive prewarm's FTS query through `buildQuery`, where their prefix was stripped and the raw values (phone numbers, email addresses, UUIDs) were joined as query terms. For Signal turns this meant the prewarm query became the sender's phone number — which matches every archived message from that sender via `metadata.sender.address`, and BM25 then ranks the *shortest* matches highest.

Result on the production fidelity trace ([#979](https://github.com/nugget/thane-ai-agent/issues/979)): the model's "Past Experience" section contained `"thanks"`, `"cd .."`, `"Activate documents"` — three one-word user messages from this sender, completely unrelated to the inbound topic.

The fix: identity-shaped subject prefixes (currently just `contact:`) are dropped from the query construction entirely. The existing `message_fallback` branch — which was already written to take over when no subjects are available — now also takes over when only identity subjects are present. The inbound user message becomes the FTS query, which gives the model a topic-relevant prewarm hit.

Content-shaped subjects (`entity:`, `zone:`, `area:`, `space:`, etc.) are unaffected: their stripped values remain useful FTS terms.

## What this is *not*

This is a surgical fix for the bug in #979 — the cheapest correct shape (option A from the issue). It does **not** introduce a formal "kinds" taxonomy for subjects (option B in the issue) or change the prewarm contract to always use the user message (option C). Those are larger redesigns that should wait until we see how this fix performs in production.

Identity subjects still flow to the knowledge subject-keyed provider, where contact-keyed retrieval is the intended shape — only the archive provider's FTS query is affected.

## Changes

- `internal/state/memory/archive_provider.go`: new `isIdentitySubject` predicate + `identitySubjectPrefixes` set; `buildQuery` skips identity subjects when building query terms.
- `internal/state/memory/archive_provider_test.go`: three new `TestBuildQuery` cases (identity-only falls through to message fallback, identity coexisting with content yields content-only query, identity-only with no message returns empty); updated `TestArchiveContextProvider_GetContext/subject_prefix_stripping` to assert the new (correct) behavior that `contact:dan@example.com` is dropped, not included.

## Test plan

- [x] `go test -run TestBuildQuery ./internal/state/memory/` — all 8 cases pass (5 pre-existing + 3 new)
- [x] `just ci` — full gate green
- [ ] Post-deploy verification on the real fidelity trace: confirm Signal turns from `+15124232707` no longer surface `"thanks"`/`"cd .."`/`"Activate documents"` as Past Experience; instead get a topically-relevant hit from the inbound message's content (or empty when the message is too long for the fallback's 100-char cap — separate concern, not in scope here).