### PR TITLE
feat(api): deprecation lifecycle for legacy WebSocket aliases

### DIFF
--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -89,8 +89,27 @@ views). The OpenAI-compatible shim runs on its own port (see below).
 | `DELETE` | `/v1/checkpoints/{id}` | Delete a checkpoint. |
 | `POST` | `/v1/checkpoints/{id}/restore` | Restore from a checkpoint. |
 | `GET` | `/v1/realtime/ws` | First-party realtime WebSocket (canonical). |
-| `GET` | `/v1/companion/ws` | Realtime WebSocket — legacy alias. |
-| `GET` | `/v1/platform/ws` | Realtime WebSocket — legacy alias. |
+| `GET` | `/v1/companion/ws` | Realtime WebSocket — legacy alias (deprecated; see below). |
+| `GET` | `/v1/platform/ws` | Realtime WebSocket — legacy alias (deprecated; see below). |
+
+### Deprecated route aliases
+
+Deprecated aliases (currently the two legacy WebSocket paths above) are
+declared in one place — the `internal/server/legacyroute` registry — which is
+the single source for the mux route wiring, the OpenAPI route-coverage
+allowlist, and a build-date gate. Each entry carries a `DeprecatedSince` date, a
+`RemoveAfter` date (a six-month window for first-party clients), and its
+tracking issue.
+
+A connection on a deprecated alias is logged (`legacy websocket alias in use`,
+tagged with path, account, and client id) so usage can be watched to zero before
+removal, and the client is signalled three ways: an RFC 8594 `Sunset` header and
+RFC 9745 `Deprecation` header on the upgrade response, a `Link` header with
+`rel="successor-version"` pointing at the canonical path, and an in-band
+`deprecation` object in the `auth_ok` message for clients that don't surface
+handshake headers. A CI test fails once an alias is past its `RemoveAfter` date,
+forcing either removal or a justified extension; culling is a one-line registry
+edit that drops the route and the allowlist entry together.
 
 ## Port 8081 — OpenAI-Compatible API
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -97,8 +97,8 @@ views). The OpenAI-compatible shim runs on its own port (see below).
 Deprecated aliases (currently the two legacy WebSocket paths above) are
 declared in one place — the `internal/server/legacyroute` registry — which is
 the single source for the mux route wiring, the OpenAPI route-coverage
-allowlist, and a build-date gate. Each entry carries a `DeprecatedSince` date, a
-`RemoveAfter` date (a six-month window for first-party clients), and its
+allowlist, and a current-date CI gate. Each entry carries a `DeprecatedSince`
+date, a `RemoveAfter` date (a six-month window for first-party clients), and its
 tracking issue.
 
 A connection on a deprecated alias is logged (`legacy websocket alias in use`,
@@ -107,9 +107,10 @@ removal, and the client is signalled three ways: an RFC 8594 `Sunset` header and
 RFC 9745 `Deprecation` header on the upgrade response, a `Link` header with
 `rel="successor-version"` pointing at the canonical path, and an in-band
 `deprecation` object in the `auth_ok` message for clients that don't surface
-handshake headers. A CI test fails once an alias is past its `RemoveAfter` date,
-forcing either removal or a justified extension; culling is a one-line registry
-edit that drops the route and the allowlist entry together.
+handshake headers. A CI test (comparing the current date, since `go test` has no
+build stamp) fails once an alias is past its `RemoveAfter` date, forcing either
+removal or a justified extension; culling is a one-line registry edit that drops
+the route and the allowlist entry together.
 
 ## Port 8081 — OpenAI-Compatible API
 

--- a/internal/integrations/companion/handler.go
+++ b/internal/integrations/companion/handler.go
@@ -73,7 +73,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// RFC 8594 Sunset / RFC 9745 Deprecation headers to the 101 upgrade
 	// response. gorilla's Upgrade emits only the headers passed here (it
 	// does not copy w.Header()), so the signal must ride the third arg.
-	alias, isLegacy := legacyroute.Lookup(r.URL.Path)
+	alias, isLegacy := legacyroute.Lookup(r.Method, r.URL.Path)
 	var upgradeHeader http.Header
 	if isLegacy {
 		upgradeHeader = alias.DeprecationHeaders()

--- a/internal/integrations/companion/handler.go
+++ b/internal/integrations/companion/handler.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/gorilla/websocket"
+	"github.com/nugget/thane-ai-agent/internal/server/legacyroute"
 )
 
 const (
@@ -68,7 +69,17 @@ func NewHandler(tokenIndex map[string]string, registry *Registry, logger *slog.L
 // ServeHTTP upgrades the connection to WebSocket, performs the auth
 // handshake, and runs the heartbeat and read loops for the provider.
 func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	conn, err := upgrader.Upgrade(w, r, nil)
+	// If the client reached us on a deprecated path alias, attach the
+	// RFC 8594 Sunset / RFC 9745 Deprecation headers to the 101 upgrade
+	// response. gorilla's Upgrade emits only the headers passed here (it
+	// does not copy w.Header()), so the signal must ride the third arg.
+	alias, isLegacy := legacyroute.Lookup(r.URL.Path)
+	var upgradeHeader http.Header
+	if isLegacy {
+		upgradeHeader = alias.DeprecationHeaders()
+	}
+
+	conn, err := upgrader.Upgrade(w, r, upgradeHeader)
 	if err != nil {
 		h.logger.Error("companion websocket upgrade failed", "error", err)
 		return
@@ -85,6 +96,28 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Usage telemetry — the linchpin for a data-driven cull (#1084). A
+	// legacy alias cannot be safely removed until this shows its usage
+	// has dropped to zero, so log every connection with client identity.
+	var deprecation *deprecationNotice
+	if isLegacy {
+		h.logger.Warn("legacy websocket alias in use",
+			"path", r.URL.Path,
+			"canonical", alias.Canonical,
+			"account", provider.Account,
+			"client_id", provider.ClientID,
+			"client_name", provider.ClientName,
+			"sunset_on", alias.RemoveAfter,
+			"issue", alias.Issue,
+		)
+		deprecation = &deprecationNotice{
+			DeprecatedSince: alias.DeprecatedSince,
+			SunsetOn:        alias.RemoveAfter,
+			CanonicalPath:   alias.Canonical,
+			Issue:           alias.Issue,
+		}
+	}
+
 	// Register the provider before confirming to the client, so the
 	// registry is consistent by the time the client reads auth_ok.
 	h.registry.Add(provider)
@@ -95,9 +128,10 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}()
 
 	if err := writeJSONWithDeadline(conn, writeWait, authOK{
-		Type:       typeAuthOK,
-		ProviderID: provider.ID,
-		Account:    provider.Account,
+		Type:        typeAuthOK,
+		ProviderID:  provider.ID,
+		Account:     provider.Account,
+		Deprecation: deprecation,
 	}); err != nil {
 		return
 	}

--- a/internal/integrations/companion/handler_test.go
+++ b/internal/integrations/companion/handler_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/gorilla/websocket"
+	"github.com/nugget/thane-ai-agent/internal/server/legacyroute"
 )
 
 // testTokenIndex returns a token index mapping "test-secret" to "nugget".
@@ -706,5 +707,98 @@ func TestRegistryCallTrimsRoutingSelectors(t *testing.T) {
 	}
 	if request.req.Method != "list_events" {
 		t.Fatalf("method: got %q, want %q", request.req.Method, "list_events")
+	}
+}
+
+// legacyAliasMux wires the handler the way server.go does: the canonical
+// realtime path plus every legacyroute alias, so a dial can exercise the
+// deprecation branch by path.
+func legacyAliasMux(handler http.Handler) *http.ServeMux {
+	mux := http.NewServeMux()
+	mux.Handle("GET /v1/realtime/ws", handler)
+	for _, a := range legacyroute.Aliases {
+		mux.Handle(a.Route(), handler)
+	}
+	return mux
+}
+
+func TestLegacyAliasEmitsDeprecationSignals(t *testing.T) {
+	if len(legacyroute.Aliases) == 0 {
+		t.Skip("no legacy aliases registered")
+	}
+	alias := legacyroute.Aliases[0]
+
+	handler := NewHandler(testTokenIndex(), NewRegistry(nil), nil)
+	srv := httptest.NewServer(legacyAliasMux(handler))
+	defer srv.Close()
+
+	wsURL := "ws" + srv.URL[len("http"):] + alias.Path
+	conn, resp, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial %s: %v", alias.Path, err)
+	}
+	defer conn.Close()
+
+	// The 101 response carries the RFC 8594 / RFC 9745 headers.
+	if got := resp.Header.Get("Sunset"); got == "" {
+		t.Error("legacy alias upgrade missing Sunset header")
+	}
+	if got := resp.Header.Get("Deprecation"); got == "" {
+		t.Error("legacy alias upgrade missing Deprecation header")
+	}
+	if got := resp.Header.Get("Link"); !strings.Contains(got, alias.Canonical) || !strings.Contains(got, "successor-version") {
+		t.Errorf("Link = %q, want successor-version to %q", got, alias.Canonical)
+	}
+
+	// The in-band auth_ok notice is populated for WS clients that ignore
+	// handshake headers.
+	var authReq authRequired
+	readJSON(t, conn, &authReq)
+	conn.SetWriteDeadline(time.Now().Add(5 * time.Second))
+	if err := conn.WriteJSON(authMessage{Type: typeAuth, Token: "test-secret", ClientName: "Legacy Mac", ClientID: "legacy-uuid"}); err != nil {
+		t.Fatalf("send auth: %v", err)
+	}
+	var ok authOK
+	readJSON(t, conn, &ok)
+	if ok.Deprecation == nil {
+		t.Fatal("auth_ok missing deprecation notice on legacy alias")
+	}
+	if ok.Deprecation.CanonicalPath != alias.Canonical {
+		t.Errorf("deprecation canonical = %q, want %q", ok.Deprecation.CanonicalPath, alias.Canonical)
+	}
+	if ok.Deprecation.SunsetOn != alias.RemoveAfter {
+		t.Errorf("deprecation sunset_on = %q, want %q", ok.Deprecation.SunsetOn, alias.RemoveAfter)
+	}
+}
+
+func TestCanonicalPathNoDeprecation(t *testing.T) {
+	handler := NewHandler(testTokenIndex(), NewRegistry(nil), nil)
+	srv := httptest.NewServer(legacyAliasMux(handler))
+	defer srv.Close()
+
+	wsURL := "ws" + srv.URL[len("http"):] + "/v1/realtime/ws"
+	conn, resp, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial realtime: %v", err)
+	}
+	defer conn.Close()
+
+	if got := resp.Header.Get("Sunset"); got != "" {
+		t.Errorf("canonical path carried a Sunset header: %q", got)
+	}
+	if got := resp.Header.Get("Deprecation"); got != "" {
+		t.Errorf("canonical path carried a Deprecation header: %q", got)
+	}
+
+	var authReq authRequired
+	readJSON(t, conn, &authReq)
+	conn.SetWriteDeadline(time.Now().Add(5 * time.Second))
+	if err := conn.WriteJSON(authMessage{Type: typeAuth, Token: "test-secret", ClientName: "Modern Mac", ClientID: "modern-uuid"}); err != nil {
+		t.Fatalf("send auth: %v", err)
+	}
+	var ok authOK
+	readJSON(t, conn, &ok)
+	if ok.Deprecation != nil {
+		t.Errorf("canonical path auth_ok carried a deprecation notice: %+v", ok.Deprecation)
 	}
 }

--- a/internal/integrations/companion/message.go
+++ b/internal/integrations/companion/message.go
@@ -73,11 +73,24 @@ type authMessage struct {
 }
 
 // authOK confirms successful authentication, assigns a provider ID, and
-// echoes back the server-resolved account name.
+// echoes back the server-resolved account name. Deprecation is populated
+// only when the client connected on a legacy path alias, giving in-band
+// notice to WebSocket clients that do not surface HTTP response headers.
 type authOK struct {
-	Type       string `json:"type"`
-	ProviderID string `json:"provider_id"`
-	Account    string `json:"account"`
+	Type        string             `json:"type"`
+	ProviderID  string             `json:"provider_id"`
+	Account     string             `json:"account"`
+	Deprecation *deprecationNotice `json:"deprecation,omitempty"`
+}
+
+// deprecationNotice is the in-band companion to the RFC 8594 Sunset /
+// RFC 9745 Deprecation response headers, carried in auth_ok so a client
+// on a deprecated path can log or surface that it must migrate.
+type deprecationNotice struct {
+	DeprecatedSince string `json:"deprecated_since"`
+	SunsetOn        string `json:"sunset_on"`
+	CanonicalPath   string `json:"canonical_path"`
+	Issue           int    `json:"issue,omitempty"`
 }
 
 // authFailed is sent when the client provides invalid credentials.

--- a/internal/server/api/server.go
+++ b/internal/server/api/server.go
@@ -28,6 +28,7 @@ import (
 	"github.com/nugget/thane-ai-agent/internal/platform/usage"
 	"github.com/nugget/thane-ai-agent/internal/runtime/agent"
 	looppkg "github.com/nugget/thane-ai-agent/internal/runtime/loop"
+	"github.com/nugget/thane-ai-agent/internal/server/legacyroute"
 	"github.com/nugget/thane-ai-agent/internal/server/openapi"
 	"github.com/nugget/thane-ai-agent/internal/state/contacts"
 	"github.com/nugget/thane-ai-agent/internal/state/memory"
@@ -520,13 +521,17 @@ func (s *Server) Start(ctx context.Context) error {
 	mux.HandleFunc("GET /v1/archive/messages", s.handleArchiveMessages)
 	mux.HandleFunc("GET /v1/archive/stats", s.handleArchiveStats)
 
-	// First-party realtime WebSocket. /v1/realtime/ws is the canonical path
-	// (per native.yaml); /v1/companion/ws and /v1/platform/ws are legacy
-	// aliases for existing thane-agent-macos installs.
+	// First-party realtime WebSocket. /v1/realtime/ws is the canonical
+	// path (per native.yaml); the legacy aliases for existing
+	// thane-agent-macos installs are wired from the legacyroute registry
+	// so the routes, the coverage allowlist, and the sunset gate share
+	// one source of truth (#1084). The handler emits deprecation signals
+	// and usage telemetry when a connection arrives on an alias.
 	if s.companionHandler != nil {
 		mux.Handle("GET /v1/realtime/ws", s.companionHandler)
-		mux.Handle("GET /v1/companion/ws", s.companionHandler)
-		mux.Handle("GET /v1/platform/ws", s.companionHandler)
+		for _, alias := range legacyroute.Aliases {
+			mux.Handle(alias.Route(), s.companionHandler)
+		}
 	}
 
 	// When a WebServerRegistrar is wired in, it owns "/" and related

--- a/internal/server/legacyroute/legacyroute.go
+++ b/internal/server/legacyroute/legacyroute.go
@@ -1,0 +1,94 @@
+// Package legacyroute is the single source of truth for deprecated API
+// route aliases kept for backward compatibility. Both the mux route
+// wiring (internal/server/api) and the OpenAPI route-coverage allowlist
+// (internal/server/openapi) derive from [Aliases], so the routes and the
+// test that guards them cannot drift apart, and a date-based gate
+// (legacyroute_test.go) fails once an alias is past its removal window —
+// turning "cull someday" into a scheduled obligation.
+//
+// The pattern is path-type-agnostic: today every entry is a WebSocket
+// upgrade alias, but any deprecated REST path can be registered the same
+// way.
+package legacyroute
+
+import (
+	"net/http"
+	"strconv"
+	"time"
+)
+
+// dateLayout is the day-granularity form for the DeprecatedSince and
+// RemoveAfter fields. Day granularity is deliberate: a deprecation
+// window is a calendar policy, not a wall-clock instant.
+const dateLayout = "2006-01-02"
+
+// Alias is one deprecated route kept as a compatibility shim for an
+// existing client, pointing at the canonical replacement.
+type Alias struct {
+	Method          string // HTTP method, e.g. "GET"
+	Path            string // deprecated path, e.g. "/v1/companion/ws"
+	Canonical       string // the path clients should move to
+	DeprecatedSince string // dateLayout; when the alias was announced deprecated
+	RemoveAfter     string // dateLayout; the alias may be culled once this date has passed
+	Issue           int    // tracking issue number
+}
+
+// Aliases is the registry of live deprecated routes. Keep RemoveAfter
+// honest: a first-party client (thane-agent-macos) gets a six-month
+// window from the deprecation date. When telemetry shows a route's usage
+// has dropped to zero past its window, one PR drops the entry here — the
+// route wiring and the coverage allowlist follow automatically, and the
+// overdue-window gate goes green by the entry's absence.
+var Aliases = []Alias{
+	{Method: "GET", Path: "/v1/companion/ws", Canonical: "/v1/realtime/ws", DeprecatedSince: "2026-06-25", RemoveAfter: "2026-12-25", Issue: 1081},
+	{Method: "GET", Path: "/v1/platform/ws", Canonical: "/v1/realtime/ws", DeprecatedSince: "2026-06-25", RemoveAfter: "2026-12-25", Issue: 1081},
+}
+
+// Route returns the "METHOD /path" key used by the mux and the OpenAPI
+// route-coverage allowlist.
+func (a Alias) Route() string { return a.Method + " " + a.Path }
+
+// DeprecatedSinceTime parses DeprecatedSince at UTC midnight. It panics
+// on a malformed literal: the registry is compile-time author-controlled
+// data that legacyroute_test.go validates, so a parse failure is a
+// programming error, never a runtime condition.
+func (a Alias) DeprecatedSinceTime() time.Time { return mustDate(a.DeprecatedSince) }
+
+// RemoveAfterTime parses RemoveAfter at UTC midnight, with the same
+// panic-on-malformed contract as [Alias.DeprecatedSinceTime].
+func (a Alias) RemoveAfterTime() time.Time { return mustDate(a.RemoveAfter) }
+
+func mustDate(s string) time.Time {
+	t, err := time.ParseInLocation(dateLayout, s, time.UTC)
+	if err != nil {
+		panic("legacyroute: malformed date " + strconv.Quote(s) + ": " + err.Error())
+	}
+	return t
+}
+
+// DeprecationHeaders returns the standards-based response headers that
+// signal this alias's deprecation to clients:
+//
+//   - Deprecation (RFC 9745): a Structured Field Date, "@<unix-seconds>"
+//     at the deprecation date.
+//   - Sunset (RFC 8594): an HTTP-date at the removal date.
+//   - Link: rel="successor-version" pointing at the canonical path so a
+//     client can discover the replacement programmatically.
+func (a Alias) DeprecationHeaders() http.Header {
+	h := http.Header{}
+	h.Set("Deprecation", "@"+strconv.FormatInt(a.DeprecatedSinceTime().Unix(), 10))
+	h.Set("Sunset", a.RemoveAfterTime().UTC().Format(http.TimeFormat))
+	h.Set("Link", "<"+a.Canonical+">; rel=\"successor-version\"")
+	return h
+}
+
+// Lookup returns the alias registered for path, if any. Callers use it to
+// decide whether an inbound request arrived on a deprecated route.
+func Lookup(path string) (Alias, bool) {
+	for _, a := range Aliases {
+		if a.Path == path {
+			return a, true
+		}
+	}
+	return Alias{}, false
+}

--- a/internal/server/legacyroute/legacyroute.go
+++ b/internal/server/legacyroute/legacyroute.go
@@ -58,6 +58,14 @@ func (a Alias) DeprecatedSinceTime() time.Time { return mustDate(a.DeprecatedSin
 // panic-on-malformed contract as [Alias.DeprecatedSinceTime].
 func (a Alias) RemoveAfterTime() time.Time { return mustDate(a.RemoveAfter) }
 
+// SunsetTime is the instant the alias is expected to become
+// unavailable: the start of the day *after* RemoveAfter. RemoveAfter is
+// the last date the alias is guaranteed to work ("removable once this
+// date has passed"), so the client-facing Sunset header and the CI
+// removal gate agree on one boundary — both treat the alias as live
+// through the end of the RemoveAfter day and removable from this instant.
+func (a Alias) SunsetTime() time.Time { return a.RemoveAfterTime().Add(24 * time.Hour) }
+
 func mustDate(s string) time.Time {
 	t, err := time.ParseInLocation(dateLayout, s, time.UTC)
 	if err != nil {
@@ -71,22 +79,25 @@ func mustDate(s string) time.Time {
 //
 //   - Deprecation (RFC 9745): a Structured Field Date, "@<unix-seconds>"
 //     at the deprecation date.
-//   - Sunset (RFC 8594): an HTTP-date at the removal date.
+//   - Sunset (RFC 8594): an HTTP-date at [Alias.SunsetTime] — the moment
+//     the alias becomes removable, matching the CI gate's boundary.
 //   - Link: rel="successor-version" pointing at the canonical path so a
 //     client can discover the replacement programmatically.
 func (a Alias) DeprecationHeaders() http.Header {
 	h := http.Header{}
 	h.Set("Deprecation", "@"+strconv.FormatInt(a.DeprecatedSinceTime().Unix(), 10))
-	h.Set("Sunset", a.RemoveAfterTime().UTC().Format(http.TimeFormat))
+	h.Set("Sunset", a.SunsetTime().UTC().Format(http.TimeFormat))
 	h.Set("Link", "<"+a.Canonical+">; rel=\"successor-version\"")
 	return h
 }
 
-// Lookup returns the alias registered for path, if any. Callers use it to
-// decide whether an inbound request arrived on a deprecated route.
-func Lookup(path string) (Alias, bool) {
+// Lookup returns the alias registered for the given method and path, if
+// any. Matching on both fields (not path alone) keeps the API consistent
+// with the method-aware [Alias.Route] and lets a future deprecated REST
+// path be aliased on one method without shadowing the others.
+func Lookup(method, path string) (Alias, bool) {
 	for _, a := range Aliases {
-		if a.Path == path {
+		if a.Method == method && a.Path == path {
 			return a, true
 		}
 	}

--- a/internal/server/legacyroute/legacyroute_test.go
+++ b/internal/server/legacyroute/legacyroute_test.go
@@ -1,0 +1,97 @@
+package legacyroute
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestRegistryWellFormed(t *testing.T) {
+	seen := make(map[string]bool)
+	for _, a := range Aliases {
+		if a.Method == "" || !strings.HasPrefix(a.Path, "/") {
+			t.Errorf("alias %+v: Method must be set and Path must be rooted", a)
+		}
+		if seen[a.Path] {
+			t.Errorf("alias %q: duplicate path in registry", a.Path)
+		}
+		seen[a.Path] = true
+
+		if a.Canonical == a.Path {
+			t.Errorf("alias %q: Canonical must differ from the deprecated path", a.Path)
+		}
+		if !strings.HasPrefix(a.Canonical, "/") {
+			t.Errorf("alias %q: Canonical %q must be a rooted path", a.Path, a.Canonical)
+		}
+		if a.Issue <= 0 {
+			t.Errorf("alias %q: Issue must reference a tracking issue", a.Path)
+		}
+
+		dep, err := time.Parse(dateLayout, a.DeprecatedSince)
+		if err != nil {
+			t.Errorf("alias %q: DeprecatedSince %q not %s", a.Path, a.DeprecatedSince, dateLayout)
+		}
+		rem, err := time.Parse(dateLayout, a.RemoveAfter)
+		if err != nil {
+			t.Errorf("alias %q: RemoveAfter %q not %s", a.Path, a.RemoveAfter, dateLayout)
+		}
+		if err == nil && !rem.After(dep) {
+			t.Errorf("alias %q: RemoveAfter %s must be after DeprecatedSince %s", a.Path, a.RemoveAfter, a.DeprecatedSince)
+		}
+	}
+}
+
+// TestNoAliasPastRemovalWindow is the forcing function: it fails once an
+// alias's RemoveAfter date has passed, demanding either removal (cull the
+// entry, which drops the route and the coverage allowlist automatically)
+// or a deliberate, justified extension of the window.
+//
+// It compares against time.Now rather than a build-stamped date because
+// `go test` runs without the ldflags that populate buildinfo.BuildTime,
+// so the build stamp is always "unknown" under test. A day-granularity
+// clock comparison is the pragmatic equivalent: it flips exactly once,
+// permanently, when the window closes — that is the reminder, not
+// flakiness.
+func TestNoAliasPastRemovalWindow(t *testing.T) {
+	today := time.Now().UTC().Truncate(24 * time.Hour)
+	for _, a := range Aliases {
+		remove := a.RemoveAfterTime()
+		if today.After(remove) {
+			t.Errorf("alias %q is past its RemoveAfter window (%s): confirm zero usage via telemetry and cull the entry (drops the route + coverage allowlist), or extend RemoveAfter with justification. Tracking: #%d",
+				a.Path, a.RemoveAfter, a.Issue)
+		}
+	}
+}
+
+func TestDeprecationHeaders(t *testing.T) {
+	a := Alias{
+		Method: "GET", Path: "/v1/companion/ws", Canonical: "/v1/realtime/ws",
+		DeprecatedSince: "2026-06-25", RemoveAfter: "2026-12-25", Issue: 1081,
+	}
+	h := a.DeprecationHeaders()
+
+	// RFC 9745 Deprecation: Structured Field Date "@<unix>" at the
+	// deprecation date's UTC midnight.
+	wantDep := "@" + strconv.FormatInt(time.Date(2026, 6, 25, 0, 0, 0, 0, time.UTC).Unix(), 10)
+	if got := h.Get("Deprecation"); got != wantDep {
+		t.Errorf("Deprecation = %q, want %q", got, wantDep)
+	}
+	// RFC 8594 Sunset: HTTP-date at the removal date.
+	wantSunset := time.Date(2026, 12, 25, 0, 0, 0, 0, time.UTC).Format("Mon, 02 Jan 2006 15:04:05 GMT")
+	if got := h.Get("Sunset"); got != wantSunset {
+		t.Errorf("Sunset = %q, want %q", got, wantSunset)
+	}
+	if got := h.Get("Link"); got != `<`+"/v1/realtime/ws"+`>; rel="successor-version"` {
+		t.Errorf("Link = %q, want successor-version pointing at the canonical path", got)
+	}
+}
+
+func TestLookup(t *testing.T) {
+	if _, ok := Lookup("/v1/companion/ws"); !ok {
+		t.Error("Lookup missed a registered alias")
+	}
+	if _, ok := Lookup("/v1/realtime/ws"); ok {
+		t.Error("Lookup matched the canonical path, which is not an alias")
+	}
+}

--- a/internal/server/legacyroute/legacyroute_test.go
+++ b/internal/server/legacyroute/legacyroute_test.go
@@ -13,10 +13,12 @@ func TestRegistryWellFormed(t *testing.T) {
 		if a.Method == "" || !strings.HasPrefix(a.Path, "/") {
 			t.Errorf("alias %+v: Method must be set and Path must be rooted", a)
 		}
-		if seen[a.Path] {
-			t.Errorf("alias %q: duplicate path in registry", a.Path)
+		// De-dupe by the method+path route, not the path alone, so the
+		// same path may be deprecated on distinct methods.
+		if seen[a.Route()] {
+			t.Errorf("alias %q: duplicate route in registry", a.Route())
 		}
-		seen[a.Path] = true
+		seen[a.Route()] = true
 
 		if a.Canonical == a.Path {
 			t.Errorf("alias %q: Canonical must differ from the deprecated path", a.Path)
@@ -77,8 +79,10 @@ func TestDeprecationHeaders(t *testing.T) {
 	if got := h.Get("Deprecation"); got != wantDep {
 		t.Errorf("Deprecation = %q, want %q", got, wantDep)
 	}
-	// RFC 8594 Sunset: HTTP-date at the removal date.
-	wantSunset := time.Date(2026, 12, 25, 0, 0, 0, 0, time.UTC).Format("Mon, 02 Jan 2006 15:04:05 GMT")
+	// RFC 8594 Sunset: HTTP-date at the start of the day AFTER
+	// RemoveAfter — the moment the alias becomes removable, aligned with
+	// the CI gate.
+	wantSunset := time.Date(2026, 12, 26, 0, 0, 0, 0, time.UTC).Format("Mon, 02 Jan 2006 15:04:05 GMT")
 	if got := h.Get("Sunset"); got != wantSunset {
 		t.Errorf("Sunset = %q, want %q", got, wantSunset)
 	}
@@ -88,10 +92,13 @@ func TestDeprecationHeaders(t *testing.T) {
 }
 
 func TestLookup(t *testing.T) {
-	if _, ok := Lookup("/v1/companion/ws"); !ok {
+	if _, ok := Lookup("GET", "/v1/companion/ws"); !ok {
 		t.Error("Lookup missed a registered alias")
 	}
-	if _, ok := Lookup("/v1/realtime/ws"); ok {
+	if _, ok := Lookup("GET", "/v1/realtime/ws"); ok {
 		t.Error("Lookup matched the canonical path, which is not an alias")
+	}
+	if _, ok := Lookup("POST", "/v1/companion/ws"); ok {
+		t.Error("Lookup matched on a different method than the registered alias")
 	}
 }

--- a/internal/server/openapi/coverage_test.go
+++ b/internal/server/openapi/coverage_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/nugget/thane-ai-agent/internal/server/legacyroute"
 	"gopkg.in/yaml.v3"
 )
 
@@ -16,15 +17,19 @@ import (
 const serverSource = "../api/server.go"
 
 // routeAllowlist are routes registered on the native mux that are intentionally
-// absent from native.yaml:
-//   - "GET /" is the JSON root / dashboard fallback, not an API resource.
-//   - /v1/companion/ws and /v1/platform/ws are legacy WebSocket aliases kept
-//     for existing thane-agent-macos installs; the canonical, documented path
-//     is /v1/realtime/ws.
-var routeAllowlist = map[string]bool{
-	"GET /":                true,
-	"GET /v1/companion/ws": true,
-	"GET /v1/platform/ws":  true,
+// absent from native.yaml. "GET /" is the JSON root / dashboard fallback, not
+// an API resource. The legacy WebSocket aliases are derived from the
+// legacyroute registry (#1084) — the same list server.go wires the routes from
+// — so a new or culled alias updates the routes and this allowlist together,
+// with no second hand-maintained copy to drift.
+var routeAllowlist = buildRouteAllowlist()
+
+func buildRouteAllowlist() map[string]bool {
+	m := map[string]bool{"GET /": true}
+	for _, a := range legacyroute.Aliases {
+		m[a.Route()] = true
+	}
+	return m
 }
 
 // muxRouteRe matches the Go 1.22 method-pattern literals that register handlers

--- a/scripts/architecture.baseline
+++ b/scripts/architecture.baseline
@@ -1,4 +1,4 @@
-packages=63
+packages=64
 interfaces=83
 large_files=49
 set_mutators=111


### PR DESCRIPTION
## Summary

Closes #1084. The legacy WebSocket aliases `/v1/companion/ws` and `/v1/platform/ws` (kept for existing `thane-agent-macos` installs, canonical is `/v1/realtime/ws`) worked fine but had no deprecation signal, no usage telemetry, and no sunset date — so they would linger forever and any removal would be a guess at whether anyone was still on them. This makes alias culling a scheduled, data-driven, CI-enforced obligation.

## The single source of truth

A new leaf package `internal/server/legacyroute` holds the registry:

```go
var Aliases = []Alias{
    {Method: "GET", Path: "/v1/companion/ws", Canonical: "/v1/realtime/ws", DeprecatedSince: "2026-06-25", RemoveAfter: "2026-12-25", Issue: 1081},
    {Method: "GET", Path: "/v1/platform/ws",  Canonical: "/v1/realtime/ws", DeprecatedSince: "2026-06-25", RemoveAfter: "2026-12-25", Issue: 1081},
}
```

It's a leaf (stdlib only) precisely because `api` already imports `openapi`, so both the route wiring and the coverage test can derive from it without a cycle. Everything else follows from this list:

- **Routes** — `server.go` registers the aliases by iterating `legacyroute.Aliases` instead of hardcoding them.
- **Coverage allowlist** — `openapi/coverage_test.go`'s route-coverage allowlist is now built from the registry, so a new or culled alias updates the routes and the drift test together. No second hand-maintained copy.
- **Sunset gate** — see below.

## Client signal (three ways)

When a connection arrives on an alias, the companion handler:

- attaches an RFC 8594 `Sunset` header (HTTP-date at `RemoveAfter`) and an RFC 9745 `Deprecation` header (`@<unix>` at `DeprecatedSince`) to the 101 upgrade response, plus a `Link: rel="successor-version"` pointing at the canonical path;
- populates a `deprecation` object in the `auth_ok` message — the reliable channel for WebSocket clients, which routinely don't surface handshake headers.

The headers ride the `responseHeader` arg to gorilla's `Upgrade` because gorilla emits only those on the 101, not `w.Header()`.

## Usage telemetry — the linchpin

Every alias connection logs `legacy websocket alias in use` at WARN, tagged `path` / `canonical` / `account` / `client_id` / `client_name` / `sunset_on` / `issue`. You cannot cull safely without watching usage drop to zero; this is that instrument. (A metrics counter is left out — there's no existing counter sink to wire into, and the issue scoped it "optional.")

## CI forcing function

`TestNoAliasPastRemovalWindow` fails once an alias's `RemoveAfter` has passed, demanding removal or a justified extension. It compares against `time.Now().UTC()` rather than a build stamp because `go test` runs without the ldflags that populate `buildinfo.BuildTime` — a day-granularity clock comparison is the working equivalent: it flips exactly once, permanently, when the window closes. Culling is then a one-line registry edit; the route, the allowlist entry, and the overdue gate all resolve from the entry's absence.

## Test plan

- [x] `legacyroute`: registry well-formedness (dates parse, `RemoveAfter` after `DeprecatedSince`, canonical differs, issue set), the sunset gate, header construction, and `Lookup`
- [x] `companion`: alias upgrade carries `Sunset`/`Deprecation`/`Link` and an `auth_ok` deprecation notice; canonical path carries none
- [x] `openapi`: route-coverage still green with the allowlist derived from the registry
- [x] Policy documented in `docs/reference/api.md`
- [x] `just ci` green locally (verified unpiped, real exit code)

## Notes

The registry is path-type-agnostic (Method + Path), so future deprecated REST paths register the same way — the mechanism isn't WebSocket-specific.

Closes #1084

🤖 Generated with [Claude Code](https://claude.com/claude-code)
