### PR TITLE
test(knowledge): pin fact timestamps so maxFacts truncation is deterministic

### DIFF
--- a/internal/state/knowledge/subject_context_test.go
+++ b/internal/state/knowledge/subject_context_test.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/nugget/thane-ai-agent/internal/runtime/agentctx"
 	_ "modernc.org/sqlite"
@@ -135,11 +136,22 @@ func TestSubjectContextProvider_GetContext(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			store := newTestStore(t)
 
-			// Populate
-			for _, f := range tt.facts {
+			// Populate. Pin updated_at deterministically afterwards:
+			// GetBySubjects orders by updated_at DESC (second precision)
+			// with a key tiebreak, so Set calls that straddle a second
+			// boundary reorder the facts and maxFacts truncation drops a
+			// different one per run (the CI flake: fact3 landing one
+			// second after fact1/fact2 evicted fact2). Earlier-listed
+			// facts are pinned newer, so truncation keeps listed order.
+			base := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+			for i, f := range tt.facts {
 				_, err := store.Set(f.category, f.key, f.value, "test", 1.0, f.subjects, "")
 				if err != nil {
 					t.Fatalf("Set(%s/%s): %v", f.category, f.key, err)
+				}
+				ts := base.Add(-time.Duration(i) * time.Minute)
+				if _, err := store.db.Exec(`UPDATE facts SET updated_at = ? WHERE key = ?`, ts, f.key); err != nil {
+					t.Fatalf("pin updated_at for %s: %v", f.key, err)
 				}
 			}
 


### PR DESCRIPTION
## Summary

The `maxFacts_limits_output` subtest flaked on [#1202's CI run](https://github.com/nugget/thane-ai-agent/actions/runs/28638550247) with `output missing "fact2"` — in code the PR never touches. Root cause: `GetBySubjects` orders by `updated_at DESC` at **second precision** with a key tiebreak (added in 5288ec12 for this same flake), but the tiebreak only helps when the timestamps actually tie. When the three seeding `Set` calls straddle a second boundary — fact3 landing one second after fact1/fact2 — the order becomes `[fact3, fact1, fact2]` and `maxFacts=2` evicts fact2. Local runs rarely straddle the boundary (passes 20/20 on a dev machine), which is why it survives locally and fires in CI.

The harness now pins `updated_at` per seeded fact (earlier-listed = newer, distinct minutes), so truncation keeps the listed order structurally — deterministic regardless of which wall-clock second each insert lands in. Test-only change; the production ORDER BY is already correct for real data.

## Test plan
- [x] `-count=20` green
- [x] `just ci` green locally (unpiped, real exit code verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)