### PR TITLE
feat(platform): in-process memory guard

### DIFF
--- a/examples/config.example.yaml
+++ b/examples/config.example.yaml
@@ -40,6 +40,14 @@ ollama_api:
 #   enabled: false
 #   providers: {}
 #
+# MemoryGuard watches process memory and restarts thane before a leak
+# can OOM the host (writing a heap profile first). Opt-in.
+memory_guard:
+  enabled: false
+  soft_limit_mb: 0
+  hard_limit_mb: 0
+  profile_dir: ""
+  interval_seconds: 0
 # HomeAssistant configures the connection to a Home Assistant instance.
 homeassistant:
   url: https://your-homeassistant.local:8123

--- a/internal/app/serve.go
+++ b/internal/app/serve.go
@@ -3,7 +3,10 @@ package app
 import (
 	"context"
 	"fmt"
+	"path/filepath"
 	"time"
+
+	"github.com/nugget/thane-ai-agent/internal/platform/memguard"
 )
 
 // Serve starts the API server(s), registers signal handlers for graceful
@@ -42,6 +45,23 @@ func (a *App) Serve(ctx context.Context) error {
 			}
 		}
 	}()
+
+	// Memory guard: write a heap profile and gracefully restart before a
+	// leak can OOM the host. Opt-in; the supervising wrapper relaunches thane
+	// after the graceful exit (internal/platform/memguard).
+	if a.cfg.MemoryGuard.Enabled {
+		profileDir := a.cfg.MemoryGuard.ProfileDir
+		if profileDir == "" {
+			profileDir = filepath.Join(a.cfg.DataDir, "profiles")
+		}
+		guard := memguard.New(memguard.Config{
+			SoftLimitMB: a.cfg.MemoryGuard.SoftLimitMB,
+			HardLimitMB: a.cfg.MemoryGuard.HardLimitMB,
+			ProfileDir:  profileDir,
+			Interval:    time.Duration(a.cfg.MemoryGuard.IntervalSeconds) * time.Second,
+		}, a.logger)
+		go guard.Start(ctx)
+	}
 
 	// Start optional servers before the shutdown goroutine so they are
 	// available to drain when shutdown fires.

--- a/internal/platform/config/config.go
+++ b/internal/platform/config/config.go
@@ -120,6 +120,10 @@ type Config struct {
 	// Companion configures native companion app connections.
 	Companion CompanionConfig `yaml:"companion"`
 
+	// MemoryGuard watches process memory and restarts thane before a leak
+	// can OOM the host (writing a heap profile first). Opt-in.
+	MemoryGuard MemoryGuardConfig `yaml:"memory_guard"`
+
 	// HomeAssistant configures the connection to a Home Assistant instance.
 	HomeAssistant HomeAssistantConfig `yaml:"homeassistant"`
 
@@ -633,6 +637,17 @@ func (c CardDAVConfig) Configured() bool {
 type CompanionConfig struct {
 	Enabled   bool                               `yaml:"enabled"`
 	Providers map[string]CompanionProviderConfig `yaml:"providers"`
+}
+
+// MemoryGuardConfig configures the in-process memory guard
+// (internal/platform/memguard). Opt-in: Enabled defaults false. Numeric
+// fields default to soft 1024 MB / hard 2048 MB / 15s poll when unset.
+type MemoryGuardConfig struct {
+	Enabled         bool   `yaml:"enabled"`
+	SoftLimitMB     int    `yaml:"soft_limit_mb"`
+	HardLimitMB     int    `yaml:"hard_limit_mb"`
+	ProfileDir      string `yaml:"profile_dir"`
+	IntervalSeconds int    `yaml:"interval_seconds"`
 }
 
 // CompanionProviderConfig defines the tokens for a single account identity.

--- a/internal/platform/config/config.go
+++ b/internal/platform/config/config.go
@@ -640,8 +640,10 @@ type CompanionConfig struct {
 }
 
 // MemoryGuardConfig configures the in-process memory guard
-// (internal/platform/memguard). Opt-in: Enabled defaults false. Numeric
-// fields default to soft 1024 MB / hard 2048 MB / 15s poll when unset.
+// (internal/platform/memguard). Opt-in: Enabled defaults false. Zero-valued
+// numeric fields are defaulted by the guard at startup (memguard.New) —
+// soft 1024 MB / hard 2048 MB / 15s poll — not by config Load, so the Config
+// object does not hold these effective defaults after loading.
 type MemoryGuardConfig struct {
 	Enabled         bool   `yaml:"enabled"`
 	SoftLimitMB     int    `yaml:"soft_limit_mb"`

--- a/internal/platform/memguard/memguard.go
+++ b/internal/platform/memguard/memguard.go
@@ -1,0 +1,161 @@
+// Package memguard is an in-process memory guard. It watches the process's
+// own memory use and, before a leak can OOM the host, (1) writes a heap
+// profile so the leak can be diagnosed and (2) triggers a graceful shutdown so
+// the supervising wrapper restarts thane clean.
+//
+// It exists because a leak in a single build (636aac6a) grew to ~6 GB and took
+// down the whole macOS host in 2026-06. The guard turns that
+// host-killing OOM into a benign restart with a heap profile on disk — and is
+// a permanent safety valve regardless of any single leak.
+//
+// Restart policy deliberately lives in the supervising wrapper, not here: the
+// guard only triggers the process's normal SIGTERM graceful-shutdown path and
+// exits; the wrapper relaunches thane.
+package memguard
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"runtime"
+	"runtime/pprof"
+	"syscall"
+	"time"
+)
+
+const mib = 1 << 20
+
+// Config controls the guard. Zero-valued numeric fields are filled with
+// defaults by New.
+type Config struct {
+	SoftLimitMB int           // write a heap profile when memory crosses this
+	HardLimitMB int           // graceful-restart when memory crosses this
+	ProfileDir  string        // directory heap profiles are written to
+	Interval    time.Duration // poll cadence
+}
+
+// Guard polls process memory on an interval and acts at two thresholds: a soft
+// limit that writes a heap profile (once per process lifetime) and a hard
+// limit that triggers a graceful restart.
+type Guard struct {
+	soft, hard uint64 // bytes
+	interval   time.Duration
+	profileDir string
+	logger     *slog.Logger
+
+	// Seams, swappable in tests so the guard can be exercised without real
+	// memory pressure, signals, or profiling.
+	readMem  func() uint64
+	dumpHeap func(path string) error
+	onHard   func()
+	now      func() time.Time
+
+	heapDumped bool
+	fired      bool
+}
+
+// New builds a Guard, applying defaults for any unset numeric fields. Soft
+// 1024 MB / hard 2048 MB / interval 15s are conservative for a process whose
+// healthy footprint is a few hundred MB; tune via config.
+func New(cfg Config, logger *slog.Logger) *Guard {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	if cfg.SoftLimitMB <= 0 {
+		cfg.SoftLimitMB = 1024
+	}
+	if cfg.HardLimitMB <= cfg.SoftLimitMB {
+		cfg.HardLimitMB = cfg.SoftLimitMB * 2
+	}
+	if cfg.Interval <= 0 {
+		cfg.Interval = 15 * time.Second
+	}
+	if cfg.ProfileDir == "" {
+		cfg.ProfileDir = os.TempDir()
+	}
+	g := &Guard{
+		soft:       uint64(cfg.SoftLimitMB) * mib,
+		hard:       uint64(cfg.HardLimitMB) * mib,
+		interval:   cfg.Interval,
+		profileDir: cfg.ProfileDir,
+		logger:     logger,
+		dumpHeap:   writeHeapProfile,
+		now:        time.Now,
+	}
+	g.readMem = func() uint64 {
+		var m runtime.MemStats
+		runtime.ReadMemStats(&m)
+		// Sys is total memory obtained from the OS — the closest cheap proxy
+		// for RSS, and it captures both heap-object and goroutine-stack growth.
+		return m.Sys
+	}
+	g.onHard = func() {
+		// Reuse the existing signal.NotifyContext graceful-shutdown path
+		// rather than wiring a second cancel; the wrapper restarts thane.
+		if p, err := os.FindProcess(os.Getpid()); err == nil {
+			_ = p.Signal(syscall.SIGTERM)
+		}
+	}
+	return g
+}
+
+// Start runs the guard until ctx is cancelled. Run it in a goroutine.
+func (g *Guard) Start(ctx context.Context) {
+	g.logger.Info("memory guard active",
+		"soft_mb", g.soft/mib, "hard_mb", g.hard/mib,
+		"interval", g.interval, "profile_dir", g.profileDir)
+	ticker := time.NewTicker(g.interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			g.check(g.readMem())
+		}
+	}
+}
+
+// check applies the threshold logic to one memory reading. It is separated
+// from the ticker loop so the behavior is unit-testable without real memory
+// pressure. The heap profile is written at most once per process lifetime (the
+// process restarts each leak cycle), and the hard action fires at most once.
+func (g *Guard) check(mem uint64) {
+	if g.fired {
+		return
+	}
+	if !g.heapDumped && mem >= g.soft {
+		g.heapDumped = true
+		path := filepath.Join(g.profileDir,
+			fmt.Sprintf("heap-%s-%dMB.pprof", g.now().UTC().Format("20060102T150405Z"), mem/mib))
+		if err := g.dumpHeap(path); err != nil {
+			g.logger.Warn("memory guard: heap profile failed", "error", err, "mem_mb", mem/mib)
+		} else {
+			g.logger.Warn("memory guard: soft limit crossed; wrote heap profile",
+				"mem_mb", mem/mib, "soft_mb", g.soft/mib, "path", path)
+		}
+	}
+	if mem >= g.hard {
+		g.fired = true
+		g.logger.Error("memory guard: hard limit reached; triggering graceful restart",
+			"mem_mb", mem/mib, "hard_mb", g.hard/mib)
+		g.onHard()
+	}
+}
+
+// writeHeapProfile GCs (for up-to-date stats, per the pprof docs) and writes a
+// heap profile to path, creating the directory if needed.
+func writeHeapProfile(path string) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	f, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	runtime.GC()
+	return pprof.WriteHeapProfile(f)
+}

--- a/internal/platform/memguard/memguard.go
+++ b/internal/platform/memguard/memguard.go
@@ -92,10 +92,14 @@ func New(cfg Config, logger *slog.Logger) *Guard {
 		return m.Sys
 	}
 	g.onHard = func() {
-		// Reuse the existing signal.NotifyContext graceful-shutdown path
-		// rather than wiring a second cancel; the wrapper restarts thane.
+		// Trigger the process's existing graceful-shutdown path: main.go's
+		// signal.Notify handler cancels the root context, which stops all
+		// goroutines (this guard included) and runs shutdown; the wrapper
+		// then restarts thane. A failed signal is logged, not swallowed.
 		if p, err := os.FindProcess(os.Getpid()); err == nil {
-			_ = p.Signal(syscall.SIGTERM)
+			if err := p.Signal(syscall.SIGTERM); err != nil {
+				g.logger.Error("memory guard: failed to signal graceful shutdown", "error", err)
+			}
 		}
 	}
 	return g
@@ -129,7 +133,8 @@ func (g *Guard) check(mem uint64) {
 	if !g.heapDumped && mem >= g.soft {
 		g.heapDumped = true
 		path := filepath.Join(g.profileDir,
-			fmt.Sprintf("heap-%s-%dMB.pprof", g.now().UTC().Format("20060102T150405Z"), mem/mib))
+			fmt.Sprintf("heap-%s-pid%d-%dMB.pprof",
+				g.now().UTC().Format("20060102T150405Z"), os.Getpid(), mem/mib))
 		if err := g.dumpHeap(path); err != nil {
 			g.logger.Warn("memory guard: heap profile failed", "error", err, "mem_mb", mem/mib)
 		} else {
@@ -146,16 +151,22 @@ func (g *Guard) check(mem uint64) {
 }
 
 // writeHeapProfile GCs (for up-to-date stats, per the pprof docs) and writes a
-// heap profile to path, creating the directory if needed.
+// heap profile to path with explicit 0o644 perms, creating the directory if
+// needed. The Close error is surfaced — on some filesystems it is the only
+// sign of a failed flush — unless a profile-write error already takes
+// precedence.
 func writeHeapProfile(path string) error {
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return err
 	}
-	f, err := os.Create(path)
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o644)
 	if err != nil {
 		return err
 	}
-	defer f.Close()
 	runtime.GC()
-	return pprof.WriteHeapProfile(f)
+	if err := pprof.WriteHeapProfile(f); err != nil {
+		f.Close() // best-effort; don't mask the write error
+		return err
+	}
+	return f.Close()
 }

--- a/internal/platform/memguard/memguard_test.go
+++ b/internal/platform/memguard/memguard_test.go
@@ -1,0 +1,77 @@
+package memguard
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// TestCheckThresholds drives check() across the soft and hard boundaries and
+// asserts the two invariants that matter: the heap profile is written exactly
+// once (on the first soft crossing), and the hard action fires exactly once.
+func TestCheckThresholds(t *testing.T) {
+	var dumps []string
+	var hardCalls int
+	g := New(Config{SoftLimitMB: 1000, HardLimitMB: 2000, ProfileDir: t.TempDir(), Interval: time.Hour}, nil)
+	g.dumpHeap = func(p string) error { dumps = append(dumps, p); return nil }
+	g.onHard = func() { hardCalls++ }
+	g.now = func() time.Time { return time.Unix(0, 0).UTC() }
+
+	g.check(500 * mib) // below soft — no action
+	if len(dumps) != 0 || hardCalls != 0 {
+		t.Fatalf("acted below soft: dumps=%d hard=%d", len(dumps), hardCalls)
+	}
+
+	g.check(1200 * mib) // first soft crossing — one dump, no hard
+	if len(dumps) != 1 {
+		t.Fatalf("soft crossing dumps=%d, want 1", len(dumps))
+	}
+	if hardCalls != 0 {
+		t.Fatalf("hard fired at soft crossing")
+	}
+
+	g.check(1500 * mib) // still above soft — no second dump
+	if len(dumps) != 1 {
+		t.Fatalf("dumped again above soft: dumps=%d, want 1", len(dumps))
+	}
+
+	g.check(2100 * mib) // hard crossing — fire once
+	if hardCalls != 1 {
+		t.Fatalf("hard hardCalls=%d, want 1", hardCalls)
+	}
+
+	g.check(3000 * mib) // already fired — no further action
+	if hardCalls != 1 {
+		t.Fatalf("hard fired again after firing: %d", hardCalls)
+	}
+}
+
+// TestNewDefaults verifies unset/invalid limits are repaired and hard > soft.
+func TestNewDefaults(t *testing.T) {
+	g := New(Config{}, nil)
+	if g.soft == 0 || g.hard <= g.soft {
+		t.Fatalf("bad defaults: soft=%d hard=%d", g.soft, g.hard)
+	}
+	// A hard <= soft is nonsensical; New must lift hard above soft.
+	g2 := New(Config{SoftLimitMB: 500, HardLimitMB: 400}, nil)
+	if g2.hard <= g2.soft {
+		t.Fatalf("hard not lifted above soft: soft=%d hard=%d", g2.soft, g2.hard)
+	}
+}
+
+// TestWriteHeapProfile confirms a real, non-empty heap profile lands at a
+// nested path (directory auto-created).
+func TestWriteHeapProfile(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "profiles", "heap.pprof")
+	if err := writeHeapProfile(p); err != nil {
+		t.Fatalf("writeHeapProfile: %v", err)
+	}
+	fi, err := os.Stat(p)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if fi.Size() == 0 {
+		t.Fatalf("heap profile is empty")
+	}
+}

--- a/scripts/architecture.baseline
+++ b/scripts/architecture.baseline
@@ -1,4 +1,4 @@
-packages=61
+packages=62
 interfaces=79
 large_files=47
 set_mutators=109


### PR DESCRIPTION
## What

Adds `internal/platform/memguard` — an opt-in, in-process memory guard. It polls the process's own memory (`runtime.MemStats.Sys`) on an interval and acts at two thresholds:

- **Soft** → writes a timestamped heap profile (`pprof.WriteHeapProfile`) for diagnosis, once per process lifetime.
- **Hard** → logs and triggers a graceful restart by self-`SIGTERM`-ing into the existing `signal.NotifyContext` shutdown path. The supervising wrapper relaunches thane.

## Why

On 2026-06 a leak in build `636aac6a` grew thane to ~6 GB and took down the whole macOS host — and because the supervising wrapper was itself memory-paused during the crisis, thane stayed down for days. The guard converts a host-killing OOM into a benign, self-healing restart that also leaves a heap profile on disk to find the leak. It's a permanent safety valve, independent of any single leak.

A static leak audit of the suspect subsystems came back inconclusive, so capturing a real heap profile under pressure is now the most reliable way to locate the leak — which is exactly what the soft-threshold dump provides.

## Design notes

- **Restart policy lives in the wrapper, not here.** memguard only triggers thane's normal graceful shutdown and exits; the `thane-agent-macos` wrapper owns relaunch. Clean boundary — no launchd, no in-process re-exec.
- **Opt-in.** Config-gated under `memory_guard:` (disabled by default). Numeric fields default to soft 1024 MB / hard 2048 MB / 15s poll when unset — conservative for a process whose healthy footprint is a few hundred MB.
- **`Sys` as the metric** — closest cheap proxy for RSS, and it captures both heap-object and goroutine-stack growth.
- Threshold logic is factored into a seam-injected `check()` so it's unit-tested without real memory pressure, signals, or profiling.

## Config

```yaml
memory_guard:
  enabled: true
  soft_limit_mb: 1024
  hard_limit_mb: 2048
  profile_dir: ""        # defaults to <data_dir>/profiles
  interval_seconds: 15
```

## Test plan

- [x] `just ci` green locally (build, `go test -race ./...`, architecture baseline updated for the new package)
- [x] Unit: soft writes one heap profile per episode; hard fires once; defaults repair `hard <= soft`; real heap profile lands non-empty
- [ ] Prod: enable in `config.yaml` on pocket, confirm the `memory guard active` log line, and verify a heap profile + clean restart when the hard limit trips
