### PR TITLE
refactor(database): migrate mattn/go-sqlite3 → modernc.org/sqlite (pure-Go), fix FTS5 prod bugs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,8 +31,12 @@ on GitHub Actions to catch what you could have caught locally.
 
 ## Code Conventions
 
-- **Go 1.24+** required. Build requires `-tags "sqlite_fts5"` (the
-  justfile handles this).
+- **Go 1.24+** required. SQLite is the pure-Go `modernc.org/sqlite`
+  driver (CGO-free; FTS5 is built in, so no build tag is needed). Open
+  databases via `database.Open`/`database.OpenMemory` or the
+  `database.DriverName` constant — never `sql.Open("sqlite", …)` directly
+  (a guard test enforces this), so every connection gets the forced
+  `_time_format=sqlite` that keeps timestamp serialization byte-stable.
 - **Conventional commits**: `feat:`, `fix:`, `docs:`, `refactor:`,
   `test:`, `chore:`.
 - **All HTTP clients** must use `httpkit.NewClient()` /

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,10 +39,6 @@ RUN test -n "${TARGETARCH}" || (echo "TARGETARCH build argument must be set" >&2
 # since the distroless final stage has no shell to mkdir/chown.
 RUN mkdir -p /out/data /out/config && chown -R 65532:65532 /out/data /out/config
 
-FROM scratch AS artifact
-
-COPY --from=builder /out/thane /thane
-
 FROM gcr.io/distroless/static-debian12:nonroot
 
 ARG THANE_VERSION=dev

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,12 +2,11 @@ FROM golang:1.25-bookworm AS builder
 
 WORKDIR /build
 
-# Install build dependencies (including CGO for SQLite)
+# No C toolchain needed: modernc.org/sqlite is pure Go, so the build is
+# CGO-free and cross-compiles natively. git is kept for build metadata.
 RUN apt-get update && apt-get install -y --no-install-recommends \
         ca-certificates \
-        gcc \
         git \
-        libc6-dev \
     && rm -rf /var/lib/apt/lists/*
 
 # Copy go mod files first for layer caching
@@ -24,10 +23,11 @@ ARG BUILD_COMMIT=unknown
 ARG BUILD_BRANCH=unknown
 ARG BUILD_TIME=unknown
 
-# Build with CGO for SQLite support
+# CGO-free static build. modernc.org/sqlite bundles FTS5 by default, so no
+# build tag is required. The static binary runs on a distroless base.
 RUN test -n "${TARGETARCH}" || (echo "TARGETARCH build argument must be set" >&2; exit 1) && \
-    CGO_ENABLED=1 GOOS="${TARGETOS}" GOARCH="${TARGETARCH}" \
-    go build -trimpath -tags "sqlite_fts5" \
+    CGO_ENABLED=0 GOOS="${TARGETOS}" GOARCH="${TARGETARCH}" \
+    go build -trimpath \
       -ldflags="-s -w \
         -X github.com/nugget/thane-ai-agent/internal/platform/buildinfo.Version=${THANE_VERSION} \
         -X github.com/nugget/thane-ai-agent/internal/platform/buildinfo.GitCommit=${BUILD_COMMIT} \
@@ -35,11 +35,15 @@ RUN test -n "${TARGETARCH}" || (echo "TARGETARCH build argument must be set" >&2
         -X github.com/nugget/thane-ai-agent/internal/platform/buildinfo.BuildTime=${BUILD_TIME}" \
       -o /out/thane ./cmd/thane
 
+# Pre-create runtime data dirs owned by the distroless nonroot uid (65532),
+# since the distroless final stage has no shell to mkdir/chown.
+RUN mkdir -p /out/data /out/config && chown -R 65532:65532 /out/data /out/config
+
 FROM scratch AS artifact
 
 COPY --from=builder /out/thane /thane
 
-FROM debian:bookworm-slim
+FROM gcr.io/distroless/static-debian12:nonroot
 
 ARG THANE_VERSION=dev
 ARG BUILD_COMMIT=unknown
@@ -58,40 +62,33 @@ LABEL \
     org.opencontainers.image.ref.name="${THANE_VERSION}" \
     org.opencontainers.image.revision="${BUILD_COMMIT}" \
     org.opencontainers.image.created="${BUILD_TIME}" \
-    org.opencontainers.image.base.name="docker.io/library/debian:bookworm-slim" \
+    org.opencontainers.image.base.name="gcr.io/distroless/static-debian12" \
     io.hass.name="Thane" \
     io.hass.description="Autonomous AI agent for Home Assistant" \
     io.hass.version="${THANE_VERSION}" \
     io.hass.type="addon" \
     io.hass.arch="aarch64|amd64"
 
-# Install runtime dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-        ca-certificates \
-        tzdata \
-        wget \
-    && rm -rf /var/lib/apt/lists/*
-
-# Create non-root user
-RUN useradd --system --no-create-home --home-dir /nonexistent --shell /usr/sbin/nologin thane
-
-# Copy binary from builder
+# Distroless static base ships ca-certificates, tzdata, and a nonroot user
+# (uid 65532) — no apt, shell, or libc. The CGO-free binary needs nothing
+# more. Runtime data dirs were pre-created with nonroot ownership in the
+# builder (the final stage has no shell to mkdir/chown).
 COPY --from=builder /out/thane /usr/local/bin/thane
-
-# Create data directories
-RUN mkdir -p /data /config && chown -R thane:thane /data /config
+COPY --from=builder --chown=65532:65532 /out/data /data
+COPY --from=builder --chown=65532:65532 /out/config /config
 
 WORKDIR /data
 
-USER thane
+USER nonroot
 
 # Default ports
 EXPOSE 8080
 EXPOSE 11434
 
-# Health check
+# Health check. Distroless has no shell or wget, so the binary probes its
+# own /health endpoint via the `health` subcommand.
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s \
-    CMD wget --no-verbose --tries=1 --spider http://localhost:8080/health || exit 1
+    CMD ["/usr/local/bin/thane", "health"]
 
 ENTRYPOINT ["/usr/local/bin/thane"]
 CMD ["serve"]

--- a/cmd/prewarm-replay/stores.go
+++ b/cmd/prewarm-replay/stores.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"path/filepath"
 
-	_ "github.com/mattn/go-sqlite3"
+	_ "modernc.org/sqlite"
 
 	"github.com/nugget/thane-ai-agent/internal/state/knowledge"
 	"github.com/nugget/thane-ai-agent/internal/state/memory"
@@ -31,8 +31,8 @@ type stores struct {
 // the harness can run ad-hoc queries against conversations metadata)
 // and the high-level wrapper stores that the providers expect.
 //
-// The mattn/go-sqlite3 driver respects URI query parameters when the
-// DSN begins with "file:". `mode=ro` opens read-only,
+// modernc.org/sqlite respects URI query parameters when the DSN begins
+// with "file:". `mode=ro` opens read-only,
 // `immutable=1` short-circuits journal recovery and lets multiple
 // readers race, `nolock=1` skips POSIX advisory locks (required for
 // SMB-mounted databases).
@@ -94,7 +94,7 @@ func (s *stores) searcher() memory.MemorySearcher {
 
 func openReadOnly(path string) (*sql.DB, error) {
 	dsn := "file:" + path + "?mode=ro&immutable=1&nolock=1"
-	db, err := sql.Open("sqlite3", dsn)
+	db, err := sql.Open("sqlite-thane", dsn)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/prewarm-replay/stores.go
+++ b/cmd/prewarm-replay/stores.go
@@ -7,8 +7,7 @@ import (
 	"os"
 	"path/filepath"
 
-	_ "modernc.org/sqlite"
-
+	"github.com/nugget/thane-ai-agent/internal/platform/database"
 	"github.com/nugget/thane-ai-agent/internal/state/knowledge"
 	"github.com/nugget/thane-ai-agent/internal/state/memory"
 )
@@ -94,7 +93,7 @@ func (s *stores) searcher() memory.MemorySearcher {
 
 func openReadOnly(path string) (*sql.DB, error) {
 	dsn := "file:" + path + "?mode=ro&immutable=1&nolock=1"
-	db, err := sql.Open("sqlite-thane", dsn)
+	db, err := sql.Open(database.DriverName, dsn)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/thane/health_test.go
+++ b/cmd/thane/health_test.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestRunHealth(t *testing.T) {
+	tests := []struct {
+		name    string
+		status  int
+		wantErr bool
+	}{
+		{name: "healthy 200", status: http.StatusOK, wantErr: false},
+		{name: "no content 204", status: http.StatusNoContent, wantErr: false},
+		{name: "service unavailable 503", status: http.StatusServiceUnavailable, wantErr: true},
+		{name: "server error 500", status: http.StatusInternalServerError, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(tt.status)
+			}))
+			defer srv.Close()
+
+			var out bytes.Buffer
+			err := runHealth(context.Background(), &out, []string{srv.URL + "/health"})
+			if tt.wantErr && err == nil {
+				t.Fatalf("runHealth(status=%d) = nil error, want error", tt.status)
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("runHealth(status=%d) = %v, want nil", tt.status, err)
+			}
+			if !tt.wantErr && !strings.Contains(out.String(), "ok") {
+				t.Errorf("runHealth(status=%d) output = %q, want it to contain \"ok\"", tt.status, out.String())
+			}
+		})
+	}
+}
+
+func TestRunHealth_Unreachable(t *testing.T) {
+	// Port 1 is reserved and never listens — connection is refused fast.
+	var out bytes.Buffer
+	if err := runHealth(context.Background(), &out, []string{"http://127.0.0.1:1/health"}); err == nil {
+		t.Fatal("runHealth against an unreachable endpoint = nil error, want error")
+	}
+}

--- a/cmd/thane/main.go
+++ b/cmd/thane/main.go
@@ -24,10 +24,12 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"net/http"
 	"os"
 	"os/signal"
 	"strings"
 	"syscall"
+	"time"
 
 	"github.com/nugget/thane-ai-agent/internal/app"
 	"github.com/nugget/thane-ai-agent/internal/integrations/homeassistant"
@@ -38,6 +40,7 @@ import (
 	"github.com/nugget/thane-ai-agent/internal/platform/buildinfo"
 	"github.com/nugget/thane-ai-agent/internal/platform/config"
 	"github.com/nugget/thane-ai-agent/internal/platform/database"
+	"github.com/nugget/thane-ai-agent/internal/platform/httpkit"
 	"github.com/nugget/thane-ai-agent/internal/platform/logging"
 	"github.com/nugget/thane-ai-agent/internal/runtime/agent"
 	"github.com/nugget/thane-ai-agent/internal/state/knowledge"
@@ -141,6 +144,8 @@ func run(ctx context.Context, stdout io.Writer, stderr io.Writer, args []string)
 		return runIngest(ctx, stdout, stderr, configPath, cmdArgs[0])
 	case "version":
 		return runVersion(stdout, outputFmt)
+	case "health":
+		return runHealth(ctx, stdout, cmdArgs)
 	case "caps":
 		return runCaps(ctx, stdout, configPath, outputFmt, cmdArgs)
 	case "":
@@ -168,6 +173,35 @@ func runVersion(w io.Writer, outputFmt string) error {
 	return nil
 }
 
+// runHealth probes a running daemon's /health endpoint and returns a
+// non-nil error (non-zero exit) when it is unreachable or unhealthy. It
+// is the container HEALTHCHECK entrypoint: the distroless runtime image
+// has no shell or wget, so the binary checks itself. The target URL
+// defaults to the local server and may be overridden by the first arg.
+func runHealth(ctx context.Context, w io.Writer, args []string) error {
+	url := "http://127.0.0.1:8080/health"
+	if len(args) > 0 && args[0] != "" {
+		url = args[0]
+	}
+
+	client := httpkit.NewClient(httpkit.WithTimeout(3 * time.Second))
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return fmt.Errorf("build health request: %w", err)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("health check failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("health check returned HTTP %d", resp.StatusCode)
+	}
+	fmt.Fprintln(w, "ok")
+	return nil
+}
+
 // printUsage writes the top-level help text to w. It is called when
 // thane is invoked with no arguments, or with -h / --help.
 func printUsage(w io.Writer) error {
@@ -182,6 +216,7 @@ func printUsage(w io.Writer) error {
 	fmt.Fprintln(w, "  ask          Ask a single question (for testing)")
 	fmt.Fprintln(w, "  ingest       Import markdown docs into fact store")
 	fmt.Fprintln(w, "  caps         Show resolved capability tags from a running daemon")
+	fmt.Fprintln(w, "  health [url] Probe a running daemon's /health endpoint (exit 0 if healthy)")
 	fmt.Fprintln(w, "  version      Show version information")
 	fmt.Fprintln(w)
 	fmt.Fprintln(w, "Flags:")

--- a/cmd/thane/main.go
+++ b/cmd/thane/main.go
@@ -43,7 +43,7 @@ import (
 	"github.com/nugget/thane-ai-agent/internal/state/knowledge"
 	"github.com/nugget/thane-ai-agent/internal/state/memory"
 
-	_ "github.com/mattn/go-sqlite3" // SQLite driver for database/sql
+	_ "modernc.org/sqlite" // SQLite driver for database/sql
 )
 
 // main is intentionally minimal. It constructs the OS-level environment

--- a/cmd/thane/main.go
+++ b/cmd/thane/main.go
@@ -193,7 +193,7 @@ func runHealth(ctx context.Context, w io.Writer, args []string) error {
 	if err != nil {
 		return fmt.Errorf("health check failed: %w", err)
 	}
-	defer resp.Body.Close()
+	defer httpkit.DrainAndClose(resp.Body, 4096)
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return fmt.Errorf("health check returned HTTP %d", resp.StatusCode)

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,6 @@ require (
 	github.com/google/go-github/v69 v69.2.0
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/websocket v1.5.3
-	github.com/mattn/go-sqlite3 v1.14.47
 	github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e
 	github.com/yuin/goldmark v1.8.2
 	golang.org/x/crypto v0.53.0

--- a/go.sum
+++ b/go.sum
@@ -33,8 +33,6 @@ github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs
 github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
-github.com/mattn/go-sqlite3 v1.14.47 h1:jOBI62gS7nKeZv+as1oGEy0+1qISgXwH/QBlR6KbfIo=
-github.com/mattn/go-sqlite3 v1.14.47/go.mod h1:6JTjA44L93a0QCyJef5YvlPoKXntQPjzWv5gtm9sB6w=
 github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOFAw7w=
 github.com/ncruces/go-strftime v1.0.0/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/internal/app/archivist_session_close_wake_test.go
+++ b/internal/app/archivist_session_close_wake_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/nugget/thane-ai-agent/internal/runtime/archivist"
 	"github.com/nugget/thane-ai-agent/internal/state/loopqueue"
 
-	_ "github.com/mattn/go-sqlite3"
+	_ "modernc.org/sqlite"
 )
 
 func newQueueTestApp(t *testing.T) (*App, *loopqueue.Store) {

--- a/internal/app/loop_focus_tools_test.go
+++ b/internal/app/loop_focus_tools_test.go
@@ -291,7 +291,7 @@ func TestMutateLoopSubscriptionsWritesPersistedAndLive(t *testing.T) {
 	// persistLoopDefinition is not a no-op and a future
 	// refactor that drops the persist call would leave the
 	// disk-side assertion below empty.
-	db, err := sql.Open("sqlite", ":memory:")
+	db, err := sql.Open("sqlite-thane", ":memory:")
 	if err != nil {
 		t.Fatalf("open db: %v", err)
 	}

--- a/internal/app/mqttwake_test.go
+++ b/internal/app/mqttwake_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/nugget/thane-ai-agent/internal/platform/events"
 	looppkg "github.com/nugget/thane-ai-agent/internal/runtime/loop"
 
-	_ "github.com/mattn/go-sqlite3"
+	_ "modernc.org/sqlite"
 )
 
 func newTestWakeStore(t *testing.T) *mqtt.SubscriptionStore {

--- a/internal/app/tooling_tags_test.go
+++ b/internal/app/tooling_tags_test.go
@@ -226,7 +226,7 @@ func TestResolveCapabilityTags_SortsBaselineTools(t *testing.T) {
 func TestResolveCapabilityTags_IncludesWatchlistToolsAfterProvider(t *testing.T) {
 	reg := tools.NewEmptyRegistry()
 
-	db, err := sql.Open("sqlite", ":memory:")
+	db, err := sql.Open("sqlite-thane", ":memory:")
 	if err != nil {
 		t.Fatalf("open db: %v", err)
 	}
@@ -275,7 +275,7 @@ func TestResolveCapabilityTags_IncludesWatchlistToolsAfterProvider(t *testing.T)
 func TestResolveCapabilityTags_IncludesMQTTWakeToolsAfterSetSubscriptionTools(t *testing.T) {
 	reg := tools.NewEmptyRegistry()
 
-	db, err := sql.Open("sqlite", ":memory:")
+	db, err := sql.Open("sqlite-thane", ":memory:")
 	if err != nil {
 		t.Fatalf("open db: %v", err)
 	}

--- a/internal/channels/email/poller_test.go
+++ b/internal/channels/email/poller_test.go
@@ -7,10 +7,10 @@ import (
 	"sync"
 	"testing"
 
-	_ "github.com/mattn/go-sqlite3"
 	"github.com/nugget/thane-ai-agent/internal/channels/messages"
 	"github.com/nugget/thane-ai-agent/internal/platform/database"
 	"github.com/nugget/thane-ai-agent/internal/platform/opstate"
+	_ "modernc.org/sqlite"
 )
 
 // stubContacts implements ContactResolver from a fixed address→zone map.

--- a/internal/channels/mqtt/subscriptions_test.go
+++ b/internal/channels/mqtt/subscriptions_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/nugget/thane-ai-agent/internal/platform/config"
 	"github.com/nugget/thane-ai-agent/internal/platform/database"
 
-	_ "github.com/mattn/go-sqlite3"
+	_ "modernc.org/sqlite"
 )
 
 func TestMatchTopicFilter(t *testing.T) {

--- a/internal/channels/mqtt/tools_test.go
+++ b/internal/channels/mqtt/tools_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/nugget/thane-ai-agent/internal/platform/config"
 	"github.com/nugget/thane-ai-agent/internal/platform/database"
 
-	_ "github.com/mattn/go-sqlite3"
+	_ "modernc.org/sqlite"
 )
 
 func newTestTools(t *testing.T) *Tools {

--- a/internal/channels/notifications/callback_test.go
+++ b/internal/channels/notifications/callback_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 	"time"
 
-	_ "github.com/mattn/go-sqlite3"
 	"github.com/nugget/thane-ai-agent/internal/platform/database"
+	_ "modernc.org/sqlite"
 )
 
 // mockInjector records InjectSystemMessage calls.

--- a/internal/channels/notifications/history_provider_test.go
+++ b/internal/channels/notifications/history_provider_test.go
@@ -8,9 +8,9 @@ import (
 	"testing"
 	"time"
 
-	_ "github.com/mattn/go-sqlite3"
 	"github.com/nugget/thane-ai-agent/internal/platform/database"
 	"github.com/nugget/thane-ai-agent/internal/runtime/agentctx"
+	_ "modernc.org/sqlite"
 )
 
 func newTestHistoryProvider(t *testing.T) (*HistoryProvider, *RecordStore) {

--- a/internal/channels/notifications/record_test.go
+++ b/internal/channels/notifications/record_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 	"time"
 
-	_ "github.com/mattn/go-sqlite3"
 	"github.com/nugget/thane-ai-agent/internal/platform/database"
+	_ "modernc.org/sqlite"
 )
 
 func newTestRecordStore(t *testing.T) *RecordStore {

--- a/internal/channels/notifications/router_test.go
+++ b/internal/channels/notifications/router_test.go
@@ -10,9 +10,9 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	_ "github.com/mattn/go-sqlite3"
 	"github.com/nugget/thane-ai-agent/internal/platform/database"
 	"github.com/nugget/thane-ai-agent/internal/state/contacts"
+	_ "modernc.org/sqlite"
 )
 
 // mockProvider records calls and optionally returns errors.

--- a/internal/channels/notifications/timeout_test.go
+++ b/internal/channels/notifications/timeout_test.go
@@ -6,8 +6,8 @@ import (
 	"testing"
 	"time"
 
-	_ "github.com/mattn/go-sqlite3"
 	"github.com/nugget/thane-ai-agent/internal/platform/database"
+	_ "modernc.org/sqlite"
 )
 
 func newTestTimeoutWatcher(t *testing.T) (*TimeoutWatcher, *RecordStore, *mockInjector, *mockDelegateSpawner) {

--- a/internal/integrations/forge/subscriptions_test.go
+++ b/internal/integrations/forge/subscriptions_test.go
@@ -11,10 +11,10 @@ import (
 	"testing"
 	"time"
 
-	_ "github.com/mattn/go-sqlite3"
 	"github.com/nugget/thane-ai-agent/internal/channels/messages"
 	"github.com/nugget/thane-ai-agent/internal/platform/database"
 	"github.com/nugget/thane-ai-agent/internal/platform/opstate"
+	_ "modernc.org/sqlite"
 )
 
 func newTestSubscriptionStore(t *testing.T) *SubscriptionStore {

--- a/internal/integrations/media/poller_test.go
+++ b/internal/integrations/media/poller_test.go
@@ -10,10 +10,10 @@ import (
 	"sync"
 	"testing"
 
-	_ "github.com/mattn/go-sqlite3"
 	"github.com/nugget/thane-ai-agent/internal/channels/messages"
 	"github.com/nugget/thane-ai-agent/internal/platform/database"
 	"github.com/nugget/thane-ai-agent/internal/platform/opstate"
+	_ "modernc.org/sqlite"
 )
 
 // newTestStore creates a temporary opstate store for testing.

--- a/internal/integrations/media/tools_analysis_test.go
+++ b/internal/integrations/media/tools_analysis_test.go
@@ -7,9 +7,9 @@ import (
 	"strings"
 	"testing"
 
-	_ "github.com/mattn/go-sqlite3"
 	"github.com/nugget/thane-ai-agent/internal/platform/database"
 	"github.com/nugget/thane-ai-agent/internal/platform/opstate"
+	_ "modernc.org/sqlite"
 )
 
 // newTestAnalysisTools creates AnalysisTools backed by temp directories.

--- a/internal/platform/checkpoint/checkpointer_test.go
+++ b/internal/platform/checkpoint/checkpointer_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	_ "github.com/mattn/go-sqlite3"
+	_ "modernc.org/sqlite"
 )
 
 func TestGetStartupStatus_Empty(t *testing.T) {
@@ -19,7 +19,7 @@ func TestGetStartupStatus_Empty(t *testing.T) {
 	defer os.Remove(tmpDB.Name())
 	tmpDB.Close()
 
-	db, err := sql.Open("sqlite3", tmpDB.Name())
+	db, err := sql.Open("sqlite-thane", tmpDB.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -65,7 +65,7 @@ func TestGetStartupStatus_WithData(t *testing.T) {
 	defer os.Remove(tmpDB.Name())
 	tmpDB.Close()
 
-	db, err := sql.Open("sqlite3", tmpDB.Name())
+	db, err := sql.Open("sqlite-thane", tmpDB.Name())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/platform/database/database.go
+++ b/internal/platform/database/database.go
@@ -10,12 +10,13 @@ import (
 )
 
 // Open opens a SQLite database at the given path with standard
-// production settings: WAL journal mode and a 5-second busy timeout.
-// Callers must ensure the github.com/mattn/go-sqlite3 driver is
-// registered (typically via a blank import in the binary's main
-// package or test file).
+// production settings: WAL journal mode and a 5-second busy timeout. It
+// uses the DriverName wrapper so time.Time values serialize to the
+// canonical SQLiteTimestampLayout. The file: URI scheme is required for
+// the _pragma query parameters to be parsed rather than treated as part
+// of the filename.
 func Open(path string) (*sql.DB, error) {
-	return sql.Open("sqlite3", path+"?_journal_mode=WAL&_busy_timeout=5000")
+	return sql.Open(DriverName, "file:"+path+"?_pragma=journal_mode(WAL)&_pragma=busy_timeout(5000)")
 }
 
 // memoryDBSeq generates unique names for in-memory test databases.
@@ -28,8 +29,8 @@ var memoryDBSeq uint64
 // connection and silently losing the in-memory state.
 func OpenMemory() (*sql.DB, error) {
 	id := atomic.AddUint64(&memoryDBSeq, 1)
-	dsn := fmt.Sprintf("file:thane_test_%d?mode=memory&cache=shared&_busy_timeout=5000", id)
-	db, err := sql.Open("sqlite3", dsn)
+	dsn := fmt.Sprintf("file:thane_test_%d?mode=memory&cache=shared&_pragma=busy_timeout(5000)", id)
+	db, err := sql.Open(DriverName, dsn)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/platform/database/database_test.go
+++ b/internal/platform/database/database_test.go
@@ -4,12 +4,12 @@ import (
 	"database/sql"
 	"testing"
 
-	_ "github.com/mattn/go-sqlite3"
+	_ "modernc.org/sqlite"
 )
 
 func openTestDB(t *testing.T) *sql.DB {
 	t.Helper()
-	db, err := sql.Open("sqlite3", ":memory:")
+	db, err := sql.Open("sqlite-thane", ":memory:")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/platform/database/driver.go
+++ b/internal/platform/database/driver.go
@@ -1,0 +1,57 @@
+package database
+
+import (
+	"database/sql"
+	"database/sql/driver"
+	"strings"
+
+	sqlite "modernc.org/sqlite"
+)
+
+// DriverName is the SQLite driver every thane store opens against. It is a
+// thin wrapper around modernc.org/sqlite that forces a deterministic
+// time.Time serialization on every connection.
+//
+// Why the wrapper exists: modernc's default time.Time binding uses Go's
+// time.Time.String() layout ("2006-01-02 15:04:05.999999999 -0700 MST"),
+// which SQLite's strftime() cannot parse (collapsing normalized sort keys
+// to NULL and breaking keyset pagination), which ParseTimestamp rejects,
+// and which does not sort lexically against the historical mattn-written
+// rows already in production databases. modernc registers itself under the
+// name "sqlite" in its own init() and database/sql panics on a duplicate
+// registration, so the "sqlite" name cannot be shadowed and modernc
+// exposes no hook to set a default _time_format globally. The wrapper
+// therefore registers under a distinct name and injects
+// _time_format=sqlite into every DSN, which makes modernc emit
+// "2006-01-02 15:04:05.999999999-07:00" — byte-identical to
+// SQLiteTimestampLayout / FormatTimestamp and to mattn's prior output, so
+// old and new rows remain mutually readable and orderable.
+const DriverName = "sqlite-thane"
+
+func init() {
+	sql.Register(DriverName, tsDriver{delegate: &sqlite.Driver{}})
+}
+
+// tsDriver wraps modernc's driver and forces _time_format=sqlite on open.
+type tsDriver struct {
+	delegate driver.Driver
+}
+
+func (d tsDriver) Open(dsn string) (driver.Conn, error) {
+	return d.delegate.Open(injectTimeFormat(dsn))
+}
+
+// injectTimeFormat appends _time_format=sqlite to a DSN unless the caller
+// already pinned the format. It selects the correct query separator so the
+// parameter is honored even on a bare DSN like ":memory:" (which has no
+// "?" yet) — modernc only parses query parameters that follow a "?".
+func injectTimeFormat(dsn string) string {
+	if strings.Contains(dsn, "_time_format=") {
+		return dsn
+	}
+	sep := "?"
+	if strings.Contains(dsn, "?") {
+		sep = "&"
+	}
+	return dsn + sep + "_time_format=sqlite"
+}

--- a/internal/platform/database/driver_guard_test.go
+++ b/internal/platform/database/driver_guard_test.go
@@ -1,0 +1,86 @@
+package database
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// TestNoBareSQLiteOpenOutsideDatabasePackage enforces that every SQLite
+// connection in the codebase opens through the [DriverName] wrapper, which
+// forces modernc's _time_format=sqlite so time.Time serializes to
+// [SQLiteTimestampLayout]. A raw sql.Open("sqlite", ...) (or the removed
+// "sqlite3") would instead emit modernc's default time.Time.String()
+// shape, silently stranding rows in a format that strftime cannot parse —
+// breaking ORDER BY normalization and keyset pagination — and that does
+// not sort lexically against existing rows. Open via Open/OpenMemory or
+// the DriverName constant; never name the bare driver directly.
+func TestNoBareSQLiteOpenOutsideDatabasePackage(t *testing.T) {
+	root := moduleRoot(t)
+	selfDir := filepath.Join(root, "internal", "platform", "database")
+	bare := regexp.MustCompile(`sql\.Open\("sqlite3?"`)
+	skipDirs := map[string]bool{"vendor": true, "dist": true, "node_modules": true}
+
+	var offenders []string
+	err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			// Skip hidden directories (.git, .claude/worktrees, etc.) and
+			// non-source trees — nested worktrees carry their own checkout.
+			if name := d.Name(); name != "." && strings.HasPrefix(name, ".") {
+				return filepath.SkipDir
+			}
+			if skipDirs[d.Name()] {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") {
+			return nil
+		}
+		// The database package is the one legitimate place that names the
+		// underlying driver (to register and delegate to the wrapper).
+		if filepath.Dir(path) == selfDir {
+			return nil
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		if bare.Match(data) {
+			rel, _ := filepath.Rel(root, path)
+			offenders = append(offenders, rel)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(offenders) > 0 {
+		t.Errorf("bare sql.Open(\"sqlite\"|\"sqlite3\") found outside internal/platform/database — "+
+			"open via database.Open/OpenMemory or the DriverName constant instead:\n  %s",
+			strings.Join(offenders, "\n  "))
+	}
+}
+
+func moduleRoot(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatal("go.mod not found above test working directory")
+		}
+		dir = parent
+	}
+}

--- a/internal/platform/database/driver_guard_test.go
+++ b/internal/platform/database/driver_guard_test.go
@@ -8,6 +8,14 @@ import (
 	"testing"
 )
 
+// bareSQLiteOpenPattern matches a call that opens the bare modernc driver
+// name ("sqlite" or the removed "sqlite3") in either string-literal form —
+// double-quoted or raw backtick — with optional whitespace after the
+// paren, so the guard cannot be evaded by switching literal style. The
+// DriverName constant and "sqlite-thane" are intentionally not matched
+// (the "-thane" suffix follows the name).
+var bareSQLiteOpenPattern = regexp.MustCompile("sql\\.Open\\(\\s*[\"`]sqlite3?[\"`]")
+
 // TestNoBareSQLiteOpenOutsideDatabasePackage enforces that every SQLite
 // connection in the codebase opens through the [DriverName] wrapper, which
 // forces modernc's _time_format=sqlite so time.Time serializes to
@@ -20,7 +28,6 @@ import (
 func TestNoBareSQLiteOpenOutsideDatabasePackage(t *testing.T) {
 	root := moduleRoot(t)
 	selfDir := filepath.Join(root, "internal", "platform", "database")
-	bare := regexp.MustCompile(`sql\.Open\("sqlite3?"`)
 	skipDirs := map[string]bool{"vendor": true, "dist": true, "node_modules": true}
 
 	var offenders []string
@@ -51,7 +58,7 @@ func TestNoBareSQLiteOpenOutsideDatabasePackage(t *testing.T) {
 		if err != nil {
 			return err
 		}
-		if bare.Match(data) {
+		if bareSQLiteOpenPattern.Match(data) {
 			rel, _ := filepath.Rel(root, path)
 			offenders = append(offenders, rel)
 		}
@@ -64,6 +71,36 @@ func TestNoBareSQLiteOpenOutsideDatabasePackage(t *testing.T) {
 		t.Errorf("bare sql.Open(\"sqlite\"|\"sqlite3\") found outside internal/platform/database — "+
 			"open via database.Open/OpenMemory or the DriverName constant instead:\n  %s",
 			strings.Join(offenders, "\n  "))
+	}
+}
+
+// TestBareSQLiteOpenPattern pins the guard regex against evasion forms:
+// both quote styles and whitespace must be caught, while the wrapped
+// driver name and the DriverName constant must pass.
+func TestBareSQLiteOpenPattern(t *testing.T) {
+	shouldMatch := []string{
+		`sql.Open("sqlite", dsn)`,
+		`sql.Open("sqlite3", dsn)`,
+		"sql.Open(`sqlite`, dsn)",       // raw string literal
+		"sql.Open(`sqlite3`, dsn)",      // raw string literal
+		`sql.Open( "sqlite" , dsn)`,     // whitespace after paren
+		"sql.Open(\n\t\t\"sqlite\", x)", // newline after paren
+	}
+	shouldNotMatch := []string{
+		`sql.Open("sqlite-thane", dsn)`, // the wrapper name
+		"sql.Open(`sqlite-thane`, dsn)",
+		`sql.Open(DriverName, dsn)`, // the constant
+		`sql.Open("postgres", dsn)`,
+	}
+	for _, s := range shouldMatch {
+		if !bareSQLiteOpenPattern.MatchString(s) {
+			t.Errorf("pattern should match %q but did not", s)
+		}
+	}
+	for _, s := range shouldNotMatch {
+		if bareSQLiteOpenPattern.MatchString(s) {
+			t.Errorf("pattern should NOT match %q but did", s)
+		}
 	}
 }
 

--- a/internal/platform/database/schema_test.go
+++ b/internal/platform/database/schema_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	_ "github.com/mattn/go-sqlite3"
+	_ "modernc.org/sqlite"
 )
 
 func discardLogger() *slog.Logger {

--- a/internal/platform/database/timestamp.go
+++ b/internal/platform/database/timestamp.go
@@ -39,6 +39,7 @@ var timestampLayouts = []string{
 	time.RFC3339,                              // 2006-01-02T15:04:05Z07:00
 	"2006-01-02T15:04:05",                     // RFC3339 without timezone
 	"2006-01-02 15:04:05Z07:00",               // space-separated with timezone
+	"2006-01-02 15:04:05.999999999",           // space-separated, nanoseconds, no timezone
 	"2006-01-02 15:04:05",                     // SQLite datetime() output
 	"2006-01-02 15:04:05.999999999 -0700 MST", // modernc default (time.Time.String); salvages migration-era rows
 }

--- a/internal/platform/database/timestamp.go
+++ b/internal/platform/database/timestamp.go
@@ -6,12 +6,18 @@ import (
 	"time"
 )
 
-// SQLiteTimestampLayout is the canonical TEXT shape go-sqlite3 emits
-// when binding a [time.Time] value: a space-separated date and time
-// with nanosecond precision and an explicit zone offset. This is the
-// on-disk form for any column whose values were inserted via bound
+// SQLiteTimestampLayout is the canonical TEXT shape the SQLite driver
+// emits when binding a [time.Time] value: a space-separated date and
+// time with nanosecond precision and an explicit zone offset. This is
+// the on-disk form for any column whose values were inserted via bound
 // parameters (the production write path), and it must be used as-is
 // when building bounds for lexical comparisons against those columns.
+//
+// This shape is stable across the modernc.org/sqlite migration: the
+// [DriverName] wrapper forces modernc's _time_format=sqlite so it emits
+// exactly the bytes the historical mattn/go-sqlite3 driver did. Rows
+// written before and after the migration are therefore byte-identical
+// and remain mutually readable and lexically orderable.
 //
 // Mixing this with [time.RFC3339Nano] (which uses a T separator)
 // produces silent miscompares: lexically " " (0x20) < "T" (0x54), so
@@ -22,18 +28,19 @@ const SQLiteTimestampLayout = "2006-01-02 15:04:05.999999999-07:00"
 
 // timestampLayouts lists accepted timestamp formats in order of
 // preference.  SQLite has no native timestamp type — values are TEXT.
-// go-sqlite3 writes [SQLiteTimestampLayout] when binding time.Time;
+// The driver writes [SQLiteTimestampLayout] when binding time.Time;
 // other Go code historically wrote RFC3339 / RFC3339Nano via Format;
 // SQLite's own datetime() emits a space-separated form without zone.
 // Parsing tries each layout in order and returns the first match.
 // Formats without an explicit timezone are treated as UTC.
 var timestampLayouts = []string{
-	SQLiteTimestampLayout,       // go-sqlite3 native binding output
-	time.RFC3339Nano,            // 2006-01-02T15:04:05.999999999Z07:00
-	time.RFC3339,                // 2006-01-02T15:04:05Z07:00
-	"2006-01-02T15:04:05",       // RFC3339 without timezone
-	"2006-01-02 15:04:05Z07:00", // space-separated with timezone
-	"2006-01-02 15:04:05",       // SQLite datetime() output
+	SQLiteTimestampLayout,                     // driver native binding output
+	time.RFC3339Nano,                          // 2006-01-02T15:04:05.999999999Z07:00
+	time.RFC3339,                              // 2006-01-02T15:04:05Z07:00
+	"2006-01-02T15:04:05",                     // RFC3339 without timezone
+	"2006-01-02 15:04:05Z07:00",               // space-separated with timezone
+	"2006-01-02 15:04:05",                     // SQLite datetime() output
+	"2006-01-02 15:04:05.999999999 -0700 MST", // modernc default (time.Time.String); salvages migration-era rows
 }
 
 // ParseTimestamp parses a timestamp string from SQLite, accepting
@@ -54,8 +61,8 @@ func ParseTimestamp(s string) (time.Time, error) {
 	return time.Time{}, fmt.Errorf("unrecognized timestamp format: %q", s)
 }
 
-// FormatTimestamp returns t in [SQLiteTimestampLayout] — the form
-// go-sqlite3 emits when binding [time.Time] directly. Use this only
+// FormatTimestamp returns t in [SQLiteTimestampLayout] — the form the
+// SQLite driver emits when binding [time.Time] directly. Use this only
 // when you need a literal string (raw SQL composition, migrations,
 // log lines, structured-data emission). For normal parameterized
 // queries, BIND time.Time directly so the driver and any stored rows

--- a/internal/platform/database/timestamp_test.go
+++ b/internal/platform/database/timestamp_test.go
@@ -48,6 +48,12 @@ func TestParseTimestamp(t *testing.T) {
 			want:  ref,
 		},
 		{
+			// Legacy archive write path (consolidated from memory.parseTimestamp).
+			name:  "space-separated nanoseconds without timezone",
+			input: "2026-03-09 21:39:58.123456789",
+			want:  time.Date(2026, 3, 9, 21, 39, 58, 123456789, time.UTC),
+		},
+		{
 			name:  "trailing whitespace",
 			input: "2026-03-09T21:39:58Z\n",
 			want:  ref,

--- a/internal/platform/database/timestamp_test.go
+++ b/internal/platform/database/timestamp_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	_ "github.com/mattn/go-sqlite3"
+	_ "modernc.org/sqlite"
 )
 
 func TestParseTimestamp(t *testing.T) {
@@ -112,10 +112,14 @@ func TestFormatTimestamp_RoundTrip(t *testing.T) {
 }
 
 func TestFormatTimestamp_MatchesDriverBinding(t *testing.T) {
-	// Pin FormatTimestamp to go-sqlite3's actual binding output. If the
-	// driver ever changes its time.Time → TEXT serialization, this test
-	// fails immediately rather than silently rotting the helper.
-	db, err := sql.Open("sqlite3", ":memory:")
+	// Pin FormatTimestamp to the driver's actual binding output under
+	// thane's configuration — the DriverName wrapper forces modernc's
+	// _time_format=sqlite. If the driver (or that wrapper) ever changes
+	// its time.Time → TEXT serialization, this test fails immediately
+	// rather than silently rotting the helper. Opening via the wrapper
+	// name (not bare "sqlite") is essential: the raw modernc default
+	// serializes as time.Time.String() and would not match.
+	db, err := sql.Open(DriverName, ":memory:")
 	if err != nil {
 		t.Fatalf("open: %v", err)
 	}

--- a/internal/platform/logging/content_test.go
+++ b/internal/platform/logging/content_test.go
@@ -8,8 +8,8 @@ import (
 	"strings"
 	"testing"
 
-	_ "github.com/mattn/go-sqlite3"
 	"github.com/nugget/thane-ai-agent/internal/model/llm"
+	_ "modernc.org/sqlite"
 )
 
 func TestContentWriter_WriteRequest(t *testing.T) {

--- a/internal/platform/logging/indexer_test.go
+++ b/internal/platform/logging/indexer_test.go
@@ -9,13 +9,13 @@ import (
 	"testing"
 	"time"
 
-	_ "github.com/mattn/go-sqlite3"
+	_ "modernc.org/sqlite"
 )
 
 // openTestDB creates a temporary SQLite database and runs Migrate.
 func openTestDB(t *testing.T) *sql.DB {
 	t.Helper()
-	db, err := sql.Open("sqlite3", t.TempDir()+"/test.db?_journal_mode=WAL&_busy_timeout=5000")
+	db, err := sql.Open("sqlite-thane", "file:"+t.TempDir()+"/test.db?_pragma=journal_mode(WAL)&_pragma=busy_timeout(5000)")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/platform/opstate/store_test.go
+++ b/internal/platform/opstate/store_test.go
@@ -5,8 +5,8 @@ import (
 	"testing"
 	"time"
 
-	_ "github.com/mattn/go-sqlite3"
 	"github.com/nugget/thane-ai-agent/internal/platform/database"
+	_ "modernc.org/sqlite"
 )
 
 func testStore(t *testing.T) *Store {

--- a/internal/platform/scheduler/store.go
+++ b/internal/platform/scheduler/store.go
@@ -8,8 +8,8 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	_ "github.com/mattn/go-sqlite3"
 	"github.com/nugget/thane-ai-agent/internal/platform/database"
+	_ "modernc.org/sqlite"
 )
 
 // Store handles task and execution persistence.

--- a/internal/platform/scheduler/store_test.go
+++ b/internal/platform/scheduler/store_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 	"time"
 
-	_ "github.com/mattn/go-sqlite3"
 	"github.com/nugget/thane-ai-agent/internal/platform/database"
+	_ "modernc.org/sqlite"
 )
 
 func newTestStore(t *testing.T) *Store {

--- a/internal/platform/telemetry/collector_test.go
+++ b/internal/platform/telemetry/collector_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	_ "github.com/mattn/go-sqlite3"
+	_ "modernc.org/sqlite"
 
 	"github.com/nugget/thane-ai-agent/internal/runtime/loop"
 )
@@ -272,7 +272,7 @@ func TestCollect_LoopsExcludeChildren(t *testing.T) {
 // log_entries schema matching the logging indexer.
 func openTestLogsDB(t *testing.T) *sql.DB {
 	t.Helper()
-	db, err := sql.Open("sqlite3", ":memory:")
+	db, err := sql.Open("sqlite-thane", ":memory:")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/platform/usage/store_test.go
+++ b/internal/platform/usage/store_test.go
@@ -5,10 +5,10 @@ import (
 	"testing"
 	"time"
 
-	_ "github.com/mattn/go-sqlite3"
 	"github.com/nugget/thane-ai-agent/internal/model/fleet"
 	"github.com/nugget/thane-ai-agent/internal/platform/config"
 	"github.com/nugget/thane-ai-agent/internal/platform/database"
+	_ "modernc.org/sqlite"
 )
 
 func testStore(t *testing.T) *Store {

--- a/internal/runtime/agent/capability_store_test.go
+++ b/internal/runtime/agent/capability_store_test.go
@@ -3,9 +3,9 @@ package agent
 import (
 	"testing"
 
-	_ "github.com/mattn/go-sqlite3"
 	"github.com/nugget/thane-ai-agent/internal/platform/database"
 	"github.com/nugget/thane-ai-agent/internal/platform/opstate"
+	_ "modernc.org/sqlite"
 )
 
 func newTestCapStore(t *testing.T) *OpstateCapabilityTagStore {

--- a/internal/server/api/contacts.go
+++ b/internal/server/api/contacts.go
@@ -10,8 +10,9 @@ import (
 	"strings"
 
 	"github.com/google/uuid"
-	sqlite3 "github.com/mattn/go-sqlite3"
 	"github.com/nugget/thane-ai-agent/internal/state/contacts"
+	sqlite3 "modernc.org/sqlite"
+	sqlite3lib "modernc.org/sqlite/lib"
 )
 
 const (
@@ -342,8 +343,8 @@ func (s *Server) writeContactStoreError(w http.ResponseWriter, err error, fallba
 }
 
 func isSQLiteConstraint(err error) bool {
-	var sqliteErr sqlite3.Error
-	if errors.As(err, &sqliteErr) && sqliteErr.Code == sqlite3.ErrConstraint {
+	var sqliteErr *sqlite3.Error
+	if errors.As(err, &sqliteErr) && sqliteErr.Code()&0xff == sqlite3lib.SQLITE_CONSTRAINT {
 		return true
 	}
 	lower := strings.ToLower(err.Error())
@@ -351,9 +352,9 @@ func isSQLiteConstraint(err error) bool {
 }
 
 func contactConstraintMessage(err error) string {
-	var sqliteErr sqlite3.Error
+	var sqliteErr *sqlite3.Error
 	if errors.As(err, &sqliteErr) {
-		if sqliteErr.ExtendedCode == sqlite3.ErrConstraintUnique {
+		if sqliteErr.Code() == sqlite3lib.SQLITE_CONSTRAINT_UNIQUE {
 			return "formatted_name must be unique"
 		}
 	}

--- a/internal/server/carddav/backend_test.go
+++ b/internal/server/carddav/backend_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/emersion/go-vcard"
 	"github.com/emersion/go-webdav/carddav"
 	"github.com/google/uuid"
-	_ "github.com/mattn/go-sqlite3"
+	_ "modernc.org/sqlite"
 
 	"github.com/nugget/thane-ai-agent/internal/platform/database"
 	"github.com/nugget/thane-ai-agent/internal/state/contacts"

--- a/internal/state/attachments/store_test.go
+++ b/internal/state/attachments/store_test.go
@@ -11,8 +11,8 @@ import (
 	"testing"
 	"time"
 
-	_ "github.com/mattn/go-sqlite3"
 	"github.com/nugget/thane-ai-agent/internal/platform/database"
+	_ "modernc.org/sqlite"
 )
 
 // newTestStore creates a Store in a temporary directory for testing.

--- a/internal/state/awareness/loop_subscription_provider_test.go
+++ b/internal/state/awareness/loop_subscription_provider_test.go
@@ -18,7 +18,7 @@ import (
 // fakeHA stub used by the rest of the awareness tests.
 func setupLoopSubProvider(t *testing.T) (*LoopSubscriptionProvider, *WatchlistStore, *looppkg.Registry, *fakeHA) {
 	t.Helper()
-	db, err := sql.Open("sqlite", ":memory:")
+	db, err := sql.Open("sqlite-thane", ":memory:")
 	if err != nil {
 		t.Fatalf("open db: %v", err)
 	}

--- a/internal/state/awareness/watchlist_provider_test.go
+++ b/internal/state/awareness/watchlist_provider_test.go
@@ -66,7 +66,7 @@ func (f *fakeHA) GetWeatherForecasts(_ context.Context, entityID, forecastType s
 
 func setupTestProvider(t *testing.T, ha StateGetter) (*WatchlistProvider, *WatchlistStore) {
 	t.Helper()
-	db, err := sql.Open("sqlite", ":memory:")
+	db, err := sql.Open("sqlite-thane", ":memory:")
 	if err != nil {
 		t.Fatalf("open db: %v", err)
 	}

--- a/internal/state/awareness/watchlist_store_test.go
+++ b/internal/state/awareness/watchlist_store_test.go
@@ -13,7 +13,7 @@ import (
 
 func setupTestStore(t *testing.T) *WatchlistStore {
 	t.Helper()
-	db, err := sql.Open("sqlite", ":memory:")
+	db, err := sql.Open("sqlite-thane", ":memory:")
 	if err != nil {
 		t.Fatalf("open db: %v", err)
 	}

--- a/internal/state/awareness/watchlist_tool_provider_test.go
+++ b/internal/state/awareness/watchlist_tool_provider_test.go
@@ -15,7 +15,7 @@ import (
 
 func setupWatchlistProvider(t *testing.T) (*WatchlistTools, *WatchlistStore, *[]string) {
 	t.Helper()
-	db, err := sql.Open("sqlite", ":memory:")
+	db, err := sql.Open("sqlite-thane", ":memory:")
 	if err != nil {
 		t.Fatalf("open db: %v", err)
 	}

--- a/internal/state/contacts/store_test.go
+++ b/internal/state/contacts/store_test.go
@@ -9,8 +9,8 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	_ "github.com/mattn/go-sqlite3"
 	"github.com/nugget/thane-ai-agent/internal/platform/database"
+	_ "modernc.org/sqlite"
 )
 
 func newTestStore(t *testing.T) *Store {

--- a/internal/state/contacts/store_test.go
+++ b/internal/state/contacts/store_test.go
@@ -226,9 +226,6 @@ func TestUpsert_InvalidKind(t *testing.T) {
 
 func TestSearch_FTS(t *testing.T) {
 	store := newTestStore(t)
-	if !store.ftsEnabled {
-		t.Skip("FTS5 not available")
-	}
 
 	contacts := []*Contact{
 		{FormattedName: "Eve Engineer", Kind: "individual", Org: "Acme Corp", AISummary: "Backend developer"},
@@ -281,9 +278,6 @@ func TestSearch_FTS(t *testing.T) {
 
 func TestSearch_ExcludesDeleted(t *testing.T) {
 	store := newTestStore(t)
-	if !store.ftsEnabled {
-		t.Skip("FTS5 not available")
-	}
 
 	c := &Contact{FormattedName: "Grace Ghosted", Kind: "individual", AISummary: "Will be deleted soon"}
 	created, err := store.Upsert(c)
@@ -669,7 +663,7 @@ func TestSanitizeFTS5Query(t *testing.T) {
 func TestFTS5Enabled(t *testing.T) {
 	store := newTestStore(t)
 	if !store.ftsEnabled {
-		t.Skip("FTS5 not available in test environment")
+		t.Fatal("FTS5 must be available with the modernc.org/sqlite driver")
 	}
 }
 

--- a/internal/state/documents/store_test.go
+++ b/internal/state/documents/store_test.go
@@ -9,8 +9,8 @@ import (
 	"testing"
 	"time"
 
-	_ "github.com/mattn/go-sqlite3"
 	"github.com/nugget/thane-ai-agent/internal/platform/database"
+	_ "modernc.org/sqlite"
 )
 
 func TestDocumentStoreBrowseSearchAndSections(t *testing.T) {

--- a/internal/state/documents/tools_test.go
+++ b/internal/state/documents/tools_test.go
@@ -9,8 +9,8 @@ import (
 	"testing"
 	"time"
 
-	_ "github.com/mattn/go-sqlite3"
 	"github.com/nugget/thane-ai-agent/internal/platform/database"
+	_ "modernc.org/sqlite"
 )
 
 func TestToolsRootsOmitAbsolutePath(t *testing.T) {

--- a/internal/state/knowledge/ingest_integration_test.go
+++ b/internal/state/knowledge/ingest_integration_test.go
@@ -6,8 +6,8 @@ import (
 	"os"
 	"testing"
 
-	_ "github.com/mattn/go-sqlite3"
 	"github.com/nugget/thane-ai-agent/internal/platform/database"
+	_ "modernc.org/sqlite"
 )
 
 func openFileBackedStore(t *testing.T, path string) *Store {

--- a/internal/state/knowledge/store.go
+++ b/internal/state/knowledge/store.go
@@ -36,7 +36,7 @@ const (
 	// Qualified columns for FTS5 JOIN queries where facts and facts_fts
 	// share column names (key, value, source). Without table prefixes,
 	// SQLite raises "ambiguous column name" errors.
-	factColumnsFTS = "id, category, key, value, source, confidence, subjects, created_at, updated_at, accessed_at, ref"
+	factColumnsFTS = "facts.id, facts.category, facts.key, facts.value, facts.source, facts.confidence, facts.subjects, facts.created_at, facts.updated_at, facts.accessed_at, facts.ref"
 	// Filter for active facts (currently: not soft-deleted).
 	activeFilter = "deleted_at IS NULL"
 )
@@ -309,7 +309,7 @@ func (s *Store) searchFTS(query string) ([]*Fact, error) {
 	rows, err := s.db.Query(`
 		SELECT `+factColumnsFTS+`
 		FROM facts_fts
-		JOIN facts ON facts_fts.rowid = rowid
+		JOIN facts ON facts_fts.rowid = facts.rowid
 		WHERE facts_fts MATCH ? AND `+activeFilter+`
 		ORDER BY rank
 		LIMIT 50

--- a/internal/state/knowledge/store_test.go
+++ b/internal/state/knowledge/store_test.go
@@ -5,8 +5,8 @@ import (
 	"os"
 	"testing"
 
-	_ "github.com/mattn/go-sqlite3"
 	"github.com/nugget/thane-ai-agent/internal/platform/database"
+	_ "modernc.org/sqlite"
 )
 
 func newTestStore(t *testing.T) *Store {

--- a/internal/state/knowledge/store_test.go
+++ b/internal/state/knowledge/store_test.go
@@ -34,15 +34,12 @@ func newTestStore(t *testing.T) *Store {
 func TestFTS5_Enabled(t *testing.T) {
 	store := newTestStore(t)
 	if !store.ftsEnabled {
-		t.Skip("FTS5 not available in test environment")
+		t.Fatal("FTS5 must be available with the modernc.org/sqlite driver")
 	}
 }
 
 func TestFTS5_SearchByKeyword(t *testing.T) {
 	store := newTestStore(t)
-	if !store.ftsEnabled {
-		t.Skip("FTS5 not available")
-	}
 
 	// Insert test
 	_, err := store.Set(CategoryHome, "living_room_layout", "Large room with sectional sofa facing the TV", "user", 1.0, nil, "")
@@ -116,9 +113,6 @@ func TestFTS5_SearchByKeyword(t *testing.T) {
 
 func TestFTS5_SearchExcludesDeleted(t *testing.T) {
 	store := newTestStore(t)
-	if !store.ftsEnabled {
-		t.Skip("FTS5 not available")
-	}
 
 	_, err := store.Set(CategoryDevice, "garage_sensor", "Temperature sensor in the garage", "observation", 1.0, nil, "")
 	if err != nil {
@@ -151,9 +145,6 @@ func TestFTS5_SearchExcludesDeleted(t *testing.T) {
 
 func TestFTS5_SearchAfterUpdate(t *testing.T) {
 	store := newTestStore(t)
-	if !store.ftsEnabled {
-		t.Skip("FTS5 not available")
-	}
 
 	_, err := store.Set(CategoryPreference, "color_temp", "Prefers warm white lights", "user", 1.0, nil, "")
 	if err != nil {

--- a/internal/state/knowledge/subject_context_test.go
+++ b/internal/state/knowledge/subject_context_test.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 	"testing"
 
-	_ "github.com/mattn/go-sqlite3"
 	"github.com/nugget/thane-ai-agent/internal/runtime/agentctx"
+	_ "modernc.org/sqlite"
 )
 
 func TestSubjectsContext(t *testing.T) {

--- a/internal/state/knowledge/tools_test.go
+++ b/internal/state/knowledge/tools_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	_ "github.com/mattn/go-sqlite3"
+	_ "modernc.org/sqlite"
 )
 
 // mockEmbeddingClient implements EmbeddingClient for testing.

--- a/internal/state/loopqueue/queue_store_test.go
+++ b/internal/state/loopqueue/queue_store_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/nugget/thane-ai-agent/internal/platform/database"
 
-	_ "github.com/mattn/go-sqlite3"
+	_ "modernc.org/sqlite"
 )
 
 func newTestStore(t *testing.T) *Store {

--- a/internal/state/memory/archive.go
+++ b/internal/state/memory/archive.go
@@ -213,15 +213,16 @@ type IdleSessionInfo struct {
 }
 
 // timestampFormats lists formats tried when parsing SQLite timestamp strings,
-// ordered from most specific to least. The mattn/go-sqlite3 driver stores
-// time.Time as RFC3339Nano by default, but other paths (or direct SQL
-// inserts) may produce different layouts.
+// ordered from most specific to least. time.Time is commonly stored as
+// RFC3339Nano, but other paths (or direct SQL inserts) may produce
+// different layouts, so parsing tries each in turn.
 var timestampFormats = []string{
 	time.RFC3339Nano,
 	time.RFC3339,
 	"2006-01-02 15:04:05.999999999-07:00",
 	"2006-01-02 15:04:05.999999999",
 	"2006-01-02 15:04:05",
+	"2006-01-02 15:04:05.999999999 -0700 MST", // modernc default (time.Time.String); salvages migration-era rows
 }
 
 // parseTimestamp attempts to parse a SQLite timestamp string using the
@@ -331,7 +332,7 @@ func NewArchiveStore(dbPath string, messagesDB *sql.DB, cfg *ArchiveConfig, logg
 		cfg = &defaults
 	}
 
-	db, err := sql.Open("sqlite3", dbPath+"?_journal_mode=WAL&_busy_timeout=5000")
+	db, err := database.Open(dbPath)
 	if err != nil {
 		return nil, fmt.Errorf("open archive database: %w", err)
 	}

--- a/internal/state/memory/archive.go
+++ b/internal/state/memory/archive.go
@@ -791,8 +791,11 @@ func (s *ArchiveStore) migrateSchema() {
 	}
 }
 
-// tryEnableFTS attempts to create the FTS5 virtual table.
-// Returns true if FTS5 is available, false otherwise.
+// tryEnableFTS attempts to create the FTS5 virtual table. Returns true if
+// FTS5 is available and, in unified mode, its sync triggers were installed
+// — i.e. searchFTS can be trusted to return complete results. Returns
+// false otherwise so the store falls back to the LIKE path rather than
+// querying an index that cannot stay in sync.
 func (s *ArchiveStore) tryEnableFTS() bool {
 	ftsTable := s.msgFTSName
 	contentTable := s.msgTableName
@@ -815,17 +818,29 @@ func (s *ArchiveStore) tryEnableFTS() bool {
 	// Search returns nothing (the consolidated-mode production path).
 	// Legacy mode keeps its explicit-insert path in ArchiveMessages;
 	// installing triggers there would double-index every row.
+	//
+	// If the triggers cannot be installed, sync cannot be established:
+	// disable FTS so Search uses the LIKE fallback instead of silently
+	// querying a stale/empty index.
 	if s.messagesDB != nil {
-		s.setupMessagesFTSSync(db, ftsTable, contentTable)
+		if err := s.setupMessagesFTSSync(db, ftsTable, contentTable); err != nil {
+			if s.logger != nil {
+				s.logger.Warn("messages_fts sync unavailable; using LIKE fallback", "error", err)
+			}
+			return false
+		}
 	}
 	return true
 }
 
-// setupMessagesFTSSync installs AFTER INSERT/DELETE/UPDATE sync triggers
-// on the unified messages table and backfills the external-content FTS
-// index. Degrades gracefully: failures are logged, never fatal, and the
-// next startup retries the backfill against the same shortfall signal.
-func (s *ArchiveStore) setupMessagesFTSSync(db *sql.DB, ftsTable, contentTable string) {
+// setupMessagesFTSSync installs AFTER INSERT/DELETE/UPDATE sync triggers on
+// the unified messages table and backfills the external-content FTS index.
+// It returns a non-nil error only when the triggers cannot be installed —
+// i.e. ongoing sync cannot be established, so the caller must not trust the
+// index. Backfill (rebuild) failure is non-fatal: the triggers keep the
+// index growing for new writes and the next startup retries the rebuild
+// against the same docsize-shortfall signal.
+func (s *ArchiveStore) setupMessagesFTSSync(db *sql.DB, ftsTable, contentTable string) error {
 	stmts := []string{
 		fmt.Sprintf(`
 			CREATE TRIGGER IF NOT EXISTS %s_ai AFTER INSERT ON %s BEGIN
@@ -854,10 +869,7 @@ func (s *ArchiveStore) setupMessagesFTSSync(db *sql.DB, ftsTable, contentTable s
 	}
 	for _, stmt := range stmts {
 		if _, err := db.Exec(stmt); err != nil {
-			if s.logger != nil {
-				s.logger.Warn("messages_fts trigger setup failed", "error", err)
-			}
-			return
+			return fmt.Errorf("install messages_fts trigger: %w", err)
 		}
 	}
 
@@ -866,18 +878,19 @@ func (s *ArchiveStore) setupMessagesFTSSync(db *sql.DB, ftsTable, contentTable s
 	// rebuild. Probe the _docsize shadow table, not COUNT(*) on the FTS
 	// table: external-content FTS5 proxies COUNT(*) through to the source
 	// table, which would always self-equal and suppress the rebuild.
+	// Backfill problems below are non-fatal — triggers are already in place.
 	var docCount, srcCount int
 	if err := db.QueryRow(fmt.Sprintf(`SELECT COUNT(*) FROM %s_docsize`, ftsTable)).Scan(&docCount); err != nil {
 		if s.logger != nil {
-			s.logger.Warn("messages_fts docsize probe failed", "error", err)
+			s.logger.Warn("messages_fts docsize probe failed; skipping backfill", "error", err)
 		}
-		return
+		return nil
 	}
 	if err := db.QueryRow(fmt.Sprintf(`SELECT COUNT(*) FROM %s`, contentTable)).Scan(&srcCount); err != nil {
 		if s.logger != nil {
-			s.logger.Warn("messages count probe failed", "error", err)
+			s.logger.Warn("messages count probe failed; skipping backfill", "error", err)
 		}
-		return
+		return nil
 	}
 	if docCount < srcCount {
 		if _, err := db.Exec(fmt.Sprintf(`INSERT INTO %s(%s) VALUES('rebuild')`, ftsTable, ftsTable)); err != nil {
@@ -887,6 +900,7 @@ func (s *ArchiveStore) setupMessagesFTSSync(db *sql.DB, ftsTable, contentTable s
 			}
 		}
 	}
+	return nil
 }
 
 // ArchiveMessages copies messages to the immutable archive.

--- a/internal/state/memory/archive.go
+++ b/internal/state/memory/archive.go
@@ -212,31 +212,6 @@ type IdleSessionInfo struct {
 	LastActivity   time.Time
 }
 
-// timestampFormats lists formats tried when parsing SQLite timestamp strings,
-// ordered from most specific to least. time.Time is commonly stored as
-// RFC3339Nano, but other paths (or direct SQL inserts) may produce
-// different layouts, so parsing tries each in turn.
-var timestampFormats = []string{
-	time.RFC3339Nano,
-	time.RFC3339,
-	"2006-01-02 15:04:05.999999999-07:00",
-	"2006-01-02 15:04:05.999999999",
-	"2006-01-02 15:04:05",
-	"2006-01-02 15:04:05.999999999 -0700 MST", // modernc default (time.Time.String); salvages migration-era rows
-}
-
-// parseTimestamp attempts to parse a SQLite timestamp string using the
-// known formats in timestampFormats. Returns zero time and false if none
-// match.
-func parseTimestamp(s string) (time.Time, bool) {
-	for _, layout := range timestampFormats {
-		if t, err := time.Parse(layout, s); err == nil {
-			return t, true
-		}
-	}
-	return time.Time{}, false
-}
-
 // ArchivedToolCall represents a tool call preserved in the archive.
 type ArchivedToolCall struct {
 	ID             string     `json:"id"`
@@ -2170,8 +2145,8 @@ func (s *ArchiveStore) ActiveSessionsWithLastActivity() ([]IdleSessionInfo, erro
 			return nil, fmt.Errorf("scan active session: %w", err)
 		}
 
-		startedAt, ok := parseTimestamp(startedAtStr)
-		if !ok {
+		startedAt, err := database.ParseTimestamp(startedAtStr)
+		if err != nil {
 			// Skip sessions with unparseable timestamps rather than
 			// risk closing them due to a zero-time default.
 			continue
@@ -2185,7 +2160,6 @@ func (s *ArchiveStore) ActiveSessionsWithLastActivity() ([]IdleSessionInfo, erro
 		// (archive_messages table), session_id is always set and
 		// there's no status column.
 		var maxTS sql.NullString
-		var err error
 		if s.messagesDB != nil {
 			err = db.QueryRow(
 				fmt.Sprintf(`SELECT MAX(timestamp) FROM %s
@@ -2207,7 +2181,7 @@ func (s *ArchiveStore) ActiveSessionsWithLastActivity() ([]IdleSessionInfo, erro
 		}
 
 		if maxTS.Valid {
-			if parsed, ok := parseTimestamp(maxTS.String); ok {
+			if parsed, err := database.ParseTimestamp(maxTS.String); err == nil {
 				info.LastActivity = parsed
 			}
 		}

--- a/internal/state/memory/archive.go
+++ b/internal/state/memory/archive.go
@@ -797,14 +797,95 @@ func (s *ArchiveStore) tryEnableFTS() bool {
 	contentTable := s.msgTableName
 	db := s.msgDB()
 
-	_, err := db.Exec(fmt.Sprintf(`
+	if _, err := db.Exec(fmt.Sprintf(`
 		CREATE VIRTUAL TABLE IF NOT EXISTS %s USING fts5(
 			content,
 			content=%s,
 			content_rowid=rowid
 		)
-	`, ftsTable, contentTable))
-	return err == nil
+	`, ftsTable, contentTable)); err != nil {
+		return false
+	}
+
+	// In unified mode the messages are written by SQLiteStore, which knows
+	// nothing about this external-content FTS index — so it can only stay
+	// in sync via triggers plus a one-time backfill, mirroring
+	// trySetupSessionsFTS. Without this the index is created empty and
+	// Search returns nothing (the consolidated-mode production path).
+	// Legacy mode keeps its explicit-insert path in ArchiveMessages;
+	// installing triggers there would double-index every row.
+	if s.messagesDB != nil {
+		s.setupMessagesFTSSync(db, ftsTable, contentTable)
+	}
+	return true
+}
+
+// setupMessagesFTSSync installs AFTER INSERT/DELETE/UPDATE sync triggers
+// on the unified messages table and backfills the external-content FTS
+// index. Degrades gracefully: failures are logged, never fatal, and the
+// next startup retries the backfill against the same shortfall signal.
+func (s *ArchiveStore) setupMessagesFTSSync(db *sql.DB, ftsTable, contentTable string) {
+	stmts := []string{
+		fmt.Sprintf(`
+			CREATE TRIGGER IF NOT EXISTS %s_ai AFTER INSERT ON %s BEGIN
+				INSERT INTO %s(rowid, content) VALUES (new.rowid, COALESCE(new.content, ''));
+			END
+		`, ftsTable, contentTable, ftsTable),
+		// DELETE/UPDATE use the FTS5 'delete' command to tombstone the old
+		// row — external-content tables cannot do partial-column updates.
+		fmt.Sprintf(`
+			CREATE TRIGGER IF NOT EXISTS %s_ad AFTER DELETE ON %s BEGIN
+				INSERT INTO %s(%s, rowid, content) VALUES ('delete', old.rowid, COALESCE(old.content, ''));
+			END
+		`, ftsTable, contentTable, ftsTable, ftsTable),
+		// Re-index only when content actually changes. Messages are updated
+		// frequently for status/archived_at, which leave content untouched;
+		// the WHEN guard avoids needless index churn on those writes. (A
+		// deliberate refinement over the sessions_fts triggers, where the
+		// indexed columns change together and no guard is warranted.)
+		fmt.Sprintf(`
+			CREATE TRIGGER IF NOT EXISTS %s_au AFTER UPDATE ON %s
+			WHEN old.content IS NOT new.content BEGIN
+				INSERT INTO %s(%s, rowid, content) VALUES ('delete', old.rowid, COALESCE(old.content, ''));
+				INSERT INTO %s(rowid, content) VALUES (new.rowid, COALESCE(new.content, ''));
+			END
+		`, ftsTable, contentTable, ftsTable, ftsTable, ftsTable),
+	}
+	for _, stmt := range stmts {
+		if _, err := db.Exec(stmt); err != nil {
+			if s.logger != nil {
+				s.logger.Warn("messages_fts trigger setup failed", "error", err)
+			}
+			return
+		}
+	}
+
+	// Idempotent backfill: rebuild when the inverted index holds fewer docs
+	// than the source table — covering first creation and a prior failed
+	// rebuild. Probe the _docsize shadow table, not COUNT(*) on the FTS
+	// table: external-content FTS5 proxies COUNT(*) through to the source
+	// table, which would always self-equal and suppress the rebuild.
+	var docCount, srcCount int
+	if err := db.QueryRow(fmt.Sprintf(`SELECT COUNT(*) FROM %s_docsize`, ftsTable)).Scan(&docCount); err != nil {
+		if s.logger != nil {
+			s.logger.Warn("messages_fts docsize probe failed", "error", err)
+		}
+		return
+	}
+	if err := db.QueryRow(fmt.Sprintf(`SELECT COUNT(*) FROM %s`, contentTable)).Scan(&srcCount); err != nil {
+		if s.logger != nil {
+			s.logger.Warn("messages count probe failed", "error", err)
+		}
+		return
+	}
+	if docCount < srcCount {
+		if _, err := db.Exec(fmt.Sprintf(`INSERT INTO %s(%s) VALUES('rebuild')`, ftsTable, ftsTable)); err != nil {
+			if s.logger != nil {
+				s.logger.Warn("messages_fts backfill failed; next startup will retry",
+					"docsize", docCount, "messages", srcCount, "error", err)
+			}
+		}
+	}
 }
 
 // ArchiveMessages copies messages to the immutable archive.

--- a/internal/state/memory/archive_test.go
+++ b/internal/state/memory/archive_test.go
@@ -2094,9 +2094,6 @@ func TestSearch_TimeRangeScopesMessages(t *testing.T) {
 // match_type marking the phrase-precision pass.
 func TestSearch_SurfacesScoreAndMatchType(t *testing.T) {
 	store := newTestArchiveStore(t)
-	if !store.ftsEnabled {
-		t.Skip("BM25 score and phrase/terms match_type require FTS5 (build with -tags sqlite_fts5)")
-	}
 	base := time.Date(2026, 2, 12, 10, 0, 0, 0, time.UTC)
 	if err := store.ArchiveMessages([]Message{
 		{ID: "m1", ConversationID: "conv-1", SessionID: "sess-1", Role: "user",
@@ -2124,9 +2121,6 @@ func TestSearch_SurfacesScoreAndMatchType(t *testing.T) {
 // the result limit.
 func TestSearch_CountMatchesEstimatesTotal(t *testing.T) {
 	store := newTestArchiveStore(t)
-	if !store.ftsEnabled {
-		t.Skip("total_estimated (OR-of-terms recall count) requires FTS5 (build with -tags sqlite_fts5)")
-	}
 	base := time.Date(2026, 2, 12, 10, 0, 0, 0, time.UTC)
 	var msgs []Message
 	for i := 0; i < 7; i++ {
@@ -2213,9 +2207,6 @@ func TestSearch_AnticipationsFilteredByDefault(t *testing.T) {
 // substring pass and has no equivalent.
 func TestSearch_OrBackfillFillsThinPhrase(t *testing.T) {
 	store := newTestArchiveStore(t)
-	if !store.FTSEnabled() {
-		t.Skip("FTS5 not available; OR-backfill path requires FTS5")
-	}
 
 	base := time.Date(2026, 2, 12, 10, 0, 0, 0, time.UTC)
 	msgs := []Message{

--- a/internal/state/memory/distilled_fts_test.go
+++ b/internal/state/memory/distilled_fts_test.go
@@ -13,9 +13,6 @@ import (
 // columns. BM25 ranking orders the most relevant hit first.
 func TestSearchSessions_FindsByTitleSummaryTags(t *testing.T) {
 	store := newTestArchiveStore(t)
-	if !store.FTSEnabled() {
-		t.Skip("FTS5 not available")
-	}
 
 	// Create three ended sessions with distinct distilled content.
 	mk := func(convID, title, summary, tags string) string {
@@ -93,10 +90,6 @@ func TestSearchSessions_BackfillOnFirstInit(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !store1.FTSEnabled() {
-		store1.Close()
-		t.Skip("FTS5 not available")
-	}
 
 	// Drop the FTS table and triggers to simulate a pre-existing db
 	// that has sessions but no FTS infrastructure yet.
@@ -155,9 +148,6 @@ func TestSearchSessions_BackfillOnFirstInit(t *testing.T) {
 // shouldn't crash or run an unbounded scan. Returns empty slice.
 func TestSearchSessions_EmptyQueryReturnsNothing(t *testing.T) {
 	store := newTestArchiveStore(t)
-	if !store.FTSEnabled() {
-		t.Skip("FTS5 not available")
-	}
 
 	got, err := store.SearchSessions("", 5)
 	if err != nil {
@@ -173,10 +163,7 @@ func TestSearchSessions_EmptyQueryReturnsNothing(t *testing.T) {
 // Set path becomes searchable through the FTS index, and a
 // phrase-shaped query returns it in BM25 order.
 func TestWorkingMemorySearch_FindsByContent(t *testing.T) {
-	store, archive := newTestWorkingMemoryStoreWithFTS(t)
-	if !archive.FTSEnabled() || !store.FTSEnabled() {
-		t.Skip("FTS5 not available")
-	}
+	store, _ := newTestWorkingMemoryStoreWithFTS(t)
 
 	// Two conversations with distinct working-memory state.
 	if err := store.Set("conv-a",
@@ -211,10 +198,7 @@ func TestWorkingMemorySearch_FindsByContent(t *testing.T) {
 // search and find it, then update the row, search and find the
 // new content (not the old).
 func TestWorkingMemorySearch_UpdateReindexes(t *testing.T) {
-	store, archive := newTestWorkingMemoryStoreWithFTS(t)
-	if !archive.FTSEnabled() || !store.FTSEnabled() {
-		t.Skip("FTS5 not available")
-	}
+	store, _ := newTestWorkingMemoryStoreWithFTS(t)
 
 	if err := store.Set("conv-update", "talking about the dryer making a clicking noise on the spin cycle"); err != nil {
 		t.Fatal(err)
@@ -294,9 +278,6 @@ func TestMemorySearch_AllSurfacesReachModelEnvelope(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Cleanup(func() { archive.Close() })
-	if !archive.FTSEnabled() {
-		t.Skip("FTS5 not available")
-	}
 
 	working, err := NewWorkingMemoryStore(archive.DB(), archive.FTSEnabled())
 	if err != nil {
@@ -385,9 +366,6 @@ func TestMemorySearch_DistilledFailureDoesNotBlockMessages(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Cleanup(func() { archive.Close() })
-	if !archive.FTSEnabled() {
-		t.Skip("FTS5 not available")
-	}
 
 	// Seed a raw message so messages_fts has something to find.
 	if err := archive.ArchiveMessages([]Message{{

--- a/internal/state/memory/sqlite.go
+++ b/internal/state/memory/sqlite.go
@@ -7,9 +7,9 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	_ "github.com/mattn/go-sqlite3"
 	"github.com/nugget/thane-ai-agent/internal/model/llm"
 	"github.com/nugget/thane-ai-agent/internal/platform/database"
+	_ "modernc.org/sqlite"
 )
 
 // SQLiteStore is a SQLite-backed memory store.

--- a/internal/state/memory/working_provider_test.go
+++ b/internal/state/memory/working_provider_test.go
@@ -7,14 +7,14 @@ import (
 	"strings"
 	"testing"
 
-	_ "github.com/mattn/go-sqlite3"
 	"github.com/nugget/thane-ai-agent/internal/runtime/agentctx"
+	_ "modernc.org/sqlite"
 )
 
 func newTestWorkingMemoryProvider(t *testing.T, convID string) (*WorkingMemoryProvider, *WorkingMemoryStore) {
 	t.Helper()
 	dbPath := filepath.Join(t.TempDir(), "test.db")
-	db, err := sql.Open("sqlite3", dbPath)
+	db, err := sql.Open("sqlite-thane", dbPath)
 	if err != nil {
 		t.Fatalf("open db: %v", err)
 	}

--- a/internal/state/memory/working_test.go
+++ b/internal/state/memory/working_test.go
@@ -6,13 +6,13 @@ import (
 	"testing"
 	"time"
 
-	_ "github.com/mattn/go-sqlite3"
+	_ "modernc.org/sqlite"
 )
 
 func newTestWorkingMemoryStore(t *testing.T) *WorkingMemoryStore {
 	t.Helper()
 	dbPath := filepath.Join(t.TempDir(), "test.db")
-	db, err := sql.Open("sqlite3", dbPath)
+	db, err := sql.Open("sqlite-thane", dbPath)
 	if err != nil {
 		t.Fatalf("open db: %v", err)
 	}

--- a/internal/tools/content_resolve_test.go
+++ b/internal/tools/content_resolve_test.go
@@ -7,11 +7,11 @@ import (
 	"strings"
 	"testing"
 
-	_ "github.com/mattn/go-sqlite3"
 	"github.com/nugget/thane-ai-agent/internal/platform/database"
 	"github.com/nugget/thane-ai-agent/internal/platform/opstate"
 	"github.com/nugget/thane-ai-agent/internal/platform/paths"
 	"github.com/nugget/thane-ai-agent/internal/state/documents"
+	_ "modernc.org/sqlite"
 )
 
 func testContentResolver(t *testing.T) (*ContentResolver, *TempFileStore, string) {

--- a/internal/tools/lens_tools_test.go
+++ b/internal/tools/lens_tools_test.go
@@ -3,9 +3,9 @@ package tools
 import (
 	"testing"
 
-	_ "github.com/mattn/go-sqlite3"
 	"github.com/nugget/thane-ai-agent/internal/platform/database"
 	"github.com/nugget/thane-ai-agent/internal/platform/opstate"
+	_ "modernc.org/sqlite"
 )
 
 func newTestLensStore(t *testing.T) *LensStore {

--- a/internal/tools/log_tools_test.go
+++ b/internal/tools/log_tools_test.go
@@ -7,14 +7,14 @@ import (
 	"testing"
 	"time"
 
-	_ "github.com/mattn/go-sqlite3"
+	_ "modernc.org/sqlite"
 
 	"github.com/nugget/thane-ai-agent/internal/platform/logging"
 )
 
 func openLogTestDB(t *testing.T) *sql.DB {
 	t.Helper()
-	db, err := sql.Open("sqlite3", t.TempDir()+"/test.db?_journal_mode=WAL&_busy_timeout=5000")
+	db, err := sql.Open("sqlite-thane", "file:"+t.TempDir()+"/test.db?_pragma=journal_mode(WAL)&_pragma=busy_timeout(5000)")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/tools/notification_tools_test.go
+++ b/internal/tools/notification_tools_test.go
@@ -7,10 +7,10 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
-	_ "github.com/mattn/go-sqlite3"
 	"github.com/nugget/thane-ai-agent/internal/channels/notifications"
 	"github.com/nugget/thane-ai-agent/internal/platform/database"
 	"github.com/nugget/thane-ai-agent/internal/state/contacts"
+	_ "modernc.org/sqlite"
 )
 
 // mockNotifyHA implements notifications.HAClient for testing.

--- a/internal/tools/tempfiles_test.go
+++ b/internal/tools/tempfiles_test.go
@@ -6,9 +6,9 @@ import (
 	"path/filepath"
 	"testing"
 
-	_ "github.com/mattn/go-sqlite3"
 	"github.com/nugget/thane-ai-agent/internal/platform/database"
 	"github.com/nugget/thane-ai-agent/internal/platform/opstate"
+	_ "modernc.org/sqlite"
 )
 
 func testTempFileStore(t *testing.T) (*TempFileStore, *opstate.Store) {

--- a/internal/tools/usage_tools_test.go
+++ b/internal/tools/usage_tools_test.go
@@ -6,9 +6,9 @@ import (
 	"testing"
 	"time"
 
-	_ "github.com/mattn/go-sqlite3"
 	"github.com/nugget/thane-ai-agent/internal/platform/database"
 	"github.com/nugget/thane-ai-agent/internal/platform/usage"
+	_ "modernc.org/sqlite"
 )
 
 func testUsageStore(t *testing.T) *usage.Store {

--- a/justfile
+++ b/justfile
@@ -41,8 +41,7 @@ generate:
 [group('build')]
 build target_os=host_os target_arch=host_arch cc="": generate
     @mkdir -p dist
-    @if [ -n "{{cc}}" ]; then export CC="{{cc}}"; fi; \
-    CGO_ENABLED=1 GOOS={{target_os}} GOARCH={{target_arch}} go build -trimpath -tags "sqlite_fts5" -ldflags "{{ldflags}}" -o dist/thane-{{target_os}}-{{target_arch}} ./cmd/thane
+    CGO_ENABLED=0 GOOS={{target_os}} GOARCH={{target_arch}} go build -trimpath -ldflags "{{ldflags}}" -o dist/thane-{{target_os}}-{{target_arch}} ./cmd/thane
     @# Ad-hoc sign macOS binaries so Gatekeeper doesn't kill them on each rebuild
     @if [ "{{target_os}}" = "darwin" ] && [ "{{host_os}}" = "darwin" ]; then codesign -s - dist/thane-{{target_os}}-{{target_arch}} 2>/dev/null && echo "Signed dist/thane-{{target_os}}-{{target_arch}}"; fi
     @echo "Built dist/thane-{{target_os}}-{{target_arch}}"
@@ -55,8 +54,10 @@ build-all:
     just build-linux-docker amd64
     just build-linux-docker arm64
 
-# Build a Linux binary through Docker Buildx so CGO-backed SQLite builds
-# stay usable even on non-Linux hosts without local cross-compilers.
+# Build a Linux binary through Docker Buildx in a clean Linux toolchain.
+# Since the SQLite driver is now pure Go (modernc), `just build linux
+# <arch>` also cross-compiles natively (CGO_ENABLED=0); this recipe
+# remains for reproducible container-based release artifacts.
 [group('build')]
 build-linux-docker target_arch:
     #!/usr/bin/env bash

--- a/justfile
+++ b/justfile
@@ -39,48 +39,22 @@ generate:
 
 # Build a binary into dist/ (defaults to current platform, or specify OS/ARCH)
 [group('build')]
-build target_os=host_os target_arch=host_arch cc="": generate
+build target_os=host_os target_arch=host_arch: generate
     @mkdir -p dist
     CGO_ENABLED=0 GOOS={{target_os}} GOARCH={{target_arch}} go build -trimpath -ldflags "{{ldflags}}" -o dist/thane-{{target_os}}-{{target_arch}} ./cmd/thane
     @# Ad-hoc sign macOS binaries so Gatekeeper doesn't kill them on each rebuild
     @if [ "{{target_os}}" = "darwin" ] && [ "{{host_os}}" = "darwin" ]; then codesign -s - dist/thane-{{target_os}}-{{target_arch}} 2>/dev/null && echo "Signed dist/thane-{{target_os}}-{{target_arch}}"; fi
     @echo "Built dist/thane-{{target_os}}-{{target_arch}}"
 
-# Build for all release targets
+# Build for all release targets. The pure-Go SQLite driver (modernc)
+# makes every target a CGO-free cross-compile, so Linux builds run
+# natively here too — no Docker/Buildx round-trip required.
 [group('build')]
 build-all:
     just build darwin amd64
     just build darwin arm64
-    just build-linux-docker amd64
-    just build-linux-docker arm64
-
-# Build a Linux binary through Docker Buildx in a clean Linux toolchain.
-# Since the SQLite driver is now pure Go (modernc), `just build linux
-# <arch>` also cross-compiles natively (CGO_ENABLED=0); this recipe
-# remains for reproducible container-based release artifacts.
-[group('build')]
-build-linux-docker target_arch:
-    #!/usr/bin/env bash
-    set -euo pipefail
-    target_arch="{{target_arch}}"
-    export_dir="dist/docker-export/linux-${target_arch}"
-    binary="dist/thane-linux-${target_arch}"
-
-    rm -rf "$export_dir"
-    mkdir -p "$export_dir" dist
-
-    docker buildx build \
-        --platform "linux/${target_arch}" \
-        --target artifact \
-        --build-arg THANE_VERSION="{{version}}" \
-        --build-arg BUILD_COMMIT="{{git_commit}}" \
-        --build-arg BUILD_BRANCH="{{git_branch}}" \
-        --build-arg BUILD_TIME="{{build_time}}" \
-        --output "type=local,dest=${export_dir}" \
-        .
-
-    install -m 755 "$export_dir/thane" "$binary"
-    echo "Built $binary via Docker Buildx"
+    just build linux amd64
+    just build linux arm64
 
 # Build a local container image for the current checkout
 [group('build')]
@@ -338,34 +312,25 @@ deploy:
 
 # Build, optionally sign/notarize, and atomically copy a binary to a remote host
 [group('deploy')]
-deploy-scp host remote_bin="Thane/bin/thane" target_os=host_os target_arch=host_arch cc="" restart_cmd="":
+deploy-scp host remote_bin="Thane/bin/thane" target_os=host_os target_arch=host_arch restart_cmd="":
     #!/usr/bin/env bash
     set -euo pipefail
     host="{{host}}"
     remote_bin="{{remote_bin}}"
     target_os="{{target_os}}"
     target_arch="{{target_arch}}"
-    cc="{{cc}}"
     restart_cmd="{{restart_cmd}}"
     binary="dist/thane-${target_os}-${target_arch}"
     version="$(git describe --tags --always --dirty 2>/dev/null || echo dev)"
 
     test -n "$host" || { echo "host is required"; exit 1; }
 
-    if [ -n "$cc" ]; then
-        THANE_VERSION="$version" just build "$target_os" "$target_arch" "$cc"
-    else
-        THANE_VERSION="$version" just build "$target_os" "$target_arch"
-    fi
+    THANE_VERSION="$version" just build "$target_os" "$target_arch"
 
     if [ "$target_os" = "darwin" ] && [ "{{host_os}}" = "darwin" ]; then
         just release-sign-macos "$binary"
         if [ -n "${THANE_NOTARY_PROFILE:-}" ]; then
-            if [ -n "$cc" ]; then
-                archive="$(just release-build-archive "$version" "$target_os" "$target_arch" "$cc" | tail -n 1)"
-            else
-                archive="$(just release-build-archive "$version" "$target_os" "$target_arch" | tail -n 1)"
-            fi
+            archive="$(just release-build-archive "$version" "$target_os" "$target_arch" | tail -n 1)"
             test -n "$archive" || { echo "release-build-archive did not report an artifact path" >&2; exit 1; }
             echo "Notarized archive ready: $archive"
         fi
@@ -535,21 +500,16 @@ release-staple-macos archive:
 
 [doc("Building block: build one release artifact for a target")]
 [group('release-engineering')]
-release-build-archive version target_os=host_os target_arch=host_arch cc="":
+release-build-archive version target_os=host_os target_arch=host_arch:
     #!/usr/bin/env bash
     set -euo pipefail
     version="{{version}}"
     target_os="{{target_os}}"
     target_arch="{{target_arch}}"
-    cc="{{cc}}"
     binary="dist/thane-${target_os}-${target_arch}"
 
     version="${version#v}"
-    if [ -n "$cc" ]; then
-        THANE_VERSION="v${version}" just build "$target_os" "$target_arch" "$cc"
-    else
-        THANE_VERSION="v${version}" just build "$target_os" "$target_arch"
-    fi
+    THANE_VERSION="v${version}" just build "$target_os" "$target_arch"
 
     if [ "$target_os" = "darwin" ]; then
         test "{{host_os}}" = "darwin" || { echo "release-build-archive for darwin targets requires a macOS host"; exit 1; }
@@ -605,17 +565,13 @@ release-write-checksums version:
 
 [doc("Building block: build one local snapshot archive")]
 [group('release-engineering')]
-release-build-snapshot version target_os=host_os target_arch=host_arch cc="":
+release-build-snapshot version target_os=host_os target_arch=host_arch:
     #!/usr/bin/env bash
     set -euo pipefail
-    if [ -n "{{cc}}" ]; then
-        just release-build-archive "{{version}}" "{{target_os}}" "{{target_arch}}" "{{cc}}"
-    else
-        just release-build-archive "{{version}}" "{{target_os}}" "{{target_arch}}"
-    fi
+    just release-build-archive "{{version}}" "{{target_os}}" "{{target_arch}}"
     just release-write-checksums "{{version}}"
 
-[doc("Building block: build one Linux archive via Docker Buildx")]
+[doc("Building block: build one Linux archive (CGO-free native cross-compile)")]
 [group('release-engineering')]
 release-build-linux-archive version target_arch:
     #!/usr/bin/env bash
@@ -624,7 +580,7 @@ release-build-linux-archive version target_arch:
     target_arch="{{target_arch}}"
 
     version="${version#v}"
-    THANE_VERSION="v${version}" just build-linux-docker "$target_arch"
+    THANE_VERSION="v${version}" just build linux "$target_arch"
 
     archive="$(scripts/package-release.sh "$version" linux "$target_arch" "dist/thane-linux-${target_arch}" "{{release-dir}}")"
     printf '%s\n' "$archive"
@@ -972,19 +928,19 @@ macos-staple archive:
     just release-staple-macos "{{archive}}"
 
 [private]
-release-archive version target_os=host_os target_arch=host_arch cc="":
-    just release-build-archive "{{version}}" "{{target_os}}" "{{target_arch}}" "{{cc}}"
+release-archive version target_os=host_os target_arch=host_arch:
+    just release-build-archive "{{version}}" "{{target_os}}" "{{target_arch}}"
 
 [private]
 release-checksums version:
     just release-write-checksums "{{version}}"
 
 [private]
-release-snapshot version target_os=host_os target_arch=host_arch cc="":
-    just release-build-snapshot "{{version}}" "{{target_os}}" "{{target_arch}}" "{{cc}}"
+release-snapshot version target_os=host_os target_arch=host_arch:
+    just release-build-snapshot "{{version}}" "{{target_os}}" "{{target_arch}}"
 
 [private]
-release-archive-linux-docker version target_arch:
+release-archive-linux version target_arch:
     just release-build-linux-archive "{{version}}" "{{target_arch}}"
 
 [private]

--- a/scripts/architecture.baseline
+++ b/scripts/architecture.baseline
@@ -2,4 +2,4 @@ packages=62
 interfaces=80
 large_files=48
 set_mutators=111
-database_opens=8
+database_opens=9


### PR DESCRIPTION
## Summary

Started from a simple question — "why does the repo import *both* `github.com/mattn/go-sqlite3` and `modernc.org/sqlite`?" — and the answer turned out to be: the second driver was test-only dead weight, **and** the way it was used was hiding a class of production FTS5 bugs. This PR migrates the whole codebase to the pure-Go `modernc.org/sqlite` driver and fixes the bugs that flipping FTS5 always-on exposed.

### Why migrate to modernc (pure-Go)
- **One driver, not two.** `modernc` was previously imported by only 7 test files; production used CGO `mattn`. Two SQLite stacks, two Dependabot streams, and tests running against a *different* engine than prod.
- **CGO-free builds.** Native cross-compilation (no Docker Buildx dance), static binaries, and a **distroless container that drops from ~135 MB → ~27 MB** with no shell/apt/wget/libc attack surface (still rootless).
- **FTS5 always on.** `modernc` bundles FTS5 with no build tag, so CI now exercises the FTS5 paths that previously skipped (`just test` built tagless `mattn` → FTS5 absent → ~10 FTS5 tests silently `t.Skip`'d, while prod shipped FTS5 on).

### Production bugs this surfaced and fixes (independent of the driver choice)
1. **`messages_fts` never populated in unified mode** — the production wiring (`NewArchiveStoreFromDB`) created the external-content FTS index with no triggers and no rebuild, and `ArchiveMessages` no-ops in unified mode, so `archive_search` over raw messages **returned nothing in prod**. Added trigger+rebuild sync (matching `sessions_fts`/`working_memory_fts`). `internal/tools` already had a "regression of the production bug" guard for exactly this — also dark until now.
2. **Knowledge BM25 search silently broken** — `factColumnsFTS` was documented as table-qualified but its value was the unqualified `factColumns`, so the FTS join raised `ambiguous column name: key` on every query and fell back to LIKE (which doesn't cover `source`). Qualified the columns + JOIN rowid.

### The timestamp hazard (the careful part)
`modernc` binds `time.Time` using Go's `time.Time.String()` layout, which `strftime` can't parse (collapses keyset-pagination sort keys to NULL) and which doesn't sort lexically against historical `mattn`-written rows. Fix: a thin wrapper driver registered as `database.DriverName` (`"sqlite-thane"`) that injects `_time_format=sqlite` into every DSN, forcing `modernc` to emit the **byte-identical** shape `mattn` did (`2006-01-02 15:04:05.999999999-07:00` == `SQLiteTimestampLayout`). Existing prod rows and new rows are indistinguishable on disk. A guard test fails the build if any code opens the bare driver name. A read-side parse layout for `modernc`'s default shape was added as a salvage net.

## ⚠️ Pre-cutover operational step (before deploying to prod Aimee)
Audit `thane.db` for any default-shape rows from in-flight testing (expect 0 — prod is mattn-only):
```sql
SELECT count(*) FROM conversations WHERE strftime('%Y-%m-%dT%H:%M:%fZ', updated_at) IS NULL;
-- repeat for messages.timestamp, conversations.created_at
```
Nonzero → one-time UPDATE rewrite via the added `time.Time.String()` parse layout.

## Test plan
- [x] `just ci` green (fmt, mod-tidy, config-gen, architecture, links, lint, openapi-lint, race tests)
- [x] Full suite green under modernc with FTS5 always-on (63 packages); the ~10 previously-skipped FTS5 tests now run
- [x] Timestamp round-trip verified byte-identical to mattn for UTC and fixed-zone instants (`TestFormatTimestamp_MatchesDriverBinding`)
- [x] `mattn/go-sqlite3` removed from go.mod/go.sum; modernc now direct
- [x] Distroless image builds, boots (`thane version`), and answers `thane health`
- [x] Read-only DSN (`mode=ro&immutable=1&nolock=1`, prewarm path) verified under modernc
- [ ] Pre-cutover prod row-format audit (operational, see above)

## Follow-ups (now folded into this PR)
- ✅ Removed the vestigial `cc` cross-compiler param and the `build-linux-docker` Buildx recipe — Linux now cross-compiles natively (CGO-free); dropped the orphaned `FROM scratch AS artifact` Dockerfile stage.
- ✅ Collapsed `archive.go`'s duplicate `parseTimestamp`/`timestampFormats` into `database.ParseTimestamp` (added the one missing layout so it is a strict superset).
- ✅ Addressed Copilot review (httpkit DrainAndClose, `database.DriverName` in prewarm, propagate messages_fts trigger-setup failure to the LIKE fallback).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Downstream impact / open-issue notes

- **`messages_fts` is now prod-load-bearing.** This PR turned a dormant (always-empty) index into the live backing for `archive_search` in unified mode. When [#939](https://github.com/nugget/thane-ai-agent/issues/939) (FTS5 over `interactions/` + `archive reindex`) lands a dedicated index that supersedes it, **migrate the path rather than dropping `messages_fts`** — and mirror its trigger+rebuild backfill as the reindex pattern.
- **New SQLite opens must go through `database.Open`/`DriverName`** (guard-test enforced) so the `_time_format=sqlite` timestamp invariant holds — relevant to any future index DB (#939) and time-windowed queries.
- Cross-referenced the facts_fts source-search fix on [#401](https://github.com/nugget/thane-ai-agent/issues/401) (foundation for #993/#105/#191) and the bridge-layer repairs on [#986](https://github.com/nugget/thane-ai-agent/issues/986). No open issue is resolved/closed by this PR.