### PR TITLE
docs: drop drift-prone native-tool counts

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -62,7 +62,7 @@ complete onboarding guide for Home Assistant users.
 
 *What exactly does X do?*
 
-- **[Tools](reference/tools.md)** — All 80+ native tools by category
+- **[Tools](reference/tools.md)** — Native tools by category
 - **[CLI](reference/cli.md)** — Commands, flags, and config discovery
 - **[API & Endpoints](reference/api.md)** — Ports, protocols, web
   dashboard, CardDAV

--- a/docs/operating/homeassistant.md
+++ b/docs/operating/homeassistant.md
@@ -74,7 +74,7 @@ polling.
 
 ### MCP (ha-mcp)
 
-[ha-mcp](https://github.com/karimkhaleel/ha-mcp) provides 90+ HA tools via
+[ha-mcp](https://github.com/karimkhaleel/ha-mcp) provides a broad set of HA tools via
 the Model Context Protocol — search, state queries, service calls, camera
 images, automation traces, area registry, and more. Thane hosts ha-mcp as a
 stdio subprocess and bridges selected tools into the agent loop.

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -1,6 +1,6 @@
 # Tools Reference
 
-Thane provides ~150 native tools organized by tag. A tool is available
+Thane's native tools are organized by tag. A tool is available
 to a given turn only when one of its default tags is active — see
 [The Agent Loop](../understanding/agent-loop.md) for how tags flip on
 and off, and [Prompt Caching](../prompt-caching.md) for how tag choices
@@ -472,7 +472,7 @@ overrides; they do not have a compiled-in entry in
 
 The primary MCP server in typical deployments is
 [`ha-mcp`](https://github.com/karimkhaleel/ha-mcp), which exposes
-90+ Home Assistant tools beyond Thane's native set. `include_tools`
+a broad set of Home Assistant tools beyond Thane's native set. `include_tools`
 filtering in the config narrows the bridged surface.
 
 See [Delegation & MCP](../understanding/delegation.md) for

--- a/docs/talent-authoring.md
+++ b/docs/talent-authoring.md
@@ -9,7 +9,7 @@ companion (file naming, frontmatter shape, what kinds exist, regression
 tests). This page is about craft: how to mark a good trail.
 
 The mental model is trail marking. The model has access to a sprawling
-tool surface — somewhere between 130 and 200 native tools depending on
+tool surface — a large native tool set that varies by
 configuration, plus MCP additions. Talents are the trail blazes that
 say "this way for that kind of work" without trying to be the whole
 map. A good talent lowers the cost of finding the right tool in the

--- a/docs/understanding/agent-loop.md
+++ b/docs/understanding/agent-loop.md
@@ -128,7 +128,7 @@ indexing, provenance, and signature policy.
 ## Capability Tags
 
 Tags are the mechanism that keeps the agent loop efficient. Instead of
-loading 80+ tools on every request, tags gate tools and talents by semantic
+loading every tool on every request, tags gate tools and talents by semantic
 domain.
 
 ### Configuration


### PR DESCRIPTION
## What
Remove hardcoded native-tool counts from the docs. An audit confirms the tool glossary is otherwise current.

## Why
`docs/reference/tools.md` was suspected of drifting. Diffed against the authoritative `internal/model/toolcatalog/catalog.go`:

- **Membership:** 157 documented tools == 157 in the catalog — zero missing, zero stale (both directions).
- **Tag placement:** clean — no tool is filed under a tag the catalog doesn't assign it; every non-coarse tag has a section.

So the content is in sync. The only inaccuracy was the **counts** — which even disagreed with each other (index said "80+", the doc itself said "~150"; actual is 157). They're low-value and a standing maintenance burden, so they're removed rather than corrected.

## Changes
- `docs/README.md` — "All 80+ native tools by category" → "Native tools by category"
- `docs/reference/tools.md` — drop "~150 native tools" + MCP "90+ HA tools"
- `docs/understanding/agent-loop.md` — "loading 80+ tools" → "loading every tool"
- `docs/talent-authoring.md` — "130 and 200 native tools" → "a large native tool set"
- `docs/operating/homeassistant.md` — ha-mcp "90+ HA tools" → "a broad set of HA tools"

## Kept intentionally
- `history.md` milestone counts — point-in-time record, not maintained for currency
- `tool-and-talent-audit.md` thresholds ("7+ tools → tree") — authoring rubric, not an inventory
- `architecture.md` / `agent-loop.md` "~15–20 tools" — teaches tag-gating (the gated/active surface, stable)

## Test plan
- [x] `just ci` green (docs-only)