### PR TITLE
feat(awareness): subscriptions by area, label, and floor

### DIFF
--- a/internal/runtime/loop/subscription.go
+++ b/internal/runtime/loop/subscription.go
@@ -24,8 +24,12 @@ import (
 // future lens routing) and are not load-bearing for the loop→
 // subscription binding.
 type EntitySubscription struct {
-	// EntityID is the Home Assistant entity identifier, e.g.
-	// "sensor.upstairs_temperature" or "weather.home".
+	// EntityID is the subscription target: a concrete Home Assistant
+	// entity ("sensor.upstairs_temperature"), a glob
+	// ("binary_sensor.*door*"), or an organizational target
+	// ("area:office", "label:critical", "floor:upstairs") whose members
+	// are re-resolved from the registry each render. The field name is
+	// historical; the awareness renderer parses the kind.
 	EntityID string `yaml:"entity_id" json:"entity_id"`
 
 	// History is the list of look-back windows (in seconds) the

--- a/internal/state/awareness/glob_subscription.go
+++ b/internal/state/awareness/glob_subscription.go
@@ -150,7 +150,23 @@ func expandGlobSubscription(
 		return ""
 	}
 	sort.Strings(matchedIDs)
-	return renderExpandedMatches(ctx, ha, logger, sub, pattern, matchedIDs, stateByID, now, registries, maxExpansion)
+	globMarker := func(matched, shown int) string {
+		return formatGlobTruncation(pattern, matched, shown)
+	}
+	return renderExpandedMatches(ctx, ha, logger, sub, matchedIDs, stateByID, now, registries, maxExpansion, globMarker)
+}
+
+// formatGlobTruncation renders the marker appended when a glob matched
+// more entities than the per-turn cap, telling the model to narrow the
+// pattern. Registry targets get their own marker (formatTargetTruncation).
+func formatGlobTruncation(pattern string, matched, shown int) string {
+	return promptfmt.MarshalCompact(map[string]any{
+		"glob":      pattern,
+		"matched":   matched,
+		"shown":     shown,
+		"truncated": true,
+		"note":      "glob matched more entities than the per-turn cap; narrow the pattern to see the rest",
+	})
 }
 
 // formatGlobFetchError renders the marker emitted when the live state

--- a/internal/state/awareness/glob_subscription.go
+++ b/internal/state/awareness/glob_subscription.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"log/slog"
 	"sort"
-	"strings"
 	"time"
 
 	"github.com/nugget/thane-ai-agent/internal/integrations/homeassistant"
@@ -151,26 +150,7 @@ func expandGlobSubscription(
 		return ""
 	}
 	sort.Strings(matchedIDs)
-
-	total := len(matchedIDs)
-	truncated := false
-	if cap := normalizeMaxGlobExpansion(maxExpansion); total > cap {
-		matchedIDs = matchedIDs[:cap]
-		truncated = true
-	}
-
-	var sb strings.Builder
-	for _, id := range matchedIDs {
-		matchSub := sub
-		matchSub.EntityID = id
-		sb.WriteString(renderWatchedState(ctx, ha, logger, matchSub, stateByID[id], now, registries))
-		sb.WriteByte('\n')
-	}
-	if truncated {
-		sb.WriteString(formatGlobTruncation(pattern, total, len(matchedIDs)))
-		sb.WriteByte('\n')
-	}
-	return sb.String()
+	return renderExpandedMatches(ctx, ha, logger, sub, pattern, matchedIDs, stateByID, now, registries, maxExpansion)
 }
 
 // formatGlobFetchError renders the marker emitted when the live state
@@ -184,18 +164,5 @@ func formatGlobFetchError(pattern string) string {
 		"available": false,
 		"reason":    "fetch_error",
 		"note":      "could not enumerate entities to expand this glob this turn",
-	})
-}
-
-// formatGlobTruncation renders the marker line appended when a glob
-// matched more entities than the per-turn cap, so the model can tell the
-// view is partial and narrow the pattern if it needs the rest.
-func formatGlobTruncation(pattern string, matched, shown int) string {
-	return promptfmt.MarshalCompact(map[string]any{
-		"glob":      pattern,
-		"matched":   matched,
-		"shown":     shown,
-		"truncated": true,
-		"note":      "glob matched more entities than the per-turn cap; narrow the pattern to see the rest",
 	})
 }

--- a/internal/state/awareness/loop_subscription_provider.go
+++ b/internal/state/awareness/loop_subscription_provider.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/nugget/thane-ai-agent/internal/integrations/homeassistant"
 	"github.com/nugget/thane-ai-agent/internal/runtime/agentctx"
 	looppkg "github.com/nugget/thane-ai-agent/internal/runtime/loop"
 )
@@ -133,19 +132,24 @@ func (p *LoopSubscriptionProvider) TagContext(ctx context.Context, _ agentctx.Co
 		if sub.IsExpired(now) {
 			continue
 		}
-		if homeassistant.IsEntityGlob(sub.EntityID) {
+		target := ParseSubscriptionTarget(sub.EntityID)
+		switch {
+		case target.Kind == TargetGlob:
 			states, statesErr := snap.get(ctx)
 			// Pass alreadyVisible so a loop glob (e.g. sensor.*) doesn't
 			// re-render entities the always-visible watchlist already
 			// injects — same dedup the concrete path applies below.
 			body.WriteString(expandGlobSubscription(ctx, p.ha, p.logger, watchedFromLoopSubscription(sub), states, statesErr, now, registries, p.maxGlobExpansion, alreadyVisible))
-			continue
+		case target.IsRegistryTarget():
+			states, statesErr := snap.get(ctx)
+			body.WriteString(expandRegistryTargetSubscription(ctx, p.ha, p.logger, watchedFromLoopSubscription(sub), target, states, statesErr, now, registries, p.maxGlobExpansion, alreadyVisible))
+		default:
+			if _, dup := alreadyVisible[sub.EntityID]; dup {
+				continue
+			}
+			body.WriteString(p.renderLoopSubscription(ctx, sub, now, registries))
+			body.WriteByte('\n')
 		}
-		if _, dup := alreadyVisible[sub.EntityID]; dup {
-			continue
-		}
-		body.WriteString(p.renderLoopSubscription(ctx, sub, now, registries))
-		body.WriteByte('\n')
 	}
 	if body.Len() == 0 {
 		return "", nil

--- a/internal/state/awareness/registry_target_subscription.go
+++ b/internal/state/awareness/registry_target_subscription.go
@@ -76,24 +76,30 @@ func expandRegistryTargetSubscription(
 		return ""
 	}
 
-	return renderExpandedMatches(ctx, ha, logger, sub, label, matchedIDs, stateByID, now, registries, maxExpansion)
+	truncationMarker := func(matched, shown int) string {
+		return formatTargetTruncation(label, matched, shown)
+	}
+	return renderExpandedMatches(ctx, ha, logger, sub, matchedIDs, stateByID, now, registries, maxExpansion, truncationMarker)
 }
 
 // renderExpandedMatches is the shared tail of glob and registry-target
 // expansion: render each matched id with the subscription's options,
-// honoring the per-turn cap and appending a truncation marker when more
-// matched than shown. matchedIDs must already be sorted and filtered.
+// honoring the per-turn cap and appending a caller-supplied truncation
+// marker when more matched than shown. matchedIDs must already be sorted
+// and filtered. The marker is passed in (not derived here) so glob and
+// registry targets keep their own schema and wording — a glob says
+// "narrow the pattern," an area/label/floor says "scope smaller."
 func renderExpandedMatches(
 	ctx context.Context,
 	ha StateGetter,
 	logger *slog.Logger,
 	sub WatchedSubscription,
-	label string,
 	matchedIDs []string,
 	stateByID map[string]*homeassistant.State,
 	now time.Time,
 	registries *renderRegistries,
 	maxExpansion int,
+	truncationMarker func(matched, shown int) string,
 ) string {
 	total := len(matchedIDs)
 	truncated := false
@@ -110,7 +116,7 @@ func renderExpandedMatches(
 		sb.WriteByte('\n')
 	}
 	if truncated {
-		sb.WriteString(formatTargetTruncation(label, total, len(matchedIDs)))
+		sb.WriteString(truncationMarker(total, len(matchedIDs)))
 		sb.WriteByte('\n')
 	}
 	return sb.String()

--- a/internal/state/awareness/registry_target_subscription.go
+++ b/internal/state/awareness/registry_target_subscription.go
@@ -1,0 +1,156 @@
+package awareness
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/nugget/thane-ai-agent/internal/integrations/homeassistant"
+	"github.com/nugget/thane-ai-agent/internal/model/promptfmt"
+)
+
+// expandRegistryTargetSubscription renders an area/label/floor
+// subscription by resolving its current members from the registry and
+// rendering each with the subscription's own options — the registry
+// twin of [expandGlobSubscription]. Membership is re-resolved every
+// render, so the subscription tracks the home's organization rather
+// than a frozen entity list.
+//
+// It needs both the registry (for membership) and the live-state
+// snapshot (to render each member); a fetch failure of either renders
+// an explicit error marker rather than looking like an empty match.
+// exclude drops ids already rendered elsewhere. Returns "" when the
+// target currently has no members, the intended "nothing here right
+// now" signal.
+func expandRegistryTargetSubscription(
+	ctx context.Context,
+	ha StateGetter,
+	logger *slog.Logger,
+	sub WatchedSubscription,
+	target SubscriptionTarget,
+	states []homeassistant.State,
+	statesErr error,
+	now time.Time,
+	registries *renderRegistries,
+	maxExpansion int,
+	exclude map[string]struct{},
+) string {
+	label := target.String()
+	if registries == nil {
+		// No registry client wired — membership can't be resolved.
+		return formatTargetFetchError(label, "registry access is unavailable, so this target's members can't be resolved this turn") + "\n"
+	}
+	if statesErr != nil {
+		return formatTargetFetchError(label, "could not enumerate entity states to expand this target this turn") + "\n"
+	}
+	resolver, err := newMembershipResolver(registries)
+	if err != nil {
+		if logger != nil {
+			logger.Warn("failed to resolve subscription target membership",
+				"target", label, "error", err)
+		}
+		return formatTargetFetchError(label, "could not read the registry to expand this target this turn") + "\n"
+	}
+
+	stateByID := make(map[string]*homeassistant.State, len(states))
+	for i := range states {
+		stateByID[states[i].EntityID] = &states[i]
+	}
+
+	matchedIDs := make([]string, 0)
+	for _, id := range resolver.members(target) {
+		if _, skip := exclude[id]; skip {
+			continue
+		}
+		// A registry member with no live state (disabled/never-loaded)
+		// is dropped from the render — renderWatchedState needs a state,
+		// and the honest empty-state case belongs to explicit reads.
+		if _, ok := stateByID[id]; !ok {
+			continue
+		}
+		matchedIDs = append(matchedIDs, id)
+	}
+	if len(matchedIDs) == 0 {
+		return ""
+	}
+
+	return renderExpandedMatches(ctx, ha, logger, sub, label, matchedIDs, stateByID, now, registries, maxExpansion)
+}
+
+// renderExpandedMatches is the shared tail of glob and registry-target
+// expansion: render each matched id with the subscription's options,
+// honoring the per-turn cap and appending a truncation marker when more
+// matched than shown. matchedIDs must already be sorted and filtered.
+func renderExpandedMatches(
+	ctx context.Context,
+	ha StateGetter,
+	logger *slog.Logger,
+	sub WatchedSubscription,
+	label string,
+	matchedIDs []string,
+	stateByID map[string]*homeassistant.State,
+	now time.Time,
+	registries *renderRegistries,
+	maxExpansion int,
+) string {
+	total := len(matchedIDs)
+	truncated := false
+	if cap := normalizeMaxGlobExpansion(maxExpansion); total > cap {
+		matchedIDs = matchedIDs[:cap]
+		truncated = true
+	}
+
+	var sb strings.Builder
+	for _, id := range matchedIDs {
+		matchSub := sub
+		matchSub.EntityID = id
+		sb.WriteString(renderWatchedState(ctx, ha, logger, matchSub, stateByID[id], now, registries))
+		sb.WriteByte('\n')
+	}
+	if truncated {
+		sb.WriteString(formatTargetTruncation(label, total, len(matchedIDs)))
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+// formatTargetFetchError mirrors the glob fetch-error marker for
+// registry targets, so a target that couldn't expand reads as "active
+// but unavailable" rather than inferring an empty membership.
+func formatTargetFetchError(target, reason string) string {
+	return promptfmt.MarshalCompact(map[string]any{
+		"target":    target,
+		"available": false,
+		"reason":    "fetch_error",
+		"note":      reason,
+	})
+}
+
+// formatTargetTruncation mirrors the glob truncation marker for registry
+// targets.
+func formatTargetTruncation(target string, matched, shown int) string {
+	return promptfmt.MarshalCompact(map[string]any{
+		"target":    target,
+		"matched":   matched,
+		"shown":     shown,
+		"truncated": true,
+		"note":      fmt.Sprintf("%s has more members than the per-turn cap; scope to a smaller area/label/floor to see the rest", target),
+	})
+}
+
+// String renders a target back to its stored form for display in
+// markers (area:office, label:critical, binary_sensor.*door*, ...).
+func (t SubscriptionTarget) String() string {
+	switch t.Kind {
+	case TargetArea:
+		return "area:" + t.Value
+	case TargetLabel:
+		return "label:" + t.Value
+	case TargetFloor:
+		return "floor:" + t.Value
+	default:
+		return t.Value
+	}
+}

--- a/internal/state/awareness/subscription_target.go
+++ b/internal/state/awareness/subscription_target.go
@@ -1,0 +1,164 @@
+package awareness
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/nugget/thane-ai-agent/internal/integrations/homeassistant"
+)
+
+// SubscriptionTargetKind classifies what a subscription's target
+// addresses. Entity and glob resolve against live states; area, label,
+// and floor resolve against the registry, so their membership follows
+// the home as the registry changes — move a sensor into the office and
+// an office subscription picks it up with no re-authoring.
+type SubscriptionTargetKind int
+
+const (
+	// TargetEntity is a concrete entity_id (e.g. sensor.office_temperature).
+	TargetEntity SubscriptionTargetKind = iota
+	// TargetGlob is an entity_id glob (e.g. binary_sensor.*door*).
+	TargetGlob
+	// TargetArea is an area, addressed as "area:<area_id>".
+	TargetArea
+	// TargetLabel is a label, addressed as "label:<label_id>".
+	TargetLabel
+	// TargetFloor is a floor, addressed as "floor:<floor_id>".
+	TargetFloor
+)
+
+// registryTargetPrefixes maps the stored-string prefix of a
+// registry-backed target to its kind. Concrete entity IDs are
+// domain.object_id (dot-separated) and globs carry wildcard runes, so a
+// "kind:value" colon form is unambiguous against both — HA has no
+// colon-bearing entity ids.
+var registryTargetPrefixes = map[string]SubscriptionTargetKind{
+	"area":  TargetArea,
+	"label": TargetLabel,
+	"floor": TargetFloor,
+}
+
+// SubscriptionTarget is the typed view of a subscription's addressing.
+// It is parsed from the stored string form (which the watchlist row and
+// the loop-spec entity_id both carry) so callers reason over a kind,
+// not a string, while storage stays a single discriminated column.
+type SubscriptionTarget struct {
+	Kind  SubscriptionTargetKind
+	Value string // entity_id, glob pattern, or bare registry id (no prefix)
+}
+
+// ParseSubscriptionTarget interprets a stored subscription string: a
+// "area:"/"label:"/"floor:" prefix selects a registry target, a
+// wildcard-bearing value is a glob, anything else is a concrete entity.
+func ParseSubscriptionTarget(raw string) SubscriptionTarget {
+	raw = strings.TrimSpace(raw)
+	if prefix, value, ok := strings.Cut(raw, ":"); ok {
+		if kind, known := registryTargetPrefixes[prefix]; known {
+			return SubscriptionTarget{Kind: kind, Value: strings.TrimSpace(value)}
+		}
+	}
+	if homeassistant.IsEntityGlob(raw) {
+		return SubscriptionTarget{Kind: TargetGlob, Value: raw}
+	}
+	return SubscriptionTarget{Kind: TargetEntity, Value: raw}
+}
+
+// IsRegistryTarget reports whether the target resolves its members
+// against the registry (area/label/floor) rather than against live
+// entity ids (entity/glob).
+func (t SubscriptionTarget) IsRegistryTarget() bool {
+	switch t.Kind {
+	case TargetArea, TargetLabel, TargetFloor:
+		return true
+	default:
+		return false
+	}
+}
+
+// membershipResolver answers "which entities belong to this registry
+// target," walking the registry with HA's inheritance rules: an
+// entity's effective area is its own area_id or, unset, its device's;
+// an entity carries a label if it or its device carries it; an entity
+// is on a floor if its effective area sits on that floor.
+type membershipResolver struct {
+	entitiesByID map[string]*homeassistant.EntityRegistryEntry
+	devicesByID  map[string]*homeassistant.DeviceRegistryEntry
+	areaToFloor  map[string]string // area_id → floor_id
+}
+
+func newMembershipResolver(registries *renderRegistries) (*membershipResolver, error) {
+	entities, err := registries.entities()
+	if err != nil {
+		return nil, err
+	}
+	devices, err := registries.devices()
+	if err != nil {
+		return nil, err
+	}
+	areas, err := registries.areaEntries()
+	if err != nil {
+		return nil, err
+	}
+	areaToFloor := make(map[string]string, len(areas))
+	for _, a := range areas {
+		if a.FloorID != "" {
+			areaToFloor[a.AreaID] = a.FloorID
+		}
+	}
+	return &membershipResolver{entitiesByID: entities, devicesByID: devices, areaToFloor: areaToFloor}, nil
+}
+
+// entityArea returns an entity's effective area, inheriting from its
+// device when the entity has no area of its own.
+func (m *membershipResolver) entityArea(e *homeassistant.EntityRegistryEntry) string {
+	if e.AreaID != "" {
+		return e.AreaID
+	}
+	if e.DeviceID != "" {
+		if d := m.devicesByID[e.DeviceID]; d != nil {
+			return d.AreaID
+		}
+	}
+	return ""
+}
+
+// entityHasLabel reports whether an entity carries a label directly or
+// through its device.
+func (m *membershipResolver) entityHasLabel(e *homeassistant.EntityRegistryEntry, labelID string) bool {
+	for _, l := range e.Labels {
+		if l == labelID {
+			return true
+		}
+	}
+	if e.DeviceID != "" {
+		if d := m.devicesByID[e.DeviceID]; d != nil {
+			for _, l := range d.Labels {
+				if l == labelID {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+// members returns the sorted entity ids belonging to a registry target.
+func (m *membershipResolver) members(target SubscriptionTarget) []string {
+	var out []string
+	for id, e := range m.entitiesByID {
+		var match bool
+		switch target.Kind {
+		case TargetArea:
+			match = m.entityArea(e) == target.Value
+		case TargetLabel:
+			match = m.entityHasLabel(e, target.Value)
+		case TargetFloor:
+			match = m.areaToFloor[m.entityArea(e)] == target.Value && target.Value != ""
+		}
+		if match {
+			out = append(out, id)
+		}
+	}
+	sort.Strings(out)
+	return out
+}

--- a/internal/state/awareness/subscription_target.go
+++ b/internal/state/awareness/subscription_target.go
@@ -54,7 +54,13 @@ func ParseSubscriptionTarget(raw string) SubscriptionTarget {
 	raw = strings.TrimSpace(raw)
 	if prefix, value, ok := strings.Cut(raw, ":"); ok {
 		if kind, known := registryTargetPrefixes[prefix]; known {
-			return SubscriptionTarget{Kind: kind, Value: strings.TrimSpace(value)}
+			// An empty id after the prefix ("area:") is a malformed
+			// target, not a wildcard. Falling through renders it as a
+			// bogus concrete entity (a clean not-found signal) rather
+			// than silently matching every entity with no area/floor.
+			if v := strings.TrimSpace(value); v != "" {
+				return SubscriptionTarget{Kind: kind, Value: v}
+			}
 		}
 	}
 	if homeassistant.IsEntityGlob(raw) {

--- a/internal/state/awareness/subscription_target_test.go
+++ b/internal/state/awareness/subscription_target_test.go
@@ -1,0 +1,179 @@
+package awareness
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/nugget/thane-ai-agent/internal/integrations/homeassistant"
+	"github.com/nugget/thane-ai-agent/internal/runtime/agentctx"
+)
+
+func TestParseSubscriptionTarget(t *testing.T) {
+	cases := []struct {
+		raw   string
+		kind  SubscriptionTargetKind
+		value string
+	}{
+		{"sensor.office_temperature", TargetEntity, "sensor.office_temperature"},
+		{"binary_sensor.*door*", TargetGlob, "binary_sensor.*door*"},
+		{"area:office", TargetArea, "office"},
+		{"label:critical_lights", TargetLabel, "critical_lights"},
+		{"floor:upstairs", TargetFloor, "upstairs"},
+		{"weather.home", TargetEntity, "weather.home"}, // dot, not a glob or prefix
+	}
+	for _, c := range cases {
+		got := ParseSubscriptionTarget(c.raw)
+		if got.Kind != c.kind || got.Value != c.value {
+			t.Errorf("ParseSubscriptionTarget(%q) = {%v %q}, want {%v %q}", c.raw, got.Kind, got.Value, c.kind, c.value)
+		}
+		// Round-trips back to stored form for registry targets.
+		if got.IsRegistryTarget() && got.String() != c.raw {
+			t.Errorf("String() = %q, want round-trip %q", got.String(), c.raw)
+		}
+	}
+}
+
+// fakeHARegistry is a StateGetter that also serves registry data, so
+// registry-target expansion can be exercised end to end.
+type fakeHARegistry struct {
+	fakeHA
+	entities []homeassistant.EntityRegistryEntry
+	devices  []homeassistant.DeviceRegistryEntry
+	areas    []homeassistant.Area
+	floors   []homeassistant.FloorRegistryEntry
+	labels   []homeassistant.LabelRegistryEntry
+}
+
+func (f *fakeHARegistry) GetEntityRegistry(context.Context) ([]homeassistant.EntityRegistryEntry, error) {
+	return f.entities, nil
+}
+func (f *fakeHARegistry) GetDeviceRegistry(context.Context) ([]homeassistant.DeviceRegistryEntry, error) {
+	return f.devices, nil
+}
+func (f *fakeHARegistry) GetAreas(context.Context) ([]homeassistant.Area, error) { return f.areas, nil }
+func (f *fakeHARegistry) GetFloorRegistry(context.Context) ([]homeassistant.FloorRegistryEntry, error) {
+	return f.floors, nil
+}
+func (f *fakeHARegistry) GetLabelRegistry(context.Context) ([]homeassistant.LabelRegistryEntry, error) {
+	return f.labels, nil
+}
+func (f *fakeHARegistry) GetConfigEntries(context.Context) ([]homeassistant.ConfigEntry, error) {
+	return nil, nil
+}
+
+// officeRegistry seeds an office with two entities addressed different
+// ways: one carries area_id directly, the other inherits area and a
+// label from its device. This proves the inheritance rules.
+func officeRegistry() *fakeHARegistry {
+	mk := func(id, state string) *homeassistant.State {
+		return &homeassistant.State{EntityID: id, State: state}
+	}
+	f := &fakeHARegistry{}
+	f.states = map[string]*homeassistant.State{
+		"light.office_overhead": mk("light.office_overhead", "on"),
+		"sensor.office_power":   mk("sensor.office_power", "42"),
+		"light.garage":          mk("light.garage", "off"),
+	}
+	f.entities = []homeassistant.EntityRegistryEntry{
+		{EntityID: "light.office_overhead", AreaID: "office", Labels: []string{"critical"}},
+		{EntityID: "sensor.office_power", DeviceID: "dev1"}, // area + label inherited from device
+		{EntityID: "light.garage", AreaID: "garage"},
+	}
+	f.devices = []homeassistant.DeviceRegistryEntry{
+		{ID: "dev1", AreaID: "office", Labels: []string{"critical"}},
+	}
+	f.areas = []homeassistant.Area{
+		{AreaID: "office", Name: "Office", FloorID: "main"},
+		{AreaID: "garage", Name: "Garage", FloorID: "main"},
+	}
+	f.floors = []homeassistant.FloorRegistryEntry{{FloorID: "main", Name: "Main"}}
+	f.labels = []homeassistant.LabelRegistryEntry{{LabelID: "critical", Name: "Critical"}}
+	return f
+}
+
+func setupRegistryProvider(t *testing.T, ha *fakeHARegistry) (*WatchlistProvider, *WatchlistStore) {
+	t.Helper()
+	p, store := setupTestProvider(t, ha)
+	p.SetRegistryClient(ha)
+	return p, store
+}
+
+func TestRegistryTarget_AreaExpandsWithInheritance(t *testing.T) {
+	ha := officeRegistry()
+	p, store := setupRegistryProvider(t, ha)
+	if err := store.Add("area:office"); err != nil {
+		t.Fatalf("add area target: %v", err)
+	}
+	got, err := p.TagContext(context.Background(), agentctx.ContextRequest{})
+	if err != nil {
+		t.Fatalf("TagContext: %v", err)
+	}
+	// Both office entities render — the direct one and the device-inherited one.
+	for _, want := range []string{"light.office_overhead", "sensor.office_power"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("area:office should include %s (inheritance):\n%s", want, got)
+		}
+	}
+	if strings.Contains(got, "light.garage") {
+		t.Errorf("area:office must not include garage:\n%s", got)
+	}
+}
+
+func TestRegistryTarget_LabelAndFloor(t *testing.T) {
+	ha := officeRegistry()
+
+	// Label: both office entities carry "critical" (one direct, one via device).
+	p, store := setupRegistryProvider(t, ha)
+	if err := store.Add("label:critical"); err != nil {
+		t.Fatalf("add: %v", err)
+	}
+	got, _ := p.TagContext(context.Background(), agentctx.ContextRequest{})
+	if !strings.Contains(got, "light.office_overhead") || !strings.Contains(got, "sensor.office_power") {
+		t.Errorf("label:critical should match both office entities:\n%s", got)
+	}
+
+	// Floor: main covers office + garage, so all three entities.
+	p2, store2 := setupRegistryProvider(t, ha)
+	if err := store2.Add("floor:main"); err != nil {
+		t.Fatalf("add: %v", err)
+	}
+	got2, _ := p2.TagContext(context.Background(), agentctx.ContextRequest{})
+	for _, want := range []string{"light.office_overhead", "sensor.office_power", "light.garage"} {
+		if !strings.Contains(got2, want) {
+			t.Errorf("floor:main should include %s:\n%s", want, got2)
+		}
+	}
+}
+
+func TestRegistryTarget_UnknownAreaIsSilent(t *testing.T) {
+	ha := officeRegistry()
+	p, store := setupRegistryProvider(t, ha)
+	if err := store.Add("area:atrium"); err != nil {
+		t.Fatalf("add: %v", err)
+	}
+	got, err := p.TagContext(context.Background(), agentctx.ContextRequest{})
+	if err != nil {
+		t.Fatalf("TagContext: %v", err)
+	}
+	// No members → the whole provider renders empty (like an empty glob).
+	if got != "" {
+		t.Errorf("unknown area should render nothing, got:\n%s", got)
+	}
+}
+
+func TestRegistryTarget_NoRegistryClientMarksUnavailable(t *testing.T) {
+	ha := officeRegistry()
+	// setupTestProvider does NOT wire the registry client.
+	p, store := setupTestProvider(t, ha)
+	if err := store.Add("area:office"); err != nil {
+		t.Fatalf("add: %v", err)
+	}
+	got, err := p.TagContext(context.Background(), agentctx.ContextRequest{})
+	if err != nil {
+		t.Fatalf("TagContext: %v", err)
+	}
+	if !strings.Contains(got, "fetch_error") || !strings.Contains(got, "area:office") {
+		t.Errorf("no registry client should mark the target unavailable, got:\n%s", got)
+	}
+}

--- a/internal/state/awareness/subscription_target_test.go
+++ b/internal/state/awareness/subscription_target_test.go
@@ -21,6 +21,8 @@ func TestParseSubscriptionTarget(t *testing.T) {
 		{"label:critical_lights", TargetLabel, "critical_lights"},
 		{"floor:upstairs", TargetFloor, "upstairs"},
 		{"weather.home", TargetEntity, "weather.home"}, // dot, not a glob or prefix
+		{"area:", TargetEntity, "area:"},               // empty id: malformed, not a wildcard-all
+		{"floor: ", TargetEntity, "floor:"},            // whitespace-only id: same
 	}
 	for _, c := range cases {
 		got := ParseSubscriptionTarget(c.raw)

--- a/internal/state/awareness/watchlist_provider.go
+++ b/internal/state/awareness/watchlist_provider.go
@@ -101,15 +101,20 @@ func (p *WatchlistProvider) TagContext(ctx context.Context, _ agentctx.ContextRe
 	// this turn) yields no bare header.
 	var body strings.Builder
 	for _, sub := range subs {
-		if homeassistant.IsEntityGlob(sub.EntityID) {
+		target := ParseSubscriptionTarget(sub.EntityID)
+		switch {
+		case target.Kind == TargetGlob:
 			states, statesErr := snap.get(ctx)
 			// No exclusion set — this provider IS the always-visible
 			// surface, so there is nothing upstream to dedup against.
 			body.WriteString(expandGlobSubscription(ctx, p.ha, p.logger, sub, states, statesErr, now, registries, p.maxGlobExpansion, nil))
-			continue
+		case target.IsRegistryTarget():
+			states, statesErr := snap.get(ctx)
+			body.WriteString(expandRegistryTargetSubscription(ctx, p.ha, p.logger, sub, target, states, statesErr, now, registries, p.maxGlobExpansion, nil))
+		default:
+			body.WriteString(p.renderSubscriptionContext(ctx, sub, now, registries))
+			body.WriteByte('\n')
 		}
-		body.WriteString(p.renderSubscriptionContext(ctx, sub, now, registries))
-		body.WriteByte('\n')
 	}
 	if body.Len() == 0 {
 		return "", nil

--- a/internal/state/awareness/watchlist_tool_provider.go
+++ b/internal/state/awareness/watchlist_tool_provider.go
@@ -67,7 +67,7 @@ func (w *WatchlistTools) Tools() []*tools.Tool {
 				"properties": map[string]any{
 					"entity_id": map[string]any{
 						"type":        "string",
-						"description": "The Home Assistant entity ID to subscribe to (e.g., sensor.office_temperature, weather.home), or a glob pattern (e.g., binary_sensor.*door*, *_temperature) to watch every matching entity, re-expanded live each turn (capped per turn).",
+						"description": "What to subscribe to. Any of: a concrete entity ID (sensor.office_temperature); a glob (binary_sensor.*door*, *_temperature); or an organizational target — area:<area_id>, label:<label_id>, floor:<floor_id> (e.g. area:office) — which watches that group's current members, re-resolved live each turn so membership follows the home as devices move (capped per turn like globs). Use ha_registry_search to find area/label/floor IDs.",
 					},
 					"tags": map[string]any{
 						"type":        "array",

--- a/talents/awareness-trailhead.md
+++ b/talents/awareness-trailhead.md
@@ -15,12 +15,18 @@ Choose the next move deliberately:
 
 - Use `list_entity_subscriptions` to see what this loop is already carrying.
 - Use `add_entity_subscription` when a room, device, person, or live state
-  should auto-load while the work continues. The `entity_id` accepts a
-  glob (e.g. `binary_sensor.*door*`, `*_temperature`) to follow a whole
-  set: it is re-expanded against live entities every turn, so newly-added
-  matches join automatically. A glob is capped per turn and reports
-  truncation when it matches more than the cap — keep patterns narrow so
-  the watch stays a focus, not a firehose.
+  should auto-load while the work continues. The `entity_id` accepts more
+  than a single entity: a glob (`binary_sensor.*door*`, `*_temperature`)
+  to follow entities by name, or an organizational target —
+  `area:<area_id>`, `label:<label_id>`, `floor:<floor_id>` (e.g.
+  `area:office`). Prefer the organizational form when the intent is
+  "watch the office," not "watch these specific sensors": its membership
+  is re-resolved from the registry every turn, so it follows the home —
+  move a device into the office and the `area:office` watch picks it up,
+  no re-authoring. All expansions are capped per turn and report
+  truncation when they overflow; scope to a smaller area/label/floor
+  rather than watching the whole house. Use `ha_registry_search` to find
+  area/label/floor IDs.
 - Add `include` metadata flags when area, owning device, HA labels, or
   descriptions would make the subscribed state easier to interpret; use
   `visibility` when hidden/enabled salience matters, and read


### PR DESCRIPTION
## Summary

Closes #1184 from the #1175 umbrella. Entity subscriptions — the agent's standing senses — spoke only entity IDs and globs. Now they speak the house's organization: **`area:<id>`, `label:<id>`, `floor:<id>`** targets whose membership is re-resolved from the registry every turn, so a subscription tracks the *organization* of the home rather than a frozen device list. Move a sensor into the office and an `area:office` watch picks it up with no re-authoring — the same durability 2026.7's purpose triggers gave automations, now for the agent's perception.

## Design

**Typed target, single column.** A new `SubscriptionTarget{Kind, Value}` is the typed view every caller reasons over; the stored string stays one discriminated column (`area:office`, `label:critical`, a glob, or a bare entity), parsed at the boundary by `ParseSubscriptionTarget`. Globs already established non-entity values in this field, and a colon form is unambiguous against dot-separated entity IDs — so no schema migration, and the code is fully typed. Both subscription surfaces — the always-visible watchlist and loop-scoped `spec.subscriptions` — dispatch through the same parse + one shared switch.

**Registry-dynamic membership with HA's inheritance.** `membershipResolver` walks the registry with HA's own rules: an entity's effective area is its own `area_id` or, unset, its device's; an entity carries a label directly or through its device; an entity is on a floor if its effective area sits on that floor. All from the #995 registry caches (`renderRegistries` already lazily loads entities-by-device, devices, areas, floors) — no new fetches.

**One expansion path.** Registry-target expansion reuses the glob path's machinery verbatim: the shared `renderExpandedMatches` tail (extracted in this PR so glob and registry can't drift), the same per-turn cap, the same `exclude` dedup against the always-visible watchlist, the same `renderWatchedState` per entity. Empty membership renders nothing (the intended quiescent signal); a registry or state fetch failure renders an explicit `fetch_error` marker rather than looking like an empty match; overflow past the cap reports truncation pointing at a narrower scope.

## Test plan

- [x] `ParseSubscriptionTarget`: entity / glob / area / label / floor, with round-trip
- [x] Area expansion honors device-inherited area (a device-only entity resolves into its device's area)
- [x] Label matches direct-and-device-inherited; floor covers all areas on it
- [x] Unknown target renders silently (empty membership); no registry client renders an unavailable marker
- [x] Glob path unchanged (existing glob tests pass through the shared tail)
- [x] `just ci` green locally (unpiped, verified)

## Notes for review

- The stored `entity_id` column is intentionally reused rather than migrated — it already held globs, and a discriminated string keeps one code path. The typing lives in `SubscriptionTarget`, not the schema.
- Talent (`awareness-trailhead.md`) teaches the organizational form as the preferred choice for "watch the office" intent, with the follow-the-home durability spelled out.

Refs #1175. The listening half of area-scoped intent — pairs with #1179 (area-scoped acting) and #1183 (area-triggered pipelines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Scope note (review)

Per-turn render silence on an empty target is intentional and matches the glob path — a momentarily-empty area/label shouldn't clutter every turn. #1184's "empty flagged, never silent" criterion belongs to the *authoring* moment (the tool), which needs an HA/registry client wired into `WatchlistTools` (store-only today). That expansion-preview affordance is split to #1193 so this PR keeps the render/storage/membership core focused; #1193 carries the remaining criterion.
