### PR TITLE
docs(loops): drop the phantom overlay-supervisor gate from the spec schema

### DIFF
--- a/internal/tools/loop_spec_schema.go
+++ b/internal/tools/loop_spec_schema.go
@@ -45,7 +45,7 @@ func loopSpecSchema(description string) map[string]any {
 			"profile": loopProfileSchema("Routing and request-shaping for normal (non-supervisor) iterations."),
 			"supervisor": map[string]any{
 				"type":        "boolean",
-				"description": "Enable periodic supervisor turns: a per-wake Bernoulli trial promotes the iteration to a more capable, non-local model. Note: a model-authored (overlay) loop may be barred from self-enabling this; config-sourced loops set it freely.",
+				"description": "Enable periodic supervisor turns: a per-wake Bernoulli trial promotes the iteration to a more capable, non-local model.",
 			},
 			"supervisor_prob": map[string]any{
 				"type":        "number",


### PR DESCRIPTION
## What
Removes the misleading clause from the `supervisor` field description in the agent-facing loop spec schema (`loop_spec_schema.go`).

**Before:**
> Enable periodic supervisor turns: a per-wake Bernoulli trial promotes the iteration to a more capable, non-local model. *Note: a model-authored (overlay) loop may be barred from self-enabling this; config-sourced loops set it freely.*

**After:**
> Enable periodic supervisor turns: a per-wake Bernoulli trial promotes the iteration to a more capable, non-local model.

## Why
That "may be barred" note advertised the #1086 **Phase 2 frontier-spend governor** — a gate that would force `Supervisor=false` for overlay/model-authored specs. During the #1086 audit we confirmed the governor was never built, and #1086 has now been **closed with an explicit decision not to implement it**. So the note describes a gate that doesn't exist and never will: overlay loops enable `supervisor` freely today (via `loop_definition_set`/`loop_definition_update`), and that's the intended state.

A model-facing description that promises non-existent enforcement is worse than silence, so the note is removed. Swept the tree — this was the only place carrying the phantom promise (the other "overlay" mentions refer to the unrelated per-turn `SupervisorProfile` overlay).

## Test plan
- [x] `just ci` green (0 architecture errors); no test asserted on the removed text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)