### PR TITLE
feat(provenance): read-only Reader + CommitSigner for revision history (#1136 PR-1)

### DIFF
--- a/internal/platform/provenance/reader.go
+++ b/internal/platform/provenance/reader.go
@@ -33,6 +33,10 @@ type Reader interface {
 
 	// Revisions returns a page of the file's commit history, newest first.
 	Revisions(ctx context.Context, filename string, opts RevisionOptions) (RevisionPage, error)
+
+	// SignerFor reports who signed one commit and whether the signature is
+	// trusted. Verification never fails the call.
+	SignerFor(ctx context.Context, commit string) (CommitSigner, error)
 }
 
 // Revision identifies one commit in a file's history.
@@ -49,6 +53,9 @@ type Revision struct {
 	Timestamp time.Time
 	// Message is the commit subject.
 	Message string
+	// Signer describes who signed this revision, populated only when
+	// [RevisionOptions.WithSigners] is set; nil otherwise.
+	Signer *CommitSigner
 }
 
 // RevisionOptions bounds a [Reader.Revisions] page.
@@ -59,6 +66,9 @@ type RevisionOptions struct {
 	// Before, when set to a commit hash, returns only revisions strictly
 	// older than it — the pagination cursor. Empty starts at HEAD.
 	Before string
+	// WithSigners populates each returned revision's Signer via the same
+	// signature check as [Reader.SignerFor], folded into one git call.
+	WithSigners bool
 }
 
 // RevisionPage is one page of file history.
@@ -123,7 +133,7 @@ func (s *Store) Diff(ctx context.Context, from, to, filename string, format Diff
 func (s *Store) Revisions(ctx context.Context, filename string, opts RevisionOptions) (RevisionPage, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	return readRevisions(ctx, s.path, filename, opts)
+	return readRevisions(ctx, s.path, s.allowedSignersPath, filename, opts)
 }
 
 // --- *Verifier satisfies Reader (read-only, so a required root without a
@@ -152,7 +162,7 @@ func (v *Verifier) Diff(ctx context.Context, from, to, filename string, format D
 func (v *Verifier) Revisions(ctx context.Context, filename string, opts RevisionOptions) (RevisionPage, error) {
 	v.mu.Lock()
 	defer v.mu.Unlock()
-	return readRevisions(ctx, v.path, filename, opts)
+	return readRevisions(ctx, v.path, v.allowedSignersPath, filename, opts)
 }
 
 // --- shared implementations ---
@@ -202,7 +212,7 @@ func describeRevision(ctx context.Context, repoPath, filename, commit, selector 
 	if err != nil {
 		return Revision{}, fmt.Errorf("describe revision %s: %w", shorten(commit), err)
 	}
-	rev, err := parseRevisionLine(strings.TrimSpace(meta))
+	rev, err := parseRevisionLine(strings.TrimSpace(meta), false)
 	if err != nil {
 		return Revision{}, err
 	}
@@ -283,7 +293,7 @@ func diffNumstat(ctx context.Context, repoPath, from, to, filename string) (int,
 	return added, removed, nil
 }
 
-func readRevisions(ctx context.Context, repoPath, filename string, opts RevisionOptions) (RevisionPage, error) {
+func readRevisions(ctx context.Context, repoPath, allowedSignersPath, filename string, opts RevisionOptions) (RevisionPage, error) {
 	total := 0
 	if out, err := runGitText(ctx, repoPath, "rev-list", "--count", "HEAD", "--", filename); err == nil {
 		total, _ = strconv.Atoi(strings.TrimSpace(out))
@@ -304,9 +314,21 @@ func readRevisions(ctx context.Context, repoPath, filename string, opts Revision
 		start = before + "^"
 	}
 
-	// Fetch one extra to detect whether an older page exists.
-	meta, err := runGitText(ctx, repoPath, "log",
-		"--format=%H%x00%aI%x00%s", fmt.Sprintf("-n%d", limit+1), start, "--", filename)
+	// Fold signature attribution into the same log call when requested, so a
+	// page costs one git invocation rather than one verify per revision.
+	// Fetch one extra entry to detect whether an older page exists.
+	format := "%H%x00%aI%x00%s"
+	logArgs := func() []string {
+		return []string{"log", "--format=" + format, fmt.Sprintf("-n%d", limit+1), start, "--", filename}
+	}
+	var meta string
+	var err error
+	if opts.WithSigners {
+		format += "%x00%G?%x00%GS%x00%GF"
+		meta, err = runGitTextVerify(ctx, repoPath, allowedSignersPath, logArgs()...)
+	} else {
+		meta, err = runGitText(ctx, repoPath, logArgs()...)
+	}
 	if err != nil {
 		// An empty repo or an out-of-range cursor yields no history.
 		return RevisionPage{Total: total}, nil
@@ -317,7 +339,7 @@ func readRevisions(ctx context.Context, repoPath, filename string, opts Revision
 		if line == "" {
 			continue
 		}
-		rev, err := parseRevisionLine(line)
+		rev, err := parseRevisionLine(line, opts.WithSigners)
 		if err != nil {
 			return RevisionPage{}, err
 		}
@@ -346,22 +368,32 @@ func readRevisions(ctx context.Context, repoPath, filename string, opts Revision
 	return page, nil
 }
 
-// parseRevisionLine parses a "hash\x00RFC3339\x00subject" log line.
-func parseRevisionLine(line string) (Revision, error) {
-	parts := strings.SplitN(line, "\x00", 3)
-	if len(parts) != 3 {
+// parseRevisionLine parses a log line "hash\x00RFC3339\x00subject", optionally
+// followed by "\x00%G?\x00%GS\x00%GF" when withSigner is set.
+func parseRevisionLine(line string, withSigner bool) (Revision, error) {
+	fields := 3
+	if withSigner {
+		fields = 6
+	}
+	parts := strings.SplitN(line, "\x00", fields)
+	if len(parts) < 3 {
 		return Revision{}, fmt.Errorf("malformed revision line %q", line)
 	}
 	t, err := time.Parse(time.RFC3339, parts[1])
 	if err != nil {
 		return Revision{}, fmt.Errorf("parse revision timestamp %q: %w", parts[1], err)
 	}
-	return Revision{
+	rev := Revision{
 		Commit:    parts[0],
 		Short:     shorten(parts[0]),
 		Timestamp: t,
 		Message:   parts[2],
-	}, nil
+	}
+	if withSigner && len(parts) == 6 {
+		cs := parseCommitSigner(parts[3], parts[4], parts[5])
+		rev.Signer = &cs
+	}
+	return rev, nil
 }
 
 func shorten(hash string) string {

--- a/internal/platform/provenance/reader.go
+++ b/internal/platform/provenance/reader.go
@@ -168,10 +168,13 @@ func (v *Verifier) Revisions(ctx context.Context, filename string, opts Revision
 // --- shared implementations ---
 
 func resolveRevision(ctx context.Context, repoPath, filename, selector string) (Revision, error) {
+	if err := validateFilename(filename); err != nil {
+		return Revision{}, fmt.Errorf("resolve revision: %w", err)
+	}
 	sel := strings.TrimSpace(selector)
 	switch strings.ToLower(sel) {
 	case "", "head", "latest":
-		commit, err := runGitText(ctx, repoPath, "rev-list", "-1", "HEAD", "--", filename)
+		commit, err := runGitText(ctx, repoPath, "rev-list", "-1", "--end-of-options", "HEAD", "--", filename)
 		if err != nil {
 			return Revision{}, fmt.Errorf("resolve revision: %w", err)
 		}
@@ -180,15 +183,19 @@ func resolveRevision(ctx context.Context, repoPath, filename, selector string) (
 
 	if t, err := time.Parse(time.RFC3339, sel); err == nil {
 		commit, err := runGitText(ctx, repoPath, "rev-list", "-1",
-			"--before="+t.UTC().Format(time.RFC3339), "HEAD", "--", filename)
+			"--before="+t.UTC().Format(time.RFC3339), "--end-of-options", "HEAD", "--", filename)
 		if err != nil {
 			return Revision{}, fmt.Errorf("resolve revision at %s: %w", sel, err)
 		}
 		return describeRevision(ctx, repoPath, filename, strings.TrimSpace(commit), sel)
 	}
 
-	// Otherwise treat the selector as a commit-ish hash.
-	full, err := runGitText(ctx, repoPath, "rev-parse", "--verify", "--quiet", sel+"^{commit}")
+	// Otherwise treat the selector as a commit-ish hash. Validate it can't be
+	// mistaken for a git option before it reaches the command line.
+	if err := checkRevisionArg("revision", sel); err != nil {
+		return Revision{}, err
+	}
+	full, err := runGitText(ctx, repoPath, "rev-parse", "--verify", "--quiet", "--end-of-options", sel+"^{commit}")
 	if err != nil {
 		return Revision{}, fmt.Errorf("revision %q is not a known commit, timestamp, or HEAD", selector)
 	}
@@ -237,13 +244,19 @@ func revisionIndex(ctx context.Context, repoPath, filename, commit string) (int,
 }
 
 func readBlob(ctx context.Context, repoPath, rev, filename string) (string, error) {
+	if err := validateFilename(filename); err != nil {
+		return "", fmt.Errorf("read blob: %w", err)
+	}
 	rev = strings.TrimSpace(rev)
 	if rev == "" {
 		rev = "HEAD"
 	}
+	if err := checkRevisionArg("revision", rev); err != nil {
+		return "", err
+	}
 	// Raw content — no trimming, since a document's own leading/trailing
 	// whitespace is meaningful.
-	out, err := runGitText(ctx, repoPath, "show", rev+":"+filename)
+	out, err := runGitText(ctx, repoPath, "show", "--end-of-options", rev+":"+filename)
 	if err != nil {
 		return "", fmt.Errorf("read %s at %s: %w", filename, shorten(rev), err)
 	}
@@ -251,10 +264,19 @@ func readBlob(ctx context.Context, repoPath, rev, filename string) (string, erro
 }
 
 func readDiff(ctx context.Context, repoPath, from, to, filename string, format DiffFormat) (RevisionDiff, error) {
+	if err := validateFilename(filename); err != nil {
+		return RevisionDiff{}, fmt.Errorf("diff: %w", err)
+	}
 	if format != DiffPatch && format != DiffStat {
 		format = DiffPatch
 	}
 	from, to = strings.TrimSpace(from), strings.TrimSpace(to)
+	if err := checkRevisionArg("from", from); err != nil {
+		return RevisionDiff{}, err
+	}
+	if err := checkRevisionArg("to", to); err != nil {
+		return RevisionDiff{}, err
+	}
 
 	added, removed, err := diffNumstat(ctx, repoPath, from, to, filename)
 	if err != nil {
@@ -265,7 +287,7 @@ func readDiff(ctx context.Context, repoPath, from, to, filename string, format D
 	if format == DiffStat {
 		bodyArgs = append(bodyArgs, "--stat")
 	}
-	bodyArgs = append(bodyArgs, from, to, "--", filename)
+	bodyArgs = append(bodyArgs, "--end-of-options", from, to, "--", filename)
 	body, err := runGitText(ctx, repoPath, bodyArgs...)
 	if err != nil {
 		return RevisionDiff{}, fmt.Errorf("diff %s %s..%s: %w", filename, shorten(from), shorten(to), err)
@@ -276,7 +298,7 @@ func readDiff(ctx context.Context, repoPath, from, to, filename string, format D
 // diffNumstat returns the added/removed line counts for filename between two
 // revisions. Binary changes (numstat "-") report as zero.
 func diffNumstat(ctx context.Context, repoPath, from, to, filename string) (int, int, error) {
-	out, err := runGitText(ctx, repoPath, "diff", "--numstat", from, to, "--", filename)
+	out, err := runGitText(ctx, repoPath, "diff", "--numstat", "--end-of-options", from, to, "--", filename)
 	if err != nil {
 		return 0, 0, fmt.Errorf("diffstat %s: %w", filename, err)
 	}
@@ -294,8 +316,11 @@ func diffNumstat(ctx context.Context, repoPath, from, to, filename string) (int,
 }
 
 func readRevisions(ctx context.Context, repoPath, allowedSignersPath, filename string, opts RevisionOptions) (RevisionPage, error) {
+	if err := validateFilename(filename); err != nil {
+		return RevisionPage{}, fmt.Errorf("revisions: %w", err)
+	}
 	total := 0
-	if out, err := runGitText(ctx, repoPath, "rev-list", "--count", "HEAD", "--", filename); err == nil {
+	if out, err := runGitText(ctx, repoPath, "rev-list", "--count", "--end-of-options", "HEAD", "--", filename); err == nil {
 		total, _ = strconv.Atoi(strings.TrimSpace(out))
 	}
 
@@ -309,6 +334,14 @@ func readRevisions(ctx context.Context, repoPath, allowedSignersPath, filename s
 
 	start := "HEAD"
 	if before := strings.TrimSpace(opts.Before); before != "" {
+		if err := checkRevisionArg("before", before); err != nil {
+			return RevisionPage{}, err
+		}
+		// Surface an invalid cursor instead of masking it as an empty page.
+		if _, err := runGitText(ctx, repoPath, "rev-parse", "--verify", "--quiet",
+			"--end-of-options", before+"^{commit}"); err != nil {
+			return RevisionPage{}, fmt.Errorf("invalid pagination cursor %q", before)
+		}
 		// Exclude the cursor commit and everything newer; its first parent
 		// and older is the next page.
 		start = before + "^"
@@ -319,7 +352,7 @@ func readRevisions(ctx context.Context, repoPath, allowedSignersPath, filename s
 	// Fetch one extra entry to detect whether an older page exists.
 	format := "%H%x00%aI%x00%s"
 	logArgs := func() []string {
-		return []string{"log", "--format=" + format, fmt.Sprintf("-n%d", limit+1), start, "--", filename}
+		return []string{"log", "--format=" + format, fmt.Sprintf("-n%d", limit+1), "--end-of-options", start, "--", filename}
 	}
 	var meta string
 	var err error
@@ -402,6 +435,22 @@ func shorten(hash string) string {
 		return hash[:shortHashLen]
 	}
 	return hash
+}
+
+// checkRevisionArg rejects a revision or cursor value that git could mistake
+// for an option (argument injection): a legitimate ref, hash, or HEAD-ish
+// selector never begins with "-". Together with --end-of-options on the
+// commands and validateFilename on paths, this stops an untrusted caller from
+// smuggling git options through the read surface.
+func checkRevisionArg(kind, rev string) error {
+	rev = strings.TrimSpace(rev)
+	if rev == "" {
+		return fmt.Errorf("%s revision is empty", kind)
+	}
+	if strings.HasPrefix(rev, "-") {
+		return fmt.Errorf("%s revision %q must not begin with '-'", kind, rev)
+	}
+	return nil
 }
 
 // runGitText runs a read-only git command in repoPath and returns its raw

--- a/internal/platform/provenance/reader.go
+++ b/internal/platform/provenance/reader.go
@@ -1,0 +1,396 @@
+package provenance
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Reader exposes read-only revision history, diff, and point-in-time recall
+// over a git-backed store, scoped to a single file. Both [*Store] and
+// [*Verifier] satisfy it, so a verify-only root (which has a Verifier but no
+// Store) can still be read.
+//
+// filename is always repo-relative; callers that map a repository onto a
+// subtree translate the prefix before calling.
+type Reader interface {
+	// ResolveRevision maps a selector onto a concrete revision of filename.
+	// Accepted selectors: "" / "HEAD" / "latest" (newest commit touching the
+	// file), an RFC3339 timestamp (newest commit at or before it), or a
+	// commit-ish hash (must exist and the file must exist at it). Relative
+	// deltas are resolved to timestamps by the caller, not here.
+	ResolveRevision(ctx context.Context, filename, selector string) (Revision, error)
+
+	// Blob returns the file's content as of rev.
+	Blob(ctx context.Context, rev, filename string) (string, error)
+
+	// Diff returns the change to filename between two revisions.
+	Diff(ctx context.Context, from, to, filename string, format DiffFormat) (RevisionDiff, error)
+
+	// Revisions returns a page of the file's commit history, newest first.
+	Revisions(ctx context.Context, filename string, opts RevisionOptions) (RevisionPage, error)
+}
+
+// Revision identifies one commit in a file's history.
+type Revision struct {
+	// Commit is the full commit hash.
+	Commit string
+	// Short is a shortened hash for display.
+	Short string
+	// Index is the number of commits that touched this file and are strictly
+	// newer than this revision (0 for the newest). It is a reasoning aid, not
+	// an addressing token.
+	Index int
+	// Timestamp is the commit's author time.
+	Timestamp time.Time
+	// Message is the commit subject.
+	Message string
+}
+
+// RevisionOptions bounds a [Reader.Revisions] page.
+type RevisionOptions struct {
+	// Limit caps the page size. Non-positive uses the default; larger than
+	// the max is clamped.
+	Limit int
+	// Before, when set to a commit hash, returns only revisions strictly
+	// older than it — the pagination cursor. Empty starts at HEAD.
+	Before string
+}
+
+// RevisionPage is one page of file history.
+type RevisionPage struct {
+	// Revisions are ordered newest first.
+	Revisions []Revision
+	// Total is the file's full revision count.
+	Total int
+	// NextBefore is the cursor for the next (older) page, or "" when the page
+	// reached the end of history.
+	NextBefore string
+}
+
+// DiffFormat selects the body a [Reader.Diff] returns.
+type DiffFormat string
+
+const (
+	// DiffPatch returns a unified diff.
+	DiffPatch DiffFormat = "patch"
+	// DiffStat returns a diffstat summary.
+	DiffStat DiffFormat = "stat"
+)
+
+// RevisionDiff is the change to one file between two revisions.
+type RevisionDiff struct {
+	Format  DiffFormat
+	Added   int
+	Removed int
+	// Body is the unified diff (DiffPatch) or the diffstat (DiffStat).
+	Body string
+}
+
+const (
+	defaultRevisionLimit = 20
+	maxRevisionLimit     = 100
+	shortHashLen         = 12
+)
+
+// --- *Store satisfies Reader (locks the write mutex to stay consistent with
+// concurrent commits) ---
+
+var _ Reader = (*Store)(nil)
+
+func (s *Store) ResolveRevision(ctx context.Context, filename, selector string) (Revision, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return resolveRevision(ctx, s.path, filename, selector)
+}
+
+func (s *Store) Blob(ctx context.Context, rev, filename string) (string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return readBlob(ctx, s.path, rev, filename)
+}
+
+func (s *Store) Diff(ctx context.Context, from, to, filename string, format DiffFormat) (RevisionDiff, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return readDiff(ctx, s.path, from, to, filename, format)
+}
+
+func (s *Store) Revisions(ctx context.Context, filename string, opts RevisionOptions) (RevisionPage, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return readRevisions(ctx, s.path, filename, opts)
+}
+
+// --- *Verifier satisfies Reader (read-only, so a required root without a
+// Store can still be inspected) ---
+
+var _ Reader = (*Verifier)(nil)
+
+func (v *Verifier) ResolveRevision(ctx context.Context, filename, selector string) (Revision, error) {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	return resolveRevision(ctx, v.path, filename, selector)
+}
+
+func (v *Verifier) Blob(ctx context.Context, rev, filename string) (string, error) {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	return readBlob(ctx, v.path, rev, filename)
+}
+
+func (v *Verifier) Diff(ctx context.Context, from, to, filename string, format DiffFormat) (RevisionDiff, error) {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	return readDiff(ctx, v.path, from, to, filename, format)
+}
+
+func (v *Verifier) Revisions(ctx context.Context, filename string, opts RevisionOptions) (RevisionPage, error) {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	return readRevisions(ctx, v.path, filename, opts)
+}
+
+// --- shared implementations ---
+
+func resolveRevision(ctx context.Context, repoPath, filename, selector string) (Revision, error) {
+	sel := strings.TrimSpace(selector)
+	switch strings.ToLower(sel) {
+	case "", "head", "latest":
+		commit, err := runGitText(ctx, repoPath, "rev-list", "-1", "HEAD", "--", filename)
+		if err != nil {
+			return Revision{}, fmt.Errorf("resolve revision: %w", err)
+		}
+		return describeRevision(ctx, repoPath, filename, strings.TrimSpace(commit), sel)
+	}
+
+	if t, err := time.Parse(time.RFC3339, sel); err == nil {
+		commit, err := runGitText(ctx, repoPath, "rev-list", "-1",
+			"--before="+t.UTC().Format(time.RFC3339), "HEAD", "--", filename)
+		if err != nil {
+			return Revision{}, fmt.Errorf("resolve revision at %s: %w", sel, err)
+		}
+		return describeRevision(ctx, repoPath, filename, strings.TrimSpace(commit), sel)
+	}
+
+	// Otherwise treat the selector as a commit-ish hash.
+	full, err := runGitText(ctx, repoPath, "rev-parse", "--verify", "--quiet", sel+"^{commit}")
+	if err != nil {
+		return Revision{}, fmt.Errorf("revision %q is not a known commit, timestamp, or HEAD", selector)
+	}
+	commit := strings.TrimSpace(full)
+	// Per-file guardrail: the file must exist at that commit, so a real hash
+	// that has nothing to do with this document is rejected rather than
+	// silently returning an empty diff or blob.
+	if err := runGitCheck(ctx, repoPath, "cat-file", "-e", commit+":"+filename); err != nil {
+		return Revision{}, fmt.Errorf("file %s does not exist at revision %s", filename, shorten(commit))
+	}
+	return describeRevision(ctx, repoPath, filename, commit, sel)
+}
+
+// describeRevision fills a Revision for a resolved commit, or errors when no
+// commit matched the selector (empty commit).
+func describeRevision(ctx context.Context, repoPath, filename, commit, selector string) (Revision, error) {
+	if commit == "" {
+		return Revision{}, fmt.Errorf("no revision of %s at or before %q", filename, selector)
+	}
+	meta, err := runGitText(ctx, repoPath, "log", "-1", "--format=%H%x00%aI%x00%s", commit)
+	if err != nil {
+		return Revision{}, fmt.Errorf("describe revision %s: %w", shorten(commit), err)
+	}
+	rev, err := parseRevisionLine(strings.TrimSpace(meta))
+	if err != nil {
+		return Revision{}, err
+	}
+	rev.Index, err = revisionIndex(ctx, repoPath, filename, rev.Commit)
+	if err != nil {
+		return Revision{}, err
+	}
+	return rev, nil
+}
+
+// revisionIndex counts the file-touching commits strictly newer than commit.
+func revisionIndex(ctx context.Context, repoPath, filename, commit string) (int, error) {
+	out, err := runGitText(ctx, repoPath, "rev-list", "--count", commit+"..HEAD", "--", filename)
+	if err != nil {
+		return 0, fmt.Errorf("count revisions: %w", err)
+	}
+	n, err := strconv.Atoi(strings.TrimSpace(out))
+	if err != nil {
+		return 0, fmt.Errorf("parse revision index %q: %w", out, err)
+	}
+	return n, nil
+}
+
+func readBlob(ctx context.Context, repoPath, rev, filename string) (string, error) {
+	rev = strings.TrimSpace(rev)
+	if rev == "" {
+		rev = "HEAD"
+	}
+	// Raw content — no trimming, since a document's own leading/trailing
+	// whitespace is meaningful.
+	out, err := runGitText(ctx, repoPath, "show", rev+":"+filename)
+	if err != nil {
+		return "", fmt.Errorf("read %s at %s: %w", filename, shorten(rev), err)
+	}
+	return out, nil
+}
+
+func readDiff(ctx context.Context, repoPath, from, to, filename string, format DiffFormat) (RevisionDiff, error) {
+	if format != DiffPatch && format != DiffStat {
+		format = DiffPatch
+	}
+	from, to = strings.TrimSpace(from), strings.TrimSpace(to)
+
+	added, removed, err := diffNumstat(ctx, repoPath, from, to, filename)
+	if err != nil {
+		return RevisionDiff{}, err
+	}
+
+	bodyArgs := []string{"diff", "--no-color"}
+	if format == DiffStat {
+		bodyArgs = append(bodyArgs, "--stat")
+	}
+	bodyArgs = append(bodyArgs, from, to, "--", filename)
+	body, err := runGitText(ctx, repoPath, bodyArgs...)
+	if err != nil {
+		return RevisionDiff{}, fmt.Errorf("diff %s %s..%s: %w", filename, shorten(from), shorten(to), err)
+	}
+	return RevisionDiff{Format: format, Added: added, Removed: removed, Body: body}, nil
+}
+
+// diffNumstat returns the added/removed line counts for filename between two
+// revisions. Binary changes (numstat "-") report as zero.
+func diffNumstat(ctx context.Context, repoPath, from, to, filename string) (int, int, error) {
+	out, err := runGitText(ctx, repoPath, "diff", "--numstat", from, to, "--", filename)
+	if err != nil {
+		return 0, 0, fmt.Errorf("diffstat %s: %w", filename, err)
+	}
+	line := strings.TrimSpace(out)
+	if line == "" {
+		return 0, 0, nil
+	}
+	fields := strings.Fields(line)
+	if len(fields) < 2 {
+		return 0, 0, nil
+	}
+	added, _ := strconv.Atoi(fields[0])   // "-" (binary) → 0
+	removed, _ := strconv.Atoi(fields[1]) // "-" (binary) → 0
+	return added, removed, nil
+}
+
+func readRevisions(ctx context.Context, repoPath, filename string, opts RevisionOptions) (RevisionPage, error) {
+	total := 0
+	if out, err := runGitText(ctx, repoPath, "rev-list", "--count", "HEAD", "--", filename); err == nil {
+		total, _ = strconv.Atoi(strings.TrimSpace(out))
+	}
+
+	limit := opts.Limit
+	if limit <= 0 {
+		limit = defaultRevisionLimit
+	}
+	if limit > maxRevisionLimit {
+		limit = maxRevisionLimit
+	}
+
+	start := "HEAD"
+	if before := strings.TrimSpace(opts.Before); before != "" {
+		// Exclude the cursor commit and everything newer; its first parent
+		// and older is the next page.
+		start = before + "^"
+	}
+
+	// Fetch one extra to detect whether an older page exists.
+	meta, err := runGitText(ctx, repoPath, "log",
+		"--format=%H%x00%aI%x00%s", fmt.Sprintf("-n%d", limit+1), start, "--", filename)
+	if err != nil {
+		// An empty repo or an out-of-range cursor yields no history.
+		return RevisionPage{Total: total}, nil
+	}
+
+	var revs []Revision
+	for _, line := range strings.Split(strings.TrimSpace(meta), "\n") {
+		if line == "" {
+			continue
+		}
+		rev, err := parseRevisionLine(line)
+		if err != nil {
+			return RevisionPage{}, err
+		}
+		revs = append(revs, rev)
+	}
+	if len(revs) == 0 {
+		return RevisionPage{Total: total}, nil
+	}
+
+	// The first entry's index anchors the page; the rest follow sequentially.
+	baseIndex, err := revisionIndex(ctx, repoPath, filename, revs[0].Commit)
+	if err != nil {
+		return RevisionPage{}, err
+	}
+
+	page := RevisionPage{Total: total}
+	for i := range revs {
+		if i >= limit {
+			// The extra entry only signals a next page.
+			page.NextBefore = revs[limit-1].Commit
+			break
+		}
+		revs[i].Index = baseIndex + i
+		page.Revisions = append(page.Revisions, revs[i])
+	}
+	return page, nil
+}
+
+// parseRevisionLine parses a "hash\x00RFC3339\x00subject" log line.
+func parseRevisionLine(line string) (Revision, error) {
+	parts := strings.SplitN(line, "\x00", 3)
+	if len(parts) != 3 {
+		return Revision{}, fmt.Errorf("malformed revision line %q", line)
+	}
+	t, err := time.Parse(time.RFC3339, parts[1])
+	if err != nil {
+		return Revision{}, fmt.Errorf("parse revision timestamp %q: %w", parts[1], err)
+	}
+	return Revision{
+		Commit:    parts[0],
+		Short:     shorten(parts[0]),
+		Timestamp: t,
+		Message:   parts[2],
+	}, nil
+}
+
+func shorten(hash string) string {
+	hash = strings.TrimSpace(hash)
+	if len(hash) > shortHashLen {
+		return hash[:shortHashLen]
+	}
+	return hash
+}
+
+// runGitText runs a read-only git command in repoPath and returns its raw
+// stdout. Stderr is kept separate and surfaced only in the error, so it never
+// contaminates blob or diff output.
+func runGitText(ctx context.Context, repoPath string, args ...string) (string, error) {
+	cmd := exec.CommandContext(ctx, "git", append([]string{"-C", repoPath}, args...)...)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		if msg := strings.TrimSpace(stderr.String()); msg != "" {
+			return "", fmt.Errorf("%s: %w", msg, err)
+		}
+		return "", err
+	}
+	return stdout.String(), nil
+}
+
+// runGitCheck runs a git command only for its exit status.
+func runGitCheck(ctx context.Context, repoPath string, args ...string) error {
+	cmd := exec.CommandContext(ctx, "git", append([]string{"-C", repoPath}, args...)...)
+	return cmd.Run()
+}

--- a/internal/platform/provenance/reader.go
+++ b/internal/platform/provenance/reader.go
@@ -168,7 +168,7 @@ func (v *Verifier) Revisions(ctx context.Context, filename string, opts Revision
 // --- shared implementations ---
 
 func resolveRevision(ctx context.Context, repoPath, filename, selector string) (Revision, error) {
-	if err := validateFilename(filename); err != nil {
+	if err := validateReaderFilename(filename); err != nil {
 		return Revision{}, fmt.Errorf("resolve revision: %w", err)
 	}
 	sel := strings.TrimSpace(selector)
@@ -178,7 +178,9 @@ func resolveRevision(ctx context.Context, repoPath, filename, selector string) (
 		if err != nil {
 			return Revision{}, fmt.Errorf("resolve revision: %w", err)
 		}
-		return describeRevision(ctx, repoPath, filename, strings.TrimSpace(commit), sel)
+		// Label the resolved revision "HEAD" so a not-found error reads
+		// sensibly even when the caller passed the empty default selector.
+		return describeRevision(ctx, repoPath, filename, strings.TrimSpace(commit), "HEAD")
 	}
 
 	if t, err := time.Parse(time.RFC3339, sel); err == nil {
@@ -244,7 +246,7 @@ func revisionIndex(ctx context.Context, repoPath, filename, commit string) (int,
 }
 
 func readBlob(ctx context.Context, repoPath, rev, filename string) (string, error) {
-	if err := validateFilename(filename); err != nil {
+	if err := validateReaderFilename(filename); err != nil {
 		return "", fmt.Errorf("read blob: %w", err)
 	}
 	rev = strings.TrimSpace(rev)
@@ -264,7 +266,7 @@ func readBlob(ctx context.Context, repoPath, rev, filename string) (string, erro
 }
 
 func readDiff(ctx context.Context, repoPath, from, to, filename string, format DiffFormat) (RevisionDiff, error) {
-	if err := validateFilename(filename); err != nil {
+	if err := validateReaderFilename(filename); err != nil {
 		return RevisionDiff{}, fmt.Errorf("diff: %w", err)
 	}
 	if format != DiffPatch && format != DiffStat {
@@ -316,7 +318,7 @@ func diffNumstat(ctx context.Context, repoPath, from, to, filename string) (int,
 }
 
 func readRevisions(ctx context.Context, repoPath, allowedSignersPath, filename string, opts RevisionOptions) (RevisionPage, error) {
-	if err := validateFilename(filename); err != nil {
+	if err := validateReaderFilename(filename); err != nil {
 		return RevisionPage{}, fmt.Errorf("revisions: %w", err)
 	}
 	total := 0
@@ -453,11 +455,27 @@ func checkRevisionArg(kind, rev string) error {
 	return nil
 }
 
+// validateReaderFilename applies validateFilename (no absolute paths or
+// traversal) and additionally rejects a leading ":" — the git pathspec-magic
+// sigil. --literal-pathspecs already neutralizes magic at the command line;
+// this rejects it early with a clear message.
+func validateReaderFilename(filename string) error {
+	if err := validateFilename(filename); err != nil {
+		return err
+	}
+	if strings.HasPrefix(strings.TrimSpace(filename), ":") {
+		return fmt.Errorf("filename %q must not begin with ':' (git pathspec magic)", filename)
+	}
+	return nil
+}
+
 // runGitText runs a read-only git command in repoPath and returns its raw
 // stdout. Stderr is kept separate and surfaced only in the error, so it never
-// contaminates blob or diff output.
+// contaminates blob or diff output. --literal-pathspecs disables git pathspec
+// magic (":(...)", ":!", ":^", …) so a caller-supplied path after "--" cannot
+// broaden a per-file query beyond the single file.
 func runGitText(ctx context.Context, repoPath string, args ...string) (string, error) {
-	cmd := exec.CommandContext(ctx, "git", append([]string{"-C", repoPath}, args...)...)
+	cmd := exec.CommandContext(ctx, "git", append([]string{"-C", repoPath, "--literal-pathspecs"}, args...)...)
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
@@ -472,6 +490,6 @@ func runGitText(ctx context.Context, repoPath string, args ...string) (string, e
 
 // runGitCheck runs a git command only for its exit status.
 func runGitCheck(ctx context.Context, repoPath string, args ...string) error {
-	cmd := exec.CommandContext(ctx, "git", append([]string{"-C", repoPath}, args...)...)
+	cmd := exec.CommandContext(ctx, "git", append([]string{"-C", repoPath, "--literal-pathspecs"}, args...)...)
 	return cmd.Run()
 }

--- a/internal/platform/provenance/reader_test.go
+++ b/internal/platform/provenance/reader_test.go
@@ -209,3 +209,38 @@ func TestReaderVerifierSatisfiesReader(t *testing.T) {
 		t.Fatalf("Verifier.Blob = %q, %v", got, err)
 	}
 }
+
+// TestReaderRejectsArgumentInjection locks in the hardening: option-like
+// revisions, traversal/absolute paths, and bad cursors are refused before
+// reaching git.
+func TestReaderRejectsArgumentInjection(t *testing.T) {
+	s := buildReaderRepo(t)
+	ctx := t.Context()
+
+	if _, err := s.ResolveRevision(ctx, "kb/doc.md", "--output=/tmp/x"); err == nil {
+		t.Fatal("ResolveRevision accepted an option-like selector")
+	}
+	if _, err := s.Blob(ctx, "--upload-pack=x", "kb/doc.md"); err == nil {
+		t.Fatal("Blob accepted an option-like revision")
+	}
+	if _, err := s.Diff(ctx, "-O/tmp/x", "HEAD", "kb/doc.md", DiffPatch); err == nil {
+		t.Fatal("Diff accepted an option-like from")
+	}
+	if _, err := s.SignerFor(ctx, "--foo"); err == nil {
+		t.Fatal("SignerFor accepted an option-like commit")
+	}
+
+	// Path traversal and absolute paths are refused.
+	if _, err := s.ResolveRevision(ctx, "../escape.md", "HEAD"); err == nil {
+		t.Fatal("ResolveRevision accepted a traversal path")
+	}
+	if _, err := s.Blob(ctx, "HEAD", "/etc/passwd"); err == nil {
+		t.Fatal("Blob accepted an absolute path")
+	}
+
+	// A syntactically valid but nonexistent cursor surfaces an error rather
+	// than masking as an empty page.
+	if _, err := s.Revisions(ctx, "kb/doc.md", RevisionOptions{Before: "deadbeefcafe"}); err == nil {
+		t.Fatal("Revisions accepted an invalid pagination cursor")
+	}
+}

--- a/internal/platform/provenance/reader_test.go
+++ b/internal/platform/provenance/reader_test.go
@@ -237,6 +237,9 @@ func TestReaderRejectsArgumentInjection(t *testing.T) {
 	if _, err := s.Blob(ctx, "HEAD", "/etc/passwd"); err == nil {
 		t.Fatal("Blob accepted an absolute path")
 	}
+	if _, err := s.Blob(ctx, "HEAD", ":(exclude)kb/doc.md"); err == nil {
+		t.Fatal("Blob accepted a git pathspec-magic filename")
+	}
 
 	// A syntactically valid but nonexistent cursor surfaces an error rather
 	// than masking as an empty page.

--- a/internal/platform/provenance/reader_test.go
+++ b/internal/platform/provenance/reader_test.go
@@ -1,0 +1,211 @@
+package provenance
+
+import (
+	"log/slog"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+)
+
+// buildReaderRepo creates a store with three signed revisions of kb/doc.md:
+// "a\n" -> "a\nb\n" -> "a\nb\nc\n" (messages first/second/third).
+func buildReaderRepo(t *testing.T) *Store {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	dir := t.TempDir()
+	s, err := New(dir, testSigner(t), slog.Default())
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	for _, step := range []struct{ content, msg string }{
+		{"a\n", "first"},
+		{"a\nb\n", "second"},
+		{"a\nb\nc\n", "third"},
+	} {
+		if err := s.Write(t.Context(), "kb/doc.md", step.content, step.msg); err != nil {
+			t.Fatalf("Write %q: %v", step.msg, err)
+		}
+	}
+	return s
+}
+
+func TestReaderRevisions(t *testing.T) {
+	s := buildReaderRepo(t)
+	ctx := t.Context()
+
+	page, err := s.Revisions(ctx, "kb/doc.md", RevisionOptions{})
+	if err != nil {
+		t.Fatalf("Revisions: %v", err)
+	}
+	if page.Total != 3 {
+		t.Fatalf("Total = %d, want 3", page.Total)
+	}
+	if len(page.Revisions) != 3 {
+		t.Fatalf("len(Revisions) = %d, want 3", len(page.Revisions))
+	}
+	wantMsgs := []string{"third", "second", "first"}
+	for i, rev := range page.Revisions {
+		if rev.Message != wantMsgs[i] {
+			t.Fatalf("Revisions[%d].Message = %q, want %q", i, rev.Message, wantMsgs[i])
+		}
+		if rev.Index != i {
+			t.Fatalf("Revisions[%d].Index = %d, want %d", i, rev.Index, i)
+		}
+		if rev.Short == "" || len(rev.Short) > len(rev.Commit) {
+			t.Fatalf("Revisions[%d].Short = %q (commit %q)", i, rev.Short, rev.Commit)
+		}
+	}
+	if page.NextBefore != "" {
+		t.Fatalf("NextBefore = %q, want empty at end of history", page.NextBefore)
+	}
+}
+
+func TestReaderRevisionsPagination(t *testing.T) {
+	s := buildReaderRepo(t)
+	ctx := t.Context()
+
+	first, err := s.Revisions(ctx, "kb/doc.md", RevisionOptions{Limit: 2})
+	if err != nil {
+		t.Fatalf("Revisions page 1: %v", err)
+	}
+	if len(first.Revisions) != 2 || first.NextBefore == "" {
+		t.Fatalf("page 1 = %d revs, NextBefore=%q; want 2 and a cursor", len(first.Revisions), first.NextBefore)
+	}
+	if first.Revisions[0].Message != "third" || first.Revisions[1].Message != "second" {
+		t.Fatalf("page 1 messages = %q/%q, want third/second", first.Revisions[0].Message, first.Revisions[1].Message)
+	}
+
+	second, err := s.Revisions(ctx, "kb/doc.md", RevisionOptions{Limit: 2, Before: first.NextBefore})
+	if err != nil {
+		t.Fatalf("Revisions page 2: %v", err)
+	}
+	if len(second.Revisions) != 1 || second.NextBefore != "" {
+		t.Fatalf("page 2 = %d revs, NextBefore=%q; want 1 and no cursor", len(second.Revisions), second.NextBefore)
+	}
+	if second.Revisions[0].Message != "first" {
+		t.Fatalf("page 2 message = %q, want first", second.Revisions[0].Message)
+	}
+	if second.Revisions[0].Index != 2 {
+		t.Fatalf("page 2 index = %d, want 2", second.Revisions[0].Index)
+	}
+}
+
+func TestReaderResolveRevision(t *testing.T) {
+	s := buildReaderRepo(t)
+	ctx := t.Context()
+
+	head, err := s.ResolveRevision(ctx, "kb/doc.md", "HEAD")
+	if err != nil {
+		t.Fatalf("resolve HEAD: %v", err)
+	}
+	if head.Message != "third" || head.Index != 0 {
+		t.Fatalf("HEAD = %q idx %d, want third idx 0", head.Message, head.Index)
+	}
+	if latest, err := s.ResolveRevision(ctx, "kb/doc.md", "latest"); err != nil || latest.Commit != head.Commit {
+		t.Fatalf("latest = %+v, %v; want same as HEAD", latest, err)
+	}
+
+	// Resolve the middle commit by hash and confirm its index.
+	page, _ := s.Revisions(ctx, "kb/doc.md", RevisionOptions{})
+	mid := page.Revisions[1] // "second"
+	byHash, err := s.ResolveRevision(ctx, "kb/doc.md", mid.Commit)
+	if err != nil {
+		t.Fatalf("resolve by hash: %v", err)
+	}
+	if byHash.Commit != mid.Commit || byHash.Index != 1 {
+		t.Fatalf("byHash = %q idx %d, want %q idx 1", byHash.Commit, byHash.Index, mid.Commit)
+	}
+
+	// A timestamp at/after HEAD resolves to the newest commit; one before the
+	// first commit resolves to nothing. Use the commits' real times so this
+	// doesn't depend on git's handling of far-future dates.
+	afterHead := head.Timestamp.Add(time.Second).UTC().Format(time.RFC3339)
+	if at, err := s.ResolveRevision(ctx, "kb/doc.md", afterHead); err != nil || at.Commit != head.Commit {
+		t.Fatalf("timestamp after HEAD = %+v, %v; want newest", at, err)
+	}
+	beforeFirst := page.Revisions[2].Timestamp.Add(-time.Second).UTC().Format(time.RFC3339)
+	if _, err := s.ResolveRevision(ctx, "kb/doc.md", beforeFirst); err == nil {
+		t.Fatal("timestamp before the first commit resolved a revision, want error")
+	}
+
+	// Unknown selector and a missing file both error.
+	if _, err := s.ResolveRevision(ctx, "kb/doc.md", "deadbeefcafe"); err == nil {
+		t.Fatal("unknown selector resolved, want error")
+	}
+	if _, err := s.ResolveRevision(ctx, "kb/missing.md", "HEAD"); err == nil {
+		t.Fatal("missing file resolved, want error")
+	}
+}
+
+func TestReaderResolveHashRejectsFileNotAtCommit(t *testing.T) {
+	s := buildReaderRepo(t)
+	ctx := t.Context()
+	// A commit exists (HEAD), but a different file did not exist at it.
+	head, _ := s.ResolveRevision(ctx, "kb/doc.md", "HEAD")
+	if _, err := s.ResolveRevision(ctx, "kb/other.md", head.Commit); err == nil {
+		t.Fatal("resolved a hash for a file that never existed there, want error")
+	}
+}
+
+func TestReaderBlob(t *testing.T) {
+	s := buildReaderRepo(t)
+	ctx := t.Context()
+
+	if got, err := s.Blob(ctx, "HEAD", "kb/doc.md"); err != nil || got != "a\nb\nc\n" {
+		t.Fatalf("Blob HEAD = %q, %v; want \"a\\nb\\nc\\n\"", got, err)
+	}
+	page, _ := s.Revisions(ctx, "kb/doc.md", RevisionOptions{})
+	firstCommit := page.Revisions[2].Commit
+	if got, err := s.Blob(ctx, firstCommit, "kb/doc.md"); err != nil || got != "a\n" {
+		t.Fatalf("Blob first = %q, %v; want \"a\\n\"", got, err)
+	}
+}
+
+func TestReaderDiff(t *testing.T) {
+	s := buildReaderRepo(t)
+	ctx := t.Context()
+	page, _ := s.Revisions(ctx, "kb/doc.md", RevisionOptions{})
+	first := page.Revisions[2].Commit
+	head := page.Revisions[0].Commit
+
+	diff, err := s.Diff(ctx, first, head, "kb/doc.md", DiffPatch)
+	if err != nil {
+		t.Fatalf("Diff: %v", err)
+	}
+	if diff.Added != 2 || diff.Removed != 0 {
+		t.Fatalf("Diff counts = +%d/-%d, want +2/-0", diff.Added, diff.Removed)
+	}
+	if !strings.Contains(diff.Body, "+b") || !strings.Contains(diff.Body, "+c") {
+		t.Fatalf("Diff body missing added lines:\n%s", diff.Body)
+	}
+	// Diff body must speak clean patch — never leak stderr noise.
+	if strings.Contains(diff.Body, "fatal:") {
+		t.Fatalf("Diff body contains stderr noise:\n%s", diff.Body)
+	}
+}
+
+// TestReaderVerifierSatisfiesReader confirms a Verifier (no Store) reads the
+// same history — the reason Reader is an interface both implement.
+func TestReaderVerifierSatisfiesReader(t *testing.T) {
+	s := buildReaderRepo(t)
+	ctx := t.Context()
+
+	verifier, err := NewVerifier(s.path, slog.Default(), Options{})
+	if err != nil {
+		t.Fatalf("NewVerifier: %v", err)
+	}
+	var r Reader = verifier
+	page, err := r.Revisions(ctx, "kb/doc.md", RevisionOptions{})
+	if err != nil {
+		t.Fatalf("Verifier.Revisions: %v", err)
+	}
+	if page.Total != 3 || len(page.Revisions) != 3 {
+		t.Fatalf("Verifier history = %d/%d, want 3/3", page.Total, len(page.Revisions))
+	}
+	if got, err := r.Blob(ctx, "HEAD", "kb/doc.md"); err != nil || got != "a\nb\nc\n" {
+		t.Fatalf("Verifier.Blob = %q, %v", got, err)
+	}
+}

--- a/internal/platform/provenance/signer.go
+++ b/internal/platform/provenance/signer.go
@@ -1,0 +1,122 @@
+package provenance
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+// CommitSigner describes who signed a commit and whether the signature is
+// trusted against the repository's allowed_signers. It is additive — the
+// boolean VerifyFile/VerifyTree contract is unchanged — and lets revision
+// history distinguish an agent-authored commit from an operator's.
+type CommitSigner struct {
+	// Verified is true only for a good signature by a trusted key.
+	Verified bool
+	// Principal is the allowed_signers identity that signed (for example
+	// "thane@provenance.local" or "alice@example.com"), when git reports one.
+	Principal string
+	// Kind classifies the principal: "agent", "operator", or "unknown".
+	Kind string
+	// KeyFingerprint is the signing key's fingerprint, when git reports one.
+	KeyFingerprint string
+	// Reason explains a non-verified result (for example "signer not in
+	// allow-list" or "unsigned"). Empty when Verified is true.
+	Reason string
+}
+
+const (
+	signerKindAgent    = "agent"
+	signerKindOperator = "operator"
+	signerKindUnknown  = "unknown"
+)
+
+// SignerFor reports who signed one commit. Verification never fails the call:
+// an unsigned or untrusted commit is a valid, reportable result, not an error.
+func (s *Store) SignerFor(ctx context.Context, commit string) (CommitSigner, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return signerFor(ctx, s.path, s.allowedSignersPath, commit)
+}
+
+// SignerFor reports who signed one commit (verify-only path).
+func (v *Verifier) SignerFor(ctx context.Context, commit string) (CommitSigner, error) {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	return signerFor(ctx, v.path, v.allowedSignersPath, commit)
+}
+
+func signerFor(ctx context.Context, repoPath, allowedSignersPath, commit string) (CommitSigner, error) {
+	out, err := runGitTextVerify(ctx, repoPath, allowedSignersPath,
+		"log", "-1", "--format=%G?%x00%GS%x00%GF", commit)
+	if err != nil {
+		return CommitSigner{}, fmt.Errorf("read signer for %s: %w", shorten(commit), err)
+	}
+	verdict, principal, fingerprint := splitSignerFields(out)
+	return parseCommitSigner(verdict, principal, fingerprint), nil
+}
+
+// splitSignerFields splits a NUL-delimited "%G?\x00%GS\x00%GF" line, padding
+// missing trailing fields.
+func splitSignerFields(line string) (verdict, principal, fingerprint string) {
+	parts := strings.SplitN(strings.TrimRight(line, "\n"), "\x00", 3)
+	for len(parts) < 3 {
+		parts = append(parts, "")
+	}
+	return parts[0], parts[1], parts[2]
+}
+
+// parseCommitSigner maps git's %G? verdict, %GS signer, and %GF fingerprint
+// onto a CommitSigner. Only "G" (good, trusted) counts as verified.
+func parseCommitSigner(verdict, principal, fingerprint string) CommitSigner {
+	cs := CommitSigner{
+		Principal:      strings.TrimSpace(principal),
+		KeyFingerprint: strings.TrimSpace(fingerprint),
+	}
+	switch strings.TrimSpace(verdict) {
+	case "G":
+		cs.Verified = true
+	case "U":
+		cs.Reason = "signature valid but signer not in allow-list"
+	case "B":
+		cs.Reason = "bad signature"
+	case "X":
+		cs.Reason = "signature outside the key's validity window"
+	case "Y":
+		cs.Reason = "signing key expired"
+	case "R":
+		cs.Reason = "signing key revoked"
+	case "E":
+		cs.Reason = "signature cannot be verified"
+	case "N", "":
+		cs.Reason = "unsigned"
+	default:
+		cs.Reason = "unrecognized verification result " + strings.TrimSpace(verdict)
+	}
+	cs.Kind = signerKind(cs.Principal)
+	return cs
+}
+
+// signerKind classifies a principal. The agent's own principal is the trust
+// anchor; any other named principal is an operator; an empty one is unknown.
+func signerKind(principal string) string {
+	switch principal {
+	case "":
+		return signerKindUnknown
+	case AgentPrincipal:
+		return signerKindAgent
+	default:
+		return signerKindOperator
+	}
+}
+
+// runGitTextVerify runs a read-only git command with SSH signature
+// verification enabled: it injects the allowed_signers file when one is
+// configured (a verify-only Verifier), and otherwise relies on the repo-local
+// git config a Store already set at init.
+func runGitTextVerify(ctx context.Context, repoPath, allowedSignersPath string, args ...string) (string, error) {
+	if strings.TrimSpace(allowedSignersPath) != "" {
+		args = append([]string{"-c", "gpg.ssh.allowedSignersFile=" + allowedSignersPath}, args...)
+	}
+	return runGitText(ctx, repoPath, args...)
+}

--- a/internal/platform/provenance/signer.go
+++ b/internal/platform/provenance/signer.go
@@ -47,8 +47,11 @@ func (v *Verifier) SignerFor(ctx context.Context, commit string) (CommitSigner, 
 }
 
 func signerFor(ctx context.Context, repoPath, allowedSignersPath, commit string) (CommitSigner, error) {
+	if err := checkRevisionArg("commit", commit); err != nil {
+		return CommitSigner{}, err
+	}
 	out, err := runGitTextVerify(ctx, repoPath, allowedSignersPath,
-		"log", "-1", "--format=%G?%x00%GS%x00%GF", commit)
+		"log", "-1", "--format=%G?%x00%GS%x00%GF", "--end-of-options", commit)
 	if err != nil {
 		return CommitSigner{}, fmt.Errorf("read signer for %s: %w", shorten(commit), err)
 	}

--- a/internal/platform/provenance/signer.go
+++ b/internal/platform/provenance/signer.go
@@ -16,7 +16,8 @@ type CommitSigner struct {
 	// Principal is the allowed_signers identity that signed (for example
 	// "thane@provenance.local" or "alice@example.com"), when git reports one.
 	Principal string
-	// Kind classifies the principal: "agent", "operator", or "unknown".
+	// Kind classifies the principal, one of [SignerKindAgent],
+	// [SignerKindOperator], or [SignerKindUnknown].
 	Kind string
 	// KeyFingerprint is the signing key's fingerprint, when git reports one.
 	KeyFingerprint string
@@ -26,9 +27,9 @@ type CommitSigner struct {
 }
 
 const (
-	signerKindAgent    = "agent"
-	signerKindOperator = "operator"
-	signerKindUnknown  = "unknown"
+	SignerKindAgent    = "agent"
+	SignerKindOperator = "operator"
+	SignerKindUnknown  = "unknown"
 )
 
 // SignerFor reports who signed one commit. Verification never fails the call:
@@ -105,11 +106,11 @@ func parseCommitSigner(verdict, principal, fingerprint string) CommitSigner {
 func signerKind(principal string) string {
 	switch principal {
 	case "":
-		return signerKindUnknown
+		return SignerKindUnknown
 	case AgentPrincipal:
-		return signerKindAgent
+		return SignerKindAgent
 	default:
-		return signerKindOperator
+		return SignerKindOperator
 	}
 }
 

--- a/internal/platform/provenance/signer_test.go
+++ b/internal/platform/provenance/signer_test.go
@@ -1,0 +1,127 @@
+package provenance
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestParseCommitSigner(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name         string
+		verdict      string
+		principal    string
+		wantVerified bool
+		wantKind     string
+		wantReason   string // substring; "" means Reason must be empty
+	}{
+		{"agent good", "G", AgentPrincipal, true, signerKindAgent, ""},
+		{"operator good", "G", "alice@example.com", true, signerKindOperator, ""},
+		{"valid but untrusted", "U", "", false, signerKindUnknown, "allow-list"},
+		{"unsigned", "N", "", false, signerKindUnknown, "unsigned"},
+		{"empty verdict is unsigned", "", "", false, signerKindUnknown, "unsigned"},
+		{"bad signature", "B", "", false, signerKindUnknown, "bad"},
+		{"cannot verify", "E", "", false, signerKindUnknown, "cannot"},
+		{"revoked", "R", "bob@example.com", false, signerKindOperator, "revoked"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			cs := parseCommitSigner(tc.verdict, tc.principal, "SHA256:fp")
+			if cs.Verified != tc.wantVerified {
+				t.Fatalf("Verified = %v, want %v", cs.Verified, tc.wantVerified)
+			}
+			if cs.Kind != tc.wantKind {
+				t.Fatalf("Kind = %q, want %q", cs.Kind, tc.wantKind)
+			}
+			if tc.wantReason == "" {
+				if cs.Reason != "" {
+					t.Fatalf("Reason = %q, want empty", cs.Reason)
+				}
+			} else if !strings.Contains(cs.Reason, tc.wantReason) {
+				t.Fatalf("Reason = %q, want containing %q", cs.Reason, tc.wantReason)
+			}
+		})
+	}
+}
+
+func TestSignerForAgentCommit(t *testing.T) {
+	s := buildReaderRepo(t)
+	ctx := t.Context()
+
+	head, err := s.ResolveRevision(ctx, "kb/doc.md", "HEAD")
+	if err != nil {
+		t.Fatalf("resolve HEAD: %v", err)
+	}
+	cs, err := s.SignerFor(ctx, head.Commit)
+	if err != nil {
+		t.Fatalf("SignerFor: %v", err)
+	}
+	if !cs.Verified {
+		t.Fatalf("agent commit not verified: %+v", cs)
+	}
+	if cs.Kind != signerKindAgent {
+		t.Fatalf("Kind = %q, want agent", cs.Kind)
+	}
+	if cs.Principal != AgentPrincipal {
+		t.Fatalf("Principal = %q, want %q", cs.Principal, AgentPrincipal)
+	}
+	if cs.Reason != "" {
+		t.Fatalf("Reason = %q, want empty for a verified commit", cs.Reason)
+	}
+}
+
+func TestSignerForUntrusted(t *testing.T) {
+	s := buildReaderRepo(t)
+	ctx := t.Context()
+	head, _ := s.ResolveRevision(ctx, "kb/doc.md", "HEAD")
+
+	// Replace the trust file with a different key: HEAD's signature is still
+	// cryptographically intact, but its signer is no longer trusted.
+	other := testSigner(t)
+	if err := os.WriteFile(filepath.Join(s.path, ".allowed_signers"),
+		[]byte(AgentPrincipal+" "+other.PublicKey()+"\n"), 0o644); err != nil {
+		t.Fatalf("overwrite .allowed_signers: %v", err)
+	}
+	cs, err := s.SignerFor(ctx, head.Commit)
+	if err != nil {
+		t.Fatalf("SignerFor: %v", err)
+	}
+	if cs.Verified {
+		t.Fatalf("untrusted commit reported verified: %+v", cs)
+	}
+	if cs.Reason == "" {
+		t.Fatal("untrusted commit has empty Reason")
+	}
+}
+
+func TestRevisionsWithSigners(t *testing.T) {
+	s := buildReaderRepo(t)
+	ctx := t.Context()
+
+	// Without the option, signers are not populated.
+	plain, err := s.Revisions(ctx, "kb/doc.md", RevisionOptions{})
+	if err != nil {
+		t.Fatalf("Revisions: %v", err)
+	}
+	if plain.Revisions[0].Signer != nil {
+		t.Fatalf("Signer populated without WithSigners: %+v", plain.Revisions[0].Signer)
+	}
+
+	page, err := s.Revisions(ctx, "kb/doc.md", RevisionOptions{WithSigners: true})
+	if err != nil {
+		t.Fatalf("Revisions WithSigners: %v", err)
+	}
+	if len(page.Revisions) != 3 {
+		t.Fatalf("len = %d, want 3", len(page.Revisions))
+	}
+	for i, rev := range page.Revisions {
+		if rev.Signer == nil {
+			t.Fatalf("Revisions[%d].Signer is nil with WithSigners", i)
+		}
+		if !rev.Signer.Verified || rev.Signer.Kind != signerKindAgent {
+			t.Fatalf("Revisions[%d].Signer = %+v, want verified agent", i, rev.Signer)
+		}
+	}
+}

--- a/internal/platform/provenance/signer_test.go
+++ b/internal/platform/provenance/signer_test.go
@@ -17,14 +17,14 @@ func TestParseCommitSigner(t *testing.T) {
 		wantKind     string
 		wantReason   string // substring; "" means Reason must be empty
 	}{
-		{"agent good", "G", AgentPrincipal, true, signerKindAgent, ""},
-		{"operator good", "G", "alice@example.com", true, signerKindOperator, ""},
-		{"valid but untrusted", "U", "", false, signerKindUnknown, "allow-list"},
-		{"unsigned", "N", "", false, signerKindUnknown, "unsigned"},
-		{"empty verdict is unsigned", "", "", false, signerKindUnknown, "unsigned"},
-		{"bad signature", "B", "", false, signerKindUnknown, "bad"},
-		{"cannot verify", "E", "", false, signerKindUnknown, "cannot"},
-		{"revoked", "R", "bob@example.com", false, signerKindOperator, "revoked"},
+		{"agent good", "G", AgentPrincipal, true, SignerKindAgent, ""},
+		{"operator good", "G", "alice@example.com", true, SignerKindOperator, ""},
+		{"valid but untrusted", "U", "", false, SignerKindUnknown, "allow-list"},
+		{"unsigned", "N", "", false, SignerKindUnknown, "unsigned"},
+		{"empty verdict is unsigned", "", "", false, SignerKindUnknown, "unsigned"},
+		{"bad signature", "B", "", false, SignerKindUnknown, "bad"},
+		{"cannot verify", "E", "", false, SignerKindUnknown, "cannot"},
+		{"revoked", "R", "bob@example.com", false, SignerKindOperator, "revoked"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
@@ -61,7 +61,7 @@ func TestSignerForAgentCommit(t *testing.T) {
 	if !cs.Verified {
 		t.Fatalf("agent commit not verified: %+v", cs)
 	}
-	if cs.Kind != signerKindAgent {
+	if cs.Kind != SignerKindAgent {
 		t.Fatalf("Kind = %q, want agent", cs.Kind)
 	}
 	if cs.Principal != AgentPrincipal {
@@ -75,7 +75,10 @@ func TestSignerForAgentCommit(t *testing.T) {
 func TestSignerForUntrusted(t *testing.T) {
 	s := buildReaderRepo(t)
 	ctx := t.Context()
-	head, _ := s.ResolveRevision(ctx, "kb/doc.md", "HEAD")
+	head, err := s.ResolveRevision(ctx, "kb/doc.md", "HEAD")
+	if err != nil {
+		t.Fatalf("resolve HEAD: %v", err)
+	}
 
 	// Replace the trust file with a different key: HEAD's signature is still
 	// cryptographically intact, but its signer is no longer trusted.
@@ -120,7 +123,7 @@ func TestRevisionsWithSigners(t *testing.T) {
 		if rev.Signer == nil {
 			t.Fatalf("Revisions[%d].Signer is nil with WithSigners", i)
 		}
-		if !rev.Signer.Verified || rev.Signer.Kind != signerKindAgent {
+		if !rev.Signer.Verified || rev.Signer.Kind != SignerKindAgent {
 			t.Fatalf("Revisions[%d].Signer = %+v, want verified agent", i, rev.Signer)
 		}
 	}

--- a/scripts/architecture.baseline
+++ b/scripts/architecture.baseline
@@ -1,5 +1,5 @@
 packages=62
-interfaces=80
+interfaces=81
 large_files=49
 set_mutators=111
 database_opens=9


### PR DESCRIPTION
## What

The internal, read-only foundation for the revision tools (#1136) — no model surface yet. It adds `provenance.Reader` plus per-revision signer attribution, hardened against argument injection. The `doc_history` / `doc_diff` / `doc_at` tools will sit on top of this in a later PR.

## `provenance.Reader`

A per-file, read-only view over a git-backed store:

```go
type Reader interface {
	ResolveRevision(ctx, filename, selector string) (Revision, error)
	Blob(ctx, rev, filename string) (string, error)
	Diff(ctx, from, to, filename string, format DiffFormat) (RevisionDiff, error)
	Revisions(ctx, filename string, opts RevisionOptions) (RevisionPage, error)
	SignerFor(ctx, commit string) (CommitSigner, error)
}
```

- **`ResolveRevision`** maps `""`/`HEAD`/`latest`, an RFC3339 timestamp, or a commit hash onto a concrete revision, with the per-file guardrail that a hash where the file never existed is rejected.
- **`Blob`** returns content at a revision (untrimmed — document whitespace matters).
- **`Diff`** returns a unified patch or diffstat, always with `+/-` counts.
- **`Revisions`** returns a newest-first page with `Total` and a `NextBefore` cursor; each `Revision` carries an `Index` reasoning aid.

The architectural point: `Reader` is an interface because **both `*Store` and `*Verifier` satisfy it** — a `required` verify-only root has no `Store` but is exactly what you want history on, so the read path works without a writer.

## `CommitSigner` attribution

An additive raw-verify parse (`%G?` / `%GS` / `%GF`) that reports who signed a commit and whether it's trusted, without touching the boolean `VerifyFile`/`VerifyTree` contract. It classifies the principal as **agent** (the trust anchor), **operator**, or **unknown**, so revision history can tell "I wrote this" from "Alice wrote this." `SignerFor` handles one commit; `Revisions` with `WithSigners` folds the signer fields into the same `git log` call — one invocation per page, not one verify per revision.

## Hardened against argument injection

Since the model will eventually drive selectors and revisions through these tools, every user-controlled revision, cursor, and filename that reaches git is validated and terminated (addressing the review): revisions/cursors beginning with `-` are refused (`checkRevisionArg`), filenames go through `validateFilename` (no absolute paths or traversal), `--end-of-options` precedes positional revision args on rev-parse/rev-list/log/show/diff, and an invalid pagination cursor surfaces an error instead of masking as an empty page. Reads also go through a `runGitText` helper that keeps stderr out of stdout, so blob/diff bodies are always clean.

We deliberately **kept exec** rather than moving to a native git library: `go-git` now has native SSH *signing* (as of Feb 2026), but no verification against `allowed_signers` — the `%G?`/principal/validity trust model this system depends on — so a native move couldn't eliminate exec for the security-critical verify path. Hardening the exec surface is the right trade for now.

## Two deliberate layering boundaries

- Relative deltas (`-7d`) are resolved to RFC3339 by the model-facing tools, so `provenance` (a platform package) imports nothing from the model layer.
- No model surface here — this is purely the internal read/attribution surface.

## Test plan

- [x] Table-driven tests on a scratch repo: revision listing/ordering/index, pagination, selector resolution (all cases + rejections), blob, diff, history read back through a `Verifier`.
- [x] Signer tests: the `%G?` verdict mapping, a verified agent commit, an untrusted commit, and `WithSigners` population.
- [x] Injection tests: option-like revisions, traversal/absolute paths, and bad cursors are refused.
- [x] `just ci` green (bumps the interfaces architecture baseline 80 → 81 for the new `Reader`).

Refs #1136
