### PR TITLE
feat(provenance): fast-forward-only sync engine (#1137)

### DIFF
--- a/internal/platform/provenance/sync.go
+++ b/internal/platform/provenance/sync.go
@@ -1,0 +1,255 @@
+package provenance
+
+import (
+	"context"
+	"fmt"
+)
+
+// SyncMode selects whether a sync pushes local commits back to the remote.
+// The zero value is fetch-only — the safe default: an engine constructed
+// without an explicit mode never writes to the remote.
+type SyncMode int
+
+const (
+	// SyncModeFetch pulls fast-forwards from the remote but never pushes.
+	SyncModeFetch SyncMode = iota
+	// SyncModeBidirectional additionally pushes local commits that are a
+	// fast-forward of the remote.
+	SyncModeBidirectional
+)
+
+// SyncOutcome classifies the result of one sync pass. The values double as
+// stable strings for logs and the operability surface.
+type SyncOutcome string
+
+const (
+	// SyncClean means local and remote already agree (or, in fetch-only
+	// mode, the only difference is unpushed local commits — nothing to do).
+	SyncClean SyncOutcome = "clean"
+	// SyncFastForwarded means the local branch was advanced to the remote.
+	SyncFastForwarded SyncOutcome = "fast_forwarded"
+	// SyncPushed means local commits were pushed to the remote.
+	SyncPushed SyncOutcome = "pushed"
+	// SyncDiverged means both sides have unique commits; fast-forward-only
+	// sync cannot reconcile and refuses with no side effects.
+	SyncDiverged SyncOutcome = "diverged"
+	// SyncBlocked means the engine refused to integrate: an incoming commit
+	// failed verification, the worktree was dirty, HEAD was detached, or a
+	// similar fail-closed condition. Detail explains which.
+	SyncBlocked SyncOutcome = "blocked"
+)
+
+// SyncRequest parameterizes one sync pass. The engine is stateless: every
+// field comes from a root's git.remote config, and no cross-pass state is
+// carried. The operability layer builds this and serializes passes per root.
+type SyncRequest struct {
+	// RemoteURL is the git remote (ssh, https, or a local path).
+	RemoteURL string
+	// Branch is the branch synced on both sides.
+	Branch string
+	// SSHCommand is the GIT_SSH_COMMAND for an ssh remote (see
+	// [BuildSSHCommand]); empty for https or local remotes.
+	SSHCommand string
+	// Mode selects fetch-only vs bidirectional.
+	Mode SyncMode
+	// RequireVerify hard-gates every fast-forward on signature verification
+	// against the store's out-of-tree allowed-signers anchor. It must be
+	// true for any signed root synced from an untrusted remote; it does not
+	// downgrade to advisory ("warn") for a worktree-mutating fast-forward.
+	RequireVerify bool
+}
+
+// SyncResult reports what one pass observed and did. Ahead/Behind and the two
+// head SHAs are always populated (they feed the operability layer's reporting
+// and its deferred rewind detector); Detail carries the reason for a Blocked
+// or Diverged outcome.
+type SyncResult struct {
+	Outcome    SyncOutcome
+	Ahead      int
+	Behind     int
+	LocalHead  string
+	RemoteHead string
+	Detail     string
+}
+
+// Sync runs one fast-forward-only sync pass against the remote: fetch, then a
+// single locked critical section that verifies and integrates, then (for a
+// bidirectional local lead) a push performed outside the lock.
+//
+// The security posture, enforced step by step below, is: the remote is
+// untrusted transport; trust is decided per-commit against an out-of-tree
+// anchor over the exact incoming range; the branch only ever moves forward;
+// and the engine never force-pushes nor rewrites local history. A hostile or
+// broken remote can, at worst, leave the pass Blocked or Diverged — never
+// corrupt the signed document root.
+func (s *Store) Sync(ctx context.Context, req SyncRequest) (SyncResult, error) {
+	if err := checkRemoteArg("remote url", req.RemoteURL); err != nil {
+		return SyncResult{}, err
+	}
+	if err := checkRevisionArg("branch", req.Branch); err != nil {
+		return SyncResult{}, err
+	}
+	if err := s.checkBranchName(ctx, req.Branch); err != nil {
+		return SyncResult{}, err
+	}
+
+	// 1. Fetch — outside the lock. Its only local effect is the
+	// remote-tracking ref; it is bounded so a hung remote cannot delay the
+	// critical section. Fetch failure aborts before any classification.
+	if err := s.Fetch(ctx, FetchOptions{RemoteURL: req.RemoteURL, Branch: req.Branch, SSHCommand: req.SSHCommand}); err != nil {
+		return SyncResult{}, err
+	}
+
+	// 2. Verify + integrate — one critical section under the store lock.
+	res, pushSHA, err := s.syncLocked(ctx, req)
+	if err != nil {
+		return res, err
+	}
+
+	// 3. Push — outside the lock, so a slow remote cannot wedge document
+	// writes. The captured local SHA is pushed with a fixed refspec, so a
+	// concurrent local commit landing after the lock released does not change
+	// what we push; a remote that advanced under us rejects the non-forced
+	// push and the next pass reclassifies.
+	if pushSHA != "" {
+		if err := s.push(ctx, req.RemoteURL, req.Branch, pushSHA, req.SSHCommand); err != nil {
+			return res, fmt.Errorf("push: %w", err)
+		}
+		res.Outcome = SyncPushed
+	}
+	return res, nil
+}
+
+// syncLocked is the critical section: it captures the two heads immutably,
+// classifies, and (for a fast-forward) verifies and advances the branch. It
+// returns a non-empty pushSHA to signal the caller to push that commit after
+// the lock is released; it never performs the network push itself.
+func (s *Store) syncLocked(ctx context.Context, req SyncRequest) (SyncResult, string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// Fail closed on the trust anchor before touching any git state. Re-run
+	// every pass (not once at construction): the anchor path is compared
+	// against the live, post-fetch worktree.
+	if req.RequireVerify {
+		if err := s.assertAnchorOutsideTree(); err != nil {
+			return SyncResult{}, "", err
+		}
+	}
+
+	// HEAD must symbolically track the configured branch. A detached HEAD or
+	// a branch-name mismatch is refused, never silently overwritten — the
+	// fast-forward and push both assume HEAD == refs/heads/<branch>. (An
+	// unborn HEAD still has a symbolic ref, so it passes here and is caught
+	// at the revParse below instead.)
+	branch, err := s.symbolicBranch(ctx)
+	if err != nil {
+		return SyncResult{Outcome: SyncBlocked, Detail: "repository HEAD is detached; sync requires HEAD on branch " + req.Branch}, "", nil
+	}
+	if branch != req.Branch {
+		return SyncResult{Outcome: SyncBlocked, Detail: fmt.Sprintf("repository is on branch %q, not the configured sync branch %q", branch, req.Branch)}, "", nil
+	}
+
+	// Capture both heads ONCE, by SHA. Every subsequent git operation
+	// consumes these values — never the ref names — so a concurrent lock-free
+	// fetch moving the tracking ref cannot make us verify one commit and
+	// fast-forward to another (TOCTOU). An unborn HEAD fails rev-parse here,
+	// yielding a clear error rather than a mutation.
+	localHead, err := s.revParse(ctx, "HEAD")
+	if err != nil {
+		return SyncResult{}, "", fmt.Errorf("resolve local HEAD (an unborn repository cannot be fast-forward-synced): %w", err)
+	}
+	remoteHead, err := s.revParse(ctx, "refs/remotes/origin/"+req.Branch)
+	if err != nil {
+		return SyncResult{}, "", fmt.Errorf("resolve fetched remote head for %q: %w", req.Branch, err)
+	}
+
+	ahead, behind, err := s.countAheadBehind(ctx, localHead, remoteHead)
+	if err != nil {
+		return SyncResult{}, "", fmt.Errorf("compute ahead/behind: %w", err)
+	}
+
+	res := SyncResult{Ahead: ahead, Behind: behind, LocalHead: localHead, RemoteHead: remoteHead}
+
+	switch {
+	case ahead == 0 && behind == 0:
+		// Already in sync. Touch nothing — is-ancestor is true for equal
+		// refs, so the fast-forward path must never run here.
+		res.Outcome = SyncClean
+		return res, "", nil
+
+	case ahead == 0 && behind > 0:
+		return s.fastForwardLocked(ctx, req, res)
+
+	case ahead > 0 && behind == 0:
+		if req.Mode == SyncModeBidirectional {
+			// Push happens after the lock releases; signal it by SHA so the
+			// exact classified commit is what gets pushed.
+			return res, localHead, nil
+		}
+		// Fetch-only: an unpushed local lead is expected and needs no action.
+		res.Outcome = SyncClean
+		return res, "", nil
+
+	default: // ahead > 0 && behind > 0
+		res.Outcome = SyncDiverged
+		res.Detail = fmt.Sprintf("local and remote diverged (%d local, %d remote); fast-forward-only sync cannot reconcile — resolve on the workstation", ahead, behind)
+		return res, "", nil
+	}
+}
+
+// fastForwardLocked handles the behind>0 && ahead==0 case under the held lock:
+// it refuses a dirty worktree, re-proves true ancestry over the captured SHAs,
+// verifies every incoming commit, and only then advances the branch.
+func (s *Store) fastForwardLocked(ctx context.Context, req SyncRequest, res SyncResult) (SyncResult, string, error) {
+	// Never destroy uncommitted local work to make a sync succeed.
+	clean, err := s.worktreeMatchesHead(ctx)
+	if err != nil {
+		return SyncResult{}, "", fmt.Errorf("check worktree: %w", err)
+	}
+	if !clean {
+		res.Outcome = SyncBlocked
+		res.Detail = "worktree has uncommitted changes; refusing to fast-forward over them"
+		return res, "", nil
+	}
+
+	// Ancestry is the sole authority for a fast-forward. ahead==0 implies it,
+	// but prove it over the captured SHAs anyway — never mutate on doubt.
+	anc, err := s.isAncestor(ctx, res.LocalHead, res.RemoteHead)
+	if err != nil {
+		return SyncResult{}, "", fmt.Errorf("ancestry check: %w", err)
+	}
+	if !anc {
+		res.Outcome = SyncBlocked
+		res.Detail = "local head is not an ancestor of the remote head; refusing a non-fast-forward"
+		return res, "", nil
+	}
+
+	// Verify EVERY incoming commit (localHead..remoteHead) against the
+	// out-of-tree anchor, fail-closed. This runs before the branch moves.
+	if req.RequireVerify {
+		commits, err := s.rangeCommits(ctx, res.LocalHead, res.RemoteHead)
+		if err != nil {
+			return SyncResult{}, "", fmt.Errorf("enumerate incoming commits: %w", err)
+		}
+		if len(commits) == 0 {
+			// behind>0 guarantees at least one incoming commit; an empty
+			// enumeration means verification would be vacuous — block, never
+			// fast-forward unverified.
+			res.Outcome = SyncBlocked
+			res.Detail = "no incoming commits enumerated despite the remote being ahead; refusing a vacuous verification"
+			return res, "", nil
+		}
+		if reason := s.firstUntrusted(ctx, commits); reason != "" {
+			res.Outcome = SyncBlocked
+			res.Detail = reason
+			return res, "", nil
+		}
+	}
+
+	if err := s.fastForward(ctx, res.RemoteHead); err != nil {
+		return SyncResult{}, "", fmt.Errorf("fast-forward: %w", err)
+	}
+	res.Outcome = SyncFastForwarded
+	return res, "", nil
+}

--- a/internal/platform/provenance/sync.go
+++ b/internal/platform/provenance/sync.go
@@ -59,10 +59,12 @@ type SyncRequest struct {
 	RequireVerify bool
 }
 
-// SyncResult reports what one pass observed and did. Ahead/Behind and the two
-// head SHAs are always populated (they feed the operability layer's reporting
-// and its deferred rewind detector); Detail carries the reason for a Blocked
-// or Diverged outcome.
+// SyncResult reports what one pass observed and did. Once a pass reaches
+// classification, Ahead/Behind and the two head SHAs are populated (they feed
+// the operability layer's reporting and its deferred rewind detector); a pass
+// blocked before then — a detached HEAD or a branch mismatch, caught before
+// the heads are resolved — leaves them zero and explains why in Detail. Detail
+// carries the reason for any Blocked or Diverged outcome.
 type SyncResult struct {
 	Outcome    SyncOutcome
 	Ahead      int
@@ -144,7 +146,7 @@ func (s *Store) syncLocked(ctx context.Context, req SyncRequest) (SyncResult, st
 	// at the revParse below instead.)
 	branch, err := s.symbolicBranch(ctx)
 	if err != nil {
-		return SyncResult{Outcome: SyncBlocked, Detail: "repository HEAD is detached; sync requires HEAD on branch " + req.Branch}, "", nil
+		return SyncResult{Outcome: SyncBlocked, Detail: fmt.Sprintf("cannot resolve HEAD to a branch (a detached HEAD, or an unhealthy repository); sync requires HEAD on branch %q: %v", req.Branch, err)}, "", nil
 	}
 	if branch != req.Branch {
 		return SyncResult{Outcome: SyncBlocked, Detail: fmt.Sprintf("repository is on branch %q, not the configured sync branch %q", branch, req.Branch)}, "", nil

--- a/internal/platform/provenance/sync_test.go
+++ b/internal/platform/provenance/sync_test.go
@@ -1,0 +1,362 @@
+package provenance
+
+import (
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// syncFixture holds the pieces shared by the sync tests: an out-of-tree
+// allowed-signers anchor trusting thane's key, and thane's signer.
+type syncFixture struct {
+	signer *SSHFileSigner
+	anchor string
+}
+
+func newSyncFixture(t *testing.T) syncFixture {
+	t.Helper()
+	signer := testSigner(t)
+	anchorDir := t.TempDir()
+	anchor := filepath.Join(anchorDir, "kb.allowed_signers")
+	if err := os.WriteFile(anchor, []byte(AgentPrincipal+" "+signer.PublicKey()+"\n"), 0o644); err != nil {
+		t.Fatalf("write anchor: %v", err)
+	}
+	return syncFixture{signer: signer, anchor: anchor}
+}
+
+// newSyncStore builds a provenance store verifying against the fixture's
+// out-of-tree anchor, signed by the given signer (thane's by default).
+func (f syncFixture) newSyncStore(t *testing.T, signer *SSHFileSigner) *Store {
+	t.Helper()
+	dir := t.TempDir()
+	s, err := NewWithOptions(dir, signer, slog.Default(), Options{AllowedSignersPath: f.anchor})
+	if err != nil {
+		t.Fatalf("NewWithOptions: %v", err)
+	}
+	return s
+}
+
+func writeStore(t *testing.T, s *Store, name, content string) {
+	t.Helper()
+	if err := s.Write(t.Context(), name, content, "commit "+name); err != nil {
+		t.Fatalf("Write %s: %v", name, err)
+	}
+}
+
+func headBranch(t *testing.T, dir string) string {
+	t.Helper()
+	return strings.TrimSpace(runGit(t, dir, "symbolic-ref", "--short", "HEAD"))
+}
+
+func headSHA(t *testing.T, dir string) string {
+	t.Helper()
+	return strings.TrimSpace(runGit(t, dir, "rev-parse", "HEAD"))
+}
+
+// cloneWorktree clones src into a fresh non-bare repo tracking the same
+// default branch and returns its path. Used when the remote must accept new
+// commits authored through a provenance store.
+func cloneWorktree(t *testing.T, src string) string {
+	t.Helper()
+	dst := filepath.Join(t.TempDir(), "remote")
+	runGitAt(t, "clone", "--quiet", src, dst)
+	return dst
+}
+
+// cloneBare clones src into a bare repo (which accepts pushes to any branch)
+// and returns its path.
+func cloneBare(t *testing.T, src string) string {
+	t.Helper()
+	dst := filepath.Join(t.TempDir(), "remote.git")
+	runGitAt(t, "clone", "--quiet", "--bare", src, dst)
+	return dst
+}
+
+func runGitAt(t *testing.T, args ...string) {
+	t.Helper()
+	// runGit requires a -C dir; for clone the dir is implicit, so shell out
+	// via runGit against the current directory using an explicit form.
+	runGit(t, ".", args...)
+}
+
+// TestSyncClean: local and remote agree — the pass touches nothing.
+func TestSyncClean(t *testing.T) {
+	f := newSyncFixture(t)
+	local := f.newSyncStore(t, f.signer)
+	writeStore(t, local, "a.md", "a\n")
+	branch := headBranch(t, local.path)
+	remote := cloneBare(t, local.path)
+
+	before := headSHA(t, local.path)
+	res, err := local.Sync(t.Context(), SyncRequest{RemoteURL: remote, Branch: branch, Mode: SyncModeBidirectional, RequireVerify: true})
+	if err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+	if res.Outcome != SyncClean {
+		t.Fatalf("Outcome = %q, want clean (detail %q)", res.Outcome, res.Detail)
+	}
+	if headSHA(t, local.path) != before {
+		t.Fatalf("local head moved on a clean sync")
+	}
+}
+
+// TestSyncFastForwardTrusted: remote is ahead by trusted commits — local
+// fast-forwards to it.
+func TestSyncFastForwardTrusted(t *testing.T) {
+	f := newSyncFixture(t)
+	local := f.newSyncStore(t, f.signer)
+	writeStore(t, local, "a.md", "a\n")
+	base := headSHA(t, local.path)
+	branch := headBranch(t, local.path)
+
+	// Advance local two trusted commits, clone the remote at that tip, then
+	// rewind local to base so the remote is two ahead.
+	writeStore(t, local, "b.md", "b\n")
+	writeStore(t, local, "c.md", "c\n")
+	tip := headSHA(t, local.path)
+	remote := cloneBare(t, local.path)
+	runGit(t, local.path, "reset", "--hard", base)
+
+	res, err := local.Sync(t.Context(), SyncRequest{RemoteURL: remote, Branch: branch, Mode: SyncModeBidirectional, RequireVerify: true})
+	if err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+	if res.Outcome != SyncFastForwarded {
+		t.Fatalf("Outcome = %q, want fast_forwarded (detail %q)", res.Outcome, res.Detail)
+	}
+	if got := headSHA(t, local.path); got != tip {
+		t.Fatalf("local head = %s, want %s (should have advanced to remote tip)", shorten(got), shorten(tip))
+	}
+}
+
+// TestSyncBlockedLaundering is the load-bearing security test: a range
+// A(trusted)-X(untrusted)-T(trusted) whose TIP verifies but whose middle
+// commit is signed by a key absent from the anchor. Range verification (not
+// tip verification) must block, and local must not move.
+func TestSyncBlockedLaundering(t *testing.T) {
+	f := newSyncFixture(t)
+	local := f.newSyncStore(t, f.signer)
+	writeStore(t, local, "a.md", "a\n") // C1, trusted
+	branch := headBranch(t, local.path)
+	base := headSHA(t, local.path)
+
+	remote := cloneWorktree(t, local.path)
+
+	// C2 signed by an attacker key NOT in the anchor (a "U" verdict).
+	attacker := testSigner(t)
+	attackerStore, err := NewWithOptions(remote, attacker, slog.Default(), Options{AllowedSignersPath: f.anchor})
+	if err != nil {
+		t.Fatalf("attacker store: %v", err)
+	}
+	writeStore(t, attackerStore, "x.md", "x\n")
+
+	// C3 signed by thane (trusted) on top — so the tip verifies.
+	thaneRemote, err := NewWithOptions(remote, f.signer, slog.Default(), Options{AllowedSignersPath: f.anchor})
+	if err != nil {
+		t.Fatalf("thane remote store: %v", err)
+	}
+	writeStore(t, thaneRemote, "t.md", "t\n")
+
+	res, err := local.Sync(t.Context(), SyncRequest{RemoteURL: remote, Branch: branch, Mode: SyncModeBidirectional, RequireVerify: true})
+	if err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+	if res.Outcome != SyncBlocked {
+		t.Fatalf("Outcome = %q, want blocked (detail %q)", res.Outcome, res.Detail)
+	}
+	if !strings.Contains(res.Detail, "not trusted") {
+		t.Fatalf("Detail = %q, want an untrusted-commit reason", res.Detail)
+	}
+	if headSHA(t, local.path) != base {
+		t.Fatalf("local head moved despite a blocked laundering attempt")
+	}
+}
+
+// TestSyncBlockedUnverifiedSkippedWhenVerifyOff shows the mode is honored:
+// with RequireVerify=false, an untrusted range still fast-forwards. (The
+// operability layer sets RequireVerify=true for signed roots; this documents
+// the engine mechanism.)
+func TestSyncFastForwardNoVerify(t *testing.T) {
+	f := newSyncFixture(t)
+	local := f.newSyncStore(t, f.signer)
+	writeStore(t, local, "a.md", "a\n")
+	branch := headBranch(t, local.path)
+	base := headSHA(t, local.path)
+
+	remote := cloneWorktree(t, local.path)
+	attacker := testSigner(t)
+	attackerStore, err := NewWithOptions(remote, attacker, slog.Default(), Options{AllowedSignersPath: f.anchor})
+	if err != nil {
+		t.Fatalf("attacker store: %v", err)
+	}
+	writeStore(t, attackerStore, "x.md", "x\n")
+	tip := headSHA(t, remote)
+
+	res, err := local.Sync(t.Context(), SyncRequest{RemoteURL: remote, Branch: branch, Mode: SyncModeFetch, RequireVerify: false})
+	if err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+	if res.Outcome != SyncFastForwarded {
+		t.Fatalf("Outcome = %q, want fast_forwarded with verify off (detail %q)", res.Outcome, res.Detail)
+	}
+	if got := headSHA(t, local.path); got != tip {
+		t.Fatalf("local head = %s, want %s", shorten(got), shorten(tip))
+	}
+	_ = base
+}
+
+// TestSyncBlockedDirtyWorktree: a behind local with uncommitted tracked
+// changes refuses the fast-forward rather than clobbering them.
+func TestSyncBlockedDirtyWorktree(t *testing.T) {
+	f := newSyncFixture(t)
+	local := f.newSyncStore(t, f.signer)
+	writeStore(t, local, "a.md", "a\n")
+	base := headSHA(t, local.path)
+	branch := headBranch(t, local.path)
+	writeStore(t, local, "b.md", "b\n")
+	remote := cloneBare(t, local.path)
+	runGit(t, local.path, "reset", "--hard", base)
+
+	// Dirty a tracked file.
+	if err := os.WriteFile(filepath.Join(local.path, "a.md"), []byte("a dirty\n"), 0o644); err != nil {
+		t.Fatalf("dirty write: %v", err)
+	}
+
+	res, err := local.Sync(t.Context(), SyncRequest{RemoteURL: remote, Branch: branch, Mode: SyncModeBidirectional, RequireVerify: true})
+	if err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+	if res.Outcome != SyncBlocked {
+		t.Fatalf("Outcome = %q, want blocked (detail %q)", res.Outcome, res.Detail)
+	}
+	if headSHA(t, local.path) != base {
+		t.Fatalf("local head moved despite a dirty worktree")
+	}
+}
+
+// TestSyncDiverged: both sides have unique commits — refuse with no effects.
+func TestSyncDiverged(t *testing.T) {
+	f := newSyncFixture(t)
+	local := f.newSyncStore(t, f.signer)
+	writeStore(t, local, "a.md", "a\n")
+	branch := headBranch(t, local.path)
+
+	remote := cloneWorktree(t, local.path)
+	remoteStore, err := NewWithOptions(remote, f.signer, slog.Default(), Options{AllowedSignersPath: f.anchor})
+	if err != nil {
+		t.Fatalf("remote store: %v", err)
+	}
+	writeStore(t, remoteStore, "r.md", "r\n") // remote-only commit
+	writeStore(t, local, "l.md", "l\n")       // local-only commit
+	localTip := headSHA(t, local.path)
+
+	res, err := local.Sync(t.Context(), SyncRequest{RemoteURL: remote, Branch: branch, Mode: SyncModeBidirectional, RequireVerify: true})
+	if err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+	if res.Outcome != SyncDiverged {
+		t.Fatalf("Outcome = %q, want diverged (detail %q)", res.Outcome, res.Detail)
+	}
+	if headSHA(t, local.path) != localTip {
+		t.Fatalf("local head moved on a diverged sync")
+	}
+}
+
+// TestSyncPush: a bidirectional local lead is pushed; fetch-only is not.
+func TestSyncPush(t *testing.T) {
+	f := newSyncFixture(t)
+	local := f.newSyncStore(t, f.signer)
+	writeStore(t, local, "a.md", "a\n")
+	branch := headBranch(t, local.path)
+	remote := cloneBare(t, local.path)
+	remoteBase := strings.TrimSpace(runGit(t, remote, "rev-parse", "refs/heads/"+branch))
+
+	writeStore(t, local, "b.md", "b\n") // local now one ahead
+	localTip := headSHA(t, local.path)
+
+	// Fetch-only: no push.
+	res, err := local.Sync(t.Context(), SyncRequest{RemoteURL: remote, Branch: branch, Mode: SyncModeFetch, RequireVerify: true})
+	if err != nil {
+		t.Fatalf("Sync fetch-only: %v", err)
+	}
+	if res.Outcome != SyncClean {
+		t.Fatalf("fetch-only Outcome = %q, want clean", res.Outcome)
+	}
+	if got := strings.TrimSpace(runGit(t, remote, "rev-parse", "refs/heads/"+branch)); got != remoteBase {
+		t.Fatalf("remote advanced under fetch-only mode: %s", shorten(got))
+	}
+
+	// Bidirectional: push.
+	res, err = local.Sync(t.Context(), SyncRequest{RemoteURL: remote, Branch: branch, Mode: SyncModeBidirectional, RequireVerify: true})
+	if err != nil {
+		t.Fatalf("Sync bidirectional: %v", err)
+	}
+	if res.Outcome != SyncPushed {
+		t.Fatalf("bidirectional Outcome = %q, want pushed (detail %q)", res.Outcome, res.Detail)
+	}
+	if got := strings.TrimSpace(runGit(t, remote, "rev-parse", "refs/heads/"+branch)); got != localTip {
+		t.Fatalf("remote head = %s, want %s after push", shorten(got), shorten(localTip))
+	}
+}
+
+// TestSyncBlockedDetachedHead: a detached HEAD refuses to sync.
+func TestSyncBlockedDetachedHead(t *testing.T) {
+	f := newSyncFixture(t)
+	local := f.newSyncStore(t, f.signer)
+	writeStore(t, local, "a.md", "a\n")
+	branch := headBranch(t, local.path)
+	remote := cloneBare(t, local.path)
+	runGit(t, local.path, "checkout", "--detach")
+
+	res, err := local.Sync(t.Context(), SyncRequest{RemoteURL: remote, Branch: branch, Mode: SyncModeBidirectional, RequireVerify: true})
+	if err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+	if res.Outcome != SyncBlocked {
+		t.Fatalf("Outcome = %q, want blocked on detached HEAD (detail %q)", res.Outcome, res.Detail)
+	}
+}
+
+func TestAssertAnchorOutsideTree(t *testing.T) {
+	repo := t.TempDir()
+
+	// Empty anchor → refuse.
+	s := &Store{path: repo, allowedSignersPath: "", logger: slog.Default()}
+	if err := s.assertAnchorOutsideTree(); err == nil {
+		t.Fatal("empty anchor accepted, want error")
+	}
+
+	// In-tree anchor → refuse.
+	s = &Store{path: repo, allowedSignersPath: filepath.Join(repo, ".allowed_signers"), logger: slog.Default()}
+	if err := s.assertAnchorOutsideTree(); err == nil {
+		t.Fatal("in-tree anchor accepted, want error")
+	}
+
+	// Out-of-tree anchor → ok.
+	outside := filepath.Join(t.TempDir(), "anchor")
+	s = &Store{path: repo, allowedSignersPath: outside, logger: slog.Default()}
+	if err := s.assertAnchorOutsideTree(); err != nil {
+		t.Fatalf("out-of-tree anchor rejected: %v", err)
+	}
+}
+
+func TestIsWithin(t *testing.T) {
+	sep := string(filepath.Separator)
+	tests := []struct {
+		parent, child string
+		want          bool
+	}{
+		{sep + "a" + sep + "repo", sep + "a" + sep + "repo" + sep + ".allowed_signers", true},
+		{sep + "a" + sep + "repo", sep + "a" + sep + "repo", true},
+		{sep + "a" + sep + "repo", sep + "a" + sep + "anchor", false},
+		{sep + "a" + sep + "repo", sep + "a" + sep + "repo-2" + sep + "x", false}, // sibling prefix
+		{sep + "a" + sep + "repo", sep + "a", false},                              // parent of parent
+	}
+	for _, tt := range tests {
+		if got := isWithin(tt.parent, tt.child); got != tt.want {
+			t.Errorf("isWithin(%q, %q) = %v, want %v", tt.parent, tt.child, got, tt.want)
+		}
+	}
+}

--- a/internal/platform/provenance/sync_test.go
+++ b/internal/platform/provenance/sync_test.go
@@ -342,6 +342,37 @@ func TestAssertAnchorOutsideTree(t *testing.T) {
 	}
 }
 
+// TestAnchorContainmentSymlinkLeaf exercises the case resolveReal exists for:
+// an anchor whose leaf does not exist yet and whose path reaches the repo
+// through a symlink. resolveReal must resolve the symlinked ancestor so the
+// containment check still catches it — the class of macOS /var → /private/var
+// resolution bug the walk-to-existing-ancestor logic guards against.
+func TestAnchorContainmentSymlinkLeaf(t *testing.T) {
+	base := t.TempDir()
+	realRepo := filepath.Join(base, "realrepo")
+	if err := os.MkdirAll(realRepo, 0o755); err != nil {
+		t.Fatalf("mkdir realRepo: %v", err)
+	}
+	linkRepo := filepath.Join(base, "linkrepo")
+	if err := os.Symlink(realRepo, linkRepo); err != nil {
+		t.Skipf("symlinks unsupported: %v", err)
+	}
+
+	// Anchor reached through the symlink, with a not-yet-created leaf: the
+	// symlinked parent must resolve to realRepo so this is caught as in-tree.
+	s := &Store{path: realRepo, allowedSignersPath: filepath.Join(linkRepo, ".allowed_signers"), logger: slog.Default()}
+	if err := s.assertAnchorOutsideTree(); err == nil {
+		t.Fatal("anchor reaching the repo through a symlink (non-existent leaf) accepted; want in-tree rejection")
+	}
+
+	// A genuinely out-of-tree anchor with a not-yet-created leaf under a
+	// not-yet-created parent is still accepted.
+	s = &Store{path: realRepo, allowedSignersPath: filepath.Join(base, "elsewhere", "sub", "anchor"), logger: slog.Default()}
+	if err := s.assertAnchorOutsideTree(); err != nil {
+		t.Fatalf("out-of-tree anchor with non-existent leaf rejected: %v", err)
+	}
+}
+
 func TestIsWithin(t *testing.T) {
 	sep := string(filepath.Separator)
 	tests := []struct {

--- a/internal/platform/provenance/syncgit.go
+++ b/internal/platform/provenance/syncgit.go
@@ -1,0 +1,280 @@
+package provenance
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+// This file holds the low-level git plumbing the fast-forward-only sync
+// engine in sync.go composes: range enumeration and per-commit verification,
+// the fast-forward and push operations, ref/branch resolution, and the
+// out-of-tree trust-anchor containment check.
+
+// rangeCommits lists the commits reachable from `to` but not from `from`
+// (git rev-list from..to) with no history-pruning flags, so every commit —
+// including merge second-parents — is enumerated for verification. Direction
+// is load-bearing: from must be the local head and to the remote head.
+func (s *Store) rangeCommits(ctx context.Context, from, to string) ([]string, error) {
+	if err := checkRevisionArg("range base", from); err != nil {
+		return nil, err
+	}
+	if err := checkRevisionArg("range tip", to); err != nil {
+		return nil, err
+	}
+	var buf bytes.Buffer
+	if err := s.git(ctx, nil, &buf, "rev-list", "--end-of-options", from+".."+to); err != nil {
+		return nil, err
+	}
+	return strings.Fields(buf.String()), nil
+}
+
+// firstUntrusted verifies each commit against the store's out-of-tree anchor
+// and returns a reason for the first one that is not trusted, or "" if all
+// pass. Trust keys strictly on CommitSigner.Verified (git %G?=="G"): a valid
+// signature by a key absent from the anchor (a "U" verdict) is untrusted. Any
+// verification error is treated as untrusted (fail-closed), never skipped.
+func (s *Store) firstUntrusted(ctx context.Context, commits []string) string {
+	for _, sha := range commits {
+		cs, err := signerFor(ctx, s.path, s.allowedSignersPath, sha)
+		if err != nil {
+			return fmt.Sprintf("cannot verify commit %s: %v", shorten(sha), err)
+		}
+		if !cs.Verified {
+			reason := cs.Reason
+			if reason == "" {
+				reason = "not trusted"
+			}
+			return fmt.Sprintf("commit %s is not trusted: %s (signer %q)", shorten(sha), reason, cs.Principal)
+		}
+	}
+	return ""
+}
+
+// fastForward advances the current branch and worktree to target using
+// git merge --ff-only. A fast-forward creates no commit (a pure ref move), so
+// there is no unsigned-commit concern; --ff-only refuses any non-fast-forward
+// and will not clobber conflicting local changes. The branch identity is
+// already asserted (HEAD == refs/heads/<branch>) and ancestry re-proven by the
+// caller, so this moves exactly the intended branch to the verified SHA.
+func (s *Store) fastForward(ctx context.Context, target string) error {
+	if err := checkRevisionArg("fast-forward target", target); err != nil {
+		return err
+	}
+	if err := s.git(ctx, nil, nil, "merge", "--ff-only", "--end-of-options", target); err != nil {
+		return fmt.Errorf("git merge --ff-only %s: %w", shorten(target), err)
+	}
+	return nil
+}
+
+// push sends the pinned commit to the remote branch with a fixed refspec.
+// It never passes --force or --force-with-lease and never prefixes the
+// refspec with '+', so a non-fast-forward push is rejected by the remote
+// rather than overwriting its history. It is bounded by remoteTimeout.
+func (s *Store) push(ctx context.Context, remoteURL, branch, sha, sshCommand string) error {
+	if err := checkRemoteArg("remote url", remoteURL); err != nil {
+		return err
+	}
+	if err := checkRevisionArg("branch", branch); err != nil {
+		return err
+	}
+	if err := checkRevisionArg("push commit", sha); err != nil {
+		return err
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, remoteTimeout)
+	defer cancel()
+
+	var env []string
+	if sshCommand != "" {
+		env = []string{"GIT_SSH_COMMAND=" + sshCommand}
+	}
+
+	refspec := sha + ":refs/heads/" + branch
+	if err := s.gitWithEnv(ctx, env, nil, nil, "push", "--end-of-options", remoteURL, refspec); err != nil {
+		return fmt.Errorf("push %s to %s: %w", shorten(sha), remoteURL, err)
+	}
+	return nil
+}
+
+// countAheadBehind counts how many commits `left` is ahead of and behind
+// `right` (git rev-list --left-right --count left...right). Both revisions are
+// resolved SHAs or refs supplied by the caller; the symmetric "..." form with
+// --left-right yields "<ahead>\t<behind>".
+func (s *Store) countAheadBehind(ctx context.Context, left, right string) (ahead, behind int, err error) {
+	if err := checkRevisionArg("left revision", left); err != nil {
+		return 0, 0, err
+	}
+	if err := checkRevisionArg("right revision", right); err != nil {
+		return 0, 0, err
+	}
+	var out bytes.Buffer
+	if err := s.git(ctx, nil, &out, "rev-list", "--left-right", "--count", "--end-of-options", left+"..."+right); err != nil {
+		return 0, 0, err
+	}
+	fields := strings.Fields(out.String())
+	if len(fields) != 2 {
+		return 0, 0, fmt.Errorf("unexpected rev-list output %q", out.String())
+	}
+	if ahead, err = strconv.Atoi(fields[0]); err != nil {
+		return 0, 0, fmt.Errorf("parse ahead %q: %w", fields[0], err)
+	}
+	if behind, err = strconv.Atoi(fields[1]); err != nil {
+		return 0, 0, fmt.Errorf("parse behind %q: %w", fields[1], err)
+	}
+	return ahead, behind, nil
+}
+
+// revParse resolves a revision to a single object SHA (git rev-parse
+// --verify). It errors on an unborn HEAD or an absent ref rather than
+// returning an empty string.
+func (s *Store) revParse(ctx context.Context, rev string) (string, error) {
+	if err := checkRevisionArg("revision", rev); err != nil {
+		return "", err
+	}
+	var buf bytes.Buffer
+	if err := s.git(ctx, nil, &buf, "rev-parse", "--verify", "--end-of-options", rev); err != nil {
+		return "", err
+	}
+	out := strings.TrimSpace(buf.String())
+	if out == "" {
+		return "", fmt.Errorf("rev-parse %s returned nothing", rev)
+	}
+	return out, nil
+}
+
+// symbolicBranch returns the short branch name HEAD points at, or an error if
+// HEAD is detached.
+func (s *Store) symbolicBranch(ctx context.Context) (string, error) {
+	var buf bytes.Buffer
+	if err := s.git(ctx, nil, &buf, "symbolic-ref", "--short", "HEAD"); err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(buf.String()), nil
+}
+
+// isAncestor reports whether ancestor is an ancestor of descendant
+// (git merge-base --is-ancestor). Exit 1 means "no"; any other non-zero exit
+// (e.g. a bad object) is a real error, not a "no".
+func (s *Store) isAncestor(ctx context.Context, ancestor, descendant string) (bool, error) {
+	if err := checkRevisionArg("ancestor", ancestor); err != nil {
+		return false, err
+	}
+	if err := checkRevisionArg("descendant", descendant); err != nil {
+		return false, err
+	}
+	err := s.git(ctx, nil, nil, "merge-base", "--is-ancestor", "--end-of-options", ancestor, descendant)
+	if err == nil {
+		return true, nil
+	}
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 {
+		return false, nil
+	}
+	return false, err
+}
+
+// worktreeMatchesHead reports whether tracked files (staged and unstaged)
+// match HEAD, via git diff --quiet HEAD. It ignores untracked files, which a
+// fast-forward will not silently overwrite.
+func (s *Store) worktreeMatchesHead(ctx context.Context) (bool, error) {
+	err := s.git(ctx, nil, nil, "diff", "--quiet", "HEAD")
+	if err == nil {
+		return true, nil
+	}
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 {
+		return false, nil
+	}
+	return false, err
+}
+
+// assertAnchorOutsideTree fails closed unless the store's allowed-signers
+// anchor is configured and resolves strictly outside the repository working
+// tree. A remote-synced root's trust set must live out-of-tree: an in-tree
+// .allowed_signers is a file a fetch can rewrite, which would let a pushed
+// commit add an attacker key and self-authorize. Both paths are resolved to
+// absolute, symlink-free form before a component-wise containment check.
+func (s *Store) assertAnchorOutsideTree() error {
+	anchor := strings.TrimSpace(s.allowedSignersPath)
+	if anchor == "" {
+		return fmt.Errorf("remote-synced verification requires an out-of-tree allowed-signers anchor, but the store has none (an in-tree .allowed_signers is rewritable by a fetch)")
+	}
+	if isWithin(resolveReal(s.path), resolveReal(anchor)) {
+		return fmt.Errorf("allowed-signers anchor %q resolves inside the synced tree %q; a fetch could rewrite the trust set and self-authorize", anchor, s.path)
+	}
+	return nil
+}
+
+// resolveReal returns an absolute, symlink-resolved path. When the leaf does
+// not exist yet (e.g. an anchor path that has not been created), it resolves
+// the deepest existing ancestor and re-attaches the remaining components, so a
+// repo path and an anchor path resolve their shared symlinks consistently
+// (on macOS, /var → /private/var). Without this, an existing repo would
+// resolve while a not-yet-created in-tree anchor would not, and the divergent
+// prefixes would make an in-tree anchor falsely appear out-of-tree.
+func resolveReal(p string) string {
+	abs, err := filepath.Abs(p)
+	if err != nil {
+		return filepath.Clean(p)
+	}
+	abs = filepath.Clean(abs)
+	if real, err := filepath.EvalSymlinks(abs); err == nil {
+		return real
+	}
+	// Walk up to the first existing ancestor, resolve it, and re-attach the
+	// non-existent tail.
+	tail := []string{}
+	dir := abs
+	for {
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break // reached the volume root
+		}
+		if real, err := filepath.EvalSymlinks(parent); err == nil {
+			parts := append([]string{real}, filepath.Base(dir))
+			for i := len(tail) - 1; i >= 0; i-- {
+				parts = append(parts, tail[i])
+			}
+			return filepath.Join(parts...)
+		}
+		tail = append(tail, filepath.Base(dir))
+		dir = parent
+	}
+	return abs
+}
+
+// isWithin reports whether child is parent or lies inside parent, comparing
+// path components (not string prefixes), so a sibling like /a/repo-2 is not
+// treated as inside /a/repo.
+func isWithin(parent, child string) bool {
+	parent = filepath.Clean(parent)
+	child = filepath.Clean(child)
+	if parent == child {
+		return true
+	}
+	pc := splitComponents(parent)
+	cc := splitComponents(child)
+	if len(cc) < len(pc) {
+		return false
+	}
+	for i := range pc {
+		if pc[i] != cc[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func splitComponents(p string) []string {
+	p = strings.Trim(p, string(filepath.Separator))
+	if p == "" {
+		return nil
+	}
+	return strings.Split(p, string(filepath.Separator))
+}

--- a/internal/platform/provenance/transport.go
+++ b/internal/platform/provenance/transport.go
@@ -1,10 +1,8 @@
 package provenance
 
 import (
-	"bytes"
 	"context"
 	"fmt"
-	"strconv"
 	"strings"
 	"time"
 )
@@ -105,21 +103,9 @@ func (s *Store) AheadBehind(ctx context.Context, branch string) (ahead, behind i
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	var out bytes.Buffer
-	if err := s.git(ctx, nil, &out, "rev-list", "--left-right", "--count",
-		"--end-of-options", "HEAD...refs/remotes/origin/"+branch); err != nil {
+	ahead, behind, err = s.countAheadBehind(ctx, "HEAD", "refs/remotes/origin/"+branch)
+	if err != nil {
 		return 0, 0, fmt.Errorf("ahead/behind %s: %w", branch, err)
-	}
-
-	fields := strings.Fields(out.String())
-	if len(fields) != 2 {
-		return 0, 0, fmt.Errorf("ahead/behind %s: unexpected rev-list output %q", branch, out.String())
-	}
-	if ahead, err = strconv.Atoi(fields[0]); err != nil {
-		return 0, 0, fmt.Errorf("ahead/behind %s: parse ahead %q: %w", branch, fields[0], err)
-	}
-	if behind, err = strconv.Atoi(fields[1]); err != nil {
-		return 0, 0, fmt.Errorf("ahead/behind %s: parse behind %q: %w", branch, fields[1], err)
 	}
 	return ahead, behind, nil
 }


### PR DESCRIPTION
> **Stacked on #1144** (the transport plumbing). Review that first; this PR's diff is only the sync engine. I'll rebase onto `main` once #1144 merges.

## What

The security-critical heart of the git-remote sync feature (#1137): `Store.Sync`, a stateless single-pass engine that fetches from the remote, verifies the incoming range against an out-of-tree trust anchor, and integrates by **fast-forward only** — never a merge, never a force-push, never a rewrite of local history. A hostile or broken remote can, at worst, leave a pass `Blocked` or `Diverged`; it can never corrupt the signed document root.

This is the ff-only MVP: thane observes the remote's true state, admits only trusted forward motion, and refuses everything else for the operator to resolve on their workstation.

## Shape

One pass is `fetch → verify+integrate (locked) → push`:

- **Fetch runs before the lock** (bounded by `remoteTimeout`, no lock held during the network round-trip).
- **A single critical section under `Store.mu`** captures local and remote heads *immutably by SHA*, classifies on ahead/behind, and — for a behind-only case — verifies then fast-forwards.
- **Push runs after the lock releases**, with a pinned-SHA refspec, so a slow remote can never wedge document writes and a local commit landing mid-pass doesn't change what's pushed.

Classification maps ahead/behind onto outcomes: `clean` (0,0), `fast_forwarded` (behind-only, verified), `pushed` (ahead-only, bidirectional), `diverged` (both — refused), `blocked` (a fail-closed refusal: untrusted commit, dirty worktree, detached HEAD, …).

## Security invariants

This design was put through an adversarial review before implementation; each invariant below answers a concrete attack the review surfaced (and every one has a test):

- **Range verification, not tip verification.** Every commit in `localHead..remoteHead` is checked, fail-fast — so a signed tip cannot launder an untrusted middle commit (`A(trusted)–X(untrusted)–T(trusted)`). Direction is load-bearing, and no history-pruning flags are used, so merge second-parents are verified too.
- **Trust keys strictly on git `%G?=="G"`.** A valid signature by a key *absent from the anchor* (a `U` verdict) is untrusted; any verification error is treated as untrusted (fail-closed, never skipped).
- **Verification uses the out-of-tree anchor exclusively.** Per-commit checks go through the unlocked `signerFor` with `-c gpg.ssh.allowedSignersFile=<anchor>` — never the repo-local config that points at the fetch-rewritable in-tree `.allowed_signers`, and never the locked `SignerFor` (which would deadlock the held `Store.mu`).
- **`assertAnchorOutsideTree` fails closed** unless the anchor resolves strictly outside the worktree (`EvalSymlinks` + component-wise containment), re-checked every pass. `resolveReal` resolves a not-yet-created anchor leaf so the macOS `/var` → `/private/var` split can't mask an in-tree anchor.
- **The fast-forward is gated** by `merge-base --is-ancestor` over the captured SHAs *and* a clean-worktree check (`git diff --quiet HEAD`); a dirty tree or a non-ancestor **blocks rather than clobbers**. HEAD must symbolically track the configured branch — detached HEAD or a branch mismatch is refused.
- **Push never forces.** Fixed argv, no `--force` / `--force-with-lease`, no `+` refspec, bounded by `remoteTimeout`; a non-fast-forward push is rejected by the remote and the next pass reclassifies. The engine never relies on the remote to enforce monotonicity — its own refuse-to-force plus the local ancestry gate are the primary defenses.
- **Diverged refuses with zero side effects** on the branch ref, worktree, and remote.

## Deferred to the operability layer (next PR)

The timer/trigger loop, the in-memory `SyncState` and remote-rewind detection (which needs cross-pass memory of the last remote SHA), the `GET/POST /v1/doc_roots/{root}/sync` surface, and the proactive operator ping on blocked/diverged. That layer constructs the synced store with the out-of-tree anchor and sets `RequireVerify=true` for any signed root.

## Notes

- `transport.AheadBehind` now shares `countAheadBehind` with the engine.
- The git plumbing (range enumeration, per-commit verify, ff, push, ref resolution, anchor containment) lives in `syncgit.go` to keep `sync.go` focused on the state machine and each file under the size budget.

## Test plan

- [x] Real git topologies for every path: clean, trusted fast-forward, the **laundering block** (trusted tip over an untrusted middle commit), verify-off fast-forward, dirty-worktree block, diverged, push + fetch-only, detached HEAD.
- [x] Anchor-containment unit tests (`assertAnchorOutsideTree`, `isWithin`), including the sibling-prefix and not-yet-created-leaf cases.
- [x] Full provenance package suite green.
- [x] `just ci` green (no architecture baseline change).

Refs #1137