### PR TITLE
feat(memory): unify archive_search across raw, sessions, and working memory

### DIFF
--- a/internal/app/new_awareness.go
+++ b/internal/app/new_awareness.go
@@ -233,10 +233,14 @@ func (a *App) initAwareness(s *newState) error {
 
 	// Archive retrieval injection — pre-warm cold-start loops with
 	// relevant past conversation excerpts so the model has experiential
-	// judgment alongside Layer 1 knowledge. See issue #404.
+	// judgment alongside Layer 1 knowledge. See issue #404. The
+	// MemorySearch wrapper unifies raw-message and distilled-surface
+	// retrieval into the same call so prewarm and the model-initiated
+	// archive_search tool can't drift apart (see #977 Finding 2).
 	if cfg.Prewarm.Enabled && cfg.Prewarm.Archive.Enabled {
+		searcher := memory.NewMemorySearch(a.archiveStore, a.wmStore, logger)
 		archiveProvider := memory.NewArchiveContextProvider(
-			a.archiveStore,
+			searcher,
 			cfg.Prewarm.Archive.MaxResults,
 			cfg.Prewarm.Archive.MaxBytes,
 			logger,

--- a/internal/state/memory/archive_provider.go
+++ b/internal/state/memory/archive_provider.go
@@ -10,35 +10,37 @@ import (
 	"github.com/nugget/thane-ai-agent/internal/state/knowledge"
 )
 
-// ArchiveSearcher abstracts archive search for testing. ArchiveStore
-// satisfies this interface — no adapter needed.
-type ArchiveSearcher interface {
-	Search(opts SearchOptions) ([]SearchResult, error)
-}
-
 // ArchiveContextProvider implements [agent.TagContextProvider] for
 // injecting relevant past conversation excerpts into the system
 // prompt. This is Layer 2 of the pre-warming system: Layer 1 provides
 // knowledge (facts + KB docs), Layer 2 provides experiential judgment
 // (prior reasoning about similar situations). Registered via
 // [agent.Loop.RegisterAlwaysContextProvider].
+//
+// Consumes the unified [MemorySearcher] interface so prewarm and the
+// model-initiated archive_search tool share one retrieval path — any
+// improvement to ranking or surface coverage applies to both
+// simultaneously.
 type ArchiveContextProvider struct {
-	store      ArchiveSearcher
+	searcher   MemorySearcher
 	maxResults int
 	maxBytes   int
 	logger     *slog.Logger
 }
 
-// NewArchiveContextProvider creates a context provider that searches the
-// conversation archive for relevant past exchanges. maxResults caps the
-// number of search hits; maxBytes caps the formatted output size to
-// prevent context flooding.
-func NewArchiveContextProvider(store ArchiveSearcher, maxResults, maxBytes int, logger *slog.Logger) *ArchiveContextProvider {
+// NewArchiveContextProvider creates a context provider that searches
+// every memory surface (raw messages, session summaries, working
+// memory) for content relevant to the current wake. maxResults caps
+// the raw-message hit count; the distilled surfaces use their own
+// tighter caps inside [MemorySearch.Search]. maxBytes caps the
+// formatted output size so the prewarm block never overruns the
+// system prompt's budget.
+func NewArchiveContextProvider(searcher MemorySearcher, maxResults, maxBytes int, logger *slog.Logger) *ArchiveContextProvider {
 	if logger == nil {
 		logger = slog.Default()
 	}
 	return &ArchiveContextProvider{
-		store:      store,
+		searcher:   searcher,
 		maxResults: maxResults,
 		maxBytes:   maxBytes,
 		logger:     logger,
@@ -82,7 +84,7 @@ func (p *ArchiveContextProvider) TagContext(ctx context.Context, req agentctx.Co
 	)
 
 	start := time.Now()
-	results, err := p.store.Search(SearchOptions{
+	bundle, err := p.searcher.Search(SearchOptions{
 		Query: query,
 		Limit: p.maxResults,
 	})
@@ -97,18 +99,24 @@ func (p *ArchiveContextProvider) TagContext(ctx context.Context, req agentctx.Co
 		return "", nil
 	}
 
+	totalHits := 0
+	if bundle != nil {
+		totalHits = len(bundle.Messages) + len(bundle.Sessions) + len(bundle.WorkingMemory)
+	}
 	p.logger.Debug("archive pre-warm: search completed",
 		"query", query,
-		"results", len(results),
+		"messages", len(bundle.Messages),
+		"sessions", len(bundle.Sessions),
+		"working_memory", len(bundle.WorkingMemory),
 		"took_ms", elapsed.Milliseconds(),
 	)
 
-	if len(results) == 0 {
+	if totalHits == 0 {
 		return "", nil
 	}
 
-	for i, r := range results {
-		p.logger.Debug("archive pre-warm: result",
+	for i, r := range bundle.Messages {
+		p.logger.Debug("archive pre-warm: message result",
 			"index", i,
 			"session_id", r.SessionID,
 			"match_role", r.Match.Role,
@@ -118,7 +126,7 @@ func (p *ArchiveContextProvider) TagContext(ctx context.Context, req agentctx.Co
 		)
 	}
 
-	return p.formatResults(results), nil
+	return p.formatResults(bundle), nil
 }
 
 // maxUserMessageLen is the longest user message we'll use as a fallback
@@ -222,39 +230,64 @@ const (
 	prewarmMessageContentMax = 300
 )
 
-// formatResults renders archive search hits as a heading followed by a
-// JSON projection produced by FormatSearchResults. Hits are first
-// trimmed for the prewarm budget (smaller per-message content cap and
-// fewer context messages per side than the archive tools use), then
-// the hit list is shortened from the tail until the rendered output
-// fits in p.maxBytes. The truncated flag in the JSON tells the model
-// when hits were dropped. Returns empty string when there are no hits
-// to render or when not even one trimmed hit fits in the byte budget.
-func (p *ArchiveContextProvider) formatResults(results []SearchResult) string {
-	if len(results) == 0 {
+// formatResults renders the multi-surface bundle as a heading
+// followed by JSON via [FormatMultiKindResults]. Raw-message hits
+// are trimmed for the prewarm budget (tighter per-message content
+// cap and fewer context messages per side than the archive tools
+// use); the distilled surfaces (sessions and working_memory) are
+// already compact and pass through untrimmed.
+//
+// The hit list is shortened from the raw-message tail until the
+// rendered output fits in p.maxBytes — distilled surfaces stay
+// because they're the higher signal-density side and they're
+// budget-cheap. Returns empty string when there's nothing to render
+// or when not even one trimmed hit fits the byte budget.
+func (p *ArchiveContextProvider) formatResults(bundle *SearchBundle) string {
+	if bundle == nil {
+		return ""
+	}
+	if len(bundle.Messages) == 0 && len(bundle.Sessions) == 0 && len(bundle.WorkingMemory) == 0 {
 		return ""
 	}
 	now := time.Now()
-	trimmed := trimResultsForPrewarm(results)
 
-	for n := len(trimmed); n > 0; n-- {
-		body := FormatSearchResults(trimmed[:n], now, n < len(trimmed))
+	trimmedMessages := trimResultsForPrewarm(bundle.Messages)
+
+	// Walk down the raw-message tail until everything fits. Distilled
+	// surfaces stay throughout — they're small and high-signal.
+	for n := len(trimmedMessages); n >= 0; n-- {
+		clipped := &SearchBundle{
+			Messages:      trimmedMessages[:n],
+			Sessions:      bundle.Sessions,
+			WorkingMemory: bundle.WorkingMemory,
+			Truncated:     bundle.Truncated,
+		}
+		body := FormatMultiKindResults(clipped, now, n < len(trimmedMessages))
 		out := archiveSectionHeading + string(body)
 		if len(out) <= p.maxBytes {
-			if n < len(trimmed) {
-				p.logger.Debug("archive pre-warm: trimmed to fit byte budget",
-					"included", n,
-					"total", len(trimmed),
+			if n < len(trimmedMessages) {
+				p.logger.Debug("archive pre-warm: trimmed messages to fit byte budget",
+					"messages_included", n,
+					"messages_total", len(trimmedMessages),
+					"sessions", len(bundle.Sessions),
+					"working_memory", len(bundle.WorkingMemory),
 					"budget", p.maxBytes,
 					"size", len(out),
 				)
 			}
 			return out
 		}
+		if n == 0 {
+			// Distilled surfaces alone exceed the budget — degrade
+			// to nothing rather than emit a half-truth.
+			break
+		}
 	}
 
-	p.logger.Debug("archive pre-warm: not even one hit fits byte budget",
-		"total", len(trimmed),
+	p.logger.Debug("archive pre-warm: not even distilled-only fits byte budget",
+		"messages_total", len(trimmedMessages),
+		"sessions", len(bundle.Sessions),
+		"working_memory", len(bundle.WorkingMemory),
 		"budget", p.maxBytes,
 	)
 	return ""

--- a/internal/state/memory/archive_provider.go
+++ b/internal/state/memory/archive_provider.go
@@ -99,10 +99,17 @@ func (p *ArchiveContextProvider) TagContext(ctx context.Context, req agentctx.Co
 		return "", nil
 	}
 
-	totalHits := 0
-	if bundle != nil {
-		totalHits = len(bundle.Messages) + len(bundle.Sessions) + len(bundle.WorkingMemory)
+	// MemorySearcher.Search MUST return a non-nil bundle on a nil error
+	// (see the interface contract). Treat a nil bundle here as a soft
+	// fault rather than panicking — log and return empty.
+	if bundle == nil {
+		p.logger.Warn("archive pre-warm: searcher returned nil bundle on nil error",
+			"query", query,
+			"took_ms", elapsed.Milliseconds(),
+		)
+		return "", nil
 	}
+	totalHits := len(bundle.Messages) + len(bundle.Sessions) + len(bundle.WorkingMemory)
 	p.logger.Debug("archive pre-warm: search completed",
 		"query", query,
 		"messages", len(bundle.Messages),

--- a/internal/state/memory/archive_provider_test.go
+++ b/internal/state/memory/archive_provider_test.go
@@ -12,28 +12,45 @@ import (
 	"github.com/nugget/thane-ai-agent/internal/state/knowledge"
 )
 
-// mockArchiveSearcher implements ArchiveSearcher for testing.
+// mockArchiveSearcher implements [MemorySearcher] for testing. Most
+// existing tests set only `results` (raw-message hits) — Search
+// wraps that into a SearchBundle so the prewarm provider's
+// multi-surface contract is satisfied. Tests that exercise the
+// distilled surfaces set `sessions` and `workingMemory` directly.
 type mockArchiveSearcher struct {
-	results   []SearchResult
-	err       error
-	lastQuery string
-	lastLimit int
-	callCount int
+	results       []SearchResult
+	sessions      []SessionMatch
+	workingMemory []WorkingMemoryMatch
+	err           error
+	lastQuery     string
+	lastLimit     int
+	callCount     int
 }
 
-func (m *mockArchiveSearcher) Search(opts SearchOptions) ([]SearchResult, error) {
+func (m *mockArchiveSearcher) Search(opts SearchOptions) (*SearchBundle, error) {
 	m.callCount++
 	m.lastQuery = opts.Query
 	m.lastLimit = opts.Limit
-	return m.results, m.err
+	if m.err != nil {
+		return nil, m.err
+	}
+	return &SearchBundle{
+		Messages:      m.results,
+		Sessions:      m.sessions,
+		WorkingMemory: m.workingMemory,
+	}, nil
 }
 
 // archivePayload is the projection produced under the "### Past
-// Experience" heading. Mirrors the shape of FormatSearchResults so the
-// tests can decode without depending on json tags directly.
+// Experience" heading. Mirrors the multi-surface envelope shape so
+// the tests can decode without depending on json tags directly. The
+// raw-message hits live under `messages`; the two distilled
+// surfaces (sessions, working_memory) sit alongside.
 type archivePayload struct {
-	Results   []map[string]any `json:"results"`
-	Truncated bool             `json:"truncated"`
+	Messages      []map[string]any `json:"messages"`
+	Sessions      []map[string]any `json:"sessions"`
+	WorkingMemory []map[string]any `json:"working_memory"`
+	Truncated     bool             `json:"truncated"`
 }
 
 // parseArchiveBody extracts the JSON body that follows the
@@ -91,10 +108,10 @@ func TestArchiveContextProvider_GetContext(t *testing.T) {
 			t.Errorf("output should start with '### Past Experience' heading, got:\n%s", got)
 		}
 		payload := parseArchiveBody(t, got)
-		if len(payload.Results) != 1 {
-			t.Fatalf("expected 1 result, got %d", len(payload.Results))
+		if len(payload.Messages) != 1 {
+			t.Fatalf("expected 1 result, got %d", len(payload.Messages))
 		}
-		match := payload.Results[0]["match"].(map[string]any)
+		match := payload.Messages[0]["match"].(map[string]any)
 		if !strings.Contains(match["content"].(string), "pool heater") {
 			t.Errorf("match content should mention pool heater, got %q", match["content"])
 		}
@@ -220,10 +237,10 @@ func TestArchiveContextProvider_GetContext(t *testing.T) {
 			t.Errorf("output length %d exceeds budget 900", len(got))
 		}
 		payload := parseArchiveBody(t, got)
-		if len(payload.Results) == 0 {
+		if len(payload.Messages) == 0 {
 			t.Fatal("expected at least one result to fit")
 		}
-		if len(payload.Results) == 3 {
+		if len(payload.Messages) == 3 {
 			t.Error("expected truncation to drop at least one result")
 		}
 		if !payload.Truncated {
@@ -265,18 +282,18 @@ func TestArchiveContextProvider_GetContext(t *testing.T) {
 			t.Errorf("output length %d exceeds budget 4000", len(got))
 		}
 		payload := parseArchiveBody(t, got)
-		if len(payload.Results) != 1 {
-			t.Fatalf("expected 1 result, got %d", len(payload.Results))
+		if len(payload.Messages) != 1 {
+			t.Fatalf("expected 1 result, got %d", len(payload.Messages))
 		}
 		// Match content is clipped to the prewarm cap.
-		match := payload.Results[0]["match"].(map[string]any)
+		match := payload.Messages[0]["match"].(map[string]any)
 		matchContent := match["content"].(string)
 		if len(matchContent) > prewarmMessageContentMax {
 			t.Errorf("match.content length %d exceeds prewarm cap %d", len(matchContent), prewarmMessageContentMax)
 		}
 		// Context is narrowed to prewarmContextPerSide on each side.
-		before, _ := payload.Results[0]["context_before"].([]any)
-		after, _ := payload.Results[0]["context_after"].([]any)
+		before, _ := payload.Messages[0]["context_before"].([]any)
+		after, _ := payload.Messages[0]["context_after"].([]any)
 		if len(before) > prewarmContextPerSide {
 			t.Errorf("context_before len %d exceeds prewarm cap %d", len(before), prewarmContextPerSide)
 		}
@@ -387,10 +404,10 @@ func TestArchiveContextProvider_GetContext(t *testing.T) {
 			t.Fatalf("TagContext: %v", err)
 		}
 		payload := parseArchiveBody(t, got)
-		if len(payload.Results) != 1 {
-			t.Fatalf("expected 1 result, got %d", len(payload.Results))
+		if len(payload.Messages) != 1 {
+			t.Fatalf("expected 1 result, got %d", len(payload.Messages))
 		}
-		hit := payload.Results[0]
+		hit := payload.Messages[0]
 		before, _ := hit["context_before"].([]any)
 		after, _ := hit["context_after"].([]any)
 		if len(before) != 1 || len(after) != 1 {
@@ -424,7 +441,7 @@ func TestArchiveContextProvider_GetContext(t *testing.T) {
 			t.Errorf("output should use deltas, not RFC3339\nGot:\n%s", got)
 		}
 		payload := parseArchiveBody(t, got)
-		match := payload.Results[0]["match"].(map[string]any)
+		match := payload.Messages[0]["match"].(map[string]any)
 		tField, _ := match["t"].(string)
 		if !strings.HasPrefix(tField, "-") {
 			t.Errorf("match.t should be a negative delta like '-Ns', got %q", tField)

--- a/internal/state/memory/distilled_fts.go
+++ b/internal/state/memory/distilled_fts.go
@@ -4,10 +4,109 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"time"
 
 	"github.com/nugget/thane-ai-agent/internal/platform/database"
 )
+
+// SearchBundle is the multi-surface result envelope. Always carries
+// all three slices — an empty slice means "no hits on this surface"
+// (the non-nil zero-length list is the explicit signal to the
+// model). Truncated propagates from the underlying raw-message
+// search; distilled surfaces don't truncate within a single call.
+type SearchBundle struct {
+	Messages      []SearchResult
+	Sessions      []SessionMatch
+	WorkingMemory []WorkingMemoryMatch
+	Truncated     bool
+}
+
+// MemorySearcher is the unified read-side interface across the
+// memory surfaces. Both the model-initiated archive_search tool and
+// the wake-time prewarm provider consume this same interface, so
+// the two paths cannot drift — any retrieval improvement applies
+// uniformly to both. Implementations: [MemorySearch] for production
+// (composed from the real stores), and test mocks.
+type MemorySearcher interface {
+	Search(opts SearchOptions) (*SearchBundle, error)
+}
+
+// MemorySearch is the production MemorySearcher: composes
+// [ArchiveStore] (raw messages via messages_fts, session summaries
+// via sessions_fts) and [WorkingMemoryStore] (per-conversation
+// distilled state via working_memory_fts) into a single search
+// surface.
+//
+// Session and working_memory hits soft-fail individually — a query
+// error on a distilled surface doesn't suppress the raw-message
+// results the model would otherwise have seen. Only a raw-message
+// search failure propagates.
+type MemorySearch struct {
+	archive *ArchiveStore
+	working *WorkingMemoryStore
+	logger  *slog.Logger
+}
+
+// distilledSurfaceLimit caps how many session and working_memory
+// matches each query returns. Distilled hits are dense per byte
+// compared to raw messages with context windows, so a small cap
+// keeps the model-visible envelope readable without sacrificing
+// useful coverage. Working memory in particular is one row per
+// conversation — more than 3 hits rarely tells the model anything
+// new at this stage of retrieval.
+const (
+	maxDistilledSessions      = 5
+	maxDistilledWorkingMemory = 3
+)
+
+// NewMemorySearch builds a MemorySearch from the underlying stores.
+// Either store may be nil at construction time (e.g. during early
+// startup or in tests that only exercise one surface); a nil archive
+// makes Search return an empty bundle, a nil working memory store
+// just skips the working_memory surface.
+func NewMemorySearch(archive *ArchiveStore, working *WorkingMemoryStore, logger *slog.Logger) *MemorySearch {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &MemorySearch{archive: archive, working: working, logger: logger}
+}
+
+// Search runs the query across every available memory surface and
+// returns a SearchBundle. The raw-message path uses opts.Limit; the
+// distilled surfaces use their own tighter caps so the envelope
+// stays bounded.
+func (m *MemorySearch) Search(opts SearchOptions) (*SearchBundle, error) {
+	bundle := &SearchBundle{}
+	if m.archive == nil {
+		return bundle, nil
+	}
+
+	msgs, err := m.archive.Search(opts)
+	if err != nil {
+		return nil, err
+	}
+	bundle.Messages = msgs
+
+	// Session summaries. Soft-fail: a sessions_fts query error
+	// shouldn't drop the raw-message results we already collected.
+	if sess, err := m.archive.SearchSessions(opts.Query, maxDistilledSessions); err == nil {
+		bundle.Sessions = sess
+	} else if m.logger != nil {
+		m.logger.Warn("session summaries search failed", "query", opts.Query, "error", err)
+	}
+
+	// Working memory. Soft-fail for the same reason.
+	if m.working != nil {
+		if wm, err := m.working.Search(opts.Query, maxDistilledWorkingMemory); err == nil {
+			bundle.WorkingMemory = wm
+		} else if m.logger != nil {
+			m.logger.Warn("working memory search failed", "query", opts.Query, "error", err)
+		}
+	}
+
+	return bundle, nil
+}
 
 // sessionsFTSTable is the FTS5 virtual table name covering the
 // sessions table's distilled columns. Indexes title, summary, and

--- a/internal/state/memory/distilled_fts.go
+++ b/internal/state/memory/distilled_fts.go
@@ -28,6 +28,14 @@ type SearchBundle struct {
 // the two paths cannot drift — any retrieval improvement applies
 // uniformly to both. Implementations: [MemorySearch] for production
 // (composed from the real stores), and test mocks.
+//
+// **Contract:** Search MUST return a non-nil *SearchBundle whenever
+// it returns a nil error. Callers may rely on this — "no hits" is
+// signaled by an empty bundle (all three slices empty), not by a nil
+// bundle. A nil bundle paired with a nil error is treated as a
+// programming bug by the prewarm provider and logged as a soft
+// fault. Returning a non-nil error means the bundle value is
+// undefined and callers should not read it.
 type MemorySearcher interface {
 	Search(opts SearchOptions) (*SearchBundle, error)
 }

--- a/internal/state/memory/distilled_fts.go
+++ b/internal/state/memory/distilled_fts.go
@@ -84,6 +84,15 @@ func NewMemorySearch(archive *ArchiveStore, working *WorkingMemoryStore, logger 
 // returns a SearchBundle. The raw-message path uses opts.Limit; the
 // distilled surfaces use their own tighter caps so the envelope
 // stays bounded.
+//
+// When opts.ConversationID is non-empty, ALL three surfaces are
+// scoped to that conversation. The raw-message search honors it
+// via ArchiveStore.Search's SQL filter; the distilled surfaces are
+// filtered in Go after the FTS pass (sessions_fts and
+// working_memory_fts are scoped over the global corpus today).
+// Filtering after BM25 ranking is acceptable because the distilled
+// hit count is capped small (5 sessions, 3 working memory) — the
+// extra fetched-then-discarded rows are bounded and cheap.
 func (m *MemorySearch) Search(opts SearchOptions) (*SearchBundle, error) {
 	bundle := &SearchBundle{}
 	if m.archive == nil {
@@ -99,7 +108,7 @@ func (m *MemorySearch) Search(opts SearchOptions) (*SearchBundle, error) {
 	// Session summaries. Soft-fail: a sessions_fts query error
 	// shouldn't drop the raw-message results we already collected.
 	if sess, err := m.archive.SearchSessions(opts.Query, maxDistilledSessions); err == nil {
-		bundle.Sessions = sess
+		bundle.Sessions = filterSessionMatchesByConversation(sess, opts.ConversationID)
 	} else if m.logger != nil {
 		m.logger.Warn("session summaries search failed", "query", opts.Query, "error", err)
 	}
@@ -107,13 +116,45 @@ func (m *MemorySearch) Search(opts SearchOptions) (*SearchBundle, error) {
 	// Working memory. Soft-fail for the same reason.
 	if m.working != nil {
 		if wm, err := m.working.Search(opts.Query, maxDistilledWorkingMemory); err == nil {
-			bundle.WorkingMemory = wm
+			bundle.WorkingMemory = filterWorkingMemoryMatchesByConversation(wm, opts.ConversationID)
 		} else if m.logger != nil {
 			m.logger.Warn("working memory search failed", "query", opts.Query, "error", err)
 		}
 	}
 
 	return bundle, nil
+}
+
+// filterSessionMatchesByConversation returns matches scoped to a
+// conversation when convID is non-empty; otherwise passes through.
+// Used by [MemorySearch.Search] to honor opts.ConversationID across
+// distilled surfaces (the raw-message search already filters in SQL).
+func filterSessionMatchesByConversation(matches []SessionMatch, convID string) []SessionMatch {
+	if convID == "" {
+		return matches
+	}
+	out := matches[:0]
+	for _, m := range matches {
+		if m.ConversationID == convID {
+			out = append(out, m)
+		}
+	}
+	return out
+}
+
+// filterWorkingMemoryMatchesByConversation — analogous helper for
+// the working_memory surface.
+func filterWorkingMemoryMatchesByConversation(matches []WorkingMemoryMatch, convID string) []WorkingMemoryMatch {
+	if convID == "" {
+		return matches
+	}
+	out := matches[:0]
+	for _, m := range matches {
+		if m.ConversationID == convID {
+			out = append(out, m)
+		}
+	}
+	return out
 }
 
 // sessionsFTSTable is the FTS5 virtual table name covering the

--- a/internal/state/memory/distilled_fts_test.go
+++ b/internal/state/memory/distilled_fts_test.go
@@ -1,8 +1,10 @@
 package memory
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
+	"time"
 )
 
 // TestSearchSessions_FindsByTitleSummaryTags exercises the
@@ -276,4 +278,139 @@ func splitTags(s string) []string {
 		}
 	}
 	return out
+}
+
+// TestMemorySearch_AllSurfacesReachModelEnvelope is the seam-level
+// test for #977 Finding 2: a query that has hits across all three
+// memory surfaces (raw messages, session summaries, working memory)
+// must produce a SearchBundle that round-trips through the
+// multi-surface JSON envelope with every surface present. Catches
+// any regression where the unified search drops a surface, or
+// FormatMultiKindResults omits an array.
+func TestMemorySearch_AllSurfacesReachModelEnvelope(t *testing.T) {
+	dbPath := t.TempDir() + "/multi-surface.db"
+	archive, err := NewArchiveStore(dbPath, nil, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { archive.Close() })
+	if !archive.FTSEnabled() {
+		t.Skip("FTS5 not available")
+	}
+
+	working, err := NewWorkingMemoryStore(archive.DB(), archive.FTSEnabled())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Raw-message hit: archive a message about the freezer alarm.
+	if err := archive.ArchiveMessages([]Message{{
+		ID: "msg-1", ConversationID: "conv-1", SessionID: "sess-1",
+		Role:          "user",
+		Content:       "Did the freezer alarm go off again last night?",
+		Timestamp:     time.Date(2026, 2, 12, 22, 0, 0, 0, time.UTC),
+		ArchiveReason: string(ArchiveReasonReset),
+	}}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Session-summary hit: a separate session distilled into metadata.
+	sess, err := archive.StartSession("conv-2")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := archive.EndSession(sess.ID, "reset"); err != nil {
+		t.Fatal(err)
+	}
+	if err := archive.SetSessionMetadata(sess.ID,
+		&SessionMetadata{OneLiner: "Diagnosed the freezer alarm wiring issue."},
+		"Freezer alarm troubleshooting",
+		[]string{"freezer", "alarm", "kitchen"},
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	// Working-memory hit: a per-conversation living distillation.
+	if err := working.Set("conv-3",
+		"Recent thread: user is monitoring the freezer alarm patterns "+
+			"after last week's wiring rework. Watching for false trips."); err != nil {
+		t.Fatal(err)
+	}
+
+	// Unified search across all three surfaces.
+	searcher := NewMemorySearch(archive, working, nil)
+	bundle, err := searcher.Search(SearchOptions{Query: "freezer alarm", Limit: 5})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(bundle.Messages) == 0 {
+		t.Error("expected at least one raw-message hit")
+	}
+	if len(bundle.Sessions) == 0 {
+		t.Error("expected at least one session-summary hit")
+	}
+	if len(bundle.WorkingMemory) == 0 {
+		t.Error("expected at least one working-memory hit")
+	}
+
+	// Round-trip through the model-facing envelope. Every surface
+	// must be present (as a non-nil array) so the model sees a
+	// consistent shape.
+	now := time.Now()
+	envelope := FormatMultiKindResults(bundle, now, false)
+	var parsed struct {
+		Messages      []json.RawMessage `json:"messages"`
+		Sessions      []json.RawMessage `json:"sessions"`
+		WorkingMemory []json.RawMessage `json:"working_memory"`
+		Truncated     bool              `json:"truncated"`
+	}
+	if err := json.Unmarshal(envelope, &parsed); err != nil {
+		t.Fatalf("envelope did not round-trip: %v\n%s", err, envelope)
+	}
+	if len(parsed.Messages) == 0 || len(parsed.Sessions) == 0 || len(parsed.WorkingMemory) == 0 {
+		t.Errorf("envelope dropped a surface: messages=%d sessions=%d working_memory=%d\n%s",
+			len(parsed.Messages), len(parsed.Sessions), len(parsed.WorkingMemory), envelope)
+	}
+}
+
+// TestMemorySearch_DistilledFailureDoesNotBlockMessages — a session
+// or working-memory search error must NOT take down the raw-message
+// results. Soft-fail of the distilled side is what keeps retrieval
+// resilient.
+func TestMemorySearch_DistilledFailureDoesNotBlockMessages(t *testing.T) {
+	dbPath := t.TempDir() + "/soft-fail.db"
+	archive, err := NewArchiveStore(dbPath, nil, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { archive.Close() })
+	if !archive.FTSEnabled() {
+		t.Skip("FTS5 not available")
+	}
+
+	// Seed a raw message so messages_fts has something to find.
+	if err := archive.ArchiveMessages([]Message{{
+		ID: "msg-1", ConversationID: "conv-1", SessionID: "sess-1",
+		Role: "user", Content: "this is the keeper",
+		Timestamp:     time.Now(),
+		ArchiveReason: string(ArchiveReasonReset),
+	}}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Working memory store deliberately nil — exercising the "no
+	// working_memory available" branch. Sessions search is in the
+	// same DB, healthy.
+	searcher := NewMemorySearch(archive, nil, nil)
+	bundle, err := searcher.Search(SearchOptions{Query: "keeper", Limit: 5})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(bundle.Messages) == 0 {
+		t.Fatal("messages search blocked by missing working memory — soft-fail broken")
+	}
+	if len(bundle.WorkingMemory) != 0 {
+		t.Errorf("expected zero working_memory hits with nil store, got %d", len(bundle.WorkingMemory))
+	}
 }

--- a/internal/state/memory/format.go
+++ b/internal/state/memory/format.go
@@ -194,7 +194,28 @@ const maxSearchContextPerSide = 5
 // Context lists are trimmed to the [maxSearchContextPerSide] messages
 // closest to the match on each side — for context_before that's the
 // last N, for context_after the first N.
+//
+// Single-surface form: used internally by [FormatMultiKindResults]
+// and (still) by paths that haven't migrated to the multi-surface
+// envelope. New callers should prefer FormatMultiKindResults so the
+// model sees the same shape from prewarm and tool calls alike.
 func FormatSearchResults(results []SearchResult, now time.Time, truncated bool) []byte {
+	views := buildSearchResultViews(results, now)
+	out := struct {
+		Results   []SearchResultView `json:"results"`
+		Truncated bool               `json:"truncated"`
+	}{
+		Results:   views,
+		Truncated: truncated,
+	}
+	data, _ := json.Marshal(out)
+	return data
+}
+
+// buildSearchResultViews is the projection step shared by the
+// single-surface and multi-surface formatters. Keeps the sender-
+// projection / context-trimming logic in one place.
+func buildSearchResultViews(results []SearchResult, now time.Time) []SearchResultView {
 	views := make([]SearchResultView, 0, len(results))
 	for _, r := range results {
 		// Search hits cross conversation boundaries — the matching
@@ -213,12 +234,93 @@ func FormatSearchResults(results []SearchResult, now time.Time, truncated bool) 
 			Highlight:     r.Highlight,
 		})
 	}
+	return views
+}
+
+// SessionMatchView is the JSON-facing projection of a sessions_fts
+// hit. Compact compared to a raw-message search result — the
+// summary is already distilled, so no context window is needed.
+// session_id pairs with archive_session_transcript for full
+// drilldown when the match looks worth reading.
+type SessionMatchView struct {
+	SessionID      string `json:"session_id"`
+	ConversationID string `json:"conversation_id"`
+	Started        string `json:"started"`
+	Ended          string `json:"ended,omitempty"`
+	Title          string `json:"title"`
+	Summary        string `json:"summary,omitempty"`
+	Tags           string `json:"tags,omitempty"`
+	Highlight      string `json:"highlight,omitempty"`
+}
+
+// WorkingMemoryMatchView is the JSON-facing projection of a
+// working_memory_fts hit. Working memory is one row per conversation
+// — the conversation_id identifies which thread's living
+// distillation matched, and content carries the full snapshot.
+type WorkingMemoryMatchView struct {
+	ConversationID string `json:"conversation_id"`
+	Updated        string `json:"updated"`
+	Content        string `json:"content"`
+	Highlight      string `json:"highlight,omitempty"`
+}
+
+// FormatMultiKindResults renders the unified multi-surface search
+// envelope: raw-message hits with context windows, session summary
+// hits, and working-memory hits, all in one document.
+//
+// Every kind is always present in the JSON (as an array, possibly
+// empty) so the model sees a consistent shape — an empty list is the
+// explicit signal "no hits on this surface," distinguishable from
+// "this surface wasn't queried." Truncated propagates from the
+// raw-message search (distilled surfaces don't truncate within a
+// single call).
+func FormatMultiKindResults(b *SearchBundle, now time.Time, truncated bool) []byte {
+	if b == nil {
+		b = &SearchBundle{}
+	}
+
+	msgViews := buildSearchResultViews(b.Messages, now)
+	if msgViews == nil {
+		msgViews = []SearchResultView{}
+	}
+
+	sessViews := make([]SessionMatchView, 0, len(b.Sessions))
+	for _, s := range b.Sessions {
+		v := SessionMatchView{
+			SessionID:      s.SessionID,
+			ConversationID: s.ConversationID,
+			Started:        promptfmt.FormatDeltaOnly(s.StartedAt, now),
+			Title:          s.Title,
+			Summary:        s.Summary,
+			Tags:           s.Tags,
+			Highlight:      s.Highlight,
+		}
+		if !s.EndedAt.IsZero() {
+			v.Ended = promptfmt.FormatDeltaOnly(s.EndedAt, now)
+		}
+		sessViews = append(sessViews, v)
+	}
+
+	wmViews := make([]WorkingMemoryMatchView, 0, len(b.WorkingMemory))
+	for _, w := range b.WorkingMemory {
+		wmViews = append(wmViews, WorkingMemoryMatchView{
+			ConversationID: w.ConversationID,
+			Updated:        promptfmt.FormatDeltaOnly(w.UpdatedAt, now),
+			Content:        w.Content,
+			Highlight:      w.Highlight,
+		})
+	}
+
 	out := struct {
-		Results   []SearchResultView `json:"results"`
-		Truncated bool               `json:"truncated"`
+		Messages      []SearchResultView       `json:"messages"`
+		Sessions      []SessionMatchView       `json:"sessions"`
+		WorkingMemory []WorkingMemoryMatchView `json:"working_memory"`
+		Truncated     bool                     `json:"truncated"`
 	}{
-		Results:   views,
-		Truncated: truncated,
+		Messages:      msgViews,
+		Sessions:      sessViews,
+		WorkingMemory: wmViews,
+		Truncated:     truncated || b.Truncated,
 	}
 	data, _ := json.Marshal(out)
 	return data

--- a/internal/state/memory/format.go
+++ b/internal/state/memory/format.go
@@ -241,16 +241,18 @@ func buildSearchResultViews(results []SearchResult, now time.Time) []SearchResul
 // hit. Compact compared to a raw-message search result — the
 // summary is already distilled, so no context window is needed.
 // session_id pairs with archive_session_transcript for full
-// drilldown when the match looks worth reading.
+// drilldown when the match looks worth reading. Tags is a structured
+// list of strings, matching SessionMatch.Tags and Session.Tags shape
+// (caller doesn't have to parse JSON).
 type SessionMatchView struct {
-	SessionID      string `json:"session_id"`
-	ConversationID string `json:"conversation_id"`
-	Started        string `json:"started"`
-	Ended          string `json:"ended,omitempty"`
-	Title          string `json:"title"`
-	Summary        string `json:"summary,omitempty"`
-	Tags           string `json:"tags,omitempty"`
-	Highlight      string `json:"highlight,omitempty"`
+	SessionID      string   `json:"session_id"`
+	ConversationID string   `json:"conversation_id"`
+	Started        string   `json:"started"`
+	Ended          string   `json:"ended,omitempty"`
+	Title          string   `json:"title"`
+	Summary        string   `json:"summary,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	Highlight      string   `json:"highlight,omitempty"`
 }
 
 // WorkingMemoryMatchView is the JSON-facing projection of a
@@ -292,7 +294,7 @@ func FormatMultiKindResults(b *SearchBundle, now time.Time, truncated bool) []by
 			Started:        promptfmt.FormatDeltaOnly(s.StartedAt, now),
 			Title:          s.Title,
 			Summary:        s.Summary,
-			Tags:           s.Tags,
+			Tags:           append([]string(nil), s.Tags...),
 			Highlight:      s.Highlight,
 		}
 		if !s.EndedAt.IsZero() {

--- a/internal/tools/archive_tools.go
+++ b/internal/tools/archive_tools.go
@@ -17,15 +17,37 @@ import (
 // defensive guard against the empty-with-truncated degenerate
 // state where the byte-cap fitter drops everything to zero.
 func countSearchHits(data []byte) int {
-	var env struct {
-		Messages      []json.RawMessage `json:"messages"`
-		Sessions      []json.RawMessage `json:"sessions"`
-		WorkingMemory []json.RawMessage `json:"working_memory"`
-	}
-	if err := json.Unmarshal(data, &env); err != nil {
-		return 0
-	}
+	env := parseSearchEnvelope(data)
 	return len(env.Messages) + len(env.Sessions) + len(env.WorkingMemory)
+}
+
+// countMessages returns the count of raw-message hits in the
+// envelope. Used by the staged byte-cap fitter to remember how
+// many raw messages the stage-1 pass retained when stage 2 shrinks
+// the distilled surfaces.
+func countMessages(data []byte) int {
+	return len(parseSearchEnvelope(data).Messages)
+}
+
+// countSessions returns the count of session hits in the envelope —
+// stage-2 fitter's analog of [countMessages] for the stage-3
+// working_memory shrink.
+func countSessions(data []byte) int {
+	return len(parseSearchEnvelope(data).Sessions)
+}
+
+// searchEnvelope is the multi-surface archive_search envelope
+// shape, projected just enough to count by surface.
+type searchEnvelope struct {
+	Messages      []json.RawMessage `json:"messages"`
+	Sessions      []json.RawMessage `json:"sessions"`
+	WorkingMemory []json.RawMessage `json:"working_memory"`
+}
+
+func parseSearchEnvelope(data []byte) searchEnvelope {
+	var env searchEnvelope
+	_ = json.Unmarshal(data, &env)
+	return env
 }
 
 // archiveResultByteCap is the per-tool byte ceiling on JSON output.
@@ -126,32 +148,70 @@ func (r *Registry) registerArchiveSearch(searcher memory.MemorySearcher) {
 				bundle = &memory.SearchBundle{}
 			}
 
-			// Fit to byte cap by dropping raw-message hits from the
-			// tail. Distilled surfaces (sessions, working_memory) are
-			// kept across all iterations — they're small, high-signal,
-			// and worth preserving even when the raw side has to
-			// shrink. Binary search avoids O(n^2) re-marshaling.
+			// Two-stage fit to the byte cap:
+			//   1. Drop raw-message hits from the tail until the
+			//      formatted envelope fits. Distilled surfaces stay
+			//      put — they're high signal per byte.
+			//   2. If the remainder STILL exceeds the cap (zero raw
+			//      messages but heavy distilled surfaces, or a single
+			//      huge session summary), drop distilled hits from
+			//      the tail. Sessions first (typically more numerous
+			//      per query), then working_memory. Honors the same
+			//      "keep at least one hit when any exist" defensive
+			//      pass at the end.
 			now := time.Now()
-			render := func(k int) []byte {
+			render := func(msgs, sess, wm int) []byte {
 				clipped := &memory.SearchBundle{
-					Messages:      bundle.Messages[:k],
-					Sessions:      bundle.Sessions,
-					WorkingMemory: bundle.WorkingMemory,
+					Messages:      bundle.Messages[:msgs],
+					Sessions:      bundle.Sessions[:sess],
+					WorkingMemory: bundle.WorkingMemory[:wm],
 					Truncated:     bundle.Truncated,
 				}
-				return memory.FormatMultiKindResults(clipped, now, k < len(bundle.Messages))
+				truncated := bundle.Truncated ||
+					msgs < len(bundle.Messages) ||
+					sess < len(bundle.Sessions) ||
+					wm < len(bundle.WorkingMemory)
+				return memory.FormatMultiKindResults(clipped, now, truncated)
 			}
-			data := memory.FitPrefix(len(bundle.Messages), archiveResultByteCap, render)
+			// Stage 1: vary raw-message prefix; keep distilled intact.
+			fullSess := len(bundle.Sessions)
+			fullWM := len(bundle.WorkingMemory)
+			data := memory.FitPrefix(len(bundle.Messages), archiveResultByteCap, func(k int) []byte {
+				return render(k, fullSess, fullWM)
+			})
+			// Stage 2: if still over budget (the FitPrefix(0) case or a
+			// single distilled hit too big on its own), shrink distilled.
+			if len(data) > archiveResultByteCap {
+				keptMessages := countMessages(data)
+				// Sessions first.
+				data = memory.FitPrefix(fullSess, archiveResultByteCap, func(s int) []byte {
+					return render(keptMessages, s, fullWM)
+				})
+				if len(data) > archiveResultByteCap {
+					keptSessions := countSessions(data)
+					// Then working_memory.
+					data = memory.FitPrefix(fullWM, archiveResultByteCap, func(w int) []byte {
+						return render(keptMessages, keptSessions, w)
+					})
+				}
+			}
 
 			// Defensive: if the fitter clipped every surface to zero
-			// despite the bundle having hits, force the top
-			// raw-message hit through even if it overshoots the
-			// budget. Returning empty with truncated=true would
+			// despite the bundle having hits, force one hit through
+			// even if it overshoots the budget. Prefer raw-message,
+			// then session, then working-memory — same priority order
+			// as the fit. Returning empty with truncated=true would
 			// silently swallow useful signal — far worse than going
 			// slightly over budget on one oversized hit.
-			if (len(bundle.Messages) > 0 || len(bundle.Sessions) > 0 || len(bundle.WorkingMemory) > 0) &&
-				countSearchHits(data) == 0 && len(bundle.Messages) > 0 {
-				data = render(1)
+			if countSearchHits(data) == 0 {
+				switch {
+				case len(bundle.Messages) > 0:
+					data = render(1, 0, 0)
+				case len(bundle.Sessions) > 0:
+					data = render(0, 1, 0)
+				case len(bundle.WorkingMemory) > 0:
+					data = render(0, 0, 1)
+				}
 			}
 			return string(data), nil
 		},

--- a/internal/tools/archive_tools.go
+++ b/internal/tools/archive_tools.go
@@ -11,18 +11,21 @@ import (
 	"github.com/nugget/thane-ai-agent/internal/state/memory"
 )
 
-// countSearchResults parses an archive_search JSON envelope and
-// returns the length of its `results` array, or 0 on parse failure
-// or absent field. Used by the search handler's defensive guard
-// against the empty-with-truncated degenerate state.
-func countSearchResults(data []byte) int {
+// countSearchHits parses the multi-surface archive_search JSON
+// envelope and returns the total number of hits across messages,
+// sessions, and working_memory. Used by the search handler's
+// defensive guard against the empty-with-truncated degenerate
+// state where the byte-cap fitter drops everything to zero.
+func countSearchHits(data []byte) int {
 	var env struct {
-		Results []json.RawMessage `json:"results"`
+		Messages      []json.RawMessage `json:"messages"`
+		Sessions      []json.RawMessage `json:"sessions"`
+		WorkingMemory []json.RawMessage `json:"working_memory"`
 	}
 	if err := json.Unmarshal(data, &env); err != nil {
 		return 0
 	}
-	return len(env.Results)
+	return len(env.Messages) + len(env.Sessions) + len(env.WorkingMemory)
 }
 
 // archiveResultByteCap is the per-tool byte ceiling on JSON output.
@@ -39,45 +42,55 @@ const archiveTranscriptByteCap = 32000
 // Together they form Thane's long-term memory surface: search across
 // past conversations, browse the catalog of sessions, pull a single
 // session in full, and grab message history by time/conversation range.
+//
+// archive_search now queries every memory surface at once — raw
+// messages, session summaries, and working memory — via the unified
+// [memory.MemorySearcher] interface. The prewarm context provider
+// uses the same MemorySearcher, so the two retrieval paths can't
+// drift apart.
 func (r *Registry) SetArchiveStore(store *memory.ArchiveStore) {
-	r.registerArchiveSearch(store)
+	searcher := memory.NewMemorySearch(store, r.workingMemoryStore, nil)
+	r.registerArchiveSearch(searcher)
 	r.registerArchiveSessions(store)
 	r.registerArchiveSessionTranscript(store)
 	r.registerArchiveRange(store)
 }
 
-func (r *Registry) registerArchiveSearch(store *memory.ArchiveStore) {
+func (r *Registry) registerArchiveSearch(searcher memory.MemorySearcher) {
 	r.Register(&Tool{
 		Name: "archive_search",
-		Description: "Search your conversation archive — semantic search across every past " +
-			"session you've had with anyone. Use this when something jogs a memory or you " +
-			"need context from a prior conversation. Each result is the matching message " +
-			"plus the surrounding context window (bounded by natural silence gaps), so you " +
-			"see a moment in conversation, not just an isolated line. Returns JSON with " +
-			"delta-second timestamps. Pair with archive_session_transcript when a hit looks " +
-			"worth reading in full.",
+		Description: "Search your memory of past conversations across three surfaces at once: " +
+			"raw message history, session summaries, and working memory. The JSON envelope " +
+			"separates them — messages[] carries the verbatim hits with surrounding context " +
+			"windows (bounded by natural silence gaps); sessions[] carries the summarizer's " +
+			"per-session distilled metadata (title, summary, tags); working_memory[] carries " +
+			"the per-conversation living distillation written by the metacog loop. " +
+			"Use this when something jogs a memory or you need context from a prior " +
+			"conversation — the distilled surfaces are higher signal per byte and worth " +
+			"reading first when they have hits. Pair with archive_session_transcript when " +
+			"a hit looks worth reading in full.",
 		Parameters: map[string]any{
 			"type": "object",
 			"properties": map[string]any{
 				"query": map[string]any{
 					"type":        "string",
-					"description": "What you're looking for. Semantic search — phrasing matters less than concept.",
+					"description": "What you're looking for. Phrase-anchored full-text search across all three surfaces.",
 				},
 				"conversation_id": map[string]any{
 					"type":        "string",
-					"description": "Optional: scope to one conversation. Omit to search across everything.",
+					"description": "Optional: scope the raw-message search to one conversation. Distilled surfaces are unscoped. Omit to search across everything.",
 				},
 				"silence_minutes": map[string]any{
 					"type":        "number",
-					"description": "How long a silence gap before context expansion stops. Default: 10.",
+					"description": "How long a silence gap before context expansion stops on raw-message hits. Default: 10.",
 				},
 				"no_context": map[string]any{
 					"type":        "boolean",
-					"description": "If true, return only matches without surrounding context. Default: false.",
+					"description": "If true, return only raw-message matches without surrounding context. Default: false.",
 				},
 				"limit": map[string]any{
 					"type":        "number",
-					"description": "Max results. Default: 5.",
+					"description": "Max raw-message results. Default: 5. Distilled surfaces have their own internal caps.",
 				},
 			},
 			"required": []string{"query"},
@@ -105,26 +118,39 @@ func (r *Registry) registerArchiveSearch(store *memory.ArchiveStore) {
 				opts.Limit = int(limit)
 			}
 
-			results, err := store.Search(opts)
+			bundle, err := searcher.Search(opts)
 			if err != nil {
 				return "", fmt.Errorf("archive search: %w", err)
 			}
+			if bundle == nil {
+				bundle = &memory.SearchBundle{}
+			}
 
-			// Fit to byte cap by dropping from the tail (lowest-relevance
-			// hits go first). Binary search avoids O(n^2) re-marshaling.
+			// Fit to byte cap by dropping raw-message hits from the
+			// tail. Distilled surfaces (sessions, working_memory) are
+			// kept across all iterations — they're small, high-signal,
+			// and worth preserving even when the raw side has to
+			// shrink. Binary search avoids O(n^2) re-marshaling.
 			now := time.Now()
 			render := func(k int) []byte {
-				return memory.FormatSearchResults(results[:k], now, k < len(results))
+				clipped := &memory.SearchBundle{
+					Messages:      bundle.Messages[:k],
+					Sessions:      bundle.Sessions,
+					WorkingMemory: bundle.WorkingMemory,
+					Truncated:     bundle.Truncated,
+				}
+				return memory.FormatMultiKindResults(clipped, now, k < len(bundle.Messages))
 			}
-			data := memory.FitPrefix(len(results), archiveResultByteCap, render)
+			data := memory.FitPrefix(len(bundle.Messages), archiveResultByteCap, render)
 
-			// Defensive: if the fitter clipped to zero results despite
-			// having raw matches, force the top-relevance hit through
-			// even if it overshoots the byte cap. Returning empty with
-			// truncated=true would silently swallow useful signal — far
-			// worse than going slightly over budget on one oversized
-			// result.
-			if len(results) > 0 && countSearchResults(data) == 0 {
+			// Defensive: if the fitter clipped every surface to zero
+			// despite the bundle having hits, force the top
+			// raw-message hit through even if it overshoots the
+			// budget. Returning empty with truncated=true would
+			// silently swallow useful signal — far worse than going
+			// slightly over budget on one oversized hit.
+			if (len(bundle.Messages) > 0 || len(bundle.Sessions) > 0 || len(bundle.WorkingMemory) > 0) &&
+				countSearchHits(data) == 0 && len(bundle.Messages) > 0 {
 				data = render(1)
 			}
 			return string(data), nil

--- a/internal/tools/archive_tools_test.go
+++ b/internal/tools/archive_tools_test.go
@@ -361,13 +361,20 @@ func TestArchiveSearchTool_NeverEmptyWhenResultsExist(t *testing.T) {
 		t.Fatalf("handler: %v", err)
 	}
 	var parsed struct {
-		Results   []memory.SearchResultView `json:"results"`
-		Truncated bool                      `json:"truncated"`
+		Messages      []memory.SearchResultView       `json:"messages"`
+		Sessions      []memory.SessionMatchView       `json:"sessions"`
+		WorkingMemory []memory.WorkingMemoryMatchView `json:"working_memory"`
+		Truncated     bool                            `json:"truncated"`
 	}
 	if err := json.Unmarshal([]byte(out), &parsed); err != nil {
 		t.Fatalf("unmarshal: %v\noutput: %s", err, out)
 	}
-	if len(parsed.Results) == 0 {
-		t.Fatalf("results empty despite real matches existing — regression of the production bug:\n%s", out)
+	// The fitter must always seat at least one hit somewhere — raw
+	// message, session summary, or working memory — when the
+	// underlying search found anything. Returning empty across all
+	// surfaces with truncated=true would silently swallow signal.
+	totalHits := len(parsed.Messages) + len(parsed.Sessions) + len(parsed.WorkingMemory)
+	if totalHits == 0 {
+		t.Fatalf("results empty across all surfaces despite real matches existing — regression of the production bug:\n%s", out)
 	}
 }

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -28,6 +28,7 @@ import (
 	"github.com/nugget/thane-ai-agent/internal/state/attachments"
 	"github.com/nugget/thane-ai-agent/internal/state/contacts"
 	"github.com/nugget/thane-ai-agent/internal/state/knowledge"
+	"github.com/nugget/thane-ai-agent/internal/state/memory"
 )
 
 // Tool represents a callable tool.
@@ -55,26 +56,27 @@ type Tool struct {
 
 // Registry holds available tools.
 type Registry struct {
-	tools           map[string]*Tool
-	tagIndex        map[string][]string // tag → tool names
-	ha              *homeassistant.Client
-	scheduler       *scheduler.Scheduler
-	factTools       *knowledge.Tools
-	contactTools    *contacts.Tools
-	emailTools      *email.Tools
-	notifier        *notifications.Sender
-	notifRecords    *notifications.RecordStore
-	notifRouter     *notifications.NotificationRouter
-	notifDispatcher CallbackDispatcher
-	companionCaller companionCallFunc
-	forgeTools      forgeHandler
-	fileTools       *FileTools
-	shellExec       *ShellExec
-	attachmentTools *attachments.Tools
-	tempFileStore   *TempFileStore
-	usageStore      *usage.Store
-	lensStore       *LensStore
-	logIndexDB      *sql.DB
+	tools              map[string]*Tool
+	tagIndex           map[string][]string // tag → tool names
+	ha                 *homeassistant.Client
+	scheduler          *scheduler.Scheduler
+	factTools          *knowledge.Tools
+	contactTools       *contacts.Tools
+	emailTools         *email.Tools
+	notifier           *notifications.Sender
+	notifRecords       *notifications.RecordStore
+	notifRouter        *notifications.NotificationRouter
+	notifDispatcher    CallbackDispatcher
+	companionCaller    companionCallFunc
+	forgeTools         forgeHandler
+	fileTools          *FileTools
+	shellExec          *ShellExec
+	attachmentTools    *attachments.Tools
+	tempFileStore      *TempFileStore
+	usageStore         *usage.Store
+	lensStore          *LensStore
+	logIndexDB         *sql.DB
+	workingMemoryStore *memory.WorkingMemoryStore
 
 	channelReactionHandlers map[string]ChannelReactionFunc
 

--- a/internal/tools/working_memory_tools.go
+++ b/internal/tools/working_memory_tools.go
@@ -9,11 +9,18 @@ import (
 	"github.com/nugget/thane-ai-agent/internal/state/memory"
 )
 
-// SetWorkingMemoryStore adds the session_working_memory tool to the registry.
-// This tool allows the agent to read and write free-form experiential notes
-// for the current conversation, capturing texture that mechanical compaction
-// destroys.
+// SetWorkingMemoryStore adds the session_working_memory tool to the
+// registry and stores a Registry-level reference so other tools
+// (notably archive_search) can search across working memory as part
+// of the unified multi-surface retrieval. Should be called before
+// SetArchiveStore so the latter sees the working memory store when
+// composing the MemorySearcher.
+//
+// This tool allows the agent to read and write free-form experiential
+// notes for the current conversation, capturing texture that mechanical
+// compaction destroys.
 func (r *Registry) SetWorkingMemoryStore(store *memory.WorkingMemoryStore) {
+	r.workingMemoryStore = store
 	r.Register(&Tool{
 		Name: "session_working_memory",
 		Description: "Read or write your working memory for this conversation. " +

--- a/talents/archive.md
+++ b/talents/archive.md
@@ -80,8 +80,8 @@ teaser: "Semantic search across past sessions — phrasing matters less than con
 
 # Search by text
 
-You have a topic, phrase, or concept in mind. Semantic search
-across every past session you've had with anyone:
+You have a topic, phrase, or concept in mind. The search runs
+against three surfaces at once and returns them in one envelope:
 
 ```json
 {
@@ -90,11 +90,30 @@ across every past session you've had with anyone:
 }
 ```
 
-Each result is the matching message plus surrounding context bounded
-by natural silence gaps — so you see a moment in conversation, not
-an isolated line. The default 10-minute silence threshold catches
-conversational breaks; tighten with `silence_minutes` for tighter
-clips, loosen for fuller context.
+Returns:
+
+```
+{
+  "messages":       [ ... ],    // verbatim raw-message hits with context
+  "sessions":       [ ... ],    // session summaries (title + summary + tags)
+  "working_memory": [ ... ],    // per-conversation distilled state
+  "truncated": false
+}
+```
+
+Read distilled first. `sessions[]` and `working_memory[]` are the
+summarizer and metacog loop's compressed view of the same history —
+higher signal per byte than scrolling through `messages[]` context
+windows. When a session summary hit looks promising, pull the full
+transcript with `archive_session_transcript`. When `messages[]` has
+the right slice but you need more context around it, the same
+trailhead applies.
+
+Each `messages[]` hit carries the matching message plus surrounding
+context bounded by natural silence gaps — so you see a moment in
+conversation, not an isolated line. The default 10-minute silence
+threshold catches conversational breaks; tighten with
+`silence_minutes` for tighter clips, loosen for fuller context.
 
 ## Scoping to one conversation
 


### PR DESCRIPTION
Refs #977 (Finding 2). **Stacks on [#982](https://github.com/nugget/thane-ai-agent/pull/982).** Merge #982 first; this PR will rebase to main automatically.

## Summary

#982 added the storage-side FTS5 indexes (`sessions_fts`, `working_memory_fts`). This PR wires them into the model's view. `archive_search` now returns a multi-surface envelope:

```json
{
  "messages":       [...],   // raw-message hits with context windows
  "sessions":       [...],   // session-summary matches (title + summary + tags)
  "working_memory": [...],   // per-conversation distilled state matches
  "truncated": false
}
```

The **same** `MemorySearcher` interface backs both the model-initiated `archive_search` tool AND the wake-time prewarm provider. They cannot drift. Any retrieval change — ranking, surface coverage, filtering — applies to both at once. (Per nugget's reminder: parallel search paths are the code smell to be on alert for; the unified `MemorySearcher` is the structural fix.)

## Composition

`MemorySearch` composes `ArchiveStore` (messages_fts + sessions_fts) and `WorkingMemoryStore` (working_memory_fts) behind a single interface:

```go
type MemorySearcher interface {
    Search(opts SearchOptions) (*SearchBundle, error)
}
```

Distilled surfaces soft-fail individually — a `sessions_fts` query error doesn't suppress the raw-message results the model would otherwise see. Only a raw-message search failure propagates.

The byte-cap fitter keeps the distilled surfaces across all truncation iterations: they're high signal per byte and cheap to keep. Only the raw-message tail shrinks under budget pressure.

## Behavior change visible to the model

Before:
```json
{"results": [/* raw messages */], "truncated": false}
```

After:
```json
{"messages": [...], "sessions": [...], "working_memory": [...], "truncated": false}
```

`talents/archive.md` is updated to teach the new shape and the "read distilled first" heuristic — `sessions[]` and `working_memory[]` are the summarizer's and metacog loop's compressed view; higher signal per byte than scrolling through raw context windows.

## Test plan

- [x] `go test -tags=sqlite_fts5 -race ./internal/state/memory/` — all pass including two new seam tests:
  - `TestMemorySearch_AllSurfacesReachModelEnvelope` — round-trips a query that has hits on all three surfaces through `FormatMultiKindResults`, verifies the envelope keeps every surface populated.
  - `TestMemorySearch_DistilledFailureDoesNotBlockMessages` — nil working memory store; raw-message results still survive.
- [x] `just ci` — full gate green (race, fmt, vet, architecture).
- [ ] Post-deploy, watch prewarm "Past Experience" blocks: when the summarizer drains the backlog (after #981) and starts populating `sessions.summary`, those hits should appear in the prewarm envelope alongside raw-message hits. Working memory matches should appear immediately on relevant queries.

## What's NOT in this PR

- Tuning the distilled vs raw weighting in `FormatMultiKindResults`. Today distilled hits always survive truncation while raw-message tails shrink — that's the right starting heuristic but may need adjustment after observation.
- A "this is what kind of result you're looking at" hint surface tag on individual hits. The envelope structure already conveys kind via the array name; per-result `kind` field would be redundant.

## Related

- #982 (depends on): adds `sessions_fts` and `working_memory_fts` + the `SearchSessions` / `WorkingMemoryStore.Search` methods this PR consumes.
- #981 (independent): unblocks the summarizer so `sessions.summary` starts getting populated again; once that lands, `sessions[]` hits in the envelope go from rare → common.