### PR TITLE
feat(ha): visible-only default on the enumeration tools

### DIFF
--- a/internal/runtime/agent/gpt_oss_toolcall_test.go
+++ b/internal/runtime/agent/gpt_oss_toolcall_test.go
@@ -44,7 +44,7 @@ func (m *rawTextMockLLM) ChatStream(_ context.Context, model string, msgs []llm.
 func (m *rawTextMockLLM) Ping(_ context.Context) error { return nil }
 
 func buildTestLoopWithClient(client llm.Client, extraNames []string, model string) *Loop {
-	reg := tools.NewRegistry(nil, nil)
+	reg := tools.NewRegistry(nil, nil, nil)
 	for _, name := range extraNames {
 		n := name
 		reg.Register(&tools.Tool{

--- a/internal/runtime/agent/history_messages_test.go
+++ b/internal/runtime/agent/history_messages_test.go
@@ -132,7 +132,7 @@ func TestRun_SendsStoredHistoryAsMessages(t *testing.T) {
 		logger: slog.Default(),
 		memory: mem,
 		llm:    mock,
-		tools:  tools.NewRegistry(nil, nil),
+		tools:  tools.NewRegistry(nil, nil, nil),
 		model:  "test-model",
 	}
 
@@ -183,7 +183,7 @@ func TestRun_UsesConfiguredClockForStoredHistoryAgeLabels(t *testing.T) {
 		logger:  slog.Default(),
 		memory:  mem,
 		llm:     mock,
-		tools:   tools.NewRegistry(nil, nil),
+		tools:   tools.NewRegistry(nil, nil, nil),
 		model:   "test-model",
 		nowFunc: func() time.Time { return now },
 	}

--- a/internal/runtime/agent/loop.go
+++ b/internal/runtime/agent/loop.go
@@ -384,7 +384,7 @@ func NewLoop(opts LoopOptions) (*Loop, error) {
 		compactor:           opts.Compactor,
 		router:              opts.Router,
 		llm:                 opts.LLM,
-		tools:               tools.NewRegistry(opts.HomeAssistant, opts.Scheduler),
+		tools:               tools.NewRegistry(opts.HomeAssistant, opts.Scheduler, opts.Logger),
 		model:               opts.Model,
 		parsedTalents:       opts.ParsedTalents,
 		persona:             opts.Persona,

--- a/internal/runtime/agent/orchestrator_tools_test.go
+++ b/internal/runtime/agent/orchestrator_tools_test.go
@@ -92,7 +92,7 @@ func hasName(names []string, target string) bool {
 // built-in tools plus the given additional tool names. Tools are no-ops;
 // only their names matter for gating tests.
 func buildTestLoop(mock *mockLLM, extraNames []string) *Loop {
-	reg := tools.NewRegistry(nil, nil)
+	reg := tools.NewRegistry(nil, nil, nil)
 	for _, name := range extraNames {
 		n := name // capture
 		reg.Register(&tools.Tool{

--- a/internal/runtime/agent/request_overrides_test.go
+++ b/internal/runtime/agent/request_overrides_test.go
@@ -289,7 +289,7 @@ func TestToolTimeout_CancelsToolExecution(t *testing.T) {
 	}
 
 	timeoutCh := make(chan error, 1)
-	reg := tools.NewRegistry(nil, nil)
+	reg := tools.NewRegistry(nil, nil, nil)
 	reg.Register(&tools.Tool{
 		Name:        "slow_tool",
 		Description: "slow tool",

--- a/internal/tools/ha_automation_tools_test.go
+++ b/internal/tools/ha_automation_tools_test.go
@@ -87,7 +87,7 @@ func (f *fakeHAServer) registry(t *testing.T) *Registry {
 	}
 	t.Cleanup(func() { _ = ws.Close() })
 
-	return NewRegistry(client, nil)
+	return NewRegistry(client, nil, nil)
 }
 
 func (f *fakeHAServer) handleServicesCatalog(w http.ResponseWriter, r *http.Request) {

--- a/internal/tools/ha_entity_metadata.go
+++ b/internal/tools/ha_entity_metadata.go
@@ -20,21 +20,83 @@ type haEntityMetadataBundle struct {
 }
 
 type haListEntitiesResult struct {
-	Domain    string             `json:"domain,omitempty"`
-	Pattern   string             `json:"pattern,omitempty"`
-	Count     int                `json:"count"`
-	Total     int                `json:"total"`
-	Truncated bool               `json:"truncated,omitempty"`
-	Items     []haListEntityItem `json:"items"`
+	Domain    string `json:"domain,omitempty"`
+	Pattern   string `json:"pattern,omitempty"`
+	Count     int    `json:"count"`
+	Total     int    `json:"total"`
+	Truncated bool   `json:"truncated,omitempty"`
+	// HiddenExcluded counts entities dropped from this result because
+	// the operator hid them (registry hidden_by). It advertises their
+	// existence so the model knows more is inspectable via include_hidden
+	// or an explicit read — the count is never silently zero-filled.
+	HiddenExcluded int                `json:"hidden_excluded,omitempty"`
+	Items          []haListEntityItem `json:"items"`
 }
 
 type haListEntityItem struct {
-	EntityID     string                        `json:"entity_id"`
-	FriendlyName string                        `json:"friendly_name,omitempty"`
-	State        string                        `json:"state"`
-	Since        string                        `json:"since,omitempty"`
-	Updated      string                        `json:"updated,omitempty"`
-	Metadata     *homeassistant.EntityMetadata `json:"metadata,omitempty"`
+	EntityID     string `json:"entity_id"`
+	FriendlyName string `json:"friendly_name,omitempty"`
+	State        string `json:"state"`
+	Since        string `json:"since,omitempty"`
+	Updated      string `json:"updated,omitempty"`
+	// Hidden is set when the operator has hidden this entity from HA's
+	// generated surfaces (registry hidden_by). It is only populated on
+	// a result that surfaced a hidden entity via include_hidden, so the
+	// model can see the entity is off the default view — never silently
+	// blended in with visible ones.
+	Hidden   bool                          `json:"hidden,omitempty"`
+	Metadata *homeassistant.EntityMetadata `json:"metadata,omitempty"`
+}
+
+// isEntityHidden reports whether a registry entry marks the entity
+// hidden (hidden_by set). A nil entry — an entity with no registry row —
+// is treated as visible: hidden is an explicit operator action, not a
+// default.
+func isEntityHidden(entry *homeassistant.EntityRegistryEntry) bool {
+	return entry != nil && entry.HiddenBy != ""
+}
+
+// filterHiddenStates partitions candidate states by the operator's HA
+// Visible flag, mirroring HA's own generated-surface behavior. When
+// includeHidden is false, hidden entities are dropped and counted — the
+// count is advertised so their existence is never silent, and the model
+// can reach for an explicit read (ha_get_state, ha_device) to see them.
+// When true, all pass and the caller marks the hidden ones. entries is
+// the registry snapshot keyed by entity_id; a nil map (registry
+// unavailable) leaves every candidate visible rather than hiding the
+// whole world on a transient failure.
+func filterHiddenStates(candidates []homeassistant.State, entries map[string]*homeassistant.EntityRegistryEntry, includeHidden bool) (kept []homeassistant.State, hiddenCount int) {
+	if includeHidden || entries == nil {
+		return candidates, 0
+	}
+	kept = candidates[:0]
+	for _, s := range candidates {
+		if isEntityHidden(entries[s.EntityID]) {
+			hiddenCount++
+			continue
+		}
+		kept = append(kept, s)
+	}
+	return kept, hiddenCount
+}
+
+// entityRegistryByID fetches the full entity registry as a lookup map,
+// for visibility filtering independent of any metadata projection. The
+// registry is TTL-cached, so this shares the fetch with a metadata
+// bundle built in the same turn.
+func entityRegistryByID(ctx context.Context, ha *homeassistant.Client) (map[string]*homeassistant.EntityRegistryEntry, error) {
+	if ha == nil {
+		return nil, nil
+	}
+	entries, err := ha.GetEntityRegistry(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("get entity registry: %w", err)
+	}
+	byID := make(map[string]*homeassistant.EntityRegistryEntry, len(entries))
+	for i := range entries {
+		byID[entries[i].EntityID] = &entries[i]
+	}
+	return byID, nil
 }
 
 // haRecencyDelta returns the delta-formatted recency signals for an entity

--- a/internal/tools/ha_entity_metadata_test.go
+++ b/internal/tools/ha_entity_metadata_test.go
@@ -211,9 +211,13 @@ func TestHAListEntitiesMetadataHydratesOnlyReturnedEntities(t *testing.T) {
 	}
 
 	reg := fake.registry(t)
+	// include_hidden so the hidden temperature sensor stays in scope —
+	// this test is about metadata hydration over the page, not the
+	// visibility default (covered separately).
 	result, err := reg.Execute(context.Background(), "ha_list_entities", `{
 		"domain": "sensor",
 		"limit": 2,
+		"include_hidden": true,
 		"include": {"description": true, "visibility": true}
 	}`)
 	if err != nil {
@@ -247,11 +251,16 @@ func TestHAListEntitiesMetadataHydratesOnlyReturnedEntities(t *testing.T) {
 	entityGetCalls := fake.wsCalls["config/entity_registry/get"]
 	entityListCalls := fake.wsCalls["config/entity_registry/list"]
 	fake.mu.Unlock()
+	// Metadata hydration stays page-scoped: only the 2 returned rows get
+	// a per-entity registry fetch, not all 3 candidates.
 	if entityGetCalls != 2 {
-		t.Fatalf("entity registry get calls = %d, want 2", entityGetCalls)
+		t.Fatalf("entity registry get calls = %d, want 2 (metadata hydrates only the returned page)", entityGetCalls)
 	}
-	if entityListCalls != 0 {
-		t.Fatalf("entity registry list calls = %d, want 0", entityListCalls)
+	// Visibility filtering reads the bulk registry once (#1185, accepted
+	// cost — the registry is TTL-cached). It is the only bulk list call;
+	// metadata still hydrates per-returned-row above.
+	if entityListCalls != 1 {
+		t.Fatalf("entity registry list calls = %d, want 1 (visibility read)", entityListCalls)
 	}
 }
 

--- a/internal/tools/ha_search_states.go
+++ b/internal/tools/ha_search_states.go
@@ -198,11 +198,13 @@ func (r *Registry) handleSearchStates(ctx context.Context, args map[string]any) 
 	visEntries := map[string]*homeassistant.EntityRegistryEntry(nil)
 	if bundle != nil {
 		visEntries = bundle.entries
+	} else if entries, regErr := entityRegistryByID(ctx, r.ha); regErr != nil {
+		// Fail open: without visibility info, keep the search usable and
+		// show everything rather than erroring. filterHiddenStates treats
+		// a nil map as "no visibility info, no filtering."
+		r.logger.Warn("ha_search_states: visibility filter degraded; entity registry unavailable", "error", regErr)
 	} else {
-		visEntries, err = entityRegistryByID(ctx, r.ha)
-		if err != nil {
-			return "", err
-		}
+		visEntries = entries
 	}
 	var hiddenExcluded int
 	candidates, hiddenExcluded = filterHiddenStates(candidates, visEntries, includeHidden)

--- a/internal/tools/ha_search_states.go
+++ b/internal/tools/ha_search_states.go
@@ -28,11 +28,15 @@ var haSearchStateComparisons = map[string]func(a, b float64) bool{
 }
 
 type haSearchStatesResult struct {
-	Count     int                  `json:"count"`
-	Total     int                  `json:"total"`
-	Truncated bool                 `json:"truncated,omitempty"`
-	Filters   haSearchStateFilters `json:"filters"`
-	Items     []haListEntityItem   `json:"items"`
+	Count     int  `json:"count"`
+	Total     int  `json:"total"`
+	Truncated bool `json:"truncated,omitempty"`
+	// HiddenExcluded counts hidden entities dropped from this result
+	// (registry hidden_by); advertised so their existence is never
+	// silent. Pass include_hidden to surface them (marked).
+	HiddenExcluded int                  `json:"hidden_excluded,omitempty"`
+	Filters        haSearchStateFilters `json:"filters"`
+	Items          []haListEntityItem   `json:"items"`
 }
 
 // haSearchStateFilters echoes the resolved filter set back to the model
@@ -106,6 +110,10 @@ func (r *Registry) registerHASearchStates() {
 					"type":        "integer",
 					"description": "Maximum matches to return (default 20, max 100).",
 				},
+				"include_hidden": map[string]any{
+					"type":        "boolean",
+					"description": "By default, entities the operator hid from Home Assistant's dashboards (registry hidden_by) are excluded, and their count is reported as hidden_excluded. Set true to include them (each marked hidden). Hidden entities are usually diagnostics/config an operator curated away — respect that default unless you specifically need them.",
+				},
 				"include": EntityMetadataIncludeParameter(),
 			},
 		},
@@ -125,6 +133,7 @@ func (r *Registry) handleSearchStates(ctx context.Context, args map[string]any) 
 	if err != nil {
 		return "", err
 	}
+	includeHidden, _ := args["include_hidden"].(bool)
 
 	states, err := r.ha.GetStates(ctx)
 	if err != nil {
@@ -181,6 +190,23 @@ func (r *Registry) handleSearchStates(ctx context.Context, args map[string]any) 
 		candidates = filtered
 	}
 
+	// Visibility filter (pre-limit, so a page never comes back
+	// half-empty after hidden entities are dropped). Discovery defaults
+	// to the operator's Visible set; include_hidden opts in and marks
+	// what it surfaces. Reuse the area bundle's registry snapshot when
+	// present, else fetch it — the registry is TTL-cached (#1185).
+	visEntries := map[string]*homeassistant.EntityRegistryEntry(nil)
+	if bundle != nil {
+		visEntries = bundle.entries
+	} else {
+		visEntries, err = entityRegistryByID(ctx, r.ha)
+		if err != nil {
+			return "", err
+		}
+	}
+	var hiddenExcluded int
+	candidates, hiddenExcluded = filterHiddenStates(candidates, visEntries, includeHidden)
+
 	total := len(candidates)
 	if len(candidates) > q.limit {
 		candidates = candidates[:q.limit]
@@ -208,6 +234,9 @@ func (r *Registry) handleSearchStates(ctx context.Context, args map[string]any) 
 		if friendly, ok := s.Attributes["friendly_name"].(string); ok {
 			item.FriendlyName = friendly
 		}
+		if includeHidden {
+			item.Hidden = isEntityHidden(visEntries[s.EntityID])
+		}
 		// Render output metadata using the CALLER's include (not the
 		// working set the area filter may have widened), so an area
 		// filter doesn't leak area metadata the caller didn't request.
@@ -218,11 +247,12 @@ func (r *Registry) handleSearchStates(ctx context.Context, args map[string]any) 
 	}
 
 	result := haSearchStatesResult{
-		Count:     len(items),
-		Total:     total,
-		Truncated: total > len(items),
-		Filters:   q.filters(),
-		Items:     items,
+		Count:          len(items),
+		Total:          total,
+		Truncated:      total > len(items),
+		HiddenExcluded: hiddenExcluded,
+		Filters:        q.filters(),
+		Items:          items,
 	}
 	return toIndentedJSONWithTruncationNote(result, haSearchStatesTruncationNote), nil
 }

--- a/internal/tools/ha_search_states.go
+++ b/internal/tools/ha_search_states.go
@@ -202,7 +202,7 @@ func (r *Registry) handleSearchStates(ctx context.Context, args map[string]any) 
 		// Fail open: without visibility info, keep the search usable and
 		// show everything rather than erroring. filterHiddenStates treats
 		// a nil map as "no visibility info, no filtering."
-		r.logger.Warn("ha_search_states: visibility filter degraded; entity registry unavailable", "error", regErr)
+		r.log().Warn("ha_search_states: visibility filter degraded; entity registry unavailable", "error", regErr)
 	} else {
 		visEntries = entries
 	}

--- a/internal/tools/ha_visibility_test.go
+++ b/internal/tools/ha_visibility_test.go
@@ -1,0 +1,106 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/nugget/thane-ai-agent/internal/integrations/homeassistant"
+)
+
+// visibilityFixture seeds three lights, one hidden by the operator.
+func visibilityFixture(t *testing.T) *fakeHAServer {
+	t.Helper()
+	fake := newFakeHAServer(t)
+	fake.states = []homeassistant.State{
+		{EntityID: "light.office_main", State: "on", Attributes: map[string]any{"friendly_name": "Office Main"}},
+		{EntityID: "light.office_debug", State: "off", Attributes: map[string]any{"friendly_name": "Office Debug"}},
+		{EntityID: "light.hall", State: "on", Attributes: map[string]any{"friendly_name": "Hall"}},
+	}
+	fake.entityRows = []map[string]any{
+		{"entity_id": "light.office_main"},
+		{"entity_id": "light.office_debug", "hidden_by": "user"},
+		{"entity_id": "light.hall"},
+	}
+	return fake
+}
+
+func TestHAListEntities_DefaultExcludesHiddenAndAdvertisesCount(t *testing.T) {
+	reg := visibilityFixture(t).registry(t)
+	raw, err := reg.Execute(context.Background(), "ha_list_entities", `{"domain":"light"}`)
+	if err != nil {
+		t.Fatalf("ha_list_entities: %v", err)
+	}
+	var got haListEntitiesResult
+	if err := json.Unmarshal([]byte(raw), &got); err != nil {
+		t.Fatalf("unmarshal: %v\n%s", err, raw)
+	}
+	if got.Count != 2 || got.Total != 2 {
+		t.Fatalf("count/total = %d/%d, want 2/2 (hidden excluded)", got.Count, got.Total)
+	}
+	if got.HiddenExcluded != 1 {
+		t.Errorf("hidden_excluded = %d, want 1 (existence advertised, never silent)", got.HiddenExcluded)
+	}
+	if strings.Contains(raw, "office_debug") {
+		t.Errorf("hidden entity leaked into the default view:\n%s", raw)
+	}
+}
+
+func TestHAListEntities_IncludeHiddenSurfacesAndMarks(t *testing.T) {
+	reg := visibilityFixture(t).registry(t)
+	raw, err := reg.Execute(context.Background(), "ha_list_entities", `{"domain":"light","include_hidden":true}`)
+	if err != nil {
+		t.Fatalf("ha_list_entities: %v", err)
+	}
+	var got haListEntitiesResult
+	if err := json.Unmarshal([]byte(raw), &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got.Count != 3 || got.HiddenExcluded != 0 {
+		t.Fatalf("count/hidden_excluded = %d/%d, want 3/0", got.Count, got.HiddenExcluded)
+	}
+	var hiddenMarked bool
+	for _, it := range got.Items {
+		if it.EntityID == "light.office_debug" {
+			hiddenMarked = it.Hidden
+		} else if it.Hidden {
+			t.Errorf("visible entity %s marked hidden", it.EntityID)
+		}
+	}
+	if !hiddenMarked {
+		t.Error("hidden entity surfaced via include_hidden must be marked hidden, never silently blended in")
+	}
+}
+
+func TestHASearchStates_DefaultExcludesHidden(t *testing.T) {
+	reg := visibilityFixture(t).registry(t)
+	// Default: hidden excluded, count advertised.
+	raw, err := reg.Execute(context.Background(), "ha_search_states", `{"domain":"light","state":["on","off"]}`)
+	if err != nil {
+		t.Fatalf("ha_search_states: %v", err)
+	}
+	var got haSearchStatesResult
+	if err := json.Unmarshal([]byte(raw), &got); err != nil {
+		t.Fatalf("unmarshal: %v\n%s", err, raw)
+	}
+	if got.Count != 2 || got.HiddenExcluded != 1 {
+		t.Fatalf("count/hidden_excluded = %d/%d, want 2/1", got.Count, got.HiddenExcluded)
+	}
+	if strings.Contains(raw, "office_debug") {
+		t.Errorf("hidden entity leaked:\n%s", raw)
+	}
+
+	// include_hidden surfaces and marks it.
+	raw2, err := reg.Execute(context.Background(), "ha_search_states", `{"domain":"light","state":["on","off"],"include_hidden":true}`)
+	if err != nil {
+		t.Fatalf("include_hidden: %v", err)
+	}
+	var got2 haSearchStatesResult
+	if err := json.Unmarshal([]byte(raw2), &got2); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got2.Count != 3 || got2.HiddenExcluded != 0 {
+		t.Errorf("include_hidden count/excluded = %d/%d, want 3/0", got2.Count, got2.HiddenExcluded)
+	}
+}

--- a/internal/tools/ha_visibility_test.go
+++ b/internal/tools/ha_visibility_test.go
@@ -104,3 +104,17 @@ func TestHASearchStates_DefaultExcludesHidden(t *testing.T) {
 		t.Errorf("include_hidden count/excluded = %d/%d, want 3/0", got2.Count, got2.HiddenExcluded)
 	}
 }
+
+func TestFilterHiddenStates_FailsOpenOnNilRegistry(t *testing.T) {
+	// A nil entries map models an unavailable registry: visibility
+	// filtering fails open (everything visible, nothing marked), so a
+	// transient registry error never hides the world (PR #1194 review).
+	states := []homeassistant.State{
+		{EntityID: "light.a", State: "on"},
+		{EntityID: "light.b", State: "off"},
+	}
+	kept, hidden := filterHiddenStates(states, nil, false)
+	if len(kept) != 2 || hidden != 0 {
+		t.Fatalf("nil registry: kept=%d hidden=%d, want 2/0 (fail open)", len(kept), hidden)
+	}
+}

--- a/internal/tools/session_tools_test.go
+++ b/internal/tools/session_tools_test.go
@@ -75,7 +75,7 @@ func TestSessionClose_CarryForwardAlias(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			mgr := &mockSessionManager{}
-			reg := NewRegistry(nil, nil)
+			reg := NewRegistry(nil, nil, nil)
 			reg.SetSessionManager(mgr)
 
 			tool := reg.Get("session_close")
@@ -120,7 +120,7 @@ func TestSessionClose_HonestResponse(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			mgr := &mockSessionManager{}
-			reg := NewRegistry(nil, nil)
+			reg := NewRegistry(nil, nil, nil)
 			reg.SetSessionManager(mgr)
 
 			tool := reg.Get("session_close")

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -6,6 +6,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"sort"
 	"strings"
 	"time"
@@ -60,6 +61,7 @@ type Registry struct {
 	tagIndex           map[string][]string // tag → tool names
 	ha                 *homeassistant.Client
 	scheduler          *scheduler.Scheduler
+	logger             *slog.Logger
 	factTools          *knowledge.Tools
 	contactTools       *contacts.Tools
 	emailTools         *email.Tools
@@ -112,11 +114,19 @@ func NewEmptyRegistry() *Registry {
 }
 
 // NewRegistry creates a tool registry with HA integration.
-func NewRegistry(ha *homeassistant.Client, sched *scheduler.Scheduler) *Registry {
+// NewRegistry builds the native tool registry. logger is the
+// subsystem/loop logger tool handlers emit to (degraded-path warnings,
+// etc.); pass nil in tests or contexts without one and it falls back to
+// [slog.Default].
+func NewRegistry(ha *homeassistant.Client, sched *scheduler.Scheduler, logger *slog.Logger) *Registry {
+	if logger == nil {
+		logger = slog.Default()
+	}
 	r := &Registry{
 		tools:     make(map[string]*Tool),
 		ha:        ha,
 		scheduler: sched,
+		logger:    logger,
 	}
 	r.registerBuiltins()
 	r.registerFindEntity()     // Smart entity discovery
@@ -1363,10 +1373,13 @@ func (r *Registry) handleListEntities(ctx context.Context, args map[string]any) 
 
 	// Visibility needs the registry snapshot before the limit so hidden
 	// entities are dropped (or marked) up front rather than padding the
-	// page. Registry is TTL-cached (#1185).
-	visEntries, err := entityRegistryByID(ctx, r.ha)
-	if err != nil {
-		return "", err
+	// page. Registry is TTL-cached (#1185). Fail open on a registry
+	// error: keep enumeration usable and show everything (nil map =
+	// "no visibility info, no filtering") rather than erroring the tool.
+	visEntries, regErr := entityRegistryByID(ctx, r.ha)
+	if regErr != nil {
+		r.logger.Warn("ha_list_entities: visibility filter degraded; entity registry unavailable", "error", regErr)
+		visEntries = nil
 	}
 
 	var matches []haListEntityItem

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -751,6 +751,10 @@ func (r *Registry) registerBuiltins() {
 					"type":        "integer",
 					"description": "Maximum number of entities to return (default 20, max 100)",
 				},
+				"include_hidden": map[string]any{
+					"type":        "boolean",
+					"description": "By default, operator-hidden entities (registry hidden_by) are excluded and their count reported as hidden_excluded. Set true to include them, each marked hidden.",
+				},
 				"include": EntityMetadataIncludeParameter(),
 			},
 			// Encode the handler's "at least one of domain or pattern"
@@ -1350,8 +1354,17 @@ func (r *Registry) handleListEntities(ctx context.Context, args map[string]any) 
 	if err != nil {
 		return "", err
 	}
+	includeHidden, _ := args["include_hidden"].(bool)
 
 	states, err := r.ha.GetStates(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	// Visibility needs the registry snapshot before the limit so hidden
+	// entities are dropped (or marked) up front rather than padding the
+	// page. Registry is TTL-cached (#1185).
+	visEntries, err := entityRegistryByID(ctx, r.ha)
 	if err != nil {
 		return "", err
 	}
@@ -1360,6 +1373,7 @@ func (r *Registry) handleListEntities(ctx context.Context, args map[string]any) 
 	var matchEntityIDs []string
 	var matchStates []homeassistant.State
 	total := 0
+	hiddenExcluded := 0
 	now := time.Now()
 	prefix := ""
 	if domain != "" {
@@ -1374,6 +1388,10 @@ func (r *Registry) handleListEntities(ctx context.Context, args map[string]any) 
 				continue
 			}
 		}
+		if !includeHidden && isEntityHidden(visEntries[s.EntityID]) {
+			hiddenExcluded++
+			continue
+		}
 		total++
 		if len(matches) >= limit {
 			continue
@@ -1385,6 +1403,9 @@ func (r *Registry) handleListEntities(ctx context.Context, args map[string]any) 
 		item.Since, item.Updated = haRecencyDelta(s, now)
 		if friendly, ok := s.Attributes["friendly_name"].(string); ok {
 			item.FriendlyName = friendly
+		}
+		if includeHidden {
+			item.Hidden = isEntityHidden(visEntries[s.EntityID])
 		}
 		matches = append(matches, item)
 		matchEntityIDs = append(matchEntityIDs, s.EntityID)
@@ -1401,12 +1422,13 @@ func (r *Registry) handleListEntities(ctx context.Context, args map[string]any) 
 	}
 
 	result := haListEntitiesResult{
-		Domain:    domain,
-		Pattern:   pattern,
-		Count:     len(matches),
-		Total:     total,
-		Truncated: total > len(matches),
-		Items:     matches,
+		Domain:         domain,
+		Pattern:        pattern,
+		Count:          len(matches),
+		Total:          total,
+		Truncated:      total > len(matches),
+		HiddenExcluded: hiddenExcluded,
+		Items:          matches,
 	}
 	return toIndentedJSONWithTruncationNote(result, haListEntitiesTruncationNote), nil
 }

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -138,6 +138,18 @@ func NewRegistry(ha *homeassistant.Client, sched *scheduler.Scheduler, logger *s
 	return r
 }
 
+// log returns the registry's logger, defaulting to [slog.Default] when
+// unset. Shallow-copy constructors (FilteredCopy, WithRuntimeTools,
+// FilterByTags, NewEmptyRegistry) may leave logger nil, so handlers use
+// this rather than r.logger directly — a degraded-path warning must
+// never itself panic.
+func (r *Registry) log() *slog.Logger {
+	if r.logger != nil {
+		return r.logger
+	}
+	return slog.Default()
+}
+
 // SetFactTools adds fact management tools to the registry.
 func (r *Registry) SetFactTools(ft *knowledge.Tools) {
 	r.factTools = ft
@@ -1000,6 +1012,7 @@ func (r *Registry) FilteredCopy(names []string) *Registry {
 		tools:           make(map[string]*Tool, len(names)),
 		contentResolver: r.contentResolver,
 		tagIndex:        r.tagIndex,
+		logger:          r.logger,
 	}
 	for _, name := range names {
 		if t := r.tools[name]; t != nil {
@@ -1020,6 +1033,7 @@ func (r *Registry) FilteredCopyExcluding(exclude []string) *Registry {
 		tools:           make(map[string]*Tool, len(r.tools)),
 		contentResolver: r.contentResolver,
 		tagIndex:        r.tagIndex,
+		logger:          r.logger,
 	}
 	for name, t := range r.tools {
 		if !skip[name] {
@@ -1041,6 +1055,7 @@ func (r *Registry) WithRuntimeTools(runtime []*Tool) *Registry {
 		tools:           make(map[string]*Tool, len(r.tools)+len(runtime)),
 		contentResolver: r.contentResolver,
 		tagIndex:        r.tagIndex,
+		logger:          r.logger,
 	}
 	for name, t := range r.tools {
 		filtered.tools[name] = t
@@ -1080,6 +1095,7 @@ func (r *Registry) WithDynamicTools(extra []*Tool, tagAdditions map[string][]str
 	filtered := &Registry{
 		tools:           make(map[string]*Tool, len(r.tools)+len(extra)),
 		contentResolver: r.contentResolver,
+		logger:          r.logger,
 	}
 	for name, t := range r.tools {
 		filtered.tools[name] = t
@@ -1174,6 +1190,7 @@ func (r *Registry) FilterByTags(tags []string) *Registry {
 			tools:           make(map[string]*Tool, len(r.tools)),
 			contentResolver: r.contentResolver,
 			tagIndex:        r.tagIndex,
+			logger:          r.logger,
 		}
 		for name, t := range r.tools {
 			filtered.tools[name] = t
@@ -1192,6 +1209,7 @@ func (r *Registry) FilterByTags(tags []string) *Registry {
 		tools:           make(map[string]*Tool, len(allowed)),
 		contentResolver: r.contentResolver,
 		tagIndex:        r.tagIndex,
+		logger:          r.logger,
 	}
 	for name, t := range r.tools {
 		if allowed[name] || t.Core {
@@ -1378,7 +1396,7 @@ func (r *Registry) handleListEntities(ctx context.Context, args map[string]any) 
 	// "no visibility info, no filtering") rather than erroring the tool.
 	visEntries, regErr := entityRegistryByID(ctx, r.ha)
 	if regErr != nil {
-		r.logger.Warn("ha_list_entities: visibility filter degraded; entity registry unavailable", "error", regErr)
+		r.log().Warn("ha_list_entities: visibility filter degraded; entity registry unavailable", "error", regErr)
 		visEntries = nil
 	}
 

--- a/internal/tools/usage_tools_test.go
+++ b/internal/tools/usage_tools_test.go
@@ -115,7 +115,7 @@ func TestParsePeriod_YesterdayBounds(t *testing.T) {
 
 func TestCostSummaryTool_Registration(t *testing.T) {
 	store := testUsageStore(t)
-	reg := NewRegistry(nil, nil)
+	reg := NewRegistry(nil, nil, nil)
 	reg.SetUsageStore(store)
 
 	tool := reg.Get("cost_summary")
@@ -129,7 +129,7 @@ func TestCostSummaryTool_Registration(t *testing.T) {
 
 func TestCostSummaryTool_EmptyStore(t *testing.T) {
 	store := testUsageStore(t)
-	reg := NewRegistry(nil, nil)
+	reg := NewRegistry(nil, nil, nil)
 	reg.SetUsageStore(store)
 
 	tool := reg.Get("cost_summary")
@@ -167,7 +167,7 @@ func TestCostSummaryTool_WithData(t *testing.T) {
 		}
 	}
 
-	reg := NewRegistry(nil, nil)
+	reg := NewRegistry(nil, nil, nil)
 	reg.SetUsageStore(store)
 
 	tool := reg.Get("cost_summary")
@@ -205,7 +205,7 @@ func TestCostSummaryTool_GroupBy(t *testing.T) {
 		}
 	}
 
-	reg := NewRegistry(nil, nil)
+	reg := NewRegistry(nil, nil, nil)
 	reg.SetUsageStore(store)
 
 	tool := reg.Get("cost_summary")
@@ -256,7 +256,7 @@ func TestCostSummaryTool_GroupBy_NormalizesInput(t *testing.T) {
 		t.Fatalf("Record: %v", err)
 	}
 
-	reg := NewRegistry(nil, nil)
+	reg := NewRegistry(nil, nil, nil)
 	reg.SetUsageStore(store)
 
 	tool := reg.Get("cost_summary")
@@ -274,7 +274,7 @@ func TestCostSummaryTool_GroupBy_NormalizesInput(t *testing.T) {
 
 func TestCostSummaryTool_GroupBy_InvalidValue(t *testing.T) {
 	store := testUsageStore(t)
-	reg := NewRegistry(nil, nil)
+	reg := NewRegistry(nil, nil, nil)
 	reg.SetUsageStore(store)
 
 	tool := reg.Get("cost_summary")
@@ -307,7 +307,7 @@ func TestCostSummaryTool_GroupBy_WhitespaceMeansUngrouped(t *testing.T) {
 		t.Fatalf("Record: %v", err)
 	}
 
-	reg := NewRegistry(nil, nil)
+	reg := NewRegistry(nil, nil, nil)
 	reg.SetUsageStore(store)
 
 	tool := reg.Get("cost_summary")
@@ -338,7 +338,7 @@ func TestCostSummaryTool_GroupByOrdering(t *testing.T) {
 		}
 	}
 
-	reg := NewRegistry(nil, nil)
+	reg := NewRegistry(nil, nil, nil)
 	reg.SetUsageStore(store)
 
 	tool := reg.Get("cost_summary")
@@ -362,7 +362,7 @@ func TestCostSummaryTool_GroupByOrdering(t *testing.T) {
 }
 
 func TestSetUsageStore_NilStore(t *testing.T) {
-	reg := NewRegistry(nil, nil)
+	reg := NewRegistry(nil, nil, nil)
 	reg.SetUsageStore(nil)
 
 	tool := reg.Get("cost_summary")

--- a/talents/ha.md
+++ b/talents/ha.md
@@ -165,6 +165,17 @@ threshold questions. This is the right reach instead of fanning out
 many `ha_get_state` calls or listing a whole domain and eyeballing it.
 Add `include` for area/device/label/visibility metadata on each match.
 
+**Hidden entities.** `ha_search_states` and `ha_list_entities` default
+to the entities the operator lets Home Assistant show — hidden ones
+(the diagnostics and config an operator curated off their dashboards)
+are excluded, and their count comes back as `hidden_excluded` so you
+know they exist. Respect that default: hidden is operator intent, not
+an obstacle. When you specifically need them — a device's power draw,
+a diagnostic sensor — pass `include_hidden: true` (each returned hidden
+entity is marked `hidden`), or read the one entity directly with
+`ha_get_state`, or inspect the whole device with `ha_device`, which
+shows everything a device exposes the way HA's device page does.
+
 ## Enumerate a domain or name pattern
 
 `ha_list_entities` enumerates by domain:


### PR DESCRIPTION
## Summary

First half of #1185 from the #1175 umbrella. Home Assistant's entity **Visible** toggle is the operator's declared boundary for assistants — hidden entities are excluded from HA's own generated dashboards (and from HomeKit/Alexa/Google, and from area-targeted service calls). Thane is exactly the consumer that flag exists to govern, but its discovery tools ignored it: `ha_search_states` and `ha_list_entities` returned hidden entities as if the operator had never spoken. This makes visible-only the default on those two highest-traffic enumeration tools, with an explicit opt-in and — crucially — an advertised count so hidden entities are never *silently* dropped.

## Behavior

- **Discovery defaults to the operator's Visible set.** Both tools now exclude entities with registry `hidden_by` set, and report `hidden_excluded: N` so the model knows more exists and can reach for it. Never a silent drop.
- **`include_hidden: true`** surfaces them, each item marked `hidden: true` — never blended in with visible entities.
- **Filtering is pre-limit** so a page never comes back half-empty after hidden entities are dropped.
- **Registry-unavailable is fail-open**: a transient registry error leaves every candidate visible rather than hiding the whole world.

## The one real tradeoff (owner-decided)

Visible-only filtering needs each candidate's `hidden_by` before the limit, so `ha_search_states` now pulls the entity registry on every search — reversing its documented "defer the registry read, never pull the whole registry for one page" optimization. Per the owner's call, we **accept the cost**: the registry is TTL-cached (and the area-filter path already paid it), so the first search per TTL window pays a bulk read and the rest hit cache. The `ha_list_entities` metadata-hydration test that enforced the old zero-bulk-reads invariant is updated — metadata still hydrates only the returned page (2 per-entity gets), plus the one bulk visibility read.

## Scope

This PR does the two highest-traffic enumeration tools — the biggest MCP-displacement surfaces per #1002. The rest of #1185/#1186 (area/home snapshots, `entity_category` grouping, and `ha_device` as explicit-inspection showing hidden entities grouped Controls/Sensors/Configuration/Diagnostic — the device-page mirror we designed with the Inovelli example) is the follow-on, tracked in those issues. `ha_get_state` (explicit named read) is deliberately never filtered — naming an entity is intent.

## Test plan

- [x] Default excludes hidden + advertises `hidden_excluded` (both tools); hidden entity provably absent from output
- [x] `include_hidden: true` surfaces the hidden entity and marks it `hidden`, leaves visible ones unmarked
- [x] Metadata hydration stays page-scoped (per-entity gets) alongside the one bulk visibility read
- [x] `just ci` green locally (unpiped, verified)

Refs #1175, #1186. `ha_get_state`/`ha_device` explicit-inspection carve-out and the snapshot surfaces follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
