### PR TITLE
refactor(loops): make ego/metacog/archivist prompts declarative (#1086)

### DIFF
--- a/examples/config.example.yaml
+++ b/examples/config.example.yaml
@@ -924,9 +924,8 @@ talents_dir: ./talents
 #   jitter: 0.2
 #   SupervisorProbability is the per-wake chance (0.0–1.0) that
 #   this iteration runs as a supervisor turn — a more capable
-#   model with the augmented prompt produced by
-#   [prompts.MetacognitivePrompt]. Default: 0.1. Set to 0.0 to
-#   disable supervisor turns entirely.
+#   model with the loop's supervisor-turn prompt prefix. Default: 0.1.
+#   Set to 0.0 to disable supervisor turns entirely.
 #   supervisor_probability: 0.1
 #   Router configures model routing for normal (non-supervisor)
 #   iterations.
@@ -963,9 +962,8 @@ ego:
   jitter: 0.2
   # SupervisorProbability is the per-wake chance (0.0–1.0) that
   # this iteration runs as a supervisor turn — a more capable
-  # model with the augmented prompt produced by
-  # [prompts.EgoPrompt]. Default: 0.2. Set to 0.0 to disable
-  # supervisor turns entirely.
+  # model with the loop's supervisor-turn prompt prefix. Default: 0.2.
+  # Set to 0.0 to disable supervisor turns entirely.
   supervisor_probability: 0.2
   # Router configures model routing for normal iterations.
   router:
@@ -1004,8 +1002,8 @@ archivist:
   jitter: 0.2
   # SupervisorProbability is the per-wake chance (0.0–1.0) that
   # this iteration runs as a supervisor turn — a frontier model
-  # with the augmented prompt produced by [prompts.ArchivistPrompt].
-  # Default: 0.1. Set to 0.0 to disable supervisor turns entirely.
+  # with the loop's supervisor-turn prompt prefix. Default: 0.1.
+  # Set to 0.0 to disable supervisor turns entirely.
   supervisor_probability: 0.1
   # Router configures model routing for normal iterations.
   router:

--- a/internal/app/loop_definition_hydration_test.go
+++ b/internal/app/loop_definition_hydration_test.go
@@ -270,11 +270,14 @@ func TestCoreServiceLoopByNameMatchesSlice(t *testing.T) {
 }
 
 // TestCoreServiceRegistrationHydrate exercises each registration's
-// Hydrate closure directly: a missing cached config is a hard error,
-// and a hydrated spec carries the runtime task builder. Driving the
-// closures (rather than hydrateLoopDefinitionSpec) keeps the test
-// focused on the #988 dispatch contract without pulling in the
-// document-output hydration machinery.
+// Hydrate closure directly: a missing cached config is a hard error, and
+// a hydrated spec attaches only genuine runtime-only hooks. The prompt is
+// now declarative (DefinitionSpec sets spec.Task and
+// SupervisorProfile.Instructions), so Hydrate attaches no TaskBuilder;
+// of the three loops only metacognitive still needs a runtime hook (its
+// PostIterate iteration-log writer). Driving the closures (rather than
+// hydrateLoopDefinitionSpec) keeps the test focused on the #988 dispatch
+// contract without pulling in the document-output hydration machinery.
 func TestCoreServiceRegistrationHydrate(t *testing.T) {
 	t.Parallel()
 
@@ -296,8 +299,16 @@ func TestCoreServiceRegistrationHydrate(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Hydrate: %v", err)
 			}
-			if spec.TaskBuilder == nil {
-				t.Error("Hydrate did not attach TaskBuilder")
+			if spec.TaskBuilder != nil {
+				t.Error("Hydrate should not attach a TaskBuilder; the prompt is the declarative spec Task")
+			}
+			// metacognitive is the only core loop with a remaining runtime
+			// hook: the PostIterate iteration-log writer (which needs the
+			// resolved state-file path). ego and archivist are hook-free
+			// here — the archivist's work-queue tools are attached later, at
+			// app hydration, not by this registration closure.
+			if reg.Name == "metacognitive" && spec.PostIterate == nil {
+				t.Error("metacognitive Hydrate should attach the PostIterate iteration-log writer")
 			}
 		})
 	}

--- a/internal/model/prompts/archivist.go
+++ b/internal/model/prompts/archivist.go
@@ -1,9 +1,10 @@
 package prompts
 
-// archivistBaseTemplate is the prompt for each archivist loop iteration.
-// Current archivist.md state is injected by the loop-declared output
-// context provider as the "Declared Durable Outputs" block.
-const archivistBaseTemplate = `Archivist loop iteration.
+// ArchivistBaseTemplate is the per-iteration prompt for the archivist
+// loop, set as the loop definition's Task. Current archivist.md state is
+// injected by the loop-declared output context provider as the "Declared
+// Durable Outputs" block.
+const ArchivistBaseTemplate = `Archivist loop iteration.
 
 You are running as a background memory archivist. You tend thane's
 accumulated understanding across the memory silos — archive (past
@@ -150,10 +151,10 @@ generating plausible-sounding text.
 - Quiet is a valid outcome. If the queue is empty and nothing feels worth
   a fresh pass, note that in your state file and sleep long.`
 
-// archivistSupervisorAugmentation is appended for frontier/supervisor turns.
-const archivistSupervisorAugmentation = `
-
-## Supervisor Review (Frontier Iteration)
+// ArchivistSupervisorInstructions is the supervisor-turn prompt prefix,
+// applied declaratively via SupervisorProfile.Instructions on frontier
+// iterations (prepended to ArchivistBaseTemplate).
+const ArchivistSupervisorInstructions = `## Supervisor Review (Frontier Iteration)
 
 This iteration was randomly selected for supervisor-level review using a
 frontier model. In addition to the normal pass, critically evaluate:
@@ -175,16 +176,3 @@ frontier model. In addition to the normal pass, critically evaluate:
 
 Be honest. Use this supervisor pass to catch drift the cheaper model
 would miss consistently.`
-
-// ArchivistPrompt returns the prompt for one archivist loop iteration.
-// When isSupervisor is true, additional self-review instructions are
-// appended for frontier-model iterations. The current archivist.md
-// content is injected by the loop's declared output context, not this
-// prompt.
-func ArchivistPrompt(isSupervisor bool) string {
-	prompt := archivistBaseTemplate
-	if isSupervisor {
-		prompt += archivistSupervisorAugmentation
-	}
-	return prompt
-}

--- a/internal/model/prompts/archivist_test.go
+++ b/internal/model/prompts/archivist_test.go
@@ -5,8 +5,8 @@ import (
 	"testing"
 )
 
-func TestArchivistPrompt_NormalIteration(t *testing.T) {
-	got := ArchivistPrompt(false)
+func TestArchivistBaseTemplate(t *testing.T) {
+	got := ArchivistBaseTemplate
 
 	for _, phrase := range []string{
 		"Archivist loop iteration",
@@ -19,26 +19,25 @@ func TestArchivistPrompt_NormalIteration(t *testing.T) {
 		"evidence",
 	} {
 		if !strings.Contains(got, phrase) {
-			t.Errorf("prompt missing expected phrase %q", phrase)
+			t.Errorf("base template missing expected phrase %q", phrase)
 		}
 	}
 	if strings.Contains(got, "Supervisor Review") {
-		t.Error("normal iteration should not include supervisor section")
+		t.Error("base template should not include the supervisor section")
 	}
 }
 
-// TestArchivistPrompt_SingleDrainMode locks in the post-#1024 shape: one
-// "drain your queue" mode, no event-wake branches, and the explicit
+// TestArchivistBaseTemplate_SingleDrainMode locks in the post-#1024 shape:
+// one "drain your queue" mode, no event-wake branches, and the explicit
 // hand-off that session metadata belongs to the summarizer (so a future
 // edit can't silently reintroduce the curator's false metadata claim or
 // the two-wake-modes amplification).
-func TestArchivistPrompt_SingleDrainMode(t *testing.T) {
-	got := ArchivistPrompt(false)
-	normalized := strings.Join(strings.Fields(got), " ")
+func TestArchivistBaseTemplate_SingleDrainMode(t *testing.T) {
+	normalized := strings.Join(strings.Fields(ArchivistBaseTemplate), " ")
 
 	for _, gone := range []string{"Two ways you wake up", "Self-paced wake", "sole writer"} {
 		if strings.Contains(normalized, gone) {
-			t.Errorf("prompt should no longer contain %q (single drain-queue mode)", gone)
+			t.Errorf("base template should no longer contain %q (single drain-queue mode)", gone)
 		}
 	}
 	for _, phrase := range []string{
@@ -48,19 +47,16 @@ func TestArchivistPrompt_SingleDrainMode(t *testing.T) {
 		"do NOT spawn loops",
 	} {
 		if !strings.Contains(normalized, phrase) {
-			t.Errorf("prompt missing drain-mode phrase %q", phrase)
+			t.Errorf("base template missing drain-mode phrase %q", phrase)
 		}
 	}
 }
 
-func TestArchivistPrompt_SupervisorTurn(t *testing.T) {
-	got := ArchivistPrompt(true)
+func TestArchivistSupervisorInstructions(t *testing.T) {
+	got := ArchivistSupervisorInstructions
 
 	if !strings.Contains(got, "Supervisor Review") {
-		t.Error("supervisor turn should include supervisor review section")
-	}
-	if !strings.Contains(got, "Archivist loop iteration") {
-		t.Error("supervisor turn should still include base prompt")
+		t.Error("supervisor instructions should include the supervisor review section")
 	}
 	for _, phrase := range []string{
 		"Evidence discipline",
@@ -68,7 +64,10 @@ func TestArchivistPrompt_SupervisorTurn(t *testing.T) {
 		"Cadence calibration",
 	} {
 		if !strings.Contains(got, phrase) {
-			t.Errorf("supervisor section missing expected phrase %q", phrase)
+			t.Errorf("supervisor instructions missing expected phrase %q", phrase)
 		}
+	}
+	if got != strings.TrimSpace(got) {
+		t.Error("supervisor instructions must not have leading/trailing whitespace")
 	}
 }

--- a/internal/model/prompts/ego.go
+++ b/internal/model/prompts/ego.go
@@ -1,9 +1,10 @@
 package prompts
 
-// egoBaseTemplate is the prompt for each ego loop iteration. Current
-// ego.md content is injected by the loop-declared output context
-// provider as the "Declared Durable Outputs" block.
-const egoBaseTemplate = `Ego loop iteration.
+// EgoBaseTemplate is the per-iteration prompt for the ego loop, set as
+// the loop definition's Task. Current ego.md content is injected by the
+// loop-declared output context provider as the "Declared Durable
+// Outputs" block.
+const EgoBaseTemplate = `Ego loop iteration.
 
 You are running as a background self-reflection process. Your job is to
 maintain ego.md — your own self-reflection document, written BY you, FOR
@@ -71,10 +72,10 @@ If it reads like something you'd put in a ticket, it doesn't belong here.
 - Quality of thought matters more than coverage. Quiet observation and
   a long sleep beats a manufactured update.`
 
-// egoSupervisorAugmentation is appended for frontier/supervisor turns.
-const egoSupervisorAugmentation = `
-
-## Supervisor Review (Frontier Iteration)
+// EgoSupervisorInstructions is the supervisor-turn prompt prefix, applied
+// declaratively via SupervisorProfile.Instructions on frontier iterations
+// (prepended to EgoBaseTemplate by the loop runtime).
+const EgoSupervisorInstructions = `## Supervisor Review (Frontier Iteration)
 
 This iteration was randomly selected for supervisor-level review using a
 frontier model. In addition to normal reflection, critically evaluate:
@@ -93,15 +94,3 @@ frontier model. In addition to normal reflection, critically evaluate:
 
 Be candid. Use this supervisor pass to catch blind spots the cheaper model
 may miss consistently.`
-
-// EgoPrompt returns the prompt for one ego loop iteration. When
-// isSupervisor is true, additional self-review instructions are
-// appended for frontier-model iterations. Current ego.md content is
-// injected by the loop's declared output context, not this prompt.
-func EgoPrompt(isSupervisor bool) string {
-	prompt := egoBaseTemplate
-	if isSupervisor {
-		prompt += egoSupervisorAugmentation
-	}
-	return prompt
-}

--- a/internal/model/prompts/ego_test.go
+++ b/internal/model/prompts/ego_test.go
@@ -5,8 +5,8 @@ import (
 	"testing"
 )
 
-func TestEgoPrompt_NormalIteration(t *testing.T) {
-	got := EgoPrompt(false)
+func TestEgoBaseTemplate(t *testing.T) {
+	got := EgoBaseTemplate
 
 	for _, phrase := range []string{
 		"Ego loop iteration",
@@ -17,27 +17,30 @@ func TestEgoPrompt_NormalIteration(t *testing.T) {
 		"durable output contract",
 	} {
 		if !strings.Contains(got, phrase) {
-			t.Errorf("prompt missing expected phrase %q", phrase)
+			t.Errorf("base template missing expected phrase %q", phrase)
 		}
 	}
 	if strings.Contains(got, "Supervisor Review") {
-		t.Error("normal iteration should not include supervisor section")
+		t.Error("base template should not include the supervisor section")
 	}
 	if strings.Contains(got, "Use ISO 8601 timestamps") {
-		t.Error("prompt should not ask ego loop to persist raw timestamps by default")
+		t.Error("base template should not ask ego loop to persist raw timestamps by default")
 	}
 	if !strings.Contains(got, "how recently ego.md was updated") {
-		t.Error("prompt should point to generated freshness context")
+		t.Error("base template should point to generated freshness context")
 	}
 }
 
-func TestEgoPrompt_SupervisorTurn(t *testing.T) {
-	got := EgoPrompt(true)
+func TestEgoSupervisorInstructions(t *testing.T) {
+	got := EgoSupervisorInstructions
 
 	if !strings.Contains(got, "Supervisor Review") {
-		t.Error("supervisor turn should include supervisor review section")
+		t.Error("supervisor instructions should include the supervisor review section")
 	}
-	if !strings.Contains(got, "Ego loop iteration") {
-		t.Error("supervisor turn should still include base prompt")
+	// Applied as a prepended prompt prefix via SupervisorProfile.Instructions,
+	// so unlike the old appended augmentation it must carry no surrounding
+	// blank lines.
+	if got != strings.TrimSpace(got) {
+		t.Error("supervisor instructions must not have leading/trailing whitespace")
 	}
 }

--- a/internal/model/prompts/metacognitive.go
+++ b/internal/model/prompts/metacognitive.go
@@ -1,9 +1,9 @@
 package prompts
 
-// metacognitiveBaseTemplate is the prompt for each metacognitive loop
-// iteration. Current state is injected by the loop-declared output
-// context provider.
-const metacognitiveBaseTemplate = `Metacognitive loop iteration.
+// MetacognitiveBaseTemplate is the per-iteration prompt for the
+// metacognitive loop, set as the loop definition's Task. Current state
+// is injected by the loop-declared output context provider.
+const MetacognitiveBaseTemplate = `Metacognitive loop iteration.
 
 You are running as a background metacognitive process — a perpetual
 attention loop that monitors the environment, reasons about what you
@@ -48,10 +48,10 @@ names the generated replacement tool for the document.
   tools are NOT available.
 - If nothing interesting is happening, note it and sleep long.`
 
-// metacognitiveSupervisorAugmentation is appended for frontier/supervisor turns.
-const metacognitiveSupervisorAugmentation = `
-
-## Supervisor Review (Frontier Iteration)
+// MetacognitiveSupervisorInstructions is the supervisor-turn prompt
+// prefix, applied declaratively via SupervisorProfile.Instructions on
+// frontier iterations (prepended to MetacognitiveBaseTemplate).
+const MetacognitiveSupervisorInstructions = `## Supervisor Review (Frontier Iteration)
 
 This iteration was randomly selected for supervisor-level review using a
 frontier model. In addition to the normal assessment, critically evaluate:
@@ -69,15 +69,3 @@ frontier model. In addition to the normal assessment, critically evaluate:
 
 Be honest. Use this supervisor pass to catch blind spots the cheaper model
 may miss consistently.`
-
-// MetacognitivePrompt returns the prompt for a metacognitive loop
-// iteration. When isSupervisor is true, additional self-review
-// instructions are appended for frontier-model iterations.
-func MetacognitivePrompt(currentState string, isSupervisor bool) string {
-	_ = currentState // State is now injected by loop-declared output context.
-	prompt := metacognitiveBaseTemplate
-	if isSupervisor {
-		prompt += metacognitiveSupervisorAugmentation
-	}
-	return prompt
-}

--- a/internal/model/prompts/metacognitive_test.go
+++ b/internal/model/prompts/metacognitive_test.go
@@ -5,122 +5,56 @@ import (
 	"testing"
 )
 
-func TestMetacognitivePrompt_Normal(t *testing.T) {
-	state := "## Current Sense\nAll quiet."
-	result := MetacognitivePrompt(state, false)
+func TestMetacognitiveBaseTemplate(t *testing.T) {
+	got := MetacognitiveBaseTemplate
 
-	if strings.Contains(result, "All quiet.") {
-		t.Error("prompt should not inline state file content")
+	for _, phrase := range []string{
+		"Metacognitive loop iteration",
+		"Declared Durable",
+		"replace_output_metacognitive_state",
+		"set_next_sleep",
+		"exactly two special tools",
+		"File tools, exec, and session management",
+		"sanctioned interface",
+		"how recently metacognitive.md was",
+		"Do not copy raw sensor timestamps",
+	} {
+		if !strings.Contains(got, phrase) {
+			t.Errorf("base template missing expected phrase %q", phrase)
+		}
 	}
-	if !strings.Contains(result, "Declared Durable") {
-		t.Error("prompt should point to declared output context")
-	}
-	if !strings.Contains(result, "Metacognitive loop iteration") {
-		t.Error("prompt should contain base template header")
-	}
-	if strings.Contains(result, "Supervisor Review") {
-		t.Error("normal prompt should not contain supervisor augmentation")
-	}
-}
-
-func TestMetacognitivePrompt_Supervisor(t *testing.T) {
-	state := "## Current Sense\nMonitoring garage."
-	result := MetacognitivePrompt(state, true)
-
-	if strings.Contains(result, "Monitoring garage.") {
-		t.Error("supervisor prompt should not inline state file content")
-	}
-	if !strings.Contains(result, "Supervisor Review") {
-		t.Error("supervisor prompt should contain supervisor augmentation")
-	}
-	if !strings.Contains(result, "Blind spots") {
-		t.Error("supervisor prompt should contain blind spots instruction")
-	}
-	if !strings.Contains(result, "Drift detection") {
-		t.Error("supervisor prompt should contain drift detection instruction")
-	}
-	// append_ego_observation was removed in #575 — ego updates belong
-	// in the interactive agent context, not the metacog loop.
-	if strings.Contains(result, "append_ego_observation") {
-		t.Error("supervisor prompt should not reference removed append_ego_observation tool")
-	}
-}
-
-func TestMetacognitivePrompt_EmptyState(t *testing.T) {
-	result := MetacognitivePrompt("", false)
-
-	if !strings.Contains(result, "Declared Durable") {
-		t.Error("empty state prompt should rely on declared output context")
-	}
-	if !strings.Contains(result, "replace_output_metacognitive_state") {
-		t.Error("prompt should mention generated output tool")
-	}
-}
-
-func TestMetacognitivePrompt_SetNextSleepMentioned(t *testing.T) {
-	result := MetacognitivePrompt("some state", false)
-
-	if !strings.Contains(result, "set_next_sleep") {
-		t.Error("prompt should mention set_next_sleep tool")
-	}
-}
-
-func TestMetacognitivePrompt_MentionsUpdateTool(t *testing.T) {
-	result := MetacognitivePrompt("some state", false)
-
-	if !strings.Contains(result, "replace_output_metacognitive_state") {
-		t.Error("prompt should mention generated output tool")
-	}
-	if strings.Contains(result, "file_write") {
-		t.Error("prompt should not mention file_write")
-	}
-}
-
-func TestMetacognitivePrompt_FileToolsNotAvailable(t *testing.T) {
-	result := MetacognitivePrompt("some state", false)
-
-	if !strings.Contains(result, "File tools, exec, and session management") {
-		t.Error("prompt should explicitly state file tools are not available")
-	}
-	if strings.Contains(result, "Read it carefully") {
-		t.Error("prompt should not contain ambiguous 'Read it carefully' phrasing")
-	}
-}
-
-func TestMetacognitivePrompt_ToolBoundary(t *testing.T) {
-	result := MetacognitivePrompt("some state", false)
-
-	if !strings.Contains(result, "exactly two special tools") {
-		t.Error("prompt should state the two special tools available")
-	}
-	if strings.Contains(result, "append_ego_observation") {
-		t.Error("prompt should not mention removed append_ego_observation tool")
-	}
-	if !strings.Contains(result, "File tools, exec,") {
-		t.Error("prompt should explicitly list unavailable tool categories")
-	}
-}
-
-func TestMetacognitivePrompt_AvoidsRawTimestampPersistence(t *testing.T) {
-	result := MetacognitivePrompt("some state", false)
-
-	if !strings.Contains(result, "how recently metacognitive.md was") {
-		t.Error("prompt should point to generated freshness context")
-	}
-	if !strings.Contains(result, "Do not copy raw sensor timestamps") {
-		t.Error("prompt should discourage raw timestamp persistence")
-	}
-	for _, unwanted := range []string{"absolute format (RFC3339", "Deltas become meaningless"} {
-		if strings.Contains(result, unwanted) {
-			t.Fatalf("prompt should not preserve old timestamp guidance %q", unwanted)
+	for _, unwanted := range []string{
+		"Supervisor Review",         // supervisor content lives in the instructions const
+		"file_write",                // file tools are excluded
+		"append_ego_observation",    // removed in #575
+		"Read it carefully",         // ambiguous phrasing, removed
+		"absolute format (RFC3339",  // old timestamp guidance, removed
+		"Deltas become meaningless", // old timestamp guidance, removed
+	} {
+		if strings.Contains(got, unwanted) {
+			t.Errorf("base template should not contain %q", unwanted)
 		}
 	}
 }
 
-func TestMetacognitivePrompt_OnlyWriteMechanism(t *testing.T) {
-	result := MetacognitivePrompt("some state", false)
+func TestMetacognitiveSupervisorInstructions(t *testing.T) {
+	got := MetacognitiveSupervisorInstructions
 
-	if !strings.Contains(result, "sanctioned interface") {
-		t.Error("prompt should clarify the generated output tool is the only write mechanism")
+	for _, phrase := range []string{
+		"Supervisor Review",
+		"Blind spots",
+		"Drift detection",
+	} {
+		if !strings.Contains(got, phrase) {
+			t.Errorf("supervisor instructions missing expected phrase %q", phrase)
+		}
+	}
+	if strings.Contains(got, "append_ego_observation") {
+		t.Error("supervisor instructions should not reference removed append_ego_observation tool")
+	}
+	// Applied as a prepended prompt prefix via SupervisorProfile.Instructions,
+	// so it must carry no surrounding blank lines.
+	if got != strings.TrimSpace(got) {
+		t.Error("supervisor instructions must not have leading/trailing whitespace")
 	}
 }

--- a/internal/platform/config/config.go
+++ b/internal/platform/config/config.go
@@ -1829,9 +1829,8 @@ type MetacognitiveConfig struct {
 
 	// SupervisorProbability is the per-wake chance (0.0–1.0) that
 	// this iteration runs as a supervisor turn — a more capable
-	// model with the augmented prompt produced by
-	// [prompts.MetacognitivePrompt]. Default: 0.1. Set to 0.0 to
-	// disable supervisor turns entirely.
+	// model with the loop's supervisor-turn prompt prefix. Default: 0.1.
+	// Set to 0.0 to disable supervisor turns entirely.
 	SupervisorProbability *float64 `yaml:"supervisor_probability,omitempty"`
 
 	// Router configures model routing for normal (non-supervisor)
@@ -1869,9 +1868,8 @@ type EgoConfig struct {
 
 	// SupervisorProbability is the per-wake chance (0.0–1.0) that
 	// this iteration runs as a supervisor turn — a more capable
-	// model with the augmented prompt produced by
-	// [prompts.EgoPrompt]. Default: 0.2. Set to 0.0 to disable
-	// supervisor turns entirely.
+	// model with the loop's supervisor-turn prompt prefix. Default: 0.2.
+	// Set to 0.0 to disable supervisor turns entirely.
 	SupervisorProbability *float64 `yaml:"supervisor_probability,omitempty"`
 
 	// Router configures model routing for normal iterations.
@@ -1917,8 +1915,8 @@ type ArchivistConfig struct {
 
 	// SupervisorProbability is the per-wake chance (0.0–1.0) that
 	// this iteration runs as a supervisor turn — a frontier model
-	// with the augmented prompt produced by [prompts.ArchivistPrompt].
-	// Default: 0.1. Set to 0.0 to disable supervisor turns entirely.
+	// with the loop's supervisor-turn prompt prefix. Default: 0.1.
+	// Set to 0.0 to disable supervisor turns entirely.
 	SupervisorProbability *float64 `yaml:"supervisor_probability,omitempty"`
 
 	// Router configures model routing for normal iterations.

--- a/internal/runtime/archivist/archivist.go
+++ b/internal/runtime/archivist/archivist.go
@@ -23,7 +23,6 @@
 package archivist
 
 import (
-	"context"
 	"fmt"
 	"strings"
 	"time"
@@ -118,7 +117,7 @@ func DefinitionSpec(cfg Config) loop.Spec {
 	return loop.Spec{
 		Name:       DefinitionName,
 		Enabled:    cfg.Enabled,
-		Task:       "Tend thane's understanding across memory silos. Drain your work queue and refine the dossiers each item touches.",
+		Task:       prompts.ArchivistBaseTemplate,
 		Operation:  loop.OperationService,
 		Completion: loop.CompletionNone,
 		Outputs: []loop.OutputSpec{
@@ -165,30 +164,25 @@ func DefinitionSpec(cfg Config) loop.Spec {
 	}
 }
 
-// supervisorProfile builds the archivist's per-turn-mode overrides from
-// the supervisor router config. Returns nil when no overrides are
-// declared, signaling the loop runtime to reuse the normal Profile
-// during supervisor turns.
+// supervisorProfile builds the archivist's supervisor-turn overlay: the
+// frontier-review prompt prefix (always) plus a higher quality floor when
+// one is configured. Unset fields fall back to the normal Profile during
+// supervisor turns; the prefix is prepended to the Task.
 func supervisorProfile(qualityFloor int) *router.LoopProfile {
-	if qualityFloor <= 0 {
-		return nil
+	p := &router.LoopProfile{Instructions: prompts.ArchivistSupervisorInstructions}
+	if qualityFloor > 0 {
+		p.QualityFloor = qualityFloor
 	}
-	return &router.LoopProfile{
-		QualityFloor: qualityFloor,
-	}
+	return p
 }
 
-// HydrateSpec attaches the runtime-only hooks needed to execute the
-// archivist service from a durable loop definition. The TaskBuilder
-// emits the archivist prompt for each iteration; the prior state file
-// content is injected via the managed-output context provider, not this
-// prompt. The work-queue tools are attached separately at app hydration.
+// HydrateSpec defaults the definition name. The archivist's prompt is
+// declarative (the spec Task and SupervisorProfile.Instructions); its one
+// genuine runtime-only dependency — the loop-private work-queue tools — is
+// attached separately at app hydration, not here.
 func HydrateSpec(spec loop.Spec, _ Config) loop.Spec {
 	if strings.TrimSpace(spec.Name) == "" {
 		spec.Name = DefinitionName
-	}
-	spec.TaskBuilder = func(_ context.Context, isSupervisor bool) (string, error) {
-		return prompts.ArchivistPrompt(isSupervisor), nil
 	}
 	return spec
 }

--- a/internal/runtime/archivist/archivist_test.go
+++ b/internal/runtime/archivist/archivist_test.go
@@ -148,23 +148,24 @@ func TestDefinitionSpec_Outputs(t *testing.T) {
 	}
 }
 
-func TestHydrateSpec_AttachesTaskBuilder(t *testing.T) {
-	cfg := Config{Enabled: true}
+func TestSpec_DeclarativePrompt(t *testing.T) {
+	cfg := Config{Enabled: true, SupervisorProbability: 0.1}
 	spec := HydrateSpec(DefinitionSpec(cfg), cfg)
 
-	if spec.TaskBuilder == nil {
-		t.Fatal("TaskBuilder should be attached after HydrateSpec")
+	// The archivist loop is declarative: no TaskBuilder closure (its one
+	// genuine runtime hook, the work-queue tools, is attached at app
+	// hydration, not here).
+	if spec.TaskBuilder != nil {
+		t.Error("archivist loop is declarative; HydrateSpec should attach no TaskBuilder")
 	}
-	prompt, err := spec.TaskBuilder(nil, false)
-	if err != nil {
-		t.Fatalf("TaskBuilder returned error: %v", err)
+	if !strings.Contains(spec.Task, "Archivist loop iteration") {
+		t.Errorf("spec.Task should be the archivist base prompt, got %q", spec.Task)
 	}
-	if prompt == "" {
-		t.Error("TaskBuilder returned empty prompt")
+	if strings.Contains(spec.Task, "Supervisor Review") {
+		t.Error("base Task should not include the supervisor section")
 	}
-	supervisorPrompt, _ := spec.TaskBuilder(nil, true)
-	if len(supervisorPrompt) <= len(prompt) {
-		t.Error("supervisor prompt should be longer than normal prompt")
+	if spec.SupervisorProfile == nil || !strings.Contains(spec.SupervisorProfile.Instructions, "Supervisor Review") {
+		t.Error("supervisor-turn prefix should live in SupervisorProfile.Instructions")
 	}
 }
 

--- a/internal/runtime/ego/ego.go
+++ b/internal/runtime/ego/ego.go
@@ -9,7 +9,6 @@
 package ego
 
 import (
-	"context"
 	"fmt"
 	"strings"
 	"time"
@@ -91,7 +90,7 @@ func DefinitionSpec(cfg Config) loop.Spec {
 	return loop.Spec{
 		Name:       DefinitionName,
 		Enabled:    cfg.Enabled,
-		Task:       "Reflect on recent experience and update self-reflection state when warranted.",
+		Task:       prompts.EgoBaseTemplate,
 		Operation:  loop.OperationService,
 		Completion: loop.CompletionNone,
 		Outputs: []loop.OutputSpec{
@@ -125,36 +124,34 @@ func DefinitionSpec(cfg Config) loop.Spec {
 	}
 }
 
-// supervisorProfile builds the ego service's per-turn-mode
-// overrides from the supervisor router config. Returns nil when
-// no overrides are declared, signaling the loop runtime to reuse
-// the normal Profile during supervisor turns.
+// supervisorProfile builds the ego service's supervisor-turn overlay: the
+// frontier-review prompt prefix (always) plus a higher quality floor when
+// one is configured. Any field left unset falls back to the normal
+// Profile during supervisor turns; the prefix is prepended to the Task.
 func supervisorProfile(qualityFloor int) *router.LoopProfile {
-	if qualityFloor <= 0 {
-		return nil
+	p := &router.LoopProfile{Instructions: prompts.EgoSupervisorInstructions}
+	if qualityFloor > 0 {
+		p.QualityFloor = qualityFloor
 	}
-	return &router.LoopProfile{
-		QualityFloor: qualityFloor,
-	}
+	return p
 }
 
-// HydrateSpec attaches the runtime-only hooks needed to execute the ego
-// service from a durable loop definition.
-func HydrateSpec(spec loop.Spec, cfg Config) loop.Spec {
+// HydrateSpec is retained for the core-service registration shape. The ego
+// loop is fully declarative — its prompt is the spec Task and its
+// supervisor-turn prefix is SupervisorProfile.Instructions — so there are
+// no runtime-only hooks to attach beyond defaulting the name.
+func HydrateSpec(spec loop.Spec, _ Config) loop.Spec {
 	if strings.TrimSpace(spec.Name) == "" {
 		spec.Name = DefinitionName
-	}
-	spec.TaskBuilder = func(ctx context.Context, isSupervisor bool) (string, error) {
-		return prompts.EgoPrompt(isSupervisor), nil
 	}
 	return spec
 }
 
 // BuildSpec returns a [loop.Spec] that implements the ego loop as a
-// service loop. The returned spec declares the durable output document
-// and uses runtime hooks to build prompts. The supervisor prompt prefix
-// is produced by [prompts.EgoPrompt] inside the TaskBuilder, not via
-// the spec-level [SupervisorProfile.Instructions] hook.
+// service loop. The returned spec declares the durable output document;
+// the per-iteration prompt is the spec Task ([prompts.EgoBaseTemplate])
+// and the supervisor-turn prefix is the declarative
+// SupervisorProfile.Instructions ([prompts.EgoSupervisorInstructions]).
 func BuildSpec(cfg Config) loop.Spec {
 	return HydrateSpec(DefinitionSpec(cfg), cfg)
 }

--- a/internal/runtime/ego/ego_test.go
+++ b/internal/runtime/ego/ego_test.go
@@ -120,22 +120,23 @@ func TestDefinitionSpec_Outputs(t *testing.T) {
 	}
 }
 
-func TestHydrateSpec_AttachesTaskBuilder(t *testing.T) {
-	cfg := Config{Enabled: true}
+func TestSpec_DeclarativePrompt(t *testing.T) {
+	cfg := Config{Enabled: true, SupervisorProbability: 0.2}
 	spec := HydrateSpec(DefinitionSpec(cfg), cfg)
 
-	if spec.TaskBuilder == nil {
-		t.Fatal("TaskBuilder should be attached after HydrateSpec")
+	// The ego loop is fully declarative: no TaskBuilder closure.
+	if spec.TaskBuilder != nil {
+		t.Error("ego loop is declarative; HydrateSpec should attach no TaskBuilder")
 	}
-	prompt, err := spec.TaskBuilder(nil, false)
-	if err != nil {
-		t.Fatalf("TaskBuilder returned error: %v", err)
+	// The per-iteration prompt is the static Task.
+	if !strings.Contains(spec.Task, "Ego loop iteration") {
+		t.Errorf("spec.Task should be the ego base prompt, got %q", spec.Task)
 	}
-	if prompt == "" {
-		t.Error("TaskBuilder returned empty prompt")
+	if strings.Contains(spec.Task, "Supervisor Review") {
+		t.Error("base Task should not include the supervisor section")
 	}
-	supervisorPrompt, _ := spec.TaskBuilder(nil, true)
-	if len(supervisorPrompt) <= len(prompt) {
-		t.Error("supervisor prompt should be longer than normal prompt")
+	// The supervisor-turn prefix is the declarative SupervisorProfile.Instructions.
+	if spec.SupervisorProfile == nil || !strings.Contains(spec.SupervisorProfile.Instructions, "Supervisor Review") {
+		t.Error("supervisor-turn prefix should live in SupervisorProfile.Instructions")
 	}
 }

--- a/internal/runtime/metacognitive/metacognitive.go
+++ b/internal/runtime/metacognitive/metacognitive.go
@@ -162,7 +162,7 @@ func DefinitionSpec(cfg Config) loop.Spec {
 	return loop.Spec{
 		Name:       DefinitionName,
 		Enabled:    cfg.Enabled,
-		Task:       "Observe the system, reason about its recent behavior, and update metacognitive state when needed.",
+		Task:       prompts.MetacognitiveBaseTemplate,
 		Operation:  loop.OperationService,
 		Completion: loop.CompletionNone,
 		Outputs: []loop.OutputSpec{
@@ -197,28 +197,29 @@ func DefinitionSpec(cfg Config) loop.Spec {
 	}
 }
 
-// supervisorProfile builds the metacognitive service's per-turn-
-// mode overrides from the supervisor router config. Returns nil
-// when no overrides are declared, signaling the loop runtime to
-// reuse the normal Profile during supervisor turns.
+// supervisorProfile builds the metacognitive service's supervisor-turn
+// overlay: the frontier-review prompt prefix (always) plus a higher
+// quality floor when one is configured. Unset fields fall back to the
+// normal Profile during supervisor turns; the prefix is prepended to the
+// Task.
 func supervisorProfile(qualityFloor int) *router.LoopProfile {
-	if qualityFloor <= 0 {
-		return nil
+	p := &router.LoopProfile{Instructions: prompts.MetacognitiveSupervisorInstructions}
+	if qualityFloor > 0 {
+		p.QualityFloor = qualityFloor
 	}
-	return &router.LoopProfile{
-		QualityFloor: qualityFloor,
-	}
+	return p
 }
 
-// HydrateSpec attaches the runtime-only hooks needed to execute the
-// metacognitive service from a durable loop definition.
+// HydrateSpec attaches the one remaining runtime-only hook the
+// metacognitive service needs from a durable loop definition: the
+// PostIterate iteration-log writer, which appends a provenance-signed
+// telemetry block to the state document each cycle and needs the
+// resolved state-file path from opts. The prompt itself is declarative
+// (the spec Task and SupervisorProfile.Instructions).
 func HydrateSpec(spec loop.Spec, cfg Config, opts Opts) loop.Spec {
 	spec = loop.Spec(spec)
 	if strings.TrimSpace(spec.Name) == "" {
 		spec.Name = DefinitionName
-	}
-	spec.TaskBuilder = func(ctx context.Context, isSupervisor bool) (string, error) {
-		return prompts.MetacognitivePrompt("", isSupervisor), nil
 	}
 	spec.PostIterate = func(ctx context.Context, result loop.IterationResult) error {
 		log := logging.Logger(ctx)
@@ -229,14 +230,11 @@ func HydrateSpec(spec loop.Spec, cfg Config, opts Opts) loop.Spec {
 }
 
 // BuildSpec returns a [loop.Spec] that implements the metacognitive
-// loop as a service loop. The returned spec declares the durable
-// output document and uses runtime hooks to build prompts and
-// append iteration logs.
+// loop as a service loop. The per-iteration prompt is the spec Task
+// ([prompts.MetacognitiveBaseTemplate]) and the supervisor-turn prefix
+// is the declarative SupervisorProfile.Instructions; HydrateSpec adds
+// the PostIterate iteration-log writer.
 func BuildSpec(cfg Config, opts Opts) loop.Spec {
-	// TaskBuilder handles supervisor augmentation itself via
-	// prompts.MetacognitivePrompt, so SupervisorProfile.Instructions
-	// is left unset; the per-turn prompt prefix comes from the
-	// prompts package rather than the spec-level overlay.
 	return HydrateSpec(DefinitionSpec(cfg), cfg, opts)
 }
 

--- a/internal/runtime/metacognitive/metacognitive_test.go
+++ b/internal/runtime/metacognitive/metacognitive_test.go
@@ -383,11 +383,16 @@ func TestHydrateSpecAttachesLoopRuntimeHooks(t *testing.T) {
 	}
 
 	spec := HydrateSpec(DefinitionSpec(cfg), cfg, opts)
-	if spec.TaskBuilder == nil {
-		t.Fatal("TaskBuilder should be set after hydration")
+	// Declarative prompt: no TaskBuilder. The one runtime hook hydration
+	// attaches is the PostIterate iteration-log writer.
+	if spec.TaskBuilder != nil {
+		t.Fatal("metacognitive loop is declarative; HydrateSpec should attach no TaskBuilder")
+	}
+	if !strings.Contains(spec.Task, "Metacognitive loop iteration") {
+		t.Error("spec.Task should be the metacognitive base prompt")
 	}
 	if spec.PostIterate == nil {
-		t.Fatal("PostIterate should be set after hydration")
+		t.Fatal("PostIterate (iteration-log writer) should be set after hydration")
 	}
 	if spec.Setup != nil {
 		t.Fatal("HydrateSpec should not attach app-level setup hooks")
@@ -419,8 +424,11 @@ func TestBuildLoopConfig(t *testing.T) {
 	if lc.Jitter == nil || *lc.Jitter != cfg.Jitter {
 		t.Errorf("Jitter = %v, want %v", lc.Jitter, cfg.Jitter)
 	}
-	if lc.TaskBuilder == nil {
-		t.Error("TaskBuilder should be set")
+	if lc.TaskBuilder != nil {
+		t.Error("metacognitive loop is declarative; no TaskBuilder expected")
+	}
+	if !strings.Contains(lc.Task, "Metacognitive loop iteration") {
+		t.Error("lc.Task should be the metacognitive base prompt")
 	}
 	if lc.PostIterate == nil {
 		t.Error("PostIterate should be set")
@@ -447,37 +455,7 @@ func TestBuildLoopConfig(t *testing.T) {
 	}
 }
 
-func TestBuildLoopConfig_TaskBuilder(t *testing.T) {
-	tmpDir := t.TempDir()
-	cfg := testConfig()
-	statePath := filepath.Join(tmpDir, cfg.StateFile)
-	opts := Opts{
-		WorkspacePath: tmpDir,
-		StateFilePath: statePath,
-	}
-
-	// Write a state file that the old TaskBuilder path would have read.
-	// Current content now comes from declared output context instead.
-	stateContent := "## Current Sense\nAll systems nominal."
-	if err := os.WriteFile(statePath, []byte(stateContent), 0644); err != nil {
-		t.Fatalf("write state file: %v", err)
-	}
-
-	lc := BuildLoopConfig(cfg, opts)
-	prompt, err := lc.TaskBuilder(context.Background(), false)
-	if err != nil {
-		t.Fatalf("TaskBuilder: %v", err)
-	}
-
-	if strings.Contains(prompt, "All systems nominal") {
-		t.Error("TaskBuilder prompt should not inline state file content")
-	}
-	if !strings.Contains(prompt, "replace_output_metacognitive_state") {
-		t.Error("TaskBuilder prompt should mention generated output tool")
-	}
-}
-
-func TestBuildLoopConfig_TaskBuilderNoState(t *testing.T) {
+func TestBuildLoopConfig_Task(t *testing.T) {
 	tmpDir := t.TempDir()
 	cfg := testConfig()
 	opts := Opts{
@@ -486,16 +464,20 @@ func TestBuildLoopConfig_TaskBuilderNoState(t *testing.T) {
 	}
 
 	lc := BuildLoopConfig(cfg, opts)
-	prompt, err := lc.TaskBuilder(context.Background(), false)
-	if err != nil {
-		t.Fatalf("TaskBuilder: %v", err)
-	}
 
-	if strings.Contains(prompt, "does not exist yet") {
-		t.Error("TaskBuilder prompt should not carry old first-iteration placeholder")
+	// The prompt is now a static Task (no TaskBuilder); current state
+	// comes from the declared output context, not inlined into the prompt.
+	if lc.TaskBuilder != nil {
+		t.Error("metacognitive loop is declarative; no TaskBuilder expected")
 	}
-	if !strings.Contains(prompt, "Declared Durable") {
-		t.Error("TaskBuilder prompt should point to declared output context")
+	if !strings.Contains(lc.Task, "replace_output_metacognitive_state") {
+		t.Error("Task should mention the generated output tool")
+	}
+	if !strings.Contains(lc.Task, "Declared Durable") {
+		t.Error("Task should point to the declared output context")
+	}
+	if strings.Contains(lc.Task, "does not exist yet") {
+		t.Error("Task should not carry the old first-iteration placeholder")
 	}
 }
 


### PR DESCRIPTION
Refs #1086 (Phase 0). **Stacked on #1088** — until that merges, the diff below includes its commit; review just the `fb72e4f` prompt commit, or merge #1088 first.

## What & why

The three core service loops built their per-iteration prompt with a runtime `TaskBuilder` closure calling `prompts.{Ego,Metacognitive,Archivist}Prompt(isSupervisor)` — base text, with the supervisor-review section **appended** on frontier turns. That closure is exactly the kind of redundant runtime hook #1086 removes: the prompt is *data*, and the envelope already has a home for both halves.

- Export each loop's base + supervisor text as consts (`EgoBaseTemplate` / `EgoSupervisorInstructions`, …); drop the leading blank lines from the supervisor text since it's now a prefix.
- `DefinitionSpec` sets the base as the declarative spec `Task`.
- `supervisorProfile()` always carries the supervisor text in `SupervisorProfile.Instructions` (plus the quality-floor override when configured); the runtime prepends it on supervisor turns.
- Delete the `TaskBuilder` closures and the `prompts.*Prompt` combiners. `ego`/`archivist` `HydrateSpec` are now pure name-defaulting; `metacognitive` keeps only its `PostIterate` iteration-log hook.

## Behavior

The supervisor section moves from **appended** to **prepended** (it's now a prompt prefix via `SupervisorProfile.Instructions`). Each augmentation is self-contained (*"In addition to normal reflection, critically evaluate…"*), so it reads correctly in either position — verified per loop. Otherwise **no runtime change**: `ToConfig` already carries `Task`, and `buildTaskTurn` uses `Config.Task` when `TaskBuilder` is nil (loop.go:1769-1785), prepending `SupervisorProfile.Instructions` on supervisor turns — confirmed in source.

## Also

Fixes the now-dangling `[prompts.*Prompt]` Godoc links in `config.go` (a direct consequence of removing those symbols) and regenerates `examples/config.example.yaml` (3 comment blocks).

## Test plan
- [x] `just ci` green
- [x] prompts tests rewritten against the new consts (base + supervisor instructions)
- [x] runtime ego/metacog/archivist tests assert the declarative shape (no `TaskBuilder`; `Task` is the base prompt; `SupervisorProfile.Instructions` holds the review prefix; metacog still attaches `PostIterate`)
- [x] `TestCoreServiceRegistrationHydrate` updated to the new contract
- [x] Net −119 lines; no behavior change beyond the documented prepend