### PR TITLE
feat(app): document-root sync driver + engine rewind detection (#1137)

### DIFF
--- a/internal/app/document_root_syncer.go
+++ b/internal/app/document_root_syncer.go
@@ -1,0 +1,252 @@
+package app
+
+import (
+	"context"
+	"log/slog"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/nugget/thane-ai-agent/internal/platform/config"
+	"github.com/nugget/thane-ai-agent/internal/platform/provenance"
+)
+
+// defaultSyncBranch and defaultSyncInterval are applied where a root's
+// git.remote config leaves them unset (config.Load deliberately does not fill
+// them, so the defaults live at the one point of consumption — here).
+const (
+	defaultSyncBranch   = "main"
+	defaultSyncInterval = 60 * time.Second
+)
+
+// parseSyncInterval maps a git.remote.interval string onto a poll cadence.
+// Empty uses [defaultSyncInterval]; "0" (a zero duration) disables the timer,
+// leaving the root sync-on-demand only. validateGitRemote has already checked
+// that a non-empty value parses, so an error here is defensive.
+func parseSyncInterval(raw string) (time.Duration, error) {
+	if raw == "" {
+		return defaultSyncInterval, nil
+	}
+	return time.ParseDuration(raw)
+}
+
+// buildSyncRequest maps a root's git config onto a [provenance.SyncRequest].
+// resolve expands a configured path (~, environment variables) — the caller
+// supplies the paths.Resolver-backed closure; tests pass an identity function.
+// The out-of-tree trust anchor, if any, is a store-construction concern and is
+// not carried here.
+func buildSyncRequest(gitCfg config.DocumentRootGitConfig, resolve func(string) string) provenance.SyncRequest {
+	// Trim before comparing: validateGitRemote validates these fields trimmed,
+	// so a value like "required " (a quoted trailing space in YAML) is accepted
+	// by config Load. An untrimmed compare here would fail open — dropping
+	// verification, or silently downgrading bidirectional to fetch-only.
+	verify := strings.TrimSpace(gitCfg.VerifySignatures)
+	remote := gitCfg.Remote
+	req := provenance.SyncRequest{
+		Branch:        defaultSyncBranch,
+		Mode:          provenance.SyncModeFetch,
+		RequireVerify: verify == "warn" || verify == "required",
+	}
+	if remote == nil {
+		return req
+	}
+	req.RemoteURL = remote.URL
+	if b := remote.Branch; b != "" {
+		req.Branch = b
+	}
+	if strings.TrimSpace(remote.Mode) == "bidirectional" {
+		req.Mode = provenance.SyncModeBidirectional
+	}
+	// GIT_SSH_COMMAND is only meaningful for an SSH remote; presence of ssh
+	// transport credentials is the signal (known_hosts is required for an SSH
+	// url, so at least one is set). It is harmless for https, which git runs
+	// without consulting GIT_SSH_COMMAND.
+	if remote.Auth.SSHKey != "" || remote.Auth.KnownHosts != "" {
+		req.SSHCommand = provenance.BuildSSHCommand(resolve(remote.Auth.SSHKey), resolve(remote.Auth.KnownHosts))
+	}
+	return req
+}
+
+// syncState is the in-memory, per-root observed state of remote sync. It is
+// re-derived every pass (never persisted) and read by the operability surface.
+type syncState struct {
+	Root       string
+	OK         bool // false when the last pass errored operationally
+	Outcome    provenance.SyncOutcome
+	Ahead      int
+	Behind     int
+	LocalHead  string
+	RemoteHead string
+	Detail     string // reason for a blocked/diverged/remote_behind outcome, or the error message
+	LastSyncAt time.Time
+}
+
+// syncStateRegistry holds per-root sync state and the remote head observed on
+// each root's previous pass (for the engine's rewind detection). It is safe
+// for concurrent access: the syncer loop writes, the operability surface reads.
+type syncStateRegistry struct {
+	mu         sync.Mutex
+	state      map[string]syncState
+	lastRemote map[string]string
+}
+
+func newSyncStateRegistry() *syncStateRegistry {
+	return &syncStateRegistry{
+		state:      make(map[string]syncState),
+		lastRemote: make(map[string]string),
+	}
+}
+
+// setState records the latest observed state for a root.
+func (r *syncStateRegistry) setState(st syncState) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.state[st.Root] = st
+}
+
+// advanceRemote records the remote head a root legitimately accepted, so the
+// next pass can detect a rewind past it. The caller advances it only for
+// accepted outcomes (clean / fast-forwarded / pushed); a refused outcome
+// (diverged, blocked, remote_behind) leaves it untouched, so the rewind keeps
+// being detected until the operator resolves it.
+func (r *syncStateRegistry) advanceRemote(root, sha string) {
+	if sha == "" {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.lastRemote[root] = sha
+}
+
+// lastKnownRemote returns the remote head recorded for a root's previous pass,
+// or "" if none.
+func (r *syncStateRegistry) lastKnownRemote(root string) string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.lastRemote[root]
+}
+
+// get returns the recorded state for a root.
+func (r *syncStateRegistry) get(root string) (syncState, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	st, ok := r.state[root]
+	return st, ok
+}
+
+// all returns every recorded state, sorted by root for a stable listing.
+func (r *syncStateRegistry) all() []syncState {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]syncState, 0, len(r.state))
+	for _, st := range r.state {
+		out = append(out, st)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Root < out[j].Root })
+	return out
+}
+
+// syncEngine is the sync surface a docRootSyncer drives — satisfied by
+// *provenance.Store. The interface keeps runOnce unit-testable with a fake,
+// without a live git repository.
+type syncEngine interface {
+	Sync(ctx context.Context, req provenance.SyncRequest) (provenance.SyncResult, error)
+}
+
+// docRootSyncer runs timed fast-forward-only sync for one git-remote-backed
+// document root. It threads the last-seen remote head into each pass (for
+// rewind detection), records the outcome in the registry, and re-indexes the
+// root after a fast-forward moves the worktree.
+type docRootSyncer struct {
+	root     string
+	engine   syncEngine
+	request  provenance.SyncRequest // LastKnownRemote is filled per pass
+	interval time.Duration          // 0 disables the ticker (sync-on-demand only)
+	refresh  func(context.Context) error
+	registry *syncStateRegistry
+	logger   *slog.Logger
+	now      func() time.Time // injectable clock; nil uses time.Now
+}
+
+func (s *docRootSyncer) clock() time.Time {
+	if s.now != nil {
+		return s.now()
+	}
+	return time.Now()
+}
+
+// runOnce performs one sync pass, records the result, and re-indexes on a
+// fast-forward. It never returns an error: an operational failure is recorded
+// as state (OK=false) and retried on the next pass.
+func (s *docRootSyncer) runOnce(ctx context.Context) syncState {
+	req := s.request
+	req.LastKnownRemote = s.registry.lastKnownRemote(s.root)
+
+	res, err := s.engine.Sync(ctx, req)
+	st := syncState{Root: s.root, LastSyncAt: s.clock()}
+	if err != nil {
+		st.OK = false
+		st.Detail = err.Error()
+		s.logger.Warn("document root sync failed", "root", s.root, "error", err)
+		s.registry.setState(st)
+		return st
+	}
+
+	st.OK = true
+	st.Outcome = res.Outcome
+	st.Ahead, st.Behind = res.Ahead, res.Behind
+	st.LocalHead, st.RemoteHead = res.LocalHead, res.RemoteHead
+	st.Detail = res.Detail
+
+	switch res.Outcome {
+	case provenance.SyncBlocked, provenance.SyncDiverged, provenance.SyncRemoteBehind:
+		s.logger.Warn("document root sync needs attention",
+			"root", s.root, "outcome", res.Outcome, "detail", res.Detail)
+	default:
+		s.logger.Info("document root sync",
+			"root", s.root, "outcome", res.Outcome, "ahead", res.Ahead, "behind", res.Behind)
+	}
+
+	// A fast-forward moved the worktree; re-index so reads see the new content
+	// without waiting for the periodic refresher.
+	if res.Outcome == provenance.SyncFastForwarded && s.refresh != nil {
+		if rerr := s.refresh(ctx); rerr != nil && ctx.Err() == nil {
+			s.logger.Warn("re-index after sync fast-forward failed", "root", s.root, "error", rerr)
+		}
+	}
+
+	s.registry.setState(st)
+	// Advance the rewind baseline only for outcomes where the remote head was
+	// legitimately accepted as authoritative (in sync, or integrated). A
+	// refused outcome — diverged, blocked, or remote_behind — must NOT advance
+	// the baseline to a head thane never accepted, or a later real rewind of
+	// the true line would escape detection and be pushed over.
+	switch res.Outcome {
+	case provenance.SyncClean, provenance.SyncFastForwarded, provenance.SyncPushed:
+		s.registry.advanceRemote(s.root, res.RemoteHead)
+	}
+	return st
+}
+
+// Run drives runOnce immediately and then on the configured interval until the
+// context is cancelled. A non-positive interval runs a single pass and then
+// blocks on ctx (sync-on-demand only — a trigger or the operability POST
+// endpoint drives further passes).
+func (s *docRootSyncer) Run(ctx context.Context) {
+	s.runOnce(ctx)
+	if s.interval <= 0 {
+		<-ctx.Done()
+		return
+	}
+	ticker := time.NewTicker(s.interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			s.runOnce(ctx)
+		}
+	}
+}

--- a/internal/app/document_root_syncer.go
+++ b/internal/app/document_root_syncer.go
@@ -25,6 +25,7 @@ const (
 // leaving the root sync-on-demand only. validateGitRemote has already checked
 // that a non-empty value parses, so an error here is defensive.
 func parseSyncInterval(raw string) (time.Duration, error) {
+	raw = strings.TrimSpace(raw) // match validateGitRemote, which trims first
 	if raw == "" {
 		return defaultSyncInterval, nil
 	}
@@ -37,10 +38,11 @@ func parseSyncInterval(raw string) (time.Duration, error) {
 // The out-of-tree trust anchor, if any, is a store-construction concern and is
 // not carried here.
 func buildSyncRequest(gitCfg config.DocumentRootGitConfig, resolve func(string) string) provenance.SyncRequest {
-	// Trim before comparing: validateGitRemote validates these fields trimmed,
-	// so a value like "required " (a quoted trailing space in YAML) is accepted
-	// by config Load. An untrimmed compare here would fail open — dropping
-	// verification, or silently downgrading bidirectional to fetch-only.
+	// Trim every field before use: validateGitRemote validates these trimmed,
+	// so a quoted trailing space in YAML ("required ", "bidirectional ", a
+	// padded url/branch/key path) is accepted by config Load. An untrimmed
+	// consume here would fail open — dropping verification, downgrading to
+	// fetch-only, or producing a broken remote/branch/GIT_SSH_COMMAND.
 	verify := strings.TrimSpace(gitCfg.VerifySignatures)
 	remote := gitCfg.Remote
 	req := provenance.SyncRequest{
@@ -51,8 +53,8 @@ func buildSyncRequest(gitCfg config.DocumentRootGitConfig, resolve func(string) 
 	if remote == nil {
 		return req
 	}
-	req.RemoteURL = remote.URL
-	if b := remote.Branch; b != "" {
+	req.RemoteURL = strings.TrimSpace(remote.URL)
+	if b := strings.TrimSpace(remote.Branch); b != "" {
 		req.Branch = b
 	}
 	if strings.TrimSpace(remote.Mode) == "bidirectional" {
@@ -62,8 +64,10 @@ func buildSyncRequest(gitCfg config.DocumentRootGitConfig, resolve func(string) 
 	// transport credentials is the signal (known_hosts is required for an SSH
 	// url, so at least one is set). It is harmless for https, which git runs
 	// without consulting GIT_SSH_COMMAND.
-	if remote.Auth.SSHKey != "" || remote.Auth.KnownHosts != "" {
-		req.SSHCommand = provenance.BuildSSHCommand(resolve(remote.Auth.SSHKey), resolve(remote.Auth.KnownHosts))
+	sshKey := strings.TrimSpace(remote.Auth.SSHKey)
+	knownHosts := strings.TrimSpace(remote.Auth.KnownHosts)
+	if sshKey != "" || knownHosts != "" {
+		req.SSHCommand = provenance.BuildSSHCommand(resolve(sshKey), resolve(knownHosts))
 	}
 	return req
 }

--- a/internal/app/document_root_syncer_test.go
+++ b/internal/app/document_root_syncer_test.go
@@ -1,0 +1,343 @@
+package app
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/nugget/thane-ai-agent/internal/platform/config"
+	"github.com/nugget/thane-ai-agent/internal/platform/provenance"
+)
+
+func testLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+func TestParseSyncInterval(t *testing.T) {
+	tests := []struct {
+		raw     string
+		want    time.Duration
+		wantErr bool
+	}{
+		{"", defaultSyncInterval, false},
+		{"0", 0, false},
+		{"30s", 30 * time.Second, false},
+		{"5m", 5 * time.Minute, false},
+		{"nonsense", 0, true},
+	}
+	for _, tt := range tests {
+		got, err := parseSyncInterval(tt.raw)
+		if tt.wantErr {
+			if err == nil {
+				t.Errorf("parseSyncInterval(%q) = nil error, want error", tt.raw)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("parseSyncInterval(%q): %v", tt.raw, err)
+		}
+		if got != tt.want {
+			t.Errorf("parseSyncInterval(%q) = %v, want %v", tt.raw, got, tt.want)
+		}
+	}
+}
+
+func TestBuildSyncRequest(t *testing.T) {
+	identity := func(s string) string { return s }
+
+	t.Run("bidirectional ssh required", func(t *testing.T) {
+		req := buildSyncRequest(config.DocumentRootGitConfig{
+			VerifySignatures: "required",
+			Remote: &config.DocumentRootGitRemoteConfig{
+				URL:  "git@example.com:o/r.git",
+				Mode: "bidirectional",
+				Auth: config.DocumentRootGitRemoteAuthConfig{SSHKey: "/k", KnownHosts: "/kh"},
+			},
+		}, identity)
+		if req.RemoteURL != "git@example.com:o/r.git" {
+			t.Errorf("RemoteURL = %q", req.RemoteURL)
+		}
+		if req.Branch != "main" {
+			t.Errorf("Branch = %q, want default main", req.Branch)
+		}
+		if req.Mode != provenance.SyncModeBidirectional {
+			t.Errorf("Mode = %v, want bidirectional", req.Mode)
+		}
+		if !req.RequireVerify {
+			t.Error("RequireVerify = false, want true for verify_signatures=required")
+		}
+		if req.SSHCommand == "" {
+			t.Error("SSHCommand empty, want a built ssh command for ssh auth")
+		}
+	})
+
+	t.Run("fetch-only https warn", func(t *testing.T) {
+		req := buildSyncRequest(config.DocumentRootGitConfig{
+			VerifySignatures: "warn",
+			Remote: &config.DocumentRootGitRemoteConfig{
+				URL:    "https://example.com/r.git",
+				Branch: "trunk",
+				Mode:   "fetch",
+			},
+		}, identity)
+		if req.Branch != "trunk" {
+			t.Errorf("Branch = %q, want trunk", req.Branch)
+		}
+		if req.Mode != provenance.SyncModeFetch {
+			t.Errorf("Mode = %v, want fetch", req.Mode)
+		}
+		if !req.RequireVerify {
+			t.Error("RequireVerify = false, want true for verify_signatures=warn")
+		}
+		if req.SSHCommand != "" {
+			t.Errorf("SSHCommand = %q, want empty for https with no ssh auth", req.SSHCommand)
+		}
+	})
+
+	t.Run("verify none", func(t *testing.T) {
+		req := buildSyncRequest(config.DocumentRootGitConfig{
+			VerifySignatures: "none",
+			Remote:           &config.DocumentRootGitRemoteConfig{URL: "u", Mode: "fetch"},
+		}, identity)
+		if req.RequireVerify {
+			t.Error("RequireVerify = true, want false for verify_signatures=none")
+		}
+	})
+
+	t.Run("trimmed verify and mode fail closed", func(t *testing.T) {
+		// A quoted trailing space passes config validation (which trims); the
+		// consumer must trim too, or it fails open (no verify / no push).
+		req := buildSyncRequest(config.DocumentRootGitConfig{
+			VerifySignatures: "required ",
+			Remote:           &config.DocumentRootGitRemoteConfig{URL: "u", Mode: "bidirectional "},
+		}, identity)
+		if !req.RequireVerify {
+			t.Error("RequireVerify = false for 'required ' (trailing space); must fail closed to true")
+		}
+		if req.Mode != provenance.SyncModeBidirectional {
+			t.Error("Mode != bidirectional for 'bidirectional ' (trailing space)")
+		}
+	})
+}
+
+func TestSyncStateRegistry(t *testing.T) {
+	r := newSyncStateRegistry()
+
+	if got := r.lastKnownRemote("kb"); got != "" {
+		t.Errorf("lastKnownRemote on empty = %q, want empty", got)
+	}
+	if _, ok := r.get("kb"); ok {
+		t.Error("get on empty registry returned ok")
+	}
+
+	r.setState(syncState{Root: "kb", OK: true, Outcome: provenance.SyncClean})
+	r.setState(syncState{Root: "apex", OK: true, Outcome: provenance.SyncFastForwarded})
+	if st, ok := r.get("kb"); !ok || st.Outcome != provenance.SyncClean {
+		t.Errorf("get(kb) = %+v, ok=%v", st, ok)
+	}
+
+	all := r.all()
+	if len(all) != 2 || all[0].Root != "apex" || all[1].Root != "kb" {
+		t.Fatalf("all() not sorted by root: %+v", all)
+	}
+
+	r.advanceRemote("kb", "sha1")
+	if got := r.lastKnownRemote("kb"); got != "sha1" {
+		t.Errorf("lastKnownRemote(kb) = %q, want sha1", got)
+	}
+	r.advanceRemote("kb", "") // no-op
+	if got := r.lastKnownRemote("kb"); got != "sha1" {
+		t.Errorf("advanceRemote with empty sha changed value to %q", got)
+	}
+}
+
+// TestSyncStateRegistryConcurrent exercises the writer (syncer loop) racing the
+// reader (operability surface) under -race.
+func TestSyncStateRegistryConcurrent(t *testing.T) {
+	r := newSyncStateRegistry()
+	done := make(chan struct{})
+	go func() {
+		for i := 0; i < 1000; i++ {
+			r.setState(syncState{Root: "kb", Outcome: provenance.SyncClean})
+			r.advanceRemote("kb", "sha")
+		}
+		close(done)
+	}()
+	for i := 0; i < 1000; i++ {
+		_ = r.all()
+		_, _ = r.get("kb")
+		_ = r.lastKnownRemote("kb")
+	}
+	<-done
+}
+
+// fakeEngine returns scripted results for successive Sync calls and records the
+// requests it received.
+type fakeEngine struct {
+	results []provenance.SyncResult
+	errs    []error
+	calls   []provenance.SyncRequest
+}
+
+func (f *fakeEngine) Sync(_ context.Context, req provenance.SyncRequest) (provenance.SyncResult, error) {
+	i := len(f.calls)
+	f.calls = append(f.calls, req)
+	var res provenance.SyncResult
+	var err error
+	if i < len(f.results) {
+		res = f.results[i]
+	}
+	if i < len(f.errs) {
+		err = f.errs[i]
+	}
+	return res, err
+}
+
+func newTestSyncer(engine syncEngine, reg *syncStateRegistry, refresh func(context.Context) error) *docRootSyncer {
+	return &docRootSyncer{
+		root:     "kb",
+		engine:   engine,
+		request:  provenance.SyncRequest{Branch: "main", Mode: provenance.SyncModeBidirectional, RequireVerify: true},
+		refresh:  refresh,
+		registry: reg,
+		logger:   testLogger(),
+	}
+}
+
+func TestRunOnceFastForwardReindexesAndAdvances(t *testing.T) {
+	reg := newSyncStateRegistry()
+	refreshes := 0
+	eng := &fakeEngine{results: []provenance.SyncResult{
+		{Outcome: provenance.SyncFastForwarded, Behind: 2, LocalHead: "l", RemoteHead: "rA"},
+		{Outcome: provenance.SyncClean, LocalHead: "rA", RemoteHead: "rA"},
+	}}
+	s := newTestSyncer(eng, reg, func(context.Context) error { refreshes++; return nil })
+
+	st := s.runOnce(context.Background())
+	if !st.OK || st.Outcome != provenance.SyncFastForwarded {
+		t.Fatalf("state = %+v, want ok fast_forwarded", st)
+	}
+	if refreshes != 1 {
+		t.Errorf("refresh called %d times after fast-forward, want 1", refreshes)
+	}
+	if got := reg.lastKnownRemote("kb"); got != "rA" {
+		t.Errorf("lastKnownRemote = %q, want rA", got)
+	}
+
+	// Second pass must thread the recorded remote head as LastKnownRemote.
+	s.runOnce(context.Background())
+	if len(eng.calls) != 2 {
+		t.Fatalf("engine called %d times, want 2", len(eng.calls))
+	}
+	if eng.calls[1].LastKnownRemote != "rA" {
+		t.Errorf("pass 2 LastKnownRemote = %q, want rA", eng.calls[1].LastKnownRemote)
+	}
+	if refreshes != 1 {
+		t.Errorf("refresh called %d times, want still 1 (clean pass does not re-index)", refreshes)
+	}
+}
+
+func TestRunOnceRemoteBehindDoesNotAdvanceOrReindex(t *testing.T) {
+	reg := newSyncStateRegistry()
+	reg.advanceRemote("kb", "rA") // a prior legitimate remote head
+	refreshes := 0
+	eng := &fakeEngine{results: []provenance.SyncResult{
+		{Outcome: provenance.SyncRemoteBehind, LocalHead: "l", RemoteHead: "rOld", Detail: "rewound"},
+	}}
+	s := newTestSyncer(eng, reg, func(context.Context) error { refreshes++; return nil })
+
+	st := s.runOnce(context.Background())
+	if st.Outcome != provenance.SyncRemoteBehind {
+		t.Fatalf("outcome = %q, want remote_behind", st.Outcome)
+	}
+	if refreshes != 0 {
+		t.Errorf("refresh called on remote_behind, want 0")
+	}
+	// The rewind baseline must NOT advance, so the rewind keeps being detected.
+	if got := reg.lastKnownRemote("kb"); got != "rA" {
+		t.Errorf("lastKnownRemote = %q, want unchanged rA", got)
+	}
+}
+
+// TestRunOnceAdvanceBaseline pins the rewind-baseline invariant: accepted
+// outcomes advance it; refused outcomes leave it untouched so a later rewind
+// stays detectable.
+func TestRunOnceAdvanceBaseline(t *testing.T) {
+	accepted := []provenance.SyncOutcome{provenance.SyncClean, provenance.SyncFastForwarded, provenance.SyncPushed}
+	refused := []provenance.SyncOutcome{provenance.SyncDiverged, provenance.SyncBlocked, provenance.SyncRemoteBehind}
+
+	for _, oc := range accepted {
+		t.Run("advances_on_"+string(oc), func(t *testing.T) {
+			reg := newSyncStateRegistry()
+			reg.advanceRemote("kb", "prior")
+			eng := &fakeEngine{results: []provenance.SyncResult{{Outcome: oc, RemoteHead: "new"}}}
+			newTestSyncer(eng, reg, nil).runOnce(context.Background())
+			if got := reg.lastKnownRemote("kb"); got != "new" {
+				t.Errorf("lastKnownRemote = %q, want advanced to new for accepted outcome %q", got, oc)
+			}
+		})
+	}
+	for _, oc := range refused {
+		t.Run("holds_on_"+string(oc), func(t *testing.T) {
+			reg := newSyncStateRegistry()
+			reg.advanceRemote("kb", "prior")
+			eng := &fakeEngine{results: []provenance.SyncResult{{Outcome: oc, RemoteHead: "new"}}}
+			newTestSyncer(eng, reg, nil).runOnce(context.Background())
+			if got := reg.lastKnownRemote("kb"); got != "prior" {
+				t.Errorf("lastKnownRemote = %q, want held at prior for refused outcome %q", got, oc)
+			}
+		})
+	}
+}
+
+// TestRunReturnsOnCancel covers both loop shapes: a manual (interval<=0) syncer
+// runs one pass then blocks on ctx, and a ticker syncer waits — both must
+// return promptly when the context is cancelled, and neither may panic on a
+// zero interval.
+func TestRunReturnsOnCancel(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		interval time.Duration
+	}{
+		{"manual", 0},
+		{"ticker", time.Hour},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			reg := newSyncStateRegistry()
+			eng := &fakeEngine{results: []provenance.SyncResult{{Outcome: provenance.SyncClean, RemoteHead: "r"}}}
+			s := newTestSyncer(eng, reg, nil)
+			s.interval = tc.interval
+			ctx, cancel := context.WithCancel(context.Background())
+			done := make(chan struct{})
+			go func() { s.Run(ctx); close(done) }()
+			cancel()
+			select {
+			case <-done:
+			case <-time.After(2 * time.Second):
+				t.Fatal("Run did not return promptly after ctx cancel")
+			}
+			if len(eng.calls) < 1 {
+				t.Error("Run did not perform the initial pass")
+			}
+		})
+	}
+}
+
+func TestRunOnceErrorRecordsState(t *testing.T) {
+	reg := newSyncStateRegistry()
+	eng := &fakeEngine{errs: []error{context.DeadlineExceeded}}
+	s := newTestSyncer(eng, reg, nil)
+
+	st := s.runOnce(context.Background())
+	if st.OK {
+		t.Error("OK = true on an errored pass, want false")
+	}
+	if st.Detail == "" {
+		t.Error("Detail empty on error, want the error message")
+	}
+	if got, ok := reg.get("kb"); !ok || got.OK {
+		t.Errorf("registry state = %+v, ok=%v; want recorded not-OK", got, ok)
+	}
+}

--- a/internal/app/document_root_syncer_test.go
+++ b/internal/app/document_root_syncer_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io"
 	"log/slog"
+	"strings"
 	"testing"
 	"time"
 
@@ -22,8 +23,10 @@ func TestParseSyncInterval(t *testing.T) {
 		wantErr bool
 	}{
 		{"", defaultSyncInterval, false},
+		{"   ", defaultSyncInterval, false}, // whitespace-only trims to empty
 		{"0", 0, false},
 		{"30s", 30 * time.Second, false},
+		{"60s ", 60 * time.Second, false}, // trailing space (validation trims)
 		{"5m", 5 * time.Minute, false},
 		{"nonsense", 0, true},
 	}
@@ -118,6 +121,29 @@ func TestBuildSyncRequest(t *testing.T) {
 		}
 		if req.Mode != provenance.SyncModeBidirectional {
 			t.Error("Mode != bidirectional for 'bidirectional ' (trailing space)")
+		}
+	})
+
+	t.Run("trimmed url branch and ssh paths", func(t *testing.T) {
+		req := buildSyncRequest(config.DocumentRootGitConfig{
+			VerifySignatures: "required",
+			Remote: &config.DocumentRootGitRemoteConfig{
+				URL:    " git@example.com:o/r.git ",
+				Branch: " trunk ",
+				Mode:   "bidirectional",
+				Auth:   config.DocumentRootGitRemoteAuthConfig{SSHKey: " /k ", KnownHosts: " /kh "},
+			},
+		}, identity)
+		if req.RemoteURL != "git@example.com:o/r.git" {
+			t.Errorf("RemoteURL = %q, want trimmed", req.RemoteURL)
+		}
+		if req.Branch != "trunk" {
+			t.Errorf("Branch = %q, want trimmed trunk", req.Branch)
+		}
+		// The built ssh command must reference the trimmed key/known_hosts,
+		// never the padded values.
+		if !strings.Contains(req.SSHCommand, "'/k'") || !strings.Contains(req.SSHCommand, "'/kh'") {
+			t.Errorf("SSHCommand = %q, want trimmed key/known_hosts", req.SSHCommand)
 		}
 	})
 }

--- a/internal/platform/provenance/sync.go
+++ b/internal/platform/provenance/sync.go
@@ -37,6 +37,12 @@ const (
 	// failed verification, the worktree was dirty, HEAD was detached, or a
 	// similar fail-closed condition. Detail explains which.
 	SyncBlocked SyncOutcome = "blocked"
+	// SyncRemoteBehind means the remote rewound: the fetched remote head is a
+	// strict ancestor of the head the caller last saw (LastKnownRemote). The
+	// engine refuses with no side effects rather than pushing local commits
+	// back over what looks like an intentional history rewrite; the operator
+	// resolves it on the workstation.
+	SyncRemoteBehind SyncOutcome = "remote_behind"
 )
 
 // SyncRequest parameterizes one sync pass. The engine is stateless: every
@@ -58,6 +64,13 @@ type SyncRequest struct {
 	// for any signed root synced from an untrusted remote; it does not
 	// downgrade to advisory ("warn") for a worktree-mutating fast-forward.
 	RequireVerify bool
+	// LastKnownRemote is the remote head SHA the caller observed on its
+	// previous pass, or empty on the first. It lets the otherwise-stateless
+	// engine detect a rewound remote: if the freshly fetched remote head is a
+	// strict ancestor of LastKnownRemote, the pass returns SyncRemoteBehind
+	// with no side effects instead of pushing local commits back over the
+	// rewind. Cross-pass memory of this value lives in the operability layer.
+	LastKnownRemote string
 }
 
 // SyncResult reports what one pass observed and did. Once a pass reaches
@@ -177,6 +190,29 @@ func (s *Store) syncLocked(ctx context.Context, req SyncRequest) (SyncResult, st
 	}
 
 	res := SyncResult{Ahead: ahead, Behind: behind, LocalHead: localHead, RemoteHead: remoteHead}
+
+	// Rewind guard: if the caller saw a different remote head last pass and the
+	// freshly fetched head is a strict ancestor of it, the remote rewound.
+	// Refuse with no side effects rather than pushing local commits back over
+	// what is likely an intentional history rewrite. A diverging rewrite (the
+	// new head is neither ancestor nor descendant) is not caught here — it
+	// falls through to the diverged classification, which also refuses safely.
+	if req.LastKnownRemote != "" && remoteHead != req.LastKnownRemote {
+		rewound, aerr := s.isAncestor(ctx, remoteHead, req.LastKnownRemote)
+		switch {
+		case aerr != nil:
+			// The prior remote head should be reachable (it was fetched last
+			// pass); a probe failure means it is pruned or misconfigured. The
+			// guard fails open, so surface it rather than silently skipping.
+			s.logger.Warn("rewind check failed; proceeding without it",
+				"branch", req.Branch, "remote_head", shorten(remoteHead),
+				"last_known_remote", shorten(req.LastKnownRemote), "error", aerr)
+		case rewound:
+			res.Outcome = SyncRemoteBehind
+			res.Detail = fmt.Sprintf("remote rewound: %s is behind the previously seen %s; refusing to push over an apparent history rewrite — resolve on the workstation", shorten(remoteHead), shorten(req.LastKnownRemote))
+			return res, "", nil
+		}
+	}
 
 	switch {
 	case ahead == 0 && behind == 0:

--- a/internal/platform/provenance/sync_test.go
+++ b/internal/platform/provenance/sync_test.go
@@ -102,6 +102,112 @@ func TestSyncClean(t *testing.T) {
 	}
 }
 
+// TestSyncRemoteBehind: after the remote rewinds to an ancestor of the head we
+// last saw, the pass returns remote_behind and does NOT push local commits
+// back over the rewind (no auto-undo of an intentional history rewrite).
+func TestSyncRemoteBehind(t *testing.T) {
+	thane := testSigner(t)
+	local := newInTreeStore(t, thane)
+	writeStore(t, local, "a.md", "a\n")
+	c1 := headSHA(t, local.path)
+	branch := headBranch(t, local.path)
+	writeStore(t, local, "b.md", "b\n")
+	writeStore(t, local, "c.md", "c\n")
+	c3 := headSHA(t, local.path)
+	remote := cloneBare(t, local.path) // remote at c3
+	runGit(t, local.path, "reset", "--hard", c1)
+
+	req := SyncRequest{RemoteURL: remote, Branch: branch, Mode: SyncModeBidirectional, RequireVerify: true}
+
+	// Pass 1: local fast-forwards up to c3; record the remote head.
+	res, err := local.Sync(t.Context(), req)
+	if err != nil {
+		t.Fatalf("Sync 1: %v", err)
+	}
+	if res.Outcome != SyncFastForwarded || res.RemoteHead != c3 {
+		t.Fatalf("pass 1 = %q at %s, want fast_forwarded at %s", res.Outcome, shorten(res.RemoteHead), shorten(c3))
+	}
+
+	// The remote rewinds to c1 (a force-push style history rewrite).
+	runGit(t, remote, "update-ref", "refs/heads/"+branch, c1)
+
+	// Pass 2: with LastKnownRemote=c3, the rewind is caught. Without the guard
+	// this would be ahead=2/behind=0 and push c2/c3 back, re-advancing the
+	// remote past the rewind.
+	req.LastKnownRemote = res.RemoteHead
+	res2, err := local.Sync(t.Context(), req)
+	if err != nil {
+		t.Fatalf("Sync 2: %v", err)
+	}
+	if res2.Outcome != SyncRemoteBehind {
+		t.Fatalf("pass 2 = %q, want remote_behind (detail %q)", res2.Outcome, res2.Detail)
+	}
+	if got := strings.TrimSpace(runGit(t, remote, "rev-parse", "refs/heads/"+branch)); got != c1 {
+		t.Fatalf("remote advanced to %s despite the rewind guard; want %s", shorten(got), shorten(c1))
+	}
+}
+
+// TestSyncRemoteForwardNotBehind: forward motion (the remote head is a
+// descendant of LastKnownRemote) must NOT be misread as a rewind.
+func TestSyncRemoteForwardNotBehind(t *testing.T) {
+	thane := testSigner(t)
+	local := newInTreeStore(t, thane)
+	writeStore(t, local, "a.md", "a\n")
+	c1 := headSHA(t, local.path)
+	branch := headBranch(t, local.path)
+	writeStore(t, local, "b.md", "b\n")
+	c2 := headSHA(t, local.path)
+	writeStore(t, local, "c.md", "c\n")
+	remote := cloneBare(t, local.path) // remote at c3 (descendant of c2)
+	runGit(t, local.path, "reset", "--hard", c1)
+
+	// LastKnownRemote = c2, remote now at c3: forward motion, not a rewind.
+	res, err := local.Sync(t.Context(), SyncRequest{
+		RemoteURL: remote, Branch: branch, Mode: SyncModeBidirectional,
+		RequireVerify: true, LastKnownRemote: c2,
+	})
+	if err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+	if res.Outcome != SyncFastForwarded {
+		t.Fatalf("outcome = %q, want fast_forwarded (forward motion misread as rewind?)", res.Outcome)
+	}
+}
+
+// TestSyncDivergedWithBaseline: a divergence with a baseline set is classified
+// as diverged (the guard fires only on a strict ancestor), refused with no
+// side effects.
+func TestSyncDivergedWithBaseline(t *testing.T) {
+	thane := testSigner(t)
+	local := newInTreeStore(t, thane)
+	writeStore(t, local, "a.md", "a\n")
+	c1 := headSHA(t, local.path)
+	branch := headBranch(t, local.path)
+
+	remote := cloneWorktree(t, local.path)
+	remoteStore, err := New(remote, thane, slog.Default())
+	if err != nil {
+		t.Fatalf("remote store: %v", err)
+	}
+	writeStore(t, remoteStore, "r.md", "r\n") // remote: c1 -> R
+	writeStore(t, local, "l.md", "l\n")       // local:  c1 -> L
+	localTip := headSHA(t, local.path)
+
+	res, err := local.Sync(t.Context(), SyncRequest{
+		RemoteURL: remote, Branch: branch, Mode: SyncModeBidirectional,
+		RequireVerify: true, LastKnownRemote: c1,
+	})
+	if err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+	if res.Outcome != SyncDiverged {
+		t.Fatalf("outcome = %q, want diverged", res.Outcome)
+	}
+	if headSHA(t, local.path) != localTip {
+		t.Fatal("local head moved on a diverged pass")
+	}
+}
+
 // TestSyncFastForwardTrusted: remote is ahead by trusted commits — local
 // fast-forwards to it.
 func TestSyncFastForwardTrusted(t *testing.T) {

--- a/scripts/architecture.baseline
+++ b/scripts/architecture.baseline
@@ -1,5 +1,5 @@
 packages=62
-interfaces=82
+interfaces=83
 large_files=49
 set_mutators=111
 database_opens=9


### PR DESCRIPTION
## What

The operability *core* of the git-remote sync feature (#1137): a per-root driver that runs the fast-forward-only engine on a timer, tracks state, and re-indexes after a fast-forward — plus the small engine addition that makes rewind detection possible. No HTTP surface or operator ping yet (next PR); this is the machinery that actually runs sync.

## Engine (provenance)

- **`SyncRequest.LastKnownRemote` + `SyncRemoteBehind` outcome.** When the freshly fetched remote head is a *strict ancestor* of the head the caller last saw, the pass returns `remote_behind` with no side effects instead of pushing local commits back over what looks like an intentional history rewrite (a force-pushed rewind). The engine stays stateless-per-call — the cross-pass memory lives in the driver. A failed rewind probe (a pruned/misconfigured baseline) is logged rather than silently skipped, since the guard fails open.
- Forward motion (remote head is a *descendant* of the baseline) and diverging rewrites (neither ancestor nor descendant) are explicitly **not** classified as `remote_behind` — the former fast-forwards, the latter falls through to `diverged`. Both directions are tested.

## Driver (`internal/app/document_root_syncer.go`)

- **`buildSyncRequest`** maps a root's git config onto a `SyncRequest` (mode, branch default `main`, verify policy, `GIT_SSH_COMMAND`); **`parseSyncInterval`** maps the interval string (`""` → 60s, `"0"` → manual-only).
- **`syncStateRegistry`**: in-memory, mutex-guarded, per-root state plus the last-*accepted* remote head that feeds rewind detection.
- **`docRootSyncer.runOnce`/`Run`**: threads `LastKnownRemote` in, records the outcome, re-indexes on a fast-forward, and advances the rewind baseline **only on accepted outcomes** (clean / fast_forwarded / pushed). A `syncEngine` interface keeps `runOnce` unit-testable with a fake — no live git.

## Adversarial review

I ran an adversarial review of the driver before landing; it caught three fail-open bugs, all fixed here:

1. **Baseline poisoning (high)** — the rewind baseline advanced on *refused* outcomes (`diverged`/`blocked`), so a later real rewind of the true line could escape detection and be pushed over. Now advances only on accepted outcomes.
2. **Untrimmed `verify_signatures` (high)** — compared exactly while config validation trims, so a quoted `"required "` passed validation yet yielded `RequireVerify=false` — verifying nothing. Now trimmed at consumption.
3. **Untrimmed `mode` (medium)** — same shape: `"bidirectional "` silently downgraded to fetch-only. Now trimmed.

The engine's rewind logic was reviewed SOUND (empirically validated against real commit graphs).

## Test plan

- [x] Engine: `remote_behind` on a real rewind (and the remote is *not* re-advanced); forward-motion not misread; diverged-with-baseline stays diverged.
- [x] Driver: advance-baseline allow-list (accepted advance, refused hold — every outcome); trimmed verify/mode fail closed; interval parsing; config mapping; `runOnce` fast-forward re-indexes + threads baseline; error path records state; `Run` returns promptly on ctx cancel (both manual and ticker); registry concurrency under `-race`.
- [x] `just ci` green (architecture baseline bumped 82→83 for the `syncEngine` testing seam).

## Not in this PR

The app lifecycle wiring (constructing per-root syncers from config in `buildDocumentStoreOptions` and launching them via `deferWorker`), the `GET/POST /v1/doc_roots/{root}/sync` surface, and the proactive operator ping. Those follow once this core is in.

Refs #1137