### PR TITLE
feat(mqtt): migrate MQTT wakes onto the shared loopqueue consumer chassis

### DIFF
--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -444,6 +444,16 @@ See [MQTT](../operating/mqtt.md) for the broker-side conventions.
 |------|-------------|
 | `mqtt_wake_list` | List runtime and config-defined wake subscriptions. |
 | `mqtt_wake_add` | Add a runtime wake subscription that delivers matching messages to a `wake_loop` target. Required args: `topic` and `wake_loop` (loop name/ID, optional tags + instructions). The legacy inline routing fields (`mission`, `quality_floor`, etc.) were retired in PR-T2b; point `wake_loop` at the built-in `mqtt-default-handler` for generic triage. |
+
+MQTT wake delivery rides the shared loopqueue chassis: matching
+messages enqueue durably per target and a short debounced wake drains
+the coalesced batch, so a burst on one topic becomes one iteration
+(latest payload wins per subscription+topic) and a message received
+just before a crash is replayed at the next startup. A payload may
+self-address by including `target_loop` (a loop definition name) — a
+general-purpose HA automation publishing to one shared wake topic can
+wake any named loop with no per-topic subscription; unresolvable
+targets fall back to the subscription's `wake_loop`.
 | `mqtt_wake_remove` | Remove a runtime wake subscription by ID. |
 
 ## `message_channel` — current message-app conversation

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -187,6 +187,12 @@ type App struct {
 	// earlier are simply no-ops.
 	ingestFilterRebuild func()
 
+	// MQTT wake delivery dispatcher over the shared loopqueue
+	// (#1033). Set during MQTT wiring in new_servers; the
+	// loop-definition worker runs its boot recovery sweep once loop
+	// targets have hydrated. Nil when MQTT is not configured.
+	mqttWakeDispatch *mqttWakeDispatcher
+
 	// Checkpointing
 	checkpointer *checkpoint.Checkpointer
 

--- a/internal/app/mqttwake.go
+++ b/internal/app/mqttwake.go
@@ -2,9 +2,11 @@ package app
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 	"unicode/utf8"
@@ -13,6 +15,7 @@ import (
 	mqtt "github.com/nugget/thane-ai-agent/internal/channels/mqtt"
 	"github.com/nugget/thane-ai-agent/internal/platform/events"
 	looppkg "github.com/nugget/thane-ai-agent/internal/runtime/loop"
+	"github.com/nugget/thane-ai-agent/internal/state/loopqueue"
 )
 
 // maxWakePayloadBytes bounds the MQTT payload size included in the
@@ -29,6 +32,18 @@ const maxWakePayloadBytes = 32 * 1024
 // the envelope-handoff hop.
 const mqttWakeDeliveryTimeout = 30 * time.Second
 
+// mqttWakePartitionPrefix namespaces the loopqueue partitions the MQTT
+// wake dispatcher owns. Partition strings are internal routing keys —
+// deliberately NOT bare loop names, so a wake target that also happens
+// to be a model-facing queue consumer (archivist-style queue_pull)
+// never finds MQTT plumbing records in its own partition.
+const mqttWakePartitionPrefix = "mqtt-wake:"
+
+// mqttWakeDrainBatch bounds one Peek pass during a drain. The drain
+// loops until the partition is empty, so this is a memory bound per
+// pass, not a delivery cap.
+const mqttWakeDrainBatch = 50
+
 // mqttWakeDeps wires the wake handler to the message bus and event
 // bus. parentID is unused in the post-retirement dispatch shape but
 // retained so the wiring in new_servers.go stays compatible during
@@ -40,8 +55,53 @@ type mqttWakeDeps struct {
 	parentID   *atomic.Value
 }
 
-// mqttWakeHandler returns a MessageHandler that delivers MQTT messages
-// to existing event-driven loops via the message bus. Every active
+// mqttQueuedWake is the loopqueue payload for one matched MQTT
+// message: the resolved wake target plus the event to deliver. Stored
+// durably at ingress and replayed by the dispatcher's drain, so a
+// crash between broker receipt and loop delivery no longer loses the
+// message, and a burst on one topic coalesces (latest payload wins
+// per subscription+topic) instead of amplifying into a wake per
+// message (#1024/#1033).
+type mqttQueuedWake struct {
+	Target messages.LoopWakeTarget   `json:"target"`
+	Event  messages.LoopEventPayload `json:"event"`
+}
+
+// mqttWakeDispatcher moves MQTT wake delivery onto the shared
+// loopqueue chassis: ingress enqueues into a per-target partition and
+// arms the WakeOnEnqueue debounce; the debounced fire drains the
+// coalesced batch and hands each record to the message bus exactly
+// the way the direct path used to. Trigger rate is decoupled from
+// wake rate; the downstream envelope contract is unchanged.
+type mqttWakeDispatcher struct {
+	queue  *loopqueue.Store
+	deps   mqttWakeDeps
+	logger *slog.Logger
+
+	// debounce/maxWait override the loopqueue wake defaults; zero
+	// values defer to [loopqueue.DefaultWakeDebounce] /
+	// [loopqueue.DefaultWakeMaxWait]. Tests shrink them.
+	debounce time.Duration
+	maxWait  time.Duration
+
+	mu         sync.Mutex
+	registered map[string]bool
+}
+
+func newMQTTWakeDispatcher(queue *loopqueue.Store, deps mqttWakeDeps, logger *slog.Logger) *mqttWakeDispatcher {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &mqttWakeDispatcher{
+		queue:      queue,
+		deps:       deps,
+		logger:     logger,
+		registered: make(map[string]bool),
+	}
+}
+
+// mqttWakeHandler returns a MessageHandler that routes MQTT messages
+// on wake topics onto the loopqueue dispatcher. Every active
 // subscription routes through a wake_loop target after the trigger-
 // unification work; legacy inline-Profile subscriptions are migrated
 // onto [mqtt.DefaultHandlerLoopName] at config load / DB hydrate time.
@@ -53,7 +113,7 @@ func mqttWakeHandler(
 	store *mqtt.SubscriptionStore,
 	fallback mqtt.MessageHandler,
 	logger *slog.Logger,
-	deps mqttWakeDeps,
+	dispatcher *mqttWakeDispatcher,
 ) mqtt.MessageHandler {
 	if logger == nil {
 		logger = slog.Default()
@@ -67,34 +127,34 @@ func mqttWakeHandler(
 			return
 		}
 
-		if deps.messageBus == nil {
-			logger.Error("mqtt wake has no message bus, dropping message",
+		if dispatcher == nil || dispatcher.deps.messageBus == nil {
+			logger.Error("mqtt wake has no dispatcher/message bus, dropping message",
 				"topic", topic,
 				"matches", len(matches),
 			)
 			return
 		}
 
-		// Fan-out: dispatch one envelope per matching subscription so
+		// Fan-out: one queue record per matching subscription so
 		// multiple subscribers (e.g. owner-attention plus security
 		// monitoring) on the same topic each see the same event in
 		// their own loop's iteration context.
 		for _, ws := range matches {
 			ws := ws
-			go dispatchViaWakeTarget(deps, ws, topic, payload, logger)
+			go dispatcher.ingress(ws, topic, payload)
 		}
 	}
 }
 
-// dispatchViaWakeTarget delivers an MQTT message to the subscription's
-// wake target as an event-source notification. Builds a
-// [messages.LoopEventPayload], wraps it in a
-// [messages.NewEventSourceEnvelope], and publishes via the bus with a
-// bounded delivery context. No new loop is spawned — the target loop
-// (a custom event-driven loop or the built-in default handler) sees
-// the event in its pending notifications and runs under its own
-// Spec.Profile / container cascade.
-func dispatchViaWakeTarget(deps mqttWakeDeps, ws mqtt.WakeSubscription, topic string, payload []byte, logger *slog.Logger) {
+// ingress converts one matched MQTT message into a durable queue
+// record: resolve the effective wake target (honoring payload
+// self-addressing), build the event, and enqueue it into the target's
+// partition — arming the debounced drain. Coalescing: a second
+// message on the same subscription+topic inside the debounce window
+// replaces the pending payload (latest wins) rather than appending.
+func (d *mqttWakeDispatcher) ingress(ws mqtt.WakeSubscription, topic string, payload []byte) {
+	target := d.resolveTarget(ws, topic, payload)
+
 	event := messages.LoopEventPayload{
 		Source:     "mqtt_wake",
 		Type:       "message",
@@ -107,42 +167,199 @@ func dispatchViaWakeTarget(deps mqttWakeDeps, ws mqtt.WakeSubscription, topic st
 			"subscription_id": ws.ID,
 		},
 	}
+	if target.Name != ws.WakeTarget.Name {
+		event.Metadata["target_loop"] = target.Name
+	}
+
+	record, err := json.Marshal(mqttQueuedWake{Target: target, Event: event})
+	if err != nil {
+		d.logger.Warn("mqtt wake record marshal failed, dropping message",
+			"subscription_id", ws.ID, "topic", topic, "error", err)
+		return
+	}
+
+	partition := mqttWakePartition(target)
+	d.ensureRegistered(partition)
+
+	enqCtx, cancel := context.WithTimeout(context.Background(), mqttWakeDeliveryTimeout)
+	defer cancel()
+	dedupKey := fmt.Sprintf("mqtt:%s:%s", ws.ID, topic)
+	if err := d.queue.Enqueue(enqCtx, partition, dedupKey, int(targetPriorityRank(target)), record); err != nil {
+		d.logger.Warn("mqtt wake enqueue failed, dropping message",
+			"subscription_id", ws.ID, "topic", topic, "partition", partition, "error", err)
+	}
+}
+
+// resolveTarget returns the subscription's wake target, overridden by
+// a payload-declared target_loop when present and resolvable (#1033
+// self-addressing: a general-purpose HA automation publishes
+// {"target_loop": "<definition name>", ...} to a shared wake topic and
+// wakes that loop with no pre-registered per-topic subscription). An
+// unresolvable self-address falls back to the subscription's static
+// target with a warning — the message still lands somewhere a model
+// can triage it rather than vanishing.
+func (d *mqttWakeDispatcher) resolveTarget(ws mqtt.WakeSubscription, topic string, payload []byte) messages.LoopWakeTarget {
+	var probe struct {
+		TargetLoop string `json:"target_loop"`
+	}
+	if err := json.Unmarshal(payload, &probe); err != nil {
+		return ws.WakeTarget
+	}
+	name := strings.TrimSpace(probe.TargetLoop)
+	if name == "" {
+		return ws.WakeTarget
+	}
+	if d.deps.registry == nil || !d.deps.registry.LoopExistsByName(name) {
+		d.logger.Warn("mqtt payload target_loop does not resolve; falling back to subscription target",
+			"subscription_id", ws.ID, "topic", topic,
+			"target_loop", name,
+			"fallback", ws.WakeTarget.Name,
+		)
+		return ws.WakeTarget
+	}
+	// The subscription's presentation fields (instructions, tags,
+	// priority, supervisor forcing) ride along; only the destination
+	// is re-addressed.
+	target := ws.WakeTarget
+	target.LoopID = ""
+	target.Name = name
+	return target
+}
+
+// ensureRegistered lazily attaches the WakeOnEnqueue debounce for a
+// partition the first time traffic addresses it. Package defaults for
+// debounce/maxWait: coalesce a burst, never starve under chatter.
+func (d *mqttWakeDispatcher) ensureRegistered(partition string) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.registered[partition] {
+		return
+	}
+	d.registered[partition] = true
+	d.queue.SetWakeOnEnqueue(partition, d.debounce, d.maxWait, func() { d.drain(partition) })
+}
+
+// drain delivers a partition's pending records to the message bus in
+// drain order and acks each attempt. Delivery failures are logged and
+// acked anyway — parity with the pre-queue direct path, where a
+// failed bus send dropped the message; the queue adds crash
+// durability and burst coalescing, not retry semantics. A record that
+// no longer unmarshals is acked and skipped for the same reason.
+func (d *mqttWakeDispatcher) drain(partition string) {
+	ctx := context.Background()
+	for {
+		items, err := d.queue.Peek(ctx, partition, mqttWakeDrainBatch)
+		if err != nil {
+			d.logger.Warn("mqtt wake drain peek failed", "partition", partition, "error", err)
+			return
+		}
+		if len(items) == 0 {
+			return
+		}
+		for _, item := range items {
+			d.deliver(partition, item)
+		}
+		if len(items) < mqttWakeDrainBatch {
+			return
+		}
+	}
+}
+
+// deliver replays one queued record through the same envelope path
+// the direct dispatch used, then acks it.
+func (d *mqttWakeDispatcher) deliver(partition string, item loopqueue.Item) {
+	ack := func() {
+		if err := d.queue.Ack(context.Background(), partition, item.DedupKey); err != nil {
+			d.logger.Warn("mqtt wake ack failed", "partition", partition, "dedup_key", item.DedupKey, "error", err)
+		}
+	}
+
+	var record mqttQueuedWake
+	if err := json.Unmarshal(item.Payload, &record); err != nil {
+		d.logger.Warn("mqtt wake record unmarshal failed, dropping",
+			"partition", partition, "dedup_key", item.DedupKey, "error", err)
+		ack()
+		return
+	}
 
 	env, err := messages.NewEventSourceEnvelope(
 		messages.Identity{Kind: messages.IdentitySystem, Name: "mqtt_wake"},
-		ws.WakeTarget,
+		record.Target,
 		"mqtt_wake",
-		[]messages.LoopEventPayload{event},
+		[]messages.LoopEventPayload{record.Event},
 	)
 	if err != nil {
-		logger.Warn("mqtt wake envelope construction failed, dropping message",
-			"subscription_id", ws.ID,
-			"topic", topic,
-			"error", err,
-		)
+		d.logger.Warn("mqtt wake envelope construction failed, dropping message",
+			"partition", partition, "dedup_key", item.DedupKey, "error", err)
+		ack()
 		return
 	}
 
 	deliveryCtx, cancel := context.WithTimeout(context.Background(), mqttWakeDeliveryTimeout)
 	defer cancel()
-	if _, err := deps.messageBus.Send(deliveryCtx, env); err != nil {
-		logger.Warn("mqtt wake envelope delivery failed, dropping message",
-			"subscription_id", ws.ID,
-			"topic", topic,
-			"target_loop_id", ws.WakeTarget.LoopID,
-			"target_loop_name", ws.WakeTarget.Name,
+	if _, err := d.deps.messageBus.Send(deliveryCtx, env); err != nil {
+		d.logger.Warn("mqtt wake envelope delivery failed, dropping message",
+			"partition", partition,
+			"dedup_key", item.DedupKey,
+			"target_loop_id", record.Target.LoopID,
+			"target_loop_name", record.Target.Name,
 			"error", err,
 		)
+		ack()
 		return
 	}
+	ack()
 
-	logger.Info("mqtt wake delivered to target loop",
-		"subscription_id", ws.ID,
-		"topic", topic,
-		"target_loop_id", ws.WakeTarget.LoopID,
-		"target_loop_name", ws.WakeTarget.Name,
-		"payload_size", len(payload),
+	d.logger.Info("mqtt wake delivered to target loop",
+		"partition", partition,
+		"dedup_key", item.DedupKey,
+		"target_loop_id", record.Target.LoopID,
+		"target_loop_name", record.Target.Name,
 	)
+}
+
+// Sweep drains every mqtt-wake partition that still holds pending
+// records — the boot-time recovery for enqueues whose debounce was
+// pending when the process died. Call after the loop registry has
+// hydrated so targets resolve. Partitions touched here are also
+// registered so subsequent traffic debounces normally.
+func (d *mqttWakeDispatcher) Sweep(ctx context.Context) {
+	partitions, err := d.queue.Consumers(ctx, mqttWakePartitionPrefix)
+	if err != nil {
+		d.logger.Warn("mqtt wake boot sweep failed to enumerate partitions", "error", err)
+		return
+	}
+	for _, partition := range partitions {
+		d.ensureRegistered(partition)
+		d.drain(partition)
+	}
+	if len(partitions) > 0 {
+		d.logger.Info("mqtt wake boot sweep drained pending partitions", "partitions", len(partitions))
+	}
+}
+
+// mqttWakePartition derives the queue partition for a wake target.
+// Keyed by destination so per-target coalescing works and two targets
+// never share a burst window.
+func mqttWakePartition(target messages.LoopWakeTarget) string {
+	if target.LoopID != "" {
+		return mqttWakePartitionPrefix + "id:" + target.LoopID
+	}
+	return mqttWakePartitionPrefix + "name:" + target.Name
+}
+
+// targetPriorityRank maps a wake target's delivery priority onto the
+// queue's integer priority so urgent wakes drain ahead of normal ones
+// within a partition.
+func targetPriorityRank(target messages.LoopWakeTarget) int {
+	switch target.Priority {
+	case messages.PriorityUrgent:
+		return 2
+	case messages.PriorityLow:
+		return 0
+	default:
+		return 1
+	}
 }
 
 // sanitizePayload converts raw MQTT bytes to a valid UTF-8 string,

--- a/internal/app/mqttwake.go
+++ b/internal/app/mqttwake.go
@@ -86,6 +86,12 @@ type mqttWakeDispatcher struct {
 
 	mu         sync.Mutex
 	registered map[string]bool
+	// draining serializes drains per partition: Peek does not claim
+	// items, so a debounce fire racing a boot Sweep (or a second
+	// fire) over the same partition would deliver the same records
+	// twice. One drain runs at a time; a follower blocks, then finds
+	// whatever the first left behind (usually nothing).
+	draining map[string]*sync.Mutex
 }
 
 func newMQTTWakeDispatcher(queue *loopqueue.Store, deps mqttWakeDeps, logger *slog.Logger) *mqttWakeDispatcher {
@@ -97,6 +103,7 @@ func newMQTTWakeDispatcher(queue *loopqueue.Store, deps mqttWakeDeps, logger *sl
 		deps:       deps,
 		logger:     logger,
 		registered: make(map[string]bool),
+		draining:   make(map[string]*sync.Mutex),
 	}
 }
 
@@ -228,7 +235,9 @@ func (d *mqttWakeDispatcher) resolveTarget(ws mqtt.WakeSubscription, topic strin
 
 // ensureRegistered lazily attaches the WakeOnEnqueue debounce for a
 // partition the first time traffic addresses it. Package defaults for
-// debounce/maxWait: coalesce a burst, never starve under chatter.
+// debounce/maxWait: coalesce a burst, never starve under chatter. The
+// fire callback must not block (loopqueue contract), so it hands off
+// to a goroutine that runs the serialized drain.
 func (d *mqttWakeDispatcher) ensureRegistered(partition string) {
 	d.mu.Lock()
 	defer d.mu.Unlock()
@@ -236,7 +245,32 @@ func (d *mqttWakeDispatcher) ensureRegistered(partition string) {
 		return
 	}
 	d.registered[partition] = true
-	d.queue.SetWakeOnEnqueue(partition, d.debounce, d.maxWait, func() { d.drain(partition) })
+	d.queue.SetWakeOnEnqueue(partition, d.debounce, d.maxWait, func() {
+		go d.drainSerialized(partition)
+	})
+}
+
+// partitionLock returns the per-partition drain mutex, creating it on
+// first use.
+func (d *mqttWakeDispatcher) partitionLock(partition string) *sync.Mutex {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	lock, ok := d.draining[partition]
+	if !ok {
+		lock = &sync.Mutex{}
+		d.draining[partition] = lock
+	}
+	return lock
+}
+
+// drainSerialized runs drain under the partition's mutex so
+// concurrent triggers (debounce fire, boot sweep) cannot replay the
+// same un-acked records twice.
+func (d *mqttWakeDispatcher) drainSerialized(partition string) {
+	lock := d.partitionLock(partition)
+	lock.Lock()
+	defer lock.Unlock()
+	d.drain(partition)
 }
 
 // drain delivers a partition's pending records to the message bus in
@@ -331,7 +365,7 @@ func (d *mqttWakeDispatcher) Sweep(ctx context.Context) {
 	}
 	for _, partition := range partitions {
 		d.ensureRegistered(partition)
-		d.drain(partition)
+		d.drainSerialized(partition)
 	}
 	if len(partitions) > 0 {
 		d.logger.Info("mqtt wake boot sweep drained pending partitions", "partitions", len(partitions))

--- a/internal/app/mqttwake_test.go
+++ b/internal/app/mqttwake_test.go
@@ -366,3 +366,54 @@ func TestSanitizePayloadEmpty(t *testing.T) {
 		t.Errorf("sanitizePayload(nil) = %q, want empty", got)
 	}
 }
+
+// TestMQTTWakeConcurrentDrainsDeliverOnce pins the serialization fix
+// from Copilot #1216: Peek does not claim items, so a debounce fire
+// racing a boot Sweep over the same partition would replay the same
+// record twice without the per-partition drain mutex. A slow bus
+// route holds the first drain open while concurrent triggers pile up;
+// exactly one delivery must come out.
+func TestMQTTWakeConcurrentDrainsDeliverOnce(t *testing.T) {
+	bus := messages.NewBus(nil)
+	var (
+		mu        sync.Mutex
+		delivered int
+	)
+	bus.RegisterRoute(messages.DestinationLoop, func(_ context.Context, env messages.Envelope) (messages.DeliveryResult, error) {
+		time.Sleep(80 * time.Millisecond) // hold the drain open
+		mu.Lock()
+		delivered++
+		mu.Unlock()
+		return messages.DeliveryResult{Envelope: env, Status: messages.DeliveryDelivered}, nil
+	})
+
+	dispatcher := newTestDispatcher(t, bus, nil)
+	target := messages.LoopWakeTarget{Name: "slow_handler"}
+	record, err := json.Marshal(mqttQueuedWake{
+		Target: target,
+		Event:  messages.LoopEventPayload{Source: "mqtt_wake", Type: "message", ID: "mqtt-slow-1", Title: "a/topic"},
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if err := dispatcher.queue.Enqueue(context.Background(), mqttWakePartition(target), "mqtt:slow:a/topic", 1, record); err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 3; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			dispatcher.Sweep(context.Background())
+		}()
+	}
+	wg.Wait()
+
+	mu.Lock()
+	got := delivered
+	mu.Unlock()
+	if got != 1 {
+		t.Fatalf("delivered = %d, want exactly 1 (concurrent drains must serialize)", got)
+	}
+}

--- a/internal/app/mqttwake_test.go
+++ b/internal/app/mqttwake_test.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"context"
+	"encoding/json"
 	"strings"
 	"sync"
 	"testing"
@@ -13,6 +14,7 @@ import (
 	"github.com/nugget/thane-ai-agent/internal/platform/database"
 	"github.com/nugget/thane-ai-agent/internal/platform/events"
 	looppkg "github.com/nugget/thane-ai-agent/internal/runtime/loop"
+	"github.com/nugget/thane-ai-agent/internal/state/loopqueue"
 
 	_ "modernc.org/sqlite"
 )
@@ -59,6 +61,33 @@ func captureBus() (*messages.Bus, func() []messages.Envelope) {
 	}
 }
 
+// newTestDispatcher builds a dispatcher over an in-memory loopqueue
+// with a fast debounce so tests observe the full enqueue → debounced
+// drain → bus path in tens of milliseconds.
+func newTestDispatcher(t *testing.T, bus *messages.Bus, registry *looppkg.Registry) *mqttWakeDispatcher {
+	t.Helper()
+	db, err := database.OpenMemory()
+	if err != nil {
+		t.Fatalf("open memory db: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	queue, err := loopqueue.NewStore(db, nil)
+	if err != nil {
+		t.Fatalf("new loopqueue store: %v", err)
+	}
+	if registry == nil {
+		registry = looppkg.NewRegistry()
+	}
+	d := newMQTTWakeDispatcher(queue, mqttWakeDeps{
+		registry:   registry,
+		messageBus: bus,
+		eventBus:   events.New(),
+	}, nil)
+	d.debounce = 30 * time.Millisecond
+	d.maxWait = 300 * time.Millisecond
+	return d
+}
+
 func waitFor(t *testing.T, snapshot func() []messages.Envelope, n int, timeout time.Duration) []messages.Envelope {
 	t.Helper()
 	deadline := time.Now().Add(timeout)
@@ -82,16 +111,12 @@ func TestMQTTWakeHandlerDispatchesViaWakeTarget(t *testing.T) {
 	}
 
 	bus, captured := captureBus()
-	deps := mqttWakeDeps{
-		registry:   looppkg.NewRegistry(),
-		messageBus: bus,
-		eventBus:   events.New(),
-	}
+	dispatcher := newTestDispatcher(t, bus, nil)
 
-	handler := mqttWakeHandler(store, nil, nil, deps)
+	handler := mqttWakeHandler(store, nil, nil, dispatcher)
 	handler("frigate/front/events", []byte(`{"event":"motion"}`))
 
-	got := waitFor(t, captured, 1, 500*time.Millisecond)
+	got := waitFor(t, captured, 1, 2*time.Second)
 	if len(got) != 1 {
 		t.Fatalf("expected 1 envelope delivered, got %d", len(got))
 	}
@@ -119,6 +144,15 @@ func TestMQTTWakeHandlerDispatchesViaWakeTarget(t *testing.T) {
 	if event.Title != "frigate/front/events" {
 		t.Errorf("event.Title = %q, want the topic", event.Title)
 	}
+
+	// The queue partition drains fully — nothing left pending.
+	pending, err := dispatcher.queue.PendingCount(context.Background(), mqttWakePartition(target))
+	if err != nil {
+		t.Fatalf("PendingCount: %v", err)
+	}
+	if pending != 0 {
+		t.Errorf("pending = %d after delivery, want acked-empty partition", pending)
+	}
 }
 
 func TestMQTTWakeHandlerFanOutDelivers(t *testing.T) {
@@ -134,22 +168,149 @@ func TestMQTTWakeHandlerFanOutDelivers(t *testing.T) {
 	}
 
 	bus, captured := captureBus()
-	deps := mqttWakeDeps{
-		registry:   looppkg.NewRegistry(),
-		messageBus: bus,
-		eventBus:   events.New(),
-	}
+	dispatcher := newTestDispatcher(t, bus, nil)
 
-	handler := mqttWakeHandler(store, nil, nil, deps)
+	handler := mqttWakeHandler(store, nil, nil, dispatcher)
 	handler("sensors/temp/reading", []byte(`{"value":22}`))
 
-	got := waitFor(t, captured, 2, 500*time.Millisecond)
+	got := waitFor(t, captured, 2, 2*time.Second)
 	if len(got) != 2 {
 		t.Fatalf("expected 2 fan-out envelopes, got %d", len(got))
 	}
 	targets := map[string]bool{got[0].To.Target: true, got[1].To.Target: true}
 	if !targets["handler_a"] || !targets["handler_b"] {
 		t.Errorf("envelope targets = %v, want both handler_a and handler_b", targets)
+	}
+}
+
+// TestMQTTWakeBurstCoalesces pins the #1033 point: a burst on one
+// subscription+topic inside the debounce window collapses into ONE
+// delivered envelope carrying the latest payload, instead of one wake
+// per message.
+func TestMQTTWakeBurstCoalesces(t *testing.T) {
+	store := newTestWakeStore(t)
+
+	target := messages.LoopWakeTarget{Name: "burst_handler"}
+	if err := store.LoadConfig([]config.SubscriptionConfig{
+		{Topic: "chatty/topic", WakeLoop: &target},
+	}); err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+
+	bus, captured := captureBus()
+	dispatcher := newTestDispatcher(t, bus, nil)
+	handler := mqttWakeHandler(store, nil, nil, dispatcher)
+
+	for i := 0; i < 5; i++ {
+		handler("chatty/topic", []byte(`{"seq":`+string(rune('0'+i))+`}`))
+		time.Sleep(3 * time.Millisecond)
+	}
+
+	waitFor(t, captured, 1, 2*time.Second)
+	// Allow the debounce to fully settle, then confirm no extra wakes.
+	time.Sleep(150 * time.Millisecond)
+	got := captured()
+	if len(got) != 1 {
+		t.Fatalf("burst delivered %d envelopes, want 1 coalesced", len(got))
+	}
+	payload := got[0].Payload.(messages.LoopNotifyPayload)
+	if len(payload.Events) != 1 || !strings.Contains(payload.Events[0].Summary, `"seq":4`) {
+		t.Errorf("coalesced event = %+v, want latest payload to win", payload.Events)
+	}
+}
+
+// TestMQTTWakeSelfAddressing covers the payload target_loop override:
+// a resolvable self-address re-routes the wake, an unresolvable one
+// falls back to the subscription's static target.
+func TestMQTTWakeSelfAddressing(t *testing.T) {
+	store := newTestWakeStore(t)
+
+	target := messages.LoopWakeTarget{Name: "shared_wake_triage", Instructions: "triage it"}
+	if err := store.LoadConfig([]config.SubscriptionConfig{
+		{Topic: "thane/wake", WakeLoop: &target},
+	}); err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+
+	registry := looppkg.NewRegistry()
+	ranch, err := looppkg.New(looppkg.Config{
+		Name:      "ranch_climate_watch",
+		Operation: looppkg.OperationContainer,
+	}, looppkg.Deps{})
+	if err != nil {
+		t.Fatalf("new loop: %v", err)
+	}
+	if err := registry.Register(ranch); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+
+	bus, captured := captureBus()
+	dispatcher := newTestDispatcher(t, bus, registry)
+	handler := mqttWakeHandler(store, nil, nil, dispatcher)
+
+	handler("thane/wake", []byte(`{"target_loop":"ranch_climate_watch","note":"tank low"}`))
+	got := waitFor(t, captured, 1, 2*time.Second)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 envelope, got %d", len(got))
+	}
+	if got[0].To.Target != "ranch_climate_watch" {
+		t.Errorf("self-addressed target = %q, want ranch_climate_watch", got[0].To.Target)
+	}
+	payload := got[0].Payload.(messages.LoopNotifyPayload)
+	if len(payload.Events) != 1 || payload.Events[0].Metadata["target_loop"] != "ranch_climate_watch" {
+		t.Errorf("event metadata = %+v, want target_loop recorded", payload.Events)
+	}
+
+	// Unresolvable self-address falls back to the subscription target.
+	handler("thane/wake", []byte(`{"target_loop":"no_such_loop"}`))
+	got = waitFor(t, captured, 2, 2*time.Second)
+	if len(got) != 2 {
+		t.Fatalf("expected fallback envelope, got %d total", len(got))
+	}
+	if got[1].To.Target != "shared_wake_triage" {
+		t.Errorf("fallback target = %q, want shared_wake_triage", got[1].To.Target)
+	}
+}
+
+// TestMQTTWakeBootSweep covers crash recovery: records enqueued with
+// no live debounce (the process died before the wake fired) are
+// delivered by Sweep once targets resolve.
+func TestMQTTWakeBootSweep(t *testing.T) {
+	bus, captured := captureBus()
+	dispatcher := newTestDispatcher(t, bus, nil)
+
+	target := messages.LoopWakeTarget{Name: "recovered_handler"}
+	record, err := json.Marshal(mqttQueuedWake{
+		Target: target,
+		Event: messages.LoopEventPayload{
+			Source: "mqtt_wake", Type: "message",
+			ID: "mqtt-crashed-1", Title: "a/topic", Summary: "left behind",
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal record: %v", err)
+	}
+	// Enqueue directly — simulating a pre-crash write whose debounce
+	// state died with the process (no registration on this store yet).
+	if err := dispatcher.queue.Enqueue(context.Background(), mqttWakePartition(target), "mqtt:crashed:a/topic", 1, record); err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+
+	dispatcher.Sweep(context.Background())
+
+	got := captured()
+	if len(got) != 1 {
+		t.Fatalf("sweep delivered %d envelopes, want 1", len(got))
+	}
+	if got[0].To.Target != "recovered_handler" {
+		t.Errorf("swept target = %q, want recovered_handler", got[0].To.Target)
+	}
+	pending, err := dispatcher.queue.PendingCount(context.Background(), mqttWakePartition(target))
+	if err != nil {
+		t.Fatalf("PendingCount: %v", err)
+	}
+	if pending != 0 {
+		t.Errorf("pending = %d after sweep, want 0", pending)
 	}
 }
 
@@ -162,7 +323,7 @@ func TestMQTTWakeHandlerNoMatchFallback(t *testing.T) {
 	}
 
 	bus, captured := captureBus()
-	handler := mqttWakeHandler(store, fallback, nil, mqttWakeDeps{messageBus: bus})
+	handler := mqttWakeHandler(store, fallback, nil, newTestDispatcher(t, bus, nil))
 
 	handler("unmatched/topic", []byte("data"))
 
@@ -174,7 +335,7 @@ func TestMQTTWakeHandlerNoMatchFallback(t *testing.T) {
 	}
 }
 
-func TestMQTTWakeHandlerNoBusDropsMessage(t *testing.T) {
+func TestMQTTWakeHandlerNoDispatcherDropsMessage(t *testing.T) {
 	store := newTestWakeStore(t)
 
 	target := messages.LoopWakeTarget{Name: "handler"}
@@ -184,11 +345,11 @@ func TestMQTTWakeHandlerNoBusDropsMessage(t *testing.T) {
 		t.Fatalf("LoadConfig: %v", err)
 	}
 
-	handler := mqttWakeHandler(store, nil, nil, mqttWakeDeps{})
+	handler := mqttWakeHandler(store, nil, nil, nil)
 	handler("test/topic", []byte("data"))
-	// No bus configured — the handler should log and return without
-	// blocking or panicking. Wait briefly to confirm nothing crashes
-	// asynchronously.
+	// No dispatcher configured — the handler should log and return
+	// without blocking or panicking. Wait briefly to confirm nothing
+	// crashes asynchronously.
 	time.Sleep(100 * time.Millisecond)
 }
 

--- a/internal/app/new_servers.go
+++ b/internal/app/new_servers.go
@@ -379,6 +379,13 @@ func (a *App) initServers(s *newState) error {
 			parentID:   &mqttParentID,
 		}
 
+		// MQTT wakes ride the shared loopqueue chassis (#1033):
+		// ingress enqueues per-target, the WakeOnEnqueue debounce
+		// coalesces bursts, and the dispatcher replays records onto
+		// the message bus. Stashed on the App so the loop-definition
+		// worker can run the boot recovery sweep once targets resolve.
+		a.mqttWakeDispatch = newMQTTWakeDispatcher(a.loopQueue, wakeDeps, logger)
+
 		// Wrap with the wake handler: wake-configured topics dispatch
 		// agent conversations, everything else falls through to the
 		// base handler above.
@@ -386,7 +393,7 @@ func (a *App) initServers(s *newState) error {
 			subStore,
 			baseMsgHandler,
 			logger,
-			wakeDeps,
+			a.mqttWakeDispatch,
 		))
 
 		// Register MQTT wake subscription tools via the provider.
@@ -619,6 +626,12 @@ func (a *App) initServers(s *newState) error {
 					"skipped_existing", result.SkippedExisting,
 					"skipped_non_service", result.SkippedNonService,
 				)
+			}
+			// Drain any mqtt-wake queue partitions left pending by a
+			// crash while their debounce was armed (#1033). Runs here
+			// — after StartEnabledServices — so wake targets resolve.
+			if a.mqttWakeDispatch != nil {
+				a.mqttWakeDispatch.Sweep(ctx)
 			}
 			// Now that the durable definition snapshot is registered,
 			// fail loud on any config-defined MQTT wake subscription

--- a/internal/channels/mqtt/subscriptions.go
+++ b/internal/channels/mqtt/subscriptions.go
@@ -27,12 +27,19 @@ const DefaultHandlerLoopName = "mqtt-default-handler"
 
 // WakeSubscription pairs an MQTT topic filter with a target loop
 // that receives matching messages as event-source notifications.
-// Matching messages produce a [messages.LoopEventPayload] delivered
-// to the target loop's pending notifications via
-// [messages.NewEventSourceEnvelope]; the target loop's next iteration
-// sees the MQTT payload as an event-source wake and runs under its
-// own Spec.Profile / SupervisorProfile / container cascade. No new
-// loop is spawned; the registry stays clean.
+// Since #1033 delivery rides the shared loopqueue chassis: a matching
+// message is enqueued durably into the target's partition (deduped
+// per subscription+topic, latest payload wins), a debounced
+// WakeOnEnqueue drain replays it as a [messages.LoopEventPayload] via
+// [messages.NewEventSourceEnvelope], and the target loop's next
+// iteration sees the MQTT payload as an event-source wake under its
+// own Spec.Profile / SupervisorProfile / container cascade — so a
+// burst on one topic coalesces into one wake instead of one per
+// message. A payload carrying a `target_loop` field re-addresses the
+// wake to that named loop when it resolves (automation-authored
+// self-targeting); this registry remains the fixed topic wiring and
+// the source of the broker SUBSCRIBE set. No new loop is spawned; the
+// registry stays clean.
 //
 // Operators that don't declare a custom wake_loop are migrated onto
 // the built-in [DefaultHandlerLoopName] event-driven loop at config

--- a/internal/channels/mqtt/wake_tool_provider.go
+++ b/internal/channels/mqtt/wake_tool_provider.go
@@ -44,6 +44,8 @@ func (w *WakeTools) Tools() []*tools.Tool {
 			Name: "mqtt_wake_add",
 			Description: `Add a runtime MQTT wake subscription. Matching messages are delivered as event-source notifications to the loop named in wake_loop; the target loop's next iteration sees the message in its pending notifications and runs under its own Spec.Profile. Use this for "topic X → metacog", "topic Y → research_watcher", and similar attention-routing patterns. If you don't have a custom handler loop in mind, point wake_loop at the built-in mqtt-default-handler.
 
+Delivery is durable and burst-safe: matching messages queue per target with a short debounced wake, so a storm on one topic coalesces (latest payload wins per topic) into a single wake instead of one iteration per message. A message payload may also self-address by including a target_loop field (a loop definition name): when it resolves, the wake routes to that loop instead of wake_loop — so one shared wake topic can serve many automation-authored targets; an unresolvable target_loop falls back to wake_loop.
+
 The subscription is persisted and a live SUBSCRIBE is sent to the broker; if the broker is not currently connected it activates on the next reconnect.
 
 Topic conventions: Use thane/{device_name}/wake/{purpose} for instance-directed wakes. Subscribe to external topics directly for shared events (e.g., frigate/+/events). MQTT wildcards: + matches one level, # matches remaining levels (must be last segment).`,

--- a/internal/model/talents/repo_corpus_test.go
+++ b/internal/model/talents/repo_corpus_test.go
@@ -128,6 +128,11 @@ var nonToolTokens = map[string]struct{}{
 	// Appears in talent prose describing routing, not as a tool call.
 	"wake_loop": {},
 
+	// MQTT wake payload field (#1033 self-addressing): an automation
+	// publishes {"target_loop": "<definition name>"} to re-address a
+	// wake. A message field, not a tool.
+	"target_loop": {},
+
 	// Talent frontmatter keys. The authoring README documents these
 	// alongside their tool-like siblings (`tags`, `kind`, `teaser`).
 	// `next_tags` matches the regex but slips past the matcher

--- a/internal/state/loopqueue/queue_store.go
+++ b/internal/state/loopqueue/queue_store.go
@@ -16,6 +16,7 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/nugget/thane-ai-agent/internal/platform/database"
@@ -41,6 +42,12 @@ type Item struct {
 // wraps.
 type Store struct {
 	db *sql.DB
+
+	// WakeOnEnqueue seam (#1033): per-consumer debounced wake
+	// registrations, armed at the Enqueue chokepoint. See
+	// [Store.SetWakeOnEnqueue].
+	wakeMu sync.Mutex
+	wakes  map[string]*wakeRegistration
 }
 
 // NewStore creates a loop-queue store, running migrations on first use.
@@ -85,6 +92,11 @@ func (s *Store) Enqueue(ctx context.Context, consumerLoop, dedupKey string, prio
 	if err != nil {
 		return fmt.Errorf("loopqueue: enqueue %s/%s: %w", consumerLoop, dedupKey, err)
 	}
+	// The single chokepoint the WakeOnEnqueue seam attaches to: an
+	// event-driven consumer's registration turns this durable write
+	// into a debounced wake (#1033). Self-paced consumers have no
+	// registration and drain on their own cadence.
+	s.armWake(consumerLoop)
 	return nil
 }
 
@@ -148,6 +160,33 @@ func (s *Store) Ack(ctx context.Context, consumerLoop, dedupKey string) error {
 		consumerLoop, dedupKey,
 	)
 	return err
+}
+
+// Consumers returns the distinct consumer partitions that currently
+// hold pending work, optionally filtered to names beginning with
+// prefix (empty prefix = all). Used by boot-time recovery sweeps:
+// debounce state is process-local, so a partition whose wake was
+// pending at crash time is found here and drained directly.
+func (s *Store) Consumers(ctx context.Context, prefix string) ([]string, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT DISTINCT consumer_loop FROM loop_queue
+		WHERE status = ? AND consumer_loop LIKE ?
+		ORDER BY consumer_loop ASC
+	`, StatusPending, prefix+"%")
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var consumers []string
+	for rows.Next() {
+		var consumer string
+		if err := rows.Scan(&consumer); err != nil {
+			return nil, err
+		}
+		consumers = append(consumers, consumer)
+	}
+	return consumers, rows.Err()
 }
 
 // PendingCount returns the number of pending items in consumerLoop's

--- a/internal/state/loopqueue/queue_store_test.go
+++ b/internal/state/loopqueue/queue_store_test.go
@@ -3,6 +3,8 @@ package loopqueue
 import (
 	"context"
 	"fmt"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -243,5 +245,51 @@ func TestSetWakeOnEnqueueNilRemoves(t *testing.T) {
 	case <-fired:
 		t.Fatal("wake fired after deregistration")
 	case <-time.After(200 * time.Millisecond):
+	}
+}
+
+// TestWakeOnEnqueueArmFireRace hammers the arm path with concurrent
+// enqueues against a tiny debounce so timer expiry constantly races
+// re-arming — the window where Reset-on-AfterFunc could double-fire
+// (Copilot #1216). The generation guard must keep the count sane and
+// the state clean: fires never exceed enqueues, at least one fires,
+// and once traffic stops the count goes quiet (no stale late fires).
+func TestWakeOnEnqueueArmFireRace(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	var fires atomic.Int64
+	store.SetWakeOnEnqueue("racy", time.Millisecond, 5*time.Millisecond, func() {
+		fires.Add(1)
+	})
+
+	const workers, perWorker = 4, 50
+	var wg sync.WaitGroup
+	for w := 0; w < workers; w++ {
+		wg.Add(1)
+		go func(w int) {
+			defer wg.Done()
+			for i := 0; i < perWorker; i++ {
+				if err := store.Enqueue(ctx, "racy", fmt.Sprintf("k:%d:%d", w, i), 0, []byte(`{}`)); err != nil {
+					t.Errorf("enqueue: %v", err)
+					return
+				}
+			}
+		}(w)
+	}
+	wg.Wait()
+
+	// Let the final burst settle, then confirm the count is stable.
+	time.Sleep(50 * time.Millisecond)
+	settled := fires.Load()
+	if settled < 1 {
+		t.Fatal("no wake fired at all")
+	}
+	if settled > workers*perWorker {
+		t.Fatalf("fires = %d exceeds enqueues — duplicate callbacks leaked", settled)
+	}
+	time.Sleep(100 * time.Millisecond)
+	if again := fires.Load(); again != settled {
+		t.Fatalf("stale late fire: count moved %d → %d after quiet", settled, again)
 	}
 }

--- a/internal/state/loopqueue/queue_store_test.go
+++ b/internal/state/loopqueue/queue_store_test.go
@@ -1,7 +1,10 @@
 package loopqueue
 
 import (
+	"context"
+	"fmt"
 	"testing"
+	"time"
 
 	"github.com/nugget/thane-ai-agent/internal/platform/database"
 
@@ -133,5 +136,112 @@ func TestStore_PartitionIsolation(t *testing.T) {
 	items, _ := s.Peek(t.Context(), "archivist", 10)
 	if len(items) != 1 || items[0].DedupKey != "session:1" {
 		t.Errorf("archivist peek leaked another partition: %+v", items)
+	}
+}
+
+// TestWakeOnEnqueueDebounce covers the #1033 seam: a burst of
+// enqueues coalesces into one debounced wake, a lone enqueue fires
+// after the trailing window, and consumers without a registration
+// (the archivist posture) never fire.
+func TestWakeOnEnqueueDebounce(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	fired := make(chan struct{}, 8)
+	store.SetWakeOnEnqueue("mqtt-dispatch", 40*time.Millisecond, 500*time.Millisecond, func() {
+		fired <- struct{}{}
+	})
+
+	// A burst inside the debounce window → exactly one wake.
+	for i := 0; i < 5; i++ {
+		if err := store.Enqueue(ctx, "mqtt-dispatch", fmt.Sprintf("mqtt:topic/%d", i), 0, []byte(`{}`)); err != nil {
+			t.Fatalf("enqueue: %v", err)
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	select {
+	case <-fired:
+	case <-time.After(time.Second):
+		t.Fatal("debounced wake never fired after burst")
+	}
+	select {
+	case <-fired:
+		t.Fatal("burst fired more than one wake")
+	case <-time.After(150 * time.Millisecond):
+	}
+
+	// A fresh enqueue after the burst starts a new window and fires again.
+	if err := store.Enqueue(ctx, "mqtt-dispatch", "mqtt:topic/later", 0, []byte(`{}`)); err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+	select {
+	case <-fired:
+	case <-time.After(time.Second):
+		t.Fatal("second burst never fired")
+	}
+
+	// An unregistered consumer stays silent.
+	if err := store.Enqueue(ctx, "archivist", "session:x", 0, []byte(`{}`)); err != nil {
+		t.Fatalf("enqueue archivist: %v", err)
+	}
+	select {
+	case <-fired:
+		t.Fatal("unregistered consumer fired the wrong consumer's wake")
+	case <-time.After(150 * time.Millisecond):
+	}
+}
+
+// TestWakeOnEnqueueMaxWait pins the anti-starvation bound: continuous
+// chatter that keeps resetting the trailing window still fires no
+// later than maxWait after the burst began.
+func TestWakeOnEnqueueMaxWait(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	fired := make(chan time.Time, 4)
+	store.SetWakeOnEnqueue("mqtt-dispatch", 60*time.Millisecond, 200*time.Millisecond, func() {
+		fired <- time.Now()
+	})
+
+	start := time.Now()
+	deadline := start.Add(600 * time.Millisecond)
+	var firedAt time.Time
+chatter:
+	for time.Now().Before(deadline) {
+		if err := store.Enqueue(ctx, "mqtt-dispatch", "mqtt:chatty", 0, []byte(`{}`)); err != nil {
+			t.Fatalf("enqueue: %v", err)
+		}
+		select {
+		case firedAt = <-fired:
+			break chatter
+		case <-time.After(25 * time.Millisecond):
+		}
+	}
+	if firedAt.IsZero() {
+		t.Fatal("chatter starved the wake past maxWait")
+	}
+	if elapsed := firedAt.Sub(start); elapsed > 450*time.Millisecond {
+		t.Errorf("wake fired %v after burst start, want ≲ maxWait+debounce slack", elapsed)
+	}
+}
+
+// TestSetWakeOnEnqueueNilRemoves verifies deregistration: a nil fire
+// removes the hook and stops any pending timer.
+func TestSetWakeOnEnqueueNilRemoves(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	fired := make(chan struct{}, 1)
+	store.SetWakeOnEnqueue("mqtt-dispatch", 50*time.Millisecond, time.Second, func() {
+		fired <- struct{}{}
+	})
+	if err := store.Enqueue(ctx, "mqtt-dispatch", "mqtt:x", 0, []byte(`{}`)); err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+	store.SetWakeOnEnqueue("mqtt-dispatch", 0, 0, nil)
+	select {
+	case <-fired:
+		t.Fatal("wake fired after deregistration")
+	case <-time.After(200 * time.Millisecond):
 	}
 }

--- a/internal/state/loopqueue/wake.go
+++ b/internal/state/loopqueue/wake.go
@@ -1,0 +1,121 @@
+package loopqueue
+
+import (
+	"time"
+)
+
+// Default debounce shape for event-driven consumers. Chosen for wake
+// semantics: long enough to coalesce an event burst (an HA automation
+// storm, a chatty MQTT topic) into one consumer wake, short enough
+// that a lone event still lands promptly. MaxWait is the
+// anti-starvation bound — continuous chatter keeps resetting a
+// trailing-edge debounce, so the wake fires no later than MaxWait
+// after the first un-drained enqueue regardless.
+const (
+	DefaultWakeDebounce = 2 * time.Second
+	DefaultWakeMaxWait  = 15 * time.Second
+)
+
+// wakeRegistration is one consumer's debounced wake state. All fields
+// are guarded by the parent Store's wakeMu.
+type wakeRegistration struct {
+	debounce time.Duration
+	maxWait  time.Duration
+	fire     func()
+
+	timer      *time.Timer // pending trailing-edge timer; nil when idle
+	firstArmed time.Time   // when the current un-fired burst began
+}
+
+// SetWakeOnEnqueue registers a debounced wake for consumerLoop: after
+// any successful [Store.Enqueue] into that partition, fire is invoked
+// once per burst — trailing-edge debounced, so a storm of enqueues
+// coalesces into a single wake after the burst quiets, with maxWait
+// bounding how long continuous chatter can postpone it. This is the
+// WakeOnEnqueue seam from #1024/#1025: self-paced consumers (the
+// archivist) simply never register and keep draining on their own
+// cadence; event-driven consumers (MQTT wake dispatch, #1033) register
+// so trigger latency stays low without trigger rate driving work rate.
+//
+// debounce/maxWait <= 0 fall back to the package defaults. fire runs
+// on a timer goroutine and must not block; registrations are expected
+// at wiring time (before traffic) and a second call for the same
+// consumer replaces the first. Passing a nil fire removes the
+// registration. The debounce state is process-local — a pending burst
+// does not survive a restart, which is why wiring pairs registration
+// with a boot-time sweep of non-empty partitions.
+func (s *Store) SetWakeOnEnqueue(consumerLoop string, debounce, maxWait time.Duration, fire func()) {
+	s.wakeMu.Lock()
+	defer s.wakeMu.Unlock()
+	if s.wakes == nil {
+		s.wakes = make(map[string]*wakeRegistration)
+	}
+	if existing, ok := s.wakes[consumerLoop]; ok && existing.timer != nil {
+		existing.timer.Stop()
+	}
+	if fire == nil {
+		delete(s.wakes, consumerLoop)
+		return
+	}
+	if debounce <= 0 {
+		debounce = DefaultWakeDebounce
+	}
+	if maxWait <= 0 {
+		maxWait = DefaultWakeMaxWait
+	}
+	s.wakes[consumerLoop] = &wakeRegistration{
+		debounce: debounce,
+		maxWait:  maxWait,
+		fire:     fire,
+	}
+}
+
+// armWake starts or extends consumerLoop's debounce window after an
+// enqueue. No-op for consumers without a registration.
+func (s *Store) armWake(consumerLoop string) {
+	s.wakeMu.Lock()
+	defer s.wakeMu.Unlock()
+	reg, ok := s.wakes[consumerLoop]
+	if !ok {
+		return
+	}
+
+	now := time.Now()
+	if reg.timer == nil {
+		// First enqueue of a burst: start the trailing window and
+		// stamp the burst origin for the maxWait bound.
+		reg.firstArmed = now
+		reg.timer = time.AfterFunc(reg.debounce, func() { s.fireWake(consumerLoop) })
+		return
+	}
+
+	// Subsequent enqueue: extend the trailing window, but never past
+	// firstArmed+maxWait — a continuously chatty producer must not
+	// starve the drain.
+	remainingToCap := reg.firstArmed.Add(reg.maxWait).Sub(now)
+	delay := reg.debounce
+	if remainingToCap < delay {
+		delay = remainingToCap
+	}
+	if delay < 0 {
+		delay = 0
+	}
+	reg.timer.Reset(delay)
+}
+
+// fireWake runs a registration's callback and returns it to idle so
+// the next enqueue starts a fresh burst.
+func (s *Store) fireWake(consumerLoop string) {
+	s.wakeMu.Lock()
+	reg, ok := s.wakes[consumerLoop]
+	if !ok {
+		s.wakeMu.Unlock()
+		return
+	}
+	reg.timer = nil
+	reg.firstArmed = time.Time{}
+	fire := reg.fire
+	s.wakeMu.Unlock()
+
+	fire()
+}

--- a/internal/state/loopqueue/wake.go
+++ b/internal/state/loopqueue/wake.go
@@ -4,17 +4,17 @@ import (
 	"time"
 )
 
-// Default debounce shape for event-driven consumers. Chosen for wake
-// semantics: long enough to coalesce an event burst (an HA automation
+// DefaultWakeDebounce is the trailing-edge window for event-driven
+// consumers: long enough to coalesce an event burst (an HA automation
 // storm, a chatty MQTT topic) into one consumer wake, short enough
-// that a lone event still lands promptly. MaxWait is the
-// anti-starvation bound — continuous chatter keeps resetting a
-// trailing-edge debounce, so the wake fires no later than MaxWait
-// after the first un-drained enqueue regardless.
-const (
-	DefaultWakeDebounce = 2 * time.Second
-	DefaultWakeMaxWait  = 15 * time.Second
-)
+// that a lone event still lands promptly.
+const DefaultWakeDebounce = 2 * time.Second
+
+// DefaultWakeMaxWait is the anti-starvation bound on the debounce:
+// continuous chatter keeps resetting a trailing-edge window, so the
+// wake fires no later than this long after the first un-drained
+// enqueue regardless.
+const DefaultWakeMaxWait = 15 * time.Second
 
 // wakeRegistration is one consumer's debounced wake state. All fields
 // are guarded by the parent Store's wakeMu.
@@ -23,8 +23,15 @@ type wakeRegistration struct {
 	maxWait  time.Duration
 	fire     func()
 
-	timer      *time.Timer // pending trailing-edge timer; nil when idle
+	timer      *time.Timer // pending timer; nil when idle
 	firstArmed time.Time   // when the current un-fired burst began
+	// gen invalidates stale timer callbacks: every re-arm and every
+	// fire bumps it, and a callback only proceeds when its captured
+	// generation is still current. Reset on a fired-or-firing
+	// time.AfterFunc timer can let an expired callback run alongside
+	// the re-armed one; the generation check turns that race into a
+	// no-op instead of a duplicate wake.
+	gen uint64
 }
 
 // SetWakeOnEnqueue registers a debounced wake for consumerLoop: after
@@ -38,20 +45,27 @@ type wakeRegistration struct {
 // so trigger latency stays low without trigger rate driving work rate.
 //
 // debounce/maxWait <= 0 fall back to the package defaults. fire runs
-// on a timer goroutine and must not block; registrations are expected
-// at wiring time (before traffic) and a second call for the same
-// consumer replaces the first. Passing a nil fire removes the
-// registration. The debounce state is process-local — a pending burst
-// does not survive a restart, which is why wiring pairs registration
-// with a boot-time sweep of non-empty partitions.
+// on a timer goroutine and must not block — a consumer whose drain
+// does real work (bus sends, I/O) should hand off to its own worker
+// and serialize its drains, since a fire can coincide with an
+// externally-triggered drain (e.g. a boot sweep). At-most-one fire
+// per burst is guaranteed by a per-registration generation guard.
+// Registrations are expected at wiring time (before traffic) and a
+// second call for the same consumer replaces the first. Passing a nil
+// fire removes the registration. The debounce state is process-local —
+// a pending burst does not survive a restart, which is why wiring
+// pairs registration with a boot-time sweep of non-empty partitions.
 func (s *Store) SetWakeOnEnqueue(consumerLoop string, debounce, maxWait time.Duration, fire func()) {
 	s.wakeMu.Lock()
 	defer s.wakeMu.Unlock()
 	if s.wakes == nil {
 		s.wakes = make(map[string]*wakeRegistration)
 	}
-	if existing, ok := s.wakes[consumerLoop]; ok && existing.timer != nil {
-		existing.timer.Stop()
+	if existing, ok := s.wakes[consumerLoop]; ok {
+		existing.gen++ // invalidate any in-flight callback
+		if existing.timer != nil {
+			existing.timer.Stop()
+		}
 	}
 	if fire == nil {
 		delete(s.wakes, consumerLoop)
@@ -71,7 +85,10 @@ func (s *Store) SetWakeOnEnqueue(consumerLoop string, debounce, maxWait time.Dur
 }
 
 // armWake starts or extends consumerLoop's debounce window after an
-// enqueue. No-op for consumers without a registration.
+// enqueue. No-op for consumers without a registration. Each arm
+// replaces the pending timer with a fresh one under a new generation
+// — never Reset, which on an already-fired [time.AfterFunc] timer can
+// let a stale callback run alongside the re-armed one.
 func (s *Store) armWake(consumerLoop string) {
 	s.wakeMu.Lock()
 	defer s.wakeMu.Unlock()
@@ -81,37 +98,40 @@ func (s *Store) armWake(consumerLoop string) {
 	}
 
 	now := time.Now()
-	if reg.timer == nil {
-		// First enqueue of a burst: start the trailing window and
-		// stamp the burst origin for the maxWait bound.
-		reg.firstArmed = now
-		reg.timer = time.AfterFunc(reg.debounce, func() { s.fireWake(consumerLoop) })
-		return
-	}
-
-	// Subsequent enqueue: extend the trailing window, but never past
-	// firstArmed+maxWait — a continuously chatty producer must not
-	// starve the drain.
-	remainingToCap := reg.firstArmed.Add(reg.maxWait).Sub(now)
 	delay := reg.debounce
-	if remainingToCap < delay {
-		delay = remainingToCap
+	if reg.timer == nil {
+		// First enqueue of a burst: stamp the burst origin for the
+		// maxWait bound.
+		reg.firstArmed = now
+	} else {
+		reg.timer.Stop()
+		// Subsequent enqueue: extend the trailing window, but never
+		// past firstArmed+maxWait — a continuously chatty producer
+		// must not starve the drain.
+		if remaining := reg.firstArmed.Add(reg.maxWait).Sub(now); remaining < delay {
+			delay = remaining
+		}
+		if delay < 0 {
+			delay = 0
+		}
 	}
-	if delay < 0 {
-		delay = 0
-	}
-	reg.timer.Reset(delay)
+	reg.gen++
+	gen := reg.gen
+	reg.timer = time.AfterFunc(delay, func() { s.fireWake(consumerLoop, gen) })
 }
 
-// fireWake runs a registration's callback and returns it to idle so
-// the next enqueue starts a fresh burst.
-func (s *Store) fireWake(consumerLoop string) {
+// fireWake runs a registration's callback — unless the captured
+// generation is stale (the timer was re-armed or the registration
+// replaced while this callback was in flight) — and returns the
+// registration to idle so the next enqueue starts a fresh burst.
+func (s *Store) fireWake(consumerLoop string, gen uint64) {
 	s.wakeMu.Lock()
 	reg, ok := s.wakes[consumerLoop]
-	if !ok {
+	if !ok || reg.gen != gen {
 		s.wakeMu.Unlock()
 		return
 	}
+	reg.gen++ // consume this generation; any other in-flight callback is stale
 	reg.timer = nil
 	reg.firstArmed = time.Time{}
 	fire := reg.fire

--- a/scripts/architecture.baseline
+++ b/scripts/architecture.baseline
@@ -1,5 +1,5 @@
 packages=64
 interfaces=84
 large_files=51
-set_mutators=114
+set_mutators=115
 database_opens=9

--- a/talents/loops-examples.md
+++ b/talents/loops-examples.md
@@ -311,9 +311,12 @@ A few choices that matter:
 - **`mode: single`** means a second trigger while the automation
   is still running won't double-fire. With `mqtt.publish` this
   matters less, but it's the safe default for any HA-side action.
-- **Payload as JSON** carries useful context to the loop side
-  even though `mqtt_wake_add` doesn't currently parse the body
-  for routing. The future-proofing is cheap, and the timestamp
+- **Payload as JSON** carries useful context to the loop side —
+  and one field IS parsed for routing: `target_loop` (a loop
+  definition name) re-addresses the wake to that loop, so one
+  shared wake topic can serve many automation-authored targets
+  without per-topic registrations. An unresolvable `target_loop`
+  falls back to the subscription's `wake_loop`. The timestamp
   helps the loop notice when it's reacting to a stale message
   (network flap, broker replay).
 - **Topic convention `thane/{device_name}/wake/{purpose}`** is


### PR DESCRIPTION
Closes #1033. Follow-up architecture from #1024/#1025; unblocks #1211 (the subscription wake feed builds on this seam).

## The seam #1025 left on purpose

The loopqueue shipped with only the self-paced drain path — the archivist works through its in-tray on its own clock, and `Enqueue` was deliberately built as the single chokepoint a future event-driven hook would attach to. This PR attaches it: `Store.SetWakeOnEnqueue(consumer, debounce, maxWait, fire)` registers a per-consumer debounced wake, trailing-edge so a burst of enqueues coalesces into one fire after the burst quiets, with `maxWait` bounding how long continuous chatter can postpone the drain (a pure trailing debounce is starvable; the cap makes it not). Self-paced consumers never register and are untouched — the archivist's posture is itself pinned by a test asserting an unregistered partition stays silent. Debounce state is process-local by design, which is why registration pairs with a boot sweep below.

## MQTT becomes the seam's first real consumer

Ingress inverts from push to enqueue: a matched message now writes a durable record — the resolved wake target plus the event — into a per-target partition (`mqtt-wake:<destination>`, deliberately namespaced rather than a bare loop name so a wake target that also happens to be a model-facing queue consumer never finds plumbing records in its own `queue_pull`). Dedup is per subscription+topic with latest-payload-wins, so a chatty topic coalesces to its freshest state; priority maps from the wake target so urgent wakes drain first. The debounced fire drains the batch and replays each record through exactly the envelope path the direct dispatch used — `NewEventSourceEnvelope` → bus → the target loop's pending notifies — so the downstream contract (profile cascade, supervisor forcing, iteration-scoped tags, the wakeCh interrupt) is byte-for-byte the machinery that already existed. What changes is the shape of a storm: one wake carrying the freshest payload instead of one iteration per message, which is #1024's lesson applied to the second class-(1) service.

Two honest boundaries, stated in the code: delivery failures ack-and-drop, matching the old direct path's semantics — the queue adds crash durability and burst coalescing, not retry; and a boot-time `Sweep` (run in the loop-definition worker, after targets hydrate) drains partitions whose debounce died with the process, closing the receive-to-dispatch crash window that used to lose the message outright.

## Self-addressing: the automation names its target

Per the scope expansion on the issue, a payload carrying `target_loop` (a loop definition name) re-routes the wake to that loop when it resolves against the live registry — one shared wake topic can now serve any automation-authored target with no pre-registered per-topic subscription. The subscription's presentation fields (instructions, tags, priority, supervisor forcing) ride along; only the destination is re-addressed, and the override is recorded in the event metadata for transparency. An unresolvable name falls back to the subscription's static `wake_loop` with a warning, so a typo'd automation still lands somewhere a model can triage it rather than vanishing.

`mqtt_wake_subscriptions` is repointed, not retired: it remains the fixed topic wiring and the source of the broker SUBSCRIBE set — the owner-confirmed posture — while delivery rides the queue. Teaching follows: `mqtt_wake_add` now describes the durable/coalesced delivery and the self-addressing contract, the reference doc gained the chassis paragraph, and the loops-examples worked example no longer claims the payload body isn't parsed for routing (it now is, for exactly one field).

## Test plan

- [x] `just ci` green locally (run unpiped; baseline bump for the one new setter)
- [x] Seam: burst → one debounced fire, quiet-gap → second fire, unregistered consumer silent, maxWait beats continuous chatter, nil-fire deregisters
- [x] Dispatch: end-to-end enqueue→drain→bus envelope shape (target, kind, event fields, acked-empty partition), fan-out to multiple subscribers, burst coalescing with latest-payload-wins, self-addressing override + fallback, boot sweep recovery
- [x] Downstream contract untouched: no changes to messages/, loop signals, or the default-handler definition

🤖 Generated with [Claude Code](https://claude.com/claude-code)
