### PR TITLE
feat(ha): ha_home_snapshot — curated whole-home overview

### DIFF
--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -124,6 +124,7 @@ becoming default context clutter.
 | `get_area_activity` | Whole-area snapshot: floor context + entities grouped by salience + transition timeline + filtered counts, with optional per-entity metadata. |
 | `ha_device` | Whole-device snapshot: device identity (manufacturer/model/firmware/area/integration) + every child entity with semantic state grouped by salience + availability rollup, resolved by id or name, with optional per-entity metadata. |
 | `ha_history` | Recorder trend for one entity over a lookback window: numeric min/max/start/end/delta/trend or a discrete change summary, optionally trending a numeric attribute instead of the state. |
+| `ha_home_snapshot` | Curated whole-home overview: anomalies, security/openings, presence, climate (energy optional), salience-first with an at-a-glance summary and a quiet status, plus optional per-entity metadata. |
 | `ha_call_service` | Direct HA service invocation. |
 | `ha_registry_search` | Search the entity/device/area registry. |
 | `ha_automation_list` | List automations with recent activation counts. |

--- a/internal/app/new_awareness.go
+++ b/internal/app/new_awareness.go
@@ -117,6 +117,10 @@ func (a *App) initAwareness(s *newState) error {
 			Client: a.ha,
 			Logger: logger,
 		}))
+		a.loop.Tools().RegisterProvider(awareness.NewHomeSnapshotTools(awareness.HomeSnapshotToolsConfig{
+			Client: a.ha,
+			Logger: logger,
+		}))
 	}
 
 	// --- State change window ---

--- a/internal/model/toolcatalog/catalog.go
+++ b/internal/model/toolcatalog/catalog.go
@@ -234,6 +234,7 @@ var builtinToolSpecs = map[string]BuiltinToolSpec{
 	"get_area_activity":           {CanonicalID: "native:get_area_activity", Source: NativeToolSource, Tags: []string{"ha"}},
 	"ha_device":                   {CanonicalID: "native:ha_device", Source: NativeToolSource, Tags: []string{"ha"}},
 	"ha_history":                  {CanonicalID: "native:ha_history", Source: NativeToolSource, Tags: []string{"ha"}},
+	"ha_home_snapshot":            {CanonicalID: "native:ha_home_snapshot", Source: NativeToolSource, Tags: []string{"ha"}},
 	"lens_list":                   {CanonicalID: "native:lens_list", Source: NativeToolSource},
 	"tag_inspect":                 {CanonicalID: "native:tag_inspect", Source: NativeToolSource},
 	"tag_reset":                   {CanonicalID: "native:tag_reset", Source: NativeToolSource},

--- a/internal/state/awareness/area_activity.go
+++ b/internal/state/awareness/area_activity.go
@@ -365,26 +365,36 @@ func selectAreaMembers(
 		}
 		counts.TotalMatched++
 
-		if entry.DisabledBy != "" {
-			counts.Disabled++
-			continue
-		}
-		if entry.HiddenBy != "" && !includeHidden {
-			counts.Hidden++
-			continue
-		}
-		if !includeDiagnostic && entry.EntityCategory == "diagnostic" {
-			counts.Diagnostic++
-			continue
-		}
-		if !includeDiagnostic && entry.EntityCategory == "config" {
-			counts.Config++
+		if !keepAfterSalienceFilter(entry, includeDiagnostic, includeHidden, &counts) {
 			continue
 		}
 
 		members = append(members, areaMember{entry: entry, device: device})
 	}
 	return members, counts
+}
+
+// keepAfterSalienceFilter reports whether an entity entry survives the
+// default salience filter applied by the area and home snapshots, and
+// bumps the relevant filtered-count bucket when it doesn't. Disabled
+// entities are always dropped (HA isn't loading them); hidden,
+// diagnostic, and config entities are dropped unless the caller opts
+// into a forensic pass. Shared so the two snapshots apply identical
+// visibility rules rather than each carrying its own copy.
+func keepAfterSalienceFilter(entry homeassistant.EntityRegistryEntry, includeDiagnostic, includeHidden bool, counts *areaFilterCounts) bool {
+	switch {
+	case entry.DisabledBy != "":
+		counts.Disabled++
+	case entry.HiddenBy != "" && !includeHidden:
+		counts.Hidden++
+	case !includeDiagnostic && entry.EntityCategory == "diagnostic":
+		counts.Diagnostic++
+	case !includeDiagnostic && entry.EntityCategory == "config":
+		counts.Config++
+	default:
+		return true
+	}
+	return false
 }
 
 func indexDevices(devices []homeassistant.DeviceRegistryEntry) map[string]*homeassistant.DeviceRegistryEntry {

--- a/internal/state/awareness/area_activity_test.go
+++ b/internal/state/awareness/area_activity_test.go
@@ -29,7 +29,8 @@ type fakeAreaClient struct {
 	logbookErr error
 	floorsErr  error
 
-	floorCalls int // how many times GetFloorRegistry was invoked
+	floorCalls  int // how many times GetFloorRegistry was invoked
+	deviceCalls int // how many times GetDeviceRegistry was invoked
 }
 
 func (f *fakeAreaClient) GetAreas(_ context.Context) ([]homeassistant.Area, error) {
@@ -39,6 +40,7 @@ func (f *fakeAreaClient) GetEntityRegistry(_ context.Context) ([]homeassistant.E
 	return f.entities, nil
 }
 func (f *fakeAreaClient) GetDeviceRegistry(_ context.Context) ([]homeassistant.DeviceRegistryEntry, error) {
+	f.deviceCalls++
 	return f.devices, nil
 }
 func (f *fakeAreaClient) GetFloorRegistry(_ context.Context) ([]homeassistant.FloorRegistryEntry, error) {

--- a/internal/state/awareness/home_snapshot.go
+++ b/internal/state/awareness/home_snapshot.go
@@ -1,0 +1,319 @@
+package awareness
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/nugget/thane-ai-agent/internal/integrations/homeassistant"
+	"github.com/nugget/thane-ai-agent/internal/model/promptfmt"
+)
+
+// homeSnapshotDefaultMaxPerSection caps each section so a large install
+// can't flood the prompt. Overflow is reported per section via
+// <section>_truncated_count, mirroring the area snapshot's bucket caps.
+const homeSnapshotDefaultMaxPerSection = 12
+
+// homeOpeningClasses are the binary_sensor device_classes whose "on"
+// state means something is physically open — the security/openings view.
+var homeOpeningClasses = map[string]bool{
+	"door":        true,
+	"window":      true,
+	"garage_door": true,
+	"opening":     true,
+}
+
+// homeEnergyClasses are the sensor device_classes surfaced in the
+// optional energy section.
+var homeEnergyClasses = map[string]bool{
+	"power":  true,
+	"energy": true,
+}
+
+// HomeSnapshotRequest describes one ha_home_snapshot invocation.
+type HomeSnapshotRequest struct {
+	IncludeDiagnostic bool                                 // include diagnostic/config entities in the scan
+	IncludeHidden     bool                                 // include hidden-but-enabled entities
+	IncludeEnergy     bool                                 // add the optional energy section
+	MaxPerSection     int                                  // per-section cap; <= 0 uses the default
+	Include           homeassistant.EntityMetadataIncludes // optional per-entity metadata projection
+}
+
+// ComputeHomeSnapshot renders a single curated "how's the house right
+// now" view across domains: anomalies first (offline / alarm), then
+// security/openings (open doors-windows, unlocked locks, armed/triggered
+// alarm panels), then presence (who's home), climate (thermostats), and
+// an optional energy section. It is the whole-home cousin of
+// [ComputeAreaActivity]: one bulk GetStates, the same registry resolver
+// and salience predicates, the same per-entity render and metadata
+// attach, the same bounded output with explicit *_truncated_count
+// fields. Unlike the area view it is deliberately curated — entities
+// that don't fall into a section are skipped, not bucketed into a
+// remainder — so the snapshot stays a glanceable overview.
+func ComputeHomeSnapshot(ctx context.Context, client HARegistryClient, req HomeSnapshotRequest, now time.Time) (string, error) {
+	if client == nil {
+		return "", fmt.Errorf("ha_home_snapshot: client is required")
+	}
+
+	maxPerSection := req.MaxPerSection
+	if maxPerSection <= 0 {
+		maxPerSection = homeSnapshotDefaultMaxPerSection
+	}
+
+	allStates, err := client.GetStates(ctx)
+	if err != nil {
+		return "", fmt.Errorf("ha_home_snapshot: get states: %w", err)
+	}
+	entities, err := client.GetEntityRegistry(ctx)
+	if err != nil {
+		return "", fmt.Errorf("ha_home_snapshot: get entity registry: %w", err)
+	}
+	devices, err := client.GetDeviceRegistry(ctx)
+	if err != nil {
+		return "", fmt.Errorf("ha_home_snapshot: get device registry: %w", err)
+	}
+
+	resolver, err := buildHomeResolver(ctx, client, devices, req.Include)
+	if err != nil {
+		return "", err
+	}
+
+	deviceByID := indexDevices(devices)
+	statesByID := indexStates(allStates)
+
+	members, filters := selectHomeMembers(entities, deviceByID, req.IncludeDiagnostic, req.IncludeHidden)
+
+	sections := classifyHomeMembers(members, statesByID, req.IncludeEnergy, now)
+
+	payload := map[string]any{
+		"summary": map[string]any{
+			"anomalies": len(sections.anomalies),
+			"security":  len(sections.security),
+			"home":      sections.home,
+			"away":      sections.away,
+		},
+		"entity_count": len(members),
+	}
+	if !sections.hasConcern() {
+		// Nothing offline, open, unlocked, or armed: tell the model the
+		// house is quiet up front so it doesn't scan empty sections to
+		// infer it. Presence/climate still render below for context.
+		payload["status"] = "quiet"
+	}
+	addAreaFilterCounts(payload, filters)
+
+	if req.Include.Any() {
+		attachAreaEntityMetadata(resolver, req.Include, members, statesByID,
+			sections.anomalies, sections.security, sections.presence, sections.climate, sections.energy)
+	}
+
+	// Salience order: lead with what's actionable or anomalous.
+	addHomeSection(payload, "anomalies", sections.anomalies, maxPerSection)
+	addHomeSection(payload, "security", sections.security, maxPerSection)
+	addHomeSection(payload, "presence", sections.presence, maxPerSection)
+	addHomeSection(payload, "climate", sections.climate, maxPerSection)
+	if req.IncludeEnergy {
+		addHomeSection(payload, "energy", sections.energy, maxPerSection)
+	}
+
+	return promptfmt.MarshalCompact(payload), nil
+}
+
+// addHomeSection writes a section into the payload, capping it at
+// maxPerSection and recording the overflow as <key>_truncated_count.
+// Empty sections are omitted so the snapshot stays lean.
+func addHomeSection(payload map[string]any, key string, items []map[string]any, maxPerSection int) {
+	if len(items) == 0 {
+		return
+	}
+	truncated := 0
+	if len(items) > maxPerSection {
+		truncated = len(items) - maxPerSection
+		items = items[:maxPerSection]
+	}
+	payload[key] = items
+	if truncated > 0 {
+		payload[key+"_truncated_count"] = truncated
+	}
+}
+
+// homeSections holds the curated cross-domain buckets plus the presence
+// rollup counts.
+type homeSections struct {
+	anomalies []map[string]any
+	security  []map[string]any
+	presence  []map[string]any
+	climate   []map[string]any
+	energy    []map[string]any
+	home      int // persons currently home
+	away      int // persons not home (not_home or in another zone)
+}
+
+// hasConcern reports whether anything actionable is present — an
+// anomaly or an open/unlocked/armed security item. Presence and climate
+// alone are normal ambient state, not a concern.
+func (s homeSections) hasConcern() bool {
+	return len(s.anomalies) > 0 || len(s.security) > 0
+}
+
+// classifyHomeMembers routes each member into at most one curated
+// section, reusing the area snapshot's per-entity render and the shared
+// salience predicates. Entities that fit no section are skipped.
+func classifyHomeMembers(members []areaMember, statesByID map[string]*homeassistant.State, includeEnergy bool, now time.Time) homeSections {
+	var s homeSections
+	for _, m := range members {
+		state := statesByID[m.entry.EntityID]
+		if state == nil {
+			continue // no live state: not part of a "right now" view
+		}
+		domain := entityDomain(m.entry.EntityID)
+
+		// Anomalies lead: unavailable/unknown, then genuine alarms
+		// (smoke/CO/gas, lock jammed, vacuum error).
+		if isSentinelState(state.State) {
+			// Presence and energy sentinels are noise here; only surface
+			// unavailability for entities a home view actually cares about.
+			if homeAnomalyDomain(domain) {
+				s.anomalies = append(s.anomalies, renderEntityForArea(state, now))
+			}
+			continue
+		}
+		if isAlarmAnomaly(state, m.entry) {
+			s.anomalies = append(s.anomalies, renderEntityForArea(state, now))
+			continue
+		}
+
+		switch domain {
+		case "person":
+			s.presence = append(s.presence, renderEntityForArea(state, now))
+			if presenceIsHome(state.State) {
+				s.home++
+			} else {
+				s.away++
+			}
+		case "lock":
+			if state.State == "unlocked" {
+				s.security = append(s.security, renderEntityForArea(state, now))
+			}
+		case "alarm_control_panel":
+			if state.State != "disarmed" {
+				s.security = append(s.security, renderEntityForArea(state, now))
+			}
+		case "cover":
+			if state.State == "open" || state.State == "opening" {
+				s.security = append(s.security, renderEntityForArea(state, now))
+			}
+		case "binary_sensor":
+			if state.State == "on" && homeOpeningClasses[registryDeviceClass(m.entry, state)] {
+				s.security = append(s.security, renderEntityForArea(state, now))
+			}
+		case "climate":
+			s.climate = append(s.climate, renderEntityForArea(state, now))
+		case "sensor":
+			if includeEnergy && homeEnergyClasses[registryDeviceClass(m.entry, state)] {
+				s.energy = append(s.energy, renderEntityForArea(state, now))
+			}
+		}
+	}
+
+	sortHomeSection(s.anomalies)
+	sortHomeSection(s.security)
+	sortHomeSection(s.presence)
+	sortHomeSection(s.climate)
+	sortHomeSection(s.energy)
+	return s
+}
+
+// homeAnomalyDomain reports whether an unavailable entity in this domain
+// is worth surfacing in the home view. Presence/energy/diagnostic noise
+// going unavailable isn't actionable at a glance; locks, covers, climate,
+// alarms, and contact/safety sensors are.
+func homeAnomalyDomain(domain string) bool {
+	switch domain {
+	case "lock", "cover", "climate", "alarm_control_panel", "binary_sensor":
+		return true
+	default:
+		return false
+	}
+}
+
+// presenceIsHome reports whether a person entity's state means they are
+// home. Any other value (not_home, or a named zone like "Work") counts
+// as away.
+func presenceIsHome(state string) bool {
+	return strings.EqualFold(state, "home")
+}
+
+// sortHomeSection orders a section's entities by entity_id for stable,
+// deterministic output.
+func sortHomeSection(items []map[string]any) {
+	sort.SliceStable(items, func(i, j int) bool {
+		ai, _ := items[i]["entity"].(string)
+		aj, _ := items[j]["entity"].(string)
+		return ai < aj
+	})
+}
+
+// selectHomeMembers returns every enabled, salient entity across the
+// whole install, plus the filtered-out counts. It is selectAreaMembers
+// without the area constraint, sharing the same salience filter.
+func selectHomeMembers(
+	entities []homeassistant.EntityRegistryEntry,
+	deviceByID map[string]*homeassistant.DeviceRegistryEntry,
+	includeDiagnostic bool,
+	includeHidden bool,
+) ([]areaMember, areaFilterCounts) {
+	members := make([]areaMember, 0, len(entities))
+	counts := areaFilterCounts{}
+	for i := range entities {
+		entry := entities[i]
+		counts.TotalMatched++
+		if !keepAfterSalienceFilter(entry, includeDiagnostic, includeHidden, &counts) {
+			continue
+		}
+		var device *homeassistant.DeviceRegistryEntry
+		if entry.DeviceID != "" {
+			device = deviceByID[entry.DeviceID]
+		}
+		members = append(members, areaMember{entry: entry, device: device})
+	}
+	return members, counts
+}
+
+// buildHomeResolver assembles the metadata resolver for the home
+// snapshot. Areas + devices are always included so per-entity area
+// context resolves; labels and floors are pulled only when the include
+// projection asks for them. Mirrors the gated build in
+// ComputeAreaActivity.
+func buildHomeResolver(
+	ctx context.Context,
+	client HARegistryClient,
+	devices []homeassistant.DeviceRegistryEntry,
+	include homeassistant.EntityMetadataIncludes,
+) (homeassistant.EntityMetadataResolver, error) {
+	areas, err := client.GetAreas(ctx)
+	if err != nil {
+		return homeassistant.EntityMetadataResolver{}, fmt.Errorf("ha_home_snapshot: get areas: %w", err)
+	}
+	var labels []homeassistant.LabelRegistryEntry
+	if include.Labels {
+		labels, err = client.GetLabelRegistry(ctx)
+		if err != nil {
+			return homeassistant.EntityMetadataResolver{}, fmt.Errorf("ha_home_snapshot: get labels: %w", err)
+		}
+	}
+	var floors []homeassistant.FloorRegistryEntry
+	if include.Area {
+		floors, err = client.GetFloorRegistry(ctx)
+		if err != nil {
+			return homeassistant.EntityMetadataResolver{}, fmt.Errorf("ha_home_snapshot: get floors: %w", err)
+		}
+	}
+	floorAlias := ""
+	if p, ok := client.(interface{ FloorMetadataAlias() string }); ok {
+		floorAlias = p.FloorMetadataAlias()
+	}
+	return homeassistant.NewEntityMetadataResolverWithFloorAlias(areas, labels, devices, floors, floorAlias), nil
+}

--- a/internal/state/awareness/home_snapshot.go
+++ b/internal/state/awareness/home_snapshot.go
@@ -70,17 +70,28 @@ func ComputeHomeSnapshot(ctx context.Context, client HARegistryClient, req HomeS
 	if err != nil {
 		return "", fmt.Errorf("ha_home_snapshot: get entity registry: %w", err)
 	}
-	devices, err := client.GetDeviceRegistry(ctx)
-	if err != nil {
-		return "", fmt.Errorf("ha_home_snapshot: get device registry: %w", err)
+
+	// The device registry and metadata resolver are only needed for the
+	// optional per-entity include projection: classification reads the
+	// entity registry and live state, and areaMember.device goes unused
+	// in this view. Skip both on the default glanceable path so the
+	// common "how's the house" call doesn't pay for device/area/floor/
+	// label registry round-trips it won't render — meaningful on a large
+	// install. selectHomeMembers tolerates a nil deviceByID.
+	var deviceByID map[string]*homeassistant.DeviceRegistryEntry
+	var resolver homeassistant.EntityMetadataResolver
+	if req.Include.Any() {
+		devices, derr := client.GetDeviceRegistry(ctx)
+		if derr != nil {
+			return "", fmt.Errorf("ha_home_snapshot: get device registry: %w", derr)
+		}
+		deviceByID = indexDevices(devices)
+		resolver, err = buildHomeResolver(ctx, client, devices, req.Include)
+		if err != nil {
+			return "", err
+		}
 	}
 
-	resolver, err := buildHomeResolver(ctx, client, devices, req.Include)
-	if err != nil {
-		return "", err
-	}
-
-	deviceByID := indexDevices(devices)
 	statesByID := indexStates(allStates)
 
 	members, filters := selectHomeMembers(entities, deviceByID, req.IncludeDiagnostic, req.IncludeHidden)

--- a/internal/state/awareness/home_snapshot_test.go
+++ b/internal/state/awareness/home_snapshot_test.go
@@ -127,6 +127,37 @@ func TestComputeHomeSnapshot_SectionAssembly(t *testing.T) {
 	}
 }
 
+// TestComputeHomeSnapshot_NoIncludeSkipsDeviceRegistry is the #1019
+// regression: the default glanceable path must not pull the device
+// registry (or the area/floor/label registries behind the resolver),
+// since classification needs only live state + the entity registry.
+func TestComputeHomeSnapshot_NoIncludeSkipsDeviceRegistry(t *testing.T) {
+	client := houseClient()
+	if _, err := ComputeHomeSnapshot(context.Background(), client, HomeSnapshotRequest{}, testNow); err != nil {
+		t.Fatalf("ComputeHomeSnapshot: %v", err)
+	}
+	if client.deviceCalls != 0 {
+		t.Errorf("GetDeviceRegistry called %d times on the no-include path, want 0", client.deviceCalls)
+	}
+	if client.floorCalls != 0 {
+		t.Errorf("GetFloorRegistry called %d times on the no-include path, want 0", client.floorCalls)
+	}
+}
+
+// TestComputeHomeSnapshot_IncludeFetchesDeviceRegistry confirms the
+// device registry IS pulled when a per-entity include projection is
+// requested.
+func TestComputeHomeSnapshot_IncludeFetchesDeviceRegistry(t *testing.T) {
+	client := houseClient()
+	req := HomeSnapshotRequest{Include: homeassistant.EntityMetadataIncludes{Device: true}}
+	if _, err := ComputeHomeSnapshot(context.Background(), client, req, testNow); err != nil {
+		t.Fatalf("ComputeHomeSnapshot: %v", err)
+	}
+	if client.deviceCalls == 0 {
+		t.Error("expected GetDeviceRegistry to be called when include.device is set")
+	}
+}
+
 func TestComputeHomeSnapshot_EnergyGated(t *testing.T) {
 	out, err := ComputeHomeSnapshot(context.Background(), houseClient(), HomeSnapshotRequest{}, testNow)
 	if err != nil {

--- a/internal/state/awareness/home_snapshot_test.go
+++ b/internal/state/awareness/home_snapshot_test.go
@@ -1,0 +1,279 @@
+package awareness
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/nugget/thane-ai-agent/internal/integrations/homeassistant"
+)
+
+// houseClient builds a representative whole-home fixture spanning every
+// curated section plus entities that must be skipped (a plain light, a
+// presence sensor going unavailable).
+func houseClient() *fakeAreaClient {
+	st := func(id, state string, attrs map[string]any) homeassistant.State {
+		return homeassistant.State{EntityID: id, State: state, Attributes: attrs}
+	}
+	return &fakeAreaClient{
+		areas: []homeassistant.Area{{AreaID: "living_room", Name: "Living Room"}},
+		entities: []homeassistant.EntityRegistryEntry{
+			{EntityID: "person.alice"},
+			{EntityID: "person.bob"},
+			{EntityID: "binary_sensor.front_door", DeviceClass: "door"},
+			{EntityID: "binary_sensor.kitchen_window", DeviceClass: "window"},
+			{EntityID: "binary_sensor.hall_motion", DeviceClass: "motion"}, // not an opening
+			{EntityID: "binary_sensor.basement_smoke", DeviceClass: "smoke"},
+			{EntityID: "lock.back_door"},
+			{EntityID: "lock.front_door"},
+			{EntityID: "cover.garage", DeviceClass: "garage"},
+			{EntityID: "alarm_control_panel.home"},
+			{EntityID: "climate.living_room", AreaID: "living_room"},
+			{EntityID: "sensor.house_power", DeviceClass: "power"},
+			{EntityID: "light.office"}, // must be curated out
+		},
+		states: []homeassistant.State{
+			st("person.alice", "home", nil),
+			st("person.bob", "not_home", nil),
+			st("binary_sensor.front_door", "on", map[string]any{"device_class": "door"}),        // open
+			st("binary_sensor.kitchen_window", "off", map[string]any{"device_class": "window"}), // closed → skip
+			st("binary_sensor.hall_motion", "on", map[string]any{"device_class": "motion"}),     // not an opening → skip
+			st("binary_sensor.basement_smoke", "on", map[string]any{"device_class": "smoke"}),   // alarm
+			st("lock.back_door", "unlocked", nil),                                               // security
+			st("lock.front_door", "unavailable", nil),                                           // anomaly
+			st("cover.garage", "open", map[string]any{"device_class": "garage"}),                // security
+			st("alarm_control_panel.home", "armed_away", nil),                                   // security
+			st("climate.living_room", "heat", map[string]any{"current_temperature": 71, "temperature": 72}),
+			st("sensor.house_power", "350", map[string]any{"device_class": "power", "unit_of_measurement": "W"}),
+			st("light.office", "on", nil), // curated out
+		},
+	}
+}
+
+func decodeHome(t *testing.T, raw string) map[string]any {
+	t.Helper()
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(raw), &payload); err != nil {
+		t.Fatalf("unmarshal: %v\n%s", err, raw)
+	}
+	return payload
+}
+
+// sectionIDs returns the entity_ids in a named home-snapshot section.
+func sectionIDs(payload map[string]any, section string) []string {
+	list, _ := payload[section].([]any)
+	out := make([]string, 0, len(list))
+	for _, item := range list {
+		if obj, ok := item.(map[string]any); ok {
+			if id, ok := obj["entity"].(string); ok {
+				out = append(out, id)
+			}
+		}
+	}
+	return out
+}
+
+func TestComputeHomeSnapshot_SectionAssembly(t *testing.T) {
+	out, err := ComputeHomeSnapshot(context.Background(), houseClient(), HomeSnapshotRequest{IncludeEnergy: true}, testNow)
+	if err != nil {
+		t.Fatalf("ComputeHomeSnapshot: %v", err)
+	}
+	p := decodeHome(t, out)
+
+	anomalies := sectionIDs(p, "anomalies")
+	if !contains(anomalies, "binary_sensor.basement_smoke") || !contains(anomalies, "lock.front_door") {
+		t.Errorf("anomalies = %v, want smoke (alarm) + front_door lock (unavailable)", anomalies)
+	}
+
+	security := sectionIDs(p, "security")
+	for _, want := range []string{"binary_sensor.front_door", "lock.back_door", "cover.garage", "alarm_control_panel.home"} {
+		if !contains(security, want) {
+			t.Errorf("security = %v, want %s", security, want)
+		}
+	}
+	// A closed window and a motion sensor are not security/openings items.
+	if contains(security, "binary_sensor.kitchen_window") || contains(security, "binary_sensor.hall_motion") {
+		t.Errorf("security wrongly included a closed/non-opening sensor: %v", security)
+	}
+
+	presence := sectionIDs(p, "presence")
+	if !contains(presence, "person.alice") || !contains(presence, "person.bob") {
+		t.Errorf("presence = %v, want alice + bob", presence)
+	}
+
+	if !contains(sectionIDs(p, "climate"), "climate.living_room") {
+		t.Errorf("climate = %v, want living_room", sectionIDs(p, "climate"))
+	}
+	if !contains(sectionIDs(p, "energy"), "sensor.house_power") {
+		t.Errorf("energy = %v, want house_power", sectionIDs(p, "energy"))
+	}
+
+	// Curation: a plain light belongs to no section.
+	for _, section := range []string{"anomalies", "security", "presence", "climate", "energy"} {
+		if contains(sectionIDs(p, section), "light.office") {
+			t.Errorf("light.office leaked into %s — home snapshot must be curated", section)
+		}
+	}
+
+	summary, _ := p["summary"].(map[string]any)
+	if summary["home"] != float64(1) || summary["away"] != float64(1) {
+		t.Errorf("summary home/away = %#v, want 1/1", summary)
+	}
+	if summary["anomalies"] != float64(2) {
+		t.Errorf("summary anomalies = %#v, want 2", summary["anomalies"])
+	}
+	if _, quiet := p["status"]; quiet {
+		t.Errorf("status should not be quiet when anomalies/security present:\n%s", out)
+	}
+}
+
+func TestComputeHomeSnapshot_EnergyGated(t *testing.T) {
+	out, err := ComputeHomeSnapshot(context.Background(), houseClient(), HomeSnapshotRequest{}, testNow)
+	if err != nil {
+		t.Fatalf("ComputeHomeSnapshot: %v", err)
+	}
+	p := decodeHome(t, out)
+	if _, ok := p["energy"]; ok {
+		t.Errorf("energy section present without include_energy:\n%s", out)
+	}
+}
+
+func TestComputeHomeSnapshot_AllQuiet(t *testing.T) {
+	st := func(id, state string, attrs map[string]any) homeassistant.State {
+		return homeassistant.State{EntityID: id, State: state, Attributes: attrs}
+	}
+	client := &fakeAreaClient{
+		areas: []homeassistant.Area{{AreaID: "living_room", Name: "Living Room"}},
+		entities: []homeassistant.EntityRegistryEntry{
+			{EntityID: "person.alice"},
+			{EntityID: "lock.front_door"},
+			{EntityID: "binary_sensor.front_door", DeviceClass: "door"},
+			{EntityID: "alarm_control_panel.home"},
+			{EntityID: "climate.living_room", AreaID: "living_room"},
+		},
+		states: []homeassistant.State{
+			st("person.alice", "home", nil),
+			st("lock.front_door", "locked", nil),
+			st("binary_sensor.front_door", "off", map[string]any{"device_class": "door"}),
+			st("alarm_control_panel.home", "disarmed", nil),
+			st("climate.living_room", "heat", map[string]any{"current_temperature": 71}),
+		},
+	}
+	out, err := ComputeHomeSnapshot(context.Background(), client, HomeSnapshotRequest{}, testNow)
+	if err != nil {
+		t.Fatalf("ComputeHomeSnapshot: %v", err)
+	}
+	p := decodeHome(t, out)
+	if p["status"] != "quiet" {
+		t.Errorf("status = %#v, want quiet (nothing offline/open/unlocked/armed)\n%s", p["status"], out)
+	}
+	if _, ok := p["anomalies"]; ok {
+		t.Errorf("expected no anomalies section when quiet")
+	}
+	if _, ok := p["security"]; ok {
+		t.Errorf("expected no security section when quiet")
+	}
+	// Presence and climate are ambient context and still render.
+	if !contains(sectionIDs(p, "presence"), "person.alice") {
+		t.Errorf("presence should still render when quiet:\n%s", out)
+	}
+	if !contains(sectionIDs(p, "climate"), "climate.living_room") {
+		t.Errorf("climate should still render when quiet:\n%s", out)
+	}
+}
+
+func TestComputeHomeSnapshot_FiltersDiagnosticAndDisabled(t *testing.T) {
+	st := func(id, state string, attrs map[string]any) homeassistant.State {
+		return homeassistant.State{EntityID: id, State: state, Attributes: attrs}
+	}
+	client := &fakeAreaClient{
+		entities: []homeassistant.EntityRegistryEntry{
+			{EntityID: "lock.front_door"},
+			{EntityID: "lock.shed", DisabledBy: "user"},                                              // filtered
+			{EntityID: "binary_sensor.diag_door", DeviceClass: "door", EntityCategory: "diagnostic"}, // filtered
+		},
+		states: []homeassistant.State{
+			st("lock.front_door", "unlocked", nil),
+			st("lock.shed", "unlocked", nil),
+			st("binary_sensor.diag_door", "on", map[string]any{"device_class": "door"}),
+		},
+	}
+	out, err := ComputeHomeSnapshot(context.Background(), client, HomeSnapshotRequest{}, testNow)
+	if err != nil {
+		t.Fatalf("ComputeHomeSnapshot: %v", err)
+	}
+	p := decodeHome(t, out)
+	security := sectionIDs(p, "security")
+	if !contains(security, "lock.front_door") {
+		t.Errorf("security = %v, want lock.front_door", security)
+	}
+	if contains(security, "lock.shed") {
+		t.Errorf("disabled lock.shed must be filtered out: %v", security)
+	}
+	if contains(security, "binary_sensor.diag_door") {
+		t.Errorf("diagnostic door must be filtered out by default: %v", security)
+	}
+	if p["disabled_count"] != float64(1) {
+		t.Errorf("disabled_count = %#v, want 1", p["disabled_count"])
+	}
+	if p["diagnostic_count"] != float64(1) {
+		t.Errorf("diagnostic_count = %#v, want 1", p["diagnostic_count"])
+	}
+}
+
+func TestComputeHomeSnapshot_SectionTruncation(t *testing.T) {
+	st := func(id, state string, attrs map[string]any) homeassistant.State {
+		return homeassistant.State{EntityID: id, State: state, Attributes: attrs}
+	}
+	var entities []homeassistant.EntityRegistryEntry
+	var states []homeassistant.State
+	for _, id := range []string{
+		"binary_sensor.door_a", "binary_sensor.door_b", "binary_sensor.door_c",
+	} {
+		entities = append(entities, homeassistant.EntityRegistryEntry{EntityID: id, DeviceClass: "door"})
+		states = append(states, st(id, "on", map[string]any{"device_class": "door"}))
+	}
+	client := &fakeAreaClient{entities: entities, states: states}
+
+	out, err := ComputeHomeSnapshot(context.Background(), client, HomeSnapshotRequest{MaxPerSection: 2}, testNow)
+	if err != nil {
+		t.Fatalf("ComputeHomeSnapshot: %v", err)
+	}
+	p := decodeHome(t, out)
+	if got := len(sectionIDs(p, "security")); got != 2 {
+		t.Errorf("security rendered %d, want 2 (capped)", got)
+	}
+	if p["security_truncated_count"] != float64(1) {
+		t.Errorf("security_truncated_count = %#v, want 1", p["security_truncated_count"])
+	}
+}
+
+func TestComputeHomeSnapshot_IncludeMetadata(t *testing.T) {
+	client := &fakeAreaClient{
+		areas: []homeassistant.Area{{AreaID: "entry", Name: "Entryway"}},
+		entities: []homeassistant.EntityRegistryEntry{
+			{EntityID: "lock.front_door", AreaID: "entry", Description: "Front deadbolt"},
+		},
+		states: []homeassistant.State{
+			{EntityID: "lock.front_door", State: "unlocked"},
+		},
+	}
+	req := HomeSnapshotRequest{Include: homeassistant.EntityMetadataIncludes{Description: true}}
+	out, err := ComputeHomeSnapshot(context.Background(), client, req, testNow)
+	if err != nil {
+		t.Fatalf("ComputeHomeSnapshot: %v", err)
+	}
+	p := decodeHome(t, out)
+	sec, _ := p["security"].([]any)
+	if len(sec) == 0 {
+		t.Fatalf("expected a security item to enrich:\n%s", out)
+	}
+	obj, _ := sec[0].(map[string]any)
+	meta, ok := obj["metadata"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected metadata on security item, got %#v", obj["metadata"])
+	}
+	if meta["description"] != "Front deadbolt" {
+		t.Errorf("metadata.description = %#v, want Front deadbolt", meta["description"])
+	}
+}

--- a/internal/state/awareness/home_snapshot_tool.go
+++ b/internal/state/awareness/home_snapshot_tool.go
@@ -1,0 +1,107 @@
+package awareness
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/nugget/thane-ai-agent/internal/tools"
+)
+
+// HomeSnapshotTools exposes the ha_home_snapshot tool, a single curated
+// cross-domain "how's the house right now" view. Implements
+// [tools.Provider].
+type HomeSnapshotTools struct {
+	client HARegistryClient
+	logger *slog.Logger
+}
+
+// HomeSnapshotToolsConfig captures the dependencies for
+// [NewHomeSnapshotTools]. Client is required.
+type HomeSnapshotToolsConfig struct {
+	Client HARegistryClient
+	Logger *slog.Logger
+}
+
+func NewHomeSnapshotTools(cfg HomeSnapshotToolsConfig) *HomeSnapshotTools {
+	if cfg.Client == nil {
+		panic("awareness: HomeSnapshotTools requires a non-nil Client")
+	}
+	logger := cfg.Logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &HomeSnapshotTools{client: cfg.Client, logger: logger}
+}
+
+// Name implements [tools.Provider].
+func (a *HomeSnapshotTools) Name() string { return "awareness.ha_home_snapshot" }
+
+// Tools implements [tools.Provider].
+func (a *HomeSnapshotTools) Tools() []*tools.Tool {
+	return []*tools.Tool{
+		{
+			Name: "ha_home_snapshot",
+			Description: "Get a single curated 'how's the house right now' overview across domains — the native answer to " +
+				"'what's going on at home', 'is the house buttoned up', 'who's home'. Leads with what's actionable: anomalies " +
+				"(offline or in alarm state), then security/openings (open doors/windows, unlocked locks, armed/triggered alarm " +
+				"panels), then presence (who's home vs away), then climate (thermostats). A top-level summary gives the counts at " +
+				"a glance, and status:quiet means nothing is offline, open, unlocked, or armed. Pass include_energy for an energy " +
+				"section, and include for per-entity area/device/label/description/visibility metadata. For a single room use " +
+				"get_area_activity; for one device use ha_device.",
+			Parameters: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"include_energy": map[string]any{
+						"type":        "boolean",
+						"description": "When true, adds an energy section listing power/energy sensors. Default false keeps the snapshot focused on presence/security/climate.",
+					},
+					"include_diagnostic": map[string]any{
+						"type":        "boolean",
+						"description": "When true, includes entities marked diagnostic or config in the scan. Default false.",
+					},
+					"include_hidden": map[string]any{
+						"type":        "boolean",
+						"description": "When true, includes hidden-but-enabled entities. Default false keeps the snapshot aligned with default HA visibility.",
+					},
+					"max_per_section": map[string]any{
+						"type":        "integer",
+						"description": "Cap on each section. Default 12. Overflow is reported via <section>_truncated_count.",
+					},
+					"include": tools.EntityMetadataIncludeParameter(),
+				},
+			},
+			Handler: a.handleHomeSnapshot,
+		},
+	}
+}
+
+func (a *HomeSnapshotTools) handleHomeSnapshot(ctx context.Context, args map[string]any) (string, error) {
+	var req HomeSnapshotRequest
+	if v, ok := args["include_energy"].(bool); ok {
+		req.IncludeEnergy = v
+	}
+	if v, ok := args["include_diagnostic"].(bool); ok {
+		req.IncludeDiagnostic = v
+	}
+	if v, ok := args["include_hidden"].(bool); ok {
+		req.IncludeHidden = v
+	}
+	if v, err := optionalIntArg(args, "max_per_section"); err != nil {
+		return "", err
+	} else if v != nil {
+		req.MaxPerSection = *v
+	}
+	include, err := tools.ParseEntityMetadataIncludesArg(args["include"], "include")
+	if err != nil {
+		return "", err
+	}
+	req.Include = include
+
+	result, err := ComputeHomeSnapshot(ctx, a.client, req, time.Now())
+	if err != nil {
+		a.logger.Warn("ha_home_snapshot failed", "error", err)
+		return "", err
+	}
+	return result, nil
+}

--- a/talents/ha.md
+++ b/talents/ha.md
@@ -234,6 +234,27 @@ For *sustained*, every-turn attention to an entity, don't poll this from
 a loop's turn budget — subscribe via `awareness` with history windows
 and let the trend stay current between turns for free.
 
+## I want the whole house at a glance
+
+`ha_home_snapshot` is the curated "how's the house right now" overview —
+the native answer to "what's going on at home", "is the house buttoned
+up", or "who's home":
+
+```json
+{
+  "include_energy": true
+}
+```
+
+Leads with what's actionable: anomalies (offline / in alarm), then
+security/openings (open doors and windows, unlocked locks, armed or
+triggered alarm panels), then presence (who's home vs away), then
+climate. A top-level `summary` gives the counts at a glance, and
+`status: "quiet"` means nothing is offline, open, unlocked, or armed.
+Pass `include_energy` for a power/energy section and `include` for
+per-entity metadata. This is the home-wide view; for one room reach for
+`get_area_activity`, for one device `ha_device`.
+
 ## I want richer search across the registry
 
 `ha_registry_search` searches areas, labels, devices, and entities


### PR DESCRIPTION
## Summary

Adds `ha_home_snapshot` — a single curated "how's the house right now" view across domains, the capstone of the #1002 native-HA fan. Leads with what's actionable:

- **anomalies** — offline / in alarm (smoke, CO, gas, jammed lock, …)
- **security** — open doors/windows/garage, unlocked locks, armed/triggered alarm panels
- **presence** — who's home vs away (`person` entities)
- **climate** — thermostats
- **energy** — optional (`include_energy`), power/energy sensors

A top-level `summary` carries the counts at a glance, and `status: "quiet"` means nothing is offline, open, unlocked, or armed. Each section is capped (`<section>_truncated_count`). Optional `include` adds per-entity metadata.

### Built as the area snapshot's cousin (per request)
`ComputeHomeSnapshot` deliberately tracks `ComputeAreaActivity` — the implementation #1015 enhanced — rather than inventing its own shape: one bulk `GetStates`, the same registry resolver, the same salience predicates (`isSentinelState`/`isAlarmAnomaly`), the same `renderEntityForArea` + `attachAreaEntityMetadata`, the same bounded output with `*_truncated_count`. The shared salience filter (disabled/hidden/diagnostic/config) is **extracted** from `selectAreaMembers` into `keepAfterSalienceFilter` so both snapshots apply identical visibility rules — no duplicated joins. Unlike the area view it's **curated**: entities that fit no section are skipped, not bucketed into a remainder, so it stays glanceable.

Closes #1006. Completes #1002 (Phase 3).

> Stacked on #1018 (`claude/1008-ha-history`). Auto-retargets to `main` as the stack lands.

## Test plan
- [x] `just ci` passes locally (no architecture bump — reuses `HARegistryClient`, no new interface).
- [x] Section assembly: each domain routes to the right section; a plain light is curated out.
- [x] All-quiet path: `status: "quiet"`, no anomalies/security sections, presence/climate still render.
- [x] Energy section gated behind `include_energy`.
- [x] Diagnostic/disabled entities filtered + counted (shared filter).
- [x] Section cap → `<section>_truncated_count`.
- [x] `include` metadata attaches to section entities.
- [x] `selectAreaMembers` refactor leaves all existing area-snapshot tests green.