### PR TITLE
feat(ha): ha_automation_traces — the debugging half of the automation family

### DIFF
--- a/internal/integrations/homeassistant/traces.go
+++ b/internal/integrations/homeassistant/traces.go
@@ -1,0 +1,119 @@
+package homeassistant
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+// TraceTimestamps carries a trace run's start and finish instants.
+// Finish is nil while a run is still executing.
+type TraceTimestamps struct {
+	Start  time.Time  `json:"start"`
+	Finish *time.Time `json:"finish"`
+}
+
+// AutomationTraceSummary is one run's row from the trace/list WebSocket
+// command: enough to see when the automation ran, what set it off, and
+// how the run ended, without the step-by-step tree.
+type AutomationTraceSummary struct {
+	// RunID identifies the run; pass it to GetAutomationTrace for the
+	// full step tree.
+	RunID string `json:"run_id"`
+
+	// State is the run's lifecycle state ("running" or "stopped").
+	State string `json:"state"`
+
+	// ScriptExecution reports how execution concluded — "finished",
+	// "failed_conditions", "cancelled", "error", and friends. Empty
+	// while the run is still in flight.
+	ScriptExecution string `json:"script_execution"`
+
+	// Timestamp carries the run's start/finish instants.
+	Timestamp TraceTimestamps `json:"timestamp"`
+
+	// Trigger is HA's human-readable description of what fired the
+	// run (e.g. "state of binary_sensor.office_motion").
+	Trigger string `json:"trigger"`
+
+	// LastStep is the path of the last step the run reached.
+	LastStep string `json:"last_step"`
+
+	// Error carries the run-level error message when the run aborted.
+	Error string `json:"error"`
+}
+
+// TraceStep is one recorded step execution inside a trace tree.
+type TraceStep struct {
+	// Path locates the step in the automation config (e.g. "trigger/0",
+	// "condition/1", "action/0/choose/1/sequence/0").
+	Path string `json:"path"`
+
+	// Timestamp is when the step executed.
+	Timestamp time.Time `json:"timestamp"`
+
+	// Result is the step's recorded outcome (shape varies by step
+	// kind: condition results carry a boolean, service steps carry
+	// call parameters).
+	Result map[string]any `json:"result,omitempty"`
+
+	// Error carries the step's error message when it failed.
+	Error string `json:"error"`
+
+	// ChangedVariables is the raw variable snapshot at this step. It
+	// is bulky and rarely worth shipping to a model verbatim; the
+	// traces tool omits it from projections.
+	ChangedVariables json.RawMessage `json:"changed_variables,omitempty"`
+}
+
+// AutomationTraceDetail is the trace/get result: the run summary plus
+// the full step tree keyed by config path.
+type AutomationTraceDetail struct {
+	AutomationTraceSummary
+
+	// Trace maps each executed config path to its step executions, in
+	// execution order per path (a path repeats when a loop re-enters it).
+	Trace map[string][]TraceStep `json:"trace"`
+}
+
+// ListAutomationTraces retrieves recent run summaries for one
+// automation, identified by its config item id. HA retains only a
+// handful of recent runs per automation; an empty result usually means
+// the automation hasn't run recently, not that it never ran.
+func (c *Client) ListAutomationTraces(ctx context.Context, itemID string) ([]AutomationTraceSummary, error) {
+	ws, err := c.requireWS()
+	if err != nil {
+		return nil, err
+	}
+	return ws.ListAutomationTraces(ctx, itemID)
+}
+
+// GetAutomationTrace retrieves one run's full step tree.
+func (c *Client) GetAutomationTrace(ctx context.Context, itemID, runID string) (*AutomationTraceDetail, error) {
+	ws, err := c.requireWS()
+	if err != nil {
+		return nil, err
+	}
+	return ws.GetAutomationTrace(ctx, itemID, runID)
+}
+
+// ListAutomationTraces implements the trace/list WebSocket command for
+// automations.
+func (c *WSClient) ListAutomationTraces(ctx context.Context, itemID string) ([]AutomationTraceSummary, error) {
+	var result []AutomationTraceSummary
+	if err := c.call(ctx, "trace/list", map[string]any{"domain": "automation", "item_id": itemID}, &result); err != nil {
+		return nil, fmt.Errorf("list automation traces: %w", err)
+	}
+	return result, nil
+}
+
+// GetAutomationTrace implements the trace/get WebSocket command for
+// automations.
+func (c *WSClient) GetAutomationTrace(ctx context.Context, itemID, runID string) (*AutomationTraceDetail, error) {
+	var result AutomationTraceDetail
+	if err := c.call(ctx, "trace/get", map[string]any{"domain": "automation", "item_id": itemID, "run_id": runID}, &result); err != nil {
+		return nil, fmt.Errorf("get automation trace: %w", err)
+	}
+	return &result, nil
+}

--- a/internal/model/toolcatalog/catalog.go
+++ b/internal/model/toolcatalog/catalog.go
@@ -236,6 +236,7 @@ var builtinToolSpecs = map[string]BuiltinToolSpec{
 	"contact_import_vcf":          {CanonicalID: "native:contact_import_vcf", Source: NativeToolSource, Tags: []string{"contacts"}},
 	"contact_list":                {CanonicalID: "native:contact_list", Source: NativeToolSource, Tags: []string{"contacts"}},
 	"ha_list_entities":            {CanonicalID: "native:ha_list_entities", Source: NativeToolSource, Tags: []string{"ha"}},
+	"ha_automation_traces":        {CanonicalID: "native:ha_automation_traces", Source: NativeToolSource, Tags: []string{"ha"}},
 	"ha_list_services":            {CanonicalID: "native:ha_list_services", Source: NativeToolSource, Tags: []string{"ha"}},
 	"ha_search_states":            {CanonicalID: "native:ha_search_states", Source: NativeToolSource, Tags: []string{"ha"}},
 	"get_area_activity":           {CanonicalID: "native:get_area_activity", Source: NativeToolSource, Tags: []string{"ha"}},

--- a/internal/tools/ha_automation_tools_test.go
+++ b/internal/tools/ha_automation_tools_test.go
@@ -22,6 +22,8 @@ type fakeHAServer struct {
 	mu           sync.Mutex
 	states       []homeassistant.State
 	services     []homeassistant.ServiceDomain
+	traces       map[string][]map[string]any
+	traceDetails map[string]map[string]any
 	configs      map[string]map[string]any
 	areas        []map[string]any
 	floors       []map[string]any
@@ -233,6 +235,20 @@ func (f *fakeHAServer) wsResult(msgType string, msg map[string]any) (any, bool) 
 	defer f.mu.Unlock()
 
 	switch msgType {
+	case "trace/list":
+		itemID, _ := msg["item_id"].(string)
+		list := f.traces[itemID]
+		if list == nil {
+			list = []map[string]any{}
+		}
+		return list, true
+	case "trace/get":
+		runID, _ := msg["run_id"].(string)
+		detail, ok := f.traceDetails[runID]
+		if !ok {
+			return nil, false
+		}
+		return detail, true
 	case "validate_config":
 		return f.validations, true
 	case "config/area_registry/list":

--- a/internal/tools/ha_automation_traces.go
+++ b/internal/tools/ha_automation_traces.go
@@ -1,0 +1,230 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/nugget/thane-ai-agent/internal/integrations/homeassistant"
+	"github.com/nugget/thane-ai-agent/internal/model/promptfmt"
+)
+
+const (
+	defaultHATraceRunLimit      = 10
+	maxHATraceRunLimit          = 25
+	haTracesTruncationNote      = "Result exceeded the tool byte cap; pass run_id for one run's detail, or lower limit."
+	haTraceVariablesOmittedNote = "Step variable snapshots are omitted; results and errors are shown per step."
+)
+
+// haTraceRunsResult is the summary shape: recent runs of one
+// automation, newest first.
+type haTraceRunsResult struct {
+	Automation string           `json:"automation"`
+	ID         string           `json:"id"`
+	Count      int              `json:"count"`
+	Truncated  bool             `json:"truncated,omitempty"`
+	Note       string           `json:"note,omitempty"`
+	Runs       []haTraceRunView `json:"runs"`
+}
+
+type haTraceRunView struct {
+	RunID       string `json:"run_id"`
+	Started     string `json:"started"`
+	DurationMS  int64  `json:"duration_ms,omitempty"`
+	State       string `json:"state"`
+	Execution   string `json:"execution,omitempty"`
+	TriggeredBy string `json:"triggered_by,omitempty"`
+	LastStep    string `json:"last_step,omitempty"`
+	Error       string `json:"error,omitempty"`
+}
+
+// haTraceDetailResult is the run-scoped shape: the step-by-step record
+// of one run, in execution order.
+type haTraceDetailResult struct {
+	Automation string            `json:"automation"`
+	ID         string            `json:"id"`
+	Run        haTraceRunView    `json:"run"`
+	StepCount  int               `json:"step_count"`
+	Truncated  bool              `json:"truncated,omitempty"`
+	Note       string            `json:"note"`
+	Steps      []haTraceStepView `json:"steps"`
+}
+
+type haTraceStepView struct {
+	Path   string         `json:"path"`
+	At     string         `json:"at"`
+	Result map[string]any `json:"result,omitempty"`
+	Error  string         `json:"error,omitempty"`
+}
+
+// registerHAAutomationTraces wires ha_automation_traces: the debugging
+// half of the automation family. Create/update/get answer "what is the
+// automation"; traces answer "what did it actually do when it ran" —
+// which trigger fired, which conditions passed, what each action did.
+// Requires the WebSocket client, like the rest of the automation family.
+func (r *Registry) registerHAAutomationTraces() {
+	if r.ha == nil || !r.ha.HasWSClient() {
+		return
+	}
+	r.Register(&Tool{
+		Name: "ha_automation_traces",
+		Description: "Inspect recent runs of a Home Assistant automation — the step-by-step record of what actually happened. " +
+			"Without run_id: recent runs newest-first (when, what triggered it, how it ended, any error). " +
+			"With run_id: that run's full step trace in execution order, with per-step results and errors. " +
+			"Home Assistant keeps only a handful of recent runs per automation; an empty list usually means it hasn't run recently. " +
+			"Use after ha_automation_create/update to verify behavior, or when an automation misfires.",
+		Parameters: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"id": map[string]any{
+					"type":        "string",
+					"description": "Automation config ID. Provide this or entity_id.",
+				},
+				"entity_id": map[string]any{
+					"type":        "string",
+					"description": "Automation entity_id (automation.*). Provide this or id.",
+				},
+				"run_id": map[string]any{
+					"type":        "string",
+					"description": "A run_id from the summary listing; returns that run's full step trace.",
+				},
+				"limit": map[string]any{
+					"type":        "integer",
+					"description": "Max runs in the summary listing (default 10, max 25).",
+				},
+			},
+		},
+		Handler: r.handleHAAutomationTraces,
+	})
+}
+
+func (r *Registry) handleHAAutomationTraces(ctx context.Context, args map[string]any) (string, error) {
+	if r.ha == nil {
+		return "", fmt.Errorf("home assistant not configured")
+	}
+	if !r.ha.IsReady() {
+		return "", fmt.Errorf("home assistant is currently unreachable (reconnecting in background)")
+	}
+
+	idArg, _ := args["id"].(string)
+	entityArg, _ := args["entity_id"].(string)
+	runID, _ := args["run_id"].(string)
+
+	resolved, err := r.resolveAutomation(ctx, idArg, entityArg)
+	if err != nil {
+		return "", err
+	}
+
+	limit := defaultHATraceRunLimit
+	if l, ok := args["limit"].(float64); ok && int(l) > 0 {
+		limit = int(l)
+	}
+	if limit > maxHATraceRunLimit {
+		limit = maxHATraceRunLimit
+	}
+
+	now := time.Now()
+	if runID != "" {
+		detail, err := r.ha.GetAutomationTrace(ctx, resolved.id, runID)
+		if err != nil {
+			return "", fmt.Errorf("get trace %q: %w (run_ids come from the summary listing; traces expire as new runs arrive)", runID, err)
+		}
+		return haTraceDetailView(resolved, detail, now), nil
+	}
+
+	runs, err := r.ha.ListAutomationTraces(ctx, resolved.id)
+	if err != nil {
+		return "", err
+	}
+	return haTraceRunsView(resolved, runs, limit, now), nil
+}
+
+func haTraceRunsView(resolved resolvedAutomation, runs []homeassistant.AutomationTraceSummary, limit int, now time.Time) string {
+	sort.Slice(runs, func(i, j int) bool {
+		return runs[i].Timestamp.Start.After(runs[j].Timestamp.Start)
+	})
+	total := len(runs)
+	if len(runs) > limit {
+		runs = runs[:limit]
+	}
+
+	out := haTraceRunsResult{
+		Automation: resolved.entityID,
+		ID:         resolved.id,
+		Count:      len(runs),
+		Truncated:  total > len(runs),
+		Runs:       make([]haTraceRunView, 0, len(runs)),
+	}
+	if total == 0 {
+		out.Note = "No stored runs. Home Assistant keeps traces only for recent runs; this usually means the automation hasn't fired lately."
+	}
+	for _, run := range runs {
+		out.Runs = append(out.Runs, haTraceRunSummaryView(run, now))
+	}
+	return toIndentedJSONWithTruncationNote(out, haTracesTruncationNote)
+}
+
+func haTraceRunSummaryView(run homeassistant.AutomationTraceSummary, now time.Time) haTraceRunView {
+	view := haTraceRunView{
+		RunID:       run.RunID,
+		Started:     promptfmt.FormatDeltaOnly(run.Timestamp.Start, now),
+		State:       run.State,
+		Execution:   run.ScriptExecution,
+		TriggeredBy: run.Trigger,
+		LastStep:    run.LastStep,
+		Error:       run.Error,
+	}
+	if run.Timestamp.Finish != nil {
+		view.DurationMS = run.Timestamp.Finish.Sub(run.Timestamp.Start).Milliseconds()
+	}
+	return view
+}
+
+func haTraceDetailView(resolved resolvedAutomation, detail *homeassistant.AutomationTraceDetail, now time.Time) string {
+	// Collect with real timestamps first: execution order must come
+	// from the instants, not from projected delta strings (which do
+	// not compare temporally) and not from the path-keyed map order.
+	type timedStep struct {
+		at   time.Time
+		view haTraceStepView
+	}
+	timed := make([]timedStep, 0, len(detail.Trace)*2)
+	for path, executions := range detail.Trace {
+		for _, step := range executions {
+			stepPath := step.Path
+			if stepPath == "" {
+				stepPath = path
+			}
+			timed = append(timed, timedStep{
+				at: step.Timestamp,
+				view: haTraceStepView{
+					Path:   stepPath,
+					At:     promptfmt.FormatDeltaOnly(step.Timestamp, now),
+					Result: step.Result,
+					Error:  step.Error,
+				},
+			})
+		}
+	}
+	sort.Slice(timed, func(i, j int) bool {
+		if !timed[i].at.Equal(timed[j].at) {
+			return timed[i].at.Before(timed[j].at)
+		}
+		return timed[i].view.Path < timed[j].view.Path
+	})
+	steps := make([]haTraceStepView, len(timed))
+	for i, ts := range timed {
+		steps[i] = ts.view
+	}
+
+	out := haTraceDetailResult{
+		Automation: resolved.entityID,
+		ID:         resolved.id,
+		Run:        haTraceRunSummaryView(detail.AutomationTraceSummary, now),
+		StepCount:  len(steps),
+		Note:       haTraceVariablesOmittedNote,
+		Steps:      steps,
+	}
+	return toIndentedJSONWithTruncationNote(out, haTracesTruncationNote)
+}

--- a/internal/tools/ha_automation_traces.go
+++ b/internal/tools/ha_automation_traces.go
@@ -11,10 +11,11 @@ import (
 )
 
 const (
-	defaultHATraceRunLimit      = 10
-	maxHATraceRunLimit          = 25
-	haTracesTruncationNote      = "Result exceeded the tool byte cap; pass run_id for one run's detail, or lower limit."
-	haTraceVariablesOmittedNote = "Step variable snapshots are omitted; results and errors are shown per step."
+	defaultHATraceRunLimit        = 10
+	maxHATraceRunLimit            = 25
+	haTracesSummaryTruncationNote = "Result exceeded the tool byte cap; pass run_id for one run's detail, or lower limit."
+	haTracesDetailTruncationNote  = "Run detail exceeded the tool byte cap; later steps were cut from this preview. The run block at the top (last_step, error) still shows where the run ended."
+	haTraceVariablesOmittedNote   = "Step variable snapshots are omitted; results and errors are shown per step."
 )
 
 // haTraceRunsResult is the summary shape: recent runs of one
@@ -162,7 +163,7 @@ func haTraceRunsView(resolved resolvedAutomation, runs []homeassistant.Automatio
 	for _, run := range runs {
 		out.Runs = append(out.Runs, haTraceRunSummaryView(run, now))
 	}
-	return toIndentedJSONWithTruncationNote(out, haTracesTruncationNote)
+	return toIndentedJSONWithTruncationNote(out, haTracesSummaryTruncationNote)
 }
 
 func haTraceRunSummaryView(run homeassistant.AutomationTraceSummary, now time.Time) haTraceRunView {
@@ -226,5 +227,5 @@ func haTraceDetailView(resolved resolvedAutomation, detail *homeassistant.Automa
 		Note:       haTraceVariablesOmittedNote,
 		Steps:      steps,
 	}
-	return toIndentedJSONWithTruncationNote(out, haTracesTruncationNote)
+	return toIndentedJSONWithTruncationNote(out, haTracesDetailTruncationNote)
 }

--- a/internal/tools/ha_automation_traces_test.go
+++ b/internal/tools/ha_automation_traces_test.go
@@ -1,0 +1,192 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/nugget/thane-ai-agent/internal/integrations/homeassistant"
+)
+
+// traceAutomationState seeds one automation entity so resolveAutomation
+// can map entity_id → config id.
+func traceAutomationState() homeassistant.State {
+	return homeassistant.State{
+		EntityID: "automation.office_lights",
+		State:    "on",
+		Attributes: map[string]any{
+			"friendly_name": "Office lights",
+			"id":            "auto-42",
+		},
+	}
+}
+
+func traceFixtureRuns(now time.Time) []map[string]any {
+	ts := func(t time.Time) string { return t.UTC().Format(time.RFC3339Nano) }
+	return []map[string]any{
+		{
+			"run_id":           "run-old",
+			"state":            "stopped",
+			"script_execution": "finished",
+			"timestamp":        map[string]any{"start": ts(now.Add(-2 * time.Hour)), "finish": ts(now.Add(-2*time.Hour + 3*time.Second))},
+			"trigger":          "state of binary_sensor.office_motion",
+			"last_step":        "action/0",
+		},
+		{
+			"run_id":           "run-new",
+			"state":            "stopped",
+			"script_execution": "failed_conditions",
+			"timestamp":        map[string]any{"start": ts(now.Add(-5 * time.Minute)), "finish": ts(now.Add(-5*time.Minute + 40*time.Millisecond))},
+			"trigger":          "time pattern",
+			"last_step":        "condition/0",
+		},
+	}
+}
+
+func TestHAAutomationTraces_SummaryNewestFirst(t *testing.T) {
+	fake := newFakeHAServer(t)
+	fake.states = []homeassistant.State{traceAutomationState()}
+	fake.configs["auto-42"] = map[string]any{"alias": "Office lights"}
+	now := time.Now()
+	fake.traces = map[string][]map[string]any{"auto-42": traceFixtureRuns(now)}
+	reg := fake.registry(t)
+
+	raw, err := reg.Execute(context.Background(), "ha_automation_traces", `{"entity_id":"automation.office_lights"}`)
+	if err != nil {
+		t.Fatalf("ha_automation_traces: %v", err)
+	}
+	var out haTraceRunsResult
+	if err := json.Unmarshal([]byte(raw), &out); err != nil {
+		t.Fatalf("unmarshal: %v\n%s", err, raw)
+	}
+	if out.Automation != "automation.office_lights" || out.ID != "auto-42" {
+		t.Fatalf("identity = %q/%q, want automation.office_lights/auto-42", out.Automation, out.ID)
+	}
+	if out.Count != 2 || len(out.Runs) != 2 {
+		t.Fatalf("count = %d/%d runs, want 2", out.Count, len(out.Runs))
+	}
+	if out.Runs[0].RunID != "run-new" || out.Runs[1].RunID != "run-old" {
+		t.Errorf("order = %q,%q, want newest first (run-new, run-old)", out.Runs[0].RunID, out.Runs[1].RunID)
+	}
+	if out.Runs[0].Execution != "failed_conditions" || out.Runs[0].TriggeredBy != "time pattern" {
+		t.Errorf("run view lost outcome/trigger: %+v", out.Runs[0])
+	}
+	if out.Runs[1].DurationMS != 3000 {
+		t.Errorf("duration_ms = %d, want 3000", out.Runs[1].DurationMS)
+	}
+	if out.Runs[0].Started == "" || out.Runs[0].Started[0] != '-' {
+		t.Errorf("started should be a past delta, got %q", out.Runs[0].Started)
+	}
+}
+
+func TestHAAutomationTraces_LimitAndTruncation(t *testing.T) {
+	fake := newFakeHAServer(t)
+	fake.states = []homeassistant.State{traceAutomationState()}
+	fake.configs["auto-42"] = map[string]any{"alias": "Office lights"}
+	fake.traces = map[string][]map[string]any{"auto-42": traceFixtureRuns(time.Now())}
+	reg := fake.registry(t)
+
+	raw, err := reg.Execute(context.Background(), "ha_automation_traces", `{"entity_id":"automation.office_lights","limit":1}`)
+	if err != nil {
+		t.Fatalf("limited: %v", err)
+	}
+	var out haTraceRunsResult
+	if err := json.Unmarshal([]byte(raw), &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if out.Count != 1 || !out.Truncated {
+		t.Errorf("count/truncated = %d/%v, want 1/true", out.Count, out.Truncated)
+	}
+}
+
+func TestHAAutomationTraces_DetailStepsInExecutionOrder(t *testing.T) {
+	fake := newFakeHAServer(t)
+	fake.states = []homeassistant.State{traceAutomationState()}
+	fake.configs["auto-42"] = map[string]any{"alias": "Office lights"}
+	now := time.Now()
+	ts := func(t time.Time) string { return t.UTC().Format(time.RFC3339Nano) }
+	start := now.Add(-10 * time.Minute)
+	fake.traces = map[string][]map[string]any{"auto-42": traceFixtureRuns(now)}
+	fake.traceDetails = map[string]map[string]any{
+		"run-new": {
+			"run_id":           "run-new",
+			"state":            "stopped",
+			"script_execution": "finished",
+			"timestamp":        map[string]any{"start": ts(start), "finish": ts(start.Add(2 * time.Second))},
+			"trigger":          "time pattern",
+			"last_step":        "action/1",
+			"trace": map[string]any{
+				// Deliberately listed with the LATER path first: order
+				// must come from timestamps, not map or path order.
+				"action/1": []map[string]any{
+					{"path": "action/1", "timestamp": ts(start.Add(2 * time.Second)), "error": "service unavailable"},
+				},
+				"trigger/0": []map[string]any{
+					{"path": "trigger/0", "timestamp": ts(start)},
+				},
+				"condition/0": []map[string]any{
+					{"path": "condition/0", "timestamp": ts(start.Add(time.Second)), "result": map[string]any{"result": true}},
+				},
+			},
+		},
+	}
+	reg := fake.registry(t)
+
+	raw, err := reg.Execute(context.Background(), "ha_automation_traces", `{"entity_id":"automation.office_lights","run_id":"run-new"}`)
+	if err != nil {
+		t.Fatalf("detail: %v", err)
+	}
+	var out haTraceDetailResult
+	if err := json.Unmarshal([]byte(raw), &out); err != nil {
+		t.Fatalf("unmarshal: %v\n%s", err, raw)
+	}
+	if out.StepCount != 3 || len(out.Steps) != 3 {
+		t.Fatalf("step count = %d/%d, want 3", out.StepCount, len(out.Steps))
+	}
+	wantOrder := []string{"trigger/0", "condition/0", "action/1"}
+	for i, want := range wantOrder {
+		if out.Steps[i].Path != want {
+			t.Fatalf("steps[%d] = %q, want %q (execution order by timestamp)", i, out.Steps[i].Path, want)
+		}
+	}
+	if out.Steps[1].Result == nil {
+		t.Error("condition step lost its result")
+	}
+	if out.Steps[2].Error != "service unavailable" {
+		t.Errorf("action step error = %q, want surfaced", out.Steps[2].Error)
+	}
+	if out.Note == "" {
+		t.Error("detail must carry the variables-omitted note")
+	}
+}
+
+func TestHAAutomationTraces_Errors(t *testing.T) {
+	fake := newFakeHAServer(t)
+	fake.states = []homeassistant.State{traceAutomationState()}
+	fake.configs["auto-42"] = map[string]any{"alias": "Office lights"}
+	fake.traces = map[string][]map[string]any{"auto-42": {}}
+	reg := fake.registry(t)
+
+	// Unknown run_id: the fake returns no result → tool error teaches
+	// where run_ids come from.
+	if _, err := reg.Execute(context.Background(), "ha_automation_traces", `{"entity_id":"automation.office_lights","run_id":"nope"}`); err == nil {
+		t.Error("unknown run_id: expected error")
+	}
+	// No automation reference at all.
+	if _, err := reg.Execute(context.Background(), "ha_automation_traces", `{}`); err == nil {
+		t.Error("missing id/entity_id: expected error")
+	}
+	// Empty trace list is a valid, non-error result with the teaching note.
+	raw, err := reg.Execute(context.Background(), "ha_automation_traces", `{"entity_id":"automation.office_lights"}`)
+	if err != nil {
+		t.Fatalf("empty list should not error: %v", err)
+	}
+	var out haTraceRunsResult
+	if err := json.Unmarshal([]byte(raw), &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if out.Count != 0 || out.Note == "" {
+		t.Errorf("empty list should carry the no-stored-runs note: %+v", out)
+	}
+}

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -123,6 +123,7 @@ func NewRegistry(ha *homeassistant.Client, sched *scheduler.Scheduler) *Registry
 	r.registerHASearchStates() // Predicate search across live state
 	r.registerHAListServices() // Service-catalog discovery (#1177)
 	r.registerHAAutomationTools()
+	r.registerHAAutomationTraces() // Run-level debugging (#1178)
 	return r
 }
 

--- a/talents/ha.md
+++ b/talents/ha.md
@@ -419,6 +419,19 @@ labels, aliases, icon). Read this before updating — config updates
 are merged shallowly, so you want to know what's there before
 modifying.
 
+## Debug a run: ha_automation_traces
+
+When an automation misfires — or right after you create or update one —
+`ha_automation_traces` shows what actually happened. Bare (with `id` or
+`entity_id`): recent runs newest-first, each with what triggered it,
+how it ended (`finished`, `failed_conditions`, `error`), duration, and
+any error. Pass a `run_id` from that listing for the full step-by-step
+trace in execution order — which trigger fired, each condition's
+result, what every action did. HA keeps traces only for a handful of
+recent runs, so an empty list usually means "hasn't fired lately," not
+"broken." Activity counts from `ha_automation_list` tell you *whether*
+it fires; traces tell you *why it did what it did*.
+
 ## Author a new automation
 
 `ha_automation_create` takes a full HA automation object:


### PR DESCRIPTION
## Summary

Closes #1178, the second pull from the #1175 HA overhaul umbrella. Stacked on #1187's branch (GitHub retargets to main when it merges).

The native automation family could create, list, inspect, update, and delete — but not *debug*. When an automation misfires, the answer lives in HA's traces: the step-by-step record of a run. The only path to them was the `ha-mcp` bridge's `ha_get_automation_traces`, which held the most valuable half of the authoring loop — create → run → *inspect why* — hostage to the server this milestone removes. This matters doubly now: a model authoring 2026.7 intent-based automations (#1176) needs to verify they behave as intended, and traces are how.

## The tool

`ha_automation_traces` takes the family's standard `id`/`entity_id` addressing (reusing `resolveAutomation`) with two shapes:

- **Summary** (no `run_id`): recent runs newest-first — when it ran (delta), what triggered it (HA's human-readable trigger description), how it ended (`finished` / `failed_conditions` / `error`…), duration, last step reached, and any error. An empty list carries a teaching note: HA keeps traces only for recent runs, so empty usually means "hasn't fired lately," not "broken."
- **Detail** (`run_id` from the summary): the full step tree flattened into execution order — which trigger fired, each condition's result, what every action did, per-step errors surfaced.

Two projection decisions worth review attention. **Execution order comes from step timestamps**, not the path-keyed map order HA returns (a first draft sorted the projected delta *strings*, which don't compare temporally — caught before commit, the sort now happens on real instants with path as the determinism tiebreak). **`changed_variables` is deliberately omitted** — it's the bulkiest part of a trace and rarely worth model tokens; the detail shape says so explicitly in its `note` so the omission is never silent.

## Plumbing

Client + WSClient methods for `trace/list` / `trace/get` with typed `AutomationTraceSummary`/`TraceStep`/`AutomationTraceDetail` projections; registration gates on `r.ha == nil || !r.ha.HasWSClient()` like the rest of the automation family; catalogued under `ha` (the #1150 CI gate); the fake HA server grows `trace/list`/`trace/get` WS routes; and `talents/ha.md`'s Automate section gains a "Debug a run" recipe distinguishing *whether it fires* (`ha_automation_list` activity counts) from *why it did what it did* (traces).

## Test plan

- [x] Summary: newest-first ordering, trigger/outcome/duration preserved, delta `started`
- [x] Limit + explicit truncation flag
- [x] Detail: steps in execution order by timestamp (fixture deliberately map-ordered against it), condition results and action errors surfaced, variables-omitted note present
- [x] Errors: unknown `run_id` teaches where run_ids come from; missing addressing errors; empty trace list is a valid teaching result, not an error
- [x] `just ci` green locally (unpiped, verified)

Refs #1175. Second native displacement of the ha-mcp allowlist (#1180 tracks the unplug).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
