### PR TITLE
fix(mqtt): robust handling of orphaned wake subscriptions (startup-resilient + cascade-on-delete)

### DIFF
--- a/internal/app/new_channels.go
+++ b/internal/app/new_channels.go
@@ -414,14 +414,14 @@ func (a *App) initChannels(s *newState) error {
 		DeletePolicy:     a.deletePersistedLoopDefinitionPolicy,
 		Reconcile:        a.reconcileLoopDefinition,
 		LaunchDefinition: a.launchLoopDefinition,
-		CascadeWakeSubscriptions: func(loopName string) (removed, configRefs []string) {
+		CascadeWakeSubscriptions: func(loopName string) (removed, configRefs []string, err error) {
 			if a.mqttSubStore == nil {
-				return nil, nil
+				return nil, nil, nil
 			}
-			rm, cfg, err := a.mqttSubStore.RemoveByWakeLoop(loopName)
-			if err != nil {
+			rm, cfg, rerr := a.mqttSubStore.RemoveByWakeLoop(loopName)
+			if rerr != nil {
 				a.logger.Warn("cascade wake-subscription cleanup had errors",
-					"loop", loopName, "error", err)
+					"loop", loopName, "error", rerr)
 			}
 			for _, ws := range rm {
 				removed = append(removed, fmt.Sprintf("%s (topic %q)", ws.ID, ws.Topic))
@@ -429,7 +429,7 @@ func (a *App) initChannels(s *newState) error {
 			for _, ws := range cfg {
 				configRefs = append(configRefs, fmt.Sprintf("%s (topic %q)", ws.ID, ws.Topic))
 			}
-			return removed, configRefs
+			return removed, configRefs, rerr
 		},
 	})
 	if a.documentTools != nil {

--- a/internal/app/new_channels.go
+++ b/internal/app/new_channels.go
@@ -414,6 +414,23 @@ func (a *App) initChannels(s *newState) error {
 		DeletePolicy:     a.deletePersistedLoopDefinitionPolicy,
 		Reconcile:        a.reconcileLoopDefinition,
 		LaunchDefinition: a.launchLoopDefinition,
+		CascadeWakeSubscriptions: func(loopName string) (removed, configRefs []string) {
+			if a.mqttSubStore == nil {
+				return nil, nil
+			}
+			rm, cfg, err := a.mqttSubStore.RemoveByWakeLoop(loopName)
+			if err != nil {
+				a.logger.Warn("cascade wake-subscription cleanup had errors",
+					"loop", loopName, "error", err)
+			}
+			for _, ws := range rm {
+				removed = append(removed, fmt.Sprintf("%s (topic %q)", ws.ID, ws.Topic))
+			}
+			for _, ws := range cfg {
+				configRefs = append(configRefs, fmt.Sprintf("%s (topic %q)", ws.ID, ws.Topic))
+			}
+			return removed, configRefs
+		},
 	})
 	if a.documentTools != nil {
 		a.loop.Tools().ConfigureLoopIntentTools(tools.LoopIntentToolDeps{

--- a/internal/channels/mqtt/subscriptions.go
+++ b/internal/channels/mqtt/subscriptions.go
@@ -388,6 +388,11 @@ func (s *SubscriptionStore) SetSubscribeHook(fn func(topics []string)) {
 // closes the gap on config-defined entries, which load before any loop
 // is registered. A nil resolver is a no-op so test wiring without a
 // registry stays simple.
+//
+// Only config-declared targets are fatal. A runtime subscription whose
+// target loop has since been deleted or disabled is an orphaned-data
+// condition: it is warned and skipped, never fatal, so one stale row
+// can't keep the agent from booting.
 func (s *SubscriptionStore) VerifyTargets(resolver messages.LoopResolver) error {
 	if resolver == nil {
 		return nil
@@ -398,9 +403,23 @@ func (s *SubscriptionStore) VerifyTargets(resolver messages.LoopResolver) error 
 	s.mu.RUnlock()
 
 	for _, ws := range subs {
-		if err := messages.VerifyLoopWakeTarget(ws.WakeTarget, resolver); err != nil {
+		err := messages.VerifyLoopWakeTarget(ws.WakeTarget, resolver)
+		if err == nil {
+			continue
+		}
+		// Config-declared targets are operator-authored, so an unresolved
+		// one is a config error worth failing startup loudly — that's the
+		// gap this pass exists to close.
+		if ws.Source == "config" {
 			return fmt.Errorf("mqtt subscription %q (topic %q, source=%s) wake_loop unresolved: %w", ws.ID, ws.Topic, ws.Source, err)
 		}
+		// A runtime subscription can outlive its target loop: the loop was
+		// deleted or disabled after the subscription was persisted. That is
+		// an orphaned-data condition, not a config error, and must not crash
+		// the whole agent at startup. Warn and skip — it simply won't
+		// dispatch, and self-heals if the loop comes back.
+		s.logger.Warn("mqtt wake subscription targets a loop that is not running; skipping",
+			"id", ws.ID, "topic", ws.Topic, "source", ws.Source, "error", err.Error())
 	}
 	return nil
 }

--- a/internal/channels/mqtt/subscriptions.go
+++ b/internal/channels/mqtt/subscriptions.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"strings"
@@ -510,6 +511,51 @@ func (s *SubscriptionStore) Remove(id string) error {
 	s.subs = append(s.subs[:idx], s.subs[idx+1:]...)
 	s.logger.Info("mqtt wake subscription removed", "id", id)
 	return nil
+}
+
+// RemoveByWakeLoop deletes every runtime subscription whose wake target
+// names the given loop, so deleting a loop doesn't leave orphaned wake
+// rows that would later fail (or, before that resilience landed, crash)
+// startup verification. It returns the removed runtime subscriptions and,
+// separately, any config-sourced subscriptions that also target the loop —
+// those are NOT deleted (config is the source of truth), but the caller can
+// warn that config still references a now-deleted loop.
+//
+// Matching is by wake-target name, the durable key a subscription uses to
+// reach a loop definition; loop_id targets an ephemeral instance and is not
+// matched here.
+func (s *SubscriptionStore) RemoveByWakeLoop(loopName string) (removed, configRefs []WakeSubscription, err error) {
+	loopName = strings.TrimSpace(loopName)
+	if loopName == "" {
+		return nil, nil, nil
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	kept := make([]WakeSubscription, 0, len(s.subs))
+	for _, ws := range s.subs {
+		if strings.TrimSpace(ws.WakeTarget.Name) != loopName {
+			kept = append(kept, ws)
+			continue
+		}
+		if ws.Source == "config" {
+			// Config owns this row; surface it but leave it in place.
+			configRefs = append(configRefs, ws)
+			kept = append(kept, ws)
+			continue
+		}
+		if _, derr := s.db.Exec(`DELETE FROM mqtt_wake_subscriptions WHERE id = ?`, ws.ID); derr != nil {
+			err = errors.Join(err, fmt.Errorf("delete subscription %q: %w", ws.ID, derr))
+			kept = append(kept, ws)
+			continue
+		}
+		removed = append(removed, ws)
+		s.logger.Info("removed orphaned mqtt wake subscription on loop delete",
+			"id", ws.ID, "topic", ws.Topic, "loop", loopName)
+	}
+	s.subs = kept
+	return removed, configRefs, err
 }
 
 // List returns all wake subscriptions (config + runtime).

--- a/internal/channels/mqtt/subscriptions.go
+++ b/internal/channels/mqtt/subscriptions.go
@@ -420,7 +420,7 @@ func (s *SubscriptionStore) VerifyTargets(resolver messages.LoopResolver) error 
 		// the whole agent at startup. Warn and skip — it simply won't
 		// dispatch, and self-heals if the loop comes back.
 		s.logger.Warn("mqtt wake subscription targets a loop that is not running; skipping",
-			"id", ws.ID, "topic", ws.Topic, "source", ws.Source, "error", err.Error())
+			"id", ws.ID, "topic", ws.Topic, "source", ws.Source, "error", err)
 	}
 	return nil
 }

--- a/internal/channels/mqtt/subscriptions_test.go
+++ b/internal/channels/mqtt/subscriptions_test.go
@@ -506,6 +506,76 @@ func TestSubscriptionStoreVerifyTargetsSkipsOrphanedRuntime(t *testing.T) {
 	}
 }
 
+// TestSubscriptionStoreRemoveByWakeLoop covers the cascade that prevents
+// orphans at the source: deleting a loop removes runtime subscriptions that
+// target it, reports (but keeps) config-sourced ones, and leaves
+// subscriptions for other loops untouched.
+func TestSubscriptionStoreRemoveByWakeLoop(t *testing.T) {
+	db, err := database.OpenMemory()
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer db.Close()
+	if _, err := NewSubscriptionStore(db, nil); err != nil {
+		t.Fatalf("schema bootstrap: %v", err)
+	}
+
+	insert := func(id, topic, loop, source string) {
+		t.Helper()
+		wt, err := json.Marshal(wakeTarget(loop))
+		if err != nil {
+			t.Fatalf("marshal target: %v", err)
+		}
+		if _, err := db.Exec(
+			`INSERT INTO mqtt_wake_subscriptions (id, topic, seed_json, initial_tags_json, wake_target_json, source, created_at) VALUES (?, ?, '{}', '[]', ?, ?, ?)`,
+			id, topic, string(wt), source, "2026-01-01T00:00:00Z",
+		); err != nil {
+			t.Fatalf("insert %s: %v", id, err)
+		}
+	}
+	insert("rt-x", "x/topic", "loop_x", "runtime")
+	insert("cfg-x", "xc/topic", "loop_x", "config")
+	insert("rt-y", "y/topic", "loop_y", "runtime")
+
+	s, err := NewSubscriptionStore(db, nil)
+	if err != nil {
+		t.Fatalf("reload store: %v", err)
+	}
+
+	removed, configRefs, err := s.RemoveByWakeLoop("loop_x")
+	if err != nil {
+		t.Fatalf("RemoveByWakeLoop: %v", err)
+	}
+	if len(removed) != 1 || removed[0].ID != "rt-x" {
+		t.Errorf("removed = %+v, want one entry rt-x", removed)
+	}
+	if len(configRefs) != 1 || configRefs[0].ID != "cfg-x" {
+		t.Errorf("configRefs = %+v, want one entry cfg-x", configRefs)
+	}
+
+	ids := map[string]bool{}
+	for _, ws := range s.List() {
+		ids[ws.ID] = true
+	}
+	if ids["rt-x"] {
+		t.Error("rt-x (runtime, loop_x) should have been removed")
+	}
+	if !ids["cfg-x"] {
+		t.Error("cfg-x (config, loop_x) must NOT be removed — config is source of truth")
+	}
+	if !ids["rt-y"] {
+		t.Error("rt-y (different loop) must be untouched")
+	}
+
+	var n int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM mqtt_wake_subscriptions WHERE id='rt-x'`).Scan(&n); err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if n != 0 {
+		t.Error("rt-x row should be deleted from the database")
+	}
+}
+
 func TestSubscriptionStoreVerifyTargetsNilResolverIsNoop(t *testing.T) {
 	s := newTestStore(t)
 	target := wakeTarget("anything")

--- a/internal/channels/mqtt/subscriptions_test.go
+++ b/internal/channels/mqtt/subscriptions_test.go
@@ -1,6 +1,7 @@
 package mqtt
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 
@@ -460,6 +461,48 @@ func TestSubscriptionStoreVerifyTargetsFailsLoudOnUnregistered(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "typo_handler") {
 		t.Fatalf("error = %v, want mention of typo_handler", err)
+	}
+}
+
+// TestSubscriptionStoreVerifyTargetsSkipsOrphanedRuntime pins the prod
+// outage fix: a runtime subscription can outlive its target loop (the loop
+// was deleted/disabled after the subscription was persisted). That orphan
+// must be warned-and-skipped, not crash startup the way a config typo does.
+func TestSubscriptionStoreVerifyTargetsSkipsOrphanedRuntime(t *testing.T) {
+	db, err := database.OpenMemory()
+	if err != nil {
+		t.Fatalf("open memory db: %v", err)
+	}
+	defer db.Close()
+
+	// Bootstrap the schema.
+	if _, err := NewSubscriptionStore(db, nil); err != nil {
+		t.Fatalf("schema bootstrap: %v", err)
+	}
+
+	// Insert a runtime subscription targeting a loop nobody runs. Add()
+	// validates targets at add-time, so an orphan can only arise from the
+	// loop being removed later — simulated here by a direct insert.
+	wtJSON, err := json.Marshal(wakeTarget("deleted_loop"))
+	if err != nil {
+		t.Fatalf("marshal target: %v", err)
+	}
+	if _, err := db.Exec(
+		`INSERT INTO mqtt_wake_subscriptions (id, topic, seed_json, initial_tags_json, wake_target_json, source, created_at) VALUES (?, ?, '{}', '[]', ?, 'runtime', ?)`,
+		"rt-orphan-1", "presence/zone_change", string(wtJSON), "2026-01-01T00:00:00Z",
+	); err != nil {
+		t.Fatalf("insert orphan: %v", err)
+	}
+
+	// Reconstruct so the store hydrates the orphaned row.
+	s, err := NewSubscriptionStore(db, nil)
+	if err != nil {
+		t.Fatalf("reload store: %v", err)
+	}
+
+	resolver := stubResolver{known: map[string]bool{"some_other_loop": true}}
+	if err := s.VerifyTargets(resolver); err != nil {
+		t.Fatalf("orphaned runtime subscription must be skipped, not fatal: %v", err)
 	}
 }
 

--- a/internal/tools/loop_definition_mutation_tools.go
+++ b/internal/tools/loop_definition_mutation_tools.go
@@ -110,11 +110,29 @@ func (r *Registry) handleLoopDefinitionDelete(ctx context.Context, args map[stri
 	if err != nil {
 		return "", err
 	}
-	return ldMarshalToolJSON(map[string]any{
+	result := map[string]any{
 		"status":     "ok",
 		"generation": view.Generation,
 		"name":       name,
-	})
+	}
+	// Cascade: a runtime MQTT wake subscription can target this loop and
+	// would be orphaned by the delete (it isn't part of the loop's spec).
+	// Remove those and tell the model what got caught, so it isn't
+	// surprised later and so a stale row can't fail a future startup.
+	if r.cascadeWakeOnLoopDelete != nil {
+		removed, configRefs := r.cascadeWakeOnLoopDelete(name)
+		if len(removed) > 0 {
+			result["removed_wake_subscriptions"] = removed
+			result["notice"] = fmt.Sprintf("Also removed %d MQTT wake subscription(s) that targeted this loop.", len(removed))
+		}
+		if len(configRefs) > 0 {
+			// Config subs are not auto-removed — flag them so the operator
+			// updates config before the next restart treats it as fatal.
+			result["config_wake_subscriptions_still_targeting"] = configRefs
+			result["warning"] = fmt.Sprintf("%d config-defined MQTT wake subscription(s) still target this now-deleted loop; update config or startup will fail.", len(configRefs))
+		}
+	}
+	return ldMarshalToolJSON(result)
 }
 
 func (r *Registry) handleLoopDefinitionSetPolicy(ctx context.Context, args map[string]any) (string, error) {

--- a/internal/tools/loop_definition_mutation_tools.go
+++ b/internal/tools/loop_definition_mutation_tools.go
@@ -120,7 +120,7 @@ func (r *Registry) handleLoopDefinitionDelete(ctx context.Context, args map[stri
 	// Remove those and tell the model what got caught, so it isn't
 	// surprised later and so a stale row can't fail a future startup.
 	if r.cascadeWakeOnLoopDelete != nil {
-		removed, configRefs := r.cascadeWakeOnLoopDelete(name)
+		removed, configRefs, cascadeErr := r.cascadeWakeOnLoopDelete(name)
 		if len(removed) > 0 {
 			result["removed_wake_subscriptions"] = removed
 			result["notice"] = fmt.Sprintf("Also removed %d MQTT wake subscription(s) that targeted this loop.", len(removed))
@@ -130,6 +130,13 @@ func (r *Registry) handleLoopDefinitionDelete(ctx context.Context, args map[stri
 			// updates config before the next restart treats it as fatal.
 			result["config_wake_subscriptions_still_targeting"] = configRefs
 			result["warning"] = fmt.Sprintf("%d config-defined MQTT wake subscription(s) still target this now-deleted loop; update config or startup will fail.", len(configRefs))
+		}
+		if cascadeErr != nil {
+			// The loop definition was deleted, but some targeted runtime
+			// subscriptions couldn't be cleaned up. Don't fail the tool —
+			// surface a warning so the operator can prune them by hand and
+			// startup verification can skip them in the meantime.
+			result["wake_cleanup_error"] = cascadeErr.Error()
 		}
 	}
 	return ldMarshalToolJSON(result)

--- a/internal/tools/loop_definition_tools.go
+++ b/internal/tools/loop_definition_tools.go
@@ -25,6 +25,12 @@ type LoopDefinitionToolDeps struct {
 	DeletePolicy     func(string) error
 	Reconcile        func(context.Context, string) error
 	LaunchDefinition func(context.Context, string, looppkg.Launch) (looppkg.LaunchResult, error)
+	// CascadeWakeSubscriptions removes runtime MQTT wake subscriptions that
+	// target a just-deleted loop and returns short descriptions of what was
+	// removed, plus any config-sourced subscriptions that still target it
+	// (those are reported, not removed — config is the source of truth).
+	// Optional; nil disables the cascade.
+	CascadeWakeSubscriptions func(loopName string) (removed, configRefs []string)
 }
 
 // ConfigureLoopDefinitionTools stores the runtime dependencies needed by
@@ -38,6 +44,7 @@ func (r *Registry) ConfigureLoopDefinitionTools(deps LoopDefinitionToolDeps) {
 	r.deletePersistedLoopDefinitionPolicy = deps.DeletePolicy
 	r.reconcileLoopDefinition = deps.Reconcile
 	r.launchLoopDefinition = deps.LaunchDefinition
+	r.cascadeWakeOnLoopDelete = deps.CascadeWakeSubscriptions
 	r.registerLoopDefinitionTools()
 }
 

--- a/internal/tools/loop_definition_tools.go
+++ b/internal/tools/loop_definition_tools.go
@@ -28,9 +28,11 @@ type LoopDefinitionToolDeps struct {
 	// CascadeWakeSubscriptions removes runtime MQTT wake subscriptions that
 	// target a just-deleted loop and returns short descriptions of what was
 	// removed, plus any config-sourced subscriptions that still target it
-	// (those are reported, not removed — config is the source of truth).
-	// Optional; nil disables the cascade.
-	CascadeWakeSubscriptions func(loopName string) (removed, configRefs []string)
+	// (those are reported, not removed — config is the source of truth). A
+	// non-nil err means some targeted runtime subscriptions could not be
+	// deleted; the caller surfaces it as a tool-level warning so the operator
+	// can follow up. Optional; nil disables the cascade.
+	CascadeWakeSubscriptions func(loopName string) (removed, configRefs []string, err error)
 }
 
 // ConfigureLoopDefinitionTools stores the runtime dependencies needed by

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -94,7 +94,7 @@ type Registry struct {
 	persistLoopDefinitionPolicy                func(string, looppkg.DefinitionPolicy) error
 	deletePersistedLoopDefinitionPolicy        func(string) error
 	reconcileLoopDefinition                    func(context.Context, string) error
-	cascadeWakeOnLoopDelete                    func(string) (removed, configRefs []string)
+	cascadeWakeOnLoopDelete                    func(string) (removed, configRefs []string, err error)
 	launchLoopDefinition                       func(context.Context, string, looppkg.Launch) (looppkg.LaunchResult, error)
 	liveLoopRegistry                           *looppkg.Registry
 	launchLoop                                 func(context.Context, looppkg.Launch) (looppkg.LaunchResult, error)

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -94,6 +94,7 @@ type Registry struct {
 	persistLoopDefinitionPolicy                func(string, looppkg.DefinitionPolicy) error
 	deletePersistedLoopDefinitionPolicy        func(string) error
 	reconcileLoopDefinition                    func(context.Context, string) error
+	cascadeWakeOnLoopDelete                    func(string) (removed, configRefs []string)
 	launchLoopDefinition                       func(context.Context, string, looppkg.Launch) (looppkg.LaunchResult, error)
 	liveLoopRegistry                           *looppkg.Registry
 	launchLoop                                 func(context.Context, looppkg.Launch) (looppkg.LaunchResult, error)


### PR DESCRIPTION
## Incident

Production (**Aimée**) crash-looped on `v0.9.2-542-gd48d3150`: the binary exited **code 1** during startup (the macOS `BinaryManager` supervisor restarts on any non-clean exit — `0`/`SIGTERM` are clean, so this looped). Root cause from a hand-run as `aimee`:

```
start worker "loop-definition-services": verify mqtt wake subscription targets:
mqtt subscription "rt-34d33ae5a719d04a-1780072365512" (topic "thane/aimee/presence/zone_change", source=runtime)
wake_loop unresolved: wake_loop.name "cota_weekend_observer" does not match any running loop
```

A persisted **runtime** MQTT wake subscription targeted a loop (`cota_weekend_observer`) that had since been deleted. `VerifyTargets` (trigger-unification, PR-T2b / `e5d4148`) treated **every** unresolved target as fatal, so one orphaned runtime row took the whole agent down on every boot. Not related to the companion-registrar work (#1017) merged in the same window — it reached prod via the upgrade to `d48d3150`.

## Fix — two complementary layers

**1. Startup-resilient (defense in depth)** — `VerifyTargets` now distinguishes by source:
- **`config`** targets stay **fatal** (operator typo, fail loud — the gap this pass was added to close).
- **`runtime`** targets that no longer resolve are an orphaned-data condition: **warn and skip**, never fatal. Self-heals if the loop returns. One stale row can't keep the agent from booting.

**2. Cascade-on-delete (prevent at the source)** — `loop_definition_delete` now removes runtime wake subscriptions that target the loop being deleted (they're persisted independently of the loop's spec, so they used to be orphaned), and **reports them back in the tool result** (`removed_wake_subscriptions` + a `notice`) so the model knows what got caught. Config-sourced subscriptions targeting the loop are reported as a `warning` but **not** deleted (config is the source of truth).

## Operational unblock (already applied)

```sql
DELETE FROM mqtt_wake_subscriptions WHERE source='runtime' AND wake_target_json LIKE '%cota_weekend_observer%';
```
Layer 1 makes the SQL delete unnecessary going forward; layer 2 stops the orphan ever forming.

## Known remaining sharp edge

A **config**-defined wake sub naming a bad loop still hard-fails startup by design (fail-loud on operator config error). Out of scope here; can revisit if you'd prefer config orphans to degrade too.

## Test plan

- [x] `just ci` green (no architecture-baseline changes)
- [x] Orphaned **runtime** subscription is skipped at startup (no error); config-typo test still fails loud
- [x] `RemoveByWakeLoop` removes the runtime sub, keeps+reports the config sub, leaves a different loop's sub untouched, and deletes the DB row

Refs #902

🤖 Generated with [Claude Code](https://claude.com/claude-code)