### PR TITLE
feat(api): queryable, paginated /v1/conversations (kills the N+1 dump)

### DIFF
--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -60,8 +60,8 @@ views). The OpenAI-compatible shim runs on its own port (see below).
 | `POST` | `/v1/loop-definitions/policy` | Set a loop-definition policy. |
 | `DELETE` | `/v1/loop-definitions/policy?name=...` | Clear a loop-definition policy. |
 | `POST` | `/v1/loop-definitions/{name}/launch` | Launch a stored loop definition. |
-| `GET` | `/v1/conversations` | Conversation summaries. |
-| `GET` | `/v1/conversations/{id}` | Conversation detail. |
+| `GET` | `/v1/conversations` | Filter/sort/keyset-paginate conversation summaries. Filters: `ids` (comma-sep, max 200), `kind` (comma-sep id-prefix families), `channel`/`contact`/`address` (channel binding), `updated_after`/`updated_before`/`created_after`/`created_before` (RFC3339 or a duration like `1h` meaning "ago"), `min_messages`/`max_messages`, `q` (metadata substring: id/contact name/address — *not* message content; use `/v1/archive/search` for that). `sort` = `updated_at` (default)\|`created_at`\|`message_count`; `order` = `desc` (default)\|`asc`; `limit` default 50, max 200; `cursor` from `next_cursor`. Returns `{conversations, count, total, next_cursor}`. `message_count` is the true active count (previously capped at the per-conversation working-memory limit). |
+| `GET` | `/v1/conversations/{id}` | Conversation detail (full transcript). |
 | `GET` | `/v1/insights/tools` | Tool-call stats plus recent tool calls (`?tool`, `?conversation_id`, `?limit` default 50). |
 | `GET` | `/v1/sessions/stats` | Current session usage and context stats. |
 | `GET` | `/v1/insights/usage` | Token/cost usage summary over a time window (`?hours`, default 24; `?group_by` to break down by a dimension, e.g. model). |

--- a/internal/server/api/conversations.go
+++ b/internal/server/api/conversations.go
@@ -1,0 +1,257 @@
+package api
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/nugget/thane-ai-agent/internal/platform/database"
+	"github.com/nugget/thane-ai-agent/internal/state/memory"
+)
+
+// conversationKindPattern bounds the kind filter to a safe identifier so the
+// value can be used as a LIKE prefix without surprises. We deliberately do
+// NOT validate against a fixed family allowlist — id prefixes (loop, sched,
+// metacog, owu, signal, email, wake, mqtt, media, ...) grow as new producers
+// appear, and a hardcoded list drifts out of date. An unknown kind simply
+// matches nothing.
+var conversationKindPattern = regexp.MustCompile(`^[a-z0-9_]+$`)
+
+// handleConversationList serves GET /v1/conversations: a filtered, sorted,
+// keyset-paginated view of conversation summaries. It returns cheap summaries
+// (no message content) and bounds the result, so cost scales with the page
+// and filter selectivity rather than the all-time conversation corpus.
+func (s *Server) handleConversationList(w http.ResponseWriter, r *http.Request) {
+	if s.memoryStore == nil {
+		s.errorResponse(w, http.StatusServiceUnavailable, "memory store not configured")
+		return
+	}
+
+	q := r.URL.Query()
+	var query memory.ConversationQuery
+
+	if ids := splitCSV(q.Get("ids")); len(ids) > 0 {
+		if len(ids) > 200 {
+			s.errorResponse(w, http.StatusBadRequest, "ids: at most 200 allowed")
+			return
+		}
+		query.IDs = ids
+	}
+
+	if kinds := splitCSV(q.Get("kind")); len(kinds) > 0 {
+		for _, k := range kinds {
+			if !conversationKindPattern.MatchString(k) {
+				s.errorResponse(w, http.StatusBadRequest, fmt.Sprintf("kind %q: must match [a-z0-9_]+", k))
+				return
+			}
+		}
+		query.Kinds = kinds
+	}
+
+	query.Channel = strings.TrimSpace(q.Get("channel"))
+	query.ContactID = strings.TrimSpace(q.Get("contact"))
+	query.Address = strings.TrimSpace(q.Get("address"))
+	query.Q = strings.TrimSpace(q.Get("q"))
+
+	for _, tf := range []struct {
+		name string
+		dst  **time.Time
+	}{
+		{"updated_after", &query.UpdatedAfter},
+		{"updated_before", &query.UpdatedBefore},
+		{"created_after", &query.CreatedAfter},
+		{"created_before", &query.CreatedBefore},
+	} {
+		t, err := parseTimeOrAgo(q.Get(tf.name))
+		if err != nil {
+			s.errorResponse(w, http.StatusBadRequest, fmt.Sprintf("%s: %v", tf.name, err))
+			return
+		}
+		*tf.dst = t
+	}
+
+	minM, err := parseIntPtr(q.Get("min_messages"))
+	if err != nil {
+		s.errorResponse(w, http.StatusBadRequest, "min_messages: "+err.Error())
+		return
+	}
+	maxM, err := parseIntPtr(q.Get("max_messages"))
+	if err != nil {
+		s.errorResponse(w, http.StatusBadRequest, "max_messages: "+err.Error())
+		return
+	}
+	if minM != nil && maxM != nil && *minM > *maxM {
+		s.errorResponse(w, http.StatusBadRequest, "min_messages must not exceed max_messages")
+		return
+	}
+	query.MinMessages, query.MaxMessages = minM, maxM
+
+	query.Sort = "updated_at"
+	if v := strings.TrimSpace(q.Get("sort")); v != "" {
+		switch v {
+		case "updated_at", "created_at", "message_count":
+			query.Sort = v
+		default:
+			s.errorResponse(w, http.StatusBadRequest, "sort: must be updated_at, created_at, or message_count")
+			return
+		}
+	}
+
+	query.Order = "desc"
+	if v := strings.TrimSpace(q.Get("order")); v != "" {
+		switch v {
+		case "asc", "desc":
+			query.Order = v
+		default:
+			s.errorResponse(w, http.StatusBadRequest, "order: must be asc or desc")
+			return
+		}
+	}
+
+	limit := parseIntParam(r, "limit", 50)
+	if limit < 1 {
+		limit = 1
+	}
+	if limit > 200 {
+		limit = 200
+	}
+	query.Limit = limit
+
+	if c := strings.TrimSpace(q.Get("cursor")); c != "" {
+		cur, err := decodeConvCursor(c)
+		if err != nil {
+			s.errorResponse(w, http.StatusBadRequest, "cursor: "+err.Error())
+			return
+		}
+		if cur.Sort != query.Sort || cur.Order != query.Order {
+			s.errorResponse(w, http.StatusBadRequest, "cursor: sort/order mismatch; restart pagination")
+			return
+		}
+		query.Cursor = cur
+	}
+
+	page, err := s.memoryStore.QueryConversations(query)
+	if err != nil {
+		s.logger.Error("conversation query failed", "error", err)
+		s.errorResponse(w, http.StatusInternalServerError, "conversation query failed")
+		return
+	}
+
+	conversations := page.Conversations
+	if conversations == nil {
+		conversations = []memory.ConversationSummary{}
+	}
+	var nextCursor any // JSON null on the last page
+	if page.NextCursor != nil {
+		token, err := encodeConvCursor(page.NextCursor)
+		if err != nil {
+			s.logger.Error("encode conversation cursor failed", "error", err)
+			s.errorResponse(w, http.StatusInternalServerError, "conversation query failed")
+			return
+		}
+		nextCursor = token
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	writeJSON(w, map[string]any{
+		"conversations": conversations,
+		"count":         len(conversations),
+		"total":         page.Total,
+		"next_cursor":   nextCursor,
+	}, s.logger)
+}
+
+// splitCSV splits a comma-separated query value into trimmed, de-duplicated,
+// non-empty tokens (preserving first-seen order). Empty input yields nil.
+func splitCSV(s string) []string {
+	if strings.TrimSpace(s) == "" {
+		return nil
+	}
+	seen := make(map[string]struct{})
+	var out []string
+	for _, part := range strings.Split(s, ",") {
+		p := strings.TrimSpace(part)
+		if p == "" {
+			continue
+		}
+		if _, dup := seen[p]; dup {
+			continue
+		}
+		seen[p] = struct{}{}
+		out = append(out, p)
+	}
+	return out
+}
+
+// parseIntPtr parses an optional non-negative integer query value. Empty
+// returns (nil, nil) so callers can distinguish "absent" from an explicit 0 —
+// which parseIntParam cannot, since it floors both to its default.
+func parseIntPtr(s string) (*int, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return nil, nil
+	}
+	n, err := strconv.Atoi(s)
+	if err != nil {
+		return nil, fmt.Errorf("must be an integer")
+	}
+	if n < 0 {
+		return nil, fmt.Errorf("must not be negative")
+	}
+	return &n, nil
+}
+
+// parseTimeOrAgo parses an optional time bound expressed either as an RFC3339
+// timestamp or as a positive Go duration meaning "that long ago" (e.g. 1h,
+// 24h — so updated_after=1h means "active in the last hour"). Empty returns
+// (nil, nil).
+func parseTimeOrAgo(s string) (*time.Time, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return nil, nil
+	}
+	if d, err := time.ParseDuration(s); err == nil {
+		if d <= 0 {
+			return nil, fmt.Errorf("duration must be positive (interpreted as time ago)")
+		}
+		t := time.Now().UTC().Add(-d)
+		return &t, nil
+	}
+	// database.ParseTimestamp accepts RFC3339/RFC3339Nano (and the SQLite TEXT
+	// shapes) — use it rather than a raw time.Parse, per AGENTS.md.
+	if t, err := database.ParseTimestamp(s); err == nil {
+		return &t, nil
+	}
+	return nil, fmt.Errorf("must be an RFC3339 timestamp or a duration like 1h or 24h")
+}
+
+// encodeConvCursor renders a keyset cursor as an opaque base64url token.
+func encodeConvCursor(c *memory.ConvCursor) (string, error) {
+	b, err := json.Marshal(c)
+	if err != nil {
+		return "", fmt.Errorf("encode cursor: %w", err)
+	}
+	return base64.RawURLEncoding.EncodeToString(b), nil
+}
+
+// decodeConvCursor parses a cursor token. Any malformed token is a client
+// error (400), never a silent reset to page one.
+func decodeConvCursor(s string) (*memory.ConvCursor, error) {
+	raw, err := base64.RawURLEncoding.DecodeString(s)
+	if err != nil {
+		return nil, fmt.Errorf("malformed cursor")
+	}
+	var c memory.ConvCursor
+	if err := json.Unmarshal(raw, &c); err != nil {
+		return nil, fmt.Errorf("malformed cursor")
+	}
+	if c.Sort == "" || c.Order == "" || c.ID == "" || c.V == "" {
+		return nil, fmt.Errorf("malformed cursor")
+	}
+	return &c, nil
+}

--- a/internal/server/api/conversations_test.go
+++ b/internal/server/api/conversations_test.go
@@ -1,0 +1,203 @@
+package api
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/nugget/thane-ai-agent/internal/state/memory"
+)
+
+func newConvTestServer(t *testing.T) (*Server, *memory.SQLiteStore) {
+	t.Helper()
+	store, err := memory.NewSQLiteStore(t.TempDir()+"/memory.db", 100)
+	if err != nil {
+		t.Fatalf("NewSQLiteStore: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	s := &Server{logger: testAPILogger()}
+	s.memoryStore = store
+	return s, store
+}
+
+func addConv(t *testing.T, store *memory.SQLiteStore, id string, messages int, binding *memory.ChannelBinding) {
+	t.Helper()
+	if _, err := store.GetOrCreateConversation(id); err != nil {
+		t.Fatalf("GetOrCreateConversation %s: %v", id, err)
+	}
+	for i := 0; i < messages; i++ {
+		if err := store.AddMessage(id, "user", "hello"); err != nil {
+			t.Fatalf("AddMessage %s: %v", id, err)
+		}
+	}
+	if binding != nil {
+		if err := store.BindConversationChannel(id, binding); err != nil {
+			t.Fatalf("BindConversationChannel %s: %v", id, err)
+		}
+	}
+}
+
+func doConvList(t *testing.T, s *Server, rawquery string) (*httptest.ResponseRecorder, map[string]any) {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, "/v1/conversations?"+rawquery, nil)
+	rr := httptest.NewRecorder()
+	s.handleConversationList(rr, req)
+	var body map[string]any
+	if rr.Code == http.StatusOK {
+		if err := json.Unmarshal(rr.Body.Bytes(), &body); err != nil {
+			t.Fatalf("decode body: %v (raw=%s)", err, rr.Body.String())
+		}
+	}
+	return rr, body
+}
+
+func TestHandleConversationListValidation(t *testing.T) {
+	s, _ := newConvTestServer(t)
+	manyIDs := make([]string, 201) // 201 DISTINCT ids (splitCSV dedups identical ones)
+	for i := range manyIDs {
+		manyIDs[i] = fmt.Sprintf("id%d", i)
+	}
+	cases := []struct {
+		name  string
+		query string
+	}{
+		{"bad_sort", "sort=bogus"},
+		{"bad_order", "order=sideways"},
+		{"bad_min_messages", "min_messages=abc"},
+		{"negative_min", "min_messages=-1"},
+		{"min_gt_max", "min_messages=5&max_messages=2"},
+		{"bad_kind", "kind=Signal!"},
+		{"bad_time", "updated_after=notatime"},
+		{"too_many_ids", "ids=" + strings.Join(manyIDs, ",")},
+		{"bad_cursor", "cursor=!!!not-base64!!!"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rr, _ := doConvList(t, s, tc.query)
+			if rr.Code != http.StatusBadRequest {
+				t.Fatalf("status = %d, want 400 (body=%s)", rr.Code, rr.Body.String())
+			}
+		})
+	}
+}
+
+func TestHandleConversationListNotConfigured(t *testing.T) {
+	s := &Server{logger: testAPILogger()} // no memory store
+	rr := httptest.NewRecorder()
+	s.handleConversationList(rr, httptest.NewRequest(http.MethodGet, "/v1/conversations", nil))
+	if rr.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503", rr.Code)
+	}
+}
+
+func TestHandleConversationListPaging(t *testing.T) {
+	s, store := newConvTestServer(t)
+	addConv(t, store, "alpha", 1, nil)
+	addConv(t, store, "beta", 2, nil)
+	addConv(t, store, "gamma", 3, nil)
+
+	// Full page (limit < total) → opaque next_cursor.
+	rr, body := doConvList(t, s, "limit=2")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d", rr.Code)
+	}
+	if got := int(body["count"].(float64)); got != 2 {
+		t.Fatalf("count = %d, want 2", got)
+	}
+	if got := int(body["total"].(float64)); got != 3 {
+		t.Fatalf("total = %d, want 3", got)
+	}
+	cursor, ok := body["next_cursor"].(string)
+	if !ok || cursor == "" {
+		t.Fatalf("next_cursor = %v, want non-empty string", body["next_cursor"])
+	}
+
+	// Following the cursor returns the remainder with a null terminal cursor.
+	rr2, body2 := doConvList(t, s, "limit=2&cursor="+cursor)
+	if rr2.Code != http.StatusOK {
+		t.Fatalf("page 2 status = %d", rr2.Code)
+	}
+	if got := int(body2["count"].(float64)); got != 1 {
+		t.Fatalf("page 2 count = %d, want 1", got)
+	}
+	if body2["next_cursor"] != nil {
+		t.Fatalf("page 2 next_cursor = %v, want null", body2["next_cursor"])
+	}
+}
+
+func TestHandleConversationListCursorMismatch(t *testing.T) {
+	s, store := newConvTestServer(t)
+	addConv(t, store, "alpha", 1, nil)
+	addConv(t, store, "beta", 1, nil)
+	addConv(t, store, "gamma", 1, nil)
+
+	_, body := doConvList(t, s, "sort=updated_at&limit=2")
+	cursor := body["next_cursor"].(string)
+
+	// Reusing the cursor under a different sort must be a 400, not silent drift.
+	rr, _ := doConvList(t, s, "sort=created_at&limit=2&cursor="+cursor)
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400 on sort mismatch", rr.Code)
+	}
+}
+
+func TestHandleConversationListMalformedCursor(t *testing.T) {
+	s, store := newConvTestServer(t)
+	addConv(t, store, "alpha", 1, nil)
+
+	// A structurally-valid token with an empty sort value must be a 400, not a
+	// 500 (an empty V would otherwise reach strconv.Atoi("") in the store).
+	token := base64.RawURLEncoding.EncodeToString(
+		[]byte(`{"s":"message_count","d":"desc","v":"","i":"alpha"}`))
+	rr, _ := doConvList(t, s, "sort=message_count&cursor="+token)
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400 for empty-value cursor (body=%s)", rr.Code, rr.Body.String())
+	}
+}
+
+func TestHandleConversationListIDsAndBinding(t *testing.T) {
+	s, store := newConvTestServer(t)
+	addConv(t, store, "signal-+15551234567", 4, &memory.ChannelBinding{
+		Channel:     "signal",
+		Address:     "+15551234567",
+		ContactName: "Alice",
+	})
+	addConv(t, store, "loop-noise", 1, nil)
+
+	// The '+' in the id must be percent-encoded (a raw '+' decodes to space),
+	// mirroring the frontend's encodeURIComponent per id.
+	_, body := doConvList(t, s, "ids="+url.QueryEscape("signal-+15551234567"))
+	convs := body["conversations"].([]any)
+	if len(convs) != 1 {
+		t.Fatalf("conversations len = %d, want 1", len(convs))
+	}
+	got := convs[0].(map[string]any)
+	if got["id"] != "signal-+15551234567" {
+		t.Fatalf("id = %v", got["id"])
+	}
+	if int(got["message_count"].(float64)) != 4 {
+		t.Fatalf("message_count = %v, want 4", got["message_count"])
+	}
+	binding, ok := got["channel_binding"].(map[string]any)
+	if !ok || binding["contact_name"] != "Alice" {
+		t.Fatalf("channel_binding = %v, want contact_name Alice", got["channel_binding"])
+	}
+}
+
+func TestHandleConversationListRelativeTime(t *testing.T) {
+	s, store := newConvTestServer(t)
+	addConv(t, store, "recent", 1, nil)
+	// Just-created conv is within the last hour.
+	rr, body := doConvList(t, s, "updated_after=1h")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d", rr.Code)
+	}
+	if int(body["total"].(float64)) != 1 {
+		t.Fatalf("total = %v, want 1 (conv created within 1h)", body["total"])
+	}
+}

--- a/internal/server/api/server.go
+++ b/internal/server/api/server.go
@@ -1471,39 +1471,9 @@ func (s *Server) handleCheckpointRestore(w http.ResponseWriter, r *http.Request)
 }
 
 // History endpoints
-
-func (s *Server) handleConversationList(w http.ResponseWriter, r *http.Request) {
-	if s.memoryStore == nil {
-		s.errorResponse(w, http.StatusServiceUnavailable, "memory store not configured")
-		return
-	}
-
-	convs := s.memoryStore.GetAllConversations()
-
-	// Return summary without full message content
-	type ConvSummary struct {
-		ID           string    `json:"id"`
-		MessageCount int       `json:"message_count"`
-		CreatedAt    time.Time `json:"created_at"`
-		UpdatedAt    time.Time `json:"updated_at"`
-	}
-
-	summaries := make([]ConvSummary, len(convs))
-	for i, c := range convs {
-		summaries[i] = ConvSummary{
-			ID:           c.ID,
-			MessageCount: len(c.Messages),
-			CreatedAt:    c.CreatedAt,
-			UpdatedAt:    c.UpdatedAt,
-		}
-	}
-
-	w.Header().Set("Content-Type", "application/json")
-	writeJSON(w, map[string]any{
-		"conversations": summaries,
-		"count":         len(summaries),
-	}, s.logger)
-}
+//
+// handleConversationList lives in conversations.go (the queryable
+// filter/sort/keyset surface); handleConversationGet stays here.
 
 func (s *Server) handleConversationGet(w http.ResponseWriter, r *http.Request) {
 	if s.memoryStore == nil {

--- a/internal/server/openapi/native.yaml
+++ b/internal/server/openapi/native.yaml
@@ -460,16 +460,53 @@ paths:
     get:
       tags: [Conversations & Sessions]
       operationId: listConversations
-      summary: List active conversations
+      summary: List, filter, search, and paginate conversation summaries
+      description: >
+        Returns lightweight conversation summaries (no message content),
+        filtered/sorted/keyset-paginated. message_count is the true active
+        message count. q matches conversation metadata only (id, contact name,
+        address) — for message-content search use /v1/archive/search.
       x-thane-scope: conversations:read
       parameters:
-        - $ref: "#/components/parameters/Limit"
+        - { name: ids, in: query, description: "Comma-separated exact conversation ids (max 200).", schema: { type: string } }
+        - { name: kind, in: query, description: "Comma-separated id-prefix families, e.g. signal,sched (matches '<kind>-…').", schema: { type: string } }
+        - { name: channel, in: query, description: "Filter by channel binding channel (e.g. signal).", schema: { type: string } }
+        - { name: contact, in: query, description: "Filter by channel binding contact id.", schema: { type: string } }
+        - { name: address, in: query, description: "Filter by channel binding address.", schema: { type: string } }
+        - { name: q, in: query, description: "Substring match over id, contact name, and address (metadata only).", schema: { type: string } }
+        - { name: updated_after, in: query, description: "RFC3339 timestamp or a duration meaning 'ago' (e.g. 1h, 24h).", schema: { type: string } }
+        - { name: updated_before, in: query, schema: { type: string } }
+        - { name: created_after, in: query, schema: { type: string } }
+        - { name: created_before, in: query, schema: { type: string } }
+        - { name: min_messages, in: query, schema: { type: integer, minimum: 0 } }
+        - { name: max_messages, in: query, schema: { type: integer, minimum: 0 } }
+        - { name: sort, in: query, schema: { type: string, enum: [updated_at, created_at, message_count], default: updated_at } }
+        - { name: order, in: query, schema: { type: string, enum: [asc, desc], default: desc } }
+        - { name: limit, in: query, description: "Page size.", schema: { type: integer, minimum: 1, maximum: 200, default: 50 } }
+        - { name: cursor, in: query, description: "Opaque keyset cursor from a prior next_cursor; valid only for the same sort/order.", schema: { type: string } }
       responses:
         "200":
-          description: Conversation summaries.
+          description: A page of conversation summaries.
           content:
             application/json:
-              schema: { type: array, items: { type: object } }
+              schema:
+                type: object
+                required: [conversations, count, total, next_cursor]
+                properties:
+                  conversations:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id: { type: string }
+                        message_count: { type: integer }
+                        created_at: { type: string, format: date-time }
+                        updated_at: { type: string, format: date-time }
+                        channel_binding: { type: object, nullable: true }
+                  count: { type: integer }
+                  total: { type: integer }
+                  next_cursor: { type: string, nullable: true }
+        "400": { $ref: "#/components/responses/BadRequest" }
   /v1/conversations/{id}:
     get:
       tags: [Conversations & Sessions]

--- a/internal/server/web/static/app.js
+++ b/internal/server/web/static/app.js
@@ -28,11 +28,6 @@ const state = {
   prevErrors: new Map(),     // id -> last known error string (for shake detection)
   knownLoopIds: new Set(),   // ids we've rendered before (for enter animation)
   canvasRect: null,          // last observed canvas viewport for responsive graph reflow
-  conversationIndex: {
-    fetchedAt: 0,
-    loading: null,
-    summaries: new Map(),
-  },
   conversationDetails: new Map(), // conversation_id -> derived dashboard summary
   conversationLoads: new Map(),   // conversation_id -> in-flight loader promise
 };
@@ -1838,39 +1833,20 @@ function buildPendingConversationSummary(conversationID) {
   return buildConversationSummary(conversationID, null, [], { loading: true });
 }
 
-async function ensureConversationIndex() {
-  if (state.conversationIndex.summaries.size > 0 &&
-      (Date.now() - state.conversationIndex.fetchedAt) < CONVERSATION_SUMMARY_TTL_MS) {
-    return state.conversationIndex.summaries;
-  }
-  if (state.conversationIndex.loading) return state.conversationIndex.loading;
-
-  state.conversationIndex.loading = fetch('/v1/conversations')
+// fetchConversationSummary resolves a single conversation's summary by id via
+// the queryable list endpoint (?ids=). The inspector already holds the loop's
+// conversation ids, so this is a cheap point lookup — no all-conversations
+// index. Resolves to the summary object, or null when the id is unknown.
+function fetchConversationSummary(conversationID) {
+  return fetch('/v1/conversations?ids=' + encodeURIComponent(conversationID))
     .then((resp) => {
-      if (!resp.ok) throw new Error('conversation index unavailable: ' + resp.status);
+      if (!resp.ok) throw new Error('conversation summary unavailable: ' + resp.status);
       return resp.json();
     })
     .then((body) => {
-      const summaries = new Map();
-      for (const conv of body.conversations || []) {
-        if (conv && conv.id) summaries.set(conv.id, conv);
-      }
-      state.conversationIndex.summaries = summaries;
-      state.conversationIndex.fetchedAt = Date.now();
-      return summaries;
-    })
-    .catch((err) => {
-      console.warn('Failed to load conversation index:', err);
-      if (state.conversationIndex.summaries.size > 0) {
-        return state.conversationIndex.summaries;
-      }
-      throw err;
-    })
-    .finally(() => {
-      state.conversationIndex.loading = null;
+      const list = Array.isArray(body.conversations) ? body.conversations : [];
+      return list.find((conv) => conv && conv.id === conversationID) || null;
     });
-
-  return state.conversationIndex.loading;
 }
 
 function refreshSelectedLoopInspector() {
@@ -1888,7 +1864,7 @@ function ensureConversationSummary(conversationID) {
   if (state.conversationLoads.has(conversationID)) return;
 
   const load = Promise.allSettled([
-    ensureConversationIndex(),
+    fetchConversationSummary(conversationID),
     fetch('/v1/archive/sessions?conversation_id=' + encodeURIComponent(conversationID) + '&limit=' + CONVERSATION_SESSION_LIMIT)
       .then((resp) => {
         if (!resp.ok) throw new Error('archive sessions unavailable: ' + resp.status);
@@ -1896,9 +1872,8 @@ function ensureConversationSummary(conversationID) {
       })
       .then((body) => Array.isArray(body.sessions) ? body.sessions : []),
   ]).then(([conversationResult, sessionsResult]) => {
-    const index = conversationResult.status === 'fulfilled' ? conversationResult.value : new Map();
+    const conversation = conversationResult.status === 'fulfilled' ? conversationResult.value : null;
     const sessions = sessionsResult.status === 'fulfilled' ? sessionsResult.value : [];
-    const conversation = index.get(conversationID) || null;
     const detail = buildConversationSummary(conversationID, conversation, sessions, {
       error: conversationResult.status !== 'fulfilled' && sessionsResult.status !== 'fulfilled',
     });

--- a/internal/state/memory/conversations_query.go
+++ b/internal/state/memory/conversations_query.go
@@ -17,11 +17,13 @@ import (
 // silently wrong across zones. These strftime expressions collapse every
 // shape to one fixed-width, millisecond-precision, UTC, lexically-sortable
 // form; the matching expression indexes (idx_conversations_{updated,created}_norm
-// in schema.go) make ORDER BY + keyset seeks index-driven. normConvTime
-// renders a Go bound in the byte-identical form so cursor comparisons round-trip.
+// in schema.go) make ORDER BY + keyset seeks index-driven. The column names are
+// UNQUALIFIED (no table alias) so they byte-match the index definitions exactly
+// — the query's single FROM table makes them unambiguous. normConvTime renders
+// a Go bound in the byte-identical form so cursor comparisons round-trip.
 const (
-	convUpdatedNorm = `strftime('%Y-%m-%dT%H:%M:%fZ', c.updated_at)`
-	convCreatedNorm = `strftime('%Y-%m-%dT%H:%M:%fZ', c.created_at)`
+	convUpdatedNorm = `strftime('%Y-%m-%dT%H:%M:%fZ', updated_at)`
+	convCreatedNorm = `strftime('%Y-%m-%dT%H:%M:%fZ', created_at)`
 	convCountExpr   = `(SELECT COUNT(*) FROM messages m WHERE m.conversation_id = c.id AND m.status = 'active')`
 
 	// convSummarySelect is the inner column list shared by both query forms
@@ -215,6 +217,16 @@ func (s *SQLiteStore) QueryConversations(q ConversationQuery) (*ConversationPage
 	}
 
 	f := s.conversationFilters(q)
+
+	// A row whose timestamp strftime cannot parse yields a NULL sort value: it
+	// has no valid position in a time ordering and would produce an unusable
+	// empty keyset cursor at a page boundary. Exclude such rows from time-sorted
+	// views (they stay reachable via ids/kind/message_count). Applied to the
+	// shared filter so the page and the total agree. message_count sort is
+	// unaffected — its cursor value is the count, not the timestamp.
+	if !sortIsCount {
+		f.inner = append(f.inner, innerSortExpr+" IS NOT NULL")
+	}
 
 	total, err := s.countConversations(f)
 	if err != nil {

--- a/internal/state/memory/conversations_query.go
+++ b/internal/state/memory/conversations_query.go
@@ -1,0 +1,387 @@
+package memory
+
+import (
+	"database/sql"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/nugget/thane-ai-agent/internal/platform/database"
+)
+
+// Conversation timestamp columns are TEXT in mixed shapes: the message
+// write path binds a bare time.Now() (local-zone, space-separated, see
+// [database.SQLiteTimestampLayout]) while the metadata write path stores
+// RFC3339Nano UTC. Raw-column ordering and keyset comparison are therefore
+// silently wrong across zones. These strftime expressions collapse every
+// shape to one fixed-width, millisecond-precision, UTC, lexically-sortable
+// form; the matching expression indexes (idx_conversations_{updated,created}_norm
+// in schema.go) make ORDER BY + keyset seeks index-driven. normConvTime
+// renders a Go bound in the byte-identical form so cursor comparisons round-trip.
+const (
+	convUpdatedNorm = `strftime('%Y-%m-%dT%H:%M:%fZ', c.updated_at)`
+	convCreatedNorm = `strftime('%Y-%m-%dT%H:%M:%fZ', c.created_at)`
+	convCountExpr   = `(SELECT COUNT(*) FROM messages m WHERE m.conversation_id = c.id AND m.status = 'active')`
+
+	// convSummarySelect is the inner column list shared by both query forms
+	// (flat and outer-wrapped). Aliased so the outer min/max or message_count
+	// wrapper can reference the columns; scanning is positional either way.
+	convSummarySelect = "c.id AS id, " + convCountExpr + " AS message_count, " +
+		convCreatedNorm + " AS created_norm, " + convUpdatedNorm + " AS updated_norm, c.metadata AS metadata"
+)
+
+func normConvTime(t time.Time) string {
+	// Round to milliseconds to match SQLite strftime('%f'), which ROUNDS the
+	// fractional seconds; a plain .000 format truncates, which would disagree
+	// with the column at the sub-millisecond edge of a range bound.
+	return t.UTC().Round(time.Millisecond).Format("2006-01-02T15:04:05.000Z")
+}
+
+// ConversationQuery describes a filtered, sorted, keyset-paginated query
+// over the conversation store. The handler validates and normalizes inputs;
+// the store also defends itself — defaulting empty sort/order, clamping limit,
+// and rejecting an unknown sort — so it is safe to call directly (e.g. tests).
+type ConversationQuery struct {
+	IDs   []string // exact id membership (c.id IN ...)
+	Kinds []string // id-prefix families WITHOUT the trailing '-' (e.g. "signal")
+
+	Channel   string // metadata.channel_binding.channel
+	ContactID string // metadata.channel_binding.contact_id
+	Address   string // metadata.channel_binding.address
+	Q         string // substring over id + contact_name + address (metadata only)
+
+	UpdatedAfter  *time.Time
+	UpdatedBefore *time.Time
+	CreatedAfter  *time.Time
+	CreatedBefore *time.Time
+
+	MinMessages *int
+	MaxMessages *int
+
+	Sort   string // "updated_at" (default) | "created_at" | "message_count"
+	Order  string // "asc" | "desc" (default)
+	Limit  int    // clamped to [1,200]
+	Cursor *ConvCursor
+}
+
+// ConvCursor is an opaque keyset position: the sort value of the last row
+// of a page plus its id tiebreak. The handler encodes/decodes it to a token;
+// the store consumes the decoded struct.
+type ConvCursor struct {
+	Sort  string `json:"s"`
+	Order string `json:"d"`
+	V     string `json:"v"` // normalized time string, or message count as a decimal string
+	ID    string `json:"i"`
+}
+
+// ConversationSummary is a lightweight conversation descriptor — identity,
+// active message count, timestamps, and channel binding — with no message
+// content. message_count is the TRUE active count (uncapped), unlike the
+// legacy list which reported min(active, maxMessages).
+type ConversationSummary struct {
+	ID             string          `json:"id"`
+	MessageCount   int             `json:"message_count"`
+	CreatedAt      time.Time       `json:"created_at"`
+	UpdatedAt      time.Time       `json:"updated_at"`
+	ChannelBinding *ChannelBinding `json:"channel_binding,omitempty"`
+}
+
+// ConversationPage is one page of summaries plus the total matching the
+// filter (stable across pages — it ignores the cursor) and the cursor for
+// the next page (nil on the last page).
+type ConversationPage struct {
+	Conversations []ConversationSummary
+	Total         int
+	NextCursor    *ConvCursor
+}
+
+// convFilters holds the shared WHERE fragments. inner clauses run against
+// conversations c; minMax clauses reference the message_count alias and so
+// must run in an outer wrapper. The cursor is applied separately (only the
+// page query carries it) so Total stays cursor-independent.
+type convFilters struct {
+	inner      []string
+	innerArgs  []any
+	minMax     []string
+	minMaxArgs []any
+}
+
+func (s *SQLiteStore) conversationFilters(q ConversationQuery) convFilters {
+	var f convFilters
+
+	// Membership group: ids OR kind-prefixes, OR'd together then AND'd with the rest.
+	var member []string
+	if len(q.IDs) > 0 {
+		member = append(member, "c.id IN ("+convPlaceholders(len(q.IDs))+")")
+		for _, id := range q.IDs {
+			f.innerArgs = append(f.innerArgs, id)
+		}
+	}
+	for _, k := range q.Kinds {
+		member = append(member, `c.id LIKE ? ESCAPE '\'`)
+		f.innerArgs = append(f.innerArgs, escapeLikePattern(k)+"-%")
+	}
+	if len(member) > 0 {
+		f.inner = append(f.inner, "("+strings.Join(member, " OR ")+")")
+	}
+
+	// Metadata filters — each guarded by json_valid so a row with invalid
+	// metadata (an expected on-disk state) is excluded rather than aborting
+	// the whole query.
+	if q.Channel != "" {
+		f.inner = append(f.inner, `(json_valid(c.metadata) AND json_extract(c.metadata,'$.channel_binding.channel') = ?)`)
+		f.innerArgs = append(f.innerArgs, q.Channel)
+	}
+	if q.ContactID != "" {
+		f.inner = append(f.inner, `(json_valid(c.metadata) AND json_extract(c.metadata,'$.channel_binding.contact_id') = ?)`)
+		f.innerArgs = append(f.innerArgs, q.ContactID)
+	}
+	if q.Address != "" {
+		f.inner = append(f.inner, `(json_valid(c.metadata) AND json_extract(c.metadata,'$.channel_binding.address') = ?)`)
+		f.innerArgs = append(f.innerArgs, q.Address)
+	}
+	if q.Q != "" {
+		like := "%" + escapeLikePattern(q.Q) + "%"
+		f.inner = append(f.inner, `(c.id LIKE ? ESCAPE '\' OR (json_valid(c.metadata) AND (COALESCE(json_extract(c.metadata,'$.channel_binding.contact_name'),'') LIKE ? ESCAPE '\' OR COALESCE(json_extract(c.metadata,'$.channel_binding.address'),'') LIKE ? ESCAPE '\')))`)
+		f.innerArgs = append(f.innerArgs, like, like, like)
+	}
+
+	// Time ranges, compared against the normalized expression (index-friendly).
+	if q.UpdatedAfter != nil {
+		f.inner = append(f.inner, convUpdatedNorm+" >= ?")
+		f.innerArgs = append(f.innerArgs, normConvTime(*q.UpdatedAfter))
+	}
+	if q.UpdatedBefore != nil {
+		f.inner = append(f.inner, convUpdatedNorm+" < ?")
+		f.innerArgs = append(f.innerArgs, normConvTime(*q.UpdatedBefore))
+	}
+	if q.CreatedAfter != nil {
+		f.inner = append(f.inner, convCreatedNorm+" >= ?")
+		f.innerArgs = append(f.innerArgs, normConvTime(*q.CreatedAfter))
+	}
+	if q.CreatedBefore != nil {
+		f.inner = append(f.inner, convCreatedNorm+" < ?")
+		f.innerArgs = append(f.innerArgs, normConvTime(*q.CreatedBefore))
+	}
+
+	if q.MinMessages != nil {
+		f.minMax = append(f.minMax, "message_count >= ?")
+		f.minMaxArgs = append(f.minMaxArgs, *q.MinMessages)
+	}
+	if q.MaxMessages != nil {
+		f.minMax = append(f.minMax, "message_count <= ?")
+		f.minMaxArgs = append(f.minMaxArgs, *q.MaxMessages)
+	}
+
+	return f
+}
+
+// QueryConversations returns one filtered, sorted, keyset-paginated page of
+// conversation summaries plus the total matching the filter. It never loads
+// message content: the active count is a correlated COUNT over the
+// idx_messages_status index, so cost scales with the page size and filter
+// selectivity, not the all-time conversation corpus. GetAllConversations is
+// left untouched for the checkpointer, which needs full message bodies.
+func (s *SQLiteStore) QueryConversations(q ConversationQuery) (*ConversationPage, error) {
+	sort := "updated_at"
+	switch q.Sort {
+	case "", "updated_at":
+	case "created_at", "message_count":
+		sort = q.Sort
+	default:
+		return nil, fmt.Errorf("invalid sort %q", q.Sort)
+	}
+	order := "desc"
+	cmp := "<"
+	if q.Order == "asc" {
+		order, cmp = "asc", ">"
+	}
+	dir := strings.ToUpper(order)
+
+	limit := q.Limit
+	if limit <= 0 {
+		limit = 50
+	}
+	if limit > 200 {
+		limit = 200
+	}
+
+	sortIsCount := sort == "message_count"
+	innerSortExpr := convUpdatedNorm
+	outerSortCol := "updated_norm"
+	if sort == "created_at" {
+		innerSortExpr, outerSortCol = convCreatedNorm, "created_norm"
+	}
+
+	f := s.conversationFilters(q)
+
+	total, err := s.countConversations(f)
+	if err != nil {
+		return nil, err
+	}
+
+	// Page query. The keyset cursor lives in the inner WHERE for time sorts
+	// (so the expression index drives the seek) and in the outer WHERE for the
+	// count sort (where the alias is referenceable).
+	inner := append([]string(nil), f.inner...)
+	innerArgs := append([]any(nil), f.innerArgs...)
+	outer := append([]string(nil), f.minMax...)
+	outerArgs := append([]any(nil), f.minMaxArgs...)
+
+	if q.Cursor != nil {
+		if sortIsCount {
+			cv, err := strconv.Atoi(q.Cursor.V)
+			if err != nil {
+				return nil, fmt.Errorf("invalid count cursor %q: %w", q.Cursor.V, err)
+			}
+			outer = append(outer, "(message_count "+cmp+" ? OR (message_count = ? AND id "+cmp+" ?))")
+			outerArgs = append(outerArgs, cv, cv, q.Cursor.ID)
+		} else {
+			inner = append(inner, "("+innerSortExpr+" "+cmp+" ? OR ("+innerSortExpr+" = ? AND c.id "+cmp+" ?))")
+			innerArgs = append(innerArgs, q.Cursor.V, q.Cursor.V, q.Cursor.ID)
+		}
+	}
+
+	needOuter := sortIsCount || len(f.minMax) > 0
+
+	var sb strings.Builder
+	var args []any
+	if !needOuter {
+		sb.WriteString("SELECT " + convSummarySelect + " FROM conversations c")
+		if len(inner) > 0 {
+			sb.WriteString(" WHERE " + strings.Join(inner, " AND "))
+		}
+		sb.WriteString(" ORDER BY " + innerSortExpr + " " + dir + ", c.id " + dir + " LIMIT ?")
+		args = append(args, innerArgs...)
+		args = append(args, limit)
+	} else {
+		var innerSQL strings.Builder
+		innerSQL.WriteString("SELECT " + convSummarySelect + " FROM conversations c")
+		if len(inner) > 0 {
+			innerSQL.WriteString(" WHERE " + strings.Join(inner, " AND "))
+		}
+
+		sb.WriteString("SELECT id, message_count, created_norm, updated_norm, metadata FROM (")
+		sb.WriteString(innerSQL.String())
+		sb.WriteString(")")
+		if len(outer) > 0 {
+			sb.WriteString(" WHERE " + strings.Join(outer, " AND "))
+		}
+		orderCol := outerSortCol
+		if sortIsCount {
+			orderCol = "message_count"
+		}
+		sb.WriteString(" ORDER BY " + orderCol + " " + dir + ", id " + dir + " LIMIT ?")
+		args = append(args, innerArgs...)
+		args = append(args, outerArgs...)
+		args = append(args, limit)
+	}
+
+	rows, err := s.db.Query(sb.String(), args...)
+	if err != nil {
+		return nil, fmt.Errorf("query conversations: %w", err)
+	}
+	defer rows.Close()
+
+	page := &ConversationPage{Total: total}
+	var lastID, lastNorm string
+	var lastCount int
+	for rows.Next() {
+		var id string
+		// strftime returns NULL for any value it cannot parse; scan into
+		// NullString so one odd row degrades to a zero timestamp (mirroring
+		// GetAllConversations' tolerate-and-continue) rather than 500-ing the
+		// whole page.
+		var createdNorm, updatedNorm, metadata sql.NullString
+		var msgCount int
+		if err := rows.Scan(&id, &msgCount, &createdNorm, &updatedNorm, &metadata); err != nil {
+			return nil, fmt.Errorf("scan conversation summary: %w", err)
+		}
+		sum := ConversationSummary{ID: id, MessageCount: msgCount}
+		if createdNorm.Valid {
+			if t, err := database.ParseTimestamp(createdNorm.String); err == nil {
+				sum.CreatedAt = t
+			}
+		}
+		if updatedNorm.Valid {
+			if t, err := database.ParseTimestamp(updatedNorm.String); err == nil {
+				sum.UpdatedAt = t
+			}
+		}
+		if metadata.Valid {
+			if meta, err := parseConversationMetadata(metadata.String); err != nil {
+				s.logger.Warn("conversation metadata invalid during query",
+					"conversation_id", id, "error", err)
+			} else if meta != nil {
+				sum.ChannelBinding = meta.ChannelBinding
+			}
+		}
+		page.Conversations = append(page.Conversations, sum)
+		lastID = id
+		lastCount = msgCount
+		if sort == "created_at" {
+			lastNorm = createdNorm.String
+		} else {
+			lastNorm = updatedNorm.String
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate conversations: %w", err)
+	}
+
+	if len(page.Conversations) == limit {
+		cur := &ConvCursor{Sort: sort, Order: order, ID: lastID}
+		if sortIsCount {
+			cur.V = strconv.Itoa(lastCount)
+		} else {
+			cur.V = lastNorm
+		}
+		page.NextCursor = cur
+	}
+	return page, nil
+}
+
+// countConversations returns the number of conversations matching the filter,
+// independent of any pagination cursor — so "N matches" stays stable as the
+// caller pages. It avoids the message_count subquery entirely unless a
+// min/max-messages filter actually needs it.
+func (s *SQLiteStore) countConversations(f convFilters) (int, error) {
+	var sb strings.Builder
+	var args []any
+	if len(f.minMax) == 0 {
+		sb.WriteString("SELECT COUNT(*) FROM conversations c")
+		if len(f.inner) > 0 {
+			sb.WriteString(" WHERE " + strings.Join(f.inner, " AND "))
+		}
+		args = append(args, f.innerArgs...)
+	} else {
+		sb.WriteString("SELECT COUNT(*) FROM (SELECT " + convCountExpr + " AS message_count FROM conversations c")
+		if len(f.inner) > 0 {
+			sb.WriteString(" WHERE " + strings.Join(f.inner, " AND "))
+		}
+		sb.WriteString(") WHERE " + strings.Join(f.minMax, " AND "))
+		args = append(args, f.innerArgs...)
+		args = append(args, f.minMaxArgs...)
+	}
+
+	var total int
+	if err := s.db.QueryRow(sb.String(), args...).Scan(&total); err != nil {
+		return 0, fmt.Errorf("count conversations: %w", err)
+	}
+	return total, nil
+}
+
+func convPlaceholders(n int) string {
+	if n <= 0 {
+		return ""
+	}
+	return strings.Repeat("?,", n-1) + "?"
+}
+
+// escapeLikePattern escapes the LIKE metacharacters %, _, and the escape
+// character itself so a literal value matches literally. Pair with
+// ESCAPE '\' in the query.
+func escapeLikePattern(s string) string {
+	return strings.NewReplacer(`\`, `\\`, `%`, `\%`, `_`, `\_`).Replace(s)
+}

--- a/internal/state/memory/conversations_query_test.go
+++ b/internal/state/memory/conversations_query_test.go
@@ -1,0 +1,352 @@
+package memory
+
+import (
+	"fmt"
+	"sort"
+	"testing"
+	"time"
+)
+
+func newConvQueryStore(t *testing.T, maxMessages int) *SQLiteStore {
+	t.Helper()
+	store, err := NewSQLiteStore(t.TempDir()+"/memory.db", maxMessages)
+	if err != nil {
+		t.Fatalf("NewSQLiteStore: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	return store
+}
+
+// seedConv inserts a conversation row with exact timestamp strings (so tests
+// can simulate the mixed-zone on-disk reality) and optional metadata.
+func seedConv(t *testing.T, s *SQLiteStore, id, created, updated, metadata string) {
+	t.Helper()
+	var meta any
+	if metadata != "" {
+		meta = metadata
+	}
+	if _, err := s.db.Exec(
+		`INSERT INTO conversations (id, created_at, updated_at, metadata) VALUES (?,?,?,?)`,
+		id, created, updated, meta); err != nil {
+		t.Fatalf("seed conversation %s: %v", id, err)
+	}
+}
+
+func seedMessages(t *testing.T, s *SQLiteStore, convID, status string, n int) {
+	t.Helper()
+	for i := 0; i < n; i++ {
+		if _, err := s.db.Exec(
+			`INSERT INTO messages (id, conversation_id, role, content, timestamp, status) VALUES (?,?,?,?,?,?)`,
+			fmt.Sprintf("%s-%s-m%d", convID, status, i), convID, "user", "x",
+			"2026-06-24T00:00:00Z", status); err != nil {
+			t.Fatalf("seed message %s/%d: %v", convID, i, err)
+		}
+	}
+}
+
+func convIDs(page *ConversationPage) []string {
+	out := make([]string, 0, len(page.Conversations))
+	for _, c := range page.Conversations {
+		out = append(out, c.ID)
+	}
+	return out
+}
+
+// TestQueryConversationsMixedZoneOrdering is the regression guard for the
+// reproduced bug: a later instant stored in local-offset form must NOT
+// mis-sort against an earlier instant stored as UTC. Raw-column ordering
+// would return the wrong order; the strftime normalization fixes it.
+func TestQueryConversationsMixedZoneOrdering(t *testing.T) {
+	s := newConvQueryStore(t, 100)
+	// X = 23:00Z written in driver-native local-offset form (sorts BEFORE the
+	// UTC rows lexically, though it is the LATEST instant).
+	seedConv(t, s, "X", "2026-06-24T10:00:00Z", "2026-06-24 18:00:00.000000000-05:00", "")
+	seedConv(t, s, "Y", "2026-06-24T11:00:00Z", "2026-06-24T20:00:00Z", "")
+	seedConv(t, s, "Z", "2026-06-24T12:00:00Z", "2026-06-24T21:00:00Z", "")
+
+	desc, err := s.QueryConversations(ConversationQuery{Sort: "updated_at", Order: "desc", Limit: 10})
+	if err != nil {
+		t.Fatalf("desc query: %v", err)
+	}
+	if got := convIDs(desc); !equalSlice(got, []string{"X", "Z", "Y"}) {
+		t.Fatalf("updated_at desc = %v, want [X Z Y] (X is 23:00Z despite local-offset storage)", got)
+	}
+
+	asc, err := s.QueryConversations(ConversationQuery{Sort: "updated_at", Order: "asc", Limit: 10})
+	if err != nil {
+		t.Fatalf("asc query: %v", err)
+	}
+	if got := convIDs(asc); !equalSlice(got, []string{"Y", "Z", "X"}) {
+		t.Fatalf("updated_at asc = %v, want [Y Z X]", got)
+	}
+}
+
+// TestQueryConversationsInvalidMetadata proves the json_valid guard is
+// load-bearing: a conversation with broken metadata must not abort metadata
+// filters, and must still be returned by non-metadata queries.
+func TestQueryConversationsInvalidMetadata(t *testing.T) {
+	s := newConvQueryStore(t, 100)
+	seedConv(t, s, "good", "2026-06-24T10:00:00Z", "2026-06-24T10:00:00Z",
+		`{"channel_binding":{"channel":"signal","contact_name":"Alice","address":"+15551234567"}}`)
+	seedConv(t, s, "broken", "2026-06-24T11:00:00Z", "2026-06-24T11:00:00Z", `{broken json`)
+
+	// Unfiltered: both returned (broken row tolerated, ChannelBinding nil).
+	all, err := s.QueryConversations(ConversationQuery{Limit: 10})
+	if err != nil {
+		t.Fatalf("unfiltered query errored (guard missing?): %v", err)
+	}
+	if len(all.Conversations) != 2 {
+		t.Fatalf("unfiltered len = %d, want 2", len(all.Conversations))
+	}
+
+	for _, tc := range []struct {
+		name  string
+		query ConversationQuery
+	}{
+		{"channel", ConversationQuery{Channel: "signal", Limit: 10}},
+		{"contact_via_q", ConversationQuery{Q: "Alice", Limit: 10}},
+		{"address", ConversationQuery{Address: "+15551234567", Limit: 10}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			page, err := s.QueryConversations(tc.query)
+			if err != nil {
+				t.Fatalf("query errored (json_valid guard missing): %v", err)
+			}
+			if got := convIDs(page); !equalSlice(got, []string{"good"}) {
+				t.Fatalf("got %v, want [good]", got)
+			}
+		})
+	}
+}
+
+// TestQueryConversationsKeysetPaging walks every sort/order through full
+// pagination and asserts the union of pages equals the correct total order
+// with no dupes or skips — including a tie-heavy message_count ranking.
+func TestQueryConversationsKeysetPaging(t *testing.T) {
+	s := newConvQueryStore(t, 100)
+	base := time.Date(2026, 6, 24, 0, 0, 0, 0, time.UTC)
+	type seed struct {
+		id      string
+		updated time.Time
+		created time.Time
+		count   int
+	}
+	seeds := []seed{
+		{"c1", base.Add(1 * time.Minute), base.Add(6 * time.Minute), 0},
+		{"c2", base.Add(2 * time.Minute), base.Add(5 * time.Minute), 0},
+		{"c3", base.Add(3 * time.Minute), base.Add(4 * time.Minute), 5},
+		{"c4", base.Add(4 * time.Minute), base.Add(3 * time.Minute), 5},
+		{"c5", base.Add(5 * time.Minute), base.Add(2 * time.Minute), 2},
+		{"c6", base.Add(6 * time.Minute), base.Add(1 * time.Minute), 2},
+	}
+	for _, sd := range seeds {
+		seedConv(t, s, sd.id,
+			sd.created.Format(time.RFC3339Nano), sd.updated.Format(time.RFC3339Nano), "")
+		seedMessages(t, s, sd.id, "active", sd.count)
+	}
+
+	expected := func(sortKey, order string) []string {
+		cp := append([]seed(nil), seeds...)
+		sort.Slice(cp, func(i, j int) bool {
+			var c int
+			switch sortKey {
+			case "updated_at":
+				c = cp[i].updated.Compare(cp[j].updated)
+			case "created_at":
+				c = cp[i].created.Compare(cp[j].created)
+			case "message_count":
+				c = cp[i].count - cp[j].count
+			}
+			if c == 0 {
+				switch {
+				case cp[i].id < cp[j].id:
+					c = -1
+				case cp[i].id > cp[j].id:
+					c = 1
+				}
+			}
+			if order == "desc" {
+				return c > 0
+			}
+			return c < 0
+		})
+		out := make([]string, len(cp))
+		for i, sd := range cp {
+			out[i] = sd.id
+		}
+		return out
+	}
+
+	for _, sortKey := range []string{"updated_at", "created_at", "message_count"} {
+		for _, order := range []string{"desc", "asc"} {
+			name := sortKey + "_" + order
+			t.Run(name, func(t *testing.T) {
+				q := ConversationQuery{Sort: sortKey, Order: order, Limit: 2}
+				var got []string
+				for i := 0; i < 100; i++ {
+					page, err := s.QueryConversations(q)
+					if err != nil {
+						t.Fatalf("page %d: %v", i, err)
+					}
+					if page.Total != len(seeds) {
+						t.Fatalf("total = %d, want %d", page.Total, len(seeds))
+					}
+					got = append(got, convIDs(page)...)
+					if page.NextCursor == nil {
+						break
+					}
+					q.Cursor = page.NextCursor
+				}
+				if want := expected(sortKey, order); !equalSlice(got, want) {
+					t.Fatalf("paged order = %v, want %v", got, want)
+				}
+			})
+		}
+	}
+}
+
+// TestQueryConversationsMessageFilters covers min/max via *int (absent vs 0),
+// the empty-stub case, the impossible range, and total reflecting the filter.
+func TestQueryConversationsMessageFilters(t *testing.T) {
+	s := newConvQueryStore(t, 100)
+	seedConv(t, s, "empty", "2026-06-24T10:00:00Z", "2026-06-24T10:00:00Z", "")
+	seedConv(t, s, "one", "2026-06-24T11:00:00Z", "2026-06-24T11:00:00Z", "")
+	seedMessages(t, s, "one", "active", 1)
+	seedConv(t, s, "five", "2026-06-24T12:00:00Z", "2026-06-24T12:00:00Z", "")
+	seedMessages(t, s, "five", "active", 5)
+
+	zero := 0
+	one := 1
+	two := 2
+	ten := 10
+
+	cases := []struct {
+		name      string
+		min, max  *int
+		wantIDs   []string
+		wantTotal int
+	}{
+		{"max0_empty_stubs", nil, &zero, []string{"empty"}, 1},
+		{"min1_excludes_empty", &one, nil, []string{"five", "one"}, 2},
+		{"range_2_10", &two, &ten, []string{"five"}, 1},
+		{"impossible_min_gt_max", &ten, &zero, nil, 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			page, err := s.QueryConversations(ConversationQuery{
+				MinMessages: tc.min, MaxMessages: tc.max, Sort: "updated_at", Order: "desc", Limit: 10,
+			})
+			if err != nil {
+				t.Fatalf("query: %v", err)
+			}
+			if got := convIDs(page); !equalSlice(got, tc.wantIDs) {
+				t.Fatalf("ids = %v, want %v", got, tc.wantIDs)
+			}
+			if page.Total != tc.wantTotal {
+				t.Fatalf("total = %d, want %d", page.Total, tc.wantTotal)
+			}
+		})
+	}
+}
+
+// TestQueryConversationsTrueCount asserts message_count is the true uncapped
+// active count, not the legacy min(active, maxMessages).
+func TestQueryConversationsTrueCount(t *testing.T) {
+	s := newConvQueryStore(t, 3) // small cap; legacy len(GetMessages) would report 3
+	seedConv(t, s, "big", "2026-06-24T10:00:00Z", "2026-06-24T10:00:00Z", "")
+	seedMessages(t, s, "big", "active", 5)
+	seedMessages(t, s, "big", "compacted", 4) // must NOT be counted
+
+	page, err := s.QueryConversations(ConversationQuery{IDs: []string{"big"}, Limit: 10})
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if len(page.Conversations) != 1 || page.Conversations[0].MessageCount != 5 {
+		t.Fatalf("message_count = %+v, want 5 (uncapped active only)", page.Conversations)
+	}
+	// Sanity: the legacy capped path still reports the cap.
+	if n := len(s.GetMessages("big")); n != 3 {
+		t.Fatalf("GetMessages len = %d, want 3 (the cap this test contrasts)", n)
+	}
+}
+
+// TestQueryConversationsFiltersAndEmpty covers ids, kind prefixes, channel
+// binding population, and the zero-match contract.
+func TestQueryConversationsFiltersAndEmpty(t *testing.T) {
+	s := newConvQueryStore(t, 100)
+	seedConv(t, s, "loop-1", "2026-06-24T10:00:00Z", "2026-06-24T10:00:00Z", "")
+	seedConv(t, s, "sched-1", "2026-06-24T11:00:00Z", "2026-06-24T11:00:00Z", "")
+	seedConv(t, s, "signal-+1555", "2026-06-24T12:00:00Z", "2026-06-24T12:00:00Z",
+		`{"channel_binding":{"channel":"signal","contact_name":"Bob"}}`)
+
+	t.Run("ids", func(t *testing.T) {
+		page, err := s.QueryConversations(ConversationQuery{IDs: []string{"loop-1", "signal-+1555"}, Limit: 10})
+		if err != nil {
+			t.Fatalf("query: %v", err)
+		}
+		if got := convIDs(page); !equalSlice(got, []string{"signal-+1555", "loop-1"}) {
+			t.Fatalf("ids filter = %v", got)
+		}
+	})
+
+	t.Run("kind_single", func(t *testing.T) {
+		page, _ := s.QueryConversations(ConversationQuery{Kinds: []string{"signal"}, Limit: 10})
+		if got := convIDs(page); !equalSlice(got, []string{"signal-+1555"}) {
+			t.Fatalf("kind=signal = %v", got)
+		}
+		if cb := page.Conversations[0].ChannelBinding; cb == nil || cb.ContactName != "Bob" {
+			t.Fatalf("channel_binding not populated: %+v", page.Conversations[0])
+		}
+	})
+
+	t.Run("kind_multi", func(t *testing.T) {
+		page, _ := s.QueryConversations(ConversationQuery{Kinds: []string{"loop", "sched"}, Order: "asc", Limit: 10})
+		if got := convIDs(page); !equalSlice(got, []string{"loop-1", "sched-1"}) {
+			t.Fatalf("kind=loop,sched = %v", got)
+		}
+	})
+
+	t.Run("zero_match", func(t *testing.T) {
+		page, err := s.QueryConversations(ConversationQuery{Kinds: []string{"nonexistent"}, Limit: 10})
+		if err != nil {
+			t.Fatalf("query: %v", err)
+		}
+		if len(page.Conversations) != 0 || page.Total != 0 || page.NextCursor != nil {
+			t.Fatalf("zero-match = %+v, want empty/total0/nilcursor", page)
+		}
+	})
+}
+
+// TestQueryConversationsUnparseableTimestamp guards against a single row with
+// a timestamp strftime cannot parse (→ NULL) crashing the whole page: it must
+// degrade to a zero timestamp and still be returned, like GetAllConversations.
+func TestQueryConversationsUnparseableTimestamp(t *testing.T) {
+	s := newConvQueryStore(t, 100)
+	seedConv(t, s, "ok", "2026-06-24T10:00:00Z", "2026-06-24T10:00:00Z", "")
+	seedConv(t, s, "garbage", "not-a-timestamp", "not-a-timestamp", "")
+
+	page, err := s.QueryConversations(ConversationQuery{Limit: 10})
+	if err != nil {
+		t.Fatalf("query errored on unparseable timestamp (should tolerate): %v", err)
+	}
+	if len(page.Conversations) != 2 {
+		t.Fatalf("len = %d, want 2 (garbage row tolerated)", len(page.Conversations))
+	}
+	for _, c := range page.Conversations {
+		if c.ID == "garbage" && !c.UpdatedAt.IsZero() {
+			t.Fatalf("garbage row UpdatedAt = %v, want zero", c.UpdatedAt)
+		}
+	}
+}
+
+func equalSlice(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/state/memory/conversations_query_test.go
+++ b/internal/state/memory/conversations_query_test.go
@@ -317,22 +317,37 @@ func TestQueryConversationsFiltersAndEmpty(t *testing.T) {
 	})
 }
 
-// TestQueryConversationsUnparseableTimestamp guards against a single row with
-// a timestamp strftime cannot parse (→ NULL) crashing the whole page: it must
-// degrade to a zero timestamp and still be returned, like GetAllConversations.
+// TestQueryConversationsUnparseableTimestamp covers a row whose timestamp
+// strftime cannot parse (→ NULL). It must never crash the page; it is excluded
+// from TIME-sorted views (no valid position in a time ordering, and it would
+// otherwise yield an empty keyset cursor), but still surfaces under a
+// non-time sort with a tolerated zero timestamp.
 func TestQueryConversationsUnparseableTimestamp(t *testing.T) {
 	s := newConvQueryStore(t, 100)
 	seedConv(t, s, "ok", "2026-06-24T10:00:00Z", "2026-06-24T10:00:00Z", "")
 	seedConv(t, s, "garbage", "not-a-timestamp", "not-a-timestamp", "")
 
-	page, err := s.QueryConversations(ConversationQuery{Limit: 10})
+	// Time sort (the default): garbage row excluded, no error, total agrees.
+	timeSorted, err := s.QueryConversations(ConversationQuery{Sort: "updated_at", Limit: 10})
 	if err != nil {
-		t.Fatalf("query errored on unparseable timestamp (should tolerate): %v", err)
+		t.Fatalf("time-sorted query errored on unparseable timestamp: %v", err)
 	}
-	if len(page.Conversations) != 2 {
-		t.Fatalf("len = %d, want 2 (garbage row tolerated)", len(page.Conversations))
+	if got := convIDs(timeSorted); !equalSlice(got, []string{"ok"}) {
+		t.Fatalf("updated_at sort = %v, want [ok] (garbage excluded)", got)
 	}
-	for _, c := range page.Conversations {
+	if timeSorted.Total != 1 {
+		t.Fatalf("time-sorted total = %d, want 1", timeSorted.Total)
+	}
+
+	// Non-time sort: garbage surfaces, with a tolerated zero timestamp.
+	countSorted, err := s.QueryConversations(ConversationQuery{Sort: "message_count", Limit: 10})
+	if err != nil {
+		t.Fatalf("count-sorted query: %v", err)
+	}
+	if len(countSorted.Conversations) != 2 {
+		t.Fatalf("message_count sort len = %d, want 2 (garbage included)", len(countSorted.Conversations))
+	}
+	for _, c := range countSorted.Conversations {
 		if c.ID == "garbage" && !c.UpdatedAt.IsZero() {
 			t.Fatalf("garbage row UpdatedAt = %v, want zero", c.UpdatedAt)
 		}

--- a/internal/state/memory/schema.go
+++ b/internal/state/memory/schema.go
@@ -44,6 +44,12 @@ var schema = database.Schema{
 		database.IndexCreate{Name: "idx_messages_conversation", SQL: `CREATE INDEX IF NOT EXISTS idx_messages_conversation ON messages(conversation_id, timestamp)`},
 		database.IndexCreate{Name: "idx_messages_session", SQL: `CREATE INDEX IF NOT EXISTS idx_messages_session ON messages(session_id, timestamp)`},
 		database.IndexCreate{Name: "idx_messages_status", SQL: `CREATE INDEX IF NOT EXISTS idx_messages_status ON messages(conversation_id, status)`},
+		// Expression indexes over the normalized (zone-collapsed, lexically
+		// sortable) timestamp form so the conversation-query endpoint's ORDER BY
+		// and keyset seeks are index-driven. They MUST match the strftime
+		// expression used in conversations_query.go verbatim to be usable.
+		database.IndexCreate{Name: "idx_conversations_updated_norm", SQL: `CREATE INDEX IF NOT EXISTS idx_conversations_updated_norm ON conversations(strftime('%Y-%m-%dT%H:%M:%fZ', updated_at), id)`},
+		database.IndexCreate{Name: "idx_conversations_created_norm", SQL: `CREATE INDEX IF NOT EXISTS idx_conversations_created_norm ON conversations(strftime('%Y-%m-%dT%H:%M:%fZ', created_at), id)`},
 		database.TableCreate{
 			Table: "tool_calls",
 			SQL: `CREATE TABLE IF NOT EXISTS tool_calls (


### PR DESCRIPTION
## Problem

`/v1/conversations` was an unbounded dump. `handleConversationList` called `GetAllConversations()`, which loads **every message of every conversation** — an N+1 over the full corpus — just to compute `len(messages)` for a summary list. On prod that's **~0.5s, 2.9 MB, and 16,746 SQL queries per call** over 16,745 conversations (and growing), which the web console re-fetched **every 15s** to resolve summaries for the handful of conversation ids the loop inspector already had in hand.

This started as "fix the N+1," but the real issue is the endpoint shape: its sole consumer wanted point lookups, and the surface returned the universe. The OpenAPI doc even claimed "List active conversations" and declared a `limit` param — both of which the handler ignored.

## Approach: the filters *are* the fix

Make `/v1/conversations` a proper **filter / sort / keyset-paginate** surface. Returning a bounded slice instead of everything is what eliminates the N+1, the 2.9 MB payload, and the refetch storm — the cost now scales with the page and filter selectivity, not the all-time conversation count.

**Backend** (`internal/state/memory/conversations_query.go`)
- New `SQLiteStore.QueryConversations`: a single query that counts active messages **in SQL** (correlated `COUNT` over the existing `idx_messages_status`) — no per-row message load. `GetAllConversations` is **left untouched** (its other caller, the checkpointer, needs full message bodies).
- Filters: `ids`, `kind` (id-prefix family), `channel`/`contact`/`address` (channel binding), `updated_/created_after/before` (RFC3339 **or** a duration meaning "ago"), `min_messages`/`max_messages`, `q` (metadata only — id/contact/address; message-content search stays at `/v1/archive/search`). `sort` = `updated_at`\|`created_at`\|`message_count`, `order`, `limit` (default 50, max 200), opaque **keyset cursor** with a stable `total`.
- **Mixed-zone timestamps:** conversation `created_at`/`updated_at` are TEXT in inconsistent shapes (bare local-offset from the message path, UTC from the metadata path). Raw-column ordering/keyset is silently wrong across zones, so `ORDER BY` and the cursor compare a `strftime`-normalized UTC form, backed by matching **expression indexes** (`idx_conversations_{updated,created}_norm`) so paging stays index-driven.
- `message_count` is now the **true uncapped active count** (was capped at the working-memory limit). "active conversations" becomes a query (`updated_after=1h`), not a fixed claim.

**Frontend** (`app.js`) — the loop inspector now fetches `/v1/conversations?ids=<its known ids>` instead of pulling the whole index. The global `conversationIndex` (2.9 MB + 15s TTL refetch) is gone.

**Docs** — OpenAPI `native.yaml` and `docs/reference/api.md` rewritten to the real contract (inline `limit` with `maximum: 200` so it doesn't impose a cap on the 8 ops that share the component param; object response shape; `400`).

## How it was built

Two design passes before code: an intent investigation (who calls it, what they actually need) and an adversarial design-validation pass that reproduced bugs against the real driver and produced a locked spec. That pass caught, before any code: the mixed-zone sort bug, an unguarded `json_extract` that would 500 on invalid-metadata rows, and the host-param cap. A post-implementation review pass then caught a NULL-timestamp scan crash, a truncate-vs-round sub-ms boundary, and a `time.Parse` convention break — all fixed with regression tests.

## Test plan

- [x] `internal/state/memory` — table-driven `QueryConversations`: mixed-zone ordering regression, invalid-metadata `json_valid` guard, keyset paging across all 6 sort/order combos (incl. tie-heavy `message_count`), min/max + empty-stub + impossible-range, true uncapped count, kind/ids filters, zero-match, unparseable-timestamp tolerance.
- [x] `internal/server/api` — handler param validation (bad sort/order/kind/time/cursor, `min>max`, `ids>200`), paging + null terminal cursor, cursor sort mismatch → 400, malformed-cursor → 400, `ids` + channel binding, relative-time filter.
- [x] `just ci` green locally (tests, vet, lint, architecture baseline).
- [x] Web console boots clean in the UI harness (graph renders, SSE connected, no JS errors). The `?ids=` happy path is covered by Go httptest end-to-end; the harness doesn't mount this endpoint.

## Notes

- First-party `/v1` contract with a single consumer we control — clean cut, no compat shim.
- One deliberate deviation from the design spec: `kind` is charset-validated (`[a-z0-9_]+`) and prefix-matched rather than checked against a hardcoded family allowlist, which already drifts from reality (prod has `media-`/`wake-` conversations). Unknown kinds simply match nothing.
- Follow-up (out of scope): the write paths bind bare `time.Now()` (local zone); normalizing them to UTC would let a plain index replace the expression index. The read-side normalization here is correct regardless.