### PR TITLE
fix(unifi): tolerate transient gateway failures before alarming

### DIFF
--- a/internal/integrations/unifi/client.go
+++ b/internal/integrations/unifi/client.go
@@ -44,6 +44,18 @@ func NewClient(baseURL, apiKey string, logger *slog.Logger) *Client {
 		httpClient: httpkit.NewClient(
 			httpkit.WithTimeout(15*time.Second),
 			httpkit.WithRetry(2, 2*time.Second),
+			// The UniFi gateway returns transient 5xx (and occasional 429) on
+			// the station-list endpoint under load or during internal restarts.
+			// The poll is an idempotent GET, so ride those out within a single
+			// poll (honoring Retry-After) instead of surfacing every blip to the
+			// loop as an alarm.
+			httpkit.WithRetryOnStatus(
+				http.StatusTooManyRequests,
+				http.StatusInternalServerError,
+				http.StatusBadGateway,
+				http.StatusServiceUnavailable,
+				http.StatusGatewayTimeout,
+			),
 			httpkit.WithTLSInsecureSkipVerify(),
 			httpkit.WithLogger(logger),
 		),

--- a/internal/integrations/unifi/client_test.go
+++ b/internal/integrations/unifi/client_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 )
 
@@ -95,13 +96,48 @@ func TestPing_Success(t *testing.T) {
 
 func TestPing_Error(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		// 503 is in the client's retry set; Retry-After:0 keeps the now-retried
+		// path instant in the test. The retries exhaust and the error surfaces.
+		w.Header().Set("Retry-After", "0")
 		w.WriteHeader(http.StatusServiceUnavailable)
 	}))
 	defer srv.Close()
 
 	client := NewClient(srv.URL, "test-key", nil)
 	if err := client.Ping(context.Background()); err == nil {
-		t.Fatal("expected error for 503 response")
+		t.Fatal("expected error for sustained 503 response")
+	}
+}
+
+// TestGetClientStations_RetriesTransient5xx verifies the client rides out a
+// transient gateway 5xx within a single call (the first layer of poll tolerance)
+// rather than surfacing it. Retry-After:0 keeps the test instant.
+func TestGetClientStations_RetriesTransient5xx(t *testing.T) {
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if atomic.AddInt32(&calls, 1) == 1 {
+			w.Header().Set("Retry-After", "0")
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte("transient gateway error"))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(struct {
+			Data []ClientStation `json:"data"`
+		}{Data: []ClientStation{{MAC: "aa:bb:cc:dd:ee:ff", LastUplinkName: "ap-office", LastSeen: 1000}}})
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL, "test-key", nil)
+	stations, err := client.GetClientStations(context.Background())
+	if err != nil {
+		t.Fatalf("expected transient 500 to be retried to success, got %v", err)
+	}
+	if len(stations) != 1 {
+		t.Fatalf("expected 1 station after retry, got %d", len(stations))
+	}
+	if got := atomic.LoadInt32(&calls); got < 2 {
+		t.Errorf("expected >=2 calls (1 fail + retry), got %d", got)
 	}
 }
 

--- a/internal/integrations/unifi/poller.go
+++ b/internal/integrations/unifi/poller.go
@@ -36,6 +36,14 @@ type PollerConfig struct {
 	// APRooms maps AP names to human-readable room names.
 	APRooms map[string]string // ap_name → room
 
+	// FailureThreshold is the number of CONSECUTIVE failed polls tolerated
+	// before Poll surfaces the error to the loop (which raises the operator
+	// alarm). A transient gateway hiccup — the UniFi controller 5xx-ing on the
+	// station-list endpoint — is absorbed silently; only a sustained outage
+	// across this many polls is treated as genuinely broken and worth alarming.
+	// Defaults to defaultFailureThreshold when <= 0.
+	FailureThreshold int
+
 	// Logger for structured logging.
 	Logger *slog.Logger
 }
@@ -54,6 +62,12 @@ type pendingRoom struct {
 // transient WiFi roaming from causing room flicker.
 const debounceThreshold = 2
 
+// defaultFailureThreshold is the number of consecutive failed polls tolerated
+// before a poll failure is surfaced to the loop as an alarm. At the 30s default
+// poll interval that is ~1.5 minutes of sustained failure — long enough to ride
+// out a flaky gateway's transient 5xx, short enough to flag a real outage.
+const defaultFailureThreshold = 3
+
 // Poller periodically queries a DeviceLocator and updates the person
 // tracker with room-level presence. It requires two consecutive polls
 // showing the same AP before updating a room (debounce), preventing
@@ -61,8 +75,17 @@ const debounceThreshold = 2
 type Poller struct {
 	cfg PollerConfig
 
-	mu      sync.Mutex
-	pending map[string]*pendingRoom // entity_id → pending room change
+	mu                  sync.Mutex
+	pending             map[string]*pendingRoom // entity_id → pending room change
+	consecutiveFailures int                     // streak of failed polls; gates the alarm
+}
+
+// failureThreshold is the configured consecutive-failure budget, or the default.
+func (p *Poller) failureThreshold() int {
+	if p.cfg.FailureThreshold > 0 {
+		return p.cfg.FailureThreshold
+	}
+	return defaultFailureThreshold
 }
 
 // NewPoller creates a UniFi room presence poller.
@@ -84,7 +107,7 @@ func (p *Poller) Poll(ctx context.Context) error {
 
 	locations, err := p.cfg.Locator.LocateDevices(ctx)
 	if err != nil {
-		return fmt.Errorf("locate devices: %w", err)
+		return p.tolerateFailure(err, summary)
 	}
 
 	// Build MAC → DeviceLocation index, keeping only tracked MACs.
@@ -133,6 +156,7 @@ func (p *Poller) Poll(ctx context.Context) error {
 	// Apply debounce and update rooms.
 	p.mu.Lock()
 	defer p.mu.Unlock()
+	p.consecutiveFailures = 0 // a successful locate clears the alarm gate
 
 	var roomsUpdated, pendingCount int
 	for entityID, best := range entityBest {
@@ -183,5 +207,35 @@ func (p *Poller) Poll(ctx context.Context) error {
 		summary["pending_changes"] = pendingCount
 	}
 
+	return nil
+}
+
+// tolerateFailure records a failed poll and decides whether to surface it. A
+// single transient gateway error (the UniFi controller 5xx-ing on /stat/sta) is
+// absorbed silently — Poll returns nil so the iteration succeeds and no operator
+// alarm flaps — and the degradation is reported to the loop dashboard instead.
+// Only once failures pile up to FailureThreshold consecutive polls, a genuine
+// sustained outage, is the error returned to the loop. A later successful poll
+// resets the streak (see Poll).
+func (p *Poller) tolerateFailure(err error, summary map[string]any) error {
+	p.mu.Lock()
+	p.consecutiveFailures++
+	n := p.consecutiveFailures
+	p.mu.Unlock()
+
+	threshold := p.failureThreshold()
+	if n >= threshold {
+		return fmt.Errorf("UniFi controller failing for %d consecutive polls: %w", n, err)
+	}
+
+	p.cfg.Logger.Warn("UniFi poll failed; tolerating as transient",
+		"consecutive_failures", n,
+		"threshold", threshold,
+		"error", err,
+	)
+	if summary != nil {
+		summary["poll_status"] = fmt.Sprintf("transient failure %d/%d", n, threshold)
+		summary["consecutive_failures"] = n
+	}
 	return nil
 }

--- a/internal/integrations/unifi/poller.go
+++ b/internal/integrations/unifi/poller.go
@@ -64,8 +64,9 @@ const debounceThreshold = 2
 
 // defaultFailureThreshold is the number of consecutive failed polls tolerated
 // before a poll failure is surfaced to the loop as an alarm. At the 30s default
-// poll interval that is ~1.5 minutes of sustained failure — long enough to ride
-// out a flaky gateway's transient 5xx, short enough to flag a real outage.
+// poll interval the 3rd consecutive failure lands ~1 minute after the first —
+// long enough to ride out a flaky gateway's transient 5xx, short enough to flag
+// a real outage.
 const defaultFailureThreshold = 3
 
 // Poller periodically queries a DeviceLocator and updates the person
@@ -101,7 +102,9 @@ func NewPoller(cfg PollerConfig) *Poller {
 
 // Poll executes a single poll cycle: query the controller for device
 // locations, apply debounce, and push room updates to the tracker.
-// Returns an error if the device locator fails; all other paths succeed.
+// A device-locator failure is tolerated (Poll returns nil) until
+// FailureThreshold consecutive failures, after which the error is surfaced to
+// the caller; all other paths succeed.
 func (p *Poller) Poll(ctx context.Context) error {
 	summary := loop.IterationSummary(ctx)
 

--- a/internal/integrations/unifi/poller_test.go
+++ b/internal/integrations/unifi/poller_test.go
@@ -3,6 +3,7 @@ package unifi
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -33,6 +34,12 @@ func (m *mockLocator) setLocations(locs []DeviceLocation) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.locations = locs
+}
+
+func (m *mockLocator) setErr(err error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.err = err
 }
 
 type roomUpdate struct {
@@ -234,10 +241,45 @@ func TestPoller_UnknownAP(t *testing.T) {
 	}
 }
 
-func TestPoller_LocatorError(t *testing.T) {
-	locator := &mockLocator{
-		err: fmt.Errorf("connection refused"),
+// TestPoller_ToleratesTransientFailures verifies a flaky gateway doesn't alarm
+// on the first failures: Poll returns nil (no loop error) until FailureThreshold
+// consecutive failures, at which point it surfaces the error.
+func TestPoller_ToleratesTransientFailures(t *testing.T) {
+	locator := &mockLocator{err: fmt.Errorf("UniFi API error 500: internal error")}
+	updater := &mockUpdater{}
+
+	p := NewPoller(PollerConfig{
+		Locator:      locator,
+		Updater:      updater,
+		PollInterval: time.Hour,
+		DeviceOwners: map[string]string{"aa:bb:cc:dd:ee:ff": "person.alice"},
+		APRooms:      map[string]string{"ap-office": "office"},
+	}) // default threshold = 3
+
+	// First two failures are tolerated (no alarm).
+	for i := 1; i <= defaultFailureThreshold-1; i++ {
+		if err := p.Poll(context.Background()); err != nil {
+			t.Fatalf("poll %d: expected tolerated (nil) error, got %v", i, err)
+		}
 	}
+	// The threshold'th consecutive failure surfaces the error (alarm).
+	err := p.Poll(context.Background())
+	if err == nil {
+		t.Fatal("expected error once failure threshold reached")
+	}
+	if !strings.Contains(err.Error(), "consecutive polls") {
+		t.Errorf("alarm error = %q, want it to mention consecutive polls", err)
+	}
+
+	if updates := updater.getUpdates(); len(updates) != 0 {
+		t.Errorf("expected no room updates on failure, got %d", len(updates))
+	}
+}
+
+// TestPoller_SuccessResetsFailureStreak verifies a single good poll clears the
+// streak so the budget resets — a gateway that recovers between blips never alarms.
+func TestPoller_SuccessResetsFailureStreak(t *testing.T) {
+	locator := &mockLocator{err: fmt.Errorf("UniFi API error 500: internal error")}
 	updater := &mockUpdater{}
 
 	p := NewPoller(PollerConfig{
@@ -248,17 +290,34 @@ func TestPoller_LocatorError(t *testing.T) {
 		APRooms:      map[string]string{"ap-office": "office"},
 	})
 
-	// Should return error and not update.
-	if err := p.Poll(context.Background()); err == nil {
-		t.Error("expected error from failing locator")
-	}
-	if err := p.Poll(context.Background()); err == nil {
-		t.Error("expected error from failing locator (second call)")
-	}
+	// Two failures (tolerated), then a success resets the streak.
+	mustPoll(t, p)
+	mustPoll(t, p)
+	locator.setErr(nil)
+	locator.setLocations([]DeviceLocation{{MAC: "aa:bb:cc:dd:ee:ff", APName: "ap-office", LastSeen: 1000}})
+	mustPoll(t, p) // success — streak reset to 0
 
-	updates := updater.getUpdates()
-	if len(updates) != 0 {
-		t.Errorf("expected no updates on error, got %d", len(updates))
+	// Failures resume; the budget is full again, so the next two are tolerated.
+	locator.setErr(fmt.Errorf("UniFi API error 500: internal error"))
+	mustPoll(t, p)
+	mustPoll(t, p)
+	if err := p.Poll(context.Background()); err == nil {
+		t.Fatal("expected error only after threshold failures following the reset")
+	}
+}
+
+// TestPoller_FailureThresholdConfigurable verifies the budget honors the config.
+func TestPoller_FailureThresholdConfigurable(t *testing.T) {
+	locator := &mockLocator{err: fmt.Errorf("UniFi API error 503")}
+	p := NewPoller(PollerConfig{
+		Locator:          locator,
+		Updater:          &mockUpdater{},
+		PollInterval:     time.Hour,
+		FailureThreshold: 1, // alarm on the very first failure
+	})
+
+	if err := p.Poll(context.Background()); err == nil {
+		t.Fatal("expected error on first failure with threshold=1")
 	}
 }
 


### PR DESCRIPTION
## Why

The `unifi-poller` service surfaced **every** gateway error to its loop, so the UniFi controller's frequent transient `HTTP 500` on `/stat/sta` raised an operator alarm in the web UI (the loop's `consecutive_errors` / error streak). That's a UniFi-side hiccup that usually clears on the next poll and isn't actionable from thane's side — it shouldn't alarm unless the controller is genuinely down.

## Sanity check (this is old code)

The thane side is clean: an **idempotent GET** read of the station list, proper `X-API-KEY`/`Accept` headers, 15s timeout, TLS-skip for the self-signed controller, body drain/close for connection reuse, polling at a **≥10s floor (30s default)** — it doesn't hammer the gateway or mutate anything. The 5xx are gateway-internal, not thane-induced. The one real gap: the client opted into connection-error retry but **not** 5xx retry, so a single transient 500 bubbled straight to an alarm.

## What changed

Two complementary layers of tolerance:

- **Client — retry transient 5xx within a poll.** Add `httpkit.WithRetryOnStatus(429, 500, 502, 503, 504)` so a blip is retried (2×, honoring `Retry-After`) and usually recovers inside one poll instead of failing it. The poll is an idempotent GET, so this is safe. (Also makes `Ping`, used by connwatch health, ride out the same blips.)
- **Poller — consecutive-failure budget before alarming.** New `FailureThreshold` (default **3**). A failed poll is absorbed silently — `Poll` returns `nil` and reports `poll_status: "transient failure N/3"` to the loop dashboard so the degradation is visible without alarming — until failures persist across the threshold (a genuine sustained outage, ~1.5 min at the 30s interval), at which point the error surfaces and the alarm fires. **A single successful poll resets the streak.**

Net: a transient 500 is retried (often recovers); if a poll still fails it's tolerated; only sustained failure across several sequential polls alarms.

## Test plan
- [x] `TestPoller_ToleratesTransientFailures` — first N-1 failures return nil, the Nth surfaces the error
- [x] `TestPoller_SuccessResetsFailureStreak` — a good poll clears the budget
- [x] `TestPoller_FailureThresholdConfigurable` — honors a custom threshold
- [x] `TestGetClientStations_RetriesTransient5xx` — a transient 500 is retried to success
- [x] `TestPing_Error` updated for the now-retried 503 path (`Retry-After:0` keeps it instant)
- [x] `just ci` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
