### PR TITLE
refactor(tools): consolidate tool-arg helpers into internal/tools/toolargs

### DIFF
--- a/internal/tools/loop_definition_mutation_tools.go
+++ b/internal/tools/loop_definition_mutation_tools.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	looppkg "github.com/nugget/thane-ai-agent/internal/runtime/loop"
+	"github.com/nugget/thane-ai-agent/internal/tools/toolargs"
 )
 
 func (r *Registry) handleLoopDefinitionSet(ctx context.Context, args map[string]any) (string, error) {
@@ -56,7 +57,7 @@ func (r *Registry) handleLoopDefinitionDelete(ctx context.Context, args map[stri
 	if r.loopDefinitionRegistry == nil {
 		return "", fmt.Errorf("loop definition registry not configured")
 	}
-	name := ldStringArg(args, "name")
+	name := toolargs.TrimmedString(args, "name")
 	if name == "" {
 		return "", fmt.Errorf("name is required")
 	}
@@ -121,7 +122,7 @@ func (r *Registry) handleLoopDefinitionSetPolicy(ctx context.Context, args map[s
 	if err != nil {
 		return "", err
 	}
-	name := ldStringArg(args, "name")
+	name := toolargs.TrimmedString(args, "name")
 	if name == "" {
 		return "", fmt.Errorf("name is required")
 	}
@@ -129,7 +130,7 @@ func (r *Registry) handleLoopDefinitionSetPolicy(ctx context.Context, args map[s
 		return "", (&looppkg.UnknownDefinitionError{Name: name})
 	}
 	clearOverride, _ := args["clear_override"].(bool)
-	stateRaw := ldStringArg(args, "state")
+	stateRaw := toolargs.TrimmedString(args, "state")
 	if clearOverride && stateRaw != "" {
 		return "", fmt.Errorf("clear_override cannot be combined with state")
 	}
@@ -153,7 +154,7 @@ func (r *Registry) handleLoopDefinitionSetPolicy(ctx context.Context, args map[s
 		}
 		policy := looppkg.DefinitionPolicy{
 			State:     state,
-			Reason:    ldStringArg(args, "reason"),
+			Reason:    toolargs.TrimmedString(args, "reason"),
 			UpdatedAt: time.Now().UTC(),
 		}
 		if r.persistLoopDefinitionPolicy != nil {
@@ -190,7 +191,7 @@ func (r *Registry) handleLoopDefinitionLaunch(ctx context.Context, args map[stri
 	if r.launchLoopDefinition == nil {
 		return "", fmt.Errorf("loop definition launch is not configured")
 	}
-	name := ldStringArg(args, "name")
+	name := toolargs.TrimmedString(args, "name")
 	if name == "" {
 		return "", fmt.Errorf("name is required")
 	}

--- a/internal/tools/loop_definition_read_tools.go
+++ b/internal/tools/loop_definition_read_tools.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	looppkg "github.com/nugget/thane-ai-agent/internal/runtime/loop"
+	"github.com/nugget/thane-ai-agent/internal/tools/toolargs"
 )
 
 type loopDefinitionLintEffective struct {
@@ -58,14 +59,14 @@ func (r *Registry) handleLoopDefinitionList(_ context.Context, args map[string]a
 	if err != nil {
 		return "", err
 	}
-	query := strings.ToLower(ldStringArg(args, "query"))
-	source := ldStringArg(args, "source")
-	operation := ldStringArg(args, "operation")
-	completion := ldStringArg(args, "completion")
-	policyState := ldStringArg(args, "policy_state")
-	runtimeState := strings.ToLower(ldStringArg(args, "runtime_state"))
-	eligibleFilter := ldStringArg(args, "eligible")
-	limit := ldIntArg(args, "limit")
+	query := strings.ToLower(toolargs.TrimmedString(args, "query"))
+	source := toolargs.TrimmedString(args, "source")
+	operation := toolargs.TrimmedString(args, "operation")
+	completion := toolargs.TrimmedString(args, "completion")
+	policyState := toolargs.TrimmedString(args, "policy_state")
+	runtimeState := strings.ToLower(toolargs.TrimmedString(args, "runtime_state"))
+	eligibleFilter := toolargs.TrimmedString(args, "eligible")
+	limit := toolargs.Int(args, "limit")
 	if limit <= 0 {
 		limit = defaultLoopDefinitionListLimit
 	}
@@ -147,7 +148,7 @@ func (r *Registry) handleLoopDefinitionGet(_ context.Context, args map[string]an
 	if err != nil {
 		return "", err
 	}
-	name := ldStringArg(args, "name")
+	name := toolargs.TrimmedString(args, "name")
 	if name == "" {
 		return "", fmt.Errorf("name is required")
 	}

--- a/internal/tools/loop_definition_tool_helpers.go
+++ b/internal/tools/loop_definition_tool_helpers.go
@@ -9,22 +9,6 @@ import (
 	looppkg "github.com/nugget/thane-ai-agent/internal/runtime/loop"
 )
 
-func ldStringArg(args map[string]any, key string) string {
-	value, _ := args[key].(string)
-	return strings.TrimSpace(value)
-}
-
-func ldIntArg(args map[string]any, key string) int {
-	switch v := args[key].(type) {
-	case int:
-		return v
-	case float64:
-		return int(v)
-	default:
-		return 0
-	}
-}
-
 func ldMarshalToolJSON(v any) (string, error) {
 	data, err := json.Marshal(v)
 	if err != nil {

--- a/internal/tools/loop_intent_tools.go
+++ b/internal/tools/loop_intent_tools.go
@@ -9,6 +9,7 @@ import (
 	"github.com/nugget/thane-ai-agent/internal/model/router"
 	looppkg "github.com/nugget/thane-ai-agent/internal/runtime/loop"
 	"github.com/nugget/thane-ai-agent/internal/state/documents"
+	"github.com/nugget/thane-ai-agent/internal/tools/toolargs"
 )
 
 // LoopIntentToolDeps wires the loop-definition registry, document
@@ -115,15 +116,15 @@ func (r *Registry) handleThaneCreateContainer(ctx context.Context, args map[stri
 		return "", fmt.Errorf("thane_create_container not configured: ConfigureLoopIntentTools must be called at startup")
 	}
 
-	name := strings.TrimSpace(ldStringArg(args, "name"))
+	name := strings.TrimSpace(toolargs.TrimmedString(args, "name"))
 	if name == "" {
 		return "", fmt.Errorf("name is required")
 	}
-	intent := strings.TrimSpace(ldStringArg(args, "intent"))
+	intent := strings.TrimSpace(toolargs.TrimmedString(args, "intent"))
 	if intent == "" {
 		return "", fmt.Errorf("intent is required")
 	}
-	parentName := strings.TrimSpace(ldStringArg(args, "parent_name"))
+	parentName := strings.TrimSpace(toolargs.TrimmedString(args, "parent_name"))
 	replace, _ := args["replace"].(bool)
 
 	var tags []string

--- a/internal/tools/loop_runtime_tools.go
+++ b/internal/tools/loop_runtime_tools.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/nugget/thane-ai-agent/internal/platform/logging"
 	looppkg "github.com/nugget/thane-ai-agent/internal/runtime/loop"
+	"github.com/nugget/thane-ai-agent/internal/tools/toolargs"
 )
 
 const (
@@ -162,10 +163,10 @@ func (r *Registry) handleLoopStatus(_ context.Context, args map[string]any) (str
 	if r.liveLoopRegistry == nil {
 		return "", fmt.Errorf("live loop registry is not configured")
 	}
-	query := strings.ToLower(ldStringArg(args, "query"))
-	state := strings.ToLower(ldStringArg(args, "state"))
-	operation := looppkg.Operation(ldStringArg(args, "operation"))
-	limit := clampLoopListLimit(ldIntArg(args, "limit"), defaultLoopStatusLimit, maxLoopStatusLimit)
+	query := strings.ToLower(toolargs.TrimmedString(args, "query"))
+	state := strings.ToLower(toolargs.TrimmedString(args, "state"))
+	operation := looppkg.Operation(toolargs.TrimmedString(args, "operation"))
+	limit := clampLoopListLimit(toolargs.Int(args, "limit"), defaultLoopStatusLimit, maxLoopStatusLimit)
 
 	statuses := r.liveLoopRegistry.Statuses()
 	filtered := make([]loopStatusView, 0, len(statuses))
@@ -235,7 +236,7 @@ func (r *Registry) handleSetNextSleep(ctx context.Context, args map[string]any) 
 	if applied > status.Config.SleepMax {
 		applied = status.Config.SleepMax
 	}
-	reason := ldStringArg(args, "reason")
+	reason := toolargs.TrimmedString(args, "reason")
 	clamped := applied != requested
 	live.SetNextSleep(applied)
 
@@ -323,8 +324,8 @@ func (r *Registry) handleStopLoop(_ context.Context, args map[string]any) (strin
 	if r.liveLoopRegistry == nil {
 		return "", fmt.Errorf("live loop registry is not configured")
 	}
-	loopID := ldStringArg(args, "loop_id")
-	name := ldStringArg(args, "name")
+	loopID := toolargs.TrimmedString(args, "loop_id")
+	name := toolargs.TrimmedString(args, "name")
 	if loopID == "" && name == "" {
 		return "", fmt.Errorf("loop_id or name is required")
 	}

--- a/internal/tools/loop_subscription_tools.go
+++ b/internal/tools/loop_subscription_tools.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	looppkg "github.com/nugget/thane-ai-agent/internal/runtime/loop"
+	"github.com/nugget/thane-ai-agent/internal/tools/toolargs"
 )
 
 // registerUpdateEntitySubscriptions wires the external CRUD tool for
@@ -85,7 +86,7 @@ func (r *Registry) handleUpdateEntitySubscriptions(ctx context.Context, args map
 		return "", fmt.Errorf("update_entity_subscriptions not configured: requires loop definition registry")
 	}
 
-	name := strings.TrimSpace(ldStringArg(args, "name"))
+	name := strings.TrimSpace(toolargs.TrimmedString(args, "name"))
 	if name == "" {
 		return "", fmt.Errorf("name is required")
 	}

--- a/internal/tools/message_tools.go
+++ b/internal/tools/message_tools.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/nugget/thane-ai-agent/internal/channels/messages"
 	looppkg "github.com/nugget/thane-ai-agent/internal/runtime/loop"
+	"github.com/nugget/thane-ai-agent/internal/tools/toolargs"
 )
 
 // MessageToolDeps wires the shared envelope bus into the tool registry.
@@ -85,7 +86,7 @@ func (r *Registry) handleRequestCoreAttention(ctx context.Context, args map[stri
 	if r.messageBus == nil {
 		return "", fmt.Errorf("message bus is not configured")
 	}
-	concern := strings.TrimSpace(ldStringArg(args, "concern"))
+	concern := strings.TrimSpace(toolargs.TrimmedString(args, "concern"))
 	if concern == "" {
 		return "", fmt.Errorf("concern is required")
 	}
@@ -97,8 +98,8 @@ func (r *Registry) handleRequestCoreAttention(ctx context.Context, args map[stri
 	payload := messages.LoopNotifyPayload{
 		Kind:            "core_attention_request",
 		Concern:         concern,
-		SuggestedAction: strings.TrimSpace(ldStringArg(args, "suggested_action")),
-		Context:         strings.TrimSpace(ldStringArg(args, "context")),
+		SuggestedAction: strings.TrimSpace(toolargs.TrimmedString(args, "suggested_action")),
+		Context:         strings.TrimSpace(toolargs.TrimmedString(args, "context")),
 		ForceSupervisor: true,
 	}
 
@@ -226,7 +227,7 @@ func senderIdentityFromContext(ctx context.Context) messages.Identity {
 }
 
 func messagePriorityArg(args map[string]any) messages.Priority {
-	switch strings.TrimSpace(ldStringArg(args, "priority")) {
+	switch strings.TrimSpace(toolargs.TrimmedString(args, "priority")) {
 	case "", "normal":
 		return messages.PriorityNormal
 	case "low":

--- a/internal/tools/model_registry_policy_tools.go
+++ b/internal/tools/model_registry_policy_tools.go
@@ -7,18 +7,19 @@ import (
 	"time"
 
 	"github.com/nugget/thane-ai-agent/internal/model/fleet"
+	"github.com/nugget/thane-ai-agent/internal/tools/toolargs"
 )
 
 func (r *Registry) handleModelResourceSetPolicy(_ context.Context, args map[string]any) (string, error) {
 	if r.modelRegistry == nil {
 		return "", fmt.Errorf("model registry not configured")
 	}
-	resourceID := strings.TrimSpace(mrStringArg(args, "resource"))
+	resourceID := strings.TrimSpace(toolargs.String(args, "resource"))
 	if resourceID == "" {
 		return "", fmt.Errorf("resource is required")
 	}
-	clearOverride := mrBoolArg(args, "clear_override")
-	stateRaw := strings.TrimSpace(mrStringArg(args, "state"))
+	clearOverride := toolargs.Bool(args, "clear_override")
+	stateRaw := strings.TrimSpace(toolargs.String(args, "state"))
 	if clearOverride && stateRaw != "" {
 		return "", fmt.Errorf("clear_override cannot be combined with state")
 	}
@@ -60,7 +61,7 @@ func (r *Registry) handleModelResourceSetPolicy(_ context.Context, args map[stri
 	}
 	policy := fleet.ResourcePolicy{
 		State:     state,
-		Reason:    strings.TrimSpace(mrStringArg(args, "reason")),
+		Reason:    strings.TrimSpace(toolargs.String(args, "reason")),
 		UpdatedAt: time.Now().UTC(),
 	}
 	if r.persistModelRegistryResourcePolicy != nil {
@@ -94,13 +95,13 @@ func (r *Registry) handleModelDeploymentSetPolicy(_ context.Context, args map[st
 	if r.modelRegistry == nil {
 		return "", fmt.Errorf("model registry not configured")
 	}
-	deploymentID := strings.TrimSpace(mrStringArg(args, "deployment"))
+	deploymentID := strings.TrimSpace(toolargs.String(args, "deployment"))
 	if deploymentID == "" {
 		return "", fmt.Errorf("deployment is required")
 	}
-	clearOverride := mrBoolArg(args, "clear_override")
-	stateRaw := strings.TrimSpace(mrStringArg(args, "state"))
-	_, hasRoutable := mrBoolArgOK(args, "routable")
+	clearOverride := toolargs.Bool(args, "clear_override")
+	stateRaw := strings.TrimSpace(toolargs.String(args, "state"))
+	_, hasRoutable := toolargs.BoolOK(args, "routable")
 	if clearOverride && (stateRaw != "" || hasRoutable) {
 		return "", fmt.Errorf("clear_override cannot be combined with state or routable")
 	}
@@ -146,10 +147,10 @@ func (r *Registry) handleModelDeploymentSetPolicy(_ context.Context, args map[st
 	}
 	policy := fleet.DeploymentPolicy{
 		State:     state,
-		Reason:    strings.TrimSpace(mrStringArg(args, "reason")),
+		Reason:    strings.TrimSpace(toolargs.String(args, "reason")),
 		UpdatedAt: time.Now().UTC(),
 	}
-	if value, ok := mrBoolArgOK(args, "routable"); ok {
+	if value, ok := toolargs.BoolOK(args, "routable"); ok {
 		policy.Routable = &value
 	}
 	if r.persistModelRegistryPolicy != nil {

--- a/internal/tools/model_registry_read_tools.go
+++ b/internal/tools/model_registry_read_tools.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/nugget/thane-ai-agent/internal/model/fleet"
 	routepkg "github.com/nugget/thane-ai-agent/internal/model/router"
+	"github.com/nugget/thane-ai-agent/internal/tools/toolargs"
 )
 
 func (r *Registry) handleModelRegistrySummary(_ context.Context, _ map[string]any) (string, error) {
@@ -98,7 +99,7 @@ func (r *Registry) handleModelRegistryList(_ context.Context, args map[string]an
 		return "", err
 	}
 
-	kind := strings.ToLower(strings.TrimSpace(mrStringArg(args, "kind")))
+	kind := strings.ToLower(strings.TrimSpace(toolargs.String(args, "kind")))
 	if kind == "" {
 		kind = "deployments"
 	}
@@ -106,18 +107,18 @@ func (r *Registry) handleModelRegistryList(_ context.Context, args map[string]an
 		return "", fmt.Errorf("kind must be one of [\"deployments\" \"resources\"]")
 	}
 
-	limit := mrIntArg(args, "limit", defaultModelRegistryListLimit)
+	limit := toolargs.IntOr(args, "limit", defaultModelRegistryListLimit)
 	if limit <= 0 {
 		limit = defaultModelRegistryListLimit
 	}
 	if limit > maxModelRegistryListLimit {
 		limit = maxModelRegistryListLimit
 	}
-	query := strings.ToLower(strings.TrimSpace(mrStringArg(args, "query")))
-	provider := strings.ToLower(strings.TrimSpace(mrStringArg(args, "provider")))
-	resource := strings.TrimSpace(mrStringArg(args, "resource"))
-	policyState := strings.ToLower(strings.TrimSpace(mrStringArg(args, "policy_state")))
-	source := strings.ToLower(strings.TrimSpace(mrStringArg(args, "source")))
+	query := strings.ToLower(strings.TrimSpace(toolargs.String(args, "query")))
+	provider := strings.ToLower(strings.TrimSpace(toolargs.String(args, "provider")))
+	resource := strings.TrimSpace(toolargs.String(args, "resource"))
+	policyState := strings.ToLower(strings.TrimSpace(toolargs.String(args, "policy_state")))
+	source := strings.ToLower(strings.TrimSpace(toolargs.String(args, "source")))
 
 	if kind == "resources" {
 		items := make([]modelRegistryResourceView, 0, len(snapshot.Resources))
@@ -131,10 +132,10 @@ func (r *Registry) handleModelRegistryList(_ context.Context, args map[string]an
 			if policyState != "" && string(res.PolicyState) != policyState {
 				continue
 			}
-			if mrHasBoolArg(args, "supports_tools") && res.SupportsTools != mrBoolArg(args, "supports_tools") {
+			if toolargs.HasBool(args, "supports_tools") && res.SupportsTools != toolargs.Bool(args, "supports_tools") {
 				continue
 			}
-			if mrHasBoolArg(args, "supports_images") && res.SupportsImages != mrBoolArg(args, "supports_images") {
+			if toolargs.HasBool(args, "supports_images") && res.SupportsImages != toolargs.Bool(args, "supports_images") {
 				continue
 			}
 			if query != "" && !matchesResourceQuery(res, query) {
@@ -169,13 +170,13 @@ func (r *Registry) handleModelRegistryList(_ context.Context, args map[string]an
 		if source != "" && string(dep.Source) != source {
 			continue
 		}
-		if mrHasBoolArg(args, "supports_tools") && dep.SupportsTools != mrBoolArg(args, "supports_tools") {
+		if toolargs.HasBool(args, "supports_tools") && dep.SupportsTools != toolargs.Bool(args, "supports_tools") {
 			continue
 		}
-		if mrHasBoolArg(args, "supports_images") && dep.SupportsImages != mrBoolArg(args, "supports_images") {
+		if toolargs.HasBool(args, "supports_images") && dep.SupportsImages != toolargs.Bool(args, "supports_images") {
 			continue
 		}
-		if mrHasBoolArg(args, "routable") && dep.Routable != mrBoolArg(args, "routable") {
+		if toolargs.HasBool(args, "routable") && dep.Routable != toolargs.Bool(args, "routable") {
 			continue
 		}
 		if query != "" && !matchesDeploymentQuery(dep, query) {
@@ -202,8 +203,8 @@ func (r *Registry) handleModelRegistryGet(_ context.Context, args map[string]any
 		return "", err
 	}
 
-	resourceID := strings.TrimSpace(mrStringArg(args, "resource"))
-	deploymentID := strings.TrimSpace(mrStringArg(args, "deployment"))
+	resourceID := strings.TrimSpace(toolargs.String(args, "resource"))
+	deploymentID := strings.TrimSpace(toolargs.String(args, "deployment"))
 	if resourceID == "" && deploymentID == "" {
 		return "", fmt.Errorf("resource or deployment is required")
 	}

--- a/internal/tools/model_registry_tool_helpers.go
+++ b/internal/tools/model_registry_tool_helpers.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/nugget/thane-ai-agent/internal/model/fleet"
 	routepkg "github.com/nugget/thane-ai-agent/internal/model/router"
+	"github.com/nugget/thane-ai-agent/internal/tools/toolargs"
 )
 
 func matchesResourceQuery(res fleet.RegistryResourceSnapshot, query string) bool {
@@ -59,83 +60,6 @@ func mrMarshalToolJSON(v any) (string, error) {
 	return string(out), nil
 }
 
-func mrStringArg(args map[string]any, key string) string {
-	if v, ok := args[key].(string); ok {
-		return v
-	}
-	return ""
-}
-
-func mrIntArg(args map[string]any, key string, def int) int {
-	if v, ok := mrIntArgOK(args, key); ok {
-		return v
-	}
-	return def
-}
-
-func mrIntArgOK(args map[string]any, key string) (int, bool) {
-	raw, ok := args[key]
-	if !ok || raw == nil {
-		return 0, false
-	}
-	switch v := raw.(type) {
-	case int:
-		return v, true
-	case int32:
-		return int(v), true
-	case int64:
-		return int(v), true
-	case float64:
-		if v != float64(int(v)) {
-			return 0, false
-		}
-		return int(v), true
-	case json.Number:
-		n, err := v.Int64()
-		if err != nil {
-			return 0, false
-		}
-		return int(n), true
-	case string:
-		n, err := strconv.Atoi(strings.TrimSpace(v))
-		if err != nil {
-			return 0, false
-		}
-		return n, true
-	default:
-		return 0, false
-	}
-}
-
-func mrBoolArg(args map[string]any, key string) bool {
-	v, _ := mrBoolArgOK(args, key)
-	return v
-}
-
-func mrHasBoolArg(args map[string]any, key string) bool {
-	_, ok := mrBoolArgOK(args, key)
-	return ok
-}
-
-func mrBoolArgOK(args map[string]any, key string) (bool, bool) {
-	raw, ok := args[key]
-	if !ok || raw == nil {
-		return false, false
-	}
-	switch v := raw.(type) {
-	case bool:
-		return v, true
-	case string:
-		switch strings.ToLower(strings.TrimSpace(v)) {
-		case "true":
-			return true, true
-		case "false":
-			return false, true
-		}
-	}
-	return false, false
-}
-
 func mrExtractRouteHints(args map[string]any) map[string]string {
 	hints := make(map[string]string)
 	if raw, ok := args["hints"].(map[string]any); ok {
@@ -147,22 +71,22 @@ func mrExtractRouteHints(args map[string]any) map[string]string {
 			hints[key] = fmt.Sprint(value)
 		}
 	}
-	if mission := strings.TrimSpace(mrStringArg(args, "mission")); mission != "" {
+	if mission := strings.TrimSpace(toolargs.String(args, "mission")); mission != "" {
 		hints[routepkg.FactorMission] = mission
 	}
-	if channel := strings.TrimSpace(mrStringArg(args, "channel")); channel != "" {
+	if channel := strings.TrimSpace(toolargs.String(args, "channel")); channel != "" {
 		hints[routepkg.FactorChannel] = channel
 	}
-	if pref := strings.TrimSpace(mrStringArg(args, "model_preference")); pref != "" {
+	if pref := strings.TrimSpace(toolargs.String(args, "model_preference")); pref != "" {
 		hints[routepkg.FactorModelPreference] = pref
 	}
-	if v, ok := mrIntArgOK(args, "quality_floor"); ok && v > 0 {
+	if v, ok := toolargs.IntOK(args, "quality_floor"); ok && v > 0 {
 		hints[routepkg.FactorQualityFloor] = strconv.Itoa(v)
 	}
-	if v, ok := mrBoolArgOK(args, "local_only"); ok {
+	if v, ok := toolargs.BoolOK(args, "local_only"); ok {
 		hints[routepkg.FactorLocalOnly] = strconv.FormatBool(v)
 	}
-	if v, ok := mrBoolArgOK(args, "prefer_speed"); ok {
+	if v, ok := toolargs.BoolOK(args, "prefer_speed"); ok {
 		hints[routepkg.FactorPreferSpeed] = strconv.FormatBool(v)
 	}
 	if len(hints) == 0 {

--- a/internal/tools/model_route_tools.go
+++ b/internal/tools/model_route_tools.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	routepkg "github.com/nugget/thane-ai-agent/internal/model/router"
+	"github.com/nugget/thane-ai-agent/internal/tools/toolargs"
 )
 
 func (r *Registry) handleModelRouteExplain(_ context.Context, args map[string]any) (string, error) {
@@ -13,11 +14,11 @@ func (r *Registry) handleModelRouteExplain(_ context.Context, args map[string]an
 		return "", fmt.Errorf("model registry router not configured")
 	}
 
-	toolCount, ok := mrIntArgOK(args, "tool_count")
+	toolCount, ok := toolargs.IntOK(args, "tool_count")
 	if !ok || toolCount < 0 {
 		toolCount = len(r.tools)
 	}
-	priority := mrParseRoutePriority(mrStringArg(args, "priority"))
+	priority := mrParseRoutePriority(toolargs.String(args, "priority"))
 	hints := mrExtractRouteHints(args)
 
 	req := routeRequestForExplanation(args, toolCount, priority, hints)
@@ -44,11 +45,11 @@ func (r *Registry) handleModelRouteExplain(_ context.Context, args map[string]an
 
 func routeRequestForExplanation(args map[string]any, toolCount int, priority routepkg.Priority, hints map[string]string) routepkg.Request {
 	return routepkg.Request{
-		Query:          strings.TrimSpace(mrStringArg(args, "query")),
-		ContextSize:    mrIntArg(args, "context_size", 0),
-		NeedsTools:     mrBoolArg(args, "needs_tools"),
-		NeedsStreaming: mrBoolArg(args, "needs_streaming"),
-		NeedsImages:    mrBoolArg(args, "needs_images"),
+		Query:          strings.TrimSpace(toolargs.String(args, "query")),
+		ContextSize:    toolargs.IntOr(args, "context_size", 0),
+		NeedsTools:     toolargs.Bool(args, "needs_tools"),
+		NeedsStreaming: toolargs.Bool(args, "needs_streaming"),
+		NeedsImages:    toolargs.Bool(args, "needs_images"),
 		ToolCount:      toolCount,
 		Priority:       priority,
 		RoutingFactors: hints,

--- a/internal/tools/toolargs/example_test.go
+++ b/internal/tools/toolargs/example_test.go
@@ -1,0 +1,52 @@
+package toolargs_test
+
+import (
+	"fmt"
+
+	"github.com/nugget/thane-ai-agent/internal/tools/toolargs"
+)
+
+// A tool handler receives its decoded JSON arguments as a
+// map[string]any. toolargs extracts typed values from that map,
+// coercing the shapes a model/JSON call tends to produce.
+
+func ExampleString() {
+	args := map[string]any{"entity_id": "light.office"}
+	fmt.Println(toolargs.String(args, "entity_id"))
+	fmt.Printf("%q\n", toolargs.String(args, "missing"))
+	// Output:
+	// light.office
+	// ""
+}
+
+func ExampleInt() {
+	// JSON numbers decode to float64; a model may also send a numeric
+	// string. Both coerce; an absent key yields 0.
+	fmt.Println(toolargs.Int(map[string]any{"limit": float64(25)}, "limit"))
+	fmt.Println(toolargs.Int(map[string]any{"limit": "25"}, "limit"))
+	fmt.Println(toolargs.Int(map[string]any{}, "limit"))
+	// Output:
+	// 25
+	// 25
+	// 0
+}
+
+func ExampleBoolOr() {
+	// BoolOr returns the documented fallback when the key is absent —
+	// the fix for models that omit a schema's `default: true` field
+	// rather than sending it explicitly.
+	fmt.Println(toolargs.BoolOr(map[string]any{}, "include_read", true))
+	fmt.Println(toolargs.BoolOr(map[string]any{"include_read": false}, "include_read", true))
+	// Output:
+	// true
+	// false
+}
+
+func ExampleStringSlice() {
+	// A JSON array or a bare string both yield a []string.
+	fmt.Println(toolargs.StringSlice(map[string]any{"tags": []any{"a", "b"}}, "tags"))
+	fmt.Println(toolargs.StringSlice(map[string]any{"tags": "solo"}, "tags"))
+	// Output:
+	// [a b]
+	// [solo]
+}

--- a/internal/tools/toolargs/toolargs.go
+++ b/internal/tools/toolargs/toolargs.go
@@ -1,0 +1,230 @@
+// Package toolargs provides the canonical translators for extracting
+// typed values from a tool handler's decoded JSON argument map
+// (map[string]any). Tool calls arrive as JSON, so numbers land as
+// float64, booleans as bool, and the model occasionally encodes a
+// number or boolean as a string. These helpers centralize that
+// coercion in one place.
+//
+// Before this package, three tool packages each carried their own
+// prefixed copies of the same logic — email's stringArg/intArg/...,
+// the loop tools' ldStringArg/ldIntArg, and the model-registry tools'
+// mrStringArg/mrIntArg/... — prefixed only because they would
+// otherwise collide. The prefixes were a workaround for the missing
+// shared home; subtle coercion differences between the copies were a
+// standing drift risk. This package is that home.
+//
+// The package is deliberately named toolargs rather than args: tool
+// handlers conventionally name their argument map `args map[string]any`,
+// and a package named `args` would be shadowed at almost every call
+// site. `toolargs.String(args, key)` reads cleanly with no alias.
+//
+// All getters are nil-safe: a nil map, an absent key, or a wrong-typed
+// value yields the zero value (or the supplied fallback). The *OK
+// variants distinguish "absent / uncoercible" from "present and zero."
+package toolargs
+
+import (
+	"encoding/json"
+	"strconv"
+	"strings"
+)
+
+// maxUint32 is the largest valid uint32 value, used for range checks
+// in Uint32Slice.
+const maxUint32 = 1<<32 - 1
+
+// String returns the string value at key, or "" when the key is absent
+// or not a string. The value is returned verbatim — use TrimmedString
+// when surrounding whitespace should be stripped.
+func String(args map[string]any, key string) string {
+	if v, ok := args[key].(string); ok {
+		return v
+	}
+	return ""
+}
+
+// TrimmedString returns String(args, key) with leading and trailing
+// whitespace removed. Matches the loop tools' historical ldStringArg
+// semantics, where trimming guarded against models padding identifiers.
+func TrimmedString(args map[string]any, key string) string {
+	return strings.TrimSpace(String(args, key))
+}
+
+// Int returns the integer value at key, or 0 when the key is absent or
+// not coercible. Equivalent to IntOr(args, key, 0); see IntOK for the
+// coercion rules.
+func Int(args map[string]any, key string) int {
+	return IntOr(args, key, 0)
+}
+
+// IntOr returns the integer value at key, or fallback when the key is
+// absent or not coercible.
+func IntOr(args map[string]any, key string, fallback int) int {
+	if v, ok := IntOK(args, key); ok {
+		return v
+	}
+	return fallback
+}
+
+// IntOK returns the integer value at key and whether it was present and
+// coercible. Coercion accepts Go int/int32/int64, JSON float64 and
+// json.Number (rejecting non-integral values), and decimal strings
+// (trimmed). A nil map, absent key, nil value, fractional number, or
+// unparseable string returns (0, false).
+func IntOK(args map[string]any, key string) (int, bool) {
+	raw, ok := args[key]
+	if !ok || raw == nil {
+		return 0, false
+	}
+	switch v := raw.(type) {
+	case int:
+		return v, true
+	case int32:
+		return int(v), true
+	case int64:
+		return int(v), true
+	case float64:
+		if v != float64(int(v)) {
+			return 0, false
+		}
+		return int(v), true
+	case json.Number:
+		n, err := v.Int64()
+		if err != nil {
+			return 0, false
+		}
+		return int(n), true
+	case string:
+		n, err := strconv.Atoi(strings.TrimSpace(v))
+		if err != nil {
+			return 0, false
+		}
+		return n, true
+	default:
+		return 0, false
+	}
+}
+
+// Bool returns the boolean value at key, or false when the key is
+// absent or not coercible. Equivalent to BoolOr(args, key, false).
+//
+// Use BoolOr for any argument whose schema documents a non-false
+// default: models routinely omit a documented `default: true` field
+// rather than sending it explicitly, and the zero value for the missing
+// key (false) is the opposite of what the schema promised (the #930
+// email_mark regression). BoolOr returns the documented fallback when
+// the key is absent, so runtime behavior matches the schema regardless
+// of how the model encodes the call.
+func Bool(args map[string]any, key string) bool {
+	return BoolOr(args, key, false)
+}
+
+// BoolOr returns the boolean value at key, or fallback when the key is
+// absent or not coercible. See Bool for when to prefer this.
+func BoolOr(args map[string]any, key string, fallback bool) bool {
+	if v, ok := BoolOK(args, key); ok {
+		return v
+	}
+	return fallback
+}
+
+// BoolOK returns the boolean value at key and whether it was present
+// and coercible. Coercion accepts a real bool, or the strings "true"/
+// "false" (case-insensitive, trimmed). Anything else returns
+// (false, false).
+func BoolOK(args map[string]any, key string) (bool, bool) {
+	raw, ok := args[key]
+	if !ok || raw == nil {
+		return false, false
+	}
+	switch v := raw.(type) {
+	case bool:
+		return v, true
+	case string:
+		switch strings.ToLower(strings.TrimSpace(v)) {
+		case "true":
+			return true, true
+		case "false":
+			return false, true
+		}
+	}
+	return false, false
+}
+
+// HasBool reports whether key holds a present, coercible boolean. Use
+// it to distinguish "the caller set this flag" from "the flag defaulted
+// to false."
+func HasBool(args map[string]any, key string) bool {
+	_, ok := BoolOK(args, key)
+	return ok
+}
+
+// StringSlice returns the value at key as a []string. A JSON array
+// ([]any) yields its string elements (non-string elements are skipped);
+// a bare non-empty string yields a single-element slice. Anything else
+// yields nil.
+func StringSlice(args map[string]any, key string) []string {
+	switch v := args[key].(type) {
+	case []any:
+		out := make([]string, 0, len(v))
+		for _, el := range v {
+			if s, ok := el.(string); ok {
+				out = append(out, s)
+			}
+		}
+		return out
+	case string:
+		if v != "" {
+			return []string{v}
+		}
+	}
+	return nil
+}
+
+// Uint32Slice returns the value at key as a []uint32. A JSON array
+// ([]any) yields its coercible elements; a bare value yields a
+// single-element slice when coercible. Elements may be float64, int, or
+// decimal strings; values that are nil, fractional, below 1, or above
+// the uint32 range are skipped. Anything uncoercible yields nil.
+func Uint32Slice(args map[string]any, key string) []uint32 {
+	switch v := args[key].(type) {
+	case []any:
+		var out []uint32
+		for _, el := range v {
+			if n, ok := coerceUint32(el); ok {
+				out = append(out, n)
+			}
+		}
+		return out
+	default:
+		if n, ok := coerceUint32(v); ok {
+			return []uint32{n}
+		}
+	}
+	return nil
+}
+
+// coerceUint32 converts a single value to a valid uint32 in [1,
+// maxUint32]. Returns (0, false) for nil, negative, fractional, or
+// out-of-range values.
+func coerceUint32(v any) (uint32, bool) {
+	switch n := v.(type) {
+	case float64:
+		if n != float64(int64(n)) || n < 1 || n > float64(maxUint32) {
+			return 0, false
+		}
+		return uint32(n), true
+	case int:
+		if n < 1 || int64(n) > int64(maxUint32) {
+			return 0, false
+		}
+		return uint32(n), true
+	case string:
+		parsed, err := strconv.Atoi(strings.TrimSpace(n))
+		if err != nil || parsed < 1 || int64(parsed) > int64(maxUint32) {
+			return 0, false
+		}
+		return uint32(parsed), true
+	}
+	return 0, false
+}

--- a/internal/tools/toolargs/toolargs.go
+++ b/internal/tools/toolargs/toolargs.go
@@ -89,11 +89,16 @@ func IntOK(args map[string]any, key string) (int, bool) {
 		}
 		return int(v), true
 	case json.Number:
-		n, err := v.Int64()
-		if err != nil {
-			return 0, false
+		if n, err := v.Int64(); err == nil {
+			return int(n), true
 		}
-		return int(n), true
+		// Decimal-form integral values (e.g. "9.0") fail Int64 but still
+		// satisfy the integer contract; parse as float and apply the
+		// same integrality check as the float64 case.
+		if f, err := v.Float64(); err == nil && f == float64(int(f)) {
+			return int(f), true
+		}
+		return 0, false
 	case string:
 		n, err := strconv.Atoi(strings.TrimSpace(v))
 		if err != nil {

--- a/internal/tools/toolargs/toolargs_test.go
+++ b/internal/tools/toolargs/toolargs_test.go
@@ -54,6 +54,7 @@ func TestIntOK(t *testing.T) {
 		{"float64 integral", float64(8), 8, true},
 		{"float64 fractional rejected", 8.5, 0, false},
 		{"json.Number integral", json.Number("9"), 9, true},
+		{"json.Number decimal-integral", json.Number("9.0"), 9, true},
 		{"json.Number fractional rejected", json.Number("9.5"), 0, false},
 		{"string decimal", "395", 395, true},
 		{"string padded", "  42 ", 42, true},

--- a/internal/tools/toolargs/toolargs_test.go
+++ b/internal/tools/toolargs/toolargs_test.go
@@ -1,0 +1,211 @@
+package toolargs
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+)
+
+func TestString(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		args map[string]any
+		key  string
+		want string
+	}{
+		{"present", map[string]any{"k": "hello"}, "k", "hello"},
+		{"absent", map[string]any{}, "k", ""},
+		{"wrong type", map[string]any{"k": 42}, "k", ""},
+		{"nil value", map[string]any{"k": nil}, "k", ""},
+		{"nil map", nil, "k", ""},
+		{"no trim", map[string]any{"k": "  pad  "}, "k", "  pad  "},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := String(tt.args, tt.key); got != tt.want {
+				t.Errorf("String = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTrimmedString(t *testing.T) {
+	t.Parallel()
+	if got := TrimmedString(map[string]any{"k": "  pad  "}, "k"); got != "pad" {
+		t.Errorf("TrimmedString = %q, want %q", got, "pad")
+	}
+	if got := TrimmedString(map[string]any{"k": 7}, "k"); got != "" {
+		t.Errorf("TrimmedString wrong-type = %q, want empty", got)
+	}
+}
+
+func TestIntOK(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		val    any
+		want   int
+		wantOK bool
+	}{
+		{"int", 5, 5, true},
+		{"int32", int32(6), 6, true},
+		{"int64", int64(7), 7, true},
+		{"float64 integral", float64(8), 8, true},
+		{"float64 fractional rejected", 8.5, 0, false},
+		{"json.Number integral", json.Number("9"), 9, true},
+		{"json.Number fractional rejected", json.Number("9.5"), 0, false},
+		{"string decimal", "395", 395, true},
+		{"string padded", "  42 ", 42, true},
+		{"string non-numeric", "abc", 0, false},
+		{"bool rejected", true, 0, false},
+		{"nil value", nil, 0, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := IntOK(map[string]any{"k": tt.val}, "k")
+			if got != tt.want || ok != tt.wantOK {
+				t.Errorf("IntOK = (%d, %v), want (%d, %v)", got, ok, tt.want, tt.wantOK)
+			}
+		})
+	}
+	if _, ok := IntOK(map[string]any{}, "missing"); ok {
+		t.Error("IntOK absent key should be not-ok")
+	}
+}
+
+func TestIntAndIntOr(t *testing.T) {
+	t.Parallel()
+	if got := Int(map[string]any{"k": float64(3)}, "k"); got != 3 {
+		t.Errorf("Int = %d, want 3", got)
+	}
+	if got := Int(map[string]any{}, "k"); got != 0 {
+		t.Errorf("Int absent = %d, want 0", got)
+	}
+	if got := IntOr(map[string]any{}, "k", 99); got != 99 {
+		t.Errorf("IntOr absent = %d, want 99", got)
+	}
+	if got := IntOr(map[string]any{"k": "abc"}, "k", 99); got != 99 {
+		t.Errorf("IntOr uncoercible = %d, want fallback 99", got)
+	}
+}
+
+func TestBoolOK(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		val    any
+		want   bool
+		wantOK bool
+	}{
+		{"true", true, true, true},
+		{"false", false, false, true},
+		{"string true", "true", true, true},
+		{"string TRUE", "TRUE", true, true},
+		{"string false padded", "  false ", false, true},
+		{"string other", "yes", false, false},
+		{"int rejected", 1, false, false},
+		{"nil value", nil, false, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := BoolOK(map[string]any{"k": tt.val}, "k")
+			if got != tt.want || ok != tt.wantOK {
+				t.Errorf("BoolOK = (%v, %v), want (%v, %v)", got, ok, tt.want, tt.wantOK)
+			}
+		})
+	}
+}
+
+func TestBoolAndBoolOrAndHasBool(t *testing.T) {
+	t.Parallel()
+	// Bool: false when absent.
+	if Bool(map[string]any{}, "k") {
+		t.Error("Bool absent should be false")
+	}
+	if !Bool(map[string]any{"k": true}, "k") {
+		t.Error("Bool true should be true")
+	}
+	// BoolOr: the #930 omitted-default case — absent key returns the
+	// documented fallback, not the zero value.
+	if !BoolOr(map[string]any{}, "k", true) {
+		t.Error("BoolOr absent with true fallback should be true")
+	}
+	if BoolOr(map[string]any{"k": false}, "k", true) {
+		t.Error("BoolOr explicit false should override true fallback")
+	}
+	// HasBool: present vs defaulted.
+	if !HasBool(map[string]any{"k": false}, "k") {
+		t.Error("HasBool present false should be true")
+	}
+	if HasBool(map[string]any{}, "k") {
+		t.Error("HasBool absent should be false")
+	}
+	if HasBool(map[string]any{"k": "maybe"}, "k") {
+		t.Error("HasBool uncoercible should be false")
+	}
+}
+
+func TestStringSlice(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		val  any
+		want []string
+	}{
+		{"json array", []any{"a", "b"}, []string{"a", "b"}},
+		{"array skips non-strings", []any{"a", 2, "b"}, []string{"a", "b"}},
+		{"single string", "solo", []string{"solo"}},
+		{"empty string", "", nil},
+		{"wrong type", 42, nil},
+		{"empty array", []any{}, []string{}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := StringSlice(map[string]any{"k": tt.val}, "k")
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("StringSlice = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+	if got := StringSlice(map[string]any{}, "missing"); got != nil {
+		t.Errorf("StringSlice absent = %#v, want nil", got)
+	}
+}
+
+func TestUint32Slice(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		val  any
+		want []uint32
+	}{
+		{"json array of floats", []any{float64(1), float64(2)}, []uint32{1, 2}},
+		{"array skips fractional", []any{float64(1), 2.5, float64(3)}, []uint32{1, 3}},
+		{"array skips zero and negative", []any{float64(0), float64(-1), float64(4)}, []uint32{4}},
+		{"single float", float64(7), []uint32{7}},
+		{"single string", "8", []uint32{8}},
+		{"string array", []any{"10", "bad", "12"}, []uint32{10, 12}},
+		{"uncoercible single", "x", nil},
+		{"wrong type", true, nil},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := Uint32Slice(map[string]any{"k": tt.val}, "k")
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Uint32Slice = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCoerceUint32RangeCeiling(t *testing.T) {
+	t.Parallel()
+	// Above the uint32 ceiling must be rejected.
+	if _, ok := coerceUint32(float64(maxUint32) + 1); ok {
+		t.Error("coerceUint32 above ceiling should be not-ok")
+	}
+	if got, ok := coerceUint32(float64(maxUint32)); !ok || got != maxUint32 {
+		t.Errorf("coerceUint32 at ceiling = (%d, %v), want (%d, true)", got, ok, uint32(maxUint32))
+	}
+}

--- a/scripts/architecture.baseline
+++ b/scripts/architecture.baseline
@@ -1,4 +1,4 @@
-packages=58
+packages=59
 interfaces=76
 large_files=43
 set_mutators=104


### PR DESCRIPTION
## Summary

Refs #965. Three tool packages each carried prefixed copies of the same JSON-arg extraction logic — `stringArg`/`ldStringArg`/`mrStringArg`, `intArg`/`ldIntArg`/`mrIntArg`, etc. — prefixed *only* because they'd collide. The prefixes were a workaround for the missing shared home; subtle coercion differences between the copies were a standing drift risk (the issue's core smell).

This lands the canonical home and migrates the `internal/tools` package onto it.

### New package: `internal/tools/toolargs`

Full translator API with thorough table-driven tests:

- `String` / `TrimmedString`
- `Int` / `IntOr` / `IntOK`
- `Bool` / `BoolOr` / `BoolOK` / `HasBool`
- `StringSlice` / `Uint32Slice`

Tests cover the JSON-coercion edge cases the issue flagged: `float64`/`json.Number` integrality, numeric strings, `"true"`/`"false"` string bools, the #930 omitted-bool default, and uint32 range/fractional filtering.

### Migration

Deleted the two prefixed sets in `internal/tools` (`mr*` in `model_registry_tool_helpers.go`, `ld*` string/int in `loop_definition_tool_helpers.go`) and repointed ~71 call sites to `toolargs`. Loop-specific decoders (`decodeLoopSpecArg`, `decodeLoopLaunchArg`) and registry-specific helpers stay put.

## Decisions worth flagging

- **Package named `toolargs`, not `args`** (the issue's sketch). Handlers universally name their argument map `args map[string]any`, so a package named `args` would be shadowed at nearly every call site — `args.String(args, key)` won't compile. `toolargs.String(args, key)` reads cleanly with no alias.
- **Canonical `Int` rejects fractional floats** (the model-registry semantics) rather than truncating (older email/loop behavior). Migrated call sites only ever pass whole-number args, so behavior is unchanged in practice; this picks the stricter, more correct contract as the single source of truth.
- **Architecture baseline:** packages 58 → 59 for the new leaf package (updated in `scripts/architecture.baseline`).

## Out of scope (follow-ups)

- **`internal/channels/email`** helper set — it carries unique UID coercion (`uint32SliceArg`/`coerceUint32`), the #930 bool-default, and warn-logging worth migrating carefully. The new `toolargs` API already includes `Uint32Slice`/`StringSlice`/`BoolOr` so that migration is pure call-site repointing.
- **~167 inline `args[...].(T)` assertion sites** — the issue's step 3, explicitly a separate opportunistic sweep.

This PR therefore uses `Refs #965`, not `Closes`.

## Test plan

- [x] `go test ./internal/tools/...` (incl. new `toolargs` package)
- [x] `just ci` green locally
- [x] Architecture baseline updated and passing
- [x] No unrelated import-grouping churn (reverted goimports `-local` side effects on untouched files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)