### PR TITLE
fix(loops): stop content-resolution from corrupting loop output refs (#1068)

### DIFF
--- a/internal/app/loop_definition_store.go
+++ b/internal/app/loop_definition_store.go
@@ -101,6 +101,23 @@ func (s *loopDefinitionStore) LoadInto(registry *looppkg.DefinitionRegistry, log
 					"name", key, "tags", legacy)
 			}
 		}
+		// Validate before adding to the batch. ReplaceOverlay is
+		// all-or-nothing: it returns on the first ValidatePersistable
+		// failure, and this error is fatal at startup (new_stores.go), so
+		// a single corrupt persisted definition would otherwise block
+		// every healthy overlay loop from loading. Mirror the bad-JSON
+		// skip above — warn and drop the offender, keep the rest. This is
+		// the safety net that lets OutputSpec.Validate tighten (#1068)
+		// without bricking boot while already-corrupt overlays still
+		// exist on disk; the dropped record stays persisted for later
+		// repair.
+		if err := record.Spec.ValidatePersistable(); err != nil {
+			if logger != nil {
+				logger.Warn("skipping invalid persisted loop definition",
+					"name", key, "error", err)
+			}
+			continue
+		}
 		records[key] = record
 	}
 	if len(records) == 0 {

--- a/internal/app/loop_definition_store_test.go
+++ b/internal/app/loop_definition_store_test.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"encoding/json"
 	"log/slog"
 	"testing"
 	"time"
@@ -121,5 +122,87 @@ func TestLoopDefinitionStoreLoadIntoSkipsInvalidEntries(t *testing.T) {
 	snap := registry.Snapshot()
 	if snap.OverlayDefinitions != 0 {
 		t.Fatalf("OverlayDefinitions = %d, want 0", snap.OverlayDefinitions)
+	}
+}
+
+func TestLoopDefinitionStoreLoadIntoSkipsUnpersistableSpec(t *testing.T) {
+	t.Parallel()
+
+	db, err := database.OpenMemory()
+	if err != nil {
+		t.Fatalf("database.OpenMemory: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+
+	op, err := opstate.NewStore(db, nil)
+	if err != nil {
+		t.Fatalf("opstate.NewStore: %v", err)
+	}
+	store := newLoopDefinitionStore(op)
+
+	// One healthy overlay definition.
+	if err := store.Save(looppkg.Spec{
+		Name:       "good_loop",
+		Task:       "Maintain the dashboard.",
+		Operation:  looppkg.OperationService,
+		Completion: looppkg.CompletionNone,
+		Outputs: []looppkg.OutputSpec{{
+			Name: "dash",
+			Type: looppkg.OutputTypeMaintainedDocument,
+			Mode: looppkg.OutputModeReplace,
+			Ref:  "core:good.md",
+		}},
+	}, time.Date(2026, 6, 25, 0, 0, 0, 0, time.UTC)); err != nil {
+		t.Fatalf("Save good_loop: %v", err)
+	}
+
+	// One already-persisted record corrupted exactly as #1068 left prod:
+	// the output ref holds the document body instead of a ref. It is valid
+	// JSON (so it decodes), but ValidatePersistable rejects it. Written
+	// straight through op.Set to bypass Save's validation, mirroring a row
+	// persisted before the grammar check existed.
+	corrupt, err := json.Marshal(looppkg.DefinitionRecord{
+		Spec: looppkg.Spec{
+			Name:       "bad_loop",
+			Task:       "Maintain.",
+			Operation:  looppkg.OperationService,
+			Completion: looppkg.CompletionNone,
+			Outputs: []looppkg.OutputSpec{{
+				Name: "doc",
+				Type: looppkg.OutputTypeMaintainedDocument,
+				Mode: looppkg.OutputModeReplace,
+				Ref:  "---\ntitle: \"corrupt\"\n---\n\nbody",
+			}},
+		},
+		UpdatedAt: time.Date(2026, 6, 25, 0, 0, 0, 0, time.UTC),
+	})
+	if err != nil {
+		t.Fatalf("Marshal corrupt record: %v", err)
+	}
+	if err := op.Set(loopDefinitionRegistryNamespace, "bad_loop", string(corrupt)); err != nil {
+		t.Fatalf("op.Set: %v", err)
+	}
+
+	// LoadInto must NOT fail the whole batch on the one bad record:
+	// ReplaceOverlay is all-or-nothing and this error is fatal at startup
+	// (new_stores.go), so without the per-record skip a single corrupt
+	// definition would block every healthy overlay loop from loading.
+	registry := testLoopDefinitionRegistry(t)
+	if err := store.LoadInto(registry, slog.Default()); err != nil {
+		t.Fatalf("LoadInto returned error (one bad record bricked the batch): %v", err)
+	}
+
+	snap := registry.Snapshot()
+	if snap.OverlayDefinitions != 1 {
+		t.Fatalf("OverlayDefinitions = %d, want 1 (healthy loads, corrupt skipped)", snap.OverlayDefinitions)
+	}
+	var overlayNames []string
+	for _, def := range snap.Definitions {
+		if def.Source == looppkg.DefinitionSourceOverlay {
+			overlayNames = append(overlayNames, def.Name)
+		}
+	}
+	if len(overlayNames) != 1 || overlayNames[0] != "good_loop" {
+		t.Fatalf("overlay definitions = %v, want [good_loop]", overlayNames)
 	}
 }

--- a/internal/runtime/loop/output.go
+++ b/internal/runtime/loop/output.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"unicode"
 )
 
 const maxOutputToolNameLength = 64
@@ -211,15 +212,15 @@ func safeOutputToolSuffix(name string) string {
 // a multi-line markdown blob in Ref. That value passes the non-empty
 // check above but is not a reference — it only fails much later at wake
 // time with "unknown document root". A real ref is a single-line
-// root:path token, so newlines/control characters are an unambiguous
-// tell that content leaked into the ref. This check stays syntactic
-// (root membership is enforced at hydration, where the document store's
-// configured roots are available) so the loop package keeps no
-// dependency on the documents store.
+// root:path token, so any control character (newlines, NUL, and the rest
+// of the C0/C1 range) is an unambiguous tell that content leaked into the
+// ref. This check stays syntactic (root membership is enforced at
+// hydration, where the document store's configured roots are available)
+// so the loop package keeps no dependency on the documents store.
 func validateOutputRefGrammar(ref string) error {
 	trimmed := strings.TrimSpace(ref)
-	if strings.ContainsAny(trimmed, "\n\r\t\f\v") {
-		return fmt.Errorf("ref must be a single root:path reference, not document content (got a multi-line value beginning %q); a ref holding document text is the #1068 content-resolution corruption signature", outputRefFirstLine(trimmed))
+	if i := strings.IndexFunc(trimmed, unicode.IsControl); i >= 0 {
+		return fmt.Errorf("ref must be a single root:path reference, not document content (got a control character at offset %d in a value beginning %q); a ref holding document text is the #1068 content-resolution corruption signature", i, outputRefFirstLine(trimmed))
 	}
 	root, relPath, ok := strings.Cut(trimmed, ":")
 	root = strings.TrimSpace(root)

--- a/internal/runtime/loop/output.go
+++ b/internal/runtime/loop/output.go
@@ -115,6 +115,9 @@ func (o OutputSpec) Validate() error {
 	if strings.TrimSpace(o.Ref) == "" {
 		return fmt.Errorf("ref is required")
 	}
+	if err := validateOutputRefGrammar(o.Ref); err != nil {
+		return err
+	}
 	switch o.Type {
 	case OutputTypeMaintainedDocument, OutputTypeJournalDocument:
 	default:
@@ -199,6 +202,45 @@ func safeOutputToolSuffix(name string) string {
 	}
 	out := strings.Trim(b.String(), "_")
 	return out
+}
+
+// validateOutputRefGrammar rejects an output ref that is not a literal
+// root:path document reference. The signature failure it guards against
+// is #1068: universal prefix-to-content resolution silently replacing a
+// real ref (e.g. projects:foo/bar.md) with that document's body, leaving
+// a multi-line markdown blob in Ref. That value passes the non-empty
+// check above but is not a reference — it only fails much later at wake
+// time with "unknown document root". A real ref is a single-line
+// root:path token, so newlines/control characters are an unambiguous
+// tell that content leaked into the ref. This check stays syntactic
+// (root membership is enforced at hydration, where the document store's
+// configured roots are available) so the loop package keeps no
+// dependency on the documents store.
+func validateOutputRefGrammar(ref string) error {
+	trimmed := strings.TrimSpace(ref)
+	if strings.ContainsAny(trimmed, "\n\r\t\f\v") {
+		return fmt.Errorf("ref must be a single root:path reference, not document content (got a multi-line value beginning %q); a ref holding document text is the #1068 content-resolution corruption signature", outputRefFirstLine(trimmed))
+	}
+	root, relPath, ok := strings.Cut(trimmed, ":")
+	root = strings.TrimSpace(root)
+	relPath = strings.TrimSpace(relPath)
+	if !ok || root == "" || relPath == "" {
+		return fmt.Errorf("ref %q must be a document reference of the form root:path (for example core:notes.md)", outputRefFirstLine(trimmed))
+	}
+	if strings.ContainsAny(root, " \t") {
+		return fmt.Errorf("ref root %q must be a single identifier; expected root:path like core:notes.md", root)
+	}
+	return nil
+}
+
+// outputRefFirstLine returns the first line of s, trimmed, so error
+// messages about a content-corrupted ref stay to one line instead of
+// dumping an entire markdown document.
+func outputRefFirstLine(s string) string {
+	if i := strings.IndexAny(s, "\r\n"); i >= 0 {
+		return strings.TrimSpace(s[:i])
+	}
+	return s
 }
 
 func firstUnsupportedOutputNameRune(name string) (rune, bool) {

--- a/internal/runtime/loop/output_test.go
+++ b/internal/runtime/loop/output_test.go
@@ -124,6 +124,8 @@ func TestOutputSpecValidateRefGrammar(t *testing.T) {
 		{name: "frontmatter blob rejected", ref: "---\ntitle: \"Ranch Climate Watch\"\ncreated: \"2026-06-25T03:45:49Z\"\n---\n\n# body", wantErr: true},
 		{name: "embedded newline rejected", ref: "core:state.md\nextra", wantErr: true},
 		{name: "carriage return rejected", ref: "core:state.md\r\nmore", wantErr: true},
+		{name: "nul byte rejected", ref: "core:sta\x00te.md", wantErr: true},
+		{name: "other control char rejected", ref: "core:sta\x07te.md", wantErr: true},
 		{name: "no root separator rejected", ref: "metacognitive.md", wantErr: true},
 		{name: "empty root rejected", ref: ":state.md", wantErr: true},
 		{name: "empty path rejected", ref: "core:", wantErr: true},

--- a/internal/runtime/loop/output_test.go
+++ b/internal/runtime/loop/output_test.go
@@ -106,6 +106,47 @@ func TestOutputSpecValidateAndToolName(t *testing.T) {
 	}
 }
 
+func TestOutputSpecValidateRefGrammar(t *testing.T) {
+	// Guards #1068: content resolution could replace a real ref with the
+	// referenced document's body, leaving a multi-line markdown blob in
+	// Ref. Validate must reject that while accepting every well-formed ref.
+	tests := []struct {
+		name    string
+		ref     string
+		wantErr bool
+	}{
+		{name: "simple core ref", ref: "core:metacognitive.md"},
+		{name: "nested path ref", ref: "projects:ranch-operations/ranch-climate-watch.md"},
+		{name: "kb ref", ref: "kb:dashboards/pr-watchlist.md"},
+		{name: "generated ref", ref: "generated:daily/digest.md"},
+		// The production corruption signature: a whole document, frontmatter
+		// and all, sitting where the ref should be.
+		{name: "frontmatter blob rejected", ref: "---\ntitle: \"Ranch Climate Watch\"\ncreated: \"2026-06-25T03:45:49Z\"\n---\n\n# body", wantErr: true},
+		{name: "embedded newline rejected", ref: "core:state.md\nextra", wantErr: true},
+		{name: "carriage return rejected", ref: "core:state.md\r\nmore", wantErr: true},
+		{name: "no root separator rejected", ref: "metacognitive.md", wantErr: true},
+		{name: "empty root rejected", ref: ":state.md", wantErr: true},
+		{name: "empty path rejected", ref: "core:", wantErr: true},
+		{name: "root with whitespace rejected", ref: "--- title:state.md", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out := OutputSpec{Name: "doc", Type: OutputTypeMaintainedDocument, Ref: tt.ref}
+			err := out.Validate()
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("Validate() error = nil for ref %q, want error", tt.ref)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Validate() error = %v for ref %q, want nil", err, tt.ref)
+			}
+		})
+	}
+}
+
 func TestSpecJSONRoundTripIncludesOutputs(t *testing.T) {
 	spec := Spec{
 		Name:       "writer",

--- a/internal/tools/loop_definition_tools.go
+++ b/internal/tools/loop_definition_tools.go
@@ -132,6 +132,13 @@ func (r *Registry) registerLoopDefinitionTools() {
 	r.Register(&Tool{
 		Name:        "loop_definition_lint",
 		Description: "Lint one candidate persistent loop definition without saving it. Returns whether the spec is persistable, the effective runtime defaults that would apply, and non-fatal warnings for common service-loop authoring mistakes such as omitted sleep envelope fields or delegation-first gating.",
+		// The spec is a declarative authoring payload: every string in it
+		// (notably outputs[].ref) is a literal to store verbatim, never a
+		// content reference to expand. Universal prefix-to-content
+		// resolution would otherwise rewrite a real ref like
+		// projects:foo/bar.md into that document's body, and lint would
+		// then green-light the corrupted spec. See #1068.
+		SkipContentResolve: true,
 		Parameters: map[string]any{
 			"type": "object",
 			"properties": map[string]any{
@@ -148,6 +155,13 @@ func (r *Registry) registerLoopDefinitionTools() {
 	r.Register(&Tool{
 		Name:        "loop_definition_set",
 		Description: "Create or replace one dynamic loop definition in the persistent loops overlay. This cannot modify config-owned definitions. The saved definition view includes warnings for common service-loop authoring mistakes. The spec uses human-facing strings for durations and retrigger mode.",
+		// Declarative spec — store its strings verbatim. Without this,
+		// universal prefix-to-content resolution recurses into
+		// spec.outputs[].ref and silently replaces a real document ref
+		// with the document's body, which then dies at wake time with
+		// `unknown document root`. This was the live prod corruption
+		// vector. See #1068.
+		SkipContentResolve: true,
 		Parameters: map[string]any{
 			"type": "object",
 			"properties": map[string]any{

--- a/internal/tools/loop_definition_tools_test.go
+++ b/internal/tools/loop_definition_tools_test.go
@@ -3,6 +3,8 @@ package tools
 import (
 	"context"
 	"encoding/json"
+	"os"
+	"path/filepath"
 	"reflect"
 	"sort"
 	"strings"
@@ -143,6 +145,72 @@ func schemaObjectProperty(t *testing.T, schema map[string]any, key string) map[s
 		t.Fatalf("schema property %q = %#v, want map[string]any", key, raw)
 	}
 	return child
+}
+
+func TestLoopDefinitionSetStoresOutputRefLiterally(t *testing.T) {
+	// #1068 regression: loop_definition_set must NOT run its spec through
+	// prefix-to-content resolution. An output ref pointing at an existing
+	// document must be stored verbatim, never replaced by that document's
+	// body (which would die at wake with "unknown document root").
+	deps := newTestLoopDefinitionDeps(t)
+	cr, _, kbDir := testContentResolver(t)
+	deps.reg.SetContentResolver(cr)
+
+	// The referenced document exists and is non-empty, so a regression
+	// that drops SkipContentResolve would pull this content into the ref.
+	poison := "---\ntitle: poison\n---\n\nbody that must never become a ref"
+	if err := os.WriteFile(filepath.Join(kbDir, "dash.md"), []byte(poison), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	spec := looppkg.Spec{
+		Name:       "test_curator",
+		Enabled:    true,
+		Task:       "Maintain the dashboard.",
+		Operation:  looppkg.OperationService,
+		Completion: looppkg.CompletionNone,
+		Outputs: []looppkg.OutputSpec{{
+			Name: "dash",
+			Type: looppkg.OutputTypeMaintainedDocument,
+			Mode: looppkg.OutputModeReplace,
+			Ref:  "kb:dash.md",
+		}},
+	}
+	argsJSON, err := json.Marshal(map[string]any{"spec": spec})
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+
+	if _, err := deps.reg.Execute(context.Background(), "loop_definition_set", string(argsJSON)); err != nil {
+		t.Fatalf("Execute loop_definition_set: %v", err)
+	}
+
+	stored, ok := deps.persisted["test_curator"]
+	if !ok {
+		t.Fatal("spec was not persisted")
+	}
+	if len(stored.Outputs) != 1 {
+		t.Fatalf("stored outputs = %d, want 1", len(stored.Outputs))
+	}
+	if got := stored.Outputs[0].Ref; got != "kb:dash.md" {
+		t.Errorf("stored output ref = %q, want literal %q (content resolution leaked into the ref)", got, "kb:dash.md")
+	}
+}
+
+func TestLoopDefinitionAuthoringToolsSkipContentResolve(t *testing.T) {
+	// The declarative authoring tools must opt out of prefix-to-content
+	// resolution so nested spec.outputs[].ref values are stored verbatim
+	// (#1068).
+	deps := newTestLoopDefinitionDeps(t)
+	for _, name := range []string{"loop_definition_set", "loop_definition_lint"} {
+		tool := deps.reg.Get(name)
+		if tool == nil {
+			t.Fatalf("%s not registered", name)
+		}
+		if !tool.SkipContentResolve {
+			t.Errorf("%s must set SkipContentResolve (#1068)", name)
+		}
+	}
 }
 
 func TestConfigureLoopDefinitionTools_RegistersTools(t *testing.T) {

--- a/internal/tools/loop_runtime_tools.go
+++ b/internal/tools/loop_runtime_tools.go
@@ -124,6 +124,12 @@ func (r *Registry) registerLoopRuntimeTools() {
 	r.Register(&Tool{
 		Name:        "spawn_loop",
 		Description: "Launch an ad hoc loop immediately using the loops launch contract without persisting a loop definition. Use this for temporary services, detached background research that should report back later, or one-shot request/reply runs that do not belong in the durable loop-definition registry. For async work, prefer operation=background_task. If completion is omitted there, the runtime infers the most natural detached delivery target from the current origin context. Tool filtering goes in the top-level launch fields (allowed_tools, etc.) — NOT inside launch.metadata. To pin a model, set spec.profile.model inside the spec object; per-launch model overrides are rejected.",
+		// The launch carries a declarative spec; its strings (notably
+		// spec.outputs[].ref) must be stored verbatim, not expanded.
+		// Universal prefix-to-content resolution would otherwise rewrite a
+		// real ref into document content, and the ad-hoc loop would die at
+		// its first wake with `unknown document root`. See #1068.
+		SkipContentResolve: true,
 		Parameters: map[string]any{
 			"type": "object",
 			"properties": map[string]any{

--- a/internal/tools/loop_runtime_tools_test.go
+++ b/internal/tools/loop_runtime_tools_test.go
@@ -81,6 +81,13 @@ func TestConfigureLoopRuntimeTools_RegistersTools(t *testing.T) {
 			t.Fatalf("%s tool not registered", name)
 		}
 	}
+	// spawn_loop accepts a declarative launch.spec whose outputs[].ref must
+	// be stored verbatim. Content resolution would otherwise rewrite a ref
+	// into document content and the ad-hoc loop would die at its first wake
+	// (#1068).
+	if spawn := deps.reg.Get("spawn_loop"); spawn == nil || !spawn.SkipContentResolve {
+		t.Error("spawn_loop must set SkipContentResolve so launch.spec.outputs[].ref is not content-expanded (#1068)")
+	}
 }
 
 func TestSpawnLoopSchemaExposesSharedLaunchFields(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes the loop output-ref content-resolution corruption (#1068) that took down `ranch_climate_watch` in production. Closes the corruption hole, adds defense-in-depth validation, and removes a related boot-failure landmine.

Scope was set by the 2026-06-25 multi-agent re-analysis ([#1068 comment](https://github.com/nugget/thane-ai-agent/issues/1068#issuecomment-4797099631)). Key correction vs. the original issue: **`thane_curate` / `loop_intent` set is SAFE** (fully exempt + builds the spec field-by-field). The vulnerable tools are `loop_definition_set`, `spawn_loop`, and `loop_definition_lint`.

## The bug

Universal prefix-to-content resolution runs on tool args before the handler and recurses into nested maps, but the literal-key exemption is **top-level only**. These three tools accept a model-supplied loop spec and exempt nothing, so a real output ref like `projects:foo/bar.md` was silently replaced with that document's *body* and persisted as the ref. The loop then died at its next wake:

```
replace_output_* → store.Write(ref="---\ntitle: …") → unknown document root "---\ntitle"
```

## Changes

**P0 — stop the corruption** (`b20137f`)
- `SkipContentResolve: true` on `loop_definition_set`, `spawn_loop`, `loop_definition_lint`. Their specs are declarative and must be stored verbatim — matching the runtime output-write tools that already opt out.

**P1 — defense-in-depth + robustness** (`ed917d4`)
- `OutputSpec.Validate` rejects a ref that isn't a single-line `root:path` token (newlines/control chars, or a whitespace root, are the signature of a document body leaking into a ref). Moves the failure from wake time to author/persist time, across every path through `ValidatePersistable`.
- `LoadInto` validates each persisted record and **skips-and-warns** instead of letting `ReplaceOverlay` fail the whole batch. `ReplaceOverlay` is all-or-nothing and its error is fatal at startup, so without this the validation tightening above would brick **every healthy overlay loop** on the next boot while corrupt prod overlays still exist. Dropped records stay persisted for repair.

## Test plan

- [x] `TestLoopDefinitionSetStoresOutputRefLiterally` — authoring an output with `ref: kb:<existing-doc>` stores the ref literally, not the document body.
- [x] `TestLoopDefinitionAuthoringToolsSkipContentResolve` / `TestConfigureLoopRuntimeTools_RegistersTools` — all three tools declare `SkipContentResolve`.
- [x] `TestOutputSpecValidateRefGrammar` — valid refs pass; frontmatter blobs / newlines / malformed refs rejected.
- [x] `TestLoopDefinitionStoreLoadIntoSkipsUnpersistableSpec` — one corrupt persisted record no longer blocks healthy overlays from loading.
- [x] `just ci` green (format, lint, vacuum, architecture baseline unchanged, full test suite).

## Follow-ups (not in this PR)

- **Operational** — repair the 2 corrupt prod overlays (`ranch_climate_watch`, `hor_conditions`); now recoverable through `loop_definition_set` once this lands. Verify the latent `thane_development_watcher`.
- **P2** — unify the `persist → upsert → reconcile` sequence (copy-pasted across tool/HTTP/curate) behind a single `commitLoopDefinition` chokepoint. Separate issue.

Refs #1068
