### PR TITLE
feat(openapi): #1060 System + Compat schema docs; enforce property descriptions

### DIFF
--- a/.vacuum.yaml
+++ b/.vacuum.yaml
@@ -9,11 +9,12 @@
 #   2. a property-level description rule (`thane-property-description`) — the
 #      Godoc-parity rule: every documented field carries a description.
 #
-# Severity strategy during the #1060 stack: structural problems (invalid
-# schemas, undefined tags, etc.) stay at `error` and fail `just ci` now; the
-# content rules (missing descriptions/examples) ride at vacuum's default `warn`
-# so each stacked PR stays green while the backfill lands. The capstone PR flips
-# the content rules to `error`, making the gate real at the atomic merge.
+# Severity strategy (#1060): structural problems (invalid schemas, undefined
+# tags) fail `just ci` at `error`. Content rules are flipped to `error` one at a
+# time as each backfill completes: thane-property-description is now ENFORCED
+# (the Execution + System component schemas are fully documented); the remaining
+# content rules (response examples, etc.) ride at vacuum's default `warn` until
+# their backfills land.
 #
 # `extends` uses the nested-list form `[[ruleset, level]]` (level is one of
 # all | recommended | off) — this enables vacuum's built-in OpenAPI ruleset at
@@ -28,13 +29,13 @@ rules:
   # so this rule is disabled by decision (#1060), not worked around.
   camel-case-properties: false
 
-  # Godoc parity: every component-schema property should be documented.
-  # Advisory now (warn); flipped to error at the #1060 capstone once the
-  # backfill phases land. ($ref properties inherit their description from the
-  # referenced schema and are refined out of the path when this goes to error.)
+  # Godoc parity: every component-schema property MUST be documented. Enforced
+  # at `error` as of the Execution + System backfills (#1060) — a missing
+  # property description now fails `just ci`. ($ref properties inherit their
+  # description from the referenced schema and are not flagged.)
   thane-property-description:
-    description: Schema properties should carry a description (Godoc parity).
-    severity: warn
+    description: Schema properties must carry a description (Godoc parity).
+    severity: error
     recommended: true
     given: "$.components.schemas[*].properties[*]"
     then:

--- a/internal/platform/logging/indexer.go
+++ b/internal/platform/logging/indexer.go
@@ -510,21 +510,21 @@ func Prune(db *sql.DB, maxAge time.Duration, minKeepLevel slog.Level) (int64, er
 // LogEntry is an exported representation of a log index row suitable
 // for display in the web dashboard and tool queries.
 type LogEntry struct {
-	ID             int64
-	Timestamp      time.Time
-	Level          string
-	Msg            string
-	RequestID      string
-	SessionID      string
-	ConversationID string
-	Subsystem      string
-	Tool           string
-	Model          string
-	LoopID         string
-	LoopName       string
-	Attrs          string
-	SourceFile     string
-	SourceLine     int
+	ID             int64     `json:"id"`
+	Timestamp      time.Time `json:"ts"`
+	Level          string    `json:"level"`
+	Msg            string    `json:"msg"`
+	RequestID      string    `json:"request_id,omitempty"`
+	SessionID      string    `json:"session_id,omitempty"`
+	ConversationID string    `json:"conversation_id,omitempty"`
+	Subsystem      string    `json:"subsystem,omitempty"`
+	Tool           string    `json:"tool,omitempty"`
+	Model          string    `json:"model,omitempty"`
+	LoopID         string    `json:"loop_id,omitempty"`
+	LoopName       string    `json:"loop_name,omitempty"`
+	Attrs          string    `json:"attrs,omitempty"`
+	SourceFile     string    `json:"source_file,omitempty"`
+	SourceLine     int       `json:"source_line,omitempty"`
 }
 
 // QueryParams holds filter criteria for querying the log index.

--- a/internal/server/openapi/compat.yaml
+++ b/internal/server/openapi/compat.yaml
@@ -166,86 +166,183 @@ components:
   schemas:
     ChatMessage:
       type: object
-      properties:
-        role: { type: string, enum: [system, user, assistant, tool] }
-        content: { type: string }
+      description: One message in a chat exchange (OpenAI/Ollama shape).
       required: [role, content]
+      properties:
+        role:
+          type: string
+          enum: [system, user, assistant, tool]
+          description: The role of the message author.
+          example: user
+        content:
+          type: string
+          description: The message text content.
+          example: Turn on the office lights.
     ChatCompletionRequest:
       type: object
+      description: OpenAI-compatible chat completion request.
+      required: [model, messages]
       properties:
         model:
           type: string
           description: Model id or a Thane routing alias (e.g. `thane:latest`).
+          example: thane:latest
         messages:
           type: array
+          description: The conversation messages, in order.
           items: { $ref: "#/components/schemas/ChatMessage" }
-        stream: { type: boolean, default: false }
-        temperature: { type: number }
-        max_tokens: { type: integer }
-      required: [model, messages]
+        stream:
+          type: boolean
+          default: false
+          description: Stream the response as Server-Sent Events instead of one JSON body.
+        temperature:
+          type: number
+          description: Sampling temperature requested by the client.
+          example: 0.7
+        max_tokens:
+          type: integer
+          description: Maximum number of tokens to generate.
+          example: 1024
     ChatCompletionResponse:
       type: object
+      description: OpenAI-compatible chat completion response.
       properties:
-        id: { type: string }
-        object: { type: string, examples: [chat.completion] }
-        created: { type: integer }
-        model: { type: string }
+        id:
+          type: string
+          description: Unique completion identifier.
+          example: chatcmpl-abc123
+        object:
+          type: string
+          description: Object type — always `chat.completion`.
+          examples: [chat.completion]
+        created:
+          type: integer
+          description: Unix timestamp (seconds) when the completion was created.
+          example: 1782735600
+        model:
+          type: string
+          description: Model that produced the completion.
+          example: thane:latest
         choices:
           type: array
+          description: The generated completion choices (Thane returns a single choice).
           items:
             type: object
             properties:
-              index: { type: integer }
+              index:
+                type: integer
+                description: Position of this choice in the list.
+                example: 0
               message: { $ref: "#/components/schemas/ChatMessage" }
-              finish_reason: { type: string }
+              finish_reason:
+                type: string
+                description: Why generation stopped (e.g. stop, length).
+                example: stop
         usage:
           type: object
+          description: Token usage for the request.
           properties:
-            prompt_tokens: { type: integer }
-            completion_tokens: { type: integer }
-            total_tokens: { type: integer }
+            prompt_tokens:
+              type: integer
+              description: Tokens in the prompt.
+              example: 412
+            completion_tokens:
+              type: integer
+              description: Tokens in the generated completion.
+              example: 96
+            total_tokens:
+              type: integer
+              description: Total tokens (prompt + completion).
+              example: 508
     ModelList:
       type: object
+      description: OpenAI-compatible list of available models.
       properties:
-        object: { type: string, examples: [list] }
+        object:
+          type: string
+          description: Object type — always `list`.
+          examples: [list]
         data:
           type: array
+          description: The available models.
           items:
             type: object
             properties:
-              id: { type: string }
-              object: { type: string, examples: [model] }
-              owned_by: { type: string }
+              id:
+                type: string
+                description: Model identifier.
+                example: thane:latest
+              object:
+                type: string
+                description: Object type — always `model`.
+                examples: [model]
+              owned_by:
+                type: string
+                description: Owner of the model.
+                example: thane
     OllamaChatRequest:
       type: object
+      description: Ollama-compatible chat request.
+      required: [model, messages]
       properties:
-        model: { type: string }
+        model:
+          type: string
+          description: Model id or a Thane routing alias.
+          example: thane:latest
         messages:
           type: array
+          description: The conversation messages, in order.
           items: { $ref: "#/components/schemas/ChatMessage" }
-        stream: { type: boolean }
-      required: [model, messages]
+        stream:
+          type: boolean
+          description: Stream the response as newline-delimited JSON objects.
     OllamaChatResponse:
       type: object
+      description: Ollama-compatible chat response (one object per stream chunk).
       additionalProperties: true
       properties:
-        model: { type: string }
-        created_at: { type: string }
+        model:
+          type: string
+          description: Model that produced the reply.
+          example: thane:latest
+        created_at:
+          type: string
+          description: RFC3339 timestamp when the reply was created.
+          example: "2026-06-24T14:31:11Z"
         message: { $ref: "#/components/schemas/ChatMessage" }
-        done: { type: boolean }
+        done:
+          type: boolean
+          description: Whether this is the final chunk of the streamed reply.
+          example: true
     OllamaError:
       type: object
-      properties:
-        error: { type: string }
+      description: Ollama-compatible error envelope.
       required: [error]
+      properties:
+        error:
+          type: string
+          description: Error message.
+          example: model not found
     OllamaTags:
       type: object
+      description: Ollama-compatible list of locally available models (the /api/tags response).
       properties:
         models:
           type: array
+          description: The available models.
           items:
             type: object
             properties:
-              name: { type: string }
-              model: { type: string }
-              size: { type: integer }
+              name:
+                type: string
+                description: Model name (e.g. `thane:latest`).
+                example: thane:latest
+              model:
+                type: string
+                description: Model identifier.
+                example: thane:latest
+              size:
+                type: integer
+                format: int64
+                description: Model size in bytes.
+                example: 4709611008

--- a/internal/server/openapi/native.yaml
+++ b/internal/server/openapi/native.yaml
@@ -947,8 +947,10 @@ components:
         commit, branch, go_version, build_time, ...). Keys are open, not fixed.
       example:
         version: v0.9.2-596-gf92a9208
-        commit: f92a9208
+        git_commit: f92a9208
+        git_branch: main
         go_version: go1.26.1
+        uptime: 133h30m0s
 
     LogEntry:
       type: object
@@ -971,7 +973,7 @@ components:
           type: string
           readOnly: true
           description: Severity level.
-          enum: [DEBUG, INFO, WARN, ERROR]
+          enum: [TRACE, DEBUG, INFO, WARN, ERROR]
           example: INFO
         msg:
           type: string
@@ -1059,8 +1061,8 @@ components:
         name:
           type: string
           readOnly: true
-          description: Service identifier.
-          example: home_assistant
+          description: Human-readable service display name (the service identifier is the key in the surrounding health map).
+          example: Home Assistant
         ready:
           type: boolean
           readOnly: true

--- a/internal/server/openapi/native.yaml
+++ b/internal/server/openapi/native.yaml
@@ -931,44 +931,151 @@ components:
   schemas:
     Error:
       type: object
-      properties:
-        error: { type: string }
+      description: Standard error envelope returned for any 4xx/5xx response.
       required: [error]
+      properties:
+        error:
+          type: string
+          description: Human-readable message describing what went wrong.
+          example: resource not found
 
     VersionInfo:
       type: object
       additionalProperties: { type: string }
-      description: Build/runtime key-value metadata (version, commit, go version...).
+      description: >-
+        Build and runtime metadata as flat string key/value pairs (version,
+        commit, branch, go_version, build_time, ...). Keys are open, not fixed.
+      example:
+        version: v0.9.2-596-gf92a9208
+        commit: f92a9208
+        go_version: go1.26.1
 
     LogEntry:
       type: object
-      description: One structured log row (schema first-pass; tighten against logging.LogEntry).
+      description: One structured log row from the process log index, as returned by the system and per-loop log endpoints.
+      required: [id, ts, level, msg]
       properties:
-        ts: { type: string, format: date-time }
-        level: { type: string }
-        msg: { type: string }
-        request_id: { type: string }
-        conversation_id: { type: string }
-      additionalProperties: true
+        id:
+          type: integer
+          format: int64
+          readOnly: true
+          description: Monotonic row identifier in the log index.
+          example: 184213
+        ts:
+          type: string
+          format: date-time
+          readOnly: true
+          description: Time the log record was emitted.
+          example: "2026-06-24T14:31:07Z"
+        level:
+          type: string
+          readOnly: true
+          description: Severity level.
+          enum: [DEBUG, INFO, WARN, ERROR]
+          example: INFO
+        msg:
+          type: string
+          readOnly: true
+          description: The log message.
+          example: loop iteration complete
+        request_id:
+          type: string
+          readOnly: true
+          description: Request this record is associated with, when emitted during a model turn.
+          example: "019e7469-3abf-7e6b-ae38-85b5e34915ac"
+        session_id:
+          type: string
+          readOnly: true
+          description: Session this record belongs to, when applicable.
+        conversation_id:
+          type: string
+          readOnly: true
+          description: Conversation this record belongs to, when applicable.
+          example: conv-aimee
+        subsystem:
+          type: string
+          readOnly: true
+          description: Originating subsystem / component tag.
+          example: scheduler
+        tool:
+          type: string
+          readOnly: true
+          description: Tool name, for tool-call log records.
+          example: ha_get_state
+        model:
+          type: string
+          readOnly: true
+          description: Model name, for model-turn log records.
+          example: claude-opus-4-8
+        loop_id:
+          type: string
+          readOnly: true
+          description: Loop that emitted the record, when applicable.
+        loop_name:
+          type: string
+          readOnly: true
+          description: Human label of the emitting loop.
+          example: signal/aimee
+        attrs:
+          type: string
+          readOnly: true
+          description: Additional structured attributes, as a JSON-encoded string.
+          example: '{"input_tokens":9123,"output_tokens":2048}'
+        source_file:
+          type: string
+          readOnly: true
+          description: Source file that emitted the log record.
+          example: internal/runtime/loop/loop.go
+        source_line:
+          type: integer
+          readOnly: true
+          description: Line number within source_file.
+          example: 412
 
     SystemStatus:
       type: object
-      description: Health, uptime, version, and snapshots for the system view.
+      description: Aggregate system view — uptime, build version, and per-service health — backing the dashboard's system panel.
       properties:
-        uptime_seconds: { type: integer }
-        version: { $ref: "#/components/schemas/VersionInfo" }
+        uptime_seconds:
+          type: integer
+          format: int64
+          readOnly: true
+          description: Seconds since the process started.
+          example: 480600
+        version:
+          $ref: "#/components/schemas/VersionInfo"
         health:
           type: object
+          readOnly: true
+          description: Per-service readiness, keyed by service name.
           additionalProperties: { $ref: "#/components/schemas/ServiceHealth" }
       additionalProperties: true
+
     ServiceHealth:
       type: object
-      properties:
-        name: { type: string }
-        ready: { type: boolean }
-        last_check: { type: string, format: date-time }
-        last_error: { type: string }
+      description: Readiness snapshot for one wired service (Home Assistant, MQTT, Signal, ...).
       required: [name, ready]
+      properties:
+        name:
+          type: string
+          readOnly: true
+          description: Service identifier.
+          example: home_assistant
+        ready:
+          type: boolean
+          readOnly: true
+          description: Whether the service is currently reachable and healthy.
+          example: true
+        last_check:
+          type: string
+          format: date-time
+          readOnly: true
+          description: Time of the most recent health probe.
+          example: "2026-06-24T14:30:55Z"
+        last_error:
+          type: string
+          readOnly: true
+          description: Error from the most recent failed probe, if any.
 
     LoopState:
       type: string

--- a/internal/server/web/static/shared.js
+++ b/internal/server/web/static/shared.js
@@ -832,7 +832,7 @@ function normalizeCapabilityCatalogEntry(entry) {
   const status = String(entry.status || entry.Status || 'available').trim() || 'available';
   const description = String(entry.description || entry.Description || '').trim();
   const toolCount = Number(entry.tool_count || entry.toolCount || 0);
-  const tools = cloneTokenList(entry.tools || entry.tools || []);
+  const tools = cloneTokenList(entry.tools || entry.Tools || []);
   const context = entry.context || entry.Context || null;
   return {
     tag,

--- a/internal/server/web/static/shared.js
+++ b/internal/server/web/static/shared.js
@@ -832,7 +832,7 @@ function normalizeCapabilityCatalogEntry(entry) {
   const status = String(entry.status || entry.Status || 'available').trim() || 'available';
   const description = String(entry.description || entry.Description || '').trim();
   const toolCount = Number(entry.tool_count || entry.toolCount || 0);
-  const tools = cloneTokenList(entry.tools || entry.Tools || []);
+  const tools = cloneTokenList(entry.tools || entry.tools || []);
   const context = entry.context || entry.Context || null;
   return {
     tag,
@@ -1107,24 +1107,24 @@ function renderLogRows(entries, els) {
 
     const tdTime = document.createElement('td');
     tdTime.className = 'log-time';
-    tdTime.textContent = entry.Timestamp
-      ? formatTime(new Date(entry.Timestamp))
+    tdTime.textContent = entry.ts
+      ? formatTime(new Date(entry.ts))
       : '';
 
     const tdLevel = document.createElement('td');
     const levelSpan = document.createElement('span');
-    levelSpan.className = 'level-badge level-badge--' + (entry.Level || 'INFO');
-    levelSpan.textContent = entry.Level || '?';
+    levelSpan.className = 'level-badge level-badge--' + (entry.level || 'INFO');
+    levelSpan.textContent = entry.level || '?';
     tdLevel.appendChild(levelSpan);
 
     const tdSub = document.createElement('td');
     tdSub.className = 'log-subsystem';
-    tdSub.textContent = entry.Subsystem || '';
+    tdSub.textContent = entry.subsystem || '';
 
     const tdMsg = document.createElement('td');
     tdMsg.className = 'log-msg';
-    tdMsg.textContent = entry.Msg || '';
-    tdMsg.title = entry.Msg || '';
+    tdMsg.textContent = entry.msg || '';
+    tdMsg.title = entry.msg || '';
 
     const tdDetail = document.createElement('td');
     tdDetail.className = 'log-detail';
@@ -1148,17 +1148,17 @@ function renderLogRows(entries, els) {
 function buildLogDetail(td, entry) {
   const parts = [];
 
-  if (entry.Model) {
-    parts.push({ key: 'model', val: entry.Model, cls: 'model' });
+  if (entry.model) {
+    parts.push({ key: 'model', val: entry.model, cls: 'model' });
   }
-  if (entry.Tool) {
-    parts.push({ key: 'tool', val: entry.Tool, cls: 'tool' });
+  if (entry.tool) {
+    parts.push({ key: 'tool', val: entry.tool, cls: 'tool' });
   }
 
   // Parse Attrs JSON for extra instrumentation.
   let attrs = null;
-  if (entry.Attrs) {
-    try { attrs = JSON.parse(entry.Attrs); } catch (_) { /* ignore */ }
+  if (entry.attrs) {
+    try { attrs = JSON.parse(entry.attrs); } catch (_) { /* ignore */ }
   }
   if (attrs) {
     // Duration fields (various naming conventions).
@@ -1220,9 +1220,9 @@ function buildLogDetail(td, entry) {
   // Copy-clickable ID chips for tracing IDs. Request ID chips are also
   // clickable to open the request detail waterfall view.
   const ids = [
-    { label: 'req', full: entry.RequestID, inspectable: typeof window.onRequestChipClick === 'function' },
-    { label: 'conv', full: entry.ConversationID },
-    { label: 'sess', full: entry.SessionID },
+    { label: 'req', full: entry.request_id, inspectable: typeof window.onRequestChipClick === 'function' },
+    { label: 'conv', full: entry.conversation_id },
+    { label: 'sess', full: entry.session_id },
   ];
   for (const { label, full, inspectable } of ids) {
     if (!full) continue;

--- a/internal/server/web/static/views/forensics.js
+++ b/internal/server/web/static/views/forensics.js
@@ -197,10 +197,10 @@ export function forensicsView(getStore, viewState) {
     }
     const list = el('div', { class: 'fx-logs' });
     for (const e of logsEntries) {
-      list.appendChild(el('div', { class: 'fx-log fx-log--' + (e.Level || 'info').toLowerCase() }, [
-        el('span', { class: 'fx-log-time', text: relTime(e.Timestamp) }),
-        el('span', { class: 'fx-log-level', text: (e.Level || '').toUpperCase() }),
-        el('span', { class: 'fx-log-msg', text: e.Tool ? '[' + e.Tool + '] ' + (e.Msg || '') : (e.Msg || '') }),
+      list.appendChild(el('div', { class: 'fx-log fx-log--' + (e.level || 'info').toLowerCase() }, [
+        el('span', { class: 'fx-log-time', text: relTime(e.ts) }),
+        el('span', { class: 'fx-log-level', text: (e.level || '').toUpperCase() }),
+        el('span', { class: 'fx-log-msg', text: e.tool ? '[' + e.tool + '] ' + (e.msg || '') : (e.msg || '') }),
       ]));
     }
     section.appendChild(list);


### PR DESCRIPTION
Phase 3 of #1060, and a **milestone**: this finishes documenting every component schema in both specs and **turns on the first content rule at `error`**. Builds on #1063 / #1064 / #1065 (merged).

## What

### System schemas (native)
Backfilled Error / VersionInfo / SystemStatus / ServiceHealth with descriptions + examples — and corrected **LogEntry** to its real wire shape.

### LogEntry root fix (the one snake_case violator)
`logging.LogEntry` had **no JSON tags**, so `/v1/system/logs` and `/v1/loops/{id}/logs` emitted **PascalCase** keys (`Timestamp`, `Level`, `Msg`, `RequestID`, …) — the single surface breaking the API's snake_case convention, while the spec documented made-up snake_case fields (`ts`/`level`/…) that didn't match the wire. Per the "fix the root" decision:
- Added snake_case `json` tags to `logging.LogEntry` (`ts`, `level`, `msg`, `request_id`, `conversation_id`, `subsystem`, `tool`, `model`, `loop_id`, `loop_name`, `attrs`, …).
- Updated the two web-console log consumers (`shared.js` log table, `forensics.js` log tail) to read snake_case.
- Documented the full, real LogEntry shape in the spec.

LogEntry is **column-stored, not JSON-persisted**, so this is wire-only; the static assets ship inside the binary, so the deploy is atomic (no mid-deploy break).

### Compat schemas
Backfilled the OpenAI/Ollama protocol shapes (ChatMessage, ChatCompletion{Request,Response}, ModelList, OllamaChat{Request,Response}, OllamaError, OllamaTags) — required because the rule applies to both specs, and it completes the Compat group.

### The milestone: `thane-property-description` → `error`
Every component-schema property in **both** specs now has a description, so I flipped the rule from `warn` to `error` in `.vacuum.yaml`. **A missing property description now fails `just ci`** — the first content rule with teeth (negative-tested). The remaining content rules (response examples, etc.) stay at `warn` until their backfills land.

## Effect
- Native quality **69 → 75**; property-description warnings **→ 0** (both specs)
- `thane-property-description` enforced at `error`; `just ci` green
- LogEntry wire is now consistent snake_case across `/v1/system/logs` + `/v1/loops/{id}/logs`

## Test plan
- [x] `just ci` green (Go compiles with the tag change; vacuum at `error`; drift tests)
- [x] vacuum passes at `--fail-severity error` for **both** specs; negative-tested (removing a description fails)
- [x] no PascalCase log-field reads remain in the web console; consumers read snake_case matching the new tags
- [x] LogEntry confirmed column-stored (not JSON-persisted) — no stored-data impact

Refs #1060
