### PR TITLE
fix(memory): compaction coherence — single-flight, fold, position, ID-set marking

### DIFF
--- a/examples/config.example.yaml
+++ b/examples/config.example.yaml
@@ -528,6 +528,16 @@ talents_dir: ./talents
 #   catalog is rendered. Default: 4000.
 #   history_tokens: 4000
 #
+# Compaction bounds per-conversation working memory: once a
+# conversation's active token count crosses the trigger, older
+# history folds into a single summary message.
+compaction:
+  # MaxTokens is the conversation token budget compaction defends;
+  # compaction triggers at 70% of it. Default: 32000. The previous
+  # hardcoded 8000 compacted interactive conversations far too
+  # early for modern context windows (#1168).
+  max_tokens: 0
+#
 # (optional) Agent configures agent loop behavior, including orchestrator
 # agent:
 #   OrchestratorTools lists tool names to advertise when

--- a/internal/app/new_stores.go
+++ b/internal/app/new_stores.go
@@ -353,7 +353,7 @@ func (a *App) initStores(s *newState) error {
 	// messages to stay within the model's context window. Routes through
 	// the model router for quality-aware model selection.
 	compactionConfig := memory.CompactionConfig{
-		MaxTokens:            8000,
+		MaxTokens:            a.cfg.Compaction.MaxTokens,
 		TriggerRatio:         0.7, // Compact at 70% of MaxTokens
 		KeepRecent:           10,  // Preserve the last 10 messages verbatim
 		MinMessagesToCompact: 15,  // Don't bother compacting tiny conversations

--- a/internal/platform/config/config.go
+++ b/internal/platform/config/config.go
@@ -226,6 +226,11 @@ type Config struct {
 	// memory files and recent conversation history).
 	Episodic EpisodicConfig `yaml:"episodic"`
 
+	// Compaction bounds per-conversation working memory: once a
+	// conversation's active token count crosses the trigger, older
+	// history folds into a single summary message.
+	Compaction CompactionConfig `yaml:"compaction"`
+
 	// Agent configures agent loop behavior, including orchestrator
 	// tool gating for delegation-first architecture.
 	Agent AgentConfig `yaml:"agent"`
@@ -1315,6 +1320,15 @@ type ExtractionConfig struct {
 // configured, the agent receives curated daily notes plus a JSON
 // catalog of recent closed sessions in its system prompt, giving it
 // continuity and discoverable archive entry points across sessions.
+// CompactionConfig controls when conversation compaction runs.
+type CompactionConfig struct {
+	// MaxTokens is the conversation token budget compaction defends;
+	// compaction triggers at 70% of it. Default: 32000. The previous
+	// hardcoded 8000 compacted interactive conversations far too
+	// early for modern context windows (#1168).
+	MaxTokens int `yaml:"max_tokens"`
+}
+
 type EpisodicConfig struct {
 	// DailyDir is the directory containing daily memory files named
 	// YYYY-MM-DD.md. Supports ~ expansion. If empty, daily memory
@@ -2431,6 +2445,9 @@ func (c *Config) applyDefaults() {
 
 	if c.Episodic.LookbackDays == 0 {
 		c.Episodic.LookbackDays = 2
+	}
+	if c.Compaction.MaxTokens == 0 {
+		c.Compaction.MaxTokens = 32000
 	}
 	if c.Episodic.HistoryTokens == 0 {
 		c.Episodic.HistoryTokens = 4000

--- a/internal/platform/config/config.go
+++ b/internal/platform/config/config.go
@@ -1316,10 +1316,6 @@ type ExtractionConfig struct {
 	TimeoutSeconds int `yaml:"timeout_seconds"`
 }
 
-// EpisodicConfig configures episodic memory context injection. When
-// configured, the agent receives curated daily notes plus a JSON
-// catalog of recent closed sessions in its system prompt, giving it
-// continuity and discoverable archive entry points across sessions.
 // CompactionConfig controls when conversation compaction runs.
 type CompactionConfig struct {
 	// MaxTokens is the conversation token budget compaction defends;
@@ -1329,6 +1325,10 @@ type CompactionConfig struct {
 	MaxTokens int `yaml:"max_tokens"`
 }
 
+// EpisodicConfig configures episodic memory context injection. When
+// configured, the agent receives curated daily notes plus a JSON
+// catalog of recent closed sessions in its system prompt, giving it
+// continuity and discoverable archive entry points across sessions.
 type EpisodicConfig struct {
 	// DailyDir is the directory containing daily memory files named
 	// YYYY-MM-DD.md. Supports ~ expansion. If empty, daily memory

--- a/internal/state/memory/compaction.go
+++ b/internal/state/memory/compaction.go
@@ -39,9 +39,10 @@ const CompactionSummaryPrefix = "[Conversation Summary]"
 type CompactableStore interface {
 	GetTokenCount(conversationID string) int
 	GetMessagesForCompaction(conversationID string, keep int) []Message
-	GetActiveCompactionSummaries(conversationID string) []Message
-	MarkCompactedByIDs(conversationID string, ids []string) error
-	AddCompactionSummaryAt(conversationID, summary string, ts time.Time) error
+	GetActiveCompactionSummaries(conversationID string) ([]Message, error)
+	// ApplyCompaction atomically marks compactedIDs compacted and
+	// inserts the replacement summary at summaryTS.
+	ApplyCompaction(conversationID string, compactedIDs []string, summary string, summaryTS time.Time) error
 }
 
 // WorkingMemoryReader is the subset of WorkingMemoryStore needed by the
@@ -183,8 +184,13 @@ func (c *Compactor) Compact(ctx context.Context, conversationID string) error {
 	// and keep the token count pinned above the trigger — a ratchet
 	// that squashes every ~15 fresh messages into yet another stacked
 	// summary (#1168 defect 2). Priors prepend to the summarizer input
-	// so their content carries forward through the new summary.
-	priors := c.store.GetActiveCompactionSummaries(conversationID)
+	// so their content carries forward through the new summary. A read
+	// error here must abort: treating it as "no priors" would insert a
+	// fresh summary and re-stack, the exact failure the fold prevents.
+	priors, err := c.store.GetActiveCompactionSummaries(conversationID)
+	if err != nil {
+		return fmt.Errorf("read prior summaries: %w", err)
+	}
 	folded := make([]Message, 0, len(priors)+len(messages))
 	folded = append(folded, priors...)
 	folded = append(folded, messages...)
@@ -215,23 +221,19 @@ func (c *Compactor) Compact(ctx context.Context, conversationID string) error {
 	// Format as a system message
 	formattedSummary := formatCompactionSummary(folded, summary)
 
-	// Mark exactly the rows that were summarized — by ID, not by a
-	// wall-clock cutoff that can slice through rows the summarizer
-	// never saw.
+	// Apply atomically: mark exactly the rows the summarizer saw
+	// (by ID, so a wall-clock cutoff can't sweep in rows written
+	// mid-compaction) and insert the replacement summary at the
+	// folded region's earliest timestamp — so it sorts at the head of
+	// surviving history rather than interleaved into the live exchange
+	// (#1168 defect 3). A single transaction means a mid-write failure
+	// can't strand history without its summary (#1168, PR #1170 review).
 	ids := make([]string, len(folded))
 	for i, m := range folded {
 		ids[i] = m.ID
 	}
-	if err := c.store.MarkCompactedByIDs(conversationID, ids); err != nil {
-		return fmt.Errorf("mark compacted: %w", err)
-	}
-
-	// The summary takes the folded region's earliest timestamp so it
-	// sorts where the region was, at the head of surviving history. A
-	// now() stamp would interleave it into the middle of the live
-	// exchange (#1168 defect 3).
-	if err := c.store.AddCompactionSummaryAt(conversationID, formattedSummary, folded[0].Timestamp); err != nil {
-		return fmt.Errorf("add summary: %w", err)
+	if err := c.store.ApplyCompaction(conversationID, ids, formattedSummary, folded[0].Timestamp); err != nil {
+		return fmt.Errorf("apply compaction: %w", err)
 	}
 
 	return nil

--- a/internal/state/memory/compaction.go
+++ b/internal/state/memory/compaction.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/nugget/thane-ai-agent/internal/model/prompts"
@@ -12,7 +13,7 @@ import (
 
 // CompactionConfig controls compaction behavior.
 type CompactionConfig struct {
-	MaxTokens            int     // Context window size
+	MaxTokens            int     // Conversation token budget compaction defends
 	TriggerRatio         float64 // Trigger compaction at this ratio (e.g., 0.7 = 70%)
 	KeepRecent           int     // Number of recent messages to always keep
 	MinMessagesToCompact int     // Minimum messages before considering compaction
@@ -21,19 +22,26 @@ type CompactionConfig struct {
 // DefaultCompactionConfig returns sensible defaults.
 func DefaultCompactionConfig() CompactionConfig {
 	return CompactionConfig{
-		MaxTokens:            8000, // Conservative default
-		TriggerRatio:         0.7,  // Trigger at 70% full
-		KeepRecent:           10,   // Keep last 10 messages
-		MinMessagesToCompact: 20,   // Don't compact tiny conversations
+		MaxTokens:            32000, // See config `compaction.max_tokens` (#1168)
+		TriggerRatio:         0.7,   // Trigger at 70% full
+		KeepRecent:           10,    // Keep last 10 messages
+		MinMessagesToCompact: 20,    // Don't compact tiny conversations
 	}
 }
+
+// CompactionSummaryPrefix marks a stored system message as a compaction
+// summary. It is both the render prefix and the discriminator that
+// separates summaries from other system rows (e.g. session handoffs),
+// so folding can find prior summaries without a schema change.
+const CompactionSummaryPrefix = "[Conversation Summary]"
 
 // CompactableStore is the interface for stores that support compaction.
 type CompactableStore interface {
 	GetTokenCount(conversationID string) int
 	GetMessagesForCompaction(conversationID string, keep int) []Message
-	MarkCompacted(conversationID string, before time.Time) error
-	AddCompactionSummary(conversationID, summary string) error
+	GetActiveCompactionSummaries(conversationID string) []Message
+	MarkCompactedByIDs(conversationID string, ids []string) error
+	AddCompactionSummaryAt(conversationID, summary string, ts time.Time) error
 }
 
 // WorkingMemoryReader is the subset of WorkingMemoryStore needed by the
@@ -50,6 +58,14 @@ type Compactor struct {
 	summarizer    Summarizer
 	workingMemory WorkingMemoryReader // optional — include in compaction prompt
 	logger        *slog.Logger
+
+	// inFlight single-flights compaction per conversation. The
+	// summarize step is a slow LLM call, and without the guard every
+	// turn that lands during one compaction spawns another — all
+	// reading overlapping history and each stacking its own summary
+	// (#1168 defect 1).
+	mu       sync.Mutex
+	inFlight map[string]bool
 }
 
 // Summarizer generates summaries from messages. When workingMemory is
@@ -66,6 +82,7 @@ func NewCompactor(store CompactableStore, config CompactionConfig, summarizer Su
 		config:     config,
 		summarizer: summarizer,
 		logger:     logger,
+		inFlight:   make(map[string]bool),
 	}
 }
 
@@ -86,10 +103,61 @@ func (c *Compactor) NeedsCompaction(conversationID string) bool {
 	return tokenCount > c.CompactionThreshold()
 }
 
-// Compact performs compaction on a conversation.
+// tryAcquire marks the conversation as compacting, returning false when
+// a compaction is already in flight for it.
+func (c *Compactor) tryAcquire(conversationID string) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.inFlight[conversationID] {
+		return false
+	}
+	c.inFlight[conversationID] = true
+	return true
+}
+
+func (c *Compactor) release(conversationID string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	delete(c.inFlight, conversationID)
+}
+
+// Compact performs compaction on a conversation: it folds any prior
+// summary together with the older messages into a single fresh summary,
+// marks the folded rows compacted, and inserts the summary at the
+// compacted region's temporal position so it renders at the head of
+// surviving history rather than interleaved into the live dialogue.
+// Concurrent calls for the same conversation coalesce — the extras
+// return nil without doing work.
 func (c *Compactor) Compact(ctx context.Context, conversationID string) error {
+	if !c.tryAcquire(conversationID) {
+		c.logger.Debug("compaction already in flight; skipping",
+			"conversation_id", conversationID)
+		return nil
+	}
+	defer c.release(conversationID)
+
+	// Re-check under the flight guard: the trigger that queued this
+	// call may predate a compaction that just finished.
+	if !c.NeedsCompaction(conversationID) {
+		return nil
+	}
+
 	// Get messages to compact (older ones)
 	messages := c.store.GetMessagesForCompaction(conversationID, c.config.KeepRecent)
+
+	// Snap the compaction boundary to a turn edge: a trailing user
+	// message here means its reply sits in the keep window (or hasn't
+	// arrived), and compacting the question while keeping the answer
+	// orphans the reply (#1168 defect 4). Bounding memory outranks
+	// turn integrity, though — if the trim would starve compaction
+	// (e.g. a long user monologue), keep the untrimmed set.
+	trimmed := messages
+	for len(trimmed) > 0 && trimmed[len(trimmed)-1].Role == "user" {
+		trimmed = trimmed[:len(trimmed)-1]
+	}
+	if len(trimmed) >= c.config.MinMessagesToCompact || len(messages) < c.config.MinMessagesToCompact {
+		messages = trimmed
+	}
 
 	c.logger.Debug("compaction check",
 		"conversation_id", conversationID,
@@ -109,15 +177,21 @@ func (c *Compactor) Compact(ctx context.Context, conversationID string) error {
 		return nil // Not enough to bother
 	}
 
+	// Fold prior summaries into this pass so exactly one summary row
+	// exists per conversation. Without the fold, summaries are
+	// immortal (they are system rows, which compaction never selects)
+	// and keep the token count pinned above the trigger — a ratchet
+	// that squashes every ~15 fresh messages into yet another stacked
+	// summary (#1168 defect 2). Priors prepend to the summarizer input
+	// so their content carries forward through the new summary.
+	priors := c.store.GetActiveCompactionSummaries(conversationID)
+	folded := make([]Message, 0, len(priors)+len(messages))
+	folded = append(folded, priors...)
+	folded = append(folded, messages...)
+
 	// Messages persist in the unified table with lifecycle status.
 	// Compaction marks them as 'compacted' — they're never deleted and
 	// remain searchable in the archive. No separate archive step needed.
-
-	// Find the cutoff time (last message being compacted)
-	var cutoffTime time.Time
-	if len(messages) > 0 {
-		cutoffTime = messages[len(messages)-1].Timestamp
-	}
 
 	// Read working memory for inclusion in the compaction prompt.
 	var workingMem string
@@ -133,21 +207,30 @@ func (c *Compactor) Compact(ctx context.Context, conversationID string) error {
 	}
 
 	// Generate summary
-	summary, err := c.summarizer.Summarize(ctx, messages, workingMem)
+	summary, err := c.summarizer.Summarize(ctx, folded, workingMem)
 	if err != nil {
 		return fmt.Errorf("summarize: %w", err)
 	}
 
 	// Format as a system message
-	formattedSummary := formatCompactionSummary(messages, summary)
+	formattedSummary := formatCompactionSummary(folded, summary)
 
-	// Mark old messages as compacted
-	if err := c.store.MarkCompacted(conversationID, cutoffTime.Add(time.Millisecond)); err != nil {
+	// Mark exactly the rows that were summarized — by ID, not by a
+	// wall-clock cutoff that can slice through rows the summarizer
+	// never saw.
+	ids := make([]string, len(folded))
+	for i, m := range folded {
+		ids[i] = m.ID
+	}
+	if err := c.store.MarkCompactedByIDs(conversationID, ids); err != nil {
 		return fmt.Errorf("mark compacted: %w", err)
 	}
 
-	// Add summary message
-	if err := c.store.AddCompactionSummary(conversationID, formattedSummary); err != nil {
+	// The summary takes the folded region's earliest timestamp so it
+	// sorts where the region was, at the head of surviving history. A
+	// now() stamp would interleave it into the middle of the live
+	// exchange (#1168 defect 3).
+	if err := c.store.AddCompactionSummaryAt(conversationID, formattedSummary, folded[0].Timestamp); err != nil {
 		return fmt.Errorf("add summary: %w", err)
 	}
 
@@ -164,7 +247,7 @@ func formatCompactionSummary(messages []Message, summary string) string {
 	endTime := messages[len(messages)-1].Timestamp
 
 	var sb strings.Builder
-	sb.WriteString("[Conversation Summary]\n")
+	sb.WriteString(CompactionSummaryPrefix + "\n")
 	sb.WriteString(fmt.Sprintf("Period: %s to %s\n",
 		startTime.Format("2006-01-02 15:04"),
 		endTime.Format("2006-01-02 15:04")))
@@ -200,7 +283,9 @@ func NewLLMSummarizer(llmFunc func(ctx context.Context, prompt string) (string, 
 
 // Summarize generates a summary of the messages using an LLM. When
 // workingMemory is non-empty, it is included in the prompt so the
-// summarizer preserves experiential context through compaction.
+// summarizer preserves experiential context through compaction. Prior
+// compaction summaries arrive as leading system-role messages and fold
+// into the new summary through the same transcript rendering.
 func (s *LLMSummarizer) Summarize(ctx context.Context, messages []Message, workingMemory string) (string, error) {
 	// Build conversation text
 	var sb strings.Builder

--- a/internal/state/memory/compaction_test.go
+++ b/internal/state/memory/compaction_test.go
@@ -3,94 +3,231 @@ package memory
 import (
 	"context"
 	"log/slog"
-	"os"
+	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 )
 
-func TestCompaction(t *testing.T) {
-	// Create temp database
-	tmpFile, err := os.CreateTemp("", "thane-test-*.db")
+// newCompactionTestStore returns a store seeded with n user/assistant
+// exchange pairs on convID, with timestamps spaced one minute apart
+// starting at base.
+func newCompactionTestStore(t *testing.T, convID string, base time.Time, pairs int) *SQLiteStore {
+	t.Helper()
+	store, err := NewSQLiteStore(t.TempDir()+"/compact.db", 100)
 	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("NewSQLiteStore: %v", err)
 	}
-	defer os.Remove(tmpFile.Name())
-	tmpFile.Close()
+	t.Cleanup(func() { _ = store.Close() })
 
-	// Create store
-	store, err := NewSQLiteStore(tmpFile.Name(), 100)
-	if err != nil {
-		t.Fatal(err)
+	if _, err := store.GetOrCreateConversation(convID); err != nil {
+		t.Fatalf("GetOrCreateConversation: %v", err)
 	}
-	defer store.Close()
-
-	convID := "test-conv"
-
-	// Add many messages to trigger compaction
-	for i := 0; i < 30; i++ {
-		store.AddMessage(convID, "user", "This is test message number "+string(rune('0'+i%10))+" with some content to make it longer")
-		store.AddMessage(convID, "assistant", "This is response number "+string(rune('0'+i%10))+" with some content to make it longer too")
+	for i := range pairs {
+		ts := base.Add(time.Duration(2*i) * time.Minute)
+		insertMessageAt(t, store, convID, "user", "question about topic number "+string(rune('a'+i%26))+" with padding to carry some weight", ts)
+		insertMessageAt(t, store, convID, "assistant", "answer covering topic number "+string(rune('a'+i%26))+" with padding to carry some weight", ts.Add(time.Minute))
 	}
+	return store
+}
 
-	// Check token count
-	tokens := store.GetTokenCount(convID)
-	t.Logf("Token count after 60 messages: %d", tokens)
+// insertMessageAt writes a message with a controlled timestamp — the
+// production AddMessage stamps now(), which these tests can't use.
+func insertMessageAt(t *testing.T, store *SQLiteStore, convID, role, content string, ts time.Time) {
+	t.Helper()
+	id := "msg-" + ts.Format("20060102150405.000000000") + "-" + role
+	if _, err := store.db.Exec(`
+		INSERT INTO messages (id, conversation_id, role, content, timestamp, token_count, status)
+		VALUES (?, ?, ?, ?, ?, 100, 'active')
+	`, id, convID, role, content, ts); err != nil {
+		t.Fatalf("insert message: %v", err)
+	}
+}
 
-	// Create compactor with simple summarizer
-	config := CompactionConfig{
-		MaxTokens:            2000, // Low threshold for testing
+// countingSummarizer counts invocations and optionally blocks until
+// released, for exercising the single-flight guard.
+type countingSummarizer struct {
+	calls   atomic.Int32
+	block   chan struct{} // nil = don't block
+	sawText []string
+	mu      sync.Mutex
+}
+
+func (c *countingSummarizer) Summarize(_ context.Context, messages []Message, _ string) (string, error) {
+	c.calls.Add(1)
+	var sb strings.Builder
+	for _, m := range messages {
+		sb.WriteString(m.Content)
+		sb.WriteString("\n")
+	}
+	c.mu.Lock()
+	c.sawText = append(c.sawText, sb.String())
+	c.mu.Unlock()
+	if c.block != nil {
+		<-c.block
+	}
+	return "condensed summary", nil
+}
+
+func compactorFor(store *SQLiteStore, sum Summarizer) *Compactor {
+	return NewCompactor(store, CompactionConfig{
+		MaxTokens:            2000, // low budget so the seeded rows trigger
 		TriggerRatio:         0.5,
-		KeepRecent:           10,
-		MinMessagesToCompact: 10,
-	}
-	compactor := NewCompactor(store, config, &SimpleSummarizer{}, slog.Default())
+		KeepRecent:           4,
+		MinMessagesToCompact: 6,
+	}, sum, slog.Default())
+}
 
-	// Check if needs compaction
-	if !compactor.NeedsCompaction(convID) {
-		t.Log("Compaction not needed (might be expected with low message count)")
-	} else {
-		t.Log("Compaction needed!")
-	}
+func TestCompaction_SingleFlightCoalescesConcurrentRuns(t *testing.T) {
+	base := time.Now().Add(-2 * time.Hour).Truncate(time.Second)
+	store := newCompactionTestStore(t, "conv-1", base, 15)
 
-	// Get messages for compaction
-	toCompact := store.GetMessagesForCompaction(convID, config.KeepRecent)
-	t.Logf("Messages to compact: %d", len(toCompact))
+	sum := &countingSummarizer{block: make(chan struct{})}
+	c := compactorFor(store, sum)
 
-	// Run compaction
-	if len(toCompact) >= config.MinMessagesToCompact {
-		err = compactor.Compact(context.Background(), convID)
-		if err != nil {
-			t.Fatalf("Compaction failed: %v", err)
+	first := make(chan error, 1)
+	go func() { first <- c.Compact(context.Background(), "conv-1") }()
+
+	// Wait for the first run to enter Summarize, then race a second.
+	deadline := time.After(5 * time.Second)
+	for sum.calls.Load() == 0 {
+		select {
+		case <-deadline:
+			t.Fatal("first compaction never reached the summarizer")
+		default:
+			time.Sleep(5 * time.Millisecond)
 		}
-		t.Log("Compaction completed!")
+	}
+	if err := c.Compact(context.Background(), "conv-1"); err != nil {
+		t.Fatalf("second Compact: %v", err)
+	}
+	if got := sum.calls.Load(); got != 1 {
+		t.Errorf("summarizer calls during flight = %d, want 1 (second run must coalesce)", got)
+	}
 
-		// Check messages after compaction
-		messages := store.GetMessages(convID)
-		t.Logf("Messages after compaction: %d", len(messages))
+	close(sum.block)
+	if err := <-first; err != nil {
+		t.Fatalf("first Compact: %v", err)
+	}
+	if got := len(store.GetActiveCompactionSummaries("conv-1")); got != 1 {
+		t.Errorf("active summaries = %d, want exactly 1", got)
+	}
+}
 
-		// Should have summary + recent messages
-		if len(messages) > config.KeepRecent+5 {
-			t.Errorf("Expected around %d messages, got %d", config.KeepRecent, len(messages))
-		}
+func TestCompaction_FoldsPriorSummariesIntoOne(t *testing.T) {
+	base := time.Now().Add(-3 * time.Hour).Truncate(time.Second)
+	store := newCompactionTestStore(t, "conv-1", base, 15)
 
-		// Check new token count
-		newTokens := store.GetTokenCount(convID)
-		t.Logf("Token count after compaction: %d (was %d)", newTokens, tokens)
+	sum := &countingSummarizer{}
+	c := compactorFor(store, sum)
 
-		if newTokens >= tokens {
-			t.Error("Token count should have decreased after compaction")
+	if err := c.Compact(context.Background(), "conv-1"); err != nil {
+		t.Fatalf("first Compact: %v", err)
+	}
+	// New traffic re-arms the trigger past the first summary.
+	for i := range 12 {
+		ts := base.Add(2 * time.Hour).Add(time.Duration(2*i) * time.Minute)
+		insertMessageAt(t, store, "conv-1", "user", "later question with enough padding to count tokens", ts)
+		insertMessageAt(t, store, "conv-1", "assistant", "later answer with enough padding to count tokens", ts.Add(time.Minute))
+	}
+	if err := c.Compact(context.Background(), "conv-1"); err != nil {
+		t.Fatalf("second Compact: %v", err)
+	}
+
+	summaries := store.GetActiveCompactionSummaries("conv-1")
+	if len(summaries) != 1 {
+		t.Fatalf("active summaries = %d, want exactly 1 (priors must fold, not stack)", len(summaries))
+	}
+	// The second summarizer invocation must have received the first
+	// summary's content, so nothing silently vanishes in the fold.
+	sum.mu.Lock()
+	lastInput := sum.sawText[len(sum.sawText)-1]
+	sum.mu.Unlock()
+	if !strings.Contains(lastInput, CompactionSummaryPrefix) {
+		t.Errorf("second summarize input missing the prior summary:\n%s", lastInput)
+	}
+}
+
+func TestCompaction_SummaryTakesCompactedRegionPosition(t *testing.T) {
+	base := time.Now().Add(-4 * time.Hour).Truncate(time.Second)
+	store := newCompactionTestStore(t, "conv-1", base, 15)
+
+	c := compactorFor(store, &countingSummarizer{})
+	if err := c.Compact(context.Background(), "conv-1"); err != nil {
+		t.Fatalf("Compact: %v", err)
+	}
+
+	// The summary must render FIRST in active history — at the
+	// compacted region's position — never interleaved after surviving
+	// messages the way a now() stamp would place it.
+	messages := store.GetMessages("conv-1")
+	if len(messages) == 0 {
+		t.Fatal("no active messages after compaction")
+	}
+	if !strings.HasPrefix(messages[0].Content, CompactionSummaryPrefix) {
+		t.Errorf("messages[0] is %q..., want the compaction summary at the head of history", messages[0].Content[:min(40, len(messages[0].Content))])
+	}
+	for i, m := range messages[1:] {
+		if strings.HasPrefix(m.Content, CompactionSummaryPrefix) {
+			t.Errorf("summary found at position %d — interleaved into live dialogue", i+1)
 		}
 	}
 }
 
-func TestCompactionStats(t *testing.T) {
-	tmpFile, err := os.CreateTemp("", "thane-test-*.db")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Remove(tmpFile.Name())
-	tmpFile.Close()
+func TestCompaction_BoundarySnapsToTurnEdge(t *testing.T) {
+	base := time.Now().Add(-2 * time.Hour).Truncate(time.Second)
+	store := newCompactionTestStore(t, "conv-1", base, 7)
+	// Arrange the boundary to fall right after a user message: with
+	// KeepRecent=4, the candidate set ends on the user half of the
+	// 5th-from-last exchange.
+	ts := base.Add(30 * time.Minute)
+	insertMessageAt(t, store, "conv-1", "user", "dangling question whose answer is in the keep window", ts)
+	insertMessageAt(t, store, "conv-1", "assistant", "the answer that must not be orphaned", ts.Add(time.Minute))
 
-	store, err := NewSQLiteStore(tmpFile.Name(), 100)
+	c := compactorFor(store, &countingSummarizer{})
+	if err := c.Compact(context.Background(), "conv-1"); err != nil {
+		t.Fatalf("Compact: %v", err)
+	}
+
+	// Every surviving non-summary message run must not START with an
+	// orphaned assistant reply: the message right after the summary is
+	// either a user message or nothing.
+	messages := store.GetMessages("conv-1")
+	if len(messages) < 2 {
+		t.Fatalf("unexpectedly few messages: %d", len(messages))
+	}
+	if messages[1].Role == "assistant" {
+		t.Errorf("first message after summary is an assistant reply (%q) — turn pair split", messages[1].Content[:min(40, len(messages[1].Content))])
+	}
+}
+
+func TestCompaction_ReleasesFlightGuardOnSkip(t *testing.T) {
+	// A conversation below MinMessages must release the single-flight
+	// guard so later, larger compactions aren't locked out forever.
+	base := time.Now().Add(-time.Hour).Truncate(time.Second)
+	store := newCompactionTestStore(t, "conv-1", base, 3)
+
+	sum := &countingSummarizer{}
+	c := compactorFor(store, sum)
+	if err := c.Compact(context.Background(), "conv-1"); err != nil {
+		t.Fatalf("skip Compact: %v", err)
+	}
+	for i := range 12 {
+		ts := base.Add(30 * time.Minute).Add(time.Duration(2*i) * time.Minute)
+		insertMessageAt(t, store, "conv-1", "user", "more traffic with padding for the token estimator", ts)
+		insertMessageAt(t, store, "conv-1", "assistant", "more replies with padding for the token estimator", ts.Add(time.Minute))
+	}
+	if err := c.Compact(context.Background(), "conv-1"); err != nil {
+		t.Fatalf("second Compact: %v", err)
+	}
+	if sum.calls.Load() == 0 {
+		t.Error("second compaction never ran — flight guard leaked on the skip path")
+	}
+}
+
+func TestCompactionStats(t *testing.T) {
+	store, err := NewSQLiteStore(t.TempDir()+"/stats.db", 100)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -100,8 +237,6 @@ func TestCompactionStats(t *testing.T) {
 	compactor := NewCompactor(store, config, &SimpleSummarizer{}, slog.Default())
 
 	stats := compactor.CompactionStats("test")
-	t.Logf("Stats: %+v", stats)
-
 	if stats["max_tokens"] != config.MaxTokens {
 		t.Errorf("Expected max_tokens %d, got %v", config.MaxTokens, stats["max_tokens"])
 	}

--- a/internal/state/memory/compaction_test.go
+++ b/internal/state/memory/compaction_test.go
@@ -110,8 +110,12 @@ func TestCompaction_SingleFlightCoalescesConcurrentRuns(t *testing.T) {
 	if err := <-first; err != nil {
 		t.Fatalf("first Compact: %v", err)
 	}
-	if got := len(store.GetActiveCompactionSummaries("conv-1")); got != 1 {
-		t.Errorf("active summaries = %d, want exactly 1", got)
+	got, err := store.GetActiveCompactionSummaries("conv-1")
+	if err != nil {
+		t.Fatalf("GetActiveCompactionSummaries: %v", err)
+	}
+	if len(got) != 1 {
+		t.Errorf("active summaries = %d, want exactly 1", len(got))
 	}
 }
 
@@ -135,7 +139,10 @@ func TestCompaction_FoldsPriorSummariesIntoOne(t *testing.T) {
 		t.Fatalf("second Compact: %v", err)
 	}
 
-	summaries := store.GetActiveCompactionSummaries("conv-1")
+	summaries, err := store.GetActiveCompactionSummaries("conv-1")
+	if err != nil {
+		t.Fatalf("GetActiveCompactionSummaries: %v", err)
+	}
 	if len(summaries) != 1 {
 		t.Fatalf("active summaries = %d, want exactly 1 (priors must fold, not stack)", len(summaries))
 	}
@@ -177,22 +184,32 @@ func TestCompaction_SummaryTakesCompactedRegionPosition(t *testing.T) {
 
 func TestCompaction_BoundarySnapsToTurnEdge(t *testing.T) {
 	base := time.Now().Add(-2 * time.Hour).Truncate(time.Second)
+	// 7 pairs (14 msgs, u,a,…,a) plus one trailing lone user makes an
+	// ODD count of 15. With KeepRecent=4 the candidate set is the first
+	// 11, whose last element is that penultimate user turn — so the
+	// boundary genuinely lands mid-turn and the trim has something to
+	// do. An even count would end the candidate set on an assistant and
+	// exercise nothing (PR #1170 review).
 	store := newCompactionTestStore(t, "conv-1", base, 7)
-	// Arrange the boundary to fall right after a user message: with
-	// KeepRecent=4, the candidate set ends on the user half of the
-	// 5th-from-last exchange.
-	ts := base.Add(30 * time.Minute)
-	insertMessageAt(t, store, "conv-1", "user", "dangling question whose answer is in the keep window", ts)
-	insertMessageAt(t, store, "conv-1", "assistant", "the answer that must not be orphaned", ts.Add(time.Minute))
+	insertMessageAt(t, store, "conv-1", "user", "dangling question whose answer is in the keep window", base.Add(30*time.Minute))
+
+	// Premise guard: without the trim, this candidate set ends on a
+	// user, so its reply (an assistant, kept) would be orphaned. If a
+	// config change moves the boundary, fail loudly rather than pass
+	// vacuously.
+	candidate := store.GetMessagesForCompaction("conv-1", 4)
+	if n := len(candidate); n == 0 || candidate[n-1].Role != "user" {
+		t.Fatalf("test premise broken: candidate set must end on a user turn to exercise the trim; got %d messages ending on %q", n, lastRole(candidate))
+	}
 
 	c := compactorFor(store, &countingSummarizer{})
 	if err := c.Compact(context.Background(), "conv-1"); err != nil {
 		t.Fatalf("Compact: %v", err)
 	}
 
-	// Every surviving non-summary message run must not START with an
-	// orphaned assistant reply: the message right after the summary is
-	// either a user message or nothing.
+	// The message right after the summary must not be an orphaned
+	// assistant reply — the trim keeps the dangling user (and its
+	// answer) together in active history.
 	messages := store.GetMessages("conv-1")
 	if len(messages) < 2 {
 		t.Fatalf("unexpectedly few messages: %d", len(messages))
@@ -200,6 +217,13 @@ func TestCompaction_BoundarySnapsToTurnEdge(t *testing.T) {
 	if messages[1].Role == "assistant" {
 		t.Errorf("first message after summary is an assistant reply (%q) — turn pair split", messages[1].Content[:min(40, len(messages[1].Content))])
 	}
+}
+
+func lastRole(msgs []Message) string {
+	if len(msgs) == 0 {
+		return "(none)"
+	}
+	return msgs[len(msgs)-1].Role
 }
 
 func TestCompaction_ReleasesFlightGuardOnSkip(t *testing.T) {

--- a/internal/state/memory/sqlite.go
+++ b/internal/state/memory/sqlite.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"fmt"
 	"log/slog"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -418,25 +419,75 @@ func (s *SQLiteStore) GetMessagesForCompaction(conversationID string, keep int) 
 	return messages
 }
 
-// MarkCompacted marks messages as compacted.
-func (s *SQLiteStore) MarkCompacted(conversationID string, before time.Time) error {
-	_, err := s.db.Exec(`
+// MarkCompactedByIDs marks exactly the given messages as compacted.
+// Compaction identifies rows by ID rather than a wall-clock cutoff so
+// the compacted set is precisely what the summarizer saw — a timestamp
+// cutoff can slice through turns and rows written mid-compaction.
+func (s *SQLiteStore) MarkCompactedByIDs(conversationID string, ids []string) error {
+	if len(ids) == 0 {
+		return nil
+	}
+	placeholders := make([]string, len(ids))
+	args := make([]any, 0, len(ids)+1)
+	args = append(args, conversationID)
+	for i, id := range ids {
+		placeholders[i] = "?"
+		args = append(args, id)
+	}
+	_, err := s.db.Exec(fmt.Sprintf(`
 		UPDATE messages
 		SET status = 'compacted'
-		WHERE conversation_id = ? AND timestamp < ? AND status = 'active' AND role != 'system'
-	`, conversationID, before)
+		WHERE conversation_id = ? AND id IN (%s)
+	`, strings.Join(placeholders, ",")), args...)
 	return err
 }
 
-// AddCompactionSummary adds a compaction summary message.
+// GetActiveCompactionSummaries returns the active compaction-summary
+// system messages for a conversation, oldest first. The prefix match
+// distinguishes summaries from other system rows (session handoffs,
+// notices) without a schema change.
+func (s *SQLiteStore) GetActiveCompactionSummaries(conversationID string) []Message {
+	rows, err := s.db.Query(`
+		SELECT id, role, content, timestamp
+		FROM messages
+		WHERE conversation_id = ? AND status = 'active' AND role = 'system'
+		  AND content LIKE ? || '%'
+		ORDER BY timestamp ASC
+	`, conversationID, CompactionSummaryPrefix)
+	if err != nil {
+		return nil
+	}
+	defer rows.Close()
+
+	var messages []Message
+	for rows.Next() {
+		var m Message
+		if err := rows.Scan(&m.ID, &m.Role, &m.Content, &m.Timestamp); err != nil {
+			continue
+		}
+		messages = append(messages, m)
+	}
+	return messages
+}
+
+// AddCompactionSummary adds a compaction summary message stamped now.
+// Used for session handoffs and other unpositioned system notes; the
+// compactor itself uses AddCompactionSummaryAt to place the summary at
+// the compacted region's position.
 func (s *SQLiteStore) AddCompactionSummary(conversationID, summary string) error {
-	now := time.Now()
+	return s.AddCompactionSummaryAt(conversationID, summary, time.Now())
+}
+
+// AddCompactionSummaryAt adds a compaction summary message with an
+// explicit timestamp, so a summary can occupy the temporal position of
+// the region it replaces instead of landing mid-dialogue at now().
+func (s *SQLiteStore) AddCompactionSummaryAt(conversationID, summary string, ts time.Time) error {
 	msgID, _ := uuid.NewV7()
 
 	_, err := s.db.Exec(`
 		INSERT INTO messages (id, conversation_id, role, content, timestamp, token_count, status)
 		VALUES (?, ?, 'system', ?, ?, ?, 'active')
-	`, msgID.String(), conversationID, summary, now, llm.EstimateTokens(summary))
+	`, msgID.String(), conversationID, summary, ts, llm.EstimateTokens(summary))
 
 	return err
 }

--- a/internal/state/memory/sqlite.go
+++ b/internal/state/memory/sqlite.go
@@ -419,34 +419,13 @@ func (s *SQLiteStore) GetMessagesForCompaction(conversationID string, keep int) 
 	return messages
 }
 
-// MarkCompactedByIDs marks exactly the given messages as compacted.
-// Compaction identifies rows by ID rather than a wall-clock cutoff so
-// the compacted set is precisely what the summarizer saw — a timestamp
-// cutoff can slice through turns and rows written mid-compaction.
-func (s *SQLiteStore) MarkCompactedByIDs(conversationID string, ids []string) error {
-	if len(ids) == 0 {
-		return nil
-	}
-	placeholders := make([]string, len(ids))
-	args := make([]any, 0, len(ids)+1)
-	args = append(args, conversationID)
-	for i, id := range ids {
-		placeholders[i] = "?"
-		args = append(args, id)
-	}
-	_, err := s.db.Exec(fmt.Sprintf(`
-		UPDATE messages
-		SET status = 'compacted'
-		WHERE conversation_id = ? AND id IN (%s)
-	`, strings.Join(placeholders, ",")), args...)
-	return err
-}
-
 // GetActiveCompactionSummaries returns the active compaction-summary
 // system messages for a conversation, oldest first. The prefix match
 // distinguishes summaries from other system rows (session handoffs,
-// notices) without a schema change.
-func (s *SQLiteStore) GetActiveCompactionSummaries(conversationID string) []Message {
+// notices) without a schema change. A query error is surfaced so the
+// caller can abort rather than mistake a transient failure for "no
+// prior summaries" and stack a fresh one.
+func (s *SQLiteStore) GetActiveCompactionSummaries(conversationID string) ([]Message, error) {
 	rows, err := s.db.Query(`
 		SELECT id, role, content, timestamp
 		FROM messages
@@ -455,7 +434,7 @@ func (s *SQLiteStore) GetActiveCompactionSummaries(conversationID string) []Mess
 		ORDER BY timestamp ASC
 	`, conversationID, CompactionSummaryPrefix)
 	if err != nil {
-		return nil
+		return nil, fmt.Errorf("query compaction summaries: %w", err)
 	}
 	defer rows.Close()
 
@@ -463,31 +442,72 @@ func (s *SQLiteStore) GetActiveCompactionSummaries(conversationID string) []Mess
 	for rows.Next() {
 		var m Message
 		if err := rows.Scan(&m.ID, &m.Role, &m.Content, &m.Timestamp); err != nil {
-			continue
+			return nil, fmt.Errorf("scan compaction summary: %w", err)
 		}
 		messages = append(messages, m)
 	}
-	return messages
+	return messages, rows.Err()
+}
+
+// ApplyCompaction atomically marks the given messages compacted and
+// inserts the replacement summary at summaryTS, in one transaction.
+// Splitting these into two writes risks losing active history if the
+// insert fails after the mark (and, with summary folding, could drop
+// the conversation's only summary) — so they commit or roll back
+// together.
+func (s *SQLiteStore) ApplyCompaction(conversationID string, compactedIDs []string, summary string, summaryTS time.Time) error {
+	msgID, err := uuid.NewV7()
+	if err != nil {
+		return fmt.Errorf("generate summary ID: %w", err)
+	}
+
+	tx, err := s.db.Begin()
+	if err != nil {
+		return fmt.Errorf("begin compaction tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	if len(compactedIDs) > 0 {
+		placeholders := make([]string, len(compactedIDs))
+		args := make([]any, 0, len(compactedIDs)+1)
+		args = append(args, conversationID)
+		for i, id := range compactedIDs {
+			placeholders[i] = "?"
+			args = append(args, id)
+		}
+		if _, err := tx.Exec(fmt.Sprintf(`
+			UPDATE messages
+			SET status = 'compacted'
+			WHERE conversation_id = ? AND id IN (%s)
+		`, strings.Join(placeholders, ",")), args...); err != nil {
+			return fmt.Errorf("mark compacted: %w", err)
+		}
+	}
+
+	if _, err := tx.Exec(`
+		INSERT INTO messages (id, conversation_id, role, content, timestamp, token_count, status)
+		VALUES (?, ?, 'system', ?, ?, ?, 'active')
+	`, msgID.String(), conversationID, summary, summaryTS, llm.EstimateTokens(summary)); err != nil {
+		return fmt.Errorf("insert summary: %w", err)
+	}
+
+	return tx.Commit()
 }
 
 // AddCompactionSummary adds a compaction summary message stamped now.
 // Used for session handoffs and other unpositioned system notes; the
-// compactor itself uses AddCompactionSummaryAt to place the summary at
-// the compacted region's position.
+// compactor itself uses ApplyCompaction to place the summary at the
+// compacted region's position atomically with the mark.
 func (s *SQLiteStore) AddCompactionSummary(conversationID, summary string) error {
-	return s.AddCompactionSummaryAt(conversationID, summary, time.Now())
-}
+	msgID, err := uuid.NewV7()
+	if err != nil {
+		return fmt.Errorf("generate summary ID: %w", err)
+	}
 
-// AddCompactionSummaryAt adds a compaction summary message with an
-// explicit timestamp, so a summary can occupy the temporal position of
-// the region it replaces instead of landing mid-dialogue at now().
-func (s *SQLiteStore) AddCompactionSummaryAt(conversationID, summary string, ts time.Time) error {
-	msgID, _ := uuid.NewV7()
-
-	_, err := s.db.Exec(`
+	_, err = s.db.Exec(`
 		INSERT INTO messages (id, conversation_id, role, content, timestamp, token_count, status)
 		VALUES (?, ?, 'system', ?, ?, ?, 'active')
-	`, msgID.String(), conversationID, summary, ts, llm.EstimateTokens(summary))
+	`, msgID.String(), conversationID, summary, time.Now(), llm.EstimateTokens(summary))
 
 	return err
 }


### PR DESCRIPTION
## Summary

Closes #1168 — the compaction defect cluster behind "production can't hold a coherent conversation." The observed pathology was 7 of 27 stored messages being `[Conversation Summary]` blobs in two triplicate sets, with summaries interleaved mid-dialogue and an orphaned assistant reply. All four defects plus the aggravator are addressed; the fixes are individually small and mutually reinforcing.

## The four defects

**Single-flight (defect 1 — the triplicates).** `Compact()` now coalesces per conversation: an in-flight map turns concurrent calls into no-ops, and the survivor re-checks `NeedsCompaction` after acquiring the guard so a trigger queued behind a just-finished compaction doesn't run redundantly. The race was wide open because the summarize step is a 30–90s local-model call while `NeedsCompaction` stayed true the whole time — every turn landing in that window spawned another compactor over the same history.

**Summary folding (defect 2 — the immortality ratchet).** Summaries insert as `role='system'`, which compaction never selects, so they accumulated forever while still counting against the token budget — pinning the conversation at the trigger threshold permanently. Each compaction now folds prior summaries into the pass: they're fetched (discriminated by the `[Conversation Summary]` prefix, which is now a named constant), prepended to the summarizer input so their content carries forward, and marked compacted alongside the messages. Exactly one summary row exists at any time. Session handoffs (`[Session Handoff]`) don't match the prefix and are untouched.

**Positional insert (defect 3 — the mid-dialogue interleave).** `AddCompactionSummaryAt` stamps the summary with the folded region's earliest timestamp, so it sorts where the region was — at the head of surviving history — instead of materializing between a user message and its reply the way the `now()` stamp did. The handoff path keeps the old now-stamped behavior via the retained `AddCompactionSummary` wrapper.

**ID-set marking with turn-edge snap (defect 4 — the orphaned reply).** `MarkCompactedByIDs` replaces the wall-clock-cutoff `MarkCompacted`: the compacted set is exactly the rows the summarizer saw, so rows written mid-compaction can't be swept up. The candidate boundary also snaps to a turn edge — trailing user messages whose replies sit in the keep window are left uncompacted — with one deliberate escape valve: if the trim would starve compaction below `MinMessagesToCompact` (a long user monologue), the untrimmed set is used, because bounding memory outranks turn aesthetics. A pre-existing integration test that seeds 20 consecutive user messages caught exactly this and shaped the fallback.

## The aggravator

`MaxTokens` was hardcoded at 8000 (trigger: 5,600 tokens) — the conversation that produced the bug report should never have been compacted at all. It's now `compaction.max_tokens` in config, defaulting to 32000. `examples/config.example.yaml` regenerated.

## What this does not do

The already-polluted production conversation keeps its stacked summaries until its next compaction folds them into one (which the new code does automatically — the fold's first act on a polluted conversation is exactly the cleanup #1168 asked for), or until a session reset. No migration needed; the repair is lazy but inherent.

## Test plan

Five new tests, one per defect plus the guard-leak edge:

- [x] `SingleFlightCoalescesConcurrentRuns` — second Compact during a blocked summarize returns without invoking the summarizer; exactly one summary lands
- [x] `FoldsPriorSummariesIntoOne` — two compaction rounds yield one active summary, and the second summarizer invocation demonstrably received the first summary's content
- [x] `SummaryTakesCompactedRegionPosition` — summary renders first in active history, never interleaved
- [x] `BoundarySnapsToTurnEdge` — the message after the summary is never an orphaned assistant reply
- [x] `ReleasesFlightGuardOnSkip` — a below-threshold skip doesn't lock the conversation out of future compaction
- [x] Pre-existing `TestCompaction_PreservesMessages` (all-user seed) green via the starvation fallback
- [x] `just ci` green locally (verified in-worktree)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
