### PR TITLE
docs: v0.10.1 pre-release audit fixes — field Godoc + revision field naming

### DIFF
--- a/internal/integrations/forge/subscriptions.go
+++ b/internal/integrations/forge/subscriptions.go
@@ -18,27 +18,84 @@ const (
 	subscriptionIndexKey  = "subscriptions"
 )
 
-// ProjectSubscription tracks releases and/or commits for one repository and
-// delivers new events to an existing loop.
+// ProjectSubscription tracks releases and/or commits for one repository
+// and delivers new events to an existing loop. The subscription tools
+// author it, the poller advances its cursor fields each cycle, and the
+// optional checkout fields — always configured as a pair — additionally
+// keep a local read-only mirror of the repository in sync so loops can
+// read source without network calls.
 type ProjectSubscription struct {
-	ID                string                  `json:"subscription_id"`
-	Account           string                  `json:"account"`
-	Repo              string                  `json:"repo"`
-	Name              string                  `json:"name"`
-	URL               string                  `json:"url,omitempty"`
-	Branch            string                  `json:"branch,omitempty"`
-	CheckoutPath      string                  `json:"local_checkout,omitempty"`
-	CheckoutRemoteURL string                  `json:"checkout_remote_url,omitempty"`
-	TrackReleases     bool                    `json:"track_releases"`
-	TrackCommits      bool                    `json:"track_commits"`
-	WakeTarget        messages.LoopWakeTarget `json:"wake_loop"`
-	LastRelease       string                  `json:"last_release,omitempty"`
-	LastCommit        string                  `json:"last_commit,omitempty"`
-	LatestRelease     string                  `json:"latest_release,omitempty"`
-	LatestCommit      string                  `json:"latest_commit,omitempty"`
-	LastSyncedSHA     string                  `json:"last_synced_sha,omitempty"`
-	LastChecked       time.Time               `json:"last_checked,omitempty"`
-	CreatedAt         time.Time               `json:"created_at"`
+	// ID uniquely identifies the subscription across its lifetime;
+	// tools use it for update and delete targeting.
+	ID string `json:"subscription_id"`
+
+	// Account names the configured forge account whose credentials and
+	// host serve this subscription's API calls.
+	Account string `json:"account"`
+
+	// Repo is the owner/name slug of the repository being watched.
+	Repo string `json:"repo"`
+
+	// Name is the operator- or model-chosen display label for the
+	// subscription, used in event payloads and status output.
+	Name string `json:"name"`
+
+	// URL is the repository's browse URL, carried for display and
+	// event enrichment. Empty when the forge doesn't report one.
+	URL string `json:"url,omitempty"`
+
+	// Branch restricts commit tracking to one branch. Empty means the
+	// repository's default branch.
+	Branch string `json:"branch,omitempty"`
+
+	// CheckoutPath is the absolute path of the local read-only mirror
+	// checkout. Empty disables the checkout features for this
+	// subscription.
+	CheckoutPath string `json:"local_checkout,omitempty"`
+
+	// CheckoutRemoteURL is the git remote the local mirror fetches
+	// from. Set exactly when a checkout is configured; the
+	// subscription tools validate and store it alongside the path.
+	CheckoutRemoteURL string `json:"checkout_remote_url,omitempty"`
+
+	// TrackReleases enables release polling for this subscription.
+	TrackReleases bool `json:"track_releases"`
+
+	// TrackCommits enables commit polling for this subscription.
+	TrackCommits bool `json:"track_commits"`
+
+	// WakeTarget names the loop that receives new forge events for
+	// this subscription via the message bus.
+	WakeTarget messages.LoopWakeTarget `json:"wake_loop"`
+
+	// LastRelease is the poller's release cursor — the marker of the
+	// newest release already delivered. Releases at or before it are
+	// not re-announced. Empty until the first release is seen.
+	LastRelease string `json:"last_release,omitempty"`
+
+	// LastCommit is the poller's commit cursor — the SHA of the newest
+	// commit already delivered. Empty until the first commit is seen.
+	LastCommit string `json:"last_commit,omitempty"`
+
+	// LatestRelease is the display title of the newest release seen,
+	// carried for status output; the cursor twin is LastRelease.
+	LatestRelease string `json:"latest_release,omitempty"`
+
+	// LatestCommit is the display title of the newest commit seen,
+	// carried for status output; the cursor twin is LastCommit.
+	LatestCommit string `json:"latest_commit,omitempty"`
+
+	// LastSyncedSHA is the remote head SHA at the last successful
+	// mirror-checkout sync. Empty when no checkout is configured or no
+	// sync has completed yet.
+	LastSyncedSHA string `json:"last_synced_sha,omitempty"`
+
+	// LastChecked is when the poller last completed a poll for this
+	// subscription, successful or not. Zero before the first poll.
+	LastChecked time.Time `json:"last_checked,omitempty"`
+
+	// CreatedAt is when the subscription was authored.
+	CreatedAt time.Time `json:"created_at"`
 }
 
 // SubscriptionStore persists forge project subscriptions in opstate.

--- a/internal/platform/checkout/mirror.go
+++ b/internal/platform/checkout/mirror.go
@@ -33,7 +33,11 @@ type MirrorSpec struct {
 // branch. It never records the remote URL in .git/config; every sync supplies
 // transport details for that command only.
 type Mirror struct {
-	Name         string
+	// Name is the caller-facing checkout identifier used in logs and
+	// sync-state reporting.
+	Name string
+	// WorktreePath is the absolute path of the mirrored working tree
+	// callers read from.
 	WorktreePath string
 
 	logger *slog.Logger

--- a/internal/platform/checkout/signed.go
+++ b/internal/platform/checkout/signed.go
@@ -39,7 +39,11 @@ type SignedSpec struct {
 type Signed struct {
 	Root
 
-	Name  string
+	// Name is the caller-facing checkout identifier used in logs and
+	// sync-state reporting.
+	Name string
+	// Store is the provenance engine for this checkout — the write,
+	// sync, and history surface callers use once the checkout is open.
 	Store *provenance.Store
 }
 

--- a/internal/platform/checkout/state.go
+++ b/internal/platform/checkout/state.go
@@ -16,8 +16,12 @@ type SyncState struct {
 	OK bool
 	// Outcome classifies the last completed sync pass.
 	Outcome SyncOutcome
-	Ahead   int
-	Behind  int
+	// Ahead counts local commits the remote does not have, as observed
+	// by the last pass. Zero on a clean mirror.
+	Ahead int
+	// Behind counts remote commits the local checkout has not applied;
+	// what the next fast-forward would take.
+	Behind int
 	// LocalHead and RemoteHead are the resolved local and remote commit SHAs
 	// observed by the sync pass.
 	LocalHead  string

--- a/internal/platform/checkout/verify.go
+++ b/internal/platform/checkout/verify.go
@@ -30,7 +30,11 @@ type VerifySpec struct {
 type Verified struct {
 	Root
 
-	Name     string
+	// Name is the caller-facing checkout identifier used in logs and
+	// verification reporting.
+	Name string
+	// Verifier is the read-side verification engine for this checkout —
+	// signature checks and revision reads without write access.
 	Verifier *provenance.Verifier
 }
 

--- a/internal/platform/provenance/provenance.go
+++ b/internal/platform/provenance/provenance.go
@@ -132,10 +132,15 @@ type FileHistory struct {
 	RecentEdits []EditEntry
 }
 
-// EditEntry represents a single commit in a file's history.
+// EditEntry is one commit in a file's history, as carried in
+// [FileHistory.RecentEdits] (newest first). The store's history readers
+// construct it; revision tools and provenance views render it.
 type EditEntry struct {
-	Hash      string
-	Message   string
+	// Hash is the full commit SHA of the edit.
+	Hash string
+	// Message is the commit's subject line as recorded by the writer.
+	Message string
+	// Timestamp is the commit time recorded in the repository.
 	Timestamp time.Time
 }
 

--- a/internal/platform/provenance/sync.go
+++ b/internal/platform/provenance/sync.go
@@ -80,12 +80,30 @@ type SyncRequest struct {
 // the heads are resolved — leaves them zero and explains why in Detail. Detail
 // carries the reason for any Blocked or Diverged outcome.
 type SyncResult struct {
-	Outcome    SyncOutcome
-	Ahead      int
-	Behind     int
-	LocalHead  string
+	// Outcome classifies what the pass observed and did (up to date,
+	// fast-forwarded, blocked, diverged, remote behind).
+	Outcome SyncOutcome
+
+	// Ahead counts local commits the remote does not have. Non-zero
+	// means local work has not been pushed (or the histories diverged).
+	Ahead int
+
+	// Behind counts remote commits the local checkout does not have —
+	// what a fast-forward would apply.
+	Behind int
+
+	// LocalHead is the resolved local branch head SHA at classification
+	// time. Empty when the pass blocked before resolving heads.
+	LocalHead string
+
+	// RemoteHead is the fetched remote branch head SHA at
+	// classification time. Empty when the pass blocked before
+	// resolving heads.
 	RemoteHead string
-	Detail     string
+
+	// Detail is the human-readable reason for a Blocked or Diverged
+	// outcome; empty on clean outcomes.
+	Detail string
 }
 
 // Sync runs one fast-forward-only sync pass against the remote: fetch, then a

--- a/internal/platform/provenance/sync.go
+++ b/internal/platform/provenance/sync.go
@@ -77,11 +77,11 @@ type SyncRequest struct {
 // classification, Ahead/Behind and the two head SHAs are populated (they feed
 // the operability layer's reporting and its deferred rewind detector); a pass
 // blocked before then — a detached HEAD or a branch mismatch, caught before
-// the heads are resolved — leaves them zero and explains why in Detail. Detail
-// carries the reason for any Blocked or Diverged outcome.
+// the heads are resolved — leaves them zero and explains why in Detail.
 type SyncResult struct {
-	// Outcome classifies what the pass observed and did (up to date,
-	// fast-forwarded, blocked, diverged, remote behind).
+	// Outcome classifies what the pass observed and did — one of the
+	// SyncOutcome constants (clean, fast_forwarded, pushed, diverged,
+	// blocked, remote_behind).
 	Outcome SyncOutcome
 
 	// Ahead counts local commits the remote does not have. Non-zero
@@ -101,8 +101,8 @@ type SyncResult struct {
 	// resolving heads.
 	RemoteHead string
 
-	// Detail is the human-readable reason for a Blocked or Diverged
-	// outcome; empty on clean outcomes.
+	// Detail is the human-readable reason for any refusing outcome
+	// (blocked, diverged, remote_behind); empty when the pass succeeded.
 	Detail string
 }
 

--- a/internal/state/documents/revision_tools.go
+++ b/internal/state/documents/revision_tools.go
@@ -178,7 +178,7 @@ func (t *Tools) At(ctx context.Context, args AtArgs) (string, error) {
 		Ref:          args.Ref,
 		Rev:          rev.Short,
 		Index:        rev.Index,
-		AsOf:         rev.Timestamp.UTC().Format(time.RFC3339),
+		Timestamp:    rev.Timestamp.UTC().Format(time.RFC3339),
 		Age:          promptfmt.FormatDeltaOnly(rev.Timestamp, now),
 		VerifyStatus: revisionVerifyStatus(rev.Signer),
 		Signer:       toModelRevisionSigner(rev.Signer),
@@ -234,7 +234,7 @@ type modelRevisionAt struct {
 	Ref            string               `json:"ref"`
 	Rev            string               `json:"rev"`
 	Index          int                  `json:"index"`
-	AsOf           string               `json:"as_of"`
+	Timestamp      string               `json:"timestamp"`
 	Age            string               `json:"age,omitempty"`
 	VerifyStatus   string               `json:"verify_status"`
 	Signer         *modelRevisionSigner `json:"signer,omitempty"`

--- a/internal/state/documents/revision_tools_test.go
+++ b/internal/state/documents/revision_tools_test.go
@@ -121,6 +121,13 @@ func TestToolsAt_TrustedAndUnverified(t *testing.T) {
 	if got.VerifyStatus != "trusted" || !strings.Contains(got.Body, "hello body") || got.UnverifiedBody != "" {
 		t.Fatalf("trusted at = status %q, body %q, unverified %q", got.VerifyStatus, got.Body, got.UnverifiedBody)
 	}
+	// Tool contract: doc_at names its revision timestamp "timestamp",
+	// matching doc_history/doc_diff — one name for one concept across
+	// the revision-tool family. Guard against the old "as_of" key
+	// regressing back in.
+	if !strings.Contains(out, `"timestamp"`) || strings.Contains(out, `"as_of"`) {
+		t.Fatalf("doc_at output must use \"timestamp\" (not \"as_of\"):\n%s", out)
+	}
 
 	// An untrusted revision ships its content under unverified_body.
 	untrustedRev := newest


### PR DESCRIPTION
## Summary

Phase-1 output of the [release checklist](docs/release-checklist.md) for v0.10.1: the Godoc compliance audit and model-facing context audit ran over every surface added this cycle (checkout, provenance, forge subscriptions, revision tools, loop tooling, doc-root sync), and this PR lands the cheap fixes while they're still cheap. Follows the `docs/v0100-prerelease-audit-fixes` precedent from last release.

## Godoc sweep

Seven types failed the checklist's stand-alone / why-it-exists tests, all fixable with documentation rather than redesign. `ProjectSubscription` was the deepest gap — 18 undocumented fields including two cursor/display pairs (`LastRelease`/`LatestRelease`) whose roles were only discoverable by reading the poller. The type narrative now carries the checkout-pair lifecycle (`CheckoutPath`/`CheckoutRemoteURL` are configured together), which is where cross-field lifecycle belongs per the checklist — each field's own doc stands alone, so this passes the #812/#813 smell test rather than triggering a redesign. Also: `SyncResult` (all six fields), `SyncState.Ahead`/`Behind`, `EditEntry` (plus its role in `FileHistory`), and the `Mirror`/`Signed`/`Verified` checkout result types.

## Model-facing naming

`doc_at` emitted its revision timestamp as `as_of` while `doc_history`/`doc_diff` call the identical concept `timestamp` — the model learns two names for one field. Normalized to `timestamp`. The rename is fully contained: no tool description, doc, or talent referenced `as_of`. (The audit's larger claim — that absolute+delta dual timestamps are themselves a violation — was rejected: for revision-forensics tools the absolute anchor is deliberate and documented, and the `age` delta means the model does no arithmetic.)

## Audit verdicts recorded

- No release-blocking findings in either audit.
- #1173 filed (v0.10.2) for the untyped-map tool outputs (`loop_containers`, placement advisory) — mechanical typing work, byte-identical output at introduction.
- Prod config, live loop definitions, docs, and registry overlays all verified clean against this cycle's tool removals (`thane_curate`/`thane_create_container` → `thane_loop_create`), which is flagged for the upgrade notes.

## Test plan

- [x] Comments-only except the contained `as_of`→`timestamp` rename; documents package tests green
- [x] `just ci` green locally (unpiped, verified exit code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)