### PR TITLE
docs: explain forge checkout root access

### DIFF
--- a/docs/operating/configuration.md
+++ b/docs/operating/configuration.md
@@ -202,6 +202,10 @@ roots:
     path: ~/Thane/scratchpad
     indexing: false
     authoring: managed
+  thanecode:
+    path: ~/Thane/checkouts/thane
+    indexing: false
+    authoring: read_only
 ```
 
 Each entry under `roots:` names one local collection Thane keeps track
@@ -225,6 +229,28 @@ roots:
 is the default and allows document tools and loop-declared output tools
 to write the root. `read_only` blocks managed writes. `restricted`
 reserves the root for narrower future flows.
+
+Code checkouts that are maintained by forge subscriptions are good
+read-only roots. Point `forge_repo_follow.local_checkout` at the same
+path, set `indexing: false` because source trees are not markdown
+corpora, and use file tools such as `file_read`, `file_search`, and
+`file_grep` with the root prefix:
+
+```yaml
+workspace:
+  path: ~/Thane
+
+roots:
+  thanecode:
+    path: ~/Thane/checkouts/thane
+    indexing: false
+    authoring: read_only
+```
+
+With that configuration, `thanecode:internal/app/new.go` resolves to the
+maintained checkout. Keep checkout roots under `workspace.path`; if a
+read-only root must live elsewhere, also include that directory in
+`workspace.read_only_dirs` so raw file tools can traverse it.
 
 `git.sign_commits` turns each managed document write/delete into a
 signed git commit. By default the root itself is the repository; set

--- a/docs/reference/event-sources.md
+++ b/docs/reference/event-sources.md
@@ -112,3 +112,8 @@ receiving `thane_loop_create` or other `thane_` loop remains the owner of durabl
 documents and corpus conventions. When a local checkout is configured,
 event metadata includes `local_checkout` and `last_synced_sha`, and
 unfollowing the subscription leaves the checkout on disk.
+
+To make the checkout easy for the receiving loop to read, declare the
+same path as a read-only root such as `thanecode:` with `indexing: false`.
+The loop can then use `file_read`, `file_search`, and `file_grep` against
+that prefix while the subscription keeps the worktree current.

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -159,6 +159,9 @@ Managed document roots (`core:`, `kb:`, `generated:`, `scratchpad:`,
 custom prefixes) are browsed through these tools rather than via raw
 filesystem access. See
 [Document Roots](../understanding/document-roots.md).
+For source-code checkouts, configure a read-only root with
+`indexing: false` and use the `file_*` tools against that prefix; the
+document index is markdown-oriented.
 
 `doc_roots` includes each root's policy summary: indexing status,
 authoring mode, git/signature expectations, and current verification
@@ -251,7 +254,12 @@ Owner channel activity recency is reported with delta fields such as
 | `file_tree` | Render a directory tree. |
 | `create_temp_file` | Create a temp file with a labelled path. |
 
-`file_stat` reports modification recency as `modified_delta`.
+File tools resolve configured root prefixes such as `kb:` or
+`thanecode:` before applying the workspace sandbox. A forge-maintained
+checkout is searchable through these tools when its `local_checkout` path
+is also declared as a read-only root under `workspace.path` or included
+in `workspace.read_only_dirs`. `file_stat` reports modification recency
+as `modified_delta`.
 
 ## `shell` — host command execution
 

--- a/docs/understanding/document-roots.md
+++ b/docs/understanding/document-roots.md
@@ -115,6 +115,28 @@ Policy is deliberately attached to the root, not to individual tools or
 prompts. A loop-declared output, a direct document write, and the
 corpus-aware intake flow should all meet the same root contract.
 
+Source checkouts can also be named roots, even though they are not
+document corpora. For a forge-maintained local checkout, use a read-only
+root with indexing disabled:
+
+```yaml
+workspace:
+  path: ~/Thane
+
+roots:
+  thanecode:
+    path: ~/Thane/checkouts/thane
+    indexing: false
+    authoring: read_only
+```
+
+Point `forge_repo_follow.local_checkout` at the same path. The `doc_*`
+tools will not browse or search that source tree when `indexing: false`,
+but raw file tools resolve the prefix: `file_read` can read
+`thanecode:go.mod`, while `file_search` and `file_grep` can traverse the
+checkout. Keep these roots under `workspace.path`, or add their directory
+to `workspace.read_only_dirs` if they live elsewhere.
+
 The current policy fields are:
 
 - `indexing`: set `false` when a root may be written/read by exact ref

--- a/internal/tools/file_tools_test.go
+++ b/internal/tools/file_tools_test.go
@@ -1028,6 +1028,53 @@ func TestResolvePath_KBPrefix_ReadViaFileRead(t *testing.T) {
 	}
 }
 
+func TestFileTools_CodeRootPrefixReadSearchAndGrep(t *testing.T) {
+	workspace, err := os.MkdirTemp("", "thane-file-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(workspace)
+
+	codeRoot := filepath.Join(workspace, "checkouts", "thane")
+	sourceDir := filepath.Join(codeRoot, "internal", "tools")
+	if err := os.MkdirAll(sourceDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	sourcePath := filepath.Join(sourceDir, "file_tools.go")
+	source := "package tools\n\nfunc NewFileTools() {}\n"
+	if err := os.WriteFile(sourcePath, []byte(source), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	ft := NewFileTools(workspace, nil)
+	ft.SetResolver(paths.New(map[string]string{"thanecode": codeRoot}))
+	ctx := context.Background()
+
+	content, err := ft.Read(ctx, "thanecode:internal/tools/file_tools.go", 0, 0)
+	if err != nil {
+		t.Fatalf("Read(thanecode:internal/tools/file_tools.go): %v", err)
+	}
+	if !strings.Contains(content, "func NewFileTools") {
+		t.Fatalf("read content = %q, want source file content", content)
+	}
+
+	found, err := ft.Search(ctx, "thanecode:", "*.go", 5)
+	if err != nil {
+		t.Fatalf("Search(thanecode:, *.go): %v", err)
+	}
+	if !strings.Contains(found, filepath.Join("checkouts", "thane", "internal", "tools", "file_tools.go")) {
+		t.Fatalf("search result = %q, want code root file", found)
+	}
+
+	grep, err := ft.Grep(ctx, "thanecode:", "NewFileTools", 5, false)
+	if err != nil {
+		t.Fatalf("Grep(thanecode:, NewFileTools): %v", err)
+	}
+	if !strings.Contains(grep, "file_tools.go:3:func NewFileTools() {}") {
+		t.Fatalf("grep result = %q, want matching source line", grep)
+	}
+}
+
 func TestResolvePath_MultiplePrefixes(t *testing.T) {
 	workspace, err := os.MkdirTemp("", "thane-file-test-*")
 	if err != nil {


### PR DESCRIPTION
## Summary

This closes the last practical gap in #1032: after #1161 taught forge subscriptions to maintain a local mirror checkout, the remaining question was how a loop should reliably read that code tree. This PR makes that path explicit instead of relying on tribal knowledge.

The docs now show the intended shape: point `forge_repo_follow.local_checkout` at a path under `workspace.path`, declare the same path as a read-only root such as `thanecode:`, disable document indexing for that source tree, and use the raw file tools for code navigation. That keeps document roots focused on markdown corpora while still giving loops stable, named access to a maintained checkout through `file_read`, `file_search`, and `file_grep`.

There is also a regression test for the access contract. It creates a code-like checkout root, resolves it through a `thanecode:` prefix, then verifies read, filename search, and grep all work through the file-tool surface.

Closes #1032
Refs #1155

## Test Plan

- [x] `just ci` passes locally
- [x] New/changed behavior has test coverage
- [x] Manual verification: checked the commit signature with `git log -1 --show-signature --format=fuller`

## Checklist

- [x] Commits are signed
- [x] Commit messages use conventional format (`feat:`, `fix:`, etc.)
- [x] Related issue referenced (`Refs #NNN` or `Closes #NNN`)
- [x] Impacted documentation updated (`docs/`, `AGENTS.md`, config examples, CLI help)
- [x] No new third-party dependencies without discussion
