### PR TITLE
refactor: code-hygiene cleanup from the v0.10.0 pre-release audit

### DIFF
--- a/cmd/prewarm-replay/stores.go
+++ b/cmd/prewarm-replay/stores.go
@@ -26,9 +26,11 @@ type stores struct {
 }
 
 // openStores opens the prod databases under dataDir in read-only
-// mode. Returns a stores struct with both raw *sql.DB handles (so
-// the harness can run ad-hoc queries against conversations metadata)
-// and the high-level wrapper stores that the providers expect.
+// mode. Returns a stores struct holding the raw thane *sql.DB handle
+// (which backs the harness's ad-hoc conversations-metadata and search
+// queries) alongside the high-level wrapper stores that the providers
+// expect. The raw knowledge handle is retained only for lifecycle
+// cleanup; knowledge access goes through its wrapper store.
 //
 // modernc.org/sqlite respects URI query parameters when the DSN begins
 // with "file:". `mode=ro` opens read-only,

--- a/cmd/thane/main.go
+++ b/cmd/thane/main.go
@@ -45,8 +45,6 @@ import (
 	"github.com/nugget/thane-ai-agent/internal/runtime/agent"
 	"github.com/nugget/thane-ai-agent/internal/state/knowledge"
 	"github.com/nugget/thane-ai-agent/internal/state/memory"
-
-	_ "modernc.org/sqlite" // SQLite driver for database/sql
 )
 
 // main is intentionally minimal. It constructs the OS-level environment

--- a/internal/app/adapters.go
+++ b/internal/app/adapters.go
@@ -821,9 +821,9 @@ func resolveSignalContact(store *contacts.Store, phone string) string {
 	return ""
 }
 
-// logQueryAdapter bridges the web package's [web.LogQuerier] interface
-// to the [logging.Query] function, keeping the web package decoupled
-// from database/sql.
+// logQueryAdapter bridges [logging.Query] to the api server's log-query
+// seam (server.UseLogQuerier), keeping the api package decoupled from
+// database/sql.
 type logQueryAdapter struct {
 	db *sql.DB
 }

--- a/internal/app/loop_definition_builtins.go
+++ b/internal/app/loop_definition_builtins.go
@@ -22,11 +22,6 @@ const (
 	telemetryDefinitionName       = "telemetry"
 )
 
-// mqttDefaultHandlerName is the in-app alias for the mqtt package's
-// built-in default-handler loop name. Aliased here so the builtin
-// spec literal reads cleanly alongside the other naming constants.
-var mqttDefaultHandlerName = mqtt.DefaultHandlerLoopName
-
 func builtInServiceDefinitionSpecs(cfg *config.Config) []looppkg.Spec {
 	if cfg == nil {
 		return nil
@@ -197,7 +192,7 @@ func builtInServiceDefinitionSpecs(cfg *config.Config) []looppkg.Spec {
 		// model decides what to do based on the topic + payload — no
 		// hardcoded routing, no inline-Profile spawn.
 		specs = append(specs, looppkg.Spec{
-			Name:       mqttDefaultHandlerName,
+			Name:       mqtt.DefaultHandlerLoopName,
 			Enabled:    true,
 			Task:       "Triage MQTT wake events: inspect topic and payload, then act or escalate.",
 			Operation:  looppkg.OperationEventDriven,

--- a/internal/app/loop_definition_runtime.go
+++ b/internal/app/loop_definition_runtime.go
@@ -363,7 +363,7 @@ func (r *loopDefinitionRuntime) StartEnabledServices(ctx context.Context) (loopD
 	// with no inheritance. Order them by ancestry depth (roots first,
 	// nested second) before spawning. Services come last because they
 	// can sit under containers but never the other way around.
-	containerSpecs, serviceSpecs := splitContainerSpecs(snap.Definitions, r.nowTime)
+	containerSpecs, serviceSpecs := splitContainerSpecs(snap.Definitions)
 	// Count non-durable definitions (request_reply, background_task)
 	// up front so the accounting still matches the pre-refactor
 	// behavior. Partitioning silently drops them, so we surface them
@@ -428,9 +428,8 @@ func (r *loopDefinitionRuntime) bootstrapDefinitionSpawn(ctx context.Context, de
 // second pass — both are persistent and may sit under containers but
 // never the other way around. Non-durable operations (request_reply,
 // background_task) are dropped — they're transient and shouldn't be
-// hydrated at startup at all. nowTime is unused today but threaded
-// through so future condition-driven ordering doesn't reshape the API.
-func splitContainerSpecs(defs []looppkg.DefinitionSnapshot, _ func() time.Time) (containers, services []looppkg.DefinitionSnapshot) {
+// hydrated at startup at all.
+func splitContainerSpecs(defs []looppkg.DefinitionSnapshot) (containers, services []looppkg.DefinitionSnapshot) {
 	byName := make(map[string]looppkg.DefinitionSnapshot, len(defs))
 	for _, def := range defs {
 		byName[def.Spec.Name] = def

--- a/internal/app/loop_queue_tools.go
+++ b/internal/app/loop_queue_tools.go
@@ -35,7 +35,7 @@ func buildLoopQueueTools(store *loopqueue.Store, loopName string) []looppkg.Runt
 		{
 			Name: "queue_pull",
 			Description: "Pull a batch of pending work items from your queue, highest priority first then oldest. " +
-				"Each item gives a subject (the key you pass to queue_ack), its source, a short summary, priority, age, and attempts — not the full payload. " +
+				"Each item gives a subject (the key you pass to queue_ack), its source, a short summary, priority, and age — not the full payload. " +
 				"Items stay queued until you queue_ack them, so an interrupted iteration just re-serves them next time. This is your inbox: drain it; you are never paged.",
 			SkipContentResolve: true,
 			Parameters: map[string]any{

--- a/internal/app/loop_queue_tools.go
+++ b/internal/app/loop_queue_tools.go
@@ -72,7 +72,6 @@ func buildLoopQueueTools(store *loopqueue.Store, loopName string) []looppkg.Runt
 						Summary:  summary,
 						Priority: it.Priority,
 						Age:      promptfmt.FormatDeltaOnly(it.EnqueuedAt, now),
-						Attempts: it.Attempts,
 					})
 				}
 				return toQueueJSON(queuePullResult{Count: len(views), Items: views})
@@ -165,7 +164,6 @@ type queueItemView struct {
 	Summary  string `json:"summary,omitempty"`
 	Priority int    `json:"priority"`
 	Age      string `json:"age,omitempty"`
-	Attempts int    `json:"attempts"`
 }
 
 type queuePullResult struct {

--- a/internal/app/serve.go
+++ b/internal/app/serve.go
@@ -11,7 +11,10 @@ import (
 
 // Serve starts the API server(s), registers signal handlers for graceful
 // shutdown, and blocks until the server stops. It returns nil on clean
-// shutdown and a non-nil error only when the server fails unexpectedly.
+// shutdown. A non-nil error means one of two things: the server failed
+// unexpectedly, or the memory guard tripped its hard limit and triggered
+// an intentional restart so the supervising wrapper relaunches the
+// process. The latter is a deliberate self-restart, not a failure.
 //
 // Cleanup of all resources opened during [New] is handled by
 // [App.shutdown], which Serve defers at entry.

--- a/internal/channels/messages/event_source.go
+++ b/internal/channels/messages/event_source.go
@@ -79,7 +79,8 @@ func (t LoopWakeTarget) Destination() (Destination, error) {
 
 // ParseLoopWakeTarget decodes the wake_loop tool argument shape used by
 // source-specific subscription tools. A string is treated as a loop name; an
-// object accepts loop_id, name, force_supervisor, priority, and instructions.
+// object accepts loop_id, name, force_supervisor, priority, instructions, and
+// tags.
 func ParseLoopWakeTarget(raw any) (LoopWakeTarget, bool, error) {
 	switch v := raw.(type) {
 	case nil:

--- a/internal/integrations/homeassistant/entity_metadata.go
+++ b/internal/integrations/homeassistant/entity_metadata.go
@@ -9,9 +9,12 @@ import (
 // relationships should be included with an entity representation.
 // Zero value means "state only."
 type EntityMetadataIncludes struct {
-	Area        bool `yaml:"area,omitempty" json:"area,omitempty"`
-	Device      bool `yaml:"device,omitempty" json:"device,omitempty"`
-	Labels      bool `yaml:"labels,omitempty" json:"labels,omitempty"`
+	Area   bool `yaml:"area,omitempty" json:"area,omitempty"`
+	Device bool `yaml:"device,omitempty" json:"device,omitempty"`
+	Labels bool `yaml:"labels,omitempty" json:"labels,omitempty"`
+	// Description gates the whole human-facing identity projection
+	// (friendly/registry names, aliases, icon, device class, entity
+	// category, capabilities), not just the description text.
 	Description bool `yaml:"description,omitempty" json:"description,omitempty"`
 	Visibility  bool `yaml:"visibility,omitempty" json:"visibility,omitempty"`
 }

--- a/internal/model/router/loopprofile.go
+++ b/internal/model/router/loopprofile.go
@@ -14,7 +14,7 @@ import (
 //
 // Each field maps to a well-known routing hint or agent.Request
 // property. Zero-value fields are omitted during serialization and
-// ignored by [LoopProfile.Hints].
+// ignored by [LoopProfile.RoutingFactors].
 type LoopProfile struct {
 	// Model sets an explicit model, bypassing the router. When empty,
 	// the router selects based on the other hint fields.

--- a/internal/model/toolcatalog/catalog.go
+++ b/internal/model/toolcatalog/catalog.go
@@ -77,11 +77,10 @@ type BuiltinTagSpec struct {
 	// the tag menu and tag_inspect output.
 	Description string
 
-	// Core tags are pinned in every scope by operator configuration.
-	// Survives capability-tag filtering; cannot be deactivated by the
-	// model. Re-seeded each run from config — not a property of
-	// individual built-in tags, but operators can set it via the
-	// capability_tags YAML overlay.
+	// Core marks a tag as pinned in every scope — it survives
+	// capability-tag filtering and cannot be deactivated by the model.
+	// Re-seeded each run from operator configuration; operators set it
+	// via the capability_tags YAML overlay.
 	Core bool
 
 	// Kind classifies the tag's surface role. Zero value is treated

--- a/internal/platform/config/gen/gencfg/main.go
+++ b/internal/platform/config/gen/gencfg/main.go
@@ -351,7 +351,7 @@ func buildValueNode(v reflect.Value, t reflect.Type, comments commentMap) *yaml.
 	// path emits "null". In a commented-out section the caller already
 	// has a non-nil value from ExampleConfig, but if somehow we reach nil
 	// here, synthesize a zero value so the YAML block is still meaningful.
-	if t.Kind() == reflect.Ptr {
+	if t.Kind() == reflect.Pointer {
 		if v.IsNil() {
 			zv := reflect.New(t.Elem()).Elem()
 			return buildValueNode(zv, t.Elem(), comments)

--- a/internal/platform/scheduler/store.go
+++ b/internal/platform/scheduler/store.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/nugget/thane-ai-agent/internal/platform/database"
-	_ "modernc.org/sqlite"
 )
 
 // Store handles task and execution persistence.

--- a/internal/runtime/agent/loop.go
+++ b/internal/runtime/agent/loop.go
@@ -1162,7 +1162,8 @@ func (l *Loop) buildSystemPromptWithProfileSections(ctx context.Context, userMes
 			IncludeAlways: !taskPrompt && !tools.SuppressAlwaysContextFromContext(ctx),
 		}
 		for _, contextSection := range assembler.BuildSections(haCtx, req) {
-			appendTrackedMarkdown(strings.ToUpper(contextSection.Title), 2, contextSection.Title, contextSection.Content)
+			title := contextSection.Bucket.Title()
+			appendTrackedMarkdown(strings.ToUpper(title), 2, title, contextSection.Content)
 		}
 	}
 

--- a/internal/runtime/agent/model_selection.go
+++ b/internal/runtime/agent/model_selection.go
@@ -288,15 +288,6 @@ func messagesNeedImages(msgs []Message) bool {
 	return false
 }
 
-func estimateRequestContextTokens(systemPrompt string, msgs []Message) int {
-	total := roughTokenCount(systemPrompt)
-	for _, msg := range msgs {
-		total += roughTokenCount(msg.Content)
-		total += len(msg.Images) * estimatedImageContextTokens
-	}
-	return total
-}
-
 func estimateLLMMessagesContextTokens(msgs []llm.Message) int {
 	total := 0
 	for _, msg := range msgs {

--- a/internal/runtime/agent/model_selection_test.go
+++ b/internal/runtime/agent/model_selection_test.go
@@ -1160,22 +1160,6 @@ func TestRun_ExplicitModelRetriesWithoutToolsWhenLMStudioAlreadyAtMaxContext(t *
 	}
 }
 
-func TestEstimateRequestContextTokens_IncludesImages(t *testing.T) {
-	got := estimateRequestContextTokens("abcd", []Message{{
-		Role:    "user",
-		Content: "abcdefgh",
-		Images: []llm.ImageContent{
-			{Data: validTinyPNGBase64ForAgentTest(), MediaType: "image/png"},
-			{Data: validTinyPNGBase64ForAgentTest(), MediaType: "image/png"},
-		},
-	}})
-
-	want := 1 + 2 + (2 * estimatedImageContextTokens)
-	if got != want {
-		t.Fatalf("estimateRequestContextTokens() = %d, want %d", got, want)
-	}
-}
-
 func TestNoEligibleImageRoutingError_IncludesContextHint(t *testing.T) {
 	cat, err := fleet.BuildCatalog(&config.Config{
 		Models: config.ModelsConfig{

--- a/internal/runtime/agent/tag_context.go
+++ b/internal/runtime/agent/tag_context.go
@@ -487,7 +487,6 @@ func (a *contextAccumulator) sections() []agentctx.ContextSection {
 		}
 		sections = append(sections, agentctx.ContextSection{
 			Bucket:  bucket,
-			Title:   bucket.Title(),
 			Content: buf.String(),
 		})
 	}

--- a/internal/runtime/agent/tag_context_test.go
+++ b/internal/runtime/agent/tag_context_test.go
@@ -615,8 +615,8 @@ func TestTagContextAssembler_BuildSectionsBuckets(t *testing.T) {
 		if sections[i].Bucket != want.bucket {
 			t.Fatalf("section %d bucket = %q, want %q", i, sections[i].Bucket, want.bucket)
 		}
-		if sections[i].Title != want.title {
-			t.Fatalf("section %d title = %q, want %q", i, sections[i].Title, want.title)
+		if sections[i].Bucket.Title() != want.title {
+			t.Fatalf("section %d title = %q, want %q", i, sections[i].Bucket.Title(), want.title)
 		}
 		if !strings.Contains(sections[i].Content, want.content) {
 			t.Fatalf("section %d content = %q, want marker %q", i, sections[i].Content, want.content)

--- a/internal/runtime/agentctx/request.go
+++ b/internal/runtime/agentctx/request.go
@@ -119,7 +119,6 @@ func (b ContextBucket) OrDefault(fallback ContextBucket) ContextBucket {
 // placement and retained section metadata.
 type ContextSection struct {
 	Bucket  ContextBucket
-	Title   string
 	Content string
 }
 

--- a/internal/runtime/archivist/archivist.go
+++ b/internal/runtime/archivist/archivist.go
@@ -188,8 +188,9 @@ func HydrateSpec(spec loop.Spec, _ Config) loop.Spec {
 }
 
 // BuildSpec returns a [loop.Spec] that implements the archivist loop as
-// a service loop. The returned spec declares the durable output document
-// and uses runtime hooks to build prompts.
+// a service loop. The per-iteration prompt is the spec Task
+// ([prompts.ArchivistBaseTemplate]) and the supervisor-turn prefix is the
+// declarative SupervisorProfile.Instructions.
 func BuildSpec(cfg Config) loop.Spec {
 	return HydrateSpec(DefinitionSpec(cfg), cfg)
 }

--- a/internal/runtime/loop/config.go
+++ b/internal/runtime/loop/config.go
@@ -618,7 +618,9 @@ type Status struct {
 	// when the loop is queried in isolation (tests that build a
 	// Status manually) AND when the loop is registered but has no
 	// effective tags to report — readers can't distinguish the two
-	// from this field alone.
+	// from this field alone. This nil-conflation is ambiguous by
+	// design and is an accepted v0.10.0 trade-off; the same applies
+	// to the sibling Effective* fields below.
 	EffectiveTags []EffectiveTag `json:"effective_tags,omitempty"`
 	// EffectiveSubscriptions is the post-ancestor-merge view of this
 	// loop's entity subscriptions, with provenance on each entry.

--- a/internal/runtime/loop/signals.go
+++ b/internal/runtime/loop/signals.go
@@ -415,7 +415,8 @@ func (l *Loop) sleep(ctx context.Context, d time.Duration) bool {
 // cancelled. The notification path used by event-driven loops
 // (operation=event_driven without a [Config.WaitFunc]) — these loops
 // have no periodic timer to wake on, so they wait indefinitely on
-// the notification channel that [Loop.Notify] writes into.
+// the wakeCh that [Loop.enqueueNotify] writes into (reached via the
+// [Registry.NotifyLoop] delivery path).
 //
 // Returns true on wake (a notification arrived; the caller should
 // continue to the iteration phase, where consumePendingNotifies

--- a/internal/runtime/loop/spec.go
+++ b/internal/runtime/loop/spec.go
@@ -29,8 +29,8 @@ const (
 	// used to group related loops and hold inheritable state (tags,
 	// entity subscriptions) that descendants pick up at iteration
 	// time. Container loops occupy registry entries, take a
-	// parent_id, carry metadata and a scope_tag, but never wake and
-	// never run a Task. See [Spec.Validate] for the shape contract.
+	// parent_id, carry metadata, but never wake and never run a Task.
+	// See [Spec.Validate] for the shape contract.
 	//
 	// The container with the well-known name [CoreLoopName] is the
 	// graph's structural root — pid-0 equivalent. Core is not a

--- a/internal/runtime/metacognitive/metacognitive.go
+++ b/internal/runtime/metacognitive/metacognitive.go
@@ -11,11 +11,13 @@
 // model's consistent reasoning patterns miss. The per-wake
 // probability is driven by [Config.SupervisorProbability]; when a
 // supervisor turn fires, the loop overlays
-// [Spec.SupervisorProfile] on its normal routing.
+// [loop.Spec.SupervisorProfile] on its normal routing.
 //
-// The loop lifecycle is managed by the [loop] package. This package
-// provides [BuildLoopConfig] to assemble a [loop.Config] with the
-// correct TaskBuilder, PostIterate, and tool exclusions.
+// The loop lifecycle is managed by the [loop] package. This loop is
+// declarative: the per-iteration prompt is the spec Task plus the
+// supervisor-turn [loop.Spec.SupervisorProfile] Instructions. The only
+// runtime-only hook is the PostIterate iteration-log writer, which
+// [HydrateSpec] attaches to a durable loop definition.
 package metacognitive
 
 import (
@@ -216,8 +218,7 @@ func supervisorProfile(qualityFloor int) *router.LoopProfile {
 // telemetry block to the state document each cycle and needs the
 // resolved state-file path from opts. The prompt itself is declarative
 // (the spec Task and SupervisorProfile.Instructions).
-func HydrateSpec(spec loop.Spec, cfg Config, opts Opts) loop.Spec {
-	spec = loop.Spec(spec)
+func HydrateSpec(spec loop.Spec, _ Config, opts Opts) loop.Spec {
 	if strings.TrimSpace(spec.Name) == "" {
 		spec.Name = DefinitionName
 	}

--- a/internal/state/awareness/area_activity.go
+++ b/internal/state/awareness/area_activity.go
@@ -19,7 +19,6 @@ import (
 // methods out of the box.
 type AreaActivityClient interface {
 	HARegistryClient
-	GetAreas(ctx context.Context) ([]homeassistant.Area, error)
 	GetLogbookEvents(ctx context.Context, startTime, endTime time.Time, entityIDs []string) ([]homeassistant.LogbookEntry, error)
 }
 

--- a/internal/state/awareness/watchlist_provider.go
+++ b/internal/state/awareness/watchlist_provider.go
@@ -22,9 +22,10 @@ type StateGetter interface {
 }
 
 // WatchlistProvider implements [agent.TagContextProvider] by fetching
-// live state for all watched entities and formatting them as a
-// markdown block for system prompt injection. Registered via
-// [agent.Loop.RegisterAlwaysContextProvider].
+// live state for the always-visible (untagged) watchlist only and
+// formatting it as a markdown block for system prompt injection.
+// Loop-scoped subscriptions are handled by LoopSubscriptionProvider.
+// Registered via [agent.Loop.RegisterAlwaysContextProvider].
 type WatchlistProvider struct {
 	store            *WatchlistStore
 	ha               StateGetter

--- a/internal/state/awareness/watchlist_store.go
+++ b/internal/state/awareness/watchlist_store.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
-	"sort"
 	"strings"
 	"time"
 
@@ -232,9 +231,9 @@ func (s *WatchlistStore) UntaggedEntityIDSet(candidates []string) (map[string]st
 	return out, nil
 }
 
-// ListByTag returns watched entity subscriptions for the given capability
-// tag. Used by the tag context assembler to inject entity context only when a
-// tag is active.
+// ListByTag returns subscription rows for a given legacy scope tag.
+// Consumed by the one-shot startup migration that lifts legacy
+// scope_tag rows onto Spec.Subscriptions.
 func (s *WatchlistStore) ListByTag(tag string) ([]WatchedSubscription, error) {
 	return s.listScopedSubscriptions(tag)
 }
@@ -250,30 +249,6 @@ func (s *WatchlistStore) ListSubscriptions(scope string) ([]WatchedSubscription,
 	}
 	query += ` ORDER BY added_at ASC`
 	return s.scanActiveSubscriptions(query, args...)
-}
-
-// DistinctTags returns all unique active scopes across watched entities.
-// Used at startup to register tag-scoped watchlist providers.
-func (s *WatchlistStore) DistinctTags() ([]string, error) {
-	subs, err := s.ListSubscriptions("")
-	if err != nil {
-		return nil, err
-	}
-
-	seen := make(map[string]bool)
-	for _, sub := range subs {
-		if sub.Scope == "" {
-			continue
-		}
-		seen[sub.Scope] = true
-	}
-
-	tags := make([]string, 0, len(seen))
-	for tag := range seen {
-		tags = append(tags, tag)
-	}
-	sort.Strings(tags)
-	return tags, nil
 }
 
 func (s *WatchlistStore) listScopedSubscriptions(scope string) ([]WatchedSubscription, error) {

--- a/internal/state/awareness/watchlist_store_test.go
+++ b/internal/state/awareness/watchlist_store_test.go
@@ -134,14 +134,6 @@ func TestStore_AddWithOptionsScopedSubscriptions(t *testing.T) {
 		t.Fatalf("ListUntagged() = %v, want empty", untagged)
 	}
 
-	tags, err := store.DistinctTags()
-	if err != nil {
-		t.Fatalf("DistinctTags: %v", err)
-	}
-	if !slices.Equal(tags, []string{"interactive", "weather_focus"}) {
-		t.Fatalf("DistinctTags() = %v, want [interactive weather_focus]", tags)
-	}
-
 	weatherFocus, err := store.ListByTag("weather_focus")
 	if err != nil {
 		t.Fatalf("ListByTag(weather_focus): %v", err)

--- a/internal/state/contacts/store.go
+++ b/internal/state/contacts/store.go
@@ -392,13 +392,14 @@ func (s *Store) ListByKind(kind string) ([]*Contact, error) {
 	return s.scanContacts(rows)
 }
 
-// ListAll returns all active contacts.
+// ListAll returns up to 100 active contacts (use [Store.ListAllLimit]
+// for a different cap).
 func (s *Store) ListAll() ([]*Contact, error) {
 	return s.ListAllLimit(100)
 }
 
-// ListAllLimit returns up to limit active contacts. Values less than
-// one use the same 100-contact cap as [Store.ListAll].
+// ListAllLimit returns up to limit active contacts. A limit less than
+// one is clamped to a default of 100.
 func (s *Store) ListAllLimit(limit int) ([]*Contact, error) {
 	if limit <= 0 {
 		limit = 100
@@ -872,10 +873,10 @@ func (s *Store) FindByTrustZone(zone string) ([]*Contact, error) {
 }
 
 // FindByTrustZoneLimit returns up to limit active contacts in the given
-// trust zone. Values less than one return all active contacts in that zone.
+// trust zone. A limit less than one is clamped to a default of 100.
 func (s *Store) FindByTrustZoneLimit(zone string, limit int) ([]*Contact, error) {
 	if limit <= 0 {
-		return s.FindByTrustZone(zone)
+		limit = 100
 	}
 	rows, err := s.db.Query(
 		`SELECT `+contactColumns+` FROM contacts WHERE `+activeFilter+` AND trust_zone = ? ORDER BY formatted_name LIMIT ?`,

--- a/internal/state/loopqueue/queue_store.go
+++ b/internal/state/loopqueue/queue_store.go
@@ -32,7 +32,6 @@ const StatusPending = "pending"
 type Item struct {
 	DedupKey   string
 	Priority   int
-	Attempts   int
 	EnqueuedAt time.Time
 	Payload    []byte
 }
@@ -103,7 +102,7 @@ func (s *Store) Peek(ctx context.Context, consumerLoop string, limit int) ([]Ite
 		limit = 1
 	}
 	rows, err := s.db.QueryContext(ctx, `
-		SELECT dedup_key, priority, attempts, payload, enqueued_at
+		SELECT dedup_key, priority, payload, enqueued_at
 		FROM loop_queue
 		WHERE consumer_loop = ? AND status = ?
 		ORDER BY priority DESC, enqueued_at ASC
@@ -121,7 +120,7 @@ func (s *Store) Peek(ctx context.Context, consumerLoop string, limit int) ([]Ite
 			payload     string
 			enqueuedRaw string
 		)
-		if err := rows.Scan(&it.DedupKey, &it.Priority, &it.Attempts, &payload, &enqueuedRaw); err != nil {
+		if err := rows.Scan(&it.DedupKey, &it.Priority, &payload, &enqueuedRaw); err != nil {
 			return nil, err
 		}
 		it.Payload = []byte(payload)

--- a/internal/state/memory/format.go
+++ b/internal/state/memory/format.go
@@ -101,9 +101,9 @@ const maxMessageMetadataKeyBytes = 64
 // stable schema across calls. ContentTruncated signals when Content was
 // clipped to [maxMessageContentBytes]. Metadata carries transport
 // provenance separated from the literal message body when a known channel
-// envelope is detected. Metadata keys and string values are individually
-// capped so one malformed envelope cannot force byte-capped tools to
-// drop all messages.
+// envelope is detected. Metadata string values are individually capped
+// so one malformed envelope cannot force byte-capped tools to drop all
+// messages; keys in this projection are fixed literals, not capped.
 //
 // Metadata is map[string]any so nested objects can appear under
 // metadata.sender for Signal-like envelopes that resolve a structured
@@ -220,9 +220,6 @@ func FormatSearchResults(results []SearchResult, now time.Time, truncated bool) 
 	return data
 }
 
-// buildSearchResultViews is the projection step shared by the
-// single-surface and multi-surface formatters. Keeps the sender-
-// projection / context-trimming logic in one place.
 // roundScoreSignificant rounds a relevance score to sigFigs significant
 // figures so the signal survives regardless of magnitude. BM25 values
 // can be tiny on small or sparse indexes (a one-row exact phrase scores
@@ -238,6 +235,9 @@ func roundScoreSignificant(v float64, sigFigs int) float64 {
 	return math.Round(v*mag) / mag
 }
 
+// buildSearchResultViews is the projection step shared by the
+// single-surface and multi-surface formatters. Keeps the sender-
+// projection / context-trimming logic in one place.
 func buildSearchResultViews(results []SearchResult, now time.Time) []SearchResultView {
 	views := make([]SearchResultView, 0, len(results))
 	for _, r := range results {

--- a/internal/tools/find_entity.go
+++ b/internal/tools/find_entity.go
@@ -315,7 +315,7 @@ func filterEntityInfosByArea(area string, entities []homeassistant.EntityInfo, b
 	if bundle == nil {
 		return entities
 	}
-	needle := strings.ToLower(strings.TrimSpace(area))
+	needle := strings.TrimSpace(area)
 	if needle == "" {
 		return entities
 	}
@@ -325,12 +325,12 @@ func filterEntityInfosByArea(area string, entities []homeassistant.EntityInfo, b
 		if meta == nil || meta.Area == nil {
 			continue
 		}
-		if strings.EqualFold(meta.Area.ID, needle) || strings.EqualFold(meta.Area.Name, area) {
+		if strings.EqualFold(meta.Area.ID, needle) || strings.EqualFold(meta.Area.Name, needle) {
 			out = append(out, entity)
 			continue
 		}
 		for _, alias := range meta.Area.Aliases {
-			if strings.EqualFold(alias, area) {
+			if strings.EqualFold(alias, needle) {
 				out = append(out, entity)
 				break
 			}

--- a/internal/tools/loop_intent_tools.go
+++ b/internal/tools/loop_intent_tools.go
@@ -123,15 +123,15 @@ func (r *Registry) handleThaneCreateContainer(ctx context.Context, args map[stri
 		return "", fmt.Errorf("thane_create_container not configured: ConfigureLoopIntentTools must be called at startup")
 	}
 
-	name := strings.TrimSpace(toolargs.TrimmedString(args, "name"))
+	name := toolargs.TrimmedString(args, "name")
 	if name == "" {
 		return "", fmt.Errorf("name is required")
 	}
-	intent := strings.TrimSpace(toolargs.TrimmedString(args, "intent"))
+	intent := toolargs.TrimmedString(args, "intent")
 	if intent == "" {
 		return "", fmt.Errorf("intent is required")
 	}
-	parentName := strings.TrimSpace(toolargs.TrimmedString(args, "parent_name"))
+	parentName := toolargs.TrimmedString(args, "parent_name")
 	replace, _ := args["replace"].(bool)
 
 	var tags []string

--- a/internal/tools/loop_subscription_tools.go
+++ b/internal/tools/loop_subscription_tools.go
@@ -89,7 +89,7 @@ func (r *Registry) handleUpdateEntitySubscriptions(ctx context.Context, args map
 		return "", fmt.Errorf("update_entity_subscriptions not configured: requires loop definition registry")
 	}
 
-	name := strings.TrimSpace(toolargs.TrimmedString(args, "name"))
+	name := toolargs.TrimmedString(args, "name")
 	if name == "" {
 		return "", fmt.Errorf("name is required")
 	}

--- a/internal/tools/message_tools.go
+++ b/internal/tools/message_tools.go
@@ -86,7 +86,7 @@ func (r *Registry) handleRequestCoreAttention(ctx context.Context, args map[stri
 	if r.messageBus == nil {
 		return "", fmt.Errorf("message bus is not configured")
 	}
-	concern := strings.TrimSpace(toolargs.TrimmedString(args, "concern"))
+	concern := toolargs.TrimmedString(args, "concern")
 	if concern == "" {
 		return "", fmt.Errorf("concern is required")
 	}
@@ -98,8 +98,8 @@ func (r *Registry) handleRequestCoreAttention(ctx context.Context, args map[stri
 	payload := messages.LoopNotifyPayload{
 		Kind:            "core_attention_request",
 		Concern:         concern,
-		SuggestedAction: strings.TrimSpace(toolargs.TrimmedString(args, "suggested_action")),
-		Context:         strings.TrimSpace(toolargs.TrimmedString(args, "context")),
+		SuggestedAction: toolargs.TrimmedString(args, "suggested_action"),
+		Context:         toolargs.TrimmedString(args, "context"),
 		ForceSupervisor: true,
 	}
 
@@ -227,7 +227,7 @@ func senderIdentityFromContext(ctx context.Context) messages.Identity {
 }
 
 func messagePriorityArg(args map[string]any) messages.Priority {
-	switch strings.TrimSpace(toolargs.TrimmedString(args, "priority")) {
+	switch toolargs.TrimmedString(args, "priority") {
 	case "", "normal":
 		return messages.PriorityNormal
 	case "low":


### PR DESCRIPTION
## Summary
Mechanical Godoc + dead-code fixes surfaced by the v0.9.2..HEAD Phase-1 audit — post-refactor residue on a 200-PR release. **No behavior change except the two noted below.** 35 files, **+83/−140**.

## Godoc (stale/broken docs)
`serve` (memguard restart error case), `adapters` (broken `[web.LogQuerier]` link), loop `spec`/`signals`/`config`, `metacognitive` + `archivist` (declarative-redesign drift + broken `[loop.Spec.SupervisorProfile]` link), `watchlist_provider`/`watchlist_store`, contacts `ListAll`, memory `format` (misattached comment + MessageView metadata keys-vs-values), `event_source`, router `loopprofile` (`Hints`→`RoutingFactors`), `toolcatalog`, HA `entity_metadata`, prewarm stores.

## Dead code removed
`DistinctTags` (+test), `estimateRequestContextTokens` (+test), duplicate `AreaActivityClient.GetAreas`, two redundant blank `modernc/sqlite` imports, a no-op `loop.Spec` self-conversion, the single-use `mqttDefaultHandlerName` alias, the discarded `splitContainerSpecs` `nowTime` param, and the redundant `ContextSection.Title` field.

## Small cleanups
8 redundant `strings.TrimSpace(toolargs.TrimmedString(...))` sites; consistent area trimming in `find_entity`.

## Behavior (2)
- `FindByTrustZoneLimit` now clamps `limit<=0` to 100 (matching `ListAllLimit`); the only prod caller passes a positive limit.
- Removed the always-0 `loopqueue.Item.Attempts` field — it was emitting a permanent `"attempts":0` to the model in `queue_pull` output. DB column retained.

## Notes
- The audit flagged `WatchlistStore.ListUntagged` as dead, but verify-before-delete found **live test callers** — left in place (corrected finding).
- Inlines `reflect.Ptr`→`reflect.Pointer` in gencfg (same govet fix as #1093; absorbed cleanly whichever lands first).
- ~10 structural findings (denormalizations, API-signature changes, design couplings) are being filed as separate issues, not fixed here.

## Test plan
- [x] `just ci` green (full gate, race tests)
- [x] Every deletion grep-verified for zero callers (`ListUntagged` correctly skipped)
- [x] Behavioral changes' callers audited

Part of the v0.10.0 pre-release Phase-1 audit (docs in #1093).