### PR TITLE
feat(memory): wire session-close events to the curator wake

### DIFF
--- a/internal/app/curator_session_close_wake.go
+++ b/internal/app/curator_session_close_wake.go
@@ -16,21 +16,37 @@ import (
 // registry is paused or shutting down.
 const curatorSessionCloseWakeTimeout = 2 * time.Second
 
+// fireCuratorSessionCloseWake constructs the session-close envelope
+// and delivers it to the curator loop. Used by BOTH the real-time
+// EndSession callback (wired in wireSessionCloseToCuratorWake) and
+// the SummarizerWorker's backstop scan path (wired via
+// SetCuratorWake). Sharing this function keeps the two delivery
+// paths' envelope shape and error handling identical.
+//
+// Returns the wake-delivery error so callers can decide whether to
+// fall back to a direct LLM call (the summarizer's behavior) or
+// just log and move on (the EndSession callback's behavior).
+func (a *App) fireCuratorSessionCloseWake(ctx context.Context, sessionID, reason string) error {
+	env, err := buildSessionCloseEnvelope(sessionID, reason)
+	if err != nil {
+		return fmt.Errorf("build envelope: %w", err)
+	}
+	if _, err := a.loopRegistry.NotifyLoopByName(ctx, curator.DefinitionName, env); err != nil {
+		return fmt.Errorf("notify curator: %w", err)
+	}
+	return nil
+}
+
 // wireSessionCloseToCuratorWake installs the [memory.ArchiveStore]
 // session-close callback that fires a curator wake every time a
-// session ends. The wake carries the closed session's ID and reason
-// as a structured event payload so the curator's iteration can
-// dispatch on Kind=="session_close" and read the just-closed session.
+// session ends, AND the equivalent backstop on the SummarizerWorker
+// scan path. The EndSession callback is real-time delivery; the
+// summarizer scan catches any session whose real-time wake was
+// dropped (curator down, queue full, restart during a callback).
 //
-// Skipped when curator.enabled is false — the callback would
-// uselessly call NotifyLoopByName against a missing loop and log a
-// warn on every session close. Skipped when archiveStore or
-// loopRegistry isn't constructed yet (defensive — both should always
-// be present by the time initStores reaches this hook).
-//
-// The summarizer worker's periodic scan remains the backstop for any
-// wake that gets dropped (loop registry shutting down, curator queue
-// full, callback panic absorbed by EndSession).
+// Skipped when curator.enabled is false — both paths fall back to
+// their prior behavior (EndSession is a no-op, SummarizerWorker
+// calls the LLM directly).
 func (a *App) wireSessionCloseToCuratorWake() {
 	if a == nil || a.archiveStore == nil || a.loopRegistry == nil {
 		return
@@ -40,32 +56,16 @@ func (a *App) wireSessionCloseToCuratorWake() {
 	}
 
 	logger := a.logger
-	registry := a.loopRegistry
-	curatorName := curator.DefinitionName
 
+	// Real-time path: EndSession callback.
 	a.archiveStore.SetSessionCloseCallback(func(sessionID, reason string) {
 		ctx, cancel := context.WithTimeout(context.Background(), curatorSessionCloseWakeTimeout)
 		defer cancel()
-
-		env, err := buildSessionCloseEnvelope(sessionID, reason)
-		if err != nil {
-			if logger != nil {
-				logger.Warn("curator session-close wake: envelope build failed",
-					"session_id", sessionID,
-					"reason", reason,
-					"error", err,
-				)
-			}
-			return
-		}
-
-		if _, err := registry.NotifyLoopByName(ctx, curatorName, env); err != nil {
+		if err := a.fireCuratorSessionCloseWake(ctx, sessionID, reason); err != nil {
 			// Common case: curator is enabled in config but not yet
 			// running (still starting up, or briefly stopped during
-			// reconcile). The backstop summarizer scan will pick up
-			// the unsummarized session on its next pass; no further
-			// action needed here. Log at Debug so steady-state noise
-			// is silent but the path stays observable when needed.
+			// reconcile). The summarizer scan will catch any missed
+			// wakes on its next pass; no further action needed here.
 			if logger != nil {
 				logger.Debug("curator session-close wake: notify failed (summarizer backstop will handle)",
 					"session_id", sessionID,
@@ -76,10 +76,17 @@ func (a *App) wireSessionCloseToCuratorWake() {
 		}
 	})
 
+	// Backstop path: summarizer scan finds anything the real-time
+	// path missed and fires the wake (instead of LLM-calling itself).
+	if a.summaryWorker != nil {
+		a.summaryWorker.SetCuratorWake(a.fireCuratorSessionCloseWake)
+	}
+
 	if logger != nil {
 		logger.Info("curator session-close wake wired",
-			"loop", curatorName,
+			"loop", curator.DefinitionName,
 			"timeout", curatorSessionCloseWakeTimeout,
+			"backstop", a.summaryWorker != nil,
 		)
 	}
 }

--- a/internal/app/curator_session_close_wake.go
+++ b/internal/app/curator_session_close_wake.go
@@ -1,0 +1,121 @@
+package app
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/nugget/thane-ai-agent/internal/channels/messages"
+	"github.com/nugget/thane-ai-agent/internal/runtime/curator"
+)
+
+// curatorSessionCloseWakeTimeout caps how long the
+// ArchiveStore.EndSession callback waits for the loop registry to
+// accept the notify. The callback runs synchronously in the goroutine
+// that closed the session — must not block forever if the loop
+// registry is paused or shutting down.
+const curatorSessionCloseWakeTimeout = 2 * time.Second
+
+// wireSessionCloseToCuratorWake installs the [memory.ArchiveStore]
+// session-close callback that fires a curator wake every time a
+// session ends. The wake carries the closed session's ID and reason
+// as a structured event payload so the curator's iteration can
+// dispatch on Kind=="session_close" and read the just-closed session.
+//
+// Skipped when curator.enabled is false — the callback would
+// uselessly call NotifyLoopByName against a missing loop and log a
+// warn on every session close. Skipped when archiveStore or
+// loopRegistry isn't constructed yet (defensive — both should always
+// be present by the time initStores reaches this hook).
+//
+// The summarizer worker's periodic scan remains the backstop for any
+// wake that gets dropped (loop registry shutting down, curator queue
+// full, callback panic absorbed by EndSession).
+func (a *App) wireSessionCloseToCuratorWake() {
+	if a == nil || a.archiveStore == nil || a.loopRegistry == nil {
+		return
+	}
+	if a.cfg == nil || !a.cfg.Curator.Enabled {
+		return
+	}
+
+	logger := a.logger
+	registry := a.loopRegistry
+	curatorName := curator.DefinitionName
+
+	a.archiveStore.SetSessionCloseCallback(func(sessionID, reason string) {
+		ctx, cancel := context.WithTimeout(context.Background(), curatorSessionCloseWakeTimeout)
+		defer cancel()
+
+		env, err := buildSessionCloseEnvelope(sessionID, reason)
+		if err != nil {
+			if logger != nil {
+				logger.Warn("curator session-close wake: envelope build failed",
+					"session_id", sessionID,
+					"reason", reason,
+					"error", err,
+				)
+			}
+			return
+		}
+
+		if _, err := registry.NotifyLoopByName(ctx, curatorName, env); err != nil {
+			// Common case: curator is enabled in config but not yet
+			// running (still starting up, or briefly stopped during
+			// reconcile). The backstop summarizer scan will pick up
+			// the unsummarized session on its next pass; no further
+			// action needed here. Log at Debug so steady-state noise
+			// is silent but the path stays observable when needed.
+			if logger != nil {
+				logger.Debug("curator session-close wake: notify failed (summarizer backstop will handle)",
+					"session_id", sessionID,
+					"reason", reason,
+					"error", err,
+				)
+			}
+		}
+	})
+
+	if logger != nil {
+		logger.Info("curator session-close wake wired",
+			"loop", curatorName,
+			"timeout", curatorSessionCloseWakeTimeout,
+		)
+	}
+}
+
+// buildSessionCloseEnvelope constructs the loop-notify envelope the
+// curator receives on session close. The payload mirrors the
+// event-source shape used by email and feed pollers so the curator's
+// notification-summary rendering path handles it uniformly: a single
+// LoopEventPayload with source="session_close", type="session_close",
+// the session ID as the event ID, and the close reason as
+// metadata.reason.
+func buildSessionCloseEnvelope(sessionID, reason string) (messages.Envelope, error) {
+	if sessionID == "" {
+		return messages.Envelope{}, fmt.Errorf("empty session_id")
+	}
+	target := messages.LoopWakeTarget{
+		Name:     curator.DefinitionName,
+		Priority: messages.PriorityNormal,
+		Instructions: "A session just closed. Read it (archive_session_transcript with this " +
+			"session_id), then fold any new evidence into relevant dossiers. The interactive " +
+			"agent has moved on — you are the bookkeeper now.",
+	}
+	event := messages.LoopEventPayload{
+		Source:     "session_close",
+		Type:       "session_close",
+		ID:         sessionID,
+		ObservedAt: time.Now().UTC(),
+		Metadata: map[string]string{
+			"session_id": sessionID,
+			"reason":     reason,
+		},
+	}
+	return messages.NewEventSourceEnvelope(
+		messages.Identity{Kind: messages.IdentitySystem, Name: "archive_store"},
+		target,
+		"session_close",
+		[]messages.LoopEventPayload{event},
+	)
+}

--- a/internal/app/curator_session_close_wake_test.go
+++ b/internal/app/curator_session_close_wake_test.go
@@ -1,0 +1,92 @@
+package app
+
+import (
+	"testing"
+	"time"
+
+	"github.com/nugget/thane-ai-agent/internal/channels/messages"
+	"github.com/nugget/thane-ai-agent/internal/runtime/curator"
+)
+
+// TestBuildSessionCloseEnvelope_HappyPath verifies the curator wake
+// envelope construction: target loop is the curator, payload is the
+// event_source shape with one LoopEventPayload carrying source +
+// type = "session_close", the session ID as event ID, and the reason
+// in metadata.
+func TestBuildSessionCloseEnvelope_HappyPath(t *testing.T) {
+	const sessionID = "019e6867-00fc-7d6d-88be-58fab5c173c4"
+	const reason = "idle_timeout"
+
+	before := time.Now().UTC()
+	env, err := buildSessionCloseEnvelope(sessionID, reason)
+	after := time.Now().UTC()
+	if err != nil {
+		t.Fatalf("buildSessionCloseEnvelope: %v", err)
+	}
+
+	// Destination — loop selected by name == "curator".
+	if env.To.Kind != messages.DestinationLoop {
+		t.Errorf("To.Kind = %q, want loop", env.To.Kind)
+	}
+	if env.To.Selector != messages.SelectorName {
+		t.Errorf("To.Selector = %q, want name", env.To.Selector)
+	}
+	if env.To.Target != curator.DefinitionName {
+		t.Errorf("To.Target = %q, want %q", env.To.Target, curator.DefinitionName)
+	}
+
+	// From — system identity from archive_store.
+	if env.From.Kind != messages.IdentitySystem {
+		t.Errorf("From.Kind = %q, want system", env.From.Kind)
+	}
+	if env.From.Name != "archive_store" {
+		t.Errorf("From.Name = %q, want archive_store", env.From.Name)
+	}
+
+	// Payload — event_source shape with one LoopEventPayload.
+	payload, ok := env.Payload.(messages.LoopNotifyPayload)
+	if !ok {
+		t.Fatalf("Payload type = %T, want LoopNotifyPayload", env.Payload)
+	}
+	if payload.Kind != "event_source" {
+		t.Errorf("payload.Kind = %q, want event_source", payload.Kind)
+	}
+	if len(payload.Events) != 1 {
+		t.Fatalf("payload.Events len = %d, want 1", len(payload.Events))
+	}
+	ev := payload.Events[0]
+	if ev.Source != "session_close" {
+		t.Errorf("event.Source = %q, want session_close", ev.Source)
+	}
+	if ev.Type != "session_close" {
+		t.Errorf("event.Type = %q, want session_close", ev.Type)
+	}
+	if ev.ID != sessionID {
+		t.Errorf("event.ID = %q, want %q", ev.ID, sessionID)
+	}
+	if ev.Metadata["session_id"] != sessionID {
+		t.Errorf("event.Metadata[session_id] = %q, want %q", ev.Metadata["session_id"], sessionID)
+	}
+	if ev.Metadata["reason"] != reason {
+		t.Errorf("event.Metadata[reason] = %q, want %q", ev.Metadata["reason"], reason)
+	}
+	if ev.ObservedAt.Before(before) || ev.ObservedAt.After(after) {
+		t.Errorf("event.ObservedAt = %v, want within [%v, %v]", ev.ObservedAt, before, after)
+	}
+
+	// Instructions on the wake — terse-but-pointed nudge the curator
+	// prompt's session_close mode references.
+	if payload.Context == "" {
+		t.Error("payload.Context (instructions) empty — curator wake should carry the 'fold into dossiers' nudge")
+	}
+}
+
+// TestBuildSessionCloseEnvelope_EmptySessionID rejects malformed
+// callers before the envelope reaches the loop runtime — preserving
+// the invariant that every wake refers to a real session.
+func TestBuildSessionCloseEnvelope_EmptySessionID(t *testing.T) {
+	_, err := buildSessionCloseEnvelope("", "test")
+	if err == nil {
+		t.Fatal("buildSessionCloseEnvelope with empty sessionID should error")
+	}
+}

--- a/internal/app/new_stores.go
+++ b/internal/app/new_stores.go
@@ -493,5 +493,11 @@ func (a *App) initStores(s *newState) error {
 		return nil
 	})
 
+	// Hook EndSession → curator wake. Must come after archiveStore is
+	// constructed and the loop registry exists (both are guaranteed at
+	// this point in initStores). No-op when curator is disabled in
+	// config. See issue #989.
+	a.wireSessionCloseToCuratorWake()
+
 	return nil
 }

--- a/internal/model/prompts/curator.go
+++ b/internal/model/prompts/curator.go
@@ -19,6 +19,33 @@ It collects what is known about that subject across every silo and
 arranges it as **claims with citations**. The interactive agent
 reads dossiers when something jogs a memory of that subject.
 
+## Two ways you wake up
+
+This iteration runs in one of two modes. Check the **Loop
+notifications for this run** block (when present) — it carries
+inbound event-source wakes that arrived since your last sleep.
+
+- **Session-close wake (event-triggered).** A session just ended.
+  The notification payload carries ` + "`source: \"session_close\"`" + ` and
+  ` + "`events[0].id`" + ` is the closed session's ID, with the close reason
+  in ` + "`metadata.reason`" + `. Your job this turn is to **read that
+  session and fold any new evidence into the dossiers it touches**.
+  Use ` + "`archive_session_transcript`" + ` with the session ID. If the
+  session mentions a subject that already has a dossier, refresh
+  it. If it surfaces a new subject worth a dossier and your queue
+  has room, add it. Per-subject deep work (the self-paced mode
+  below) waits for the next scheduled wake — don't try to do both
+  in one iteration.
+- **Self-paced wake (no event payload).** No inbound notification.
+  Pick one subject from your queue and do the per-subject work
+  described in "What To Do This Iteration" below.
+
+If multiple session-close events arrive in one wake (batch
+delivery), process them all in this iteration. The
+` + "`events_truncated`" + ` flag on the payload tells you when the runtime
+clipped a larger batch; what you can't reach here will be picked up
+on a later wake via the summarizer's periodic scan backstop.
+
 ## Your Durable Output
 
 Your current durable output contract is injected in the "Declared
@@ -26,6 +53,10 @@ Durable Outputs" block. That block shows core:curator.md when it
 exists and names the generated replacement tool for the document.
 
 ## What To Do This Iteration
+
+(Self-paced mode — when there is no session-close notification in
+your wake context. The session-close mode above is the alternative.)
+
 
 1. **Read your state file** — Review your curator.md content. It
    carries: the subject you worked on last pass, the queue of

--- a/internal/model/prompts/curator.go
+++ b/internal/model/prompts/curator.go
@@ -8,9 +8,13 @@ const curatorBaseTemplate = `Curator loop iteration.
 You are running as a background memory curator. You tend thane's
 accumulated understanding across the memory silos — archive (past
 conversations), session summaries, working memory, facts, documents,
-contacts. The Go-side summarizer worker is the clerk that stamps
-session metadata as sessions close; you are the librarian who turns
-that flow of records into coherent dossiers keyed by subject.
+contacts. When a session closes the Go-side summarizer wakes you
+with a session_close event and you write the session's metadata
+(title, summary, tags) as the model-output side. The summarizer's
+own LLM path is the fallback for setups without you; with you
+running, you are the sole writer. On your self-paced wakes you
+turn the accumulated flow of records into coherent dossiers keyed
+by subject.
 
 A dossier is a long-lived synthesis document about one subject —
 an entity (` + "`entity:binary_sensor.game_room_door`" + `), an area

--- a/internal/model/prompts/curator.go
+++ b/internal/model/prompts/curator.go
@@ -44,11 +44,11 @@ inbound event-source wakes that arrived since your last sleep.
   Pick one subject from your queue and do the per-subject work
   described in "What To Do This Iteration" below.
 
-If multiple session-close events arrive in one wake (batch
-delivery), process them all in this iteration. The
-` + "`events_truncated`" + ` flag on the payload tells you when the runtime
-clipped a larger batch; what you can't reach here will be picked up
-on a later wake via the summarizer's periodic scan backstop.
+If multiple session-close events arrive in one wake — the runtime
+can batch up to fifty events into a single envelope — process them
+all in this iteration. Larger backlogs aren't truncated; producers
+split them into multiple wakes, and the summarizer's periodic scan
+backstop refires anything the real-time path dropped.
 
 ## Your Durable Output
 

--- a/internal/model/prompts/curator_test.go
+++ b/internal/model/prompts/curator_test.go
@@ -26,6 +26,32 @@ func TestCuratorPrompt_NormalIteration(t *testing.T) {
 	}
 }
 
+// TestCuratorPrompt_TwoModesPresent verifies the prompt teaches the
+// curator both wake modes — self-paced and event-triggered
+// (session_close). Lock this in so a future prompt edit doesn't
+// silently drop one path; the curator's behavior on each shape is
+// load-bearing for the issue-989 wake delivery.
+func TestCuratorPrompt_TwoModesPresent(t *testing.T) {
+	got := CuratorPrompt(false)
+	for _, phrase := range []string{
+		"Two ways you wake up",
+		"Session-close wake",
+		"Self-paced wake",
+		"session_close",
+		"archive_session_transcript",
+		// Reference to the runtime's notification block (the literal
+		// header is "Loop notifications for this run:"). Normalize
+		// out whitespace so prompt line-wrapping doesn't break this
+		// assertion.
+		"notifications for this run",
+	} {
+		normalized := strings.Join(strings.Fields(got), " ")
+		if !strings.Contains(normalized, phrase) {
+			t.Errorf("prompt missing two-modes phrase %q", phrase)
+		}
+	}
+}
+
 func TestCuratorPrompt_SupervisorTurn(t *testing.T) {
 	got := CuratorPrompt(true)
 

--- a/internal/runtime/curator/curator.go
+++ b/internal/runtime/curator/curator.go
@@ -138,7 +138,14 @@ func DefinitionSpec(cfg Config) loop.Spec {
 		SleepDefault: cfg.DefaultSleep,
 		Jitter:       loop.Float64Ptr(cfg.Jitter),
 		ExcludeTools: curatorExcludeTools,
-		Tags:         []string{"curator"},
+		// Tags = capability surfaces the curator boots with active.
+		// `curator` is the loop's own identity tag; the rest match the
+		// tool families the curator's prompt promises it can use
+		// (archive_search, recall_fact, contact_lookup, the documents
+		// tools for dossier writes). Since ExcludeTools blocks
+		// tag_activate, the curator can't expand its surface at
+		// runtime — it has to ship with the right initial set.
+		Tags: []string{"curator", "documents", "archive", "memory", "contacts"},
 		Profile: router.LoopProfile{
 			Mission:          "curator",
 			DelegationGating: "disabled",

--- a/internal/runtime/curator/curator_test.go
+++ b/internal/runtime/curator/curator_test.go
@@ -115,8 +115,33 @@ func TestDefinitionSpec_Outputs(t *testing.T) {
 	if spec.Profile.DelegationGating != "disabled" {
 		t.Errorf("Profile.DelegationGating = %q, want disabled", spec.Profile.DelegationGating)
 	}
-	if len(spec.Tags) != 1 || spec.Tags[0] != "curator" {
-		t.Errorf("Tags = %v, want [curator]", spec.Tags)
+	// Tags = the curator's initial capability surface. "curator" is
+	// the identity tag; the rest are the tool families the prompt
+	// promises (and tag_activate is excluded, so this is the full
+	// boot-time set the curator can use).
+	wantTags := map[string]bool{
+		"curator": true, "documents": true, "archive": true,
+		"memory": true, "contacts": true,
+	}
+	if len(spec.Tags) != len(wantTags) {
+		t.Errorf("Tags = %v, want %d entries", spec.Tags, len(wantTags))
+	}
+	for _, tag := range spec.Tags {
+		if !wantTags[tag] {
+			t.Errorf("unexpected Tag %q in spec.Tags = %v", tag, spec.Tags)
+		}
+	}
+	for tag := range wantTags {
+		found := false
+		for _, t := range spec.Tags {
+			if t == tag {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("missing Tag %q from spec.Tags = %v", tag, spec.Tags)
+		}
 	}
 	if spec.Profile.ExtraHints["source"] != "curator" {
 		t.Errorf("Profile.ExtraHints[source] = %q, want curator", spec.Profile.ExtraHints["source"])

--- a/internal/state/memory/archive.go
+++ b/internal/state/memory/archive.go
@@ -58,6 +58,17 @@ type ArchiveStore struct {
 	// erroring at query time against a missing/broken FTS table.
 	sessionsFTSEnabled bool
 
+	// sessionCloseCallback runs after EndSession / EndSessionAt commits.
+	// Used by the app wiring to fire a curator wake event for the just-
+	// closed session — see issue #989. The callback runs synchronously
+	// in the calling goroutine; implementations MUST be fast and
+	// non-blocking (e.g. enqueue to a channel, return immediately).
+	// Errors are swallowed by the caller: closing a session is the
+	// authoritative state change; downstream notification is best-effort
+	// and the summarizer's periodic scan is the backstop for missed
+	// deliveries.
+	sessionCloseCallback func(sessionID, reason string)
+
 	// Context expansion defaults
 	defaultSilenceThreshold time.Duration
 	defaultMaxMessages      int
@@ -1706,12 +1717,49 @@ func (s *ArchiveStore) EndSession(sessionID string, reason string) error {
 	return s.EndSessionAt(sessionID, reason, time.Now().UTC())
 }
 
-// EndSessionAt marks a session as ended at a specific time.
+// EndSessionAt marks a session as ended at a specific time. After the
+// commit succeeds, any [SetSessionCloseCallback] registered on the
+// store fires synchronously with (sessionID, reason). The session
+// state change is authoritative; the callback is best-effort
+// notification and any panic / slow execution there does NOT roll back
+// the DB write.
 func (s *ArchiveStore) EndSessionAt(sessionID string, reason string, endedAt time.Time) error {
 	_, err := s.db.Exec(`
 		UPDATE sessions SET ended_at = ?, end_reason = ? WHERE id = ?
 	`, endedAt.Format(time.RFC3339Nano), reason, sessionID)
-	return err
+	if err != nil {
+		return err
+	}
+	if cb := s.sessionCloseCallback; cb != nil {
+		// Defer-recover guard: a bad callback should never poison the
+		// store's caller. The session is already closed — we just
+		// failed to notify whoever cared.
+		func() {
+			defer func() {
+				if r := recover(); r != nil && s.logger != nil {
+					s.logger.Error("session close callback panicked",
+						"session", ShortID(sessionID),
+						"panic", r,
+					)
+				}
+			}()
+			cb(sessionID, reason)
+		}()
+	}
+	return nil
+}
+
+// SetSessionCloseCallback registers a function to be called after every
+// successful EndSession / EndSessionAt commit. Passing nil clears the
+// callback. The callback receives the just-closed session's ID and end
+// reason and runs synchronously in the caller's goroutine — keep it
+// fast and non-blocking (channel send, then return).
+//
+// Used by the app wiring to fire a curator wake on session close (see
+// issue #989). Single callback per store; calling this more than once
+// replaces the previous callback rather than chaining.
+func (s *ArchiveStore) SetSessionCloseCallback(cb func(sessionID, reason string)) {
+	s.sessionCloseCallback = cb
 }
 
 // ClaimActiveMessages stamps session_id on active messages for a conversation

--- a/internal/state/memory/archive_test.go
+++ b/internal/state/memory/archive_test.go
@@ -2172,3 +2172,79 @@ func TestSearch_OrBackfillFillsThinPhrase(t *testing.T) {
 		seen[r.Match.ID] = true
 	}
 }
+
+// TestEndSession_FiresCloseCallback verifies the post-commit
+// notification hook that the curator wake event (issue #989) is built
+// on. After EndSession returns successfully, any registered callback
+// runs synchronously with the closed session's ID and reason.
+func TestEndSession_FiresCloseCallback(t *testing.T) {
+	store := newTestArchiveStore(t)
+	sess, err := store.StartSession("conv-callback")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var gotID, gotReason string
+	var calls int
+	store.SetSessionCloseCallback(func(id, reason string) {
+		calls++
+		gotID = id
+		gotReason = reason
+	})
+
+	if err := store.EndSession(sess.ID, "test"); err != nil {
+		t.Fatalf("EndSession: %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("callback fired %d times, want 1", calls)
+	}
+	if gotID != sess.ID {
+		t.Errorf("callback sessionID = %q, want %q", gotID, sess.ID)
+	}
+	if gotReason != "test" {
+		t.Errorf("callback reason = %q, want %q", gotReason, "test")
+	}
+}
+
+// TestEndSession_NoCallbackWhenUnset confirms the zero-callback path
+// is a clean no-op — EndSession works fine without a registered
+// callback (the common case before app wiring runs).
+func TestEndSession_NoCallbackWhenUnset(t *testing.T) {
+	store := newTestArchiveStore(t)
+	sess, err := store.StartSession("conv-no-cb")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// No SetSessionCloseCallback call — store.sessionCloseCallback stays nil.
+	if err := store.EndSession(sess.ID, "test"); err != nil {
+		t.Fatalf("EndSession with no callback: %v", err)
+	}
+}
+
+// TestEndSession_PanickingCallbackDoesNotPoisonCaller — a bad
+// callback should never roll back the session-close state change or
+// crash the caller. The DB commit is authoritative; the notification
+// is best-effort.
+func TestEndSession_PanickingCallbackDoesNotPoisonCaller(t *testing.T) {
+	store := newTestArchiveStore(t)
+	sess, err := store.StartSession("conv-panic")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	store.SetSessionCloseCallback(func(_, _ string) {
+		panic("intentional test panic")
+	})
+
+	if err := store.EndSession(sess.ID, "test"); err != nil {
+		t.Errorf("EndSession should swallow callback panic, got error: %v", err)
+	}
+	// Verify the session actually closed despite the panic.
+	got, err := store.GetSession(sess.ID)
+	if err != nil {
+		t.Fatalf("GetSession: %v", err)
+	}
+	if got.EndedAt == nil {
+		t.Error("session ended_at not set — DB write was rolled back by panic")
+	}
+}

--- a/internal/state/memory/summarizer.go
+++ b/internal/state/memory/summarizer.go
@@ -92,6 +92,13 @@ type SummarizerWorker struct {
 	startTime     time.Time // process start time — sessions older than this are orphan candidates
 	interactionCB InteractionCallback
 
+	// curatorWake, when set, is fired for each unsummarized session
+	// the worker finds instead of the worker calling the LLM itself.
+	// Wired by the app when the curator loop is enabled (#989). When
+	// unset (curator disabled), the worker falls back to its own LLM
+	// path so SummarizerWorker remains useful on its own.
+	curatorWake func(ctx context.Context, sessionID, reason string) error
+
 	cancel context.CancelFunc
 	done   chan struct{}
 }
@@ -109,6 +116,19 @@ func NewSummarizerWorker(store *ArchiveStore, llmClient llm.Client, rtr *router.
 		startTime: time.Now().UTC(),
 		done:      make(chan struct{}),
 	}
+}
+
+// SetCuratorWake registers the curator wake-firing function. When
+// set, the worker fires a curator wake for each unsummarized
+// session it finds instead of calling the LLM directly — the
+// curator becomes the sole writer of session metadata (#989).
+// Setting cb to nil restores the LLM-direct fallback path.
+//
+// Should be called from the app wiring whenever the curator loop is
+// enabled. The fallback (no curator wake) preserves backwards
+// compatibility for setups that haven't enabled the curator.
+func (w *SummarizerWorker) SetCuratorWake(cb func(ctx context.Context, sessionID, reason string) error) {
+	w.curatorWake = cb
 }
 
 // SetInteractionCallback registers a callback invoked after each
@@ -326,8 +346,35 @@ func (w *SummarizerWorker) summarizeSession(ctx context.Context, sess *Session) 
 		// Empty-transcript sessions (scheduler tasks, empty delegates,
 		// crash_recovery placeholders) must be marked as summarized
 		// so they don't re-enter the queue on every scan cycle.
+		// markEmpty is a SQL write — no LLM needed regardless of
+		// curator mode, so this path stays unchanged.
 		w.markEmpty(sess.ID)
 		return false
+	}
+
+	// Curator-wake path (#989). When the worker has a curator wake
+	// hook, fire it for this session and skip the LLM call entirely.
+	// The curator becomes the sole writer of session metadata; this
+	// worker reverts to a thin backstop scanner. A wake failure (curator
+	// disabled, queue full, transient) falls through to the LLM path
+	// so the session still gets summarized one way or the other.
+	if w.curatorWake != nil {
+		reason := ""
+		if sess.EndReason != "" {
+			reason = sess.EndReason
+		}
+		if err := w.curatorWake(ctx, sess.ID, reason); err == nil {
+			w.logger.Debug("session-close wake fired via summarizer scan",
+				"session", ShortID(sess.ID),
+				"reason", reason,
+			)
+			return false
+		} else {
+			w.logger.Warn("curator wake failed; falling back to direct LLM path",
+				"session", ShortID(sess.ID),
+				"error", err,
+			)
+		}
 	}
 
 	// Route model selection through the router.

--- a/internal/state/memory/summarizer.go
+++ b/internal/state/memory/summarizer.go
@@ -294,12 +294,13 @@ func (w *SummarizerWorker) scan(ctx context.Context) {
 			// session needs LLM work. It re-fetches the transcript
 			// to decide, so we don't rely on the (possibly stale or
 			// silently-zero) MessageCount from UnsummarizedSessions.
-			calledLLM := w.summarizeSession(ctx, sess)
-			if calledLLM {
+			workedThisRow := w.summarizeSession(ctx, sess)
+			if workedThisRow {
 				didLLMWork = true
-				// Rate-limit only when we actually called a model.
-				// Cleanup markEmpty paths are cheap SQL writes and
-				// don't need to throttle for interactive traffic.
+				// Rate-limit between rows when this one cost
+				// per-session budget — either an LLM call or a
+				// curator wake. Cleanup markEmpty paths are cheap
+				// SQL writes and don't need to throttle.
 				if !sleepCtx(ctx, w.config.PauseBetween) {
 					return
 				}
@@ -320,11 +321,15 @@ func (w *SummarizerWorker) scan(ctx context.Context) {
 }
 
 // summarizeSession processes one session candidate. Returns true when
-// an LLM call was made (so the caller knows to rate-limit), false
-// when the session was empty (markEmpty'd at SQL speed) or when an
-// unrecoverable error short-circuited the path before any model
-// call. The returned bool is the scan loop's signal: "did this row
-// cost real LLM/router budget?"
+// the row consumed real per-session budget that the scan loop should
+// rate-limit and break-batch on — either an LLM call (the legacy
+// metadata-generation path) or a successful curator-wake delivery (the
+// #989 path; wakes are cheap individually but enqueue model work
+// downstream and don't mutate the unsummarized-row state, so without
+// the break a backlogged tick would re-fire the same wakes every
+// batch until [maxBatchesPerScan]). Returns false when the session was
+// empty (markEmpty'd at SQL speed) or when an unrecoverable error
+// short-circuited the path before any work was emitted.
 func (w *SummarizerWorker) summarizeSession(ctx context.Context, sess *Session) bool {
 	ctx, cancel := context.WithTimeout(ctx, w.config.Timeout)
 	defer cancel()
@@ -368,7 +373,18 @@ func (w *SummarizerWorker) summarizeSession(ctx context.Context, sess *Session) 
 				"session", ShortID(sess.ID),
 				"reason", reason,
 			)
-			return false
+			// Return true so [scan] rate-limits via PauseBetween and
+			// exits its batch loop after this tick. The wake itself
+			// doesn't mark the row summarized (the curator does, on
+			// its next iteration), so a `return false` here would
+			// loop the same UnsummarizedSessions batch up to
+			// [maxBatchesPerScan] times per tick — re-firing the
+			// same wakes and flooding the loop notify queue. Cost
+			// of the conservative `true`: a single-batch backlog
+			// processes across multiple scan ticks instead of one,
+			// which is the correct backstop cadence (the real-time
+			// EndSession callback already handled the live case).
+			return true
 		} else {
 			w.logger.Warn("curator wake failed; falling back to direct LLM path",
 				"session", ShortID(sess.ID),

--- a/internal/state/memory/summarizer_test.go
+++ b/internal/state/memory/summarizer_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -707,4 +708,121 @@ func waitFor(t *testing.T, timeout time.Duration, condition func() bool) {
 		time.Sleep(10 * time.Millisecond)
 	}
 	t.Fatal("condition not met within timeout")
+}
+
+// TestWorker_CuratorWakeShortCircuitsLLM verifies the #989
+// transformation: when the worker has a curator-wake function set,
+// real sessions fire the wake instead of calling the LLM. The wake
+// becomes the backstop delivery channel; the LLM path is gone.
+// markEmpty still runs for zero-message sessions (SQL-only, no
+// model needed regardless of mode).
+func TestWorker_CuratorWakeShortCircuitsLLM(t *testing.T) {
+	store := newTestStore(t)
+	mock := &mockLLMClient{}
+	rtr := newTestRouter()
+
+	// One real session (with messages) + one empty session.
+	real := createUnsummarizedSession(t, store, "conv-real")
+	empty, err := store.StartSession("conv-empty")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.EndSession(empty.ID, "test"); err != nil {
+		t.Fatal(err)
+	}
+
+	var (
+		mu            sync.Mutex
+		wakedSessions []string
+	)
+	cfg := SummarizerConfig{
+		Interval:     time.Hour,
+		Timeout:      10 * time.Second,
+		PauseBetween: 1 * time.Millisecond,
+		BatchSize:    10,
+	}
+	w := NewSummarizerWorker(store, mock, rtr, slog.Default(), cfg)
+	w.SetCuratorWake(func(_ context.Context, sessionID, _ string) error {
+		mu.Lock()
+		wakedSessions = append(wakedSessions, sessionID)
+		mu.Unlock()
+		return nil
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	w.Start(ctx)
+
+	// Give the startup scan time to process both sessions.
+	waitFor(t, 5*time.Second, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return len(wakedSessions) >= 1
+	})
+	time.Sleep(50 * time.Millisecond) // settle any further work
+
+	cancel()
+	w.Stop()
+
+	// Real session: wake fired, LLM NOT called.
+	if mock.calls.Load() != 0 {
+		t.Errorf("expected 0 LLM calls when curator wake is set, got %d", mock.calls.Load())
+	}
+	mu.Lock()
+	snapshot := append([]string(nil), wakedSessions...)
+	mu.Unlock()
+	foundReal := false
+	for _, id := range snapshot {
+		if id == real.ID {
+			foundReal = true
+		}
+	}
+	if !foundReal {
+		t.Errorf("real session %s never fired curator wake; waked=%v", ShortID(real.ID), snapshot)
+	}
+
+	// Empty session: markEmpty ran (SQL-only path), so it should not
+	// be in the unsummarized list anymore.
+	remaining, err := store.UnsummarizedSessions(10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, sess := range remaining {
+		if sess.ID == empty.ID {
+			t.Error("empty session should have been markEmpty'd, still in queue")
+		}
+	}
+}
+
+// TestWorker_CuratorWakeFailureFallsBackToLLM — when the wake hook
+// returns an error (curator down, queue full), the worker falls
+// through to the direct LLM path so the session still gets
+// summarized one way or the other.
+func TestWorker_CuratorWakeFailureFallsBackToLLM(t *testing.T) {
+	store := newTestStore(t)
+	mock := &mockLLMClient{}
+	rtr := newTestRouter()
+	createUnsummarizedSession(t, store, "conv-fallback")
+
+	cfg := SummarizerConfig{
+		Interval:     time.Hour,
+		Timeout:      10 * time.Second,
+		PauseBetween: 1 * time.Millisecond,
+		BatchSize:    10,
+	}
+	w := NewSummarizerWorker(store, mock, rtr, slog.Default(), cfg)
+	w.SetCuratorWake(func(_ context.Context, _, _ string) error {
+		return fmt.Errorf("simulated curator unavailable")
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	w.Start(ctx)
+	waitFor(t, 5*time.Second, func() bool {
+		return mock.calls.Load() >= 1
+	})
+	cancel()
+	w.Stop()
+
+	if mock.calls.Load() == 0 {
+		t.Error("expected LLM fallback when curator wake fails, got 0 calls")
+	}
 }

--- a/internal/state/memory/summarizer_test.go
+++ b/internal/state/memory/summarizer_test.go
@@ -770,14 +770,23 @@ func TestWorker_CuratorWakeShortCircuitsLLM(t *testing.T) {
 	mu.Lock()
 	snapshot := append([]string(nil), wakedSessions...)
 	mu.Unlock()
-	foundReal := false
+	realWakes := 0
 	for _, id := range snapshot {
 		if id == real.ID {
-			foundReal = true
+			realWakes++
 		}
 	}
-	if !foundReal {
+	if realWakes == 0 {
 		t.Errorf("real session %s never fired curator wake; waked=%v", ShortID(real.ID), snapshot)
+	}
+	// Regression guard for the tight-loop bug (Copilot review on
+	// #994): the wake doesn't mark the row summarized, so without
+	// the "wake counts as work" signal the scan() batch loop would
+	// re-fetch the same UnsummarizedSessions and re-fire the same
+	// wake up to maxBatchesPerScan times per tick. With the fix one
+	// scan tick fires exactly once per session.
+	if realWakes > 1 {
+		t.Errorf("real session %s waked %d times in a single scan tick; expected 1 (scan tight-loop regression)", ShortID(real.ID), realWakes)
 	}
 
 	// Empty session: markEmpty ran (SQL-only path), so it should not

--- a/scripts/architecture.baseline
+++ b/scripts/architecture.baseline
@@ -1,5 +1,5 @@
 packages=58
 interfaces=76
-large_files=42
-set_mutators=102
+large_files=43
+set_mutators=103
 database_opens=8

--- a/scripts/architecture.baseline
+++ b/scripts/architecture.baseline
@@ -1,5 +1,5 @@
 packages=58
 interfaces=76
 large_files=43
-set_mutators=103
+set_mutators=104
 database_opens=8


### PR DESCRIPTION
Closes #989.

## What this PR does

Wires session-close events to the curator loop so per-session synthesis stops being a parallel model voice and becomes the curator's job.

Two delivery paths share one envelope and one notify call:

| Path | When it fires | Behavior on success | Behavior on failure |
|---|---|---|---|
| **Real-time** — \`EndSession\` callback | Immediately after the DB commit closes a session | Curator wake delivered; nothing else | Log Debug; summarizer scan picks it up later |
| **Backstop** — \`SummarizerWorker\` scan | Periodic scan finds an unsummarized session | Curator wake delivered; LLM call skipped | Falls through to existing LLM-direct path |

When the curator is disabled in config, both paths fall back to prior behavior — \`EndSession\` callback is a no-op, \`SummarizerWorker\` runs its existing LLM path. Backwards compatible.

## Architectural shape

\`fireCuratorSessionCloseWake\` is the single function both paths call. It builds an event-source envelope (\`Kind: \"event_source\"\`, \`source: \"session_close\"\`, event ID = session ID, \`metadata.reason\` = close reason) and delivers via \`loopRegistry.NotifyLoopByName(ctx, \"curator\", env)\`. The curator's prompt grows a **two-modes section** that dispatches on whether a notification block is present in the wake context:

- **Session-close wake** — read the session via \`archive_session_transcript\`, fold any new evidence into relevant dossiers. Per-subject deep work waits.
- **Self-paced wake** — the existing queue-driven dossier work.

## Side fix: curator capability surface

The curator's \`spec.Tags\` previously held only \`{curator}\` while \`tag_activate\` was excluded, so the curator couldn't actually call the tool families its prompt promised (\`archive_search\`, \`recall_fact\`, \`contact_lookup\`, documents tools). This was a latent bug — would have surfaced the first time the curator tried to write a dossier. Tags expanded to \`{curator, documents, archive, memory, contacts}\` so the boot-time set matches the prompt.

## Test coverage

- \`TestEndSession_FiresCloseCallback\` — callback invoked with right ID + reason
- \`TestEndSession_NoCallbackWhenUnset\` — zero-callback path is a clean no-op
- \`TestEndSession_PanickingCallbackDoesNotPoisonCaller\` — bad callback doesn't roll back the DB write
- \`TestBuildSessionCloseEnvelope_HappyPath\` — envelope shape locked in
- \`TestBuildSessionCloseEnvelope_EmptySessionID\` — invalid sessions rejected before reaching loop runtime
- \`TestCuratorPrompt_TwoModesPresent\` — prompt teaches both wake modes
- \`TestWorker_CuratorWakeShortCircuitsLLM\` — wake hook bypasses LLM; markEmpty still works for zero-message sessions
- \`TestWorker_CuratorWakeFailureFallsBackToLLM\` — wake failure falls through to LLM-direct path

\`just ci\` green. Architecture baseline bumped for two SetX mutators (\`SetSessionCloseCallback\`, \`SetCuratorWake\`) and \`new_stores.go\` crossing 500 lines for the wiring entry point.

## What's NOT in this PR

- **#993 (curator as knowledge custodian).** The wake delivery channel is this PR; what the curator does with the wake beyond writing session metadata — extracting facts, auditing existing facts, confidence decay/reinforcement — is the next PR.
- **Backpressure tuning.** Lossy behavior via the existing loop-notify queue is good enough for v1. If session-close storms become a real problem on production, batching can land as a separate PR.
- **SummarizerWorker deletion.** The worker is now a thin backstop + LLM fallback. Once the curator's run on production proves the wake path is reliable, the LLM path inside the worker can come out entirely and the worker shrinks to a scan-and-emit shim. That's the natural endgame but not this PR.

## Test plan

- [x] Unit tests above all pass under \`-race\`
- [x] \`just ci\` full gate green
- [ ] **Post-deploy on a non-prod host with curator enabled:** observe curator iterations after a real session closes. Expect to see the curator loop wake within \`curatorSessionCloseWakeTimeout\` (2s) of the close, prompt context includes the \`Loop notifications for this run\` block with the session_close event, and the next iteration writes session metadata.
- [ ] **Post-deploy:** verify summary-worker logs show the curator-wake path (Debug message) instead of LLM-direct calls when the curator is running.

## Related

- #986 — architecture umbrella (synthesis layer)
- #985 — curator scaffold (the loop this wires into)
- #993 — curator as knowledge custodian (next PR; rides this delivery channel)
- #984 — \`remember_fact\` noticing nudge (in-flight write path; complementary)