### PR TITLE
refactor: share checkout sync state registry

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -30,6 +30,7 @@ import (
 	"github.com/nugget/thane-ai-agent/internal/model/llm"
 	"github.com/nugget/thane-ai-agent/internal/model/router"
 	"github.com/nugget/thane-ai-agent/internal/model/toolcatalog"
+	"github.com/nugget/thane-ai-agent/internal/platform/checkout"
 	"github.com/nugget/thane-ai-agent/internal/platform/checkpoint"
 	"github.com/nugget/thane-ai-agent/internal/platform/config"
 	"github.com/nugget/thane-ai-agent/internal/platform/events"
@@ -95,7 +96,7 @@ type App struct {
 	documentStore             *documents.Store
 	documentTools             *documents.Tools
 	docRootSyncers            []*docRootSyncer
-	syncRegistry              *syncStateRegistry
+	syncRegistry              *checkout.SyncStateRegistry
 	contactStore              *contacts.Store
 	watchlistStore            *awareness.WatchlistStore
 	loopQueue                 *loopqueue.Store

--- a/internal/app/document_root_sync_attention.go
+++ b/internal/app/document_root_sync_attention.go
@@ -70,13 +70,13 @@ func docRootSyncTransitionConcern(transition syncStateTransition) string {
 	switch transition.Kind {
 	case syncTransitionAttentionRequired:
 		if detail := strings.TrimSpace(st.Detail); detail != "" {
-			return fmt.Sprintf("Document root sync requires core review: root %q entered %s: %s", st.Root, st.Outcome, detail)
+			return fmt.Sprintf("Document root sync requires core review: root %q entered %s: %s", st.Name, st.Outcome, detail)
 		}
-		return fmt.Sprintf("Document root sync requires core review: root %q entered %s.", st.Root, st.Outcome)
+		return fmt.Sprintf("Document root sync requires core review: root %q entered %s.", st.Name, st.Outcome)
 	case syncTransitionRecovered:
-		return fmt.Sprintf("Document root sync recovered: root %q is %s after %s.", st.Root, st.Outcome, transition.Previous.Outcome)
+		return fmt.Sprintf("Document root sync recovered: root %q is %s after %s.", st.Name, st.Outcome, transition.Previous.Outcome)
 	default:
-		return fmt.Sprintf("Document root sync changed state for root %q.", st.Root)
+		return fmt.Sprintf("Document root sync changed state for root %q.", st.Name)
 	}
 }
 
@@ -94,14 +94,14 @@ func docRootSyncTransitionAction(transition syncStateTransition) string {
 func docRootSyncTransitionID(transition syncStateTransition) string {
 	st := transition.Current
 	h := sha256.Sum256([]byte(strings.Join([]string{
-		st.Root,
+		st.Name,
 		string(transition.Kind),
 		string(st.Outcome),
 		strings.TrimSpace(st.Detail),
 		string(transition.Previous.Outcome),
 		strings.TrimSpace(transition.Previous.Detail),
 	}, "\x00")))
-	return fmt.Sprintf("%s:%s:%s:%x", st.Root, transition.Kind, st.Outcome, h[:8])
+	return fmt.Sprintf("%s:%s:%s:%x", st.Name, transition.Kind, st.Outcome, h[:8])
 }
 
 func docRootSyncTransitionTitle(transition syncStateTransition) string {
@@ -118,15 +118,15 @@ func docRootSyncTransitionTitle(transition syncStateTransition) string {
 func docRootSyncTransitionSummary(transition syncStateTransition) string {
 	st := transition.Current
 	if st.Detail == "" {
-		return fmt.Sprintf("root=%s outcome=%s", st.Root, st.Outcome)
+		return fmt.Sprintf("root=%s outcome=%s", st.Name, st.Outcome)
 	}
-	return fmt.Sprintf("root=%s outcome=%s detail=%s", st.Root, st.Outcome, st.Detail)
+	return fmt.Sprintf("root=%s outcome=%s detail=%s", st.Name, st.Outcome, st.Detail)
 }
 
 func docRootSyncTransitionMetadata(transition syncStateTransition) map[string]string {
 	st := transition.Current
 	meta := map[string]string{
-		"root":        st.Root,
+		"root":        st.Name,
 		"outcome":     string(st.Outcome),
 		"ahead":       strconv.Itoa(st.Ahead),
 		"behind":      strconv.Itoa(st.Behind),

--- a/internal/app/document_root_sync_attention_test.go
+++ b/internal/app/document_root_sync_attention_test.go
@@ -37,7 +37,7 @@ func TestDocRootSyncAttentionNotifierSendsCoreWake(t *testing.T) {
 	transition := syncStateTransition{
 		Kind: syncTransitionAttentionRequired,
 		Current: syncState{
-			Root:       "kb",
+			Name:       "kb",
 			OK:         true,
 			Outcome:    checkout.SyncBlocked,
 			Ahead:      0,
@@ -94,13 +94,13 @@ func TestDocRootSyncRecoveryWakeIsNotSupervisorForced(t *testing.T) {
 	env := docRootSyncTransitionEnvelope(looppkg.CoreAttentionTarget{LoopID: "loop-1"}, syncStateTransition{
 		Kind: syncTransitionRecovered,
 		Previous: syncState{
-			Root:    "kb",
+			Name:    "kb",
 			OK:      true,
 			Outcome: checkout.SyncBlocked,
 			Detail:  "first untrusted commit abc123",
 		},
 		Current: syncState{
-			Root:    "kb",
+			Name:    "kb",
 			OK:      true,
 			Outcome: checkout.SyncFastForwarded,
 		},

--- a/internal/app/document_root_syncer.go
+++ b/internal/app/document_root_syncer.go
@@ -4,9 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"sort"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/nugget/thane-ai-agent/internal/platform/checkout"
@@ -74,14 +72,14 @@ func buildSyncRequest(gitCfg config.DocumentRootGitConfig, resolve func(string) 
 }
 
 // buildDocRootSyncer constructs a per-root syncer from a root's git config,
-// driving the given engine (the root's provenance store). It returns (nil, nil)
-// when the root has no remote block. resolve expands configured paths.
+// driving the given checkout sync engine. It returns (nil, nil) when the root
+// has no remote block. resolve expands configured paths.
 //
 // An out-of-tree trust_anchor is not yet wired: the default is the in-tree
 // .allowed_signers (which the sync engine verifies safely, since a fetch never
 // rewrites the worktree before verification), so a configured trust_anchor is
 // refused rather than silently ignored.
-func buildDocRootSyncer(root string, gitCfg config.DocumentRootGitConfig, engine syncEngine, registry *syncStateRegistry, resolve func(string) string, logger *slog.Logger) (*docRootSyncer, error) {
+func buildDocRootSyncer(root string, gitCfg config.DocumentRootGitConfig, engine syncEngine, registry *checkout.SyncStateRegistry, resolve func(string) string, logger *slog.Logger) (*docRootSyncer, error) {
 	remote := gitCfg.Remote
 	if remote == nil {
 		return nil, nil
@@ -106,87 +104,7 @@ func buildDocRootSyncer(root string, gitCfg config.DocumentRootGitConfig, engine
 	}, nil
 }
 
-// syncState is the in-memory, per-root observed state of remote sync. It is
-// re-derived every pass (never persisted) and read by the operability surface.
-type syncState struct {
-	Root       string
-	OK         bool // false when the last pass errored operationally
-	Outcome    checkout.SyncOutcome
-	Ahead      int
-	Behind     int
-	LocalHead  string
-	RemoteHead string
-	Detail     string // reason for a blocked/diverged/remote_behind outcome, or the error message
-	LastSyncAt time.Time
-}
-
-// syncStateRegistry holds per-root sync state and the remote head observed on
-// each root's previous pass (for the engine's rewind detection). It is safe
-// for concurrent access: the syncer loop writes, the operability surface reads.
-type syncStateRegistry struct {
-	mu         sync.Mutex
-	state      map[string]syncState
-	lastRemote map[string]string
-}
-
-func newSyncStateRegistry() *syncStateRegistry {
-	return &syncStateRegistry{
-		state:      make(map[string]syncState),
-		lastRemote: make(map[string]string),
-	}
-}
-
-// setState records the latest observed state for a root and returns the state
-// it replaced, if any.
-func (r *syncStateRegistry) setState(st syncState) (syncState, bool) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	prev, ok := r.state[st.Root]
-	r.state[st.Root] = st
-	return prev, ok
-}
-
-// advanceRemote records the remote head a root legitimately accepted, so the
-// next pass can detect a rewind past it. The caller advances it only for
-// accepted outcomes (clean / fast-forwarded / pushed); a refused outcome
-// (diverged, blocked, remote_behind) leaves it untouched, so the rewind keeps
-// being detected until the operator resolves it.
-func (r *syncStateRegistry) advanceRemote(root, sha string) {
-	if sha == "" {
-		return
-	}
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	r.lastRemote[root] = sha
-}
-
-// lastKnownRemote returns the remote head recorded for a root's previous pass,
-// or "" if none.
-func (r *syncStateRegistry) lastKnownRemote(root string) string {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	return r.lastRemote[root]
-}
-
-// get returns the recorded state for a root.
-func (r *syncStateRegistry) get(root string) (syncState, bool) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	st, ok := r.state[root]
-	return st, ok
-}
-
-// all returns every recorded state, sorted by root for a stable listing.
-func (r *syncStateRegistry) all() []syncState {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	out := make([]syncState, 0, len(r.state))
-	for _, st := range r.state {
-		out = append(out, st)
-	}
-	sort.Slice(out, func(i, j int) bool { return out[i].Root < out[j].Root })
-	return out
-}
+type syncState = checkout.SyncState
 
 // syncEngine is the sync surface a docRootSyncer drives — satisfied by
 // *checkout.Signed. The interface keeps runOnce unit-testable with a fake,
@@ -222,7 +140,7 @@ type docRootSyncer struct {
 	interval         time.Duration        // 0 disables the ticker (sync-on-demand only)
 	refresh          func(context.Context) error
 	notifyTransition syncTransitionNotifier
-	registry         *syncStateRegistry
+	registry         *checkout.SyncStateRegistry
 	logger           *slog.Logger
 	now              func() time.Time // injectable clock; nil uses time.Now
 }
@@ -235,7 +153,7 @@ func (s *docRootSyncer) clock() time.Time {
 }
 
 func (s *docRootSyncer) recordState(ctx context.Context, st syncState) {
-	prev, hadPrev := s.registry.setState(st)
+	prev, hadPrev := s.registry.RecordState(st)
 	if s.notifyTransition == nil {
 		return
 	}
@@ -245,7 +163,7 @@ func (s *docRootSyncer) recordState(ctx context.Context, st syncState) {
 	}
 	if err := s.notifyTransition(ctx, transition); err != nil && ctx.Err() == nil {
 		s.logger.Warn("document root sync attention wake failed",
-			"root", st.Root,
+			"root", st.Name,
 			"outcome", st.Outcome,
 			"transition", transition.Kind,
 			"detail", st.Detail,
@@ -293,10 +211,10 @@ func syncOutcomeNeedsAttention(outcome checkout.SyncOutcome) bool {
 // as state (OK=false) and retried on the next pass.
 func (s *docRootSyncer) runOnce(ctx context.Context) syncState {
 	req := s.request
-	req.LastKnownRemote = s.registry.lastKnownRemote(s.root)
+	req.LastKnownRemote = s.registry.LastKnownRemote(s.root)
 
 	res, err := s.engine.Sync(ctx, req)
-	st := syncState{Root: s.root, LastSyncAt: s.clock()}
+	st := syncState{Name: s.root, LastSyncAt: s.clock()}
 	if err != nil {
 		st.OK = false
 		st.Detail = err.Error()
@@ -336,7 +254,7 @@ func (s *docRootSyncer) runOnce(ctx context.Context) syncState {
 	// the true line would escape detection and be pushed over.
 	switch res.Outcome {
 	case checkout.SyncClean, checkout.SyncFastForwarded, checkout.SyncPushed:
-		s.registry.advanceRemote(s.root, res.RemoteHead)
+		s.registry.AdvanceRemote(s.root, res.RemoteHead)
 	}
 	return st
 }

--- a/internal/app/document_root_syncer_test.go
+++ b/internal/app/document_root_syncer_test.go
@@ -149,7 +149,7 @@ func TestBuildSyncRequest(t *testing.T) {
 }
 
 func TestBuildDocRootSyncer(t *testing.T) {
-	reg := newSyncStateRegistry()
+	reg := checkout.NewSyncStateRegistry()
 	identity := func(s string) string { return s }
 
 	t.Run("nil remote yields nil syncer", func(t *testing.T) {
@@ -197,57 +197,6 @@ func TestBuildDocRootSyncer(t *testing.T) {
 	})
 }
 
-func TestSyncStateRegistry(t *testing.T) {
-	r := newSyncStateRegistry()
-
-	if got := r.lastKnownRemote("kb"); got != "" {
-		t.Errorf("lastKnownRemote on empty = %q, want empty", got)
-	}
-	if _, ok := r.get("kb"); ok {
-		t.Error("get on empty registry returned ok")
-	}
-
-	r.setState(syncState{Root: "kb", OK: true, Outcome: checkout.SyncClean})
-	r.setState(syncState{Root: "apex", OK: true, Outcome: checkout.SyncFastForwarded})
-	if st, ok := r.get("kb"); !ok || st.Outcome != checkout.SyncClean {
-		t.Errorf("get(kb) = %+v, ok=%v", st, ok)
-	}
-
-	all := r.all()
-	if len(all) != 2 || all[0].Root != "apex" || all[1].Root != "kb" {
-		t.Fatalf("all() not sorted by root: %+v", all)
-	}
-
-	r.advanceRemote("kb", "sha1")
-	if got := r.lastKnownRemote("kb"); got != "sha1" {
-		t.Errorf("lastKnownRemote(kb) = %q, want sha1", got)
-	}
-	r.advanceRemote("kb", "") // no-op
-	if got := r.lastKnownRemote("kb"); got != "sha1" {
-		t.Errorf("advanceRemote with empty sha changed value to %q", got)
-	}
-}
-
-// TestSyncStateRegistryConcurrent exercises the writer (syncer loop) racing the
-// reader (operability surface) under -race.
-func TestSyncStateRegistryConcurrent(t *testing.T) {
-	r := newSyncStateRegistry()
-	done := make(chan struct{})
-	go func() {
-		for i := 0; i < 1000; i++ {
-			r.setState(syncState{Root: "kb", Outcome: checkout.SyncClean})
-			r.advanceRemote("kb", "sha")
-		}
-		close(done)
-	}()
-	for i := 0; i < 1000; i++ {
-		_ = r.all()
-		_, _ = r.get("kb")
-		_ = r.lastKnownRemote("kb")
-	}
-	<-done
-}
-
 // fakeEngine returns scripted results for successive Sync calls and records the
 // requests it received.
 type fakeEngine struct {
@@ -270,7 +219,7 @@ func (f *fakeEngine) Sync(_ context.Context, req checkout.SyncRequest) (checkout
 	return res, err
 }
 
-func newTestSyncer(engine syncEngine, reg *syncStateRegistry, refresh func(context.Context) error) *docRootSyncer {
+func newTestSyncer(engine syncEngine, reg *checkout.SyncStateRegistry, refresh func(context.Context) error) *docRootSyncer {
 	return &docRootSyncer{
 		root:     "kb",
 		engine:   engine,
@@ -282,7 +231,7 @@ func newTestSyncer(engine syncEngine, reg *syncStateRegistry, refresh func(conte
 }
 
 func TestRunOnceFastForwardReindexesAndAdvances(t *testing.T) {
-	reg := newSyncStateRegistry()
+	reg := checkout.NewSyncStateRegistry()
 	refreshes := 0
 	eng := &fakeEngine{results: []checkout.SyncResult{
 		{Outcome: checkout.SyncFastForwarded, Behind: 2, LocalHead: "l", RemoteHead: "rA"},
@@ -297,7 +246,7 @@ func TestRunOnceFastForwardReindexesAndAdvances(t *testing.T) {
 	if refreshes != 1 {
 		t.Errorf("refresh called %d times after fast-forward, want 1", refreshes)
 	}
-	if got := reg.lastKnownRemote("kb"); got != "rA" {
+	if got := reg.LastKnownRemote("kb"); got != "rA" {
 		t.Errorf("lastKnownRemote = %q, want rA", got)
 	}
 
@@ -315,8 +264,8 @@ func TestRunOnceFastForwardReindexesAndAdvances(t *testing.T) {
 }
 
 func TestRunOnceRemoteBehindDoesNotAdvanceOrReindex(t *testing.T) {
-	reg := newSyncStateRegistry()
-	reg.advanceRemote("kb", "rA") // a prior legitimate remote head
+	reg := checkout.NewSyncStateRegistry()
+	reg.AdvanceRemote("kb", "rA") // a prior legitimate remote head
 	refreshes := 0
 	eng := &fakeEngine{results: []checkout.SyncResult{
 		{Outcome: checkout.SyncRemoteBehind, LocalHead: "l", RemoteHead: "rOld", Detail: "rewound"},
@@ -331,7 +280,7 @@ func TestRunOnceRemoteBehindDoesNotAdvanceOrReindex(t *testing.T) {
 		t.Errorf("refresh called on remote_behind, want 0")
 	}
 	// The rewind baseline must NOT advance, so the rewind keeps being detected.
-	if got := reg.lastKnownRemote("kb"); got != "rA" {
+	if got := reg.LastKnownRemote("kb"); got != "rA" {
 		t.Errorf("lastKnownRemote = %q, want unchanged rA", got)
 	}
 }
@@ -345,22 +294,22 @@ func TestRunOnceAdvanceBaseline(t *testing.T) {
 
 	for _, oc := range accepted {
 		t.Run("advances_on_"+string(oc), func(t *testing.T) {
-			reg := newSyncStateRegistry()
-			reg.advanceRemote("kb", "prior")
+			reg := checkout.NewSyncStateRegistry()
+			reg.AdvanceRemote("kb", "prior")
 			eng := &fakeEngine{results: []checkout.SyncResult{{Outcome: oc, RemoteHead: "new"}}}
 			newTestSyncer(eng, reg, nil).runOnce(context.Background())
-			if got := reg.lastKnownRemote("kb"); got != "new" {
+			if got := reg.LastKnownRemote("kb"); got != "new" {
 				t.Errorf("lastKnownRemote = %q, want advanced to new for accepted outcome %q", got, oc)
 			}
 		})
 	}
 	for _, oc := range refused {
 		t.Run("holds_on_"+string(oc), func(t *testing.T) {
-			reg := newSyncStateRegistry()
-			reg.advanceRemote("kb", "prior")
+			reg := checkout.NewSyncStateRegistry()
+			reg.AdvanceRemote("kb", "prior")
 			eng := &fakeEngine{results: []checkout.SyncResult{{Outcome: oc, RemoteHead: "new"}}}
 			newTestSyncer(eng, reg, nil).runOnce(context.Background())
-			if got := reg.lastKnownRemote("kb"); got != "prior" {
+			if got := reg.LastKnownRemote("kb"); got != "prior" {
 				t.Errorf("lastKnownRemote = %q, want held at prior for refused outcome %q", got, oc)
 			}
 		})
@@ -368,7 +317,7 @@ func TestRunOnceAdvanceBaseline(t *testing.T) {
 }
 
 func TestRunOnceNotifiesOnAttentionTransitions(t *testing.T) {
-	reg := newSyncStateRegistry()
+	reg := checkout.NewSyncStateRegistry()
 	eng := &fakeEngine{results: []checkout.SyncResult{
 		{Outcome: checkout.SyncBlocked, RemoteHead: "r1", Detail: "first untrusted commit abc123"},
 		{Outcome: checkout.SyncBlocked, RemoteHead: "r1", Detail: "first untrusted commit abc123"},
@@ -427,7 +376,7 @@ func TestRunReturnsOnCancel(t *testing.T) {
 		{"ticker", time.Hour},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			reg := newSyncStateRegistry()
+			reg := checkout.NewSyncStateRegistry()
 			eng := &fakeEngine{results: []checkout.SyncResult{{Outcome: checkout.SyncClean, RemoteHead: "r"}}}
 			s := newTestSyncer(eng, reg, nil)
 			s.interval = tc.interval
@@ -448,7 +397,7 @@ func TestRunReturnsOnCancel(t *testing.T) {
 }
 
 func TestRunOnceErrorRecordsState(t *testing.T) {
-	reg := newSyncStateRegistry()
+	reg := checkout.NewSyncStateRegistry()
 	eng := &fakeEngine{errs: []error{context.DeadlineExceeded}}
 	s := newTestSyncer(eng, reg, nil)
 
@@ -459,7 +408,7 @@ func TestRunOnceErrorRecordsState(t *testing.T) {
 	if st.Detail == "" {
 		t.Error("Detail empty on error, want the error message")
 	}
-	if got, ok := reg.get("kb"); !ok || got.OK {
+	if got, ok := reg.Get("kb"); !ok || got.OK {
 		t.Errorf("registry state = %+v, ok=%v; want recorded not-OK", got, ok)
 	}
 }

--- a/internal/app/document_roots.go
+++ b/internal/app/document_roots.go
@@ -220,7 +220,7 @@ func (a *App) buildDocumentStoreOptions(documentRoots map[string]string, resolve
 				return documents.StoreOptions{}, fmt.Errorf("doc_roots.%s.git.remote requires sign_commits (the sync engine needs the signing store)", root)
 			}
 			if a.syncRegistry == nil {
-				a.syncRegistry = newSyncStateRegistry()
+				a.syncRegistry = checkout.NewSyncStateRegistry()
 			}
 			resolve := func(p string) string { return resolvePath(p, resolver) }
 			syncer, err := buildDocRootSyncer(root, rootCfg.Git, writer.checkout, a.syncRegistry, resolve, logger)

--- a/internal/platform/checkout/state.go
+++ b/internal/platform/checkout/state.go
@@ -1,0 +1,96 @@
+package checkout
+
+import (
+	"sort"
+	"sync"
+	"time"
+)
+
+// SyncState is the in-memory observed state of a checkout's remote sync. It is
+// re-derived every pass and can be surfaced by whichever domain owns the
+// checkout.
+type SyncState struct {
+	// Name is the caller-facing checkout identifier.
+	Name string
+	// OK is false when the last pass errored before producing a SyncResult.
+	OK bool
+	// Outcome classifies the last completed sync pass.
+	Outcome SyncOutcome
+	Ahead   int
+	Behind  int
+	// LocalHead and RemoteHead are the resolved local and remote commit SHAs
+	// observed by the sync pass.
+	LocalHead  string
+	RemoteHead string
+	// Detail carries the reason for a blocked/diverged/remote_behind outcome,
+	// or the error message when OK is false.
+	Detail string
+	// LastSyncAt records when this state was observed.
+	LastSyncAt time.Time
+}
+
+// SyncStateRegistry stores per-checkout sync state and the remote head
+// accepted on the previous pass. It is safe for concurrent readers and
+// writers.
+type SyncStateRegistry struct {
+	mu         sync.Mutex
+	state      map[string]SyncState
+	lastRemote map[string]string
+}
+
+// NewSyncStateRegistry creates an empty sync-state registry.
+func NewSyncStateRegistry() *SyncStateRegistry {
+	return &SyncStateRegistry{
+		state:      make(map[string]SyncState),
+		lastRemote: make(map[string]string),
+	}
+}
+
+// RecordState records the latest observed state for a checkout and returns the
+// state it replaced, if any.
+func (r *SyncStateRegistry) RecordState(st SyncState) (SyncState, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	prev, ok := r.state[st.Name]
+	r.state[st.Name] = st
+	return prev, ok
+}
+
+// AdvanceRemote records the remote head a checkout legitimately accepted, so
+// the next pass can detect a rewind past it. Empty SHAs are ignored.
+func (r *SyncStateRegistry) AdvanceRemote(name, sha string) {
+	if sha == "" {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.lastRemote[name] = sha
+}
+
+// LastKnownRemote returns the remote head recorded for a checkout's previous
+// accepted pass, or "" if none.
+func (r *SyncStateRegistry) LastKnownRemote(name string) string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.lastRemote[name]
+}
+
+// Get returns the recorded state for a checkout.
+func (r *SyncStateRegistry) Get(name string) (SyncState, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	st, ok := r.state[name]
+	return st, ok
+}
+
+// All returns every recorded state, sorted by Name for stable listings.
+func (r *SyncStateRegistry) All() []SyncState {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]SyncState, 0, len(r.state))
+	for _, st := range r.state {
+		out = append(out, st)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out
+}

--- a/internal/platform/checkout/state.go
+++ b/internal/platform/checkout/state.go
@@ -51,6 +51,7 @@ func NewSyncStateRegistry() *SyncStateRegistry {
 func (r *SyncStateRegistry) RecordState(st SyncState) (SyncState, bool) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
+	r.ensureLocked()
 	prev, ok := r.state[st.Name]
 	r.state[st.Name] = st
 	return prev, ok
@@ -64,6 +65,7 @@ func (r *SyncStateRegistry) AdvanceRemote(name, sha string) {
 	}
 	r.mu.Lock()
 	defer r.mu.Unlock()
+	r.ensureLocked()
 	r.lastRemote[name] = sha
 }
 
@@ -93,4 +95,13 @@ func (r *SyncStateRegistry) All() []SyncState {
 	}
 	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
 	return out
+}
+
+func (r *SyncStateRegistry) ensureLocked() {
+	if r.state == nil {
+		r.state = make(map[string]SyncState)
+	}
+	if r.lastRemote == nil {
+		r.lastRemote = make(map[string]string)
+	}
 }

--- a/internal/platform/checkout/state_test.go
+++ b/internal/platform/checkout/state_test.go
@@ -1,0 +1,54 @@
+package checkout
+
+import "testing"
+
+func TestSyncStateRegistry(t *testing.T) {
+	r := NewSyncStateRegistry()
+
+	if got := r.LastKnownRemote("kb"); got != "" {
+		t.Errorf("LastKnownRemote on empty = %q, want empty", got)
+	}
+	if _, ok := r.Get("kb"); ok {
+		t.Error("Get on empty registry returned ok")
+	}
+
+	r.RecordState(SyncState{Name: "kb", OK: true, Outcome: SyncClean})
+	r.RecordState(SyncState{Name: "apex", OK: true, Outcome: SyncFastForwarded})
+	if st, ok := r.Get("kb"); !ok || st.Outcome != SyncClean {
+		t.Errorf("Get(kb) = %+v, ok=%v", st, ok)
+	}
+
+	all := r.All()
+	if len(all) != 2 || all[0].Name != "apex" || all[1].Name != "kb" {
+		t.Fatalf("All() not sorted by name: %+v", all)
+	}
+
+	r.AdvanceRemote("kb", "sha1")
+	if got := r.LastKnownRemote("kb"); got != "sha1" {
+		t.Errorf("LastKnownRemote(kb) = %q, want sha1", got)
+	}
+	r.AdvanceRemote("kb", "") // no-op
+	if got := r.LastKnownRemote("kb"); got != "sha1" {
+		t.Errorf("AdvanceRemote with empty sha changed value to %q", got)
+	}
+}
+
+// TestSyncStateRegistryConcurrent exercises a syncer loop racing an
+// operability surface under -race.
+func TestSyncStateRegistryConcurrent(t *testing.T) {
+	r := NewSyncStateRegistry()
+	done := make(chan struct{})
+	go func() {
+		for i := 0; i < 1000; i++ {
+			r.RecordState(SyncState{Name: "kb", Outcome: SyncClean})
+			r.AdvanceRemote("kb", "sha")
+		}
+		close(done)
+	}()
+	for i := 0; i < 1000; i++ {
+		_ = r.All()
+		_, _ = r.Get("kb")
+		_ = r.LastKnownRemote("kb")
+	}
+	<-done
+}

--- a/internal/platform/checkout/state_test.go
+++ b/internal/platform/checkout/state_test.go
@@ -33,6 +33,22 @@ func TestSyncStateRegistry(t *testing.T) {
 	}
 }
 
+func TestSyncStateRegistryZeroValue(t *testing.T) {
+	var r SyncStateRegistry
+
+	if prev, ok := r.RecordState(SyncState{Name: "kb", OK: true, Outcome: SyncClean}); ok {
+		t.Fatalf("RecordState on zero value replaced %+v, want no previous state", prev)
+	}
+	if st, ok := r.Get("kb"); !ok || st.Outcome != SyncClean {
+		t.Fatalf("Get(kb) after zero-value RecordState = %+v, ok=%v", st, ok)
+	}
+
+	r.AdvanceRemote("kb", "sha1")
+	if got := r.LastKnownRemote("kb"); got != "sha1" {
+		t.Fatalf("LastKnownRemote(kb) after zero-value AdvanceRemote = %q, want sha1", got)
+	}
+}
+
 // TestSyncStateRegistryConcurrent exercises a syncer loop racing an
 // operability surface under -race.
 func TestSyncStateRegistryConcurrent(t *testing.T) {


### PR DESCRIPTION
## Summary

This is the next small step in the checkout primitive work from #1155. The previous slice moved document-root remote sync onto the checkout-facing request/result vocabulary. This one moves the state that surrounds those sync passes into `internal/platform/checkout` too.

The shape is intentionally modest: `checkout.SyncState` records the last observed sync pass, and `checkout.SyncStateRegistry` owns the concurrent state map plus the last accepted remote head used for rewind detection. Document roots still decide what the state means operationally. Their transition classification, indexing refresh, and core-loop wake path stay in `internal/app`, because those are document-root policy rather than checkout mechanics.

A small naming cleanup came with the move: the shared state uses `Name` instead of the old doc-root-specific `Root`, while the document-root wake metadata still emits `root` for the model/operator-facing event. That keeps the shared primitive neutral enough for forge mirrors and other future checkout consumers without changing the existing doc-root surface.

Refs #1155

## Validation

- `just test`
- `just ci`