### PR TITLE
fix(documents): cap document read size to prevent OOM

### DIFF
--- a/internal/state/documents/mutate.go
+++ b/internal/state/documents/mutate.go
@@ -298,8 +298,30 @@ func (s *Store) JournalUpdate(ctx context.Context, args JournalUpdateArgs) (*Mut
 	return mutationResultFromRecord("doc_journal_update", record, existed, windowHeading, windowKind), nil
 }
 
+// maxReadableDocumentBytes caps how much of a managed document Thane will read
+// into memory at once. Documents are markdown meant for LLM context; anything
+// larger is a runaway or corrupt artifact (e.g. a journal window that grew
+// without bound). Reading such a file whole risks OOMing the host — a single
+// 8 GB document did exactly that in 2026-06 — so the store refuses oversized
+// reads instead of allocating gigabytes.
+const maxReadableDocumentBytes = 32 << 20 // 32 MiB
+
+// readDocumentBytes reads a document file into memory, refusing any file larger
+// than maxReadableDocumentBytes so a pathological document cannot exhaust the
+// host's memory. Every document-file read funnels through here.
+func readDocumentBytes(absPath string) ([]byte, error) {
+	info, err := os.Stat(absPath)
+	if err != nil {
+		return nil, err
+	}
+	if info.Size() > maxReadableDocumentBytes {
+		return nil, fmt.Errorf("document %q is %d bytes, exceeding the maximum readable size of %d bytes; it is likely runaway or corrupt and must be truncated or removed before Thane can read it", filepath.Base(absPath), info.Size(), maxReadableDocumentBytes)
+	}
+	return os.ReadFile(absPath)
+}
+
 func (s *Store) readDocumentFile(absPath, root, relPath string) (*DocumentRecord, string, string, error) {
-	rawBytes, err := os.ReadFile(absPath)
+	rawBytes, err := readDocumentBytes(absPath)
 	if err != nil {
 		return nil, "", "", err
 	}

--- a/internal/state/documents/mutate.go
+++ b/internal/state/documents/mutate.go
@@ -3,6 +3,7 @@ package documents
 import (
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -306,18 +307,34 @@ func (s *Store) JournalUpdate(ctx context.Context, args JournalUpdateArgs) (*Mut
 // reads instead of allocating gigabytes.
 const maxReadableDocumentBytes = 32 << 20 // 32 MiB
 
-// readDocumentBytes reads a document file into memory, refusing any file larger
-// than maxReadableDocumentBytes so a pathological document cannot exhaust the
-// host's memory. Every document-file read funnels through here.
+// readDocumentBytes reads a document file into memory, refusing any document
+// larger than maxReadableDocumentBytes so a pathological file cannot exhaust
+// the host's memory. Every document-file read funnels through here.
+//
+// The cap is enforced during the read with io.LimitReader, not just by an
+// upfront stat: a file that grows or is swapped after the stat (TOCTOU) still
+// cannot allocate more than the cap. The stat is kept only as a fast path that
+// refuses an already-oversized file — reporting its actual size — without
+// opening it.
 func readDocumentBytes(absPath string) ([]byte, error) {
-	info, err := os.Stat(absPath)
+	if info, err := os.Stat(absPath); err == nil && info.Size() > maxReadableDocumentBytes {
+		return nil, fmt.Errorf("document %q is %d bytes, exceeding the maximum readable size of %d bytes; it is likely runaway or corrupt and must be truncated or removed before Thane can read it", filepath.Base(absPath), info.Size(), maxReadableDocumentBytes)
+	}
+	f, err := os.Open(absPath)
 	if err != nil {
 		return nil, err
 	}
-	if info.Size() > maxReadableDocumentBytes {
-		return nil, fmt.Errorf("document %q is %d bytes, exceeding the maximum readable size of %d bytes; it is likely runaway or corrupt and must be truncated or removed before Thane can read it", filepath.Base(absPath), info.Size(), maxReadableDocumentBytes)
+	defer f.Close()
+	// Read at most one byte past the cap so an over-cap file is detected
+	// without allocating the whole of a pathological file.
+	data, err := io.ReadAll(io.LimitReader(f, maxReadableDocumentBytes+1))
+	if err != nil {
+		return nil, err
 	}
-	return os.ReadFile(absPath)
+	if int64(len(data)) > maxReadableDocumentBytes {
+		return nil, fmt.Errorf("document %q exceeds the maximum readable size of %d bytes; it is likely runaway or corrupt and must be truncated or removed before Thane can read it", filepath.Base(absPath), maxReadableDocumentBytes)
+	}
+	return data, nil
 }
 
 func (s *Store) readDocumentFile(absPath, root, relPath string) (*DocumentRecord, string, string, error) {

--- a/internal/state/documents/mutate_document_ops.go
+++ b/internal/state/documents/mutate_document_ops.go
@@ -145,7 +145,7 @@ func (s *Store) Move(ctx context.Context, args MoveArgs) (*MoveResult, error) {
 		}
 		return nil, err
 	}
-	raw, err := os.ReadFile(srcAbsPath)
+	raw, err := readDocumentBytes(srcAbsPath)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil, fmt.Errorf("document not found: %s", args.Ref)
@@ -157,7 +157,7 @@ func (s *Store) Move(ctx context.Context, args MoveArgs) (*MoveResult, error) {
 	var originalDestinationRaw []byte
 	if _, err := os.Stat(dstAbsPath); err == nil {
 		destinationExists = true
-		originalDestinationRaw, err = os.ReadFile(dstAbsPath)
+		originalDestinationRaw, err = readDocumentBytes(dstAbsPath)
 		if err != nil {
 			if os.IsNotExist(err) {
 				return nil, fmt.Errorf("destination document disappeared during move: %s", args.DestinationRef)
@@ -231,7 +231,7 @@ func (s *Store) Copy(ctx context.Context, args CopyArgs) (*CopyResult, error) {
 		}
 		return nil, err
 	}
-	raw, err := os.ReadFile(srcAbsPath)
+	raw, err := readDocumentBytes(srcAbsPath)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil, fmt.Errorf("document not found: %s", args.Ref)

--- a/internal/state/documents/query.go
+++ b/internal/state/documents/query.go
@@ -318,7 +318,7 @@ func (s *Store) Section(ctx context.Context, ref string, selector string) (*Sect
 		}
 		return nil, fmt.Errorf("resolve document: %w", err)
 	}
-	raw, err := os.ReadFile(absPath)
+	raw, err := readDocumentBytes(absPath)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			return nil, fmt.Errorf("document not found: %s", ref)

--- a/internal/state/documents/read_bounds_test.go
+++ b/internal/state/documents/read_bounds_test.go
@@ -1,0 +1,44 @@
+package documents
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestReadDocumentBytes_RefusesOversize is the regression guard for the
+// 2026-06 incident: a loop output document grew to 8 GB and reading it whole
+// OOM-crashed the host. readDocumentBytes must refuse oversized files (by
+// stat, before allocating) while reading normal documents unchanged.
+func TestReadDocumentBytes_RefusesOversize(t *testing.T) {
+	dir := t.TempDir()
+
+	small := filepath.Join(dir, "small.md")
+	if err := os.WriteFile(small, []byte("# hello\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got, err := readDocumentBytes(small)
+	if err != nil {
+		t.Fatalf("normal document read failed: %v", err)
+	}
+	if string(got) != "# hello\n" {
+		t.Fatalf("normal document content = %q, want %q", got, "# hello\n")
+	}
+
+	// A sparse file one byte over the cap: Stat reports the apparent size, so
+	// the guard trips without writing or allocating the full size.
+	big := filepath.Join(dir, "big.md")
+	f, err := os.Create(big)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Truncate(maxReadableDocumentBytes + 1); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := readDocumentBytes(big); err == nil {
+		t.Fatalf("expected oversize document to be refused, got nil error")
+	}
+}

--- a/internal/state/documents/store.go
+++ b/internal/state/documents/store.go
@@ -334,7 +334,7 @@ func (s *Store) upsertFile(ctx context.Context, root, relPath string) error {
 		return fmt.Errorf("lookup indexed document: %w", err)
 	}
 
-	raw, err := os.ReadFile(absPath)
+	raw, err := readDocumentBytes(absPath)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## What

Adds a 32 MiB size guard to every document read in the store. `readDocumentBytes` stats the file first and refuses anything larger than `maxReadableDocumentBytes`; all six `os.ReadFile` sites in the `documents` package now route through it.

## Why — the prod OOM root cause

Production thane (`v0.9.2-522`, running the new memory guard) was OOM-crashing on a ~20-minute cycle. The heap profiles memguard captured pointed at a single 8 GB allocation:

```
8 GB (99.7%)  os.ReadFile
 ← documents.(*Store).readDocumentFile
 ← documents.(*Store).Read
 ← app.hydrateLoopOutputs.func1     (loop output-context hydration)
 ← loop.buildAgentTurn / buildTaskTurn
```

The `cota_weekend_observer` curate loop's journal output — `Obsidian/HPDE/Events/2026-05-30 HOD COTA.md` — had grown to **8.0 GB**. Every loop turn hydrated its declared-output context, which `os.ReadFile`'d the whole 8 GB document into memory, only truncating to 16 KB *after* the read. The allocation alone OOM'd the host.

This is why the static leak audit came back 0/20: it's an unbounded read of a runaway **data** artifact, not a leaking code pattern — invisible without the 8 GB file present.

## Behavior after the fix

A too-large document produces a clear error instead of allocating gigabytes:
- **Loop output-context hydration** catches the read error and marks the output `unavailable` — the loop keeps running.
- **Journal append / copy / move** ops fail cleanly with a message telling the operator the document is runaway and must be truncated.

The 32 MiB cap is far above any legitimate LLM-context document (≈8 M tokens) and far below the gigabyte scale that threatens the host.

## Out of scope (tracked follow-ups)

- **Growth bug:** `JournalUpdate` prunes whole *windows* but not *within* a window, so one active window can grow without bound — that's how the file reached 8 GB. Needs a within-window byte/entry cap.
- **Restart handoff:** memguard's graceful shutdown exits 0, and the macOS wrapper doesn't relaunch on a clean exit, so the guard's restarts left thane down. Separate fix.
- **Prod data:** the 8 GB `COTA.md` is operational cleanup, not code.

## Test plan

- [x] `just ci` green (build, `go test -race ./...`)
- [x] Unit: `readDocumentBytes` reads a normal document unchanged and refuses a file one byte over the cap (sparse file — no 32 MB write)
