### PR TITLE
feat(config): operator allowed signers — schema + fail-closed validation (#1135 PR-1)

### DIFF
--- a/examples/config.example.yaml
+++ b/examples/config.example.yaml
@@ -245,6 +245,13 @@ roots:
       # SigningKey is the SSH private key used to sign managed commits.
       # Supports ~ expansion at startup.
       signing_key: ""
+      # AllowedSigners lists operator SSH public keys trusted to sign
+      # commits in this root, in addition to the shared
+      # signing.allowed_signers set and the agent's own (always-trusted,
+      # unremovable) key. This only extends the trust set for one root; it
+      # never replaces or removes from it. Use it to let an operator
+      # co-author a signed root.
+      allowed_signers: []
   kb:
     # Path is the directory the root resolves to. Supports ~
     # expansion at resolver construction time. For the reserved
@@ -278,6 +285,32 @@ roots:
       # SigningKey is the SSH private key used to sign managed commits.
       # Supports ~ expansion at startup.
       signing_key: ~/.ssh/id_ed25519
+      # AllowedSigners lists operator SSH public keys trusted to sign
+      # commits in this root, in addition to the shared
+      # signing.allowed_signers set and the agent's own (always-trusted,
+      # unremovable) key. This only extends the trust set for one root; it
+      # never replaces or removes from it. Use it to let an operator
+      # co-author a signed root.
+      allowed_signers:
+        - # Principal is the OpenSSH signer identity, conventionally an email
+          # such as "alice@example.com". Required. It must not contain
+          # whitespace or control characters — the allowed_signers format is
+          # space-delimited, so either would corrupt the line or smuggle a
+          # second entry.
+          principal: bob@example.com
+          # Key is the SSH public key in authorized_keys form, such as
+          # "ssh-ed25519 AAAA...". Required. It must parse as a valid public
+          # key.
+          key: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIO+3xdUdsJA9XoATiuDErHwn2cDSIO1U1/t+BuN6P3Gv
+          # Label is an optional human note rendered as the key's trailing
+          # comment. It must not contain control characters.
+          label: Bob (kb co-author)
+          # ValidAfter and ValidBefore optionally bound when the key is trusted.
+          # Each is an RFC3339 timestamp; when both are set, ValidAfter must be
+          # strictly before ValidBefore. Enforcement is delegated to OpenSSH at
+          # verify time; thane does not yet surface expiry.
+          valid_after: ""
+          valid_before: ""
   scratchpad:
     # Path is the directory the root resolves to. Supports ~
     # expansion at resolver construction time. For the reserved
@@ -311,6 +344,13 @@ roots:
       # SigningKey is the SSH private key used to sign managed commits.
       # Supports ~ expansion at startup.
       signing_key: ""
+      # AllowedSigners lists operator SSH public keys trusted to sign
+      # commits in this root, in addition to the shared
+      # signing.allowed_signers set and the agent's own (always-trusted,
+      # unremovable) key. This only extends the trust set for one root; it
+      # never replaces or removes from it. Use it to let an operator
+      # co-author a signed root.
+      allowed_signers: []
 #
 # (optional) Paths is the legacy directory-mapping block. Replaced by roots:.
 # paths: {}
@@ -806,6 +846,34 @@ talents_dir: ./talents
 #   commits. The key is loaded at startup and held in memory.
 #   Supports ~ expansion. Example: ~/.ssh/id_ed25519
 #   signing_key: ~/.ssh/id_ed25519
+#
+# (optional) Signing declares the operator-managed set of SSH public keys trusted
+# signing:
+#   AllowedSigners lists SSH public keys trusted to sign commits across
+#   all signing roots. Each entry is an operator identity; a root may
+#   add more via its git.allowed_signers. The agent's own key is
+#   implicit and unremovable, so this list never needs — and must not
+#   include — it.
+#   allowed_signers:
+#     - # Principal is the OpenSSH signer identity, conventionally an email
+#       such as "alice@example.com". Required. It must not contain
+#       whitespace or control characters — the allowed_signers format is
+#       space-delimited, so either would corrupt the line or smuggle a
+#       second entry.
+#       principal: alice@example.com
+#       Key is the SSH public key in authorized_keys form, such as
+#       "ssh-ed25519 AAAA...". Required. It must parse as a valid public
+#       key.
+#       key: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGyUStZXWURqF4b7IWfSTz2W6zYz5JnXrKbcuPfGAmUo
+#       Label is an optional human note rendered as the key's trailing
+#       comment. It must not contain control characters.
+#       label: Alice laptop
+#       ValidAfter and ValidBefore optionally bound when the key is trusted.
+#       Each is an RFC3339 timestamp; when both are set, ValidAfter must be
+#       strictly before ValidBefore. Enforcement is delegated to OpenSSH at
+#       verify time; thane does not yet surface expiry.
+#       valid_after: ""
+#       valid_before: ""
 #
 # (optional) StateWindow configures the rolling window of recent Home Assistant
 # state_window:

--- a/internal/platform/config/config.go
+++ b/internal/platform/config/config.go
@@ -2823,11 +2823,13 @@ func validateAllowedSigners(label string, list []AllowedSigner) error {
 // with whitespace would corrupt the line, and a newline anywhere would
 // smuggle an entire extra trusted key.
 func validateAllowedSigner(label string, s AllowedSigner) error {
-	principal := strings.TrimSpace(s.Principal)
-	if principal == "" {
+	if strings.TrimSpace(s.Principal) == "" {
 		return fmt.Errorf("%s.principal is required", label)
 	}
-	if strings.IndexFunc(principal, func(r rune) bool { return unicode.IsSpace(r) || unicode.IsControl(r) }) >= 0 {
+	// Check the raw principal, not a trimmed copy: leading or trailing
+	// whitespace (a trailing newline especially) must be rejected, not
+	// silently normalized away, since allowed_signers is space-delimited.
+	if strings.IndexFunc(s.Principal, func(r rune) bool { return unicode.IsSpace(r) || unicode.IsControl(r) }) >= 0 {
 		return fmt.Errorf("%s.principal %q must not contain whitespace or control characters", label, s.Principal)
 	}
 	if strings.TrimSpace(s.Key) == "" {
@@ -2871,10 +2873,18 @@ func parseAllowedSignerTime(label, field, value string) (*time.Time, error) {
 // canonicalAllowedSignerKey parses an authorized_keys-form public key and
 // returns its canonical "<type> <base64>" form with the comment stripped, so
 // keys that differ only by comment or surrounding whitespace compare equal.
+//
+// It rejects any value carrying more than one key: ssh.ParseAuthorizedKey
+// parses only the first line and returns the remainder in rest, so a value
+// with an embedded newline and a second key would otherwise be silently
+// accepted — exactly the injection the fail-closed rules exist to stop.
 func canonicalAllowedSignerKey(key string) (string, error) {
-	pub, _, _, _, err := ssh.ParseAuthorizedKey([]byte(key))
+	pub, _, _, rest, err := ssh.ParseAuthorizedKey([]byte(key))
 	if err != nil {
 		return "", fmt.Errorf("not a valid SSH public key: %w", err)
+	}
+	if strings.TrimSpace(string(rest)) != "" {
+		return "", fmt.Errorf("value must contain exactly one SSH public key")
 	}
 	return strings.TrimSpace(string(ssh.MarshalAuthorizedKey(pub))), nil
 }

--- a/internal/platform/config/config.go
+++ b/internal/platform/config/config.go
@@ -34,6 +34,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode"
 
 	"github.com/nugget/thane-ai-agent/internal/channels/email"
 	"github.com/nugget/thane-ai-agent/internal/channels/messages"
@@ -43,6 +44,7 @@ import (
 	"github.com/nugget/thane-ai-agent/internal/model/router"
 	"github.com/nugget/thane-ai-agent/internal/model/toolcatalog"
 	looppkg "github.com/nugget/thane-ai-agent/internal/runtime/loop"
+	"golang.org/x/crypto/ssh"
 	"gopkg.in/yaml.v3"
 )
 
@@ -295,6 +297,15 @@ type Config struct {
 	// layouts read always-on identity documents directly from
 	// {workspace.path}/core rather than from this store.
 	Provenance ProvenanceConfig `yaml:"provenance"`
+
+	// Signing declares the operator-managed set of SSH public keys trusted
+	// to sign commits in git-backed document roots, in addition to the
+	// agent's own generated signing key (which is always trusted and can
+	// never be removed). These shared keys apply to every signing root; a
+	// root may extend the set with its own git.allowed_signers. Keys live
+	// only here in config and are never reachable by a model loop. This is
+	// the trust gate that lets an operator co-author a signed root.
+	Signing SigningConfig `yaml:"signing"`
 
 	// StateWindow configures the rolling window of recent Home Assistant
 	// state changes injected into the agent's system prompt on every run.
@@ -815,6 +826,48 @@ func (c ProvenanceConfig) Configured() bool {
 	return c.Path != "" && c.SigningKey != ""
 }
 
+// SigningConfig declares the operator-managed set of trusted signing keys
+// for git-backed document roots. These keys are unioned with the agent's
+// own signing key — which is always trusted and can never be removed — to
+// form the trust set that signature verification checks against. Keys are
+// operator-only: they live in config and are never exposed to a model.
+type SigningConfig struct {
+	// AllowedSigners lists SSH public keys trusted to sign commits across
+	// all signing roots. Each entry is an operator identity; a root may
+	// add more via its git.allowed_signers. The agent's own key is
+	// implicit and unremovable, so this list never needs — and must not
+	// include — it.
+	AllowedSigners []AllowedSigner `yaml:"allowed_signers,omitempty"`
+}
+
+// AllowedSigner is one trusted signing identity: an SSH public key bound to
+// a principal, with an optional label and validity window. It renders to
+// one line of an OpenSSH allowed_signers file at startup.
+type AllowedSigner struct {
+	// Principal is the OpenSSH signer identity, conventionally an email
+	// such as "alice@example.com". Required. It must not contain
+	// whitespace or control characters — the allowed_signers format is
+	// space-delimited, so either would corrupt the line or smuggle a
+	// second entry.
+	Principal string `yaml:"principal"`
+
+	// Key is the SSH public key in authorized_keys form, such as
+	// "ssh-ed25519 AAAA...". Required. It must parse as a valid public
+	// key.
+	Key string `yaml:"key"`
+
+	// Label is an optional human note rendered as the key's trailing
+	// comment. It must not contain control characters.
+	Label string `yaml:"label,omitempty"`
+
+	// ValidAfter and ValidBefore optionally bound when the key is trusted.
+	// Each is an RFC3339 timestamp; when both are set, ValidAfter must be
+	// strictly before ValidBefore. Enforcement is delegated to OpenSSH at
+	// verify time; thane does not yet surface expiry.
+	ValidAfter  string `yaml:"valid_after,omitempty"`
+	ValidBefore string `yaml:"valid_before,omitempty"`
+}
+
 // RootEntry combines a managed root's path with its per-root policy
 // in the unified roots: block. Accepts either a bare-string shorthand
 // (the entire entry is the path, all policy fields default) or a
@@ -915,6 +968,14 @@ type DocumentRootGitConfig struct {
 	// SigningKey is the SSH private key used to sign managed commits.
 	// Supports ~ expansion at startup.
 	SigningKey string `yaml:"signing_key,omitempty"`
+
+	// AllowedSigners lists operator SSH public keys trusted to sign
+	// commits in this root, in addition to the shared
+	// signing.allowed_signers set and the agent's own (always-trusted,
+	// unremovable) key. This only extends the trust set for one root; it
+	// never replaces or removes from it. Use it to let an operator
+	// co-author a signed root.
+	AllowedSigners []AllowedSigner `yaml:"allowed_signers,omitempty"`
 }
 
 // HomeAssistantConfig configures the connection to a Home Assistant
@@ -2154,7 +2215,7 @@ func entryHasPolicy(entry RootEntry) bool {
 	}
 	g := entry.Git
 	return g.Enabled || g.SignCommits || g.VerifySignatures != "" ||
-		g.RepoPath != "" || g.SigningKey != ""
+		g.RepoPath != "" || g.SigningKey != "" || len(g.AllowedSigners) > 0
 }
 
 // applyServiceLoopDefaults fills the unset fields of one core service-loop
@@ -2633,6 +2694,9 @@ func (c *Config) Validate() error {
 	if err := c.validateDocRoots(); err != nil {
 		return err
 	}
+	if err := c.validateSigning(); err != nil {
+		return err
+	}
 	if err := c.validateMetacognitive(); err != nil {
 		return err
 	}
@@ -2715,8 +2779,104 @@ func (c *Config) validateDocRoots() error {
 		if git.Enabled && git.SignCommits && strings.TrimSpace(git.SigningKey) == "" {
 			return fmt.Errorf("doc_roots.%s.git.signing_key is required when sign_commits is true", root)
 		}
+		if err := validateAllowedSigners(fmt.Sprintf("doc_roots.%s.git.allowed_signers", root), git.AllowedSigners); err != nil {
+			return err
+		}
 	}
 	return nil
+}
+
+// validateSigning checks the shared operator allowed-signers block.
+func (c *Config) validateSigning() error {
+	return validateAllowedSigners("signing.allowed_signers", c.Signing.AllowedSigners)
+}
+
+// validateAllowedSigners validates a list of trusted signing keys, prefixing
+// errors with label (e.g. "signing.allowed_signers" or
+// "doc_roots.kb.git.allowed_signers"). It is fail-closed: a single malformed
+// entry rejects the whole config rather than being silently dropped, because
+// silently shrinking a trust set is worse than refusing to boot. It also
+// rejects the same public key appearing twice in one list — redundant at
+// best, a principal-spoofing typo at worst.
+func validateAllowedSigners(label string, list []AllowedSigner) error {
+	seen := make(map[string]string, len(list))
+	for i, s := range list {
+		entry := fmt.Sprintf("%s[%d]", label, i)
+		if err := validateAllowedSigner(entry, s); err != nil {
+			return err
+		}
+		blob, err := canonicalAllowedSignerKey(s.Key)
+		if err != nil {
+			return fmt.Errorf("%s.key: %w", entry, err)
+		}
+		if prev, ok := seen[blob]; ok {
+			return fmt.Errorf("%s.key duplicates the key already declared for principal %q", entry, prev)
+		}
+		seen[blob] = strings.TrimSpace(s.Principal)
+	}
+	return nil
+}
+
+// validateAllowedSigner validates one trusted signing identity. Every field
+// that renders into the space-delimited OpenSSH allowed_signers line is
+// checked for the injection vectors that format is prone to: a principal
+// with whitespace would corrupt the line, and a newline anywhere would
+// smuggle an entire extra trusted key.
+func validateAllowedSigner(label string, s AllowedSigner) error {
+	principal := strings.TrimSpace(s.Principal)
+	if principal == "" {
+		return fmt.Errorf("%s.principal is required", label)
+	}
+	if strings.IndexFunc(principal, func(r rune) bool { return unicode.IsSpace(r) || unicode.IsControl(r) }) >= 0 {
+		return fmt.Errorf("%s.principal %q must not contain whitespace or control characters", label, s.Principal)
+	}
+	if strings.TrimSpace(s.Key) == "" {
+		return fmt.Errorf("%s.key is required", label)
+	}
+	if _, err := canonicalAllowedSignerKey(s.Key); err != nil {
+		return fmt.Errorf("%s.key: %w", label, err)
+	}
+	if strings.IndexFunc(s.Label, unicode.IsControl) >= 0 {
+		return fmt.Errorf("%s.label must not contain control characters", label)
+	}
+	after, err := parseAllowedSignerTime(label, "valid_after", s.ValidAfter)
+	if err != nil {
+		return err
+	}
+	before, err := parseAllowedSignerTime(label, "valid_before", s.ValidBefore)
+	if err != nil {
+		return err
+	}
+	if after != nil && before != nil && !after.Before(*before) {
+		return fmt.Errorf("%s.valid_after must be strictly before valid_before", label)
+	}
+	return nil
+}
+
+// parseAllowedSignerTime parses an optional RFC3339 validity bound. Operators
+// author windows in RFC3339; conversion to the OpenSSH allowed_signers time
+// format happens at render time.
+func parseAllowedSignerTime(label, field, value string) (*time.Time, error) {
+	v := strings.TrimSpace(value)
+	if v == "" {
+		return nil, nil
+	}
+	t, err := time.Parse(time.RFC3339, v)
+	if err != nil {
+		return nil, fmt.Errorf("%s.%s %q must be an RFC3339 timestamp: %w", label, field, value, err)
+	}
+	return &t, nil
+}
+
+// canonicalAllowedSignerKey parses an authorized_keys-form public key and
+// returns its canonical "<type> <base64>" form with the comment stripped, so
+// keys that differ only by comment or surrounding whitespace compare equal.
+func canonicalAllowedSignerKey(key string) (string, error) {
+	pub, _, _, _, err := ssh.ParseAuthorizedKey([]byte(key))
+	if err != nil {
+		return "", fmt.Errorf("not a valid SSH public key: %w", err)
+	}
+	return strings.TrimSpace(string(ssh.MarshalAuthorizedKey(pub))), nil
 }
 
 // validateServiceLoop checks one core service-loop config for internal

--- a/internal/platform/config/example.go
+++ b/internal/platform/config/example.go
@@ -119,6 +119,11 @@ func ExampleConfig() *Config {
 					SignCommits:      true,
 					VerifySignatures: "warn",
 					SigningKey:       "~/.ssh/id_ed25519",
+					AllowedSigners: []AllowedSigner{{
+						Principal: "bob@example.com",
+						Key:       "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIO+3xdUdsJA9XoATiuDErHwn2cDSIO1U1/t+BuN6P3Gv",
+						Label:     "Bob (kb co-author)",
+					}},
 				},
 			},
 			"scratchpad": {
@@ -265,6 +270,14 @@ func ExampleConfig() *Config {
 		Provenance: ProvenanceConfig{
 			Path:       "~/Thane/core",
 			SigningKey: "~/.ssh/id_ed25519",
+		},
+
+		Signing: SigningConfig{
+			AllowedSigners: []AllowedSigner{{
+				Principal: "alice@example.com",
+				Key:       "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGyUStZXWURqF4b7IWfSTz2W6zYz5JnXrKbcuPfGAmUo",
+				Label:     "Alice laptop",
+			}},
 		},
 
 		Loops: LoopsConfig{

--- a/internal/platform/config/gen/gencfg/main.go
+++ b/internal/platform/config/gen/gencfg/main.go
@@ -46,6 +46,7 @@ var optionalKeys = map[string]bool{
 	"identity":        true,
 	"attachments":     true,
 	"provenance":      true,
+	"signing":         true,
 	"forge":           true,
 	"email":           true,
 	"archive":         true,

--- a/internal/platform/config/signing_test.go
+++ b/internal/platform/config/signing_test.go
@@ -51,9 +51,19 @@ func TestValidateAllowedSigners(t *testing.T) {
 			want:    "whitespace or control",
 		},
 		{
+			name:    "principal with surrounding whitespace is rejected, not trimmed",
+			signers: []AllowedSigner{{Principal: "  alice@example.com\n", Key: testSignerKeyAlice}},
+			want:    "whitespace or control",
+		},
+		{
 			name:    "missing key",
 			signers: []AllowedSigner{{Principal: "alice@example.com"}},
 			want:    "key is required",
+		},
+		{
+			name:    "key smuggling a second key via embedded newline",
+			signers: []AllowedSigner{{Principal: "alice@example.com", Key: testSignerKeyAlice + "\n" + testSignerKeyBob}},
+			want:    "exactly one SSH public key",
 		},
 		{
 			name:    "malformed key",

--- a/internal/platform/config/signing_test.go
+++ b/internal/platform/config/signing_test.go
@@ -1,0 +1,164 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// Two distinct, valid ed25519 public keys (throwaway pairs generated for
+// tests). Comment-free so tests can append their own comments to probe
+// canonicalization.
+const (
+	testSignerKeyAlice = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGyUStZXWURqF4b7IWfSTz2W6zYz5JnXrKbcuPfGAmUo"
+	testSignerKeyBob   = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIO+3xdUdsJA9XoATiuDErHwn2cDSIO1U1/t+BuN6P3Gv"
+)
+
+func TestValidateAllowedSigners(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name    string
+		signers []AllowedSigner
+		want    string // substring of expected error; "" means the entry is valid
+	}{
+		{
+			name:    "valid minimal",
+			signers: []AllowedSigner{{Principal: "alice@example.com", Key: testSignerKeyAlice}},
+		},
+		{
+			name: "valid with label and window",
+			signers: []AllowedSigner{{
+				Principal:   "alice@example.com",
+				Key:         testSignerKeyAlice,
+				Label:       "Alice laptop",
+				ValidAfter:  "2026-01-01T00:00:00Z",
+				ValidBefore: "2027-01-01T00:00:00Z",
+			}},
+		},
+		{
+			name:    "missing principal",
+			signers: []AllowedSigner{{Key: testSignerKeyAlice}},
+			want:    "principal is required",
+		},
+		{
+			name:    "principal with space",
+			signers: []AllowedSigner{{Principal: "alice example", Key: testSignerKeyAlice}},
+			want:    "whitespace or control",
+		},
+		{
+			name:    "principal with embedded newline",
+			signers: []AllowedSigner{{Principal: "alice\n@example.com", Key: testSignerKeyAlice}},
+			want:    "whitespace or control",
+		},
+		{
+			name:    "missing key",
+			signers: []AllowedSigner{{Principal: "alice@example.com"}},
+			want:    "key is required",
+		},
+		{
+			name:    "malformed key",
+			signers: []AllowedSigner{{Principal: "alice@example.com", Key: "definitely-not-a-key"}},
+			want:    "valid SSH public key",
+		},
+		{
+			name:    "label with control character",
+			signers: []AllowedSigner{{Principal: "alice@example.com", Key: testSignerKeyAlice, Label: "bad\x07label"}},
+			want:    "label must not contain control",
+		},
+		{
+			name:    "unparseable valid_after",
+			signers: []AllowedSigner{{Principal: "alice@example.com", Key: testSignerKeyAlice, ValidAfter: "yesterday"}},
+			want:    "valid_after",
+		},
+		{
+			name: "inverted validity window",
+			signers: []AllowedSigner{{
+				Principal:   "alice@example.com",
+				Key:         testSignerKeyAlice,
+				ValidAfter:  "2027-01-01T00:00:00Z",
+				ValidBefore: "2026-01-01T00:00:00Z",
+			}},
+			want: "strictly before",
+		},
+		{
+			name: "duplicate key blob under different principals",
+			signers: []AllowedSigner{
+				{Principal: "alice@example.com", Key: testSignerKeyAlice},
+				{Principal: "eve@example.com", Key: testSignerKeyAlice},
+			},
+			want: "duplicates the key",
+		},
+		{
+			name: "same key differing only by comment is still a duplicate",
+			signers: []AllowedSigner{
+				{Principal: "alice@example.com", Key: testSignerKeyAlice + " comment-a"},
+				{Principal: "alice2@example.com", Key: testSignerKeyAlice + " comment-b"},
+			},
+			want: "duplicates the key",
+		},
+		{
+			name: "two distinct keys are fine",
+			signers: []AllowedSigner{
+				{Principal: "alice@example.com", Key: testSignerKeyAlice},
+				{Principal: "bob@example.com", Key: testSignerKeyBob},
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			err := validateAllowedSigners("signing.allowed_signers", tc.signers)
+			if tc.want == "" {
+				if err != nil {
+					t.Fatalf("validateAllowedSigners() = %v, want nil", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("validateAllowedSigners() = nil, want error containing %q", tc.want)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("validateAllowedSigners() = %v, want containing %q", err, tc.want)
+			}
+		})
+	}
+}
+
+// TestValidate_SigningBlockWired confirms the shared signing.allowed_signers
+// block is reached by Config.Validate and labels errors with its path.
+func TestValidate_SigningBlockWired(t *testing.T) {
+	t.Parallel()
+	cfg := Default()
+	cfg.Signing = SigningConfig{AllowedSigners: []AllowedSigner{{Principal: "alice example", Key: testSignerKeyAlice}}}
+	err := cfg.Validate()
+	if err == nil || !strings.Contains(err.Error(), "signing.allowed_signers[0].principal") {
+		t.Fatalf("Validate() = %v, want signing.allowed_signers[0].principal error", err)
+	}
+}
+
+// TestValidate_PerRootAllowedSignersWired confirms per-root
+// git.allowed_signers is reached by Config.Validate through validateDocRoots.
+func TestValidate_PerRootAllowedSignersWired(t *testing.T) {
+	t.Parallel()
+	cfg := Default()
+	cfg.DocRoots = map[string]DocumentRootConfig{
+		"kb": {Git: DocumentRootGitConfig{AllowedSigners: []AllowedSigner{{Principal: "bob@example.com", Key: "not-a-key"}}}},
+	}
+	err := cfg.Validate()
+	if err == nil || !strings.Contains(err.Error(), "doc_roots.kb.git.allowed_signers[0].key") {
+		t.Fatalf("Validate() = %v, want doc_roots.kb.git.allowed_signers[0].key error", err)
+	}
+}
+
+// TestValidate_ValidAllowedSignersPass confirms a well-formed shared block and
+// per-root block validate cleanly end-to-end.
+func TestValidate_ValidAllowedSignersPass(t *testing.T) {
+	t.Parallel()
+	cfg := Default()
+	cfg.Signing = SigningConfig{AllowedSigners: []AllowedSigner{{Principal: "alice@example.com", Key: testSignerKeyAlice, Label: "Alice laptop"}}}
+	cfg.DocRoots = map[string]DocumentRootConfig{
+		"kb": {Git: DocumentRootGitConfig{AllowedSigners: []AllowedSigner{{Principal: "bob@example.com", Key: testSignerKeyBob}}}},
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("Validate() = %v, want nil", err)
+	}
+}

--- a/scripts/architecture.baseline
+++ b/scripts/architecture.baseline
@@ -1,5 +1,5 @@
 packages=62
 interfaces=80
-large_files=48
+large_files=49
 set_mutators=111
 database_opens=9


### PR DESCRIPTION
## What

This is **PR-1 of the #1135 stack** — the pure config surface for operator-managed allowed signers, with no rendering yet. It gives operators a place to declare the SSH public keys they trust to sign commits in a git-backed document root, and it validates those declarations fail-closed. Nothing here touches `.allowed_signers` on disk or changes verification behavior; that lands in the follow-up render PR.

## The shape

Trust comes from config, in two composing places. A shared `signing.allowed_signers` block covers the common "these are my keys" case across every signing root, and a per-root `git.allowed_signers` list *extends* it for a root that needs an extra principal. Both are additive — nothing here removes from the set — and both are unioned (at render time, a later PR) with the agent's own key, which is always trusted and can never be removed.

```yaml
signing:
  allowed_signers:
    - principal: alice@example.com
      key: "ssh-ed25519 AAAA..."
      label: "Alice laptop"

roots:
  kb:
    git:
      enabled: true
      sign_commits: true
      signing_key: ~/.ssh/id_ed25519
      allowed_signers:
        - { principal: bob@example.com, key: "ssh-ed25519 AAAA..." }
```

## Why validation is fail-closed

A trust surface that fails *open* is worse than one that refuses to start, so a single malformed entry rejects the whole config rather than being silently dropped — silently shrinking a trust set is exactly the kind of quiet weakening this feature exists to prevent. Concretely, each entry is checked for the injection vectors the space-delimited OpenSSH `allowed_signers` format is prone to: a principal with whitespace would corrupt the line and a newline anywhere would smuggle an entire extra trusted key, so principals reject whitespace and control characters and labels reject control characters. Keys must parse as real SSH public keys, validity windows must be RFC3339 with `valid_after` strictly before `valid_before`, and the same public-key blob appearing twice in one list is rejected regardless of principal (a duplicate is redundant at best and a principal-spoof typo at worst), compared by canonical blob so comment or whitespace noise doesn't hide a match.

Two checks named in the issue live where their runtime inputs actually exist, not in static config validation: the **reserved-agent-blob** check (an operator entry equal to the agent's own key) needs the agent's public key, which is loaded at startup, so it belongs in the render step; and the **config-isolation invariant** (no root path overlaps `config.yaml`) needs resolved paths, so it belongs in the startup/app wiring. Both are called out in #1137 and will land with the render PR and app wiring respectively.

## Changes

- `SigningConfig` + `AllowedSigner` types and a top-level `signing:` block on `Config`; an additive `AllowedSigners` field on `DocumentRootGitConfig` (shared by both root config forms).
- `validateAllowedSigners` / `validateAllowedSigner`, wired into `Config.Validate` for the shared block and into `validateDocRoots` for the per-root lists.
- `entryHasPolicy` now counts a root that declares only `allowed_signers` as having policy, so it desugars correctly.
- Regenerated `examples/config.example.yaml` (the `signing:` block is emitted commented-out as an optional section) and added `signing` to the generator's optional-keys set.
- Table-driven tests covering valid entries and every rejection path.

## Test plan

- [x] `go test ./internal/platform/config/...` — new `signing_test.go` cases pass
- [x] `just ci` passes locally (fmt, mod-tidy, config-generate-check, architecture-check, lint, lint-openapi, test)
- [x] `examples/config.example.yaml` regenerated and committed (config-generate-check clean)

Refs #1135
