### PR TITLE
fix(context): drop in-prompt verbatim history, curate the older-sessions catalog

### DIFF
--- a/internal/app/new_awareness.go
+++ b/internal/app/new_awareness.go
@@ -65,12 +65,14 @@ func (a *App) initAwareness(s *newState) error {
 	wmProvider := memory.NewWorkingMemoryProvider(a.wmStore, tools.ConversationIDFromContext)
 	a.loop.RegisterAlwaysContextProvider(wmProvider)
 
-	// Message-channel verbatim tail + older-sessions context. Gated on
-	// the message_channel capability tag, asserted by Signal (and
-	// future Matrix/iMessage) inbound bridges. Output sits in CONTINUITY
-	// CONTEXT (uncached) per docs/prompt-caching.md — the delta
-	// timestamps tick every turn so it's intrinsically uncacheable,
-	// but the cached prefix above stays warm.
+	// Message-channel older-sessions catalog. Gated on the
+	// message_channel capability tag, asserted by Signal (and future
+	// Matrix/iMessage) inbound bridges. Verbatim history is NOT
+	// injected here — stored history already reaches the model as
+	// role-native messages (#1160). Output sits in CONTINUITY CONTEXT
+	// (uncached) per docs/prompt-caching.md — the delta timestamps
+	// tick every turn so it's intrinsically uncacheable, but the
+	// cached prefix above stays warm.
 	messageChannelProvider := memory.NewMessageChannelProvider(
 		a.archiveStore,
 		tools.ConversationIDFromContext,

--- a/internal/state/memory/archive.go
+++ b/internal/state/memory/archive.go
@@ -2258,6 +2258,53 @@ func (s *ArchiveStore) ListSessions(conversationID string, limit int) ([]*Sessio
 	return sessions, nil
 }
 
+// ListClosedSessionsEndedBefore returns closed sessions on the given
+// conversation whose ended_at is strictly before cutoff, most recently
+// ended first, with message counts populated. Paginated by limit and
+// offset so callers that filter rows out (e.g. dropping empty
+// sessions) can scan deeper instead of working from a fixed window.
+// Time bounds and ordering go through SQLite's datetime() because
+// stored session timestamps mix RFC3339 local-offset and driver-native
+// forms; raw text comparison would misorder them (#761).
+func (s *ArchiveStore) ListClosedSessionsEndedBefore(conversationID string, cutoff time.Time, limit, offset int) ([]*Session, error) {
+	if limit <= 0 {
+		limit = 50
+	}
+	if offset < 0 {
+		offset = 0
+	}
+
+	rows, err := s.db.Query(`
+		SELECT id, conversation_id, started_at, ended_at, end_reason,
+		       0 AS message_count,
+		       summary, title, tags, metadata, parent_session_id, parent_tool_call_id
+		FROM sessions
+		WHERE conversation_id = ? AND ended_at IS NOT NULL
+		  AND datetime(ended_at) < datetime(?)
+		ORDER BY datetime(ended_at) DESC, datetime(started_at) DESC
+		LIMIT ? OFFSET ?
+	`, conversationID, cutoff.UTC().Format(time.RFC3339Nano), limit, offset)
+	if err != nil {
+		return nil, fmt.Errorf("list closed sessions: %w", err)
+	}
+	defer rows.Close()
+
+	var sessions []*Session
+	for rows.Next() {
+		sess, err := s.scanSessionRow(rows)
+		if err != nil {
+			return nil, err
+		}
+		sessions = append(sessions, sess)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	s.populateMessageCounts(sessions)
+	return sessions, nil
+}
+
 // ListChildSessions returns sessions whose parent_session_id matches
 // the given ID, ordered chronologically. Used by the session inspector
 // to show delegate sub-sessions.

--- a/internal/state/memory/message_channel_provider.go
+++ b/internal/state/memory/message_channel_provider.go
@@ -125,40 +125,47 @@ func (p *MessageChannelProvider) TagContext(ctx context.Context, _ agentctx.Cont
 	return sb.String(), nil
 }
 
+// olderSessionsMaxScan bounds how many candidate rows one turn will
+// examine while filling the catalog. A conversation would need this
+// many consecutive zero-message sessions before the cutoff to starve
+// the catalog; when the ceiling is hit the result is marked as having
+// more, so the drop is never silent.
+const olderSessionsMaxScan = 500
+
 // olderSessions returns closed, non-empty sessions on the given
-// conversation that ended before the cutoff, newest first, capped at
-// SessionsLimit. Active sessions and sessions ending after the cutoff
-// are excluded because their messages are still in the model's working
-// message list; zero-message sessions are excluded as noise. The
-// second return reports whether qualifying sessions were dropped by
-// the limit, so the catalog can mark itself truncated.
+// conversation that ended before the cutoff, most recently ended
+// first, capped at SessionsLimit. Active and in-window sessions are
+// excluded in SQL because their messages are still in the model's
+// working message list; zero-message sessions are filtered here as
+// noise (message counts can live on a separate DB connection, so the
+// filter cannot be pushed into the session query). The second return
+// reports whether qualifying sessions beyond the limit are known or
+// possible, so the catalog can mark itself truncated.
 func (p *MessageChannelProvider) olderSessions(conversationID string, cutoff time.Time) ([]*Session, bool, error) {
-	// Over-fetch so the cutoff and empty-session filters still have
-	// enough candidates to fill the limit. Empty sessions are common
-	// on quiet conversations (session rotation without traffic), so
-	// the buffer is generous. When even the over-fetch is exhausted,
-	// deeper qualifying sessions can go uncounted — acceptable, since
-	// the truncated flag is already set well before that point.
-	sessions, err := p.archive.ListSessions(conversationID, p.cfg.SessionsLimit*8)
-	if err != nil {
-		return nil, false, err
+	pageSize := p.cfg.SessionsLimit * 4
+	if pageSize < 20 {
+		pageSize = 20
 	}
 	out := make([]*Session, 0, p.cfg.SessionsLimit)
-	qualifying := 0
-	for _, s := range sessions {
-		if s.EndedAt == nil {
-			continue
+	for offset := 0; offset < olderSessionsMaxScan; offset += pageSize {
+		page, err := p.archive.ListClosedSessionsEndedBefore(conversationID, cutoff, pageSize, offset)
+		if err != nil {
+			return out, false, err
 		}
-		if !s.EndedAt.Before(cutoff) {
-			continue
-		}
-		if s.MessageCount == 0 {
-			continue
-		}
-		qualifying++
-		if len(out) < p.cfg.SessionsLimit {
+		for _, s := range page {
+			if s.MessageCount == 0 {
+				continue
+			}
+			if len(out) >= p.cfg.SessionsLimit {
+				// One qualifying session beyond the limit proves
+				// the catalog is a window.
+				return out, true, nil
+			}
 			out = append(out, s)
 		}
+		if len(page) < pageSize {
+			return out, false, nil
+		}
 	}
-	return out, qualifying > len(out), nil
+	return out, true, nil
 }

--- a/internal/state/memory/message_channel_provider.go
+++ b/internal/state/memory/message_channel_provider.go
@@ -9,57 +9,42 @@ import (
 	"github.com/nugget/thane-ai-agent/internal/runtime/agentctx"
 )
 
-// MessageChannelProviderConfig configures the verbatim-tail + older-
-// sessions context provider for message-channel conversations (Signal,
-// Matrix, iMessage). Zero values fall back to defaults.
+// MessageChannelProviderConfig configures the older-sessions catalog
+// provider for message-channel conversations (Signal, Matrix, iMessage).
+// Zero values fall back to defaults.
 type MessageChannelProviderConfig struct {
-	// TailWindow is the time bound on the verbatim tail. Default: 30m.
-	TailWindow time.Duration
+	// RecentWindow excludes sessions that ended within this duration
+	// of now. Their messages are still present in the model's
+	// role-native working message list, so cataloging them would
+	// restate context the model already sees. Default: 30m.
+	RecentWindow time.Duration
 
-	// TailMinMessages is the floor: at least this many of the most
-	// recent archived messages on the conversation are returned even
-	// if the time window is empty. Default: 50.
-	TailMinMessages int
+	// SessionsLimit caps the number of session entries listed in the
+	// catalog block. Default: 5.
+	SessionsLimit int
 
-	// TailMaxMessages caps the verbatim tail before byte-cap fitting.
-	// Default: 200.
-	TailMaxMessages int
-
-	// TailByteCap is the JSON output ceiling for the verbatim tail.
-	// Default: 32000.
-	TailByteCap int
-
-	// OlderSessionsLimit caps the number of older-session entries
-	// listed in the catalog block. Default: 20.
-	OlderSessionsLimit int
-
-	// OlderSessionsByteCap is the JSON output ceiling for the older-
-	// sessions catalog. Default: 16000.
-	OlderSessionsByteCap int
+	// SessionsByteCap is the JSON output ceiling for the catalog.
+	// Default: 8000.
+	SessionsByteCap int
 }
 
-// MessageChannelProvider injects two context blocks into the system
-// prompt for message-channel conversations:
+// MessageChannelProvider injects an "Older Sessions" context block for
+// message-channel conversations: a compact JSON catalog of recent
+// closed sessions with substance, acting as enticement to call
+// archive_session_transcript or archive_search for fuller content.
 //
-//   - "Recent Conversation" — verbatim tail of recent archived messages
-//     (last [TailWindow] OR floor of [TailMinMessages] of the most
-//     recent, whichever yields more, capped at [TailMaxMessages] and
-//     [TailByteCap]). Crosses session boundaries. Excludes the active
-//     session's currently in-memory rows so the model does not see
-//     them twice (once in its working message list, again here).
-//
-//   - "Older Sessions" — JSON metadata block for sessions ending
-//     before the verbatim window. Acts as enticement to call
-//     archive_session_transcript or archive_search for fuller content.
+// Verbatim conversation history is deliberately NOT emitted here. The
+// model's working message list already carries stored history in
+// role-native messages; a second in-prompt transcript was the largest
+// duplicated-context source found by the #1160 audit and broke the
+// prompt-cache prefix every turn. Sessions whose messages are still in
+// the working list (ended within [RecentWindow], or still active) are
+// excluded so the catalog never restates visible context, and sessions
+// with zero messages are skipped as noise.
 //
 // Implements [agent.TagContextProvider] via structural typing; gated
 // on the message_channel capability tag asserted by Signal (and future
 // Matrix/iMessage) inbound bridges.
-//
-// Output sits in the system prompt's CONTINUITY CONTEXT section per
-// [docs/prompt-caching.md]: the delta timestamps tick every turn so
-// the block is intrinsically uncached, but the cached prefix above it
-// stays warm.
 type MessageChannelProvider struct {
 	archive               *ArchiveStore
 	conversationIDFromCtx func(context.Context) string
@@ -74,23 +59,14 @@ type MessageChannelProvider struct {
 // Zero-valued config fields fall back to defaults documented on
 // [MessageChannelProviderConfig].
 func NewMessageChannelProvider(archive *ArchiveStore, conversationIDFromCtx func(context.Context) string, cfg MessageChannelProviderConfig, logger *slog.Logger) *MessageChannelProvider {
-	if cfg.TailWindow <= 0 {
-		cfg.TailWindow = 30 * time.Minute
+	if cfg.RecentWindow <= 0 {
+		cfg.RecentWindow = 30 * time.Minute
 	}
-	if cfg.TailMinMessages <= 0 {
-		cfg.TailMinMessages = 50
+	if cfg.SessionsLimit <= 0 {
+		cfg.SessionsLimit = 5
 	}
-	if cfg.TailMaxMessages <= 0 {
-		cfg.TailMaxMessages = 200
-	}
-	if cfg.TailByteCap <= 0 {
-		cfg.TailByteCap = 32000
-	}
-	if cfg.OlderSessionsLimit <= 0 {
-		cfg.OlderSessionsLimit = 20
-	}
-	if cfg.OlderSessionsByteCap <= 0 {
-		cfg.OlderSessionsByteCap = 16000
+	if cfg.SessionsByteCap <= 0 {
+		cfg.SessionsByteCap = 8000
 	}
 	if logger == nil {
 		logger = slog.Default()
@@ -104,15 +80,15 @@ func NewMessageChannelProvider(archive *ArchiveStore, conversationIDFromCtx func
 	}
 }
 
-// TagContextBucket places message-channel transcript tail and older
-// session catalogs in continuity context.
+// TagContextBucket places the older-sessions catalog in continuity
+// context.
 func (p *MessageChannelProvider) TagContextBucket() agentctx.ContextBucket {
 	return agentctx.ContextBucketContinuity
 }
 
-// TagContext returns the verbatim tail + older-sessions blocks for the
-// active conversation. Returns the empty string when there is nothing
-// to emit (no conversation context, no archived content).
+// TagContext returns the older-sessions catalog for the active
+// conversation. Returns the empty string when there is nothing to emit
+// (no conversation context, no cataloged sessions).
 func (p *MessageChannelProvider) TagContext(ctx context.Context, _ agentctx.ContextRequest) (string, error) {
 	if p.conversationIDFromCtx == nil {
 		return "", nil
@@ -123,89 +99,66 @@ func (p *MessageChannelProvider) TagContext(ctx context.Context, _ agentctx.Cont
 	}
 
 	now := p.nowFunc()
-	windowStart := now.Add(-p.cfg.TailWindow)
+	cutoff := now.Add(-p.cfg.RecentWindow)
 
-	// Resolve the active session so we can drop its rows from the
-	// verbatim tail — those messages are already in the model's
-	// working message list.
-	var excludeSessionID string
-	if active, err := p.archive.ActiveSession(convID); err == nil && active != nil {
-		excludeSessionID = active.ID
-	}
-
-	var sb strings.Builder
-
-	// ---- Verbatim tail ----
-	messages, msgsTruncated, err := p.archive.GetMessagesInRange(RangeOptions{
-		ConversationID:   convID,
-		ExcludeSessionID: excludeSessionID,
-		From:             windowStart,
-		To:               now,
-		MinMessages:      p.cfg.TailMinMessages,
-		MaxMessages:      p.cfg.TailMaxMessages,
-	})
-	if err != nil {
-		p.logger.Warn("verbatim tail query failed",
-			"conversation_id", convID, "error", err)
-	}
-	if len(messages) > 0 {
-		tailJSON := FitSuffix(len(messages), p.cfg.TailByteCap, func(drop int) []byte {
-			return FormatRecentMessages(messages[drop:], now, msgsTruncated || drop > 0)
-		})
-		sb.WriteString("## Recent Conversation\n\n")
-		sb.WriteString("Verbatim history. Crosses session boundaries; sessions are an internal abstraction here.\n\n")
-		sb.WriteString("```json\n")
-		sb.Write(tailJSON)
-		sb.WriteString("\n```\n")
-	}
-
-	// ---- Older sessions ----
-	older, err := p.olderSessions(convID, windowStart)
+	older, more, err := p.olderSessions(convID, cutoff)
 	if err != nil {
 		p.logger.Warn("older sessions query failed",
 			"conversation_id", convID, "error", err)
 	}
-	if len(older) > 0 {
-		sessionsJSON := FitPrefix(len(older), p.cfg.OlderSessionsByteCap, func(k int) []byte {
-			return FormatSessionsList(older[:k], now, k < len(older))
-		})
-		if sb.Len() > 0 {
-			sb.WriteString("\n")
-		}
-		sb.WriteString("## Older Sessions\n\n")
-		sb.WriteString("Sessions before the tail above. Use archive_session_transcript for full transcripts, or archive_search to search semantically.\n\n")
-		sb.WriteString("```json\n")
-		sb.Write(sessionsJSON)
-		sb.WriteString("\n```\n")
+	if len(older) == 0 {
+		return "", nil
 	}
 
+	// The truncated flag covers both fitting passes — the entry limit
+	// and the byte cap — so dropped sessions are never silent.
+	sessionsJSON := FitPrefix(len(older), p.cfg.SessionsByteCap, func(k int) []byte {
+		return FormatSessionsList(older[:k], now, more || k < len(older))
+	})
+
+	var sb strings.Builder
+	sb.WriteString("## Older Sessions\n\n")
+	sb.WriteString("Past sessions on this conversation, newest first. Use archive_session_transcript for full transcripts, or archive_search to search semantically.\n\n")
+	sb.WriteString("```json\n")
+	sb.Write(sessionsJSON)
+	sb.WriteString("\n```\n")
 	return sb.String(), nil
 }
 
-// olderSessions returns closed sessions on the given conversation that
-// ended before the verbatim window started, capped at OlderSessionsLimit.
-// Active sessions and sessions still inside the verbatim window are
-// excluded so the two blocks don't duplicate content.
-func (p *MessageChannelProvider) olderSessions(conversationID string, windowStart time.Time) ([]*Session, error) {
-	// Pull a small over-fetch so the windowStart filter still has
-	// enough candidates for the limit when recent sessions are
-	// excluded.
-	sessions, err := p.archive.ListSessions(conversationID, p.cfg.OlderSessionsLimit*2)
+// olderSessions returns closed, non-empty sessions on the given
+// conversation that ended before the cutoff, newest first, capped at
+// SessionsLimit. Active sessions and sessions ending after the cutoff
+// are excluded because their messages are still in the model's working
+// message list; zero-message sessions are excluded as noise. The
+// second return reports whether qualifying sessions were dropped by
+// the limit, so the catalog can mark itself truncated.
+func (p *MessageChannelProvider) olderSessions(conversationID string, cutoff time.Time) ([]*Session, bool, error) {
+	// Over-fetch so the cutoff and empty-session filters still have
+	// enough candidates to fill the limit. Empty sessions are common
+	// on quiet conversations (session rotation without traffic), so
+	// the buffer is generous. When even the over-fetch is exhausted,
+	// deeper qualifying sessions can go uncounted — acceptable, since
+	// the truncated flag is already set well before that point.
+	sessions, err := p.archive.ListSessions(conversationID, p.cfg.SessionsLimit*8)
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
-	out := make([]*Session, 0, p.cfg.OlderSessionsLimit)
+	out := make([]*Session, 0, p.cfg.SessionsLimit)
+	qualifying := 0
 	for _, s := range sessions {
 		if s.EndedAt == nil {
 			continue
 		}
-		if !s.EndedAt.Before(windowStart) {
+		if !s.EndedAt.Before(cutoff) {
 			continue
 		}
-		out = append(out, s)
-		if len(out) >= p.cfg.OlderSessionsLimit {
-			break
+		if s.MessageCount == 0 {
+			continue
+		}
+		qualifying++
+		if len(out) < p.cfg.SessionsLimit {
+			out = append(out, s)
 		}
 	}
-	return out, nil
+	return out, qualifying > len(out), nil
 }

--- a/internal/state/memory/message_channel_provider_test.go
+++ b/internal/state/memory/message_channel_provider_test.go
@@ -3,6 +3,7 @@ package memory
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -60,6 +61,40 @@ func newMessageChannelTestSetup(t *testing.T) (*MessageChannelProvider, *Archive
 	return provider, archive, insert
 }
 
+// closedSession creates a closed session with n messages, started and
+// ended at the given offsets from now.
+func closedSession(t *testing.T, archive *ArchiveStore, insert func(convID, sessID, role, content string, ts time.Time), convID string, started, ended time.Time, n int) *Session {
+	t.Helper()
+	sess, err := archive.StartSessionAt(convID, started)
+	if err != nil {
+		t.Fatalf("StartSessionAt: %v", err)
+	}
+	for i := range n {
+		insert(convID, sess.ID, "user", fmt.Sprintf("msg-%d-%s", i, sess.ID), started.Add(time.Duration(i)*time.Minute))
+	}
+	if err := archive.EndSessionAt(sess.ID, "idle", ended); err != nil {
+		t.Fatalf("EndSessionAt: %v", err)
+	}
+	return sess
+}
+
+// olderSessionsFromOutput parses the Older Sessions fenced JSON block.
+func olderSessionsFromOutput(t *testing.T, got string) (sessions []SessionView, truncated bool) {
+	t.Helper()
+	blocks := extractFencedJSON(got)
+	if len(blocks) != 1 {
+		t.Fatalf("expected 1 fenced JSON block, got %d:\n%s", len(blocks), got)
+	}
+	var parsed struct {
+		Sessions  []SessionView `json:"sessions"`
+		Truncated bool          `json:"truncated"`
+	}
+	if err := json.Unmarshal([]byte(blocks[0]), &parsed); err != nil {
+		t.Fatalf("unmarshal older sessions block: %v", err)
+	}
+	return parsed.Sessions, parsed.Truncated
+}
+
 func TestMessageChannelProvider_NoConversationIDIsSilent(t *testing.T) {
 	provider, _, _ := newMessageChannelTestSetup(t)
 
@@ -72,107 +107,46 @@ func TestMessageChannelProvider_NoConversationIDIsSilent(t *testing.T) {
 	}
 }
 
-func TestMessageChannelProvider_EmitsBothBlocks(t *testing.T) {
+func TestMessageChannelProvider_EmitsNoVerbatimHistory(t *testing.T) {
+	// Stored history reaches the model as role-native messages in its
+	// working message list. The provider must not emit a second
+	// in-prompt transcript (#1160 finding 1) — only the session
+	// catalog.
 	provider, archive, insert := newMessageChannelTestSetup(t)
 	now := time.Now()
 
-	// Closed older session 2 days ago — should appear in Older Sessions.
-	older, err := archive.StartSessionAt("conv-1", now.Add(-48*time.Hour))
-	if err != nil {
-		t.Fatalf("StartSessionAt older: %v", err)
-	}
-	if err := archive.EndSessionAt(older.ID, "idle", now.Add(-47*time.Hour)); err != nil {
-		t.Fatalf("EndSessionAt older: %v", err)
-	}
-	insert("conv-1", older.ID, "user", "ancient", now.Add(-47*time.Hour))
-
-	// Recent CLOSED session whose tail falls in the verbatim window.
-	recent, err := archive.StartSessionAt("conv-1", now.Add(-25*time.Minute))
-	if err != nil {
-		t.Fatalf("StartSessionAt recent: %v", err)
-	}
-	if err := archive.EndSessionAt(recent.ID, "idle", now.Add(-15*time.Minute)); err != nil {
-		t.Fatalf("EndSessionAt recent: %v", err)
-	}
-	insert("conv-1", recent.ID, "user", "recent-1", now.Add(-20*time.Minute))
-	insert("conv-1", recent.ID, "assistant", "recent-2", now.Add(-19*time.Minute))
-
-	// Active session with no messages — exists so the provider has
-	// something to exclude. Mirrors a fresh conversation turn where
-	// the model is about to reply.
-	if _, err := archive.StartSessionAt("conv-1", now.Add(-1*time.Minute)); err != nil {
-		t.Fatalf("StartSessionAt active: %v", err)
-	}
+	closedSession(t, archive, insert, "conv-1", now.Add(-48*time.Hour), now.Add(-47*time.Hour), 2)
 
 	ctx := providerCtxWithConvID(context.Background(), "conv-1")
 	got, err := provider.TagContext(ctx, agentctx.ContextRequest{})
 	if err != nil {
 		t.Fatalf("TagContext: %v", err)
 	}
-	if !strings.Contains(got, "## Recent Conversation") {
-		t.Errorf("output missing Recent Conversation block:\n%s", got)
+	if strings.Contains(got, "## Recent Conversation") {
+		t.Errorf("output contains removed Recent Conversation block:\n%s", got)
 	}
-	if !strings.Contains(got, "recent-1") || !strings.Contains(got, "recent-2") {
-		t.Errorf("verbatim tail missing recent messages:\n%s", got)
+	if strings.Contains(got, "msg-0-") {
+		t.Errorf("output leaked verbatim message content:\n%s", got)
 	}
-}
-
-func TestMessageChannelProvider_ExcludesActiveSessionMessages(t *testing.T) {
-	// Active session messages are already in the model's working
-	// message list. The verbatim tail must drop them so the model
-	// doesn't see them twice.
-	provider, archive, insert := newMessageChannelTestSetup(t)
-	now := time.Now()
-
-	// Closed prior session that should appear in the tail.
-	prior, err := archive.StartSessionAt("conv-1", now.Add(-25*time.Minute))
-	if err != nil {
-		t.Fatalf("StartSessionAt prior: %v", err)
-	}
-	if err := archive.EndSessionAt(prior.ID, "idle", now.Add(-15*time.Minute)); err != nil {
-		t.Fatalf("EndSessionAt prior: %v", err)
-	}
-	insert("conv-1", prior.ID, "user", "prior-msg", now.Add(-20*time.Minute))
-
-	// Active session — these messages should NOT appear in the tail.
-	active, err := archive.StartSessionAt("conv-1", now.Add(-2*time.Minute))
-	if err != nil {
-		t.Fatalf("StartSessionAt active: %v", err)
-	}
-	insert("conv-1", active.ID, "user", "active-msg", now.Add(-1*time.Minute))
-
-	ctx := providerCtxWithConvID(context.Background(), "conv-1")
-	got, err := provider.TagContext(ctx, agentctx.ContextRequest{})
-	if err != nil {
-		t.Fatalf("TagContext: %v", err)
-	}
-	if !strings.Contains(got, "prior-msg") {
-		t.Errorf("tail missing prior-session message:\n%s", got)
-	}
-	if strings.Contains(got, "active-msg") {
-		t.Errorf("tail leaked active-session message — duplicates the model's working list:\n%s", got)
+	if !strings.Contains(got, "## Older Sessions") {
+		t.Errorf("output missing Older Sessions block:\n%s", got)
 	}
 }
 
-func TestMessageChannelProvider_OlderSessionsExcludesActiveAndInWindow(t *testing.T) {
+func TestMessageChannelProvider_OlderSessionsExcludesActiveInWindowAndEmpty(t *testing.T) {
 	provider, archive, insert := newMessageChannelTestSetup(t)
 	now := time.Now()
 
-	// Active session — should not appear in older sessions.
+	// Active session — messages are in the working list; must not appear.
 	if _, err := archive.StartSessionAt("conv-1", now.Add(-1*time.Minute)); err != nil {
 		t.Fatalf("StartSessionAt active: %v", err)
 	}
-	// Closed but EndedAt inside the verbatim window — should not appear in older.
-	inWindow, err := archive.StartSessionAt("conv-1", now.Add(-25*time.Minute))
-	if err != nil {
-		t.Fatalf("StartSessionAt inWindow: %v", err)
-	}
-	if err := archive.EndSessionAt(inWindow.ID, "idle", now.Add(-15*time.Minute)); err != nil {
-		t.Fatalf("EndSessionAt inWindow: %v", err)
-	}
-	insert("conv-1", inWindow.ID, "user", "in-window", now.Add(-20*time.Minute))
-
-	// Closed and EndedAt BEFORE the verbatim window — should appear.
+	// Closed but ended inside RecentWindow — still in the working list;
+	// must not appear.
+	inWindow := closedSession(t, archive, insert, "conv-1", now.Add(-25*time.Minute), now.Add(-15*time.Minute), 1)
+	// Closed before the window but empty — rotation noise; must not appear.
+	empty := closedSession(t, archive, insert, "conv-1", now.Add(-4*time.Hour), now.Add(-3*time.Hour), 0)
+	// Closed before the window with substance — the one entry expected.
 	older, err := archive.StartSessionAt("conv-1", now.Add(-3*time.Hour))
 	if err != nil {
 		t.Fatalf("StartSessionAt older: %v", err)
@@ -180,36 +154,78 @@ func TestMessageChannelProvider_OlderSessionsExcludesActiveAndInWindow(t *testin
 	if err := archive.SetSessionMetadata(older.ID, &SessionMetadata{OneLiner: "freezer alarm"}, "Freezer alarm troubleshooting", []string{"home-automation"}); err != nil {
 		t.Fatalf("SetSessionMetadata: %v", err)
 	}
+	insert("conv-1", older.ID, "user", "old-msg", now.Add(-2*time.Hour))
 	if err := archive.EndSessionAt(older.ID, "idle", now.Add(-2*time.Hour)); err != nil {
 		t.Fatalf("EndSessionAt older: %v", err)
 	}
-	insert("conv-1", older.ID, "user", "old-msg", now.Add(-2*time.Hour))
 
 	ctx := providerCtxWithConvID(context.Background(), "conv-1")
 	got, err := provider.TagContext(ctx, agentctx.ContextRequest{})
 	if err != nil {
 		t.Fatalf("TagContext: %v", err)
 	}
-	if !strings.Contains(got, "## Older Sessions") {
-		t.Fatalf("output missing Older Sessions block:\n%s", got)
+	sessions, truncated := olderSessionsFromOutput(t, got)
+	if len(sessions) != 1 {
+		t.Fatalf("older sessions len = %d, want 1 (in-window %s and empty %s must be excluded):\n%s",
+			len(sessions), inWindow.ID, empty.ID, got)
 	}
-	// Parse the JSON in the older sessions block to confirm exactly
-	// the right session IDs are present.
-	jsonBlocks := extractFencedJSON(got)
-	if len(jsonBlocks) < 2 {
-		t.Fatalf("expected 2 fenced JSON blocks, got %d:\n%s", len(jsonBlocks), got)
+	if sessions[0].ID != older.ID {
+		t.Errorf("older session id = %q, want %q", sessions[0].ID, older.ID)
 	}
-	var olderParsed struct {
-		Sessions []SessionView `json:"sessions"`
+	if truncated {
+		t.Errorf("truncated = true, want false for a single entry")
 	}
-	if err := json.Unmarshal([]byte(jsonBlocks[len(jsonBlocks)-1]), &olderParsed); err != nil {
-		t.Fatalf("unmarshal older block: %v", err)
+}
+
+func TestMessageChannelProvider_CapsSessionsNewestFirst(t *testing.T) {
+	provider, archive, insert := newMessageChannelTestSetup(t)
+	now := time.Now()
+
+	// Eight closed non-empty sessions, oldest first. Default limit is 5.
+	var ids []string
+	for i := range 8 {
+		started := now.Add(-time.Duration(30-i) * time.Hour)
+		sess := closedSession(t, archive, insert, "conv-1", started, started.Add(30*time.Minute), 1)
+		ids = append(ids, sess.ID)
 	}
-	if len(olderParsed.Sessions) != 1 {
-		t.Fatalf("older sessions len = %d, want 1", len(olderParsed.Sessions))
+
+	ctx := providerCtxWithConvID(context.Background(), "conv-1")
+	got, err := provider.TagContext(ctx, agentctx.ContextRequest{})
+	if err != nil {
+		t.Fatalf("TagContext: %v", err)
 	}
-	if olderParsed.Sessions[0].ID != older.ID {
-		t.Errorf("older session id = %q, want %q", olderParsed.Sessions[0].ID, older.ID)
+	sessions, truncated := olderSessionsFromOutput(t, got)
+	if len(sessions) != 5 {
+		t.Fatalf("older sessions len = %d, want 5:\n%s", len(sessions), got)
+	}
+	// Newest first: the last five created, in reverse creation order.
+	for i, want := range []string{ids[7], ids[6], ids[5], ids[4], ids[3]} {
+		if sessions[i].ID != want {
+			t.Errorf("sessions[%d].ID = %q, want %q", i, sessions[i].ID, want)
+		}
+	}
+	if !truncated {
+		t.Errorf("truncated = false, want true when the limit drops sessions")
+	}
+}
+
+func TestMessageChannelProvider_AllSessionsFilteredIsSilent(t *testing.T) {
+	provider, archive, insert := newMessageChannelTestSetup(t)
+	now := time.Now()
+
+	// Only rotation noise: an empty closed session and an active one.
+	closedSession(t, archive, insert, "conv-1", now.Add(-4*time.Hour), now.Add(-3*time.Hour), 0)
+	if _, err := archive.StartSessionAt("conv-1", now.Add(-1*time.Minute)); err != nil {
+		t.Fatalf("StartSessionAt active: %v", err)
+	}
+
+	ctx := providerCtxWithConvID(context.Background(), "conv-1")
+	got, err := provider.TagContext(ctx, agentctx.ContextRequest{})
+	if err != nil {
+		t.Fatalf("TagContext: %v", err)
+	}
+	if got != "" {
+		t.Errorf("expected empty output when every session is filtered, got:\n%s", got)
 	}
 }
 

--- a/internal/state/memory/message_channel_provider_test.go
+++ b/internal/state/memory/message_channel_provider_test.go
@@ -209,6 +209,65 @@ func TestMessageChannelProvider_CapsSessionsNewestFirst(t *testing.T) {
 	}
 }
 
+func TestMessageChannelProvider_DeepNoiseDoesNotStarveCatalog(t *testing.T) {
+	// A long run of empty rotation sessions must not push qualifying
+	// sessions out of reach: the provider pages past noise instead of
+	// scanning a fixed window (PR #1164 review).
+	provider, archive, insert := newMessageChannelTestSetup(t)
+	now := time.Now()
+
+	// Two real sessions, ended long ago.
+	oldA := closedSession(t, archive, insert, "conv-1", now.Add(-100*time.Hour), now.Add(-99*time.Hour), 1)
+	oldB := closedSession(t, archive, insert, "conv-1", now.Add(-98*time.Hour), now.Add(-97*time.Hour), 1)
+	// 45 empty sessions between them and the cutoff — more than two
+	// pages of noise at the default page size of 20.
+	for i := range 45 {
+		started := now.Add(-time.Duration(96-i) * time.Hour)
+		closedSession(t, archive, insert, "conv-1", started, started.Add(30*time.Minute), 0)
+	}
+
+	ctx := providerCtxWithConvID(context.Background(), "conv-1")
+	got, err := provider.TagContext(ctx, agentctx.ContextRequest{})
+	if err != nil {
+		t.Fatalf("TagContext: %v", err)
+	}
+	sessions, truncated := olderSessionsFromOutput(t, got)
+	if len(sessions) != 2 {
+		t.Fatalf("older sessions len = %d, want 2 (noise must not starve the catalog):\n%s", len(sessions), got)
+	}
+	if sessions[0].ID != oldB.ID || sessions[1].ID != oldA.ID {
+		t.Errorf("session order = [%q, %q], want [%q, %q]", sessions[0].ID, sessions[1].ID, oldB.ID, oldA.ID)
+	}
+	if truncated {
+		t.Errorf("truncated = true, want false when every qualifying session is listed")
+	}
+}
+
+func TestMessageChannelProvider_OrdersByEndedAtNotStartedAt(t *testing.T) {
+	// The catalog contract is most-recently-ENDED first. A session
+	// that started earlier but ended later must sort ahead of one
+	// that started later but ended sooner.
+	provider, archive, insert := newMessageChannelTestSetup(t)
+	now := time.Now()
+
+	longRunning := closedSession(t, archive, insert, "conv-1", now.Add(-10*time.Hour), now.Add(-2*time.Hour), 1)
+	quick := closedSession(t, archive, insert, "conv-1", now.Add(-6*time.Hour), now.Add(-5*time.Hour), 1)
+
+	ctx := providerCtxWithConvID(context.Background(), "conv-1")
+	got, err := provider.TagContext(ctx, agentctx.ContextRequest{})
+	if err != nil {
+		t.Fatalf("TagContext: %v", err)
+	}
+	sessions, _ := olderSessionsFromOutput(t, got)
+	if len(sessions) != 2 {
+		t.Fatalf("older sessions len = %d, want 2:\n%s", len(sessions), got)
+	}
+	if sessions[0].ID != longRunning.ID || sessions[1].ID != quick.ID {
+		t.Errorf("session order = [%q, %q], want [%q(ended -2h), %q(ended -5h)]",
+			sessions[0].ID, sessions[1].ID, longRunning.ID, quick.ID)
+	}
+}
+
 func TestMessageChannelProvider_AllSessionsFilteredIsSilent(t *testing.T) {
 	provider, archive, insert := newMessageChannelTestSetup(t)
 	now := time.Now()


### PR DESCRIPTION
## Summary

First tranche of #1160 (findings 1 and 2): the message-channel continuity provider no longer ships a second copy of conversation history into the system prompt, and the older-sessions catalog it keeps is now curated instead of dumped.

The audit's live artifact made the case concrete. An ordinary interactive Signal turn carried a 30.7KB `## Recent Conversation` JSON transcript inside the system prompt — the same utterances the model had just received as role-native messages, re-encoded with a nonstandard `"past you"` role — plus a 25.8KB `## Older Sessions` block listing twenty sessions, six of which were `"(empty session)"` rotation noise with zero messages. The doctrine in [docs/model-facing-context.md](docs/model-facing-context.md) names both patterns directly: "historical conversation turns belong in role-native chat messages rather than the root system prompt," and "do not present the same fact in multiple conflicting shapes."

## What changed

**The verbatim tail is gone, not patched.** The old provider already knew duplication was a hazard — it excluded the *active session's* rows on the theory that those were the ones in the model's working list. But live memory spans far more than the active session (sessions rotate on a ~30-minute idle timer while conversation memory persists for days), so the exclusion never matched reality and the tail re-stated hours of visible context every turn. Since stored history reaches the model role-natively — with the doc-prescribed metadata envelopes, `original_role` preservation, and gap markers — the in-prompt transcript had no job left to do. Removing it also stops the prompt-cache prefix from breaking at the same offset every turn, since the block's delta timestamps made it permanently uncacheable.

**The older-sessions catalog is curated.** Zero-message sessions are filtered out as rotation noise, the default cap drops from 20 entries to 5 (newest first), and the byte ceiling drops from 16KB to 8KB. The framing note still points the model at `archive_session_transcript` and `archive_search` for anything deeper — that reach-back path is the catalog's whole purpose, and it survives.

**Truncation is never silent.** The old `truncated` flag only reflected byte-cap fitting; sessions dropped by the entry limit disappeared without a trace, which is the doctrine's silent-truncation anti-pattern. The flag now covers both fitting passes, so the model can tell when the catalog is a window rather than the whole set.

Config fields for the removed tail (`TailWindow`, `TailMinMessages`, `TailMaxMessages`, `TailByteCap`) are deleted rather than deprecated — the struct is internal and zero-config wiring in `new_awareness.go` is unchanged. `FitSuffix` and `FormatRecentMessages` stay: `archive_tools.go` still uses them for tool output, which is where verbatim history belongs.

Finding 3 (the doubled `## This is the one` heading) turned out to be prod content, not assembler code — the assembler never emits article-title headings, so the duplicate lives in the authored document itself. That fix happens in the production knowledge base, not this repo.

## Test plan

- [x] `TestMessageChannelProvider_EmitsNoVerbatimHistory` — no `## Recent Conversation` block, no leaked message content, catalog still present
- [x] `TestMessageChannelProvider_OlderSessionsExcludesActiveInWindowAndEmpty` — active, in-window, and empty sessions all excluded; sole qualifying session listed
- [x] `TestMessageChannelProvider_CapsSessionsNewestFirst` — 8 qualifying sessions → 5 newest listed, `truncated: true`
- [x] `TestMessageChannelProvider_AllSessionsFilteredIsSilent` — provider emits nothing when only noise qualifies
- [x] `just ci` green locally

Refs #1160

🤖 Generated with [Claude Code](https://claude.com/claude-code)
