### PR TITLE
feat(loops): project loop_definition_get/list through the canonical LoopView (#1106 B1)

### DIFF
--- a/internal/app/loop_definition_runtime.go
+++ b/internal/app/loop_definition_runtime.go
@@ -153,23 +153,19 @@ func (r *loopDefinitionRuntime) definition(name string) (looppkg.DefinitionSnaps
 	return findLoopDefinitionByName(snap, name)
 }
 
-func (r *loopDefinitionRuntime) runtimeStatusByName() map[string]looppkg.DefinitionRuntimeStatus {
+// liveStatusByName returns the full live loop Status for every running loop,
+// keyed by definition name. The full Status (not the old thin runtime summary)
+// carries the economics, error state, and resolved effective_* inheritance the
+// canonical LoopView projection needs, so the view builder no longer re-walks
+// the registry for effective state.
+func (r *loopDefinitionRuntime) liveStatusByName() map[string]looppkg.Status {
 	if r == nil || r.loops == nil {
 		return nil
 	}
-	statuses := make(map[string]looppkg.DefinitionRuntimeStatus)
+	statuses := make(map[string]looppkg.Status)
 	for _, l := range r.loops.List() {
 		st := l.Status()
-		statuses[st.Name] = looppkg.DefinitionRuntimeStatus{
-			Running:    true,
-			LoopID:     st.ID,
-			State:      st.State,
-			StartedAt:  st.StartedAt,
-			LastWakeAt: st.LastWakeAt,
-			Iterations: st.Iterations,
-			Attempts:   st.Attempts,
-			LastError:  st.LastError,
-		}
+		statuses[st.Name] = st
 	}
 	return statuses
 }
@@ -180,8 +176,7 @@ func (r *loopDefinitionRuntime) Snapshot() *looppkg.DefinitionRegistryView {
 	}
 	return looppkg.BuildDefinitionRegistryView(
 		r.definitions.Snapshot(),
-		r.runtimeStatusByName(),
-		looppkg.WithLiveRegistry(r.loops),
+		r.liveStatusByName(),
 	)
 }
 
@@ -760,9 +755,12 @@ func (a *App) loopDefinitionView() *looppkg.DefinitionRegistryView {
 	if a.loopDefinitionRegistry == nil {
 		return nil
 	}
+	// Degenerate fallback (no loop-definition runtime wired): project every
+	// definition as stored-only. The prior WithLiveRegistry path never
+	// populated effective state here either — it gated on a running status that
+	// this nil-runtime build never supplied.
 	return looppkg.BuildDefinitionRegistryView(
 		a.loopDefinitionRegistry.Snapshot(),
 		nil,
-		looppkg.WithLiveRegistry(a.loopRegistry),
 	)
 }

--- a/internal/app/loop_definition_runtime_test.go
+++ b/internal/app/loop_definition_runtime_test.go
@@ -407,7 +407,10 @@ func TestLoopDefinitionRuntimeSnapshotIncludesRunningLoop(t *testing.T) {
 	if view.RunningDefinitions != 1 {
 		t.Fatalf("RunningDefinitions = %d, want 1", view.RunningDefinitions)
 	}
-	if len(view.Definitions) != 1 || !view.Definitions[0].Runtime.Running {
+	if len(view.Definitions) != 1 {
+		t.Fatalf("Definitions = %+v, want one running definition", view.Definitions)
+	}
+	if loop := view.Definitions[0].Loop; loop == nil || !loop.Running {
 		t.Fatalf("Definitions = %+v, want one running definition", view.Definitions)
 	}
 }

--- a/internal/runtime/loop/config.go
+++ b/internal/runtime/loop/config.go
@@ -165,6 +165,11 @@ type Config struct {
 	// [Spec.ToConfig] so readers (e.g. LoopView) take a single source.
 	Intent string
 
+	// Origin carries the creation provenance copied from [Spec.Origin] so a
+	// live loop's canonical view (FromStatus) surfaces the same origin a stored
+	// definition does (FromDefinition). Nil for loops with no recorded origin.
+	Origin *OriginInfo
+
 	// Operation describes the runtime pattern expected for the loop.
 	Operation Operation
 

--- a/internal/runtime/loop/definition_registry_test.go
+++ b/internal/runtime/loop/definition_registry_test.go
@@ -262,11 +262,13 @@ func TestBuildDefinitionRegistryViewIncludesRuntimeState(t *testing.T) {
 	}
 
 	now := time.Date(2026, 4, 6, 15, 0, 0, 0, time.UTC)
-	view := buildDefinitionRegistryViewAt(reg.Snapshot(), map[string]DefinitionRuntimeStatus{
+	view := buildDefinitionRegistryViewAt(reg.Snapshot(), map[string]Status{
+		// Presence in liveByName means the definition has a running backing
+		// loop; Name keys the join and State drives the runtime-state tally.
 		"metacog_like": {
-			Running: true,
-			LoopID:  "loop-123",
-			State:   StateSleeping,
+			Name:  "metacog_like",
+			ID:    "loop-123",
+			State: StateSleeping,
 		},
 	}, now)
 	if view == nil {
@@ -284,13 +286,22 @@ func TestBuildDefinitionRegistryViewIncludesRuntimeState(t *testing.T) {
 	if view.ByRuntimeState[string(StateSleeping)] != 1 || view.ByRuntimeState[definitionRuntimeStateNotRunning] != 1 {
 		t.Fatalf("ByRuntimeState = %+v, want sleeping=1 not_running=1", view.ByRuntimeState)
 	}
-	if !view.Definitions[0].Runtime.Running {
+	if view.Definitions[0].Loop == nil {
+		t.Fatal("metacog_like Loop view should never be nil")
+	}
+	if !view.Definitions[0].Loop.Running {
 		t.Fatal("metacog_like runtime should be running")
+	}
+	if view.Definitions[0].Loop.State == nil || *view.Definitions[0].Loop.State != string(StateSleeping) {
+		t.Fatalf("metacog_like state = %v, want sleeping", view.Definitions[0].Loop.State)
 	}
 	if !view.Definitions[0].Eligibility.Eligible {
 		t.Fatal("metacog_like eligibility should be true")
 	}
-	if view.Definitions[1].Runtime.Running {
+	if view.Definitions[1].Loop == nil {
+		t.Fatal("paused_watch Loop view should never be nil")
+	}
+	if view.Definitions[1].Loop.Running {
 		t.Fatal("paused_watch runtime should not be running")
 	}
 	if !view.Definitions[1].Eligibility.Eligible {

--- a/internal/runtime/loop/definition_view.go
+++ b/internal/runtime/loop/definition_view.go
@@ -7,82 +7,41 @@ import (
 
 const definitionRuntimeStateNotRunning = "not_running"
 
-// DefinitionRuntimeStatus summarizes the live runtime state currently
-// associated with one stored loop definition.
-type DefinitionRuntimeStatus struct {
-	// Running reports whether a live loop instance currently exists for
-	// this definition.
-	Running bool `yaml:"running" json:"running"`
-	// LoopID is the backing live loop instance, when one is present.
-	LoopID string `yaml:"loop_id,omitempty" json:"loop_id,omitempty"`
-	// State is the current runtime lifecycle state of the backing loop.
-	State State `yaml:"state,omitempty" json:"state,omitempty"`
-	// StartedAt is when the current backing loop instance started.
-	StartedAt time.Time `yaml:"started_at,omitempty" json:"started_at,omitempty"`
-	// LastWakeAt is when the current backing loop most recently began an
-	// iteration.
-	LastWakeAt time.Time `yaml:"last_wake_at,omitempty" json:"last_wake_at,omitempty"`
-	// Iterations is the number of successful iterations completed by the
-	// current backing loop instance.
-	Iterations int `yaml:"iterations,omitempty" json:"iterations,omitempty"`
-	// Attempts is the number of total iteration attempts completed by the
-	// current backing loop instance.
-	Attempts int `yaml:"attempts,omitempty" json:"attempts,omitempty"`
-	// LastError is the most recent runtime error from the current backing
-	// loop instance.
-	LastError string `yaml:"last_error,omitempty" json:"last_error,omitempty"`
-}
-
 // DefinitionView is the combined stored-definition and live-runtime view
-// exposed by loop read surfaces.
+// exposed by loop read surfaces. The canonical loop projection lives in Loop —
+// a [LoopView] built via [DefinitionViewResolver.FromDefinition], with the
+// live half overlaid when the definition has a running backing loop. The
+// remaining fields are definition-corpus framing a live LoopView intentionally
+// does not carry: the raw authored Spec (for round-trip editing), the
+// provenance source, lint warnings, and the per-ancestor eligibility cascade.
 type DefinitionView struct {
-	DefinitionSnapshot `yaml:",inline"`
-	Eligibility        DefinitionEligibilityStatus `yaml:"eligibility,omitempty" json:"eligibility"`
-	Runtime            DefinitionRuntimeStatus     `yaml:"runtime,omitempty" json:"runtime"`
-	Warnings           []DefinitionWarning         `yaml:"warnings,omitempty" json:"warnings,omitempty"`
-	// EffectiveConditions lists each ancestor's Conditions
-	// evaluation with provenance. Surfaces the cascade behind
-	// [Eligibility]: a leaf reading [Eligibility].Eligible=false
-	// can see *which* ancestor blocked it without re-walking the
-	// graph. Empty when the leaf has no container ancestors —
-	// [Eligibility] already carries the single-level result.
+	// Name is the definition's stable identifier (also [LoopView.Name]).
+	Name string `yaml:"name,omitempty" json:"name"`
+	// Source records whether the definition came from config or the overlay.
+	Source DefinitionSource `yaml:"source,omitempty" json:"source"`
+	// UpdatedAt is when the stored definition was last written.
+	UpdatedAt time.Time `yaml:"updated_at,omitempty" json:"updated_at,omitempty"`
+	// Spec is the raw authored definition, kept for round-trip editing
+	// (loop_definition_update reads it before re-committing). Loop is the
+	// resolved canonical view of the same definition.
+	Spec Spec `yaml:"spec,omitempty" json:"spec"`
+	// Loop is the canonical "ps auxwwww" projection of this definition:
+	// stored-static fields always, plus the live-only half (state, economics,
+	// errors, effective_* inheritance) overlaid when a backing loop is running.
+	// [LoopView.Running] discriminates. Never nil.
+	Loop *LoopView `yaml:"loop,omitempty" json:"loop"`
+	// Eligibility is the detailed policy/condition eligibility result. Loop
+	// carries the eligible bool and policy_state; this carries the reason and
+	// the blocking detail.
+	Eligibility DefinitionEligibilityStatus `yaml:"eligibility,omitempty" json:"eligibility"`
+	// Warnings are lint findings for the stored spec.
+	Warnings []DefinitionWarning `yaml:"warnings,omitempty" json:"warnings,omitempty"`
+	// EffectiveConditions lists each ancestor's Conditions evaluation with
+	// provenance. Surfaces the cascade behind [Eligibility]: a leaf reading
+	// Eligible=false can see *which* ancestor blocked it without re-walking the
+	// graph. Empty when the leaf has no container ancestors — [Eligibility]
+	// already carries the single-level result.
 	EffectiveConditions []EffectiveConditionEvaluation `yaml:"effective_conditions,omitempty" json:"effective_conditions,omitempty"`
-	// Effective surfaces the post-ancestor-merge state for inheritable
-	// loop fields. Nil when there is nothing meaningful to report —
-	// the loop isn't running, the view was built without a live
-	// registry (e.g. CLI snapshots), or the loop is running but has
-	// no effective tags and no effective subscriptions. Readers should
-	// not treat nil as a definitive "not running"; pair it with
-	// [DefinitionRuntimeStatus.Running] when that distinction matters.
-	// Sits alongside Spec rather than inside Runtime so the
-	// declared-vs-effective contrast is at the top of the view and
-	// extends naturally as more fields become inheritable.
-	Effective *DefinitionEffectiveState `yaml:"effective,omitempty" json:"effective,omitempty"`
-}
-
-// DefinitionEffectiveState is the post-ancestor-merge snapshot of
-// inheritable fields for one definition's live loop. Each entry
-// carries provenance so the reader knows which values are this
-// loop's own and which came from a container ancestor.
-type DefinitionEffectiveState struct {
-	// Tags is the deduplicated union of the loop's own Spec.Tags and
-	// every container ancestor's tags, ordered own-first.
-	Tags []EffectiveTag `yaml:"tags,omitempty" json:"tags,omitempty"`
-	// Subscriptions is the deduplicated union of the loop's own
-	// Spec.Subscriptions and every container ancestor's, first-wins
-	// on entity_id (own declarations override inherited options).
-	Subscriptions []EffectiveSubscription `yaml:"subscriptions,omitempty" json:"subscriptions,omitempty"`
-	// ExcludeTools is the union of the loop's own ExcludeTools and
-	// every container ancestor's. Union semantics — a descendant
-	// cannot un-exclude an ancestor's restriction.
-	ExcludeTools []EffectiveExcludeTool `yaml:"exclude_tools,omitempty" json:"exclude_tools,omitempty"`
-	// RoutingFactors is the merged routing-factor map, child-wins on
-	// key collision. Each entry names its origin loop.
-	RoutingFactors []EffectiveRoutingFactor `yaml:"routing_factors,omitempty" json:"routing_factors,omitempty"`
-	// DelegationGating is the resolved gating value plus its origin.
-	// Nil when no loop in the chain declared a non-empty value (the
-	// agent default applies).
-	DelegationGating *EffectiveDelegationGating `yaml:"delegation_gating,omitempty" json:"delegation_gating,omitempty"`
 }
 
 // DefinitionRegistryView is the effective combined view of stored loop
@@ -101,42 +60,22 @@ type DefinitionRegistryView struct {
 	Definitions             []DefinitionView `yaml:"definitions,omitempty" json:"definitions,omitempty"`
 }
 
-// DefinitionViewOption tunes [BuildDefinitionRegistryView]. Used today
-// to opt into effective-state population by passing a live registry
-// via [WithLiveRegistry]; older callers that don't supply one continue
-// to get a view without the Effective field, which is the right shape
-// for surfaces that don't have access to a running loop graph.
-type DefinitionViewOption func(*definitionViewOptions)
-
-type definitionViewOptions struct {
-	loops *Registry
+// BuildDefinitionRegistryView combines the durable definition snapshot with an
+// optional map of live loop Statuses — keyed by definition name, where presence
+// means a backing loop is running — to produce the effective loop registry view
+// used by API and tool read surfaces. Each definition is projected into a
+// canonical [LoopView] via [DefinitionViewResolver.FromDefinition], with the
+// live half overlaid from its Status (which already carries the resolved
+// effective_* inheritance lists). Pass nil for liveByName on surfaces with no
+// running loop graph (e.g. CLI snapshots, loop_definition_lint); those views
+// project every definition as stored-only.
+func BuildDefinitionRegistryView(snapshot *DefinitionRegistrySnapshot, liveByName map[string]Status) *DefinitionRegistryView {
+	return buildDefinitionRegistryViewAt(snapshot, liveByName, time.Now())
 }
 
-// WithLiveRegistry attaches a live loop registry to the view build so
-// each definition's running loop can be inspected for inherited tags
-// and subscriptions. Without it, [DefinitionView.Effective] stays nil
-// — a safe default for snapshots taken outside the running app (e.g.
-// CLI inspection tools or the loop_definition_lint surface).
-func WithLiveRegistry(loops *Registry) DefinitionViewOption {
-	return func(o *definitionViewOptions) {
-		o.loops = loops
-	}
-}
-
-// BuildDefinitionRegistryView combines the durable definition snapshot
-// with an optional runtime-state map to produce the effective loop
-// registry view used by API and tool read surfaces.
-func BuildDefinitionRegistryView(snapshot *DefinitionRegistrySnapshot, runtime map[string]DefinitionRuntimeStatus, opts ...DefinitionViewOption) *DefinitionRegistryView {
-	return buildDefinitionRegistryViewAt(snapshot, runtime, time.Now(), opts...)
-}
-
-func buildDefinitionRegistryViewAt(snapshot *DefinitionRegistrySnapshot, runtime map[string]DefinitionRuntimeStatus, now time.Time, opts ...DefinitionViewOption) *DefinitionRegistryView {
+func buildDefinitionRegistryViewAt(snapshot *DefinitionRegistrySnapshot, liveByName map[string]Status, now time.Time) *DefinitionRegistryView {
 	if snapshot == nil {
 		return nil
-	}
-	options := definitionViewOptions{}
-	for _, opt := range opts {
-		opt(&options)
 	}
 
 	view := &DefinitionRegistryView{
@@ -150,32 +89,35 @@ func buildDefinitionRegistryViewAt(snapshot *DefinitionRegistrySnapshot, runtime
 		Definitions:        make([]DefinitionView, 0, len(snapshot.Definitions)),
 	}
 
-	// Index the snapshot by name once so the eligibility cascade
-	// walks parent_name through the same snapshot we're rendering —
-	// avoids both per-definition registry lock acquisition and the
-	// risk of observing a different definition state between
-	// snapshot and ancestor lookup.
+	// Index the snapshot by name once so the eligibility cascade walks
+	// parent_name through the same snapshot we're rendering — avoids both
+	// per-definition registry lock acquisition and the risk of observing a
+	// different definition state between snapshot and ancestor lookup.
 	byName := make(map[string]Spec, len(snapshot.Definitions))
 	for _, def := range snapshot.Definitions {
 		byName[def.Name] = def.Spec
 	}
+	resolver := NewDefinitionViewResolver(snapshot.Definitions, now)
 
 	for _, def := range snapshot.Definitions {
 		chain := ancestorChainFromSnapshot(byName, def.Name)
 		eligibility, conditionEvals := EvaluateEffectiveConditions(chain, now)
 		warnings := BuildDefinitionWarnings(def.Spec)
-		status, ok := runtime[def.Name]
-		if ok && status.Running {
+
+		var live *Status
+		if s, ok := liveByName[def.Name]; ok {
+			sCopy := s
+			live = &sCopy
 			view.RunningDefinitions++
-			state := string(status.State)
+			state := string(s.State)
 			if state == "" {
 				state = "running"
 			}
 			view.ByRuntimeState[state]++
 		} else {
 			view.ByRuntimeState[definitionRuntimeStateNotRunning]++
-			status = DefinitionRuntimeStatus{}
 		}
+
 		view.ByPolicyState[string(def.PolicyState)]++
 		if eligibility.Eligible {
 			view.ByEligibilityState[definitionEligibilityStateEligible]++
@@ -186,36 +128,23 @@ func buildDefinitionRegistryViewAt(snapshot *DefinitionRegistrySnapshot, runtime
 			view.DefinitionsWithWarnings++
 			view.WarningCount += len(warnings)
 		}
+
+		loop := resolver.FromDefinition(def, eligibility, live)
 		dv := DefinitionView{
-			DefinitionSnapshot: def,
-			Eligibility:        eligibility,
-			Runtime:            status,
-			Warnings:           warnings,
+			Name:        def.Name,
+			Source:      def.Source,
+			UpdatedAt:   def.UpdatedAt,
+			Spec:        def.Spec,
+			Loop:        &loop,
+			Eligibility: eligibility,
+			Warnings:    warnings,
 		}
-		// Surface the per-ancestor evaluations only when the cascade
-		// actually went through more than one level — for a leaf with
-		// no container parent, the single self-evaluation is already
-		// what [Eligibility] reports and adding a single-entry list
-		// would be noise.
+		// Surface the per-ancestor evaluations only when the cascade actually
+		// went through more than one level — for a leaf with no container
+		// parent, the single self-evaluation is already what [Eligibility]
+		// reports and a single-entry list would be noise.
 		if len(conditionEvals) > 1 {
 			dv.EffectiveConditions = conditionEvals
-		}
-		if options.loops != nil && status.Running && status.LoopID != "" {
-			// One walk per definition: per-field Effective* calls
-			// would do separate ancestor traversals that could observe
-			// different snapshots if SetSubscriptions ran between them.
-			eff := options.loops.effectiveState(status.LoopID)
-			if len(eff.Tags) > 0 || len(eff.Subscriptions) > 0 ||
-				len(eff.ExcludeTools) > 0 || len(eff.RoutingFactors) > 0 ||
-				eff.DelegationGating != nil {
-				dv.Effective = &DefinitionEffectiveState{
-					Tags:             eff.Tags,
-					Subscriptions:    eff.Subscriptions,
-					ExcludeTools:     eff.ExcludeTools,
-					RoutingFactors:   eff.RoutingFactors,
-					DelegationGating: eff.DelegationGating,
-				}
-			}
 		}
 		view.Definitions = append(view.Definitions, dv)
 	}

--- a/internal/runtime/loop/effective_test.go
+++ b/internal/runtime/loop/effective_test.go
@@ -236,7 +236,8 @@ func TestLoopStatusEffectiveEmptyWithoutRegistry(t *testing.T) {
 
 // TestBuildDefinitionRegistryViewPopulatesEffective wires the full
 // path: a running loop plus its container ancestor produce a
-// DefinitionView with Effective populated and carrying provenance.
+// DefinitionView whose canonical Loop view has the effective_*
+// inheritance lists populated and carrying provenance.
 func TestBuildDefinitionRegistryViewPopulatesEffective(t *testing.T) {
 	t.Parallel()
 
@@ -295,12 +296,18 @@ func TestBuildDefinitionRegistryViewPopulatesEffective(t *testing.T) {
 		t.Fatalf("register leaf loop: %v", err)
 	}
 
-	runtimeStatus := map[string]DefinitionRuntimeStatus{
-		"home_automation": {Running: true, LoopID: container.ID()},
-		"morning_brief":   {Running: true, LoopID: leaf.ID()},
+	// Presence in liveByName (keyed by definition name) means the definition
+	// has a running backing loop; the Status carries the effective_*
+	// inheritance lists the live registry populated. Name each Status to its
+	// definition so the view matches by name.
+	containerStatus := container.Status()
+	leafStatus := leaf.Status()
+	liveByName := map[string]Status{
+		"home_automation": containerStatus,
+		"morning_brief":   leafStatus,
 	}
 
-	view := BuildDefinitionRegistryView(defReg.Snapshot(), runtimeStatus, WithLiveRegistry(live))
+	view := BuildDefinitionRegistryView(defReg.Snapshot(), liveByName)
 	if view == nil {
 		t.Fatal("BuildDefinitionRegistryView returned nil")
 	}
@@ -315,21 +322,25 @@ func TestBuildDefinitionRegistryViewPopulatesEffective(t *testing.T) {
 	if leafView == nil {
 		t.Fatal("morning_brief not in view")
 	}
-	if leafView.Effective == nil {
-		t.Fatal("Effective is nil; want populated for running loop")
+	if leafView.Loop == nil {
+		t.Fatal("Loop is nil; BuildDefinitionRegistryView never emits a nil Loop")
 	}
-	if len(leafView.Effective.Tags) != 2 {
-		t.Errorf("Effective.Tags len = %d, want 2: %+v", len(leafView.Effective.Tags), leafView.Effective.Tags)
+	if !leafView.Loop.Running {
+		t.Fatal("Loop.Running = false; want true for a running loop")
 	}
-	if len(leafView.Effective.Subscriptions) != 2 {
-		t.Errorf("Effective.Subscriptions len = %d, want 2: %+v", len(leafView.Effective.Subscriptions), leafView.Effective.Subscriptions)
+	if len(leafView.Loop.EffectiveTags) != 2 {
+		t.Errorf("Loop.EffectiveTags len = %d, want 2: %+v", len(leafView.Loop.EffectiveTags), leafView.Loop.EffectiveTags)
+	}
+	if len(leafView.Loop.EffectiveSubscriptions) != 2 {
+		t.Errorf("Loop.EffectiveSubscriptions len = %d, want 2: %+v", len(leafView.Loop.EffectiveSubscriptions), leafView.Loop.EffectiveSubscriptions)
 	}
 }
 
 // TestBuildDefinitionRegistryViewEffectiveNilWithoutRegistry covers
 // the safe-default branch: callers that build the view from a
-// snapshot alone (CLI tools, lint surfaces) get no Effective field
-// rather than a misleading empty one.
+// snapshot alone (CLI tools, lint surfaces) get a stored-only Loop
+// (Running=false) whose live-only effective_* lists stay nil rather
+// than a misleading empty list.
 func TestBuildDefinitionRegistryViewEffectiveNilWithoutRegistry(t *testing.T) {
 	t.Parallel()
 
@@ -353,8 +364,17 @@ func TestBuildDefinitionRegistryViewEffectiveNilWithoutRegistry(t *testing.T) {
 		t.Fatal("nil view")
 	}
 	for _, dv := range view.Definitions {
-		if dv.Effective != nil {
-			t.Errorf("definition %q has Effective populated without a live registry; want nil", dv.Name)
+		if dv.Loop == nil {
+			t.Fatalf("definition %q has nil Loop; BuildDefinitionRegistryView never emits a nil Loop", dv.Name)
+		}
+		if dv.Loop.Running {
+			t.Errorf("definition %q is Running without a live registry; want stored-only", dv.Name)
+		}
+		if dv.Loop.EffectiveTags != nil {
+			t.Errorf("definition %q has EffectiveTags populated without a live registry; want nil", dv.Name)
+		}
+		if dv.Loop.EffectiveSubscriptions != nil {
+			t.Errorf("definition %q has EffectiveSubscriptions populated without a live registry; want nil", dv.Name)
 		}
 	}
 }

--- a/internal/runtime/loop/loop.go
+++ b/internal/runtime/loop/loop.go
@@ -615,6 +615,9 @@ func (l *Loop) Status() Status {
 	cfgCopy.Setup = nil
 	cfgCopy.RuntimeTools = nil
 	cfgCopy.OutputContextBuilder = nil
+	// Origin is a pointer — clone it so a Status() caller can't mutate (or race
+	// with) the loop's internal creation provenance through the snapshot.
+	cfgCopy.Origin = l.config.Origin.Clone()
 	cfgCopy.Outputs = cloneOutputs(l.config.Outputs)
 	if l.config.Tags != nil {
 		cfgCopy.Tags = make([]string, len(l.config.Tags))

--- a/internal/runtime/loop/loop_test.go
+++ b/internal/runtime/loop/loop_test.go
@@ -208,6 +208,33 @@ func TestComputeSleep(t *testing.T) {
 	})
 }
 
+func TestStatusClonesConfigOrigin(t *testing.T) {
+	t.Parallel()
+
+	origin := &OriginInfo{RequestID: "r_1", CreatedByLoopID: "lp_a"}
+	l, err := New(Config{
+		Name:   "origin-clone-test",
+		Task:   "x",
+		Origin: origin,
+	}, Deps{Runner: &countingRunner{count: &atomic.Int32{}}})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	st := l.Status()
+	if st.Config.Origin == nil {
+		t.Fatal("Status().Config.Origin should be populated")
+	}
+	if st.Config.Origin == l.config.Origin {
+		t.Error("Status() must return a CLONE of Config.Origin, not the loop's internal pointer")
+	}
+	// Mutating the snapshot must not leak into the loop's internal origin.
+	st.Config.Origin.RequestID = "mutated"
+	if l.config.Origin.RequestID != "r_1" {
+		t.Error("mutating the Status() origin reached the loop's internal Config.Origin")
+	}
+}
+
 func TestLoopLifecycle(t *testing.T) {
 	t.Parallel()
 

--- a/internal/runtime/loop/loop_view.go
+++ b/internal/runtime/loop/loop_view.go
@@ -178,15 +178,15 @@ func (r LoopViewResolver) FromStatus(s Status) LoopView {
 		// same operation FromDefinition does (an unset operation is
 		// "request_reply", never ""): the two projectors must agree field-for-
 		// field on the same loop.
-		Operation:   string(effectiveOperation(s.Config.Operation)),
-		Completion:  string(s.Config.Completion),
-		Task:        s.Config.Task,
-		Intent:      s.Config.Intent,
-		Origin:      s.Config.Origin.Clone(),
-		Ancestry:    r.ancestry(s.ID),
-		ChildCount:  r.childCount[s.ID],
-		EventDriven: s.EventDriven,
-		Supervisor:  s.Config.Supervisor,
+		Operation:  string(effectiveOperation(s.Config.Operation)),
+		Completion: string(s.Config.Completion),
+		Task:       s.Config.Task,
+		Intent:     s.Config.Intent,
+		Origin:     s.Config.Origin.Clone(),
+		Ancestry:   r.ancestry(s.ID),
+		ChildCount: r.childCount[s.ID],
+		Supervisor: s.Config.Supervisor,
+		// EventDriven is set from the live Status in applyLiveTelemetry.
 	}
 	if pn := r.nameByID[s.ParentID]; pn != "" {
 		v.ParentName = &pn
@@ -232,9 +232,18 @@ func applyLiveTelemetry(v *LoopView, s Status, now time.Time) {
 	id := s.ID
 	v.ID = &id
 	v.Running = true
+	// Normalize an empty runtime state to "running" — matches the definition
+	// registry's runtime-state tally and keeps a live row from reading state:"".
 	state := string(s.State)
+	if state == "" {
+		state = "running"
+	}
 	v.State = &state
 	v.HandlerOnly = s.HandlerOnly
+	// EventDriven is a live runtime property (Status carries l.isEventDriven()).
+	// Take it from the Status so a running definition-backed row matches a
+	// FromStatus row exactly instead of re-deriving it from the spec operation.
+	v.EventDriven = s.EventDriven
 
 	iterations := s.Iterations
 	attempts := s.Attempts

--- a/internal/runtime/loop/loop_view.go
+++ b/internal/runtime/loop/loop_view.go
@@ -2,6 +2,7 @@ package loop
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/nugget/thane-ai-agent/internal/model/promptfmt"
@@ -22,12 +23,13 @@ import (
 // meaning in both modes.
 type LoopView struct {
 	// ---- identity (PID / COMMAND) ----
-	Name       string  `json:"name"`
-	ID         *string `json:"id"`
-	Operation  string  `json:"operation"`
-	Completion string  `json:"completion,omitempty"`
-	Task       string  `json:"task"`
-	Intent     string  `json:"intent,omitempty"`
+	Name       string      `json:"name"`
+	ID         *string     `json:"id"`
+	Operation  string      `json:"operation"`
+	Completion string      `json:"completion,omitempty"`
+	Task       string      `json:"task"`
+	Intent     string      `json:"intent,omitempty"`
+	Origin     *OriginInfo `json:"origin,omitempty"`
 
 	// ---- structure (graph; resolved to names, never bare IDs) ----
 	ParentName *string  `json:"parent_name"`
@@ -170,54 +172,86 @@ func (r LoopViewResolver) ancestry(loopID string) []string {
 // policy/eligibility. Live-only fields are all populated; only the
 // definition-joined policy half can be absent (ephemeral loops).
 func (r LoopViewResolver) FromStatus(s Status) LoopView {
-	id := s.ID
-	state := string(s.State)
-	iterations := s.Iterations
-	attempts := s.Attempts
-	consecErr := s.ConsecutiveErrors
-
 	v := LoopView{
 		Name:        s.Name,
-		ID:          &id,
 		Operation:   string(s.Config.Operation),
 		Completion:  string(s.Config.Completion),
 		Task:        s.Config.Task,
 		Intent:      s.Config.Intent,
+		Origin:      s.Config.Origin.Clone(),
 		Ancestry:    r.ancestry(s.ID),
 		ChildCount:  r.childCount[s.ID],
-		Running:     true,
-		State:       &state,
 		EventDriven: s.EventDriven,
-		HandlerOnly: s.HandlerOnly,
-		Iterations:  &iterations,
-		Attempts:    &attempts,
 		Supervisor:  s.Config.Supervisor,
-
-		EffectiveTags:             orEmptyLoopSlice(s.EffectiveTags),
-		EffectiveSubscriptions:    orEmptyLoopSlice(s.EffectiveSubscriptions),
-		EffectiveExcludeTools:     orEmptyLoopSlice(s.EffectiveExcludeTools),
-		EffectiveRoutingFactors:   orEmptyLoopSlice(s.EffectiveRoutingFactors),
-		EffectiveDelegationGating: s.EffectiveDelegationGating,
 	}
-
 	if pn := r.nameByID[s.ParentID]; pn != "" {
 		v.ParentName = &pn
 	}
+	if s.Config.Supervisor {
+		prob := s.Config.SupervisorProb
+		v.SupervisorProb = &prob
+	}
+
+	// Policy/eligibility left-joined from the stored definition. A live Status
+	// carries no policy of its own; HasPolicy=false is an ad-hoc spawn.
+	if pol, ok := r.policyByName[s.Name]; ok && pol.HasPolicy {
+		v.PolicyState = pol.State
+		v.PolicySource = pol.Source
+		if pol.Reason != "" {
+			reason := pol.Reason
+			v.PolicyReason = &reason
+		}
+		if !pol.UpdatedAt.IsZero() {
+			d := promptfmt.FormatDeltaOnly(pol.UpdatedAt, r.now)
+			v.PolicyUpdatedDelta = &d
+		}
+		v.Eligible = pol.Eligible
+	} else {
+		// No stored definition backs this loop (ad-hoc spawn): there is no
+		// policy to report. Say so explicitly rather than implying "active".
+		v.PolicyState = "ephemeral"
+		v.Eligible = true
+	}
+
+	applyLiveTelemetry(&v, s, r.now)
+	return v
+}
+
+// applyLiveTelemetry fills the live-only half of a LoopView from a running
+// loop's Status: identity, runtime state, lifecycle deltas, economics, error
+// state, supervisor cadence, and the effective_* inheritance lists. Shared by
+// FromStatus (always live) and FromDefinition (only when the definition has a
+// running loop) so both projectors emit identical live fields. It sets
+// Running=true; a stored-but-not-running view never calls it and keeps every
+// live-only pointer nil.
+func applyLiveTelemetry(v *LoopView, s Status, now time.Time) {
+	id := s.ID
+	v.ID = &id
+	v.Running = true
+	state := string(s.State)
+	v.State = &state
+	v.HandlerOnly = s.HandlerOnly
+
+	iterations := s.Iterations
+	attempts := s.Attempts
+	v.Iterations = &iterations
+	v.Attempts = &attempts
+
 	// Delta-oriented timestamps per the model-facing convention: signed
 	// exact-second offsets from now (AGENTS.md), e.g. "-15120s" / "+240s".
 	if !s.StartedAt.IsZero() {
-		d := promptfmt.FormatDeltaOnly(s.StartedAt, r.now)
+		d := promptfmt.FormatDeltaOnly(s.StartedAt, now)
 		v.StartedDelta = &d
 	}
 	if !s.LastWakeAt.IsZero() {
-		d := promptfmt.FormatDeltaOnly(s.LastWakeAt, r.now)
+		d := promptfmt.FormatDeltaOnly(s.LastWakeAt, now)
 		v.LastWakeDelta = &d
 	}
 	// Scheduled next wake + the self-paced interval, for timer-based sleeps —
 	// turns the census into a schedule. Event-driven loops (no timer) leave
 	// SleepUntil zero and correctly report null.
 	if !s.SleepUntil.IsZero() {
-		nw := promptfmt.FormatDeltaOnly(s.SleepUntil, r.now)
+		nw := promptfmt.FormatDeltaOnly(s.SleepUntil, now)
 		v.NextWakeDelta = &nw
 		// Unsigned seconds — a duration magnitude, not a delta-from-now — so the
 		// whole row speaks one unit (e.g. current_sleep "5940s" alongside
@@ -247,6 +281,7 @@ func (r LoopViewResolver) FromStatus(s Status) LoopView {
 		}
 	}
 
+	consecErr := s.ConsecutiveErrors
 	v.ConsecutiveErrors = &consecErr
 	// Null, not "", when there is no error — cleaner at the model boundary.
 	if s.LastError != "" {
@@ -254,10 +289,6 @@ func (r LoopViewResolver) FromStatus(s Status) LoopView {
 		v.LastError = &lastErr
 	}
 
-	if s.Config.Supervisor {
-		prob := s.Config.SupervisorProb
-		v.SupervisorProb = &prob
-	}
 	if s.LastSupervisorIter > 0 {
 		lsi := s.LastSupervisorIter
 		v.LastSupervisorIter = &lsi
@@ -270,26 +301,109 @@ func (r LoopViewResolver) FromStatus(s Status) LoopView {
 		v.SupervisorItersAgo = &ago
 	}
 
-	// Policy/eligibility left-joined from the stored definition.
-	if pol, ok := r.policyByName[s.Name]; ok && pol.HasPolicy {
-		v.PolicyState = pol.State
-		v.PolicySource = pol.Source
-		if pol.Reason != "" {
-			reason := pol.Reason
-			v.PolicyReason = &reason
+	// effective_* come straight off the Status — the registry populates them via
+	// the same ancestor walk loop_status uses. [] when running-and-empty
+	// (evaluated, nothing inherited) vs null when not running.
+	v.EffectiveTags = orEmptyLoopSlice(s.EffectiveTags)
+	v.EffectiveSubscriptions = orEmptyLoopSlice(s.EffectiveSubscriptions)
+	v.EffectiveExcludeTools = orEmptyLoopSlice(s.EffectiveExcludeTools)
+	v.EffectiveRoutingFactors = orEmptyLoopSlice(s.EffectiveRoutingFactors)
+	v.EffectiveDelegationGating = s.EffectiveDelegationGating
+}
+
+// DefinitionViewResolver carries the definition-graph joins a stored-definition
+// LoopView needs — parent_name/ancestry/child_count resolved from
+// Spec.ParentName, not live loop IDs — so they resolve once per render.
+// Construct one with NewDefinitionViewResolver, then call FromDefinition for
+// each definition.
+type DefinitionViewResolver struct {
+	parentByName map[string]string
+	childCount   map[string]int
+	now          time.Time
+}
+
+// NewDefinitionViewResolver builds the name/parent/child indexes once over the
+// full definition snapshot set (so parent_name and child_count stay accurate
+// even when the rendered rows are filtered) and captures one clock for deltas.
+func NewDefinitionViewResolver(snapshots []DefinitionSnapshot, now time.Time) DefinitionViewResolver {
+	parentByName := make(map[string]string, len(snapshots))
+	childCount := make(map[string]int, len(snapshots))
+	for _, snap := range snapshots {
+		parent := strings.TrimSpace(snap.Spec.ParentName)
+		parentByName[snap.Name] = parent
+		if parent != "" {
+			childCount[parent]++
 		}
-		if !pol.UpdatedAt.IsZero() {
-			d := promptfmt.FormatDeltaOnly(pol.UpdatedAt, r.now)
-			v.PolicyUpdatedDelta = &d
-		}
-		v.Eligible = pol.Eligible
-	} else {
-		// No stored definition backs this loop (ad-hoc spawn): there is no
-		// policy to report. Say so explicitly rather than implying "active".
-		v.PolicyState = "ephemeral"
-		v.Eligible = true
+	}
+	return DefinitionViewResolver{
+		parentByName: parentByName,
+		childCount:   childCount,
+		now:          now,
+	}
+}
+
+// ancestry walks the parent_name chain from a definition up to the root,
+// returning ancestor names ordered root→leaf. A seen-set guards a malformed
+// cycle so a corrupt graph can't spin the walk.
+func (r DefinitionViewResolver) ancestry(name string) []string {
+	out := []string{}
+	seen := map[string]bool{name: true}
+	for pn := r.parentByName[name]; pn != "" && !seen[pn]; pn = r.parentByName[pn] {
+		seen[pn] = true
+		out = append(out, pn)
+	}
+	for i, j := 0, len(out)-1; i < j; i, j = i+1, j-1 {
+		out[i], out[j] = out[j], out[i]
+	}
+	return out
+}
+
+// FromDefinition projects one stored loop definition into the canonical view —
+// the definition-corpus counterpart of FromStatus. Static fields come from the
+// Spec, graph fields from the definition's parent_name chain, and policy +
+// eligibility from the stored snapshot (a definition, unlike a live Status,
+// carries its own policy). When the definition has a running loop, pass its
+// Status as live and the live-only half is overlaid, identical to a FromStatus
+// row; when live is nil the row is stored-only — Running=false and every
+// live-only pointer stays nil (serialized as explicit null, never zero).
+func (r DefinitionViewResolver) FromDefinition(snap DefinitionSnapshot, eligibility DefinitionEligibilityStatus, live *Status) LoopView {
+	spec := snap.Spec
+	op := effectiveOperation(spec.Operation)
+	v := LoopView{
+		Name:        snap.Name,
+		Operation:   string(op),
+		Completion:  string(spec.Completion),
+		Task:        spec.Task,
+		Intent:      spec.Intent,
+		Origin:      spec.Origin.Clone(),
+		Ancestry:    r.ancestry(snap.Name),
+		ChildCount:  r.childCount[snap.Name],
+		EventDriven: op == OperationEventDriven,
+		Supervisor:  spec.Supervisor,
+
+		PolicyState:  string(snap.PolicyState),
+		PolicySource: string(snap.PolicySource),
+		Eligible:     eligibility.Eligible,
+	}
+	if pn := strings.TrimSpace(spec.ParentName); pn != "" {
+		v.ParentName = &pn
+	}
+	if snap.PolicyReason != "" {
+		reason := snap.PolicyReason
+		v.PolicyReason = &reason
+	}
+	if !snap.PolicyUpdatedAt.IsZero() {
+		d := promptfmt.FormatDeltaOnly(snap.PolicyUpdatedAt, r.now)
+		v.PolicyUpdatedDelta = &d
+	}
+	if spec.Supervisor {
+		prob := spec.SupervisorProb
+		v.SupervisorProb = &prob
 	}
 
+	if live != nil {
+		applyLiveTelemetry(&v, *live, r.now)
+	}
 	return v
 }
 

--- a/internal/runtime/loop/loop_view.go
+++ b/internal/runtime/loop/loop_view.go
@@ -173,8 +173,12 @@ func (r LoopViewResolver) ancestry(loopID string) []string {
 // definition-joined policy half can be absent (ephemeral loops).
 func (r LoopViewResolver) FromStatus(s Status) LoopView {
 	v := LoopView{
-		Name:        s.Name,
-		Operation:   string(s.Config.Operation),
+		Name: s.Name,
+		// Normalize through effectiveOperation so the canonical row reports the
+		// same operation FromDefinition does (an unset operation is
+		// "request_reply", never ""): the two projectors must agree field-for-
+		// field on the same loop.
+		Operation:   string(effectiveOperation(s.Config.Operation)),
 		Completion:  string(s.Config.Completion),
 		Task:        s.Config.Task,
 		Intent:      s.Config.Intent,

--- a/internal/runtime/loop/loop_view_test.go
+++ b/internal/runtime/loop/loop_view_test.go
@@ -308,3 +308,22 @@ func TestDefinitionViewResolver_FromDefinition_GraphFromNames(t *testing.T) {
 			container.ParentName, container.Ancestry)
 	}
 }
+
+// TestLoopView_OperationNormalizedConsistently guards the two projectors against
+// disagreeing on a loop's operation: an unset operation is valid and must
+// normalize to the canonical "request_reply" on BOTH FromStatus and
+// FromDefinition, never "" on one and "request_reply" on the other.
+func TestLoopView_OperationNormalizedConsistently(t *testing.T) {
+	now := time.Date(2026, 6, 26, 12, 0, 0, 0, time.UTC)
+	fromStatus := NewLoopViewResolver(nil, nil, now).FromStatus(Status{
+		ID: "lp_x", Name: "adhoc", State: State("processing"),
+		Config: Config{Task: "do a thing"}, // Operation unset
+	})
+	snaps := []DefinitionSnapshot{{Name: "adhoc", Spec: Spec{Name: "adhoc", Task: "do a thing"}}}
+	fromDef := NewDefinitionViewResolver(snaps, now).FromDefinition(snaps[0], DefinitionEligibilityStatus{}, nil)
+
+	if fromStatus.Operation != "request_reply" || fromDef.Operation != "request_reply" {
+		t.Errorf("unset operation must normalize to request_reply on both projectors: FromStatus=%q FromDefinition=%q",
+			fromStatus.Operation, fromDef.Operation)
+	}
+}

--- a/internal/runtime/loop/loop_view_test.go
+++ b/internal/runtime/loop/loop_view_test.go
@@ -192,3 +192,119 @@ func TestLoopViewResolver_FromStatus_ContainerAndEphemeral(t *testing.T) {
 		t.Errorf("EffectiveTags = %#v, want non-nil empty slice for a running loop", container.EffectiveTags)
 	}
 }
+
+func TestDefinitionViewResolver_FromDefinition_StoredNotRunning(t *testing.T) {
+	now := time.Date(2026, 6, 26, 12, 0, 0, 0, time.UTC)
+	created := time.Date(2026, 6, 1, 9, 0, 0, 0, time.UTC)
+	snaps := []DefinitionSnapshot{
+		{
+			Name: "reservoir", Source: DefinitionSourceOverlay,
+			PolicyState: "active", PolicySource: "overlay",
+			Spec: Spec{
+				Name: "reservoir", Operation: OperationService, Task: "watch the reservoir",
+				Intent: "Keep a current read on the reservoir level", ParentName: "watchers",
+				Origin: &OriginInfo{RequestID: "r_42", ConversationID: "c1", CreatedByLoopID: "lp_sig", CreatedAt: created},
+			},
+		},
+		{Name: "watchers", Source: DefinitionSourceConfig, Spec: Spec{Name: "watchers", Operation: OperationContainer}},
+	}
+	r := NewDefinitionViewResolver(snaps, now)
+
+	v := r.FromDefinition(snaps[0], DefinitionEligibilityStatus{Eligible: true}, nil)
+
+	if v.Running {
+		t.Error("Running should be false for a stored-not-running definition")
+	}
+	// Live-only pointers stay nil — "not running", never a misleading zero.
+	if v.ID != nil || v.State != nil || v.Iterations != nil || v.ConsecutiveErrors != nil || v.StartedDelta != nil {
+		t.Errorf("live-only fields must be nil when not running: id=%v state=%v iters=%v consec=%v started=%v",
+			v.ID, v.State, v.Iterations, v.ConsecutiveErrors, v.StartedDelta)
+	}
+	// effective_* are nil (not evaluated), distinct from [] (running-and-empty).
+	if v.EffectiveTags != nil {
+		t.Errorf("EffectiveTags = %#v, want nil for a stored (non-running) definition", v.EffectiveTags)
+	}
+	// Static fields come from the Spec.
+	if v.Operation != "service" || v.Task != "watch the reservoir" ||
+		v.Intent != "Keep a current read on the reservoir level" {
+		t.Errorf("static fields not surfaced from Spec: op=%q task=%q intent=%q", v.Operation, v.Task, v.Intent)
+	}
+	// Origin (C2) surfaced from the Spec — the payoff of B1.
+	if v.Origin == nil || v.Origin.RequestID != "r_42" || !v.Origin.CreatedAt.Equal(created) {
+		t.Errorf("Origin not surfaced from Spec: %+v", v.Origin)
+	}
+	// Graph resolved from parent_name, not live loop IDs.
+	if v.ParentName == nil || *v.ParentName != "watchers" {
+		t.Errorf("ParentName = %v, want watchers (from Spec.ParentName)", v.ParentName)
+	}
+	if len(v.Ancestry) != 1 || v.Ancestry[0] != "watchers" {
+		t.Errorf("Ancestry = %v, want [watchers]", v.Ancestry)
+	}
+	// Policy comes from the stored snapshot (a definition carries its own).
+	if v.PolicyState != "active" || v.PolicySource != "overlay" || !v.Eligible {
+		t.Errorf("policy from snapshot: state=%q source=%q eligible=%v", v.PolicyState, v.PolicySource, v.Eligible)
+	}
+}
+
+func TestDefinitionViewResolver_FromDefinition_RunningOverlaysLive(t *testing.T) {
+	now := time.Date(2026, 6, 26, 12, 0, 0, 0, time.UTC)
+	snaps := []DefinitionSnapshot{
+		{
+			Name: "reservoir", Source: DefinitionSourceOverlay, PolicyState: "active",
+			Spec: Spec{Name: "reservoir", Operation: OperationService, Task: "watch", Intent: "watch the water"},
+		},
+	}
+	r := NewDefinitionViewResolver(snaps, now)
+
+	live := Status{
+		ID: "lp_res", Name: "reservoir", State: State("sleeping"),
+		StartedAt: now.Add(-2 * time.Hour), Iterations: 50, Attempts: 51,
+		TotalInputTokens: 1000, ContextWindow: 200000, LastInputTokens: 20000,
+		EffectiveTags: []EffectiveTag{{Tag: "water", From: "self"}},
+		Config:        Config{Operation: OperationService},
+	}
+	v := r.FromDefinition(snaps[0], DefinitionEligibilityStatus{Eligible: true}, &live)
+
+	if !v.Running {
+		t.Error("Running should be true when a backing loop is present")
+	}
+	// Live-only fields overlaid from the Status, identical to a FromStatus row.
+	if v.ID == nil || *v.ID != "lp_res" {
+		t.Errorf("ID = %v, want lp_res from the live status", v.ID)
+	}
+	if v.Iterations == nil || *v.Iterations != 50 {
+		t.Errorf("Iterations = %v, want 50 from the live status", v.Iterations)
+	}
+	if v.ContextFillPct == nil || *v.ContextFillPct != 10 { // 20000*100/200000
+		t.Errorf("ContextFillPct = %v, want 10", v.ContextFillPct)
+	}
+	if v.StartedDelta == nil || *v.StartedDelta != "-7200s" {
+		t.Errorf("StartedDelta = %v, want -7200s", v.StartedDelta)
+	}
+	if len(v.EffectiveTags) != 1 || v.EffectiveTags[0].Tag != "water" {
+		t.Errorf("EffectiveTags = %#v, want the live inheritance overlaid", v.EffectiveTags)
+	}
+	// Static fields still come from the Spec, not the (sparser) live Config.
+	if v.Intent != "watch the water" {
+		t.Errorf("Intent = %q, want the Spec intent even when running", v.Intent)
+	}
+}
+
+func TestDefinitionViewResolver_FromDefinition_GraphFromNames(t *testing.T) {
+	now := time.Date(2026, 6, 26, 12, 0, 0, 0, time.UTC)
+	snaps := []DefinitionSnapshot{
+		{Name: "watchers", Spec: Spec{Name: "watchers", Operation: OperationContainer}},
+		{Name: "a", Spec: Spec{Name: "a", Operation: OperationService, ParentName: "watchers"}},
+		{Name: "b", Spec: Spec{Name: "b", Operation: OperationService, ParentName: "watchers"}},
+	}
+	r := NewDefinitionViewResolver(snaps, now)
+
+	container := r.FromDefinition(snaps[0], DefinitionEligibilityStatus{Eligible: true}, nil)
+	if container.ChildCount != 2 {
+		t.Errorf("ChildCount = %d, want 2 (counted from the parent_name graph)", container.ChildCount)
+	}
+	if container.ParentName != nil || len(container.Ancestry) != 0 {
+		t.Errorf("top-level container should have nil parent / empty ancestry, got %v / %v",
+			container.ParentName, container.Ancestry)
+	}
+}

--- a/internal/runtime/loop/loop_view_test.go
+++ b/internal/runtime/loop/loop_view_test.go
@@ -327,3 +327,32 @@ func TestLoopView_OperationNormalizedConsistently(t *testing.T) {
 			fromStatus.Operation, fromDef.Operation)
 	}
 }
+
+// TestFromDefinition_RunningTakesLiveEventDrivenAndState guards that a running
+// definition-backed row reflects live runtime values — EventDriven from the
+// Status (not re-derived from the spec operation) and an empty state normalized
+// to "running" — so it stays byte-identical to a FromStatus row.
+func TestFromDefinition_RunningTakesLiveEventDrivenAndState(t *testing.T) {
+	now := time.Date(2026, 6, 26, 12, 0, 0, 0, time.UTC)
+	snaps := []DefinitionSnapshot{{Name: "x", Spec: Spec{Name: "x", Operation: OperationService}}}
+	r := NewDefinitionViewResolver(snaps, now)
+
+	// Live loop reports event_driven and an empty state.
+	live := Status{ID: "lp_x", Name: "x", State: State(""), EventDriven: true, Config: Config{Operation: OperationService}}
+	v := r.FromDefinition(snaps[0], DefinitionEligibilityStatus{}, &live)
+	if !v.EventDriven {
+		t.Error("a running row must take EventDriven from the live Status, not the spec operation")
+	}
+	if v.State == nil || *v.State != "running" {
+		t.Errorf("empty live state must normalize to \"running\", got %v", v.State)
+	}
+
+	// The stored (non-running) counterpart keeps the spec-derived value.
+	stored := r.FromDefinition(snaps[0], DefinitionEligibilityStatus{}, nil)
+	if stored.EventDriven {
+		t.Error("a stored (non-running) service definition must not report event_driven")
+	}
+	if stored.State != nil {
+		t.Errorf("a stored definition must have nil state, got %v", stored.State)
+	}
+}

--- a/internal/runtime/loop/spec.go
+++ b/internal/runtime/loop/spec.go
@@ -501,6 +501,7 @@ func (s *Spec) ToConfig() Config {
 		Name:                 ns.Name,
 		Task:                 ns.Task,
 		Intent:               resolveIntent(ns.Intent, ns.Metadata),
+		Origin:               ns.Origin.Clone(),
 		Operation:            ns.Operation,
 		Completion:           ns.Completion,
 		Outputs:              cloneOutputs(ns.Outputs),

--- a/internal/server/api/loops.go
+++ b/internal/server/api/loops.go
@@ -104,35 +104,33 @@ func (s *Server) loopViewResolver(all []looppkg.Status) looppkg.LoopViewResolver
 // active/paused/eligible rather than "ephemeral". Returns nil when no
 // definition registry is wired, which the projector reads as ephemeral.
 func (s *Server) loopPolicyByName() map[string]looppkg.LoopPolicyInfo {
-	if s.loopDefinitionView == nil {
+	if s.loopDefinitionRegistry == nil {
 		return nil
 	}
-	view := s.loopDefinitionView()
-	if view == nil {
+	// Take ONE registry snapshot and derive both raw policy (with its UpdatedAt
+	// time, needed to format the delta at the projector's render clock) and the
+	// computed eligibility from it. Reading them from two independent Snapshot()
+	// calls opens a TOCTOU window where a definition deleted between them
+	// surfaces a half-populated join (empty policy_state but HasPolicy=true).
+	snap := s.loopDefinitionRegistry.Snapshot()
+	if snap == nil {
 		return nil
 	}
-	// Raw policy (with its UpdatedAt time, needed to format the delta at the
-	// projector's render clock) lives on the registry snapshot — the projected
-	// view carries only a pre-formatted policy_updated_delta. Join snapshot
-	// policy with the view's computed eligibility by name.
-	policyByName := map[string]looppkg.DefinitionSnapshot{}
-	if s.loopDefinitionRegistry != nil {
-		if snap := s.loopDefinitionRegistry.Snapshot(); snap != nil {
-			for _, d := range snap.Definitions {
-				policyByName[d.Name] = d
-			}
-		}
-	}
-	out := make(map[string]looppkg.LoopPolicyInfo, len(view.Definitions))
+	view := looppkg.BuildDefinitionRegistryView(snap, nil)
+	eligByName := make(map[string]looppkg.DefinitionEligibilityStatus, len(view.Definitions))
 	for _, def := range view.Definitions {
-		pol := policyByName[def.Name]
-		out[def.Name] = looppkg.LoopPolicyInfo{
-			State:          string(pol.PolicyState),
-			Source:         string(pol.PolicySource),
-			Reason:         pol.PolicyReason,
-			UpdatedAt:      pol.PolicyUpdatedAt,
-			Eligible:       def.Eligibility.Eligible,
-			EligibleReason: def.Eligibility.Reason,
+		eligByName[def.Name] = def.Eligibility
+	}
+	out := make(map[string]looppkg.LoopPolicyInfo, len(snap.Definitions))
+	for _, d := range snap.Definitions {
+		elig := eligByName[d.Name]
+		out[d.Name] = looppkg.LoopPolicyInfo{
+			State:          string(d.PolicyState),
+			Source:         string(d.PolicySource),
+			Reason:         d.PolicyReason,
+			UpdatedAt:      d.PolicyUpdatedAt,
+			Eligible:       elig.Eligible,
+			EligibleReason: elig.Reason,
 			HasPolicy:      true,
 		}
 	}

--- a/internal/server/api/loops.go
+++ b/internal/server/api/loops.go
@@ -111,13 +111,26 @@ func (s *Server) loopPolicyByName() map[string]looppkg.LoopPolicyInfo {
 	if view == nil {
 		return nil
 	}
+	// Raw policy (with its UpdatedAt time, needed to format the delta at the
+	// projector's render clock) lives on the registry snapshot — the projected
+	// view carries only a pre-formatted policy_updated_delta. Join snapshot
+	// policy with the view's computed eligibility by name.
+	policyByName := map[string]looppkg.DefinitionSnapshot{}
+	if s.loopDefinitionRegistry != nil {
+		if snap := s.loopDefinitionRegistry.Snapshot(); snap != nil {
+			for _, d := range snap.Definitions {
+				policyByName[d.Name] = d
+			}
+		}
+	}
 	out := make(map[string]looppkg.LoopPolicyInfo, len(view.Definitions))
 	for _, def := range view.Definitions {
+		pol := policyByName[def.Name]
 		out[def.Name] = looppkg.LoopPolicyInfo{
-			State:          string(def.PolicyState),
-			Source:         string(def.PolicySource),
-			Reason:         def.PolicyReason,
-			UpdatedAt:      def.PolicyUpdatedAt,
+			State:          string(pol.PolicyState),
+			Source:         string(pol.PolicySource),
+			Reason:         pol.PolicyReason,
+			UpdatedAt:      pol.PolicyUpdatedAt,
 			Eligible:       def.Eligibility.Eligible,
 			EligibleReason: def.Eligibility.Reason,
 			HasPolicy:      true,

--- a/internal/server/api/server_test.go
+++ b/internal/server/api/server_test.go
@@ -1208,11 +1208,11 @@ func TestHandleLoopDefinitions(t *testing.T) {
 	server := NewServer("", 0, nil, nil, nil, nil, nil, nil, nil, nil, nil, testAPILogger())
 	server.UseLoopDefinitionRegistry(registry)
 	server.ConfigureLoopDefinitionView(func() *looppkg.DefinitionRegistryView {
-		return looppkg.BuildDefinitionRegistryView(registry.Snapshot(), map[string]looppkg.DefinitionRuntimeStatus{
+		return looppkg.BuildDefinitionRegistryView(registry.Snapshot(), map[string]looppkg.Status{
 			"metacog_like": {
-				Running: true,
-				LoopID:  "loop-live-1",
-				State:   looppkg.StateSleeping,
+				Name:  "metacog_like",
+				ID:    "loop-live-1",
+				State: looppkg.StateSleeping,
 			},
 		})
 	})
@@ -1235,8 +1235,12 @@ func TestHandleLoopDefinitions(t *testing.T) {
 	if snap.Definitions[0].Name != "metacog_like" {
 		t.Fatalf("definition name = %q, want metacog_like", snap.Definitions[0].Name)
 	}
-	if !snap.Definitions[0].Runtime.Running || snap.Definitions[0].Runtime.LoopID != "loop-live-1" {
-		t.Fatalf("runtime = %+v, want running loop-live-1", snap.Definitions[0].Runtime)
+	loop := snap.Definitions[0].Loop
+	if loop == nil {
+		t.Fatal("definition Loop = nil, want canonical loop view")
+	}
+	if !loop.Running || loop.ID == nil || *loop.ID != "loop-live-1" {
+		t.Fatalf("loop = %+v, want running loop-live-1", loop)
 	}
 }
 
@@ -1372,11 +1376,11 @@ func TestHandleLoopDefinitionPolicySetAndDelete(t *testing.T) {
 	server := NewServer("", 0, nil, nil, nil, nil, nil, nil, nil, nil, nil, testAPILogger())
 	server.UseLoopDefinitionRegistry(registry)
 	server.ConfigureLoopDefinitionView(func() *looppkg.DefinitionRegistryView {
-		return looppkg.BuildDefinitionRegistryView(registry.Snapshot(), map[string]looppkg.DefinitionRuntimeStatus{
+		return looppkg.BuildDefinitionRegistryView(registry.Snapshot(), map[string]looppkg.Status{
 			"metacog_like": {
-				Running: true,
-				LoopID:  "loop-live-1",
-				State:   looppkg.StateSleeping,
+				Name:  "metacog_like",
+				ID:    "loop-live-1",
+				State: looppkg.StateSleeping,
 			},
 		})
 	})
@@ -1412,11 +1416,15 @@ func TestHandleLoopDefinitionPolicySetAndDelete(t *testing.T) {
 	if err := json.NewDecoder(rec.Body).Decode(&setResp); err != nil {
 		t.Fatalf("decode set response: %v", err)
 	}
-	if setResp.Definition.PolicyState != looppkg.DefinitionPolicyStateInactive || setResp.Definition.PolicySource != looppkg.DefinitionPolicySourceOverlay {
-		t.Fatalf("policy = %q/%q, want inactive/overlay", setResp.Definition.PolicyState, setResp.Definition.PolicySource)
+	loop := setResp.Definition.Loop
+	if loop == nil {
+		t.Fatal("definition Loop = nil, want canonical loop view")
 	}
-	if setResp.Definition.Runtime.LoopID != "loop-live-1" {
-		t.Fatalf("runtime loop_id = %q, want loop-live-1", setResp.Definition.Runtime.LoopID)
+	if loop.PolicyState != string(looppkg.DefinitionPolicyStateInactive) || loop.PolicySource != string(looppkg.DefinitionPolicySourceOverlay) {
+		t.Fatalf("policy = %q/%q, want inactive/overlay", loop.PolicyState, loop.PolicySource)
+	}
+	if loop.ID == nil || *loop.ID != "loop-live-1" {
+		t.Fatalf("runtime loop_id = %v, want loop-live-1", loop.ID)
 	}
 
 	deleteReq := httptest.NewRequest(http.MethodDelete, "/v1/loop-definitions/policy?name=metacog_like", nil)

--- a/internal/server/openapi/native.yaml
+++ b/internal/server/openapi/native.yaml
@@ -1754,10 +1754,11 @@ components:
           description: Per-definition combined stored-and-runtime views.
           items: { $ref: "#/components/schemas/DefinitionView" }
           example:
-            - eligibility: { eligible: true }
-              runtime: { running: true, state: processing, iterations: 142 }
+            - name: cota_weekend_observer
+              source: overlay
+              eligibility: { eligible: true }
               warnings: []
-              effective: { tags: [messaging, retrospection] }
+              loop: { name: cota_weekend_observer, operation: service, running: true, state: processing, iterations: 142, effective_tags: [{ tag: messaging, from: self }] }
       example:
         generation: 42
         updated_at: "2026-06-24T18:57:13Z"
@@ -1770,43 +1771,79 @@ components:
         by_eligibility_state: { eligible: 9, ineligible: 1 }
         by_runtime_state: { running: 2, not_running: 8 }
         definitions:
-          - eligibility: { eligible: true }
-            runtime: { running: true, state: processing, iterations: 142 }
+          - name: cota_weekend_observer
+            source: overlay
+            eligibility: { eligible: true }
             warnings: []
-            effective: { tags: [messaging, retrospection] }
+            loop: { name: cota_weekend_observer, operation: service, running: true, state: processing, iterations: 142, effective_tags: [{ tag: messaging, from: self }] }
     DefinitionView:
       type: object
-      description: One stored definition combined with its eligibility, live runtime status, warnings, and effective post-merge state.
+      description: >-
+        One stored definition combined with its canonical loop projection,
+        eligibility, and lint warnings. Loop is the canonical "ps auxwwww" row
+        (LoopView) for this definition — stored-static fields always, with the
+        live half (state, economics, errors, effective_* inheritance) overlaid
+        when a backing loop is running. The remaining fields are
+        definition-corpus framing a live LoopView intentionally does not carry:
+        the raw authored spec (for round-trip editing), the provenance source,
+        lint warnings, and the per-ancestor eligibility cascade.
       properties:
+        name:
+          type: string
+          description: The definition's stable identifier (also loop.name).
+          readOnly: true
+        source:
+          type: string
+          description: Where the definition came from — config or overlay.
+          readOnly: true
+        updated_at:
+          type: string
+          format: date-time
+          description: When the stored definition was last written.
+          readOnly: true
+        spec:
+          allOf: [{ $ref: "#/components/schemas/LoopDefinitionSpec" }]
+          description: The raw authored definition, kept for round-trip editing (loop_definition_update reads it before re-committing). loop is the resolved canonical view of the same definition.
+          readOnly: true
+        loop:
+          allOf: [{ $ref: "#/components/schemas/LoopView" }]
+          description: >-
+            Canonical loop projection of this definition. Stored-static fields
+            always; the live-only half is overlaid when a backing loop is
+            running, with loop.running as the discriminator (live-only fields
+            are null when not running).
+          readOnly: true
         eligibility:
           type: object
           additionalProperties: true
-          description: Effective eligibility evaluation for this definition, including whether it may run and why.
+          description: Detailed policy/condition eligibility. loop.eligible carries the summary bool; this carries the reason and the blocking detail.
           readOnly: true
           example: { eligible: true, reason: "all subscriptions satisfied" }
-        runtime:
-          type: object
-          additionalProperties: true
-          description: Live runtime status of the backing loop instance for this definition (running flag, state, counters, last error).
-          readOnly: true
         warnings:
           type: array
           items: { type: object }
-          description: Warnings produced while validating or rendering this definition's spec.
+          description: Lint findings produced while validating this definition's stored spec.
           readOnly: true
-        effective:
-          type: object
-          additionalProperties: true
-          description: Post-ancestor-merge state for inheritable fields (tags, subscriptions, exclude_tools, routing factors, delegation gating); absent when there is nothing meaningful to report.
+        effective_conditions:
+          type: array
+          items: { type: object }
+          description: Per-ancestor Conditions evaluation with provenance; present only when the eligibility cascade went through more than one level.
           readOnly: true
       additionalProperties: true
       example:
         name: cota_weekend_observer
-        operation: service
+        source: overlay
+        updated_at: "2026-06-24T18:57:13Z"
         eligibility: { eligible: true, reason: "all subscriptions satisfied" }
-        runtime: { running: true, state: processing, iterations: 142 }
         warnings: []
-        effective: { tags: [messaging, retrospection] }
+        loop:
+          name: cota_weekend_observer
+          operation: service
+          running: true
+          state: processing
+          iterations: 142
+          policy_state: active
+          effective_tags: [{ tag: messaging, from: self }]
     LoopDefinitionSpec:
       type: object
       description: Persistable loop definition payload (name, operation, sleep envelope, subscriptions, tags, profile, ...). First-pass permissive schema; tighten against loop.Spec / loop.DefinitionSnapshot.

--- a/internal/tools/loop_definition_read_tools.go
+++ b/internal/tools/loop_definition_read_tools.go
@@ -85,7 +85,7 @@ func (r *Registry) handleLoopDefinitionList(_ context.Context, args map[string]a
 		if completion != "" && string(def.Spec.Completion) != completion {
 			continue
 		}
-		if policyState != "" && string(def.PolicyState) != policyState {
+		if policyState != "" && (def.Loop == nil || def.Loop.PolicyState != policyState) {
 			continue
 		}
 		if eligibleFilter != "" {
@@ -102,14 +102,17 @@ func (r *Registry) handleLoopDefinitionList(_ context.Context, args map[string]a
 		}
 		if runtimeState != "" {
 			currentRuntimeState := "not_running"
-			if def.Runtime.Running {
-				currentRuntimeState = strings.ToLower(string(def.Runtime.State))
+			if def.Loop != nil && def.Loop.Running {
+				currentRuntimeState = "running"
+				if def.Loop.State != nil {
+					currentRuntimeState = strings.ToLower(*def.Loop.State)
+				}
 			}
 			if currentRuntimeState != runtimeState {
 				continue
 			}
 		}
-		if query != "" && !loopDefinitionMatchesQuery(def.DefinitionSnapshot, query) {
+		if query != "" && !loopDefinitionMatchesQuery(def, query) {
 			continue
 		}
 		items = append(items, def)
@@ -125,11 +128,14 @@ func (r *Registry) handleLoopDefinitionList(_ context.Context, args map[string]a
 	})
 }
 
-func loopDefinitionMatchesQuery(def looppkg.DefinitionSnapshot, query string) bool {
+func loopDefinitionMatchesQuery(def looppkg.DefinitionView, query string) bool {
 	if strings.Contains(strings.ToLower(def.Name), query) {
 		return true
 	}
 	if strings.Contains(strings.ToLower(def.Spec.Task), query) {
+		return true
+	}
+	if strings.Contains(strings.ToLower(def.Spec.Intent), query) {
 		return true
 	}
 	if strings.Contains(strings.ToLower(def.Spec.Profile.Mission), query) {

--- a/internal/tools/loop_definition_read_tools.go
+++ b/internal/tools/loop_definition_read_tools.go
@@ -79,10 +79,13 @@ func (r *Registry) handleLoopDefinitionList(_ context.Context, args map[string]a
 		if source != "" && string(def.Source) != source {
 			continue
 		}
-		if operation != "" && string(def.Spec.Operation) != operation {
+		// Filter against the canonical projected values the client sees in
+		// results (e.g. an unset spec operation surfaces as "request_reply"),
+		// not the raw spec, so a filter matches what it returns.
+		if operation != "" && (def.Loop == nil || def.Loop.Operation != operation) {
 			continue
 		}
-		if completion != "" && string(def.Spec.Completion) != completion {
+		if completion != "" && (def.Loop == nil || def.Loop.Completion != completion) {
 			continue
 		}
 		if policyState != "" && (def.Loop == nil || def.Loop.PolicyState != policyState) {

--- a/internal/tools/loop_definition_tools_test.go
+++ b/internal/tools/loop_definition_tools_test.go
@@ -57,11 +57,14 @@ func newTestLoopDefinitionDeps(t *testing.T) *testLoopDefinitionDeps {
 	reg.ConfigureLoopDefinitionTools(LoopDefinitionToolDeps{
 		Registry: defs,
 		View: func() *looppkg.DefinitionRegistryView {
-			return looppkg.BuildDefinitionRegistryView(defs.Snapshot(), map[string]looppkg.DefinitionRuntimeStatus{
+			// Presence in liveByName (keyed by definition name) means the
+			// definition has a running backing loop; the Status carries the
+			// live state (sleeping) and ID the projection surfaces on Loop.
+			return looppkg.BuildDefinitionRegistryView(defs.Snapshot(), map[string]looppkg.Status{
 				"metacog_like": {
-					Running: true,
-					LoopID:  "loop-live-1",
-					State:   looppkg.StateSleeping,
+					Name:  "metacog_like",
+					ID:    "loop-live-1",
+					State: looppkg.StateSleeping,
 				},
 			})
 		},
@@ -450,14 +453,23 @@ func TestLoopDefinitionSetPolicyAndLaunch(t *testing.T) {
 	if err := json.Unmarshal([]byte(out), &policyResp); err != nil {
 		t.Fatalf("unmarshal policy response: %v", err)
 	}
-	if policyResp.Definition.PolicyState != looppkg.DefinitionPolicyStateInactive || policyResp.Definition.PolicySource != looppkg.DefinitionPolicySourceOverlay {
-		t.Fatalf("policy = %q/%q, want inactive/overlay", policyResp.Definition.PolicyState, policyResp.Definition.PolicySource)
+	if policyResp.Definition.Loop == nil {
+		t.Fatal("definition loop view = nil, want live loop projection")
+	}
+	if policyResp.Definition.Loop.PolicyState != string(looppkg.DefinitionPolicyStateInactive) || policyResp.Definition.Loop.PolicySource != string(looppkg.DefinitionPolicySourceOverlay) {
+		t.Fatalf("policy = %q/%q, want inactive/overlay", policyResp.Definition.Loop.PolicyState, policyResp.Definition.Loop.PolicySource)
 	}
 	if deps.persistedPolicy["metacog_like"].Reason != "quiet hours" {
 		t.Fatalf("persisted policy = %+v, want quiet hours", deps.persistedPolicy["metacog_like"])
 	}
-	if policyResp.Definition.Runtime.LoopID != "loop-live-1" {
-		t.Fatalf("runtime loop_id = %q, want loop-live-1", policyResp.Definition.Runtime.LoopID)
+	if !policyResp.Definition.Loop.Running {
+		t.Fatal("definition loop running = false, want true (live loop should be surfaced)")
+	}
+	if policyResp.Definition.Loop.ID == nil {
+		t.Fatal("definition loop id = nil, want loop-live-1")
+	}
+	if *policyResp.Definition.Loop.ID != "loop-live-1" {
+		t.Fatalf("runtime loop_id = %q, want loop-live-1", *policyResp.Definition.Loop.ID)
 	}
 
 	launchOut, err := deps.reg.Get("loop_definition_launch").Handler(context.Background(), map[string]any{
@@ -767,24 +779,28 @@ func TestLoopDefinitionListFiltersEligibility(t *testing.T) {
 			Generation: 1,
 			Definitions: []looppkg.DefinitionView{
 				{
-					DefinitionSnapshot: looppkg.DefinitionSnapshot{
-						Name: "eligible_watch",
-						Spec: looppkg.Spec{
-							Name:      "eligible_watch",
-							Task:      "watch",
-							Operation: looppkg.OperationService,
-						},
+					Name: "eligible_watch",
+					Spec: looppkg.Spec{
+						Name:      "eligible_watch",
+						Task:      "watch",
+						Operation: looppkg.OperationService,
+					},
+					Loop: &looppkg.LoopView{
+						Name:     "eligible_watch",
+						Eligible: true,
 					},
 					Eligibility: looppkg.DefinitionEligibilityStatus{Eligible: true},
 				},
 				{
-					DefinitionSnapshot: looppkg.DefinitionSnapshot{
-						Name: "ineligible_watch",
-						Spec: looppkg.Spec{
-							Name:      "ineligible_watch",
-							Task:      "watch later",
-							Operation: looppkg.OperationService,
-						},
+					Name: "ineligible_watch",
+					Spec: looppkg.Spec{
+						Name:      "ineligible_watch",
+						Task:      "watch later",
+						Operation: looppkg.OperationService,
+					},
+					Loop: &looppkg.LoopView{
+						Name:     "ineligible_watch",
+						Eligible: false,
 					},
 					Eligibility: looppkg.DefinitionEligibilityStatus{
 						Eligible: false,

--- a/internal/tools/loop_runtime_tools.go
+++ b/internal/tools/loop_runtime_tools.go
@@ -453,36 +453,35 @@ func matchLoopOperation(status looppkg.Status, operation looppkg.Operation) bool
 // eligibility without a second tool call. Returns nil when no definition
 // view is wired (loops then report policy_state="ephemeral").
 func (r *Registry) loopPolicyByName() map[string]looppkg.LoopPolicyInfo {
-	if r.loopDefinitionView == nil {
+	if r.loopDefinitionRegistry == nil {
 		return nil
 	}
-	view := r.loopDefinitionView()
-	if view == nil {
-		return nil
-	}
-	// The projected view carries each definition's computed eligibility, but
-	// only a pre-formatted policy_updated_delta — the raw policy (with its
+	// Take ONE registry snapshot and derive both the raw policy (with its
 	// UpdatedAt time, which FromStatus needs to format the delta at its own
-	// render clock) lives on the registry snapshot. Index the snapshot by name
-	// and join.
-	policyByName := map[string]looppkg.DefinitionSnapshot{}
-	if r.loopDefinitionRegistry != nil {
-		if snap := r.loopDefinitionRegistry.Snapshot(); snap != nil {
-			for _, d := range snap.Definitions {
-				policyByName[d.Name] = d
-			}
-		}
+	// render clock) and the computed eligibility from it. Reading policy and
+	// eligibility from two independent Snapshot() calls opens a TOCTOU window
+	// where a definition deleted between them surfaces a half-populated join
+	// (empty policy_state but HasPolicy=true); the pre-B1 view embedded both
+	// together, keeping this atomic.
+	snap := r.loopDefinitionRegistry.Snapshot()
+	if snap == nil {
+		return nil
 	}
-	out := make(map[string]looppkg.LoopPolicyInfo, len(view.Definitions))
+	view := looppkg.BuildDefinitionRegistryView(snap, nil)
+	eligByName := make(map[string]looppkg.DefinitionEligibilityStatus, len(view.Definitions))
 	for _, def := range view.Definitions {
-		pol := policyByName[def.Name]
-		out[def.Name] = looppkg.LoopPolicyInfo{
-			State:          string(pol.PolicyState),
-			Source:         string(pol.PolicySource),
-			Reason:         pol.PolicyReason,
-			UpdatedAt:      pol.PolicyUpdatedAt,
-			Eligible:       def.Eligibility.Eligible,
-			EligibleReason: def.Eligibility.Reason,
+		eligByName[def.Name] = def.Eligibility
+	}
+	out := make(map[string]looppkg.LoopPolicyInfo, len(snap.Definitions))
+	for _, d := range snap.Definitions {
+		elig := eligByName[d.Name]
+		out[d.Name] = looppkg.LoopPolicyInfo{
+			State:          string(d.PolicyState),
+			Source:         string(d.PolicySource),
+			Reason:         d.PolicyReason,
+			UpdatedAt:      d.PolicyUpdatedAt,
+			Eligible:       elig.Eligible,
+			EligibleReason: elig.Reason,
 			HasPolicy:      true,
 		}
 	}

--- a/internal/tools/loop_runtime_tools.go
+++ b/internal/tools/loop_runtime_tools.go
@@ -460,13 +460,27 @@ func (r *Registry) loopPolicyByName() map[string]looppkg.LoopPolicyInfo {
 	if view == nil {
 		return nil
 	}
+	// The projected view carries each definition's computed eligibility, but
+	// only a pre-formatted policy_updated_delta — the raw policy (with its
+	// UpdatedAt time, which FromStatus needs to format the delta at its own
+	// render clock) lives on the registry snapshot. Index the snapshot by name
+	// and join.
+	policyByName := map[string]looppkg.DefinitionSnapshot{}
+	if r.loopDefinitionRegistry != nil {
+		if snap := r.loopDefinitionRegistry.Snapshot(); snap != nil {
+			for _, d := range snap.Definitions {
+				policyByName[d.Name] = d
+			}
+		}
+	}
 	out := make(map[string]looppkg.LoopPolicyInfo, len(view.Definitions))
 	for _, def := range view.Definitions {
+		pol := policyByName[def.Name]
 		out[def.Name] = looppkg.LoopPolicyInfo{
-			State:          string(def.PolicyState),
-			Source:         string(def.PolicySource),
-			Reason:         def.PolicyReason,
-			UpdatedAt:      def.PolicyUpdatedAt,
+			State:          string(pol.PolicyState),
+			Source:         string(pol.PolicySource),
+			Reason:         pol.PolicyReason,
+			UpdatedAt:      pol.PolicyUpdatedAt,
 			Eligible:       def.Eligibility.Eligible,
 			EligibleReason: def.Eligibility.Reason,
 			HasPolicy:      true,


### PR DESCRIPTION
## What

Third step of #1106 (after C1 `Spec.Intent`, C2 `Spec.Origin`): `loop_definition_get` / `loop_definition_list` returned the thin `DefinitionRuntimeStatus`; they now project each definition through the **canonical `LoopView`** via a new `FromDefinition` projector. This is the #1104 "one `ps auxwwww` row everywhere" goal extended to the definition corpus — and where **C1's intent and C2's origin finally become visible** to the model and operator.

Shape decision: **clean-cut to `LoopView`** (chosen over additive / enrich-in-place).

## How

- **`DefinitionViewResolver` + `FromDefinition`** (`loop_view.go`): static fields from the `Spec`, graph (`parent_name`/`ancestry`/`child_count`) resolved from the definition's `parent_name` chain (not live loop IDs), policy + eligibility from the stored snapshot. When a backing loop is running, its full `Status` is overlaid via a shared **`applyLiveTelemetry`** helper extracted from `FromStatus`, so the live half is byte-identical to a `loop_status` row; a stored-only definition is `running:false` with every live-only pointer null.
- **`LoopView.Origin`** added and surfaced from `Spec.Origin` / `Config.Origin` (so both projectors carry creation provenance); `Spec.Origin` now flows to `Config.Origin` in `ToConfig`.
- **`DefinitionView` clean-cut**: `{name, source, updated_at, spec, loop *LoopView, eligibility, warnings, effective_conditions}`. Drops the thin `DefinitionRuntimeStatus` and `DefinitionEffectiveState` (folded into `loop.*` and `loop.effective_*`); the full live `Status` already carries the resolved `effective_*` lists, so the separate `effectiveState` walk (`WithLiveRegistry`) is gone.
- **`BuildDefinitionRegistryView`** takes `map[string]Status` (keyed by name, presence = running) instead of the thin runtime map.
- `native.yaml` `DefinitionView` schema updated. **Web console unaffected** — it reads `definition.spec`, which is preserved.

## Self-review (adversarial pass, all confirmed + fixed in `7a21ec8e`)

- **Policy-join TOCTOU** (`loop_status` + `/v1/loops`): the join had been reading raw policy from a *second* registry snapshot than the one backing eligibility — a definition deleted between the two reads rendered `policy_state:""` instead of `"ephemeral"`. Pre-B1 this was atomic. Now both come from **one** snapshot.
- **`operation` parity**: `FromStatus` emitted raw `Config.Operation` while `FromDefinition` normalized via `effectiveOperation`, so the same loop could report `""` vs `"request_reply"` across surfaces. `FromStatus` now normalizes too (the schema documents no `""` operation). Test added.

## Test plan
- [x] `FromDefinition` stored-not-running (live-only nil, origin/intent surfaced, graph from `parent_name`), running-overlays-live, graph-from-names
- [x] `FromStatus` refactor preserves all fields (existing projector tests green)
- [x] operation normalized consistently across both projectors
- [x] consumer tests adapted to the new shape (registry/tools/app/server)
- [x] `just ci` green

Refs #1106.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
