### PR TITLE
refactor: route doc-root sync through checkout

### DIFF
--- a/internal/app/document_root_sync_attention_test.go
+++ b/internal/app/document_root_sync_attention_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/nugget/thane-ai-agent/internal/channels/messages"
-	"github.com/nugget/thane-ai-agent/internal/platform/provenance"
+	"github.com/nugget/thane-ai-agent/internal/platform/checkout"
 	looppkg "github.com/nugget/thane-ai-agent/internal/runtime/loop"
 )
 
@@ -39,7 +39,7 @@ func TestDocRootSyncAttentionNotifierSendsCoreWake(t *testing.T) {
 		Current: syncState{
 			Root:       "kb",
 			OK:         true,
-			Outcome:    provenance.SyncBlocked,
+			Outcome:    checkout.SyncBlocked,
 			Ahead:      0,
 			Behind:     2,
 			LocalHead:  "local",
@@ -80,7 +80,7 @@ func TestDocRootSyncAttentionNotifierSendsCoreWake(t *testing.T) {
 	if event.Source != "document_root_sync" || event.Type != string(syncTransitionAttentionRequired) {
 		t.Fatalf("event = %#v, want document_root_sync attention event", event)
 	}
-	if event.Metadata["root"] != "kb" || event.Metadata["outcome"] != string(provenance.SyncBlocked) || event.Metadata["detail"] != "first untrusted commit abc123" {
+	if event.Metadata["root"] != "kb" || event.Metadata["outcome"] != string(checkout.SyncBlocked) || event.Metadata["detail"] != "first untrusted commit abc123" {
 		t.Fatalf("event metadata = %#v", event.Metadata)
 	}
 	changedDetail := transition
@@ -96,13 +96,13 @@ func TestDocRootSyncRecoveryWakeIsNotSupervisorForced(t *testing.T) {
 		Previous: syncState{
 			Root:    "kb",
 			OK:      true,
-			Outcome: provenance.SyncBlocked,
+			Outcome: checkout.SyncBlocked,
 			Detail:  "first untrusted commit abc123",
 		},
 		Current: syncState{
 			Root:    "kb",
 			OK:      true,
-			Outcome: provenance.SyncFastForwarded,
+			Outcome: checkout.SyncFastForwarded,
 		},
 		HasPrevious: true,
 	})

--- a/internal/app/document_root_syncer.go
+++ b/internal/app/document_root_syncer.go
@@ -9,8 +9,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/nugget/thane-ai-agent/internal/platform/checkout"
 	"github.com/nugget/thane-ai-agent/internal/platform/config"
-	"github.com/nugget/thane-ai-agent/internal/platform/provenance"
 )
 
 // defaultSyncBranch and defaultSyncInterval are applied where a root's
@@ -33,12 +33,12 @@ func parseSyncInterval(raw string) (time.Duration, error) {
 	return time.ParseDuration(raw)
 }
 
-// buildSyncRequest maps a root's git config onto a [provenance.SyncRequest].
+// buildSyncRequest maps a root's git config onto a [checkout.SyncRequest].
 // resolve expands a configured path (~, environment variables) — the caller
 // supplies the paths.Resolver-backed closure; tests pass an identity function.
 // The out-of-tree trust anchor, if any, is a store-construction concern and is
 // not carried here.
-func buildSyncRequest(gitCfg config.DocumentRootGitConfig, resolve func(string) string) provenance.SyncRequest {
+func buildSyncRequest(gitCfg config.DocumentRootGitConfig, resolve func(string) string) checkout.SyncRequest {
 	// Trim every field before use: validateGitRemote validates these trimmed,
 	// so a quoted trailing space in YAML ("required ", "bidirectional ", a
 	// padded url/branch/key path) is accepted by config Load. An untrimmed
@@ -46,9 +46,9 @@ func buildSyncRequest(gitCfg config.DocumentRootGitConfig, resolve func(string) 
 	// fetch-only, or producing a broken remote/branch/GIT_SSH_COMMAND.
 	verify := strings.TrimSpace(gitCfg.VerifySignatures)
 	remote := gitCfg.Remote
-	req := provenance.SyncRequest{
+	req := checkout.SyncRequest{
 		Branch:        defaultSyncBranch,
-		Mode:          provenance.SyncModeFetch,
+		Mode:          checkout.SyncModeFetch,
 		RequireVerify: verify == "warn" || verify == "required",
 	}
 	if remote == nil {
@@ -59,7 +59,7 @@ func buildSyncRequest(gitCfg config.DocumentRootGitConfig, resolve func(string) 
 		req.Branch = b
 	}
 	if strings.TrimSpace(remote.Mode) == "bidirectional" {
-		req.Mode = provenance.SyncModeBidirectional
+		req.Mode = checkout.SyncModeBidirectional
 	}
 	// GIT_SSH_COMMAND is only meaningful for an SSH remote; presence of ssh
 	// transport credentials is the signal (known_hosts is required for an SSH
@@ -68,7 +68,7 @@ func buildSyncRequest(gitCfg config.DocumentRootGitConfig, resolve func(string) 
 	sshKey := strings.TrimSpace(remote.Auth.SSHKey)
 	knownHosts := strings.TrimSpace(remote.Auth.KnownHosts)
 	if sshKey != "" || knownHosts != "" {
-		req.SSHCommand = provenance.BuildSSHCommand(resolve(sshKey), resolve(knownHosts))
+		req.SSHCommand = checkout.BuildSSHCommand(resolve(sshKey), resolve(knownHosts))
 	}
 	return req
 }
@@ -111,7 +111,7 @@ func buildDocRootSyncer(root string, gitCfg config.DocumentRootGitConfig, engine
 type syncState struct {
 	Root       string
 	OK         bool // false when the last pass errored operationally
-	Outcome    provenance.SyncOutcome
+	Outcome    checkout.SyncOutcome
 	Ahead      int
 	Behind     int
 	LocalHead  string
@@ -189,10 +189,10 @@ func (r *syncStateRegistry) all() []syncState {
 }
 
 // syncEngine is the sync surface a docRootSyncer drives — satisfied by
-// *provenance.Store. The interface keeps runOnce unit-testable with a fake,
+// *checkout.Signed. The interface keeps runOnce unit-testable with a fake,
 // without a live git repository.
 type syncEngine interface {
-	Sync(ctx context.Context, req provenance.SyncRequest) (provenance.SyncResult, error)
+	Sync(ctx context.Context, req checkout.SyncRequest) (checkout.SyncResult, error)
 }
 
 type syncTransitionKind string
@@ -218,8 +218,8 @@ type syncTransitionNotifier func(context.Context, syncStateTransition) error
 type docRootSyncer struct {
 	root             string
 	engine           syncEngine
-	request          provenance.SyncRequest // LastKnownRemote is filled per pass
-	interval         time.Duration          // 0 disables the ticker (sync-on-demand only)
+	request          checkout.SyncRequest // LastKnownRemote is filled per pass
+	interval         time.Duration        // 0 disables the ticker (sync-on-demand only)
 	refresh          func(context.Context) error
 	notifyTransition syncTransitionNotifier
 	registry         *syncStateRegistry
@@ -279,9 +279,9 @@ func classifySyncStateTransition(prev syncState, hadPrev bool, current syncState
 	return syncStateTransition{}, false
 }
 
-func syncOutcomeNeedsAttention(outcome provenance.SyncOutcome) bool {
+func syncOutcomeNeedsAttention(outcome checkout.SyncOutcome) bool {
 	switch outcome {
-	case provenance.SyncBlocked, provenance.SyncDiverged, provenance.SyncRemoteBehind:
+	case checkout.SyncBlocked, checkout.SyncDiverged, checkout.SyncRemoteBehind:
 		return true
 	default:
 		return false
@@ -312,7 +312,7 @@ func (s *docRootSyncer) runOnce(ctx context.Context) syncState {
 	st.Detail = res.Detail
 
 	switch res.Outcome {
-	case provenance.SyncBlocked, provenance.SyncDiverged, provenance.SyncRemoteBehind:
+	case checkout.SyncBlocked, checkout.SyncDiverged, checkout.SyncRemoteBehind:
 		s.logger.Warn("document root sync needs attention",
 			"root", s.root, "outcome", res.Outcome, "detail", res.Detail)
 	default:
@@ -322,7 +322,7 @@ func (s *docRootSyncer) runOnce(ctx context.Context) syncState {
 
 	// A fast-forward moved the worktree; re-index so reads see the new content
 	// without waiting for the periodic refresher.
-	if res.Outcome == provenance.SyncFastForwarded && s.refresh != nil {
+	if res.Outcome == checkout.SyncFastForwarded && s.refresh != nil {
 		if rerr := s.refresh(ctx); rerr != nil && ctx.Err() == nil {
 			s.logger.Warn("re-index after sync fast-forward failed", "root", s.root, "error", rerr)
 		}
@@ -335,7 +335,7 @@ func (s *docRootSyncer) runOnce(ctx context.Context) syncState {
 	// the baseline to a head thane never accepted, or a later real rewind of
 	// the true line would escape detection and be pushed over.
 	switch res.Outcome {
-	case provenance.SyncClean, provenance.SyncFastForwarded, provenance.SyncPushed:
+	case checkout.SyncClean, checkout.SyncFastForwarded, checkout.SyncPushed:
 		s.registry.advanceRemote(s.root, res.RemoteHead)
 	}
 	return st

--- a/internal/app/document_root_syncer_test.go
+++ b/internal/app/document_root_syncer_test.go
@@ -8,8 +8,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/nugget/thane-ai-agent/internal/platform/checkout"
 	"github.com/nugget/thane-ai-agent/internal/platform/config"
-	"github.com/nugget/thane-ai-agent/internal/platform/provenance"
 )
 
 func testLogger() *slog.Logger {
@@ -65,7 +65,7 @@ func TestBuildSyncRequest(t *testing.T) {
 		if req.Branch != "main" {
 			t.Errorf("Branch = %q, want default main", req.Branch)
 		}
-		if req.Mode != provenance.SyncModeBidirectional {
+		if req.Mode != checkout.SyncModeBidirectional {
 			t.Errorf("Mode = %v, want bidirectional", req.Mode)
 		}
 		if !req.RequireVerify {
@@ -88,7 +88,7 @@ func TestBuildSyncRequest(t *testing.T) {
 		if req.Branch != "trunk" {
 			t.Errorf("Branch = %q, want trunk", req.Branch)
 		}
-		if req.Mode != provenance.SyncModeFetch {
+		if req.Mode != checkout.SyncModeFetch {
 			t.Errorf("Mode = %v, want fetch", req.Mode)
 		}
 		if !req.RequireVerify {
@@ -119,7 +119,7 @@ func TestBuildSyncRequest(t *testing.T) {
 		if !req.RequireVerify {
 			t.Error("RequireVerify = false for 'required ' (trailing space); must fail closed to true")
 		}
-		if req.Mode != provenance.SyncModeBidirectional {
+		if req.Mode != checkout.SyncModeBidirectional {
 			t.Error("Mode != bidirectional for 'bidirectional ' (trailing space)")
 		}
 	})
@@ -188,7 +188,7 @@ func TestBuildDocRootSyncer(t *testing.T) {
 		if s.root != "kb" || s.interval != 30*time.Second {
 			t.Errorf("root=%q interval=%v, want kb/30s", s.root, s.interval)
 		}
-		if s.request.Mode != provenance.SyncModeBidirectional || !s.request.RequireVerify {
+		if s.request.Mode != checkout.SyncModeBidirectional || !s.request.RequireVerify {
 			t.Errorf("request = %+v, want bidirectional + RequireVerify", s.request)
 		}
 		if s.registry != reg {
@@ -207,9 +207,9 @@ func TestSyncStateRegistry(t *testing.T) {
 		t.Error("get on empty registry returned ok")
 	}
 
-	r.setState(syncState{Root: "kb", OK: true, Outcome: provenance.SyncClean})
-	r.setState(syncState{Root: "apex", OK: true, Outcome: provenance.SyncFastForwarded})
-	if st, ok := r.get("kb"); !ok || st.Outcome != provenance.SyncClean {
+	r.setState(syncState{Root: "kb", OK: true, Outcome: checkout.SyncClean})
+	r.setState(syncState{Root: "apex", OK: true, Outcome: checkout.SyncFastForwarded})
+	if st, ok := r.get("kb"); !ok || st.Outcome != checkout.SyncClean {
 		t.Errorf("get(kb) = %+v, ok=%v", st, ok)
 	}
 
@@ -235,7 +235,7 @@ func TestSyncStateRegistryConcurrent(t *testing.T) {
 	done := make(chan struct{})
 	go func() {
 		for i := 0; i < 1000; i++ {
-			r.setState(syncState{Root: "kb", Outcome: provenance.SyncClean})
+			r.setState(syncState{Root: "kb", Outcome: checkout.SyncClean})
 			r.advanceRemote("kb", "sha")
 		}
 		close(done)
@@ -251,15 +251,15 @@ func TestSyncStateRegistryConcurrent(t *testing.T) {
 // fakeEngine returns scripted results for successive Sync calls and records the
 // requests it received.
 type fakeEngine struct {
-	results []provenance.SyncResult
+	results []checkout.SyncResult
 	errs    []error
-	calls   []provenance.SyncRequest
+	calls   []checkout.SyncRequest
 }
 
-func (f *fakeEngine) Sync(_ context.Context, req provenance.SyncRequest) (provenance.SyncResult, error) {
+func (f *fakeEngine) Sync(_ context.Context, req checkout.SyncRequest) (checkout.SyncResult, error) {
 	i := len(f.calls)
 	f.calls = append(f.calls, req)
-	var res provenance.SyncResult
+	var res checkout.SyncResult
 	var err error
 	if i < len(f.results) {
 		res = f.results[i]
@@ -274,7 +274,7 @@ func newTestSyncer(engine syncEngine, reg *syncStateRegistry, refresh func(conte
 	return &docRootSyncer{
 		root:     "kb",
 		engine:   engine,
-		request:  provenance.SyncRequest{Branch: "main", Mode: provenance.SyncModeBidirectional, RequireVerify: true},
+		request:  checkout.SyncRequest{Branch: "main", Mode: checkout.SyncModeBidirectional, RequireVerify: true},
 		refresh:  refresh,
 		registry: reg,
 		logger:   testLogger(),
@@ -284,14 +284,14 @@ func newTestSyncer(engine syncEngine, reg *syncStateRegistry, refresh func(conte
 func TestRunOnceFastForwardReindexesAndAdvances(t *testing.T) {
 	reg := newSyncStateRegistry()
 	refreshes := 0
-	eng := &fakeEngine{results: []provenance.SyncResult{
-		{Outcome: provenance.SyncFastForwarded, Behind: 2, LocalHead: "l", RemoteHead: "rA"},
-		{Outcome: provenance.SyncClean, LocalHead: "rA", RemoteHead: "rA"},
+	eng := &fakeEngine{results: []checkout.SyncResult{
+		{Outcome: checkout.SyncFastForwarded, Behind: 2, LocalHead: "l", RemoteHead: "rA"},
+		{Outcome: checkout.SyncClean, LocalHead: "rA", RemoteHead: "rA"},
 	}}
 	s := newTestSyncer(eng, reg, func(context.Context) error { refreshes++; return nil })
 
 	st := s.runOnce(context.Background())
-	if !st.OK || st.Outcome != provenance.SyncFastForwarded {
+	if !st.OK || st.Outcome != checkout.SyncFastForwarded {
 		t.Fatalf("state = %+v, want ok fast_forwarded", st)
 	}
 	if refreshes != 1 {
@@ -318,13 +318,13 @@ func TestRunOnceRemoteBehindDoesNotAdvanceOrReindex(t *testing.T) {
 	reg := newSyncStateRegistry()
 	reg.advanceRemote("kb", "rA") // a prior legitimate remote head
 	refreshes := 0
-	eng := &fakeEngine{results: []provenance.SyncResult{
-		{Outcome: provenance.SyncRemoteBehind, LocalHead: "l", RemoteHead: "rOld", Detail: "rewound"},
+	eng := &fakeEngine{results: []checkout.SyncResult{
+		{Outcome: checkout.SyncRemoteBehind, LocalHead: "l", RemoteHead: "rOld", Detail: "rewound"},
 	}}
 	s := newTestSyncer(eng, reg, func(context.Context) error { refreshes++; return nil })
 
 	st := s.runOnce(context.Background())
-	if st.Outcome != provenance.SyncRemoteBehind {
+	if st.Outcome != checkout.SyncRemoteBehind {
 		t.Fatalf("outcome = %q, want remote_behind", st.Outcome)
 	}
 	if refreshes != 0 {
@@ -340,14 +340,14 @@ func TestRunOnceRemoteBehindDoesNotAdvanceOrReindex(t *testing.T) {
 // outcomes advance it; refused outcomes leave it untouched so a later rewind
 // stays detectable.
 func TestRunOnceAdvanceBaseline(t *testing.T) {
-	accepted := []provenance.SyncOutcome{provenance.SyncClean, provenance.SyncFastForwarded, provenance.SyncPushed}
-	refused := []provenance.SyncOutcome{provenance.SyncDiverged, provenance.SyncBlocked, provenance.SyncRemoteBehind}
+	accepted := []checkout.SyncOutcome{checkout.SyncClean, checkout.SyncFastForwarded, checkout.SyncPushed}
+	refused := []checkout.SyncOutcome{checkout.SyncDiverged, checkout.SyncBlocked, checkout.SyncRemoteBehind}
 
 	for _, oc := range accepted {
 		t.Run("advances_on_"+string(oc), func(t *testing.T) {
 			reg := newSyncStateRegistry()
 			reg.advanceRemote("kb", "prior")
-			eng := &fakeEngine{results: []provenance.SyncResult{{Outcome: oc, RemoteHead: "new"}}}
+			eng := &fakeEngine{results: []checkout.SyncResult{{Outcome: oc, RemoteHead: "new"}}}
 			newTestSyncer(eng, reg, nil).runOnce(context.Background())
 			if got := reg.lastKnownRemote("kb"); got != "new" {
 				t.Errorf("lastKnownRemote = %q, want advanced to new for accepted outcome %q", got, oc)
@@ -358,7 +358,7 @@ func TestRunOnceAdvanceBaseline(t *testing.T) {
 		t.Run("holds_on_"+string(oc), func(t *testing.T) {
 			reg := newSyncStateRegistry()
 			reg.advanceRemote("kb", "prior")
-			eng := &fakeEngine{results: []provenance.SyncResult{{Outcome: oc, RemoteHead: "new"}}}
+			eng := &fakeEngine{results: []checkout.SyncResult{{Outcome: oc, RemoteHead: "new"}}}
 			newTestSyncer(eng, reg, nil).runOnce(context.Background())
 			if got := reg.lastKnownRemote("kb"); got != "prior" {
 				t.Errorf("lastKnownRemote = %q, want held at prior for refused outcome %q", got, oc)
@@ -369,13 +369,13 @@ func TestRunOnceAdvanceBaseline(t *testing.T) {
 
 func TestRunOnceNotifiesOnAttentionTransitions(t *testing.T) {
 	reg := newSyncStateRegistry()
-	eng := &fakeEngine{results: []provenance.SyncResult{
-		{Outcome: provenance.SyncBlocked, RemoteHead: "r1", Detail: "first untrusted commit abc123"},
-		{Outcome: provenance.SyncBlocked, RemoteHead: "r1", Detail: "first untrusted commit abc123"},
-		{Outcome: provenance.SyncBlocked, RemoteHead: "r2", Detail: "first untrusted commit def456"},
-		{Outcome: provenance.SyncDiverged, RemoteHead: "r3", Detail: "local and remote diverged"},
-		{Outcome: provenance.SyncFastForwarded, RemoteHead: "r3"},
-		{Outcome: provenance.SyncClean, RemoteHead: "r3"},
+	eng := &fakeEngine{results: []checkout.SyncResult{
+		{Outcome: checkout.SyncBlocked, RemoteHead: "r1", Detail: "first untrusted commit abc123"},
+		{Outcome: checkout.SyncBlocked, RemoteHead: "r1", Detail: "first untrusted commit abc123"},
+		{Outcome: checkout.SyncBlocked, RemoteHead: "r2", Detail: "first untrusted commit def456"},
+		{Outcome: checkout.SyncDiverged, RemoteHead: "r3", Detail: "local and remote diverged"},
+		{Outcome: checkout.SyncFastForwarded, RemoteHead: "r3"},
+		{Outcome: checkout.SyncClean, RemoteHead: "r3"},
 	}}
 	s := newTestSyncer(eng, reg, nil)
 	var transitions []syncStateTransition
@@ -394,13 +394,13 @@ func TestRunOnceNotifiesOnAttentionTransitions(t *testing.T) {
 	tests := []struct {
 		i       int
 		kind    syncTransitionKind
-		outcome provenance.SyncOutcome
+		outcome checkout.SyncOutcome
 		detail  string
 	}{
-		{0, syncTransitionAttentionRequired, provenance.SyncBlocked, "first untrusted commit abc123"},
-		{1, syncTransitionAttentionRequired, provenance.SyncBlocked, "first untrusted commit def456"},
-		{2, syncTransitionAttentionRequired, provenance.SyncDiverged, "local and remote diverged"},
-		{3, syncTransitionRecovered, provenance.SyncFastForwarded, ""},
+		{0, syncTransitionAttentionRequired, checkout.SyncBlocked, "first untrusted commit abc123"},
+		{1, syncTransitionAttentionRequired, checkout.SyncBlocked, "first untrusted commit def456"},
+		{2, syncTransitionAttentionRequired, checkout.SyncDiverged, "local and remote diverged"},
+		{3, syncTransitionRecovered, checkout.SyncFastForwarded, ""},
 	}
 	for _, tt := range tests {
 		tr := transitions[tt.i]
@@ -409,7 +409,7 @@ func TestRunOnceNotifiesOnAttentionTransitions(t *testing.T) {
 				tt.i, tr.Kind, tr.Current.Outcome, tr.Current.Detail, tt.kind, tt.outcome, tt.detail)
 		}
 	}
-	if transitions[3].Previous.Outcome != provenance.SyncDiverged {
+	if transitions[3].Previous.Outcome != checkout.SyncDiverged {
 		t.Fatalf("recovery previous outcome = %q, want diverged", transitions[3].Previous.Outcome)
 	}
 }
@@ -428,7 +428,7 @@ func TestRunReturnsOnCancel(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			reg := newSyncStateRegistry()
-			eng := &fakeEngine{results: []provenance.SyncResult{{Outcome: provenance.SyncClean, RemoteHead: "r"}}}
+			eng := &fakeEngine{results: []checkout.SyncResult{{Outcome: checkout.SyncClean, RemoteHead: "r"}}}
 			s := newTestSyncer(eng, reg, nil)
 			s.interval = tc.interval
 			ctx, cancel := context.WithCancel(context.Background())

--- a/internal/app/document_roots.go
+++ b/internal/app/document_roots.go
@@ -17,8 +17,7 @@ import (
 )
 
 type documentRootProvenanceWriter struct {
-	store  *provenance.Store
-	prefix string
+	checkout *checkout.Signed
 }
 
 type documentRootProvenanceVerifier struct {
@@ -27,15 +26,15 @@ type documentRootProvenanceVerifier struct {
 }
 
 func (w *documentRootProvenanceWriter) Write(ctx context.Context, filename, content, message string) error {
-	return w.store.Write(ctx, w.storeFilename(filename), content, message)
+	return w.checkout.Store.Write(ctx, w.storeFilename(filename), content, message)
 }
 
 func (w *documentRootProvenanceWriter) Delete(ctx context.Context, filename, message string) error {
-	return w.store.Delete(ctx, w.storeFilename(filename), message)
+	return w.checkout.Store.Delete(ctx, w.storeFilename(filename), message)
 }
 
 func (w *documentRootProvenanceWriter) storeFilename(filename string) string {
-	return checkout.RepoFilename(w.prefix, filename)
+	return w.checkout.RepoFilename(filename)
 }
 
 func (v *documentRootProvenanceVerifier) Verify(ctx context.Context, filename string) (documents.SignatureVerification, error) {
@@ -186,7 +185,7 @@ func (a *App) buildDocumentStoreOptions(documentRoots map[string]string, resolve
 		var reviser *documentRootProvenanceReviser
 		switch {
 		case writer != nil:
-			reviser = &documentRootProvenanceReviser{reader: writer.store, prefix: writer.prefix}
+			reviser = &documentRootProvenanceReviser{reader: writer.checkout.Reader(), prefix: writer.checkout.Prefix}
 		case verifier != nil:
 			reviser = &documentRootProvenanceReviser{reader: verifier.verifier, prefix: verifier.prefix}
 		}
@@ -209,7 +208,7 @@ func (a *App) buildDocumentStoreOptions(documentRoots map[string]string, resolve
 				a.syncRegistry = newSyncStateRegistry()
 			}
 			resolve := func(p string) string { return resolvePath(p, resolver) }
-			syncer, err := buildDocRootSyncer(root, rootCfg.Git, writer.store, a.syncRegistry, resolve, logger)
+			syncer, err := buildDocRootSyncer(root, rootCfg.Git, writer.checkout, a.syncRegistry, resolve, logger)
 			if err != nil {
 				return documents.StoreOptions{}, fmt.Errorf("doc_roots.%s.git.remote: %w", root, err)
 			}
@@ -327,7 +326,7 @@ func (a *App) newDocumentRootProvenanceWriter(root, rootPath string, gitCfg conf
 		"repo", signed.Store.Path(),
 		"prefix", signed.Prefix,
 	)
-	return &documentRootProvenanceWriter{store: signed.Store, prefix: signed.Prefix}, nil
+	return &documentRootProvenanceWriter{checkout: signed}, nil
 }
 
 func (a *App) newDocumentRootProvenanceVerifier(root, rootPath string, gitCfg config.DocumentRootGitConfig, resolver *paths.Resolver) (*documentRootProvenanceVerifier, error) {

--- a/internal/app/document_roots.go
+++ b/internal/app/document_roots.go
@@ -26,15 +26,30 @@ type documentRootProvenanceVerifier struct {
 }
 
 func (w *documentRootProvenanceWriter) Write(ctx context.Context, filename, content, message string) error {
-	return w.checkout.Store.Write(ctx, w.storeFilename(filename), content, message)
+	store, err := w.store()
+	if err != nil {
+		return err
+	}
+	return store.Write(ctx, w.storeFilename(filename), content, message)
 }
 
 func (w *documentRootProvenanceWriter) Delete(ctx context.Context, filename, message string) error {
-	return w.checkout.Store.Delete(ctx, w.storeFilename(filename), message)
+	store, err := w.store()
+	if err != nil {
+		return err
+	}
+	return store.Delete(ctx, w.storeFilename(filename), message)
 }
 
 func (w *documentRootProvenanceWriter) storeFilename(filename string) string {
 	return w.checkout.RepoFilename(filename)
+}
+
+func (w *documentRootProvenanceWriter) store() (*provenance.Store, error) {
+	if w == nil || w.checkout == nil || w.checkout.Store == nil {
+		return nil, fmt.Errorf("document root signed checkout is not configured")
+	}
+	return w.checkout.Store, nil
 }
 
 func (v *documentRootProvenanceVerifier) Verify(ctx context.Context, filename string) (documents.SignatureVerification, error) {

--- a/internal/app/document_roots_test.go
+++ b/internal/app/document_roots_test.go
@@ -396,6 +396,58 @@ func TestDocumentRootProvenanceWriterDoesNotCleanEscapesIntoPrefix(t *testing.T)
 	}
 }
 
+func TestDocumentRootProvenanceWriterMisconfiguredCheckoutReturnsError(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		writer *documentRootProvenanceWriter
+		call   func(*testing.T, *documentRootProvenanceWriter) error
+	}{
+		{
+			name:   "nil writer write",
+			writer: nil,
+			call: func(t *testing.T, w *documentRootProvenanceWriter) error {
+				return w.Write(t.Context(), "doc.md", "content", "message")
+			},
+		},
+		{
+			name:   "missing checkout write",
+			writer: &documentRootProvenanceWriter{},
+			call: func(t *testing.T, w *documentRootProvenanceWriter) error {
+				return w.Write(t.Context(), "doc.md", "content", "message")
+			},
+		},
+		{
+			name:   "missing store write",
+			writer: &documentRootProvenanceWriter{checkout: &checkout.Signed{}},
+			call: func(t *testing.T, w *documentRootProvenanceWriter) error {
+				return w.Write(t.Context(), "doc.md", "content", "message")
+			},
+		},
+		{
+			name:   "missing store delete",
+			writer: &documentRootProvenanceWriter{checkout: &checkout.Signed{}},
+			call: func(t *testing.T, w *documentRootProvenanceWriter) error {
+				return w.Delete(t.Context(), "doc.md", "message")
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := tt.call(t, tt.writer)
+			if err == nil {
+				t.Fatal("writer operation returned nil, want configuration error")
+			}
+			if !strings.Contains(err.Error(), "signed checkout is not configured") {
+				t.Fatalf("error = %q, want signed-checkout configuration error", err)
+			}
+		})
+	}
+}
+
 // TestDocumentRootProvenanceReviser exercises the app adapter that bridges a
 // provenance.Reader to documents.RootReviser against a real signed repo.
 func TestDocumentRootProvenanceReviser(t *testing.T) {

--- a/internal/app/document_roots_test.go
+++ b/internal/app/document_roots_test.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/nugget/thane-ai-agent/internal/platform/checkout"
 	"github.com/nugget/thane-ai-agent/internal/platform/config"
 	"github.com/nugget/thane-ai-agent/internal/platform/identity"
 	"github.com/nugget/thane-ai-agent/internal/platform/paths"
@@ -384,7 +385,9 @@ func TestApplyBootVerification(t *testing.T) {
 func TestDocumentRootProvenanceWriterDoesNotCleanEscapesIntoPrefix(t *testing.T) {
 	t.Parallel()
 
-	writer := &documentRootProvenanceWriter{prefix: "knowledge/kb"}
+	writer := &documentRootProvenanceWriter{checkout: &checkout.Signed{
+		Root: checkout.Root{Prefix: "knowledge/kb"},
+	}}
 	if got := writer.storeFilename("notes/doc.md"); got != "knowledge/kb/notes/doc.md" {
 		t.Fatalf("storeFilename(valid) = %q, want prefixed path", got)
 	}

--- a/internal/platform/checkout/sync.go
+++ b/internal/platform/checkout/sync.go
@@ -23,7 +23,8 @@ const (
 type SyncOutcome = provenance.SyncOutcome
 
 const (
-	// SyncClean means local and remote already agree.
+	// SyncClean means local and remote already agree, or a fetch-only sync saw
+	// local commits that do not need pushing.
 	SyncClean = provenance.SyncClean
 	// SyncFastForwarded means the local branch was advanced to the remote.
 	SyncFastForwarded = provenance.SyncFastForwarded

--- a/internal/platform/checkout/sync.go
+++ b/internal/platform/checkout/sync.go
@@ -1,0 +1,58 @@
+package checkout
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/nugget/thane-ai-agent/internal/platform/provenance"
+)
+
+// SyncMode selects whether a checkout sync pushes local commits back to the
+// remote. The zero value is fetch-only.
+type SyncMode = provenance.SyncMode
+
+const (
+	// SyncModeFetch pulls fast-forwards from the remote but never pushes.
+	SyncModeFetch = provenance.SyncModeFetch
+	// SyncModeBidirectional additionally pushes local commits that are a
+	// fast-forward of the remote.
+	SyncModeBidirectional = provenance.SyncModeBidirectional
+)
+
+// SyncOutcome classifies the result of one checkout sync pass.
+type SyncOutcome = provenance.SyncOutcome
+
+const (
+	// SyncClean means local and remote already agree.
+	SyncClean = provenance.SyncClean
+	// SyncFastForwarded means the local branch was advanced to the remote.
+	SyncFastForwarded = provenance.SyncFastForwarded
+	// SyncPushed means local commits were pushed to the remote.
+	SyncPushed = provenance.SyncPushed
+	// SyncDiverged means both sides have unique commits.
+	SyncDiverged = provenance.SyncDiverged
+	// SyncBlocked means the engine refused to integrate.
+	SyncBlocked = provenance.SyncBlocked
+	// SyncRemoteBehind means the remote rewound behind the caller's last
+	// accepted remote head.
+	SyncRemoteBehind = provenance.SyncRemoteBehind
+)
+
+// SyncRequest parameterizes one fast-forward-only checkout sync pass.
+type SyncRequest = provenance.SyncRequest
+
+// SyncResult reports what one checkout sync pass observed and did.
+type SyncResult = provenance.SyncResult
+
+// BuildSSHCommand assembles the hardened GIT_SSH_COMMAND used for SSH remotes.
+func BuildSSHCommand(sshKey, knownHosts string) string {
+	return provenance.BuildSSHCommand(sshKey, knownHosts)
+}
+
+// Sync runs one fast-forward-only sync pass for the signed checkout.
+func (c *Signed) Sync(ctx context.Context, req SyncRequest) (SyncResult, error) {
+	if c == nil || c.Store == nil {
+		return SyncResult{}, fmt.Errorf("signed checkout is not configured")
+	}
+	return c.Store.Sync(ctx, req)
+}


### PR DESCRIPTION
## Summary

This is the next small step toward the shared checkout primitive from #1155. The first slice moved document-root open/bootstrap mechanics into `internal/platform/checkout`; this one moves the remote-sync vocabulary there too, so callers can talk about checkout sync without depending directly on the provenance store.

The implementation is deliberately conservative. `checkout` now exposes the sync request, result, mode, outcome, SSH-command helper, and a `Signed.Sync` method. Underneath, the proven provenance sync engine still does the real git and signature work. The value here is the boundary: document roots now drive sync through the signed checkout object, while the app package keeps the doc-root-specific pieces it should own, like transition classification, indexing refresh, and core-loop wake notifications.

That leaves us with a better seam for the next consumers. Forge local checkouts and the old provenance root can reuse the checkout-level sync surface instead of growing their own fetch/pull/push vocabulary.

Refs #1155

## Validation

- `just test`
- `just ci`