### PR TITLE
feat(ha): ha_device — device + child entities + states in one view

### DIFF
--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -122,6 +122,7 @@ becoming default context clutter.
 | `ha_list_entities` | Browse entities by domain and/or entity_id glob (e.g. `binary_sensor.*door*`), with optional HA metadata. |
 | `ha_search_states` | Predicate search across live entity state (state value, numeric attribute, domain, area). |
 | `get_area_activity` | Whole-area snapshot: floor context + entities grouped by salience + transition timeline + filtered counts, with optional per-entity metadata. |
+| `ha_device` | Whole-device snapshot: device identity (manufacturer/model/firmware/area/integration) + every child entity with semantic state grouped by salience + availability rollup, resolved by id or name, with optional per-entity metadata. |
 | `ha_call_service` | Direct HA service invocation. |
 | `ha_registry_search` | Search the entity/device/area registry. |
 | `ha_automation_list` | List automations with recent activation counts. |

--- a/internal/app/new_awareness.go
+++ b/internal/app/new_awareness.go
@@ -109,6 +109,10 @@ func (a *App) initAwareness(s *newState) error {
 			Client: a.ha,
 			Logger: logger,
 		}))
+		a.loop.Tools().RegisterProvider(awareness.NewDeviceSnapshotTools(awareness.DeviceSnapshotToolsConfig{
+			Client: a.ha,
+			Logger: logger,
+		}))
 	}
 
 	// --- State change window ---

--- a/internal/integrations/homeassistant/entity_metadata.go
+++ b/internal/integrations/homeassistant/entity_metadata.go
@@ -425,6 +425,18 @@ func cloneIntPtr(src *int) *int {
 	return &cp
 }
 
+// DeviceMetadata projects model-facing metadata for a single device —
+// identity, firmware, area, and the resolved area name. It exposes the
+// same device projection the per-entity resolver uses, for surfaces
+// (e.g. the ha_device snapshot) that describe a device directly rather
+// than an entity owned by it. Returns nil for a nil device.
+func (r EntityMetadataResolver) DeviceMetadata(device *DeviceRegistryEntry) *EntityDeviceMetadata {
+	if device == nil {
+		return nil
+	}
+	return r.deviceMetadata(device)
+}
+
 func (r EntityMetadataResolver) deviceMetadata(device *DeviceRegistryEntry) *EntityDeviceMetadata {
 	out := &EntityDeviceMetadata{
 		ID:               device.ID,

--- a/internal/model/toolcatalog/catalog.go
+++ b/internal/model/toolcatalog/catalog.go
@@ -232,6 +232,7 @@ var builtinToolSpecs = map[string]BuiltinToolSpec{
 	"ha_list_entities":            {CanonicalID: "native:ha_list_entities", Source: NativeToolSource, Tags: []string{"ha"}},
 	"ha_search_states":            {CanonicalID: "native:ha_search_states", Source: NativeToolSource, Tags: []string{"ha"}},
 	"get_area_activity":           {CanonicalID: "native:get_area_activity", Source: NativeToolSource, Tags: []string{"ha"}},
+	"ha_device":                   {CanonicalID: "native:ha_device", Source: NativeToolSource, Tags: []string{"ha"}},
 	"lens_list":                   {CanonicalID: "native:lens_list", Source: NativeToolSource},
 	"tag_inspect":                 {CanonicalID: "native:tag_inspect", Source: NativeToolSource},
 	"tag_reset":                   {CanonicalID: "native:tag_reset", Source: NativeToolSource},

--- a/internal/state/awareness/device_snapshot.go
+++ b/internal/state/awareness/device_snapshot.go
@@ -1,0 +1,351 @@
+package awareness
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/nugget/thane-ai-agent/internal/integrations/homeassistant"
+	"github.com/nugget/thane-ai-agent/internal/model/promptfmt"
+)
+
+// DeviceSnapshotClient is the slice of Home Assistant calls the
+// ha_device tool needs. It extends the shared registry surface with a
+// targeted single-entity state read: a device owns a handful of
+// entities whose ids we already know from the registry, so we fetch
+// each one directly rather than pulling the whole live state set
+// (15k+ entities in production) just to keep a few. The concrete
+// homeassistant.Client implements every method out of the box.
+type DeviceSnapshotClient interface {
+	HARegistryClient
+	GetState(ctx context.Context, entityID string) (*homeassistant.State, error)
+}
+
+// DeviceSnapshotRequest describes one ha_device invocation.
+type DeviceSnapshotRequest struct {
+	// Device is a device_id or a name (matched case-insensitively
+	// against the user-assigned name, then the registry name, then by
+	// substring).
+	Device string
+	// Include is the optional per-entity metadata projection applied to
+	// each child entity, mirroring the other native HA tools.
+	Include homeassistant.EntityMetadataIncludes
+}
+
+// maxDeviceOtherEntities caps the least-salient ("other") bucket so a
+// device that exposes a long tail of config/diagnostic sensors can't
+// flood the prompt. Anomalies, active, and ambient buckets are
+// inherently small and stay uncapped; overflow on "other" is reported
+// via other_truncated_count. Mirrors area_activity's stable-bucket cap.
+const maxDeviceOtherEntities = 15
+
+// ComputeDeviceSnapshot resolves a device, gathers its child entities +
+// states, buckets them by salience, and returns a single JSON object
+// describing the device for model consumption. The output leads with
+// device identity and an availability rollup, then the entities grouped
+// most-actionable-first (anomalies → active → ambient → other), matching
+// the model-facing-context conventions used by the area snapshot.
+func ComputeDeviceSnapshot(ctx context.Context, client DeviceSnapshotClient, req DeviceSnapshotRequest, now time.Time) (string, error) {
+	if client == nil {
+		return "", fmt.Errorf("ha_device: client is required")
+	}
+	if strings.TrimSpace(req.Device) == "" {
+		return "", fmt.Errorf("ha_device: device is required")
+	}
+
+	devices, err := client.GetDeviceRegistry(ctx)
+	if err != nil {
+		return "", fmt.Errorf("ha_device: get device registry: %w", err)
+	}
+	device, candidates, ok := resolveDevice(devices, req.Device)
+	if !ok {
+		if len(candidates) > 0 {
+			return promptfmt.MarshalCompact(map[string]any{
+				"query":      req.Device,
+				"found":      false,
+				"reason":     "ambiguous",
+				"candidates": candidates,
+				"note":       "multiple devices matched; re-call with a device_id from candidates",
+			}), nil
+		}
+		return promptfmt.MarshalCompact(map[string]any{
+			"query":  req.Device,
+			"found":  false,
+			"reason": "no_match",
+			"note":   "no device matched by id, name, or substring",
+		}), nil
+	}
+
+	entities, err := client.GetEntityRegistry(ctx)
+	if err != nil {
+		return "", fmt.Errorf("ha_device: get entity registry: %w", err)
+	}
+
+	// Child entities: every registry entry owned by this device.
+	// Disabled entities are excluded from the buckets (HA doesn't load
+	// them, so they have no live state and would render as misleading
+	// "no_state" anomalies) and reported via disabled_count instead.
+	deviceByID := indexDevices(devices)
+	var children []areaMember
+	disabled := 0
+	for i := range entities {
+		entry := entities[i]
+		if entry.DeviceID != device.ID {
+			continue
+		}
+		if entry.DisabledBy != "" {
+			disabled++
+			continue
+		}
+		children = append(children, areaMember{entry: entry, device: deviceByID[entry.DeviceID]})
+	}
+
+	// Targeted state read per child — exact ids, bounded count.
+	statesByID := make(map[string]*homeassistant.State, len(children))
+	for _, m := range children {
+		state, stateErr := client.GetState(ctx, m.entry.EntityID)
+		if stateErr != nil {
+			// A failed read is surfaced as an unavailable child rather
+			// than failing the whole snapshot — other children still
+			// describe the device's health.
+			continue
+		}
+		statesByID[m.entry.EntityID] = state
+	}
+
+	cls := classifyDeviceChildren(children, statesByID, now)
+
+	resolver, err := buildDeviceResolver(ctx, client, devices, req.Include)
+	if err != nil {
+		return "", err
+	}
+
+	payload := map[string]any{
+		"device":       deviceDisplayName(device),
+		"device_id":    device.ID,
+		"entity_count": len(children),
+		"availability": map[string]any{
+			"reporting": cls.reporting,
+			"total":     len(children),
+		},
+	}
+	if identity := resolver.DeviceMetadata(&device); identity != nil {
+		payload["identity"] = identity
+	}
+	if integration := deviceIntegration(ctx, client, device); integration != "" {
+		payload["integration"] = integration
+	}
+	if via := deviceByID[device.ViaDeviceID]; via != nil {
+		payload["via_device"] = deviceDisplayName(*via)
+	}
+	if disabled > 0 {
+		payload["disabled_count"] = disabled
+	}
+	if len(cls.unavailable) > 0 {
+		payload["unavailable"] = cls.unavailable
+	}
+
+	otherTruncated := 0
+	if len(cls.other) > maxDeviceOtherEntities {
+		otherTruncated = len(cls.other) - maxDeviceOtherEntities
+		cls.other = cls.other[:maxDeviceOtherEntities]
+	}
+
+	if req.Include.Any() {
+		attachAreaEntityMetadata(resolver, req.Include, children, statesByID,
+			cls.anomalies, cls.active, cls.ambient, cls.other)
+	}
+
+	if len(cls.anomalies) > 0 {
+		payload["anomalies"] = cls.anomalies
+	}
+	if len(cls.active) > 0 {
+		payload["active"] = cls.active
+	}
+	if len(cls.ambient) > 0 {
+		payload["ambient"] = cls.ambient
+	}
+	if len(cls.other) > 0 {
+		payload["other"] = cls.other
+	}
+	if otherTruncated > 0 {
+		payload["other_truncated_count"] = otherTruncated
+	}
+
+	return promptfmt.MarshalCompact(payload), nil
+}
+
+// buildDeviceResolver assembles the metadata resolver for the device
+// snapshot. Areas are always fetched so device identity can carry the
+// resolved area name; labels and floors are pulled only when the
+// include projection asks for them. devices is reused from the caller's
+// already-fetched device registry rather than re-fetched. Mirrors the
+// gated-fetch pattern in ComputeAreaActivity.
+func buildDeviceResolver(
+	ctx context.Context,
+	client DeviceSnapshotClient,
+	devices []homeassistant.DeviceRegistryEntry,
+	include homeassistant.EntityMetadataIncludes,
+) (homeassistant.EntityMetadataResolver, error) {
+	areas, err := client.GetAreas(ctx)
+	if err != nil {
+		return homeassistant.EntityMetadataResolver{}, fmt.Errorf("ha_device: get areas: %w", err)
+	}
+	var labels []homeassistant.LabelRegistryEntry
+	if include.Labels {
+		labels, err = client.GetLabelRegistry(ctx)
+		if err != nil {
+			return homeassistant.EntityMetadataResolver{}, fmt.Errorf("ha_device: get labels: %w", err)
+		}
+	}
+	var floors []homeassistant.FloorRegistryEntry
+	if include.Area {
+		floors, err = client.GetFloorRegistry(ctx)
+		if err != nil {
+			return homeassistant.EntityMetadataResolver{}, fmt.Errorf("ha_device: get floors: %w", err)
+		}
+	}
+	floorAlias := ""
+	if p, ok := client.(interface{ FloorMetadataAlias() string }); ok {
+		floorAlias = p.FloorMetadataAlias()
+	}
+	return homeassistant.NewEntityMetadataResolverWithFloorAlias(areas, labels, devices, floors, floorAlias), nil
+}
+
+// deviceChildBuckets holds the salience-grouped render of a device's
+// child entities plus the availability rollup.
+type deviceChildBuckets struct {
+	anomalies   []map[string]any
+	active      []map[string]any
+	ambient     []map[string]any
+	other       []map[string]any
+	reporting   int      // children with a live, non-sentinel state
+	unavailable []string // entity_ids missing a state or in a sentinel state
+}
+
+// classifyDeviceChildren buckets a device's child entities by salience,
+// reusing the same per-entity render and classification predicates the
+// area snapshot uses so the two views stay consistent. Unlike the area
+// classifier there is no recent-changes window — a device view answers
+// "what does this device expose and is it healthy" rather than "what
+// happened in this room lately."
+func classifyDeviceChildren(children []areaMember, statesByID map[string]*homeassistant.State, now time.Time) deviceChildBuckets {
+	var b deviceChildBuckets
+	for _, m := range children {
+		state := statesByID[m.entry.EntityID]
+		if state == nil {
+			b.anomalies = append(b.anomalies, map[string]any{
+				"entity":    m.entry.EntityID,
+				"available": false,
+				"reason":    "no_state",
+			})
+			b.unavailable = append(b.unavailable, m.entry.EntityID)
+			continue
+		}
+		rendered := renderEntityForArea(state, now)
+		switch {
+		case isSentinelState(state.State):
+			b.anomalies = append(b.anomalies, rendered)
+			b.unavailable = append(b.unavailable, m.entry.EntityID)
+		case isAlarmAnomaly(state, m.entry):
+			b.anomalies = append(b.anomalies, rendered)
+			b.reporting++
+		case isActive(state, m.entry):
+			b.active = append(b.active, rendered)
+			b.reporting++
+		case isAmbientNumeric(state, m.entry):
+			b.ambient = append(b.ambient, rendered)
+			b.reporting++
+		default:
+			b.other = append(b.other, rendered)
+			b.reporting++
+		}
+	}
+	sort.Strings(b.unavailable)
+	return b
+}
+
+// resolveDevice matches a device by id, then by case-insensitive
+// user-assigned name or registry name, then by substring. It mirrors
+// resolveArea's exact-first strategy and returns candidate device_ids
+// when a substring query is ambiguous so the model can disambiguate.
+func resolveDevice(devices []homeassistant.DeviceRegistryEntry, query string) (homeassistant.DeviceRegistryEntry, []string, bool) {
+	q := strings.TrimSpace(query)
+	if q == "" {
+		return homeassistant.DeviceRegistryEntry{}, nil, false
+	}
+	// Exact id.
+	for i := range devices {
+		if devices[i].ID == q {
+			return devices[i], nil, true
+		}
+	}
+	// Exact (case-insensitive) name or user-assigned name.
+	for i := range devices {
+		if strings.EqualFold(devices[i].NameByUser, q) || strings.EqualFold(devices[i].Name, q) {
+			return devices[i], nil, true
+		}
+	}
+	// Substring on either name; collect all matches for disambiguation.
+	qLower := strings.ToLower(q)
+	var matches []int
+	for i := range devices {
+		name := strings.ToLower(deviceDisplayName(devices[i]))
+		if name != "" && strings.Contains(name, qLower) {
+			matches = append(matches, i)
+		}
+	}
+	switch len(matches) {
+	case 0:
+		return homeassistant.DeviceRegistryEntry{}, nil, false
+	case 1:
+		return devices[matches[0]], nil, true
+	default:
+		candidates := make([]string, 0, len(matches))
+		for _, idx := range matches {
+			candidates = append(candidates, fmt.Sprintf("%s (%s)", devices[idx].ID, deviceDisplayName(devices[idx])))
+		}
+		sort.Strings(candidates)
+		return homeassistant.DeviceRegistryEntry{}, candidates, false
+	}
+}
+
+// deviceDisplayName prefers the user-assigned name, then the registry
+// name, then the device id so a device always renders with a stable
+// label.
+func deviceDisplayName(device homeassistant.DeviceRegistryEntry) string {
+	if device.NameByUser != "" {
+		return device.NameByUser
+	}
+	if device.Name != "" {
+		return device.Name
+	}
+	return device.ID
+}
+
+// deviceIntegration resolves the device's owning integration (config
+// entry domain) from the primary config entry, falling back to the
+// first config entry. Returns "" when the device has no config entry or
+// the registry can't be read — integration is enrichment, not load-
+// bearing, so a fetch failure just omits it.
+func deviceIntegration(ctx context.Context, client DeviceSnapshotClient, device homeassistant.DeviceRegistryEntry) string {
+	entryID := device.PrimaryConfigEntry
+	if entryID == "" {
+		if len(device.ConfigEntries) == 0 {
+			return ""
+		}
+		entryID = device.ConfigEntries[0]
+	}
+	entries, err := client.GetConfigEntries(ctx)
+	if err != nil {
+		return ""
+	}
+	for i := range entries {
+		if entries[i].EntryID == entryID {
+			return entries[i].Domain
+		}
+	}
+	return ""
+}

--- a/internal/state/awareness/device_snapshot_test.go
+++ b/internal/state/awareness/device_snapshot_test.go
@@ -1,0 +1,341 @@
+package awareness
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/nugget/thane-ai-agent/internal/integrations/homeassistant"
+)
+
+// fakeDeviceClient supplies the registry calls plus a per-entity state
+// map for ha_device tests. An entity_id absent from states makes
+// GetState return an error, exercising the "no_state" anomaly path.
+type fakeDeviceClient struct {
+	areas    []homeassistant.Area
+	entities []homeassistant.EntityRegistryEntry
+	devices  []homeassistant.DeviceRegistryEntry
+	floors   []homeassistant.FloorRegistryEntry
+	labels   []homeassistant.LabelRegistryEntry
+	configs  []homeassistant.ConfigEntry
+	states   map[string]*homeassistant.State
+
+	devicesErr error
+}
+
+func (f *fakeDeviceClient) GetAreas(_ context.Context) ([]homeassistant.Area, error) {
+	return f.areas, nil
+}
+func (f *fakeDeviceClient) GetEntityRegistry(_ context.Context) ([]homeassistant.EntityRegistryEntry, error) {
+	return f.entities, nil
+}
+func (f *fakeDeviceClient) GetDeviceRegistry(_ context.Context) ([]homeassistant.DeviceRegistryEntry, error) {
+	return f.devices, f.devicesErr
+}
+func (f *fakeDeviceClient) GetFloorRegistry(_ context.Context) ([]homeassistant.FloorRegistryEntry, error) {
+	return f.floors, nil
+}
+func (f *fakeDeviceClient) GetLabelRegistry(_ context.Context) ([]homeassistant.LabelRegistryEntry, error) {
+	return f.labels, nil
+}
+func (f *fakeDeviceClient) GetStates(_ context.Context) ([]homeassistant.State, error) {
+	out := make([]homeassistant.State, 0, len(f.states))
+	for _, s := range f.states {
+		out = append(out, *s)
+	}
+	return out, nil
+}
+func (f *fakeDeviceClient) GetConfigEntries(_ context.Context) ([]homeassistant.ConfigEntry, error) {
+	return f.configs, nil
+}
+func (f *fakeDeviceClient) GetState(_ context.Context, entityID string) (*homeassistant.State, error) {
+	s, ok := f.states[entityID]
+	if !ok {
+		return nil, fmt.Errorf("entity %s not found", entityID)
+	}
+	return s, nil
+}
+
+func mkState(id, state string, attrs map[string]any) *homeassistant.State {
+	return &homeassistant.State{EntityID: id, State: state, Attributes: attrs}
+}
+
+// thermostatClient builds a device with a rich, mixed-salience set of
+// child entities including one sentinel (unavailable) and one with no
+// state at all, for the multi-entity / availability tests.
+func thermostatClient() *fakeDeviceClient {
+	return &fakeDeviceClient{
+		areas: []homeassistant.Area{{AreaID: "office", Name: "Office"}},
+		devices: []homeassistant.DeviceRegistryEntry{
+			{
+				ID:                 "dev_thermo",
+				Name:               "Ecobee Thermostat",
+				Manufacturer:       "Ecobee",
+				Model:              "SmartThermostat",
+				SWVersion:          "4.7",
+				AreaID:             "office",
+				PrimaryConfigEntry: "cfg_ecobee",
+			},
+		},
+		configs: []homeassistant.ConfigEntry{
+			{EntryID: "cfg_ecobee", Domain: "ecobee", Title: "Ecobee"},
+		},
+		entities: []homeassistant.EntityRegistryEntry{
+			{EntityID: "climate.thermostat", DeviceID: "dev_thermo"},
+			{EntityID: "sensor.thermostat_temp", DeviceID: "dev_thermo", DeviceClass: "temperature"},
+			{EntityID: "sensor.thermostat_humidity", DeviceID: "dev_thermo", DeviceClass: "humidity"},
+			{EntityID: "binary_sensor.thermostat_motion", DeviceID: "dev_thermo", DeviceClass: "motion"},
+			{EntityID: "sensor.thermostat_battery", DeviceID: "dev_thermo", DeviceClass: "battery"},
+			{EntityID: "sensor.thermostat_signal", DeviceID: "dev_thermo", DeviceClass: "signal_strength"},
+			// Belongs to a different device — must not appear.
+			{EntityID: "light.hall", DeviceID: "dev_other"},
+		},
+		states: map[string]*homeassistant.State{
+			"climate.thermostat":              mkState("climate.thermostat", "heat", map[string]any{"hvac_action": "heating"}),
+			"sensor.thermostat_temp":          mkState("sensor.thermostat_temp", "72", map[string]any{"device_class": "temperature"}),
+			"sensor.thermostat_humidity":      mkState("sensor.thermostat_humidity", "40", map[string]any{"device_class": "humidity"}),
+			"binary_sensor.thermostat_motion": mkState("binary_sensor.thermostat_motion", "off", map[string]any{"device_class": "motion"}),
+			"sensor.thermostat_battery":       mkState("sensor.thermostat_battery", "unavailable", map[string]any{"device_class": "battery"}),
+			// sensor.thermostat_signal intentionally absent → no_state.
+			"light.hall": mkState("light.hall", "on", nil),
+		},
+	}
+}
+
+func decodeDevicePayload(t *testing.T, raw string) map[string]any {
+	t.Helper()
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(raw), &payload); err != nil {
+		t.Fatalf("unmarshal: %v\n%s", err, raw)
+	}
+	return payload
+}
+
+// bucketEntities returns the entity_ids present in a named bucket.
+func bucketEntities(payload map[string]any, bucket string) []string {
+	list, _ := payload[bucket].([]any)
+	out := make([]string, 0, len(list))
+	for _, item := range list {
+		if obj, ok := item.(map[string]any); ok {
+			if id, ok := obj["entity"].(string); ok {
+				out = append(out, id)
+			}
+		}
+	}
+	return out
+}
+
+func contains(haystack []string, needle string) bool {
+	for _, s := range haystack {
+		if s == needle {
+			return true
+		}
+	}
+	return false
+}
+
+func TestComputeDeviceSnapshot_ByID(t *testing.T) {
+	out, err := ComputeDeviceSnapshot(context.Background(), thermostatClient(), DeviceSnapshotRequest{Device: "dev_thermo"}, testNow)
+	if err != nil {
+		t.Fatalf("ComputeDeviceSnapshot: %v", err)
+	}
+	payload := decodeDevicePayload(t, out)
+	if payload["device"] != "Ecobee Thermostat" {
+		t.Errorf("device = %#v, want Ecobee Thermostat", payload["device"])
+	}
+	if payload["device_id"] != "dev_thermo" {
+		t.Errorf("device_id = %#v, want dev_thermo", payload["device_id"])
+	}
+	if payload["integration"] != "ecobee" {
+		t.Errorf("integration = %#v, want ecobee", payload["integration"])
+	}
+	// The cross-device entity must never leak into the snapshot.
+	for _, bucket := range []string{"anomalies", "active", "ambient", "other"} {
+		if contains(bucketEntities(payload, bucket), "light.hall") {
+			t.Errorf("light.hall (other device) leaked into %s", bucket)
+		}
+	}
+}
+
+func TestComputeDeviceSnapshot_ByName(t *testing.T) {
+	cases := []string{"Ecobee Thermostat", "ecobee thermostat", "thermostat"}
+	for _, q := range cases {
+		t.Run(q, func(t *testing.T) {
+			out, err := ComputeDeviceSnapshot(context.Background(), thermostatClient(), DeviceSnapshotRequest{Device: q}, testNow)
+			if err != nil {
+				t.Fatalf("ComputeDeviceSnapshot(%q): %v", q, err)
+			}
+			payload := decodeDevicePayload(t, out)
+			if payload["device_id"] != "dev_thermo" {
+				t.Errorf("device_id = %#v, want dev_thermo (query %q)", payload["device_id"], q)
+			}
+		})
+	}
+}
+
+func TestComputeDeviceSnapshot_MultiEntityAndAvailability(t *testing.T) {
+	out, err := ComputeDeviceSnapshot(context.Background(), thermostatClient(), DeviceSnapshotRequest{Device: "dev_thermo"}, testNow)
+	if err != nil {
+		t.Fatalf("ComputeDeviceSnapshot: %v", err)
+	}
+	payload := decodeDevicePayload(t, out)
+
+	if got := payload["entity_count"]; got != float64(6) {
+		t.Errorf("entity_count = %#v, want 6", got)
+	}
+
+	avail, ok := payload["availability"].(map[string]any)
+	if !ok {
+		t.Fatalf("availability missing or wrong type: %#v", payload["availability"])
+	}
+	if avail["reporting"] != float64(4) || avail["total"] != float64(6) {
+		t.Errorf("availability = %#v, want reporting 4 / total 6", avail)
+	}
+
+	active := bucketEntities(payload, "active")
+	if !contains(active, "climate.thermostat") {
+		t.Errorf("active = %v, want climate.thermostat", active)
+	}
+	ambient := bucketEntities(payload, "ambient")
+	if !contains(ambient, "sensor.thermostat_temp") || !contains(ambient, "sensor.thermostat_humidity") {
+		t.Errorf("ambient = %v, want temp + humidity", ambient)
+	}
+	other := bucketEntities(payload, "other")
+	if !contains(other, "binary_sensor.thermostat_motion") {
+		t.Errorf("other = %v, want binary_sensor.thermostat_motion", other)
+	}
+	anomalies := bucketEntities(payload, "anomalies")
+	if !contains(anomalies, "sensor.thermostat_battery") || !contains(anomalies, "sensor.thermostat_signal") {
+		t.Errorf("anomalies = %v, want battery (sentinel) + signal (no_state)", anomalies)
+	}
+
+	unavailable, _ := payload["unavailable"].([]any)
+	if len(unavailable) != 2 {
+		t.Errorf("unavailable = %#v, want 2 entries", payload["unavailable"])
+	}
+}
+
+func TestComputeDeviceSnapshot_AmbiguousName(t *testing.T) {
+	client := &fakeDeviceClient{
+		devices: []homeassistant.DeviceRegistryEntry{
+			{ID: "dev_a", Name: "Front Door Sensor"},
+			{ID: "dev_b", Name: "Back Door Sensor"},
+		},
+	}
+	out, err := ComputeDeviceSnapshot(context.Background(), client, DeviceSnapshotRequest{Device: "sensor"}, testNow)
+	if err != nil {
+		t.Fatalf("ComputeDeviceSnapshot: %v", err)
+	}
+	payload := decodeDevicePayload(t, out)
+	if payload["found"] != false {
+		t.Errorf("found = %#v, want false", payload["found"])
+	}
+	if payload["reason"] != "ambiguous" {
+		t.Errorf("reason = %#v, want ambiguous", payload["reason"])
+	}
+	cands, _ := payload["candidates"].([]any)
+	if len(cands) != 2 {
+		t.Errorf("candidates = %#v, want 2", payload["candidates"])
+	}
+}
+
+func TestComputeDeviceSnapshot_NotFound(t *testing.T) {
+	client := &fakeDeviceClient{
+		devices: []homeassistant.DeviceRegistryEntry{{ID: "dev_a", Name: "Thermostat"}},
+	}
+	out, err := ComputeDeviceSnapshot(context.Background(), client, DeviceSnapshotRequest{Device: "garage opener"}, testNow)
+	if err != nil {
+		t.Fatalf("ComputeDeviceSnapshot: %v", err)
+	}
+	payload := decodeDevicePayload(t, out)
+	if payload["found"] != false || payload["reason"] != "no_match" {
+		t.Errorf("expected found=false reason=no_match, got %#v", payload)
+	}
+}
+
+func TestComputeDeviceSnapshot_IncludeMetadata(t *testing.T) {
+	client := thermostatClient()
+	// Give one child a description to surface through the projection.
+	for i := range client.entities {
+		if client.entities[i].EntityID == "climate.thermostat" {
+			client.entities[i].Description = "Main floor thermostat"
+		}
+	}
+
+	req := DeviceSnapshotRequest{
+		Device:  "dev_thermo",
+		Include: homeassistant.EntityMetadataIncludes{Description: true},
+	}
+	out, err := ComputeDeviceSnapshot(context.Background(), client, req, testNow)
+	if err != nil {
+		t.Fatalf("ComputeDeviceSnapshot: %v", err)
+	}
+	payload := decodeDevicePayload(t, out)
+	active, _ := payload["active"].([]any)
+	if len(active) == 0 {
+		t.Fatalf("expected an active entity to enrich:\n%s", out)
+	}
+	obj, _ := active[0].(map[string]any)
+	meta, ok := obj["metadata"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected metadata on active entity, got %#v", obj["metadata"])
+	}
+	if meta["description"] != "Main floor thermostat" {
+		t.Errorf("metadata.description = %#v, want Main floor thermostat", meta["description"])
+	}
+}
+
+func TestComputeDeviceSnapshot_NoIncludeNoMetadata(t *testing.T) {
+	out, err := ComputeDeviceSnapshot(context.Background(), thermostatClient(), DeviceSnapshotRequest{Device: "dev_thermo"}, testNow)
+	if err != nil {
+		t.Fatalf("ComputeDeviceSnapshot: %v", err)
+	}
+	payload := decodeDevicePayload(t, out)
+	for _, bucket := range []string{"anomalies", "active", "ambient", "other"} {
+		list, _ := payload[bucket].([]any)
+		for _, item := range list {
+			if obj, ok := item.(map[string]any); ok {
+				if _, has := obj["metadata"]; has {
+					t.Errorf("entity in %s carries metadata without include:\n%s", bucket, out)
+				}
+			}
+		}
+	}
+}
+
+func TestComputeDeviceSnapshot_DisabledChildExcluded(t *testing.T) {
+	client := &fakeDeviceClient{
+		areas:   []homeassistant.Area{{AreaID: "office", Name: "Office"}},
+		devices: []homeassistant.DeviceRegistryEntry{{ID: "dev_x", Name: "Widget", AreaID: "office"}},
+		entities: []homeassistant.EntityRegistryEntry{
+			{EntityID: "switch.widget", DeviceID: "dev_x"},
+			{EntityID: "sensor.widget_legacy", DeviceID: "dev_x", DisabledBy: "integration"},
+		},
+		states: map[string]*homeassistant.State{
+			"switch.widget": mkState("switch.widget", "on", nil),
+		},
+	}
+	out, err := ComputeDeviceSnapshot(context.Background(), client, DeviceSnapshotRequest{Device: "dev_x"}, testNow)
+	if err != nil {
+		t.Fatalf("ComputeDeviceSnapshot: %v", err)
+	}
+	payload := decodeDevicePayload(t, out)
+	if payload["entity_count"] != float64(1) {
+		t.Errorf("entity_count = %#v, want 1 (disabled excluded)", payload["entity_count"])
+	}
+	if payload["disabled_count"] != float64(1) {
+		t.Errorf("disabled_count = %#v, want 1", payload["disabled_count"])
+	}
+	for _, bucket := range []string{"anomalies", "active", "ambient", "other"} {
+		if contains(bucketEntities(payload, bucket), "sensor.widget_legacy") {
+			t.Errorf("disabled entity rendered in %s", bucket)
+		}
+	}
+}
+
+func TestComputeDeviceSnapshot_RequiresDevice(t *testing.T) {
+	if _, err := ComputeDeviceSnapshot(context.Background(), thermostatClient(), DeviceSnapshotRequest{}, testNow); err == nil {
+		t.Error("expected error when device is empty")
+	}
+}

--- a/internal/state/awareness/device_snapshot_tool.go
+++ b/internal/state/awareness/device_snapshot_tool.go
@@ -1,0 +1,92 @@
+package awareness
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/nugget/thane-ai-agent/internal/tools"
+)
+
+// DeviceSnapshotTools exposes the ha_device tool, an on-demand view of
+// one Home Assistant device as a unit: its identity plus every child
+// entity it exposes, with semantic state grouped by salience and an
+// availability rollup. Implements [tools.Provider].
+type DeviceSnapshotTools struct {
+	client DeviceSnapshotClient
+	logger *slog.Logger
+}
+
+// DeviceSnapshotToolsConfig captures the dependencies for
+// [NewDeviceSnapshotTools]. Client is required.
+type DeviceSnapshotToolsConfig struct {
+	Client DeviceSnapshotClient
+	Logger *slog.Logger
+}
+
+func NewDeviceSnapshotTools(cfg DeviceSnapshotToolsConfig) *DeviceSnapshotTools {
+	if cfg.Client == nil {
+		panic("awareness: DeviceSnapshotTools requires a non-nil Client")
+	}
+	logger := cfg.Logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &DeviceSnapshotTools{client: cfg.Client, logger: logger}
+}
+
+// Name implements [tools.Provider].
+func (a *DeviceSnapshotTools) Name() string { return "awareness.ha_device" }
+
+// Tools implements [tools.Provider].
+func (a *DeviceSnapshotTools) Tools() []*tools.Tool {
+	return []*tools.Tool{
+		{
+			Name: "ha_device",
+			Description: "Get a full snapshot of one Home Assistant device as a unit — its identity " +
+				"(manufacturer/model/firmware/serial/area/integration/via_device) and every child entity it exposes, " +
+				"with semantic state grouped by salience (anomalies first, then active devices, ambient sensors, then the rest), " +
+				"plus an availability rollup (how many of its entities are reporting). " +
+				"Use this to understand a physical device as a whole — 'show me the thermostat device', " +
+				"'what does the front-door sensor expose', 'is this device healthy' — rather than fetching one entity at a time. " +
+				"Resolves by device_id or by name (user-assigned or registry name, with substring fallback; returns candidates when ambiguous). " +
+				"Add include for per-entity area/device/label/description/visibility metadata.",
+			Parameters: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"device": map[string]any{
+						"type":        "string",
+						"description": "The device to inspect. Accepts the device_id, the user-assigned name, or the registry name (substring match falls back when there is no exact hit).",
+					},
+					"include": tools.EntityMetadataIncludeParameter(),
+				},
+				"required": []string{"device"},
+			},
+			Handler: a.handleDevice,
+		},
+	}
+}
+
+func (a *DeviceSnapshotTools) handleDevice(ctx context.Context, args map[string]any) (string, error) {
+	device, _ := args["device"].(string)
+	if device == "" {
+		return "", fmt.Errorf("device is required")
+	}
+
+	include, err := tools.ParseEntityMetadataIncludesArg(args["include"], "include")
+	if err != nil {
+		return "", err
+	}
+
+	req := DeviceSnapshotRequest{Device: device, Include: include}
+	result, err := ComputeDeviceSnapshot(ctx, a.client, req, time.Now())
+	if err != nil {
+		a.logger.Warn("ha_device failed",
+			"device", device,
+			"error", err,
+		)
+		return "", err
+	}
+	return result, nil
+}

--- a/scripts/architecture.baseline
+++ b/scripts/architecture.baseline
@@ -1,5 +1,5 @@
 packages=59
-interfaces=76
+interfaces=77
 large_files=46
 set_mutators=107
 database_opens=8

--- a/talents/ha.md
+++ b/talents/ha.md
@@ -188,6 +188,28 @@ pass `include_hidden` or `include_diagnostic` for a forensic pass. Reach
 for this instead of listing a domain and cross-referencing rooms by
 hand.
 
+## I want everything one device exposes
+
+`ha_device` is the whole-device perception view — the native answer to
+"show me the thermostat device", "what does the front-door sensor
+expose", or "is this device healthy":
+
+```json
+{
+  "device": "front door lock",
+  "include": {"labels": true}
+}
+```
+
+Returns the device identity (manufacturer/model/firmware/serial/area/
+integration/via_device) plus every child entity it owns, with semantic
+state grouped by salience (anomalies first, then active, ambient, then
+the rest) and an availability rollup (how many of its entities are
+reporting). Resolves by `device_id` or by name — user-assigned or
+registry name, with a substring fallback, returning candidates when a
+name is ambiguous. Reach for this instead of discovering a device's
+child entities one `ha_get_state` at a time.
+
 ## I want richer search across the registry
 
 `ha_registry_search` searches areas, labels, devices, and entities


### PR DESCRIPTION
## Summary

Adds the `ha_device` native tool — a whole-device perception view answering "show me the thermostat device", "what does the front-door sensor expose", "is this device healthy" — rather than fetching one entity at a time.

- **Identity**: manufacturer/model/firmware/serial/area/integration/via_device, via a new exported `EntityMetadataResolver.DeviceMetadata` (mirrors `AreaMetadata`).
- **Child entities**: every entity the device owns, rendered with semantic state and grouped by salience (anomalies → active → ambient → other), plus an availability rollup (`reporting`/`total`) and an `unavailable` list.
- **Resolution**: by `device_id`, then case-insensitive user/registry name, then substring — returns `candidates` when a name is ambiguous, `no_match` when nothing matches.
- **Optional `include`**: per-entity area/device/label/description/visibility metadata, same shape as the other native HA tools.

### Reuse, not parallel implementation
Lives in `internal/state/awareness/` alongside `get_area_activity` and reuses its per-entity renderer (`renderEntityForArea`), salience predicates (`isActive`/`isAlarmAnomaly`/`isAmbientNumeric`/`isSentinelState`), the metadata-attach helper (`attachAreaEntityMetadata`), and the resolver. The only new shared primitive is `DeviceMetadata`.

### Performance
Disabled children are excluded (reported via `disabled_count`). State reads are **targeted `GetState` per known child id** — never a 15k-entity bulk `GetStates` — consistent with the #1002 doctrine. The least-salient "other" bucket is capped (`other_truncated_count`).

Closes #1007. Part of #1002 (Phase 2).

> Stacked on #1015 (`claude/1005-area-snapshot`). Will auto-retarget to `main` once #1015 merges.

## Test plan
- [x] `just ci` passes locally (incl. architecture baseline bump: interfaces 76→77 for the new `DeviceSnapshotClient`).
- [x] Resolve by id and by fuzzy name (`device_snapshot_test.go`).
- [x] Multi-entity device buckets by salience.
- [x] Partially-unavailable device: availability rollup + anomalies + `unavailable` list.
- [x] Ambiguous name → candidates; no match → `no_match`.
- [x] `include` metadata projection attaches to child entities; absent without `include`.
- [x] Disabled children excluded + counted.