### PR TITLE
fix(context): provider drift cleanup — framing, headings, deterministic order

### DIFF
--- a/internal/integrations/companion/context.go
+++ b/internal/integrations/companion/context.go
@@ -90,5 +90,5 @@ func (p *ContextProvider) TagContext(_ context.Context, _ agentctx.ContextReques
 	if err != nil {
 		return "", fmt.Errorf("marshal companion context: %w", err)
 	}
-	return string(data), nil
+	return "### Connected Companions\n\n" + string(data) + "\n", nil
 }

--- a/internal/integrations/companion/context_test.go
+++ b/internal/integrations/companion/context_test.go
@@ -3,6 +3,7 @@ package companion
 import (
 	"context"
 	"encoding/json"
+	"strings"
 	"testing"
 	"time"
 
@@ -22,8 +23,9 @@ func TestContextProvider_Empty(t *testing.T) {
 	if err != nil {
 		t.Fatalf("TagContext: %v", err)
 	}
-	if out != `{"companions":[]}` {
-		t.Errorf("empty registry: got %q, want explicit empty array", out)
+	want := "### Connected Companions\n\n{\"companions\":[]}\n"
+	if out != want {
+		t.Errorf("empty registry: got %q, want headed explicit empty array", out)
 	}
 }
 
@@ -52,8 +54,9 @@ func TestContextProvider_ListsConnected(t *testing.T) {
 		t.Fatalf("TagContext: %v", err)
 	}
 
+	payload := strings.TrimSpace(strings.TrimPrefix(out, "### Connected Companions\n\n"))
 	var ctx companionContextJSON
-	if err := json.Unmarshal([]byte(out), &ctx); err != nil {
+	if err := json.Unmarshal([]byte(payload), &ctx); err != nil {
 		t.Fatalf("decode context: %v (%s)", err, out)
 	}
 	if len(ctx.Companions) != 1 {

--- a/internal/integrations/forge/context.go
+++ b/internal/integrations/forge/context.go
@@ -101,5 +101,5 @@ func (p *ContextProvider) buildContext() (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("marshal forge context: %w", err)
 	}
-	return string(data), nil
+	return "### Forge Accounts\n\n" + string(data) + "\n", nil
 }

--- a/internal/integrations/forge/context_test.go
+++ b/internal/integrations/forge/context_test.go
@@ -32,10 +32,14 @@ func TestContextProvider_AccountConfig(t *testing.T) {
 		t.Error("should contain default owner")
 	}
 
-	// Should be valid JSON.
+	// Heading frames the block; the payload after it is valid JSON.
+	if !strings.HasPrefix(got, "### Forge Accounts\n\n") {
+		t.Fatalf("missing section heading, got: %s", got)
+	}
+	payload := strings.TrimPrefix(got, "### Forge Accounts\n\n")
 	var parsed map[string]any
-	if err := json.Unmarshal([]byte(got), &parsed); err != nil {
-		t.Fatalf("output should be valid JSON: %v\nGot: %s", err, got)
+	if err := json.Unmarshal([]byte(strings.TrimSpace(payload)), &parsed); err != nil {
+		t.Fatalf("payload should be valid JSON: %v\nGot: %s", err, got)
 	}
 }
 
@@ -69,8 +73,9 @@ func TestContextProvider_WithRecentOps(t *testing.T) {
 			Ago     string `json:"ago"`
 		} `json:"recent_operations"`
 	}
-	if err := json.Unmarshal([]byte(got), &parsed); err != nil {
-		t.Fatalf("output should be valid JSON: %v\nGot: %s", err, got)
+	payload := strings.TrimSpace(strings.TrimPrefix(got, "### Forge Accounts\n\n"))
+	if err := json.Unmarshal([]byte(payload), &parsed); err != nil {
+		t.Fatalf("payload should be valid JSON: %v\nGot: %s", err, got)
 	}
 
 	if len(parsed.RecentOps) != 2 {

--- a/internal/runtime/agent/channel_overview.go
+++ b/internal/runtime/agent/channel_overview.go
@@ -97,6 +97,13 @@ type channelEntry struct {
 	LoopID       string `json:"loop_id,omitempty"`
 	ConvID       string `json:"conv_id,omitempty"`
 	YouAreHere   bool   `json:"you_are_here,omitempty"`
+
+	// fullLoopID carries the untruncated loop ID for sort tie-breaking.
+	// LoopID above is an 8-rune display prefix — UUIDv7 prefixes collide
+	// for every loop created in the same ~65s window (e.g. a restart
+	// hydration burst), so it cannot anchor a total order. Unexported,
+	// so encoding/json omits it from the rendered entry.
+	fullLoopID string
 }
 
 // TagContext returns a compact JSON channel overview for injection into
@@ -141,9 +148,10 @@ func (p *ChannelOverviewProvider) TagContext(ctx context.Context, _ agentctx.Con
 		}
 
 		e := channelEntry{
-			Channel: subsystem,
-			State:   l.State,
-			LoopID:  promptfmt.ShortIDPrefix(l.ID),
+			Channel:    subsystem,
+			State:      l.State,
+			LoopID:     promptfmt.ShortIDPrefix(l.ID),
+			fullLoopID: l.ID,
 		}
 
 		// Skip parent loops (no per-conversation identity).
@@ -225,7 +233,7 @@ func (p *ChannelOverviewProvider) TagContext(ctx context.Context, _ agentctx.Con
 		if a.ConvID != b.ConvID {
 			return a.ConvID < b.ConvID
 		}
-		return a.LoopID < b.LoopID
+		return a.fullLoopID < b.fullLoopID
 	})
 
 	data, err := json.Marshal(entries)

--- a/internal/runtime/agent/channel_overview.go
+++ b/internal/runtime/agent/channel_overview.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"log/slog"
+	"sort"
 	"strings"
 	"time"
 
@@ -197,7 +198,7 @@ func (p *ChannelOverviewProvider) TagContext(ctx context.Context, _ agentctx.Con
 			}
 		}
 
-		// Exact-second delta per issue #458.
+		// Tiered delta per the model-facing time convention (#458, #1160).
 		if !l.LastWakeAt.IsZero() {
 			e.LastActivity = promptfmt.FormatDeltaOnly(l.LastWakeAt, now)
 		}
@@ -208,6 +209,24 @@ func (p *ChannelOverviewProvider) TagContext(ctx context.Context, _ agentctx.Con
 	if len(entries) == 0 {
 		return "", nil
 	}
+
+	// Deterministic order regardless of how the loop registry happens
+	// to iterate — the interface asks ChannelLoops() for sorted output,
+	// but prompt stability across turns must not rest on an upstream
+	// comment being honored.
+	sort.Slice(entries, func(i, j int) bool {
+		a, b := entries[i], entries[j]
+		if a.Channel != b.Channel {
+			return a.Channel < b.Channel
+		}
+		if a.Sender != b.Sender {
+			return a.Sender < b.Sender
+		}
+		if a.ConvID != b.ConvID {
+			return a.ConvID < b.ConvID
+		}
+		return a.LoopID < b.LoopID
+	})
 
 	data, err := json.Marshal(entries)
 	if err != nil {

--- a/internal/runtime/agent/channel_overview_test.go
+++ b/internal/runtime/agent/channel_overview_test.go
@@ -82,37 +82,39 @@ func TestChannelOverview_SignalAndOWU(t *testing.T) {
 		t.Fatalf("expected 2 entries, got %d", len(entries))
 	}
 
-	// Signal entry.
-	sig := entries[0]
-	if sig.Channel != "signal" {
-		t.Errorf("entry[0].channel = %q, want signal", sig.Channel)
-	}
-	if sig.Contact != "nugget" {
-		t.Errorf("entry[0].contact = %q, want nugget", sig.Contact)
-	}
-	if sig.Sender != "+15551234567" {
-		t.Errorf("entry[0].sender = %q, want +15551234567", sig.Sender)
-	}
-	if sig.State != "waiting" {
-		t.Errorf("entry[0].state = %q, want waiting", sig.State)
-	}
-	if sig.LastActivity != "-120s" {
-		t.Errorf("entry[0].last_activity = %q, want -120s", sig.LastActivity)
-	}
-	if sig.ConvID != "signal-15551234567" {
-		t.Errorf("entry[0].conv_id = %q, want signal-15551234567", sig.ConvID)
-	}
-
-	// OWU entry.
-	owu := entries[1]
+	// Entries sort by channel name, so owu precedes signal regardless
+	// of registry arrival order.
+	owu, sig := entries[0], entries[1]
 	if owu.Channel != "owu" {
-		t.Errorf("entry[1].channel = %q, want owu", owu.Channel)
+		t.Errorf("entry[0].channel = %q, want owu", owu.Channel)
 	}
 	if owu.DisplayName != "home-automation" {
-		t.Errorf("entry[1].display_name = %q, want home-automation", owu.DisplayName)
+		t.Errorf("entry[0].display_name = %q, want home-automation", owu.DisplayName)
 	}
 	if owu.ConvID != "owu-xyz" {
-		t.Errorf("entry[1].conv_id = %q, want owu-xyz", owu.ConvID)
+		t.Errorf("entry[0].conv_id = %q, want owu-xyz", owu.ConvID)
+	}
+	if owu.LastActivity != "-4h" {
+		t.Errorf("entry[0].last_activity = %q, want -4h", owu.LastActivity)
+	}
+
+	if sig.Channel != "signal" {
+		t.Errorf("entry[1].channel = %q, want signal", sig.Channel)
+	}
+	if sig.Contact != "nugget" {
+		t.Errorf("entry[1].contact = %q, want nugget", sig.Contact)
+	}
+	if sig.Sender != "+15551234567" {
+		t.Errorf("entry[1].sender = %q, want +15551234567", sig.Sender)
+	}
+	if sig.State != "waiting" {
+		t.Errorf("entry[1].state = %q, want waiting", sig.State)
+	}
+	if sig.LastActivity != "-120s" {
+		t.Errorf("entry[1].last_activity = %q, want -120s", sig.LastActivity)
+	}
+	if sig.ConvID != "signal-15551234567" {
+		t.Errorf("entry[1].conv_id = %q, want signal-15551234567", sig.ConvID)
 	}
 }
 

--- a/internal/runtime/agent/channel_overview_test.go
+++ b/internal/runtime/agent/channel_overview_test.go
@@ -214,3 +214,55 @@ func TestChannelOverview_NilPhoneResolver(t *testing.T) {
 		t.Errorf("sender should still be set: got %q", entries[0].Sender)
 	}
 }
+
+func TestChannelOverview_SortTieBreaksOnFullLoopID(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 3, 29, 15, 0, 0, 0, time.UTC)
+
+	// Two loops whose UUIDv7 IDs share the same 8-rune display prefix —
+	// the norm for loops created in the same ~65s window (e.g. restart
+	// hydration) — and identical channel/sender/conv sort keys. Fed in
+	// descending full-ID order; output must sort ascending by full ID.
+	p := NewChannelOverviewProvider(ChannelOverviewConfig{
+		Loops: &mockLoopSource{loops: []LoopSnapshot{
+			// State is the observable marker for order: it differs per
+			// loop but plays no part in the sort key.
+			{
+				ID: "019f2400-ffff-7000-8000-000000000002", Name: "matrix/b",
+				State:    "sleeping",
+				Metadata: map[string]string{"subsystem": "matrix", "category": "channel"},
+			},
+			{
+				ID: "019f2400-aaaa-7000-8000-000000000001", Name: "matrix/a",
+				State:    "waiting",
+				Metadata: map[string]string{"subsystem": "matrix", "category": "channel"},
+			},
+		}},
+	})
+	p.nowFunc = func() time.Time { return now }
+
+	got, err := p.TagContext(context.Background(), agentctx.ContextRequest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	jsonStr := strings.TrimSpace(strings.TrimPrefix(got, "### Channel Overview\n\n"))
+	var entries []channelEntry
+	if err := json.Unmarshal([]byte(jsonStr), &entries); err != nil {
+		t.Fatalf("invalid JSON: %v\n%s", err, jsonStr)
+	}
+	if len(entries) != 2 {
+		t.Fatalf("expected 2 entries, got %d", len(entries))
+	}
+	if entries[0].LoopID != entries[1].LoopID {
+		t.Fatalf("test premise broken: display prefixes differ (%q vs %q)", entries[0].LoopID, entries[1].LoopID)
+	}
+	// The unexported tie-break field must not leak into the JSON.
+	if strings.Contains(jsonStr, "fullLoopID") || strings.Contains(jsonStr, "000000000001\",\"full") {
+		t.Errorf("full loop ID leaked into rendered JSON:\n%s", jsonStr)
+	}
+	// Ascending full-ID order: the -aaaa- loop (state=waiting) sorts
+	// first even though it arrived second.
+	if entries[0].State != "waiting" || entries[1].State != "sleeping" {
+		t.Errorf("order = [%s, %s], want [waiting, sleeping] (full-ID ascending)", entries[0].State, entries[1].State)
+	}
+}

--- a/internal/state/awareness/watchlist_provider.go
+++ b/internal/state/awareness/watchlist_provider.go
@@ -115,9 +115,9 @@ func (p *WatchlistProvider) TagContext(ctx context.Context, _ agentctx.ContextRe
 		return "", nil
 	}
 	return "### Watched Entities\n\n" +
-		"_This is a keyhole onto a few subscribed entities, not the house. " +
-		"For anything wider — another room, a device, live state, history, " +
-		"control, or automations — activate the `ha` capability tag._\n\n" +
+		"Live state for explicitly subscribed entities only. Wider Home " +
+		"Assistant access (other rooms, devices, history, control, " +
+		"automations) is behind the `ha` capability tag.\n\n" +
 		body.String(), nil
 }
 


### PR DESCRIPTION
## Summary

Finding 6 of #1160, closing out the provider drift table — the small per-provider deviations from [docs/model-facing-context.md](docs/model-facing-context.md) that each cost a little model clarity per turn. Stacked on #1165 (the tiered-delta change); GitHub will retarget to main when that merges.

An honest correction first: the audit listed five provider-level violations, and verification killed two of them. The archive transcript renderer with the emoji role headers (`### 🧑 User [15:04:05]`) and the absolute-timestamp session headers both live in `ExportSessionMarkdown`, which is consumed only by the human-facing `GET /v1/archive/sessions/{id}/export` download — the model-facing `archive_session_transcript` tool already emits the clean JSON projection with metadata separated from corpus. No model ever sees the emoji. Those two entries were false positives from reviewing the renderer without checking its call graph, and #1160 gets a correcting comment.

## What actually changed

**Watchlist framing rewritten from the model's vantage point** ([watchlist_provider.go](internal/state/awareness/watchlist_provider.go)). The block opened with an italicized editor-voice aside — "_This is a keyhole onto a few subscribed entities, not the house…_" — deictic language whose referent the model has to infer, wrapped around a behavioral instruction. It's now a plain statement of scope with the affordance named factually: live state for subscribed entities only; wider Home Assistant access is behind the `ha` tag.

**Forge and companion contexts get section boundaries** ([forge/context.go](internal/integrations/forge/context.go), [companion/context.go](internal/integrations/companion/context.go)). Both providers emitted bare JSON straight into the continuity bucket while every sibling frames its payload with a `### Heading` — the doctrine's "markdown for section boundaries, JSON for data" split. They now render `### Forge Accounts` and `### Connected Companions`, matching the `### Channel Context` pattern. The companion provider's deliberate explicit-empty `{"companions":[]}` behavior is preserved under the heading.

**Channel overview ordering no longer trusts an upstream comment** ([channel_overview.go](internal/runtime/agent/channel_overview.go)). The `ChannelLoops()` interface *asks* implementations for deterministic order, but nothing enforced it, and JSON array order flows straight into the prompt — any upstream map-iteration change would silently churn prompt bytes every turn. Entries now sort locally (channel, then sender, then conversation, then loop ID) before marshaling. The existing overview test now pins the sorted order, feeding the registry signal-first and asserting owu-first output.

Also swept up: the overview's "exact-second delta" comment was stale after #1165's tiered deltas — updated to reference the current convention.

## Test plan

- [x] `TestChannelOverview_SignalAndOWU` — registry arrival order (signal, owu) renders sorted (owu, signal), with tiered `-4h` delta
- [x] Forge/companion tests assert the heading and parse the payload after it
- [x] `TestContextProvider_Empty` — headed explicit empty array preserved
- [x] `just ci` green locally

Refs #1160

🤖 Generated with [Claude Code](https://claude.com/claude-code)
