### PR TITLE
Built-in grouping containers for the node graph (cognition, home-assistant, channels)

### DIFF
--- a/internal/app/loop_core.go
+++ b/internal/app/loop_core.go
@@ -55,26 +55,21 @@ func (a *App) ensureCoreLoop(ctx context.Context) error {
 	return nil
 }
 
-// channelsContainerName is the implicit grouping container for interactive
-// counterparty channel loops (signal, owu, …). Keep in sync with the literal
-// used by the channel integrations (signal bridge, OWU tracker), which can't
-// import this package.
-const channelsContainerName = "channels"
-
-// ensureChannelsContainer spawns the channels grouping container as an inert
-// implicit container under core, mirroring [App.ensureCoreLoop]. It must run
-// before the channel integrations spawn their dynamically-created channel
-// loops: there is no late-reattach path, so a child that registers before its
-// parent is live stays parentless. Idempotent — a no-op once it exists.
+// ensureChannelsContainer spawns the channels grouping container
+// ([looppkg.ChannelsContainerName]) as an inert implicit container under core,
+// mirroring [App.ensureCoreLoop]. It must run before the channel integrations
+// spawn their dynamically-created channel loops: there is no late-reattach
+// path, so a child that registers before its parent is live stays parentless.
+// Idempotent — a no-op once it exists.
 func (a *App) ensureChannelsContainer(ctx context.Context) error {
 	if a == nil || a.loopRegistry == nil {
 		return nil
 	}
-	if a.loopRegistry.GetByName(channelsContainerName) != nil {
+	if a.loopRegistry.GetByName(looppkg.ChannelsContainerName) != nil {
 		return nil
 	}
 	spec := looppkg.Spec{
-		Name:      channelsContainerName,
+		Name:      looppkg.ChannelsContainerName,
 		Enabled:   true,
 		Operation: looppkg.OperationContainer,
 		Metadata:  map[string]string{"intent": "Interactive counterparty channels (Signal, OWU, and others)."},
@@ -82,6 +77,6 @@ func (a *App) ensureChannelsContainer(ctx context.Context) error {
 	if _, err := a.loopRegistry.SpawnSpec(ctx, spec, looppkg.Deps{Logger: a.logger}); err != nil {
 		return err
 	}
-	a.logger.Info("channels container auto-created", "name", channelsContainerName)
+	a.logger.Info("channels container auto-created", "name", looppkg.ChannelsContainerName)
 	return nil
 }

--- a/internal/app/loop_core.go
+++ b/internal/app/loop_core.go
@@ -54,3 +54,34 @@ func (a *App) ensureCoreLoop(ctx context.Context) error {
 	a.logger.Info("core loop auto-created", "name", looppkg.CoreLoopName)
 	return nil
 }
+
+// channelsContainerName is the implicit grouping container for interactive
+// counterparty channel loops (signal, owu, …). Keep in sync with the literal
+// used by the channel integrations (signal bridge, OWU tracker), which can't
+// import this package.
+const channelsContainerName = "channels"
+
+// ensureChannelsContainer spawns the channels grouping container as an inert
+// implicit container under core, mirroring [App.ensureCoreLoop]. It must run
+// before the channel integrations spawn their dynamically-created channel
+// loops: there is no late-reattach path, so a child that registers before its
+// parent is live stays parentless. Idempotent — a no-op once it exists.
+func (a *App) ensureChannelsContainer(ctx context.Context) error {
+	if a == nil || a.loopRegistry == nil {
+		return nil
+	}
+	if a.loopRegistry.GetByName(channelsContainerName) != nil {
+		return nil
+	}
+	spec := looppkg.Spec{
+		Name:      channelsContainerName,
+		Enabled:   true,
+		Operation: looppkg.OperationContainer,
+		Metadata:  map[string]string{"intent": "Interactive counterparty channels (Signal, OWU, and others)."},
+	}
+	if _, err := a.loopRegistry.SpawnSpec(ctx, spec, looppkg.Deps{Logger: a.logger}); err != nil {
+		return err
+	}
+	a.logger.Info("channels container auto-created", "name", channelsContainerName)
+	return nil
+}

--- a/internal/app/loop_core_test.go
+++ b/internal/app/loop_core_test.go
@@ -19,7 +19,7 @@ func TestEnsureChannelsContainer(t *testing.T) {
 	if err := a.ensureChannelsContainer(ctx); err != nil {
 		t.Fatalf("ensureChannelsContainer: %v", err)
 	}
-	c := a.loopRegistry.GetByName(channelsContainerName)
+	c := a.loopRegistry.GetByName(looppkg.ChannelsContainerName)
 	if c == nil {
 		t.Fatal("channels container not created")
 	}
@@ -31,7 +31,7 @@ func TestEnsureChannelsContainer(t *testing.T) {
 	if err := a.ensureChannelsContainer(ctx); err != nil {
 		t.Fatalf("second ensureChannelsContainer: %v", err)
 	}
-	if got := len(a.loopRegistry.FindByName(channelsContainerName)); got != 1 {
+	if got := len(a.loopRegistry.FindByName(looppkg.ChannelsContainerName)); got != 1 {
 		t.Errorf("channels container count = %d, want 1", got)
 	}
 }

--- a/internal/app/loop_core_test.go
+++ b/internal/app/loop_core_test.go
@@ -1,0 +1,37 @@
+package app
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	looppkg "github.com/nugget/thane-ai-agent/internal/runtime/loop"
+)
+
+// TestEnsureChannelsContainer verifies the channels grouping container is
+// spawned as an inert container under core and that the call is idempotent.
+func TestEnsureChannelsContainer(t *testing.T) {
+	t.Parallel()
+
+	a := &App{loopRegistry: looppkg.NewRegistry(), logger: slog.Default()}
+	ctx := context.Background()
+
+	if err := a.ensureChannelsContainer(ctx); err != nil {
+		t.Fatalf("ensureChannelsContainer: %v", err)
+	}
+	c := a.loopRegistry.GetByName(channelsContainerName)
+	if c == nil {
+		t.Fatal("channels container not created")
+	}
+	if got := c.Status().Config.Operation; got != looppkg.OperationContainer {
+		t.Errorf("channels Operation = %q, want %q", got, looppkg.OperationContainer)
+	}
+
+	// Idempotent: a second call is a no-op, not a duplicate.
+	if err := a.ensureChannelsContainer(ctx); err != nil {
+		t.Fatalf("second ensureChannelsContainer: %v", err)
+	}
+	if got := len(a.loopRegistry.FindByName(channelsContainerName)); got != 1 {
+		t.Errorf("channels container count = %d, want 1", got)
+	}
+}

--- a/internal/app/loop_definition_builtins.go
+++ b/internal/app/loop_definition_builtins.go
@@ -22,6 +22,49 @@ const (
 	telemetryDefinitionName       = "telemetry"
 )
 
+// Built-in grouping containers. Each is an inert Operation=container loop that
+// hangs under core and gives the node graph its top-level shape; member loops
+// join by setting ParentName to one of these names. The definition registry's
+// topological sort spawns each container before its members, so these work for
+// members that are themselves base definitions (dynamically-spawned members,
+// e.g. channel loops, need a different mechanism — they spawn before the
+// definition-driven containers are live).
+const (
+	cognitionContainerName     = "cognition"
+	homeAssistantContainerName = "home-assistant"
+)
+
+// builtInContainerDefinitionSpecs returns the built-in grouping containers,
+// each gated so an empty container never appears: cognition when any core
+// cognition loop is enabled, home-assistant when HA or MQTT is configured.
+func builtInContainerDefinitionSpecs(cfg *config.Config) []looppkg.Spec {
+	if cfg == nil {
+		return nil
+	}
+	var specs []looppkg.Spec
+
+	if cfg.Metacognitive.Enabled || cfg.Ego.Enabled || cfg.Archivist.Enabled {
+		specs = append(specs, containerSpec(cognitionContainerName,
+			"Core cognition loops: reflection, identity, and memory."))
+	}
+	if cfg.HomeAssistant.Configured() || cfg.MQTT.Configured() {
+		specs = append(specs, containerSpec(homeAssistantContainerName,
+			"Home Assistant integration: state watching, MQTT transport, and telemetry."))
+	}
+
+	return specs
+}
+
+// containerSpec builds an inert grouping-container definition under core.
+func containerSpec(name, intent string) looppkg.Spec {
+	return looppkg.Spec{
+		Name:      name,
+		Enabled:   true,
+		Operation: looppkg.OperationContainer,
+		Metadata:  map[string]string{"intent": intent},
+	}
+}
+
 func builtInServiceDefinitionSpecs(cfg *config.Config) []looppkg.Spec {
 	if cfg == nil {
 		return nil
@@ -52,6 +95,7 @@ func builtInServiceDefinitionSpecs(cfg *config.Config) []looppkg.Spec {
 		specs = append(specs, looppkg.Spec{
 			Name:       haStateWatcherDefinitionName,
 			Enabled:    true,
+			ParentName: homeAssistantContainerName,
 			Task:       "Watch Home Assistant state_changed events and feed ambient awareness state.",
 			Operation:  looppkg.OperationService,
 			Completion: looppkg.CompletionNone,
@@ -194,6 +238,7 @@ func builtInServiceDefinitionSpecs(cfg *config.Config) []looppkg.Spec {
 		specs = append(specs, looppkg.Spec{
 			Name:       mqtt.DefaultHandlerLoopName,
 			Enabled:    true,
+			ParentName: homeAssistantContainerName,
 			Task:       "Triage MQTT wake events: inspect topic and payload, then act or escalate.",
 			Operation:  looppkg.OperationEventDriven,
 			Completion: looppkg.CompletionNone,
@@ -211,6 +256,7 @@ func builtInServiceDefinitionSpecs(cfg *config.Config) []looppkg.Spec {
 		specs = append(specs, looppkg.Spec{
 			Name:         mqttPublisherDefinitionName,
 			Enabled:      true,
+			ParentName:   homeAssistantContainerName,
 			Task:         "Publish MQTT state and discovery updates on the configured cadence.",
 			Operation:    looppkg.OperationService,
 			Completion:   looppkg.CompletionNone,
@@ -230,6 +276,7 @@ func builtInServiceDefinitionSpecs(cfg *config.Config) []looppkg.Spec {
 		specs = append(specs, looppkg.Spec{
 			Name:         telemetryDefinitionName,
 			Enabled:      true,
+			ParentName:   homeAssistantContainerName,
 			Task:         "Collect runtime telemetry and publish it through MQTT sensors.",
 			Operation:    looppkg.OperationService,
 			Completion:   looppkg.CompletionNone,

--- a/internal/app/loop_definition_hydration.go
+++ b/internal/app/loop_definition_hydration.go
@@ -16,6 +16,11 @@ func (a *App) buildLoopDefinitionBaseSpecs() ([]looppkg.Spec, error) {
 	for _, def := range baseDefinitions {
 		seen[strings.TrimSpace(def.Name)] = struct{}{}
 	}
+	// Grouping containers first, so member loops resolve their ParentName to
+	// a container that's already registered.
+	for _, spec := range builtInContainerDefinitionSpecs(a.cfg) {
+		baseDefinitions = appendMissingDefinition(baseDefinitions, seen, spec)
+	}
 	for _, spec := range builtInServiceDefinitionSpecs(a.cfg) {
 		baseDefinitions = appendMissingDefinition(baseDefinitions, seen, spec)
 	}
@@ -35,7 +40,11 @@ func (a *App) buildLoopDefinitionBaseSpecs() ([]looppkg.Spec, error) {
 			return nil, fmt.Errorf("%s config: %w", reg.Name, err)
 		}
 		if enabled && !hasDefinition {
-			baseDefinitions = appendMissingDefinition(baseDefinitions, seen, reg.DefinitionSpec(a))
+			spec := reg.DefinitionSpec(a)
+			// The core cognition loops (ego, metacognitive, archivist) live
+			// under the cognition container.
+			spec.ParentName = cognitionContainerName
+			baseDefinitions = appendMissingDefinition(baseDefinitions, seen, spec)
 		}
 	}
 	return baseDefinitions, nil

--- a/internal/app/loop_definition_hydration_test.go
+++ b/internal/app/loop_definition_hydration_test.go
@@ -269,6 +269,89 @@ func TestCoreServiceLoopByNameMatchesSlice(t *testing.T) {
 	}
 }
 
+// TestBuildLoopDefinitionBaseSpecs_GroupingContainers checks that the
+// built-in grouping containers are seeded and that their member loops nest
+// under them via ParentName, giving the node graph its top-level shape.
+func TestBuildLoopDefinitionBaseSpecs_GroupingContainers(t *testing.T) {
+	t.Parallel()
+
+	cfg := coreServiceTestConfig() // ego / metacognitive / archivist enabled
+	cfg.HomeAssistant = config.HomeAssistantConfig{URL: "http://ha.local:8123", Token: "tok"}
+	cfg.MQTT = config.MQTTConfig{
+		Broker:             "mqtt://broker.local:1883",
+		DeviceName:         "thane-dev",
+		PublishIntervalSec: 60,
+		Telemetry:          config.TelemetryConfig{Enabled: true, Interval: 60},
+	}
+
+	a := &App{cfg: cfg}
+	specs, err := a.buildLoopDefinitionBaseSpecs()
+	if err != nil {
+		t.Fatalf("buildLoopDefinitionBaseSpecs: %v", err)
+	}
+	byName := make(map[string]looppkg.Spec, len(specs))
+	for _, s := range specs {
+		byName[s.Name] = s
+	}
+
+	// Containers exist and are inert grouping containers.
+	for _, name := range []string{cognitionContainerName, homeAssistantContainerName} {
+		s, ok := byName[name]
+		if !ok {
+			t.Errorf("grouping container %q missing from base specs", name)
+			continue
+		}
+		if s.Operation != looppkg.OperationContainer {
+			t.Errorf("container %q Operation = %q, want %q", name, s.Operation, looppkg.OperationContainer)
+		}
+	}
+
+	// Cognition members nest under the cognition container.
+	for _, name := range []string{ego.DefinitionName, metacognitive.DefinitionName, archivist.DefinitionName} {
+		if got := byName[name].ParentName; got != cognitionContainerName {
+			t.Errorf("%s ParentName = %q, want %q", name, got, cognitionContainerName)
+		}
+	}
+
+	// Home Assistant members nest under the home-assistant container.
+	for _, name := range []string{haStateWatcherDefinitionName, mqttPublisherDefinitionName, telemetryDefinitionName, "mqtt-default-handler"} {
+		if got := byName[name].ParentName; got != homeAssistantContainerName {
+			t.Errorf("%s ParentName = %q, want %q", name, got, homeAssistantContainerName)
+		}
+	}
+}
+
+// TestBuiltInContainerDefinitionSpecs_Gating guards the container gating:
+// cognition only when a core loop is enabled, home-assistant only when HA or
+// MQTT is configured, channels always.
+func TestBuiltInContainerDefinitionSpecs_Gating(t *testing.T) {
+	t.Parallel()
+
+	names := func(specs []looppkg.Spec) map[string]bool {
+		m := make(map[string]bool, len(specs))
+		for _, s := range specs {
+			m[s.Name] = true
+		}
+		return m
+	}
+
+	bare := names(builtInContainerDefinitionSpecs(&config.Config{}))
+	if len(bare) != 0 {
+		t.Errorf("bare config seeded a gated container, want none: %v", bare)
+	}
+
+	if cog := names(builtInContainerDefinitionSpecs(coreServiceTestConfig())); !cog[cognitionContainerName] {
+		t.Error("cognition container missing when core loops enabled")
+	}
+
+	ha := names(builtInContainerDefinitionSpecs(&config.Config{
+		MQTT: config.MQTTConfig{Broker: "mqtt://b:1883", DeviceName: "d"},
+	}))
+	if !ha[homeAssistantContainerName] {
+		t.Error("home-assistant container missing when MQTT configured")
+	}
+}
+
 // TestCoreServiceRegistrationHydrate exercises each registration's
 // Hydrate closure directly: a missing cached config is a hard error, and
 // a hydrated spec attaches only genuine runtime-only hooks. The prompt is

--- a/internal/app/loop_definition_hydration_test.go
+++ b/internal/app/loop_definition_hydration_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	emailcfg "github.com/nugget/thane-ai-agent/internal/channels/email"
+	mqtt "github.com/nugget/thane-ai-agent/internal/channels/mqtt"
 	"github.com/nugget/thane-ai-agent/internal/integrations/forge"
 	"github.com/nugget/thane-ai-agent/internal/integrations/homeassistant"
 	"github.com/nugget/thane-ai-agent/internal/integrations/media"
@@ -314,7 +315,7 @@ func TestBuildLoopDefinitionBaseSpecs_GroupingContainers(t *testing.T) {
 	}
 
 	// Home Assistant members nest under the home-assistant container.
-	for _, name := range []string{haStateWatcherDefinitionName, mqttPublisherDefinitionName, telemetryDefinitionName, "mqtt-default-handler"} {
+	for _, name := range []string{haStateWatcherDefinitionName, mqttPublisherDefinitionName, telemetryDefinitionName, mqtt.DefaultHandlerLoopName} {
 		if got := byName[name].ParentName; got != homeAssistantContainerName {
 			t.Errorf("%s ParentName = %q, want %q", name, got, homeAssistantContainerName)
 		}
@@ -323,7 +324,8 @@ func TestBuildLoopDefinitionBaseSpecs_GroupingContainers(t *testing.T) {
 
 // TestBuiltInContainerDefinitionSpecs_Gating guards the container gating:
 // cognition only when a core loop is enabled, home-assistant only when HA or
-// MQTT is configured, channels always.
+// MQTT is configured. (channels is not a base-definition container — it is
+// spawned eagerly as an implicit container; see TestEnsureChannelsContainer.)
 func TestBuiltInContainerDefinitionSpecs_Gating(t *testing.T) {
 	t.Parallel()
 

--- a/internal/app/new_stores.go
+++ b/internal/app/new_stores.go
@@ -74,6 +74,13 @@ func (a *App) initStores(s *newState) error {
 		return fmt.Errorf("ensure core loop: %w", err)
 	}
 
+	// The channels grouping container must be live before the channel
+	// integrations (wired later in new_servers) spawn their dynamic channel
+	// loops under it — there is no late-reattach path.
+	if err := a.ensureChannelsContainer(s.ctx); err != nil {
+		return fmt.Errorf("ensure channels container: %w", err)
+	}
+
 	baseDefinitions, err := a.buildLoopDefinitionBaseSpecs()
 	if err != nil {
 		return err

--- a/internal/channels/messaging/signal/bridge.go
+++ b/internal/channels/messaging/signal/bridge.go
@@ -195,9 +195,9 @@ func (b *Bridge) Register(ctx context.Context) error {
 
 	parentID, err := b.registry.SpawnLoopUnderParentOrCore(ctx, loop.Config{
 		Name: "signal",
-		// Group under the built-in "channels" container (channelsContainerName
-		// in internal/app); falls back to core if it isn't live yet.
-		ParentName: "channels",
+		// Group under the built-in channels container; falls back to core if
+		// it isn't live yet.
+		ParentName: loop.ChannelsContainerName,
 		WaitFunc: func(wCtx context.Context) (any, error) {
 			select {
 			case <-wCtx.Done():

--- a/internal/channels/messaging/signal/bridge.go
+++ b/internal/channels/messaging/signal/bridge.go
@@ -193,8 +193,11 @@ func (b *Bridge) Register(ctx context.Context) error {
 		return nil
 	}
 
-	parentID, err := b.registry.SpawnLoop(ctx, loop.Config{
+	parentID, err := b.registry.SpawnLoopUnderParentOrCore(ctx, loop.Config{
 		Name: "signal",
+		// Group under the built-in "channels" container (channelsContainerName
+		// in internal/app); falls back to core if it isn't live yet.
+		ParentName: "channels",
 		WaitFunc: func(wCtx context.Context) (any, error) {
 			select {
 			case <-wCtx.Done():

--- a/internal/runtime/loop/registry.go
+++ b/internal/runtime/loop/registry.go
@@ -795,6 +795,26 @@ func (r *Registry) SpawnLoop(ctx context.Context, cfg Config, deps Deps) (string
 	return l.id, nil
 }
 
+// SpawnLoopUnderParentOrCore resolves cfg.ParentName to a live parent's ID and
+// spawns under it, falling back to core when the named parent isn't live yet.
+// Register only accepts an explicit ParentID — the bootstrap's topological sort
+// resolves names for definition-driven specs — so a loop spawned dynamically
+// during bootstrap (e.g. a channel loop whose grouping container may not be
+// live) must resolve its parent here. There is no late-reattach path, so a
+// fallback is permanent until the next spawn.
+func (r *Registry) SpawnLoopUnderParentOrCore(ctx context.Context, cfg Config, deps Deps) (string, error) {
+	if name := strings.TrimSpace(cfg.ParentName); name != "" {
+		cfg.ParentName = ""
+		if parent := r.GetByName(name); parent != nil {
+			cfg.ParentID = parent.ID()
+		} else if deps.Logger != nil {
+			deps.Logger.Debug("loop attached to core; grouping container not live",
+				"loop", cfg.Name, "parent_name", name)
+		}
+	}
+	return r.SpawnLoop(ctx, cfg, deps)
+}
+
 // SpawnSpec creates, registers, and starts a loop from a [Spec]. It is
 // the spec-based entrypoint; [Registry.SpawnLoop] with [Config] remains
 // available for callers that build a Config directly.

--- a/internal/runtime/loop/spawn_under_parent_test.go
+++ b/internal/runtime/loop/spawn_under_parent_test.go
@@ -36,17 +36,24 @@ func TestSpawnLoopUnderParentOrCore(t *testing.T) {
 		}
 	})
 
-	t.Run("falls back when parent missing", func(t *testing.T) {
+	t.Run("falls back to core when parent missing", func(t *testing.T) {
 		t.Parallel()
 		r := NewRegistry()
-		id, err := r.SpawnLoopUnderParentOrCore(context.Background(), Config{
+		ctx := context.Background()
+		if _, err := r.SpawnSpec(ctx, Spec{Name: CoreLoopName, Enabled: true, Operation: OperationContainer}, Deps{}); err != nil {
+			t.Fatalf("spawn core: %v", err)
+		}
+		if _, err := r.SpawnLoopUnderParentOrCore(ctx, Config{
 			Name: "orphan-child", ParentName: "nonexistent", Handler: noop,
-		}, Deps{})
-		if err != nil {
+		}, Deps{}); err != nil {
 			t.Fatalf("expected graceful fallback, got error: %v", err)
 		}
-		if id == "" || r.GetByName("orphan-child") == nil {
+		child := r.GetByName("orphan-child")
+		if child == nil {
 			t.Fatal("child not registered after fallback")
+		}
+		if core := r.Core(); core == nil || child.ParentID() != core.ID() {
+			t.Errorf("child ParentID = %q, want core's id", child.ParentID())
 		}
 	})
 }

--- a/internal/runtime/loop/spawn_under_parent_test.go
+++ b/internal/runtime/loop/spawn_under_parent_test.go
@@ -1,0 +1,52 @@
+package loop
+
+import (
+	"context"
+	"testing"
+)
+
+// TestSpawnLoopUnderParentOrCore covers the tolerant spawn used by loops that
+// are created dynamically during bootstrap and want a grouping container: they
+// attach to a live parent when present and fall back to core (rather than
+// failing to register) when the parent isn't live yet.
+func TestSpawnLoopUnderParentOrCore(t *testing.T) {
+	t.Parallel()
+
+	noop := func(context.Context, any) error { return nil }
+
+	t.Run("attaches to live parent", func(t *testing.T) {
+		t.Parallel()
+		r := NewRegistry()
+		ctx := context.Background()
+		if _, err := r.SpawnSpec(ctx, Spec{Name: "grp", Enabled: true, Operation: OperationContainer}, Deps{}); err != nil {
+			t.Fatalf("spawn parent container: %v", err)
+		}
+		if _, err := r.SpawnLoopUnderParentOrCore(ctx, Config{
+			Name: "child", ParentName: "grp", Handler: noop,
+		}, Deps{}); err != nil {
+			t.Fatalf("spawn child: %v", err)
+		}
+
+		child := r.GetByName("child")
+		if child == nil {
+			t.Fatal("child not registered")
+		}
+		if grp := r.GetByName("grp"); child.ParentID() != grp.ID() {
+			t.Errorf("child ParentID = %q, want grp %q", child.ParentID(), grp.ID())
+		}
+	})
+
+	t.Run("falls back when parent missing", func(t *testing.T) {
+		t.Parallel()
+		r := NewRegistry()
+		id, err := r.SpawnLoopUnderParentOrCore(context.Background(), Config{
+			Name: "orphan-child", ParentName: "nonexistent", Handler: noop,
+		}, Deps{})
+		if err != nil {
+			t.Fatalf("expected graceful fallback, got error: %v", err)
+		}
+		if id == "" || r.GetByName("orphan-child") == nil {
+			t.Fatal("child not registered after fallback")
+		}
+	})
+}

--- a/internal/runtime/loop/spec.go
+++ b/internal/runtime/loop/spec.go
@@ -77,6 +77,13 @@ const (
 // constant rather than re-spelling the string.
 const CoreLoopName = "core"
 
+// ChannelsContainerName is the well-known name of the built-in grouping
+// container for interactive counterparty channel loops (signal, owu, …).
+// Spawned eagerly under core at startup so dynamically-created channel loops
+// can attach to it. Shared here so the app bootstrap and the channel
+// integrations reference one constant instead of re-spelling the string.
+const ChannelsContainerName = "channels"
+
 // Completion describes how a loop's result should be delivered.
 // The zero value is accepted and means "no outward delivery declared".
 type Completion string

--- a/internal/server/api/owu_tracker.go
+++ b/internal/server/api/owu_tracker.go
@@ -71,9 +71,9 @@ func NewOWUTracker(ctx context.Context, registry *loop.Registry, eventBus *event
 
 	parentID, err := registry.SpawnLoopUnderParentOrCore(ctx, loop.Config{
 		Name: "owu",
-		// Group under the built-in "channels" container (channelsContainerName
-		// in internal/app); falls back to core if it isn't live yet.
-		ParentName: "channels",
+		// Group under the built-in channels container; falls back to core if
+		// it isn't live yet.
+		ParentName: loop.ChannelsContainerName,
 		Handler:    func(context.Context, any) error { return nil },
 		Metadata:   map[string]string{"subsystem": "owu", "category": "channel"},
 	}, loop.Deps{Logger: logger, EventBus: eventBus})

--- a/internal/server/api/owu_tracker.go
+++ b/internal/server/api/owu_tracker.go
@@ -69,10 +69,13 @@ func NewOWUTracker(ctx context.Context, registry *loop.Registry, eventBus *event
 		return t, nil
 	}
 
-	parentID, err := registry.SpawnLoop(ctx, loop.Config{
-		Name:     "owu",
-		Handler:  func(context.Context, any) error { return nil },
-		Metadata: map[string]string{"subsystem": "owu", "category": "channel"},
+	parentID, err := registry.SpawnLoopUnderParentOrCore(ctx, loop.Config{
+		Name: "owu",
+		// Group under the built-in "channels" container (channelsContainerName
+		// in internal/app); falls back to core if it isn't live yet.
+		ParentName: "channels",
+		Handler:    func(context.Context, any) error { return nil },
+		Metadata:   map[string]string{"subsystem": "owu", "category": "channel"},
 	}, loop.Deps{Logger: logger, EventBus: eventBus})
 	if err != nil {
 		return nil, fmt.Errorf("spawn owu parent loop: %w", err)


### PR DESCRIPTION
Gives the node graph real top-level structure instead of a flat ring under `core`, by grouping built-in loops into inert `Operation=container` parents and reusing the `parent_name` rendering that already powers `temporal`/`travel` — so **zero frontend work**; the depth renders for free.

## What groups
- **cognition** ← `ego`, `metacognitive`, `archivist` (thane's core cognition loops: reflection, identity, memory)
- **home-assistant** ← `ha-state-watcher`, `mqtt`, `mqtt-default-handler`, `telemetry` (the HA integration domain, spanning the `mqtt` + `homeassistant` subsystems)
- **channels** ← `owu`, `signal` (interactive counterparty channels; more join automatically)

## Two mechanisms, because the members bootstrap differently
**cognition / home-assistant** members are *base definitions*, so the containers are seeded as base definitions too (via the existing `appendMissingDefinition` insert-if-not-present path, ordered first). The definition registry's **topological sort** spawns each container before its members, which resolve `parent_name` → `parent_id` at that point. Containers are gated (cognition when a core loop is enabled; home-assistant when HA or MQTT is configured) so an empty container never appears.

**channels** members (`owu`, `signal`) are spawned *dynamically during app init*, before the definition layer is live — and the registry's `Register` only accepts an explicit `ParentID`, never a bare `ParentName`. So `channels` can't be a base definition. Instead:
- `ensureChannelsContainer` spawns it eagerly as an **implicit container under `core`**, right after `ensureCoreLoop` (mirroring how `core` itself is created) — there is no late-reattach path, so the parent must exist before the children register.
- `Registry.SpawnLoopUnderParentOrCore` resolves a `ParentName` to the live parent's ID and **falls back to core** if it isn't live yet — so the channel loops group under `channels` in normal operation and can never hard-fail to register.

## Test plan
- [x] `just ci` green.
- [x] cognition/home-assistant: containers seeded + `Operation=container`; members carry the right `ParentName`; container gating.
- [x] channels: `ensureChannelsContainer` creates the container + is idempotent; `SpawnLoopUnderParentOrCore` attaches to a live parent and falls back to core when absent.
- [ ] Deploy + confirm on the live graph that `core → {cognition, home-assistant, channels, …}` renders with real prod loops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)