### PR TITLE
feat(openapi): #1060 Phase 2 — info, tag groups, Scalar config

### DIFF
--- a/internal/server/openapi/compat.yaml
+++ b/internal/server/openapi/compat.yaml
@@ -19,6 +19,12 @@ info:
     AuthN is a per-client bearer API key (`Authorization: Bearer <key>`);
     authorization is coarse (inference access), intentionally distinct from the
     native API's granular `resource:action` scopes.
+  contact:
+    name: Thane — nugget/thane-ai-agent
+    url: https://github.com/nugget/thane-ai-agent
+  license:
+    name: Apache-2.0
+    identifier: Apache-2.0
 
 servers:
   - url: http://localhost:8081
@@ -34,6 +40,10 @@ tags:
     description: OpenAI-compatible endpoints — generic OpenAI clients only (HA and open-webui use the Ollama surface).
   - name: ollama
     description: Ollama-compatible endpoints — HA integration, open-webui chat, model listing.
+
+externalDocs:
+  description: Source, architecture, and contributor guides on GitHub.
+  url: https://github.com/nugget/thane-ai-agent/tree/main/docs
 
 paths:
   /v1/chat/completions:

--- a/internal/server/openapi/coverage_test.go
+++ b/internal/server/openapi/coverage_test.go
@@ -118,3 +118,59 @@ func sortedKeys(m map[string]bool) []string {
 	sort.Strings(keys)
 	return keys
 }
+
+// TestNativeTagGroupsCoverage guards the Scalar `x-tagGroups` sidebar config in
+// native.yaml against drift: every tag declared under top-level `tags` must
+// appear in exactly one `x-tagGroups` group, and every tag a group references
+// must be a declared tag. (vacuum's `operation-tag-defined` already enforces
+// that operations only use declared tags; together they guarantee every
+// operation's tag lands in exactly one sidebar group.) A mismatch — a typo, or
+// a new tag added without a group — silently orphans the tag in the /docs
+// sidebar, which no other check would catch.
+func TestNativeTagGroupsCoverage(t *testing.T) {
+	data, err := files.ReadFile("native.yaml")
+	if err != nil {
+		t.Fatalf("read embedded native.yaml: %v", err)
+	}
+	var doc struct {
+		Tags []struct {
+			Name string `yaml:"name"`
+		} `yaml:"tags"`
+		TagGroups []struct {
+			Name string   `yaml:"name"`
+			Tags []string `yaml:"tags"`
+		} `yaml:"x-tagGroups"`
+	}
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		t.Fatalf("parse native.yaml: %v", err)
+	}
+	if len(doc.Tags) < 5 || len(doc.TagGroups) < 2 {
+		t.Fatalf("parsed %d tags / %d groups — parsing likely broke", len(doc.Tags), len(doc.TagGroups))
+	}
+
+	declared := make(map[string]bool, len(doc.Tags))
+	for _, tag := range doc.Tags {
+		declared[tag.Name] = true
+	}
+
+	groupCount := make(map[string]int) // declared tag -> number of groups containing it
+	for _, g := range doc.TagGroups {
+		for _, name := range g.Tags {
+			if !declared[name] {
+				t.Errorf("x-tagGroups group %q references tag %q, which is not declared under top-level `tags`", g.Name, name)
+				continue
+			}
+			groupCount[name]++
+		}
+	}
+
+	for _, name := range sortedKeys(declared) {
+		switch groupCount[name] {
+		case 1: // exactly one group — correct
+		case 0:
+			t.Errorf("tag %q is declared but not placed in any x-tagGroups group (it would be orphaned in the /docs sidebar)", name)
+		default:
+			t.Errorf("tag %q appears in %d x-tagGroups groups; it must be in exactly one", name, groupCount[name])
+		}
+	}
+}

--- a/internal/server/openapi/explorer.go
+++ b/internal/server/openapi/explorer.go
@@ -37,6 +37,9 @@ const indexHTML = `<!doctype html>
           { url: '/docs/openapi/native.yaml', title: 'Thane Native API', slug: 'native' },
           { url: '/docs/openapi/compat.yaml', title: 'Compatibility API', slug: 'compat' },
         ],
+        // Default the "Try it" code samples to curl — the operator's lingua
+        // franca for a self-hosted API.
+        defaultHttpClient: { targetKey: 'shell', clientKey: 'curl' },
       })
     </script>
   </body>

--- a/internal/server/openapi/native.yaml
+++ b/internal/server/openapi/native.yaml
@@ -27,7 +27,8 @@ info:
       written OIDC-ready; tokens are minted directly for now.
     - **AuthZ scopes** are `resource:action`:
       `loops:read`, `definitions:read`, `definitions:write`, `requests:read`,
-      `conversations:read`, `sessions:read`, `sessions:write`, `archive:read`,
+      `schedules:read`, `conversations:read`, `sessions:read`, `sessions:write`,
+      `archive:read`,
       `checkpoints:read`, `checkpoints:write`, `models:read`, `models:admin`,
       `insights:read`, `contacts:read`, `contacts:write`, `system:read`.
     - **Roles** bundle scopes: `observer` (all `:read`), `operator`
@@ -37,12 +38,18 @@ info:
     CORS is a per-surface concern: the native API allowlists the UI origins
     (credentialed, cross-origin since the hosts differ); the compatibility API
     has its own, narrower policy.
+  contact:
+    name: Thane — nugget/thane-ai-agent
+    url: https://github.com/nugget/thane-ai-agent
+  license:
+    name: Apache-2.0
+    identifier: Apache-2.0
 
 servers:
   - url: http://localhost:8080
     description: Local development (native API + web UI)
-  # Production native host is fronted separately from the compatibility host
-  # (e.g. thane.hollowoak.net serves compat). Final URL TBD with ops.
+  # In production the native API is fronted by a reverse proxy on its own host,
+  # separate from the compatibility API; each deployment sets its public URL.
 
 security:
   - bearerAuth: []
@@ -72,6 +79,22 @@ tags:
     description: Health, version, and process logs.
   - name: Realtime
     description: WebSocket channel for first-party live interaction.
+
+externalDocs:
+  description: Source, architecture, and contributor guides on GitHub.
+  url: https://github.com/nugget/thane-ai-agent/tree/main/docs
+
+# Sidebar grouping for the Scalar explorer. Every tag above belongs to exactly
+# one group; the groups order the /docs navigation by domain.
+x-tagGroups:
+  - name: Execution
+    tags: [Loops, Loop Definitions, Requests, Scheduler]
+  - name: Memory & History
+    tags: [Conversations & Sessions, Archive, Checkpoints]
+  - name: Models & Insights
+    tags: [Models & Fleet, Insights]
+  - name: Platform
+    tags: [Contacts, System, Realtime]
 
 paths:
   # ----------------------------------------------------------------- System


### PR DESCRIPTION
Phase 2 of #1060 — the global scaffolding that frames the Scalar `/docs/` explorer. Builds on the Phase 1 guardrails (#1063, merged).

Non-breaking and lints clean — content rules still ride at `warn`; this adds structure, not field docs (those are Phases 3…N).

## What

### `native.yaml`
- **`info`**: `contact` (the GitHub repo) + `license` (Apache-2.0 via the OAS 3.1 SPDX `identifier`).
- **`servers`**: scrubbed a leaked LAN hostname (`thane.hollowoak.net`) from the prod comment — it shouldn't be in a public repo.
- **root `externalDocs`** → the GitHub `docs/` tree.
- **`x-tagGroups`**: clusters the 12 tags into 4 Scalar sidebar groups — **Execution** (Loops / Loop Definitions / Requests / Scheduler), **Memory & History** (Conversations & Sessions / Archive / Checkpoints), **Models & Insights** (Models & Fleet / Insights), **Platform** (Contacts / System / Realtime). Every tag is in exactly one group.
- **security model**: declared the dangling `schedules:read` scope — the Scheduler operations already require it via `x-thane-scope`, but it wasn't enumerated in `info.description`.

### `compat.yaml`
- Matching `contact` / `license` / `externalDocs`.

### `explorer.go`
- Default Scalar's "Try it" code samples to **curl** (`defaultHttpClient`) — the operator's lingua franca for a self-hosted API. Verified the key and the `shell`/`curl` pair are supported by the pinned Scalar bundle.

## Verification
- [x] vacuum green at `--fail-severity error` for both specs; `just ci` green
- [x] route-coverage drift test still passes
- [x] `x-logo` deliberately **not** used — the pinned Scalar bundle doesn't support it (it's a Redoc extension); confirmed by probing the bundle
- [x] **5-lens adversarial review** (3.1 correctness · tag-group completeness · Scalar pinned-bundle support · privacy/no-leak · doc quality) → **0 blockers**. The `schedules:read` and "Telemetry"→"Insights" fixes came from that review.

## Not in this phase
- Field-level backfill (property descriptions + examples) — Phases 3…N.
- Flipping content rules to `error` — the capstone.

Refs #1060
