### PR TITLE
feat(ha): preview a subscription target's live expansion, flag zero members

### DIFF
--- a/internal/app/new_awareness.go
+++ b/internal/app/new_awareness.go
@@ -107,10 +107,18 @@ func (a *App) initAwareness(s *newState) error {
 		logger.Info("entity watchlist context enabled")
 	}
 
-	a.loop.Tools().RegisterProvider(awareness.NewWatchlistTools(awareness.WatchlistToolsConfig{
+	watchlistCfg := awareness.WatchlistToolsConfig{
 		Store:  watchlistStore,
 		Logger: logger,
-	}))
+	}
+	// Only set Registry when the HA client is present. a.ha is a concrete
+	// *homeassistant.Client, so assigning a nil one into the interface
+	// field would make a non-nil interface wrapping a nil pointer — the
+	// preview would then dereference it instead of skipping cleanly.
+	if a.ha != nil {
+		watchlistCfg.Registry = a.ha
+	}
+	a.loop.Tools().RegisterProvider(awareness.NewWatchlistTools(watchlistCfg))
 
 	if a.ha != nil {
 		a.loop.Tools().RegisterProvider(awareness.NewAreaActivityTools(awareness.AreaActivityToolsConfig{

--- a/internal/state/awareness/watchlist_expansion.go
+++ b/internal/state/awareness/watchlist_expansion.go
@@ -1,0 +1,82 @@
+package awareness
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/nugget/thane-ai-agent/internal/integrations/homeassistant"
+)
+
+// previewSampleSize is how many member ids a target-expansion preview
+// carries as a concrete sample alongside the count.
+const previewSampleSize = 5
+
+// targetExpansion is the author-time membership preview for a glob or
+// registry-backed subscription target: how many entities it matches right
+// now and a sample of them.
+type targetExpansion struct {
+	Count  int
+	Sample []string
+}
+
+// previewTargetExpansion resolves a glob or area/label/floor target's
+// current membership against the registry so add/list can advertise the
+// expansion and flag a zero-member target as a likely mistake. It returns
+// nil (no error) when there is no registry client wired, or when the
+// target is a concrete entity_id that is its own membership and needs no
+// preview. Membership is registry truth, not state-filtered: a member
+// that is momentarily stateless is still a real member, and "matches
+// zero" is exactly the typo signal worth surfacing.
+func previewTargetExpansion(registries *renderRegistries, target SubscriptionTarget) (*targetExpansion, error) {
+	if registries == nil {
+		return nil, nil
+	}
+	var members []string
+	switch target.Kind {
+	case TargetArea, TargetLabel, TargetFloor:
+		resolver, err := newMembershipResolver(registries)
+		if err != nil {
+			return nil, err
+		}
+		members = resolver.members(target)
+	case TargetGlob:
+		entities, err := registries.entities()
+		if err != nil {
+			return nil, err
+		}
+		for id := range entities {
+			ok, err := homeassistant.MatchEntityGlob(target.Value, id)
+			if err != nil {
+				return nil, err
+			}
+			if ok {
+				members = append(members, id)
+			}
+		}
+		sort.Strings(members)
+	default:
+		return nil, nil
+	}
+	sample := members
+	if len(sample) > previewSampleSize {
+		sample = sample[:previewSampleSize]
+	}
+	return &targetExpansion{Count: len(members), Sample: append([]string(nil), sample...)}, nil
+}
+
+// entityNoun agrees "entity"/"entities" with a count.
+func entityNoun(n int) string {
+	if n == 1 {
+		return "entity"
+	}
+	return "entities"
+}
+
+// moreMembersSuffix renders " (+N more)" when a sample is shorter than
+// the full membership, and "" when the sample is the whole set.
+func moreMembersSuffix(total, shown int) string {
+	if total > shown {
+		return fmt.Sprintf(" (+%d more)", total-shown)
+	}
+	return ""
+}

--- a/internal/state/awareness/watchlist_expansion_test.go
+++ b/internal/state/awareness/watchlist_expansion_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -11,6 +12,17 @@ import (
 
 	"github.com/nugget/thane-ai-agent/internal/integrations/homeassistant"
 )
+
+// failingRegistryClient wraps a working registry fixture but errors on
+// the entity-registry read, so target-expansion previews fail the way a
+// transient HA registry outage would.
+type failingRegistryClient struct {
+	*fakeDeviceClient
+}
+
+func (failingRegistryClient) GetEntityRegistry(context.Context) ([]homeassistant.EntityRegistryEntry, error) {
+	return nil, fmt.Errorf("registry unavailable")
+}
 
 // expansionRegistryClient is a small HARegistryClient fixture whose
 // entities populate a couple of areas, for exercising the author-time
@@ -200,5 +212,64 @@ func TestListEntitySubscriptions_IncludesExpansion(t *testing.T) {
 	concrete := got.Items[byID["sensor.office_temp"]]
 	if concrete.Expansion != nil {
 		t.Errorf("concrete entity should have no expansion: %#v", concrete.Expansion)
+	}
+}
+
+func TestAddEntitySubscription_PreviewFailureIsSurfaced(t *testing.T) {
+	client := failingRegistryClient{expansionRegistryClient()}
+	p, store := setupWatchlistProviderWithRegistry(t, client)
+
+	result, err := p.handleAddEntitySubscription(context.Background(), map[string]any{
+		"entity_id": "area:office",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// A failed preview must be spoken, not swallowed into a bare
+	// "Now watching …" that reads as a validated subscribe.
+	if !strings.Contains(result, "couldn't preview") {
+		t.Errorf("result = %q, want a preview-failure note", result)
+	}
+	// The subscription still records — a transient read failure shouldn't
+	// lose the intent.
+	ids, err := store.List()
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(ids) != 1 || ids[0] != "area:office" {
+		t.Errorf("store.List() = %v, want [area:office]", ids)
+	}
+}
+
+func TestListEntitySubscriptions_PreviewFailureMarked(t *testing.T) {
+	client := failingRegistryClient{expansionRegistryClient()}
+	p, _ := setupWatchlistProviderWithRegistry(t, client)
+	ctx := context.Background()
+
+	if _, err := p.handleAddEntitySubscription(ctx, map[string]any{"entity_id": "area:office"}); err != nil {
+		t.Fatalf("add: %v", err)
+	}
+
+	result, err := p.handleListEntitySubscriptions(ctx, map[string]any{})
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	var got struct {
+		Items []struct {
+			EntityID  string `json:"entity_id"`
+			Expansion *struct {
+				Unavailable bool   `json:"unavailable"`
+				Note        string `json:"note"`
+			} `json:"expansion"`
+		} `json:"items"`
+	}
+	if err := json.Unmarshal([]byte(result), &got); err != nil {
+		t.Fatalf("unmarshal: %v\n%s", err, result)
+	}
+	if len(got.Items) != 1 {
+		t.Fatalf("items = %d, want 1", len(got.Items))
+	}
+	if got.Items[0].Expansion == nil || !got.Items[0].Expansion.Unavailable {
+		t.Errorf("expansion = %#v, want an unavailable marker", got.Items[0].Expansion)
 	}
 }

--- a/internal/state/awareness/watchlist_expansion_test.go
+++ b/internal/state/awareness/watchlist_expansion_test.go
@@ -1,0 +1,204 @@
+package awareness
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	_ "modernc.org/sqlite"
+
+	"github.com/nugget/thane-ai-agent/internal/integrations/homeassistant"
+)
+
+// expansionRegistryClient is a small HARegistryClient fixture whose
+// entities populate a couple of areas, for exercising the author-time
+// target-expansion preview on add_entity_subscription /
+// list_entity_subscriptions.
+func expansionRegistryClient() *fakeDeviceClient {
+	return &fakeDeviceClient{
+		areas: []homeassistant.Area{
+			{AreaID: "office", Name: "Office"},
+			{AreaID: "kitchen", Name: "Kitchen"},
+			{AreaID: "entry", Name: "Entry"},
+		},
+		entities: []homeassistant.EntityRegistryEntry{
+			{EntityID: "light.office_main", AreaID: "office"},
+			{EntityID: "sensor.office_temp", AreaID: "office"},
+			{EntityID: "switch.office_fan", AreaID: "office"},
+			{EntityID: "light.kitchen_main", AreaID: "kitchen"},
+			{EntityID: "binary_sensor.front_door", AreaID: "entry"},
+			{EntityID: "binary_sensor.back_door", AreaID: "entry"},
+		},
+	}
+}
+
+func setupWatchlistProviderWithRegistry(t *testing.T, client HARegistryClient) (*WatchlistTools, *WatchlistStore) {
+	t.Helper()
+	db, err := sql.Open("sqlite-thane", ":memory:")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+
+	store, err := NewWatchlistStore(db, nil)
+	if err != nil {
+		t.Fatalf("new store: %v", err)
+	}
+	p := NewWatchlistTools(WatchlistToolsConfig{
+		Store:    store,
+		Registry: client,
+	})
+	return p, store
+}
+
+func TestAddEntitySubscription_AreaTargetPreviewsExpansion(t *testing.T) {
+	p, _ := setupWatchlistProviderWithRegistry(t, expansionRegistryClient())
+
+	result, err := p.handleAddEntitySubscription(context.Background(), map[string]any{
+		"entity_id": "area:office",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(result, "Currently matches 3 entities") {
+		t.Errorf("result = %q, want a 3-entity expansion count", result)
+	}
+	// The sample lists concrete members so a typo is obvious.
+	for _, id := range []string{"light.office_main", "sensor.office_temp", "switch.office_fan"} {
+		if !strings.Contains(result, id) {
+			t.Errorf("result = %q, want it to sample %s", result, id)
+		}
+	}
+}
+
+func TestAddEntitySubscription_ZeroMemberTargetFlagged(t *testing.T) {
+	p, store := setupWatchlistProviderWithRegistry(t, expansionRegistryClient())
+
+	result, err := p.handleAddEntitySubscription(context.Background(), map[string]any{
+		"entity_id": "area:atrium", // no such area — likely a typo
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(result, "matches no entities right now") {
+		t.Errorf("result = %q, want a zero-member flag", result)
+	}
+	// Flagged, not rejected — the subscription is still recorded so it can
+	// pick up members later (the point of a registry-tracking target).
+	ids, err := store.List()
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(ids) != 1 || ids[0] != "area:atrium" {
+		t.Errorf("store.List() = %v, want [area:atrium] (flag, don't reject)", ids)
+	}
+}
+
+func TestAddEntitySubscription_GlobTargetPreviewsExpansion(t *testing.T) {
+	p, _ := setupWatchlistProviderWithRegistry(t, expansionRegistryClient())
+
+	result, err := p.handleAddEntitySubscription(context.Background(), map[string]any{
+		"entity_id": "binary_sensor.*door*",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(result, "Currently matches 2 entities") {
+		t.Errorf("result = %q, want a 2-entity glob expansion", result)
+	}
+	if !strings.Contains(result, "binary_sensor.back_door") || !strings.Contains(result, "binary_sensor.front_door") {
+		t.Errorf("result = %q, want both door sensors in the sample", result)
+	}
+}
+
+func TestAddEntitySubscription_ConcreteEntityHasNoExpansion(t *testing.T) {
+	p, _ := setupWatchlistProviderWithRegistry(t, expansionRegistryClient())
+
+	result, err := p.handleAddEntitySubscription(context.Background(), map[string]any{
+		"entity_id": "light.office_main",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if strings.Contains(result, "Currently matches") || strings.Contains(result, "matches no entities") {
+		t.Errorf("result = %q, want no expansion clause for a concrete entity", result)
+	}
+}
+
+func TestAddEntitySubscription_NoRegistryClientNoPreview(t *testing.T) {
+	// Store-only provider (no Registry): a glob target still subscribes
+	// cleanly, just without an expansion preview.
+	p, store, _ := setupWatchlistProvider(t)
+
+	result, err := p.handleAddEntitySubscription(context.Background(), map[string]any{
+		"entity_id": "binary_sensor.*door*",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if strings.Contains(result, "Currently matches") {
+		t.Errorf("result = %q, want no expansion clause without a registry client", result)
+	}
+	ids, err := store.List()
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(ids) != 1 || ids[0] != "binary_sensor.*door*" {
+		t.Errorf("store.List() = %v, want the glob subscription recorded", ids)
+	}
+}
+
+func TestListEntitySubscriptions_IncludesExpansion(t *testing.T) {
+	p, _ := setupWatchlistProviderWithRegistry(t, expansionRegistryClient())
+	ctx := context.Background()
+
+	for _, id := range []string{"area:office", "area:atrium", "sensor.office_temp"} {
+		if _, err := p.handleAddEntitySubscription(ctx, map[string]any{"entity_id": id}); err != nil {
+			t.Fatalf("add %s: %v", id, err)
+		}
+	}
+
+	result, err := p.handleListEntitySubscriptions(ctx, map[string]any{})
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	var got struct {
+		Items []struct {
+			EntityID  string `json:"entity_id"`
+			Expansion *struct {
+				Count  int      `json:"count"`
+				Sample []string `json:"sample"`
+				Note   string   `json:"note"`
+			} `json:"expansion"`
+		} `json:"items"`
+	}
+	if err := json.Unmarshal([]byte(result), &got); err != nil {
+		t.Fatalf("unmarshal: %v\n%s", err, result)
+	}
+
+	byID := make(map[string]int, len(got.Items))
+	for i, item := range got.Items {
+		byID[item.EntityID] = i
+	}
+
+	office := got.Items[byID["area:office"]]
+	if office.Expansion == nil || office.Expansion.Count != 3 {
+		t.Errorf("area:office expansion = %#v, want count 3", office.Expansion)
+	}
+	if office.Expansion != nil && len(office.Expansion.Sample) == 0 {
+		t.Errorf("area:office expansion should carry a sample: %#v", office.Expansion)
+	}
+
+	atrium := got.Items[byID["area:atrium"]]
+	if atrium.Expansion == nil || atrium.Expansion.Count != 0 || atrium.Expansion.Note == "" {
+		t.Errorf("area:atrium expansion = %#v, want count 0 with a note", atrium.Expansion)
+	}
+
+	// A concrete entity carries no expansion — it is its own membership.
+	concrete := got.Items[byID["sensor.office_temp"]]
+	if concrete.Expansion != nil {
+		t.Errorf("concrete entity should have no expansion: %#v", concrete.Expansion)
+	}
+}

--- a/internal/state/awareness/watchlist_tool_provider.go
+++ b/internal/state/awareness/watchlist_tool_provider.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
-	"sort"
 	"strings"
 	"time"
 
@@ -71,7 +70,7 @@ func (w *WatchlistTools) Tools() []*tools.Tool {
 				"For a specific named loop's view use update_entity_subscriptions; from inside a loop's own turn use watch_entity. " +
 				"Optional tags carry lens-style classifiers on the subscription itself for future filtering; they no longer act as a scope binding. " +
 				"Use ttl_seconds for subscriptions that should expire after a bounded task. Use history to include historical state snapshots at specific intervals. Use forecast for weather entities when future weather context is needed. " +
-				"For a glob or area/label/floor target, the result reports how many entities it currently matches (with a sample) — and flags a zero-member expansion, which almost always means a typo'd id or an empty group.",
+				"When Home Assistant is connected, a glob or area/label/floor target reports how many entities it currently matches (with a sample) — and flags a zero-member expansion, which almost always means a typo'd id or an empty group.",
 			Parameters: map[string]any{
 				"type": "object",
 				"properties": map[string]any{
@@ -106,7 +105,7 @@ func (w *WatchlistTools) Tools() []*tools.Tool {
 		},
 		{
 			Name:        "list_entity_subscriptions",
-			Description: "List always-visible entity subscriptions used for live context injection — entities that are surfaced on every turn regardless of which loop or capability tags are active. Each glob or area/label/floor subscription carries an expansion object with its current member count and a sample, so a subscription that currently matches nothing is visible at a glance. For per-loop subscriptions, call loop_definition_get and read the spec's subscriptions field; effective inherited subscriptions are surfaced there too.",
+			Description: "List always-visible entity subscriptions used for live context injection — entities that are surfaced on every turn regardless of which loop or capability tags are active. When Home Assistant is connected, each glob or area/label/floor subscription carries an expansion object with its current member count and a sample, so a subscription that currently matches nothing is visible at a glance. For per-loop subscriptions, call loop_definition_get and read the spec's subscriptions field; effective inherited subscriptions are surfaced there too.",
 			Parameters: map[string]any{
 				"type": "object",
 				"properties": map[string]any{
@@ -225,8 +224,14 @@ func (w *WatchlistTools) handleAddEntitySubscription(ctx context.Context, args m
 		exp, perr := previewTargetExpansion(newRenderRegistries(ctx, w.registry), target)
 		switch {
 		case perr != nil:
+			// The preview couldn't run (transient registry read failure).
+			// Say so rather than returning a bare "Now watching …" — an
+			// unspoken failure would read as a clean, validated subscribe,
+			// the exact silent-accept this preview exists to prevent.
 			w.logger.Warn("subscription target expansion preview failed",
 				"entity_id", entityID, "error", perr)
+			msg += " Note: couldn't preview its current expansion this turn" +
+				" (registry read failed), so the member count is unverified."
 		case exp == nil:
 			// No registry client wired — subscription stands without a preview.
 		case exp.Count == 0:
@@ -284,8 +289,15 @@ func (w *WatchlistTools) handleListEntitySubscriptions(ctx context.Context, args
 		// silently-empty subscription is visible at a glance.
 		if target := ParseSubscriptionTarget(sub.EntityID); target.Kind != TargetEntity {
 			if exp, err := previewTargetExpansion(registries, target); err != nil {
+				// A failed read is marked, not omitted — an absent
+				// expansion would read as "not a registry target" rather
+				// than "couldn't resolve it this turn."
 				w.logger.Warn("subscription target expansion preview failed",
 					"entity_id", sub.EntityID, "error", err)
+				item["expansion"] = map[string]any{
+					"unavailable": true,
+					"note":        "registry read failed this turn; membership unverified",
+				}
 			} else if exp != nil {
 				expObj := map[string]any{"count": exp.Count}
 				if len(exp.Sample) > 0 {
@@ -335,80 +347,6 @@ func (w *WatchlistTools) handleRemoveEntitySubscription(_ context.Context, args 
 		return fmt.Sprintf("Stopped watching %s in scopes %v.", entityID, tags), nil
 	}
 	return fmt.Sprintf("Stopped watching %s.", entityID), nil
-}
-
-// previewSampleSize is how many member ids a target-expansion preview
-// carries as a concrete sample alongside the count.
-const previewSampleSize = 5
-
-// targetExpansion is the author-time membership preview for a glob or
-// registry-backed subscription target: how many entities it matches right
-// now and a sample of them.
-type targetExpansion struct {
-	Count  int
-	Sample []string
-}
-
-// previewTargetExpansion resolves a glob or area/label/floor target's
-// current membership against the registry so add/list can advertise the
-// expansion and flag a zero-member target as a likely mistake. It returns
-// nil (no error) when there is no registry client wired, or when the
-// target is a concrete entity_id that is its own membership and needs no
-// preview. Membership is registry truth, not state-filtered: a member
-// that is momentarily stateless is still a real member, and "matches
-// zero" is exactly the typo signal worth surfacing.
-func previewTargetExpansion(registries *renderRegistries, target SubscriptionTarget) (*targetExpansion, error) {
-	if registries == nil {
-		return nil, nil
-	}
-	var members []string
-	switch target.Kind {
-	case TargetArea, TargetLabel, TargetFloor:
-		resolver, err := newMembershipResolver(registries)
-		if err != nil {
-			return nil, err
-		}
-		members = resolver.members(target)
-	case TargetGlob:
-		entities, err := registries.entities()
-		if err != nil {
-			return nil, err
-		}
-		for id := range entities {
-			ok, err := homeassistant.MatchEntityGlob(target.Value, id)
-			if err != nil {
-				return nil, err
-			}
-			if ok {
-				members = append(members, id)
-			}
-		}
-		sort.Strings(members)
-	default:
-		return nil, nil
-	}
-	sample := members
-	if len(sample) > previewSampleSize {
-		sample = sample[:previewSampleSize]
-	}
-	return &targetExpansion{Count: len(members), Sample: append([]string(nil), sample...)}, nil
-}
-
-// entityNoun agrees "entity"/"entities" with a count.
-func entityNoun(n int) string {
-	if n == 1 {
-		return "entity"
-	}
-	return "entities"
-}
-
-// moreMembersSuffix renders " (+N more)" when a sample is shorter than
-// the full membership, and "" when the sample is the whole set.
-func moreMembersSuffix(total, shown int) string {
-	if total > shown {
-		return fmt.Sprintf(" (+%d more)", total-shown)
-	}
-	return ""
 }
 
 func parseWatchlistTagArgs(raw any) ([]string, error) {

--- a/internal/state/awareness/watchlist_tool_provider.go
+++ b/internal/state/awareness/watchlist_tool_provider.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"sort"
 	"strings"
 	"time"
 
@@ -15,18 +16,25 @@ import (
 
 // WatchlistTools is the [tools.Provider] for the add_entity_subscription,
 // list_entity_subscriptions, and remove_entity_subscription tools. It
-// owns the watchlist store the handlers read/write and an optional
-// callback invoked when new scoped tags are introduced (so the caller
-// can wire up tag-specific context providers on demand).
+// owns the watchlist store the handlers read/write and an optional HA
+// registry client used to preview what a glob or area/label/floor target
+// expands to at the moment it is authored — so the model learns
+// immediately that area:office matches three entities, or that a typo'd
+// area:atrium matches none.
 type WatchlistTools struct {
-	store  *WatchlistStore
-	logger *slog.Logger
+	store    *WatchlistStore
+	registry HARegistryClient
+	logger   *slog.Logger
 }
 
 // WatchlistToolsConfig captures the dependencies for [NewWatchlistTools].
 type WatchlistToolsConfig struct {
 	// Store is the persistent watchlist store. Required.
 	Store *WatchlistStore
+	// Registry is the HA client used to preview a target's current
+	// membership when a subscription is authored or listed. Optional:
+	// when nil, subscriptions still work but carry no expansion preview.
+	Registry HARegistryClient
 	// Logger defaults to slog.Default when nil.
 	Logger *slog.Logger
 }
@@ -43,8 +51,9 @@ func NewWatchlistTools(cfg WatchlistToolsConfig) *WatchlistTools {
 		logger = slog.Default()
 	}
 	return &WatchlistTools{
-		store:  cfg.Store,
-		logger: logger,
+		store:    cfg.Store,
+		registry: cfg.Registry,
+		logger:   logger,
 	}
 }
 
@@ -61,7 +70,8 @@ func (w *WatchlistTools) Tools() []*tools.Tool {
 				"This tool adds always-visible subscriptions: the entity appears on every turn regardless of which loop or capability tags are active — this is how you, or a conversation, watch an entity in your own field of view. " +
 				"For a specific named loop's view use update_entity_subscriptions; from inside a loop's own turn use watch_entity. " +
 				"Optional tags carry lens-style classifiers on the subscription itself for future filtering; they no longer act as a scope binding. " +
-				"Use ttl_seconds for subscriptions that should expire after a bounded task. Use history to include historical state snapshots at specific intervals. Use forecast for weather entities when future weather context is needed.",
+				"Use ttl_seconds for subscriptions that should expire after a bounded task. Use history to include historical state snapshots at specific intervals. Use forecast for weather entities when future weather context is needed. " +
+				"For a glob or area/label/floor target, the result reports how many entities it currently matches (with a sample) — and flags a zero-member expansion, which almost always means a typo'd id or an empty group.",
 			Parameters: map[string]any{
 				"type": "object",
 				"properties": map[string]any{
@@ -96,7 +106,7 @@ func (w *WatchlistTools) Tools() []*tools.Tool {
 		},
 		{
 			Name:        "list_entity_subscriptions",
-			Description: "List always-visible entity subscriptions used for live context injection — entities that are surfaced on every turn regardless of which loop or capability tags are active. For per-loop subscriptions, call loop_definition_get and read the spec's subscriptions field; effective inherited subscriptions are surfaced there too.",
+			Description: "List always-visible entity subscriptions used for live context injection — entities that are surfaced on every turn regardless of which loop or capability tags are active. Each glob or area/label/floor subscription carries an expansion object with its current member count and a sample, so a subscription that currently matches nothing is visible at a glance. For per-loop subscriptions, call loop_definition_get and read the spec's subscriptions field; effective inherited subscriptions are surfaced there too.",
 			Parameters: map[string]any{
 				"type": "object",
 				"properties": map[string]any{
@@ -135,7 +145,7 @@ func (w *WatchlistTools) Tools() []*tools.Tool {
 	}
 }
 
-func (w *WatchlistTools) handleAddEntitySubscription(_ context.Context, args map[string]any) (string, error) {
+func (w *WatchlistTools) handleAddEntitySubscription(ctx context.Context, args map[string]any) (string, error) {
 	entityID, _ := args["entity_id"].(string)
 	if entityID == "" {
 		return "", fmt.Errorf("entity_id is required")
@@ -206,12 +216,36 @@ func (w *WatchlistTools) handleAddEntitySubscription(_ context.Context, args map
 	}
 	msg += "."
 
+	// Author-time expansion preview: for a glob or area/label/floor
+	// target, report what it matches right now so the model isn't left
+	// guessing — and a zero-member expansion is flagged loudly, since it
+	// is almost always a typo'd id that would otherwise inject nothing
+	// forever. A concrete entity_id is its own membership and needs none.
+	if target := ParseSubscriptionTarget(entityID); target.Kind != TargetEntity {
+		exp, perr := previewTargetExpansion(newRenderRegistries(ctx, w.registry), target)
+		switch {
+		case perr != nil:
+			w.logger.Warn("subscription target expansion preview failed",
+				"entity_id", entityID, "error", perr)
+		case exp == nil:
+			// No registry client wired — subscription stands without a preview.
+		case exp.Count == 0:
+			msg += " Note: this target matches no entities right now —" +
+				" check the id (a likely typo or an empty group); it will" +
+				" inject nothing until it has members."
+		default:
+			msg += fmt.Sprintf(" Currently matches %d %s: %s%s.",
+				exp.Count, entityNoun(exp.Count), strings.Join(exp.Sample, ", "),
+				moreMembersSuffix(exp.Count, len(exp.Sample)))
+		}
+	}
+
 	w.logger.Info("entity subscription added",
 		"entity_id", entityID, "tags", tags, "history", history, "forecast", forecast, "include", include, "ttl_seconds", ttlSeconds)
 	return msg, nil
 }
 
-func (w *WatchlistTools) handleListEntitySubscriptions(_ context.Context, args map[string]any) (string, error) {
+func (w *WatchlistTools) handleListEntitySubscriptions(ctx context.Context, args map[string]any) (string, error) {
 	tag, _ := args["tag"].(string)
 	entityID, _ := args["entity_id"].(string)
 
@@ -221,6 +255,9 @@ func (w *WatchlistTools) handleListEntitySubscriptions(_ context.Context, args m
 	}
 
 	now := time.Now()
+	// One registries bundle shared across the whole list: it fetches each
+	// registry once and every glob/registry target's expansion reuses it.
+	registries := newRenderRegistries(ctx, w.registry)
 	items := make([]map[string]any, 0, len(subs))
 	for _, sub := range subs {
 		if entityID != "" && sub.EntityID != entityID {
@@ -242,6 +279,23 @@ func (w *WatchlistTools) handleListEntitySubscriptions(_ context.Context, args m
 		}
 		if sub.ExpiresAt != nil {
 			item["expires_delta"] = promptfmt.FormatDeltaOnly(*sub.ExpiresAt, now)
+		}
+		// Show each glob/registry target's current expansion so a
+		// silently-empty subscription is visible at a glance.
+		if target := ParseSubscriptionTarget(sub.EntityID); target.Kind != TargetEntity {
+			if exp, err := previewTargetExpansion(registries, target); err != nil {
+				w.logger.Warn("subscription target expansion preview failed",
+					"entity_id", sub.EntityID, "error", err)
+			} else if exp != nil {
+				expObj := map[string]any{"count": exp.Count}
+				if len(exp.Sample) > 0 {
+					expObj["sample"] = exp.Sample
+				}
+				if exp.Count == 0 {
+					expObj["note"] = "matches no entities right now — likely a typo'd id or an empty group"
+				}
+				item["expansion"] = expObj
+			}
 		}
 		items = append(items, item)
 	}
@@ -281,6 +335,80 @@ func (w *WatchlistTools) handleRemoveEntitySubscription(_ context.Context, args 
 		return fmt.Sprintf("Stopped watching %s in scopes %v.", entityID, tags), nil
 	}
 	return fmt.Sprintf("Stopped watching %s.", entityID), nil
+}
+
+// previewSampleSize is how many member ids a target-expansion preview
+// carries as a concrete sample alongside the count.
+const previewSampleSize = 5
+
+// targetExpansion is the author-time membership preview for a glob or
+// registry-backed subscription target: how many entities it matches right
+// now and a sample of them.
+type targetExpansion struct {
+	Count  int
+	Sample []string
+}
+
+// previewTargetExpansion resolves a glob or area/label/floor target's
+// current membership against the registry so add/list can advertise the
+// expansion and flag a zero-member target as a likely mistake. It returns
+// nil (no error) when there is no registry client wired, or when the
+// target is a concrete entity_id that is its own membership and needs no
+// preview. Membership is registry truth, not state-filtered: a member
+// that is momentarily stateless is still a real member, and "matches
+// zero" is exactly the typo signal worth surfacing.
+func previewTargetExpansion(registries *renderRegistries, target SubscriptionTarget) (*targetExpansion, error) {
+	if registries == nil {
+		return nil, nil
+	}
+	var members []string
+	switch target.Kind {
+	case TargetArea, TargetLabel, TargetFloor:
+		resolver, err := newMembershipResolver(registries)
+		if err != nil {
+			return nil, err
+		}
+		members = resolver.members(target)
+	case TargetGlob:
+		entities, err := registries.entities()
+		if err != nil {
+			return nil, err
+		}
+		for id := range entities {
+			ok, err := homeassistant.MatchEntityGlob(target.Value, id)
+			if err != nil {
+				return nil, err
+			}
+			if ok {
+				members = append(members, id)
+			}
+		}
+		sort.Strings(members)
+	default:
+		return nil, nil
+	}
+	sample := members
+	if len(sample) > previewSampleSize {
+		sample = sample[:previewSampleSize]
+	}
+	return &targetExpansion{Count: len(members), Sample: append([]string(nil), sample...)}, nil
+}
+
+// entityNoun agrees "entity"/"entities" with a count.
+func entityNoun(n int) string {
+	if n == 1 {
+		return "entity"
+	}
+	return "entities"
+}
+
+// moreMembersSuffix renders " (+N more)" when a sample is shorter than
+// the full membership, and "" when the sample is the whole set.
+func moreMembersSuffix(total, shown int) string {
+	if total > shown {
+		return fmt.Sprintf(" (+%d more)", total-shown)
+	}
+	return ""
 }
 
 func parseWatchlistTagArgs(raw any) ([]string, error) {

--- a/talents/awareness-trailhead.md
+++ b/talents/awareness-trailhead.md
@@ -23,10 +23,14 @@ Choose the next move deliberately:
   "watch the office," not "watch these specific sensors": its membership
   is re-resolved from the registry every turn, so it follows the home —
   move a device into the office and the `area:office` watch picks it up,
-  no re-authoring. All expansions are capped per turn and report
-  truncation when they overflow; scope to a smaller area/label/floor
-  rather than watching the whole house. Use `ha_registry_search` to find
-  area/label/floor IDs.
+  no re-authoring. When you subscribe to a glob or organizational target,
+  the result reports how many entities it matches right now, with a
+  sample — and flags a zero-member expansion, which almost always means a
+  typo'd id or an empty group. Read that back: if `area:office` was meant
+  to catch three sensors and matches zero, fix the id before moving on.
+  All expansions are capped per turn and report truncation when they
+  overflow; scope to a smaller area/label/floor rather than watching the
+  whole house. Use `ha_registry_search` to find area/label/floor IDs.
 - Add `include` metadata flags when area, owning device, HA labels, or
   descriptions would make the subscribed state easier to interpret; use
   `visibility` when hidden/enabled salience matters, and read


### PR DESCRIPTION
## Summary

Closes #1193, the last open acceptance criterion from #1184. #1184 taught subscriptions to speak globs and `area:`/`label:`/`floor:` targets whose membership resolves live each render. What it couldn't do — because `WatchlistTools` held only the store, not an HA client — was tell the model, *at the moment it subscribes*, what that target actually matches. So `add_entity_subscription` with `area:office` accepted the subscription in silence, and a typo'd `area:atrium` accepted just as silently a subscription that would render nothing forever.

This is the "advertise, don't silently drop" principle from the #1185 visibility work, applied to the authoring moment. Per-turn render silence is still correct for the ambient watchlist — a target that's momentarily empty shouldn't clutter every turn. But the moment you *author* a subscription is exactly where an empty expansion is a signal, not noise.

## Behavior

- **Author-time expansion preview.** `add_entity_subscription` with a glob or area/label/floor target now reports how many entities it matches right now, with a sample: *"Now watching area:office. Currently matches 3 entities: light.office_main, sensor.office_temp, switch.office_fan."*
- **Zero-member expansions flagged loudly.** *"Note: this target matches no entities right now — check the id (a likely typo or an empty group); it will inject nothing until it has members."* Never a silent accept.
- **Flagged, not rejected.** A registry-tracking target legitimately starts empty and gains members as the home changes (subscribe to `area:garage` before the garage has sensors). So the subscription still records — the flag is a nudge, not a wall.
- **`list_entity_subscriptions` shows each target's current expansion** as an `expansion: {count, sample, note?}` object, so a subscription that has quietly gone empty is visible at a glance. Concrete entity_ids carry no expansion — an entity is its own membership.

## Design notes

- **Membership is registry truth, not state-filtered.** A member that's momentarily stateless is still a real member, and "matches zero" is precisely the typo signal worth surfacing — so the preview counts registry membership, reusing #1184's `membershipResolver` for area/label/floor and `MatchEntityGlob` for globs.
- **Optional and nil-safe.** `WatchlistTools` gained an optional HA registry client. With none wired, subscriptions work exactly as before, just without the preview. `a.ha` is a concrete `*homeassistant.Client`, so it's only assigned into the interface field when non-nil — avoiding the typed-nil-in-interface trap where a nil pointer in a non-nil interface would slip past the `== nil` guard and get dereferenced.
- **One read per list.** The list handler shares a single `renderRegistries` bundle across all rows, so previewing N targets costs one registry fetch, not N.

## Test plan

- [x] `add_entity_subscription` reports an area/glob target's current expansion count and sample
- [x] Zero-member expansion is flagged and the subscription is still recorded (flag, don't reject)
- [x] Concrete entity_ids get no expansion clause
- [x] Store-only provider (no registry client) subscribes cleanly with no preview and no error
- [x] `list_entity_subscriptions` carries an `expansion` object per glob/registry target, with a note on zero
- [x] A failed preview (registry outage) is surfaced, not swallowed — `add` appends an "unverified" note, `list` marks the row `{unavailable: true}` (Copilot review round)
- [x] `just ci` green locally (unpiped, real exit code verified)

Refs #1184, #1175.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

