### PR TITLE
feat(provenance): render + reconcile document-root allowed_signers (#1135 PR-2)

### DIFF
--- a/internal/app/document_roots.go
+++ b/internal/app/document_roots.go
@@ -302,6 +302,15 @@ func (a *App) newDocumentRootProvenanceWriter(root, rootPath string, gitCfg conf
 		return nil, fmt.Errorf("doc_roots.%s bootstrap birth commit: %w", root, err)
 	}
 
+	// Render the repo's .allowed_signers as the union of the agent key and
+	// the operator keys the operator declared (shared plus this root's own),
+	// committing an update only when the set changed. This is what makes an
+	// operator's key trusted so they can co-author a signed root.
+	operators := buildTrustedSigners(a.cfg.Signing.AllowedSigners, gitCfg.AllowedSigners)
+	if _, err := store.ReconcileAllowedSigners(bootstrapCtx, operators); err != nil {
+		return nil, fmt.Errorf("doc_roots.%s reconcile allowed_signers: %w", root, err)
+	}
+
 	logger.Info("document root provenance enabled",
 		"root", root,
 		"repo", store.Path(),
@@ -342,6 +351,26 @@ func (a *App) newDocumentRootProvenanceVerifier(root, rootPath string, gitCfg co
 		return nil, fmt.Errorf("initialize git verifier for document root %s: %w", root, err)
 	}
 	return &documentRootProvenanceVerifier{verifier: verifier, prefix: prefix}, nil
+}
+
+// buildTrustedSigners flattens the shared and per-root operator allowed-signer
+// config into provenance.TrustedSigner values for rendering. Order does not
+// matter — the renderer canonicalizes, deduplicates, and sorts — so the two
+// lists are simply concatenated (shared first).
+func buildTrustedSigners(shared, perRoot []config.AllowedSigner) []provenance.TrustedSigner {
+	out := make([]provenance.TrustedSigner, 0, len(shared)+len(perRoot))
+	for _, list := range [][]config.AllowedSigner{shared, perRoot} {
+		for _, s := range list {
+			out = append(out, provenance.TrustedSigner{
+				Principal:   s.Principal,
+				PublicKey:   s.Key,
+				Comment:     s.Label,
+				ValidAfter:  s.ValidAfter,
+				ValidBefore: s.ValidBefore,
+			})
+		}
+	}
+	return out
 }
 
 func configureRepoLocalAllowedSigners(root, repoPath string, logger *slog.Logger) error {

--- a/internal/platform/provenance/allowed_signers.go
+++ b/internal/platform/provenance/allowed_signers.go
@@ -158,10 +158,18 @@ func opensshTime(rfc3339 string) (string, error) {
 // canonicalKeyBlob parses an authorized_keys-form public key and returns its
 // canonical "keytype base64" form with the comment stripped, so keys that
 // differ only by comment or surrounding whitespace compare equal.
+//
+// It rejects any value carrying more than one key: ssh.ParseAuthorizedKey
+// parses only the first line and returns the remainder in rest, so a value
+// with an embedded newline and a second key would otherwise be silently
+// accepted (and its second key dropped on render) — refuse it instead.
 func canonicalKeyBlob(key string) (string, error) {
-	pub, _, _, _, err := ssh.ParseAuthorizedKey([]byte(key))
+	pub, _, _, rest, err := ssh.ParseAuthorizedKey([]byte(key))
 	if err != nil {
 		return "", fmt.Errorf("not a valid SSH public key: %w", err)
+	}
+	if strings.TrimSpace(string(rest)) != "" {
+		return "", fmt.Errorf("value must contain exactly one SSH public key")
 	}
 	return strings.TrimSpace(string(ssh.MarshalAuthorizedKey(pub))), nil
 }

--- a/internal/platform/provenance/allowed_signers.go
+++ b/internal/platform/provenance/allowed_signers.go
@@ -1,0 +1,167 @@
+package provenance
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"golang.org/x/crypto/ssh"
+)
+
+// AgentPrincipal is the fixed principal under which thane's own signing key
+// is trusted in every rendered allowed_signers file. It is an internal
+// identity, not a contactable address.
+const AgentPrincipal = "thane@provenance.local"
+
+// TrustedSigner is one operator identity destined for an OpenSSH
+// allowed_signers file. Times are RFC3339 as authored in config;
+// [RenderAllowedSigners] converts them to OpenSSH's on-disk format.
+type TrustedSigner struct {
+	// Principal is the OpenSSH signer identity, conventionally an email.
+	Principal string
+
+	// PublicKey is the key in authorized_keys form ("ssh-ed25519 AAAA...").
+	// Any trailing comment is ignored for identity and rendering; use
+	// Comment for the rendered trailing note.
+	PublicKey string
+
+	// Comment is an optional trailing note rendered after the key.
+	Comment string
+
+	// ValidAfter and ValidBefore are optional RFC3339 validity bounds.
+	ValidAfter  string
+	ValidBefore string
+}
+
+// RenderAllowedSigners produces the content of an OpenSSH allowed_signers
+// file that trusts the agent key plus the operator keys, deterministically.
+//
+// The agent key is the unremovable trust anchor: it is always emitted first,
+// under [AgentPrincipal], and an operator entry whose public key equals the
+// agent key is rejected — that is a principal-spoof that would let another
+// identity ride the agent's own key. Operator keys are canonicalized (comment
+// and whitespace stripped for identity), deduplicated by key blob, and sorted
+// by (principal, blob) so the rendered file never churns across boots when the
+// configured set is unchanged. The returned content ends with a trailing
+// newline and is safe to compare byte-for-byte for drift detection.
+func RenderAllowedSigners(agentPublicKey string, operators []TrustedSigner) (string, error) {
+	agentBlob, err := canonicalKeyBlob(agentPublicKey)
+	if err != nil {
+		return "", fmt.Errorf("agent signing key: %w", err)
+	}
+
+	type entry struct {
+		principal string
+		blob      string
+		line      string
+	}
+	// seen maps a canonical key blob to the principal that first claimed
+	// it, so a key reused under a second principal is caught.
+	seen := map[string]string{agentBlob: AgentPrincipal}
+	others := make([]entry, 0, len(operators))
+	for i, s := range operators {
+		blob, err := canonicalKeyBlob(s.PublicKey)
+		if err != nil {
+			return "", fmt.Errorf("operator signer %d (%s): %w", i, strings.TrimSpace(s.Principal), err)
+		}
+		if blob == agentBlob {
+			return "", fmt.Errorf("operator signer %q uses the agent's own signing key; the agent key is trusted implicitly and must not be listed", strings.TrimSpace(s.Principal))
+		}
+		if prev, ok := seen[blob]; ok {
+			return "", fmt.Errorf("operator signer %q duplicates the key already trusted for %q", strings.TrimSpace(s.Principal), prev)
+		}
+		seen[blob] = strings.TrimSpace(s.Principal)
+		line, err := renderSignerLine(s.Principal, blob, s.Comment, s.ValidAfter, s.ValidBefore)
+		if err != nil {
+			return "", fmt.Errorf("operator signer %q: %w", strings.TrimSpace(s.Principal), err)
+		}
+		others = append(others, entry{principal: strings.TrimSpace(s.Principal), blob: blob, line: line})
+	}
+	sort.Slice(others, func(i, j int) bool {
+		if others[i].principal != others[j].principal {
+			return others[i].principal < others[j].principal
+		}
+		return others[i].blob < others[j].blob
+	})
+
+	agentLine, err := renderSignerLine(AgentPrincipal, agentBlob, "", "", "")
+	if err != nil {
+		return "", err
+	}
+	var b strings.Builder
+	b.WriteString(agentLine)
+	b.WriteByte('\n')
+	for _, e := range others {
+		b.WriteString(e.line)
+		b.WriteByte('\n')
+	}
+	return b.String(), nil
+}
+
+// renderSignerLine builds one allowed_signers line:
+//
+//	principal [valid-after="...",valid-before="..."] keytype base64 [comment]
+//
+// blob is the canonical "keytype base64" form (no comment).
+func renderSignerLine(principal, blob, comment, validAfter, validBefore string) (string, error) {
+	principal = strings.TrimSpace(principal)
+	if principal == "" {
+		return "", fmt.Errorf("principal is required")
+	}
+	parts := []string{principal}
+	opts, err := renderValidityOptions(validAfter, validBefore)
+	if err != nil {
+		return "", err
+	}
+	if opts != "" {
+		parts = append(parts, opts)
+	}
+	parts = append(parts, blob)
+	if c := strings.TrimSpace(comment); c != "" {
+		parts = append(parts, c)
+	}
+	return strings.Join(parts, " "), nil
+}
+
+// renderValidityOptions renders the comma-joined OpenSSH options field for a
+// validity window, or "" when neither bound is set.
+func renderValidityOptions(validAfter, validBefore string) (string, error) {
+	var opts []string
+	if v := strings.TrimSpace(validAfter); v != "" {
+		ts, err := opensshTime(v)
+		if err != nil {
+			return "", fmt.Errorf("valid_after: %w", err)
+		}
+		opts = append(opts, `valid-after="`+ts+`"`)
+	}
+	if v := strings.TrimSpace(validBefore); v != "" {
+		ts, err := opensshTime(v)
+		if err != nil {
+			return "", fmt.Errorf("valid_before: %w", err)
+		}
+		opts = append(opts, `valid-before="`+ts+`"`)
+	}
+	return strings.Join(opts, ","), nil
+}
+
+// opensshTime converts an RFC3339 timestamp to OpenSSH's allowed_signers time
+// format (YYYYMMDDHHMMSSZ, UTC).
+func opensshTime(rfc3339 string) (string, error) {
+	t, err := time.Parse(time.RFC3339, rfc3339)
+	if err != nil {
+		return "", fmt.Errorf("%q must be an RFC3339 timestamp: %w", rfc3339, err)
+	}
+	return t.UTC().Format("20060102150405Z"), nil
+}
+
+// canonicalKeyBlob parses an authorized_keys-form public key and returns its
+// canonical "keytype base64" form with the comment stripped, so keys that
+// differ only by comment or surrounding whitespace compare equal.
+func canonicalKeyBlob(key string) (string, error) {
+	pub, _, _, _, err := ssh.ParseAuthorizedKey([]byte(key))
+	if err != nil {
+		return "", fmt.Errorf("not a valid SSH public key: %w", err)
+	}
+	return strings.TrimSpace(string(ssh.MarshalAuthorizedKey(pub))), nil
+}

--- a/internal/platform/provenance/allowed_signers.go
+++ b/internal/platform/provenance/allowed_signers.go
@@ -1,7 +1,11 @@
 package provenance
 
 import (
+	"context"
+	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 	"time"
@@ -65,18 +69,27 @@ func RenderAllowedSigners(agentPublicKey string, operators []TrustedSigner) (str
 		if err != nil {
 			return "", fmt.Errorf("operator signer %d (%s): %w", i, strings.TrimSpace(s.Principal), err)
 		}
+		principal := strings.TrimSpace(s.Principal)
 		if blob == agentBlob {
-			return "", fmt.Errorf("operator signer %q uses the agent's own signing key; the agent key is trusted implicitly and must not be listed", strings.TrimSpace(s.Principal))
+			return "", fmt.Errorf("operator signer %q uses the agent's own signing key; the agent key is trusted implicitly and must not be listed", principal)
 		}
 		if prev, ok := seen[blob]; ok {
-			return "", fmt.Errorf("operator signer %q duplicates the key already trusted for %q", strings.TrimSpace(s.Principal), prev)
+			// The same key under the same principal collapses silently:
+			// this is the benign case where a key is listed in both the
+			// shared block and a root's own list (the sets union). The
+			// same key under a *different* principal is a spoof and is
+			// refused.
+			if prev == principal {
+				continue
+			}
+			return "", fmt.Errorf("operator signer %q duplicates the key already trusted for %q", principal, prev)
 		}
-		seen[blob] = strings.TrimSpace(s.Principal)
-		line, err := renderSignerLine(s.Principal, blob, s.Comment, s.ValidAfter, s.ValidBefore)
+		seen[blob] = principal
+		line, err := renderSignerLine(principal, blob, s.Comment, s.ValidAfter, s.ValidBefore)
 		if err != nil {
-			return "", fmt.Errorf("operator signer %q: %w", strings.TrimSpace(s.Principal), err)
+			return "", fmt.Errorf("operator signer %q: %w", principal, err)
 		}
-		others = append(others, entry{principal: strings.TrimSpace(s.Principal), blob: blob, line: line})
+		others = append(others, entry{principal: principal, blob: blob, line: line})
 	}
 	sort.Slice(others, func(i, j int) bool {
 		if others[i].principal != others[j].principal {
@@ -97,6 +110,51 @@ func RenderAllowedSigners(agentPublicKey string, operators []TrustedSigner) (str
 		b.WriteByte('\n')
 	}
 	return b.String(), nil
+}
+
+// ReconcileAllowedSigners renders this repository's trust set — the agent key
+// plus the given operator signers — and, when it differs from the repo's
+// current .allowed_signers, writes it and makes a signed commit so the tracked
+// trust surface stays clean and covered by signed history. It reports whether
+// a commit was made and is idempotent: an unchanged set is a no-op with no
+// commit, so it can run on every boot without churning history.
+//
+// The repository must already have a HEAD, so call it after
+// [Store.BootstrapBirthCommit]. Rendering enforces the trust invariants
+// (agent key unremovable and never reused by an operator, no principal-spoof
+// duplicates), so a config that violates them fails here rather than silently
+// weakening verification.
+func (s *Store) ReconcileAllowedSigners(ctx context.Context, operators []TrustedSigner) (bool, error) {
+	desired, err := RenderAllowedSigners(s.signer.PublicKey(), operators)
+	if err != nil {
+		return false, fmt.Errorf("render allowed_signers: %w", err)
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	path := filepath.Join(s.path, ".allowed_signers")
+	// A symlink here would let the trust surface be redirected out from
+	// under verification; reject anything but a regular file (absent is
+	// fine — we are about to create it).
+	if err := validateAllowedSignersFile(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return false, err
+	}
+	current, err := os.ReadFile(path)
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return false, fmt.Errorf("read .allowed_signers: %w", err)
+	}
+	if string(current) == desired {
+		return false, nil
+	}
+	if err := os.WriteFile(path, []byte(desired), 0o644); err != nil {
+		return false, fmt.Errorf("write .allowed_signers: %w", err)
+	}
+	if _, err := s.commitFiles(ctx, []string{".allowed_signers"}, "reconcile allowed_signers"); err != nil {
+		return false, fmt.Errorf("commit .allowed_signers: %w", err)
+	}
+	s.logger.Info("reconciled allowed_signers", "operator_entries", len(operators))
+	return true, nil
 }
 
 // renderSignerLine builds one allowed_signers line:

--- a/internal/platform/provenance/allowed_signers.go
+++ b/internal/platform/provenance/allowed_signers.go
@@ -125,6 +125,15 @@ func RenderAllowedSigners(agentPublicKey string, operators []TrustedSigner) (str
 // duplicates), so a config that violates them fails here rather than silently
 // weakening verification.
 func (s *Store) ReconcileAllowedSigners(ctx context.Context, operators []TrustedSigner) (bool, error) {
+	// This reconcile writes and commits the repo-local trust file. When the
+	// Store verifies against an external allowed_signers file, that file is
+	// not in the worktree and cannot be committed — reconciling the
+	// repo-local file would write a trust surface git never consults. Refuse
+	// rather than silently diverge; out-of-tree trust is a separate path.
+	if s.allowedSignersPath != "" {
+		return false, fmt.Errorf("ReconcileAllowedSigners: store verifies against an external allowed_signers file (%s); in-tree reconcile does not apply", s.allowedSignersPath)
+	}
+
 	desired, err := RenderAllowedSigners(s.signer.PublicKey(), operators)
 	if err != nil {
 		return false, fmt.Errorf("render allowed_signers: %w", err)
@@ -147,14 +156,58 @@ func (s *Store) ReconcileAllowedSigners(ctx context.Context, operators []Trusted
 	if string(current) == desired {
 		return false, nil
 	}
-	if err := os.WriteFile(path, []byte(desired), 0o644); err != nil {
+	if err := atomicWriteFile(path, []byte(desired), 0o644); err != nil {
 		return false, fmt.Errorf("write .allowed_signers: %w", err)
+	}
+	// Re-validate after the rename: a swapped symlink would have been
+	// replaced by our regular file, but confirm the invariant still holds.
+	if err := validateAllowedSignersFile(path); err != nil {
+		return false, err
 	}
 	if _, err := s.commitFiles(ctx, []string{".allowed_signers"}, "reconcile allowed_signers"); err != nil {
 		return false, fmt.Errorf("commit .allowed_signers: %w", err)
 	}
 	s.logger.Info("reconciled allowed_signers", "operator_entries", len(operators))
 	return true, nil
+}
+
+// atomicWriteFile writes data to path atomically: it writes a temp file in the
+// same directory, fsyncs it, renames it into place, then fsyncs the directory
+// so a crash cannot leave a partial or truncated file. Renaming over the
+// target also collapses the symlink/regular-file TOCTOU window — the result is
+// always the regular file we wrote.
+func atomicWriteFile(path string, data []byte, perm os.FileMode) error {
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, ".allowed_signers-*.tmp")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	defer os.Remove(tmpName) // best-effort cleanup; a no-op once renamed
+
+	if err := tmp.Chmod(perm); err != nil {
+		tmp.Close()
+		return err
+	}
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Sync(); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		return err
+	}
+	if d, err := os.Open(dir); err == nil {
+		_ = d.Sync()
+		_ = d.Close()
+	}
+	return nil
 }
 
 // renderSignerLine builds one allowed_signers line:
@@ -183,34 +236,45 @@ func renderSignerLine(principal, blob, comment, validAfter, validBefore string) 
 }
 
 // renderValidityOptions renders the comma-joined OpenSSH options field for a
-// validity window, or "" when neither bound is set.
+// validity window, or "" when neither bound is set. Config already validates
+// the window, but this renderer is a security-sensitive seam other callers can
+// reach, so it independently enforces that valid_after is strictly before
+// valid_before rather than emit an options field that violates the contract.
 func renderValidityOptions(validAfter, validBefore string) (string, error) {
 	var opts []string
+	var after, before time.Time
+	haveAfter, haveBefore := false, false
+
 	if v := strings.TrimSpace(validAfter); v != "" {
-		ts, err := opensshTime(v)
+		t, ts, err := opensshTime(v)
 		if err != nil {
 			return "", fmt.Errorf("valid_after: %w", err)
 		}
+		after, haveAfter = t, true
 		opts = append(opts, `valid-after="`+ts+`"`)
 	}
 	if v := strings.TrimSpace(validBefore); v != "" {
-		ts, err := opensshTime(v)
+		t, ts, err := opensshTime(v)
 		if err != nil {
 			return "", fmt.Errorf("valid_before: %w", err)
 		}
+		before, haveBefore = t, true
 		opts = append(opts, `valid-before="`+ts+`"`)
+	}
+	if haveAfter && haveBefore && !after.Before(before) {
+		return "", fmt.Errorf("valid_after must be strictly before valid_before")
 	}
 	return strings.Join(opts, ","), nil
 }
 
-// opensshTime converts an RFC3339 timestamp to OpenSSH's allowed_signers time
-// format (YYYYMMDDHHMMSSZ, UTC).
-func opensshTime(rfc3339 string) (string, error) {
+// opensshTime parses an RFC3339 timestamp and returns both the parsed time and
+// its rendering in OpenSSH's allowed_signers time format (YYYYMMDDHHMMSSZ, UTC).
+func opensshTime(rfc3339 string) (time.Time, string, error) {
 	t, err := time.Parse(time.RFC3339, rfc3339)
 	if err != nil {
-		return "", fmt.Errorf("%q must be an RFC3339 timestamp: %w", rfc3339, err)
+		return time.Time{}, "", fmt.Errorf("%q must be an RFC3339 timestamp: %w", rfc3339, err)
 	}
-	return t.UTC().Format("20060102150405Z"), nil
+	return t, t.UTC().Format("20060102150405Z"), nil
 }
 
 // canonicalKeyBlob parses an authorized_keys-form public key and returns its

--- a/internal/platform/provenance/allowed_signers_test.go
+++ b/internal/platform/provenance/allowed_signers_test.go
@@ -134,6 +134,17 @@ func TestRenderAllowedSigners_Rejections(t *testing.T) {
 			ops:   []TrustedSigner{{Principal: "alice@example.com", PublicKey: testAliceKey + "\n" + testBobKey}},
 			want:  "exactly one SSH public key",
 		},
+		{
+			name:  "inverted validity window",
+			agent: testAgentKey,
+			ops: []TrustedSigner{{
+				Principal:   "alice@example.com",
+				PublicKey:   testAliceKey,
+				ValidAfter:  "2027-01-01T00:00:00Z",
+				ValidBefore: "2026-01-01T00:00:00Z",
+			}},
+			want: "strictly before",
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
@@ -232,6 +243,29 @@ func TestReconcileAllowedSignersCommitsUnionAndIsIdempotent(t *testing.T) {
 	}
 	if after := headHash(t, s); after != before {
 		t.Fatalf("HEAD moved on idempotent reconcile: %s -> %s", before, after)
+	}
+}
+
+// TestReconcileAllowedSignersRejectsExternalTrustFile confirms the in-tree
+// reconcile refuses to run when the Store verifies against an external
+// allowed_signers file it could not commit anyway.
+func TestReconcileAllowedSignersRejectsExternalTrustFile(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	dir := t.TempDir()
+	signer := testSigner(t)
+	allowedPath := filepath.Join(dir, "allowed_signers")
+	if err := os.WriteFile(allowedPath, []byte(AgentPrincipal+" "+signer.PublicKey()+"\n"), 0o644); err != nil {
+		t.Fatalf("write external allowed_signers: %v", err)
+	}
+	s, err := NewWithOptions(filepath.Join(dir, "repo"), signer, slog.Default(), Options{AllowedSignersPath: allowedPath})
+	if err != nil {
+		t.Fatalf("NewWithOptions: %v", err)
+	}
+	_, err = s.ReconcileAllowedSigners(t.Context(), []TrustedSigner{{Principal: "alice@example.com", PublicKey: testAliceKey}})
+	if err == nil || !strings.Contains(err.Error(), "external allowed_signers") {
+		t.Fatalf("ReconcileAllowedSigners error = %v, want external-file rejection", err)
 	}
 }
 

--- a/internal/platform/provenance/allowed_signers_test.go
+++ b/internal/platform/provenance/allowed_signers_test.go
@@ -1,6 +1,11 @@
 package provenance
 
 import (
+	"bytes"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -153,4 +158,88 @@ func TestRenderAllowedSigners_CanonicalizesComments(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "agent's own signing key") {
 		t.Fatalf("RenderAllowedSigners() error = %v, want agent-key rejection despite comment", err)
 	}
+}
+
+// TestRenderAllowedSigners_CollapsesSamePrincipalDuplicate confirms the same
+// key under the same principal (e.g. listed in both the shared block and a
+// root's own list, which union) collapses to one line rather than erroring.
+func TestRenderAllowedSigners_CollapsesSamePrincipalDuplicate(t *testing.T) {
+	t.Parallel()
+	got, err := RenderAllowedSigners(testAgentKey, []TrustedSigner{
+		{Principal: "alice@example.com", PublicKey: testAliceKey},
+		{Principal: "alice@example.com", PublicKey: testAliceKey, Comment: "listed twice"},
+	})
+	if err != nil {
+		t.Fatalf("RenderAllowedSigners() error = %v", err)
+	}
+	if n := strings.Count(got, testAliceKey); n != 1 {
+		t.Fatalf("alice key appears %d times, want 1:\n%s", n, got)
+	}
+}
+
+// TestReconcileAllowedSignersCommitsUnionAndIsIdempotent covers the full I/O
+// path: rendering the agent+operator union into the repo's .allowed_signers,
+// committing it as signed history, keeping HEAD verifiable, and doing nothing
+// on an unchanged set.
+func TestReconcileAllowedSignersCommitsUnionAndIsIdempotent(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	dir := t.TempDir()
+	signer := testSigner(t)
+	s, err := New(dir, signer, slog.Default())
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := s.BootstrapBirthCommit(t.Context()); err != nil {
+		t.Fatalf("BootstrapBirthCommit: %v", err)
+	}
+
+	ops := []TrustedSigner{{Principal: "alice@example.com", PublicKey: testAliceKey, Comment: "Alice laptop"}}
+	changed, err := s.ReconcileAllowedSigners(t.Context(), ops)
+	if err != nil {
+		t.Fatalf("ReconcileAllowedSigners: %v", err)
+	}
+	if !changed {
+		t.Fatal("first reconcile changed = false, want true")
+	}
+
+	got, err := os.ReadFile(filepath.Join(dir, ".allowed_signers"))
+	if err != nil {
+		t.Fatalf("read .allowed_signers: %v", err)
+	}
+	if !strings.HasPrefix(string(got), AgentPrincipal+" ") {
+		t.Fatalf("agent anchor is not the first line:\n%s", got)
+	}
+	if !strings.Contains(string(got), "alice@example.com "+testAliceKey+" Alice laptop") {
+		t.Fatalf("operator line missing or malformed:\n%s", got)
+	}
+
+	// HEAD (the reconcile commit) must still verify against the rendered
+	// trust file — the agent key that signed it is in the file.
+	if err := s.git(t.Context(), nil, nil, "verify-commit", "HEAD"); err != nil {
+		t.Fatalf("verify-commit HEAD after reconcile: %v", err)
+	}
+
+	// Idempotent: an unchanged set makes no commit and does not move HEAD.
+	before := headHash(t, s)
+	changed, err = s.ReconcileAllowedSigners(t.Context(), ops)
+	if err != nil {
+		t.Fatalf("second ReconcileAllowedSigners: %v", err)
+	}
+	if changed {
+		t.Fatal("second reconcile changed = true, want false (idempotent)")
+	}
+	if after := headHash(t, s); after != before {
+		t.Fatalf("HEAD moved on idempotent reconcile: %s -> %s", before, after)
+	}
+}
+
+func headHash(t *testing.T, s *Store) string {
+	t.Helper()
+	var buf bytes.Buffer
+	if err := s.git(t.Context(), nil, &buf, "rev-parse", "HEAD"); err != nil {
+		t.Fatalf("rev-parse HEAD: %v", err)
+	}
+	return strings.TrimSpace(buf.String())
 }

--- a/internal/platform/provenance/allowed_signers_test.go
+++ b/internal/platform/provenance/allowed_signers_test.go
@@ -1,0 +1,150 @@
+package provenance
+
+import (
+	"strings"
+	"testing"
+)
+
+const (
+	testAgentKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIM72/tw9yIXLKQ+TL3E9g3BvJYyYyOaC6l2bSIEfkeHQ"
+	testAliceKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGyUStZXWURqF4b7IWfSTz2W6zYz5JnXrKbcuPfGAmUo"
+	testBobKey   = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIO+3xdUdsJA9XoATiuDErHwn2cDSIO1U1/t+BuN6P3Gv"
+)
+
+func TestRenderAllowedSigners_AgentAnchorFirst(t *testing.T) {
+	t.Parallel()
+	got, err := RenderAllowedSigners(testAgentKey, nil)
+	if err != nil {
+		t.Fatalf("RenderAllowedSigners() error = %v", err)
+	}
+	want := AgentPrincipal + " " + testAgentKey + "\n"
+	if got != want {
+		t.Fatalf("RenderAllowedSigners() = %q, want %q", got, want)
+	}
+}
+
+func TestRenderAllowedSigners_UnionSortedDeterministic(t *testing.T) {
+	t.Parallel()
+	// Bob before Alice in the input; output must sort by principal, with the
+	// agent pinned first regardless.
+	got, err := RenderAllowedSigners(testAgentKey, []TrustedSigner{
+		{Principal: "bob@example.com", PublicKey: testBobKey, Comment: "Bob laptop"},
+		{Principal: "alice@example.com", PublicKey: testAliceKey},
+	})
+	if err != nil {
+		t.Fatalf("RenderAllowedSigners() error = %v", err)
+	}
+	want := strings.Join([]string{
+		AgentPrincipal + " " + testAgentKey,
+		"alice@example.com " + testAliceKey,
+		"bob@example.com " + testBobKey + " Bob laptop",
+		"",
+	}, "\n")
+	if got != want {
+		t.Fatalf("RenderAllowedSigners() =\n%q\nwant\n%q", got, want)
+	}
+}
+
+func TestRenderAllowedSigners_Stable(t *testing.T) {
+	t.Parallel()
+	ops := []TrustedSigner{
+		{Principal: "alice@example.com", PublicKey: testAliceKey},
+		{Principal: "bob@example.com", PublicKey: testBobKey},
+	}
+	first, err := RenderAllowedSigners(testAgentKey, ops)
+	if err != nil {
+		t.Fatalf("RenderAllowedSigners() error = %v", err)
+	}
+	// Reversed input must render identically (deterministic sort).
+	second, err := RenderAllowedSigners(testAgentKey, []TrustedSigner{ops[1], ops[0]})
+	if err != nil {
+		t.Fatalf("RenderAllowedSigners() error = %v", err)
+	}
+	if first != second {
+		t.Fatalf("render not stable across input order:\n%q\nvs\n%q", first, second)
+	}
+}
+
+func TestRenderAllowedSigners_ValidityWindow(t *testing.T) {
+	t.Parallel()
+	got, err := RenderAllowedSigners(testAgentKey, []TrustedSigner{{
+		Principal:   "alice@example.com",
+		PublicKey:   testAliceKey,
+		ValidAfter:  "2026-01-01T00:00:00Z",
+		ValidBefore: "2027-06-15T12:30:45Z",
+	}})
+	if err != nil {
+		t.Fatalf("RenderAllowedSigners() error = %v", err)
+	}
+	wantLine := `alice@example.com valid-after="20260101000000Z",valid-before="20270615123045Z" ` + testAliceKey
+	if !strings.Contains(got, wantLine) {
+		t.Fatalf("RenderAllowedSigners() =\n%s\nwant line %q", got, wantLine)
+	}
+}
+
+func TestRenderAllowedSigners_Rejections(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name  string
+		agent string
+		ops   []TrustedSigner
+		want  string
+	}{
+		{
+			name:  "operator reuses agent key",
+			agent: testAgentKey,
+			ops:   []TrustedSigner{{Principal: "evil@example.com", PublicKey: testAgentKey}},
+			want:  "agent's own signing key",
+		},
+		{
+			name:  "duplicate operator key under two principals",
+			agent: testAgentKey,
+			ops: []TrustedSigner{
+				{Principal: "alice@example.com", PublicKey: testAliceKey},
+				{Principal: "eve@example.com", PublicKey: testAliceKey},
+			},
+			want: "duplicates the key already trusted",
+		},
+		{
+			name:  "malformed operator key",
+			agent: testAgentKey,
+			ops:   []TrustedSigner{{Principal: "alice@example.com", PublicKey: "not-a-key"}},
+			want:  "not a valid SSH public key",
+		},
+		{
+			name:  "malformed agent key",
+			agent: "not-a-key",
+			ops:   nil,
+			want:  "agent signing key",
+		},
+		{
+			name:  "bad validity timestamp",
+			agent: testAgentKey,
+			ops:   []TrustedSigner{{Principal: "alice@example.com", PublicKey: testAliceKey, ValidAfter: "nope"}},
+			want:  "valid_after",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := RenderAllowedSigners(tc.agent, tc.ops)
+			if err == nil {
+				t.Fatalf("RenderAllowedSigners() = nil error, want error containing %q", tc.want)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("RenderAllowedSigners() error = %v, want containing %q", err, tc.want)
+			}
+		})
+	}
+}
+
+// TestRenderAllowedSigners_CanonicalizesComments confirms that keys differing
+// only by trailing comment are treated as identical (so a comment can't slip a
+// duplicate past dedup, and the agent-key check can't be evaded by appending a
+// comment).
+func TestRenderAllowedSigners_CanonicalizesComments(t *testing.T) {
+	t.Parallel()
+	_, err := RenderAllowedSigners(testAgentKey, []TrustedSigner{{Principal: "evil@example.com", PublicKey: testAgentKey + " looks-different"}})
+	if err == nil || !strings.Contains(err.Error(), "agent's own signing key") {
+		t.Fatalf("RenderAllowedSigners() error = %v, want agent-key rejection despite comment", err)
+	}
+}

--- a/internal/platform/provenance/allowed_signers_test.go
+++ b/internal/platform/provenance/allowed_signers_test.go
@@ -123,6 +123,12 @@ func TestRenderAllowedSigners_Rejections(t *testing.T) {
 			ops:   []TrustedSigner{{Principal: "alice@example.com", PublicKey: testAliceKey, ValidAfter: "nope"}},
 			want:  "valid_after",
 		},
+		{
+			name:  "operator key smuggles a second key via embedded newline",
+			agent: testAgentKey,
+			ops:   []TrustedSigner{{Principal: "alice@example.com", PublicKey: testAliceKey + "\n" + testBobKey}},
+			want:  "exactly one SSH public key",
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()


### PR DESCRIPTION
## What

This is **PR-2 of #1135** — the half that actually makes an operator's key trusted. #1138 (merged) added the config surface and its fail-closed validation; this turns that config into a rendered `.allowed_signers` trust file on a signed document root, so an operator can commit a signed edit and have thane trust it and build on it. It is the piece the whole co-authoring goal (and, downstream, remote sync in #1137) rests on.

## How it works

The trust file is rendered, not hand-managed. When a signing root is constructed, after its birth commit, thane renders `.allowed_signers` as the **union of the agent's key and the operator keys** the operator declared — the shared `signing.allowed_signers` block plus that root's own `git.allowed_signers` — and, *only when the set changed*, writes it and makes a signed commit. Going through the signed-commit path is the point: the trust file is itself tracked, so committing it keeps the worktree clean and keeps HEAD covered by verified history, which is exactly what `verify_signatures: required` checks. Because git evaluates every principal in a multi-principal `allowed_signers` file, an operator's signed commit then verifies as trusted with **no change to the verification logic** — the file is the whole mechanism.

The render is deterministic and safe by construction. The agent key is the unremovable anchor: always emitted first under `thane@provenance.local`, and an operator entry that reuses the agent's own key is refused (a principal-spoof that would let another identity ride the agent's key). Keys are canonicalized (comment and whitespace stripped) so a comment can't smuggle a duplicate or evade the agent-key check, deduplicated, and sorted, so the rendered file never churns across boots when the configured set is unchanged. That determinism is what makes the reconcile idempotent — an unchanged set makes no commit — so it can run on every boot without piling up history.

One semantic was relaxed from the render primitive as first written: the same key under the *same* principal now collapses rather than erroring, because a key legitimately appears in both the shared block and a root's own list when the two sets union. The same key under a *different* principal is still refused.

## Scope

This lands trust rendering for **signing roots** (`sign_commits: true`) — the roots an operator co-authors, which is the motivating case. Verify-only roots authored only by humans want an out-of-tree anchor (thane isn't a committer there), and that is entangled with the remote-sync design in #1137, so it stays deferred rather than half-built here.

Two safety items named in #1135 are intentionally held for a small **PR-3**, since each is a distinct concern from "make operator keys trusted": the **boot verify-commit round-trip** (assert a known agent-signed commit verifies after rendering, catching OpenSSH validity-window version skew) and the **config-isolation invariant** (a startup check that no root path overlaps `config.yaml`, proving the model can't reach keys).

## Test plan

- [x] `RenderAllowedSigners` unit tests — union/sort/determinism, validity-window → OpenSSH format, canonicalization, same-principal collapse, and every rejection (agent-key reuse, cross-principal duplicate, malformed key, multi-key smuggling, bad window).
- [x] `ReconcileAllowedSigners` integration test on a real repo — commits the union, keeps HEAD verifying against the rendered file, and is a no-op (no new commit, HEAD unmoved) on an unchanged set.
- [x] `just ci` green locally.

Refs #1135
Relates to #1137
