### PR TITLE
fix(archivist): gate enqueue on session origin; fix the ack prompt

### DIFF
--- a/internal/app/archivist_session_close_wake.go
+++ b/internal/app/archivist_session_close_wake.go
@@ -4,34 +4,68 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/nugget/thane-ai-agent/internal/channels/messages"
 	"github.com/nugget/thane-ai-agent/internal/runtime/archivist"
 )
 
-// sessionCloseEnqueueTimeout caps how long the ArchiveStore.EndSession
-// callback waits to enqueue archivist work. The callback runs
-// synchronously in the goroutine that closed the session, so it must not
-// block forever if the queue store is locked or shutting down.
-const sessionCloseEnqueueTimeout = 2 * time.Second
-
-// enqueueSessionCloseWork records a closed session as a pending work item
-// in the archivist's durable queue, keyed dedup on "session:<id>" so the
-// same session can't pile up. It does NOT wake the archivist — the
-// archivist is a self-paced consumer that drains its queue on its own
-// cadence (issue #1024). This is wired into both the real-time
-// EndSession callback and the summarizer's backstop scan; sharing it
-// keeps the enqueue shape identical on both paths.
+// archivistAutomationOrigins are conversation-id prefixes whose sessions
+// carry no dossier-worthy evidence: autonomous service-loop iterations,
+// scheduled-task runs, metacognitive bookkeeping, and auxiliary utility
+// traffic. Sessions from these origins are never enqueued for the archivist.
 //
-// Signature matches the summarizer's wake-callback type so it can be
-// registered there unchanged.
-func (a *App) enqueueSessionCloseWork(ctx context.Context, sessionID, reason string) error {
+// This is a denylist on purpose — any origin NOT named here (interactive
+// channels like signal-/email-, delegate work, external events) is treated
+// as archivable, so the rare substantive case is never silently dropped.
+// The archivist-queue flood that motivated this (issue #1024) was exactly
+// these: loop- service iterations, sched- automation, metacog- bookkeeping.
+var archivistAutomationOrigins = []string{
+	"loop-",    // self-paced service loops (metacognitive, pollers, HA automations)
+	"sched-",   // scheduled tasks
+	"metacog-", // metacognitive bookkeeping
+	"owu-",     // open-webui auxiliary requests
+}
+
+// isArchivableSession reports whether a closed session is worth folding into
+// dossiers, judged solely from its conversation origin — a deterministic
+// property, no LLM call or content scan. Automation/auxiliary origins are
+// skipped; everything else is archivable.
+func isArchivableSession(conversationID string) bool {
+	for _, prefix := range archivistAutomationOrigins {
+		if strings.HasPrefix(conversationID, prefix) {
+			return false
+		}
+	}
+	return true
+}
+
+// enqueueSessionCloseWork records a closed session as a pending work item in
+// the archivist's durable queue, keyed dedup on "session:<id>" so the same
+// session can't pile up. It does NOT wake the archivist — the archivist is a
+// self-paced consumer that drains its queue on its own cadence (issue #1024).
+//
+// Only sessions with conversational substance are enqueued: autonomous,
+// scheduled, and auxiliary origins are filtered out by [isArchivableSession]
+// so the archivist isn't drowned in automation bookkeeping. The signature
+// matches the summarizer's enqueue hook, which is the single enqueue gate
+// (it processes every closed session and carries the conversation origin).
+func (a *App) enqueueSessionCloseWork(ctx context.Context, sessionID, conversationID, reason string) error {
 	if a.loopQueue == nil {
 		return fmt.Errorf("loop queue not configured")
 	}
 	if sessionID == "" {
 		return fmt.Errorf("empty session_id")
+	}
+	if !isArchivableSession(conversationID) {
+		if a.logger != nil {
+			a.logger.Debug("archivist: skipping non-archival session origin",
+				"session_id", sessionID,
+				"conversation_id", conversationID,
+			)
+		}
+		return nil
 	}
 	payload := messages.LoopNotifyPayload{
 		Events: []messages.LoopEventPayload{{
@@ -40,8 +74,9 @@ func (a *App) enqueueSessionCloseWork(ctx context.Context, sessionID, reason str
 			ID:         sessionID,
 			ObservedAt: time.Now().UTC(),
 			Metadata: map[string]string{
-				"session_id": sessionID,
-				"reason":     reason,
+				"session_id":      sessionID,
+				"conversation_id": conversationID,
+				"reason":          reason,
 			},
 		}},
 	}
@@ -55,17 +90,19 @@ func (a *App) enqueueSessionCloseWork(ctx context.Context, sessionID, reason str
 	return nil
 }
 
-// wireSessionCloseToArchivistQueue installs the [memory.ArchiveStore]
-// session-close callback that enqueues archivist work every time a
-// session ends, AND the equivalent backstop on the SummarizerWorker scan
-// path. The EndSession callback is real-time; the summarizer scan catches
-// any session whose real-time enqueue was dropped (queue locked, restart
-// mid-callback). Both paths enqueue — neither wakes the archivist.
+// wireSessionCloseToArchivistQueue makes the SummarizerWorker the single gate
+// that enqueues archivist work. The summarizer already processes every closed
+// session (to stamp its title/tags) and has the full session context —
+// including the conversation origin the archival filter keys on — so it is the
+// natural and only place to decide what becomes dossier work.
 //
-// Skipped when archivist.enabled is false or the queue is absent: there
-// is no consumer, so don't accumulate work. The summarizer still stamps
-// session metadata itself either way (it no longer defers that to the
-// archivist — see [memory.SummarizerWorker.summarizeSession]).
+// The former real-time EndSession callback was dropped: it saw only
+// sessionID/reason, so it could not apply the origin filter, and its
+// few-minutes latency advantage is irrelevant to the hourly, self-paced
+// archivist. One gate, not two (issue #1024).
+//
+// Skipped when archivist.enabled is false or the queue is absent: there is no
+// consumer, so don't accumulate work.
 func (a *App) wireSessionCloseToArchivistQueue() {
 	if a == nil || a.archiveStore == nil || a.loopQueue == nil {
 		return
@@ -73,37 +110,18 @@ func (a *App) wireSessionCloseToArchivistQueue() {
 	if a.cfg == nil || !a.cfg.Archivist.Enabled {
 		return
 	}
-
-	logger := a.logger
-
-	// Real-time path: EndSession callback.
-	a.archiveStore.SetSessionCloseCallback(func(sessionID, reason string) {
-		ctx, cancel := context.WithTimeout(context.Background(), sessionCloseEnqueueTimeout)
-		defer cancel()
-		if err := a.enqueueSessionCloseWork(ctx, sessionID, reason); err != nil {
-			// The summarizer scan re-enqueues anything the real-time
-			// path missed on its next pass; no further action here.
-			if logger != nil {
-				logger.Debug("archivist session-close enqueue failed (summarizer backstop will handle)",
-					"session_id", sessionID,
-					"reason", reason,
-					"error", err,
-				)
-			}
+	if a.summaryWorker == nil {
+		if a.logger != nil {
+			a.logger.Warn("archivist enabled but summarizer worker absent; no session-close enqueue path")
 		}
-	})
-
-	// Backstop path: summarizer scan re-enqueues anything the real-time
-	// path missed. The summarizer stamps metadata regardless.
-	if a.summaryWorker != nil {
-		a.summaryWorker.SetArchivistEnqueue(a.enqueueSessionCloseWork)
+		return
 	}
 
-	if logger != nil {
-		logger.Info("archivist session-close queue wired",
+	a.summaryWorker.SetArchivistEnqueue(a.enqueueSessionCloseWork)
+
+	if a.logger != nil {
+		a.logger.Info("archivist session-close queue wired (summarizer gate)",
 			"loop", archivist.DefinitionName,
-			"timeout", sessionCloseEnqueueTimeout,
-			"backstop", a.summaryWorker != nil,
 		)
 	}
 }

--- a/internal/app/archivist_session_close_wake.go
+++ b/internal/app/archivist_session_close_wake.go
@@ -22,10 +22,10 @@ import (
 // The archivist-queue flood that motivated this (issue #1024) was exactly
 // these: loop- service iterations, sched- automation, metacog- bookkeeping.
 var archivistAutomationOrigins = []string{
-	"loop-",    // self-paced service loops (metacognitive, pollers, HA automations)
-	"sched-",   // scheduled tasks
-	"metacog-", // metacognitive bookkeeping
-	"owu-",     // open-webui auxiliary requests
+	"loop-",         // self-paced service loops (metacognitive, pollers, HA automations)
+	"sched-",        // scheduled tasks
+	"metacog-",      // metacognitive bookkeeping
+	"owu-auxiliary", // open-webui auxiliary requests ONLY — real OWU chats are owu-<hash> and stay archivable
 }
 
 // isArchivableSession reports whether a closed session is worth folding into

--- a/internal/app/archivist_session_close_wake_test.go
+++ b/internal/app/archivist_session_close_wake_test.go
@@ -105,11 +105,12 @@ func TestIsArchivableSession(t *testing.T) {
 		{"email-handler-1", true},
 		{"delegate-abc", true},
 		{"media-feed-1", true},
-		{"", true}, // unknown/empty origin defaults archivable (don't drop substance)
+		{"owu-a1b2c3d4e5f6a7b8", true}, // real OWU chat (owu-<hash>) is substantive
+		{"", true},                     // unknown/empty origin defaults archivable (don't drop substance)
 		{"loop-metacognitive-1-2", false},
 		{"sched-task-exec", false},
 		{"metacog-1", false},
-		{"owu-auxiliary", false},
+		{"owu-auxiliary", false}, // only the fixed auxiliary id is skipped
 	}
 	for _, tc := range cases {
 		if got := isArchivableSession(tc.conv); got != tc.want {

--- a/internal/app/archivist_session_close_wake_test.go
+++ b/internal/app/archivist_session_close_wake_test.go
@@ -31,8 +31,9 @@ func newQueueTestApp(t *testing.T) (*App, *loopqueue.Store) {
 func TestEnqueueSessionCloseWork(t *testing.T) {
 	a, store := newQueueTestApp(t)
 	const sessionID = "019e6867-00fc-7d6d-88be-58fab5c173c4"
+	const convID = "signal-15125551234" // interactive origin → archivable
 
-	if err := a.enqueueSessionCloseWork(context.Background(), sessionID, "idle_timeout"); err != nil {
+	if err := a.enqueueSessionCloseWork(context.Background(), sessionID, convID, "idle_timeout"); err != nil {
 		t.Fatalf("enqueueSessionCloseWork: %v", err)
 	}
 
@@ -52,7 +53,7 @@ func TestEnqueueSessionCloseWork(t *testing.T) {
 	}
 
 	// Re-enqueue of the same session coalesces (dedup), not duplicates.
-	if err := a.enqueueSessionCloseWork(context.Background(), sessionID, "again"); err != nil {
+	if err := a.enqueueSessionCloseWork(context.Background(), sessionID, convID, "again"); err != nil {
 		t.Fatalf("re-enqueue: %v", err)
 	}
 	if n, _ := store.PendingCount(context.Background(), archivist.DefinitionName); n != 1 {
@@ -62,7 +63,57 @@ func TestEnqueueSessionCloseWork(t *testing.T) {
 
 func TestEnqueueSessionCloseWork_EmptySessionID(t *testing.T) {
 	a, _ := newQueueTestApp(t)
-	if err := a.enqueueSessionCloseWork(context.Background(), "", "x"); err == nil {
+	if err := a.enqueueSessionCloseWork(context.Background(), "", "signal-x", "x"); err == nil {
 		t.Fatal("enqueueSessionCloseWork with empty session_id should error")
+	}
+}
+
+// TestEnqueueSessionCloseWork_SkipsAutomationOrigins verifies the archival
+// policy (issue #1024): sessions from autonomous/automation/auxiliary origins
+// are not enqueued for the archivist, so it isn't drowned in service-loop and
+// scheduled-task bookkeeping — while an interactive origin still enqueues.
+func TestEnqueueSessionCloseWork_SkipsAutomationOrigins(t *testing.T) {
+	a, store := newQueueTestApp(t)
+	for _, convID := range []string{
+		"loop-metacognitive-3-1780000000000",
+		"sched-019c8366-b115-7203-88f7-b765f7c068be-019d6487",
+		"metacog-abc",
+		"owu-auxiliary",
+	} {
+		if err := a.enqueueSessionCloseWork(context.Background(), "sess-"+convID, convID, "idle_timeout"); err != nil {
+			t.Fatalf("enqueue %s: %v", convID, err)
+		}
+	}
+	if n, _ := store.PendingCount(context.Background(), archivist.DefinitionName); n != 0 {
+		t.Errorf("automation-origin sessions enqueued %d items, want 0", n)
+	}
+
+	if err := a.enqueueSessionCloseWork(context.Background(), "sess-real", "signal-15125551234", "idle_timeout"); err != nil {
+		t.Fatalf("enqueue interactive: %v", err)
+	}
+	if n, _ := store.PendingCount(context.Background(), archivist.DefinitionName); n != 1 {
+		t.Errorf("after interactive enqueue, pending = %d, want 1", n)
+	}
+}
+
+func TestIsArchivableSession(t *testing.T) {
+	cases := []struct {
+		conv string
+		want bool
+	}{
+		{"signal-15125551234", true},
+		{"email-handler-1", true},
+		{"delegate-abc", true},
+		{"media-feed-1", true},
+		{"", true}, // unknown/empty origin defaults archivable (don't drop substance)
+		{"loop-metacognitive-1-2", false},
+		{"sched-task-exec", false},
+		{"metacog-1", false},
+		{"owu-auxiliary", false},
+	}
+	for _, tc := range cases {
+		if got := isArchivableSession(tc.conv); got != tc.want {
+			t.Errorf("isArchivableSession(%q) = %v, want %v", tc.conv, got, tc.want)
+		}
 	}
 }

--- a/internal/model/prompts/archivist.go
+++ b/internal/model/prompts/archivist.go
@@ -62,9 +62,13 @@ and notes — NOT the work queue (the durable queue holds that).
    Structure each claim with an evidence citation — an archive session
    ID, a fact category+key, a document ref, or a working-memory
    conversation ID — so a reader can check any claim against its source.
-4. **Ack what you finished** — Call ` + "`queue_ack`" + ` with each item's subject
-   once its evidence is folded in. Unacked items return next iteration,
-   so an interrupted pass is safe.
+4. **Ack every item you handle** — Call ` + "`queue_ack`" + ` with each item's
+   subject once you have handled it, whether or not it produced a dossier.
+   Acking means "I am done with this item," not "I created a dossier": a
+   session with nothing worth folding is still acked — read it, decide there
+   is nothing, ack it. Unacked items return every iteration forever and
+   starve the queue (an empty item at the head blocks everything behind it),
+   so never leave a handled item unacked.
 5. **Enqueue what you discovered** — When folding a subject in surfaces
    a related subject worth its own dossier (a connected entity, a sibling
    area), call ` + "`queue_enqueue`" + ` to add it to your queue for a future

--- a/internal/model/prompts/archivist_test.go
+++ b/internal/model/prompts/archivist_test.go
@@ -43,7 +43,7 @@ func TestArchivistPrompt_SingleDrainMode(t *testing.T) {
 	}
 	for _, phrase := range []string{
 		"Pull your queue",
-		"Ack what you finished",
+		"Ack every item you handle",
 		"summarizer owns",
 		"do NOT spawn loops",
 	} {

--- a/internal/state/memory/summarizer.go
+++ b/internal/state/memory/summarizer.go
@@ -98,7 +98,7 @@ type SummarizerWorker struct {
 	// session's own metadata. Wired by the app when the archivist loop is
 	// enabled (#989, #1024). When unset, the enqueue is simply skipped;
 	// metadata generation is unaffected either way.
-	archivistEnqueue func(ctx context.Context, sessionID, reason string) error
+	archivistEnqueue func(ctx context.Context, sessionID, conversationID, reason string) error
 
 	cancel context.CancelFunc
 	done   chan struct{}
@@ -128,7 +128,7 @@ func NewSummarizerWorker(store *ArchiveStore, llmClient llm.Client, rtr *router.
 // disables the enqueue side effect.
 //
 // Called from the app wiring whenever the archivist loop is enabled.
-func (w *SummarizerWorker) SetArchivistEnqueue(cb func(ctx context.Context, sessionID, reason string) error) {
+func (w *SummarizerWorker) SetArchivistEnqueue(cb func(ctx context.Context, sessionID, conversationID, reason string) error) {
 	w.archivistEnqueue = cb
 }
 
@@ -366,7 +366,7 @@ func (w *SummarizerWorker) summarizeSession(ctx context.Context, sess *Session) 
 	// session forever; generating metadata unconditionally fixes that
 	// and removes the wake-amplification that DoSed the loop.)
 	if w.archivistEnqueue != nil {
-		if err := w.archivistEnqueue(ctx, sess.ID, sess.EndReason); err != nil {
+		if err := w.archivistEnqueue(ctx, sess.ID, sess.ConversationID, sess.EndReason); err != nil {
 			w.logger.Debug("archivist enqueue failed (session still summarized here)",
 				"session", ShortID(sess.ID),
 				"error", err,

--- a/internal/state/memory/summarizer_test.go
+++ b/internal/state/memory/summarizer_test.go
@@ -742,7 +742,7 @@ func TestWorker_ArchivistEnqueueStillSummarizes(t *testing.T) {
 		BatchSize:    10,
 	}
 	w := NewSummarizerWorker(store, mock, rtr, slog.Default(), cfg)
-	w.SetArchivistEnqueue(func(_ context.Context, sessionID, _ string) error {
+	w.SetArchivistEnqueue(func(_ context.Context, sessionID, _, _ string) error {
 		mu.Lock()
 		enqueued = append(enqueued, sessionID)
 		mu.Unlock()
@@ -809,7 +809,7 @@ func TestWorker_ArchivistEnqueueFailureStillSummarizes(t *testing.T) {
 		BatchSize:    10,
 	}
 	w := NewSummarizerWorker(store, mock, rtr, slog.Default(), cfg)
-	w.SetArchivistEnqueue(func(_ context.Context, _, _ string) error {
+	w.SetArchivistEnqueue(func(_ context.Context, _, _, _ string) error {
 		return fmt.Errorf("simulated archivist queue unavailable")
 	})
 


### PR DESCRIPTION
## Why

Audit of a live archivist run (`r_be6c2f3c57e05b3b`, queue depth **932**) found it **livelocked**: it re-read the same head-of-queue "no new email" sessions every pass, made zero forward progress, and acked nothing, while a 7-week backlog of automation sessions piled up behind. Joining the queue to the sessions table:

| Origin | Count | What |
|---|---|---|
| `loop-` | 714 | metacognitive iterations, hourly HA automations, supervisor reviews |
| `sched-` | 249 | scheduled tasks (incl. a long-disabled `email_poll` routine) |
| interactive | ~8 | the actually-substantive sessions |

So **99% of the archivist's work was automation exhaust.** Two root causes:

1. **The producer enqueued every closed session** with no notion of archival worth. The #1025 deploy's summarizer backstop then dumped ~7 weeks of accumulated unsummarized sessions into the brand-new queue at once.
2. **The ack prompt tied acking to producing a dossier** ("ack once its evidence is folded in"). A no-evidence session was never acked; `queue_pull` is read-only (Peek), so the same empty items returned at the head forever — the livelock.

## What changed

- **Archival policy at the producer** — `isArchivableSession` skips autonomous/automation/auxiliary origins (`loop-`, `sched-`, `metacog-`, `owu-`) by conversation-id prefix. Deterministic, no LLM, **default-allow** (a denylist) so the rare substantive case is never silently dropped — and interactive origins (`signal-`, `email-`, `delegate-`, …) still archive.
- **Summarizer is the single enqueue gate** — it already processes every closed session and carries the origin context the filter keys on. Dropped the blind real-time `EndSession` firehose, which couldn't filter (only had `sessionID`/`reason`) and whose few-minutes latency the hourly, self-paced archivist doesn't need. One gate, not two.
- **Ack prompt fixed** — ack *every* pulled item once handled, dossier or not. "Acking means 'I am done with this item,' not 'I created a dossier'" — empty items get read-and-acked instead of livelocking the head.

## Test plan
- [x] `TestEnqueueSessionCloseWork_SkipsAutomationOrigins` — `loop-`/`sched-`/`metacog-`/`owu-` enqueue 0 items; an interactive origin enqueues 1.
- [x] `TestIsArchivableSession` — origin table (interactive + empty → archivable; automation → skipped).
- [x] Existing enqueue/summarizer tests updated for the new `conversationID` signature; prompt test updated for the new ack wording.
- [x] `just ci` green (no architecture-baseline drift).

## Operational follow-up (not code)
The pre-existing **932-item backlog is a one-time historical flood** (everything `enqueued_at` today; sessions span 7 weeks). It needs a one-time purge — run with thane stopped (or via a maintenance step), **not** a hot write to the live WAL DB:

```sql
DELETE FROM loop_queue
WHERE consumer_loop = 'archivist'
  AND dedup_key IN (
    SELECT 'session:' || id FROM sessions
    WHERE substr(conversation_id, 1, instr(conversation_id,'-')-1)
          IN ('loop','sched','metacog','owu')
  );
```

That clears the ~960 automation rows and keeps the ~8 substantive ones. (Also worth deleting the disabled `email_poll` scheduler task — it's redundant with the deterministic Go email poller.)

Refs #1024