### PR TITLE
refactor(loops): unify loop-definition commit behind one chokepoint

### DIFF
--- a/internal/app/loop_definition_commit_test.go
+++ b/internal/app/loop_definition_commit_test.go
@@ -1,0 +1,97 @@
+package app
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	looppkg "github.com/nugget/thane-ai-agent/internal/runtime/loop"
+)
+
+// commitLoopDefinition is the single durable-commit chokepoint every
+// model-facing authoring tool routes through. With no store or runtime
+// wired, persist and reconcile are no-ops, so these tests isolate the
+// overlay-upsert behavior and the error contract callers depend on.
+
+func TestCommitLoopDefinitionUpsertsOverlay(t *testing.T) {
+	t.Parallel()
+
+	reg := testLoopDefinitionRegistry(t)
+	a := &App{loopDefinitionRegistry: reg}
+
+	spec := looppkg.Spec{
+		Name:       "room_watch",
+		Task:       "Watch the room and surface noteworthy changes.",
+		Operation:  looppkg.OperationService,
+		Completion: looppkg.CompletionNone,
+	}
+	updatedAt := time.Date(2026, 6, 25, 0, 0, 0, 0, time.UTC)
+	if err := a.commitLoopDefinition(context.Background(), spec, updatedAt); err != nil {
+		t.Fatalf("commitLoopDefinition: %v", err)
+	}
+
+	stored, ok := reg.Get("room_watch")
+	if !ok {
+		t.Fatal("committed definition not present in registry overlay")
+	}
+	if stored.Task != spec.Task {
+		t.Fatalf("stored task = %q, want %q", stored.Task, spec.Task)
+	}
+}
+
+func TestCommitLoopDefinitionPropagatesImmutableError(t *testing.T) {
+	t.Parallel()
+
+	// testLoopDefinitionRegistry seeds a config-owned base loop named
+	// "metacog_like"; committing over it must surface a typed
+	// ImmutableDefinitionError. The chokepoint returns the upsert error
+	// bare (no wrapping) precisely so callers can errors.As it to map a
+	// 409/Conflict — guard that contract here.
+	reg := testLoopDefinitionRegistry(t)
+	a := &App{loopDefinitionRegistry: reg}
+
+	spec := looppkg.Spec{
+		Name:       "metacog_like",
+		Task:       "Try to shadow a config-owned definition.",
+		Operation:  looppkg.OperationService,
+		Completion: looppkg.CompletionNone,
+	}
+	err := a.commitLoopDefinition(context.Background(), spec, time.Now().UTC())
+	if err == nil {
+		t.Fatal("expected error committing over a config-owned definition")
+	}
+	var immutable *looppkg.ImmutableDefinitionError
+	if !errors.As(err, &immutable) {
+		t.Fatalf("error = %v, want it to unwrap to *ImmutableDefinitionError", err)
+	}
+}
+
+func TestCommitLoopDefinitionRejectsInvalidSpec(t *testing.T) {
+	t.Parallel()
+
+	// A structurally invalid spec (corrupt output ref — the #1068 shape)
+	// must be rejected at commit time by the upsert's ValidatePersistable,
+	// not silently stored.
+	reg := testLoopDefinitionRegistry(t)
+	a := &App{loopDefinitionRegistry: reg}
+
+	spec := looppkg.Spec{
+		Name:       "broken_output",
+		Task:       "Maintain a doc.",
+		Operation:  looppkg.OperationService,
+		Completion: looppkg.CompletionNone,
+		Outputs: []looppkg.OutputSpec{{
+			Name: "doc",
+			Type: looppkg.OutputTypeMaintainedDocument,
+			Mode: looppkg.OutputModeReplace,
+			Ref:  "---\ntitle: \"corrupt\"\n---\n\nbody",
+		}},
+	}
+	if err := a.commitLoopDefinition(context.Background(), spec, time.Now().UTC()); err == nil {
+		t.Fatal("expected commit to reject a spec with a content-corrupted output ref")
+	}
+	if _, ok := reg.Get("broken_output"); ok {
+		t.Fatal("invalid definition must not be stored in the overlay")
+	}
+}

--- a/internal/app/loop_definition_runtime.go
+++ b/internal/app/loop_definition_runtime.go
@@ -673,6 +673,31 @@ func (a *App) reconcileLoopDefinition(ctx context.Context, name string) error {
 	return a.loopDefinitionRuntime.ReconcileDefinition(ctx, name)
 }
 
+// commitLoopDefinition is the single durable-commit chokepoint for a loop
+// definition: persist it, upsert it into the live overlay registry, then
+// reconcile the running loop against it. Every model-facing authoring
+// surface (loop_definition_set, thane_curate, thane_create_container)
+// routes through here instead of open-coding the same three steps, so a
+// guard added once (validation, audit, signing) protects all of them and
+// the surfaces cannot drift in commit semantics. Error wrapping matches
+// the previous hand-rolled sequences: persist and reconcile failures are
+// prefixed, while the Upsert error is returned bare so callers that
+// inspect it (errors.As for ImmutableDefinitionError) keep working.
+func (a *App) commitLoopDefinition(ctx context.Context, spec looppkg.Spec, updatedAt time.Time) error {
+	if err := a.persistLoopDefinition(spec, updatedAt); err != nil {
+		return fmt.Errorf("persist loop definition: %w", err)
+	}
+	if a.loopDefinitionRegistry != nil {
+		if err := a.loopDefinitionRegistry.Upsert(spec, updatedAt); err != nil {
+			return err
+		}
+	}
+	if err := a.reconcileLoopDefinition(ctx, spec.Name); err != nil {
+		return fmt.Errorf("reconcile loop definition: %w", err)
+	}
+	return nil
+}
+
 func (a *App) launchLoopDefinition(ctx context.Context, name string, launch looppkg.Launch) (looppkg.LaunchResult, error) {
 	if a == nil || a.loopDefinitionRuntime == nil {
 		return looppkg.LaunchResult{}, fmt.Errorf("loop definition runtime is not configured")

--- a/internal/app/new_channels.go
+++ b/internal/app/new_channels.go
@@ -408,7 +408,7 @@ func (a *App) initChannels(s *newState) error {
 	a.loop.Tools().ConfigureLoopDefinitionTools(tools.LoopDefinitionToolDeps{
 		Registry:         a.loopDefinitionRegistry,
 		View:             a.loopDefinitionView,
-		PersistSpec:      a.persistLoopDefinition,
+		CommitSpec:       a.commitLoopDefinition,
 		DeleteSpec:       a.deletePersistedLoopDefinition,
 		PersistPolicy:    a.persistLoopDefinitionPolicy,
 		DeletePolicy:     a.deletePersistedLoopDefinitionPolicy,
@@ -437,7 +437,7 @@ func (a *App) initChannels(s *newState) error {
 			DocTools:         a.documentTools,
 			Registry:         a.loopDefinitionRegistry,
 			PersistSpec:      a.persistLoopDefinition,
-			Reconcile:        a.reconcileLoopDefinition,
+			CommitSpec:       a.commitLoopDefinition,
 			LaunchDefinition: a.launchLoopDefinition,
 			LiveRegistry:     a.loopRegistry,
 		})

--- a/internal/tools/loop_container_tools_test.go
+++ b/internal/tools/loop_container_tools_test.go
@@ -73,10 +73,12 @@ func newContainerTestRig(t *testing.T) *containerTestRig {
 		return looppkg.LaunchResult{LoopID: l.ID(), Operation: cfg.Operation, Detached: true}, nil
 	}
 	rig.reg.ConfigureLoopIntentTools(LoopIntentToolDeps{
-		DocTools:         nil, // not needed for container tool
-		Registry:         defs,
-		PersistSpec:      func(spec looppkg.Spec, _ time.Time) error { rig.persisted[spec.Name] = spec; return nil },
-		Reconcile:        func(_ context.Context, _ string) error { return nil },
+		DocTools: nil, // not needed for container tool
+		Registry: defs,
+		CommitSpec: func(_ context.Context, spec looppkg.Spec, updatedAt time.Time) error {
+			rig.persisted[spec.Name] = spec
+			return defs.Upsert(spec, updatedAt)
+		},
 		LaunchDefinition: launchDef,
 		LiveRegistry:     loops,
 	})

--- a/internal/tools/loop_definition_mutation_tools.go
+++ b/internal/tools/loop_definition_mutation_tools.go
@@ -25,18 +25,15 @@ func (r *Registry) handleLoopDefinitionSet(ctx context.Context, args map[string]
 		return "", (&looppkg.ImmutableDefinitionError{Name: spec.Name})
 	}
 	updatedAt := time.Now().UTC()
-	if r.persistLoopDefinition != nil {
-		if err := r.persistLoopDefinition(spec, updatedAt); err != nil {
-			return "", fmt.Errorf("persist loop definition: %w", err)
+	// Single durable commit (persist + upsert + reconcile). Fall back to a
+	// bare overlay upsert when no commit hook is wired so a registry-only
+	// configuration still works.
+	if r.commitLoopDefinitionSpec != nil {
+		if err := r.commitLoopDefinitionSpec(ctx, spec, updatedAt); err != nil {
+			return "", err
 		}
-	}
-	if err := r.loopDefinitionRegistry.Upsert(spec, updatedAt); err != nil {
+	} else if err := r.loopDefinitionRegistry.Upsert(spec, updatedAt); err != nil {
 		return "", err
-	}
-	if r.reconcileLoopDefinition != nil {
-		if err := r.reconcileLoopDefinition(ctx, spec.Name); err != nil {
-			return "", fmt.Errorf("reconcile loop definition: %w", err)
-		}
 	}
 	view, err := currentLoopDefinitionView(r)
 	if err != nil {

--- a/internal/tools/loop_definition_tools.go
+++ b/internal/tools/loop_definition_tools.go
@@ -17,9 +17,12 @@ const (
 // tool registry so the model can inspect and mutate the persistent loops
 // definition overlay.
 type LoopDefinitionToolDeps struct {
-	Registry         *looppkg.DefinitionRegistry
-	View             func() *looppkg.DefinitionRegistryView
-	PersistSpec      func(looppkg.Spec, time.Time) error
+	Registry *looppkg.DefinitionRegistry
+	View     func() *looppkg.DefinitionRegistryView
+	// CommitSpec durably commits a definition (persist + overlay upsert +
+	// reconcile) in one step. loop_definition_set routes through it instead
+	// of sequencing the steps by hand.
+	CommitSpec       func(context.Context, looppkg.Spec, time.Time) error
 	DeleteSpec       func(string) error
 	PersistPolicy    func(string, looppkg.DefinitionPolicy) error
 	DeletePolicy     func(string) error
@@ -40,7 +43,7 @@ type LoopDefinitionToolDeps struct {
 func (r *Registry) ConfigureLoopDefinitionTools(deps LoopDefinitionToolDeps) {
 	r.loopDefinitionRegistry = deps.Registry
 	r.loopDefinitionView = deps.View
-	r.persistLoopDefinition = deps.PersistSpec
+	r.commitLoopDefinitionSpec = deps.CommitSpec
 	r.deletePersistedLoopDefinition = deps.DeleteSpec
 	r.persistLoopDefinitionPolicy = deps.PersistPolicy
 	r.deletePersistedLoopDefinitionPolicy = deps.DeletePolicy

--- a/internal/tools/loop_definition_tools_test.go
+++ b/internal/tools/loop_definition_tools_test.go
@@ -65,9 +65,13 @@ func newTestLoopDefinitionDeps(t *testing.T) *testLoopDefinitionDeps {
 				},
 			})
 		},
-		PersistSpec: func(spec looppkg.Spec, updatedAt time.Time) error {
+		CommitSpec: func(_ context.Context, spec looppkg.Spec, updatedAt time.Time) error {
 			deps.persisted[spec.Name] = spec
 			deps.persistedUpdated[spec.Name] = updatedAt
+			if err := defs.Upsert(spec, updatedAt); err != nil {
+				return err
+			}
+			deps.reconciled = append(deps.reconciled, spec.Name)
 			return nil
 		},
 		DeleteSpec: func(name string) error {

--- a/internal/tools/loop_intent_tools.go
+++ b/internal/tools/loop_intent_tools.go
@@ -37,10 +37,16 @@ import (
 // reconcile + launch path used by loop_definition_set and
 // loop_definition_launch.
 type LoopIntentToolDeps struct {
-	DocTools         *documents.Tools
-	Registry         *looppkg.DefinitionRegistry
-	PersistSpec      func(looppkg.Spec, time.Time) error
-	Reconcile        func(context.Context, string) error
+	DocTools *documents.Tools
+	Registry *looppkg.DefinitionRegistry
+	// PersistSpec persists a spec without upsert/reconcile. Used by the
+	// subscription-mutation path, which propagates to the live loop itself
+	// rather than reconciling.
+	PersistSpec func(looppkg.Spec, time.Time) error
+	// CommitSpec durably commits a definition (persist + overlay upsert +
+	// reconcile) in one step. thane_curate and thane_create_container route
+	// through it instead of sequencing the steps by hand.
+	CommitSpec       func(context.Context, looppkg.Spec, time.Time) error
 	LaunchDefinition func(context.Context, string, looppkg.Launch) (looppkg.LaunchResult, error)
 	// LiveRegistry resolves container parent names to live loop IDs and
 	// propagates subscription mutations to running loops. Optional but
@@ -179,18 +185,12 @@ func (r *Registry) handleThaneCreateContainer(ctx context.Context, args map[stri
 	}
 
 	updatedAt := time.Now().UTC()
-	if deps.PersistSpec != nil {
-		if err := deps.PersistSpec(spec, updatedAt); err != nil {
-			return "", fmt.Errorf("persist container definition: %w", err)
+	if deps.CommitSpec != nil {
+		if err := deps.CommitSpec(ctx, spec, updatedAt); err != nil {
+			return "", err
 		}
-	}
-	if err := deps.Registry.Upsert(spec, updatedAt); err != nil {
+	} else if err := deps.Registry.Upsert(spec, updatedAt); err != nil {
 		return "", err
-	}
-	if deps.Reconcile != nil {
-		if err := deps.Reconcile(ctx, name); err != nil {
-			return "", fmt.Errorf("reconcile container definition: %w", err)
-		}
 	}
 
 	// Launch with an empty Launch so a retry of this tool against an
@@ -455,22 +455,16 @@ func (r *Registry) handleThaneCurate(ctx context.Context, args map[string]any) (
 	}
 	_ = docResult // discard structured result; we surface the ref directly
 
-	// Persist + reconcile + launch. Mirrors handleLoopDefinitionSet +
-	// handleLoopDefinitionLaunch; collapsed here so the model only sees
-	// one round-trip for the intent.
+	// Commit (persist + upsert + reconcile) then launch. Mirrors
+	// handleLoopDefinitionSet + handleLoopDefinitionLaunch; collapsed here
+	// so the model only sees one round-trip for the intent.
 	updatedAt := now
-	if deps.PersistSpec != nil {
-		if err := deps.PersistSpec(spec, updatedAt); err != nil {
-			return "", fmt.Errorf("persist loop definition: %w", err)
+	if deps.CommitSpec != nil {
+		if err := deps.CommitSpec(ctx, spec, updatedAt); err != nil {
+			return "", err
 		}
-	}
-	if err := deps.Registry.Upsert(spec, updatedAt); err != nil {
+	} else if err := deps.Registry.Upsert(spec, updatedAt); err != nil {
 		return "", err
-	}
-	if deps.Reconcile != nil {
-		if err := deps.Reconcile(ctx, name); err != nil {
-			return "", fmt.Errorf("reconcile loop definition: %w", err)
-		}
 	}
 
 	launchResult, err := deps.LaunchDefinition(ctx, name, looppkg.Launch{})

--- a/internal/tools/loop_intent_tools_test.go
+++ b/internal/tools/loop_intent_tools_test.go
@@ -16,10 +16,12 @@ import (
 	"github.com/nugget/thane-ai-agent/internal/state/documents"
 )
 
-// upsertCommitSpec builds a LoopIntentToolDeps.CommitSpec /
-// LoopDefinitionToolDeps.CommitSpec stand-in for tests: it commits a
-// definition by upserting it into the given registry, mirroring the
-// production chokepoint's persist→upsert→reconcile without a real store.
+// upsertCommitSpec builds a CommitSpec stand-in for tests that only need
+// the overlay effect of a commit: it upserts the definition into the
+// given registry so downstream lookups see it. It deliberately does NOT
+// simulate the persist or reconcile stages of the production chokepoint —
+// these tests don't assert on those — so it is not a faithful stand-in,
+// just enough to keep the registry populated.
 func upsertCommitSpec(reg *looppkg.DefinitionRegistry) func(context.Context, looppkg.Spec, time.Time) error {
 	return func(_ context.Context, spec looppkg.Spec, updatedAt time.Time) error {
 		if reg == nil {

--- a/internal/tools/loop_intent_tools_test.go
+++ b/internal/tools/loop_intent_tools_test.go
@@ -16,6 +16,19 @@ import (
 	"github.com/nugget/thane-ai-agent/internal/state/documents"
 )
 
+// upsertCommitSpec builds a LoopIntentToolDeps.CommitSpec /
+// LoopDefinitionToolDeps.CommitSpec stand-in for tests: it commits a
+// definition by upserting it into the given registry, mirroring the
+// production chokepoint's persist→upsert→reconcile without a real store.
+func upsertCommitSpec(reg *looppkg.DefinitionRegistry) func(context.Context, looppkg.Spec, time.Time) error {
+	return func(_ context.Context, spec looppkg.Spec, updatedAt time.Time) error {
+		if reg == nil {
+			return nil
+		}
+		return reg.Upsert(spec, updatedAt)
+	}
+}
+
 // mkdirAllForTest is a tiny helper used by the thane_curate tests to
 // pre-create the document root directory before invoking the document
 // store, which refuses to write into a non-existent root.
@@ -178,9 +191,7 @@ func TestThaneCurate_EndToEnd(t *testing.T) {
 		PersistSpec: func(_ looppkg.Spec, _ time.Time) error {
 			return nil
 		},
-		Reconcile: func(_ context.Context, _ string) error {
-			return nil
-		},
+		CommitSpec:       upsertCommitSpec(defRegistry),
 		LaunchDefinition: launchFn,
 	})
 
@@ -370,7 +381,7 @@ func TestThaneCurate_RefusesToClobber(t *testing.T) {
 		DocTools:    docTools,
 		Registry:    defRegistry,
 		PersistSpec: func(_ looppkg.Spec, _ time.Time) error { return nil },
-		Reconcile:   func(_ context.Context, _ string) error { return nil },
+		CommitSpec:  upsertCommitSpec(defRegistry),
 		LaunchDefinition: func(_ context.Context, _ string, _ looppkg.Launch) (looppkg.LaunchResult, error) {
 			return looppkg.LaunchResult{}, nil
 		},
@@ -441,7 +452,7 @@ func TestThaneCurate_RefusesToClobberDocument(t *testing.T) {
 		DocTools:    docTools,
 		Registry:    defRegistry,
 		PersistSpec: func(_ looppkg.Spec, _ time.Time) error { return nil },
-		Reconcile:   func(_ context.Context, _ string) error { return nil },
+		CommitSpec:  upsertCommitSpec(defRegistry),
 		LaunchDefinition: func(_ context.Context, _ string, _ looppkg.Launch) (looppkg.LaunchResult, error) {
 			return looppkg.LaunchResult{LoopID: "should-not-fire"}, nil
 		},
@@ -508,7 +519,7 @@ func TestThaneCurate_JournalDeclaresAppendOutput(t *testing.T) {
 		DocTools:    docTools,
 		Registry:    defRegistry,
 		PersistSpec: func(_ looppkg.Spec, _ time.Time) error { return nil },
-		Reconcile:   func(_ context.Context, _ string) error { return nil },
+		CommitSpec:  upsertCommitSpec(defRegistry),
 		LaunchDefinition: func(_ context.Context, _ string, _ looppkg.Launch) (looppkg.LaunchResult, error) {
 			return looppkg.LaunchResult{LoopID: "loop-journal-1"}, nil
 		},
@@ -604,7 +615,7 @@ func TestThaneCurate_InstructionsFlowToProfile(t *testing.T) {
 		DocTools:    docTools,
 		Registry:    defRegistry,
 		PersistSpec: func(_ looppkg.Spec, _ time.Time) error { return nil },
-		Reconcile:   func(_ context.Context, _ string) error { return nil },
+		CommitSpec:  upsertCommitSpec(defRegistry),
 		LaunchDefinition: func(_ context.Context, _ string, _ looppkg.Launch) (looppkg.LaunchResult, error) {
 			return looppkg.LaunchResult{LoopID: "loop-inst-1"}, nil
 		},
@@ -684,7 +695,7 @@ func TestThaneCurate_InstructionsOmitted(t *testing.T) {
 		DocTools:    docTools,
 		Registry:    defRegistry,
 		PersistSpec: func(_ looppkg.Spec, _ time.Time) error { return nil },
-		Reconcile:   func(_ context.Context, _ string) error { return nil },
+		CommitSpec:  upsertCommitSpec(defRegistry),
 		LaunchDefinition: func(_ context.Context, _ string, _ looppkg.Launch) (looppkg.LaunchResult, error) {
 			return looppkg.LaunchResult{LoopID: "loop-inst-2"}, nil
 		},
@@ -762,7 +773,7 @@ func newCurateTestRig(t *testing.T) *curateTestRig {
 		DocTools:    docTools,
 		Registry:    defRegistry,
 		PersistSpec: func(_ looppkg.Spec, _ time.Time) error { return nil },
-		Reconcile:   func(_ context.Context, _ string) error { return nil },
+		CommitSpec:  upsertCommitSpec(defRegistry),
 		LaunchDefinition: func(_ context.Context, name string, _ looppkg.Launch) (looppkg.LaunchResult, error) {
 			return looppkg.LaunchResult{LoopID: "loop-test-" + name}, nil
 		},

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -89,7 +89,7 @@ type Registry struct {
 	deletePersistedModelRegistryResourcePolicy func(string) error
 	loopDefinitionRegistry                     *looppkg.DefinitionRegistry
 	loopDefinitionView                         func() *looppkg.DefinitionRegistryView
-	persistLoopDefinition                      func(looppkg.Spec, time.Time) error
+	commitLoopDefinitionSpec                   func(context.Context, looppkg.Spec, time.Time) error
 	deletePersistedLoopDefinition              func(string) error
 	persistLoopDefinitionPolicy                func(string, looppkg.DefinitionPolicy) error
 	deletePersistedLoopDefinitionPolicy        func(string) error


### PR DESCRIPTION
## Summary

Implements the first (model-facing) part of #1075: the durable-commit sequence for a loop definition is now a single chokepoint instead of being hand-rolled per surface.

`persist → registry.Upsert → reconcile` was copy-pasted across `loop_definition_set`, `thane_curate`, and `thane_create_container`. Because each copy decided its own commit/validation/content-resolution posture independently, the surfaces drifted — the exact structural problem that let #1068 corrupt refs on one path but not another.

## Changes

- **New `App.commitLoopDefinition(ctx, spec, updatedAt)`** — the single durable-commit chokepoint (persist + overlay upsert + reconcile). Error wrapping matches the previous sequences: persist/reconcile failures are prefixed; the Upsert error is returned **bare** so callers can `errors.As` it for `ImmutableDefinitionError`.
- **Routed the three authoring handlers** through a `CommitSpec` dependency (`loop_definition_set`, `thane_curate`, `thane_create_container`), each with a bare-upsert fallback for registry-only configs.
- Dropped the now-redundant `PersistSpec` from `LoopDefinitionToolDeps` and `Reconcile` from `LoopIntentToolDeps` (the chokepoint owns them); `PersistSpec` stays on the intent deps for the subscription-mutation path, which propagates to the live loop rather than reconciling.

## Behavior preservation

- `loop_definition_set` and `thane_curate` error text is byte-identical (same wrapping). `thane_create_container`'s bespoke "container definition" wording normalizes to the shared "loop definition" phrasing — the only intentional text change.
- HTTP status codes and error **types** are unaffected (HTTP path unchanged in this PR).

## Test plan

- [x] `TestCommitLoopDefinitionUpsertsOverlay` / `...PropagatesImmutableError` / `...RejectsInvalidSpec` — direct chokepoint coverage incl. the bare-upsert `errors.As` contract.
- [x] Existing `loop_definition_set` / `thane_curate` / `thane_create_container` tests pass through the routed path (harnesses provide a stand-in `CommitSpec`).
- [x] `just ci` green — format, lint, vacuum, architecture baseline unchanged, full suite.

## Deferred (remaining on #1075)

- Fold the **HTTP `POST /v1/loop-definitions`** write path onto the chokepoint. It maps failures per-stage (persist→500, upsert-immutable→409, upsert-other→400, reconcile→500); preserving that needs stage-tagged commit errors (a `looppkg.CommitError`), which also drags in removing an unexported server field + a `ConfigureLoopDefinitionPersistence` signature change. Kept out to keep this PR behavior-preserving and focused.
- Collapse the duplicate `findAPILoopDefinition*` snapshot/view helpers onto shared app-layer equivalents.

Refs #1075
