### PR TITLE
fix(loops): catalog loop_reparent so the model is actually offered it (#1106)

### DIFF
--- a/internal/model/toolcatalog/catalog.go
+++ b/internal/model/toolcatalog/catalog.go
@@ -253,6 +253,7 @@ var builtinToolSpecs = map[string]BuiltinToolSpec{
 	"loop_definition_set":         {CanonicalID: "native:loop_definition_set", Source: NativeToolSource, Tags: []string{"loops"}},
 	"loop_definition_set_policy":  {CanonicalID: "native:loop_definition_set_policy", Source: NativeToolSource, Tags: []string{"loops"}},
 	"loop_definition_summary":     {CanonicalID: "native:loop_definition_summary", Source: NativeToolSource, Tags: []string{"loops"}},
+	"loop_reparent":               {CanonicalID: "native:loop_reparent", Source: NativeToolSource, Tags: []string{"loops"}},
 	"spawn_loop":                  {CanonicalID: "native:spawn_loop", Source: NativeToolSource, Tags: []string{"loops"}},
 	"stop_loop":                   {CanonicalID: "native:stop_loop", Source: NativeToolSource, Tags: []string{"loops"}},
 	"thane_assign":                {CanonicalID: "native:thane_assign", Source: NativeToolSource},

--- a/internal/tools/loop_tool_catalog_test.go
+++ b/internal/tools/loop_tool_catalog_test.go
@@ -1,7 +1,8 @@
 package tools
 
 import (
-	"sort"
+	"slices"
+	"strings"
 	"testing"
 
 	"github.com/nugget/thane-ai-agent/internal/model/toolcatalog"
@@ -10,32 +11,41 @@ import (
 
 // TestLoopToolsAreCatalogued guards against the loop_reparent (#1105) gap: a loop
 // tool can ship with a working handler yet be invisible to every model loop if it
-// has no toolcatalog entry — the catalog is what assigns the `loops` tag and makes
-// a tool discoverable and offered. loop_reparent was registered but never
-// catalogued, so the model was never offered it and reparented by hand.
+// isn't actually offered to loops-gated sessions. Being offered takes two things —
+// a toolcatalog entry AND the `loops` capability tag on that entry, since the tag
+// is what gates visibility. loop_reparent was registered but never catalogued, so
+// the model was never offered it and reparented loops by hand.
 //
 // This enumerates the loop tool families (definition + runtime) and asserts every
-// registered tool has a catalog entry, so a future loop tool can't silently ship
-// dead the same way.
+// registered tool is both catalogued and `loops`-tagged, so a future loop tool
+// can't silently ship dead either way: by skipping the catalog entirely, or by
+// landing a catalog entry without the tag that actually gates it into scope.
 func TestLoopToolsAreCatalogued(t *testing.T) {
 	defs, err := looppkg.NewDefinitionRegistry(nil)
 	if err != nil {
 		t.Fatalf("NewDefinitionRegistry: %v", err)
 	}
 
+	// Start from an empty registry and configure only the loop tool families, so
+	// AllToolNames() is exactly the set under test.
 	r := NewEmptyRegistry()
 	// Stub registries are enough to register the tools; handlers aren't called.
 	r.ConfigureLoopDefinitionTools(LoopDefinitionToolDeps{Registry: defs})
 	r.ConfigureLoopRuntimeTools(LoopRuntimeToolDeps{Registry: looppkg.NewRegistry()})
 
-	var uncatalogued []string
-	for name := range r.tools {
-		if _, ok := toolcatalog.LookupBuiltinToolSpec(name); !ok {
-			uncatalogued = append(uncatalogued, name)
+	var problems []string
+	for _, name := range r.AllToolNames() {
+		spec, ok := toolcatalog.LookupBuiltinToolSpec(name)
+		if !ok {
+			problems = append(problems, name+" — no builtin catalog entry")
+			continue
+		}
+		if !slices.Contains(spec.Tags, "loops") {
+			problems = append(problems, name+" — catalogued but missing the \"loops\" tag")
 		}
 	}
-	if len(uncatalogued) > 0 {
-		sort.Strings(uncatalogued)
-		t.Errorf("loop tools registered but absent from the builtin tool catalog — they will never be offered to a model loop: %v", uncatalogued)
+	if len(problems) > 0 {
+		t.Errorf("loop tools that will not be offered to a loops-gated model session:\n  %s",
+			strings.Join(problems, "\n  "))
 	}
 }

--- a/internal/tools/loop_tool_catalog_test.go
+++ b/internal/tools/loop_tool_catalog_test.go
@@ -1,0 +1,41 @@
+package tools
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/nugget/thane-ai-agent/internal/model/toolcatalog"
+	looppkg "github.com/nugget/thane-ai-agent/internal/runtime/loop"
+)
+
+// TestLoopToolsAreCatalogued guards against the loop_reparent (#1105) gap: a loop
+// tool can ship with a working handler yet be invisible to every model loop if it
+// has no toolcatalog entry — the catalog is what assigns the `loops` tag and makes
+// a tool discoverable and offered. loop_reparent was registered but never
+// catalogued, so the model was never offered it and reparented by hand.
+//
+// This enumerates the loop tool families (definition + runtime) and asserts every
+// registered tool has a catalog entry, so a future loop tool can't silently ship
+// dead the same way.
+func TestLoopToolsAreCatalogued(t *testing.T) {
+	defs, err := looppkg.NewDefinitionRegistry(nil)
+	if err != nil {
+		t.Fatalf("NewDefinitionRegistry: %v", err)
+	}
+
+	r := NewEmptyRegistry()
+	// Stub registries are enough to register the tools; handlers aren't called.
+	r.ConfigureLoopDefinitionTools(LoopDefinitionToolDeps{Registry: defs})
+	r.ConfigureLoopRuntimeTools(LoopRuntimeToolDeps{Registry: looppkg.NewRegistry()})
+
+	var uncatalogued []string
+	for name := range r.tools {
+		if _, ok := toolcatalog.LookupBuiltinToolSpec(name); !ok {
+			uncatalogued = append(uncatalogued, name)
+		}
+	}
+	if len(uncatalogued) > 0 {
+		sort.Strings(uncatalogued)
+		t.Errorf("loop tools registered but absent from the builtin tool catalog — they will never be offered to a model loop: %v", uncatalogued)
+	}
+}


### PR DESCRIPTION
## Why

`loop_reparent` shipped in **v0.10.0** (#1105) with a working handler + tests, and prod runs v0.10.0 — but it has **no entry in the builtin tool catalog** (`internal/model/toolcatalog/catalog.go`). The catalog is what assigns a native tool its `loops` tag and makes it *discoverable and offered* to a model loop. Every other loop tool is catalogued; `loop_reparent` was missed, so it shipped **dead** — no loop is ever offered it.

Caught in prod request `r_81e65a55af96da69`: David asked over Signal *"can you reparent ranch_climate_watch to the hor container?"* — the exact use case. The model's tool catalog that turn had `loop_definition_get/set/launch`, `loop_status`, `stop_loop` but **not** `loop_reparent`, so it did the job by hand (`loop_definition_set` parent_name → `stop_loop` → relaunch, 8 iterations) and even narrated the "sticky-parent" friction `loop_reparent` exists to eliminate.

## What changed

- **Catalog `loop_reparent`** under the `loops` tag, alongside the rest of the family. One line; makes the shipped tool actually usable.
- **Drift guard** — `TestLoopToolsAreCatalogued` registers the loop tool families (definition + runtime) and asserts every registered tool has a catalog entry. This would have failed on `loop_reparent` before the fix, and stops a future loop tool from shipping invisible the same way. (The existing `catalog_test` only spot-checked named tools, which is how this slipped through.)

Belongs to #1106 (making the model's native loop tooling coherent and actually usable). No deploy/runtime change needed beyond shipping — once merged + released, loops with `loops` active are offered `loop_reparent`.

## Test plan
- [x] `TestLoopToolsAreCatalogued` passes (and fails without the catalog entry)
- [x] `toolcatalog` + `tools` package tests green
- [x] `just ci` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
