### PR TITLE
feat(openapi): #1060 Phase 1 — vacuum lint + route-coverage drift guardrails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,9 @@ jobs:
       - name: Install golangci-lint
         run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.9.0
 
+      - name: Install vacuum (OpenAPI linter)
+        run: go install github.com/daveshanley/vacuum@v0.29.5
+
       - name: Install lychee
         run: |
           curl -sSfL "https://github.com/lycheeverse/lychee/releases/download/lychee-v0.23.0/lychee-x86_64-unknown-linux-gnu.tar.gz" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,7 @@ permissions:
 env:
   GO_VERSION: '1.25'
   GOLANGCI_LINT_VERSION: 'v2.9.0'
+  VACUUM_VERSION: 'v0.29.5'
   LYCHEE_VERSION: '0.23.0'
 
 jobs:
@@ -40,6 +41,9 @@ jobs:
 
       - name: Install golangci-lint
         run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@${{ env.GOLANGCI_LINT_VERSION }}
+
+      - name: Install vacuum (OpenAPI linter)
+        run: go install github.com/daveshanley/vacuum@${{ env.VACUUM_VERSION }}
 
       - name: Install lychee
         run: |

--- a/.vacuum.yaml
+++ b/.vacuum.yaml
@@ -1,0 +1,38 @@
+# Vacuum ruleset for Thane's OpenAPI specs — issue #1060 (Godoc parity for /docs/).
+#
+# Extends vacuum's recommended OpenAPI ruleset, with two Thane-specific changes:
+#
+#   1. snake_case property names are deliberate — they are the JSON wire
+#      convention for the whole API — so the built-in camelCase rule (which
+#      fired 61 false positives) is disabled.
+#
+#   2. a property-level description rule (`thane-property-description`) — the
+#      Godoc-parity rule: every documented field carries a description.
+#
+# Severity strategy during the #1060 stack: structural problems (invalid
+# schemas, undefined tags, etc.) stay at `error` and fail `just ci` now; the
+# content rules (missing descriptions/examples) ride at vacuum's default `warn`
+# so each stacked PR stays green while the backfill lands. The capstone PR flips
+# the content rules to `error`, making the gate real at the atomic merge.
+extends: [[spectral:oas, recommended]]
+
+rules:
+  # snake_case is the deliberate, API-wide wire convention — it matches the
+  # frozen OpenAI/Ollama compat surfaces (completion_tokens, finish_reason),
+  # Home Assistant, the shared Go json tags, and the persisted message/archive
+  # shapes. camelCase would split native from the unchangeable compat protocols,
+  # so this rule is disabled by decision (#1060), not worked around.
+  camel-case-properties: false
+
+  # Godoc parity: every component-schema property should be documented.
+  # Advisory now (warn); flipped to error at the #1060 capstone once the
+  # backfill phases land. ($ref properties inherit their description from the
+  # referenced schema and are refined out of the path when this goes to error.)
+  thane-property-description:
+    description: Schema properties should carry a description (Godoc parity).
+    severity: warn
+    recommended: true
+    given: "$.components.schemas[*].properties[*]"
+    then:
+      field: description
+      function: truthy

--- a/.vacuum.yaml
+++ b/.vacuum.yaml
@@ -14,7 +14,11 @@
 # content rules (missing descriptions/examples) ride at vacuum's default `warn`
 # so each stacked PR stays green while the backfill lands. The capstone PR flips
 # the content rules to `error`, making the gate real at the atomic merge.
-extends: [[spectral:oas, recommended]]
+#
+# `extends` uses the nested-list form `[[ruleset, level]]` (level is one of
+# all | recommended | off) — this enables vacuum's built-in OpenAPI ruleset at
+# its `recommended` subset. `vacuum:oas` is vacuum's native ruleset identifier.
+extends: [[vacuum:oas, recommended]]
 
 rules:
   # snake_case is the deliberate, API-wide wire convention — it matches the

--- a/internal/server/openapi/coverage_test.go
+++ b/internal/server/openapi/coverage_test.go
@@ -1,0 +1,120 @@
+package openapi
+
+import (
+	"os"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// serverSource is the file that builds the native API mux. The route-coverage
+// test reads its registration literals; if NewServer's routes move to another
+// file, update this path — the test will tell you by extracting too few routes.
+const serverSource = "../api/server.go"
+
+// routeAllowlist are routes registered on the native mux that are intentionally
+// absent from native.yaml:
+//   - "GET /" is the JSON root / dashboard fallback, not an API resource.
+//   - /v1/companion/ws and /v1/platform/ws are legacy WebSocket aliases kept
+//     for existing thane-agent-macos installs; the canonical, documented path
+//     is /v1/realtime/ws.
+var routeAllowlist = map[string]bool{
+	"GET /":                true,
+	"GET /v1/companion/ws": true,
+	"GET /v1/platform/ws":  true,
+}
+
+// muxRouteRe matches the Go 1.22 method-pattern literals that register handlers
+// on the native mux, e.g. `mux.HandleFunc("GET /v1/loops", ...)` and
+// `mux.Handle("GET /v1/realtime/ws", ...)`.
+var muxRouteRe = regexp.MustCompile(`mux\.Handle(?:Func)?\("([A-Z]+) (/[^"]*)"`)
+
+// TestNativeSpecRouteCoverage guards drift between the native API routes
+// registered in server.go and the paths documented in native.yaml. The spec is
+// hand-authored — a mirror of the code that can silently fall out of step — so
+// this fails CI when a registered route is undocumented or a documented path is
+// not actually served. Intentional exceptions live in routeAllowlist.
+func TestNativeSpecRouteCoverage(t *testing.T) {
+	registered := registeredRoutes(t)
+	documented := documentedRoutes(t)
+
+	if len(registered) < 30 {
+		t.Fatalf("only %d routes extracted from %s — the registration format likely changed; update muxRouteRe", len(registered), serverSource)
+	}
+	if len(documented) < 30 {
+		t.Fatalf("only %d paths parsed from native.yaml — parsing likely broke", len(documented))
+	}
+
+	// Direction 1: every registered native route is documented (or allowlisted).
+	for _, r := range sortedKeys(registered) {
+		if routeAllowlist[r] || documented[r] {
+			continue
+		}
+		t.Errorf("route %q is registered in server.go but undocumented in native.yaml", r)
+	}
+
+	// Direction 2: every documented path is actually registered.
+	for _, d := range sortedKeys(documented) {
+		if registered[d] {
+			continue
+		}
+		t.Errorf("path %q is documented in native.yaml but not registered in server.go", d)
+	}
+}
+
+// registeredRoutes returns the "METHOD /path" set the native mux registers,
+// scraped from server.go's registration literals.
+func registeredRoutes(t *testing.T) map[string]bool {
+	t.Helper()
+	src, err := os.ReadFile(serverSource)
+	if err != nil {
+		t.Fatalf("read %s: %v", serverSource, err)
+	}
+	out := make(map[string]bool)
+	for _, m := range muxRouteRe.FindAllStringSubmatch(string(src), -1) {
+		out[m[1]+" "+m[2]] = true
+	}
+	return out
+}
+
+// documentedRoutes returns the "METHOD /path" set declared under `paths` in the
+// embedded native.yaml. Non-operation keys (parameters, $ref, summary) are
+// skipped by the HTTP-method filter.
+func documentedRoutes(t *testing.T) map[string]bool {
+	t.Helper()
+	data, err := files.ReadFile("native.yaml")
+	if err != nil {
+		t.Fatalf("read embedded native.yaml: %v", err)
+	}
+	var doc struct {
+		Paths map[string]map[string]any `yaml:"paths"`
+	}
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		t.Fatalf("parse native.yaml: %v", err)
+	}
+	httpMethods := map[string]bool{
+		"get": true, "put": true, "post": true, "delete": true,
+		"patch": true, "head": true, "options": true, "trace": true,
+	}
+	out := make(map[string]bool)
+	for path, ops := range doc.Paths {
+		for method := range ops {
+			if httpMethods[strings.ToLower(method)] {
+				out[strings.ToUpper(method)+" "+path] = true
+			}
+		}
+	}
+	return out
+}
+
+func sortedKeys(m map[string]bool) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/internal/server/openapi/native.yaml
+++ b/internal/server/openapi/native.yaml
@@ -60,6 +60,8 @@ tags:
     description: Historical sessions with full-text search and export.
   - name: Checkpoints
     description: Conversation state snapshots for restart survival.
+  - name: Scheduler
+    description: Durable scheduled tasks and their execution history.
   - name: Models & Fleet
     description: Available models and the routing/registry policy.
   - name: Insights
@@ -502,10 +504,10 @@ paths:
                         message_count: { type: integer }
                         created_at: { type: string, format: date-time }
                         updated_at: { type: string, format: date-time }
-                        channel_binding: { type: object, nullable: true }
+                        channel_binding: { type: [object, "null"] }
                   count: { type: integer }
                   total: { type: integer }
-                  next_cursor: { type: string, nullable: true }
+                  next_cursor: { type: [string, "null"] }
         "400": { $ref: "#/components/responses/BadRequest" }
   /v1/conversations/{id}:
     get:

--- a/justfile
+++ b/justfile
@@ -118,6 +118,15 @@ fmt-check:
 lint: generate
     golangci-lint run ./...
 
+# Lint the OpenAPI specs against the Thane ruleset (.vacuum.yaml). Structural
+# errors fail the build; content gaps (missing descriptions/examples) ride at
+# `warn` during the #1060 stack and become errors at its capstone. Install:
+# `go install github.com/daveshanley/vacuum@v0.29.5` (CI does this).
+[group('test')]
+lint-openapi:
+    vacuum lint -r .vacuum.yaml --fail-severity error internal/server/openapi/native.yaml
+    vacuum lint -r .vacuum.yaml --fail-severity error internal/server/openapi/compat.yaml
+
 # Check go.mod/go.sum are tidy
 [group('test')]
 mod-tidy-check:
@@ -149,7 +158,7 @@ link-check:
 
 # CI: format check, lint, and tests
 [group('test')]
-ci: fmt-check mod-tidy-check config-generate-check architecture-check link-check lint test
+ci: fmt-check mod-tidy-check config-generate-check architecture-check link-check lint lint-openapi test
 
 # --- Install ---
 


### PR DESCRIPTION
Phase 1 of #1060 — the OpenAPI documentation-parity effort. This PR lands the **enforcement machinery** (the Godoc "revive + drift-check" analog), so every later backfill phase is measured against it.

Part of a stack that co-lands atomically (#1060). **Non-breaking on its own:** structural rules gate at `error`, content rules ride at `warn`, so `main` stays green.

## What

### vacuum linter + Thane ruleset (`.vacuum.yaml`)
- Extends vacuum's recommended OpenAPI ruleset.
- **Disables `camel-case-properties`** — snake_case is the deliberate, API-wide wire convention, shared with the frozen OpenAI/Ollama compat surfaces (`completion_tokens`, `finish_reason`), Home Assistant, the shared Go json tags, and the persisted message/archive shapes. (Discussed: camelCase would permanently split native from the unchangeable compat protocols — not worth it.)
- **Adds `thane-property-description`** — the Godoc-parity rule: every component-schema property carries a description. Advisory (`warn`) during the stack; the capstone flips it (and the other content rules) to `error`.

### CI wiring
- `just lint-openapi` (added to the `ci` chain) runs vacuum at `--fail-severity error` over both specs.
- CI installs vacuum `v0.29.5` via `go install` in `ci.yml` + `release.yml`, mirroring the `golangci-lint` pattern — **no new `go.mod` dependency**, offline-friendly once cached.

### Route-coverage drift test (`coverage_test.go`)
- Bidirectional: every native route registered in `server.go` must be documented in `native.yaml`, and every documented path must be registered. The hand-authored spec is a mirror that can silently lie; this catches it in CI.
- An explicit allowlist covers intentional exceptions (the JSON root `/`, and the legacy `/v1/companion/ws` + `/v1/platform/ws` WS aliases of the canonical `/v1/realtime/ws`).

### Bugs the linter immediately surfaced (fixed here)
- **Two OpenAPI 3.1 errors:** `nullable: true` is invalid in 3.1 — replaced with `type: [T, "null"]` at the `/v1/conversations` response (introduced by #1061).
- **Undefined tag:** the schedule operations referenced a `Scheduler` tag that wasn't declared; added it to the global tags.

## Effect

Native quality score **10 → 43** — from fixing the 2 errors and silencing 61 camelCase false-positives. The remaining ~187 warnings (missing descriptions/examples) are the backlog the backfill phases (3…N) burn down before the capstone makes them errors.

## Test plan
- [x] `just ci` green locally (includes `lint-openapi` + the drift test under `-race`)
- [x] vacuum passes at `--fail-severity error` for both specs (exit 0)
- [x] drift test passes on the real spec **and** fails on injected drift (verified: a ghost documented path is caught)
- [x] `go.mod`/`go.sum` untouched (vacuum installed separately, like golangci-lint)
- [x] commit signed

## Not in this phase
- Global scaffolding (info/servers/tags/`x-tagGroups` + Scalar config) — Phase 2.
- Field-level backfill by tag-group — Phases 3…N.
- Flipping content rules to `error` — the capstone.

Refs #1060
