### PR TITLE
feat(loops): canonical loop:LoopView on spawn_loop + stop_loop results (#1106 B2)

### DIFF
--- a/internal/tools/loop_result_view.go
+++ b/internal/tools/loop_result_view.go
@@ -36,12 +36,29 @@ func (r *Registry) loopViewByID(id string) (looppkg.LoopView, bool) {
 
 // loopViewFromStatus projects an already-captured Status — e.g. the pre-stop
 // snapshot stop_loop holds, or a launch's final status — into its canonical
-// LoopView, resolving the graph against the current live batch (the loop itself
-// may no longer be in it).
+// LoopView, resolving the graph against the current live batch.
+//
+// The captured loop is often no longer in the live batch (stop_loop captures it
+// before stopping; a synchronous spawn's loop has finished), so we add the
+// status to the batch before building the resolver. ancestry/child_count are
+// keyed by loop ID, so without its own entry the resolver would report an empty
+// ancestry even when ParentID is known. Guard against double-indexing — which
+// would over-count the parent's child_count — for the case where the loop is
+// still live.
 func (r *Registry) loopViewFromStatus(s looppkg.Status) looppkg.LoopView {
 	var statuses []looppkg.Status
 	if r.liveLoopRegistry != nil {
 		statuses = r.liveLoopRegistry.Statuses()
+	}
+	present := false
+	for _, existing := range statuses {
+		if existing.ID == s.ID {
+			present = true
+			break
+		}
+	}
+	if !present {
+		statuses = append(statuses, s)
 	}
 	return r.loopViewResolver(statuses).FromStatus(s)
 }

--- a/internal/tools/loop_result_view.go
+++ b/internal/tools/loop_result_view.go
@@ -1,0 +1,47 @@
+package tools
+
+import (
+	"time"
+
+	looppkg "github.com/nugget/thane-ai-agent/internal/runtime/loop"
+)
+
+// This file provides the canonical-LoopView projection helpers the model-facing
+// loop result surfaces share (#1106 B2), so spawn_loop / stop_loop and the
+// definition mutation tools all emit the same "ps auxwwww" row that loop_status
+// and loop_definition_get do, rather than a bespoke per-tool shape.
+
+// loopViewResolver builds a LoopView resolver over the given live status batch
+// (so parent_name / ancestry / child_count resolve) joined with the definition
+// policy/eligibility, capturing one clock for all delta strings.
+func (r *Registry) loopViewResolver(statuses []looppkg.Status) looppkg.LoopViewResolver {
+	return looppkg.NewLoopViewResolver(statuses, r.loopPolicyByName(), time.Now())
+}
+
+// loopViewByID projects the currently-live loop with the given id into its
+// canonical LoopView, returning ok=false when no live loop matches.
+func (r *Registry) loopViewByID(id string) (looppkg.LoopView, bool) {
+	if r.liveLoopRegistry == nil {
+		return looppkg.LoopView{}, false
+	}
+	statuses := r.liveLoopRegistry.Statuses()
+	resolver := r.loopViewResolver(statuses)
+	for _, s := range statuses {
+		if s.ID == id {
+			return resolver.FromStatus(s), true
+		}
+	}
+	return looppkg.LoopView{}, false
+}
+
+// loopViewFromStatus projects an already-captured Status — e.g. the pre-stop
+// snapshot stop_loop holds, or a launch's final status — into its canonical
+// LoopView, resolving the graph against the current live batch (the loop itself
+// may no longer be in it).
+func (r *Registry) loopViewFromStatus(s looppkg.Status) looppkg.LoopView {
+	var statuses []looppkg.Status
+	if r.liveLoopRegistry != nil {
+		statuses = r.liveLoopRegistry.Statuses()
+	}
+	return r.loopViewResolver(statuses).FromStatus(s)
+}

--- a/internal/tools/loop_runtime_tools.go
+++ b/internal/tools/loop_runtime_tools.go
@@ -310,11 +310,19 @@ func (r *Registry) handleSpawnLoop(ctx context.Context, args map[string]any) (st
 	if err != nil {
 		return "", err
 	}
-	return ldMarshalToolJSON(map[string]any{
+	out := map[string]any{
 		"status":     "ok",
 		"result":     result,
 		"completion": completion,
-	})
+	}
+	// Surface the spawned loop's canonical row (#1106 B2): the live instance
+	// while it runs, else its captured final status for a synchronous spawn.
+	if lv, ok := r.loopViewByID(result.LoopID); ok {
+		out["loop"] = lv
+	} else if result.FinalStatus != nil {
+		out["loop"] = r.loopViewFromStatus(*result.FinalStatus)
+	}
+	return ldMarshalToolJSON(out)
 }
 
 func parseNextSleepDurationArg(args map[string]any) (time.Duration, string, error) {
@@ -390,7 +398,9 @@ func (r *Registry) handleStopLoop(_ context.Context, args map[string]any) (strin
 	}
 	return ldMarshalToolJSON(map[string]any{
 		"status": "ok",
-		"loop":   status,
+		// status is the pre-stop snapshot; project it to the canonical row so
+		// stop_loop returns the same loop shape as every other surface (#1106 B2).
+		"loop": r.loopViewFromStatus(status),
 	})
 }
 

--- a/internal/tools/loop_runtime_tools_test.go
+++ b/internal/tools/loop_runtime_tools_test.go
@@ -190,6 +190,35 @@ func TestSpawnLoopReturnsCanonicalLoopView(t *testing.T) {
 	}
 }
 
+func TestLoopViewFromStatus_ResolvesAncestryOfDeregisteredLoop(t *testing.T) {
+	// stop_loop captures a loop's status before deregistering it, so by the time
+	// the result is projected the loop is gone from the live batch. Its parent
+	// (still live) must resolve, and ancestry must not come back empty just
+	// because the loop's own id is no longer in the batch.
+	parent, err := looppkg.New(looppkg.Config{Name: "watchers", Operation: looppkg.OperationContainer}, looppkg.Deps{Runner: noopLoopRunner{}})
+	if err != nil {
+		t.Fatalf("New(parent): %v", err)
+	}
+	live := looppkg.NewRegistry(looppkg.WithMaxLoops(3))
+	if err := live.Register(parent); err != nil {
+		t.Fatalf("Register(parent): %v", err)
+	}
+	reg := NewEmptyRegistry()
+	reg.ConfigureLoopRuntimeTools(LoopRuntimeToolDeps{Registry: live})
+
+	captured := looppkg.Status{
+		ID: "lp_child", Name: "child", ParentID: parent.ID(),
+		State: looppkg.State("sleeping"), Config: looppkg.Config{Operation: looppkg.OperationService},
+	}
+	lv := reg.loopViewFromStatus(captured)
+	if lv.ParentName == nil || *lv.ParentName != "watchers" {
+		t.Errorf("parent_name = %v, want watchers", lv.ParentName)
+	}
+	if len(lv.Ancestry) != 1 || lv.Ancestry[0] != "watchers" {
+		t.Errorf("ancestry = %v, want [watchers] — a deregistered loop's parent link must still resolve", lv.Ancestry)
+	}
+}
+
 func TestSetNextSleepForCurrentServiceLoop(t *testing.T) {
 	deps := newTestLoopRuntimeDeps(t)
 	live := deps.live.GetByName("battery_watch")
@@ -365,7 +394,7 @@ func TestLoopStatusFiltersAndStopLoop(t *testing.T) {
 	if stopped.Loop["name"] != "battery_watch" {
 		t.Fatalf("stopped loop = %#v, want battery_watch", stopped.Loop)
 	}
-	// B2: stop_loop now returns the spawned loop's canonical LoopView, not the
+	// B2: stop_loop now returns the stopped loop's canonical LoopView, not the
 	// raw Status it used to emit — policy_state is a LoopView-only field.
 	if _, ok := stopped.Loop["policy_state"]; !ok {
 		t.Errorf("stop_loop should return the canonical LoopView, got %#v", stopped.Loop)

--- a/internal/tools/loop_runtime_tools_test.go
+++ b/internal/tools/loop_runtime_tools_test.go
@@ -137,6 +137,59 @@ func TestSpawnLoopRejectsTopLevelModelOverride(t *testing.T) {
 	}
 }
 
+func TestSpawnLoopReturnsCanonicalLoopView(t *testing.T) {
+	live := looppkg.NewRegistry(looppkg.WithMaxLoops(3))
+	spawned, err := looppkg.New(looppkg.Config{
+		Name:      "adhoc_task",
+		Task:      "do a thing",
+		Operation: looppkg.OperationBackgroundTask,
+	}, looppkg.Deps{Runner: noopLoopRunner{}})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := live.Register(spawned); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	reg := NewEmptyRegistry()
+	reg.ConfigureLoopRuntimeTools(LoopRuntimeToolDeps{
+		Registry: live,
+		LaunchLoop: func(_ context.Context, _ looppkg.Launch) (looppkg.LaunchResult, error) {
+			return looppkg.LaunchResult{LoopID: spawned.ID(), Operation: looppkg.OperationBackgroundTask, Detached: true}, nil
+		},
+	})
+
+	out, err := reg.Get("spawn_loop").Handler(context.Background(), map[string]any{
+		"launch": map[string]any{
+			"spec": map[string]any{"task": "do a thing", "operation": "background_task"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("spawn_loop: %v", err)
+	}
+
+	var resp struct {
+		Status string         `json:"status"`
+		Loop   map[string]any `json:"loop"`
+	}
+	if err := json.Unmarshal([]byte(out), &resp); err != nil {
+		t.Fatalf("unmarshal spawn_loop: %v", err)
+	}
+	if resp.Loop == nil {
+		t.Fatal("spawn_loop should surface the spawned loop's canonical row (#1106 B2)")
+	}
+	if resp.Loop["name"] != "adhoc_task" {
+		t.Errorf("loop.name = %v, want adhoc_task", resp.Loop["name"])
+	}
+	// Canonical LoopView, not the raw LaunchResult — policy_state is LoopView-only.
+	if _, ok := resp.Loop["policy_state"]; !ok {
+		t.Errorf("spawn_loop loop should be a canonical LoopView, got %#v", resp.Loop)
+	}
+	if resp.Loop["operation"] != "background_task" {
+		t.Errorf("loop.operation = %v, want background_task", resp.Loop["operation"])
+	}
+}
+
 func TestSetNextSleepForCurrentServiceLoop(t *testing.T) {
 	deps := newTestLoopRuntimeDeps(t)
 	live := deps.live.GetByName("battery_watch")
@@ -304,13 +357,21 @@ func TestLoopStatusFiltersAndStopLoop(t *testing.T) {
 	}
 	var stopped struct {
 		Status string         `json:"status"`
-		Loop   looppkg.Status `json:"loop"`
+		Loop   map[string]any `json:"loop"`
 	}
 	if err := json.Unmarshal([]byte(stopOut), &stopped); err != nil {
 		t.Fatalf("unmarshal stop_loop: %v", err)
 	}
-	if stopped.Loop.Name != "battery_watch" {
+	if stopped.Loop["name"] != "battery_watch" {
 		t.Fatalf("stopped loop = %#v, want battery_watch", stopped.Loop)
+	}
+	// B2: stop_loop now returns the spawned loop's canonical LoopView, not the
+	// raw Status it used to emit — policy_state is a LoopView-only field.
+	if _, ok := stopped.Loop["policy_state"]; !ok {
+		t.Errorf("stop_loop should return the canonical LoopView, got %#v", stopped.Loop)
+	}
+	if stopped.Loop["operation"] != "service" {
+		t.Errorf("stopped loop.operation = %v, want service (normalized)", stopped.Loop["operation"])
 	}
 	if deps.live.ActiveCount() != 1 {
 		t.Fatalf("ActiveCount after stop = %d, want 1", deps.live.ActiveCount())


### PR DESCRIPTION
## What

B2 of #1106: every loop **result surface** should carry the canonical `LoopView` row (the #1104 "one ps-auxwwww row everywhere" goal, extended to tool results).

Post-B1, most already do:
- `loop_definition_set` / `set_policy` / `launch` return `definition` whose `.loop` is the canonical row (from B1's `FromDefinition`).
- `loop_reparent` returns a top-level `loop` (#1105).

The gap was the two **live/ephemeral** surfaces that returned raw shapes:
- **`spawn_loop`** returned only the raw `LaunchResult` — now also surfaces the spawned loop's canonical row as a top-level `loop` (the live instance by id; else the launch's `final_status` for a synchronous spawn).
- **`stop_loop`** returned the raw pre-stop `Status` as `loop` — now projects that captured snapshot through the canonical `LoopView`, so it matches every other surface.

## How

Shared projection helpers in `loop_result_view.go` so the result surfaces emit the same row `loop_status`/`loop_definition_get` do, rather than bespoke per-tool shapes:
- `loopViewResolver(statuses)` — resolver over the live batch + policy join
- `loopViewByID(id)` — project a live loop by id
- `loopViewFromStatus(s)` — project an already-captured `Status` (graph resolved against the current live batch, since the loop itself may be gone)

These are model-facing tool JSON outputs, not `/v1` endpoints, so there's no `native.yaml`/HTTP schema change.

## Test plan
- [x] `stop_loop` returns the canonical `LoopView` (policy_state/normalized operation present), not the raw Status
- [x] `spawn_loop` surfaces the spawned loop's canonical row
- [x] `just ci` green

Refs #1106.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
