### PR TITLE
Resolve all 13 deferred structural findings from the v0.10.0 audit (#1096)

### DIFF
--- a/docs/operating/configuration.md
+++ b/docs/operating/configuration.md
@@ -186,13 +186,9 @@ Where SQLite databases live (`thane.db`, `facts.db`). Defaults to
 workspace:
   path: ~/Thane
 
-paths:
-  kb: ~/Thane/knowledge
-  scratchpad: ~/Thane/scratchpad
-  dossiers: ~/Vaults/private-dossiers
-
-doc_roots:
+roots:
   kb:
+    path: ~/Thane/knowledge
     authoring: managed
     git:
       enabled: true
@@ -200,19 +196,30 @@ doc_roots:
       verify_signatures: warn
       signing_key: ~/.ssh/id_ed25519
   dossiers:
+    path: ~/Vaults/private-dossiers
     authoring: read_only
   scratchpad:
+    path: ~/Thane/scratchpad
     indexing: false
     authoring: managed
 ```
 
-Any directory listed in `paths:` becomes a named local collection that
-Thane can keep track of.
+Each entry under `roots:` names one local collection Thane keeps track
+of, combining its `path` with optional per-root policy: whether Thane
+indexes it, whether managed document tools may write to it, and whether
+writes should go through a signed git history. An entry may be a bare
+string when it needs no policy beyond its path:
 
-Use `paths:` to name the collection. Use `doc_roots:` only when that
-collection needs policy: whether Thane indexes it, whether managed
-document tools may write to it, and whether writes should go through a
-signed git history.
+```yaml
+roots:
+  kb: ~/Thane/knowledge
+```
+
+> **Deprecated:** the older `paths:` / `doc_roots:` split — one block to
+> name the path, a second to attach policy — is still parsed but emits a
+> deprecation warning and cannot appear in the same config as `roots:`.
+> Migrate each `paths:` entry and its matching `doc_roots:` policy into a
+> single `roots:` entry.
 
 `authoring` accepts `managed`, `read_only`, or `restricted`. `managed`
 is the default and allows document tools and loop-declared output tools

--- a/docs/understanding/document-roots.md
+++ b/docs/understanding/document-roots.md
@@ -7,11 +7,15 @@ That starts with **document roots**: named directories in config that
 tell Thane which local collections matter.
 
 ```yaml
-paths:
+roots:
   kb: ./knowledge
   scratchpad: ./scratchpad
   dossiers: ~/Vaults/private-dossiers
 ```
+
+> The legacy `paths:` / `doc_roots:` split is still parsed with a
+> deprecation warning but cannot be combined with `roots:`. Prefer
+> `roots:`, which keeps a root's path and its policy in one entry.
 
 Each entry gives a directory a stable identity. Instead of treating your
 files as one anonymous pile, Thane can understand that some notes live
@@ -62,8 +66,8 @@ The cleaner the boundary, the easier it is for Thane to stay oriented.
 
 You do not need any special indexing section or separate feature flag.
 
-If a directory is listed in `paths:` and exists on disk, it becomes one
-of Thane's managed local document collections.
+If a directory is listed under `roots:` and exists on disk, it becomes
+one of Thane's managed local document collections.
 
 Example:
 
@@ -71,7 +75,7 @@ Example:
 workspace:
   path: ~/Thane
 
-paths:
+roots:
   kb: ~/Thane/knowledge
   scratchpad: ~/Thane/scratchpad
   dossiers: ~/Vaults/private-dossiers
@@ -84,19 +88,17 @@ time.
 
 ## Root Policy
 
-Most roots do not need extra policy. If a root is listed in `paths:` and
-exists on disk, Thane indexes markdown in that root and managed document
-tools may write it.
+Most roots do not need extra policy. If a root is listed under `roots:`
+as a bare string and exists on disk, Thane indexes markdown in that root
+and managed document tools may write it.
 
-When a root needs a stronger contract, add `doc_roots:`:
+When a root needs a stronger contract, give its entry the full mapping
+form with policy fields:
 
 ```yaml
-paths:
-  kb: ~/Thane/knowledge
-  scratchpad: ~/Thane/scratchpad
-
-doc_roots:
+roots:
   kb:
+    path: ~/Thane/knowledge
     authoring: managed
     git:
       enabled: true
@@ -104,6 +106,7 @@ doc_roots:
       verify_signatures: warn
       signing_key: ~/.ssh/id_ed25519
   scratchpad:
+    path: ~/Thane/scratchpad
     indexing: false
     authoring: managed
 ```

--- a/internal/integrations/forge/tools.go
+++ b/internal/integrations/forge/tools.go
@@ -27,17 +27,15 @@ type Tools struct {
 
 // NewTools creates forge tools backed by the given manager. The opLog
 // records successful operations for context injection; pass nil to
-// disable operation tracking.
-func NewTools(mgr *Manager, opLog *OperationLog, logger *slog.Logger, subscriptions ...*SubscriptionStore) *Tools {
-	t := &Tools{
-		manager: mgr,
-		opLog:   opLog,
-		logger:  logger,
+// disable operation tracking. subscriptions may be nil to disable the
+// repository-subscription surface.
+func NewTools(mgr *Manager, opLog *OperationLog, logger *slog.Logger, subscriptions *SubscriptionStore) *Tools {
+	return &Tools{
+		manager:       mgr,
+		opLog:         opLog,
+		logger:        logger,
+		subscriptions: subscriptions,
 	}
-	if len(subscriptions) > 0 {
-		t.subscriptions = subscriptions[0]
-	}
-	return t
 }
 
 // SetLoopResolver wires the live loop registry into forge tools so

--- a/internal/integrations/homeassistant/entity_metadata.go
+++ b/internal/integrations/homeassistant/entity_metadata.go
@@ -100,7 +100,6 @@ func (m *EntityMetadata) Empty() bool {
 type EntityVisibility struct {
 	Enabled        bool   `json:"enabled"`
 	Visible        bool   `json:"visible"`
-	DefaultContext bool   `json:"default_context"`
 	ContextRole    string `json:"context_role"`
 	HiddenBy       string `json:"hidden_by,omitempty"`
 	DisabledBy     string `json:"disabled_by,omitempty"`
@@ -115,8 +114,13 @@ type EntityAreaMetadata struct {
 	Name                string               `json:"name,omitempty"`
 	Aliases             []string             `json:"aliases,omitempty"`
 	FloorID             string               `json:"floor_id,omitempty"`
-	Floor               *EntityFloorMetadata `json:"floor,omitempty"`
-	Building            *EntityFloorMetadata `json:"building,omitempty"`
+	// Floor and Building are mutually exclusive: an area's floor is reported
+	// under exactly one of them, chosen by the homeassistant.floor_alias
+	// deployment setting. By default the floor lands in Floor; with
+	// floor_alias: building it lands in Building instead. At most one is ever
+	// non-nil.
+	Floor    *EntityFloorMetadata `json:"floor,omitempty"`
+	Building *EntityFloorMetadata `json:"building,omitempty"`
 	Icon                string               `json:"icon,omitempty"`
 	TemperatureEntityID string               `json:"temperature_entity_id,omitempty"`
 	HumidityEntityID    string               `json:"humidity_entity_id,omitempty"`
@@ -304,19 +308,11 @@ func applyEntityVisibility(meta *EntityMetadata, entry *EntityRegistryEntry) {
 	meta.Visibility = &EntityVisibility{
 		Enabled:        entry.DisabledBy == "",
 		Visible:        entry.HiddenBy == "",
-		DefaultContext: entityDefaultContext(entry),
 		ContextRole:    entityContextRole(entry),
 		HiddenBy:       entry.HiddenBy,
 		DisabledBy:     entry.DisabledBy,
 		EntityCategory: entry.EntityCategory,
 	}
-}
-
-func entityDefaultContext(entry *EntityRegistryEntry) bool {
-	return entry.DisabledBy == "" &&
-		entry.HiddenBy == "" &&
-		entry.EntityCategory != "diagnostic" &&
-		entry.EntityCategory != "config"
 }
 
 func entityContextRole(entry *EntityRegistryEntry) string {

--- a/internal/integrations/homeassistant/entity_metadata.go
+++ b/internal/integrations/homeassistant/entity_metadata.go
@@ -110,17 +110,17 @@ type EntityVisibility struct {
 // for an entity, resolved through direct entity area first and device
 // area second.
 type EntityAreaMetadata struct {
-	ID                  string               `json:"id"`
-	Name                string               `json:"name,omitempty"`
-	Aliases             []string             `json:"aliases,omitempty"`
-	FloorID             string               `json:"floor_id,omitempty"`
+	ID      string   `json:"id"`
+	Name    string   `json:"name,omitempty"`
+	Aliases []string `json:"aliases,omitempty"`
+	FloorID string   `json:"floor_id,omitempty"`
 	// Floor and Building are mutually exclusive: an area's floor is reported
 	// under exactly one of them, chosen by the homeassistant.floor_alias
 	// deployment setting. By default the floor lands in Floor; with
 	// floor_alias: building it lands in Building instead. At most one is ever
 	// non-nil.
-	Floor    *EntityFloorMetadata `json:"floor,omitempty"`
-	Building *EntityFloorMetadata `json:"building,omitempty"`
+	Floor               *EntityFloorMetadata `json:"floor,omitempty"`
+	Building            *EntityFloorMetadata `json:"building,omitempty"`
 	Icon                string               `json:"icon,omitempty"`
 	TemperatureEntityID string               `json:"temperature_entity_id,omitempty"`
 	HumidityEntityID    string               `json:"humidity_entity_id,omitempty"`

--- a/internal/integrations/homeassistant/entity_metadata_test.go
+++ b/internal/integrations/homeassistant/entity_metadata_test.go
@@ -102,8 +102,8 @@ func TestEntityMetadataResolverJoinsPhysicalContext(t *testing.T) {
 	if got.Visibility == nil || !got.Visibility.Enabled || !got.Visibility.Visible {
 		t.Fatalf("Visibility = %#v, want enabled and visible", got.Visibility)
 	}
-	if got.Visibility.ContextRole != "default" || !got.Visibility.DefaultContext {
-		t.Fatalf("Visibility role/default = %q/%v, want default/true", got.Visibility.ContextRole, got.Visibility.DefaultContext)
+	if got.Visibility.ContextRole != "default" {
+		t.Fatalf("Visibility role = %q, want default", got.Visibility.ContextRole)
 	}
 
 	wantLabels := map[string]string{
@@ -147,9 +147,6 @@ func TestEntityMetadataResolverProjectsVisibility(t *testing.T) {
 	if got.Visibility.Visible {
 		t.Errorf("Visible = true, want false for hidden entity")
 	}
-	if got.Visibility.DefaultContext {
-		t.Errorf("DefaultContext = true, want false for hidden entity")
-	}
 	if got.Visibility.ContextRole != "hidden" {
 		t.Errorf("ContextRole = %q, want hidden", got.Visibility.ContextRole)
 	}
@@ -172,16 +169,14 @@ func TestEntityMetadataResolverVisibilityContextRoles(t *testing.T) {
 
 	resolver := NewEntityMetadataResolver(nil, nil, nil)
 	tests := []struct {
-		name        string
-		entry       EntityRegistryEntry
-		wantRole    string
-		wantDefault bool
+		name     string
+		entry    EntityRegistryEntry
+		wantRole string
 	}{
 		{
-			name:        "default",
-			entry:       EntityRegistryEntry{EntityID: "light.office"},
-			wantRole:    "default",
-			wantDefault: true,
+			name:     "default",
+			entry:    EntityRegistryEntry{EntityID: "light.office"},
+			wantRole: "default",
 		},
 		{
 			name:     "diagnostic",
@@ -205,8 +200,8 @@ func TestEntityMetadataResolverVisibilityContextRoles(t *testing.T) {
 			if got == nil || got.Visibility == nil {
 				t.Fatalf("MetadataForEntity returned %#v, want visibility", got)
 			}
-			if got.Visibility.ContextRole != tt.wantRole || got.Visibility.DefaultContext != tt.wantDefault {
-				t.Fatalf("role/default = %q/%v, want %q/%v", got.Visibility.ContextRole, got.Visibility.DefaultContext, tt.wantRole, tt.wantDefault)
+			if got.Visibility.ContextRole != tt.wantRole {
+				t.Fatalf("role = %q, want %q", got.Visibility.ContextRole, tt.wantRole)
 			}
 		})
 	}

--- a/internal/model/toolcatalog/catalog.go
+++ b/internal/model/toolcatalog/catalog.go
@@ -97,12 +97,16 @@ type BuiltinTagSpec struct {
 	// `owner`) without being a menu.
 	Protected bool
 
-	// Parents lists the menu tag(s) this leaf appears under in the
+	// Parents lists the menu tag(s) a leaf appears under in the intended
 	// hierarchical capability menu. Multi-valued because some leaves
-	// legitimately serve more than one menu (e.g. `files` is
-	// reachable from both development and knowledge). Omitted for
-	// menus themselves and for tags that don't fit any menu — those
-	// surface as top-level entries in the menu rendering.
+	// legitimately serve more than one menu (e.g. `files` is reachable
+	// from both development and knowledge). Omitted for menus themselves
+	// and for tags that don't fit any menu.
+	//
+	// Reserved: Parents is authored on every leaf and validated by the
+	// catalog invariant test, but no renderer consumes it yet — the
+	// hierarchical menu that would group leaves beneath their parents has
+	// not shipped. Until it does, menu navigation flows through NextTags.
 	Parents []string
 }
 

--- a/internal/model/toolcatalog/catalog_tags.go
+++ b/internal/model/toolcatalog/catalog_tags.go
@@ -2,10 +2,12 @@ package toolcatalog
 
 // builtinTagSpecs is the compiled-in tag catalog. PR-G formalized the
 // hierarchy: every leaf declares its Parents (the menu trailheads it
-// appears under), and coarse trailheads are explicitly marked
+// would appear under), and coarse trailheads are explicitly marked
 // Kind: TagKindMenu. Some leaves legitimately serve more than one
 // menu (files spans development and knowledge; web spans development,
-// knowledge, and media) and declare multi-valued Parents.
+// knowledge, and media) and declare multi-valued Parents. Parents is
+// authored and invariant-checked but not yet rendered — see the
+// [BuiltinTagSpec.Parents] doc.
 //
 // Adding a new tag: pick a Kind, write a Description that fits the
 // model-facing menu, and assign Parents from the existing menus when

--- a/internal/runtime/agent/capability_surface_prompt_test.go
+++ b/internal/runtime/agent/capability_surface_prompt_test.go
@@ -26,7 +26,7 @@ func TestBuildSystemPrompt_ActiveCapabilitiesUseSharedSurface(t *testing.T) {
 		},
 	})
 
-	prompt := l.buildSystemPrompt(testCtxForLoop(l), "hello", nil)
+	prompt := l.buildSystemPrompt(testCtxForLoop(l), "hello")
 	if !strings.Contains(prompt, "## Active Tags") {
 		t.Fatalf("prompt missing Active Tags section: %s", prompt)
 	}
@@ -51,7 +51,7 @@ func TestBuildSystemPrompt_ActiveCapabilitiesEmptyStateUsesSharedSurface(t *test
 		},
 	})
 
-	prompt := l.buildSystemPrompt(testCtxForLoop(l), "hello", nil)
+	prompt := l.buildSystemPrompt(testCtxForLoop(l), "hello")
 	if !strings.Contains(prompt, "## Active Tags") {
 		t.Fatalf("prompt missing Active Tags section: %s", prompt)
 	}

--- a/internal/runtime/agent/core_context.go
+++ b/internal/runtime/agent/core_context.go
@@ -13,7 +13,6 @@ import (
 	"github.com/nugget/thane-ai-agent/internal/model/promptfmt"
 	"github.com/nugget/thane-ai-agent/internal/model/talents"
 	"github.com/nugget/thane-ai-agent/internal/platform/provenance"
-	"github.com/nugget/thane-ai-agent/internal/runtime/agentctx"
 )
 
 // CoreContextProvider reads curated core identity documents for prompt
@@ -132,28 +131,6 @@ func (p *CoreContextProvider) updateProvenanceStore(store *provenance.Store) {
 	p.mu.Lock()
 	p.provenanceStore = store
 	p.mu.Unlock()
-}
-
-// TagContextBucket keeps compatibility output in continuity when a
-// CoreContextProvider is explicitly registered as a context provider.
-// Normal prompt assembly renders core files as first-class stable
-// sections before runtime context.
-func (p *CoreContextProvider) TagContextBucket() agentctx.ContextBucket {
-	return agentctx.ContextBucketContinuity
-}
-
-// TagContext returns core context for compatibility with the
-// context-provider interface.
-func (p *CoreContextProvider) TagContext(ctx context.Context, _ agentctx.ContextRequest) (string, error) {
-	sections := p.promptSections(ctx)
-	if len(sections) == 0 {
-		return "", nil
-	}
-	var sb strings.Builder
-	for _, section := range sections {
-		promptfmt.AppendMarkdownSection(&sb, 3, section.title, section.content)
-	}
-	return strings.TrimSpace(sb.String()), nil
 }
 
 func (p *CoreContextProvider) preambleSections(ctx context.Context) []corePromptSection {

--- a/internal/runtime/agent/ego_prompt_test.go
+++ b/internal/runtime/agent/ego_prompt_test.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/nugget/thane-ai-agent/internal/model/llm"
 	"github.com/nugget/thane-ai-agent/internal/runtime/agentctx"
-	"github.com/nugget/thane-ai-agent/internal/state/memory"
 )
 
 func newMinimalLoop() *Loop {
@@ -32,7 +31,7 @@ func TestBuildSystemPrompt_EgoFileIncluded(t *testing.T) {
 	l := newMinimalLoop()
 	l.SetEgoFile(egoPath)
 
-	prompt := l.buildSystemPrompt(context.Background(), "hello", nil)
+	prompt := l.buildSystemPrompt(context.Background(), "hello")
 
 	if !strings.Contains(prompt, content) {
 		t.Error("system prompt should contain ego.md content")
@@ -61,7 +60,7 @@ literal ego body
 	l := newMinimalLoop()
 	l.SetEgoFile(egoPath)
 
-	prompt := l.buildSystemPrompt(context.Background(), "hello", nil)
+	prompt := l.buildSystemPrompt(context.Background(), "hello")
 
 	if !strings.Contains(prompt, "literal ego body") {
 		t.Fatal("system prompt should contain ego.md body")
@@ -90,7 +89,7 @@ func TestBuildSystemPrompt_AxiomsFileIncludedBeforePersona(t *testing.T) {
 	l.persona = "PERSONA_MARKER"
 	l.ensureCoreContextProvider().updateAxiomsFile(axiomsPath)
 
-	prompt, sections := l.buildSystemPromptWithProfileSections(context.Background(), "hello", nil, llm.DefaultModelInteractionProfile())
+	prompt, sections := l.buildSystemPromptWithProfileSections(context.Background(), "hello", llm.DefaultModelInteractionProfile())
 
 	if !strings.Contains(prompt, content) {
 		t.Error("system prompt should contain axioms.md content")
@@ -114,7 +113,7 @@ func TestBuildSystemPrompt_AxiomsFileMissing(t *testing.T) {
 	l := newMinimalLoop()
 	l.ensureCoreContextProvider().updateAxiomsFile(filepath.Join(t.TempDir(), "nonexistent.md"))
 
-	prompt := l.buildSystemPrompt(context.Background(), "hello", nil)
+	prompt := l.buildSystemPrompt(context.Background(), "hello")
 
 	if strings.Contains(prompt, "axioms.md") {
 		t.Error("system prompt should not contain axioms section when file is missing")
@@ -131,7 +130,7 @@ func TestBuildSystemPrompt_AxiomsFileEmpty(t *testing.T) {
 	l := newMinimalLoop()
 	l.ensureCoreContextProvider().updateAxiomsFile(axiomsPath)
 
-	prompt := l.buildSystemPrompt(context.Background(), "hello", nil)
+	prompt := l.buildSystemPrompt(context.Background(), "hello")
 
 	if strings.Contains(prompt, "axioms.md") {
 		t.Error("system prompt should not contain axioms section when file is empty")
@@ -149,7 +148,7 @@ func TestBuildSystemPrompt_PersonaFileIncludedAndReread(t *testing.T) {
 	l.persona = "PERSONA_FALLBACK"
 	l.ensureCoreContextProvider().updatePersonaFile(personaPath)
 
-	prompt1 := l.buildSystemPrompt(context.Background(), "hello", nil)
+	prompt1 := l.buildSystemPrompt(context.Background(), "hello")
 	if !strings.Contains(prompt1, "PERSONA_VERSION_1") {
 		t.Fatalf("prompt missing persona file content:\n%s", prompt1)
 	}
@@ -160,7 +159,7 @@ func TestBuildSystemPrompt_PersonaFileIncludedAndReread(t *testing.T) {
 	if err := os.WriteFile(personaPath, []byte("PERSONA_VERSION_2"), 0o644); err != nil {
 		t.Fatalf("rewrite persona.md: %v", err)
 	}
-	prompt2 := l.buildSystemPrompt(context.Background(), "hello", nil)
+	prompt2 := l.buildSystemPrompt(context.Background(), "hello")
 	if strings.Contains(prompt2, "PERSONA_VERSION_1") || !strings.Contains(prompt2, "PERSONA_VERSION_2") {
 		t.Fatalf("persona file should be reread each turn:\n%s", prompt2)
 	}
@@ -171,7 +170,7 @@ func TestBuildSystemPrompt_PersonaFileMissingUsesFallback(t *testing.T) {
 	l.persona = "PERSONA_FALLBACK"
 	l.ensureCoreContextProvider().updatePersonaFile(filepath.Join(t.TempDir(), "missing.md"))
 
-	prompt := l.buildSystemPrompt(context.Background(), "hello", nil)
+	prompt := l.buildSystemPrompt(context.Background(), "hello")
 
 	if !strings.Contains(prompt, "PERSONA_FALLBACK") {
 		t.Fatalf("missing persona file should use fallback persona:\n%s", prompt)
@@ -188,7 +187,7 @@ func TestBuildSystemPrompt_PersonaFileReadErrorLogsWarning(t *testing.T) {
 	l.persona = "PERSONA_FALLBACK"
 	l.ensureCoreContextProvider().updatePersonaFile(personaPath)
 
-	prompt := l.buildSystemPrompt(context.Background(), "hello", nil)
+	prompt := l.buildSystemPrompt(context.Background(), "hello")
 
 	if !strings.Contains(prompt, "PERSONA_FALLBACK") {
 		t.Fatalf("unreadable persona file should use fallback persona:\n%s", prompt)
@@ -213,7 +212,7 @@ func TestBuildSystemPrompt_MissionFileIncluded(t *testing.T) {
 	l := newMinimalLoop()
 	l.ensureCoreContextProvider().updateMissionFile(missionPath)
 
-	prompt, sections := l.buildSystemPromptWithProfileSections(context.Background(), "hello", nil, llm.DefaultModelInteractionProfile())
+	prompt, sections := l.buildSystemPromptWithProfileSections(context.Background(), "hello", llm.DefaultModelInteractionProfile())
 
 	if !strings.Contains(prompt, content) {
 		t.Error("system prompt should contain mission.md content")
@@ -232,7 +231,7 @@ func TestBuildSystemPrompt_MissionFileMissingAndEmpty(t *testing.T) {
 	l := newMinimalLoop()
 	l.ensureCoreContextProvider().updateMissionFile(filepath.Join(t.TempDir(), "missing.md"))
 
-	prompt := l.buildSystemPrompt(context.Background(), "hello", nil)
+	prompt := l.buildSystemPrompt(context.Background(), "hello")
 	if strings.Contains(prompt, "mission.md") {
 		t.Fatalf("missing mission file should not render section:\n%s", prompt)
 	}
@@ -243,7 +242,7 @@ func TestBuildSystemPrompt_MissionFileMissingAndEmpty(t *testing.T) {
 		t.Fatalf("write mission.md: %v", err)
 	}
 	l.ensureCoreContextProvider().updateMissionFile(missionPath)
-	prompt = l.buildSystemPrompt(context.Background(), "hello", nil)
+	prompt = l.buildSystemPrompt(context.Background(), "hello")
 	if strings.Contains(prompt, "mission.md") {
 		t.Fatalf("empty mission file should not render section:\n%s", prompt)
 	}
@@ -253,7 +252,7 @@ func TestBuildSystemPrompt_EgoFileMissing(t *testing.T) {
 	l := newMinimalLoop()
 	l.SetEgoFile(filepath.Join(t.TempDir(), "nonexistent.md"))
 
-	prompt := l.buildSystemPrompt(context.Background(), "hello", nil)
+	prompt := l.buildSystemPrompt(context.Background(), "hello")
 
 	if strings.Contains(prompt, "ego.md") {
 		t.Error("system prompt should not contain ego section when file is missing")
@@ -270,7 +269,7 @@ func TestBuildSystemPrompt_EgoFileEmpty(t *testing.T) {
 	l := newMinimalLoop()
 	l.SetEgoFile(egoPath)
 
-	prompt := l.buildSystemPrompt(context.Background(), "hello", nil)
+	prompt := l.buildSystemPrompt(context.Background(), "hello")
 
 	if strings.Contains(prompt, "ego.md") {
 		t.Error("system prompt should not contain ego section when file is empty")
@@ -290,7 +289,7 @@ func TestBuildSystemPrompt_EgoFileTruncated(t *testing.T) {
 	l := newMinimalLoop()
 	l.SetEgoFile(egoPath)
 
-	prompt := l.buildSystemPrompt(context.Background(), "hello", nil)
+	prompt := l.buildSystemPrompt(context.Background(), "hello")
 
 	if !strings.Contains(prompt, "truncated") {
 		t.Error("system prompt should contain truncation marker for oversized ego.md")
@@ -304,7 +303,7 @@ func TestBuildSystemPrompt_NoEgoFile(t *testing.T) {
 	l := newMinimalLoop()
 	// egoFile not set — default empty string
 
-	prompt := l.buildSystemPrompt(context.Background(), "hello", nil)
+	prompt := l.buildSystemPrompt(context.Background(), "hello")
 
 	if strings.Contains(prompt, "ego.md") {
 		t.Error("system prompt should not contain ego section when egoFile is not set")
@@ -314,7 +313,7 @@ func TestBuildSystemPrompt_NoEgoFile(t *testing.T) {
 func TestBuildSystemPrompt_RuntimeContractIncluded(t *testing.T) {
 	l := newMinimalLoop()
 
-	prompt := l.buildSystemPrompt(context.Background(), "summarize kb:article.md", nil)
+	prompt := l.buildSystemPrompt(context.Background(), "summarize kb:article.md")
 
 	if !strings.Contains(prompt, "## Runtime Contract") {
 		t.Fatal("system prompt should contain runtime contract section")
@@ -342,7 +341,7 @@ func TestBuildSystemPrompt_InjectFilesIncluded(t *testing.T) {
 	l := newMinimalLoop()
 	l.SetInjectFiles([]string{f1, f2})
 
-	prompt := l.buildSystemPrompt(context.Background(), "hello", nil)
+	prompt := l.buildSystemPrompt(context.Background(), "hello")
 
 	if !strings.Contains(prompt, "key fact") {
 		t.Error("system prompt should contain first inject file content")
@@ -377,7 +376,7 @@ literal context body
 	l := newMinimalLoop()
 	l.SetInjectFiles([]string{f})
 
-	prompt := l.buildSystemPrompt(context.Background(), "hello", nil)
+	prompt := l.buildSystemPrompt(context.Background(), "hello")
 
 	if !strings.Contains(prompt, "literal context body") {
 		t.Fatal("system prompt should contain inject file body")
@@ -411,7 +410,7 @@ func TestBuildSystemPrompt_InjectFilesVerifierBlocks(t *testing.T) {
 	l.SetInjectFiles([]string{f})
 	l.UseInjectFileVerifier(rejectingInjectFileVerifier{}.VerifyPath)
 
-	prompt := l.buildSystemPrompt(context.Background(), "hello", nil)
+	prompt := l.buildSystemPrompt(context.Background(), "hello")
 
 	if strings.Contains(prompt, "blocked context") {
 		t.Fatal("system prompt should not contain content rejected by the inject-file verifier")
@@ -429,7 +428,7 @@ func TestBuildSystemPrompt_InjectFilesRereadOnChange(t *testing.T) {
 	l := newMinimalLoop()
 	l.SetInjectFiles([]string{f})
 
-	prompt1 := l.buildSystemPrompt(context.Background(), "hello", nil)
+	prompt1 := l.buildSystemPrompt(context.Background(), "hello")
 	if !strings.Contains(prompt1, "version-1") {
 		t.Fatal("first prompt should contain version-1")
 	}
@@ -437,7 +436,7 @@ func TestBuildSystemPrompt_InjectFilesRereadOnChange(t *testing.T) {
 	// Modify the file between turns.
 	os.WriteFile(f, []byte("version-2"), 0644)
 
-	prompt2 := l.buildSystemPrompt(context.Background(), "hello", nil)
+	prompt2 := l.buildSystemPrompt(context.Background(), "hello")
 	if strings.Contains(prompt2, "version-1") {
 		t.Error("second prompt should not contain stale version-1")
 	}
@@ -450,7 +449,7 @@ func TestBuildSystemPrompt_InjectFilesMissing(t *testing.T) {
 	l := newMinimalLoop()
 	l.SetInjectFiles([]string{filepath.Join(t.TempDir(), "nonexistent.md")})
 
-	prompt := l.buildSystemPrompt(context.Background(), "hello", nil)
+	prompt := l.buildSystemPrompt(context.Background(), "hello")
 
 	if strings.Contains(prompt, "Injected Context") {
 		t.Error("system prompt should not contain injected context section when all files are missing")
@@ -461,7 +460,7 @@ func TestBuildSystemPrompt_InjectFilesEmpty(t *testing.T) {
 	l := newMinimalLoop()
 	// injectFiles not set — default nil
 
-	prompt := l.buildSystemPrompt(context.Background(), "hello", nil)
+	prompt := l.buildSystemPrompt(context.Background(), "hello")
 
 	if strings.Contains(prompt, "Injected Context") {
 		t.Error("system prompt should not contain injected context section when no files configured")
@@ -485,14 +484,12 @@ func TestBuildSystemPrompt_TaskModeOmitsIdentityContinuityContext(t *testing.T) 
 	l.SetInjectFiles([]string{injectPath})
 
 	ctx := agentctx.WithPromptMode(context.Background(), agentctx.PromptModeTask)
-	history := []memory.Message{{Role: "user", Content: "HISTORY_MARKER"}}
-	prompt := l.buildSystemPrompt(ctx, "hello", history)
+	prompt := l.buildSystemPrompt(ctx, "hello")
 
 	for _, marker := range []string{
 		"PERSONA_MARKER",
 		"EGO_MARKER",
 		"INJECT_MARKER",
-		"HISTORY_MARKER",
 		"Self-Reflection (ego.md)",
 		"Injected Context",
 		"Conversation History",

--- a/internal/runtime/agent/history_messages_test.go
+++ b/internal/runtime/agent/history_messages_test.go
@@ -15,12 +15,7 @@ import (
 func TestBuildSystemPrompt_OmitsConversationHistory(t *testing.T) {
 	l := newMinimalLoop()
 
-	history := []memory.Message{
-		{Role: "user", Content: "Turn on the lights", Timestamp: time.Now().Add(-time.Hour)},
-		{Role: "assistant", Content: "Done, lights are on.", Timestamp: time.Now().Add(-59 * time.Minute)},
-	}
-
-	prompt := l.buildSystemPrompt(context.Background(), "what is the temperature?", history)
+	prompt := l.buildSystemPrompt(context.Background(), "what is the temperature?")
 
 	for _, marker := range []string{
 		"## Conversation History",

--- a/internal/runtime/agent/loop.go
+++ b/internal/runtime/agent/loop.go
@@ -1015,17 +1015,17 @@ type promptSection struct {
 	end   int
 }
 
-func (l *Loop) buildSystemPrompt(ctx context.Context, userMessage string, _ []memory.Message) string {
-	prompt, _ := l.buildSystemPromptWithProfileSections(ctx, userMessage, nil, llm.DefaultModelInteractionProfile())
+func (l *Loop) buildSystemPrompt(ctx context.Context, userMessage string) string {
+	prompt, _ := l.buildSystemPromptWithProfileSections(ctx, userMessage, llm.DefaultModelInteractionProfile())
 	return prompt
 }
 
-func (l *Loop) buildSystemPromptWithProfile(ctx context.Context, userMessage string, _ []memory.Message, profile llm.ModelInteractionProfile) string {
-	prompt, _ := l.buildSystemPromptWithProfileSections(ctx, userMessage, nil, profile)
+func (l *Loop) buildSystemPromptWithProfile(ctx context.Context, userMessage string, profile llm.ModelInteractionProfile) string {
+	prompt, _ := l.buildSystemPromptWithProfileSections(ctx, userMessage, profile)
 	return prompt
 }
 
-func (l *Loop) buildSystemPromptWithProfileSections(ctx context.Context, userMessage string, _ []memory.Message, profile llm.ModelInteractionProfile) (string, []llm.PromptSection) {
+func (l *Loop) buildSystemPromptWithProfileSections(ctx context.Context, userMessage string, profile llm.ModelInteractionProfile) (string, []llm.PromptSection) {
 	var sb strings.Builder
 	promptMode := agentctx.PromptModeFromContext(ctx)
 	taskPrompt := promptMode == agentctx.PromptModeTask
@@ -1792,7 +1792,7 @@ func (l *Loop) Run(ctx context.Context, req *Request, stream StreamCallback) (re
 	if req.SystemPrompt != "" {
 		systemPrompt = req.SystemPrompt
 	} else {
-		systemPrompt, systemSections = l.buildSystemPromptWithProfileSections(promptCtx, userMessage, history, llm.DefaultModelInteractionProfile())
+		systemPrompt, systemSections = l.buildSystemPromptWithProfileSections(promptCtx, userMessage, llm.DefaultModelInteractionProfile())
 	}
 
 	usageInfo := awareness.ContextUsageInfo{
@@ -1825,7 +1825,7 @@ func (l *Loop) Run(ctx context.Context, req *Request, stream StreamCallback) (re
 			return
 		}
 		usageInfo.Model = model
-		systemPrompt, systemSections = l.buildSystemPromptWithProfileSections(promptCtx, userMessage, history, l.modelInteractionProfileForModel(model))
+		systemPrompt, systemSections = l.buildSystemPromptWithProfileSections(promptCtx, userMessage, l.modelInteractionProfileForModel(model))
 		updateSystemMessage()
 	}
 
@@ -2152,7 +2152,7 @@ func (l *Loop) Run(ctx context.Context, req *Request, stream StreamCallback) (re
 			// Skip rebuild when a custom SystemPrompt is in use for callers
 			// that assemble their own context externally.
 			if i > 0 && len(msgs) > 0 && msgs[0].Role == "system" && req.SystemPrompt == "" {
-				rebuilt := l.buildSystemPromptWithProfile(iterCtx, userMessage, history, l.modelInteractionProfileForModel(currentModel))
+				rebuilt := l.buildSystemPromptWithProfile(iterCtx, userMessage, l.modelInteractionProfileForModel(currentModel))
 				// Omit FormatContextUsage — usageInfo was computed before the
 				// run and would be misleading after prompt content changes.
 				msgs[0].Content = rebuilt

--- a/internal/runtime/agent/model_selection_test.go
+++ b/internal/runtime/agent/model_selection_test.go
@@ -94,9 +94,9 @@ func TestRun_ExplicitModelPreflightUsesModelSpecificPromptSize(t *testing.T) {
 
 	userMessage := "please inspect the loaded memory timeline"
 	reqMessages := []Message{{Role: "user", Content: userMessage}}
-	defaultPrompt, defaultSections := loop.buildSystemPromptWithProfileSections(context.Background(), userMessage, nil, llm.DefaultModelInteractionProfile())
+	defaultPrompt, defaultSections := loop.buildSystemPromptWithProfileSections(context.Background(), userMessage, llm.DefaultModelInteractionProfile())
 	defaultSize := estimateLLMMessagesContextTokens(buildInitialLLMMessages(defaultPrompt, defaultSections, nil, reqMessages, "default", time.Time{}))
-	modelPrompt, modelSections := loop.buildSystemPromptWithProfileSections(context.Background(), userMessage, nil, loop.modelInteractionProfileForModel("gemma-local"))
+	modelPrompt, modelSections := loop.buildSystemPromptWithProfileSections(context.Background(), userMessage, loop.modelInteractionProfileForModel("gemma-local"))
 	modelSize := estimateLLMMessagesContextTokens(buildInitialLLMMessages(modelPrompt, modelSections, nil, reqMessages, "default", time.Time{}))
 	if modelSize <= defaultSize {
 		t.Fatalf("model-specific prompt size = %d, want > default size %d", modelSize, defaultSize)
@@ -137,9 +137,9 @@ func TestRun_RoutedModelRechecksModelSpecificPromptSize(t *testing.T) {
 
 	userMessage := "what is the status"
 	reqMessages := []Message{{Role: "user", Content: userMessage}}
-	defaultPrompt, defaultSections := loop.buildSystemPromptWithProfileSections(context.Background(), userMessage, nil, llm.DefaultModelInteractionProfile())
+	defaultPrompt, defaultSections := loop.buildSystemPromptWithProfileSections(context.Background(), userMessage, llm.DefaultModelInteractionProfile())
 	defaultSize := estimateLLMMessagesContextTokens(buildInitialLLMMessages(defaultPrompt, defaultSections, nil, reqMessages, "default", time.Time{}))
-	qwenPrompt, qwenSections := loop.buildSystemPromptWithProfileSections(context.Background(), userMessage, nil, loop.modelInteractionProfileForModel("qwen3:8b"))
+	qwenPrompt, qwenSections := loop.buildSystemPromptWithProfileSections(context.Background(), userMessage, loop.modelInteractionProfileForModel("qwen3:8b"))
 	qwenSize := estimateLLMMessagesContextTokens(buildInitialLLMMessages(qwenPrompt, qwenSections, nil, reqMessages, "default", time.Time{}))
 	if qwenSize <= defaultSize {
 		t.Fatalf("qwen prompt size = %d, want > default size %d", qwenSize, defaultSize)

--- a/internal/runtime/agent/prompt_order_test.go
+++ b/internal/runtime/agent/prompt_order_test.go
@@ -57,9 +57,9 @@ func TestBuildSystemPromptSections_FullPromptUsesInvertedPyramidOrder(t *testing
 	_, sections := l.buildSystemPromptWithProfileSections(
 		testCtxForLoop(l),
 		"hello",
-		nil,
-		llm.DefaultModelInteractionProfile(),
-	)
+
+		llm.DefaultModelInteractionProfile())
+
 	index := promptSectionIndex(t, sections)
 	assertPromptSectionsStartAtContent(t, sections)
 
@@ -131,9 +131,9 @@ func TestBuildSystemPromptSections_TaskPromptUsesCompactOrder(t *testing.T) {
 	_, sections := l.buildSystemPromptWithProfileSections(
 		ctx,
 		"hello",
-		nil,
-		llm.DefaultModelInteractionProfile(),
-	)
+
+		llm.DefaultModelInteractionProfile())
+
 	index := promptSectionIndex(t, sections)
 	assertPromptSectionsStartAtContent(t, sections)
 
@@ -189,9 +189,8 @@ func TestBuildSystemPromptSections_CoreFileBudgetTruncation(t *testing.T) {
 	_, sections := l.buildSystemPromptWithProfileSections(
 		context.Background(),
 		"hello",
-		nil,
-		llm.DefaultModelInteractionProfile(),
-	)
+
+		llm.DefaultModelInteractionProfile())
 
 	assertPromptSectionContains(t, sections, "AXIOMS", "axioms.md truncated")
 	assertPromptSectionContains(t, sections, "PERSONA", "persona.md truncated")

--- a/internal/runtime/agent/tag_context_test.go
+++ b/internal/runtime/agent/tag_context_test.go
@@ -74,7 +74,7 @@ func TestBuildSystemPrompt_TagContextIncluded(t *testing.T) {
 		},
 	}, nil)
 
-	prompt := l.buildSystemPrompt(testCtxForLoop(l), "hello", nil)
+	prompt := l.buildSystemPrompt(testCtxForLoop(l), "hello")
 
 	if !strings.Contains(prompt, "hexagonal pattern") {
 		t.Error("system prompt should contain first KB article content")
@@ -108,7 +108,7 @@ func TestBuildSystemPrompt_TagContextInactiveExcluded(t *testing.T) {
 		Logger:  l.logger,
 	}))
 
-	prompt := l.buildSystemPrompt(testCtxForLoop(l), "hello", nil)
+	prompt := l.buildSystemPrompt(testCtxForLoop(l), "hello")
 
 	if strings.Contains(prompt, "Secret content") {
 		t.Error("system prompt should not contain context from inactive tags")
@@ -145,7 +145,7 @@ func TestBuildSystemPrompt_TagContextDedup(t *testing.T) {
 		Logger:  l.logger,
 	}))
 
-	prompt := l.buildSystemPrompt(testCtxForLoop(l), "hello", nil)
+	prompt := l.buildSystemPrompt(testCtxForLoop(l), "hello")
 
 	// The shared file should appear exactly once.
 	count := strings.Count(prompt, "shared knowledge")
@@ -176,7 +176,7 @@ func TestBuildSystemPrompt_TagContextTrailheadFirst(t *testing.T) {
 		Logger:  l.logger,
 	}))
 
-	prompt := l.buildSystemPrompt(testCtxForLoop(l), "hello", nil)
+	prompt := l.buildSystemPrompt(testCtxForLoop(l), "hello")
 	treeIdx := strings.Index(prompt, "TREE_MARKER")
 	articleIdx := strings.Index(prompt, "ARTICLE_MARKER")
 	if treeIdx < 0 || articleIdx < 0 {
@@ -191,7 +191,7 @@ func TestBuildSystemPrompt_TagContextNoCapTags(t *testing.T) {
 	l := newMinimalLoop()
 	// capTags not set — should not inject any tag context
 
-	prompt := l.buildSystemPrompt(testCtxForLoop(l), "hello", nil)
+	prompt := l.buildSystemPrompt(testCtxForLoop(l), "hello")
 
 	if strings.Contains(prompt, "Tagged Guidance") {
 		t.Error("system prompt should not contain tagged guidance section when capTags is nil")
@@ -220,7 +220,7 @@ func TestBuildSystemPrompt_TagContextChannelPinnedBuiltinTagIncluded(t *testing.
 	scope.PinChannelTags([]string{"interactive"})
 	ctx := withCapabilityScope(context.Background(), scope)
 
-	prompt := l.buildSystemPrompt(ctx, "hello", nil)
+	prompt := l.buildSystemPrompt(ctx, "hello")
 
 	if !strings.Contains(prompt, "INTERACTIVE_CONTEXT_MARKER") {
 		t.Fatal("channel-pinned builtin helper tag should inject matching KB article")
@@ -256,7 +256,7 @@ func TestBuildSystemPrompt_CoreContextProviderOrder(t *testing.T) {
 		Logger:  l.logger,
 	}))
 
-	prompt := l.buildSystemPrompt(testCtxForLoop(l), "hello", nil)
+	prompt := l.buildSystemPrompt(testCtxForLoop(l), "hello")
 
 	injectedIdx := strings.Index(prompt, "INJECTED_MARKER")
 	tagCtxIdx := strings.Index(prompt, "TAG_CONTEXT_MARKER")
@@ -321,7 +321,7 @@ func TestBuildSystemPrompt_HAInjectResolved(t *testing.T) {
 		Logger:   l.logger,
 	}))
 
-	prompt := l.buildSystemPrompt(testCtxForLoop(l), "hello", nil)
+	prompt := l.buildSystemPrompt(testCtxForLoop(l), "hello")
 
 	if !strings.Contains(prompt, "## Current HA State (live)") {
 		t.Error("prompt should contain live state header")
@@ -356,7 +356,7 @@ func TestBuildSystemPrompt_HAInjectNilFetcher(t *testing.T) {
 	}))
 	// haInject not set — should pass through without resolving
 
-	prompt := l.buildSystemPrompt(testCtxForLoop(l), "hello", nil)
+	prompt := l.buildSystemPrompt(testCtxForLoop(l), "hello")
 
 	if strings.Contains(prompt, "## Current HA State") {
 		t.Error("prompt should not contain state block when haInject is nil")
@@ -389,7 +389,7 @@ func TestBuildSystemPrompt_HAInjectFetchFailure(t *testing.T) {
 		Logger:   l.logger,
 	}))
 
-	prompt := l.buildSystemPrompt(testCtxForLoop(l), "hello", nil)
+	prompt := l.buildSystemPrompt(testCtxForLoop(l), "hello")
 
 	if !strings.Contains(prompt, "⚠️ HA entity state unavailable") {
 		t.Error("prompt should contain unavailability warning when all fetches fail")
@@ -804,7 +804,7 @@ func TestBuildSystemPrompt_TagContextViaProvider(t *testing.T) {
 		content: `{"accounts":["github-primary"]}`,
 	})
 
-	prompt := l.buildSystemPrompt(testCtxForLoop(l), "hello", nil)
+	prompt := l.buildSystemPrompt(testCtxForLoop(l), "hello")
 
 	if !strings.Contains(prompt, "github-primary") {
 		t.Error("system prompt should contain live provider content")
@@ -833,7 +833,7 @@ func TestRegisterTagContextProvider_NormalizesTag(t *testing.T) {
 			},
 		}, nil)
 
-		prompt := l.buildSystemPrompt(testCtxForLoop(l), "hello", nil)
+		prompt := l.buildSystemPrompt(testCtxForLoop(l), "hello")
 		if !strings.Contains(prompt, "github-primary") {
 			t.Error("provider registered with whitespace-padded tag should fire under the trimmed tag")
 		}
@@ -851,7 +851,7 @@ func TestRegisterTagContextProvider_NormalizesTag(t *testing.T) {
 			"forge": {Description: "x", Tools: []string{"t"}, Core: true},
 		}, nil)
 
-		prompt := l.buildSystemPrompt(testCtxForLoop(l), "hello", nil)
+		prompt := l.buildSystemPrompt(testCtxForLoop(l), "hello")
 		// Exactly one provider's content must appear; both would
 		// indicate the staging map kept whitespace-distinct keys.
 		hasFirst := strings.Contains(prompt, "first")
@@ -872,7 +872,7 @@ func TestRegisterTagContextProvider_NormalizesTag(t *testing.T) {
 			"forge": {Description: "x", Tools: []string{"t"}, Core: true},
 		}, nil)
 
-		prompt := l.buildSystemPrompt(testCtxForLoop(l), "hello", nil)
+		prompt := l.buildSystemPrompt(testCtxForLoop(l), "hello")
 		if strings.Contains(prompt, "leak") {
 			t.Error("empty-after-trim registration should be dropped, not staged")
 		}

--- a/internal/runtime/agent/talents_prompt_test.go
+++ b/internal/runtime/agent/talents_prompt_test.go
@@ -21,7 +21,7 @@ func TestBuildSystemPrompt_TaggedTalentsLoadForActiveTags(t *testing.T) {
 		"files":     {Description: "Files", Core: false},
 	}, parsed)
 
-	prompt := l.buildSystemPrompt(testCtxForLoop(l), "hello", nil)
+	prompt := l.buildSystemPrompt(testCtxForLoop(l), "hello")
 
 	if !strings.Contains(prompt, "KNOWLEDGE_TREE_MARKER") {
 		t.Fatalf("prompt missing knowledge talent: %s", prompt)
@@ -47,7 +47,7 @@ func TestBuildSystemPrompt_CommunicationSlicesFollowActiveTags(t *testing.T) {
 		"forge":       {Description: "Forge", Core: false},
 	}, parsed)
 
-	prompt := l.buildSystemPrompt(testCtxForLoop(l), "hello", nil)
+	prompt := l.buildSystemPrompt(testCtxForLoop(l), "hello")
 
 	if !strings.Contains(prompt, "CORE_COMMUNICATION_MARKER") {
 		t.Fatalf("prompt missing core communication slice: %s", prompt)
@@ -72,7 +72,7 @@ func TestBuildSystemPrompt_TrailheadTalentsPrecedeTaggedDoctrine(t *testing.T) {
 		"interactive": {Description: "Interactive", Core: true},
 	}, parsed)
 
-	prompt := l.buildSystemPrompt(testCtxForLoop(l), "hello", nil)
+	prompt := l.buildSystemPrompt(testCtxForLoop(l), "hello")
 	coreIdx := strings.Index(prompt, "CORE_MARKER")
 	entryIdx := strings.Index(prompt, "INTERACTIVE_ENTRY_MARKER")
 	commIdx := strings.Index(prompt, "INTERACTIVE_COMM_MARKER")
@@ -100,9 +100,8 @@ func TestBuildSystemPromptWithProfileSections_SplitsCacheableBehaviorPrefix(t *t
 	prompt, sections := l.buildSystemPromptWithProfileSections(
 		testCtxForLoop(l),
 		"hello",
-		nil,
-		llm.DefaultModelInteractionProfile(),
-	)
+
+		llm.DefaultModelInteractionProfile())
 
 	if !strings.Contains(prompt, "CORE_MARKER") || !strings.Contains(prompt, "INTERACTIVE_ENTRY_MARKER") {
 		t.Fatalf("prompt missing expected markers:\n%s", prompt)

--- a/internal/runtime/agent/tool_call_contract_prompt_test.go
+++ b/internal/runtime/agent/tool_call_contract_prompt_test.go
@@ -13,13 +13,12 @@ func TestBuildSystemPromptWithProfile_AddsToolCallingContractForRawTextModels(t 
 	prompt := l.buildSystemPromptWithProfile(
 		testCtxForLoop(l),
 		"activate forge",
-		nil,
+
 		llm.ProfileForModel(llm.ModelProfileInput{
 			Provider: "lmstudio",
 			Model:    "google/gemma-3-4b",
 			Family:   "gemma3",
-		}),
-	)
+		}))
 
 	if !strings.Contains(prompt, "## Tool Calling Contract") {
 		t.Fatalf("prompt missing Tool Calling Contract section: %s", prompt)
@@ -41,9 +40,8 @@ func TestBuildSystemPromptWithProfile_OmitsToolCallingContractForNativeModels(t 
 	prompt := l.buildSystemPromptWithProfile(
 		testCtxForLoop(l),
 		"hello",
-		nil,
-		llm.DefaultModelInteractionProfile(),
-	)
+
+		llm.DefaultModelInteractionProfile())
 
 	if strings.Contains(prompt, "## Tool Calling Contract") {
 		t.Fatalf("prompt unexpectedly included Tool Calling Contract: %s", prompt)

--- a/internal/runtime/archivist/archivist.go
+++ b/internal/runtime/archivist/archivist.go
@@ -187,35 +187,6 @@ func HydrateSpec(spec loop.Spec, _ Config) loop.Spec {
 	return spec
 }
 
-// BuildSpec returns a [loop.Spec] that implements the archivist loop as
-// a service loop. The per-iteration prompt is the spec Task
-// ([prompts.ArchivistBaseTemplate]) and the supervisor-turn prefix is the
-// declarative SupervisorProfile.Instructions.
-func BuildSpec(cfg Config) loop.Spec {
-	return HydrateSpec(DefinitionSpec(cfg), cfg)
-}
-
-// BuildLoopConfig returns the engine-facing [loop.Config] view of the
-// archivist loop. Kept as a compatibility shim for callers that work
-// directly with [loop.Config] rather than [loop.Spec].
-func BuildLoopConfig(cfg Config) loop.Config {
-	spec := BuildSpec(cfg)
-	out := spec.ToConfig()
-	profileHints := spec.Profile.RoutingFactors()
-	if len(profileHints) > 0 {
-		if out.RoutingFactors == nil {
-			out.RoutingFactors = make(map[string]string, len(profileHints))
-		}
-		for k, v := range profileHints {
-			out.RoutingFactors[k] = v
-		}
-	}
-	if spec.Profile.DelegationGating != "" {
-		out.DelegationGating = spec.Profile.DelegationGating
-	}
-	return out
-}
-
 // archivistExcludeTools lists tools the archivist loop should not have
 // access to. The archivist's writes go through the managed output
 // (`core:archivist.md`) and the documents tools (for dossiers in the

--- a/internal/runtime/ego/ego.go
+++ b/internal/runtime/ego/ego.go
@@ -147,36 +147,6 @@ func HydrateSpec(spec loop.Spec, _ Config) loop.Spec {
 	return spec
 }
 
-// BuildSpec returns a [loop.Spec] that implements the ego loop as a
-// service loop. The returned spec declares the durable output document;
-// the per-iteration prompt is the spec Task ([prompts.EgoBaseTemplate])
-// and the supervisor-turn prefix is the declarative
-// SupervisorProfile.Instructions ([prompts.EgoSupervisorInstructions]).
-func BuildSpec(cfg Config) loop.Spec {
-	return HydrateSpec(DefinitionSpec(cfg), cfg)
-}
-
-// BuildLoopConfig returns the engine-facing [loop.Config] view of the
-// ego loop. Kept as a compatibility shim for callers that work directly
-// with [loop.Config] rather than [loop.Spec].
-func BuildLoopConfig(cfg Config) loop.Config {
-	spec := BuildSpec(cfg)
-	out := spec.ToConfig()
-	profileHints := spec.Profile.RoutingFactors()
-	if len(profileHints) > 0 {
-		if out.RoutingFactors == nil {
-			out.RoutingFactors = make(map[string]string, len(profileHints))
-		}
-		for k, v := range profileHints {
-			out.RoutingFactors[k] = v
-		}
-	}
-	if spec.Profile.DelegationGating != "" {
-		out.DelegationGating = spec.Profile.DelegationGating
-	}
-	return out
-}
-
 // egoExcludeTools lists tools that the ego loop should not have access
 // to. File tools are replaced by the declared durable output tool, exec
 // is unnecessary, session management is for interactive use only.

--- a/internal/runtime/loop/config.go
+++ b/internal/runtime/loop/config.go
@@ -476,9 +476,10 @@ type IterationResult struct {
 	LoadedCapabilities []toolcatalog.LoadedCapabilityEntry
 	// Elapsed is the wall-clock duration of the iteration.
 	Elapsed time.Duration
-	// Supervisor indicates whether this iteration ran a supervisor
-	// turn. Derived from SupervisorTrigger; preserved for
-	// backwards-compatible consumers that just want the bool.
+	// Supervisor reports whether this iteration ran a supervisor turn.
+	// It is a convenience projection of SupervisorTrigger != "" for event
+	// payloads and consumers that only need the boolean and don't match on
+	// the trigger enum.
 	Supervisor bool
 	// SupervisorTrigger names why a supervisor turn fired (or
 	// reports the empty string when this iteration ran as a normal
@@ -523,9 +524,10 @@ type IterationSnapshot struct {
 	// value is directly usable by the client without nanosecond
 	// conversion.
 	ElapsedMs int64 `json:"elapsed_ms"`
-	// Supervisor indicates whether this iteration ran a supervisor
-	// turn. Derived from SupervisorTrigger; the JSON wire format
-	// keeps the bool so existing dashboard clients render correctly.
+	// Supervisor reports whether this iteration ran a supervisor turn.
+	// It is a convenience projection of SupervisorTrigger != "" kept on
+	// the JSON wire so dashboard clients can read the boolean directly
+	// without matching on supervisor_trigger.
 	Supervisor bool `json:"supervisor,omitempty"`
 	// SupervisorTrigger names why a supervisor turn fired. Empty
 	// string for normal turns. Emitted alongside the bool so

--- a/internal/runtime/loop/signals.go
+++ b/internal/runtime/loop/signals.go
@@ -73,22 +73,6 @@ func NotifyEnvelopesFromContext(ctx context.Context) []messages.Envelope {
 	return out
 }
 
-// WakeTagsFromContext returns the iteration-scoped capability tags
-// carried on the envelopes that woke the current loop iteration, if any.
-// Handler-based loops can use this to observe source-classified tags
-// (for example contacts → "owner", MQTT topic → "security") that the
-// loop runtime has already folded into the iteration's Request.InitialTags
-// for task-built turns.
-func WakeTagsFromContext(ctx context.Context) []string {
-	tags, _ := ctx.Value(wakeTagsContextKey{}).([]string)
-	if len(tags) == 0 {
-		return nil
-	}
-	out := make([]string, len(tags))
-	copy(out, tags)
-	return out
-}
-
 func withNotifyEnvelopes(ctx context.Context, envs []messages.Envelope) context.Context {
 	if len(envs) == 0 {
 		return ctx

--- a/internal/runtime/metacognitive/metacognitive.go
+++ b/internal/runtime/metacognitive/metacognitive.go
@@ -230,36 +230,6 @@ func HydrateSpec(spec loop.Spec, _ Config, opts Opts) loop.Spec {
 	return spec
 }
 
-// BuildSpec returns a [loop.Spec] that implements the metacognitive
-// loop as a service loop. The per-iteration prompt is the spec Task
-// ([prompts.MetacognitiveBaseTemplate]) and the supervisor-turn prefix
-// is the declarative SupervisorProfile.Instructions; HydrateSpec adds
-// the PostIterate iteration-log writer.
-func BuildSpec(cfg Config, opts Opts) loop.Spec {
-	return HydrateSpec(DefinitionSpec(cfg), cfg, opts)
-}
-
-// BuildLoopConfig returns the engine-facing [loop.Config] view of the
-// metacognitive loop. Kept as a compatibility shim for callers that
-// work directly with [loop.Config] rather than [loop.Spec].
-func BuildLoopConfig(cfg Config, opts Opts) loop.Config {
-	spec := BuildSpec(cfg, opts)
-	out := spec.ToConfig()
-	profileHints := spec.Profile.RoutingFactors()
-	if len(profileHints) > 0 {
-		if out.RoutingFactors == nil {
-			out.RoutingFactors = make(map[string]string, len(profileHints))
-		}
-		for k, v := range profileHints {
-			out.RoutingFactors[k] = v
-		}
-	}
-	if spec.Profile.DelegationGating != "" {
-		out.DelegationGating = spec.Profile.DelegationGating
-	}
-	return out
-}
-
 // metacogExcludeTools lists tools that the metacognitive loop should not
 // have access to. File tools are replaced by the declared durable output
 // tool, exec is unnecessary and dangerous, session management is for

--- a/internal/runtime/metacognitive/metacognitive_test.go
+++ b/internal/runtime/metacognitive/metacognitive_test.go
@@ -315,9 +315,9 @@ func TestFormatToolsUsed_Sorted(t *testing.T) {
 	}
 }
 
-// --- BuildLoopConfig tests ---
+// --- Hydrated spec/config projection tests ---
 
-func TestBuildSpec(t *testing.T) {
+func TestHydratedSpec(t *testing.T) {
 	tmpDir := t.TempDir()
 	cfg := testConfig()
 	opts := Opts{
@@ -325,7 +325,7 @@ func TestBuildSpec(t *testing.T) {
 		StateFilePath: filepath.Join(tmpDir, cfg.StateFile),
 	}
 
-	spec := BuildSpec(cfg, opts)
+	spec := HydrateSpec(DefinitionSpec(cfg), cfg, opts)
 	if spec.Name != "metacognitive" {
 		t.Errorf("Name = %q, want metacognitive", spec.Name)
 	}
@@ -399,7 +399,7 @@ func TestHydrateSpecAttachesLoopRuntimeHooks(t *testing.T) {
 	}
 }
 
-func TestBuildLoopConfig(t *testing.T) {
+func TestHydratedConfig(t *testing.T) {
 	tmpDir := t.TempDir()
 	cfg := testConfig()
 	opts := Opts{
@@ -407,7 +407,8 @@ func TestBuildLoopConfig(t *testing.T) {
 		StateFilePath: filepath.Join(tmpDir, cfg.StateFile),
 	}
 
-	lc := BuildLoopConfig(cfg, opts)
+	spec := HydrateSpec(DefinitionSpec(cfg), cfg, opts)
+	lc := spec.ToConfig()
 
 	if lc.Name != "metacognitive" {
 		t.Errorf("Name = %q, want metacognitive", lc.Name)
@@ -433,15 +434,10 @@ func TestBuildLoopConfig(t *testing.T) {
 	if lc.PostIterate == nil {
 		t.Error("PostIterate should be set")
 	}
-	if lc.RoutingFactors["source"] != "metacognitive" {
-		t.Errorf("Hints[source] = %q, want metacognitive", lc.RoutingFactors["source"])
-	}
-	if lc.RoutingFactors["mission"] != "metacognitive" {
-		t.Errorf("Hints[mission] = %q, want metacognitive", lc.RoutingFactors["mission"])
-	}
-	if lc.DelegationGating != "disabled" {
-		t.Errorf("Config.DelegationGating = %q, want disabled", lc.DelegationGating)
-	}
+	// Profile-derived routing factors (mission/source) and DelegationGating
+	// are applied by the live loop at request time via Profile.RequestOptions,
+	// not by ToConfig — so they are asserted on the Spec in TestHydratedSpec
+	// rather than on this bare Config projection.
 
 	// Verify ExcludeTools contains key entries.
 	excluded := make(map[string]bool)
@@ -455,7 +451,7 @@ func TestBuildLoopConfig(t *testing.T) {
 	}
 }
 
-func TestBuildLoopConfig_Task(t *testing.T) {
+func TestHydratedConfig_Task(t *testing.T) {
 	tmpDir := t.TempDir()
 	cfg := testConfig()
 	opts := Opts{
@@ -463,7 +459,8 @@ func TestBuildLoopConfig_Task(t *testing.T) {
 		StateFilePath: filepath.Join(tmpDir, cfg.StateFile),
 	}
 
-	lc := BuildLoopConfig(cfg, opts)
+	spec := HydrateSpec(DefinitionSpec(cfg), cfg, opts)
+	lc := spec.ToConfig()
 
 	// The prompt is now a static Task (no TaskBuilder); current state
 	// comes from the declared output context, not inlined into the prompt.
@@ -481,7 +478,7 @@ func TestBuildLoopConfig_Task(t *testing.T) {
 	}
 }
 
-func TestBuildLoopConfig_PostIterate(t *testing.T) {
+func TestHydratedConfig_PostIterate(t *testing.T) {
 	tmpDir := t.TempDir()
 	cfg := testConfig()
 	statePath := filepath.Join(tmpDir, cfg.StateFile)
@@ -490,7 +487,8 @@ func TestBuildLoopConfig_PostIterate(t *testing.T) {
 		StateFilePath: statePath,
 	}
 
-	lc := BuildLoopConfig(cfg, opts)
+	spec := HydrateSpec(DefinitionSpec(cfg), cfg, opts)
+	lc := spec.ToConfig()
 
 	result := loop.IterationResult{
 		ConvID:       "metacog-post-test",

--- a/internal/state/awareness/loop_subscription_provider.go
+++ b/internal/state/awareness/loop_subscription_provider.go
@@ -156,12 +156,14 @@ func (p *LoopSubscriptionProvider) TagContext(ctx context.Context, _ agentctx.Co
 	return sb.String(), nil
 }
 
-// renderLoopSubscription adapts a loop.EntitySubscription into the
-// same rendering pipeline the watchlist providers use. The
-// intermediate WatchedSubscription is a thin shim — once the
-// migration is complete and WatchedSubscription is no longer used
-// as a storage type elsewhere, the renderer can take fields
-// directly.
+// renderLoopSubscription adapts a loop.EntitySubscription into the same
+// rendering pipeline the always-visible watchlist providers use, mapping it
+// onto WatchedSubscription. The two are deliberately distinct representations,
+// not a migration in flight: WatchedSubscription is the SQLite row type for
+// the always-visible watchlist (it carries Scope and ExpiresAt), while
+// loop.EntitySubscription is the loop-scoped attribute on Spec. The shared
+// renderer consumes the WatchedSubscription shape so both sources render
+// identically.
 func (p *LoopSubscriptionProvider) renderLoopSubscription(ctx context.Context, sub looppkg.EntitySubscription, now time.Time, registries *renderRegistries) string {
 	w := watchedFromLoopSubscription(sub)
 	state, err := p.ha.GetState(ctx, w.EntityID)
@@ -175,8 +177,9 @@ func (p *LoopSubscriptionProvider) renderLoopSubscription(ctx context.Context, s
 	return renderWatchedState(ctx, p.ha, p.logger, w, state, now, registries)
 }
 
-// watchedFromLoopSubscription adapts a loop.EntitySubscription into the
-// WatchedSubscription shim the shared render/expansion path consumes.
+// watchedFromLoopSubscription maps a loop.EntitySubscription onto the
+// WatchedSubscription shape the shared render/expansion path consumes. The two
+// types stay distinct by design (see renderLoopSubscription).
 func watchedFromLoopSubscription(sub looppkg.EntitySubscription) WatchedSubscription {
 	return WatchedSubscription{
 		EntityID: sub.EntityID,

--- a/internal/tools/archive_tools.go
+++ b/internal/tools/archive_tools.go
@@ -71,11 +71,24 @@ const archiveTranscriptByteCap = 32000
 // uses the same MemorySearcher, so the two retrieval paths can't
 // drift apart.
 func (r *Registry) SetArchiveStore(store *memory.ArchiveStore) {
-	searcher := memory.NewMemorySearch(store, r.workingMemoryStore, nil)
-	r.registerArchiveSearch(searcher)
+	r.archiveStore = store
+	r.composeArchiveSearch()
 	r.registerArchiveSessions(store)
 	r.registerArchiveSessionTranscript(store)
 	r.registerArchiveRange(store)
+}
+
+// composeArchiveSearch (re)registers archive_search from the currently wired
+// archive and working-memory stores. Both SetArchiveStore and
+// SetWorkingMemoryStore call it, so the unified searcher picks up whichever
+// store is set second — archive_search no longer silently drops the
+// working-memory surface when the two setters run out of order (#1096). It is
+// a no-op until the archive store is present.
+func (r *Registry) composeArchiveSearch() {
+	if r.archiveStore == nil {
+		return
+	}
+	r.registerArchiveSearch(memory.NewMemorySearch(r.archiveStore, r.workingMemoryStore, nil))
 }
 
 func (r *Registry) registerArchiveSearch(searcher memory.MemorySearcher) {

--- a/internal/tools/ha_entity_metadata.go
+++ b/internal/tools/ha_entity_metadata.go
@@ -3,8 +3,10 @@ package tools
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/nugget/thane-ai-agent/internal/integrations/homeassistant"
+	"github.com/nugget/thane-ai-agent/internal/model/promptfmt"
 )
 
 const maxHAListEntitiesLimit = 100
@@ -30,7 +32,25 @@ type haListEntityItem struct {
 	EntityID     string                        `json:"entity_id"`
 	FriendlyName string                        `json:"friendly_name,omitempty"`
 	State        string                        `json:"state"`
+	Since        string                        `json:"since,omitempty"`
+	Updated      string                        `json:"updated,omitempty"`
 	Metadata     *homeassistant.EntityMetadata `json:"metadata,omitempty"`
+}
+
+// haRecencyDelta returns the delta-formatted recency signals for an entity
+// state, mirroring the canonical entity contextfmt projection
+// (contextfmt/entity_format.go) so ha_search_states and ha_list_entities carry
+// the same "how fresh is this?" signal the always-on context does. since is the
+// time since the last state change; updated is set only when the last attribute
+// update meaningfully post-dates that change.
+func haRecencyDelta(s homeassistant.State, now time.Time) (since, updated string) {
+	if !s.LastChanged.IsZero() {
+		since = promptfmt.FormatDeltaOnly(s.LastChanged, now)
+	}
+	if !s.LastUpdated.IsZero() && s.LastUpdated.Sub(s.LastChanged) > time.Second {
+		updated = promptfmt.FormatDeltaOnly(s.LastUpdated, now)
+	}
+	return since, updated
 }
 
 // EntityMetadataIncludeParameter returns the shared JSON schema

--- a/internal/tools/ha_entity_metadata.go
+++ b/internal/tools/ha_entity_metadata.go
@@ -44,9 +44,14 @@ type haListEntityItem struct {
 // time since the last state change; updated is set only when the last attribute
 // update meaningfully post-dates that change.
 func haRecencyDelta(s homeassistant.State, now time.Time) (since, updated string) {
-	if !s.LastChanged.IsZero() {
-		since = promptfmt.FormatDeltaOnly(s.LastChanged, now)
+	// Without a last-changed timestamp there is no meaningful recency signal:
+	// return neither field rather than deriving a nonsense delta against the
+	// zero time — which would also let `updated` populate while `since` stays
+	// empty, since LastUpdated.Sub(zero) is an enormous duration.
+	if s.LastChanged.IsZero() {
+		return "", ""
 	}
+	since = promptfmt.FormatDeltaOnly(s.LastChanged, now)
 	if !s.LastUpdated.IsZero() && s.LastUpdated.Sub(s.LastChanged) > time.Second {
 		updated = promptfmt.FormatDeltaOnly(s.LastUpdated, now)
 	}

--- a/internal/tools/ha_entity_metadata_test.go
+++ b/internal/tools/ha_entity_metadata_test.go
@@ -86,11 +86,10 @@ func TestHAGetStateIncludesEntityMetadata(t *testing.T) {
 				NameByUser string `json:"name_by_user"`
 			} `json:"device"`
 			Visibility struct {
-				Enabled        bool   `json:"enabled"`
-				Visible        bool   `json:"visible"`
-				DefaultContext bool   `json:"default_context"`
-				ContextRole    string `json:"context_role"`
-				HiddenBy       string `json:"hidden_by"`
+				Enabled     bool   `json:"enabled"`
+				Visible     bool   `json:"visible"`
+				ContextRole string `json:"context_role"`
+				HiddenBy    string `json:"hidden_by"`
 			} `json:"visibility"`
 			TranslationKey string `json:"translation_key"`
 			HasEntityName  bool   `json:"has_entity_name"`
@@ -121,7 +120,6 @@ func TestHAGetStateIncludesEntityMetadata(t *testing.T) {
 	}
 	if !got.Metadata.Visibility.Enabled ||
 		got.Metadata.Visibility.Visible ||
-		got.Metadata.Visibility.DefaultContext ||
 		got.Metadata.Visibility.ContextRole != "hidden" ||
 		got.Metadata.Visibility.HiddenBy != "user" {
 		t.Errorf("visibility = %#v, want enabled hidden-by-user", got.Metadata.Visibility)

--- a/internal/tools/ha_recency_delta_test.go
+++ b/internal/tools/ha_recency_delta_test.go
@@ -1,0 +1,60 @@
+package tools
+
+import (
+	"testing"
+	"time"
+
+	"github.com/nugget/thane-ai-agent/internal/integrations/homeassistant"
+)
+
+// TestHARecencyDelta covers the since/updated consistency guaranteed by
+// haRecencyDelta, including the #1131 edge case where a zero LastChanged must
+// not let `updated` populate off a nonsense delta against the zero time.
+func TestHARecencyDelta(t *testing.T) {
+	now := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	changed := now.Add(-10 * time.Minute)
+
+	cases := []struct {
+		name        string
+		state       homeassistant.State
+		wantSince   bool
+		wantUpdated bool
+	}{
+		{
+			name:        "both set, updated equals changed",
+			state:       homeassistant.State{LastChanged: changed, LastUpdated: changed},
+			wantSince:   true,
+			wantUpdated: false,
+		},
+		{
+			name:        "updated meaningfully after changed",
+			state:       homeassistant.State{LastChanged: changed, LastUpdated: now.Add(-time.Minute)},
+			wantSince:   true,
+			wantUpdated: true,
+		},
+		{
+			name:        "last_changed zero but last_updated set yields neither",
+			state:       homeassistant.State{LastUpdated: now.Add(-time.Minute)},
+			wantSince:   false,
+			wantUpdated: false,
+		},
+		{
+			name:        "both zero yields neither",
+			state:       homeassistant.State{},
+			wantSince:   false,
+			wantUpdated: false,
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			since, updated := haRecencyDelta(tc.state, now)
+			if (since != "") != tc.wantSince {
+				t.Errorf("since = %q, want non-empty = %v", since, tc.wantSince)
+			}
+			if (updated != "") != tc.wantUpdated {
+				t.Errorf("updated = %q, want non-empty = %v", updated, tc.wantUpdated)
+			}
+		})
+	}
+}

--- a/internal/tools/ha_search_states.go
+++ b/internal/tools/ha_search_states.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/nugget/thane-ai-agent/internal/integrations/homeassistant"
 )
@@ -198,10 +199,12 @@ func (r *Registry) handleSearchStates(ctx context.Context, args map[string]any) 
 		}
 	}
 
+	now := time.Now()
 	items := make([]haListEntityItem, 0, len(candidates))
 	for i := range candidates {
 		s := candidates[i]
 		item := haListEntityItem{EntityID: s.EntityID, State: s.State}
+		item.Since, item.Updated = haRecencyDelta(s, now)
 		if friendly, ok := s.Attributes["friendly_name"].(string); ok {
 			item.FriendlyName = friendly
 		}

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -77,6 +77,7 @@ type Registry struct {
 	lensStore          *LensStore
 	logIndexDB         *sql.DB
 	workingMemoryStore *memory.WorkingMemoryStore
+	archiveStore       *memory.ArchiveStore
 
 	channelReactionHandlers map[string]ChannelReactionFunc
 

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -1343,6 +1343,7 @@ func (r *Registry) handleListEntities(ctx context.Context, args map[string]any) 
 	var matchEntityIDs []string
 	var matchStates []homeassistant.State
 	total := 0
+	now := time.Now()
 	prefix := ""
 	if domain != "" {
 		prefix = domain + "."
@@ -1364,6 +1365,7 @@ func (r *Registry) handleListEntities(ctx context.Context, args map[string]any) 
 			EntityID: s.EntityID,
 			State:    s.State,
 		}
+		item.Since, item.Updated = haRecencyDelta(s, now)
 		if friendly, ok := s.Attributes["friendly_name"].(string); ok {
 			item.FriendlyName = friendly
 		}

--- a/internal/tools/working_memory_tools.go
+++ b/internal/tools/working_memory_tools.go
@@ -12,9 +12,10 @@ import (
 // SetWorkingMemoryStore adds the session_working_memory tool to the
 // registry and stores a Registry-level reference so other tools
 // (notably archive_search) can search across working memory as part
-// of the unified multi-surface retrieval. Should be called before
-// SetArchiveStore so the latter sees the working memory store when
-// composing the MemorySearcher.
+// of the unified multi-surface retrieval. Order-independent with
+// SetArchiveStore: whichever runs second re-composes archive_search via
+// composeArchiveSearch, so the working-memory surface is never silently
+// dropped (#1096).
 //
 // This tool allows the agent to read and write free-form experiential
 // notes for the current conversation, capturing texture that mechanical
@@ -73,4 +74,7 @@ func (r *Registry) SetWorkingMemoryStore(store *memory.WorkingMemoryStore) {
 			}
 		},
 	})
+	// Re-compose archive_search so it includes the working-memory surface
+	// even when SetWorkingMemoryStore runs after SetArchiveStore.
+	r.composeArchiveSearch()
 }


### PR DESCRIPTION
Closes #1096.

The v0.10.0 pre-release audit deferred 13 structural/behavioral findings. An audit against current code confirmed **all 13 were still outstanding** (none had been picked up). This PR resolves every one, grouped into five commits by kind.

## Loop runtime
- [x] **LR1** — `IterationResult`/`IterationSnapshot.Supervisor`: reworded the false "backwards-compatible" doc to state the real reason (a convenience projection of `SupervisorTrigger != ""` for event/wire consumers). Kept the bool (it's on the JSON wire).
- [x] **LR2** — deleted the zero-caller `BuildLoopConfig` (ego/archivist/metacog) + `BuildSpec` (ego/archivist). Production registers via `DefinitionSpec` + `HydrateSpec` and applies `Profile` at request time, so the manual merge was a dead duplicate. Metacog tests re-pointed to the live `HydrateSpec(DefinitionSpec(...))` path.
- [x] **LR3** — deleted the zero-caller `WakeTagsFromContext` getter (the `withWakeTags` write path stays live).
- [x] **LR4** — `WatchedSubscription` isn't a migration-in-flight shim; it's the SQLite row type for the always-visible watchlist (carries `Scope`/`ExpiresAt`), deliberately distinct from `loop.EntitySubscription`. Reworded the comments to say so.

## Model-facing (HA)
- [x] **HA1** — `ha_search_states`/`ha_list_entities` now carry the recency delta (`since`/`updated`) via a shared `haRecencyDelta` helper mirroring the canonical `contextfmt` projection.
- [x] **HA2** — dropped `EntityVisibility.DefaultContext` (+ `entityDefaultContext`), a redundant parallel encoding of `ContextRole`. Tests derive the bool from `context_role`.
- [x] **HA3** — documented that `EntityAreaMetadata.Floor`/`Building` are mutually exclusive, gated by `homeassistant.floor_alias`.

## Code-path / API shape
- [x] **CP1** — made the working-memory search surface order-independent: `archive_search` re-composes from whichever of `SetArchiveStore`/`SetWorkingMemoryStore` runs second, instead of silently freezing a nil working store.
- [x] **CP2** — `forge.NewTools` takes a plain required `*SubscriptionStore` instead of a variadic that silently used only the first element.
- [x] **CP3** — dropped the ignored `history []memory.Message` param from the three `buildSystemPrompt*` builders + all call sites (history flows as role-native messages via `buildInitialLLMMessages`). Call sites rewritten with `gofmt -r`.
- [x] **CP4** — deleted the dead `CoreContextProvider.TagContext`/`TagContextBucket` (the provider is never registered; `promptSections` is called directly).
- [x] **CP5** — marked `toolcatalog` `Parents` as reserved: authored + invariant-checked, but no renderer consumes it yet (navigation flows through `NextTags`).

## Docs
- [x] **DOC1** — rewrote the Document Roots sections of `configuration.md` and `document-roots.md` to teach the unified `roots:` block (path + policy in one entry), with `paths:`/`doc_roots:` demoted to a deprecation note.

## Test plan
- [x] `just ci` green (exit 0, 0 architecture errors).
- [x] Dead-code deletions verified zero-caller before removal; coverage preserved by re-pointing tests to live paths.
- [x] `gofmt -r` call-site rewrites verified: agent package builds + tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)