### PR TITLE
feat: sync forge subscription checkouts

### DIFF
--- a/docs/reference/event-sources.md
+++ b/docs/reference/event-sources.md
@@ -100,10 +100,13 @@ tagging strategy.
 Repository event subscriptions are managed with `forge_repo_follow`,
 `forge_repo_unfollow`, and `forge_repo_subscriptions`. Each subscription
 tracks new releases, commits, or both with high-water marks stored in
-opstate.
+opstate. A subscription may also carry `local_checkout`, a path maintained
+as a read-only mirror checkout by the poller before event delivery.
 
 Unlike legacy pollers that start a fresh generic conversation, forge
 subscriptions require `wake_loop`. New `release` and `commit` events are
 delivered to the named loop as structured event-source notifications, so the
 receiving `thane_loop_create` or other `thane_` loop remains the owner of durable
-documents and corpus conventions.
+documents and corpus conventions. When a local checkout is configured,
+event metadata includes `local_checkout` and `last_synced_sha`, and
+unfollowing the subscription leaves the checkout on disk.

--- a/docs/reference/event-sources.md
+++ b/docs/reference/event-sources.md
@@ -101,7 +101,9 @@ Repository event subscriptions are managed with `forge_repo_follow`,
 `forge_repo_unfollow`, and `forge_repo_subscriptions`. Each subscription
 tracks new releases, commits, or both with high-water marks stored in
 opstate. A subscription may also carry `local_checkout`, a path maintained
-as a read-only mirror checkout by the poller before event delivery.
+as a read-only mirror checkout by the poller before event delivery. That
+path must be empty or an existing Thane-owned mirror checkout; non-empty
+directories and unmarked git checkouts are refused.
 
 Unlike legacy pollers that start a fresh generic conversation, forge
 subscriptions require `wake_loop`. New `release` and `commit` events are

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -321,13 +321,16 @@ Attachment list and search results report arrival recency as
 | `forge_pr_request_review` | Request reviewers on a PR. |
 | `forge_react` | Add an emoji reaction to an issue/PR/comment. |
 | `forge_search` | Search code and issues across the forge. |
-| `forge_repo_follow` | Follow a repository for release/commit events and wake an existing loop. |
+| `forge_repo_follow` | Follow a repository for release/commit events, optionally maintain a local mirror checkout, and wake an existing loop. |
 | `forge_repo_unfollow` | Stop following a repository event subscription. |
 | `forge_repo_subscriptions` | List repository event subscriptions and target loops. |
 
 Repository subscriptions require `wake_loop` so event handling is owned by
 an existing loop, usually one created with `thane_loop_create`
-(`operation: service`) for a specific managed document.
+(`operation: service`) for a specific managed document. Pass
+`local_checkout` when the loop should read a local mirror checkout; the
+poller syncs that checkout before delivering repository events and leaves
+the checkout on disk when the subscription is unfollowed.
 
 ## `scheduler` — time-based tasks
 

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -329,8 +329,10 @@ Repository subscriptions require `wake_loop` so event handling is owned by
 an existing loop, usually one created with `thane_loop_create`
 (`operation: service`) for a specific managed document. Pass
 `local_checkout` when the loop should read a local mirror checkout; the
-poller syncs that checkout before delivering repository events and leaves
-the checkout on disk when the subscription is unfollowed.
+poller syncs that checkout before delivering repository events. The path
+must be empty or an existing Thane-owned mirror checkout; non-empty
+directories and unmarked git checkouts are refused. Unfollowing leaves
+the checkout on disk.
 
 ## `scheduler` — time-based tasks
 

--- a/internal/integrations/forge/github.go
+++ b/internal/integrations/forge/github.go
@@ -85,6 +85,7 @@ func (g *GitHub) GetRepository(ctx context.Context, repo string) (*Repository, e
 		FullName:      ghRepo.GetFullName(),
 		DefaultBranch: ghRepo.GetDefaultBranch(),
 		URL:           ghRepo.GetHTMLURL(),
+		CloneURL:      ghRepo.GetCloneURL(),
 	}, nil
 }
 

--- a/internal/integrations/forge/poller.go
+++ b/internal/integrations/forge/poller.go
@@ -24,10 +24,11 @@ const forgePollFetchLimit = 100
 // SubscriptionPoller checks followed forge projects for new releases and
 // commits, then wakes the loop declared by each subscription.
 type SubscriptionPoller struct {
-	manager *Manager
-	store   *SubscriptionStore
-	bus     *messages.Bus
-	logger  *slog.Logger
+	manager      *Manager
+	store        *SubscriptionStore
+	bus          *messages.Bus
+	logger       *slog.Logger
+	checkoutSync func(context.Context, ProjectSubscription) (string, error)
 }
 
 // NewSubscriptionPoller creates a poller for forge project subscriptions.
@@ -36,10 +37,11 @@ func NewSubscriptionPoller(manager *Manager, store *SubscriptionStore, bus *mess
 		logger = slog.Default()
 	}
 	return &SubscriptionPoller{
-		manager: manager,
-		store:   store,
-		bus:     bus,
-		logger:  logger,
+		manager:      manager,
+		store:        store,
+		bus:          bus,
+		logger:       logger,
+		checkoutSync: mirrorSubscriptionCheckoutSyncer{logger: logger}.Sync,
 	}
 }
 
@@ -186,6 +188,19 @@ func (p *SubscriptionPoller) checkSubscription(ctx context.Context, sub ProjectS
 		}
 	}
 
+	if strings.TrimSpace(sub.CheckoutPath) != "" {
+		checkoutSync := p.checkoutSync
+		if checkoutSync == nil {
+			checkoutSync = mirrorSubscriptionCheckoutSyncer{logger: p.logger}.Sync
+		}
+		remoteHead, err := checkoutSync(ctx, sub)
+		if err != nil {
+			return sub, nil, 0, 0, fmt.Errorf("sync local checkout: %w", err)
+		}
+		sub.LastSyncedSHA = remoteHead
+		annotateSubscriptionEvents(events, sub)
+	}
+
 	sub.LastChecked = time.Now().UTC()
 	return sub, events, newReleaseCount, newCommitCount, nil
 }
@@ -231,6 +246,9 @@ func (p *SubscriptionPoller) dispatchEvents(ctx context.Context, sub ProjectSubs
 func initialBatchProgress(sub, final ProjectSubscription, events []messages.LoopEventPayload) ProjectSubscription {
 	progress := sub
 	progress.LastChecked = final.LastChecked
+	progress.CheckoutPath = final.CheckoutPath
+	progress.CheckoutRemoteURL = final.CheckoutRemoteURL
+	progress.LastSyncedSHA = final.LastSyncedSHA
 	hasReleaseEvents := false
 	hasCommitEvents := false
 	for _, event := range events {
@@ -400,21 +418,6 @@ func commitEvent(sub ProjectSubscription, commit *Commit) messages.LoopEventPayl
 		ObservedAt: commitTime(commit),
 		Metadata:   metadata,
 	}
-}
-
-func subscriptionMetadata(sub ProjectSubscription) map[string]string {
-	metadata := map[string]string{
-		"subscription_id": sub.ID,
-		"account":         sub.Account,
-		"repo":            sub.Repo,
-	}
-	if sub.Branch != "" {
-		metadata["branch"] = sub.Branch
-	}
-	if sub.Name != "" {
-		metadata["name"] = sub.Name
-	}
-	return metadata
 }
 
 func releaseMarker(release *Release) string {

--- a/internal/integrations/forge/provider.go
+++ b/internal/integrations/forge/provider.go
@@ -17,7 +17,7 @@ type ForgeProvider interface {
 	// --- Repositories ---
 
 	// GetRepository retrieves repository metadata used by subscription
-	// setup, such as the default branch and web URL.
+	// setup, such as the default branch, web URL, and clone URL.
 	GetRepository(ctx context.Context, repo string) (*Repository, error)
 
 	// ListReleases returns recent repository releases, newest first.

--- a/internal/integrations/forge/subscription_events.go
+++ b/internal/integrations/forge/subscription_events.go
@@ -56,9 +56,6 @@ func (s mirrorSubscriptionCheckoutSyncer) Sync(ctx context.Context, sub ProjectS
 	}
 	remoteURL := strings.TrimSpace(sub.CheckoutRemoteURL)
 	if remoteURL == "" {
-		remoteURL = strings.TrimSpace(sub.URL)
-	}
-	if remoteURL == "" {
 		return "", fmt.Errorf("subscription %s has local_checkout=%q but no checkout_remote_url", sub.ID, localCheckout)
 	}
 	branch := strings.TrimSpace(sub.Branch)

--- a/internal/integrations/forge/subscription_events.go
+++ b/internal/integrations/forge/subscription_events.go
@@ -1,0 +1,85 @@
+package forge
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+
+	"github.com/nugget/thane-ai-agent/internal/channels/messages"
+	"github.com/nugget/thane-ai-agent/internal/platform/checkout"
+)
+
+func subscriptionMetadata(sub ProjectSubscription) map[string]string {
+	metadata := map[string]string{
+		"subscription_id": sub.ID,
+		"account":         sub.Account,
+		"repo":            sub.Repo,
+	}
+	if sub.Branch != "" {
+		metadata["branch"] = sub.Branch
+	}
+	if sub.Name != "" {
+		metadata["name"] = sub.Name
+	}
+	if sub.CheckoutPath != "" {
+		metadata["local_checkout"] = sub.CheckoutPath
+	}
+	if sub.LastSyncedSHA != "" {
+		metadata["last_synced_sha"] = sub.LastSyncedSHA
+	}
+	return metadata
+}
+
+func annotateSubscriptionEvents(events []messages.LoopEventPayload, sub ProjectSubscription) {
+	for i := range events {
+		if events[i].Metadata == nil {
+			events[i].Metadata = map[string]string{}
+		}
+		if sub.CheckoutPath != "" {
+			events[i].Metadata["local_checkout"] = sub.CheckoutPath
+		}
+		if sub.LastSyncedSHA != "" {
+			events[i].Metadata["last_synced_sha"] = sub.LastSyncedSHA
+		}
+	}
+}
+
+type mirrorSubscriptionCheckoutSyncer struct {
+	logger *slog.Logger
+}
+
+func (s mirrorSubscriptionCheckoutSyncer) Sync(ctx context.Context, sub ProjectSubscription) (string, error) {
+	localCheckout := strings.TrimSpace(sub.CheckoutPath)
+	if localCheckout == "" {
+		return "", nil
+	}
+	remoteURL := strings.TrimSpace(sub.CheckoutRemoteURL)
+	if remoteURL == "" {
+		remoteURL = strings.TrimSpace(sub.URL)
+	}
+	if remoteURL == "" {
+		return "", fmt.Errorf("subscription %s has local_checkout=%q but no checkout_remote_url", sub.ID, localCheckout)
+	}
+	branch := strings.TrimSpace(sub.Branch)
+	if branch == "" {
+		return "", fmt.Errorf("subscription %s has local_checkout=%q but no branch", sub.ID, localCheckout)
+	}
+
+	mirror, err := checkout.OpenMirror(checkout.MirrorSpec{
+		Name:         "forge subscription " + sub.ID,
+		WorktreePath: localCheckout,
+		Logger:       s.logger,
+	})
+	if err != nil {
+		return "", err
+	}
+	result, err := mirror.Sync(ctx, checkout.MirrorSyncRequest{
+		RemoteURL: remoteURL,
+		Branch:    branch,
+	})
+	if err != nil {
+		return "", err
+	}
+	return result.RemoteHead, nil
+}

--- a/internal/integrations/forge/subscriptions.go
+++ b/internal/integrations/forge/subscriptions.go
@@ -21,21 +21,24 @@ const (
 // ProjectSubscription tracks releases and/or commits for one repository and
 // delivers new events to an existing loop.
 type ProjectSubscription struct {
-	ID            string                  `json:"subscription_id"`
-	Account       string                  `json:"account"`
-	Repo          string                  `json:"repo"`
-	Name          string                  `json:"name"`
-	URL           string                  `json:"url,omitempty"`
-	Branch        string                  `json:"branch,omitempty"`
-	TrackReleases bool                    `json:"track_releases"`
-	TrackCommits  bool                    `json:"track_commits"`
-	WakeTarget    messages.LoopWakeTarget `json:"wake_loop"`
-	LastRelease   string                  `json:"last_release,omitempty"`
-	LastCommit    string                  `json:"last_commit,omitempty"`
-	LatestRelease string                  `json:"latest_release,omitempty"`
-	LatestCommit  string                  `json:"latest_commit,omitempty"`
-	LastChecked   time.Time               `json:"last_checked,omitempty"`
-	CreatedAt     time.Time               `json:"created_at"`
+	ID                string                  `json:"subscription_id"`
+	Account           string                  `json:"account"`
+	Repo              string                  `json:"repo"`
+	Name              string                  `json:"name"`
+	URL               string                  `json:"url,omitempty"`
+	Branch            string                  `json:"branch,omitempty"`
+	CheckoutPath      string                  `json:"local_checkout,omitempty"`
+	CheckoutRemoteURL string                  `json:"checkout_remote_url,omitempty"`
+	TrackReleases     bool                    `json:"track_releases"`
+	TrackCommits      bool                    `json:"track_commits"`
+	WakeTarget        messages.LoopWakeTarget `json:"wake_loop"`
+	LastRelease       string                  `json:"last_release,omitempty"`
+	LastCommit        string                  `json:"last_commit,omitempty"`
+	LatestRelease     string                  `json:"latest_release,omitempty"`
+	LatestCommit      string                  `json:"latest_commit,omitempty"`
+	LastSyncedSHA     string                  `json:"last_synced_sha,omitempty"`
+	LastChecked       time.Time               `json:"last_checked,omitempty"`
+	CreatedAt         time.Time               `json:"created_at"`
 }
 
 // SubscriptionStore persists forge project subscriptions in opstate.

--- a/internal/integrations/forge/subscriptions_checkout_test.go
+++ b/internal/integrations/forge/subscriptions_checkout_test.go
@@ -1,0 +1,223 @@
+package forge
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/nugget/thane-ai-agent/internal/channels/messages"
+)
+
+func TestHandleRepoFollowStoresLocalCheckout(t *testing.T) {
+	t.Parallel()
+
+	store := newTestSubscriptionStore(t)
+	checkoutPath := t.TempDir()
+	provider := &mockProvider{
+		name: "test",
+		getRepositoryResult: &Repository{
+			FullName:      "owner/repo",
+			DefaultBranch: "main",
+			URL:           "https://github.com/owner/repo",
+			CloneURL:      "https://github.com/owner/repo.git",
+		},
+		listCommitsResult: []*Commit{{
+			SHA:     "abcdef123",
+			Message: "initial commit",
+			Author:  "Dev",
+			Date:    time.Now(),
+			URL:     "https://github.com/owner/repo/commit/abcdef123",
+		}},
+	}
+	tools := newTestTools(provider, "owner")
+	tools.subscriptions = store
+
+	raw, err := tools.HandleRepoFollow(context.Background(), map[string]any{
+		"repo":           "repo",
+		"track_releases": false,
+		"track_commits":  true,
+		"local_checkout": checkoutPath,
+		"wake_loop":      map[string]any{"name": "repo_curator"},
+	})
+	if err != nil {
+		t.Fatalf("HandleRepoFollow: %v", err)
+	}
+	var follow repoFollowResponse
+	if err := json.Unmarshal([]byte(raw), &follow); err != nil {
+		t.Fatalf("decode follow response: %v", err)
+	}
+	if follow.LocalCheckout != checkoutPath {
+		t.Fatalf("response local_checkout = %q, want %q", follow.LocalCheckout, checkoutPath)
+	}
+
+	subs, err := store.List()
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(subs) != 1 {
+		t.Fatalf("subscriptions len = %d, want 1", len(subs))
+	}
+	if subs[0].CheckoutPath != checkoutPath {
+		t.Fatalf("CheckoutPath = %q, want %q", subs[0].CheckoutPath, checkoutPath)
+	}
+	if subs[0].CheckoutRemoteURL != "https://github.com/owner/repo.git" {
+		t.Fatalf("CheckoutRemoteURL = %q, want clone URL", subs[0].CheckoutRemoteURL)
+	}
+
+	raw, err = tools.HandleRepoSubscriptions(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("HandleRepoSubscriptions: %v", err)
+	}
+	var list repoSubscriptionsResponse
+	if err := json.Unmarshal([]byte(raw), &list); err != nil {
+		t.Fatalf("decode subscriptions response: %v", err)
+	}
+	if len(list.Subscriptions) != 1 || list.Subscriptions[0].LocalCheckout != checkoutPath {
+		t.Fatalf("list local_checkout = %+v, want %q", list.Subscriptions, checkoutPath)
+	}
+
+	raw, err = tools.HandleRepoUnfollow(context.Background(), map[string]any{
+		"subscription_id": follow.SubscriptionID,
+	})
+	if err != nil {
+		t.Fatalf("HandleRepoUnfollow: %v", err)
+	}
+	var unfollow repoUnfollowResponse
+	if err := json.Unmarshal([]byte(raw), &unfollow); err != nil {
+		t.Fatalf("decode unfollow response: %v", err)
+	}
+	if unfollow.LocalCheckout != checkoutPath || !unfollow.CheckoutRetained {
+		t.Fatalf("unfollow checkout response = %+v, want retained %q", unfollow, checkoutPath)
+	}
+}
+
+func TestSubscriptionStoreLocalCheckoutRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	store := newTestSubscriptionStore(t)
+	now := time.Now().UTC()
+	sub := ProjectSubscription{
+		ID:                "sub",
+		Account:           "test",
+		Repo:              "owner/repo",
+		Name:              "owner/repo",
+		Branch:            "main",
+		CheckoutPath:      t.TempDir(),
+		CheckoutRemoteURL: "https://github.com/owner/repo.git",
+		TrackCommits:      true,
+		WakeTarget:        messages.LoopWakeTarget{Name: "repo_curator"},
+		LastSyncedSHA:     "abc123",
+		CreatedAt:         now,
+	}
+	if err := store.Add(sub); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+
+	got, err := store.Get("sub")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.CheckoutPath != sub.CheckoutPath || got.CheckoutRemoteURL != sub.CheckoutRemoteURL || got.LastSyncedSHA != sub.LastSyncedSHA {
+		t.Fatalf("checkout fields = path:%q remote:%q sha:%q, want path:%q remote:%q sha:%q",
+			got.CheckoutPath, got.CheckoutRemoteURL, got.LastSyncedSHA,
+			sub.CheckoutPath, sub.CheckoutRemoteURL, sub.LastSyncedSHA,
+		)
+	}
+}
+
+func TestSubscriptionPollerSyncsLocalCheckoutBeforeWake(t *testing.T) {
+	t.Parallel()
+
+	store := newTestSubscriptionStore(t)
+	now := time.Now().UTC()
+	sub := ProjectSubscription{
+		ID:                "sub",
+		Account:           "test",
+		Repo:              "owner/repo",
+		Name:              "owner/repo",
+		Branch:            "main",
+		CheckoutPath:      t.TempDir(),
+		CheckoutRemoteURL: "https://github.com/owner/repo.git",
+		TrackCommits:      true,
+		WakeTarget:        messages.LoopWakeTarget{Name: "repo_curator"},
+		LastCommit:        "oldsha",
+		LastChecked:       now.Add(-2 * time.Hour),
+		CreatedAt:         now.Add(-24 * time.Hour),
+	}
+	if err := store.Add(sub); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+
+	provider := &mockProvider{
+		name: "test",
+		listCommitsResult: []*Commit{
+			{SHA: "newsha", Message: "add feature", Author: "Dev", Date: now.Add(-30 * time.Minute), URL: "https://commit"},
+			{SHA: "oldsha", Message: "old feature", Author: "Dev", Date: now.Add(-3 * time.Hour), URL: "https://old-commit"},
+		},
+	}
+	mgr := &Manager{
+		providers: map[string]ForgeProvider{"test": provider},
+		configs:   map[string]AccountConfig{"test": {Name: "test", Owner: "owner"}},
+		order:     []string{"test"},
+		logger:    slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+
+	syncer := &recordingSubscriptionCheckoutSyncer{sha: "syncedsha"}
+	var delivered messages.Envelope
+	bus := messages.NewBus(slog.New(slog.NewTextHandler(io.Discard, nil)))
+	bus.RegisterRoute(messages.DestinationLoop, func(_ context.Context, env messages.Envelope) (messages.DeliveryResult, error) {
+		delivered = env
+		return messages.DeliveryResult{Route: "test", Status: messages.DeliveryDelivered}, nil
+	})
+
+	poller := NewSubscriptionPoller(mgr, store, bus, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	poller.checkoutSync = syncer.Sync
+	count, err := poller.CheckSubscriptions(context.Background())
+	if err != nil {
+		t.Fatalf("CheckSubscriptions: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("event count = %d, want 1", count)
+	}
+	if len(syncer.calls) != 1 {
+		t.Fatalf("checkout sync calls = %d, want 1", len(syncer.calls))
+	}
+	if syncer.calls[0].CheckoutPath != sub.CheckoutPath || syncer.calls[0].CheckoutRemoteURL != sub.CheckoutRemoteURL {
+		t.Fatalf("checkout sync subscription = %+v, want path %q remote %q", syncer.calls[0], sub.CheckoutPath, sub.CheckoutRemoteURL)
+	}
+	payload, ok := delivered.Payload.(messages.LoopNotifyPayload)
+	if !ok {
+		t.Fatalf("payload type = %T, want LoopNotifyPayload", delivered.Payload)
+	}
+	if got := payload.Events[0].Metadata["local_checkout"]; got != sub.CheckoutPath {
+		t.Fatalf("event local_checkout = %q, want %q", got, sub.CheckoutPath)
+	}
+	if got := payload.Events[0].Metadata["last_synced_sha"]; got != "syncedsha" {
+		t.Fatalf("event last_synced_sha = %q, want syncedsha", got)
+	}
+
+	subs, err := store.List()
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(subs) != 1 {
+		t.Fatalf("subscriptions len = %d, want 1", len(subs))
+	}
+	if subs[0].LastSyncedSHA != "syncedsha" {
+		t.Fatalf("LastSyncedSHA = %q, want syncedsha", subs[0].LastSyncedSHA)
+	}
+}
+
+type recordingSubscriptionCheckoutSyncer struct {
+	sha   string
+	err   error
+	calls []ProjectSubscription
+}
+
+func (s *recordingSubscriptionCheckoutSyncer) Sync(_ context.Context, sub ProjectSubscription) (string, error) {
+	s.calls = append(s.calls, sub)
+	return s.sha, s.err
+}

--- a/internal/integrations/forge/subscriptions_checkout_test.go
+++ b/internal/integrations/forge/subscriptions_checkout_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"io"
 	"log/slog"
+	"strings"
 	"testing"
 	"time"
 
@@ -125,6 +126,56 @@ func TestSubscriptionStoreLocalCheckoutRoundTrip(t *testing.T) {
 			got.CheckoutPath, got.CheckoutRemoteURL, got.LastSyncedSHA,
 			sub.CheckoutPath, sub.CheckoutRemoteURL, sub.LastSyncedSHA,
 		)
+	}
+}
+
+func TestHandleRepoFollowRejectsLocalCheckoutWithoutCloneURL(t *testing.T) {
+	t.Parallel()
+
+	store := newTestSubscriptionStore(t)
+	provider := &mockProvider{
+		name: "test",
+		getRepositoryResult: &Repository{
+			FullName:      "owner/repo",
+			DefaultBranch: "main",
+			URL:           "https://github.com/owner/repo",
+		},
+		listCommitsResult: []*Commit{{SHA: "abcdef123", Date: time.Now()}},
+	}
+	tools := newTestTools(provider, "owner")
+	tools.subscriptions = store
+
+	_, err := tools.HandleRepoFollow(context.Background(), map[string]any{
+		"repo":           "repo",
+		"track_releases": false,
+		"track_commits":  true,
+		"local_checkout": t.TempDir(),
+		"wake_loop":      map[string]any{"name": "repo_curator"},
+	})
+	if err == nil {
+		t.Fatal("expected local_checkout without clone URL to fail")
+	}
+	if !strings.Contains(err.Error(), "requires a clone URL") {
+		t.Fatalf("error = %q, want clone URL guidance", err)
+	}
+}
+
+func TestSubscriptionCheckoutSyncRequiresRemoteURL(t *testing.T) {
+	t.Parallel()
+
+	syncer := mirrorSubscriptionCheckoutSyncer{logger: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	_, err := syncer.Sync(context.Background(), ProjectSubscription{
+		ID:           "sub",
+		Repo:         "owner/repo",
+		Branch:       "main",
+		URL:          "https://github.com/owner/repo",
+		CheckoutPath: t.TempDir(),
+	})
+	if err == nil {
+		t.Fatal("expected missing checkout_remote_url to fail")
+	}
+	if !strings.Contains(err.Error(), "no checkout_remote_url") {
+		t.Fatalf("error = %q, want checkout_remote_url guidance", err)
 	}
 }
 

--- a/internal/integrations/forge/tools_subscriptions.go
+++ b/internal/integrations/forge/tools_subscriptions.go
@@ -3,10 +3,12 @@ package forge
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/nugget/thane-ai-agent/internal/channels/messages"
 	"github.com/nugget/thane-ai-agent/internal/model/promptfmt"
+	"github.com/nugget/thane-ai-agent/internal/platform/checkout"
 )
 
 type repoFollowResponse struct {
@@ -19,8 +21,10 @@ type repoFollowResponse struct {
 	TrackReleases  bool                    `json:"track_releases"`
 	TrackCommits   bool                    `json:"track_commits"`
 	WakeLoop       messages.LoopWakeTarget `json:"wake_loop"`
+	LocalCheckout  string                  `json:"local_checkout,omitempty"`
 	LatestRelease  string                  `json:"latest_release,omitempty"`
 	LatestCommit   string                  `json:"latest_commit,omitempty"`
+	LastSyncedSHA  string                  `json:"last_synced_sha,omitempty"`
 }
 
 type repoSubscriptionEntry struct {
@@ -33,8 +37,10 @@ type repoSubscriptionEntry struct {
 	TrackReleases  bool                    `json:"track_releases"`
 	TrackCommits   bool                    `json:"track_commits"`
 	WakeLoop       messages.LoopWakeTarget `json:"wake_loop"`
+	LocalCheckout  string                  `json:"local_checkout,omitempty"`
 	LatestRelease  string                  `json:"latest_release,omitempty"`
 	LatestCommit   string                  `json:"latest_commit,omitempty"`
+	LastSyncedSHA  string                  `json:"last_synced_sha,omitempty"`
 	LastChecked    string                  `json:"last_checked,omitempty"`
 	Created        string                  `json:"created,omitempty"`
 }
@@ -45,8 +51,10 @@ type repoSubscriptionsResponse struct {
 }
 
 type repoUnfollowResponse struct {
-	Action         string `json:"action"`
-	SubscriptionID string `json:"subscription_id"`
+	Action           string `json:"action"`
+	SubscriptionID   string `json:"subscription_id"`
+	LocalCheckout    string `json:"local_checkout,omitempty"`
+	CheckoutRetained bool   `json:"checkout_retained,omitempty"`
 }
 
 // HandleRepoFollow follows a repository and wakes an existing loop when new
@@ -80,9 +88,30 @@ func (t *Tools) HandleRepoFollow(ctx context.Context, args map[string]any) (stri
 		return "", fmt.Errorf("repository %s not found", repo)
 	}
 
-	branch := stringArg(args, "branch")
+	branch := strings.TrimSpace(stringArg(args, "branch"))
 	if branch == "" {
 		branch = meta.DefaultBranch
+	}
+	localCheckout := strings.TrimSpace(stringArg(args, "local_checkout"))
+	checkoutRemoteURL := ""
+	subscriptionID := SubscriptionID(acct, repo, branch, wakeTarget)
+	if localCheckout != "" {
+		if branch == "" {
+			return "", fmt.Errorf("local_checkout requires branch because repository %s has no default branch; set branch", repo)
+		}
+		checkoutRemoteURL = repositoryCheckoutRemoteURL(meta)
+		if checkoutRemoteURL == "" {
+			return "", fmt.Errorf("local_checkout requires a clone URL for repository %s", repo)
+		}
+		mirror, err := checkout.OpenMirror(checkout.MirrorSpec{
+			Name:         "forge subscription " + subscriptionID,
+			WorktreePath: localCheckout,
+			Logger:       t.logger,
+		})
+		if err != nil {
+			return "", err
+		}
+		localCheckout = mirror.WorktreePath
 	}
 	trackReleases := boolArg(args, "track_releases", true)
 	trackCommits := boolArg(args, "track_commits", true)
@@ -97,17 +126,19 @@ func (t *Tools) HandleRepoFollow(ctx context.Context, args map[string]any) (stri
 
 	now := time.Now().UTC()
 	sub := ProjectSubscription{
-		ID:            SubscriptionID(acct, repo, branch, wakeTarget),
-		Account:       acct,
-		Repo:          repo,
-		Name:          name,
-		URL:           meta.URL,
-		Branch:        branch,
-		TrackReleases: trackReleases,
-		TrackCommits:  trackCommits,
-		WakeTarget:    wakeTarget,
-		LastChecked:   now,
-		CreatedAt:     now,
+		ID:                subscriptionID,
+		Account:           acct,
+		Repo:              repo,
+		Name:              name,
+		URL:               meta.URL,
+		Branch:            branch,
+		CheckoutPath:      localCheckout,
+		CheckoutRemoteURL: checkoutRemoteURL,
+		TrackReleases:     trackReleases,
+		TrackCommits:      trackCommits,
+		WakeTarget:        wakeTarget,
+		LastChecked:       now,
+		CreatedAt:         now,
 	}
 
 	if trackReleases {
@@ -146,8 +177,10 @@ func (t *Tools) HandleRepoFollow(ctx context.Context, args map[string]any) (stri
 		TrackReleases:  sub.TrackReleases,
 		TrackCommits:   sub.TrackCommits,
 		WakeLoop:       sub.WakeTarget,
+		LocalCheckout:  sub.CheckoutPath,
 		LatestRelease:  sub.LatestRelease,
 		LatestCommit:   sub.LatestCommit,
+		LastSyncedSHA:  sub.LastSyncedSHA,
 	})
 }
 
@@ -160,12 +193,18 @@ func (t *Tools) HandleRepoUnfollow(_ context.Context, args map[string]any) (stri
 	if id == "" {
 		return "", fmt.Errorf("subscription_id is required")
 	}
+	sub, err := t.subscriptions.Get(id)
+	if err != nil {
+		return "", err
+	}
 	if err := t.subscriptions.Remove(id); err != nil {
 		return "", err
 	}
 	return marshalResponse(repoUnfollowResponse{
-		Action:         "unfollowed",
-		SubscriptionID: id,
+		Action:           "unfollowed",
+		SubscriptionID:   id,
+		LocalCheckout:    sub.CheckoutPath,
+		CheckoutRetained: sub.CheckoutPath != "",
 	})
 }
 
@@ -192,8 +231,10 @@ func (t *Tools) HandleRepoSubscriptions(_ context.Context, _ map[string]any) (st
 			TrackReleases:  sub.TrackReleases,
 			TrackCommits:   sub.TrackCommits,
 			WakeLoop:       sub.WakeTarget,
+			LocalCheckout:  sub.CheckoutPath,
 			LatestRelease:  sub.LatestRelease,
 			LatestCommit:   sub.LatestCommit,
+			LastSyncedSHA:  sub.LastSyncedSHA,
 		}
 		if !sub.LastChecked.IsZero() {
 			entry.LastChecked = promptfmt.FormatDeltaOnly(sub.LastChecked, now)
@@ -220,4 +261,11 @@ func boolArg(args map[string]any, key string, fallback bool) bool {
 		return fallback
 	}
 	return b
+}
+
+func repositoryCheckoutRemoteURL(meta *Repository) string {
+	if meta == nil {
+		return ""
+	}
+	return firstNonEmpty(meta.CloneURL, meta.URL)
 }

--- a/internal/integrations/forge/tools_subscriptions.go
+++ b/internal/integrations/forge/tools_subscriptions.go
@@ -267,5 +267,5 @@ func repositoryCheckoutRemoteURL(meta *Repository) string {
 	if meta == nil {
 		return ""
 	}
-	return firstNonEmpty(meta.CloneURL, meta.URL)
+	return strings.TrimSpace(meta.CloneURL)
 }

--- a/internal/integrations/forge/types.go
+++ b/internal/integrations/forge/types.go
@@ -22,6 +22,8 @@ type Repository struct {
 	DefaultBranch string
 	// URL is the web URL for the repository.
 	URL string
+	// CloneURL is the git transport URL for cloning or fetching.
+	CloneURL string
 }
 
 // Release represents a repository release.

--- a/internal/tools/forge_subscription_tools.go
+++ b/internal/tools/forge_subscription_tools.go
@@ -44,7 +44,7 @@ func (r *Registry) registerForgeSubscriptionTools() {
 				},
 				"local_checkout": map[string]any{
 					"type":        "string",
-					"description": "Optional absolute or working-directory-relative path to keep as a read-only mirror checkout. The subscription poller syncs this path before waking the loop and leaves it on disk when unfollowed.",
+					"description": "Optional absolute or working-directory-relative path to keep as a read-only mirror checkout. The path must be empty or an existing Thane-owned mirror checkout; non-empty directories and unmarked git checkouts are refused. The subscription poller syncs this path before waking the loop and leaves it on disk when unfollowed.",
 				},
 				"wake_loop": forgeWakeLoopDefinition(),
 			},

--- a/internal/tools/forge_subscription_tools.go
+++ b/internal/tools/forge_subscription_tools.go
@@ -42,6 +42,10 @@ func (r *Registry) registerForgeSubscriptionTools() {
 					"type":        "boolean",
 					"description": "Whether to report new commits on branch/ref. Defaults to true.",
 				},
+				"local_checkout": map[string]any{
+					"type":        "string",
+					"description": "Optional absolute or working-directory-relative path to keep as a read-only mirror checkout. The subscription poller syncs this path before waking the loop and leaves it on disk when unfollowed.",
+				},
 				"wake_loop": forgeWakeLoopDefinition(),
 			},
 			"required": []string{"repo", "wake_loop"},


### PR DESCRIPTION
## Summary

This picks up the next checkout-abstraction slice by making forge repository subscriptions a real consumer of the shared mirror path. `forge_repo_follow` can now accept `local_checkout`, store the normalized checkout path and provider clone URL with the subscription, and surface that path back through follow/list/unfollow responses.

On each poll, the subscription poller now syncs the checkout through `internal/platform/checkout.Mirror` before it wakes the target loop. That keeps the git fetch/reset/scrub behavior on the shared checkout rail instead of growing a forge-specific implementation, and it means repository event wakes can tell the receiving loop exactly which local checkout was refreshed and which SHA it now reflects. Unfollowing is deliberately non-destructive: the subscription record is removed, and the response says the checkout was retained on disk.

Refs #1032
Refs #1155

## Test Plan

- [x] `just ci` passes locally
- [x] New/changed behavior has test coverage
- [x] Manual verification: checked architecture metrics after the helper split and verified the commit signature with `git log -1 --show-signature --format=fuller`

## Checklist

- [x] Commits are signed
- [x] Commit messages use conventional format (`feat:`, `fix:`, etc.)
- [x] Related issue referenced (`Refs #NNN` or `Closes #NNN`)
- [x] Impacted documentation updated (`docs/`, `AGENTS.md`, config examples, CLI help)
- [x] No new third-party dependencies without discussion
