### PR TITLE
fix(loops): default-deny human-egress tools on thane_curate (#696)

### DIFF
--- a/internal/tools/loop_intent_tools.go
+++ b/internal/tools/loop_intent_tools.go
@@ -414,6 +414,14 @@ func (r *Registry) handleThaneCurate(ctx context.Context, args map[string]any) (
 		Tags:          tags,
 		Outputs:       []looppkg.OutputSpec{outputSpec},
 		Subscriptions: curateEntitiesToSubscriptions(entities, now),
+		// Default-deny direct human-egress tools (#696): a model-authored
+		// curate loop is a subsystem loop that should wake the core loop via
+		// request_core_attention rather than contact a person directly. This
+		// matches the ego/metacognitive/archivist exclusion baseline; without
+		// it a wrong-tagged curate loop could acquire signal_send_message /
+		// email_send / ha_notify. (An operator-facing exclude_tools knob layers
+		// on top of this default in a later change.)
+		ExcludeTools: DirectHumanEgressToolNames(),
 		Profile: router.LoopProfile{
 			DelegationGating: "disabled",
 			Instructions:     strings.TrimSpace(instructions),

--- a/internal/tools/loop_intent_tools_test.go
+++ b/internal/tools/loop_intent_tools_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -265,6 +266,14 @@ func TestThaneCurate_EndToEnd(t *testing.T) {
 	// Only caller-supplied tags; the scope-tag mechanism is gone.
 	if len(found.Spec.Tags) != 1 || found.Spec.Tags[0] != "forge" {
 		t.Errorf("Tags = %v, want [forge]", found.Spec.Tags)
+	}
+	// Subsystem curate loops must default-deny direct human-egress tools
+	// (#696): the sanctioned path is request_core_attention, not
+	// signal_send_message / email_send / ha_notify.
+	for _, egress := range DirectHumanEgressToolNames() {
+		if !slices.Contains(found.Spec.ExcludeTools, egress) {
+			t.Errorf("curate spec ExcludeTools missing egress tool %q; got %v", egress, found.Spec.ExcludeTools)
+		}
 	}
 	if _, ok := found.Spec.Metadata["scope_tag"]; ok {
 		t.Errorf("scope_tag metadata should be gone, found %v", found.Spec.Metadata["scope_tag"])


### PR DESCRIPTION
Refs #1086 (Phase 0, item 1) · hardens #696.

## Problem (verified live)

`thane_curate` builds its loop `Spec` with **no `ExcludeTools`** ([loop_intent_tools.go](internal/tools/loop_intent_tools.go)), while the core service loops (ego/metacognitive/archivist) all append `DirectHumanEgressToolNames()` to theirs. So a **model-authored** curate loop with the wrong tags could acquire direct human-egress tools — `signal_send_message`, `email_send`, `ha_notify`, `request_human_*`, `send_notification`, `send_reaction` — which is exactly the #696 boundary ("subsystem loops should wake the core loop via `request_core_attention`, not contact a person directly").

## Fix

Default-deny the same `DirectHumanEgressToolNames()` set on the curate-built spec, matching the core-loop baseline. Adds a regression guard asserting the registered definition excludes every egress tool.

This is the standalone security item of the #1086 curate-envelope unification — shipped on its own because it's a live latent hole independent of the broader refactor. An operator-facing `exclude_tools` knob will layer *on top of* this default in a later Phase-0 change.

## Test plan
- [x] `just ci` green
- [x] New guard: built curate definition excludes all `DirectHumanEgressToolNames()`
- [x] Existing `thane_curate` handler/clobber/document tests pass unchanged