### PR TITLE
refactor(tools): typed schemas for loop_containers and the placement advisory

### DIFF
--- a/internal/tools/loop_containers_tool.go
+++ b/internal/tools/loop_containers_tool.go
@@ -31,6 +31,36 @@ func (r *Registry) registerLoopContainers() {
 	})
 }
 
+// LoopContainerView is one row of the loop_containers placement
+// directory: a container loop expressed for model consumption. Field
+// declaration order matches the alphabetical order the previous
+// map-based output marshaled in, so the rendered JSON is byte-identical
+// across the typed-schema introduction (#1173).
+type LoopContainerView struct {
+	// ChildCount is how many loops nest directly under this container.
+	ChildCount int `json:"child_count"`
+	// ConfersTags is the sorted capability tag set the container passes
+	// to everything nested under it. Always non-nil so it serializes as
+	// [] rather than null.
+	ConfersTags []string `json:"confers_tags"`
+	// DescendantCount is the transitive nested-loop count.
+	DescendantCount int `json:"descendant_count"`
+	// Intent is the container's declared purpose.
+	Intent string `json:"intent"`
+	// Name is the container's loop name — the value a new loop passes as
+	// parent_name to nest here.
+	Name string `json:"name"`
+	// SampleChildren previews up to loopContainerSampleChildrenCap child
+	// loop names; ChildCount carries the true total.
+	SampleChildren []string `json:"sample_children"`
+}
+
+// loopContainersResult is the loop_containers tool's response envelope.
+type loopContainersResult struct {
+	Containers []LoopContainerView `json:"containers"`
+	Status     string              `json:"status"`
+}
+
 func (r *Registry) handleLoopContainers(_ context.Context, _ map[string]any) (string, error) {
 	if r.liveLoopRegistry == nil {
 		return "", fmt.Errorf("live loop registry is not configured")
@@ -58,7 +88,7 @@ func (r *Registry) handleLoopContainers(_ context.Context, _ map[string]any) (st
 		return containerStatuses[i].Name < containerStatuses[j].Name
 	})
 
-	containers := make([]map[string]any, 0, len(containerStatuses))
+	containers := make([]LoopContainerView, 0, len(containerStatuses))
 	for _, s := range containerStatuses {
 		childIDs := append([]string(nil), childrenByParent[s.ID]...)
 		sort.Slice(childIDs, func(i, j int) bool {
@@ -71,18 +101,18 @@ func (r *Registry) handleLoopContainers(_ context.Context, _ map[string]any) (st
 			}
 			sample = append(sample, byID[cid].Name)
 		}
-		containers = append(containers, map[string]any{
-			"name":             s.Name,
-			"intent":           s.Config.Intent,
-			"child_count":      len(childIDs),
-			"descendant_count": countDescendants(s.ID, childrenByParent),
-			"confers_tags":     containerConfersTags(s),
-			"sample_children":  sample,
+		containers = append(containers, LoopContainerView{
+			Name:            s.Name,
+			Intent:          s.Config.Intent,
+			ChildCount:      len(childIDs),
+			DescendantCount: countDescendants(s.ID, childrenByParent),
+			ConfersTags:     containerConfersTags(s),
+			SampleChildren:  sample,
 		})
 	}
-	return ldMarshalToolJSON(map[string]any{
-		"status":     "ok",
-		"containers": containers,
+	return ldMarshalToolJSON(loopContainersResult{
+		Status:     "ok",
+		Containers: containers,
 	})
 }
 

--- a/internal/tools/loop_placement_advisory.go
+++ b/internal/tools/loop_placement_advisory.go
@@ -15,6 +15,33 @@ type containerTagSet struct {
 	tags []string
 }
 
+// LoopPlacementAdvisoryCandidate is one container the placement
+// advisory suggests as a better parent, with the tag overlap that
+// motivates it.
+type LoopPlacementAdvisoryCandidate struct {
+	// Container is the suggested parent container's name.
+	Container string `json:"container"`
+	// Rationale is the human-readable reason this container matches.
+	Rationale string `json:"rationale"`
+	// SharedTags is the sorted set of tags the loop and container share.
+	SharedTags []string `json:"shared_tags"`
+}
+
+// LoopPlacementAdvisory is the non-blocking placement suggestion
+// attached to loop creation and lint results when a tagged loop lands
+// at the structural root while existing containers declare tags it
+// shares. Field declaration order matches the previous map output's
+// alphabetical marshal order so the JSON is byte-identical across the
+// typed-schema introduction (#1173).
+type LoopPlacementAdvisory struct {
+	// Candidates are the overlapping containers, sorted by name.
+	Candidates []LoopPlacementAdvisoryCandidate `json:"candidates"`
+	// CurrentParent is where the loop is currently parented (the root).
+	CurrentParent string `json:"current_parent"`
+	// Message summarizes the suggestion for the model.
+	Message string `json:"message"`
+}
+
 // buildPlacementAdvisory returns a non-blocking placement suggestion (#1102
 // Tier 2 — the loop-graph analog of doc_intake's recommendation + caution)
 // when a tagged loop lands at the structural root yet existing containers
@@ -22,7 +49,7 @@ type containerTagSet struct {
 // Returns nil when the loop is not at root, declares no tags, or nothing
 // overlaps — the field is present only when it has something to say, and it
 // never blocks creation.
-func buildPlacementAdvisory(loopName, parentName string, loopTags []string, containers []containerTagSet) map[string]any {
+func buildPlacementAdvisory(loopName, parentName string, loopTags []string, containers []containerTagSet) *LoopPlacementAdvisory {
 	if !placementAtRoot(parentName) || len(loopTags) == 0 {
 		return nil
 	}
@@ -36,7 +63,7 @@ func buildPlacementAdvisory(loopName, parentName string, loopTags []string, cont
 	sorted := append([]containerTagSet(nil), containers...)
 	sort.Slice(sorted, func(i, j int) bool { return sorted[i].name < sorted[j].name })
 
-	candidates := make([]map[string]any, 0)
+	candidates := make([]LoopPlacementAdvisoryCandidate, 0)
 	for _, c := range sorted {
 		if c.name == loopName {
 			// Never suggest a loop nest under itself — relevant when the loop
@@ -54,22 +81,22 @@ func buildPlacementAdvisory(loopName, parentName string, loopTags []string, cont
 			continue
 		}
 		sort.Strings(shared)
-		candidates = append(candidates, map[string]any{
-			"container":   c.name,
-			"shared_tags": shared,
-			"rationale":   fmt.Sprintf("declares %s, which this loop also has", quotedTagList(shared)),
+		candidates = append(candidates, LoopPlacementAdvisoryCandidate{
+			Container:  c.name,
+			SharedTags: shared,
+			Rationale:  fmt.Sprintf("declares %s, which this loop also has", quotedTagList(shared)),
 		})
 	}
 	if len(candidates) == 0 {
 		return nil
 	}
 
-	return map[string]any{
-		"message": fmt.Sprintf(
+	return &LoopPlacementAdvisory{
+		Message: fmt.Sprintf(
 			"This loop is parented to %q (the root), but %d existing container(s) declare tags it shares — consider setting parent_name to one of them so the loop nests under it and inherits its context.",
 			looppkg.CoreLoopName, len(candidates)),
-		"current_parent": looppkg.CoreLoopName,
-		"candidates":     candidates,
+		CurrentParent: looppkg.CoreLoopName,
+		Candidates:    candidates,
 	}
 }
 
@@ -92,7 +119,7 @@ func quotedTagList(tags []string) string {
 // livePlacementAdvisory computes the advisory for the loop-creation path from
 // the live container set (the loops a live spawn can actually nest under).
 // Returns nil when the live registry is unavailable or nothing applies.
-func (r *Registry) livePlacementAdvisory(loopName string, loopTags []string, parentName string) map[string]any {
+func (r *Registry) livePlacementAdvisory(loopName string, loopTags []string, parentName string) *LoopPlacementAdvisory {
 	if !placementAtRoot(parentName) || len(loopTags) == 0 {
 		return nil
 	}
@@ -112,7 +139,7 @@ func (r *Registry) livePlacementAdvisory(loopName string, loopTags []string, par
 
 // placementAdvisoryFromView computes the advisory for the lint path from the
 // stored definition set (lint is a dry-run over definitions, not live loops).
-func placementAdvisoryFromView(loopName string, loopTags []string, parentName string, view *looppkg.DefinitionRegistryView) map[string]any {
+func placementAdvisoryFromView(loopName string, loopTags []string, parentName string, view *looppkg.DefinitionRegistryView) *LoopPlacementAdvisory {
 	if !placementAtRoot(parentName) || len(loopTags) == 0 || view == nil {
 		return nil
 	}

--- a/internal/tools/loop_placement_advisory_test.go
+++ b/internal/tools/loop_placement_advisory_test.go
@@ -17,11 +17,10 @@ func TestBuildPlacementAdvisory(t *testing.T) {
 		{name: "trips", tags: []string{"travel"}},
 	}
 
-	candNames := func(adv map[string]any) []string {
-		cands := adv["candidates"].([]map[string]any)
-		out := make([]string, len(cands))
-		for i, c := range cands {
-			out[i] = c["container"].(string)
+	candNames := func(adv *LoopPlacementAdvisory) []string {
+		out := make([]string, len(adv.Candidates))
+		for i, c := range adv.Candidates {
+			out[i] = c.Container
 		}
 		return out
 	}
@@ -34,8 +33,8 @@ func TestBuildPlacementAdvisory(t *testing.T) {
 		if got := candNames(adv); len(got) != 2 || got[0] != "travel" || got[1] != "trips" {
 			t.Fatalf("candidates = %v, want [travel trips]", got)
 		}
-		if adv["current_parent"] != looppkg.CoreLoopName {
-			t.Errorf("current_parent = %v, want core", adv["current_parent"])
+		if adv.CurrentParent != looppkg.CoreLoopName {
+			t.Errorf("current_parent = %v, want core", adv.CurrentParent)
 		}
 	})
 
@@ -165,5 +164,49 @@ func TestPlacementAdvisoryOnLint(t *testing.T) {
 	if len(got.PlacementAdvisory.Candidates) != 1 ||
 		got.PlacementAdvisory.Candidates[0].Container != "travel" {
 		t.Fatalf("candidates = %+v, want [travel]", got.PlacementAdvisory.Candidates)
+	}
+}
+
+// The typed schemas exist so field names and presence are a compile-time
+// contract (#1173). This golden pins the exact wire shape — byte-identical
+// to the map-based output they replaced — so schema drift is a test
+// failure, not a silent model-facing change.
+func TestPlacementAdvisoryWireShapeGolden(t *testing.T) {
+	t.Parallel()
+
+	adv := buildPlacementAdvisory("flight_watch", "", []string{"travel"}, []containerTagSet{
+		{name: "travel", tags: []string{"travel", "calendar"}},
+	})
+	if adv == nil {
+		t.Fatal("expected an advisory")
+	}
+	got, err := json.Marshal(adv)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	want := `{"candidates":[{"container":"travel","rationale":"declares \"travel\", which this loop also has","shared_tags":["travel"]}],"current_parent":"core","message":"This loop is parented to \"core\" (the root), but 1 existing container(s) declare tags it shares — consider setting parent_name to one of them so the loop nests under it and inherits its context."}`
+	if string(got) != want {
+		t.Fatalf("wire shape drifted:\n got: %s\nwant: %s", got, want)
+	}
+}
+
+func TestLoopContainerViewWireShapeGolden(t *testing.T) {
+	t.Parallel()
+
+	view := LoopContainerView{
+		Name:            "home",
+		Intent:          "House awareness loops",
+		ChildCount:      2,
+		DescendantCount: 3,
+		ConfersTags:     []string{"ha"},
+		SampleChildren:  []string{"climate-watch", "garage-bays"},
+	}
+	got, err := json.Marshal(view)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	want := `{"child_count":2,"confers_tags":["ha"],"descendant_count":3,"intent":"House awareness loops","name":"home","sample_children":["climate-watch","garage-bays"]}`
+	if string(got) != want {
+		t.Fatalf("wire shape drifted:\n got: %s\nwant: %s", got, want)
 	}
 }


### PR DESCRIPTION
## Summary

Closes #1173, from the v0.10.1 model-facing audit. `loop_containers` built its rows as `[]map[string]any` and the placement advisory assembled as `map[string]any` — model-facing tool outputs whose field names and presence were a runtime accident, free to drift silently as the code evolves. The doctrine wants generated state as typed JSON with a declared schema.

## The change

`LoopContainerView`, `LoopPlacementAdvisory`, and `LoopPlacementAdvisoryCandidate` make the schemas compile-time contracts, with Godoc on every field. Two details that keep the introduction invisible to the model:

- **Struct field declaration order matches the alphabetical order Go marshals maps in**, so the rendered JSON is byte-identical to yesterday's output — same names, same order, same non-nil-slice invariants (`confers_tags`/`sample_children` serialize as `[]`, never `null`).
- The advisory functions return `*LoopPlacementAdvisory`; the existing nil-check-then-embed call sites (create ×2, lint) compile unchanged, with no typed-nil hazard since every site checks before embedding.

**Wire-shape golden tests** pin the exact serialization of both schemas. That's the real payoff: the issue's "becomes load-bearing the first time someone edits those maps without noticing they're a schema" is now a test failure instead of a silent model-facing change.

## Test plan

- [x] Golden tests pin the exact wire shape of both schemas (names, order, escaping)
- [x] Pre-existing behavior tests (create-path advisory, lint-path advisory, containers directory) pass — the JSON-decoding tests passed unmodified, confirming the wire format is intact
- [x] `just ci` green locally (unpiped, real exit code verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
