### PR TITLE
feat(loops): promote loop intent to first-class Spec.Intent (#1106 C1)

### DIFF
--- a/examples/config.example.yaml
+++ b/examples/config.example.yaml
@@ -1041,6 +1041,7 @@ archivist:
 #     - name: office_watch
 #       enabled: true
 #       task: Watch the office and report noteworthy changes or trends.
+#       intent: Keep a current read on office activity so notable changes surface without being asked.
 #       profile:
 #         model: ""
 #         quality_floor: 0

--- a/internal/app/loop_core.go
+++ b/internal/app/loop_core.go
@@ -72,7 +72,7 @@ func (a *App) ensureChannelsContainer(ctx context.Context) error {
 		Name:      looppkg.ChannelsContainerName,
 		Enabled:   true,
 		Operation: looppkg.OperationContainer,
-		Metadata:  map[string]string{"intent": "Interactive counterparty channels (Signal, OWU, and others)."},
+		Intent:    "Interactive counterparty channels (Signal, OWU, and others).",
 	}
 	if _, err := a.loopRegistry.SpawnSpec(ctx, spec, looppkg.Deps{Logger: a.logger}); err != nil {
 		return err

--- a/internal/app/loop_definition_builtins.go
+++ b/internal/app/loop_definition_builtins.go
@@ -61,7 +61,7 @@ func containerSpec(name, intent string) looppkg.Spec {
 		Name:      name,
 		Enabled:   true,
 		Operation: looppkg.OperationContainer,
-		Metadata:  map[string]string{"intent": intent},
+		Intent:    intent,
 	}
 }
 

--- a/internal/app/loop_definition_builtins_test.go
+++ b/internal/app/loop_definition_builtins_test.go
@@ -1,0 +1,19 @@
+package app
+
+import "testing"
+
+// TestContainerSpec_IntentIsFirstClass guards that built-in grouping containers
+// carry their purpose on the first-class Spec.Intent field, not the legacy
+// metadata["intent"] bag. Built-ins on the metadata path would emit a
+// (non-actionable) deprecation warning and lose their intent once the #1106
+// one-release fallback is removed.
+func TestContainerSpec_IntentIsFirstClass(t *testing.T) {
+	spec := containerSpec("cognition", "Core cognition loops.")
+
+	if spec.Intent != "Core cognition loops." {
+		t.Errorf("containerSpec Intent = %q, want it on the first-class field", spec.Intent)
+	}
+	if _, ok := spec.Metadata["intent"]; ok {
+		t.Error("containerSpec wrote intent into metadata; built-ins must use the first-class Intent field")
+	}
+}

--- a/internal/platform/config/example.go
+++ b/internal/platform/config/example.go
@@ -274,6 +274,7 @@ func ExampleConfig() *Config {
 					Name:       "office_watch",
 					Enabled:    true,
 					Task:       "Watch the office and report noteworthy changes or trends.",
+					Intent:     "Keep a current read on office activity so notable changes surface without being asked.",
 					Operation:  looppkg.OperationService,
 					Completion: looppkg.CompletionNone,
 					Conditions: looppkg.Conditions{

--- a/internal/runtime/loop/config.go
+++ b/internal/runtime/loop/config.go
@@ -160,6 +160,11 @@ type Config struct {
 	// TaskBuilder or TurnBuilder is set.
 	Task string
 
+	// Intent is the resolved purpose string for the loop — [Spec.Intent] if
+	// set, otherwise the legacy metadata["intent"] fallback. Resolved once in
+	// [Spec.ToConfig] so readers (e.g. LoopView) take a single source.
+	Intent string
+
 	// Operation describes the runtime pattern expected for the loop.
 	Operation Operation
 

--- a/internal/runtime/loop/definition_warnings.go
+++ b/internal/runtime/loop/definition_warnings.go
@@ -104,7 +104,7 @@ func BuildDefinitionWarnings(spec Spec) []DefinitionWarning {
 // supervisor_quality_floor), which are deliberately not part of the canonical
 // authoring surface.
 var shadowableSpecFields = map[string]struct{}{
-	"name": {}, "enabled": {}, "task": {}, "profile": {}, "operation": {},
+	"name": {}, "enabled": {}, "task": {}, "intent": {}, "profile": {}, "operation": {},
 	"completion": {}, "outputs": {}, "subscriptions": {}, "conditions": {},
 	"tags": {}, "exclude_tools": {}, "sleep_min": {}, "sleep_max": {},
 	"sleep_default": {}, "jitter": {}, "max_duration": {}, "max_iter": {},
@@ -117,7 +117,9 @@ var shadowableSpecFields = map[string]struct{}{
 // top-level spec field. Such keys are inert: the runtime reads the structural
 // field, not metadata, so the value never takes effect. parent_name/parent_id
 // get a placement-specific message because the failure is silent
-// mis-parenting rather than a generic dropped value.
+// mis-parenting rather than a generic dropped value; intent gets a
+// deprecation message instead of "inert" because, during the #1106 promotion,
+// the runtime still reads metadata["intent"] as a one-release fallback.
 func metadataShadowWarnings(spec Spec) []DefinitionWarning {
 	if len(spec.Metadata) == 0 {
 		return nil
@@ -139,6 +141,8 @@ func metadataShadowWarnings(spec Spec) []DefinitionWarning {
 		switch key {
 		case "parent_name", "parent_id":
 			msg = "metadata." + key + " is inert and does not nest this loop under a parent: a metadata entry does not set a structural spec field. Set the top-level parent_name field instead."
+		case "intent":
+			msg = "metadata.intent is the legacy location for the loop's purpose. The runtime now prefers the top-level intent field and reads metadata.intent only as a one-release fallback. Set the top-level intent field; the metadata fallback is removed next release."
 		default:
 			msg = fmt.Sprintf("metadata.%s shadows the top-level %s field, which the runtime reads instead of metadata. A metadata entry does not set a structural spec field, so this copy is inert; set the top-level %s field.", key, key, key)
 		}

--- a/internal/runtime/loop/definition_warnings_test.go
+++ b/internal/runtime/loop/definition_warnings_test.go
@@ -77,6 +77,14 @@ func TestBuildDefinitionWarnings_MetadataShadowsSpecField(t *testing.T) {
 			wantInMsg: "shadows the top-level tags field",
 		},
 		{
+			// intent keeps a one-release metadata fallback, so its message must
+			// say deprecated/still-read, NOT "inert" like the generic case.
+			name:      "intent in metadata fires with deprecation guidance, not inert",
+			spec:      Spec{Operation: OperationService, Metadata: map[string]string{"intent": "watch the lake"}},
+			wantCode:  "metadata_shadows_spec_field",
+			wantInMsg: "one-release fallback",
+		},
+		{
 			// Containers and event-driven loops nest too, so the shadow check
 			// must fire regardless of operation — this guards the placement of
 			// the check before the service-only early return.

--- a/internal/runtime/loop/intent_test.go
+++ b/internal/runtime/loop/intent_test.go
@@ -1,0 +1,72 @@
+package loop
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestSpecIntent_ToConfigResolution covers the #1106 C1 promotion: ToConfig
+// prefers the first-class Spec.Intent field and falls back to the legacy
+// metadata["intent"] for one release.
+func TestSpecIntent_ToConfigResolution(t *testing.T) {
+	tests := []struct {
+		name string
+		spec Spec
+		want string
+	}{
+		{"field set", Spec{Intent: "watch the lake"}, "watch the lake"},
+		{"field preferred over metadata", Spec{Intent: "field wins", Metadata: map[string]string{"intent": "stale"}}, "field wins"},
+		{"metadata fallback when field empty", Spec{Metadata: map[string]string{"intent": "legacy intent"}}, "legacy intent"},
+		{"empty when neither set", Spec{}, ""},
+		{"whitespace-only field falls back to metadata", Spec{Intent: "   ", Metadata: map[string]string{"intent": "legacy"}}, "legacy"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.spec.ToConfig().Intent; got != tc.want {
+				t.Errorf("ToConfig().Intent = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestSpecIntent_JSONRoundTrip confirms the first-class Intent field survives
+// the custom Spec marshal/unmarshal wire format (specJSON).
+func TestSpecIntent_JSONRoundTrip(t *testing.T) {
+	spec := Spec{
+		Name:      "canyon_lake_watch",
+		Operation: OperationService,
+		Intent:    "hold a current belief about the reservoir level",
+	}
+	data, err := json.Marshal(spec)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if !strings.Contains(string(data), `"intent":"hold a current belief about the reservoir level"`) {
+		t.Errorf("marshaled JSON missing first-class intent field: %s", data)
+	}
+	var got Spec
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if got.Intent != spec.Intent {
+		t.Errorf("round-trip Intent = %q, want %q", got.Intent, spec.Intent)
+	}
+}
+
+// TestSpecIntent_LoopViewReadsResolved confirms LoopView.Intent reads the
+// resolved Config.Intent — including the legacy metadata fallback, end to end.
+func TestSpecIntent_LoopViewReadsResolved(t *testing.T) {
+	r := NewLoopViewResolver(nil, nil, time.Now())
+
+	fieldStatus := Status{ID: "lp_a", Name: "a", Config: (&Spec{Intent: "from field"}).ToConfig()}
+	if got := r.FromStatus(fieldStatus).Intent; got != "from field" {
+		t.Errorf("field intent: LoopView.Intent = %q, want %q", got, "from field")
+	}
+
+	fallbackStatus := Status{ID: "lp_b", Name: "b", Config: (&Spec{Metadata: map[string]string{"intent": "from metadata"}}).ToConfig()}
+	if got := r.FromStatus(fallbackStatus).Intent; got != "from metadata" {
+		t.Errorf("fallback intent: LoopView.Intent = %q, want %q", got, "from metadata")
+	}
+}

--- a/internal/runtime/loop/loop_view.go
+++ b/internal/runtime/loop/loop_view.go
@@ -182,7 +182,7 @@ func (r LoopViewResolver) FromStatus(s Status) LoopView {
 		Operation:   string(s.Config.Operation),
 		Completion:  string(s.Config.Completion),
 		Task:        s.Config.Task,
-		Intent:      s.Config.Metadata["intent"],
+		Intent:      s.Config.Intent,
 		Ancestry:    r.ancestry(s.ID),
 		ChildCount:  r.childCount[s.ID],
 		Running:     true,

--- a/internal/runtime/loop/loop_view_test.go
+++ b/internal/runtime/loop/loop_view_test.go
@@ -167,14 +167,14 @@ func TestLoopViewResolver_FromStatus_ContainerAndEphemeral(t *testing.T) {
 		ID:     "lp_travel",
 		Name:   "travel",
 		State:  State("pending"),
-		Config: Config{Operation: OperationContainer, Metadata: map[string]string{"intent": "away trips"}},
+		Config: Config{Operation: OperationContainer, Intent: "away trips"},
 	})
 
 	if container.ChildCount != 2 {
 		t.Errorf("ChildCount = %d, want 2", container.ChildCount)
 	}
 	if container.Intent != "away trips" {
-		t.Errorf("Intent = %q, want the metadata intent surfaced", container.Intent)
+		t.Errorf("Intent = %q, want the resolved Config.Intent surfaced", container.Intent)
 	}
 	if container.ParentName != nil {
 		t.Errorf("top-level container ParentName = %v, want nil", container.ParentName)

--- a/internal/runtime/loop/spec.go
+++ b/internal/runtime/loop/spec.go
@@ -138,6 +138,13 @@ type Spec struct {
 	// TaskBuilder or TurnBuilder is set.
 	Task string `yaml:"task,omitempty" json:"task,omitempty"`
 
+	// Intent is a short (one- or two-sentence) statement of why this loop
+	// exists — its purpose, distinct from Task (the per-iteration prompt).
+	// First-class as of #1106 (promoted out of the metadata["intent"] bag): the
+	// runtime prefers this field and falls back to metadata["intent"] for one
+	// release (see [Spec.ToConfig]). Surfaced verbatim as LoopView.Intent.
+	Intent string `yaml:"intent,omitempty" json:"intent,omitempty"`
+
 	// Profile shapes loop execution: routing hints, context-injection
 	// tags, tool exclusions, and related request-shaping guidance.
 	Profile router.LoopProfile `yaml:"profile,omitempty" json:"profile,omitempty"`
@@ -451,6 +458,7 @@ func (s *Spec) ToConfig() Config {
 	return Config{
 		Name:                 ns.Name,
 		Task:                 ns.Task,
+		Intent:               resolveIntent(ns.Intent, ns.Metadata),
 		Operation:            ns.Operation,
 		Completion:           ns.Completion,
 		Outputs:              cloneOutputs(ns.Outputs),
@@ -482,6 +490,17 @@ func (s *Spec) ToConfig() Config {
 		ParentID:             ns.ParentID,
 		ParentName:           ns.ParentName,
 	}
+}
+
+// resolveIntent returns the loop's purpose string, preferring the first-class
+// [Spec.Intent] field and falling back to the legacy metadata["intent"] for one
+// release (#1106). When authoring no longer writes metadata["intent"] and stored
+// specs are migrated, the fallback collapses to the field alone.
+func resolveIntent(field string, metadata map[string]string) string {
+	if strings.TrimSpace(field) != "" {
+		return field
+	}
+	return metadata["intent"]
 }
 
 // containerShape is the shared shape contract for container loops. It

--- a/internal/runtime/loop/spec_json.go
+++ b/internal/runtime/loop/spec_json.go
@@ -13,6 +13,7 @@ type specJSON struct {
 	Name           string               `json:"name,omitempty"`
 	Enabled        bool                 `json:"enabled"`
 	Task           string               `json:"task,omitempty"`
+	Intent         string               `json:"intent,omitempty"`
 	Profile        any                  `json:"profile,omitempty"`
 	Operation      Operation            `json:"operation,omitempty"`
 	Completion     Completion           `json:"completion,omitempty"`
@@ -68,6 +69,7 @@ func (s Spec) MarshalJSON() ([]byte, error) {
 		Name:              s.Name,
 		Enabled:           s.Enabled,
 		Task:              s.Task,
+		Intent:            s.Intent,
 		Profile:           s.Profile,
 		Operation:         s.Operation,
 		Completion:        s.Completion,
@@ -148,6 +150,7 @@ func (s *Spec) UnmarshalJSON(data []byte) error {
 		Name:             wire.Name,
 		Enabled:          wire.Enabled,
 		Task:             wire.Task,
+		Intent:           wire.Intent,
 		Operation:        wire.Operation,
 		Completion:       wire.Completion,
 		Outputs:          cloneOutputs(wire.Outputs),

--- a/internal/tools/loop_container_tools_test.go
+++ b/internal/tools/loop_container_tools_test.go
@@ -134,8 +134,8 @@ func TestThaneCreateContainerStoresAndLaunches(t *testing.T) {
 	if len(spec.Tags) != 2 || spec.Tags[0] != "home" || spec.Tags[1] != "ha" {
 		t.Errorf("persisted Tags = %v, want [home ha]", spec.Tags)
 	}
-	if spec.Metadata["intent"] == "" {
-		t.Error("intent missing from container metadata")
+	if spec.Intent == "" {
+		t.Error("intent missing from container spec (should be the first-class Intent field, not metadata)")
 	}
 	if rig.loops.GetByName("home_automation") == nil {
 		t.Error("container not registered in live registry after launch")

--- a/internal/tools/loop_intent_tools.go
+++ b/internal/tools/loop_intent_tools.go
@@ -174,11 +174,9 @@ func (r *Registry) handleThaneCreateContainer(ctx context.Context, args map[stri
 		Name:       name,
 		Enabled:    true,
 		Operation:  looppkg.OperationContainer,
+		Intent:     intent,
 		Tags:       tags,
 		ParentName: parentName,
-		Metadata: map[string]string{
-			"intent": intent,
-		},
 	}
 	if err := spec.ValidatePersistable(); err != nil {
 		return "", fmt.Errorf("derived container spec invalid: %w", err)
@@ -467,6 +465,7 @@ func (r *Registry) handleThaneCurate(ctx context.Context, args map[string]any) (
 		Name:          name,
 		Enabled:       true,
 		Task:          buildCurateTask(intent, documentRef, outputMode, outputSpec.ToolName()),
+		Intent:        intent,
 		Operation:     looppkg.OperationService,
 		SleepMin:      envelope.sleepMin,
 		SleepMax:      envelope.sleepMax,

--- a/internal/tools/loop_intent_tools_test.go
+++ b/internal/tools/loop_intent_tools_test.go
@@ -351,6 +351,14 @@ func TestThaneCurate_EndToEnd(t *testing.T) {
 	if found.Spec.Profile.QualityFloor != 7 {
 		t.Errorf("Profile.QualityFloor = %d, want 7", found.Spec.Profile.QualityFloor)
 	}
+	// #1106 C1: intent lands on the first-class Spec.Intent field, not the
+	// metadata bag. (operator metadata {"team":"release"} stays separate.)
+	if found.Spec.Intent != "Track v1.0 PR activity for the upcoming release." {
+		t.Errorf("curate Spec.Intent = %q, want the first-class intent field populated", found.Spec.Intent)
+	}
+	if _, leaked := found.Spec.Metadata["intent"]; leaked {
+		t.Error("curate leaked intent into metadata; it must use the first-class Intent field")
+	}
 	// exclude_tools is a trimmed, de-duplicated union over the egress floor:
 	// the duplicate "exec" collapses to one entry, and the whitespace-padded
 	// "  email_send  " trims and folds into the existing egress entry rather

--- a/internal/tools/loop_spec_schema.go
+++ b/internal/tools/loop_spec_schema.go
@@ -33,6 +33,10 @@ func loopSpecSchema(description string) map[string]any {
 				"type":        "string",
 				"description": "Static prompt run each iteration.",
 			},
+			"intent": map[string]any{
+				"type":        "string",
+				"description": "One- or two-sentence statement of why this loop exists — its purpose, distinct from task. Surfaced as LoopView.intent across loop tools. Set this top-level field; do not put intent in metadata.",
+			},
 			"operation": map[string]any{
 				"type":        "string",
 				"enum":        []string{"request_reply", "background_task", "service", "container", "event_driven"},

--- a/internal/tools/loop_spec_schema_test.go
+++ b/internal/tools/loop_spec_schema_test.go
@@ -30,7 +30,7 @@ func TestLoopSpecSchemaEnumeratesAuthorableFields(t *testing.T) {
 		t.Fatal("properties missing or wrong type")
 	}
 	for _, key := range []string{
-		"name", "enabled", "task", "operation", "profile", "supervisor",
+		"name", "enabled", "task", "intent", "operation", "profile", "supervisor",
 		"supervisor_prob", "supervisor_profile", "outputs", "tags",
 		"exclude_tools", "sleep_min", "sleep_max", "sleep_default", "jitter",
 		"max_duration", "max_iter", "on_retrigger", "conditions", "completion",


### PR DESCRIPTION
First slice of #1106 (the **C → B → A** loop-tooling arc): **C1**, promoting `intent` out of the opaque metadata bag into a first-class `Spec.Intent` field — the schema foundation the later placement inference (A) depends on.

## Why

`intent` lived only in `Metadata["intent"]`, written by `thane_create_container` but **not** `thane_curate` (which bakes intent into `Task` and the output-doc frontmatter, but never stored it in metadata). So `LoopView.Intent` was effectively **container-only** — curate service loops showed a blank intent. Promoting it to a real field makes intent uniformly populated across all model-authored loops for the first time, and gets placement-relevant structure out of the bag that birthed #1102.

## What changed (mirrors the #1103 `parent_name` promotion)

- `Spec.Intent` + `Config.Intent`; `ToConfig` resolves the field, **falling back to `metadata["intent"]` for one release** (`resolveIntent`).
- `LoopView` reads the resolved `Config.Intent` (was `Metadata["intent"]`).
- `specJSON` round-trips the field; the loop spec schema advertises `intent`.
- `thane_curate` + `thane_create_container` both write the field. Curate's `Task` injection of intent is **unchanged**, so the per-iteration prompt is unaffected — service loops simply gain a populated `intent` too.
- `metadata.intent` gets a **deprecation** shadow-warning ("still read this release as a fallback; set the top-level field — removed next release"), deliberately distinct from `parent_name`'s *inert* message, since intent is genuinely still read during the transition.
- example config's `office_watch` loop gains a sample `intent`.

## Test plan
- [x] `TestSpecIntent_ToConfigResolution` — field preferred, metadata fallback, whitespace-only falls back, empty when neither
- [x] `TestSpecIntent_JSONRoundTrip` — field survives the custom `specJSON` wire format
- [x] `TestSpecIntent_LoopViewReadsResolved` — `LoopView.Intent` reads field and (via `ToConfig`) the fallback
- [x] metadata-shadow test gains an `intent` case asserting the deprecation wording (not "inert")
- [x] `TestThaneCurate_EndToEnd` now asserts `Spec.Intent` is set and **not** leaked into metadata; container test asserts the field
- [x] spec-schema enumeration guards `intent`
- [x] `just ci` green (incl. regenerated `examples/config.example.yaml`)

Refs #1106. Next: **C2** (origin provenance), then **B** (LoopView rollout), then **A** (`thane_loop_create`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
