### PR TITLE
feat(loops): expose quality_floor / exclude_tools / metadata on thane_curate (#1086)

### DIFF
--- a/internal/tools/loop_intent_tools.go
+++ b/internal/tools/loop_intent_tools.go
@@ -230,9 +230,10 @@ func (r *Registry) registerThaneCurate() {
 			"Future modes will accept a directory ref for tree-shaped collections (multiple files maintained as a structured corpus); the output parameter shape will grow additively. " +
 			"Sleep envelope: pass sleep_min and sleep_max as Go duration strings (\"5m\", \"30m\", \"1h\"). The running loop uses set_next_sleep to self-pace within those bounds — pick them to match the topic's metabolism (tight when busy work deserves quick checks, loose when quiet periods should cost nothing). sleep_default and jitter are optional with sensible defaults. " +
 			"Tags scope the loop's tools; omit to inherit the core tag set. " +
+			"Optional quality_floor sets the loop's minimum model quality rating; exclude_tools adds tool denials on top of the always-denied human-egress set; metadata attaches opaque string labels. " +
 			"Entities is a list of Home Assistant entity subscriptions the loop should see every iteration; they are persisted on the loop's own spec and surfaced into the loop's prompt automatically. Container ancestors' subscriptions also cascade in. " +
 			"Returns the document ref, loop definition name, loop_id, output mode, the generated output tool name (output_tool) the receiving loop writes through, the count of declared entity subscriptions, and the resolved sleep envelope.",
-		ContentResolveExempt: []string{"name", "intent", "sleep_min", "sleep_max", "sleep_default", "jitter", "tags", "instructions", "output", "entities", "replace"},
+		ContentResolveExempt: []string{"name", "intent", "sleep_min", "sleep_max", "sleep_default", "jitter", "tags", "instructions", "quality_floor", "exclude_tools", "metadata", "output", "entities", "replace"},
 		Parameters: map[string]any{
 			"type": "object",
 			"properties": map[string]any{
@@ -318,6 +319,20 @@ func (r *Registry) registerThaneCurate() {
 					"type":        "string",
 					"description": "Optional steering text prepended to every iteration's task (output format guidance, what to focus on, what to skip). Persists on the spec's Profile and shows up in loop_definition_get.",
 				},
+				"quality_floor": map[string]any{
+					"type":        "integer",
+					"description": "Optional minimum model quality rating (1–10) for the loop's iterations. Omit to let the router choose; raise it for loops whose synthesis needs a stronger model.",
+				},
+				"exclude_tools": map[string]any{
+					"type":        "array",
+					"items":       map[string]any{"type": "string"},
+					"description": "Optional additional tool names to deny this loop. These layer on top of the always-denied direct human-egress tools (signal/email/notify) — they extend the denylist, they do not replace the egress floor.",
+				},
+				"metadata": map[string]any{
+					"type":                 "object",
+					"additionalProperties": map[string]any{"type": "string"},
+					"description":          "Optional opaque string-keyed metadata stored on the loop definition (surfaced by loop_definition_get).",
+				},
 				"replace": map[string]any{
 					"type":        "boolean",
 					"description": "When true, overwrite an existing definition or document of the same name/ref. Default false; the tool refuses to clobber existing artifacts.",
@@ -376,6 +391,19 @@ func (r *Registry) handleThaneCurate(ctx context.Context, args map[string]any) (
 	}
 	instructions, _ := args["instructions"].(string)
 	replace, _ := args["replace"].(bool)
+	qualityFloor := toolargs.Int(args, "quality_floor")
+	// Operator-provided tool exclusions layer ON TOP of the always-denied
+	// human-egress baseline (#696): they extend the denylist, never shrink it.
+	excludeTools := append(DirectHumanEgressToolNames(), toolargs.StringSlice(args, "exclude_tools")...)
+	var metadata map[string]string
+	if raw, ok := args["metadata"].(map[string]any); ok && len(raw) > 0 {
+		metadata = make(map[string]string, len(raw))
+		for k, v := range raw {
+			if s, ok := v.(string); ok {
+				metadata[k] = s
+			}
+		}
+	}
 
 	entities, err := parseEntityList("entities", args["entities"])
 	if err != nil {
@@ -419,13 +447,15 @@ func (r *Registry) handleThaneCurate(ctx context.Context, args map[string]any) (
 		// request_core_attention rather than contact a person directly. This
 		// matches the ego/metacognitive/archivist exclusion baseline; without
 		// it a wrong-tagged curate loop could acquire signal_send_message /
-		// email_send / ha_notify. (An operator-facing exclude_tools knob layers
-		// on top of this default in a later change.)
-		ExcludeTools: DirectHumanEgressToolNames(),
+		// email_send / ha_notify. The operator-facing exclude_tools knob
+		// (parsed above) extends this floor — it can only add denials.
+		ExcludeTools: excludeTools,
 		Profile: router.LoopProfile{
 			DelegationGating: "disabled",
+			QualityFloor:     qualityFloor,
 			Instructions:     strings.TrimSpace(instructions),
 		},
+		Metadata: metadata,
 	}
 	if err := spec.ValidatePersistable(); err != nil {
 		return "", fmt.Errorf("derived spec invalid: %w", err)

--- a/internal/tools/loop_intent_tools.go
+++ b/internal/tools/loop_intent_tools.go
@@ -391,15 +391,48 @@ func (r *Registry) handleThaneCurate(ctx context.Context, args map[string]any) (
 	}
 	instructions, _ := args["instructions"].(string)
 	replace, _ := args["replace"].(bool)
-	qualityFloor := toolargs.Int(args, "quality_floor")
+	// quality_floor: fail fast when present-but-invalid rather than silently
+	// coercing to 0 (which would drop the floor the caller asked for). Absent
+	// is fine — the router uses its default.
+	qualityFloor := 0
+	if raw, present := args["quality_floor"]; present && raw != nil {
+		n, ok := toolargs.IntOK(args, "quality_floor")
+		if !ok {
+			return "", fmt.Errorf("quality_floor must be an integer, got %v", raw)
+		}
+		qualityFloor = n
+	}
+
 	// Operator-provided tool exclusions layer ON TOP of the always-denied
-	// human-egress baseline (#696): they extend the denylist, never shrink it.
-	excludeTools := append(DirectHumanEgressToolNames(), toolargs.StringSlice(args, "exclude_tools")...)
+	// human-egress baseline (#696): a true union — trimmed, de-duplicated, and
+	// never shrinking the egress floor.
+	excludeTools := DirectHumanEgressToolNames()
+	seenExclude := make(map[string]bool, len(excludeTools))
+	for _, t := range excludeTools {
+		seenExclude[t] = true
+	}
+	for _, t := range toolargs.StringSlice(args, "exclude_tools") {
+		if t = strings.TrimSpace(t); t != "" && !seenExclude[t] {
+			seenExclude[t] = true
+			excludeTools = append(excludeTools, t)
+		}
+	}
+
+	// metadata: fail fast on a non-object, or non-string values, rather than
+	// silently dropping them so partial caller intent can't slip through.
 	var metadata map[string]string
-	if raw, ok := args["metadata"].(map[string]any); ok && len(raw) > 0 {
-		metadata = make(map[string]string, len(raw))
-		for k, v := range raw {
-			if s, ok := v.(string); ok {
+	if raw, present := args["metadata"]; present && raw != nil {
+		m, ok := raw.(map[string]any)
+		if !ok {
+			return "", fmt.Errorf("metadata must be an object with string values")
+		}
+		if len(m) > 0 {
+			metadata = make(map[string]string, len(m))
+			for k, v := range m {
+				s, ok := v.(string)
+				if !ok {
+					return "", fmt.Errorf("metadata[%q] must be a string, got %T", k, v)
+				}
 				metadata[k] = s
 			}
 		}

--- a/internal/tools/loop_intent_tools_test.go
+++ b/internal/tools/loop_intent_tools_test.go
@@ -149,6 +149,74 @@ func TestParseSleepEnvelope_Rejections(t *testing.T) {
 	}
 }
 
+// TestThaneCurate_RejectsInvalidKnobs verifies the declarative knobs fail
+// fast on malformed input rather than silently coercing or dropping it: a
+// present-but-non-integer quality_floor, and a metadata value that is not a
+// string object. Failing fast gives the model an actionable error instead
+// of a loop quietly missing the floor/labels it asked for.
+func TestThaneCurate_RejectsInvalidKnobs(t *testing.T) {
+	t.Parallel()
+
+	tempDir := t.TempDir()
+	kbDir := filepath.Join(tempDir, "kb")
+	if err := mkdirAllForTest(kbDir); err != nil {
+		t.Fatalf("mkdir kb: %v", err)
+	}
+	db, err := database.OpenMemory()
+	if err != nil {
+		t.Fatalf("open memory db: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	docStore, err := documents.NewStore(db, map[string]string{"kb": kbDir}, nil)
+	if err != nil {
+		t.Fatalf("documents.NewStore: %v", err)
+	}
+	defRegistry, err := looppkg.NewDefinitionRegistry(nil)
+	if err != nil {
+		t.Fatalf("NewDefinitionRegistry: %v", err)
+	}
+	reg := NewEmptyRegistry()
+	reg.ConfigureLoopIntentTools(LoopIntentToolDeps{
+		DocTools:   documents.NewTools(docStore),
+		Registry:   defRegistry,
+		CommitSpec: upsertCommitSpec(defRegistry),
+		LaunchDefinition: func(_ context.Context, _ string, _ looppkg.Launch) (looppkg.LaunchResult, error) {
+			return looppkg.LaunchResult{LoopID: "x"}, nil
+		},
+	})
+	tool := reg.Get("thane_curate")
+	if tool == nil {
+		t.Fatal("thane_curate not registered")
+	}
+
+	base := func() map[string]any {
+		return map[string]any{
+			"name": "knob_test", "intent": "track stuff",
+			"sleep_min": "5m", "sleep_max": "30m",
+			"output": map[string]any{"mode": "maintain", "document": "kb:knob.md"},
+		}
+	}
+	cases := []struct {
+		name    string
+		mutate  func(map[string]any)
+		wantMsg string
+	}{
+		{"fractional quality_floor", func(a map[string]any) { a["quality_floor"] = 7.2 }, "quality_floor must be an integer"},
+		{"non-numeric quality_floor", func(a map[string]any) { a["quality_floor"] = "high" }, "quality_floor must be an integer"},
+		{"metadata not an object", func(a map[string]any) { a["metadata"] = "nope" }, "metadata must be an object"},
+		{"metadata non-string value", func(a map[string]any) { a["metadata"] = map[string]any{"k": 1} }, "must be a string"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			args := base()
+			tc.mutate(args)
+			if _, err := tool.Handler(context.Background(), args); err == nil || !strings.Contains(err.Error(), tc.wantMsg) {
+				t.Errorf("err = %v, want substring %q", err, tc.wantMsg)
+			}
+		})
+	}
+}
+
 // TestThaneCurate_EndToEnd exercises the full happy path: scaffold
 // the output document with frontmatter recording loop ownership,
 // register and reconcile a service-loop definition, and launch it.
@@ -215,7 +283,7 @@ func TestThaneCurate_EndToEnd(t *testing.T) {
 		},
 		"tags":          []any{"forge"},
 		"quality_floor": float64(7),
-		"exclude_tools": []any{"exec"},
+		"exclude_tools": []any{"exec", "exec", "  email_send  "},
 		"metadata":      map[string]any{"team": "release"},
 	})
 	if err != nil {
@@ -283,8 +351,27 @@ func TestThaneCurate_EndToEnd(t *testing.T) {
 	if found.Spec.Profile.QualityFloor != 7 {
 		t.Errorf("Profile.QualityFloor = %d, want 7", found.Spec.Profile.QualityFloor)
 	}
-	if !slices.Contains(found.Spec.ExcludeTools, "exec") {
-		t.Errorf("exclude_tools knob: expected \"exec\" in ExcludeTools, got %v", found.Spec.ExcludeTools)
+	// exclude_tools is a trimmed, de-duplicated union over the egress floor:
+	// the duplicate "exec" collapses to one entry, and the whitespace-padded
+	// "  email_send  " trims and folds into the existing egress entry rather
+	// than adding a second (or a whitespace) copy.
+	countExclude := func(name string) int {
+		n := 0
+		for _, e := range found.Spec.ExcludeTools {
+			if e == name {
+				n++
+			}
+		}
+		return n
+	}
+	if countExclude("exec") != 1 {
+		t.Errorf("exclude_tools: want exactly one \"exec\", got %d in %v", countExclude("exec"), found.Spec.ExcludeTools)
+	}
+	if countExclude("email_send") != 1 {
+		t.Errorf("exclude_tools: \"email_send\" must not duplicate the egress floor, got %d", countExclude("email_send"))
+	}
+	if slices.Contains(found.Spec.ExcludeTools, "  email_send  ") {
+		t.Error("exclude_tools: surrounding whitespace must be trimmed")
 	}
 	if found.Spec.Metadata["team"] != "release" {
 		t.Errorf("Metadata[team] = %q, want release", found.Spec.Metadata["team"])

--- a/internal/tools/loop_intent_tools_test.go
+++ b/internal/tools/loop_intent_tools_test.go
@@ -213,7 +213,10 @@ func TestThaneCurate_EndToEnd(t *testing.T) {
 			"document": "kb:dashboards/pr-watchlist.md",
 			"title":    "PR Watchlist",
 		},
-		"tags": []any{"forge"},
+		"tags":          []any{"forge"},
+		"quality_floor": float64(7),
+		"exclude_tools": []any{"exec"},
+		"metadata":      map[string]any{"team": "release"},
 	})
 	if err != nil {
 		t.Fatalf("thane_curate handler: %v", err)
@@ -274,6 +277,17 @@ func TestThaneCurate_EndToEnd(t *testing.T) {
 		if !slices.Contains(found.Spec.ExcludeTools, egress) {
 			t.Errorf("curate spec ExcludeTools missing egress tool %q; got %v", egress, found.Spec.ExcludeTools)
 		}
+	}
+	// Operator declarative knobs land on the spec, with exclude_tools layered
+	// on top of the egress floor (extending it, not replacing it).
+	if found.Spec.Profile.QualityFloor != 7 {
+		t.Errorf("Profile.QualityFloor = %d, want 7", found.Spec.Profile.QualityFloor)
+	}
+	if !slices.Contains(found.Spec.ExcludeTools, "exec") {
+		t.Errorf("exclude_tools knob: expected \"exec\" in ExcludeTools, got %v", found.Spec.ExcludeTools)
+	}
+	if found.Spec.Metadata["team"] != "release" {
+		t.Errorf("Metadata[team] = %q, want release", found.Spec.Metadata["team"])
 	}
 	if _, ok := found.Spec.Metadata["scope_tag"]; ok {
 		t.Errorf("scope_tag metadata should be gone, found %v", found.Spec.Metadata["scope_tag"])


### PR DESCRIPTION
Refs #1086 — the **last Phase 0 item**.

## What & why

`thane_curate` built a deliberately narrow projection of the loop spec: an agent could set name/intent/sleep/output/tags/entities/instructions, but **not** a model quality floor, extra tool denials, or metadata — even though `loop.Spec` supports all three. This closes that gap (discoverability/ergonomics, not new capability).

| New param | → Spec field |
|---|---|
| `quality_floor` (int) | `Profile.QualityFloor` |
| `exclude_tools` ([]string) | `ExcludeTools`, **unioned on top of** the always-denied human-egress floor (#696) |
| `metadata` (obj) | `Spec.Metadata` |

`exclude_tools` is additive only — it extends the egress denylist and can never remove the floor. All three are declarative and added to `ContentResolveExempt`.

## Deliberately out of scope
- **supervisor / supervisor_prob** — exposing self-service frontier-spend to a model-authored loop is the #1024 cost class; gated behind the **Phase 2 governor** before exposure.
- **conditions** — a structured/nested feature that fits the full-spec `loop_definition_set` path (made discoverable by #1088), not the flat intent tool.

## Test plan
- [x] `just ci` green
- [x] Extended the `thane_curate` handler test: `quality_floor`→`Profile.QualityFloor`, `exclude_tools` rides on top of the egress floor (both `exec` and the egress set present), `metadata` lands on the spec