### PR TITLE
refactor(loops): fold HTTP write + shared lookups onto the commit chokepoint

### DIFF
--- a/internal/app/loop_definition_commit_test.go
+++ b/internal/app/loop_definition_commit_test.go
@@ -65,6 +65,12 @@ func TestCommitLoopDefinitionPropagatesImmutableError(t *testing.T) {
 	if !errors.As(err, &immutable) {
 		t.Fatalf("error = %v, want it to unwrap to *ImmutableDefinitionError", err)
 	}
+	// The failure must be tagged as the register stage so transport layers
+	// can map it to a 409 without re-running the sequence.
+	var commit *looppkg.CommitError
+	if !errors.As(err, &commit) || commit.Stage != looppkg.CommitStageRegister {
+		t.Fatalf("error = %v, want a CommitError at the register stage", err)
+	}
 }
 
 func TestCommitLoopDefinitionRejectsInvalidSpec(t *testing.T) {

--- a/internal/app/loop_definition_runtime.go
+++ b/internal/app/loop_definition_runtime.go
@@ -685,15 +685,15 @@ func (a *App) reconcileLoopDefinition(ctx context.Context, name string) error {
 // inspect it (errors.As for ImmutableDefinitionError) keep working.
 func (a *App) commitLoopDefinition(ctx context.Context, spec looppkg.Spec, updatedAt time.Time) error {
 	if err := a.persistLoopDefinition(spec, updatedAt); err != nil {
-		return fmt.Errorf("persist loop definition: %w", err)
+		return &looppkg.CommitError{Stage: looppkg.CommitStagePersist, Err: err}
 	}
 	if a.loopDefinitionRegistry != nil {
 		if err := a.loopDefinitionRegistry.Upsert(spec, updatedAt); err != nil {
-			return err
+			return &looppkg.CommitError{Stage: looppkg.CommitStageRegister, Err: err}
 		}
 	}
 	if err := a.reconcileLoopDefinition(ctx, spec.Name); err != nil {
-		return fmt.Errorf("reconcile loop definition: %w", err)
+		return &looppkg.CommitError{Stage: looppkg.CommitStageReconcile, Err: err}
 	}
 	return nil
 }

--- a/internal/app/new_servers.go
+++ b/internal/app/new_servers.go
@@ -54,7 +54,7 @@ func (a *App) initServers(s *newState) error {
 	server.UseContactStore(a.contactStore)
 	server.UseLoopDefinitionRegistry(a.loopDefinitionRegistry)
 	server.ConfigureLoopDefinitionView(a.loopDefinitionView)
-	server.ConfigureLoopDefinitionPersistence(a.persistLoopDefinition, a.deletePersistedLoopDefinition)
+	server.ConfigureLoopDefinitionPersistence(a.commitLoopDefinition, a.deletePersistedLoopDefinition)
 	server.ConfigureLoopDefinitionLifecycle(
 		a.persistLoopDefinitionPolicy,
 		a.deletePersistedLoopDefinitionPolicy,

--- a/internal/runtime/loop/commit_error.go
+++ b/internal/runtime/loop/commit_error.go
@@ -1,0 +1,50 @@
+package loop
+
+import "fmt"
+
+// CommitStage identifies which step of a durable loop-definition commit
+// failed. Transport layers (the tool surface, the HTTP API) use it to map
+// a commit failure to the right response without re-implementing the
+// persist → register → reconcile sequence themselves.
+type CommitStage string
+
+const (
+	// CommitStagePersist is the durable-store write.
+	CommitStagePersist CommitStage = "persist"
+	// CommitStageRegister is the in-memory overlay upsert. Its failures
+	// are caller-facing (a bad spec, or an immutable-config conflict).
+	CommitStageRegister CommitStage = "register"
+	// CommitStageReconcile is the live-loop reconciliation.
+	CommitStageReconcile CommitStage = "reconcile"
+)
+
+// CommitError tags a loop-definition commit failure with the stage that
+// produced it. It unwraps to the underlying error, so typed checks such as
+// errors.As for *ImmutableDefinitionError keep working through it.
+type CommitError struct {
+	Stage CommitStage
+	Err   error
+}
+
+// Error reproduces the wording each stage used before the commit sequence
+// was centralized: the register (overlay upsert) error is returned bare
+// because its messages — ImmutableDefinitionError, spec validation — are
+// already self-describing and callers historically saw them unprefixed,
+// while persist and reconcile failures carry a stage prefix for context.
+func (e *CommitError) Error() string {
+	if e == nil {
+		return "<nil>"
+	}
+	if e.Stage == CommitStageRegister {
+		return e.Err.Error()
+	}
+	return fmt.Sprintf("%s loop definition: %s", e.Stage, e.Err)
+}
+
+// Unwrap exposes the underlying error for errors.Is / errors.As.
+func (e *CommitError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Err
+}

--- a/internal/runtime/loop/commit_error.go
+++ b/internal/runtime/loop/commit_error.go
@@ -35,6 +35,11 @@ func (e *CommitError) Error() string {
 	if e == nil {
 		return "<nil>"
 	}
+	// Guard a nil Err: Error() must never panic, since it runs on every
+	// logging/formatting path that touches a commit failure.
+	if e.Err == nil {
+		return fmt.Sprintf("%s loop definition: <nil>", e.Stage)
+	}
 	if e.Stage == CommitStageRegister {
 		return e.Err.Error()
 	}

--- a/internal/runtime/loop/commit_error_test.go
+++ b/internal/runtime/loop/commit_error_test.go
@@ -25,6 +25,17 @@ func TestCommitErrorErrorText(t *testing.T) {
 	}
 }
 
+func TestCommitErrorErrorTextNilErr(t *testing.T) {
+	// Error() must not panic on a nil Err at any stage — it runs on every
+	// logging/formatting path that touches a commit failure.
+	for _, stage := range []CommitStage{CommitStagePersist, CommitStageRegister, CommitStageReconcile} {
+		ce := &CommitError{Stage: stage}
+		if got, want := ce.Error(), string(stage)+" loop definition: <nil>"; got != want {
+			t.Errorf("stage %q: Error() = %q, want %q", stage, got, want)
+		}
+	}
+}
+
 func TestCommitErrorUnwrapsTypedErrors(t *testing.T) {
 	immutable := &ImmutableDefinitionError{Name: "metacog_like"}
 	ce := &CommitError{Stage: CommitStageRegister, Err: immutable}

--- a/internal/runtime/loop/commit_error_test.go
+++ b/internal/runtime/loop/commit_error_test.go
@@ -1,0 +1,39 @@
+package loop
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestCommitErrorErrorText(t *testing.T) {
+	base := errors.New("boom")
+	cases := []struct {
+		stage CommitStage
+		want  string
+	}{
+		{CommitStagePersist, "persist loop definition: boom"},
+		{CommitStageReconcile, "reconcile loop definition: boom"},
+		// The register stage returns the underlying error verbatim so its
+		// already-self-describing messages stay unprefixed.
+		{CommitStageRegister, "boom"},
+	}
+	for _, c := range cases {
+		ce := &CommitError{Stage: c.stage, Err: base}
+		if got := ce.Error(); got != c.want {
+			t.Errorf("stage %q: Error() = %q, want %q", c.stage, got, c.want)
+		}
+	}
+}
+
+func TestCommitErrorUnwrapsTypedErrors(t *testing.T) {
+	immutable := &ImmutableDefinitionError{Name: "metacog_like"}
+	ce := &CommitError{Stage: CommitStageRegister, Err: immutable}
+
+	var target *ImmutableDefinitionError
+	if !errors.As(ce, &target) {
+		t.Fatal("errors.As did not unwrap CommitError to *ImmutableDefinitionError")
+	}
+	if target.Name != "metacog_like" {
+		t.Errorf("unwrapped name = %q, want metacog_like", target.Name)
+	}
+}

--- a/internal/runtime/loop/find.go
+++ b/internal/runtime/loop/find.go
@@ -1,0 +1,30 @@
+package loop
+
+// FindDefinition returns the snapshot entry whose name matches, if present.
+// A snapshot holds a small, bounded set of definitions, so a linear scan
+// is fine; this lives here so the tool and HTTP surfaces share one lookup
+// instead of each re-rolling it.
+func FindDefinition(snapshot *DefinitionRegistrySnapshot, name string) (DefinitionSnapshot, bool) {
+	if snapshot == nil {
+		return DefinitionSnapshot{}, false
+	}
+	for _, def := range snapshot.Definitions {
+		if def.Name == name {
+			return def, true
+		}
+	}
+	return DefinitionSnapshot{}, false
+}
+
+// FindDefinitionView returns the view entry whose name matches, if present.
+func FindDefinitionView(view *DefinitionRegistryView, name string) (DefinitionView, bool) {
+	if view == nil {
+		return DefinitionView{}, false
+	}
+	for _, def := range view.Definitions {
+		if def.Name == name {
+			return def, true
+		}
+	}
+	return DefinitionView{}, false
+}

--- a/internal/server/api/loop_definitions.go
+++ b/internal/server/api/loop_definitions.go
@@ -71,7 +71,7 @@ func (s *Server) handleLoopDefinitionGet(w http.ResponseWriter, r *http.Request)
 		return
 	}
 	view := s.currentLoopDefinitionView()
-	def, found := findAPILoopDefinitionView(view, name)
+	def, found := looppkg.FindDefinitionView(view, name)
 	if !found {
 		s.errorResponse(w, http.StatusNotFound, (&looppkg.UnknownDefinitionError{Name: name}).Error())
 		return
@@ -96,7 +96,7 @@ func (s *Server) handleLoopDefinitionSet(w http.ResponseWriter, r *http.Request)
 		return
 	}
 	snapshot := s.loopDefinitionRegistry.Snapshot()
-	if existing, found := findAPILoopDefinition(snapshot, req.Spec.Name); found && existing.Source == looppkg.DefinitionSourceConfig {
+	if existing, found := looppkg.FindDefinition(snapshot, req.Spec.Name); found && existing.Source == looppkg.DefinitionSourceConfig {
 		s.errorResponse(w, http.StatusConflict, (&looppkg.ImmutableDefinitionError{Name: req.Spec.Name}).Error())
 		return
 	}
@@ -114,7 +114,7 @@ func (s *Server) handleLoopDefinitionSet(w http.ResponseWriter, r *http.Request)
 		return
 	}
 	view := s.currentLoopDefinitionView()
-	def, found := findAPILoopDefinitionView(view, req.Spec.Name)
+	def, found := looppkg.FindDefinitionView(view, req.Spec.Name)
 	if !found {
 		s.errorResponse(w, http.StatusInternalServerError, "loop definition stored but snapshot is unavailable")
 		return
@@ -159,7 +159,7 @@ func (s *Server) handleLoopDefinitionDelete(w http.ResponseWriter, r *http.Reque
 		return
 	}
 	snapshot := s.loopDefinitionRegistry.Snapshot()
-	if existing, found := findAPILoopDefinition(snapshot, name); found && existing.Source == looppkg.DefinitionSourceConfig {
+	if existing, found := looppkg.FindDefinition(snapshot, name); found && existing.Source == looppkg.DefinitionSourceConfig {
 		s.errorResponse(w, http.StatusConflict, (&looppkg.ImmutableDefinitionError{Name: name}).Error())
 		return
 	} else if !found {
@@ -217,7 +217,7 @@ func (s *Server) handleLoopDefinitionPolicySet(w http.ResponseWriter, r *http.Re
 		s.errorResponse(w, http.StatusBadRequest, "name is required")
 		return
 	}
-	if _, found := findAPILoopDefinition(s.loopDefinitionRegistry.Snapshot(), req.Name); !found {
+	if _, found := looppkg.FindDefinition(s.loopDefinitionRegistry.Snapshot(), req.Name); !found {
 		s.errorResponse(w, http.StatusNotFound, (&looppkg.UnknownDefinitionError{Name: req.Name}).Error())
 		return
 	}
@@ -256,7 +256,7 @@ func (s *Server) handleLoopDefinitionPolicySet(w http.ResponseWriter, r *http.Re
 		}
 	}
 	view := s.currentLoopDefinitionView()
-	def, found := findAPILoopDefinitionView(view, req.Name)
+	def, found := looppkg.FindDefinitionView(view, req.Name)
 	if !found {
 		s.errorResponse(w, http.StatusInternalServerError, "loop definition policy applied but snapshot is unavailable")
 		return
@@ -279,7 +279,7 @@ func (s *Server) handleLoopDefinitionPolicyDelete(w http.ResponseWriter, r *http
 		s.errorResponse(w, http.StatusBadRequest, "name is required")
 		return
 	}
-	if _, found := findAPILoopDefinition(s.loopDefinitionRegistry.Snapshot(), name); !found {
+	if _, found := looppkg.FindDefinition(s.loopDefinitionRegistry.Snapshot(), name); !found {
 		s.errorResponse(w, http.StatusNotFound, (&looppkg.UnknownDefinitionError{Name: name}).Error())
 		return
 	}
@@ -307,7 +307,7 @@ func (s *Server) handleLoopDefinitionPolicyDelete(w http.ResponseWriter, r *http
 		}
 	}
 	view := s.currentLoopDefinitionView()
-	def, found := findAPILoopDefinitionView(view, name)
+	def, found := looppkg.FindDefinitionView(view, name)
 	if !found {
 		s.errorResponse(w, http.StatusInternalServerError, "loop definition policy cleared but snapshot is unavailable")
 		return
@@ -358,7 +358,7 @@ func (s *Server) handleLoopDefinitionLaunch(w http.ResponseWriter, r *http.Reque
 		return
 	}
 	view := s.currentLoopDefinitionView()
-	def, found := findAPILoopDefinitionView(view, name)
+	def, found := looppkg.FindDefinitionView(view, name)
 	if !found {
 		s.errorResponse(w, http.StatusInternalServerError, "loop definition launched but snapshot is unavailable")
 		return
@@ -370,28 +370,4 @@ func (s *Server) handleLoopDefinitionLaunch(w http.ResponseWriter, r *http.Reque
 		Definition: def,
 		Result:     result,
 	}, s.logger)
-}
-
-func findAPILoopDefinition(snapshot *looppkg.DefinitionRegistrySnapshot, name string) (looppkg.DefinitionSnapshot, bool) {
-	if snapshot == nil {
-		return looppkg.DefinitionSnapshot{}, false
-	}
-	for _, def := range snapshot.Definitions {
-		if def.Name == name {
-			return def, true
-		}
-	}
-	return looppkg.DefinitionSnapshot{}, false
-}
-
-func findAPILoopDefinitionView(view *looppkg.DefinitionRegistryView, name string) (looppkg.DefinitionView, bool) {
-	if view == nil {
-		return looppkg.DefinitionView{}, false
-	}
-	for _, def := range view.Definitions {
-		if def.Name == name {
-			return def, true
-		}
-	}
-	return looppkg.DefinitionView{}, false
 }

--- a/internal/server/api/loop_definitions.go
+++ b/internal/server/api/loop_definitions.go
@@ -101,30 +101,17 @@ func (s *Server) handleLoopDefinitionSet(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	updatedAt := time.Now().UTC()
-	if s.persistLoopDefinition != nil {
-		if err := s.persistLoopDefinition(req.Spec, updatedAt); err != nil {
-			s.logger.Error("persist loop definition failed", "name", req.Spec.Name, "error", err)
-			s.errorResponse(w, http.StatusInternalServerError, "failed to persist loop definition")
+	// Single durable commit (persist + upsert + reconcile) through the
+	// shared chokepoint, with a bare overlay upsert fallback for a
+	// registry-only server — mirroring the loop-authoring tool surfaces.
+	if s.commitLoopDefinition != nil {
+		if err := s.commitLoopDefinition(r.Context(), req.Spec, time.Now().UTC()); err != nil {
+			s.respondLoopCommitError(w, req.Spec.Name, err)
 			return
 		}
-	}
-	if err := s.loopDefinitionRegistry.Upsert(req.Spec, updatedAt); err != nil {
-		var immutable *looppkg.ImmutableDefinitionError
-		switch {
-		case errors.As(err, &immutable):
-			s.errorResponse(w, http.StatusConflict, err.Error())
-		default:
-			s.errorResponse(w, http.StatusBadRequest, err.Error())
-		}
+	} else if err := s.loopDefinitionRegistry.Upsert(req.Spec, time.Now().UTC()); err != nil {
+		s.respondLoopCommitError(w, req.Spec.Name, &looppkg.CommitError{Stage: looppkg.CommitStageRegister, Err: err})
 		return
-	}
-	if s.reconcileLoopDefinition != nil {
-		if err := s.reconcileLoopDefinition(r.Context(), req.Spec.Name); err != nil {
-			s.logger.Error("reconcile loop definition failed", "name", req.Spec.Name, "error", err)
-			s.errorResponse(w, http.StatusInternalServerError, "failed to reconcile loop definition")
-			return
-		}
 	}
 	view := s.currentLoopDefinitionView()
 	def, found := findAPILoopDefinitionView(view, req.Spec.Name)
@@ -138,6 +125,27 @@ func (s *Server) handleLoopDefinitionSet(w http.ResponseWriter, r *http.Request)
 		Generation: view.Generation,
 		Definition: def,
 	}, s.logger)
+}
+
+// respondLoopCommitError maps a commitLoopDefinition failure to the same
+// status codes the previous per-stage inline sequence returned: an
+// immutable-config conflict → 409, any other register/validation failure
+// → 400, and persist/reconcile (infrastructure) failures → 500. The stage
+// tag on looppkg.CommitError lets the transport classify without
+// re-implementing the commit sequence.
+func (s *Server) respondLoopCommitError(w http.ResponseWriter, name string, err error) {
+	var immutable *looppkg.ImmutableDefinitionError
+	if errors.As(err, &immutable) {
+		s.errorResponse(w, http.StatusConflict, err.Error())
+		return
+	}
+	var commit *looppkg.CommitError
+	if errors.As(err, &commit) && commit.Stage == looppkg.CommitStageRegister {
+		s.errorResponse(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	s.logger.Error("commit loop definition failed", "name", name, "error", err)
+	s.errorResponse(w, http.StatusInternalServerError, "failed to commit loop definition")
 }
 
 func (s *Server) handleLoopDefinitionDelete(w http.ResponseWriter, r *http.Request) {

--- a/internal/server/api/server.go
+++ b/internal/server/api/server.go
@@ -172,6 +172,13 @@ func (s *Server) ConfigureLoopDefinitionView(fn func() *looppkg.DefinitionRegist
 // runs the full persist → overlay upsert → reconcile sequence (the same
 // chokepoint the loop-authoring tools use) so the HTTP write path cannot
 // drift from them.
+//
+// Contract: commit must tag its failures with *looppkg.CommitError (stage
+// persist/register/reconcile) — that is what handleLoopDefinitionSet's
+// respondLoopCommitError uses to map a register failure to 400 and a
+// persist/reconcile failure to 500. A commit that returns a raw error
+// instead silently collapses every failure to 500. App.commitLoopDefinition
+// satisfies this; alternative wiring (tests, custom setups) must too.
 func (s *Server) ConfigureLoopDefinitionPersistence(
 	commit func(context.Context, looppkg.Spec, time.Time) error,
 	remove func(string) error,

--- a/internal/server/api/server.go
+++ b/internal/server/api/server.go
@@ -97,7 +97,7 @@ type Server struct {
 	deleteModelRegistryPolicy          func(string) error
 	persistModelRegistryResourcePolicy func(string, fleet.ResourcePolicy) error
 	deleteModelRegistryResourcePolicy  func(string) error
-	persistLoopDefinition              func(looppkg.Spec, time.Time) error
+	commitLoopDefinition               func(context.Context, looppkg.Spec, time.Time) error
 	deleteLoopDefinition               func(string) error
 	persistLoopDefinitionPolicy        func(string, looppkg.DefinitionPolicy) error
 	deleteLoopDefinitionPolicy         func(string) error
@@ -167,13 +167,16 @@ func (s *Server) ConfigureLoopDefinitionView(fn func() *looppkg.DefinitionRegist
 	s.loopDefinitionView = fn
 }
 
-// ConfigureLoopDefinitionPersistence configures persistence callbacks for
-// dynamic loop-definition overlay mutations.
+// ConfigureLoopDefinitionPersistence configures the durable-commit and
+// delete callbacks for dynamic loop-definition overlay mutations. commit
+// runs the full persist → overlay upsert → reconcile sequence (the same
+// chokepoint the loop-authoring tools use) so the HTTP write path cannot
+// drift from them.
 func (s *Server) ConfigureLoopDefinitionPersistence(
-	save func(looppkg.Spec, time.Time) error,
+	commit func(context.Context, looppkg.Spec, time.Time) error,
 	remove func(string) error,
 ) {
-	s.persistLoopDefinition = save
+	s.commitLoopDefinition = commit
 	s.deleteLoopDefinition = remove
 }
 

--- a/internal/server/api/server_test.go
+++ b/internal/server/api/server_test.go
@@ -1252,9 +1252,13 @@ func TestHandleLoopDefinitionSetAndDelete(t *testing.T) {
 		return looppkg.BuildDefinitionRegistryView(registry.Snapshot(), nil)
 	})
 	server.ConfigureLoopDefinitionPersistence(
-		func(spec looppkg.Spec, updatedAt time.Time) error {
+		func(_ context.Context, spec looppkg.Spec, updatedAt time.Time) error {
 			savedSpec = spec
 			savedAt = updatedAt
+			if err := registry.Upsert(spec, updatedAt); err != nil {
+				return err
+			}
+			reconciled = append(reconciled, spec.Name)
 			return nil
 		},
 		func(name string) error {
@@ -1321,6 +1325,43 @@ func TestHandleLoopDefinitionSet_ConfigDefinitionConflict(t *testing.T) {
 
 	if rec.Code != http.StatusConflict {
 		t.Fatalf("status = %d, want 409", rec.Code)
+	}
+}
+
+func TestHandleLoopDefinitionSet_CommitErrorStatusMapping(t *testing.T) {
+	// The HTTP set path folds onto commitLoopDefinition; respondLoopCommitError
+	// must preserve the per-stage status codes the old inline sequence
+	// returned: immutable conflict -> 409, register validation -> 400,
+	// persist/reconcile infra -> 500.
+	cases := []struct {
+		name      string
+		commitErr error
+		want      int
+	}{
+		{"register immutable -> 409", &looppkg.CommitError{Stage: looppkg.CommitStageRegister, Err: &looppkg.ImmutableDefinitionError{Name: "dyn_loop"}}, http.StatusConflict},
+		{"register validation -> 400", &looppkg.CommitError{Stage: looppkg.CommitStageRegister, Err: errors.New("outputs[0]: invalid ref")}, http.StatusBadRequest},
+		{"persist failure -> 500", &looppkg.CommitError{Stage: looppkg.CommitStagePersist, Err: errors.New("disk full")}, http.StatusInternalServerError},
+		{"reconcile failure -> 500", &looppkg.CommitError{Stage: looppkg.CommitStageReconcile, Err: errors.New("boom")}, http.StatusInternalServerError},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			registry := testAPILoopDefinitionRegistry(t)
+			server := NewServer("", 0, nil, nil, nil, nil, nil, nil, nil, nil, nil, testAPILogger())
+			server.UseLoopDefinitionRegistry(registry)
+			server.ConfigureLoopDefinitionPersistence(
+				func(_ context.Context, _ looppkg.Spec, _ time.Time) error { return tc.commitErr },
+				func(string) error { return nil },
+			)
+
+			body := bytes.NewBufferString(`{"spec":{"name":"dyn_loop","task":"t","operation":"service"}}`)
+			req := httptest.NewRequest(http.MethodPost, "/v1/loop-definitions", body)
+			rec := httptest.NewRecorder()
+			server.handleLoopDefinitionSet(rec, req)
+
+			if rec.Code != tc.want {
+				t.Fatalf("status = %d, want %d", rec.Code, tc.want)
+			}
+		})
 	}
 }
 

--- a/internal/tools/loop_definition_mutation_tools.go
+++ b/internal/tools/loop_definition_mutation_tools.go
@@ -21,7 +21,7 @@ func (r *Registry) handleLoopDefinitionSet(ctx context.Context, args map[string]
 	if err != nil {
 		return "", err
 	}
-	if existing, ok := findLoopDefinition(snapshot, spec.Name); ok && existing.Source == looppkg.DefinitionSourceConfig {
+	if existing, ok := looppkg.FindDefinition(snapshot, spec.Name); ok && existing.Source == looppkg.DefinitionSourceConfig {
 		return "", (&looppkg.ImmutableDefinitionError{Name: spec.Name})
 	}
 	updatedAt := time.Now().UTC()
@@ -39,7 +39,7 @@ func (r *Registry) handleLoopDefinitionSet(ctx context.Context, args map[string]
 	if err != nil {
 		return "", err
 	}
-	def, ok := findLoopDefinitionView(view, spec.Name)
+	def, ok := looppkg.FindDefinitionView(view, spec.Name)
 	if !ok {
 		return "", fmt.Errorf("loop definition stored but snapshot is unavailable")
 	}
@@ -62,7 +62,7 @@ func (r *Registry) handleLoopDefinitionDelete(ctx context.Context, args map[stri
 	if err != nil {
 		return "", err
 	}
-	existing, ok := findLoopDefinition(snapshot, name)
+	existing, ok := looppkg.FindDefinition(snapshot, name)
 	if ok && existing.Source == looppkg.DefinitionSourceConfig {
 		return "", (&looppkg.ImmutableDefinitionError{Name: name})
 	} else if !ok {
@@ -148,7 +148,7 @@ func (r *Registry) handleLoopDefinitionSetPolicy(ctx context.Context, args map[s
 	if name == "" {
 		return "", fmt.Errorf("name is required")
 	}
-	if _, found := findLoopDefinition(snapshot, name); !found {
+	if _, found := looppkg.FindDefinition(snapshot, name); !found {
 		return "", (&looppkg.UnknownDefinitionError{Name: name})
 	}
 	clearOverride, _ := args["clear_override"].(bool)
@@ -198,7 +198,7 @@ func (r *Registry) handleLoopDefinitionSetPolicy(ctx context.Context, args map[s
 	if err != nil {
 		return "", err
 	}
-	def, found := findLoopDefinitionView(view, name)
+	def, found := looppkg.FindDefinitionView(view, name)
 	if !found {
 		return "", fmt.Errorf("definition policy updated but snapshot is unavailable")
 	}
@@ -225,7 +225,7 @@ func (r *Registry) handleLoopDefinitionLaunch(ctx context.Context, args map[stri
 	if err != nil {
 		return "", err
 	}
-	def, found := findLoopDefinitionView(view, name)
+	def, found := looppkg.FindDefinitionView(view, name)
 	if !found {
 		return "", (&looppkg.UnknownDefinitionError{Name: name})
 	}
@@ -238,7 +238,7 @@ func (r *Registry) handleLoopDefinitionLaunch(ctx context.Context, args map[stri
 	if err != nil {
 		return "", err
 	}
-	def, found = findLoopDefinitionView(view, name)
+	def, found = looppkg.FindDefinitionView(view, name)
 	if !found {
 		return "", fmt.Errorf("definition launched but snapshot is unavailable")
 	}

--- a/internal/tools/loop_definition_read_tools.go
+++ b/internal/tools/loop_definition_read_tools.go
@@ -152,7 +152,7 @@ func (r *Registry) handleLoopDefinitionGet(_ context.Context, args map[string]an
 	if name == "" {
 		return "", fmt.Errorf("name is required")
 	}
-	def, ok := findLoopDefinitionView(view, name)
+	def, ok := looppkg.FindDefinitionView(view, name)
 	if !ok {
 		return "", (&looppkg.UnknownDefinitionError{Name: name})
 	}
@@ -173,7 +173,7 @@ func (r *Registry) handleLoopDefinitionLint(_ context.Context, args map[string]a
 		errText string
 	)
 	if snapshot, snapErr := currentLoopDefinitionSnapshot(r); snapErr == nil {
-		if existing, ok := findLoopDefinition(snapshot, spec.Name); ok && existing.Source == looppkg.DefinitionSourceConfig {
+		if existing, ok := looppkg.FindDefinition(snapshot, spec.Name); ok && existing.Source == looppkg.DefinitionSourceConfig {
 			valid = false
 			errText = (&looppkg.ImmutableDefinitionError{Name: spec.Name}).Error()
 		}

--- a/internal/tools/loop_definition_tool_helpers.go
+++ b/internal/tools/loop_definition_tool_helpers.go
@@ -275,18 +275,6 @@ func loopLaunchOverrideProperties() map[string]any {
 	}
 }
 
-func findLoopDefinition(snapshot *looppkg.DefinitionRegistrySnapshot, name string) (looppkg.DefinitionSnapshot, bool) {
-	if snapshot == nil {
-		return looppkg.DefinitionSnapshot{}, false
-	}
-	for _, def := range snapshot.Definitions {
-		if def.Name == name {
-			return def, true
-		}
-	}
-	return looppkg.DefinitionSnapshot{}, false
-}
-
 func currentLoopDefinitionSnapshot(r *Registry) (*looppkg.DefinitionRegistrySnapshot, error) {
 	if r.loopDefinitionRegistry == nil {
 		return nil, fmt.Errorf("loop definition registry not configured")
@@ -296,18 +284,6 @@ func currentLoopDefinitionSnapshot(r *Registry) (*looppkg.DefinitionRegistrySnap
 		return nil, fmt.Errorf("loop definition registry snapshot unavailable")
 	}
 	return snapshot, nil
-}
-
-func findLoopDefinitionView(view *looppkg.DefinitionRegistryView, name string) (looppkg.DefinitionView, bool) {
-	if view == nil {
-		return looppkg.DefinitionView{}, false
-	}
-	for _, def := range view.Definitions {
-		if def.Name == name {
-			return def, true
-		}
-	}
-	return looppkg.DefinitionView{}, false
 }
 
 func currentLoopDefinitionView(r *Registry) (*looppkg.DefinitionRegistryView, error) {

--- a/internal/tools/loop_intent_tools.go
+++ b/internal/tools/loop_intent_tools.go
@@ -148,7 +148,7 @@ func (r *Registry) handleThaneCreateContainer(ctx context.Context, args map[stri
 	// rather than abstracted because the surrounding handler shape is
 	// shallow and an extracted helper would obscure the refusal flow.
 	if snap := deps.Registry.Snapshot(); snap != nil {
-		if existing, ok := findLoopDefinition(snap, name); ok {
+		if existing, ok := looppkg.FindDefinition(snap, name); ok {
 			if existing.Source == looppkg.DefinitionSourceConfig {
 				return "", (&looppkg.ImmutableDefinitionError{Name: name})
 			}
@@ -388,7 +388,7 @@ func (r *Registry) handleThaneCurate(ctx context.Context, args map[string]any) (
 	// r.loopDefinitionRegistry (set by ConfigureLoopDefinitionTools)
 	// rather than the registry handle this tool was configured with.
 	if snap := deps.Registry.Snapshot(); snap != nil {
-		if existing, ok := findLoopDefinition(snap, name); ok {
+		if existing, ok := looppkg.FindDefinition(snap, name); ok {
 			if existing.Source == looppkg.DefinitionSourceConfig {
 				return "", (&looppkg.ImmutableDefinitionError{Name: name})
 			}
@@ -507,7 +507,7 @@ func (r *Registry) mutateLoopSubscriptions(ctx context.Context, loopName string,
 		return nil, fmt.Errorf("loop definition registry not configured")
 	}
 	snap := deps.Registry.Snapshot()
-	existing, ok := findLoopDefinition(snap, loopName)
+	existing, ok := looppkg.FindDefinition(snap, loopName)
 	if !ok {
 		return nil, (&looppkg.UnknownDefinitionError{Name: loopName})
 	}


### PR DESCRIPTION
## Summary

Completes #1075 — folds the last two duplicated surfaces onto the loop-definition commit chokepoint introduced in #1076.

## Changes

**1. HTTP write path → `commitLoopDefinition`** (`refactor(loops): fold HTTP loop-definition write onto the commit chokepoint`)

`POST /v1/loop-definitions` was the last handler still open-coding `persist → upsert → reconcile` with its own per-stage status mapping. It now routes through `App.commitLoopDefinition` like the tool surfaces.

To preserve the per-stage HTTP status codes through a single commit call, this adds **`looppkg.CommitError{Stage, Err}`**: `commitLoopDefinition` tags each failure with its stage (`persist`/`register`/`reconcile`) and the error unwraps to the underlying cause, so `respondLoopCommitError` maps:
- immutable-config conflict → **409**
- register/validation failure → **400**
- persist/reconcile (infra) → **500**

`CommitError.Error()` reproduces the prior wording (register bare; persist/reconcile prefixed), so **tool-facing error text is unchanged**. The server's `persistLoopDefinition` field is replaced by `commitLoopDefinition`; `ConfigureLoopDefinitionPersistence` now takes the commit func.

**2. Shared lookup helpers** (`refactor(loops): share loop-definition lookup helpers via looppkg`)

`findLoopDefinition*` (tools) and `findAPILoopDefinition*` (HTTP) were byte-equal scans over the same `looppkg` types. Hoisted to `looppkg.FindDefinition` / `looppkg.FindDefinitionView`; both copies deleted. Pure dedup.

## Behavior preservation

- HTTP status codes 409/400/500 preserved (the only generalization is the 500 *message* text → "failed to commit loop definition", which was already generic; status unchanged).
- Tool-facing commit error text unchanged.
- Net **−18 lines** from the dedup.

## Test plan

- [x] `looppkg.CommitError` — `Error()` text per stage + `errors.As` unwrap (incl. `ImmutableDefinitionError` through it).
- [x] `TestHandleLoopDefinitionSet_CommitErrorStatusMapping` — 409/400/500/500 preserved via `respondLoopCommitError`.
- [x] `TestCommitLoopDefinitionPropagatesImmutableError` now also asserts the register-stage tag.
- [x] Existing HTTP set/delete + tool tests pass through the routed path.
- [x] `just ci` green — format, lint, vacuum, architecture baseline unchanged, full suite.

Closes #1075
