### PR TITLE
feat(loops): canonical LoopView — one rich row for every loop tool

### DIFF
--- a/internal/runtime/loop/loop_view.go
+++ b/internal/runtime/loop/loop_view.go
@@ -1,0 +1,301 @@
+package loop
+
+import (
+	"fmt"
+	"time"
+)
+
+// LoopView is the canonical model-facing projection of one loop — the
+// "ps auxwwww" row. Every model-facing tool that returns loop data emits
+// this single shape so the model reads one consistent, comprehensive row
+// no matter which tool surfaced the loop.
+//
+// `Running` is the discriminator. For a live loop (built via FromStatus)
+// every live-only group — lifecycle deltas, economics, error state,
+// supervisor cadence, the effective_* inheritance lists — is populated.
+// For a stored-but-not-running definition those pointer fields are nil
+// and serialize as explicit JSON null (never silently dropped), so the
+// model reads "running=false ⇒ counters null" as "not running", not
+// "zero work". Always-present scalars stay value-typed because they carry
+// meaning in both modes.
+type LoopView struct {
+	// ---- identity (PID / COMMAND) ----
+	Name       string  `json:"name"`
+	ID         *string `json:"id"`
+	Operation  string  `json:"operation"`
+	Completion string  `json:"completion,omitempty"`
+	Task       string  `json:"task"`
+	Intent     string  `json:"intent,omitempty"`
+
+	// ---- structure (graph; resolved to names, never bare IDs) ----
+	ParentName *string  `json:"parent_name"`
+	Ancestry   []string `json:"ancestry"`
+	ChildCount int      `json:"child_count"`
+
+	// ---- state (STAT) ----
+	Running      bool    `json:"running"`
+	State        *string `json:"state"`
+	PolicyState  string  `json:"policy_state"`
+	PolicySource string  `json:"policy_source,omitempty"`
+	PolicyReason *string `json:"policy_reason"`
+	Eligible     bool    `json:"eligible"`
+	EventDriven  bool    `json:"event_driven"`
+	HandlerOnly  bool    `json:"handler_only"`
+
+	// ---- lifecycle / time (delta-oriented) ----
+	StartedDelta       *string `json:"started_delta"`
+	LastWakeDelta      *string `json:"last_wake_delta"`
+	PolicyUpdatedDelta *string `json:"policy_updated_delta"`
+
+	// ---- economics (%CPU / %MEM / TIME) ----
+	Iterations        *int `json:"iterations"`
+	Attempts          *int `json:"attempts"`
+	TotalInputTokens  *int `json:"total_input_tokens"`
+	TotalOutputTokens *int `json:"total_output_tokens"`
+	LastInputTokens   *int `json:"last_input_tokens"`
+	ContextWindow     *int `json:"context_window"`
+	ContextFillPct    *int `json:"context_fill_pct"`
+
+	// ---- error state ----
+	ConsecutiveErrors *int    `json:"consecutive_errors"`
+	LastError         *string `json:"last_error"`
+
+	// ---- supervisor cadence ----
+	Supervisor            bool     `json:"supervisor"`
+	SupervisorProb        *float64 `json:"supervisor_prob"`
+	LastSupervisorIter    *int     `json:"last_supervisor_iter"`
+	LastSupervisorTrigger *string  `json:"last_supervisor_trigger"`
+	SupervisorItersAgo    *int     `json:"supervisor_iters_ago"`
+
+	// ---- inheritance + provenance (live-only; [] when running-and-empty,
+	// null when not running) ----
+	EffectiveTags             []EffectiveTag             `json:"effective_tags"`
+	EffectiveSubscriptions    []EffectiveSubscription    `json:"effective_subscriptions"`
+	EffectiveExcludeTools     []EffectiveExcludeTool     `json:"effective_exclude_tools"`
+	EffectiveRoutingFactors   []EffectiveRoutingFactor   `json:"effective_routing_factors"`
+	EffectiveDelegationGating *EffectiveDelegationGating `json:"effective_delegation_gating"`
+}
+
+// LoopPolicyInfo is the policy/eligibility slice a LoopView needs, keyed
+// by loop name and joined from the definition registry. A live Status has
+// no policy of its own; the projector left-joins this so the model reads
+// active/paused/eligible without a second tool call. HasPolicy=false means
+// no stored definition backs the loop (a pure ad-hoc spawn) — the
+// projector reports policy_state="ephemeral" rather than a misleading
+// default.
+type LoopPolicyInfo struct {
+	State          string
+	Source         string
+	Reason         string
+	UpdatedAt      time.Time
+	Eligible       bool
+	EligibleReason string
+	HasPolicy      bool
+}
+
+// LoopViewResolver carries the graph and policy joins a LoopView needs so
+// they resolve once per tool call (a single pass over the status batch),
+// not per row. Construct one with NewLoopViewResolver, then call FromStatus
+// for each loop.
+type LoopViewResolver struct {
+	nameByID     map[string]string
+	parentByID   map[string]string
+	childCount   map[string]int
+	policyByName map[string]LoopPolicyInfo
+	now          time.Time
+}
+
+// NewLoopViewResolver builds the id/name/parent/child indexes once from the
+// full status batch (so parent_name and child_count stay accurate even when
+// the displayed rows are filtered) and captures a single clock for all
+// delta strings. policyByName may be nil when no definition registry is
+// available; affected loops then report policy_state="ephemeral".
+func NewLoopViewResolver(statuses []Status, policyByName map[string]LoopPolicyInfo, now time.Time) LoopViewResolver {
+	nameByID := make(map[string]string, len(statuses))
+	parentByID := make(map[string]string, len(statuses))
+	childCount := make(map[string]int, len(statuses))
+	for _, s := range statuses {
+		nameByID[s.ID] = s.Name
+		parentByID[s.ID] = s.ParentID
+		if s.ParentID != "" {
+			childCount[s.ParentID]++
+		}
+	}
+	if policyByName == nil {
+		policyByName = map[string]LoopPolicyInfo{}
+	}
+	return LoopViewResolver{
+		nameByID:     nameByID,
+		parentByID:   parentByID,
+		childCount:   childCount,
+		policyByName: policyByName,
+		now:          now,
+	}
+}
+
+// ancestry walks the parent chain from loopID up to the root, returning
+// ancestor names ordered root→leaf. A seen-set guards against a malformed
+// cycle so a corrupt graph can't spin the walk.
+func (r LoopViewResolver) ancestry(loopID string) []string {
+	out := []string{}
+	seen := map[string]bool{loopID: true}
+	for pid := r.parentByID[loopID]; pid != "" && !seen[pid]; pid = r.parentByID[pid] {
+		seen[pid] = true
+		name, ok := r.nameByID[pid]
+		if !ok {
+			break
+		}
+		out = append(out, name)
+	}
+	// Reverse to root→leaf.
+	for i, j := 0, len(out)-1; i < j; i, j = i+1, j-1 {
+		out[i], out[j] = out[j], out[i]
+	}
+	return out
+}
+
+// FromStatus projects a live loop Status into the canonical view, joining
+// the graph (parent_name/ancestry/child_count) and the stored definition's
+// policy/eligibility. Live-only fields are all populated; only the
+// definition-joined policy half can be absent (ephemeral loops).
+func (r LoopViewResolver) FromStatus(s Status) LoopView {
+	id := s.ID
+	state := string(s.State)
+	iterations := s.Iterations
+	attempts := s.Attempts
+	totalIn := s.TotalInputTokens
+	totalOut := s.TotalOutputTokens
+	lastIn := s.LastInputTokens
+	consecErr := s.ConsecutiveErrors
+	lastErr := s.LastError
+
+	v := LoopView{
+		Name:        s.Name,
+		ID:          &id,
+		Operation:   string(s.Config.Operation),
+		Completion:  string(s.Config.Completion),
+		Task:        s.Config.Task,
+		Intent:      s.Config.Metadata["intent"],
+		Ancestry:    r.ancestry(s.ID),
+		ChildCount:  r.childCount[s.ID],
+		Running:     true,
+		State:       &state,
+		EventDriven: s.EventDriven,
+		HandlerOnly: s.HandlerOnly,
+		Iterations:  &iterations,
+		Attempts:    &attempts,
+		Supervisor:  s.Config.Supervisor,
+
+		EffectiveTags:             orEmptyLoopSlice(s.EffectiveTags),
+		EffectiveSubscriptions:    orEmptyLoopSlice(s.EffectiveSubscriptions),
+		EffectiveExcludeTools:     orEmptyLoopSlice(s.EffectiveExcludeTools),
+		EffectiveRoutingFactors:   orEmptyLoopSlice(s.EffectiveRoutingFactors),
+		EffectiveDelegationGating: s.EffectiveDelegationGating,
+	}
+
+	if pn := r.nameByID[s.ParentID]; pn != "" {
+		v.ParentName = &pn
+	}
+	if !s.StartedAt.IsZero() {
+		d := "running for " + humanLoopDuration(r.now.Sub(s.StartedAt))
+		v.StartedDelta = &d
+	}
+	if !s.LastWakeAt.IsZero() {
+		d := humanLoopDuration(r.now.Sub(s.LastWakeAt)) + " ago"
+		v.LastWakeDelta = &d
+	}
+
+	// Token economics; context fill is precomputed so the model never divides.
+	v.TotalInputTokens = &totalIn
+	v.TotalOutputTokens = &totalOut
+	v.LastInputTokens = &lastIn
+	if s.ContextWindow > 0 {
+		cw := s.ContextWindow
+		v.ContextWindow = &cw
+		if s.LastInputTokens > 0 {
+			pct := s.LastInputTokens * 100 / s.ContextWindow
+			v.ContextFillPct = &pct
+		}
+	}
+
+	v.ConsecutiveErrors = &consecErr
+	v.LastError = &lastErr
+
+	if s.Config.Supervisor {
+		prob := s.Config.SupervisorProb
+		v.SupervisorProb = &prob
+	}
+	if s.LastSupervisorIter > 0 {
+		lsi := s.LastSupervisorIter
+		v.LastSupervisorIter = &lsi
+		trig := string(s.LastSupervisorTrigger)
+		v.LastSupervisorTrigger = &trig
+		ago := s.Iterations - s.LastSupervisorIter
+		if ago < 0 {
+			ago = 0
+		}
+		v.SupervisorItersAgo = &ago
+	}
+
+	// Policy/eligibility left-joined from the stored definition.
+	if pol, ok := r.policyByName[s.Name]; ok && pol.HasPolicy {
+		v.PolicyState = pol.State
+		v.PolicySource = pol.Source
+		if pol.Reason != "" {
+			reason := pol.Reason
+			v.PolicyReason = &reason
+		}
+		if !pol.UpdatedAt.IsZero() {
+			d := humanLoopDuration(r.now.Sub(pol.UpdatedAt)) + " ago"
+			v.PolicyUpdatedDelta = &d
+		}
+		v.Eligible = pol.Eligible
+	} else {
+		// No stored definition backs this loop (ad-hoc spawn): there is no
+		// policy to report. Say so explicitly rather than implying "active".
+		v.PolicyState = "ephemeral"
+		v.Eligible = true
+	}
+
+	return v
+}
+
+// orEmptyLoopSlice returns a non-nil empty slice for a nil input so a
+// running loop with nothing to inherit serializes as `[]` (evaluated,
+// empty) rather than `null` (not running / not evaluated) — resolving the
+// Status Effective* nil-conflation at the model-facing boundary.
+func orEmptyLoopSlice[T any](s []T) []T {
+	if s == nil {
+		return []T{}
+	}
+	return s
+}
+
+// humanLoopDuration renders a duration as a compact relative string
+// ("47s", "4h12m", "2d3h") for delta-oriented timestamps. Always
+// non-negative; callers add the "ago"/"running for" framing.
+func humanLoopDuration(d time.Duration) string {
+	if d < 0 {
+		d = -d
+	}
+	switch {
+	case d < time.Minute:
+		return fmt.Sprintf("%ds", int(d.Seconds()))
+	case d < time.Hour:
+		return fmt.Sprintf("%dm", int(d.Minutes()))
+	case d < 24*time.Hour:
+		h := int(d.Hours())
+		m := int(d.Minutes()) % 60
+		if m == 0 {
+			return fmt.Sprintf("%dh", h)
+		}
+		return fmt.Sprintf("%dh%dm", h, m)
+	default:
+		days := int(d.Hours()) / 24
+		h := int(d.Hours()) % 24
+		if h == 0 {
+			return fmt.Sprintf("%dd", days)
+		}
+		return fmt.Sprintf("%dd%dh", days, h)
+	}
+}

--- a/internal/runtime/loop/loop_view.go
+++ b/internal/runtime/loop/loop_view.go
@@ -1,8 +1,9 @@
 package loop
 
 import (
-	"fmt"
 	"time"
+
+	"github.com/nugget/thane-ai-agent/internal/model/promptfmt"
 )
 
 // LoopView is the canonical model-facing projection of one loop — the
@@ -163,11 +164,7 @@ func (r LoopViewResolver) FromStatus(s Status) LoopView {
 	state := string(s.State)
 	iterations := s.Iterations
 	attempts := s.Attempts
-	totalIn := s.TotalInputTokens
-	totalOut := s.TotalOutputTokens
-	lastIn := s.LastInputTokens
 	consecErr := s.ConsecutiveErrors
-	lastErr := s.LastError
 
 	v := LoopView{
 		Name:        s.Name,
@@ -196,30 +193,44 @@ func (r LoopViewResolver) FromStatus(s Status) LoopView {
 	if pn := r.nameByID[s.ParentID]; pn != "" {
 		v.ParentName = &pn
 	}
+	// Delta-oriented timestamps per the model-facing convention: signed
+	// exact-second offsets from now (AGENTS.md), e.g. "-15120s" / "+240s".
 	if !s.StartedAt.IsZero() {
-		d := "running for " + humanLoopDuration(r.now.Sub(s.StartedAt))
+		d := promptfmt.FormatDeltaOnly(s.StartedAt, r.now)
 		v.StartedDelta = &d
 	}
 	if !s.LastWakeAt.IsZero() {
-		d := humanLoopDuration(r.now.Sub(s.LastWakeAt)) + " ago"
+		d := promptfmt.FormatDeltaOnly(s.LastWakeAt, r.now)
 		v.LastWakeDelta = &d
 	}
 
-	// Token economics; context fill is precomputed so the model never divides.
-	v.TotalInputTokens = &totalIn
-	v.TotalOutputTokens = &totalOut
-	v.LastInputTokens = &lastIn
-	if s.ContextWindow > 0 {
-		cw := s.ContextWindow
-		v.ContextWindow = &cw
-		if s.LastInputTokens > 0 {
-			pct := s.LastInputTokens * 100 / s.ContextWindow
-			v.ContextFillPct = &pct
+	// Token economics — left nil for handler-only loops, which run no LLM
+	// iterations and have no token metrics (a literal 0 would read as a real
+	// datum, not "not applicable"). Context fill is precomputed so the model
+	// never divides.
+	if !s.HandlerOnly {
+		totalIn := s.TotalInputTokens
+		totalOut := s.TotalOutputTokens
+		lastIn := s.LastInputTokens
+		v.TotalInputTokens = &totalIn
+		v.TotalOutputTokens = &totalOut
+		v.LastInputTokens = &lastIn
+		if s.ContextWindow > 0 {
+			cw := s.ContextWindow
+			v.ContextWindow = &cw
+			if s.LastInputTokens > 0 {
+				pct := s.LastInputTokens * 100 / s.ContextWindow
+				v.ContextFillPct = &pct
+			}
 		}
 	}
 
 	v.ConsecutiveErrors = &consecErr
-	v.LastError = &lastErr
+	// Null, not "", when there is no error — cleaner at the model boundary.
+	if s.LastError != "" {
+		lastErr := s.LastError
+		v.LastError = &lastErr
+	}
 
 	if s.Config.Supervisor {
 		prob := s.Config.SupervisorProb
@@ -246,7 +257,7 @@ func (r LoopViewResolver) FromStatus(s Status) LoopView {
 			v.PolicyReason = &reason
 		}
 		if !pol.UpdatedAt.IsZero() {
-			d := humanLoopDuration(r.now.Sub(pol.UpdatedAt)) + " ago"
+			d := promptfmt.FormatDeltaOnly(pol.UpdatedAt, r.now)
 			v.PolicyUpdatedDelta = &d
 		}
 		v.Eligible = pol.Eligible
@@ -269,33 +280,4 @@ func orEmptyLoopSlice[T any](s []T) []T {
 		return []T{}
 	}
 	return s
-}
-
-// humanLoopDuration renders a duration as a compact relative string
-// ("47s", "4h12m", "2d3h") for delta-oriented timestamps. Always
-// non-negative; callers add the "ago"/"running for" framing.
-func humanLoopDuration(d time.Duration) string {
-	if d < 0 {
-		d = -d
-	}
-	switch {
-	case d < time.Minute:
-		return fmt.Sprintf("%ds", int(d.Seconds()))
-	case d < time.Hour:
-		return fmt.Sprintf("%dm", int(d.Minutes()))
-	case d < 24*time.Hour:
-		h := int(d.Hours())
-		m := int(d.Minutes()) % 60
-		if m == 0 {
-			return fmt.Sprintf("%dh", h)
-		}
-		return fmt.Sprintf("%dh%dm", h, m)
-	default:
-		days := int(d.Hours()) / 24
-		h := int(d.Hours()) % 24
-		if h == 0 {
-			return fmt.Sprintf("%dd", days)
-		}
-		return fmt.Sprintf("%dd%dh", days, h)
-	}
 }

--- a/internal/runtime/loop/loop_view_test.go
+++ b/internal/runtime/loop/loop_view_test.go
@@ -1,0 +1,123 @@
+package loop
+
+import (
+	"testing"
+	"time"
+)
+
+func TestLoopViewResolver_FromStatus_RunningService(t *testing.T) {
+	now := time.Date(2026, 6, 26, 12, 0, 0, 0, time.UTC)
+	statuses := []Status{
+		{ID: "lp_core", Name: "core", Config: Config{Operation: OperationContainer}},
+		{ID: "lp_travel", Name: "travel", ParentID: "lp_core", Config: Config{Operation: OperationContainer}},
+		{ID: "lp_trip", Name: "trip", ParentID: "lp_travel", Config: Config{Operation: OperationService}},
+	}
+	policy := map[string]LoopPolicyInfo{
+		"trip": {State: "active", Source: "overlay", Eligible: true, HasPolicy: true},
+	}
+	r := NewLoopViewResolver(statuses, policy, now)
+
+	trip := Status{
+		ID:                    "lp_trip",
+		Name:                  "trip",
+		ParentID:              "lp_travel",
+		State:                 State("sleeping"),
+		StartedAt:             now.Add(-(4*time.Hour + 12*time.Minute)),
+		LastWakeAt:            now.Add(-47 * time.Second),
+		Iterations:            138,
+		Attempts:              141,
+		TotalInputTokens:      2104882,
+		TotalOutputTokens:     51440,
+		LastInputTokens:       18000,
+		ContextWindow:         200000,
+		ConsecutiveErrors:     0,
+		LastError:             "",
+		LastSupervisorIter:    135,
+		LastSupervisorTrigger: SupervisorTrigger("random"),
+		EffectiveTags:         []EffectiveTag{{Tag: "home", From: "travel"}, {Tag: "curate", From: "self"}},
+		Config:                Config{Operation: OperationService, Task: "watch ranch", Supervisor: true, SupervisorProb: 0.15},
+	}
+	v := r.FromStatus(trip)
+
+	if !v.Running {
+		t.Error("Running should be true for a live loop")
+	}
+	if v.ID == nil || *v.ID != "lp_trip" {
+		t.Errorf("ID = %v, want lp_trip", v.ID)
+	}
+	if v.ParentName == nil || *v.ParentName != "travel" {
+		t.Errorf("ParentName = %v, want travel", v.ParentName)
+	}
+	if got := v.Ancestry; len(got) != 2 || got[0] != "core" || got[1] != "travel" {
+		t.Errorf("Ancestry = %v, want [core travel] (root→leaf)", got)
+	}
+	// iterations = SUCCESSFUL turns, attempts = total incl failures.
+	if v.Iterations == nil || *v.Iterations != 138 {
+		t.Errorf("Iterations = %v, want 138", v.Iterations)
+	}
+	if v.Attempts == nil || *v.Attempts != 141 {
+		t.Errorf("Attempts = %v, want 141", v.Attempts)
+	}
+	// Precomputed so the model never divides: 18000*100/200000 = 9.
+	if v.ContextFillPct == nil || *v.ContextFillPct != 9 {
+		t.Errorf("ContextFillPct = %v, want 9", v.ContextFillPct)
+	}
+	// 138 - 135 = 3 successful turns since the last supervisor pass.
+	if v.SupervisorItersAgo == nil || *v.SupervisorItersAgo != 3 {
+		t.Errorf("SupervisorItersAgo = %v, want 3", v.SupervisorItersAgo)
+	}
+	if v.LastSupervisorTrigger == nil || *v.LastSupervisorTrigger != "random" {
+		t.Errorf("LastSupervisorTrigger = %v, want random", v.LastSupervisorTrigger)
+	}
+	if v.PolicyState != "active" || !v.Eligible {
+		t.Errorf("policy join: state=%q eligible=%v, want active/true", v.PolicyState, v.Eligible)
+	}
+	if len(v.EffectiveTags) != 2 || v.EffectiveTags[0].From != "travel" {
+		t.Errorf("EffectiveTags = %#v, want inheritance provenance carried through", v.EffectiveTags)
+	}
+	if v.StartedDelta == nil || *v.StartedDelta != "running for 4h12m" {
+		t.Errorf("StartedDelta = %v, want 'running for 4h12m'", v.StartedDelta)
+	}
+	if v.LastWakeDelta == nil || *v.LastWakeDelta != "47s ago" {
+		t.Errorf("LastWakeDelta = %v, want '47s ago'", v.LastWakeDelta)
+	}
+}
+
+func TestLoopViewResolver_FromStatus_ContainerAndEphemeral(t *testing.T) {
+	now := time.Date(2026, 6, 26, 12, 0, 0, 0, time.UTC)
+	statuses := []Status{
+		{ID: "lp_travel", Name: "travel", Config: Config{Operation: OperationContainer}},
+		{ID: "c1", Name: "c1", ParentID: "lp_travel", Config: Config{Operation: OperationService}},
+		{ID: "c2", Name: "c2", ParentID: "lp_travel", Config: Config{Operation: OperationService}},
+	}
+	r := NewLoopViewResolver(statuses, nil, now) // nil policy join
+
+	container := r.FromStatus(Status{
+		ID:     "lp_travel",
+		Name:   "travel",
+		State:  State("pending"),
+		Config: Config{Operation: OperationContainer, Metadata: map[string]string{"intent": "away trips"}},
+	})
+
+	if container.ChildCount != 2 {
+		t.Errorf("ChildCount = %d, want 2", container.ChildCount)
+	}
+	if container.Intent != "away trips" {
+		t.Errorf("Intent = %q, want the metadata intent surfaced", container.Intent)
+	}
+	if container.ParentName != nil {
+		t.Errorf("top-level container ParentName = %v, want nil", container.ParentName)
+	}
+	if len(container.Ancestry) != 0 {
+		t.Errorf("top-level Ancestry = %v, want []", container.Ancestry)
+	}
+	// No definition policy join wired → explicit "ephemeral", not a misleading default.
+	if container.PolicyState != "ephemeral" {
+		t.Errorf("PolicyState = %q, want ephemeral when no policy join", container.PolicyState)
+	}
+	// Running loop with nothing to inherit must serialize [] (evaluated-empty),
+	// never null (which would read as "not running").
+	if container.EffectiveTags == nil || len(container.EffectiveTags) != 0 {
+		t.Errorf("EffectiveTags = %#v, want non-nil empty slice for a running loop", container.EffectiveTags)
+	}
+}

--- a/internal/runtime/loop/loop_view_test.go
+++ b/internal/runtime/loop/loop_view_test.go
@@ -75,11 +75,46 @@ func TestLoopViewResolver_FromStatus_RunningService(t *testing.T) {
 	if len(v.EffectiveTags) != 2 || v.EffectiveTags[0].From != "travel" {
 		t.Errorf("EffectiveTags = %#v, want inheritance provenance carried through", v.EffectiveTags)
 	}
-	if v.StartedDelta == nil || *v.StartedDelta != "running for 4h12m" {
-		t.Errorf("StartedDelta = %v, want 'running for 4h12m'", v.StartedDelta)
+	// Signed exact-second deltas per the model-facing convention: 4h12m =
+	// 15120s ago, last wake 47s ago.
+	if v.StartedDelta == nil || *v.StartedDelta != "-15120s" {
+		t.Errorf("StartedDelta = %v, want -15120s", v.StartedDelta)
 	}
-	if v.LastWakeDelta == nil || *v.LastWakeDelta != "47s ago" {
-		t.Errorf("LastWakeDelta = %v, want '47s ago'", v.LastWakeDelta)
+	if v.LastWakeDelta == nil || *v.LastWakeDelta != "-47s" {
+		t.Errorf("LastWakeDelta = %v, want -47s", v.LastWakeDelta)
+	}
+}
+
+func TestLoopViewResolver_FromStatus_HandlerOnlyAndCleanError(t *testing.T) {
+	now := time.Date(2026, 6, 26, 12, 0, 0, 0, time.UTC)
+	r := NewLoopViewResolver(nil, nil, now)
+
+	v := r.FromStatus(Status{
+		ID:               "lp_owu",
+		Name:             "owu",
+		State:            State("waiting"),
+		HandlerOnly:      true,
+		Iterations:       537,
+		Attempts:         537,
+		TotalInputTokens: 0,
+		ContextWindow:    200000,
+		LastError:        "",
+		Config:           Config{Operation: OperationService},
+	})
+
+	// Handler-only loops run no LLM iterations — token fields are nil, not 0,
+	// so "0" can't read as a real datum.
+	if v.TotalInputTokens != nil || v.ContextWindow != nil || v.ContextFillPct != nil {
+		t.Errorf("handler-only token fields should be nil, got in=%v ctx=%v fill=%v",
+			v.TotalInputTokens, v.ContextWindow, v.ContextFillPct)
+	}
+	// Iteration counters are still meaningful for handler loops.
+	if v.Iterations == nil || *v.Iterations != 537 {
+		t.Errorf("Iterations = %v, want 537 even for handler-only", v.Iterations)
+	}
+	// No error => null, not "".
+	if v.LastError != nil {
+		t.Errorf("LastError = %v, want nil for a clean loop", v.LastError)
 	}
 }
 

--- a/internal/tools/loop_definition_mutation_tools.go
+++ b/internal/tools/loop_definition_mutation_tools.go
@@ -3,6 +3,7 @@ package tools
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	looppkg "github.com/nugget/thane-ai-agent/internal/runtime/loop"
@@ -248,4 +249,149 @@ func (r *Registry) handleLoopDefinitionLaunch(ctx context.Context, args map[stri
 		"definition": def,
 		"result":     result,
 	})
+}
+
+// handleLoopReparent moves a stored loop under a different container (or to
+// top-level) by name and relaunches it so it re-homes immediately. Parenting
+// is resolved at launch, so a plain definition edit does not move a running
+// loop — this verb pairs the parent_name change with a stop+reconcile so the
+// loop comes back up under the new parent in one step. It is the first-class
+// form of the manual edit-then-relaunch recipe.
+func (r *Registry) handleLoopReparent(ctx context.Context, args map[string]any) (string, error) {
+	if r.loopDefinitionRegistry == nil {
+		return "", fmt.Errorf("loop definition registry not configured")
+	}
+	name := toolargs.TrimmedString(args, "name")
+	if name == "" {
+		return "", fmt.Errorf("name is required")
+	}
+	// Empty, omitted, or "core" means top-level: directly under the
+	// structural root, with no container inheritance.
+	target := toolargs.TrimmedString(args, "parent_name")
+	topLevel := target == "" || strings.EqualFold(target, "core")
+
+	snapshot, err := currentLoopDefinitionSnapshot(r)
+	if err != nil {
+		return "", err
+	}
+	def, ok := looppkg.FindDefinition(snapshot, name)
+	if !ok {
+		return "", (&looppkg.UnknownDefinitionError{Name: name})
+	}
+	if def.Source == looppkg.DefinitionSourceConfig {
+		return "", (&looppkg.ImmutableDefinitionError{Name: name})
+	}
+
+	live := r.loopIntentDeps.LiveRegistry
+
+	newParent := ""
+	if !topLevel {
+		if strings.EqualFold(target, name) {
+			return "", fmt.Errorf("cannot reparent %q under itself", name)
+		}
+		if live == nil {
+			return "", fmt.Errorf("live registry not configured; cannot resolve container %q", target)
+		}
+		container := live.GetByName(target)
+		if container == nil {
+			return "", fmt.Errorf("target container %q is not currently registered; create it first or wait for hydration", target)
+		}
+		if container.Operation() != looppkg.OperationContainer {
+			return "", fmt.Errorf("target %q is a %s, not a container; loops can only nest under containers", target, container.Operation())
+		}
+		newParent = container.Name()
+	}
+
+	oldParent := strings.TrimSpace(def.Spec.ParentName)
+	if oldParent == newParent {
+		dest := newParent
+		if dest == "" {
+			dest = "core (top-level)"
+		}
+		return ldMarshalToolJSON(map[string]any{
+			"status":      "noop",
+			"name":        name,
+			"parent_name": newParent,
+			"detail":      fmt.Sprintf("%q is already parented to %s", name, dest),
+		})
+	}
+
+	// A container being moved must not have live children: descendants resolve
+	// their home from the container's current launch, so relaunching it would
+	// strand them. Reparent or stop the children first.
+	if live != nil && def.Spec.Operation == looppkg.OperationContainer {
+		if cur := live.GetByName(name); cur != nil {
+			if children := live.Children(cur.ID()); len(children) > 0 {
+				kids := make([]string, 0, len(children))
+				for _, c := range children {
+					kids = append(kids, c.Name())
+				}
+				return "", fmt.Errorf("container %q still has %d child loop(s): %v; reparent or stop them before moving the container", name, len(children), kids)
+			}
+		}
+	}
+
+	// Commit the new structural parent onto the persisted spec. ParentID is
+	// cleared so hydration resolves parent_name -> the live parent id afresh.
+	spec := def.Spec
+	spec.ParentName = newParent
+	spec.ParentID = ""
+	updatedAt := time.Now().UTC()
+	if r.commitLoopDefinitionSpec != nil {
+		if err := r.commitLoopDefinitionSpec(ctx, spec, updatedAt); err != nil {
+			return "", err
+		}
+	} else if err := r.loopDefinitionRegistry.Upsert(spec, updatedAt); err != nil {
+		return "", err
+	}
+
+	// The commit reconciles, but reconcile is a no-op on an already-running
+	// loop. Force a relaunch so the loop re-homes: stop it (StopLoop
+	// deregisters synchronously once the goroutine exits), then reconcile to
+	// respawn through the hydration path that resolves parent_name.
+	relaunched := false
+	if live != nil {
+		if cur := live.GetByName(name); cur != nil {
+			if err := live.StopLoop(cur.ID()); err != nil {
+				return "", fmt.Errorf("parent_name updated but relaunch could not stop %q: %w", name, err)
+			}
+			if live.GetByName(name) != nil {
+				return "", fmt.Errorf("parent_name updated but %q did not stop cleanly; run loop_reparent again to finish the relaunch", name)
+			}
+			relaunched = true
+		}
+	}
+	if r.reconcileLoopDefinition != nil {
+		if err := r.reconcileLoopDefinition(ctx, name); err != nil {
+			return "", fmt.Errorf("reconcile after reparent: %w", err)
+		}
+	}
+
+	result := map[string]any{
+		"status":      "ok",
+		"name":        name,
+		"old_parent":  oldParent,
+		"parent_name": newParent,
+		"relaunched":  relaunched,
+	}
+	if newParent == "" {
+		result["detail"] = fmt.Sprintf("%q moved to top-level (under core)", name)
+	} else {
+		result["detail"] = fmt.Sprintf("%q reparented under %q", name, newParent)
+	}
+	// Return the moved loop as the canonical LoopView so the model reads back
+	// the full row — new parent_name, ancestry, inherited tags — in the same
+	// shape loop_status emits. old_parent/relaunched stay envelope-level as
+	// transition facts that aren't loop-row fields.
+	if live != nil {
+		statuses := live.Statuses()
+		resolver := looppkg.NewLoopViewResolver(statuses, r.loopPolicyByName(), time.Now())
+		for _, s := range statuses {
+			if s.Name == name {
+				result["loop"] = resolver.FromStatus(s)
+				break
+			}
+		}
+	}
+	return ldMarshalToolJSON(result)
 }

--- a/internal/tools/loop_definition_mutation_tools.go
+++ b/internal/tools/loop_definition_mutation_tools.go
@@ -265,10 +265,13 @@ func (r *Registry) handleLoopReparent(ctx context.Context, args map[string]any) 
 	if name == "" {
 		return "", fmt.Errorf("name is required")
 	}
-	// Empty, omitted, or "core" means top-level: directly under the
-	// structural root, with no container inheritance.
+	// Empty, omitted, or the core name means top-level: directly under the
+	// structural root, with no container inheritance. Match the core name
+	// exactly — loop names are case-sensitive everywhere else (GetByName,
+	// Spec.Validate), so a real container named "Core" must not be treated
+	// as the root.
 	target := toolargs.TrimmedString(args, "parent_name")
-	topLevel := target == "" || strings.EqualFold(target, "core")
+	topLevel := target == "" || target == looppkg.CoreLoopName
 
 	snapshot, err := currentLoopDefinitionSnapshot(r)
 	if err != nil {
@@ -282,11 +285,19 @@ func (r *Registry) handleLoopReparent(ctx context.Context, args map[string]any) 
 		return "", (&looppkg.ImmutableDefinitionError{Name: name})
 	}
 
-	live := r.loopIntentDeps.LiveRegistry
+	// Prefer the always-wired runtime registry. loopIntentDeps is only
+	// configured when the intent-tool surface is enabled (conditional on doc
+	// tools), so relying on it would silently disable container resolution,
+	// the children guard, and the relaunch in common configurations. Fall
+	// back to it for registry-only test setups.
+	live := r.liveLoopRegistry
+	if live == nil {
+		live = r.loopIntentDeps.LiveRegistry
+	}
 
 	newParent := ""
 	if !topLevel {
-		if strings.EqualFold(target, name) {
+		if target == name {
 			return "", fmt.Errorf("cannot reparent %q under itself", name)
 		}
 		if live == nil {
@@ -302,16 +313,34 @@ func (r *Registry) handleLoopReparent(ctx context.Context, args map[string]any) 
 		newParent = container.Name()
 	}
 
+	// attachLoopView adds the moved loop's canonical row to a result so ok and
+	// noop responses share one shape the model can read uniformly.
+	attachLoopView := func(result map[string]any) (string, error) {
+		if live != nil {
+			statuses := live.Statuses()
+			resolver := looppkg.NewLoopViewResolver(statuses, r.loopPolicyByName(), time.Now())
+			for _, s := range statuses {
+				if s.Name == name {
+					result["loop"] = resolver.FromStatus(s)
+					break
+				}
+			}
+		}
+		return ldMarshalToolJSON(result)
+	}
+
 	oldParent := strings.TrimSpace(def.Spec.ParentName)
 	if oldParent == newParent {
 		dest := newParent
 		if dest == "" {
 			dest = "core (top-level)"
 		}
-		return ldMarshalToolJSON(map[string]any{
+		return attachLoopView(map[string]any{
 			"status":      "noop",
 			"name":        name,
+			"old_parent":  oldParent,
 			"parent_name": newParent,
+			"relaunched":  false,
 			"detail":      fmt.Sprintf("%q is already parented to %s", name, dest),
 		})
 	}
@@ -379,19 +408,7 @@ func (r *Registry) handleLoopReparent(ctx context.Context, args map[string]any) 
 	} else {
 		result["detail"] = fmt.Sprintf("%q reparented under %q", name, newParent)
 	}
-	// Return the moved loop as the canonical LoopView so the model reads back
-	// the full row — new parent_name, ancestry, inherited tags — in the same
-	// shape loop_status emits. old_parent/relaunched stay envelope-level as
-	// transition facts that aren't loop-row fields.
-	if live != nil {
-		statuses := live.Statuses()
-		resolver := looppkg.NewLoopViewResolver(statuses, r.loopPolicyByName(), time.Now())
-		for _, s := range statuses {
-			if s.Name == name {
-				result["loop"] = resolver.FromStatus(s)
-				break
-			}
-		}
-	}
-	return ldMarshalToolJSON(result)
+	// Return the moved loop as the canonical LoopView (same shape loop_status
+	// emits); old_parent/relaunched stay envelope-level as transition facts.
+	return attachLoopView(result)
 }

--- a/internal/tools/loop_definition_tools.go
+++ b/internal/tools/loop_definition_tools.go
@@ -237,4 +237,24 @@ func (r *Registry) registerLoopDefinitionTools() {
 		},
 		Handler: r.handleLoopDefinitionLaunch,
 	})
+
+	r.Register(&Tool{
+		Name:        "loop_reparent",
+		Description: "Move a stored loop under a different container by name and relaunch it so it re-homes immediately. This is the correct way to fix a loop that sits in the wrong place in the loop graph: set parent_name to the destination container, or omit it (or pass \"core\") to move the loop to top-level. The loop inherits the destination container's tags and subscriptions on relaunch. Parenting is resolved at launch, so editing parent_name alone does NOT move a running loop — this verb pairs the change with the relaunch. Config-owned definitions are immutable; a container that still has live children must have them moved or stopped first.",
+		Parameters: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"name": map[string]any{
+					"type":        "string",
+					"description": "Name of the loop (or childless container) to move.",
+				},
+				"parent_name": map[string]any{
+					"type":        "string",
+					"description": "Name of the destination container. Omit, leave empty, or pass \"core\" to move the loop to top-level (directly under the structural root).",
+				},
+			},
+			"required": []string{"name"},
+		},
+		Handler: r.handleLoopReparent,
+	})
 }

--- a/internal/tools/loop_reparent_test.go
+++ b/internal/tools/loop_reparent_test.go
@@ -1,0 +1,173 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	looppkg "github.com/nugget/thane-ai-agent/internal/runtime/loop"
+)
+
+type reparentHarness struct {
+	tool           *Tool
+	defReg         *looppkg.DefinitionRegistry
+	live           *looppkg.Registry
+	reconcileCalls *[]string
+}
+
+// newReparentHarness builds a fresh graph each call so the mutating happy
+// path can't bleed into the validation cases: live containers travel +
+// temporal, a service loop trip parented under travel, and a standalone
+// service loop trip2. Overlay definitions back each one so the reparent
+// handler's FindDefinition/commit path is exercised end to end.
+func newReparentHarness(t *testing.T) reparentHarness {
+	t.Helper()
+	runner := noopLoopRunner{}
+	live := looppkg.NewRegistry()
+
+	mk := func(name string, op looppkg.Operation, parentID string) *looppkg.Loop {
+		cfg := looppkg.Config{Name: name, Operation: op, ParentID: parentID}
+		if op != looppkg.OperationContainer {
+			cfg.Task = "do " + name // executing loops require a task; containers never run one
+		}
+		l, err := looppkg.New(cfg, looppkg.Deps{Runner: runner})
+		if err != nil {
+			t.Fatalf("New(%s): %v", name, err)
+		}
+		if err := live.Register(l); err != nil {
+			t.Fatalf("Register(%s): %v", name, err)
+		}
+		return l
+	}
+	travel := mk("travel", looppkg.OperationContainer, "")
+	mk("temporal", looppkg.OperationContainer, "")
+	mk("trip", looppkg.OperationService, travel.ID()) // child of travel
+	mk("trip2", looppkg.OperationService, "")
+
+	defReg, err := looppkg.NewDefinitionRegistry(nil)
+	if err != nil {
+		t.Fatalf("NewDefinitionRegistry: %v", err)
+	}
+	now := time.Now().UTC()
+	for _, spec := range []looppkg.Spec{
+		{Name: "travel", Operation: looppkg.OperationContainer},
+		{Name: "temporal", Operation: looppkg.OperationContainer},
+		{Name: "trip", Operation: looppkg.OperationService, Task: "do trip"},
+		{Name: "trip2", Operation: looppkg.OperationService, Task: "do trip2"},
+	} {
+		if err := defReg.Upsert(spec, now); err != nil {
+			t.Fatalf("Upsert(%s): %v", spec.Name, err)
+		}
+	}
+
+	reconcileCalls := &[]string{}
+	reg := NewEmptyRegistry()
+	reg.ConfigureLoopDefinitionTools(LoopDefinitionToolDeps{
+		Registry:   defReg,
+		CommitSpec: upsertCommitSpec(defReg),
+		Reconcile: func(_ context.Context, name string) error {
+			*reconcileCalls = append(*reconcileCalls, name)
+			return nil
+		},
+	})
+	reg.ConfigureLoopIntentTools(LoopIntentToolDeps{
+		Registry:   defReg,
+		CommitSpec: upsertCommitSpec(defReg),
+		LaunchDefinition: func(_ context.Context, _ string, _ looppkg.Launch) (looppkg.LaunchResult, error) {
+			return looppkg.LaunchResult{}, nil
+		},
+		LiveRegistry: live,
+	})
+
+	tool := reg.Get("loop_reparent")
+	if tool == nil {
+		t.Fatal("loop_reparent tool not registered")
+	}
+	return reparentHarness{tool: tool, defReg: defReg, live: live, reconcileCalls: reconcileCalls}
+}
+
+func (h reparentHarness) defParentName(t *testing.T, name string) string {
+	t.Helper()
+	def, ok := looppkg.FindDefinition(h.defReg.Snapshot(), name)
+	if !ok {
+		t.Fatalf("definition %q not found", name)
+	}
+	return def.Spec.ParentName
+}
+
+func TestLoopReparent_HappyPath(t *testing.T) {
+	h := newReparentHarness(t)
+
+	out, err := h.tool.Handler(context.Background(), map[string]any{"name": "trip", "parent_name": "travel"})
+	if err != nil {
+		t.Fatalf("reparent: %v", err)
+	}
+	var res map[string]any
+	if err := json.Unmarshal([]byte(out), &res); err != nil {
+		t.Fatalf("unmarshal result: %v", err)
+	}
+	if res["status"] != "ok" || res["parent_name"] != "travel" {
+		t.Fatalf("result status/parent_name = %v/%v, want ok/travel: %s", res["status"], res["parent_name"], out)
+	}
+	// The durable structural fix: the persisted spec now names the new parent.
+	if got := h.defParentName(t, "trip"); got != "travel" {
+		t.Errorf("persisted parent_name = %q, want travel", got)
+	}
+	// The relaunch: the running loop was stopped (deregistered) and reconcile
+	// was asked to bring it back under the new parent.
+	if h.live.GetByName("trip") != nil {
+		t.Error("trip should have been stopped for relaunch")
+	}
+	if len(*h.reconcileCalls) == 0 || (*h.reconcileCalls)[len(*h.reconcileCalls)-1] != "trip" {
+		t.Errorf("reconcile calls = %v, want trip reconciled", *h.reconcileCalls)
+	}
+}
+
+func TestLoopReparent_Validations(t *testing.T) {
+	cases := []struct {
+		name    string
+		args    map[string]any
+		wantErr string
+	}{
+		{"unknown loop", map[string]any{"name": "ghost", "parent_name": "travel"}, "ghost"},
+		{"reparent to self", map[string]any{"name": "trip", "parent_name": "trip"}, "itself"},
+		{"target not a container", map[string]any{"name": "trip", "parent_name": "trip2"}, "not a container"},
+		{"move container with live children", map[string]any{"name": "travel", "parent_name": "temporal"}, "child loop"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newReparentHarness(t)
+			_, err := h.tool.Handler(context.Background(), tc.args)
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("err = %v, want substring %q", err, tc.wantErr)
+			}
+			// A rejected reparent must not have mutated the persisted parent.
+			if name, _ := tc.args["name"].(string); name == "trip" {
+				if got := h.defParentName(t, "trip"); got != "" {
+					t.Errorf("parent_name = %q after rejected reparent, want unchanged empty", got)
+				}
+			}
+		})
+	}
+}
+
+func TestLoopReparent_NoopWhenAlreadyParented(t *testing.T) {
+	h := newReparentHarness(t)
+	// Move trip under travel, then ask again — second call is a no-op.
+	if _, err := h.tool.Handler(context.Background(), map[string]any{"name": "trip", "parent_name": "travel"}); err != nil {
+		t.Fatalf("first reparent: %v", err)
+	}
+	out, err := h.tool.Handler(context.Background(), map[string]any{"name": "trip", "parent_name": "travel"})
+	if err != nil {
+		t.Fatalf("second reparent: %v", err)
+	}
+	var res map[string]any
+	if err := json.Unmarshal([]byte(out), &res); err != nil {
+		t.Fatalf("unmarshal result: %v", err)
+	}
+	if res["status"] != "noop" {
+		t.Errorf("second reparent should be a noop, got %s", out)
+	}
+}

--- a/internal/tools/loop_reparent_test.go
+++ b/internal/tools/loop_reparent_test.go
@@ -170,4 +170,12 @@ func TestLoopReparent_NoopWhenAlreadyParented(t *testing.T) {
 	if res["status"] != "noop" {
 		t.Errorf("second reparent should be a noop, got %s", out)
 	}
+	// A noop carries the same envelope fields as ok, so callers read both
+	// shapes uniformly.
+	if _, ok := res["old_parent"]; !ok {
+		t.Errorf("noop result missing old_parent (should match the ok envelope): %s", out)
+	}
+	if res["relaunched"] != false {
+		t.Errorf("noop relaunched = %v, want false", res["relaunched"])
+	}
 }

--- a/internal/tools/loop_runtime_tools.go
+++ b/internal/tools/loop_runtime_tools.go
@@ -17,35 +17,6 @@ const (
 	maxLoopStatusLimit     = 200
 )
 
-type loopStatusView struct {
-	ID                    string                 `json:"id"`
-	Name                  string                 `json:"name"`
-	State                 looppkg.State          `json:"state"`
-	Operation             looppkg.Operation      `json:"operation,omitempty"`
-	Completion            looppkg.Completion     `json:"completion,omitempty"`
-	Intent                string                 `json:"intent,omitempty"`
-	ParentID              string                 `json:"parent_id,omitempty"`
-	ParentName            string                 `json:"parent_name,omitempty"`
-	ChildCount            int                    `json:"child_count"`
-	StartedAt             time.Time              `json:"started_at"`
-	LastWakeAt            time.Time              `json:"last_wake_at,omitempty"`
-	Iterations            int                    `json:"iterations"`
-	Attempts              int                    `json:"attempts"`
-	TotalInputTokens      int                    `json:"total_input_tokens"`
-	TotalOutputTokens     int                    `json:"total_output_tokens"`
-	LastInputTokens       int                    `json:"last_input_tokens,omitempty"`
-	LastOutputTokens      int                    `json:"last_output_tokens,omitempty"`
-	LastError             string                 `json:"last_error,omitempty"`
-	ConsecutiveErrors     int                    `json:"consecutive_errors,omitempty"`
-	HandlerOnly           bool                   `json:"handler_only,omitempty"`
-	EventDriven           bool                   `json:"event_driven,omitempty"`
-	LastSupervisorIter    int                    `json:"last_supervisor_iter,omitempty"`
-	LastSupervisorTrigger string                 `json:"last_supervisor_trigger,omitempty"`
-	ActiveTags            []string               `json:"active_tags,omitempty"`
-	EffectiveTags         []looppkg.EffectiveTag `json:"effective_tags,omitempty"`
-	Metadata              map[string]string      `json:"metadata,omitempty"`
-}
-
 // LoopRuntimeToolDeps wires the live loop registry and ad hoc launch path
 // into the tool registry so the model can inspect and control currently
 // running loops.
@@ -69,7 +40,7 @@ func (r *Registry) registerLoopRuntimeTools() {
 
 	r.Register(&Tool{
 		Name:        "loop_status",
-		Description: "Inspect the live loop registry. Returns compact structured status for currently running loops, with optional filters by query text, state, operation, and a result limit.",
+		Description: "Inspect the live loop registry. Returns a rich canonical row per running loop — identity, parent container and ancestry, lifecycle counters (successful iterations vs attempts), token economics, state and policy, supervisor cadence, and effective tags/subscriptions with inheritance provenance — with optional filters by query text, state, operation, and a result limit.",
 		Parameters: map[string]any{
 			"type": "object",
 			"properties": map[string]any{
@@ -83,8 +54,8 @@ func (r *Registry) registerLoopRuntimeTools() {
 				},
 				"operation": map[string]any{
 					"type":        "string",
-					"enum":        []string{"request_reply", "background_task", "service"},
-					"description": "Optional exact operation filter.",
+					"enum":        []string{"request_reply", "background_task", "service", "container", "event_driven"},
+					"description": "Optional exact operation filter. Use container to list only grouping nodes.",
 				},
 				"limit": map[string]any{
 					"type":        "integer",
@@ -176,23 +147,16 @@ func (r *Registry) handleLoopStatus(_ context.Context, args map[string]any) (str
 	limit := clampLoopListLimit(toolargs.Int(args, "limit"), defaultLoopStatusLimit, maxLoopStatusLimit)
 
 	statuses := r.liveLoopRegistry.Statuses()
-	// Derive name and child-count lookups from the FULL set (before the
-	// display filter) so parent_name and child_count stay accurate even when
-	// the parent or some children are filtered out of the returned rows.
-	nameByID := make(map[string]string, len(statuses))
-	childCount := make(map[string]int, len(statuses))
-	for _, status := range statuses {
-		nameByID[status.ID] = status.Name
-		if status.ParentID != "" {
-			childCount[status.ParentID]++
-		}
-	}
-	filtered := make([]loopStatusView, 0, len(statuses))
+	// One resolver over the FULL status set (graph joins built once, not
+	// per row) plus the definition-policy join, so every row is the canonical
+	// LoopView — the same rich shape every loop-data tool emits.
+	resolver := looppkg.NewLoopViewResolver(statuses, r.loopPolicyByName(), time.Now())
+	filtered := make([]looppkg.LoopView, 0, len(statuses))
 	for _, status := range statuses {
 		if !matchLoopStatus(status, query, state, operation) {
 			continue
 		}
-		filtered = append(filtered, summarizeLoopStatus(status, nameByID, childCount))
+		filtered = append(filtered, resolver.FromStatus(status))
 		if len(filtered) >= limit {
 			break
 		}
@@ -416,49 +380,29 @@ func matchLoopStatus(status looppkg.Status, query, state string, operation loopp
 	return false
 }
 
-// summarizeLoopStatus projects a runtime Status into the compact model-facing
-// row. nameByID and childCount are derived once from the full status set so a
-// row can show the human parent_name (not just an opaque parent_id) and how
-// many children a container holds — the grouping facts the model needs but
-// would otherwise have to reconstruct by cross-referencing parent_id itself.
-func summarizeLoopStatus(status looppkg.Status, nameByID map[string]string, childCount map[string]int) loopStatusView {
-	return loopStatusView{
-		ID:                    status.ID,
-		Name:                  status.Name,
-		State:                 status.State,
-		Operation:             status.Config.Operation,
-		Completion:            status.Config.Completion,
-		Intent:                status.Config.Metadata["intent"],
-		ParentID:              status.ParentID,
-		ParentName:            nameByID[status.ParentID],
-		ChildCount:            childCount[status.ID],
-		StartedAt:             status.StartedAt,
-		LastWakeAt:            status.LastWakeAt,
-		Iterations:            status.Iterations,
-		Attempts:              status.Attempts,
-		TotalInputTokens:      status.TotalInputTokens,
-		TotalOutputTokens:     status.TotalOutputTokens,
-		LastInputTokens:       status.LastInputTokens,
-		LastOutputTokens:      status.LastOutputTokens,
-		LastError:             status.LastError,
-		ConsecutiveErrors:     status.ConsecutiveErrors,
-		HandlerOnly:           status.HandlerOnly,
-		EventDriven:           status.EventDriven,
-		LastSupervisorIter:    status.LastSupervisorIter,
-		LastSupervisorTrigger: string(status.LastSupervisorTrigger),
-		ActiveTags:            append([]string(nil), status.ActiveTags...),
-		EffectiveTags:         append([]looppkg.EffectiveTag(nil), status.EffectiveTags...),
-		Metadata:              cloneLoopMetadata(status.Config.Metadata),
-	}
-}
-
-func cloneLoopMetadata(src map[string]string) map[string]string {
-	if len(src) == 0 {
+// loopPolicyByName builds the name→policy/eligibility join the LoopView
+// projector left-joins onto live loops, so each row shows active/paused and
+// eligibility without a second tool call. Returns nil when no definition
+// view is wired (loops then report policy_state="ephemeral").
+func (r *Registry) loopPolicyByName() map[string]looppkg.LoopPolicyInfo {
+	if r.loopDefinitionView == nil {
 		return nil
 	}
-	dst := make(map[string]string, len(src))
-	for k, v := range src {
-		dst[k] = v
+	view := r.loopDefinitionView()
+	if view == nil {
+		return nil
 	}
-	return dst
+	out := make(map[string]looppkg.LoopPolicyInfo, len(view.Definitions))
+	for _, def := range view.Definitions {
+		out[def.Name] = looppkg.LoopPolicyInfo{
+			State:          string(def.PolicyState),
+			Source:         string(def.PolicySource),
+			Reason:         def.PolicyReason,
+			UpdatedAt:      def.PolicyUpdatedAt,
+			Eligible:       def.Eligibility.Eligible,
+			EligibleReason: def.Eligibility.Reason,
+			HasPolicy:      true,
+		}
+	}
+	return out
 }

--- a/internal/tools/loop_runtime_tools.go
+++ b/internal/tools/loop_runtime_tools.go
@@ -18,28 +18,32 @@ const (
 )
 
 type loopStatusView struct {
-	ID                    string             `json:"id"`
-	Name                  string             `json:"name"`
-	State                 looppkg.State      `json:"state"`
-	Operation             looppkg.Operation  `json:"operation,omitempty"`
-	Completion            looppkg.Completion `json:"completion,omitempty"`
-	ParentID              string             `json:"parent_id,omitempty"`
-	StartedAt             time.Time          `json:"started_at"`
-	LastWakeAt            time.Time          `json:"last_wake_at,omitempty"`
-	Iterations            int                `json:"iterations"`
-	Attempts              int                `json:"attempts"`
-	TotalInputTokens      int                `json:"total_input_tokens"`
-	TotalOutputTokens     int                `json:"total_output_tokens"`
-	LastInputTokens       int                `json:"last_input_tokens,omitempty"`
-	LastOutputTokens      int                `json:"last_output_tokens,omitempty"`
-	LastError             string             `json:"last_error,omitempty"`
-	ConsecutiveErrors     int                `json:"consecutive_errors,omitempty"`
-	HandlerOnly           bool               `json:"handler_only,omitempty"`
-	EventDriven           bool               `json:"event_driven,omitempty"`
-	LastSupervisorIter    int                `json:"last_supervisor_iter,omitempty"`
-	LastSupervisorTrigger string             `json:"last_supervisor_trigger,omitempty"`
-	ActiveTags            []string           `json:"active_tags,omitempty"`
-	Metadata              map[string]string  `json:"metadata,omitempty"`
+	ID                    string                 `json:"id"`
+	Name                  string                 `json:"name"`
+	State                 looppkg.State          `json:"state"`
+	Operation             looppkg.Operation      `json:"operation,omitempty"`
+	Completion            looppkg.Completion     `json:"completion,omitempty"`
+	Intent                string                 `json:"intent,omitempty"`
+	ParentID              string                 `json:"parent_id,omitempty"`
+	ParentName            string                 `json:"parent_name,omitempty"`
+	ChildCount            int                    `json:"child_count"`
+	StartedAt             time.Time              `json:"started_at"`
+	LastWakeAt            time.Time              `json:"last_wake_at,omitempty"`
+	Iterations            int                    `json:"iterations"`
+	Attempts              int                    `json:"attempts"`
+	TotalInputTokens      int                    `json:"total_input_tokens"`
+	TotalOutputTokens     int                    `json:"total_output_tokens"`
+	LastInputTokens       int                    `json:"last_input_tokens,omitempty"`
+	LastOutputTokens      int                    `json:"last_output_tokens,omitempty"`
+	LastError             string                 `json:"last_error,omitempty"`
+	ConsecutiveErrors     int                    `json:"consecutive_errors,omitempty"`
+	HandlerOnly           bool                   `json:"handler_only,omitempty"`
+	EventDriven           bool                   `json:"event_driven,omitempty"`
+	LastSupervisorIter    int                    `json:"last_supervisor_iter,omitempty"`
+	LastSupervisorTrigger string                 `json:"last_supervisor_trigger,omitempty"`
+	ActiveTags            []string               `json:"active_tags,omitempty"`
+	EffectiveTags         []looppkg.EffectiveTag `json:"effective_tags,omitempty"`
+	Metadata              map[string]string      `json:"metadata,omitempty"`
 }
 
 // LoopRuntimeToolDeps wires the live loop registry and ad hoc launch path
@@ -172,12 +176,23 @@ func (r *Registry) handleLoopStatus(_ context.Context, args map[string]any) (str
 	limit := clampLoopListLimit(toolargs.Int(args, "limit"), defaultLoopStatusLimit, maxLoopStatusLimit)
 
 	statuses := r.liveLoopRegistry.Statuses()
+	// Derive name and child-count lookups from the FULL set (before the
+	// display filter) so parent_name and child_count stay accurate even when
+	// the parent or some children are filtered out of the returned rows.
+	nameByID := make(map[string]string, len(statuses))
+	childCount := make(map[string]int, len(statuses))
+	for _, status := range statuses {
+		nameByID[status.ID] = status.Name
+		if status.ParentID != "" {
+			childCount[status.ParentID]++
+		}
+	}
 	filtered := make([]loopStatusView, 0, len(statuses))
 	for _, status := range statuses {
 		if !matchLoopStatus(status, query, state, operation) {
 			continue
 		}
-		filtered = append(filtered, summarizeLoopStatus(status))
+		filtered = append(filtered, summarizeLoopStatus(status, nameByID, childCount))
 		if len(filtered) >= limit {
 			break
 		}
@@ -401,14 +416,22 @@ func matchLoopStatus(status looppkg.Status, query, state string, operation loopp
 	return false
 }
 
-func summarizeLoopStatus(status looppkg.Status) loopStatusView {
+// summarizeLoopStatus projects a runtime Status into the compact model-facing
+// row. nameByID and childCount are derived once from the full status set so a
+// row can show the human parent_name (not just an opaque parent_id) and how
+// many children a container holds — the grouping facts the model needs but
+// would otherwise have to reconstruct by cross-referencing parent_id itself.
+func summarizeLoopStatus(status looppkg.Status, nameByID map[string]string, childCount map[string]int) loopStatusView {
 	return loopStatusView{
 		ID:                    status.ID,
 		Name:                  status.Name,
 		State:                 status.State,
 		Operation:             status.Config.Operation,
 		Completion:            status.Config.Completion,
+		Intent:                status.Config.Metadata["intent"],
 		ParentID:              status.ParentID,
+		ParentName:            nameByID[status.ParentID],
+		ChildCount:            childCount[status.ID],
 		StartedAt:             status.StartedAt,
 		LastWakeAt:            status.LastWakeAt,
 		Iterations:            status.Iterations,
@@ -424,6 +447,7 @@ func summarizeLoopStatus(status looppkg.Status) loopStatusView {
 		LastSupervisorIter:    status.LastSupervisorIter,
 		LastSupervisorTrigger: string(status.LastSupervisorTrigger),
 		ActiveTags:            append([]string(nil), status.ActiveTags...),
+		EffectiveTags:         append([]looppkg.EffectiveTag(nil), status.EffectiveTags...),
 		Metadata:              cloneLoopMetadata(status.Config.Metadata),
 	}
 }

--- a/internal/tools/loop_runtime_tools.go
+++ b/internal/tools/loop_runtime_tools.go
@@ -153,10 +153,13 @@ func (r *Registry) handleLoopStatus(_ context.Context, args map[string]any) (str
 	resolver := looppkg.NewLoopViewResolver(statuses, r.loopPolicyByName(), time.Now())
 	filtered := make([]looppkg.LoopView, 0, len(statuses))
 	for _, status := range statuses {
-		if !matchLoopStatus(status, query, state, operation) {
+		// Project first so the query can match the human parent_name/ancestry
+		// the row now surfaces, not just the opaque parent_id.
+		view := resolver.FromStatus(status)
+		if !matchLoopStatus(status, view, query, state, operation) {
 			continue
 		}
-		filtered = append(filtered, resolver.FromStatus(status))
+		filtered = append(filtered, view)
 		if len(filtered) >= limit {
 			break
 		}
@@ -359,18 +362,29 @@ func clampLoopListLimit(raw, def, max int) int {
 	}
 }
 
-func matchLoopStatus(status looppkg.Status, query, state string, operation looppkg.Operation) bool {
+func matchLoopStatus(status looppkg.Status, view looppkg.LoopView, query, state string, operation looppkg.Operation) bool {
 	if state != "" && strings.ToLower(string(status.State)) != state {
 		return false
 	}
-	if operation != "" && status.Config.Operation != operation {
+	if operation != "" && !matchLoopOperation(status, operation) {
 		return false
 	}
 	if query == "" {
 		return true
 	}
-	if strings.Contains(strings.ToLower(status.ID), query) || strings.Contains(strings.ToLower(status.Name), query) || strings.Contains(strings.ToLower(status.ParentID), query) {
+	if strings.Contains(strings.ToLower(status.ID), query) || strings.Contains(strings.ToLower(status.Name), query) {
 		return true
+	}
+	// Match the human parent/ancestry names the row surfaces, so searching a
+	// container name (e.g. "travel") finds its descendants — the opaque
+	// parent_id is no longer the searchable handle.
+	if view.ParentName != nil && strings.Contains(strings.ToLower(*view.ParentName), query) {
+		return true
+	}
+	for _, anc := range view.Ancestry {
+		if strings.Contains(strings.ToLower(anc), query) {
+			return true
+		}
 	}
 	for _, value := range status.Config.Metadata {
 		if strings.Contains(strings.ToLower(value), query) {
@@ -378,6 +392,17 @@ func matchLoopStatus(status looppkg.Status, query, state string, operation loopp
 		}
 	}
 	return false
+}
+
+// matchLoopOperation matches the operation filter. event_driven is inclusive
+// of WaitFunc-based loops (Status.EventDriven=true) whose declared operation
+// is still service, so the filter catches every event-driven loop, not only
+// those whose Config.Operation literally equals event_driven.
+func matchLoopOperation(status looppkg.Status, operation looppkg.Operation) bool {
+	if operation == looppkg.OperationEventDriven {
+		return status.EventDriven || status.Config.Operation == looppkg.OperationEventDriven
+	}
+	return status.Config.Operation == operation
 }
 
 // loopPolicyByName builds the name→policy/eligibility join the LoopView

--- a/internal/tools/loop_runtime_tools_test.go
+++ b/internal/tools/loop_runtime_tools_test.go
@@ -317,58 +317,6 @@ func TestLoopStatusFiltersAndStopLoop(t *testing.T) {
 	}
 }
 
-func TestSummarizeLoopStatus_ContainerRollupsAndProvenance(t *testing.T) {
-	nameByID := map[string]string{"lp_core": "core", "lp_travel": "travel"}
-	childCount := map[string]int{"lp_core": 3, "lp_travel": 2}
-
-	container := summarizeLoopStatus(looppkg.Status{
-		ID:       "lp_travel",
-		Name:     "travel",
-		ParentID: "lp_core",
-		Config: looppkg.Config{
-			Operation: looppkg.OperationContainer,
-			Metadata:  map[string]string{"intent": "loops that run while owners are away"},
-		},
-		EffectiveTags: []looppkg.EffectiveTag{
-			{Tag: "away", From: "self"},
-			{Tag: "trusted", From: "core"},
-		},
-	}, nameByID, childCount)
-
-	if container.ParentName != "core" {
-		t.Errorf("ParentName = %q, want core", container.ParentName)
-	}
-	if container.ChildCount != 2 {
-		t.Errorf("ChildCount = %d, want 2", container.ChildCount)
-	}
-	if container.Intent != "loops that run while owners are away" {
-		t.Errorf("Intent = %q, want the metadata intent surfaced", container.Intent)
-	}
-	// Provenance must survive the projection — this {tag, from} data is exactly
-	// what the runtime computed and the old summarizer discarded.
-	if len(container.EffectiveTags) != 2 || container.EffectiveTags[1].From != "core" {
-		t.Errorf("EffectiveTags = %#v, want inherited provenance carried through", container.EffectiveTags)
-	}
-
-	// A leaf: parent resolves to a human name, no children, no intent.
-	leaf := summarizeLoopStatus(looppkg.Status{
-		ID:       "lp_pl",
-		Name:     "porch_lights",
-		ParentID: "lp_travel",
-		Config:   looppkg.Config{Operation: looppkg.OperationService},
-	}, nameByID, childCount)
-
-	if leaf.ParentName != "travel" {
-		t.Errorf("leaf ParentName = %q, want travel", leaf.ParentName)
-	}
-	if leaf.ChildCount != 0 {
-		t.Errorf("leaf ChildCount = %d, want 0", leaf.ChildCount)
-	}
-	if leaf.Intent != "" {
-		t.Errorf("leaf Intent = %q, want empty", leaf.Intent)
-	}
-}
-
 func TestSpawnLoopAppliesConversationDefaults(t *testing.T) {
 	deps := newTestLoopRuntimeDeps(t)
 

--- a/internal/tools/loop_runtime_tools_test.go
+++ b/internal/tools/loop_runtime_tools_test.go
@@ -317,6 +317,58 @@ func TestLoopStatusFiltersAndStopLoop(t *testing.T) {
 	}
 }
 
+func TestSummarizeLoopStatus_ContainerRollupsAndProvenance(t *testing.T) {
+	nameByID := map[string]string{"lp_core": "core", "lp_travel": "travel"}
+	childCount := map[string]int{"lp_core": 3, "lp_travel": 2}
+
+	container := summarizeLoopStatus(looppkg.Status{
+		ID:       "lp_travel",
+		Name:     "travel",
+		ParentID: "lp_core",
+		Config: looppkg.Config{
+			Operation: looppkg.OperationContainer,
+			Metadata:  map[string]string{"intent": "loops that run while owners are away"},
+		},
+		EffectiveTags: []looppkg.EffectiveTag{
+			{Tag: "away", From: "self"},
+			{Tag: "trusted", From: "core"},
+		},
+	}, nameByID, childCount)
+
+	if container.ParentName != "core" {
+		t.Errorf("ParentName = %q, want core", container.ParentName)
+	}
+	if container.ChildCount != 2 {
+		t.Errorf("ChildCount = %d, want 2", container.ChildCount)
+	}
+	if container.Intent != "loops that run while owners are away" {
+		t.Errorf("Intent = %q, want the metadata intent surfaced", container.Intent)
+	}
+	// Provenance must survive the projection — this {tag, from} data is exactly
+	// what the runtime computed and the old summarizer discarded.
+	if len(container.EffectiveTags) != 2 || container.EffectiveTags[1].From != "core" {
+		t.Errorf("EffectiveTags = %#v, want inherited provenance carried through", container.EffectiveTags)
+	}
+
+	// A leaf: parent resolves to a human name, no children, no intent.
+	leaf := summarizeLoopStatus(looppkg.Status{
+		ID:       "lp_pl",
+		Name:     "porch_lights",
+		ParentID: "lp_travel",
+		Config:   looppkg.Config{Operation: looppkg.OperationService},
+	}, nameByID, childCount)
+
+	if leaf.ParentName != "travel" {
+		t.Errorf("leaf ParentName = %q, want travel", leaf.ParentName)
+	}
+	if leaf.ChildCount != 0 {
+		t.Errorf("leaf ChildCount = %d, want 0", leaf.ChildCount)
+	}
+	if leaf.Intent != "" {
+		t.Errorf("leaf Intent = %q, want empty", leaf.Intent)
+	}
+}
+
 func TestSpawnLoopAppliesConversationDefaults(t *testing.T) {
 	deps := newTestLoopRuntimeDeps(t)
 


### PR DESCRIPTION
## What

The **standard loop expression** — a single canonical `LoopView` (a `ps auxwwww`-style row) emitted through one shared projector, so the model reads the same rich, comprehensive row no matter which tool surfaced the loop. This PR lands the type + projector and migrates `loop_status` onto it.

- **`internal/runtime/loop/loop_view.go`** — the canonical `LoopView` + `LoopViewResolver` (`FromStatus`). One row, grouped: identity / parent container + full ancestry + child_count / state + policy + eligibility / lifecycle deltas / token economics / error state / supervisor cadence / effective tags·subscriptions·exclude-tools with inheritance provenance.
- **Precomputed in Go** (model never divides): `context_fill_pct`, `supervisor_iters_ago`, and the `iterations` (successful turns) vs `attempts` (total incl. failures) distinction.
- **Joins resolve once per call** (no N+1): the graph indexes are built from the full status batch; `policy_state`/`eligible` are left-joined from the definition registry by name. Ad-hoc loops with no stored definition report `policy_state: "ephemeral"`.
- **Null discipline**: live-only fields are pointer-`null` when not running; `effective_*` lists emit `[]` (evaluated-empty) vs `null` (not running), resolving the `Status` nil-conflation at the model boundary.
- **`loop_status`** now emits `[]LoopView`, drops the old hand-picked `loopStatusView`/`summarizeLoopStatus`, and gains `container`/`event_driven` in the `operation` filter so the model can list grouping nodes.

## Why

The runtime `Status` was already rich, but every loop-data tool hand-picked a different thin subset. This makes one canonical, consistent expression the single code path — "rich and comprehensive everywhere," enforced by the type, not re-decided per tool.

## Scope / follow-ups (tracked in #1102, milestone v0.10.1)

This PR is the foundation + the `loop_status` (live) consumer. Migrating the remaining surfaces onto the same projector is sequenced next: `FromDefinition` for `loop_definition_get`/`list`; `loop: LoopView` in the `spawn_loop`/`launch`/`set`/`set_policy`/`stop_loop`/`loop_reparent`/`thane_*` results; and the always-on self-context block. A compact list density (`LoopView.Compact()`) is reserved if registries grow.

## Test plan

- [x] `TestLoopViewResolver_FromStatus_RunningService` — parent_name + root→leaf ancestry, iterations/attempts, precomputed `context_fill_pct`(9) and `supervisor_iters_ago`(3), policy join, inheritance provenance, delta strings.
- [x] `TestLoopViewResolver_FromStatus_ContainerAndEphemeral` — child_count, intent, top-level null parent, `ephemeral` policy without a join, `[]`-not-null effective lists for a running loop.
- [x] `loop_status` integration test unchanged-green.
- [x] `just ci` green locally.

Refs #1102
