### PR TITLE
feat(web): container-aware node graph + visual attribute-projection seam

### DIFF
--- a/internal/server/api/uiharness.go
+++ b/internal/server/api/uiharness.go
@@ -124,6 +124,21 @@ func harnessLoops() []looppkg.Status {
 			StartedAt: boot, EventDriven: true,
 			LastError: "connection refused: broker unreachable", ConsecutiveErrors: 4,
 		},
+		// A non-executing container (semantic grouping) holding a child loop —
+		// mirrors prod's "temporal" → "hor_conditions". Named NOT "core" so it
+		// exercises the general container render path (small/dimmed), not the
+		// __system__-collapsed core special case.
+		{
+			ID: "temporal", Name: "temporal", State: looppkg.StatePending, ParentID: "supervisor",
+			StartedAt: boot,
+			Config:    looppkg.Config{Name: "temporal", Operation: looppkg.OperationContainer},
+		},
+		{
+			ID: "hor_conditions", Name: "hor_conditions", State: looppkg.StateSleeping, ParentID: "temporal",
+			StartedAt: boot, Iterations: 2, Attempts: 2,
+			TotalInputTokens: 309_853, TotalOutputTokens: 5_252, LastInputTokens: 29_702,
+			ContextWindow: 131072, RecentConvIDs: []string{"conv-hor"},
+		},
 	}
 }
 

--- a/internal/server/web/static/app.js
+++ b/internal/server/web/static/app.js
@@ -471,6 +471,16 @@ function isRegistryCoreLoop(loop) {
   return op === 'container';
 }
 
+// isContainerLoop reports whether a loop is a non-executing container — a
+// semantic grouping node (config.Operation === "container") that holds child
+// loops but never runs iterations itself. Distinct from isRegistryCoreLoop,
+// which is the name-bound special case for the singleton "core" container
+// (collapsed into __system__). Containers are rendered as small, dimmed nodes
+// with no activity affordances; see projectLoopCharacteristics + style.css.
+function isContainerLoop(loop) {
+  return !!(loop && loop.config && loop.config.Operation === 'container');
+}
+
 // getRegistryCoreID returns the id of the collapsed registry-core loop
 // when one is present and the __system__ node is active, otherwise null.
 // Returns null whenever state.system is absent so that, before system
@@ -944,6 +954,7 @@ const CATEGORY_LABELS = {
   delegate: 'delegate',
   scheduled: 'scheduled',
   generic: 'generic',
+  container: 'container',
 };
 
 const NODE_LABEL_GAP = 24;
@@ -951,6 +962,9 @@ const SYSTEM_LABEL_GAP = 20;
 
 // Derive a visual category from loop data. Drives fill tone and sigil.
 function getLoopCategoryInfo(loop) {
+  if (isContainerLoop(loop)) {
+    return { category: 'container', source: 'config.Operation=container' };
+  }
   const hints = loop.config && loop.config.Hints;
   if (hints && hints.source === 'metacognitive') {
     return { category: 'metacognitive', source: 'hint source=metacognitive' };
@@ -988,10 +1002,19 @@ const CATEGORY_SIGILS = {
   delegate:      '↗',
   scheduled:     '◷',
   generic:       '•',
+  container:     '', // semantic grouping — empty center, no sigil
 };
 
+// categorySigil returns the center glyph for a category, preserving an
+// intentional empty sigil (e.g. containers) instead of falling back to the
+// generic dot.
+function categorySigil(category) {
+  const sigil = CATEGORY_SIGILS[category];
+  return sigil != null ? sigil : CATEGORY_SIGILS.generic;
+}
+
 function normalizeVisualCategory(category) {
-  return CATEGORY_SIGILS[category] ? category : 'generic';
+  return CATEGORY_LABELS[category] ? category : 'generic';
 }
 
 // Context-window tiers drive node radius. The steps are intentionally
@@ -1064,6 +1087,9 @@ function getModelParams(modelName) {
 const MIN_NODE_R = 22;
 const MAX_NODE_R = 50;
 const DEFAULT_NODE_R = 32;
+// Containers are semantic groupings, not executing entities — rendered small,
+// just large enough to be a comfortable context-menu click target.
+const CONTAINER_NODE_R = 16;
 
 function getModelRadiusFromParams(params) {
   if (params === null) return DEFAULT_NODE_R;
@@ -1147,6 +1173,11 @@ function getContextTier(contextWindow) {
 }
 
 function getLoopVisualCapacity(loop) {
+  // Containers don't execute, so context capacity is meaningless for them:
+  // fixed small radius, no tier label/badge.
+  if (isContainerLoop(loop)) {
+    return { radius: CONTAINER_NODE_R, label: '', key: 'container', basis: 'container', contextWindow: 0 };
+  }
   const contextWindow = getLoopContextWindow(loop);
   if (contextWindow > 0) {
     const tier = getContextTier(contextWindow);
@@ -1413,6 +1444,7 @@ function getLoopLatestSnapshot(loop) {
 }
 
 function describeLoopExecutionMode(loop) {
+  if (isContainerLoop(loop)) return 'container';
   if (loop.handler_only) return 'handler';
   if (loop.event_driven) return 'event-driven llm';
   return 'timer-driven llm';
@@ -2935,6 +2967,39 @@ function flashLinkingLine(loopId) {
   }
 }
 
+// setNodeData writes a data-* attribute only when it changed, keeping the
+// per-frame projection cheap (no redundant attribute churn).
+function setNodeData(dataset, key, value) {
+  if (dataset[key] !== value) dataset[key] = value;
+}
+
+// projectLoopCharacteristics is the single seam between loop data and node
+// styling: it projects a loop's semantic characteristics onto the outer <g>
+// as data-* attributes so CSS — and future themes/skins/layers — drive fill,
+// ring, sigil visibility, animation, etc. off the cascade rather than off
+// imperative branches here. Geometry (r/cx/cy) stays imperative in renderNode
+// because SVG cannot read CSS custom properties for layout. We project only
+// facts already on the wire; owner/sigil await dedicated spec fields.
+function projectLoopCharacteristics(loop, capacity, visualState, group) {
+  const d = group.dataset;
+  setNodeData(d, 'operation',
+    isContainerLoop(loop) ? 'container'
+      : loop.handler_only ? 'handler'
+      : loop.event_driven ? 'event'
+      : 'timer');
+  setNodeData(d, 'category', normalizeVisualCategory(getLoopCategory(loop)));
+  setNodeData(d, 'state', visualState);
+  setNodeData(d, 'contextTier', capacity.key);
+  setNodeData(d, 'contextWindow', String(capacity.contextWindow || 0));
+  setNodeData(d, 'relation', loop.parent_id ? 'child' : 'root');
+  const tz = loop.config && loop.config.Metadata && loop.config.Metadata.trust_zone;
+  if (tz && TRUST_ZONES.has(tz)) {
+    setNodeData(d, 'trustZone', tz);
+  } else if (d.trustZone !== undefined) {
+    delete d.trustZone;
+  }
+}
+
 function renderNode(loop) {
   const category = normalizeVisualCategory(getLoopCategory(loop));
   const capacity = getLoopVisualCapacity(loop);
@@ -2946,7 +3011,6 @@ function renderNode(loop) {
     group = createSVG('g', {
       class: 'loop-node',
       'data-loop-id': loop.id,
-      'data-category': category,
     });
     group.addEventListener('click', () => {
       if (Date.now() < suppressNextNodeClickUntil) return;
@@ -3024,7 +3088,7 @@ function renderNode(loop) {
       'dominant-baseline': 'central',
       'font-size': Math.round(nodeR * 0.5),
     });
-    icon.textContent = CATEGORY_SIGILS[category] || CATEGORY_SIGILS.generic;
+    icon.textContent = categorySigil(category);
 
     // Supervisor ring (larger circle outside the node).
     const supDot = createSVG('circle', {
@@ -3130,13 +3194,15 @@ function renderNode(loop) {
     group.querySelector('.node-label').setAttribute('y', nodeR + NODE_LABEL_GAP);
   }
   group.dataset.nodeR = nodeR;
-  group.setAttribute('data-category', category);
 
   const shapeEl = group.querySelector('.node-shape');
   const iconEl = group.querySelector('.node-icon');
   const visualState = getLoopVisualState(loop);
+  // Project semantic characteristics onto the node (data-* attrs) — the single
+  // seam CSS/themes drive visuals from. Owns data-category and data-state.
+  projectLoopCharacteristics(loop, capacity, visualState, group);
   shapeEl.setAttribute('class', 'node-shape node-shape--category-' + category + ' node-shape--activity-' + visualState);
-  iconEl.textContent = CATEGORY_SIGILS[category] || CATEGORY_SIGILS.generic;
+  iconEl.textContent = categorySigil(category);
   iconEl.setAttribute('class', 'node-icon node-icon--' + category);
 
   const ring = group.querySelector('.node-ring');
@@ -3224,6 +3290,9 @@ function renderNode(loop) {
 }
 
 function updateSleepRing(group, loopId) {
+  // Containers never sleep; their ring is hidden in CSS — skip the per-tick
+  // offset math entirely.
+  if (group.dataset.operation === 'container') return;
   const sleepRing = group.querySelector('.sleep-ring');
   const timer = state.sleepTimers.get(loopId);
   const r = parseFloat(sleepRing.getAttribute('r'));

--- a/internal/server/web/static/style.css
+++ b/internal/server/web/static/style.css
@@ -55,6 +55,9 @@
   /* Graph neutrals — families read by sigil, not decorative fill color. */
   --node-fill:   color-mix(in srgb, var(--text-secondary) 16%, transparent);
   --node-fill-2: color-mix(in srgb, var(--text-secondary) 24%, transparent);
+  /* Containers are structural groupings, not workers — a fainter fill so they
+     recede behind executing loops. Theme-controllable independently. */
+  --node-fill-container: color-mix(in srgb, var(--text-secondary) 9%, transparent);
   --node-stroke: var(--text-muted);
   --edge:        color-mix(in srgb, var(--text-muted) 55%, transparent);
 
@@ -2198,6 +2201,22 @@ body.resize-col .schema-card__fade {
 .node-shape--category-channel       { fill: var(--node-fill); }
 .node-shape--category-delegate      { fill: var(--node-fill); }
 .node-shape--category-scheduled     { fill: var(--node-fill); }
+.node-shape--category-container     { fill: var(--node-fill-container); }
+
+/* Container loops — semantic groupings, not executing entities. Rendered
+   small (16px, set in app.js), dimmed, and stripped of activity affordances
+   (sleep ring, capacity badge, supervisor dot). Routed off the projected
+   data-operation attribute so themes/skins/layers can override per-attribute
+   without touching render code — the first consumer of the projection seam. */
+.loop-node[data-operation="container"] .node-shape { opacity: 0.6; animation: none; }
+.loop-node[data-operation="container"] .node-ring {
+  stroke: var(--border-light);
+  filter: none;
+  opacity: 0.3;
+}
+.loop-node[data-operation="container"] .sleep-ring,
+.loop-node[data-operation="container"] .node-rim-badge,
+.loop-node[data-operation="container"] .supervisor-dot { display: none; }
 
 /* Runtime-state rings */
 /* Active work glows in the agent's accent; idle states are neutral; strong


### PR DESCRIPTION
## Problem

Container loops — `config.Operation == "container"`, semantic groupings that hold child loops but never execute — rendered as ordinary timer-driven nodes: full size, sleep ring, capacity badge, the "timed sleep" look. Prod example: `temporal` (off core, holding `hor_conditions`) looked like a sleeping worker.

Root cause: the graph only knew containers via `isRegistryCoreLoop`, hardcoded to `name === 'core'`. A user container fell through `describeLoopExecutionMode` → `'timer-driven llm'` and `getLoopCategoryInfo` → `'generic'`, then got the round executing-loop treatment. The API was a clean passthrough — container-ness is already on the wire via `config.Operation` — so this is **frontend-only**.

## What this does

Rather than special-casing containers, this builds the **CSS-attribute-projection foundation** we want for node visuals generally, and makes containers its first consumer.

**The seam** — `projectLoopCharacteristics(loop, capacity, visualState, group)` projects a loop's semantic characteristics onto the node `<g>` as `data-*` attributes (`data-operation`, `data-category`, `data-state`, `data-context-tier`, `data-context-window`, `data-relation`, `data-trust-zone`). CSS — and future themes/skins/layers — drive fill/ring/sigil/visibility off the cascade instead of imperative JS branches. Per-attribute dirty-checked; **geometry (`r`/`cx`/`cy`) stays imperative** because SVG can't read CSS custom properties for layout. We project only facts already on the wire.

**Container = first consumer** — `isContainerLoop(loop)` (general, distinct from the `core` special case) drives: small **16px** node, dimmed (opacity 0.6, fainter `--node-fill-container` token), **empty center** (no sigil), and **no** sleep ring / capacity badge / supervisor dot — a grouping sized just as a context-menu click target. Routed purely via `[data-operation="container"]` CSS. `describeLoopExecutionMode` reports `'container'` for the inspector label. `updateSleepRing` bails early for containers (no per-tick math for a hidden ring).

**Harness** — added a synthetic `temporal` container + `hor_conditions` child to `uiharness.go` (mirroring prod) so the general container path is verifiable locally.

## Anticipating the future direction

The stated intent (size-by-context, owner visuals, loop-defined sigils) slots onto this seam additively. Context-tier is already projected (`data-context-tier`/`data-context-window`); future characteristics become more projected attributes + CSS with no render-code change. **Deferred** (no wire data yet): owner visuals and loop sigils — they need `Spec.Owner` / `Spec.Sigil` fields. Rule applied: project an attribute only when the fact already exists, else it's noise.

## Verification

Built via a design-validation + adversarial-review workflow, then verified live in the UI harness:

| | `temporal` (container) | executing loops |
|---|---|---|
| `data-operation` | `container` | `timer` |
| radius | **16** | 34 |
| fill | opacity 0.6, token 0.09 | opacity 1.0, 0.16 |
| sleep ring / badge / supervisor dot | none | visible |
| center sigil | empty | category glyph |

Projection seam confirmed live on all nodes; executing loops unchanged. Screenshot attached in review notes shows `temporal` as a faint small grouping with its child hanging off normally.

- [x] `just ci` green locally
- [x] tagged harness build (`go build -tags uiharness`) compiles; untagged build unaffected (stub.go)
- [x] visual + computed-style verification in uiharness

## Notes
- No backend change (container-ness already exposed via `config.Operation`).
- Heads-up: the existing `.claude/launch.json` `uiharness` entry points at a stale `/tmp/thane-webconsole` worktree (leftover from the merged web-console PR) and serves old code. I verified against a fresh build via a separate local entry; you may want to repoint or drop the stale one.