### PR TITLE
feat(curator): bake in a memory curator loop alongside ego and metacog

### DIFF
--- a/examples/config.example.yaml
+++ b/examples/config.example.yaml
@@ -952,6 +952,46 @@ ego:
     # selection. Built-in service defaults: metacognitive uses 3
     # (normal) / 8 (supervisor); ego uses 5 (normal) / 8 (supervisor).
     quality_floor: 8
+# Curator configures the memory curator loop. When enabled, a
+# self-paced service loop tends thane's understanding across the
+# memory silos by authoring dossiers — long-lived synthesis
+# documents keyed by subject. Unlike the Go-side session
+# summarizer worker (event-triggered on session close), the
+# curator picks its own targets each iteration. Maintains
+# core/curator.md as its working state.
+curator:
+  # Enabled controls whether the curator loop starts. Default: false.
+  enabled: false
+  # MinSleep is the minimum allowed sleep duration between iterations.
+  # Default: "15m". Parsed as a Go duration string.
+  min_sleep: 15m
+  # MaxSleep is the maximum allowed sleep duration between iterations.
+  # Default: "12h".
+  max_sleep: 12h
+  # DefaultSleep is used when the LLM does not call set_next_sleep.
+  # Default: "1h".
+  default_sleep: 1h
+  # Jitter is the sleep randomization factor (0.0–1.0). Default: 0.2.
+  # Set to 0.0 for deterministic timing.
+  jitter: 0.2
+  # SupervisorProbability is the per-wake chance (0.0–1.0) that
+  # this iteration runs as a supervisor turn — a frontier model
+  # with the augmented prompt produced by [prompts.CuratorPrompt].
+  # Default: 0.1. Set to 0.0 to disable supervisor turns entirely.
+  supervisor_probability: 0.1
+  # Router configures model routing for normal iterations.
+  router:
+    # QualityFloor is the minimum quality rating (1–10) for model
+    # selection. Built-in service defaults: metacognitive uses 3
+    # (normal) / 8 (supervisor); ego uses 5 (normal) / 8 (supervisor).
+    quality_floor: 5
+  # SupervisorRouter configures model routing for supervisor
+  # turns (frontier model with augmented prompt).
+  supervisor_router:
+    # QualityFloor is the minimum quality rating (1–10) for model
+    # selection. Built-in service defaults: metacognitive uses 3
+    # (normal) / 8 (supervisor); ego uses 5 (normal) / 8 (supervisor).
+    quality_floor: 8
 #
 # (optional) Loops configures immutable loop definitions loaded from the config
 # loops:

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -39,6 +39,7 @@ import (
 	"github.com/nugget/thane-ai-agent/internal/platform/telemetry"
 	"github.com/nugget/thane-ai-agent/internal/platform/usage"
 	"github.com/nugget/thane-ai-agent/internal/runtime/agent"
+	"github.com/nugget/thane-ai-agent/internal/runtime/curator"
 	"github.com/nugget/thane-ai-agent/internal/runtime/delegate"
 	"github.com/nugget/thane-ai-agent/internal/runtime/ego"
 	looppkg "github.com/nugget/thane-ai-agent/internal/runtime/loop"
@@ -187,6 +188,9 @@ type App struct {
 
 	// Ego loop config (stored for loop-definition hydration)
 	egoCfg *ego.Config
+
+	// Curator loop config (stored for loop-definition hydration)
+	curatorCfg *curator.Config
 
 	// Event bus
 	eventBus *events.Bus

--- a/internal/app/loop_definition_hydration.go
+++ b/internal/app/loop_definition_hydration.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/nugget/thane-ai-agent/internal/integrations/homeassistant"
+	"github.com/nugget/thane-ai-agent/internal/runtime/curator"
 	"github.com/nugget/thane-ai-agent/internal/runtime/ego"
 	looppkg "github.com/nugget/thane-ai-agent/internal/runtime/loop"
 	"github.com/nugget/thane-ai-agent/internal/runtime/metacognitive"
@@ -44,6 +45,17 @@ func (a *App) buildLoopDefinitionBaseSpecs() ([]looppkg.Spec, error) {
 			baseDefinitions = appendMissingDefinition(baseDefinitions, seen, ego.DefinitionSpec(egoCfg))
 		}
 	}
+	_, hasCuratorDefinition := seen[curator.DefinitionName]
+	if a.cfg.Curator.Enabled || hasCuratorDefinition {
+		curatorCfg, err := curator.ParseConfig(a.cfg.Curator)
+		if err != nil {
+			return nil, fmt.Errorf("curator config: %w", err)
+		}
+		a.curatorCfg = &curatorCfg
+		if a.cfg.Curator.Enabled && !hasCuratorDefinition {
+			baseDefinitions = appendMissingDefinition(baseDefinitions, seen, curator.DefinitionSpec(curatorCfg))
+		}
+	}
 	return baseDefinitions, nil
 }
 
@@ -68,6 +80,12 @@ func (a *App) hydrateLoopDefinitionSpec(spec looppkg.Spec) (looppkg.Spec, error)
 			return looppkg.Spec{}, fmt.Errorf("ego definition requires ego config")
 		}
 		runtimeSpec := ego.HydrateSpec(spec, *a.egoCfg)
+		return a.hydrateLoopOutputs(runtimeSpec)
+	case curator.DefinitionName:
+		if a.curatorCfg == nil {
+			return looppkg.Spec{}, fmt.Errorf("curator definition requires curator config")
+		}
+		runtimeSpec := curator.HydrateSpec(spec, *a.curatorCfg)
 		return a.hydrateLoopOutputs(runtimeSpec)
 	case unifiPollerDefinitionName:
 		if a.unifiPoller == nil {

--- a/internal/model/prompts/curator.go
+++ b/internal/model/prompts/curator.go
@@ -1,0 +1,177 @@
+package prompts
+
+// curatorBaseTemplate is the prompt for each curator loop iteration.
+// Current curator.md state is injected by the loop-declared output
+// context provider as the "Declared Durable Outputs" block.
+const curatorBaseTemplate = `Curator loop iteration.
+
+You are running as a background memory curator. You tend thane's
+accumulated understanding across the memory silos — archive (past
+conversations), session summaries, working memory, facts, documents,
+contacts. The Go-side summarizer worker is the clerk that stamps
+session metadata as sessions close; you are the librarian who turns
+that flow of records into coherent dossiers keyed by subject.
+
+A dossier is a long-lived synthesis document about one subject —
+an entity (` + "`entity:binary_sensor.game_room_door`" + `), an area
+(` + "`area:kitchen`" + `), a contact (` + "`contact:<id>`" + `), a routine, a theme.
+It collects what is known about that subject across every silo and
+arranges it as **claims with citations**. The interactive agent
+reads dossiers when something jogs a memory of that subject.
+
+## Your Durable Output
+
+Your current durable output contract is injected in the "Declared
+Durable Outputs" block. That block shows core:curator.md when it
+exists and names the generated replacement tool for the document.
+
+## What To Do This Iteration
+
+1. **Read your state file** — Review your curator.md content. It
+   carries: the subject you worked on last pass, the queue of
+   subjects worth refining, and a directory of dossiers you've
+   already authored.
+2. **Pick one subject** — Either the next item in your queue, or
+   the one that feels most needed (a known fertile subject whose
+   dossier is stale, a subject with rising cross-silo presence,
+   or a new arrival that has hits everywhere but no dossier yet).
+   One subject per iteration. Depth over breadth.
+3. **Walk the silos** for that subject. Use ` + "`archive_search`" + ` for
+   raw conversation hits and session summaries; ` + "`recall_fact`" + ` for
+   stored facts; ` + "`contact_lookup`" + ` if the subject is contact-
+   shaped; the documents tools to read any existing dossier and
+   adjacent KB content.
+4. **Write or refresh the dossier** as a document under the
+   ` + "`dossiers/`" + ` namespace via the documents tools. Use the subject
+   identifier as the filename (` + "`dossiers/entity-binary_sensor-game_room_door.md`" + `
+   etc.). Structure each claim with an evidence citation — an
+   archive session ID, a fact category+key, a document ref, or a
+   working-memory conversation ID — so a reader (you, future) can
+   check any claim against its source.
+5. **Update curator.md** — Call replace_output_curator_state with
+   the complete updated body. Record what subject you worked on,
+   what came next in the queue, and any pointers to the dossier
+   you wrote/updated.
+6. **Set your sleep** — Call set_next_sleep with your chosen
+   duration. Around 1h is the default rhythm; shorter if you sense
+   an active accumulation worth following, longer if the corpus
+   feels quiet and there is nothing new to synthesize.
+
+## What a dossier should look like
+
+A short markdown document. The standard skeleton:
+
+` + "```" + `markdown
+# Dossier: <subject identifier>
+
+**Subject:** ` + "`entity:binary_sensor.game_room_door`" + `
+**Last refreshed:** <ISO date>
+**Cross-silo presence:** archive (N hits), sessions (M summaries), facts (K), working_memory (J)
+
+## Summary
+
+One paragraph synthesizing what thane currently understands about
+this subject. Write it so a fresh wake into a conversation
+mentioning the subject benefits from reading just this paragraph.
+
+## Claims
+
+- <claim> — evidence: archive:session-019c598e, fact:home/game_room_door
+- <claim> — evidence: archive:session-019c5990
+- <claim> — evidence: contact:019c76e4 notes field
+- <claim> — evidence: documents:households/layout.md
+- <claim> — evidence: working_memory:conv-signal-15124232707
+
+## Open questions
+
+- <question> — what evidence might resolve it
+- <question> — …
+
+## Connections
+
+- Related subjects: ` + "`area:game_room`" + `, ` + "`zone:smoke_break`" + `
+- Dossiers that reference this one: <links>
+` + "```" + `
+
+Every claim line carries citations. If you cannot back a claim with
+specific evidence from the corpus, do not assert it — note it as an
+open question instead. Synthesis is connecting things you can
+defend, not generating plausible-sounding text.
+
+## What you are NOT for
+
+- Writing facts on the model's behalf. The interactive agent has
+  its own ` + "`remember_fact`" + ` instinct. Your job is synthesis above
+  that layer, not replacing it.
+- Sending messages to the user or any other channel. The curator
+  is a silent process. Direct human egress tools are not available.
+- Producing dashboards, status reports, or work logs. The dossiers
+  are about subjects, not about the agent's activity.
+- Refreshing every dossier every iteration. One subject per pass.
+  A dossier you wrote last week and that has no new evidence is
+  fine; leave it alone.
+
+## Guidelines
+
+- Each iteration is a fresh conversation. Your state file is your
+  ONLY memory between iterations. Write what your next-iteration
+  self needs to know.
+- Optimize for machine readability over human prose. Dossiers are
+  read by the interactive model during retrieval; future-you is
+  the only reader of the state file.
+- Quality over coverage. A small set of evidence-grounded dossiers
+  is more useful than a sprawling collection of plausibly-worded
+  ones.
+- If you cannot find enough cross-silo evidence to write a
+  meaningful dossier on the subject you picked, drop the subject
+  back into the queue with a note about what evidence would have
+  to accumulate before it is worth another pass. Honest "not yet"
+  beats premature synthesis.
+- Quiet observation is a valid outcome. If nothing in the corpus
+  feels worth a fresh dossier pass, note that in your state file
+  and sleep long.`
+
+// curatorSupervisorAugmentation is appended for frontier/supervisor turns.
+const curatorSupervisorAugmentation = `
+
+## Supervisor Review (Frontier Iteration)
+
+This iteration was randomly selected for supervisor-level review
+using a frontier model. In addition to the normal pass, critically
+evaluate:
+
+- **Evidence discipline** — Are the dossiers you've authored really
+  claim-with-citation, or have some lines drifted into unsupported
+  prose? A dossier whose claims cannot be checked is worse than no
+  dossier; it teaches the interactive agent to trust synthesis it
+  should not.
+- **Subject selection** — Is the queue you've been working through
+  serving thane's real retrieval needs, or have you fallen into a
+  pattern of refining the same easy subjects while harder ones sit
+  unattended?
+- **Dossier coherence** — Are dossiers staying focused on one
+  subject, or sprawling into the adjacent? Cross-references belong
+  in the Connections section, not in the body of an unrelated
+  dossier.
+- **Cadence calibration** — Is the loop sleeping appropriately?
+  Are short sleeps producing real work, or churn? Long sleeps
+  during quiet stretches are honorable.
+- **Blind spots** — What subjects are NOT being curated that
+  obviously should be? What patterns is the curator missing in
+  the corpus?
+
+Be honest. Use this supervisor pass to catch drift the cheaper
+model would miss consistently.`
+
+// CuratorPrompt returns the prompt for one curator loop iteration.
+// When isSupervisor is true, additional self-review instructions
+// are appended for frontier-model iterations. The current
+// curator.md content is injected by the loop's declared output
+// context, not this prompt.
+func CuratorPrompt(isSupervisor bool) string {
+	prompt := curatorBaseTemplate
+	if isSupervisor {
+		prompt += curatorSupervisorAugmentation
+	}
+	return prompt
+}

--- a/internal/model/prompts/curator.go
+++ b/internal/model/prompts/curator.go
@@ -41,13 +41,17 @@ exists and names the generated replacement tool for the document.
    stored facts; ` + "`contact_lookup`" + ` if the subject is contact-
    shaped; the documents tools to read any existing dossier and
    adjacent KB content.
-4. **Write or refresh the dossier** as a document under the
-   ` + "`dossiers/`" + ` namespace via the documents tools. Use the subject
-   identifier as the filename (` + "`dossiers/entity-binary_sensor-game_room_door.md`" + `
-   etc.). Structure each claim with an evidence citation — an
-   archive session ID, a fact category+key, a document ref, or a
-   working-memory conversation ID — so a reader (you, future) can
-   check any claim against its source.
+4. **Write or refresh the dossier** as a managed document under
+   the ` + "`kb:dossiers/`" + ` namespace via the documents tools. All
+   document refs MUST use the canonical ` + "`root:path`" + ` form — for the
+   dossier on the game room door, the ref is
+   ` + "`kb:dossiers/entity-binary_sensor-game_room_door.md`" + `, not a bare
+   ` + "`dossiers/...`" + ` path (bare paths fail with an invalid-ref error).
+   Use the subject identifier as the filename. Structure each claim
+   with an evidence citation — an archive session ID, a fact
+   category+key, a document ref, or a working-memory conversation
+   ID — so a reader (you, future) can check any claim against its
+   source.
 5. **Update curator.md** — Call replace_output_curator_state with
    the complete updated body. Record what subject you worked on,
    what came next in the queue, and any pointers to the dossier
@@ -90,7 +94,7 @@ mentioning the subject benefits from reading just this paragraph.
 ## Connections
 
 - Related subjects: ` + "`area:game_room`" + `, ` + "`zone:smoke_break`" + `
-- Dossiers that reference this one: <links>
+- Dossiers that reference this one: ` + "`kb:dossiers/<other-subject>.md`" + `, …
 ` + "```" + `
 
 Every claim line carries citations. If you cannot back a claim with

--- a/internal/model/prompts/curator.go
+++ b/internal/model/prompts/curator.go
@@ -36,11 +36,18 @@ exists and names the generated replacement tool for the document.
    dossier is stale, a subject with rising cross-silo presence,
    or a new arrival that has hits everywhere but no dossier yet).
    One subject per iteration. Depth over breadth.
-3. **Walk the silos** for that subject. Use ` + "`archive_search`" + ` for
-   raw conversation hits and session summaries; ` + "`recall_fact`" + ` for
-   stored facts; ` + "`contact_lookup`" + ` if the subject is contact-
-   shaped; the documents tools to read any existing dossier and
-   adjacent KB content.
+3. **Walk the silos** for that subject. Search **both the canonical
+   handle and the human aliases** — the handle (e.g.
+   ` + "`entity:binary_sensor.game_room_door`" + `) appears in facts and
+   automation configs, while conversations call it "game room door,"
+   "the door with the brass handle," "smoke-break door," or whatever
+   inside-joke vocabulary the household uses. Phrase-first FTS will
+   miss whichever form you didn't query. Use ` + "`archive_search`" + ` for
+   each known phrasing; ` + "`recall_fact`" + ` for stored facts; ` + "`contact_lookup`" + `
+   if the subject is contact-shaped; the documents tools to read any
+   existing dossier and adjacent KB content. Record every alias you
+   discover in the dossier's Aliases section so future passes don't
+   have to re-derive them.
 4. **Write or refresh the dossier** as a managed document under
    the ` + "`kb:dossiers/`" + ` namespace via the documents tools. All
    document refs MUST use the canonical ` + "`root:path`" + ` form — for the
@@ -69,6 +76,7 @@ A short markdown document. The standard skeleton:
 # Dossier: <subject identifier>
 
 **Subject:** ` + "`entity:binary_sensor.game_room_door`" + `
+**Aliases:** "game room door", "smoke-break door", "the brass-handle door"
 **Last refreshed:** <ISO date>
 **Cross-silo presence:** archive (N hits), sessions (M summaries), facts (K), working_memory (J)
 

--- a/internal/model/prompts/curator_test.go
+++ b/internal/model/prompts/curator_test.go
@@ -1,0 +1,47 @@
+package prompts
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCuratorPrompt_NormalIteration(t *testing.T) {
+	got := CuratorPrompt(false)
+
+	for _, phrase := range []string{
+		"Curator loop iteration",
+		"replace_output_curator_state",
+		"set_next_sleep",
+		"dossier",
+		"durable output contract",
+		"One subject per iteration",
+		"evidence",
+	} {
+		if !strings.Contains(got, phrase) {
+			t.Errorf("prompt missing expected phrase %q", phrase)
+		}
+	}
+	if strings.Contains(got, "Supervisor Review") {
+		t.Error("normal iteration should not include supervisor section")
+	}
+}
+
+func TestCuratorPrompt_SupervisorTurn(t *testing.T) {
+	got := CuratorPrompt(true)
+
+	if !strings.Contains(got, "Supervisor Review") {
+		t.Error("supervisor turn should include supervisor review section")
+	}
+	if !strings.Contains(got, "Curator loop iteration") {
+		t.Error("supervisor turn should still include base prompt")
+	}
+	for _, phrase := range []string{
+		"Evidence discipline",
+		"Subject selection",
+		"Cadence calibration",
+	} {
+		if !strings.Contains(got, phrase) {
+			t.Errorf("supervisor section missing expected phrase %q", phrase)
+		}
+	}
+}

--- a/internal/platform/config/config.go
+++ b/internal/platform/config/config.go
@@ -315,6 +315,15 @@ type Config struct {
 	// output, with supervisor randomization for periodic frontier review.
 	Ego EgoConfig `yaml:"ego"`
 
+	// Curator configures the memory curator loop. When enabled, a
+	// self-paced service loop tends thane's understanding across the
+	// memory silos by authoring dossiers — long-lived synthesis
+	// documents keyed by subject. Unlike the Go-side session
+	// summarizer worker (event-triggered on session close), the
+	// curator picks its own targets each iteration. Maintains
+	// core/curator.md as its working state.
+	Curator CuratorConfig `yaml:"curator"`
+
 	// Loops configures immutable loop definitions loaded from the config
 	// file. These definitions become the base layer for the loop
 	// definition registry, with a persistent dynamic overlay applied at
@@ -1826,10 +1835,56 @@ type EgoConfig struct {
 	SupervisorRouter RouterConfig `yaml:"supervisor_router"`
 }
 
+// CuratorConfig configures the memory curator loop. The loop runs as
+// a service loop: bounded voluntary sleep, supervisor randomization,
+// and a declared maintained-document output at core/curator.md.
+// Where ego maintains self-reflection and metacognitive watches
+// in-flight behavior, the curator synthesizes durable knowledge
+// across the memory silos into long-lived dossiers keyed by subject.
+//
+// Self-paced by design: each iteration picks its own subject rather
+// than reacting to events. The Go-side session summarizer worker
+// still fires on session close and stamps session metadata; the
+// curator works above that layer, turning session summaries (and
+// the rest of the corpus) into per-subject dossiers.
+type CuratorConfig struct {
+	// Enabled controls whether the curator loop starts. Default: false.
+	Enabled bool `yaml:"enabled"`
+
+	// MinSleep is the minimum allowed sleep duration between iterations.
+	// Default: "15m". Parsed as a Go duration string.
+	MinSleep string `yaml:"min_sleep"`
+
+	// MaxSleep is the maximum allowed sleep duration between iterations.
+	// Default: "12h".
+	MaxSleep string `yaml:"max_sleep"`
+
+	// DefaultSleep is used when the LLM does not call set_next_sleep.
+	// Default: "1h".
+	DefaultSleep string `yaml:"default_sleep"`
+
+	// Jitter is the sleep randomization factor (0.0–1.0). Default: 0.2.
+	// Set to 0.0 for deterministic timing.
+	Jitter *float64 `yaml:"jitter,omitempty"`
+
+	// SupervisorProbability is the per-wake chance (0.0–1.0) that
+	// this iteration runs as a supervisor turn — a frontier model
+	// with the augmented prompt produced by [prompts.CuratorPrompt].
+	// Default: 0.1. Set to 0.0 to disable supervisor turns entirely.
+	SupervisorProbability *float64 `yaml:"supervisor_probability,omitempty"`
+
+	// Router configures model routing for normal iterations.
+	Router RouterConfig `yaml:"router"`
+
+	// SupervisorRouter configures model routing for supervisor
+	// turns (frontier model with augmented prompt).
+	SupervisorRouter RouterConfig `yaml:"supervisor_router"`
+}
+
 // RouterConfig holds routing hints used by the built-in services
-// (metacognitive, ego) for both normal and supervisor turns. It is
-// deliberately narrow — operator-tunable knobs only — and gets
-// translated into the spec-level [router.LoopProfile] /
+// (metacognitive, ego, curator) for both normal and supervisor
+// turns. It is deliberately narrow — operator-tunable knobs only —
+// and gets translated into the spec-level [router.LoopProfile] /
 // [router.LoopProfile.QualityFloor] at hydration time. Replaces
 // the previously-duplicated `MetacognitiveRouterConfig` and
 // `EgoRouterConfig` types which were byte-identical apart from
@@ -2290,6 +2345,34 @@ func (c *Config) applyDefaults() {
 		c.Ego.SupervisorRouter.QualityFloor = 8
 	}
 
+	// Curator loop defaults. Sleep envelope: wider than metacog (which
+	// runs minutes apart), narrower than ego (which runs hours apart).
+	// One hour as the default cadence gives the corpus time to
+	// accumulate new evidence between passes without going stale.
+	if c.Curator.MinSleep == "" {
+		c.Curator.MinSleep = "15m"
+	}
+	if c.Curator.MaxSleep == "" {
+		c.Curator.MaxSleep = "12h"
+	}
+	if c.Curator.DefaultSleep == "" {
+		c.Curator.DefaultSleep = "1h"
+	}
+	if c.Curator.Jitter == nil {
+		v := 0.2
+		c.Curator.Jitter = &v
+	}
+	if c.Curator.SupervisorProbability == nil {
+		v := 0.1
+		c.Curator.SupervisorProbability = &v
+	}
+	if c.Curator.Router.QualityFloor == 0 {
+		c.Curator.Router.QualityFloor = 5
+	}
+	if c.Curator.SupervisorRouter.QualityFloor == 0 {
+		c.Curator.SupervisorRouter.QualityFloor = 8
+	}
+
 	if c.Agent.DelegationRequired && len(c.Agent.OrchestratorTools) == 0 {
 		c.Agent.OrchestratorTools = []string{
 			"thane_now",
@@ -2564,6 +2647,9 @@ func (c *Config) Validate() error {
 	if err := c.validateMetacognitive(); err != nil {
 		return err
 	}
+	if err := c.validateCurator(); err != nil {
+		return err
+	}
 	if err := c.validateEgo(); err != nil {
 		return err
 	}
@@ -2714,6 +2800,43 @@ func (c *Config) validateEgo() error {
 	}
 	if c.Ego.SupervisorProbability != nil && (*c.Ego.SupervisorProbability < 0 || *c.Ego.SupervisorProbability > 1.0) {
 		return fmt.Errorf("ego.supervisor_probability %.2f must be in [0.0, 1.0]", *c.Ego.SupervisorProbability)
+	}
+	return nil
+}
+
+// validateCurator checks curator loop configuration for internal
+// consistency. No-op when the loop is disabled.
+func (c *Config) validateCurator() error {
+	if !c.Curator.Enabled {
+		return nil
+	}
+	if c.Workspace.Path == "" {
+		return fmt.Errorf("curator requires workspace.path (state file lives under workspace/core)")
+	}
+	minSleep, err := time.ParseDuration(c.Curator.MinSleep)
+	if err != nil {
+		return fmt.Errorf("curator.min_sleep %q: %w", c.Curator.MinSleep, err)
+	}
+	maxSleep, err := time.ParseDuration(c.Curator.MaxSleep)
+	if err != nil {
+		return fmt.Errorf("curator.max_sleep %q: %w", c.Curator.MaxSleep, err)
+	}
+	defaultSleep, err := time.ParseDuration(c.Curator.DefaultSleep)
+	if err != nil {
+		return fmt.Errorf("curator.default_sleep %q: %w", c.Curator.DefaultSleep, err)
+	}
+	if minSleep > maxSleep {
+		return fmt.Errorf("curator.min_sleep (%s) exceeds max_sleep (%s)", minSleep, maxSleep)
+	}
+	if defaultSleep < minSleep || defaultSleep > maxSleep {
+		return fmt.Errorf("curator.default_sleep (%s) must be between min_sleep (%s) and max_sleep (%s)",
+			defaultSleep, minSleep, maxSleep)
+	}
+	if c.Curator.Jitter != nil && (*c.Curator.Jitter < 0 || *c.Curator.Jitter > 1.0) {
+		return fmt.Errorf("curator.jitter %.2f must be in [0.0, 1.0]", *c.Curator.Jitter)
+	}
+	if c.Curator.SupervisorProbability != nil && (*c.Curator.SupervisorProbability < 0 || *c.Curator.SupervisorProbability > 1.0) {
+		return fmt.Errorf("curator.supervisor_probability %.2f must be in [0.0, 1.0]", *c.Curator.SupervisorProbability)
 	}
 	return nil
 }

--- a/internal/platform/config/config_test.go
+++ b/internal/platform/config/config_test.go
@@ -1419,3 +1419,143 @@ func TestApplyDefaults_MetacognitiveZeroFloatsArePreserved(t *testing.T) {
 		t.Errorf("SupervisorProbability = %v, want explicit 0.0 to survive applyDefaults", cfg.Metacognitive.SupervisorProbability)
 	}
 }
+
+// curatorBaseConfig returns a Config with a valid enabled curator loop
+// for the validation-path tests below. Mirrors [egoBaseConfig].
+func curatorBaseConfig() *Config {
+	cfg := Default()
+	cfg.Workspace.Path = "/tmp/thane-test-workspace"
+	cfg.Curator = CuratorConfig{
+		Enabled:      true,
+		MinSleep:     "15m",
+		MaxSleep:     "12h",
+		DefaultSleep: "1h",
+	}
+	cfg.applyDefaults()
+	return cfg
+}
+
+func TestValidateCurator_Disabled_NoOp(t *testing.T) {
+	cfg := Default()
+	cfg.Curator = CuratorConfig{Enabled: false, MinSleep: "junk"} // would fail if enabled
+	if err := cfg.validateCurator(); err != nil {
+		t.Fatalf("validateCurator with Enabled=false should be a no-op, got: %v", err)
+	}
+}
+
+func TestValidateCurator_RequiresWorkspace(t *testing.T) {
+	cfg := curatorBaseConfig()
+	cfg.Workspace.Path = ""
+	err := cfg.validateCurator()
+	if err == nil {
+		t.Fatal("expected error when workspace.path is unset")
+	}
+	if !strings.Contains(err.Error(), "workspace.path") {
+		t.Errorf("error should mention workspace.path, got: %v", err)
+	}
+}
+
+func TestValidateCurator_DurationParsing(t *testing.T) {
+	cases := []struct {
+		name   string
+		mutate func(c *Config)
+		expect string
+	}{
+		{"min_sleep", func(c *Config) { c.Curator.MinSleep = "junk" }, "curator.min_sleep"},
+		{"max_sleep", func(c *Config) { c.Curator.MaxSleep = "junk" }, "curator.max_sleep"},
+		{"default_sleep", func(c *Config) { c.Curator.DefaultSleep = "junk" }, "curator.default_sleep"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := curatorBaseConfig()
+			tc.mutate(cfg)
+			err := cfg.validateCurator()
+			if err == nil {
+				t.Fatalf("expected error for invalid %s", tc.name)
+			}
+			if !strings.Contains(err.Error(), tc.expect) {
+				t.Errorf("error should mention %s, got: %v", tc.expect, err)
+			}
+		})
+	}
+}
+
+func TestValidateCurator_MinExceedsMax(t *testing.T) {
+	cfg := curatorBaseConfig()
+	cfg.Curator.MinSleep = "2h"
+	cfg.Curator.MaxSleep = "1h"
+	err := cfg.validateCurator()
+	if err == nil {
+		t.Fatal("expected error when min_sleep exceeds max_sleep")
+	}
+	if !strings.Contains(err.Error(), "min_sleep") || !strings.Contains(err.Error(), "max_sleep") {
+		t.Errorf("error should mention min_sleep and max_sleep, got: %v", err)
+	}
+}
+
+func TestValidateCurator_DefaultOutOfRange(t *testing.T) {
+	cfg := curatorBaseConfig()
+	cfg.Curator.DefaultSleep = "24h" // exceeds max
+	err := cfg.validateCurator()
+	if err == nil {
+		t.Fatal("expected error when default_sleep is outside [min_sleep, max_sleep]")
+	}
+	if !strings.Contains(err.Error(), "default_sleep") {
+		t.Errorf("error should mention default_sleep, got: %v", err)
+	}
+}
+
+func TestValidateCurator_JitterOutOfRange(t *testing.T) {
+	cases := []float64{-0.1, 1.5}
+	for _, v := range cases {
+		cfg := curatorBaseConfig()
+		cfg.Curator.Jitter = &v
+		err := cfg.validateCurator()
+		if err == nil {
+			t.Fatalf("expected error for jitter=%v", v)
+		}
+		if !strings.Contains(err.Error(), "curator.jitter") {
+			t.Errorf("error should mention curator.jitter, got: %v", err)
+		}
+	}
+}
+
+func TestValidateCurator_SupervisorProbabilityOutOfRange(t *testing.T) {
+	cases := []float64{-0.1, 1.5}
+	for _, v := range cases {
+		cfg := curatorBaseConfig()
+		cfg.Curator.SupervisorProbability = &v
+		err := cfg.validateCurator()
+		if err == nil {
+			t.Fatalf("expected error for supervisor_probability=%v", v)
+		}
+		if !strings.Contains(err.Error(), "curator.supervisor_probability") {
+			t.Errorf("error should mention curator.supervisor_probability, got: %v", err)
+		}
+	}
+}
+
+// TestApplyDefaults_CuratorZeroFloatsArePreserved — same regression
+// guard as the ego and metacognitive variants. Explicit 0.0 for
+// Jitter or SupervisorProbability must survive applyDefaults rather
+// than being silently overwritten by the package default.
+func TestApplyDefaults_CuratorZeroFloatsArePreserved(t *testing.T) {
+	zero := 0.0
+	cfg := Default()
+	cfg.Workspace.Path = "/tmp/thane-test-workspace"
+	cfg.Curator = CuratorConfig{
+		Enabled:               true,
+		MinSleep:              "15m",
+		MaxSleep:              "12h",
+		DefaultSleep:          "1h",
+		Jitter:                &zero,
+		SupervisorProbability: &zero,
+	}
+	cfg.applyDefaults()
+	if cfg.Curator.Jitter == nil || *cfg.Curator.Jitter != 0.0 {
+		t.Errorf("Jitter = %v, want explicit 0.0 to survive applyDefaults", cfg.Curator.Jitter)
+	}
+	if cfg.Curator.SupervisorProbability == nil || *cfg.Curator.SupervisorProbability != 0.0 {
+		t.Errorf("SupervisorProbability = %v, want explicit 0.0 to survive applyDefaults", cfg.Curator.SupervisorProbability)
+	}
+}

--- a/internal/platform/config/example.go
+++ b/internal/platform/config/example.go
@@ -396,6 +396,17 @@ func ExampleConfig() *Config {
 			SupervisorRouter:      RouterConfig{QualityFloor: 8},
 		},
 
+		Curator: CuratorConfig{
+			Enabled:               false,
+			MinSleep:              "15m",
+			MaxSleep:              "12h",
+			DefaultSleep:          "1h",
+			Jitter:                floatPtr(0.2),
+			SupervisorProbability: floatPtr(0.1),
+			Router:                RouterConfig{QualityFloor: 5},
+			SupervisorRouter:      RouterConfig{QualityFloor: 8},
+		},
+
 		Agent: AgentConfig{
 			DelegationRequired: false,
 		},

--- a/internal/runtime/curator/curator.go
+++ b/internal/runtime/curator/curator.go
@@ -1,0 +1,231 @@
+// Package curator implements the memory curator loop — a baked-in
+// service loop that tends thane's accumulated understanding of its
+// own corpus. Where the ego loop maintains self-reflection and the
+// metacognitive loop watches in-flight behavior, the curator
+// synthesizes durable knowledge across the memory silos (archive,
+// session summaries, working memory, facts, documents, contacts)
+// into long-lived dossiers keyed by subject.
+//
+// The curator is self-paced. Unlike the Go-side session summarizer
+// worker (which is event-triggered on session close), it has its
+// own sleep envelope and picks its own target each iteration —
+// "what aspect of memory does the corpus want me to refine right
+// now?" That autonomy is the structural point: a librarian, not a
+// clerk.
+//
+// State persists across iterations via a markdown file
+// (curator.md by default). The current iteration is one fresh
+// conversation; the model reads its prior queue and dossier
+// pointers from the state file, picks a subject, walks the
+// silos, and writes a dossier — or updates an existing one — via
+// the documents tools.
+package curator
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/nugget/thane-ai-agent/internal/model/prompts"
+	"github.com/nugget/thane-ai-agent/internal/model/router"
+	"github.com/nugget/thane-ai-agent/internal/platform/config"
+	"github.com/nugget/thane-ai-agent/internal/runtime/loop"
+	"github.com/nugget/thane-ai-agent/internal/tools"
+)
+
+// DefinitionName is the durable loop definition name for the
+// curator service. Used as both the loop registry name and the
+// routing factor ("source: curator").
+const DefinitionName = "curator"
+
+// stateFileName is the fixed filename of the curator's state
+// document. The runtime places it under workspace/core, alongside
+// ego.md and metacognitive.md. The interactive agent doesn't read
+// this file the way it reads ego.md — it's the curator's own
+// memory between iterations.
+const stateFileName = "curator.md"
+
+// Config holds the parsed curator loop configuration with
+// time.Duration fields (the YAML representation in
+// [config.CuratorConfig] is strings).
+//
+// Sleep envelope chosen deliberately wider than metacog and
+// narrower than ego: the curator's work is real synthesis (slower
+// than metacog's quick observations) but doesn't need to wait the
+// long stretches ego does for genuine introspective drift. A
+// default cadence around an hour gives the corpus time to
+// accumulate new evidence between passes without the curator
+// running stale.
+type Config struct {
+	Enabled                bool
+	StateFile              string
+	MinSleep               time.Duration
+	MaxSleep               time.Duration
+	DefaultSleep           time.Duration
+	Jitter                 float64
+	SupervisorProbability  float64
+	QualityFloor           int
+	SupervisorQualityFloor int
+}
+
+// ParseConfig converts a [config.CuratorConfig] (string durations)
+// into a [Config] (time.Duration fields). Call after config
+// validation has passed.
+func ParseConfig(raw config.CuratorConfig) (Config, error) {
+	minSleep, err := time.ParseDuration(raw.MinSleep)
+	if err != nil {
+		return Config{}, fmt.Errorf("min_sleep %q: %w", raw.MinSleep, err)
+	}
+	maxSleep, err := time.ParseDuration(raw.MaxSleep)
+	if err != nil {
+		return Config{}, fmt.Errorf("max_sleep %q: %w", raw.MaxSleep, err)
+	}
+	defaultSleep, err := time.ParseDuration(raw.DefaultSleep)
+	if err != nil {
+		return Config{}, fmt.Errorf("default_sleep %q: %w", raw.DefaultSleep, err)
+	}
+	return Config{
+		Enabled:                raw.Enabled,
+		StateFile:              stateFileName,
+		MinSleep:               minSleep,
+		MaxSleep:               maxSleep,
+		DefaultSleep:           defaultSleep,
+		Jitter:                 derefFloat(raw.Jitter, 0.2),
+		SupervisorProbability:  derefFloat(raw.SupervisorProbability, 0.1),
+		QualityFloor:           raw.Router.QualityFloor,
+		SupervisorQualityFloor: raw.SupervisorRouter.QualityFloor,
+	}, nil
+}
+
+// derefFloat returns *p when non-nil, otherwise def. Used to apply
+// package-level fallbacks when ParseConfig is called with a raw
+// config struct that bypassed [config.Config.applyDefaults]
+// (typically in tests).
+func derefFloat(p *float64, def float64) float64 {
+	if p == nil {
+		return def
+	}
+	return *p
+}
+
+// DefinitionSpec returns the persistable loop definition for the
+// curator service. Runtime hooks are attached later by [HydrateSpec]
+// so the definition can live in the durable registry alongside
+// metacognitive and ego.
+func DefinitionSpec(cfg Config) loop.Spec {
+	return loop.Spec{
+		Name:       DefinitionName,
+		Enabled:    cfg.Enabled,
+		Task:       "Tend thane's understanding across memory silos. Pick one subject per iteration and refine its dossier.",
+		Operation:  loop.OperationService,
+		Completion: loop.CompletionNone,
+		Outputs: []loop.OutputSpec{
+			{
+				Name: "curator_state",
+				Type: loop.OutputTypeMaintainedDocument,
+				Ref:  "core:curator.md",
+				Mode: loop.OutputModeReplace,
+				Purpose: "Curator working state written by the curator loop, for the curator. Tracks: " +
+					"the subject worked on this pass, the queue of subjects pending or worth revisiting, " +
+					"dossier pointers (which dossiers exist and where), and notes from the last few " +
+					"iterations. Read each turn so the curator picks up where it left off. NOT a " +
+					"public-facing document; the dossiers themselves are the model-facing output.",
+			},
+		},
+		SleepMin:     cfg.MinSleep,
+		SleepMax:     cfg.MaxSleep,
+		SleepDefault: cfg.DefaultSleep,
+		Jitter:       loop.Float64Ptr(cfg.Jitter),
+		ExcludeTools: curatorExcludeTools,
+		Tags:         []string{"curator"},
+		Profile: router.LoopProfile{
+			Mission:          "curator",
+			DelegationGating: "disabled",
+			QualityFloor:     cfg.QualityFloor,
+			ExtraHints:       map[string]string{"source": "curator"},
+		},
+		SupervisorProfile: supervisorProfile(cfg.SupervisorQualityFloor),
+		Supervisor:        cfg.SupervisorProbability > 0,
+		SupervisorProb:    cfg.SupervisorProbability,
+		Metadata: map[string]string{
+			"subsystem": "curator",
+			"category":  "service",
+		},
+	}
+}
+
+// supervisorProfile builds the curator's per-turn-mode overrides
+// from the supervisor router config. Returns nil when no overrides
+// are declared, signaling the loop runtime to reuse the normal
+// Profile during supervisor turns.
+func supervisorProfile(qualityFloor int) *router.LoopProfile {
+	if qualityFloor <= 0 {
+		return nil
+	}
+	return &router.LoopProfile{
+		QualityFloor: qualityFloor,
+	}
+}
+
+// HydrateSpec attaches the runtime-only hooks needed to execute the
+// curator service from a durable loop definition. The TaskBuilder
+// emits [prompts.CuratorPrompt] for each iteration; the prior
+// state file content is injected via the managed-output context
+// provider, not this prompt.
+func HydrateSpec(spec loop.Spec, _ Config) loop.Spec {
+	if strings.TrimSpace(spec.Name) == "" {
+		spec.Name = DefinitionName
+	}
+	spec.TaskBuilder = func(_ context.Context, isSupervisor bool) (string, error) {
+		return prompts.CuratorPrompt(isSupervisor), nil
+	}
+	return spec
+}
+
+// BuildSpec returns a [loop.Spec] that implements the curator loop
+// as a service loop. The returned spec declares the durable output
+// document and uses runtime hooks to build prompts.
+func BuildSpec(cfg Config) loop.Spec {
+	return HydrateSpec(DefinitionSpec(cfg), cfg)
+}
+
+// BuildLoopConfig returns the engine-facing [loop.Config] view of
+// the curator loop. Kept as a compatibility shim for callers that
+// work directly with [loop.Config] rather than [loop.Spec].
+func BuildLoopConfig(cfg Config) loop.Config {
+	spec := BuildSpec(cfg)
+	out := spec.ToConfig()
+	profileHints := spec.Profile.RoutingFactors()
+	if len(profileHints) > 0 {
+		if out.RoutingFactors == nil {
+			out.RoutingFactors = make(map[string]string, len(profileHints))
+		}
+		for k, v := range profileHints {
+			out.RoutingFactors[k] = v
+		}
+	}
+	if spec.Profile.DelegationGating != "" {
+		out.DelegationGating = spec.Profile.DelegationGating
+	}
+	return out
+}
+
+// curatorExcludeTools lists tools the curator loop should not have
+// access to. The curator's writes go through the managed output
+// (`core:curator.md`) and the documents tools (for dossiers in the
+// `dossiers/` namespace) — bare workspace file tools, exec, session
+// management, tag manipulation, and direct human-egress channels
+// are out of scope for a synthesis loop.
+//
+// Read tools are deliberately left in: archive_search, recall_fact,
+// contact_lookup, working memory access — the curator needs to walk
+// across silos to do its job.
+var curatorExcludeTools = append([]string{
+	"file_read", "file_write", "file_edit", "file_list",
+	"file_search", "file_grep", "file_stat", "file_tree",
+	"exec",
+	"conversation_reset", "session_close", "session_split", "session_checkpoint",
+	"create_temp_file",
+	"tag_activate", "tag_deactivate",
+}, tools.DirectHumanEgressToolNames()...)

--- a/internal/runtime/curator/curator_test.go
+++ b/internal/runtime/curator/curator_test.go
@@ -1,0 +1,182 @@
+package curator
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nugget/thane-ai-agent/internal/platform/config"
+	"github.com/nugget/thane-ai-agent/internal/runtime/loop"
+)
+
+func TestParseConfig_Valid(t *testing.T) {
+	jitter, supervisor := 0.2, 0.1
+	raw := config.CuratorConfig{
+		Enabled:               true,
+		MinSleep:              "15m",
+		MaxSleep:              "12h",
+		DefaultSleep:          "1h",
+		Jitter:                &jitter,
+		SupervisorProbability: &supervisor,
+		Router:                config.RouterConfig{QualityFloor: 5},
+		SupervisorRouter:      config.RouterConfig{QualityFloor: 8},
+	}
+
+	cfg, err := ParseConfig(raw)
+	if err != nil {
+		t.Fatalf("ParseConfig: %v", err)
+	}
+
+	if cfg.MinSleep != 15*time.Minute {
+		t.Errorf("MinSleep = %v, want 15m", cfg.MinSleep)
+	}
+	if cfg.MaxSleep != 12*time.Hour {
+		t.Errorf("MaxSleep = %v, want 12h", cfg.MaxSleep)
+	}
+	if cfg.DefaultSleep != time.Hour {
+		t.Errorf("DefaultSleep = %v, want 1h", cfg.DefaultSleep)
+	}
+	if cfg.StateFile != stateFileName {
+		t.Errorf("StateFile = %q, want %q", cfg.StateFile, stateFileName)
+	}
+	if cfg.QualityFloor != 5 {
+		t.Errorf("QualityFloor = %d, want 5", cfg.QualityFloor)
+	}
+	if cfg.SupervisorQualityFloor != 8 {
+		t.Errorf("SupervisorQualityFloor = %d, want 8", cfg.SupervisorQualityFloor)
+	}
+	if cfg.SupervisorProbability != 0.1 {
+		t.Errorf("SupervisorProbability = %v, want 0.1", cfg.SupervisorProbability)
+	}
+}
+
+func TestParseConfig_InvalidDuration(t *testing.T) {
+	cases := []struct {
+		name string
+		raw  config.CuratorConfig
+	}{
+		{"bad_min", config.CuratorConfig{MinSleep: "junk", MaxSleep: "12h", DefaultSleep: "1h"}},
+		{"bad_max", config.CuratorConfig{MinSleep: "15m", MaxSleep: "junk", DefaultSleep: "1h"}},
+		{"bad_default", config.CuratorConfig{MinSleep: "15m", MaxSleep: "12h", DefaultSleep: "junk"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := ParseConfig(tc.raw); err == nil {
+				t.Fatal("ParseConfig: want error, got nil")
+			}
+		})
+	}
+}
+
+func TestDefinitionSpec_Outputs(t *testing.T) {
+	cfg := Config{
+		Enabled:                true,
+		MinSleep:               15 * time.Minute,
+		MaxSleep:               12 * time.Hour,
+		DefaultSleep:           time.Hour,
+		Jitter:                 0.2,
+		SupervisorProbability:  0.1,
+		QualityFloor:           5,
+		SupervisorQualityFloor: 8,
+	}
+	spec := DefinitionSpec(cfg)
+
+	if spec.Name != DefinitionName {
+		t.Errorf("Name = %q, want %q", spec.Name, DefinitionName)
+	}
+	if spec.Operation != loop.OperationService {
+		t.Errorf("Operation = %q, want %q", spec.Operation, loop.OperationService)
+	}
+	if len(spec.Outputs) != 1 {
+		t.Fatalf("Outputs len = %d, want 1", len(spec.Outputs))
+	}
+	out := spec.Outputs[0]
+	if out.Ref != "core:curator.md" {
+		t.Errorf("Outputs[0].Ref = %q, want core:curator.md", out.Ref)
+	}
+	if out.Type != loop.OutputTypeMaintainedDocument {
+		t.Errorf("Outputs[0].Type = %q, want maintained_document", out.Type)
+	}
+	if out.EffectiveMode() != loop.OutputModeReplace {
+		t.Errorf("Outputs[0].Mode = %q, want replace", out.EffectiveMode())
+	}
+	if !strings.HasPrefix(out.ToolName(), "replace_output_") {
+		t.Errorf("ToolName = %q, want replace_output_* prefix", out.ToolName())
+	}
+	if !spec.Supervisor {
+		t.Error("Supervisor should be enabled when SupervisorProbability > 0")
+	}
+	if spec.SleepMin != 15*time.Minute {
+		t.Errorf("SleepMin = %v, want 15m", spec.SleepMin)
+	}
+	if spec.Profile.Mission != "curator" {
+		t.Errorf("Profile.Mission = %q, want curator", spec.Profile.Mission)
+	}
+	if spec.Profile.DelegationGating != "disabled" {
+		t.Errorf("Profile.DelegationGating = %q, want disabled", spec.Profile.DelegationGating)
+	}
+	if len(spec.Tags) != 1 || spec.Tags[0] != "curator" {
+		t.Errorf("Tags = %v, want [curator]", spec.Tags)
+	}
+	if spec.Profile.ExtraHints["source"] != "curator" {
+		t.Errorf("Profile.ExtraHints[source] = %q, want curator", spec.Profile.ExtraHints["source"])
+	}
+}
+
+func TestHydrateSpec_AttachesTaskBuilder(t *testing.T) {
+	cfg := Config{Enabled: true}
+	spec := HydrateSpec(DefinitionSpec(cfg), cfg)
+
+	if spec.TaskBuilder == nil {
+		t.Fatal("TaskBuilder should be attached after HydrateSpec")
+	}
+	prompt, err := spec.TaskBuilder(nil, false)
+	if err != nil {
+		t.Fatalf("TaskBuilder returned error: %v", err)
+	}
+	if prompt == "" {
+		t.Error("TaskBuilder returned empty prompt")
+	}
+	supervisorPrompt, _ := spec.TaskBuilder(nil, true)
+	if len(supervisorPrompt) <= len(prompt) {
+		t.Error("supervisor prompt should be longer than normal prompt")
+	}
+}
+
+// TestExcludeTools_LocksDownHumanEgressAndFileWrites verifies the
+// curator can't reach for tools outside its declared surface. The
+// curator's job is silent synthesis: no Signal/notification sends,
+// no bare workspace file writes (managed output handles state, the
+// documents tools handle dossiers), no tag manipulation, no session
+// control. Documents tools and read-side tools (archive_search,
+// recall_fact, contact_lookup) are deliberately NOT excluded.
+func TestExcludeTools_LocksDownHumanEgressAndFileWrites(t *testing.T) {
+	spec := DefinitionSpec(Config{})
+
+	excluded := make(map[string]bool, len(spec.ExcludeTools))
+	for _, name := range spec.ExcludeTools {
+		excluded[name] = true
+	}
+
+	mustExclude := []string{
+		"file_write", "file_edit", "exec",
+		"conversation_reset", "session_close",
+		"tag_activate", "tag_deactivate",
+	}
+	for _, tool := range mustExclude {
+		if !excluded[tool] {
+			t.Errorf("expected %q in ExcludeTools", tool)
+		}
+	}
+
+	// Tools the curator DOES need access to should not be excluded.
+	mustNotExclude := []string{
+		"archive_search", "recall_fact", "contact_lookup",
+		"set_next_sleep",
+	}
+	for _, tool := range mustNotExclude {
+		if excluded[tool] {
+			t.Errorf("%q should remain available to the curator", tool)
+		}
+	}
+}

--- a/scripts/architecture.baseline
+++ b/scripts/architecture.baseline
@@ -1,4 +1,4 @@
-packages=57
+packages=58
 interfaces=76
 large_files=42
 set_mutators=102


### PR DESCRIPTION
## What this is

A third baked-in service loop, sibling to **ego** and **metacognitive**. Where ego maintains self-reflection and metacog watches in-flight behavior, the **curator** tends thane's understanding across the memory silos by authoring **dossiers** — long-lived synthesis documents keyed by subject.

Disabled by default. Enable via:

```yaml
curator:
  enabled: true
```

## Augment, not replacement

The existing Go-side `SummarizerWorker` stays exactly as it is. It remains the clerk that stamps session metadata on session-close events. The curator is the **librarian** who turns that flow of records into per-subject dossiers. Two cadences, two roles.

| | Summarizer worker | Curator loop |
|---|---|---|
| Trigger | Session close event | Self-paced (cron-like) |
| Scope | Per-session | Per-subject |
| Output | `sessions.summary` row | Dossier as managed document |
| Cadence | Reactive (~ minutes after close) | ~1h default, self-tunable 15m–12h |
| Role | Clerk | Librarian |

## What each iteration does

1. Read prior state from `core/curator.md` — the subject queue and dossier directory.
2. Pick one subject. Either the next item in the queue, or one that feels most needed.
3. Walk the silos: `archive_search`, `recall_fact`, `contact_lookup`, the documents tools. Pull every piece of evidence for the subject.
4. Write or refresh a dossier under `dossiers/` via the documents tools, structured as claim-with-citation:

   ```markdown
   ## Claims
   - <claim> — evidence: archive:session-019c598e, fact:home/game_room_door
   - <claim> — evidence: contact:019c76e4 notes
   ```

   No claim without a citation. If you can't back it, it's an open question, not a claim.
5. Update `core/curator.md` with what was worked on and what's queued next.
6. Set the next sleep.

## Architecture

Mirrors `ego.go` exactly so the maintenance pattern is shared:

- `internal/runtime/curator/curator.go` — `DefinitionName`, `Config`, `ParseConfig`, `DefinitionSpec`, `HydrateSpec`, `BuildSpec`, `BuildLoopConfig`.
- `internal/model/prompts/curator.go` — `CuratorPrompt` (normal + supervisor augmentation).
- `internal/platform/config/config.go` — `CuratorConfig` + defaults + validation.
- `internal/platform/config/example.go` — example values for config render.
- `internal/app/app.go` + `loop_definition_hydration.go` — wiring into the app's loop-definition base specs and runtime hydration.
- Maintained output `core:curator.md` is the working state file.
- Tool exclusions match ego's exclusions: bare workspace file tools, exec, session control, tag manipulation, direct human egress. Documents tools and read tools (archive_search, recall_fact, contact_lookup) deliberately stay in.

Sleep envelope sits between metacog (minutes) and ego (hours-days). Default 1h cadence with 15m–12h range. Supervisor probability 0.1 — lower than ego's 0.2 since the curator's job is more deterministic in shape (the supervisor catches evidence-discipline drift rather than novel observation).

## What's NOT in v1

Deliberately minimal:
- **No auto-trending detector.** Subject selection is hand-driven via the queue the curator maintains in `core/curator.md`.
- **No cross-silo subject-presence index.** A future enhancement; for now the curator's evidence-gathering uses the existing search tools.
- **No metacog watchdog for fact extraction.** A future variant could scan `"noted"/"got it"` patterns and surface fact candidates; that's its own loop.
- **No formal dossier schema.** The prompt describes the recommended skeleton; the loop is free to evolve it. Iteration 1 is about seeing what shape the curator naturally produces.

These build naturally on this scaffold once production observation tells us what works.

## Test plan

- [x] `go test -race ./internal/runtime/curator/ ./internal/model/prompts/` — all pass
- [x] `just ci` — full gate green (fmt, vet, lint, race, architecture, link-check, config-generate-check). Architecture baseline bumped for the new package (57 → 58).
- [ ] **Post-merge / post-deploy on a non-prod host**: enable the curator, give it 4–6 hours, inspect:
  - Is `core/curator.md` being maintained sensibly (queue, dossier directory, notes)?
  - Are dossiers landing under `dossiers/` with claim-citation structure?
  - Does the loop converge on quiet sleeps when there's nothing to do, or does it churn?
  - Do dossier writes overlap with the existing summarizer worker output, or do they sit cleanly above it?
- [ ] **Once observation looks good**: enable on production. Watch whether interactive turns that touch curated subjects (e.g. `entity:binary_sensor.game_room_door`) start surfacing dossiers via `archive_search` (depends on #983's multi-surface envelope landing first to be model-visible).

## Strategic context

This realizes the curator-as-librarian discussion from the recent strategic round-trip. The kernel was: silos are organizational convenience for storage, but the agent's mental model is unified — make the meta-layer reflect that. The curator's dossier-keyed-by-subject output is the first concrete artifact of that unified-meta-model.

Most of the in-flight #977 work (especially #982 + #983) makes the curator's output reachable to the interactive model. Without the multi-surface FTS envelope, dossiers are just files; with it, they show up as session-summary-tier hits during semantic search. The two PR threads compose cleanly.