### PR TITLE
feat(awareness): state-watcher ingestion filter becomes a dynamic registry

### DIFF
--- a/examples/config.example.yaml
+++ b/examples/config.example.yaml
@@ -72,21 +72,12 @@ homeassistant:
   # default; "0" disables caching (always refetch). Live entity state
   # is never cached.
   registry_cache_ttl: ""
-  # Subscribe configures WebSocket event subscriptions for real-time
-  # state change monitoring. When entity_globs is non-empty, only
-  # matching entities are processed; when empty, all state changes
-  # are accepted.
-  subscribe:
-    # EntityGlobs is a list of glob patterns (using path.Match syntax)
-    # that select which entity IDs to process. Examples: "person.*",
-    # "binary_sensor.*door*", "light.living_room". An empty list
-    # means all entities are accepted.
-    entity_globs:
-      - person.*
-      - binary_sensor.*door*
-    # RateLimitPerMinute caps how many state changes per entity are
-    # forwarded per minute. Zero means no rate limiting.
-    rate_limit_per_minute: 10
+  # IngestRateLimitPerMinute caps how many state changes per entity
+  # the state watcher forwards per minute. Zero means no rate
+  # limiting. The ingestion *filter* is runtime state (ingest-mode
+  # entity subscriptions, #1192); this protective limit stays
+  # operator policy in config.
+  ingest_rate_limit_per_minute: 10
 # Models configures LLM providers, model routing, and the default model.
 models:
   # Default is the model name used when no specific model is requested.

--- a/internal/app/new_awareness.go
+++ b/internal/app/new_awareness.go
@@ -111,6 +111,14 @@ func (a *App) initAwareness(s *newState) error {
 	watchlistCfg := awareness.WatchlistToolsConfig{
 		Store:  watchlistStore,
 		Logger: logger,
+		// The watcher is constructed later in this function; the rebuild
+		// hook binds through newState so mutations that land before the
+		// watcher exists are simply no-ops.
+		OnIngestChange: func() {
+			if s.ingestFilterRebuild != nil {
+				s.ingestFilterRebuild()
+			}
+		},
 	}
 	// Only set Registry when the HA client is present. a.ha is a concrete
 	// *homeassistant.Client, so assigning a nil one into the interface
@@ -286,16 +294,30 @@ func (a *App) initAwareness(s *newState) error {
 
 	// --- State watcher ---
 	// Consumes state_changed events from the HA WebSocket and forwards
-	// them to the state window and person tracker. Person entity IDs
-	// are auto-merged into entity globs so the person tracker receives
-	// state changes regardless of the user's subscribe config.
+	// them to the state window and person tracker. The ingestion filter
+	// is a dynamic registry (#1192): ingest/both-mode watchlist rows,
+	// rebuilt on every watchlist mutation via OnIngestChange — no HA
+	// re-subscription needed, the WS feed is a firehose gated
+	// client-side. Person entity IDs are auto-merged so the person
+	// tracker receives state changes regardless of the registry.
 	if a.haWS != nil {
-		globs := append([]string(nil), cfg.HomeAssistant.Subscribe.EntityGlobs...)
-		if s.personTracker != nil {
-			globs = append(globs, s.personTracker.EntityIDs()...)
+		buildIngestFilter := func() *homeassistant.EntityFilter {
+			globs, err := watchlistStore.IngestGlobs(time.Now())
+			if err != nil {
+				logger.Warn("ingest registry read failed; keeping previous filter shape", "error", err)
+			}
+			if s.personTracker != nil {
+				globs = append(globs, s.personTracker.EntityIDs()...)
+			}
+			if len(globs) == 0 {
+				// Nothing registered must mean ingest nothing — an empty
+				// EntityFilter would mean ingest everything.
+				return homeassistant.NewEntityFilterMatchNone(logger)
+			}
+			return homeassistant.NewEntityFilter(globs, logger)
 		}
-		filter := homeassistant.NewEntityFilter(globs, logger)
-		limiter := homeassistant.NewEntityRateLimiter(cfg.HomeAssistant.Subscribe.RateLimitPerMinute)
+		filter := buildIngestFilter()
+		limiter := homeassistant.NewEntityRateLimiter(cfg.HomeAssistant.IngestRateLimitPerMinute)
 
 		// Compose handler: state window and person tracker both see
 		// every state change that passes the filter and rate limiter.
@@ -311,9 +333,9 @@ func (a *App) initAwareness(s *newState) error {
 
 		watcher := homeassistant.NewStateWatcher(a.haWS.Events(), filter, limiter, handler, logger)
 		a.haStateWatcher = watcher
+		s.ingestFilterRebuild = func() { watcher.SetFilter(buildIngestFilter()) }
 		logger.Info("state watcher configured",
-			"entity_globs", globs,
-			"rate_limit_per_minute", cfg.HomeAssistant.Subscribe.RateLimitPerMinute,
+			"ingest_rate_limit_per_minute", cfg.HomeAssistant.IngestRateLimitPerMinute,
 		)
 	}
 

--- a/internal/app/new_awareness.go
+++ b/internal/app/new_awareness.go
@@ -301,10 +301,10 @@ func (a *App) initAwareness(s *newState) error {
 	// client-side. Person entity IDs are auto-merged so the person
 	// tracker receives state changes regardless of the registry.
 	if a.haWS != nil {
-		buildIngestFilter := func() *homeassistant.EntityFilter {
+		buildIngestFilter := func() (*homeassistant.EntityFilter, error) {
 			globs, err := watchlistStore.IngestGlobs(time.Now())
 			if err != nil {
-				logger.Warn("ingest registry read failed; keeping previous filter shape", "error", err)
+				return nil, err
 			}
 			if s.personTracker != nil {
 				globs = append(globs, s.personTracker.EntityIDs()...)
@@ -312,11 +312,25 @@ func (a *App) initAwareness(s *newState) error {
 			if len(globs) == 0 {
 				// Nothing registered must mean ingest nothing — an empty
 				// EntityFilter would mean ingest everything.
-				return homeassistant.NewEntityFilterMatchNone(logger)
+				return homeassistant.NewEntityFilterMatchNone(logger), nil
 			}
-			return homeassistant.NewEntityFilter(globs, logger)
+			return homeassistant.NewEntityFilter(globs, logger), nil
 		}
-		filter := buildIngestFilter()
+		filter, err := buildIngestFilter()
+		if err != nil {
+			// A failed registry read at boot degrades to the person
+			// floor — the tracker must not go deaf — and says so.
+			logger.Warn("ingest registry read failed at startup; ingesting the person-entity floor only", "error", err)
+			var personGlobs []string
+			if s.personTracker != nil {
+				personGlobs = s.personTracker.EntityIDs()
+			}
+			if len(personGlobs) == 0 {
+				filter = homeassistant.NewEntityFilterMatchNone(logger)
+			} else {
+				filter = homeassistant.NewEntityFilter(personGlobs, logger)
+			}
+		}
 		limiter := homeassistant.NewEntityRateLimiter(cfg.HomeAssistant.IngestRateLimitPerMinute)
 
 		// Compose handler: state window and person tracker both see
@@ -333,7 +347,17 @@ func (a *App) initAwareness(s *newState) error {
 
 		watcher := homeassistant.NewStateWatcher(a.haWS.Events(), filter, limiter, handler, logger)
 		a.haStateWatcher = watcher
-		s.ingestFilterRebuild = func() { watcher.SetFilter(buildIngestFilter()) }
+		s.ingestFilterRebuild = func() {
+			rebuilt, err := buildIngestFilter()
+			if err != nil {
+				// A transient read failure keeps the previous filter —
+				// genuinely, by not swapping — rather than narrowing
+				// ingestion on bad luck.
+				logger.Warn("ingest registry read failed; keeping the previous ingestion filter", "error", err)
+				return
+			}
+			watcher.SetFilter(rebuilt)
+		}
 		logger.Info("state watcher configured",
 			"ingest_rate_limit_per_minute", cfg.HomeAssistant.IngestRateLimitPerMinute,
 		)

--- a/internal/app/new_state.go
+++ b/internal/app/new_state.go
@@ -30,6 +30,11 @@ type newState struct {
 	// constructed in initAwareness.
 	personTracker *contacts.PresenceTracker
 
+	// Set in initAwareness once the state watcher exists; invoked by the
+	// watchlist tools' OnIngestChange hook to rebuild the ingestion
+	// filter from the registry (#1192). Nil until the watcher is wired.
+	ingestFilterRebuild func()
+
 	// Built in initAgentLoop, used by initChannels and initDelegation.
 	resolver *paths.Resolver
 

--- a/internal/integrations/homeassistant/statewatch.go
+++ b/internal/integrations/homeassistant/statewatch.go
@@ -20,8 +20,20 @@ type StateWatchHandler func(entityID, oldState, newState, deviceClass string)
 // EntityFilter selects which entity IDs to process using glob patterns.
 // An empty filter matches all entities.
 type EntityFilter struct {
-	patterns []string
-	logger   *slog.Logger
+	patterns  []string
+	matchNone bool
+	logger    *slog.Logger
+}
+
+// NewEntityFilterMatchNone returns a filter that matches no entities.
+// Distinct from an empty pattern list, which matches everything: with a
+// runtime-managed ingestion registry, "nothing registered" must mean
+// ingest nothing, not ingest the whole firehose.
+func NewEntityFilterMatchNone(logger *slog.Logger) *EntityFilter {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &EntityFilter{matchNone: true, logger: logger}
 }
 
 // NewEntityFilter creates an entity filter from glob patterns. Patterns
@@ -37,6 +49,9 @@ func NewEntityFilter(globs []string, logger *slog.Logger) *EntityFilter {
 // Match reports whether the entity ID matches at least one pattern.
 // If no patterns are configured, Match always returns true.
 func (f *EntityFilter) Match(entityID string) bool {
+	if f.matchNone {
+		return false
+	}
 	if len(f.patterns) == 0 {
 		return true
 	}
@@ -133,11 +148,25 @@ func (r *EntityRateLimiter) Cleanup() {
 // WebSocket event channel, applies entity filtering and rate limiting,
 // and dispatches matching events to a handler.
 type StateWatcher struct {
-	events  <-chan Event
-	filter  *EntityFilter
-	limiter *EntityRateLimiter
-	handler StateWatchHandler
-	logger  *slog.Logger
+	events   <-chan Event
+	filterMu sync.RWMutex
+	filter   *EntityFilter
+	limiter  *EntityRateLimiter
+	handler  StateWatchHandler
+	logger   *slog.Logger
+}
+
+// SetFilter swaps the ingestion filter at runtime. The WebSocket
+// subscription is a firehose filtered client-side, so changing the
+// filter needs no HA re-subscription — the next event simply sees the
+// new gate. Safe for concurrent use with Run.
+func (w *StateWatcher) SetFilter(filter *EntityFilter) {
+	if filter == nil {
+		filter = NewEntityFilterMatchNone(w.logger)
+	}
+	w.filterMu.Lock()
+	w.filter = filter
+	w.filterMu.Unlock()
 }
 
 // NewStateWatcher creates a state watcher that consumes events from the
@@ -237,7 +266,10 @@ func (w *StateWatcher) handleEvent(ev Event) bool {
 		return false
 	}
 
-	if !w.filter.Match(data.EntityID) {
+	w.filterMu.RLock()
+	filter := w.filter
+	w.filterMu.RUnlock()
+	if !filter.Match(data.EntityID) {
 		return false
 	}
 

--- a/internal/integrations/homeassistant/statewatch_test.go
+++ b/internal/integrations/homeassistant/statewatch_test.go
@@ -359,3 +359,36 @@ func TestStateWatcher_DeliversDeviceClass(t *testing.T) {
 		t.Errorf("device_class for classless entity = %q, want empty", classes["light.kitchen"])
 	}
 }
+
+// The ingestion filter is a dynamic registry (#1192): SetFilter swaps
+// the gate at runtime with no HA re-subscription — the next event sees
+// the new filter. Match-none is distinct from empty (which matches all).
+func TestStateWatcher_SetFilterLiveSwap(t *testing.T) {
+	watcher := NewStateWatcher(nil, NewEntityFilter([]string{"lock.*"}, nil), nil, func(_, _, _, _ string) {}, nil)
+
+	if !watcher.HandleEvent(makeStateEvent(t, "lock.front", "locked", "unlocked")) {
+		t.Fatal("lock.front should pass the initial filter")
+	}
+	if watcher.HandleEvent(makeStateEvent(t, "light.office", "off", "on")) {
+		t.Fatal("light.office should be filtered initially")
+	}
+
+	watcher.SetFilter(NewEntityFilter([]string{"light.*"}, nil))
+	if watcher.HandleEvent(makeStateEvent(t, "lock.front", "unlocked", "locked")) {
+		t.Fatal("lock.front should be filtered after the swap")
+	}
+	if !watcher.HandleEvent(makeStateEvent(t, "light.office", "on", "off")) {
+		t.Fatal("light.office should pass after the swap")
+	}
+
+	// Nothing registered must mean ingest nothing.
+	watcher.SetFilter(NewEntityFilterMatchNone(nil))
+	if watcher.HandleEvent(makeStateEvent(t, "light.office", "off", "on")) {
+		t.Fatal("match-none filter should drop everything")
+	}
+	// And SetFilter(nil) defaults to match-none, not match-all.
+	watcher.SetFilter(nil)
+	if watcher.HandleEvent(makeStateEvent(t, "lock.front", "locked", "unlocked")) {
+		t.Fatal("nil filter should default to match-none")
+	}
+}

--- a/internal/platform/config/config.go
+++ b/internal/platform/config/config.go
@@ -39,7 +39,6 @@ import (
 	"github.com/nugget/thane-ai-agent/internal/channels/email"
 	"github.com/nugget/thane-ai-agent/internal/channels/messages"
 	"github.com/nugget/thane-ai-agent/internal/integrations/forge"
-	"github.com/nugget/thane-ai-agent/internal/integrations/homeassistant"
 	"github.com/nugget/thane-ai-agent/internal/integrations/search"
 	"github.com/nugget/thane-ai-agent/internal/model/router"
 	"github.com/nugget/thane-ai-agent/internal/model/toolcatalog"
@@ -1066,25 +1065,12 @@ type HomeAssistantConfig struct {
 	// is never cached.
 	RegistryCacheTTL string `yaml:"registry_cache_ttl,omitempty"`
 
-	// Subscribe configures WebSocket event subscriptions for real-time
-	// state change monitoring. When entity_globs is non-empty, only
-	// matching entities are processed; when empty, all state changes
-	// are accepted.
-	Subscribe SubscribeConfig `yaml:"subscribe"`
-}
-
-// SubscribeConfig configures entity-level filtering and rate limiting
-// for Home Assistant WebSocket state_changed event subscriptions.
-type SubscribeConfig struct {
-	// EntityGlobs is a list of glob patterns (using path.Match syntax)
-	// that select which entity IDs to process. Examples: "person.*",
-	// "binary_sensor.*door*", "light.living_room". An empty list
-	// means all entities are accepted.
-	EntityGlobs []string `yaml:"entity_globs"`
-
-	// RateLimitPerMinute caps how many state changes per entity are
-	// forwarded per minute. Zero means no rate limiting.
-	RateLimitPerMinute int `yaml:"rate_limit_per_minute"`
+	// IngestRateLimitPerMinute caps how many state changes per entity
+	// the state watcher forwards per minute. Zero means no rate
+	// limiting. The ingestion *filter* is runtime state (ingest-mode
+	// entity subscriptions, #1192); this protective limit stays
+	// operator policy in config.
+	IngestRateLimitPerMinute int `yaml:"ingest_rate_limit_per_minute"`
 }
 
 // Configured reports whether both URL and Token are set. A partial
@@ -3180,16 +3166,13 @@ func (c *Config) validateMCP() error {
 	return nil
 }
 
-// validateSubscribe checks the Home Assistant subscribe configuration
-// for consistency.
+// validateSubscribe checks the Home Assistant state-watch ingestion
+// configuration for consistency. The ingestion filter itself moved to a
+// runtime registry (#1192); only the protective rate limit remains in
+// config.
 func (c *Config) validateSubscribe() error {
-	for i, glob := range c.HomeAssistant.Subscribe.EntityGlobs {
-		if err := homeassistant.ValidateEntityGlob(glob); err != nil {
-			return fmt.Errorf("homeassistant.subscribe.entity_globs[%d] %q: invalid glob pattern: %w", i, glob, err)
-		}
-	}
-	if c.HomeAssistant.Subscribe.RateLimitPerMinute < 0 {
-		return fmt.Errorf("homeassistant.subscribe.rate_limit_per_minute %d must be non-negative", c.HomeAssistant.Subscribe.RateLimitPerMinute)
+	if c.HomeAssistant.IngestRateLimitPerMinute < 0 {
+		return fmt.Errorf("homeassistant.ingest_rate_limit_per_minute %d must be non-negative", c.HomeAssistant.IngestRateLimitPerMinute)
 	}
 	return nil
 }

--- a/internal/platform/config/example.go
+++ b/internal/platform/config/example.go
@@ -61,10 +61,9 @@ func ExampleConfig() *Config {
 		HomeAssistant: HomeAssistantConfig{
 			URL:   "https://your-homeassistant.local:8123",
 			Token: "your-long-lived-access-token",
-			Subscribe: SubscribeConfig{
-				EntityGlobs:        []string{"person.*", "binary_sensor.*door*"},
-				RateLimitPerMinute: 10,
-			},
+			// Which entities feed the state-change window is runtime
+			// state: add_entity_subscription with mode "ingest" (#1192).
+			IngestRateLimitPerMinute: 10,
 		},
 
 		Models: ModelsConfig{

--- a/internal/state/awareness/watchlist_expansion.go
+++ b/internal/state/awareness/watchlist_expansion.go
@@ -11,6 +11,12 @@ import (
 // carries as a concrete sample alongside the count.
 const previewSampleSize = 5
 
+// maxIngestEntries caps the ingestion registry (#1192): the guardrail
+// that keeps a runaway subscription loop from feeding the state-change
+// window an unbounded glob set. Globs make the cap generous — one
+// pattern covers a family of entities.
+const maxIngestEntries = 64
+
 // targetExpansion is the author-time membership preview for a glob or
 // registry-backed subscription target: how many entities it matches right
 // now and a sample of them.

--- a/internal/state/awareness/watchlist_ingest_test.go
+++ b/internal/state/awareness/watchlist_ingest_test.go
@@ -123,6 +123,16 @@ func TestIngestModeToolFlow(t *testing.T) {
 		t.Errorf("OnIngestChange fired %d times, want 1", fired)
 	}
 
+	// Tag-scoped ingest rows would sit in the store doing nothing
+	// (the filter reads only always-visible rows) — rejected loudly.
+	if _, err := p.handleAddEntitySubscription(ctx, map[string]any{
+		"entity_id": "sensor.tagged",
+		"mode":      "ingest",
+		"tags":      []any{"focus"},
+	}); err == nil || !strings.Contains(err.Error(), "cannot carry tags") {
+		t.Errorf("tag-scoped ingest should error, got: %v", err)
+	}
+
 	// Registry targets can't feed the ingestion filter.
 	if _, err := p.handleAddEntitySubscription(ctx, map[string]any{
 		"entity_id": "area:office",
@@ -169,6 +179,36 @@ func TestIngestCap(t *testing.T) {
 		"mode":      "ingest",
 	}); err == nil || !strings.Contains(err.Error(), "cap") {
 		t.Errorf("over-cap add should error, got: %v", err)
+	}
+
+	// Re-adding an existing entry at the cap is an in-place update,
+	// not growth — it must pass.
+	if _, err := p.handleAddEntitySubscription(ctx, map[string]any{
+		"entity_id": "sensor.ingest_xaa",
+		"mode":      "ingest",
+		"history":   []any{600},
+	}); err != nil {
+		t.Errorf("re-add at cap should succeed as an update: %v", err)
+	}
+}
+
+// An unrecognized stored mode degrades to render, keeping the decode
+// contract (Mode never empty) and legacy behavior.
+func TestUnknownStoredModeDecodesAsRender(t *testing.T) {
+	store := newIngestStore(t)
+	if err := store.Add("sensor.future"); err != nil {
+		t.Fatalf("add: %v", err)
+	}
+	if _, err := store.db.Exec(
+		`UPDATE watched_entity_subscriptions SET options = '{"mode":"telepathy"}' WHERE entity_id = 'sensor.future'`); err != nil {
+		t.Fatalf("plant unknown mode: %v", err)
+	}
+	subs, err := store.ListUntaggedSubscriptions()
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(subs) != 1 || subs[0].Mode != SubscriptionModeRender {
+		t.Errorf("unknown mode decoded as %q, want render", subs[0].Mode)
 	}
 }
 

--- a/internal/state/awareness/watchlist_ingest_test.go
+++ b/internal/state/awareness/watchlist_ingest_test.go
@@ -1,0 +1,200 @@
+package awareness
+
+import (
+	"context"
+	"database/sql"
+	"strings"
+	"testing"
+	"time"
+
+	_ "modernc.org/sqlite"
+
+	"github.com/nugget/thane-ai-agent/internal/runtime/agentctx"
+)
+
+func newIngestStore(t *testing.T) *WatchlistStore {
+	t.Helper()
+	db, err := sql.Open("sqlite-thane", ":memory:")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	store, err := NewWatchlistStore(db, nil)
+	if err != nil {
+		t.Fatalf("new store: %v", err)
+	}
+	return store
+}
+
+// The ingestion registry (#1192): ingest/both rows feed the state
+// watcher's filter; render rows and expired rows do not.
+func TestIngestGlobs(t *testing.T) {
+	store := newIngestStore(t)
+	now := time.Now()
+
+	if err := store.AddWithOptions("binary_sensor.*_door", nil, nil, 0, "", SubscriptionModeIngest); err != nil {
+		t.Fatalf("add ingest glob: %v", err)
+	}
+	if err := store.AddWithOptions("lock.front", nil, nil, 0, "", SubscriptionModeBoth); err != nil {
+		t.Fatalf("add both: %v", err)
+	}
+	if err := store.Add("sensor.render_only"); err != nil {
+		t.Fatalf("add render: %v", err)
+	}
+	// Expired ingest row drops out of the rebuild.
+	if err := store.AddWithOptions("sensor.expired", nil, nil, 1, "", SubscriptionModeIngest); err != nil {
+		t.Fatalf("add expiring: %v", err)
+	}
+
+	globs, err := store.IngestGlobs(now.Add(2 * time.Second))
+	if err != nil {
+		t.Fatalf("IngestGlobs: %v", err)
+	}
+	got := strings.Join(globs, ",")
+	if !strings.Contains(got, "binary_sensor.*_door") || !strings.Contains(got, "lock.front") {
+		t.Errorf("globs = %v, want ingest + both rows", globs)
+	}
+	if strings.Contains(got, "render_only") {
+		t.Errorf("render-only row leaked into ingest globs: %v", globs)
+	}
+	if strings.Contains(got, "expired") {
+		t.Errorf("expired row leaked into ingest globs: %v", globs)
+	}
+}
+
+// Mode survives the options round trip and defaults to render for
+// pre-mode rows (absent field).
+func TestSubscriptionModeRoundTrip(t *testing.T) {
+	store := newIngestStore(t)
+	if err := store.AddWithOptions("sensor.a", nil, nil, 0, "", SubscriptionModeIngest); err != nil {
+		t.Fatalf("add: %v", err)
+	}
+	if err := store.Add("sensor.b"); err != nil {
+		t.Fatalf("add plain: %v", err)
+	}
+	subs, err := store.ListUntaggedSubscriptions()
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	modes := map[string]string{}
+	for _, s := range subs {
+		modes[s.EntityID] = s.Mode
+	}
+	if modes["sensor.a"] != SubscriptionModeIngest {
+		t.Errorf("sensor.a mode = %q, want ingest", modes["sensor.a"])
+	}
+	if modes["sensor.b"] != SubscriptionModeRender {
+		t.Errorf("sensor.b mode = %q, want render default", modes["sensor.b"])
+	}
+}
+
+// Ingest-only rows must not render per-turn state (they feed the
+// state-change window instead); the tool result and list expose mode.
+func TestIngestModeToolFlow(t *testing.T) {
+	client := expansionRegistryClient()
+	fired := 0
+	db, err := sql.Open("sqlite-thane", ":memory:")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	store, err := NewWatchlistStore(db, nil)
+	if err != nil {
+		t.Fatalf("new store: %v", err)
+	}
+	p := NewWatchlistTools(WatchlistToolsConfig{
+		Store:          store,
+		Registry:       client,
+		OnIngestChange: func() { fired++ },
+	})
+	ctx := context.Background()
+
+	out, err := p.handleAddEntitySubscription(ctx, map[string]any{
+		"entity_id": "binary_sensor.*door*",
+		"mode":      "ingest",
+	})
+	if err != nil {
+		t.Fatalf("add ingest: %v", err)
+	}
+	if !strings.Contains(out, "mode: ingest") || !strings.Contains(out, "recent-state-changes window") {
+		t.Errorf("result should describe ingest mode: %s", out)
+	}
+	if fired != 1 {
+		t.Errorf("OnIngestChange fired %d times, want 1", fired)
+	}
+
+	// Registry targets can't feed the ingestion filter.
+	if _, err := p.handleAddEntitySubscription(ctx, map[string]any{
+		"entity_id": "area:office",
+		"mode":      "ingest",
+	}); err == nil || !strings.Contains(err.Error(), "entity ids and globs only") {
+		t.Errorf("registry target in ingest mode should error, got: %v", err)
+	}
+
+	// Unknown mode is rejected.
+	if _, err := p.handleAddEntitySubscription(ctx, map[string]any{
+		"entity_id": "sensor.x",
+		"mode":      "firehose",
+	}); err == nil || !strings.Contains(err.Error(), "render, ingest, or both") {
+		t.Errorf("bad mode should error, got: %v", err)
+	}
+
+	// Removal also triggers a rebuild.
+	if _, err := p.handleRemoveEntitySubscription(ctx, map[string]any{
+		"entity_id": "binary_sensor.*door*",
+	}); err != nil {
+		t.Fatalf("remove: %v", err)
+	}
+	if fired != 2 {
+		t.Errorf("OnIngestChange fired %d times after remove, want 2", fired)
+	}
+}
+
+// The ingest registry cap: the guardrail against a runaway subscription
+// loop flooding the ingestion filter.
+func TestIngestCap(t *testing.T) {
+	store := newIngestStore(t)
+	p := NewWatchlistTools(WatchlistToolsConfig{Store: store})
+	ctx := context.Background()
+	for i := 0; i < maxIngestEntries; i++ {
+		if _, err := p.handleAddEntitySubscription(ctx, map[string]any{
+			"entity_id": "sensor.ingest_" + strings.Repeat("x", 1) + string(rune('a'+i%26)) + string(rune('a'+(i/26)%26)),
+			"mode":      "ingest",
+		}); err != nil {
+			t.Fatalf("add %d: %v", i, err)
+		}
+	}
+	if _, err := p.handleAddEntitySubscription(ctx, map[string]any{
+		"entity_id": "sensor.one_too_many",
+		"mode":      "ingest",
+	}); err == nil || !strings.Contains(err.Error(), "cap") {
+		t.Errorf("over-cap add should error, got: %v", err)
+	}
+}
+
+// Ingest-only rows feed the push pipeline, not the per-turn render: the
+// watchlist context provider must skip them.
+func TestWatchlistProviderSkipsIngestOnlyRows(t *testing.T) {
+	store := newIngestStore(t)
+	if err := store.AddWithOptions("sensor.ingest_only", nil, nil, 0, "", SubscriptionModeIngest); err != nil {
+		t.Fatalf("add: %v", err)
+	}
+	subs, err := store.ListUntaggedSubscriptions()
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(subs) != 1 || subs[0].Mode != SubscriptionModeIngest {
+		t.Fatalf("subs = %+v, want one ingest row", subs)
+	}
+	// Provider with a nil HA client renders nothing anyway on fetch,
+	// but the skip must happen before any state fetch: an ingest-only
+	// watchlist yields an empty context block.
+	p := NewWatchlistProvider(store, nil, nil)
+	got, err := p.TagContext(context.Background(), agentctx.ContextRequest{})
+	if err != nil {
+		t.Fatalf("TagContext: %v", err)
+	}
+	if got != "" {
+		t.Errorf("ingest-only watchlist rendered context: %q", got)
+	}
+}

--- a/internal/state/awareness/watchlist_modes.go
+++ b/internal/state/awareness/watchlist_modes.go
@@ -1,0 +1,64 @@
+package awareness
+
+import (
+	"fmt"
+	"time"
+)
+
+// Subscription modes: what a watched entry feeds. Render is the
+// classic watchlist behavior (per-turn context injection); ingest feeds
+// the state-change window's push pipeline without rendering every turn;
+// both does both. Stored in the options blob — absent means render, so
+// existing rows keep their behavior unchanged.
+const (
+	SubscriptionModeRender = "render"
+	SubscriptionModeIngest = "ingest"
+	SubscriptionModeBoth   = "both"
+)
+
+// normalizeSubscriptionMode maps stored/user mode strings to a
+// canonical value, treating empty as render. Returns "" for anything
+// unrecognized so callers can reject it.
+func normalizeSubscriptionMode(mode string) string {
+	switch mode {
+	case "", SubscriptionModeRender:
+		return SubscriptionModeRender
+	case SubscriptionModeIngest:
+		return SubscriptionModeIngest
+	case SubscriptionModeBoth:
+		return SubscriptionModeBoth
+	default:
+		return ""
+	}
+}
+
+// IngestGlobs returns the entity ids/globs of always-visible rows whose
+// mode feeds the state-change window (ingest or both), excluding
+// expired entries. This is the runtime source of the StateWatcher's
+// ingestion filter — the registry replacement for the retired
+// homeassistant.subscribe config globs (#1192). Expired TTL rows drop
+// out at the next rebuild rather than instantly.
+func (s *WatchlistStore) IngestGlobs(now time.Time) ([]string, error) {
+	rows, err := s.db.Query(
+		`SELECT entity_id, options FROM watched_entity_subscriptions WHERE scope = ''`)
+	if err != nil {
+		return nil, fmt.Errorf("query ingest globs: %w", err)
+	}
+	defer rows.Close()
+
+	var globs []string
+	for rows.Next() {
+		var entityID, optsJSON string
+		if err := rows.Scan(&entityID, &optsJSON); err != nil {
+			return nil, err
+		}
+		opts := parseWatchlistOptions(optsJSON)
+		if opts.expired(now) {
+			continue
+		}
+		if opts.Mode == SubscriptionModeIngest || opts.Mode == SubscriptionModeBoth {
+			globs = append(globs, entityID)
+		}
+	}
+	return globs, rows.Err()
+}

--- a/internal/state/awareness/watchlist_provider.go
+++ b/internal/state/awareness/watchlist_provider.go
@@ -83,6 +83,16 @@ func (p *WatchlistProvider) TagContext(ctx context.Context, _ agentctx.ContextRe
 	if err != nil {
 		return "", fmt.Errorf("list watched entities: %w", err)
 	}
+	// Ingest-only entries feed the state-change window's push pipeline;
+	// they don't render per-turn state here (#1192).
+	rendered := subs[:0]
+	for _, sub := range subs {
+		if sub.Mode == SubscriptionModeIngest {
+			continue
+		}
+		rendered = append(rendered, sub)
+	}
+	subs = rendered
 	if len(subs) == 0 {
 		return "", nil
 	}

--- a/internal/state/awareness/watchlist_provider_test.go
+++ b/internal/state/awareness/watchlist_provider_test.go
@@ -118,7 +118,7 @@ func TestProvider_RendersIncludedEntityMetadata(t *testing.T) {
 		Labels:      true,
 		Description: true,
 	}
-	if err := store.AddWithOptions(state.EntityID, nil, nil, 0, "", include); err != nil {
+	if err := store.AddWithOptions(state.EntityID, nil, nil, 0, "", "", include); err != nil {
 		t.Fatalf("AddWithOptions: %v", err)
 	}
 	p.SetRegistryClient(&fakeRegistries{
@@ -351,7 +351,7 @@ func TestProvider_IncludesNumericHistorySummaries(t *testing.T) {
 	}
 
 	p, store := setupTestProvider(t, ha)
-	if err := store.AddWithOptions("sensor.office_temperature", nil, []int{24 * 60 * 60}, 0, ""); err != nil {
+	if err := store.AddWithOptions("sensor.office_temperature", nil, []int{24 * 60 * 60}, 0, "", ""); err != nil {
 		t.Fatalf("AddWithOptions: %v", err)
 	}
 
@@ -418,7 +418,7 @@ func TestProvider_IncludesWeatherForecastWhenSubscribed(t *testing.T) {
 	}
 
 	p, store := setupTestProvider(t, ha)
-	if err := store.AddWithOptions("weather.home", nil, nil, 0, "hourly"); err != nil {
+	if err := store.AddWithOptions("weather.home", nil, nil, 0, "hourly", ""); err != nil {
 		t.Fatalf("AddWithOptions: %v", err)
 	}
 
@@ -478,7 +478,7 @@ func TestProvider_ForecastFetchFailureSurfacesUnavailableMarker(t *testing.T) {
 	}
 
 	p, store := setupTestProvider(t, ha)
-	if err := store.AddWithOptions("weather.home", nil, nil, 0, "daily"); err != nil {
+	if err := store.AddWithOptions("weather.home", nil, nil, 0, "daily", ""); err != nil {
 		t.Fatalf("AddWithOptions: %v", err)
 	}
 
@@ -565,7 +565,7 @@ func TestProvider_IncludesDiscreteHistorySummaries(t *testing.T) {
 	}
 
 	p, store := setupTestProvider(t, ha)
-	if err := store.AddWithOptions("binary_sensor.front_door", nil, []int{24 * 60 * 60}, 0, ""); err != nil {
+	if err := store.AddWithOptions("binary_sensor.front_door", nil, []int{24 * 60 * 60}, 0, "", ""); err != nil {
 		t.Fatalf("AddWithOptions: %v", err)
 	}
 
@@ -624,7 +624,7 @@ func TestProvider_DiscreteHistoryUsesDeviceClassLabels(t *testing.T) {
 	}
 
 	p, store := setupTestProvider(t, ha)
-	if err := store.AddWithOptions("binary_sensor.front_door", nil, []int{24 * 60 * 60}, 0, ""); err != nil {
+	if err := store.AddWithOptions("binary_sensor.front_door", nil, []int{24 * 60 * 60}, 0, "", ""); err != nil {
 		t.Fatalf("AddWithOptions: %v", err)
 	}
 

--- a/internal/state/awareness/watchlist_store.go
+++ b/internal/state/awareness/watchlist_store.go
@@ -388,9 +388,16 @@ func parseWatchlistOptions(optsJSON string) watchlistOptions {
 	if err := json.Unmarshal([]byte(optsJSON), &wire); err != nil {
 		return watchlistOptions{Mode: SubscriptionModeRender}
 	}
+	mode := normalizeSubscriptionMode(wire.Mode)
+	if mode == "" {
+		// An unrecognized stored mode (a future value, or corruption)
+		// degrades to render — the legacy behavior — keeping the struct
+		// contract that Mode is never empty after decode.
+		mode = SubscriptionModeRender
+	}
 	out := watchlistOptions{
 		History: append([]int(nil), wire.History...),
-		Mode:    normalizeSubscriptionMode(wire.Mode),
+		Mode:    mode,
 		Include: wire.Include.Clone(),
 	}
 	if forecast, err := normalizeForecastType(wire.Forecast); err == nil {

--- a/internal/state/awareness/watchlist_store.go
+++ b/internal/state/awareness/watchlist_store.go
@@ -12,11 +12,40 @@ import (
 	"github.com/nugget/thane-ai-agent/internal/platform/database"
 )
 
+// Subscription modes: what a watched entry feeds. Render is the
+// classic watchlist behavior (per-turn context injection); ingest feeds
+// the state-change window's push pipeline without rendering every turn;
+// both does both. Stored in the options blob — absent means render, so
+// existing rows keep their behavior unchanged.
+const (
+	SubscriptionModeRender = "render"
+	SubscriptionModeIngest = "ingest"
+	SubscriptionModeBoth   = "both"
+)
+
+// normalizeSubscriptionMode maps stored/user mode strings to a
+// canonical value, treating empty as render. Returns "" for anything
+// unrecognized so callers can reject it.
+func normalizeSubscriptionMode(mode string) string {
+	switch mode {
+	case "", SubscriptionModeRender:
+		return SubscriptionModeRender
+	case SubscriptionModeIngest:
+		return SubscriptionModeIngest
+	case SubscriptionModeBoth:
+		return SubscriptionModeBoth
+	default:
+		return ""
+	}
+}
+
 // WatchedSubscription represents one entity subscription scope with its stored
-// options. Empty Scope means the entity is always visible.
+// options. Empty Scope means the entity is always visible. Mode is one
+// of the SubscriptionMode constants (never empty after decode).
 type WatchedSubscription struct {
 	EntityID  string
 	Scope     string
+	Mode      string
 	History   []int
 	Forecast  string
 	Include   *homeassistant.EntityMetadataIncludes
@@ -51,16 +80,17 @@ func (s *WatchlistStore) Add(entityID string) error {
 
 // AddWithOptions inserts or updates entity subscriptions with tag scopes,
 // historical offsets, optional weather forecast type, an optional TTL,
-// and optional HA entity metadata include flags. Empty tags means the
+// a subscription mode (render/ingest/both; empty means render), and
+// optional HA entity metadata include flags. Empty tags means the
 // entity is always visible in context.
-func (s *WatchlistStore) AddWithOptions(entityID string, tags []string, history []int, ttlSeconds int, forecast string, includes ...homeassistant.EntityMetadataIncludes) error {
+func (s *WatchlistStore) AddWithOptions(entityID string, tags []string, history []int, ttlSeconds int, forecast, mode string, includes ...homeassistant.EntityMetadataIncludes) error {
 	scopes := normalizeScopes(tags)
 	var include homeassistant.EntityMetadataIncludes
 	if len(includes) > 0 {
 		include = includes[0]
 	}
 
-	optsJSON, err := marshalWatchlistOptions(history, ttlSeconds, forecast, include)
+	optsJSON, err := marshalWatchlistOptions(history, ttlSeconds, forecast, mode, include)
 	if err != nil {
 		return fmt.Errorf("marshal options: %w", err)
 	}
@@ -85,6 +115,37 @@ func (s *WatchlistStore) AddWithOptions(entityID string, tags []string, history 
 		return fmt.Errorf("commit watchlist tx: %w", err)
 	}
 	return nil
+}
+
+// IngestGlobs returns the entity ids/globs of always-visible rows whose
+// mode feeds the state-change window (ingest or both), excluding
+// expired entries. This is the runtime source of the StateWatcher's
+// ingestion filter — the registry replacement for the retired
+// homeassistant.subscribe config globs (#1192). Expired TTL rows drop
+// out at the next rebuild rather than instantly.
+func (s *WatchlistStore) IngestGlobs(now time.Time) ([]string, error) {
+	rows, err := s.db.Query(
+		`SELECT entity_id, options FROM watched_entity_subscriptions WHERE scope = ''`)
+	if err != nil {
+		return nil, fmt.Errorf("query ingest globs: %w", err)
+	}
+	defer rows.Close()
+
+	var globs []string
+	for rows.Next() {
+		var entityID, optsJSON string
+		if err := rows.Scan(&entityID, &optsJSON); err != nil {
+			return nil, err
+		}
+		opts := parseWatchlistOptions(optsJSON)
+		if opts.expired(now) {
+			continue
+		}
+		if opts.Mode == SubscriptionModeIngest || opts.Mode == SubscriptionModeBoth {
+			globs = append(globs, entityID)
+		}
+	}
+	return globs, rows.Err()
 }
 
 // Remove deletes all subscriptions for an entity. Non-existent IDs are a no-op.
@@ -284,6 +345,7 @@ func (s *WatchlistStore) scanActiveSubscriptions(query string, args ...any) ([]W
 		subs = append(subs, WatchedSubscription{
 			EntityID:  entityID,
 			Scope:     scope,
+			Mode:      opts.Mode,
 			History:   append([]int(nil), opts.History...),
 			Forecast:  opts.Forecast,
 			Include:   opts.Include.Clone(),
@@ -335,6 +397,7 @@ func (s *WatchlistStore) subscriptionCount() (int, error) {
 type watchlistOptions struct {
 	History   []int
 	Forecast  string
+	Mode      string
 	Include   *homeassistant.EntityMetadataIncludes
 	ExpiresAt *time.Time
 }
@@ -342,19 +405,29 @@ type watchlistOptions struct {
 type watchlistOptionsWire struct {
 	History   []int                                 `json:"history,omitempty"`
 	Forecast  string                                `json:"forecast,omitempty"`
+	Mode      string                                `json:"mode,omitempty"`
 	Include   *homeassistant.EntityMetadataIncludes `json:"include,omitempty"`
 	ExpiresAt string                                `json:"expires_at,omitempty"`
 }
 
-func marshalWatchlistOptions(history []int, ttlSeconds int, forecast string, include homeassistant.EntityMetadataIncludes) ([]byte, error) {
+func marshalWatchlistOptions(history []int, ttlSeconds int, forecast, mode string, include homeassistant.EntityMetadataIncludes) ([]byte, error) {
 	forecast, err := normalizeForecastType(forecast)
 	if err != nil {
 		return nil, err
+	}
+	normalizedMode := normalizeSubscriptionMode(mode)
+	if normalizedMode == "" {
+		return nil, fmt.Errorf("mode must be one of render, ingest, or both; got %q", mode)
 	}
 	wire := watchlistOptionsWire{
 		History:  append([]int(nil), history...),
 		Forecast: forecast,
 		Include:  (&include).Clone(),
+	}
+	// Render is the absent-field default so pre-mode rows and new
+	// default rows serialize identically.
+	if normalizedMode != SubscriptionModeRender {
+		wire.Mode = normalizedMode
 	}
 	if wire.Include != nil && !wire.Include.Any() {
 		wire.Include = nil
@@ -367,14 +440,15 @@ func marshalWatchlistOptions(history []int, ttlSeconds int, forecast string, inc
 
 func parseWatchlistOptions(optsJSON string) watchlistOptions {
 	if optsJSON == "" || optsJSON == "{}" {
-		return watchlistOptions{}
+		return watchlistOptions{Mode: SubscriptionModeRender}
 	}
 	var wire watchlistOptionsWire
 	if err := json.Unmarshal([]byte(optsJSON), &wire); err != nil {
-		return watchlistOptions{}
+		return watchlistOptions{Mode: SubscriptionModeRender}
 	}
 	out := watchlistOptions{
 		History: append([]int(nil), wire.History...),
+		Mode:    normalizeSubscriptionMode(wire.Mode),
 		Include: wire.Include.Clone(),
 	}
 	if forecast, err := normalizeForecastType(wire.Forecast); err == nil {

--- a/internal/state/awareness/watchlist_store.go
+++ b/internal/state/awareness/watchlist_store.go
@@ -12,33 +12,6 @@ import (
 	"github.com/nugget/thane-ai-agent/internal/platform/database"
 )
 
-// Subscription modes: what a watched entry feeds. Render is the
-// classic watchlist behavior (per-turn context injection); ingest feeds
-// the state-change window's push pipeline without rendering every turn;
-// both does both. Stored in the options blob — absent means render, so
-// existing rows keep their behavior unchanged.
-const (
-	SubscriptionModeRender = "render"
-	SubscriptionModeIngest = "ingest"
-	SubscriptionModeBoth   = "both"
-)
-
-// normalizeSubscriptionMode maps stored/user mode strings to a
-// canonical value, treating empty as render. Returns "" for anything
-// unrecognized so callers can reject it.
-func normalizeSubscriptionMode(mode string) string {
-	switch mode {
-	case "", SubscriptionModeRender:
-		return SubscriptionModeRender
-	case SubscriptionModeIngest:
-		return SubscriptionModeIngest
-	case SubscriptionModeBoth:
-		return SubscriptionModeBoth
-	default:
-		return ""
-	}
-}
-
 // WatchedSubscription represents one entity subscription scope with its stored
 // options. Empty Scope means the entity is always visible. Mode is one
 // of the SubscriptionMode constants (never empty after decode).
@@ -115,37 +88,6 @@ func (s *WatchlistStore) AddWithOptions(entityID string, tags []string, history 
 		return fmt.Errorf("commit watchlist tx: %w", err)
 	}
 	return nil
-}
-
-// IngestGlobs returns the entity ids/globs of always-visible rows whose
-// mode feeds the state-change window (ingest or both), excluding
-// expired entries. This is the runtime source of the StateWatcher's
-// ingestion filter — the registry replacement for the retired
-// homeassistant.subscribe config globs (#1192). Expired TTL rows drop
-// out at the next rebuild rather than instantly.
-func (s *WatchlistStore) IngestGlobs(now time.Time) ([]string, error) {
-	rows, err := s.db.Query(
-		`SELECT entity_id, options FROM watched_entity_subscriptions WHERE scope = ''`)
-	if err != nil {
-		return nil, fmt.Errorf("query ingest globs: %w", err)
-	}
-	defer rows.Close()
-
-	var globs []string
-	for rows.Next() {
-		var entityID, optsJSON string
-		if err := rows.Scan(&entityID, &optsJSON); err != nil {
-			return nil, err
-		}
-		opts := parseWatchlistOptions(optsJSON)
-		if opts.expired(now) {
-			continue
-		}
-		if opts.Mode == SubscriptionModeIngest || opts.Mode == SubscriptionModeBoth {
-			globs = append(globs, entityID)
-		}
-	}
-	return globs, rows.Err()
 }
 
 // Remove deletes all subscriptions for an entity. Non-existent IDs are a no-op.

--- a/internal/state/awareness/watchlist_store_test.go
+++ b/internal/state/awareness/watchlist_store_test.go
@@ -114,7 +114,7 @@ func TestStore_RemoveNonExistent(t *testing.T) {
 func TestStore_AddWithOptionsScopedSubscriptions(t *testing.T) {
 	store := setupTestStore(t)
 
-	if err := store.AddWithOptions("weather.home", []string{"weather_focus", "interactive", "weather_focus"}, []int{600, 3600}, 300, "daily"); err != nil {
+	if err := store.AddWithOptions("weather.home", []string{"weather_focus", "interactive", "weather_focus"}, []int{600, 3600}, 300, "daily", ""); err != nil {
 		t.Fatalf("AddWithOptions: %v", err)
 	}
 
@@ -158,7 +158,7 @@ func TestStore_AddWithOptionsScopedSubscriptions(t *testing.T) {
 func TestStore_AddWithOptionsRejectsInvalidForecast(t *testing.T) {
 	store := setupTestStore(t)
 
-	err := store.AddWithOptions("weather.home", nil, nil, 0, "monthly")
+	err := store.AddWithOptions("weather.home", nil, nil, 0, "monthly", "")
 	if err == nil {
 		t.Fatal("expected invalid forecast error")
 	}
@@ -173,7 +173,7 @@ func TestStore_RemoveWithScopesPreservesOtherSubscriptions(t *testing.T) {
 	if err := store.Add("sensor.battery"); err != nil {
 		t.Fatalf("Add: %v", err)
 	}
-	if err := store.AddWithOptions("sensor.battery", []string{"battery_focus"}, nil, 0, ""); err != nil {
+	if err := store.AddWithOptions("sensor.battery", []string{"battery_focus"}, nil, 0, "", ""); err != nil {
 		t.Fatalf("AddWithOptions: %v", err)
 	}
 
@@ -248,7 +248,7 @@ func TestStore_UntaggedEntityIDSet(t *testing.T) {
 	}
 	// Tagged → NOT in the always-visible set even though the
 	// entity_id matches a candidate.
-	if err := store.AddWithOptions("sensor.tagged_only", []string{"focus"}, nil, 0, ""); err != nil {
+	if err := store.AddWithOptions("sensor.tagged_only", []string{"focus"}, nil, 0, "", ""); err != nil {
 		t.Fatalf("AddWithOptions: %v", err)
 	}
 

--- a/internal/state/awareness/watchlist_tool_provider.go
+++ b/internal/state/awareness/watchlist_tool_provider.go
@@ -204,11 +204,26 @@ func (w *WatchlistTools) handleAddEntitySubscription(ctx context.Context, args m
 		if ParseSubscriptionTarget(entityID).IsRegistryTarget() {
 			return "", fmt.Errorf("mode %q accepts entity ids and globs only — area/label/floor targets cannot feed the ingestion filter; subscribe the target with mode render, or list its member entities", mode)
 		}
+		// The ingestion filter reads only always-visible rows; a
+		// tag-scoped ingest subscription would sit in the store doing
+		// nothing. Reject rather than silently no-op.
+		if len(tags) > 0 {
+			return "", fmt.Errorf("mode %q subscriptions are always-visible and cannot carry tags — drop the tags, or use mode render for a tag-scoped subscription", mode)
+		}
 		globs, err := w.store.IngestGlobs(time.Now())
 		if err != nil {
 			return "", fmt.Errorf("count ingest entries: %w", err)
 		}
-		if len(globs) >= maxIngestEntries {
+		// Re-adding an existing entry updates it in place and doesn't
+		// grow the registry; the cap gates only genuinely new entries.
+		exists := false
+		for _, g := range globs {
+			if g == entityID {
+				exists = true
+				break
+			}
+		}
+		if !exists && len(globs) >= maxIngestEntries {
 			return "", fmt.Errorf("ingest registry is at its cap (%d entries) — remove entries before adding more; a broad glob covers more for less", maxIngestEntries)
 		}
 	}

--- a/internal/state/awareness/watchlist_tool_provider.go
+++ b/internal/state/awareness/watchlist_tool_provider.go
@@ -21,9 +21,10 @@ import (
 // immediately that area:office matches three entities, or that a typo'd
 // area:atrium matches none.
 type WatchlistTools struct {
-	store    *WatchlistStore
-	registry HARegistryClient
-	logger   *slog.Logger
+	store          *WatchlistStore
+	registry       HARegistryClient
+	onIngestChange func()
+	logger         *slog.Logger
 }
 
 // WatchlistToolsConfig captures the dependencies for [NewWatchlistTools].
@@ -34,6 +35,11 @@ type WatchlistToolsConfig struct {
 	// membership when a subscription is authored or listed. Optional:
 	// when nil, subscriptions still work but carry no expansion preview.
 	Registry HARegistryClient
+	// OnIngestChange is invoked after any mutation that may affect the
+	// state-watcher ingestion filter (an ingest/both-mode add, or any
+	// removal), so the wiring can rebuild the filter from the registry.
+	// Optional.
+	OnIngestChange func()
 	// Logger defaults to slog.Default when nil.
 	Logger *slog.Logger
 }
@@ -50,9 +56,10 @@ func NewWatchlistTools(cfg WatchlistToolsConfig) *WatchlistTools {
 		logger = slog.Default()
 	}
 	return &WatchlistTools{
-		store:    cfg.Store,
-		registry: cfg.Registry,
-		logger:   logger,
+		store:          cfg.Store,
+		registry:       cfg.Registry,
+		onIngestChange: cfg.OnIngestChange,
+		logger:         logger,
 	}
 }
 
@@ -96,6 +103,11 @@ func (w *WatchlistTools) Tools() []*tools.Tool {
 					"ttl_seconds": map[string]any{
 						"type":        "integer",
 						"description": "Optional expiration in seconds. After this TTL elapses, the subscription is automatically removed from future context injection.",
+					},
+					"mode": map[string]any{
+						"type":        "string",
+						"enum":        []string{"render", "ingest", "both"},
+						"description": "What the subscription feeds. render (default): inject live state into context each turn. ingest: feed the recent-state-changes window only — the entity's transitions appear there without per-turn state injection. both: do both. ingest/both accept entity ids and globs, not area/label/floor targets.",
 					},
 					"include": tools.EntityMetadataIncludeParameter(),
 				},
@@ -180,18 +192,47 @@ func (w *WatchlistTools) handleAddEntitySubscription(ctx context.Context, args m
 	if err != nil {
 		return "", err
 	}
+	rawMode, _ := args["mode"].(string)
+	mode := normalizeSubscriptionMode(rawMode)
+	if mode == "" {
+		return "", fmt.Errorf("mode must be one of render, ingest, or both; got %q", rawMode)
+	}
+	if mode != SubscriptionModeRender {
+		// The ingestion filter speaks the EntityFilter's native
+		// vocabulary: concrete ids and globs. Registry targets would be
+		// silently approximated, so they are rejected outright (#1192).
+		if ParseSubscriptionTarget(entityID).IsRegistryTarget() {
+			return "", fmt.Errorf("mode %q accepts entity ids and globs only — area/label/floor targets cannot feed the ingestion filter; subscribe the target with mode render, or list its member entities", mode)
+		}
+		globs, err := w.store.IngestGlobs(time.Now())
+		if err != nil {
+			return "", fmt.Errorf("count ingest entries: %w", err)
+		}
+		if len(globs) >= maxIngestEntries {
+			return "", fmt.Errorf("ingest registry is at its cap (%d entries) — remove entries before adding more; a broad glob covers more for less", maxIngestEntries)
+		}
+	}
 
-	if len(tags) == 0 && len(history) == 0 && ttlSeconds == 0 && forecast == "" && !forecastSet && !include.Any() {
+	if mode == SubscriptionModeRender && len(tags) == 0 && len(history) == 0 && ttlSeconds == 0 && forecast == "" && !forecastSet && !include.Any() {
 		if err := w.store.Add(entityID); err != nil {
 			return "", fmt.Errorf("add to watchlist: %w", err)
 		}
 	} else {
-		if err := w.store.AddWithOptions(entityID, tags, history, ttlSeconds, forecast, include); err != nil {
+		if err := w.store.AddWithOptions(entityID, tags, history, ttlSeconds, forecast, mode, include); err != nil {
 			return "", fmt.Errorf("add to watchlist: %w", err)
 		}
 	}
+	if mode != SubscriptionModeRender && w.onIngestChange != nil {
+		w.onIngestChange()
+	}
 
 	msg := fmt.Sprintf("Now watching %s", entityID)
+	switch mode {
+	case SubscriptionModeIngest:
+		msg += " (mode: ingest — transitions feed the recent-state-changes window; no per-turn state render)"
+	case SubscriptionModeBoth:
+		msg += " (mode: both — transitions feed the recent-state-changes window and live state renders each turn)"
+	}
 	if len(tags) > 0 {
 		msg += fmt.Sprintf(" (scoped to tags: %v)", tags)
 	}
@@ -271,6 +312,7 @@ func (w *WatchlistTools) handleListEntitySubscriptions(ctx context.Context, args
 		item := map[string]any{
 			"entity_id":      sub.EntityID,
 			"scope":          sub.Scope,
+			"mode":           sub.Mode,
 			"always_visible": sub.Scope == "",
 		}
 		if len(sub.History) > 0 {
@@ -342,6 +384,9 @@ func (w *WatchlistTools) handleRemoveEntitySubscription(_ context.Context, args 
 		return "", fmt.Errorf("remove from watchlist: %w", err)
 	}
 
+	if w.onIngestChange != nil {
+		w.onIngestChange()
+	}
 	w.logger.Info("entity subscription removed", "entity_id", entityID, "tags", tags)
 	if len(tags) > 0 {
 		return fmt.Sprintf("Stopped watching %s in scopes %v.", entityID, tags), nil

--- a/internal/state/awareness/watchlist_tool_provider_test.go
+++ b/internal/state/awareness/watchlist_tool_provider_test.go
@@ -243,10 +243,10 @@ func TestListEntitySubscriptions_ReturnsScopedSubscriptions(t *testing.T) {
 	if err := store.Add("sensor.always_on"); err != nil {
 		t.Fatalf("Add: %v", err)
 	}
-	if err := store.AddWithOptions("sensor.battery", []string{"battery_focus"}, []int{600}, 300, ""); err != nil {
+	if err := store.AddWithOptions("sensor.battery", []string{"battery_focus"}, []int{600}, 300, "", ""); err != nil {
 		t.Fatalf("AddWithOptions: %v", err)
 	}
-	if err := store.AddWithOptions("weather.home", []string{"weather_focus"}, nil, 0, "daily"); err != nil {
+	if err := store.AddWithOptions("weather.home", []string{"weather_focus"}, nil, 0, "daily", ""); err != nil {
 		t.Fatalf("AddWithOptions weather: %v", err)
 	}
 
@@ -347,7 +347,7 @@ func TestRemoveEntitySubscription_ScopedRemovalKeepsOtherSubscriptions(t *testin
 	if err := store.Add("sensor.battery"); err != nil {
 		t.Fatalf("Add: %v", err)
 	}
-	if err := store.AddWithOptions("sensor.battery", []string{"battery_focus"}, nil, 0, ""); err != nil {
+	if err := store.AddWithOptions("sensor.battery", []string{"battery_focus"}, nil, 0, "", ""); err != nil {
 		t.Fatalf("AddWithOptions: %v", err)
 	}
 

--- a/scripts/architecture.baseline
+++ b/scripts/architecture.baseline
@@ -1,5 +1,5 @@
 packages=64
 interfaces=83
 large_files=49
-set_mutators=111
+set_mutators=112
 database_opens=9

--- a/talents/awareness-trailhead.md
+++ b/talents/awareness-trailhead.md
@@ -31,6 +31,13 @@ Choose the next move deliberately:
   All expansions are capped per turn and report truncation when they
   overflow; scope to a smaller area/label/floor rather than watching the
   whole house. Use `ha_registry_search` to find area/label/floor IDs.
+- Pass `mode` to choose what a subscription feeds: `render` (default)
+  injects live state each turn; `ingest` feeds the recent-state-changes
+  window only — the entity's transitions appear there without spending
+  per-turn context on its full state; `both` does both. Ingest is the
+  right shape for "I want to notice when this changes" without carrying
+  it every turn. Ingest accepts entity ids and globs (not
+  area/label/floor targets), and the ingest registry is capped.
 - Add `include` metadata flags when area, owning device, HA labels, or
   descriptions would make the subscribed state easier to interpret; use
   `visibility` when hidden/enabled salience matters, and read


### PR DESCRIPTION
## Summary

Closes #1192 — the last static-config island in awareness. Which entities' `state_changed` events feed the state-change window was declared in `homeassistant.subscribe.entity_globs`, frozen at boot; changing it meant a config edit and a restart. The WebSocket feed was always a firehose filtered client-side, so the filter was always swappable — this makes it so, the same way #1184 made the pull side dynamic.

Both load-bearing design decisions were recorded on the issue before implementation (owner-confirmed): **model-facing and capped**, and **one unified registry with per-entry modes**.

## The shape

`add_entity_subscription` gains **`mode`**: `render` (the classic per-turn state injection — the absent-field default, so every existing row keeps its behavior), `ingest` (feed the recent-state-changes window only; no per-turn render), or `both`. Mode rides the existing options JSON blob — **zero DDL**. `list_entity_subscriptions` shows it; ingest-only rows are skipped by the render provider.

`StateWatcher.SetFilter` swaps the ingestion gate at runtime under a RWMutex — no HA re-subscription, the next event sees the new filter. Watchlist mutations fire an `OnIngestChange` hook that rebuilds the filter from `IngestGlobs()` (ingest/both rows, expired excluded) plus the person-entity auto-merge floor, which is preserved and tested.

**One semantic worth calling out**: with nothing registered, the filter now matches *nothing* (`NewEntityFilterMatchNone`). The old block's "empty means all entities" made sense for hand-written config; under a runtime registry, empty must mean ingest-nothing — anything else is a firehose default one `remove_entity_subscription` away.

## Guardrails (per the recorded decision)

- `maxIngestEntries` cap (64 — globs make it generous)
- Registry targets (`area:`/`label:`/`floor:`) rejected for ingest with a teaching error — the filter speaks the EntityFilter's native vocabulary (ids + globs); membership-resolved ingestion is future work, not a silent approximation
- **One deliberate deviation from the issue sketch**: the per-entity rate limit stays *operator policy in config* (relocated to `homeassistant.ingest_rate_limit_per_minute`) rather than moving into the model-mutable registry — a model raising its own ingestion rate limit would defeat the #1024 wakestorm guard the limit exists to be

## Upgrade note (release material)

The `homeassistant.subscribe` block is retired. `entity_globs` become ingest-mode subscriptions; `rate_limit_per_minute` becomes `homeassistant.ingest_rate_limit_per_minute`. For the production cutover, each old glob maps to one call:

```json
add_entity_subscription {"entity_id": "binary_sensor.*_door", "mode": "ingest"}
```

(Prod currently carries 13 globs + rate limit 12; I'll hand the exact seeding list at deploy time.)

## Test plan

- [x] `IngestGlobs`: ingest+both rows in, render rows out, expired rows out
- [x] Mode round-trips through the options blob; pre-mode rows decode as render
- [x] `SetFilter` live swap changes matching with no reconnection; match-none drops everything; `SetFilter(nil)` defaults to match-none
- [x] Ingest-only rows don't render per-turn context
- [x] Tool flow: mode validation, registry-target rejection, cap enforcement, `OnIngestChange` fires on add and remove
- [x] Person auto-merge preserved in the rebuild path
- [x] `set_mutators` baseline bump justified (SetFilter is genuine runtime mutation); store split keeps `large_files` at baseline
- [x] `just ci` green locally (unpiped, real exit code verified)

Refs #1184, #1175, #1024.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
