### PR TITLE
docs: correct stale documentation from the v0.10.0 pre-release audit

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,6 +30,8 @@ Thank you for your interest in contributing to Thane!
 - [Go](https://go.dev/) 1.24+
 - [just](https://just.systems/) (command runner)
 - [golangci-lint](https://golangci-lint.run/) v2.x
+- [vacuum](https://github.com/daveshanley/vacuum) (OpenAPI spec linter — `go install github.com/daveshanley/vacuum@v0.29.5`)
+- [lychee](https://github.com/lycheeverse/lychee) (markdown link checker)
 
 ### Workflow
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ workflow and credential requirements.
 ### Extend It
 
 - [Delegation & MCP](docs/understanding/delegation.md) — Orchestrator/delegate pattern and MCP tool servers
-- [Tools Reference](docs/reference/tools.md) — All 150+ native tools
+- [Tools Reference](docs/reference/tools.md) — Reference for all native tools
 - [Full Documentation](docs/) — Guided tour of all docs
 
 ## Name

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Everything runs on your hardware, behind your firewall. Thane works with any mod
 git clone https://github.com/nugget/thane-ai-agent.git
 cd thane-ai-agent
 just build && just init
-# Edit ~/Thane/config.yaml with your HA token, Ollama URL, and MQTT broker
+# Edit ./Thane/config.yaml with your HA token, Ollama URL, and MQTT broker
 just serve
 ```
 
@@ -81,7 +81,7 @@ workflow and credential requirements.
 ### Extend It
 
 - [Delegation & MCP](docs/understanding/delegation.md) — Orchestrator/delegate pattern and MCP tool servers
-- [Tools Reference](docs/reference/tools.md) — All 80+ native tools
+- [Tools Reference](docs/reference/tools.md) — All 150+ native tools
 - [Full Documentation](docs/) — Guided tour of all docs
 
 ## Name

--- a/docs/operating/configuration.md
+++ b/docs/operating/configuration.md
@@ -114,12 +114,12 @@ running as a daemon with JSON-RPC over Unix socket.
 ## Contacts & CardDAV
 
 ```yaml
-contacts:
-  carddav:
-    enabled: true
-    port: 8843
-    username: thane
-    password: your_password
+carddav:
+  enabled: true
+  listen:
+    - 127.0.0.1:8843
+  username: thane
+  password: your_password
 ```
 
 The contact directory is always active. The CardDAV server is optional —
@@ -139,8 +139,9 @@ companion:
 Optional. Companion apps connect inward to Thane and expose local host
 capabilities, such as macOS Calendar access from
 [thane-agent-macos](https://github.com/nugget/thane-agent-macos).
-Use `companion:` for new configs. Older `platform:` configs still load as
-a compatibility alias.
+Use `companion:`. A top-level `platform:` section is rejected at config
+load with an actionable error and must be renamed to `companion:` (the
+field shape is unchanged).
 
 ## Capability Tags
 
@@ -148,7 +149,7 @@ a compatibility alias.
 capability_tags:
   project_ops:
     description: "Project-specific research and archive tools"
-    tools: [archive_search, web_search]
+    include: [archive_search, web_search]
 ```
 
 Thane ships with a compiled-in capability-tag catalog for native and
@@ -368,8 +369,20 @@ See [Delegation](../understanding/delegation.md).
 listen:
   address: "0.0.0.0"
   port: 8080
-  ollama_port: 11434
+
+ollama_api:
+  enabled: true
+  address: ""
+  port: 11434
+
+openai_api:
+  enabled: true
+  address: ""
+  port: 8081
 ```
 
-Network binding for the API servers. Default is localhost-only; set to
-`0.0.0.0` to accept connections from other hosts.
+Network binding for the API servers. `listen:` binds the native Thane
+/v1 API and web dashboard (default port 8080). The optional
+Ollama-compatible (port 11434) and OpenAI-compatible (port 8081) shims
+bind separately under their own blocks. Default is localhost-only; set
+`address` to `0.0.0.0` to accept connections from other hosts.

--- a/docs/operating/getting-started.md
+++ b/docs/operating/getting-started.md
@@ -92,8 +92,9 @@ just serve
 ~/Thane/bin/thane ask "Hello!"
 ```
 
-The server starts three listeners:
-- `http://localhost:8080` — Native API (OpenAI-compatible) + operational dashboard
+The server starts these listeners:
+- `http://localhost:8080` — Native Thane /v1 API + operational dashboard
+- `http://localhost:8081` — OpenAI-compatible API (optional)
 - `http://localhost:11434` — Ollama-compatible API (for Home Assistant)
 - `http://localhost:8843` — CardDAV server (for contact sync)
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -22,6 +22,7 @@ views). The OpenAI-compatible shim runs on its own port (see below).
 | Method | Path | Purpose |
 | --- | --- | --- |
 | `GET` | `/` | Embedded Cognition Engine dashboard. |
+| `GET` | `/docs` | Interactive OpenAPI explorer (Scalar) for the API. |
 | `GET` | `/health` | Dependency health for service monitoring. |
 | `GET` | `/v1/version` | Build and runtime metadata. |
 | `GET` | `/v1/system` | Slim system rollup: status, dependency health, `uptime_seconds`, version. |

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1,6 +1,6 @@
 # CLI Reference
 
-Thane ships as a single binary with seven commands.
+Thane ships as a single binary with eight commands.
 
 ```
 $ thane --help
@@ -15,6 +15,7 @@ Commands:
   ask          Ask a single question (for testing)
   ingest       Import markdown docs into fact store
   caps         Show resolved capability tags from a running daemon
+  health [url] Probe a running daemon's /health endpoint (exit 0 if healthy)
   version      Show version information
 
 Flags:
@@ -30,8 +31,9 @@ Start the API server. This is the primary runtime mode — Thane runs as a
 long-lived process serving APIs, processing events, and managing scheduled
 tasks.
 
-Starts three listeners:
-- **Port 8080** — Native API (OpenAI-compatible) + web dashboard
+Starts these listeners:
+- **Port 8080** — Native Thane /v1 API + web dashboard
+- **Port 8081** — OpenAI-compatible API (optional)
 - **Port 11434** — Ollama-compatible API (for Home Assistant)
 - **Port 8843** — CardDAV server (for contact sync)
 
@@ -99,6 +101,18 @@ the daemon to be running.
 thane caps
 thane caps -x          # include tags the operator overlay excluded
 thane -o json caps     # structured output
+```
+
+### `thane health`
+
+Probe a running daemon's `/health` endpoint and exit 0 if it reports
+healthy, non-zero otherwise. Useful as a liveness check in scripts,
+supervisors, or container health probes. Takes an optional URL; defaults
+to the local daemon if omitted.
+
+```bash
+thane health
+thane health http://127.0.0.1:8080/health
 ```
 
 ### `thane version`

--- a/docs/reference/event-sources.md
+++ b/docs/reference/event-sources.md
@@ -8,7 +8,7 @@ came from.
 ## API Requests
 
 The most direct path. A user types in the web dashboard, a client calls the
-OpenAI-compatible API on port 8080, or Home Assistant sends a conversation
+OpenAI-compatible API on port 8081, or Home Assistant sends a conversation
 through the Ollama-compatible API on port 11434.
 
 API requests carry a conversation ID for session continuity and can specify

--- a/docs/understanding/architecture.md
+++ b/docs/understanding/architecture.md
@@ -81,7 +81,7 @@ window.
 
 Talent files bridge the knowledge gap. The orchestrator doesn't see
 delegate tool schemas directly (they're gated by tags), but
-`delegate-hints.md` teaches it what tools exist, what patterns work,
+`delegation.md` teaches it what tools exist, what patterns work,
 and what anti-patterns to avoid. The frontier model writes precise
 delegation prompts without ever seeing the tool definitions.
 See [Delegation](delegation.md).
@@ -212,7 +212,7 @@ native Ollama integration connects without modification. From HA's
 perspective, Thane *is* an Ollama instance. No custom integration, no
 HACS, no protocol adapters.
 
-The **OpenAI-compatible API** on port 8080 means any client that speaks
+The **OpenAI-compatible API** on port 8081 means any client that speaks
 the chat completions API works out of the box. Open WebUI, custom
 scripts, other agents.
 

--- a/docs/understanding/architecture.md
+++ b/docs/understanding/architecture.md
@@ -81,7 +81,7 @@ window.
 
 Talent files bridge the knowledge gap. The orchestrator doesn't see
 delegate tool schemas directly (they're gated by tags), but
-`delegation.md` teaches it what tools exist, what patterns work,
+the `talents/delegation.md` talent teaches it what tools exist, what patterns work,
 and what anti-patterns to avoid. The frontier model writes precise
 delegation prompts without ever seeing the tool definitions.
 See [Delegation](delegation.md).

--- a/docs/understanding/context-layers.md
+++ b/docs/understanding/context-layers.md
@@ -41,15 +41,13 @@ interaction styles.
 
 **Does NOT contain:** Identity statements, personal history, factual knowledge.
 
-**Shipped talents:**
-- `channel-awareness.md` — adapt output to the communication channel
-- `conversational.md` — natural dialogue patterns
-- `engagement-mirroring.md` — match the user's energy level
-- `judicious-presence.md` — know when to speak vs stay silent
-- `proactive-curiosity.md` — take initiative, explore, suggest
-- `spatial-reasoning.md` — understand physical spaces and locations
-- `time-awareness.md` — reason about time, schedules, urgency
-- `tool-guidance.md` — when and how to use tools
+**Shipped talents:** a growing, tag-organized set under `talents/`.
+Foundation talents load on every turn; domain talents load only when
+their capability tags are active. A few examples:
+- `foundation.md` — baseline behavioral patterns loaded always
+- `communication.md` — how to phrase and shape output
+- `presence.md` — when to speak vs stay silent
+- `awareness.md` — situational and contextual reasoning
 
 Custom talents: add `.md` files to the talents directory. They're loaded
 alphabetically and injected into the system prompt. Talents are tag-filtered
@@ -117,7 +115,7 @@ conversation history.
 
 | Anti-Pattern | Problem | Fix |
 |---|---|---|
-| Tool rules in persona | Suppresses personality (e.g., "only use tools when asked" kills proactive behavior) | Move to `tool-guidance.md` talent |
+| Tool rules in persona | Suppresses personality (e.g., "only use tools when asked" kills proactive behavior) | Move to a behavioral talent |
 | Identity in talents | Confusing — talent says "you are X" but persona says "you are Y" | Keep identity in persona only |
 | Behavioral directives in core context | Core context is knowledge, not instructions | Move directives to talents |
 | Static time in build info | Model treats version metadata as ignorable | Use Current Conditions section |

--- a/docs/understanding/delegation.md
+++ b/docs/understanding/delegation.md
@@ -66,7 +66,7 @@ The orchestrator model doesn't see tool definitions directly (they're gated).
 Instead, **talent files** teach it what's available and how to write effective
 delegation prompts.
 
-`delegate-hints.md` contains:
+`delegation.md` contains:
 - Which capability tags and tool families exist
 - Patterns to follow (search, act, verify for HA)
 - Anti-patterns to avoid (multi-entity delegations, `ha_list_entities` abuse)
@@ -169,5 +169,5 @@ specific the prompt, the fewer iterations wasted:
 
 **Bad:** "Find the Hue Go light in the office and make it teal."
 
-The delegate-hints talent teaches the orchestrator these patterns. Over
+The delegation talent teaches the orchestrator these patterns. Over
 time, as delegation successes and failures are observed, the talent evolves.

--- a/docs/understanding/delegation.md
+++ b/docs/understanding/delegation.md
@@ -66,7 +66,7 @@ The orchestrator model doesn't see tool definitions directly (they're gated).
 Instead, **talent files** teach it what's available and how to write effective
 delegation prompts.
 
-`delegation.md` contains:
+The `talents/delegation.md` talent contains:
 - Which capability tags and tool families exist
 - Patterns to follow (search, act, verify for HA)
 - Anti-patterns to avoid (multi-entity delegations, `ha_list_entities` abuse)
@@ -169,5 +169,5 @@ specific the prompt, the fewer iterations wasted:
 
 **Bad:** "Find the Hue Go light in the office and make it teal."
 
-The delegation talent teaches the orchestrator these patterns. Over
+The `talents/delegation.md` talent teaches the orchestrator these patterns. Over
 time, as delegation successes and failures are observed, the talent evolves.

--- a/docs/understanding/glossary.md
+++ b/docs/understanding/glossary.md
@@ -183,6 +183,15 @@ service loop with bounded voluntary sleep, supervisor randomization,
 and a declared maintained-document output. The interactive agent reads
 `ego.md` every turn; the ego loop is the sole writer.
 
+### Archivist Loop
+
+The third peer service loop introduced in v0.10.0. A self-paced,
+queue-driven loop that synthesizes durable knowledge across the memory
+silos into per-subject dossiers and maintains `core/archivist.md` via a
+declared maintained-document output. Rather than waking on every event,
+it consumes work from a queue at its own pace, keeping synthesis steady
+without saturating the model.
+
 ### Orchestrator
 
 The primary model in a delegation interaction. Plans the approach,

--- a/internal/platform/config/gen/gencfg/main.go
+++ b/internal/platform/config/gen/gencfg/main.go
@@ -351,7 +351,7 @@ func buildValueNode(v reflect.Value, t reflect.Type, comments commentMap) *yaml.
 	// path emits "null". In a commented-out section the caller already
 	// has a non-nil value from ExampleConfig, but if somehow we reach nil
 	// here, synthesize a zero value so the YAML block is still meaningful.
-	if t.Kind() == reflect.Ptr {
+	if t.Kind() == reflect.Pointer {
 		if v.IsNil() {
 			zv := reflect.New(t.Elem()).Elem()
 			return buildValueNode(zv, t.Elem(), comments)


### PR DESCRIPTION
## Summary
Phase-1 documentation audit of the v0.9.2..HEAD release surface found docs drifted from the implementation. Several `configuration.md` examples **would fail to load as written** — those are the highest-value fixes here.

## Config examples that no longer load (now fixed)
- **CardDAV** is a top-level `carddav:` key with `listen: ["127.0.0.1:8843"]` — not `contacts.carddav.port`.
- **Capability tags** use `include:` — the `tools:` sub-key was removed.
- **`listen:`** has no `ollama_port`; the Ollama (11434) and OpenAI (8081) shims are separate `ollama_api:`/`openai_api:` blocks.
- A top-level **`platform:`** section is now hard-rejected (renamed to `companion:`), not a compat alias.

## Other accuracy fixes
- **Ports**: the OpenAI-compatible shim is on its own port **8081** (8080 = native /v1 + dashboard) — fixed in architecture.md, cli.md, event-sources.md, getting-started.md.
- **Talents**: `delegate-hints.md`→`delegation.md`; context-layers.md's stale 8-file "shipped talents" list (none existed) replaced with an accurate tag-organized description.
- **glossary.md**: added the Archivist loop (third peer service loop).
- **cli.md**: now documents eight commands (added `health`); api.md notes the `/docs` Scalar explorer.
- **CONTRIBUTING.md**: Prerequisites now list `vacuum` + `lychee` (both required by `just ci`).

## Also
- Inlines `reflect.Ptr`→`reflect.Pointer` in gencfg (a govet `inline` finding from golangci-lint 2.12, newer than CI's pinned 2.9.0) to keep the local gate green. Forward-compatible; no generated-output change.

## Test plan
- [x] `just ci` green (incl. `lychee` link-check: 0 errors)
- [x] Residual stale-pattern sweep clean (`delegate-hints`, `ollama_port`, stale talent names, `8080.*OpenAI` all gone)
- [x] Config examples cross-checked against `examples/config.example.yaml`

Part of the v0.10.0 pre-release Phase-1 audit. Code-hygiene and model-facing fixes follow in separate PRs.