### PR TITLE
feat(loops): enumerate the loop-definition spec schema for agents (#1086)

### DIFF
--- a/internal/tools/loop_definition_tools.go
+++ b/internal/tools/loop_definition_tools.go
@@ -145,10 +145,7 @@ func (r *Registry) registerLoopDefinitionTools() {
 		Parameters: map[string]any{
 			"type": "object",
 			"properties": map[string]any{
-				"spec": map[string]any{
-					"type":        "object",
-					"description": "Candidate loop definition spec to validate and inspect before saving.",
-				},
+				"spec": loopSpecSchema("Candidate loop definition spec to validate and inspect before saving."),
 			},
 			"required": []string{"spec"},
 		},
@@ -168,10 +165,7 @@ func (r *Registry) registerLoopDefinitionTools() {
 		Parameters: map[string]any{
 			"type": "object",
 			"properties": map[string]any{
-				"spec": map[string]any{
-					"type":        "object",
-					"description": "Loop definition spec to persist into the overlay.",
-				},
+				"spec": loopSpecSchema("Loop definition spec to persist into the overlay."),
 			},
 			"required": []string{"spec"},
 		},

--- a/internal/tools/loop_runtime_tools.go
+++ b/internal/tools/loop_runtime_tools.go
@@ -116,10 +116,7 @@ func (r *Registry) registerLoopRuntimeTools() {
 	})
 
 	spawnLoopLaunchProperties := loopLaunchOverrideProperties()
-	spawnLoopLaunchProperties["spec"] = map[string]any{
-		"type":        "object",
-		"description": "Ad-hoc loop spec (name, task, operation, completion, sleep settings, etc.). Required.",
-	}
+	spawnLoopLaunchProperties["spec"] = loopSpecSchema("Ad-hoc loop spec (name, task, operation, completion, sleep settings, etc.). Required.")
 
 	r.Register(&Tool{
 		Name:        "spawn_loop",

--- a/internal/tools/loop_spec_schema.go
+++ b/internal/tools/loop_spec_schema.go
@@ -89,8 +89,8 @@ func loopSpecSchema(description string) map[string]any {
 			},
 			"on_retrigger": map[string]any{
 				"type":        "string",
-				"enum":        []string{"single", "restart", "queue"},
-				"description": "Behavior when triggered again while running: single = ignore the new trigger; restart = cancel and restart; queue = run again after the current iteration.",
+				"enum":        []string{"single", "restart", "queue", "spawn"},
+				"description": "Behavior when triggered again while running: single = ignore the new trigger; restart = cancel and restart; queue = run again after the current iteration; spawn = start another concurrent instance.",
 			},
 			"conditions": map[string]any{
 				"type":        "object",
@@ -103,8 +103,9 @@ func loopSpecSchema(description string) map[string]any {
 				},
 			},
 			"completion": map[string]any{
-				"type":        "object",
-				"description": "How results are delivered back to a caller, conversation, or channel — mainly for request_reply and detached background_task loops.",
+				"type":        "string",
+				"enum":        []string{"return", "conversation", "channel", "none"},
+				"description": "Where results are delivered: return = to the caller; conversation = into the originating conversation; channel = to a channel; none = no outward delivery (the default for service loops). Mainly relevant for request_reply and detached background_task loops.",
 			},
 			"subscriptions": map[string]any{
 				"type":        "array",

--- a/internal/tools/loop_spec_schema.go
+++ b/internal/tools/loop_spec_schema.go
@@ -1,0 +1,170 @@
+package tools
+
+// loopSpecSchema returns the JSON-Schema description of the agent-facing
+// loop-definition spec object, shared by loop_definition_set,
+// loop_definition_lint, and spawn_loop. Until this existed those tools
+// advertised the spec as a bare {"type":"object"}: every field below was
+// already decoded by decodeLoopSpecArg's json.Unmarshal, but the model was
+// taught none of them, so authoring a loop meant guessing the shape.
+//
+// The schema is deliberately ADVISORY — it documents the canonical surface
+// without setting additionalProperties:false, so it never rejects the extra
+// or legacy keys the decoder still accepts (e.g. the backwards-compat
+// top-level quality_floor). It adds no new `required` fields beyond what the
+// handlers already enforce, so existing valid calls keep validating. The
+// description argument lets each tool frame the spec for its own verb.
+//
+// This is the single source of truth for the agent-facing spec surface: add
+// a new authorable field here and all three tools advertise it.
+func loopSpecSchema(description string) map[string]any {
+	return map[string]any{
+		"type":        "object",
+		"description": description,
+		"properties": map[string]any{
+			"name": map[string]any{
+				"type":        "string",
+				"description": "Unique definition name. Required to save or launch.",
+			},
+			"enabled": map[string]any{
+				"type":        "boolean",
+				"description": "Whether the definition is eligible for runtime lifecycle management; service loops auto-start when enabled.",
+			},
+			"task": map[string]any{
+				"type":        "string",
+				"description": "Static prompt run each iteration.",
+			},
+			"operation": map[string]any{
+				"type":        "string",
+				"enum":        []string{"request_reply", "background_task", "service", "container", "event_driven"},
+				"description": "Runtime pattern. service = perpetual self-paced loop; event_driven = wakes only on subscription/tag events (no periodic sleep); background_task = detached one-shot; request_reply = synchronous; container = non-executing graph node.",
+			},
+			"profile": loopProfileSchema("Routing and request-shaping for normal (non-supervisor) iterations."),
+			"supervisor": map[string]any{
+				"type":        "boolean",
+				"description": "Enable periodic supervisor turns: a per-wake Bernoulli trial promotes the iteration to a more capable, non-local model. Note: a model-authored (overlay) loop may be barred from self-enabling this; config-sourced loops set it freely.",
+			},
+			"supervisor_prob": map[string]any{
+				"type":        "number",
+				"description": "Per-wake probability in [0.0, 1.0] of a supervisor turn when supervisor is true.",
+			},
+			"supervisor_profile": loopProfileSchema("Overlay applied on supervisor turns (e.g. a higher quality_floor and review-specific instructions). Any field set here wins over profile; unset fields fall back to profile."),
+			"outputs": map[string]any{
+				"type":        "array",
+				"description": "Durable documents this loop maintains through scoped runtime tools (replace_output_*/append_output_*).",
+				"items":       loopOutputSpecSchema(),
+			},
+			"tags": map[string]any{
+				"type":        "array",
+				"items":       map[string]any{"type": "string"},
+				"description": "Capability tags activated at iteration 0 (tool-registry scope, KB exposure); stay active across iterations unless deactivated.",
+			},
+			"exclude_tools": map[string]any{
+				"type":        "array",
+				"items":       map[string]any{"type": "string"},
+				"description": "Tool names to exclude from this loop. Direct human-egress tools are denied by default for subsystem loops — wake the core loop with request_core_attention instead.",
+			},
+			"sleep_min": map[string]any{
+				"type":        "string",
+				"description": "Minimum sleep between iterations as a duration string (e.g. \"15m\"); the loop cannot self-select a shorter sleep.",
+			},
+			"sleep_max": map[string]any{
+				"type":        "string",
+				"description": "Maximum sleep between iterations as a duration string (e.g. \"12h\").",
+			},
+			"sleep_default": map[string]any{
+				"type":        "string",
+				"description": "Initial sleep before the loop self-adjusts via set_next_sleep, as a duration string.",
+			},
+			"jitter": map[string]any{
+				"type":        "number",
+				"description": "Sleep randomization factor in [0.0, 1.0]; 0.2 varies sleep by ±20%, 0 = deterministic timing.",
+			},
+			"max_duration": map[string]any{
+				"type":        "string",
+				"description": "Maximum wall-clock lifetime as a duration string; empty = unbounded.",
+			},
+			"max_iter": map[string]any{
+				"type":        "integer",
+				"description": "Maximum iteration attempts; 0 = unbounded.",
+			},
+			"on_retrigger": map[string]any{
+				"type":        "string",
+				"enum":        []string{"single", "restart", "queue"},
+				"description": "Behavior when triggered again while running: single = ignore the new trigger; restart = cancel and restart; queue = run again after the current iteration.",
+			},
+			"conditions": map[string]any{
+				"type":        "object",
+				"description": "Eligibility constraints; empty = always eligible unless blocked by policy.",
+				"properties": map[string]any{
+					"schedule": map[string]any{
+						"type":        "object",
+						"description": "Schedule constraint controlling the window in which the definition may run or launch.",
+					},
+				},
+			},
+			"completion": map[string]any{
+				"type":        "object",
+				"description": "How results are delivered back to a caller, conversation, or channel — mainly for request_reply and detached background_task loops.",
+			},
+			"subscriptions": map[string]any{
+				"type":        "array",
+				"description": "Entities surfaced in context every iteration; the effective set unions every container ancestor's subscriptions.",
+				"items": map[string]any{
+					"type": "object",
+					"properties": map[string]any{
+						"entity_id": map[string]any{"type": "string", "description": "Subscribed entity id (e.g. a Home Assistant entity)."},
+						"history":   map[string]any{"type": "array", "items": map[string]any{"type": "integer"}, "description": "Optional history windows to include."},
+						"forecast":  map[string]any{"type": "string", "description": "Optional forecast horizon to include."},
+						"ttl_seconds": map[string]any{
+							"type":        "integer",
+							"description": "Optional time-to-live; the subscription is dropped after this many seconds.",
+						},
+						"tags": map[string]any{"type": "array", "items": map[string]any{"type": "string"}, "description": "Optional tags scoping the subscription."},
+					},
+				},
+			},
+			"metadata": map[string]any{
+				"type":                 "object",
+				"description":          "Opaque string-keyed metadata stored with the definition.",
+				"additionalProperties": map[string]any{"type": "string"},
+			},
+		},
+	}
+}
+
+// loopProfileSchema describes a router.LoopProfile, used for both a loop's
+// normal profile and its supervisor_profile overlay. The description is
+// supplied by the caller to frame which of the two it is.
+func loopProfileSchema(description string) map[string]any {
+	return map[string]any{
+		"type":        "object",
+		"description": description,
+		"properties": map[string]any{
+			"model":             map[string]any{"type": "string", "description": "Pin a specific model as this loop's persistent baseline; omit to let the router choose."},
+			"quality_floor":     map[string]any{"type": "integer", "description": "Minimum model quality rating (1–10) for selection."},
+			"mission":           map[string]any{"type": "string", "description": "Mission/context profile name shaping prompt assembly."},
+			"local_only":        map[string]any{"type": "string", "description": "\"true\"/\"false\" string — restrict routing to local models. Supervisor turns force this to false."},
+			"delegation_gating": map[string]any{"type": "string", "description": "Set \"disabled\" to forbid this loop from delegating or spawning sub-work."},
+			"prefer_speed":      map[string]any{"type": "string", "description": "\"true\"/\"false\" string — bias routing toward faster models."},
+			"exclude_tools":     map[string]any{"type": "array", "items": map[string]any{"type": "string"}, "description": "Profile-level tool exclusions, unioned with the spec-level exclude_tools."},
+			"instructions":      map[string]any{"type": "string", "description": "Self-only prompt prefix prepended to the task (does not cascade to container children). On a supervisor_profile this is the supervisor-turn guidance."},
+			"extra_hints":       map[string]any{"type": "object", "additionalProperties": map[string]any{"type": "string"}, "description": "Free-form string routing hints."},
+		},
+	}
+}
+
+// loopOutputSpecSchema describes one entry in a spec's outputs array.
+func loopOutputSpecSchema() map[string]any {
+	return map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"name":           map[string]any{"type": "string", "description": "Stable semantic name for this output within the loop."},
+			"type":           map[string]any{"type": "string", "enum": []string{"maintained_document", "journal_document"}, "description": "maintained_document = idempotent rewrite each cycle; journal_document = append-only dated entries."},
+			"ref":            map[string]any{"type": "string", "description": "Managed document ref, e.g. \"core:metacognitive.md\" or \"kb:dashboards/x.md\". Stored verbatim — not resolved to content."},
+			"mode":           map[string]any{"type": "string", "enum": []string{"replace", "append"}, "description": "Write mode; defaults from type when omitted (maintained→replace, journal→append)."},
+			"purpose":        map[string]any{"type": "string", "description": "Optional model-facing guidance describing what this output is for."},
+			"journal_window": map[string]any{"type": "string", "enum": []string{"day", "week", "month"}, "description": "Rolling window for journal outputs; empty uses the document-layer default."},
+			"max_windows":    map[string]any{"type": "integer", "description": "Cap on retained journal windows; 0 uses the document-layer default."},
+		},
+	}
+}

--- a/internal/tools/loop_spec_schema_test.go
+++ b/internal/tools/loop_spec_schema_test.go
@@ -1,0 +1,72 @@
+package tools
+
+import "testing"
+
+// TestLoopSpecSchemaEnumeratesAuthorableFields guards the #1086 Phase-0
+// discoverability win: the loop-definition spec param must advertise its
+// authorable fields, not collapse back to a bare {"type":"object"}.
+func TestLoopSpecSchemaEnumeratesAuthorableFields(t *testing.T) {
+	s := loopSpecSchema("frame this spec")
+
+	if s["type"] != "object" {
+		t.Fatalf("type = %v, want object", s["type"])
+	}
+	if s["description"] != "frame this spec" {
+		t.Errorf("description not threaded through: %v", s["description"])
+	}
+	// Advisory invariant: the schema documents the canonical surface but must
+	// stay OPEN, so the decoder's extra/legacy keys (e.g. top-level
+	// quality_floor) still validate at the tool-call layer.
+	if _, ok := s["additionalProperties"]; ok {
+		t.Error("loopSpecSchema must stay open (no additionalProperties) — it is advisory, not restrictive")
+	}
+
+	props, ok := s["properties"].(map[string]any)
+	if !ok {
+		t.Fatal("properties missing or wrong type")
+	}
+	for _, key := range []string{
+		"name", "enabled", "task", "operation", "profile", "supervisor",
+		"supervisor_prob", "supervisor_profile", "outputs", "tags",
+		"exclude_tools", "sleep_min", "sleep_max", "sleep_default", "jitter",
+		"max_duration", "max_iter", "on_retrigger", "conditions", "completion",
+		"subscriptions", "metadata",
+	} {
+		if _, ok := props[key].(map[string]any); !ok {
+			t.Errorf("spec schema missing enumerated property %q", key)
+		}
+	}
+
+	// The constrained string fields must carry their enums so the model picks
+	// valid values rather than guessing.
+	for _, key := range []string{"operation", "on_retrigger"} {
+		field, _ := props[key].(map[string]any)
+		if field["enum"] == nil {
+			t.Errorf("%q must carry an enum", key)
+		}
+	}
+
+	// profile (and supervisor_profile, same builder) must expose the routing
+	// knobs that were the whole point of exposing the envelope.
+	prof, ok := props["profile"].(map[string]any)
+	if !ok {
+		t.Fatal("profile schema missing")
+	}
+	pprops, _ := prof["properties"].(map[string]any)
+	for _, key := range []string{"quality_floor", "instructions", "model", "delegation_gating"} {
+		if _, ok := pprops[key]; !ok {
+			t.Errorf("profile schema missing %q", key)
+		}
+	}
+
+	// outputs items must describe ref + the type enum.
+	outs, _ := props["outputs"].(map[string]any)
+	item, _ := outs["items"].(map[string]any)
+	iprops, _ := item["properties"].(map[string]any)
+	if _, ok := iprops["ref"]; !ok {
+		t.Error("output item schema missing ref")
+	}
+	if ot, _ := iprops["type"].(map[string]any); ot["enum"] == nil {
+		t.Error("output item type must carry an enum")
+	}
+}

--- a/internal/tools/loop_spec_schema_test.go
+++ b/internal/tools/loop_spec_schema_test.go
@@ -1,6 +1,9 @@
 package tools
 
-import "testing"
+import (
+	"slices"
+	"testing"
+)
 
 // TestLoopSpecSchemaEnumeratesAuthorableFields guards the #1086 Phase-0
 // discoverability win: the loop-definition spec param must advertise its
@@ -37,13 +40,25 @@ func TestLoopSpecSchemaEnumeratesAuthorableFields(t *testing.T) {
 		}
 	}
 
-	// The constrained string fields must carry their enums so the model picks
-	// valid values rather than guessing.
-	for _, key := range []string{"operation", "on_retrigger"} {
+	// The constrained string fields must be typed string AND carry their
+	// enums, so the model picks valid values rather than guessing — and so a
+	// schema-following caller never sends the wrong JSON type. completion in
+	// particular is a string enum (loop.Completion), not an object.
+	for _, key := range []string{"operation", "on_retrigger", "completion"} {
 		field, _ := props[key].(map[string]any)
-		if field["enum"] == nil {
-			t.Errorf("%q must carry an enum", key)
+		if field["type"] != "string" {
+			t.Errorf("%q must be type string, got %v", key, field["type"])
 		}
+		enum, ok := field["enum"].([]string)
+		if !ok || len(enum) == 0 {
+			t.Errorf("%q must carry a non-empty enum", key)
+		}
+	}
+	// on_retrigger must advertise every mode ParseRetriggerMode accepts,
+	// including spawn (RetriggerSpawn) — omitting it hides a valid value.
+	retrigger, _ := props["on_retrigger"].(map[string]any)
+	if enum, _ := retrigger["enum"].([]string); !slices.Contains(enum, "spawn") {
+		t.Errorf("on_retrigger enum must include \"spawn\", got %v", retrigger["enum"])
 	}
 
 	// profile (and supervisor_profile, same builder) must expose the routing


### PR DESCRIPTION
Refs #1086 (Phase 0 — discoverability).

## Problem

`loop_definition_set`, `loop_definition_lint`, and `spawn_loop` advertised their `spec` param as a bare `{"type":"object"}` with no properties ([loop_definition_tools.go](internal/tools/loop_definition_tools.go), [loop_runtime_tools.go](internal/tools/loop_runtime_tools.go)). Every field is *already* decoded by `decodeLoopSpecArg`'s blanket `json.Unmarshal` — but the model was taught **none** of them, so authoring a loop meant guessing the shape. The gap was discoverability, not capability.

## Change

Add `loopSpecSchema(description)` ([loop_spec_schema.go](internal/tools/loop_spec_schema.go)) as the **single source of truth** for the agent-facing spec surface, and wire all three tools to it. Enumerates: `name`, `enabled`, `task`, `operation` (enum), `profile`/`supervisor_profile` (model, quality_floor, mission, local_only, delegation_gating, prefer_speed, exclude_tools, instructions, extra_hints), `supervisor`, `supervisor_prob`, `outputs` (with type/mode enums + ref/journal_window), `tags`, `exclude_tools`, `sleep_min/max/default`, `jitter`, `max_duration`, `max_iter`, `on_retrigger` (enum), `conditions`, `completion`, `subscriptions`, `metadata`.

**Deliberately advisory:**
- No `additionalProperties: false` — documents the canonical shape without rejecting the extra/legacy keys the decoder still accepts (e.g. top-level `quality_floor`).
- No new `required` fields beyond what the handlers/`ValidatePersistable` already enforce — existing valid calls keep validating.
- `SkipContentResolve` (#1068, on `set`/`lint`) untouched.

This is the highest-leverage, lowest-cost Phase-0 item of #1086: it exposes the full envelope the core loops already use, so agent-authored ad-hoc loops become materially easier to instantiate. (The `supervisor`/`supervisor_prob` knobs are *described* here but their **use** by overlay/model-authored loops is gated behind the Phase 2 frontier-spend governor.)

## Test plan
- [x] `just ci` green
- [x] New unit guard (`loop_spec_schema_test.go`): schema enumerates all authorable fields, carries enums on operation/on_retrigger/output-type, exposes profile routing knobs, and stays open (no `additionalProperties`)
- [x] Existing loop-definition / spawn / curate tests pass unchanged