### PR TITLE
feat(ha): "did you mean?" suggestions when an entity_id is not found

### DIFF
--- a/internal/state/awareness/area_activity.go
+++ b/internal/state/awareness/area_activity.go
@@ -97,7 +97,22 @@ func ComputeAreaActivity(ctx context.Context, client AreaActivityClient, req Are
 	}
 	area, ok := resolveArea(areas, req.Area)
 	if !ok {
-		return "", fmt.Errorf("area_activity: no area matched %q", req.Area)
+		// A bad or stale area name is recoverable: return a structured
+		// "did you mean?" with candidate areas instead of a flat error,
+		// mirroring ha_device's not-found shape.
+		payload := map[string]any{
+			"found":          false,
+			"reason":         "not_found",
+			"requested_area": req.Area,
+			"note":           "area not found. Pick a candidate, or use ha_registry_search to look up the area name/id; do not retry with a guessed area.",
+		}
+		if cands := suggestAreaCandidates(areas, req.Area); len(cands) > 0 {
+			payload["candidates"] = cands
+		} else {
+			payload["available_areas"] = listAreas(areas, maxAreaSuggestions)
+			payload["note"] = "area not found and nothing similar matched. Choose from available_areas, or use ha_registry_search to discover the right area."
+		}
+		return promptfmt.MarshalCompact(payload), nil
 	}
 
 	entities, err := client.GetEntityRegistry(ctx)
@@ -253,6 +268,71 @@ func resolveArea(areas []homeassistant.Area, query string) (homeassistant.Area, 
 		}
 	}
 	return homeassistant.Area{}, false
+}
+
+// maxAreaSuggestions caps the candidate / available-area lists returned
+// when get_area_activity can't resolve the requested area.
+const maxAreaSuggestions = 8
+
+// suggestAreaCandidates returns the areas whose name, id, or alias
+// overlaps the query (by substring or shared word), as {area_id, name}
+// pairs for chaining. It is the area-shaped sibling of the entity
+// "did you mean?" suggestion: a deliberately simple match, not a scorer,
+// so a near-miss surfaces real area ids without guessing.
+func suggestAreaCandidates(areas []homeassistant.Area, query string) []map[string]any {
+	q := strings.ToLower(strings.TrimSpace(query))
+	if q == "" {
+		return nil
+	}
+	out := make([]map[string]any, 0, maxAreaSuggestions)
+	for _, a := range areas {
+		if len(out) >= maxAreaSuggestions {
+			break
+		}
+		if areaMatchesQuery(a, q) {
+			out = append(out, map[string]any{"area_id": a.AreaID, "name": a.Name})
+		}
+	}
+	return out
+}
+
+// areaMatchesQuery reports whether the area's name, id, or any alias
+// shares a substring or a whole word with the lowercased query.
+func areaMatchesQuery(a homeassistant.Area, q string) bool {
+	hay := []string{strings.ToLower(a.Name), strings.ToLower(a.AreaID)}
+	for _, alias := range a.Aliases {
+		hay = append(hay, strings.ToLower(alias))
+	}
+	qWords := strings.Fields(strings.ReplaceAll(q, "_", " "))
+	for _, h := range hay {
+		if h == "" {
+			continue
+		}
+		if strings.Contains(h, q) || strings.Contains(q, h) {
+			return true
+		}
+		for _, hw := range strings.Fields(strings.ReplaceAll(h, "_", " ")) {
+			for _, qw := range qWords {
+				if hw == qw {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+// listAreas returns up to limit areas as {area_id, name} pairs, used to
+// enumerate valid choices when no candidate resembled the query.
+func listAreas(areas []homeassistant.Area, limit int) []map[string]any {
+	out := make([]map[string]any, 0, min(limit, len(areas)))
+	for i, a := range areas {
+		if i >= limit {
+			break
+		}
+		out = append(out, map[string]any{"area_id": a.AreaID, "name": a.Name})
+	}
+	return out
 }
 
 // areaMember pairs an entity registry entry with the resolved

--- a/internal/state/awareness/area_activity_test.go
+++ b/internal/state/awareness/area_activity_test.go
@@ -60,6 +60,58 @@ func (f *fakeAreaClient) GetLogbookEvents(_ context.Context, _, _ time.Time, _ [
 	return f.logbook, f.logbookErr
 }
 
+func TestComputeAreaActivity_UnknownAreaSuggestsCandidates(t *testing.T) {
+	client := &fakeAreaClient{areas: []homeassistant.Area{
+		{AreaID: "kitchen", Name: "Kitchen"},
+		{AreaID: "living_room", Name: "Living Room"},
+	}}
+
+	out, err := ComputeAreaActivity(context.Background(), client, AreaActivityRequest{Area: "kitch"}, testNow)
+	if err != nil {
+		t.Fatalf("ComputeAreaActivity: %v", err)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(out), &payload); err != nil {
+		t.Fatalf("unmarshal: %v\n%s", err, out)
+	}
+	if payload["found"] != false {
+		t.Errorf("found = %v, want false", payload["found"])
+	}
+	if payload["reason"] != "not_found" {
+		t.Errorf("reason = %v, want not_found", payload["reason"])
+	}
+	cands, ok := payload["candidates"].([]any)
+	if !ok || len(cands) == 0 {
+		t.Fatalf("expected candidate areas for a near-miss, got %v", payload["candidates"])
+	}
+}
+
+func TestComputeAreaActivity_UnknownAreaListsAvailable(t *testing.T) {
+	client := &fakeAreaClient{areas: []homeassistant.Area{
+		{AreaID: "kitchen", Name: "Kitchen"},
+		{AreaID: "living_room", Name: "Living Room"},
+	}}
+
+	out, err := ComputeAreaActivity(context.Background(), client, AreaActivityRequest{Area: "zzzqqq nowhere"}, testNow)
+	if err != nil {
+		t.Fatalf("ComputeAreaActivity: %v", err)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(out), &payload); err != nil {
+		t.Fatalf("unmarshal: %v\n%s", err, out)
+	}
+	if payload["found"] != false || payload["reason"] != "not_found" {
+		t.Errorf("expected not_found envelope, got %v", payload)
+	}
+	if _, ok := payload["candidates"]; ok {
+		t.Errorf("did not expect candidates for an unrelated query, got %v", payload["candidates"])
+	}
+	avail, ok := payload["available_areas"].([]any)
+	if !ok || len(avail) == 0 {
+		t.Fatalf("expected available_areas fallback, got %v", payload["available_areas"])
+	}
+}
+
 func TestComputeAreaActivity_BucketsByRelevance(t *testing.T) {
 	now := testNow
 
@@ -335,11 +387,24 @@ func TestComputeAreaActivity_EntityInheritsAreaFromDevice(t *testing.T) {
 	}
 }
 
-func TestComputeAreaActivity_UnknownAreaErrors(t *testing.T) {
+func TestComputeAreaActivity_UnknownAreaReturnsStructuredNotFound(t *testing.T) {
+	// An unresolvable area is a recoverable not-found, not a hard error:
+	// the tool returns a structured envelope so the model can pick a real
+	// area instead of getting a bare failure string.
 	client := &fakeAreaClient{areas: []homeassistant.Area{{AreaID: "kitchen", Name: "Kitchen"}}}
-	_, err := ComputeAreaActivity(context.Background(), client, AreaActivityRequest{Area: "Bathroom"}, testNow)
-	if err == nil {
-		t.Fatal("expected error for unknown area")
+	out, err := ComputeAreaActivity(context.Background(), client, AreaActivityRequest{Area: "Bathroom"}, testNow)
+	if err != nil {
+		t.Fatalf("ComputeAreaActivity: %v", err)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(out), &payload); err != nil {
+		t.Fatalf("unmarshal: %v\n%s", err, out)
+	}
+	if payload["found"] != false || payload["reason"] != "not_found" {
+		t.Errorf("expected structured not_found, got %v", payload)
+	}
+	if payload["requested_area"] != "Bathroom" {
+		t.Errorf("requested_area = %v, want Bathroom", payload["requested_area"])
 	}
 }
 

--- a/internal/state/awareness/entity_trend.go
+++ b/internal/state/awareness/entity_trend.go
@@ -19,12 +19,14 @@ const (
 // tool needs: the current state (for classification, precision, and
 // unit) plus recorder-backed history. The attributes-enabled history
 // path is used only when a specific attribute is being trended, so a
-// plain state trend stays on the lean no_attributes fetch. The concrete
-// homeassistant.Client implements all three.
+// plain state trend stays on the lean no_attributes fetch. GetEntities
+// powers the "did you mean?" suggestion when the requested entity_id
+// isn't found. The concrete homeassistant.Client implements all four.
 type TrendHistoryClient interface {
 	GetState(ctx context.Context, entityID string) (*homeassistant.State, error)
 	GetStateHistory(ctx context.Context, entityID string, startTime, endTime time.Time) ([]homeassistant.State, error)
 	GetStateHistoryWithAttributes(ctx context.Context, entityID string, startTime, endTime time.Time) ([]homeassistant.State, error)
+	GetEntities(ctx context.Context, domain string) ([]homeassistant.EntityInfo, error)
 }
 
 // TrendRequest describes one ha_history invocation.

--- a/internal/state/awareness/entity_trend_test.go
+++ b/internal/state/awareness/entity_trend_test.go
@@ -19,6 +19,7 @@ type fakeTrendClient struct {
 	history     []homeassistant.State // GetStateHistory (lean)
 	historyAttr []homeassistant.State // GetStateHistoryWithAttributes
 	historyErr  error
+	entities    []homeassistant.EntityInfo // GetEntities (suggestion fallback)
 
 	gotStart time.Time
 }
@@ -33,6 +34,9 @@ func (f *fakeTrendClient) GetStateHistory(_ context.Context, _ string, start, _ 
 func (f *fakeTrendClient) GetStateHistoryWithAttributes(_ context.Context, _ string, start, _ time.Time) ([]homeassistant.State, error) {
 	f.gotStart = start
 	return f.historyAttr, f.historyErr
+}
+func (f *fakeTrendClient) GetEntities(_ context.Context, _ string) ([]homeassistant.EntityInfo, error) {
+	return f.entities, nil
 }
 
 func histState(id, state string, attrs map[string]any, ago time.Duration) homeassistant.State {
@@ -237,5 +241,27 @@ func TestComputeEntityTrend_CurrentStateError(t *testing.T) {
 	client := &fakeTrendClient{currentErr: errors.New("entity not found")}
 	if _, err := ComputeEntityTrend(context.Background(), client, TrendRequest{EntityID: "sensor.ghost"}, testNow); err == nil {
 		t.Error("expected error when current state cannot be fetched")
+	}
+}
+
+func TestHandleHistory_UnknownEntitySuggests(t *testing.T) {
+	client := &fakeTrendClient{
+		currentErr: &homeassistant.APIError{StatusCode: 404},
+		entities: []homeassistant.EntityInfo{
+			{EntityID: "sensor.office_temperature", FriendlyName: "Office Temperature", Domain: "sensor"},
+		},
+	}
+	tool := NewEntityTrendTools(EntityTrendToolsConfig{Client: client})
+
+	out, err := tool.handleHistory(context.Background(), map[string]any{"entity_id": "sensor.office_temperatur"})
+	if err != nil {
+		t.Fatalf("handleHistory: %v", err)
+	}
+	payload := decodeTrend(t, out)
+	if payload["found"] != false {
+		t.Errorf("found = %v, want false", payload["found"])
+	}
+	if payload["reason"] != "not_found" {
+		t.Errorf("reason = %v, want not_found", payload["reason"])
 	}
 }

--- a/internal/state/awareness/entity_trend_tool.go
+++ b/internal/state/awareness/entity_trend_tool.go
@@ -93,6 +93,12 @@ func (a *EntityTrendTools) handleHistory(ctx context.Context, args map[string]an
 
 	result, err := ComputeEntityTrend(ctx, a.client, req, time.Now())
 	if err != nil {
+		// A bad or stale entity_id is recoverable: return the shared
+		// "did you mean?" envelope rather than a raw 404 the model can't
+		// act on.
+		if tools.IsHAEntityNotFound(err) {
+			return tools.SuggestEntityNotFound(ctx, a.client, entityID), nil
+		}
 		a.logger.Warn("ha_history failed",
 			"entity_id", entityID,
 			"attribute", req.Attribute,

--- a/internal/tools/ha_entity_suggest.go
+++ b/internal/tools/ha_entity_suggest.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"net/http"
-	"strings"
 
 	"github.com/nugget/thane-ai-agent/internal/integrations/homeassistant"
 )
@@ -61,26 +60,23 @@ type ControlDeviceNoMatchResult struct {
 }
 
 // SuggestEntityNotFound builds the not-found envelope for a missing
-// entity_id, fuzzy-matching it against the live entity set (scoped to the
-// id's own domain when it carries one) so the result surfaces plausible
-// corrections for a typo'd or stale id. It is the shared recovery path for
-// the native HA tools that take an exact entity_id.
+// entity_id, fuzzy-matching it against the live entity set so the result
+// surfaces plausible corrections for a typo'd or stale id. It is the
+// shared recovery path for the native HA tools that take an exact
+// entity_id.
+//
+// The full set is fetched once and matched across all domains: GetEntities
+// pulls the entire state machine regardless of any domain filter (it
+// filters in-process), so domain-scoping would not save a fetch, and the
+// requested id's own domain token already steers the fuzzy ranking toward
+// same-domain candidates. This keeps the tool to a single bulk GetStates
+// per call, per the #1002 performance doctrine.
 //
 // It never returns an error: a discovery failure degrades to an empty
 // candidate list with a note pointing at ha_find_entity, which is still
 // strictly more useful to the model than a raw 404 or a silent no-op.
 func SuggestEntityNotFound(ctx context.Context, ha EntityLister, requested string) string {
-	domain := ""
-	if i := strings.IndexByte(requested, '.'); i > 0 {
-		domain = requested[:i]
-	}
-
-	entities, err := ha.GetEntities(ctx, domain)
-	if (err != nil || len(entities) == 0) && domain != "" {
-		// The domain itself may be the typo (e.g. lights.x vs light.x).
-		// Fall back to the full set so we can still suggest neighbors.
-		entities, err = ha.GetEntities(ctx, "")
-	}
+	entities, err := ha.GetEntities(ctx, "")
 
 	var candidates []EntitySuggestion
 	if err == nil {

--- a/internal/tools/ha_entity_suggest.go
+++ b/internal/tools/ha_entity_suggest.go
@@ -1,0 +1,127 @@
+package tools
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strings"
+
+	"github.com/nugget/thane-ai-agent/internal/integrations/homeassistant"
+)
+
+// maxEntitySuggestions caps the "did you mean?" candidate list returned by
+// the HA not-found envelope. Small enough to stay compact in the model's
+// context, large enough to cover a typo's plausible neighbors.
+const maxEntitySuggestions = 8
+
+// EntityLister is the slice of the Home Assistant client that
+// SuggestEntityNotFound needs: enumerate entities (optionally
+// domain-scoped) so it can rank "did you mean?" candidates. The concrete
+// *homeassistant.Client satisfies it, and so does any awareness-side
+// client that exposes entity discovery. Taking an interface lets tools in
+// other packages reuse the shared not-found envelope.
+type EntityLister interface {
+	GetEntities(ctx context.Context, domain string) ([]homeassistant.EntityInfo, error)
+}
+
+// EntityNotFoundResult is the structured envelope the native Home
+// Assistant tools return when a caller-supplied entity_id is not present
+// in Home Assistant's live state machine. It mirrors the
+// {found:false, reason, candidates} shape that ha_find_entity and
+// ha_device already use, so a model can recover in one follow-up call
+// instead of guessing another id.
+type EntityNotFoundResult struct {
+	Found             bool               `json:"found"` // always false
+	Reason            string             `json:"reason"`
+	RequestedEntityID string             `json:"requested_entity_id"`
+	Candidates        []EntitySuggestion `json:"candidates,omitempty"`
+	Note              string             `json:"note"`
+}
+
+// EntitySuggestion is one "did you mean?" candidate: the canonical
+// entity_id needed for the follow-up call plus the friendly name that
+// explains it.
+type EntitySuggestion struct {
+	EntityID     string  `json:"entity_id"`
+	FriendlyName string  `json:"friendly_name,omitempty"`
+	Score        float64 `json:"score"`
+}
+
+// ControlDeviceNoMatchResult is returned by ha_control_device when no
+// device matches the description. It reports explicitly that nothing was
+// changed and offers candidates (found by broadening past the inferred
+// domain) so the model refines rather than assuming the device was
+// controlled.
+type ControlDeviceNoMatchResult struct {
+	Acted                bool               `json:"acted"` // always false
+	Reason               string             `json:"reason"`
+	RequestedDescription string             `json:"requested_description"`
+	Candidates           []EntitySuggestion `json:"candidates,omitempty"`
+	Note                 string             `json:"note"`
+}
+
+// SuggestEntityNotFound builds the not-found envelope for a missing
+// entity_id, fuzzy-matching it against the live entity set (scoped to the
+// id's own domain when it carries one) so the result surfaces plausible
+// corrections for a typo'd or stale id. It is the shared recovery path for
+// the native HA tools that take an exact entity_id.
+//
+// It never returns an error: a discovery failure degrades to an empty
+// candidate list with a note pointing at ha_find_entity, which is still
+// strictly more useful to the model than a raw 404 or a silent no-op.
+func SuggestEntityNotFound(ctx context.Context, ha EntityLister, requested string) string {
+	domain := ""
+	if i := strings.IndexByte(requested, '.'); i > 0 {
+		domain = requested[:i]
+	}
+
+	entities, err := ha.GetEntities(ctx, domain)
+	if (err != nil || len(entities) == 0) && domain != "" {
+		// The domain itself may be the typo (e.g. lights.x vs light.x).
+		// Fall back to the full set so we can still suggest neighbors.
+		entities, err = ha.GetEntities(ctx, "")
+	}
+
+	var candidates []EntitySuggestion
+	if err == nil {
+		for i, m := range fuzzyMatchEntityInfos(requested, entities) {
+			if i >= maxEntitySuggestions {
+				break
+			}
+			candidates = append(candidates, EntitySuggestion{
+				EntityID:     m.EntityID,
+				FriendlyName: m.FriendlyName,
+				Score:        m.Score,
+			})
+		}
+	}
+
+	note := "entity_id not found in Home Assistant. Pick a candidate, or use ha_find_entity (look up by description) or ha_control_device (find + act) instead of retrying a guessed entity_id."
+	if len(candidates) == 0 {
+		note = "entity_id not found in Home Assistant and nothing similar exists. Use ha_find_entity or ha_list_entities to discover a valid entity_id; do not retry with a guessed id."
+	}
+
+	return toJSON(EntityNotFoundResult{
+		Found:             false,
+		Reason:            "not_found",
+		RequestedEntityID: requested,
+		Candidates:        candidates,
+		Note:              note,
+	})
+}
+
+// IsHAEntityNotFound reports whether err indicates Home Assistant could
+// not find the requested entity — an HTTP 404 from the states API, or a
+// registry "not_found" sentinel. Tools use it to separate a bad/stale
+// entity_id (recoverable via SuggestEntityNotFound) from an upstream
+// failure that should surface as-is.
+func IsHAEntityNotFound(err error) bool {
+	if err == nil {
+		return false
+	}
+	var apiErr *homeassistant.APIError
+	if errors.As(err, &apiErr) {
+		return apiErr.StatusCode == http.StatusNotFound
+	}
+	return isEntityRegistryNotFound(err)
+}

--- a/internal/tools/ha_entity_suggest_handlers_test.go
+++ b/internal/tools/ha_entity_suggest_handlers_test.go
@@ -1,0 +1,111 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/nugget/thane-ai-agent/internal/integrations/homeassistant"
+)
+
+func seedKitchen(f *fakeHAServer) {
+	f.states = []homeassistant.State{
+		{EntityID: "light.kitchen", State: "on", Attributes: map[string]any{"friendly_name": "Kitchen"}},
+		{EntityID: "light.kitchen_counter", State: "off", Attributes: map[string]any{"friendly_name": "Kitchen Counter"}},
+	}
+}
+
+func TestHandleCallService_UnknownEntitySuggestsAndDoesNotCall(t *testing.T) {
+	fake := newFakeHAServer(t)
+	seedKitchen(fake)
+	reg := fake.registry(t)
+
+	out, err := reg.handleCallService(context.Background(), map[string]any{
+		"domain":    "light",
+		"service":   "turn_on",
+		"entity_id": "light.kitchen_countr", // typo
+	})
+	if err != nil {
+		t.Fatalf("handleCallService: %v", err)
+	}
+
+	got := decodeNotFound(t, out)
+	if got.Found || got.Reason != "not_found" {
+		t.Errorf("expected not_found envelope, got %+v", got)
+	}
+	if len(got.Candidates) == 0 {
+		t.Errorf("expected candidates for a near-miss entity_id")
+	}
+	if len(fake.serviceCalls) != 0 {
+		t.Errorf("service must NOT be called for an unknown entity_id; got %v", fake.serviceCalls)
+	}
+}
+
+func TestHandleCallService_KnownEntityCalls(t *testing.T) {
+	fake := newFakeHAServer(t)
+	seedKitchen(fake)
+	reg := fake.registry(t)
+
+	out, err := reg.handleCallService(context.Background(), map[string]any{
+		"domain":    "light",
+		"service":   "turn_on",
+		"entity_id": "light.kitchen",
+	})
+	if err != nil {
+		t.Fatalf("handleCallService: %v", err)
+	}
+	if len(fake.serviceCalls) != 1 {
+		t.Errorf("expected exactly one forwarded service call, got %v", fake.serviceCalls)
+	}
+	if want := "Successfully called"; len(out) < len(want) || out[:len(want)] != want {
+		t.Errorf("expected success message, got %q", out)
+	}
+}
+
+func TestHandleGetState_UnknownEntitySuggests(t *testing.T) {
+	fake := newFakeHAServer(t)
+	seedKitchen(fake)
+	reg := fake.registry(t)
+
+	out, err := reg.handleGetState(context.Background(), map[string]any{
+		"entity_id": "light.kitchen_countr", // typo
+	})
+	if err != nil {
+		t.Fatalf("handleGetState: %v", err)
+	}
+	got := decodeNotFound(t, out)
+	if got.Found || got.Reason != "not_found" {
+		t.Errorf("expected not_found envelope, got %+v", got)
+	}
+	if got.RequestedEntityID != "light.kitchen_countr" {
+		t.Errorf("RequestedEntityID = %q", got.RequestedEntityID)
+	}
+}
+
+func TestHandleControlDevice_NoMatchReportsNotActed(t *testing.T) {
+	fake := newFakeHAServer(t)
+	seedKitchen(fake)
+	reg := fake.registry(t)
+
+	out, err := reg.handleControlDevice(context.Background(), map[string]any{
+		"description": "nonexistent widget zzzqqq",
+		"action":      "turn_on",
+	})
+	if err != nil {
+		t.Fatalf("handleControlDevice: %v", err)
+	}
+
+	var got ControlDeviceNoMatchResult
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("unmarshal control no-match: %v\n%s", err, out)
+	}
+	if got.Acted {
+		t.Errorf("Acted = true, want false")
+	}
+	if got.Reason != "no_match" {
+		t.Errorf("Reason = %q, want no_match", got.Reason)
+	}
+	if len(fake.serviceCalls) != 0 {
+		t.Errorf("no service call should be made on no-match; got %v", fake.serviceCalls)
+	}
+}

--- a/internal/tools/ha_entity_suggest_test.go
+++ b/internal/tools/ha_entity_suggest_test.go
@@ -1,0 +1,131 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/nugget/thane-ai-agent/internal/integrations/homeassistant"
+)
+
+func TestIsHAEntityNotFound(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"api 404", &homeassistant.APIError{StatusCode: 404}, true},
+		{"api 404 wrapped", fmt.Errorf("get state: %w", &homeassistant.APIError{StatusCode: 404}), true},
+		{"api 500", &homeassistant.APIError{StatusCode: 500}, false},
+		{"registry not_found", errors.New("not_found: entity does not exist"), true},
+		{"generic error", errors.New("connection refused"), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsHAEntityNotFound(tt.err); got != tt.want {
+				t.Errorf("IsHAEntityNotFound(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
+// fakeEntityLister implements EntityLister for suggestion tests without a
+// live HA client.
+type fakeEntityLister struct {
+	entities []homeassistant.EntityInfo
+	err      error
+}
+
+func (f *fakeEntityLister) GetEntities(_ context.Context, domain string) ([]homeassistant.EntityInfo, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	if domain == "" {
+		return f.entities, nil
+	}
+	var out []homeassistant.EntityInfo
+	for _, e := range f.entities {
+		if e.Domain == domain {
+			out = append(out, e)
+		}
+	}
+	return out, nil
+}
+
+func decodeNotFound(t *testing.T, raw string) EntityNotFoundResult {
+	t.Helper()
+	var got EntityNotFoundResult
+	if err := json.Unmarshal([]byte(raw), &got); err != nil {
+		t.Fatalf("unmarshal not-found envelope: %v\n%s", err, raw)
+	}
+	return got
+}
+
+func TestSuggestEntityNotFound_SurfacesCandidates(t *testing.T) {
+	lister := &fakeEntityLister{entities: []homeassistant.EntityInfo{
+		{EntityID: "light.office_main", FriendlyName: "Office Main", Domain: "light"},
+		{EntityID: "light.office_desk", FriendlyName: "Office Desk", Domain: "light"},
+		{EntityID: "switch.coffee", FriendlyName: "Coffee", Domain: "switch"},
+	}}
+
+	got := decodeNotFound(t, SuggestEntityNotFound(context.Background(), lister, "light.office_mian"))
+
+	if got.Found {
+		t.Errorf("Found = true, want false")
+	}
+	if got.Reason != "not_found" {
+		t.Errorf("Reason = %q, want not_found", got.Reason)
+	}
+	if got.RequestedEntityID != "light.office_mian" {
+		t.Errorf("RequestedEntityID = %q", got.RequestedEntityID)
+	}
+	if len(got.Candidates) == 0 {
+		t.Fatalf("expected candidates, got none")
+	}
+	// The office lights share the "office" token with the typo'd id, so
+	// they must surface; the unrelated switch must not crowd them out of
+	// the top slot.
+	if got.Candidates[0].EntityID != "light.office_main" && got.Candidates[0].EntityID != "light.office_desk" {
+		t.Errorf("top candidate = %q, want an office light", got.Candidates[0].EntityID)
+	}
+	if got.Note == "" {
+		t.Errorf("Note should always be set")
+	}
+}
+
+func TestSuggestEntityNotFound_NoSimilarEntities(t *testing.T) {
+	lister := &fakeEntityLister{entities: []homeassistant.EntityInfo{
+		{EntityID: "switch.coffee", FriendlyName: "Coffee", Domain: "switch"},
+	}}
+
+	got := decodeNotFound(t, SuggestEntityNotFound(context.Background(), lister, "lock.front_door"))
+
+	if got.Found {
+		t.Errorf("Found = true, want false")
+	}
+	if len(got.Candidates) != 0 {
+		t.Errorf("expected no candidates, got %d", len(got.Candidates))
+	}
+	if got.Note == "" {
+		t.Errorf("Note should guide discovery when nothing matches")
+	}
+}
+
+func TestSuggestEntityNotFound_DiscoveryFailureDegrades(t *testing.T) {
+	lister := &fakeEntityLister{err: errors.New("ha unreachable")}
+
+	got := decodeNotFound(t, SuggestEntityNotFound(context.Background(), lister, "light.kitchen"))
+
+	if got.Found {
+		t.Errorf("Found = true, want false")
+	}
+	if len(got.Candidates) != 0 {
+		t.Errorf("discovery failure should degrade to no candidates, got %d", len(got.Candidates))
+	}
+	if got.Note == "" {
+		t.Errorf("Note should still be set on discovery failure")
+	}
+}

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -1206,6 +1206,9 @@ func (r *Registry) handleGetState(ctx context.Context, args map[string]any) (str
 
 	state, err := r.ha.GetState(ctx, entityID)
 	if err != nil {
+		if IsHAEntityNotFound(err) {
+			return SuggestEntityNotFound(ctx, r.ha, entityID), nil
+		}
 		return "", err
 	}
 
@@ -1344,6 +1347,17 @@ func (r *Registry) handleCallService(ctx context.Context, args map[string]any) (
 		return "", fmt.Errorf("domain, service, and entity_id are required")
 	}
 
+	// HA accepts a service call for an unknown entity_id and silently
+	// no-ops, so a typo'd or stale id otherwise vanishes without feedback.
+	// Probe the entity first (a 404 here is authoritative) and return a
+	// recoverable "did you mean?" suggestion instead of a phantom success.
+	if _, err := r.ha.GetState(ctx, entityID); err != nil {
+		if IsHAEntityNotFound(err) {
+			return SuggestEntityNotFound(ctx, r.ha, entityID), nil
+		}
+		return "", fmt.Errorf("verify entity_id %q before calling %s.%s: %w", entityID, domain, service, err)
+	}
+
 	data := map[string]any{
 		"entity_id": entityID,
 	}
@@ -1410,7 +1424,33 @@ func (r *Registry) handleControlDevice(ctx context.Context, args map[string]any)
 	// Use the fuzzy matching from ha_find_entity
 	matches := fuzzyMatchEntityInfos(searchStr, entities)
 	if len(matches) == 0 {
-		return fmt.Sprintf("Could not find a device matching '%s'", description), nil
+		// The inferred domain may be wrong, so broaden to all domains to
+		// suggest candidates — but do not act on a low-confidence
+		// cross-domain guess. Return them for the model to confirm.
+		var candidates []EntitySuggestion
+		if all, aerr := r.ha.GetEntities(ctx, ""); aerr == nil {
+			for i, m := range fuzzyMatchEntityInfos(searchStr, all) {
+				if i >= maxEntitySuggestions {
+					break
+				}
+				candidates = append(candidates, EntitySuggestion{
+					EntityID:     m.EntityID,
+					FriendlyName: m.FriendlyName,
+					Score:        m.Score,
+				})
+			}
+		}
+		note := "No device matched and nothing was changed. Confirm one of the candidates, or use ha_find_entity to locate the entity_id, then retry."
+		if len(candidates) == 0 {
+			note = "No device matched and nothing was changed. Use ha_find_entity or ha_list_entities to discover the entity_id; nothing similar was found."
+		}
+		return toJSON(ControlDeviceNoMatchResult{
+			Acted:                false,
+			Reason:               "no_match",
+			RequestedDescription: description,
+			Candidates:           candidates,
+			Note:                 note,
+		}), nil
 	}
 
 	best := matches[0]

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -1409,10 +1409,23 @@ func (r *Registry) handleControlDevice(ctx context.Context, args map[string]any)
 		domain = "lock"
 	}
 
-	// Find the entity
-	entities, err := r.ha.GetEntities(ctx, domain)
+	// Fetch the full entity set once. GetEntities pulls the entire state
+	// machine regardless of any domain filter (it filters in-process), so
+	// fetching all and deriving the domain slice locally keeps this to a
+	// single bulk GetStates — the inferred-domain match and the broaden-on-
+	// miss suggestion both read from the same payload.
+	allEntities, err := r.ha.GetEntities(ctx, "")
 	if err != nil {
 		return "", fmt.Errorf("failed to get entities: %w", err)
+	}
+	entities := allEntities
+	if domain != "" {
+		entities = entities[:0:0]
+		for _, e := range allEntities {
+			if e.Domain == domain {
+				entities = append(entities, e)
+			}
+		}
 	}
 
 	// Build search string
@@ -1426,19 +1439,18 @@ func (r *Registry) handleControlDevice(ctx context.Context, args map[string]any)
 	if len(matches) == 0 {
 		// The inferred domain may be wrong, so broaden to all domains to
 		// suggest candidates — but do not act on a low-confidence
-		// cross-domain guess. Return them for the model to confirm.
+		// cross-domain guess. Return them for the model to confirm. Reuse
+		// the already-fetched full set rather than fetching again.
 		var candidates []EntitySuggestion
-		if all, aerr := r.ha.GetEntities(ctx, ""); aerr == nil {
-			for i, m := range fuzzyMatchEntityInfos(searchStr, all) {
-				if i >= maxEntitySuggestions {
-					break
-				}
-				candidates = append(candidates, EntitySuggestion{
-					EntityID:     m.EntityID,
-					FriendlyName: m.FriendlyName,
-					Score:        m.Score,
-				})
+		for i, m := range fuzzyMatchEntityInfos(searchStr, allEntities) {
+			if i >= maxEntitySuggestions {
+				break
 			}
+			candidates = append(candidates, EntitySuggestion{
+				EntityID:     m.EntityID,
+				FriendlyName: m.FriendlyName,
+				Score:        m.Score,
+			})
 		}
 		note := "No device matched and nothing was changed. Confirm one of the candidates, or use ha_find_entity to locate the entity_id, then retry."
 		if len(candidates) == 0 {

--- a/scripts/architecture.baseline
+++ b/scripts/architecture.baseline
@@ -1,5 +1,5 @@
 packages=59
-interfaces=78
+interfaces=79
 large_files=46
 set_mutators=107
 database_opens=8


### PR DESCRIPTION
## Summary

The native HA tools that take an exact `entity_id` gave the model nothing to recover from on a miss. **`ha_call_service` was the worst**: Home Assistant accepts a service call for an unknown `entity_id` and silently no-ops, so a typo'd or stale id vanished with a phantom success — the documented gotcha behind the talent's "ha_call_service does not validate entity IDs" warning.

This adds a shared, structured not-found envelope (`{found:false, reason:"not_found", requested_entity_id, candidates:[…], note}`) mirroring the shape `ha_find_entity` and `ha_device` already use, and wires it into the tools that previously returned a raw 404, a silent no-op, or a flat string.

## Changes

- **`ha_call_service`** — pre-validates the `entity_id` against HA's live state (a single-entity `GetState` probe; a 404 is authoritative). On a miss it returns suggestions **without forwarding**, turning the silent no-op into a recoverable error. Cost on the happy path: one extra single-entity GET, not a full states fetch.
- **`ha_get_state` / `ha_history`** — catch the 404 and enrich with candidates instead of surfacing a raw `API error 404`.
- **`ha_control_device`** — replaces the flat "could not find" string with candidates, broadening past the inferred domain (which is lossy) without acting on a low-confidence cross-domain guess.
- **`get_area_activity`** — returns area candidates (or `available_areas`) instead of a bare error, mirroring `ha_device`'s not-found shape (area-shaped, since the input is an area name).

Suggestion ranking reuses the existing `fuzzyMatchEntityInfos` matcher — **no new matcher**. `TrendHistoryClient` gains `GetEntities` so `ha_history` (in the awareness package) can reach the shared helper; the dependency runs awareness → tools, so the helper lives in `internal/tools`.

## Cost note (15k-entity production)

The full `/api/states` fetch is confined to the **not-found path** (building candidates). Happy paths for call_service/get_state/history are single-entity. `ha_control_device` already full-fetches per call (pre-existing). `GetStates` is uncached; a short-TTL cache is a reasonable follow-up but deliberately out of scope here.

## Test plan

- [x] `just ci` green locally (full gate; architecture baseline bumped for the one new interface, `EntityLister`)
- [x] `IsHAEntityNotFound`: APIError 404 (incl. wrapped), 500, registry `not_found`, nil, generic
- [x] `SuggestEntityNotFound`: surfaces ranked candidates; empty when nothing similar; degrades on discovery failure
- [x] `ha_call_service`: unknown id suggests **and does not forward**; known id calls through
- [x] `ha_get_state` / `ha_control_device` / `ha_history` / `get_area_activity` not-found paths
- [ ] Observe in prod: a stale/typo'd entity_id yields candidates the model can act on

Refs #1002