### PR TITLE
feat(app): wire document-root syncers into the app lifecycle (#1137)

### DIFF
--- a/examples/config.example.yaml
+++ b/examples/config.example.yaml
@@ -339,9 +339,14 @@ roots:
         # Empty means the sync uses 60s (applied where the remote is consumed,
         # not by config Load); "0" disables the timer (manual/trigger-only).
         interval: 60s
-        # TrustAnchor is the out-of-tree OpenSSH allowed_signers file that
-        # verification checks against. It must live outside the synced tree so a
-        # fetched commit can never rewrite the trust set. See #1135.
+        # TrustAnchor is an OPTIONAL out-of-tree OpenSSH allowed_signers file for
+        # verification. It is not required: by default verification uses the
+        # in-tree .allowed_signers (rendered from signing.allowed_signers), which
+        # the sync engine checks safely because a fetch never rewrites the
+        # worktree before the incoming range is verified. An out-of-tree anchor is
+        # extra hardening for those who want the trust set removed from the synced
+        # tree entirely — but it is not yet wired: set it and the root is refused
+        # at construction. See #1135, #1147.
         trust_anchor: ""
         # Auth carries transport credentials only — never commit-signing
         # material.

--- a/examples/config.example.yaml
+++ b/examples/config.example.yaml
@@ -342,7 +342,7 @@ roots:
         # TrustAnchor is the out-of-tree OpenSSH allowed_signers file that
         # verification checks against. It must live outside the synced tree so a
         # fetched commit can never rewrite the trust set. See #1135.
-        trust_anchor: ~/.thane/keys/kb.allowed_signers
+        trust_anchor: ""
         # Auth carries transport credentials only — never commit-signing
         # material.
         auth:

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -94,6 +94,8 @@ type App struct {
 	factStore                 *knowledge.Store
 	documentStore             *documents.Store
 	documentTools             *documents.Tools
+	docRootSyncers            []*docRootSyncer
+	syncRegistry              *syncStateRegistry
 	contactStore              *contacts.Store
 	watchlistStore            *awareness.WatchlistStore
 	loopQueue                 *loopqueue.Store

--- a/internal/app/document_root_syncer.go
+++ b/internal/app/document_root_syncer.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"sort"
 	"strings"
@@ -70,6 +71,39 @@ func buildSyncRequest(gitCfg config.DocumentRootGitConfig, resolve func(string) 
 		req.SSHCommand = provenance.BuildSSHCommand(resolve(sshKey), resolve(knownHosts))
 	}
 	return req
+}
+
+// buildDocRootSyncer constructs a per-root syncer from a root's git config,
+// driving the given engine (the root's provenance store). It returns (nil, nil)
+// when the root has no remote block. resolve expands configured paths.
+//
+// An out-of-tree trust_anchor is not yet wired: the default is the in-tree
+// .allowed_signers (which the sync engine verifies safely, since a fetch never
+// rewrites the worktree before verification), so a configured trust_anchor is
+// refused rather than silently ignored.
+func buildDocRootSyncer(root string, gitCfg config.DocumentRootGitConfig, engine syncEngine, registry *syncStateRegistry, resolve func(string) string, logger *slog.Logger) (*docRootSyncer, error) {
+	remote := gitCfg.Remote
+	if remote == nil {
+		return nil, nil
+	}
+	if strings.TrimSpace(remote.TrustAnchor) != "" {
+		return nil, fmt.Errorf("git.remote.trust_anchor (out-of-tree verification) is not yet wired; omit it to use the in-tree .allowed_signers")
+	}
+	interval, err := parseSyncInterval(remote.Interval)
+	if err != nil {
+		return nil, fmt.Errorf("git.remote.interval: %w", err)
+	}
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &docRootSyncer{
+		root:     root,
+		engine:   engine,
+		request:  buildSyncRequest(gitCfg, resolve),
+		interval: interval,
+		registry: registry,
+		logger:   logger.With("component", "docroot_syncer", "root", root),
+	}, nil
 }
 
 // syncState is the in-memory, per-root observed state of remote sync. It is

--- a/internal/app/document_root_syncer_test.go
+++ b/internal/app/document_root_syncer_test.go
@@ -148,6 +148,55 @@ func TestBuildSyncRequest(t *testing.T) {
 	})
 }
 
+func TestBuildDocRootSyncer(t *testing.T) {
+	reg := newSyncStateRegistry()
+	identity := func(s string) string { return s }
+
+	t.Run("nil remote yields nil syncer", func(t *testing.T) {
+		s, err := buildDocRootSyncer("kb", config.DocumentRootGitConfig{}, &fakeEngine{}, reg, identity, testLogger())
+		if err != nil || s != nil {
+			t.Fatalf("got (%v, %v), want (nil, nil)", s, err)
+		}
+	})
+
+	t.Run("trust_anchor is deferred with a clear error", func(t *testing.T) {
+		_, err := buildDocRootSyncer("kb", config.DocumentRootGitConfig{
+			Remote: &config.DocumentRootGitRemoteConfig{URL: "u", Mode: "fetch", TrustAnchor: "/anchor"},
+		}, &fakeEngine{}, reg, identity, testLogger())
+		if err == nil {
+			t.Fatal("trust_anchor accepted, want a not-yet-wired error")
+		}
+	})
+
+	t.Run("bad interval errors", func(t *testing.T) {
+		_, err := buildDocRootSyncer("kb", config.DocumentRootGitConfig{
+			Remote: &config.DocumentRootGitRemoteConfig{URL: "u", Mode: "fetch", Interval: "xyz"},
+		}, &fakeEngine{}, reg, identity, testLogger())
+		if err == nil {
+			t.Fatal("bad interval accepted")
+		}
+	})
+
+	t.Run("constructs with mapped request and interval", func(t *testing.T) {
+		s, err := buildDocRootSyncer("kb", config.DocumentRootGitConfig{
+			VerifySignatures: "required",
+			Remote:           &config.DocumentRootGitRemoteConfig{URL: "u", Mode: "bidirectional", Interval: "30s"},
+		}, &fakeEngine{}, reg, identity, testLogger())
+		if err != nil {
+			t.Fatalf("buildDocRootSyncer: %v", err)
+		}
+		if s.root != "kb" || s.interval != 30*time.Second {
+			t.Errorf("root=%q interval=%v, want kb/30s", s.root, s.interval)
+		}
+		if s.request.Mode != provenance.SyncModeBidirectional || !s.request.RequireVerify {
+			t.Errorf("request = %+v, want bidirectional + RequireVerify", s.request)
+		}
+		if s.registry != reg {
+			t.Error("registry not wired")
+		}
+	})
+}
+
 func TestSyncStateRegistry(t *testing.T) {
 	r := newSyncStateRegistry()
 

--- a/internal/app/document_roots.go
+++ b/internal/app/document_roots.go
@@ -203,6 +203,25 @@ func (a *App) buildDocumentStoreOptions(documentRoots map[string]string, resolve
 			}
 			opts.RootRevisers[root] = reviser
 		}
+
+		// A remote-backed root gets a syncer driving the fast-forward-only
+		// engine on the writer's store — the same store the writer and reviser
+		// use, so its lock serializes sync against local writes. Sync needs the
+		// signing store, so a remote requires sign_commits.
+		if rootCfg.Git.Remote != nil {
+			if writer == nil {
+				return documents.StoreOptions{}, fmt.Errorf("doc_roots.%s.git.remote requires sign_commits (the sync engine needs the signing store)", root)
+			}
+			if a.syncRegistry == nil {
+				a.syncRegistry = newSyncStateRegistry()
+			}
+			resolve := func(p string) string { return resolvePath(p, resolver) }
+			syncer, err := buildDocRootSyncer(root, rootCfg.Git, writer.store, a.syncRegistry, resolve, logger)
+			if err != nil {
+				return documents.StoreOptions{}, fmt.Errorf("doc_roots.%s.git.remote: %w", root, err)
+			}
+			a.docRootSyncers = append(a.docRootSyncers, syncer)
+		}
 	}
 	return opts, nil
 }

--- a/internal/app/new_channels.go
+++ b/internal/app/new_channels.go
@@ -328,7 +328,12 @@ func (a *App) initChannels(s *newState) error {
 
 			// Remote-backed roots sync on their own cadence. Wire the
 			// post-fast-forward re-index to the document store (now that it
-			// exists) and launch each syncer under the app lifecycle.
+			// exists) and launch each syncer under the app lifecycle. The
+			// re-index is a best-effort nudge: Store.Refresh is throttled and
+			// covers all roots, so it may no-op right after a recent refresh —
+			// but the periodic refresher re-indexes within refreshInterval
+			// regardless, so a fast-forward's content becomes visible promptly
+			// either way.
 			if len(a.docRootSyncers) > 0 {
 				refresh := func(ctx context.Context) error { return docStore.Refresh(ctx) }
 				for _, syncer := range a.docRootSyncers {

--- a/internal/app/new_channels.go
+++ b/internal/app/new_channels.go
@@ -325,6 +325,22 @@ func (a *App) initChannels(s *newState) error {
 				go docStore.RunRefresher(ctx)
 				return nil
 			})
+
+			// Remote-backed roots sync on their own cadence. Wire the
+			// post-fast-forward re-index to the document store (now that it
+			// exists) and launch each syncer under the app lifecycle.
+			if len(a.docRootSyncers) > 0 {
+				refresh := func(ctx context.Context) error { return docStore.Refresh(ctx) }
+				for _, syncer := range a.docRootSyncers {
+					syncer.refresh = refresh
+				}
+				a.deferWorker("docroot-sync", func(ctx context.Context) error {
+					for _, syncer := range a.docRootSyncers {
+						go syncer.Run(ctx)
+					}
+					return nil
+				})
+			}
 			roots := sortedDocumentRootNames(documentRoots)
 			attrs := append([]slog.Attr{slog.Any("roots", roots)}, documentRootPolicyAttrs(docOptions, roots)...)
 			a.logger.LogAttrs(context.Background(), slog.LevelInfo, "document index enabled", attrs...)

--- a/internal/platform/config/config.go
+++ b/internal/platform/config/config.go
@@ -1007,9 +1007,14 @@ type DocumentRootGitRemoteConfig struct {
 	// not by config Load); "0" disables the timer (manual/trigger-only).
 	Interval string `yaml:"interval,omitempty"`
 
-	// TrustAnchor is the out-of-tree OpenSSH allowed_signers file that
-	// verification checks against. It must live outside the synced tree so a
-	// fetched commit can never rewrite the trust set. See #1135.
+	// TrustAnchor is an OPTIONAL out-of-tree OpenSSH allowed_signers file for
+	// verification. It is not required: by default verification uses the
+	// in-tree .allowed_signers (rendered from signing.allowed_signers), which
+	// the sync engine checks safely because a fetch never rewrites the
+	// worktree before the incoming range is verified. An out-of-tree anchor is
+	// extra hardening for those who want the trust set removed from the synced
+	// tree entirely — but it is not yet wired: set it and the root is refused
+	// at construction. See #1135, #1147.
 	TrustAnchor string `yaml:"trust_anchor,omitempty"`
 
 	// Auth carries transport credentials only — never commit-signing
@@ -2883,13 +2888,11 @@ func validateGitRemote(root string, git DocumentRootGitConfig) error {
 	if key := strings.TrimSpace(r.Auth.SSHKey); key != "" && key == strings.TrimSpace(git.SigningKey) {
 		return fmt.Errorf("%s.auth.ssh_key must not be the same key as git.signing_key: transport auth and commit signing are separate", label)
 	}
-	// Verification needs an out-of-tree trust anchor; without it the
-	// operator's own signed history would read as untrusted and the root
-	// would boot permanently blocked.
-	verify := strings.TrimSpace(git.VerifySignatures)
-	if (verify == "warn" || verify == "required") && strings.TrimSpace(r.TrustAnchor) == "" {
-		return fmt.Errorf("%s.trust_anchor is required when verify_signatures is %q: it must be an out-of-tree allowed_signers file", label, verify)
-	}
+	// trust_anchor is optional: verification defaults to the in-tree
+	// .allowed_signers (rendered from signing.allowed_signers), which the sync
+	// engine checks safely because a fetch never rewrites the worktree before
+	// the incoming range is verified. An out-of-tree anchor is optional extra
+	// hardening; it is validated where it is consumed, not here.
 	return nil
 }
 

--- a/internal/platform/config/example.go
+++ b/internal/platform/config/example.go
@@ -125,11 +125,10 @@ func ExampleConfig() *Config {
 						Label:     "Bob (kb co-author)",
 					}},
 					Remote: &DocumentRootGitRemoteConfig{
-						URL:         "aimee@pocket.hollowoak.net:Thane/knowledge.git",
-						Branch:      "main",
-						Mode:        "bidirectional",
-						Interval:    "60s",
-						TrustAnchor: "~/.thane/keys/kb.allowed_signers",
+						URL:      "aimee@pocket.hollowoak.net:Thane/knowledge.git",
+						Branch:   "main",
+						Mode:     "bidirectional",
+						Interval: "60s",
 						Auth: DocumentRootGitRemoteAuthConfig{
 							SSHKey:     "~/.thane/keys/transport_ed25519",
 							KnownHosts: "~/.thane/ssh/known_hosts",

--- a/internal/platform/config/remote_config_test.go
+++ b/internal/platform/config/remote_config_test.go
@@ -15,10 +15,11 @@ func TestValidateGitRemote(t *testing.T) {
 			VerifySignatures: "required",
 			SigningKey:       "/keys/signing_ed25519",
 			Remote: &DocumentRootGitRemoteConfig{
-				URL:         "aimee@pocket.hollowoak.net:Thane/kb.git",
-				Mode:        "bidirectional",
-				Interval:    "60s",
-				TrustAnchor: "/keys/kb.allowed_signers",
+				URL:      "aimee@pocket.hollowoak.net:Thane/kb.git",
+				Mode:     "bidirectional",
+				Interval: "60s",
+				// No trust_anchor: verification defaults to the in-tree
+				// .allowed_signers.
 				Auth: DocumentRootGitRemoteAuthConfig{
 					SSHKey:     "/keys/transport_ed25519",
 					KnownHosts: "/ssh/known_hosts",
@@ -49,7 +50,8 @@ func TestValidateGitRemote(t *testing.T) {
 		{"bidirectional requires sign_commits", func(g *DocumentRootGitConfig) { g.SignCommits = false }, "requires git.sign_commits"},
 		{"ssh url requires known_hosts", func(g *DocumentRootGitConfig) { g.Remote.Auth.KnownHosts = "" }, "known_hosts is required"},
 		{"transport key must differ from signing key", func(g *DocumentRootGitConfig) { g.Remote.Auth.SSHKey = g.SigningKey }, "must not be the same key"},
-		{"verify required needs trust_anchor", func(g *DocumentRootGitConfig) { g.Remote.TrustAnchor = "" }, "trust_anchor is required"},
+		{"verify required is valid without trust_anchor (in-tree default)", func(*DocumentRootGitConfig) {}, ""},
+		{"trust_anchor is config-optional", func(g *DocumentRootGitConfig) { g.Remote.TrustAnchor = "/keys/kb.allowed_signers" }, ""},
 		{"bad interval", func(g *DocumentRootGitConfig) { g.Remote.Interval = "soon" }, "interval"},
 		{"interval 0 disables timer", func(g *DocumentRootGitConfig) { g.Remote.Interval = "0" }, ""},
 	} {


### PR DESCRIPTION
## What

Makes remote-backed document roots **actually sync**. This is the lifecycle wiring that connects the syncer machinery (merged in #1148) to a running thane: on boot, every root with a `git.remote` block gets a per-root syncer driving the fast-forward-only engine on a timer.

## How it wires

- In `buildDocumentStoreOptions`, a root with a `git.remote` block gets a `docRootSyncer` driving the engine on **the writer's provenance store** — the same store the writer and reviser already use, so its mutex serializes sync against local writes (two stores on one repo would defeat that lock).
- In `new_channels`, once the document store exists, each syncer's post-fast-forward re-index is wired to `docStore.Refresh` and the syncers are launched via `deferWorker`. Each `Run` exits on context cancellation at shutdown.

## Trust model & scope

- **A remote requires `sign_commits`** — the engine needs the signing store, so a remote without a writer is a construction error.
- **Verification uses the in-tree `.allowed_signers` by default** — rendered from `signing.allowed_signers` exactly as for local signed roots (#1135). The sync engine verifies against it safely because a fetch never rewrites the worktree before verification (established in #1147). This is the operator co-authorship path: declare your key once in `signing.allowed_signers`, and it rides along in the synced history.
- **`git.remote.trust_anchor` (out-of-tree) is not yet wired** and is refused with a clear message rather than silently ignored. The example config now shows the in-tree default (no `trust_anchor`). Out-of-tree hardening is a documented follow-up.

## Test plan

- [x] `buildDocRootSyncer` unit tests (fake engine): nil remote → nil syncer; a configured `trust_anchor` → deferred error; a bad interval → error; a full config → correctly mapped request (bidirectional + RequireVerify) and interval.
- [x] Driver domain and engine tests from #1148 unchanged and green.
- [x] `just ci` green; `examples/config.example.yaml` regenerated (kb remote drops `trust_anchor`).

## Not in this PR

The `GET/POST /v1/doc_roots/{root}/sync` operability surface and the proactive operator ping (deduped on state transition). The syncers run and log outcomes today; that surface is the final MVP slice.

Refs #1137