### PR TITLE
feat(provenance): boot verify-commit round-trip for signed roots (#1135 PR-3)

### DIFF
--- a/internal/app/document_roots.go
+++ b/internal/app/document_roots.go
@@ -314,17 +314,13 @@ func (a *App) newDocumentRootProvenanceWriter(root, rootPath string, gitCfg conf
 	// Boot-time round-trip: confirm HEAD actually verifies against the trust
 	// file we just rendered, so a malformed signer line or an OpenSSH version
 	// that can't parse a rendered option fails loudly now instead of silently
-	// blocking reads later. Honor the root's verification policy — hard-fail a
-	// required root, warn a warn root, skip when verification is off.
-	switch strings.TrimSpace(gitCfg.VerifySignatures) {
-	case "required":
-		if err := store.VerifyHead(bootstrapCtx); err != nil {
-			return nil, fmt.Errorf("doc_roots.%s allowed_signers boot verification: %w", root, err)
-		}
-	case "warn":
-		if err := store.VerifyHead(bootstrapCtx); err != nil {
-			logger.Warn("document root allowed_signers boot verification failed",
-				"root", root, "error", err)
+	// blocking reads later. Only worth running where verification is actually
+	// consumed; the policy mapping (fail vs. warn) lives in applyBootVerification.
+	mode := documents.VerificationMode(strings.TrimSpace(gitCfg.VerifySignatures))
+	switch mode {
+	case documents.VerificationRequired, documents.VerificationWarn:
+		if err := applyBootVerification(mode, root, store.VerifyHead(bootstrapCtx), logger); err != nil {
+			return nil, err
 		}
 	}
 
@@ -368,6 +364,26 @@ func (a *App) newDocumentRootProvenanceVerifier(root, rootPath string, gitCfg co
 		return nil, fmt.Errorf("initialize git verifier for document root %s: %w", root, err)
 	}
 	return &documentRootProvenanceVerifier{verifier: verifier, prefix: prefix}, nil
+}
+
+// applyBootVerification maps a boot-time VerifyHead result onto the root's
+// verification policy: a required root fails to construct, a warn root logs and
+// continues, and any other mode is a no-op. A nil verifyErr is always a no-op,
+// so callers can pass the VerifyHead result directly.
+func applyBootVerification(mode documents.VerificationMode, root string, verifyErr error, logger *slog.Logger) error {
+	if verifyErr == nil {
+		return nil
+	}
+	switch mode {
+	case documents.VerificationRequired:
+		return fmt.Errorf("doc_roots.%s allowed_signers boot verification: %w", root, verifyErr)
+	case documents.VerificationWarn:
+		logger.Warn("document root allowed_signers boot verification failed",
+			"root", root, "error", verifyErr)
+		return nil
+	default:
+		return nil
+	}
 }
 
 // buildTrustedSigners flattens the shared and per-root operator allowed-signer

--- a/internal/app/document_roots.go
+++ b/internal/app/document_roots.go
@@ -311,6 +311,23 @@ func (a *App) newDocumentRootProvenanceWriter(root, rootPath string, gitCfg conf
 		return nil, fmt.Errorf("doc_roots.%s reconcile allowed_signers: %w", root, err)
 	}
 
+	// Boot-time round-trip: confirm HEAD actually verifies against the trust
+	// file we just rendered, so a malformed signer line or an OpenSSH version
+	// that can't parse a rendered option fails loudly now instead of silently
+	// blocking reads later. Honor the root's verification policy — hard-fail a
+	// required root, warn a warn root, skip when verification is off.
+	switch strings.TrimSpace(gitCfg.VerifySignatures) {
+	case "required":
+		if err := store.VerifyHead(bootstrapCtx); err != nil {
+			return nil, fmt.Errorf("doc_roots.%s allowed_signers boot verification: %w", root, err)
+		}
+	case "warn":
+		if err := store.VerifyHead(bootstrapCtx); err != nil {
+			logger.Warn("document root allowed_signers boot verification failed",
+				"root", root, "error", err)
+		}
+	}
+
 	logger.Info("document root provenance enabled",
 		"root", root,
 		"repo", store.Path(),

--- a/internal/app/document_roots_test.go
+++ b/internal/app/document_roots_test.go
@@ -1,6 +1,8 @@
 package app
 
 import (
+	"errors"
+	"io"
 	"log/slog"
 	"os"
 	"os/exec"
@@ -364,6 +366,42 @@ func TestBuildDocumentStoreOptionsNonBootstrapMissingDirStillErrors(t *testing.T
 	}
 	if !strings.Contains(err.Error(), "does not exist on disk") {
 		t.Fatalf("error = %v, want does-not-exist message", err)
+	}
+}
+
+// TestApplyBootVerification locks in the boot round-trip's policy mapping: a
+// required root fails to construct on a verification failure, a warn root logs
+// and continues, verification-off is a no-op, and a passing check never errors.
+func TestApplyBootVerification(t *testing.T) {
+	sentinel := errors.New("verify HEAD failed")
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	for _, tc := range []struct {
+		name    string
+		mode    documents.VerificationMode
+		verErr  error
+		wantErr bool
+	}{
+		{"required + failure fails construction", documents.VerificationRequired, sentinel, true},
+		{"warn + failure continues", documents.VerificationWarn, sentinel, false},
+		{"none + failure is a no-op", documents.VerificationNone, sentinel, false},
+		{"required + success is a no-op", documents.VerificationRequired, nil, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := applyBootVerification(tc.mode, "kb", tc.verErr, logger)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("applyBootVerification = nil, want error")
+				}
+				if !strings.Contains(err.Error(), "kb") {
+					t.Fatalf("error %q should name the root", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("applyBootVerification = %v, want nil", err)
+			}
+		})
 	}
 }
 

--- a/internal/platform/provenance/allowed_signers.go
+++ b/internal/platform/provenance/allowed_signers.go
@@ -171,6 +171,22 @@ func (s *Store) ReconcileAllowedSigners(ctx context.Context, operators []Trusted
 	return true, nil
 }
 
+// VerifyHead confirms the repository's HEAD commit verifies as trusted against
+// the current allowed_signers file. Run it after reconciling the trust set as
+// a boot-time round-trip: git parses the whole allowed_signers file to verify
+// any commit, so this catches a malformed signer line or an OpenSSH version
+// that cannot parse a rendered option (such as a validity window) right away,
+// rather than letting it surface later as a silent verification failure on the
+// first managed read.
+func (s *Store) VerifyHead(ctx context.Context) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if err := s.git(ctx, nil, nil, "verify-commit", "HEAD"); err != nil {
+		return fmt.Errorf("verify HEAD against allowed_signers: %w", err)
+	}
+	return nil
+}
+
 // atomicWriteFile writes data to path atomically: it writes a temp file in the
 // same directory, fsyncs it, renames it into place, then fsyncs the directory
 // so a crash cannot leave a partial or truncated file. Renaming over the

--- a/internal/platform/provenance/allowed_signers_test.go
+++ b/internal/platform/provenance/allowed_signers_test.go
@@ -269,6 +269,40 @@ func TestReconcileAllowedSignersRejectsExternalTrustFile(t *testing.T) {
 	}
 }
 
+// TestVerifyHead covers the boot round-trip: HEAD verifies against a trust
+// file that includes its signer, and fails against one that does not.
+func TestVerifyHead(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	dir := t.TempDir()
+	signer := testSigner(t)
+	s, err := New(dir, signer, slog.Default())
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := s.BootstrapBirthCommit(t.Context()); err != nil {
+		t.Fatalf("BootstrapBirthCommit: %v", err)
+	}
+
+	// HEAD is signed by the agent key, which the bootstrapped trust file
+	// trusts — the round-trip passes.
+	if err := s.VerifyHead(t.Context()); err != nil {
+		t.Fatalf("VerifyHead on a well-formed repo: %v", err)
+	}
+
+	// Point the trust file at an unrelated key: HEAD's signer is no longer
+	// trusted, so the round-trip must fail.
+	other := testSigner(t)
+	if err := os.WriteFile(filepath.Join(dir, ".allowed_signers"),
+		[]byte(AgentPrincipal+" "+other.PublicKey()+"\n"), 0o644); err != nil {
+		t.Fatalf("overwrite .allowed_signers: %v", err)
+	}
+	if err := s.VerifyHead(t.Context()); err == nil {
+		t.Fatal("VerifyHead with an untrusted signer = nil, want error")
+	}
+}
+
 func headHash(t *testing.T, s *Store) string {
 	t.Helper()
 	var buf bytes.Buffer


### PR DESCRIPTION
## What

This is **PR-3 of #1135** — the boot-time integrity round-trip for signed document roots. #1138 gave the config surface, #1139 rendered it into a trust file an operator's key is trusted through; this closes the loop by confirming, at boot, that the trust file actually verifies before anything depends on it.

## Why

git parses the *entire* `allowed_signers` file to verify any commit, so a single malformed line — or an OpenSSH version too old to parse a rendered option like a validity window — breaks verification for every commit, including the agent's own. Without a round-trip that failure is silent until the first managed read comes back untrusted, which on a `required` root means the root quietly goes dark. Verifying HEAD right after we render the trust set turns that into a loud, immediate boot failure pointing at the root.

The check honors the root's own verification policy rather than imposing a new one: a `required` root **hard-fails** the boot, a `warn` root **logs** and continues, and a root with verification off is **skipped** (there are no verification consumers to protect, so failing boot there would be wrong).

## Changes

- `Store.VerifyHead(ctx)` — runs `git verify-commit HEAD` against the store's configured `allowed_signers`.
- Wired into the signing-root writer path right after `ReconcileAllowedSigners`, gated on `verify_signatures`.
- Tests: HEAD verifies on a well-formed repo; pointing the trust file at an unrelated key makes it fail.

## The other #1135 safety item, and why it's not here

#1135 also named a **config-isolation invariant** — proving the model can't reach the keys. The obvious form, "`config.yaml` must not live inside any document root," collides head-on with **#787**'s direction, where `core/config.yaml` is the canonical config and lives *inside* the `core` document root by design. A path-containment check would reject that layout (and likely current prod). The correct invariant is "`config.yaml` is not reachable by *model tools*" — a model-reachability property, not a path-overlap one — which is entangled with #787's core-hardening and belongs there rather than as a check that would break the core-config layout. Deferred to #787 rather than shipped wrong.

## Test plan

- [x] `Store.VerifyHead` unit tests (pass on a well-formed repo, fail with an untrusted signer).
- [x] `just ci` green locally.

Closes #1135
Relates to #787

<sub>Closes #1135 as the final PR in the operator-allowed-signers stack (#1138 + #1139 + this). Out-of-scope follow-ups have homes: revision tools #1136, verify-only out-of-tree anchor #1137, config-isolation #787; key revocation remains a documented future design pass.</sub>
