### PR TITLE
feat(ha): ha_history — on-demand recorder trend for one entity

### DIFF
--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -123,6 +123,7 @@ becoming default context clutter.
 | `ha_search_states` | Predicate search across live entity state (state value, numeric attribute, domain, area). |
 | `get_area_activity` | Whole-area snapshot: floor context + entities grouped by salience + transition timeline + filtered counts, with optional per-entity metadata. |
 | `ha_device` | Whole-device snapshot: device identity (manufacturer/model/firmware/area/integration) + every child entity with semantic state grouped by salience + availability rollup, resolved by id or name, with optional per-entity metadata. |
+| `ha_history` | Recorder trend for one entity over a lookback window: numeric min/max/start/end/delta/trend or a discrete change summary, optionally trending a numeric attribute instead of the state. |
 | `ha_call_service` | Direct HA service invocation. |
 | `ha_registry_search` | Search the entity/device/area registry. |
 | `ha_automation_list` | List automations with recent activation counts. |

--- a/internal/app/new_awareness.go
+++ b/internal/app/new_awareness.go
@@ -113,6 +113,10 @@ func (a *App) initAwareness(s *newState) error {
 			Client: a.ha,
 			Logger: logger,
 		}))
+		a.loop.Tools().RegisterProvider(awareness.NewEntityTrendTools(awareness.EntityTrendToolsConfig{
+			Client: a.ha,
+			Logger: logger,
+		}))
 	}
 
 	// --- State change window ---

--- a/internal/integrations/homeassistant/client.go
+++ b/internal/integrations/homeassistant/client.go
@@ -189,7 +189,27 @@ func (c *Client) GetState(ctx context.Context, entityID string) (*State, error) 
 // GetStateHistory retrieves recorder-backed state history for one entity across
 // a time window. The result is sorted in Home Assistant's returned order, which
 // is typically chronological.
+//
+// This is the lean path: it requests no_attributes, so each sample carries only
+// the state value (not its attribute map). It is the right default for the
+// always-on watchlist injection, which trends the state value itself. To trend
+// a value carried in an attribute (e.g. a climate entity's current_temperature),
+// use [Client.GetStateHistoryWithAttributes].
 func (c *Client) GetStateHistory(ctx context.Context, entityID string, startTime, endTime time.Time) ([]State, error) {
+	return c.stateHistory(ctx, entityID, startTime, endTime, false)
+}
+
+// GetStateHistoryWithAttributes retrieves recorder-backed state history for one
+// entity across a time window with each sample's attribute map intact. It is the
+// attributes-enabled counterpart to [Client.GetStateHistory] for callers that
+// need to trend a value living in an attribute rather than the state string.
+// The richer payload is heavier on the recorder, so prefer the lean
+// GetStateHistory unless attributes are actually needed.
+func (c *Client) GetStateHistoryWithAttributes(ctx context.Context, entityID string, startTime, endTime time.Time) ([]State, error) {
+	return c.stateHistory(ctx, entityID, startTime, endTime, true)
+}
+
+func (c *Client) stateHistory(ctx context.Context, entityID string, startTime, endTime time.Time, includeAttributes bool) ([]State, error) {
 	if entityID == "" {
 		return nil, nil
 	}
@@ -197,7 +217,9 @@ func (c *Client) GetStateHistory(ctx context.Context, entityID string, startTime
 	query := url.Values{}
 	query.Set("filter_entity_id", entityID)
 	query.Set("end_time", endTime.UTC().Format(time.RFC3339))
-	query.Set("no_attributes", "1")
+	if !includeAttributes {
+		query.Set("no_attributes", "1")
+	}
 	query.Set("significant_changes_only", "0")
 
 	path := "/api/history/period/" + startTime.UTC().Format(time.RFC3339)

--- a/internal/integrations/homeassistant/client_history_test.go
+++ b/internal/integrations/homeassistant/client_history_test.go
@@ -55,6 +55,46 @@ func TestClient_GetStateHistory(t *testing.T) {
 	}
 }
 
+func TestClient_GetStateHistoryWithAttributes(t *testing.T) {
+	var capturedPath string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedPath = r.URL.RequestURI()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[
+			[
+				{
+					"entity_id":"climate.office",
+					"state":"heat",
+					"attributes":{"current_temperature":70.1},
+					"last_changed":"2025-01-15T10:00:00Z",
+					"last_updated":"2025-01-15T10:00:00Z"
+				}
+			]
+		]`))
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "token", nil)
+	start := time.Date(2025, 1, 15, 9, 0, 0, 0, time.UTC)
+	end := time.Date(2025, 1, 15, 12, 0, 0, 0, time.UTC)
+
+	states, err := client.GetStateHistoryWithAttributes(context.Background(), "climate.office", start, end)
+	if err != nil {
+		t.Fatalf("GetStateHistoryWithAttributes: %v", err)
+	}
+	if len(states) != 1 {
+		t.Fatalf("len(states) = %d, want 1", len(states))
+	}
+	// The attributes-enabled path must NOT request no_attributes, and the
+	// attribute payload must survive into the parsed state.
+	if strings.Contains(capturedPath, "no_attributes") {
+		t.Errorf("path = %q, must not set no_attributes", capturedPath)
+	}
+	if got := states[0].Attributes["current_temperature"]; got != 70.1 {
+		t.Errorf("current_temperature = %#v, want 70.1", got)
+	}
+}
+
 func TestClient_GetWeatherForecasts(t *testing.T) {
 	var capturedPath string
 	var capturedBody map[string]any

--- a/internal/model/toolcatalog/catalog.go
+++ b/internal/model/toolcatalog/catalog.go
@@ -233,6 +233,7 @@ var builtinToolSpecs = map[string]BuiltinToolSpec{
 	"ha_search_states":            {CanonicalID: "native:ha_search_states", Source: NativeToolSource, Tags: []string{"ha"}},
 	"get_area_activity":           {CanonicalID: "native:get_area_activity", Source: NativeToolSource, Tags: []string{"ha"}},
 	"ha_device":                   {CanonicalID: "native:ha_device", Source: NativeToolSource, Tags: []string{"ha"}},
+	"ha_history":                  {CanonicalID: "native:ha_history", Source: NativeToolSource, Tags: []string{"ha"}},
 	"lens_list":                   {CanonicalID: "native:lens_list", Source: NativeToolSource},
 	"tag_inspect":                 {CanonicalID: "native:tag_inspect", Source: NativeToolSource},
 	"tag_reset":                   {CanonicalID: "native:tag_reset", Source: NativeToolSource},

--- a/internal/state/awareness/entity_trend.go
+++ b/internal/state/awareness/entity_trend.go
@@ -153,20 +153,25 @@ func projectAttributeSeries(states []homeassistant.State, attribute string) []ho
 
 // projectAttributeState returns a copy of current with its state value
 // replaced by the named attribute's value, preserving the attribute map
-// so precision/unit resolution still works. Returns current unchanged
-// when the attribute is absent or non-coercible (the empty/garbage
-// series then yields a clean no-history marker).
+// so precision/unit resolution still works. Returns nil when the
+// attribute is absent or non-coercible on the current state: the shared
+// summarizer appends the current sample to the series, so handing back
+// the *unprojected* state (e.g. a climate entity's "heat") would
+// contaminate a projected numeric attribute series and force a discrete
+// fallback. Dropping the current sample instead lets the recorded
+// attribute history summarize cleanly (or yield a no-history marker
+// when the recorder also has nothing for the attribute).
 func projectAttributeState(current *homeassistant.State, attribute string) *homeassistant.State {
 	if current == nil {
 		return nil
 	}
 	raw, ok := current.Attributes[attribute]
 	if !ok {
-		return current
+		return nil
 	}
 	value, ok := attributeValueString(raw)
 	if !ok {
-		return current
+		return nil
 	}
 	next := *current
 	next.State = value

--- a/internal/state/awareness/entity_trend.go
+++ b/internal/state/awareness/entity_trend.go
@@ -1,0 +1,194 @@
+package awareness
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/nugget/thane-ai-agent/internal/integrations/homeassistant"
+	"github.com/nugget/thane-ai-agent/internal/model/promptfmt"
+)
+
+const (
+	defaultTrendLookback = 86400   // 24h
+	maxTrendLookback     = 2592000 // 30d — bounds recorder load; clamped, not rejected
+)
+
+// TrendHistoryClient is the slice of Home Assistant calls the ha_history
+// tool needs: the current state (for classification, precision, and
+// unit) plus recorder-backed history. The attributes-enabled history
+// path is used only when a specific attribute is being trended, so a
+// plain state trend stays on the lean no_attributes fetch. The concrete
+// homeassistant.Client implements all three.
+type TrendHistoryClient interface {
+	GetState(ctx context.Context, entityID string) (*homeassistant.State, error)
+	GetStateHistory(ctx context.Context, entityID string, startTime, endTime time.Time) ([]homeassistant.State, error)
+	GetStateHistoryWithAttributes(ctx context.Context, entityID string, startTime, endTime time.Time) ([]homeassistant.State, error)
+}
+
+// TrendRequest describes one ha_history invocation.
+type TrendRequest struct {
+	EntityID        string
+	LookbackSeconds int    // <= 0 falls back to default; clamped to maxTrendLookback
+	Attribute       string // optional: trend this numeric attribute instead of the state value
+}
+
+// ComputeEntityTrend summarizes how one entity (or one of its numeric
+// attributes) has moved over a lookback window, reusing the same
+// numeric/discrete summarization the always-on watchlist injection uses.
+// It returns a single compact JSON object: a numeric trend
+// (min/max/start/end/delta/trend) for numeric series, a discrete change
+// summary (change_count/recent_states) otherwise, or an explicit
+// no-history marker when the recorder has nothing in the window.
+func ComputeEntityTrend(ctx context.Context, client TrendHistoryClient, req TrendRequest, now time.Time) (string, error) {
+	if client == nil {
+		return "", fmt.Errorf("ha_history: client is required")
+	}
+	if req.EntityID == "" {
+		return "", fmt.Errorf("ha_history: entity_id is required")
+	}
+
+	lookback := req.LookbackSeconds
+	if lookback <= 0 {
+		lookback = defaultTrendLookback
+	}
+	if lookback > maxTrendLookback {
+		lookback = maxTrendLookback
+	}
+
+	current, err := client.GetState(ctx, req.EntityID)
+	if err != nil {
+		return "", fmt.Errorf("ha_history: get current state: %w", err)
+	}
+
+	windows, _ := normalizeHistoryOffsets([]int{lookback})
+	startTime := now.Add(-time.Duration(lookback) * time.Second)
+
+	var states []homeassistant.State
+	summaryCurrent := current
+	if req.Attribute != "" {
+		// Trend a value carried in an attribute (e.g. current_temperature
+		// on a climate entity): pull the attributes-enabled history, then
+		// project each sample's attribute into the state slot so the shared
+		// numeric/discrete summarizer can work unmodified.
+		raw, histErr := client.GetStateHistoryWithAttributes(ctx, req.EntityID, startTime, now)
+		if histErr != nil {
+			return "", fmt.Errorf("ha_history: get history: %w", histErr)
+		}
+		states = projectAttributeSeries(raw, req.Attribute)
+		summaryCurrent = projectAttributeState(current, req.Attribute)
+	} else {
+		raw, histErr := client.GetStateHistory(ctx, req.EntityID, startTime, now)
+		if histErr != nil {
+			return "", fmt.Errorf("ha_history: get history: %w", histErr)
+		}
+		states = raw
+	}
+
+	noHistory := func() string {
+		payload := map[string]any{
+			"entity_id": req.EntityID,
+			"lookback":  historyLookbackDelta(lookback),
+			"available": false,
+			"reason":    "no_history",
+			"note":      "no recorder history for this entity in the lookback window (it may not be recorded)",
+		}
+		if req.Attribute != "" {
+			payload["attribute"] = req.Attribute
+		}
+		return promptfmt.MarshalCompact(payload)
+	}
+
+	// No recorder rows in the window → an explicit no-history marker. We
+	// check the raw fetched series here rather than the summary count
+	// because summarizeHistorySeries always folds in the current state,
+	// so a non-recorded entity would otherwise masquerade as a flat
+	// one-sample trend.
+	if len(states) == 0 {
+		return noHistory(), nil
+	}
+
+	summaries := summarizeHistorySeries(states, summaryCurrent, windows, now)
+	if len(summaries) == 0 {
+		return noHistory(), nil
+	}
+
+	// Exactly one window was requested, so flatten its summary into the
+	// top-level object for a lean, model-friendly shape.
+	payload := summaries[0]
+	payload["entity_id"] = req.EntityID
+	if req.Attribute != "" {
+		payload["attribute"] = req.Attribute
+	}
+	if unit := attrString(current.Attributes, "unit_of_measurement"); unit != "" && payload["kind"] == "numeric" {
+		payload["unit"] = unit
+	}
+
+	return promptfmt.MarshalCompact(payload), nil
+}
+
+// projectAttributeSeries returns a copy of states with each sample's
+// state value replaced by the named attribute's value (string-coerced).
+// Samples missing the attribute or carrying a non-coercible value are
+// dropped, so the resulting series reflects only points where the
+// attribute was actually recorded.
+func projectAttributeSeries(states []homeassistant.State, attribute string) []homeassistant.State {
+	out := make([]homeassistant.State, 0, len(states))
+	for _, s := range states {
+		raw, ok := s.Attributes[attribute]
+		if !ok {
+			continue
+		}
+		value, ok := attributeValueString(raw)
+		if !ok {
+			continue
+		}
+		next := s
+		next.State = value
+		out = append(out, next)
+	}
+	return out
+}
+
+// projectAttributeState returns a copy of current with its state value
+// replaced by the named attribute's value, preserving the attribute map
+// so precision/unit resolution still works. Returns current unchanged
+// when the attribute is absent or non-coercible (the empty/garbage
+// series then yields a clean no-history marker).
+func projectAttributeState(current *homeassistant.State, attribute string) *homeassistant.State {
+	if current == nil {
+		return nil
+	}
+	raw, ok := current.Attributes[attribute]
+	if !ok {
+		return current
+	}
+	value, ok := attributeValueString(raw)
+	if !ok {
+		return current
+	}
+	next := *current
+	next.State = value
+	return &next
+}
+
+// attributeValueString coerces a JSON attribute value into the string
+// form the history summarizer parses. Numbers are rendered without a
+// fixed precision so the numeric path can re-parse them faithfully.
+func attributeValueString(raw any) (string, bool) {
+	switch v := raw.(type) {
+	case string:
+		return v, true
+	case float64:
+		return strconv.FormatFloat(v, 'f', -1, 64), true
+	case int:
+		return strconv.Itoa(v), true
+	case int64:
+		return strconv.FormatInt(v, 10), true
+	case bool:
+		return strconv.FormatBool(v), true
+	default:
+		return "", false
+	}
+}

--- a/internal/state/awareness/entity_trend_test.go
+++ b/internal/state/awareness/entity_trend_test.go
@@ -180,6 +180,35 @@ func TestComputeEntityTrend_Attribute(t *testing.T) {
 	}
 }
 
+// TestComputeEntityTrend_AttributeAbsentOnCurrent is the #1018 regression:
+// when the recorder has the attribute but the current state no longer
+// exposes it (e.g. a climate entity turned off), the unprojected current
+// state must NOT be folded into the projected numeric series — the trend
+// stays numeric over the recorded attribute values rather than collapsing
+// to a discrete summary.
+func TestComputeEntityTrend_AttributeAbsentOnCurrent(t *testing.T) {
+	client := &fakeTrendClient{
+		// Current state dropped current_temperature (entity is "off").
+		current: histStateP("climate.office", "off", map[string]any{"unit_of_measurement": "°F"}, 0),
+		historyAttr: []homeassistant.State{
+			histState("climate.office", "heat", map[string]any{"current_temperature": 68.0}, 3*time.Hour),
+			histState("climate.office", "heat", map[string]any{"current_temperature": 70.0}, 2*time.Hour),
+			histState("climate.office", "heat", map[string]any{"current_temperature": 71.5}, 1*time.Hour),
+		},
+	}
+	out, err := ComputeEntityTrend(context.Background(), client, TrendRequest{EntityID: "climate.office", Attribute: "current_temperature"}, testNow)
+	if err != nil {
+		t.Fatalf("ComputeEntityTrend: %v", err)
+	}
+	p := decodeTrend(t, out)
+	if p["kind"] != "numeric" {
+		t.Fatalf("kind = %#v, want numeric (current lacks the attribute; must not poison to discrete)\n%s", p["kind"], out)
+	}
+	if p["max_value"] != "71.5" {
+		t.Errorf("max_value = %#v, want \"71.5\" (the off-state current must not be appended)", p["max_value"])
+	}
+}
+
 func TestComputeEntityTrend_LookbackClamped(t *testing.T) {
 	client := &fakeTrendClient{
 		current: histStateP("sensor.office_temp", "72.5", nil, 0),

--- a/internal/state/awareness/entity_trend_test.go
+++ b/internal/state/awareness/entity_trend_test.go
@@ -1,0 +1,212 @@
+package awareness
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/nugget/thane-ai-agent/internal/integrations/homeassistant"
+)
+
+// fakeTrendClient implements TrendHistoryClient for ha_history tests.
+// It records the start time the tool requested so lookback clamping can
+// be asserted, and serves separate lean / attributes-enabled history.
+type fakeTrendClient struct {
+	current     *homeassistant.State
+	currentErr  error
+	history     []homeassistant.State // GetStateHistory (lean)
+	historyAttr []homeassistant.State // GetStateHistoryWithAttributes
+	historyErr  error
+
+	gotStart time.Time
+}
+
+func (f *fakeTrendClient) GetState(_ context.Context, _ string) (*homeassistant.State, error) {
+	return f.current, f.currentErr
+}
+func (f *fakeTrendClient) GetStateHistory(_ context.Context, _ string, start, _ time.Time) ([]homeassistant.State, error) {
+	f.gotStart = start
+	return f.history, f.historyErr
+}
+func (f *fakeTrendClient) GetStateHistoryWithAttributes(_ context.Context, _ string, start, _ time.Time) ([]homeassistant.State, error) {
+	f.gotStart = start
+	return f.historyAttr, f.historyErr
+}
+
+func histState(id, state string, attrs map[string]any, ago time.Duration) homeassistant.State {
+	at := testNow.Add(-ago)
+	return homeassistant.State{EntityID: id, State: state, Attributes: attrs, LastChanged: at, LastUpdated: at}
+}
+
+func histStateP(id, state string, attrs map[string]any, ago time.Duration) *homeassistant.State {
+	s := histState(id, state, attrs, ago)
+	return &s
+}
+
+func decodeTrend(t *testing.T, raw string) map[string]any {
+	t.Helper()
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(raw), &payload); err != nil {
+		t.Fatalf("unmarshal: %v\n%s", err, raw)
+	}
+	return payload
+}
+
+func TestComputeEntityTrend_Numeric(t *testing.T) {
+	client := &fakeTrendClient{
+		current: histStateP("sensor.office_temp", "72.5",
+			map[string]any{"device_class": "temperature", "unit_of_measurement": "°F"}, 0),
+		history: []homeassistant.State{
+			histState("sensor.office_temp", "70.1", nil, 3*time.Hour),
+			histState("sensor.office_temp", "71.4", nil, 2*time.Hour),
+			histState("sensor.office_temp", "72.0", nil, 1*time.Hour),
+		},
+	}
+	out, err := ComputeEntityTrend(context.Background(), client, TrendRequest{EntityID: "sensor.office_temp"}, testNow)
+	if err != nil {
+		t.Fatalf("ComputeEntityTrend: %v", err)
+	}
+	p := decodeTrend(t, out)
+	if p["kind"] != "numeric" {
+		t.Fatalf("kind = %#v, want numeric\n%s", p["kind"], out)
+	}
+	if p["trend"] != "rising" {
+		t.Errorf("trend = %#v, want rising", p["trend"])
+	}
+	if p["entity_id"] != "sensor.office_temp" {
+		t.Errorf("entity_id = %#v", p["entity_id"])
+	}
+	if p["unit"] != "°F" {
+		t.Errorf("unit = %#v, want °F", p["unit"])
+	}
+	// Numeric summary values are rendered as formatted strings.
+	if p["min_value"] != "70.1" {
+		t.Errorf("min_value = %#v, want \"70.1\"", p["min_value"])
+	}
+	if p["max_value"] != "72.5" {
+		t.Errorf("max_value = %#v, want \"72.5\" (current is the latest sample)", p["max_value"])
+	}
+}
+
+func TestComputeEntityTrend_Discrete(t *testing.T) {
+	client := &fakeTrendClient{
+		current: histStateP("binary_sensor.front_door", "off", map[string]any{"device_class": "door"}, 0),
+		history: []homeassistant.State{
+			histState("binary_sensor.front_door", "off", nil, 3*time.Hour),
+			histState("binary_sensor.front_door", "on", nil, 2*time.Hour),
+			histState("binary_sensor.front_door", "off", nil, 1*time.Hour),
+		},
+	}
+	out, err := ComputeEntityTrend(context.Background(), client, TrendRequest{EntityID: "binary_sensor.front_door"}, testNow)
+	if err != nil {
+		t.Fatalf("ComputeEntityTrend: %v", err)
+	}
+	p := decodeTrend(t, out)
+	if p["kind"] != "discrete" {
+		t.Fatalf("kind = %#v, want discrete\n%s", p["kind"], out)
+	}
+	cc, ok := p["change_count"].(float64)
+	if !ok || cc < 1 {
+		t.Errorf("change_count = %#v, want >= 1", p["change_count"])
+	}
+	if _, ok := p["recent_states"]; !ok {
+		t.Errorf("expected recent_states in discrete summary:\n%s", out)
+	}
+}
+
+func TestComputeEntityTrend_EmptyWindow(t *testing.T) {
+	client := &fakeTrendClient{
+		current: histStateP("sensor.office_temp", "72.5", nil, 0),
+		history: nil, // recorder returned nothing in the window
+	}
+	out, err := ComputeEntityTrend(context.Background(), client, TrendRequest{EntityID: "sensor.office_temp"}, testNow)
+	if err != nil {
+		t.Fatalf("ComputeEntityTrend: %v", err)
+	}
+	p := decodeTrend(t, out)
+	if p["available"] != false || p["reason"] != "no_history" {
+		t.Errorf("expected available=false reason=no_history, got %#v", p)
+	}
+}
+
+func TestComputeEntityTrend_NonRecorderEntity(t *testing.T) {
+	// A non-recorded entity: current state resolves, but the recorder has
+	// no history at all. Must surface the explicit no-history marker, not
+	// an error or a bogus zero-change summary.
+	client := &fakeTrendClient{
+		current: histStateP("sensor.uptime_text", "online", nil, 0),
+		history: []homeassistant.State{},
+	}
+	out, err := ComputeEntityTrend(context.Background(), client, TrendRequest{EntityID: "sensor.uptime_text"}, testNow)
+	if err != nil {
+		t.Fatalf("ComputeEntityTrend: %v", err)
+	}
+	p := decodeTrend(t, out)
+	if p["reason"] != "no_history" {
+		t.Errorf("reason = %#v, want no_history\n%s", p["reason"], out)
+	}
+}
+
+func TestComputeEntityTrend_Attribute(t *testing.T) {
+	client := &fakeTrendClient{
+		current: histStateP("climate.office", "heat",
+			map[string]any{"current_temperature": 72.5, "unit_of_measurement": "°F"}, 0),
+		// Lean history must NOT be consulted for an attribute trend.
+		history: []homeassistant.State{histState("climate.office", "heat", nil, 1*time.Hour)},
+		historyAttr: []homeassistant.State{
+			histState("climate.office", "heat", map[string]any{"current_temperature": 68.0}, 3*time.Hour),
+			histState("climate.office", "heat", map[string]any{"current_temperature": 70.0}, 2*time.Hour),
+			histState("climate.office", "heat", map[string]any{"current_temperature": 71.5}, 1*time.Hour),
+		},
+	}
+	out, err := ComputeEntityTrend(context.Background(), client, TrendRequest{EntityID: "climate.office", Attribute: "current_temperature"}, testNow)
+	if err != nil {
+		t.Fatalf("ComputeEntityTrend: %v", err)
+	}
+	p := decodeTrend(t, out)
+	if p["attribute"] != "current_temperature" {
+		t.Errorf("attribute = %#v, want current_temperature", p["attribute"])
+	}
+	if p["kind"] != "numeric" {
+		t.Fatalf("kind = %#v, want numeric (attribute is numeric)\n%s", p["kind"], out)
+	}
+	if p["trend"] != "rising" {
+		t.Errorf("trend = %#v, want rising", p["trend"])
+	}
+	if p["min_value"] != "68" {
+		t.Errorf("min_value = %#v, want \"68\" (from the attribute series)", p["min_value"])
+	}
+}
+
+func TestComputeEntityTrend_LookbackClamped(t *testing.T) {
+	client := &fakeTrendClient{
+		current: histStateP("sensor.office_temp", "72.5", nil, 0),
+	}
+	_, err := ComputeEntityTrend(context.Background(), client,
+		TrendRequest{EntityID: "sensor.office_temp", LookbackSeconds: 999999999}, testNow)
+	if err != nil {
+		t.Fatalf("ComputeEntityTrend: %v", err)
+	}
+	// The requested window must be clamped to maxTrendLookback before the
+	// recorder query, not passed through verbatim.
+	wantStart := testNow.Add(-maxTrendLookback * time.Second)
+	if !client.gotStart.Equal(wantStart) {
+		t.Errorf("history start = %v, want clamped %v", client.gotStart, wantStart)
+	}
+}
+
+func TestComputeEntityTrend_RequiresEntity(t *testing.T) {
+	client := &fakeTrendClient{}
+	if _, err := ComputeEntityTrend(context.Background(), client, TrendRequest{}, testNow); err == nil {
+		t.Error("expected error when entity_id is empty")
+	}
+}
+
+func TestComputeEntityTrend_CurrentStateError(t *testing.T) {
+	client := &fakeTrendClient{currentErr: errors.New("entity not found")}
+	if _, err := ComputeEntityTrend(context.Background(), client, TrendRequest{EntityID: "sensor.ghost"}, testNow); err == nil {
+		t.Error("expected error when current state cannot be fetched")
+	}
+}

--- a/internal/state/awareness/entity_trend_tool.go
+++ b/internal/state/awareness/entity_trend_tool.go
@@ -1,0 +1,104 @@
+package awareness
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/nugget/thane-ai-agent/internal/tools"
+)
+
+// EntityTrendTools exposes the ha_history tool, an on-demand recorder
+// trend for one entity (or one of its numeric attributes) over a
+// lookback window. Implements [tools.Provider].
+type EntityTrendTools struct {
+	client TrendHistoryClient
+	logger *slog.Logger
+}
+
+// EntityTrendToolsConfig captures the dependencies for
+// [NewEntityTrendTools]. Client is required.
+type EntityTrendToolsConfig struct {
+	Client TrendHistoryClient
+	Logger *slog.Logger
+}
+
+func NewEntityTrendTools(cfg EntityTrendToolsConfig) *EntityTrendTools {
+	if cfg.Client == nil {
+		panic("awareness: EntityTrendTools requires a non-nil Client")
+	}
+	logger := cfg.Logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &EntityTrendTools{client: cfg.Client, logger: logger}
+}
+
+// Name implements [tools.Provider].
+func (a *EntityTrendTools) Name() string { return "awareness.ha_history" }
+
+// Tools implements [tools.Provider].
+func (a *EntityTrendTools) Tools() []*tools.Tool {
+	return []*tools.Tool{
+		{
+			Name: "ha_history",
+			Description: "Summarize how one Home Assistant entity has trended over a recorder lookback window — " +
+				"the native answer to 'how has the office temperature moved over the last 24h' or 'how often did the front door open today' " +
+				"without fetching raw history yourself. Returns a numeric trend (min/max/start/end/delta/rising-falling) for numeric entities " +
+				"and a discrete change summary (change count + recent states) for non-numeric ones. " +
+				"By default it trends the entity's state value; pass attribute to trend a numeric value carried in an attribute " +
+				"(e.g. current_temperature on a climate entity). For sustained, every-turn awareness of an entity, prefer an awareness " +
+				"subscription with history windows instead of polling this from a loop.",
+			Parameters: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"entity_id": map[string]any{
+						"type":        "string",
+						"description": "The entity to summarize, e.g. sensor.office_temperature.",
+					},
+					"lookback_seconds": map[string]any{
+						"type":        "integer",
+						"description": "How far back to summarize. Defaults to 86400 (24h); clamped to a 30-day maximum. Larger windows pull more recorder rows.",
+					},
+					"attribute": map[string]any{
+						"type":        "string",
+						"description": "Optional: trend this numeric attribute instead of the state value (e.g. current_temperature, battery). Use when the interesting value lives in an attribute rather than the state.",
+					},
+				},
+				"required": []string{"entity_id"},
+			},
+			Handler: a.handleHistory,
+		},
+	}
+}
+
+func (a *EntityTrendTools) handleHistory(ctx context.Context, args map[string]any) (string, error) {
+	entityID, _ := args["entity_id"].(string)
+	entityID = strings.TrimSpace(entityID)
+	if entityID == "" {
+		return "", fmt.Errorf("entity_id is required")
+	}
+
+	req := TrendRequest{EntityID: entityID}
+	if v, ok := args["attribute"].(string); ok {
+		req.Attribute = strings.TrimSpace(v)
+	}
+	if v, err := optionalIntArg(args, "lookback_seconds"); err != nil {
+		return "", err
+	} else if v != nil {
+		req.LookbackSeconds = *v
+	}
+
+	result, err := ComputeEntityTrend(ctx, a.client, req, time.Now())
+	if err != nil {
+		a.logger.Warn("ha_history failed",
+			"entity_id", entityID,
+			"attribute", req.Attribute,
+			"error", err,
+		)
+		return "", err
+	}
+	return result, nil
+}

--- a/internal/state/awareness/watchlist_history.go
+++ b/internal/state/awareness/watchlist_history.go
@@ -39,9 +39,20 @@ func buildWatchlistHistorySummaries(
 		return nil, truncated, err
 	}
 
+	return summarizeHistorySeries(states, current, windows, now), truncated, nil
+}
+
+// summarizeHistorySeries is the post-fetch half of the history pipeline:
+// it normalizes an already-fetched state series, then produces one
+// numeric-or-discrete summary per lookback window. Split out so the
+// on-demand ha_history tool and the always-on watchlist injection share
+// exactly one summarization implementation rather than diverging copies.
+// windows must already be normalized (positive, deduped, sorted
+// ascending); callers get that from [normalizeHistoryOffsets].
+func summarizeHistorySeries(states []homeassistant.State, current *homeassistant.State, windows []int, now time.Time) []map[string]any {
 	series := normalizeHistoryStates(states, current)
 	if len(series) == 0 {
-		return nil, truncated, nil
+		return nil
 	}
 
 	summaries := make([]map[string]any, 0, len(windows))
@@ -55,8 +66,7 @@ func buildWatchlistHistorySummaries(
 			summaries = append(summaries, summary)
 		}
 	}
-
-	return summaries, truncated, nil
+	return summaries
 }
 
 func mergeHistoryIntoEntityContext(base string, summaries []map[string]any, truncated bool) string {

--- a/scripts/architecture.baseline
+++ b/scripts/architecture.baseline
@@ -1,5 +1,5 @@
 packages=59
-interfaces=77
+interfaces=78
 large_files=46
 set_mutators=107
 database_opens=8

--- a/talents/ha.md
+++ b/talents/ha.md
@@ -210,6 +210,30 @@ registry name, with a substring fallback, returning candidates when a
 name is ambiguous. Reach for this instead of discovering a device's
 child entities one `ha_get_state` at a time.
 
+## I want to know how something has trended
+
+`ha_history` summarizes one entity's recorder history over a lookback
+window — the native answer to "how has the office temperature moved over
+the last 24h" or "how many times did the front door open today":
+
+```json
+{
+  "entity_id": "sensor.office_temperature",
+  "lookback_seconds": 86400
+}
+```
+
+Returns a numeric trend (min/max/start/end/delta + rising/falling/flat)
+for numeric entities, or a discrete change summary (change count +
+recent states) for non-numeric ones. To trend a value that lives in an
+attribute rather than the state — a `climate` entity's
+`current_temperature`, say — pass `attribute`. Defaults to a 24h window,
+clamped to 30 days.
+
+For *sustained*, every-turn attention to an entity, don't poll this from
+a loop's turn budget — subscribe via `awareness` with history windows
+and let the trend stay current between turns for free.
+
 ## I want richer search across the registry
 
 `ha_registry_search` searches areas, labels, devices, and entities


### PR DESCRIPTION
## Summary

Adds the `ha_history` native tool — give it an entity + lookback window, get back a trend summary, without fetching raw history yourself:

- **Numeric** entities → min/max/start/end/delta + rising/falling/flat.
- **Non-numeric** entities → change count + recent states.
- Defaults to a 24h window, clamped to 30 days. Byte-lean, model-facing deltas.

It reuses the *exact* numeric/discrete summarization the always-on watchlist injection already computes — `buildWatchlistHistorySummaries` is refactored to share its post-fetch half (`summarizeHistorySeries`) rather than growing a parallel copy.

### Client change (the issue's core ask)
`GetStateHistory` keeps its lean `no_attributes` default, so **existing watchlist callers are unaffected**. A new `GetStateHistoryWithAttributes` sibling fetches the attribute map. The tool uses it **only when an `attribute` is requested**.

### A note on the issue's framing
The issue says `no_attributes=1` means "state strings only — no numeric values." That's not quite right: `no_attributes` strips only the *attribute map*, not the state value, so for a numeric sensor the state string *is* the number — the watchlist already trends those fine. The real gap the attributes path unlocks is trending a numeric value that lives in an **attribute** (e.g. a `climate` entity's `current_temperature` while its state is `"heat"`). So `ha_history` grows an optional `attribute` param for exactly that, which is what makes the new client method genuinely load-bearing rather than fetching bytes the summarizer ignores.

Closes #1008. Part of #1002 (Phase 3).

> Stacked on #1016 (`claude/1007-ha-device`). Auto-retargets to `main` as the stack lands.

## Test plan
- [x] `just ci` passes locally (architecture baseline: interfaces 77→78 for `TrendHistoryClient`).
- [x] Numeric trend (rising, min/max, unit) — `entity_trend_test.go`.
- [x] Discrete history (change count + recent states).
- [x] Empty window → explicit `no_history` marker (not a bogus 1-sample flat trend).
- [x] Non-recorder entity → `no_history`.
- [x] Attribute trend uses the attributes-enabled path and summarizes the attribute series.
- [x] Lookback clamped to 30 days before the recorder query.
- [x] Client: `GetStateHistoryWithAttributes` omits `no_attributes` and preserves attributes; `GetStateHistory` path byte-identical (existing test unchanged).