### PR TITLE
refactor: route core bootstrap through checkout

### DIFF
--- a/internal/platform/checkout/signed.go
+++ b/internal/platform/checkout/signed.go
@@ -27,6 +27,10 @@ type SignedSpec struct {
 	SigningKeyPath string
 	// TrustedSigners are operator signing keys added to the repo-local trust set.
 	TrustedSigners []provenance.TrustedSigner
+	// SkipBirthCommit leaves the first commit to the caller. Use this when the
+	// domain needs its own birth commit contents; TrustedSigners must be empty
+	// because trust reconciliation requires an existing signed HEAD.
+	SkipBirthCommit bool
 	// Logger receives setup logs. Nil uses slog.Default.
 	Logger *slog.Logger
 }
@@ -51,6 +55,9 @@ func OpenSigned(ctx context.Context, spec SignedSpec) (*Signed, error) {
 	}
 	if strings.TrimSpace(spec.WorktreePath) == "" {
 		return nil, fmt.Errorf("%s: worktree path is required", name)
+	}
+	if spec.SkipBirthCommit && len(spec.TrustedSigners) > 0 {
+		return nil, fmt.Errorf("%s: trusted signers require a birth commit before reconciliation", name)
 	}
 	signingKey := strings.TrimSpace(spec.SigningKeyPath)
 	if signingKey == "" {
@@ -78,11 +85,13 @@ func OpenSigned(ctx context.Context, spec SignedSpec) (*Signed, error) {
 		return nil, fmt.Errorf("%s: initialize provenance store: %w", name, err)
 	}
 
-	if err := store.BootstrapBirthCommit(ctx); err != nil {
-		return nil, fmt.Errorf("%s: bootstrap birth commit: %w", name, err)
-	}
-	if _, err := store.ReconcileAllowedSigners(ctx, spec.TrustedSigners); err != nil {
-		return nil, fmt.Errorf("%s: reconcile allowed_signers: %w", name, err)
+	if !spec.SkipBirthCommit {
+		if err := store.BootstrapBirthCommit(ctx); err != nil {
+			return nil, fmt.Errorf("%s: bootstrap birth commit: %w", name, err)
+		}
+		if _, err := store.ReconcileAllowedSigners(ctx, spec.TrustedSigners); err != nil {
+			return nil, fmt.Errorf("%s: reconcile allowed_signers: %w", name, err)
+		}
 	}
 
 	logger.Info("signed checkout enabled",

--- a/internal/platform/checkout/signed_test.go
+++ b/internal/platform/checkout/signed_test.go
@@ -1,6 +1,9 @@
 package checkout
 
 import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/pem"
 	"log/slog"
 	"os"
 	"os/exec"
@@ -8,8 +11,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/nugget/thane-ai-agent/internal/platform/identity"
 	"github.com/nugget/thane-ai-agent/internal/platform/provenance"
+	"golang.org/x/crypto/ssh"
 )
 
 func writeSigningKey(t *testing.T, name string) (privPath, pub string) {
@@ -17,16 +20,24 @@ func writeSigningKey(t *testing.T, name string) (privPath, pub string) {
 	if _, err := exec.LookPath("git"); err != nil {
 		t.Skip("git not available")
 	}
-	pair, err := identity.GenerateSigningKeyPair(name)
+	publicKey, privateKey, err := ed25519.GenerateKey(rand.Reader)
 	if err != nil {
-		t.Fatalf("GenerateSigningKeyPair: %v", err)
+		t.Fatalf("generate signing key: %v", err)
+	}
+	sshPub, err := ssh.NewPublicKey(publicKey)
+	if err != nil {
+		t.Fatalf("encode signing public key: %v", err)
+	}
+	block, err := ssh.MarshalPrivateKey(privateKey, name)
+	if err != nil {
+		t.Fatalf("marshal signing private key: %v", err)
 	}
 	dir := t.TempDir()
 	privPath = filepath.Join(dir, "id_ed25519")
-	if err := os.WriteFile(privPath, pair.PrivatePEM, 0o600); err != nil {
+	if err := os.WriteFile(privPath, pem.EncodeToMemory(block), 0o600); err != nil {
 		t.Fatalf("write signing key: %v", err)
 	}
-	return privPath, strings.TrimSpace(pair.Public)
+	return privPath, strings.TrimSpace(string(ssh.MarshalAuthorizedKey(sshPub)))
 }
 
 func TestOpenSignedBootstrapsAndReconciles(t *testing.T) {
@@ -79,6 +90,56 @@ func TestOpenSignedBootstrapsAndReconciles(t *testing.T) {
 	}
 	if _, err := verified.Verifier.VerifyTree(t.Context(), ""); err != nil {
 		t.Fatalf("VerifyTree: %v", err)
+	}
+}
+
+func TestOpenSignedCanLeaveBirthCommitToCaller(t *testing.T) {
+	worktree := t.TempDir()
+	signingKey, _ := writeSigningKey(t, "checkout-test")
+
+	signed, err := OpenSigned(t.Context(), SignedSpec{
+		Name:            "core.identity",
+		WorktreePath:    worktree,
+		SigningKeyPath:  signingKey,
+		SkipBirthCommit: true,
+		Logger:          slog.Default(),
+	})
+	if err != nil {
+		t.Fatalf("OpenSigned: %v", err)
+	}
+	if signed.Store == nil {
+		t.Fatal("Store missing")
+	}
+	if _, err := os.Stat(filepath.Join(worktree, ".allowed_signers")); err != nil {
+		t.Fatalf("expected .allowed_signers: %v", err)
+	}
+
+	cmd := exec.Command("git", "-C", worktree, "rev-parse", "--verify", "HEAD^{commit}")
+	if err := cmd.Run(); err == nil {
+		t.Fatal("HEAD exists after SkipBirthCommit, want caller-owned first commit")
+	}
+}
+
+func TestOpenSignedRejectsDeferredBirthWithTrustedSigners(t *testing.T) {
+	worktree := t.TempDir()
+	signingKey, _ := writeSigningKey(t, "checkout-test")
+	_, operatorPublic := writeSigningKey(t, "operator-test")
+
+	_, err := OpenSigned(t.Context(), SignedSpec{
+		Name:            "core.identity",
+		WorktreePath:    worktree,
+		SigningKeyPath:  signingKey,
+		SkipBirthCommit: true,
+		TrustedSigners: []provenance.TrustedSigner{{
+			Principal: "operator@example.com",
+			PublicKey: operatorPublic,
+		}},
+	})
+	if err == nil {
+		t.Fatal("OpenSigned() error = nil, want trusted signer guard")
+	}
+	if !strings.Contains(err.Error(), "trusted signers require a birth commit") {
+		t.Fatalf("error = %v, want trusted signer guard", err)
 	}
 }
 

--- a/internal/platform/identity/bootstrap.go
+++ b/internal/platform/identity/bootstrap.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/nugget/thane-ai-agent/internal/platform/provenance"
+	"github.com/nugget/thane-ai-agent/internal/platform/checkout"
 	"gopkg.in/yaml.v3"
 )
 
@@ -95,13 +95,15 @@ func BootstrapCore(ctx context.Context, coreDir, instanceName string, logger *sl
 		return nil, err
 	}
 
-	signer, err := provenance.NewSSHSignerFromKey(signing.PrivateKey)
+	signed, err := checkout.OpenSigned(ctx, checkout.SignedSpec{
+		Name:            "core.identity",
+		WorktreePath:    absCoreDir,
+		SigningKeyPath:  filepath.Join(absCoreDir, SigningPrivateKeyFile),
+		SkipBirthCommit: true,
+		Logger:          logger.With("component", "core_identity_checkout"),
+	})
 	if err != nil {
-		return nil, err
-	}
-	store, err := provenance.New(absCoreDir, signer, logger)
-	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("open core identity checkout: %w", err)
 	}
 
 	policy, err := renderCoreConfig(instanceName, now, signing, channelCA)
@@ -109,7 +111,7 @@ func BootstrapCore(ctx context.Context, coreDir, instanceName string, logger *sl
 		return nil, err
 	}
 
-	if err := store.WriteFiles(ctx, map[string]string{
+	if err := signed.Store.WriteFiles(ctx, map[string]string{
 		".gitignore":         coreGitIgnore,
 		".allowed_signers":   fmt.Sprintf("thane@provenance.local %s\n", strings.TrimSpace(signing.Public)),
 		SigningPublicKeyFile: signing.Public,


### PR DESCRIPTION
## Summary

The checkout abstraction now has one small escape hatch for domains that need to own their first commit. Document roots still get the automatic birth commit and allowed-signers reconciliation they already relied on. Core identity bootstrap takes the new deferred path: checkout initializes the signed local repository and trust plumbing, then the identity package writes its own signed birth commit containing `core/config.yaml`, public identity material, `.gitignore`, and `.allowed_signers`.

That folds the last core/provenance-shaped path into the same local-checkout construction layer now used by document roots and forge mirrors, while keeping the public config story domain-owned behind `roots:` and forge subscription config instead of introducing a top-level `checkouts:` block before it earns its keep.

Closes #1155

## Test Plan

- `just test`
- `just ci`