### PR TITLE
perf(ha): shared TTL registry-snapshot cache on the HA client

### DIFF
--- a/examples/config.example.yaml
+++ b/examples/config.example.yaml
@@ -48,6 +48,15 @@ homeassistant:
   # operator-local semantic alias in model-facing metadata. Set to
   # "building" when floors represent buildings in this deployment.
   floor_alias: ""
+  # RegistryCacheTTL bounds how long entity/device/area/label/floor
+  # registry snapshots are reused across native HA tool calls before a
+  # refetch. These registries change only on HA config edits, so a
+  # short window collapses the repeated (multi-MB at scale) registry
+  # pulls that metadata-bearing tool calls would otherwise issue.
+  # Accepts a Go duration string ("30s", "1m"); empty uses the 30s
+  # default; "0" disables caching (always refetch). Live entity state
+  # is never cached.
+  registry_cache_ttl: ""
   # Subscribe configures WebSocket event subscriptions for real-time
   # state change monitoring. When entity_globs is non-empty, only
   # matching entities are processed; when empty, all state changes

--- a/internal/app/new_stores.go
+++ b/internal/app/new_stores.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 	"sync"
 	"time"
 
@@ -124,6 +125,14 @@ func (a *App) initStores(s *newState) error {
 	if cfg.HomeAssistant.Configured() {
 		a.ha = homeassistant.NewClient(cfg.HomeAssistant.URL, cfg.HomeAssistant.Token, logger)
 		a.ha.UseFloorMetadataAlias(cfg.HomeAssistant.FloorAlias)
+		if ttl := strings.TrimSpace(cfg.HomeAssistant.RegistryCacheTTL); ttl != "" {
+			if d, err := time.ParseDuration(ttl); err != nil {
+				logger.Warn("invalid home_assistant.registry_cache_ttl; using default",
+					"value", ttl, "error", err)
+			} else {
+				a.ha.SetRegistryCacheTTL(d)
+			}
+		}
 		a.haWS = homeassistant.NewWSClient(cfg.HomeAssistant.URL, cfg.HomeAssistant.Token, logger)
 		a.ha.UseWSClient(a.haWS)
 		a.onCloseErr("ha-websocket", a.haWS.Close)

--- a/internal/integrations/homeassistant/client.go
+++ b/internal/integrations/homeassistant/client.go
@@ -23,6 +23,7 @@ type Client struct {
 	watcher            readyChecker // set via SetWatcher for health status
 	ws                 *WSClient
 	floorMetadataAlias string
+	registry           *registryCache
 }
 
 // readyChecker is satisfied by connwatch.Watcher. Defined here to avoid
@@ -84,7 +85,32 @@ func NewClient(baseURL, token string, logger *slog.Logger) *Client {
 			httpkit.WithRetry(3, 2*time.Second),
 			httpkit.WithLogger(logger),
 		),
+		registry: &registryCache{ttl: defaultRegistryCacheTTL},
 	}
+}
+
+// SetRegistryCacheTTL overrides the freshness window for cached
+// entity/device/area/label/floor registry snapshots. A value <= 0
+// disables caching (every registry read refetches). Call once at wiring
+// time, before any registry getter runs.
+func (c *Client) SetRegistryCacheTTL(ttl time.Duration) {
+	if c.registry == nil {
+		c.registry = &registryCache{}
+	}
+	c.registry.ttl = ttl
+}
+
+// InvalidateRegistryCache drops all cached registry snapshots. Useful
+// after an out-of-band change that the TTL would otherwise serve stale.
+func (c *Client) InvalidateRegistryCache() {
+	if c.registry == nil {
+		return
+	}
+	c.registry.areas.invalidate()
+	c.registry.entities.invalidate()
+	c.registry.devices.invalidate()
+	c.registry.labels.invalidate()
+	c.registry.floors.invalidate()
 }
 
 // State represents an entity state from Home Assistant.
@@ -262,14 +288,20 @@ type Area struct {
 
 // GetAreas retrieves all areas from the area registry.
 func (c *Client) GetAreas(ctx context.Context) ([]Area, error) {
-	if c.ws != nil {
-		return c.ws.GetAreaRegistry(ctx)
+	fetch := func() ([]Area, error) {
+		if c.ws != nil {
+			return c.ws.GetAreaRegistry(ctx)
+		}
+		var areas []Area
+		if err := c.get(ctx, "/api/config/area_registry/list", &areas); err != nil {
+			return nil, err
+		}
+		return areas, nil
 	}
-	var areas []Area
-	if err := c.get(ctx, "/api/config/area_registry/list", &areas); err != nil {
-		return nil, err
+	if c.registry == nil {
+		return fetch()
 	}
-	return areas, nil
+	return c.registry.areas.get(c.registry.ttl, time.Now(), fetch)
 }
 
 // EntityRegistryEntry represents an entity from the registry with area info.
@@ -306,14 +338,20 @@ func (e EntityRegistryEntry) IsDisabled() bool {
 
 // GetEntityRegistry retrieves the entity registry.
 func (c *Client) GetEntityRegistry(ctx context.Context) ([]EntityRegistryEntry, error) {
-	if c.ws != nil {
-		return c.ws.GetEntityRegistryWS(ctx)
+	fetch := func() ([]EntityRegistryEntry, error) {
+		if c.ws != nil {
+			return c.ws.GetEntityRegistryWS(ctx)
+		}
+		var entries []EntityRegistryEntry
+		if err := c.get(ctx, "/api/config/entity_registry/list", &entries); err != nil {
+			return nil, err
+		}
+		return entries, nil
 	}
-	var entries []EntityRegistryEntry
-	if err := c.get(ctx, "/api/config/entity_registry/list", &entries); err != nil {
-		return nil, err
+	if c.registry == nil {
+		return fetch()
 	}
-	return entries, nil
+	return c.registry.entities.get(c.registry.ttl, time.Now(), fetch)
 }
 
 // EntityInfo combines state and registry info for an entity.

--- a/internal/integrations/homeassistant/configapi.go
+++ b/internal/integrations/homeassistant/configapi.go
@@ -110,11 +110,17 @@ func (c *Client) requireWS() (*WSClient, error) {
 
 // GetLabelRegistry retrieves all labels from Home Assistant.
 func (c *Client) GetLabelRegistry(ctx context.Context) ([]LabelRegistryEntry, error) {
-	ws, err := c.requireWS()
-	if err != nil {
-		return nil, err
+	fetch := func() ([]LabelRegistryEntry, error) {
+		ws, err := c.requireWS()
+		if err != nil {
+			return nil, err
+		}
+		return ws.GetLabelRegistry(ctx)
 	}
-	return ws.GetLabelRegistry(ctx)
+	if c.registry == nil {
+		return fetch()
+	}
+	return c.registry.labels.get(c.registry.ttl, time.Now(), fetch)
 }
 
 // GetCategoryRegistry retrieves all categories for a given scope from Home Assistant.
@@ -128,20 +134,32 @@ func (c *Client) GetCategoryRegistry(ctx context.Context, scope string) ([]Categ
 
 // GetFloorRegistry retrieves all floors from Home Assistant.
 func (c *Client) GetFloorRegistry(ctx context.Context) ([]FloorRegistryEntry, error) {
-	ws, err := c.requireWS()
-	if err != nil {
-		return nil, err
+	fetch := func() ([]FloorRegistryEntry, error) {
+		ws, err := c.requireWS()
+		if err != nil {
+			return nil, err
+		}
+		return ws.GetFloorRegistry(ctx)
 	}
-	return ws.GetFloorRegistry(ctx)
+	if c.registry == nil {
+		return fetch()
+	}
+	return c.registry.floors.get(c.registry.ttl, time.Now(), fetch)
 }
 
 // GetDeviceRegistry retrieves all devices from Home Assistant.
 func (c *Client) GetDeviceRegistry(ctx context.Context) ([]DeviceRegistryEntry, error) {
-	ws, err := c.requireWS()
-	if err != nil {
-		return nil, err
+	fetch := func() ([]DeviceRegistryEntry, error) {
+		ws, err := c.requireWS()
+		if err != nil {
+			return nil, err
+		}
+		return ws.GetDeviceRegistry(ctx)
 	}
-	return ws.GetDeviceRegistry(ctx)
+	if c.registry == nil {
+		return fetch()
+	}
+	return c.registry.devices.get(c.registry.ttl, time.Now(), fetch)
 }
 
 // GetConfigEntries retrieves all installed integrations and their
@@ -165,13 +183,19 @@ func (c *Client) GetEntityRegistryEntry(ctx context.Context, entityID string) (*
 	return ws.GetEntityRegistryEntry(ctx, entityID)
 }
 
-// UpdateEntityRegistryEntry updates entity metadata through the registry API.
+// UpdateEntityRegistryEntry updates entity metadata through the registry
+// API. On success it invalidates the cached entity-registry snapshot so
+// the change is not served stale for the rest of the TTL window.
 func (c *Client) UpdateEntityRegistryEntry(ctx context.Context, entityID string, updates map[string]any) (*EntityRegistryEntry, error) {
 	ws, err := c.requireWS()
 	if err != nil {
 		return nil, err
 	}
-	return ws.UpdateEntityRegistryEntry(ctx, entityID, updates)
+	entry, err := ws.UpdateEntityRegistryEntry(ctx, entityID, updates)
+	if err == nil && c.registry != nil {
+		c.registry.entities.invalidate()
+	}
+	return entry, err
 }
 
 // ValidateConfig validates automation trigger/condition/action sections.

--- a/internal/integrations/homeassistant/registry_cache.go
+++ b/internal/integrations/homeassistant/registry_cache.go
@@ -1,0 +1,72 @@
+package homeassistant
+
+import (
+	"sync"
+	"time"
+)
+
+// defaultRegistryCacheTTL is the default freshness window for cached HA
+// registry snapshots. The entity/device/area/label/floor registries
+// change only on Home Assistant configuration edits, so a short window
+// collapses the repeated (multi-MB at 15k+ entities) registry pulls that
+// metadata-bearing tool calls would otherwise issue into a single fetch
+// per window. Live entity state is deliberately NOT cached here — it is
+// volatile and read through one bulk GetStates per call.
+const defaultRegistryCacheTTL = 30 * time.Second
+
+// cachedSlice is a single-flight TTL cache for one registry snapshot.
+// The fetch runs while the lock is held so concurrent callers for the
+// same registry coalesce onto one Home Assistant request rather than
+// stampeding it.
+//
+// The cached slice is shared read-only with every caller inside the TTL
+// window; callers MUST NOT mutate the returned slice or its elements.
+// All current consumers ([EntityMetadataResolver], area activity) treat
+// registry data as immutable.
+type cachedSlice[T any] struct {
+	mu        sync.Mutex
+	value     []T
+	fetchedAt time.Time
+	valid     bool
+}
+
+// get returns the cached value when it is still fresh, otherwise it
+// fetches, stores, and returns. A ttl <= 0 disables caching and always
+// fetches.
+func (c *cachedSlice[T]) get(ttl time.Duration, now time.Time, fetch func() ([]T, error)) ([]T, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.valid && ttl > 0 && now.Sub(c.fetchedAt) < ttl {
+		return c.value, nil
+	}
+	value, err := fetch()
+	if err != nil {
+		return nil, err
+	}
+	c.value = value
+	c.fetchedAt = now
+	c.valid = true
+	return value, nil
+}
+
+// invalidate drops any cached value so the next get refetches. Used
+// after a mutation that the cache would otherwise serve stale.
+func (c *cachedSlice[T]) invalidate() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.valid = false
+	c.value = nil
+}
+
+// registryCache holds the TTL-bounded snapshots of the Home Assistant
+// topology registries shared across all native HA tool calls. ttl is
+// set once at client construction (and optionally overridden at wiring
+// time) before any getter runs, so it carries no separate lock.
+type registryCache struct {
+	ttl      time.Duration
+	areas    cachedSlice[Area]
+	entities cachedSlice[EntityRegistryEntry]
+	devices  cachedSlice[DeviceRegistryEntry]
+	labels   cachedSlice[LabelRegistryEntry]
+	floors   cachedSlice[FloorRegistryEntry]
+}

--- a/internal/integrations/homeassistant/registry_cache_test.go
+++ b/internal/integrations/homeassistant/registry_cache_test.go
@@ -1,0 +1,190 @@
+package homeassistant
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// TestClient_GetAreasUsesRegistryCache verifies the getter wiring: a
+// repeat call inside the TTL is served from cache (no second HTTP hit),
+// invalidation forces a refetch, and a zero TTL disables caching. Uses
+// the REST fallback path (no WS client) so the server hit is countable.
+func TestClient_GetAreasUsesRegistryCache(t *testing.T) {
+	var hits int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/config/area_registry/list" {
+			atomic.AddInt32(&hits, 1)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[{"area_id":"office","name":"Office"}]`))
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "token", nil)
+	ctx := context.Background()
+
+	if _, err := client.GetAreas(ctx); err != nil {
+		t.Fatalf("GetAreas 1: %v", err)
+	}
+	if _, err := client.GetAreas(ctx); err != nil {
+		t.Fatalf("GetAreas 2: %v", err)
+	}
+	if got := atomic.LoadInt32(&hits); got != 1 {
+		t.Fatalf("server hits within TTL = %d, want 1 (second call cached)", got)
+	}
+
+	client.InvalidateRegistryCache()
+	if _, err := client.GetAreas(ctx); err != nil {
+		t.Fatalf("GetAreas after invalidate: %v", err)
+	}
+	if got := atomic.LoadInt32(&hits); got != 2 {
+		t.Fatalf("server hits after invalidate = %d, want 2", got)
+	}
+
+	client.SetRegistryCacheTTL(0)
+	for i := 0; i < 2; i++ {
+		if _, err := client.GetAreas(ctx); err != nil {
+			t.Fatalf("GetAreas ttl=0 #%d: %v", i, err)
+		}
+	}
+	if got := atomic.LoadInt32(&hits); got != 4 {
+		t.Fatalf("server hits with ttl=0 = %d, want 4 (caching disabled)", got)
+	}
+}
+
+func TestCachedSlice_ReusesWithinTTL(t *testing.T) {
+	t.Parallel()
+
+	var calls int
+	fetch := func() ([]int, error) {
+		calls++
+		return []int{calls}, nil
+	}
+
+	var c cachedSlice[int]
+	base := time.Unix(1000, 0)
+
+	first, err := c.get(time.Minute, base, fetch)
+	if err != nil {
+		t.Fatalf("first get: %v", err)
+	}
+	// 30s later, still within the 1m TTL — must reuse, no refetch.
+	second, err := c.get(time.Minute, base.Add(30*time.Second), fetch)
+	if err != nil {
+		t.Fatalf("second get: %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("fetch called %d times within TTL, want 1", calls)
+	}
+	if first[0] != 1 || second[0] != 1 {
+		t.Fatalf("cached values = %v/%v, want both from the single fetch", first, second)
+	}
+}
+
+func TestCachedSlice_RefetchesAfterExpiry(t *testing.T) {
+	t.Parallel()
+
+	var calls int
+	fetch := func() ([]int, error) {
+		calls++
+		return []int{calls}, nil
+	}
+
+	var c cachedSlice[int]
+	base := time.Unix(1000, 0)
+
+	if _, err := c.get(time.Minute, base, fetch); err != nil {
+		t.Fatalf("first get: %v", err)
+	}
+	// Past the TTL — must refetch.
+	got, err := c.get(time.Minute, base.Add(90*time.Second), fetch)
+	if err != nil {
+		t.Fatalf("second get: %v", err)
+	}
+	if calls != 2 {
+		t.Fatalf("fetch called %d times across expiry, want 2", calls)
+	}
+	if got[0] != 2 {
+		t.Fatalf("post-expiry value = %v, want fresh fetch (2)", got)
+	}
+}
+
+func TestCachedSlice_InvalidateForcesRefetch(t *testing.T) {
+	t.Parallel()
+
+	var calls int
+	fetch := func() ([]int, error) {
+		calls++
+		return []int{calls}, nil
+	}
+
+	var c cachedSlice[int]
+	base := time.Unix(1000, 0)
+
+	if _, err := c.get(time.Minute, base, fetch); err != nil {
+		t.Fatalf("first get: %v", err)
+	}
+	c.invalidate()
+	// Still within TTL, but invalidated — must refetch.
+	if _, err := c.get(time.Minute, base.Add(time.Second), fetch); err != nil {
+		t.Fatalf("post-invalidate get: %v", err)
+	}
+	if calls != 2 {
+		t.Fatalf("fetch called %d times after invalidate, want 2", calls)
+	}
+}
+
+func TestCachedSlice_TTLZeroDisablesCaching(t *testing.T) {
+	t.Parallel()
+
+	var calls int
+	fetch := func() ([]int, error) {
+		calls++
+		return []int{calls}, nil
+	}
+
+	var c cachedSlice[int]
+	base := time.Unix(1000, 0)
+	for i := 0; i < 3; i++ {
+		if _, err := c.get(0, base, fetch); err != nil {
+			t.Fatalf("get %d: %v", i, err)
+		}
+	}
+	if calls != 3 {
+		t.Fatalf("fetch called %d times with ttl=0, want 3 (caching disabled)", calls)
+	}
+}
+
+func TestCachedSlice_FetchErrorNotCached(t *testing.T) {
+	t.Parallel()
+
+	var calls int
+	wantErr := errors.New("boom")
+	fetch := func() ([]int, error) {
+		calls++
+		if calls == 1 {
+			return nil, wantErr
+		}
+		return []int{calls}, nil
+	}
+
+	var c cachedSlice[int]
+	base := time.Unix(1000, 0)
+
+	if _, err := c.get(time.Minute, base, fetch); !errors.Is(err, wantErr) {
+		t.Fatalf("first get err = %v, want %v", err, wantErr)
+	}
+	// The error must not be cached — a subsequent get retries.
+	got, err := c.get(time.Minute, base.Add(time.Second), fetch)
+	if err != nil {
+		t.Fatalf("retry get: %v", err)
+	}
+	if calls != 2 || got[0] != 2 {
+		t.Fatalf("calls=%d got=%v, want retry after a non-cached error", calls, got)
+	}
+}

--- a/internal/platform/config/config.go
+++ b/internal/platform/config/config.go
@@ -891,6 +891,16 @@ type HomeAssistantConfig struct {
 	// "building" when floors represent buildings in this deployment.
 	FloorAlias string `yaml:"floor_alias,omitempty"`
 
+	// RegistryCacheTTL bounds how long entity/device/area/label/floor
+	// registry snapshots are reused across native HA tool calls before a
+	// refetch. These registries change only on HA config edits, so a
+	// short window collapses the repeated (multi-MB at scale) registry
+	// pulls that metadata-bearing tool calls would otherwise issue.
+	// Accepts a Go duration string ("30s", "1m"); empty uses the 30s
+	// default; "0" disables caching (always refetch). Live entity state
+	// is never cached.
+	RegistryCacheTTL string `yaml:"registry_cache_ttl,omitempty"`
+
 	// Subscribe configures WebSocket event subscriptions for real-time
 	// state change monitoring. When entity_globs is non-empty, only
 	// matching entities are processed; when empty, all state changes

--- a/scripts/architecture.baseline
+++ b/scripts/architecture.baseline
@@ -1,5 +1,5 @@
 packages=58
 interfaces=76
-large_files=43
-set_mutators=104
+large_files=44
+set_mutators=105
 database_opens=8


### PR DESCRIPTION
Closes #1010. Enabling perf work for the native-HA overhaul (#1002), implementing the #1002 doctrine's rule #6.

## Why

At production scale (**15k+ live entities**) the entity/device/area/label/floor registries are multi-MB, yet every metadata-bearing or area-filtered native HA tool call refetched them. A burst of `ha_search_states` / `ha_find_entity` / `ha_get_state include=...` in a single turn re-pulled the full registry each time. Only the awareness render path cached — and only *per render*.

This is the single highest-leverage efficiency win for the overhaul: it turns "every metadata call re-pulls 15k rows" into **one fetch per TTL window**, making the perception tools cheap enough to use freely.

## What

A TTL-bounded snapshot cache on the HA client, shared by every native HA tool transparently (zero call-site changes):

- **`registry_cache.go`** — a generic **single-flight** `cachedSlice[T]` (the fetch runs under the lock so concurrent callers for the same registry coalesce onto one HA request instead of stampeding it), plus a `registryCache` holding the five topology registries.
- `GetAreas` / `GetEntityRegistry` / `GetDeviceRegistry` / `GetLabelRegistry` / `GetFloorRegistry` now read through the cache. A nil cache (struct-literal clients) bypasses transparently.
- **Live state (`GetStates`) and config-entry health are deliberately NOT cached** — they're volatile (the doctrine's "best surface" split).
- `UpdateEntityRegistryEntry` invalidates the entity snapshot so a write is never served stale; `InvalidateRegistryCache` clears all five.
- Default TTL **30s**; `SetRegistryCacheTTL` (≤0 disables) wired to a new `home_assistant.registry_cache_ttl` config knob (example config regenerated). Operators get an off-switch without a redeploy.

Cached slices are shared **read-only** within the window — documented as an immutability contract (the metadata resolver and area activity already treat registry data as immutable).

## Tests

- `cachedSlice`: reuse-within-TTL, refetch-after-expiry, invalidate-forces-refetch, ttl=0-disables, error-not-cached.
- Client-level end-to-end: second `GetAreas` served from cache (one server hit), invalidation refetches, ttl=0 disables.

## Grounding

Validated against HA's own developer docs (coordinator single-fetch + `always_update=False`, push-over-poll, parallel-request throttling). Follow-up noted on #1010: evaluate `config/entity_registry/list_for_display` as a lighter bulk surface for the cache-miss fetch.

## Test plan

- [x] `go test ./internal/integrations/homeassistant/...`
- [x] `just ci` green locally (incl. config-generate + architecture baseline)
- [x] Architecture baseline bumped (large_files 43→44, set_mutators 104→105) with rationale

🤖 Generated with [Claude Code](https://claude.com/claude-code)