### PR TITLE
feat: wake core loop on doc-root sync transitions

### DIFF
--- a/internal/app/document_root_sync_attention.go
+++ b/internal/app/document_root_sync_attention.go
@@ -1,0 +1,146 @@
+package app
+
+import (
+	"context"
+	"crypto/sha256"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/nugget/thane-ai-agent/internal/channels/messages"
+	looppkg "github.com/nugget/thane-ai-agent/internal/runtime/loop"
+)
+
+const docRootSyncTransitionKind = "document_root_sync_transition"
+
+func (a *App) docRootSyncAttentionNotifier() syncTransitionNotifier {
+	if a == nil || a.messageBus == nil || a.loopRegistry == nil {
+		return nil
+	}
+	return a.notifyDocRootSyncTransition
+}
+
+func (a *App) notifyDocRootSyncTransition(ctx context.Context, transition syncStateTransition) error {
+	_, err := looppkg.WakeCoreLoop(ctx, a.loopRegistry, a.messageBus, docRootSyncTransitionWake(transition))
+	return err
+}
+
+func docRootSyncTransitionWake(transition syncStateTransition) looppkg.CoreWakeRequest {
+	priority := messages.PriorityNormal
+	forceSupervisor := false
+	if transition.Kind == syncTransitionAttentionRequired {
+		priority = messages.PriorityUrgent
+		forceSupervisor = true
+	}
+
+	return looppkg.CoreWakeRequest{
+		From: messages.Identity{
+			Kind: messages.IdentitySystem,
+			Name: "document_root_syncer",
+		},
+		Kind:            docRootSyncTransitionKind,
+		Concern:         docRootSyncTransitionConcern(transition),
+		SuggestedAction: docRootSyncTransitionAction(transition),
+		Events:          []messages.LoopEventPayload{docRootSyncTransitionEvent(transition)},
+		Priority:        priority,
+		Scope:           []string{"document_root_sync"},
+		ForceSupervisor: forceSupervisor,
+	}
+}
+
+func docRootSyncTransitionEnvelope(target looppkg.CoreAttentionTarget, transition syncStateTransition) messages.Envelope {
+	return looppkg.CoreWakeEnvelope(target, docRootSyncTransitionWake(transition))
+}
+
+func docRootSyncTransitionEvent(transition syncStateTransition) messages.LoopEventPayload {
+	st := transition.Current
+	return messages.LoopEventPayload{
+		Source:     "document_root_sync",
+		Type:       string(transition.Kind),
+		ID:         docRootSyncTransitionID(transition),
+		Title:      docRootSyncTransitionTitle(transition),
+		Summary:    docRootSyncTransitionSummary(transition),
+		ObservedAt: st.LastSyncAt,
+		Metadata:   docRootSyncTransitionMetadata(transition),
+	}
+}
+
+func docRootSyncTransitionConcern(transition syncStateTransition) string {
+	st := transition.Current
+	switch transition.Kind {
+	case syncTransitionAttentionRequired:
+		if detail := strings.TrimSpace(st.Detail); detail != "" {
+			return fmt.Sprintf("Document root sync requires core review: root %q entered %s: %s", st.Root, st.Outcome, detail)
+		}
+		return fmt.Sprintf("Document root sync requires core review: root %q entered %s.", st.Root, st.Outcome)
+	case syncTransitionRecovered:
+		return fmt.Sprintf("Document root sync recovered: root %q is %s after %s.", st.Root, st.Outcome, transition.Previous.Outcome)
+	default:
+		return fmt.Sprintf("Document root sync changed state for root %q.", st.Root)
+	}
+}
+
+func docRootSyncTransitionAction(transition syncStateTransition) string {
+	switch transition.Kind {
+	case syncTransitionAttentionRequired:
+		return "Review the refusal state and decide whether to wait for the next self-healing pass or ask the operator to resolve the remote/worktree condition."
+	case syncTransitionRecovered:
+		return "Note the recovery; no direct human message is required unless other current context makes follow-up useful."
+	default:
+		return "Review the sync state change."
+	}
+}
+
+func docRootSyncTransitionID(transition syncStateTransition) string {
+	st := transition.Current
+	h := sha256.Sum256([]byte(strings.Join([]string{
+		st.Root,
+		string(transition.Kind),
+		string(st.Outcome),
+		strings.TrimSpace(st.Detail),
+		string(transition.Previous.Outcome),
+		strings.TrimSpace(transition.Previous.Detail),
+	}, "\x00")))
+	return fmt.Sprintf("%s:%s:%s:%x", st.Root, transition.Kind, st.Outcome, h[:8])
+}
+
+func docRootSyncTransitionTitle(transition syncStateTransition) string {
+	switch transition.Kind {
+	case syncTransitionAttentionRequired:
+		return "Document root sync attention required"
+	case syncTransitionRecovered:
+		return "Document root sync recovered"
+	default:
+		return "Document root sync state changed"
+	}
+}
+
+func docRootSyncTransitionSummary(transition syncStateTransition) string {
+	st := transition.Current
+	if st.Detail == "" {
+		return fmt.Sprintf("root=%s outcome=%s", st.Root, st.Outcome)
+	}
+	return fmt.Sprintf("root=%s outcome=%s detail=%s", st.Root, st.Outcome, st.Detail)
+}
+
+func docRootSyncTransitionMetadata(transition syncStateTransition) map[string]string {
+	st := transition.Current
+	meta := map[string]string{
+		"root":        st.Root,
+		"outcome":     string(st.Outcome),
+		"ahead":       strconv.Itoa(st.Ahead),
+		"behind":      strconv.Itoa(st.Behind),
+		"local_head":  st.LocalHead,
+		"remote_head": st.RemoteHead,
+	}
+	if st.Detail != "" {
+		meta["detail"] = st.Detail
+	}
+	if transition.HasPrevious {
+		meta["previous_outcome"] = string(transition.Previous.Outcome)
+		if transition.Previous.Detail != "" {
+			meta["previous_detail"] = transition.Previous.Detail
+		}
+	}
+	return meta
+}

--- a/internal/app/document_root_sync_attention_test.go
+++ b/internal/app/document_root_sync_attention_test.go
@@ -1,0 +1,126 @@
+package app
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/nugget/thane-ai-agent/internal/channels/messages"
+	"github.com/nugget/thane-ai-agent/internal/platform/provenance"
+	looppkg "github.com/nugget/thane-ai-agent/internal/runtime/loop"
+)
+
+func TestDocRootSyncAttentionNotifierSendsCoreWake(t *testing.T) {
+	bus := messages.NewBus(testLogger())
+	var got messages.Envelope
+	bus.RegisterRoute(messages.DestinationLoop, func(_ context.Context, env messages.Envelope) (messages.DeliveryResult, error) {
+		got = env
+		return messages.DeliveryResult{Route: "test", Status: messages.DeliveryDelivered}, nil
+	})
+
+	loops := looppkg.NewRegistry()
+	target, err := looppkg.New(looppkg.Config{
+		Name: "core-attention",
+		Task: "Review core attention requests.",
+		Metadata: map[string]string{
+			"core_attention_target": "true",
+		},
+	}, looppkg.Deps{Runner: testLoopRunner{}})
+	if err != nil {
+		t.Fatalf("New target loop: %v", err)
+	}
+	if err := loops.Register(target); err != nil {
+		t.Fatalf("Register target loop: %v", err)
+	}
+
+	a := &App{messageBus: bus, loopRegistry: loops}
+	transition := syncStateTransition{
+		Kind: syncTransitionAttentionRequired,
+		Current: syncState{
+			Root:       "kb",
+			OK:         true,
+			Outcome:    provenance.SyncBlocked,
+			Ahead:      0,
+			Behind:     2,
+			LocalHead:  "local",
+			RemoteHead: "remote",
+			Detail:     "first untrusted commit abc123",
+		},
+	}
+	if err := a.notifyDocRootSyncTransition(context.Background(), transition); err != nil {
+		t.Fatalf("notifyDocRootSyncTransition: %v", err)
+	}
+
+	if got.From.Kind != messages.IdentitySystem || got.From.Name != "document_root_syncer" {
+		t.Fatalf("from = %#v, want document_root_syncer system identity", got.From)
+	}
+	if got.To.Target != target.ID() || got.To.Selector != messages.SelectorID {
+		t.Fatalf("to = %#v, want target loop id %q", got.To, target.ID())
+	}
+	if got.Priority != messages.PriorityUrgent {
+		t.Fatalf("priority = %q, want urgent", got.Priority)
+	}
+	payload, ok := got.Payload.(messages.LoopNotifyPayload)
+	if !ok {
+		t.Fatalf("payload type = %T, want LoopNotifyPayload", got.Payload)
+	}
+	if payload.Kind != docRootSyncTransitionKind || !payload.ForceSupervisor {
+		t.Fatalf("payload = %#v, want doc-root sync supervisor transition", payload)
+	}
+	if !strings.Contains(payload.Concern, "first untrusted commit abc123") {
+		t.Fatalf("concern = %q, want refusal detail in primary concern", payload.Concern)
+	}
+	if strings.Contains(strings.ToLower(payload.SuggestedAction), "send") {
+		t.Fatalf("suggested action should not command direct human delivery: %q", payload.SuggestedAction)
+	}
+	if len(payload.Events) != 1 {
+		t.Fatalf("events len = %d, want 1", len(payload.Events))
+	}
+	event := payload.Events[0]
+	if event.Source != "document_root_sync" || event.Type != string(syncTransitionAttentionRequired) {
+		t.Fatalf("event = %#v, want document_root_sync attention event", event)
+	}
+	if event.Metadata["root"] != "kb" || event.Metadata["outcome"] != string(provenance.SyncBlocked) || event.Metadata["detail"] != "first untrusted commit abc123" {
+		t.Fatalf("event metadata = %#v", event.Metadata)
+	}
+	changedDetail := transition
+	changedDetail.Current.Detail = "first untrusted commit def456"
+	if event.ID == docRootSyncTransitionEvent(changedDetail).ID {
+		t.Fatalf("event ID %q should differ when transition detail differs", event.ID)
+	}
+}
+
+func TestDocRootSyncRecoveryWakeIsNotSupervisorForced(t *testing.T) {
+	env := docRootSyncTransitionEnvelope(looppkg.CoreAttentionTarget{LoopID: "loop-1"}, syncStateTransition{
+		Kind: syncTransitionRecovered,
+		Previous: syncState{
+			Root:    "kb",
+			OK:      true,
+			Outcome: provenance.SyncBlocked,
+			Detail:  "first untrusted commit abc123",
+		},
+		Current: syncState{
+			Root:    "kb",
+			OK:      true,
+			Outcome: provenance.SyncFastForwarded,
+		},
+		HasPrevious: true,
+	})
+
+	if env.Priority != messages.PriorityNormal {
+		t.Fatalf("priority = %q, want normal", env.Priority)
+	}
+	payload, ok := env.Payload.(messages.LoopNotifyPayload)
+	if !ok {
+		t.Fatalf("payload type = %T, want LoopNotifyPayload", env.Payload)
+	}
+	if payload.ForceSupervisor {
+		t.Fatal("recovery wake should not force supervisor")
+	}
+	if !strings.Contains(payload.Concern, "is fast_forwarded after blocked") {
+		t.Fatalf("concern = %q, want actual recovered outcome", payload.Concern)
+	}
+	if !strings.Contains(payload.SuggestedAction, "no direct human message") {
+		t.Fatalf("suggested action = %q, want no-direct-human guidance", payload.SuggestedAction)
+	}
+}

--- a/internal/app/document_root_syncer.go
+++ b/internal/app/document_root_syncer.go
@@ -136,11 +136,14 @@ func newSyncStateRegistry() *syncStateRegistry {
 	}
 }
 
-// setState records the latest observed state for a root.
-func (r *syncStateRegistry) setState(st syncState) {
+// setState records the latest observed state for a root and returns the state
+// it replaced, if any.
+func (r *syncStateRegistry) setState(st syncState) (syncState, bool) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
+	prev, ok := r.state[st.Root]
 	r.state[st.Root] = st
+	return prev, ok
 }
 
 // advanceRemote records the remote head a root legitimately accepted, so the
@@ -192,19 +195,36 @@ type syncEngine interface {
 	Sync(ctx context.Context, req provenance.SyncRequest) (provenance.SyncResult, error)
 }
 
+type syncTransitionKind string
+
+const (
+	syncTransitionAttentionRequired syncTransitionKind = "attention_required"
+	syncTransitionRecovered         syncTransitionKind = "recovered"
+)
+
+type syncStateTransition struct {
+	Kind        syncTransitionKind
+	Previous    syncState
+	Current     syncState
+	HasPrevious bool
+}
+
+type syncTransitionNotifier func(context.Context, syncStateTransition) error
+
 // docRootSyncer runs timed fast-forward-only sync for one git-remote-backed
 // document root. It threads the last-seen remote head into each pass (for
 // rewind detection), records the outcome in the registry, and re-indexes the
 // root after a fast-forward moves the worktree.
 type docRootSyncer struct {
-	root     string
-	engine   syncEngine
-	request  provenance.SyncRequest // LastKnownRemote is filled per pass
-	interval time.Duration          // 0 disables the ticker (sync-on-demand only)
-	refresh  func(context.Context) error
-	registry *syncStateRegistry
-	logger   *slog.Logger
-	now      func() time.Time // injectable clock; nil uses time.Now
+	root             string
+	engine           syncEngine
+	request          provenance.SyncRequest // LastKnownRemote is filled per pass
+	interval         time.Duration          // 0 disables the ticker (sync-on-demand only)
+	refresh          func(context.Context) error
+	notifyTransition syncTransitionNotifier
+	registry         *syncStateRegistry
+	logger           *slog.Logger
+	now              func() time.Time // injectable clock; nil uses time.Now
 }
 
 func (s *docRootSyncer) clock() time.Time {
@@ -212,6 +232,60 @@ func (s *docRootSyncer) clock() time.Time {
 		return s.now()
 	}
 	return time.Now()
+}
+
+func (s *docRootSyncer) recordState(ctx context.Context, st syncState) {
+	prev, hadPrev := s.registry.setState(st)
+	if s.notifyTransition == nil {
+		return
+	}
+	transition, ok := classifySyncStateTransition(prev, hadPrev, st)
+	if !ok {
+		return
+	}
+	if err := s.notifyTransition(ctx, transition); err != nil && ctx.Err() == nil {
+		s.logger.Warn("document root sync attention wake failed",
+			"root", st.Root,
+			"outcome", st.Outcome,
+			"transition", transition.Kind,
+			"detail", st.Detail,
+			"error", err)
+	}
+}
+
+func classifySyncStateTransition(prev syncState, hadPrev bool, current syncState) (syncStateTransition, bool) {
+	if !current.OK {
+		return syncStateTransition{}, false
+	}
+	if syncOutcomeNeedsAttention(current.Outcome) {
+		if !hadPrev || !prev.OK || prev.Outcome != current.Outcome || strings.TrimSpace(prev.Detail) != strings.TrimSpace(current.Detail) {
+			return syncStateTransition{
+				Kind:        syncTransitionAttentionRequired,
+				Previous:    prev,
+				Current:     current,
+				HasPrevious: hadPrev,
+			}, true
+		}
+		return syncStateTransition{}, false
+	}
+	if hadPrev && prev.OK && syncOutcomeNeedsAttention(prev.Outcome) {
+		return syncStateTransition{
+			Kind:        syncTransitionRecovered,
+			Previous:    prev,
+			Current:     current,
+			HasPrevious: true,
+		}, true
+	}
+	return syncStateTransition{}, false
+}
+
+func syncOutcomeNeedsAttention(outcome provenance.SyncOutcome) bool {
+	switch outcome {
+	case provenance.SyncBlocked, provenance.SyncDiverged, provenance.SyncRemoteBehind:
+		return true
+	default:
+		return false
+	}
 }
 
 // runOnce performs one sync pass, records the result, and re-indexes on a
@@ -227,7 +301,7 @@ func (s *docRootSyncer) runOnce(ctx context.Context) syncState {
 		st.OK = false
 		st.Detail = err.Error()
 		s.logger.Warn("document root sync failed", "root", s.root, "error", err)
-		s.registry.setState(st)
+		s.recordState(ctx, st)
 		return st
 	}
 
@@ -254,7 +328,7 @@ func (s *docRootSyncer) runOnce(ctx context.Context) syncState {
 		}
 	}
 
-	s.registry.setState(st)
+	s.recordState(ctx, st)
 	// Advance the rewind baseline only for outcomes where the remote head was
 	// legitimately accepted as authoritative (in sync, or integrated). A
 	// refused outcome — diverged, blocked, or remote_behind — must NOT advance

--- a/internal/app/document_root_syncer_test.go
+++ b/internal/app/document_root_syncer_test.go
@@ -367,6 +367,53 @@ func TestRunOnceAdvanceBaseline(t *testing.T) {
 	}
 }
 
+func TestRunOnceNotifiesOnAttentionTransitions(t *testing.T) {
+	reg := newSyncStateRegistry()
+	eng := &fakeEngine{results: []provenance.SyncResult{
+		{Outcome: provenance.SyncBlocked, RemoteHead: "r1", Detail: "first untrusted commit abc123"},
+		{Outcome: provenance.SyncBlocked, RemoteHead: "r1", Detail: "first untrusted commit abc123"},
+		{Outcome: provenance.SyncBlocked, RemoteHead: "r2", Detail: "first untrusted commit def456"},
+		{Outcome: provenance.SyncDiverged, RemoteHead: "r3", Detail: "local and remote diverged"},
+		{Outcome: provenance.SyncFastForwarded, RemoteHead: "r3"},
+		{Outcome: provenance.SyncClean, RemoteHead: "r3"},
+	}}
+	s := newTestSyncer(eng, reg, nil)
+	var transitions []syncStateTransition
+	s.notifyTransition = func(_ context.Context, tr syncStateTransition) error {
+		transitions = append(transitions, tr)
+		return nil
+	}
+
+	for range eng.results {
+		s.runOnce(context.Background())
+	}
+
+	if len(transitions) != 4 {
+		t.Fatalf("transitions len = %d, want 4: %+v", len(transitions), transitions)
+	}
+	tests := []struct {
+		i       int
+		kind    syncTransitionKind
+		outcome provenance.SyncOutcome
+		detail  string
+	}{
+		{0, syncTransitionAttentionRequired, provenance.SyncBlocked, "first untrusted commit abc123"},
+		{1, syncTransitionAttentionRequired, provenance.SyncBlocked, "first untrusted commit def456"},
+		{2, syncTransitionAttentionRequired, provenance.SyncDiverged, "local and remote diverged"},
+		{3, syncTransitionRecovered, provenance.SyncFastForwarded, ""},
+	}
+	for _, tt := range tests {
+		tr := transitions[tt.i]
+		if tr.Kind != tt.kind || tr.Current.Outcome != tt.outcome || tr.Current.Detail != tt.detail {
+			t.Errorf("transition[%d] = kind=%q outcome=%q detail=%q, want %q/%q/%q",
+				tt.i, tr.Kind, tr.Current.Outcome, tr.Current.Detail, tt.kind, tt.outcome, tt.detail)
+		}
+	}
+	if transitions[3].Previous.Outcome != provenance.SyncDiverged {
+		t.Fatalf("recovery previous outcome = %q, want diverged", transitions[3].Previous.Outcome)
+	}
+}
+
 // TestRunReturnsOnCancel covers both loop shapes: a manual (interval<=0) syncer
 // runs one pass then blocks on ctx, and a ticker syncer waits — both must
 // return promptly when the context is cancelled, and neither may panic on a

--- a/internal/app/document_roots.go
+++ b/internal/app/document_roots.go
@@ -220,6 +220,7 @@ func (a *App) buildDocumentStoreOptions(documentRoots map[string]string, resolve
 			if err != nil {
 				return documents.StoreOptions{}, fmt.Errorf("doc_roots.%s.git.remote: %w", root, err)
 			}
+			syncer.notifyTransition = a.docRootSyncAttentionNotifier()
 			a.docRootSyncers = append(a.docRootSyncers, syncer)
 		}
 	}

--- a/internal/app/new_channels.go
+++ b/internal/app/new_channels.go
@@ -328,7 +328,9 @@ func (a *App) initChannels(s *newState) error {
 
 			// Remote-backed roots sync on their own cadence. Wire the
 			// post-fast-forward re-index to the document store (now that it
-			// exists) and launch each syncer under the app lifecycle. The
+			// exists); initServers launches the syncers after durable loop
+			// definitions have reconciled, so core-attention wake targets can
+			// exist before the first pass. The
 			// re-index is a best-effort nudge: Store.Refresh is throttled and
 			// covers all roots, so it may no-op right after a recent refresh —
 			// but the periodic refresher re-indexes within refreshInterval
@@ -339,12 +341,6 @@ func (a *App) initChannels(s *newState) error {
 				for _, syncer := range a.docRootSyncers {
 					syncer.refresh = refresh
 				}
-				a.deferWorker("docroot-sync", func(ctx context.Context) error {
-					for _, syncer := range a.docRootSyncers {
-						go syncer.Run(ctx)
-					}
-					return nil
-				})
 			}
 			roots := sortedDocumentRootNames(documentRoots)
 			attrs := append([]slog.Attr{slog.Any("roots", roots)}, documentRootPolicyAttrs(docOptions, roots)...)

--- a/internal/app/new_servers.go
+++ b/internal/app/new_servers.go
@@ -647,6 +647,14 @@ func (a *App) initServers(s *newState) error {
 			return a.loopDefinitionRuntime.StartScheduleWatcher(ctx)
 		})
 	}
+	if len(a.docRootSyncers) > 0 {
+		a.deferWorker("docroot-sync", func(ctx context.Context) error {
+			for _, syncer := range a.docRootSyncers {
+				go syncer.Run(ctx)
+			}
+			return nil
+		})
+	}
 	if mqttConnectWorker != nil {
 		a.deferWorker("mqtt-connect", mqttConnectWorker)
 	}

--- a/internal/runtime/loop/core_attention.go
+++ b/internal/runtime/loop/core_attention.go
@@ -1,0 +1,212 @@
+package loop
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/nugget/thane-ai-agent/internal/channels/messages"
+)
+
+const (
+	// CoreAttentionScope marks loop notifications that request core review.
+	CoreAttentionScope = "core_attention"
+	// CoreAttentionRequestKind is the default payload kind for direct
+	// loop-to-core attention requests.
+	CoreAttentionRequestKind = "core_attention_request"
+)
+
+// CoreAttentionTarget identifies the live loop that should receive
+// supervisor/core attention requests.
+type CoreAttentionTarget struct {
+	LoopID     string     `json:"loop_id"`
+	LoopName   string     `json:"loop_name"`
+	Reason     string     `json:"reason"`
+	LastActive *time.Time `json:"last_active,omitempty"`
+}
+
+// CoreWakeRequest describes one request to wake the designated core-attention
+// loop. It is the Go-side counterpart to the request_core_attention tool:
+// callers provide the concern and optional structured event context, while the
+// helper resolves the live target and sends the loop notification envelope.
+type CoreWakeRequest struct {
+	From            messages.Identity
+	Kind            string
+	Concern         string
+	SuggestedAction string
+	Context         string
+	Events          []messages.LoopEventPayload
+	Priority        messages.Priority
+	Scope           []string
+	ForceSupervisor bool
+}
+
+// CoreWakeResult reports the resolved target and bus delivery outcome for a
+// core wake.
+type CoreWakeResult struct {
+	Target   CoreAttentionTarget     `json:"target"`
+	Delivery messages.DeliveryResult `json:"delivery"`
+}
+
+// WakeCoreLoop resolves the current core-attention target and delivers one
+// signal envelope to it. Use this for system/runtime code that needs core
+// review without choosing a human delivery channel directly.
+func WakeCoreLoop(ctx context.Context, registry *Registry, bus *messages.Bus, req CoreWakeRequest) (CoreWakeResult, error) {
+	if registry == nil {
+		return CoreWakeResult{}, fmt.Errorf("core attention target unavailable: loop registry is not configured")
+	}
+	if bus == nil {
+		return CoreWakeResult{}, fmt.Errorf("message bus is not configured")
+	}
+	target, err := ResolveCoreAttentionTarget(registry.Statuses())
+	if err != nil {
+		return CoreWakeResult{}, err
+	}
+	env := CoreWakeEnvelope(target, req)
+	delivery, err := bus.Send(ctx, env)
+	if err != nil {
+		return CoreWakeResult{}, err
+	}
+	return CoreWakeResult{Target: target, Delivery: delivery}, nil
+}
+
+// CoreWakeEnvelope builds the message envelope used by [WakeCoreLoop]. Tests
+// and callers that need to inspect the model-facing payload can use this
+// directly; production delivery should normally go through [WakeCoreLoop].
+func CoreWakeEnvelope(target CoreAttentionTarget, req CoreWakeRequest) messages.Envelope {
+	kind := strings.TrimSpace(req.Kind)
+	if kind == "" {
+		kind = CoreAttentionRequestKind
+	}
+	priority := req.Priority
+	if priority == "" {
+		priority = messages.PriorityNormal
+	}
+	return messages.Envelope{
+		From: req.From,
+		To: messages.Destination{
+			Kind:     messages.DestinationLoop,
+			Target:   target.LoopID,
+			Selector: messages.SelectorID,
+		},
+		Type:     messages.TypeSignal,
+		Priority: priority,
+		Scope:    coreWakeScope(req.Scope),
+		Payload: messages.LoopNotifyPayload{
+			Kind:            kind,
+			Concern:         req.Concern,
+			SuggestedAction: req.SuggestedAction,
+			Context:         req.Context,
+			ForceSupervisor: req.ForceSupervisor,
+			Events:          cloneLoopEvents(req.Events),
+		},
+	}
+}
+
+func coreWakeScope(extra []string) []string {
+	scope := []string{CoreAttentionScope}
+	seen := map[string]struct{}{CoreAttentionScope: {}}
+	for _, raw := range extra {
+		s := strings.TrimSpace(raw)
+		if s == "" {
+			continue
+		}
+		if _, ok := seen[s]; ok {
+			continue
+		}
+		seen[s] = struct{}{}
+		scope = append(scope, s)
+	}
+	return scope
+}
+
+func cloneLoopEvents(in []messages.LoopEventPayload) []messages.LoopEventPayload {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]messages.LoopEventPayload, len(in))
+	copy(out, in)
+	return out
+}
+
+// ResolveCoreAttentionTarget chooses the live loop that should receive a
+// core-attention wake. Explicit metadata wins; otherwise the newest active
+// owner channel is the fallback.
+func ResolveCoreAttentionTarget(statuses []Status) (CoreAttentionTarget, error) {
+	if len(statuses) == 0 {
+		return CoreAttentionTarget{}, fmt.Errorf("core attention target unavailable: no live loops are registered")
+	}
+	if target, ok := newestCoreAttentionTarget(statuses, func(st Status) bool {
+		return metadataFlag(st.Config.Metadata, "core_attention_target") ||
+			metadataEquals(st.Config.Metadata, "attention_role", "core") ||
+			metadataEquals(st.Config.Metadata, "role", "core")
+	}, "metadata_core_attention_target"); ok {
+		return target, nil
+	}
+	if target, ok := newestCoreAttentionTarget(statuses, func(st Status) bool {
+		return metadataEquals(st.Config.Metadata, "category", "channel") && metadataFlag(st.Config.Metadata, "is_owner")
+	}, "recent_owner_channel"); ok {
+		return target, nil
+	}
+	return CoreAttentionTarget{}, fmt.Errorf("core attention target unavailable: no loop has metadata core_attention_target=true and no active owner channel loop was found")
+}
+
+func newestCoreAttentionTarget(statuses []Status, accept func(Status) bool, reason string) (CoreAttentionTarget, bool) {
+	matches := make([]Status, 0, len(statuses))
+	for _, st := range statuses {
+		if st.ID == "" || st.Name == "" || !accept(st) {
+			continue
+		}
+		matches = append(matches, st)
+	}
+	if len(matches) == 0 {
+		return CoreAttentionTarget{}, false
+	}
+	sort.SliceStable(matches, func(i, j int) bool {
+		iActive := loopStatusLastActive(matches[i])
+		jActive := loopStatusLastActive(matches[j])
+		if iActive.Equal(jActive) {
+			return matches[i].ID < matches[j].ID
+		}
+		return iActive.After(jActive)
+	})
+	st := matches[0]
+	return CoreAttentionTarget{
+		LoopID:     st.ID,
+		LoopName:   st.Name,
+		Reason:     reason,
+		LastActive: optionalTime(loopStatusLastActive(st)),
+	}, true
+}
+
+func optionalTime(t time.Time) *time.Time {
+	if t.IsZero() {
+		return nil
+	}
+	return &t
+}
+
+func loopStatusLastActive(st Status) time.Time {
+	if !st.LastWakeAt.IsZero() {
+		return st.LastWakeAt
+	}
+	if !st.StartedAt.IsZero() {
+		return st.StartedAt
+	}
+	return time.Time{}
+}
+
+func metadataFlag(meta map[string]string, key string) bool {
+	switch strings.ToLower(strings.TrimSpace(meta[key])) {
+	case "1", "t", "true", "y", "yes", "on":
+		return true
+	default:
+		return false
+	}
+}
+
+func metadataEquals(meta map[string]string, key, want string) bool {
+	return strings.EqualFold(strings.TrimSpace(meta[key]), want)
+}

--- a/internal/runtime/loop/core_attention_test.go
+++ b/internal/runtime/loop/core_attention_test.go
@@ -1,0 +1,66 @@
+package loop
+
+import (
+	"context"
+	"testing"
+
+	"github.com/nugget/thane-ai-agent/internal/channels/messages"
+)
+
+func TestWakeCoreLoopDeliversSharedCoreAttentionEnvelope(t *testing.T) {
+	t.Parallel()
+
+	registry := NewRegistry()
+	target, err := New(Config{
+		Name: "core-attention",
+		Task: "Review core attention requests.",
+		Metadata: map[string]string{
+			"core_attention_target": "true",
+		},
+	}, Deps{Runner: &noopRunner{}})
+	if err != nil {
+		t.Fatalf("New target: %v", err)
+	}
+	if err := registry.Register(target); err != nil {
+		t.Fatalf("Register target: %v", err)
+	}
+
+	bus := messages.NewBus(nil)
+	var got messages.Envelope
+	bus.RegisterRoute(messages.DestinationLoop, func(_ context.Context, env messages.Envelope) (messages.DeliveryResult, error) {
+		got = env
+		return messages.DeliveryResult{Route: "test", Status: messages.DeliveryDelivered}, nil
+	})
+
+	result, err := WakeCoreLoop(context.Background(), registry, bus, CoreWakeRequest{
+		From:            messages.Identity{Kind: messages.IdentitySystem, Name: "test_subsystem"},
+		Concern:         "A subsystem needs core review.",
+		SuggestedAction: "Decide whether to escalate.",
+		Priority:        messages.PriorityUrgent,
+		Scope:           []string{CoreAttentionScope, "test_scope"},
+		ForceSupervisor: true,
+	})
+	if err != nil {
+		t.Fatalf("WakeCoreLoop: %v", err)
+	}
+
+	if result.Target.LoopID != target.ID() || result.Target.LoopName != target.Name() {
+		t.Fatalf("target = %#v, want %s/%s", result.Target, target.ID(), target.Name())
+	}
+	if got.To.Target != target.ID() || got.To.Selector != messages.SelectorID {
+		t.Fatalf("to = %#v, want target id %q", got.To, target.ID())
+	}
+	if got.Priority != messages.PriorityUrgent {
+		t.Fatalf("priority = %q, want urgent", got.Priority)
+	}
+	if len(got.Scope) != 2 || got.Scope[0] != CoreAttentionScope || got.Scope[1] != "test_scope" {
+		t.Fatalf("scope = %#v, want deduped core + test scope", got.Scope)
+	}
+	payload, ok := got.Payload.(messages.LoopNotifyPayload)
+	if !ok {
+		t.Fatalf("payload type = %T, want LoopNotifyPayload", got.Payload)
+	}
+	if payload.Kind != CoreAttentionRequestKind || !payload.ForceSupervisor {
+		t.Fatalf("payload = %#v, want default core attention supervisor wake", payload)
+	}
+}

--- a/internal/tools/message_tools.go
+++ b/internal/tools/message_tools.go
@@ -3,9 +3,7 @@ package tools
 import (
 	"context"
 	"fmt"
-	"sort"
 	"strings"
-	"time"
 
 	"github.com/nugget/thane-ai-agent/internal/channels/messages"
 	looppkg "github.com/nugget/thane-ai-agent/internal/runtime/loop"
@@ -169,13 +167,6 @@ func coreAttentionToolParameters() map[string]any {
 	}
 }
 
-type coreAttentionTarget struct {
-	LoopID     string     `json:"loop_id"`
-	LoopName   string     `json:"loop_name"`
-	Reason     string     `json:"reason"`
-	LastActive *time.Time `json:"last_active,omitempty"`
-}
-
 func (r *Registry) handleRequestCoreAttention(ctx context.Context, args map[string]any) (string, error) {
 	if r.messageBus == nil {
 		return "", fmt.Errorf("message bus is not configured")
@@ -184,122 +175,24 @@ func (r *Registry) handleRequestCoreAttention(ctx context.Context, args map[stri
 	if concern == "" {
 		return "", fmt.Errorf("concern is required")
 	}
-	target, err := r.resolveCoreAttentionTarget()
-	if err != nil {
-		return "", err
-	}
 
-	payload := messages.LoopNotifyPayload{
-		Kind:            "core_attention_request",
+	result, err := looppkg.WakeCoreLoop(ctx, r.liveLoopRegistry, r.messageBus, looppkg.CoreWakeRequest{
+		From:            senderIdentityFromContext(ctx),
+		Kind:            looppkg.CoreAttentionRequestKind,
 		Concern:         concern,
 		SuggestedAction: toolargs.TrimmedString(args, "suggested_action"),
 		Context:         toolargs.TrimmedString(args, "context"),
+		Priority:        messagePriorityArg(args),
 		ForceSupervisor: true,
-	}
-
-	env := messages.Envelope{
-		From: senderIdentityFromContext(ctx),
-		To: messages.Destination{
-			Kind:     messages.DestinationLoop,
-			Target:   target.LoopID,
-			Selector: messages.SelectorID,
-		},
-		Type:     messages.TypeSignal,
-		Payload:  payload,
-		Priority: messagePriorityArg(args),
-		Scope:    []string{"core_attention"},
-	}
-
-	result, err := r.messageBus.Send(ctx, env)
+	})
 	if err != nil {
 		return "", err
 	}
 	return ldMarshalToolJSON(map[string]any{
 		"status":   "ok",
-		"target":   target,
-		"delivery": result,
+		"target":   result.Target,
+		"delivery": result.Delivery,
 	})
-}
-
-func (r *Registry) resolveCoreAttentionTarget() (coreAttentionTarget, error) {
-	if r.liveLoopRegistry == nil {
-		return coreAttentionTarget{}, fmt.Errorf("core attention target unavailable: loop registry is not configured")
-	}
-	statuses := r.liveLoopRegistry.Statuses()
-	if len(statuses) == 0 {
-		return coreAttentionTarget{}, fmt.Errorf("core attention target unavailable: no live loops are registered")
-	}
-	if target, ok := newestCoreAttentionTarget(statuses, func(st looppkg.Status) bool {
-		return metadataFlag(st.Config.Metadata, "core_attention_target") ||
-			metadataEquals(st.Config.Metadata, "attention_role", "core") ||
-			metadataEquals(st.Config.Metadata, "role", "core")
-	}, "metadata_core_attention_target"); ok {
-		return target, nil
-	}
-	if target, ok := newestCoreAttentionTarget(statuses, func(st looppkg.Status) bool {
-		return metadataEquals(st.Config.Metadata, "category", "channel") && metadataFlag(st.Config.Metadata, "is_owner")
-	}, "recent_owner_channel"); ok {
-		return target, nil
-	}
-	return coreAttentionTarget{}, fmt.Errorf("core attention target unavailable: no loop has metadata core_attention_target=true and no active owner channel loop was found")
-}
-
-func newestCoreAttentionTarget(statuses []looppkg.Status, accept func(looppkg.Status) bool, reason string) (coreAttentionTarget, bool) {
-	matches := make([]looppkg.Status, 0, len(statuses))
-	for _, st := range statuses {
-		if st.ID == "" || st.Name == "" || !accept(st) {
-			continue
-		}
-		matches = append(matches, st)
-	}
-	if len(matches) == 0 {
-		return coreAttentionTarget{}, false
-	}
-	sort.SliceStable(matches, func(i, j int) bool {
-		iActive := loopStatusLastActive(matches[i])
-		jActive := loopStatusLastActive(matches[j])
-		if iActive.Equal(jActive) {
-			return matches[i].ID < matches[j].ID
-		}
-		return iActive.After(jActive)
-	})
-	st := matches[0]
-	return coreAttentionTarget{
-		LoopID:     st.ID,
-		LoopName:   st.Name,
-		Reason:     reason,
-		LastActive: optionalTime(loopStatusLastActive(st)),
-	}, true
-}
-
-func optionalTime(t time.Time) *time.Time {
-	if t.IsZero() {
-		return nil
-	}
-	return &t
-}
-
-func loopStatusLastActive(st looppkg.Status) time.Time {
-	if !st.LastWakeAt.IsZero() {
-		return st.LastWakeAt
-	}
-	if !st.StartedAt.IsZero() {
-		return st.StartedAt
-	}
-	return time.Time{}
-}
-
-func metadataFlag(meta map[string]string, key string) bool {
-	switch strings.ToLower(strings.TrimSpace(meta[key])) {
-	case "1", "t", "true", "y", "yes", "on":
-		return true
-	default:
-		return false
-	}
-}
-
-func metadataEquals(meta map[string]string, key, want string) bool {
-	return strings.EqualFold(strings.TrimSpace(meta[key]), want)
 }
 
 func senderIdentityFromContext(ctx context.Context) messages.Identity {

--- a/internal/tools/message_tools_test.go
+++ b/internal/tools/message_tools_test.go
@@ -155,11 +155,9 @@ func TestResolveCoreAttentionTargetPrefersExplicitMetadata(t *testing.T) {
 		t.Fatalf("Register core: %v", err)
 	}
 
-	reg := NewEmptyRegistry()
-	reg.ConfigureLoopRuntimeTools(LoopRuntimeToolDeps{Registry: loops})
-	target, err := reg.resolveCoreAttentionTarget()
+	target, err := looppkg.ResolveCoreAttentionTarget(loops.Statuses())
 	if err != nil {
-		t.Fatalf("resolveCoreAttentionTarget: %v", err)
+		t.Fatalf("ResolveCoreAttentionTarget: %v", err)
 	}
 	if target.LoopID != core.ID() || target.LoopName != "core-attention" || target.Reason != "metadata_core_attention_target" {
 		t.Fatalf("target = %#v, want explicit core loop", target)


### PR DESCRIPTION
## Summary

- Add transition detection for document-root sync refusal states (`blocked`, `diverged`, `remote_behind`) and clean recovery.
- Route those transitions through the loop message bus as system-originated core-attention wakes instead of sending directly to a human notification channel.
- Share the core-attention target resolver with `request_core_attention`, and start doc-root sync workers after durable loop definitions reconcile so configured attention targets can exist before the first sync pass.

## Validation

- `just ci`

Closes #1151