### PR TITLE
fix(ha): disambiguate the three entity-subscription tools; teach the unknown-loop error

### DIFF
--- a/internal/app/loop_focus_tools.go
+++ b/internal/app/loop_focus_tools.go
@@ -49,7 +49,7 @@ func buildLoopFocusToolsWithMutator(loopName string, mutator subscriptionMutator
 	return []looppkg.RuntimeTool{
 		{
 			Name:               "watch_entity",
-			Description:        "Add a Home Assistant entity to this loop's watched set. Its live state is injected into your context every iteration. Use history for compact rolling-window summaries, forecast for weather entities, ttl_seconds for time-bounded watches. The subscription is scoped to this loop only — other loops and conversations are unaffected. Changes persist across restart.",
+			Description:        "Add a Home Assistant entity to this loop's watched set. Its live state is injected into your context every iteration. Use history for compact rolling-window summaries, forecast for weather entities, ttl_seconds for time-bounded watches. The subscription is scoped to this loop only — other loops and conversations are unaffected. Changes persist across restart. Scope: this is the loop you are currently running; for an always-visible subscription in your own field of view use add_entity_subscription, and for a different named loop use update_entity_subscriptions.",
 			SkipContentResolve: true,
 			Parameters: map[string]any{
 				"type": "object",

--- a/internal/state/awareness/watchlist_tool_provider.go
+++ b/internal/state/awareness/watchlist_tool_provider.go
@@ -58,8 +58,8 @@ func (w *WatchlistTools) Tools() []*tools.Tool {
 		{
 			Name: "add_entity_subscription",
 			Description: "Subscribe to a Home Assistant entity so its live state is injected into the model's context. " +
-				"This tool adds always-visible subscriptions: the entity appears in every turn, regardless of which loop or capability tags are active. " +
-				"For loop-scoped subscriptions, use update_entity_subscriptions (by name) or watch_entity (from inside the loop's own turn). " +
+				"This tool adds always-visible subscriptions: the entity appears on every turn regardless of which loop or capability tags are active — this is how you, or a conversation, watch an entity in your own field of view. " +
+				"For a specific named loop's view use update_entity_subscriptions; from inside a loop's own turn use watch_entity. " +
 				"Optional tags carry lens-style classifiers on the subscription itself for future filtering; they no longer act as a scope binding. " +
 				"Use ttl_seconds for subscriptions that should expire after a bounded task. Use history to include historical state snapshots at specific intervals. Use forecast for weather entities when future weather context is needed.",
 			Parameters: map[string]any{

--- a/internal/tools/loop_subscription_tools.go
+++ b/internal/tools/loop_subscription_tools.go
@@ -2,6 +2,7 @@ package tools
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -25,8 +26,9 @@ import (
 func (r *Registry) registerUpdateEntitySubscriptions() {
 	r.Register(&Tool{
 		Name: "update_entity_subscriptions",
-		Description: "Add or remove Home Assistant entities from a running loop's subscription set. " +
-			"Use this when you want a peer loop or conversation to start (or stop) seeing specific entities in its context every iteration — for example, when the core loop learns that a curate loop should also watch a newly-relevant sensor. " +
+		Description: "Add or remove Home Assistant entities from a specific named loop's subscription set. " +
+			"Use this to make a peer loop start (or stop) seeing specific entities in its context every iteration — for example, when the core loop learns that a curate loop should also watch a newly-relevant sensor. " +
+			"Scope: this targets a NAMED loop only. To watch an entity in your own always-visible context (what a conversation uses for itself), use add_entity_subscription instead — a conversation is not a loop and cannot be named here. " +
 			"From inside the running loop's own iteration, prefer the scoped watch_entity / unwatch_entity tools surfaced on that loop's tool list; those don't need the loop name because it is baked in. " +
 			"Both add and remove are optional and may be combined in one call; at least one must carry entries. Removes are applied before adds, so re-adding the same entity with new options is a single round-trip. " +
 			"Add items mirror thane_curate.entities (entity_id with optional history, forecast, ttl_seconds). Remove items are bare entity_id strings. " +
@@ -108,6 +110,15 @@ func (r *Registry) handleUpdateEntitySubscriptions(ctx context.Context, args map
 		return applySubscriptionDelta(current, addList, removeList, time.Now().UTC()), nil
 	})
 	if err != nil {
+		// Teach the next move (docs/model-facing-tools.md §4): the most
+		// common miss is aiming this loop-scoped tool at a conversation
+		// (passing a conversation/session id as name). Point at the
+		// always-visible tool for own-context watches and the loop lister
+		// for targeting a real loop, instead of a bare "unknown definition".
+		var unknown *looppkg.UnknownDefinitionError
+		if errors.As(err, &unknown) {
+			return "", fmt.Errorf("no loop definition named %q; update_entity_subscriptions targets a specific named loop's watch set, not your own context (a conversation is not a loop); for an always-visible subscription that follows you every turn use add_entity_subscription, or pick a real loop name from loop_definition_list", name)
+		}
 		return "", err
 	}
 

--- a/internal/tools/loop_subscription_tools.go
+++ b/internal/tools/loop_subscription_tools.go
@@ -117,7 +117,12 @@ func (r *Registry) handleUpdateEntitySubscriptions(ctx context.Context, args map
 		// for targeting a real loop, instead of a bare "unknown definition".
 		var unknown *looppkg.UnknownDefinitionError
 		if errors.As(err, &unknown) {
-			return "", fmt.Errorf("no loop definition named %q; update_entity_subscriptions targets a specific named loop's watch set, not your own context (a conversation is not a loop); for an always-visible subscription that follows you every turn use add_entity_subscription, or pick a real loop name from loop_definition_list", name)
+			// Wrap the source error with %w so the causal chain survives for
+			// any future errors.As/Is, while the message still teaches the
+			// next move. The wrapped error leads — it already names the loop
+			// (`loop: unknown definition "X"`) — so the guidance follows
+			// without duplicating it.
+			return "", fmt.Errorf("%w; update_entity_subscriptions targets a specific named loop's watch set, not your own context (a conversation is not a loop); for an always-visible subscription that follows you every turn use add_entity_subscription, or pick a real loop name from loop_definition_list", err)
 		}
 		return "", err
 	}

--- a/internal/tools/loop_subscription_tools_test.go
+++ b/internal/tools/loop_subscription_tools_test.go
@@ -125,6 +125,15 @@ func TestUpdateEntitySubscriptions_UnknownLoop(t *testing.T) {
 	if !strings.Contains(err.Error(), "no_such_loop") {
 		t.Errorf("error %q should name the missing loop", err)
 	}
+	// The error must teach the next move (docs/model-facing-tools.md §4):
+	// point to the always-visible tool for own-context watches and to the
+	// loop lister for targeting a real loop — the fork the model took wrong
+	// when it passed a conversation id as the loop name.
+	for _, want := range []string{"add_entity_subscription", "loop_definition_list"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("unknown-loop error %q should mention %q to teach the next move", err, want)
+		}
+	}
 }
 
 // TestUpdateEntitySubscriptions_AppliesToTaglessLoop covers the


### PR DESCRIPTION
## Why

A production Signal turn (request `r_8afadc7c222068e3`) showed the model unable to set up an entity subscription it actually had the tool for. Sequence from the request trace:

1. `list_entity_subscriptions` ✅ (so the watchlist provider *was* on its surface)
2. `update_entity_subscriptions {name: "signal-15124232707", …}` ❌ → `loop: unknown definition "signal-15124232707"` (it passed the *conversation id* as a loop name)
3. fell back to a real loop and succeeded — but concluded the "conversation-wide add tool isn't on my surface," **never trying `add_entity_subscription`**, which was available the whole time.

Root cause is **naming, not a missing tool**: three overlapping families all mean "subscribe an entity," with no decision guidance and a dead-end error:

| Tool | Scope |
|---|---|
| `add_/remove_/list_entity_subscription(s)` | your own **always-visible** view (every turn) |
| `update_entity_subscriptions` | a **named loop's** view |
| `watch_entity` / `unwatch_entity` | the **current loop** |

The `update_entity_subscriptions` description even *claimed it could target a "conversation"* — it can't (a conversation isn't a loop), and that false hint is exactly the fork the model took.

## What changed (model-facing — follows `docs/model-facing-tools.md`)

- **Teach the unknown-loop error** (§4 "errors must teach the next move"): `update_entity_subscriptions` now returns *"no loop definition named X; …for an always-visible subscription that follows you every turn use `add_entity_subscription`, or pick a real loop name from `loop_definition_list`"* instead of the bare unknown-definition error.
- **Scope cross-reference on all three families** so the model can pick the right one — and explicit that the conversational agent's own field of view = the always-visible tools.
- **Fixed the misleading "conversation" wording** in `update_entity_subscriptions`.

No new tool or per-conversation scope — `add_entity_subscription` already *is* the "my own view" path; the surface just never pointed there when the model took the wrong fork.

## Test plan
- [x] Extended `TestUpdateEntitySubscriptions_UnknownLoop` to assert the error names both `add_entity_subscription` and `loop_definition_list`.
- [x] Existing subscription tool tests still pass.
- [x] `just ci` green (no architecture-baseline drift).

## Follow-up (not in this PR)
The agent's own KB "doctrine" on subscriptions is also out of sync with the surface (it's what left her believing the tool was missing). That's prod KB content, not repo code — I can reconcile it separately if you want.