### PR TITLE
fix(documents): stop frontmatter escaping amplification in managed docs

### DIFF
--- a/internal/state/documents/frontmatter_roundtrip_test.go
+++ b/internal/state/documents/frontmatter_roundtrip_test.go
@@ -1,0 +1,91 @@
+package documents
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestFrontmatterValueRoundTripIsStable guards against the escaping-
+// amplification bug that grew a loop-managed document's loop_intent
+// frontmatter value into a 32 MiB run of backslashes on prod
+// (knowledge/temporal/ranch-conditions.md, 2026-06). renderFrontmatter
+// quotes values with strconv.Quote, so any embedded double-quote,
+// backslash, or control character is escaped on write; the parser must
+// reverse that escaping on read. When it does not, every read→render
+// cycle re-escapes the already-escaped characters and the value doubles
+// in size each iteration of the owning service loop.
+//
+// The invariant under test: a value survives render→parse unchanged, and
+// re-rendering a parsed value is a fixed point (no growth across cycles).
+func TestFrontmatterValueRoundTripIsStable(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name  string
+		value string
+	}{
+		{"plain", "just some prose with no special characters"},
+		{"embedded_double_quote", `a one-line "still settling toward evening, quiet" is correct`},
+		{"backslash", `a path C:\Users\aimee and an escape \n literal`},
+		{"newline", "first paragraph\n\nsecond paragraph"},
+		{"tab", "col1\tcol2"},
+		{"unicode", "Aimée — felt sense, who's home"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			meta := map[string][]string{"loop_intent": {tc.value}}
+
+			rendered := renderFrontmatter(meta)
+			parsed := parseFrontmatterMap(rendered)
+			if got := firstValue(parsed, "loop_intent"); got != tc.value {
+				t.Fatalf("value not preserved across render→parse:\n  want %q\n   got %q", tc.value, got)
+			}
+
+			// A second cycle must be a fixed point: re-rendering the parsed
+			// value yields byte-identical frontmatter. Any growth here is the
+			// amplification bug.
+			reRendered := renderFrontmatter(parsed)
+			if reRendered != rendered {
+				t.Fatalf("render is not a fixed point — value is amplifying across cycles:\n  cycle 1 (%d bytes): %q\n  cycle 2 (%d bytes): %q",
+					len(rendered), rendered, len(reRendered), reRendered)
+			}
+
+			// Belt and suspenders: simulate several owning-loop cycles and
+			// assert the rendered size never grows.
+			cur := rendered
+			for i := 0; i < 5; i++ {
+				next := renderFrontmatter(parseFrontmatterMap(cur))
+				if len(next) > len(cur) {
+					t.Fatalf("frontmatter grew on cycle %d: %d → %d bytes", i+1, len(cur), len(next))
+				}
+				cur = next
+			}
+		})
+	}
+}
+
+// TestFrontmatterBlockListRoundTripIsStable covers the multi-value /
+// block-list rendering path (e.g. source_refs, tags) which is quoted with
+// the same strconv.Quote escaping and must parse back losslessly.
+func TestFrontmatterBlockListRoundTripIsStable(t *testing.T) {
+	t.Parallel()
+
+	meta := map[string][]string{
+		"tags": {`tag-with-"quote"`, `tag\with\backslash`},
+	}
+	rendered := renderFrontmatter(meta)
+	parsed := parseFrontmatterMap(rendered)
+	if reRendered := renderFrontmatter(parsed); reRendered != rendered {
+		t.Fatalf("block-list render is not a fixed point:\n  cycle 1: %q\n  cycle 2: %q", rendered, reRendered)
+	}
+	// Values must survive intact (order-independent: parse dedupe-sorts).
+	got := strings.Join(parsed["tags"], "|")
+	for _, want := range meta["tags"] {
+		if !strings.Contains(got, want) {
+			t.Fatalf("tag %q lost across round-trip; got %q", want, got)
+		}
+	}
+}

--- a/internal/state/documents/frontmatter_roundtrip_test.go
+++ b/internal/state/documents/frontmatter_roundtrip_test.go
@@ -67,25 +67,74 @@ func TestFrontmatterValueRoundTripIsStable(t *testing.T) {
 	}
 }
 
-// TestFrontmatterBlockListRoundTripIsStable covers the multi-value /
-// block-list rendering path (e.g. source_refs, tags) which is quoted with
-// the same strconv.Quote escaping and must parse back losslessly.
-func TestFrontmatterBlockListRoundTripIsStable(t *testing.T) {
+// TestFrontmatterInlineListRoundTripIsStable covers the inline multi-value
+// list path — `key: ["a", "b"]` — which renderFrontmatter uses for every
+// multi-value key except source_refs. Each element is quoted with the same
+// strconv.Quote escaping and must parse back losslessly.
+func TestFrontmatterInlineListRoundTripIsStable(t *testing.T) {
 	t.Parallel()
 
 	meta := map[string][]string{
 		"tags": {`tag-with-"quote"`, `tag\with\backslash`},
 	}
 	rendered := renderFrontmatter(meta)
-	parsed := parseFrontmatterMap(rendered)
-	if reRendered := renderFrontmatter(parsed); reRendered != rendered {
-		t.Fatalf("block-list render is not a fixed point:\n  cycle 1: %q\n  cycle 2: %q", rendered, reRendered)
+	if !strings.Contains(rendered, "[") {
+		t.Fatalf("expected inline list rendering, got %q", rendered)
 	}
-	// Values must survive intact (order-independent: parse dedupe-sorts).
-	got := strings.Join(parsed["tags"], "|")
-	for _, want := range meta["tags"] {
-		if !strings.Contains(got, want) {
-			t.Fatalf("tag %q lost across round-trip; got %q", want, got)
+	assertListRoundTripStable(t, meta, "tags", rendered)
+}
+
+// TestFrontmatterBlockListRoundTripIsStable covers the block-list path —
+//
+//	source_refs:
+//	  - "a"
+//	  - "b"
+//
+// which renderFrontmatter uses *only* for source_refs (GeneratedFieldSourceRefs),
+// and which parseFrontmatterMap parses through its separate `- item`
+// branch. That branch does its own quote-stripping, so it is independently
+// vulnerable to the escaping-amplification bug and needs its own coverage.
+func TestFrontmatterBlockListRoundTripIsStable(t *testing.T) {
+	t.Parallel()
+
+	meta := map[string][]string{
+		GeneratedFieldSourceRefs: {`kb:notes/with "quotes".md`, `core:path\with\backslash`, "plain-ref"},
+	}
+	rendered := renderFrontmatter(meta)
+	if !strings.Contains(rendered, GeneratedFieldSourceRefs+":\n") || !strings.Contains(rendered, "\n  - ") {
+		t.Fatalf("expected block-list rendering for %s, got %q", GeneratedFieldSourceRefs, rendered)
+	}
+	assertListRoundTripStable(t, meta, GeneratedFieldSourceRefs, rendered)
+}
+
+// assertListRoundTripStable verifies a multi-value frontmatter key both
+// preserves its values across render→parse and stops growing across
+// repeated cycles. Value order is normalized by the parser (dedupe-sorted),
+// so the fixed-point check is taken from the second cycle onward; the
+// no-growth check spans every cycle and is what actually catches the
+// amplification bug regardless of ordering.
+func assertListRoundTripStable(t *testing.T, meta map[string][]string, key, rendered string) {
+	t.Helper()
+
+	parsed := parseFrontmatterMap(rendered)
+	got := strings.Join(parsed[key], "\x00")
+	for _, want := range meta[key] {
+		if !strings.Contains("\x00"+got+"\x00", "\x00"+want+"\x00") {
+			t.Fatalf("value %q for key %q lost across round-trip; got %q", want, key, parsed[key])
 		}
+	}
+
+	// Run several owning-loop cycles. Past the first normalization the
+	// rendered bytes must be a fixed point, and the size must never grow.
+	prev := renderFrontmatter(parseFrontmatterMap(rendered))
+	for i := 0; i < 5; i++ {
+		cur := renderFrontmatter(parseFrontmatterMap(prev))
+		if len(cur) > len(prev) {
+			t.Fatalf("%s frontmatter grew on cycle %d: %d → %d bytes", key, i+1, len(prev), len(cur))
+		}
+		if cur != prev {
+			t.Fatalf("%s render is not a fixed point on cycle %d:\n  prev: %q\n  cur:  %q", key, i+1, prev, cur)
+		}
+		prev = cur
 	}
 }

--- a/internal/state/documents/parser.go
+++ b/internal/state/documents/parser.go
@@ -4,6 +4,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 	"unicode"
 )
@@ -118,7 +119,7 @@ func parseFrontmatterMap(raw string) map[string][]string {
 			continue
 		}
 		if pendingKey != "" && strings.HasPrefix(trimmed, "-") {
-			value := strings.Trim(strings.TrimSpace(strings.TrimPrefix(trimmed, "-")), `"'`)
+			value := unquoteFrontmatterScalar(strings.TrimPrefix(trimmed, "-"))
 			if value != "" {
 				meta[pendingKey] = append(meta[pendingKey], value)
 			}
@@ -162,18 +163,46 @@ func parseFrontmatterValue(raw string) []string {
 		parts := strings.Split(raw, ",")
 		values := make([]string, 0, len(parts))
 		for _, part := range parts {
-			part = strings.Trim(strings.TrimSpace(part), `"'`)
+			part = unquoteFrontmatterScalar(part)
 			if part != "" {
 				values = append(values, part)
 			}
 		}
 		return dedupeSorted(values)
 	}
-	value := strings.Trim(raw, `"'`)
+	value := unquoteFrontmatterScalar(raw)
 	if value == "" {
 		return nil
 	}
 	return []string{value}
+}
+
+// unquoteFrontmatterScalar reverses the quoting applied by
+// renderFrontmatter, which writes every value through strconv.Quote.
+// Rendered values are therefore double-quoted Go string literals, and
+// strconv.Unquote inverts them exactly — including the backslash and
+// embedded-quote escaping that, left un-reversed, re-escapes and doubles
+// the value on every render→parse cycle. That asymmetry grew a
+// loop-managed document's loop_intent into a 32 MiB run of backslashes on
+// prod (knowledge/temporal/ranch-conditions.md, 2026-06): the intent held
+// a literal "quoted phrase", strconv.Quote escaped the quotes to \", the
+// old parser stripped only the outer quotes, and the owning service loop
+// doubled the backslashes each iteration until the file hit the document
+// read cap and wedged.
+//
+// Hand-authored frontmatter may instead use single quotes or bare,
+// unquoted values; those are not valid Go literals, so they fall back to
+// the historical quote-trim. This keeps the parser a strict superset of
+// the previous behavior while making our own rendered output round-trip
+// losslessly.
+func unquoteFrontmatterScalar(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if len(raw) >= 2 && raw[0] == '"' && raw[len(raw)-1] == '"' {
+		if unquoted, err := strconv.Unquote(raw); err == nil {
+			return unquoted
+		}
+	}
+	return strings.Trim(raw, `"'`)
 }
 
 func parseSections(body string) []Section {


### PR DESCRIPTION
## What happened

A production managed document — `knowledge/temporal/ranch-conditions.md`, owned by the `hor_conditions` `thane_curate` service loop (output mode `maintain`) — grew from ~2 KB to **33,556,168 bytes in ~2 days**, then wedged the loop. The 32 MB file was only **13 lines**: line 7 (`loop_intent`) was a single 33.5 MB run of backslashes. (Gzipped, the corrupt file is 34 KB — it's almost entirely one repeated escape character.)

## Root cause

The frontmatter render/parse round-trip is **asymmetric**:

- **Render** (`renderFrontmatter`): writes every value through `strconv.Quote`, which escapes `\` → `\\`, `"` → `\"`, and control chars.
- **Parse** (`parseFrontmatterValue`): only did `strings.Trim(raw, "\"'")` — strips the *outer* quotes but never reverses the escaping. No `strconv.Unquote` anywhere.

So a value containing an escapable character is re-escaped on every read→render cycle:

```
in-memory:  \"           (1 backslash)
on disk:    \\\"          (strconv.Quote doubles it)
parsed:     \\\"          (outer-quote trim only — backslash survives)
re-rendered:\\\\\"        (doubled again)  →  exponential
```

A `maintain`-mode `thane_curate` loop re-renders the document's frontmatter every iteration via `touchDocumentFrontmatter`. The `hor_conditions` intent contained a literal felt-sense example — `a one-line "still settling toward evening, quiet" is correct` — so the embedded `"` seeded the run, and the loop's 20m–1h cadence doubled it each cycle until it crossed the 32 MiB document read cap. Past that cap every mutation fails (mutations read the doc first), so growth froze right at the boundary and the loop stopped producing output.

The 32 MiB read cap (added after an earlier 8 GB runaway) did its job as a backstop — it turned an unbounded OOM into a frozen 32 MB file — but the amplification itself is the bug.

## Fix

Parse frontmatter scalars with `strconv.Unquote`, the exact inverse of the `strconv.Quote` used to render them, so `render ∘ parse` is a fixed point. Hand-authored single-quoted/bare values (not valid Go literals) fall back to the historical quote-trim, so the parser stays a strict superset of prior behavior. Applied to all three quote-stripping sites: scalar, inline-list (`[a, b]`), and block-list (`- item`).

## Tests

`frontmatter_roundtrip_test.go` adds:
- render→parse value preservation across embedded quotes, backslashes, newlines, tabs, unicode, and plain text
- a fixed-point assertion (re-render is byte-identical)
- a multi-cycle no-growth loop (simulating the owning service loop)

All fail on `main`, pass with the fix. Full `just ci` green.

## Prod remediation (done out-of-band)

The wedged file has already been repaired on `pocket`: corrupt original backed up (gzipped) to `~aimee/ranch-conditions.runaway-20260626.md.gz`, replaced with a clean 1.7 KB document. The restored `loop_intent` uses single quotes around the example phrase so it stays stable even on the **current** (unfixed) prod binary; once this lands and deploys, the quoting no longer matters.

## Notes

- Other managed docs whose frontmatter happened to contain an escapable char have latent (frozen, post-cap or sub-cap) over-escaping; after this deploys, growth stops everywhere, and lightly-corrupted values collapse one escape level on next read. The ranch doc was repaired fully by hand.
- Follow-up worth considering (not in this PR): a write-side guard that rejects an absurdly large frontmatter value as defense-in-depth.