### PR TITLE
fix(releng): harden release-artifact integrity against the macOS auto-updater contract

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,8 @@ jobs:
 
       - name: Validate release tag
         run: |
-          [[ "${GITHUB_REF_NAME}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$ ]]
+          # No +build-metadata — the macOS auto-updater's SemanticVersion parser can't read it.
+          [[ "${GITHUB_REF_NAME}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]
 
       - name: Set up Go
         uses: actions/setup-go@v6

--- a/docs/operating/release-engineering.md
+++ b/docs/operating/release-engineering.md
@@ -111,3 +111,36 @@ ships to operators:
 
 Raw binary copies are still possible with lower-level tooling, but they are no
 longer the preferred operational path.
+
+## Release Artifact Contract (the macOS auto-updater)
+
+The [thane-agent-macos](https://github.com/nugget/thane-agent-macos) companion
+app auto-updates its managed `thane` binary from this repo's GitHub releases.
+Its updater (`LocalServer/UpdateManager.swift`) is the consumer and arbiter of
+release integrity, so the following are a hard contract — breaking one bricks the
+update path. `just ci`, `package-macos-pkg.sh`'s self-check, and the
+`prepare-release`/`publish-release` guards enforce most of them; keep the rest in
+mind when touching the release recipes.
+
+- **Asset names** — each release exposes `thane_<version>_darwin_arm64.pkg` and
+  `thane_<version>_darwin_amd64.pkg` (the updater matches the `darwin_<arch>.pkg`
+  suffix), plus exactly one `thane_<version>_checksums.txt`. No second `.pkg` per
+  arch and no second `*_checksums.txt` per release.
+- **Checksums** — `checksums.txt` is `sha256sum`/`shasum -a 256` text-mode lines
+  (`<hex>  <bare-basename>`), hashed *after* signing/notarizing/stapling. The
+  entry name must equal the uploaded asset name exactly.
+- **Pkg layout** — `pkgutil --expand-full` must yield
+  `thane-component.pkg/Payload/Thane/bin/thane`; the binary stays named `thane`
+  and installs to `~/Thane/bin/thane`. `package-macos-pkg.sh` self-checks this.
+- **Signing** — production pkgs are Developer ID Installer-signed, notarized, and
+  stapled. The updater records but does not reject an unsigned pkg, so
+  `prepare-release`/`publish-release` fail fast without the signing credentials.
+- **Version tags** — `vX.Y.Z[-pre]` with a three-integer core and **no
+  `+build-metadata`** (the updater's `SemanticVersion` parser can't read it).
+- **Release visibility** — published on `nugget/thane-ai-agent`, non-draft; a
+  non-prerelease "latest" must exist for default-channel updaters.
+
+The app updates *itself* (a `.dmg`) from the thane-agent-macos repo through a
+parallel updater; that contract is arch-agnostic where this one is
+arch-specific. Any future convergence of the two release pipelines must keep the
+`.pkg` arch-qualified and the `.dmg` arch-agnostic.

--- a/justfile
+++ b/justfile
@@ -801,13 +801,23 @@ prepare-release version container_tag="thane:prepare-release":
 
     version="${version#v}"
 
-    if ! printf '%s' "$version" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$'; then
+    if ! printf '%s' "$version" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$'; then
         echo "Version must look like 0.9.0 or 0.9.0-rc.1" >&2
         exit 1
     fi
 
     test "{{host_os}}" = "darwin" || { echo "prepare-release must run on a macOS release workstation"; exit 1; }
     test -z "$(git status --short)" || { echo "Worktree must be clean before a prepare-release run"; exit 1; }
+
+    # A published release MUST be signed + notarized: the thane-agent-macos
+    # auto-updater records provenance but never rejects an unsigned pkg, so the
+    # integrity guarantee has to live on the producer. Enforce it on every
+    # build/publish entry point — not just release-github.sh — so a direct
+    # prepare/publish can't ship an unsigned artifact the updater installs.
+    source scripts/releng/common.sh
+    require_real_codesign_identity
+    require_real_installer_identity
+    require_notary_profile
 
     mkdir -p "{{release-dir}}"
     rm -f \
@@ -861,12 +871,19 @@ publish-release version release_kind="auto":
     force_release="${THANE_RELEASE_FORCE:-false}"
     remote_tag_commit=""
 
-    if ! printf '%s' "$version" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$'; then
+    if ! printf '%s' "$version" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$'; then
         echo "Version must look like 0.9.0 or 0.9.0-rc.1" >&2
         exit 1
     fi
 
     test -z "$(git status --short)" || { echo "Worktree must be clean before cutting a release"; exit 1; }
+
+    # See prepare-release: the published artifacts must be signed + notarized
+    # (the updater won't reject unsigned), so enforce it on this publish path too.
+    source scripts/releng/common.sh
+    require_real_codesign_identity
+    require_real_installer_identity
+    require_notary_profile
 
     just --quiet release-github-check "$tag"
     export GH_TOKEN="${THANE_GH_TOKEN}"

--- a/scripts/package-macos-pkg.sh
+++ b/scripts/package-macos-pkg.sh
@@ -211,4 +211,18 @@ if [ -n "$installer_identity" ] && [ "$installer_identity" != "-" ]; then
     pkgutil --check-signature "$artifact_path" >&2
 fi
 
+# Contract self-check (cross-repo coupling): the thane-agent-macos auto-updater
+# extracts the managed binary at thane-component.pkg/Payload/Thane/bin/thane
+# after `pkgutil --expand-full`. Assert that exact layout here so a component or
+# payload-path rename fails the build instead of silently shipping a pkg the
+# updater can't unpack.
+contract_dir="$stage_dir/contract-check"
+rm -rf "$contract_dir"
+pkgutil --expand-full "$artifact_path" "$contract_dir" >&2
+if [ ! -f "$contract_dir/thane-component.pkg/Payload/Thane/bin/thane" ]; then
+    echo "pkg contract broken: expected thane-component.pkg/Payload/Thane/bin/thane after expand-full (the thane-agent-macos auto-updater's findBinary primary path); the component/payload layout changed" >&2
+    exit 1
+fi
+rm -rf "$contract_dir"
+
 printf '%s\n' "$artifact_path"

--- a/scripts/package-release.sh
+++ b/scripts/package-release.sh
@@ -42,11 +42,12 @@ cp -R "$root_dir/init/." "$package_dir/init/"
 
 case "$target_os" in
     darwin)
-        archive_path="$output_dir/${package_name}.zip"
-        (
-            cd "$stage_dir"
-            COPYFILE_DISABLE=1 ditto -c -k --norsrc --keepParent "$package_name" "$archive_path"
-        )
+        # darwin release artifacts are signed .pkg files from
+        # package-macos-pkg.sh. This generic packer must never produce a second
+        # darwin asset — a stray .zip would collide with the macOS auto-updater's
+        # single-asset suffix match for the release.
+        echo "package-release.sh does not package darwin — use package-macos-pkg.sh for the signed .pkg" >&2
+        exit 1
         ;;
     *)
         archive_path="$output_dir/${package_name}.tar.gz"

--- a/scripts/releng/common.sh
+++ b/scripts/releng/common.sh
@@ -66,7 +66,10 @@ normalize_version() {
 
 validate_release_version() {
     local version="$1"
-    [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$ ]] || \
+    # No +build-metadata: the macOS updater's shared SemanticVersion parser
+    # splits only on '-', so a vX.Y.Z+meta tag is silently dropped to .idle.
+    # Keep the producer's accepted set == the consumer's parseable set.
+    [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]] || \
         die "version must look like 0.9.0 or 0.9.0-rc.1"
 }
 


### PR DESCRIPTION
## Summary
The **thane-agent-macos** companion app auto-updates its managed `thane` binary from *this repo's* GitHub releases, so its updater (`LocalServer/UpdateManager.swift`) is the consumer and arbiter of our release integrity. I ran a full clause-by-clause audit of that contract against this repo's release process (adversarially verified).

**Headline: the release process satisfies the entire contract byte-for-byte — 0 blockers, 0 brick-the-update gaps.** The pkg layout, asset names, `sha256sum` checksums, repo target, and version handling all line up (the audit even reproduced the pkg layout empirically). This PR closes the **defense-in-depth** gaps so the guarantees are structural, not dependent on operator discipline.

## Fixes (all producer-side)
- **Signing/notarization on every publish path** *(should-fix)* — the blessed `release-github.sh` requires the Developer ID + notary creds, but a direct `just prepare-release` / `just publish-release` would build + upload an **unsigned** pkg, which the updater installs without rejecting (it records provenance, doesn't gate). Both recipes now fail fast via the existing `common.sh` `require_*` guards. *(Verified: the guard fires when creds are unset.)*
- **Pkg-layout self-check** — `package-macos-pkg.sh` now `pkgutil --expand-full`s its own output and asserts `thane-component.pkg/Payload/Thane/bin/thane` (the updater's hardcoded `findBinary` path). A component/payload rename fails the build instead of silently shipping a pkg the updater can't unpack. *(Verified: passes on a real build.)*
- **Version regex** — dropped `+build-metadata` from all four spots (`common.sh`, `justfile` ×2, `release.yml`); the updater's `SemanticVersion` parser splits only on `-`, so a `vX.Y.Z+meta` tag would be silently dropped to `.idle`.
- **package-release.sh** rejects `darwin` loudly instead of producing a stray `.zip` that could collide with the updater's single-asset suffix match (the branch was already dead on the release path).

## Documentation
Added a **Release Artifact Contract** section to `release-engineering.md` — the asset-name / checksum / pkg-layout / signing / version-tag / visibility invariants the release must hold, so future recipe changes don't break the updater.

## Out of scope (tracked for thane-agent-macos)
Consumer-side robustness from the same audit: `html_url` force-unwrap (crash on unparseable URL), and list-mode trusting GitHub's ordering (backstopped today by the semver gate). Those are updater-side and belong in that repo.

## Test plan
- [x] `just ci` green
- [x] `bash -n` on all edited scripts
- [x] Signing guard fires with creds unset (`require_real_codesign_identity` → dies)
- [x] Pkg contract-check passes on a real `release-build-snapshot` build (exit 0)
- [x] Version regex change applied identically in all 4 locations

Stacked on #1099 (shares the justfile); GitHub will retarget to `main` when that merges.