### PR TITLE
docs: retire ha-mcp — native-first is the only HA path

### DIFF
--- a/docs/operating/configuration.md
+++ b/docs/operating/configuration.md
@@ -366,8 +366,8 @@ mcp:
   servers:
     - name: github
       transport: stdio
-      command: npx
-      args: ["-y", "@modelcontextprotocol/server-github"]
+      command: docker
+      args: ["run", "-i", "--rm", "-e", "GITHUB_PERSONAL_ACCESS_TOKEN", "ghcr.io/github/github-mcp-server"]
       env:
         - "GITHUB_PERSONAL_ACCESS_TOKEN=your_token"
       include_tools:

--- a/docs/operating/configuration.md
+++ b/docs/operating/configuration.md
@@ -364,17 +364,15 @@ filesystem record.
 ```yaml
 mcp:
   servers:
-    - name: home-assistant
+    - name: github
       transport: stdio
-      command: /opt/homebrew/bin/uvx
-      args: ["ha-mcp@latest"]
+      command: npx
+      args: ["-y", "@modelcontextprotocol/server-github"]
       env:
-        - "HOMEASSISTANT_URL=https://homeassistant.local"
-        - "HOMEASSISTANT_TOKEN=your_token"
+        - "GITHUB_PERSONAL_ACCESS_TOKEN=your_token"
       include_tools:
-        - ha_search_entities
-        - ha_get_state
-        - ha_call_service
+        - search_code
+        - issue_read
 ```
 
 Optional. Extends Thane's capabilities via the Model Context Protocol.

--- a/docs/operating/homeassistant.md
+++ b/docs/operating/homeassistant.md
@@ -72,15 +72,18 @@ the HA frontend and mobile apps — the official, first-class event bus.
 WebSocket events can trigger agent wakes, enabling proactive behavior without
 polling.
 
-### MCP (ha-mcp)
+### No MCP bridge required
 
-[ha-mcp](https://github.com/karimkhaleel/ha-mcp) provides a broad set of HA tools via
-the Model Context Protocol — search, state queries, service calls, camera
-images, automation traces, area registry, and more. Thane hosts ha-mcp as a
-stdio subprocess and bridges selected tools into the agent loop.
+The native tool set is the complete HA surface — search, state, control
+with target fan-out, history, automation CRUD with traces, service
+discovery, and registry access all speak HA's REST and WebSocket APIs
+directly. Earlier deployments bridged the third-party `ha-mcp` MCP
+server to fill gaps; native parity landed in v0.10.2 and the bridge was
+retired (dropping the `uvx` startup dependency and its supply-chain
+exposure with it).
 
-See [Delegation & MCP](../understanding/delegation.md) for tool gating and
-MCP configuration.
+See [Delegation & MCP](../understanding/delegation.md) for MCP as a
+general extension path.
 
 ### MQTT
 

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -485,10 +485,11 @@ tags from the MCP config's `default_tags` or configuration-side tag
 overrides; they do not have a compiled-in entry in
 `internal/model/toolcatalog/catalog.go`.
 
-The primary MCP server in typical deployments is
-[`ha-mcp`](https://github.com/karimkhaleel/ha-mcp), which exposes
-a broad set of Home Assistant tools beyond Thane's native set. `include_tools`
-filtering in the config narrows the bridged surface.
+Home Assistant needs no MCP bridge: the native `ha_*` tool set above is
+the complete HA surface (the `ha-mcp` bridge was retired in v0.10.2 once
+native parity landed). MCP remains the extension path for capabilities
+Thane doesn't implement natively; `include_tools` filtering in the config
+narrows the bridged surface.
 
 See [Delegation & MCP](../understanding/delegation.md) for
 configuration details.

--- a/docs/understanding/agent-loop.md
+++ b/docs/understanding/agent-loop.md
@@ -91,7 +91,7 @@ Tool calls execute — in parallel where possible. Results feed back into
 the next iteration. Tool calls can be:
 
 - **Native tools** (80+ built-in: HA control, email, contacts, memory, files, etc.)
-- **MCP tools** (bridged from external servers like ha-mcp)
+- **MCP tools** (bridged from external MCP servers)
 - **Runtime tools** generated for this specific loop run, such as declared
   document output tools
 - **Delegation** (spawning a local model to execute a multi-step task)

--- a/docs/understanding/architecture.md
+++ b/docs/understanding/architecture.md
@@ -217,8 +217,8 @@ the chat completions API works out of the box. Open WebUI, custom
 scripts, other agents.
 
 **MCP** (Model Context Protocol) means external tool servers bridge
-into the agent loop without writing Go code. ha-mcp alone adds 90+
-Home Assistant tools.
+into the agent loop without writing Go code — the extension path for
+capabilities Thane doesn't implement natively.
 
 **CardDAV** means contacts sync natively with macOS, iOS, and
 Thunderbird. No export/import workflow, no proprietary sync.

--- a/docs/understanding/delegation.md
+++ b/docs/understanding/delegation.md
@@ -88,8 +88,8 @@ mcp:
   servers:
     - name: github
       transport: stdio
-      command: npx
-      args: ["-y", "@modelcontextprotocol/server-github"]
+      command: docker
+      args: ["run", "-i", "--rm", "-e", "GITHUB_PERSONAL_ACCESS_TOKEN", "ghcr.io/github/github-mcp-server"]
       env:
         - "GITHUB_PERSONAL_ACCESS_TOKEN=your_token"
       include_tools:

--- a/docs/understanding/delegation.md
+++ b/docs/understanding/delegation.md
@@ -70,7 +70,7 @@ The `talents/delegation.md` talent contains:
 - Which capability tags and tool families exist
 - Patterns to follow (search, act, verify for HA)
 - Anti-patterns to avoid (multi-entity delegations, `ha_list_entities` abuse)
-- Known quirks (ha-mcp `return_response` errors, silent `ha_call_service` failures)
+- Known quirks (e.g. silent `ha_call_service` failures)
 
 The frontier model writes precise delegation instructions without ever seeing
 the tool schemas — it knows the tools exist from the talent, and it knows the
@@ -86,17 +86,15 @@ the agent loop. This extends Thane's capabilities without writing Go code.
 ```yaml
 mcp:
   servers:
-    - name: home-assistant
+    - name: github
       transport: stdio
-      command: /opt/homebrew/bin/uvx
-      args: ["ha-mcp@latest"]
+      command: npx
+      args: ["-y", "@modelcontextprotocol/server-github"]
       env:
-        - "HOMEASSISTANT_URL=https://homeassistant.local"
-        - "HOMEASSISTANT_TOKEN=your_token"
+        - "GITHUB_PERSONAL_ACCESS_TOKEN=your_token"
       include_tools:
-        - ha_search_entities
-        - ha_get_state
-        - ha_call_service
+        - search_code
+        - issue_read
         # ... selective inclusion keeps context manageable
 ```
 
@@ -105,12 +103,15 @@ available tools via the MCP protocol, filters to `include_tools` (if
 specified), and bridges filtered tools into the agent loop as
 `mcp_{server}_{tool}` functions.
 
-### ha-mcp
+### A note on Home Assistant
 
-[ha-mcp](https://github.com/karimkhaleel/ha-mcp) provides 90+ Home
-Assistant tools — far more than Thane's native HA tools. With
-`include_tools` filtering, you select the high-value tools to keep delegate
-context manageable.
+HA does not go through MCP. Earlier deployments bridged
+[ha-mcp](https://github.com/karimkhaleel/ha-mcp) for capabilities the
+native tools lacked; the native `ha_*` set reached full parity in
+v0.10.2 (search, targeting, traces, service discovery, vocabulary) and
+the bridge was retired — telemetry showed the model had already stopped
+reaching for it. MCP is for capabilities Thane doesn't implement
+natively.
 
 ### Adding MCP Servers
 

--- a/docs/understanding/glossary.md
+++ b/docs/understanding/glossary.md
@@ -163,8 +163,8 @@ only in Go contexts where the type matters.
 
 A standard protocol for extending LLM capabilities via external tool
 servers. Thane hosts MCP servers as subprocesses and bridges their tools
-into the agent loop. The primary example is ha-mcp, which provides 90+
-Home Assistant tools.
+into the agent loop as `mcp_{server}_{tool}` — the extension path for
+capabilities Thane doesn't implement natively.
 See [Delegation](delegation.md).
 
 ### Metacognitive Loop


### PR DESCRIPTION
## Summary

Closes #1180 — the umbrella's capstone. The operator removed the ha-mcp server block from the production config today; this PR finishes the repo half: the teaching surfaces, so new installs never learn the old path. With this, native-first isn't a preference — it's the only HA path that exists.

## The data that confirmed the removal

Queried prod's `tool_calls` before the config edit, per the issue's watch-usage-to-zero discipline (#1084):

- **Last `mcp_home_assistant_*` call: 2026-05-29** — five weeks of organic zero. The model stopped reaching for the bridge on its own as native tools displaced it, well before anyone pulled the plug.
- **Native `ha_*` tools carry the full load**: `ha_call_service` (28), `ha_get_state` (13), `ha_search_states` (8), `ha_list_entities` (8) in the trailing 48h alone.
- Lifetime bridge traffic for perspective: `ha_call_service` 714, `ha_get_state` 416, `ha_search_entities` 206 — real workhorse volume, all of it now native.

## Acceptance state

- [x] **Prod telemetry confirms zero MCP HA-tool traffic** — five weeks, evidence above
- [x] **Prod config drops the MCP server** — operator edit, 2026-07-03 (kills the `uvx ha-mcp@latest` startup dependency and its supply-chain exposure; takes effect at next restart)
- [x] **Example config allowlist** — already clean; `examples/config.example.yaml` carries only a generic MCP schema example
- [x] **`talents/ha.md` native-first pass** — already clean; the successive umbrella PRs (#1187–#1199) removed every MCP reference as they landed the native replacements
- [x] **Gated on the umbrella landing first** — all six allowlisted tools displaced: `ha_list_services` (#1187), traces (#1188), `bulk_control`/`operation_status` (#1189 targets), `deep_search` (native search suite), `ha_get_zone` (#1199 zone semantics + talent grammar)

## What this PR edits

Seven docs. `operating/homeassistant.md`'s integration section now states the native set is the complete HA surface, with the retirement note; `delegation.md` and `configuration.md` swap their MCP config examples to a neutral server (github) so ha-mcp isn't the canonical example a new operator copies; `reference/tools.md`, `architecture.md`, `glossary.md`, and `agent-loop.md` drop the ha-mcp-as-primary-example framing. `docs/history.md` is deliberately untouched — it's a historical record and ha-mcp is genuinely part of the history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
