### PR TITLE
refactor: introduce checkout lifecycle package

### DIFF
--- a/internal/app/document_root_reviser.go
+++ b/internal/app/document_root_reviser.go
@@ -3,10 +3,8 @@ package app
 import (
 	"context"
 	"fmt"
-	"path"
-	"path/filepath"
-	"strings"
 
+	"github.com/nugget/thane-ai-agent/internal/platform/checkout"
 	"github.com/nugget/thane-ai-agent/internal/platform/provenance"
 	"github.com/nugget/thane-ai-agent/internal/state/documents"
 )
@@ -23,7 +21,7 @@ type documentRootProvenanceReviser struct {
 var _ documents.RootReviser = (*documentRootProvenanceReviser)(nil)
 
 func (r *documentRootProvenanceReviser) storeFilename(filename string) string {
-	return repoPrefixedFilename(r.prefix, filename)
+	return checkout.RepoFilename(r.prefix, filename)
 }
 
 func (r *documentRootProvenanceReviser) Resolve(ctx context.Context, filename, selector string) (documents.RevisionRef, error) {
@@ -124,18 +122,4 @@ func revisionSignerFromProvenance(cs provenance.CommitSigner) documents.Revision
 		KeyFingerprint: cs.KeyFingerprint,
 		Reason:         cs.Reason,
 	}
-}
-
-// repoPrefixedFilename joins a root-relative filename onto the repo prefix
-// (when the git repo is a parent of the root), leaving traversal/absolute
-// inputs untouched so downstream validation can reject them.
-func repoPrefixedFilename(prefix, filename string) string {
-	clean := filepath.ToSlash(filepath.Clean(filename))
-	if clean == "." || clean == ".." || strings.HasPrefix(clean, "../") || path.IsAbs(clean) {
-		return clean
-	}
-	if prefix == "" || prefix == "." {
-		return clean
-	}
-	return path.Join(prefix, clean)
 }

--- a/internal/app/document_roots.go
+++ b/internal/app/document_roots.go
@@ -5,23 +5,16 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"sort"
 	"strings"
-	"time"
 
+	"github.com/nugget/thane-ai-agent/internal/platform/checkout"
 	"github.com/nugget/thane-ai-agent/internal/platform/config"
 	"github.com/nugget/thane-ai-agent/internal/platform/paths"
 	"github.com/nugget/thane-ai-agent/internal/platform/provenance"
 	"github.com/nugget/thane-ai-agent/internal/state/documents"
 )
-
-// docRootBootstrapTimeout bounds the per-root birth-commit work
-// (stat/write .gitignore, stage, sign commit). Matches the
-// 30s ceiling provenance uses for its own startup git operations
-// so the budget stays consistent across the boot path.
-const docRootBootstrapTimeout = 30 * time.Second
 
 type documentRootProvenanceWriter struct {
 	store  *provenance.Store
@@ -42,7 +35,7 @@ func (w *documentRootProvenanceWriter) Delete(ctx context.Context, filename, mes
 }
 
 func (w *documentRootProvenanceWriter) storeFilename(filename string) string {
-	return repoPrefixedFilename(w.prefix, filename)
+	return checkout.RepoFilename(w.prefix, filename)
 }
 
 func (v *documentRootProvenanceVerifier) Verify(ctx context.Context, filename string) (documents.SignatureVerification, error) {
@@ -56,7 +49,7 @@ func (v *documentRootProvenanceVerifier) VerifyRoot(ctx context.Context) (docume
 }
 
 func (v *documentRootProvenanceVerifier) storeFilename(filename string) string {
-	return repoPrefixedFilename(v.prefix, filename)
+	return checkout.RepoFilename(v.prefix, filename)
 }
 
 func documentSignatureVerificationFromProvenance(result provenance.VerificationResult) documents.SignatureVerification {
@@ -297,42 +290,23 @@ func (a *App) newDocumentRootProvenanceWriter(root, rootPath string, gitCfg conf
 	if err != nil {
 		return nil, fmt.Errorf("resolve document root %s path: %w", root, err)
 	}
-	prefix, err := rootPrefixWithinRepo(absRepoPath, absRootPath)
-	if err != nil {
+	if _, err := checkout.ResolveRoot(absRepoPath, absRootPath); err != nil {
 		return nil, fmt.Errorf("doc_roots.%s.git.repo_path: %w", root, err)
-	}
-
-	signer, err := provenance.NewSSHFileSigner(signingKey)
-	if err != nil {
-		return nil, fmt.Errorf("doc_roots.%s.git.signing_key: %w", root, err)
 	}
 	logger := a.logger
 	if logger == nil {
 		logger = slog.Default()
 	}
-	store, err := provenance.New(absRepoPath, signer, logger.With("component", "document_root_provenance", "root", root))
+	signed, err := checkout.OpenSigned(context.Background(), checkout.SignedSpec{
+		Name:           "doc_roots." + root + ".git",
+		WorktreePath:   absRootPath,
+		RepoPath:       absRepoPath,
+		SigningKeyPath: signingKey,
+		TrustedSigners: buildTrustedSigners(a.cfg.Signing.AllowedSigners, gitCfg.AllowedSigners),
+		Logger:         logger.With("component", "document_root_provenance", "root", root),
+	})
 	if err != nil {
 		return nil, fmt.Errorf("initialize git provenance for document root %s: %w", root, err)
-	}
-
-	// Make sure HEAD exists before any verifier construction. No-op
-	// when the repo already has commits; for a fresh repo this
-	// commits a templated .gitignore plus the repo-local
-	// .allowed_signers (when present) so verification has signed
-	// history to verify against.
-	bootstrapCtx, cancel := context.WithTimeout(context.Background(), docRootBootstrapTimeout)
-	defer cancel()
-	if err := store.BootstrapBirthCommit(bootstrapCtx); err != nil {
-		return nil, fmt.Errorf("doc_roots.%s bootstrap birth commit: %w", root, err)
-	}
-
-	// Render the repo's .allowed_signers as the union of the agent key and
-	// the operator keys the operator declared (shared plus this root's own),
-	// committing an update only when the set changed. This is what makes an
-	// operator's key trusted so they can co-author a signed root.
-	operators := buildTrustedSigners(a.cfg.Signing.AllowedSigners, gitCfg.AllowedSigners)
-	if _, err := store.ReconcileAllowedSigners(bootstrapCtx, operators); err != nil {
-		return nil, fmt.Errorf("doc_roots.%s reconcile allowed_signers: %w", root, err)
 	}
 
 	// Boot-time round-trip: confirm HEAD actually verifies against the trust
@@ -343,17 +317,17 @@ func (a *App) newDocumentRootProvenanceWriter(root, rootPath string, gitCfg conf
 	mode := documents.VerificationMode(strings.TrimSpace(gitCfg.VerifySignatures))
 	switch mode {
 	case documents.VerificationRequired, documents.VerificationWarn:
-		if err := applyBootVerification(mode, root, store.VerifyHead(bootstrapCtx), logger); err != nil {
+		if err := applyBootVerification(mode, root, signed.VerifyHead(context.Background()), logger); err != nil {
 			return nil, err
 		}
 	}
 
 	logger.Info("document root provenance enabled",
 		"root", root,
-		"repo", store.Path(),
-		"prefix", prefix,
+		"repo", signed.Store.Path(),
+		"prefix", signed.Prefix,
 	)
-	return &documentRootProvenanceWriter{store: store, prefix: prefix}, nil
+	return &documentRootProvenanceWriter{store: signed.Store, prefix: signed.Prefix}, nil
 }
 
 func (a *App) newDocumentRootProvenanceVerifier(root, rootPath string, gitCfg config.DocumentRootGitConfig, resolver *paths.Resolver) (*documentRootProvenanceVerifier, error) {
@@ -371,23 +345,23 @@ func (a *App) newDocumentRootProvenanceVerifier(root, rootPath string, gitCfg co
 	if err != nil {
 		return nil, fmt.Errorf("resolve document root %s path: %w", root, err)
 	}
-	prefix, err := rootPrefixWithinRepo(absRepoPath, absRootPath)
-	if err != nil {
+	if _, err := checkout.ResolveRoot(absRepoPath, absRootPath); err != nil {
 		return nil, fmt.Errorf("doc_roots.%s.git.repo_path: %w", root, err)
 	}
-
 	logger := a.logger
 	if logger == nil {
 		logger = slog.Default()
 	}
-	if err := configureRepoLocalAllowedSigners(root, absRepoPath, logger); err != nil {
-		return nil, err
-	}
-	verifier, err := provenance.NewVerifier(absRepoPath, logger.With("component", "document_root_verifier", "root", root), provenance.Options{})
+	verified, err := checkout.OpenVerified(context.Background(), checkout.VerifySpec{
+		Name:         "doc_roots." + root + ".git",
+		WorktreePath: absRootPath,
+		RepoPath:     absRepoPath,
+		Logger:       logger.With("component", "document_root_verifier", "root", root),
+	})
 	if err != nil {
 		return nil, fmt.Errorf("initialize git verifier for document root %s: %w", root, err)
 	}
-	return &documentRootProvenanceVerifier{verifier: verifier, prefix: prefix}, nil
+	return &documentRootProvenanceVerifier{verifier: verified.Verifier, prefix: verified.Prefix}, nil
 }
 
 // applyBootVerification maps a boot-time VerifyHead result onto the root's
@@ -428,47 +402,6 @@ func buildTrustedSigners(shared, perRoot []config.AllowedSigner) []provenance.Tr
 		}
 	}
 	return out
-}
-
-func configureRepoLocalAllowedSigners(root, repoPath string, logger *slog.Logger) error {
-	allowedSignersPath := filepath.Join(repoPath, ".allowed_signers")
-	if info, err := os.Lstat(allowedSignersPath); err != nil {
-		if os.IsNotExist(err) {
-			return fmt.Errorf("doc_roots.%s.git requires repo-local .allowed_signers at %s", root, allowedSignersPath)
-		}
-		return fmt.Errorf("doc_roots.%s.git stat .allowed_signers: %w", root, err)
-	} else if info.Mode()&os.ModeSymlink != 0 {
-		return fmt.Errorf("doc_roots.%s.git .allowed_signers must be a regular file, not a symlink: %s", root, allowedSignersPath)
-	} else if !info.Mode().IsRegular() {
-		return fmt.Errorf("doc_roots.%s.git .allowed_signers must be a regular file: %s", root, allowedSignersPath)
-	}
-	ctx, cancel := context.WithTimeout(context.Background(), docRootBootstrapTimeout)
-	defer cancel()
-	cmd := exec.CommandContext(ctx, "git", "-C", repoPath, "config", "gpg.ssh.allowedSignersFile", allowedSignersPath)
-	if out, err := cmd.CombinedOutput(); err != nil {
-		logger.Warn("document root git config allowedSignersFile failed; verification will still use per-command configuration",
-			"root", root,
-			"repo", repoPath,
-			"allowed_signers", allowedSignersPath,
-			"error", strings.TrimSpace(fmt.Sprintf("%v: %s", err, out)),
-		)
-	}
-	return nil
-}
-
-func rootPrefixWithinRepo(repoPath, rootPath string) (string, error) {
-	rel, err := filepath.Rel(repoPath, rootPath)
-	if err != nil {
-		return "", fmt.Errorf("compare repository and root paths: %w", err)
-	}
-	rel = filepath.Clean(rel)
-	if rel == "." {
-		return "", nil
-	}
-	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
-		return "", fmt.Errorf("repository %s must be the root path %s or one of its parents", repoPath, rootPath)
-	}
-	return filepath.ToSlash(rel), nil
 }
 
 func sortedDocumentRootNames(documentRoots map[string]string) []string {

--- a/internal/app/document_roots_test.go
+++ b/internal/app/document_roots_test.go
@@ -320,33 +320,6 @@ func TestBuildDocumentStoreOptionsVerifierUsesRepoLocalAllowedSigners(t *testing
 	}
 }
 
-func TestConfigureRepoLocalAllowedSignersBestEffortGitConfig(t *testing.T) {
-	targetPath := t.TempDir()
-	allowedPath := filepath.Join(targetPath, ".allowed_signers")
-	if err := os.WriteFile(allowedPath, []byte("thane@example.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFakeKeyForConfigOnly\n"), 0o644); err != nil {
-		t.Fatalf("WriteFile .allowed_signers: %v", err)
-	}
-
-	if err := configureRepoLocalAllowedSigners("kb", targetPath, slog.Default()); err != nil {
-		t.Fatalf("configureRepoLocalAllowedSigners() = %v, want nil despite non-git dir", err)
-	}
-}
-
-func TestConfigureRepoLocalAllowedSignersRejectsNonRegularFile(t *testing.T) {
-	targetPath := t.TempDir()
-	if err := os.Mkdir(filepath.Join(targetPath, ".allowed_signers"), 0o755); err != nil {
-		t.Fatalf("Mkdir .allowed_signers: %v", err)
-	}
-
-	err := configureRepoLocalAllowedSigners("kb", targetPath, slog.Default())
-	if err == nil {
-		t.Fatal("configureRepoLocalAllowedSigners() returned nil, want non-regular file error")
-	}
-	if !strings.Contains(err.Error(), "must be a regular file") {
-		t.Fatalf("error = %v, want regular-file message", err)
-	}
-}
-
 // TestBuildDocumentStoreOptionsNonBootstrapMissingDirStillErrors
 // preserves the original behavior for non-bootstrap configs: a
 // missing directory without git+sign_commits stays an error, since
@@ -405,32 +378,6 @@ func TestApplyBootVerification(t *testing.T) {
 				t.Fatalf("applyBootVerification = %v, want nil", err)
 			}
 		})
-	}
-}
-
-func TestRootPrefixWithinRepo(t *testing.T) {
-	t.Parallel()
-
-	rootDir := t.TempDir()
-	repo := filepath.Join(rootDir, "repo")
-	child := filepath.Join(repo, "knowledge", "kb")
-	prefix, err := rootPrefixWithinRepo(repo, child)
-	if err != nil {
-		t.Fatalf("rootPrefixWithinRepo child: %v", err)
-	}
-	if prefix != "knowledge/kb" {
-		t.Fatalf("prefix = %q, want knowledge/kb", prefix)
-	}
-	prefix, err = rootPrefixWithinRepo(repo, repo)
-	if err != nil {
-		t.Fatalf("rootPrefixWithinRepo same: %v", err)
-	}
-	if prefix != "" {
-		t.Fatalf("same-root prefix = %q, want empty", prefix)
-	}
-	_, err = rootPrefixWithinRepo(filepath.Join(rootDir, "other"), child)
-	if err == nil {
-		t.Fatal("rootPrefixWithinRepo outside repo returned nil, want error")
 	}
 }
 

--- a/internal/platform/checkout/doc.go
+++ b/internal/platform/checkout/doc.go
@@ -1,0 +1,8 @@
+// Package checkout provides shared local git working-tree lifecycle helpers.
+//
+// A checkout is the local thing Thane owns: a working tree at a path, possibly
+// backed by a remote and possibly governed by signing or verification policy.
+// Domain packages such as document roots and forge subscriptions attach their
+// own meaning to a checkout; this package keeps the local git mechanics in one
+// place.
+package checkout

--- a/internal/platform/checkout/paths.go
+++ b/internal/platform/checkout/paths.go
@@ -1,0 +1,76 @@
+package checkout
+
+import (
+	"fmt"
+	"path"
+	"path/filepath"
+	"strings"
+)
+
+// Root describes how a managed subtree maps onto its backing git repository.
+type Root struct {
+	// RepoPath is the absolute path to the git repository.
+	RepoPath string
+	// WorktreePath is the absolute path to the managed working-tree subtree.
+	WorktreePath string
+	// Prefix is the slash-separated path from RepoPath to WorktreePath. It is
+	// empty when the managed root is the repository root.
+	Prefix string
+}
+
+// ResolveRoot resolves repoPath and worktreePath to absolute paths and verifies
+// that the worktree is the repository root or a subtree inside it.
+func ResolveRoot(repoPath, worktreePath string) (Root, error) {
+	absRepoPath, err := filepath.Abs(repoPath)
+	if err != nil {
+		return Root{}, fmt.Errorf("resolve repository path: %w", err)
+	}
+	absWorktreePath, err := filepath.Abs(worktreePath)
+	if err != nil {
+		return Root{}, fmt.Errorf("resolve worktree path: %w", err)
+	}
+	prefix, err := prefixWithinRepo(absRepoPath, absWorktreePath)
+	if err != nil {
+		return Root{}, err
+	}
+	return Root{
+		RepoPath:     absRepoPath,
+		WorktreePath: absWorktreePath,
+		Prefix:       prefix,
+	}, nil
+}
+
+// RepoFilename maps a worktree-relative filename to the repository-relative
+// path for this checkout. Escaping names are left for the git/provenance layer
+// to reject so callers do not accidentally clean "../" into the prefix.
+func (r Root) RepoFilename(filename string) string {
+	return RepoFilename(r.Prefix, filename)
+}
+
+// RepoFilename maps a worktree-relative filename under prefix to a
+// repository-relative path.
+func RepoFilename(prefix, filename string) string {
+	clean := filepath.ToSlash(filepath.Clean(filename))
+	if clean == "." || clean == ".." || strings.HasPrefix(clean, "../") || path.IsAbs(clean) {
+		return clean
+	}
+	if prefix == "" || prefix == "." {
+		return clean
+	}
+	return path.Join(prefix, clean)
+}
+
+func prefixWithinRepo(repoPath, worktreePath string) (string, error) {
+	rel, err := filepath.Rel(repoPath, worktreePath)
+	if err != nil {
+		return "", fmt.Errorf("compare repository and worktree paths: %w", err)
+	}
+	rel = filepath.Clean(rel)
+	if rel == "." {
+		return "", nil
+	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("repository %s must be the worktree path %s or one of its parents", repoPath, worktreePath)
+	}
+	return filepath.ToSlash(rel), nil
+}

--- a/internal/platform/checkout/paths_test.go
+++ b/internal/platform/checkout/paths_test.go
@@ -1,0 +1,62 @@
+package checkout
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestResolveRoot(t *testing.T) {
+	t.Parallel()
+
+	rootDir := t.TempDir()
+	repo := filepath.Join(rootDir, "repo")
+	child := filepath.Join(repo, "knowledge", "kb")
+
+	root, err := ResolveRoot(repo, child)
+	if err != nil {
+		t.Fatalf("ResolveRoot child: %v", err)
+	}
+	if root.Prefix != "knowledge/kb" {
+		t.Fatalf("Prefix = %q, want knowledge/kb", root.Prefix)
+	}
+	if !filepath.IsAbs(root.RepoPath) || !filepath.IsAbs(root.WorktreePath) {
+		t.Fatalf("paths should be absolute: %+v", root)
+	}
+
+	root, err = ResolveRoot(repo, repo)
+	if err != nil {
+		t.Fatalf("ResolveRoot same: %v", err)
+	}
+	if root.Prefix != "" {
+		t.Fatalf("same-root Prefix = %q, want empty", root.Prefix)
+	}
+
+	_, err = ResolveRoot(filepath.Join(rootDir, "other"), child)
+	if err == nil {
+		t.Fatal("ResolveRoot outside repo returned nil, want error")
+	}
+	if !strings.Contains(err.Error(), "one of its parents") {
+		t.Fatalf("error = %v, want parent relationship message", err)
+	}
+}
+
+func TestRepoFilenameDoesNotCleanEscapesIntoPrefix(t *testing.T) {
+	t.Parallel()
+
+	if got := RepoFilename("knowledge/kb", "notes/doc.md"); got != "knowledge/kb/notes/doc.md" {
+		t.Fatalf("RepoFilename(valid) = %q, want prefixed path", got)
+	}
+	if got := RepoFilename("knowledge/kb", "../outside.md"); got != "../outside.md" {
+		t.Fatalf("RepoFilename(escape) = %q, want provenance validator to see escape", got)
+	}
+	if got := RepoFilename("knowledge/kb", "."); got != "." {
+		t.Fatalf("RepoFilename(dot) = %q, want unchanged dot", got)
+	}
+	if got := RepoFilename("knowledge/kb", "notes/../doc.md"); got != "knowledge/kb/doc.md" {
+		t.Fatalf("RepoFilename(clean) = %q, want cleaned path under prefix", got)
+	}
+	if got := RepoFilename("", "doc.md"); got != "doc.md" {
+		t.Fatalf("RepoFilename(no prefix) = %q, want unchanged", got)
+	}
+}

--- a/internal/platform/checkout/signed.go
+++ b/internal/platform/checkout/signed.go
@@ -1,0 +1,123 @@
+package checkout
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/nugget/thane-ai-agent/internal/platform/provenance"
+)
+
+// DefaultBootstrapTimeout bounds checkout birth-commit and trust reconciliation
+// work. It matches the provenance package's own git startup timeout.
+const DefaultBootstrapTimeout = 30 * time.Second
+
+// SignedSpec describes a checkout that can author signed commits.
+type SignedSpec struct {
+	// Name is a caller-facing identifier used in logs and errors.
+	Name string
+	// WorktreePath is the local path exposed to the domain caller.
+	WorktreePath string
+	// RepoPath optionally points at the backing git repository. Empty means the
+	// worktree path itself is the repository.
+	RepoPath string
+	// SigningKeyPath is the SSH private key used for signed commits.
+	SigningKeyPath string
+	// TrustedSigners are operator signing keys added to the repo-local trust set.
+	TrustedSigners []provenance.TrustedSigner
+	// Logger receives setup logs. Nil uses slog.Default.
+	Logger *slog.Logger
+}
+
+// Signed is a local checkout backed by a provenance store.
+type Signed struct {
+	Root
+
+	Name  string
+	Store *provenance.Store
+}
+
+// OpenSigned opens or initializes a signed checkout, creates a birth commit
+// when needed, and reconciles its repo-local allowed_signers file.
+func OpenSigned(ctx context.Context, spec SignedSpec) (*Signed, error) {
+	ctx, cancel := withDefaultTimeout(ctx)
+	defer cancel()
+
+	name := strings.TrimSpace(spec.Name)
+	if name == "" {
+		name = "checkout"
+	}
+	if strings.TrimSpace(spec.WorktreePath) == "" {
+		return nil, fmt.Errorf("%s: worktree path is required", name)
+	}
+	signingKey := strings.TrimSpace(spec.SigningKeyPath)
+	if signingKey == "" {
+		return nil, fmt.Errorf("%s: signing key path is required", name)
+	}
+	repoPath := strings.TrimSpace(spec.RepoPath)
+	if repoPath == "" {
+		repoPath = spec.WorktreePath
+	}
+	root, err := ResolveRoot(repoPath, spec.WorktreePath)
+	if err != nil {
+		return nil, err
+	}
+
+	signer, err := provenance.NewSSHFileSigner(signingKey)
+	if err != nil {
+		return nil, fmt.Errorf("%s: signing key: %w", name, err)
+	}
+	logger := spec.Logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+	store, err := provenance.New(root.RepoPath, signer, logger)
+	if err != nil {
+		return nil, fmt.Errorf("%s: initialize provenance store: %w", name, err)
+	}
+
+	if err := store.BootstrapBirthCommit(ctx); err != nil {
+		return nil, fmt.Errorf("%s: bootstrap birth commit: %w", name, err)
+	}
+	if _, err := store.ReconcileAllowedSigners(ctx, spec.TrustedSigners); err != nil {
+		return nil, fmt.Errorf("%s: reconcile allowed_signers: %w", name, err)
+	}
+
+	logger.Info("signed checkout enabled",
+		"name", name,
+		"repo", store.Path(),
+		"worktree", root.WorktreePath,
+		"prefix", root.Prefix,
+	)
+	return &Signed{Name: name, Root: root, Store: store}, nil
+}
+
+func withDefaultTimeout(ctx context.Context) (context.Context, context.CancelFunc) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if _, ok := ctx.Deadline(); ok {
+		return ctx, func() {}
+	}
+	return context.WithTimeout(ctx, DefaultBootstrapTimeout)
+}
+
+// VerifyHead confirms that the checkout HEAD verifies against its trust set.
+func (c *Signed) VerifyHead(ctx context.Context) error {
+	if c == nil || c.Store == nil {
+		return fmt.Errorf("signed checkout is not configured")
+	}
+	ctx, cancel := withDefaultTimeout(ctx)
+	defer cancel()
+	return c.Store.VerifyHead(ctx)
+}
+
+// Reader returns the checkout's revision reader.
+func (c *Signed) Reader() provenance.Reader {
+	if c == nil {
+		return nil
+	}
+	return c.Store
+}

--- a/internal/platform/checkout/signed.go
+++ b/internal/platform/checkout/signed.go
@@ -62,7 +62,7 @@ func OpenSigned(ctx context.Context, spec SignedSpec) (*Signed, error) {
 	}
 	root, err := ResolveRoot(repoPath, spec.WorktreePath)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("%s: resolve root: %w", name, err)
 	}
 
 	signer, err := provenance.NewSSHFileSigner(signingKey)

--- a/internal/platform/checkout/signed_test.go
+++ b/internal/platform/checkout/signed_test.go
@@ -1,0 +1,83 @@
+package checkout
+
+import (
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nugget/thane-ai-agent/internal/platform/identity"
+	"github.com/nugget/thane-ai-agent/internal/platform/provenance"
+)
+
+func writeSigningKey(t *testing.T, name string) (privPath, pub string) {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	pair, err := identity.GenerateSigningKeyPair(name)
+	if err != nil {
+		t.Fatalf("GenerateSigningKeyPair: %v", err)
+	}
+	dir := t.TempDir()
+	privPath = filepath.Join(dir, "id_ed25519")
+	if err := os.WriteFile(privPath, pair.PrivatePEM, 0o600); err != nil {
+		t.Fatalf("write signing key: %v", err)
+	}
+	return privPath, strings.TrimSpace(pair.Public)
+}
+
+func TestOpenSignedBootstrapsAndReconciles(t *testing.T) {
+	worktree := t.TempDir()
+	signingKey, _ := writeSigningKey(t, "checkout-test")
+	_, operatorPublic := writeSigningKey(t, "operator-test")
+
+	signed, err := OpenSigned(t.Context(), SignedSpec{
+		Name:           "kb",
+		WorktreePath:   worktree,
+		SigningKeyPath: signingKey,
+		TrustedSigners: []provenance.TrustedSigner{{
+			Principal: "operator@example.com",
+			PublicKey: operatorPublic,
+			Comment:   "operator laptop",
+		}},
+		Logger: slog.Default(),
+	})
+	if err != nil {
+		t.Fatalf("OpenSigned: %v", err)
+	}
+	if signed.Store == nil {
+		t.Fatal("Store missing")
+	}
+	if signed.Prefix != "" || signed.RepoPath != worktree {
+		t.Fatalf("root = %+v, want repo root checkout", signed.Root)
+	}
+	if err := signed.VerifyHead(t.Context()); err != nil {
+		t.Fatalf("VerifyHead: %v", err)
+	}
+
+	allowed, err := os.ReadFile(filepath.Join(worktree, ".allowed_signers"))
+	if err != nil {
+		t.Fatalf("read .allowed_signers: %v", err)
+	}
+	if !strings.Contains(string(allowed), operatorPublic) {
+		t.Fatalf(".allowed_signers = %q, want operator key", allowed)
+	}
+
+	verified, err := OpenVerified(t.Context(), VerifySpec{
+		Name:         "kb",
+		WorktreePath: worktree,
+		Logger:       slog.Default(),
+	})
+	if err != nil {
+		t.Fatalf("OpenVerified: %v", err)
+	}
+	if verified.Verifier == nil {
+		t.Fatal("Verifier missing")
+	}
+	if _, err := verified.Verifier.VerifyTree(t.Context(), ""); err != nil {
+		t.Fatalf("VerifyTree: %v", err)
+	}
+}

--- a/internal/platform/checkout/signed_test.go
+++ b/internal/platform/checkout/signed_test.go
@@ -81,3 +81,22 @@ func TestOpenSignedBootstrapsAndReconciles(t *testing.T) {
 		t.Fatalf("VerifyTree: %v", err)
 	}
 }
+
+func TestOpenSignedResolveRootErrorNamesCheckout(t *testing.T) {
+	rootDir := t.TempDir()
+	errRepo := filepath.Join(rootDir, "other")
+	worktree := filepath.Join(rootDir, "repo", "kb")
+
+	_, err := OpenSigned(t.Context(), SignedSpec{
+		Name:           "kb",
+		WorktreePath:   worktree,
+		RepoPath:       errRepo,
+		SigningKeyPath: filepath.Join(rootDir, "missing_key"),
+	})
+	if err == nil {
+		t.Fatal("OpenSigned() error = nil, want root relationship error")
+	}
+	if !strings.Contains(err.Error(), "kb: resolve root") {
+		t.Fatalf("error = %v, want checkout name context", err)
+	}
+}

--- a/internal/platform/checkout/verify.go
+++ b/internal/platform/checkout/verify.go
@@ -1,0 +1,111 @@
+package checkout
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/nugget/thane-ai-agent/internal/platform/provenance"
+)
+
+// VerifySpec describes an existing checkout opened only for verification and
+// revision reads.
+type VerifySpec struct {
+	// Name is a caller-facing identifier used in logs and errors.
+	Name string
+	// WorktreePath is the local path exposed to the domain caller.
+	WorktreePath string
+	// RepoPath optionally points at the backing git repository. Empty means the
+	// worktree path itself is the repository.
+	RepoPath string
+	// Logger receives setup logs. Nil uses slog.Default.
+	Logger *slog.Logger
+}
+
+// Verified is a local checkout opened for verification and revision reads.
+type Verified struct {
+	Root
+
+	Name     string
+	Verifier *provenance.Verifier
+}
+
+// OpenVerified opens an existing checkout for verification and revision reads.
+// It never initializes the repository or writes commits.
+func OpenVerified(ctx context.Context, spec VerifySpec) (*Verified, error) {
+	name := strings.TrimSpace(spec.Name)
+	if name == "" {
+		name = "checkout"
+	}
+	if strings.TrimSpace(spec.WorktreePath) == "" {
+		return nil, fmt.Errorf("%s: worktree path is required", name)
+	}
+	repoPath := strings.TrimSpace(spec.RepoPath)
+	if repoPath == "" {
+		repoPath = spec.WorktreePath
+	}
+	root, err := ResolveRoot(repoPath, spec.WorktreePath)
+	if err != nil {
+		return nil, err
+	}
+	logger := spec.Logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+	if err := ConfigureRepoLocalAllowedSigners(ctx, name, root.RepoPath, logger); err != nil {
+		return nil, err
+	}
+	verifier, err := provenance.NewVerifier(root.RepoPath, logger, provenance.Options{})
+	if err != nil {
+		return nil, fmt.Errorf("%s: initialize verifier: %w", name, err)
+	}
+	return &Verified{Name: name, Root: root, Verifier: verifier}, nil
+}
+
+// Reader returns the checkout's revision reader.
+func (c *Verified) Reader() provenance.Reader {
+	if c == nil {
+		return nil
+	}
+	return c.Verifier
+}
+
+// ConfigureRepoLocalAllowedSigners validates the repo-local .allowed_signers
+// file and best-effort configures git to use it for SSH signature verification.
+func ConfigureRepoLocalAllowedSigners(ctx context.Context, name, repoPath string, logger *slog.Logger) error {
+	ctx, cancel := withDefaultTimeout(ctx)
+	defer cancel()
+
+	if logger == nil {
+		logger = slog.Default()
+	}
+	name = strings.TrimSpace(name)
+	if name == "" {
+		name = "checkout"
+	}
+	allowedSignersPath := filepath.Join(repoPath, ".allowed_signers")
+	if info, err := os.Lstat(allowedSignersPath); err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("%s: repo-local .allowed_signers is required at %s", name, allowedSignersPath)
+		}
+		return fmt.Errorf("%s: stat .allowed_signers: %w", name, err)
+	} else if info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("%s: .allowed_signers must be a regular file, not a symlink: %s", name, allowedSignersPath)
+	} else if !info.Mode().IsRegular() {
+		return fmt.Errorf("%s: .allowed_signers must be a regular file: %s", name, allowedSignersPath)
+	}
+	cmd := exec.CommandContext(ctx, "git", "-C", repoPath, "config", "gpg.ssh.allowedSignersFile", allowedSignersPath)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		logger.Warn("checkout git config allowedSignersFile failed; verification will still use per-command configuration",
+			"name", name,
+			"repo", repoPath,
+			"allowed_signers", allowedSignersPath,
+			"error", strings.TrimSpace(fmt.Sprintf("%v: %s", err, out)),
+		)
+	}
+	return nil
+}

--- a/internal/platform/checkout/verify.go
+++ b/internal/platform/checkout/verify.go
@@ -35,7 +35,9 @@ type Verified struct {
 }
 
 // OpenVerified opens an existing checkout for verification and revision reads.
-// It never initializes the repository or writes commits.
+// It never initializes the repository or writes commits. It may best-effort
+// update repo-local git config so command-line verification uses the checkout's
+// repo-local .allowed_signers file by default.
 func OpenVerified(ctx context.Context, spec VerifySpec) (*Verified, error) {
 	name := strings.TrimSpace(spec.Name)
 	if name == "" {
@@ -50,7 +52,7 @@ func OpenVerified(ctx context.Context, spec VerifySpec) (*Verified, error) {
 	}
 	root, err := ResolveRoot(repoPath, spec.WorktreePath)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("%s: resolve root: %w", name, err)
 	}
 	logger := spec.Logger
 	if logger == nil {

--- a/internal/platform/checkout/verify_test.go
+++ b/internal/platform/checkout/verify_test.go
@@ -1,0 +1,36 @@
+package checkout
+
+import (
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestConfigureRepoLocalAllowedSignersBestEffortGitConfig(t *testing.T) {
+	targetPath := t.TempDir()
+	allowedPath := filepath.Join(targetPath, ".allowed_signers")
+	if err := os.WriteFile(allowedPath, []byte("thane@example.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFakeKeyForConfigOnly\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile .allowed_signers: %v", err)
+	}
+
+	if err := ConfigureRepoLocalAllowedSigners(t.Context(), "kb", targetPath, slog.Default()); err != nil {
+		t.Fatalf("ConfigureRepoLocalAllowedSigners() = %v, want nil despite non-git dir", err)
+	}
+}
+
+func TestConfigureRepoLocalAllowedSignersRejectsNonRegularFile(t *testing.T) {
+	targetPath := t.TempDir()
+	if err := os.Mkdir(filepath.Join(targetPath, ".allowed_signers"), 0o755); err != nil {
+		t.Fatalf("Mkdir .allowed_signers: %v", err)
+	}
+
+	err := ConfigureRepoLocalAllowedSigners(t.Context(), "kb", targetPath, slog.Default())
+	if err == nil {
+		t.Fatal("ConfigureRepoLocalAllowedSigners() returned nil, want non-regular file error")
+	}
+	if !strings.Contains(err.Error(), "must be a regular file") {
+		t.Fatalf("error = %v, want regular-file message", err)
+	}
+}

--- a/internal/platform/checkout/verify_test.go
+++ b/internal/platform/checkout/verify_test.go
@@ -34,3 +34,21 @@ func TestConfigureRepoLocalAllowedSignersRejectsNonRegularFile(t *testing.T) {
 		t.Fatalf("error = %v, want regular-file message", err)
 	}
 }
+
+func TestOpenVerifiedResolveRootErrorNamesCheckout(t *testing.T) {
+	rootDir := t.TempDir()
+	errRepo := filepath.Join(rootDir, "other")
+	worktree := filepath.Join(rootDir, "repo", "kb")
+
+	_, err := OpenVerified(t.Context(), VerifySpec{
+		Name:         "kb",
+		WorktreePath: worktree,
+		RepoPath:     errRepo,
+	})
+	if err == nil {
+		t.Fatal("OpenVerified() error = nil, want root relationship error")
+	}
+	if !strings.Contains(err.Error(), "kb: resolve root") {
+		t.Fatalf("error = %v, want checkout name context", err)
+	}
+}

--- a/scripts/architecture.baseline
+++ b/scripts/architecture.baseline
@@ -1,4 +1,4 @@
-packages=62
+packages=63
 interfaces=83
 large_files=49
 set_mutators=111


### PR DESCRIPTION
## Summary

This is the first foundation slice for #1155. The larger goal is to make local Git working trees a shared platform primitive instead of something each subsystem assembles on its own. For this step, document roots stay the anchor: signed roots still bootstrap their repositories, reconcile allowed signers, verify HEAD when configured, expose revision history, and keep the same root-to-repository path handling.

The reusable lifecycle pieces now live in `internal/platform/checkout`. That package owns the neutral checkout mechanics for signed and verify-only local working trees: resolving the repository/worktree relationship, mapping root-relative filenames into repo-relative paths, opening signed provenance stores, reconciling trust, and opening verification-only readers. The document-root layer now adapts those checkout handles back into document writers, verifiers, and revisers instead of constructing the Git machinery itself.

This PR does not try to finish the whole checkout abstraction in one move. It intentionally leaves forge subscriptions, mirror checkouts, and reusable sync/status as follow-on slices. The point here is to give those next pieces a real shared home, so #1032 can consume the same checkout path instead of growing a forge-specific clone/fetch implementation.

Refs #1155

## Validation

`just test` passed before the PR was opened. Full `just ci` passed locally after updating the architecture baseline for the intentional new package. GitHub CI is green for `lint`, `test`, and `checks`.