### PR TITLE
fix(docs): reject confusable doc_write/doc_edit parameters, guard bodiless creates

### DIFF
--- a/internal/app/loop_outputs.go
+++ b/internal/app/loop_outputs.go
@@ -87,17 +87,23 @@ func buildLoopOutputTools(store *documents.Store, outputs []looppkg.OutputSpec) 
 				Parameters: map[string]any{
 					"type": "object",
 					"properties": map[string]any{
-						"content": map[string]any{
+						"body": map[string]any{
 							"type":        "string",
 							"description": "Complete markdown body for this output. This replaces the document body as the current authoritative state.",
 						},
 					},
-					"required": []string{"content"},
+					"required": []string{"body"},
 				},
 				Handler: func(ctx context.Context, args map[string]any) (string, error) {
-					content, _ := args["content"].(string)
+					// Rename guard: this tool's parameter was unified with the
+					// document tools' body. A loop mid-conversation may replay
+					// the old key from its own history — teach, don't eat.
+					if _, hasContent := args["content"]; hasContent {
+						return "", fmt.Errorf("this tool's markdown parameter is %q (renamed from %q for consistency with the doc tools) — re-call with body", "body", "content")
+					}
+					content, _ := args["body"].(string)
 					if strings.TrimSpace(content) == "" {
-						return "", fmt.Errorf("content is required")
+						return "", fmt.Errorf("body is required")
 					}
 					result, err := store.Write(ctx, documents.WriteArgs{
 						Ref:  output.Ref,

--- a/internal/app/loop_outputs_test.go
+++ b/internal/app/loop_outputs_test.go
@@ -62,7 +62,7 @@ func TestHydrateLoopOutputsBuildsScopedToolsAndContext(t *testing.T) {
 	}
 
 	_, err = hydrated.RuntimeTools[0].Handler(context.Background(), map[string]any{
-		"content": "## Current Sense\n\nEverything is calm.",
+		"body": "## Current Sense\n\nEverything is calm.",
 	})
 	if err != nil {
 		t.Fatalf("replace output handler: %v", err)

--- a/internal/state/documents/intake_tools.go
+++ b/internal/state/documents/intake_tools.go
@@ -109,7 +109,7 @@ func (t *Tools) Commit(ctx context.Context, args CommitArgs) (string, error) {
 		out, err = t.store.Edit(ctx, EditArgs{
 			Ref:     ref,
 			Mode:    mode,
-			Content: body,
+			Body:    body,
 			Section: section,
 			Heading: heading,
 		})

--- a/internal/state/documents/mutate.go
+++ b/internal/state/documents/mutate.go
@@ -131,6 +131,16 @@ func (s *Store) Write(ctx context.Context, args WriteArgs) (*MutationResult, err
 		existingRecord = record
 	}
 
+	// A new document with no body at all is almost never intent — it is
+	// the signature of arguments that missed the schema (a misnamed body
+	// parameter is silently absent here). "Omit to preserve the existing
+	// body" is meaningless on a create, so require the body explicitly;
+	// an empty string remains the documented way to create one blank. A
+	// journal-entry-only write is the one legitimate bodiless create.
+	if !existed && args.Body == nil && strings.TrimSpace(args.JournalEntry) == "" {
+		return nil, fmt.Errorf("creating %s requires body — this write would produce an empty document (pass body, or an explicit empty string to create one blank)", args.Ref)
+	}
+
 	now := time.Now()
 	body := ""
 	if args.Body != nil {

--- a/internal/state/documents/mutate.go
+++ b/internal/state/documents/mutate.go
@@ -42,7 +42,7 @@ type WriteArgs struct {
 type EditArgs struct {
 	Ref         string              `json:"ref"`
 	Mode        string              `json:"mode"`
-	Content     string              `json:"content,omitempty"`
+	Body        string              `json:"body,omitempty"`
 	Section     string              `json:"section,omitempty"`
 	Heading     string              `json:"heading,omitempty"`
 	Level       int                 `json:"level,omitempty"`
@@ -200,13 +200,13 @@ func (s *Store) Edit(ctx context.Context, args EditArgs) (*MutationResult, error
 	case "metadata":
 		// metadata-only update
 	case "replace_body":
-		editedBody = trimDocumentBody(args.Content)
+		editedBody = trimDocumentBody(args.Body)
 	case "append_body":
-		editedBody = appendDocumentBody(body, args.Content)
+		editedBody = appendDocumentBody(body, args.Body)
 	case "prepend_body":
-		editedBody = prependDocumentBody(body, args.Content)
+		editedBody = prependDocumentBody(body, args.Body)
 	case "upsert_section":
-		editedBody, sectionName, err = upsertDocumentSection(body, args.Section, args.Heading, args.Level, args.Content)
+		editedBody, sectionName, err = upsertDocumentSection(body, args.Section, args.Heading, args.Level, args.Body)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/state/documents/mutate_test.go
+++ b/internal/state/documents/mutate_test.go
@@ -73,7 +73,7 @@ func TestStoreEditUpsertSectionPreservesCreated(t *testing.T) {
 		Ref:     "kb:system.md",
 		Mode:    "upsert_section",
 		Section: "Observations",
-		Content: "Fresh note.",
+		Body:    "Fresh note.",
 	})
 	if err != nil {
 		t.Fatalf("Edit: %v", err)

--- a/internal/state/knowledge/subject_context_test.go
+++ b/internal/state/knowledge/subject_context_test.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/nugget/thane-ai-agent/internal/runtime/agentctx"
 	_ "modernc.org/sqlite"
@@ -135,11 +136,22 @@ func TestSubjectContextProvider_GetContext(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			store := newTestStore(t)
 
-			// Populate
-			for _, f := range tt.facts {
+			// Populate. Pin updated_at deterministically afterwards:
+			// GetBySubjects orders by updated_at DESC (second precision)
+			// with a key tiebreak, so Set calls that straddle a second
+			// boundary reorder the facts and maxFacts truncation drops a
+			// different one per run (the CI flake: fact3 landing one
+			// second after fact1/fact2 evicted fact2). Earlier-listed
+			// facts are pinned newer, so truncation keeps listed order.
+			base := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+			for i, f := range tt.facts {
 				_, err := store.Set(f.category, f.key, f.value, "test", 1.0, f.subjects, "")
 				if err != nil {
 					t.Fatalf("Set(%s/%s): %v", f.category, f.key, err)
+				}
+				ts := base.Add(-time.Duration(i) * time.Minute)
+				if _, err := store.db.Exec(`UPDATE facts SET updated_at = ? WHERE key = ?`, ts, f.key); err != nil {
+					t.Fatalf("pin updated_at for %s: %v", f.key, err)
 				}
 			}
 

--- a/internal/tools/document_mutation_tools.go
+++ b/internal/tools/document_mutation_tools.go
@@ -44,7 +44,7 @@ func registerDocumentMutationTools(r *Registry, dt *documents.Tools) {
 				},
 				"body": map[string]any{
 					"type":        "string",
-					"description": "Markdown body content to write. Omit to preserve an existing document's body; pass an empty string to intentionally clear it. Creating a new document requires body. (This tool's parameter is body — doc_edit is the tool that takes content.)",
+					"description": "Markdown body content to write. Omit to preserve an existing document's body; pass an empty string to intentionally clear it. Creating a new document requires body. Every document tool's markdown parameter is named body.",
 				},
 				"journal_entry": map[string]any{
 					"type":        "string",
@@ -65,7 +65,7 @@ func registerDocumentMutationTools(r *Registry, dt *documents.Tools) {
 			// (the model sent content + mode: replace_body). Fail fast
 			// with a redirect so the model self-corrects on retry.
 			if _, hasContent := args["content"]; hasContent {
-				return "", fmt.Errorf("doc_write has no %q parameter — markdown goes in %q. (doc_edit is the tool whose body edits take %q.) Re-call doc_write with body, or use doc_edit", "content", "body", "content")
+				return "", fmt.Errorf("doc_write has no %q parameter — markdown goes in %q (every document tool takes body). Re-call with body", "content", "body")
 			}
 			if _, hasMode := args["mode"]; hasMode {
 				return "", fmt.Errorf("doc_write has no %q parameter — it always creates or replaces the whole document. For mode-based edits (replace_body, append_body, upsert_section, ...) use doc_edit", "mode")
@@ -99,9 +99,9 @@ func registerDocumentMutationTools(r *Registry, dt *documents.Tools) {
 					"type":        "string",
 					"description": "Edit mode: `metadata`, `replace_body`, `append_body`, `prepend_body`, `upsert_section`, or `delete_section`.",
 				},
-				"content": map[string]any{
+				"body": map[string]any{
 					"type":        "string",
-					"description": "Markdown content for body or section edits.",
+					"description": "Markdown text for body or section edits — the same parameter name doc_write uses.",
 				},
 				"section": map[string]any{
 					"type":        "string",
@@ -145,13 +145,14 @@ func registerDocumentMutationTools(r *Registry, dt *documents.Tools) {
 			if mode == "" {
 				return "", fmt.Errorf("mode is required")
 			}
-			// Mirror of doc_write's confusable guard: doc_write's body on
-			// doc_edit would be silently ignored and the edit would apply
-			// with empty content.
-			if _, hasBody := args["body"]; hasBody {
-				return "", fmt.Errorf("doc_edit has no %q parameter — markdown for body and section edits goes in %q. (doc_write is the tool that takes %q.)", "body", "content", "body")
+			// Rename guard: doc_edit's text parameter was unified with
+			// doc_write's as body (the content/body split silently ate a
+			// write's markdown — see doc_write's guard). Teach the rename
+			// instead of silently ignoring the old key.
+			if _, hasContent := args["content"]; hasContent {
+				return "", fmt.Errorf("doc_edit's markdown parameter is %q (the %q parameter was renamed for consistency with doc_write) — re-call with body", "body", "content")
 			}
-			content, _ := args["content"].(string)
+			content, _ := args["body"].(string)
 			section, _ := args["section"].(string)
 			heading, _ := args["heading"].(string)
 			title, _ := args["title"].(string)
@@ -159,7 +160,7 @@ func registerDocumentMutationTools(r *Registry, dt *documents.Tools) {
 			return dt.Edit(ctx, documents.EditArgs{
 				Ref:         ref,
 				Mode:        mode,
-				Content:     content,
+				Body:        content,
 				Section:     section,
 				Heading:     heading,
 				Level:       numericArg(args["level"], 2, 6),

--- a/internal/tools/document_mutation_tools.go
+++ b/internal/tools/document_mutation_tools.go
@@ -101,7 +101,7 @@ func registerDocumentMutationTools(r *Registry, dt *documents.Tools) {
 				},
 				"body": map[string]any{
 					"type":        "string",
-					"description": "Markdown text for body or section edits — the same parameter name doc_write uses.",
+					"description": "Markdown text for the edit — the same parameter name doc_write uses. For the body modes this is the document's new body (whole or appended/prepended text); for upsert_section it is only that one section's text — never the whole document.",
 				},
 				"section": map[string]any{
 					"type":        "string",

--- a/internal/tools/document_mutation_tools.go
+++ b/internal/tools/document_mutation_tools.go
@@ -44,7 +44,7 @@ func registerDocumentMutationTools(r *Registry, dt *documents.Tools) {
 				},
 				"body": map[string]any{
 					"type":        "string",
-					"description": "Markdown body content to write. Omit to preserve the existing body; pass an empty string to intentionally clear it.",
+					"description": "Markdown body content to write. Omit to preserve an existing document's body; pass an empty string to intentionally clear it. Creating a new document requires body. (This tool's parameter is body — doc_edit is the tool that takes content.)",
 				},
 				"journal_entry": map[string]any{
 					"type":        "string",
@@ -57,6 +57,18 @@ func registerDocumentMutationTools(r *Registry, dt *documents.Tools) {
 			ref, _ := args["ref"].(string)
 			if ref == "" {
 				return "", fmt.Errorf("ref is required")
+			}
+			// Confusable-parameter guards: doc_edit's vocabulary on
+			// doc_write previously vanished silently — the unknown key was
+			// ignored, an empty document was written, and success was
+			// returned. A prod archivist run lost three dossiers this way
+			// (the model sent content + mode: replace_body). Fail fast
+			// with a redirect so the model self-corrects on retry.
+			if _, hasContent := args["content"]; hasContent {
+				return "", fmt.Errorf("doc_write has no %q parameter — markdown goes in %q. (doc_edit is the tool whose body edits take %q.) Re-call doc_write with body, or use doc_edit", "content", "body", "content")
+			}
+			if _, hasMode := args["mode"]; hasMode {
+				return "", fmt.Errorf("doc_write has no %q parameter — it always creates or replaces the whole document. For mode-based edits (replace_body, append_body, upsert_section, ...) use doc_edit", "mode")
 			}
 			title, _ := args["title"].(string)
 			description, _ := args["description"].(string)
@@ -132,6 +144,12 @@ func registerDocumentMutationTools(r *Registry, dt *documents.Tools) {
 			}
 			if mode == "" {
 				return "", fmt.Errorf("mode is required")
+			}
+			// Mirror of doc_write's confusable guard: doc_write's body on
+			// doc_edit would be silently ignored and the edit would apply
+			// with empty content.
+			if _, hasBody := args["body"]; hasBody {
+				return "", fmt.Errorf("doc_edit has no %q parameter — markdown for body and section edits goes in %q. (doc_write is the tool that takes %q.)", "body", "content", "body")
 			}
 			content, _ := args["content"].(string)
 			section, _ := args["section"].(string)

--- a/internal/tools/document_tools_test.go
+++ b/internal/tools/document_tools_test.go
@@ -404,19 +404,55 @@ func TestDocWriteRejectsDocEditVocabulary(t *testing.T) {
 	}
 }
 
-func TestDocEditRejectsDocWriteVocabulary(t *testing.T) {
+// doc_edit's text parameter is unified with doc_write's as body; the
+// legacy content key gets a rename-teaching error instead of being
+// silently ignored (a model replaying old history would otherwise
+// apply an edit with empty text).
+func TestDocEditTakesBodyAndTeachesContentRename(t *testing.T) {
 	t.Parallel()
 
-	reg, _ := newTestDocumentRegistry(t)
+	reg, store := newTestDocumentRegistry(t)
+	writeTool := reg.Get("doc_write")
 	editTool := reg.Get("doc_edit")
 
-	_, err := editTool.Handler(context.Background(), map[string]any{
-		"ref":  "kb:notes/anything.md",
+	if _, err := writeTool.Handler(context.Background(), map[string]any{
+		"ref":  "kb:notes/unified.md",
+		"body": "original",
+	}); err != nil {
+		t.Fatalf("seed doc_write: %v", err)
+	}
+
+	// The unified vocabulary: body works on doc_edit.
+	if _, err := editTool.Handler(context.Background(), map[string]any{
+		"ref":  "kb:notes/unified.md",
 		"mode": "replace_body",
-		"body": "content in the wrong parameter",
+		"body": "replaced via body",
+	}); err != nil {
+		t.Fatalf("doc_edit with body: %v", err)
+	}
+	record, err := store.Read(context.Background(), "kb:notes/unified.md")
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if strings.TrimSpace(record.Body) != "replaced via body" {
+		t.Fatalf("body = %q, want replacement applied", record.Body)
+	}
+
+	// The legacy key teaches the rename and applies nothing.
+	_, err = editTool.Handler(context.Background(), map[string]any{
+		"ref":     "kb:notes/unified.md",
+		"mode":    "replace_body",
+		"content": "must not be applied",
 	})
-	if err == nil || !strings.Contains(err.Error(), "content") {
-		t.Errorf("doc_edit with body should teach the content parameter, got: %v", err)
+	if err == nil || !strings.Contains(err.Error(), "renamed") {
+		t.Errorf("doc_edit with content should teach the rename, got: %v", err)
+	}
+	record, err = store.Read(context.Background(), "kb:notes/unified.md")
+	if err != nil {
+		t.Fatalf("Read after rejected edit: %v", err)
+	}
+	if strings.TrimSpace(record.Body) != "replaced via body" {
+		t.Errorf("rejected edit still mutated the document: %q", record.Body)
 	}
 }
 

--- a/internal/tools/document_tools_test.go
+++ b/internal/tools/document_tools_test.go
@@ -363,3 +363,89 @@ func newTestDocumentRegistry(t *testing.T) (*Registry, *documents.Store) {
 func stringPtr(s string) *string {
 	return &s
 }
+
+// The prod incident (2026-07-02): the archivist model called doc_write
+// with doc_edit's vocabulary — {"content": <full dossier>, "mode":
+// "replace_body", "ref": ...}. The unknown keys were silently ignored,
+// an empty document was created, and success was returned; three
+// dossiers' content survived only in the tool-call log. These guards
+// turn that silent data loss into a self-correcting error.
+func TestDocWriteRejectsDocEditVocabulary(t *testing.T) {
+	t.Parallel()
+
+	reg, store := newTestDocumentRegistry(t)
+	writeTool := reg.Get("doc_write")
+
+	// The exact prod argument shape.
+	_, err := writeTool.Handler(context.Background(), map[string]any{
+		"ref":     "kb:dossiers/entity-binary_sensor-zone25_garage_bay_3.md",
+		"content": "# Dossier: full content that must not be lost",
+		"mode":    "replace_body",
+	})
+	if err == nil {
+		t.Fatal("doc_write with content+mode succeeded; want a redirect error")
+	}
+	if !strings.Contains(err.Error(), "body") {
+		t.Errorf("error should teach the body parameter: %v", err)
+	}
+	// Nothing may be created by the failed call.
+	if _, readErr := store.Read(context.Background(), "kb:dossiers/entity-binary_sensor-zone25_garage_bay_3.md"); readErr == nil {
+		t.Error("failed doc_write still created a document")
+	}
+
+	// mode alone (even with a valid body) is doc_edit vocabulary.
+	_, err = writeTool.Handler(context.Background(), map[string]any{
+		"ref":  "kb:notes/mode-guard.md",
+		"body": "real body",
+		"mode": "append_body",
+	})
+	if err == nil || !strings.Contains(err.Error(), "doc_edit") {
+		t.Errorf("doc_write with mode should redirect to doc_edit, got: %v", err)
+	}
+}
+
+func TestDocEditRejectsDocWriteVocabulary(t *testing.T) {
+	t.Parallel()
+
+	reg, _ := newTestDocumentRegistry(t)
+	editTool := reg.Get("doc_edit")
+
+	_, err := editTool.Handler(context.Background(), map[string]any{
+		"ref":  "kb:notes/anything.md",
+		"mode": "replace_body",
+		"body": "content in the wrong parameter",
+	})
+	if err == nil || !strings.Contains(err.Error(), "content") {
+		t.Errorf("doc_edit with body should teach the content parameter, got: %v", err)
+	}
+}
+
+// Creating a new document requires body: an omitted body means
+// "preserve", which is meaningless on a create and is the signature of
+// arguments that missed the schema. An explicit empty string stays the
+// documented way to create a blank document.
+func TestDocWriteCreateRequiresBody(t *testing.T) {
+	t.Parallel()
+
+	reg, store := newTestDocumentRegistry(t)
+	writeTool := reg.Get("doc_write")
+
+	_, err := writeTool.Handler(context.Background(), map[string]any{
+		"ref":   "kb:notes/bodiless-create.md",
+		"title": "Bodiless",
+	})
+	if err == nil || !strings.Contains(err.Error(), "requires body") {
+		t.Fatalf("bodiless create should error, got: %v", err)
+	}
+	if _, readErr := store.Read(context.Background(), "kb:notes/bodiless-create.md"); readErr == nil {
+		t.Error("failed bodiless create still produced a document")
+	}
+
+	// Explicit empty string: intentional blank create still works.
+	if _, err := writeTool.Handler(context.Background(), map[string]any{
+		"ref":  "kb:notes/intentional-blank.md",
+		"body": "",
+	}); err != nil {
+		t.Fatalf("explicit empty-body create should succeed: %v", err)
+	}
+}

--- a/talents/documents.md
+++ b/talents/documents.md
@@ -291,7 +291,10 @@ section-level upsert/delete.
 
 Section edits target by heading text or slug. The upsert mode inserts
 if the section is missing, replaces if present; the delete mode removes
-the named section entirely.
+the named section entirely. In section modes, `body` carries only that
+one section's text — never the whole document; the rest of the document
+is untouched. (For whole-document rewrites, `body` is the full new
+document body, same as `doc_write`.)
 
 ## Rolling journal — `doc_journal_update`
 

--- a/talents/documents.md
+++ b/talents/documents.md
@@ -285,7 +285,7 @@ section-level upsert/delete.
   "mode": "upsert_section",
   "section": "VLAN 30 — IoT",
   "level": 2,
-  "content": "VLAN 30 carries IoT devices. DHCP pool: 10.30.0.0/24. No outbound WAN.\n"
+  "body": "VLAN 30 carries IoT devices. DHCP pool: 10.30.0.0/24. No outbound WAN.\n"
 }
 ```
 


### PR DESCRIPTION
## Summary

Closes #1201 — the prod incident where `doc_write` silently ate three dossiers' content. Full forensics in the issue; the short version: the archivist model sent a complete dossier in `content` + `mode: "replace_body"` (doc_edit's vocabulary), `doc_write` ignored the unknown keys, created a frontmatter-only file, and **returned success** — so the model narrated a completion that never happened. No pre-existing data was touched (every empty commit was a new file), and the lost content was recovered from the `tool_calls` log.

The trap was ours: `doc_write` takes `body` while its sibling `doc_edit` takes `content` for the same concept. A local model blending the two vocabularies isn't unreasonable — the tool's job at that moment is to fail loudly, not write an empty file. Same failure class as #1103's `parent_name`-in-metadata: real data lands where the runtime doesn't read, and tolerance converts a naming slip into phantom success.

## The guards

- **`doc_write` rejects `content` and `mode`** with redirects that teach the correct parameter and name `doc_edit` for mode-based edits. Tool errors land in the model's context, so the retry self-corrects — exactly how the #1189 phantom-success guard works for unknown service targets.
- **`doc_edit` rejects `body`** symmetrically.
- **Creating a *new* document requires `body`** (store-level, `Store.Write`): "omit to preserve the existing body" is meaningless on a create, and a bodiless create is the signature of arguments that missed the schema — this catches *any* misnamed body key, not just the two we know about. Explicit `body: ""` still creates a blank document (the documented contract); a journal-entry-only write remains the one legitimate bodiless create. All non-tool `Write` callers pass `Body` explicitly (verified: loop-create scaffold, loop outputs, intake).

The `body` parameter description now also states that creating a new document requires it, and names the `body`-vs-`content` distinction outright.

## Round 2: remove the trap, don't just fence it

The operator asked the right question: why keep two names at all? This PR now **unifies the vocabulary** — `doc_edit` and the loop-declared replace-output runtime tool take `body`, matching `doc_write`, `doc_intake`, `doc_read`'s output shape, and `doc_edit`'s own mode names (`replace_body`, `append_body`). Every model-facing markdown parameter on the document surface shares one name; journal entries stay `entry` (a genuinely distinct concept).

The legacy `content` key gets a rename-teaching error on both tools instead of silent ignoring — a model replaying old conversation history would otherwise apply an edit with empty text, the exact bug class this PR closes. And the smoking gun for how the model learned the blend: `talents/documents.md`'s own `doc_edit` example taught `content`. Updated.

The original guards remain as defense-in-depth: `mode` on `doc_write` still redirects to `doc_edit`, and the store-level bodiless-create guard catches any *future* vocabulary drift regardless of key name.

## Test plan

- [x] The exact prod argument shape (`content` + `mode`) errors with a teaching redirect and creates nothing
- [x] `mode` on doc_write redirects to doc_edit even alongside a valid `body`
- [x] `doc_edit` with `body` errors symmetrically
- [x] Bodiless create errors and creates nothing; explicit `body: ""` create and journal-only create still work
- [x] Pre-existing preserve/clear-by-intent and journal tests still green
- [x] `doc_edit` accepts `body` and rejects legacy `content` with a rename-teaching error that mutates nothing
- [x] Loop replace-output runtime tool renamed with the same guard
- [x] `just ci` green locally (unpiped, real exit code verified)

Refs #1103, #1173.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

