### PR TITLE
fix(ha): make the Home Assistant WebSocket self-healing

### DIFF
--- a/internal/app/new_stores.go
+++ b/internal/app/new_stores.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"os"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/nugget/thane-ai-agent/internal/connwatch"
@@ -148,6 +147,17 @@ func (a *App) initStores(s *newState) error {
 		a.haWS = homeassistant.NewWSClient(cfg.HomeAssistant.URL, cfg.HomeAssistant.Token, logger)
 		a.ha.UseWSClient(a.haWS)
 		a.onCloseErr("ha-websocket", a.haWS.Close)
+
+		// The WebSocket owns its own reconnect loop: a transient drop (or an
+		// HA restart) recovers on the supervisor's backoff without depending
+		// on the REST health edge. Register state_changed as sticky intent —
+		// the supervisor (re)applies it on every connect, so the subscription
+		// survives a failed attempt. connwatch only nudges recovery faster
+		// (see OnReady → NotifyReachable).
+		a.haWS.Start(s.ctx)
+		if err := a.haWS.Subscribe(s.ctx, "state_changed"); err != nil {
+			logger.Warn("failed to record HA state_changed subscription intent", "error", err)
+		}
 		logger.Debug("Home Assistant configured", "url", cfg.HomeAssistant.URL)
 	} else {
 		logger.Warn("Home Assistant not configured - tools will be limited")
@@ -211,7 +221,6 @@ func (a *App) initStores(s *newState) error {
 
 	// The OnReady callback captures s (pointer) so it sees the
 	// personTracker assigned later in initAwareness.
-	var subscribeOnce sync.Once
 	if a.ha != nil {
 		haWatcher := connMgr.Watch(s.ctx, connwatch.WatcherConfig{
 			Name:    "homeassistant",
@@ -229,26 +238,13 @@ func (a *App) initStores(s *newState) error {
 					)
 				}
 
-				// Reconnect WebSocket when HA comes back.
+				// REST is reachable again — nudge the WebSocket supervisor so a
+				// down socket shortcuts its backoff and retries immediately.
+				// The WS otherwise self-heals on its own loop (see Start, where
+				// the connection is established and state_changed is registered
+				// as sticky subscription intent).
 				if a.haWS != nil {
-					wsCtx, wsCancel := context.WithTimeout(context.Background(), 30*time.Second)
-					defer wsCancel()
-					if err := a.haWS.Reconnect(wsCtx); err != nil {
-						logger.Error("WebSocket reconnect failed", "error", err)
-					}
-
-					// Subscribe to state_changed events on first connection.
-					// Subsequent reconnects restore subscriptions automatically
-					// via WSClient.restoreSubscriptions.
-					subscribeOnce.Do(func() {
-						subCtx, subCancel := context.WithTimeout(context.Background(), 30*time.Second)
-						defer subCancel()
-						if err := a.haWS.Subscribe(subCtx, "state_changed"); err != nil {
-							logger.Error("subscribe to state_changed failed", "error", err)
-						} else {
-							logger.Info("subscribed to state_changed events")
-						}
-					})
+					a.haWS.NotifyReachable()
 				}
 
 				// Initialize (or refresh) person tracker from current HA state.

--- a/internal/integrations/homeassistant/websocket.go
+++ b/internal/integrations/homeassistant/websocket.go
@@ -20,6 +20,13 @@ const (
 	defaultWSBackoffInitial    = 2 * time.Second
 	defaultWSBackoffMax        = 60 * time.Second
 	defaultWSBackoffMultiplier = 2.0
+
+	// defaultWSHandshakeTimeout bounds the WS opening handshake and the
+	// subsequent HA auth exchange. DialContext only covers the dial itself,
+	// so without this a connection that is accepted but never completes the
+	// auth_required/auth_ok exchange would block Connect — and the whole
+	// supervisor — forever.
+	defaultWSHandshakeTimeout = 15 * time.Second
 )
 
 // WSClient manages a self-healing WebSocket connection to Home Assistant.
@@ -65,6 +72,7 @@ type WSClient struct {
 	backoffInitial    time.Duration
 	backoffMax        time.Duration
 	backoffMultiplier float64
+	handshakeTimeout  time.Duration
 
 	logger *slog.Logger
 }
@@ -122,6 +130,7 @@ func NewWSClient(baseURL, token string, logger *slog.Logger) *WSClient {
 		backoffInitial:    defaultWSBackoffInitial,
 		backoffMax:        defaultWSBackoffMax,
 		backoffMultiplier: defaultWSBackoffMultiplier,
+		handshakeTimeout:  defaultWSHandshakeTimeout,
 		logger:            logger,
 	}
 }
@@ -137,6 +146,15 @@ func (c *WSClient) SetReconnectBackoff(initial, max time.Duration, multiplier fl
 	}
 	if multiplier >= 1 {
 		c.backoffMultiplier = multiplier
+	}
+}
+
+// SetHandshakeTimeout overrides how long the WS opening handshake and HA
+// auth exchange may take before the attempt is abandoned (and retried by the
+// supervisor). Intended for tests and tuning; call before Start.
+func (c *WSClient) SetHandshakeTimeout(d time.Duration) {
+	if d > 0 {
+		c.handshakeTimeout = d
 	}
 }
 
@@ -221,11 +239,14 @@ func (c *WSClient) NotifyReachable() {
 // (called by applyDesiredSubscriptions → sendSubscribe) which also takes
 // connMu.
 func (c *WSClient) Connect(ctx context.Context) error {
-	// Close any stale connection before dialing a new one.
+	// Tear down any stale connection and mark the client disconnected for
+	// the duration of the (re)connect, so IsConnected reflects reality and
+	// NotifyReachable can still nudge a retry while we dial and handshake.
 	c.connMu.Lock()
 	old := c.conn
 	c.conn = nil
 	c.connMu.Unlock()
+	c.connected.Store(false)
 	if old != nil {
 		old.Close()
 	}
@@ -248,8 +269,9 @@ func (c *WSClient) Connect(ctx context.Context) error {
 
 	// Use custom dialer with larger buffer for big responses (entity registry can be huge).
 	dialer := websocket.Dialer{
-		ReadBufferSize:  1024 * 1024, // 1MB
-		WriteBufferSize: 64 * 1024,   // 64KB
+		ReadBufferSize:   1024 * 1024, // 1MB
+		WriteBufferSize:  64 * 1024,   // 64KB
+		HandshakeTimeout: c.handshakeTimeout,
 	}
 
 	conn, _, err := dialer.DialContext(ctx, u.String(), nil)
@@ -259,6 +281,14 @@ func (c *WSClient) Connect(ctx context.Context) error {
 
 	// Set read limit for large responses (HA can have 12000+ entities).
 	conn.SetReadLimit(100 * 1024 * 1024) // 100MB max message size
+
+	// Bound the auth handshake itself: the dialer's HandshakeTimeout covers
+	// only the WS upgrade, so a connection that upgrades but then never
+	// sends auth_required/auth_ok would block these reads forever. Cleared
+	// right after auth_ok (below), before the long-lived readLoop starts.
+	handshakeDeadline := time.Now().Add(c.handshakeTimeout)
+	_ = conn.SetReadDeadline(handshakeDeadline)
+	_ = conn.SetWriteDeadline(handshakeDeadline)
 
 	// Auth handshake uses the local conn directly — no concurrent readers yet.
 
@@ -300,6 +330,12 @@ func (c *WSClient) Connect(ctx context.Context) error {
 	}
 
 	c.logger.Info("WebSocket authenticated")
+
+	// Clear the handshake deadlines before the long-lived readLoop takes
+	// over: an idle but healthy socket must not inherit a fixed deadline,
+	// or it would trip it and force a needless reconnect.
+	_ = conn.SetReadDeadline(time.Time{})
+	_ = conn.SetWriteDeadline(time.Time{})
 
 	// Publish the authenticated connection so sendAndWait can use it.
 	c.connMu.Lock()

--- a/internal/integrations/homeassistant/websocket.go
+++ b/internal/integrations/homeassistant/websocket.go
@@ -13,24 +13,58 @@ import (
 	"github.com/gorilla/websocket"
 )
 
-// WSClient manages a WebSocket connection to Home Assistant.
+// Default reconnect backoff schedule. The supervisor retries forever
+// (until its context is cancelled) — Home Assistant is core infrastructure,
+// so a transient outage must never leave the socket permanently dead.
+const (
+	defaultWSBackoffInitial    = 2 * time.Second
+	defaultWSBackoffMax        = 60 * time.Second
+	defaultWSBackoffMultiplier = 2.0
+)
+
+// WSClient manages a self-healing WebSocket connection to Home Assistant.
+//
+// Once Start is called, the client owns its own connection lifecycle: it
+// dials with exponential backoff, restores its subscriptions on every
+// (re)connect, and reconnects automatically whenever the connection drops
+// — whether the drop is a network error or a server-initiated close (e.g.
+// HA restarting). Reconnection does NOT depend on any external health
+// watcher; connwatch's NotifyReachable is only an optional fast-path nudge.
 type WSClient struct {
 	baseURL string
 	token   string
 	conn    *websocket.Conn
-	connMu  sync.Mutex
+	connMu  sync.Mutex // guards the conn pointer
+	writeMu sync.Mutex // serializes writes; gorilla forbids concurrent writers
 	msgID   atomic.Int64
 
-	// Response channels keyed by message ID
+	// connected reflects whether an authenticated connection is live. It
+	// is the source of truth for IsConnected and gates the reconnect nudge.
+	connected atomic.Bool
+
+	// Response channels keyed by message ID.
 	pending   map[int64]chan wsResponse
 	pendingMu sync.Mutex
 
-	// Event channel for subscribed events
+	// Event channel for subscribed events. Created once and reused across
+	// reconnects so downstream consumers (e.g. the state watcher) keep a
+	// stable channel.
 	events chan Event
 
-	// Subscriptions to restore on reconnect
-	subscriptions   []string
-	subscriptionsMu sync.Mutex
+	// desired is the set of event types we want subscribed. It is sticky:
+	// recorded on Subscribe regardless of connection state and re-applied
+	// on every (re)connect, so a subscription survives a failed attempt.
+	desired   map[string]struct{}
+	desiredMu sync.Mutex
+
+	// Supervisor plumbing.
+	startOnce sync.Once
+	lost      chan struct{} // readLoop signals genuine connection loss
+	retryNow  chan struct{} // NotifyReachable shortcuts the backoff wait
+
+	backoffInitial    time.Duration
+	backoffMax        time.Duration
+	backoffMultiplier float64
 
 	logger *slog.Logger
 }
@@ -78,12 +112,105 @@ func NewWSClient(baseURL, token string, logger *slog.Logger) *WSClient {
 		logger = slog.Default()
 	}
 	return &WSClient{
-		baseURL:       baseURL,
-		token:         token,
-		pending:       make(map[int64]chan wsResponse),
-		events:        make(chan Event, 100),
-		subscriptions: make([]string, 0),
-		logger:        logger,
+		baseURL:           baseURL,
+		token:             token,
+		pending:           make(map[int64]chan wsResponse),
+		events:            make(chan Event, 100),
+		desired:           make(map[string]struct{}),
+		lost:              make(chan struct{}, 1),
+		retryNow:          make(chan struct{}, 1),
+		backoffInitial:    defaultWSBackoffInitial,
+		backoffMax:        defaultWSBackoffMax,
+		backoffMultiplier: defaultWSBackoffMultiplier,
+		logger:            logger,
+	}
+}
+
+// SetReconnectBackoff overrides the reconnect backoff schedule. Intended
+// for tests and tuning; call before Start.
+func (c *WSClient) SetReconnectBackoff(initial, max time.Duration, multiplier float64) {
+	if initial > 0 {
+		c.backoffInitial = initial
+	}
+	if max > 0 {
+		c.backoffMax = max
+	}
+	if multiplier >= 1 {
+		c.backoffMultiplier = multiplier
+	}
+}
+
+// IsConnected reports whether an authenticated connection is currently live.
+func (c *WSClient) IsConnected() bool { return c.connected.Load() }
+
+// Start launches the connection supervisor. It is idempotent: only the
+// first call starts the goroutine. The supervisor runs until ctx is
+// cancelled, at which point it closes the connection and exits.
+func (c *WSClient) Start(ctx context.Context) {
+	c.startOnce.Do(func() {
+		go c.supervise(ctx)
+	})
+}
+
+// supervise keeps the connection alive: connect (with backoff), wait for
+// loss or shutdown, repeat. It is the single owner of the reconnect loop.
+func (c *WSClient) supervise(ctx context.Context) {
+	for {
+		if err := c.connectWithBackoff(ctx); err != nil {
+			// Only ctx cancellation ends connectWithBackoff.
+			c.Close()
+			return
+		}
+		select {
+		case <-ctx.Done():
+			c.Close()
+			return
+		case <-c.lost:
+			c.logger.Warn("HA WebSocket connection lost; reconnecting")
+		}
+	}
+}
+
+// connectWithBackoff retries Connect until it succeeds or ctx is cancelled.
+// The delay grows geometrically up to backoffMax; a NotifyReachable nudge
+// resets it and retries immediately.
+func (c *WSClient) connectWithBackoff(ctx context.Context) error {
+	delay := c.backoffInitial
+	for attempt := 1; ; attempt++ {
+		if err := c.Connect(ctx); err == nil {
+			return nil
+		} else if ctx.Err() != nil {
+			return ctx.Err()
+		} else {
+			c.logger.Warn("HA WebSocket connect failed; will retry",
+				"attempt", attempt, "delay", delay, "error", err)
+		}
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-c.retryNow:
+			delay = c.backoffInitial
+		case <-time.After(delay):
+			delay = time.Duration(float64(delay) * c.backoffMultiplier)
+			if delay > c.backoffMax {
+				delay = c.backoffMax
+			}
+		}
+	}
+}
+
+// NotifyReachable hints that Home Assistant may be reachable again (e.g.
+// from a connwatch OnReady on the REST probe). If the socket is already
+// connected it is a no-op; otherwise it shortcuts the supervisor's backoff
+// so recovery is immediate rather than waiting out the current delay.
+func (c *WSClient) NotifyReachable() {
+	if c.connected.Load() {
+		return
+	}
+	select {
+	case c.retryNow <- struct{}{}:
+	default:
 	}
 }
 
@@ -91,7 +218,8 @@ func NewWSClient(baseURL, token string, logger *slog.Logger) *WSClient {
 //
 // connMu is held only while swapping the conn pointer, not for the full
 // duration of the handshake. This avoids deadlocking with sendAndWait
-// (called by restoreSubscriptions → Subscribe) which also takes connMu.
+// (called by applyDesiredSubscriptions → sendSubscribe) which also takes
+// connMu.
 func (c *WSClient) Connect(ctx context.Context) error {
 	// Close any stale connection before dialing a new one.
 	c.connMu.Lock()
@@ -102,7 +230,7 @@ func (c *WSClient) Connect(ctx context.Context) error {
 		old.Close()
 	}
 
-	// Parse base URL and convert to WebSocket URL
+	// Parse base URL and convert to WebSocket URL.
 	u, err := url.Parse(c.baseURL)
 	if err != nil {
 		return fmt.Errorf("parse base URL: %w", err)
@@ -118,7 +246,7 @@ func (c *WSClient) Connect(ctx context.Context) error {
 
 	c.logger.Info("connecting to Home Assistant WebSocket", "url", u.String())
 
-	// Use custom dialer with larger buffer for big responses (entity registry can be huge)
+	// Use custom dialer with larger buffer for big responses (entity registry can be huge).
 	dialer := websocket.Dialer{
 		ReadBufferSize:  1024 * 1024, // 1MB
 		WriteBufferSize: 64 * 1024,   // 64KB
@@ -129,12 +257,12 @@ func (c *WSClient) Connect(ctx context.Context) error {
 		return fmt.Errorf("dial websocket: %w", err)
 	}
 
-	// Set read limit for large responses (HA can have 12000+ entities)
+	// Set read limit for large responses (HA can have 12000+ entities).
 	conn.SetReadLimit(100 * 1024 * 1024) // 100MB max message size
 
 	// Auth handshake uses the local conn directly — no concurrent readers yet.
 
-	// Read auth_required message
+	// Read auth_required message.
 	var authReq wsMessage
 	if err := conn.ReadJSON(&authReq); err != nil {
 		conn.Close()
@@ -145,7 +273,7 @@ func (c *WSClient) Connect(ctx context.Context) error {
 		return fmt.Errorf("expected auth_required, got %s", authReq.Type)
 	}
 
-	// Send auth
+	// Send auth.
 	authMsg := map[string]string{
 		"type":         "auth",
 		"access_token": c.token,
@@ -155,7 +283,7 @@ func (c *WSClient) Connect(ctx context.Context) error {
 		return fmt.Errorf("send auth: %w", err)
 	}
 
-	// Read auth response
+	// Read auth response.
 	var authResp wsMessage
 	if err := conn.ReadJSON(&authResp); err != nil {
 		conn.Close()
@@ -177,20 +305,24 @@ func (c *WSClient) Connect(ctx context.Context) error {
 	c.connMu.Lock()
 	c.conn = conn
 	c.connMu.Unlock()
+	c.connected.Store(true)
 
-	// Start read loop
-	go c.readLoop()
+	// Start read loop.
+	go c.readLoop(conn)
 
-	// Restore subscriptions (calls Subscribe → sendAndWait, which takes connMu).
-	c.restoreSubscriptions()
+	// (Re)apply desired subscriptions on the fresh connection.
+	c.applyDesiredSubscriptions()
 
 	return nil
 }
 
-// Close closes the WebSocket connection. The readLoop goroutine
-// exits when the underlying read returns an error from the closed
-// connection. Safe to call multiple times.
+// Close closes the WebSocket connection. The readLoop goroutine exits
+// when the underlying read returns an error from the closed connection.
+// Safe to call multiple times. Close marks the client disconnected but
+// does not stop the supervisor — cancel the Start context for that.
 func (c *WSClient) Close() error {
+	c.connected.Store(false)
+
 	c.connMu.Lock()
 	conn := c.conn
 	c.conn = nil
@@ -202,46 +334,69 @@ func (c *WSClient) Close() error {
 	return nil
 }
 
-// Reconnect re-establishes the WebSocket connection, authenticating and
-// restoring all prior subscriptions. Safe to call from any goroutine.
-// Intended to be called from a connwatch OnReady callback when Home
-// Assistant becomes reachable again. Connect() handles closing any
-// stale connection before dialing.
-func (c *WSClient) Reconnect(ctx context.Context) error {
-	c.logger.Info("reconnecting WebSocket")
-	return c.Connect(ctx)
-}
-
 // Events returns the channel for receiving subscribed events.
 func (c *WSClient) Events() <-chan Event {
 	return c.events
 }
 
-// Subscribe subscribes to a Home Assistant event type.
+// Subscribe records a desired subscription and applies it immediately if
+// connected. The intent is sticky: it is re-applied on every (re)connect,
+// so a subscription survives a connection that drops or a send that fails.
+// When called while disconnected it returns nil — the intent is recorded
+// and the supervisor will apply it on the next connect.
 func (c *WSClient) Subscribe(ctx context.Context, eventType string) error {
-	id := c.msgID.Add(1)
+	c.desiredMu.Lock()
+	c.desired[eventType] = struct{}{}
+	c.desiredMu.Unlock()
 
+	if !c.connected.Load() {
+		c.logger.Debug("subscription intent recorded; will apply on connect",
+			"event_type", eventType)
+		return nil
+	}
+	return c.sendSubscribe(ctx, eventType)
+}
+
+// sendSubscribe sends a single subscribe_events request and waits for the
+// ack. It does not touch the desired set.
+func (c *WSClient) sendSubscribe(ctx context.Context, eventType string) error {
+	id := c.msgID.Add(1)
 	msg := map[string]any{
 		"id":         id,
 		"type":       "subscribe_events",
 		"event_type": eventType,
 	}
-
-	_, err := c.sendAndWait(ctx, id, msg)
-	if err != nil {
+	if _, err := c.sendAndWait(ctx, id, msg); err != nil {
 		return fmt.Errorf("subscribe to %s: %w", eventType, err)
 	}
-
-	// If we got here without error, subscription succeeded
-	// (errors are returned by sendAndWait if the response indicates failure)
-
-	// Track subscription for reconnect
-	c.subscriptionsMu.Lock()
-	c.subscriptions = append(c.subscriptions, eventType)
-	c.subscriptionsMu.Unlock()
-
 	c.logger.Info("subscribed to events", "event_type", eventType)
 	return nil
+}
+
+// applyDesiredSubscriptions re-subscribes to every desired event type on a
+// freshly established connection. Uses a fresh context so it is not bound
+// to a dial context that may already be cancelled.
+func (c *WSClient) applyDesiredSubscriptions() {
+	c.desiredMu.Lock()
+	subs := make([]string, 0, len(c.desired))
+	for eventType := range c.desired {
+		subs = append(subs, eventType)
+	}
+	c.desiredMu.Unlock()
+
+	if len(subs) == 0 {
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	for _, eventType := range subs {
+		if err := c.sendSubscribe(ctx, eventType); err != nil {
+			c.logger.Error("failed to apply subscription",
+				"event_type", eventType, "error", err)
+		}
+	}
 }
 
 // GetAreaRegistry retrieves the area registry.
@@ -288,7 +443,7 @@ func (c *WSClient) GetEntityRegistryWS(ctx context.Context) ([]EntityRegistryEnt
 
 // sendAndWait sends a message and waits for the response.
 func (c *WSClient) sendAndWait(ctx context.Context, id int64, msg any) (json.RawMessage, error) {
-	// Create response channel
+	// Create response channel.
 	respCh := make(chan wsResponse, 1)
 	c.pendingMu.Lock()
 	c.pending[id] = respCh
@@ -300,18 +455,23 @@ func (c *WSClient) sendAndWait(ctx context.Context, id int64, msg any) (json.Raw
 		c.pendingMu.Unlock()
 	}()
 
-	// Send message
+	// Send message. Writes are serialized through writeMu: gorilla forbids
+	// concurrent writers, and applyDesiredSubscriptions, live Subscribe
+	// calls, and request methods can all send concurrently.
 	c.connMu.Lock()
 	conn := c.conn
 	c.connMu.Unlock()
 	if conn == nil {
 		return nil, fmt.Errorf("send message: connection closed")
 	}
-	if err := conn.WriteJSON(msg); err != nil {
+	c.writeMu.Lock()
+	err := conn.WriteJSON(msg)
+	c.writeMu.Unlock()
+	if err != nil {
 		return nil, fmt.Errorf("send message: %w", err)
 	}
 
-	// Wait for response
+	// Wait for response.
 	select {
 	case resp := <-respCh:
 		if !resp.Success {
@@ -328,45 +488,40 @@ func (c *WSClient) sendAndWait(ctx context.Context, id int64, msg any) (json.Raw
 	}
 }
 
-// readLoop continuously reads messages from the WebSocket.
-func (c *WSClient) readLoop() {
+// readLoop continuously reads messages from the given connection. It owns
+// exactly one connection; when that connection ends it returns, and (for a
+// genuine loss) signals the supervisor to reconnect.
+func (c *WSClient) readLoop(conn *websocket.Conn) {
 	defer c.logger.Debug("readLoop exited")
 
 	for {
 		var msg wsMessage
-
-		c.connMu.Lock()
-		conn := c.conn
-		c.connMu.Unlock()
-
-		if conn == nil {
-			return
-		}
-
 		if err := conn.ReadJSON(&msg); err != nil {
-			if websocket.IsCloseError(err, websocket.CloseNormalClosure, websocket.CloseGoingAway) {
-				c.logger.Info("WebSocket closed normally")
-				return
-			}
-			// When Close() nils c.conn, or Connect() replaces it with a
-			// new connection, ReadJSON on the old conn returns an error.
-			// Distinguish intentional close/replacement from genuine loss.
+			// Distinguish an intentional close/replacement (Close() nils
+			// c.conn, or Connect() swapped in a new one) from a genuine
+			// loss. Only a genuine loss of the *current* connection should
+			// trigger a reconnect.
 			c.connMu.Lock()
 			current := c.conn
 			c.connMu.Unlock()
 			if current == nil || current != conn {
-				c.logger.Info("WebSocket connection closed")
+				c.logger.Info("HA WebSocket connection closed")
 				return
 			}
-			c.logger.Error("WebSocket read error, connection lost", "error", err)
-			// Reconnection is handled by connwatch: when the HA service
-			// becomes reachable again, the OnReady callback calls Reconnect().
+
+			if websocket.IsCloseError(err, websocket.CloseNormalClosure, websocket.CloseGoingAway) {
+				c.logger.Info("HA WebSocket closed by server; will reconnect", "error", err)
+			} else {
+				c.logger.Error("HA WebSocket read error; connection lost", "error", err)
+			}
+			c.connected.Store(false)
+			c.signalLost()
 			return
 		}
 
 		switch msg.Type {
 		case "result":
-			// Response to a request
+			// Response to a request.
 			c.pendingMu.Lock()
 			if ch, ok := c.pending[msg.ID]; ok {
 				ch <- wsResponse{
@@ -378,7 +533,7 @@ func (c *WSClient) readLoop() {
 			c.pendingMu.Unlock()
 
 		case "event":
-			// Subscribed event
+			// Subscribed event.
 			if msg.Event != nil {
 				select {
 				case c.events <- *msg.Event:
@@ -388,7 +543,7 @@ func (c *WSClient) readLoop() {
 			}
 
 		case "pong":
-			// Ping/pong keepalive, ignore
+			// Ping/pong keepalive, ignore.
 
 		default:
 			c.logger.Debug("unhandled WebSocket message type", "type", msg.Type)
@@ -396,22 +551,11 @@ func (c *WSClient) readLoop() {
 	}
 }
 
-// restoreSubscriptions re-subscribes to all tracked event types.
-// It clears the subscription list first because Subscribe() appends to it;
-// without clearing, each reconnect would duplicate every entry.
-func (c *WSClient) restoreSubscriptions() {
-	c.subscriptionsMu.Lock()
-	subs := make([]string, len(c.subscriptions))
-	copy(subs, c.subscriptions)
-	c.subscriptions = c.subscriptions[:0] // clear to prevent duplicates
-	c.subscriptionsMu.Unlock()
-
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-
-	for _, eventType := range subs {
-		if err := c.Subscribe(ctx, eventType); err != nil {
-			c.logger.Error("failed to restore subscription", "event_type", eventType, "error", err)
-		}
+// signalLost notifies the supervisor of a connection loss without blocking.
+// The buffered channel coalesces multiple signals into one reconnect.
+func (c *WSClient) signalLost() {
+	select {
+	case c.lost <- struct{}{}:
+	default:
 	}
 }

--- a/internal/integrations/homeassistant/websocket_reconnect_test.go
+++ b/internal/integrations/homeassistant/websocket_reconnect_test.go
@@ -1,0 +1,287 @@
+package homeassistant
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+// fakeHA is a controllable stand-in for the Home Assistant WebSocket
+// endpoint. It performs the auth handshake, acks subscribe_events, and lets
+// a test push events, force-drop the live connection, or refuse the first N
+// connections — enough to exercise the self-healing supervisor.
+type fakeHA struct {
+	upgrader   websocket.Upgrader
+	mu         sync.Mutex // guards conns/cur and serializes server-side writes
+	conns      int
+	cur        *websocket.Conn
+	failFirst  int         // close the first N connections right after upgrade
+	subscribed chan string // event_type of each acked subscribe
+}
+
+func newFakeHA() *fakeHA {
+	return &fakeHA{subscribed: make(chan string, 16)}
+}
+
+func (f *fakeHA) start(t *testing.T) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/websocket", f.handle)
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func (f *fakeHA) handle(w http.ResponseWriter, r *http.Request) {
+	conn, err := f.upgrader.Upgrade(w, r, nil)
+	if err != nil {
+		return
+	}
+
+	f.mu.Lock()
+	f.conns++
+	n := f.conns
+	f.cur = conn
+	fail := n <= f.failFirst
+	f.mu.Unlock()
+
+	if fail {
+		conn.Close()
+		return
+	}
+
+	if err := f.write(conn, map[string]any{"type": "auth_required"}); err != nil {
+		return
+	}
+	var auth map[string]any
+	if err := conn.ReadJSON(&auth); err != nil {
+		return
+	}
+	if err := f.write(conn, map[string]any{"type": "auth_ok"}); err != nil {
+		return
+	}
+
+	for {
+		var m map[string]any
+		if err := conn.ReadJSON(&m); err != nil {
+			return
+		}
+		id, _ := m["id"].(float64)
+		if m["type"] == "subscribe_events" {
+			_ = f.write(conn, map[string]any{"id": int64(id), "type": "result", "success": true})
+			if et, ok := m["event_type"].(string); ok {
+				select {
+				case f.subscribed <- et:
+				default:
+				}
+			}
+			continue
+		}
+		// Ack anything else so request/response calls don't hang.
+		_ = f.write(conn, map[string]any{"id": int64(id), "type": "result", "success": true})
+	}
+}
+
+// write serializes all server-side writes: gorilla forbids concurrent
+// writers, and a test's pushStateChanged can race the handler's acks.
+func (f *fakeHA) write(conn *websocket.Conn, v any) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return conn.WriteJSON(v)
+}
+
+func (f *fakeHA) pushStateChanged(entityID string) {
+	f.mu.Lock()
+	conn := f.cur
+	f.mu.Unlock()
+	if conn == nil {
+		return
+	}
+	_ = f.write(conn, map[string]any{
+		"type": "event",
+		"event": map[string]any{
+			"event_type": "state_changed",
+			"data":       map[string]any{"entity_id": entityID},
+		},
+	})
+}
+
+func (f *fakeHA) dropCurrent() {
+	f.mu.Lock()
+	conn := f.cur
+	f.mu.Unlock()
+	if conn != nil {
+		conn.Close()
+	}
+}
+
+func (f *fakeHA) connCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.conns
+}
+
+func discardLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+func newFastWS(t *testing.T, url string) *WSClient {
+	t.Helper()
+	ws := NewWSClient(url, "test-token", discardLogger())
+	// Tiny backoff so reconnect tests run in milliseconds, not seconds.
+	ws.SetReconnectBackoff(time.Millisecond, 10*time.Millisecond, 2.0)
+	return ws
+}
+
+func waitSubscribe(t *testing.T, f *fakeHA, want string) {
+	t.Helper()
+	select {
+	case got := <-f.subscribed:
+		if got != want {
+			t.Fatalf("subscribed to %q, want %q", got, want)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatalf("timed out waiting for subscribe to %q", want)
+	}
+}
+
+func waitEvent(t *testing.T, ws *WSClient) Event {
+	t.Helper()
+	select {
+	case ev := <-ws.Events():
+		return ev
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for event")
+		return Event{}
+	}
+}
+
+func waitUntil(t *testing.T, cond func() bool, msg string) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("condition not met within timeout: %s", msg)
+}
+
+// TestWSClient_ConnectSubscribeEvent covers the happy path: a subscription
+// recorded before Start is applied on connect, and events flow. It also
+// exercises the connected-path Subscribe (sent immediately).
+func TestWSClient_ConnectSubscribeEvent(t *testing.T) {
+	f := newFakeHA()
+	srv := f.start(t)
+	ws := newFastWS(t, srv.URL)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Recorded as sticky intent while disconnected; applied on connect.
+	if err := ws.Subscribe(ctx, "state_changed"); err != nil {
+		t.Fatalf("Subscribe (pre-connect intent): %v", err)
+	}
+	ws.Start(ctx)
+
+	waitSubscribe(t, f, "state_changed")
+	waitUntil(t, ws.IsConnected, "client should report connected")
+	if got := f.connCount(); got != 1 {
+		t.Fatalf("connCount = %d, want 1", got)
+	}
+
+	// Live subscribe (while connected) is sent immediately.
+	if err := ws.Subscribe(ctx, "automation_triggered"); err != nil {
+		t.Fatalf("Subscribe (live): %v", err)
+	}
+	waitSubscribe(t, f, "automation_triggered")
+
+	f.pushStateChanged("light.kitchen")
+	ev := waitEvent(t, ws)
+	if ev.Type != "state_changed" {
+		t.Fatalf("event type = %q, want state_changed", ev.Type)
+	}
+}
+
+// TestWSClient_ReconnectsAndResubscribesAfterDrop is the core regression:
+// a dropped connection (while the REST side stays healthy) must self-heal —
+// the supervisor reconnects and re-applies the subscription with no external
+// trigger, and events flow again on the new connection.
+func TestWSClient_ReconnectsAndResubscribesAfterDrop(t *testing.T) {
+	f := newFakeHA()
+	srv := f.start(t)
+	ws := newFastWS(t, srv.URL)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if err := ws.Subscribe(ctx, "state_changed"); err != nil {
+		t.Fatalf("Subscribe: %v", err)
+	}
+	ws.Start(ctx)
+
+	waitSubscribe(t, f, "state_changed")
+	waitUntil(t, ws.IsConnected, "initial connect")
+
+	// Kill the live connection out from under the client.
+	f.dropCurrent()
+
+	// Supervisor reconnects and re-applies the subscription unprompted.
+	waitSubscribe(t, f, "state_changed")
+	waitUntil(t, func() bool { return f.connCount() >= 2 }, "should have reconnected")
+	waitUntil(t, ws.IsConnected, "reconnected")
+
+	// Events flow again on the fresh connection.
+	f.pushStateChanged("binary_sensor.door")
+	ev := waitEvent(t, ws)
+	if ev.Type != "state_changed" {
+		t.Fatalf("post-reconnect event type = %q, want state_changed", ev.Type)
+	}
+}
+
+// TestWSClient_RetriesUntilServerAccepts verifies the supervisor keeps
+// dialing through repeated failures (the transient-DNS/dial-timeout case
+// from the incident) and connects once the endpoint is healthy.
+func TestWSClient_RetriesUntilServerAccepts(t *testing.T) {
+	f := newFakeHA()
+	f.failFirst = 2 // first two connections are refused right after upgrade
+	srv := f.start(t)
+	ws := newFastWS(t, srv.URL)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if err := ws.Subscribe(ctx, "state_changed"); err != nil {
+		t.Fatalf("Subscribe: %v", err)
+	}
+	ws.Start(ctx)
+
+	waitUntil(t, ws.IsConnected, "should connect after retries")
+	if got := f.connCount(); got < 3 {
+		t.Fatalf("connCount = %d, want >= 3 (two refusals then success)", got)
+	}
+	waitSubscribe(t, f, "state_changed")
+}
+
+// TestWSClient_StopsOnContextCancel verifies the supervisor tears down when
+// its Start context is cancelled.
+func TestWSClient_StopsOnContextCancel(t *testing.T) {
+	f := newFakeHA()
+	srv := f.start(t)
+	ws := newFastWS(t, srv.URL)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	ws.Start(ctx)
+	waitUntil(t, ws.IsConnected, "initial connect")
+
+	cancel()
+	waitUntil(t, func() bool { return !ws.IsConnected() }, "should disconnect on ctx cancel")
+}

--- a/internal/integrations/homeassistant/websocket_reconnect_test.go
+++ b/internal/integrations/homeassistant/websocket_reconnect_test.go
@@ -18,12 +18,13 @@ import (
 // a test push events, force-drop the live connection, or refuse the first N
 // connections — enough to exercise the self-healing supervisor.
 type fakeHA struct {
-	upgrader   websocket.Upgrader
-	mu         sync.Mutex // guards conns/cur and serializes server-side writes
-	conns      int
-	cur        *websocket.Conn
-	failFirst  int         // close the first N connections right after upgrade
-	subscribed chan string // event_type of each acked subscribe
+	upgrader       websocket.Upgrader
+	mu             sync.Mutex // guards conns/cur and serializes server-side writes
+	conns          int
+	cur            *websocket.Conn
+	failFirst      int         // close the first N connections right after upgrade
+	stallHandshake bool        // upgrade, then never send auth_required (hang)
+	subscribed     chan string // event_type of each acked subscribe
 }
 
 func newFakeHA() *fakeHA {
@@ -50,11 +51,21 @@ func (f *fakeHA) handle(w http.ResponseWriter, r *http.Request) {
 	n := f.conns
 	f.cur = conn
 	fail := n <= f.failFirst
+	stall := f.stallHandshake
 	f.mu.Unlock()
 
 	if fail {
 		conn.Close()
 		return
+	}
+	if stall {
+		// Upgrade succeeds, but auth_required is never sent. Block until the
+		// client abandons the handshake (its deadline) and closes the conn.
+		for {
+			if _, _, err := conn.ReadMessage(); err != nil {
+				return
+			}
+		}
 	}
 
 	if err := f.write(conn, map[string]any{"type": "auth_required"}); err != nil {
@@ -284,4 +295,56 @@ func TestWSClient_StopsOnContextCancel(t *testing.T) {
 
 	cancel()
 	waitUntil(t, func() bool { return !ws.IsConnected() }, "should disconnect on ctx cancel")
+}
+
+// TestWSClient_HandshakeTimeoutDoesNotHang verifies that a connection which
+// upgrades but never completes the HA auth handshake cannot block Connect
+// forever: the attempt times out and the supervisor keeps retrying. If
+// Connect hung, connCount would stay at 1 and this would never reach 2.
+func TestWSClient_HandshakeTimeoutDoesNotHang(t *testing.T) {
+	f := newFakeHA()
+	f.stallHandshake = true // upgrade succeeds, but auth_required never arrives
+	srv := f.start(t)
+	ws := newFastWS(t, srv.URL)
+	ws.SetHandshakeTimeout(50 * time.Millisecond)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ws.Start(ctx)
+
+	waitUntil(t, func() bool { return f.connCount() >= 2 },
+		"supervisor should time out the stalled handshake and retry")
+	if ws.IsConnected() {
+		t.Fatal("must not report connected to a server that never completes the auth handshake")
+	}
+}
+
+// TestWSClient_HealthyIdleConnectionStaysUp verifies the handshake deadline
+// is cleared before the long-lived readLoop: a healthy but idle socket must
+// not trip the deadline and force a reconnect. With the deadline leaked, the
+// connection would drop ~one handshake-timeout after connecting.
+func TestWSClient_HealthyIdleConnectionStaysUp(t *testing.T) {
+	f := newFakeHA()
+	srv := f.start(t)
+	ws := newFastWS(t, srv.URL)
+	ws.SetHandshakeTimeout(50 * time.Millisecond)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err := ws.Subscribe(ctx, "state_changed"); err != nil {
+		t.Fatalf("Subscribe: %v", err)
+	}
+	ws.Start(ctx)
+	waitSubscribe(t, f, "state_changed")
+	waitUntil(t, ws.IsConnected, "initial connect")
+
+	// Stay idle well past the handshake timeout.
+	time.Sleep(150 * time.Millisecond)
+
+	if got := f.connCount(); got != 1 {
+		t.Fatalf("idle healthy connection reconnected (connCount=%d); handshake deadline leaked into readLoop", got)
+	}
+	if !ws.IsConnected() {
+		t.Fatal("idle healthy connection should still be connected")
+	}
 }

--- a/scripts/architecture.baseline
+++ b/scripts/architecture.baseline
@@ -1,5 +1,5 @@
 packages=60
 interfaces=79
 large_files=47
-set_mutators=108
+set_mutators=109
 database_opens=8

--- a/scripts/architecture.baseline
+++ b/scripts/architecture.baseline
@@ -1,5 +1,5 @@
 packages=60
 interfaces=79
-large_files=46
-set_mutators=107
+large_files=47
+set_mutators=108
 database_opens=8


### PR DESCRIPTION
## Why

The HA WebSocket only reconnected via a `connwatch` `OnReady` callback that is **edge-triggered on the REST health probe**. So a transient WS dial failure *while REST stayed healthy* (a network/DNS blip) left the socket — and the `state_changed` subscription — **durably down for the whole process lifetime, with no retry**. The initial subscription was also a `sync.Once` consumed even when it failed, so a later reconnect could never restore it.

**This bit production.** After today's deploy + restart, a restart-window network blip dropped the WS reconnect dial (`dial tcp 172.28.10.8:443: operation timed out`), REST recovered on its own, and live `state_changed` push events silently stopped flowing until a manual restart. REST polling masked it (health stayed green), so it was invisible to the dependency health check.

HA is core infrastructure — its event stream needs to recover on its own.

## What

Make the WebSocket own its own connection lifecycle:

- **`Start(ctx)` supervisor** — connects with exponential backoff and reconnects automatically on *any* genuine loss, including a server-initiated close (HA restart). Retries forever until ctx is cancelled.
- **Declarative subscriptions** — `Subscribe` records *sticky intent* that is re-applied on every (re)connect, so it survives a failed attempt. Removes the burned-on-failure `sync.Once`.
- **connwatch becomes a nudge** — REST-ready calls `NotifyReachable()` to shortcut the backoff, rather than being the *sole* reconnect trigger. Clean separation: connwatch owns REST + person-tracker init; the WS owns itself.
- **Write serialization** — all socket writes go through a write mutex. gorilla forbids concurrent writers, and `applyDesiredSubscriptions` + live `Subscribe` + request methods can now race (the race detector caught this; it was a latent gap before too).
- **`IsConnected()`** for health/observability and testability.

## Test plan

New `websocket_reconnect_test.go` drives a fake HA WS server (auth handshake + subscribe acks + controllable drop/refuse), all **race-clean**:

- [x] `ConnectSubscribeEvent` — pre-Start intent applied on connect; live subscribe sent immediately; events flow
- [x] `ReconnectsAndResubscribesAfterDrop` — **the core regression**: connection dropped out from under the client → supervisor reconnects and re-applies the subscription with no external trigger → events flow again
- [x] `RetriesUntilServerAccepts` — supervisor keeps dialing through refusals (the transient-dial-timeout case) and connects once healthy
- [x] `StopsOnContextCancel` — clean teardown on ctx cancel
- [x] `just ci` green locally (architecture baseline bumped for the larger WS file + new set-mutator)

## Notes

- Production was already recovered via manual restart; this prevents recurrence.
- Backoff: 2s → 60s, geometric. Tunable via `SetReconnectBackoff` (tests use ms).