### PR TITLE
fix(engine): stop erasing the model's pre-tool-call reasoning (narrate-then-stop outage)

### DIFF
--- a/internal/model/fleet/providers/anthropic.go
+++ b/internal/model/fleet/providers/anthropic.go
@@ -358,7 +358,7 @@ func (c *AnthropicClient) ChatStream(ctx context.Context, model string, messages
 		Model:        model,
 		Messages:     anthropicMsgs,
 		System:       systemPayload,
-		MaxTokens:    4096,
+		MaxTokens:    anthropicMaxTokens(model),
 		Stream:       stream,
 		Tools:        anthropicTools,
 		CacheControl: anthropicPromptCacheControl(systemPrompt, anthropicMsgs, anthropicTools, explicitCaching),
@@ -701,6 +701,29 @@ const maxAnthropicCacheBreakpoints = 4
 // publishes for English prose. Used to check per-run prefix lengths
 // against the model-specific minimum cacheable tokens.
 const estimatedCharsPerToken = 4
+
+// anthropicMaxTokens returns the per-request output ceiling for a model.
+// The old blanket 4096 was far below the modern family limits and could
+// truncate a turn that needs to both reason and emit a large tool payload
+// (e.g. a long plan plus a full loop_definition_set spec) in one response —
+// the model would hit the cap mid-thought and never reach the write. These
+// values stay comfortably within the published per-family output maximums
+// (Opus/Sonnet 4.x ≥32k, Haiku 4.5 ≥8k) so the ceiling stops being a
+// constraint without risking an over-limit API rejection. max_tokens is a
+// ceiling, not a target: a response still costs only the tokens it generates.
+func anthropicMaxTokens(model string) int {
+	lower := strings.ToLower(model)
+	switch {
+	case strings.Contains(lower, "opus"), strings.Contains(lower, "sonnet"):
+		return 16384
+	case strings.Contains(lower, "haiku"):
+		return 8192
+	default:
+		// Unknown models keep the conservative legacy ceiling so a provider
+		// we can't reason about never gets an out-of-range max_tokens.
+		return 4096
+	}
+}
 
 // minCacheablePrefixTokens returns the minimum token count a cached
 // prefix must reach for the Anthropic API to actually cache it. Runs

--- a/internal/model/fleet/providers/anthropic_test.go
+++ b/internal/model/fleet/providers/anthropic_test.go
@@ -989,3 +989,21 @@ type roundTripFunc func(*http.Request) (*http.Response, error)
 func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
 	return f(req)
 }
+
+func TestAnthropicMaxTokens(t *testing.T) {
+	cases := []struct {
+		model string
+		want  int
+	}{
+		{"claude-opus-4-8", 16384},
+		{"claude-sonnet-4-6", 16384},
+		{"claude-haiku-4-5", 8192},
+		{"some-unknown-model", 4096},
+		{"", 4096},
+	}
+	for _, tc := range cases {
+		if got := anthropicMaxTokens(tc.model); got != tc.want {
+			t.Errorf("anthropicMaxTokens(%q) = %d, want %d", tc.model, got, tc.want)
+		}
+	}
+}

--- a/internal/runtime/agent/empty_response_test.go
+++ b/internal/runtime/agent/empty_response_test.go
@@ -355,10 +355,12 @@ func TestDeferredText_FreshTextOverrides(t *testing.T) {
 	}
 }
 
-func TestDeferredText_StrippedFromContext(t *testing.T) {
-	// The text from a mixed (text + tool_call) response should be stripped
-	// from the assistant message in llmMessages so the model doesn't see
-	// its own text and restate it.
+func TestDeferredText_PreservedInContext(t *testing.T) {
+	// The text from a mixed (text + tool_call) response is PRESERVED on the
+	// assistant message in llmMessages so the model retains its own reasoning
+	// across iterations. Erasing it made the model lose its pre-write plan and
+	// stall (the narrate-then-stop outage). The empty-response fallback still
+	// uses the deferred copy, so #347's user-visible duplication stays fixed.
 	mock := &mockLLM{
 		responses: []*llm.ChatResponse{
 			// Iter 0: text + tool call
@@ -400,14 +402,19 @@ func TestDeferredText_StrippedFromContext(t *testing.T) {
 		t.Fatalf("Run() error: %v", err)
 	}
 
-	// Inspect the messages sent to the second LLM call. The assistant
-	// message from iter 0 should have empty Content (text stripped).
+	// Inspect the messages sent to the second LLM call. The assistant message
+	// from iter 0 must RETAIN its text (the model's reasoning), not be stripped.
 	secondCall := mock.calls[1]
+	found := false
 	for _, msg := range secondCall.Messages {
 		if msg.Role == "assistant" && len(msg.ToolCalls) > 0 {
-			if msg.Content != "" {
-				t.Errorf("assistant message with tool calls should have empty Content, got %q", msg.Content)
+			found = true
+			if msg.Content != "Here's what I found." {
+				t.Errorf("assistant message with tool calls should preserve its reasoning text, got %q", msg.Content)
 			}
 		}
+	}
+	if !found {
+		t.Fatal("expected an assistant message with tool calls in the second call's history")
 	}
 }

--- a/internal/runtime/iterate/engine.go
+++ b/internal/runtime/iterate/engine.go
@@ -207,13 +207,21 @@ func (e *Engine) Run(ctx context.Context, cfg Config, messages []llm.Message) (*
 		// TOOL CALL PATH
 		// =============================================
 		if len(llmResp.Message.ToolCalls) > 0 {
-			// When the model returns text alongside tool calls, defer
-			// the text for later use and strip it from the message
-			// context. This prevents the model from restating already-
-			// streamed content after tool execution (issue #347).
+			// When the model returns text alongside tool calls, capture it as
+			// deferredText so an empty post-tool response falls back to it
+			// instead of nudging the model into restating (issue #347).
+			//
+			// The text is deliberately NOT stripped from the message appended
+			// to history. Erasing the model's pre-tool-call reasoning made it
+			// lose its own plan across iterations: on a hard edit it would
+			// narrate a long plan alongside a loop_definition_get read, the
+			// stripped (empty) message went into history, and the next
+			// iteration — now blind to that plan — stalled without ever
+			// emitting the follow-up write. Keeping the text lets the reasoning
+			// survive; the empty-response fallback below still consumes
+			// deferredText, so #347's user-visible duplication stays fixed.
 			if cfg.DeferMixedText && llmResp.Message.Content != "" {
 				deferredText = llmResp.Message.Content
-				llmResp.Message.Content = ""
 			}
 
 			if cfg.NormalizeToolCall != nil {

--- a/internal/runtime/iterate/engine_test.go
+++ b/internal/runtime/iterate/engine_test.go
@@ -516,6 +516,47 @@ func TestEngine_DeferMixedText(t *testing.T) {
 	}
 }
 
+func TestEngine_DeferMixedText_PreservesReasoningInHistory(t *testing.T) {
+	// Mixed text+tool, then a FRESH (non-empty) response. The pre-tool
+	// reasoning must survive in conversation history rather than being
+	// stripped to empty — otherwise the model loses its own plan between a
+	// read and the follow-up write and stalls (the narrate-then-stop outage).
+	mock := &mockLLM{
+		responses: []*llm.ChatResponse{
+			{
+				Model: "test-model",
+				Message: llm.Message{
+					Role:      "assistant",
+					Content:   "Here is my detailed plan.",
+					ToolCalls: []llm.ToolCall{makeToolCall("read", map[string]any{"k": "v"})},
+				},
+			},
+			textResponse("done"),
+		},
+	}
+	exec := &mockExecutor{results: map[string]string{"read": "ok"}}
+	cfg := baseCfg(mock, exec)
+	cfg.DeferMixedText = true
+
+	engine := &Engine{}
+	result, err := engine.Run(context.Background(), cfg, baseMessages())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Content != "done" {
+		t.Errorf("content = %q, want the fresh iter-2 text", result.Content)
+	}
+	found := false
+	for _, m := range result.Messages {
+		if m.Role == "assistant" && strings.Contains(m.Content, "Here is my detailed plan.") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("pre-tool reasoning was stripped from history; the model would lose its plan. messages=%+v", result.Messages)
+	}
+}
+
 func TestEngine_BudgetExhaustion(t *testing.T) {
 	// Budget fires on the second iteration (after iter 0's tool has been
 	// executed, so the last message is a tool result). This lets forceText


### PR DESCRIPTION
## The outage

In a Signal conversation, the model repeatedly promised to call `loop_definition_set`, read the spec via `loop_definition_get`, and ended the turn without ever emitting the write — 10+ turns running. Earlier passes pinned it as a model-behavior attractor; this PR fixes a **concrete framework cause underneath it**.

## Root cause (confirmed in prod)

The agent loop sets `DeferMixedText: true` (`agent/loop.go:2094`). When a response mixes text + a tool call, `iterate/engine.go:214-217` (added for #347) **stripped the text from the assistant message before appending it to history**.

On a hard edit the model writes a long *plan* in the text channel and calls `loop_definition_get` in the same response. The strip erased that plan; the next iteration — now blind to its own reasoning — produced a short "ok, writing now" and stalled.

Verified on `r_b88b07c2d4867d5f`: the iter-1 assistant message is stored with `content: null`, yet the turn billed **4,177 output tokens** and the final response is ~80 tokens — ~4,000 tokens of generated reasoning, stripped and discarded.

## Fix

1. **Stop erasing the reasoning** (`iterate/engine.go`). Keep the pre-tool text on the history message. The text is still captured as `deferredText`, so an empty post-tool response falls back to it instead of nudging — **#347's user-visible duplication stays fixed** (the original empty-case test still passes).
2. **Model-aware `max_tokens`** (`anthropic.go`). The hardcoded `4096` was far below the family limits and could truncate a turn that must both reason and emit a large `loop_definition_set` payload. Now 16384 (opus/sonnet), 8192 (haiku), 4096 (unknown — conservative, never over-limit). It's a ceiling, not a target.

## Why this is the tight fix, not the whole story

Stacks with the already-shipped levers: #1109 (interactive contract nudge), #1110 (`loop_definition_patch` removes the full-replace compose burden). The **deeper cure remains extended thinking** — give the model a real reasoning channel so its planning doesn't live in (and consume) the text/turn at all — which is the larger, separate piece of work this branch was originally named for. This PR unblocks the prod outage without that scope.

## Test plan
- [x] `iterate`: new `TestEngine_DeferMixedText_PreservesReasoningInHistory` (reasoning survives a fresh follow-up); existing `TestEngine_DeferMixedText` empty-case fallback still green.
- [x] `agent`: `TestDeferredText_StrippedFromContext` → `TestDeferredText_PreservedInContext`, asserting the mixed-text message retains its content.
- [x] `providers`: `TestAnthropicMaxTokens` table.
- [x] `just ci` green; no architecture-baseline drift.

## Prod verification (post-deploy)
Re-prompt Aimée to perform the `tde-msrh-2026-06` edit; expect her to retain her plan across the read and emit the write.
