### PR TITLE
feat(ha): ha_list_entities glob, on a shared entity-glob matcher

### DIFF
--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -111,7 +111,7 @@ becoming default context clutter.
 | `ha_control_device` | Natural-language device control with fuzzy entity matching. |
 | `ha_find_entity` | Smart entity discovery across HA domains, optionally enriched with HA metadata. |
 | `ha_get_state` | Current state of any entity, with optional area/device/label/description/visibility metadata. |
-| `ha_list_entities` | Browse entities by domain with optional HA metadata. |
+| `ha_list_entities` | Browse entities by domain and/or entity_id glob (e.g. `binary_sensor.*door*`), with optional HA metadata. |
 | `ha_search_states` | Predicate search across live entity state (state value, numeric attribute, domain, area). |
 | `ha_call_service` | Direct HA service invocation. |
 | `ha_registry_search` | Search the entity/device/area registry. |

--- a/internal/integrations/homeassistant/entity_glob.go
+++ b/internal/integrations/homeassistant/entity_glob.go
@@ -1,0 +1,29 @@
+package homeassistant
+
+import "path"
+
+// MatchEntityGlob reports whether entityID matches the glob pattern.
+// Patterns use [path.Match] syntax — '*' matches any run of characters.
+// Entity IDs contain no '/' separators, so '*' spans the domain dot
+// freely: "binary_sensor.*door*" matches "binary_sensor.front_door" and
+// "*_temperature" spans domains. Returns an error only for a malformed
+// pattern (see [ValidateEntityGlob]).
+//
+// This is the single entity-glob primitive shared across the codebase:
+// [EntityFilter] (the state-watch stream), the ha_list_entities tool,
+// entity-subscription expansion, and config validation all route through
+// it so the glob contract can't drift between surfaces.
+func MatchEntityGlob(pattern, entityID string) (bool, error) {
+	return path.Match(pattern, entityID)
+}
+
+// ValidateEntityGlob reports whether pattern is a well-formed entity
+// glob. Use it at tool and config boundaries to reject malformed
+// patterns up front, rather than letting them silently fail to match.
+func ValidateEntityGlob(pattern string) error {
+	// path.Match only inspects the pattern for ErrBadPattern; the
+	// subject string is irrelevant, so a representative entity_id shape
+	// is enough to surface a syntax error.
+	_, err := path.Match(pattern, "domain.entity")
+	return err
+}

--- a/internal/integrations/homeassistant/entity_glob_test.go
+++ b/internal/integrations/homeassistant/entity_glob_test.go
@@ -1,0 +1,50 @@
+package homeassistant
+
+import "testing"
+
+func TestMatchEntityGlob(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		pattern string
+		entity  string
+		want    bool
+	}{
+		{"within domain", "binary_sensor.*door*", "binary_sensor.front_door", true},
+		{"within domain no match", "binary_sensor.*door*", "binary_sensor.kitchen_window", false},
+		{"cross-domain suffix", "*_temperature", "sensor.office_temperature", true},
+		{"cross-domain suffix climate", "*_temperature", "climate.living_room_temperature", true},
+		{"domain prefix wildcard", "light.office_*", "light.office_lamp", true},
+		{"domain prefix wildcard miss", "light.office_*", "light.hall", false},
+		{"star spans the dot", "*office*", "light.office_lamp", true},
+		{"exact", "light.hall", "light.hall", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := MatchEntityGlob(tt.pattern, tt.entity)
+			if err != nil {
+				t.Fatalf("MatchEntityGlob error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("MatchEntityGlob(%q, %q) = %v, want %v", tt.pattern, tt.entity, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMatchEntityGlob_MalformedReturnsError(t *testing.T) {
+	t.Parallel()
+	if _, err := MatchEntityGlob("light.[bad", "light.x"); err == nil {
+		t.Fatal("expected error for malformed pattern")
+	}
+}
+
+func TestValidateEntityGlob(t *testing.T) {
+	t.Parallel()
+	if err := ValidateEntityGlob("binary_sensor.*door*"); err != nil {
+		t.Errorf("valid pattern reported error: %v", err)
+	}
+	if err := ValidateEntityGlob("light.[bad"); err == nil {
+		t.Error("malformed pattern should report an error")
+	}
+}

--- a/internal/integrations/homeassistant/statewatch.go
+++ b/internal/integrations/homeassistant/statewatch.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"log/slog"
-	"path"
 	"sync"
 	"time"
 )
@@ -38,7 +37,7 @@ func (f *EntityFilter) Match(entityID string) bool {
 		return true
 	}
 	for _, pat := range f.patterns {
-		matched, err := path.Match(pat, entityID)
+		matched, err := MatchEntityGlob(pat, entityID)
 		if err != nil {
 			f.logger.Debug("glob match error", "pattern", pat, "entity_id", entityID, "error", err)
 			continue

--- a/internal/platform/config/config.go
+++ b/internal/platform/config/config.go
@@ -29,7 +29,6 @@ import (
 	"net"
 	"net/url"
 	"os"
-	"path"
 	"path/filepath"
 	"sort"
 	"strconv"
@@ -39,6 +38,7 @@ import (
 	"github.com/nugget/thane-ai-agent/internal/channels/email"
 	"github.com/nugget/thane-ai-agent/internal/channels/messages"
 	"github.com/nugget/thane-ai-agent/internal/integrations/forge"
+	"github.com/nugget/thane-ai-agent/internal/integrations/homeassistant"
 	"github.com/nugget/thane-ai-agent/internal/integrations/search"
 	"github.com/nugget/thane-ai-agent/internal/model/router"
 	"github.com/nugget/thane-ai-agent/internal/model/toolcatalog"
@@ -2955,7 +2955,7 @@ func (c *Config) validateMCP() error {
 // for consistency.
 func (c *Config) validateSubscribe() error {
 	for i, glob := range c.HomeAssistant.Subscribe.EntityGlobs {
-		if _, err := path.Match(glob, ""); err != nil {
+		if err := homeassistant.ValidateEntityGlob(glob); err != nil {
 			return fmt.Errorf("homeassistant.subscribe.entity_globs[%d] %q: invalid glob pattern: %w", i, glob, err)
 		}
 	}

--- a/internal/tools/ha_entity_metadata.go
+++ b/internal/tools/ha_entity_metadata.go
@@ -18,7 +18,8 @@ type haEntityMetadataBundle struct {
 }
 
 type haListEntitiesResult struct {
-	Domain    string             `json:"domain"`
+	Domain    string             `json:"domain,omitempty"`
+	Pattern   string             `json:"pattern,omitempty"`
 	Count     int                `json:"count"`
 	Total     int                `json:"total"`
 	Truncated bool               `json:"truncated,omitempty"`

--- a/internal/tools/ha_list_entities_test.go
+++ b/internal/tools/ha_list_entities_test.go
@@ -1,0 +1,107 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/nugget/thane-ai-agent/internal/integrations/homeassistant"
+)
+
+func listEntitiesFixture(t *testing.T) *Registry {
+	t.Helper()
+	fake := newFakeHAServer(t)
+	fake.states = []homeassistant.State{
+		{EntityID: "binary_sensor.front_door", State: "off"},
+		{EntityID: "binary_sensor.back_door", State: "on"},
+		{EntityID: "binary_sensor.kitchen_window", State: "off"},
+		{EntityID: "sensor.office_temperature", State: "72"},
+		{EntityID: "climate.living_room_temperature", State: "70"},
+		{EntityID: "light.office_lamp", State: "on"},
+		{EntityID: "light.office_desk", State: "off"},
+		{EntityID: "light.hall", State: "off"},
+	}
+	return fake.registry(t)
+}
+
+func listEntities(t *testing.T, reg *Registry, argsJSON string) haListEntitiesResult {
+	t.Helper()
+	out, err := reg.Execute(context.Background(), "ha_list_entities", argsJSON)
+	if err != nil {
+		t.Fatalf("ha_list_entities(%s): %v", argsJSON, err)
+	}
+	var res haListEntitiesResult
+	if err := json.Unmarshal([]byte(out), &res); err != nil {
+		t.Fatalf("unmarshal: %v\n%s", err, out)
+	}
+	return res
+}
+
+func listEntityIDs(res haListEntitiesResult) map[string]bool {
+	ids := make(map[string]bool, len(res.Items))
+	for _, it := range res.Items {
+		ids[it.EntityID] = true
+	}
+	return ids
+}
+
+func TestHAListEntities_DomainPrefixUnchanged(t *testing.T) {
+	reg := listEntitiesFixture(t)
+	res := listEntities(t, reg, `{"domain":"light"}`)
+	if res.Total != 3 || res.Count != 3 {
+		t.Fatalf("light total/count = %d/%d, want 3/3", res.Total, res.Count)
+	}
+	ids := listEntityIDs(res)
+	if !ids["light.office_lamp"] || !ids["light.hall"] || ids["binary_sensor.front_door"] {
+		t.Errorf("domain filter leaked: %v", ids)
+	}
+}
+
+func TestHAListEntities_PatternWithinDomain(t *testing.T) {
+	reg := listEntitiesFixture(t)
+	res := listEntities(t, reg, `{"pattern":"binary_sensor.*door*"}`)
+	ids := listEntityIDs(res)
+	if len(ids) != 2 || !ids["binary_sensor.front_door"] || !ids["binary_sensor.back_door"] {
+		t.Errorf("matched = %v, want front_door + back_door (not kitchen_window)", ids)
+	}
+}
+
+func TestHAListEntities_PatternCrossDomainSuffix(t *testing.T) {
+	reg := listEntitiesFixture(t)
+	res := listEntities(t, reg, `{"pattern":"*_temperature"}`)
+	ids := listEntityIDs(res)
+	if len(ids) != 2 || !ids["sensor.office_temperature"] || !ids["climate.living_room_temperature"] {
+		t.Errorf("matched = %v, want the two *_temperature entities across domains", ids)
+	}
+}
+
+func TestHAListEntities_DomainAndPatternCombine(t *testing.T) {
+	reg := listEntitiesFixture(t)
+	res := listEntities(t, reg, `{"domain":"light","pattern":"*office*"}`)
+	ids := listEntityIDs(res)
+	if len(ids) != 2 || !ids["light.office_lamp"] || !ids["light.office_desk"] {
+		t.Errorf("matched = %v, want only office lights (domain AND pattern)", ids)
+	}
+}
+
+func TestHAListEntities_NoMatch(t *testing.T) {
+	reg := listEntitiesFixture(t)
+	res := listEntities(t, reg, `{"pattern":"*nonexistent*"}`)
+	if res.Total != 0 || res.Count != 0 || len(res.Items) != 0 {
+		t.Errorf("expected zero matches, got %#v", res)
+	}
+}
+
+func TestHAListEntities_MalformedPatternErrors(t *testing.T) {
+	reg := listEntitiesFixture(t)
+	if _, err := reg.Execute(context.Background(), "ha_list_entities", `{"pattern":"light.[bad"}`); err == nil {
+		t.Fatal("expected error for malformed glob pattern")
+	}
+}
+
+func TestHAListEntities_RequiresDomainOrPattern(t *testing.T) {
+	reg := listEntitiesFixture(t)
+	if _, err := reg.Execute(context.Background(), "ha_list_entities", `{}`); err == nil {
+		t.Fatal("expected error when neither domain nor pattern is supplied")
+	}
+}

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -6,6 +6,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"path"
 	"sort"
 	"strings"
 	"time"
@@ -727,16 +728,20 @@ func (r *Registry) registerBuiltins() {
 		Handler: r.handleGetState,
 	})
 
-	// List entities by domain
+	// List entities by domain or entity_id glob
 	r.Register(&Tool{
 		Name:        "ha_list_entities",
-		Description: "List all entities in a domain (e.g., all lights, all sensors). Use this to discover what's available.",
+		Description: "List Home Assistant entities by domain and/or an entity_id glob. Use domain for a whole domain (all lights); use pattern for substring/cross-domain matching (e.g. binary_sensor.*door*, *_temperature). At least one of domain or pattern is required; when both are given they combine (AND).",
 		Parameters: map[string]any{
 			"type": "object",
 			"properties": map[string]any{
 				"domain": map[string]any{
 					"type":        "string",
-					"description": "The domain to list (e.g., light, switch, sensor, binary_sensor, climate, cover)",
+					"description": "List every entity in this exact domain (e.g., light, switch, sensor, binary_sensor, climate, cover). Optional when pattern is supplied.",
+				},
+				"pattern": map[string]any{
+					"type":        "string",
+					"description": "Glob over the full entity_id (path.Match syntax, '*' matches any run of characters): binary_sensor.*door*, *_temperature, light.office_*. Optional when domain is supplied; combined with domain as an AND.",
 				},
 				"limit": map[string]any{
 					"type":        "integer",
@@ -744,7 +749,6 @@ func (r *Registry) registerBuiltins() {
 				},
 				"include": EntityMetadataIncludeParameter(),
 			},
-			"required": []string{"domain"},
 		},
 		Handler: r.handleListEntities,
 	})
@@ -1237,9 +1241,18 @@ func (r *Registry) handleListEntities(ctx context.Context, args map[string]any) 
 		return "", fmt.Errorf("home assistant is currently unreachable (reconnecting in background)")
 	}
 
-	domain, _ := args["domain"].(string)
-	if domain == "" {
-		return "", fmt.Errorf("domain is required")
+	domain := strings.TrimSpace(stringArgValue(args, "domain"))
+	pattern := strings.TrimSpace(stringArgValue(args, "pattern"))
+	if domain == "" && pattern == "" {
+		return "", fmt.Errorf("at least one of domain or pattern is required")
+	}
+	// Validate the glob up-front so a malformed pattern is a clear error
+	// rather than a silent no-match. path.Match only errors on bad
+	// syntax, so once this passes the per-entity calls below cannot.
+	if pattern != "" {
+		if _, err := path.Match(pattern, "domain.entity"); err != nil {
+			return "", fmt.Errorf("invalid pattern %q: %w", pattern, err)
+		}
 	}
 
 	limit, err := boundedIntArg(args, "limit", 20, maxHAListEntitiesLimit)
@@ -1260,24 +1273,33 @@ func (r *Registry) handleListEntities(ctx context.Context, args map[string]any) 
 	var matchEntityIDs []string
 	var matchStates []homeassistant.State
 	total := 0
-	prefix := domain + "."
+	prefix := ""
+	if domain != "" {
+		prefix = domain + "."
+	}
 	for _, s := range states {
-		if strings.HasPrefix(s.EntityID, prefix) {
-			total++
-			if len(matches) >= limit {
+		if prefix != "" && !strings.HasPrefix(s.EntityID, prefix) {
+			continue
+		}
+		if pattern != "" {
+			if ok, _ := path.Match(pattern, s.EntityID); !ok {
 				continue
 			}
-			item := haListEntityItem{
-				EntityID: s.EntityID,
-				State:    s.State,
-			}
-			if friendly, ok := s.Attributes["friendly_name"].(string); ok {
-				item.FriendlyName = friendly
-			}
-			matches = append(matches, item)
-			matchEntityIDs = append(matchEntityIDs, s.EntityID)
-			matchStates = append(matchStates, s)
 		}
+		total++
+		if len(matches) >= limit {
+			continue
+		}
+		item := haListEntityItem{
+			EntityID: s.EntityID,
+			State:    s.State,
+		}
+		if friendly, ok := s.Attributes["friendly_name"].(string); ok {
+			item.FriendlyName = friendly
+		}
+		matches = append(matches, item)
+		matchEntityIDs = append(matchEntityIDs, s.EntityID)
+		matchStates = append(matchStates, s)
 	}
 	if include.Any() && len(matches) > 0 {
 		bundle, err := fetchHAEntityMetadataBundleForEntityIDs(ctx, r.ha, include, matchEntityIDs)
@@ -1291,6 +1313,7 @@ func (r *Registry) handleListEntities(ctx context.Context, args map[string]any) 
 
 	result := haListEntitiesResult{
 		Domain:    domain,
+		Pattern:   pattern,
 		Count:     len(matches),
 		Total:     total,
 		Truncated: total > len(matches),

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -6,7 +6,6 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
-	"path"
 	"sort"
 	"strings"
 	"time"
@@ -1247,10 +1246,10 @@ func (r *Registry) handleListEntities(ctx context.Context, args map[string]any) 
 		return "", fmt.Errorf("at least one of domain or pattern is required")
 	}
 	// Validate the glob up-front so a malformed pattern is a clear error
-	// rather than a silent no-match. path.Match only errors on bad
-	// syntax, so once this passes the per-entity calls below cannot.
+	// rather than a silent no-match. Once this passes the per-entity
+	// matches below cannot error.
 	if pattern != "" {
-		if _, err := path.Match(pattern, "domain.entity"); err != nil {
+		if err := homeassistant.ValidateEntityGlob(pattern); err != nil {
 			return "", fmt.Errorf("invalid pattern %q: %w", pattern, err)
 		}
 	}
@@ -1282,7 +1281,7 @@ func (r *Registry) handleListEntities(ctx context.Context, args map[string]any) 
 			continue
 		}
 		if pattern != "" {
-			if ok, _ := path.Match(pattern, s.EntityID); !ok {
+			if ok, _ := homeassistant.MatchEntityGlob(pattern, s.EntityID); !ok {
 				continue
 			}
 		}

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -748,6 +748,13 @@ func (r *Registry) registerBuiltins() {
 				},
 				"include": EntityMetadataIncludeParameter(),
 			},
+			// Encode the handler's "at least one of domain or pattern"
+			// rule in the schema so the model/tooling won't generate an
+			// empty {} call. The handler still enforces it at runtime.
+			"anyOf": []map[string]any{
+				{"required": []string{"domain"}},
+				{"required": []string{"pattern"}},
+			},
 		},
 		Handler: r.handleListEntities,
 	})

--- a/talents/ha.md
+++ b/talents/ha.md
@@ -124,6 +124,21 @@ set ("check every door sensor"). Returns structured entity rows; add
 metadata when the model needs room, device, label, or description
 context to choose the right follow-up.
 
+For substring or cross-domain matches, pass a `pattern` glob over the
+full entity_id instead of (or alongside) `domain`:
+
+```json
+{
+  "pattern": "binary_sensor.*door*"
+}
+```
+
+`*` matches any run of characters, so `*_temperature` spans domains and
+`light.office_*` narrows within one. Domain and pattern combine (AND)
+when both are given. This is for *naming*-shaped discovery; to find
+entities by their live *state* (what's on, what's open, low batteries),
+reach for `ha_search_states` instead.
+
 ## I want everything matching a live-state condition
 
 `ha_search_states` filters by *current state* across all domains —


### PR DESCRIPTION
Closes #1004. Phase 1 of the native-HA overhaul (#1002).

## ha_list_entities glob (the feature)
`ha_list_entities` did a strict domain-prefix match — no `binary_sensor.*door*` or cross-domain `*_temperature`. Adds an optional **`pattern`** glob over the full entity_id (`path.Match` syntax); `domain` becomes optional; at least one is required; both combine (AND). Malformed globs error up front. The resolved `pattern` is echoed in the result. Tool description, `tools.md`, and `talents/ha.md` all describe it (doc-drift acceptance criterion); `ha.md` routes state-shaped discovery to `ha_search_states`.

## Single entity-glob matcher (the consolidation)
The new glob was a *third* copy of `path.Match`-based entity globbing, alongside `homeassistant.EntityFilter` (state-watch stream) and `config.validateSubscribe`. This PR consolidates them onto one primitive so the contract can't drift:

- New `homeassistant.MatchEntityGlob` / `ValidateEntityGlob` own the entity-glob contract.
- `EntityFilter.Match`, `ha_list_entities`, and `config.validateSubscribe` all route through it; the inline `path.Match` copies (and their imports) are removed.

This is also the reusable foundation for **live-glob entity subscriptions** (a follow-up): the subscription providers will expand globs through the same `MatchEntityGlob`.

## Performance
Per the #1002 doctrine, `ha_list_entities`' access pattern is unchanged: one bulk `GetStates`, in-process filter, scoped per-page registry enrichment.

## Tests
- ha_list_entities: domain-prefix unchanged, within-domain glob, cross-domain suffix, domain+pattern AND, no-match, malformed pattern, neither-supplied error.
- matcher: pattern forms + malformed-pattern + validation.

## Test plan
- [x] `go test ./...` (homeassistant, tools, config)
- [x] `just ci` green locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)