### PR TITLE
fix(ha): tolerate numeric values across all integration-supplied registry fields

### DIFF
--- a/internal/integrations/homeassistant/client.go
+++ b/internal/integrations/homeassistant/client.go
@@ -353,7 +353,7 @@ type EntityRegistryEntry struct {
 	ID                  string            `json:"id"`
 	EntityID            string            `json:"entity_id"`
 	Name                string            `json:"name"`
-	OriginalName        string            `json:"original_name"`
+	OriginalName        flexString        `json:"original_name"`
 	Description         string            `json:"description"`
 	Aliases             []string          `json:"aliases"`
 	AreaID              string            `json:"area_id"`
@@ -368,7 +368,7 @@ type EntityRegistryEntry struct {
 	DeviceClass         string            `json:"device_class"`
 	OriginalDeviceClass string            `json:"original_device_class"`
 	HasEntityName       bool              `json:"has_entity_name"`
-	UniqueID            string            `json:"unique_id"`
+	UniqueID            flexString        `json:"unique_id"`
 	TranslationKey      string            `json:"translation_key"`
 	Options             map[string]any    `json:"options"`
 	Categories          map[string]string `json:"categories"`

--- a/internal/integrations/homeassistant/configapi.go
+++ b/internal/integrations/homeassistant/configapi.go
@@ -55,19 +55,19 @@ type DeviceRegistryEntry struct {
 	ID                    string               `json:"id"`
 	ConfigEntries         []string             `json:"config_entries"`
 	ConfigEntriesSubentry map[string][]*string `json:"config_entries_subentries"`
-	Connections           [][]string           `json:"connections"`
-	Identifiers           [][]string           `json:"identifiers"`
-	Manufacturer          string               `json:"manufacturer"`
-	Model                 string               `json:"model"`
-	ModelID               string               `json:"model_id"`
-	Name                  string               `json:"name"`
+	Connections           [][]flexString       `json:"connections"`
+	Identifiers           [][]flexString       `json:"identifiers"`
+	Manufacturer          flexString           `json:"manufacturer"`
+	Model                 flexString           `json:"model"`
+	ModelID               flexString           `json:"model_id"`
+	Name                  flexString           `json:"name"`
 	Labels                []string             `json:"labels"`
 	SWVersion             flexString           `json:"sw_version"`
 	HWVersion             flexString           `json:"hw_version"`
-	SerialNumber          string               `json:"serial_number"`
+	SerialNumber          flexString           `json:"serial_number"`
 	ViaDeviceID           string               `json:"via_device_id"`
 	AreaID                string               `json:"area_id"`
-	NameByUser            string               `json:"name_by_user"`
+	NameByUser            flexString           `json:"name_by_user"`
 	EntryType             string               `json:"entry_type"`
 	DisabledBy            string               `json:"disabled_by"`
 	ConfigurationURL      string               `json:"configuration_url"`

--- a/internal/integrations/homeassistant/device_registry_test.go
+++ b/internal/integrations/homeassistant/device_registry_test.go
@@ -68,3 +68,94 @@ func TestDeviceRegistryEntry_NumericVersionDoesNotFailDecode(t *testing.T) {
 		t.Errorf("device[2].SWVersion = %q, want empty", got)
 	}
 }
+
+// TestDeviceRegistryEntry_AllIntegrationFieldsTolerateNumbers is the broad
+// guarantee behind this hardening: HA does not strictly validate integration
+// input, so every integration-supplied device field can arrive as a number —
+// and none of them may fail the device_registry/list decode. Each numeric
+// value is coerced to its string form, including elements nested inside the
+// identifiers/connections tuples.
+func TestDeviceRegistryEntry_AllIntegrationFieldsTolerateNumbers(t *testing.T) {
+	raw := `[{
+		"id":"a",
+		"manufacturer":3,
+		"model":650,
+		"model_id":42,
+		"name":12345,
+		"name_by_user":99,
+		"serial_number":1234567890,
+		"sw_version":2,
+		"hw_version":1.5,
+		"identifiers":[["mqtt",42],["hue","light-1"]],
+		"connections":[["mac",112233]]
+	}]`
+
+	var devices []DeviceRegistryEntry
+	if err := json.Unmarshal([]byte(raw), &devices); err != nil {
+		t.Fatalf("decode device list with all-numeric fields: %v", err)
+	}
+	if len(devices) != 1 {
+		t.Fatalf("decoded %d devices, want 1", len(devices))
+	}
+	d := devices[0]
+
+	got := map[string]string{
+		"manufacturer":  string(d.Manufacturer),
+		"model":         string(d.Model),
+		"model_id":      string(d.ModelID),
+		"name":          string(d.Name),
+		"name_by_user":  string(d.NameByUser),
+		"serial_number": string(d.SerialNumber),
+		"sw_version":    string(d.SWVersion),
+		"hw_version":    string(d.HWVersion),
+	}
+	want := map[string]string{
+		"manufacturer":  "3",
+		"model":         "650",
+		"model_id":      "42",
+		"name":          "12345",
+		"name_by_user":  "99",
+		"serial_number": "1234567890",
+		"sw_version":    "2",
+		"hw_version":    "1.5",
+	}
+	for k, w := range want {
+		if got[k] != w {
+			t.Errorf("%s = %q, want %q", k, got[k], w)
+		}
+	}
+
+	if len(d.Identifiers) != 2 || string(d.Identifiers[0][1]) != "42" {
+		t.Errorf("numeric identifier element not coerced: %+v", d.Identifiers)
+	}
+	if len(d.Connections) != 1 || string(d.Connections[0][1]) != "112233" {
+		t.Errorf("numeric connection element not coerced: %+v", d.Connections)
+	}
+}
+
+// TestEntityRegistryEntry_NumericFieldsTolerated covers the entity-registry
+// counterpart: a numeric unique_id (common — integrations use raw device IDs)
+// or original_name must not fail the entity_registry/list decode. unique_id
+// has no readers, but the decode still crashed on it before this fix.
+func TestEntityRegistryEntry_NumericFieldsTolerated(t *testing.T) {
+	raw := `[
+		{"entity_id":"sensor.a","unique_id":1234567890,"original_name":42},
+		{"entity_id":"sensor.b","unique_id":"abc-123","original_name":"Temp"}
+	]`
+	var entries []EntityRegistryEntry
+	if err := json.Unmarshal([]byte(raw), &entries); err != nil {
+		t.Fatalf("decode entity list: %v", err)
+	}
+	if len(entries) != 2 {
+		t.Fatalf("decoded %d entities, want 2", len(entries))
+	}
+	if got := string(entries[0].UniqueID); got != "1234567890" {
+		t.Errorf("entries[0].UniqueID = %q, want \"1234567890\"", got)
+	}
+	if got := string(entries[0].OriginalName); got != "42" {
+		t.Errorf("entries[0].OriginalName = %q, want \"42\"", got)
+	}
+	if got := string(entries[1].UniqueID); got != "abc-123" {
+		t.Errorf("entries[1].UniqueID = %q, want \"abc-123\"", got)
+	}
+}

--- a/internal/integrations/homeassistant/entity_metadata.go
+++ b/internal/integrations/homeassistant/entity_metadata.go
@@ -264,7 +264,7 @@ func applyEntityDescription(meta *EntityMetadata, entry *EntityRegistryEntry, st
 		return
 	}
 	meta.Name = entry.Name
-	meta.OriginalName = entry.OriginalName
+	meta.OriginalName = string(entry.OriginalName)
 	meta.Aliases = append([]string(nil), entry.Aliases...)
 	if entry.Description != "" {
 		meta.Description = entry.Description
@@ -440,14 +440,14 @@ func (r EntityMetadataResolver) DeviceMetadata(device *DeviceRegistryEntry) *Ent
 func (r EntityMetadataResolver) deviceMetadata(device *DeviceRegistryEntry) *EntityDeviceMetadata {
 	out := &EntityDeviceMetadata{
 		ID:               device.ID,
-		Name:             device.Name,
-		NameByUser:       device.NameByUser,
-		Manufacturer:     device.Manufacturer,
-		Model:            device.Model,
-		ModelID:          device.ModelID,
+		Name:             string(device.Name),
+		NameByUser:       string(device.NameByUser),
+		Manufacturer:     string(device.Manufacturer),
+		Model:            string(device.Model),
+		ModelID:          string(device.ModelID),
 		SWVersion:        string(device.SWVersion),
 		HWVersion:        string(device.HWVersion),
-		SerialNumber:     device.SerialNumber,
+		SerialNumber:     string(device.SerialNumber),
 		AreaID:           device.AreaID,
 		ViaDeviceID:      device.ViaDeviceID,
 		EntryType:        device.EntryType,

--- a/internal/state/awareness/device_snapshot.go
+++ b/internal/state/awareness/device_snapshot.go
@@ -284,7 +284,7 @@ func resolveDevice(devices []homeassistant.DeviceRegistryEntry, query string) (h
 	}
 	// Exact (case-insensitive) name or user-assigned name.
 	for i := range devices {
-		if strings.EqualFold(devices[i].NameByUser, q) || strings.EqualFold(devices[i].Name, q) {
+		if strings.EqualFold(string(devices[i].NameByUser), q) || strings.EqualFold(string(devices[i].Name), q) {
 			return devices[i], nil, true
 		}
 	}
@@ -317,10 +317,10 @@ func resolveDevice(devices []homeassistant.DeviceRegistryEntry, query string) (h
 // label.
 func deviceDisplayName(device homeassistant.DeviceRegistryEntry) string {
 	if device.NameByUser != "" {
-		return device.NameByUser
+		return string(device.NameByUser)
 	}
 	if device.Name != "" {
-		return device.Name
+		return string(device.Name)
 	}
 	return device.ID
 }

--- a/internal/state/awareness/watchlist_unavailable.go
+++ b/internal/state/awareness/watchlist_unavailable.go
@@ -100,18 +100,18 @@ func applyIntegrationContext(payload map[string]any, platform string, registries
 // row does not leak empty keys into the payload.
 func compactDeviceInfo(d *homeassistant.DeviceRegistryEntry) map[string]any {
 	info := map[string]any{}
-	name := d.NameByUser
+	name := string(d.NameByUser)
 	if name == "" {
-		name = d.Name
+		name = string(d.Name)
 	}
 	if name != "" {
 		info["name"] = name
 	}
 	if d.Manufacturer != "" {
-		info["manufacturer"] = d.Manufacturer
+		info["manufacturer"] = string(d.Manufacturer)
 	}
 	if d.Model != "" {
-		info["model"] = d.Model
+		info["model"] = string(d.Model)
 	}
 	if d.SWVersion != "" {
 		info["sw_version"] = string(d.SWVersion)

--- a/internal/tools/ha_automation_tools.go
+++ b/internal/tools/ha_automation_tools.go
@@ -509,11 +509,11 @@ func (r *Registry) handleHARegistrySearch(ctx context.Context, args map[string]a
 				continue
 			}
 			score := queryScore(
-				device.NameByUser,
-				device.Name,
-				device.Manufacturer,
-				device.Model,
-				device.SerialNumber,
+				string(device.NameByUser),
+				string(device.Name),
+				string(device.Manufacturer),
+				string(device.Model),
+				string(device.SerialNumber),
 				areaMap[device.AreaID],
 				strings.Join(resolveNames(device.Labels, labelMap), " "),
 			)
@@ -523,10 +523,10 @@ func (r *Registry) handleHARegistrySearch(ctx context.Context, args map[string]a
 			matches = append(matches, scoredDevice{
 				match: haRegistryDeviceMatch{
 					DeviceID:      device.ID,
-					Name:          device.Name,
-					NameByUser:    device.NameByUser,
-					Manufacturer:  device.Manufacturer,
-					Model:         device.Model,
+					Name:          string(device.Name),
+					NameByUser:    string(device.NameByUser),
+					Manufacturer:  string(device.Manufacturer),
+					Model:         string(device.Model),
 					AreaID:        device.AreaID,
 					AreaName:      areaMap[device.AreaID],
 					LabelIDs:      device.Labels,
@@ -568,13 +568,13 @@ func (r *Registry) handleHARegistrySearch(ctx context.Context, args map[string]a
 
 			deviceName := ""
 			if device := deviceMap[entity.DeviceID]; device != nil {
-				deviceName = coalesce(device.NameByUser, device.Name)
+				deviceName = coalesce(string(device.NameByUser), string(device.Name))
 			}
 			friendlyName := friendlyNameForState(stateMap[entity.EntityID])
 			score := queryScore(
 				entity.EntityID,
 				entity.Name,
-				entity.OriginalName,
+				string(entity.OriginalName),
 				strings.Join(entity.Aliases, " "),
 				friendlyName,
 				deviceName,
@@ -593,7 +593,7 @@ func (r *Registry) handleHARegistrySearch(ctx context.Context, args map[string]a
 					EntityID:       entity.EntityID,
 					Domain:         domain,
 					Name:           entity.Name,
-					OriginalName:   entity.OriginalName,
+					OriginalName:   string(entity.OriginalName),
 					FriendlyName:   friendlyName,
 					DeviceID:       entity.DeviceID,
 					DeviceName:     deviceName,


### PR DESCRIPTION
## Why

Production hit a **second** decode failure of the same class as the `sw_version` one (#1028):

```
cannot unmarshal number into Go struct field DeviceRegistryEntry.identifiers of type string
```

This is the broader issue, not another one-off. Home Assistant types these device/entity fields as `str | None` but **does not strictly validate integration input**, so any of them can arrive as a bare number. Go's `encoding/json` then fails the **entire** `device_registry/list` (or `entity_registry/list`) decode on one bad field — breaking every device/entity-level tool. The crash is at *decode*, independent of whether we read the field: `unique_id` has no readers yet still took down the whole entity-registry decode.

So instead of fixing fields one at a time, generalize the tolerance across the whole integration-supplied surface.

## Audit + what changed

Extended the existing `flexString` (accepts string | number | bool | null, coerces to string) to **every integration-freeform field**:

- **`DeviceRegistryEntry`**: `manufacturer`, `model`, `model_id`, `name`, `name_by_user`, `serial_number` (plus `sw_version`/`hw_version` from #1028); the nested `identifiers` / `connections` tuples become `[][]flexString` (numeric elements inside the tuples were the new crash).
- **`EntityRegistryEntry`**: `unique_id`, `original_name`.

### Deliberately left as `string` (not integration-freeform)
- **Entity state** (`State`): HA always serializes `state` as a string even for numeric sensors, and `attributes` is already `map[string]any`.
- **Area / Floor / Label / Category / ConfigEntry registries**: HA-core-controlled (ids, names, icons, enums) — the operator/HA owns these, not integrations.
- **Entity/device ids, area_id, platform, entry_type, disabled_by, etc.**: HA-generated identifiers and enums.

### Not in scope (no occurrence observed)
The reverse direction — a numeric field arriving as a *string* — would need a `flexFloat`/`flexInt`. The only numeric decode targets (`logbook.when`, `floor.level`, category timestamps) are HA-core, not integration-set. Easy to add the same way if we ever see it; flexString covers 100% of observed crashes.

## Test plan

- [x] `TestDeviceRegistryEntry_AllIntegrationFieldsTolerateNumbers` — torture payload: **every** device field (and nested identifier/connection elements) decoded as a number, asserting no decode error and string coercion.
- [x] `TestEntityRegistryEntry_NumericFieldsTolerated` — numeric `unique_id` / `original_name`.
- [x] `TestDeviceRegistryEntry_NumericVersionDoesNotFailDecode` + `TestFlexString_UnmarshalJSON` (existing) still pass.
- [x] Conversions verified compiler-complete: changed the field types, then fixed every site `go build ./...` flagged (entity_metadata, ha_automation_tools, device_snapshot, watchlist_unavailable).
- [x] `just ci` green (no architecture-baseline drift).

Follows #1028 (the first instance, `sw_version`).