### PR TITLE
fix(web): auto-update the loop graph on add/remove/reparent

### DIFF
--- a/internal/app/loop_runtime_setup.go
+++ b/internal/app/loop_runtime_setup.go
@@ -4,7 +4,9 @@ import (
 	"database/sql"
 	"fmt"
 	"log/slog"
+	"time"
 
+	"github.com/nugget/thane-ai-agent/internal/platform/events"
 	"github.com/nugget/thane-ai-agent/internal/platform/usage"
 	looppkg "github.com/nugget/thane-ai-agent/internal/runtime/loop"
 )
@@ -14,7 +16,28 @@ func (a *App) newLoopRegistry(logger *slog.Logger) *looppkg.Registry {
 	if a != nil && a.cfg != nil && a.cfg.Loops.MaxRunning > 0 {
 		registryOpts = append(registryOpts, looppkg.WithMaxLoops(a.cfg.Loops.MaxRunning))
 	}
+	if a != nil {
+		registryOpts = append(registryOpts, looppkg.WithRegistryChangeHook(a.publishLoopTopologyChange))
+	}
 	return looppkg.NewRegistry(registryOpts...)
+}
+
+// publishLoopTopologyChange emits a loop-topology event so live consumers
+// (the web console graph) re-sync when the graph's membership changes —
+// covering adds, removals, and reparents of any loop, including inert
+// container nodes that never emit a goroutine lifecycle event. a.eventBus is
+// read lazily (at loop register/deregister time, well after startup) so the
+// hook works regardless of construction order.
+func (a *App) publishLoopTopologyChange(loopID string) {
+	if a == nil || a.eventBus == nil {
+		return
+	}
+	a.eventBus.Publish(events.Event{
+		Timestamp: time.Now(),
+		Source:    events.SourceLoop,
+		Kind:      events.KindLoopTopology,
+		Data:      map[string]any{"loop_id": loopID},
+	})
 }
 
 func (a *App) initLoopUsageStores(db *sql.DB, logger *slog.Logger) error {

--- a/internal/platform/events/bus.go
+++ b/internal/platform/events/bus.go
@@ -96,6 +96,13 @@ const (
 	// KindLoopStopped signals a loop goroutine has stopped.
 	// Data: loop_id, loop_name, iterations, attempts.
 	KindLoopStopped = "loop_stopped"
+	// KindLoopTopology signals the loop graph's membership or parentage
+	// changed — a loop was added, removed, or reparented. Unlike the
+	// goroutine lifecycle events above, this fires for inert container
+	// nodes too (they never run a goroutine), giving live consumers a
+	// single reliable "the graph changed, re-sync it" signal.
+	// Data: loop_id.
+	KindLoopTopology = "loop_topology"
 	// KindLoopIterationStart signals the beginning of a loop iteration.
 	// Data: loop_id, loop_name, conversation_id, supervisor,
 	// supervisor_trigger, attempt, signal_envelopes.

--- a/internal/runtime/loop/registry.go
+++ b/internal/runtime/loop/registry.go
@@ -20,6 +20,13 @@ type Registry struct {
 	loops    map[string]*Loop
 	maxLoops int
 	logger   *slog.Logger
+	// onChange, when set, is invoked with the affected loop ID after a
+	// Register or Deregister actually mutates graph membership. It fires
+	// outside the lock so the callback (publishing a topology event) can't
+	// deadlock or stall registry operations. Every structural add/remove —
+	// including inert container nodes, which never run a goroutine — flows
+	// through here, so consumers get one reliable "the graph changed" signal.
+	onChange func(loopID string)
 }
 
 // RegistryOption configures a Registry.
@@ -39,6 +46,20 @@ func WithRegistryLogger(l *slog.Logger) RegistryOption {
 	return func(r *Registry) {
 		if l != nil {
 			r.logger = l
+		}
+	}
+}
+
+// WithRegistryChangeHook registers a callback invoked (outside the lock)
+// whenever a loop is added to or removed from the registry — the chokepoints
+// for adds, removals, and reparents (which relaunch through both). Used to
+// publish a topology-changed event so live consumers (the web console graph)
+// can re-sync, including for container nodes that emit no goroutine lifecycle
+// events. Nil is ignored.
+func WithRegistryChangeHook(fn func(loopID string)) RegistryOption {
+	return func(r *Registry) {
+		if fn != nil {
+			r.onChange = fn
 		}
 	}
 }
@@ -116,7 +137,15 @@ func (e *ContainerHasChildrenError) Error() string {
 // ID is already registered or the concurrency limit would be exceeded.
 // The loop is not started — call [Loop.Start] after registering.
 func (r *Registry) Register(l *Loop) error {
+	registered := false
 	r.mu.Lock()
+	// Registered first so it runs LAST (LIFO) — after the unlock below — so the
+	// topology hook fires without the registry lock held.
+	defer func() {
+		if registered && r.onChange != nil {
+			r.onChange(l.id)
+		}
+	}()
 	defer r.mu.Unlock()
 
 	if _, exists := r.loops[l.id]; exists {
@@ -179,6 +208,7 @@ func (r *Registry) Register(l *Loop) error {
 	}
 
 	r.loops[l.id] = l
+	registered = true
 	// Containers inherit nothing themselves (they exist precisely to
 	// provide tags to descendants). Wiring the function uniformly is
 	// still fine — the resolver simply returns nil for a container with
@@ -207,13 +237,22 @@ func (r *Registry) Register(l *Loop) error {
 // Deregister removes a loop from the registry. Safe to call for a loop
 // that is not registered (no-op).
 func (r *Registry) Deregister(id string) {
+	removed := false
 	r.mu.Lock()
+	// Fire the change hook after the unlock below (LIFO), and only when a loop
+	// was actually removed — a no-op Deregister must not emit a topology event.
+	defer func() {
+		if removed && r.onChange != nil {
+			r.onChange(id)
+		}
+	}()
 	defer r.mu.Unlock()
 
 	if _, exists := r.loops[id]; !exists {
 		return
 	}
 	delete(r.loops, id)
+	removed = true
 	r.logger.Debug("loop deregistered",
 		"loop_id", id,
 		"active_loops", len(r.loops),

--- a/internal/runtime/loop/registry_test.go
+++ b/internal/runtime/loop/registry_test.go
@@ -48,6 +48,34 @@ func TestRegistryRegisterDeregister(t *testing.T) {
 	r.Deregister("nonexistent")
 }
 
+func TestRegistryChangeHook(t *testing.T) {
+	t.Parallel()
+
+	// The hook fires synchronously inside Register/Deregister (in a deferred
+	// call after the lock releases), so plain appends are race-free here.
+	var changes []string
+	r := NewRegistry(WithRegistryChangeHook(func(id string) {
+		changes = append(changes, id)
+	}))
+	l := mustNew(t, Config{Name: "hooked", Task: "x"}, Deps{Runner: &noopRunner{}})
+
+	if err := r.Register(l); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	// A failed (duplicate) Register must not fire the hook.
+	if err := r.Register(l); err == nil {
+		t.Fatal("duplicate Register should fail")
+	}
+	// A no-op Deregister (unknown ID) must not fire the hook.
+	r.Deregister("does-not-exist")
+	// A real Deregister fires it.
+	r.Deregister(l.ID())
+
+	if want := []string{l.ID(), l.ID()}; !slices.Equal(changes, want) {
+		t.Fatalf("hook calls = %v, want [register, deregister] = %v", changes, want)
+	}
+}
+
 func TestRegistryConcurrencyLimit(t *testing.T) {
 	t.Parallel()
 

--- a/internal/server/web/static/data/loops.js
+++ b/internal/server/web/static/data/loops.js
@@ -111,6 +111,10 @@ export function ancestorPath(loops, anchorId) {
 
 const MAX_EVENTS = 50;
 const DELEGATE_LINGER_MS = 15000;
+// REFETCH_DEBOUNCE_MS coalesces a burst of change signals (topology events,
+// loop_started/stopped) into a single /v1/loops re-sync — a reconcile that
+// stops and restarts several loops would otherwise refetch once per event.
+const REFETCH_DEBOUNCE_MS = 200;
 
 export function createLoopStore({ client, events } = {}) {
   const loops = new Map();
@@ -119,6 +123,7 @@ export function createLoopStore({ client, events } = {}) {
   const eventLog = [];
   let connState = 'connecting';
   let unsubscribe = null;
+  let refetchTimer = null;
 
   const changeListeners = new Set();
   const lifecycle = new Map();
@@ -177,6 +182,16 @@ export function createLoopStore({ client, events } = {}) {
   function ingestLoopEvent(evt) {
     const loopId = evt.data && evt.data.loop_id;
     const loopName = evt.data && evt.data.loop_name;
+
+    // Topology events (a loop added/removed/reparented — containers included,
+    // which emit no goroutine lifecycle event) carry no per-loop state; just
+    // re-sync the graph from /v1/loops. Handled before pushEvent so these
+    // re-sync signals don't crowd the recent-events log.
+    if (evt.kind === 'loop_topology') {
+      scheduleRefetch();
+      return;
+    }
+
     pushEvent(evt);
 
     // loop_started needs a full re-fetch; bootstrap a minimal entry so events
@@ -188,7 +203,7 @@ export function createLoopStore({ client, events } = {}) {
           parent_id: evt.data.parent_id || null, iterations: 0, _iterStartTs: Date.now(),
         });
       }
-      void refetch();
+      scheduleRefetch();
       emitChange();
       return;
     }
@@ -214,6 +229,13 @@ export function createLoopStore({ client, events } = {}) {
     if (evt.kind === 'loop_error') {
       const message = (evt.data && evt.data.error) || loop.last_error || 'Loop iteration failed.';
       emit('loop_error', { loopId, loop, message });
+    }
+    // A stopped loop may have been removed from the registry (stop/reparent);
+    // re-sync so it drops from the graph rather than lingering as 'stopped'.
+    // (A stopped-but-still-registered loop is preserved — /v1/loops still
+    // reports it, so the refetch keeps it.)
+    if (evt.kind === 'loop_stopped') {
+      scheduleRefetch();
     }
     emitChange();
   }
@@ -295,6 +317,17 @@ export function createLoopStore({ client, events } = {}) {
     }
   }
 
+  // scheduleRefetch coalesces rapid change signals into one refetch (see
+  // REFETCH_DEBOUNCE_MS). Leading-edge guarded so a burst schedules exactly one
+  // trailing re-sync rather than resetting the timer indefinitely.
+  function scheduleRefetch() {
+    if (refetchTimer) return;
+    refetchTimer = setTimeout(() => {
+      refetchTimer = null;
+      void refetch();
+    }, REFETCH_DEBOUNCE_MS);
+  }
+
   return {
     // shared structures (view layers may reference these directly during the
     // graph migration; new consumers should prefer the accessors below)
@@ -341,6 +374,10 @@ export function createLoopStore({ client, events } = {}) {
       if (unsubscribe) {
         unsubscribe();
         unsubscribe = null;
+      }
+      if (refetchTimer) {
+        clearTimeout(refetchTimer);
+        refetchTimer = null;
       }
     },
 


### PR DESCRIPTION
## The bug

In production (v0.10.0-46-gc2b23ae7), reparenting, adding, or removing loops — especially **containers** — left the web console graph stale until a manual browser refresh.

## Root cause

The console only learned about the loop graph through loop-*goroutine* lifecycle events (`loop_started`/`loop_stopped`), which miss exactly these mutations:

1. **Containers are inert.** `loop.go` skips the goroutine for a container (`Operation == OperationContainer`), so a container never emits `loop_started`/`loop_stopped`. Creating, reparenting, or deleting one is invisible.
2. **The client only re-synced on `loop_started`.** `data/loops.js` calls `refetch()` (re-pull `/v1/loops`, drop missing loops) *only* on `loop_started` — so a removal never triggered a re-sync.
3. **`Registry.Register`/`Deregister` — the actual add/remove chokepoints — published nothing.**

The graph itself already re-flows on every store change (`app.js` `store.subscribe(renderAll)`); the gap was purely that these mutations produced no signal the store reacted to.

## Fix (event-driven)

- **Registry change hook** — `WithRegistryChangeHook` fires (outside the lock) on every `Register`/`Deregister`. Those are the chokepoints for adds, removals, and reparents (which relaunch through both), for **all** loops including inert containers.
- **App publishes a `KindLoopTopology` event** on the existing events bus, which the `/v1/loops/events` SSE forwards as a `"loop"` event (no server-handler change — it rides the existing channel).
- **Client re-syncs** `/v1/loops` on `loop_topology` (and on `loop_stopped`), coalescing bursts through a 200ms debounced `scheduleRefetch` so a reconcile that stops/starts several loops refetches once.

## Verification

- `TestRegistryChangeHook` — hook fires on Register + Deregister, not on a failed/no-op call.
- Live-verified in the UI harness (imported `data/loops.js` with a mock client):
  - a removed loop drops from the store on a `loop_topology` event without a refresh (2 → 1, `stillHasY: false`);
  - a topology **burst** coalesces into exactly **one** `/loops` refetch;
  - `loop_stopped` also schedules a refetch;
  - graph renders cleanly (8 nodes, no console errors) with the edited data layer.
- `just ci` green (0 architecture errors).

## Note
The client (`internal/server/web/static/*.js`) isn't covered by CI (Go-only), so the client path was verified live rather than by unit test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)