### PR TITLE
feat(ha): live-glob entity subscriptions (expand-at-render, capped)

### DIFF
--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -94,6 +94,14 @@ fetch Home Assistant forecast response data each turn and include a
 compact forecast in the injected entity context. Use `forecast: none` to
 clear forecast fetching for that subscription.
 
+An entity subscription's `entity_id` may be a glob (e.g.
+`binary_sensor.*door*`, `*_temperature`) instead of a concrete id. A glob
+subscription is re-expanded against live entities every turn — newly
+matching entities join automatically — and is capped per turn, emitting a
+truncation marker when it matches more than the cap. This works across
+`add_entity_subscription`, `watch_entity`, `thane_curate.entities`, and
+`update_entity_subscriptions`.
+
 Entity subscriptions also accept `include`, a set of HA metadata flags:
 `area`, `device`, `labels`, `description`, and `visibility`, or
 `all: true`. Enabled metadata is resolved through the native HA registries and

--- a/internal/app/loop_focus_tools.go
+++ b/internal/app/loop_focus_tools.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/nugget/thane-ai-agent/internal/integrations/homeassistant"
 	looppkg "github.com/nugget/thane-ai-agent/internal/runtime/loop"
 	"github.com/nugget/thane-ai-agent/internal/tools"
 )
@@ -55,7 +56,7 @@ func buildLoopFocusToolsWithMutator(loopName string, mutator subscriptionMutator
 				"properties": map[string]any{
 					"entity_id": map[string]any{
 						"type":        "string",
-						"description": "The Home Assistant entity ID to watch (e.g., sensor.upstairs_temperature, weather.home).",
+						"description": "The Home Assistant entity ID to watch (e.g., sensor.upstairs_temperature, weather.home), or a glob pattern (e.g., binary_sensor.*door*, *_temperature) to watch every matching entity, re-expanded live each turn (capped per turn).",
 					},
 					"history": map[string]any{
 						"type":        "array",
@@ -79,6 +80,9 @@ func buildLoopFocusToolsWithMutator(loopName string, mutator subscriptionMutator
 				entityID := strings.TrimSpace(stringMapValue(args, "entity_id"))
 				if entityID == "" {
 					return "", fmt.Errorf("entity_id is required")
+				}
+				if err := homeassistant.ValidateEntityTarget(entityID); err != nil {
+					return "", fmt.Errorf("entity_id %q: invalid glob pattern: %w", entityID, err)
 				}
 				history, err := intSliceFromMap(args, "history")
 				if err != nil {

--- a/internal/integrations/homeassistant/entity_glob.go
+++ b/internal/integrations/homeassistant/entity_glob.go
@@ -1,6 +1,19 @@
 package homeassistant
 
-import "path"
+import (
+	"path"
+	"strings"
+)
+
+// IsEntityGlob reports whether s is a glob pattern rather than a concrete
+// entity_id. Home Assistant entity IDs are domain.object_id over
+// [a-z0-9_] and never contain glob metacharacters, so the presence of
+// '*', '?', or '[' unambiguously marks a pattern. Callers use this to
+// decide whether an entity-subscription target should be expanded against
+// live entities or treated as a single concrete entity.
+func IsEntityGlob(s string) bool {
+	return strings.ContainsAny(s, "*?[")
+}
 
 // MatchEntityGlob reports whether entityID matches the glob pattern.
 // Patterns use [path.Match] syntax — '*' matches any run of characters.
@@ -26,4 +39,17 @@ func ValidateEntityGlob(pattern string) error {
 	// is enough to surface a syntax error.
 	_, err := path.Match(pattern, "domain.entity")
 	return err
+}
+
+// ValidateEntityTarget validates a subscription or tool target that may
+// be either a concrete entity_id or a glob. Concrete IDs always pass; a
+// glob must be well-formed. An empty string passes (callers enforce
+// required-ness separately). This is the one call subscription-creation
+// surfaces make so a malformed glob is rejected up front instead of
+// silently never matching at render time.
+func ValidateEntityTarget(s string) error {
+	if IsEntityGlob(s) {
+		return ValidateEntityGlob(s)
+	}
+	return nil
 }

--- a/internal/state/awareness/glob_subscription.go
+++ b/internal/state/awareness/glob_subscription.go
@@ -1,0 +1,168 @@
+package awareness
+
+import (
+	"context"
+	"log/slog"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/nugget/thane-ai-agent/internal/integrations/homeassistant"
+	"github.com/nugget/thane-ai-agent/internal/model/promptfmt"
+)
+
+// defaultMaxGlobExpansion caps how many entities a single glob
+// subscription renders per turn. A glob subscription is re-expanded
+// against live entities on every render, so an unbounded match set
+// (e.g. "*_temperature" in a 15k-entity install) would flood the prompt
+// each iteration. The cap bounds the per-turn cost; overflow is reported
+// via a truncation marker so the model knows the view is partial.
+const defaultMaxGlobExpansion = 25
+
+// normalizeMaxGlobExpansion returns a sane cap, applying the default
+// when v is non-positive.
+func normalizeMaxGlobExpansion(v int) int {
+	if v <= 0 {
+		return defaultMaxGlobExpansion
+	}
+	return v
+}
+
+// lazyStates fetches the full live state snapshot once, on first use,
+// and reuses it across a single render. Glob expansion needs the entity
+// universe; concrete subscriptions don't, so a render with no glob
+// subscriptions never calls GetStates at all.
+type lazyStates struct {
+	ha     StateGetter
+	logger *slog.Logger
+	states []homeassistant.State
+	done   bool
+}
+
+func newLazyStates(ha StateGetter, logger *slog.Logger) *lazyStates {
+	return &lazyStates{ha: ha, logger: logger}
+}
+
+func (l *lazyStates) get(ctx context.Context) []homeassistant.State {
+	if l.done {
+		return l.states
+	}
+	l.done = true
+	s, err := l.ha.GetStates(ctx)
+	if err != nil {
+		if l.logger != nil {
+			l.logger.Warn("failed to fetch states for glob subscription expansion", "error", err)
+		}
+		return nil
+	}
+	l.states = s
+	return l.states
+}
+
+// renderWatchedState renders one entity's watched-context block from an
+// already-fetched state, applying the subscription's forecast, metadata,
+// and history options. It is the single per-entity render shared by the
+// concrete-id path and the glob-expansion path, so the two can't drift —
+// the glob path passes states it pulled in bulk, avoiding a per-entity
+// GetState.
+func renderWatchedState(
+	ctx context.Context,
+	ha StateGetter,
+	logger *slog.Logger,
+	sub WatchedSubscription,
+	state *homeassistant.State,
+	now time.Time,
+	registries *renderRegistries,
+) string {
+	state = watchlistStateWithForecast(ctx, ha, logger, sub, state, "failed to fetch watched weather forecast")
+
+	content := formatEntityContextWithMetadata(state, now, registries.entityMetadata(sub.EntityID, state, sub.Include))
+	content = enrichWithLastKnownGood(ctx, ha, content, state, now)
+	content = enrichUnavailable(content, state, registries)
+	if len(sub.History) == 0 {
+		return content
+	}
+
+	summaries, truncated, err := buildWatchlistHistorySummaries(ctx, ha, state, sub.History, now)
+	if err != nil {
+		if logger != nil {
+			logger.Warn("failed to fetch watched entity history",
+				"entity_id", sub.EntityID, "history", sub.History, "error", err)
+		}
+		return content
+	}
+	if len(summaries) == 0 && !truncated {
+		return content
+	}
+	return mergeHistoryIntoEntityContext(content, summaries, truncated)
+}
+
+// expandGlobSubscription renders a glob subscription by matching its
+// pattern (carried in sub.EntityID) against the supplied live states,
+// rendering up to maxExpansion matches — sorted for stable output, with
+// the subscription's own options applied to each — and appending a
+// truncation marker when more matched than the cap.
+//
+// Returns "" when the glob matches nothing this turn; the subscription
+// stays live and is re-evaluated next render, so a silent empty turn is
+// the intended "nothing matches right now" signal rather than an error.
+// states is the single bulk snapshot the caller fetched once per render,
+// so expansion adds no per-entity state fetch.
+func expandGlobSubscription(
+	ctx context.Context,
+	ha StateGetter,
+	logger *slog.Logger,
+	sub WatchedSubscription,
+	states []homeassistant.State,
+	now time.Time,
+	registries *renderRegistries,
+	maxExpansion int,
+) string {
+	pattern := sub.EntityID
+	stateByID := make(map[string]*homeassistant.State, len(states))
+	matchedIDs := make([]string, 0)
+	for i := range states {
+		s := &states[i]
+		stateByID[s.EntityID] = s
+		if ok, _ := homeassistant.MatchEntityGlob(pattern, s.EntityID); ok {
+			matchedIDs = append(matchedIDs, s.EntityID)
+		}
+	}
+	if len(matchedIDs) == 0 {
+		return ""
+	}
+	sort.Strings(matchedIDs)
+
+	total := len(matchedIDs)
+	truncated := false
+	if cap := normalizeMaxGlobExpansion(maxExpansion); total > cap {
+		matchedIDs = matchedIDs[:cap]
+		truncated = true
+	}
+
+	var sb strings.Builder
+	for _, id := range matchedIDs {
+		matchSub := sub
+		matchSub.EntityID = id
+		sb.WriteString(renderWatchedState(ctx, ha, logger, matchSub, stateByID[id], now, registries))
+		sb.WriteByte('\n')
+	}
+	if truncated {
+		sb.WriteString(formatGlobTruncation(pattern, total, len(matchedIDs)))
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+// formatGlobTruncation renders the marker line appended when a glob
+// matched more entities than the per-turn cap, so the model can tell the
+// view is partial and narrow the pattern if it needs the rest.
+func formatGlobTruncation(pattern string, matched, shown int) string {
+	return promptfmt.MarshalCompact(map[string]any{
+		"glob":      pattern,
+		"matched":   matched,
+		"shown":     shown,
+		"truncated": true,
+		"note":      "glob matched more entities than the per-turn cap; narrow the pattern to see the rest",
+	})
+}

--- a/internal/state/awareness/glob_subscription.go
+++ b/internal/state/awareness/glob_subscription.go
@@ -36,6 +36,7 @@ type lazyStates struct {
 	ha     StateGetter
 	logger *slog.Logger
 	states []homeassistant.State
+	err    error
 	done   bool
 }
 
@@ -43,20 +44,21 @@ func newLazyStates(ha StateGetter, logger *slog.Logger) *lazyStates {
 	return &lazyStates{ha: ha, logger: logger}
 }
 
-func (l *lazyStates) get(ctx context.Context) []homeassistant.State {
+// get returns the live state snapshot and the fetch error, caching both
+// so repeated glob expansions in one render share a single GetStates.
+// The error is surfaced (not swallowed) so the caller can render an
+// explicit fetch-error marker rather than hide an active glob as if it
+// matched nothing.
+func (l *lazyStates) get(ctx context.Context) ([]homeassistant.State, error) {
 	if l.done {
-		return l.states
+		return l.states, l.err
 	}
 	l.done = true
-	s, err := l.ha.GetStates(ctx)
-	if err != nil {
-		if l.logger != nil {
-			l.logger.Warn("failed to fetch states for glob subscription expansion", "error", err)
-		}
-		return nil
+	l.states, l.err = l.ha.GetStates(ctx)
+	if l.err != nil && l.logger != nil {
+		l.logger.Warn("failed to fetch states for glob subscription expansion", "error", l.err)
 	}
-	l.states = s
-	return l.states
+	return l.states, l.err
 }
 
 // renderWatchedState renders one entity's watched-context block from an
@@ -103,6 +105,15 @@ func renderWatchedState(
 // the subscription's own options applied to each — and appending a
 // truncation marker when more matched than the cap.
 //
+// statesErr is the error from the bulk GetStates that produced states.
+// When non-nil the snapshot couldn't be enumerated, so the glob renders
+// an explicit fetch-error marker rather than silently looking like it
+// matched nothing — mirroring the concrete path's fetch_error block.
+//
+// exclude is the set of entity_ids already rendered elsewhere (the
+// always-visible watchlist, for loop-scoped globs); matches in it are
+// skipped to avoid duplicate prompt blocks. Pass nil for no exclusion.
+//
 // Returns "" when the glob matches nothing this turn; the subscription
 // stays live and is re-evaluated next render, so a silent empty turn is
 // the intended "nothing matches right now" signal rather than an error.
@@ -114,16 +125,24 @@ func expandGlobSubscription(
 	logger *slog.Logger,
 	sub WatchedSubscription,
 	states []homeassistant.State,
+	statesErr error,
 	now time.Time,
 	registries *renderRegistries,
 	maxExpansion int,
+	exclude map[string]struct{},
 ) string {
 	pattern := sub.EntityID
+	if statesErr != nil {
+		return formatGlobFetchError(pattern) + "\n"
+	}
 	stateByID := make(map[string]*homeassistant.State, len(states))
 	matchedIDs := make([]string, 0)
 	for i := range states {
 		s := &states[i]
 		stateByID[s.EntityID] = s
+		if _, skip := exclude[s.EntityID]; skip {
+			continue
+		}
 		if ok, _ := homeassistant.MatchEntityGlob(pattern, s.EntityID); ok {
 			matchedIDs = append(matchedIDs, s.EntityID)
 		}
@@ -152,6 +171,20 @@ func expandGlobSubscription(
 		sb.WriteByte('\n')
 	}
 	return sb.String()
+}
+
+// formatGlobFetchError renders the marker emitted when the live state
+// snapshot needed to expand a glob couldn't be fetched this turn. It
+// mirrors the concrete path's fetch_error shape so the model reads a
+// uniform "active but unavailable" signal instead of inferring the glob
+// matched nothing.
+func formatGlobFetchError(pattern string) string {
+	return promptfmt.MarshalCompact(map[string]any{
+		"glob":      pattern,
+		"available": false,
+		"reason":    "fetch_error",
+		"note":      "could not enumerate entities to expand this glob this turn",
+	})
 }
 
 // formatGlobTruncation renders the marker line appended when a glob

--- a/internal/state/awareness/glob_subscription_test.go
+++ b/internal/state/awareness/glob_subscription_test.go
@@ -2,8 +2,11 @@ package awareness
 
 import (
 	"context"
+	"errors"
+	"log/slog"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/nugget/thane-ai-agent/internal/integrations/homeassistant"
 	"github.com/nugget/thane-ai-agent/internal/runtime/agentctx"
@@ -84,6 +87,53 @@ func TestProvider_GlobSubscriptionEmptyIsSilent(t *testing.T) {
 	}
 	if got != "" {
 		t.Errorf("a glob matching nothing should render nothing (no bare header), got:\n%s", got)
+	}
+}
+
+func TestProvider_GlobSubscriptionFetchErrorMarker(t *testing.T) {
+	ha := globTestHA()
+	ha.statesErr = errors.New("HA unavailable")
+	p, store := setupTestProvider(t, ha)
+	if err := store.Add("binary_sensor.*door*"); err != nil {
+		t.Fatalf("add glob: %v", err)
+	}
+
+	got, err := p.TagContext(context.Background(), agentctx.ContextRequest{})
+	if err != nil {
+		t.Fatalf("TagContext: %v", err)
+	}
+	// A failed bulk fetch must surface an explicit marker, not look like
+	// "matched nothing".
+	if !strings.Contains(got, `"reason":"fetch_error"`) || !strings.Contains(got, `"glob":"binary_sensor.*door*"`) {
+		t.Errorf("expected glob fetch-error marker, got:\n%s", got)
+	}
+}
+
+func TestExpandGlobSubscription_ExcludesAlreadyVisible(t *testing.T) {
+	states := []homeassistant.State{
+		{EntityID: "sensor.a", State: "1"},
+		{EntityID: "sensor.b", State: "2"},
+		{EntityID: "sensor.c", State: "3"},
+	}
+	exclude := map[string]struct{}{"sensor.b": {}}
+
+	out := expandGlobSubscription(
+		context.Background(),
+		globTestHA(),
+		slog.Default(),
+		WatchedSubscription{EntityID: "sensor.*"},
+		states,
+		nil, // no fetch error
+		time.Now(),
+		nil, // no registries
+		25,
+		exclude,
+	)
+	if !strings.Contains(out, "sensor.a") || !strings.Contains(out, "sensor.c") {
+		t.Errorf("expected sensor.a and sensor.c, got:\n%s", out)
+	}
+	if strings.Contains(out, "sensor.b") {
+		t.Errorf("sensor.b should be excluded (already-visible), got:\n%s", out)
 	}
 }
 

--- a/internal/state/awareness/glob_subscription_test.go
+++ b/internal/state/awareness/glob_subscription_test.go
@@ -1,0 +1,108 @@
+package awareness
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/nugget/thane-ai-agent/internal/integrations/homeassistant"
+	"github.com/nugget/thane-ai-agent/internal/runtime/agentctx"
+)
+
+func globTestHA() *fakeHA {
+	mk := func(id, state string) *homeassistant.State {
+		return &homeassistant.State{EntityID: id, State: state}
+	}
+	return &fakeHA{
+		states: map[string]*homeassistant.State{
+			"binary_sensor.front_door":     mk("binary_sensor.front_door", "off"),
+			"binary_sensor.back_door":      mk("binary_sensor.back_door", "on"),
+			"binary_sensor.kitchen_window": mk("binary_sensor.kitchen_window", "off"),
+			"light.hall":                   mk("light.hall", "on"),
+		},
+	}
+}
+
+func TestProvider_GlobSubscriptionExpands(t *testing.T) {
+	p, store := setupTestProvider(t, globTestHA())
+	if err := store.Add("binary_sensor.*door*"); err != nil {
+		t.Fatalf("add glob: %v", err)
+	}
+
+	got, err := p.TagContext(context.Background(), agentctx.ContextRequest{})
+	if err != nil {
+		t.Fatalf("TagContext: %v", err)
+	}
+	if !strings.Contains(got, "### Watched Entities") {
+		t.Fatalf("missing header:\n%s", got)
+	}
+	for _, want := range []string{"binary_sensor.front_door", "binary_sensor.back_door"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("expected %s in glob expansion:\n%s", want, got)
+		}
+	}
+	for _, absent := range []string{"binary_sensor.kitchen_window", "light.hall"} {
+		if strings.Contains(got, absent) {
+			t.Errorf("did not expect %s (glob shouldn't match):\n%s", absent, got)
+		}
+	}
+}
+
+func TestProvider_GlobSubscriptionCapAndTruncation(t *testing.T) {
+	p, store := setupTestProvider(t, globTestHA())
+	p.SetMaxGlobExpansion(2)
+	if err := store.Add("binary_sensor.*"); err != nil { // matches 3
+		t.Fatalf("add glob: %v", err)
+	}
+
+	got, err := p.TagContext(context.Background(), agentctx.ContextRequest{})
+	if err != nil {
+		t.Fatalf("TagContext: %v", err)
+	}
+	// Sorted: back_door, front_door come before kitchen_window, so the
+	// first two render and kitchen_window is cut.
+	if !strings.Contains(got, "binary_sensor.back_door") || !strings.Contains(got, "binary_sensor.front_door") {
+		t.Errorf("expected the first two sorted matches:\n%s", got)
+	}
+	if strings.Contains(got, "binary_sensor.kitchen_window") {
+		t.Errorf("third match should have been truncated:\n%s", got)
+	}
+	if !strings.Contains(got, `"truncated":true`) || !strings.Contains(got, `"matched":3`) || !strings.Contains(got, `"shown":2`) {
+		t.Errorf("expected truncation marker (matched 3, shown 2):\n%s", got)
+	}
+}
+
+func TestProvider_GlobSubscriptionEmptyIsSilent(t *testing.T) {
+	p, store := setupTestProvider(t, globTestHA())
+	if err := store.Add("climate.*"); err != nil { // matches nothing
+		t.Fatalf("add glob: %v", err)
+	}
+
+	got, err := p.TagContext(context.Background(), agentctx.ContextRequest{})
+	if err != nil {
+		t.Fatalf("TagContext: %v", err)
+	}
+	if got != "" {
+		t.Errorf("a glob matching nothing should render nothing (no bare header), got:\n%s", got)
+	}
+}
+
+func TestProvider_GlobAndConcreteMix(t *testing.T) {
+	p, store := setupTestProvider(t, globTestHA())
+	if err := store.Add("light.hall"); err != nil { // concrete
+		t.Fatalf("add concrete: %v", err)
+	}
+	if err := store.Add("binary_sensor.*door*"); err != nil { // glob
+		t.Fatalf("add glob: %v", err)
+	}
+
+	got, err := p.TagContext(context.Background(), agentctx.ContextRequest{})
+	if err != nil {
+		t.Fatalf("TagContext: %v", err)
+	}
+	for _, want := range []string{"light.hall", "binary_sensor.front_door", "binary_sensor.back_door"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("expected %s (concrete + glob mix):\n%s", want, got)
+		}
+	}
+}

--- a/internal/state/awareness/loop_subscription_provider.go
+++ b/internal/state/awareness/loop_subscription_provider.go
@@ -122,7 +122,7 @@ func (p *LoopSubscriptionProvider) TagContext(ctx context.Context, _ agentctx.Co
 	// render; fetch that snapshot once (lazily, only if a glob is
 	// present) and reuse it across every glob — one bulk GetStates per
 	// render. Concrete subscriptions keep their targeted GetState path.
-	states := newLazyStates(p.ha, p.logger)
+	snap := newLazyStates(p.ha, p.logger)
 
 	// Render the body first so an all-expired list yields no header.
 	// Otherwise a quiescent loop whose TTLs all elapsed would still
@@ -134,11 +134,11 @@ func (p *LoopSubscriptionProvider) TagContext(ctx context.Context, _ agentctx.Co
 			continue
 		}
 		if homeassistant.IsEntityGlob(sub.EntityID) {
-			// Cross-provider dedup is by exact entity_id, so a glob's
-			// expanded matches aren't deduped against always-visible
-			// entries — an acceptable rare double-render for an opt-in
-			// glob, not worth sharing state across providers.
-			body.WriteString(expandGlobSubscription(ctx, p.ha, p.logger, watchedFromLoopSubscription(sub), states.get(ctx), now, registries, p.maxGlobExpansion))
+			states, statesErr := snap.get(ctx)
+			// Pass alreadyVisible so a loop glob (e.g. sensor.*) doesn't
+			// re-render entities the always-visible watchlist already
+			// injects — same dedup the concrete path applies below.
+			body.WriteString(expandGlobSubscription(ctx, p.ha, p.logger, watchedFromLoopSubscription(sub), states, statesErr, now, registries, p.maxGlobExpansion, alreadyVisible))
 			continue
 		}
 		if _, dup := alreadyVisible[sub.EntityID]; dup {

--- a/internal/state/awareness/loop_subscription_provider.go
+++ b/internal/state/awareness/loop_subscription_provider.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/nugget/thane-ai-agent/internal/integrations/homeassistant"
 	"github.com/nugget/thane-ai-agent/internal/runtime/agentctx"
 	looppkg "github.com/nugget/thane-ai-agent/internal/runtime/loop"
 )
@@ -21,11 +22,12 @@ import (
 // still emitted by [WatchlistProvider]; this provider only covers
 // loop- and container-scoped subscriptions.
 type LoopSubscriptionProvider struct {
-	loops      *looppkg.Registry
-	store      *WatchlistStore
-	ha         StateGetter
-	registries HARegistryClient
-	logger     *slog.Logger
+	loops            *looppkg.Registry
+	store            *WatchlistStore
+	ha               StateGetter
+	registries       HARegistryClient
+	logger           *slog.Logger
+	maxGlobExpansion int
 }
 
 // NewLoopSubscriptionProvider creates a provider bound to the live
@@ -41,7 +43,13 @@ func NewLoopSubscriptionProvider(loops *looppkg.Registry, store *WatchlistStore,
 	if logger == nil {
 		logger = slog.Default()
 	}
-	return &LoopSubscriptionProvider{loops: loops, store: store, ha: ha, logger: logger}
+	return &LoopSubscriptionProvider{loops: loops, store: store, ha: ha, logger: logger, maxGlobExpansion: defaultMaxGlobExpansion}
+}
+
+// SetMaxGlobExpansion overrides the per-turn cap on how many entities a
+// single glob subscription renders. A value <= 0 restores the default.
+func (p *LoopSubscriptionProvider) SetMaxGlobExpansion(n int) {
+	p.maxGlobExpansion = normalizeMaxGlobExpansion(n)
 }
 
 // TagContextBucket places loop-scoped entity snapshots in live state,
@@ -110,6 +118,12 @@ func (p *LoopSubscriptionProvider) TagContext(ctx context.Context, _ agentctx.Co
 		}
 	}
 
+	// Glob subscriptions re-expand against the live entity set each
+	// render; fetch that snapshot once (lazily, only if a glob is
+	// present) and reuse it across every glob — one bulk GetStates per
+	// render. Concrete subscriptions keep their targeted GetState path.
+	states := newLazyStates(p.ha, p.logger)
+
 	// Render the body first so an all-expired list yields no header.
 	// Otherwise a quiescent loop whose TTLs all elapsed would still
 	// add a "### Watched Entities (loop)" line with no entries, which
@@ -117,6 +131,14 @@ func (p *LoopSubscriptionProvider) TagContext(ctx context.Context, _ agentctx.Co
 	var body strings.Builder
 	for _, sub := range subs {
 		if sub.IsExpired(now) {
+			continue
+		}
+		if homeassistant.IsEntityGlob(sub.EntityID) {
+			// Cross-provider dedup is by exact entity_id, so a glob's
+			// expanded matches aren't deduped against always-visible
+			// entries — an acceptable rare double-render for an opt-in
+			// glob, not worth sharing state across providers.
+			body.WriteString(expandGlobSubscription(ctx, p.ha, p.logger, watchedFromLoopSubscription(sub), states.get(ctx), now, registries, p.maxGlobExpansion))
 			continue
 		}
 		if _, dup := alreadyVisible[sub.EntityID]; dup {
@@ -141,12 +163,7 @@ func (p *LoopSubscriptionProvider) TagContext(ctx context.Context, _ agentctx.Co
 // as a storage type elsewhere, the renderer can take fields
 // directly.
 func (p *LoopSubscriptionProvider) renderLoopSubscription(ctx context.Context, sub looppkg.EntitySubscription, now time.Time, registries *renderRegistries) string {
-	w := WatchedSubscription{
-		EntityID: sub.EntityID,
-		History:  append([]int(nil), sub.History...),
-		Forecast: sub.Forecast,
-		Include:  sub.Include.Clone(),
-	}
+	w := watchedFromLoopSubscription(sub)
 	state, err := p.ha.GetState(ctx, w.EntityID)
 	if err != nil {
 		p.logger.Warn("failed to fetch loop-scoped entity state",
@@ -155,26 +172,16 @@ func (p *LoopSubscriptionProvider) renderLoopSubscription(ctx context.Context, s
 		)
 		return formatFetchError(w.EntityID)
 	}
-	state = watchlistStateWithForecast(ctx, p.ha, p.logger, w, state, "failed to fetch loop-scoped weather forecast")
+	return renderWatchedState(ctx, p.ha, p.logger, w, state, now, registries)
+}
 
-	content := formatEntityContextWithMetadata(state, now, registries.entityMetadata(w.EntityID, state, w.Include))
-	content = enrichWithLastKnownGood(ctx, p.ha, content, state, now)
-	content = enrichUnavailable(content, state, registries)
-	if len(w.History) == 0 {
-		return content
+// watchedFromLoopSubscription adapts a loop.EntitySubscription into the
+// WatchedSubscription shim the shared render/expansion path consumes.
+func watchedFromLoopSubscription(sub looppkg.EntitySubscription) WatchedSubscription {
+	return WatchedSubscription{
+		EntityID: sub.EntityID,
+		History:  append([]int(nil), sub.History...),
+		Forecast: sub.Forecast,
+		Include:  sub.Include.Clone(),
 	}
-
-	summaries, truncated, err := buildWatchlistHistorySummaries(ctx, p.ha, state, w.History, now)
-	if err != nil {
-		p.logger.Warn("failed to fetch loop-scoped entity history",
-			"entity_id", w.EntityID,
-			"history", w.History,
-			"error", err,
-		)
-		return content
-	}
-	if len(summaries) == 0 && !truncated {
-		return content
-	}
-	return mergeHistoryIntoEntityContext(content, summaries, truncated)
 }

--- a/internal/state/awareness/watchlist_provider.go
+++ b/internal/state/awareness/watchlist_provider.go
@@ -16,6 +16,7 @@ import (
 // real HA instance.
 type StateGetter interface {
 	GetState(ctx context.Context, entityID string) (*homeassistant.State, error)
+	GetStates(ctx context.Context) ([]homeassistant.State, error)
 	GetStateHistory(ctx context.Context, entityID string, startTime, endTime time.Time) ([]homeassistant.State, error)
 	GetWeatherForecasts(ctx context.Context, entityID, forecastType string) ([]map[string]any, error)
 }
@@ -25,10 +26,11 @@ type StateGetter interface {
 // markdown block for system prompt injection. Registered via
 // [agent.Loop.RegisterAlwaysContextProvider].
 type WatchlistProvider struct {
-	store      *WatchlistStore
-	ha         StateGetter
-	registries HARegistryClient // optional; nil disables unavailable enrichment
-	logger     *slog.Logger
+	store            *WatchlistStore
+	ha               StateGetter
+	registries       HARegistryClient // optional; nil disables unavailable enrichment
+	logger           *slog.Logger
+	maxGlobExpansion int
 }
 
 // NewWatchlistProvider creates a watchlist context provider.
@@ -37,10 +39,17 @@ func NewWatchlistProvider(store *WatchlistStore, ha StateGetter, logger *slog.Lo
 		logger = slog.Default()
 	}
 	return &WatchlistProvider{
-		store:  store,
-		ha:     ha,
-		logger: logger,
+		store:            store,
+		ha:               ha,
+		logger:           logger,
+		maxGlobExpansion: defaultMaxGlobExpansion,
 	}
+}
+
+// SetMaxGlobExpansion overrides the per-turn cap on how many entities a
+// single glob subscription renders. A value <= 0 restores the default.
+func (p *WatchlistProvider) SetMaxGlobExpansion(n int) {
+	p.maxGlobExpansion = normalizeMaxGlobExpansion(n)
 }
 
 // TagContextBucket places watched entity snapshots in live state.
@@ -80,15 +89,28 @@ func (p *WatchlistProvider) TagContext(ctx context.Context, _ agentctx.ContextRe
 	now := time.Now()
 	registries := newRenderRegistries(ctx, p.registries)
 
-	var sb strings.Builder
-	sb.WriteString("### Watched Entities\n\n")
+	// Glob subscriptions are re-expanded against the live entity set
+	// each render. Fetch that snapshot once (lazily, only if a glob is
+	// present) and reuse it for every glob — one bulk GetStates per
+	// render, never a per-entity scan. Concrete subscriptions keep their
+	// targeted GetState path.
+	states := newLazyStates(p.ha, p.logger)
 
+	// Body first so an all-empty render (e.g. globs that matched nothing
+	// this turn) yields no bare header.
+	var body strings.Builder
 	for _, sub := range subs {
-		sb.WriteString(p.renderSubscriptionContext(ctx, sub, now, registries))
-		sb.WriteByte('\n')
+		if homeassistant.IsEntityGlob(sub.EntityID) {
+			body.WriteString(expandGlobSubscription(ctx, p.ha, p.logger, sub, states.get(ctx), now, registries, p.maxGlobExpansion))
+			continue
+		}
+		body.WriteString(p.renderSubscriptionContext(ctx, sub, now, registries))
+		body.WriteByte('\n')
 	}
-
-	return sb.String(), nil
+	if body.Len() == 0 {
+		return "", nil
+	}
+	return "### Watched Entities\n\n" + body.String(), nil
 }
 
 func (p *WatchlistProvider) renderSubscriptionContext(ctx context.Context, sub WatchedSubscription, now time.Time, registries *renderRegistries) string {
@@ -100,33 +122,7 @@ func (p *WatchlistProvider) renderSubscriptionContext(ctx context.Context, sub W
 		)
 		return formatFetchError(sub.EntityID)
 	}
-	state = p.stateWithForecast(ctx, sub, state)
-
-	content := formatEntityContextWithMetadata(state, now, registries.entityMetadata(sub.EntityID, state, sub.Include))
-	content = enrichWithLastKnownGood(ctx, p.ha, content, state, now)
-	content = enrichUnavailable(content, state, registries)
-	if len(sub.History) == 0 {
-		return content
-	}
-
-	summaries, truncated, err := buildWatchlistHistorySummaries(ctx, p.ha, state, sub.History, now)
-	if err != nil {
-		p.logger.Warn("failed to fetch watched entity history",
-			"entity_id", sub.EntityID,
-			"history", sub.History,
-			"error", err,
-		)
-		return content
-	}
-	if len(summaries) == 0 && !truncated {
-		return content
-	}
-
-	return mergeHistoryIntoEntityContext(content, summaries, truncated)
-}
-
-func (p *WatchlistProvider) stateWithForecast(ctx context.Context, sub WatchedSubscription, state *homeassistant.State) *homeassistant.State {
-	return watchlistStateWithForecast(ctx, p.ha, p.logger, sub, state, "failed to fetch watched weather forecast")
+	return renderWatchedState(ctx, p.ha, p.logger, sub, state, now, registries)
 }
 
 func watchlistStateWithForecast(

--- a/internal/state/awareness/watchlist_provider.go
+++ b/internal/state/awareness/watchlist_provider.go
@@ -94,14 +94,17 @@ func (p *WatchlistProvider) TagContext(ctx context.Context, _ agentctx.ContextRe
 	// present) and reuse it for every glob — one bulk GetStates per
 	// render, never a per-entity scan. Concrete subscriptions keep their
 	// targeted GetState path.
-	states := newLazyStates(p.ha, p.logger)
+	snap := newLazyStates(p.ha, p.logger)
 
 	// Body first so an all-empty render (e.g. globs that matched nothing
 	// this turn) yields no bare header.
 	var body strings.Builder
 	for _, sub := range subs {
 		if homeassistant.IsEntityGlob(sub.EntityID) {
-			body.WriteString(expandGlobSubscription(ctx, p.ha, p.logger, sub, states.get(ctx), now, registries, p.maxGlobExpansion))
+			states, statesErr := snap.get(ctx)
+			// No exclusion set — this provider IS the always-visible
+			// surface, so there is nothing upstream to dedup against.
+			body.WriteString(expandGlobSubscription(ctx, p.ha, p.logger, sub, states, statesErr, now, registries, p.maxGlobExpansion, nil))
 			continue
 		}
 		body.WriteString(p.renderSubscriptionContext(ctx, sub, now, registries))

--- a/internal/state/awareness/watchlist_provider_test.go
+++ b/internal/state/awareness/watchlist_provider_test.go
@@ -22,6 +22,7 @@ type fakeHA struct {
 	forecasts        map[string][]map[string]any
 	forecastRequests []string
 	err              error // returned for any entity not in states
+	statesErr        error // returned by GetStates (bulk fetch)
 	histErr          error
 	forecastErr      error
 }
@@ -34,6 +35,17 @@ func (f *fakeHA) GetState(_ context.Context, entityID string) (*homeassistant.St
 		return nil, f.err
 	}
 	return nil, errors.New("entity not found")
+}
+
+func (f *fakeHA) GetStates(_ context.Context) ([]homeassistant.State, error) {
+	if f.statesErr != nil {
+		return nil, f.statesErr
+	}
+	out := make([]homeassistant.State, 0, len(f.states))
+	for _, s := range f.states {
+		out = append(out, *s)
+	}
+	return out, nil
 }
 
 func (f *fakeHA) GetStateHistory(_ context.Context, entityID string, _ time.Time, _ time.Time) ([]homeassistant.State, error) {

--- a/internal/state/awareness/watchlist_tool_provider.go
+++ b/internal/state/awareness/watchlist_tool_provider.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/nugget/thane-ai-agent/internal/integrations/homeassistant"
 	"github.com/nugget/thane-ai-agent/internal/model/promptfmt"
 	"github.com/nugget/thane-ai-agent/internal/tools"
 )
@@ -66,7 +67,7 @@ func (w *WatchlistTools) Tools() []*tools.Tool {
 				"properties": map[string]any{
 					"entity_id": map[string]any{
 						"type":        "string",
-						"description": "The Home Assistant entity ID to subscribe to (e.g., sensor.office_temperature, weather.home).",
+						"description": "The Home Assistant entity ID to subscribe to (e.g., sensor.office_temperature, weather.home), or a glob pattern (e.g., binary_sensor.*door*, *_temperature) to watch every matching entity, re-expanded live each turn (capped per turn).",
 					},
 					"tags": map[string]any{
 						"type":        "array",
@@ -138,6 +139,9 @@ func (w *WatchlistTools) handleAddEntitySubscription(_ context.Context, args map
 	entityID, _ := args["entity_id"].(string)
 	if entityID == "" {
 		return "", fmt.Errorf("entity_id is required")
+	}
+	if err := homeassistant.ValidateEntityTarget(entityID); err != nil {
+		return "", fmt.Errorf("entity_id %q: invalid glob pattern: %w", entityID, err)
 	}
 
 	tags, err := parseWatchlistTagArgs(args["tags"])

--- a/internal/tools/loop_intent_tools.go
+++ b/internal/tools/loop_intent_tools.go
@@ -293,7 +293,7 @@ func (r *Registry) registerThaneCurate() {
 						"properties": map[string]any{
 							"entity_id": map[string]any{
 								"type":        "string",
-								"description": "The Home Assistant entity ID to watch (e.g., sensor.upstairs_temperature, weather.home).",
+								"description": "The Home Assistant entity ID to watch (e.g., sensor.upstairs_temperature, weather.home), or a glob pattern (e.g., binary_sensor.*door*, *_temperature) to watch every matching entity, re-expanded live each turn (capped per turn).",
 							},
 							"history": map[string]any{
 								"type":        "array",
@@ -612,6 +612,9 @@ func parseEntityList(fieldName string, raw any) ([]curateEntity, error) {
 		entityID = strings.TrimSpace(entityID)
 		if entityID == "" {
 			return nil, fmt.Errorf("%s[%d].entity_id is required", fieldName, i)
+		}
+		if err := homeassistant.ValidateEntityTarget(entityID); err != nil {
+			return nil, fmt.Errorf("%s[%d].entity_id %q: invalid glob pattern: %w", fieldName, i, entityID, err)
 		}
 		if seen[entityID] {
 			return nil, fmt.Errorf("%s[%d] duplicates entity_id %q; each entity may appear at most once", fieldName, i, entityID)

--- a/internal/tools/loop_subscription_tools.go
+++ b/internal/tools/loop_subscription_tools.go
@@ -48,7 +48,7 @@ func (r *Registry) registerUpdateEntitySubscriptions() {
 						"properties": map[string]any{
 							"entity_id": map[string]any{
 								"type":        "string",
-								"description": "The Home Assistant entity ID to watch.",
+								"description": "The Home Assistant entity ID to watch, or a glob pattern (e.g., binary_sensor.*door*) to watch every matching entity, re-expanded live each turn (capped per turn).",
 							},
 							"history": map[string]any{
 								"type":        "array",

--- a/scripts/architecture.baseline
+++ b/scripts/architecture.baseline
@@ -1,5 +1,5 @@
 packages=59
 interfaces=76
 large_files=44
-set_mutators=105
+set_mutators=107
 database_opens=8

--- a/talents/awareness-trailhead.md
+++ b/talents/awareness-trailhead.md
@@ -15,7 +15,12 @@ Choose the next move deliberately:
 
 - Use `list_entity_subscriptions` to see what this loop is already carrying.
 - Use `add_entity_subscription` when a room, device, person, or live state
-  should auto-load while the work continues.
+  should auto-load while the work continues. The `entity_id` accepts a
+  glob (e.g. `binary_sensor.*door*`, `*_temperature`) to follow a whole
+  set: it is re-expanded against live entities every turn, so newly-added
+  matches join automatically. A glob is capped per turn and reports
+  truncation when it matches more than the cap — keep patterns narrow so
+  the watch stays a focus, not a firehose.
 - Add `include` metadata flags when area, owning device, HA labels, or
   descriptions would make the subscribed state easier to interpret; use
   `visibility` when hidden/enabled salience matters, and read


### PR DESCRIPTION
Closes #1013. Part of the native-HA overhaul (#1002), building on the shared entity-glob matcher from #1012.

## What
An entity subscription's `entity_id` may now be a **glob** (`binary_sensor.*door*`, `*_temperature`). It's re-expanded against live entities **every render**, so newly-matching entities join automatically — the live-glob semantics chosen for this work.

## Design
- **Representation:** a glob is detected via `homeassistant.IsEntityGlob` (real entity_ids never contain `*?[`), so it rides the existing `entity_id` field — **no new model/storage fields, no migration**. Concrete-id subscriptions are untouched.
- **Render (both providers, shared `glob_subscription.go`):**
  - **One bulk `GetStates` per render**, fetched lazily only when a glob is present and reused across all globs — never a per-entity scan. Concrete subs keep their targeted `GetState`.
  - Matches are sorted, rendered through the **same** per-entity path as concrete subs (`renderWatchedState`, extracted and shared so the two can't drift), and bounded by a **hard per-turn cap (default 25)**. Overflow emits a truncation marker.
  - A glob matching nothing renders nothing (re-evaluated next turn).
  - `StateGetter` gains `GetStates`; the test fake implements it.
- **Creation/validation:** `add_entity_subscription`, `watch_entity`, `thane_curate.entities`, and `update_entity_subscriptions` validate a glob target via `homeassistant.ValidateEntityTarget` (one shared call) and advertise the glob form in their schemas.

## Result-size safety (the #1002 doctrine)
Bulk-once + hard cap + truncation keep a broad glob from flooding the prompt every turn at 15k-entity scale.

## Tests
Glob expansion correctness, cap + truncation marker, empty-glob silence, concrete+glob mix; plus the matcher's own tests (from #1012). Existing concrete-path tests unchanged (the render refactor is behavior-preserving).

## Docs
`talents/awareness-trailhead.md` and `tools.md` describe glob subscriptions and the cap.

## Follow-up (noted on #1013)
Expose the cap as a YAML config knob — it currently ships as a conservative default (25) with a programmatic setter (test-used). Needs a config-home decision.

## Test plan
- [x] `go test ./...` (awareness, tools, app, homeassistant)
- [x] `just ci` green locally (incl. architecture baseline bump)

🤖 Generated with [Claude Code](https://claude.com/claude-code)