### PR TITLE
feat(config): optional git.remote block for document roots (#1137)

### DIFF
--- a/examples/config.example.yaml
+++ b/examples/config.example.yaml
@@ -258,35 +258,7 @@ roots:
       # remote. The remote is untrusted transport: it conveys commits but
       # never confers trust, which comes only from signature verification
       # against the out-of-tree trust_anchor. Ignored unless Enabled.
-      remote:
-        # URL is the remote git URL (SSH like user@host:path, ssh://…, or an
-        # https URL). Required.
-        url: ""
-        # Branch is the remote branch to track. Empty defaults to "main".
-        branch: ""
-        # Mode is required and explicit: "fetch" (pull the operator's signed
-        # commits in) or "bidirectional" (also push thane's own signed commits
-        # out). There is no default, so a one-way setup is never silent.
-        mode: ""
-        # Interval is the sync poll cadence as a Go duration (e.g. "60s").
-        # Empty defaults to 60s; "0" disables the timer (manual/trigger-only).
-        interval: ""
-        # TrustAnchor is the out-of-tree OpenSSH allowed_signers file that
-        # verification checks against. It must live outside the synced tree so a
-        # fetched commit can never rewrite the trust set. See #1135.
-        trust_anchor: ""
-        # Auth carries transport credentials only — never commit-signing
-        # material.
-        auth:
-          # SSHKey is the private key path for SSH transport, passed via
-          # GIT_SSH_COMMAND with IdentitiesOnly. Must not equal git.signing_key.
-          ssh_key: ""
-          # KnownHosts is the pinned known_hosts file, required for an SSH url:
-          # host-key verification is strict, with no trust-on-first-use.
-          known_hosts: ""
-          # Token is an https personal access token. Documented, but SSH is the
-          # recommended transport.
-          token: ""
+      remote: null
   kb:
     # Path is the directory the root resolves to. Supports ~
     # expansion at resolver construction time. For the reserved
@@ -356,14 +328,16 @@ roots:
         # URL is the remote git URL (SSH like user@host:path, ssh://…, or an
         # https URL). Required.
         url: aimee@pocket.hollowoak.net:Thane/knowledge.git
-        # Branch is the remote branch to track. Empty defaults to "main".
+        # Branch is the remote branch to track. Empty means the sync uses
+        # "main" (applied where the remote is consumed, not by config Load).
         branch: main
         # Mode is required and explicit: "fetch" (pull the operator's signed
         # commits in) or "bidirectional" (also push thane's own signed commits
         # out). There is no default, so a one-way setup is never silent.
         mode: bidirectional
         # Interval is the sync poll cadence as a Go duration (e.g. "60s").
-        # Empty defaults to 60s; "0" disables the timer (manual/trigger-only).
+        # Empty means the sync uses 60s (applied where the remote is consumed,
+        # not by config Load); "0" disables the timer (manual/trigger-only).
         interval: 60s
         # TrustAnchor is the out-of-tree OpenSSH allowed_signers file that
         # verification checks against. It must live outside the synced tree so a
@@ -427,35 +401,7 @@ roots:
       # remote. The remote is untrusted transport: it conveys commits but
       # never confers trust, which comes only from signature verification
       # against the out-of-tree trust_anchor. Ignored unless Enabled.
-      remote:
-        # URL is the remote git URL (SSH like user@host:path, ssh://…, or an
-        # https URL). Required.
-        url: ""
-        # Branch is the remote branch to track. Empty defaults to "main".
-        branch: ""
-        # Mode is required and explicit: "fetch" (pull the operator's signed
-        # commits in) or "bidirectional" (also push thane's own signed commits
-        # out). There is no default, so a one-way setup is never silent.
-        mode: ""
-        # Interval is the sync poll cadence as a Go duration (e.g. "60s").
-        # Empty defaults to 60s; "0" disables the timer (manual/trigger-only).
-        interval: ""
-        # TrustAnchor is the out-of-tree OpenSSH allowed_signers file that
-        # verification checks against. It must live outside the synced tree so a
-        # fetched commit can never rewrite the trust set. See #1135.
-        trust_anchor: ""
-        # Auth carries transport credentials only — never commit-signing
-        # material.
-        auth:
-          # SSHKey is the private key path for SSH transport, passed via
-          # GIT_SSH_COMMAND with IdentitiesOnly. Must not equal git.signing_key.
-          ssh_key: ""
-          # KnownHosts is the pinned known_hosts file, required for an SSH url:
-          # host-key verification is strict, with no trust-on-first-use.
-          known_hosts: ""
-          # Token is an https personal access token. Documented, but SSH is the
-          # recommended transport.
-          token: ""
+      remote: null
 #
 # (optional) Paths is the legacy directory-mapping block. Replaced by roots:.
 # paths: {}
@@ -686,27 +632,12 @@ talents_dir: ./talents
 #       is how every wake delivers; the target's own Spec.Profile
 #       governs routing. Point this at "mqtt-default-handler" for the
 #       built-in triage loop when you don't have a bespoke handler.
-#       wake_loop:
-#         loop_id: ""
-#         name: ""
-#         force_supervisor: false
-#         priority: ""
-#         instructions: ""
-#         tags: []
+#       wake_loop: null
 #       Wake is the deprecated inline-routing form. Entries that use
 #       it are auto-migrated onto the default handler at config load
 #       (a one-shot upgrade). New subscriptions should declare
 #       WakeLoop directly instead.
-#       wake:
-#         model: ""
-#         quality_floor: 0
-#         mission: ""
-#         local_only: ""
-#         delegation_gating: ""
-#         prefer_speed: ""
-#         exclude_tools: []
-#         extra_hints: {}
-#         instructions: ""
+#       wake: null
 #       InitialTags is the deprecated companion to Wake. Migrated
 #       values flow into the resulting wake_loop target's Tags field
 #       at load time, so per-iteration capability tag activation
@@ -721,27 +652,12 @@ talents_dir: ./talents
 #       is how every wake delivers; the target's own Spec.Profile
 #       governs routing. Point this at "mqtt-default-handler" for the
 #       built-in triage loop when you don't have a bespoke handler.
-#       wake_loop:
-#         loop_id: ""
-#         name: ""
-#         force_supervisor: false
-#         priority: ""
-#         instructions: ""
-#         tags: []
+#       wake_loop: null
 #       Wake is the deprecated inline-routing form. Entries that use
 #       it are auto-migrated onto the default handler at config load
 #       (a one-shot upgrade). New subscriptions should declare
 #       WakeLoop directly instead.
-#       wake:
-#         model: ""
-#         quality_floor: 0
-#         mission: ""
-#         local_only: ""
-#         delegation_gating: ""
-#         prefer_speed: ""
-#         exclude_tools: []
-#         extra_hints: {}
-#         instructions: ""
+#       wake: null
 #       InitialTags is the deprecated companion to Wake. Migrated
 #       values flow into the resulting wake_loop target's Tags field
 #       at load time, so per-iteration capability tag activation
@@ -756,13 +672,7 @@ talents_dir: ./talents
 #       is how every wake delivers; the target's own Spec.Profile
 #       governs routing. Point this at "mqtt-default-handler" for the
 #       built-in triage loop when you don't have a bespoke handler.
-#       wake_loop:
-#         loop_id: ""
-#         name: ""
-#         force_supervisor: false
-#         priority: ""
-#         instructions: ""
-#         tags: []
+#       wake_loop: null
 #       Wake is the deprecated inline-routing form. Entries that use
 #       it are auto-migrated onto the default handler at config load
 #       (a one-shot upgrade). New subscriptions should declare
@@ -1252,16 +1162,7 @@ archivist:
 #       max_iter: 0
 #       supervisor: false
 #       supervisor_prob: 0.0
-#       supervisor_profile:
-#         model: ""
-#         quality_floor: 0
-#         mission: ""
-#         local_only: ""
-#         delegation_gating: ""
-#         prefer_speed: ""
-#         exclude_tools: []
-#         extra_hints: {}
-#         instructions: ""
+#       supervisor_profile: null
 #       on_retrigger: 0
 #       routing_factors: {}
 #       delegation_gating: ""

--- a/examples/config.example.yaml
+++ b/examples/config.example.yaml
@@ -252,6 +252,41 @@ roots:
       # never replaces or removes from it. Use it to let an operator
       # co-author a signed root.
       allowed_signers: []
+      # Remote optionally makes this root a full git citizen that fetches,
+      # verifies, and (in bidirectional mode) pushes against a shared remote.
+      # Nil means local-only — behavior is byte-for-byte as it is without a
+      # remote. The remote is untrusted transport: it conveys commits but
+      # never confers trust, which comes only from signature verification
+      # against the out-of-tree trust_anchor. Ignored unless Enabled.
+      remote:
+        # URL is the remote git URL (SSH like user@host:path, ssh://…, or an
+        # https URL). Required.
+        url: ""
+        # Branch is the remote branch to track. Empty defaults to "main".
+        branch: ""
+        # Mode is required and explicit: "fetch" (pull the operator's signed
+        # commits in) or "bidirectional" (also push thane's own signed commits
+        # out). There is no default, so a one-way setup is never silent.
+        mode: ""
+        # Interval is the sync poll cadence as a Go duration (e.g. "60s").
+        # Empty defaults to 60s; "0" disables the timer (manual/trigger-only).
+        interval: ""
+        # TrustAnchor is the out-of-tree OpenSSH allowed_signers file that
+        # verification checks against. It must live outside the synced tree so a
+        # fetched commit can never rewrite the trust set. See #1135.
+        trust_anchor: ""
+        # Auth carries transport credentials only — never commit-signing
+        # material.
+        auth:
+          # SSHKey is the private key path for SSH transport, passed via
+          # GIT_SSH_COMMAND with IdentitiesOnly. Must not equal git.signing_key.
+          ssh_key: ""
+          # KnownHosts is the pinned known_hosts file, required for an SSH url:
+          # host-key verification is strict, with no trust-on-first-use.
+          known_hosts: ""
+          # Token is an https personal access token. Documented, but SSH is the
+          # recommended transport.
+          token: ""
   kb:
     # Path is the directory the root resolves to. Supports ~
     # expansion at resolver construction time. For the reserved
@@ -311,6 +346,41 @@ roots:
           # verify time; thane does not yet surface expiry.
           valid_after: ""
           valid_before: ""
+      # Remote optionally makes this root a full git citizen that fetches,
+      # verifies, and (in bidirectional mode) pushes against a shared remote.
+      # Nil means local-only — behavior is byte-for-byte as it is without a
+      # remote. The remote is untrusted transport: it conveys commits but
+      # never confers trust, which comes only from signature verification
+      # against the out-of-tree trust_anchor. Ignored unless Enabled.
+      remote:
+        # URL is the remote git URL (SSH like user@host:path, ssh://…, or an
+        # https URL). Required.
+        url: aimee@pocket.hollowoak.net:Thane/knowledge.git
+        # Branch is the remote branch to track. Empty defaults to "main".
+        branch: main
+        # Mode is required and explicit: "fetch" (pull the operator's signed
+        # commits in) or "bidirectional" (also push thane's own signed commits
+        # out). There is no default, so a one-way setup is never silent.
+        mode: bidirectional
+        # Interval is the sync poll cadence as a Go duration (e.g. "60s").
+        # Empty defaults to 60s; "0" disables the timer (manual/trigger-only).
+        interval: 60s
+        # TrustAnchor is the out-of-tree OpenSSH allowed_signers file that
+        # verification checks against. It must live outside the synced tree so a
+        # fetched commit can never rewrite the trust set. See #1135.
+        trust_anchor: ~/.thane/keys/kb.allowed_signers
+        # Auth carries transport credentials only — never commit-signing
+        # material.
+        auth:
+          # SSHKey is the private key path for SSH transport, passed via
+          # GIT_SSH_COMMAND with IdentitiesOnly. Must not equal git.signing_key.
+          ssh_key: ~/.thane/keys/transport_ed25519
+          # KnownHosts is the pinned known_hosts file, required for an SSH url:
+          # host-key verification is strict, with no trust-on-first-use.
+          known_hosts: ~/.thane/ssh/known_hosts
+          # Token is an https personal access token. Documented, but SSH is the
+          # recommended transport.
+          token: ""
   scratchpad:
     # Path is the directory the root resolves to. Supports ~
     # expansion at resolver construction time. For the reserved
@@ -351,6 +421,41 @@ roots:
       # never replaces or removes from it. Use it to let an operator
       # co-author a signed root.
       allowed_signers: []
+      # Remote optionally makes this root a full git citizen that fetches,
+      # verifies, and (in bidirectional mode) pushes against a shared remote.
+      # Nil means local-only — behavior is byte-for-byte as it is without a
+      # remote. The remote is untrusted transport: it conveys commits but
+      # never confers trust, which comes only from signature verification
+      # against the out-of-tree trust_anchor. Ignored unless Enabled.
+      remote:
+        # URL is the remote git URL (SSH like user@host:path, ssh://…, or an
+        # https URL). Required.
+        url: ""
+        # Branch is the remote branch to track. Empty defaults to "main".
+        branch: ""
+        # Mode is required and explicit: "fetch" (pull the operator's signed
+        # commits in) or "bidirectional" (also push thane's own signed commits
+        # out). There is no default, so a one-way setup is never silent.
+        mode: ""
+        # Interval is the sync poll cadence as a Go duration (e.g. "60s").
+        # Empty defaults to 60s; "0" disables the timer (manual/trigger-only).
+        interval: ""
+        # TrustAnchor is the out-of-tree OpenSSH allowed_signers file that
+        # verification checks against. It must live outside the synced tree so a
+        # fetched commit can never rewrite the trust set. See #1135.
+        trust_anchor: ""
+        # Auth carries transport credentials only — never commit-signing
+        # material.
+        auth:
+          # SSHKey is the private key path for SSH transport, passed via
+          # GIT_SSH_COMMAND with IdentitiesOnly. Must not equal git.signing_key.
+          ssh_key: ""
+          # KnownHosts is the pinned known_hosts file, required for an SSH url:
+          # host-key verification is strict, with no trust-on-first-use.
+          known_hosts: ""
+          # Token is an https personal access token. Documented, but SSH is the
+          # recommended transport.
+          token: ""
 #
 # (optional) Paths is the legacy directory-mapping block. Replaced by roots:.
 # paths: {}

--- a/internal/platform/config/config.go
+++ b/internal/platform/config/config.go
@@ -993,7 +993,8 @@ type DocumentRootGitRemoteConfig struct {
 	// https URL). Required.
 	URL string `yaml:"url"`
 
-	// Branch is the remote branch to track. Empty defaults to "main".
+	// Branch is the remote branch to track. Empty means the sync uses
+	// "main" (applied where the remote is consumed, not by config Load).
 	Branch string `yaml:"branch,omitempty"`
 
 	// Mode is required and explicit: "fetch" (pull the operator's signed
@@ -1002,7 +1003,8 @@ type DocumentRootGitRemoteConfig struct {
 	Mode string `yaml:"mode"`
 
 	// Interval is the sync poll cadence as a Go duration (e.g. "60s").
-	// Empty defaults to 60s; "0" disables the timer (manual/trigger-only).
+	// Empty means the sync uses 60s (applied where the remote is consumed,
+	// not by config Load); "0" disables the timer (manual/trigger-only).
 	Interval string `yaml:"interval,omitempty"`
 
 	// TrustAnchor is the out-of-tree OpenSSH allowed_signers file that
@@ -2891,8 +2893,11 @@ func validateGitRemote(root string, git DocumentRootGitConfig) error {
 	return nil
 }
 
-// isSSHGitURL reports whether a git remote URL uses SSH transport (scp-like
-// user@host:path or ssh://…), as opposed to https/git.
+// isSSHGitURL reports whether a git remote URL uses SSH transport (an ssh://
+// URL or the scp-like [user@]host:path form), as opposed to https/git. It
+// mirrors git's own rule: a URL with no scheme is scp-like when its first
+// colon comes before any slash — which also catches the user-less "host:repo"
+// form that must still require pinned host keys.
 func isSSHGitURL(url string) bool {
 	u := strings.TrimSpace(url)
 	if strings.HasPrefix(u, "ssh://") {
@@ -2901,7 +2906,12 @@ func isSSHGitURL(url string) bool {
 	if strings.Contains(u, "://") {
 		return false
 	}
-	return strings.Contains(u, "@") && strings.Contains(u, ":")
+	colon := strings.IndexByte(u, ':')
+	if colon < 0 {
+		return false // a local path, no remote host
+	}
+	slash := strings.IndexByte(u, '/')
+	return slash < 0 || colon < slash
 }
 
 // validateSigning checks the shared operator allowed-signers block.

--- a/internal/platform/config/config.go
+++ b/internal/platform/config/config.go
@@ -976,6 +976,60 @@ type DocumentRootGitConfig struct {
 	// never replaces or removes from it. Use it to let an operator
 	// co-author a signed root.
 	AllowedSigners []AllowedSigner `yaml:"allowed_signers,omitempty"`
+
+	// Remote optionally makes this root a full git citizen that fetches,
+	// verifies, and (in bidirectional mode) pushes against a shared remote.
+	// Nil means local-only — behavior is byte-for-byte as it is without a
+	// remote. The remote is untrusted transport: it conveys commits but
+	// never confers trust, which comes only from signature verification
+	// against the out-of-tree trust_anchor. Ignored unless Enabled.
+	Remote *DocumentRootGitRemoteConfig `yaml:"remote,omitempty"`
+}
+
+// DocumentRootGitRemoteConfig configures optional sync of a git-backed
+// document root against a shared remote.
+type DocumentRootGitRemoteConfig struct {
+	// URL is the remote git URL (SSH like user@host:path, ssh://…, or an
+	// https URL). Required.
+	URL string `yaml:"url"`
+
+	// Branch is the remote branch to track. Empty defaults to "main".
+	Branch string `yaml:"branch,omitempty"`
+
+	// Mode is required and explicit: "fetch" (pull the operator's signed
+	// commits in) or "bidirectional" (also push thane's own signed commits
+	// out). There is no default, so a one-way setup is never silent.
+	Mode string `yaml:"mode"`
+
+	// Interval is the sync poll cadence as a Go duration (e.g. "60s").
+	// Empty defaults to 60s; "0" disables the timer (manual/trigger-only).
+	Interval string `yaml:"interval,omitempty"`
+
+	// TrustAnchor is the out-of-tree OpenSSH allowed_signers file that
+	// verification checks against. It must live outside the synced tree so a
+	// fetched commit can never rewrite the trust set. See #1135.
+	TrustAnchor string `yaml:"trust_anchor,omitempty"`
+
+	// Auth carries transport credentials only — never commit-signing
+	// material.
+	Auth DocumentRootGitRemoteAuthConfig `yaml:"auth,omitempty"`
+}
+
+// DocumentRootGitRemoteAuthConfig carries transport credentials for a remote.
+// The transport key proves "who may reach the remote"; the signing key proves
+// "who authored the commit" — they are deliberately distinct.
+type DocumentRootGitRemoteAuthConfig struct {
+	// SSHKey is the private key path for SSH transport, passed via
+	// GIT_SSH_COMMAND with IdentitiesOnly. Must not equal git.signing_key.
+	SSHKey string `yaml:"ssh_key,omitempty"`
+
+	// KnownHosts is the pinned known_hosts file, required for an SSH url:
+	// host-key verification is strict, with no trust-on-first-use.
+	KnownHosts string `yaml:"known_hosts,omitempty"`
+
+	// Token is an https personal access token. Documented, but SSH is the
+	// recommended transport.
+	Token string `yaml:"token,omitempty"`
 }
 
 // HomeAssistantConfig configures the connection to a Home Assistant
@@ -2782,8 +2836,72 @@ func (c *Config) validateDocRoots() error {
 		if err := validateAllowedSigners(fmt.Sprintf("doc_roots.%s.git.allowed_signers", root), git.AllowedSigners); err != nil {
 			return err
 		}
+		if err := validateGitRemote(root, git); err != nil {
+			return err
+		}
 	}
 	return nil
+}
+
+// validateGitRemote fail-closed-checks an optional remote-sync block. The
+// structural invariants are enforced here; checks that need the resolved
+// on-disk repo path (that trust_anchor is genuinely outside the tree) run at
+// wiring time.
+func validateGitRemote(root string, git DocumentRootGitConfig) error {
+	r := git.Remote
+	if r == nil {
+		return nil
+	}
+	label := fmt.Sprintf("doc_roots.%s.git.remote", root)
+	if !git.Enabled {
+		return fmt.Errorf("%s requires doc_roots.%s.git.enabled", label, root)
+	}
+	if strings.TrimSpace(r.URL) == "" {
+		return fmt.Errorf("%s.url is required", label)
+	}
+	switch strings.TrimSpace(r.Mode) {
+	case "fetch":
+	case "bidirectional":
+		if !git.SignCommits {
+			return fmt.Errorf("%s.mode=bidirectional requires git.sign_commits: thane must sign the commits it pushes", label)
+		}
+	case "":
+		return fmt.Errorf("%s.mode is required and must be \"fetch\" or \"bidirectional\"", label)
+	default:
+		return fmt.Errorf("%s.mode %q must be \"fetch\" or \"bidirectional\"", label, r.Mode)
+	}
+	if v := strings.TrimSpace(r.Interval); v != "" && v != "0" {
+		if _, err := time.ParseDuration(v); err != nil {
+			return fmt.Errorf("%s.interval %q must be a Go duration like \"60s\" (or \"0\" to disable the timer): %w", label, r.Interval, err)
+		}
+	}
+	if isSSHGitURL(r.URL) && strings.TrimSpace(r.Auth.KnownHosts) == "" {
+		return fmt.Errorf("%s.auth.known_hosts is required for an SSH url (host keys are pinned; there is no trust-on-first-use)", label)
+	}
+	if key := strings.TrimSpace(r.Auth.SSHKey); key != "" && key == strings.TrimSpace(git.SigningKey) {
+		return fmt.Errorf("%s.auth.ssh_key must not be the same key as git.signing_key: transport auth and commit signing are separate", label)
+	}
+	// Verification needs an out-of-tree trust anchor; without it the
+	// operator's own signed history would read as untrusted and the root
+	// would boot permanently blocked.
+	verify := strings.TrimSpace(git.VerifySignatures)
+	if (verify == "warn" || verify == "required") && strings.TrimSpace(r.TrustAnchor) == "" {
+		return fmt.Errorf("%s.trust_anchor is required when verify_signatures is %q: it must be an out-of-tree allowed_signers file", label, verify)
+	}
+	return nil
+}
+
+// isSSHGitURL reports whether a git remote URL uses SSH transport (scp-like
+// user@host:path or ssh://…), as opposed to https/git.
+func isSSHGitURL(url string) bool {
+	u := strings.TrimSpace(url)
+	if strings.HasPrefix(u, "ssh://") {
+		return true
+	}
+	if strings.Contains(u, "://") {
+		return false
+	}
+	return strings.Contains(u, "@") && strings.Contains(u, ":")
 }
 
 // validateSigning checks the shared operator allowed-signers block.

--- a/internal/platform/config/example.go
+++ b/internal/platform/config/example.go
@@ -124,6 +124,17 @@ func ExampleConfig() *Config {
 						Key:       "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIO+3xdUdsJA9XoATiuDErHwn2cDSIO1U1/t+BuN6P3Gv",
 						Label:     "Bob (kb co-author)",
 					}},
+					Remote: &DocumentRootGitRemoteConfig{
+						URL:         "aimee@pocket.hollowoak.net:Thane/knowledge.git",
+						Branch:      "main",
+						Mode:        "bidirectional",
+						Interval:    "60s",
+						TrustAnchor: "~/.thane/keys/kb.allowed_signers",
+						Auth: DocumentRootGitRemoteAuthConfig{
+							SSHKey:     "~/.thane/keys/transport_ed25519",
+							KnownHosts: "~/.thane/ssh/known_hosts",
+						},
+					},
 				},
 			},
 			"scratchpad": {

--- a/internal/platform/config/gen/gencfg/main.go
+++ b/internal/platform/config/gen/gencfg/main.go
@@ -354,6 +354,13 @@ func buildValueNode(v reflect.Value, t reflect.Type, comments commentMap) *yaml.
 	// here, synthesize a zero value so the YAML block is still meaningful.
 	if t.Kind() == reflect.Pointer {
 		if v.IsNil() {
+			// A nil pointer to a composite (struct/map/slice) renders as an
+			// empty block that can trip fail-closed validation on parse; emit
+			// null so it round-trips back to a nil pointer. Scalar pointers
+			// keep a meaningful zero value.
+			if k := t.Elem().Kind(); k == reflect.Struct || k == reflect.Map || k == reflect.Slice {
+				return &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!null", Value: "null"}
+			}
 			zv := reflect.New(t.Elem()).Elem()
 			return buildValueNode(zv, t.Elem(), comments)
 		}

--- a/internal/platform/config/remote_config_test.go
+++ b/internal/platform/config/remote_config_test.go
@@ -1,0 +1,110 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidateGitRemote(t *testing.T) {
+	t.Parallel()
+
+	base := func() DocumentRootGitConfig {
+		return DocumentRootGitConfig{
+			Enabled:          true,
+			SignCommits:      true,
+			VerifySignatures: "required",
+			SigningKey:       "/keys/signing_ed25519",
+			Remote: &DocumentRootGitRemoteConfig{
+				URL:         "aimee@pocket.hollowoak.net:Thane/kb.git",
+				Mode:        "bidirectional",
+				Interval:    "60s",
+				TrustAnchor: "/keys/kb.allowed_signers",
+				Auth: DocumentRootGitRemoteAuthConfig{
+					SSHKey:     "/keys/transport_ed25519",
+					KnownHosts: "/ssh/known_hosts",
+				},
+			},
+		}
+	}
+
+	for _, tc := range []struct {
+		name   string
+		mutate func(*DocumentRootGitConfig)
+		want   string // substring of expected error; "" means valid
+	}{
+		{"valid bidirectional", func(*DocumentRootGitConfig) {}, ""},
+		{"nil remote is valid", func(g *DocumentRootGitConfig) { g.Remote = nil }, ""},
+		{"fetch mode does not require sign_commits", func(g *DocumentRootGitConfig) {
+			g.SignCommits = false
+			g.Remote.Mode = "fetch"
+		}, ""},
+		{"https url does not require known_hosts", func(g *DocumentRootGitConfig) {
+			g.Remote.URL = "https://example.com/kb.git"
+			g.Remote.Auth.KnownHosts = ""
+		}, ""},
+		{"remote requires git.enabled", func(g *DocumentRootGitConfig) { g.Enabled = false }, "requires"},
+		{"url required", func(g *DocumentRootGitConfig) { g.Remote.URL = "" }, "url is required"},
+		{"mode required", func(g *DocumentRootGitConfig) { g.Remote.Mode = "" }, "mode is required"},
+		{"mode invalid", func(g *DocumentRootGitConfig) { g.Remote.Mode = "sync" }, "must be"},
+		{"bidirectional requires sign_commits", func(g *DocumentRootGitConfig) { g.SignCommits = false }, "requires git.sign_commits"},
+		{"ssh url requires known_hosts", func(g *DocumentRootGitConfig) { g.Remote.Auth.KnownHosts = "" }, "known_hosts is required"},
+		{"transport key must differ from signing key", func(g *DocumentRootGitConfig) { g.Remote.Auth.SSHKey = g.SigningKey }, "must not be the same key"},
+		{"verify required needs trust_anchor", func(g *DocumentRootGitConfig) { g.Remote.TrustAnchor = "" }, "trust_anchor is required"},
+		{"bad interval", func(g *DocumentRootGitConfig) { g.Remote.Interval = "soon" }, "interval"},
+		{"interval 0 disables timer", func(g *DocumentRootGitConfig) { g.Remote.Interval = "0" }, ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			git := base()
+			tc.mutate(&git)
+			err := validateGitRemote("kb", git)
+			if tc.want == "" {
+				if err != nil {
+					t.Fatalf("validateGitRemote() = %v, want nil", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("validateGitRemote() = nil, want error containing %q", tc.want)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("validateGitRemote() = %v, want containing %q", err, tc.want)
+			}
+		})
+	}
+}
+
+// TestValidate_GitRemoteWired confirms the remote block is reached by
+// Config.Validate through validateDocRoots.
+func TestValidate_GitRemoteWired(t *testing.T) {
+	t.Parallel()
+	cfg := Default()
+	cfg.DocRoots = map[string]DocumentRootConfig{
+		"kb": {Git: DocumentRootGitConfig{
+			Enabled: true,
+			Remote:  &DocumentRootGitRemoteConfig{URL: "https://example.com/kb.git", Mode: "nope"},
+		}},
+	}
+	err := cfg.Validate()
+	if err == nil || !strings.Contains(err.Error(), "doc_roots.kb.git.remote.mode") {
+		t.Fatalf("Validate() = %v, want doc_roots.kb.git.remote.mode error", err)
+	}
+}
+
+func TestIsSSHGitURL(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		url string
+		ssh bool
+	}{
+		{"aimee@pocket.hollowoak.net:Thane/kb.git", true},
+		{"ssh://git@host/repo.git", true},
+		{"https://example.com/kb.git", false},
+		{"git://example.com/kb.git", false},
+		{"/local/path/repo.git", false},
+	} {
+		if got := isSSHGitURL(tc.url); got != tc.ssh {
+			t.Fatalf("isSSHGitURL(%q) = %v, want %v", tc.url, got, tc.ssh)
+		}
+	}
+}

--- a/internal/platform/config/remote_config_test.go
+++ b/internal/platform/config/remote_config_test.go
@@ -98,10 +98,12 @@ func TestIsSSHGitURL(t *testing.T) {
 		ssh bool
 	}{
 		{"aimee@pocket.hollowoak.net:Thane/kb.git", true},
+		{"pocket.hollowoak.net:Thane/kb.git", true}, // scp-like without a user
 		{"ssh://git@host/repo.git", true},
 		{"https://example.com/kb.git", false},
 		{"git://example.com/kb.git", false},
 		{"/local/path/repo.git", false},
+		{"./relative/path:notacolon.git", false}, // colon after a slash → local path
 	} {
 		if got := isSSHGitURL(tc.url); got != tc.ssh {
 			t.Fatalf("isSSHGitURL(%q) = %v, want %v", tc.url, got, tc.ssh)


### PR DESCRIPTION
## What

First slice of the git-remote sync feature (#1137): the **config surface and its fail-closed validation**. No live sync yet — this lands the schema and the guardrails so the transport and syncer PRs have something to build against.

## The block

An optional `remote` pointer under a root's `git:` — nil means local-only, byte-for-byte as today (a structural gate, not a sentinel string):

```yaml
git:
  enabled: true
  sign_commits: true
  verify_signatures: required
  signing_key: ~/.thane/keys/provenance_ed25519    # commit signing (unchanged)
  remote:
    url: aimee@pocket.hollowoak.net:Thane/knowledge.git
    mode: bidirectional                            # REQUIRED-EXPLICIT: fetch | bidirectional
    interval: 60s                                  # default 60s; "0" disables the timer
    trust_anchor: ~/.thane/keys/kb.allowed_signers # OUT-OF-TREE allowed_signers
    auth:
      ssh_key: ~/.thane/keys/transport_ed25519     # TRANSPORT key — distinct from signing_key
      known_hosts: ~/.thane/ssh/known_hosts        # required for SSH; no TOFU
```

Two deliberate shapes from the design: **`mode` is required-explicit** (the goal is co-authoring, which needs push, so a silent `fetch` default would quietly deliver half the loop), and there is **no `enabled` boolean** (presence of the block plus a non-empty `url` is the gate, collapsing the confusing nil/dormant/active three-state).

## Validation (fail-closed)

- `remote` requires `git.enabled`; `url` is required; `mode` is required and must be `fetch` or `bidirectional`.
- `bidirectional` requires `sign_commits` — thane must sign the commits it pushes.
- an SSH url requires `known_hosts` — host keys are pinned, no trust-on-first-use.
- the transport `ssh_key` must differ from the commit `signing_key` — transport auth and authorship are separate keys.
- `verify_signatures: warn|required` requires a `trust_anchor` — without it the operator's own signed history reads as untrusted and the root would boot permanently blocked.
- `interval` must parse as a Go duration (or `"0"`).

The one check deferred: that `trust_anchor` is *genuinely* outside the synced tree (not the in-tree `.allowed_signers` a fetch can rewrite) needs the resolved on-disk repo path, so it lands with the syncer wiring, alongside the transport/fetch plumbing.

## A scope note

The design's PR-2 was a `buildSignedCommit` single-parent refactor to seed a future merge phase. Since the **fast-forward-only MVP never builds a commit in the syncer** (a fast-forward is a pure ref move) and thane-authored merges are deferred, that seam would be unused — so I've deferred the refactor to land *with* the merge phase rather than add a speculative abstraction now. This PR is the real MVP foundation.

## Test plan

- [x] Table-driven `validateGitRemote` tests: valid bidirectional/fetch/https, plus every rejection (no enabled, no url, no/invalid mode, bidirectional-without-sign_commits, ssh-without-known_hosts, transport==signing key, verify-without-trust_anchor, bad interval).
- [x] `Config.Validate` wiring test and an `isSSHGitURL` table.
- [x] `examples/config.example.yaml` regenerated (the `kb` root shows a full remote example).
- [x] `just ci` green.

Refs #1137
