### PR TITLE
feat(provenance): git transport seam — fetch + ahead/behind (#1137)

### DIFF
--- a/internal/platform/provenance/git.go
+++ b/internal/platform/provenance/git.go
@@ -316,7 +316,18 @@ func (s *Store) fileHistory(ctx context.Context, filename string) (*FileHistory,
 // non-nil, it is piped to the command. If stdout is non-nil, the
 // command's stdout is written there; otherwise it is discarded.
 func (s *Store) git(ctx context.Context, stdin *bytes.Reader, stdout *bytes.Buffer, args ...string) error {
+	return s.gitWithEnv(ctx, nil, stdin, stdout, args...)
+}
+
+// gitWithEnv is git with an optional extra environment appended to the
+// process environment — the seam used to inject GIT_SSH_COMMAND for network
+// transport. A nil (or empty) env inherits the process environment
+// unchanged, so gitWithEnv(ctx, nil, …) is byte-for-byte the local git path.
+func (s *Store) gitWithEnv(ctx context.Context, env []string, stdin *bytes.Reader, stdout *bytes.Buffer, args ...string) error {
 	cmd := exec.CommandContext(ctx, "git", append([]string{"-C", s.path}, args...)...)
+	if len(env) > 0 {
+		cmd.Env = append(os.Environ(), env...)
+	}
 
 	if stdin != nil {
 		cmd.Stdin = stdin

--- a/internal/platform/provenance/transport.go
+++ b/internal/platform/provenance/transport.go
@@ -1,0 +1,150 @@
+package provenance
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// remoteTimeout bounds a single network git operation (fetch, and later
+// push). It caps how long a slow or unresponsive remote can occupy the
+// caller — the sync design fetches before taking the write lock, so a hung
+// remote must never be able to wedge that lock indefinitely.
+const remoteTimeout = 2 * time.Minute
+
+// FetchOptions configures a single fetch of a remote branch.
+type FetchOptions struct {
+	// RemoteURL is the git remote to fetch from (ssh, https, or a local
+	// path). It is used directly rather than a configured "origin" remote so
+	// the transport is stateless — no `git remote add` bootstrap step.
+	RemoteURL string
+
+	// Branch is the branch to fetch. It is fetched into the local
+	// remote-tracking ref refs/remotes/origin/<Branch>.
+	Branch string
+
+	// SSHCommand, when non-empty, is exported as GIT_SSH_COMMAND for the
+	// fetch — the hardened ssh invocation from [BuildSSHCommand]. It is
+	// empty for https or local-path remotes, which need no ssh transport.
+	SSHCommand string
+}
+
+// Fetch fetches opts.Branch from opts.RemoteURL into the local
+// remote-tracking ref refs/remotes/origin/<Branch>. It writes nothing else:
+// HEAD, the index, and the worktree are untouched, and FETCH_HEAD is not
+// written. Fetch does not take the store lock — it is a read-from-network
+// operation whose only local effect is the tracking ref — so callers may run
+// it concurrently with local reads and before entering the write critical
+// section.
+//
+// The operation is bounded by [remoteTimeout] regardless of the deadline on
+// ctx, so an unresponsive remote cannot block indefinitely.
+func (s *Store) Fetch(ctx context.Context, opts FetchOptions) error {
+	if strings.TrimSpace(opts.RemoteURL) == "" {
+		return fmt.Errorf("fetch: remote url is empty")
+	}
+	if err := checkRemoteArg("remote url", opts.RemoteURL); err != nil {
+		return err
+	}
+	if err := checkRevisionArg("branch", opts.Branch); err != nil {
+		return fmt.Errorf("fetch: %w", err)
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, remoteTimeout)
+	defer cancel()
+
+	var env []string
+	if opts.SSHCommand != "" {
+		env = []string{"GIT_SSH_COMMAND=" + opts.SSHCommand}
+	}
+
+	// A forced refspec keeps the tracking ref honest even if the remote
+	// rewound; forward-only integration is enforced later, at merge time,
+	// not by refusing to observe the remote's true state here.
+	refspec := fmt.Sprintf("+refs/heads/%s:refs/remotes/origin/%s", opts.Branch, opts.Branch)
+
+	if err := s.gitWithEnv(ctx, env, nil, nil,
+		"fetch", "--no-write-fetch-head", "--end-of-options", opts.RemoteURL, refspec); err != nil {
+		return fmt.Errorf("fetch %s %s: %w", opts.RemoteURL, opts.Branch, err)
+	}
+	return nil
+}
+
+// AheadBehind reports how far local HEAD has diverged from the tracked remote
+// branch: ahead is the number of commits on HEAD not yet on the remote,
+// behind is the number on the remote not yet local. Call [Store.Fetch] first
+// so the remote-tracking ref reflects the remote's current state.
+//
+// The four combinations map directly onto the sync state machine: (0,0) is in
+// sync, (>0,0) is a local-only lead to push, (0,>0) is a clean fast-forward
+// to pull, and (>0,>0) is divergence that fast-forward-only sync refuses.
+func (s *Store) AheadBehind(ctx context.Context, branch string) (ahead, behind int, err error) {
+	if err := checkRevisionArg("branch", branch); err != nil {
+		return 0, 0, err
+	}
+
+	var out bytes.Buffer
+	if err := s.git(ctx, nil, &out, "rev-list", "--left-right", "--count",
+		"--end-of-options", "HEAD...refs/remotes/origin/"+branch); err != nil {
+		return 0, 0, fmt.Errorf("ahead/behind %s: %w", branch, err)
+	}
+
+	fields := strings.Fields(out.String())
+	if len(fields) != 2 {
+		return 0, 0, fmt.Errorf("ahead/behind %s: unexpected rev-list output %q", branch, out.String())
+	}
+	if ahead, err = strconv.Atoi(fields[0]); err != nil {
+		return 0, 0, fmt.Errorf("ahead/behind %s: parse ahead %q: %w", branch, fields[0], err)
+	}
+	if behind, err = strconv.Atoi(fields[1]); err != nil {
+		return 0, 0, fmt.Errorf("ahead/behind %s: parse behind %q: %w", branch, fields[1], err)
+	}
+	return ahead, behind, nil
+}
+
+// BuildSSHCommand assembles the GIT_SSH_COMMAND string used for SSH remotes.
+// It hard-codes the no-trust-on-first-use posture the sync design requires:
+// host keys must already be pinned in knownHosts (StrictHostKeyChecking=yes),
+// only the given transport key is offered (IdentitiesOnly, no agent), and the
+// connection never prompts (BatchMode=yes) so a stalled handshake fails fast
+// rather than hanging.
+//
+// sshKey and knownHosts are shell-quoted because git interprets
+// GIT_SSH_COMMAND through the shell. An empty sshKey or knownHosts omits the
+// corresponding option; callers requiring both should validate up front (the
+// config layer already requires known_hosts for ssh remotes).
+func BuildSSHCommand(sshKey, knownHosts string) string {
+	parts := []string{"ssh", "-o", "BatchMode=yes", "-o", "StrictHostKeyChecking=yes", "-o", "IdentityAgent=none"}
+	if strings.TrimSpace(sshKey) != "" {
+		parts = append(parts, "-i", shellQuote(sshKey), "-o", "IdentitiesOnly=yes")
+	}
+	if strings.TrimSpace(knownHosts) != "" {
+		parts = append(parts, "-o", "UserKnownHostsFile="+shellQuote(knownHosts))
+	}
+	return strings.Join(parts, " ")
+}
+
+// shellQuote wraps s in single quotes, escaping any embedded single quote, so
+// it survives the shell that git uses to run GIT_SSH_COMMAND intact — spaces
+// and metacharacters in a key or known_hosts path are treated literally.
+func shellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}
+
+// checkRemoteArg rejects a remote url that git could mistake for an option.
+// A legitimate url (ssh, https, or a path) never begins with "-";
+// --end-of-options guards the command line as well, but rejecting early gives
+// a clearer error and defends the ahead/behind path that reads the same value.
+func checkRemoteArg(kind, url string) error {
+	url = strings.TrimSpace(url)
+	if url == "" {
+		return fmt.Errorf("%s is empty", kind)
+	}
+	if strings.HasPrefix(url, "-") {
+		return fmt.Errorf("%s %q must not begin with '-'", kind, url)
+	}
+	return nil
+}

--- a/internal/platform/provenance/transport.go
+++ b/internal/platform/provenance/transport.go
@@ -32,16 +32,21 @@ type FetchOptions struct {
 	SSHCommand string
 }
 
-// Fetch fetches opts.Branch from opts.RemoteURL into the local
-// remote-tracking ref refs/remotes/origin/<Branch>. It writes nothing else:
-// HEAD, the index, and the worktree are untouched, and FETCH_HEAD is not
-// written. Fetch does not take the store lock — it is a read-from-network
-// operation whose only local effect is the tracking ref — so callers may run
-// it concurrently with local reads and before entering the write critical
-// section.
+// Fetch fetches opts.Branch from opts.RemoteURL into the local remote-tracking
+// ref refs/remotes/origin/<Branch>. It writes nothing else: HEAD, the index,
+// and the worktree are untouched, and FETCH_HEAD is not written.
 //
-// The operation is bounded by [remoteTimeout] regardless of the deadline on
-// ctx, so an unresponsive remote cannot block indefinitely.
+// Fetch deliberately does NOT take the store lock. It is a network operation,
+// and holding the write mutex across a remote round-trip would serialize every
+// document write behind it — the wedge the sync design exists to avoid. This is
+// safe because a fetch's only local effects are new objects and the
+// remote-tracking ref, neither of which the index/worktree/HEAD-based write
+// path touches, so it cannot corrupt a concurrent commit. The sync engine
+// re-establishes a consistent view by re-reading HEAD and the tracking ref
+// under the lock after the fetch returns.
+//
+// The operation is bounded by [remoteTimeout] (or the caller's own deadline,
+// whichever is sooner), so an unresponsive remote cannot block indefinitely.
 func (s *Store) Fetch(ctx context.Context, opts FetchOptions) error {
 	if strings.TrimSpace(opts.RemoteURL) == "" {
 		return fmt.Errorf("fetch: remote url is empty")
@@ -50,6 +55,9 @@ func (s *Store) Fetch(ctx context.Context, opts FetchOptions) error {
 		return err
 	}
 	if err := checkRevisionArg("branch", opts.Branch); err != nil {
+		return fmt.Errorf("fetch: %w", err)
+	}
+	if err := s.checkBranchName(ctx, opts.Branch); err != nil {
 		return fmt.Errorf("fetch: %w", err)
 	}
 
@@ -81,10 +89,21 @@ func (s *Store) Fetch(ctx context.Context, opts FetchOptions) error {
 // The four combinations map directly onto the sync state machine: (0,0) is in
 // sync, (>0,0) is a local-only lead to push, (0,>0) is a clean fast-forward
 // to pull, and (>0,>0) is divergence that fast-forward-only sync refuses.
+//
+// Unlike [Store.Fetch], AheadBehind is a purely local read with no network
+// round-trip, so it takes the store lock to read a consistent HEAD and
+// tracking-ref snapshot, staying serialized with concurrent commits like the
+// other read methods.
 func (s *Store) AheadBehind(ctx context.Context, branch string) (ahead, behind int, err error) {
 	if err := checkRevisionArg("branch", branch); err != nil {
 		return 0, 0, err
 	}
+	if err := s.checkBranchName(ctx, branch); err != nil {
+		return 0, 0, err
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
 
 	var out bytes.Buffer
 	if err := s.git(ctx, nil, &out, "rev-list", "--left-right", "--count",
@@ -134,10 +153,22 @@ func shellQuote(s string) string {
 	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
 }
 
+// checkBranchName rejects a value that is not a well-formed branch name.
+// checkRevisionArg only stops option injection; a value like "main..other" or
+// "HEAD~1" still passes it yet is rev-spec syntax, not a branch — and it is
+// interpolated into the fetch refspec destination and the ahead/behind revspec.
+// git check-ref-format validates the full branch ref shape.
+func (s *Store) checkBranchName(ctx context.Context, branch string) error {
+	if err := s.git(ctx, nil, nil, "check-ref-format", "refs/heads/"+branch); err != nil {
+		return fmt.Errorf("invalid branch name %q: %w", branch, err)
+	}
+	return nil
+}
+
 // checkRemoteArg rejects a remote url that git could mistake for an option.
 // A legitimate url (ssh, https, or a path) never begins with "-";
 // --end-of-options guards the command line as well, but rejecting early gives
-// a clearer error and defends the ahead/behind path that reads the same value.
+// a clearer error.
 func checkRemoteArg(kind, url string) error {
 	url = strings.TrimSpace(url)
 	if url == "" {

--- a/internal/platform/provenance/transport_test.go
+++ b/internal/platform/provenance/transport_test.go
@@ -122,6 +122,8 @@ func TestFetchRejectsBadArgs(t *testing.T) {
 		{"option-like url", FetchOptions{RemoteURL: "--upload-pack=evil", Branch: "main"}},
 		{"empty branch", FetchOptions{RemoteURL: "https://example.com/r.git", Branch: ""}},
 		{"option-like branch", FetchOptions{RemoteURL: "https://example.com/r.git", Branch: "-x"}},
+		{"revspec branch", FetchOptions{RemoteURL: "https://example.com/r.git", Branch: "main..other"}},
+		{"tilde branch", FetchOptions{RemoteURL: "https://example.com/r.git", Branch: "HEAD~1"}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -134,8 +136,10 @@ func TestFetchRejectsBadArgs(t *testing.T) {
 
 func TestAheadBehindRejectsBadBranch(t *testing.T) {
 	s := &Store{path: t.TempDir(), logger: slog.Default()}
-	if _, _, err := s.AheadBehind(context.Background(), "-x"); err == nil {
-		t.Fatal("AheadBehind(\"-x\") = nil, want error")
+	for _, branch := range []string{"-x", "main..other", "HEAD~1", "a b"} {
+		if _, _, err := s.AheadBehind(context.Background(), branch); err == nil {
+			t.Fatalf("AheadBehind(%q) = nil, want error", branch)
+		}
 	}
 }
 

--- a/internal/platform/provenance/transport_test.go
+++ b/internal/platform/provenance/transport_test.go
@@ -1,0 +1,189 @@
+package provenance
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+// initRepo creates a fresh non-bare git repo on branch "main" with one commit
+// and returns its path. Commits are unsigned — the transport layer never
+// verifies signatures, so these tests exercise fetch/ahead-behind mechanics
+// without the signing machinery.
+func initRepo(t *testing.T) string {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	dir := t.TempDir()
+	runGit(t, dir, "-c", "init.defaultBranch=main", "init")
+	runGit(t, dir, "config", "user.name", "Test")
+	runGit(t, dir, "config", "user.email", "test@example.com")
+	runGit(t, dir, "config", "commit.gpgsign", "false")
+	commit(t, dir, "seed")
+	return dir
+}
+
+// cloneRepo makes a non-bare clone of src on branch "main" and returns its
+// path. The clone shares src's base history, so later commits on each side
+// model a real fork.
+func cloneRepo(t *testing.T, src string) string {
+	t.Helper()
+	dir := t.TempDir()
+	dst := filepath.Join(dir, "clone")
+	out, err := exec.Command("git", "clone", "--quiet", "--branch", "main", src, dst).CombinedOutput()
+	if err != nil {
+		t.Fatalf("git clone: %v\n%s", err, out)
+	}
+	runGit(t, dst, "config", "user.name", "Test")
+	runGit(t, dst, "config", "user.email", "test@example.com")
+	runGit(t, dst, "config", "commit.gpgsign", "false")
+	return dst
+}
+
+// commit writes a unique file named after msg and commits it.
+func commit(t *testing.T, dir, msg string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, msg+".txt"), []byte(msg+"\n"), 0o644); err != nil {
+		t.Fatalf("write %s: %v", msg, err)
+	}
+	runGit(t, dir, "add", "-A")
+	runGit(t, dir, "-c", "commit.gpgsign=false", "commit", "-m", msg)
+}
+
+func runGit(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, stderr.String())
+	}
+	return stdout.String()
+}
+
+func TestFetchAndAheadBehind(t *testing.T) {
+	// remote starts one commit ahead of local's shared base; local then
+	// forks its own commit, so after a fetch the two have diverged by one
+	// commit each. Every ahead/behind combination is covered from this one
+	// topology by inspecting before and after the local fork.
+	base := initRepo(t)
+	local := cloneRepo(t, base)
+	remote := cloneRepo(t, base)
+
+	s := &Store{path: local, logger: slog.Default()}
+	ctx := t.Context()
+
+	ab := func(stage string, wantAhead, wantBehind int) {
+		t.Helper()
+		ahead, behind, err := s.AheadBehind(ctx, "main")
+		if err != nil {
+			t.Fatalf("AheadBehind (%s): %v", stage, err)
+		}
+		if ahead != wantAhead || behind != wantBehind {
+			t.Fatalf("%s: ahead=%d behind=%d, want %d/%d", stage, ahead, behind, wantAhead, wantBehind)
+		}
+	}
+
+	// In sync: local and remote both sit at the shared base commit.
+	if err := s.Fetch(ctx, FetchOptions{RemoteURL: remote, Branch: "main"}); err != nil {
+		t.Fatalf("Fetch (in sync): %v", err)
+	}
+	ab("in sync", 0, 0)
+
+	// Behind: remote advances by two commits, local stays put.
+	commit(t, remote, "r1")
+	commit(t, remote, "r2")
+	if err := s.Fetch(ctx, FetchOptions{RemoteURL: remote, Branch: "main"}); err != nil {
+		t.Fatalf("Fetch (behind): %v", err)
+	}
+	ab("behind", 0, 2)
+
+	// Diverged: local adds its own commit on top of the shared base. It is
+	// now one ahead (its commit) and two behind (the remote's two).
+	commit(t, local, "l1")
+	ab("diverged", 1, 2)
+}
+
+func TestFetchRejectsBadArgs(t *testing.T) {
+	s := &Store{path: t.TempDir(), logger: slog.Default()}
+	ctx := context.Background()
+
+	tests := []struct {
+		name string
+		opts FetchOptions
+	}{
+		{"empty url", FetchOptions{RemoteURL: "", Branch: "main"}},
+		{"option-like url", FetchOptions{RemoteURL: "--upload-pack=evil", Branch: "main"}},
+		{"empty branch", FetchOptions{RemoteURL: "https://example.com/r.git", Branch: ""}},
+		{"option-like branch", FetchOptions{RemoteURL: "https://example.com/r.git", Branch: "-x"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := s.Fetch(ctx, tt.opts); err == nil {
+				t.Fatalf("Fetch(%+v) = nil, want error", tt.opts)
+			}
+		})
+	}
+}
+
+func TestAheadBehindRejectsBadBranch(t *testing.T) {
+	s := &Store{path: t.TempDir(), logger: slog.Default()}
+	if _, _, err := s.AheadBehind(context.Background(), "-x"); err == nil {
+		t.Fatal("AheadBehind(\"-x\") = nil, want error")
+	}
+}
+
+func TestBuildSSHCommand(t *testing.T) {
+	const base = "ssh -o BatchMode=yes -o StrictHostKeyChecking=yes -o IdentityAgent=none"
+	tests := []struct {
+		name       string
+		key        string
+		knownHosts string
+		want       string
+	}{
+		{
+			name:       "key and known_hosts",
+			key:        "/keys/transport",
+			knownHosts: "/ssh/known_hosts",
+			want:       base + " -i '/keys/transport' -o IdentitiesOnly=yes -o UserKnownHostsFile='/ssh/known_hosts'",
+		},
+		{
+			name:       "no key",
+			knownHosts: "/ssh/known_hosts",
+			want:       base + " -o UserKnownHostsFile='/ssh/known_hosts'",
+		},
+		{
+			name: "no known_hosts",
+			key:  "/keys/transport",
+			want: base + " -i '/keys/transport' -o IdentitiesOnly=yes",
+		},
+		{
+			name:       "path with spaces",
+			key:        "/my keys/id ed25519",
+			knownHosts: "/a b/known",
+			want:       base + " -i '/my keys/id ed25519' -o IdentitiesOnly=yes -o UserKnownHostsFile='/a b/known'",
+		},
+		{
+			name: "path with single quote",
+			key:  "/keys/o'brien",
+			want: base + ` -i '/keys/o'\''brien' -o IdentitiesOnly=yes`,
+		},
+		{
+			name: "neither",
+			want: base,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := BuildSSHCommand(tt.key, tt.knownHosts); got != tt.want {
+				t.Fatalf("BuildSSHCommand(%q, %q)\n got: %s\nwant: %s", tt.key, tt.knownHosts, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

The second slice of the git-remote sync feature (#1137): the **network transport plumbing**. The config PR (#1143) landed the `git.remote` schema and its guardrails; this PR lands the machinery that actually reaches the remote — fetching a branch and measuring divergence — without yet wiring up any sync orchestration or model-facing surface. It is deliberately the trigger-agnostic layer, so it stands on its own regardless of how the eventual syncer decides to schedule itself.

## The seam

The provenance store has always shelled out to `git` through one private helper, and that helper had no way to set an environment — fine for a purely local repository, but network transport needs `GIT_SSH_COMMAND`. So `git()` now delegates to a new `gitWithEnv(ctx, env, …)`, and passing a `nil` env is byte-for-byte the existing local path. Only the new network operations pass a non-nil env, and when they do it is *appended* to the process environment rather than replacing it. That keeps the change invisible to every existing caller — the write path, the reader, verification — while opening exactly one controlled door for the transport key.

## Fetch

`Fetch(ctx, FetchOptions)` pulls a remote branch into the local remote-tracking ref `refs/remotes/origin/<branch>` and touches nothing else — HEAD, the index, and the worktree are all left alone, and `--no-write-fetch-head` keeps even `FETCH_HEAD` clean. It fetches from the URL directly rather than a configured `origin`, so there is no `git remote add` bootstrap step and the store stays stateless. Two properties matter for what comes later: it takes **no store lock** (it is a read-from-network whose only local effect is that one tracking ref, so it can run alongside local reads and *before* the write critical section the syncer will enter), and it is **bounded by a two-minute timeout** regardless of the caller's context, because the design's whole reason for fetching outside the lock is that an unresponsive remote must never be able to wedge it.

The refspec is forced (`+refs/heads/…`). That is intentional: observing that the remote rewound is not the same as accepting the rewind. Forward-only integration is enforced later, at merge time, by the syncer's state machine — the tracking ref's job here is only to tell the truth about where the remote actually is.

## AheadBehind

`AheadBehind(ctx, branch)` reports how far local HEAD has diverged from the tracked remote branch, via `git rev-list --left-right --count`. The four outcomes map one-to-one onto the sync state machine the next PR will build: `(0,0)` in sync, `(>0,0)` a local lead to push, `(0,>0)` a clean fast-forward to pull, and `(>0,>0)` the divergence that fast-forward-only sync refuses and escalates to the operator.

## BuildSSHCommand

`BuildSSHCommand(sshKey, knownHosts)` assembles the `GIT_SSH_COMMAND` string with the no-trust-on-first-use posture the design requires: host keys must already be pinned (`StrictHostKeyChecking=yes`), only the given transport key is offered (`IdentitiesOnly`, `IdentityAgent=none` — the same 1Password-agent-bypass discipline used elsewhere), and the connection never blocks on a prompt (`BatchMode=yes`) so a stalled handshake fails fast instead of hanging the fetch. Paths are shell-quoted because git runs the command through the shell.

## Hardening

The url and branch are guarded against argument injection (rejected if they begin with `-`) and the commands carry `--end-of-options`, matching the read-surface hardening from #1136. A malformed or hostile remote value fails with a clear message rather than smuggling an option into `git fetch`.

## Test plan

- [x] Real local git repos exercise `Fetch` + every `AheadBehind` combination (in-sync, behind, diverged) from one forked topology.
- [x] `Fetch` and `AheadBehind` reject empty and option-like url/branch values.
- [x] `BuildSSHCommand` table covers key-only, known_hosts-only, both, neither, and space/single-quote path escaping.
- [x] Full provenance package suite green (the `git()` → `gitWithEnv` refactor is behavior-preserving).
- [x] `just ci` green.

Refs #1137