### PR TITLE
feat(openapi): relative Try-it server + native /docs taxonomy & insights→telemetry rename

### DIFF
--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -31,7 +31,7 @@ views). The OpenAI-compatible shim runs on its own port (see below).
 
 | Method | Path | Purpose |
 | --- | --- | --- |
-| `GET` | `/v1/insights/router` | Router stats (with Anthropic rate-limit snapshot) plus the recent routing-audit trail (`?limit`, default 20). |
+| `GET` | `/v1/telemetry/router` | Router stats (with Anthropic rate-limit snapshot) plus the recent routing-audit trail (`?limit`, default 20). |
 | `GET` | `/v1/requests/{id}` | Detail for one model turn: prompt, messages, tool calls, token metadata. |
 | `GET` | `/v1/requests/{id}/routing` | Router decision trace for the request (replaces `/v1/router/explain`). |
 | `GET` | `/v1/requests/{id}/tools` | Tool calls made during the request (bare array). |
@@ -62,11 +62,11 @@ views). The OpenAI-compatible shim runs on its own port (see below).
 | `POST` | `/v1/loop-definitions/{name}/launch` | Launch a stored loop definition. |
 | `GET` | `/v1/conversations` | Filter/sort/keyset-paginate conversation summaries. Filters: `ids` (comma-sep, max 200), `kind` (comma-sep id-prefix families), `channel`/`contact`/`address` (channel binding), `updated_after`/`updated_before`/`created_after`/`created_before` (RFC3339 or a duration like `1h` meaning "ago"), `min_messages`/`max_messages`, `q` (metadata substring: id/contact name/address — *not* message content; use `/v1/archive/search` for that). `sort` = `updated_at` (default)\|`created_at`\|`message_count`; `order` = `desc` (default)\|`asc`; `limit` default 50, max 200; `cursor` from `next_cursor`. Returns `{conversations, count, total, next_cursor}`. `message_count` is the true active count (previously capped at the per-conversation working-memory limit). |
 | `GET` | `/v1/conversations/{id}` | Conversation detail (full transcript). |
-| `GET` | `/v1/insights/tools` | Tool-call stats plus recent tool calls (`?tool`, `?conversation_id`, `?limit` default 50). |
+| `GET` | `/v1/telemetry/tools` | Tool-call stats plus recent tool calls (`?tool`, `?conversation_id`, `?limit` default 50). |
 | `GET` | `/v1/sessions/stats` | Current session usage and context stats. |
-| `GET` | `/v1/insights/usage` | Token/cost usage summary over a time window (`?hours`, default 24; `?group_by` to break down by a dimension, e.g. model). |
-| `GET` | `/v1/insights/capabilities` | Resolved capability-tag catalog (`?include=excluded` to surface operator-disabled tools). |
-| `GET` | `/v1/insights/capabilities/{tag}` | One capability tag's resolved view (404 when absent). |
+| `GET` | `/v1/telemetry/usage` | Token/cost usage summary over a time window (`?hours`, default 24; `?group_by` to break down by a dimension, e.g. model). |
+| `GET` | `/v1/telemetry/capabilities` | Resolved capability-tag catalog (`?include=excluded` to surface operator-disabled tools). |
+| `GET` | `/v1/telemetry/capabilities/{tag}` | One capability tag's resolved view (404 when absent). |
 | `POST` | `/v1/sessions/balance` | Set reported balance for session cost tracking. |
 | `POST` | `/v1/sessions/reset` | Reset current session stats. |
 | `POST` | `/v1/sessions/compact` | Compact current session history. |

--- a/internal/server/api/server.go
+++ b/internal/server/api/server.go
@@ -445,12 +445,12 @@ func (s *Server) Start(ctx context.Context) error {
 	mux.HandleFunc("GET /v1/system", s.handleSystem)
 	mux.HandleFunc("GET /v1/system/logs", s.handleSystemLogs)
 
-	// Insights — consolidated router, tool, and usage analytics
-	mux.HandleFunc("GET /v1/insights/router", s.handleRouterInsights)
-	mux.HandleFunc("GET /v1/insights/tools", s.handleToolInsights)
-	mux.HandleFunc("GET /v1/insights/usage", s.handleUsageSummary)
-	mux.HandleFunc("GET /v1/insights/capabilities", s.handleCapabilities)
-	mux.HandleFunc("GET /v1/insights/capabilities/{tag}", s.handleCapability)
+	// Telemetry — consolidated router, tool, and usage analytics
+	mux.HandleFunc("GET /v1/telemetry/router", s.handleRouterTelemetry)
+	mux.HandleFunc("GET /v1/telemetry/tools", s.handleToolTelemetry)
+	mux.HandleFunc("GET /v1/telemetry/usage", s.handleUsageSummary)
+	mux.HandleFunc("GET /v1/telemetry/capabilities", s.handleCapabilities)
+	mux.HandleFunc("GET /v1/telemetry/capabilities/{tag}", s.handleCapability)
 
 	// Request introspection — detail, routing decision, and tool calls
 	mux.HandleFunc("GET /v1/requests/{id}", s.handleRequest)

--- a/internal/server/api/server_test.go
+++ b/internal/server/api/server_test.go
@@ -435,7 +435,7 @@ func TestHandleUsageSummary(t *testing.T) {
 
 	server := NewServer("", 0, nil, nil, nil, nil, store, nil, nil, nil, nil, testAPILogger())
 
-	req := httptest.NewRequest(http.MethodGet, "/v1/insights/usage?hours=48&group_by=resource", nil)
+	req := httptest.NewRequest(http.MethodGet, "/v1/telemetry/usage?hours=48&group_by=resource", nil)
 	rec := httptest.NewRecorder()
 	server.handleUsageSummary(rec, req)
 
@@ -471,7 +471,7 @@ func TestHandleUsageSummary(t *testing.T) {
 func TestHandleUsageSummary_InvalidGroupBy(t *testing.T) {
 	server := NewServer("", 0, nil, nil, nil, nil, testAPIUsageStore(t), nil, nil, nil, nil, testAPILogger())
 
-	req := httptest.NewRequest(http.MethodGet, "/v1/insights/usage?group_by=bogus", nil)
+	req := httptest.NewRequest(http.MethodGet, "/v1/telemetry/usage?group_by=bogus", nil)
 	rec := httptest.NewRecorder()
 	server.handleUsageSummary(rec, req)
 
@@ -483,7 +483,7 @@ func TestHandleUsageSummary_InvalidGroupBy(t *testing.T) {
 func TestHandleUsageSummary_InvalidHours(t *testing.T) {
 	server := NewServer("", 0, nil, nil, nil, nil, testAPIUsageStore(t), nil, nil, nil, nil, testAPILogger())
 
-	req := httptest.NewRequest(http.MethodGet, "/v1/insights/usage?hours=zero", nil)
+	req := httptest.NewRequest(http.MethodGet, "/v1/telemetry/usage?hours=zero", nil)
 	rec := httptest.NewRecorder()
 	server.handleUsageSummary(rec, req)
 
@@ -542,7 +542,7 @@ func TestHandleModelRegistry(t *testing.T) {
 	}
 }
 
-func TestHandleRouterInsightsIncludesAnthropicRateLimitSnapshot(t *testing.T) {
+func TestHandleRouterTelemetryIncludesAnthropicRateLimitSnapshot(t *testing.T) {
 	registry := testAPIModelRegistry(t)
 	rtr := router.NewRouter(testAPILogger(), registry.Catalog().RouterConfig(10))
 	server := NewServer("", 0, nil, rtr, nil, registry, nil, nil, nil, nil, nil, testAPILogger())
@@ -562,9 +562,9 @@ func TestHandleRouterInsightsIncludesAnthropicRateLimitSnapshot(t *testing.T) {
 		}
 	})
 
-	req := httptest.NewRequest(http.MethodGet, "/v1/insights/router", nil)
+	req := httptest.NewRequest(http.MethodGet, "/v1/telemetry/router", nil)
 	rec := httptest.NewRecorder()
-	server.handleRouterInsights(rec, req)
+	server.handleRouterTelemetry(rec, req)
 
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status = %d, want 200", rec.Code)
@@ -575,14 +575,14 @@ func TestHandleRouterInsightsIncludesAnthropicRateLimitSnapshot(t *testing.T) {
 		t.Fatalf("decode response: %v", err)
 	}
 	if _, ok := body["audit"]; !ok {
-		t.Fatal("audit missing from router insights response")
+		t.Fatal("audit missing from router telemetry response")
 	}
 	stats, ok := body["stats"].(map[string]any)
 	if !ok {
-		t.Fatal("stats missing from router insights response")
+		t.Fatal("stats missing from router telemetry response")
 	}
 	if _, ok := stats["total_requests"]; !ok {
-		t.Fatal("total_requests missing from router insights stats")
+		t.Fatal("total_requests missing from router telemetry stats")
 	}
 	limit, ok := stats["anthropic_rate_limit"].(map[string]any)
 	if !ok {

--- a/internal/server/api/system.go
+++ b/internal/server/api/system.go
@@ -11,7 +11,7 @@ import (
 // handleSystem returns a slim system-status rollup: overall status, dependency
 // health, uptime, and version. Heavier snapshots (model registry, router
 // stats, capabilities) have dedicated endpoints under /v1/models and
-// /v1/insights. [GET /v1/system]
+// /v1/telemetry. [GET /v1/system]
 func (s *Server) handleSystem(w http.ResponseWriter, r *http.Request) {
 	health := map[string]DependencyStatus{}
 	if s.healthDeps != nil {

--- a/internal/server/api/telemetry.go
+++ b/internal/server/api/telemetry.go
@@ -9,11 +9,11 @@ import (
 	"github.com/nugget/thane-ai-agent/internal/state/memory"
 )
 
-// handleRouterInsights returns router statistics and the recent routing-audit
+// handleRouterTelemetry returns router statistics and the recent routing-audit
 // trail in one object, consolidating the former /v1/router/stats and
 // /v1/router/audit. The audit honors ?limit (default 20).
-// [GET /v1/insights/router]
-func (s *Server) handleRouterInsights(w http.ResponseWriter, r *http.Request) {
+// [GET /v1/telemetry/router]
+func (s *Server) handleRouterTelemetry(w http.ResponseWriter, r *http.Request) {
 	if s.router == nil {
 		s.errorResponse(w, http.StatusServiceUnavailable, "router not configured")
 		return
@@ -36,11 +36,11 @@ func (s *Server) handleRouterInsights(w http.ResponseWriter, r *http.Request) {
 	}, s.logger)
 }
 
-// handleToolInsights returns tool-call statistics plus the recent tool calls
+// handleToolTelemetry returns tool-call statistics plus the recent tool calls
 // in one object, consolidating the former /v1/tools/stats and /v1/tools/calls.
 // Recent calls honor ?tool, ?conversation_id, and ?limit (default 50).
-// [GET /v1/insights/tools]
-func (s *Server) handleToolInsights(w http.ResponseWriter, r *http.Request) {
+// [GET /v1/telemetry/tools]
+func (s *Server) handleToolTelemetry(w http.ResponseWriter, r *http.Request) {
 	if s.memoryStore == nil {
 		s.errorResponse(w, http.StatusServiceUnavailable, "memory store not configured")
 		return
@@ -68,14 +68,14 @@ func (s *Server) handleToolInsights(w http.ResponseWriter, r *http.Request) {
 }
 
 // UseCapabilitySurface wires the capability-surface getter that backs the
-// /v1/insights/capabilities endpoints.
+// /v1/telemetry/capabilities endpoints.
 func (s *Server) UseCapabilitySurface(getter func() []toolcatalog.CapabilitySurface) {
 	s.capSurface = getter
 }
 
 // handleCapabilities returns the resolved capability-tag catalog. By default it
 // includes only active tools per tag; ?include=excluded also surfaces
-// operator-disabled tools. [GET /v1/insights/capabilities]
+// operator-disabled tools. [GET /v1/telemetry/capabilities]
 func (s *Server) handleCapabilities(w http.ResponseWriter, r *http.Request) {
 	if s.capSurface == nil {
 		s.errorResponse(w, http.StatusServiceUnavailable, "capability catalog unavailable")
@@ -92,7 +92,7 @@ func (s *Server) handleCapabilities(w http.ResponseWriter, r *http.Request) {
 
 // handleCapability returns the resolved view of one capability tag, 404ing when
 // the tag is absent from the current surface. Honors the same ?include=excluded
-// as the catalog. [GET /v1/insights/capabilities/{tag}]
+// as the catalog. [GET /v1/telemetry/capabilities/{tag}]
 func (s *Server) handleCapability(w http.ResponseWriter, r *http.Request) {
 	if s.capSurface == nil {
 		s.errorResponse(w, http.StatusServiceUnavailable, "capability catalog unavailable")

--- a/internal/server/api/telemetry_test.go
+++ b/internal/server/api/telemetry_test.go
@@ -8,26 +8,26 @@ import (
 	"github.com/nugget/thane-ai-agent/internal/model/toolcatalog"
 )
 
-func TestHandleInsights_Unconfigured(t *testing.T) {
+func TestHandleTelemetry_Unconfigured(t *testing.T) {
 	s := &Server{logger: testAPILogger()} // no router, no memory store
 
 	rr := httptest.NewRecorder()
-	s.handleRouterInsights(rr, httptest.NewRequest(http.MethodGet, "/v1/insights/router", nil))
+	s.handleRouterTelemetry(rr, httptest.NewRequest(http.MethodGet, "/v1/telemetry/router", nil))
 	if rr.Code != http.StatusServiceUnavailable {
-		t.Errorf("router insights: status = %d, want 503 when router unset", rr.Code)
+		t.Errorf("router telemetry: status = %d, want 503 when router unset", rr.Code)
 	}
 
 	rr2 := httptest.NewRecorder()
-	s.handleToolInsights(rr2, httptest.NewRequest(http.MethodGet, "/v1/insights/tools", nil))
+	s.handleToolTelemetry(rr2, httptest.NewRequest(http.MethodGet, "/v1/telemetry/tools", nil))
 	if rr2.Code != http.StatusServiceUnavailable {
-		t.Errorf("tool insights: status = %d, want 503 when memory store unset", rr2.Code)
+		t.Errorf("tool telemetry: status = %d, want 503 when memory store unset", rr2.Code)
 	}
 }
 
 func TestHandleCapabilities_Unconfigured(t *testing.T) {
 	s := &Server{logger: testAPILogger()} // capSurface nil
 	rr := httptest.NewRecorder()
-	s.handleCapabilities(rr, httptest.NewRequest(http.MethodGet, "/v1/insights/capabilities", nil))
+	s.handleCapabilities(rr, httptest.NewRequest(http.MethodGet, "/v1/telemetry/capabilities", nil))
 	if rr.Code != http.StatusServiceUnavailable {
 		t.Errorf("status = %d, want 503 when capability surface unset", rr.Code)
 	}
@@ -39,7 +39,7 @@ func TestHandleCapability_NotFoundAndMissingTag(t *testing.T) {
 		return []toolcatalog.CapabilitySurface{{Tag: "ha"}}
 	})
 
-	req := httptest.NewRequest(http.MethodGet, "/v1/insights/capabilities/nope", nil)
+	req := httptest.NewRequest(http.MethodGet, "/v1/telemetry/capabilities/nope", nil)
 	req.SetPathValue("tag", "nope")
 	rr := httptest.NewRecorder()
 	s.handleCapability(rr, req)
@@ -47,7 +47,7 @@ func TestHandleCapability_NotFoundAndMissingTag(t *testing.T) {
 		t.Errorf("unknown tag: status = %d, want 404", rr.Code)
 	}
 
-	req2 := httptest.NewRequest(http.MethodGet, "/v1/insights/capabilities/", nil)
+	req2 := httptest.NewRequest(http.MethodGet, "/v1/telemetry/capabilities/", nil)
 	req2.SetPathValue("tag", "")
 	rr2 := httptest.NewRecorder()
 	s.handleCapability(rr2, req2)

--- a/internal/server/openapi/explorer.go
+++ b/internal/server/openapi/explorer.go
@@ -40,6 +40,10 @@ const indexHTML = `<!doctype html>
         // Default the "Try it" code samples to curl — the operator's lingua
         // franca for a self-hosted API.
         defaultHttpClient: { targetKey: 'shell', clientKey: 'curl' },
+        // Label the auto-rendered components/schemas section "Schemas" so it no
+        // longer reads as a bare "Models" — that title collided with the
+        // "Model Routing" tag and the "Routing & Telemetry" group.
+        modelsSectionLabel: 'Schemas',
       })
     </script>
   </body>

--- a/internal/server/openapi/native.yaml
+++ b/internal/server/openapi/native.yaml
@@ -46,10 +46,14 @@ info:
     identifier: Apache-2.0
 
 servers:
-  - url: http://localhost:8080
-    description: Local development (native API + web UI)
-  # In production the native API is fronted by a reverse proxy on its own host,
-  # separate from the compatibility API; each deployment sets its public URL.
+  # Relative to the origin that serves /docs, so "Try it" targets the same host
+  # the explorer was loaded from: http://localhost:8080 in local dev and the
+  # public reverse-proxy host (e.g. https://pocket.hollowoak.net) in production —
+  # with no per-deployment edit. OpenAPI 3.1 permits a document-relative server
+  # URL, and Scalar resolves "/" against the page origin. The compatibility API
+  # lives on its own host/port, so compat.yaml keeps absolute servers.
+  - url: /
+    description: This Thane instance (same origin as the docs)
 
 security:
   - bearerAuth: []
@@ -69,10 +73,10 @@ tags:
     description: Conversation state snapshots for restart survival.
   - name: Scheduler
     description: Durable scheduled tasks and their execution history.
-  - name: Models & Fleet
-    description: Available models and the routing/registry policy.
-  - name: Insights
-    description: Read-only aggregate telemetry — routing, tools, usage, capabilities.
+  - name: Model Routing
+    description: Available models, plus the registry and routing/resource policies that decide which model runs where.
+  - name: Telemetry
+    description: Read-only aggregate measurements — routing, tool calls, usage, and capabilities.
   - name: Contacts
     description: Address book (also synced via CardDAV on a separate surface).
   - name: System
@@ -85,16 +89,20 @@ externalDocs:
   url: https://github.com/nugget/thane-ai-agent/tree/main/docs
 
 # Sidebar grouping for the Scalar explorer. Every tag above belongs to exactly
-# one group; the groups order the /docs navigation by domain.
+# one group; the groups order the /docs navigation by domain. New native
+# subsystems (e.g. a future Documents suite) add a tag under "Integrations &
+# Data"; "Runtime" stays the host/process surface and doesn't grow with them.
 x-tagGroups:
   - name: Execution
     tags: [Loops, Loop Definitions, Requests, Scheduler]
   - name: Memory & History
     tags: [Conversations & Sessions, Archive, Checkpoints]
-  - name: Models & Insights
-    tags: [Models & Fleet, Insights]
-  - name: Platform
-    tags: [Contacts, System, Realtime]
+  - name: Routing & Telemetry
+    tags: [Model Routing, Telemetry]
+  - name: Integrations & Data
+    tags: [Contacts]
+  - name: Runtime
+    tags: [System, Realtime]
 
 paths:
   # ----------------------------------------------------------------- System
@@ -780,10 +788,10 @@ paths:
               schema: { $ref: "#/components/schemas/CheckpointRestoreAck" }
         "404": { $ref: "#/components/responses/NotFound" }
 
-  # -------------------------------------------------------- Models & Fleet
+  # --------------------------------------------------------- Model Routing
   /v1/models:
     get:
-      tags: [Models & Fleet]
+      tags: [Model Routing]
       operationId: listModels
       summary: Available models (native fleet view)
       description: |
@@ -804,7 +812,7 @@ paths:
                   - { name: gpt-oss:120b, context_window: 131072, capabilities: [messaging], healthy: true, resource: spark }
   /v1/models/registry:
     get:
-      tags: [Models & Fleet]
+      tags: [Model Routing]
       operationId: getModelRegistry
       summary: Model-registry snapshot
       x-thane-scope: models:read
@@ -825,7 +833,7 @@ paths:
                     - { name: spark, host: "spark.hollowoak.net", available: true }
   /v1/models/registry/policy:
     put:
-      tags: [Models & Fleet]
+      tags: [Model Routing]
       operationId: setModelPolicy
       summary: Set a model routing policy
       x-thane-scope: models:admin
@@ -843,14 +851,14 @@ paths:
                 tags: [messaging, retrospection]
       responses: { "200": { description: Applied. } }
     delete:
-      tags: [Models & Fleet]
+      tags: [Model Routing]
       operationId: clearModelPolicy
       summary: Clear a model routing policy
       x-thane-scope: models:admin
       responses: { "204": { description: Cleared. } }
   /v1/models/registry/resource-policy:
     put:
-      tags: [Models & Fleet]
+      tags: [Model Routing]
       operationId: setResourcePolicy
       summary: Set a resource (host) policy
       x-thane-scope: models:admin
@@ -868,16 +876,16 @@ paths:
                 max_concurrent: 4
       responses: { "200": { description: Applied. } }
     delete:
-      tags: [Models & Fleet]
+      tags: [Model Routing]
       operationId: clearResourcePolicy
       summary: Clear a resource policy
       x-thane-scope: models:admin
       responses: { "204": { description: Cleared. } }
 
-  # ------------------------------------------------------------- Insights
+  # ------------------------------------------------------------ Telemetry
   /v1/insights/router:
     get:
-      tags: [Insights]
+      tags: [Telemetry]
       operationId: getRouterInsights
       summary: Router stats and recent audit
       description: Consolidates `/v1/router/stats` and `/v1/router/audit`.
@@ -897,7 +905,7 @@ paths:
                     - { request_id: "019e7469-3abf-7e6b-ae38-85b5e34915ac", selected_model: thane:latest, ts: "2026-06-24T14:31:07Z" }
   /v1/insights/tools:
     get:
-      tags: [Insights]
+      tags: [Telemetry]
       operationId: getToolInsights
       summary: Tool-call stats and recent calls
       description: Consolidates `/v1/tools/stats` and `/v1/tools/calls`.
@@ -917,7 +925,7 @@ paths:
                     - { tool_name: ha_get_state, request_id: "019e7469-3abf-7e6b-ae38-85b5e34915ac", ts: "2026-06-24T14:31:09Z" }
   /v1/insights/usage:
     get:
-      tags: [Insights]
+      tags: [Telemetry]
       operationId: getUsageInsights
       summary: Token / cost usage summary
       description: Was `/v1/usage/summary`.
@@ -942,7 +950,7 @@ paths:
                     "gpt-oss:120b": { input_tokens: 302392, output_tokens: 77201 }
   /v1/insights/capabilities:
     get:
-      tags: [Insights]
+      tags: [Telemetry]
       operationId: listCapabilities
       summary: Resolved capability-tag catalog
       description: Was the dashboard-private `/api/capabilities`.
@@ -961,7 +969,7 @@ paths:
                   count: 2
   /v1/insights/capabilities/{tag}:
     get:
-      tags: [Insights]
+      tags: [Telemetry]
       operationId: getCapability
       summary: One capability tag's resolved view
       x-thane-scope: insights:read

--- a/internal/server/openapi/native.yaml
+++ b/internal/server/openapi/native.yaml
@@ -30,7 +30,7 @@ info:
       `schedules:read`, `conversations:read`, `sessions:read`, `sessions:write`,
       `archive:read`,
       `checkpoints:read`, `checkpoints:write`, `models:read`, `models:admin`,
-      `insights:read`, `contacts:read`, `contacts:write`, `system:read`.
+      `telemetry:read`, `contacts:read`, `contacts:write`, `system:read`.
     - **Roles** bundle scopes: `observer` (all `:read`), `operator`
       (observer + `definitions:write`, `sessions:write`, `checkpoints:write`),
       `admin` (everything, incl. `models:admin`, `contacts:write`).
@@ -883,16 +883,16 @@ paths:
       responses: { "204": { description: Cleared. } }
 
   # ------------------------------------------------------------ Telemetry
-  /v1/insights/router:
+  /v1/telemetry/router:
     get:
       tags: [Telemetry]
-      operationId: getRouterInsights
+      operationId: getRouterTelemetry
       summary: Router stats and recent audit
       description: Consolidates `/v1/router/stats` and `/v1/router/audit`.
-      x-thane-scope: insights:read
+      x-thane-scope: telemetry:read
       responses:
         "200":
-          description: Router insights.
+          description: Router telemetry.
           content:
             application/json:
               schema:
@@ -903,16 +903,16 @@ paths:
                     by_model: { "thane:latest": 9871, "gpt-oss:120b": 4211 }
                   recent:
                     - { request_id: "019e7469-3abf-7e6b-ae38-85b5e34915ac", selected_model: thane:latest, ts: "2026-06-24T14:31:07Z" }
-  /v1/insights/tools:
+  /v1/telemetry/tools:
     get:
       tags: [Telemetry]
-      operationId: getToolInsights
+      operationId: getToolTelemetry
       summary: Tool-call stats and recent calls
       description: Consolidates `/v1/tools/stats` and `/v1/tools/calls`.
-      x-thane-scope: insights:read
+      x-thane-scope: telemetry:read
       responses:
         "200":
-          description: Tool insights.
+          description: Tool telemetry.
           content:
             application/json:
               schema:
@@ -923,13 +923,13 @@ paths:
                     by_tool: { ha_get_state: 3120, send_message: 2841, log_search: 1204 }
                   recent:
                     - { tool_name: ha_get_state, request_id: "019e7469-3abf-7e6b-ae38-85b5e34915ac", ts: "2026-06-24T14:31:09Z" }
-  /v1/insights/usage:
+  /v1/telemetry/usage:
     get:
       tags: [Telemetry]
-      operationId: getUsageInsights
+      operationId: getUsageTelemetry
       summary: Token / cost usage summary
       description: Was `/v1/usage/summary`.
-      x-thane-scope: insights:read
+      x-thane-scope: telemetry:read
       parameters:
         - { name: hours, in: query, description: "Lookback window in hours (default 24).", schema: { type: integer, minimum: 1, default: 24 } }
         - { name: group_by, in: query, description: "Break the summary down by a dimension (e.g. model); omit for an ungrouped total.", schema: { type: string } }
@@ -948,13 +948,13 @@ paths:
                   by_model:
                     "thane:latest": { input_tokens: 982140, output_tokens: 241003 }
                     "gpt-oss:120b": { input_tokens: 302392, output_tokens: 77201 }
-  /v1/insights/capabilities:
+  /v1/telemetry/capabilities:
     get:
       tags: [Telemetry]
       operationId: listCapabilities
       summary: Resolved capability-tag catalog
       description: Was the dashboard-private `/api/capabilities`.
-      x-thane-scope: insights:read
+      x-thane-scope: telemetry:read
       responses:
         "200":
           description: Capability catalog.
@@ -967,12 +967,12 @@ paths:
                     - { tag: messaging, models: ["thane:latest", "gpt-oss:120b"], tools: [send_message] }
                     - { tag: vision, models: ["thane:latest"], tools: [image_describe] }
                   count: 2
-  /v1/insights/capabilities/{tag}:
+  /v1/telemetry/capabilities/{tag}:
     get:
       tags: [Telemetry]
       operationId: getCapability
       summary: One capability tag's resolved view
-      x-thane-scope: insights:read
+      x-thane-scope: telemetry:read
       parameters: [ { name: tag, in: path, required: true, description: "Capability tag.", schema: { type: string } } ]
       responses:
         "200":

--- a/internal/server/web/static/app.js
+++ b/internal/server/web/static/app.js
@@ -2664,8 +2664,8 @@ async function fetchSystemStatus() {
     const [sys, models, router, capabilities] = await Promise.all([
       api.tryGet('/system'),
       api.tryGet('/models/registry'),
-      api.tryGet('/insights/router'),
-      api.tryGet('/insights/capabilities'),
+      api.tryGet('/telemetry/router'),
+      api.tryGet('/telemetry/capabilities'),
     ]);
     if (!sys) {
       state.system = null;


### PR DESCRIPTION
## Why

Two operator-facing problems with the Scalar `/docs` explorer, both fully in our control:

1. **"Try it" targeted the wrong host.** `native.yaml` hardcoded `http://localhost:8080` as its only `server`, so the explorer's request form fired at the operator's own localhost instead of the host that served the page (e.g. `https://pocket.hollowoak.net` behind Traefik). The workaround was to manually deselect the server prefix in the UI.
2. **The sidebar read as architecture trivia, with "Models" meaning three different things** — the `Models & Fleet` tag, the `Models & Insights` group, and Scalar's auto-rendered `components/schemas` section (which is literally titled "Models" and looks like "a random assortment of undocumented endpoints"). `Insights` and `Platform` were also under-descriptive.

## What changed

**Server URL** — replace the absolute server with a single document-relative entry (`url: /`). Scalar resolves `/` against the page origin, so "Try it" is same-origin by default: `http://localhost:8080` locally and the reverse-proxy host in production, with **no per-deployment edit**. OpenAPI 3.1 permits a document-relative server URL. `compat.yaml` stays absolute on purpose — the OpenAI (`:8081`) / Ollama (`:11434`) surfaces live on their own host/port, not the `/docs` origin.

**Taxonomy** — names only; all 57 operations keep their existing tag membership.

| Layer | Before | After |
|---|---|---|
| Tag | `Models & Fleet` | **`Model Routing`** |
| Tag | `Insights` | **`Telemetry`** |
| Group | `Models & Insights` | **`Routing & Telemetry`** |
| Group | `Platform` | **`Integrations & Data`** (Contacts) + **`Runtime`** (System, Realtime) |
| Schemas section | "Models" | **"Schemas"** (`modelsSectionLabel`) |

`Platform` is split rather than renamed so the structure is **ready for growth**: future native subsystems (e.g. a Documents suite) land as their own tag under `Integrations & Data`, while `Runtime` stays the small host/process surface. This kills all three "Models" collisions — the only surviving "model" token is the singular adjective in `Model Routing`.

**Insights → Telemetry surface rename** — so the API itself agrees with the new `Telemetry` tag, not just the doc label. Hard rename, no back-compat alias (single controlled native surface). Routes and spec paths renamed in lockstep so route-coverage stays green.

| Layer | Before | After |
|---|---|---|
| Paths | `/v1/insights/*` | `/v1/telemetry/*` |
| Scope | `insights:read` | `telemetry:read` |
| operationIds | `get{Router,Tool,Usage}Insights` | `…Telemetry` |
| Handlers | `handleRouterInsights` / `handleToolInsights` | `…Telemetry` |
| Files | `insights.go` / `insights_test.go` | `telemetry.go` / `telemetry_test.go` |
| Callers | web console (`app.js`), `docs/reference/api.md`, `system.go` xref | updated |

The unrelated media/contact "insights" domain term elsewhere in the tree is deliberately untouched.

New sidebar (verified in a browser against the embedded bundle):

```
Execution            Loops · Loop Definitions · Requests · Scheduler
Memory & History     Conversations & Sessions · Archive · Checkpoints
Routing & Telemetry  Model Routing · Telemetry
Integrations & Data  Contacts
Runtime              System · Realtime
Schemas              (auto components/schemas)
```

Orthogonal to the OpenAPI field-doc effort (#1060); no field-coverage rule keys on tag names.

## Test plan

- [x] `just ci` green locally (architecture check, golangci-lint, `vacuum --fail-severity error` on both specs, all tests incl. `internal/server/openapi` + `internal/server/api`)
- [x] `TestNativeTagGroupsCoverage` holds: declared tags == grouped tags, each tag in exactly one group
- [x] `TestNativeSpecRouteCoverage` holds after the `/v1/insights` → `/v1/telemetry` route rename (server.go ↔ native.yaml in lockstep)
- [x] Rendered the explorer in a browser: sidebar shows the 5 new groups + `Schemas`; no `Models`/`Insights`/`Platform`; tags render in authored order (Loops first)
- [x] Confirmed the relative server resolves to the **serving origin** in the request panel (not a hardcoded `:8080`)
- [ ] Eyeball on the deployed instance (`https://pocket.hollowoak.net/docs`) after merge: "Try it" targets the public host, and the web console dashboard still loads (now calling `/v1/telemetry/*`)
