### PR TITLE
fix(loops): tolerate stringified spec/launch args at the decode boundary

### DIFF
--- a/internal/tools/loop_definition_tool_helpers.go
+++ b/internal/tools/loop_definition_tool_helpers.go
@@ -22,6 +22,10 @@ func decodeLoopSpecArg(args map[string]any, key string) (looppkg.Spec, error) {
 	if !ok {
 		return looppkg.Spec{}, fmt.Errorf("%s is required", key)
 	}
+	raw, err := coerceStringifiedJSON(raw)
+	if err != nil {
+		return looppkg.Spec{}, fmt.Errorf("%s was a JSON string but did not parse: %w", key, err)
+	}
 	data, err := json.Marshal(raw)
 	if err != nil {
 		return looppkg.Spec{}, err
@@ -38,6 +42,10 @@ func decodeLoopLaunchArg(args map[string]any, key string) (looppkg.Launch, error
 	if !ok {
 		return looppkg.Launch{}, nil
 	}
+	raw, err := coerceStringifiedJSON(raw)
+	if err != nil {
+		return looppkg.Launch{}, fmt.Errorf("%s was a JSON string but did not parse: %w", key, err)
+	}
 	if err := rejectLaunchModelKeys(raw); err != nil {
 		return looppkg.Launch{}, err
 	}
@@ -50,6 +58,40 @@ func decodeLoopLaunchArg(args map[string]any, key string) (looppkg.Launch, error
 		return looppkg.Launch{}, err
 	}
 	return launch, nil
+}
+
+// coerceStringifiedJSON canonicalizes a tool argument that models sometimes
+// emit as a JSON *string* (a stringified object/array) instead of a native
+// object. This is a known LLM quirk that bites hardest on tools whose whole
+// argument is a single large nested object — the loop spec/launch payloads —
+// where big or complex values get serialized as a quoted string while small
+// ones arrive as a native dict. Without coercion the string flows into
+// json.Marshal→Unmarshal and fails with the opaque "cannot unmarshal string
+// into Go value of type loop.specJSON" (see #1116). This applies the
+// model-facing-tools.md §2 principle: accept how models think, then
+// canonicalize.
+//
+// A string is only coerced when it looks like a JSON object or array (first
+// non-space rune is '{' or '['), so a legitimate bare-string value is never
+// reinterpreted. On success the decoded value is returned for the normal
+// marshal→unmarshal path (which preserves rejectLaunchModelKeys and every
+// other downstream check). A JSON-looking string that fails to parse returns
+// an error so the caller can surface a precise message rather than the opaque
+// type error. Non-string and non-JSON-looking values pass through unchanged.
+func coerceStringifiedJSON(raw any) (any, error) {
+	s, ok := raw.(string)
+	if !ok {
+		return raw, nil
+	}
+	trimmed := strings.TrimSpace(s)
+	if trimmed == "" || (trimmed[0] != '{' && trimmed[0] != '[') {
+		return raw, nil
+	}
+	var decoded any
+	if err := json.Unmarshal([]byte(trimmed), &decoded); err != nil {
+		return nil, err
+	}
+	return decoded, nil
 }
 
 // rejectLaunchModelKeys catches tool-facing launch payloads that try to

--- a/internal/tools/loop_definition_tool_helpers.go
+++ b/internal/tools/loop_definition_tool_helpers.go
@@ -72,7 +72,7 @@ func decodeLoopLaunchArg(args map[string]any, key string) (looppkg.Launch, error
 // canonicalize.
 //
 // A string is only coerced when it looks like a JSON object or array (first
-// non-space rune is '{' or '['), so a legitimate bare-string value is never
+// non-space byte is '{' or '['), so a legitimate bare-string value is never
 // reinterpreted. On success the decoded value is returned for the normal
 // marshal→unmarshal path (which preserves rejectLaunchModelKeys and every
 // other downstream check). A JSON-looking string that fails to parse returns

--- a/internal/tools/loop_definition_tool_helpers_test.go
+++ b/internal/tools/loop_definition_tool_helpers_test.go
@@ -1,0 +1,184 @@
+package tools
+
+import (
+	"strings"
+	"testing"
+
+	looppkg "github.com/nugget/thane-ai-agent/internal/runtime/loop"
+)
+
+// TestDecodeLoopSpecArgAcceptsStringifiedJSON covers #1116: models sometimes
+// emit the nested spec argument as a JSON *string* rather than a native
+// object (a size-correlated LLM quirk). Both shapes must decode to the same
+// spec.
+func TestDecodeLoopSpecArgAcceptsStringifiedJSON(t *testing.T) {
+	cases := []struct {
+		name string
+		spec any
+	}{
+		{
+			name: "native object",
+			spec: map[string]any{
+				"name":      "ranch_climate_watch",
+				"task":      "Watch the barn sensors.",
+				"intent":    "Keep the ranch climate within range.",
+				"operation": "service",
+			},
+		},
+		{
+			name: "stringified object",
+			spec: `{"name":"ranch_climate_watch","task":"Watch the barn sensors.",` +
+				`"intent":"Keep the ranch climate within range.","operation":"service"}`,
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			spec, err := decodeLoopSpecArg(map[string]any{"spec": tc.spec}, "spec")
+			if err != nil {
+				t.Fatalf("decodeLoopSpecArg: unexpected error: %v", err)
+			}
+			if spec.Name != "ranch_climate_watch" {
+				t.Errorf("Name = %q, want ranch_climate_watch", spec.Name)
+			}
+			if spec.Task != "Watch the barn sensors." {
+				t.Errorf("Task = %q, want the sensor task", spec.Task)
+			}
+			if spec.Intent != "Keep the ranch climate within range." {
+				t.Errorf("Intent = %q, want the climate intent", spec.Intent)
+			}
+			if spec.Operation != looppkg.OperationService {
+				t.Errorf("Operation = %q, want service", spec.Operation)
+			}
+		})
+	}
+}
+
+// TestDecodeLoopSpecArgStringifiedInvalidJSON verifies that a JSON-looking
+// string that fails to parse surfaces a precise error rather than the opaque
+// "cannot unmarshal string into Go value of type loop.specJSON".
+func TestDecodeLoopSpecArgStringifiedInvalidJSON(t *testing.T) {
+	_, err := decodeLoopSpecArg(map[string]any{"spec": `{"name": "oops",`}, "spec")
+	if err == nil {
+		t.Fatal("expected an error for a truncated JSON string, got nil")
+	}
+	if !strings.Contains(err.Error(), "spec was a JSON string but did not parse") {
+		t.Fatalf("error = %q, want the tolerant-decode parse message", err.Error())
+	}
+}
+
+// TestDecodeLoopLaunchArgAcceptsStringifiedJSON covers the same #1116 quirk on
+// the launch payload (spawn_loop / loop_definition_launch).
+func TestDecodeLoopLaunchArgAcceptsStringifiedJSON(t *testing.T) {
+	cases := []struct {
+		name   string
+		launch any
+	}{
+		{
+			name:   "native object",
+			launch: map[string]any{"task": "Do the thing.", "max_iterations": 7},
+		},
+		{
+			name:   "stringified object",
+			launch: `{"task":"Do the thing.","max_iterations":7}`,
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			launch, err := decodeLoopLaunchArg(map[string]any{"launch": tc.launch}, "launch")
+			if err != nil {
+				t.Fatalf("decodeLoopLaunchArg: unexpected error: %v", err)
+			}
+			if launch.Task != "Do the thing." {
+				t.Errorf("Task = %q, want the launch task", launch.Task)
+			}
+			if launch.MaxIterations != 7 {
+				t.Errorf("MaxIterations = %d, want 7", launch.MaxIterations)
+			}
+		})
+	}
+}
+
+// TestDecodeLoopLaunchArgStringifiedStillRejectsModel guards the ordering:
+// coercion must run BEFORE rejectLaunchModelKeys, so a stringified launch
+// cannot smuggle a model override past the raw-map pre-check.
+func TestDecodeLoopLaunchArgStringifiedStillRejectsModel(t *testing.T) {
+	_, err := decodeLoopLaunchArg(
+		map[string]any{"launch": `{"model":"claude-sonnet-4-5"}`},
+		"launch",
+	)
+	if err == nil {
+		t.Fatal("expected launch.model to be rejected even when the launch arrives stringified, got nil")
+	}
+	if !strings.Contains(err.Error(), "launch.model") || !strings.Contains(err.Error(), "spec.profile.model") {
+		t.Fatalf("error = %q, want guidance pointing from launch.model to spec.profile.model", err.Error())
+	}
+}
+
+// TestCoerceStringifiedJSON exercises the coercion boundary directly.
+func TestCoerceStringifiedJSON(t *testing.T) {
+	cases := []struct {
+		name    string
+		in      any
+		want    any
+		wantErr bool
+	}{
+		{name: "non-string passthrough", in: map[string]any{"a": 1}, want: map[string]any{"a": 1}},
+		{name: "empty string passthrough", in: "", want: ""},
+		{name: "bare string passthrough", in: "not json", want: "not json"},
+		{name: "json object string decoded", in: `{"a":1}`, want: map[string]any{"a": float64(1)}},
+		{name: "json array string decoded", in: `[1,2]`, want: []any{float64(1), float64(2)}},
+		{name: "whitespace-led object decoded", in: "  {\"a\":1}", want: map[string]any{"a": float64(1)}},
+		{name: "invalid json object string errors", in: `{"a":`, wantErr: true},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := coerceStringifiedJSON(tc.in)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got value %#v", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !jsonEqual(got, tc.want) {
+				t.Fatalf("got %#v, want %#v", got, tc.want)
+			}
+		})
+	}
+}
+
+// jsonEqual compares two decoded-JSON values structurally. Sufficient for the
+// scalar/object/array shapes coerceStringifiedJSON returns.
+func jsonEqual(a, b any) bool {
+	switch av := a.(type) {
+	case map[string]any:
+		bv, ok := b.(map[string]any)
+		if !ok || len(av) != len(bv) {
+			return false
+		}
+		for k, v := range av {
+			if !jsonEqual(v, bv[k]) {
+				return false
+			}
+		}
+		return true
+	case []any:
+		bv, ok := b.([]any)
+		if !ok || len(av) != len(bv) {
+			return false
+		}
+		for i := range av {
+			if !jsonEqual(av[i], bv[i]) {
+				return false
+			}
+		}
+		return true
+	default:
+		return a == b
+	}
+}


### PR DESCRIPTION
## What

Makes the loop spec/launch tool-arg decoders tolerant of a JSON *string* value where a native object is expected.

`decodeLoopSpecArg` (loop_definition_set / lint / update) and `decodeLoopLaunchArg` (spawn_loop / loop_definition_launch) now run every arg through a new `coerceStringifiedJSON`: if the value is a string that looks like JSON (first non-space rune is `{` or `[`), it's parsed and the decoded value flows into the existing marshal→unmarshal path.

## Why

Models sometimes serialize the single large nested `spec`/`launch` argument as a **stringified JSON object** rather than a native object — a size-correlated LLM quirk (small payloads arrive as a dict and succeed; large ones arrive stringified). The stringified case failed with the opaque:

```
Error: json: cannot unmarshal string into Go value of type loop.specJSON
```

Per #1116 this was a prod blocker: once #1112 fixed the narrate-then-stop stall, the model reached the large-`loop_definition_set` emit and hit this wall on every real-sized edit.

## Design notes

- **Coercion runs before `rejectLaunchModelKeys`**, so a stringified launch cannot smuggle a `model` override past the raw-map pre-check. Covered by a dedicated test.
- Only strings that **look like** JSON (`{`/`[`-leading) are coerced — a legitimate bare-string value is never reinterpreted.
- A JSON-looking string that **fails to parse** now returns a precise error (`spec was a JSON string but did not parse: …`) instead of the opaque type message.
- Non-string and non-JSON-looking values pass through unchanged (pure regression-safety).
- Applies the [model-facing-tools.md §2](docs/model-facing-tools.md) principle: *accept how models think, then canonicalize.*

## Test plan

- [x] `go test ./internal/tools/ -run 'TestDecodeLoop|TestCoerceStringifiedJSON'` — native + stringified spec/launch decode identically; stringified launch still rejects `model`; invalid JSON-string surfaces the clear error; coercion boundary unit table.
- [x] `just ci` green (0 architecture errors).

Closes #1116