### PR TITLE
fix(ha): ha_search_states/ha_list_entities emit class-aware state, not raw on/off

### DIFF
--- a/internal/tools/ha_entity_metadata.go
+++ b/internal/tools/ha_entity_metadata.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/nugget/thane-ai-agent/internal/integrations/homeassistant"
+	"github.com/nugget/thane-ai-agent/internal/integrations/homeassistant/contextfmt"
 	"github.com/nugget/thane-ai-agent/internal/model/promptfmt"
 )
 
@@ -118,6 +119,22 @@ func haRecencyDelta(s homeassistant.State, now time.Time) (since, updated string
 		updated = promptfmt.FormatDeltaOnly(s.LastUpdated, now)
 	}
 	return since, updated
+}
+
+// haSemanticState returns the class-aware state label for an entity — the
+// same translation the canonical contextfmt projection applies, so
+// ha_search_states and ha_list_entities express a garage_door binary_sensor
+// as "open" (not "on"), a moisture sensor as "wet"/"dry", and round numeric
+// states by device_class, exactly like ha_get_state and the snapshot tools.
+// HA writes the operator's "Show as" device_class override into the state's
+// attributes, so the state-attribute class is already the effective one.
+// Sentinel (unavailable/unknown) and unmapped states pass through unchanged.
+func haSemanticState(s homeassistant.State) string {
+	return contextfmt.SemanticState(
+		contextfmt.EntityDomain(s.EntityID),
+		contextfmt.AttrString(s.Attributes, "device_class"),
+		s.State,
+	)
 }
 
 // EntityMetadataIncludeParameter returns the shared JSON schema

--- a/internal/tools/ha_search_states.go
+++ b/internal/tools/ha_search_states.go
@@ -83,7 +83,7 @@ func (r *Registry) registerHASearchStates() {
 				"state": map[string]any{
 					"type":        []string{"string", "array"},
 					"items":       map[string]any{"type": "string"},
-					"description": "Match entities whose current state is one of these values. Accepts a single string (\"on\") or an array ([\"unavailable\",\"unknown\"]). Filter by the raw HA state (\"on\"/\"off\"); results render the class-aware label (a garage_door reads \"open\", not \"on\"), so filter on \"on\" even when you expect \"open\".",
+					"description": "Match entities whose current state is one of these values — the raw HA state (a binary_sensor is \"on\"/\"off\", a cover \"open\"/\"closed\", a lock \"locked\"/\"unlocked\"). Accepts a single string (\"on\") or an array ([\"unavailable\",\"unknown\"]). Results may render a class-aware label (a garage_door binary_sensor shows \"open\" for raw \"on\"), so filter on the raw value even when the displayed label differs.",
 				},
 				"domain": map[string]any{
 					"type":        "string",

--- a/internal/tools/ha_search_states.go
+++ b/internal/tools/ha_search_states.go
@@ -83,7 +83,7 @@ func (r *Registry) registerHASearchStates() {
 				"state": map[string]any{
 					"type":        []string{"string", "array"},
 					"items":       map[string]any{"type": "string"},
-					"description": "Match entities whose current state is one of these values. Accepts a single string (\"on\") or an array ([\"unavailable\",\"unknown\"]).",
+					"description": "Match entities whose current state is one of these values. Accepts a single string (\"on\") or an array ([\"unavailable\",\"unknown\"]). Filter by the raw HA state (\"on\"/\"off\"); results render the class-aware label (a garage_door reads \"open\", not \"on\"), so filter on \"on\" even when you expect \"open\".",
 				},
 				"domain": map[string]any{
 					"type":        "string",
@@ -231,7 +231,7 @@ func (r *Registry) handleSearchStates(ctx context.Context, args map[string]any) 
 	items := make([]haListEntityItem, 0, len(candidates))
 	for i := range candidates {
 		s := candidates[i]
-		item := haListEntityItem{EntityID: s.EntityID, State: s.State}
+		item := haListEntityItem{EntityID: s.EntityID, State: haSemanticState(s)}
 		item.Since, item.Updated = haRecencyDelta(s, now)
 		if friendly, ok := s.Attributes["friendly_name"].(string); ok {
 			item.FriendlyName = friendly

--- a/internal/tools/ha_semantic_state_test.go
+++ b/internal/tools/ha_semantic_state_test.go
@@ -1,0 +1,79 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/nugget/thane-ai-agent/internal/integrations/homeassistant"
+)
+
+// semanticStateFixture registers a garage_door binary_sensor (the prod bug:
+// operator "Show as: Garage Door" → device_class garage_door, which HA writes
+// into the state attributes), a plain binary_sensor with no device_class, and
+// a numeric sensor — so we can prove ha_search_states / ha_list_entities carry
+// the same class-aware translation ha_get_state and the snapshots already do.
+func semanticStateFixture(t *testing.T) *Registry {
+	t.Helper()
+	fake := newFakeHAServer(t)
+	fake.states = []homeassistant.State{
+		{
+			EntityID:   "binary_sensor.zone25_garage_bay_3",
+			State:      "on",
+			Attributes: map[string]any{"device_class": "garage_door", "friendly_name": "Garage Bay 3"},
+		},
+		{
+			// No device_class → nothing to translate, raw state passes through.
+			EntityID:   "binary_sensor.mystery",
+			State:      "on",
+			Attributes: map[string]any{"friendly_name": "Mystery"},
+		},
+	}
+	return fake.registry(t)
+}
+
+func itemStateByID(items []haListEntityItem, id string) (string, bool) {
+	for _, it := range items {
+		if it.EntityID == id {
+			return it.State, true
+		}
+	}
+	return "", false
+}
+
+func TestHAListEntities_TranslatesDeviceClassState(t *testing.T) {
+	reg := semanticStateFixture(t)
+	out, err := reg.Execute(context.Background(), "ha_list_entities", `{"domain":"binary_sensor"}`)
+	if err != nil {
+		t.Fatalf("ha_list_entities: %v", err)
+	}
+	var res haListEntitiesResult
+	if err := json.Unmarshal([]byte(out), &res); err != nil {
+		t.Fatalf("unmarshal: %v\n%s", err, out)
+	}
+
+	if got, ok := itemStateByID(res.Items, "binary_sensor.zone25_garage_bay_3"); !ok || got != "open" {
+		t.Errorf("garage_door state = %q (found=%v), want \"open\" — device_class transform must be honored", got, ok)
+	}
+	if got, ok := itemStateByID(res.Items, "binary_sensor.mystery"); !ok || got != "on" {
+		t.Errorf("plain binary_sensor state = %q (found=%v), want passthrough \"on\"", got, ok)
+	}
+}
+
+func TestHASearchStates_TranslatesDeviceClassState(t *testing.T) {
+	reg := semanticStateFixture(t)
+	// The filter still speaks raw HA state ("on"); the rendered result is
+	// the semantic label ("open"), matching ha_get_state and the snapshots.
+	out, err := reg.Execute(context.Background(), "ha_search_states", `{"state":["on"]}`)
+	if err != nil {
+		t.Fatalf("ha_search_states: %v", err)
+	}
+	var res haSearchStatesResult
+	if err := json.Unmarshal([]byte(out), &res); err != nil {
+		t.Fatalf("unmarshal: %v\n%s", err, out)
+	}
+
+	if got, ok := itemStateByID(res.Items, "binary_sensor.zone25_garage_bay_3"); !ok || got != "open" {
+		t.Errorf("garage_door state = %q (found=%v), want \"open\"", got, ok)
+	}
+}

--- a/internal/tools/ha_semantic_state_test.go
+++ b/internal/tools/ha_semantic_state_test.go
@@ -6,13 +6,15 @@ import (
 	"testing"
 
 	"github.com/nugget/thane-ai-agent/internal/integrations/homeassistant"
+	"github.com/nugget/thane-ai-agent/internal/integrations/homeassistant/contextfmt"
 )
 
 // semanticStateFixture registers a garage_door binary_sensor (the prod bug:
 // operator "Show as: Garage Door" → device_class garage_door, which HA writes
-// into the state attributes), a plain binary_sensor with no device_class, and
-// a numeric sensor — so we can prove ha_search_states / ha_list_entities carry
-// the same class-aware translation ha_get_state and the snapshots already do.
+// into the state attributes) and a plain binary_sensor with no device_class —
+// so we can prove ha_search_states / ha_list_entities carry the same
+// class-aware translation ha_get_state and the snapshots already do. Numeric
+// rounding parity is covered separately in TestHASemanticState_MatchesContextfmt.
 func semanticStateFixture(t *testing.T) *Registry {
 	t.Helper()
 	fake := newFakeHAServer(t)
@@ -75,5 +77,29 @@ func TestHASearchStates_TranslatesDeviceClassState(t *testing.T) {
 
 	if got, ok := itemStateByID(res.Items, "binary_sensor.zone25_garage_bay_3"); !ok || got != "open" {
 		t.Errorf("garage_door state = %q (found=%v), want \"open\"", got, ok)
+	}
+}
+
+// haSemanticState must be exactly the canonical contextfmt projection — the
+// whole point is that search/list match ha_get_state and the snapshots. This
+// covers the numeric-rounding branch (rounded by device_class) that the
+// binary_sensor cases above don't reach.
+func TestHASemanticState_MatchesContextfmt(t *testing.T) {
+	cases := []homeassistant.State{
+		{EntityID: "binary_sensor.garage", State: "on", Attributes: map[string]any{"device_class": "garage_door"}},
+		{EntityID: "sensor.office_temperature", State: "72.13", Attributes: map[string]any{"device_class": "temperature"}},
+		{EntityID: "binary_sensor.mystery", State: "on"},                                               // no device_class → passthrough
+		{EntityID: "sensor.unavail", State: "unavailable"},                                             // sentinel → passthrough
+		{EntityID: "cover.front", State: "open", Attributes: map[string]any{"device_class": "garage"}}, // non-binary domain
+	}
+	for _, s := range cases {
+		want := contextfmt.SemanticState(
+			contextfmt.EntityDomain(s.EntityID),
+			contextfmt.AttrString(s.Attributes, "device_class"),
+			s.State,
+		)
+		if got := haSemanticState(s); got != want {
+			t.Errorf("haSemanticState(%s state=%q) = %q, want %q (contextfmt parity)", s.EntityID, s.State, got, want)
+		}
 	}
 }

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -1429,7 +1429,7 @@ func (r *Registry) handleListEntities(ctx context.Context, args map[string]any) 
 		}
 		item := haListEntityItem{
 			EntityID: s.EntityID,
-			State:    s.State,
+			State:    haSemanticState(s),
 		}
 		item.Since, item.Updated = haRecencyDelta(s, now)
 		if friendly, ok := s.Attributes["friendly_name"].(string); ok {


### PR DESCRIPTION
## Summary

A live prod bug the owner caught through the new tools: `binary_sensor.zone25_garage_bay_3` is configured in Home Assistant as **Show as: Garage Door** (`device_class: garage_door`), but `ha_search_states` and `ha_list_entities` rendered it as state `"on"` instead of `"open"` — the operator's configured transform wasn't honored.

Verified against prod HA before fixing: `GET /api/states/binary_sensor.zone25_garage_bay_3` reports `attributes.device_class: "garage_door"`, `state: "on"`. So HA *does* write the "Show as" override into the state attributes — the class was there all along; we just weren't translating it.

## Root cause — the #1186 coverage gap, live

`ha_get_state` and the area/device/home snapshots translate state through `contextfmt` (`garage_door` + `on` → `open`). The two **enumeration/search** tools did not — they emitted the raw HA state:

```go
item := haListEntityItem{EntityID: s.EntityID, State: s.State}  // "on", not "open"
```

Telling detail: these tools had already borrowed contextfmt's recency delta (`haRecencyDelta`) to "mirror the canonical projection" — but only the *recency* signal came across, never the semantic-state translation. So the model saw a garage door as `on` whenever it reached the entity via search/list rather than `ha_get_state`.

## Fix

Both construction sites now route the `state` field through a shared `haSemanticState` helper (`contextfmt.SemanticState` by domain + `device_class`), so search/list express entities exactly like `ha_get_state` and the snapshots:

- a `garage_door` binary_sensor reads `open`, a `moisture` sensor `wet`/`dry`, motion `detected`/`clear`
- numeric states round by `device_class`
- sentinel (`unavailable`/`unknown`) and unmapped states pass through unchanged

The `state` **filter** still speaks raw HA values (`on`/`off`) — clarified in the tool description so the model filters on `on` even when results now display `open` (same as HA itself, where the underlying state stays `on`).

## Test plan

- [x] `ha_list_entities` renders a `garage_door` binary_sensor as `open`, not `on`
- [x] `ha_search_states` (filter `state:["on"]`) renders the same match as `open`
- [x] A binary_sensor with no `device_class` passes through as raw `on`
- [x] Full `internal/tools` suite green (no regression from the added numeric rounding / translation)
- [x] `just ci` green locally (unpiped, real exit code verified)

Refs #1186, #1175. This is the enumeration-surface slice of #1186's "route every entity-emitting surface through the class-aware projection" coverage axis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
