### PR TITLE
feat(ha): ha_search_states — predicate search across live entity state

### DIFF
--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -112,6 +112,7 @@ becoming default context clutter.
 | `ha_find_entity` | Smart entity discovery across HA domains, optionally enriched with HA metadata. |
 | `ha_get_state` | Current state of any entity, with optional area/device/label/description/visibility metadata. |
 | `ha_list_entities` | Browse entities by domain with optional HA metadata. |
+| `ha_search_states` | Predicate search across live entity state (state value, numeric attribute, domain, area). |
 | `ha_call_service` | Direct HA service invocation. |
 | `ha_registry_search` | Search the entity/device/area registry. |
 | `ha_automation_list` | List automations with recent activation counts. |

--- a/internal/model/toolcatalog/catalog.go
+++ b/internal/model/toolcatalog/catalog.go
@@ -230,6 +230,7 @@ var builtinToolSpecs = map[string]BuiltinToolSpec{
 	"contact_import_vcf":          {CanonicalID: "native:contact_import_vcf", Source: NativeToolSource, Tags: []string{"contacts"}},
 	"contact_list":                {CanonicalID: "native:contact_list", Source: NativeToolSource, Tags: []string{"contacts"}},
 	"ha_list_entities":            {CanonicalID: "native:ha_list_entities", Source: NativeToolSource, Tags: []string{"ha"}},
+	"ha_search_states":            {CanonicalID: "native:ha_search_states", Source: NativeToolSource, Tags: []string{"ha"}},
 	"lens_list":                   {CanonicalID: "native:lens_list", Source: NativeToolSource},
 	"tag_inspect":                 {CanonicalID: "native:tag_inspect", Source: NativeToolSource},
 	"tag_reset":                   {CanonicalID: "native:tag_reset", Source: NativeToolSource},

--- a/internal/tools/ha_search_states.go
+++ b/internal/tools/ha_search_states.go
@@ -1,0 +1,368 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/nugget/thane-ai-agent/internal/integrations/homeassistant"
+)
+
+const (
+	defaultHASearchStatesLimit   = 20
+	maxHASearchStatesLimit       = 100
+	haSearchStatesTruncationNote = "Result exceeded the tool byte cap; tighten the filter (narrower state set, a domain, or an area) or lower limit."
+)
+
+// haSearchStateComparisons is the set of numeric-attribute comparison
+// operators the tool accepts.
+var haSearchStateComparisons = map[string]func(a, b float64) bool{
+	">":  func(a, b float64) bool { return a > b },
+	"<":  func(a, b float64) bool { return a < b },
+	">=": func(a, b float64) bool { return a >= b },
+	"<=": func(a, b float64) bool { return a <= b },
+	"==": func(a, b float64) bool { return a == b },
+	"!=": func(a, b float64) bool { return a != b },
+}
+
+type haSearchStatesResult struct {
+	Count     int                  `json:"count"`
+	Total     int                  `json:"total"`
+	Truncated bool                 `json:"truncated,omitempty"`
+	Filters   haSearchStateFilters `json:"filters"`
+	Items     []haListEntityItem   `json:"items"`
+}
+
+// haSearchStateFilters echoes the resolved filter set back to the model
+// so it can confirm what was actually searched.
+type haSearchStateFilters struct {
+	Domain     string   `json:"domain,omitempty"`
+	States     []string `json:"states,omitempty"`
+	Area       string   `json:"area,omitempty"`
+	Attribute  string   `json:"attribute,omitempty"`
+	Comparison string   `json:"comparison,omitempty"`
+	Value      *float64 `json:"value,omitempty"`
+}
+
+type haSearchStateQuery struct {
+	domain     string
+	states     []string
+	area       string
+	attribute  string
+	comparison string
+	value      float64
+	hasValue   bool
+	limit      int
+	include    homeassistant.EntityMetadataIncludes
+}
+
+// registerHASearchStates wires the ha_search_states tool: predicate
+// search across the live state set. It is the native answer to the
+// high-traffic "what's on / open / unavailable / low-battery" questions
+// that previously forced a model to fan out N ha_get_state calls or
+// reach for an MCP search tool.
+func (r *Registry) registerHASearchStates() {
+	if r.ha == nil {
+		return
+	}
+	r.Register(&Tool{
+		Name: "ha_search_states",
+		Description: "Search Home Assistant entities by live state across all domains. " +
+			"Answers 'what's on right now', 'what doors are open', 'which sensors are unavailable', 'what batteries are low'. " +
+			"Filter by state value(s), by a numeric attribute predicate (e.g. battery < 20, temperature > 80), by domain, and/or by area — filters compose (AND). " +
+			"At least one filter is required. Add include for area/device/label/description/visibility metadata on each match.",
+		Parameters: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"state": map[string]any{
+					"type":        "array",
+					"items":       map[string]any{"type": "string"},
+					"description": "Match entities whose current state is one of these values (e.g. [\"on\"], [\"open\"], [\"unavailable\",\"unknown\"]). A single string is also accepted.",
+				},
+				"domain": map[string]any{
+					"type":        "string",
+					"description": "Restrict to one domain (e.g. light, binary_sensor, climate, lock, cover).",
+				},
+				"area": map[string]any{
+					"type":        "string",
+					"description": "Restrict to entities resolved (via the HA registry, including device-inherited area) to this area name, alias, or area_id.",
+				},
+				"attribute": map[string]any{
+					"type":        "string",
+					"description": "Numeric attribute to compare on each entity (e.g. battery, temperature, current_temperature). Requires comparison and value.",
+				},
+				"comparison": map[string]any{
+					"type":        "string",
+					"enum":        []string{">", "<", ">=", "<=", "==", "!="},
+					"description": "Comparison operator for the attribute predicate.",
+				},
+				"value": map[string]any{
+					"type":        "number",
+					"description": "Numeric threshold for the attribute predicate.",
+				},
+				"limit": map[string]any{
+					"type":        "integer",
+					"description": "Maximum matches to return (default 20, max 100).",
+				},
+				"include": EntityMetadataIncludeParameter(),
+			},
+		},
+		Handler: r.handleSearchStates,
+	})
+}
+
+func (r *Registry) handleSearchStates(ctx context.Context, args map[string]any) (string, error) {
+	if r.ha == nil {
+		return "", fmt.Errorf("home assistant not configured")
+	}
+	if !r.ha.IsReady() {
+		return "", fmt.Errorf("home assistant is currently unreachable (reconnecting in background)")
+	}
+
+	q, err := parseHASearchStateQuery(args)
+	if err != nil {
+		return "", err
+	}
+
+	states, err := r.ha.GetStates(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	// Pass 1: cheap predicates (domain, state membership, numeric
+	// attribute) over the raw state set — no registry round-trip.
+	candidates := make([]homeassistant.State, 0, len(states))
+	for _, s := range states {
+		if q.domain != "" && entityDomainOf(s.EntityID) != q.domain {
+			continue
+		}
+		if len(q.states) > 0 && !stateMatches(s.State, q.states) {
+			continue
+		}
+		if q.attribute != "" && !attributeMatches(s, q.attribute, q.comparison, q.value) {
+			continue
+		}
+		candidates = append(candidates, s)
+	}
+
+	// Pass 2: area filter and/or metadata enrichment need the registry.
+	// Fetch one full-registry bundle (single GetEntityRegistry pass plus
+	// the area/device/label/floor reads the include implies) rather than
+	// one registry call per candidate.
+	working := q.include
+	if q.area != "" {
+		working.Area = true
+	}
+	var bundle *haEntityMetadataBundle
+	if working.Any() {
+		bundle, err = fetchHAEntityMetadataBundle(ctx, r.ha, working)
+		if err != nil {
+			return "", err
+		}
+	}
+
+	if q.area != "" {
+		filtered := candidates[:0]
+		areaOnly := homeassistant.EntityMetadataIncludes{Area: true}
+		for _, s := range candidates {
+			meta := bundle.resolver.MetadataForEntity(bundle.entries[s.EntityID], &s, areaOnly)
+			if meta == nil || meta.Area == nil || !areaMetadataMatches(meta.Area, q.area) {
+				continue
+			}
+			filtered = append(filtered, s)
+		}
+		candidates = filtered
+	}
+
+	total := len(candidates)
+	if len(candidates) > q.limit {
+		candidates = candidates[:q.limit]
+	}
+
+	items := make([]haListEntityItem, 0, len(candidates))
+	for i := range candidates {
+		s := candidates[i]
+		item := haListEntityItem{EntityID: s.EntityID, State: s.State}
+		if friendly, ok := s.Attributes["friendly_name"].(string); ok {
+			item.FriendlyName = friendly
+		}
+		// Render output metadata using the CALLER's include (not the
+		// working set the area filter may have widened), so an area
+		// filter doesn't leak area metadata the caller didn't request.
+		if q.include.Any() && bundle != nil {
+			item.Metadata = bundle.resolver.MetadataForEntity(bundle.entries[s.EntityID], &s, q.include)
+		}
+		items = append(items, item)
+	}
+
+	result := haSearchStatesResult{
+		Count:     len(items),
+		Total:     total,
+		Truncated: total > len(items),
+		Filters:   q.filters(),
+		Items:     items,
+	}
+	return toIndentedJSONWithTruncationNote(result, haSearchStatesTruncationNote), nil
+}
+
+func (q haSearchStateQuery) filters() haSearchStateFilters {
+	f := haSearchStateFilters{
+		Domain:     q.domain,
+		States:     q.states,
+		Area:       q.area,
+		Attribute:  q.attribute,
+		Comparison: q.comparison,
+	}
+	if q.hasValue {
+		v := q.value
+		f.Value = &v
+	}
+	return f
+}
+
+func parseHASearchStateQuery(args map[string]any) (haSearchStateQuery, error) {
+	var q haSearchStateQuery
+
+	q.domain = strings.TrimSpace(stringArgValue(args, "domain"))
+	q.area = strings.TrimSpace(stringArgValue(args, "area"))
+	q.states = stringListArg(args["state"])
+
+	include, err := ParseEntityMetadataIncludesArg(args["include"], "include")
+	if err != nil {
+		return haSearchStateQuery{}, err
+	}
+	q.include = include
+
+	limit, err := boundedIntArg(args, "limit", defaultHASearchStatesLimit, maxHASearchStatesLimit)
+	if err != nil {
+		return haSearchStateQuery{}, err
+	}
+	q.limit = limit
+
+	q.attribute = strings.TrimSpace(stringArgValue(args, "attribute"))
+	q.comparison = strings.TrimSpace(stringArgValue(args, "comparison"))
+	if rawValue, ok := args["value"]; ok && rawValue != nil {
+		v, ok := coerceFloat(rawValue)
+		if !ok {
+			return haSearchStateQuery{}, fmt.Errorf("value must be a number")
+		}
+		q.value = v
+		q.hasValue = true
+	}
+
+	// The attribute predicate is all-or-nothing: attribute + comparison
+	// + value travel together or not at all.
+	if q.attribute != "" || q.comparison != "" || q.hasValue {
+		if q.attribute == "" || q.comparison == "" || !q.hasValue {
+			return haSearchStateQuery{}, fmt.Errorf("attribute, comparison, and value must all be set together for a numeric predicate")
+		}
+		if _, ok := haSearchStateComparisons[q.comparison]; !ok {
+			return haSearchStateQuery{}, fmt.Errorf("comparison must be one of >, <, >=, <=, ==, !=")
+		}
+	}
+
+	if q.domain == "" && q.area == "" && len(q.states) == 0 && q.attribute == "" {
+		return haSearchStateQuery{}, fmt.Errorf("at least one filter is required: state, domain, area, or an attribute predicate")
+	}
+	return q, nil
+}
+
+func stateMatches(state string, want []string) bool {
+	for _, w := range want {
+		if strings.EqualFold(state, w) {
+			return true
+		}
+	}
+	return false
+}
+
+func attributeMatches(s homeassistant.State, attribute, comparison string, threshold float64) bool {
+	raw, ok := s.Attributes[attribute]
+	if !ok {
+		return false
+	}
+	value, ok := coerceFloat(raw)
+	if !ok {
+		return false
+	}
+	cmp, ok := haSearchStateComparisons[comparison]
+	if !ok {
+		return false
+	}
+	return cmp(value, threshold)
+}
+
+func areaMetadataMatches(area *homeassistant.EntityAreaMetadata, query string) bool {
+	if area == nil {
+		return false
+	}
+	if strings.EqualFold(area.ID, query) || strings.EqualFold(area.Name, query) {
+		return true
+	}
+	for _, alias := range area.Aliases {
+		if strings.EqualFold(alias, query) {
+			return true
+		}
+	}
+	return false
+}
+
+func entityDomainOf(entityID string) string {
+	if idx := strings.IndexByte(entityID, '.'); idx > 0 {
+		return entityID[:idx]
+	}
+	return ""
+}
+
+// stringArgValue reads a string argument, returning "" when absent or
+// not a string.
+func stringArgValue(args map[string]any, key string) string {
+	if v, ok := args[key].(string); ok {
+		return v
+	}
+	return ""
+}
+
+// stringListArg accepts a JSON array of strings or a single string,
+// returning the non-empty trimmed values.
+func stringListArg(raw any) []string {
+	switch v := raw.(type) {
+	case []any:
+		out := make([]string, 0, len(v))
+		for _, el := range v {
+			if s, ok := el.(string); ok {
+				if s = strings.TrimSpace(s); s != "" {
+					out = append(out, s)
+				}
+			}
+		}
+		return out
+	case string:
+		if s := strings.TrimSpace(v); s != "" {
+			return []string{s}
+		}
+	}
+	return nil
+}
+
+func coerceFloat(v any) (float64, bool) {
+	switch n := v.(type) {
+	case float64:
+		return n, true
+	case float32:
+		return float64(n), true
+	case int:
+		return float64(n), true
+	case int64:
+		return float64(n), true
+	case string:
+		f, err := strconv.ParseFloat(strings.TrimSpace(n), 64)
+		if err != nil {
+			return 0, false
+		}
+		return f, true
+	default:
+		return 0, false
+	}
+}

--- a/internal/tools/ha_search_states.go
+++ b/internal/tools/ha_search_states.go
@@ -146,25 +146,30 @@ func (r *Registry) handleSearchStates(ctx context.Context, args map[string]any) 
 		candidates = append(candidates, s)
 	}
 
-	// Pass 2: area filter and/or metadata enrichment need the registry.
-	// Fetch one full-registry bundle (single GetEntityRegistry pass plus
-	// the area/device/label/floor reads the include implies) rather than
-	// one registry call per candidate.
-	working := q.include
-	if q.area != "" {
-		working.Area = true
-	}
+	// Pass 2: area filtering and metadata enrichment need the registry.
+	// The access pattern is deliberately bounded for production scale
+	// (15k+ live entities): at most one bulk GetStates (above) plus at
+	// most one projection-gated registry read here — never a per-entity
+	// registry loop over the full candidate set.
+	//
+	//   - With an area filter we need the entity->area mapping for the
+	//     whole candidate set (before limiting), so we pull one bulk
+	//     registry snapshot, gated to the requested projection, and
+	//     reuse it for output enrichment too.
+	//   - Without an area filter we defer the registry read until after
+	//     the limit is applied and fetch only the rows we actually
+	//     return, so an enriched search never pulls the entire entity
+	//     registry just to render a single page of results.
 	var bundle *haEntityMetadataBundle
-	if working.Any() {
+	if q.area != "" {
+		working := q.include
+		working.Area = true
 		bundle, err = fetchHAEntityMetadataBundle(ctx, r.ha, working)
 		if err != nil {
 			return "", err
 		}
-	}
-
-	if q.area != "" {
-		filtered := candidates[:0]
 		areaOnly := homeassistant.EntityMetadataIncludes{Area: true}
+		filtered := candidates[:0]
 		for _, s := range candidates {
 			meta := bundle.resolver.MetadataForEntity(bundle.entries[s.EntityID], &s, areaOnly)
 			if meta == nil || meta.Area == nil || !areaMetadataMatches(meta.Area, q.area) {
@@ -178,6 +183,19 @@ func (r *Registry) handleSearchStates(ctx context.Context, args map[string]any) 
 	total := len(candidates)
 	if len(candidates) > q.limit {
 		candidates = candidates[:q.limit]
+	}
+
+	// No area filter but enrichment requested: fetch registry rows only
+	// for the limited result set rather than the whole registry.
+	if q.include.Any() && bundle == nil {
+		ids := make([]string, 0, len(candidates))
+		for i := range candidates {
+			ids = append(ids, candidates[i].EntityID)
+		}
+		bundle, err = fetchHAEntityMetadataBundleForEntityIDs(ctx, r.ha, q.include, ids)
+		if err != nil {
+			return "", err
+		}
 	}
 
 	items := make([]haListEntityItem, 0, len(candidates))

--- a/internal/tools/ha_search_states.go
+++ b/internal/tools/ha_search_states.go
@@ -38,7 +38,7 @@ type haSearchStatesResult struct {
 // so it can confirm what was actually searched.
 type haSearchStateFilters struct {
 	Domain     string   `json:"domain,omitempty"`
-	States     []string `json:"states,omitempty"`
+	State      []string `json:"state,omitempty"`
 	Area       string   `json:"area,omitempty"`
 	Attribute  string   `json:"attribute,omitempty"`
 	Comparison string   `json:"comparison,omitempty"`
@@ -76,9 +76,9 @@ func (r *Registry) registerHASearchStates() {
 			"type": "object",
 			"properties": map[string]any{
 				"state": map[string]any{
-					"type":        "array",
+					"type":        []string{"string", "array"},
 					"items":       map[string]any{"type": "string"},
-					"description": "Match entities whose current state is one of these values (e.g. [\"on\"], [\"open\"], [\"unavailable\",\"unknown\"]). A single string is also accepted.",
+					"description": "Match entities whose current state is one of these values. Accepts a single string (\"on\") or an array ([\"unavailable\",\"unknown\"]).",
 				},
 				"domain": map[string]any{
 					"type":        "string",
@@ -227,7 +227,7 @@ func (r *Registry) handleSearchStates(ctx context.Context, args map[string]any) 
 func (q haSearchStateQuery) filters() haSearchStateFilters {
 	f := haSearchStateFilters{
 		Domain:     q.domain,
-		States:     q.states,
+		State:      q.states,
 		Area:       q.area,
 		Attribute:  q.attribute,
 		Comparison: q.comparison,

--- a/internal/tools/ha_search_states_test.go
+++ b/internal/tools/ha_search_states_test.go
@@ -146,6 +146,32 @@ func TestHASearchStates_RendersIncludeMetadataWithoutLeakingAreaOnAreaFilter(t *
 	}
 }
 
+func TestHASearchStates_ScopedEnrichmentWithoutAreaFilter(t *testing.T) {
+	fake := newFakeHAServer(t)
+	fake.states = []homeassistant.State{
+		{EntityID: "sensor.office_temp", State: "72", Attributes: map[string]any{"friendly_name": "Office Temp"}},
+	}
+	fake.entityRows = []map[string]any{
+		{"entity_id": "sensor.office_temp", "description": "Ambient office temperature", "platform": "zwave_js"},
+	}
+	reg := fake.registry(t)
+
+	// include without area must still render description metadata —
+	// this exercises the post-limit scoped registry fetch path
+	// (fetchHAEntityMetadataBundleForEntityIDs), not the bulk path.
+	result, err := reg.Execute(context.Background(), "ha_search_states", `{"state":["72"],"include":{"description":true}}`)
+	if err != nil {
+		t.Fatalf("ha_search_states: %v", err)
+	}
+	res := decodeSearchStates(t, result)
+	if len(res.Items) != 1 || res.Items[0].Metadata == nil {
+		t.Fatalf("expected one enriched item, got %#v", res.Items)
+	}
+	if res.Items[0].Metadata.Description != "Ambient office temperature" {
+		t.Errorf("description = %q, want registry description", res.Items[0].Metadata.Description)
+	}
+}
+
 func TestHASearchStates_RequiresAFilter(t *testing.T) {
 	fake := newFakeHAServer(t)
 	reg := fake.registry(t)

--- a/internal/tools/ha_search_states_test.go
+++ b/internal/tools/ha_search_states_test.go
@@ -1,0 +1,188 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/nugget/thane-ai-agent/internal/integrations/homeassistant"
+)
+
+func decodeSearchStates(t *testing.T, raw string) haSearchStatesResult {
+	t.Helper()
+	var out haSearchStatesResult
+	if err := json.Unmarshal([]byte(raw), &out); err != nil {
+		t.Fatalf("unmarshal result: %v\n%s", err, raw)
+	}
+	return out
+}
+
+func searchStatesEntityIDs(res haSearchStatesResult) map[string]bool {
+	ids := make(map[string]bool, len(res.Items))
+	for _, it := range res.Items {
+		ids[it.EntityID] = true
+	}
+	return ids
+}
+
+func TestHASearchStates_StateAndDomainFilter(t *testing.T) {
+	fake := newFakeHAServer(t)
+	fake.states = []homeassistant.State{
+		{EntityID: "light.office", State: "on", Attributes: map[string]any{"friendly_name": "Office"}},
+		{EntityID: "light.hall", State: "off", Attributes: map[string]any{"friendly_name": "Hall"}},
+		{EntityID: "switch.fan", State: "on", Attributes: map[string]any{"friendly_name": "Fan"}},
+	}
+	reg := fake.registry(t)
+
+	result, err := reg.Execute(context.Background(), "ha_search_states", `{"domain":"light","state":["on"]}`)
+	if err != nil {
+		t.Fatalf("ha_search_states: %v", err)
+	}
+	res := decodeSearchStates(t, result)
+	if res.Count != 1 || res.Total != 1 {
+		t.Fatalf("count/total = %d/%d, want 1/1\n%s", res.Count, res.Total, result)
+	}
+	ids := searchStatesEntityIDs(res)
+	if !ids["light.office"] || ids["light.hall"] || ids["switch.fan"] {
+		t.Errorf("matched ids = %v, want only light.office", ids)
+	}
+}
+
+func TestHASearchStates_StateAcrossDomains(t *testing.T) {
+	fake := newFakeHAServer(t)
+	fake.states = []homeassistant.State{
+		{EntityID: "binary_sensor.door", State: "unavailable"},
+		{EntityID: "sensor.temp", State: "unavailable"},
+		{EntityID: "light.lamp", State: "on"},
+	}
+	reg := fake.registry(t)
+
+	result, err := reg.Execute(context.Background(), "ha_search_states", `{"state":["unavailable","unknown"]}`)
+	if err != nil {
+		t.Fatalf("ha_search_states: %v", err)
+	}
+	res := decodeSearchStates(t, result)
+	ids := searchStatesEntityIDs(res)
+	if len(ids) != 2 || !ids["binary_sensor.door"] || !ids["sensor.temp"] {
+		t.Errorf("matched ids = %v, want door+temp", ids)
+	}
+}
+
+func TestHASearchStates_NumericAttributePredicate(t *testing.T) {
+	fake := newFakeHAServer(t)
+	fake.states = []homeassistant.State{
+		{EntityID: "sensor.a_batt", State: "12", Attributes: map[string]any{"battery": float64(12)}},
+		{EntityID: "sensor.b_batt", State: "88", Attributes: map[string]any{"battery": float64(88)}},
+		{EntityID: "sensor.c_batt", State: "5", Attributes: map[string]any{"battery": "5"}}, // string-encoded
+		{EntityID: "sensor.no_batt", State: "on", Attributes: map[string]any{}},
+	}
+	reg := fake.registry(t)
+
+	result, err := reg.Execute(context.Background(), "ha_search_states", `{"attribute":"battery","comparison":"<","value":20}`)
+	if err != nil {
+		t.Fatalf("ha_search_states: %v", err)
+	}
+	res := decodeSearchStates(t, result)
+	ids := searchStatesEntityIDs(res)
+	if len(ids) != 2 || !ids["sensor.a_batt"] || !ids["sensor.c_batt"] {
+		t.Errorf("matched ids = %v, want a_batt(12) + c_batt(5); b_batt(88) and no_batt excluded", ids)
+	}
+}
+
+func TestHASearchStates_AreaFilter(t *testing.T) {
+	fake := newFakeHAServer(t)
+	fake.states = []homeassistant.State{
+		{EntityID: "light.office_lamp", State: "on", Attributes: map[string]any{"friendly_name": "Office Lamp"}},
+		{EntityID: "light.kitchen_lamp", State: "on", Attributes: map[string]any{"friendly_name": "Kitchen Lamp"}},
+	}
+	fake.areas = []map[string]any{
+		{"area_id": "office", "name": "Office"},
+		{"area_id": "kitchen", "name": "Kitchen"},
+	}
+	fake.entityRows = []map[string]any{
+		{"entity_id": "light.office_lamp", "area_id": "office"},
+		{"entity_id": "light.kitchen_lamp", "area_id": "kitchen"},
+	}
+	reg := fake.registry(t)
+
+	result, err := reg.Execute(context.Background(), "ha_search_states", `{"state":["on"],"area":"Office"}`)
+	if err != nil {
+		t.Fatalf("ha_search_states: %v", err)
+	}
+	res := decodeSearchStates(t, result)
+	ids := searchStatesEntityIDs(res)
+	if len(ids) != 1 || !ids["light.office_lamp"] {
+		t.Errorf("matched ids = %v, want only light.office_lamp (area Office)", ids)
+	}
+}
+
+func TestHASearchStates_RendersIncludeMetadataWithoutLeakingAreaOnAreaFilter(t *testing.T) {
+	fake := newFakeHAServer(t)
+	fake.states = []homeassistant.State{
+		{EntityID: "light.office_lamp", State: "on", Attributes: map[string]any{"friendly_name": "Office Lamp"}},
+	}
+	fake.areas = []map[string]any{{"area_id": "office", "name": "Office"}}
+	fake.entityRows = []map[string]any{
+		{"entity_id": "light.office_lamp", "area_id": "office", "platform": "hue"},
+	}
+	reg := fake.registry(t)
+
+	// Filter by area but only request description metadata. The area
+	// resolution must not leak an area block into the rendered output.
+	result, err := reg.Execute(context.Background(), "ha_search_states", `{"state":["on"],"area":"office","include":{"description":true}}`)
+	if err != nil {
+		t.Fatalf("ha_search_states: %v", err)
+	}
+	res := decodeSearchStates(t, result)
+	if len(res.Items) != 1 {
+		t.Fatalf("items = %d, want 1", len(res.Items))
+	}
+	meta := res.Items[0].Metadata
+	if meta == nil {
+		t.Fatal("expected description metadata to be rendered")
+	}
+	if meta.Area != nil {
+		t.Errorf("area metadata leaked into output despite include only requesting description: %#v", meta.Area)
+	}
+}
+
+func TestHASearchStates_RequiresAFilter(t *testing.T) {
+	fake := newFakeHAServer(t)
+	reg := fake.registry(t)
+	if _, err := reg.Execute(context.Background(), "ha_search_states", `{}`); err == nil {
+		t.Fatal("expected error when no filter is supplied")
+	}
+}
+
+func TestHASearchStates_PartialAttributePredicateRejected(t *testing.T) {
+	fake := newFakeHAServer(t)
+	reg := fake.registry(t)
+	// attribute without comparison/value is incomplete.
+	if _, err := reg.Execute(context.Background(), "ha_search_states", `{"attribute":"battery"}`); err == nil {
+		t.Fatal("expected error for attribute predicate missing comparison/value")
+	}
+	// bad comparison operator.
+	if _, err := reg.Execute(context.Background(), "ha_search_states", `{"attribute":"battery","comparison":"=<","value":10}`); err == nil {
+		t.Fatal("expected error for invalid comparison operator")
+	}
+}
+
+func TestHASearchStates_Truncation(t *testing.T) {
+	fake := newFakeHAServer(t)
+	for i := 0; i < 5; i++ {
+		fake.states = append(fake.states, homeassistant.State{
+			EntityID: "light.l" + string(rune('a'+i)),
+			State:    "on",
+		})
+	}
+	reg := fake.registry(t)
+
+	result, err := reg.Execute(context.Background(), "ha_search_states", `{"state":["on"],"limit":2}`)
+	if err != nil {
+		t.Fatalf("ha_search_states: %v", err)
+	}
+	res := decodeSearchStates(t, result)
+	if res.Count != 2 || res.Total != 5 || !res.Truncated {
+		t.Errorf("count=%d total=%d truncated=%v, want 2/5/true", res.Count, res.Total, res.Truncated)
+	}
+}

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -117,7 +117,8 @@ func NewRegistry(ha *homeassistant.Client, sched *scheduler.Scheduler) *Registry
 		scheduler: sched,
 	}
 	r.registerBuiltins()
-	r.registerFindEntity() // Smart entity discovery
+	r.registerFindEntity()     // Smart entity discovery
+	r.registerHASearchStates() // Predicate search across live state
 	r.registerHAAutomationTools()
 	return r
 }

--- a/talents/ha.md
+++ b/talents/ha.md
@@ -124,6 +124,33 @@ set ("check every door sensor"). Returns structured entity rows; add
 metadata when the model needs room, device, label, or description
 context to choose the right follow-up.
 
+## I want everything matching a live-state condition
+
+`ha_search_states` filters by *current state* across all domains —
+the native answer to "what's on right now," "what doors are open,"
+"which sensors are unavailable," "what batteries are low":
+
+```json
+{
+  "state": ["on"],
+  "area": "office"
+}
+```
+
+```json
+{
+  "attribute": "battery",
+  "comparison": "<",
+  "value": 20
+}
+```
+
+Filters compose (AND): pair a `state` set with a `domain` or `area`,
+or use a numeric `attribute`/`comparison`/`value` predicate for
+threshold questions. This is the right reach instead of fanning out
+many `ha_get_state` calls or listing a whole domain and eyeballing it.
+Add `include` for area/device/label/visibility metadata on each match.
+
 ## I want richer search across the registry
 
 `ha_registry_search` searches areas, labels, devices, and entities


### PR DESCRIPTION
Closes #1003. Phase 1 of the native-HA overhaul (#1002).

> **Stacked on #995.** Base is `codex/ha-entity-metadata` because this composes on that PR's metadata substrate (`EntityMetadataResolver`, the `include` projection). GitHub will retarget this to `main` automatically when #995 merges. Review/merge #995 first.

## Why

The #1 reason a model reached for the `ha-mcp` bridge: "what's on right now," "what doors are open," "which sensors are unavailable," "what batteries are low." No native tool answered these — it took N `ha_get_state` calls or listing a whole domain and eyeballing it.

## What

`ha_search_states` filters the live state set by **composable** predicates (AND):
- `state` — match one or more state values (`["on"]`, `["open"]`, `["unavailable","unknown"]`)
- `attribute` + `comparison` + `value` — numeric predicate (`battery < 20`, `temperature > 80`)
- `domain` — restrict to one domain
- `area` — registry-resolved (name/alias/id, incl. device-inherited area)
- `include` — area/device/label/description/visibility metadata per match

**Efficiency:** cheap predicates (domain/state/attribute) run over the raw `GetStates` result with zero registry round-trips. Area filtering + `include` enrichment fetch a **single full-registry bundle** (reusing #995's resolver) rather than one registry call per candidate. Output metadata renders with the *caller's* `include`, so an area filter never leaks an area block the caller didn't request (covered by a test).

## Tests

State filter, cross-domain state, numeric predicate (incl. string-encoded values + missing attribute), area filter, include-no-leak, validation (no-filter rejected, partial predicate rejected, bad operator rejected), truncation.

## Deferred (follow-ups)

- `label` filtering (lower traffic; reuses the same bundle).
- Semantic-state rendering (door `open` vs `on`) — kept raw to match `ha_list_entities` for now.

## Test plan

- [x] `go test ./internal/tools/...`
- [x] `just ci` green locally (incl. catalog + tools.md consistency)
- [ ] Retargets to `main` after #995 merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)