### PR TITLE
fix(ci): stop vacuum lint-openapi from flaking the build (#1078)

### DIFF
--- a/justfile
+++ b/justfile
@@ -97,10 +97,32 @@ lint: generate
 # errors fail the build; content gaps (missing descriptions/examples) ride at
 # `warn` during the #1060 stack and become errors at its capstone. Install:
 # `go install github.com/daveshanley/vacuum@v0.29.5` (CI does this).
+#
+# Flake guard (#1078): vacuum's schema rules (oas-schema-check, oas-missing-type)
+# nondeterministically collapse — emitting wholesale spurious errors with varying
+# counts — when their per-rule / JSONPath-lookup timeouts are starved on a loaded
+# runner; a residual ~2% race remains even with slack. The rules finish in well
+# under a second locally, so the generous --timeout/--lookup-timeout below are
+# pure headroom, and a bounded retry clears the rare residual collapse. A genuine
+# spec error is deterministic and still fails all three attempts.
 [group('test')]
 lint-openapi:
-    vacuum lint -r .vacuum.yaml --fail-severity error internal/server/openapi/native.yaml
-    vacuum lint -r .vacuum.yaml --fail-severity error internal/server/openapi/compat.yaml
+    #!/usr/bin/env bash
+    set -euo pipefail
+    lint_spec() {
+        local spec="$1" attempt
+        for attempt in 1 2 3; do
+            if vacuum lint -r .vacuum.yaml --fail-severity error \
+                --timeout 120 --lookup-timeout 10000 "$spec"; then
+                return 0
+            fi
+            echo "lint-openapi: ${spec} failed (attempt ${attempt}/3); retrying" >&2
+        done
+        echo "lint-openapi: ${spec} still failing after 3 attempts" >&2
+        return 1
+    }
+    lint_spec internal/server/openapi/native.yaml
+    lint_spec internal/server/openapi/compat.yaml
 
 # Check go.mod/go.sum are tidy
 [group('test')]

--- a/justfile
+++ b/justfile
@@ -116,7 +116,9 @@ lint-openapi:
                 --timeout 120 --lookup-timeout 10000 "$spec"; then
                 return 0
             fi
-            echo "lint-openapi: ${spec} failed (attempt ${attempt}/3); retrying" >&2
+            if [ "$attempt" -lt 3 ]; then
+                echo "lint-openapi: ${spec} failed (attempt ${attempt}/3); retrying" >&2
+            fi
         done
         echo "lint-openapi: ${spec} still failing after 3 attempts" >&2
         return 1


### PR DESCRIPTION
Closes #1078.

## Problem

`just lint-openapi` (vacuum v0.29.5, `--fail-severity error` since the #1060 capstone) intermittently collapses OpenAPI schema validation on **valid, unchanged** specs — emitting wholesale spurious `oas-schema-check` / `oas-missing-type` errors with *varying* counts run-to-run. Because it's an error-severity gate, a flake blocks the merge. Observed on CI runs `28154683671` (11×), `28188072061` (29×), `28182218743` (18×, passed on re-run).

## Root cause (confirmed locally)

The collapse is driven by vacuum's per-rule **`--timeout` (default 5s)** and JSONPath **`--lookup-timeout` (default 500ms)** being starved when the runner is loaded — the heavy schema rules don't finish and emit nondeterministic partial results:

| Condition | Result |
|---|---|
| `--timeout 1` | collapses **deterministically** (6/6 runs, `oas-missing-type` ×11 — matches CI run 28154683671) |
| default `--timeout 5` | load-sensitive; clean locally, ~10% on loaded CI |
| `--timeout 120 --lookup-timeout 10000` | clean, with a **~2% residual** internal race (1/50) |

Not a network/ref issue — the specs have no external `$ref`s.

## Fix

Two layers, both contained in the `lint-openapi` recipe (no CI-workflow or vacuum-version change):

1. **Generous timeouts** `--timeout 120 --lookup-timeout 10000` — the rules complete in well under a second, so these caps are pure slack that removes the dominant load-induced starvation.
2. **Bounded 3-attempt retry** per spec — clears the rare residual collapse. At ~2%/attempt this drives the effective flake rate to ~negligible.

A **genuine** spec error is deterministic, so it still fails all three attempts — the retry cannot mask a real regression.

## Test plan

- [x] `just ci` green locally (lint-openapi passes both specs)
- [x] Happy path: `just lint-openapi` passes 3/3
- [x] Retry mechanics: a stub that fails attempt 1 then passes returns exit 0 via the loop
- [x] Non-masking: a deliberately-broken spec fails all 3 attempts and exits non-zero
- [ ] Watch the next few CI runs to confirm the flake is gone in practice
