### PR TITLE
feat(ha): event + alarm panel projections, vocabulary verified against current HA docs

### DIFF
--- a/internal/integrations/homeassistant/contextfmt/entity_format.go
+++ b/internal/integrations/homeassistant/contextfmt/entity_format.go
@@ -130,6 +130,10 @@ func formatEntityContext(state *homeassistant.State, now time.Time) string {
 		return formatVacuum(state, now)
 	case "update":
 		return formatUpdate(state, now)
+	case "alarm_control_panel":
+		return formatAlarmControlPanel(state, now)
+	case "event":
+		return formatEvent(state, now)
 	default:
 		return formatDefault(state, now)
 	}

--- a/internal/integrations/homeassistant/contextfmt/entity_format_alarm.go
+++ b/internal/integrations/homeassistant/contextfmt/entity_format_alarm.go
@@ -11,10 +11,11 @@ import (
 // Panel state is already semantic (disarmed, armed_home, armed_away,
 // armed_night, armed_vacation, arming, pending, triggered), so no
 // translation is needed — the curation is the attributes a security
-// decision actually wants: who changed it last, and whether disarming
-// needs a code (the model should never suggest an arm/disarm flow the
-// panel will refuse). Attribute names per the current HA
-// alarm_control_panel documentation.
+// decision actually wants: who changed it last, and whether *arming*
+// requires a code (code_arm_required; disarming a panel virtually
+// always does — the flag says whether arming shares that requirement,
+// so the model never proposes an arming flow the panel will refuse).
+// Attribute names per the current HA alarm_control_panel documentation.
 type alarmContext struct {
 	Entity          string `json:"entity"`
 	Name            string `json:"name,omitempty"`

--- a/internal/integrations/homeassistant/contextfmt/entity_format_alarm.go
+++ b/internal/integrations/homeassistant/contextfmt/entity_format_alarm.go
@@ -1,0 +1,39 @@
+package contextfmt
+
+import (
+	"time"
+
+	"github.com/nugget/thane-ai-agent/internal/integrations/homeassistant"
+	"github.com/nugget/thane-ai-agent/internal/model/promptfmt"
+)
+
+// alarmContext is the JSON structure for alarm_control_panel context.
+// Panel state is already semantic (disarmed, armed_home, armed_away,
+// armed_night, armed_vacation, arming, pending, triggered), so no
+// translation is needed — the curation is the attributes a security
+// decision actually wants: who changed it last, and whether disarming
+// needs a code (the model should never suggest an arm/disarm flow the
+// panel will refuse). Attribute names per the current HA
+// alarm_control_panel documentation.
+type alarmContext struct {
+	Entity          string `json:"entity"`
+	Name            string `json:"name,omitempty"`
+	State           string `json:"state"`
+	ChangedBy       string `json:"changed_by,omitempty"`
+	CodeArmRequired bool   `json:"code_arm_required,omitempty"`
+	Since           string `json:"since"`
+}
+
+func formatAlarmControlPanel(state *homeassistant.State, now time.Time) string {
+	ac := alarmContext{
+		Entity:          state.EntityID,
+		State:           state.State,
+		ChangedBy:       attrString(state.Attributes, "changed_by"),
+		CodeArmRequired: attrBool(state.Attributes, "code_arm_required"),
+		Since:           promptfmt.FormatDeltaOnly(state.LastChanged, now),
+	}
+	if name, ok := state.Attributes["friendly_name"].(string); ok && name != "" {
+		ac.Name = name
+	}
+	return promptfmt.MarshalCompact(ac)
+}

--- a/internal/integrations/homeassistant/contextfmt/entity_format_event.go
+++ b/internal/integrations/homeassistant/contextfmt/entity_format_event.go
@@ -1,0 +1,43 @@
+package contextfmt
+
+import (
+	"time"
+
+	"github.com/nugget/thane-ai-agent/internal/integrations/homeassistant"
+	"github.com/nugget/thane-ai-agent/internal/model/promptfmt"
+)
+
+// eventContext is the JSON structure for event entity context (the
+// 2026.7 event domain: doorbell rings, button presses, motion events).
+// An event entity's raw state is the ISO timestamp of the last firing —
+// exactly the shape the model-facing conventions say never to emit.
+// The projection leads with what fired (event_type) and expresses when
+// as the standard since delta; the raw timestamp never appears.
+type eventContext struct {
+	Entity      string `json:"entity"`
+	Name        string `json:"name,omitempty"`
+	Event       string `json:"event"`
+	DeviceClass string `json:"device_class,omitempty"`
+	Since       string `json:"since"`
+}
+
+func formatEvent(state *homeassistant.State, now time.Time) string {
+	ec := eventContext{
+		Entity:      state.EntityID,
+		Event:       attrString(state.Attributes, "event_type"),
+		DeviceClass: attrString(state.Attributes, "device_class"),
+		Since:       promptfmt.FormatDeltaOnly(state.LastChanged, now),
+	}
+	// The state itself is the firing timestamp; when it parses and
+	// LastChanged is missing or zero, derive the delta from it so the
+	// "when" survives sparse inputs.
+	if state.LastChanged.IsZero() {
+		if fired, err := time.Parse(time.RFC3339Nano, state.State); err == nil {
+			ec.Since = promptfmt.FormatDeltaOnly(fired, now)
+		}
+	}
+	if name, ok := state.Attributes["friendly_name"].(string); ok && name != "" {
+		ec.Name = name
+	}
+	return promptfmt.MarshalCompact(ec)
+}

--- a/internal/integrations/homeassistant/contextfmt/entity_format_test.go
+++ b/internal/integrations/homeassistant/contextfmt/entity_format_test.go
@@ -89,3 +89,96 @@ func TestFormatPersonCarriesInZones(t *testing.T) {
 		t.Errorf("in_zones should be omitted when absent: %s", out)
 	}
 }
+
+// The 2026.7 event domain: raw state is the ISO timestamp of the last
+// firing — the exact shape the conventions forbid. The projection leads
+// with what fired and expresses when as a delta; the raw timestamp
+// never reaches the model. Fixture mirrors a live DoorBird event
+// entity verbatim.
+func TestFormatEventProjectsFiringNotTimestamp(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 3, 0, 0, 0, 0, time.UTC)
+	fired := time.Date(2026, 7, 2, 16, 44, 40, 0, time.UTC)
+	state := &homeassistant.State{
+		EntityID: "event.doorbird_3040_motion",
+		State:    "2026-07-02T16:44:40.728+00:00",
+		Attributes: map[string]any{
+			"event_types":   []any{"motion"},
+			"event_type":    "motion",
+			"device_class":  "motion",
+			"friendly_name": "DoorBird-3040 Motion",
+		},
+		LastChanged: fired,
+	}
+
+	got := Format(state, now)
+	if strings.Contains(got, "2026-07-02T16") {
+		t.Errorf("raw ISO timestamp leaked into event context: %s", got)
+	}
+	var ec struct {
+		Event       string `json:"event"`
+		DeviceClass string `json:"device_class"`
+		Since       string `json:"since"`
+	}
+	if err := json.Unmarshal([]byte(got), &ec); err != nil {
+		t.Fatalf("unmarshal: %v\n%s", err, got)
+	}
+	if ec.Event != "motion" || ec.DeviceClass != "motion" {
+		t.Errorf("event/device_class = %q/%q, want motion/motion", ec.Event, ec.DeviceClass)
+	}
+	if ec.Since == "" {
+		t.Errorf("since delta missing: %s", got)
+	}
+
+	// Sparse input: no LastChanged — the delta derives from the state
+	// timestamp itself.
+	sparse := &homeassistant.State{
+		EntityID:   "event.doorbird_3040_pool",
+		State:      "2026-06-29T16:47:15.978+00:00",
+		Attributes: map[string]any{"event_type": "ring", "device_class": "doorbell"},
+	}
+	out := Format(sparse, now)
+	if strings.Contains(out, "2026-06-29T16") {
+		t.Errorf("raw timestamp leaked on sparse input: %s", out)
+	}
+	if !strings.Contains(out, `"since":"-`) {
+		t.Errorf("since not derived from state timestamp: %s", out)
+	}
+}
+
+// Alarm panel state is already semantic; the curation is who changed it
+// and whether arming needs a code. Attribute names per current HA
+// alarm_control_panel documentation.
+func TestFormatAlarmControlPanel(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 3, 0, 0, 0, 0, time.UTC)
+	state := &homeassistant.State{
+		EntityID: "alarm_control_panel.home",
+		State:    "armed_away",
+		Attributes: map[string]any{
+			"friendly_name":      "Home Alarm",
+			"changed_by":         "Alice",
+			"code_arm_required":  true,
+			"supported_features": float64(63), // raw bitmask must not leak
+		},
+		LastChanged: now.Add(-2 * time.Hour),
+	}
+
+	got := Format(state, now)
+	var ac struct {
+		State           string `json:"state"`
+		ChangedBy       string `json:"changed_by"`
+		CodeArmRequired bool   `json:"code_arm_required"`
+	}
+	if err := json.Unmarshal([]byte(got), &ac); err != nil {
+		t.Fatalf("unmarshal: %v\n%s", err, got)
+	}
+	if ac.State != "armed_away" || ac.ChangedBy != "Alice" || !ac.CodeArmRequired {
+		t.Errorf("alarm context = %+v, want armed_away/Alice/code required", ac)
+	}
+	if strings.Contains(got, "supported_features") || strings.Contains(got, "63") {
+		t.Errorf("raw bitmask leaked: %s", got)
+	}
+}

--- a/talents/ha.md
+++ b/talents/ha.md
@@ -123,9 +123,11 @@ entity_id is already in hand:
 }
 ```
 
-The fastest path when the entity_id is already known. Returns the
-state value plus all attributes (brightness, color, last_changed,
-etc.).
+The fastest path when the entity_id is already known. Returns a
+curated, class-aware projection — semantic state plus the attributes
+that matter for that class (a climate entity shows mode, current,
+target, and hvac_action; a lock shows battery and jammed-vs-unlocked;
+an event shows what fired and when) — not a raw attribute dump.
 
 Add `include` when physical-world metadata would improve reasoning:
 


### PR DESCRIPTION
## Summary

Closes #1186 — the remaining acceptance items, after #1195 (device-page grouping), #1197 (search/list semantic states), and #1198 (state-window transitions) landed the structure and coverage axes. What was left: verify the vocabulary against current HA documentation *and record it*, close the per-class curation gaps that matter, and finish the bitmask audit.

## Catalog verification (recorded, not assumed)

Diffed `binarySensorStateLabels` against HA's current binary_sensor device-class documentation on **2026-07-03**: **all 28 device classes present with correct on/off polarity** — `door`/`garage_door`/`window`/`opening` → open/closed, `moisture` → wet/dry, `motion`/`smoke`/`gas`/`co`/`vibration`/`tamper`/`sound` → detected/clear, `presence` → home/away, `lock` → unlocked/locked, and the rest. Full parity, no drift since the table was written.

## The event domain (2026.7) — a live conventions violation, fixed

An event entity's **raw state is the ISO timestamp of its last firing** — verified against prod: `event.doorbird_3040_motion: state='2026-07-02T16:44:40.728+00:00'`. That's precisely the shape the model-facing conventions forbid, on high-value signals (DoorBird rings, motion events). The new projection:

```json
{"entity":"event.doorbird_3040_pool","name":"DoorBird-3040 Pool","event":"ring","device_class":"doorbell","since":"-3d10h"}
```

What fired leads, when is a delta, the raw timestamp never appears. Sparse inputs (no `last_changed`) derive the delta from the state timestamp itself.

## alarm_control_panel

Panel state is already semantic (`armed_away`, `triggered`, …); the curation is what a security decision wants: **`changed_by`** and **`code_arm_required`** (the model should never propose an arm/disarm flow the panel will refuse). Attribute names per current HA docs — no panel exists on prod to verify live, noted honestly. `supported_features` stays dropped, pinned by test.

## Bitmask audit — clean

No emitting surface passes `supported_features` raw: every path routes through the curated formatters (`ha_get_state`, snapshots, watchlist, search/list, state window). The registry `capabilities`/`options` metadata maps are semantic option lists (not bitmasks) and stay include-gated. Also fixed: `talents/ha.md` claimed `ha_get_state` returns "all attributes" — it returns the curated class-aware projection, and the talent now says so instead of over-promising a raw dump.

## Acceptance state

- [x] Class-aware projection layer: 13 rich domains + binary_sensor semantics + generic fallback
- [x] Semantics verified against current HA per-domain docs, recorded above
- [x] All entity-emitting surfaces route through the shared projection (#1197/#1198 + pre-existing)
- [x] Stable per-class field schemas (struct-ordered compact JSON), delta timestamps (event was the last violation), deterministic ordering
- [x] `supported_features`-style bitmasks never reach the model raw
- [x] `just ci` green locally (unpiped, real exit code verified)

Refs #1175.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
