### PR TITLE
fix(model-facing): resolve two v0.10.0 audit contradictions in model context

### DIFF
--- a/internal/platform/config/gen/gencfg/main.go
+++ b/internal/platform/config/gen/gencfg/main.go
@@ -351,7 +351,7 @@ func buildValueNode(v reflect.Value, t reflect.Type, comments commentMap) *yaml.
 	// path emits "null". In a commented-out section the caller already
 	// has a non-nil value from ExampleConfig, but if somehow we reach nil
 	// here, synthesize a zero value so the YAML block is still meaningful.
-	if t.Kind() == reflect.Ptr {
+	if t.Kind() == reflect.Pointer {
 		if v.IsNil() {
 			zv := reflect.New(t.Elem()).Elem()
 			return buildValueNode(zv, t.Elem(), comments)

--- a/internal/state/contacts/context.go
+++ b/internal/state/contacts/context.go
@@ -77,7 +77,7 @@ func (p *ContextProvider) TagContext(ctx context.Context, req agentctx.ContextRe
 		viewProps := make([]contextfmt.Property, 0, len(props))
 		for _, prop := range props {
 			viewProps = append(viewProps, contextfmt.Property{
-				Label: prop.Property,
+				Kind:  prop.Property,
 				Type:  prop.Type,
 				Value: prop.Value,
 			})

--- a/internal/state/contacts/context_test.go
+++ b/internal/state/contacts/context_test.go
@@ -105,7 +105,7 @@ func TestContextProvider_ReturnsRelevant(t *testing.T) {
 	if m.TrustZone != "known" {
 		t.Errorf("trust_zone = %q, want %q", m.TrustZone, "known")
 	}
-	props := propsByLabel(m.Properties)
+	props := propsByKind(m.Properties)
 	if _, ok := props["EMAIL"]; !ok {
 		t.Errorf("expected EMAIL property, got %+v", m.Properties)
 	}
@@ -202,7 +202,7 @@ func TestSetMaxContacts_ClampsToMin(t *testing.T) {
 	}
 }
 
-func propsByLabel(props []contextfmt.Property) map[string]contextfmt.Property {
+func propsByKind(props []contextfmt.Property) map[string]contextfmt.Property {
 	m := make(map[string]contextfmt.Property, len(props))
 	for _, p := range props {
 		m[p.Kind] = p

--- a/internal/state/contacts/context_test.go
+++ b/internal/state/contacts/context_test.go
@@ -205,7 +205,7 @@ func TestSetMaxContacts_ClampsToMin(t *testing.T) {
 func propsByLabel(props []contextfmt.Property) map[string]contextfmt.Property {
 	m := make(map[string]contextfmt.Property, len(props))
 	for _, p := range props {
-		m[p.Label] = p
+		m[p.Kind] = p
 	}
 	return m
 }

--- a/internal/state/contacts/contextfmt/contacts.go
+++ b/internal/state/contacts/contextfmt/contacts.go
@@ -31,10 +31,10 @@ type Match struct {
 	Properties []Property `json:"properties,omitempty"`
 }
 
-// Property is one vCard-style property of a contact. Kind is the vCard
-// property name (e.g. "EMAIL", "TEL", "URL", "IMPP"); Type carries the
-// vCard subtype when present (e.g. "INTERNET", "HOME"); Value is the
-// property value.
+// Property is one structured property of a contact. Kind is the property
+// name — usually a vCard property (e.g. "EMAIL", "TEL", "URL", "IMPP"), but
+// may be an app-specific key such as "timezone"; Type carries the vCard
+// subtype when present (e.g. "INTERNET", "HOME"); Value is the property value.
 type Property struct {
 	Kind  string `json:"kind"`
 	Type  string `json:"type,omitempty"`

--- a/internal/state/contacts/contextfmt/contacts.go
+++ b/internal/state/contacts/contextfmt/contacts.go
@@ -31,11 +31,12 @@ type Match struct {
 	Properties []Property `json:"properties,omitempty"`
 }
 
-// Property is one vCard-style property of a contact (email, phone,
-// timezone, etc.). Type carries the vCard subtype when present
-// (e.g., "INTERNET", "HOME").
+// Property is one vCard-style property of a contact. Kind is the vCard
+// property name (e.g. "EMAIL", "TEL", "URL", "IMPP"); Type carries the
+// vCard subtype when present (e.g. "INTERNET", "HOME"); Value is the
+// property value.
 type Property struct {
-	Label string `json:"label"`
+	Kind  string `json:"kind"`
 	Type  string `json:"type,omitempty"`
 	Value string `json:"value"`
 }

--- a/internal/state/contacts/contextfmt/contacts_test.go
+++ b/internal/state/contacts/contextfmt/contacts_test.go
@@ -33,8 +33,8 @@ func TestFormat_JSONIsParseable(t *testing.T) {
 			TrustZone: "trusted",
 			Score:     0.92,
 			Properties: []Property{
-				{Label: "EMAIL", Type: "INTERNET", Value: "alice@techco.com"},
-				{Label: "timezone", Value: "America/Chicago"},
+				{Kind: "EMAIL", Type: "INTERNET", Value: "alice@techco.com"},
+				{Kind: "timezone", Value: "America/Chicago"},
 			},
 		},
 	})

--- a/talents/awareness.md
+++ b/talents/awareness.md
@@ -14,7 +14,7 @@ When you *speak* time to humans, translate to what's useful:
 
 Sunrise and sunset are meaningful anchors in a home context. "20 minutes after sunrise" connects time to lived experience.
 
-When you *write* timestamps to persistent files (metacognitive.md, memory), always convert back to absolute RFC3339. Deltas rot. `-300s` means nothing an hour later.
+Deltas like `-300s` are relative to now — they rot the moment they're read later, so never persist a delta as if it were a fixed time. When a moment genuinely belongs in something durable, write it as an absolute time; but record a wall-clock time only when the time itself is the point, and let each durable surface's own guidance govern what timestamps belong in its body.
 
 **Never cache or infer the current time.** The conditions block is authoritative. If you wrote "Sunday morning" to working memory and it's actually Monday, that error compounds.
 


### PR DESCRIPTION
## Summary
Two model-facing contradictions surfaced (and adversarially verified) by the v0.9.2..HEAD Phase-1 audit — both feed the model conflicting or misleading context.

### 1. `awareness.md` timestamp rule vs. the reworked durable-output prompts
`awareness.md` is an **always-on foundation talent** (no tags → loads into every non-task system prompt, including the metacognitive and ego background loops). Its line *"when you write timestamps to metacognitive.md/memory, always convert to absolute RFC3339"* directly contradicts the **metacog and ego `BaseTemplate` prompts reworked this release**, which now say *"include a wall-clock time only when the time itself is the point."* The metacog loop receives **both** texts in one prompt (model-facing-context.md anti-pattern: *same fact in conflicting shapes*).

**Fix:** keep the delta-rot principle, drop the blanket "always convert" mandate and the per-file naming, and defer body-timestamp policy to each loop's own durable-output prompt. (Mirror at `internal/model/talents/defaults` regenerates via `just ci`.)

### 2. contacts projection key `label` carried the wrong thing
In `contextfmt`, `Property.Label` (json `label`) was populated from the domain `Property.Property` — the vCard property **kind** (`EMAIL`/`TEL`/`URL`). So the model saw `{"label":"EMAIL","type":"INTERNET",...}` where `label` meant *kind*, **and** it collided with the domain's real `Property.Label` (the vCard LABEL param, dropped from the projection).

**Fix:** rename the view field + JSON key to `kind` (honest name; `type` still carries the subtype). Updated the call site, godoc, and test fixtures. The domain `Property.Label` is untouched.

## Test plan
- [x] `just ci` green
- [x] All `.Label` refs audited — only the contextfmt projection renamed; domain `Property.Label` (store/vcard/tools) left intact

Part of the v0.10.0 pre-release Phase-1 audit (docs #1093, code-hygiene #1094). Also carries the shared `reflect.Ptr`→`reflect.Pointer` govet fix.