### PR TITLE
feat: add checkout mirror mode

### DIFF
--- a/internal/platform/checkout/mirror.go
+++ b/internal/platform/checkout/mirror.go
@@ -17,6 +17,8 @@ import (
 // DefaultMirrorSyncTimeout bounds one mirror fetch/reset pass.
 const DefaultMirrorSyncTimeout = 2 * time.Minute
 
+const mirrorOwnedConfigKey = "checkout.mirror"
+
 // MirrorSpec describes a read-only mirror checkout.
 type MirrorSpec struct {
 	// Name is a caller-facing identifier used in logs and errors.
@@ -105,6 +107,9 @@ func (m *Mirror) Sync(ctx context.Context, req MirrorSyncRequest) (MirrorSyncRes
 	if err := m.fetch(ctx, req, branch); err != nil {
 		return MirrorSyncResult{}, err
 	}
+	if err := m.removeFetchHead(ctx); err != nil {
+		return MirrorSyncResult{}, err
+	}
 	remoteRef := "refs/remotes/origin/" + branch
 	remoteHead, err := m.revParse(ctx, remoteRef)
 	if err != nil {
@@ -191,7 +196,7 @@ func (m *Mirror) ensureRepo(ctx context.Context) error {
 	if ok, err := m.isGitWorktree(ctx); err != nil {
 		return err
 	} else if ok {
-		return nil
+		return m.requireMirrorOwned(ctx)
 	}
 	empty, err := isEmptyDir(m.WorktreePath)
 	if err != nil {
@@ -202,6 +207,31 @@ func (m *Mirror) ensureRepo(ctx context.Context) error {
 	}
 	if err := m.git(ctx, nil, nil, nil, "init"); err != nil {
 		return fmt.Errorf("%s: initialize mirror repository: %w", m.Name, err)
+	}
+	if err := m.markMirrorOwned(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (m *Mirror) markMirrorOwned(ctx context.Context) error {
+	if err := m.git(ctx, nil, nil, nil, "config", mirrorOwnedConfigKey, "true"); err != nil {
+		return fmt.Errorf("%s: mark mirror repository owned: %w", m.Name, err)
+	}
+	return nil
+}
+
+func (m *Mirror) requireMirrorOwned(ctx context.Context) error {
+	var out bytes.Buffer
+	err := m.git(ctx, nil, nil, &out, "config", "--bool", "--get", mirrorOwnedConfigKey)
+	if err != nil {
+		if isGitExit(err, 1) {
+			return fmt.Errorf("%s: mirror path %s is an existing git checkout but is not marked as mirror-owned; refusing destructive reset/clean", m.Name, m.WorktreePath)
+		}
+		return fmt.Errorf("%s: inspect mirror ownership marker: %w", m.Name, err)
+	}
+	if strings.TrimSpace(out.String()) != "true" {
+		return fmt.Errorf("%s: mirror path %s has %s=%q, want true; refusing destructive reset/clean", m.Name, m.WorktreePath, mirrorOwnedConfigKey, strings.TrimSpace(out.String()))
 	}
 	return nil
 }
@@ -224,7 +254,7 @@ func (m *Mirror) fetch(ctx context.Context, req MirrorSyncRequest, branch string
 		env = []string{"GIT_SSH_COMMAND=" + req.SSHCommand}
 	}
 	refspec := fmt.Sprintf("+refs/heads/%s:refs/remotes/origin/%s", branch, branch)
-	if err := m.git(ctx, env, nil, nil, "fetch", "--no-tags", "--prune", "--end-of-options", strings.TrimSpace(req.RemoteURL), refspec); err != nil {
+	if err := m.git(ctx, env, nil, nil, "fetch", "--no-tags", "--prune", "--no-write-fetch-head", "--end-of-options", strings.TrimSpace(req.RemoteURL), refspec); err != nil {
 		return fmt.Errorf("%s: fetch mirror branch %q: %w", m.Name, branch, err)
 	}
 	return nil
@@ -264,6 +294,32 @@ func (m *Mirror) removeOriginConfig(ctx context.Context) error {
 		return fmt.Errorf("%s: remove origin config: %w", m.Name, err)
 	}
 	return nil
+}
+
+func (m *Mirror) removeFetchHead(ctx context.Context) error {
+	fetchHead, err := m.gitPath(ctx, "FETCH_HEAD")
+	if err != nil {
+		return err
+	}
+	if err := os.Remove(fetchHead); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("%s: remove FETCH_HEAD transport trace: %w", m.Name, err)
+	}
+	return nil
+}
+
+func (m *Mirror) gitPath(ctx context.Context, name string) (string, error) {
+	var out bytes.Buffer
+	if err := m.git(ctx, nil, nil, &out, "rev-parse", "--git-path", name); err != nil {
+		return "", fmt.Errorf("%s: resolve git path %s: %w", m.Name, name, err)
+	}
+	p := strings.TrimSpace(out.String())
+	if p == "" {
+		return "", fmt.Errorf("%s: git path %s resolved to empty path", m.Name, name)
+	}
+	if !filepath.IsAbs(p) {
+		p = filepath.Join(m.WorktreePath, p)
+	}
+	return p, nil
 }
 
 func (m *Mirror) git(ctx context.Context, env []string, stdin io.Reader, stdout io.Writer, args ...string) error {
@@ -309,9 +365,12 @@ func isGitExit(err error, code int) bool {
 
 func sanitizeGitArgs(args []string) []string {
 	out := append([]string(nil), args...)
-	for i, arg := range out {
-		if arg == "--end-of-options" && i+1 < len(out) && i > 0 && out[i-1] == "--prune" {
-			out[i+1] = "<remote>"
+	if len(out) > 0 && out[0] == "fetch" {
+		for i, arg := range out {
+			if arg == "--end-of-options" && i+1 < len(out) {
+				out[i+1] = "<remote>"
+				break
+			}
 		}
 	}
 	return out

--- a/internal/platform/checkout/mirror.go
+++ b/internal/platform/checkout/mirror.go
@@ -1,0 +1,343 @@
+package checkout
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// DefaultMirrorSyncTimeout bounds one mirror fetch/reset pass.
+const DefaultMirrorSyncTimeout = 2 * time.Minute
+
+// MirrorSpec describes a read-only mirror checkout.
+type MirrorSpec struct {
+	// Name is a caller-facing identifier used in logs and errors.
+	Name string
+	// WorktreePath is the local path maintained as a mirror.
+	WorktreePath string
+	// Logger receives setup and sync logs. Nil uses slog.Default.
+	Logger *slog.Logger
+}
+
+// Mirror is a local checkout maintained as an exact read-only copy of a remote
+// branch. It never records the remote URL in .git/config; every sync supplies
+// transport details for that command only.
+type Mirror struct {
+	Name         string
+	WorktreePath string
+
+	logger *slog.Logger
+}
+
+// MirrorSyncRequest parameterizes one mirror sync pass.
+type MirrorSyncRequest struct {
+	// RemoteURL is the git remote (ssh, https, or a local path).
+	RemoteURL string
+	// Branch is the remote branch mirrored into the local worktree.
+	Branch string
+	// SSHCommand, when non-empty, is exported as GIT_SSH_COMMAND for fetch.
+	SSHCommand string
+}
+
+// MirrorSyncResult reports what one mirror sync pass observed and applied.
+type MirrorSyncResult struct {
+	// PreviousHead is the local HEAD before the mirror was reset. It is empty
+	// on the first sync into a fresh checkout.
+	PreviousHead string
+	// RemoteHead is the fetched remote branch head that the mirror now matches.
+	RemoteHead string
+	// Changed is true when the mirror's HEAD moved during the sync.
+	Changed bool
+}
+
+// OpenMirror resolves a mirror checkout path. The repository is created lazily
+// by [Mirror.Sync] so callers can construct mirrors during startup without
+// touching disk until the first sync pass.
+func OpenMirror(spec MirrorSpec) (*Mirror, error) {
+	name := strings.TrimSpace(spec.Name)
+	if name == "" {
+		name = "checkout"
+	}
+	worktreePath := strings.TrimSpace(spec.WorktreePath)
+	if worktreePath == "" {
+		return nil, fmt.Errorf("%s: worktree path is required", name)
+	}
+	absWorktreePath, err := filepath.Abs(worktreePath)
+	if err != nil {
+		return nil, fmt.Errorf("%s: resolve worktree path: %w", name, err)
+	}
+	logger := spec.Logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Mirror{Name: name, WorktreePath: absWorktreePath, logger: logger}, nil
+}
+
+// Sync fetches the requested branch and resets the mirror worktree to match it
+// exactly. Local modifications and untracked files are discarded by design.
+func (m *Mirror) Sync(ctx context.Context, req MirrorSyncRequest) (MirrorSyncResult, error) {
+	if m == nil {
+		return MirrorSyncResult{}, fmt.Errorf("mirror checkout is not configured")
+	}
+	ctx, cancel := withMirrorTimeout(ctx)
+	defer cancel()
+
+	branch, err := validateMirrorSyncRequest(ctx, req)
+	if err != nil {
+		return MirrorSyncResult{}, fmt.Errorf("%s: %w", m.Name, err)
+	}
+	if err := m.ensureRepo(ctx); err != nil {
+		return MirrorSyncResult{}, err
+	}
+
+	previousHead, err := m.optionalRevParse(ctx, "HEAD")
+	if err != nil {
+		return MirrorSyncResult{}, err
+	}
+	if err := m.fetch(ctx, req, branch); err != nil {
+		return MirrorSyncResult{}, err
+	}
+	remoteRef := "refs/remotes/origin/" + branch
+	remoteHead, err := m.revParse(ctx, remoteRef)
+	if err != nil {
+		return MirrorSyncResult{}, err
+	}
+
+	localRef := "refs/heads/" + branch
+	if err := m.git(ctx, nil, nil, nil, "update-ref", localRef, remoteHead); err != nil {
+		return MirrorSyncResult{}, fmt.Errorf("%s: update mirror branch %q: %w", m.Name, branch, err)
+	}
+	if err := m.git(ctx, nil, nil, nil, "symbolic-ref", "HEAD", localRef); err != nil {
+		return MirrorSyncResult{}, fmt.Errorf("%s: set mirror HEAD to %q: %w", m.Name, branch, err)
+	}
+	if err := m.git(ctx, nil, nil, nil, "reset", "--hard", "--end-of-options", remoteHead); err != nil {
+		return MirrorSyncResult{}, fmt.Errorf("%s: reset mirror to %s: %w", m.Name, shortenForLog(remoteHead), err)
+	}
+	if err := m.git(ctx, nil, nil, nil, "clean", "-fdx"); err != nil {
+		return MirrorSyncResult{}, fmt.Errorf("%s: clean mirror worktree: %w", m.Name, err)
+	}
+	if err := m.removeOriginConfig(ctx); err != nil {
+		return MirrorSyncResult{}, err
+	}
+
+	res := MirrorSyncResult{
+		PreviousHead: previousHead,
+		RemoteHead:   remoteHead,
+		Changed:      previousHead != remoteHead,
+	}
+	m.logger.Info("mirror checkout synced",
+		"name", m.Name,
+		"path", m.WorktreePath,
+		"branch", branch,
+		"remote_head", shortenForLog(remoteHead),
+		"changed", res.Changed,
+	)
+	return res, nil
+}
+
+func validateMirrorSyncRequest(ctx context.Context, req MirrorSyncRequest) (string, error) {
+	remoteURL := strings.TrimSpace(req.RemoteURL)
+	if err := checkMirrorRemoteArg("remote url", remoteURL); err != nil {
+		return "", err
+	}
+	branch := strings.TrimSpace(req.Branch)
+	if branch == "" {
+		return "", fmt.Errorf("branch is empty")
+	}
+	if strings.HasPrefix(branch, "-") {
+		return "", fmt.Errorf("branch %q must not begin with '-'", branch)
+	}
+	cmd := exec.CommandContext(ctx, "git", "check-ref-format", "refs/heads/"+branch)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("invalid branch name %q: %w: %s", branch, err, strings.TrimSpace(string(out)))
+	}
+	return branch, nil
+}
+
+func checkMirrorRemoteArg(kind, url string) error {
+	url = strings.TrimSpace(url)
+	if url == "" {
+		return fmt.Errorf("%s is empty", kind)
+	}
+	if strings.HasPrefix(url, "-") {
+		return fmt.Errorf("%s %q must not begin with '-'", kind, url)
+	}
+	return nil
+}
+
+func (m *Mirror) ensureRepo(ctx context.Context) error {
+	info, err := os.Stat(m.WorktreePath)
+	switch {
+	case err == nil:
+		if !info.IsDir() {
+			return fmt.Errorf("%s: mirror path %s is not a directory", m.Name, m.WorktreePath)
+		}
+	case errors.Is(err, os.ErrNotExist):
+		if err := os.MkdirAll(m.WorktreePath, 0o755); err != nil {
+			return fmt.Errorf("%s: create mirror directory: %w", m.Name, err)
+		}
+	default:
+		return fmt.Errorf("%s: stat mirror path: %w", m.Name, err)
+	}
+
+	if ok, err := m.isGitWorktree(ctx); err != nil {
+		return err
+	} else if ok {
+		return nil
+	}
+	empty, err := isEmptyDir(m.WorktreePath)
+	if err != nil {
+		return fmt.Errorf("%s: inspect mirror directory: %w", m.Name, err)
+	}
+	if !empty {
+		return fmt.Errorf("%s: mirror path %s exists but is not an empty directory or git checkout", m.Name, m.WorktreePath)
+	}
+	if err := m.git(ctx, nil, nil, nil, "init"); err != nil {
+		return fmt.Errorf("%s: initialize mirror repository: %w", m.Name, err)
+	}
+	return nil
+}
+
+func (m *Mirror) isGitWorktree(ctx context.Context) (bool, error) {
+	var out bytes.Buffer
+	err := m.git(ctx, nil, nil, &out, "rev-parse", "--is-inside-work-tree")
+	if err == nil {
+		return strings.TrimSpace(out.String()) == "true", nil
+	}
+	if isGitExit(err, 128) {
+		return false, nil
+	}
+	return false, fmt.Errorf("%s: inspect git worktree: %w", m.Name, err)
+}
+
+func (m *Mirror) fetch(ctx context.Context, req MirrorSyncRequest, branch string) error {
+	var env []string
+	if req.SSHCommand != "" {
+		env = []string{"GIT_SSH_COMMAND=" + req.SSHCommand}
+	}
+	refspec := fmt.Sprintf("+refs/heads/%s:refs/remotes/origin/%s", branch, branch)
+	if err := m.git(ctx, env, nil, nil, "fetch", "--no-tags", "--prune", "--end-of-options", strings.TrimSpace(req.RemoteURL), refspec); err != nil {
+		return fmt.Errorf("%s: fetch mirror branch %q: %w", m.Name, branch, err)
+	}
+	return nil
+}
+
+func (m *Mirror) optionalRevParse(ctx context.Context, rev string) (string, error) {
+	sha, err := m.revParse(ctx, rev)
+	if err == nil {
+		return sha, nil
+	}
+	if isGitExit(err, 128) {
+		return "", nil
+	}
+	return "", err
+}
+
+func (m *Mirror) revParse(ctx context.Context, rev string) (string, error) {
+	var out bytes.Buffer
+	if err := m.git(ctx, nil, nil, &out, "rev-parse", "--verify", "--end-of-options", rev); err != nil {
+		return "", fmt.Errorf("%s: resolve %s: %w", m.Name, rev, err)
+	}
+	sha := strings.TrimSpace(out.String())
+	if sha == "" {
+		return "", fmt.Errorf("%s: rev-parse %s returned nothing", m.Name, rev)
+	}
+	return sha, nil
+}
+
+func (m *Mirror) removeOriginConfig(ctx context.Context) error {
+	if err := m.git(ctx, nil, nil, nil, "config", "--get-regexp", "^remote\\.origin\\."); err != nil {
+		if isGitExit(err, 1) {
+			return nil
+		}
+		return fmt.Errorf("%s: inspect origin config: %w", m.Name, err)
+	}
+	if err := m.git(ctx, nil, nil, nil, "config", "--remove-section", "remote.origin"); err != nil {
+		return fmt.Errorf("%s: remove origin config: %w", m.Name, err)
+	}
+	return nil
+}
+
+func (m *Mirror) git(ctx context.Context, env []string, stdin io.Reader, stdout io.Writer, args ...string) error {
+	cmd := exec.CommandContext(ctx, "git", append([]string{"-C", m.WorktreePath}, args...)...)
+	if len(env) > 0 {
+		cmd.Env = append(os.Environ(), env...)
+	}
+	cmd.Stdin = stdin
+	cmd.Stdout = stdout
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return &gitCommandError{
+			args:   sanitizeGitArgs(args),
+			err:    err,
+			stderr: strings.TrimSpace(stderr.String()),
+		}
+	}
+	return nil
+}
+
+type gitCommandError struct {
+	args   []string
+	err    error
+	stderr string
+}
+
+func (e *gitCommandError) Error() string {
+	if e.stderr == "" {
+		return fmt.Sprintf("git %s: %v", strings.Join(e.args, " "), e.err)
+	}
+	return fmt.Sprintf("git %s: %v: %s", strings.Join(e.args, " "), e.err, e.stderr)
+}
+
+func (e *gitCommandError) Unwrap() error {
+	return e.err
+}
+
+func isGitExit(err error, code int) bool {
+	var exitErr *exec.ExitError
+	return errors.As(err, &exitErr) && exitErr.ExitCode() == code
+}
+
+func sanitizeGitArgs(args []string) []string {
+	out := append([]string(nil), args...)
+	for i, arg := range out {
+		if arg == "--end-of-options" && i+1 < len(out) && i > 0 && out[i-1] == "--prune" {
+			out[i+1] = "<remote>"
+		}
+	}
+	return out
+}
+
+func isEmptyDir(dir string) (bool, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return false, err
+	}
+	return len(entries) == 0, nil
+}
+
+func withMirrorTimeout(ctx context.Context) (context.Context, context.CancelFunc) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if _, ok := ctx.Deadline(); ok {
+		return ctx, func() {}
+	}
+	return context.WithTimeout(ctx, DefaultMirrorSyncTimeout)
+}
+
+func shortenForLog(sha string) string {
+	if len(sha) <= 12 {
+		return sha
+	}
+	return sha[:12]
+}

--- a/internal/platform/checkout/mirror_test.go
+++ b/internal/platform/checkout/mirror_test.go
@@ -37,9 +37,10 @@ func TestMirrorSyncInitializesWithoutPersistingRemote(t *testing.T) {
 	if got := readMirrorFile(t, worktree, "README.md"); got != "one\n" {
 		t.Fatalf("README.md = %q, want source content", got)
 	}
-	if remoteURL := mirrorGitOptional(t, worktree, "config", "--get", "remote.origin.url"); remoteURL != "" {
-		t.Fatalf("remote.origin.url = %q, want no persisted remote", remoteURL)
+	if got := mirrorGitOptional(t, worktree, "config", "--bool", "--get", mirrorOwnedConfigKey); got != "true" {
+		t.Fatalf("%s = %q, want true", mirrorOwnedConfigKey, got)
 	}
+	assertMirrorDidNotPersistRemoteURL(t, worktree, source)
 }
 
 func TestMirrorSyncResetsAndCleansLocalWorktree(t *testing.T) {
@@ -60,6 +61,9 @@ func TestMirrorSyncResetsAndCleansLocalWorktree(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(worktree, "scratch.txt"), []byte("local\n"), 0o644); err != nil {
 		t.Fatalf("write scratch.txt: %v", err)
 	}
+	if err := os.WriteFile(filepath.Join(worktree, ".git", "FETCH_HEAD"), []byte(source+"\tbranch 'main' of "+source+"\n"), 0o644); err != nil {
+		t.Fatalf("write stale FETCH_HEAD: %v", err)
+	}
 	commitMirrorFile(t, source, "README.md", "two\n", "advance")
 	remoteHead := mirrorHead(t, source)
 
@@ -76,6 +80,7 @@ func TestMirrorSyncResetsAndCleansLocalWorktree(t *testing.T) {
 	if _, err := os.Stat(filepath.Join(worktree, "scratch.txt")); !os.IsNotExist(err) {
 		t.Fatalf("scratch.txt still exists after mirror clean; stat err=%v", err)
 	}
+	assertMirrorDidNotPersistRemoteURL(t, worktree, source)
 }
 
 func TestMirrorSyncAcceptsRemoteRewrite(t *testing.T) {
@@ -134,6 +139,39 @@ func TestMirrorSyncRejectsNonEmptyNonRepo(t *testing.T) {
 	}
 }
 
+func TestMirrorSyncRejectsUnmarkedGitWorktree(t *testing.T) {
+	source := newMirrorSourceRepo(t)
+	commitMirrorFile(t, source, "README.md", "one\n", "initial")
+	worktree := newMirrorSourceRepo(t)
+	commitMirrorFile(t, worktree, "README.md", "local\n", "local")
+	originURL := "https://example.invalid/repo.git"
+	runMirrorGit(t, worktree, "remote", "add", "origin", originURL)
+	if err := os.WriteFile(filepath.Join(worktree, "scratch.txt"), []byte("keep\n"), 0o644); err != nil {
+		t.Fatalf("write scratch.txt: %v", err)
+	}
+
+	mirror, err := OpenMirror(MirrorSpec{Name: "thane", WorktreePath: worktree})
+	if err != nil {
+		t.Fatalf("OpenMirror: %v", err)
+	}
+	_, err = mirror.Sync(t.Context(), MirrorSyncRequest{RemoteURL: source, Branch: "main"})
+	if err == nil {
+		t.Fatal("Sync returned nil, want unmarked git checkout error")
+	}
+	if !strings.Contains(err.Error(), "not marked as mirror-owned") {
+		t.Fatalf("error = %v, want mirror ownership marker message", err)
+	}
+	if got := mirrorGitOptional(t, worktree, "config", "--get", "remote.origin.url"); got != originURL {
+		t.Fatalf("remote.origin.url = %q, want preserved %q", got, originURL)
+	}
+	if got := readMirrorFile(t, worktree, "README.md"); got != "local\n" {
+		t.Fatalf("README.md = %q, want local content preserved", got)
+	}
+	if _, err := os.Stat(filepath.Join(worktree, "scratch.txt")); err != nil {
+		t.Fatalf("scratch.txt was removed despite rejected mirror sync: %v", err)
+	}
+}
+
 func newMirrorSourceRepo(t *testing.T) string {
 	t.Helper()
 	if _, err := exec.LookPath("git"); err != nil {
@@ -185,6 +223,24 @@ func mirrorGitOptional(t *testing.T, dir string, args ...string) string {
 		return ""
 	}
 	return strings.TrimSpace(stdout.String())
+}
+
+func assertMirrorDidNotPersistRemoteURL(t *testing.T, worktree, remoteURL string) {
+	t.Helper()
+	if got := mirrorGitOptional(t, worktree, "config", "--get", "remote.origin.url"); got != "" {
+		t.Fatalf("remote.origin.url = %q, want no persisted remote", got)
+	}
+	fetchHeadPath := filepath.Join(worktree, ".git", "FETCH_HEAD")
+	b, err := os.ReadFile(fetchHeadPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return
+		}
+		t.Fatalf("read FETCH_HEAD: %v", err)
+	}
+	if strings.Contains(string(b), remoteURL) {
+		t.Fatalf("FETCH_HEAD contains remote URL %q: %q", remoteURL, b)
+	}
 }
 
 func runMirrorGit(t *testing.T, dir string, args ...string) string {

--- a/internal/platform/checkout/mirror_test.go
+++ b/internal/platform/checkout/mirror_test.go
@@ -1,0 +1,200 @@
+package checkout
+
+import (
+	"bytes"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestMirrorSyncInitializesWithoutPersistingRemote(t *testing.T) {
+	source := newMirrorSourceRepo(t)
+	commitMirrorFile(t, source, "README.md", "one\n", "initial")
+	remoteHead := mirrorHead(t, source)
+	worktree := filepath.Join(t.TempDir(), "mirror")
+
+	mirror, err := OpenMirror(MirrorSpec{Name: "thane", WorktreePath: worktree, Logger: slog.Default()})
+	if err != nil {
+		t.Fatalf("OpenMirror: %v", err)
+	}
+	res, err := mirror.Sync(t.Context(), MirrorSyncRequest{RemoteURL: source, Branch: "main"})
+	if err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+
+	if res.PreviousHead != "" {
+		t.Fatalf("PreviousHead = %q, want empty for first sync", res.PreviousHead)
+	}
+	if res.RemoteHead != remoteHead || !res.Changed {
+		t.Fatalf("result = %+v, want changed sync to %s", res, remoteHead)
+	}
+	if got := mirrorHead(t, worktree); got != remoteHead {
+		t.Fatalf("mirror HEAD = %s, want %s", got, remoteHead)
+	}
+	if got := readMirrorFile(t, worktree, "README.md"); got != "one\n" {
+		t.Fatalf("README.md = %q, want source content", got)
+	}
+	if remoteURL := mirrorGitOptional(t, worktree, "config", "--get", "remote.origin.url"); remoteURL != "" {
+		t.Fatalf("remote.origin.url = %q, want no persisted remote", remoteURL)
+	}
+}
+
+func TestMirrorSyncResetsAndCleansLocalWorktree(t *testing.T) {
+	source := newMirrorSourceRepo(t)
+	commitMirrorFile(t, source, "README.md", "one\n", "initial")
+	worktree := filepath.Join(t.TempDir(), "mirror")
+	mirror, err := OpenMirror(MirrorSpec{Name: "thane", WorktreePath: worktree})
+	if err != nil {
+		t.Fatalf("OpenMirror: %v", err)
+	}
+	if _, err := mirror.Sync(t.Context(), MirrorSyncRequest{RemoteURL: source, Branch: "main"}); err != nil {
+		t.Fatalf("initial Sync: %v", err)
+	}
+
+	if err := os.WriteFile(filepath.Join(worktree, "README.md"), []byte("dirty\n"), 0o644); err != nil {
+		t.Fatalf("dirty README.md: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(worktree, "scratch.txt"), []byte("local\n"), 0o644); err != nil {
+		t.Fatalf("write scratch.txt: %v", err)
+	}
+	commitMirrorFile(t, source, "README.md", "two\n", "advance")
+	remoteHead := mirrorHead(t, source)
+
+	res, err := mirror.Sync(t.Context(), MirrorSyncRequest{RemoteURL: source, Branch: "main"})
+	if err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+	if res.RemoteHead != remoteHead || !res.Changed {
+		t.Fatalf("result = %+v, want changed sync to %s", res, remoteHead)
+	}
+	if got := readMirrorFile(t, worktree, "README.md"); got != "two\n" {
+		t.Fatalf("README.md = %q, want reset source content", got)
+	}
+	if _, err := os.Stat(filepath.Join(worktree, "scratch.txt")); !os.IsNotExist(err) {
+		t.Fatalf("scratch.txt still exists after mirror clean; stat err=%v", err)
+	}
+}
+
+func TestMirrorSyncAcceptsRemoteRewrite(t *testing.T) {
+	source := newMirrorSourceRepo(t)
+	commitMirrorFile(t, source, "README.md", "one\n", "initial")
+	baseHead := mirrorHead(t, source)
+	commitMirrorFile(t, source, "README.md", "two\n", "advance")
+	advancedHead := mirrorHead(t, source)
+
+	worktree := filepath.Join(t.TempDir(), "mirror")
+	mirror, err := OpenMirror(MirrorSpec{Name: "thane", WorktreePath: worktree})
+	if err != nil {
+		t.Fatalf("OpenMirror: %v", err)
+	}
+	if _, err := mirror.Sync(t.Context(), MirrorSyncRequest{RemoteURL: source, Branch: "main"}); err != nil {
+		t.Fatalf("initial Sync: %v", err)
+	}
+	if got := mirrorHead(t, worktree); got != advancedHead {
+		t.Fatalf("initial mirror HEAD = %s, want %s", got, advancedHead)
+	}
+
+	runMirrorGit(t, source, "reset", "--hard", baseHead)
+	res, err := mirror.Sync(t.Context(), MirrorSyncRequest{RemoteURL: source, Branch: "main"})
+	if err != nil {
+		t.Fatalf("Sync after rewrite: %v", err)
+	}
+	if res.PreviousHead != advancedHead || res.RemoteHead != baseHead || !res.Changed {
+		t.Fatalf("rewrite result = %+v, want previous=%s remote=%s changed", res, advancedHead, baseHead)
+	}
+	if got := mirrorHead(t, worktree); got != baseHead {
+		t.Fatalf("mirror HEAD after rewrite = %s, want %s", got, baseHead)
+	}
+	if got := readMirrorFile(t, worktree, "README.md"); got != "one\n" {
+		t.Fatalf("README.md after rewrite = %q, want base content", got)
+	}
+}
+
+func TestMirrorSyncRejectsNonEmptyNonRepo(t *testing.T) {
+	source := newMirrorSourceRepo(t)
+	commitMirrorFile(t, source, "README.md", "one\n", "initial")
+	worktree := t.TempDir()
+	if err := os.WriteFile(filepath.Join(worktree, "local.txt"), []byte("keep\n"), 0o644); err != nil {
+		t.Fatalf("write local file: %v", err)
+	}
+
+	mirror, err := OpenMirror(MirrorSpec{Name: "thane", WorktreePath: worktree})
+	if err != nil {
+		t.Fatalf("OpenMirror: %v", err)
+	}
+	_, err = mirror.Sync(t.Context(), MirrorSyncRequest{RemoteURL: source, Branch: "main"})
+	if err == nil {
+		t.Fatal("Sync returned nil, want non-empty non-repo error")
+	}
+	if !strings.Contains(err.Error(), "not an empty directory or git checkout") {
+		t.Fatalf("error = %v, want non-empty directory message", err)
+	}
+}
+
+func newMirrorSourceRepo(t *testing.T) string {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	dir := t.TempDir()
+	runMirrorGit(t, dir, "init")
+	runMirrorGit(t, dir, "checkout", "-b", "main")
+	runMirrorGit(t, dir, "config", "user.name", "Test")
+	runMirrorGit(t, dir, "config", "user.email", "test@example.com")
+	runMirrorGit(t, dir, "config", "commit.gpgsign", "false")
+	return dir
+}
+
+func commitMirrorFile(t *testing.T, dir, name, content, msg string) {
+	t.Helper()
+	path := filepath.Join(dir, filepath.FromSlash(name))
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", name, err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", name, err)
+	}
+	runMirrorGit(t, dir, "add", "-A")
+	runMirrorGit(t, dir, "-c", "commit.gpgsign=false", "commit", "-m", msg)
+}
+
+func mirrorHead(t *testing.T, dir string) string {
+	t.Helper()
+	return strings.TrimSpace(runMirrorGit(t, dir, "rev-parse", "HEAD"))
+}
+
+func readMirrorFile(t *testing.T, dir, name string) string {
+	t.Helper()
+	b, err := os.ReadFile(filepath.Join(dir, filepath.FromSlash(name)))
+	if err != nil {
+		t.Fatalf("read %s: %v", name, err)
+	}
+	return string(b)
+}
+
+func mirrorGitOptional(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	var stdout, stderr bytes.Buffer
+	cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return ""
+	}
+	return strings.TrimSpace(stdout.String())
+}
+
+func runMirrorGit(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	var stdout, stderr bytes.Buffer
+	cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("git -C %s %s: %v\nstdout: %s\nstderr: %s", dir, strings.Join(args, " "), err, stdout.String(), stderr.String())
+	}
+	return stdout.String()
+}


### PR DESCRIPTION
## Summary

This is the next slice of the shared checkout work. Document-root sync now has reusable state in `checkout`; #1032 needs the other half of that foundation: a local checkout mode that can be maintained as a read-only mirror of an upstream repository.

This PR adds `checkout.Mirror`, which initializes a working tree on first sync, fetches the requested branch with the remote URL supplied only to that git command, and then resets and cleans the worktree to match the fetched head. It avoids configuring `origin`, so a checkout sync does not persist transport URLs or credentials in `.git/config`.

The result type reports the previous local head and fetched remote head directly. That keeps the contract honest: a mirror is allowed to accept an upstream rewrite and move backward, while signed document roots continue to use the separate fast-forward-only sync path that refuses rewinds.

Refs #1155
Refs #1032

## Validation

- `just test`
- `just ci`
