### PR TITLE
feat(ha): group ha_device by HA's four device-page groups

### DIFF
--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -122,7 +122,7 @@ becoming default context clutter.
 | `ha_list_entities` | Browse entities by domain and/or entity_id glob (e.g. `binary_sensor.*door*`), with optional HA metadata. |
 | `ha_search_states` | Predicate search across live entity state (state value, numeric attribute, domain, area). |
 | `get_area_activity` | Whole-area snapshot: floor context + entities grouped by salience + transition timeline + filtered counts, with optional per-entity metadata. |
-| `ha_device` | Whole-device snapshot: device identity (manufacturer/model/firmware/area/integration) + every child entity with semantic state grouped by salience + availability rollup, resolved by id or name, with optional per-entity metadata. |
+| `ha_device` | Whole-device snapshot: the full device-info card (manufacturer/model/firmware/serial/MAC connections/area/labels/integration) + every child entity grouped the way HA's device page groups them (controls/sensors/configuration/diagnostic), with hidden entities shown marked, per-group truncation counts, and an availability rollup; resolved by id or name, with optional per-entity metadata. |
 | `ha_history` | Recorder trend for one entity over a lookback window: numeric min/max/start/end/delta/trend or a discrete change summary, optionally trending a numeric attribute instead of the state. |
 | `ha_home_snapshot` | Curated whole-home overview: anomalies, security/openings, presence, climate (energy optional), salience-first with an at-a-glance summary and a quiet status, plus optional per-entity metadata. |
 | `ha_call_service` | Direct HA service invocation. |

--- a/internal/integrations/homeassistant/entity_metadata.go
+++ b/internal/integrations/homeassistant/entity_metadata.go
@@ -153,6 +153,13 @@ type EntityDeviceMetadata struct {
 	EntryType        string `json:"entry_type,omitempty"`
 	DisabledBy       string `json:"disabled_by,omitempty"`
 	ConfigurationURL string `json:"configuration_url,omitempty"`
+	// Connections and Labels complete the device-info card for surfaces
+	// that describe a device directly (the ha_device snapshot). They are
+	// populated by [EntityMetadataResolver.DeviceMetadata], not by the
+	// per-entity device sub-block, which stays lean. Connections maps the
+	// network-connection type to its value (e.g. {"mac": "aa:bb:.."}).
+	Connections map[string]string     `json:"connections,omitempty"`
+	Labels      []EntityLabelMetadata `json:"labels,omitempty"`
 }
 
 // EntityLabelMetadata is one resolved HA label with its source
@@ -425,15 +432,78 @@ func cloneIntPtr(src *int) *int {
 }
 
 // DeviceMetadata projects model-facing metadata for a single device —
-// identity, firmware, area, and the resolved area name. It exposes the
-// same device projection the per-entity resolver uses, for surfaces
-// (e.g. the ha_device snapshot) that describe a device directly rather
-// than an entity owned by it. Returns nil for a nil device.
+// identity, firmware, area, and the resolved area name — plus the full
+// device-info card (network connections and the device's own labels)
+// that a direct device view wants. It builds on the same lean projection
+// the per-entity resolver uses, then enriches it with the fields that
+// belong on a device page but would be noise repeated under every entity.
+// Returns nil for a nil device.
 func (r EntityMetadataResolver) DeviceMetadata(device *DeviceRegistryEntry) *EntityDeviceMetadata {
 	if device == nil {
 		return nil
 	}
-	return r.deviceMetadata(device)
+	out := r.deviceMetadata(device)
+	out.Connections = deviceConnections(device)
+	out.Labels = r.deviceLabels(device)
+	return out
+}
+
+// deviceConnections projects HA's connection tuples into a type→value
+// map (e.g. {"mac": "aa:bb:cc:.."}). HA stores connections as a set of
+// [type, value] pairs; a device typically carries at most one per type,
+// so a map gives the model named access ("the mac") over a list. Returns
+// nil when the device has no connections.
+func deviceConnections(device *DeviceRegistryEntry) map[string]string {
+	if len(device.Connections) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(device.Connections))
+	for _, pair := range device.Connections {
+		if len(pair) != 2 {
+			continue
+		}
+		kind, value := string(pair[0]), string(pair[1])
+		if kind == "" || value == "" {
+			continue
+		}
+		out[kind] = value
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// deviceLabels resolves a device's own labels to their registry names,
+// sorted by id for stable output. Returns nil when the device carries no
+// labels. Unlike labelsForEntity this is device-only — a device view's
+// labels are the device's, with no entity/area aggregation to attribute.
+func (r EntityMetadataResolver) deviceLabels(device *DeviceRegistryEntry) []EntityLabelMetadata {
+	if len(device.Labels) == 0 {
+		return nil
+	}
+	ids := make([]string, 0, len(device.Labels))
+	for _, id := range device.Labels {
+		if id != "" {
+			ids = append(ids, id)
+		}
+	}
+	if len(ids) == 0 {
+		return nil
+	}
+	sort.Strings(ids)
+	out := make([]EntityLabelMetadata, 0, len(ids))
+	for _, id := range ids {
+		label := EntityLabelMetadata{ID: id}
+		if registry := r.labelsByID[id]; registry != nil {
+			label.Name = registry.Name
+			label.Description = registry.Description
+			label.Icon = registry.Icon
+			label.Color = registry.Color
+		}
+		out = append(out, label)
+	}
+	return out
 }
 
 func (r EntityMetadataResolver) deviceMetadata(device *DeviceRegistryEntry) *EntityDeviceMetadata {

--- a/internal/integrations/homeassistant/entity_metadata_test.go
+++ b/internal/integrations/homeassistant/entity_metadata_test.go
@@ -275,3 +275,93 @@ func TestEntityMetadataResolverAppliesFloorAlias(t *testing.T) {
 		t.Fatalf("Building = %#v, want floor metadata exposed as building", got.Area.Building)
 	}
 }
+
+func TestDeviceMetadataDeviceInfoCard(t *testing.T) {
+	t.Parallel()
+
+	resolver := NewEntityMetadataResolver(
+		[]Area{{AreaID: "office", Name: "Office"}},
+		[]LabelRegistryEntry{
+			{LabelID: "label_critical", Name: "Critical", Color: "red"},
+			{LabelID: "label_zwave", Name: "Z-Wave"},
+		},
+		nil,
+	)
+
+	device := &DeviceRegistryEntry{
+		ID:           "device_1",
+		NameByUser:   "Office Overhead Lights",
+		Manufacturer: "Inovelli",
+		Model:        "VZM31-SN",
+		SWVersion:    "2.15",
+		SerialNumber: "0xA1B2C3",
+		AreaID:       "office",
+		Labels:       []string{"label_zwave", "label_critical"},
+		Connections:  [][]flexString{{"mac", "aa:bb:cc:dd:ee:ff"}, {"zigbee", "00:12:4b:00:1c"}},
+	}
+
+	got := resolver.DeviceMetadata(device)
+	if got == nil {
+		t.Fatal("DeviceMetadata returned nil")
+	}
+	// Pre-existing identity fields still project.
+	if got.Manufacturer != "Inovelli" || got.Model != "VZM31-SN" {
+		t.Errorf("vendor/model = %q/%q, want Inovelli/VZM31-SN", got.Manufacturer, got.Model)
+	}
+	if got.SWVersion != "2.15" || got.SerialNumber != "0xA1B2C3" {
+		t.Errorf("firmware/serial = %q/%q, want 2.15/0xA1B2C3", got.SWVersion, got.SerialNumber)
+	}
+	if got.AreaID != "office" || got.AreaName != "Office" {
+		t.Errorf("area = %q/%q, want office/Office", got.AreaID, got.AreaName)
+	}
+	// New: network connections (the MAC and friends), keyed by type.
+	if got.Connections["mac"] != "aa:bb:cc:dd:ee:ff" {
+		t.Errorf("connections.mac = %q, want the MAC", got.Connections["mac"])
+	}
+	if got.Connections["zigbee"] != "00:12:4b:00:1c" {
+		t.Errorf("connections.zigbee = %q, want the zigbee id", got.Connections["zigbee"])
+	}
+	// New: the device's own labels, resolved to names and sorted by id.
+	if len(got.Labels) != 2 {
+		t.Fatalf("labels = %#v, want 2", got.Labels)
+	}
+	if got.Labels[0].ID != "label_critical" || got.Labels[0].Name != "Critical" || got.Labels[0].Color != "red" {
+		t.Errorf("labels[0] = %#v, want Critical/red", got.Labels[0])
+	}
+	if got.Labels[1].ID != "label_zwave" || got.Labels[1].Name != "Z-Wave" {
+		t.Errorf("labels[1] = %#v, want Z-Wave", got.Labels[1])
+	}
+}
+
+func TestPerEntityDeviceSubBlockStaysLean(t *testing.T) {
+	t.Parallel()
+
+	// The device-info card (connections + labels) belongs on a direct
+	// device view, not repeated under every entity the device owns. The
+	// per-entity device sub-block must stay lean even with full includes.
+	resolver := NewEntityMetadataResolver(
+		[]Area{{AreaID: "office", Name: "Office"}},
+		[]LabelRegistryEntry{{LabelID: "label_zwave", Name: "Z-Wave"}},
+		[]DeviceRegistryEntry{{
+			ID:          "device_1",
+			NameByUser:  "Hub",
+			AreaID:      "office",
+			Labels:      []string{"label_zwave"},
+			Connections: [][]flexString{{"mac", "aa:bb:cc:dd:ee:ff"}},
+		}},
+	)
+
+	got := resolver.MetadataForEntity(&EntityRegistryEntry{
+		EntityID: "light.office",
+		DeviceID: "device_1",
+	}, &State{EntityID: "light.office", State: "on"}, AllEntityMetadataIncludes())
+	if got == nil || got.Device == nil {
+		t.Fatalf("MetadataForEntity returned %#v, want device sub-block", got)
+	}
+	if got.Device.Connections != nil {
+		t.Errorf("per-entity device.connections = %#v, want nil (card is device-view only)", got.Device.Connections)
+	}
+	if got.Device.Labels != nil {
+		t.Errorf("per-entity device.labels = %#v, want nil (card is device-view only)", got.Device.Labels)
+	}
+}

--- a/internal/state/awareness/device_snapshot.go
+++ b/internal/state/awareness/device_snapshot.go
@@ -195,11 +195,12 @@ func truncateGroup(group *[]map[string]any, limit int) int {
 }
 
 // buildDeviceResolver assembles the metadata resolver for the device
-// snapshot. Areas are always fetched so device identity can carry the
-// resolved area name; labels and floors are pulled only when the
-// include projection asks for them. devices is reused from the caller's
-// already-fetched device registry rather than re-fetched. Mirrors the
-// gated-fetch pattern in ComputeAreaActivity.
+// snapshot. Areas and labels are always fetched so the device's own
+// identity card can carry its resolved area name and label names by
+// default (a device view is where those belong); floors are pulled only
+// when the include projection asks for them. devices is reused from the
+// caller's already-fetched device registry rather than re-fetched.
+// Mirrors the gated-fetch pattern in ComputeAreaActivity.
 func buildDeviceResolver(
 	ctx context.Context,
 	client DeviceSnapshotClient,
@@ -210,12 +211,9 @@ func buildDeviceResolver(
 	if err != nil {
 		return homeassistant.EntityMetadataResolver{}, fmt.Errorf("ha_device: get areas: %w", err)
 	}
-	var labels []homeassistant.LabelRegistryEntry
-	if include.Labels {
-		labels, err = client.GetLabelRegistry(ctx)
-		if err != nil {
-			return homeassistant.EntityMetadataResolver{}, fmt.Errorf("ha_device: get labels: %w", err)
-		}
+	labels, err := client.GetLabelRegistry(ctx)
+	if err != nil {
+		return homeassistant.EntityMetadataResolver{}, fmt.Errorf("ha_device: get labels: %w", err)
 	}
 	var floors []homeassistant.FloorRegistryEntry
 	if include.Area {

--- a/internal/state/awareness/device_snapshot.go
+++ b/internal/state/awareness/device_snapshot.go
@@ -34,19 +34,20 @@ type DeviceSnapshotRequest struct {
 	Include homeassistant.EntityMetadataIncludes
 }
 
-// maxDeviceOtherEntities caps the least-salient ("other") bucket so a
-// device that exposes a long tail of config/diagnostic sensors can't
-// flood the prompt. Anomalies, active, and ambient buckets are
-// inherently small and stay uncapped; overflow on "other" is reported
-// via other_truncated_count. Mirrors area_activity's stable-bucket cap.
+// maxDeviceOtherEntities caps the Configuration and Diagnostic groups so
+// a device that exposes a long tail of tuning knobs and health counters
+// can't flood the prompt. Controls and Sensors are inherently small and
+// stay uncapped; overflow is reported via the per-group
+// *_truncated_count fields. Mirrors area_activity's stable-bucket cap.
 const maxDeviceOtherEntities = 15
 
 // ComputeDeviceSnapshot resolves a device, gathers its child entities +
-// states, buckets them by salience, and returns a single JSON object
-// describing the device for model consumption. The output leads with
-// device identity and an availability rollup, then the entities grouped
-// most-actionable-first (anomalies → active → ambient → other), matching
-// the model-facing-context conventions used by the area snapshot.
+// states, groups them the way Home Assistant's device page does, and
+// returns a single JSON object describing the device for model
+// consumption. The output leads with device identity and an availability
+// rollup, then the entities in HA's four device-page groups — Controls,
+// Sensors, Configuration, Diagnostic — so the model reads a device as its
+// whole instrument panel, the same structure a human sees in HA.
 func ComputeDeviceSnapshot(ctx context.Context, client DeviceSnapshotClient, req DeviceSnapshotRequest, now time.Time) (string, error) {
 	if client == nil {
 		return "", fmt.Errorf("ha_device: client is required")
@@ -147,34 +148,50 @@ func ComputeDeviceSnapshot(ctx context.Context, client DeviceSnapshotClient, req
 		payload["unavailable"] = cls.unavailable
 	}
 
-	otherTruncated := 0
-	if len(cls.other) > maxDeviceOtherEntities {
-		otherTruncated = len(cls.other) - maxDeviceOtherEntities
-		cls.other = cls.other[:maxDeviceOtherEntities]
-	}
+	// Configuration and Diagnostic are the noisy groups — a single
+	// Z-Wave device can expose dozens of tuning knobs and health
+	// counters. Cap them (with an honest per-group truncation count) so
+	// the instrument panel stays legible; Controls and Sensors are
+	// inherently small and stay uncapped.
+	configTruncated := truncateGroup(&cls.configuration, maxDeviceOtherEntities)
+	diagnosticTruncated := truncateGroup(&cls.diagnostic, maxDeviceOtherEntities)
 
 	if req.Include.Any() {
 		attachAreaEntityMetadata(resolver, req.Include, children, statesByID,
-			cls.anomalies, cls.active, cls.ambient, cls.other)
+			cls.controls, cls.sensors, cls.configuration, cls.diagnostic)
 	}
 
-	if len(cls.anomalies) > 0 {
-		payload["anomalies"] = cls.anomalies
+	if len(cls.controls) > 0 {
+		payload["controls"] = cls.controls
 	}
-	if len(cls.active) > 0 {
-		payload["active"] = cls.active
+	if len(cls.sensors) > 0 {
+		payload["sensors"] = cls.sensors
 	}
-	if len(cls.ambient) > 0 {
-		payload["ambient"] = cls.ambient
+	if len(cls.configuration) > 0 {
+		payload["configuration"] = cls.configuration
 	}
-	if len(cls.other) > 0 {
-		payload["other"] = cls.other
+	if configTruncated > 0 {
+		payload["configuration_truncated_count"] = configTruncated
 	}
-	if otherTruncated > 0 {
-		payload["other_truncated_count"] = otherTruncated
+	if len(cls.diagnostic) > 0 {
+		payload["diagnostic"] = cls.diagnostic
+	}
+	if diagnosticTruncated > 0 {
+		payload["diagnostic_truncated_count"] = diagnosticTruncated
 	}
 
 	return promptfmt.MarshalCompact(payload), nil
+}
+
+// truncateGroup caps a device group in place, returning how many entries
+// were dropped so the caller can advertise the overflow.
+func truncateGroup(group *[]map[string]any, limit int) int {
+	if len(*group) <= limit {
+		return 0
+	}
+	dropped := len(*group) - limit
+	*group = (*group)[:limit]
+	return dropped
 }
 
 // buildDeviceResolver assembles the metadata resolver for the device
@@ -214,57 +231,100 @@ func buildDeviceResolver(
 	return homeassistant.NewEntityMetadataResolverWithFloorAlias(areas, labels, devices, floors, floorAlias), nil
 }
 
-// deviceChildBuckets holds the salience-grouped render of a device's
-// child entities plus the availability rollup.
-type deviceChildBuckets struct {
-	anomalies   []map[string]any
-	active      []map[string]any
-	ambient     []map[string]any
-	other       []map[string]any
-	reporting   int      // children with a live, non-sentinel state
-	unavailable []string // entity_ids missing a state or in a sentinel state
+// deviceControlDomains are the entity domains Home Assistant treats as
+// device Controls — the actionable primaries. Uncategorized entities
+// outside this set are read-only Sensors. Config/diagnostic entities go
+// to their own groups regardless of domain (see [deviceGroupFor]).
+var deviceControlDomains = map[string]bool{
+	"light": true, "switch": true, "fan": true, "climate": true,
+	"cover": true, "lock": true, "media_player": true, "vacuum": true,
+	"number": true, "select": true, "button": true, "siren": true,
+	"valve": true, "humidifier": true, "water_heater": true,
+	"lawn_mower": true, "alarm_control_panel": true, "camera": true,
+	"remote": true, "text": true, "date": true, "time": true,
+	"datetime": true, "scene": true, "script": true, "automation": true,
+	"input_boolean": true, "input_number": true, "input_select": true,
+	"input_text": true, "input_datetime": true, "input_button": true,
+	"update": true,
 }
 
-// classifyDeviceChildren buckets a device's child entities by salience,
-// reusing the same per-entity render and classification predicates the
-// area snapshot uses so the two views stay consistent. Unlike the area
-// classifier there is no recent-changes window — a device view answers
-// "what does this device expose and is it healthy" rather than "what
-// happened in this room lately."
-func classifyDeviceChildren(children []areaMember, statesByID map[string]*homeassistant.State, now time.Time) deviceChildBuckets {
-	var b deviceChildBuckets
+// deviceGroupFor places an entity into one of Home Assistant's device-
+// page groups. Configuration and Diagnostic follow the registry's
+// entity_category; the uncategorized primaries split into Controls
+// (actionable domains) and Sensors (read-only) — the exact structure a
+// human sees on a device page.
+func deviceGroupFor(entry homeassistant.EntityRegistryEntry) string {
+	switch entry.EntityCategory {
+	case "config":
+		return "configuration"
+	case "diagnostic":
+		return "diagnostic"
+	}
+	if deviceControlDomains[entityDomain(entry.EntityID)] {
+		return "controls"
+	}
+	return "sensors"
+}
+
+// deviceChildGroups holds a device's child entities grouped the way HA's
+// device page groups them, plus the availability rollup. Controls and
+// Sensors are the primary affordances; Configuration and Diagnostic are
+// the categorized entities HA keeps off its generated dashboards but
+// shows on the device page — which is why a device view surfaces them.
+type deviceChildGroups struct {
+	controls      []map[string]any
+	sensors       []map[string]any
+	configuration []map[string]any
+	diagnostic    []map[string]any
+	reporting     int      // children with a live, non-sentinel state
+	unavailable   []string // entity_ids missing a state or in a sentinel state
+}
+
+// classifyDeviceChildren groups a device's child entities into HA's four
+// device-page groups, reusing the area snapshot's per-entity render so
+// the two views stay consistent. It mirrors the HA device page: every
+// entity the device exposes is shown (including hidden ones, marked, and
+// the config/diagnostic entities the generated dashboard omits), because
+// inspecting a device by name is explicit intent — you want its whole
+// instrument panel, not the curated subset.
+func classifyDeviceChildren(children []areaMember, statesByID map[string]*homeassistant.State, now time.Time) deviceChildGroups {
+	var g deviceChildGroups
 	for _, m := range children {
 		state := statesByID[m.entry.EntityID]
+		var rendered map[string]any
 		if state == nil {
-			b.anomalies = append(b.anomalies, map[string]any{
+			rendered = map[string]any{
 				"entity":    m.entry.EntityID,
 				"available": false,
 				"reason":    "no_state",
-			})
-			b.unavailable = append(b.unavailable, m.entry.EntityID)
-			continue
+			}
+			g.unavailable = append(g.unavailable, m.entry.EntityID)
+		} else {
+			rendered = renderEntityForArea(state, now)
+			if isSentinelState(state.State) {
+				g.unavailable = append(g.unavailable, m.entry.EntityID)
+			} else {
+				g.reporting++
+			}
 		}
-		rendered := renderEntityForArea(state, now)
-		switch {
-		case isSentinelState(state.State):
-			b.anomalies = append(b.anomalies, rendered)
-			b.unavailable = append(b.unavailable, m.entry.EntityID)
-		case isAlarmAnomaly(state, m.entry):
-			b.anomalies = append(b.anomalies, rendered)
-			b.reporting++
-		case isActive(state, m.entry):
-			b.active = append(b.active, rendered)
-			b.reporting++
-		case isAmbientNumeric(state, m.entry):
-			b.ambient = append(b.ambient, rendered)
-			b.reporting++
+		// Mark operator-hidden entities so the model can see this one is
+		// off HA's generated surfaces even though the device view shows it.
+		if m.entry.HiddenBy != "" {
+			rendered["hidden"] = true
+		}
+		switch deviceGroupFor(m.entry) {
+		case "controls":
+			g.controls = append(g.controls, rendered)
+		case "configuration":
+			g.configuration = append(g.configuration, rendered)
+		case "diagnostic":
+			g.diagnostic = append(g.diagnostic, rendered)
 		default:
-			b.other = append(b.other, rendered)
-			b.reporting++
+			g.sensors = append(g.sensors, rendered)
 		}
 	}
-	sort.Strings(b.unavailable)
-	return b
+	sort.Strings(g.unavailable)
+	return g
 }
 
 // resolveDevice matches a device by id, then by case-insensitive

--- a/internal/state/awareness/device_snapshot.go
+++ b/internal/state/awareness/device_snapshot.go
@@ -34,12 +34,12 @@ type DeviceSnapshotRequest struct {
 	Include homeassistant.EntityMetadataIncludes
 }
 
-// maxDeviceOtherEntities caps the Configuration and Diagnostic groups so
+// maxDeviceNoisyGroupEntities caps the Configuration and Diagnostic groups so
 // a device that exposes a long tail of tuning knobs and health counters
 // can't flood the prompt. Controls and Sensors are inherently small and
 // stay uncapped; overflow is reported via the per-group
 // *_truncated_count fields. Mirrors area_activity's stable-bucket cap.
-const maxDeviceOtherEntities = 15
+const maxDeviceNoisyGroupEntities = 15
 
 // ComputeDeviceSnapshot resolves a device, gathers its child entities +
 // states, groups them the way Home Assistant's device page does, and
@@ -153,8 +153,8 @@ func ComputeDeviceSnapshot(ctx context.Context, client DeviceSnapshotClient, req
 	// counters. Cap them (with an honest per-group truncation count) so
 	// the instrument panel stays legible; Controls and Sensors are
 	// inherently small and stay uncapped.
-	configTruncated := truncateGroup(&cls.configuration, maxDeviceOtherEntities)
-	diagnosticTruncated := truncateGroup(&cls.diagnostic, maxDeviceOtherEntities)
+	configTruncated := truncateGroup(&cls.configuration, maxDeviceNoisyGroupEntities)
+	diagnosticTruncated := truncateGroup(&cls.diagnostic, maxDeviceNoisyGroupEntities)
 
 	if req.Include.Any() {
 		attachAreaEntityMetadata(resolver, req.Include, children, statesByID,

--- a/internal/state/awareness/device_snapshot_test.go
+++ b/internal/state/awareness/device_snapshot_test.go
@@ -61,9 +61,12 @@ func mkState(id, state string, attrs map[string]any) *homeassistant.State {
 	return &homeassistant.State{EntityID: id, State: state, Attributes: attrs}
 }
 
-// thermostatClient builds a device with a rich, mixed-salience set of
-// child entities including one sentinel (unavailable) and one with no
-// state at all, for the multi-entity / availability tests.
+// thermostatClient builds a device whose children populate all four of
+// HA's device-page groups — a control (climate), read-only sensors, a
+// config entity (aux-heat switch, entity_category=config), and two
+// diagnostics (battery + signal, entity_category=diagnostic) — including
+// one sentinel (unavailable) and one with no state at all, for the
+// grouping / availability tests.
 func thermostatClient() *fakeDeviceClient {
 	return &fakeDeviceClient{
 		areas: []homeassistant.Area{{AreaID: "office", Name: "Office"}},
@@ -86,8 +89,11 @@ func thermostatClient() *fakeDeviceClient {
 			{EntityID: "sensor.thermostat_temp", DeviceID: "dev_thermo", DeviceClass: "temperature"},
 			{EntityID: "sensor.thermostat_humidity", DeviceID: "dev_thermo", DeviceClass: "humidity"},
 			{EntityID: "binary_sensor.thermostat_motion", DeviceID: "dev_thermo", DeviceClass: "motion"},
-			{EntityID: "sensor.thermostat_battery", DeviceID: "dev_thermo", DeviceClass: "battery"},
-			{EntityID: "sensor.thermostat_signal", DeviceID: "dev_thermo", DeviceClass: "signal_strength"},
+			// entity_category=config → a switch that would otherwise be a
+			// control lands in Configuration, proving category wins over domain.
+			{EntityID: "switch.thermostat_aux_heat", DeviceID: "dev_thermo", EntityCategory: "config"},
+			{EntityID: "sensor.thermostat_battery", DeviceID: "dev_thermo", DeviceClass: "battery", EntityCategory: "diagnostic"},
+			{EntityID: "sensor.thermostat_signal", DeviceID: "dev_thermo", DeviceClass: "signal_strength", EntityCategory: "diagnostic"},
 			// Belongs to a different device — must not appear.
 			{EntityID: "light.hall", DeviceID: "dev_other"},
 		},
@@ -96,6 +102,7 @@ func thermostatClient() *fakeDeviceClient {
 			"sensor.thermostat_temp":          mkState("sensor.thermostat_temp", "72", map[string]any{"device_class": "temperature"}),
 			"sensor.thermostat_humidity":      mkState("sensor.thermostat_humidity", "40", map[string]any{"device_class": "humidity"}),
 			"binary_sensor.thermostat_motion": mkState("binary_sensor.thermostat_motion", "off", map[string]any{"device_class": "motion"}),
+			"switch.thermostat_aux_heat":      mkState("switch.thermostat_aux_heat", "off", nil),
 			"sensor.thermostat_battery":       mkState("sensor.thermostat_battery", "unavailable", map[string]any{"device_class": "battery"}),
 			// sensor.thermostat_signal intentionally absent → no_state.
 			"light.hall": mkState("light.hall", "on", nil),
@@ -112,7 +119,10 @@ func decodeDevicePayload(t *testing.T, raw string) map[string]any {
 	return payload
 }
 
-// bucketEntities returns the entity_ids present in a named bucket.
+// deviceGroups are HA's four device-page groups, in output order.
+var deviceGroups = []string{"controls", "sensors", "configuration", "diagnostic"}
+
+// bucketEntities returns the entity_ids present in a named group.
 func bucketEntities(payload map[string]any, bucket string) []string {
 	list, _ := payload[bucket].([]any)
 	out := make([]string, 0, len(list))
@@ -151,7 +161,7 @@ func TestComputeDeviceSnapshot_ByID(t *testing.T) {
 		t.Errorf("integration = %#v, want ecobee", payload["integration"])
 	}
 	// The cross-device entity must never leak into the snapshot.
-	for _, bucket := range []string{"anomalies", "active", "ambient", "other"} {
+	for _, bucket := range deviceGroups {
 		if contains(bucketEntities(payload, bucket), "light.hall") {
 			t.Errorf("light.hall (other device) leaked into %s", bucket)
 		}
@@ -174,40 +184,51 @@ func TestComputeDeviceSnapshot_ByName(t *testing.T) {
 	}
 }
 
-func TestComputeDeviceSnapshot_MultiEntityAndAvailability(t *testing.T) {
+func TestComputeDeviceSnapshot_GroupsAndAvailability(t *testing.T) {
 	out, err := ComputeDeviceSnapshot(context.Background(), thermostatClient(), DeviceSnapshotRequest{Device: "dev_thermo"}, testNow)
 	if err != nil {
 		t.Fatalf("ComputeDeviceSnapshot: %v", err)
 	}
 	payload := decodeDevicePayload(t, out)
 
-	if got := payload["entity_count"]; got != float64(6) {
-		t.Errorf("entity_count = %#v, want 6", got)
+	if got := payload["entity_count"]; got != float64(7) {
+		t.Errorf("entity_count = %#v, want 7", got)
 	}
 
 	avail, ok := payload["availability"].(map[string]any)
 	if !ok {
 		t.Fatalf("availability missing or wrong type: %#v", payload["availability"])
 	}
-	if avail["reporting"] != float64(4) || avail["total"] != float64(6) {
-		t.Errorf("availability = %#v, want reporting 4 / total 6", avail)
+	// 5 reporting (climate, temp, humidity, motion, aux_heat); battery is
+	// a sentinel and signal has no state, so neither counts as reporting.
+	if avail["reporting"] != float64(5) || avail["total"] != float64(7) {
+		t.Errorf("availability = %#v, want reporting 5 / total 7", avail)
 	}
 
-	active := bucketEntities(payload, "active")
-	if !contains(active, "climate.thermostat") {
-		t.Errorf("active = %v, want climate.thermostat", active)
+	// Controls: the actionable primary.
+	controls := bucketEntities(payload, "controls")
+	if !contains(controls, "climate.thermostat") {
+		t.Errorf("controls = %v, want climate.thermostat", controls)
 	}
-	ambient := bucketEntities(payload, "ambient")
-	if !contains(ambient, "sensor.thermostat_temp") || !contains(ambient, "sensor.thermostat_humidity") {
-		t.Errorf("ambient = %v, want temp + humidity", ambient)
+	// Sensors: read-only primaries (temperature, humidity, motion).
+	sensors := bucketEntities(payload, "sensors")
+	if !contains(sensors, "sensor.thermostat_temp") ||
+		!contains(sensors, "sensor.thermostat_humidity") ||
+		!contains(sensors, "binary_sensor.thermostat_motion") {
+		t.Errorf("sensors = %v, want temp + humidity + motion", sensors)
 	}
-	other := bucketEntities(payload, "other")
-	if !contains(other, "binary_sensor.thermostat_motion") {
-		t.Errorf("other = %v, want binary_sensor.thermostat_motion", other)
+	// Configuration: entity_category=config wins over the switch domain.
+	config := bucketEntities(payload, "configuration")
+	if !contains(config, "switch.thermostat_aux_heat") {
+		t.Errorf("configuration = %v, want switch.thermostat_aux_heat", config)
 	}
-	anomalies := bucketEntities(payload, "anomalies")
-	if !contains(anomalies, "sensor.thermostat_battery") || !contains(anomalies, "sensor.thermostat_signal") {
-		t.Errorf("anomalies = %v, want battery (sentinel) + signal (no_state)", anomalies)
+	if contains(controls, "switch.thermostat_aux_heat") {
+		t.Errorf("config switch leaked into controls: %v", controls)
+	}
+	// Diagnostic: battery (sentinel) + signal (no_state) still group here.
+	diagnostic := bucketEntities(payload, "diagnostic")
+	if !contains(diagnostic, "sensor.thermostat_battery") || !contains(diagnostic, "sensor.thermostat_signal") {
+		t.Errorf("diagnostic = %v, want battery + signal", diagnostic)
 	}
 
 	unavailable, _ := payload["unavailable"].([]any)
@@ -272,14 +293,14 @@ func TestComputeDeviceSnapshot_IncludeMetadata(t *testing.T) {
 		t.Fatalf("ComputeDeviceSnapshot: %v", err)
 	}
 	payload := decodeDevicePayload(t, out)
-	active, _ := payload["active"].([]any)
-	if len(active) == 0 {
-		t.Fatalf("expected an active entity to enrich:\n%s", out)
+	controls, _ := payload["controls"].([]any)
+	if len(controls) == 0 {
+		t.Fatalf("expected a control entity to enrich:\n%s", out)
 	}
-	obj, _ := active[0].(map[string]any)
+	obj, _ := controls[0].(map[string]any)
 	meta, ok := obj["metadata"].(map[string]any)
 	if !ok {
-		t.Fatalf("expected metadata on active entity, got %#v", obj["metadata"])
+		t.Fatalf("expected metadata on control entity, got %#v", obj["metadata"])
 	}
 	if meta["description"] != "Main floor thermostat" {
 		t.Errorf("metadata.description = %#v, want Main floor thermostat", meta["description"])
@@ -292,7 +313,7 @@ func TestComputeDeviceSnapshot_NoIncludeNoMetadata(t *testing.T) {
 		t.Fatalf("ComputeDeviceSnapshot: %v", err)
 	}
 	payload := decodeDevicePayload(t, out)
-	for _, bucket := range []string{"anomalies", "active", "ambient", "other"} {
+	for _, bucket := range deviceGroups {
 		list, _ := payload[bucket].([]any)
 		for _, item := range list {
 			if obj, ok := item.(map[string]any); ok {
@@ -327,10 +348,97 @@ func TestComputeDeviceSnapshot_DisabledChildExcluded(t *testing.T) {
 	if payload["disabled_count"] != float64(1) {
 		t.Errorf("disabled_count = %#v, want 1", payload["disabled_count"])
 	}
-	for _, bucket := range []string{"anomalies", "active", "ambient", "other"} {
+	for _, bucket := range deviceGroups {
 		if contains(bucketEntities(payload, bucket), "sensor.widget_legacy") {
 			t.Errorf("disabled entity rendered in %s", bucket)
 		}
+	}
+}
+
+// findEntity returns the rendered object for an entity_id across every
+// device group, or nil if it isn't present.
+func findEntity(payload map[string]any, entityID string) map[string]any {
+	for _, group := range deviceGroups {
+		list, _ := payload[group].([]any)
+		for _, item := range list {
+			obj, ok := item.(map[string]any)
+			if ok && obj["entity"] == entityID {
+				return obj
+			}
+		}
+	}
+	return nil
+}
+
+// A device view is explicit inspection: unlike the enumeration tools it
+// shows hidden entities, marked, so the model sees the whole instrument
+// panel the way HA's device page does.
+func TestComputeDeviceSnapshot_ShowsHiddenEntitiesMarked(t *testing.T) {
+	client := &fakeDeviceClient{
+		areas:   []homeassistant.Area{{AreaID: "office", Name: "Office"}},
+		devices: []homeassistant.DeviceRegistryEntry{{ID: "dev_dimmer", Name: "Office Overhead Lights", AreaID: "office"}},
+		entities: []homeassistant.EntityRegistryEntry{
+			{EntityID: "light.office_overhead", DeviceID: "dev_dimmer"},
+			// Operator-hidden config knob — off HA's generated dashboards
+			// but present on the device page.
+			{EntityID: "number.office_overhead_ramp_rate", DeviceID: "dev_dimmer", EntityCategory: "config", HiddenBy: "user"},
+		},
+		states: map[string]*homeassistant.State{
+			"light.office_overhead":            mkState("light.office_overhead", "on", nil),
+			"number.office_overhead_ramp_rate": mkState("number.office_overhead_ramp_rate", "3", nil),
+		},
+	}
+	out, err := ComputeDeviceSnapshot(context.Background(), client, DeviceSnapshotRequest{Device: "dev_dimmer"}, testNow)
+	if err != nil {
+		t.Fatalf("ComputeDeviceSnapshot: %v", err)
+	}
+	payload := decodeDevicePayload(t, out)
+
+	hidden := findEntity(payload, "number.office_overhead_ramp_rate")
+	if hidden == nil {
+		t.Fatalf("hidden entity missing from device view:\n%s", out)
+	}
+	if hidden["hidden"] != true {
+		t.Errorf("hidden entity not marked hidden: %#v", hidden)
+	}
+	visible := findEntity(payload, "light.office_overhead")
+	if visible == nil {
+		t.Fatalf("visible entity missing:\n%s", out)
+	}
+	if _, marked := visible["hidden"]; marked {
+		t.Errorf("visible entity wrongly marked hidden: %#v", visible)
+	}
+}
+
+// The noisy groups (Configuration, Diagnostic) are capped with an honest
+// overflow count so a device with dozens of tuning knobs stays legible.
+func TestComputeDeviceSnapshot_CapsConfigurationGroup(t *testing.T) {
+	client := &fakeDeviceClient{
+		areas:   []homeassistant.Area{{AreaID: "office", Name: "Office"}},
+		devices: []homeassistant.DeviceRegistryEntry{{ID: "dev_zwave", Name: "Z-Wave Switch", AreaID: "office"}},
+		states:  map[string]*homeassistant.State{},
+	}
+	const configCount = maxDeviceOtherEntities + 4
+	for i := 0; i < configCount; i++ {
+		id := fmt.Sprintf("number.zwave_param_%02d", i)
+		client.entities = append(client.entities, homeassistant.EntityRegistryEntry{
+			EntityID: id, DeviceID: "dev_zwave", EntityCategory: "config",
+		})
+		client.states[id] = mkState(id, fmt.Sprintf("%d", i), nil)
+	}
+
+	out, err := ComputeDeviceSnapshot(context.Background(), client, DeviceSnapshotRequest{Device: "dev_zwave"}, testNow)
+	if err != nil {
+		t.Fatalf("ComputeDeviceSnapshot: %v", err)
+	}
+	payload := decodeDevicePayload(t, out)
+
+	config, _ := payload["configuration"].([]any)
+	if len(config) != maxDeviceOtherEntities {
+		t.Errorf("configuration length = %d, want cap %d", len(config), maxDeviceOtherEntities)
+	}
+	if payload["configuration_truncated_count"] != float64(configCount-maxDeviceOtherEntities) {
+		t.Errorf("configuration_truncated_count = %#v, want %d", payload["configuration_truncated_count"], configCount-maxDeviceOtherEntities)
 	}
 }
 

--- a/internal/state/awareness/device_snapshot_test.go
+++ b/internal/state/awareness/device_snapshot_test.go
@@ -418,7 +418,7 @@ func TestComputeDeviceSnapshot_CapsConfigurationGroup(t *testing.T) {
 		devices: []homeassistant.DeviceRegistryEntry{{ID: "dev_zwave", Name: "Z-Wave Switch", AreaID: "office"}},
 		states:  map[string]*homeassistant.State{},
 	}
-	const configCount = maxDeviceOtherEntities + 4
+	const configCount = maxDeviceNoisyGroupEntities + 4
 	for i := 0; i < configCount; i++ {
 		id := fmt.Sprintf("number.zwave_param_%02d", i)
 		client.entities = append(client.entities, homeassistant.EntityRegistryEntry{
@@ -434,11 +434,44 @@ func TestComputeDeviceSnapshot_CapsConfigurationGroup(t *testing.T) {
 	payload := decodeDevicePayload(t, out)
 
 	config, _ := payload["configuration"].([]any)
-	if len(config) != maxDeviceOtherEntities {
-		t.Errorf("configuration length = %d, want cap %d", len(config), maxDeviceOtherEntities)
+	if len(config) != maxDeviceNoisyGroupEntities {
+		t.Errorf("configuration length = %d, want cap %d", len(config), maxDeviceNoisyGroupEntities)
 	}
-	if payload["configuration_truncated_count"] != float64(configCount-maxDeviceOtherEntities) {
-		t.Errorf("configuration_truncated_count = %#v, want %d", payload["configuration_truncated_count"], configCount-maxDeviceOtherEntities)
+	if payload["configuration_truncated_count"] != float64(configCount-maxDeviceNoisyGroupEntities) {
+		t.Errorf("configuration_truncated_count = %#v, want %d", payload["configuration_truncated_count"], configCount-maxDeviceNoisyGroupEntities)
+	}
+}
+
+// The Diagnostic group caps the same way Configuration does — a device
+// with a long tail of health counters stays legible, with an honest
+// diagnostic_truncated_count.
+func TestComputeDeviceSnapshot_CapsDiagnosticGroup(t *testing.T) {
+	client := &fakeDeviceClient{
+		areas:   []homeassistant.Area{{AreaID: "office", Name: "Office"}},
+		devices: []homeassistant.DeviceRegistryEntry{{ID: "dev_zwave", Name: "Z-Wave Switch", AreaID: "office"}},
+		states:  map[string]*homeassistant.State{},
+	}
+	const diagCount = maxDeviceNoisyGroupEntities + 3
+	for i := 0; i < diagCount; i++ {
+		id := fmt.Sprintf("sensor.zwave_diag_%02d", i)
+		client.entities = append(client.entities, homeassistant.EntityRegistryEntry{
+			EntityID: id, DeviceID: "dev_zwave", EntityCategory: "diagnostic",
+		})
+		client.states[id] = mkState(id, fmt.Sprintf("%d", i), nil)
+	}
+
+	out, err := ComputeDeviceSnapshot(context.Background(), client, DeviceSnapshotRequest{Device: "dev_zwave"}, testNow)
+	if err != nil {
+		t.Fatalf("ComputeDeviceSnapshot: %v", err)
+	}
+	payload := decodeDevicePayload(t, out)
+
+	diag, _ := payload["diagnostic"].([]any)
+	if len(diag) != maxDeviceNoisyGroupEntities {
+		t.Errorf("diagnostic length = %d, want cap %d", len(diag), maxDeviceNoisyGroupEntities)
+	}
+	if payload["diagnostic_truncated_count"] != float64(diagCount-maxDeviceNoisyGroupEntities) {
+		t.Errorf("diagnostic_truncated_count = %#v, want %d", payload["diagnostic_truncated_count"], diagCount-maxDeviceNoisyGroupEntities)
 	}
 }
 

--- a/internal/state/awareness/device_snapshot_test.go
+++ b/internal/state/awareness/device_snapshot_test.go
@@ -442,6 +442,48 @@ func TestComputeDeviceSnapshot_CapsConfigurationGroup(t *testing.T) {
 	}
 }
 
+// The device-info card — area and the device's own labels — rides on the
+// identity block by default (no include projection needed), because a
+// device view is exactly where that context belongs.
+func TestComputeDeviceSnapshot_IdentityCarriesLabelsAndArea(t *testing.T) {
+	client := &fakeDeviceClient{
+		areas: []homeassistant.Area{{AreaID: "office", Name: "Office"}},
+		labels: []homeassistant.LabelRegistryEntry{
+			{LabelID: "label_hvac", Name: "HVAC", Color: "blue"},
+		},
+		devices: []homeassistant.DeviceRegistryEntry{{
+			ID: "dev_thermo", Name: "Ecobee Thermostat", AreaID: "office",
+			Labels: []string{"label_hvac"},
+		}},
+		entities: []homeassistant.EntityRegistryEntry{
+			{EntityID: "climate.thermostat", DeviceID: "dev_thermo"},
+		},
+		states: map[string]*homeassistant.State{
+			"climate.thermostat": mkState("climate.thermostat", "heat", nil),
+		},
+	}
+	out, err := ComputeDeviceSnapshot(context.Background(), client, DeviceSnapshotRequest{Device: "dev_thermo"}, testNow)
+	if err != nil {
+		t.Fatalf("ComputeDeviceSnapshot: %v", err)
+	}
+	payload := decodeDevicePayload(t, out)
+	identity, ok := payload["identity"].(map[string]any)
+	if !ok {
+		t.Fatalf("identity missing or wrong type: %#v", payload["identity"])
+	}
+	if identity["area_name"] != "Office" {
+		t.Errorf("identity.area_name = %#v, want Office (no include needed)", identity["area_name"])
+	}
+	labels, ok := identity["labels"].([]any)
+	if !ok || len(labels) != 1 {
+		t.Fatalf("identity.labels = %#v, want 1 label by default", identity["labels"])
+	}
+	label0, _ := labels[0].(map[string]any)
+	if label0["name"] != "HVAC" {
+		t.Errorf("identity.labels[0].name = %#v, want HVAC", label0["name"])
+	}
+}
+
 func TestComputeDeviceSnapshot_RequiresDevice(t *testing.T) {
 	if _, err := ComputeDeviceSnapshot(context.Background(), thermostatClient(), DeviceSnapshotRequest{}, testNow); err == nil {
 		t.Error("expected error when device is empty")

--- a/internal/state/awareness/device_snapshot_tool.go
+++ b/internal/state/awareness/device_snapshot_tool.go
@@ -45,8 +45,8 @@ func (a *DeviceSnapshotTools) Tools() []*tools.Tool {
 	return []*tools.Tool{
 		{
 			Name: "ha_device",
-			Description: "Get a full snapshot of one Home Assistant device as a unit — its identity " +
-				"(manufacturer/model/firmware/serial/area/integration/via_device) and every child entity it exposes, " +
+			Description: "Get a full snapshot of one Home Assistant device as a unit — its device-info card " +
+				"(manufacturer/model/firmware/serial/network connections like MAC/area/labels/integration/via_device) and every child entity it exposes, " +
 				"grouped exactly the way HA's device page groups them: controls (actionable primaries), sensors (read-only), " +
 				"configuration (tuning knobs), and diagnostic (health counters), plus an availability rollup (how many entities are reporting). " +
 				"Explicit inspection, so it also shows hidden entities (marked hidden:true) that the enumeration tools omit. " +

--- a/internal/state/awareness/device_snapshot_tool.go
+++ b/internal/state/awareness/device_snapshot_tool.go
@@ -11,8 +11,9 @@ import (
 
 // DeviceSnapshotTools exposes the ha_device tool, an on-demand view of
 // one Home Assistant device as a unit: its identity plus every child
-// entity it exposes, with semantic state grouped by salience and an
-// availability rollup. Implements [tools.Provider].
+// entity it exposes, grouped the way HA's device page groups them
+// (Controls / Sensors / Configuration / Diagnostic) with an availability
+// rollup. Implements [tools.Provider].
 type DeviceSnapshotTools struct {
 	client DeviceSnapshotClient
 	logger *slog.Logger
@@ -46,8 +47,9 @@ func (a *DeviceSnapshotTools) Tools() []*tools.Tool {
 			Name: "ha_device",
 			Description: "Get a full snapshot of one Home Assistant device as a unit — its identity " +
 				"(manufacturer/model/firmware/serial/area/integration/via_device) and every child entity it exposes, " +
-				"with semantic state grouped by salience (anomalies first, then active devices, ambient sensors, then the rest), " +
-				"plus an availability rollup (how many of its entities are reporting). " +
+				"grouped exactly the way HA's device page groups them: controls (actionable primaries), sensors (read-only), " +
+				"configuration (tuning knobs), and diagnostic (health counters), plus an availability rollup (how many entities are reporting). " +
+				"Explicit inspection, so it also shows hidden entities (marked hidden:true) that the enumeration tools omit. " +
 				"Use this to understand a physical device as a whole — 'show me the thermostat device', " +
 				"'what does the front-door sensor expose', 'is this device healthy' — rather than fetching one entity at a time. " +
 				"Resolves by device_id or by name (user-assigned or registry name, with substring fallback; returns candidates when ambiguous). " +

--- a/talents/ha.md
+++ b/talents/ha.md
@@ -75,13 +75,21 @@ expose", or "is this device healthy":
 ```
 
 Returns the device identity (manufacturer/model/firmware/serial/area/
-integration/via_device) plus every child entity it owns, with semantic
-state grouped by salience (anomalies first, then active, ambient, then
-the rest) and an availability rollup (how many of its entities are
-reporting). Resolves by `device_id` or by name — user-assigned or
-registry name, with a substring fallback, returning candidates when a
-name is ambiguous. Reach for this instead of discovering a device's
-child entities one `ha_get_state` at a time.
+integration/via_device) plus every child entity it owns, grouped exactly
+the way Home Assistant's own device page groups them — `controls` (the
+actionable primaries: lights, switches, climate), `sensors` (the
+read-only primaries), `configuration` (tuning knobs), and `diagnostic`
+(health counters) — with an availability rollup (how many entities are
+reporting). This is explicit inspection, so unlike the enumeration tools
+it shows **hidden** entities too, each marked `"hidden": true`: naming a
+device means you want its whole instrument panel, including the config
+and diagnostic entities HA keeps off its generated dashboards. The
+`configuration` and `diagnostic` groups are capped for a device with a
+long tail of knobs, with an honest `*_truncated_count`. Resolves by
+`device_id` or by name — user-assigned or registry name, with a
+substring fallback, returning candidates when a name is ambiguous. Reach
+for this instead of discovering a device's child entities one
+`ha_get_state` at a time.
 
 ## Find one entity by description
 

--- a/talents/ha.md
+++ b/talents/ha.md
@@ -74,8 +74,9 @@ expose", or "is this device healthy":
 }
 ```
 
-Returns the device identity (manufacturer/model/firmware/serial/area/
-integration/via_device) plus every child entity it owns, grouped exactly
+Returns the full device-info card — manufacturer, model, firmware,
+serial, network connections (MAC and friends), area, labels, integration,
+and via_device — plus every child entity it owns, grouped exactly
 the way Home Assistant's own device page groups them — `controls` (the
 actionable primaries: lights, switches, climate), `sensors` (the
 read-only primaries), `configuration` (tuning knobs), and `diagnostic`


### PR DESCRIPTION
## Summary

Part of #1186 from the #1175 umbrella — the class-aware device projection. When a human opens a device in Home Assistant, they don't get a flat list sorted by "how interesting is this right now." They get an instrument panel: **Controls** at the top (the lights and switches and thermostats you act on), **Sensors** below (what the device reads), then **Configuration** (the tuning knobs) and **Diagnostic** (the health counters) — the structure HA derives from each entity's `entity_category`. `ha_device` now returns exactly those four groups, so the model reads a device the way its owner does.

This replaces the homegrown salience bucketing (anomalies/active/ambient/other) that `ha_device` inherited from the area snapshot. Salience is the right lens for "what's going on in this room *right now*" — it stays on `get_area_activity` and `ha_home_snapshot`. But a device view answers a different question: "what does this thing expose, and is it healthy." For that, HA's own grouping is the better structure, and mirroring it means the model and the operator are looking at the same picture.

## Behavior

- **Four groups, HA's way.** `controls` / `sensors` / `configuration` / `diagnostic`. Configuration and Diagnostic follow the registry `entity_category`; the uncategorized primaries split into Controls (an actionable-domain set: lights, switches, climate, locks, covers, media players, …) and Sensors (everything else read-only). `entity_category` wins over domain — a config switch is a knob, not a control.
- **Hidden entities shown, marked.** Inspecting a device by name is explicit intent, so this view shows hidden entities too, each marked `"hidden": true`. This is the deliberate carve-out from the visible-only default the enumeration tools adopted in #1194 (#1185): the operator hid those diagnostics and config knobs from their *dashboards*, but on the *device page* HA shows them, and so do we. Naming a device means you want its whole instrument panel.
- **Noisy groups capped honestly.** A single Z-Wave device can expose dozens of parameters. Configuration and Diagnostic are capped with a per-group `*_truncated_count`; Controls and Sensors are inherently small and stay uncapped.
- **Health signals preserved.** The availability rollup (`reporting`/`total`) and the `unavailable` list survive unchanged — an entity sits in its semantic group *and* is flagged unavailable if it's sentinel or missing state.

## Worked example

The Inovelli "Office Overhead Lights" dimmer we designed against: `light.office_overhead` lands in **controls**; its power/energy sensors in **sensors**; the ramp-rate, dimming-speed, and LED-config knobs in **configuration** (several hidden — shown here, marked, though the enumeration tools would omit them); the last-seen and signal-strength counters in **diagnostic**. One call, the whole panel, grouped the way the HA UI groups it.

## Test plan

- [x] All four groups populate from `entity_category` + domain; a config switch lands in Configuration, not Controls
- [x] Hidden entities appear in the device view marked `hidden: true`; visible ones are unmarked
- [x] Configuration cap enforced with an accurate `configuration_truncated_count`
- [x] Diagnostic cap enforced with an accurate `diagnostic_truncated_count` (Copilot review round)
- [x] Device-info card completes the `identity` block: connections (MAC) + labels, by default; per-entity `metadata.device` stays lean
- [x] Availability rollup + `unavailable` list preserved; cross-device and disabled entities still excluded
- [x] Public tools reference (`docs/reference/tools.md`) updated to the new grouping (Copilot review round)
- [x] `just ci` green locally (unpiped, real exit code verified)

Refs #1186, #1175. The larger class-aware semantic-state projection (per-domain field shaping) is the remaining part of #1186.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

