### PR TITLE
feat(loops): always-on loop self-context block (#1106 B3)

### DIFF
--- a/internal/app/loop_definition_runtime.go
+++ b/internal/app/loop_definition_runtime.go
@@ -758,11 +758,19 @@ func (a *App) loopViewByID(loopID string) (looppkg.LoopView, bool) {
 	if !ok {
 		return looppkg.LoopView{}, false
 	}
+	// Prefer the definition view (policy/eligibility/effective_* resolved), but
+	// only when it resolves to THIS exact loop. Loop names are not unique — the
+	// live registry keys by id while the definition view is name-keyed — so a
+	// same-named sibling could otherwise have its row returned for the wrong id.
 	if view := a.loopDefinitionView(); view != nil {
-		if def, ok := looppkg.FindDefinitionView(view, st.Name); ok && def.Loop != nil {
+		if def, ok := looppkg.FindDefinitionView(view, st.Name); ok &&
+			def.Loop != nil && def.Loop.ID != nil && *def.Loop.ID == loopID {
 			return *def.Loop, true
 		}
 	}
+	// Ephemeral loop (no definition), or a name collision the name-keyed view
+	// can't disambiguate: project the id-precise Status directly. This is the
+	// rare path, so its extra Statuses() walk is not on the common hot path.
 	resolver := looppkg.NewLoopViewResolver(a.loopRegistry.Statuses(), nil, time.Now())
 	return resolver.FromStatus(st), true
 }

--- a/internal/app/loop_definition_runtime.go
+++ b/internal/app/loop_definition_runtime.go
@@ -745,6 +745,28 @@ func (a *App) launchLoopDefinition(ctx context.Context, name string, launch loop
 	return a.loopDefinitionRuntime.LaunchDefinition(ctx, name, launch)
 }
 
+// loopViewByID resolves a live loop id to its canonical LoopView for the
+// self-context provider (#1106 B3). It prefers the definition view — where
+// policy, eligibility, and effective_* are already resolved with live telemetry
+// overlaid — and falls back to a live projection for ephemeral, definition-less
+// loops. Returns ok=false for an id with no live loop.
+func (a *App) loopViewByID(loopID string) (looppkg.LoopView, bool) {
+	if a == nil || a.loopRegistry == nil {
+		return looppkg.LoopView{}, false
+	}
+	st, ok := a.loopRegistry.StatusByID(loopID)
+	if !ok {
+		return looppkg.LoopView{}, false
+	}
+	if view := a.loopDefinitionView(); view != nil {
+		if def, ok := looppkg.FindDefinitionView(view, st.Name); ok && def.Loop != nil {
+			return *def.Loop, true
+		}
+	}
+	resolver := looppkg.NewLoopViewResolver(a.loopRegistry.Statuses(), nil, time.Now())
+	return resolver.FromStatus(st), true
+}
+
 func (a *App) loopDefinitionView() *looppkg.DefinitionRegistryView {
 	if a == nil {
 		return nil

--- a/internal/app/loop_definition_runtime.go
+++ b/internal/app/loop_definition_runtime.go
@@ -758,21 +758,42 @@ func (a *App) loopViewByID(loopID string) (looppkg.LoopView, bool) {
 	if !ok {
 		return looppkg.LoopView{}, false
 	}
-	// Prefer the definition view (policy/eligibility/effective_* resolved), but
-	// only when it resolves to THIS exact loop. Loop names are not unique — the
-	// live registry keys by id while the definition view is name-keyed — so a
-	// same-named sibling could otherwise have its row returned for the wrong id.
+	// Prefer the definition view — policy, eligibility, and effective_* are
+	// already resolved there. Loop names are not unique (the live registry keys
+	// by id while the definition view is name-keyed), so use the name-matched
+	// row directly only when it resolves to THIS exact loop; otherwise a
+	// same-named sibling's live telemetry would be returned for the wrong id.
 	if view := a.loopDefinitionView(); view != nil {
-		if def, ok := looppkg.FindDefinitionView(view, st.Name); ok &&
-			def.Loop != nil && def.Loop.ID != nil && *def.Loop.ID == loopID {
-			return *def.Loop, true
+		if def, ok := looppkg.FindDefinitionView(view, st.Name); ok && def.Loop != nil {
+			if def.Loop.ID != nil && *def.Loop.ID == loopID {
+				return *def.Loop, true
+			}
+			// Name collision: project THIS loop id-precisely, but carry the
+			// definition's policy/eligibility. Those are per-definition (keyed by
+			// name), not per-instance, so they hold for any loop of this name —
+			// and keep the self-context from misreporting a definition-backed
+			// loop as "ephemeral".
+			v := a.projectLiveLoopView(st)
+			v.PolicyState = def.Loop.PolicyState
+			v.PolicySource = def.Loop.PolicySource
+			v.PolicyReason = def.Loop.PolicyReason
+			v.PolicyUpdatedDelta = def.Loop.PolicyUpdatedDelta
+			v.Eligible = def.Loop.Eligible
+			return v, true
 		}
 	}
-	// Ephemeral loop (no definition), or a name collision the name-keyed view
-	// can't disambiguate: project the id-precise Status directly. This is the
-	// rare path, so its extra Statuses() walk is not on the common hot path.
-	resolver := looppkg.NewLoopViewResolver(a.loopRegistry.Statuses(), nil, time.Now())
-	return resolver.FromStatus(st), true
+	// No definition of this name (a genuinely ephemeral loop): an id-precise
+	// projection carrying the "ephemeral" policy the projector assigns a loop
+	// with no backing definition.
+	return a.projectLiveLoopView(st), true
+}
+
+// projectLiveLoopView projects a live Status into its canonical LoopView using
+// the current live batch for graph resolution (parent_name/ancestry/child_count),
+// with no definition policy join — callers overlay policy when a definition
+// backs the loop.
+func (a *App) projectLiveLoopView(st looppkg.Status) looppkg.LoopView {
+	return looppkg.NewLoopViewResolver(a.loopRegistry.Statuses(), nil, time.Now()).FromStatus(st)
 }
 
 func (a *App) loopDefinitionView() *looppkg.DefinitionRegistryView {

--- a/internal/app/loop_definition_runtime_test.go
+++ b/internal/app/loop_definition_runtime_test.go
@@ -407,6 +407,11 @@ func TestLoopViewByID_IsIDPreciseUnderNameCollision(t *testing.T) {
 		if v.ID == nil || *v.ID != id {
 			t.Errorf("loopViewByID(%s) resolved to id %v — a same-named sibling's row leaked into this loop's self-context", id, v.ID)
 		}
+		// A "worker" definition backs this name, so the collision path must carry
+		// its (per-name) policy, not fall back to a misleading "ephemeral".
+		if v.PolicyState == "ephemeral" {
+			t.Errorf("loopViewByID(%s) reported policy_state=ephemeral, but a definition backs this name — the definition's policy must be carried", id)
+		}
 	}
 }
 

--- a/internal/app/loop_definition_runtime_test.go
+++ b/internal/app/loop_definition_runtime_test.go
@@ -361,6 +361,55 @@ func TestLoopDefinitionRuntimeLaunchDefinition(t *testing.T) {
 	}
 }
 
+func TestLoopViewByID_IsIDPreciseUnderNameCollision(t *testing.T) {
+	t.Parallel()
+
+	// The definition view is name-keyed, but the live registry keys by id and
+	// loop names are not unique. loopViewByID must resolve THIS exact loop, never
+	// a same-named sibling's row (#1106 B3 review).
+	defs, err := looppkg.NewDefinitionRegistry([]looppkg.Spec{
+		{
+			Name: "worker", Enabled: true, Task: "work", Operation: looppkg.OperationService,
+			SleepMin: time.Minute, SleepMax: time.Minute, SleepDefault: time.Minute, Jitter: looppkg.Float64Ptr(0),
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewDefinitionRegistry: %v", err)
+	}
+
+	loopFor := func() *looppkg.Loop {
+		l, err := looppkg.New(looppkg.Config{Name: "worker", Operation: looppkg.OperationService, Task: "work"}, looppkg.Deps{Runner: testLoopRunner{}})
+		if err != nil {
+			t.Fatalf("New: %v", err)
+		}
+		return l
+	}
+	loops := looppkg.NewRegistry()
+	a1, a2 := loopFor(), loopFor()
+	if err := loops.Register(a1); err != nil {
+		t.Fatalf("Register a1: %v", err)
+	}
+	if err := loops.Register(a2); err != nil {
+		t.Fatalf("Register a2: %v", err)
+	}
+
+	runtime := &loopDefinitionRuntime{
+		definitions: defs, loops: loops, runner: testLoopRunner{},
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)), now: time.Now, scheduleCh: make(chan struct{}, 1),
+	}
+	app := &App{loopRegistry: loops, loopDefinitionRuntime: runtime}
+
+	for _, id := range []string{a1.ID(), a2.ID()} {
+		v, ok := app.loopViewByID(id)
+		if !ok {
+			t.Fatalf("loopViewByID(%s): not found", id)
+		}
+		if v.ID == nil || *v.ID != id {
+			t.Errorf("loopViewByID(%s) resolved to id %v — a same-named sibling's row leaked into this loop's self-context", id, v.ID)
+		}
+	}
+}
+
 func TestLoopDefinitionRuntimeSnapshotIncludesRunningLoop(t *testing.T) {
 	t.Parallel()
 

--- a/internal/app/new_awareness.go
+++ b/internal/app/new_awareness.go
@@ -32,6 +32,12 @@ func (a *App) initAwareness(s *newState) error {
 	contactLookup := &contactNameLookup{store: a.contactStore, logger: logger}
 	a.loop.RegisterAlwaysContextProvider(agent.NewChannelProvider(contactLookup))
 	a.loop.UseContactLookup(contactLookup)
+	// Self-context: inject the running loop's own canonical row each iteration
+	// so it is self-aware — id/state/parent/intent/cadence/effective-tags —
+	// without a loop_status tool call (#1106 B3). One provider serves every
+	// non-container loop; it resolves the current loop from the iteration's
+	// loop_id.
+	a.loop.RegisterAlwaysContextProvider(agent.NewLoopSelfContextProvider(a.loopViewByID))
 	a.loop.RegisterAlwaysContextProvider(agent.NewChannelOverviewProvider(agent.ChannelOverviewConfig{
 		Loops:  &channelLoopAdapter{registry: a.loopRegistry},
 		Phones: &contactPhoneResolver{store: a.contactStore},

--- a/internal/runtime/agent/loop_self_context.go
+++ b/internal/runtime/agent/loop_self_context.go
@@ -1,0 +1,48 @@
+package agent
+
+import (
+	"context"
+
+	"github.com/nugget/thane-ai-agent/internal/runtime/agentctx"
+	"github.com/nugget/thane-ai-agent/internal/runtime/loop"
+)
+
+// LoopSelfContextProvider injects a running loop's own canonical view into its
+// system prompt each iteration (#1106 B3), so a loop sees its id/state/parent/
+// intent/cadence/effective-tags without a loop_status tool call. It resolves the
+// current loop from the loop_id the runtime stamps into the iteration context
+// (loop.Loop.run), so a single registered provider serves every non-container
+// loop. Suppressed for delegate runs like every always-on provider.
+type LoopSelfContextProvider struct {
+	viewByID func(loopID string) (loop.LoopView, bool)
+}
+
+// NewLoopSelfContextProvider builds the provider. viewByID resolves a live
+// loop_id to its canonical LoopView — the app wires this over the loop registry
+// and definition view — returning ok=false for an unknown or not-yet-live id.
+func NewLoopSelfContextProvider(viewByID func(loopID string) (loop.LoopView, bool)) *LoopSelfContextProvider {
+	return &LoopSelfContextProvider{viewByID: viewByID}
+}
+
+// TagContextBucket places the self-context under the live-state bucket — it is
+// the loop's current runtime state.
+func (p *LoopSelfContextProvider) TagContextBucket() agentctx.ContextBucket {
+	return agentctx.ContextBucketLiveState
+}
+
+// TagContext renders the current loop's self-context block, or "" when there is
+// no resolvable loop — a delegate run, or a turn with no loop_id in context.
+func (p *LoopSelfContextProvider) TagContext(ctx context.Context, _ agentctx.ContextRequest) (string, error) {
+	if p == nil || p.viewByID == nil {
+		return "", nil
+	}
+	loopID := loop.LoopIDFromContext(ctx)
+	if loopID == "" {
+		return "", nil
+	}
+	v, ok := p.viewByID(loopID)
+	if !ok {
+		return "", nil
+	}
+	return v.SelfContextMarkdown(), nil
+}

--- a/internal/runtime/agent/loop_self_context_test.go
+++ b/internal/runtime/agent/loop_self_context_test.go
@@ -1,0 +1,47 @@
+package agent
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/nugget/thane-ai-agent/internal/runtime/agentctx"
+	"github.com/nugget/thane-ai-agent/internal/runtime/loop"
+)
+
+func TestLoopSelfContextProvider_RendersCurrentLoop(t *testing.T) {
+	state := "processing"
+	view := loop.LoopView{Name: "ego", Operation: "service", State: &state, Eligible: true}
+	p := NewLoopSelfContextProvider(func(id string) (loop.LoopView, bool) {
+		if id == "lp_ego" {
+			return view, true
+		}
+		return loop.LoopView{}, false
+	})
+
+	// With the loop_id in context, the block renders for that loop.
+	ctx := loop.WithLoopIDForTest(context.Background(), "lp_ego")
+	out, err := p.TagContext(ctx, agentctx.ContextRequest{})
+	if err != nil {
+		t.Fatalf("TagContext: %v", err)
+	}
+	if !strings.Contains(out, "### This loop") || !strings.Contains(out, "ego · service") {
+		t.Errorf("expected the ego loop's self-context block, got %q", out)
+	}
+
+	// No loop_id in context (e.g. a delegate or ad-hoc turn) → empty, not an error.
+	if empty, _ := p.TagContext(context.Background(), agentctx.ContextRequest{}); empty != "" {
+		t.Errorf("no loop id should render empty, got %q", empty)
+	}
+
+	// An unknown loop id (not yet live) → empty.
+	unknownCtx := loop.WithLoopIDForTest(context.Background(), "lp_missing")
+	if empty, _ := p.TagContext(unknownCtx, agentctx.ContextRequest{}); empty != "" {
+		t.Errorf("unknown loop id should render empty, got %q", empty)
+	}
+
+	// Self-context is live runtime state.
+	if p.TagContextBucket() != agentctx.ContextBucketLiveState {
+		t.Errorf("bucket = %v, want live_state", p.TagContextBucket())
+	}
+}

--- a/internal/runtime/loop/loop_self_context.go
+++ b/internal/runtime/loop/loop_self_context.go
@@ -1,0 +1,116 @@
+package loop
+
+import (
+	"fmt"
+	"strings"
+)
+
+// SelfContextMarkdown renders this loop's canonical view as the compact,
+// always-on "self-context" block a running loop sees each iteration (#1106 B3):
+// who it is, where it sits in the graph, why it exists, its live cadence and
+// health, and what capability tags it inherited — so the loop is self-aware
+// without a loop_status tool call. Absent fields are omitted so the block stays
+// tight; a zero view renders "".
+func (v LoopView) SelfContextMarkdown() string {
+	if v.Name == "" {
+		return ""
+	}
+	var b strings.Builder
+	b.WriteString("### This loop\n")
+
+	// Identity: name (short id) · operation · state · eligibility.
+	line := v.Name
+	if v.ID != nil && *v.ID != "" {
+		line += " (" + shortLoopID(*v.ID) + ")"
+	}
+	line += " · " + v.Operation
+	if v.State != nil && *v.State != "" {
+		line += " · " + *v.State
+	}
+	if v.Eligible {
+		line += " · eligible"
+	} else {
+		line += " · ineligible"
+	}
+	b.WriteString(line + "\n")
+
+	// Structure: graph position (leaf-adjacent first) + child count if any.
+	if chain := ancestryChain(v.ParentName, v.Ancestry); chain != "" {
+		b.WriteString("parent: " + chain)
+		if v.ChildCount > 0 {
+			b.WriteString(fmt.Sprintf("  (%d children)", v.ChildCount))
+		}
+		b.WriteString("\n")
+	}
+
+	// Purpose.
+	if v.Intent != "" {
+		b.WriteString("intent: " + v.Intent + "\n")
+	}
+
+	// Live cadence & health — only the facts a self-pacing loop acts on.
+	if cadence := selfCadenceLine(v); cadence != "" {
+		b.WriteString(cadence + "\n")
+	}
+
+	// Inherited capability tags with provenance.
+	if len(v.EffectiveTags) > 0 {
+		b.WriteString("effective tags: " + renderSelfEffectiveTags(v.EffectiveTags) + "\n")
+	}
+
+	return b.String()
+}
+
+// shortLoopID trims a UUID-style loop id to its first segment for legibility.
+func shortLoopID(id string) string {
+	if i := strings.IndexByte(id, '-'); i > 0 {
+		return id[:i]
+	}
+	if len(id) > 8 {
+		return id[:8]
+	}
+	return id
+}
+
+// ancestryChain renders the loop's graph position leaf-adjacent first
+// ("watchers ← core"). Ancestry is ordered root→leaf, so it is reversed here;
+// ParentName is the fallback when the ancestry list is empty.
+func ancestryChain(parentName *string, ancestry []string) string {
+	if len(ancestry) > 0 {
+		rev := make([]string, len(ancestry))
+		for i, n := range ancestry {
+			rev[len(ancestry)-1-i] = n
+		}
+		return strings.Join(rev, " ← ")
+	}
+	if parentName != nil && *parentName != "" {
+		return *parentName
+	}
+	return ""
+}
+
+func selfCadenceLine(v LoopView) string {
+	var parts []string
+	if v.Iterations != nil {
+		parts = append(parts, fmt.Sprintf("iteration %d", *v.Iterations))
+	}
+	if v.NextWakeDelta != nil {
+		parts = append(parts, "next wake "+*v.NextWakeDelta)
+	}
+	if v.ConsecutiveErrors != nil {
+		parts = append(parts, fmt.Sprintf("consecutive_errors %d", *v.ConsecutiveErrors))
+	}
+	return strings.Join(parts, " · ")
+}
+
+func renderSelfEffectiveTags(tags []EffectiveTag) string {
+	parts := make([]string, 0, len(tags))
+	for _, t := range tags {
+		if t.From == "" || t.From == EffectiveOriginSelf {
+			parts = append(parts, t.Tag+" (self)")
+		} else {
+			parts = append(parts, t.Tag+" (←"+t.From+")")
+		}
+	}
+	return strings.Join(parts, ", ")
+}

--- a/internal/runtime/loop/loop_self_context_test.go
+++ b/internal/runtime/loop/loop_self_context_test.go
@@ -1,0 +1,58 @@
+package loop
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestLoopView_SelfContextMarkdown_Full(t *testing.T) {
+	id := "019f16aa-f878-730d-9756-dc9d8ffedb0c"
+	state := "sleeping"
+	iters := 138
+	nextWake := "+5940s"
+	consec := 0
+	parent := "watchers"
+	v := LoopView{
+		Name: "reservoir_watch", ID: &id, Operation: "service", State: &state,
+		Eligible: true, ParentName: &parent, Ancestry: []string{"core", "watchers"},
+		Intent:            "Keep a current read on the reservoir level",
+		Iterations:        &iters,
+		NextWakeDelta:     &nextWake,
+		ConsecutiveErrors: &consec,
+		EffectiveTags:     []EffectiveTag{{Tag: "home", From: "travel"}, {Tag: "curate", From: EffectiveOriginSelf}},
+	}
+
+	got := v.SelfContextMarkdown()
+	for _, w := range []string{
+		"### This loop",
+		"reservoir_watch (019f16aa) · service · sleeping · eligible",
+		"parent: watchers ← core", // ancestry root→leaf, rendered leaf-adjacent first
+		"intent: Keep a current read on the reservoir level",
+		"iteration 138 · next wake +5940s · consecutive_errors 0",
+		"effective tags: home (←travel), curate (self)",
+	} {
+		if !strings.Contains(got, w) {
+			t.Errorf("self-context missing %q\n--- got ---\n%s", w, got)
+		}
+	}
+}
+
+func TestLoopView_SelfContextMarkdown_OmitsAbsentFields(t *testing.T) {
+	// No intent, no live cadence, no tags: the block must stay tight, never
+	// printing an empty label.
+	v := LoopView{Name: "bare", Operation: "service", Eligible: false}
+	got := v.SelfContextMarkdown()
+	if strings.Contains(got, "intent:") || strings.Contains(got, "effective tags:") ||
+		strings.Contains(got, "iteration") || strings.Contains(got, "parent:") {
+		t.Errorf("block should omit absent fields, got:\n%s", got)
+	}
+	if !strings.Contains(got, "bare · service · ineligible") {
+		t.Errorf("identity line wrong:\n%s", got)
+	}
+}
+
+func TestLoopView_SelfContextMarkdown_Empty(t *testing.T) {
+	if got := (LoopView{}).SelfContextMarkdown(); got != "" {
+		t.Errorf("zero view should render empty, got %q", got)
+	}
+}


### PR DESCRIPTION
## What

Final B item of #1106 (the #1102 legibility layer): a running loop had **no built-in awareness of which loop it is** — it had to call `loop_status`. B3 injects the loop's own canonical row into its system prompt **every iteration**, so it sees its id/state/parent/intent/cadence/effective-tags without a tool call:

```
### This loop
reservoir_watch (019f16aa) · service · sleeping · eligible
parent: watchers ← core
intent: Keep a current read on the reservoir level
iteration 138 · next wake +5940s · consecutive_errors 0
effective tags: home (←travel), curate (self)
```

Content level (identity + structure + **live cadence & errors** + inherited tags) was chosen for best self-awareness-per-token.

## How

- **`LoopView.SelfContextMarkdown()`** (loop package) renders the compact block, omitting absent fields so it stays tight.
- **`LoopSelfContextProvider`** (agent package) — an always-on `TagContextProvider` in the live-state bucket. It resolves the current loop from the `loop_id` the runtime stamps into the iteration context (`loop.Loop.run`), so **one registration serves every non-container loop**. Suppressed for delegate runs like every always-on provider.
- **`App.loopViewByID`** resolves a `loop_id` to its canonical `LoopView`, reusing B1's `def.Loop` (policy/eligibility/effective_* resolved, live telemetry overlaid) with a live-projection fallback for ephemeral loops. Registered once in `initAwareness`.

Container loops don't iterate, so they never render a self-block.

## Self-review (adversarial pass)

A find→verify review of the diff **caught a real bug before this PR**: `loopViewByID` fetched the Status by *id* but resolved the canonical view by *name*, so under a loop-name collision (the registry keys by id; names aren't unique) the self-block could show a **same-named sibling's identity**. Fixed with an id-precise guard + a regression test (two same-named live loops; fails without the guard). The review also *refuted* two speculative concerns — `eligible` carries real signal (a schedule window can close mid-iteration) and the effective-tags don't duplicate the ACTIVE TAGS section.

## Test plan
- [x] `SelfContextMarkdown` full render + field omission + zero view
- [x] provider resolves the current loop / empty for no-loop-id / unknown id / live-state bucket
- [x] `loopViewByID` id-precise under a name collision (regression)
- [x] `just ci` green

Refs #1106.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
