### PR TITLE
feat(provenance): accept in-tree .allowed_signers for sync verification (#1137)

### DIFF
--- a/internal/platform/provenance/sync.go
+++ b/internal/platform/provenance/sync.go
@@ -132,10 +132,12 @@ func (s *Store) syncLocked(ctx context.Context, req SyncRequest) (SyncResult, st
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	// Fail closed on trust-file placement before touching any git state. The
-	// in-tree .allowed_signers is permitted (a fetch never rewrites the
-	// worktree before verification); a configured external anchor must resolve
-	// outside the worktree. Re-checked every pass, not once at construction.
+	// Fail closed on trust-file placement before verifying or integrating. The
+	// fetch has already run, but it touched only objects and the tracking ref,
+	// not the worktree — so .allowed_signers is still HEAD's version here,
+	// which is exactly why the in-tree file is permitted. A configured external
+	// anchor must resolve outside the worktree. Re-checked every pass, not once
+	// at construction.
 	if req.RequireVerify {
 		if err := s.assertAnchorPlacement(); err != nil {
 			return SyncResult{}, "", err

--- a/internal/platform/provenance/sync.go
+++ b/internal/platform/provenance/sync.go
@@ -53,8 +53,9 @@ type SyncRequest struct {
 	// Mode selects fetch-only vs bidirectional.
 	Mode SyncMode
 	// RequireVerify hard-gates every fast-forward on signature verification
-	// against the store's out-of-tree allowed-signers anchor. It must be
-	// true for any signed root synced from an untrusted remote; it does not
+	// against the store's allowed-signers trust set — the in-tree
+	// .allowed_signers, or a configured out-of-tree anchor. It must be true
+	// for any signed root synced from an untrusted remote; it does not
 	// downgrade to advisory ("warn") for a worktree-mutating fast-forward.
 	RequireVerify bool
 }
@@ -79,10 +80,11 @@ type SyncResult struct {
 // bidirectional local lead) a push performed outside the lock.
 //
 // The security posture, enforced step by step below, is: the remote is
-// untrusted transport; trust is decided per-commit against an out-of-tree
-// anchor over the exact incoming range; the branch only ever moves forward;
-// and the engine never force-pushes nor rewrites local history. A hostile or
-// broken remote can, at worst, leave the pass Blocked or Diverged — never
+// untrusted transport; trust is decided per-commit against the store's
+// allowed-signers trust set over the exact incoming range; the branch only
+// ever moves forward; and the engine never force-pushes nor rewrites local
+// history. A hostile or broken remote can, at worst, leave the pass Blocked or
+// Diverged — never
 // corrupt the signed document root.
 func (s *Store) Sync(ctx context.Context, req SyncRequest) (SyncResult, error) {
 	if err := checkRemoteArg("remote url", req.RemoteURL); err != nil {
@@ -130,11 +132,12 @@ func (s *Store) syncLocked(ctx context.Context, req SyncRequest) (SyncResult, st
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	// Fail closed on the trust anchor before touching any git state. Re-run
-	// every pass (not once at construction): the anchor path is compared
-	// against the live, post-fetch worktree.
+	// Fail closed on trust-file placement before touching any git state. The
+	// in-tree .allowed_signers is permitted (a fetch never rewrites the
+	// worktree before verification); a configured external anchor must resolve
+	// outside the worktree. Re-checked every pass, not once at construction.
 	if req.RequireVerify {
-		if err := s.assertAnchorOutsideTree(); err != nil {
+		if err := s.assertAnchorPlacement(); err != nil {
 			return SyncResult{}, "", err
 		}
 	}
@@ -228,7 +231,8 @@ func (s *Store) fastForwardLocked(ctx context.Context, req SyncRequest, res Sync
 	}
 
 	// Verify EVERY incoming commit (localHead..remoteHead) against the
-	// out-of-tree anchor, fail-closed. This runs before the branch moves.
+	// allowed-signers trust set, fail-closed. This runs before the branch
+	// moves, so the trust file is still HEAD's version.
 	if req.RequireVerify {
 		commits, err := s.rangeCommits(ctx, res.LocalHead, res.RemoteHead)
 		if err != nil {

--- a/internal/platform/provenance/sync_test.go
+++ b/internal/platform/provenance/sync_test.go
@@ -317,25 +317,110 @@ func TestSyncBlockedDetachedHead(t *testing.T) {
 	}
 }
 
-func TestAssertAnchorOutsideTree(t *testing.T) {
+// newInTreeStore builds a signing store that verifies against its own in-tree
+// .allowed_signers (no external anchor) — the default trust model for a
+// remote-synced root. ensureRepo bootstraps the file with the signer's key, so
+// the signer's own commits verify as trusted.
+func newInTreeStore(t *testing.T, signer *SSHFileSigner) *Store {
+	t.Helper()
+	s, err := New(t.TempDir(), signer, slog.Default())
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	return s
+}
+
+// TestSyncInTreeFastForward proves a trusted fast-forward works with the
+// in-tree .allowed_signers and no configured out-of-tree anchor.
+func TestSyncInTreeFastForward(t *testing.T) {
+	thane := testSigner(t)
+	local := newInTreeStore(t, thane)
+	writeStore(t, local, "a.md", "a\n")
+	base := headSHA(t, local.path)
+	branch := headBranch(t, local.path)
+
+	writeStore(t, local, "b.md", "b\n")
+	writeStore(t, local, "c.md", "c\n")
+	tip := headSHA(t, local.path)
+	remote := cloneBare(t, local.path)
+	runGit(t, local.path, "reset", "--hard", base)
+
+	res, err := local.Sync(t.Context(), SyncRequest{RemoteURL: remote, Branch: branch, Mode: SyncModeBidirectional, RequireVerify: true})
+	if err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+	if res.Outcome != SyncFastForwarded {
+		t.Fatalf("Outcome = %q, want fast_forwarded (detail %q)", res.Outcome, res.Detail)
+	}
+	if got := headSHA(t, local.path); got != tip {
+		t.Fatalf("local head = %s, want %s", shorten(got), shorten(tip))
+	}
+}
+
+// TestSyncInTreeBlockedLaundering is the load-bearing test for the in-tree
+// trust model: a laundered range A(trusted)-X(untrusted)-T(trusted) is blocked
+// exactly as with an out-of-tree anchor. Verification runs against HEAD's
+// in-tree .allowed_signers — a fetch never rewrites the worktree before the
+// range is checked — so the attacker's middle commit is judged against a trust
+// set that does not contain its key, and local never moves.
+func TestSyncInTreeBlockedLaundering(t *testing.T) {
+	thane := testSigner(t)
+	local := newInTreeStore(t, thane)
+	writeStore(t, local, "a.md", "a\n") // C1, thane-signed
+	branch := headBranch(t, local.path)
+	base := headSHA(t, local.path)
+
+	remote := cloneWorktree(t, local.path)
+
+	// C2 signed by an attacker key absent from the in-tree .allowed_signers.
+	attacker := testSigner(t)
+	attackerStore, err := New(remote, attacker, slog.Default())
+	if err != nil {
+		t.Fatalf("attacker store: %v", err)
+	}
+	writeStore(t, attackerStore, "x.md", "x\n")
+
+	// C3 signed by thane (trusted) on top — so the tip verifies.
+	thaneRemote, err := New(remote, thane, slog.Default())
+	if err != nil {
+		t.Fatalf("thane remote store: %v", err)
+	}
+	writeStore(t, thaneRemote, "t.md", "t\n")
+
+	res, err := local.Sync(t.Context(), SyncRequest{RemoteURL: remote, Branch: branch, Mode: SyncModeBidirectional, RequireVerify: true})
+	if err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+	if res.Outcome != SyncBlocked {
+		t.Fatalf("Outcome = %q, want blocked (detail %q)", res.Outcome, res.Detail)
+	}
+	if !strings.Contains(res.Detail, "not trusted") {
+		t.Fatalf("Detail = %q, want an untrusted-commit reason", res.Detail)
+	}
+	if headSHA(t, local.path) != base {
+		t.Fatalf("local head moved despite a blocked in-tree laundering attempt")
+	}
+}
+
+func TestAssertAnchorPlacement(t *testing.T) {
 	repo := t.TempDir()
 
-	// Empty anchor → refuse.
+	// Empty anchor → permitted (in-tree .allowed_signers).
 	s := &Store{path: repo, allowedSignersPath: "", logger: slog.Default()}
-	if err := s.assertAnchorOutsideTree(); err == nil {
-		t.Fatal("empty anchor accepted, want error")
+	if err := s.assertAnchorPlacement(); err != nil {
+		t.Fatalf("empty (in-tree) anchor rejected: %v", err)
 	}
 
-	// In-tree anchor → refuse.
-	s = &Store{path: repo, allowedSignersPath: filepath.Join(repo, ".allowed_signers"), logger: slog.Default()}
-	if err := s.assertAnchorOutsideTree(); err == nil {
-		t.Fatal("in-tree anchor accepted, want error")
+	// A configured anchor inside the tree → refuse.
+	s = &Store{path: repo, allowedSignersPath: filepath.Join(repo, "sub", "anchor"), logger: slog.Default()}
+	if err := s.assertAnchorPlacement(); err == nil {
+		t.Fatal("in-tree configured anchor accepted, want error")
 	}
 
-	// Out-of-tree anchor → ok.
+	// A configured anchor outside the tree → ok.
 	outside := filepath.Join(t.TempDir(), "anchor")
 	s = &Store{path: repo, allowedSignersPath: outside, logger: slog.Default()}
-	if err := s.assertAnchorOutsideTree(); err != nil {
+	if err := s.assertAnchorPlacement(); err != nil {
 		t.Fatalf("out-of-tree anchor rejected: %v", err)
 	}
 }
@@ -359,14 +444,14 @@ func TestAnchorContainmentSymlinkLeaf(t *testing.T) {
 	// Anchor reached through the symlink, with a not-yet-created leaf: the
 	// symlinked parent must resolve to realRepo so this is caught as in-tree.
 	s := &Store{path: realRepo, allowedSignersPath: filepath.Join(linkRepo, ".allowed_signers"), logger: slog.Default()}
-	if err := s.assertAnchorOutsideTree(); err == nil {
+	if err := s.assertAnchorPlacement(); err == nil {
 		t.Fatal("anchor reaching the repo through a symlink (non-existent leaf) accepted; want in-tree rejection")
 	}
 
 	// A genuinely out-of-tree anchor with a not-yet-created leaf under a
 	// not-yet-created parent is still accepted.
 	s = &Store{path: realRepo, allowedSignersPath: filepath.Join(base, "elsewhere", "sub", "anchor"), logger: slog.Default()}
-	if err := s.assertAnchorOutsideTree(); err != nil {
+	if err := s.assertAnchorPlacement(); err != nil {
 		t.Fatalf("out-of-tree anchor with non-existent leaf rejected: %v", err)
 	}
 }

--- a/internal/platform/provenance/syncgit.go
+++ b/internal/platform/provenance/syncgit.go
@@ -14,7 +14,7 @@ import (
 // This file holds the low-level git plumbing the fast-forward-only sync
 // engine in sync.go composes: range enumeration and per-commit verification,
 // the fast-forward and push operations, ref/branch resolution, and the
-// out-of-tree trust-anchor containment check.
+// allowed-signers trust-file placement check.
 
 // rangeCommits lists the commits reachable from `to` but not from `from`
 // (git rev-list from..to) with no history-pruning flags, so every commit —
@@ -34,11 +34,12 @@ func (s *Store) rangeCommits(ctx context.Context, from, to string) ([]string, er
 	return strings.Fields(buf.String()), nil
 }
 
-// firstUntrusted verifies each commit against the store's out-of-tree anchor
+// firstUntrusted verifies each commit against the store's allowed-signers
+// trust set (the in-tree .allowed_signers, or a configured out-of-tree anchor)
 // and returns a reason for the first one that is not trusted, or "" if all
 // pass. Trust keys strictly on CommitSigner.Verified (git %G?=="G"): a valid
-// signature by a key absent from the anchor (a "U" verdict) is untrusted. Any
-// verification error is treated as untrusted (fail-closed), never skipped.
+// signature by a key absent from the trust set (a "U" verdict) is untrusted.
+// Any verification error is treated as untrusted (fail-closed), never skipped.
 func (s *Store) firstUntrusted(ctx context.Context, commits []string) string {
 	for _, sha := range commits {
 		cs, err := signerFor(ctx, s.path, s.allowedSignersPath, sha)
@@ -194,19 +195,28 @@ func (s *Store) worktreeMatchesHead(ctx context.Context) (bool, error) {
 	return false, err
 }
 
-// assertAnchorOutsideTree fails closed unless the store's allowed-signers
-// anchor is configured and resolves strictly outside the repository working
-// tree. A remote-synced root's trust set must live out-of-tree: an in-tree
-// .allowed_signers is a file a fetch can rewrite, which would let a pushed
-// commit add an attacker key and self-authorize. Both paths are resolved to
-// absolute, symlink-free form before a component-wise containment check.
-func (s *Store) assertAnchorOutsideTree() error {
+// assertAnchorPlacement fails closed if the store's verification trust file
+// sits somewhere a fetch could rewrite before it is consulted.
+//
+// An empty allowedSignersPath means verification uses the repository's in-tree
+// .allowed_signers, which is permitted: the sync engine's fetch writes only
+// objects and the remote-tracking ref, never the worktree, so the in-tree file
+// stays at HEAD's version while the incoming range is verified. Every commit
+// is checked against the pre-integration trust set, and the worktree only
+// advances (via the fast-forward) after verification passes — so an incoming
+// commit cannot rewrite the very file that authorizes it.
+//
+// A configured external anchor is a deliberate out-of-tree trust file and MUST
+// resolve strictly outside the worktree; one that resolves inside is a
+// misconfiguration a fetch could rewrite, so it is refused. Paths are resolved
+// to absolute, symlink-free form before a component-wise containment check.
+func (s *Store) assertAnchorPlacement() error {
 	anchor := strings.TrimSpace(s.allowedSignersPath)
 	if anchor == "" {
-		return fmt.Errorf("remote-synced verification requires an out-of-tree allowed-signers anchor, but the store has none (an in-tree .allowed_signers is rewritable by a fetch)")
+		return nil // in-tree .allowed_signers; safe under fetch-before-verify
 	}
 	if isWithin(resolveReal(s.path), resolveReal(anchor)) {
-		return fmt.Errorf("allowed-signers anchor %q resolves inside the synced tree %q; a fetch could rewrite the trust set and self-authorize", anchor, s.path)
+		return fmt.Errorf("configured allowed-signers anchor %q resolves inside the synced tree %q; move it outside the worktree, or leave it unset to use the in-tree .allowed_signers", anchor, s.path)
 	}
 	return nil
 }


### PR DESCRIPTION
## What

Relaxes the sync engine's trust-file requirement so an **out-of-tree anchor is no longer mandatory**. `RequireVerify` now also accepts the repository's **in-tree `.allowed_signers`** — the trust file thane already renders from `signing.allowed_signers` (#1135) and commits.

## Why

The out-of-tree anchor requirement (from this feature's original design) was defense-in-depth against a `git fetch` rewriting an in-tree trust file mid-verification. But our syncer's fetch **never touches the worktree** — it writes only objects and the remote-tracking ref — so `.allowed_signers` stays at HEAD's version while the incoming range is verified. Every commit is checked against the *pre-integration* trust set, and the worktree only advances (via the fast-forward) after verification passes. **An incoming commit therefore cannot rewrite the very file that authorizes it**, which is the attack the out-of-tree rule guarded against.

For the operator co-authorship use case the in-tree file is the *better* default: the trust set is committed, so it rides along in the synced history and both machines converge on it automatically — versus maintaining a separate out-of-tree file on each machine and keeping them consistent by hand. The operator declares their key once in `signing.allowed_signers` (as they already do for local signed roots); thane renders and commits it; sync carries it.

The one invariant this rests on — *the syncer never checks the remote out into the worktree before verifying* — is guaranteed by the engine (fetch into a tracking ref, verify `HEAD..REMOTE`, then fast-forward). Out-of-tree anchors remain fully supported as an optional hardening knob for anyone who wants that invariant removed from the trust argument.

## Changes

- `assertAnchorOutsideTree` → `assertAnchorPlacement`: an empty (in-tree) anchor is now permitted; a *configured* external anchor must still resolve outside the worktree (a configured-but-in-tree anchor is a misconfiguration and is refused).
- Doc comments (`SyncRequest.RequireVerify`, `Sync`, `firstUntrusted`) now describe the trust set as "the in-tree `.allowed_signers`, or a configured out-of-tree anchor."

## Test plan

- [x] `TestSyncInTreeBlockedLaundering` — the `A(trusted)-X(untrusted)-T(trusted-tip)` range is blocked against the in-tree file, and local does not move. This is the load-bearing proof that in-tree verification is safe.
- [x] `TestSyncInTreeFastForward` — a trusted fast-forward works with no external anchor.
- [x] `TestAssertAnchorPlacement` — empty anchor permitted; configured-in-tree refused; out-of-tree accepted.
- [x] Existing out-of-tree tests unchanged and green.
- [x] `just ci` green.

Refs #1137