### PR TITLE
fix(prompts): close the narrate-then-stop gap in the runtime contract

### DIFF
--- a/internal/model/prompts/agent.go
+++ b/internal/model/prompts/agent.go
@@ -39,6 +39,8 @@ func RuntimeContract() string {
 		"",
 		"Keep the straight path clean. If persona, mission, conversation history, and current context are enough, answer directly.",
 		"",
+		"Naming an action is not taking it. If you say you are about to act, emit the tool call in the same turn — a turn that announces work but makes no tool call has not done the work, and the announcement must not stand in its place.",
+		"",
 		"Tags are bright trailheads into richer tool, context, and talent menus. When a task needs a domain, open one relevant door, read what appears, and keep moving without narrating the machinery.",
 		"",
 		"- Use only exact tool names that are actually available in this turn. Do not invent aliases, wrappers, or MCP helper tools.",

--- a/internal/runtime/agent/ego_prompt_test.go
+++ b/internal/runtime/agent/ego_prompt_test.go
@@ -325,6 +325,9 @@ func TestBuildSystemPrompt_RuntimeContractIncluded(t *testing.T) {
 	if !strings.Contains(prompt, "Keep the straight path clean") {
 		t.Fatal("runtime contract should keep direct answers prominent")
 	}
+	if !strings.Contains(prompt, "Naming an action is not taking it") {
+		t.Fatal("runtime contract should close the narrate-then-stop gap (promise an action ⇒ emit the tool call this turn)")
+	}
 	if !strings.Contains(prompt, "`thane_now`") {
 		t.Fatal("runtime contract should mention delegation when top-level tools are gated")
 	}


### PR DESCRIPTION
## What

Adds one line to the runtime contract (`prompts.RuntimeContract()`) closing the gap between *announcing* an action and *taking* it:

> Naming an action is not taking it. If you say you are about to act, emit the tool call in the same turn — a turn that announces work but makes no tool call has not done the work, and the announcement must not stand in its place.

## Why

**Prod incident (2026-06-26, build `cecec4b2`).** In the Signal conversation loop `signal/019c76e4`, `claude-opus-4-8` was asked to enable supervisor + reshape the kickoff doc on the `tde-msrh-2026-06` loop. Across **10 consecutive turns** it told the owner it would call `loop_definition_set`, narrated *"doing it for real this turn,"* read the spec via `loop_definition_get`, and **ended each turn on the preamble without ever emitting the write** — even producing a flawless self-diagnosis (*"treating 'I'm about to' as if it were 'I did,' burning the turn on the preamble"*) and still not acting.

**This is not a turn-engine bug.** Verified two ways:
- The final assistant message of the stalled turn is plain text with **no `tool_use` block** — the harness didn't drop a call; the model never emitted one.
- The engine is correct: `iterate/engine.go:209` continues only when the model emits ≥1 tool call; a text-only message returns the turn at `engine.go:428`. Mixed text+tool continues. Cap is 50 — nothing forced the 2-iteration stop. `iteration_count=2, exhausted=false` is the normal text-path exit.

It's a model-behavior attractor, amplified by an interactive persona that rewards conversational status utterances (`talents/communication.md`, `talents/interactive-doctrine.md:24` "narrate the wait") with nothing in the contract requiring the announced action to actually land in the same turn. This line is the counterweight.

## Scope / placement

- Goes in `RuntimeContract()` (always injected, every loop) rather than the interactive talent: it's an **execution-contract** rule, not persona, and the same trap can bite service loops. Coheres with the section's existing "act, don't narrate the machinery" voice.
- The delegate contract (`DelegateRuntimeContract()`) already covers the spirit ("capability changes are runtime actions… instead of describing… conversationally") and isn't a chat surface — left unchanged.

This is a **behavioral mitigation**, not a cure. The underlying model attractor and the `loop_definition_set` full-replace friction that amplifies it (re-read whole spec → recompose entire payload → defer the emit) are tracked separately — a `loop_definition_patch` / field-scoped-setter follow-up will shrink that compose burden.

## Test plan
- [x] `TestBuildSystemPrompt_RuntimeContractIncluded` extended to assert the new line is present in the assembled system prompt.
- [x] `just ci` green locally.
