### PR TITLE
refactor(app): registration descriptor for core service loops

### DIFF
--- a/internal/app/core_service_loops.go
+++ b/internal/app/core_service_loops.go
@@ -1,0 +1,144 @@
+package app
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/nugget/thane-ai-agent/internal/platform/config"
+	"github.com/nugget/thane-ai-agent/internal/runtime/curator"
+	"github.com/nugget/thane-ai-agent/internal/runtime/ego"
+	looppkg "github.com/nugget/thane-ai-agent/internal/runtime/loop"
+	"github.com/nugget/thane-ai-agent/internal/runtime/metacognitive"
+)
+
+// coreServiceRegistration describes one model-facing core service loop
+// (ego, metacognitive, curator). The three loops share a parallel
+// construction shape — parse a config sub-struct, cache it on the App,
+// emit a durable definition spec, and attach runtime hooks at hydration
+// time — that previously lived as repeated three-way blocks across
+// buildLoopDefinitionBaseSpecs and hydrateLoopDefinitionSpec. Collapsing
+// them behind this descriptor means adding a fourth core loop is one new
+// entry in [coreServiceLoops] rather than an edit to every wiring site.
+//
+// The closures intentionally operate on *App: each loop's config has a
+// distinct type (ego.Config vs metacognitive.Config vs curator.Config),
+// so the descriptor can't hold a typed pointer. Instead ParseAndCache
+// writes the typed cache field (a.egoCfg, etc.) and the later closures
+// read it back. Metacognitive's extra hydration input (Opts with the
+// resolved state-file path) is absorbed by its Hydrate closure, keeping
+// the dispatcher uniform across all three.
+type coreServiceRegistration struct {
+	// Name is the durable loop definition name, matched against
+	// spec.Name during hydration and used to dedupe against
+	// operator-declared definitions.
+	Name string
+
+	// ConfigEnabled reports whether the loop's config block has
+	// Enabled set. A disabled loop with no operator-declared override
+	// is skipped entirely.
+	ConfigEnabled func(*config.Config) bool
+
+	// ParseAndCache parses the loop's config sub-struct and stores the
+	// typed result on the App for later DefinitionSpec/Hydrate reads.
+	ParseAndCache func(*App, *config.Config) error
+
+	// DefinitionSpec builds the persistable loop definition from the
+	// cached config. Only called after ParseAndCache has run.
+	DefinitionSpec func(*App) looppkg.Spec
+
+	// Hydrate attaches runtime-only hooks (task builder, post-iterate,
+	// etc.) to a stored definition spec. Returns an error when the
+	// cached config is missing — a definition can't be hydrated
+	// without the config that shapes its runtime behavior.
+	Hydrate func(*App, looppkg.Spec) (looppkg.Spec, error)
+}
+
+// coreServiceLoops is the registry of model-facing core service loops.
+// Order matches the historical append/parse sequence (metacognitive,
+// ego, curator) so the resulting base-definition ordering is unchanged.
+var coreServiceLoops = []coreServiceRegistration{
+	metacognitiveRegistration,
+	egoRegistration,
+	curatorRegistration,
+}
+
+// coreServiceLoopByName indexes coreServiceLoops for O(1) hydration
+// dispatch by definition name.
+var coreServiceLoopByName = func() map[string]coreServiceRegistration {
+	m := make(map[string]coreServiceRegistration, len(coreServiceLoops))
+	for _, reg := range coreServiceLoops {
+		m[reg.Name] = reg
+	}
+	return m
+}()
+
+var metacognitiveRegistration = coreServiceRegistration{
+	Name:          metacognitive.DefinitionName,
+	ConfigEnabled: func(c *config.Config) bool { return c.Metacognitive.Enabled },
+	ParseAndCache: func(a *App, c *config.Config) error {
+		cfg, err := metacognitive.ParseConfig(c.Metacognitive)
+		if err != nil {
+			return err
+		}
+		a.metacogCfg = &cfg
+		return nil
+	},
+	DefinitionSpec: func(a *App) looppkg.Spec {
+		return metacognitive.DefinitionSpec(*a.metacogCfg)
+	},
+	Hydrate: func(a *App, spec looppkg.Spec) (looppkg.Spec, error) {
+		if a.metacogCfg == nil {
+			return looppkg.Spec{}, fmt.Errorf("metacognitive definition requires metacognitive config")
+		}
+		stateFileName := filepath.Base(a.metacogCfg.StateFile)
+		stateFilePath := coreFilePath(a.cfg.Workspace.Path, stateFileName)
+		return metacognitive.HydrateSpec(spec, *a.metacogCfg, metacognitive.Opts{
+			StateFilePath: stateFilePath,
+			StateFileName: stateFileName,
+		}), nil
+	},
+}
+
+var egoRegistration = coreServiceRegistration{
+	Name:          ego.DefinitionName,
+	ConfigEnabled: func(c *config.Config) bool { return c.Ego.Enabled },
+	ParseAndCache: func(a *App, c *config.Config) error {
+		cfg, err := ego.ParseConfig(c.Ego)
+		if err != nil {
+			return err
+		}
+		a.egoCfg = &cfg
+		return nil
+	},
+	DefinitionSpec: func(a *App) looppkg.Spec {
+		return ego.DefinitionSpec(*a.egoCfg)
+	},
+	Hydrate: func(a *App, spec looppkg.Spec) (looppkg.Spec, error) {
+		if a.egoCfg == nil {
+			return looppkg.Spec{}, fmt.Errorf("ego definition requires ego config")
+		}
+		return ego.HydrateSpec(spec, *a.egoCfg), nil
+	},
+}
+
+var curatorRegistration = coreServiceRegistration{
+	Name:          curator.DefinitionName,
+	ConfigEnabled: func(c *config.Config) bool { return c.Curator.Enabled },
+	ParseAndCache: func(a *App, c *config.Config) error {
+		cfg, err := curator.ParseConfig(c.Curator)
+		if err != nil {
+			return err
+		}
+		a.curatorCfg = &cfg
+		return nil
+	},
+	DefinitionSpec: func(a *App) looppkg.Spec {
+		return curator.DefinitionSpec(*a.curatorCfg)
+	},
+	Hydrate: func(a *App, spec looppkg.Spec) (looppkg.Spec, error) {
+		if a.curatorCfg == nil {
+			return looppkg.Spec{}, fmt.Errorf("curator definition requires curator config")
+		}
+		return curator.HydrateSpec(spec, *a.curatorCfg), nil
+	},
+}

--- a/internal/app/loop_definition_hydration.go
+++ b/internal/app/loop_definition_hydration.go
@@ -3,15 +3,11 @@ package app
 import (
 	"context"
 	"fmt"
-	"path/filepath"
 	"strings"
 	"time"
 
 	"github.com/nugget/thane-ai-agent/internal/integrations/homeassistant"
-	"github.com/nugget/thane-ai-agent/internal/runtime/curator"
-	"github.com/nugget/thane-ai-agent/internal/runtime/ego"
 	looppkg "github.com/nugget/thane-ai-agent/internal/runtime/loop"
-	"github.com/nugget/thane-ai-agent/internal/runtime/metacognitive"
 )
 
 func (a *App) buildLoopDefinitionBaseSpecs() ([]looppkg.Spec, error) {
@@ -23,37 +19,23 @@ func (a *App) buildLoopDefinitionBaseSpecs() ([]looppkg.Spec, error) {
 	for _, spec := range builtInServiceDefinitionSpecs(a.cfg) {
 		baseDefinitions = appendMissingDefinition(baseDefinitions, seen, spec)
 	}
-	_, hasMetacogDefinition := seen[metacognitive.DefinitionName]
-	if a.cfg.Metacognitive.Enabled || hasMetacogDefinition {
-		metacogCfg, err := metacognitive.ParseConfig(a.cfg.Metacognitive)
-		if err != nil {
-			return nil, fmt.Errorf("metacognitive config: %w", err)
+	// Core model-facing service loops (ego, metacognitive, curator)
+	// share a parse-cache-emit shape captured by [coreServiceLoops].
+	// Parse+cache whenever the loop is enabled OR an operator declared
+	// its definition (so an override still gets a config to hydrate
+	// against); only auto-append the built-in definition when enabled
+	// and not already declared.
+	for _, reg := range coreServiceLoops {
+		_, hasDefinition := seen[reg.Name]
+		enabled := reg.ConfigEnabled(a.cfg)
+		if !enabled && !hasDefinition {
+			continue
 		}
-		a.metacogCfg = &metacogCfg
-		if a.cfg.Metacognitive.Enabled && !hasMetacogDefinition {
-			baseDefinitions = appendMissingDefinition(baseDefinitions, seen, metacognitive.DefinitionSpec(metacogCfg))
+		if err := reg.ParseAndCache(a, a.cfg); err != nil {
+			return nil, fmt.Errorf("%s config: %w", reg.Name, err)
 		}
-	}
-	_, hasEgoDefinition := seen[ego.DefinitionName]
-	if a.cfg.Ego.Enabled || hasEgoDefinition {
-		egoCfg, err := ego.ParseConfig(a.cfg.Ego)
-		if err != nil {
-			return nil, fmt.Errorf("ego config: %w", err)
-		}
-		a.egoCfg = &egoCfg
-		if a.cfg.Ego.Enabled && !hasEgoDefinition {
-			baseDefinitions = appendMissingDefinition(baseDefinitions, seen, ego.DefinitionSpec(egoCfg))
-		}
-	}
-	_, hasCuratorDefinition := seen[curator.DefinitionName]
-	if a.cfg.Curator.Enabled || hasCuratorDefinition {
-		curatorCfg, err := curator.ParseConfig(a.cfg.Curator)
-		if err != nil {
-			return nil, fmt.Errorf("curator config: %w", err)
-		}
-		a.curatorCfg = &curatorCfg
-		if a.cfg.Curator.Enabled && !hasCuratorDefinition {
-			baseDefinitions = appendMissingDefinition(baseDefinitions, seen, curator.DefinitionSpec(curatorCfg))
+		if enabled && !hasDefinition {
+			baseDefinitions = appendMissingDefinition(baseDefinitions, seen, reg.DefinitionSpec(a))
 		}
 	}
 	return baseDefinitions, nil
@@ -63,30 +45,19 @@ func (a *App) hydrateLoopDefinitionSpec(spec looppkg.Spec) (looppkg.Spec, error)
 	if a == nil {
 		return spec, nil
 	}
-	switch strings.TrimSpace(spec.Name) {
-	case metacognitive.DefinitionName:
-		if a.metacogCfg == nil {
-			return looppkg.Spec{}, fmt.Errorf("metacognitive definition requires metacognitive config")
+	name := strings.TrimSpace(spec.Name)
+	// Core model-facing service loops dispatch through their shared
+	// registration descriptor (see [coreServiceLoops]); each one's
+	// Hydrate closure absorbs its specifics (e.g. metacognitive's
+	// resolved state-file Opts) so this site stays uniform.
+	if reg, ok := coreServiceLoopByName[name]; ok {
+		runtimeSpec, err := reg.Hydrate(a, spec)
+		if err != nil {
+			return looppkg.Spec{}, err
 		}
-		stateFileName := filepath.Base(a.metacogCfg.StateFile)
-		stateFilePath := coreFilePath(a.cfg.Workspace.Path, stateFileName)
-		runtimeSpec := metacognitive.HydrateSpec(spec, *a.metacogCfg, metacognitive.Opts{
-			StateFilePath: stateFilePath,
-			StateFileName: stateFileName,
-		})
 		return a.hydrateLoopOutputs(runtimeSpec)
-	case ego.DefinitionName:
-		if a.egoCfg == nil {
-			return looppkg.Spec{}, fmt.Errorf("ego definition requires ego config")
-		}
-		runtimeSpec := ego.HydrateSpec(spec, *a.egoCfg)
-		return a.hydrateLoopOutputs(runtimeSpec)
-	case curator.DefinitionName:
-		if a.curatorCfg == nil {
-			return looppkg.Spec{}, fmt.Errorf("curator definition requires curator config")
-		}
-		runtimeSpec := curator.HydrateSpec(spec, *a.curatorCfg)
-		return a.hydrateLoopOutputs(runtimeSpec)
+	}
+	switch name {
 	case unifiPollerDefinitionName:
 		if a.unifiPoller == nil {
 			return looppkg.Spec{}, fmt.Errorf("%s definition requires UniFi poller runtime", unifiPollerDefinitionName)

--- a/internal/app/loop_definition_hydration_test.go
+++ b/internal/app/loop_definition_hydration_test.go
@@ -14,8 +14,29 @@ import (
 	"github.com/nugget/thane-ai-agent/internal/integrations/media"
 	"github.com/nugget/thane-ai-agent/internal/integrations/unifi"
 	"github.com/nugget/thane-ai-agent/internal/platform/config"
+	"github.com/nugget/thane-ai-agent/internal/runtime/curator"
+	"github.com/nugget/thane-ai-agent/internal/runtime/ego"
 	looppkg "github.com/nugget/thane-ai-agent/internal/runtime/loop"
+	"github.com/nugget/thane-ai-agent/internal/runtime/metacognitive"
 )
+
+// coreServiceTestConfig returns a config with all three model-facing
+// core service loops enabled and valid sleep envelopes, mirroring what
+// applyDefaults stamps in production (which the app-package test can't
+// call directly since it's unexported in the config package).
+func coreServiceTestConfig() *config.Config {
+	return &config.Config{
+		Metacognitive: config.MetacognitiveConfig{
+			Enabled: true, MinSleep: "2m", MaxSleep: "30m", DefaultSleep: "10m",
+		},
+		Ego: config.EgoConfig{
+			Enabled: true, MinSleep: "30m", MaxSleep: "24h", DefaultSleep: "6h",
+		},
+		Curator: config.CuratorConfig{
+			Enabled: true, MinSleep: "15m", MaxSleep: "12h", DefaultSleep: "1h",
+		},
+	}
+}
 
 type testDeviceLocator struct {
 	locations []unifi.DeviceLocation
@@ -176,6 +197,109 @@ func TestBuildLoopDefinitionBaseSpecs_SkipsDuplicateBuiltinNames(t *testing.T) {
 	}
 	if count != 1 {
 		t.Fatalf("mqtt definition count = %d, want 1", count)
+	}
+}
+
+// TestBuildLoopDefinitionBaseSpecs_AppendsCoreServiceLoops covers the
+// coreServiceLoops registration path: enabled ego/metacognitive/curator
+// definitions are appended and their parsed configs cached for later
+// hydration. Replaces the assertions the three hand-written blocks used
+// to carry before #988 collapsed them behind one descriptor slice.
+func TestBuildLoopDefinitionBaseSpecs_AppendsCoreServiceLoops(t *testing.T) {
+	t.Parallel()
+
+	a := &App{cfg: coreServiceTestConfig()}
+	specs, err := a.buildLoopDefinitionBaseSpecs()
+	if err != nil {
+		t.Fatalf("buildLoopDefinitionBaseSpecs: %v", err)
+	}
+
+	want := map[string]bool{
+		metacognitive.DefinitionName: false,
+		ego.DefinitionName:           false,
+		curator.DefinitionName:       false,
+	}
+	for _, spec := range specs {
+		if _, ok := want[spec.Name]; ok {
+			want[spec.Name] = true
+		}
+	}
+	for name, found := range want {
+		if !found {
+			t.Errorf("core service definition %q missing from base specs", name)
+		}
+	}
+
+	// Each enabled core loop must cache its parsed config so
+	// hydrateLoopDefinitionSpec can attach runtime hooks later.
+	if a.metacogCfg == nil {
+		t.Error("metacogCfg not cached after build")
+	}
+	if a.egoCfg == nil {
+		t.Error("egoCfg not cached after build")
+	}
+	if a.curatorCfg == nil {
+		t.Error("curatorCfg not cached after build")
+	}
+}
+
+// TestCoreServiceLoopByNameMatchesSlice guards the invariant that the
+// hydration dispatch index stays in lockstep with the registration
+// slice — and that all three model-facing core loops are registered.
+func TestCoreServiceLoopByNameMatchesSlice(t *testing.T) {
+	t.Parallel()
+
+	if len(coreServiceLoopByName) != len(coreServiceLoops) {
+		t.Fatalf("index size %d != slice size %d", len(coreServiceLoopByName), len(coreServiceLoops))
+	}
+	for _, reg := range coreServiceLoops {
+		indexed, ok := coreServiceLoopByName[reg.Name]
+		if !ok {
+			t.Errorf("registration %q missing from dispatch index", reg.Name)
+			continue
+		}
+		if indexed.Name != reg.Name {
+			t.Errorf("index[%q].Name = %q", reg.Name, indexed.Name)
+		}
+	}
+	for _, name := range []string{ego.DefinitionName, metacognitive.DefinitionName, curator.DefinitionName} {
+		if _, ok := coreServiceLoopByName[name]; !ok {
+			t.Errorf("core loop %q not registered in coreServiceLoops", name)
+		}
+	}
+}
+
+// TestCoreServiceRegistrationHydrate exercises each registration's
+// Hydrate closure directly: a missing cached config is a hard error,
+// and a hydrated spec carries the runtime task builder. Driving the
+// closures (rather than hydrateLoopDefinitionSpec) keeps the test
+// focused on the #988 dispatch contract without pulling in the
+// document-output hydration machinery.
+func TestCoreServiceRegistrationHydrate(t *testing.T) {
+	t.Parallel()
+
+	cfg := coreServiceTestConfig()
+	for _, reg := range coreServiceLoops {
+		t.Run(reg.Name, func(t *testing.T) {
+			// Missing cached config: a definition can't hydrate
+			// without the config that shapes its runtime behavior.
+			bare := &App{cfg: cfg}
+			if _, err := reg.Hydrate(bare, looppkg.Spec{Name: reg.Name}); err == nil {
+				t.Fatalf("Hydrate without cached config: expected error, got nil")
+			}
+
+			a := &App{cfg: cfg}
+			if err := reg.ParseAndCache(a, cfg); err != nil {
+				t.Fatalf("ParseAndCache: %v", err)
+			}
+			spec, err := reg.Hydrate(a, looppkg.Spec{Name: reg.Name})
+			if err != nil {
+				t.Fatalf("Hydrate: %v", err)
+			}
+			if spec.TaskBuilder == nil {
+				t.Error("Hydrate did not attach TaskBuilder")
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

Refs #988. The three model-facing core service loops — ego, metacognitive, curator — shared a parallel parse-cache-emit-hydrate shape repeated as three-way blocks in `buildLoopDefinitionBaseSpecs` and a three-case switch in `hydrateLoopDefinitionSpec`. Adding a fourth core loop meant editing every site.

This collapses the **app-package** wiring behind a `coreServiceRegistration` descriptor + `coreServiceLoops` slice (new `core_service_loops.go`):

- **`buildLoopDefinitionBaseSpecs`**: three hand-written blocks → one loop over the slice. Same semantics — parse-and-cache when the loop is enabled OR an operator declared its definition; auto-append the built-in definition only when enabled and not already declared.
- **`hydrateLoopDefinitionSpec`**: three switch cases → one O(1) lookup in `coreServiceLoopByName` dispatching to each loop's `Hydrate` closure. Metacognitive's extra `Opts` (resolved state-file path) is absorbed by its closure, so the dispatch site stays uniform.

Adding a fourth core loop is now **one new descriptor entry** in the app wiring.

## Behavior preservation

- Slice order matches the historical parse/append sequence (metacognitive, ego, curator).
- Config-error strings are byte-identical (`"<name> config: %w"`).
- No new dependency on the `loop` package; descriptors live in `app`.
- Architecture baseline unchanged (large_files 43/43, set_mutators 104/104).

## Tests

The core-service-loop path previously had **no app-level coverage** (existing tests only exercised the pollers). Added:

- `TestBuildLoopDefinitionBaseSpecs_AppendsCoreServiceLoops` — all three definitions appended + parsed configs cached.
- `TestCoreServiceLoopByNameMatchesSlice` — dispatch index stays in lockstep with the slice; all three loops registered.
- `TestCoreServiceRegistrationHydrate` — missing-config is a hard error; a hydrated spec carries the runtime `TaskBuilder`.

## Out of scope (deferred → #999)

The config-package `applyDefaults` blocks and `validate{Metacognitive,Ego,Curator}` remain three-way. Folding those needs a shared embedded `ServiceLoopConfig` type (the three structs are structurally identical) — a config-type change with its own blast radius, and the config package must not import `app`. Filed as #999 to complete the "fourth loop = one entry" goal on the config side. This PR therefore uses `Refs #988`, not `Closes`.

## Test plan

- [x] `go build ./internal/app/...`
- [x] `go test` for app + ego/metacognitive/curator/config packages
- [x] New tests pass
- [x] `just ci` green locally
- [x] Architecture baseline unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)