### PR TITLE
fix(ha): state-change window renders class-aware transitions, not raw on/off

### DIFF
--- a/internal/app/loop_definition_hydration_test.go
+++ b/internal/app/loop_definition_hydration_test.go
@@ -437,7 +437,7 @@ func TestHydrateLoopDefinitionSpec_HAStateWatcher(t *testing.T) {
 
 	eventsCh := make(chan homeassistant.Event, 1)
 	var handled int
-	watcher := homeassistant.NewStateWatcher(eventsCh, nil, nil, func(entityID, oldState, newState string) {
+	watcher := homeassistant.NewStateWatcher(eventsCh, nil, nil, func(entityID, oldState, newState, _ string) {
 		handled++
 	}, slog.New(slog.NewTextHandler(io.Discard, nil)))
 

--- a/internal/app/new_awareness.go
+++ b/internal/app/new_awareness.go
@@ -143,12 +143,6 @@ func (a *App) initAwareness(s *newState) error {
 	// --- State change window ---
 	// Maintains a rolling buffer of recent HA state changes, injected
 	// into the system prompt on every agent run for ambient awareness.
-	stateWindowLoc := time.Local
-	if cfg.Timezone != "" {
-		if parsed, err := time.LoadLocation(cfg.Timezone); err == nil {
-			stateWindowLoc = parsed
-		}
-	}
 	// contextfmt.SemanticState routes transitions through the canonical
 	// class-aware projection so the window reads closed→open for a
 	// garage_door, not off→on — injected here because contextfmt imports
@@ -156,7 +150,6 @@ func (a *App) initAwareness(s *newState) error {
 	stateWindowProvider := homeassistant.NewStateWindowProvider(
 		cfg.StateWindow.MaxEntries,
 		time.Duration(cfg.StateWindow.MaxAgeMinutes)*time.Minute,
-		stateWindowLoc,
 		contextfmt.SemanticState,
 		logger,
 	)

--- a/internal/app/new_awareness.go
+++ b/internal/app/new_awareness.go
@@ -8,6 +8,7 @@ import (
 	"github.com/nugget/thane-ai-agent/internal/channels/notifications"
 	"github.com/nugget/thane-ai-agent/internal/connwatch"
 	"github.com/nugget/thane-ai-agent/internal/integrations/homeassistant"
+	"github.com/nugget/thane-ai-agent/internal/integrations/homeassistant/contextfmt"
 	"github.com/nugget/thane-ai-agent/internal/integrations/unifi"
 	"github.com/nugget/thane-ai-agent/internal/runtime/agent"
 	"github.com/nugget/thane-ai-agent/internal/state/awareness"
@@ -148,10 +149,15 @@ func (a *App) initAwareness(s *newState) error {
 			stateWindowLoc = parsed
 		}
 	}
+	// contextfmt.SemanticState routes transitions through the canonical
+	// class-aware projection so the window reads closed→open for a
+	// garage_door, not off→on — injected here because contextfmt imports
+	// the homeassistant package and the provider cannot import it back.
 	stateWindowProvider := homeassistant.NewStateWindowProvider(
 		cfg.StateWindow.MaxEntries,
 		time.Duration(cfg.StateWindow.MaxAgeMinutes)*time.Minute,
 		stateWindowLoc,
+		contextfmt.SemanticState,
 		logger,
 	)
 	a.loop.RegisterAlwaysContextProvider(stateWindowProvider)
@@ -302,9 +308,9 @@ func (a *App) initAwareness(s *newState) error {
 		// every state change that passes the filter and rate limiter.
 		var handler homeassistant.StateWatchHandler
 		if s.personTracker != nil {
-			handler = func(entityID, oldState, newState string) {
-				stateWindowProvider.HandleStateChange(entityID, oldState, newState)
-				s.personTracker.HandleStateChange(entityID, oldState, newState)
+			handler = func(entityID, oldState, newState, deviceClass string) {
+				stateWindowProvider.HandleStateChange(entityID, oldState, newState, deviceClass)
+				s.personTracker.HandleStateChange(entityID, oldState, newState, deviceClass)
 			}
 		} else {
 			handler = stateWindowProvider.HandleStateChange

--- a/internal/integrations/homeassistant/statewatch.go
+++ b/internal/integrations/homeassistant/statewatch.go
@@ -10,8 +10,12 @@ import (
 
 // StateWatchHandler is called for each state change that passes the
 // entity filter and rate limiter. The handler receives the entity ID,
-// old state string, and new state string.
-type StateWatchHandler func(entityID, oldState, newState string)
+// old state string, new state string, and the entity's device_class.
+// deviceClass comes from the new state's attributes — HA writes the
+// operator's "Show as" override there, so it is the effective key for
+// class-aware rendering (a garage bay shows garage_door, not the
+// integration's original class). Empty when the entity has none.
+type StateWatchHandler func(entityID, oldState, newState, deviceClass string)
 
 // EntityFilter selects which entity IDs to process using glob patterns.
 // An empty filter matches all entities.
@@ -247,6 +251,11 @@ func (w *StateWatcher) handleEvent(ev Event) bool {
 		oldState = data.OldState.State
 	}
 
-	w.handler(data.EntityID, oldState, data.NewState.State)
+	deviceClass := ""
+	if dc, ok := data.NewState.Attributes["device_class"].(string); ok {
+		deviceClass = dc
+	}
+
+	w.handler(data.EntityID, oldState, data.NewState.State, deviceClass)
 	return true
 }

--- a/internal/integrations/homeassistant/statewatch_test.go
+++ b/internal/integrations/homeassistant/statewatch_test.go
@@ -332,7 +332,21 @@ func TestStateWatcher_DeliversDeviceClass(t *testing.T) {
 	events <- Event{Type: "state_changed", Data: raw}
 	events <- makeStateEvent(t, "light.kitchen", "off", "on") // no device_class
 
-	time.Sleep(50 * time.Millisecond)
+	// Poll until both events land instead of a fixed sleep, so the test
+	// stays deterministic under slow CI rather than timing-sensitive.
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		mu.Lock()
+		n := len(classes)
+		mu.Unlock()
+		if n == 2 {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("watcher processed %d/2 events before deadline", n)
+		}
+		time.Sleep(time.Millisecond)
+	}
 	cancel()
 	<-done
 

--- a/internal/integrations/homeassistant/statewatch_test.go
+++ b/internal/integrations/homeassistant/statewatch_test.go
@@ -136,7 +136,7 @@ func TestStateWatcher_Run(t *testing.T) {
 		entityID, oldState, newState string
 	}
 
-	handler := func(entityID, oldState, newState string) {
+	handler := func(entityID, oldState, newState, _ string) {
 		mu.Lock()
 		defer mu.Unlock()
 		received = append(received, struct {
@@ -195,7 +195,7 @@ func TestStateWatcher_NilNewStateSkipped(t *testing.T) {
 	events := make(chan Event, 10)
 
 	called := false
-	handler := func(_, _, _ string) { called = true }
+	handler := func(_, _, _, _ string) { called = true }
 
 	watcher := NewStateWatcher(events, nil, nil, handler, nil)
 
@@ -230,7 +230,7 @@ func TestStateWatcher_NonStateChangedIgnored(t *testing.T) {
 	events := make(chan Event, 10)
 
 	called := false
-	handler := func(_, _, _ string) { called = true }
+	handler := func(_, _, _, _ string) { called = true }
 
 	watcher := NewStateWatcher(events, nil, nil, handler, nil)
 
@@ -257,7 +257,7 @@ func TestStateWatcher_NonStateChangedIgnored(t *testing.T) {
 
 func TestHandleEvent_ReturnValue(t *testing.T) {
 	events := make(chan Event, 10)
-	handler := func(_, _, _ string) {}
+	handler := func(_, _, _, _ string) {}
 
 	// Filter accepts only "light.*".
 	filter := NewEntityFilter([]string{"light.*"}, nil)
@@ -295,4 +295,53 @@ func makeStateEvent(t *testing.T, entityID, oldState, newState string) Event {
 		t.Fatalf("marshal state data: %v", err)
 	}
 	return Event{Type: "state_changed", Data: raw}
+}
+
+// The watcher must deliver the new state's device_class to the handler —
+// it carries the operator's "Show as" override, the key class-aware
+// renderers translate by. Missing device_class arrives as "".
+func TestStateWatcher_DeliversDeviceClass(t *testing.T) {
+	events := make(chan Event, 10)
+
+	var mu sync.Mutex
+	classes := map[string]string{}
+	handler := func(entityID, _, _, deviceClass string) {
+		mu.Lock()
+		defer mu.Unlock()
+		classes[entityID] = deviceClass
+	}
+
+	watcher := NewStateWatcher(events, nil, nil, handler, nil)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan struct{})
+	go func() {
+		watcher.Run(ctx)
+		close(done)
+	}()
+
+	withClass := StateChangedData{
+		EntityID: "binary_sensor.zone25_garage_bay_3",
+		OldState: &State{State: "off"},
+		NewState: &State{State: "on", Attributes: map[string]any{"device_class": "garage_door"}},
+	}
+	raw, err := json.Marshal(withClass)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	events <- Event{Type: "state_changed", Data: raw}
+	events <- makeStateEvent(t, "light.kitchen", "off", "on") // no device_class
+
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+	<-done
+
+	mu.Lock()
+	defer mu.Unlock()
+	if classes["binary_sensor.zone25_garage_bay_3"] != "garage_door" {
+		t.Errorf("device_class = %q, want garage_door", classes["binary_sensor.zone25_garage_bay_3"])
+	}
+	if classes["light.kitchen"] != "" {
+		t.Errorf("device_class for classless entity = %q, want empty", classes["light.kitchen"])
+	}
 }

--- a/internal/integrations/homeassistant/statewindow.go
+++ b/internal/integrations/homeassistant/statewindow.go
@@ -13,12 +13,16 @@ import (
 )
 
 // StateWindowEntry records a single state transition observed from the Home
-// Assistant WebSocket event stream.
+// Assistant WebSocket event stream. DeviceClass is the effective
+// device_class at event time (carrying the operator's "Show as"
+// override), kept so the render can translate raw states into
+// class-aware labels.
 type StateWindowEntry struct {
-	EntityID  string
-	OldState  string
-	NewState  string
-	Timestamp time.Time
+	EntityID    string
+	OldState    string
+	NewState    string
+	DeviceClass string
+	Timestamp   time.Time
 }
 
 // StateWindowProvider maintains a rolling window of recent state changes and
@@ -34,14 +38,24 @@ type StateWindowProvider struct {
 	loc     *time.Location
 	nowFunc func() time.Time
 	logger  *slog.Logger
+	// translate maps (domain, deviceClass, rawState) to the class-aware
+	// label the model should read (garage_door "on" → "open"). Injected
+	// at construction — the canonical table lives in contextfmt, which
+	// imports this package, so the dependency must point inward. Nil
+	// means raw states pass through untranslated.
+	translate func(domain, deviceClass, state string) string
 }
 
 // NewStateWindowProvider creates a state window provider with the given
 // buffer capacity and maximum entry age. The loc parameter controls the
 // timezone used when formatting future-event timestamps in the context
-// output; nil falls back to time.Local. Entries older than maxAge are
-// filtered out at read time in TagContext.
-func NewStateWindowProvider(maxEntries int, maxAge time.Duration, loc *time.Location, logger *slog.Logger) *StateWindowProvider {
+// output; nil falls back to time.Local. translate is the class-aware
+// state translation applied when rendering transitions (normally
+// contextfmt.SemanticState, so a garage_door reads closed→open rather
+// than off→on — the same language every other entity-emitting surface
+// uses); nil renders raw states. Entries older than maxAge are filtered
+// out at read time in TagContext.
+func NewStateWindowProvider(maxEntries int, maxAge time.Duration, loc *time.Location, translate func(domain, deviceClass, state string) string, logger *slog.Logger) *StateWindowProvider {
 	if maxEntries <= 0 {
 		maxEntries = 50
 	}
@@ -55,11 +69,12 @@ func NewStateWindowProvider(maxEntries int, maxAge time.Duration, loc *time.Loca
 		logger = slog.Default()
 	}
 	return &StateWindowProvider{
-		entries: make([]StateWindowEntry, maxEntries),
-		maxAge:  maxAge,
-		loc:     loc,
-		nowFunc: time.Now,
-		logger:  logger,
+		entries:   make([]StateWindowEntry, maxEntries),
+		maxAge:    maxAge,
+		loc:       loc,
+		translate: translate,
+		nowFunc:   time.Now,
+		logger:    logger,
 	}
 }
 
@@ -72,7 +87,7 @@ func (p *StateWindowProvider) TagContextBucket() agentctx.ContextBucket {
 // HandleStateChange records a state transition in the circular buffer.
 // It matches the homeassistant.StateWatchHandler function signature and
 // can be composed directly into the state watcher handler chain.
-func (p *StateWindowProvider) HandleStateChange(entityID, oldState, newState string) {
+func (p *StateWindowProvider) HandleStateChange(entityID, oldState, newState, deviceClass string) {
 	// Filter no-op transitions (device tracker refreshes, etc.).
 	if oldState == newState {
 		return
@@ -82,10 +97,11 @@ func (p *StateWindowProvider) HandleStateChange(entityID, oldState, newState str
 
 	p.mu.Lock()
 	p.entries[p.head] = StateWindowEntry{
-		EntityID:  entityID,
-		OldState:  oldState,
-		NewState:  newState,
-		Timestamp: now,
+		EntityID:    entityID,
+		OldState:    oldState,
+		NewState:    newState,
+		DeviceClass: deviceClass,
+		Timestamp:   now,
 	}
 	p.head = (p.head + 1) % len(p.entries)
 	if p.count < len(p.entries) {
@@ -127,10 +143,21 @@ func (p *StateWindowProvider) TagContext(_ context.Context, _ agentctx.ContextRe
 		if e.Timestamp.Before(cutoff) {
 			continue
 		}
+		from, to := e.OldState, e.NewState
+		if p.translate != nil {
+			// Render class-aware labels so the model reads closed→open,
+			// not off→on, for a garage_door — matching every other
+			// entity-emitting surface. An entity's first observation has
+			// an empty OldState; translation passes unmapped values
+			// through, so that stays empty.
+			domain, _, _ := strings.Cut(e.EntityID, ".")
+			from = p.translate(domain, e.DeviceClass, from)
+			to = p.translate(domain, e.DeviceClass, to)
+		}
 		entries = append(entries, stateChangeJSON{
 			Entity: e.EntityID,
-			From:   e.OldState,
-			To:     e.NewState,
+			From:   from,
+			To:     to,
 			Ago:    promptfmt.FormatDeltaOnly(e.Timestamp, now),
 		})
 	}

--- a/internal/integrations/homeassistant/statewindow.go
+++ b/internal/integrations/homeassistant/statewindow.go
@@ -35,7 +35,6 @@ type StateWindowProvider struct {
 	head    int                // next write position
 	count   int                // entries currently stored (≤ len(entries))
 	maxAge  time.Duration
-	loc     *time.Location
 	nowFunc func() time.Time
 	logger  *slog.Logger
 	// translate maps (domain, deviceClass, rawState) to the class-aware
@@ -47,23 +46,18 @@ type StateWindowProvider struct {
 }
 
 // NewStateWindowProvider creates a state window provider with the given
-// buffer capacity and maximum entry age. The loc parameter controls the
-// timezone used when formatting future-event timestamps in the context
-// output; nil falls back to time.Local. translate is the class-aware
+// buffer capacity and maximum entry age. translate is the class-aware
 // state translation applied when rendering transitions (normally
 // contextfmt.SemanticState, so a garage_door reads closed→open rather
 // than off→on — the same language every other entity-emitting surface
 // uses); nil renders raw states. Entries older than maxAge are filtered
 // out at read time in TagContext.
-func NewStateWindowProvider(maxEntries int, maxAge time.Duration, loc *time.Location, translate func(domain, deviceClass, state string) string, logger *slog.Logger) *StateWindowProvider {
+func NewStateWindowProvider(maxEntries int, maxAge time.Duration, translate func(domain, deviceClass, state string) string, logger *slog.Logger) *StateWindowProvider {
 	if maxEntries <= 0 {
 		maxEntries = 50
 	}
 	if maxAge <= 0 {
 		maxAge = 30 * time.Minute
-	}
-	if loc == nil {
-		loc = time.Local
 	}
 	if logger == nil {
 		logger = slog.Default()
@@ -71,7 +65,6 @@ func NewStateWindowProvider(maxEntries int, maxAge time.Duration, loc *time.Loca
 	return &StateWindowProvider{
 		entries:   make([]StateWindowEntry, maxEntries),
 		maxAge:    maxAge,
-		loc:       loc,
 		translate: translate,
 		nowFunc:   time.Now,
 		logger:    logger,

--- a/internal/integrations/homeassistant/statewindow_semantic_test.go
+++ b/internal/integrations/homeassistant/statewindow_semantic_test.go
@@ -19,7 +19,7 @@ import (
 // binary_sensor shown as garage_door must render closed→open in the
 // ambient state window, matching every other entity-emitting surface.
 func TestStateWindow_ContextfmtVocabularyEndToEnd(t *testing.T) {
-	p := homeassistant.NewStateWindowProvider(10, 30*time.Minute, time.UTC, contextfmt.SemanticState, nil)
+	p := homeassistant.NewStateWindowProvider(10, 30*time.Minute, contextfmt.SemanticState, nil)
 
 	p.HandleStateChange("binary_sensor.zone25_garage_bay_3", "off", "on", "garage_door")
 	p.HandleStateChange("binary_sensor.leak", "off", "on", "moisture")

--- a/internal/integrations/homeassistant/statewindow_semantic_test.go
+++ b/internal/integrations/homeassistant/statewindow_semantic_test.go
@@ -1,0 +1,42 @@
+package homeassistant_test
+
+// External test package: contextfmt imports homeassistant, so wiring the
+// real canonical translator into the state window can only be exercised
+// from outside the package — exactly the shape the app wiring uses.
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nugget/thane-ai-agent/internal/integrations/homeassistant"
+	"github.com/nugget/thane-ai-agent/internal/integrations/homeassistant/contextfmt"
+	"github.com/nugget/thane-ai-agent/internal/runtime/agentctx"
+)
+
+// The prod garage-bay scenario end-to-end with the real vocabulary: a
+// binary_sensor shown as garage_door must render closed→open in the
+// ambient state window, matching every other entity-emitting surface.
+func TestStateWindow_ContextfmtVocabularyEndToEnd(t *testing.T) {
+	p := homeassistant.NewStateWindowProvider(10, 30*time.Minute, time.UTC, contextfmt.SemanticState, nil)
+
+	p.HandleStateChange("binary_sensor.zone25_garage_bay_3", "off", "on", "garage_door")
+	p.HandleStateChange("binary_sensor.leak", "off", "on", "moisture")
+	p.HandleStateChange("light.office", "off", "on", "")
+
+	got, err := p.TagContext(context.Background(), agentctx.ContextRequest{})
+	if err != nil {
+		t.Fatalf("TagContext: %v", err)
+	}
+	if !strings.Contains(got, `"from":"closed"`) || !strings.Contains(got, `"to":"open"`) {
+		t.Errorf("garage_door transition = want closed→open, got:\n%s", got)
+	}
+	if !strings.Contains(got, `"from":"dry"`) || !strings.Contains(got, `"to":"wet"`) {
+		t.Errorf("moisture transition = want dry→wet, got:\n%s", got)
+	}
+	// A light has no binary_sensor translation — raw on/off passes through.
+	if !strings.Contains(got, `{"entity":"light.office","from":"off","to":"on"`) {
+		t.Errorf("light transition should stay raw off→on, got:\n%s", got)
+	}
+}

--- a/internal/integrations/homeassistant/statewindow_test.go
+++ b/internal/integrations/homeassistant/statewindow_test.go
@@ -30,7 +30,7 @@ func advancingClock(start time.Time, step time.Duration) func() time.Time {
 }
 
 func TestProvider_EmptyBuffer(t *testing.T) {
-	p := NewStateWindowProvider(10, 30*time.Minute, time.UTC, nil)
+	p := NewStateWindowProvider(10, 30*time.Minute, time.UTC, nil, nil)
 
 	got, err := p.TagContext(context.Background(), agentctx.ContextRequest{UserMessage: ""})
 	if err != nil {
@@ -43,10 +43,10 @@ func TestProvider_EmptyBuffer(t *testing.T) {
 
 func TestProvider_SingleEntry(t *testing.T) {
 	now := time.Date(2025, 6, 15, 14, 30, 0, 0, time.UTC)
-	p := NewStateWindowProvider(10, 30*time.Minute, time.UTC, nil)
+	p := NewStateWindowProvider(10, 30*time.Minute, time.UTC, nil, nil)
 	p.nowFunc = fixedClock(now)
 
-	p.HandleStateChange("binary_sensor.front_door", "off", "on")
+	p.HandleStateChange("binary_sensor.front_door", "off", "on", "")
 
 	got, err := p.TagContext(context.Background(), agentctx.ContextRequest{UserMessage: ""})
 	if err != nil {
@@ -72,13 +72,13 @@ func TestProvider_SingleEntry(t *testing.T) {
 
 func TestProvider_MultipleEntries_NewestFirst(t *testing.T) {
 	base := time.Date(2025, 6, 15, 14, 0, 0, 0, time.UTC)
-	p := NewStateWindowProvider(10, 30*time.Minute, time.UTC, nil)
+	p := NewStateWindowProvider(10, 30*time.Minute, time.UTC, nil, nil)
 	clock := advancingClock(base, time.Minute)
 	p.nowFunc = clock
 
-	p.HandleStateChange("sensor.temp", "20", "21")
-	p.HandleStateChange("light.living_room", "on", "off")
-	p.HandleStateChange("person.nugget", "not_home", "home")
+	p.HandleStateChange("sensor.temp", "20", "21", "")
+	p.HandleStateChange("light.living_room", "on", "off", "")
+	p.HandleStateChange("person.nugget", "not_home", "home", "")
 
 	got, err := p.TagContext(context.Background(), agentctx.ContextRequest{UserMessage: ""})
 	if err != nil {
@@ -98,16 +98,16 @@ func TestProvider_MultipleEntries_NewestFirst(t *testing.T) {
 
 func TestProvider_CircularEviction(t *testing.T) {
 	now := time.Date(2025, 6, 15, 14, 0, 0, 0, time.UTC)
-	p := NewStateWindowProvider(3, time.Hour, time.UTC, nil)
+	p := NewStateWindowProvider(3, time.Hour, time.UTC, nil, nil)
 	clock := advancingClock(now, time.Minute)
 	p.nowFunc = clock
 
 	// Fill buffer with 5 entries; only last 3 should survive.
-	p.HandleStateChange("entity.a", "0", "1")
-	p.HandleStateChange("entity.b", "0", "1")
-	p.HandleStateChange("entity.c", "0", "1")
-	p.HandleStateChange("entity.d", "0", "1")
-	p.HandleStateChange("entity.e", "0", "1")
+	p.HandleStateChange("entity.a", "0", "1", "")
+	p.HandleStateChange("entity.b", "0", "1", "")
+	p.HandleStateChange("entity.c", "0", "1", "")
+	p.HandleStateChange("entity.d", "0", "1", "")
+	p.HandleStateChange("entity.e", "0", "1", "")
 
 	got, err := p.TagContext(context.Background(), agentctx.ContextRequest{UserMessage: ""})
 	if err != nil {
@@ -131,15 +131,15 @@ func TestProvider_CircularEviction(t *testing.T) {
 
 func TestProvider_AgeEviction(t *testing.T) {
 	now := time.Date(2025, 6, 15, 14, 0, 0, 0, time.UTC)
-	p := NewStateWindowProvider(10, 10*time.Minute, time.UTC, nil)
+	p := NewStateWindowProvider(10, 10*time.Minute, time.UTC, nil, nil)
 
 	// Insert an entry 15 minutes ago.
 	p.nowFunc = fixedClock(now.Add(-15 * time.Minute))
-	p.HandleStateChange("sensor.old", "0", "1")
+	p.HandleStateChange("sensor.old", "0", "1", "")
 
 	// Insert a recent entry.
 	p.nowFunc = fixedClock(now.Add(-2 * time.Minute))
-	p.HandleStateChange("sensor.recent", "0", "1")
+	p.HandleStateChange("sensor.recent", "0", "1", "")
 
 	// Read at "now" — old entry should be filtered out.
 	p.nowFunc = fixedClock(now)
@@ -158,12 +158,12 @@ func TestProvider_AgeEviction(t *testing.T) {
 
 func TestProvider_AllExpired(t *testing.T) {
 	now := time.Date(2025, 6, 15, 14, 0, 0, 0, time.UTC)
-	p := NewStateWindowProvider(10, 5*time.Minute, time.UTC, nil)
+	p := NewStateWindowProvider(10, 5*time.Minute, time.UTC, nil, nil)
 
 	// Insert entries 10 minutes ago.
 	p.nowFunc = fixedClock(now.Add(-10 * time.Minute))
-	p.HandleStateChange("sensor.a", "0", "1")
-	p.HandleStateChange("sensor.b", "0", "1")
+	p.HandleStateChange("sensor.a", "0", "1", "")
+	p.HandleStateChange("sensor.b", "0", "1", "")
 
 	// Read at "now" — all entries expired.
 	p.nowFunc = fixedClock(now)
@@ -178,11 +178,11 @@ func TestProvider_AllExpired(t *testing.T) {
 
 func TestProvider_DeltaFormat(t *testing.T) {
 	now := time.Date(2025, 6, 15, 14, 30, 0, 0, time.UTC)
-	p := NewStateWindowProvider(10, 30*time.Minute, time.UTC, nil)
+	p := NewStateWindowProvider(10, 30*time.Minute, time.UTC, nil, nil)
 
 	// Insert an entry 5 minutes ago.
 	p.nowFunc = fixedClock(now.Add(-5 * time.Minute))
-	p.HandleStateChange("sensor.test", "a", "b")
+	p.HandleStateChange("sensor.test", "a", "b", "")
 
 	// Read at "now" — should show 300 second delta.
 	p.nowFunc = fixedClock(now)
@@ -197,14 +197,14 @@ func TestProvider_DeltaFormat(t *testing.T) {
 }
 
 func TestProvider_HandleStateChange_Concurrent(t *testing.T) {
-	p := NewStateWindowProvider(100, time.Hour, time.UTC, nil)
+	p := NewStateWindowProvider(100, time.Hour, time.UTC, nil, nil)
 
 	var wg sync.WaitGroup
 	for i := 0; i < 50; i++ {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			p.HandleStateChange("sensor.concurrent", "0", "1")
+			p.HandleStateChange("sensor.concurrent", "0", "1", "")
 		}()
 	}
 	wg.Wait()
@@ -220,15 +220,15 @@ func TestProvider_HandleStateChange_Concurrent(t *testing.T) {
 
 func TestProvider_SameStateSuppressed(t *testing.T) {
 	now := time.Date(2025, 6, 15, 14, 30, 0, 0, time.UTC)
-	p := NewStateWindowProvider(10, 30*time.Minute, time.UTC, nil)
+	p := NewStateWindowProvider(10, 30*time.Minute, time.UTC, nil, nil)
 	p.nowFunc = fixedClock(now)
 
 	// Same→same should be filtered.
-	p.HandleStateChange("person.nugget", "home", "home")
-	p.HandleStateChange("sensor.temp", "20", "20")
+	p.HandleStateChange("person.nugget", "home", "home", "")
+	p.HandleStateChange("sensor.temp", "20", "20", "")
 
 	// Real transition should be recorded.
-	p.HandleStateChange("light.office", "off", "on")
+	p.HandleStateChange("light.office", "off", "on", "")
 
 	got, err := p.TagContext(context.Background(), agentctx.ContextRequest{UserMessage: ""})
 	if err != nil {
@@ -248,7 +248,7 @@ func TestProvider_SameStateSuppressed(t *testing.T) {
 
 func TestProvider_NilDefaults(t *testing.T) {
 	// Verify constructor handles zero/nil values gracefully.
-	p := NewStateWindowProvider(0, 0, nil, nil)
+	p := NewStateWindowProvider(0, 0, nil, nil, nil)
 	if len(p.entries) != 50 {
 		t.Errorf("expected default maxEntries=50, got %d", len(p.entries))
 	}
@@ -257,5 +257,37 @@ func TestProvider_NilDefaults(t *testing.T) {
 	}
 	if p.loc != time.Local {
 		t.Error("expected time.Local as default location")
+	}
+}
+
+// With a semantic translator wired, transitions render class-aware
+// labels; without one, raw states pass through. The real vocabulary is
+// asserted end-to-end in statewindow_semantic_test.go (external package,
+// since contextfmt imports this one).
+func TestStateWindow_SemanticTranslatorApplied(t *testing.T) {
+	p := NewStateWindowProvider(10, 30*time.Minute, time.UTC, func(domain, deviceClass, state string) string {
+		if domain == "binary_sensor" && deviceClass == "garage_door" {
+			switch state {
+			case "on":
+				return "open"
+			case "off":
+				return "closed"
+			}
+		}
+		return state
+	}, nil)
+
+	p.HandleStateChange("binary_sensor.garage", "off", "on", "garage_door")
+	p.HandleStateChange("sensor.temp", "20", "21", "temperature")
+
+	got, err := p.TagContext(context.Background(), agentctx.ContextRequest{})
+	if err != nil {
+		t.Fatalf("TagContext: %v", err)
+	}
+	if !strings.Contains(got, `"from":"closed"`) || !strings.Contains(got, `"to":"open"`) {
+		t.Errorf("garage transition not translated:\n%s", got)
+	}
+	if !strings.Contains(got, `"from":"20"`) || !strings.Contains(got, `"to":"21"`) {
+		t.Errorf("numeric transition should pass through:\n%s", got)
 	}
 }

--- a/internal/integrations/homeassistant/statewindow_test.go
+++ b/internal/integrations/homeassistant/statewindow_test.go
@@ -30,7 +30,7 @@ func advancingClock(start time.Time, step time.Duration) func() time.Time {
 }
 
 func TestProvider_EmptyBuffer(t *testing.T) {
-	p := NewStateWindowProvider(10, 30*time.Minute, time.UTC, nil, nil)
+	p := NewStateWindowProvider(10, 30*time.Minute, nil, nil)
 
 	got, err := p.TagContext(context.Background(), agentctx.ContextRequest{UserMessage: ""})
 	if err != nil {
@@ -43,7 +43,7 @@ func TestProvider_EmptyBuffer(t *testing.T) {
 
 func TestProvider_SingleEntry(t *testing.T) {
 	now := time.Date(2025, 6, 15, 14, 30, 0, 0, time.UTC)
-	p := NewStateWindowProvider(10, 30*time.Minute, time.UTC, nil, nil)
+	p := NewStateWindowProvider(10, 30*time.Minute, nil, nil)
 	p.nowFunc = fixedClock(now)
 
 	p.HandleStateChange("binary_sensor.front_door", "off", "on", "")
@@ -72,7 +72,7 @@ func TestProvider_SingleEntry(t *testing.T) {
 
 func TestProvider_MultipleEntries_NewestFirst(t *testing.T) {
 	base := time.Date(2025, 6, 15, 14, 0, 0, 0, time.UTC)
-	p := NewStateWindowProvider(10, 30*time.Minute, time.UTC, nil, nil)
+	p := NewStateWindowProvider(10, 30*time.Minute, nil, nil)
 	clock := advancingClock(base, time.Minute)
 	p.nowFunc = clock
 
@@ -98,7 +98,7 @@ func TestProvider_MultipleEntries_NewestFirst(t *testing.T) {
 
 func TestProvider_CircularEviction(t *testing.T) {
 	now := time.Date(2025, 6, 15, 14, 0, 0, 0, time.UTC)
-	p := NewStateWindowProvider(3, time.Hour, time.UTC, nil, nil)
+	p := NewStateWindowProvider(3, time.Hour, nil, nil)
 	clock := advancingClock(now, time.Minute)
 	p.nowFunc = clock
 
@@ -131,7 +131,7 @@ func TestProvider_CircularEviction(t *testing.T) {
 
 func TestProvider_AgeEviction(t *testing.T) {
 	now := time.Date(2025, 6, 15, 14, 0, 0, 0, time.UTC)
-	p := NewStateWindowProvider(10, 10*time.Minute, time.UTC, nil, nil)
+	p := NewStateWindowProvider(10, 10*time.Minute, nil, nil)
 
 	// Insert an entry 15 minutes ago.
 	p.nowFunc = fixedClock(now.Add(-15 * time.Minute))
@@ -158,7 +158,7 @@ func TestProvider_AgeEviction(t *testing.T) {
 
 func TestProvider_AllExpired(t *testing.T) {
 	now := time.Date(2025, 6, 15, 14, 0, 0, 0, time.UTC)
-	p := NewStateWindowProvider(10, 5*time.Minute, time.UTC, nil, nil)
+	p := NewStateWindowProvider(10, 5*time.Minute, nil, nil)
 
 	// Insert entries 10 minutes ago.
 	p.nowFunc = fixedClock(now.Add(-10 * time.Minute))
@@ -178,7 +178,7 @@ func TestProvider_AllExpired(t *testing.T) {
 
 func TestProvider_DeltaFormat(t *testing.T) {
 	now := time.Date(2025, 6, 15, 14, 30, 0, 0, time.UTC)
-	p := NewStateWindowProvider(10, 30*time.Minute, time.UTC, nil, nil)
+	p := NewStateWindowProvider(10, 30*time.Minute, nil, nil)
 
 	// Insert an entry 5 minutes ago.
 	p.nowFunc = fixedClock(now.Add(-5 * time.Minute))
@@ -197,7 +197,7 @@ func TestProvider_DeltaFormat(t *testing.T) {
 }
 
 func TestProvider_HandleStateChange_Concurrent(t *testing.T) {
-	p := NewStateWindowProvider(100, time.Hour, time.UTC, nil, nil)
+	p := NewStateWindowProvider(100, time.Hour, nil, nil)
 
 	var wg sync.WaitGroup
 	for i := 0; i < 50; i++ {
@@ -220,7 +220,7 @@ func TestProvider_HandleStateChange_Concurrent(t *testing.T) {
 
 func TestProvider_SameStateSuppressed(t *testing.T) {
 	now := time.Date(2025, 6, 15, 14, 30, 0, 0, time.UTC)
-	p := NewStateWindowProvider(10, 30*time.Minute, time.UTC, nil, nil)
+	p := NewStateWindowProvider(10, 30*time.Minute, nil, nil)
 	p.nowFunc = fixedClock(now)
 
 	// Same→same should be filtered.
@@ -248,15 +248,15 @@ func TestProvider_SameStateSuppressed(t *testing.T) {
 
 func TestProvider_NilDefaults(t *testing.T) {
 	// Verify constructor handles zero/nil values gracefully.
-	p := NewStateWindowProvider(0, 0, nil, nil, nil)
+	p := NewStateWindowProvider(0, 0, nil, nil)
 	if len(p.entries) != 50 {
 		t.Errorf("expected default maxEntries=50, got %d", len(p.entries))
 	}
 	if p.maxAge != 30*time.Minute {
 		t.Errorf("expected default maxAge=30m, got %v", p.maxAge)
 	}
-	if p.loc != time.Local {
-		t.Error("expected time.Local as default location")
+	if p.translate != nil {
+		t.Error("expected nil translate to stay nil (raw passthrough)")
 	}
 }
 
@@ -265,7 +265,7 @@ func TestProvider_NilDefaults(t *testing.T) {
 // asserted end-to-end in statewindow_semantic_test.go (external package,
 // since contextfmt imports this one).
 func TestStateWindow_SemanticTranslatorApplied(t *testing.T) {
-	p := NewStateWindowProvider(10, 30*time.Minute, time.UTC, func(domain, deviceClass, state string) string {
+	p := NewStateWindowProvider(10, 30*time.Minute, func(domain, deviceClass, state string) string {
 		if domain == "binary_sensor" && deviceClass == "garage_door" {
 			switch state {
 			case "on":

--- a/internal/state/contacts/presence.go
+++ b/internal/state/contacts/presence.go
@@ -193,10 +193,11 @@ func (t *PresenceTracker) Initialize(ctx context.Context, ha StateGetter) error 
 
 // HandleStateChange updates the tracked person's state when a
 // state_changed event is received. It matches the
-// homeassistant.StateWatchHandler function signature. Untracked
-// entities and no-change events are silently ignored. Room data is
-// cleared when a person transitions to "not_home".
-func (t *PresenceTracker) HandleStateChange(entityID, _, newState string) {
+// homeassistant.StateWatchHandler function signature; the old-state and
+// device_class arguments are unused. Untracked entities and no-change
+// events are silently ignored. Room data is cleared when a person
+// transitions to "not_home".
+func (t *PresenceTracker) HandleStateChange(entityID, _, newState, _ string) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 

--- a/internal/state/contacts/presence_test.go
+++ b/internal/state/contacts/presence_test.go
@@ -143,7 +143,7 @@ func TestTracker_HandleStateChange(t *testing.T) {
 	_ = tracker.Initialize(context.Background(), getter)
 
 	// State changes to not_home.
-	tracker.HandleStateChange("person.alice", "home", "not_home")
+	tracker.HandleStateChange("person.alice", "home", "not_home", "")
 
 	result, _ := tracker.TagContext(context.Background(), agentctx.ContextRequest{UserMessage: ""})
 	if !strings.Contains(result, `"state":"away"`) {
@@ -155,8 +155,8 @@ func TestTracker_HandleStateChange_IgnoresUntracked(t *testing.T) {
 	tracker := NewPresenceTracker([]string{"person.alice"}, "UTC", nil)
 
 	// Should not panic or affect tracked entities.
-	tracker.HandleStateChange("person.unknown", "home", "not_home")
-	tracker.HandleStateChange("light.kitchen", "off", "on")
+	tracker.HandleStateChange("person.unknown", "home", "not_home", "")
+	tracker.HandleStateChange("light.kitchen", "off", "on", "")
 
 	result, _ := tracker.TagContext(context.Background(), agentctx.ContextRequest{UserMessage: ""})
 	if !strings.Contains(result, "- **Alice**: unknown") {
@@ -181,7 +181,7 @@ func TestTracker_HandleStateChange_SameState(t *testing.T) {
 	_ = tracker.Initialize(context.Background(), getter)
 
 	// Same state — Since should NOT update.
-	tracker.HandleStateChange("person.alice", "home", "home")
+	tracker.HandleStateChange("person.alice", "home", "home", "")
 
 	tracker.mu.RLock()
 	p := tracker.people["person.alice"]
@@ -218,7 +218,7 @@ func TestTracker_HandleStateChange_ClearsRoom(t *testing.T) {
 	}
 
 	// Transition to not_home should clear room.
-	tracker.HandleStateChange("person.alice", "home", "not_home")
+	tracker.HandleStateChange("person.alice", "home", "not_home", "")
 
 	result, _ = tracker.TagContext(context.Background(), agentctx.ContextRequest{UserMessage: ""})
 	if strings.Contains(result, `"room"`) {
@@ -497,7 +497,7 @@ func TestTracker_ConcurrentAccess(t *testing.T) {
 				if i%2 == 0 {
 					state = "not_home"
 				}
-				tracker.HandleStateChange("person.alice", "", state)
+				tracker.HandleStateChange("person.alice", "", state, "")
 			}
 		}()
 	}


### PR DESCRIPTION
## Summary

The sibling of #1197, on the highest-traffic surface of all. The ambient **state-change window** is injected into the prompt *every turn*, and it rendered every transition as raw HA state — a `garage_door` binary_sensor read `off→on` instead of `closed→open`. So even with #1197 deployed, the surface the model sees most often still ignored the operator's configured "Show as" transform.

## Root cause — attributes discarded at dispatch

`StateWatchHandler` narrowed the WebSocket event to three strings:

```go
type StateWatchHandler func(entityID, oldState, newState string)
```

`StateChangedData.NewState` is a full `*State` whose attributes carry `device_class` (including the operator's "Show as" override — verified against prod in #1197), but the watcher threw it away at dispatch. The window never had the key it needed to translate.

## Fix

- **The watcher delivers `deviceClass`** as a fourth handler argument, extracted from the new state's attributes. `PresenceTracker` (the only other handler) ignores it.
- **The window records it per entry** and translates `from`/`to` at render time through an injected translator — render-time translation means entries buffered up to 30 minutes still pick up vocabulary improvements.
- **The translator is constructor-injected** (`contextfmt.SemanticState`, wired in app): `contextfmt` imports the `homeassistant` package, so the provider can't import it back — the dependency points inward as a plain-strings func. Nil translator = raw passthrough, keeping the provider's dependency-free zero value.

First-observation entries (empty `OldState`), sentinel states, and unmapped values all pass through unchanged.

With this, the same class-aware vocabulary now covers **every** entity-emitting surface: `ha_get_state`, the area/device/home snapshots, watchlist/subscriptions, search/list (#1197), and the ambient window — one visual language for the home, per #1186.

## Design note

The first cut used a `SetSemanticTranslator` setter and tripped the `set_mutators` architecture ratchet (112 vs 111) — rightly: the translator is construction-time wiring, not runtime mutation. Converted to a constructor parameter; the ratchet stays at baseline.

Review round: the constructor's `loc` parameter turned out to be dead weight — stored, defaulted, and documented but never read anywhere in the file's history (`git log -S`). Removed it (and the timezone plumbing in app that fed it) rather than carry a phantom API parameter through a signature change.

## Test plan

- [x] Watcher delivers `device_class` from the new state's attributes (empty for classless entities)
- [x] Window plumbing: translator applied to `from`/`to`; untranslated states pass through (in-package test, stub translator)
- [x] End-to-end with the real vocabulary (`contextfmt.SemanticState`, external test package to dodge the import cycle): the prod garage-bay scenario renders `closed→open`, moisture renders `dry→wet`, a classless light stays raw `off→on`
- [x] PresenceTracker behavior unchanged (signature updated, tests green)
- [x] `just ci` green locally (unpiped, real exit code verified)

Refs #1186, #1175.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

