### PR TITLE
fix(loops): document parent_name in spec schema and warn on metadata shadows

### DIFF
--- a/internal/runtime/loop/definition_warnings.go
+++ b/internal/runtime/loop/definition_warnings.go
@@ -2,6 +2,7 @@ package loop
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 )
 
@@ -17,11 +18,17 @@ type DefinitionWarning struct {
 // BuildDefinitionWarnings returns authoring warnings for one loop spec.
 // These warnings are advisory: the spec may still validate and persist.
 func BuildDefinitionWarnings(spec Spec) []DefinitionWarning {
+	// Shadow checks run for every operation: a metadata key that duplicates a
+	// real top-level spec field is inert for any loop kind, and parent_name in
+	// metadata in particular silently fails to nest the loop — the runtime
+	// parents off the structural field, never metadata. Collect these before
+	// the service-only gate so containers and event-driven loops are covered.
+	warnings := metadataShadowWarnings(spec)
+
 	if effectiveOperation(spec.Operation) != OperationService {
-		return nil
+		return warnings
 	}
 
-	var warnings []DefinitionWarning
 	missingSleep := missingServiceSleepFields(spec)
 	switch len(missingSleep) {
 	case 4:
@@ -83,6 +90,63 @@ func BuildDefinitionWarnings(spec Spec) []DefinitionWarning {
 		})
 	}
 
+	return warnings
+}
+
+// shadowableSpecFields is the set of canonical top-level spec wire names (the
+// json tags on specJSON in spec_json.go) that a metadata key can collide
+// with. A metadata entry matching one of these is almost certainly a
+// misplaced structural field: Metadata is stored verbatim and never
+// interpreted, so the real field stays unset. parent_name is the motivating
+// case — a loop authored with parent_name in metadata silently lands at the
+// graph root instead of under its container. The set excludes "metadata"
+// itself and the legacy compat keys (quality_floor, supervisor_context,
+// supervisor_quality_floor), which are deliberately not part of the canonical
+// authoring surface.
+var shadowableSpecFields = map[string]struct{}{
+	"name": {}, "enabled": {}, "task": {}, "profile": {}, "operation": {},
+	"completion": {}, "outputs": {}, "subscriptions": {}, "conditions": {},
+	"tags": {}, "exclude_tools": {}, "sleep_min": {}, "sleep_max": {},
+	"sleep_default": {}, "jitter": {}, "max_duration": {}, "max_iter": {},
+	"supervisor": {}, "supervisor_prob": {}, "supervisor_profile": {},
+	"on_retrigger": {}, "routing_factors": {}, "delegation_gating": {},
+	"fallback_content": {}, "parent_name": {}, "parent_id": {},
+}
+
+// metadataShadowWarnings flags metadata keys that collide with a real
+// top-level spec field. Such keys are inert: the runtime reads the structural
+// field, not metadata, so the value never takes effect. parent_name/parent_id
+// get a placement-specific message because the failure is silent
+// mis-parenting rather than a generic dropped value.
+func metadataShadowWarnings(spec Spec) []DefinitionWarning {
+	if len(spec.Metadata) == 0 {
+		return nil
+	}
+	shadowed := make([]string, 0, len(spec.Metadata))
+	for key := range spec.Metadata {
+		if _, ok := shadowableSpecFields[key]; ok {
+			shadowed = append(shadowed, key)
+		}
+	}
+	if len(shadowed) == 0 {
+		return nil
+	}
+	sort.Strings(shadowed) // deterministic order across repeated lint/set calls
+
+	warnings := make([]DefinitionWarning, 0, len(shadowed))
+	for _, key := range shadowed {
+		var msg string
+		switch key {
+		case "parent_name", "parent_id":
+			msg = "metadata." + key + " is inert and does not nest this loop under a parent: metadata is stored verbatim and never interpreted. Set the top-level parent_name field instead."
+		default:
+			msg = fmt.Sprintf("metadata.%s shadows the top-level %s field, which the runtime reads instead of metadata. The metadata copy is stored verbatim and never interpreted, so it is inert; set the top-level %s field.", key, key, key)
+		}
+		warnings = append(warnings, DefinitionWarning{
+			Code:    "metadata_shadows_spec_field",
+			Message: msg,
+		})
+	}
 	return warnings
 }
 

--- a/internal/runtime/loop/definition_warnings.go
+++ b/internal/runtime/loop/definition_warnings.go
@@ -96,8 +96,8 @@ func BuildDefinitionWarnings(spec Spec) []DefinitionWarning {
 // shadowableSpecFields is the set of canonical top-level spec wire names (the
 // json tags on specJSON in spec_json.go) that a metadata key can collide
 // with. A metadata entry matching one of these is almost certainly a
-// misplaced structural field: Metadata is stored verbatim and never
-// interpreted, so the real field stays unset. parent_name is the motivating
+// misplaced structural field: metadata keys are not interpreted as
+// structural spec fields, so the real field stays unset. parent_name is the motivating
 // case — a loop authored with parent_name in metadata silently lands at the
 // graph root instead of under its container. The set excludes "metadata"
 // itself and the legacy compat keys (quality_floor, supervisor_context,
@@ -138,9 +138,9 @@ func metadataShadowWarnings(spec Spec) []DefinitionWarning {
 		var msg string
 		switch key {
 		case "parent_name", "parent_id":
-			msg = "metadata." + key + " is inert and does not nest this loop under a parent: metadata is stored verbatim and never interpreted. Set the top-level parent_name field instead."
+			msg = "metadata." + key + " is inert and does not nest this loop under a parent: a metadata entry does not set a structural spec field. Set the top-level parent_name field instead."
 		default:
-			msg = fmt.Sprintf("metadata.%s shadows the top-level %s field, which the runtime reads instead of metadata. The metadata copy is stored verbatim and never interpreted, so it is inert; set the top-level %s field.", key, key, key)
+			msg = fmt.Sprintf("metadata.%s shadows the top-level %s field, which the runtime reads instead of metadata. A metadata entry does not set a structural spec field, so this copy is inert; set the top-level %s field.", key, key, key)
 		}
 		warnings = append(warnings, DefinitionWarning{
 			Code:    "metadata_shadows_spec_field",

--- a/internal/runtime/loop/definition_warnings_test.go
+++ b/internal/runtime/loop/definition_warnings_test.go
@@ -1,6 +1,7 @@
 package loop
 
 import (
+	"strings"
 	"testing"
 	"time"
 )
@@ -53,5 +54,95 @@ func TestBuildDefinitionWarnings_FixedIntervalJitterAndCompletion(t *testing.T) 
 	}
 	if !codes["fixed_interval_with_jitter"] {
 		t.Fatalf("warning codes = %#v, want fixed_interval_with_jitter", codes)
+	}
+}
+
+func TestBuildDefinitionWarnings_MetadataShadowsSpecField(t *testing.T) {
+	tests := []struct {
+		name      string
+		spec      Spec
+		wantCode  string // "" = assert the shadow code is ABSENT
+		wantInMsg string
+	}{
+		{
+			name:      "parent_name in metadata fires with parent guidance",
+			spec:      Spec{Operation: OperationService, Metadata: map[string]string{"parent_name": "travel"}},
+			wantCode:  "metadata_shadows_spec_field",
+			wantInMsg: "top-level parent_name field",
+		},
+		{
+			name:      "generic shadow (tags) fires and names the field",
+			spec:      Spec{Operation: OperationService, Metadata: map[string]string{"tags": "x"}},
+			wantCode:  "metadata_shadows_spec_field",
+			wantInMsg: "shadows the top-level tags field",
+		},
+		{
+			// Containers and event-driven loops nest too, so the shadow check
+			// must fire regardless of operation — this guards the placement of
+			// the check before the service-only early return.
+			name:      "shadow fires for a container, not just services",
+			spec:      Spec{Operation: OperationContainer, Metadata: map[string]string{"parent_name": "core"}},
+			wantCode:  "metadata_shadows_spec_field",
+			wantInMsg: "does not nest this loop",
+		},
+		{
+			name:     "non-shadow metadata key stays silent",
+			spec:     Spec{Operation: OperationService, Metadata: map[string]string{"owner": "alice"}},
+			wantCode: "",
+		},
+		{
+			name:     "legacy quality_floor key is not flagged",
+			spec:     Spec{Operation: OperationService, Metadata: map[string]string{"quality_floor": "3"}},
+			wantCode: "",
+		},
+		{
+			name:     "metadata key named metadata is not self-shadowed",
+			spec:     Spec{Operation: OperationService, Metadata: map[string]string{"metadata": "x"}},
+			wantCode: "",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var got *DefinitionWarning
+			for _, w := range BuildDefinitionWarnings(tc.spec) {
+				if w.Code == "metadata_shadows_spec_field" {
+					w := w
+					got = &w
+					break
+				}
+			}
+			if tc.wantCode == "" {
+				if got != nil {
+					t.Fatalf("unexpected shadow warning: %q", got.Message)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatalf("missing %q warning for spec %+v", tc.wantCode, tc.spec)
+			}
+			if tc.wantInMsg != "" && !strings.Contains(got.Message, tc.wantInMsg) {
+				t.Errorf("message = %q, want substring %q", got.Message, tc.wantInMsg)
+			}
+		})
+	}
+}
+
+func TestBuildDefinitionWarnings_MetadataShadowDeterministicOrder(t *testing.T) {
+	spec := Spec{
+		Operation: OperationService,
+		Metadata:  map[string]string{"tags": "x", "parent_name": "travel"},
+	}
+	var order []string
+	for _, w := range BuildDefinitionWarnings(spec) {
+		if w.Code == "metadata_shadows_spec_field" {
+			order = append(order, w.Message)
+		}
+	}
+	if len(order) != 2 {
+		t.Fatalf("want 2 shadow warnings, got %d: %#v", len(order), order)
+	}
+	// Keys are sorted, so parent_name (the inert-parent message) precedes tags.
+	if !strings.Contains(order[0], "parent_name") || !strings.Contains(order[1], "tags") {
+		t.Errorf("shadow warnings not deterministically sorted: %#v", order)
 	}
 }

--- a/internal/tools/loop_spec_schema.go
+++ b/internal/tools/loop_spec_schema.go
@@ -126,8 +126,12 @@ func loopSpecSchema(description string) map[string]any {
 			},
 			"metadata": map[string]any{
 				"type":                 "object",
-				"description":          "Opaque string-keyed metadata stored with the definition.",
+				"description":          "Opaque string-keyed metadata stored with the definition. Stored verbatim and never interpreted — a key here never sets a structural field. To nest this loop under a parent, use the top-level parent_name field, not a metadata entry.",
 				"additionalProperties": map[string]any{"type": "string"},
+			},
+			"parent_name": map[string]any{
+				"type":        "string",
+				"description": "Durable name of the container to nest this loop under. The loop is placed beneath that node in the loop graph and inherits the container's tags and subscriptions. This is the author-time parent reference — a name, not an id — resolved to a live parent at launch. Today only container parents are honored; naming a non-container parent carries no inheritance. Omit for a top-level loop.",
 			},
 		},
 	}

--- a/internal/tools/loop_spec_schema.go
+++ b/internal/tools/loop_spec_schema.go
@@ -126,7 +126,7 @@ func loopSpecSchema(description string) map[string]any {
 			},
 			"metadata": map[string]any{
 				"type":                 "object",
-				"description":          "Opaque string-keyed metadata stored with the definition. Stored verbatim and never interpreted — a key here never sets a structural field. To nest this loop under a parent, use the top-level parent_name field, not a metadata entry.",
+				"description":          "Opaque string-keyed metadata stored with the definition. Keys here are not interpreted as structural spec fields — a metadata entry never sets a top-level field like parent_name. To nest this loop under a parent, use the top-level parent_name field, not a metadata entry.",
 				"additionalProperties": map[string]any{"type": "string"},
 			},
 			"parent_name": map[string]any{

--- a/internal/tools/loop_spec_schema_test.go
+++ b/internal/tools/loop_spec_schema_test.go
@@ -2,6 +2,7 @@ package tools
 
 import (
 	"slices"
+	"strings"
 	"testing"
 )
 
@@ -33,11 +34,26 @@ func TestLoopSpecSchemaEnumeratesAuthorableFields(t *testing.T) {
 		"supervisor_prob", "supervisor_profile", "outputs", "tags",
 		"exclude_tools", "sleep_min", "sleep_max", "sleep_default", "jitter",
 		"max_duration", "max_iter", "on_retrigger", "conditions", "completion",
-		"subscriptions", "metadata",
+		"subscriptions", "metadata", "parent_name",
 	} {
 		if _, ok := props[key].(map[string]any); !ok {
 			t.Errorf("spec schema missing enumerated property %q", key)
 		}
+	}
+
+	// parent_name must be advertised as a string and frame the container
+	// relationship — it is the field a model otherwise misfiles into metadata
+	// (the tde-msrh-2026-06 mis-parenting incident). Guard both so the menu
+	// item can't silently regress into a bare or undocumented field.
+	pn, ok := props["parent_name"].(map[string]any)
+	if !ok {
+		t.Fatal("spec schema missing parent_name property")
+	}
+	if pn["type"] != "string" {
+		t.Errorf("parent_name must be type string, got %v", pn["type"])
+	}
+	if desc, _ := pn["description"].(string); !strings.Contains(desc, "container") {
+		t.Errorf("parent_name description must mention container nesting, got %q", desc)
 	}
 
 	// The constrained string fields must be typed string AND carry their


### PR DESCRIPTION
## What

The **write-side Tier-0 step** of #1102 — closes the menu-tree gap behind the `tde-msrh-2026-06` mis-parenting incident.

- **Adds `parent_name` to `loopSpecSchema`** (the shared spec schema for `loop_definition_set` / `loop_definition_lint` / `spawn_loop`). The field already decoded; it was simply never advertised, so a model authoring a loop never saw the way to nest it under a container.
- **Amends the `metadata` description** to say keys there are stored verbatim and never set structural fields, pointing at `parent_name` — teaching at the exact decision point where the misfile happens.
- **Adds a `metadata_shadows_spec_field` lint warning** in `BuildDefinitionWarnings` that fires when a metadata key collides with a real top-level spec field. It runs *before* the service-only early return so containers and event-driven loops (which also nest) are covered. `parent_name`/`parent_id` get a placement-specific message; other shadowed fields get a generic one.

## Why

A service loop meant to nest under a `travel` container kept landing under the root `core` node. It carried `parent_name` in its opaque `metadata` map, not the structural `spec.parent_name` field — and hydration parents exclusively off `Spec.ParentName`, never metadata. The schema advertised `metadata` but not `parent_name`, so the model filed the value in the only drawer it was shown. This makes the field visible (proactive) and flags the misfile (reactive); the structural path also fails *loudly* (`UnresolvedParentNameError`) where the metadata path failed silently.

Deferred to follow-ups under #1102: the `conditions.schedule` sub-tree documentation, and the read-side `loop_status` provenance/intent enrichment.

## Test plan

- [x] `TestLoopSpecSchemaEnumeratesAuthorableFields` — `parent_name` present, typed string, description mentions container nesting.
- [x] `TestBuildDefinitionWarnings_MetadataShadowsSpecField` — table-driven: `parent_name` fires with parent guidance; generic shadow (`tags`) fires and names the field; fires for containers too (guards the pre-early-return placement); non-shadow / legacy `quality_floor` / self-named `metadata` keys stay silent.
- [x] `TestBuildDefinitionWarnings_MetadataShadowDeterministicOrder` — sorted, stable output.
- [x] `just ci` green locally.

Refs #1102
