### PR TITLE
feat(loops): stamp first-class origin provenance at the commit chokepoint (#1106 C2)

### DIFF
--- a/examples/config.example.yaml
+++ b/examples/config.example.yaml
@@ -1096,6 +1096,11 @@ archivist:
 #         category: observer
 #       parent_id: ""
 #       parent_name: ""
+#       origin:
+#         request_id: ""
+#         conversation_id: ""
+#         created_by_loop_id: ""
+#         created_at: {}
 #
 # (optional) Debug configures diagnostic options for inspecting the assembled
 # debug:

--- a/examples/config.example.yaml
+++ b/examples/config.example.yaml
@@ -1096,11 +1096,6 @@ archivist:
 #         category: observer
 #       parent_id: ""
 #       parent_name: ""
-#       origin:
-#         request_id: ""
-#         conversation_id: ""
-#         created_by_loop_id: ""
-#         created_at: {}
 #
 # (optional) Debug configures diagnostic options for inspecting the assembled
 # debug:

--- a/internal/app/loop_definition_runtime.go
+++ b/internal/app/loop_definition_runtime.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/nugget/thane-ai-agent/internal/platform/events"
 	looppkg "github.com/nugget/thane-ai-agent/internal/runtime/loop"
+	"github.com/nugget/thane-ai-agent/internal/tools"
 )
 
 // loopDefinitionBootstrapResult summarizes one startup reconciliation
@@ -683,6 +684,12 @@ func (a *App) reconcileLoopDefinition(ctx context.Context, name string) error {
 // prefixed, while the Upsert error is returned bare so callers that
 // inspect it (errors.As for ImmutableDefinitionError) keep working.
 func (a *App) commitLoopDefinition(ctx context.Context, spec looppkg.Spec, updatedAt time.Time) error {
+	// Stamp authoritative creation provenance (#1106 C2). This is the single
+	// place that owns origin: it overwrites any model-supplied value (so it
+	// can't be forged) and preserves the original creation provenance across
+	// later updates/replaces.
+	spec.Origin = a.authoritativeOrigin(ctx, spec.Name, updatedAt)
+
 	if err := a.persistLoopDefinition(spec, updatedAt); err != nil {
 		return &looppkg.CommitError{Stage: looppkg.CommitStagePersist, Err: err}
 	}
@@ -695,6 +702,38 @@ func (a *App) commitLoopDefinition(ctx context.Context, spec looppkg.Spec, updat
 		return &looppkg.CommitError{Stage: looppkg.CommitStageReconcile, Err: err}
 	}
 	return nil
+}
+
+// authoritativeOrigin returns the creation provenance to stamp on a definition
+// being committed. It preserves the original creation provenance across updates
+// and replaces by carrying forward any origin already on the stored definition;
+// only a genuinely new definition is stamped fresh from the authoring turn's
+// context (nil when there is no authoring identity).
+func (a *App) authoritativeOrigin(ctx context.Context, name string, now time.Time) *looppkg.OriginInfo {
+	if a.loopDefinitionRegistry != nil {
+		if existing, ok := a.loopDefinitionRegistry.Get(name); ok && existing.Origin != nil {
+			return existing.Origin.Clone()
+		}
+	}
+	return originFromContext(ctx, now)
+}
+
+// originFromContext builds creation provenance from the authoring turn's
+// context, or nil when there is no authoring identity (e.g. config-sourced
+// definitions hydrated at startup carry no request or loop id). conversation_id
+// defaults to "default", so it is not used as the identity signal.
+func originFromContext(ctx context.Context, now time.Time) *looppkg.OriginInfo {
+	reqID := tools.RequestIDFromContext(ctx)
+	byLoop := tools.LoopIDFromContext(ctx)
+	if reqID == "" && byLoop == "" {
+		return nil
+	}
+	return &looppkg.OriginInfo{
+		RequestID:       reqID,
+		ConversationID:  tools.ConversationIDFromContext(ctx),
+		CreatedByLoopID: byLoop,
+		CreatedAt:       now,
+	}
 }
 
 func (a *App) launchLoopDefinition(ctx context.Context, name string, launch looppkg.Launch) (looppkg.LaunchResult, error) {

--- a/internal/app/loop_definition_runtime.go
+++ b/internal/app/loop_definition_runtime.go
@@ -705,13 +705,20 @@ func (a *App) commitLoopDefinition(ctx context.Context, spec looppkg.Spec, updat
 }
 
 // authoritativeOrigin returns the creation provenance to stamp on a definition
-// being committed. It preserves the original creation provenance across updates
-// and replaces by carrying forward any origin already on the stored definition;
-// only a genuinely new definition is stamped fresh from the authoring turn's
-// context (nil when there is no authoring identity).
+// being committed. Existence is the discriminator: if the name already exists in
+// the registry, its stored origin is carried forward unchanged — including none
+// at all, for config-sourced or pre-C2 definitions that never recorded one. An
+// edit or replace must never be recorded as the creation, so an existing
+// definition is never re-stamped from the editing turn. Only a genuinely new
+// name is stamped fresh from the authoring turn's context (nil when there is no
+// authoring identity).
+//
+// Startup hydration loads persisted definitions straight into the registry via
+// loopDefinitionStore.LoadInto, bypassing this chokepoint, so a persisted origin
+// is never seen by — and so never wiped by — this path on restart.
 func (a *App) authoritativeOrigin(ctx context.Context, name string, now time.Time) *looppkg.OriginInfo {
 	if a.loopDefinitionRegistry != nil {
-		if existing, ok := a.loopDefinitionRegistry.Get(name); ok && existing.Origin != nil {
+		if existing, ok := a.loopDefinitionRegistry.Get(name); ok {
 			return existing.Origin.Clone()
 		}
 	}

--- a/internal/app/loop_origin_test.go
+++ b/internal/app/loop_origin_test.go
@@ -88,3 +88,25 @@ func TestAuthoritativeOrigin_StampsNewDefinition(t *testing.T) {
 		t.Fatalf("new definition origin = %+v", got)
 	}
 }
+
+// TestAuthoritativeOrigin_ExistingWithoutOriginStaysNil guards the #1125 review
+// fix: an existing definition that carries no origin (config-sourced or pre-C2)
+// must NOT be re-stamped on a later edit — that would record the editing turn as
+// the creation. Existence, not non-nil origin, is the discriminator.
+func TestAuthoritativeOrigin_ExistingWithoutOriginStaysNil(t *testing.T) {
+	defs, err := looppkg.NewDefinitionRegistry(nil)
+	if err != nil {
+		t.Fatalf("NewDefinitionRegistry: %v", err)
+	}
+	// A pre-existing definition with NO origin (e.g. a config-sourced loop).
+	if err := defs.Upsert(looppkg.Spec{Name: "config_loop", Enabled: true, Task: "watch", Operation: looppkg.OperationService}, time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)); err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+	a := &App{loopDefinitionRegistry: defs}
+
+	// A later edit from a real authoring turn must not fabricate creation origin.
+	got := a.authoritativeOrigin(authoringCtx("r_edit", "conv-2", "lp_b"), "config_loop", time.Now())
+	if got != nil {
+		t.Errorf("existing origin-less definition must stay origin-less on edit, got %+v", got)
+	}
+}

--- a/internal/app/loop_origin_test.go
+++ b/internal/app/loop_origin_test.go
@@ -1,0 +1,90 @@
+package app
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	looppkg "github.com/nugget/thane-ai-agent/internal/runtime/loop"
+	"github.com/nugget/thane-ai-agent/internal/tools"
+)
+
+func authoringCtx(reqID, convID, loopID string) context.Context {
+	ctx := context.Background()
+	if reqID != "" {
+		ctx = tools.WithRequestID(ctx, reqID)
+	}
+	if convID != "" {
+		ctx = tools.WithConversationID(ctx, convID)
+	}
+	if loopID != "" {
+		ctx = tools.WithLoopID(ctx, loopID)
+	}
+	return ctx
+}
+
+// TestOriginFromContext_StampsAuthoringIdentity confirms a real authoring turn
+// produces full provenance from the tool context.
+func TestOriginFromContext_StampsAuthoringIdentity(t *testing.T) {
+	now := time.Date(2026, 6, 30, 9, 0, 0, 0, time.UTC)
+	got := originFromContext(authoringCtx("r_new", "conv-9", "lp_x"), now)
+	if got == nil {
+		t.Fatal("expected origin from an authoring turn")
+	}
+	if got.RequestID != "r_new" || got.ConversationID != "conv-9" ||
+		got.CreatedByLoopID != "lp_x" || !got.CreatedAt.Equal(now) {
+		t.Errorf("origin = %+v", got)
+	}
+}
+
+// TestOriginFromContext_NilWithoutIdentity guards the config-hydration case: a
+// bare context carries no request or loop id, and conversation_id's "default"
+// fallback must not, by itself, stamp a hollow origin.
+func TestOriginFromContext_NilWithoutIdentity(t *testing.T) {
+	if got := originFromContext(context.Background(), time.Now()); got != nil {
+		t.Errorf("expected nil origin without authoring identity, got %+v", got)
+	}
+}
+
+// TestAuthoritativeOrigin_PreservesCreationProvenance is the core C2 invariant:
+// a later update/replace from a DIFFERENT turn keeps the original creation
+// origin rather than re-stamping it with the editing turn.
+func TestAuthoritativeOrigin_PreservesCreationProvenance(t *testing.T) {
+	defs, err := looppkg.NewDefinitionRegistry(nil)
+	if err != nil {
+		t.Fatalf("NewDefinitionRegistry: %v", err)
+	}
+	created := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	orig := &looppkg.OriginInfo{
+		RequestID:       "r_orig",
+		ConversationID:  "conv-1",
+		CreatedByLoopID: "lp_a",
+		CreatedAt:       created,
+	}
+	if err := defs.Upsert(looppkg.Spec{Name: "watcher", Enabled: true, Task: "watch the reservoir", Operation: looppkg.OperationService, Origin: orig}, created); err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+	a := &App{loopDefinitionRegistry: defs}
+
+	got := a.authoritativeOrigin(authoringCtx("r_later", "conv-2", "lp_b"), "watcher", time.Now())
+	if got == nil || got.RequestID != "r_orig" || !got.CreatedAt.Equal(created) {
+		t.Fatalf("update must preserve creation origin, got %+v", got)
+	}
+}
+
+// TestAuthoritativeOrigin_StampsNewDefinition confirms a genuinely new name is
+// stamped fresh from the committing turn.
+func TestAuthoritativeOrigin_StampsNewDefinition(t *testing.T) {
+	defs, err := looppkg.NewDefinitionRegistry(nil)
+	if err != nil {
+		t.Fatalf("NewDefinitionRegistry: %v", err)
+	}
+	a := &App{loopDefinitionRegistry: defs}
+	now := time.Date(2026, 6, 30, 0, 0, 0, 0, time.UTC)
+
+	got := a.authoritativeOrigin(authoringCtx("r_fresh", "conv-7", "lp_z"), "brand_new", now)
+	if got == nil || got.RequestID != "r_fresh" || got.CreatedByLoopID != "lp_z" ||
+		got.ConversationID != "conv-7" || !got.CreatedAt.Equal(now) {
+		t.Fatalf("new definition origin = %+v", got)
+	}
+}

--- a/internal/runtime/agent/loop.go
+++ b/internal/runtime/agent/loop.go
@@ -2250,6 +2250,7 @@ func (l *Loop) Run(ctx context.Context, req *Request, stream StreamCallback) (re
 			}
 			toolCtx = tools.WithToolCallID(toolCtx, toolCallIDStr)
 			toolCtx = tools.WithIterationIndex(toolCtx, i)
+			toolCtx = tools.WithRequestID(toolCtx, requestID)
 			if lid := loop.LoopIDFromContext(ctx); lid != "" {
 				toolCtx = tools.WithLoopID(toolCtx, lid)
 			} else if lid := req.RoutingFactors["loop_id"]; lid != "" {

--- a/internal/runtime/loop/origin_test.go
+++ b/internal/runtime/loop/origin_test.go
@@ -5,7 +5,35 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"gopkg.in/yaml.v3"
 )
+
+// TestSpecOrigin_ExcludedFromYAML guards the #1125 review fix: origin is
+// runtime-stamped, not config-authorable, so it must not serialize to YAML —
+// otherwise the generated config example carries an invalid zero-time
+// placeholder (created_at: {}) that fails to parse if uncommented. JSON still
+// carries it (the overlay is JSON); that path is covered by the round-trip test.
+func TestSpecOrigin_ExcludedFromYAML(t *testing.T) {
+	spec := Spec{
+		Name:      "canyon_lake_watch",
+		Operation: OperationService,
+		Origin: &OriginInfo{
+			RequestID:       "r_x",
+			CreatedByLoopID: "lp_x",
+			CreatedAt:       time.Date(2026, 6, 30, 0, 0, 0, 0, time.UTC),
+		},
+	}
+	out, err := yaml.Marshal(spec)
+	if err != nil {
+		t.Fatalf("yaml.Marshal: %v", err)
+	}
+	for _, leak := range []string{"origin", "created_by_loop_id", "created_at"} {
+		if strings.Contains(string(out), leak) {
+			t.Errorf("origin must not serialize to YAML (found %q):\n%s", leak, out)
+		}
+	}
+}
 
 // TestSpecOrigin_JSONRoundTrip confirms the first-class Origin provenance
 // survives the custom specJSON wire format (#1106 C2).

--- a/internal/runtime/loop/origin_test.go
+++ b/internal/runtime/loop/origin_test.go
@@ -1,0 +1,61 @@
+package loop
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestSpecOrigin_JSONRoundTrip confirms the first-class Origin provenance
+// survives the custom specJSON wire format (#1106 C2).
+func TestSpecOrigin_JSONRoundTrip(t *testing.T) {
+	created := time.Date(2026, 6, 30, 12, 0, 0, 0, time.UTC)
+	spec := Spec{
+		Name:      "canyon_lake_watch",
+		Operation: OperationService,
+		Origin: &OriginInfo{
+			RequestID:       "r_81e65a55af96da69",
+			ConversationID:  "loop-signal-42",
+			CreatedByLoopID: "lp_signal",
+			CreatedAt:       created,
+		},
+	}
+	data, err := json.Marshal(spec)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if !strings.Contains(string(data), `"created_by_loop_id":"lp_signal"`) {
+		t.Errorf("marshaled JSON missing origin pointers: %s", data)
+	}
+
+	var got Spec
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if got.Origin == nil {
+		t.Fatal("round-trip dropped origin")
+	}
+	if got.Origin.RequestID != "r_81e65a55af96da69" ||
+		got.Origin.ConversationID != "loop-signal-42" ||
+		got.Origin.CreatedByLoopID != "lp_signal" ||
+		!got.Origin.CreatedAt.Equal(created) {
+		t.Errorf("round-trip origin mismatch: %+v", got.Origin)
+	}
+}
+
+func TestOriginInfo_Clone(t *testing.T) {
+	var nilOrigin *OriginInfo
+	if nilOrigin.Clone() != nil {
+		t.Error("nil.Clone() should be nil")
+	}
+	o := &OriginInfo{RequestID: "r_1"}
+	c := o.Clone()
+	if c == o {
+		t.Error("Clone returned the same pointer")
+	}
+	c.RequestID = "r_2"
+	if o.RequestID != "r_1" {
+		t.Error("Clone aliased the original")
+	}
+}

--- a/internal/runtime/loop/spec.go
+++ b/internal/runtime/loop/spec.go
@@ -296,6 +296,42 @@ type Spec struct {
 	// Today only container parents are honored (children of services
 	// have no inheritance semantics).
 	ParentName string `yaml:"parent_name,omitempty" json:"parent_name,omitempty"`
+
+	// Origin is the creation provenance of this definition: pointers (plain
+	// foreign keys) back to the request, conversation, and loop that authored
+	// it, plus when. Runtime-stamped at the durable commit chokepoint (#1106
+	// C2) and authoritative — a model-supplied origin is overwritten, and the
+	// original creation provenance is preserved across later updates/replaces.
+	// Resolved on demand against the request/conversation stores; no turn
+	// snapshot is stored here. Nil for definitions authored outside a runtime
+	// authoring context (e.g. config-sourced loops).
+	Origin *OriginInfo `yaml:"origin,omitempty" json:"origin,omitempty"`
+}
+
+// OriginInfo records who/what/when created a loop definition — pointer-only
+// provenance (#1106 C2). The ids are foreign keys resolved on demand against
+// the primary-source stores (request store, conversation store), not copies of
+// any content.
+type OriginInfo struct {
+	// RequestID is the model request (r_…) whose turn authored the definition.
+	RequestID string `yaml:"request_id,omitempty" json:"request_id,omitempty"`
+	// ConversationID is the conversation that turn belonged to.
+	ConversationID string `yaml:"conversation_id,omitempty" json:"conversation_id,omitempty"`
+	// CreatedByLoopID is the live loop ID that ran the authoring turn.
+	CreatedByLoopID string `yaml:"created_by_loop_id,omitempty" json:"created_by_loop_id,omitempty"`
+	// CreatedAt is when the definition was first committed.
+	CreatedAt time.Time `yaml:"created_at,omitempty" json:"created_at,omitempty"`
+}
+
+// Clone returns a copy of the origin (or nil). OriginInfo holds only value
+// types, so a shallow copy is a deep copy; the method exists to make the
+// preserve-across-update intent explicit at call sites.
+func (o *OriginInfo) Clone() *OriginInfo {
+	if o == nil {
+		return nil
+	}
+	cp := *o
+	return &cp
 }
 
 // IsZero reports whether the spec is the zero value (no fields set).

--- a/internal/runtime/loop/spec.go
+++ b/internal/runtime/loop/spec.go
@@ -305,22 +305,28 @@ type Spec struct {
 	// Resolved on demand against the request/conversation stores; no turn
 	// snapshot is stored here. Nil for definitions authored outside a runtime
 	// authoring context (e.g. config-sourced loops).
-	Origin *OriginInfo `yaml:"origin,omitempty" json:"origin,omitempty"`
+	//
+	// `yaml:"-"`: origin is not config-authorable — it is runtime-stamped and
+	// would otherwise surface in the generated config example as an invalid
+	// zero-time placeholder. It still persists in the dynamic overlay, which is
+	// JSON (see loopDefinitionStore), routed through the custom specJSON wire.
+	Origin *OriginInfo `yaml:"-" json:"origin,omitempty"`
 }
 
 // OriginInfo records who/what/when created a loop definition — pointer-only
 // provenance (#1106 C2). The ids are foreign keys resolved on demand against
 // the primary-source stores (request store, conversation store), not copies of
-// any content.
+// any content. JSON-only: origin is never YAML-serialized (its Spec field is
+// `yaml:"-"`), and the overlay that persists it is JSON.
 type OriginInfo struct {
 	// RequestID is the model request (r_…) whose turn authored the definition.
-	RequestID string `yaml:"request_id,omitempty" json:"request_id,omitempty"`
+	RequestID string `json:"request_id,omitempty"`
 	// ConversationID is the conversation that turn belonged to.
-	ConversationID string `yaml:"conversation_id,omitempty" json:"conversation_id,omitempty"`
+	ConversationID string `json:"conversation_id,omitempty"`
 	// CreatedByLoopID is the live loop ID that ran the authoring turn.
-	CreatedByLoopID string `yaml:"created_by_loop_id,omitempty" json:"created_by_loop_id,omitempty"`
+	CreatedByLoopID string `json:"created_by_loop_id,omitempty"`
 	// CreatedAt is when the definition was first committed.
-	CreatedAt time.Time `yaml:"created_at,omitempty" json:"created_at,omitempty"`
+	CreatedAt time.Time `json:"created_at,omitempty"`
 }
 
 // Clone returns a copy of the origin (or nil). OriginInfo holds only value

--- a/internal/runtime/loop/spec_json.go
+++ b/internal/runtime/loop/spec_json.go
@@ -44,6 +44,7 @@ type specJSON struct {
 	Metadata          map[string]string   `json:"metadata,omitempty"`
 	ParentID          string              `json:"parent_id,omitempty"`
 	ParentName        string              `json:"parent_name,omitempty"`
+	Origin            *OriginInfo         `json:"origin,omitempty"`
 
 	// Legacy top-level fields, accepted on UnmarshalJSON for backwards
 	// compatibility with persisted overlay specs written before the
@@ -91,6 +92,7 @@ func (s Spec) MarshalJSON() ([]byte, error) {
 		Metadata:          s.Metadata,
 		ParentID:          s.ParentID,
 		ParentName:        s.ParentName,
+		Origin:            s.Origin.Clone(),
 	}
 	onRetrigger, err := s.OnRetrigger.MarshalText()
 	if err != nil {
@@ -170,6 +172,7 @@ func (s *Spec) UnmarshalJSON(data []byte) error {
 		Metadata:         cloneStringMap(wire.Metadata),
 		ParentID:         wire.ParentID,
 		ParentName:       wire.ParentName,
+		Origin:           wire.Origin.Clone(),
 	}
 	profileData, err := json.Marshal(wire.Profile)
 	if err != nil {

--- a/internal/tools/context.go
+++ b/internal/tools/context.go
@@ -18,6 +18,7 @@ const hintsKey contextKey = "hints"
 const loopIDKey contextKey = "loop_id"
 const channelBindingKey contextKey = "channel_binding"
 const inheritableCapabilityTagsKey contextKey = "inheritable_capability_tags"
+const requestIDKey contextKey = "request_id"
 
 // WithConversationID adds the conversation ID to the context.
 func WithConversationID(ctx context.Context, id string) context.Context {
@@ -31,6 +32,22 @@ func ConversationIDFromContext(ctx context.Context) string {
 		return id
 	}
 	return "default"
+}
+
+// WithRequestID adds the model request ID (r_…) of the current turn to the
+// context, so a tool can record which request authored a side effect (e.g. loop
+// origin provenance, #1106 C2).
+func WithRequestID(ctx context.Context, id string) context.Context {
+	return context.WithValue(ctx, requestIDKey, id)
+}
+
+// RequestIDFromContext extracts the model request ID from the context, or ""
+// when none is set (e.g. outside a model turn).
+func RequestIDFromContext(ctx context.Context) string {
+	if id, ok := ctx.Value(requestIDKey).(string); ok {
+		return id
+	}
+	return ""
 }
 
 // WithSessionID adds the archive session ID to the context. This allows

--- a/internal/tools/context_request_id_test.go
+++ b/internal/tools/context_request_id_test.go
@@ -1,0 +1,18 @@
+package tools
+
+import (
+	"context"
+	"testing"
+)
+
+// TestRequestIDContext_RoundTrip covers the request_id carrier added so tools
+// can record which model turn authored a side effect (#1106 C2 loop origin).
+func TestRequestIDContext_RoundTrip(t *testing.T) {
+	if got := RequestIDFromContext(context.Background()); got != "" {
+		t.Errorf("bare context request id = %q, want empty", got)
+	}
+	ctx := WithRequestID(context.Background(), "r_abc123")
+	if got := RequestIDFromContext(ctx); got != "r_abc123" {
+		t.Errorf("request id = %q, want r_abc123", got)
+	}
+}


### PR DESCRIPTION
## What

Second of the #1106 Container-corpus Tier-1 schema steps (after C1's `Spec.Intent`): promote loop **creation provenance** to a first-class `Spec.Origin`.

```go
type OriginInfo struct {
    RequestID       string    // r_… that authored the definition
    ConversationID  string    // conversation that turn belonged to
    CreatedByLoopID string    // live loop ID that ran the authoring turn
    CreatedAt       time.Time // first commit
}
```

**Pointer-only** (the decided shape): these are plain foreign keys resolved on demand against the request/conversation stores — no turn snapshot is copied onto the loop.

## How

- **`Spec.Origin *OriginInfo`**, round-tripped through the custom `specJSON` wire format (placed away from C1's `Intent` to keep the two PRs merge-clean).
- **`commitLoopDefinition`** — the single durable-commit chokepoint every authoring surface routes through — **owns** origin:
  - **Authoritative**: it always overwrites any model-supplied `origin`, so provenance can't be forged via `loop_definition_set`.
  - **Preserve-on-edit**: it carries forward the existing stored origin across later updates/replaces, so the field stays the *creation* provenance, not the last-edit provenance.
  - **Stamp-if-new**: a genuinely new name is stamped from the authoring turn's context; nil when there's no authoring identity (e.g. config-sourced loops hydrated at startup).
- **Request-id threading**: the tool context already carries conversation/session/loop/iteration ids but not the model request id. Added `tools.WithRequestID` / `RequestIDFromContext` and one line in the agent tool-ctx assembly (where `requestID` is already in scope).
- **Not** added to the authoring schema (`loopSpecSchema`) — origin is runtime-stamped, not authored.

## Why it matters

When the model reparents/edits/recreates a loop, we lose track of *where a loop came from* — which Signal turn, which conversation, which parent loop spawned it. Origin is the durable backbone the loop corpus needs to answer "who created this and why" (and feeds the #1102 corpus-mirror direction). Pointer-only keeps it cheap: the heavy content stays in the primary-source stores and is fetched only when someone actually inspects a loop.

## Scope boundaries
- Ephemeral `spawn_loop` origin (no persisted spec) is **out of scope** here — noted as follow-up.
- Surfacing origin in `LoopView` / `loop_definition_get` is **#1106 B**. C2 just persists it.

## Test plan
- [x] `Spec.Origin` JSON round-trip + `OriginInfo.Clone` (`internal/runtime/loop/origin_test.go`)
- [x] `request_id` context round-trip (`internal/tools`)
- [x] stamping: stamp-from-turn, nil-without-identity, **preserve-across-update**, stamp-new (`internal/app/loop_origin_test.go`)
- [x] `just ci` green (incl. regenerated `examples/config.example.yaml`)

Refs #1106.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
