### PR TITLE
refactor(app): drop vestigial deferredTools capability-tag exemption

### DIFF
--- a/internal/app/finalize_capability_tags.go
+++ b/internal/app/finalize_capability_tags.go
@@ -25,14 +25,14 @@ import (
 // Subsystems whose backing runtime binds asynchronously (Signal is
 // the canonical example) declare their tools up front via
 // tools.Provider and return tools.ErrUnavailable from the handler
-// until Bind is called. Those tools ARE in the snapshot and do NOT
-// belong in s.deferredTools — the registry sees them from initChannels
-// onwards.
+// until Bind is called. Those tools ARE in the snapshot — the registry
+// sees them from initChannels onwards.
 //
-// s.deferredTools is a narrow remaining exemption for tool families
-// whose handler is still registered inside a deferWorker closure
-// (today: macos_calendar_events). See the doc comment in new.go for
-// the ordering rules.
+// Tools registered synchronously by an earlier init phase (the
+// macos_calendar_events companion tool and mqtt_wake_* in initServers,
+// watchlist tools in initAwareness) are likewise present here, because
+// the finalizer runs last. See the doc comment in new.go for the
+// ordering rules.
 func (a *App) finalizeCapabilityTags(s *newState) error {
 	cfg := a.cfg
 	logger := a.logger
@@ -68,15 +68,16 @@ func (a *App) finalizeCapabilityTags(s *newState) error {
 	// config (e.g., shell_exec disabled). Non-fatal: skip the missing
 	// tool.
 	//
-	// Tools in s.deferredTools are registered by a deferWorker closure
-	// that runs after New() completes — today only macos_calendar_events.
-	// Provider-migrated subsystems (Signal, watchlist, mqtt_wake) are
-	// declared up front and never appear in deferredTools; their tools
-	// are visible here and only invocation would surface
-	// tools.ErrUnavailable until Bind supplies the runtime.
+	// Every tool a config tag can reference is registered by an init
+	// phase before this finalizer runs: synchronously (e.g.
+	// macos_calendar_events and mqtt_wake_* in initServers) or declared
+	// up front via tools.Provider (Signal, watchlist). Provider tools
+	// whose runtime has not bound yet are still present here; only
+	// invocation surfaces tools.ErrUnavailable until Bind supplies the
+	// runtime.
 	for tag, tagCfg := range resolvedCapTags {
 		for _, toolName := range tagCfg.Tools {
-			if a.loop.Tools().Get(toolName) == nil && !s.deferredTools[toolName] {
+			if a.loop.Tools().Get(toolName) == nil {
 				logger.Warn("capability tag references unregistered tool",
 					"tag", tag, "tool", toolName)
 			}

--- a/internal/app/new.go
+++ b/internal/app/new.go
@@ -55,11 +55,13 @@ import (
 //   - Subsystems whose backing runtime starts asynchronously (Signal)
 //     declare their tools up front via tools.Provider and return
 //     tools.ErrUnavailable from the handler until Bind is called. Those
-//     tools DO appear in the snapshot; they are not in s.deferredTools.
-//   - s.deferredTools is a narrow remaining escape hatch for tool
-//     families whose handler is still registered inside a deferWorker
-//     closure (today: macos_calendar_events). New subsystems should use
-//     Provider + declared-but-unavailable instead of adding entries here.
+//     tools DO appear in the snapshot.
+//   - The legacy macos_calendar_events companion tool is registered
+//     synchronously in initServers via Tools().EnableCompanionTools
+//     (which calls registerCompanionTools → Register), exactly like
+//     mqtt_wake_*, so it is in the registry before the finalizer runs.
+//     No deferred-registration escape hatch remains; new subsystems use
+//     Provider + declared-but-unavailable.
 //   - initDelegation no longer takes a capability-tag snapshot; it
 //     creates the delegate executor without tag state and leaves
 //     coreTags / SetTagContextFunc to the finalizer.

--- a/internal/app/new_channels.go
+++ b/internal/app/new_channels.go
@@ -696,20 +696,6 @@ func (a *App) initChannels(s *newState) error {
 	// messages event-driven, routing them through the agent loop.
 	// Deferred to StartWorkers because Start() spawns a subprocess and
 	// the entire tool/bridge/notification wiring depends on it running.
-	//
-	// deferredTools is now a narrow escape hatch for the macOS
-	// companion calendar tool, whose registration still happens inside
-	// a deferWorker closure. Signal used to live here too; it has
-	// since migrated to the tools.Provider async-binding pattern
-	// (see internal/channels/messaging/signal/tool_provider.go). Tools
-	// registered synchronously in any init phase land in the
-	// capability-tag snapshot naturally (finalizeCapabilityTags runs
-	// last) and never belong here. New subsystems should follow the
-	// Signal pattern rather than adding entries here.
-	s.deferredTools = make(map[string]bool)
-	if a.cfg.Companion.Configured() {
-		s.deferredTools["macos_calendar_events"] = true
-	}
 	if a.cfg.Signal.Configured() {
 		// Signal tools are declared at init time via the Provider so
 		// they appear in the capability-tag snapshot immediately. The
@@ -798,8 +784,8 @@ func (a *App) initChannels(s *newState) error {
 
 	// MQTT wake tools (mqtt_wake_list/add/remove) are registered in
 	// initServers, which runs before finalizeCapabilityTags, so they
-	// land in the capability-tag snapshot naturally and don't need
-	// a deferredTools exemption. See #733.
+	// land in the capability-tag snapshot naturally — like every tool
+	// registered during an init phase. See #733.
 
 	return nil
 }

--- a/internal/app/new_state.go
+++ b/internal/app/new_state.go
@@ -38,9 +38,4 @@ type newState struct {
 
 	// Built in initChannels, used by initDelegation.
 	forgeOpLog *forge.OperationLog
-
-	// Tools registered by deferred workers (e.g., Signal tools). The
-	// capability-tag validation in initDelegation skips these names so
-	// it doesn't warn about tools that will appear after StartWorkers.
-	deferredTools map[string]bool
 }


### PR DESCRIPTION
## Summary

Three doc comments falsely claimed the `macos_calendar_events` companion calendar tool handler is registered "inside a deferWorker closure," and that its `s.deferredTools` entry is needed to exempt it from `finalizeCapabilityTags`'s presence check. **Both claims are wrong**, and verifying the real path showed the exemption is dead code.

### What the code actually does

- The handler is registered **synchronously** during `initServers`, via `a.loop.Tools().EnableCompanionTools(a.companionRegistry.Call)` ([new_servers.go:203](https://github.com/nugget/thane-ai-agent/blob/main/internal/app/new_servers.go#L203)), which immediately calls `registerCompanionTools()` → `Register(&Tool{Name: "macos_calendar_events"})` ([companion_tools.go:46-57](https://github.com/nugget/thane-ai-agent/blob/main/internal/tools/companion_tools.go#L46-L57)). No goroutine, no `deferWorker` (a grep for one returns zero matches).
- Phase order in `New()` is `initChannels` → … → `initServers` (registers the tool) → `finalizeCapabilityTags` (presence check). So the tool is **already in the registry** when the check runs — exactly like the `mqtt_wake_*` tools, which deliberately carry **no** exemption.
- The `s.deferredTools` map's only functional read was the presence check at `finalize_capability_tags.go:79`, and `macos_calendar_events` was its sole and last entry. The exemption never changed any outcome.

### Change

- Remove the now-vestigial `deferredTools` mechanism: the `newState` field, its population in `initChannels`, and the read clause in `finalizeCapabilityTags`.
- Rewrite the four stale comment sites (`new.go`, `new_channels.go` ×2, `finalize_capability_tags.go` ×2) to describe the real synchronous `initServers` registration and the capability-tag snapshot ordering.

Historical past-tense references to the old escape hatch in `tools/provider.go` and `signal/tool_provider.go` are left intact — they correctly describe the pre-#733 era and become *more* accurate now that the hatch is gone.

**No behavior change**: the exemption was a no-op given the registration order.

Refs #733

## Test plan

- [x] `just ci` passes locally (build, vet, lint, tests — 0 errors)
- [x] `grep -rn deferredTools internal/ --include='*.go'` shows only the intended historical comments remain
- [x] Commit is signed (good signature)

🤖 Generated with [Claude Code](https://claude.com/claude-code)