### PR TITLE
feat(ha): ha_automation_vocabulary + purpose-trigger authoring (2026.7)

### DIFF
--- a/internal/integrations/homeassistant/target_capabilities.go
+++ b/internal/integrations/homeassistant/target_capabilities.go
@@ -1,0 +1,50 @@
+package homeassistant
+
+import (
+	"context"
+	"fmt"
+)
+
+// GetTriggersForTarget returns the purpose-specific trigger identifiers
+// (domain.trigger_name) applicable to entities of the given target —
+// the same vocabulary the 2026.7 automation editor offers a human for
+// that target. The target uses service-call target structure
+// (entity_id/device_id/area_id/floor_id/label_id).
+func (c *Client) GetTriggersForTarget(ctx context.Context, target map[string]any) ([]string, error) {
+	ws, err := c.requireWS()
+	if err != nil {
+		return nil, err
+	}
+	return ws.itemsForTarget(ctx, "get_triggers_for_target", target)
+}
+
+// GetConditionsForTarget returns the purpose-specific condition
+// identifiers applicable to entities of the given target.
+func (c *Client) GetConditionsForTarget(ctx context.Context, target map[string]any) ([]string, error) {
+	ws, err := c.requireWS()
+	if err != nil {
+		return nil, err
+	}
+	return ws.itemsForTarget(ctx, "get_conditions_for_target", target)
+}
+
+// GetServicesForTarget returns the service identifiers applicable to
+// entities of the given target — what can actually be done to them.
+func (c *Client) GetServicesForTarget(ctx context.Context, target map[string]any) ([]string, error) {
+	ws, err := c.requireWS()
+	if err != nil {
+		return nil, err
+	}
+	return ws.itemsForTarget(ctx, "get_services_for_target", target)
+}
+
+// itemsForTarget implements the shared shape of the three
+// *_for_target discovery commands: identical request structure,
+// identical string-array result.
+func (c *WSClient) itemsForTarget(ctx context.Context, msgType string, target map[string]any) ([]string, error) {
+	var result []string
+	if err := c.call(ctx, msgType, map[string]any{"target": target}, &result); err != nil {
+		return nil, fmt.Errorf("%s: %w", msgType, err)
+	}
+	return result, nil
+}

--- a/internal/model/toolcatalog/catalog.go
+++ b/internal/model/toolcatalog/catalog.go
@@ -237,6 +237,7 @@ var builtinToolSpecs = map[string]BuiltinToolSpec{
 	"contact_list":                {CanonicalID: "native:contact_list", Source: NativeToolSource, Tags: []string{"contacts"}},
 	"ha_list_entities":            {CanonicalID: "native:ha_list_entities", Source: NativeToolSource, Tags: []string{"ha"}},
 	"ha_automation_traces":        {CanonicalID: "native:ha_automation_traces", Source: NativeToolSource, Tags: []string{"ha"}},
+	"ha_automation_vocabulary":    {CanonicalID: "native:ha_automation_vocabulary", Source: NativeToolSource, Tags: []string{"ha"}},
 	"ha_list_services":            {CanonicalID: "native:ha_list_services", Source: NativeToolSource, Tags: []string{"ha"}},
 	"ha_search_states":            {CanonicalID: "native:ha_search_states", Source: NativeToolSource, Tags: []string{"ha"}},
 	"get_area_activity":           {CanonicalID: "native:get_area_activity", Source: NativeToolSource, Tags: []string{"ha"}},

--- a/internal/tools/ha_automation_tools.go
+++ b/internal/tools/ha_automation_tools.go
@@ -255,7 +255,7 @@ func (r *Registry) registerHAAutomationTools() {
 
 	r.Register(&Tool{
 		Name: "ha_automation_create",
-		Description: "Create a Home Assistant automation directly from a raw HA automation object. Author triggers and conditions in the purpose-specific form when one fits — {\"trigger\": \"light.turned_off\", \"target\": {\"area_id\": \"office\"}} — so the automation describes intent and survives device changes; ha_automation_vocabulary lists the identifiers a target supports. Classic triggers ({\"trigger\": \"state\", ...}) remain fully supported for cases the purpose vocabulary doesn't cover. " +
+		Description: "Create a Home Assistant automation directly from a raw HA automation object. Each trigger is an entry in the config.triggers array, each condition in config.conditions, each action in config.actions. Author triggers and conditions in the purpose-specific form when one fits — a config.triggers entry of {\"trigger\": \"light.turned_off\", \"target\": {\"area_id\": \"office\"}} — so the automation describes intent and survives device changes; ha_automation_vocabulary lists the identifiers a target supports. Classic triggers (a config.triggers entry of {\"trigger\": \"state\", ...}) remain fully supported for cases the purpose vocabulary doesn't cover. " +
 			"Supports the full depth of triggers, conditions, actions, variables, mode, max, and use_blueprint. Optional metadata can set area, labels, icon, aliases, category_id, hidden state, and entity_id rename after creation.",
 		Parameters: map[string]any{
 			"type": "object",

--- a/internal/tools/ha_automation_tools.go
+++ b/internal/tools/ha_automation_tools.go
@@ -254,8 +254,9 @@ func (r *Registry) registerHAAutomationTools() {
 	})
 
 	r.Register(&Tool{
-		Name:        "ha_automation_create",
-		Description: "Create a Home Assistant automation directly from a raw HA automation object. Supports the full depth of triggers, conditions, actions, variables, mode, max, and use_blueprint. Optional metadata can set area, labels, icon, aliases, category_id, hidden state, and entity_id rename after creation.",
+		Name: "ha_automation_create",
+		Description: "Create a Home Assistant automation directly from a raw HA automation object. Author triggers and conditions in the purpose-specific form when one fits — {\"trigger\": \"light.turned_off\", \"target\": {\"area_id\": \"office\"}} — so the automation describes intent and survives device changes; ha_automation_vocabulary lists the identifiers a target supports. Classic triggers ({\"trigger\": \"state\", ...}) remain fully supported for cases the purpose vocabulary doesn't cover. " +
+			"Supports the full depth of triggers, conditions, actions, variables, mode, max, and use_blueprint. Optional metadata can set area, labels, icon, aliases, category_id, hidden state, and entity_id rename after creation.",
 		Parameters: map[string]any{
 			"type": "object",
 			"properties": map[string]any{
@@ -265,7 +266,7 @@ func (r *Registry) registerHAAutomationTools() {
 				},
 				"config": map[string]any{
 					"type":        "object",
-					"description": "Raw Home Assistant automation config object. Preserve HA-native field names such as alias, description, triggers, conditions, actions, variables, mode, max, or use_blueprint.",
+					"description": "Raw Home Assistant automation config object. Preserve HA-native field names such as alias, description, triggers, conditions, actions, variables, mode, max, or use_blueprint. Purpose-specific entries use domain.name identifiers with a target block; note the 2026.7 renames (battery.became_low, vacuum.returned_to_dock, update.became_available, climate.is_target_temperature). Always fill alias and description with genuine intent prose.",
 				},
 				"metadata": map[string]any{
 					"type":        "object",

--- a/internal/tools/ha_automation_tools_test.go
+++ b/internal/tools/ha_automation_tools_test.go
@@ -26,6 +26,9 @@ type fakeHAServer struct {
 	traceDetails    map[string]map[string]any
 	servicePayloads []map[string]any
 	serviceChanged  []homeassistant.State
+	targetTriggers  []string
+	targetConds     []string
+	targetServices  []string
 	configs         map[string]map[string]any
 	areas           []map[string]any
 	floors          []map[string]any
@@ -247,6 +250,21 @@ func (f *fakeHAServer) wsResult(msgType string, msg map[string]any) (any, bool) 
 	defer f.mu.Unlock()
 
 	switch msgType {
+	case "get_triggers_for_target":
+		if f.targetTriggers == nil {
+			return []string{}, true
+		}
+		return f.targetTriggers, true
+	case "get_conditions_for_target":
+		if f.targetConds == nil {
+			return []string{}, true
+		}
+		return f.targetConds, true
+	case "get_services_for_target":
+		if f.targetServices == nil {
+			return []string{}, true
+		}
+		return f.targetServices, true
 	case "trace/list":
 		itemID, _ := msg["item_id"].(string)
 		list := f.traces[itemID]

--- a/internal/tools/ha_automation_vocabulary.go
+++ b/internal/tools/ha_automation_vocabulary.go
@@ -22,7 +22,7 @@ type haVocabularyResult struct {
 	Note       string         `json:"note"`
 }
 
-const haVocabularyNote = "Use these in ha_automation_create: a purpose trigger is {\"trigger\": \"<identifier>\", \"target\": {...}} — same target shape as this call. ha_list_services has field detail for the services."
+const haVocabularyNote = "Use these in ha_automation_create: each identifier is one ENTRY in the config.triggers or config.conditions array — {\"trigger\": \"<identifier>\", \"target\": {...}} for a trigger, {\"condition\": \"<identifier>\", \"target\": {...}} for a condition (same target shape as this call). Services go in config.actions as {\"action\": \"<identifier>\", ...}; ha_list_services has their field detail."
 
 // registerHAAutomationVocabulary wires ha_automation_vocabulary: the
 // discovery half of 2026.7 purpose-trigger authoring. The editor shows

--- a/internal/tools/ha_automation_vocabulary.go
+++ b/internal/tools/ha_automation_vocabulary.go
@@ -1,0 +1,109 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+	"sort"
+)
+
+const haVocabularyTruncationNote = "Result exceeded the tool byte cap; narrow the target (one area or a few entities)."
+
+// haVocabularyResult answers "what can I sense, check, and do" for one
+// target: the purpose-specific trigger and condition identifiers plus
+// the applicable services, in the exact domain.name form the
+// automation config takes. This is the install's live vocabulary —
+// integrations register their own triggers and conditions, so the set
+// is discovered per call, never hardcoded.
+type haVocabularyResult struct {
+	Target     map[string]any `json:"target"`
+	Triggers   []string       `json:"triggers"`
+	Conditions []string       `json:"conditions"`
+	Services   []string       `json:"services"`
+	Note       string         `json:"note"`
+}
+
+const haVocabularyNote = "Use these in ha_automation_create: a purpose trigger is {\"trigger\": \"<identifier>\", \"target\": {...}} — same target shape as this call. ha_list_services has field detail for the services."
+
+// registerHAAutomationVocabulary wires ha_automation_vocabulary: the
+// discovery half of 2026.7 purpose-trigger authoring. The editor shows
+// a human what a target can do; this shows the model the same live
+// vocabulary, so automations get authored in intent terms ("motion in
+// the office") instead of entity-state primitives.
+func (r *Registry) registerHAAutomationVocabulary() {
+	if r.ha == nil || !r.ha.HasWSClient() {
+		return
+	}
+	r.Register(&Tool{
+		Name: "ha_automation_vocabulary",
+		Description: "Discover the automation vocabulary for a target: which purpose-specific triggers and conditions apply to it, and which services can act on it — the same building blocks Home Assistant's automation editor offers for that target. " +
+			"Identifiers come back in the domain.name form automation configs take (e.g. light.turned_off, battery.became_low). " +
+			"Call this before authoring an automation so triggers match what the install actually supports — integrations add their own, so the vocabulary varies per home.",
+		Parameters: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"target": map[string]any{
+					"type":        "object",
+					"description": "What to discover for: any of entity_id, device_id, area_id, floor_id, label_id (string or array each). Names resolve like ha_call_service targets.",
+					"properties": map[string]any{
+						"entity_id": map[string]any{"type": []string{"string", "array"}, "items": map[string]any{"type": "string"}},
+						"device_id": map[string]any{"type": []string{"string", "array"}, "items": map[string]any{"type": "string"}},
+						"area_id":   map[string]any{"type": []string{"string", "array"}, "items": map[string]any{"type": "string"}},
+						"floor_id":  map[string]any{"type": []string{"string", "array"}, "items": map[string]any{"type": "string"}},
+						"label_id":  map[string]any{"type": []string{"string", "array"}, "items": map[string]any{"type": "string"}},
+					},
+				},
+			},
+			"required": []string{"target"},
+		},
+		Handler: r.handleHAAutomationVocabulary,
+	})
+}
+
+func (r *Registry) handleHAAutomationVocabulary(ctx context.Context, args map[string]any) (string, error) {
+	if r.ha == nil {
+		return "", fmt.Errorf("home assistant not configured")
+	}
+	if !r.ha.IsReady() {
+		return "", fmt.Errorf("home assistant is currently unreachable (reconnecting in background)")
+	}
+
+	targetRaw, ok := args["target"].(map[string]any)
+	if !ok {
+		return "", fmt.Errorf("target must be an object like {\"area_id\": \"office\"}")
+	}
+	resolution, err := r.resolveServiceTarget(ctx, targetRaw)
+	if err != nil {
+		return "", err
+	}
+	if resolution.Suggestion != "" {
+		return resolution.Suggestion, nil
+	}
+
+	triggers, err := r.ha.GetTriggersForTarget(ctx, resolution.Resolved)
+	if err != nil {
+		return "", err
+	}
+	conditions, err := r.ha.GetConditionsForTarget(ctx, resolution.Resolved)
+	if err != nil {
+		return "", err
+	}
+	services, err := r.ha.GetServicesForTarget(ctx, resolution.Resolved)
+	if err != nil {
+		return "", err
+	}
+	sort.Strings(triggers)
+	sort.Strings(conditions)
+	sort.Strings(services)
+
+	out := haVocabularyResult{
+		Target:     resolution.Resolved,
+		Triggers:   triggers,
+		Conditions: conditions,
+		Services:   services,
+		Note:       haVocabularyNote,
+	}
+	if len(triggers) == 0 && len(conditions) == 0 && len(services) == 0 {
+		out.Note = "Nothing applies to this target — it may contain no entities (or only hidden ones). Verify the target with ha_search_states."
+	}
+	return toIndentedJSONWithTruncationNote(out, haVocabularyTruncationNote), nil
+}

--- a/internal/tools/ha_automation_vocabulary_test.go
+++ b/internal/tools/ha_automation_vocabulary_test.go
@@ -1,0 +1,79 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+)
+
+func vocabTestServer(t *testing.T) *fakeHAServer {
+	t.Helper()
+	fake := newFakeHAServer(t)
+	fake.areas = []map[string]any{
+		{"area_id": "office", "name": "Office", "aliases": []string{"study"}},
+	}
+	fake.targetTriggers = []string{"light.turned_off", "light.turned_on", "motion.detected"}
+	fake.targetConds = []string{"light.is_on"}
+	fake.targetServices = []string{"light.turn_on", "light.turn_off", "light.toggle"}
+	return fake
+}
+
+func TestHAAutomationVocabulary_ResolvesTargetAndReturnsVocabulary(t *testing.T) {
+	fake := vocabTestServer(t)
+	reg := fake.registry(t)
+
+	raw, err := reg.Execute(context.Background(), "ha_automation_vocabulary", `{"target":{"area_id":"Office"}}`)
+	if err != nil {
+		t.Fatalf("ha_automation_vocabulary: %v", err)
+	}
+	var out haVocabularyResult
+	if err := json.Unmarshal([]byte(raw), &out); err != nil {
+		t.Fatalf("unmarshal: %v\n%s", err, raw)
+	}
+	// Target name resolved to the registry id.
+	if out.Target["area_id"] != "office" {
+		t.Errorf("target.area_id = %v, want resolved \"office\"", out.Target["area_id"])
+	}
+	// All three vocabularies present and sorted.
+	if len(out.Triggers) != 3 || out.Triggers[0] != "light.turned_off" {
+		t.Errorf("triggers = %v, want 3 sorted", out.Triggers)
+	}
+	if len(out.Conditions) != 1 || len(out.Services) != 3 {
+		t.Errorf("conditions/services = %v/%v", out.Conditions, out.Services)
+	}
+	if out.Note == "" {
+		t.Error("result should carry authoring guidance note")
+	}
+}
+
+func TestHAAutomationVocabulary_EmptyTargetCarriesGuidance(t *testing.T) {
+	fake := vocabTestServer(t)
+	fake.targetTriggers = []string{}
+	fake.targetConds = []string{}
+	fake.targetServices = []string{}
+	reg := fake.registry(t)
+
+	raw, err := reg.Execute(context.Background(), "ha_automation_vocabulary", `{"target":{"area_id":"office"}}`)
+	if err != nil {
+		t.Fatalf("vocabulary: %v", err)
+	}
+	var out haVocabularyResult
+	if err := json.Unmarshal([]byte(raw), &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(out.Triggers) != 0 || out.Note == haVocabularyNote {
+		t.Errorf("empty vocabulary should carry the diagnostic note, got %q", out.Note)
+	}
+}
+
+func TestHAAutomationVocabulary_UnknownTargetFailsFast(t *testing.T) {
+	fake := vocabTestServer(t)
+	reg := fake.registry(t)
+
+	if _, err := reg.Execute(context.Background(), "ha_automation_vocabulary", `{"target":{"area_id":"Atrium"}}`); err == nil {
+		t.Error("unknown area should fail fast (reuses ha_call_service target resolution)")
+	}
+	if _, err := reg.Execute(context.Background(), "ha_automation_vocabulary", `{}`); err == nil {
+		t.Error("missing target should error")
+	}
+}

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -123,7 +123,8 @@ func NewRegistry(ha *homeassistant.Client, sched *scheduler.Scheduler) *Registry
 	r.registerHASearchStates() // Predicate search across live state
 	r.registerHAListServices() // Service-catalog discovery (#1177)
 	r.registerHAAutomationTools()
-	r.registerHAAutomationTraces() // Run-level debugging (#1178)
+	r.registerHAAutomationTraces()     // Run-level debugging (#1178)
+	r.registerHAAutomationVocabulary() // Target-scoped 2026.7 vocabulary discovery (#1176)
 	return r
 }
 

--- a/talents/ha.md
+++ b/talents/ha.md
@@ -500,10 +500,17 @@ break the moment a device is renamed or replaced.
 
 Classic platform triggers still work and are the right tool when no
 purpose trigger fits (a raw MQTT topic, a template, a specific
-webhook):
+webhook). Like purpose triggers, each is an entry in `config.triggers`
+— never a top-level `trigger` field on the config:
 
 ```json
-{ "trigger": "state", "entity_id": "binary_sensor.driveway_motion", "to": "on" }
+{
+  "config": {
+    "triggers": [
+      { "trigger": "state", "entity_id": "binary_sensor.driveway_motion", "to": "on" }
+    ]
+  }
+}
 ```
 
 The `config` key holds the raw HA automation object — preserve

--- a/talents/ha.md
+++ b/talents/ha.md
@@ -455,55 +455,75 @@ it fires; traces tell you *why it did what it did*.
 
 ## Author a new automation
 
-`ha_automation_create` takes a full HA automation object:
+Home Assistant (2026.7+) authors automations around *intent*, not
+device internals. A purpose-specific trigger describes what you want
+to happen — "motion in the office," "a battery got low" — and targets
+an area, floor, label, or set of entities. The automation then follows
+the home as it changes: move a sensor into the office and the "motion
+in the office" trigger picks it up, no re-authoring. Prefer this form.
+
+`ha_automation_vocabulary` lists what a target supports — its purpose
+triggers, conditions, and services, in the `domain.name` form the
+config takes. Call it first; the vocabulary is per-install because
+integrations register their own.
 
 ```json
 {
   "config": {
-    "alias": "Driveway camera notification",
-    "description": "Notify when the driveway camera sees motion at night",
-    "trigger": [
-      {
-        "platform": "state",
-        "entity_id": "binary_sensor.driveway_motion",
-        "to": "on"
-      }
+    "alias": "Office lights on with motion after dark",
+    "description": "When anyone moves in the office after sunset, bring the office lights up — so the room is never dark when occupied.",
+    "triggers": [
+      { "trigger": "motion.detected", "target": { "area_id": "office" } }
     ],
-    "condition": [
-      {
-        "condition": "sun",
-        "after": "sunset",
-        "before": "sunrise"
-      }
+    "conditions": [
+      { "condition": "sun.is_below_horizon" }
     ],
-    "action": [
-      {
-        "service": "notify.mobile_app_pixel",
-        "data": {
-          "message": "Driveway motion detected"
-        }
-      }
+    "actions": [
+      { "action": "light.turn_on", "target": { "area_id": "office" } }
     ],
     "mode": "single"
   },
   "metadata": {
-    "area_id": "driveway",
-    "label_ids": ["security"]
+    "area_id": "office",
+    "label_ids": ["lighting"]
   }
 }
 ```
 
-The `config` key holds the raw HA automation object — preserve
-HA-native field names (alias, description, trigger, condition,
-action, mode). The `metadata` key holds entity registry overrides;
-prefer the `_id` suffixed variants (`area_id`, `label_ids`,
-`category_id`) over their friendly-name siblings.
+The purpose trigger targets the *area*, not a specific
+`binary_sensor.*`. That is the durable choice — entity-ID triggers
+break the moment a device is renamed or replaced.
 
-**Before authoring**: use `ha_registry_search` to find real area
-IDs, label IDs, and entity IDs. Don't guess — typos in entity_ids
-inside a trigger silently break the automation the same way they
-silently break `ha_call_service`. The automation will register, return
-success, and never fire.
+**2026.7 renames** — use the current names: `battery.became_low`,
+`vacuum.returned_to_dock`, `update.became_available`,
+`climate.is_target_temperature`.
+
+Classic platform triggers still work and are the right tool when no
+purpose trigger fits (a raw MQTT topic, a template, a specific
+webhook):
+
+```json
+{ "trigger": "state", "entity_id": "binary_sensor.driveway_motion", "to": "on" }
+```
+
+The `config` key holds the raw HA automation object — preserve
+HA-native field names. The `metadata` key holds entity registry
+overrides; prefer the `_id` variants (`area_id`, `label_ids`,
+`category_id`).
+
+**Author it well.** Every automation you create should read like a
+careful operator wrote it: a real `alias` and a `description` that
+states the intent (not "Automation 7"), an `area_id`, and `label_ids`
+where they apply. The metadata is courtesy to whoever opens the HA UI
+and context you yourself read back later.
+
+**Before authoring**: resolve real IDs. `ha_automation_vocabulary`
+gives you valid trigger/condition/service identifiers for a target;
+`ha_registry_search` finds area, label, and entity IDs. Purpose
+triggers targeting an area sidestep the classic failure mode — a typo
+in an `entity_id` inside a trigger silently breaks the automation:
+it registers, returns success, and never fires. After creating, use
+`ha_automation_traces` to confirm it does what you intended.
 
 ## Update an existing automation
 


### PR DESCRIPTION
## Summary

Closes #1176, the vocabulary centerpiece of the #1175 umbrella. Stacked on #1189 (whose target resolver this reuses; GitHub retargets to main as the stack merges). Prod HA is confirmed on 2026.7.0, so this ships against a live install of the release it aligns to.

HA 2026.7 made intent-based authoring the default: purpose-specific triggers (`light.turned_off`, `battery.became_low`) that target areas/floors/labels rather than entity IDs, so an automation follows the home as devices move. Our tools passed raw config through unchanged endpoints — so the new shapes already *worked* — but nothing taught the model they existed, so it authored 2024-style entity-state triggers that break the moment a sensor is swapped. This is the teaching, in three parts.

## Discovery: `ha_automation_vocabulary`

The 2026.7 editor shows a human what a target can do; this shows the model the same live vocabulary. One tool over HA's `get_triggers_for_target` / `get_conditions_for_target` / `get_services_for_target` WebSocket commands (all three share one request/response shape — a target block in, a `domain.name` identifier array out), returning the purpose triggers, conditions, and services applicable to a target. It **reuses #1189's target resolver**, so names resolve to IDs, unknowns fail fast, and entity typos return the recoverable did-you-mean envelope — one addressing grammar across the HA surface. The vocabulary is fetched per call because integrations register their own triggers, so it varies per home and can't be hardcoded — exactly the issue's stated design constraint.

## Authoring: schema + talent

`ha_automation_create`/`update` descriptions now present the purpose form (`{"trigger": "light.turned_off", "target": {"area_id": "office"}}`) as the primary shape, cross-reference `ha_automation_vocabulary`, name the 2026.7 renames (`battery.became_low`, `vacuum.returned_to_dock`, `update.became_available`, `climate.is_target_temperature`), and keep classic triggers documented as the fallback for cases the purpose vocabulary doesn't cover. `talents/ha.md`'s authoring section is rewritten around the glossary: intent over primitives, area targets as the durable choice, the discover-then-author flow, and — per the umbrella's authoring standard — the mandate that every automation carry a genuine `alias`/`description`/metadata, closing with the create → `ha_automation_traces` verification loop.

## Test plan

- [x] Vocabulary tool: target name resolves to ID, all three vocabularies returned sorted, authoring note present
- [x] Empty-vocabulary target carries the diagnostic note (not the generic authoring note)
- [x] Unknown target fails fast (resolver reuse verified); missing target errors
- [x] Fake HA server grows the three `*_for_target` WS routes
- [x] `just ci` green locally (unpiped, verified)

Refs #1175. The intent-authoring half of the milestone's "speak HA's language" movement; #1183's detect→decide pipelines will author their HA side in this vocabulary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
