### PR TITLE
feat(loops): restore loop_wake — directed wake of a live loop with a message

### DIFF
--- a/internal/model/toolcatalog/catalog.go
+++ b/internal/model/toolcatalog/catalog.go
@@ -243,6 +243,7 @@ var builtinToolSpecs = map[string]BuiltinToolSpec{
 	"contact_owner":               {CanonicalID: "native:contact_owner", Source: NativeToolSource, Tags: []string{"owner"}},
 	"set_next_sleep":              {CanonicalID: "native:set_next_sleep", Source: NativeToolSource, Tags: []string{"loops"}},
 	"loop_status":                 {CanonicalID: "native:loop_status", Source: NativeToolSource, Tags: []string{"loops"}},
+	"loop_wake":                   {CanonicalID: "native:loop_wake", Source: NativeToolSource, Tags: []string{"loops"}},
 	"loop_definition_delete":      {CanonicalID: "native:loop_definition_delete", Source: NativeToolSource, Tags: []string{"loops"}},
 	"loop_definition_get":         {CanonicalID: "native:loop_definition_get", Source: NativeToolSource, Tags: []string{"loops"}},
 	"loop_definition_lint":        {CanonicalID: "native:loop_definition_lint", Source: NativeToolSource, Tags: []string{"loops"}},

--- a/internal/tools/loop_wake_test.go
+++ b/internal/tools/loop_wake_test.go
@@ -70,6 +70,13 @@ func TestLoopWakeDeliversMessageAndForceSupervisor(t *testing.T) {
 	if payload.Message == "" || !payload.ForceSupervisor {
 		t.Fatalf("payload = %#v, want message + force supervisor", payload)
 	}
+	// A stable kind/scope makes the wake legible in the envelope audit trail.
+	if payload.Kind != "loop_wake" {
+		t.Errorf("payload.Kind = %q, want loop_wake", payload.Kind)
+	}
+	if len(handler.env.Scope) != 1 || handler.env.Scope[0] != "loop_wake" {
+		t.Errorf("scope = %#v, want [loop_wake]", handler.env.Scope)
+	}
 
 	var got struct {
 		Status string `json:"status"`
@@ -107,5 +114,10 @@ func TestLoopWakeByIDAndRequiresTarget(t *testing.T) {
 	// Neither loop_id nor name is an error, not a silent no-op.
 	if _, err := tool.Handler(context.Background(), map[string]any{"message": "hi"}); err == nil {
 		t.Fatal("expected error when neither loop_id nor name is provided")
+	}
+
+	// Both selectors at once is rejected so targeting is unambiguous.
+	if _, err := tool.Handler(context.Background(), map[string]any{"loop_id": "lp_abc", "name": "trip"}); err == nil {
+		t.Fatal("expected error when both loop_id and name are provided")
 	}
 }

--- a/internal/tools/loop_wake_test.go
+++ b/internal/tools/loop_wake_test.go
@@ -1,0 +1,111 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/nugget/thane-ai-agent/internal/channels/messages"
+	looppkg "github.com/nugget/thane-ai-agent/internal/runtime/loop"
+)
+
+func TestLoopWakeDeliversMessageAndForceSupervisor(t *testing.T) {
+	t.Parallel()
+
+	bus := messages.NewBus(slog.New(slog.NewTextHandler(io.Discard, nil)))
+	handler := &recordingMessageHandler{}
+	bus.RegisterRoute(messages.DestinationLoop, handler.Deliver)
+
+	loops := looppkg.NewRegistry()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	t.Cleanup(func() {
+		shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer shutdownCancel()
+		loops.ShutdownAll(shutdownCtx)
+	})
+	if _, err := loops.SpawnLoop(ctx, looppkg.Config{
+		Name:         "tde-msrh-2026-06",
+		Task:         "owner-away presence watch",
+		SleepDefault: time.Hour,
+	}, looppkg.Deps{Runner: &messageToolLoopRunner{}}); err != nil {
+		t.Fatalf("SpawnLoop: %v", err)
+	}
+
+	reg := NewEmptyRegistry()
+	reg.ConfigureLoopRuntimeTools(LoopRuntimeToolDeps{Registry: loops})
+	reg.ConfigureMessageTools(MessageToolDeps{Bus: bus})
+
+	tool := reg.Get("loop_wake")
+	if tool == nil {
+		t.Fatal("loop_wake tool not registered")
+	}
+	if tool.Core {
+		t.Error("loop_wake should be a loops-tagged mechanism tool, not Core")
+	}
+
+	out, err := tool.Handler(context.Background(), map[string]any{
+		"name":             "tde-msrh-2026-06",
+		"message":          "Dan moved a car at 22:00; garage bay 1 cycling is expected, not an anomaly.",
+		"force_supervisor": true,
+		"priority":         "urgent",
+	})
+	if err != nil {
+		t.Fatalf("loop_wake: %v", err)
+	}
+
+	if handler.env.To.Target != "tde-msrh-2026-06" || handler.env.To.Selector != messages.SelectorName {
+		t.Fatalf("to = %#v, want name selector for tde-msrh-2026-06", handler.env.To)
+	}
+	if handler.env.Priority != messages.PriorityUrgent {
+		t.Fatalf("priority = %q, want urgent", handler.env.Priority)
+	}
+	payload, err := messagesPayload(handler.env.Payload)
+	if err != nil {
+		t.Fatalf("messagesPayload: %v", err)
+	}
+	if payload.Message == "" || !payload.ForceSupervisor {
+		t.Fatalf("payload = %#v, want message + force supervisor", payload)
+	}
+
+	var got struct {
+		Status string `json:"status"`
+	}
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got.Status != "ok" {
+		t.Fatalf("status = %q, want ok", got.Status)
+	}
+}
+
+func TestLoopWakeByIDAndRequiresTarget(t *testing.T) {
+	t.Parallel()
+
+	bus := messages.NewBus(slog.New(slog.NewTextHandler(io.Discard, nil)))
+	handler := &recordingMessageHandler{}
+	bus.RegisterRoute(messages.DestinationLoop, handler.Deliver)
+
+	reg := NewEmptyRegistry()
+	reg.ConfigureMessageTools(MessageToolDeps{Bus: bus})
+	tool := reg.Get("loop_wake")
+	if tool == nil {
+		t.Fatal("loop_wake not registered")
+	}
+
+	// Targeting by loop_id uses the ID selector.
+	if _, err := tool.Handler(context.Background(), map[string]any{"loop_id": "lp_abc", "message": "fyi"}); err != nil {
+		t.Fatalf("loop_wake by id: %v", err)
+	}
+	if handler.env.To.Target != "lp_abc" || handler.env.To.Selector != messages.SelectorID {
+		t.Fatalf("to = %#v, want id selector for lp_abc", handler.env.To)
+	}
+
+	// Neither loop_id nor name is an error, not a silent no-op.
+	if _, err := tool.Handler(context.Background(), map[string]any{"message": "hi"}); err == nil {
+		t.Fatal("expected error when neither loop_id nor name is provided")
+	}
+}

--- a/internal/tools/message_tools.go
+++ b/internal/tools/message_tools.go
@@ -24,9 +24,12 @@ func (r *Registry) ConfigureMessageTools(deps MessageToolDeps) {
 	r.registerMessageTools()
 }
 
-// registerMessageTools registers request_core_attention.
+// registerMessageTools registers request_core_attention (loop → core
+// escalation) and loop_wake (directed wake of a specific loop with a
+// one-shot message). Both are thin envelope-construction wrappers over the
+// shared message bus.
 //
-// Core-tool rationale: escalation primitive. Any tightly
+// Core-tool rationale (request_core_attention): escalation primitive. Any tightly
 // scoped service or delegate loop must be able to reach back to the
 // core loop when something deserves the operator's attention. Hiding
 // this behind a tag would orphan loops that already filtered down to
@@ -46,6 +49,90 @@ func (r *Registry) registerMessageTools() {
 		Parameters: coreAttentionToolParameters(),
 		Handler:    r.handleRequestCoreAttention,
 		Core:       true,
+	})
+
+	r.Register(&Tool{
+		Name:        "loop_wake",
+		Description: "Wake a specific live loop now and hand its next iteration a one-shot context message. Use this to tell a running watcher or service loop a fact it needs before its own schedule would surface it — correct a reading, deliver an event, hand off a decision — addressing the loop by name or loop_id from loop_status. If the loop is sleeping it wakes immediately; if it is mid-iteration the message is queued for its next turn. Set force_supervisor to promote that next iteration to a supervisor turn when the update warrants more capable handling. The message reaches only that one loop's next iteration; this is a directed signal between loops, not a broadcast or a channel for delivering to a human.",
+		Parameters:  wakeToolParameters(),
+		Handler:     r.handleLoopWake,
+	})
+}
+
+// wakeToolParameters is the schema for loop_wake: target a live loop by
+// loop_id or name, with an optional one-shot message and a force_supervisor
+// flag for the next iteration.
+func wakeToolParameters() map[string]any {
+	return map[string]any{
+		"type": "object",
+		"anyOf": []any{
+			map[string]any{"required": []string{"loop_id"}},
+			map[string]any{"required": []string{"name"}},
+		},
+		"properties": map[string]any{
+			"loop_id": map[string]any{
+				"type":        "string",
+				"description": "Exact live loop ID to wake. Preferred when available from loop_status.",
+			},
+			"name": map[string]any{
+				"type":        "string",
+				"description": "Exact live loop name to wake when loop_id is not known.",
+			},
+			"message": map[string]any{
+				"type":        "string",
+				"description": "Optional one-shot context message delivered only to the loop's next iteration.",
+			},
+			"force_supervisor": map[string]any{
+				"type":        "boolean",
+				"description": "When true, force that next iteration to run in supervisor mode.",
+			},
+			"priority": map[string]any{
+				"type":        "string",
+				"enum":        []string{"low", "normal", "urgent"},
+				"description": "Optional delivery priority recorded in the envelope audit trail.",
+			},
+		},
+	}
+}
+
+func (r *Registry) handleLoopWake(ctx context.Context, args map[string]any) (string, error) {
+	if r.messageBus == nil {
+		return "", fmt.Errorf("message bus is not configured")
+	}
+	loopID := toolargs.TrimmedString(args, "loop_id")
+	name := toolargs.TrimmedString(args, "name")
+	if loopID == "" && name == "" {
+		return "", fmt.Errorf("loop_id or name is required")
+	}
+
+	destination := messages.Destination{Kind: messages.DestinationLoop}
+	if loopID != "" {
+		destination.Target = loopID
+		destination.Selector = messages.SelectorID
+	} else {
+		destination.Target = name
+		destination.Selector = messages.SelectorName
+	}
+
+	payload := messages.LoopNotifyPayload{
+		Message:         toolargs.TrimmedString(args, "message"),
+		ForceSupervisor: boolArg(args, "force_supervisor"),
+	}
+	env := messages.Envelope{
+		From:     senderIdentityFromContext(ctx),
+		To:       destination,
+		Type:     messages.TypeSignal,
+		Payload:  payload,
+		Priority: messagePriorityArg(args),
+	}
+
+	result, err := r.messageBus.Send(ctx, env)
+	if err != nil {
+		return "", err
+	}
+	return ldMarshalToolJSON(map[string]any{
+		"status":   "ok",
+		"delivery": result,
 	})
 }
 

--- a/internal/tools/message_tools.go
+++ b/internal/tools/message_tools.go
@@ -104,6 +104,11 @@ func (r *Registry) handleLoopWake(ctx context.Context, args map[string]any) (str
 	if loopID == "" && name == "" {
 		return "", fmt.Errorf("loop_id or name is required")
 	}
+	if loopID != "" && name != "" {
+		// Reject both so targeting is unambiguous — a stale loop_id paired
+		// with a correct name could otherwise wake the wrong loop.
+		return "", fmt.Errorf("provide loop_id or name, not both")
+	}
 
 	destination := messages.Destination{Kind: messages.DestinationLoop}
 	if loopID != "" {
@@ -115,12 +120,14 @@ func (r *Registry) handleLoopWake(ctx context.Context, args map[string]any) (str
 	}
 
 	payload := messages.LoopNotifyPayload{
+		Kind:            "loop_wake",
 		Message:         toolargs.TrimmedString(args, "message"),
 		ForceSupervisor: boolArg(args, "force_supervisor"),
 	}
 	env := messages.Envelope{
 		From:     senderIdentityFromContext(ctx),
 		To:       destination,
+		Scope:    []string{"loop_wake"},
 		Type:     messages.TypeSignal,
 		Payload:  payload,
 		Priority: messagePriorityArg(args),


### PR DESCRIPTION
## What

Restores **`loop_wake`** — the model tool to wake a specific live loop and hand its next iteration a one-shot context message, with an optional `force_supervisor` flag. Target by `name` or `loop_id` from `loop_status`.

```
loop_wake { name: "tde-msrh-2026-06",
            message: "Dan moved a car at 22:00 — garage bay 1 cycling is expected, not an anomaly.",
            force_supervisor: true }
```

## Why this was missing

This capability existed as **`thane_wake`** (alias `notify_loop`) and was removed in `88a72c91` (2026-05-19) on the theory that wakes should be "infrastructural." That over-reached: it correctly moved *external producer* wakes (MQTT/feeds/forge) onto the bus, but left **no model-facing path to wake an arbitrary loop with a fact** — `set_next_sleep` is self-only (from inside the loop), `request_core_attention` is core-only. The operator/agent literally could not tell a running watcher a thing it needed to know.

The receiving substrate was never removed — `messages.LoopNotifyPayload{Message, ForceSupervisor}`, `consumePendingNotifies`, `shouldRunSupervisor(forceSupervisor)` are all live. So this is a thin dispatch wrapper over the existing bus, re-added in the `loop_*` mechanism family and `loops`-tagged like its siblings.

## Test plan

- [x] `TestLoopWakeDeliversMessageAndForceSupervisor` — by-name delivery carries the message + `force_supervisor` in a `LoopNotifyPayload` to the target loop's envelope, with priority.
- [x] `TestLoopWakeByIDAndRequiresTarget` — by-`loop_id` uses the ID selector; missing target errors rather than silently no-op'ing.
- [x] `just ci` green locally.

Refs #1106
