### PR TITLE
fix(loops): correct subscriptions[].forecast schema (type, not horizon)

### DIFF
--- a/internal/tools/loop_spec_schema.go
+++ b/internal/tools/loop_spec_schema.go
@@ -115,7 +115,7 @@ func loopSpecSchema(description string) map[string]any {
 					"properties": map[string]any{
 						"entity_id": map[string]any{"type": "string", "description": "Subscribed entity id (e.g. a Home Assistant entity)."},
 						"history":   map[string]any{"type": "array", "items": map[string]any{"type": "integer"}, "description": "Optional history windows to include."},
-						"forecast":  map[string]any{"type": "string", "description": "Optional forecast horizon to include."},
+						"forecast":  map[string]any{"type": "string", "enum": []string{"daily", "hourly", "twice_daily", "none"}, "description": "For weather.* entities, the Home Assistant forecast type to include."},
 						"ttl_seconds": map[string]any{
 							"type":        "integer",
 							"description": "Optional time-to-live; the subscription is dropped after this many seconds.",

--- a/internal/tools/loop_spec_schema_test.go
+++ b/internal/tools/loop_spec_schema_test.go
@@ -85,13 +85,17 @@ func TestLoopSpecSchemaEnumeratesAuthorableFields(t *testing.T) {
 		t.Error("output item type must carry an enum")
 	}
 
-	// subscriptions[].forecast is a Home Assistant forecast TYPE
-	// (daily/hourly/twice_daily/none), not a free-form horizon — it must
-	// carry the enum so callers send a valid value.
+	// subscriptions[].forecast is a Home Assistant forecast TYPE, not a
+	// free-form horizon — it must be a string carrying exactly the HA
+	// forecast types so a caller can't send an invalid value.
 	subs, _ := props["subscriptions"].(map[string]any)
 	subItem, _ := subs["items"].(map[string]any)
 	subProps, _ := subItem["properties"].(map[string]any)
-	if fc, _ := subProps["forecast"].(map[string]any); fc["enum"] == nil {
-		t.Error("subscriptions[].forecast must carry an enum (daily/hourly/twice_daily/none)")
+	fc, _ := subProps["forecast"].(map[string]any)
+	if fc["type"] != "string" {
+		t.Errorf("subscriptions[].forecast must be type string, got %v", fc["type"])
+	}
+	if got, _ := fc["enum"].([]string); !slices.Equal(got, []string{"daily", "hourly", "twice_daily", "none"}) {
+		t.Errorf("subscriptions[].forecast enum = %v, want [daily hourly twice_daily none]", fc["enum"])
 	}
 }

--- a/internal/tools/loop_spec_schema_test.go
+++ b/internal/tools/loop_spec_schema_test.go
@@ -84,4 +84,14 @@ func TestLoopSpecSchemaEnumeratesAuthorableFields(t *testing.T) {
 	if ot, _ := iprops["type"].(map[string]any); ot["enum"] == nil {
 		t.Error("output item type must carry an enum")
 	}
+
+	// subscriptions[].forecast is a Home Assistant forecast TYPE
+	// (daily/hourly/twice_daily/none), not a free-form horizon — it must
+	// carry the enum so callers send a valid value.
+	subs, _ := props["subscriptions"].(map[string]any)
+	subItem, _ := subs["items"].(map[string]any)
+	subProps, _ := subItem["properties"].(map[string]any)
+	if fc, _ := subProps["forecast"].(map[string]any); fc["enum"] == nil {
+		t.Error("subscriptions[].forecast must carry an enum (daily/hourly/twice_daily/none)")
+	}
 }


### PR DESCRIPTION
Refs #1086. Follow-up to the #1088 review (the comment was raised on #1089's cumulative diff *after* #1088 had already merged, so it lands as its own fix against `main`).

`EntitySubscription.Forecast` is the Home Assistant forecast **type** for `weather.*` entities — `daily` / `hourly` / `twice_daily` / `none` (see [subscription.go:35-36](internal/runtime/loop/subscription.go#L35) and the `NormalizeSubscriptionForecast` validation) — not a free-form "horizon". The enumerated schema described it as a horizon with no enum, which could mislead a caller into sending an invalid value.

- Re-describe `subscriptions[].forecast` and add `enum: [daily, hourly, twice_daily, none]`.
- Guard it in `loop_spec_schema_test.go`.

## Test plan
- [x] `just ci` green
- [x] schema test asserts the forecast enum