### PR TITLE
feat(loops): loop_reparent — move a loop between containers and relaunch it

### DIFF
--- a/internal/tools/loop_definition_mutation_tools.go
+++ b/internal/tools/loop_definition_mutation_tools.go
@@ -3,6 +3,7 @@ package tools
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	looppkg "github.com/nugget/thane-ai-agent/internal/runtime/loop"
@@ -248,4 +249,149 @@ func (r *Registry) handleLoopDefinitionLaunch(ctx context.Context, args map[stri
 		"definition": def,
 		"result":     result,
 	})
+}
+
+// handleLoopReparent moves a stored loop under a different container (or to
+// top-level) by name and relaunches it so it re-homes immediately. Parenting
+// is resolved at launch, so a plain definition edit does not move a running
+// loop — this verb pairs the parent_name change with a stop+reconcile so the
+// loop comes back up under the new parent in one step. It is the first-class
+// form of the manual edit-then-relaunch recipe.
+func (r *Registry) handleLoopReparent(ctx context.Context, args map[string]any) (string, error) {
+	if r.loopDefinitionRegistry == nil {
+		return "", fmt.Errorf("loop definition registry not configured")
+	}
+	name := toolargs.TrimmedString(args, "name")
+	if name == "" {
+		return "", fmt.Errorf("name is required")
+	}
+	// Empty, omitted, or "core" means top-level: directly under the
+	// structural root, with no container inheritance.
+	target := toolargs.TrimmedString(args, "parent_name")
+	topLevel := target == "" || strings.EqualFold(target, "core")
+
+	snapshot, err := currentLoopDefinitionSnapshot(r)
+	if err != nil {
+		return "", err
+	}
+	def, ok := looppkg.FindDefinition(snapshot, name)
+	if !ok {
+		return "", (&looppkg.UnknownDefinitionError{Name: name})
+	}
+	if def.Source == looppkg.DefinitionSourceConfig {
+		return "", (&looppkg.ImmutableDefinitionError{Name: name})
+	}
+
+	live := r.loopIntentDeps.LiveRegistry
+
+	newParent := ""
+	if !topLevel {
+		if strings.EqualFold(target, name) {
+			return "", fmt.Errorf("cannot reparent %q under itself", name)
+		}
+		if live == nil {
+			return "", fmt.Errorf("live registry not configured; cannot resolve container %q", target)
+		}
+		container := live.GetByName(target)
+		if container == nil {
+			return "", fmt.Errorf("target container %q is not currently registered; create it first or wait for hydration", target)
+		}
+		if container.Operation() != looppkg.OperationContainer {
+			return "", fmt.Errorf("target %q is a %s, not a container; loops can only nest under containers", target, container.Operation())
+		}
+		newParent = container.Name()
+	}
+
+	oldParent := strings.TrimSpace(def.Spec.ParentName)
+	if oldParent == newParent {
+		dest := newParent
+		if dest == "" {
+			dest = "core (top-level)"
+		}
+		return ldMarshalToolJSON(map[string]any{
+			"status":      "noop",
+			"name":        name,
+			"parent_name": newParent,
+			"detail":      fmt.Sprintf("%q is already parented to %s", name, dest),
+		})
+	}
+
+	// A container being moved must not have live children: descendants resolve
+	// their home from the container's current launch, so relaunching it would
+	// strand them. Reparent or stop the children first.
+	if live != nil && def.Spec.Operation == looppkg.OperationContainer {
+		if cur := live.GetByName(name); cur != nil {
+			if children := live.Children(cur.ID()); len(children) > 0 {
+				kids := make([]string, 0, len(children))
+				for _, c := range children {
+					kids = append(kids, c.Name())
+				}
+				return "", fmt.Errorf("container %q still has %d child loop(s): %v; reparent or stop them before moving the container", name, len(children), kids)
+			}
+		}
+	}
+
+	// Commit the new structural parent onto the persisted spec. ParentID is
+	// cleared so hydration resolves parent_name -> the live parent id afresh.
+	spec := def.Spec
+	spec.ParentName = newParent
+	spec.ParentID = ""
+	updatedAt := time.Now().UTC()
+	if r.commitLoopDefinitionSpec != nil {
+		if err := r.commitLoopDefinitionSpec(ctx, spec, updatedAt); err != nil {
+			return "", err
+		}
+	} else if err := r.loopDefinitionRegistry.Upsert(spec, updatedAt); err != nil {
+		return "", err
+	}
+
+	// The commit reconciles, but reconcile is a no-op on an already-running
+	// loop. Force a relaunch so the loop re-homes: stop it (StopLoop
+	// deregisters synchronously once the goroutine exits), then reconcile to
+	// respawn through the hydration path that resolves parent_name.
+	relaunched := false
+	if live != nil {
+		if cur := live.GetByName(name); cur != nil {
+			if err := live.StopLoop(cur.ID()); err != nil {
+				return "", fmt.Errorf("parent_name updated but relaunch could not stop %q: %w", name, err)
+			}
+			if live.GetByName(name) != nil {
+				return "", fmt.Errorf("parent_name updated but %q did not stop cleanly; run loop_reparent again to finish the relaunch", name)
+			}
+			relaunched = true
+		}
+	}
+	if r.reconcileLoopDefinition != nil {
+		if err := r.reconcileLoopDefinition(ctx, name); err != nil {
+			return "", fmt.Errorf("reconcile after reparent: %w", err)
+		}
+	}
+
+	result := map[string]any{
+		"status":      "ok",
+		"name":        name,
+		"old_parent":  oldParent,
+		"parent_name": newParent,
+		"relaunched":  relaunched,
+	}
+	if newParent == "" {
+		result["detail"] = fmt.Sprintf("%q moved to top-level (under core)", name)
+	} else {
+		result["detail"] = fmt.Sprintf("%q reparented under %q", name, newParent)
+	}
+	// Return the moved loop as the canonical LoopView so the model reads back
+	// the full row — new parent_name, ancestry, inherited tags — in the same
+	// shape loop_status emits. old_parent/relaunched stay envelope-level as
+	// transition facts that aren't loop-row fields.
+	if live != nil {
+		statuses := live.Statuses()
+		resolver := looppkg.NewLoopViewResolver(statuses, r.loopPolicyByName(), time.Now())
+		for _, s := range statuses {
+			if s.Name == name {
+				result["loop"] = resolver.FromStatus(s)
+				break
+			}
+		}
+	}
+	return ldMarshalToolJSON(result)
 }

--- a/internal/tools/loop_definition_mutation_tools.go
+++ b/internal/tools/loop_definition_mutation_tools.go
@@ -265,10 +265,13 @@ func (r *Registry) handleLoopReparent(ctx context.Context, args map[string]any) 
 	if name == "" {
 		return "", fmt.Errorf("name is required")
 	}
-	// Empty, omitted, or "core" means top-level: directly under the
-	// structural root, with no container inheritance.
+	// Empty, omitted, or the core name means top-level: directly under the
+	// structural root, with no container inheritance. Match the core name
+	// exactly — loop names are case-sensitive everywhere else (GetByName,
+	// Spec.Validate), so a real container named "Core" must not be treated
+	// as the root.
 	target := toolargs.TrimmedString(args, "parent_name")
-	topLevel := target == "" || strings.EqualFold(target, "core")
+	topLevel := target == "" || target == looppkg.CoreLoopName
 
 	snapshot, err := currentLoopDefinitionSnapshot(r)
 	if err != nil {
@@ -282,11 +285,19 @@ func (r *Registry) handleLoopReparent(ctx context.Context, args map[string]any) 
 		return "", (&looppkg.ImmutableDefinitionError{Name: name})
 	}
 
-	live := r.loopIntentDeps.LiveRegistry
+	// Prefer the always-wired runtime registry. loopIntentDeps is only
+	// configured when the intent-tool surface is enabled (conditional on doc
+	// tools), so relying on it would silently disable container resolution,
+	// the children guard, and the relaunch in common configurations. Fall
+	// back to it for registry-only test setups.
+	live := r.liveLoopRegistry
+	if live == nil {
+		live = r.loopIntentDeps.LiveRegistry
+	}
 
 	newParent := ""
 	if !topLevel {
-		if strings.EqualFold(target, name) {
+		if target == name {
 			return "", fmt.Errorf("cannot reparent %q under itself", name)
 		}
 		if live == nil {
@@ -302,16 +313,34 @@ func (r *Registry) handleLoopReparent(ctx context.Context, args map[string]any) 
 		newParent = container.Name()
 	}
 
+	// attachLoopView adds the moved loop's canonical row to a result so ok and
+	// noop responses share one shape the model can read uniformly.
+	attachLoopView := func(result map[string]any) (string, error) {
+		if live != nil {
+			statuses := live.Statuses()
+			resolver := looppkg.NewLoopViewResolver(statuses, r.loopPolicyByName(), time.Now())
+			for _, s := range statuses {
+				if s.Name == name {
+					result["loop"] = resolver.FromStatus(s)
+					break
+				}
+			}
+		}
+		return ldMarshalToolJSON(result)
+	}
+
 	oldParent := strings.TrimSpace(def.Spec.ParentName)
 	if oldParent == newParent {
 		dest := newParent
 		if dest == "" {
 			dest = "core (top-level)"
 		}
-		return ldMarshalToolJSON(map[string]any{
+		return attachLoopView(map[string]any{
 			"status":      "noop",
 			"name":        name,
+			"old_parent":  oldParent,
 			"parent_name": newParent,
+			"relaunched":  false,
 			"detail":      fmt.Sprintf("%q is already parented to %s", name, dest),
 		})
 	}
@@ -379,19 +408,7 @@ func (r *Registry) handleLoopReparent(ctx context.Context, args map[string]any) 
 	} else {
 		result["detail"] = fmt.Sprintf("%q reparented under %q", name, newParent)
 	}
-	// Return the moved loop as the canonical LoopView so the model reads back
-	// the full row — new parent_name, ancestry, inherited tags — in the same
-	// shape loop_status emits. old_parent/relaunched stay envelope-level as
-	// transition facts that aren't loop-row fields.
-	if live != nil {
-		statuses := live.Statuses()
-		resolver := looppkg.NewLoopViewResolver(statuses, r.loopPolicyByName(), time.Now())
-		for _, s := range statuses {
-			if s.Name == name {
-				result["loop"] = resolver.FromStatus(s)
-				break
-			}
-		}
-	}
-	return ldMarshalToolJSON(result)
+	// Return the moved loop as the canonical LoopView (same shape loop_status
+	// emits); old_parent/relaunched stay envelope-level as transition facts.
+	return attachLoopView(result)
 }

--- a/internal/tools/loop_definition_tools.go
+++ b/internal/tools/loop_definition_tools.go
@@ -237,4 +237,24 @@ func (r *Registry) registerLoopDefinitionTools() {
 		},
 		Handler: r.handleLoopDefinitionLaunch,
 	})
+
+	r.Register(&Tool{
+		Name:        "loop_reparent",
+		Description: "Move a stored loop under a different container by name and relaunch it so it re-homes immediately. This is the correct way to fix a loop that sits in the wrong place in the loop graph: set parent_name to the destination container, or omit it (or pass \"core\") to move the loop to top-level. The loop inherits the destination container's tags and subscriptions on relaunch. Parenting is resolved at launch, so editing parent_name alone does NOT move a running loop — this verb pairs the change with the relaunch. Config-owned definitions are immutable; a container that still has live children must have them moved or stopped first.",
+		Parameters: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"name": map[string]any{
+					"type":        "string",
+					"description": "Name of the loop (or childless container) to move.",
+				},
+				"parent_name": map[string]any{
+					"type":        "string",
+					"description": "Name of the destination container. Omit, leave empty, or pass \"core\" to move the loop to top-level (directly under the structural root).",
+				},
+			},
+			"required": []string{"name"},
+		},
+		Handler: r.handleLoopReparent,
+	})
 }

--- a/internal/tools/loop_reparent_test.go
+++ b/internal/tools/loop_reparent_test.go
@@ -1,0 +1,173 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	looppkg "github.com/nugget/thane-ai-agent/internal/runtime/loop"
+)
+
+type reparentHarness struct {
+	tool           *Tool
+	defReg         *looppkg.DefinitionRegistry
+	live           *looppkg.Registry
+	reconcileCalls *[]string
+}
+
+// newReparentHarness builds a fresh graph each call so the mutating happy
+// path can't bleed into the validation cases: live containers travel +
+// temporal, a service loop trip parented under travel, and a standalone
+// service loop trip2. Overlay definitions back each one so the reparent
+// handler's FindDefinition/commit path is exercised end to end.
+func newReparentHarness(t *testing.T) reparentHarness {
+	t.Helper()
+	runner := noopLoopRunner{}
+	live := looppkg.NewRegistry()
+
+	mk := func(name string, op looppkg.Operation, parentID string) *looppkg.Loop {
+		cfg := looppkg.Config{Name: name, Operation: op, ParentID: parentID}
+		if op != looppkg.OperationContainer {
+			cfg.Task = "do " + name // executing loops require a task; containers never run one
+		}
+		l, err := looppkg.New(cfg, looppkg.Deps{Runner: runner})
+		if err != nil {
+			t.Fatalf("New(%s): %v", name, err)
+		}
+		if err := live.Register(l); err != nil {
+			t.Fatalf("Register(%s): %v", name, err)
+		}
+		return l
+	}
+	travel := mk("travel", looppkg.OperationContainer, "")
+	mk("temporal", looppkg.OperationContainer, "")
+	mk("trip", looppkg.OperationService, travel.ID()) // child of travel
+	mk("trip2", looppkg.OperationService, "")
+
+	defReg, err := looppkg.NewDefinitionRegistry(nil)
+	if err != nil {
+		t.Fatalf("NewDefinitionRegistry: %v", err)
+	}
+	now := time.Now().UTC()
+	for _, spec := range []looppkg.Spec{
+		{Name: "travel", Operation: looppkg.OperationContainer},
+		{Name: "temporal", Operation: looppkg.OperationContainer},
+		{Name: "trip", Operation: looppkg.OperationService, Task: "do trip"},
+		{Name: "trip2", Operation: looppkg.OperationService, Task: "do trip2"},
+	} {
+		if err := defReg.Upsert(spec, now); err != nil {
+			t.Fatalf("Upsert(%s): %v", spec.Name, err)
+		}
+	}
+
+	reconcileCalls := &[]string{}
+	reg := NewEmptyRegistry()
+	reg.ConfigureLoopDefinitionTools(LoopDefinitionToolDeps{
+		Registry:   defReg,
+		CommitSpec: upsertCommitSpec(defReg),
+		Reconcile: func(_ context.Context, name string) error {
+			*reconcileCalls = append(*reconcileCalls, name)
+			return nil
+		},
+	})
+	reg.ConfigureLoopIntentTools(LoopIntentToolDeps{
+		Registry:   defReg,
+		CommitSpec: upsertCommitSpec(defReg),
+		LaunchDefinition: func(_ context.Context, _ string, _ looppkg.Launch) (looppkg.LaunchResult, error) {
+			return looppkg.LaunchResult{}, nil
+		},
+		LiveRegistry: live,
+	})
+
+	tool := reg.Get("loop_reparent")
+	if tool == nil {
+		t.Fatal("loop_reparent tool not registered")
+	}
+	return reparentHarness{tool: tool, defReg: defReg, live: live, reconcileCalls: reconcileCalls}
+}
+
+func (h reparentHarness) defParentName(t *testing.T, name string) string {
+	t.Helper()
+	def, ok := looppkg.FindDefinition(h.defReg.Snapshot(), name)
+	if !ok {
+		t.Fatalf("definition %q not found", name)
+	}
+	return def.Spec.ParentName
+}
+
+func TestLoopReparent_HappyPath(t *testing.T) {
+	h := newReparentHarness(t)
+
+	out, err := h.tool.Handler(context.Background(), map[string]any{"name": "trip", "parent_name": "travel"})
+	if err != nil {
+		t.Fatalf("reparent: %v", err)
+	}
+	var res map[string]any
+	if err := json.Unmarshal([]byte(out), &res); err != nil {
+		t.Fatalf("unmarshal result: %v", err)
+	}
+	if res["status"] != "ok" || res["parent_name"] != "travel" {
+		t.Fatalf("result status/parent_name = %v/%v, want ok/travel: %s", res["status"], res["parent_name"], out)
+	}
+	// The durable structural fix: the persisted spec now names the new parent.
+	if got := h.defParentName(t, "trip"); got != "travel" {
+		t.Errorf("persisted parent_name = %q, want travel", got)
+	}
+	// The relaunch: the running loop was stopped (deregistered) and reconcile
+	// was asked to bring it back under the new parent.
+	if h.live.GetByName("trip") != nil {
+		t.Error("trip should have been stopped for relaunch")
+	}
+	if len(*h.reconcileCalls) == 0 || (*h.reconcileCalls)[len(*h.reconcileCalls)-1] != "trip" {
+		t.Errorf("reconcile calls = %v, want trip reconciled", *h.reconcileCalls)
+	}
+}
+
+func TestLoopReparent_Validations(t *testing.T) {
+	cases := []struct {
+		name    string
+		args    map[string]any
+		wantErr string
+	}{
+		{"unknown loop", map[string]any{"name": "ghost", "parent_name": "travel"}, "ghost"},
+		{"reparent to self", map[string]any{"name": "trip", "parent_name": "trip"}, "itself"},
+		{"target not a container", map[string]any{"name": "trip", "parent_name": "trip2"}, "not a container"},
+		{"move container with live children", map[string]any{"name": "travel", "parent_name": "temporal"}, "child loop"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newReparentHarness(t)
+			_, err := h.tool.Handler(context.Background(), tc.args)
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("err = %v, want substring %q", err, tc.wantErr)
+			}
+			// A rejected reparent must not have mutated the persisted parent.
+			if name, _ := tc.args["name"].(string); name == "trip" {
+				if got := h.defParentName(t, "trip"); got != "" {
+					t.Errorf("parent_name = %q after rejected reparent, want unchanged empty", got)
+				}
+			}
+		})
+	}
+}
+
+func TestLoopReparent_NoopWhenAlreadyParented(t *testing.T) {
+	h := newReparentHarness(t)
+	// Move trip under travel, then ask again — second call is a no-op.
+	if _, err := h.tool.Handler(context.Background(), map[string]any{"name": "trip", "parent_name": "travel"}); err != nil {
+		t.Fatalf("first reparent: %v", err)
+	}
+	out, err := h.tool.Handler(context.Background(), map[string]any{"name": "trip", "parent_name": "travel"})
+	if err != nil {
+		t.Fatalf("second reparent: %v", err)
+	}
+	var res map[string]any
+	if err := json.Unmarshal([]byte(out), &res); err != nil {
+		t.Fatalf("unmarshal result: %v", err)
+	}
+	if res["status"] != "noop" {
+		t.Errorf("second reparent should be a noop, got %s", out)
+	}
+}

--- a/internal/tools/loop_reparent_test.go
+++ b/internal/tools/loop_reparent_test.go
@@ -170,4 +170,12 @@ func TestLoopReparent_NoopWhenAlreadyParented(t *testing.T) {
 	if res["status"] != "noop" {
 		t.Errorf("second reparent should be a noop, got %s", out)
 	}
+	// A noop carries the same envelope fields as ok, so callers read both
+	// shapes uniformly.
+	if _, ok := res["old_parent"]; !ok {
+		t.Errorf("noop result missing old_parent (should match the ok envelope): %s", out)
+	}
+	if res["relaunched"] != false {
+		t.Errorf("noop relaunched = %v, want false", res["relaunched"])
+	}
 }


### PR DESCRIPTION
## What

Adds **`loop_reparent`** — the first-class verb for moving a loop in the graph. Move a stored loop under a different container (or to top-level) by name, and relaunch it so it re-homes immediately.

```
loop_reparent { name: "tde-msrh-2026-06", parent_name: "travel" }
```

- Pairs the `parent_name` change with a **stop + reconcile relaunch** — because parenting resolves at launch, editing `parent_name` alone never moves a *running* loop (the exact gap behind the `tde-msrh-2026-06` incident, which had to be fixed by hand). This encodes that recipe as one safe verb.
- Omit / empty / `"core"` for `parent_name` moves the loop to top-level.
- Returns the moved loop as the **canonical `LoopView`** (from #1104) so the model reads back the full row — new `parent_name`, `ancestry`, inherited tags — in the same shape `loop_status` emits. `old_parent` / `relaunched` stay envelope-level as transition facts.

**Guards:** config-owned definitions are immutable; the destination must be a live container (not a service/leaf); a container with live children can't be moved until they're re-parented or stopped; reparent-to-self and already-parented (no-op) are handled.

## Why

Operationally, the model could already author + policy-cycle a loop, but "move this loop to the right container" had no first-class verb — it was a multi-step recipe the model didn't know (and mis-diagnosed as a framework bug). This makes the move a single, safe, legible operation, and its result speaks the standard loop expression.

## Stacking

Stacked on **#1104** (canonical `LoopView`) — its result reuses the shared projector, so this targets `feat/loop-status-container-legibility` and should merge after #1104. Milestone `v0.10.1`.

## Test plan

- [x] `TestLoopReparent_HappyPath` — persisted `parent_name` updated to the new container; running loop stopped and reconcile invoked to relaunch.
- [x] `TestLoopReparent_Validations` — unknown loop, reparent-to-self, target-not-a-container, container-with-live-children all rejected; a rejected reparent leaves `parent_name` unmutated.
- [x] `TestLoopReparent_NoopWhenAlreadyParented` — second move to the same parent is a no-op.
- [x] `just ci` green locally.

Refs #1102
