### PR TITLE
fix(models): adopt Claude Opus 4.8 / Sonnet 4.6 / Haiku 4.5 model IDs in code

### DIFF
--- a/examples/config.example.yaml
+++ b/examples/config.example.yaml
@@ -1086,9 +1086,15 @@ curator:
 #
 # (optional) Pricing maps model names to their per-million-token costs (USD).
 # pricing:
-#   claude-opus-4-20250514:
-#     input_per_million: 15.0
-#     output_per_million: 75.0
+#   claude-haiku-4-5:
+#     input_per_million: 1.0
+#     output_per_million: 5.0
+#   claude-opus-4-8:
+#     input_per_million: 5.0
+#     output_per_million: 25.0
+#   claude-sonnet-4-6:
+#     input_per_million: 3.0
+#     output_per_million: 15.0
 #
 # Logging configures Thane's filesystem datasets, stdout policy, and
 # queryable request/log retention.

--- a/internal/model/fleet/providers/anthropic.go
+++ b/internal/model/fleet/providers/anthropic.go
@@ -447,7 +447,10 @@ func (c *AnthropicClient) Ping(ctx context.Context) error {
 	// Anthropic doesn't have a dedicated health endpoint.
 	// We'll send a minimal request to verify the API key works.
 	req := anthropicRequest{
-		Model:     "claude-sonnet-4-20250514",
+		// Cheapest current model — a liveness probe only needs the API
+		// key to authenticate, not a heavyweight model. Avoids pinning a
+		// deprecated model that would 404 the health check post-retirement.
+		Model:     "claude-haiku-4-5",
 		Messages:  []anthropicMessage{{Role: "user", Content: "ping"}},
 		MaxTokens: 1,
 	}
@@ -705,9 +708,10 @@ const estimatedCharsPerToken = 4
 // indistinguishable from a cache miss in the usage response — hence
 // the guard surfaces them as warnings.
 //
-// Values track the published per-family minimums (Sonnet 1024, Opus
-// 4096, Haiku 4096). Unknown models default to the strictest minimum
-// so we never advertise caching we can't confirm.
+// Values track the published per-family minimums (Opus 4096, Haiku
+// 4096, Sonnet 4.6 2048, earlier Sonnet 1024). Unknown models default
+// to the strictest minimum so we never advertise caching we can't
+// confirm.
 func minCacheablePrefixTokens(model string) int {
 	lower := strings.ToLower(model)
 	switch {
@@ -716,6 +720,11 @@ func minCacheablePrefixTokens(model string) int {
 	case strings.Contains(lower, "haiku"):
 		return 4096
 	case strings.Contains(lower, "sonnet"):
+		// Sonnet 4.6 raised the minimum cacheable prefix to 2048;
+		// Sonnet 4.5 and earlier cache from 1024.
+		if strings.Contains(lower, "sonnet-4-6") {
+			return 2048
+		}
 		return 1024
 	default:
 		return 4096

--- a/internal/model/fleet/providers/anthropic_test.go
+++ b/internal/model/fleet/providers/anthropic_test.go
@@ -374,7 +374,9 @@ func TestMinCacheablePrefixTokens(t *testing.T) {
 	}{
 		{"claude-sonnet-4-5", 1024},
 		{"claude-sonnet-4-20250514", 1024},
+		{"claude-sonnet-4-6", 2048}, // Sonnet 4.6 raised the minimum to 2048
 		{"claude-opus-4-7", 4096},
+		{"claude-opus-4-8", 4096},
 		{"claude-haiku-4-5", 4096},
 		{"unknown-model", 4096},
 	}

--- a/internal/platform/config/config.go
+++ b/internal/platform/config/config.go
@@ -975,7 +975,7 @@ type ModelsConfig struct {
 // The model router uses these fields to select the best model for each
 // request.
 type ModelConfig struct {
-	Name              string `yaml:"name"`               // Model identifier (e.g., "claude-opus-4-20250514")
+	Name              string `yaml:"name"`               // Model identifier (e.g., "claude-opus-4-8")
 	Provider          string `yaml:"provider"`           // Provider name: ollama, anthropic, lmstudio. Defaults to ollama when no resource is set
 	Resource          string `yaml:"resource"`           // Named provider resource from models.resources for this deployment
 	SupportsTools     bool   `yaml:"supports_tools"`     // Optional per-deployment tool-use override. When omitted, runtime/provider capability is used.
@@ -2293,6 +2293,13 @@ func (c *Config) applyDefaults() {
 
 	if c.Pricing == nil {
 		c.Pricing = map[string]PricingEntry{
+			// Current models (per-million USD, input/output).
+			"claude-opus-4-8":   {InputPerMillion: 5.0, OutputPerMillion: 25.0},
+			"claude-sonnet-4-6": {InputPerMillion: 3.0, OutputPerMillion: 15.0},
+			"claude-haiku-4-5":  {InputPerMillion: 1.0, OutputPerMillion: 5.0},
+			// Deprecated models kept for pricing historical usage records
+			// (retire 2026-06-15 / 2026-04-19); note Opus 4 was $15/$75,
+			// far above Opus 4.8's $5/$25.
 			"claude-opus-4-20250514":   {InputPerMillion: 15.0, OutputPerMillion: 75.0},
 			"claude-sonnet-4-20250514": {InputPerMillion: 3.0, OutputPerMillion: 15.0},
 			"claude-haiku-3-20240307":  {InputPerMillion: 0.25, OutputPerMillion: 1.25},

--- a/internal/platform/config/config_test.go
+++ b/internal/platform/config/config_test.go
@@ -326,6 +326,29 @@ func TestContentMaxLength_Default(t *testing.T) {
 	}
 }
 
+// TestApplyDefaults_PricingHasCurrentModels locks in cost-tracking
+// pricing for the current model fleet. Opus 4.8 is $5/$25 — far below
+// the retired Opus 4's $15/$75 — so a missing entry would silently
+// mis-price usage rather than error.
+func TestApplyDefaults_PricingHasCurrentModels(t *testing.T) {
+	cfg := Default()
+	want := map[string]PricingEntry{
+		"claude-opus-4-8":   {InputPerMillion: 5.0, OutputPerMillion: 25.0},
+		"claude-sonnet-4-6": {InputPerMillion: 3.0, OutputPerMillion: 15.0},
+		"claude-haiku-4-5":  {InputPerMillion: 1.0, OutputPerMillion: 5.0},
+	}
+	for model, exp := range want {
+		got, ok := cfg.Pricing[model]
+		if !ok {
+			t.Errorf("Pricing missing entry for current model %q", model)
+			continue
+		}
+		if got != exp {
+			t.Errorf("Pricing[%q] = %+v, want %+v", model, got, exp)
+		}
+	}
+}
+
 func TestContentMaxLength_Explicit(t *testing.T) {
 	cfg := Default()
 	n := 8192

--- a/internal/platform/config/example.go
+++ b/internal/platform/config/example.go
@@ -460,9 +460,17 @@ func ExampleConfig() *Config {
 		},
 
 		Pricing: map[string]PricingEntry{
-			"claude-opus-4-20250514": {
-				InputPerMillion:  15.0,
-				OutputPerMillion: 75.0,
+			"claude-opus-4-8": {
+				InputPerMillion:  5.0,
+				OutputPerMillion: 25.0,
+			},
+			"claude-sonnet-4-6": {
+				InputPerMillion:  3.0,
+				OutputPerMillion: 15.0,
+			},
+			"claude-haiku-4-5": {
+				InputPerMillion:  1.0,
+				OutputPerMillion: 5.0,
 			},
 		},
 

--- a/internal/state/awareness/context_usage.go
+++ b/internal/state/awareness/context_usage.go
@@ -13,7 +13,7 @@ import (
 // pre-computed by the caller so that formatting is deterministic
 // and free of I/O.
 type ContextUsageInfo struct {
-	// Model is the default model name (e.g., "claude-opus-4-20250514").
+	// Model is the default model name (e.g., "claude-opus-4-8").
 	// The "(routed)" suffix is appended when Routed is true, signaling
 	// that the router may select a different model for this turn.
 	Model string


### PR DESCRIPTION
## Summary

Prod `config.yaml` is already migrated to **`claude-opus-4-8`** (default) plus `claude-sonnet-4-6` and `claude-haiku-4-5`. This PR catches the **code-side** references the config swap left behind — the spots that still pinned the now-deprecated `…-20250514` models.

**Why the request layer needs no change:** Thane's `anthropicRequest` struct carries only `model / messages / system / max_tokens / stream / tools / cache_control`. It never sends `temperature`, `top_p`, `top_k`, `thinking`, or `budget_tokens` — exactly the parameters Opus 4.8 *removed* and now 400s on. So the migration's scary breaking changes don't apply; Thane's wire format was already 4.8-clean.

## Changes

- **Cost-tracking price table** (`config.go` `applyDefaults`, `example.go` `ExampleConfig`): add `claude-opus-4-8` ($5/$25), `claude-sonnet-4-6` ($3/$15), `claude-haiku-4-5` ($1/$5). Without these, usage cost for the new models was **unpriced** — and note Opus 4.8 is **$5/$25**, far below the retired Opus 4's $15/$75. Legacy entries kept for historical usage records.
- **`AnthropicClient.Ping()`**: `claude-sonnet-4-20250514` (deprecated, **retires 2026-06-15** → would 404 the health check) → `claude-haiku-4-5` (cheapest current model; a liveness probe only needs the key to authenticate).
- **`minCacheablePrefixTokens`**: Sonnet **4.6** raised the minimum cacheable prefix to **2048** (older Sonnet stays 1024; Opus/Haiku already 4096, correct for Opus 4.8). Without this, a 1024–2047-token prefix on `claude-sonnet-4-6` would *silently* fail to cache.
- Refresh stale `e.g. claude-opus-4-20250514` doc comments; regenerate `examples/config.example.yaml`.

## Tests

- [x] `just ci` green locally (incl. `config-generate-check` on the committed, regenerated example)
- [x] `TestApplyDefaults_PricingHasCurrentModels` — current fleet priced correctly
- [x] `TestMinCacheablePrefixTokens` extended: `opus-4-8` → 4096, `sonnet-4-6` → 2048 (older Sonnet unchanged at 1024)

## Out of scope (deliberately)

Behavioral prompt-tuning for Opus 4.8 — it narrates more, under-reaches for tools/tag-activation (relevant to #1002), and asks more often. That's an **observe-then-adjust** pass once 4.8 is actually running in prod, not a guess now. Adopting the `effort` parameter (`output_config`) is a separate feature, not a model-ID fix.