### PR TITLE
feat(docs): doc_create — the collision check rides the create verb

### DIFF
--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -186,9 +186,10 @@ or signed deltas like `-604800s`.
 | `doc_search` | Full-text and tagged search across roots. |
 | `doc_links` | List inbound/outbound links for a document. |
 | `doc_values` | List frontmatter values (tags, statuses, etc.) across a root. |
-| `doc_intake` | Analyze proposed knowledge against the existing corpus before writing it. |
-| `doc_commit` | Commit an approved `doc_intake` result through managed mutations. |
-| `doc_write` | Write or replace a document. |
+| `doc_create` | Create a new document safely: corpus collision check + normalized placement + write in one call; declines with an analysis when a similar document exists. |
+| `doc_intake` | Analyze proposed knowledge against the existing corpus before writing it (the deliberate two-step form of `doc_create`). |
+| `doc_commit` | Commit an approved `doc_intake`/declined `doc_create` result through managed mutations. |
+| `doc_write` | Replace a document's content (creates at a fresh ref only when the destination is already deliberate — prefer `doc_create` for new documents). |
 | `doc_edit` | Targeted edit within a document. |
 | `doc_copy` | Copy a document to another location. |
 | `doc_move` | Move or rename a document. |

--- a/docs/understanding/document-roots.md
+++ b/docs/understanding/document-roots.md
@@ -203,8 +203,11 @@ signed history.
 
 ## Corpus-Aware Intake
 
-When Thane is about to create durable knowledge, the safest first step
-is `doc_intake`, not guessing a new filename. Intake looks at the target
+When Thane is about to create durable knowledge, the default path is
+`doc_create`, which runs the intake analysis and writes in one call
+when placement is clean — no filename guessing, and the collision check
+rides the create verb itself. The two-step `doc_intake` → `doc_commit`
+form remains for inspecting the plan first. Intake looks at the target
 root, searches related documents, checks observed tag vocabulary and
 path patterns, and returns a proposed destination with a recommended
 action:

--- a/internal/model/toolcatalog/catalog.go
+++ b/internal/model/toolcatalog/catalog.go
@@ -162,6 +162,7 @@ var builtinToolSpecs = map[string]BuiltinToolSpec{
 	"doc_at":                      {CanonicalID: "native:doc_at", Source: NativeToolSource, Tags: []string{"documents"}},
 	"doc_browse":                  {CanonicalID: "native:doc_browse", Source: NativeToolSource, Tags: []string{"documents"}},
 	"doc_commit":                  {CanonicalID: "native:doc_commit", Source: NativeToolSource, Tags: []string{"documents"}},
+	"doc_create":                  {CanonicalID: "native:doc_create", Source: NativeToolSource, Tags: []string{"documents"}},
 	"doc_copy":                    {CanonicalID: "native:doc_copy", Source: NativeToolSource, Tags: []string{"documents"}},
 	"doc_copy_section":            {CanonicalID: "native:doc_copy_section", Source: NativeToolSource, Tags: []string{"documents"}},
 	"doc_delete":                  {CanonicalID: "native:doc_delete", Source: NativeToolSource, Tags: []string{"documents"}},

--- a/internal/state/documents/intake_test.go
+++ b/internal/state/documents/intake_test.go
@@ -290,3 +290,114 @@ func containsString(values []string, want string) bool {
 	}
 	return false
 }
+
+// doc_create's clean path: unique knowledge, ready placement — one call
+// analyzes and writes, returning the commit result.
+func TestDocumentCreateCleanPathWritesInOneCall(t *testing.T) {
+	t.Parallel()
+
+	tools, _ := newIntakeTools(t, nil)
+	ctx := context.Background()
+
+	out, err := tools.Create(ctx, CreateArgs{
+		Root:         "kb",
+		DesiredTitle: "Water Softener Service Log",
+		Tags:         []string{"home"},
+		Body:         "# Water Softener Service Log\n\nSalt refilled; next check due in six weeks.",
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	var commit CommitResult
+	if err := json.Unmarshal([]byte(out), &commit); err != nil {
+		t.Fatalf("unmarshal: %v\n%s", err, out)
+	}
+	if commit.Action != IntakeActionCreateNew || commit.Status != "committed" || commit.Ref == "" {
+		t.Fatalf("commit = %#v, want committed create_new with a ref", commit)
+	}
+	doc, err := tools.store.Read(ctx, commit.Ref)
+	if err != nil {
+		t.Fatalf("Read created doc: %v", err)
+	}
+	if !strings.Contains(doc.Body, "Salt refilled") {
+		t.Fatalf("body = %q, want the provided body written", doc.Body)
+	}
+	if doc.Title != "Water Softener Service Log" {
+		t.Fatalf("title = %q, want normalized title", doc.Title)
+	}
+}
+
+// doc_create against a near-duplicate: nothing is written, the analysis
+// comes back created=false with an intake_id, and doc_commit completes
+// the flow deliberately — the COTA-collision scenario from #1038.
+func TestDocumentCreateDeclinesOnSimilarCorpus(t *testing.T) {
+	t.Parallel()
+
+	tools, _ := newIntakeTools(t, nil)
+	ctx := context.Background()
+	body := "# VLAN Guide\n\nHome network VLAN layout for trusted, IoT, and camera segments."
+	if _, err := tools.store.Write(ctx, WriteArgs{
+		Ref:   "kb:network/vlans.md",
+		Title: "VLAN Guide",
+		Tags:  []string{"network", "vlans"},
+		Body:  &body,
+	}); err != nil {
+		t.Fatalf("seed Write: %v", err)
+	}
+
+	out, err := tools.Create(ctx, CreateArgs{
+		Root:         "kb",
+		DesiredTitle: "VLAN Guide",
+		Tags:         []string{"network", "vlans"},
+		Body:         body,
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	var declined struct {
+		Created bool         `json:"created"`
+		Note    string       `json:"note"`
+		Intake  IntakeResult `json:"intake"`
+	}
+	if err := json.Unmarshal([]byte(out), &declined); err != nil {
+		t.Fatalf("unmarshal: %v\n%s", err, out)
+	}
+	if declined.Created {
+		t.Fatal("Create wrote despite a near-duplicate; want created=false")
+	}
+	if declined.Intake.IntakeID == "" || declined.Note == "" {
+		t.Fatalf("declined result missing intake_id or note: %+v", declined)
+	}
+	// The duplicate must not exist as a second document.
+	if declined.Intake.ProposedRef != "" && declined.Intake.ProposedRef != "kb:network/vlans.md" {
+		if _, err := tools.store.Read(ctx, declined.Intake.ProposedRef); err == nil {
+			t.Fatalf("declined create still wrote %s", declined.Intake.ProposedRef)
+		}
+	}
+
+	// The two-step affordance completes from the same intake_id.
+	if _, err := tools.Commit(ctx, CommitArgs{
+		IntakeID: declined.Intake.IntakeID,
+		Action:   IntakeActionUpdateExisting,
+		Body:     "Additional VLAN operational detail via doc_create decline flow.",
+		Confirm:  true,
+	}); err != nil {
+		t.Fatalf("Commit after declined create: %v", err)
+	}
+	doc, err := tools.store.Read(ctx, "kb:network/vlans.md")
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if !strings.Contains(doc.Body, "decline flow") {
+		t.Fatalf("update did not land: %q", doc.Body)
+	}
+}
+
+func TestDocumentCreateRequiresBody(t *testing.T) {
+	t.Parallel()
+
+	tools, _ := newIntakeTools(t, nil)
+	if _, err := tools.Create(context.Background(), CreateArgs{Root: "kb", DesiredTitle: "Empty"}); err == nil || !strings.Contains(err.Error(), "body is required") {
+		t.Fatalf("Create without body error = %v, want body-required", err)
+	}
+}

--- a/internal/state/documents/intake_tools.go
+++ b/internal/state/documents/intake_tools.go
@@ -72,7 +72,8 @@ func (t *Tools) Create(ctx context.Context, args CreateArgs) (string, error) {
 	if !clean {
 		note := "Nothing was created. The corpus analysis recommends " +
 			string(result.RecommendedAction) + " — review related_documents, then either " +
-			"doc_commit with this intake_id (confirm=true if overriding the recommendation) " +
+			"doc_commit with this intake_id and confirm=true (a cautioned intake requires " +
+			"confirmation for any mutating action, even the recommended one) " +
 			"or adjust and call doc_create again."
 		if result.Status == IntakeRefused {
 			note = "Nothing was created: " + result.Reason

--- a/internal/state/documents/intake_tools.go
+++ b/internal/state/documents/intake_tools.go
@@ -9,6 +9,87 @@ import (
 	"time"
 )
 
+// CreateArgs is the one-call create verb: corpus-aware intake analysis
+// plus an immediate managed write when the placement is clean.
+type CreateArgs struct {
+	Root         string   `json:"root,omitempty"`
+	Body         string   `json:"body"`
+	DesiredTitle string   `json:"desired_title,omitempty"`
+	DesiredRef   string   `json:"desired_ref,omitempty"`
+	Tags         []string `json:"tags,omitempty"`
+	PathPrefix   string   `json:"path_prefix,omitempty"`
+	Intent       string   `json:"intent,omitempty"`
+}
+
+// createDeclinedResult wraps the intake analysis when doc_create stops
+// short of writing, so "nothing was created" is an explicit statement
+// the model reads rather than an inference it might skip.
+type createDeclinedResult struct {
+	Created bool         `json:"created"`
+	Note    string       `json:"note"`
+	Intake  IntakeResult `json:"intake"`
+}
+
+// Create is the default create path: it runs the same corpus-aware
+// intake analysis as doc_intake and, when the placement is clean —
+// ready status, create_new recommendation, no confirmation required —
+// commits the document in the same call. When the corpus pushes back
+// (a similar document exists, root policy wants review), nothing is
+// written; the analysis comes back with created=false and an intake_id
+// so doc_commit can proceed deliberately. This puts the collision
+// check on the verb models actually reach for (#1038): creating safely
+// is the default, not an act of discipline.
+func (t *Tools) Create(ctx context.Context, args CreateArgs) (string, error) {
+	if t == nil || t.store == nil {
+		return "", fmt.Errorf("document index not configured")
+	}
+	body := strings.TrimSpace(args.Body)
+	if body == "" {
+		return "", fmt.Errorf("body is required — doc_create writes the full document when placement is clean")
+	}
+	intent := strings.TrimSpace(args.Intent)
+	if intent == "" {
+		intent = "create a new document"
+	}
+	result, err := t.store.Intake(ctx, IntakeArgs{
+		Root:         args.Root,
+		Intent:       intent,
+		BodySnippet:  body,
+		DesiredTitle: args.DesiredTitle,
+		DesiredRef:   args.DesiredRef,
+		Tags:         args.Tags,
+		PathPrefix:   args.PathPrefix,
+	})
+	if err != nil {
+		return "", err
+	}
+	t.rememberIntake(result)
+
+	clean := result.Status == IntakeReady &&
+		result.RecommendedAction == IntakeActionCreateNew &&
+		!result.CommitPlan.RequiresConfirmation &&
+		result.ProposedRef != ""
+	if !clean {
+		note := "Nothing was created. The corpus analysis recommends " +
+			string(result.RecommendedAction) + " — review related_documents, then either " +
+			"doc_commit with this intake_id (confirm=true if overriding the recommendation) " +
+			"or adjust and call doc_create again."
+		if result.Status == IntakeRefused {
+			note = "Nothing was created: " + result.Reason
+		}
+		return marshalToolResult(createDeclinedResult{
+			Created: false,
+			Note:    note,
+			Intake:  *result,
+		})
+	}
+	return t.Commit(ctx, CommitArgs{
+		IntakeID: result.IntakeID,
+		Action:   IntakeActionCreateNew,
+		Body:     body,
+	})
+}
+
 // Intake analyzes where new knowledge should land in a managed corpus.
 func (t *Tools) Intake(ctx context.Context, args IntakeArgs) (string, error) {
 	if t == nil || t.store == nil {

--- a/internal/tools/document_intake_tools.go
+++ b/internal/tools/document_intake_tools.go
@@ -9,8 +9,73 @@ import (
 
 func registerDocumentIntakeTools(r *Registry, dt *documents.Tools) {
 	r.Register(&Tool{
+		Name: "doc_create",
+		Description: "Create a new managed markdown document safely — the default way to make a document exist. Runs the corpus-aware placement analysis (related-document search, title/tags/path normalization, root policy) and, when placement is clean, writes the document in the same call. " +
+			"When a similar document already exists or policy wants review, nothing is written: the result comes back created=false with the analysis and an intake_id for doc_commit. " +
+			"Prefer this over doc_write for any brand-new document; doc_write's create is for destinations that are already deliberate.",
+		ContentResolveExempt: []string{"root", "title", "ref", "tags", "path_prefix"},
+		Parameters: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"root": map[string]any{
+					"type":        "string",
+					"description": "Target managed root without trailing colon, such as `kb` or `scratchpad`. Required unless only one document root exists.",
+				},
+				"body": map[string]any{
+					"type":        "string",
+					"description": "Complete markdown body for the new document. Written as-is when placement is clean.",
+				},
+				"title": map[string]any{
+					"type":        "string",
+					"description": "Optional title hint; the tool may normalize it against corpus conventions.",
+				},
+				"ref": map[string]any{
+					"type":        "string",
+					"description": "Optional explicit document ref such as `kb:network/unifi/vlans.md`. Use only when the destination is already intentional.",
+				},
+				"tags": map[string]any{
+					"type":        "array",
+					"description": "Optional desired tags, normalized against observed corpus vocabulary.",
+					"items":       map[string]any{"type": "string"},
+				},
+				"path_prefix": map[string]any{
+					"type":        "string",
+					"description": "Optional directory hint inside the root, such as `network/unifi`.",
+				},
+				"intent": map[string]any{
+					"type":        "string",
+					"description": "Optional note on what the document is for; improves placement analysis.",
+				},
+			},
+			"required": []string{"body"},
+		},
+		Handler: func(ctx context.Context, args map[string]any) (string, error) {
+			// The vocabulary invariant: every document tool's markdown
+			// parameter is named body (#1201).
+			if _, hasContent := args["content"]; hasContent {
+				return "", fmt.Errorf("doc_create has no %q parameter — markdown goes in %q (every document tool takes body)", "content", "body")
+			}
+			body, _ := args["body"].(string)
+			root, _ := args["root"].(string)
+			title, _ := args["title"].(string)
+			ref, _ := args["ref"].(string)
+			pathPrefix, _ := args["path_prefix"].(string)
+			intent, _ := args["intent"].(string)
+			return dt.Create(ctx, documents.CreateArgs{
+				Root:         root,
+				Body:         body,
+				DesiredTitle: title,
+				DesiredRef:   ref,
+				Tags:         documentStringSliceArg(args["tags"]),
+				PathPrefix:   pathPrefix,
+				Intent:       intent,
+			})
+		},
+	})
+
+	r.Register(&Tool{
 		Name:                 "doc_intake",
-		Description:          "Analyze where proposed new knowledge belongs in a managed markdown corpus before writing it. Use this before creating new knowledge documents: it searches related documents, normalizes title/tags/path, checks root policy, and returns an intake_id plus a commit_plan for doc_commit.",
+		Description:          "Analyze where proposed new knowledge belongs in a managed markdown corpus before writing it — the deliberate two-step flow. It searches related documents, normalizes title/tags/path, checks root policy, and returns an intake_id plus a commit_plan for doc_commit. For the common create case, doc_create runs this analysis and commits in one call; reach for doc_intake when you want to inspect the plan first or when the knowledge may belong in an existing document (update/append).",
 		ContentResolveExempt: []string{"root", "desired_title", "desired_ref", "tags", "path_prefix"},
 		Parameters: map[string]any{
 			"type": "object",

--- a/internal/tools/document_intake_tools.go
+++ b/internal/tools/document_intake_tools.go
@@ -23,7 +23,7 @@ func registerDocumentIntakeTools(r *Registry, dt *documents.Tools) {
 				},
 				"body": map[string]any{
 					"type":        "string",
-					"description": "Complete markdown body for the new document. Written as-is when placement is clean.",
+					"description": "Complete markdown body for the new document, written when placement is clean (outer whitespace is trimmed; frontmatter is managed by the tool).",
 				},
 				"title": map[string]any{
 					"type":        "string",

--- a/internal/tools/document_mutation_tools.go
+++ b/internal/tools/document_mutation_tools.go
@@ -15,7 +15,7 @@ func registerDocumentMutationTools(r *Registry, dt *documents.Tools) {
 
 	r.Register(&Tool{
 		Name:                 "doc_write",
-		Description:          "Create or replace a managed markdown document by semantic ref like `kb:article.md`. This tool owns frontmatter integrity for title, description, tags, created, and updated timestamps, and it can append a stamped entry to a standard `Journal` section so the model can think in documents instead of filesystem paths.",
+		Description:          "Write (replace) a managed markdown document by semantic ref like `kb:article.md`. This tool owns frontmatter integrity for title, description, tags, created, and updated timestamps, and it can append a stamped entry to a standard `Journal` section so the model can think in documents instead of filesystem paths. For brand-new documents prefer doc_create, which collision-checks the corpus and normalizes placement first — doc_write creating a fresh ref is for destinations that are already deliberate.",
 		ContentResolveExempt: []string{"ref", "title", "description", "tags", "frontmatter"},
 		Parameters: map[string]any{
 			"type": "object",

--- a/internal/tools/document_tools_test.go
+++ b/internal/tools/document_tools_test.go
@@ -485,3 +485,46 @@ func TestDocWriteCreateRequiresBody(t *testing.T) {
 		t.Fatalf("explicit empty-body create should succeed: %v", err)
 	}
 }
+
+// doc_create is the default create verb (#1038): one call collision-
+// checks and writes. It carries the unified body vocabulary (#1201).
+func TestDocCreateHandlerWritesAndGuardsVocabulary(t *testing.T) {
+	t.Parallel()
+
+	reg, store := newTestDocumentRegistry(t)
+	createTool := reg.Get("doc_create")
+	if createTool == nil {
+		t.Fatal("doc_create not registered")
+	}
+
+	out, err := createTool.Handler(context.Background(), map[string]any{
+		"root":  "kb",
+		"title": "Fence Charger Notes",
+		"body":  "# Fence Charger Notes\n\nSouth paddock charger reads 7.2kV after the storm.",
+	})
+	if err != nil {
+		t.Fatalf("doc_create: %v", err)
+	}
+	var commit struct {
+		Ref    string `json:"ref"`
+		Status string `json:"status"`
+	}
+	if err := json.Unmarshal([]byte(out), &commit); err != nil {
+		t.Fatalf("unmarshal: %v\n%s", err, out)
+	}
+	if commit.Status != "committed" || commit.Ref == "" {
+		t.Fatalf("result = %s, want committed with ref", out)
+	}
+	if _, err := store.Read(context.Background(), commit.Ref); err != nil {
+		t.Fatalf("created doc unreadable: %v", err)
+	}
+
+	// The unified vocabulary holds here too.
+	_, err = createTool.Handler(context.Background(), map[string]any{
+		"root":    "kb",
+		"content": "markdown in the wrong parameter",
+	})
+	if err == nil || !strings.Contains(err.Error(), "body") {
+		t.Errorf("doc_create with content should teach body, got: %v", err)
+	}
+}

--- a/talents/documents.md
+++ b/talents/documents.md
@@ -247,11 +247,34 @@ teaser: "Body, section, or metadata changes inside one existing document."
 
 Three tools, each owning a different mutation shape.
 
-## Replace or create — `doc_write`
+## Create a new document — `doc_create`
 
-Use when the document should hold *exactly* this body. Creates the
-document if the ref doesn't exist yet. Owns `title`, `description`,
-`tags`, `created`, `updated`:
+The default way to make a document exist. One call collision-checks the
+corpus (related documents, title/tags/path normalization, root policy)
+and writes when placement is clean:
+
+```json
+{
+  "root": "kb",
+  "title": "VLAN renumbering decision",
+  "tags": ["network"],
+  "body": "# VLAN renumbering decision\n\nGuest VLAN moved from 50 to 40...\n"
+}
+```
+
+When a similar document already exists, nothing is written — the result
+comes back `created: false` with the analysis and an `intake_id`:
+review `related_documents`, then `doc_commit` with the intake_id
+(update the existing doc, or `confirm: true` to create anyway), or
+adjust and re-call. Creating safely is the default, not something to
+remember.
+
+## Replace — `doc_write`
+
+Use when an existing document should hold *exactly* this body. It can
+also create at a fresh ref, but that skips the collision check — reach
+for `doc_create` unless the destination is already deliberate. Owns
+`title`, `description`, `tags`, `created`, `updated`:
 
 ```json
 {
@@ -428,9 +451,11 @@ teaser: "Introduce brand-new knowledge into the corpus — intake decides title/
 
 A two-step pipeline for proposing new managed knowledge: `doc_intake`
 analyzes where the knowledge belongs, then `doc_commit` performs the
-mutation through the approved plan. Use this instead of `doc_write`
-when the document doesn't exist yet and you want the system to decide
-the title, path, tags, and target action.
+mutation through the approved plan. For the common create case,
+`doc_create` runs this same analysis and commits in one call — reach
+for the two-step form when you want to inspect the plan before
+committing, or when the knowledge likely belongs in an *existing*
+document (update/append) rather than a new one.
 
 ## Step 1 — propose and analyze
 


### PR DESCRIPTION
## Summary

Closes #1038. The COTA-weekend collision happened because the safety lived on a side door: `doc_intake`'s analysis is exactly what would have caught the 78-day-old near-duplicate, but the model's actual impulse — *I want a document to exist* — reaches for a create verb, and `doc_write` answered it with an unchecked write. As the issue puts it: willpower isn't a strategy; shape the channel.

**`doc_create` is that channel.** One call runs the corpus-aware intake analysis (related-document search, title/tags/path normalization, root policy) and writes immediately when placement is clean. When the corpus pushes back — a similar document exists, policy wants review — **nothing is written**: the result comes back `created: false` with the full analysis and an `intake_id`, and `doc_commit` completes the flow deliberately (update the existing doc, or `confirm: true` to create anyway). Internally it's intake + commit: one code path, no new mutation machinery.

## The issue's open questions, answered

- **Straight rename vs wrapper?** Wrapper. A straight rename would produce a tool named `create` that returns a plan and creates nothing — a different kind of lie than the one we're fixing. `doc_create` creates when it's safe to, and says `created: false` in so many words when it isn't (explicit statement over inference, per model-facing conventions).
- **Keeping the two-step affordance?** `doc_intake` → `doc_commit` survives unchanged for plan-inspection and update/append analysis; both descriptions now cross-reference honestly ("for the common create case, doc_create runs this analysis and commits in one call"). A declined `doc_create` hands you the same `intake_id` the two-step flow would.
- **Back-compat?** Nothing renames away, so no tombstones. `doc_write` keeps its create ability for deliberate destinations (loop scaffolds, known refs) but its description reframes from "create or replace" to "replace" with a pointed nudge toward `doc_create` for anything brand-new — the affordance shift is the mechanism, since models pick tools by name and description every turn.

`doc_create` carries the unified `body` vocabulary from #1202, including the `content`-key teaching guard.

## Test plan

- [x] Clean placement: one call analyzes + writes; normalized title/tags land; body written verbatim
- [x] Near-duplicate corpus (the COTA shape): `created: false`, nothing written, `intake_id` present — and `doc_commit` completes the update from that id
- [x] `body` required; `content` key gets the vocabulary teaching error
- [x] Registered + catalogued (CI gate `TestNativeToolLiteralsAreCatalogued` passes)
- [x] Talent + reference docs teach the new shape
- [x] `just ci` green locally (unpiped, real exit code verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
