### PR TITLE
feat(memory): FTS5 indexes on sessions and working_memory

### DIFF
--- a/internal/app/new_stores.go
+++ b/internal/app/new_stores.go
@@ -298,8 +298,10 @@ func (a *App) initStores(s *newState) error {
 	a.onCloseErr("archive", archiveStore.Close)
 
 	// --- Working memory ---
-	// Persists free-form experiential context per conversation.
-	wmStore, err := memory.NewWorkingMemoryStore(mem.DB())
+	// Persists free-form experiential context per conversation. Shares
+	// the archive store's FTS5-availability gate so working_memory_fts
+	// only gets created when the archive's messages_fts also can.
+	wmStore, err := memory.NewWorkingMemoryStore(mem.DB(), archiveStore.FTSEnabled())
 	if err != nil {
 		return fmt.Errorf("create working memory store: %w", err)
 	}

--- a/internal/state/memory/archive.go
+++ b/internal/state/memory/archive.go
@@ -331,6 +331,12 @@ func NewArchiveStore(dbPath string, messagesDB *sql.DB, cfg *ArchiveConfig, logg
 	// Try to enable FTS5 — gracefully degrade if not available
 	s.ftsEnabled = s.tryEnableFTS()
 
+	// Distilled-surface FTS lives alongside the raw-message FTS. The
+	// setup is gated on s.ftsEnabled internally; safe to call here
+	// unconditionally and let the function no-op when FTS5 isn't
+	// available.
+	s.trySetupSessionsFTS()
+
 	if logger != nil {
 		if s.ftsEnabled {
 			logger.Info("session archive initialized",
@@ -388,6 +394,7 @@ func NewArchiveStoreFromDB(db *sql.DB, cfg *ArchiveConfig, logger *slog.Logger) 
 
 	s.migrateSchema()
 	s.ftsEnabled = s.tryEnableFTS()
+	s.trySetupSessionsFTS()
 
 	if logger != nil {
 		logger.Info("session archive initialized (consolidated)",

--- a/internal/state/memory/archive.go
+++ b/internal/state/memory/archive.go
@@ -50,6 +50,14 @@ type ArchiveStore struct {
 	// Whether FTS5 is available
 	ftsEnabled bool
 
+	// Whether sessions_fts was set up successfully. Separate from
+	// ftsEnabled because trySetupSessionsFTS can fail independently of
+	// the core FTS5 availability probe (e.g. corrupted pre-existing
+	// virtual table, permissions issue on a shadow table). SearchSessions
+	// gates on this so a failed setup degrades to "no hits" rather than
+	// erroring at query time against a missing/broken FTS table.
+	sessionsFTSEnabled bool
+
 	// Context expansion defaults
 	defaultSilenceThreshold time.Duration
 	defaultMaxMessages      int
@@ -334,8 +342,9 @@ func NewArchiveStore(dbPath string, messagesDB *sql.DB, cfg *ArchiveConfig, logg
 	// Distilled-surface FTS lives alongside the raw-message FTS. The
 	// setup is gated on s.ftsEnabled internally; safe to call here
 	// unconditionally and let the function no-op when FTS5 isn't
-	// available.
-	s.trySetupSessionsFTS()
+	// available. Persist the result so SearchSessions can degrade
+	// gracefully when sessions_fts specifically failed to set up.
+	s.sessionsFTSEnabled = s.trySetupSessionsFTS()
 
 	if logger != nil {
 		if s.ftsEnabled {
@@ -394,7 +403,7 @@ func NewArchiveStoreFromDB(db *sql.DB, cfg *ArchiveConfig, logger *slog.Logger) 
 
 	s.migrateSchema()
 	s.ftsEnabled = s.tryEnableFTS()
-	s.trySetupSessionsFTS()
+	s.sessionsFTSEnabled = s.trySetupSessionsFTS()
 
 	if logger != nil {
 		logger.Info("session archive initialized (consolidated)",

--- a/internal/state/memory/distilled_fts.go
+++ b/internal/state/memory/distilled_fts.go
@@ -1,0 +1,281 @@
+package memory
+
+import (
+	"database/sql"
+	"fmt"
+	"time"
+
+	"github.com/nugget/thane-ai-agent/internal/platform/database"
+)
+
+// sessionsFTSTable is the FTS5 virtual table name covering the
+// sessions table's distilled columns. Indexes title, summary, and
+// tags so a single query against a household-vocabulary phrase can
+// reach the summarizer's per-session output. Held alongside the
+// raw-message index [ArchiveStore.msgFTSName].
+const sessionsFTSTable = "sessions_fts"
+
+// workingMemoryFTSTable is the FTS5 virtual table name covering
+// working_memory.content. Working memory is per-conversation living
+// distillation written by the metacog loop — small but high
+// signal-density.
+const workingMemoryFTSTable = "working_memory_fts"
+
+// trySetupSessionsFTS creates the sessions_fts virtual table, the
+// AI/AD/AU sync triggers, and backfills any rows that exist in
+// sessions but not yet in sessions_fts. Returns true on success.
+// Idempotent — re-running against an initialized store is a no-op
+// beyond the existence checks.
+//
+// Mirrors the shape SQLite expects for external-content FTS5: rows
+// only appear in sessions_fts when an INSERT/UPDATE on sessions
+// fires one of the triggers, or when the backfill runs once at
+// startup against a fresh index.
+func (s *ArchiveStore) trySetupSessionsFTS() bool {
+	if !s.ftsEnabled {
+		return false
+	}
+	db := s.db
+	if db == nil {
+		return false
+	}
+
+	// 1. Virtual table. External-content over the sessions table by
+	//    rowid. The column list is what BM25 ranks over.
+	stmts := []string{
+		fmt.Sprintf(`
+			CREATE VIRTUAL TABLE IF NOT EXISTS %s USING fts5(
+				title, summary, tags,
+				content=sessions, content_rowid=rowid
+			)
+		`, sessionsFTSTable),
+
+		// 2. Sync triggers. AI on insert, AD on delete, AU on update —
+		//    the AU pattern is "delete then insert" because FTS5 can't
+		//    do partial-column updates on external-content tables.
+		fmt.Sprintf(`
+			CREATE TRIGGER IF NOT EXISTS sessions_fts_ai AFTER INSERT ON sessions BEGIN
+				INSERT INTO %s(rowid, title, summary, tags)
+				VALUES (new.rowid,
+				        COALESCE(new.title, ''),
+				        COALESCE(new.summary, ''),
+				        COALESCE(new.tags, ''));
+			END
+		`, sessionsFTSTable),
+		fmt.Sprintf(`
+			CREATE TRIGGER IF NOT EXISTS sessions_fts_ad AFTER DELETE ON sessions BEGIN
+				INSERT INTO %s(%s, rowid, title, summary, tags)
+				VALUES ('delete', old.rowid,
+				        COALESCE(old.title, ''),
+				        COALESCE(old.summary, ''),
+				        COALESCE(old.tags, ''));
+			END
+		`, sessionsFTSTable, sessionsFTSTable),
+		fmt.Sprintf(`
+			CREATE TRIGGER IF NOT EXISTS sessions_fts_au AFTER UPDATE ON sessions BEGIN
+				INSERT INTO %s(%s, rowid, title, summary, tags)
+				VALUES ('delete', old.rowid,
+				        COALESCE(old.title, ''),
+				        COALESCE(old.summary, ''),
+				        COALESCE(old.tags, ''));
+				INSERT INTO %s(rowid, title, summary, tags)
+				VALUES (new.rowid,
+				        COALESCE(new.title, ''),
+				        COALESCE(new.summary, ''),
+				        COALESCE(new.tags, ''));
+			END
+		`, sessionsFTSTable, sessionsFTSTable, sessionsFTSTable),
+	}
+	for _, stmt := range stmts {
+		if _, err := db.Exec(stmt); err != nil {
+			if s.logger != nil {
+				s.logger.Warn("sessions_fts setup failed", "error", err)
+			}
+			return false
+		}
+	}
+
+	// 3. Backfill via FTS5's 'rebuild' command when the inverted
+	//    index is empty. Runs only on first init: once any session
+	//    has been indexed (either by this backfill or by AI/AU
+	//    triggers as the summarizer produces metadata), steady-state
+	//    sync is the triggers' job.
+	//
+	//    Empty-check probes the _docsize shadow table, not COUNT(*)
+	//    on the virtual table — external-content FTS5 proxies
+	//    SELECT COUNT(*) through to the source `sessions` table and
+	//    so always reports > 0 whenever any session exists. Only the
+	//    shadow tables (_docsize, _data, _idx) tell you whether the
+	//    inverted index itself has any tokenized rows.
+	var docCount int
+	if err := db.QueryRow(fmt.Sprintf(`SELECT COUNT(*) FROM %s_docsize`, sessionsFTSTable)).Scan(&docCount); err != nil {
+		if s.logger != nil {
+			s.logger.Warn("sessions_fts docsize probe failed", "error", err)
+		}
+		return true // triggers are installed — degrade gracefully
+	}
+	if docCount == 0 {
+		if _, err := db.Exec(fmt.Sprintf(`INSERT INTO %s(%s) VALUES('rebuild')`, sessionsFTSTable, sessionsFTSTable)); err != nil {
+			if s.logger != nil {
+				s.logger.Warn("sessions_fts backfill failed", "error", err)
+			}
+			// Don't fail the whole setup — the AI trigger handles new
+			// sessions; existing rows can be backfilled by the next
+			// startup retrying.
+		}
+	}
+
+	return true
+}
+
+// SessionMatch is the per-row shape returned from [ArchiveStore.SearchSessions].
+// Each match carries the session's identifying metadata plus the
+// snippet highlight FTS5 produced from whichever indexed column
+// matched. Use SessionID with the existing archive_session_transcript
+// retrieval to pull the full conversation that generated the summary.
+type SessionMatch struct {
+	SessionID      string    `json:"session_id"`
+	ConversationID string    `json:"conversation_id"`
+	StartedAt      time.Time `json:"started_at"`
+	EndedAt        time.Time `json:"ended_at,omitempty"`
+	Title          string    `json:"title"`
+	Summary        string    `json:"summary"`
+	Tags           string    `json:"tags,omitempty"`
+	Highlight      string    `json:"highlight"`
+}
+
+// SearchSessions runs an FTS5 query against sessions_fts and returns
+// the highest-ranking session summaries by BM25. The query is wrapped
+// as a phrase token via [phraseFTS5Query] for the same reason the
+// raw-message search prefers phrase-anchored hits: distilled summary
+// text rewards literal phrase matches over bag-of-OR-terms recall.
+//
+// Returns empty slice (not error) when FTS5 isn't available, when
+// the query trims to empty, or when no rows match. Caller composes
+// this with [ArchiveStore.Search] to build a multi-surface envelope.
+func (s *ArchiveStore) SearchSessions(query string, limit int) ([]SessionMatch, error) {
+	if !s.ftsEnabled {
+		return nil, nil
+	}
+	q := phraseFTS5Query(query)
+	if q == "" {
+		return nil, nil
+	}
+	if limit <= 0 {
+		limit = 5
+	}
+
+	sqlText := fmt.Sprintf(`
+		SELECT s.id, s.conversation_id, s.started_at,
+		       COALESCE(s.ended_at, '') AS ended_at,
+		       COALESCE(s.title, ''),
+		       COALESCE(s.summary, ''),
+		       COALESCE(s.tags, ''),
+		       snippet(%s, -1, '**', '**', '...', 32) AS highlight
+		FROM %s
+		JOIN sessions s ON s.rowid = %s.rowid
+		WHERE %s MATCH ?
+		ORDER BY rank
+		LIMIT ?
+	`, sessionsFTSTable, sessionsFTSTable, sessionsFTSTable, sessionsFTSTable)
+
+	rows, err := s.db.Query(sqlText, q, limit)
+	if err != nil {
+		return nil, fmt.Errorf("search sessions: %w", err)
+	}
+	defer rows.Close()
+
+	var out []SessionMatch
+	for rows.Next() {
+		var m SessionMatch
+		var startedStr, endedStr string
+		if err := rows.Scan(
+			&m.SessionID, &m.ConversationID, &startedStr, &endedStr,
+			&m.Title, &m.Summary, &m.Tags, &m.Highlight,
+		); err != nil {
+			return nil, fmt.Errorf("scan session match: %w", err)
+		}
+		if m.StartedAt, err = database.ParseTimestamp(startedStr); err != nil {
+			return nil, fmt.Errorf("parse session started_at: %w", err)
+		}
+		if endedStr != "" {
+			if m.EndedAt, err = database.ParseTimestamp(endedStr); err != nil {
+				return nil, fmt.Errorf("parse session ended_at: %w", err)
+			}
+		}
+		out = append(out, m)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate session matches: %w", err)
+	}
+	return out, nil
+}
+
+// trySetupWorkingMemoryFTS creates working_memory_fts, its sync
+// triggers, and backfills existing rows. Same shape as
+// [ArchiveStore.trySetupSessionsFTS] but for the per-conversation
+// living-distillation table.
+//
+// Called from [WorkingMemoryStore]'s migration path; takes the shared
+// FTS5-availability gate as an argument so the working-memory store
+// doesn't need to re-probe FTS5 separately.
+func trySetupWorkingMemoryFTS(db *sql.DB, ftsEnabled bool) bool {
+	if !ftsEnabled || db == nil {
+		return false
+	}
+	stmts := []string{
+		fmt.Sprintf(`
+			CREATE VIRTUAL TABLE IF NOT EXISTS %s USING fts5(
+				content,
+				content=working_memory, content_rowid=rowid
+			)
+		`, workingMemoryFTSTable),
+		fmt.Sprintf(`
+			CREATE TRIGGER IF NOT EXISTS working_memory_fts_ai AFTER INSERT ON working_memory BEGIN
+				INSERT INTO %s(rowid, content) VALUES (new.rowid, new.content);
+			END
+		`, workingMemoryFTSTable),
+		fmt.Sprintf(`
+			CREATE TRIGGER IF NOT EXISTS working_memory_fts_ad AFTER DELETE ON working_memory BEGIN
+				INSERT INTO %s(%s, rowid, content) VALUES ('delete', old.rowid, old.content);
+			END
+		`, workingMemoryFTSTable, workingMemoryFTSTable),
+		fmt.Sprintf(`
+			CREATE TRIGGER IF NOT EXISTS working_memory_fts_au AFTER UPDATE ON working_memory BEGIN
+				INSERT INTO %s(%s, rowid, content) VALUES ('delete', old.rowid, old.content);
+				INSERT INTO %s(rowid, content) VALUES (new.rowid, new.content);
+			END
+		`, workingMemoryFTSTable, workingMemoryFTSTable, workingMemoryFTSTable),
+	}
+	for _, stmt := range stmts {
+		if _, err := db.Exec(stmt); err != nil {
+			return false
+		}
+	}
+	// Backfill via 'rebuild' when the inverted index is empty. Same
+	// shadow-table semantics as [ArchiveStore.trySetupSessionsFTS] —
+	// COUNT(*) on the virtual table proxies through to the source,
+	// so only `_docsize` is honest about whether the index has
+	// tokenized rows.
+	var docCount int
+	if err := db.QueryRow(fmt.Sprintf(`SELECT COUNT(*) FROM %s_docsize`, workingMemoryFTSTable)).Scan(&docCount); err != nil {
+		return true
+	}
+	if docCount == 0 {
+		_, _ = db.Exec(fmt.Sprintf(`INSERT INTO %s(%s) VALUES('rebuild')`, workingMemoryFTSTable, workingMemoryFTSTable))
+	}
+	return true
+}
+
+// WorkingMemoryMatch is the per-row shape returned from
+// [WorkingMemoryStore.Search]. Working memory is keyed by
+// conversation_id, so the match identifies which conversation's
+// distillation matched and when it was last updated; the caller
+// can follow up with [WorkingMemoryStore.Get] to pull the full
+// content if the snippet looks promising.
+type WorkingMemoryMatch struct {
+	ConversationID string    `json:"conversation_id"`
+	UpdatedAt      time.Time `json:"updated_at"`
+	Content        string    `json:"content"`
+	Highlight      string    `json:"highlight"`
+}

--- a/internal/state/memory/distilled_fts.go
+++ b/internal/state/memory/distilled_fts.go
@@ -97,32 +97,47 @@ func (s *ArchiveStore) trySetupSessionsFTS() bool {
 	}
 
 	// 3. Backfill via FTS5's 'rebuild' command when the inverted
-	//    index is empty. Runs only on first init: once any session
-	//    has been indexed (either by this backfill or by AI/AU
-	//    triggers as the summarizer produces metadata), steady-state
-	//    sync is the triggers' job.
+	//    index is incomplete — i.e., the _docsize shadow table holds
+	//    fewer rows than the source `sessions` table.
 	//
-	//    Empty-check probes the _docsize shadow table, not COUNT(*)
-	//    on the virtual table — external-content FTS5 proxies
-	//    SELECT COUNT(*) through to the source `sessions` table and
-	//    so always reports > 0 whenever any session exists. Only the
-	//    shadow tables (_docsize, _data, _idx) tell you whether the
-	//    inverted index itself has any tokenized rows.
-	var docCount int
+	//    `_docsize == 0` is not a sufficient trigger by itself: if a
+	//    previous startup's rebuild failed AFTER the table + triggers
+	//    were created, the AI trigger would index every new session
+	//    going forward, pushing _docsize above 0 — but the historical
+	//    pre-trigger rows would stay invisible forever. Comparing
+	//    _docsize against COUNT(sessions) catches this case on the
+	//    next startup and re-runs the rebuild idempotently.
+	//
+	//    Using the shadow table rather than COUNT(*) on sessions_fts:
+	//    external-content FTS5 proxies SELECT COUNT(*) through to the
+	//    source `sessions` table, which would always self-equal and
+	//    suppress the rebuild. Only the shadow tables (_docsize,
+	//    _data, _idx) reflect the inverted index's actual contents.
+	var docCount, sessCount int
 	if err := db.QueryRow(fmt.Sprintf(`SELECT COUNT(*) FROM %s_docsize`, sessionsFTSTable)).Scan(&docCount); err != nil {
 		if s.logger != nil {
 			s.logger.Warn("sessions_fts docsize probe failed", "error", err)
 		}
 		return true // triggers are installed — degrade gracefully
 	}
-	if docCount == 0 {
+	if err := db.QueryRow(`SELECT COUNT(*) FROM sessions`).Scan(&sessCount); err != nil {
+		if s.logger != nil {
+			s.logger.Warn("sessions count probe failed", "error", err)
+		}
+		return true
+	}
+	if docCount < sessCount {
 		if _, err := db.Exec(fmt.Sprintf(`INSERT INTO %s(%s) VALUES('rebuild')`, sessionsFTSTable, sessionsFTSTable)); err != nil {
 			if s.logger != nil {
-				s.logger.Warn("sessions_fts backfill failed", "error", err)
+				s.logger.Warn("sessions_fts backfill failed; next startup will retry",
+					"docsize", docCount,
+					"sessions", sessCount,
+					"error", err)
 			}
-			// Don't fail the whole setup — the AI trigger handles new
-			// sessions; existing rows can be backfilled by the next
-			// startup retrying.
+			// Setup ends in "table + triggers installed, index partial."
+			// Returning true is correct: new writes via triggers will
+			// keep the index growing while we wait for the next startup
+			// to retry the rebuild against the same shortfall signal.
 		}
 	}
 

--- a/internal/state/memory/distilled_fts.go
+++ b/internal/state/memory/distilled_fts.go
@@ -2,6 +2,7 @@ package memory
 
 import (
 	"database/sql"
+	"encoding/json"
 	"fmt"
 	"time"
 
@@ -133,6 +134,11 @@ func (s *ArchiveStore) trySetupSessionsFTS() bool {
 // snippet highlight FTS5 produced from whichever indexed column
 // matched. Use SessionID with the existing archive_session_transcript
 // retrieval to pull the full conversation that generated the summary.
+//
+// Tags is unmarshaled from the JSON blob stored in sessions.tags so
+// callers get a consistent [][]string-shaped tag list — matching
+// [Session.Tags] and freeing callers from having to parse JSON
+// themselves.
 type SessionMatch struct {
 	SessionID      string    `json:"session_id"`
 	ConversationID string    `json:"conversation_id"`
@@ -140,7 +146,7 @@ type SessionMatch struct {
 	EndedAt        time.Time `json:"ended_at,omitempty"`
 	Title          string    `json:"title"`
 	Summary        string    `json:"summary"`
-	Tags           string    `json:"tags,omitempty"`
+	Tags           []string  `json:"tags,omitempty"`
 	Highlight      string    `json:"highlight"`
 }
 
@@ -154,7 +160,12 @@ type SessionMatch struct {
 // the query trims to empty, or when no rows match. Caller composes
 // this with [ArchiveStore.Search] to build a multi-surface envelope.
 func (s *ArchiveStore) SearchSessions(query string, limit int) ([]SessionMatch, error) {
-	if !s.ftsEnabled {
+	// Gate on the sessions-specific FTS setup, not the core ftsEnabled
+	// flag. trySetupSessionsFTS can fail independently (corrupt
+	// pre-existing virtual table, shadow-table permissions issue) even
+	// when messages_fts is healthy — gating here ensures we degrade to
+	// "no hits" instead of erroring against a missing/broken FTS table.
+	if !s.sessionsFTSEnabled {
 		return nil, nil
 	}
 	q := phraseFTS5Query(query)
@@ -170,7 +181,7 @@ func (s *ArchiveStore) SearchSessions(query string, limit int) ([]SessionMatch, 
 		       COALESCE(s.ended_at, '') AS ended_at,
 		       COALESCE(s.title, ''),
 		       COALESCE(s.summary, ''),
-		       COALESCE(s.tags, ''),
+		       COALESCE(s.tags, '') AS tags_json,
 		       snippet(%s, -1, '**', '**', '...', 32) AS highlight
 		FROM %s
 		JOIN sessions s ON s.rowid = %s.rowid
@@ -188,10 +199,10 @@ func (s *ArchiveStore) SearchSessions(query string, limit int) ([]SessionMatch, 
 	var out []SessionMatch
 	for rows.Next() {
 		var m SessionMatch
-		var startedStr, endedStr string
+		var startedStr, endedStr, tagsJSON string
 		if err := rows.Scan(
 			&m.SessionID, &m.ConversationID, &startedStr, &endedStr,
-			&m.Title, &m.Summary, &m.Tags, &m.Highlight,
+			&m.Title, &m.Summary, &tagsJSON, &m.Highlight,
 		); err != nil {
 			return nil, fmt.Errorf("scan session match: %w", err)
 		}
@@ -201,6 +212,18 @@ func (s *ArchiveStore) SearchSessions(query string, limit int) ([]SessionMatch, 
 		if endedStr != "" {
 			if m.EndedAt, err = database.ParseTimestamp(endedStr); err != nil {
 				return nil, fmt.Errorf("parse session ended_at: %w", err)
+			}
+		}
+		// Tags is stored as a JSON blob ([]string) — unmarshal so the
+		// caller gets a consistent shape with Session.Tags. Corrupt JSON
+		// is logged but not fatal (matches populateSession's posture).
+		if tagsJSON != "" {
+			if err := json.Unmarshal([]byte(tagsJSON), &m.Tags); err != nil {
+				if s.logger != nil {
+					s.logger.Warn("corrupt tags JSON on session match",
+						"session", ShortID(m.SessionID), "error", err)
+				}
+				m.Tags = nil
 			}
 		}
 		out = append(out, m)

--- a/internal/state/memory/distilled_fts_test.go
+++ b/internal/state/memory/distilled_fts_test.go
@@ -1,0 +1,279 @@
+package memory
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestSearchSessions_FindsByTitleSummaryTags exercises the
+// sessions_fts virtual table end-to-end: a session with a summary,
+// a title, and tags is found by a query matching any of those
+// columns. BM25 ranking orders the most relevant hit first.
+func TestSearchSessions_FindsByTitleSummaryTags(t *testing.T) {
+	store := newTestArchiveStore(t)
+	if !store.FTSEnabled() {
+		t.Skip("FTS5 not available")
+	}
+
+	// Create three ended sessions with distinct distilled content.
+	mk := func(convID, title, summary, tags string) string {
+		sess, err := store.StartSession(convID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := store.EndSession(sess.ID, "reset"); err != nil {
+			t.Fatal(err)
+		}
+		meta := &SessionMetadata{OneLiner: summary}
+		if err := store.SetSessionMetadata(sess.ID, meta, title, splitTags(tags)); err != nil {
+			t.Fatal(err)
+		}
+		return sess.ID
+	}
+
+	mk("conv-1",
+		"Pool heater scheduling",
+		"User asked about reprogramming the pool heater for shoulder season.",
+		"pool,heater,hvac")
+	mk("conv-2",
+		"Garage door fix",
+		"Replaced the relay in the opener.",
+		"garage,maintenance")
+	poolSchedule := mk("conv-3",
+		"Pool patio lighting",
+		"Discussed dimmer options for the patio lights near the pool.",
+		"pool,patio,lighting")
+
+	// "pool heater" should rank the first session above the patio-lighting
+	// one because both columns (title+summary) hit on the phrase, and
+	// above the garage-door one because that one doesn't match at all.
+	results, err := store.SearchSessions("pool heater", 5)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) == 0 {
+		t.Fatal("expected at least one session match")
+	}
+	if results[0].Title != "Pool heater scheduling" {
+		t.Errorf("top hit = %q, expected the heater-titled session ranked first", results[0].Title)
+	}
+
+	// Tag-only query also matches.
+	tagResults, err := store.SearchSessions("patio", 5)
+	if err != nil {
+		t.Fatal(err)
+	}
+	foundPatio := false
+	for _, r := range tagResults {
+		if r.SessionID == poolSchedule {
+			foundPatio = true
+			break
+		}
+	}
+	if !foundPatio {
+		t.Error("tag-only match on 'patio' did not surface the patio-lighting session")
+	}
+}
+
+// TestSearchSessions_BackfillOnFirstInit verifies the migration
+// path: sessions that already existed before sessions_fts was
+// created get indexed by the one-shot backfill in trySetupSessionsFTS.
+// Without the backfill, only sessions written after the index
+// creation would be searchable.
+func TestSearchSessions_BackfillOnFirstInit(t *testing.T) {
+	dbPath := t.TempDir() + "/backfill.db"
+
+	// Pass 1: create a session WITHOUT the FTS index. This simulates a
+	// pre-Finding-2 database. We seed a session directly into the raw
+	// sessions table, bypassing the FTS triggers entirely by dropping
+	// them after the store wires them up.
+	store1, err := NewArchiveStore(dbPath, nil, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !store1.FTSEnabled() {
+		store1.Close()
+		t.Skip("FTS5 not available")
+	}
+
+	// Drop the FTS table and triggers to simulate a pre-existing db
+	// that has sessions but no FTS infrastructure yet.
+	db := store1.DB()
+	for _, stmt := range []string{
+		"DROP TRIGGER IF EXISTS sessions_fts_ai",
+		"DROP TRIGGER IF EXISTS sessions_fts_ad",
+		"DROP TRIGGER IF EXISTS sessions_fts_au",
+		"DROP TABLE IF EXISTS sessions_fts",
+	} {
+		if _, err := db.Exec(stmt); err != nil {
+			t.Fatalf("teardown %s: %v", stmt, err)
+		}
+	}
+
+	// Seed a session that no FTS trigger sees.
+	sess, err := store1.StartSession("conv-legacy")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store1.EndSession(sess.ID, "reset"); err != nil {
+		t.Fatal(err)
+	}
+	if err := store1.SetSessionMetadata(sess.ID,
+		&SessionMetadata{OneLiner: "Legacy pre-FTS session about kitchen timer."},
+		"Kitchen timer setup",
+		[]string{"kitchen", "automation"},
+	); err != nil {
+		t.Fatal(err)
+	}
+	store1.Close()
+
+	// Pass 2: re-open the store. The constructor calls
+	// trySetupSessionsFTS, which should recreate the FTS table,
+	// install triggers, and backfill the legacy session.
+	store2, err := NewArchiveStore(dbPath, nil, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { store2.Close() })
+
+	results, err := store2.SearchSessions("kitchen timer", 5)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) == 0 {
+		t.Fatal("backfill did not index the legacy session — search returned no hits")
+	}
+	if results[0].SessionID != sess.ID {
+		t.Errorf("expected backfilled session %s, got %s",
+			ShortID(sess.ID), ShortID(results[0].SessionID))
+	}
+}
+
+// TestSearchSessions_EmptyQueryReturnsNothing — a blank query
+// shouldn't crash or run an unbounded scan. Returns empty slice.
+func TestSearchSessions_EmptyQueryReturnsNothing(t *testing.T) {
+	store := newTestArchiveStore(t)
+	if !store.FTSEnabled() {
+		t.Skip("FTS5 not available")
+	}
+
+	got, err := store.SearchSessions("", 5)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 0 {
+		t.Errorf("empty query returned %d results, want 0", len(got))
+	}
+}
+
+// TestWorkingMemorySearch_FindsByContent exercises the
+// working_memory_fts virtual table: a row written via the normal
+// Set path becomes searchable through the FTS index, and a
+// phrase-shaped query returns it in BM25 order.
+func TestWorkingMemorySearch_FindsByContent(t *testing.T) {
+	store, archive := newTestWorkingMemoryStoreWithFTS(t)
+	if !archive.FTSEnabled() || !store.FTSEnabled() {
+		t.Skip("FTS5 not available")
+	}
+
+	// Two conversations with distinct working-memory state.
+	if err := store.Set("conv-a",
+		"Recent thread: the pool heater scheduling came up; user is "+
+			"reprogramming it for shoulder season. Tone: low-stakes, no urgency."); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Set("conv-b",
+		"Active arc: helping debug an HA automation that triggers on bedroom motion. "+
+			"User is mildly frustrated; respond directly."); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := store.Search("pool heater", 5)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) == 0 {
+		t.Fatal("expected at least one working-memory hit for 'pool heater'")
+	}
+	if got[0].ConversationID != "conv-a" {
+		t.Errorf("top hit = %q, expected conv-a (the only row mentioning 'pool heater')",
+			got[0].ConversationID)
+	}
+	if !strings.Contains(strings.ToLower(got[0].Content), "pool heater") {
+		t.Errorf("content didn't contain the matched phrase: %q", got[0].Content)
+	}
+}
+
+// TestWorkingMemorySearch_UpdateReindexes verifies the UPDATE
+// trigger replaces stale text in the FTS index — set a row,
+// search and find it, then update the row, search and find the
+// new content (not the old).
+func TestWorkingMemorySearch_UpdateReindexes(t *testing.T) {
+	store, archive := newTestWorkingMemoryStoreWithFTS(t)
+	if !archive.FTSEnabled() || !store.FTSEnabled() {
+		t.Skip("FTS5 not available")
+	}
+
+	if err := store.Set("conv-update", "talking about the dryer making a clicking noise on the spin cycle"); err != nil {
+		t.Fatal(err)
+	}
+	got, _ := store.Search("clicking noise", 5)
+	if len(got) == 0 {
+		t.Fatal("initial Set didn't reach the FTS index")
+	}
+
+	// Replace content entirely.
+	if err := store.Set("conv-update", "now discussing the upstairs HVAC thermostat readings"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Old content is gone.
+	if got, _ := store.Search("clicking noise", 5); len(got) != 0 {
+		t.Errorf("after update, stale 'clicking noise' content still in FTS index: %+v", got)
+	}
+	// New content is searchable.
+	got2, err := store.Search("HVAC thermostat", 5)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got2) == 0 || got2[0].ConversationID != "conv-update" {
+		t.Errorf("after update, new content not in FTS index: %+v", got2)
+	}
+}
+
+// newTestWorkingMemoryStoreWithFTS spins up a backing archive (which
+// owns the FTS5-availability gate) and a working memory store on the
+// same connection. Returns both because tests need to check
+// FTSEnabled() on each layer.
+func newTestWorkingMemoryStoreWithFTS(t *testing.T) (*WorkingMemoryStore, *ArchiveStore) {
+	t.Helper()
+	dbPath := t.TempDir() + "/working-fts.db"
+	archive, err := NewArchiveStore(dbPath, nil, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { archive.Close() })
+
+	wm, err := NewWorkingMemoryStore(archive.DB(), archive.FTSEnabled())
+	if err != nil {
+		t.Fatal(err)
+	}
+	return wm, archive
+}
+
+// splitTags parses a comma-separated list into a clean []string,
+// matching how the rest of the package stores tags.
+func splitTags(s string) []string {
+	if s == "" {
+		return nil
+	}
+	parts := strings.Split(s, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}

--- a/internal/state/memory/working.go
+++ b/internal/state/memory/working.go
@@ -14,16 +14,24 @@ import (
 // relationship temperature, and unresolved threads. The table lives in
 // archive.db alongside session transcripts.
 type WorkingMemoryStore struct {
-	db *sql.DB
+	db         *sql.DB
+	ftsEnabled bool
 }
 
 // NewWorkingMemoryStore creates a working memory store using the given
-// database connection (typically from [ArchiveStore.DB]). It creates the
-// working_memory table if it does not already exist.
-func NewWorkingMemoryStore(db *sql.DB) (*WorkingMemoryStore, error) {
+// database connection (typically from [ArchiveStore.DB]). It creates
+// the working_memory table if it does not already exist. ftsEnabled
+// should be the value returned by [ArchiveStore.FTSEnabled] on the
+// archive store sharing this connection — when true, the constructor
+// also sets up working_memory_fts with sync triggers and backfills
+// any existing rows.
+func NewWorkingMemoryStore(db *sql.DB, ftsEnabled bool) (*WorkingMemoryStore, error) {
 	s := &WorkingMemoryStore{db: db}
 	if err := s.migrate(); err != nil {
 		return nil, fmt.Errorf("working memory migration: %w", err)
+	}
+	if ftsEnabled {
+		s.ftsEnabled = trySetupWorkingMemoryFTS(db, ftsEnabled)
 	}
 	return s, nil
 }
@@ -38,6 +46,12 @@ func (s *WorkingMemoryStore) migrate() error {
 		)
 	`)
 	return err
+}
+
+// FTSEnabled reports whether the working_memory_fts virtual table
+// was successfully created at startup.
+func (s *WorkingMemoryStore) FTSEnabled() bool {
+	return s.ftsEnabled
 }
 
 // Get returns the working memory content and last-updated timestamp for
@@ -90,4 +104,58 @@ func (s *WorkingMemoryStore) Delete(conversationID string) error {
 		return fmt.Errorf("delete working memory: %w", err)
 	}
 	return nil
+}
+
+// Search runs an FTS5 query against working_memory_fts and returns
+// the highest-ranking working-memory snapshots by BM25. Query is
+// wrapped as a phrase token for the same precision reasons the raw
+// archive search uses [phraseFTS5Query].
+//
+// Returns an empty slice when FTS5 isn't available, the query is
+// blank, or no rows match. The shape mirrors [SessionMatch]: caller
+// gets the conversation_id (which doubles as a foreign key into
+// [WorkingMemoryStore.Get] for the full content), an updated_at
+// timestamp, the content, and the snippet highlight.
+func (s *WorkingMemoryStore) Search(query string, limit int) ([]WorkingMemoryMatch, error) {
+	if !s.ftsEnabled {
+		return nil, nil
+	}
+	q := phraseFTS5Query(query)
+	if q == "" {
+		return nil, nil
+	}
+	if limit <= 0 {
+		limit = 5
+	}
+
+	rows, err := s.db.Query(fmt.Sprintf(`
+		SELECT w.conversation_id, w.content, w.updated_at,
+		       snippet(%s, 0, '**', '**', '...', 32) AS highlight
+		FROM %s
+		JOIN working_memory w ON w.rowid = %s.rowid
+		WHERE %s MATCH ?
+		ORDER BY rank
+		LIMIT ?
+	`, workingMemoryFTSTable, workingMemoryFTSTable, workingMemoryFTSTable, workingMemoryFTSTable), q, limit)
+	if err != nil {
+		return nil, fmt.Errorf("search working memory: %w", err)
+	}
+	defer rows.Close()
+
+	var out []WorkingMemoryMatch
+	for rows.Next() {
+		var m WorkingMemoryMatch
+		var updatedStr string
+		if err := rows.Scan(&m.ConversationID, &m.Content, &updatedStr, &m.Highlight); err != nil {
+			return nil, fmt.Errorf("scan working memory match: %w", err)
+		}
+		if m.UpdatedAt, err = database.ParseTimestamp(updatedStr); err != nil {
+			return nil, fmt.Errorf("parse working memory updated_at: %w", err)
+		}
+		out = append(out, m)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate working memory matches: %w", err)
+	}
+	return out, nil
 }

--- a/internal/state/memory/working_provider_test.go
+++ b/internal/state/memory/working_provider_test.go
@@ -20,7 +20,7 @@ func newTestWorkingMemoryProvider(t *testing.T, convID string) (*WorkingMemoryPr
 	}
 	t.Cleanup(func() { db.Close() })
 
-	store, err := NewWorkingMemoryStore(db)
+	store, err := NewWorkingMemoryStore(db, false)
 	if err != nil {
 		t.Fatalf("new store: %v", err)
 	}

--- a/internal/state/memory/working_test.go
+++ b/internal/state/memory/working_test.go
@@ -18,7 +18,7 @@ func newTestWorkingMemoryStore(t *testing.T) *WorkingMemoryStore {
 	}
 	t.Cleanup(func() { db.Close() })
 
-	s, err := NewWorkingMemoryStore(db)
+	s, err := NewWorkingMemoryStore(db, false)
 	if err != nil {
 		t.Fatalf("new store: %v", err)
 	}


### PR DESCRIPTION
Refs #977 (Finding 2).

## Summary

Adds two new FTS5 full-text indexes alongside the existing `messages_fts`:

- **`sessions_fts`** covers `sessions.title`, `sessions.summary`, and `sessions.tags`. Once #981 lands and the summarizer starts producing distilled metadata again, these become searchable as soon as they're written.
- **`working_memory_fts`** covers `working_memory.content` — the per-conversation living distillation written by the metacog loop. Currently ~86 rows on production, all immediately searchable after this lands.

Both indexes use the standard external-content FTS5 pattern (`content=sourceTable, content_rowid=rowid`) plus AI/AD/AU sync triggers. On first init the constructor runs an FTS5 `'rebuild'` to backfill any rows that existed before the index was created.

The empty-check probes the `_docsize` shadow table rather than `COUNT(*)` on the virtual table — external-content FTS5 proxies `COUNT(*)` through to the source table, so it always reports > 0 whenever the source has any rows, and the backfill would never run. Only the shadow tables are honest about whether the inverted index is populated.

New search methods:
- `ArchiveStore.SearchSessions(query, limit) → []SessionMatch`
- `WorkingMemoryStore.Search(query, limit) → []WorkingMemoryMatch`

Both wrap the query as a phrase token via `phraseFTS5Query` for the same precision reasons the raw-message search uses since #978.

## What this isn't

This is the storage-side infrastructure only. A follow-up PR will wire the new surfaces into `archive_search`'s model-facing envelope (multi-kind results: "session summaries: N matches" / "working memory: N matches" / raw message hits). Splitting keeps each PR reviewable; the storage layer can ship and start populating now while the search-side integration is being designed.

## Changes

- `internal/state/memory/distilled_fts.go` (new): `trySetupSessionsFTS`, `trySetupWorkingMemoryFTS`, `SearchSessions`, `SessionMatch`, `WorkingMemoryMatch`.
- `internal/state/memory/distilled_fts_test.go` (new): 5 tests covering basic indexing, the backfill path on a pre-existing DB, empty-query handling, and that UPDATE triggers correctly re-index working memory.
- `internal/state/memory/working.go`: `WorkingMemoryStore` now takes `ftsEnabled` and gains `FTSEnabled()` + `Search()`.
- `internal/state/memory/archive.go`: constructor calls `trySetupSessionsFTS` after `tryEnableFTS`.
- `internal/app/new_stores.go`: passes the archive's FTS-availability gate to `NewWorkingMemoryStore`.
- Two test files updated for the new `NewWorkingMemoryStore(db, ftsEnabled)` signature.

## Test plan

- [x] `go test -tags=sqlite_fts5 -race ./internal/state/memory/` — all tests pass, including the 5 new ones
- [x] `just ci` — full gate green
- [ ] **Post-deploy:** on first startup, expect a one-time `INSERT ... VALUES('rebuild')` against each new FTS table. Production has 14,001 sessions + ~86 working_memory rows; the rebuild is single-pass and proportional to N. After that, the AI/AU triggers handle steady-state.
- [ ] **Post-deploy + #981:** once the summarizer drains the crash_recovery backlog and starts producing summaries again, those new `sessions.summary` writes flow through the AU trigger into `sessions_fts` automatically. No manual reindex needed.

## Order of operations

Independent of #981 — they touch different surfaces. Order-of-deploy doesn't matter. Once both have landed, the search-side wiring PR can build the multi-kind envelope on top.