### PR TITLE
feat(ha): target blocks on ha_call_service — one-call fan-out with visible results

### DIFF
--- a/internal/integrations/homeassistant/client.go
+++ b/internal/integrations/homeassistant/client.go
@@ -317,6 +317,19 @@ func (c *Client) CallService(ctx context.Context, domain, service string, data m
 	return c.post(ctx, path, data, nil)
 }
 
+// CallServiceWithResponse invokes a service and returns the states HA
+// reports as changed by the call. For target-addressed calls (area,
+// floor, label, device) this is the caller's only direct evidence of
+// fan-out — which entities the call actually touched.
+func (c *Client) CallServiceWithResponse(ctx context.Context, domain, service string, data map[string]any) ([]State, error) {
+	var changed []State
+	path := fmt.Sprintf("/api/services/%s/%s", domain, service)
+	if err := c.post(ctx, path, data, &changed); err != nil {
+		return nil, err
+	}
+	return changed, nil
+}
+
 // Area represents a Home Assistant area.
 type Area struct {
 	AreaID              string   `json:"area_id"`

--- a/internal/tools/ha_automation_tools_test.go
+++ b/internal/tools/ha_automation_tools_test.go
@@ -19,23 +19,25 @@ type fakeHAServer struct {
 	server   *httptest.Server
 	upgrader websocket.Upgrader
 
-	mu           sync.Mutex
-	states       []homeassistant.State
-	services     []homeassistant.ServiceDomain
-	traces       map[string][]map[string]any
-	traceDetails map[string]map[string]any
-	configs      map[string]map[string]any
-	areas        []map[string]any
-	floors       []map[string]any
-	labels       []map[string]any
-	categories   map[string][]map[string]any
-	devices      []map[string]any
-	entityRows   []map[string]any
-	entityByID   map[string]map[string]any
-	logbook      []map[string]any
-	serviceCalls []string
-	validations  map[string]homeassistant.ConfigValidationResult
-	wsCalls      map[string]int
+	mu              sync.Mutex
+	states          []homeassistant.State
+	services        []homeassistant.ServiceDomain
+	traces          map[string][]map[string]any
+	traceDetails    map[string]map[string]any
+	servicePayloads []map[string]any
+	serviceChanged  []homeassistant.State
+	configs         map[string]map[string]any
+	areas           []map[string]any
+	floors          []map[string]any
+	labels          []map[string]any
+	categories      map[string][]map[string]any
+	devices         []map[string]any
+	entityRows      []map[string]any
+	entityByID      map[string]map[string]any
+	logbook         []map[string]any
+	serviceCalls    []string
+	validations     map[string]homeassistant.ConfigValidationResult
+	wsCalls         map[string]int
 }
 
 func newFakeHAServer(t *testing.T) *fakeHAServer {
@@ -163,6 +165,7 @@ func (f *fakeHAServer) handleServiceCall(w http.ResponseWriter, r *http.Request)
 	defer f.mu.Unlock()
 
 	f.serviceCalls = append(f.serviceCalls, strings.TrimPrefix(r.URL.Path, "/api/services/"))
+	f.servicePayloads = append(f.servicePayloads, payload)
 	entityID, _ := payload["entity_id"].(string)
 	switch {
 	case strings.HasSuffix(r.URL.Path, "/turn_off"):
@@ -171,8 +174,17 @@ func (f *fakeHAServer) handleServiceCall(w http.ResponseWriter, r *http.Request)
 		f.setAutomationStateLocked(entityID, "on")
 	}
 
+	// Real HA answers a service call with the array of states the call
+	// changed; tests seed serviceChanged to simulate fan-out.
+	changed := f.serviceChanged
+	if changed == nil {
+		changed = []homeassistant.State{}
+		if entityID != "" {
+			changed = append(changed, homeassistant.State{EntityID: entityID, State: "on"})
+		}
+	}
 	w.WriteHeader(http.StatusOK)
-	writeJSON(f.t, w, map[string]any{"result": "ok"})
+	writeJSON(f.t, w, changed)
 }
 
 func (f *fakeHAServer) handleWebSocket(w http.ResponseWriter, r *http.Request) {

--- a/internal/tools/ha_call_service_target.go
+++ b/internal/tools/ha_call_service_target.go
@@ -34,21 +34,34 @@ type haCallServiceResult struct {
 // the order the resolver processes them.
 var haTargetKeys = []string{"entity_id", "device_id", "area_id", "floor_id", "label_id"}
 
+// targetResolution is resolveServiceTarget's outcome. When Suggestion
+// is non-empty the resolution stopped on an unknown target entity and
+// Suggestion carries the same recoverable did-you-mean envelope the
+// single-entity path returns — the handler returns it as the tool
+// result (not an error), keeping typo recovery consistent across both
+// addressing forms.
+type targetResolution struct {
+	Resolved   map[string]any
+	Suggestion string
+}
+
 // resolveServiceTarget validates and resolves a target block. IDs pass
-// through; for areas, floors, labels, and devices a human name (or area
-// alias) resolves to its ID case-insensitively, because the model often
-// holds the name ("Office") before the ID ("office"). Unknown
-// references fail fast with the known names — HA itself silently
-// no-ops an unknown area_id, which is the phantom-success failure mode
-// this tool exists to prevent.
-func (r *Registry) resolveServiceTarget(ctx context.Context, raw map[string]any) (map[string]any, error) {
-	resolved := make(map[string]any, len(raw))
+// through; for areas, floors, labels, and devices a human name (or
+// area/floor alias) resolves to its ID case-insensitively, because the
+// model often holds the name ("Office") before the ID ("office").
+// Unknown references fail fast with the known names — HA itself
+// silently no-ops an unknown area_id, which is the phantom-success
+// failure mode this tool exists to prevent. Each registry is fetched
+// once per call (and served from the client's TTL cache besides), no
+// matter how many values a key carries.
+func (r *Registry) resolveServiceTarget(ctx context.Context, raw map[string]any) (targetResolution, error) {
 	for key := range raw {
 		if !slicesContains(haTargetKeys, key) {
-			return nil, fmt.Errorf("unknown target key %q; valid keys: %s", key, strings.Join(haTargetKeys, ", "))
+			return targetResolution{}, fmt.Errorf("unknown target key %q; valid keys: %s", key, strings.Join(haTargetKeys, ", "))
 		}
 	}
 
+	resolved := make(map[string]any, len(raw))
 	for _, key := range haTargetKeys {
 		rawVal, ok := raw[key]
 		if !ok {
@@ -56,19 +69,34 @@ func (r *Registry) resolveServiceTarget(ctx context.Context, raw map[string]any)
 		}
 		values, err := stringOrList(rawVal)
 		if err != nil {
-			return nil, fmt.Errorf("target.%s: %w", key, err)
+			return targetResolution{}, fmt.Errorf("target.%s: %w", key, err)
 		}
 		if len(values) == 0 {
 			continue
 		}
-		out := make([]string, 0, len(values))
-		for _, v := range values {
-			id, err := r.resolveTargetValue(ctx, key, v)
-			if err != nil {
-				return nil, err
+
+		var out []string
+		switch key {
+		case "entity_id":
+			for _, v := range values {
+				// Same phantom-success guard as the single-entity
+				// path, with the same recoverable outcome: HA accepts
+				// unknown entity ids and silently no-ops.
+				if _, err := r.ha.GetState(ctx, v); err != nil {
+					if IsHAEntityNotFound(err) {
+						return targetResolution{Suggestion: SuggestEntityNotFound(ctx, r.ha, v)}, nil
+					}
+					return targetResolution{}, fmt.Errorf("verify target entity %q: %w", v, err)
+				}
+				out = append(out, v)
 			}
-			out = append(out, id)
+		default:
+			out, err = r.resolveRegistryTargets(ctx, key, values)
+			if err != nil {
+				return targetResolution{}, err
+			}
 		}
+
 		if len(out) == 1 {
 			resolved[key] = out[0]
 		} else {
@@ -76,111 +104,105 @@ func (r *Registry) resolveServiceTarget(ctx context.Context, raw map[string]any)
 		}
 	}
 	if len(resolved) == 0 {
-		return nil, fmt.Errorf("target must set at least one of: %s", strings.Join(haTargetKeys, ", "))
+		return targetResolution{}, fmt.Errorf("target must set at least one of: %s", strings.Join(haTargetKeys, ", "))
 	}
-	return resolved, nil
+	return targetResolution{Resolved: resolved}, nil
 }
 
-func (r *Registry) resolveTargetValue(ctx context.Context, key, value string) (string, error) {
-	switch key {
-	case "entity_id":
-		// Same phantom-success guard as the single-entity path: HA
-		// accepts unknown entity ids and silently no-ops.
-		if _, err := r.ha.GetState(ctx, value); err != nil {
-			if IsHAEntityNotFound(err) {
-				return "", fmt.Errorf("target entity %q not found: %s", value, SuggestEntityNotFound(ctx, r.ha, value))
-			}
-			return "", fmt.Errorf("verify target entity %q: %w", value, err)
+// registryTargetEntry is one resolvable row of a registry: its ID plus
+// the names and aliases a caller may reference it by.
+type registryTargetEntry struct {
+	id      string
+	matches []string
+}
+
+// resolveRegistryTargets resolves every value for one registry-backed
+// target key against a single registry fetch.
+func (r *Registry) resolveRegistryTargets(ctx context.Context, key string, values []string) ([]string, error) {
+	entries, kind, err := r.registryTargetEntries(ctx, key)
+	if err != nil {
+		return nil, fmt.Errorf("resolve %s %q: %w", kind, values[0], err)
+	}
+
+	names := make([]string, 0, len(entries))
+	for _, e := range entries {
+		if len(e.matches) > 0 {
+			names = append(names, e.matches[0])
 		}
-		return value, nil
+	}
+
+	out := make([]string, 0, len(values))
+	for _, v := range values {
+		id, ok := matchRegistryTarget(entries, v)
+		if !ok {
+			return nil, fmt.Errorf("unknown %s %q; known %ss: %s", kind, v, kind, joinCapped(names, 15))
+		}
+		out = append(out, id)
+	}
+	return out, nil
+}
+
+func matchRegistryTarget(entries []registryTargetEntry, value string) (string, bool) {
+	for _, e := range entries {
+		if e.id == value {
+			return e.id, true
+		}
+	}
+	lower := strings.ToLower(value)
+	for _, e := range entries {
+		for _, m := range e.matches {
+			if strings.ToLower(m) == lower {
+				return e.id, true
+			}
+		}
+	}
+	return "", false
+}
+
+func (r *Registry) registryTargetEntries(ctx context.Context, key string) ([]registryTargetEntry, string, error) {
+	switch key {
 	case "area_id":
 		areas, err := r.ha.GetAreas(ctx)
 		if err != nil {
-			return "", fmt.Errorf("resolve area %q: %w", value, err)
+			return nil, "area", err
 		}
-		names := make([]string, 0, len(areas))
+		entries := make([]registryTargetEntry, 0, len(areas))
 		for _, a := range areas {
-			if a.AreaID == value {
-				return value, nil
-			}
-			names = append(names, a.Name)
+			entries = append(entries, registryTargetEntry{id: a.AreaID, matches: append([]string{a.Name}, a.Aliases...)})
 		}
-		lower := strings.ToLower(value)
-		for _, a := range areas {
-			if strings.ToLower(a.Name) == lower {
-				return a.AreaID, nil
-			}
-			for _, alias := range a.Aliases {
-				if strings.ToLower(alias) == lower {
-					return a.AreaID, nil
-				}
-			}
-		}
-		return "", fmt.Errorf("unknown area %q; known areas: %s", value, joinCapped(names, 15))
+		return entries, "area", nil
 	case "floor_id":
 		floors, err := r.ha.GetFloorRegistry(ctx)
 		if err != nil {
-			return "", fmt.Errorf("resolve floor %q: %w", value, err)
+			return nil, "floor", err
 		}
-		names := make([]string, 0, len(floors))
+		entries := make([]registryTargetEntry, 0, len(floors))
 		for _, f := range floors {
-			if f.FloorID == value {
-				return value, nil
-			}
-			names = append(names, f.Name)
+			entries = append(entries, registryTargetEntry{id: f.FloorID, matches: append([]string{f.Name}, f.Aliases...)})
 		}
-		lower := strings.ToLower(value)
-		for _, f := range floors {
-			if strings.ToLower(f.Name) == lower {
-				return f.FloorID, nil
-			}
-			for _, alias := range f.Aliases {
-				if strings.ToLower(alias) == lower {
-					return f.FloorID, nil
-				}
-			}
-		}
-		return "", fmt.Errorf("unknown floor %q; known floors: %s", value, joinCapped(names, 15))
+		return entries, "floor", nil
 	case "label_id":
 		labels, err := r.ha.GetLabelRegistry(ctx)
 		if err != nil {
-			return "", fmt.Errorf("resolve label %q: %w", value, err)
+			return nil, "label", err
 		}
-		names := make([]string, 0, len(labels))
+		entries := make([]registryTargetEntry, 0, len(labels))
 		for _, l := range labels {
-			if l.LabelID == value {
-				return value, nil
-			}
-			names = append(names, l.Name)
+			entries = append(entries, registryTargetEntry{id: l.LabelID, matches: []string{l.Name}})
 		}
-		lower := strings.ToLower(value)
-		for _, l := range labels {
-			if strings.ToLower(l.Name) == lower {
-				return l.LabelID, nil
-			}
-		}
-		return "", fmt.Errorf("unknown label %q; known labels: %s", value, joinCapped(names, 15))
+		return entries, "label", nil
 	case "device_id":
 		devices, err := r.ha.GetDeviceRegistry(ctx)
 		if err != nil {
-			return "", fmt.Errorf("resolve device %q: %w", value, err)
+			return nil, "device", err
 		}
-		names := make([]string, 0, len(devices))
+		entries := make([]registryTargetEntry, 0, len(devices))
 		for _, d := range devices {
-			if d.ID == value {
-				return value, nil
-			}
-			names = append(names, string(d.Name))
+			entries = append(entries, registryTargetEntry{id: d.ID, matches: []string{string(d.Name)}})
 		}
-		lower := strings.ToLower(value)
-		for _, d := range devices {
-			if strings.ToLower(string(d.Name)) == lower {
-				return d.ID, nil
-			}
-		}
-		return "", fmt.Errorf("unknown device %q; known devices: %s", value, joinCapped(names, 15))
+		return entries, "device", nil
 	}
-	return value, nil
+	return nil, key, fmt.Errorf("unsupported registry target key %q", key)
 }
 
 func haCallServiceResponse(domain, service, entityID string, target map[string]any, changed []homeassistant.State) string {

--- a/internal/tools/ha_call_service_target.go
+++ b/internal/tools/ha_call_service_target.go
@@ -1,0 +1,253 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/nugget/thane-ai-agent/internal/integrations/homeassistant"
+)
+
+const haCallServiceTruncationNote = "Result exceeded the tool byte cap; the call succeeded — changed-entity listing was clipped."
+
+// maxHACallServiceChangedIDs bounds the changed-entity listing in the
+// call response; the count is always exact even when the list is capped.
+const maxHACallServiceChangedIDs = 20
+
+// haCallServiceResult reports what a service call did: the resolved
+// addressing it ran with and the states HA says changed. A zero
+// changed_count on a target call is not an error — entities may already
+// be in the requested state — but it is the signal to look, so the note
+// says exactly that.
+type haCallServiceResult struct {
+	Called       string         `json:"called"`
+	EntityID     string         `json:"entity_id,omitempty"`
+	Target       map[string]any `json:"target,omitempty"`
+	ChangedCount int            `json:"changed_count"`
+	Changed      []string       `json:"changed,omitempty"`
+	Truncated    bool           `json:"truncated,omitempty"`
+	Note         string         `json:"note,omitempty"`
+}
+
+// haTargetKeys are the service-call target selectors HA accepts, in
+// the order the resolver processes them.
+var haTargetKeys = []string{"entity_id", "device_id", "area_id", "floor_id", "label_id"}
+
+// resolveServiceTarget validates and resolves a target block. IDs pass
+// through; for areas, floors, labels, and devices a human name (or area
+// alias) resolves to its ID case-insensitively, because the model often
+// holds the name ("Office") before the ID ("office"). Unknown
+// references fail fast with the known names — HA itself silently
+// no-ops an unknown area_id, which is the phantom-success failure mode
+// this tool exists to prevent.
+func (r *Registry) resolveServiceTarget(ctx context.Context, raw map[string]any) (map[string]any, error) {
+	resolved := make(map[string]any, len(raw))
+	for key := range raw {
+		if !slicesContains(haTargetKeys, key) {
+			return nil, fmt.Errorf("unknown target key %q; valid keys: %s", key, strings.Join(haTargetKeys, ", "))
+		}
+	}
+
+	for _, key := range haTargetKeys {
+		rawVal, ok := raw[key]
+		if !ok {
+			continue
+		}
+		values, err := stringOrList(rawVal)
+		if err != nil {
+			return nil, fmt.Errorf("target.%s: %w", key, err)
+		}
+		if len(values) == 0 {
+			continue
+		}
+		out := make([]string, 0, len(values))
+		for _, v := range values {
+			id, err := r.resolveTargetValue(ctx, key, v)
+			if err != nil {
+				return nil, err
+			}
+			out = append(out, id)
+		}
+		if len(out) == 1 {
+			resolved[key] = out[0]
+		} else {
+			resolved[key] = out
+		}
+	}
+	if len(resolved) == 0 {
+		return nil, fmt.Errorf("target must set at least one of: %s", strings.Join(haTargetKeys, ", "))
+	}
+	return resolved, nil
+}
+
+func (r *Registry) resolveTargetValue(ctx context.Context, key, value string) (string, error) {
+	switch key {
+	case "entity_id":
+		// Same phantom-success guard as the single-entity path: HA
+		// accepts unknown entity ids and silently no-ops.
+		if _, err := r.ha.GetState(ctx, value); err != nil {
+			if IsHAEntityNotFound(err) {
+				return "", fmt.Errorf("target entity %q not found: %s", value, SuggestEntityNotFound(ctx, r.ha, value))
+			}
+			return "", fmt.Errorf("verify target entity %q: %w", value, err)
+		}
+		return value, nil
+	case "area_id":
+		areas, err := r.ha.GetAreas(ctx)
+		if err != nil {
+			return "", fmt.Errorf("resolve area %q: %w", value, err)
+		}
+		names := make([]string, 0, len(areas))
+		for _, a := range areas {
+			if a.AreaID == value {
+				return value, nil
+			}
+			names = append(names, a.Name)
+		}
+		lower := strings.ToLower(value)
+		for _, a := range areas {
+			if strings.ToLower(a.Name) == lower {
+				return a.AreaID, nil
+			}
+			for _, alias := range a.Aliases {
+				if strings.ToLower(alias) == lower {
+					return a.AreaID, nil
+				}
+			}
+		}
+		return "", fmt.Errorf("unknown area %q; known areas: %s", value, joinCapped(names, 15))
+	case "floor_id":
+		floors, err := r.ha.GetFloorRegistry(ctx)
+		if err != nil {
+			return "", fmt.Errorf("resolve floor %q: %w", value, err)
+		}
+		names := make([]string, 0, len(floors))
+		for _, f := range floors {
+			if f.FloorID == value {
+				return value, nil
+			}
+			names = append(names, f.Name)
+		}
+		lower := strings.ToLower(value)
+		for _, f := range floors {
+			if strings.ToLower(f.Name) == lower {
+				return f.FloorID, nil
+			}
+			for _, alias := range f.Aliases {
+				if strings.ToLower(alias) == lower {
+					return f.FloorID, nil
+				}
+			}
+		}
+		return "", fmt.Errorf("unknown floor %q; known floors: %s", value, joinCapped(names, 15))
+	case "label_id":
+		labels, err := r.ha.GetLabelRegistry(ctx)
+		if err != nil {
+			return "", fmt.Errorf("resolve label %q: %w", value, err)
+		}
+		names := make([]string, 0, len(labels))
+		for _, l := range labels {
+			if l.LabelID == value {
+				return value, nil
+			}
+			names = append(names, l.Name)
+		}
+		lower := strings.ToLower(value)
+		for _, l := range labels {
+			if strings.ToLower(l.Name) == lower {
+				return l.LabelID, nil
+			}
+		}
+		return "", fmt.Errorf("unknown label %q; known labels: %s", value, joinCapped(names, 15))
+	case "device_id":
+		devices, err := r.ha.GetDeviceRegistry(ctx)
+		if err != nil {
+			return "", fmt.Errorf("resolve device %q: %w", value, err)
+		}
+		names := make([]string, 0, len(devices))
+		for _, d := range devices {
+			if d.ID == value {
+				return value, nil
+			}
+			names = append(names, string(d.Name))
+		}
+		lower := strings.ToLower(value)
+		for _, d := range devices {
+			if strings.ToLower(string(d.Name)) == lower {
+				return d.ID, nil
+			}
+		}
+		return "", fmt.Errorf("unknown device %q; known devices: %s", value, joinCapped(names, 15))
+	}
+	return value, nil
+}
+
+func haCallServiceResponse(domain, service, entityID string, target map[string]any, changed []homeassistant.State) string {
+	ids := make([]string, 0, len(changed))
+	for _, st := range changed {
+		ids = append(ids, st.EntityID)
+	}
+	sort.Strings(ids)
+	out := haCallServiceResult{
+		Called:       domain + "." + service,
+		EntityID:     entityID,
+		Target:       target,
+		ChangedCount: len(ids),
+	}
+	if len(ids) > maxHACallServiceChangedIDs {
+		out.Changed = ids[:maxHACallServiceChangedIDs]
+		out.Truncated = true
+	} else {
+		out.Changed = ids
+	}
+	if len(ids) == 0 {
+		if target != nil {
+			out.Note = "HA reports no state changes. Entities may already be in the requested state — or the target matched nothing (hidden entities are skipped in area/floor/label targets)."
+		} else {
+			out.Note = "HA reports no state changes; the entity may already be in the requested state."
+		}
+	}
+	return toIndentedJSONWithTruncationNote(out, haCallServiceTruncationNote)
+}
+
+func stringOrList(v any) ([]string, error) {
+	switch t := v.(type) {
+	case string:
+		if strings.TrimSpace(t) == "" {
+			return nil, nil
+		}
+		return []string{strings.TrimSpace(t)}, nil
+	case []any:
+		out := make([]string, 0, len(t))
+		for _, item := range t {
+			s, ok := item.(string)
+			if !ok {
+				return nil, fmt.Errorf("expected strings, got %T", item)
+			}
+			if strings.TrimSpace(s) != "" {
+				out = append(out, strings.TrimSpace(s))
+			}
+		}
+		return out, nil
+	default:
+		return nil, fmt.Errorf("expected a string or array of strings, got %T", v)
+	}
+}
+
+func joinCapped(names []string, limit int) string {
+	sort.Strings(names)
+	if len(names) > limit {
+		return strings.Join(names[:limit], ", ") + fmt.Sprintf(", … (%d total)", len(names))
+	}
+	return strings.Join(names, ", ")
+}
+
+func slicesContains(list []string, v string) bool {
+	for _, item := range list {
+		if item == v {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/tools/ha_call_service_target_test.go
+++ b/internal/tools/ha_call_service_target_test.go
@@ -145,3 +145,64 @@ func containsAll(s string, subs ...string) bool {
 	}
 	return true
 }
+
+func TestHACallService_DataCannotOverrideAddressing(t *testing.T) {
+	// data.entity_id would silently clobber the verified addressing and
+	// desync the reported result from the wire (PR #1189 review).
+	fake := targetTestServer(t)
+	reg := fake.registry(t)
+
+	_, err := reg.Execute(context.Background(), "ha_call_service",
+		`{"domain":"light","service":"turn_on","entity_id":"light.office_main","data":{"entity_id":"light.nonexistent","brightness_pct":50}}`)
+	if err == nil {
+		t.Fatal("addressing keys in data must be rejected")
+	}
+	if !strings.Contains(err.Error(), "data.entity_id is addressing") {
+		t.Errorf("error should teach where addressing belongs, got %q", err.Error())
+	}
+	if len(fake.servicePayloads) != 0 {
+		t.Errorf("no call may reach HA; got %v", fake.servicePayloads)
+	}
+}
+
+func TestHACallService_NonObjectTargetTeaches(t *testing.T) {
+	fake := targetTestServer(t)
+	reg := fake.registry(t)
+
+	_, err := reg.Execute(context.Background(), "ha_call_service",
+		`{"domain":"light","service":"turn_on","target":"office"}`)
+	if err == nil {
+		t.Fatal("string target must error, not fall through to the generic message")
+	}
+	if !strings.Contains(err.Error(), "target must be an object") {
+		t.Errorf("error should name the real problem, got %q", err.Error())
+	}
+}
+
+func TestHACallService_TargetEntityTypoIsRecoverable(t *testing.T) {
+	// Consistency with the single-entity path: an unknown target entity
+	// returns the did-you-mean envelope as a RESULT, not a tool error.
+	fake := targetTestServer(t)
+	reg := fake.registry(t)
+
+	out, err := reg.Execute(context.Background(), "ha_call_service",
+		`{"domain":"light","service":"turn_on","target":{"entity_id":"light.office_mian"}}`)
+	if err != nil {
+		t.Fatalf("typo'd target entity must be recoverable, got error: %v", err)
+	}
+	var envelope struct {
+		Found      bool `json:"found"`
+		Candidates []struct {
+			EntityID string `json:"entity_id"`
+		} `json:"candidates"`
+	}
+	if uerr := json.Unmarshal([]byte(out), &envelope); uerr != nil {
+		t.Fatalf("expected not-found envelope, got: %s", out)
+	}
+	if envelope.Found || len(envelope.Candidates) == 0 {
+		t.Errorf("envelope should carry did-you-mean candidates: %s", out)
+	}
+	if len(fake.servicePayloads) != 0 {
+		t.Errorf("no call may reach HA on a typo; got %v", fake.servicePayloads)
+	}
+}

--- a/internal/tools/ha_call_service_target_test.go
+++ b/internal/tools/ha_call_service_target_test.go
@@ -1,0 +1,147 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/nugget/thane-ai-agent/internal/integrations/homeassistant"
+)
+
+func targetTestServer(t *testing.T) *fakeHAServer {
+	t.Helper()
+	fake := newFakeHAServer(t)
+	fake.states = []homeassistant.State{
+		{EntityID: "light.office_main", State: "on", Attributes: map[string]any{"friendly_name": "Office Main"}},
+		{EntityID: "light.office_lamp", State: "on", Attributes: map[string]any{"friendly_name": "Office Lamp"}},
+	}
+	fake.areas = []map[string]any{
+		{"area_id": "office", "name": "Office", "aliases": []string{"study"}},
+		{"area_id": "garage", "name": "Garage"},
+	}
+	fake.labels = []map[string]any{
+		{"label_id": "critical_lights", "name": "Critical Lights"},
+	}
+	return fake
+}
+
+func decodeCallResult(t *testing.T, raw string) haCallServiceResult {
+	t.Helper()
+	var out haCallServiceResult
+	if err := json.Unmarshal([]byte(raw), &out); err != nil {
+		t.Fatalf("unmarshal call result: %v\n%s", err, raw)
+	}
+	return out
+}
+
+func TestHACallService_AreaTargetByNameResolvesAndFansOut(t *testing.T) {
+	fake := targetTestServer(t)
+	fake.serviceChanged = []homeassistant.State{
+		{EntityID: "light.office_main", State: "off"},
+		{EntityID: "light.office_lamp", State: "off"},
+	}
+	reg := fake.registry(t)
+
+	raw, err := reg.Execute(context.Background(), "ha_call_service", `{"domain":"light","service":"turn_off","target":{"area_id":"Office"}}`)
+	if err != nil {
+		t.Fatalf("area target: %v", err)
+	}
+	res := decodeCallResult(t, raw)
+	if res.Called != "light.turn_off" {
+		t.Errorf("called = %q", res.Called)
+	}
+	// The human name resolved to the registry id before the call.
+	if res.Target["area_id"] != "office" {
+		t.Errorf("target.area_id = %v, want resolved id \"office\"", res.Target["area_id"])
+	}
+	if res.ChangedCount != 2 || len(res.Changed) != 2 {
+		t.Errorf("changed = %d/%v, want the 2-entity fan-out visible", res.ChangedCount, res.Changed)
+	}
+	// The resolved id (not the name) is what went over the wire.
+	if len(fake.servicePayloads) != 1 || fake.servicePayloads[0]["area_id"] != "office" {
+		t.Errorf("wire payload = %v, want area_id \"office\"", fake.servicePayloads)
+	}
+}
+
+func TestHACallService_AreaAliasAndIDPassThrough(t *testing.T) {
+	fake := targetTestServer(t)
+	reg := fake.registry(t)
+
+	// Alias resolves.
+	raw, err := reg.Execute(context.Background(), "ha_call_service", `{"domain":"light","service":"turn_on","target":{"area_id":"study"}}`)
+	if err != nil {
+		t.Fatalf("alias target: %v", err)
+	}
+	if res := decodeCallResult(t, raw); res.Target["area_id"] != "office" {
+		t.Errorf("alias should resolve to office, got %v", res.Target["area_id"])
+	}
+	// Exact id passes through untouched.
+	raw, err = reg.Execute(context.Background(), "ha_call_service", `{"domain":"light","service":"turn_on","target":{"area_id":"garage"}}`)
+	if err != nil {
+		t.Fatalf("id target: %v", err)
+	}
+	if res := decodeCallResult(t, raw); res.Target["area_id"] != "garage" {
+		t.Errorf("id should pass through, got %v", res.Target["area_id"])
+	}
+}
+
+func TestHACallService_UnknownAreaFailsFastWithKnownNames(t *testing.T) {
+	fake := targetTestServer(t)
+	reg := fake.registry(t)
+
+	_, err := reg.Execute(context.Background(), "ha_call_service", `{"domain":"light","service":"turn_on","target":{"area_id":"Atrium"}}`)
+	if err == nil {
+		t.Fatal("unknown area must fail fast, not silently no-op")
+	}
+	if got := err.Error(); !containsAll(got, "Atrium", "Office", "Garage") {
+		t.Errorf("error should teach known areas, got %q", got)
+	}
+	if len(fake.servicePayloads) != 0 {
+		t.Errorf("no service call may reach HA on a failed resolution; got %v", fake.servicePayloads)
+	}
+}
+
+func TestHACallService_ArgumentValidation(t *testing.T) {
+	fake := targetTestServer(t)
+	reg := fake.registry(t)
+
+	cases := map[string]string{
+		"neither entity nor target": `{"domain":"light","service":"turn_on"}`,
+		"both entity and target":    `{"domain":"light","service":"turn_on","entity_id":"light.office_main","target":{"area_id":"office"}}`,
+		"unknown target key":        `{"domain":"light","service":"turn_on","target":{"room_id":"office"}}`,
+		"empty target":              `{"domain":"light","service":"turn_on","target":{}}`,
+	}
+	for name, args := range cases {
+		if _, err := reg.Execute(context.Background(), "ha_call_service", args); err == nil {
+			t.Errorf("%s: expected error", name)
+		}
+	}
+}
+
+func TestHACallService_ZeroChangesCarriesNote(t *testing.T) {
+	fake := targetTestServer(t)
+	fake.serviceChanged = []homeassistant.State{}
+	reg := fake.registry(t)
+
+	raw, err := reg.Execute(context.Background(), "ha_call_service", `{"domain":"light","service":"turn_on","target":{"label_id":"Critical Lights"}}`)
+	if err != nil {
+		t.Fatalf("label target: %v", err)
+	}
+	res := decodeCallResult(t, raw)
+	if res.Target["label_id"] != "critical_lights" {
+		t.Errorf("label name should resolve, got %v", res.Target["label_id"])
+	}
+	if res.ChangedCount != 0 || res.Note == "" {
+		t.Errorf("zero-change fan-out must carry the explanatory note: %+v", res)
+	}
+}
+
+func containsAll(s string, subs ...string) bool {
+	for _, sub := range subs {
+		if !strings.Contains(s, sub) {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/tools/ha_entity_suggest_handlers_test.go
+++ b/internal/tools/ha_entity_suggest_handlers_test.go
@@ -57,8 +57,12 @@ func TestHandleCallService_KnownEntityCalls(t *testing.T) {
 	if len(fake.serviceCalls) != 1 {
 		t.Errorf("expected exactly one forwarded service call, got %v", fake.serviceCalls)
 	}
-	if want := "Successfully called"; len(out) < len(want) || out[:len(want)] != want {
-		t.Errorf("expected success message, got %q", out)
+	var res haCallServiceResult
+	if err := json.Unmarshal([]byte(out), &res); err != nil {
+		t.Fatalf("unmarshal call result: %v\n%s", err, out)
+	}
+	if res.Called != "light.turn_on" || res.EntityID != "light.kitchen" {
+		t.Errorf("call result identity = %q/%q, want light.turn_on/light.kitchen", res.Called, res.EntityID)
 	}
 }
 

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -1421,7 +1421,18 @@ func (r *Registry) handleCallService(ctx context.Context, args map[string]any) (
 	domain, _ := args["domain"].(string)
 	service, _ := args["service"].(string)
 	entityID, _ := args["entity_id"].(string)
-	targetRaw, hasTarget := args["target"].(map[string]any)
+
+	// A present-but-malformed target must say so, not fall through to
+	// the generic "provide entity_id or target" error.
+	var targetRaw map[string]any
+	hasTarget := false
+	if rawTarget, present := args["target"]; present {
+		obj, ok := rawTarget.(map[string]any)
+		if !ok {
+			return "", fmt.Errorf("target must be an object like {\"area_id\": \"office\"}, got %T", rawTarget)
+		}
+		targetRaw, hasTarget = obj, true
+	}
 
 	if domain == "" || service == "" {
 		return "", fmt.Errorf("domain and service are required")
@@ -1434,6 +1445,20 @@ func (r *Registry) handleCallService(ctx context.Context, args map[string]any) (
 	}
 
 	data := map[string]any{}
+
+	// Merge service data FIRST, and refuse addressing keys inside it:
+	// data.entity_id would silently override the verified/resolved
+	// addressing below, reintroducing the phantom-success no-op and
+	// making the reported result disagree with what went to HA.
+	if extra, ok := args["data"].(map[string]any); ok {
+		for k, v := range extra {
+			if slicesContains(haTargetKeys, k) {
+				return "", fmt.Errorf("data.%s is addressing, not service data — use entity_id or target for addressing", k)
+			}
+			data[k] = v
+		}
+	}
+
 	var resolvedTarget map[string]any
 
 	if entityID != "" {
@@ -1449,19 +1474,15 @@ func (r *Registry) handleCallService(ctx context.Context, args map[string]any) (
 		}
 		data["entity_id"] = entityID
 	} else {
-		var err error
-		resolvedTarget, err = r.resolveServiceTarget(ctx, targetRaw)
+		resolution, err := r.resolveServiceTarget(ctx, targetRaw)
 		if err != nil {
 			return "", err
 		}
-		for k, v := range resolvedTarget {
-			data[k] = v
+		if resolution.Suggestion != "" {
+			return resolution.Suggestion, nil
 		}
-	}
-
-	// Merge additional data
-	if extra, ok := args["data"].(map[string]any); ok {
-		for k, v := range extra {
+		resolvedTarget = resolution.Resolved
+		for k, v := range resolvedTarget {
 			data[k] = v
 		}
 	}

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -799,8 +799,10 @@ func (r *Registry) registerBuiltins() {
 
 	// Call service (low-level, use ha_control_device for voice commands)
 	r.Register(&Tool{
-		Name:        "ha_call_service",
-		Description: "Low-level Home Assistant service call. Only use if you already have the exact entity_id. For voice commands, use ha_control_device instead.",
+		Name: "ha_call_service",
+		Description: "Low-level Home Assistant service call. Address one verified entity_id, OR a target block to fan out across an area, floor, label, or device in a single call — \"turn off the office lights\" is one call with target.area_id, not N entity calls. " +
+			"ha_list_services shows which services accept targets (accepts_target). HA skips hidden entities in area/floor/label targets — that is operator curation, not an error. " +
+			"For voice-style commands against one device, prefer ha_control_device.",
 		Parameters: map[string]any{
 			"type": "object",
 			"properties": map[string]any{
@@ -814,14 +816,25 @@ func (r *Registry) registerBuiltins() {
 				},
 				"entity_id": map[string]any{
 					"type":        "string",
-					"description": "The EXACT entity ID (must be verified, not guessed)",
+					"description": "The EXACT entity ID (must be verified, not guessed). Provide this or target.",
+				},
+				"target": map[string]any{
+					"type":        "object",
+					"description": "Fan-out addressing: any of entity_id, device_id, area_id, floor_id, label_id (string or array each). Areas, floors, labels, and devices accept human names (\"Office\") as well as registry IDs — names resolve case-insensitively, unknown references fail fast with the known names. Provide this or entity_id.",
+					"properties": map[string]any{
+						"entity_id": map[string]any{"type": []string{"string", "array"}, "items": map[string]any{"type": "string"}},
+						"device_id": map[string]any{"type": []string{"string", "array"}, "items": map[string]any{"type": "string"}},
+						"area_id":   map[string]any{"type": []string{"string", "array"}, "items": map[string]any{"type": "string"}},
+						"floor_id":  map[string]any{"type": []string{"string", "array"}, "items": map[string]any{"type": "string"}},
+						"label_id":  map[string]any{"type": []string{"string", "array"}, "items": map[string]any{"type": "string"}},
+					},
 				},
 				"data": map[string]any{
 					"type":        "object",
 					"description": "Additional service data (e.g., brightness, temperature)",
 				},
 			},
-			"required": []string{"domain", "service", "entity_id"},
+			"required": []string{"domain", "service"},
 		},
 		Handler: r.handleCallService,
 	})
@@ -1408,24 +1421,42 @@ func (r *Registry) handleCallService(ctx context.Context, args map[string]any) (
 	domain, _ := args["domain"].(string)
 	service, _ := args["service"].(string)
 	entityID, _ := args["entity_id"].(string)
+	targetRaw, hasTarget := args["target"].(map[string]any)
 
-	if domain == "" || service == "" || entityID == "" {
-		return "", fmt.Errorf("domain, service, and entity_id are required")
+	if domain == "" || service == "" {
+		return "", fmt.Errorf("domain and service are required")
+	}
+	if entityID == "" && !hasTarget {
+		return "", fmt.Errorf("provide entity_id (one verified entity) or target (fan out by area/floor/label/device)")
+	}
+	if entityID != "" && hasTarget {
+		return "", fmt.Errorf("provide entity_id or target, not both; put the entity in target.entity_id to combine it with other selectors")
 	}
 
-	// HA accepts a service call for an unknown entity_id and silently
-	// no-ops, so a typo'd or stale id otherwise vanishes without feedback.
-	// Probe the entity first (a 404 here is authoritative) and return a
-	// recoverable "did you mean?" suggestion instead of a phantom success.
-	if _, err := r.ha.GetState(ctx, entityID); err != nil {
-		if IsHAEntityNotFound(err) {
-			return SuggestEntityNotFound(ctx, r.ha, entityID), nil
+	data := map[string]any{}
+	var resolvedTarget map[string]any
+
+	if entityID != "" {
+		// HA accepts a service call for an unknown entity_id and silently
+		// no-ops, so a typo'd or stale id otherwise vanishes without feedback.
+		// Probe the entity first (a 404 here is authoritative) and return a
+		// recoverable "did you mean?" suggestion instead of a phantom success.
+		if _, err := r.ha.GetState(ctx, entityID); err != nil {
+			if IsHAEntityNotFound(err) {
+				return SuggestEntityNotFound(ctx, r.ha, entityID), nil
+			}
+			return "", fmt.Errorf("verify entity_id %q before calling %s.%s: %w", entityID, domain, service, err)
 		}
-		return "", fmt.Errorf("verify entity_id %q before calling %s.%s: %w", entityID, domain, service, err)
-	}
-
-	data := map[string]any{
-		"entity_id": entityID,
+		data["entity_id"] = entityID
+	} else {
+		var err error
+		resolvedTarget, err = r.resolveServiceTarget(ctx, targetRaw)
+		if err != nil {
+			return "", err
+		}
+		for k, v := range resolvedTarget {
+			data[k] = v
+		}
 	}
 
 	// Merge additional data
@@ -1435,11 +1466,12 @@ func (r *Registry) handleCallService(ctx context.Context, args map[string]any) (
 		}
 	}
 
-	if err := r.ha.CallService(ctx, domain, service, data); err != nil {
+	changed, err := r.ha.CallServiceWithResponse(ctx, domain, service, data)
+	if err != nil {
 		return "", err
 	}
 
-	return fmt.Sprintf("Successfully called %s.%s on %s", domain, service, entityID), nil
+	return haCallServiceResponse(domain, service, entityID, resolvedTarget, changed), nil
 }
 
 func (r *Registry) handleControlDevice(ctx context.Context, args map[string]any) (string, error) {

--- a/talents/ha.md
+++ b/talents/ha.md
@@ -338,7 +338,28 @@ descriptions, required flags, examples, and whether it accepts a
 target block. Check it before guessing; a wrong service name costs a
 failed call.
 
-`ha_call_service` requires the exact entity_id:
+`ha_call_service` addresses one verified entity_id, or fans out with a
+`target` block. Multi-device intent is ONE call, not N: "turn off the
+office lights" is a single call targeting the area —
+
+```json
+{
+  "domain": "light",
+  "service": "turn_off",
+  "target": { "area_id": "Office" }
+}
+```
+
+Targets take `entity_id`, `device_id`, `area_id`, `floor_id`, and
+`label_id` (string or array each), and areas/floors/labels/devices
+accept human names as well as registry IDs — names resolve against the
+registry, and unknown references fail fast with the known names instead
+of HA's silent no-op. HA skips hidden entities in area/floor/label
+targets; that's the operator's curation, not a bug. The response
+reports which entities actually changed state — zero changes with a
+note usually means everything was already in the requested state.
+
+Single-entity form, with the exact entity_id:
 
 ```json
 {


### PR DESCRIPTION
## Summary

Closes #1179, the third pull from the #1175 umbrella. The issue framed this as "teaching, not plumbing" — HA service calls have accepted `target:` blocks for years — but the reality was starker: the tool's schema hard-**required** `entity_id`, so target-addressed calls weren't just untaught, they were impossible. "Turn off the office lights" meant N individual entity calls or a trip through `ha-mcp`'s `ha_bulk_control` and its `ha_get_operation_status` babysitter. Both come off the displacement allowlist with this PR.

## What changed

**Targets are first-class.** `ha_call_service` now takes `entity_id` *or* a `target` block (`entity_id`/`device_id`/`area_id`/`floor_id`/`label_id`, string or array each) — exactly one of the two, with the validation error explaining how to combine them (`target.entity_id` alongside other selectors). The schema and `talents/ha.md` teach the one-call fan-out idiom and note that HA skips hidden entities in area/floor/label targets — the operator-curation semantics #1185 will make uniform.

**Names resolve; unknowns fail fast.** The model usually holds "Office," not `office`. Area, floor, label, and device references accept human names (and area/floor aliases), resolved case-insensitively against the cached registries; registry IDs pass through untouched. An unknown reference errors with the known names — the same phantom-success guard the entity path has had, extended to targets, because HA silently no-ops an unknown `area_id` just like an unknown entity. Target entities get the existing probe + did-you-mean treatment.

**Fan-out is visible.** The client gains `CallServiceWithResponse`, surfacing what HA already returns and the old path discarded: the array of states the call changed. The tool's response is now a typed result — resolved target (IDs after name resolution), `changed_count`, changed entity IDs (capped at 20 with the count always exact), and an explanatory note when zero states changed (already-in-state vs. matched-nothing vs. hidden-skipped). This replaces the old `"Successfully called …"` string, which reported nothing about what actually happened.

## Notes for review

- The response-shape change required updating one existing test that asserted the success string; it now asserts the typed result. The entity-path behavior (probe, suggestions on 404) is unchanged.
- The fake HA server now answers service calls HA-accurately (changed-states array, seedable via `serviceChanged`) and records full payloads so tests can assert what actually went over the wire — the name→ID resolution is verified at the wire level, not just in the echo.
- `ha_list_services` (#1187) already advertises `accepts_target` per service; the schema cross-references it.

## Test plan

- [x] Area target by human name: resolves to registry ID (verified in the wire payload), fan-out visible in `changed_count`/`changed`
- [x] Alias resolves; exact ID passes through untouched
- [x] Unknown area fails fast, teaches known names, and provably never reaches HA
- [x] Validation: neither/both addressing forms, unknown target key, empty target
- [x] Zero-change fan-out carries the explanatory note; label name resolution covered
- [x] `just ci` green locally (unpiped, verified)

Refs #1175. Third and fourth MCP allowlist entries displaced (`ha_bulk_control`, `ha_get_operation_status`) — #1180 tracks the unplug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
