### PR TITLE
feat(documents): doc_history / doc_diff / doc_at revision tools (closes #1136)

### DIFF
--- a/internal/app/document_root_reviser.go
+++ b/internal/app/document_root_reviser.go
@@ -1,0 +1,141 @@
+package app
+
+import (
+	"context"
+	"fmt"
+	"path"
+	"path/filepath"
+	"strings"
+
+	"github.com/nugget/thane-ai-agent/internal/platform/provenance"
+	"github.com/nugget/thane-ai-agent/internal/state/documents"
+)
+
+// documentRootProvenanceReviser adapts a provenance.Reader (a signing Store or
+// a verify-only Verifier) to documents.RootReviser, translating the root's
+// prefix and the provenance revision/signer types into the documents-layer
+// forms so the documents package never depends on provenance.
+type documentRootProvenanceReviser struct {
+	reader provenance.Reader
+	prefix string
+}
+
+var _ documents.RootReviser = (*documentRootProvenanceReviser)(nil)
+
+func (r *documentRootProvenanceReviser) storeFilename(filename string) string {
+	return repoPrefixedFilename(r.prefix, filename)
+}
+
+func (r *documentRootProvenanceReviser) Resolve(ctx context.Context, filename, selector string) (documents.RevisionRef, error) {
+	rev, err := r.reader.ResolveRevision(ctx, r.storeFilename(filename), selector)
+	if err != nil {
+		return documents.RevisionRef{}, err
+	}
+	return revisionRefFromProvenance(rev), nil
+}
+
+func (r *documentRootProvenanceReviser) History(ctx context.Context, filename string, opts documents.RevisionQuery) (documents.RevisionListing, error) {
+	page, err := r.reader.Revisions(ctx, r.storeFilename(filename), provenance.RevisionOptions{
+		Limit:       opts.Limit,
+		Before:      opts.Before,
+		WithSigners: opts.WithSigners,
+	})
+	if err != nil {
+		return documents.RevisionListing{}, err
+	}
+	out := documents.RevisionListing{Total: page.Total, NextBefore: page.NextBefore}
+	for _, rev := range page.Revisions {
+		out.Revisions = append(out.Revisions, revisionRefFromProvenance(rev))
+	}
+	return out, nil
+}
+
+func (r *documentRootProvenanceReviser) Diff(ctx context.Context, filename, from, to, format string) (documents.RevisionDiff, error) {
+	sf := r.storeFilename(filename)
+	base, err := r.reader.ResolveRevision(ctx, sf, from)
+	if err != nil {
+		return documents.RevisionDiff{}, fmt.Errorf("resolve from: %w", err)
+	}
+	target, err := r.reader.ResolveRevision(ctx, sf, to)
+	if err != nil {
+		return documents.RevisionDiff{}, fmt.Errorf("resolve to: %w", err)
+	}
+	// Order by ancestry so the older revision is always the diff base,
+	// regardless of the order the caller passed the endpoints. Index (commits
+	// newer than this one) is reliable even when two commits share a second,
+	// where author timestamps would tie.
+	if base.Index < target.Index {
+		base, target = target, base
+	}
+	diff, err := r.reader.Diff(ctx, base.Commit, target.Commit, sf, provenance.DiffFormat(format))
+	if err != nil {
+		return documents.RevisionDiff{}, err
+	}
+	return documents.RevisionDiff{
+		Base:    revisionRefFromProvenance(base),
+		Target:  revisionRefFromProvenance(target),
+		Format:  string(diff.Format),
+		Added:   diff.Added,
+		Removed: diff.Removed,
+		Body:    diff.Body,
+	}, nil
+}
+
+func (r *documentRootProvenanceReviser) Content(ctx context.Context, filename, selector string) (documents.RevisionContent, error) {
+	sf := r.storeFilename(filename)
+	rev, err := r.reader.ResolveRevision(ctx, sf, selector)
+	if err != nil {
+		return documents.RevisionContent{}, err
+	}
+	ref := revisionRefFromProvenance(rev)
+	// Attach the signer so the caller can gate content on trust. A signer
+	// lookup failure is non-fatal — the content is still returned, unsigned.
+	if signer, sErr := r.reader.SignerFor(ctx, rev.Commit); sErr == nil {
+		s := revisionSignerFromProvenance(signer)
+		ref.Signer = &s
+	}
+	content, err := r.reader.Blob(ctx, rev.Commit, sf)
+	if err != nil {
+		return documents.RevisionContent{}, err
+	}
+	return documents.RevisionContent{Revision: ref, Content: content}, nil
+}
+
+func revisionRefFromProvenance(rev provenance.Revision) documents.RevisionRef {
+	ref := documents.RevisionRef{
+		Commit:    rev.Commit,
+		Short:     rev.Short,
+		Index:     rev.Index,
+		Timestamp: rev.Timestamp,
+		Message:   rev.Message,
+	}
+	if rev.Signer != nil {
+		s := revisionSignerFromProvenance(*rev.Signer)
+		ref.Signer = &s
+	}
+	return ref
+}
+
+func revisionSignerFromProvenance(cs provenance.CommitSigner) documents.RevisionSigner {
+	return documents.RevisionSigner{
+		Verified:       cs.Verified,
+		Principal:      cs.Principal,
+		Kind:           cs.Kind,
+		KeyFingerprint: cs.KeyFingerprint,
+		Reason:         cs.Reason,
+	}
+}
+
+// repoPrefixedFilename joins a root-relative filename onto the repo prefix
+// (when the git repo is a parent of the root), leaving traversal/absolute
+// inputs untouched so downstream validation can reject them.
+func repoPrefixedFilename(prefix, filename string) string {
+	clean := filepath.ToSlash(filepath.Clean(filename))
+	if clean == "." || clean == ".." || strings.HasPrefix(clean, "../") || path.IsAbs(clean) {
+		return clean
+	}
+	if prefix == "" || prefix == "." {
+		return clean
+	}
+	return path.Join(prefix, clean)
+}

--- a/internal/app/document_roots.go
+++ b/internal/app/document_roots.go
@@ -6,7 +6,6 @@ import (
 	"log/slog"
 	"os"
 	"os/exec"
-	"path"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -43,14 +42,7 @@ func (w *documentRootProvenanceWriter) Delete(ctx context.Context, filename, mes
 }
 
 func (w *documentRootProvenanceWriter) storeFilename(filename string) string {
-	clean := filepath.ToSlash(filepath.Clean(filename))
-	if clean == "." || clean == ".." || strings.HasPrefix(clean, "../") || path.IsAbs(clean) {
-		return clean
-	}
-	if w.prefix == "" || w.prefix == "." {
-		return clean
-	}
-	return path.Join(w.prefix, clean)
+	return repoPrefixedFilename(w.prefix, filename)
 }
 
 func (v *documentRootProvenanceVerifier) Verify(ctx context.Context, filename string) (documents.SignatureVerification, error) {
@@ -64,14 +56,7 @@ func (v *documentRootProvenanceVerifier) VerifyRoot(ctx context.Context) (docume
 }
 
 func (v *documentRootProvenanceVerifier) storeFilename(filename string) string {
-	clean := filepath.ToSlash(filepath.Clean(filename))
-	if clean == "." || clean == ".." || strings.HasPrefix(clean, "../") || path.IsAbs(clean) {
-		return clean
-	}
-	if v.prefix == "" || v.prefix == "." {
-		return clean
-	}
-	return path.Join(v.prefix, clean)
+	return repoPrefixedFilename(v.prefix, filename)
 }
 
 func documentSignatureVerificationFromProvenance(result provenance.VerificationResult) documents.SignatureVerification {
@@ -174,8 +159,9 @@ func (a *App) buildDocumentStoreOptions(documentRoots map[string]string, resolve
 			writer = w
 		}
 
+		var verifier *documentRootProvenanceVerifier
 		if policy.Git.Enabled && policy.Git.VerifySignatures != documents.VerificationNone {
-			verifier, err := a.newDocumentRootProvenanceVerifier(root, rootPath, rootCfg.Git, resolver)
+			v, err := a.newDocumentRootProvenanceVerifier(root, rootPath, rootCfg.Git, resolver)
 			if err != nil {
 				if policy.Git.VerifySignatures == documents.VerificationRequired {
 					return documents.StoreOptions{}, fmt.Errorf("doc_roots.%s verify_signatures=required but verifier unavailable: %w", root, err)
@@ -186,6 +172,7 @@ func (a *App) buildDocumentStoreOptions(documentRoots map[string]string, resolve
 					"error", err,
 				)
 			} else {
+				verifier = v
 				if opts.RootVerifiers == nil {
 					opts.RootVerifiers = make(map[string]documents.RootVerifier)
 				}
@@ -198,6 +185,23 @@ func (a *App) buildDocumentStoreOptions(documentRoots map[string]string, resolve
 				opts.RootWriters = make(map[string]documents.RootWriter)
 			}
 			opts.RootWriters[root] = writer
+		}
+
+		// Expose revision history for any git-backed root: prefer the signing
+		// store, otherwise the verify-only verifier. Both satisfy
+		// provenance.Reader, so a required verify-only root is inspectable too.
+		var reviser *documentRootProvenanceReviser
+		switch {
+		case writer != nil:
+			reviser = &documentRootProvenanceReviser{reader: writer.store, prefix: writer.prefix}
+		case verifier != nil:
+			reviser = &documentRootProvenanceReviser{reader: verifier.verifier, prefix: verifier.prefix}
+		}
+		if reviser != nil {
+			if opts.RootRevisers == nil {
+				opts.RootRevisers = make(map[string]documents.RootReviser)
+			}
+			opts.RootRevisers[root] = reviser
 		}
 	}
 	return opts, nil

--- a/internal/app/document_roots_test.go
+++ b/internal/app/document_roots_test.go
@@ -1,6 +1,8 @@
 package app
 
 import (
+	"crypto/ed25519"
+	"crypto/rand"
 	"errors"
 	"io"
 	"log/slog"
@@ -13,6 +15,7 @@ import (
 	"github.com/nugget/thane-ai-agent/internal/platform/config"
 	"github.com/nugget/thane-ai-agent/internal/platform/identity"
 	"github.com/nugget/thane-ai-agent/internal/platform/paths"
+	"github.com/nugget/thane-ai-agent/internal/platform/provenance"
 	"github.com/nugget/thane-ai-agent/internal/state/documents"
 )
 
@@ -440,5 +443,78 @@ func TestDocumentRootProvenanceWriterDoesNotCleanEscapesIntoPrefix(t *testing.T)
 	}
 	if got := writer.storeFilename("../outside.md"); got != "../outside.md" {
 		t.Fatalf("storeFilename(escape) = %q, want provenance validator to see escape", got)
+	}
+}
+
+// TestDocumentRootProvenanceReviser exercises the app adapter that bridges a
+// provenance.Reader to documents.RootReviser against a real signed repo.
+func TestDocumentRootProvenanceReviser(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	dir := t.TempDir()
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	signer, err := provenance.NewSSHSignerFromKey(priv)
+	if err != nil {
+		t.Fatalf("signer: %v", err)
+	}
+	store, err := provenance.New(dir, signer, slog.Default())
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	for _, step := range []struct{ content, msg string }{
+		{"a\n", "first"}, {"a\nb\n", "second"}, {"a\nb\nc\n", "third"},
+	} {
+		if err := store.Write(t.Context(), "doc.md", step.content, step.msg); err != nil {
+			t.Fatalf("write %q: %v", step.msg, err)
+		}
+	}
+
+	reviser := &documentRootProvenanceReviser{reader: store, prefix: ""}
+	ctx := t.Context()
+
+	listing, err := reviser.History(ctx, "doc.md", documents.RevisionQuery{WithSigners: true})
+	if err != nil {
+		t.Fatalf("History: %v", err)
+	}
+	if listing.Total != 3 || len(listing.Revisions) != 3 {
+		t.Fatalf("history = %d/%d, want 3/3", listing.Total, len(listing.Revisions))
+	}
+	if listing.Revisions[0].Message != "third" || listing.Revisions[0].Index != 0 {
+		t.Fatalf("newest = %q idx %d, want third idx 0", listing.Revisions[0].Message, listing.Revisions[0].Index)
+	}
+	if s := listing.Revisions[0].Signer; s == nil || !s.Verified || s.Kind != provenance.SignerKindAgent {
+		t.Fatalf("newest signer = %+v, want verified agent", s)
+	}
+
+	head, err := reviser.Resolve(ctx, "doc.md", "HEAD")
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	content, err := reviser.Content(ctx, "doc.md", head.Commit)
+	if err != nil {
+		t.Fatalf("Content: %v", err)
+	}
+	if content.Content != "a\nb\nc\n" {
+		t.Fatalf("Content = %q, want full doc", content.Content)
+	}
+	if content.Revision.Signer == nil || !content.Revision.Signer.Verified {
+		t.Fatalf("Content signer = %+v, want verified", content.Revision.Signer)
+	}
+
+	// Endpoints passed reversed to confirm the reviser time-orders base<target.
+	first := listing.Revisions[2] // "first"
+	diff, err := reviser.Diff(ctx, "doc.md", "HEAD", first.Short, "patch")
+	if err != nil {
+		t.Fatalf("Diff: %v", err)
+	}
+	if diff.Base.Message != "first" || diff.Target.Message != "third" {
+		t.Fatalf("diff base/target = %q/%q, want first/third", diff.Base.Message, diff.Target.Message)
+	}
+	if diff.Added != 2 || diff.Removed != 0 {
+		t.Fatalf("diff counts = +%d/-%d, want +2/-0", diff.Added, diff.Removed)
 	}
 }

--- a/internal/state/documents/policy.go
+++ b/internal/state/documents/policy.go
@@ -67,6 +67,10 @@ type RootGitPolicySummary struct {
 	Enabled          bool             `json:"enabled"`
 	SignCommits      bool             `json:"sign_commits,omitempty"`
 	VerifySignatures VerificationMode `json:"verify_signatures,omitempty"`
+	// Revisions reports whether this root exposes revision history
+	// (doc_history / doc_diff / doc_at). Always emitted so the model can
+	// rely on it to decide whether to reach for those tools.
+	Revisions bool `json:"revisions"`
 }
 
 // SignatureStatus describes the last known signature verification state
@@ -117,6 +121,7 @@ type StoreOptions struct {
 	RootPolicies  map[string]RootPolicy
 	RootWriters   map[string]RootWriter
 	RootVerifiers map[string]RootVerifier
+	RootRevisers  map[string]RootReviser
 }
 
 func defaultRootPolicy() RootPolicy {
@@ -193,6 +198,24 @@ func normalizeRootVerifiers(roots map[string]string, verifiers map[string]RootVe
 	return out
 }
 
+func normalizeRootRevisers(roots map[string]string, revisers map[string]RootReviser) map[string]RootReviser {
+	if len(revisers) == 0 {
+		return nil
+	}
+	out := make(map[string]RootReviser, len(revisers))
+	for root, reviser := range revisers {
+		root = normalizeRootName(root)
+		if root == "" || reviser == nil {
+			continue
+		}
+		if _, ok := roots[root]; !ok {
+			continue
+		}
+		out[root] = reviser
+	}
+	return out
+}
+
 func normalizeRootName(root string) string {
 	return strings.TrimSuffix(strings.TrimSpace(root), ":")
 }
@@ -209,6 +232,7 @@ func (s *Store) rootPolicy(root string) RootPolicy {
 }
 
 func (s *Store) rootPolicySummary(root string) RootPolicySummary {
+	root = normalizeRootName(root)
 	policy := s.rootPolicy(root)
 	return RootPolicySummary{
 		Indexing:  policy.Indexing,
@@ -217,6 +241,7 @@ func (s *Store) rootPolicySummary(root string) RootPolicySummary {
 			Enabled:          policy.Git.Enabled,
 			SignCommits:      policy.Git.SignCommits,
 			VerifySignatures: policy.Git.VerifySignatures,
+			Revisions:        s.rootReviser(root) != nil,
 		},
 	}
 }
@@ -235,4 +260,12 @@ func (s *Store) rootVerifier(root string) RootVerifier {
 		return nil
 	}
 	return s.rootVerifiers[root]
+}
+
+func (s *Store) rootReviser(root string) RootReviser {
+	root = normalizeRootName(root)
+	if s == nil || len(s.rootRevisers) == 0 {
+		return nil
+	}
+	return s.rootRevisers[root]
 }

--- a/internal/state/documents/revision.go
+++ b/internal/state/documents/revision.go
@@ -1,0 +1,88 @@
+package documents
+
+import (
+	"context"
+	"time"
+)
+
+// RootReviser exposes read-only revision history, diff, and point-in-time
+// recall for a git-backed document root. It is the documents-layer,
+// verifier-neutral counterpart to [RootWriter] and [RootVerifier]: the app
+// adapts a git backend to it, so this package never depends on the git
+// implementation.
+//
+// Filenames are root-relative; an implementation translates any repository
+// prefix (when the git repo is a parent of the root) before querying.
+// Selectors are resolved forms — "HEAD"/"latest", an RFC3339 timestamp, or a
+// commit hash. Relative deltas are normalized to timestamps by the caller.
+type RootReviser interface {
+	// Resolve maps a selector onto a concrete revision of the file.
+	Resolve(ctx context.Context, filename, selector string) (RevisionRef, error)
+	// History returns a newest-first page of the file's revisions.
+	History(ctx context.Context, filename string, opts RevisionQuery) (RevisionListing, error)
+	// Diff returns the change to the file between two revisions.
+	Diff(ctx context.Context, filename, from, to, format string) (RevisionDiff, error)
+	// Content returns the file's content as of a revision, with that
+	// revision's signer so the caller can gate on trust.
+	Content(ctx context.Context, filename, selector string) (RevisionContent, error)
+}
+
+// RevisionQuery bounds a [RootReviser.History] page.
+type RevisionQuery struct {
+	// Limit caps the page size; non-positive means the implementation default.
+	Limit int
+	// Before is a pagination cursor (a commit hash); empty starts at HEAD.
+	Before string
+	// WithSigners populates each revision's Signer.
+	WithSigners bool
+}
+
+// RevisionRef identifies one commit in a document's history.
+type RevisionRef struct {
+	// Commit is the full commit hash.
+	Commit string
+	// Short is the shortened hash used as the round-trippable token.
+	Short string
+	// Index is the count of revisions of this file newer than this one
+	// (0 for the newest) — a reasoning aid, not an addressing token.
+	Index int
+	// Timestamp is the commit's author time.
+	Timestamp time.Time
+	// Message is the commit subject.
+	Message string
+	// Signer describes who signed this revision, when populated.
+	Signer *RevisionSigner
+}
+
+// RevisionSigner is the documents-layer, verifier-neutral form of a commit's
+// signature attribution.
+type RevisionSigner struct {
+	Verified       bool
+	Principal      string
+	Kind           string
+	KeyFingerprint string
+	Reason         string
+}
+
+// RevisionListing is one page of a document's history, newest first.
+type RevisionListing struct {
+	Revisions  []RevisionRef
+	Total      int
+	NextBefore string
+}
+
+// RevisionDiff is the change to one document between two revisions.
+type RevisionDiff struct {
+	Base    RevisionRef
+	Target  RevisionRef
+	Format  string
+	Added   int
+	Removed int
+	Body    string
+}
+
+// RevisionContent is a document's content as of a revision.
+type RevisionContent struct {
+	Revision RevisionRef
+	Content  string
+}

--- a/internal/state/documents/revision_tools.go
+++ b/internal/state/documents/revision_tools.go
@@ -1,0 +1,302 @@
+package documents
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/nugget/thane-ai-agent/internal/model/promptfmt"
+)
+
+const (
+	defaultHistoryLimit = 20
+	maxHistoryLimit     = 100
+	// diffPatchBudget bounds an inline unified diff. A larger patch degrades
+	// to a diffstat rather than being clipped mid-hunk into unparseable text.
+	diffPatchBudget = 14 * 1024
+)
+
+// HistoryArgs requests the revision log for one document.
+type HistoryArgs struct {
+	Ref    string `json:"ref"`
+	Limit  int    `json:"limit,omitempty"`
+	Before string `json:"before,omitempty"`
+}
+
+// DiffArgs requests the change to one document between two revisions.
+type DiffArgs struct {
+	Ref    string `json:"ref"`
+	From   string `json:"from"`
+	To     string `json:"to,omitempty"`
+	Format string `json:"format,omitempty"`
+}
+
+// AtArgs recalls one document's content as of a revision.
+type AtArgs struct {
+	Ref string `json:"ref"`
+	Rev string `json:"rev,omitempty"`
+}
+
+// resolveReviser maps a ref to its root's reviser and the root-relative path,
+// distinguishing an unknown root from a known-but-not-git-backed one so the
+// model can recover.
+func (s *Store) resolveReviser(ref string) (RootReviser, string, error) {
+	root, relPath, err := parseRef(ref)
+	if err != nil {
+		return nil, "", err
+	}
+	if _, ok := s.roots[normalizeRootName(root)]; !ok {
+		return nil, "", fmt.Errorf("unknown root %q; call doc_roots to list roots", root)
+	}
+	reviser := s.rootReviser(root)
+	if reviser == nil {
+		return nil, "", fmt.Errorf("root %q has no revision history (it is not git-backed); doc_roots reports revisions=true for roots that do", root)
+	}
+	return reviser, relPath, nil
+}
+
+func (s *Store) revisionHistory(ctx context.Context, ref string, opts RevisionQuery) (RevisionListing, error) {
+	reviser, relPath, err := s.resolveReviser(ref)
+	if err != nil {
+		return RevisionListing{}, err
+	}
+	return reviser.History(ctx, relPath, opts)
+}
+
+func (s *Store) revisionDiff(ctx context.Context, ref, from, to, format string) (RevisionDiff, error) {
+	reviser, relPath, err := s.resolveReviser(ref)
+	if err != nil {
+		return RevisionDiff{}, err
+	}
+	return reviser.Diff(ctx, relPath, from, to, format)
+}
+
+func (s *Store) revisionContent(ctx context.Context, ref, selector string) (RevisionContent, error) {
+	reviser, relPath, err := s.resolveReviser(ref)
+	if err != nil {
+		return RevisionContent{}, err
+	}
+	return reviser.Content(ctx, relPath, selector)
+}
+
+// History returns the revision log for one document, newest first.
+func (t *Tools) History(ctx context.Context, args HistoryArgs) (string, error) {
+	if t == nil || t.store == nil {
+		return "", fmt.Errorf("document index not configured")
+	}
+	if strings.TrimSpace(args.Ref) == "" {
+		return "", fmt.Errorf("ref is required")
+	}
+	listing, err := t.store.revisionHistory(ctx, args.Ref, RevisionQuery{
+		Limit:       clampPositiveLimit(args.Limit, defaultHistoryLimit, maxHistoryLimit),
+		Before:      strings.TrimSpace(args.Before),
+		WithSigners: true,
+	})
+	if err != nil {
+		return "", err
+	}
+	now := nowUTC()
+	out := modelHistory{
+		Ref:           args.Ref,
+		RevisionCount: listing.Total,
+		Revisions:     make([]modelRevision, 0, len(listing.Revisions)),
+		NextBefore:    listing.NextBefore,
+	}
+	for _, rev := range listing.Revisions {
+		out.Revisions = append(out.Revisions, toModelRevision(rev, now))
+	}
+	return marshalToolResult(out)
+}
+
+// Diff returns the change to one document between two revisions.
+func (t *Tools) Diff(ctx context.Context, args DiffArgs) (string, error) {
+	if t == nil || t.store == nil {
+		return "", fmt.Errorf("document index not configured")
+	}
+	if strings.TrimSpace(args.Ref) == "" {
+		return "", fmt.Errorf("ref is required")
+	}
+	if strings.TrimSpace(args.From) == "" {
+		return "", fmt.Errorf("from is required; pass a rev from doc_history, a timestamp, or a delta like -7d")
+	}
+	from := t.normalizeSelector(args.From)
+	to := t.normalizeSelector(defaultString(args.To, "HEAD"))
+	format := "patch"
+	if strings.TrimSpace(args.Format) == "stat" {
+		format = "stat"
+	}
+	diff, err := t.store.revisionDiff(ctx, args.Ref, from, to, format)
+	if err != nil {
+		return "", err
+	}
+	// A unified patch over the byte budget degrades to a diffstat so a clipped,
+	// unparseable patch never reaches the model.
+	note := ""
+	if format == "patch" && len(diff.Body) > diffPatchBudget {
+		if statDiff, sErr := t.store.revisionDiff(ctx, args.Ref, from, to, "stat"); sErr == nil {
+			diff = statDiff
+			note = fmt.Sprintf("patch exceeded %d bytes; showing diffstat — narrow the range for the full patch", diffPatchBudget)
+		}
+	}
+	now := nowUTC()
+	return marshalToolResult(modelDiff{
+		Ref:     args.Ref,
+		Base:    toModelRevision(diff.Base, now),
+		Target:  toModelRevision(diff.Target, now),
+		Format:  diff.Format,
+		Added:   diff.Added,
+		Removed: diff.Removed,
+		Patch:   diff.Body,
+		Note:    note,
+	})
+}
+
+// At recalls one document's content as of a revision.
+func (t *Tools) At(ctx context.Context, args AtArgs) (string, error) {
+	if t == nil || t.store == nil {
+		return "", fmt.Errorf("document index not configured")
+	}
+	if strings.TrimSpace(args.Ref) == "" {
+		return "", fmt.Errorf("ref is required")
+	}
+	selector := t.normalizeSelector(defaultString(args.Rev, "HEAD"))
+	content, err := t.store.revisionContent(ctx, args.Ref, selector)
+	if err != nil {
+		return "", err
+	}
+	_, relPath, _ := parseRef(args.Ref)
+	meta, body := splitFrontmatter(content.Content)
+	parsed := parseMarkdownDocumentParts(relPath, meta, body)
+	now := nowUTC()
+	rev := content.Revision
+	out := modelRevisionAt{
+		Ref:          args.Ref,
+		Rev:          rev.Short,
+		Index:        rev.Index,
+		AsOf:         rev.Timestamp.UTC().Format(time.RFC3339),
+		Age:          promptfmt.FormatDeltaOnly(rev.Timestamp, now),
+		VerifyStatus: revisionVerifyStatus(rev.Signer),
+		Signer:       toModelRevisionSigner(rev.Signer),
+		Title:        parsed.Title,
+		Frontmatter:  modelFrontmatter(parsed.Frontmatter, now),
+		Outline:      parsed.Sections,
+	}
+	// Honesty seam: an untrusted recall ships under "unverified_body", never
+	// "body", so the model can't pattern-match it as a normal doc_read payload.
+	if out.VerifyStatus == "trusted" {
+		out.Body = body
+	} else {
+		out.UnverifiedBody = body
+	}
+	return marshalToolResult(out)
+}
+
+type modelRevision struct {
+	Rev       string               `json:"rev"`
+	Index     int                  `json:"index"`
+	Timestamp string               `json:"timestamp"`
+	Age       string               `json:"age,omitempty"`
+	Message   string               `json:"message,omitempty"`
+	Signer    *modelRevisionSigner `json:"signer,omitempty"`
+}
+
+type modelRevisionSigner struct {
+	Verified  bool   `json:"verified"`
+	Principal string `json:"principal,omitempty"`
+	Kind      string `json:"kind,omitempty"`
+	Reason    string `json:"reason,omitempty"`
+}
+
+type modelHistory struct {
+	Ref           string          `json:"ref"`
+	RevisionCount int             `json:"revision_count"`
+	Revisions     []modelRevision `json:"revisions"`
+	NextBefore    string          `json:"next_before,omitempty"`
+}
+
+type modelDiff struct {
+	Ref     string        `json:"ref"`
+	Base    modelRevision `json:"base_rev"`
+	Target  modelRevision `json:"target_rev"`
+	Format  string        `json:"format"`
+	Added   int           `json:"added"`
+	Removed int           `json:"removed"`
+	Patch   string        `json:"patch,omitempty"`
+	Note    string        `json:"note,omitempty"`
+}
+
+type modelRevisionAt struct {
+	Ref            string               `json:"ref"`
+	Rev            string               `json:"rev"`
+	Index          int                  `json:"index"`
+	AsOf           string               `json:"as_of"`
+	Age            string               `json:"age,omitempty"`
+	VerifyStatus   string               `json:"verify_status"`
+	Signer         *modelRevisionSigner `json:"signer,omitempty"`
+	Title          string               `json:"title,omitempty"`
+	Frontmatter    map[string][]string  `json:"frontmatter,omitempty"`
+	Outline        []Section            `json:"outline,omitempty"`
+	Body           string               `json:"body,omitempty"`
+	UnverifiedBody string               `json:"unverified_body,omitempty"`
+}
+
+func toModelRevision(r RevisionRef, now time.Time) modelRevision {
+	return modelRevision{
+		Rev:       r.Short,
+		Index:     r.Index,
+		Timestamp: r.Timestamp.UTC().Format(time.RFC3339),
+		Age:       promptfmt.FormatDeltaOnly(r.Timestamp, now),
+		Message:   r.Message,
+		Signer:    toModelRevisionSigner(r.Signer),
+	}
+}
+
+func toModelRevisionSigner(s *RevisionSigner) *modelRevisionSigner {
+	if s == nil {
+		return nil
+	}
+	return &modelRevisionSigner{
+		Verified:  s.Verified,
+		Principal: s.Principal,
+		Kind:      s.Kind,
+		Reason:    s.Reason,
+	}
+}
+
+func revisionVerifyStatus(s *RevisionSigner) string {
+	switch {
+	case s == nil:
+		return "unknown"
+	case s.Verified:
+		return "trusted"
+	default:
+		return "unverified"
+	}
+}
+
+// normalizeSelector converts a delta ("-7d") or absolute timestamp into the
+// RFC3339 form the reviser understands, leaving "HEAD"/"latest" and commit
+// hashes untouched. Deltas are recognized by a leading +/-, timestamps by a
+// 'T' or ':' — neither can occur in a hex commit hash — so a hash is never
+// mistaken for a time.
+func (t *Tools) normalizeSelector(sel string) string {
+	s := strings.TrimSpace(sel)
+	switch strings.ToLower(s) {
+	case "", "head", "latest":
+		return s
+	}
+	if strings.HasPrefix(s, "-") || strings.HasPrefix(s, "+") || strings.ContainsAny(s, "T:") {
+		if parsed, err := promptfmt.ParseTimeOrDelta(s, nowUTC()); err == nil {
+			return parsed.UTC().Format(time.RFC3339)
+		}
+	}
+	return s
+}
+
+func defaultString(s, def string) string {
+	if strings.TrimSpace(s) == "" {
+		return def
+	}
+	return s
+}

--- a/internal/state/documents/revision_tools.go
+++ b/internal/state/documents/revision_tools.go
@@ -131,13 +131,17 @@ func (t *Tools) Diff(ctx context.Context, args DiffArgs) (string, error) {
 		return "", err
 	}
 	// A unified patch over the byte budget degrades to a diffstat so a clipped,
-	// unparseable patch never reaches the model.
+	// unparseable patch never reaches the model. The fallback is mandatory: if
+	// the diffstat itself fails, error rather than emit the over-budget patch
+	// (which marshalToolResult would clip into a meaningless preview).
 	note := ""
 	if format == "patch" && len(diff.Body) > diffPatchBudget {
-		if statDiff, sErr := t.store.revisionDiff(ctx, args.Ref, from, to, "stat"); sErr == nil {
-			diff = statDiff
-			note = fmt.Sprintf("patch exceeded %d bytes; showing diffstat — narrow the range for the full patch", diffPatchBudget)
+		statDiff, sErr := t.store.revisionDiff(ctx, args.Ref, from, to, "stat")
+		if sErr != nil {
+			return "", fmt.Errorf("diff for %s exceeded %d bytes and the diffstat fallback failed: %w", args.Ref, diffPatchBudget, sErr)
 		}
+		diff = statDiff
+		note = fmt.Sprintf("patch exceeded %d bytes; showing diffstat — narrow the range for the full patch", diffPatchBudget)
 	}
 	now := nowUTC()
 	return marshalToolResult(modelDiff{

--- a/internal/state/documents/revision_tools_test.go
+++ b/internal/state/documents/revision_tools_test.go
@@ -1,0 +1,177 @@
+package documents
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nugget/thane-ai-agent/internal/platform/database"
+)
+
+type stubReviser struct {
+	listing RevisionListing
+	diff    RevisionDiff
+	content RevisionContent
+}
+
+func (s stubReviser) Resolve(context.Context, string, string) (RevisionRef, error) {
+	return s.content.Revision, nil
+}
+func (s stubReviser) History(context.Context, string, RevisionQuery) (RevisionListing, error) {
+	return s.listing, nil
+}
+func (s stubReviser) Diff(context.Context, string, string, string, string) (RevisionDiff, error) {
+	return s.diff, nil
+}
+func (s stubReviser) Content(context.Context, string, string) (RevisionContent, error) {
+	return s.content, nil
+}
+
+func newRevisionTools(t *testing.T, roots map[string]string, revisers map[string]RootReviser) *Tools {
+	t.Helper()
+	db, err := database.OpenMemory()
+	if err != nil {
+		t.Fatalf("OpenMemory: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	store, err := NewStoreWithOptions(db, roots, nil, StoreOptions{RootRevisers: revisers})
+	if err != nil {
+		t.Fatalf("NewStoreWithOptions: %v", err)
+	}
+	return NewTools(store)
+}
+
+func testRevisions() (RevisionRef, RevisionRef) {
+	ts := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	agent := &RevisionSigner{Verified: true, Principal: "thane@provenance.local", Kind: "agent"}
+	newest := RevisionRef{Commit: "aaaaaaaaaaaa", Short: "aaaaaaaaaaaa", Index: 0, Timestamp: ts, Message: "third", Signer: agent}
+	older := RevisionRef{Commit: "bbbbbbbbbbbb", Short: "bbbbbbbbbbbb", Index: 1, Timestamp: ts.Add(-time.Hour), Message: "second", Signer: agent}
+	return newest, older
+}
+
+func TestToolsHistory(t *testing.T) {
+	newest, older := testRevisions()
+	tools := newRevisionTools(t,
+		map[string]string{"kb": t.TempDir()},
+		map[string]RootReviser{"kb": stubReviser{listing: RevisionListing{
+			Revisions: []RevisionRef{newest, older}, Total: 5, NextBefore: "bbbbbbbbbbbb",
+		}}},
+	)
+	out, err := tools.History(context.Background(), HistoryArgs{Ref: "kb:doc.md"})
+	if err != nil {
+		t.Fatalf("History: %v", err)
+	}
+	var got modelHistory
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("unmarshal: %v\n%s", err, out)
+	}
+	if got.RevisionCount != 5 || len(got.Revisions) != 2 || got.NextBefore != "bbbbbbbbbbbb" {
+		t.Fatalf("history = count %d, %d revs, next %q; want 5/2/bbbb", got.RevisionCount, len(got.Revisions), got.NextBefore)
+	}
+	if got.Revisions[0].Rev != "aaaaaaaaaaaa" || got.Revisions[0].Index != 0 || got.Revisions[0].Age == "" {
+		t.Fatalf("newest = %+v, want rev aaaa idx 0 with an age", got.Revisions[0])
+	}
+	if s := got.Revisions[0].Signer; s == nil || !s.Verified || s.Kind != "agent" {
+		t.Fatalf("newest signer = %+v, want verified agent", s)
+	}
+}
+
+func TestToolsDiff(t *testing.T) {
+	newest, older := testRevisions()
+	tools := newRevisionTools(t,
+		map[string]string{"kb": t.TempDir()},
+		map[string]RootReviser{"kb": stubReviser{diff: RevisionDiff{
+			Base: older, Target: newest, Format: "patch", Added: 2, Removed: 0, Body: "+b\n+c\n",
+		}}},
+	)
+	out, err := tools.Diff(context.Background(), DiffArgs{Ref: "kb:doc.md", From: "bbbbbbbbbbbb"})
+	if err != nil {
+		t.Fatalf("Diff: %v", err)
+	}
+	var got modelDiff
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("unmarshal: %v\n%s", err, out)
+	}
+	if got.Base.Rev != "bbbbbbbbbbbb" || got.Target.Rev != "aaaaaaaaaaaa" {
+		t.Fatalf("base/target = %q/%q, want bbbb/aaaa", got.Base.Rev, got.Target.Rev)
+	}
+	if got.Added != 2 || !strings.Contains(got.Patch, "+b") {
+		t.Fatalf("diff = +%d, patch %q", got.Added, got.Patch)
+	}
+}
+
+func TestToolsAt_TrustedAndUnverified(t *testing.T) {
+	newest, _ := testRevisions()
+	body := "---\ntitle: Doc\n---\nhello body\n"
+
+	trusted := newRevisionTools(t,
+		map[string]string{"kb": t.TempDir()},
+		map[string]RootReviser{"kb": stubReviser{content: RevisionContent{Revision: newest, Content: body}}},
+	)
+	out, err := trusted.At(context.Background(), AtArgs{Ref: "kb:doc.md"})
+	if err != nil {
+		t.Fatalf("At: %v", err)
+	}
+	var got modelRevisionAt
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("unmarshal: %v\n%s", err, out)
+	}
+	if got.VerifyStatus != "trusted" || !strings.Contains(got.Body, "hello body") || got.UnverifiedBody != "" {
+		t.Fatalf("trusted at = status %q, body %q, unverified %q", got.VerifyStatus, got.Body, got.UnverifiedBody)
+	}
+
+	// An untrusted revision ships its content under unverified_body.
+	untrustedRev := newest
+	untrustedRev.Signer = &RevisionSigner{Verified: false, Kind: "unknown", Reason: "unsigned"}
+	untrusted := newRevisionTools(t,
+		map[string]string{"kb": t.TempDir()},
+		map[string]RootReviser{"kb": stubReviser{content: RevisionContent{Revision: untrustedRev, Content: body}}},
+	)
+	out2, err := untrusted.At(context.Background(), AtArgs{Ref: "kb:doc.md"})
+	if err != nil {
+		t.Fatalf("At untrusted: %v", err)
+	}
+	var got2 modelRevisionAt
+	if err := json.Unmarshal([]byte(out2), &got2); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got2.VerifyStatus != "unverified" || got2.Body != "" || !strings.Contains(got2.UnverifiedBody, "hello body") {
+		t.Fatalf("untrusted at = status %q, body %q, unverified %q", got2.VerifyStatus, got2.Body, got2.UnverifiedBody)
+	}
+}
+
+func TestToolsRevisionErrors(t *testing.T) {
+	tools := newRevisionTools(t,
+		map[string]string{"kb": t.TempDir(), "plain": t.TempDir()},
+		map[string]RootReviser{"kb": stubReviser{}},
+	)
+	ctx := context.Background()
+
+	if _, err := tools.History(ctx, HistoryArgs{Ref: ""}); err == nil {
+		t.Fatal("empty ref accepted")
+	}
+	if _, err := tools.History(ctx, HistoryArgs{Ref: "ghost:doc.md"}); err == nil || !strings.Contains(err.Error(), "unknown root") {
+		t.Fatalf("unknown root err = %v, want 'unknown root'", err)
+	}
+	if _, err := tools.History(ctx, HistoryArgs{Ref: "plain:doc.md"}); err == nil || !strings.Contains(err.Error(), "not git-backed") {
+		t.Fatalf("non-git root err = %v, want 'not git-backed'", err)
+	}
+	if _, err := tools.Diff(ctx, DiffArgs{Ref: "kb:doc.md"}); err == nil || !strings.Contains(err.Error(), "from is required") {
+		t.Fatalf("missing from err = %v, want 'from is required'", err)
+	}
+}
+
+func TestNormalizeSelector(t *testing.T) {
+	tools := newRevisionTools(t, map[string]string{"kb": t.TempDir()}, map[string]RootReviser{"kb": stubReviser{}})
+	if got := tools.normalizeSelector("HEAD"); got != "HEAD" {
+		t.Fatalf("HEAD = %q, want HEAD", got)
+	}
+	if got := tools.normalizeSelector("a1b2c3def456"); got != "a1b2c3def456" {
+		t.Fatalf("hash = %q, want unchanged", got)
+	}
+	if got := tools.normalizeSelector("-3600s"); !strings.Contains(got, "T") || strings.HasPrefix(got, "-") {
+		t.Fatalf("delta = %q, want an RFC3339 timestamp", got)
+	}
+}

--- a/internal/state/documents/store.go
+++ b/internal/state/documents/store.go
@@ -79,6 +79,7 @@ type Store struct {
 	rootPolicies    map[string]RootPolicy
 	rootWriters     map[string]RootWriter
 	rootVerifiers   map[string]RootVerifier
+	rootRevisers    map[string]RootReviser
 	verificationMu  sync.Mutex
 	verification    map[string]SignatureVerification
 	logger          *slog.Logger
@@ -110,6 +111,7 @@ func NewStoreWithOptions(db *sql.DB, roots map[string]string, logger *slog.Logge
 		rootPolicies:    normalizePolicies(normalizedRoots, opts.RootPolicies),
 		rootWriters:     normalizeRootWriters(normalizedRoots, opts.RootWriters),
 		rootVerifiers:   normalizeRootVerifiers(normalizedRoots, opts.RootVerifiers),
+		rootRevisers:    normalizeRootRevisers(normalizedRoots, opts.RootRevisers),
 		verification:    make(map[string]SignatureVerification),
 		logger:          logger,
 		refreshInterval: defaultRefreshInterval,

--- a/internal/tools/document_tools.go
+++ b/internal/tools/document_tools.go
@@ -44,6 +44,81 @@ func RegisterDocumentTools(r *Registry, dt *documents.Tools) {
 	})
 
 	r.Register(&Tool{
+		Name:                 "doc_history",
+		Description:          "List the revision history of one managed document by semantic ref like `kb:network/vlans.md`, newest first. Only git-backed roots have history — `doc_roots` reports `revisions: true` for those. Each revision has a short `rev` hash (feed it to `doc_diff`/`doc_at`), an `index` (0 is newest), an `age` delta plus absolute `timestamp`, the commit message, and a `signer` (`verified`, `principal`, `kind`: agent or operator). Paginate older by passing `before` set to the returned `next_before`.",
+		ContentResolveExempt: []string{"ref", "before"},
+		Parameters: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"ref":    map[string]any{"type": "string", "description": "Canonical document ref like `kb:network/vlans.md`."},
+				"limit":  map[string]any{"type": "integer", "description": "Max revisions to return (integer, not string; default 20, max 100)."},
+				"before": map[string]any{"type": "string", "description": "Pagination cursor: a `rev` hash; returns revisions older than it. Use the `next_before` from a prior call."},
+			},
+			"required": []string{"ref"},
+		},
+		Handler: func(ctx context.Context, args map[string]any) (string, error) {
+			ref, _ := args["ref"].(string)
+			if ref == "" {
+				return "", fmt.Errorf("ref is required")
+			}
+			before, _ := args["before"].(string)
+			return dt.History(ctx, documents.HistoryArgs{
+				Ref:    ref,
+				Limit:  numericArg(args["limit"], 20, 100),
+				Before: before,
+			})
+		},
+	})
+
+	r.Register(&Tool{
+		Name:                 "doc_diff",
+		Description:          "Show the diff of one managed document between two revisions. `from` and `to` accept a `rev` hash from `doc_history`, `HEAD`/`latest`, an RFC3339 timestamp, or a relative delta like `-7d`; `to` defaults to `HEAD`. Endpoints are ordered automatically so the older one is the base. Returns added/removed line counts and the patch; a patch too large to return whole degrades to a diffstat with a note. `format` is `patch` (default) or `stat`.",
+		ContentResolveExempt: []string{"ref", "from", "to"},
+		Parameters: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"ref":    map[string]any{"type": "string", "description": "Canonical document ref like `kb:network/vlans.md`."},
+				"from":   map[string]any{"type": "string", "description": "One endpoint: a `rev` hash, `HEAD`/`latest`, an RFC3339 timestamp, or a delta like `-7d`."},
+				"to":     map[string]any{"type": "string", "description": "Other endpoint (default `HEAD`)."},
+				"format": map[string]any{"type": "string", "description": "`patch` (default, unified diff) or `stat` (summary)."},
+			},
+			"required": []string{"ref", "from"},
+		},
+		Handler: func(ctx context.Context, args map[string]any) (string, error) {
+			ref, _ := args["ref"].(string)
+			if ref == "" {
+				return "", fmt.Errorf("ref is required")
+			}
+			from, _ := args["from"].(string)
+			to, _ := args["to"].(string)
+			format, _ := args["format"].(string)
+			return dt.Diff(ctx, documents.DiffArgs{Ref: ref, From: from, To: to, Format: format})
+		},
+	})
+
+	r.Register(&Tool{
+		Name:                 "doc_at",
+		Description:          "Recall one managed document's content as of a past revision. `rev` accepts a `rev` hash from `doc_history`, `HEAD`/`latest` (default), an RFC3339 timestamp, or a delta like `-7d`. Returns the frontmatter, outline, and body as of that revision, plus `verify_status` and the `signer`. When the revision is not trusted, the content is returned under `unverified_body` instead of `body`.",
+		ContentResolveExempt: []string{"ref", "rev"},
+		Parameters: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"ref": map[string]any{"type": "string", "description": "Canonical document ref like `kb:network/vlans.md`."},
+				"rev": map[string]any{"type": "string", "description": "Revision to recall: a `rev` hash, `HEAD` (default), an RFC3339 timestamp, or a delta like `-7d`."},
+			},
+			"required": []string{"ref"},
+		},
+		Handler: func(ctx context.Context, args map[string]any) (string, error) {
+			ref, _ := args["ref"].(string)
+			if ref == "" {
+				return "", fmt.Errorf("ref is required")
+			}
+			rev, _ := args["rev"].(string)
+			return dt.At(ctx, documents.AtArgs{Ref: ref, Rev: rev})
+		},
+	})
+
+	r.Register(&Tool{
 		Name:        "doc_roots",
 		Description: "List indexed markdown roots with helpful corpus summaries such as document counts, total size, last modification delta, top tags, top directories, and recent example documents. Use first when the answer probably lives in a managed document corpus but you do not yet know which root to browse.",
 		Parameters: map[string]any{

--- a/scripts/architecture.baseline
+++ b/scripts/architecture.baseline
@@ -1,5 +1,5 @@
 packages=62
-interfaces=81
+interfaces=82
 large_files=49
 set_mutators=111
 database_opens=9


### PR DESCRIPTION
## What

This completes #1136: the model-facing revision tools, sitting on the `provenance.Reader` foundation that merged in #1141. It's two commits — the documents-layer plumbing, then the three tools.

## The tools

- **`doc_history`** — one document's revision log, newest first. Each revision carries a round-trippable short `rev` (feed it to the other two), an `index` (0 is newest), an `age` delta *and* the absolute `timestamp`, the commit message, and a `signer` (`verified`, `principal`, `kind: agent|operator`). Paginates older via `before`/`next_before`.
- **`doc_diff`** — the change between two revisions. `from`/`to` accept a `rev` hash, `HEAD`/`latest`, an RFC3339 timestamp, or a delta like `-7d`; `to` defaults to `HEAD`, and the endpoints are ordered so the older one is always the base. A patch that would blow the tool byte budget degrades to a diffstat with a note rather than being clipped mid-hunk into unparseable output.
- **`doc_at`** — the document's frontmatter, outline, and body as of a revision, plus `verify_status` and `signer`. When the revision isn't trusted, the content ships under **`unverified_body`** instead of `body`, so the model can't pattern-match an untrusted recall as a normal `doc_read`.

Discovery is handled too: `doc_roots` now reports a stable `revisions` flag per root, so a loop knows which roots even have history before reaching for these.

## The foundation

`documents.RootReviser` is the verifier-neutral counterpart to `RootWriter`/`RootVerifier` — the app adapter bridges a `provenance.Reader` (a signing `Store` *or* a verify-only `Verifier`, both of which satisfy it) to it, so a `required` verify-only root is inspectable too, and the documents package never depends on provenance.

## Conventions applied

Per `docs/model-facing-{tools,context}.md`: compact JSON, newest-first, delta-oriented time (`age` for reading, the absolute `timestamp` as the chainable token), explicit truncation, and errors that teach — an unknown root reads differently from a known-but-not-git-backed one, and a missing `from` names what to pass. Deltas are normalized to RFC3339 *at the tools layer* (keeping `provenance` free of the model package), and a hex hash is never mistaken for a timestamp (deltas start with `+/-`, timestamps carry `T`/`:` — neither occurs in a hash).

One correctness note from the foundation: `doc_diff` orders endpoints by **ancestry (`index`)**, not author timestamp — two commits made in the same second would otherwise tie and mis-order.

## Test plan

- [x] App-layer adapter test against a real 3-commit signed repo: history/ordering/index/signer, resolve, content, and reversed-endpoint diff ordering.
- [x] Documents-layer tool tests with a stub reviser: `doc_history` shape (rev/index/age/signer/next_before), `doc_diff` (base/target/counts/patch), `doc_at` trusted→`body` vs untrusted→`unverified_body`, error paths (unknown root, not-git-backed, missing `from`), and selector normalization (HEAD/hash untouched, delta→RFC3339).
- [x] `just ci` green (interfaces baseline +1 for `RootReviser`; reviser adapter extracted to its own file to keep `document_roots.go` focused).

Closes #1136
