### PR TITLE
feat(promptfmt): tiered humane delta units with compound round-trip parsing

### DIFF
--- a/internal/app/loop_outputs_test.go
+++ b/internal/app/loop_outputs_test.go
@@ -136,7 +136,7 @@ Everything is calm.
 		t.Fatalf("renderLoopOutputContextWithNow: %v", err)
 	}
 
-	if !strings.Contains(ctx, `"updated_delta": "-7200s"`) {
+	if !strings.Contains(ctx, `"updated_delta": "-2h"`) {
 		t.Fatalf("output context missing delta freshness:\n%s", ctx)
 	}
 	for _, unwanted := range []string{

--- a/internal/model/promptfmt/timefmt.go
+++ b/internal/model/promptfmt/timefmt.go
@@ -2,6 +2,7 @@ package promptfmt
 
 import (
 	"fmt"
+	"math"
 	"strconv"
 	"strings"
 	"time"
@@ -137,7 +138,16 @@ func parseDeltaTerms(s string) (time.Duration, error) {
 		if err != nil {
 			return 0, fmt.Errorf("invalid offset %q: %w", s, err)
 		}
-		total += time.Duration(n) * unit
+		// Terms are model-supplied; reject magnitudes that would wrap
+		// time.Duration instead of silently returning garbage.
+		if n > int64(math.MaxInt64)/int64(unit) {
+			return 0, fmt.Errorf("invalid offset %q: term %s%c is too large to represent", s, body[:i], body[i])
+		}
+		term := time.Duration(n) * unit
+		if total > time.Duration(math.MaxInt64)-term {
+			return 0, fmt.Errorf("invalid offset %q: terms sum past the representable range", s)
+		}
+		total += term
 		body = body[i+1:]
 	}
 	return total, nil

--- a/internal/model/promptfmt/timefmt.go
+++ b/internal/model/promptfmt/timefmt.go
@@ -8,32 +8,65 @@ import (
 )
 
 // FormatDelta returns a delta-annotated timestamp string relative to now.
-// Past timestamps produce just the delta: "(-3247s)".
-// Future timestamps keep the absolute time and annotate: "2026-03-07T18:00-06:00 (+52143s)".
+// Past timestamps produce just the delta: "(-3247s)", "(-26h45m)",
+// "(-5d9h)". Future timestamps keep the absolute time and annotate:
+// "2026-03-07T18:00-06:00 (+14h29m)".
 func FormatDelta(t time.Time, now time.Time) string {
 	secs := int64(t.Sub(now).Truncate(time.Second) / time.Second)
 
 	if secs <= 0 {
-		return fmt.Sprintf("(-%ds)", -secs)
+		return fmt.Sprintf("(-%s)", formatDeltaMagnitude(-secs))
 	}
-	return fmt.Sprintf("%s (+%ds)", t.Format(time.RFC3339), secs)
+	return fmt.Sprintf("%s (+%s)", t.Format(time.RFC3339), formatDeltaMagnitude(secs))
 }
 
-// FormatDeltaOnly returns just the signed delta string: "-3247s" or "+3600s".
+// FormatDeltaOnly returns just the signed delta string: "-3247s",
+// "-26h45m", "+5d9h".
+//
+// Magnitudes under an hour stay in exact seconds; from one hour the
+// shape switches to hours+minutes, and from two days to days+hours.
+// Models must not be made to divide second counts into human scales
+// (docs/model-facing-context.md), and every emitted form round-trips
+// through [ParseTimeOrDelta], so tool arguments can echo these values
+// back verbatim.
 func FormatDeltaOnly(t time.Time, now time.Time) string {
 	secs := int64(t.Sub(now).Truncate(time.Second) / time.Second)
 
 	if secs <= 0 {
-		return fmt.Sprintf("-%ds", -secs)
+		return "-" + formatDeltaMagnitude(-secs)
 	}
-	return fmt.Sprintf("+%ds", secs)
+	return "+" + formatDeltaMagnitude(secs)
 }
 
-// deltaUnits maps the single-character suffix of a signed offset to its
-// duration. Seconds remain the canonical form [FormatDeltaOnly] emits;
-// minutes/hours/days/weeks are accepted on input so model-facing tools
-// can advertise human-scale windows ("-7d") instead of large second
-// counts ("-604800s").
+// formatDeltaMagnitude renders an absolute second count in the tiered
+// unit shape shared by FormatDelta and FormatDeltaOnly: exact seconds
+// under an hour, hours+minutes under two days, then days+hours. At
+// most two units appear and zero-valued trailing units are dropped, so
+// output stays compact and unambiguous ("26h", "5d9h"). Sub-unit
+// remainders below the second term are deliberately dropped — at those
+// magnitudes they carry no reasoning value for a model.
+func formatDeltaMagnitude(secs int64) string {
+	switch {
+	case secs < 3600:
+		return strconv.FormatInt(secs, 10) + "s"
+	case secs < 48*3600:
+		h, m := secs/3600, (secs%3600)/60
+		if m == 0 {
+			return fmt.Sprintf("%dh", h)
+		}
+		return fmt.Sprintf("%dh%dm", h, m)
+	default:
+		d, h := secs/86400, (secs%86400)/3600
+		if h == 0 {
+			return fmt.Sprintf("%dd", d)
+		}
+		return fmt.Sprintf("%dd%dh", d, h)
+	}
+}
+
+// deltaUnits maps the single-character suffix of a signed-offset term
+// to its duration. All five units are accepted on input; output uses
+// s, m, h, and d (see [formatDeltaMagnitude]).
 var deltaUnits = map[byte]time.Duration{
 	's': time.Second,
 	'm': time.Minute,
@@ -43,10 +76,12 @@ var deltaUnits = map[byte]time.Duration{
 }
 
 // ParseTimeOrDelta parses either an absolute RFC3339 timestamp or a signed
-// offset relative to now. Offsets are "<sign><integer><unit>" where unit is
-// s (seconds), m (minutes), h (hours), d (days), or w (weeks) — e.g.
-// "+3600s", "-300s", "-30m", "-24h", "-7d". Any tool parameter that accepts
-// a timestamp should use this for backwards-compatible offset support.
+// offset relative to now. Offsets are "<sign><integer><unit>..." where unit
+// is s (seconds), m (minutes), h (hours), d (days), or w (weeks), and
+// multiple integer+unit terms compound under one leading sign — e.g.
+// "+3600s", "-30m", "-24h", "-7d", "-5d9h", "-26h45m". Any tool parameter
+// that accepts a timestamp should use this so it accepts every delta shape
+// the prompt formatters emit.
 func ParseTimeOrDelta(s string, now time.Time) (time.Time, error) {
 	s = strings.TrimSpace(s)
 	if s == "" {
@@ -56,22 +91,14 @@ func ParseTimeOrDelta(s string, now time.Time) (time.Time, error) {
 	// A leading sign unambiguously marks a signed offset (RFC3339 never
 	// starts with + or -), so parse the unit-suffixed delta form here.
 	if s[0] == '+' || s[0] == '-' {
-		if len(s) < 3 {
-			return time.Time{}, fmt.Errorf("invalid offset %q: want <sign><number><unit> (s, m, h, d, or w)", s)
-		}
-		unit, ok := deltaUnits[s[len(s)-1]]
-		if !ok {
-			return time.Time{}, fmt.Errorf("invalid offset %q: unit must be s, m, h, d, or w", s)
-		}
-		n, err := strconv.ParseInt(s[1:len(s)-1], 10, 64)
+		total, err := parseDeltaTerms(s)
 		if err != nil {
-			return time.Time{}, fmt.Errorf("invalid offset %q: %w", s, err)
+			return time.Time{}, err
 		}
-		d := time.Duration(n) * unit
 		if s[0] == '-' {
-			return now.Add(-d), nil
+			return now.Add(-total), nil
 		}
-		return now.Add(d), nil
+		return now.Add(total), nil
 	}
 
 	// Fall back to RFC3339 absolute timestamp.
@@ -80,4 +107,38 @@ func ParseTimeOrDelta(s string, now time.Time) (time.Time, error) {
 		return time.Time{}, fmt.Errorf("invalid timestamp %q: %w", s, err)
 	}
 	return t, nil
+}
+
+// parseDeltaTerms sums the integer+unit terms of a signed offset string
+// ("-5d9h" → 5 days + 9 hours). The magnitude is returned unsigned; the
+// caller applies the leading sign.
+func parseDeltaTerms(s string) (time.Duration, error) {
+	body := s[1:]
+	if body == "" {
+		return 0, fmt.Errorf("invalid offset %q: want <sign><number><unit>... (s, m, h, d, or w)", s)
+	}
+	var total time.Duration
+	for len(body) > 0 {
+		i := 0
+		for i < len(body) && body[i] >= '0' && body[i] <= '9' {
+			i++
+		}
+		if i == 0 {
+			return 0, fmt.Errorf("invalid offset %q: want <sign><number><unit>... (s, m, h, d, or w)", s)
+		}
+		if i == len(body) {
+			return 0, fmt.Errorf("invalid offset %q: term %q is missing its unit (s, m, h, d, or w)", s, body)
+		}
+		unit, ok := deltaUnits[body[i]]
+		if !ok {
+			return 0, fmt.Errorf("invalid offset %q: unit must be s, m, h, d, or w", s)
+		}
+		n, err := strconv.ParseInt(body[:i], 10, 64)
+		if err != nil {
+			return 0, fmt.Errorf("invalid offset %q: %w", s, err)
+		}
+		total += time.Duration(n) * unit
+		body = body[i+1:]
+	}
+	return total, nil
 }

--- a/internal/model/promptfmt/timefmt_test.go
+++ b/internal/model/promptfmt/timefmt_test.go
@@ -16,7 +16,7 @@ func TestFormatDelta(t *testing.T) {
 		{
 			name: "past 1 hour",
 			t:    now.Add(-1 * time.Hour),
-			want: "(-3600s)",
+			want: "(-1h)",
 		},
 		{
 			name: "past 54 minutes 7 seconds",
@@ -26,7 +26,7 @@ func TestFormatDelta(t *testing.T) {
 		{
 			name: "future 1 hour",
 			t:    now.Add(1 * time.Hour),
-			want: "2026-03-07T13:00:00Z (+3600s)",
+			want: "2026-03-07T13:00:00Z (+1h)",
 		},
 		{
 			name: "exactly now",
@@ -41,7 +41,7 @@ func TestFormatDelta(t *testing.T) {
 		{
 			name: "future 24 hours",
 			t:    now.Add(24 * time.Hour),
-			want: "2026-03-08T12:00:00Z (+86400s)",
+			want: "2026-03-08T12:00:00Z (+24h)",
 		},
 	}
 
@@ -66,7 +66,7 @@ func TestFormatDeltaOnly(t *testing.T) {
 		{
 			name: "past 1 hour",
 			t:    now.Add(-1 * time.Hour),
-			want: "-3600s",
+			want: "-1h",
 		},
 		{
 			name: "future 30 minutes",
@@ -79,9 +79,39 @@ func TestFormatDeltaOnly(t *testing.T) {
 			want: "-0s",
 		},
 		{
-			name: "past 1 day",
+			name: "past 1 day renders hours under the two-day tier",
 			t:    now.Add(-24 * time.Hour),
-			want: "-86400s",
+			want: "-24h",
+		},
+		{
+			name: "past 59 minutes 59 seconds stays exact seconds",
+			t:    now.Add(-59*time.Minute - 59*time.Second),
+			want: "-3599s",
+		},
+		{
+			name: "past 26 hours 45 minutes",
+			t:    now.Add(-26*time.Hour - 45*time.Minute - 30*time.Second),
+			want: "-26h45m",
+		},
+		{
+			name: "past 47 hours 59 minutes stays hours",
+			t:    now.Add(-47*time.Hour - 59*time.Minute),
+			want: "-47h59m",
+		},
+		{
+			name: "past 5 days 9 hours",
+			t:    now.Add(-5*24*time.Hour - 9*time.Hour - 51*time.Minute),
+			want: "-5d9h",
+		},
+		{
+			name: "past exactly 3 days",
+			t:    now.Add(-3 * 24 * time.Hour),
+			want: "-3d",
+		},
+		{
+			name: "future 2 hours 30 minutes",
+			t:    now.Add(2*time.Hour + 30*time.Minute),
+			want: "+2h30m",
 		},
 	}
 
@@ -172,6 +202,31 @@ func TestParseTimeOrDelta(t *testing.T) {
 		{
 			name:    "unknown unit",
 			input:   "-7y",
+			wantErr: true,
+		},
+		{
+			name:  "compound days and hours",
+			input: "-5d9h",
+			want:  now.Add(-5*24*time.Hour - 9*time.Hour),
+		},
+		{
+			name:  "compound hours and minutes",
+			input: "-26h45m",
+			want:  now.Add(-26*time.Hour - 45*time.Minute),
+		},
+		{
+			name:  "compound future",
+			input: "+2h30m",
+			want:  now.Add(2*time.Hour + 30*time.Minute),
+		},
+		{
+			name:    "compound with trailing digits missing unit",
+			input:   "-5d9",
+			wantErr: true,
+		},
+		{
+			name:    "compound with bad unit in second term",
+			input:   "-5d9y",
 			wantErr: true,
 		},
 	}

--- a/internal/model/promptfmt/timefmt_test.go
+++ b/internal/model/promptfmt/timefmt_test.go
@@ -229,6 +229,26 @@ func TestParseTimeOrDelta(t *testing.T) {
 			input:   "-5d9y",
 			wantErr: true,
 		},
+		{
+			name:    "term multiplication would wrap duration",
+			input:   "+9223372036854775807s",
+			wantErr: true,
+		},
+		{
+			name:    "term multiplication would wrap at coarse unit",
+			input:   "+15251w",
+			wantErr: true,
+		},
+		{
+			name:    "term sum would wrap duration",
+			input:   "+106751d106751d",
+			wantErr: true,
+		},
+		{
+			name:  "largest representable day count parses",
+			input: "-106751d",
+			want:  now.Add(-106751 * 24 * time.Hour),
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/runtime/loop/loop_view_test.go
+++ b/internal/runtime/loop/loop_view_test.go
@@ -75,10 +75,10 @@ func TestLoopViewResolver_FromStatus_RunningService(t *testing.T) {
 	if len(v.EffectiveTags) != 2 || v.EffectiveTags[0].From != "travel" {
 		t.Errorf("EffectiveTags = %#v, want inheritance provenance carried through", v.EffectiveTags)
 	}
-	// Signed exact-second deltas per the model-facing convention: 4h12m =
-	// 15120s ago, last wake 47s ago.
-	if v.StartedDelta == nil || *v.StartedDelta != "-15120s" {
-		t.Errorf("StartedDelta = %v, want -15120s", v.StartedDelta)
+	// Signed tiered deltas per the model-facing convention: 4h12m ago
+	// renders hours+minutes, last wake 47s ago stays exact seconds.
+	if v.StartedDelta == nil || *v.StartedDelta != "-4h12m" {
+		t.Errorf("StartedDelta = %v, want -4h12m", v.StartedDelta)
 	}
 	if v.LastWakeDelta == nil || *v.LastWakeDelta != "-47s" {
 		t.Errorf("LastWakeDelta = %v, want -47s", v.LastWakeDelta)
@@ -99,8 +99,8 @@ func TestLoopViewResolver_FromStatus_NextWake(t *testing.T) {
 		CurrentSleep: 99 * time.Minute,
 		Config:       Config{Operation: OperationService},
 	})
-	if sleeping.NextWakeDelta == nil || *sleeping.NextWakeDelta != "+5940s" {
-		t.Errorf("NextWakeDelta = %v, want +5940s", sleeping.NextWakeDelta)
+	if sleeping.NextWakeDelta == nil || *sleeping.NextWakeDelta != "+1h39m" {
+		t.Errorf("NextWakeDelta = %v, want +1h39m", sleeping.NextWakeDelta)
 	}
 	// Unsigned seconds (a duration magnitude), not a delta: 99m = 5940s.
 	if sleeping.CurrentSleepDuration == nil || *sleeping.CurrentSleepDuration != "5940s" {
@@ -278,8 +278,8 @@ func TestDefinitionViewResolver_FromDefinition_RunningOverlaysLive(t *testing.T)
 	if v.ContextFillPct == nil || *v.ContextFillPct != 10 { // 20000*100/200000
 		t.Errorf("ContextFillPct = %v, want 10", v.ContextFillPct)
 	}
-	if v.StartedDelta == nil || *v.StartedDelta != "-7200s" {
-		t.Errorf("StartedDelta = %v, want -7200s", v.StartedDelta)
+	if v.StartedDelta == nil || *v.StartedDelta != "-2h" {
+		t.Errorf("StartedDelta = %v, want -2h", v.StartedDelta)
 	}
 	if len(v.EffectiveTags) != 1 || v.EffectiveTags[0].Tag != "water" {
 		t.Errorf("EffectiveTags = %#v, want the live inheritance overlaid", v.EffectiveTags)

--- a/internal/state/awareness/entity_format_test.go
+++ b/internal/state/awareness/entity_format_test.go
@@ -493,8 +493,8 @@ func TestFormatPerson(t *testing.T) {
 	if parsed["state"] != "home" {
 		t.Error("missing state")
 	}
-	if parsed["since"] != "-3600s" {
-		t.Errorf("since = %v, want -3600s", parsed["since"])
+	if parsed["since"] != "-1h" {
+		t.Errorf("since = %v, want -1h", parsed["since"])
 	}
 }
 

--- a/internal/state/awareness/watchlist_provider_test.go
+++ b/internal/state/awareness/watchlist_provider_test.go
@@ -372,8 +372,8 @@ func TestProvider_IncludesNumericHistorySummaries(t *testing.T) {
 	if summary["kind"] != "numeric" {
 		t.Fatalf("kind = %#v, want numeric", summary["kind"])
 	}
-	if summary["lookback"] != "-86400s" {
-		t.Fatalf("lookback = %#v, want -86400s", summary["lookback"])
+	if summary["lookback"] != "-24h" {
+		t.Fatalf("lookback = %#v, want -24h", summary["lookback"])
 	}
 	if summary["trend"] != "rising" {
 		t.Fatalf("trend = %#v, want rising", summary["trend"])
@@ -586,8 +586,8 @@ func TestProvider_IncludesDiscreteHistorySummaries(t *testing.T) {
 	if summary["kind"] != "discrete" {
 		t.Fatalf("kind = %#v, want discrete", summary["kind"])
 	}
-	if summary["lookback"] != "-86400s" {
-		t.Fatalf("lookback = %#v, want -86400s", summary["lookback"])
+	if summary["lookback"] != "-24h" {
+		t.Fatalf("lookback = %#v, want -24h", summary["lookback"])
 	}
 	if summary["change_count"] != float64(2) {
 		t.Fatalf("change_count = %#v, want 2", summary["change_count"])

--- a/internal/state/documents/tools_test.go
+++ b/internal/state/documents/tools_test.go
@@ -65,7 +65,7 @@ func TestDocumentToolsUseDeltaTimeFields(t *testing.T) {
 		Root:            "kb",
 		Query:           "note",
 		FrontmatterKeys: []string{"created"},
-		ModifiedAfter:   "-3600s",
+		ModifiedAfter:   "-1h",
 	})
 	if err != nil {
 		t.Fatalf("Search: %v", err)
@@ -108,8 +108,8 @@ func TestModelDeltaValueCountsSkipsUnparseableTimestamps(t *testing.T) {
 	if len(got) != 1 {
 		t.Fatalf("modelDeltaValueCounts() = %#v, want one parsed delta", got)
 	}
-	if got[0].Value != "-3600s" || got[0].Count != 2 {
-		t.Fatalf("modelDeltaValueCounts()[0] = %#v, want -3600s count 2", got[0])
+	if got[0].Value != "-1h" || got[0].Count != 2 {
+		t.Fatalf("modelDeltaValueCounts()[0] = %#v, want -1h count 2", got[0])
 	}
 }
 
@@ -126,8 +126,8 @@ func TestModelFrontmatterSkipsUnparseableTimestampValues(t *testing.T) {
 	if _, ok := got["created_delta"]; ok {
 		t.Fatalf("modelFrontmatter() = %#v, should omit unparseable created_delta", got)
 	}
-	if values := got["updated_delta"]; len(values) != 1 || values[0] != "-7200s" {
-		t.Fatalf("updated_delta = %#v, want [-7200s]", values)
+	if values := got["updated_delta"]; len(values) != 1 || values[0] != "-2h" {
+		t.Fatalf("updated_delta = %#v, want [-2h]", values)
 	}
 	if values := got["status"]; len(values) != 1 || values[0] != "open" {
 		t.Fatalf("status = %#v, want [open]", values)
@@ -145,9 +145,9 @@ func TestModelFrontmatterNormalizesTimestampAliases(t *testing.T) {
 	}, now)
 
 	tests := map[string]string{
-		"created_delta":   "-3600s",
-		"updated_delta":   "-7200s",
-		"generated_delta": "-10800s",
+		"created_delta":   "-1h",
+		"updated_delta":   "-2h",
+		"generated_delta": "-3h",
 	}
 	for key, want := range tests {
 		if values := got[key]; len(values) != 1 || values[0] != want {
@@ -165,8 +165,8 @@ func TestModelFrontmatterCanonicalTimestampWinsOverAlias(t *testing.T) {
 		"created_at": {now.Add(-2 * time.Hour).Format(time.RFC3339)},
 	}, now)
 
-	if values := got["created_delta"]; len(values) != 1 || values[0] != "-3600s" {
-		t.Fatalf("created_delta = %#v, want canonical created value [-3600s]", values)
+	if values := got["created_delta"]; len(values) != 1 || values[0] != "-1h" {
+		t.Fatalf("created_delta = %#v, want canonical created value [-1h]", values)
 	}
 }
 

--- a/internal/state/memory/format_test.go
+++ b/internal/state/memory/format_test.go
@@ -92,8 +92,8 @@ func TestFormatSessionsList_StableSchema(t *testing.T) {
 	}
 
 	closed := parsed.Sessions[0]
-	if closed.Started != "-7200s" {
-		t.Errorf("closed.Started = %q, want -7200s", closed.Started)
+	if closed.Started != "-2h" {
+		t.Errorf("closed.Started = %q, want -2h", closed.Started)
 	}
 	if closed.Ended != "-1800s" {
 		t.Errorf("closed.Ended = %q, want -1800s", closed.Ended)
@@ -447,8 +447,8 @@ func TestFormatSearchResults_StructurePreserved(t *testing.T) {
 	if r.Match.SessionID != "s_xyz" {
 		t.Errorf("match.SessionID = %q, want s_xyz", r.Match.SessionID)
 	}
-	if r.Match.T != "-7200s" {
-		t.Errorf("match.T = %q, want -7200s", r.Match.T)
+	if r.Match.T != "-2h" {
+		t.Errorf("match.T = %q, want -2h", r.Match.T)
 	}
 	if len(r.ContextBefore) != 1 || len(r.ContextAfter) != 1 {
 		t.Errorf("context shape mismatch: before=%d after=%d", len(r.ContextBefore), len(r.ContextAfter))

--- a/talents/archive.md
+++ b/talents/archive.md
@@ -56,9 +56,11 @@ conversation*? The split is clean once named.
 
 ## Result envelopes and byte caps
 
-All archive tools return JSON envelopes with delta-second timestamps
-(`-3600s` = an hour ago). All four enforce per-tool byte caps that
-truncate gracefully when results exceed the budget:
+All archive tools return JSON envelopes with delta timestamps —
+exact seconds under an hour (`-3247s`), hours+minutes beyond that
+(`-26h45m`), days+hours past two days (`-5d9h`). All four enforce
+per-tool byte caps that truncate gracefully when results exceed the
+budget:
 
 - `truncated: true` in the envelope means the result was clipped —
   narrow the query (tighter time range, more specific phrase,

--- a/talents/awareness.md
+++ b/talents/awareness.md
@@ -4,7 +4,7 @@ You exist in a physical world you can't see. Your senses are entity states, zone
 
 ## Time
 
-Your context shows timestamps as deltas: `-300s` means 5 minutes ago, `+3600s` means an hour from now. You process these natively, no conversion needed.
+Your context shows timestamps as deltas: `-300s` means 5 minutes ago, `-26h45m` means yesterday, `+5d9h` means five days out. Under an hour they stay in exact seconds; beyond that they arrive pre-scaled to hours or days. You process these natively, no conversion needed, and any tool that takes a timestamp accepts the same delta shapes back.
 
 When you *speak* time to humans, translate to what's useful:
 - Recent: "5 minutes ago" or "14:30"

--- a/talents/documents.md
+++ b/talents/documents.md
@@ -197,7 +197,7 @@ against the whole corpus are usually too broad to be useful:
 ```
 
 `modified_after` and `modified_before` take RFC3339 timestamps or signed
-deltas (`-604800s` = past week). Search returns compact summaries with
+deltas (`-7d` = past week). Search returns compact summaries with
 refs, not bodies — pipe a ref to `documents_read` to actually read the
 hit.
 


### PR DESCRIPTION
## Summary

Finding 5 of #1160: the delta formatters emitted canonical seconds at any magnitude, so the model read `"started":"-460301s"` and had to do the ÷86400 arithmetic that [docs/model-facing-context.md](docs/model-facing-context.md) exists to forbid. The #1160 audit found six-figure second counts throughout the live prompt — session catalogs, contact interaction ages, loop views — every one of them a small tax on the model's attention.

`FormatDelta` and `FormatDeltaOnly` now emit tiered, pre-scaled deltas, and `ParseTimeOrDelta` learned to read them back, because the two directions are one contract: models copy displayed deltas into tool arguments, so anything the formatters emit must round-trip through the parser.

## The format

| Magnitude | Shape | Example |
|---|---|---|
| under 1 hour | exact seconds | `-3247s` |
| 1 hour – 2 days | hours+minutes | `-26h45m` |
| 2 days and up | days+hours | `-5d9h` |

Sub-hour deltas keep exact seconds deliberately: that's where recency precision carries reasoning weight (message pacing, presence, tool latency), and it means the highest-churn context lines don't change shape at all. Above an hour, at most two units render and zero-valued trailing units drop (`-26h`, `-5d`), so output stays compact and deterministic. Sub-unit remainders below the second term are dropped — at those magnitudes they carry no reasoning value.

`ParseTimeOrDelta` accepts compound terms under one leading sign (`-5d9h`, `-26h45m`) alongside every previously valid form. All eight call sites already route through the shared helper, so archive, document, and revision tools pick this up for free — the parser change is the round-trip guarantee, not a new feature surface.

## Ripple

The talents that teach the model the delta contract are updated to match (`talents/awareness.md`, `talents/archive.md`, `talents/documents.md` — repo-root sources, not the generated mirror). Downstream test fixtures asserting exact second-strings at hour-plus magnitudes moved to the tiered forms (`loop_view`, `loop_outputs`, `watchlist`, `entity_format`).

One boundary worth naming: exactly 24 hours renders `-24h`, not `-1d` — the day tier starts at 48h so yesterday-scale deltas keep hour resolution.

## Test plan

- [x] Tier boundaries pinned: `-3599s` / `-1h` / `-47h59m` / `-5d9h` / `-3d`, future forms, zero-minute and zero-hour dropping
- [x] Compound parsing round-trips: `-5d9h`, `-26h45m`, `+2h30m`; malformed compounds (`-5d9`, `-5d9y`) rejected
- [x] All previously valid parser inputs unchanged
- [x] `just ci` green locally

Refs #1160

🤖 Generated with [Claude Code](https://claude.com/claude-code)
