### PR TITLE
feat(ha): enhance + expose get_area_activity as the area snapshot

### DIFF
--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -121,6 +121,7 @@ becoming default context clutter.
 | `ha_get_state` | Current state of any entity, with optional area/device/label/description/visibility metadata. |
 | `ha_list_entities` | Browse entities by domain and/or entity_id glob (e.g. `binary_sensor.*door*`), with optional HA metadata. |
 | `ha_search_states` | Predicate search across live entity state (state value, numeric attribute, domain, area). |
+| `get_area_activity` | Whole-area snapshot: floor context + entities grouped by salience + transition timeline + filtered counts, with optional per-entity metadata. |
 | `ha_call_service` | Direct HA service invocation. |
 | `ha_registry_search` | Search the entity/device/area registry. |
 | `ha_automation_list` | List automations with recent activation counts. |

--- a/internal/integrations/homeassistant/entity_metadata.go
+++ b/internal/integrations/homeassistant/entity_metadata.go
@@ -374,6 +374,19 @@ func (r EntityMetadataResolver) areaForEntity(entry *EntityRegistryEntry, device
 	return r.areasByID[areaID]
 }
 
+// AreaMetadata projects model-facing metadata for a single area —
+// name, aliases, icon, climate sensors, and the resolved floor/building
+// hierarchy. It exposes the same area projection the per-entity resolver
+// uses, for surfaces (e.g. the area-activity snapshot) that describe an
+// area directly rather than an entity within it. Returns nil for a nil
+// area.
+func (r EntityMetadataResolver) AreaMetadata(area *Area) *EntityAreaMetadata {
+	if area == nil {
+		return nil
+	}
+	return r.areaMetadata(area)
+}
+
 func (r EntityMetadataResolver) areaMetadata(area *Area) *EntityAreaMetadata {
 	out := &EntityAreaMetadata{
 		ID:                  area.AreaID,

--- a/internal/model/toolcatalog/catalog.go
+++ b/internal/model/toolcatalog/catalog.go
@@ -231,6 +231,7 @@ var builtinToolSpecs = map[string]BuiltinToolSpec{
 	"contact_list":                {CanonicalID: "native:contact_list", Source: NativeToolSource, Tags: []string{"contacts"}},
 	"ha_list_entities":            {CanonicalID: "native:ha_list_entities", Source: NativeToolSource, Tags: []string{"ha"}},
 	"ha_search_states":            {CanonicalID: "native:ha_search_states", Source: NativeToolSource, Tags: []string{"ha"}},
+	"get_area_activity":           {CanonicalID: "native:get_area_activity", Source: NativeToolSource, Tags: []string{"ha"}},
 	"lens_list":                   {CanonicalID: "native:lens_list", Source: NativeToolSource},
 	"tag_inspect":                 {CanonicalID: "native:tag_inspect", Source: NativeToolSource},
 	"tag_reset":                   {CanonicalID: "native:tag_reset", Source: NativeToolSource},

--- a/internal/state/awareness/area_activity.go
+++ b/internal/state/awareness/area_activity.go
@@ -24,11 +24,12 @@ type AreaActivityClient interface {
 
 // AreaActivityRequest describes one invocation of the tool.
 type AreaActivityRequest struct {
-	Area              string // name or area_id (case-insensitive on name)
-	LookbackSeconds   int    // <= 0 falls back to default
-	IncludeDiagnostic bool   // include diagnostic/config category entities
-	IncludeHidden     bool   // include hidden-but-enabled entities
-	MaxStable         int    // cap on the stable bucket; <= 0 uses default
+	Area              string                               // name or area_id (case-insensitive on name)
+	LookbackSeconds   int                                  // <= 0 falls back to default
+	IncludeDiagnostic bool                                 // include diagnostic/config category entities
+	IncludeHidden     bool                                 // include hidden-but-enabled entities
+	MaxStable         int                                  // cap on the stable bucket; <= 0 uses default
+	Include           homeassistant.EntityMetadataIncludes // optional per-entity metadata projection
 }
 
 const (
@@ -114,9 +115,32 @@ func ComputeAreaActivity(ctx context.Context, client AreaActivityClient, req Are
 	deviceByID := indexDevices(devices)
 	statesByID := indexStates(allStates)
 
+	// Build the metadata resolver once. It powers the area's floor/
+	// building context (always emitted) and the optional per-entity
+	// include projection. Floors are tiny and registry-cached; labels
+	// are pulled only when the include set asks for them.
+	floors, err := client.GetFloorRegistry(ctx)
+	if err != nil {
+		return "", fmt.Errorf("area_activity: get floors: %w", err)
+	}
+	var labels []homeassistant.LabelRegistryEntry
+	if req.Include.Labels {
+		labels, err = client.GetLabelRegistry(ctx)
+		if err != nil {
+			return "", fmt.Errorf("area_activity: get labels: %w", err)
+		}
+	}
+	floorAlias := ""
+	if p, ok := client.(interface{ FloorMetadataAlias() string }); ok {
+		floorAlias = p.FloorMetadataAlias()
+	}
+	resolver := homeassistant.NewEntityMetadataResolverWithFloorAlias(areas, labels, devices, floors, floorAlias)
+
 	members, filters := selectAreaMembers(entities, deviceByID, area.AreaID, req.IncludeDiagnostic, req.IncludeHidden)
 	if len(members) == 0 {
-		return promptfmt.MarshalCompact(emptyAreaPayload(area, lookback, filters)), nil
+		payload := emptyAreaPayload(area, lookback, filters)
+		addAreaFloorContext(payload, resolver, area)
+		return promptfmt.MarshalCompact(payload), nil
 	}
 
 	cutoff := now.Add(-time.Duration(lookback) * time.Second)
@@ -164,6 +188,11 @@ func ComputeAreaActivity(ctx context.Context, client AreaActivityClient, req Are
 		"stable":         stable,
 	}
 	addAreaFilterCounts(payload, filters)
+	addAreaFloorContext(payload, resolver, area)
+	if req.Include.Any() {
+		attachAreaEntityMetadata(resolver, req.Include, members, statesByID,
+			anomalies, active, recent, ambient, stable)
+	}
 	if recentTruncated > 0 {
 		payload["recent_changes_truncated_count"] = recentTruncated
 	}
@@ -243,6 +272,51 @@ func addAreaFilterCounts(payload map[string]any, counts areaFilterCounts) {
 	}
 	if counts.Config > 0 {
 		payload["config_count"] = counts.Config
+	}
+}
+
+// addAreaFloorContext attaches the area's resolved floor (or building,
+// when this deployment aliases floors as buildings) to the payload.
+// No-op when the area has no floor assignment.
+func addAreaFloorContext(payload map[string]any, resolver homeassistant.EntityMetadataResolver, area homeassistant.Area) {
+	am := resolver.AreaMetadata(&area)
+	if am == nil {
+		return
+	}
+	if am.Floor != nil {
+		payload["floor"] = am.Floor
+	}
+	if am.Building != nil {
+		payload["building"] = am.Building
+	}
+}
+
+// attachAreaEntityMetadata enriches each bucketed entity object in place
+// with the requested per-entity metadata projection, keyed by the
+// entity_id carried in the object's "entity" field. Buckets share their
+// map objects with the payload, so mutating here updates the rendered
+// output.
+func attachAreaEntityMetadata(
+	resolver homeassistant.EntityMetadataResolver,
+	include homeassistant.EntityMetadataIncludes,
+	members []areaMember,
+	statesByID map[string]*homeassistant.State,
+	buckets ...[]map[string]any,
+) {
+	entryByID := make(map[string]*homeassistant.EntityRegistryEntry, len(members))
+	for i := range members {
+		entryByID[members[i].entry.EntityID] = &members[i].entry
+	}
+	for _, bucket := range buckets {
+		for _, obj := range bucket {
+			id, _ := obj["entity"].(string)
+			if id == "" {
+				continue
+			}
+			if meta := resolver.MetadataForEntity(entryByID[id], statesByID[id], include); meta != nil {
+				obj["metadata"] = meta
+			}
+		}
 	}
 }
 

--- a/internal/state/awareness/area_activity.go
+++ b/internal/state/awareness/area_activity.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"strconv"
 	"strings"
 	"time"
@@ -116,12 +117,26 @@ func ComputeAreaActivity(ctx context.Context, client AreaActivityClient, req Are
 	statesByID := indexStates(allStates)
 
 	// Build the metadata resolver once. It powers the area's floor/
-	// building context (always emitted) and the optional per-entity
-	// include projection. Floors are tiny and registry-cached; labels
-	// are pulled only when the include set asks for them.
-	floors, err := client.GetFloorRegistry(ctx)
-	if err != nil {
-		return "", fmt.Errorf("area_activity: get floors: %w", err)
+	// building context and the optional per-entity include projection.
+	// Floor/building context is optional enrichment: fetch the floor
+	// registry only when this area is actually assigned to a floor —
+	// most areas (and every area on a deployment without floor-registry
+	// support) aren't, so the common case skips the WS call entirely.
+	// A fetch failure is best-effort: omit floor/building context rather
+	// than sink the whole snapshot, since nothing else in the view
+	// depends on floors. Labels are pulled only when the include set
+	// asks for them.
+	var floors []homeassistant.FloorRegistryEntry
+	if area.FloorID != "" {
+		if fetched, ferr := client.GetFloorRegistry(ctx); ferr != nil {
+			slog.Default().Warn("area_activity: floor registry unavailable; omitting floor/building context",
+				"area_id", area.AreaID,
+				"floor_id", area.FloorID,
+				"error", ferr,
+			)
+		} else {
+			floors = fetched
+		}
 	}
 	var labels []homeassistant.LabelRegistryEntry
 	if req.Include.Labels {

--- a/internal/state/awareness/area_activity_snapshot_test.go
+++ b/internal/state/awareness/area_activity_snapshot_test.go
@@ -1,0 +1,128 @@
+package awareness
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/nugget/thane-ai-agent/internal/integrations/homeassistant"
+)
+
+// TestComputeAreaActivity_FloorContext covers the #1005 enhancement:
+// the snapshot carries the area's resolved floor context.
+func TestComputeAreaActivity_FloorContext(t *testing.T) {
+	client := &fakeAreaClient{
+		areas:  []homeassistant.Area{{AreaID: "office", Name: "Office", FloorID: "ground"}},
+		floors: []homeassistant.FloorRegistryEntry{{FloorID: "ground", Name: "Ground Floor"}},
+		entities: []homeassistant.EntityRegistryEntry{
+			{EntityID: "light.office_lamp", AreaID: "office"},
+		},
+		states: []homeassistant.State{
+			{EntityID: "light.office_lamp", State: "on"},
+		},
+	}
+
+	out, err := ComputeAreaActivity(context.Background(), client, AreaActivityRequest{Area: "office"}, testNow)
+	if err != nil {
+		t.Fatalf("ComputeAreaActivity: %v", err)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(out), &payload); err != nil {
+		t.Fatalf("unmarshal: %v\n%s", err, out)
+	}
+	floor, ok := payload["floor"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected floor context, got %#v", payload["floor"])
+	}
+	if floor["id"] != "ground" || floor["name"] != "Ground Floor" {
+		t.Errorf("floor = %#v, want ground/Ground Floor", floor)
+	}
+}
+
+// TestComputeAreaActivity_IncludeMetadata covers per-entity metadata
+// projection: each bucketed entity carries the requested include block.
+func TestComputeAreaActivity_IncludeMetadata(t *testing.T) {
+	client := &fakeAreaClient{
+		areas: []homeassistant.Area{{AreaID: "office", Name: "Office"}},
+		entities: []homeassistant.EntityRegistryEntry{
+			{
+				EntityID:    "light.office_lamp",
+				AreaID:      "office",
+				Description: "Desk lamp",
+				Platform:    "hue",
+			},
+		},
+		states: []homeassistant.State{
+			{EntityID: "light.office_lamp", State: "on"},
+		},
+	}
+
+	req := AreaActivityRequest{
+		Area:    "office",
+		Include: homeassistant.EntityMetadataIncludes{Description: true},
+	}
+	out, err := ComputeAreaActivity(context.Background(), client, req, testNow)
+	if err != nil {
+		t.Fatalf("ComputeAreaActivity: %v", err)
+	}
+	var payload struct {
+		Active []struct {
+			Entity   string `json:"entity"`
+			Metadata *struct {
+				Description string `json:"description"`
+			} `json:"metadata"`
+		} `json:"active"`
+	}
+	if err := json.Unmarshal([]byte(out), &payload); err != nil {
+		t.Fatalf("unmarshal: %v\n%s", err, out)
+	}
+	if len(payload.Active) != 1 {
+		t.Fatalf("active bucket = %#v, want one entity\n%s", payload.Active, out)
+	}
+	if payload.Active[0].Metadata == nil {
+		t.Fatalf("expected metadata on the active entity:\n%s", out)
+	}
+	if payload.Active[0].Metadata.Description != "Desk lamp" {
+		t.Errorf("metadata.description = %q, want Desk lamp", payload.Active[0].Metadata.Description)
+	}
+}
+
+// TestComputeAreaActivity_NoIncludeNoMetadata confirms the projection
+// is opt-in: without include, entities carry no metadata block.
+func TestComputeAreaActivity_NoIncludeNoMetadata(t *testing.T) {
+	client := &fakeAreaClient{
+		areas: []homeassistant.Area{{AreaID: "office", Name: "Office"}},
+		entities: []homeassistant.EntityRegistryEntry{
+			{EntityID: "light.office_lamp", AreaID: "office", Description: "Desk lamp"},
+		},
+		states: []homeassistant.State{
+			{EntityID: "light.office_lamp", State: "on"},
+		},
+	}
+	out, err := ComputeAreaActivity(context.Background(), client, AreaActivityRequest{Area: "office"}, testNow)
+	if err != nil {
+		t.Fatalf("ComputeAreaActivity: %v", err)
+	}
+	if got := out; jsonHasKey(t, got, "metadata") {
+		t.Errorf("expected no metadata block without include:\n%s", got)
+	}
+}
+
+func jsonHasKey(t *testing.T, raw, key string) bool {
+	t.Helper()
+	var doc map[string]any
+	if err := json.Unmarshal([]byte(raw), &doc); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	for _, bucket := range []string{"anomalies", "active", "recent_changes", "ambient", "stable"} {
+		list, _ := doc[bucket].([]any)
+		for _, item := range list {
+			if obj, ok := item.(map[string]any); ok {
+				if _, has := obj[key]; has {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}

--- a/internal/state/awareness/area_activity_snapshot_test.go
+++ b/internal/state/awareness/area_activity_snapshot_test.go
@@ -3,6 +3,7 @@ package awareness
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"testing"
 
 	"github.com/nugget/thane-ai-agent/internal/integrations/homeassistant"
@@ -36,6 +37,73 @@ func TestComputeAreaActivity_FloorContext(t *testing.T) {
 	}
 	if floor["id"] != "ground" || floor["name"] != "Ground Floor" {
 		t.Errorf("floor = %#v, want ground/Ground Floor", floor)
+	}
+}
+
+// TestComputeAreaActivity_FloorRegistryErrorDegrades covers the #1015
+// regression fix: floor/building context is optional enrichment, so a
+// floor-registry fetch failure (e.g. a deployment without the floor
+// registry WS API, or a transient outage) must not sink the whole
+// snapshot — it just omits the floor/building fields.
+func TestComputeAreaActivity_FloorRegistryErrorDegrades(t *testing.T) {
+	client := &fakeAreaClient{
+		areas:     []homeassistant.Area{{AreaID: "office", Name: "Office", FloorID: "ground"}},
+		floorsErr: errors.New("floor registry unavailable"),
+		entities: []homeassistant.EntityRegistryEntry{
+			{EntityID: "light.office_lamp", AreaID: "office"},
+		},
+		states: []homeassistant.State{
+			{EntityID: "light.office_lamp", State: "on"},
+		},
+	}
+
+	out, err := ComputeAreaActivity(context.Background(), client, AreaActivityRequest{Area: "office"}, testNow)
+	if err != nil {
+		t.Fatalf("ComputeAreaActivity should degrade, not fail, on floor-registry error: %v", err)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(out), &payload); err != nil {
+		t.Fatalf("unmarshal: %v\n%s", err, out)
+	}
+	if _, ok := payload["floor"]; ok {
+		t.Errorf("expected floor context omitted on registry error, got %#v", payload["floor"])
+	}
+	if _, ok := payload["building"]; ok {
+		t.Errorf("expected building context omitted on registry error, got %#v", payload["building"])
+	}
+	// The rest of the snapshot must still render.
+	if payload["area"] != "Office" {
+		t.Errorf("area = %#v, want Office (snapshot should survive)", payload["area"])
+	}
+}
+
+// TestComputeAreaActivity_NoFloorSkipsRegistry covers the gating: an
+// area with no floor assignment must not call the floor registry at all.
+func TestComputeAreaActivity_NoFloorSkipsRegistry(t *testing.T) {
+	client := &fakeAreaClient{
+		areas:     []homeassistant.Area{{AreaID: "office", Name: "Office"}}, // no FloorID
+		floorsErr: errors.New("should never be called"),
+		entities: []homeassistant.EntityRegistryEntry{
+			{EntityID: "light.office_lamp", AreaID: "office"},
+		},
+		states: []homeassistant.State{
+			{EntityID: "light.office_lamp", State: "on"},
+		},
+	}
+
+	out, err := ComputeAreaActivity(context.Background(), client, AreaActivityRequest{Area: "office"}, testNow)
+	if err != nil {
+		t.Fatalf("ComputeAreaActivity must skip the floor registry when the area has no floor: %v", err)
+	}
+	if client.floorCalls != 0 {
+		t.Errorf("floor registry called %d times for a floorless area, want 0", client.floorCalls)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(out), &payload); err != nil {
+		t.Fatalf("unmarshal: %v\n%s", err, out)
+	}
+	if _, ok := payload["floor"]; ok {
+		t.Errorf("did not expect floor context for a floorless area, got %#v", payload["floor"])
 	}
 }
 

--- a/internal/state/awareness/area_activity_test.go
+++ b/internal/state/awareness/area_activity_test.go
@@ -27,6 +27,9 @@ type fakeAreaClient struct {
 
 	areasErr   error
 	logbookErr error
+	floorsErr  error
+
+	floorCalls int // how many times GetFloorRegistry was invoked
 }
 
 func (f *fakeAreaClient) GetAreas(_ context.Context) ([]homeassistant.Area, error) {
@@ -39,7 +42,8 @@ func (f *fakeAreaClient) GetDeviceRegistry(_ context.Context) ([]homeassistant.D
 	return f.devices, nil
 }
 func (f *fakeAreaClient) GetFloorRegistry(_ context.Context) ([]homeassistant.FloorRegistryEntry, error) {
-	return f.floors, nil
+	f.floorCalls++
+	return f.floors, f.floorsErr
 }
 func (f *fakeAreaClient) GetLabelRegistry(_ context.Context) ([]homeassistant.LabelRegistryEntry, error) {
 	return f.labels, nil

--- a/internal/state/awareness/area_activity_test.go
+++ b/internal/state/awareness/area_activity_test.go
@@ -19,6 +19,8 @@ type fakeAreaClient struct {
 	areas    []homeassistant.Area
 	entities []homeassistant.EntityRegistryEntry
 	devices  []homeassistant.DeviceRegistryEntry
+	floors   []homeassistant.FloorRegistryEntry
+	labels   []homeassistant.LabelRegistryEntry
 	states   []homeassistant.State
 	configs  []homeassistant.ConfigEntry
 	logbook  []homeassistant.LogbookEntry
@@ -37,10 +39,10 @@ func (f *fakeAreaClient) GetDeviceRegistry(_ context.Context) ([]homeassistant.D
 	return f.devices, nil
 }
 func (f *fakeAreaClient) GetFloorRegistry(_ context.Context) ([]homeassistant.FloorRegistryEntry, error) {
-	return nil, nil
+	return f.floors, nil
 }
 func (f *fakeAreaClient) GetLabelRegistry(_ context.Context) ([]homeassistant.LabelRegistryEntry, error) {
-	return nil, nil
+	return f.labels, nil
 }
 func (f *fakeAreaClient) GetStates(_ context.Context) ([]homeassistant.State, error) {
 	return f.states, nil

--- a/internal/state/awareness/area_activity_tool.go
+++ b/internal/state/awareness/area_activity_tool.go
@@ -45,12 +45,13 @@ func (a *AreaActivityTools) Tools() []*tools.Tool {
 	return []*tools.Tool{
 		{
 			Name: "get_area_activity",
-			Description: "Get a snapshot of one Home Assistant area's current state plus a timeline of recent transitions. " +
-				"Returns entities bucketed by relevance: anomalies (offline or in alarm state) first, then active devices " +
+			Description: "Get a full snapshot of one Home Assistant area — the native answer to 'what's in <room>' or " +
+				"'what's happening in <room>' without polling individual entities. Returns the area with its floor/building " +
+				"context and entities bucketed by relevance: anomalies (offline or in alarm state) first, then active devices " +
 				"(lights on, climate running, media playing), then recent changes within the lookback window, then ambient " +
-				"baseline sensors (temperature, humidity), then the rest (capped). Plus a cross-entity timeline of " +
-				"discrete state transitions ordered newest-first. Use this to answer 'what's happening in <room>' or " +
-				"'is everything okay in <room>' without polling individual entities.",
+				"baseline sensors (temperature, humidity), then the rest (capped), plus a cross-entity timeline of discrete " +
+				"transitions newest-first and counts of what was filtered out (disabled/hidden/diagnostic/config). Add include " +
+				"for per-entity area/device/label/description/visibility metadata.",
 			Parameters: map[string]any{
 				"type": "object",
 				"properties": map[string]any{
@@ -74,6 +75,7 @@ func (a *AreaActivityTools) Tools() []*tools.Tool {
 						"type":        "integer",
 						"description": "Cap on the stable bucket (entities not in any other bucket). Default 5. Truncated count is reported via stable_truncated_count.",
 					},
+					"include": tools.EntityMetadataIncludeParameter(),
 				},
 				"required": []string{"area"},
 			},
@@ -105,6 +107,11 @@ func (a *AreaActivityTools) handleAreaActivity(ctx context.Context, args map[str
 	} else if v != nil {
 		req.MaxStable = *v
 	}
+	include, err := tools.ParseEntityMetadataIncludesArg(args["include"], "include")
+	if err != nil {
+		return "", err
+	}
+	req.Include = include
 
 	result, err := ComputeAreaActivity(ctx, a.client, req, time.Now())
 	if err != nil {

--- a/scripts/architecture.baseline
+++ b/scripts/architecture.baseline
@@ -1,5 +1,5 @@
 packages=59
 interfaces=76
-large_files=44
+large_files=46
 set_mutators=107
 database_opens=8

--- a/talents/ha.md
+++ b/talents/ha.md
@@ -166,6 +166,28 @@ threshold questions. This is the right reach instead of fanning out
 many `ha_get_state` calls or listing a whole domain and eyeballing it.
 Add `include` for area/device/label/visibility metadata on each match.
 
+## I want everything in a room
+
+`get_area_activity` is the whole-area perception view — the native
+answer to "what's in the office" or "is everything okay in the
+kitchen":
+
+```json
+{
+  "area": "office",
+  "include": {"device": true, "labels": true}
+}
+```
+
+Returns the area with its floor/building context and its entities
+grouped by salience — anomalies (offline / alarm) first, then active
+devices, recent changes, ambient sensors, and the stable remainder —
+plus a transition timeline and counts of what was filtered out
+(disabled/hidden/diagnostic/config). Default-context entities only;
+pass `include_hidden` or `include_diagnostic` for a forensic pass. Reach
+for this instead of listing a domain and cross-referencing rooms by
+hand.
+
 ## I want richer search across the registry
 
 `ha_registry_search` searches areas, labels, devices, and entities


### PR DESCRIPTION
Closes #1005. Phase 2 of the native-HA overhaul (#1002).

> **Stacked on #1014** (glob subscriptions) — base is `claude/1013-glob-subscriptions`. GitHub retargets to `main` when #1014 merges.

## The finding
#1005 asked for a new `ha_area_snapshot`, but **`get_area_activity` already delivers the salience-grouped snapshot** — anomalies/active/recent/ambient/stable buckets + the #995 filter counts + a transition timeline. Building a second tool would be the parallel-implementation trap. So this **enhances and exposes the existing tool** (your call on the review question).

## What changed
- **Floor/building context:** the snapshot now carries the area's resolved floor (or building, when floors are aliased). New exported `homeassistant.EntityMetadataResolver.AreaMetadata` reuses the per-entity resolver's area projection — no duplicated floor logic.
- **Optional per-entity `include`** (area/device/labels/description/visibility) attached to each bucketed entity, reusing #995's resolver.
- **Discoverability:** catalogued under the **`ha`** tag — it was previously uncatalogued/untagged, so a model doing HA work couldn't reach it — and documented in `talents/ha.md` ("what's in <room>") + `tools.md`.

## Performance (the #1002 doctrine)
Floors are tiny + registry-cached; labels fetched only when `include.labels` is set; the per-entity attach is a post-pass over the already-bucketed (and capped) entities — no extra state fetches.

## Tests
Floor context, per-entity include projection, opt-in (no include → no metadata). Existing `area_activity` tests unchanged (enhancement is additive).

## Notes
No rename (avoids churn to `get_area_activity` references). Architecture baseline: large_files 44→46 (area_activity.go + entity_metadata.go cross 500).

## Test plan
- [x] `go test ./internal/state/awareness/...` + homeassistant
- [x] `just ci` green locally (incl. baseline bump)

🤖 Generated with [Claude Code](https://claude.com/claude-code)