### PR TITLE
feat(ha): adopt 2026.7 in_zones presence semantics

### DIFF
--- a/internal/integrations/homeassistant/contextfmt/entity_format.go
+++ b/internal/integrations/homeassistant/contextfmt/entity_format.go
@@ -285,15 +285,15 @@ func attrString(attrs map[string]any, key string) string {
 	return ""
 }
 
-// attrBool extracts a boolean attribute, returning false if missing or
-// not a bool.
 // attrStringSlice extracts a []string attribute (JSON decodes arrays as
-// []any). Non-string elements are skipped; a missing or empty attribute
-// returns nil.
-func attrStringSlice(attrs map[string]any, key string) []string {
-	raw, ok := attrs[key].([]any)
-	if !ok || len(raw) == 0 {
-		return nil
+// []any). ok reports whether the attribute exists as an array at all, so
+// callers can distinguish present-but-empty (a real, informative value —
+// e.g. an away person's in_zones: []) from an absent attribute. The
+// returned slice is never nil when ok; non-string elements are skipped.
+func attrStringSlice(attrs map[string]any, key string) (values []string, ok bool) {
+	raw, isArray := attrs[key].([]any)
+	if !isArray {
+		return nil, false
 	}
 	out := make([]string, 0, len(raw))
 	for _, v := range raw {
@@ -301,12 +301,11 @@ func attrStringSlice(attrs map[string]any, key string) []string {
 			out = append(out, s)
 		}
 	}
-	if len(out) == 0 {
-		return nil
-	}
-	return out
+	return out, true
 }
 
+// attrBool extracts a boolean attribute, returning false if missing or
+// not a bool.
 func attrBool(attrs map[string]any, key string) bool {
 	if v, ok := attrs[key].(bool); ok {
 		return v
@@ -326,17 +325,21 @@ type personContext struct {
 	// several zones at once (nested zones); State reports only the
 	// smallest, so "is she home" reads from in_zones, not State — a
 	// person whose State is a nested zone's name is still home when
-	// zone.home is in this list.
-	InZones []string `json:"in_zones,omitempty"`
+	// zone.home is in this list. Pointer so present-but-empty (away: HA
+	// reports in_zones: []) renders an explicit [] rather than being
+	// omitted — absence means the source doesn't speak in_zones at all.
+	InZones *[]string `json:"in_zones,omitempty"`
 }
 
 func formatPerson(state *homeassistant.State, now time.Time) string {
 	pc := personContext{
-		Entity:  state.EntityID,
-		State:   state.State,
-		Since:   promptfmt.FormatDeltaOnly(state.LastChanged, now),
-		Source:  attrString(state.Attributes, "source"),
-		InZones: attrStringSlice(state.Attributes, "in_zones"),
+		Entity: state.EntityID,
+		State:  state.State,
+		Since:  promptfmt.FormatDeltaOnly(state.LastChanged, now),
+		Source: attrString(state.Attributes, "source"),
+	}
+	if zones, ok := attrStringSlice(state.Attributes, "in_zones"); ok {
+		pc.InZones = &zones
 	}
 	return promptfmt.MarshalCompact(pc)
 }

--- a/internal/integrations/homeassistant/contextfmt/entity_format.go
+++ b/internal/integrations/homeassistant/contextfmt/entity_format.go
@@ -287,6 +287,26 @@ func attrString(attrs map[string]any, key string) string {
 
 // attrBool extracts a boolean attribute, returning false if missing or
 // not a bool.
+// attrStringSlice extracts a []string attribute (JSON decodes arrays as
+// []any). Non-string elements are skipped; a missing or empty attribute
+// returns nil.
+func attrStringSlice(attrs map[string]any, key string) []string {
+	raw, ok := attrs[key].([]any)
+	if !ok || len(raw) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(raw))
+	for _, v := range raw {
+		if s, ok := v.(string); ok && s != "" {
+			out = append(out, s)
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
 func attrBool(attrs map[string]any, key string) bool {
 	if v, ok := attrs[key].(bool); ok {
 		return v
@@ -302,14 +322,21 @@ type personContext struct {
 	State  string `json:"state"`
 	Since  string `json:"since"`
 	Source string `json:"source,omitempty"`
+	// InZones is HA 2026.7's multi-zone membership. A person can be in
+	// several zones at once (nested zones); State reports only the
+	// smallest, so "is she home" reads from in_zones, not State — a
+	// person whose State is a nested zone's name is still home when
+	// zone.home is in this list.
+	InZones []string `json:"in_zones,omitempty"`
 }
 
 func formatPerson(state *homeassistant.State, now time.Time) string {
 	pc := personContext{
-		Entity: state.EntityID,
-		State:  state.State,
-		Since:  promptfmt.FormatDeltaOnly(state.LastChanged, now),
-		Source: attrString(state.Attributes, "source"),
+		Entity:  state.EntityID,
+		State:   state.State,
+		Since:   promptfmt.FormatDeltaOnly(state.LastChanged, now),
+		Source:  attrString(state.Attributes, "source"),
+		InZones: attrStringSlice(state.Attributes, "in_zones"),
 	}
 	return promptfmt.MarshalCompact(pc)
 }

--- a/internal/integrations/homeassistant/contextfmt/entity_format_test.go
+++ b/internal/integrations/homeassistant/contextfmt/entity_format_test.go
@@ -1,7 +1,10 @@
 package contextfmt
 
 import (
+	"encoding/json"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/nugget/thane-ai-agent/internal/integrations/homeassistant"
 )
@@ -34,5 +37,43 @@ func TestAttachMetadataSkipsNonJSONObject(t *testing.T) {
 
 	if got := AttachMetadata(formatted, metadata); got != formatted {
 		t.Fatalf("AttachMetadata() = %s, want original payload", got)
+	}
+}
+
+func TestFormatPersonCarriesInZones(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 2, 12, 0, 0, 0, time.UTC)
+	state := &homeassistant.State{
+		EntityID: "person.alice",
+		State:    "Pool House",
+		Attributes: map[string]any{
+			"source":   "device_tracker.alicephone",
+			"in_zones": []any{"zone.pool_house", "zone.home"},
+		},
+		LastChanged: now.Add(-5 * time.Minute),
+	}
+
+	got := Format(state, now)
+	var pc struct {
+		State   string   `json:"state"`
+		InZones []string `json:"in_zones"`
+	}
+	if err := json.Unmarshal([]byte(got), &pc); err != nil {
+		t.Fatalf("unmarshal: %v\n%s", err, got)
+	}
+	// State stays the smallest zone (HA semantics); in_zones carries the
+	// full membership so the model can see she is still home.
+	if pc.State != "Pool House" {
+		t.Errorf("state = %q, want Pool House", pc.State)
+	}
+	if len(pc.InZones) != 2 || pc.InZones[0] != "zone.pool_house" || pc.InZones[1] != "zone.home" {
+		t.Errorf("in_zones = %v, want [zone.pool_house zone.home]", pc.InZones)
+	}
+
+	// Without the attribute (scanner-derived person), the field is omitted.
+	bare := &homeassistant.State{EntityID: "person.bob", State: "not_home", LastChanged: now}
+	if out := Format(bare, now); strings.Contains(out, "in_zones") {
+		t.Errorf("in_zones should be omitted when absent: %s", out)
 	}
 }

--- a/internal/integrations/homeassistant/contextfmt/entity_format_test.go
+++ b/internal/integrations/homeassistant/contextfmt/entity_format_test.go
@@ -71,7 +71,19 @@ func TestFormatPersonCarriesInZones(t *testing.T) {
 		t.Errorf("in_zones = %v, want [zone.pool_house zone.home]", pc.InZones)
 	}
 
-	// Without the attribute (scanner-derived person), the field is omitted.
+	// Present-but-empty (HA 2026.7 away): renders an explicit [] so the
+	// model can tell "in no zone" apart from "source doesn't report zones".
+	away := &homeassistant.State{
+		EntityID:    "person.carol",
+		State:       "not_home",
+		Attributes:  map[string]any{"in_zones": []any{}},
+		LastChanged: now,
+	}
+	if out := Format(away, now); !strings.Contains(out, `"in_zones":[]`) {
+		t.Errorf("present-but-empty in_zones should render []: %s", out)
+	}
+
+	// Without the attribute entirely, the field is omitted.
 	bare := &homeassistant.State{EntityID: "person.bob", State: "not_home", LastChanged: now}
 	if out := Format(bare, now); strings.Contains(out, "in_zones") {
 		t.Errorf("in_zones should be omitted when absent: %s", out)

--- a/internal/state/awareness/home_snapshot.go
+++ b/internal/state/awareness/home_snapshot.go
@@ -255,8 +255,9 @@ func homeAnomalyDomain(domain string) bool {
 // several nested zones at once and State reports only the *smallest*,
 // so someone in a zone inside the home (State = that zone's name) is
 // still home — a bare State comparison would miscount them as away.
-// When the attribute is absent (pre-2026.7 HA, scanner-derived person
-// entities), fall back to the State string.
+// When the attribute is absent (a pre-2026.7 HA, or a tracker source
+// that doesn't populate it), fall back to the State string rather than
+// assuming any particular wire shape.
 func presenceIsHome(state *homeassistant.State) bool {
 	if raw, ok := state.Attributes["in_zones"].([]any); ok {
 		for _, z := range raw {

--- a/internal/state/awareness/home_snapshot.go
+++ b/internal/state/awareness/home_snapshot.go
@@ -199,7 +199,7 @@ func classifyHomeMembers(members []areaMember, statesByID map[string]*homeassist
 		switch domain {
 		case "person":
 			s.presence = append(s.presence, renderEntityForArea(state, now))
-			if presenceIsHome(state.State) {
+			if presenceIsHome(state) {
 				s.home++
 			} else {
 				s.away++
@@ -250,11 +250,23 @@ func homeAnomalyDomain(domain string) bool {
 	}
 }
 
-// presenceIsHome reports whether a person entity's state means they are
-// home. Any other value (not_home, or a named zone like "Work") counts
-// as away.
-func presenceIsHome(state string) bool {
-	return strings.EqualFold(state, "home")
+// presenceIsHome reports whether a person entity is home. HA 2026.7's
+// in_zones attribute is authoritative when present: a person can occupy
+// several nested zones at once and State reports only the *smallest*,
+// so someone in a zone inside the home (State = that zone's name) is
+// still home — a bare State comparison would miscount them as away.
+// When the attribute is absent (pre-2026.7 HA, scanner-derived person
+// entities), fall back to the State string.
+func presenceIsHome(state *homeassistant.State) bool {
+	if raw, ok := state.Attributes["in_zones"].([]any); ok {
+		for _, z := range raw {
+			if s, ok := z.(string); ok && strings.EqualFold(s, "zone.home") {
+				return true
+			}
+		}
+		return false
+	}
+	return strings.EqualFold(state.State, "home")
 }
 
 // sortHomeSection orders a section's entities by entity_id for stable,

--- a/internal/state/awareness/home_snapshot_test.go
+++ b/internal/state/awareness/home_snapshot_test.go
@@ -308,3 +308,44 @@ func TestComputeHomeSnapshot_IncludeMetadata(t *testing.T) {
 		t.Errorf("metadata.description = %#v, want Front deadbolt", meta["description"])
 	}
 }
+
+// HA 2026.7 presence semantics: in_zones is authoritative for the
+// home/away rollup. State reports only the *smallest* zone a person is
+// in, so someone in a nested zone inside the home would miscount as
+// away on a bare state comparison.
+func TestComputeHomeSnapshot_InZonesPresence(t *testing.T) {
+	st := func(id, state string, attrs map[string]any) homeassistant.State {
+		return homeassistant.State{EntityID: id, State: state, Attributes: attrs}
+	}
+	client := &fakeAreaClient{
+		entities: []homeassistant.EntityRegistryEntry{
+			{EntityID: "person.alice"},
+			{EntityID: "person.bob"},
+			{EntityID: "person.carol"},
+			{EntityID: "person.dave"},
+		},
+		states: []homeassistant.State{
+			// Alice is in a nested zone inside home: state = smallest zone
+			// name, but zone.home is in in_zones → home.
+			st("person.alice", "Pool House", map[string]any{"in_zones": []any{"zone.pool_house", "zone.home"}}),
+			// Bob is away with the attribute present-and-empty → away.
+			st("person.bob", "not_home", map[string]any{"in_zones": []any{}}),
+			// Carol is in an unrelated zone → away (zone.home absent).
+			st("person.carol", "Work", map[string]any{"in_zones": []any{"zone.work"}}),
+			// Dave has no in_zones (pre-2026.7 / scanner-derived person):
+			// state fallback keeps him home.
+			st("person.dave", "home", nil),
+		},
+	}
+
+	out, err := ComputeHomeSnapshot(context.Background(), client, HomeSnapshotRequest{}, testNow)
+	if err != nil {
+		t.Fatalf("ComputeHomeSnapshot: %v", err)
+	}
+	payload := decodeHome(t, out)
+	summary, _ := payload["summary"].(map[string]any)
+	if summary["home"] != float64(2) || summary["away"] != float64(2) {
+		t.Errorf("summary home/away = %v/%v, want 2/2 (nested-zone alice + fallback dave home)",
+			summary["home"], summary["away"])
+	}
+}

--- a/talents/ha.md
+++ b/talents/ha.md
@@ -286,6 +286,22 @@ rises:
   next move is "tell someone about this," activate notifications;
   HA's tools are about state and control, not interruption.
 
+## Presence and zones
+
+Person entities carry `in_zones` — the full list of zones someone is in
+right now (zones nest, so it can be several at once). The `state` field
+reports only the *smallest* zone: a person in a zone inside the home
+shows that zone's name as state, and `zone.home` in their `in_zones` is
+what says they're still home. Read membership from `in_zones`, not from
+`state == "home"`.
+
+For the reverse question — "who's in zone X" — read the zone entity
+itself: its state is the live occupant count and its `persons` attribute
+lists them (`ha_get_state` on `zone.home`, or `ha_list_entities` with
+`domain: zone` to survey every zone at once). No person-by-person sweep
+needed. Person entities whose location comes from presence scanners
+carry no coordinates — never assume `latitude`/`longitude` exist.
+
 ## Cross-references
 
 - For sustained entity attention across loop iterations, bounce to


### PR DESCRIPTION
## Summary

Closes #1181 — both threads: the 2026.7 presence-semantics alignment and the `battery_level` prod audit. This also clears the last blocker on #1180: the zone-entity guidance here is the native replacement for `ha_get_zone`, the only tool left on the prod ha-mcp allowlist.

## The 2026.7 trap, verified against prod

2026.7 made a person's `state` report only the **smallest** zone they're in, with the new `in_zones` attribute carrying full multi-zone membership. Probed against prod HA (2026.7.0) before writing a line: every person entity carries `in_zones` (`["zone.home"]` when home, `[]` away); scanner-derived persons carry it empty **with no lat/long**; zone entities natively report occupancy (`zone.home` state=`6`, `persons` lists them).

The concrete bug: `ha_home_snapshot`'s presence rollup used `state == "home"`. A person in a nested zone inside the home (state = that zone's name, e.g. `"Pool House"`) counted **away**.

## Changes

- **`presenceIsHome` reads `in_zones`** when present — `zone.home` membership means home, regardless of which nested zone the state names. Falls back to the state string for pre-2026.7 instances and scanner-derived persons that lack the attribute.
- **`formatPerson` (canonical contextfmt projection) emits `in_zones`**, so the watchlist, `ha_get_state`, the state window, and every other person-rendering surface shows full zone membership alongside the smallest-zone state.
- **`talents/ha.md` teaches the grammar**: membership reads from `in_zones`, not `state == "home"`; the reverse "who's in zone X" reads the zone entity itself (state = occupant count, `persons` attribute — no person-by-person sweep); scanner-derived persons carry no coordinates.
- **`PresenceTracker` needs no change** — verified its logic branches only on `not_home`, which stays correct under smallest-zone semantics (a nested-zone person displays that zone's name, which is accurate). Noting it explicitly since the issue names presence context providers.

## battery_level audit (issue thread 2) — clean

Swept prod: **watchlist** (no `device_tracker.*` subscriptions; the UPS battery entities are dedicated sensors — exactly the 2026.7-preferred pattern), **scheduler task payloads** (zero hits), and the **full doc corpus** — kb, dossiers, loop definitions (zero `battery_level` or `device_tracker` mentions). In code, only the vacuum/lock formatters read `battery_level` — domains unaffected by the tracker removals, and nil-safe via `roundAttr`. Prod's device_trackers still carry `battery_level` under 2026.7, i.e. they are not from the removed integrations (iCloud/StarLine/Tractive). **Nothing to repoint.**

## Test plan

- [x] Nested-zone person (state=`"Pool House"`, `in_zones` includes `zone.home`) counts **home** in the snapshot rollup
- [x] `in_zones` present-but-empty counts away; absent attribute falls back to state (scanner-derived / pre-2026.7)
- [x] `formatPerson` carries `in_zones` when present, omits it when absent
- [x] Semantics verified against the live 2026.7 prod instance (attribute shapes recorded above)
- [x] `just ci` green locally (unpiped, real exit code verified)

Refs #1175, #1180.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
