### PR TITLE
feat(loops): next_wake_delta + current_sleep_duration and a health rollup in loop_status

### DIFF
--- a/internal/runtime/loop/config.go
+++ b/internal/runtime/loop/config.go
@@ -558,11 +558,16 @@ type Status struct {
 	LastWakeAt time.Time `json:"last_wake_at,omitempty"`
 	// SleepUntil is the scheduled wake instant while the loop is in a
 	// timer-based sleep; zero when processing or event-driven (no timer to
-	// wake on). A notification can still cut the sleep short.
-	SleepUntil time.Time `json:"sleep_until,omitempty"`
+	// wake on). A notification can still cut the sleep short. Projection-only
+	// input for [LoopView] — `json:"-"` so it does not change the directly
+	// serialized HTTP /v1/loops contract (where a model-facing delta string
+	// belongs on the view, not a raw timestamp on Status).
+	SleepUntil time.Time `json:"-"`
 	// CurrentSleep is the post-clamp/post-jitter sleep duration being honored
-	// this cycle; zero when not sleeping.
-	CurrentSleep time.Duration `json:"current_sleep,omitempty"`
+	// this cycle; zero when not sleeping. Projection-only — `json:"-"` so a
+	// raw time.Duration (nanoseconds) never leaks into the HTTP /v1/loops
+	// JSON; [LoopView] emits the seconds form.
+	CurrentSleep time.Duration `json:"-"`
 	// Iterations is the total number of completed (successful) iterations.
 	Iterations int `json:"iterations"`
 	// Attempts is the total number of iteration attempts (including failures).

--- a/internal/runtime/loop/config.go
+++ b/internal/runtime/loop/config.go
@@ -556,6 +556,13 @@ type Status struct {
 	StartedAt time.Time `json:"started_at"`
 	// LastWakeAt is when the loop last began an iteration.
 	LastWakeAt time.Time `json:"last_wake_at,omitempty"`
+	// SleepUntil is the scheduled wake instant while the loop is in a
+	// timer-based sleep; zero when processing or event-driven (no timer to
+	// wake on). A notification can still cut the sleep short.
+	SleepUntil time.Time `json:"sleep_until,omitempty"`
+	// CurrentSleep is the post-clamp/post-jitter sleep duration being honored
+	// this cycle; zero when not sleeping.
+	CurrentSleep time.Duration `json:"current_sleep,omitempty"`
 	// Iterations is the total number of completed (successful) iterations.
 	Iterations int `json:"iterations"`
 	// Attempts is the total number of iteration attempts (including failures).

--- a/internal/runtime/loop/loop.go
+++ b/internal/runtime/loop/loop.go
@@ -209,6 +209,13 @@ type Loop struct {
 	contextWindow     int
 	lastError         string
 
+	// sleepUntil is the scheduled wake instant while the loop is in a
+	// timer-based sleep (zero when processing or event-driven); currentSleep
+	// is the post-clamp/post-jitter duration being honored. Both are set in
+	// [Loop.sleep] and cleared on wake, under l.mu.
+	sleepUntil   time.Time
+	currentSleep time.Duration
+
 	// currentConvID is the conversation ID of the in-flight iteration.
 	// Set at the start of each iteration, cleared after. Tool handlers
 	// read it via [Loop.CurrentConvID].
@@ -686,6 +693,8 @@ func (l *Loop) Status() Status {
 		ParentID:              l.config.ParentID,
 		StartedAt:             l.startedAt,
 		LastWakeAt:            l.lastWakeAt,
+		SleepUntil:            l.sleepUntil,
+		CurrentSleep:          l.currentSleep,
 		Iterations:            l.iterations,
 		Attempts:              l.attempts,
 		TotalInputTokens:      l.totalInputTokens,

--- a/internal/runtime/loop/loop_view.go
+++ b/internal/runtime/loop/loop_view.go
@@ -1,6 +1,7 @@
 package loop
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/nugget/thane-ai-agent/internal/model/promptfmt"
@@ -48,11 +49,14 @@ type LoopView struct {
 	LastWakeDelta *string `json:"last_wake_delta"`
 	// NextWakeIn is the signed-second delta to the scheduled wake while the
 	// loop is in a timer-based sleep (e.g. "+5953s"); null when processing or
-	// event-driven. CurrentSleep is the self-paced interval it is honoring
-	// this cycle (a duration string like "1h40m0s").
-	NextWakeIn         *string `json:"next_wake_in"`
-	CurrentSleep       *string `json:"current_sleep"`
-	PolicyUpdatedDelta *string `json:"policy_updated_delta"`
+	// event-driven. CurrentSleepDuration is the self-paced interval it is
+	// honoring this cycle, in the same seconds unit but UNSIGNED — it is a
+	// duration, not a delta-from-now (e.g. "5940s"). So a freshly-started sleep
+	// reads next_wake_in≈"+5940s" / current_sleep_duration="5940s", and you
+	// watch the former shrink while the latter holds.
+	NextWakeIn           *string `json:"next_wake_in"`
+	CurrentSleepDuration *string `json:"current_sleep_duration"`
+	PolicyUpdatedDelta   *string `json:"policy_updated_delta"`
 
 	// ---- economics (%CPU / %MEM / TIME) ----
 	Iterations        *int `json:"iterations"`
@@ -215,8 +219,11 @@ func (r LoopViewResolver) FromStatus(s Status) LoopView {
 	if !s.SleepUntil.IsZero() {
 		nw := promptfmt.FormatDeltaOnly(s.SleepUntil, r.now)
 		v.NextWakeIn = &nw
-		cs := s.CurrentSleep.String()
-		v.CurrentSleep = &cs
+		// Unsigned seconds — a duration magnitude, not a delta-from-now — so the
+		// whole row speaks one unit (e.g. current_sleep "5940s" alongside
+		// next_wake_in "+5940s").
+		cs := fmt.Sprintf("%ds", int64(s.CurrentSleep/time.Second))
+		v.CurrentSleepDuration = &cs
 	}
 
 	// Token economics — left nil for handler-only loops, which run no LLM

--- a/internal/runtime/loop/loop_view.go
+++ b/internal/runtime/loop/loop_view.go
@@ -44,8 +44,14 @@ type LoopView struct {
 	HandlerOnly  bool    `json:"handler_only"`
 
 	// ---- lifecycle / time (delta-oriented) ----
-	StartedDelta       *string `json:"started_delta"`
-	LastWakeDelta      *string `json:"last_wake_delta"`
+	StartedDelta  *string `json:"started_delta"`
+	LastWakeDelta *string `json:"last_wake_delta"`
+	// NextWakeIn is the signed-second delta to the scheduled wake while the
+	// loop is in a timer-based sleep (e.g. "+5953s"); null when processing or
+	// event-driven. CurrentSleep is the self-paced interval it is honoring
+	// this cycle (a duration string like "1h40m0s").
+	NextWakeIn         *string `json:"next_wake_in"`
+	CurrentSleep       *string `json:"current_sleep"`
 	PolicyUpdatedDelta *string `json:"policy_updated_delta"`
 
 	// ---- economics (%CPU / %MEM / TIME) ----
@@ -202,6 +208,15 @@ func (r LoopViewResolver) FromStatus(s Status) LoopView {
 	if !s.LastWakeAt.IsZero() {
 		d := promptfmt.FormatDeltaOnly(s.LastWakeAt, r.now)
 		v.LastWakeDelta = &d
+	}
+	// Scheduled next wake + the self-paced interval, for timer-based sleeps —
+	// turns the census into a schedule. Event-driven loops (no timer) leave
+	// SleepUntil zero and correctly report null.
+	if !s.SleepUntil.IsZero() {
+		nw := promptfmt.FormatDeltaOnly(s.SleepUntil, r.now)
+		v.NextWakeIn = &nw
+		cs := s.CurrentSleep.String()
+		v.CurrentSleep = &cs
 	}
 
 	// Token economics — left nil for handler-only loops, which run no LLM

--- a/internal/runtime/loop/loop_view.go
+++ b/internal/runtime/loop/loop_view.go
@@ -47,14 +47,14 @@ type LoopView struct {
 	// ---- lifecycle / time (delta-oriented) ----
 	StartedDelta  *string `json:"started_delta"`
 	LastWakeDelta *string `json:"last_wake_delta"`
-	// NextWakeIn is the signed-second delta to the scheduled wake while the
+	// NextWakeDelta is the signed-second delta to the scheduled wake while the
 	// loop is in a timer-based sleep (e.g. "+5953s"); null when processing or
 	// event-driven. CurrentSleepDuration is the self-paced interval it is
 	// honoring this cycle, in the same seconds unit but UNSIGNED — it is a
 	// duration, not a delta-from-now (e.g. "5940s"). So a freshly-started sleep
-	// reads next_wake_in≈"+5940s" / current_sleep_duration="5940s", and you
+	// reads next_wake_delta≈"+5940s" / current_sleep_duration="5940s", and you
 	// watch the former shrink while the latter holds.
-	NextWakeIn           *string `json:"next_wake_in"`
+	NextWakeDelta        *string `json:"next_wake_delta"`
 	CurrentSleepDuration *string `json:"current_sleep_duration"`
 	PolicyUpdatedDelta   *string `json:"policy_updated_delta"`
 
@@ -218,10 +218,10 @@ func (r LoopViewResolver) FromStatus(s Status) LoopView {
 	// SleepUntil zero and correctly report null.
 	if !s.SleepUntil.IsZero() {
 		nw := promptfmt.FormatDeltaOnly(s.SleepUntil, r.now)
-		v.NextWakeIn = &nw
+		v.NextWakeDelta = &nw
 		// Unsigned seconds — a duration magnitude, not a delta-from-now — so the
 		// whole row speaks one unit (e.g. current_sleep "5940s" alongside
-		// next_wake_in "+5940s").
+		// next_wake_delta "+5940s").
 		cs := fmt.Sprintf("%ds", int64(s.CurrentSleep/time.Second))
 		v.CurrentSleepDuration = &cs
 	}

--- a/internal/runtime/loop/loop_view_test.go
+++ b/internal/runtime/loop/loop_view_test.go
@@ -102,8 +102,9 @@ func TestLoopViewResolver_FromStatus_NextWake(t *testing.T) {
 	if sleeping.NextWakeIn == nil || *sleeping.NextWakeIn != "+5940s" {
 		t.Errorf("NextWakeIn = %v, want +5940s", sleeping.NextWakeIn)
 	}
-	if sleeping.CurrentSleep == nil || *sleeping.CurrentSleep != "1h39m0s" {
-		t.Errorf("CurrentSleep = %v, want 1h39m0s", sleeping.CurrentSleep)
+	// Unsigned seconds (a duration magnitude), not a delta: 99m = 5940s.
+	if sleeping.CurrentSleepDuration == nil || *sleeping.CurrentSleepDuration != "5940s" {
+		t.Errorf("CurrentSleepDuration = %v, want 5940s", sleeping.CurrentSleepDuration)
 	}
 
 	// A loop not in a timer sleep (no SleepUntil) reports null for both —
@@ -114,9 +115,9 @@ func TestLoopViewResolver_FromStatus_NextWake(t *testing.T) {
 		State:  State("processing"),
 		Config: Config{Operation: OperationService},
 	})
-	if processing.NextWakeIn != nil || processing.CurrentSleep != nil {
+	if processing.NextWakeIn != nil || processing.CurrentSleepDuration != nil {
 		t.Errorf("non-sleeping loop should have nil next_wake/current_sleep, got %v/%v",
-			processing.NextWakeIn, processing.CurrentSleep)
+			processing.NextWakeIn, processing.CurrentSleepDuration)
 	}
 }
 

--- a/internal/runtime/loop/loop_view_test.go
+++ b/internal/runtime/loop/loop_view_test.go
@@ -85,6 +85,41 @@ func TestLoopViewResolver_FromStatus_RunningService(t *testing.T) {
 	}
 }
 
+func TestLoopViewResolver_FromStatus_NextWake(t *testing.T) {
+	now := time.Date(2026, 6, 26, 12, 0, 0, 0, time.UTC)
+	r := NewLoopViewResolver(nil, nil, now)
+
+	// A timer-sleeping loop reports the scheduled wake (signed-second delta)
+	// and the self-paced interval it is honoring.
+	sleeping := r.FromStatus(Status{
+		ID:           "lp_a",
+		Name:         "a",
+		State:        State("sleeping"),
+		SleepUntil:   now.Add(99 * time.Minute),
+		CurrentSleep: 99 * time.Minute,
+		Config:       Config{Operation: OperationService},
+	})
+	if sleeping.NextWakeIn == nil || *sleeping.NextWakeIn != "+5940s" {
+		t.Errorf("NextWakeIn = %v, want +5940s", sleeping.NextWakeIn)
+	}
+	if sleeping.CurrentSleep == nil || *sleeping.CurrentSleep != "1h39m0s" {
+		t.Errorf("CurrentSleep = %v, want 1h39m0s", sleeping.CurrentSleep)
+	}
+
+	// A loop not in a timer sleep (no SleepUntil) reports null for both —
+	// processing loops and event-driven loops have no scheduled wake.
+	processing := r.FromStatus(Status{
+		ID:     "lp_b",
+		Name:   "b",
+		State:  State("processing"),
+		Config: Config{Operation: OperationService},
+	})
+	if processing.NextWakeIn != nil || processing.CurrentSleep != nil {
+		t.Errorf("non-sleeping loop should have nil next_wake/current_sleep, got %v/%v",
+			processing.NextWakeIn, processing.CurrentSleep)
+	}
+}
+
 func TestLoopViewResolver_FromStatus_HandlerOnlyAndCleanError(t *testing.T) {
 	now := time.Date(2026, 6, 26, 12, 0, 0, 0, time.UTC)
 	r := NewLoopViewResolver(nil, nil, now)

--- a/internal/runtime/loop/loop_view_test.go
+++ b/internal/runtime/loop/loop_view_test.go
@@ -99,8 +99,8 @@ func TestLoopViewResolver_FromStatus_NextWake(t *testing.T) {
 		CurrentSleep: 99 * time.Minute,
 		Config:       Config{Operation: OperationService},
 	})
-	if sleeping.NextWakeIn == nil || *sleeping.NextWakeIn != "+5940s" {
-		t.Errorf("NextWakeIn = %v, want +5940s", sleeping.NextWakeIn)
+	if sleeping.NextWakeDelta == nil || *sleeping.NextWakeDelta != "+5940s" {
+		t.Errorf("NextWakeDelta = %v, want +5940s", sleeping.NextWakeDelta)
 	}
 	// Unsigned seconds (a duration magnitude), not a delta: 99m = 5940s.
 	if sleeping.CurrentSleepDuration == nil || *sleeping.CurrentSleepDuration != "5940s" {
@@ -115,9 +115,9 @@ func TestLoopViewResolver_FromStatus_NextWake(t *testing.T) {
 		State:  State("processing"),
 		Config: Config{Operation: OperationService},
 	})
-	if processing.NextWakeIn != nil || processing.CurrentSleepDuration != nil {
+	if processing.NextWakeDelta != nil || processing.CurrentSleepDuration != nil {
 		t.Errorf("non-sleeping loop should have nil next_wake/current_sleep, got %v/%v",
-			processing.NextWakeIn, processing.CurrentSleepDuration)
+			processing.NextWakeDelta, processing.CurrentSleepDuration)
 	}
 }
 

--- a/internal/runtime/loop/signals.go
+++ b/internal/runtime/loop/signals.go
@@ -399,6 +399,21 @@ func (l *Loop) waitForEvent(ctx context.Context) (any, error) {
 }
 
 func (l *Loop) sleep(ctx context.Context, d time.Duration) bool {
+	// Record the scheduled wake instant so loop_status can report when the
+	// loop next fires; clear it on wake so a processing loop never reports a
+	// stale deadline. A wakeCh notification can cut the sleep short — this is
+	// the *scheduled* deadline, not a guarantee.
+	l.mu.Lock()
+	l.sleepUntil = time.Now().Add(d)
+	l.currentSleep = d
+	l.mu.Unlock()
+	defer func() {
+		l.mu.Lock()
+		l.sleepUntil = time.Time{}
+		l.currentSleep = 0
+		l.mu.Unlock()
+	}()
+
 	timer := time.NewTimer(d)
 	defer timer.Stop()
 	select {

--- a/internal/tools/loop_runtime_tools.go
+++ b/internal/tools/loop_runtime_tools.go
@@ -185,8 +185,46 @@ func (r *Registry) handleLoopStatus(_ context.Context, args map[string]any) (str
 			"operation": operation,
 			"limit":     limit,
 		},
-		"loops": filtered,
+		// Health is computed over the FULL registry, not the filtered/limited
+		// rows, so "is anything wrong" is answerable in one read even when a
+		// degraded loop falls below the result limit.
+		"health": loopStatusHealth(statuses),
+		"loops":  filtered,
 	})
+}
+
+// maxDegradedLoopNames caps the degraded_loops list to keep the health
+// rollup's prompt footprint bounded; the count stays exact.
+const maxDegradedLoopNames = 10
+
+// loopStatusHealth summarizes the live registry: counts by state and the
+// loops that are degraded (in error, or carrying consecutive errors), so the
+// model can read "is anything wrong" without eyeballing every row. statuses
+// is already name-sorted (Registry.Statuses), so degraded_loops is
+// deterministic without an explicit sort.
+func loopStatusHealth(statuses []looppkg.Status) map[string]any {
+	byState := make(map[string]int)
+	degraded := make([]string, 0)
+	for _, s := range statuses {
+		byState[string(s.State)]++
+		if s.ConsecutiveErrors > 0 || s.State == looppkg.StateError {
+			degraded = append(degraded, fmt.Sprintf("%s (%d consecutive errors)", s.Name, s.ConsecutiveErrors))
+		}
+	}
+	degradedCount := len(degraded)
+	if len(degraded) > maxDegradedLoopNames {
+		degraded = degraded[:maxDegradedLoopNames]
+	}
+	health := map[string]any{
+		"total":          len(statuses),
+		"degraded":       degradedCount,
+		"by_state":       byState,
+		"degraded_loops": degraded,
+	}
+	if degradedCount > len(degraded) {
+		health["degraded_truncated"] = degradedCount - len(degraded)
+	}
+	return health
 }
 
 func (r *Registry) handleSetNextSleep(ctx context.Context, args map[string]any) (string, error) {

--- a/internal/tools/loop_runtime_tools.go
+++ b/internal/tools/loop_runtime_tools.go
@@ -40,7 +40,7 @@ func (r *Registry) registerLoopRuntimeTools() {
 
 	r.Register(&Tool{
 		Name:        "loop_status",
-		Description: "Inspect the live loop registry. Returns a rich canonical row per running loop — identity, parent container and ancestry, lifecycle counters (successful iterations vs attempts), token economics, state and policy, supervisor cadence, and effective tags/subscriptions with inheritance provenance — with optional filters by query text, state, operation, and a result limit.",
+		Description: "Inspect the live loop registry. Returns a rich canonical row per running loop — identity, parent container and ancestry, lifecycle counters (successful iterations vs attempts), schedule (next_wake_delta + current_sleep_duration), token economics, state and policy, supervisor cadence, and effective tags/subscriptions with inheritance provenance — with optional filters by query text, state, operation, and a result limit. The envelope also carries a top-level health rollup (total, degraded count + names, by_state, degraded_truncated) computed over the whole registry, so you can tell at a glance whether anything is wrong even when a degraded loop falls below the limit.",
 		Parameters: map[string]any{
 			"type": "object",
 			"properties": map[string]any{

--- a/internal/tools/loop_runtime_tools.go
+++ b/internal/tools/loop_runtime_tools.go
@@ -207,8 +207,13 @@ func loopStatusHealth(statuses []looppkg.Status) map[string]any {
 	degraded := make([]string, 0)
 	for _, s := range statuses {
 		byState[string(s.State)]++
-		if s.ConsecutiveErrors > 0 || s.State == looppkg.StateError {
+		switch {
+		case s.ConsecutiveErrors > 0:
 			degraded = append(degraded, fmt.Sprintf("%s (%d consecutive errors)", s.Name, s.ConsecutiveErrors))
+		case s.State == looppkg.StateError:
+			// Errored this cycle but the counter already reset (or never
+			// incremented) — label the state, not a misleading "0 errors".
+			degraded = append(degraded, fmt.Sprintf("%s (error)", s.Name))
 		}
 	}
 	degradedCount := len(degraded)

--- a/internal/tools/loop_runtime_tools_test.go
+++ b/internal/tools/loop_runtime_tools_test.go
@@ -317,6 +317,34 @@ func TestLoopStatusFiltersAndStopLoop(t *testing.T) {
 	}
 }
 
+func TestLoopStatusHealth(t *testing.T) {
+	statuses := []looppkg.Status{
+		{Name: "a", State: looppkg.State("sleeping")},
+		{Name: "b", State: looppkg.State("sleeping")},
+		{Name: "c", State: looppkg.State("error"), ConsecutiveErrors: 3},
+		{Name: "d", State: looppkg.State("waiting"), ConsecutiveErrors: 2},
+	}
+	h := loopStatusHealth(statuses)
+
+	if h["total"] != 4 {
+		t.Errorf("total = %v, want 4", h["total"])
+	}
+	if h["degraded"] != 2 {
+		t.Errorf("degraded = %v, want 2 (error state + consecutive errors)", h["degraded"])
+	}
+	bs, _ := h["by_state"].(map[string]int)
+	if bs["sleeping"] != 2 || bs["error"] != 1 || bs["waiting"] != 1 {
+		t.Errorf("by_state = %v", bs)
+	}
+	dl, _ := h["degraded_loops"].([]string)
+	if len(dl) != 2 || dl[0] != "c (3 consecutive errors)" {
+		t.Errorf("degraded_loops = %v, want [c..., d...]", dl)
+	}
+	if _, ok := h["degraded_truncated"]; ok {
+		t.Errorf("degraded_truncated should be absent when under the cap: %v", h)
+	}
+}
+
 func TestSpawnLoopAppliesConversationDefaults(t *testing.T) {
 	deps := newTestLoopRuntimeDeps(t)
 

--- a/internal/tools/loop_runtime_tools_test.go
+++ b/internal/tools/loop_runtime_tools_test.go
@@ -323,22 +323,24 @@ func TestLoopStatusHealth(t *testing.T) {
 		{Name: "b", State: looppkg.State("sleeping")},
 		{Name: "c", State: looppkg.State("error"), ConsecutiveErrors: 3},
 		{Name: "d", State: looppkg.State("waiting"), ConsecutiveErrors: 2},
+		{Name: "e", State: looppkg.State("error")}, // error state, counter already reset
 	}
 	h := loopStatusHealth(statuses)
 
-	if h["total"] != 4 {
-		t.Errorf("total = %v, want 4", h["total"])
+	if h["total"] != 5 {
+		t.Errorf("total = %v, want 5", h["total"])
 	}
-	if h["degraded"] != 2 {
-		t.Errorf("degraded = %v, want 2 (error state + consecutive errors)", h["degraded"])
+	if h["degraded"] != 3 {
+		t.Errorf("degraded = %v, want 3 (consecutive errors + error state)", h["degraded"])
 	}
 	bs, _ := h["by_state"].(map[string]int)
-	if bs["sleeping"] != 2 || bs["error"] != 1 || bs["waiting"] != 1 {
+	if bs["sleeping"] != 2 || bs["error"] != 2 || bs["waiting"] != 1 {
 		t.Errorf("by_state = %v", bs)
 	}
 	dl, _ := h["degraded_loops"].([]string)
-	if len(dl) != 2 || dl[0] != "c (3 consecutive errors)" {
-		t.Errorf("degraded_loops = %v, want [c..., d...]", dl)
+	// Error state with a zero counter labels "(error)", not "(0 consecutive errors)".
+	if len(dl) != 3 || dl[0] != "c (3 consecutive errors)" || dl[2] != "e (error)" {
+		t.Errorf("degraded_loops = %v, want [c.../d.../e (error)]", dl)
 	}
 	if _, ok := h["degraded_truncated"]; ok {
 		t.Errorf("degraded_truncated should be absent when under the cap: %v", h)


### PR DESCRIPTION
## What

Two situational-awareness additions to the canonical `LoopView` / `loop_status`. (A third, `whisper`, was **dropped** — see below.)

### `next_wake_delta` + `current_sleep_duration` — census → schedule
The next-wake instant was computed and discarded. Now a running loop records its scheduled wake + the self-paced interval it's honoring — captured once inside `l.sleep` (so every sleep call site is covered) and **cleared on wake**, so a `processing` loop never reports a stale deadline.
- `next_wake_delta`: signed-second delta per the repo's `_delta` convention (`"+5940s"`); the sign carries future vs past.
- `current_sleep_duration`: the interval being honored this cycle, **unsigned seconds** (`"5940s"`) — it's a duration magnitude, not a delta-from-now, so it gets a distinct suffix and no sign.
- Both `null` for processing loops and event-driven loops (no timer to wake on). A notification can still cut a sleep short — this is the *scheduled* deadline.
- The raw `Status.SleepUntil`/`CurrentSleep` fields are `json:"-"` (projection-only): they feed `LoopView` but never touch the directly-serialized `/v1/loops` HTTP contract.

### Health rollup — "is anything wrong" in one read
`loop_status`'s envelope carries a `health` summary: `total`, `degraded` (count), `degraded_loops` (names + error labels), `by_state`, and `degraded_truncated` (overflow). Computed over the **full** registry, not the filtered/limited rows, so a degraded loop below the result limit still surfaces. An errored loop whose consecutive-error counter has reset reads `"(error)"`, not `"(0 consecutive errors)"`.

```json
"health": { "total": 24, "degraded": 1, "by_state": {"sleeping": 18, "waiting": 4, "pending": 2},
            "degraded_loops": ["unifi-poller (3 consecutive errors)"] }
```

The `loop_status` tool description documents both the schedule fields and the health rollup.

## Scope note — whisper deferred to v0.10.1
Cut intentionally. Surfacing it via document-section scraping is the wrong shape; it'll be designed in v0.10.1 as a **universal self-set status** every running loop maintains.

## Why no Spec/migration ripple
Pure runtime-state projection on `Status` → `LoopView` — no `Spec` change, no persistence, no gencfg/`architecture.baseline` bump.

## Test plan
- [x] `TestLoopViewResolver_FromStatus_NextWake` — sleeping loop reports `next_wake_delta="+5940s"` / `current_sleep_duration="5940s"`; non-sleeping reports null for both.
- [x] `TestLoopStatusHealth` — total/degraded/by_state/degraded_loops over a mixed batch; `(error)` label for an errored loop with a 0 counter; no `degraded_truncated` under the cap.
- [x] `just ci` green locally.

Refs #1102
