### PR TITLE
feat(web): progressive-disclosure loop inspector + LoopView API foundation

### DIFF
--- a/internal/server/api/loops.go
+++ b/internal/server/api/loops.go
@@ -44,18 +44,21 @@ func (s *Server) handleLoops(w http.ResponseWriter, r *http.Request) {
 		s.errorResponse(w, http.StatusServiceUnavailable, "loop registry not configured")
 		return
 	}
-	statuses := s.loopRegistry.Statuses()
+	all := s.loopRegistry.Statuses()
+	rows := all
 	if state := strings.TrimSpace(r.URL.Query().Get("state")); state != "" {
-		filtered := make([]looppkg.Status, 0, len(statuses))
-		for _, st := range statuses {
+		filtered := make([]looppkg.Status, 0, len(all))
+		for _, st := range all {
 			if string(st.State) == state {
 				filtered = append(filtered, st)
 			}
 		}
-		statuses = filtered
+		rows = filtered
 	}
 	w.Header().Set("Content-Type", "application/json")
-	writeJSON(w, statuses, s.logger)
+	// The resolver is built over the FULL batch so parent_name/child_count/
+	// ancestry stay correct even when ?state= filtered the returned rows.
+	writeJSON(w, projectLoops(s.loopViewResolver(all), rows), s.logger)
 }
 
 // handleLoop returns one running loop's status snapshot. [GET /v1/loops/{id}]
@@ -74,8 +77,63 @@ func (s *Server) handleLoop(w http.ResponseWriter, r *http.Request) {
 		s.errorResponse(w, http.StatusNotFound, "loop not found")
 		return
 	}
+	resolver := s.loopViewResolver(s.loopRegistry.Statuses())
 	w.Header().Set("Content-Type", "application/json")
-	writeJSON(w, status, s.logger)
+	writeJSON(w, loopWithView{Status: status, View: resolver.FromStatus(status)}, s.logger)
+}
+
+// loopWithView is a running-loop Status enriched with its canonical LoopView
+// projection (the "ps auxwwww" row) under a `view` key, so the web console
+// speaks the same schedule/structure/economics/policy vocabulary as the
+// model-facing Loops table. Status fields stay promoted (flat) for existing
+// clients; `view` is purely additive.
+type loopWithView struct {
+	looppkg.Status
+	View looppkg.LoopView `json:"view"`
+}
+
+// loopViewResolver builds a LoopView resolver over the full status batch joined
+// to the live definition policy, so one pass resolves parent_name, child_count,
+// ancestry, and policy_state for every projected row.
+func (s *Server) loopViewResolver(all []looppkg.Status) looppkg.LoopViewResolver {
+	return looppkg.NewLoopViewResolver(all, s.loopPolicyByName(), time.Now())
+}
+
+// loopPolicyByName joins each loop name to its stored definition's policy and
+// eligibility from the live registry view, so the projection reports
+// active/paused/eligible rather than "ephemeral". Returns nil when no
+// definition registry is wired, which the projector reads as ephemeral.
+func (s *Server) loopPolicyByName() map[string]looppkg.LoopPolicyInfo {
+	if s.loopDefinitionView == nil {
+		return nil
+	}
+	view := s.loopDefinitionView()
+	if view == nil {
+		return nil
+	}
+	out := make(map[string]looppkg.LoopPolicyInfo, len(view.Definitions))
+	for _, def := range view.Definitions {
+		out[def.Name] = looppkg.LoopPolicyInfo{
+			State:          string(def.PolicyState),
+			Source:         string(def.PolicySource),
+			Reason:         def.PolicyReason,
+			UpdatedAt:      def.PolicyUpdatedAt,
+			Eligible:       def.Eligibility.Eligible,
+			EligibleReason: def.Eligibility.Reason,
+			HasPolicy:      true,
+		}
+	}
+	return out
+}
+
+// projectLoops wraps each row with its LoopView projection using one shared
+// resolver.
+func projectLoops(resolver looppkg.LoopViewResolver, rows []looppkg.Status) []loopWithView {
+	out := make([]loopWithView, len(rows))
+	for i, st := range rows {
+		out[i] = loopWithView{Status: st, View: resolver.FromStatus(st)}
+	}
+	return out
 }
 
 // handleLoopLogs returns log entries scoped to one loop's recent conversation
@@ -182,7 +240,8 @@ func (s *Server) handleLoopEvents(w http.ResponseWriter, r *http.Request) {
 	ch := s.eventBus.Subscribe(64)
 	defer s.eventBus.Unsubscribe(ch)
 
-	snapJSON, err := json.Marshal(s.loopRegistry.Statuses())
+	allStatuses := s.loopRegistry.Statuses()
+	snapJSON, err := json.Marshal(projectLoops(s.loopViewResolver(allStatuses), allStatuses))
 	if err != nil {
 		s.logger.Warn("failed to marshal loop snapshot", "error", err)
 		return

--- a/internal/server/api/loops_test.go
+++ b/internal/server/api/loops_test.go
@@ -80,6 +80,53 @@ func TestHandleLoops(t *testing.T) {
 	}
 }
 
+func TestHandleLoops_IncludesLoopView(t *testing.T) {
+	s := quietServer(fakeLoopReg{statuses: []looppkg.Status{
+		{ID: "p", Name: "parent", State: looppkg.StateSleeping},
+		{ID: "c", Name: "child", State: looppkg.StateSleeping, ParentID: "p",
+			ContextWindow: 200000, LastInputTokens: 100000},
+	}})
+
+	rr := httptest.NewRecorder()
+	s.handleLoops(rr, httptest.NewRequest(http.MethodGet, "/v1/loops", nil))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rr.Code)
+	}
+	var rows []struct {
+		ID   string `json:"id"`
+		View struct {
+			ParentName     *string `json:"parent_name"`
+			ChildCount     int     `json:"child_count"`
+			ContextFillPct *int    `json:"context_fill_pct"`
+			PolicyState    string  `json:"policy_state"`
+		} `json:"view"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &rows); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	byID := map[string]int{}
+	for i, r := range rows {
+		byID[r.ID] = i
+	}
+	parent, child := rows[byID["p"]], rows[byID["c"]]
+
+	// Resolver runs over the full batch, so graph joins are populated.
+	if parent.View.ChildCount != 1 {
+		t.Errorf("parent child_count = %d, want 1", parent.View.ChildCount)
+	}
+	if child.View.ParentName == nil || *child.View.ParentName != "parent" {
+		t.Errorf("child parent_name = %v, want \"parent\"", child.View.ParentName)
+	}
+	// Precomputed so the client never divides.
+	if child.View.ContextFillPct == nil || *child.View.ContextFillPct != 50 {
+		t.Errorf("child context_fill_pct = %v, want 50", child.View.ContextFillPct)
+	}
+	// No definition registry wired on quietServer ⇒ ephemeral, not a misleading default.
+	if child.View.PolicyState != "ephemeral" {
+		t.Errorf("child policy_state = %q, want ephemeral", child.View.PolicyState)
+	}
+}
+
 func TestHandleLoops_Unconfigured(t *testing.T) {
 	s := &Server{logger: slog.New(slog.NewTextHandler(io.Discard, nil))}
 	rr := httptest.NewRecorder()

--- a/internal/server/openapi/native.yaml
+++ b/internal/server/openapi/native.yaml
@@ -230,7 +230,7 @@ paths:
             application/json:
               schema:
                 type: array
-                items: { $ref: "#/components/schemas/LoopStatus" }
+                items: { $ref: "#/components/schemas/LoopStatusWithView" }
   /v1/loops/{id}:
     get:
       tags: [Loops]
@@ -244,7 +244,7 @@ paths:
           description: Loop status.
           content:
             application/json:
-              schema: { $ref: "#/components/schemas/LoopStatus" }
+              schema: { $ref: "#/components/schemas/LoopStatusWithView" }
         "404": { $ref: "#/components/responses/NotFound" }
   /v1/loops/{id}/logs:
     get:
@@ -1466,6 +1466,80 @@ components:
         recent_conv_ids: ["019e7469-3abf-7e6b-ae38-85b5e34915ac", "019e7469-1a2b-7c3d-9e4f-0a1b2c3d4e5f"]
         handler_only: false
         event_driven: false
+    LoopView:
+      type: object
+      description: |
+        Canonical model-facing projection of one loop — the "ps auxwwww" row the
+        Loops table and loop_* tools emit, attached to each running loop on
+        /v1/loops as `view` so the console reads schedule, structure, economics,
+        and policy in one consistent vocabulary. Pointer fields serialize as
+        explicit null when not applicable (e.g. token counters on a handler-only
+        loop). Mirrors internal/runtime/loop.LoopView; the inspector-relevant
+        fields are documented here and the remainder are tracked under the
+        OpenAPI field-parity effort.
+      additionalProperties: true
+      properties:
+        operation:
+          type: string
+          description: Canonical run shape (container, service, event_driven, request_reply, background_task).
+        intent:
+          type: string
+          description: One-line statement of what the loop is for, from its definition.
+        parent_name:
+          type: [string, "null"]
+          description: Parent loop's resolved name (never a bare ID); null at the root.
+        ancestry:
+          type: array
+          items: { type: string }
+          description: Ancestor names ordered root→leaf, for blast-radius context.
+        child_count:
+          type: integer
+          description: Number of direct child loops.
+        policy_state:
+          type: string
+          description: active, paused, or ephemeral (no stored definition backs the loop).
+        eligible:
+          type: boolean
+          description: Whether the loop's definition is currently eligible to run.
+        next_wake_delta:
+          type: [string, "null"]
+          description: Signed-second delta to the scheduled wake while timer-sleeping (e.g. "+5953s"); null when processing or event-driven.
+        current_sleep_duration:
+          type: [string, "null"]
+          description: Unsigned-second self-paced sleep interval honored this cycle (e.g. "5940s").
+        context_fill_pct:
+          type: [integer, "null"]
+          description: Last input tokens as a percentage of the context window; null for handler-only loops.
+        consecutive_errors:
+          type: [integer, "null"]
+          description: Length of the current error streak.
+        last_error:
+          type: [string, "null"]
+          description: Most recent error text; null when clean.
+    LoopStatusWithView:
+      description: A running loop's status snapshot enriched with its canonical LoopView projection under `view`.
+      allOf:
+        - $ref: "#/components/schemas/LoopStatus"
+        - type: object
+          properties:
+            view: { $ref: "#/components/schemas/LoopView" }
+      example:
+        id: 019e7469-3abf-7e6b-ae38-85b5e34915ac
+        name: signal-interactive
+        state: sleeping
+        view:
+          operation: service
+          intent: Tend the Signal conversation and respond to inbound messages.
+          parent_name: channels
+          ancestry: [core, channels]
+          child_count: 0
+          policy_state: active
+          eligible: true
+          next_wake_delta: "+5953s"
+          current_sleep_duration: "5940s"
+          context_fill_pct: 42
+          consecutive_errors: 0
+          last_error: null
     IterationSnapshot:
       type: object
       description: Serializable summary of a single completed loop iteration, retained in a ring buffer for the dashboard timeline.

--- a/internal/server/openapi/native.yaml
+++ b/internal/server/openapi/native.yaml
@@ -1470,9 +1470,10 @@ components:
       type: object
       description: |
         Canonical model-facing projection of one loop — the "ps auxwwww" row the
-        Loops table and loop_* tools emit, attached to each running loop on
-        /v1/loops as `view` so the console reads schedule, structure, economics,
-        and policy in one consistent vocabulary. Pointer fields serialize as
+        Loops table and loop_* tools emit, attached to each running loop as
+        `view` on /v1/loops, /v1/loops/{id}, and the /v1/loops/events snapshot so
+        the console reads schedule, structure, economics, and policy in one
+        consistent vocabulary. Pointer fields serialize as
         explicit null when not applicable (e.g. token counters on a handler-only
         loop). Mirrors internal/runtime/loop.LoopView; the inspector-relevant
         fields are documented here and the remainder are tracked under the

--- a/internal/server/web/static/app.js
+++ b/internal/server/web/static/app.js
@@ -4491,7 +4491,14 @@ function renderLoopSpecSection(loop) {
     e.preventDefault();
     e.stopPropagation();
     state.specMode.set(name, nextSpecMode(mode));
-    try { renderDetail(); } catch (err) { console.error('spec mode renderDetail:', err); }
+    // Force the re-render through the hover/interaction defer gate (see
+    // withPreservedDetailScroll). A plain renderDetail() is suppressed while the
+    // pointer is over the control, so the new mode wouldn't paint until mouse-
+    // out — the same path the schema-card controls take via applySchemaCardPreset.
+    bumpDetailInteractionHold(180);
+    requestAnimationFrame(() => {
+      try { renderDetail({ force: true }); } catch (err) { console.error('spec mode renderDetail:', err); }
+    });
   });
   controls.appendChild(btn);
   head.appendChild(controls);

--- a/internal/server/web/static/app.js
+++ b/internal/server/web/static/app.js
@@ -4199,6 +4199,15 @@ function renderIterationStrip(loop) {
     const row = document.createElement('div');
     row.className = 'iter-row';
 
+    // Hover reveals the wall-clock when (kept off the row to stay compact): when
+    // it started, how long ago, and the duration that's already shown inline.
+    const startRaw = s.started_at || s.completed_at;
+    const startDate = startRaw ? new Date(startRaw) : null;
+    if (startDate && !isNaN(startDate)) {
+      const durTxt = s.elapsed_ms ? ' · took ' + formatDuration(s.elapsed_ms) : '';
+      row.title = `#${s.number || '?'} · ran ${formatWhen(startDate)} (${timeAgo(startDate)})${durTxt}`;
+    }
+
     const num = document.createElement('span');
     num.className = 'iter-num';
     num.textContent = '#' + (s.number || '');

--- a/internal/server/web/static/app.js
+++ b/internal/server/web/static/app.js
@@ -31,7 +31,7 @@ const state = {
   conversationDetails: new Map(), // conversation_id -> derived dashboard summary
   conversationLoads: new Map(),   // conversation_id -> in-flight loader promise
   loopDefs: new Map(),            // loop name -> { status, def, at } cached /v1/loop-definitions
-  specExpanded: new Set(),        // "name::field" keys whose spec text is expanded inline
+  specMode: new Map(),            // loop name -> 'summary' | 'brief' | 'verbose' spec view
 };
 
 const MAX_EVENTS = 50;
@@ -4403,12 +4403,25 @@ function ensureLoopDef(name) {
     });
 }
 
+// Spec view modes mirror the schema cards' title/widget/full ladder so the
+// hamburger reads the same: summary = head only, brief = collapsed field
+// whispers, verbose = full bodies inline. The icon maps onto the shared
+// schema-card glyphs (1 / 2 / 3 bars).
+const SPEC_MODES = ['summary', 'brief', 'verbose'];
+const SPEC_MODE_ICON = { summary: 'title', brief: 'widget', verbose: 'full' };
+
+function nextSpecMode(mode) {
+  const i = SPEC_MODES.indexOf(SPEC_MODES.includes(mode) ? mode : 'brief');
+  return SPEC_MODES[(i + 1) % SPEC_MODES.length];
+}
+
 // renderLoopSpecSection surfaces the loop's stored DEFINITION — what the loop
 // IS, against the runtime sections above that show what it's DOING. Three
 // things an operator asks of a spec: the prompt it runs each wake, the
 // supervisor-review messaging (when the loop opts into frontier review turns),
-// and the documents it's declared to maintain. Ephemeral loops (no stored
-// definition) and containers (structural only) say so plainly.
+// and the documents it's declared to maintain. A hamburger cycles the whole
+// section summary → brief → verbose, the same control the schema cards carry.
+// Ephemeral loops (no stored definition) and containers (structural) say so.
 function renderLoopSpecSection(loop) {
   const name = loop && loop.name;
   if (!name || name === 'core') return null; // core has no registry definition
@@ -4419,13 +4432,16 @@ function renderLoopSpecSection(loop) {
   section.className = 'loop-spec';
   const head = document.createElement('div');
   head.className = 'loop-spec__head';
+  const heading = document.createElement('div');
+  heading.className = 'loop-spec__heading';
   const title = document.createElement('span');
   title.className = 'loop-spec__title';
   title.textContent = 'spec';
-  head.appendChild(title);
+  heading.appendChild(title);
   const meta = document.createElement('span');
   meta.className = 'loop-spec__meta';
-  head.appendChild(meta);
+  heading.appendChild(meta);
+  head.appendChild(heading);
   section.appendChild(head);
 
   if (!entry || entry.status === 'loading') {
@@ -4450,19 +4466,56 @@ function renderLoopSpecSection(loop) {
   ].filter(Boolean).join('  ·  ');
 
   const hasTask = (spec.task || '').trim();
+  const instr = spec.profile && spec.profile.instructions;
+  const hasInstr = (instr || '').trim();
+  const hasSupervisor = !!spec.supervisor;
   const hasOutputs = (spec.outputs || []).length > 0;
   if (spec.operation === 'container' && !hasTask && !hasOutputs) {
     appendSpecEmpty(section, 'Container node — organizes its children and cascades subscriptions. No prompt or outputs of its own.');
     return section;
   }
 
+  // Hamburger toggle — reuses the schema-card control look + glyph, cycling the
+  // whole section's disclosure. Lives in the head, right-aligned.
+  const mode = SPEC_MODES.includes(state.specMode.get(name)) ? state.specMode.get(name) : 'brief';
+  const controls = document.createElement('div');
+  controls.className = 'loop-spec__controls';
+  const btn = document.createElement('button');
+  btn.type = 'button';
+  btn.className = 'schema-card__control';
+  btn.innerHTML = makeSchemaCardModeIcon(SPEC_MODE_ICON[mode]);
+  const nm = nextSpecMode(mode);
+  btn.title = 'Spec view: ' + mode + '. Click for ' + nm;
+  btn.setAttribute('aria-label', 'Spec view: ' + mode + '. Click for ' + nm);
+  btn.addEventListener('click', (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+    state.specMode.set(name, nextSpecMode(mode));
+    try { renderDetail(); } catch (err) { console.error('spec mode renderDetail:', err); }
+  });
+  controls.appendChild(btn);
+  head.appendChild(controls);
+
+  // Summary: head + a one-line census of what the spec carries, nothing more.
+  if (mode === 'summary') {
+    const census = [
+      hasTask ? 'prompt' : null,
+      hasInstr ? 'instructions' : null,
+      hasSupervisor ? 'supervisor review' : null,
+      hasOutputs ? (spec.outputs.length === 1 ? '1 output document' : formatNumber(spec.outputs.length) + ' output documents') : null,
+    ].filter(Boolean).join('  ·  ');
+    if (census) appendSpecEmpty(section, census);
+    return section;
+  }
+
+  const verbose = mode === 'verbose';
+
   // Prompt — the per-iteration task, plus method instructions when present.
-  if (hasTask) section.appendChild(makeSpecTextField(name, 'prompt', spec.task));
-  const instr = spec.profile && spec.profile.instructions;
-  if ((instr || '').trim()) section.appendChild(makeSpecTextField(name, 'instructions', instr));
+  if (hasTask) section.appendChild(makeSpecTextField('prompt', spec.task, null, verbose));
+  if (hasInstr) section.appendChild(makeSpecTextField('instructions', instr, null, verbose));
 
   // Supervisor review — the frontier-review messaging, only when the loop opts in.
-  if (spec.supervisor) {
+  if (hasSupervisor) {
     const sup = spec.supervisor_profile || {};
     const pct = typeof spec.supervisor_prob === 'number' ? Math.round(spec.supervisor_prob * 100) : null;
     const supMeta = [
@@ -4470,7 +4523,7 @@ function renderLoopSpecSection(loop) {
       sup.quality_floor ? 'quality floor ' + sup.quality_floor : null,
     ].filter(Boolean).join(' · ');
     if ((sup.instructions || '').trim()) {
-      section.appendChild(makeSpecTextField(name, 'supervisor review', sup.instructions, supMeta));
+      section.appendChild(makeSpecTextField('supervisor review', sup.instructions, supMeta, verbose));
     } else {
       appendSpecEmpty(section, 'Supervisor review on (' + (supMeta || 'periodic') + ') using baseline frontier overrides — no custom review prompt.');
     }
@@ -4489,15 +4542,12 @@ function appendSpecEmpty(section, text) {
 }
 
 // makeSpecTextField renders one long spec text (prompt / instructions /
-// supervisor messaging) as a compact, copyable field. Collapsed by default to a
-// one-line whisper + char count; expand reads it inline, copy lifts the full
-// body to the clipboard for pasting into an editor (the owner's stated way of
-// working with prompt bodies). Expand state lives in state.specExpanded so it
-// survives the inspector's ~1/s full re-render.
-function makeSpecTextField(name, label, text, extraMeta) {
+// supervisor messaging) as a copyable field. The section's view mode governs
+// disclosure: brief shows a one-line whisper + char count, verbose shows the
+// full body inline. Copy always lifts the full body to the clipboard for
+// pasting into an editor (the owner's stated way of working with prompt bodies).
+function makeSpecTextField(label, text, extraMeta, verbose) {
   const body = String(text);
-  const key = name + '::' + label;
-  const expanded = state.specExpanded.has(key);
 
   const field = document.createElement('div');
   field.className = 'spec-field';
@@ -4516,17 +4566,6 @@ function makeSpecTextField(name, label, text, extraMeta) {
   spacer.className = 'spec-field__spacer';
   fhead.appendChild(spacer);
 
-  const expandBtn = document.createElement('button');
-  expandBtn.type = 'button';
-  expandBtn.className = 'spec-field__btn';
-  expandBtn.textContent = expanded ? 'collapse' : 'expand';
-  expandBtn.addEventListener('click', () => {
-    if (state.specExpanded.has(key)) state.specExpanded.delete(key);
-    else state.specExpanded.add(key);
-    try { renderDetail(); } catch (e) { console.error('spec expand renderDetail:', e); }
-  });
-  fhead.appendChild(expandBtn);
-
   const copyBtn = document.createElement('button');
   copyBtn.type = 'button';
   copyBtn.className = 'spec-field__btn';
@@ -4541,7 +4580,7 @@ function makeSpecTextField(name, label, text, extraMeta) {
   fhead.appendChild(copyBtn);
   field.appendChild(fhead);
 
-  if (expanded) {
+  if (verbose) {
     const pre = document.createElement('pre');
     pre.className = 'spec-field__body';
     pre.textContent = body;

--- a/internal/server/web/static/app.js
+++ b/internal/server/web/static/app.js
@@ -30,6 +30,8 @@ const state = {
   canvasRect: null,          // last observed canvas viewport for responsive graph reflow
   conversationDetails: new Map(), // conversation_id -> derived dashboard summary
   conversationLoads: new Map(),   // conversation_id -> in-flight loader promise
+  loopDefs: new Map(),            // loop name -> { status, def, at } cached /v1/loop-definitions
+  specExpanded: new Set(),        // "name::field" keys whose spec text is expanded inline
 };
 
 const MAX_EVENTS = 50;
@@ -1502,8 +1504,6 @@ function renderLoopCurrentTurnCard(loop, entity, conversationSummary) {
     titleSummary = [
       threadLabel,
       latestModelLabel !== 'model pending' ? 'on ' + latestModelLabel : '',
-      currentEffectiveTools.length > 0 ? `${formatNumber(currentEffectiveTools.length)} tools in scope` : '',
-      currentLoadedCapabilities.length > 0 ? `${formatNumber(currentLoadedCapabilities.length)} capabilities loaded` : '',
       activeToolNames.length > 0
         ? `${formatNumber(activeToolNames.length)} tool${activeToolNames.length === 1 ? '' : 's'} in flight`
         : `iteration ${iterationLabel} in progress`,
@@ -1512,9 +1512,7 @@ function renderLoopCurrentTurnCard(loop, entity, conversationSummary) {
     titleSummary = [
       threadLabel,
       formatSchemaToken(entity.stateLabel),
-      'req ' + shortID(entity.latestRequestID),
-      currentEffectiveTools.length > 0 ? `${formatNumber(currentEffectiveTools.length)} tools in scope` : '',
-      lastWakeAgo ? 'wake ' + lastWakeAgo : '',
+      'req ' + shortID(entity.latestRequestID),      lastWakeAgo ? 'wake ' + lastWakeAgo : '',
     ].filter(Boolean).join(' · ');
   } else {
     titleSummary = [
@@ -1542,8 +1540,6 @@ function renderLoopCurrentTurnCard(loop, entity, conversationSummary) {
       { label: 'Iteration', value: iterationLabel },
       { label: 'Model', value: latestModelLabel },
       { label: 'Health', value: serviceDegraded ? 'degraded' : (entity.lastError ? 'recovering' : 'steady') },
-      currentEffectiveTools.length > 0 ? { label: 'Tool surface', value: formatNumber(currentEffectiveTools.length) } : null,
-      currentLoadedCapabilities.length > 0 ? { label: 'Loaded capabilities', value: currentLoadedCapabilities.map((entry) => entry.tag).join(', ') } : null,
       entity.activeLiveTools.length > 0 ? { label: 'Tools live', value: activeToolSet.join(', ') } : null,
       lastWakeAgo ? { label: 'Wake', value: lastWakeAgo } : null,
     ],
@@ -1562,8 +1558,6 @@ function renderLoopCurrentTurnCard(loop, entity, conversationSummary) {
     entity.activeLiveTools.length > 0
       ? { label: 'Tools in flight', value: activeToolSet.join(', ') }
       : { label: 'Thread', value: threadLabel },
-    currentEffectiveTools.length > 0 ? { label: 'Tool surface', value: formatNumber(currentEffectiveTools.length) } : null,
-    currentLoadedCapabilities.length > 0 ? { label: 'Loaded capabilities', value: currentLoadedCapabilities.map((entry) => entry.tag).join(', ') } : null,
   ]);
   if (turnMetrics) card.body.appendChild(turnMetrics);
 
@@ -1592,8 +1586,6 @@ function renderLoopCurrentTurnCard(loop, entity, conversationSummary) {
     { label: 'Model', value: latestModelLabel },
     { label: 'State', value: formatSchemaToken(entity.stateLabel) },
     { label: 'Context', value: contextLabel || 'pending' },
-    { label: 'Loaded capabilities', value: currentLoadedCapabilities.length > 0 ? currentLoadedCapabilities.map((entry) => entry.tag).join(', ') : 'none' },
-    { label: 'Tool surface', value: currentEffectiveTools.length > 0 ? formatNumber(currentEffectiveTools.length) : 'pending' },
     { label: 'Wake', value: lastWakeAgo || 'pending' },
   ];
   for (const item of briefFacts) {
@@ -1612,18 +1604,8 @@ function renderLoopCurrentTurnCard(loop, entity, conversationSummary) {
   brief.appendChild(briefGrid);
   card.body.appendChild(brief);
 
-  const loadedTagsWrap = document.createElement('div');
-  loadedTagsWrap.className = 'schema-subsection';
-  loadedTagsWrap.innerHTML = '<h4 class="schema-subsection__title">Loaded Capabilities</h4>';
-  if (currentLoadedCapabilities.length > 0) {
-    loadedTagsWrap.appendChild(makeSchemaChipList(currentLoadedCapabilities.map((entry) => entry.tag), 'tag-chip tag-chip--active'));
-  } else {
-    const empty = document.createElement('div');
-    empty.className = 'loop-turn-empty';
-    empty.textContent = 'No capabilities are currently loaded for this loop.';
-    loadedTagsWrap.appendChild(empty);
-  }
-  card.body.appendChild(loadedTagsWrap);
+  // Capabilities render once, in the shared renderActiveCapabilities() section —
+  // not duplicated here (this was the conversation-vs-non-conversation divergence).
 
   if (entity.latestRequestID) {
     const requestWrap = document.createElement('div');
@@ -3945,6 +3927,692 @@ function renderSystemEntityDetail(sys) {
   updateSystemUptime();
 }
 
+// ---------------------------------------------------------------------------
+// Tier 0 — the glance header.
+// An always-on, zero-click read that answers what the NODE itself can't already
+// encode: an error STREAK (not just an "error" hue), what the loop is doing
+// right NOW (model phase vs tool phase, ticking), context pressure, and next
+// wake. Replaces the hero / identity / relationship cards. Prefers the
+// loop.view (LoopView) projection and falls back to existing fields when the
+// server hasn't shipped `view` yet, so it degrades cleanly across the deploy.
+
+function glanceMetric(label, fill) {
+  const m = document.createElement('div');
+  m.className = 'glance-metric';
+  const l = document.createElement('div');
+  l.className = 'glance-metric__label';
+  l.textContent = label;
+  m.appendChild(l);
+  const v = document.createElement('div');
+  v.className = 'glance-metric__value';
+  fill(v);
+  m.appendChild(v);
+  return m;
+}
+
+// makeSparkline draws a word-sized trend line from a value series (oldest→newest).
+function makeSparkline(values, w, h) {
+  const max = Math.max(...values);
+  const min = Math.min(...values);
+  const range = (max - min) || 1;
+  const n = values.length;
+  const pts = values.map((val, i) => {
+    const x = n > 1 ? (i / (n - 1)) * (w - 2) + 1 : w / 2;
+    const y = h - 1 - ((val - min) / range) * (h - 2);
+    return x.toFixed(1) + ',' + y.toFixed(1);
+  }).join(' ');
+  const svg = createSVG('svg', { class: 'glance-spark', width: w, height: h, viewBox: '0 0 ' + w + ' ' + h });
+  svg.appendChild(createSVG('polyline', { points: pts, fill: 'none' }));
+  return svg;
+}
+
+// makeFillBar renders a filled-to-ceiling bar, hued by pressure past comfortable.
+function makeFillBar(pct) {
+  const clamped = Math.max(0, Math.min(100, pct));
+  const bar = document.createElement('div');
+  bar.className = 'glance-fill';
+  const fill = document.createElement('div');
+  fill.className = 'glance-fill__fill';
+  fill.style.width = clamped + '%';
+  fill.style.background = pct >= 85 ? 'var(--red)' : pct >= 60 ? 'var(--orange)' : 'var(--text-secondary)';
+  bar.appendChild(fill);
+  return bar;
+}
+
+// parseDurationSecs reads a signed-second LoopView string ("5940s", "+5953s",
+// "-12s") into seconds (sign preserved); null when absent/unparseable.
+function parseDurationSecs(str) {
+  if (!str) return null;
+  const m = String(str).match(/^([+-]?)(\d+)s$/);
+  if (!m) return null;
+  return (m[1] === '-' ? -1 : 1) * parseInt(m[2], 10);
+}
+
+// renderSleepScrubber draws the loop's sleep cycle as a non-interactive
+// timeline: a track from 0 to the latest allowed wake (SleepMax), a hatched
+// locked zone before SleepMin, a marker at the chosen wake, and a playhead at
+// elapsed crawling toward it — red and past the marker when overdue. Chosen +
+// elapsed prefer the LoopView projection and fall back to the client's observed
+// sleep timer; bounds come from the loop config (nanoseconds). Returns null
+// when there is no timer sleep to show (event-driven, or no wake data yet).
+function renderSleepScrubber(loop) {
+  if (loop.event_driven) return null;
+  const view = loop.view || {};
+  const cfg = loop.config || {};
+  const ns2s = (ns) => (typeof ns === 'number' && ns > 0) ? ns / 1e9 : null;
+  const minS = parseDurationSecs(view.sleep_min) || ns2s(cfg.SleepMin);
+  const maxS = parseDurationSecs(view.sleep_max) || ns2s(cfg.SleepMax);
+
+  let chosenS = parseDurationSecs(view.current_sleep_duration);
+  const toWakeView = parseDurationSecs(view.next_wake_delta);
+  let toWakeS = toWakeView;
+  let elapsedS = (chosenS != null && toWakeView != null) ? (chosenS - toWakeView) : null;
+  if (chosenS == null) {
+    const timer = state.sleepTimers.get(loop.id);
+    if (timer && timer.durationMs > 0) {
+      chosenS = timer.durationMs / 1000;
+      elapsedS = (Date.now() - timer.startedAt) / 1000;
+      toWakeS = chosenS - elapsedS;
+    }
+  }
+  if (chosenS == null || elapsedS == null || chosenS <= 0) return null;
+
+  // Axis = the chosen sleep (0 → chosen = the wake at the right edge). Anchoring
+  // to the choice rather than SleepMax keeps a short choice from squishing
+  // against a far-larger ceiling; the ceiling rides in the label instead. The
+  // locked zone + min tick draw only when there is a real "can't wake before
+  // SleepMin yet, but chose to sleep past it" gap — otherwise (fixed-interval
+  // pollers where min ≈ chosen) the whole track would read as locked.
+  const pct = (s) => Math.max(0, Math.min(100, (s / chosenS) * 100));
+  const overdue = elapsedS > chosenS + 1;
+  const showMin = minS != null && minS > 0 && minS < chosenS * 0.98;
+  const showMaxLabel = maxS != null && maxS > chosenS * 1.1;
+
+  const wrap = document.createElement('div');
+  wrap.className = 'sleep-scrubber' + (overdue ? ' sleep-scrubber--overdue' : '');
+
+  const label = document.createElement('div');
+  label.className = 'sleep-scrubber__label';
+  const chose = document.createElement('span');
+  chose.textContent = 'chose ' + formatDuration(Math.round(chosenS) * 1000)
+    + (showMaxLabel ? '  ·  max ' + formatDuration(Math.round(maxS) * 1000) : '');
+  label.appendChild(chose);
+  const eta = document.createElement('span');
+  eta.className = 'sleep-scrubber__eta';
+  eta.textContent = overdue
+    ? ('overdue ' + formatDuration(Math.round(elapsedS - chosenS) * 1000))
+    : ('wakes in ' + formatDuration(Math.max(0, Math.round(toWakeS)) * 1000));
+  label.appendChild(eta);
+  wrap.appendChild(label);
+
+  const track = document.createElement('div');
+  track.className = 'sleep-scrubber__track';
+  if (showMin) {
+    const locked = document.createElement('div');
+    locked.className = 'sleep-scrubber__locked';
+    locked.style.width = pct(minS) + '%';
+    track.appendChild(locked);
+  }
+  const fill = document.createElement('div');
+  fill.className = 'sleep-scrubber__fill';
+  fill.style.width = pct(elapsedS) + '%';
+  track.appendChild(fill);
+  const head = document.createElement('div');
+  head.className = 'sleep-scrubber__head';
+  head.style.left = pct(elapsedS) + '%';
+  track.appendChild(head);
+  if (showMin) {
+    const minTick = document.createElement('div');
+    minTick.className = 'sleep-scrubber__min';
+    minTick.style.left = pct(minS) + '%';
+    track.appendChild(minTick);
+  }
+  wrap.appendChild(track);
+
+  return wrap;
+}
+
+function renderLoopGlanceHeader(loop) {
+  const view = loop.view || {};
+  const header = document.createElement('section');
+  header.className = 'glance-header';
+  header.dataset.state = getLoopVisualState(loop);
+
+  // Identity: status dot (hue agrees with the node) + name + mono meta line.
+  const idLine = document.createElement('div');
+  idLine.className = 'glance-id';
+  const dot = document.createElement('span');
+  dot.className = 'glance-dot';
+  idLine.appendChild(dot);
+  const name = document.createElement('span');
+  name.className = 'glance-name';
+  name.textContent = (loop.name || loop.id || '').split('/').pop() || loop.id || 'loop';
+  idLine.appendChild(name);
+  const meta = document.createElement('span');
+  meta.className = 'glance-meta';
+  const model = loop._liveModel || loop._lastModel || (getLoopLatestSnapshot(loop) || {}).model || '';
+  meta.textContent = [shortID(loop.id), describeLoopExecutionMode(loop), model ? shortModelName(model) : null]
+    .filter(Boolean).join('  ·  ');
+  idLine.appendChild(meta);
+  header.appendChild(idLine);
+
+  // Error STREAK — draws nothing at zero (empty is the datum).
+  const errs = loop.consecutive_errors || 0;
+  if (errs > 0) {
+    const alert = document.createElement('div');
+    alert.className = 'glance-alert';
+    const count = document.createElement('span');
+    count.className = 'glance-alert__count';
+    count.textContent = 'errors ' + errs;
+    alert.appendChild(count);
+    if (loop.last_error) {
+      const msg = document.createElement('span');
+      msg.className = 'glance-alert__msg';
+      msg.textContent = truncate(String(loop.last_error).split('\n')[0], 76);
+      msg.title = loop.last_error;
+      alert.appendChild(msg);
+    }
+    header.appendChild(alert);
+  }
+
+  // Live phase badge — only while processing; the model-vs-tool read, erased
+  // when idle. Elapsed ticks from the turn start (per-phase timestamps are a
+  // later slice — this is the whole-turn interim).
+  if (loop.state === 'processing') {
+    const running = (loop._liveTools || []).find((t) => !t.status || t.status === 'running');
+    let label = '';
+    if (running && running.tool) label = 'waiting on ' + running.tool;
+    else if (loop._liveModel) label = 'thinking on ' + shortModelName(loop._liveModel);
+    if (label) {
+      const phase = document.createElement('div');
+      phase.className = 'glance-phase' + (running ? ' glance-phase--tool' : '');
+      const lbl = document.createElement('span');
+      lbl.className = 'glance-phase__label';
+      lbl.textContent = label;
+      phase.appendChild(lbl);
+      if (loop._iterStartTs) {
+        const el = document.createElement('span');
+        el.className = 'glance-phase__elapsed';
+        el.textContent = formatDuration(Date.now() - loop._iterStartTs);
+        phase.appendChild(el);
+      }
+      header.appendChild(phase);
+    }
+  }
+
+  // Metrics: iterations + cadence · context fill · next wake.
+  const metrics = document.createElement('div');
+  metrics.className = 'glance-metrics';
+
+  // Iteration count is the honest Tier-0 progress signal; per-turn duration
+  // variation (where a sparkline earns its ink) lives in the Tier-1 small
+  // multiples, a fixed frame where a real slow turn spikes against uniform
+  // neighbors instead of an auto-scaled line amplifying steady-state jitter.
+  const iters = loop.iterations || 0;
+  metrics.appendChild(glanceMetric('iterations', (v) => {
+    v.textContent = formatNumber(iters);
+  }));
+
+  const cw = loop.context_window || view.context_window || 0;
+  const used = loop.last_input_tokens || (loop._llmContext && loop._llmContext.est_tokens) || 0;
+  const pct = (view.context_fill_pct != null) ? view.context_fill_pct
+    : (cw > 0 && used > 0 ? Math.round((used * 100) / cw) : null);
+  if (pct != null) {
+    metrics.appendChild(glanceMetric('context', (v) => {
+      v.appendChild(makeFillBar(pct));
+      const lbl = document.createElement('span');
+      lbl.className = 'glance-fill-label';
+      lbl.textContent = cw > 0 ? (formatTokens(used) + ' / ' + formatTokens(cw)) : (pct + '%');
+      v.appendChild(lbl);
+    }));
+  }
+
+  header.appendChild(metrics);
+
+  // The sleep scrubber subsumes a plain "wakes in X" cell — a full-width
+  // timeline of the sleep cycle. Shown only for timer loops with wake data.
+  const scrubber = renderSleepScrubber(loop);
+  if (scrubber) header.appendChild(scrubber);
+
+  return header;
+}
+
+// renderIterationStrip — the Tier 1 small multiples. The last ~10 completed
+// turns as identical rows on a SHARED scale, so a genuinely slow or token-heavy
+// turn spikes against uniform neighbors (the fixed frame the header sparkline
+// lacked). No per-tool chips — tool itemization is a Tier 2 / catalog concern.
+function renderIterationStrip(loop) {
+  const history = state.iterationHistory.get(loop.id) || [];
+  if (history.length === 0) return null;
+  const rows = history.slice(0, 10); // newest-first
+  const maxElapsed = Math.max(1, ...rows.map((s) => s.elapsed_ms || 0));
+  const maxTokens = Math.max(1, ...rows.map((s) => (s.input_tokens || 0) + (s.output_tokens || 0)));
+
+  const section = document.createElement('section');
+  section.className = 'iter-strip';
+  const head = document.createElement('div');
+  head.className = 'iter-strip__head';
+  head.textContent = 'recent turns';
+  section.appendChild(head);
+
+  for (const s of rows) {
+    const row = document.createElement('div');
+    row.className = 'iter-row';
+
+    const num = document.createElement('span');
+    num.className = 'iter-num';
+    num.textContent = '#' + (s.number || '');
+    row.appendChild(num);
+
+    const model = document.createElement('span');
+    model.className = 'iter-model';
+    model.textContent = s.model ? shortModelName(s.model) : '';
+    row.appendChild(model);
+
+    const tokBar = document.createElement('div');
+    tokBar.className = 'iter-bar iter-bar--tokens';
+    const inTok = s.input_tokens || 0;
+    const outTok = s.output_tokens || 0;
+    if (inTok + outTok > 0) {
+      const inEl = document.createElement('span');
+      inEl.className = 'iter-tok-in';
+      inEl.style.width = ((inTok / maxTokens) * 100) + '%';
+      tokBar.appendChild(inEl);
+      const outEl = document.createElement('span');
+      outEl.className = 'iter-tok-out';
+      outEl.style.width = ((outTok / maxTokens) * 100) + '%';
+      tokBar.appendChild(outEl);
+    }
+    row.appendChild(tokBar);
+
+    const elBar = document.createElement('div');
+    elBar.className = 'iter-bar iter-bar--elapsed';
+    const elFill = document.createElement('span');
+    elFill.style.width = (((s.elapsed_ms || 0) / maxElapsed) * 100) + '%';
+    elBar.appendChild(elFill);
+    row.appendChild(elBar);
+
+    const dur = document.createElement('span');
+    dur.className = 'iter-dur';
+    dur.textContent = s.elapsed_ms ? formatDuration(s.elapsed_ms) : '';
+    row.appendChild(dur);
+
+    section.appendChild(row);
+  }
+  return section;
+}
+
+// formatToolPayload renders a tool's args/result for the live feed — a JSON
+// string for objects, the value as-is for strings.
+function formatToolPayload(v) {
+  if (v == null) return '';
+  if (typeof v === 'string') return v;
+  try { return JSON.stringify(v); } catch (e) { return String(v); }
+}
+
+// renderLiveToolFeed is the in-situ window into a running loop: a live transcript
+// of the turn's tool calls — name, status, args in, result out — streaming as
+// they fire and return. Sits directly under the glance header so an operator can
+// watch a loop's focus and direction while it works. Sourced from loop._liveTools
+// (accumulated by the SSE reducer); shown only while there's a turn in flight.
+function renderLiveToolFeed(loop) {
+  const tools = loop._liveTools || [];
+  if (loop.state !== 'processing' && tools.length === 0) return null;
+
+  const section = document.createElement('section');
+  section.className = 'live-feed';
+
+  const head = document.createElement('div');
+  head.className = 'live-feed__head';
+  const dot = document.createElement('span');
+  dot.className = 'live-feed__dot';
+  head.appendChild(dot);
+  const label = document.createElement('span');
+  label.className = 'live-feed__label';
+  label.textContent = 'live · this turn';
+  head.appendChild(label);
+  const count = document.createElement('span');
+  count.className = 'live-feed__count';
+  const running = tools.filter((t) => t.status === 'running').length;
+  if (tools.length) {
+    count.textContent = formatNumber(tools.length) + (tools.length === 1 ? ' tool' : ' tools')
+      + (running ? ' · ' + running + ' running' : '');
+  }
+  head.appendChild(count);
+  section.appendChild(head);
+
+  if (tools.length === 0) {
+    const idle = document.createElement('div');
+    idle.className = 'live-feed__idle';
+    idle.textContent = loop._liveModel
+      ? 'thinking on ' + shortModelName(loop._liveModel) + ' — no tool in flight'
+      : 'working — no tool in flight';
+    section.appendChild(idle);
+    return section;
+  }
+
+  for (const t of tools) {
+    const card = document.createElement('div');
+    card.className = 'live-tool live-tool--' + (t.error ? 'error' : (t.status || 'done'));
+    const th = document.createElement('div');
+    th.className = 'live-tool__head';
+    const name = document.createElement('span');
+    name.className = 'live-tool__name';
+    name.textContent = t.tool || '?';
+    th.appendChild(name);
+    const status = document.createElement('span');
+    status.className = 'live-tool__status';
+    status.textContent = t.error ? 'error' : (t.status || 'done');
+    th.appendChild(status);
+    card.appendChild(th);
+    const args = formatToolPayload(t.args);
+    if (args) {
+      const pre = document.createElement('pre');
+      pre.className = 'live-tool__args';
+      pre.textContent = args.slice(0, 240);
+      card.appendChild(pre);
+    }
+    const out = t.error ? formatToolPayload(t.error) : formatToolPayload(t.result);
+    if (out) {
+      const pre = document.createElement('pre');
+      pre.className = 'live-tool__result' + (t.error ? ' live-tool__result--error' : '');
+      pre.textContent = out.slice(0, 240);
+      card.appendChild(pre);
+    }
+    section.appendChild(card);
+  }
+  return section;
+}
+
+// renderActiveCapabilities is the SINGLE shared tooling block — used for every
+// loop (conversation-backed or not) so the section reads identically instead of
+// the old split where conversation loops showed chips and others showed comma
+// lists. Minimized read = aggregate counts; brief = the loop's ACTIVE capability
+// tags as a full-width chip list, one box each ("active" tracks the tag_activate
+// verb the model-facing tooling uses). The available count lives in the summary,
+// never as its own box. (Full view → tool-reference catalog links once that
+// surface lands.)
+function renderActiveCapabilities(entity) {
+  const active = entity.currentLoadedCapabilities || [];
+  const toolCount = (entity.currentEffectiveTools || []).length;
+  const availCount = (entity.availableCapabilities || []).length;
+  if (active.length === 0 && toolCount === 0 && availCount === 0) return null;
+
+  const section = document.createElement('section');
+  section.className = 'tooling-section';
+
+  const head = document.createElement('div');
+  head.className = 'tooling-section__head';
+  const title = document.createElement('span');
+  title.className = 'tooling-section__title';
+  title.textContent = 'tooling';
+  head.appendChild(title);
+  const counts = document.createElement('span');
+  counts.className = 'tooling-section__counts';
+  counts.textContent = [
+    active.length ? formatNumber(active.length) + ' active' : null,
+    toolCount ? formatNumber(toolCount) + ' tools' : null,
+    availCount ? formatNumber(availCount) + ' available' : null,
+  ].filter(Boolean).join('  ·  ');
+  head.appendChild(counts);
+  section.appendChild(head);
+
+  if (active.length > 0) {
+    const chips = makeSchemaChipList(active.map((e) => e.tag), 'tag-chip tag-chip--active');
+    chips.classList.add('tooling-section__chips');
+    section.appendChild(chips);
+  }
+  return section;
+}
+
+const LOOP_DEF_TTL_MS = 60000; // specs change rarely; refetch at most once a minute
+
+// ensureLoopDef lazily loads a loop's stored definition (its spec: prompt,
+// supervisor config, declared outputs) from /v1/loop-definitions/{name} and
+// caches it on state.loopDefs. The inspector re-renders ~1/s, so this guards
+// against refetching: it only fires when there's no entry or the cached entry
+// is past its TTL, and the resolve handler re-renders the still-selected loop so
+// the spec appears without waiting for the next periodic tick.
+function ensureLoopDef(name) {
+  if (!name) return;
+  const cached = state.loopDefs.get(name);
+  const now = Date.now();
+  if (cached && (cached.status === 'loading' || (now - cached.at) < LOOP_DEF_TTL_MS)) return;
+  state.loopDefs.set(name, { status: 'loading', def: cached ? cached.def : null, at: now });
+  api.tryGet('/loop-definitions/' + encodeURIComponent(name))
+    .then((def) => {
+      state.loopDefs.set(name, { status: def ? 'ready' : 'absent', def: def || null, at: Date.now() });
+    })
+    .catch(() => {
+      state.loopDefs.set(name, { status: 'error', def: cached ? cached.def : null, at: Date.now() });
+    })
+    .finally(() => {
+      const sel = state.selected && state.loops.get(state.selected);
+      if (sel && sel.name === name) {
+        try { renderDetail(); } catch (e) { console.error('spec renderDetail:', e); }
+      }
+    });
+}
+
+// renderLoopSpecSection surfaces the loop's stored DEFINITION — what the loop
+// IS, against the runtime sections above that show what it's DOING. Three
+// things an operator asks of a spec: the prompt it runs each wake, the
+// supervisor-review messaging (when the loop opts into frontier review turns),
+// and the documents it's declared to maintain. Ephemeral loops (no stored
+// definition) and containers (structural only) say so plainly.
+function renderLoopSpecSection(loop) {
+  const name = loop && loop.name;
+  if (!name || name === 'core') return null; // core has no registry definition
+  ensureLoopDef(name);
+  const entry = state.loopDefs.get(name);
+
+  const section = document.createElement('section');
+  section.className = 'loop-spec';
+  const head = document.createElement('div');
+  head.className = 'loop-spec__head';
+  const title = document.createElement('span');
+  title.className = 'loop-spec__title';
+  title.textContent = 'spec';
+  head.appendChild(title);
+  const meta = document.createElement('span');
+  meta.className = 'loop-spec__meta';
+  head.appendChild(meta);
+  section.appendChild(head);
+
+  if (!entry || entry.status === 'loading') {
+    meta.textContent = 'reading definition…';
+    return section;
+  }
+  if (entry.status === 'error') {
+    meta.textContent = 'definition unavailable';
+    return section;
+  }
+  if (entry.status === 'absent') {
+    meta.textContent = 'ephemeral';
+    appendSpecEmpty(section, 'This loop runs from a runtime spec, not the definition registry — no persisted prompt, supervisor config, or declared outputs to show.');
+    return section;
+  }
+
+  const spec = (entry.def && entry.def.spec) || {};
+  meta.textContent = [
+    spec.operation || '',
+    spec.parent_name ? 'child of ' + spec.parent_name : null,
+    (spec.tags && spec.tags.length) ? spec.tags.join(', ') : null,
+  ].filter(Boolean).join('  ·  ');
+
+  const hasTask = (spec.task || '').trim();
+  const hasOutputs = (spec.outputs || []).length > 0;
+  if (spec.operation === 'container' && !hasTask && !hasOutputs) {
+    appendSpecEmpty(section, 'Container node — organizes its children and cascades subscriptions. No prompt or outputs of its own.');
+    return section;
+  }
+
+  // Prompt — the per-iteration task, plus method instructions when present.
+  if (hasTask) section.appendChild(makeSpecTextField(name, 'prompt', spec.task));
+  const instr = spec.profile && spec.profile.instructions;
+  if ((instr || '').trim()) section.appendChild(makeSpecTextField(name, 'instructions', instr));
+
+  // Supervisor review — the frontier-review messaging, only when the loop opts in.
+  if (spec.supervisor) {
+    const sup = spec.supervisor_profile || {};
+    const pct = typeof spec.supervisor_prob === 'number' ? Math.round(spec.supervisor_prob * 100) : null;
+    const supMeta = [
+      pct != null ? '~' + pct + '% of wakes' : null,
+      sup.quality_floor ? 'quality floor ' + sup.quality_floor : null,
+    ].filter(Boolean).join(' · ');
+    if ((sup.instructions || '').trim()) {
+      section.appendChild(makeSpecTextField(name, 'supervisor review', sup.instructions, supMeta));
+    } else {
+      appendSpecEmpty(section, 'Supervisor review on (' + (supMeta || 'periodic') + ') using baseline frontier overrides — no custom review prompt.');
+    }
+  }
+
+  // Outputs — documents the loop maintains through scoped runtime tools.
+  if (hasOutputs) section.appendChild(makeSpecOutputs(spec.outputs));
+  return section;
+}
+
+function appendSpecEmpty(section, text) {
+  const note = document.createElement('div');
+  note.className = 'loop-spec__empty';
+  note.textContent = text;
+  section.appendChild(note);
+}
+
+// makeSpecTextField renders one long spec text (prompt / instructions /
+// supervisor messaging) as a compact, copyable field. Collapsed by default to a
+// one-line whisper + char count; expand reads it inline, copy lifts the full
+// body to the clipboard for pasting into an editor (the owner's stated way of
+// working with prompt bodies). Expand state lives in state.specExpanded so it
+// survives the inspector's ~1/s full re-render.
+function makeSpecTextField(name, label, text, extraMeta) {
+  const body = String(text);
+  const key = name + '::' + label;
+  const expanded = state.specExpanded.has(key);
+
+  const field = document.createElement('div');
+  field.className = 'spec-field';
+
+  const fhead = document.createElement('div');
+  fhead.className = 'spec-field__head';
+  const lab = document.createElement('span');
+  lab.className = 'spec-field__label';
+  lab.textContent = label;
+  fhead.appendChild(lab);
+  const bytes = document.createElement('span');
+  bytes.className = 'spec-field__bytes';
+  bytes.textContent = [extraMeta, formatNumber(body.length) + ' chars'].filter(Boolean).join(' · ');
+  fhead.appendChild(bytes);
+  const spacer = document.createElement('span');
+  spacer.className = 'spec-field__spacer';
+  fhead.appendChild(spacer);
+
+  const expandBtn = document.createElement('button');
+  expandBtn.type = 'button';
+  expandBtn.className = 'spec-field__btn';
+  expandBtn.textContent = expanded ? 'collapse' : 'expand';
+  expandBtn.addEventListener('click', () => {
+    if (state.specExpanded.has(key)) state.specExpanded.delete(key);
+    else state.specExpanded.add(key);
+    try { renderDetail(); } catch (e) { console.error('spec expand renderDetail:', e); }
+  });
+  fhead.appendChild(expandBtn);
+
+  const copyBtn = document.createElement('button');
+  copyBtn.type = 'button';
+  copyBtn.className = 'spec-field__btn';
+  copyBtn.textContent = 'copy';
+  copyBtn.addEventListener('click', () => {
+    navigator.clipboard.writeText(body).then(() => {
+      copyBtn.textContent = 'copied';
+      copyBtn.classList.add('is-copied');
+      setTimeout(() => { copyBtn.textContent = 'copy'; copyBtn.classList.remove('is-copied'); }, 1200);
+    }).catch(() => {});
+  });
+  fhead.appendChild(copyBtn);
+  field.appendChild(fhead);
+
+  if (expanded) {
+    const pre = document.createElement('pre');
+    pre.className = 'spec-field__body';
+    pre.textContent = body;
+    field.appendChild(pre);
+  } else {
+    const whisper = body.split('\n').map((s) => s.trim()).filter(Boolean)[0] || '';
+    const preview = document.createElement('div');
+    preview.className = 'spec-field__preview';
+    preview.textContent = truncate(whisper, 150);
+    field.appendChild(preview);
+  }
+  return field;
+}
+
+// makeSpecOutputs lists the documents the loop is declared to maintain. Each row
+// shows the document root + path (click to copy the ref), the write mode, the
+// scoped runtime tool the loop writes through (replace_output_<name> for replace
+// mode), and the declared purpose — connecting the spec to the live tool feed.
+function makeSpecOutputs(outputs) {
+  const wrap = document.createElement('div');
+  wrap.className = 'spec-outputs';
+  const lab = document.createElement('div');
+  lab.className = 'spec-field__label spec-outputs__label';
+  lab.textContent = outputs.length === 1 ? 'output document' : formatNumber(outputs.length) + ' output documents';
+  wrap.appendChild(lab);
+
+  for (const out of outputs) {
+    const row = document.createElement('div');
+    row.className = 'spec-output';
+
+    const refLine = document.createElement('div');
+    refLine.className = 'spec-output__refline';
+    const ref = String(out.ref || '');
+    const ci = ref.indexOf(':');
+    const root = ci > 0 ? ref.slice(0, ci) : '';
+    const path = ci > 0 ? ref.slice(ci + 1) : ref;
+    if (root) {
+      const rootTag = document.createElement('span');
+      rootTag.className = 'spec-output__root';
+      rootTag.textContent = root;
+      refLine.appendChild(rootTag);
+    }
+    const pathEl = document.createElement('button');
+    pathEl.type = 'button';
+    pathEl.className = 'spec-output__path';
+    pathEl.textContent = path;
+    pathEl.title = 'copy ' + ref;
+    pathEl.addEventListener('click', () => {
+      navigator.clipboard.writeText(ref).then(() => {
+        pathEl.textContent = 'copied ref';
+        pathEl.classList.add('is-copied');
+        setTimeout(() => { pathEl.textContent = path; pathEl.classList.remove('is-copied'); }, 1200);
+      }).catch(() => {});
+    });
+    refLine.appendChild(pathEl);
+    if (out.mode) {
+      const mode = document.createElement('span');
+      mode.className = 'spec-output__mode';
+      mode.textContent = out.mode;
+      refLine.appendChild(mode);
+    }
+    row.appendChild(refLine);
+
+    if (out.mode === 'replace' && out.name) {
+      const tool = document.createElement('div');
+      tool.className = 'spec-output__tool';
+      tool.textContent = 'replace_output_' + out.name;
+      row.appendChild(tool);
+    }
+    if (out.purpose) {
+      const purpose = document.createElement('div');
+      purpose.className = 'spec-output__purpose';
+      purpose.textContent = out.purpose;
+      row.appendChild(purpose);
+    }
+    wrap.appendChild(row);
+  }
+  return wrap;
+}
+
 function renderLoopEntityDetail(loop) {
   const entity = buildLoopEntity(loop);
   detailEntity.innerHTML = '';
@@ -3965,46 +4633,25 @@ function renderLoopEntityDetail(loop) {
   const latestToolsUsed = Object.keys(entity.latestToolsUsed || {}).filter(Boolean).sort();
   const liveToolNames = Array.from(new Set(entity.activeLiveTools.map((entry) => entry.tool).filter(Boolean))).sort();
 
-  const hero = document.createElement('section');
-  hero.className = 'detail-card schema-card schema-card--hero';
-  hero.innerHTML = `
-    <div class="schema-hero">
-      <div class="schema-hero__copy">
-        <div class="schema-kind">${entity.kind}</div>
-        <h2 class="detail-name">${escapeHTML(entity.title)}</h2>
-        <div class="schema-subtitle">
-          <strong>${escapeHTML(entity.categoryLabel)}</strong>
-          via ${escapeHTML(entity.categorySource)}
-        </div>
-      </div>
-      <div class="schema-badge-list">
-        <span class="state-badge state-badge--${escapeHTML(entity.stateLabel === 'supervisor' ? 'supervisor' : entity.state)}">${escapeHTML(formatSchemaToken(entity.stateLabel))}</span>
-        <span class="schema-badge">${escapeHTML(entity.executionMode)}</span>
-        <span class="schema-badge">${escapeHTML(entity.relation)}</span>
-      </div>
-    </div>
-  `;
-  const utilities = document.createElement('div');
-  utilities.className = 'inspector-utility-bar';
-  utilities.appendChild(makeInspectorUtility('loop', makeIDChip(entity.loopID)));
-  if (primaryConvID) {
-    utilities.appendChild(makeInspectorUtility('thread', makeIDChip(primaryConvID)));
-  }
-  utilities.appendChild(makeInspectorUtility(
-    'loaded capabilities',
-    currentLoadedCapabilities.length > 0
-      ? makeSchemaChipList(currentLoadedCapabilities.map((entry) => entry.tag), 'tag-chip tag-chip--active')
-      : 'none',
-  ));
-  if (entity.latestRequestID) {
-    utilities.appendChild(makeInspectorUtility('request', makeRequestChip(entity.latestRequestID)));
-  }
-  hero.appendChild(utilities);
-  detailEntity.appendChild(hero);
+  detailEntity.appendChild(renderLoopGlanceHeader(loop));
+
+  // Live tool feed — the in-situ window into a running loop, directly under the
+  // header so it's the first thing you read while watching a loop work.
+  const liveFeed = renderLiveToolFeed(loop);
+  if (liveFeed) detailEntity.appendChild(liveFeed);
+
+  const iterStrip = renderIterationStrip(loop);
+  if (iterStrip) detailEntity.appendChild(iterStrip);
 
   if (conversationBacked) {
     detailEntity.appendChild(renderLoopCurrentTurnCard(loop, entity, currentConversation));
   }
+
+  // Spec — what the loop IS (prompt, supervisor review, declared outputs), from
+  // the definition registry. Sits above tooling/execution: definitional context
+  // before runtime stats. Lazy-loads; renders a placeholder until it arrives.
+  const specSection = renderLoopSpecSection(loop);
+  if (specSection) detailEntity.appendChild(specSection);
 
   const identity = makeSchemaCard('Identity', 'Role in the graph', {
     entityKind: entity.kind,
@@ -4103,60 +4750,7 @@ function renderLoopEntityDetail(loop) {
     appendSchemaRow(execution.body, 'last error', err, { multiline: true });
   }
 
-  const tooling = makeSchemaCard('Tooling', 'Capability scope, tool surface, and live activity', {
-    entityKind: entity.kind,
-    key: 'tooling',
-    titleSummary: [
-      currentLoadedCapabilities.length > 0
-        ? `${formatNumber(currentLoadedCapabilities.length)} capabilities loaded`
-        : (entity.configTags.length > 0 ? `${formatNumber(entity.configTags.length)} tags configured` : ''),
-      currentEffectiveTools.length > 0
-        ? `${formatNumber(currentEffectiveTools.length)} tools in scope`
-        : (entity.excludedTools.length > 0 ? `${formatNumber(entity.excludedTools.length)} tools excluded` : ''),
-      entity.availableCapabilities.length > 0 ? `${formatNumber(entity.availableCapabilities.length)} capabilities available` : '',
-      liveToolNames.length > 0 ? `${formatNumber(liveToolNames.length)} tools live` : '',
-    ].filter(Boolean).join(' · ') || 'Capability state and tool surface pending.',
-    titleFacts: [
-      entity.configTags.length ? `${formatNumber(entity.configTags.length)} configured` : '',
-      currentLoadedCapabilities.length ? `${formatNumber(currentLoadedCapabilities.length)} loaded` : '',
-      currentEffectiveTools.length ? `${formatNumber(currentEffectiveTools.length)} in scope` : '',
-      liveToolNames.length ? `${formatNumber(liveToolNames.length)} running` : '',
-    ].filter(Boolean),
-    widgetFacts: [
-      entity.configTags.length ? { label: 'Configured tags', value: entity.configTags.join(', ') } : null,
-      currentLoadedCapabilities.length ? { label: 'Loaded capabilities', value: currentLoadedCapabilities.map((entry) => entry.tag).join(', ') } : null,
-      entity.availableCapabilities.length ? { label: 'Available capabilities', value: formatNumber(entity.availableCapabilities.length) } : null,
-      currentEffectiveTools.length ? { label: 'Tool surface', value: formatNumber(currentEffectiveTools.length) } : null,
-      entity.excludedTools.length ? { label: 'Excluded', value: formatNumber(entity.excludedTools.length) } : null,
-      liveToolNames.length ? { label: 'Running', value: liveToolNames.join(', ') } : null,
-    ],
-  });
-  if (entity.configTags.length > 0) {
-    appendSchemaRow(tooling.body, 'configured tags', makeSchemaChipList(entity.configTags, 'tag-chip tag-chip--muted'));
-  }
-  if (currentLoadedCapabilities.length > 0) {
-    appendSchemaRow(tooling.body, 'loaded capabilities', makeSchemaChipList(currentLoadedCapabilities.map((entry) => entry.tag), 'tag-chip tag-chip--active'));
-  }
-  if (entity.availableCapabilities.length > 0) {
-    appendSchemaRow(tooling.body, 'available capabilities', makeSchemaChipList(entity.availableCapabilities.map((entry) => entry.tag), 'tag-chip'));
-  }
-  if (entity.excludedTools.length > 0) {
-    appendSchemaRow(tooling.body, 'excluded tools', makeSchemaChipList(entity.excludedTools, 'iter-card__tool-item iter-card__tool-item--scope'));
-  }
-  if (currentEffectiveTools.length > 0) {
-    appendSchemaRow(
-      tooling.body,
-      loop.state === 'processing' ? 'tool surface this turn' : 'tool surface last turn',
-      makeSchemaChipList(currentEffectiveTools, 'iter-card__tool-item iter-card__tool-item--scope'),
-      { multiline: true },
-    );
-  }
-  if (liveToolNames.length > 0) {
-    appendSchemaRow(tooling.body, 'tools in flight', makeSchemaChipList(liveToolNames, 'iter-card__tool-item'));
-  }
-  if (latestToolsUsed.length > 0) {
-    appendSchemaRow(tooling.body, 'tools used last turn', makeSchemaChipList(latestToolsUsed, 'iter-card__tool-item'));
-  }
+  const toolingSection = renderActiveCapabilities(entity);
 
   const profile = makeSchemaCard('Profile', 'Intent, trust, and carried context', {
     entityKind: entity.kind,
@@ -4216,7 +4810,7 @@ function renderLoopEntityDetail(loop) {
     if (delegateGuidance) appendSchemaRow(profile.body, 'delegate guidance', delegateGuidance, { multiline: true });
   }
 
-  detailEntity.appendChild(tooling.card);
+  if (toolingSection) detailEntity.appendChild(toolingSection);
   const activity = makeSchemaCard('Activity', 'Recent rhythm and iteration history', {
     entityKind: entity.kind,
     key: 'activity',
@@ -4283,20 +4877,17 @@ function renderLoopEntityDetail(loop) {
   renderTimeline(loop, timeline, state.iterationHistory.get(loop.id) || [], loop.id, state.sleepTimers);
   activity.body.appendChild(timeline);
 
+  // Tier 0: the hero / identity / relationship cards are subsumed by the glance
+  // header above. The remaining cards are Tier 1/2 fodder, kept until those
+  // slices rework them (their builds are pruned then).
   if (conversationBacked) {
     detailEntity.appendChild(execution.card);
-    detailEntity.appendChild(activity.card);
-    detailEntity.appendChild(relationships.card);
     detailEntity.appendChild(profile.card);
-    detailEntity.appendChild(identity.card);
     return;
   }
 
   detailEntity.appendChild(execution.card);
-  detailEntity.appendChild(activity.card);
-  detailEntity.appendChild(relationships.card);
   detailEntity.appendChild(profile.card);
-  detailEntity.appendChild(identity.card);
 }
 
 function buildLoopContextMenu(loop) {

--- a/internal/server/web/static/app.js
+++ b/internal/server/web/static/app.js
@@ -3989,9 +3989,11 @@ function parseDurationSecs(str) {
 }
 
 // renderSleepScrubber draws the loop's sleep cycle as a non-interactive
-// timeline: a track from 0 to the latest allowed wake (SleepMax), a hatched
-// locked zone before SleepMin, a marker at the chosen wake, and a playhead at
-// elapsed crawling toward it — red and past the marker when overdue. Chosen +
+// timeline: a track from 0 to the chosen wake (which sits at the right edge), a
+// hatched locked zone before SleepMin when the loop chose to sleep past it, and
+// a playhead at elapsed crawling toward the wake — clamped to the track and
+// turning red in place at the edge when overdue (it never renders past the
+// right edge). The SleepMax ceiling rides in the label, not the axis. Chosen +
 // elapsed prefer the LoopView projection and fall back to the client's observed
 // sleep timer; bounds come from the loop config (nanoseconds). Returns null
 // when there is no timer sleep to show (event-driven, or no wake data yet).

--- a/internal/server/web/static/app.js
+++ b/internal/server/web/static/app.js
@@ -32,6 +32,7 @@ const state = {
   conversationLoads: new Map(),   // conversation_id -> in-flight loader promise
   loopDefs: new Map(),            // loop name -> { status, def, at } cached /v1/loop-definitions
   specMode: new Map(),            // loop name -> 'summary' | 'brief' | 'verbose' spec view
+  recentMode: new Map(),          // loop id   -> 'summary' | 'brief' | 'verbose' recent-turns view
 };
 
 const MAX_EVENTS = 50;
@@ -4186,71 +4187,105 @@ function renderLoopGlanceHeader(loop) {
 function renderIterationStrip(loop) {
   const history = state.iterationHistory.get(loop.id) || [];
   if (history.length === 0) return null;
-  const rows = history.slice(0, 10); // newest-first
+  const mode = sectionViewMode(state.recentMode, loop.id);
+  const rows = history.slice(0, mode === 'verbose' ? 30 : 10); // newest-first
   const maxElapsed = Math.max(1, ...rows.map((s) => s.elapsed_ms || 0));
   const maxTokens = Math.max(1, ...rows.map((s) => (s.input_tokens || 0) + (s.output_tokens || 0)));
 
   const section = document.createElement('section');
-  section.className = 'iter-strip';
+  section.className = 'insp-section iter-strip';
+
   const head = document.createElement('div');
-  head.className = 'iter-strip__head';
-  head.textContent = 'recent turns';
+  head.className = 'insp-section__head';
+  const heading = document.createElement('div');
+  heading.className = 'insp-section__heading';
+  const title = document.createElement('span');
+  title.className = 'insp-section__title';
+  title.textContent = 'recent turns';
+  heading.appendChild(title);
+  const meta = document.createElement('span');
+  meta.className = 'insp-section__meta';
+  const newest = history[0];
+  meta.textContent = [
+    formatNumber(history.length) + (history.length === 1 ? ' turn' : ' turns'),
+    newest && newest.elapsed_ms ? 'last ' + formatDuration(newest.elapsed_ms) : null,
+  ].filter(Boolean).join('  ·  ');
+  heading.appendChild(meta);
+  head.appendChild(heading);
+  head.appendChild(makeSectionModeControl(mode, 'Recent turns', (nm) => state.recentMode.set(loop.id, nm)));
   section.appendChild(head);
 
-  for (const s of rows) {
-    const row = document.createElement('div');
-    row.className = 'iter-row';
-
-    // Hover reveals the wall-clock when (kept off the row to stay compact): when
-    // it started, how long ago, and the duration that's already shown inline.
-    const startRaw = s.started_at || s.completed_at;
+  // Summary: just an aggregate line — the newest turn's model and when it ran.
+  if (mode === 'summary') {
+    const startRaw = newest && (newest.started_at || newest.completed_at);
     const startDate = startRaw ? new Date(startRaw) : null;
-    if (startDate && !isNaN(startDate)) {
-      const durTxt = s.elapsed_ms ? ' · took ' + formatDuration(s.elapsed_ms) : '';
-      row.title = `#${s.number || '?'} · ran ${formatWhen(startDate)} (${timeAgo(startDate)})${durTxt}`;
-    }
-
-    const num = document.createElement('span');
-    num.className = 'iter-num';
-    num.textContent = '#' + (s.number || '');
-    row.appendChild(num);
-
-    const model = document.createElement('span');
-    model.className = 'iter-model';
-    model.textContent = s.model ? shortModelName(s.model) : '';
-    row.appendChild(model);
-
-    const tokBar = document.createElement('div');
-    tokBar.className = 'iter-bar iter-bar--tokens';
-    const inTok = s.input_tokens || 0;
-    const outTok = s.output_tokens || 0;
-    if (inTok + outTok > 0) {
-      const inEl = document.createElement('span');
-      inEl.className = 'iter-tok-in';
-      inEl.style.width = ((inTok / maxTokens) * 100) + '%';
-      tokBar.appendChild(inEl);
-      const outEl = document.createElement('span');
-      outEl.className = 'iter-tok-out';
-      outEl.style.width = ((outTok / maxTokens) * 100) + '%';
-      tokBar.appendChild(outEl);
-    }
-    row.appendChild(tokBar);
-
-    const elBar = document.createElement('div');
-    elBar.className = 'iter-bar iter-bar--elapsed';
-    const elFill = document.createElement('span');
-    elFill.style.width = (((s.elapsed_ms || 0) / maxElapsed) * 100) + '%';
-    elBar.appendChild(elFill);
-    row.appendChild(elBar);
-
-    const dur = document.createElement('span');
-    dur.className = 'iter-dur';
-    dur.textContent = s.elapsed_ms ? formatDuration(s.elapsed_ms) : '';
-    row.appendChild(dur);
-
-    section.appendChild(row);
+    const note = document.createElement('div');
+    note.className = 'insp-section__summary';
+    note.textContent = [
+      newest && newest.model ? 'on ' + shortModelName(newest.model) : null,
+      startDate && !isNaN(startDate) ? 'last ran ' + timeAgo(startDate) : null,
+    ].filter(Boolean).join('  ·  ') || 'No turn detail yet.';
+    section.appendChild(note);
+    return section;
   }
+
+  for (const s of rows) section.appendChild(buildIterRow(s, maxElapsed, maxTokens));
   return section;
+}
+
+// buildIterRow renders one small-multiple row: number, model, token bar, elapsed
+// bar, duration. Hover reveals the wall-clock when it ran (kept off the row to
+// stay compact): when it started, how long ago, and the duration shown inline.
+function buildIterRow(s, maxElapsed, maxTokens) {
+  const row = document.createElement('div');
+  row.className = 'iter-row';
+
+  const startRaw = s.started_at || s.completed_at;
+  const startDate = startRaw ? new Date(startRaw) : null;
+  if (startDate && !isNaN(startDate)) {
+    const durTxt = s.elapsed_ms ? ' · took ' + formatDuration(s.elapsed_ms) : '';
+    row.title = `#${s.number || '?'} · ran ${formatWhen(startDate)} (${timeAgo(startDate)})${durTxt}`;
+  }
+
+  const num = document.createElement('span');
+  num.className = 'iter-num';
+  num.textContent = '#' + (s.number || '');
+  row.appendChild(num);
+
+  const model = document.createElement('span');
+  model.className = 'iter-model';
+  model.textContent = s.model ? shortModelName(s.model) : '';
+  row.appendChild(model);
+
+  const tokBar = document.createElement('div');
+  tokBar.className = 'iter-bar iter-bar--tokens';
+  const inTok = s.input_tokens || 0;
+  const outTok = s.output_tokens || 0;
+  if (inTok + outTok > 0) {
+    const inEl = document.createElement('span');
+    inEl.className = 'iter-tok-in';
+    inEl.style.width = ((inTok / maxTokens) * 100) + '%';
+    tokBar.appendChild(inEl);
+    const outEl = document.createElement('span');
+    outEl.className = 'iter-tok-out';
+    outEl.style.width = ((outTok / maxTokens) * 100) + '%';
+    tokBar.appendChild(outEl);
+  }
+  row.appendChild(tokBar);
+
+  const elBar = document.createElement('div');
+  elBar.className = 'iter-bar iter-bar--elapsed';
+  const elFill = document.createElement('span');
+  elFill.style.width = (((s.elapsed_ms || 0) / maxElapsed) * 100) + '%';
+  elBar.appendChild(elFill);
+  row.appendChild(elBar);
+
+  const dur = document.createElement('span');
+  dur.className = 'iter-dur';
+  dur.textContent = s.elapsed_ms ? formatDuration(s.elapsed_ms) : '';
+  row.appendChild(dur);
+
+  return row;
 }
 
 // formatToolPayload renders a tool's args/result for the live feed — a JSON
@@ -4405,16 +4440,152 @@ function ensureLoopDef(name) {
     });
 }
 
-// Spec view modes mirror the schema cards' title/widget/full ladder so the
-// hamburger reads the same: summary = head only, brief = collapsed field
-// whispers, verbose = full bodies inline. The icon maps onto the shared
+// Section view modes mirror the schema cards' title/widget/full ladder so every
+// hamburger reads the same: summary = head only, brief = collapsed, verbose =
+// expanded. Shared by the spec and recent-turns sections; the icon maps onto the
 // schema-card glyphs (1 / 2 / 3 bars).
-const SPEC_MODES = ['summary', 'brief', 'verbose'];
-const SPEC_MODE_ICON = { summary: 'title', brief: 'widget', verbose: 'full' };
+const SECTION_VIEW_MODES = ['summary', 'brief', 'verbose'];
+const SECTION_VIEW_ICON = { summary: 'title', brief: 'widget', verbose: 'full' };
 
-function nextSpecMode(mode) {
-  const i = SPEC_MODES.indexOf(SPEC_MODES.includes(mode) ? mode : 'brief');
-  return SPEC_MODES[(i + 1) % SPEC_MODES.length];
+function nextSectionViewMode(mode) {
+  const i = SECTION_VIEW_MODES.indexOf(SECTION_VIEW_MODES.includes(mode) ? mode : 'brief');
+  return SECTION_VIEW_MODES[(i + 1) % SECTION_VIEW_MODES.length];
+}
+
+function sectionViewMode(store, key) {
+  return SECTION_VIEW_MODES.includes(store.get(key)) ? store.get(key) : 'brief';
+}
+
+// makeSectionModeControl builds the right-aligned hamburger that cycles a
+// section summary → brief → verbose, reusing the schema-card control look and
+// glyph. onCycle receives the next mode. The re-render is forced through the
+// hover/interaction defer gate — a plain renderDetail() is suppressed while the
+// pointer is over the control and would only paint on mouse-out.
+function makeSectionModeControl(mode, label, onCycle) {
+  const controls = document.createElement('div');
+  controls.className = 'insp-section__controls';
+  const btn = document.createElement('button');
+  btn.type = 'button';
+  btn.className = 'schema-card__control';
+  btn.innerHTML = makeSchemaCardModeIcon(SECTION_VIEW_ICON[mode]);
+  const nm = nextSectionViewMode(mode);
+  btn.title = label + ' view: ' + mode + '. Click for ' + nm;
+  btn.setAttribute('aria-label', label + ' view: ' + mode + '. Click for ' + nm);
+  btn.addEventListener('click', (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+    onCycle(nm);
+    bumpDetailInteractionHold(180);
+    requestAnimationFrame(() => {
+      try { renderDetail({ force: true }); } catch (err) { console.error('section mode renderDetail:', err); }
+    });
+  });
+  controls.appendChild(btn);
+  return controls;
+}
+
+// --- Inspector block reordering -------------------------------------------
+// The content blocks below the pinned glance header + live feed are drag-to-
+// reorderable. Order is a single global layout preference (not per-loop),
+// persisted to localStorage — it survives across browser sessions for free.
+const INSPECTOR_ORDER_KEY = 'thane.inspector.blockOrder';
+const INSPECTOR_DEFAULT_ORDER = ['recent', 'current-turn', 'spec', 'tooling', 'execution', 'profile'];
+
+function loadInspectorOrder() {
+  try {
+    const raw = localStorage.getItem(INSPECTOR_ORDER_KEY);
+    const arr = raw ? JSON.parse(raw) : null;
+    return Array.isArray(arr) ? arr.filter((k) => typeof k === 'string') : null;
+  } catch (e) { return null; }
+}
+
+function saveInspectorOrder(keys) {
+  try { localStorage.setItem(INSPECTOR_ORDER_KEY, JSON.stringify(keys)); } catch (e) { /* private mode / no storage */ }
+}
+
+// orderInspectorBlocks lays the available {key,el} blocks out in the saved
+// order. Keys present this render but absent from the saved order (e.g. the
+// current-turn card, which only exists on conversation loops, when the order was
+// last saved from a loop without one) are spliced in next to their default-order
+// neighbor — not dumped at the end — so they land somewhere sensible.
+function orderInspectorBlocks(blocks) {
+  const saved = loadInspectorOrder() || [];
+  const present = new Set(blocks.map((b) => b.key));
+  const result = saved.filter((k) => present.has(k));
+  const placed = new Set(result);
+  for (const key of INSPECTOR_DEFAULT_ORDER) {
+    if (!present.has(key) || placed.has(key)) continue;
+    const di = INSPECTOR_DEFAULT_ORDER.indexOf(key);
+    let insertAt = result.length;
+    for (let i = di - 1; i >= 0; i--) {
+      const idx = result.indexOf(INSPECTOR_DEFAULT_ORDER[i]);
+      if (idx !== -1) { insertAt = idx + 1; break; }
+    }
+    result.splice(insertAt, 0, key);
+    placed.add(key);
+  }
+  for (const b of blocks) if (!placed.has(b.key)) { result.push(b.key); placed.add(b.key); }
+  const byKey = new Map(blocks.map((b) => [b.key, b]));
+  return result.map((k) => byKey.get(k)).filter(Boolean);
+}
+
+let inspectorDrag = null;
+
+// makeReorderable tags a content block with its stable key and a hover-reveal
+// drag grip in the left gutter. The grip is header-agnostic (absolute, in the
+// panel's left padding) so it works for every block regardless of internal
+// chrome — schema card, custom section, or turn card.
+function makeReorderable(key, el) {
+  el.classList.add('insp-block');
+  el.dataset.blockKey = key;
+  const grip = document.createElement('button');
+  grip.type = 'button';
+  grip.className = 'insp-grip';
+  grip.title = 'Drag to reorder';
+  grip.setAttribute('aria-label', 'Drag to reorder this section');
+  grip.innerHTML = '<svg viewBox="0 0 12 16" aria-hidden="true" class="insp-grip__icon">'
+    + '<circle cx="4" cy="4" r="1"/><circle cx="8" cy="4" r="1"/>'
+    + '<circle cx="4" cy="8" r="1"/><circle cx="8" cy="8" r="1"/>'
+    + '<circle cx="4" cy="12" r="1"/><circle cx="8" cy="12" r="1"/></svg>';
+  grip.addEventListener('pointerdown', (e) => startInspectorDrag(e, el));
+  el.appendChild(grip);
+  return el;
+}
+
+function startInspectorDrag(e, el) {
+  if (e.button != null && e.button !== 0) return;
+  const container = el.parentElement;
+  if (!container) return;
+  e.preventDefault();
+  e.stopPropagation();
+  // Capture the pointer so pointerup lands even if released outside the panel.
+  try { e.currentTarget.setPointerCapture(e.pointerId); } catch (err) { /* unsupported */ }
+  el.classList.add('insp-block--dragging');
+  bumpDetailInteractionHold(60000); // freeze the re-render for the whole gesture
+  const onMove = (ev) => {
+    if (!el.isConnected) return; // a re-render slipped through and detached us
+    const siblings = Array.from(container.querySelectorAll(':scope > .insp-block:not(.insp-block--dragging)'));
+    let before = null;
+    for (const s of siblings) {
+      const r = s.getBoundingClientRect();
+      if (ev.clientY < r.top + r.height / 2) { before = s; break; }
+    }
+    if (before) container.insertBefore(el, before);
+    else container.appendChild(el);
+  };
+  const onUp = () => {
+    document.removeEventListener('pointermove', onMove);
+    document.removeEventListener('pointerup', onUp);
+    el.classList.remove('insp-block--dragging');
+    const order = Array.from(container.querySelectorAll(':scope > .insp-block'))
+      .map((b) => b.dataset.blockKey).filter(Boolean);
+    saveInspectorOrder(order);
+    inspectorDrag = null;
+    bumpDetailInteractionHold(200);
+  };
+  inspectorDrag = { el, onMove, onUp };
+  document.addEventListener('pointermove', onMove);
+  document.addEventListener('pointerup', onUp);
 }
 
 // renderLoopSpecSection surfaces the loop's stored DEFINITION — what the loop
@@ -4477,33 +4648,9 @@ function renderLoopSpecSection(loop) {
     return section;
   }
 
-  // Hamburger toggle — reuses the schema-card control look + glyph, cycling the
-  // whole section's disclosure. Lives in the head, right-aligned.
-  const mode = SPEC_MODES.includes(state.specMode.get(name)) ? state.specMode.get(name) : 'brief';
-  const controls = document.createElement('div');
-  controls.className = 'loop-spec__controls';
-  const btn = document.createElement('button');
-  btn.type = 'button';
-  btn.className = 'schema-card__control';
-  btn.innerHTML = makeSchemaCardModeIcon(SPEC_MODE_ICON[mode]);
-  const nm = nextSpecMode(mode);
-  btn.title = 'Spec view: ' + mode + '. Click for ' + nm;
-  btn.setAttribute('aria-label', 'Spec view: ' + mode + '. Click for ' + nm);
-  btn.addEventListener('click', (e) => {
-    e.preventDefault();
-    e.stopPropagation();
-    state.specMode.set(name, nextSpecMode(mode));
-    // Force the re-render through the hover/interaction defer gate (see
-    // withPreservedDetailScroll). A plain renderDetail() is suppressed while the
-    // pointer is over the control, so the new mode wouldn't paint until mouse-
-    // out — the same path the schema-card controls take via applySchemaCardPreset.
-    bumpDetailInteractionHold(180);
-    requestAnimationFrame(() => {
-      try { renderDetail({ force: true }); } catch (err) { console.error('spec mode renderDetail:', err); }
-    });
-  });
-  controls.appendChild(btn);
-  head.appendChild(controls);
+  // Hamburger toggle — the shared section control cycling summary/brief/verbose.
+  const mode = sectionViewMode(state.specMode, name);
+  head.appendChild(makeSectionModeControl(mode, 'Spec', (nm) => state.specMode.set(name, nm)));
 
   // Summary: head + a one-line census of what the spec carries, nothing more.
   if (mode === 'summary') {
@@ -4693,22 +4840,21 @@ function renderLoopEntityDetail(loop) {
   detailEntity.appendChild(renderLoopGlanceHeader(loop));
 
   // Live tool feed — the in-situ window into a running loop, directly under the
-  // header so it's the first thing you read while watching a loop work.
+  // header so it's the first thing you read while watching a loop work. Pinned
+  // (along with the glance header); only the content blocks below reorder.
   const liveFeed = renderLiveToolFeed(loop);
   if (liveFeed) detailEntity.appendChild(liveFeed);
 
-  const iterStrip = renderIterationStrip(loop);
-  if (iterStrip) detailEntity.appendChild(iterStrip);
+  // Content blocks below the header are drag-to-reorderable; collect them with
+  // stable keys and lay them out per the saved order at the end.
+  const blocks = [];
+  const pushBlock = (key, el) => { if (el) blocks.push({ key, el }); };
 
-  if (conversationBacked) {
-    detailEntity.appendChild(renderLoopCurrentTurnCard(loop, entity, currentConversation));
-  }
-
+  pushBlock('recent', renderIterationStrip(loop));
+  if (conversationBacked) pushBlock('current-turn', renderLoopCurrentTurnCard(loop, entity, currentConversation));
   // Spec — what the loop IS (prompt, supervisor review, declared outputs), from
-  // the definition registry. Sits above tooling/execution: definitional context
-  // before runtime stats. Lazy-loads; renders a placeholder until it arrives.
-  const specSection = renderLoopSpecSection(loop);
-  if (specSection) detailEntity.appendChild(specSection);
+  // the definition registry. Lazy-loads; renders a placeholder until it arrives.
+  pushBlock('spec', renderLoopSpecSection(loop));
 
   const identity = makeSchemaCard('Identity', 'Role in the graph', {
     entityKind: entity.kind,
@@ -4867,7 +5013,7 @@ function renderLoopEntityDetail(loop) {
     if (delegateGuidance) appendSchemaRow(profile.body, 'delegate guidance', delegateGuidance, { multiline: true });
   }
 
-  if (toolingSection) detailEntity.appendChild(toolingSection);
+  pushBlock('tooling', toolingSection);
   const activity = makeSchemaCard('Activity', 'Recent rhythm and iteration history', {
     entityKind: entity.kind,
     key: 'activity',
@@ -4935,16 +5081,19 @@ function renderLoopEntityDetail(loop) {
   activity.body.appendChild(timeline);
 
   // Tier 0: the hero / identity / relationship cards are subsumed by the glance
-  // header above. The remaining cards are Tier 1/2 fodder, kept until those
-  // slices rework them (their builds are pruned then).
-  if (conversationBacked) {
-    detailEntity.appendChild(execution.card);
-    detailEntity.appendChild(profile.card);
-    return;
-  }
+  // header above. Execution + Profile are Tier 1/2 fodder, kept until those
+  // slices rework them (the activity card is built for its parts but not shown).
+  pushBlock('execution', execution.card);
+  pushBlock('profile', profile.card);
 
-  detailEntity.appendChild(execution.card);
-  detailEntity.appendChild(profile.card);
+  // Lay the content blocks out in the user's saved order, each wrapped with a
+  // drag grip, inside a reorder container below the pinned header + live feed.
+  const reorder = document.createElement('div');
+  reorder.className = 'insp-reorder';
+  for (const { key, el } of orderInspectorBlocks(blocks)) {
+    reorder.appendChild(makeReorderable(key, el));
+  }
+  detailEntity.appendChild(reorder);
 }
 
 function buildLoopContextMenu(loop) {

--- a/internal/server/web/static/app.js
+++ b/internal/server/web/static/app.js
@@ -4242,9 +4242,27 @@ function buildIterRow(s, maxElapsed, maxTokens) {
 
   const startRaw = s.started_at || s.completed_at;
   const startDate = startRaw ? new Date(startRaw) : null;
-  if (startDate && !isNaN(startDate)) {
-    const durTxt = s.elapsed_ms ? ' · took ' + formatDuration(s.elapsed_ms) : '';
-    row.title = `#${s.number || '?'} · ran ${formatWhen(startDate)} (${timeAgo(startDate)})${durTxt}`;
+  const whenTxt = (startDate && !isNaN(startDate))
+    ? `ran ${formatWhen(startDate)} (${timeAgo(startDate)})${s.elapsed_ms ? ' · took ' + formatDuration(s.elapsed_ms) : ''}`
+    : '';
+
+  // Click a row to open that turn's request detail pane — same path as the live
+  // `req:` chip (window.onRequestChipClick → showRequestDetail, which fetches
+  // /v1/requests/{id} and closes gracefully if the request was evicted). Only
+  // when the turn recorded a request_id and the handler is wired (graph context).
+  const inspectable = s.request_id && typeof window.onRequestChipClick === 'function';
+  if (inspectable) {
+    row.classList.add('iter-row--clickable');
+    row.setAttribute('role', 'button');
+    row.tabIndex = 0;
+    row.title = `inspect request ${shortID(s.request_id)}${whenTxt ? ' · ' + whenTxt : ''}`;
+    const open = () => window.onRequestChipClick(s.request_id);
+    row.addEventListener('click', open);
+    row.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); open(); }
+    });
+  } else if (whenTxt) {
+    row.title = `#${s.number || '?'} · ${whenTxt}`;
   }
 
   const num = document.createElement('span');

--- a/internal/server/web/static/shared.js
+++ b/internal/server/web/static/shared.js
@@ -50,6 +50,20 @@ function formatTimeShort(date) {
   });
 }
 
+// formatWhen renders an absolute wall-clock instant for hover/detail text:
+// time-of-day (HH:MM:SS) when it happened today, prefixed with the month/day
+// when it didn't — so a long-sleep loop's turns from days ago stay unambiguous.
+// Rendered in the viewer's local timezone.
+function formatWhen(date) {
+  if (!(date instanceof Date) || isNaN(date)) return '';
+  const sameDay = date.toDateString() === new Date().toDateString();
+  if (sameDay) return formatTime(date);
+  return date.toLocaleString(undefined, {
+    month: 'short', day: 'numeric',
+    hour: '2-digit', minute: '2-digit', second: '2-digit', hour12: false,
+  });
+}
+
 function timeAgo(date) {
   if (!(date instanceof Date) || isNaN(date)) return '';
   const diff = Date.now() - date.getTime();

--- a/internal/server/web/static/style.css
+++ b/internal/server/web/static/style.css
@@ -796,6 +796,7 @@ body.resize-col *, body.resize-row * { cursor: inherit; user-select: none; }
   display: grid; grid-template-columns: 36px 48px 1fr 1.4fr 40px;
   align-items: center; gap: 8px; height: 12px; margin-bottom: 4px;
   font-family: var(--font-mono); font-size: 11px;
+  cursor: help; /* row title reveals the wall-clock when it ran */
 }
 .iter-num { color: var(--text-muted); }
 .iter-model { color: var(--text-secondary); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }

--- a/internal/server/web/static/style.css
+++ b/internal/server/web/static/style.css
@@ -700,7 +700,9 @@ body.resize-col *, body.resize-row * { cursor: inherit; user-select: none; }
   padding: clamp(0.55rem, 1.25vw, 0.85rem);
   margin-bottom: 0.75rem;
 }
-.loop-spec__head { display: flex; align-items: baseline; gap: 10px; margin-bottom: 9px; }
+.loop-spec__head { display: flex; align-items: center; gap: 10px; margin-bottom: 9px; }
+.loop-spec__heading { display: flex; align-items: baseline; gap: 10px; flex: 1; min-width: 0; flex-wrap: wrap; }
+.loop-spec__controls { margin-left: auto; flex-shrink: 0; display: inline-flex; }
 .loop-spec__title {
   font-size: 11px; text-transform: uppercase; letter-spacing: 0.05em; color: var(--text-muted);
 }

--- a/internal/server/web/static/style.css
+++ b/internal/server/web/static/style.css
@@ -590,6 +590,208 @@ body.resize-col *, body.resize-row * { cursor: inherit; user-select: none; }
   text-wrap: balance;
 }
 
+/* Tier 0 glance header — dense, always-on triage read. */
+.glance-header {
+  padding: 14px 16px 13px;
+  border-bottom: 0.5px solid var(--border);
+  font-size: 13px;
+}
+.glance-id { display: flex; align-items: center; gap: 7px; }
+.glance-dot { width: 9px; height: 9px; border-radius: 50%; background: var(--text-muted); flex: none; }
+.glance-header[data-state="processing"] .glance-dot { background: var(--accent); }
+.glance-header[data-state="error"]      .glance-dot { background: var(--red); }
+.glance-header[data-state="degraded"]   .glance-dot { background: var(--orange); }
+.glance-header[data-state="supervisor"] .glance-dot { background: var(--purple); }
+.glance-header[data-state="waiting"]    .glance-dot { background: var(--blue); }
+.glance-name { font-weight: 500; font-size: 15px; color: var(--text-primary); }
+.glance-meta {
+  margin-left: auto; font-family: var(--font-mono); font-size: 11px; color: var(--text-muted);
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis; max-width: 62%;
+}
+.glance-alert { display: flex; align-items: baseline; gap: 8px; margin-top: 8px; font-size: 12px; color: var(--red); }
+.glance-alert__count { font-weight: 500; }
+.glance-alert__msg {
+  color: var(--text-secondary); font-family: var(--font-mono); font-size: 11px;
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+.glance-phase {
+  display: flex; align-items: center; gap: 8px; margin-top: 9px; padding: 5px 9px;
+  border-radius: 6px; background: var(--accent-dim); color: var(--accent); font-size: 12px;
+}
+.glance-phase--tool { background: var(--orange-dim); color: var(--orange); }
+.glance-phase__elapsed { margin-left: auto; font-family: var(--font-mono); font-weight: 500; }
+.glance-metrics { display: flex; gap: 18px; margin-top: 11px; }
+.glance-metric { min-width: 0; }
+.glance-metric__label { font-size: 11px; color: var(--text-muted); margin-bottom: 1px; }
+.glance-metric__value {
+  display: flex; align-items: center; gap: 6px;
+  font-family: var(--font-mono); font-size: 12px; color: var(--text-primary);
+}
+.glance-spark { display: inline-block; vertical-align: middle; }
+.glance-spark polyline { stroke: var(--text-secondary); stroke-width: 1; }
+.glance-fill {
+  width: 64px; height: 8px; background: var(--bg-tertiary);
+  border-radius: 2px; overflow: hidden; flex: none;
+}
+.glance-fill__fill { height: 100%; }
+.glance-fill-label { font-size: 11px; color: var(--text-secondary); }
+
+/* Sleep scrubber — a non-interactive timeline of the loop's sleep cycle. */
+.sleep-scrubber { margin-top: 12px; }
+.sleep-scrubber__label {
+  display: flex; justify-content: space-between; align-items: baseline;
+  font-size: 11px; color: var(--text-muted); margin-bottom: 6px;
+}
+.sleep-scrubber__eta { font-family: var(--font-mono); }
+.sleep-scrubber--overdue .sleep-scrubber__eta { color: var(--red); }
+.sleep-scrubber__track { position: relative; height: 12px; }
+.sleep-scrubber__track::before {
+  content: ''; position: absolute; top: 4px; left: 0; right: 0; height: 4px;
+  border-radius: 2px; background: var(--bg-tertiary);
+}
+.sleep-scrubber__locked {
+  position: absolute; top: 4px; left: 0; height: 4px; border-radius: 2px 0 0 2px;
+  opacity: 0.55;
+  background: repeating-linear-gradient(45deg, var(--text-muted) 0 1px, transparent 1px 3px);
+}
+.sleep-scrubber__fill {
+  position: absolute; top: 4px; left: 0; height: 4px; border-radius: 2px; background: var(--accent);
+}
+.sleep-scrubber--overdue .sleep-scrubber__fill { background: var(--red); }
+.sleep-scrubber__head {
+  position: absolute; top: 2px; width: 8px; height: 8px; border-radius: 50%;
+  background: var(--accent); transform: translateX(-4px);
+  box-shadow: 0 0 0 2px var(--bg-tertiary);
+}
+.sleep-scrubber--overdue .sleep-scrubber__head { background: var(--red); }
+.sleep-scrubber__min { position: absolute; top: 1px; width: 1px; height: 10px; background: var(--text-muted); }
+
+/* Tooling — the single shared active-capabilities section (one render path for
+   every loop, conversation-backed or not). */
+.tooling-section {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: clamp(0.55rem, 1.25vw, 0.85rem);
+  margin-bottom: 0.75rem;
+}
+.tooling-section__head { display: flex; align-items: baseline; gap: 10px; margin-bottom: 9px; }
+.tooling-section__title {
+  font-size: 11px; text-transform: uppercase; letter-spacing: 0.05em; color: var(--text-muted);
+}
+.tooling-section__counts { font-family: var(--font-mono); font-size: 11px; color: var(--text-secondary); }
+.tooling-section__chips { display: flex; flex-wrap: wrap; gap: 5px; }
+
+/* Loop spec — the stored definition: prompt, supervisor messaging, declared
+   output documents. What the loop IS, vs. the runtime sections' what it DOES. */
+.loop-spec {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: clamp(0.55rem, 1.25vw, 0.85rem);
+  margin-bottom: 0.75rem;
+}
+.loop-spec__head { display: flex; align-items: baseline; gap: 10px; margin-bottom: 9px; }
+.loop-spec__title {
+  font-size: 11px; text-transform: uppercase; letter-spacing: 0.05em; color: var(--text-muted);
+}
+.loop-spec__meta { font-family: var(--font-mono); font-size: 11px; color: var(--text-secondary); }
+.loop-spec__empty { font-size: 12px; line-height: 1.45; color: var(--text-secondary); }
+
+.spec-field { border-left: 2px solid var(--border-light); padding: 2px 0 4px 10px; margin-bottom: 9px; }
+.spec-field:last-child { margin-bottom: 0; }
+.spec-field__head { display: flex; align-items: baseline; gap: 8px; margin-bottom: 4px; }
+.spec-field__label {
+  font-size: 10px; text-transform: uppercase; letter-spacing: 0.04em; color: var(--text-muted);
+}
+.spec-field__bytes { font-family: var(--font-mono); font-size: 10px; color: var(--text-secondary); }
+.spec-field__spacer { flex: 1; }
+.spec-field__btn {
+  font-family: var(--font-mono); font-size: 10px; color: var(--text-secondary);
+  background: var(--bg-tertiary); border: 1px solid var(--border);
+  border-radius: 4px; padding: 1px 7px; cursor: pointer;
+}
+.spec-field__btn:hover { color: var(--text-primary); border-color: var(--border-light); }
+.spec-field__btn.is-copied { color: var(--accent); border-color: color-mix(in srgb, var(--accent) 50%, transparent); }
+.spec-field__preview {
+  font-size: 12px; line-height: 1.4; color: var(--text-secondary);
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+.spec-field__body {
+  font-family: var(--font-mono); font-size: 11px; line-height: 1.45; margin: 0;
+  color: var(--text-secondary); white-space: pre-wrap; word-break: break-word;
+  max-height: 22em; overflow-y: auto;
+  background: var(--bg-primary); border: 1px solid var(--border);
+  border-radius: 4px; padding: 8px 10px;
+}
+
+.spec-outputs { border-left: 2px solid var(--accent-soft); padding: 2px 0 4px 10px; }
+.spec-outputs__label { display: block; margin-bottom: 5px; }
+.spec-output { margin-bottom: 8px; }
+.spec-output:last-child { margin-bottom: 0; }
+.spec-output__refline { display: flex; align-items: center; flex-wrap: wrap; gap: 6px; }
+.spec-output__root {
+  font-family: var(--font-mono); font-size: 10px; color: var(--accent);
+  background: var(--accent-dim); border-radius: 3px; padding: 0 5px;
+}
+.spec-output__path {
+  font-family: var(--font-mono); font-size: 12px; color: var(--text-primary);
+  background: none; border: none; padding: 0; cursor: pointer; text-align: left;
+}
+.spec-output__path:hover { color: var(--accent); }
+.spec-output__path.is-copied { color: var(--accent); }
+.spec-output__mode {
+  font-size: 10px; text-transform: uppercase; letter-spacing: 0.04em; color: var(--text-muted);
+}
+.spec-output__tool { font-family: var(--font-mono); font-size: 11px; color: var(--text-muted); margin-top: 2px; }
+.spec-output__purpose { font-size: 12px; line-height: 1.4; color: var(--text-secondary); margin-top: 3px; }
+
+/* Live tool feed — in-situ transcript of a running loop's tool calls. */
+.live-feed { padding: 12px 16px; border-bottom: 0.5px solid var(--border); background: var(--accent-dim); }
+.live-feed__head { display: flex; align-items: center; gap: 7px; margin-bottom: 9px; }
+.live-feed__dot {
+  width: 7px; height: 7px; border-radius: 50%; background: var(--accent);
+  animation: live-pulse 1.4s ease-in-out infinite;
+}
+@keyframes live-pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.25; } }
+.live-feed__label { font-size: 12px; font-weight: 500; color: var(--accent); }
+.live-feed__count { margin-left: auto; font-family: var(--font-mono); font-size: 11px; color: var(--text-secondary); }
+.live-feed__idle { font-size: 12px; color: var(--text-secondary); }
+.live-tool { border-left: 2px solid var(--border-light); padding: 4px 0 5px 10px; margin-bottom: 7px; }
+.live-tool:last-child { margin-bottom: 0; }
+.live-tool--running { border-left-color: var(--accent); }
+.live-tool--done { border-left-color: var(--green); }
+.live-tool--error { border-left-color: var(--red); }
+.live-tool__head { display: flex; align-items: baseline; gap: 8px; }
+.live-tool__name { font-family: var(--font-mono); font-size: 12px; color: var(--text-primary); }
+.live-tool__status { font-size: 10px; text-transform: uppercase; letter-spacing: 0.04em; color: var(--text-muted); }
+.live-tool--running .live-tool__status { color: var(--accent); }
+.live-tool--error .live-tool__status { color: var(--red); }
+.live-tool__args, .live-tool__result {
+  font-family: var(--font-mono); font-size: 11px; line-height: 1.35; margin: 4px 0 0;
+  white-space: pre-wrap; word-break: break-word; max-height: 3.4em; overflow: hidden;
+}
+.live-tool__args { color: var(--text-muted); }
+.live-tool__result { color: var(--text-secondary); }
+.live-tool__result--error { color: var(--red); }
+
+/* Iteration small multiples — last ~10 turns on a shared scale, so a slow or
+   token-heavy turn spikes against uniform neighbors. */
+.iter-strip { padding: 12px 16px; border-bottom: 0.5px solid var(--border); }
+.iter-strip__head { font-size: 11px; color: var(--text-muted); margin-bottom: 8px; }
+.iter-row {
+  display: grid; grid-template-columns: 36px 48px 1fr 1.4fr 40px;
+  align-items: center; gap: 8px; height: 12px; margin-bottom: 4px;
+  font-family: var(--font-mono); font-size: 11px;
+}
+.iter-num { color: var(--text-muted); }
+.iter-model { color: var(--text-secondary); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.iter-bar { height: 7px; background: var(--bg-tertiary); border-radius: 1px; display: flex; gap: 1px; overflow: hidden; }
+.iter-tok-in { background: var(--text-secondary); height: 100%; }
+.iter-tok-out { background: var(--border-light); height: 100%; }
+.iter-bar--elapsed > span { background: var(--accent); height: 100%; display: block; border-radius: 1px; }
+.iter-dur { color: var(--text-muted); text-align: right; }
+
 .inspector-utility-bar {
   display: flex;
   flex-wrap: wrap;

--- a/internal/server/web/static/style.css
+++ b/internal/server/web/static/style.css
@@ -761,6 +761,40 @@ body.resize-col *, body.resize-row * { cursor: inherit; user-select: none; }
 }
 .spec-output__purpose { font-size: 12px; line-height: 1.4; color: var(--text-secondary); margin-top: 3px; }
 
+/* Shared bordered section chrome — recent turns, and any block that wants the
+   spec/tooling look + a mode hamburger, on one presentation codepath. */
+.insp-section {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: clamp(0.55rem, 1.25vw, 0.85rem);
+}
+.insp-section__head { display: flex; align-items: center; gap: 10px; margin-bottom: 9px; }
+.insp-section__heading { display: flex; align-items: baseline; gap: 10px; flex: 1; min-width: 0; flex-wrap: wrap; }
+.insp-section__title { font-size: 11px; text-transform: uppercase; letter-spacing: 0.05em; color: var(--text-muted); }
+.insp-section__meta { font-family: var(--font-mono); font-size: 11px; color: var(--text-secondary); }
+.insp-section__controls { margin-left: auto; flex-shrink: 0; display: inline-flex; }
+.insp-section__summary { font-size: 12px; line-height: 1.45; color: var(--text-secondary); }
+
+/* Drag-to-reorder: the content blocks below the pinned header live in
+   .insp-reorder; each gets a hover-reveal grip in the panel's left padding
+   gutter. The grip is absolute (header-agnostic) so it works for every block. */
+.insp-reorder { display: flex; flex-direction: column; gap: 0.75rem; }
+.insp-reorder > .insp-block { margin-bottom: 0; }
+.insp-block { position: relative; }
+.insp-grip {
+  position: absolute; top: 0; bottom: 0; left: -10px; width: 12px;
+  display: flex; align-items: center; justify-content: center;
+  background: none; border: none; padding: 0;
+  color: var(--text-muted); opacity: 0; cursor: grab;
+  transition: opacity 0.15s, color 0.15s; touch-action: none;
+}
+.insp-block:hover > .insp-grip { opacity: 0.4; }
+.insp-grip:hover { opacity: 0.95; color: var(--text-secondary); }
+.insp-grip:active { cursor: grabbing; }
+.insp-grip__icon { width: 11px; height: 15px; fill: currentColor; }
+.insp-block--dragging { opacity: 0.6; outline: 1px dashed var(--border-light); outline-offset: 2px; }
+
 /* Live tool feed — in-situ transcript of a running loop's tool calls. */
 .live-feed { padding: 12px 16px; border-bottom: 0.5px solid var(--border); background: var(--accent-dim); }
 .live-feed__head { display: flex; align-items: center; gap: 7px; margin-bottom: 9px; }
@@ -790,10 +824,9 @@ body.resize-col *, body.resize-row * { cursor: inherit; user-select: none; }
 .live-tool__result { color: var(--text-secondary); }
 .live-tool__result--error { color: var(--red); }
 
-/* Iteration small multiples — last ~10 turns on a shared scale, so a slow or
-   token-heavy turn spikes against uniform neighbors. */
-.iter-strip { padding: 12px 16px; border-bottom: 0.5px solid var(--border); }
-.iter-strip__head { font-size: 11px; color: var(--text-muted); margin-bottom: 8px; }
+/* Iteration small multiples — recent turns on a shared scale, so a slow or
+   token-heavy turn spikes against uniform neighbors. Box chrome comes from the
+   shared .insp-section; only the rows are styled here. */
 .iter-row {
   display: grid; grid-template-columns: 36px 48px 1fr 1.4fr 40px;
   align-items: center; gap: 8px; height: 12px; margin-bottom: 4px;

--- a/internal/server/web/static/style.css
+++ b/internal/server/web/static/style.css
@@ -560,8 +560,17 @@ body.resize-col *, body.resize-row * { cursor: inherit; user-select: none; }
 
 .detail-entity {
   display: grid;
+  /* Cap the single column at the panel width: an implicit `auto` track grows
+     to its widest child's min-content, so one wide leaf (a long mono tool name,
+     a nowrap preview, an unbreakable doc path) would push the whole column past
+     the panel and overflow:hidden would clip its right edge. minmax(0, 1fr)
+     pins the track to the container; min-width:0 lets each section shrink into
+     it (text wraps, nowrap leaves ellipsize) instead of forcing it wide. */
+  grid-template-columns: minmax(0, 1fr);
   gap: clamp(0.55rem, 1.2vw, 0.85rem);
 }
+
+.detail-entity > * { min-width: 0; }
 
 .detail-entity .detail-card {
   margin-bottom: 0;
@@ -737,13 +746,17 @@ body.resize-col *, body.resize-row * { cursor: inherit; user-select: none; }
 .spec-output__path {
   font-family: var(--font-mono); font-size: 12px; color: var(--text-primary);
   background: none; border: none; padding: 0; cursor: pointer; text-align: left;
+  overflow-wrap: anywhere;
 }
 .spec-output__path:hover { color: var(--accent); }
 .spec-output__path.is-copied { color: var(--accent); }
 .spec-output__mode {
   font-size: 10px; text-transform: uppercase; letter-spacing: 0.04em; color: var(--text-muted);
 }
-.spec-output__tool { font-family: var(--font-mono); font-size: 11px; color: var(--text-muted); margin-top: 2px; }
+.spec-output__tool {
+  font-family: var(--font-mono); font-size: 11px; color: var(--text-muted);
+  margin-top: 2px; overflow-wrap: anywhere;
+}
 .spec-output__purpose { font-size: 12px; line-height: 1.4; color: var(--text-secondary); margin-top: 3px; }
 
 /* Live tool feed — in-situ transcript of a running loop's tool calls. */

--- a/internal/server/web/static/style.css
+++ b/internal/server/web/static/style.css
@@ -840,6 +840,14 @@ body.resize-col *, body.resize-row * { cursor: inherit; user-select: none; }
 .iter-tok-out { background: var(--border-light); height: 100%; }
 .iter-bar--elapsed > span { background: var(--accent); height: 100%; display: block; border-radius: 1px; }
 .iter-dur { color: var(--text-muted); text-align: right; }
+/* A turn row that records a request_id is a link to its request-detail pane. */
+.iter-row--clickable {
+  cursor: pointer; border-radius: 3px;
+  margin-left: -4px; margin-right: -4px; padding-left: 4px; padding-right: 4px;
+}
+.iter-row--clickable:hover { background: var(--bg-hover); }
+.iter-row--clickable:focus-visible { outline: 1px solid var(--accent); outline-offset: 0; }
+.iter-row--clickable .iter-num { color: var(--accent); }
 
 .inspector-utility-bar {
   display: flex;


### PR DESCRIPTION
## Why

The node inspector was a seven-card "schema-card" firehose — it restated each
fact up to three times and ranked nothing — and the standalone Forensics view
duplicated the same per-loop store. This rebuilds it as one progressive-
disclosure inspector that serves both the *inspect* goal ("is this loop healthy /
what's it doing") and the *forensics* goal ("what happened / why slow"), in a
high-data-ink, Edward-Tufte style. Scope locked with the owner: read-only first
pass · live-only model/tool split.

## Server — data foundation

`/v1/loops`, `/v1/loops/{id}`, and the `/v1/loops/events` snapshot now embed the
canonical `LoopView` projection (the "ps auxwwww" row) as an additive `view`
object on each loop, built via `LoopViewResolver` with the policy join from the
live definition registry:

- **schedule** — `next_wake_delta`, `current_sleep_duration`
- **structure** — `parent_name`, `ancestry`, `child_count`
- **economics** — `context_fill_pct` (precomputed; the client never divides)
- **policy** — `policy_state`, `eligible` (`ephemeral` when no stored definition backs the loop)
- plus `intent`, `operation`, error streak, etc.

Additive — the flat `Status` fields are untouched, so existing clients are
unaffected. The resolver runs over the full status batch so `parent_name` /
`child_count` / `ancestry` stay correct even under `?state=` filtering.
Documented as `LoopView` + `LoopStatusWithView` in `native.yaml`.

## Client — the inspector

One progressive-disclosure pane, top to bottom:

- **Glance header** — status-dot health + error streak, a live model-vs-tool
  phase badge while processing, iterations, a context-fill bar, and a
  non-interactive "video-scrubber" sleep timeline (chosen duration, elapsed
  playhead, min/max bounds). Replaces the old hero / identity / relationship
  cards. (The misleading steady-state jitter sparkline was dropped.)
- **Live tool feed** — in-situ transcript of a running loop's tool calls
  (name / status / args / result), directly under the header.
- **Recent turns** — iteration-history small multiples on a shared scale, so a
  slow or token-heavy turn spikes against uniform neighbors. Hover any row for
  the wall-clock time it ran (`ran 10:03:18 (7m ago) · took 1m 28s`, date-aware
  for long-sleep loops whose turns span days).
- **Spec** — the stored definition from `/v1/loop-definitions/{name}` (lazy,
  cached): the prompt it runs each wake, the supervisor-review messaging when
  the loop opts into frontier review turns, and the declared output documents
  (root-tagged ref, write mode, scoped `replace_output_*` tool, purpose). A
  hamburger cycles the whole section **summary → brief → verbose**, the same
  control the schema cards carry; `copy` lifts any body to the clipboard.
  Ephemeral loops and containers say so plainly.
- **Tooling** — one shared block for every loop (aggregate counts + the loop's
  *active* capability tags as chips), ending the old conversation-vs-service
  divergence. "active" tracks the model-facing `tag_activate` verb.
- **Execution / Profile** — the remaining legacy schema cards, kept until the
  Tier 2 slice reworks them.

## Notable fixes

- **Panel overflow** — `.detail-entity`'s implicit `auto` grid track grew to its
  widest child's min-content, so a long mono tool name or unbreakable doc path
  pushed the whole column past the fixed-width panel and `overflow:hidden`
  clipped the right edge. Capped with `grid-template-columns: minmax(0, 1fr)` +
  `min-width: 0` on children.
- **Spec toggle defer** — the toggle's plain `renderDetail()` was suppressed by
  the hover/interaction defer gate (`shouldDeferDetailRender`), so it only
  painted on mouse-out; now re-renders with `{ force: true }` like the
  schema-card controls.

## Still to come (follow-up)

- Tier 2 per-turn drill — click a finished turn → its rendered system-prompt /
  context to clipboard + the turn's tool I/O.
- Absorb and delete the standalone Forensics surface; replace the full-innerHTML
  live re-render with surgical cell updates.
- Auto-generated tool-catalog surface (the spec section's eventual "full view"
  doc links).

## Test plan
- [x] `LoopView` present on `/v1/loops` with resolved `parent_name` / `child_count` / `context_fill_pct`, and `ephemeral` policy without a registry — `TestHandleLoops_IncludesLoopView`
- [x] Existing loop tests unaffected (additive field)
- [x] `native.yaml` lints clean (vacuum, 0 errors); openapi coverage green
- [x] `just ci` green
- [x] Client live-verified against prod (proxy harness) across loop shapes — service, supervisor, container, ephemeral: glance header + sleep scrubber, recent-turns strip + wall-clock hover, unified tooling, live tool feed, spec section + summary/brief/verbose toggle, panel overflow cap; console clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
