### PR TITLE
feat(ha): log duration and payload size of full GetStates fetches

### DIFF
--- a/internal/integrations/homeassistant/client.go
+++ b/internal/integrations/homeassistant/client.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
 	"net/url"
@@ -24,6 +25,16 @@ type Client struct {
 	ws                 *WSClient
 	floorMetadataAlias string
 	registry           *registryCache
+	logger             *slog.Logger
+}
+
+// log returns the client's logger, falling back to the default so callers
+// never have to nil-check.
+func (c *Client) log() *slog.Logger {
+	if c.logger != nil {
+		return c.logger
+	}
+	return slog.Default()
 }
 
 // readyChecker is satisfied by connwatch.Watcher. Defined here to avoid
@@ -86,6 +97,7 @@ func NewClient(baseURL, token string, logger *slog.Logger) *Client {
 			httpkit.WithLogger(logger),
 		),
 		registry: &registryCache{ttl: defaultRegistryCacheTTL},
+		logger:   logger,
 	}
 }
 
@@ -171,9 +183,19 @@ func (c *Client) GetConfig(ctx context.Context) (*Config, error) {
 // GetStates retrieves all entity states.
 func (c *Client) GetStates(ctx context.Context) ([]State, error) {
 	var states []State
-	if err := c.get(ctx, "/api/states", &states); err != nil {
+	start := time.Now()
+	payloadBytes, err := c.getMeasured(ctx, "/api/states", &states)
+	if err != nil {
 		return nil, err
 	}
+	// /api/states is the full state-machine dump — hot (watchlist renders,
+	// ha_control_device, entity-not-found suggestions) and large at scale.
+	// Log its cost so the load is quantifiable rather than guessed at.
+	c.log().LogAttrs(ctx, slog.LevelInfo, "ha get_states fetched full state machine",
+		slog.Duration("duration", time.Since(start)),
+		slog.Int64("payload_bytes", payloadBytes),
+		slog.Int("entity_count", len(states)),
+	)
 	return states, nil
 }
 
@@ -441,32 +463,56 @@ func (e *APIError) Error() string {
 
 // get performs a GET request to the HA API.
 func (c *Client) get(ctx context.Context, path string, result any) error {
+	_, err := c.getMeasured(ctx, path, result)
+	return err
+}
+
+// countingReader wraps a reader and tallies the bytes read through it, so
+// callers can measure a streamed-decode payload without buffering it.
+type countingReader struct {
+	r io.Reader
+	n int64
+}
+
+func (cr *countingReader) Read(p []byte) (int, error) {
+	n, err := cr.r.Read(p)
+	cr.n += int64(n)
+	return n, err
+}
+
+// getMeasured is get with the decoded response size reported back. The
+// byte count covers what the JSON decoder consumed (effectively the whole
+// payload for HA's array/object responses); it lets hot, large endpoints
+// like /api/states log their wire cost.
+func (c *Client) getMeasured(ctx context.Context, path string, result any) (int64, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+path, nil)
 	if err != nil {
-		return fmt.Errorf("build request: %w", err)
+		return 0, fmt.Errorf("build request: %w", err)
 	}
 	req.Header.Set("Authorization", "Bearer "+c.token)
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
-		return fmt.Errorf("request %s: %w", path, err)
+		return 0, fmt.Errorf("request %s: %w", path, err)
 	}
 	// Drain and close to ensure connection reuse even when result is nil.
 	defer httpkit.DrainAndClose(resp.Body, 4096)
 
 	if resp.StatusCode != http.StatusOK {
 		body := httpkit.ReadErrorBody(resp.Body, 512)
-		return &APIError{StatusCode: resp.StatusCode, Body: body}
+		return 0, &APIError{StatusCode: resp.StatusCode, Body: body}
 	}
 
 	if result != nil {
-		if err := json.NewDecoder(resp.Body).Decode(result); err != nil {
-			return fmt.Errorf("decode response: %w", err)
+		cr := &countingReader{r: resp.Body}
+		if err := json.NewDecoder(cr).Decode(result); err != nil {
+			return cr.n, fmt.Errorf("decode response: %w", err)
 		}
+		return cr.n, nil
 	}
 
-	return nil
+	return 0, nil
 }
 
 // post performs a POST request to the HA API.

--- a/internal/integrations/homeassistant/client_getstates_test.go
+++ b/internal/integrations/homeassistant/client_getstates_test.go
@@ -1,0 +1,63 @@
+package homeassistant
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestClient_GetStatesMeasuresPayload(t *testing.T) {
+	body := `[{"entity_id":"light.kitchen","state":"on"},{"entity_id":"switch.fan","state":"off"}]`
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/states" {
+			http.Error(w, "unexpected path", http.StatusNotFound)
+			return
+		}
+		_, _ = io.WriteString(w, body)
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "token", nil)
+
+	var states []State
+	n, err := client.getMeasured(context.Background(), "/api/states", &states)
+	if err != nil {
+		t.Fatalf("getMeasured: %v", err)
+	}
+	if len(states) != 2 {
+		t.Fatalf("decoded %d states, want 2", len(states))
+	}
+	if n != int64(len(body)) {
+		t.Errorf("payload bytes = %d, want %d", n, len(body))
+	}
+
+	// GetStates decodes the same set (and logs the measured cost).
+	got, err := client.GetStates(context.Background())
+	if err != nil {
+		t.Fatalf("GetStates: %v", err)
+	}
+	if len(got) != 2 {
+		t.Errorf("GetStates returned %d states, want 2", len(got))
+	}
+}
+
+func TestClient_GetMeasuredZeroOnNoResult(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, `{"ok":true}`)
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "token", nil)
+
+	// With a nil result the body is drained, not decoded, so no bytes are
+	// counted — get() must still succeed for callers that ignore the body.
+	n, err := client.getMeasured(context.Background(), "/api/whatever", nil)
+	if err != nil {
+		t.Fatalf("getMeasured: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("payload bytes = %d, want 0 for nil result", n)
+	}
+}

--- a/internal/integrations/homeassistant/client_getstates_test.go
+++ b/internal/integrations/homeassistant/client_getstates_test.go
@@ -3,10 +3,26 @@ package homeassistant
 import (
 	"context"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
+
+// captureHandler collects slog records so a test can assert the log
+// contract a feature promises (message + attributes).
+type captureHandler struct {
+	records []slog.Record
+}
+
+func (h *captureHandler) Enabled(context.Context, slog.Level) bool { return true }
+func (h *captureHandler) Handle(_ context.Context, r slog.Record) error {
+	h.records = append(h.records, r)
+	return nil
+}
+func (h *captureHandler) WithAttrs([]slog.Attr) slog.Handler { return h }
+func (h *captureHandler) WithGroup(string) slog.Handler      { return h }
 
 func TestClient_GetStatesMeasuresPayload(t *testing.T) {
 	body := `[{"entity_id":"light.kitchen","state":"on"},{"entity_id":"switch.fan","state":"off"}]`
@@ -40,6 +56,49 @@ func TestClient_GetStatesMeasuresPayload(t *testing.T) {
 	}
 	if len(got) != 2 {
 		t.Errorf("GetStates returned %d states, want 2", len(got))
+	}
+}
+
+func TestClient_GetStatesLogsCost(t *testing.T) {
+	body := `[{"entity_id":"light.kitchen","state":"on"},{"entity_id":"switch.fan","state":"off"}]`
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, body)
+	}))
+	defer server.Close()
+
+	h := &captureHandler{}
+	client := NewClient(server.URL, "token", slog.New(h))
+
+	if _, err := client.GetStates(context.Background()); err != nil {
+		t.Fatalf("GetStates: %v", err)
+	}
+
+	var rec *slog.Record
+	for i := range h.records {
+		if strings.Contains(h.records[i].Message, "get_states") {
+			rec = &h.records[i]
+			break
+		}
+	}
+	if rec == nil {
+		t.Fatal("GetStates emitted no get_states cost log record")
+	}
+
+	attrs := map[string]slog.Value{}
+	rec.Attrs(func(a slog.Attr) bool {
+		attrs[a.Key] = a.Value
+		return true
+	})
+	for _, key := range []string{"duration", "payload_bytes", "entity_count"} {
+		if _, ok := attrs[key]; !ok {
+			t.Errorf("cost log missing attr %q", key)
+		}
+	}
+	if got := attrs["entity_count"].Int64(); got != 2 {
+		t.Errorf("entity_count = %d, want 2", got)
+	}
+	if got := attrs["payload_bytes"].Int64(); got != int64(len(body)) {
+		t.Errorf("payload_bytes = %d, want %d", got, len(body))
 	}
 }
 


### PR DESCRIPTION
## Summary

`GetStates` (`GET /api/states`) is the full Home Assistant state-machine dump — hot and large, but its cost was invisible. This logs it so we can quantify the load rather than argue about it from intuition.

It's called on every watchlist render, every `ha_control_device` invocation, and every entity-not-found suggestion (see #1022 discussion). At ~15k entities in production each of those pulls the entire payload (`GetEntities(domain)` filters in Go *after* fetching everything).

## Changes

- Retain the `*slog.Logger` on the HA `Client` (it was previously only passed to the http layer, never kept).
- Add a `countingReader` + `getMeasured` GET path that reports the decoded payload size without buffering the whole body; `get()` becomes a thin wrapper.
- `GetStates` now logs `duration`, `payload_bytes`, and `entity_count` at **INFO** on every fetch.

INFO (not DEBUG) is deliberate: the call *frequency* is itself part of the signal we want to see. Easy to dial back to DEBUG once we've characterized the load.

## What this enables

A production log sweep will show how big `/api/states` actually is, how long it takes, and how often we pull it — the data needed to decide whether a short-TTL `GetStates` cache (the deferred follow-up) is worth it.

## Test plan

- [x] `just ci` green locally
- [x] `getMeasured` reports the exact decoded byte count for a known body; returns 0 for a nil result (drain-only)
- [x] `GetStates` still decodes correctly through the counting path
- [ ] Read prod logs after deploy: confirm payload_bytes / duration / entity_count land and look sane

Refs #1002