### PR TITLE
fix(memguard): exit non-zero on hard-limit restart

### DIFF
--- a/internal/app/serve.go
+++ b/internal/app/serve.go
@@ -46,15 +46,17 @@ func (a *App) Serve(ctx context.Context) error {
 		}
 	}()
 
-	// Memory guard: write a heap profile and gracefully restart before a
-	// leak can OOM the host. Opt-in; the supervising wrapper relaunches thane
-	// after the graceful exit (internal/platform/memguard).
+	// Memory guard: write a heap profile and restart before a leak can OOM the
+	// host. Opt-in. A hard-limit trip makes Serve return an error below so the
+	// process exits non-zero — a memory-limit restart is a failure even though
+	// the shutdown is clean — and the supervising wrapper relaunches thane.
+	var guard *memguard.Guard
 	if a.cfg.MemoryGuard.Enabled {
 		profileDir := a.cfg.MemoryGuard.ProfileDir
 		if profileDir == "" {
 			profileDir = filepath.Join(a.cfg.DataDir, "profiles")
 		}
-		guard := memguard.New(memguard.Config{
+		guard = memguard.New(memguard.Config{
 			SoftLimitMB: a.cfg.MemoryGuard.SoftLimitMB,
 			HardLimitMB: a.cfg.MemoryGuard.HardLimitMB,
 			ProfileDir:  profileDir,
@@ -137,6 +139,9 @@ func (a *App) Serve(ctx context.Context) error {
 	}
 
 	a.logger.Info("Thane stopped")
+	if guard != nil && guard.Tripped() {
+		return fmt.Errorf("memory guard reached its hard limit and triggered a restart")
+	}
 	return nil
 }
 

--- a/internal/platform/memguard/memguard.go
+++ b/internal/platform/memguard/memguard.go
@@ -21,6 +21,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"runtime/pprof"
+	"sync/atomic"
 	"syscall"
 	"time"
 )
@@ -54,6 +55,9 @@ type Guard struct {
 
 	heapDumped bool
 	fired      bool
+	// tripped mirrors a hard-limit firing for cross-goroutine reads: the
+	// poller sets it; Serve reads it after shutdown to pick the exit code.
+	tripped atomic.Bool
 }
 
 // New builds a Guard, applying defaults for any unset numeric fields. Soft
@@ -105,6 +109,12 @@ func New(cfg Config, logger *slog.Logger) *Guard {
 	return g
 }
 
+// Tripped reports whether the guard reached its hard limit and initiated a
+// restart. It is read after graceful shutdown to choose the process exit code:
+// a memory-limit restart is a failure condition even though the shutdown itself
+// is clean, so the supervising wrapper must see a non-zero exit and relaunch.
+func (g *Guard) Tripped() bool { return g.tripped.Load() }
+
 // Start runs the guard until ctx is cancelled. Run it in a goroutine.
 func (g *Guard) Start(ctx context.Context) {
 	g.logger.Info("memory guard active",
@@ -144,6 +154,7 @@ func (g *Guard) check(mem uint64) {
 	}
 	if mem >= g.hard {
 		g.fired = true
+		g.tripped.Store(true)
 		g.logger.Error("memory guard: hard limit reached; triggering graceful restart",
 			"mem_mb", mem/mib, "hard_mb", g.hard/mib)
 		g.onHard()

--- a/internal/platform/memguard/memguard_test.go
+++ b/internal/platform/memguard/memguard_test.go
@@ -22,6 +22,9 @@ func TestCheckThresholds(t *testing.T) {
 	if len(dumps) != 0 || hardCalls != 0 {
 		t.Fatalf("acted below soft: dumps=%d hard=%d", len(dumps), hardCalls)
 	}
+	if g.Tripped() {
+		t.Fatalf("Tripped() reported true before the hard limit")
+	}
 
 	g.check(1200 * mib) // first soft crossing — one dump, no hard
 	if len(dumps) != 1 {
@@ -39,6 +42,9 @@ func TestCheckThresholds(t *testing.T) {
 	g.check(2100 * mib) // hard crossing — fire once
 	if hardCalls != 1 {
 		t.Fatalf("hard hardCalls=%d, want 1", hardCalls)
+	}
+	if !g.Tripped() {
+		t.Fatalf("Tripped() reported false after the hard limit")
 	}
 
 	g.check(3000 * mib) // already fired — no further action


### PR DESCRIPTION
## What

Makes a memory-guard hard-limit restart exit the process **non-zero**, so a supervising wrapper that relaunches on failure brings thane back.

## Why

In prod, memguard tripped its hard limit twice in a row and neither restart auto-recovered. Root cause: the guard self-`SIGTERM`s into the normal graceful-shutdown path, which exits **0** — identical to an operator stop. The macOS wrapper only relaunches on a *failure* exit, so a clean exit left thane down.

A memory-limit shutdown is a failure that happens to shut down cleanly. The exit code should say so.

## How

- `Guard.Tripped()` records that the hard limit fired (atomic — set in the poller goroutine, read after shutdown).
- `App.Serve` returns an error when the guard tripped, so `run` → `main` exits non-zero through the existing error path.
- An operator `SIGINT`/`SIGTERM` leaves the guard un-tripped → exit 0, unchanged.

The graceful-shutdown sequence itself is untouched — DBs still close cleanly before exit; only the final exit code differs.

## Test plan

- [x] `just ci` green (build, `go test -race ./...`)
- [x] Unit: `Tripped()` is false below the hard limit and true after it
