### PR TITLE
feat(ha): ha_list_services — native service-catalog discovery

### DIFF
--- a/internal/integrations/homeassistant/services.go
+++ b/internal/integrations/homeassistant/services.go
@@ -1,0 +1,63 @@
+package homeassistant
+
+import "context"
+
+// ServiceField describes one input a service accepts, as reported by
+// the /api/services catalog. Description and Example carry the pieces
+// a caller needs to fill the field correctly without guessing.
+type ServiceField struct {
+	// Name is the field's human-readable label from the catalog;
+	// empty when the integration didn't provide one.
+	Name string `json:"name,omitempty"`
+
+	// Description explains what the field does, verbatim from the
+	// integration's service definition.
+	Description string `json:"description,omitempty"`
+
+	// Required reports whether the service rejects calls that omit
+	// this field.
+	Required bool `json:"required,omitempty"`
+
+	// Example is the catalog's sample value, useful for inferring the
+	// expected shape when the description alone is ambiguous.
+	Example any `json:"example,omitempty"`
+}
+
+// ServiceDescription is one service's entry in the catalog. A non-nil
+// Target means the service accepts a target block (entity/device/area/
+// floor/label selectors) in addition to — or instead of — explicit
+// per-field addressing.
+type ServiceDescription struct {
+	// Name is the service's human-readable label.
+	Name string `json:"name,omitempty"`
+
+	// Description explains what the service does.
+	Description string `json:"description,omitempty"`
+
+	// Fields maps field key → schema for the service's inputs.
+	Fields map[string]ServiceField `json:"fields,omitempty"`
+
+	// Target is the raw target-selector block when the service is
+	// target-addressable; nil when it takes no target.
+	Target map[string]any `json:"target,omitempty"`
+}
+
+// ServiceDomain groups one domain's callable services, as returned by
+// the /api/services catalog.
+type ServiceDomain struct {
+	Domain   string                        `json:"domain"`
+	Services map[string]ServiceDescription `json:"services"`
+}
+
+// GetServices retrieves the service catalog: every callable service by
+// domain, with field schemas and target support. This is the discovery
+// surface behind ha_list_services — how a caller learns what
+// CallService can actually do, instead of guessing names and burning a
+// failed call to find out.
+func (c *Client) GetServices(ctx context.Context) ([]ServiceDomain, error) {
+	var domains []ServiceDomain
+	if err := c.get(ctx, "/api/services", &domains); err != nil {
+		return nil, err
+	}
+	return domains, nil
+}

--- a/internal/model/toolcatalog/catalog.go
+++ b/internal/model/toolcatalog/catalog.go
@@ -236,6 +236,7 @@ var builtinToolSpecs = map[string]BuiltinToolSpec{
 	"contact_import_vcf":          {CanonicalID: "native:contact_import_vcf", Source: NativeToolSource, Tags: []string{"contacts"}},
 	"contact_list":                {CanonicalID: "native:contact_list", Source: NativeToolSource, Tags: []string{"contacts"}},
 	"ha_list_entities":            {CanonicalID: "native:ha_list_entities", Source: NativeToolSource, Tags: []string{"ha"}},
+	"ha_list_services":            {CanonicalID: "native:ha_list_services", Source: NativeToolSource, Tags: []string{"ha"}},
 	"ha_search_states":            {CanonicalID: "native:ha_search_states", Source: NativeToolSource, Tags: []string{"ha"}},
 	"get_area_activity":           {CanonicalID: "native:get_area_activity", Source: NativeToolSource, Tags: []string{"ha"}},
 	"ha_device":                   {CanonicalID: "native:ha_device", Source: NativeToolSource, Tags: []string{"ha"}},

--- a/internal/tools/ha_automation_tools_test.go
+++ b/internal/tools/ha_automation_tools_test.go
@@ -21,6 +21,7 @@ type fakeHAServer struct {
 
 	mu           sync.Mutex
 	states       []homeassistant.State
+	services     []homeassistant.ServiceDomain
 	configs      map[string]map[string]any
 	areas        []map[string]any
 	floors       []map[string]any
@@ -58,6 +59,7 @@ func newFakeHAServer(t *testing.T) *fakeHAServer {
 	mux.HandleFunc("/api/states/", f.handleState)
 	mux.HandleFunc("/api/config/automation/config/", f.handleAutomationConfig)
 	mux.HandleFunc("/api/services/", f.handleServiceCall)
+	mux.HandleFunc("/api/services", f.handleServicesCatalog)
 
 	f.server = httptest.NewServer(mux)
 	t.Cleanup(f.server.Close)
@@ -79,6 +81,16 @@ func (f *fakeHAServer) registry(t *testing.T) *Registry {
 	t.Cleanup(func() { _ = ws.Close() })
 
 	return NewRegistry(client, nil)
+}
+
+func (f *fakeHAServer) handleServicesCatalog(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	writeJSON(f.t, w, f.services)
 }
 
 func (f *fakeHAServer) handleStates(w http.ResponseWriter, r *http.Request) {

--- a/internal/tools/ha_list_services.go
+++ b/internal/tools/ha_list_services.go
@@ -1,0 +1,198 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/nugget/thane-ai-agent/internal/integrations/homeassistant"
+)
+
+const haListServicesTruncationNote = "Result exceeded the tool byte cap; pass domain (and optionally service) to narrow to the detail you need."
+
+// haServicesIndex is the no-argument shape: a compact directory of
+// every domain and its service names, sized to answer "what can I
+// call" without shipping every field schema in the install.
+type haServicesIndex struct {
+	DomainCount int                      `json:"domain_count"`
+	Truncated   bool                     `json:"truncated,omitempty"`
+	Note        string                   `json:"note"`
+	Domains     []haServiceDomainSummary `json:"domains"`
+}
+
+type haServiceDomainSummary struct {
+	Domain   string   `json:"domain"`
+	Services []string `json:"services"`
+}
+
+// haServicesDetail is the domain- or service-scoped shape: full field
+// schemas and target support for the requested slice of the catalog.
+type haServicesDetail struct {
+	Domain    string            `json:"domain"`
+	Count     int               `json:"count"`
+	Truncated bool              `json:"truncated,omitempty"`
+	Services  []haServiceDetail `json:"services"`
+}
+
+type haServiceDetail struct {
+	// Service is the callable domain.service identifier — exactly what
+	// ha_call_service takes.
+	Service       string           `json:"service"`
+	Name          string           `json:"name,omitempty"`
+	Description   string           `json:"description,omitempty"`
+	AcceptsTarget bool             `json:"accepts_target"`
+	Fields        []haServiceField `json:"fields,omitempty"`
+}
+
+type haServiceField struct {
+	Field       string `json:"field"`
+	Name        string `json:"name,omitempty"`
+	Description string `json:"description,omitempty"`
+	Required    bool   `json:"required,omitempty"`
+	Example     any    `json:"example,omitempty"`
+}
+
+// registerHAListServices wires the ha_list_services tool: the service
+// catalog as a discovery surface, so a caller learns what
+// ha_call_service can do — names, fields, target support — instead of
+// guessing and burning a failed call. Progressive disclosure keeps the
+// payload honest: the bare call returns a name directory; domain (and
+// service) scope in the full field schemas.
+func (r *Registry) registerHAListServices() {
+	r.Register(&Tool{
+		Name: "ha_list_services",
+		Description: "Discover what Home Assistant services can be called. " +
+			"Without arguments: a directory of every domain and its service names. " +
+			"With domain: full detail for that domain's services — description, fields (with required/example), and whether the service accepts a target block (area/floor/label/device/entity). " +
+			"With domain and service: just that service. " +
+			"Use this before ha_call_service when unsure of a service name or its fields.",
+		Parameters: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"domain": map[string]any{
+					"type":        "string",
+					"description": "Scope to one domain (e.g. \"light\", \"climate\") and return full field detail.",
+				},
+				"service": map[string]any{
+					"type":        "string",
+					"description": "With domain: return just this service. Accepts \"turn_on\" or the combined \"light.turn_on\" form.",
+				},
+			},
+		},
+		Handler: r.handleHAListServices,
+	})
+}
+
+func (r *Registry) handleHAListServices(ctx context.Context, args map[string]any) (string, error) {
+	if r.ha == nil {
+		return "", fmt.Errorf("home assistant not configured")
+	}
+	if !r.ha.IsReady() {
+		return "", fmt.Errorf("home assistant is currently unreachable (reconnecting in background)")
+	}
+
+	domain, _ := args["domain"].(string)
+	service, _ := args["service"].(string)
+	domain = strings.TrimSpace(domain)
+	service = strings.TrimSpace(service)
+
+	// Tolerate the combined form the model naturally reaches for:
+	// service "light.turn_on" implies (and must agree with) the domain.
+	if d, s, ok := strings.Cut(service, "."); ok {
+		if domain != "" && domain != d {
+			return "", fmt.Errorf("service %q names domain %q but domain argument says %q — drop one or make them agree", service, d, domain)
+		}
+		domain, service = d, s
+	}
+	if service != "" && domain == "" {
+		return "", fmt.Errorf("service requires a domain (pass domain, or use the combined \"domain.service\" form)")
+	}
+
+	catalog, err := r.ha.GetServices(ctx)
+	if err != nil {
+		return "", err
+	}
+	sort.Slice(catalog, func(i, j int) bool { return catalog[i].Domain < catalog[j].Domain })
+
+	if domain == "" {
+		return haServicesIndexResult(catalog), nil
+	}
+
+	for _, d := range catalog {
+		if d.Domain != domain {
+			continue
+		}
+		detail, err := haServicesDomainResult(d, service)
+		if err != nil {
+			return "", err
+		}
+		return detail, nil
+	}
+
+	known := make([]string, 0, len(catalog))
+	for _, d := range catalog {
+		known = append(known, d.Domain)
+	}
+	return "", fmt.Errorf("domain %q has no services; known domains: %s", domain, strings.Join(known, ", "))
+}
+
+func haServicesIndexResult(catalog []homeassistant.ServiceDomain) string {
+	out := haServicesIndex{
+		DomainCount: len(catalog),
+		Note:        "Names only. Pass domain (and optionally service) for fields and target support.",
+		Domains:     make([]haServiceDomainSummary, 0, len(catalog)),
+	}
+	for _, d := range catalog {
+		names := make([]string, 0, len(d.Services))
+		for name := range d.Services {
+			names = append(names, name)
+		}
+		sort.Strings(names)
+		out.Domains = append(out.Domains, haServiceDomainSummary{Domain: d.Domain, Services: names})
+	}
+	return toIndentedJSONWithTruncationNote(out, haListServicesTruncationNote)
+}
+
+func haServicesDomainResult(d homeassistant.ServiceDomain, service string) (string, error) {
+	names := make([]string, 0, len(d.Services))
+	for name := range d.Services {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	out := haServicesDetail{Domain: d.Domain}
+	for _, name := range names {
+		if service != "" && name != service {
+			continue
+		}
+		desc := d.Services[name]
+		detail := haServiceDetail{
+			Service:       d.Domain + "." + name,
+			Name:          desc.Name,
+			Description:   desc.Description,
+			AcceptsTarget: desc.Target != nil,
+		}
+		fieldKeys := make([]string, 0, len(desc.Fields))
+		for k := range desc.Fields {
+			fieldKeys = append(fieldKeys, k)
+		}
+		sort.Strings(fieldKeys)
+		for _, k := range fieldKeys {
+			f := desc.Fields[k]
+			detail.Fields = append(detail.Fields, haServiceField{
+				Field:       k,
+				Name:        f.Name,
+				Description: f.Description,
+				Required:    f.Required,
+				Example:     f.Example,
+			})
+		}
+		out.Services = append(out.Services, detail)
+	}
+	if service != "" && len(out.Services) == 0 {
+		return "", fmt.Errorf("domain %q has no service %q; it has: %s", d.Domain, service, strings.Join(names, ", "))
+	}
+	out.Count = len(out.Services)
+	return toIndentedJSONWithTruncationNote(out, haListServicesTruncationNote), nil
+}

--- a/internal/tools/ha_list_services.go
+++ b/internal/tools/ha_list_services.go
@@ -60,12 +60,15 @@ type haServiceField struct {
 // payload honest: the bare call returns a name directory; domain (and
 // service) scope in the full field schemas.
 func (r *Registry) registerHAListServices() {
+	if r.ha == nil {
+		return
+	}
 	r.Register(&Tool{
 		Name: "ha_list_services",
 		Description: "Discover what Home Assistant services can be called. " +
 			"Without arguments: a directory of every domain and its service names. " +
 			"With domain: full detail for that domain's services — description, fields (with required/example), and whether the service accepts a target block (area/floor/label/device/entity). " +
-			"With domain and service: just that service. " +
+			"With a specific service — either domain plus service, or just service in the combined \"light.turn_on\" form — returns that single service. " +
 			"Use this before ha_call_service when unsure of a service name or its fields.",
 		Parameters: map[string]any{
 			"type": "object",
@@ -76,7 +79,7 @@ func (r *Registry) registerHAListServices() {
 				},
 				"service": map[string]any{
 					"type":        "string",
-					"description": "With domain: return just this service. Accepts \"turn_on\" or the combined \"light.turn_on\" form.",
+					"description": "Return just this one service. Accepts \"turn_on\" (paired with domain) or the self-contained combined form \"light.turn_on\" with no domain argument needed.",
 				},
 			},
 		},
@@ -134,7 +137,7 @@ func (r *Registry) handleHAListServices(ctx context.Context, args map[string]any
 	for _, d := range catalog {
 		known = append(known, d.Domain)
 	}
-	return "", fmt.Errorf("domain %q has no services; known domains: %s", domain, strings.Join(known, ", "))
+	return "", fmt.Errorf("unknown domain %q; known domains: %s", domain, strings.Join(known, ", "))
 }
 
 func haServicesIndexResult(catalog []homeassistant.ServiceDomain) string {

--- a/internal/tools/ha_list_services_test.go
+++ b/internal/tools/ha_list_services_test.go
@@ -1,0 +1,139 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/nugget/thane-ai-agent/internal/integrations/homeassistant"
+)
+
+func servicesFixture() []homeassistant.ServiceDomain {
+	return []homeassistant.ServiceDomain{
+		{
+			Domain: "light",
+			Services: map[string]homeassistant.ServiceDescription{
+				"turn_on": {
+					Name:        "Turn on",
+					Description: "Turns on one or more lights.",
+					Target:      map[string]any{"entity": map[string]any{"domain": "light"}},
+					Fields: map[string]homeassistant.ServiceField{
+						"brightness_pct": {Name: "Brightness", Description: "Percent brightness.", Example: 80},
+						"transition":     {Description: "Fade duration in seconds."},
+					},
+				},
+				"turn_off": {Name: "Turn off", Target: map[string]any{}},
+			},
+		},
+		{
+			Domain: "notify",
+			Services: map[string]homeassistant.ServiceDescription{
+				"send_message": {
+					Name:   "Send message",
+					Fields: map[string]homeassistant.ServiceField{"message": {Required: true}},
+				},
+			},
+		},
+	}
+}
+
+func TestHAListServices_IndexIsCompactAndSorted(t *testing.T) {
+	fake := newFakeHAServer(t)
+	fake.services = servicesFixture()
+	reg := fake.registry(t)
+
+	raw, err := reg.Execute(context.Background(), "ha_list_services", `{}`)
+	if err != nil {
+		t.Fatalf("ha_list_services: %v", err)
+	}
+	var idx haServicesIndex
+	if err := json.Unmarshal([]byte(raw), &idx); err != nil {
+		t.Fatalf("unmarshal: %v\n%s", err, raw)
+	}
+	if idx.DomainCount != 2 || len(idx.Domains) != 2 {
+		t.Fatalf("domain count = %d/%d entries, want 2/2", idx.DomainCount, len(idx.Domains))
+	}
+	// Sorted: light before notify; service names sorted within a domain.
+	if idx.Domains[0].Domain != "light" || idx.Domains[1].Domain != "notify" {
+		t.Errorf("domain order = %q,%q, want light,notify", idx.Domains[0].Domain, idx.Domains[1].Domain)
+	}
+	if idx.Domains[0].Services[0] != "turn_off" || idx.Domains[0].Services[1] != "turn_on" {
+		t.Errorf("light services = %v, want sorted [turn_off turn_on]", idx.Domains[0].Services)
+	}
+	// The index is names-only: no field schemas leak into the compact shape.
+	if strings.Contains(raw, "brightness_pct") {
+		t.Errorf("index leaked field detail:\n%s", raw)
+	}
+}
+
+func TestHAListServices_DomainDetailFieldsAndTarget(t *testing.T) {
+	fake := newFakeHAServer(t)
+	fake.services = servicesFixture()
+	reg := fake.registry(t)
+
+	raw, err := reg.Execute(context.Background(), "ha_list_services", `{"domain":"light"}`)
+	if err != nil {
+		t.Fatalf("ha_list_services domain: %v", err)
+	}
+	var det haServicesDetail
+	if err := json.Unmarshal([]byte(raw), &det); err != nil {
+		t.Fatalf("unmarshal: %v\n%s", err, raw)
+	}
+	if det.Domain != "light" || det.Count != 2 {
+		t.Fatalf("domain/count = %q/%d, want light/2", det.Domain, det.Count)
+	}
+	// Sorted by name: turn_off first, then turn_on.
+	on := det.Services[1]
+	if on.Service != "light.turn_on" {
+		t.Fatalf("services[1] = %q, want light.turn_on", on.Service)
+	}
+	if !on.AcceptsTarget {
+		t.Error("light.turn_on should report accepts_target")
+	}
+	if len(on.Fields) != 2 || on.Fields[0].Field != "brightness_pct" {
+		t.Errorf("fields = %+v, want sorted with brightness_pct first", on.Fields)
+	}
+}
+
+func TestHAListServices_CombinedServiceForm(t *testing.T) {
+	fake := newFakeHAServer(t)
+	fake.services = servicesFixture()
+	reg := fake.registry(t)
+
+	raw, err := reg.Execute(context.Background(), "ha_list_services", `{"service":"notify.send_message"}`)
+	if err != nil {
+		t.Fatalf("combined form: %v", err)
+	}
+	var det haServicesDetail
+	if err := json.Unmarshal([]byte(raw), &det); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if det.Count != 1 || det.Services[0].Service != "notify.send_message" {
+		t.Fatalf("got %+v, want exactly notify.send_message", det.Services)
+	}
+	if det.Services[0].AcceptsTarget {
+		t.Error("notify.send_message has no target block; accepts_target must be false")
+	}
+	if len(det.Services[0].Fields) != 1 || !det.Services[0].Fields[0].Required {
+		t.Errorf("message field should be present and required: %+v", det.Services[0].Fields)
+	}
+}
+
+func TestHAListServices_Errors(t *testing.T) {
+	fake := newFakeHAServer(t)
+	fake.services = servicesFixture()
+	reg := fake.registry(t)
+
+	cases := map[string]string{
+		"unknown domain":          `{"domain":"vacuum"}`,
+		"unknown service":         `{"domain":"light","service":"strobe"}`,
+		"service without domain":  `{"service":"turn_on"}`,
+		"domain/service mismatch": `{"domain":"notify","service":"light.turn_on"}`,
+	}
+	for name, args := range cases {
+		if _, err := reg.Execute(context.Background(), "ha_list_services", args); err == nil {
+			t.Errorf("%s: expected error, got success", name)
+		}
+	}
+}

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -121,6 +121,7 @@ func NewRegistry(ha *homeassistant.Client, sched *scheduler.Scheduler) *Registry
 	r.registerBuiltins()
 	r.registerFindEntity()     // Smart entity discovery
 	r.registerHASearchStates() // Predicate search across live state
+	r.registerHAListServices() // Service-catalog discovery (#1177)
 	r.registerHAAutomationTools()
 	return r
 }

--- a/talents/ha.md
+++ b/talents/ha.md
@@ -331,11 +331,12 @@ a guessed entity_id.
 ## Low-level: ha_call_service
 
 Unsure of a service name or its fields? `ha_list_services` is the
-catalog: bare call for a directory of every domain's service names,
-`domain` (or `"domain.service"`) for full field detail — descriptions,
-required flags, examples, and whether the service accepts a target
-block. Check it before guessing; a wrong service name costs a failed
-call.
+catalog: bare call for a directory of every domain's service names;
+`domain` for full field detail on all of that domain's services;
+`"domain.service"` (e.g. `"light.turn_on"`) for just that one service —
+descriptions, required flags, examples, and whether it accepts a
+target block. Check it before guessing; a wrong service name costs a
+failed call.
 
 `ha_call_service` requires the exact entity_id:
 

--- a/talents/ha.md
+++ b/talents/ha.md
@@ -330,6 +330,13 @@ a guessed entity_id.
 
 ## Low-level: ha_call_service
 
+Unsure of a service name or its fields? `ha_list_services` is the
+catalog: bare call for a directory of every domain's service names,
+`domain` (or `"domain.service"`) for full field detail — descriptions,
+required flags, examples, and whether the service accepts a target
+block. Check it before guessing; a wrong service name costs a failed
+call.
+
 `ha_call_service` requires the exact entity_id:
 
 ```json


### PR DESCRIPTION
## Summary

Closes #1177 — the first pull from the #1175 HA overhaul umbrella. The model could never natively answer "what services can I call?": the client had no wrapper for HA's `/api/services` catalog, so service discovery meant either guessing names and burning a failed `ha_call_service` learning otherwise, or leaning on the `ha-mcp` bridge's `ha_list_services` — one of the six allowlisted MCP tools this milestone retires.

## The tool

`ha_list_services` is the catalog as a discovery surface, with progressive disclosure keeping the payload honest against a full install's catalog size:

- **Bare call** → a compact directory: every domain with its service names, sorted, names only. Answers "what exists" without shipping every field schema in the install.
- **`domain`** → full detail for that domain: description, sorted field schemas (name/description/required/example), and `accepts_target` — whether the service takes a target block (area/floor/label/device/entity).
- **`domain` + `service`** (or the combined `"light.turn_on"` form the model naturally reaches for) → just that service.

Errors teach the next move per the tool doctrine: an unknown domain lists the known domains, an unknown service lists the domain's actual services, and a domain/service mismatch in the combined form says exactly which argument to drop.

`accepts_target` is deliberate bridge-building: it's the signal #1179 (target-scoped `ha_call_service`) will lean on, so the model learns which services fan out across areas before that teaching lands.

## Plumbing

One client method (`GetServices`, REST `/api/services`) with typed `ServiceDomain`/`ServiceDescription`/`ServiceField` projections; the tool sorts everything deterministically (domains, services, fields) per the model-facing conventions, and the byte cap carries the standard explicit truncation note steering toward narrower scoping. Catalogued in `toolcatalog` (the #1150 CI gate enforces this) under the `ha` tag, and `talents/ha.md` teaches check-before-guessing in the `ha_call_service` section.

## Test plan

- [x] Index shape: compact, sorted, names-only (field schemas verified absent)
- [x] Domain detail: sorted fields, `accepts_target` true/false both covered
- [x] Combined `"domain.service"` form resolves; required fields surface
- [x] Error paths: unknown domain, unknown service, service-without-domain, combined-form mismatch
- [x] `just ci` green locally (unpiped, verified)

Refs #1175. First native displacement of the ha-mcp allowlist (#1180 tracks the eventual unplug).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
