### PR TITLE
feat(awareness): wake on change — the subscription wake feed on the loopqueue chassis

### DIFF
--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -113,6 +113,18 @@ retention behind the shared window — so `mode: ingest` is never needed
 for it. Entity ids and globs only; complementary to `history` (numeric
 trend summaries) rather than a replacement.
 
+A loop-owned subscription may declare `wake: true`: the owning loop is
+awakened when the entity changes, with the event delivered as
+`{entity, from, to, ago}` in the class-aware vocabulary through the
+shared loopqueue chassis — debounced (`wake_debounce_seconds`, default
+a few seconds), coalesced per entity (latest change wins while a wake
+is pending), and crash-durable. Capture derives automatically, wake
+subscriptions count against the ingest entry cap, and the upstream
+rate limiter still applies — a chattering sensor cannot wakestorm a
+loop. Simple native change triggers only: HA-side derivation
+(compound conditions, zone dwell, templates) remains the
+automation→MQTT→wake pipeline, draining the same queue.
+
 A subscription may carry `requires_tag`, a capability tag gating its
 visibility: it renders only while that tag is active in the consuming
 context. This is the macro-set lens — one tag activation surfaces a

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -193,6 +193,12 @@ type App struct {
 	// targets have hydrated. Nil when MQTT is not configured.
 	mqttWakeDispatch *mqttWakeDispatcher
 
+	// Subscription wake feed (#1211): state changes on wake-declaring
+	// subscriptions enqueue debounced loop wakes over the same
+	// chassis. Set in initAwareness; nil when HA/bus/queue wiring is
+	// absent. The loop-definition worker runs its boot sweep.
+	subWakeFeeder *subscriptionWakeFeeder
+
 	// Checkpointing
 	checkpointer *checkpoint.Checkpointer
 

--- a/internal/app/loop_focus_tools.go
+++ b/internal/app/loop_focus_tools.go
@@ -94,6 +94,14 @@ func buildLoopFocusToolsWithMutator(loopName string, mutator subscriptionMutator
 						"type":        "integer",
 						"description": "Bound the transition log to changes within this trailing window (seconds); combine with transitions or set alone (still capped).",
 					},
+					"wake": map[string]any{
+						"type":        "boolean",
+						"description": "Wake this loop when the entity changes — debounced and coalesced (a chattering sensor becomes one wake with the latest change). Capture follows automatically. Entity ids and globs only; incompatible with requires_tag.",
+					},
+					"wake_debounce_seconds": map[string]any{
+						"type":        "integer",
+						"description": "How long changes coalesce before waking (default a few seconds); the loop's cadence follows its twitchiest wake subscription.",
+					},
 					"include": tools.EntityMetadataIncludeParameter(),
 				},
 				"required": []string{"entity_id"},
@@ -147,6 +155,14 @@ func buildLoopFocusToolsWithMutator(loopName string, mutator subscriptionMutator
 				if transitions > looppkg.MaxSubscriptionTransitions {
 					return "", fmt.Errorf("transitions is capped at %d per subscription — ask for fewer, or add transitions_window_seconds to bound by recency instead", looppkg.MaxSubscriptionTransitions)
 				}
+				wake, _ := args["wake"].(bool)
+				wakeDebounce, err := intFromMap(args, "wake_debounce_seconds")
+				if err != nil {
+					return "", fmt.Errorf("wake_debounce_seconds: %w", err)
+				}
+				if wakeDebounce < 0 {
+					return "", fmt.Errorf("wake_debounce_seconds must be >= 0")
+				}
 				sub := looppkg.EntitySubscription{
 					EntityID:                 entityID,
 					History:                  history,
@@ -159,6 +175,16 @@ func buildLoopFocusToolsWithMutator(loopName string, mutator subscriptionMutator
 					RequiresTag:              strings.TrimSpace(stringMapValue(args, "requires_tag")),
 					Transitions:              transitions,
 					TransitionsWindowSeconds: transitionsWindow,
+					Wake:                     wake,
+					WakeDebounceSeconds:      wakeDebounce,
+				}
+				if sub.Wake {
+					if sub.RequiresTag != "" {
+						return "", fmt.Errorf("wake cannot combine with requires_tag — waking must not follow tag state; drop one of the two")
+					}
+					if awareness.ParseSubscriptionTarget(entityID).IsRegistryTarget() {
+						return "", fmt.Errorf("wake needs the entity's event stream, and area/label/floor targets cannot feed the ingestion filter — watch a concrete entity or glob to wake on")
+					}
 				}
 				// The gate is render-only: capture must never depend
 				// on tag state (#1213).

--- a/internal/app/mqttwake.go
+++ b/internal/app/mqttwake.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
-	"sync"
 	"sync/atomic"
 	"time"
 	"unicode/utf8"
@@ -24,25 +23,12 @@ import (
 // blow up downstream prompt rendering.
 const maxWakePayloadBytes = 32 * 1024
 
-// mqttWakeDeliveryTimeout bounds the bus.Send call for envelope
-// delivery. Each MQTT message arrives in its own goroutine; without
-// this bound, a stuck downstream route handler could leak goroutines
-// under steady MQTT traffic. The actual agent work happens in the
-// target loop's next iteration on its own clock — this only bounds
-// the envelope-handoff hop.
-const mqttWakeDeliveryTimeout = 30 * time.Second
-
 // mqttWakePartitionPrefix namespaces the loopqueue partitions the MQTT
 // wake dispatcher owns. Partition strings are internal routing keys —
 // deliberately NOT bare loop names, so a wake target that also happens
 // to be a model-facing queue consumer (archivist-style queue_pull)
 // never finds MQTT plumbing records in its own partition.
 const mqttWakePartitionPrefix = "mqtt-wake:"
-
-// mqttWakeDrainBatch bounds one Peek pass during a drain. The drain
-// loops until the partition is empty, so this is a memory bound per
-// pass, not a delivery cap.
-const mqttWakeDrainBatch = 50
 
 // mqttWakeDeps wires the wake handler to the message bus and event
 // bus. parentID is unused in the post-retirement dispatch shape but
@@ -55,43 +41,21 @@ type mqttWakeDeps struct {
 	parentID   *atomic.Value
 }
 
-// mqttQueuedWake is the loopqueue payload for one matched MQTT
-// message: the resolved wake target plus the event to deliver. Stored
-// durably at ingress and replayed by the dispatcher's drain, so a
-// crash between broker receipt and loop delivery no longer loses the
-// message, and a burst on one topic coalesces (latest payload wins
-// per subscription+topic) instead of amplifying into a wake per
-// message (#1024/#1033).
-type mqttQueuedWake struct {
-	Target messages.LoopWakeTarget   `json:"target"`
-	Event  messages.LoopEventPayload `json:"event"`
-}
-
-// mqttWakeDispatcher moves MQTT wake delivery onto the shared
-// loopqueue chassis: ingress enqueues into a per-target partition and
-// arms the WakeOnEnqueue debounce; the debounced fire drains the
-// coalesced batch and hands each record to the message bus exactly
-// the way the direct path used to. Trigger rate is decoupled from
-// wake rate; the downstream envelope contract is unchanged.
+// mqttWakeDispatcher is the MQTT ingress over the shared
+// [queuedWakeDispatcher] chassis: matched messages enqueue durably
+// into per-target partitions (deduped per subscription+topic, latest
+// payload wins) and the debounced drain replays them onto the message
+// bus exactly the way the old direct dispatch did.
 type mqttWakeDispatcher struct {
-	queue  *loopqueue.Store
-	deps   mqttWakeDeps
-	logger *slog.Logger
+	dispatch *queuedWakeDispatcher
+	deps     mqttWakeDeps
+	logger   *slog.Logger
 
 	// debounce/maxWait override the loopqueue wake defaults; zero
 	// values defer to [loopqueue.DefaultWakeDebounce] /
 	// [loopqueue.DefaultWakeMaxWait]. Tests shrink them.
 	debounce time.Duration
 	maxWait  time.Duration
-
-	mu         sync.Mutex
-	registered map[string]bool
-	// draining serializes drains per partition: Peek does not claim
-	// items, so a debounce fire racing a boot Sweep (or a second
-	// fire) over the same partition would deliver the same records
-	// twice. One drain runs at a time; a follower blocks, then finds
-	// whatever the first left behind (usually nothing).
-	draining map[string]*sync.Mutex
 }
 
 func newMQTTWakeDispatcher(queue *loopqueue.Store, deps mqttWakeDeps, logger *slog.Logger) *mqttWakeDispatcher {
@@ -99,11 +63,9 @@ func newMQTTWakeDispatcher(queue *loopqueue.Store, deps mqttWakeDeps, logger *sl
 		logger = slog.Default()
 	}
 	return &mqttWakeDispatcher{
-		queue:      queue,
-		deps:       deps,
-		logger:     logger,
-		registered: make(map[string]bool),
-		draining:   make(map[string]*sync.Mutex),
+		dispatch: newQueuedWakeDispatcher(queue, deps.messageBus, mqttWakePartitionPrefix, "mqtt_wake", nil, logger),
+		deps:     deps,
+		logger:   logger,
 	}
 }
 
@@ -178,20 +140,11 @@ func (d *mqttWakeDispatcher) ingress(ws mqtt.WakeSubscription, topic string, pay
 		event.Metadata["target_loop"] = target.Name
 	}
 
-	record, err := json.Marshal(mqttQueuedWake{Target: target, Event: event})
-	if err != nil {
-		d.logger.Warn("mqtt wake record marshal failed, dropping message",
-			"subscription_id", ws.ID, "topic", topic, "error", err)
-		return
-	}
-
 	partition := mqttWakePartition(target)
-	d.ensureRegistered(partition)
+	d.dispatch.register(partition, d.debounce, d.maxWait)
 
-	enqCtx, cancel := context.WithTimeout(context.Background(), mqttWakeDeliveryTimeout)
-	defer cancel()
 	dedupKey := fmt.Sprintf("mqtt:%s:%s", ws.ID, topic)
-	if err := d.queue.Enqueue(enqCtx, partition, dedupKey, int(targetPriorityRank(target)), record); err != nil {
+	if err := d.dispatch.enqueue(partition, dedupKey, targetPriorityRank(target), queuedWakeRecord{Target: target, Event: event}); err != nil {
 		d.logger.Warn("mqtt wake enqueue failed, dropping message",
 			"subscription_id", ws.ID, "topic", topic, "partition", partition, "error", err)
 	}
@@ -233,143 +186,11 @@ func (d *mqttWakeDispatcher) resolveTarget(ws mqtt.WakeSubscription, topic strin
 	return target
 }
 
-// ensureRegistered lazily attaches the WakeOnEnqueue debounce for a
-// partition the first time traffic addresses it. Package defaults for
-// debounce/maxWait: coalesce a burst, never starve under chatter. The
-// fire callback must not block (loopqueue contract), so it hands off
-// to a goroutine that runs the serialized drain.
-func (d *mqttWakeDispatcher) ensureRegistered(partition string) {
-	d.mu.Lock()
-	defer d.mu.Unlock()
-	if d.registered[partition] {
-		return
-	}
-	d.registered[partition] = true
-	d.queue.SetWakeOnEnqueue(partition, d.debounce, d.maxWait, func() {
-		go d.drainSerialized(partition)
-	})
-}
-
-// partitionLock returns the per-partition drain mutex, creating it on
-// first use.
-func (d *mqttWakeDispatcher) partitionLock(partition string) *sync.Mutex {
-	d.mu.Lock()
-	defer d.mu.Unlock()
-	lock, ok := d.draining[partition]
-	if !ok {
-		lock = &sync.Mutex{}
-		d.draining[partition] = lock
-	}
-	return lock
-}
-
-// drainSerialized runs drain under the partition's mutex so
-// concurrent triggers (debounce fire, boot sweep) cannot replay the
-// same un-acked records twice.
-func (d *mqttWakeDispatcher) drainSerialized(partition string) {
-	lock := d.partitionLock(partition)
-	lock.Lock()
-	defer lock.Unlock()
-	d.drain(partition)
-}
-
-// drain delivers a partition's pending records to the message bus in
-// drain order and acks each attempt. Delivery failures are logged and
-// acked anyway — parity with the pre-queue direct path, where a
-// failed bus send dropped the message; the queue adds crash
-// durability and burst coalescing, not retry semantics. A record that
-// no longer unmarshals is acked and skipped for the same reason.
-func (d *mqttWakeDispatcher) drain(partition string) {
-	ctx := context.Background()
-	for {
-		items, err := d.queue.Peek(ctx, partition, mqttWakeDrainBatch)
-		if err != nil {
-			d.logger.Warn("mqtt wake drain peek failed", "partition", partition, "error", err)
-			return
-		}
-		if len(items) == 0 {
-			return
-		}
-		for _, item := range items {
-			d.deliver(partition, item)
-		}
-		if len(items) < mqttWakeDrainBatch {
-			return
-		}
-	}
-}
-
-// deliver replays one queued record through the same envelope path
-// the direct dispatch used, then acks it.
-func (d *mqttWakeDispatcher) deliver(partition string, item loopqueue.Item) {
-	ack := func() {
-		if err := d.queue.Ack(context.Background(), partition, item.DedupKey); err != nil {
-			d.logger.Warn("mqtt wake ack failed", "partition", partition, "dedup_key", item.DedupKey, "error", err)
-		}
-	}
-
-	var record mqttQueuedWake
-	if err := json.Unmarshal(item.Payload, &record); err != nil {
-		d.logger.Warn("mqtt wake record unmarshal failed, dropping",
-			"partition", partition, "dedup_key", item.DedupKey, "error", err)
-		ack()
-		return
-	}
-
-	env, err := messages.NewEventSourceEnvelope(
-		messages.Identity{Kind: messages.IdentitySystem, Name: "mqtt_wake"},
-		record.Target,
-		"mqtt_wake",
-		[]messages.LoopEventPayload{record.Event},
-	)
-	if err != nil {
-		d.logger.Warn("mqtt wake envelope construction failed, dropping message",
-			"partition", partition, "dedup_key", item.DedupKey, "error", err)
-		ack()
-		return
-	}
-
-	deliveryCtx, cancel := context.WithTimeout(context.Background(), mqttWakeDeliveryTimeout)
-	defer cancel()
-	if _, err := d.deps.messageBus.Send(deliveryCtx, env); err != nil {
-		d.logger.Warn("mqtt wake envelope delivery failed, dropping message",
-			"partition", partition,
-			"dedup_key", item.DedupKey,
-			"target_loop_id", record.Target.LoopID,
-			"target_loop_name", record.Target.Name,
-			"error", err,
-		)
-		ack()
-		return
-	}
-	ack()
-
-	d.logger.Info("mqtt wake delivered to target loop",
-		"partition", partition,
-		"dedup_key", item.DedupKey,
-		"target_loop_id", record.Target.LoopID,
-		"target_loop_name", record.Target.Name,
-	)
-}
-
-// Sweep drains every mqtt-wake partition that still holds pending
-// records — the boot-time recovery for enqueues whose debounce was
-// pending when the process died. Call after the loop registry has
-// hydrated so targets resolve. Partitions touched here are also
-// registered so subsequent traffic debounces normally.
+// Sweep drains any mqtt-wake partitions left pending by a crash while
+// their debounce was armed. Call after the loop registry has hydrated
+// so targets resolve.
 func (d *mqttWakeDispatcher) Sweep(ctx context.Context) {
-	partitions, err := d.queue.Consumers(ctx, mqttWakePartitionPrefix)
-	if err != nil {
-		d.logger.Warn("mqtt wake boot sweep failed to enumerate partitions", "error", err)
-		return
-	}
-	for _, partition := range partitions {
-		d.ensureRegistered(partition)
-		d.drainSerialized(partition)
-	}
-	if len(partitions) > 0 {
-		d.logger.Info("mqtt wake boot sweep drained pending partitions", "partitions", len(partitions))
-	}
+	d.dispatch.Sweep(ctx)
 }
 
 // mqttWakePartition derives the queue partition for a wake target.

--- a/internal/app/mqttwake_test.go
+++ b/internal/app/mqttwake_test.go
@@ -146,7 +146,7 @@ func TestMQTTWakeHandlerDispatchesViaWakeTarget(t *testing.T) {
 	}
 
 	// The queue partition drains fully — nothing left pending.
-	pending, err := dispatcher.queue.PendingCount(context.Background(), mqttWakePartition(target))
+	pending, err := dispatcher.dispatch.queue.PendingCount(context.Background(), mqttWakePartition(target))
 	if err != nil {
 		t.Fatalf("PendingCount: %v", err)
 	}
@@ -280,7 +280,7 @@ func TestMQTTWakeBootSweep(t *testing.T) {
 	dispatcher := newTestDispatcher(t, bus, nil)
 
 	target := messages.LoopWakeTarget{Name: "recovered_handler"}
-	record, err := json.Marshal(mqttQueuedWake{
+	record, err := json.Marshal(queuedWakeRecord{
 		Target: target,
 		Event: messages.LoopEventPayload{
 			Source: "mqtt_wake", Type: "message",
@@ -292,7 +292,7 @@ func TestMQTTWakeBootSweep(t *testing.T) {
 	}
 	// Enqueue directly — simulating a pre-crash write whose debounce
 	// state died with the process (no registration on this store yet).
-	if err := dispatcher.queue.Enqueue(context.Background(), mqttWakePartition(target), "mqtt:crashed:a/topic", 1, record); err != nil {
+	if err := dispatcher.dispatch.queue.Enqueue(context.Background(), mqttWakePartition(target), "mqtt:crashed:a/topic", 1, record); err != nil {
 		t.Fatalf("enqueue: %v", err)
 	}
 
@@ -305,7 +305,7 @@ func TestMQTTWakeBootSweep(t *testing.T) {
 	if got[0].To.Target != "recovered_handler" {
 		t.Errorf("swept target = %q, want recovered_handler", got[0].To.Target)
 	}
-	pending, err := dispatcher.queue.PendingCount(context.Background(), mqttWakePartition(target))
+	pending, err := dispatcher.dispatch.queue.PendingCount(context.Background(), mqttWakePartition(target))
 	if err != nil {
 		t.Fatalf("PendingCount: %v", err)
 	}
@@ -389,14 +389,14 @@ func TestMQTTWakeConcurrentDrainsDeliverOnce(t *testing.T) {
 
 	dispatcher := newTestDispatcher(t, bus, nil)
 	target := messages.LoopWakeTarget{Name: "slow_handler"}
-	record, err := json.Marshal(mqttQueuedWake{
+	record, err := json.Marshal(queuedWakeRecord{
 		Target: target,
 		Event:  messages.LoopEventPayload{Source: "mqtt_wake", Type: "message", ID: "mqtt-slow-1", Title: "a/topic"},
 	})
 	if err != nil {
 		t.Fatalf("marshal: %v", err)
 	}
-	if err := dispatcher.queue.Enqueue(context.Background(), mqttWakePartition(target), "mqtt:slow:a/topic", 1, record); err != nil {
+	if err := dispatcher.dispatch.queue.Enqueue(context.Background(), mqttWakePartition(target), "mqtt:slow:a/topic", 1, record); err != nil {
 		t.Fatalf("enqueue: %v", err)
 	}
 

--- a/internal/app/new_awareness.go
+++ b/internal/app/new_awareness.go
@@ -337,6 +337,18 @@ func (a *App) initAwareness(s *newState) error {
 		"episodic_history_tokens", cfg.Episodic.HistoryTokens,
 	)
 
+	// --- Subscription wake feed (#1211) ---
+	// Wake-declaring subscriptions awaken their owning loop on entity
+	// change: the feeder taps the filtered state stream below,
+	// enqueues entity-deduped records per owner, and the shared
+	// queued-wake dispatcher's debounce delivers coalesced batches.
+	if a.loopQueue != nil && a.messageBus != nil && watchlistStore != nil {
+		a.subWakeFeeder = newSubscriptionWakeFeeder(
+			a.loopQueue, a.messageBus, watchlistStore, a.loopRegistry,
+			contextfmt.SemanticState, logger,
+		)
+	}
+
 	// --- State watcher ---
 	// Consumes state_changed events from the HA WebSocket and forwards
 	// them to the state window and person tracker. The ingestion filter
@@ -375,16 +387,24 @@ func (a *App) initAwareness(s *newState) error {
 		}
 		limiter := homeassistant.NewEntityRateLimiter(cfg.HomeAssistant.IngestRateLimitPerMinute)
 
-		// Compose handler: state window and person tracker both see
-		// every state change that passes the filter and rate limiter.
-		var handler homeassistant.StateWatchHandler
+		// Compose handler: the state window, person tracker, and
+		// subscription wake feeder all see every state change that
+		// passes the filter and rate limiter.
+		taps := []homeassistant.StateWatchHandler{stateWindowProvider.HandleStateChange}
 		if s.personTracker != nil {
+			taps = append(taps, s.personTracker.HandleStateChange)
+		}
+		if a.subWakeFeeder != nil {
+			taps = append(taps, a.subWakeFeeder.HandleStateChange)
+		}
+		handler := taps[0]
+		if len(taps) > 1 {
+			all := taps
 			handler = func(entityID, oldState, newState, deviceClass string) {
-				stateWindowProvider.HandleStateChange(entityID, oldState, newState, deviceClass)
-				s.personTracker.HandleStateChange(entityID, oldState, newState, deviceClass)
+				for _, tap := range all {
+					tap(entityID, oldState, newState, deviceClass)
+				}
 			}
-		} else {
-			handler = stateWindowProvider.HandleStateChange
 		}
 
 		watcher := homeassistant.NewStateWatcher(a.haWS.Events(), filter, limiter, handler, logger)
@@ -396,9 +416,14 @@ func (a *App) initAwareness(s *newState) error {
 				// genuinely, by not swapping — rather than narrowing
 				// ingestion on bad luck.
 				logger.Warn("ingest registry read failed; keeping the previous ingestion filter", "error", err)
-				return
+			} else {
+				watcher.SetFilter(rebuilt)
 			}
-			watcher.SetFilter(rebuilt)
+			// The wake index derives from the same registry state, so
+			// it rides the same rebuild signal (#1211).
+			if a.subWakeFeeder != nil {
+				a.subWakeFeeder.Rebuild()
+			}
 		}
 		logger.Info("state watcher configured",
 			"ingest_rate_limit_per_minute", cfg.HomeAssistant.IngestRateLimitPerMinute,

--- a/internal/app/new_servers.go
+++ b/internal/app/new_servers.go
@@ -627,11 +627,18 @@ func (a *App) initServers(s *newState) error {
 					"skipped_non_service", result.SkippedNonService,
 				)
 			}
-			// Drain any mqtt-wake queue partitions left pending by a
-			// crash while their debounce was armed (#1033). Runs here
-			// — after StartEnabledServices — so wake targets resolve.
+			// Drain any queued-wake partitions left pending by a
+			// crash while their debounce was armed (#1033/#1211).
+			// Runs here — after StartEnabledServices — so wake
+			// targets resolve. The subscription feeder also compiles
+			// its initial wake index now that loop-owned rows are
+			// mirrored.
 			if a.mqttWakeDispatch != nil {
 				a.mqttWakeDispatch.Sweep(ctx)
+			}
+			if a.subWakeFeeder != nil {
+				a.subWakeFeeder.Rebuild()
+				a.subWakeFeeder.Sweep(ctx)
 			}
 			// Now that the durable definition snapshot is registered,
 			// fail loud on any config-defined MQTT wake subscription

--- a/internal/app/queue_wake_dispatch.go
+++ b/internal/app/queue_wake_dispatch.go
@@ -1,0 +1,260 @@
+package app
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/nugget/thane-ai-agent/internal/channels/messages"
+	"github.com/nugget/thane-ai-agent/internal/state/loopqueue"
+)
+
+// queueWakeDeliveryTimeout bounds each bus.Send during a drain. The
+// actual agent work happens in the target loop's next iteration on
+// its own clock — this only bounds the envelope-handoff hop.
+const queueWakeDeliveryTimeout = 30 * time.Second
+
+// queueWakeDrainBatch bounds one Peek pass during a drain. The drain
+// loops until the partition is empty, so this is a memory bound per
+// pass, not a delivery cap.
+const queueWakeDrainBatch = 50
+
+// queuedWakeRecord is the shared loopqueue payload for one pending
+// wake: the resolved target plus the event to deliver. Stored durably
+// at ingress and replayed at drain, so a crash between trigger and
+// loop delivery doesn't lose the wake, and a burst coalesces via the
+// queue's dedup instead of amplifying into a wake per trigger.
+type queuedWakeRecord struct {
+	Target messages.LoopWakeTarget   `json:"target"`
+	Event  messages.LoopEventPayload `json:"event"`
+}
+
+// queuedWakeDispatcher is the shared trigger→enqueue→debounced-drain→
+// bus chassis (#1033): MQTT wakes and subscription state-change wakes
+// (#1211) are both instances, differing only in partition prefix,
+// ingress logic, and an optional per-delivery decorate hook. Drains
+// are serialized per partition because loopqueue.Peek does not claim
+// items — a debounce fire racing a boot Sweep would otherwise replay
+// the same records twice.
+type queuedWakeDispatcher struct {
+	queue  *loopqueue.Store
+	bus    *messages.Bus
+	logger *slog.Logger
+
+	// prefix namespaces this instance's partitions. Partition strings
+	// are internal routing keys — deliberately NOT bare loop names,
+	// so a wake target that is also a model-facing queue consumer
+	// (archivist-style queue_pull) never finds plumbing records in
+	// its own partition.
+	prefix string
+
+	// source names the event source on constructed envelopes
+	// ("mqtt_wake", "subscription_wake").
+	source string
+
+	// decorate, when non-nil, runs on each event at delivery time —
+	// the seam for delivery-relative fields like the wake payload's
+	// "ago" delta, which would go stale if rendered at ingress.
+	decorate func(*messages.LoopEventPayload)
+
+	mu         sync.Mutex
+	registered map[string]registeredWake
+	draining   map[string]*sync.Mutex
+}
+
+// registeredWake remembers a partition's current debounce shape so
+// re-registration only happens when the values actually change.
+type registeredWake struct {
+	debounce time.Duration
+	maxWait  time.Duration
+}
+
+func newQueuedWakeDispatcher(queue *loopqueue.Store, bus *messages.Bus, prefix, source string, decorate func(*messages.LoopEventPayload), logger *slog.Logger) *queuedWakeDispatcher {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &queuedWakeDispatcher{
+		queue:      queue,
+		bus:        bus,
+		logger:     logger,
+		prefix:     prefix,
+		source:     source,
+		decorate:   decorate,
+		registered: make(map[string]registeredWake),
+		draining:   make(map[string]*sync.Mutex),
+	}
+}
+
+// register attaches (or retunes) the partition's WakeOnEnqueue
+// debounce. The fire callback must not block (loopqueue contract), so
+// it hands off to a goroutine that runs the serialized drain.
+func (d *queuedWakeDispatcher) register(partition string, debounce, maxWait time.Duration) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if cur, ok := d.registered[partition]; ok && cur.debounce == debounce && cur.maxWait == maxWait {
+		return
+	}
+	d.registered[partition] = registeredWake{debounce: debounce, maxWait: maxWait}
+	d.queue.SetWakeOnEnqueue(partition, debounce, maxWait, func() {
+		go d.drainSerialized(partition)
+	})
+}
+
+// deregister removes a partition's wake registration (its pending
+// items, if any, remain durable and are found by the next Sweep).
+func (d *queuedWakeDispatcher) deregister(partition string) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if _, ok := d.registered[partition]; !ok {
+		return
+	}
+	delete(d.registered, partition)
+	d.queue.SetWakeOnEnqueue(partition, 0, 0, nil)
+}
+
+// registeredPartitions snapshots the currently registered partitions.
+func (d *queuedWakeDispatcher) registeredPartitions() []string {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	out := make([]string, 0, len(d.registered))
+	for p := range d.registered {
+		out = append(out, p)
+	}
+	return out
+}
+
+// enqueue stores one record durably, arming the partition's debounce.
+func (d *queuedWakeDispatcher) enqueue(partition, dedupKey string, priority int, record queuedWakeRecord) error {
+	payload, err := json.Marshal(record)
+	if err != nil {
+		return err
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), queueWakeDeliveryTimeout)
+	defer cancel()
+	return d.queue.Enqueue(ctx, partition, dedupKey, priority, payload)
+}
+
+// partitionLock returns the per-partition drain mutex, creating it on
+// first use.
+func (d *queuedWakeDispatcher) partitionLock(partition string) *sync.Mutex {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	lock, ok := d.draining[partition]
+	if !ok {
+		lock = &sync.Mutex{}
+		d.draining[partition] = lock
+	}
+	return lock
+}
+
+// drainSerialized runs drain under the partition's mutex so
+// concurrent triggers (debounce fire, boot sweep) cannot replay the
+// same un-acked records twice.
+func (d *queuedWakeDispatcher) drainSerialized(partition string) {
+	lock := d.partitionLock(partition)
+	lock.Lock()
+	defer lock.Unlock()
+	d.drain(partition)
+}
+
+// drain delivers a partition's pending records to the message bus in
+// drain order and acks each attempt. Delivery failures are logged and
+// acked anyway — parity with the pre-queue direct dispatch, where a
+// failed bus send dropped the message; the queue adds crash
+// durability and burst coalescing, not retry semantics. A record that
+// no longer unmarshals is acked and skipped for the same reason.
+func (d *queuedWakeDispatcher) drain(partition string) {
+	ctx := context.Background()
+	for {
+		items, err := d.queue.Peek(ctx, partition, queueWakeDrainBatch)
+		if err != nil {
+			d.logger.Warn("queued wake drain peek failed", "partition", partition, "error", err)
+			return
+		}
+		if len(items) == 0 {
+			return
+		}
+		for _, item := range items {
+			d.deliver(partition, item)
+		}
+		if len(items) < queueWakeDrainBatch {
+			return
+		}
+	}
+}
+
+// deliver replays one queued record onto the message bus, then acks it.
+func (d *queuedWakeDispatcher) deliver(partition string, item loopqueue.Item) {
+	ack := func() {
+		if err := d.queue.Ack(context.Background(), partition, item.DedupKey); err != nil {
+			d.logger.Warn("queued wake ack failed", "partition", partition, "dedup_key", item.DedupKey, "error", err)
+		}
+	}
+
+	var record queuedWakeRecord
+	if err := json.Unmarshal(item.Payload, &record); err != nil {
+		d.logger.Warn("queued wake record unmarshal failed, dropping",
+			"partition", partition, "dedup_key", item.DedupKey, "error", err)
+		ack()
+		return
+	}
+	if d.decorate != nil {
+		d.decorate(&record.Event)
+	}
+
+	env, err := messages.NewEventSourceEnvelope(
+		messages.Identity{Kind: messages.IdentitySystem, Name: d.source},
+		record.Target,
+		d.source,
+		[]messages.LoopEventPayload{record.Event},
+	)
+	if err != nil {
+		d.logger.Warn("queued wake envelope construction failed, dropping",
+			"partition", partition, "dedup_key", item.DedupKey, "error", err)
+		ack()
+		return
+	}
+
+	deliveryCtx, cancel := context.WithTimeout(context.Background(), queueWakeDeliveryTimeout)
+	defer cancel()
+	if _, err := d.bus.Send(deliveryCtx, env); err != nil {
+		d.logger.Warn("queued wake delivery failed, dropping",
+			"partition", partition,
+			"dedup_key", item.DedupKey,
+			"target_loop_id", record.Target.LoopID,
+			"target_loop_name", record.Target.Name,
+			"error", err,
+		)
+		ack()
+		return
+	}
+	ack()
+
+	d.logger.Info("queued wake delivered to target loop",
+		"partition", partition,
+		"dedup_key", item.DedupKey,
+		"source", d.source,
+		"target_loop_id", record.Target.LoopID,
+		"target_loop_name", record.Target.Name,
+	)
+}
+
+// Sweep drains every partition under this dispatcher's prefix that
+// still holds pending records — the boot-time recovery for enqueues
+// whose debounce was pending when the process died. Call after the
+// loop registry has hydrated so targets resolve.
+func (d *queuedWakeDispatcher) Sweep(ctx context.Context) {
+	partitions, err := d.queue.Consumers(ctx, d.prefix)
+	if err != nil {
+		d.logger.Warn("queued wake boot sweep failed to enumerate partitions", "prefix", d.prefix, "error", err)
+		return
+	}
+	for _, partition := range partitions {
+		d.drainSerialized(partition)
+	}
+	if len(partitions) > 0 {
+		d.logger.Info("queued wake boot sweep drained pending partitions", "prefix", d.prefix, "partitions", len(partitions))
+	}
+}

--- a/internal/app/queue_wake_dispatch.go
+++ b/internal/app/queue_wake_dispatch.go
@@ -11,9 +11,10 @@ import (
 	"github.com/nugget/thane-ai-agent/internal/state/loopqueue"
 )
 
-// queueWakeDeliveryTimeout bounds each bus.Send during a drain. The
-// actual agent work happens in the target loop's next iteration on
-// its own clock — this only bounds the envelope-handoff hop.
+// queueWakeDeliveryTimeout bounds each of the dispatcher's queue
+// hops: the durable Enqueue at ingress and each bus.Send during a
+// drain. The actual agent work happens in the target loop's next
+// iteration on its own clock — this only bounds the handoff hops.
 const queueWakeDeliveryTimeout = 30 * time.Second
 
 // queueWakeDrainBatch bounds one Peek pass during a drain. The drain

--- a/internal/app/subscription_wake.go
+++ b/internal/app/subscription_wake.go
@@ -1,0 +1,250 @@
+package app
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/nugget/thane-ai-agent/internal/channels/messages"
+	"github.com/nugget/thane-ai-agent/internal/integrations/homeassistant"
+	"github.com/nugget/thane-ai-agent/internal/model/promptfmt"
+	looppkg "github.com/nugget/thane-ai-agent/internal/runtime/loop"
+	"github.com/nugget/thane-ai-agent/internal/state/awareness"
+	"github.com/nugget/thane-ai-agent/internal/state/loopqueue"
+)
+
+// subWakePartitionPrefix namespaces the subscription wake feed's
+// loopqueue partitions (#1211), disjoint from mqtt-wake: so the two
+// chassis instances never cross-drain.
+const subWakePartitionPrefix = "sub-wake:"
+
+// wakeWatch is one compiled wake-feed entry: a subscription row that
+// declared wake, resolved to the loop it wakes and the debounce it
+// asked for. Glob targets match at event time via the shared glob
+// primitive.
+type wakeWatch struct {
+	owner    string
+	target   string // entity id or glob (registry targets are rejected upstream)
+	isGlob   bool
+	debounce time.Duration
+}
+
+// subscriptionWakeFeeder implements the #1211 wake feed: state
+// changes on wake-subscribed entities enqueue durable, entity-deduped
+// records into the owning loop's sub-wake partition, and the shared
+// queued-wake dispatcher's debounced drain wakes the loop with a
+// coalesced batch. Simple native change triggers only — HA-side
+// derivation (compound conditions, zone dwell, templates) remains
+// #1183's automation→MQTT→wake pipeline; both drain the same
+// loopqueue chassis.
+type subscriptionWakeFeeder struct {
+	dispatch *queuedWakeDispatcher
+	store    *awareness.WatchlistStore
+	loops    *looppkg.Registry
+	// translate renders raw states into the class-aware vocabulary at
+	// ingress (contextfmt.SemanticState in production wiring), so the
+	// wake payload reads closed→open like every other surface.
+	translate func(domain, deviceClass, state string) string
+	logger    *slog.Logger
+
+	// defaultDebounce is the window used for wake subscriptions that
+	// don't ask for one; zero falls back to
+	// [loopqueue.DefaultWakeDebounce]. Tests shrink it.
+	defaultDebounce time.Duration
+
+	mu      sync.RWMutex
+	watches []wakeWatch
+}
+
+func newSubscriptionWakeFeeder(
+	queue *loopqueue.Store,
+	bus *messages.Bus,
+	store *awareness.WatchlistStore,
+	loops *looppkg.Registry,
+	translate func(domain, deviceClass, state string) string,
+	logger *slog.Logger,
+) *subscriptionWakeFeeder {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	f := &subscriptionWakeFeeder{
+		store:     store,
+		loops:     loops,
+		translate: translate,
+		logger:    logger,
+	}
+	f.dispatch = newQueuedWakeDispatcher(queue, bus, subWakePartitionPrefix, "subscription_wake", decorateWakeEvent, logger)
+	return f
+}
+
+// decorateWakeEvent renders the wake payload's delivery-relative
+// summary: {entity, from, to, ago} in the class-aware vocabulary,
+// with ago computed at delivery time so a record that waited out a
+// debounce (or a crash) reports how stale it actually is.
+func decorateWakeEvent(event *messages.LoopEventPayload) {
+	event.Summary = promptfmt.MarshalCompact(map[string]any{
+		"entity": event.Metadata["entity"],
+		"from":   event.Metadata["from"],
+		"to":     event.Metadata["to"],
+		"ago":    promptfmt.FormatDeltaOnly(event.ObservedAt, time.Now()),
+	})
+}
+
+// Rebuild recompiles the wake index from the subscription registry:
+// wake-declaring rows owned by loops, with per-consumer debounce
+// derived as the minimum positive ask among that loop's wake
+// subscriptions (one wake drains everything pending, so the
+// twitchiest subscription governs the shared cadence). Registered
+// partitions are retuned in place; partitions whose loop no longer
+// has wake subscriptions are deregistered (their pending items stay
+// durable for the boot sweep). Called from the same hook that
+// rebuilds the ingestion filter, so the index tracks every registry
+// mutation.
+func (f *subscriptionWakeFeeder) Rebuild() {
+	rows, err := f.store.ListAll()
+	if err != nil {
+		f.logger.Warn("subscription wake index rebuild failed; keeping previous index", "error", err)
+		return
+	}
+
+	var watches []wakeWatch
+	debounces := make(map[string]time.Duration)
+	for _, row := range rows {
+		if !row.Wake {
+			continue
+		}
+		owner := strings.TrimSpace(row.Owner)
+		if owner == "" || owner == awareness.OwnerSystem {
+			// Nobody to wake: the tool boundaries reject these, this
+			// is the backstop for rows arriving by other routes.
+			continue
+		}
+		if awareness.ParseSubscriptionTarget(row.EntityID).IsRegistryTarget() {
+			continue
+		}
+		if live := f.loops.GetByName(owner); live != nil && live.Operation() == looppkg.OperationContainer {
+			f.logger.Warn("wake subscription owned by a container — containers never iterate, skipping",
+				"owner", owner, "entity_id", row.EntityID)
+			continue
+		}
+		debounce := time.Duration(row.WakeDebounceSeconds) * time.Second
+		watches = append(watches, wakeWatch{
+			owner:    owner,
+			target:   row.EntityID,
+			isGlob:   homeassistant.IsEntityGlob(row.EntityID),
+			debounce: debounce,
+		})
+		effective := debounce
+		if effective <= 0 {
+			effective = f.defaultDebounce
+		}
+		if effective <= 0 {
+			effective = loopqueue.DefaultWakeDebounce
+		}
+		if cur, ok := debounces[owner]; !ok || effective < cur {
+			debounces[owner] = effective
+		}
+	}
+
+	// Retune live partitions and drop registrations whose loop no
+	// longer declares any wake subscription.
+	current := make(map[string]bool, len(debounces))
+	for owner, debounce := range debounces {
+		partition := subWakePartition(owner)
+		current[partition] = true
+		maxWait := loopqueue.DefaultWakeMaxWait
+		if capped := 4 * debounce; capped > maxWait {
+			maxWait = capped
+		}
+		f.dispatch.register(partition, debounce, maxWait)
+	}
+	for _, partition := range f.dispatch.registeredPartitions() {
+		if !current[partition] {
+			f.dispatch.deregister(partition)
+		}
+	}
+
+	f.mu.Lock()
+	f.watches = watches
+	f.mu.Unlock()
+}
+
+// HandleStateChange is the state-watcher tap: called for every change
+// that passed the ingestion filter and rate limiter (wake
+// subscriptions derive their entities into that filter, so their
+// changes are guaranteed to arrive here). Each matching wake
+// subscription enqueues one entity-deduped record for its owner —
+// latest change wins while a wake is pending, and the partition's
+// debounced drain does the rest.
+func (f *subscriptionWakeFeeder) HandleStateChange(entityID, oldState, newState, deviceClass string) {
+	if oldState == newState {
+		return
+	}
+	f.mu.RLock()
+	watches := f.watches
+	f.mu.RUnlock()
+	if len(watches) == 0 {
+		return
+	}
+
+	now := time.Now()
+	var from, to string
+	translated := false
+	for i := range watches {
+		w := &watches[i]
+		if w.isGlob {
+			if ok, _ := homeassistant.MatchEntityGlob(w.target, entityID); !ok {
+				continue
+			}
+		} else if w.target != entityID {
+			continue
+		}
+
+		if !translated {
+			from, to = oldState, newState
+			if f.translate != nil {
+				domain, _, _ := strings.Cut(entityID, ".")
+				from = f.translate(domain, deviceClass, from)
+				to = f.translate(domain, deviceClass, to)
+			}
+			translated = true
+		}
+
+		event := messages.LoopEventPayload{
+			Source:     "subscription_wake",
+			Type:       "state_change",
+			ID:         fmt.Sprintf("subwake-%s-%d", entityID, now.UnixMilli()),
+			Title:      entityID,
+			ObservedAt: now,
+			Metadata: map[string]string{
+				"entity": entityID,
+				"from":   from,
+				"to":     to,
+			},
+		}
+		record := queuedWakeRecord{
+			Target: messages.LoopWakeTarget{Name: w.owner},
+			Event:  event,
+		}
+		partition := subWakePartition(w.owner)
+		if err := f.dispatch.enqueue(partition, "wake:"+entityID, 1, record); err != nil {
+			f.logger.Warn("subscription wake enqueue failed, dropping change",
+				"owner", w.owner, "entity_id", entityID, "error", err)
+		}
+	}
+}
+
+// Sweep drains sub-wake partitions left pending by a crash while
+// their debounce was armed. Call after the loop registry has hydrated
+// so targets resolve.
+func (f *subscriptionWakeFeeder) Sweep(ctx context.Context) {
+	f.dispatch.Sweep(ctx)
+}
+
+// subWakePartition derives the queue partition for a wake-owning loop.
+func subWakePartition(owner string) string {
+	return subWakePartitionPrefix + "name:" + owner
+}

--- a/internal/app/subscription_wake.go
+++ b/internal/app/subscription_wake.go
@@ -22,14 +22,15 @@ import (
 const subWakePartitionPrefix = "sub-wake:"
 
 // wakeWatch is one compiled wake-feed entry: a subscription row that
-// declared wake, resolved to the loop it wakes and the debounce it
-// asked for. Glob targets match at event time via the shared glob
-// primitive.
+// declared wake, resolved to the loop it wakes. Per-subscription
+// debounce asks are folded into the owner's partition registration at
+// index-build time (the twitchiest governs), so the match path
+// carries no timing state. Glob targets match at event time via the
+// shared glob primitive.
 type wakeWatch struct {
-	owner    string
-	target   string // entity id or glob (registry targets are rejected upstream)
-	isGlob   bool
-	debounce time.Duration
+	owner  string
+	target string // entity id or glob (registry targets are rejected upstream)
+	isGlob bool
 }
 
 // subscriptionWakeFeeder implements the #1211 wake feed: state
@@ -130,14 +131,12 @@ func (f *subscriptionWakeFeeder) Rebuild() {
 				"owner", owner, "entity_id", row.EntityID)
 			continue
 		}
-		debounce := time.Duration(row.WakeDebounceSeconds) * time.Second
 		watches = append(watches, wakeWatch{
-			owner:    owner,
-			target:   row.EntityID,
-			isGlob:   homeassistant.IsEntityGlob(row.EntityID),
-			debounce: debounce,
+			owner:  owner,
+			target: row.EntityID,
+			isGlob: homeassistant.IsEntityGlob(row.EntityID),
 		})
-		effective := debounce
+		effective := time.Duration(row.WakeDebounceSeconds) * time.Second
 		if effective <= 0 {
 			effective = f.defaultDebounce
 		}

--- a/internal/app/subscription_wake_test.go
+++ b/internal/app/subscription_wake_test.go
@@ -1,0 +1,243 @@
+package app
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nugget/thane-ai-agent/internal/channels/messages"
+	"github.com/nugget/thane-ai-agent/internal/platform/database"
+	looppkg "github.com/nugget/thane-ai-agent/internal/runtime/loop"
+	"github.com/nugget/thane-ai-agent/internal/state/awareness"
+	"github.com/nugget/thane-ai-agent/internal/state/loopqueue"
+
+	_ "modernc.org/sqlite"
+)
+
+// newTestWakeFeeder wires a feeder over in-memory stores with a fast
+// debounce and a garage-door translation so tests exercise the whole
+// change → enqueue → debounced drain → bus path.
+func newTestWakeFeeder(t *testing.T, bus *messages.Bus) (*subscriptionWakeFeeder, *awareness.WatchlistStore, *looppkg.Registry) {
+	t.Helper()
+	qdb, err := database.OpenMemory()
+	if err != nil {
+		t.Fatalf("open queue db: %v", err)
+	}
+	t.Cleanup(func() { qdb.Close() })
+	queue, err := loopqueue.NewStore(qdb, nil)
+	if err != nil {
+		t.Fatalf("new queue: %v", err)
+	}
+
+	sdb, err := database.OpenMemory()
+	if err != nil {
+		t.Fatalf("open store db: %v", err)
+	}
+	t.Cleanup(func() { sdb.Close() })
+	store, err := awareness.NewWatchlistStore(sdb, nil)
+	if err != nil {
+		t.Fatalf("new watchlist store: %v", err)
+	}
+
+	registry := looppkg.NewRegistry()
+	translate := func(domain, deviceClass, state string) string {
+		if domain == "binary_sensor" && deviceClass == "garage_door" {
+			switch state {
+			case "on":
+				return "open"
+			case "off":
+				return "closed"
+			}
+		}
+		return state
+	}
+	f := newSubscriptionWakeFeeder(queue, bus, store, registry, translate, nil)
+	f.defaultDebounce = 30 * time.Millisecond
+	return f, store, registry
+}
+
+// TestSubscriptionWakeFeedEndToEnd covers the #1211 payoff: a wake
+// subscription's entity changes, the owning loop receives one
+// debounced event-source envelope whose payload speaks the class-aware
+// {entity, from, to, ago} vocabulary, and the partition drains clean.
+func TestSubscriptionWakeFeedEndToEnd(t *testing.T) {
+	bus, captured := captureBus()
+	f, store, _ := newTestWakeFeeder(t, bus)
+
+	if err := store.Upsert("ranch_climate_watch", looppkg.EntitySubscription{
+		EntityID: "binary_sensor.garage_bay_3",
+		Wake:     true,
+	}); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+	f.Rebuild()
+
+	f.HandleStateChange("binary_sensor.garage_bay_3", "off", "on", "garage_door")
+
+	got := waitFor(t, captured, 1, 2*time.Second)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 wake envelope, got %d", len(got))
+	}
+	env := got[0]
+	if env.To.Target != "ranch_climate_watch" {
+		t.Errorf("target = %q, want the owning loop", env.To.Target)
+	}
+	payload, ok := env.Payload.(messages.LoopNotifyPayload)
+	if !ok {
+		t.Fatalf("payload type = %T", env.Payload)
+	}
+	if payload.Kind != "event_source" || len(payload.Events) != 1 {
+		t.Fatalf("payload = %+v, want one event_source event", payload)
+	}
+	event := payload.Events[0]
+	if event.Source != "subscription_wake" || event.Type != "state_change" {
+		t.Errorf("event source/type = %s/%s", event.Source, event.Type)
+	}
+	// Class-aware vocabulary with a delivery-time ago delta.
+	for _, want := range []string{`"entity":"binary_sensor.garage_bay_3"`, `"from":"closed"`, `"to":"open"`, `"ago":`} {
+		if !strings.Contains(event.Summary, want) {
+			t.Errorf("summary = %q, missing %s", event.Summary, want)
+		}
+	}
+
+	pending, err := f.dispatch.queue.PendingCount(context.Background(), subWakePartition("ranch_climate_watch"))
+	if err != nil {
+		t.Fatalf("PendingCount: %v", err)
+	}
+	if pending != 0 {
+		t.Errorf("pending = %d after delivery, want drained partition", pending)
+	}
+}
+
+// TestSubscriptionWakeCoalescesBurst pins the wakestorm discipline: a
+// chattering entity produces ONE wake per debounce window, carrying
+// the latest transition.
+func TestSubscriptionWakeCoalescesBurst(t *testing.T) {
+	bus, captured := captureBus()
+	f, store, _ := newTestWakeFeeder(t, bus)
+
+	if err := store.Upsert("watcher", looppkg.EntitySubscription{
+		EntityID: "sensor.chatty",
+		Wake:     true,
+	}); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+	f.Rebuild()
+
+	for i := 0; i < 6; i++ {
+		f.HandleStateChange("sensor.chatty", "a", string(rune('b'+i)), "")
+		time.Sleep(3 * time.Millisecond)
+	}
+
+	waitFor(t, captured, 1, 2*time.Second)
+	time.Sleep(150 * time.Millisecond)
+	got := captured()
+	if len(got) != 1 {
+		t.Fatalf("burst delivered %d wakes, want 1 coalesced", len(got))
+	}
+	event := got[0].Payload.(messages.LoopNotifyPayload).Events[0]
+	if !strings.Contains(event.Summary, `"to":"g"`) {
+		t.Errorf("summary = %q, want latest transition to win", event.Summary)
+	}
+}
+
+// TestSubscriptionWakeGlobAndIndexGuards covers glob matching plus the
+// index backstops: global/system rows and container owners never wake.
+func TestSubscriptionWakeGlobAndIndexGuards(t *testing.T) {
+	bus, captured := captureBus()
+	f, store, registry := newTestWakeFeeder(t, bus)
+
+	container, err := looppkg.New(looppkg.Config{
+		Name:      "ranch_container",
+		Operation: looppkg.OperationContainer,
+	}, looppkg.Deps{})
+	if err != nil {
+		t.Fatalf("new container: %v", err)
+	}
+	if err := registry.Register(container); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+
+	// Glob wake for a real loop owner.
+	if err := store.Upsert("door_watcher", looppkg.EntitySubscription{
+		EntityID: "binary_sensor.*door*",
+		Wake:     true,
+	}); err != nil {
+		t.Fatalf("upsert glob: %v", err)
+	}
+	// Backstop rows that must be ignored: global, system, container-owned.
+	if err := store.Upsert("", looppkg.EntitySubscription{EntityID: "sensor.global", Wake: true}); err != nil {
+		t.Fatalf("upsert global: %v", err)
+	}
+	if err := store.Upsert(awareness.OwnerSystem, looppkg.EntitySubscription{EntityID: "person.alice", Wake: true, Mode: looppkg.SubscriptionModeIngest}); err != nil {
+		t.Fatalf("upsert system: %v", err)
+	}
+	if err := store.Upsert("ranch_container", looppkg.EntitySubscription{EntityID: "sensor.container_owned", Wake: true}); err != nil {
+		t.Fatalf("upsert container-owned: %v", err)
+	}
+	f.Rebuild()
+
+	f.HandleStateChange("binary_sensor.front_door", "off", "on", "")
+	f.HandleStateChange("sensor.global", "1", "2", "")
+	f.HandleStateChange("sensor.container_owned", "1", "2", "")
+
+	waitFor(t, captured, 1, 2*time.Second)
+	time.Sleep(150 * time.Millisecond)
+	got := captured()
+	if len(got) != 1 {
+		t.Fatalf("delivered %d wakes, want only the glob match", len(got))
+	}
+	if got[0].To.Target != "door_watcher" {
+		t.Errorf("target = %q, want door_watcher", got[0].To.Target)
+	}
+}
+
+// TestSubscriptionWakeDebounceDerivation pins the per-consumer window
+// math: the twitchiest wake subscription governs a loop's partition
+// debounce, and loops that stop declaring wake are deregistered.
+func TestSubscriptionWakeDebounceDerivation(t *testing.T) {
+	bus, _ := captureBus()
+	f, store, _ := newTestWakeFeeder(t, bus)
+
+	if err := store.Upsert("watcher", looppkg.EntitySubscription{
+		EntityID: "sensor.slow", Wake: true, WakeDebounceSeconds: 60,
+	}); err != nil {
+		t.Fatalf("upsert slow: %v", err)
+	}
+	if err := store.Upsert("watcher", looppkg.EntitySubscription{
+		EntityID: "sensor.fast", Wake: true, WakeDebounceSeconds: 5,
+	}); err != nil {
+		t.Fatalf("upsert fast: %v", err)
+	}
+	f.Rebuild()
+
+	partition := subWakePartition("watcher")
+	f.dispatch.mu.Lock()
+	reg, ok := f.dispatch.registered[partition]
+	f.dispatch.mu.Unlock()
+	if !ok {
+		t.Fatal("watcher partition not registered")
+	}
+	if reg.debounce != 5*time.Second {
+		t.Errorf("debounce = %v, want the twitchiest ask (5s)", reg.debounce)
+	}
+	if reg.maxWait != 4*5*time.Second {
+		t.Errorf("maxWait = %v, want 4× the derived debounce", reg.maxWait)
+	}
+
+	// Dropping the wake flag deregisters the partition.
+	if err := store.Remove("watcher", "sensor.slow"); err != nil {
+		t.Fatalf("remove: %v", err)
+	}
+	if err := store.Remove("watcher", "sensor.fast"); err != nil {
+		t.Fatalf("remove: %v", err)
+	}
+	f.Rebuild()
+	f.dispatch.mu.Lock()
+	_, still := f.dispatch.registered[partition]
+	f.dispatch.mu.Unlock()
+	if still {
+		t.Error("partition still registered after its wake subscriptions were removed")
+	}
+}

--- a/internal/runtime/loop/subscription.go
+++ b/internal/runtime/loop/subscription.go
@@ -101,6 +101,24 @@ type EntitySubscription struct {
 	// set alone it renders every retained change inside the window,
 	// still clamped to the render cap.
 	TransitionsWindowSeconds int `yaml:"transitions_window_seconds,omitempty" json:"transitions_window_seconds,omitempty"`
+
+	// Wake declares the wake feed (#1211): the OWNING loop is
+	// awakened when the watched entity changes — debounced,
+	// coalesced per entity, and delivered through the shared
+	// loopqueue chassis, never a private wake driver. Requires a
+	// loop owner (always-visible and system rows have nobody to
+	// wake) and, like every capture-dependent option, derives the
+	// entity into the ingestion filter and refuses registry targets
+	// and requires_tag (wake must not follow tag state).
+	Wake bool `yaml:"wake,omitempty" json:"wake,omitempty"`
+
+	// WakeDebounceSeconds is this subscription's ask for how long
+	// changes coalesce before its loop wakes. Zero uses the shared
+	// default. A loop's effective wake cadence follows its twitchiest
+	// wake subscription — one wake drains everything pending — so a
+	// slower ask here bounds only how fast THIS subscription's
+	// changes demand a wake.
+	WakeDebounceSeconds int `yaml:"wake_debounce_seconds,omitempty" json:"wake_debounce_seconds,omitempty"`
 }
 
 // IsExpired reports whether this subscription's TTL has elapsed
@@ -282,6 +300,19 @@ func normalizeSubscriptionsOnLoad(subs []EntitySubscription, now time.Time) ([]E
 		}
 		if sub.TransitionsWindowSeconds < 0 {
 			return nil, fmt.Errorf("subscriptions[%d] (entity_id=%q): transitions_window_seconds must be >= 0, got %d", i, sub.EntityID, sub.TransitionsWindowSeconds)
+		}
+		if sub.WakeDebounceSeconds < 0 {
+			return nil, fmt.Errorf("subscriptions[%d] (entity_id=%q): wake_debounce_seconds must be >= 0, got %d", i, sub.EntityID, sub.WakeDebounceSeconds)
+		}
+		// The wake feed must not follow tag state (#1213's boundary
+		// extended to #1211: capture-adjacent behavior stays
+		// unconditional) and cannot ride registry targets (their
+		// members never reach the ingestion filter).
+		if sub.Wake && sub.RequiresTag != "" {
+			return nil, fmt.Errorf("subscriptions[%d] (entity_id=%q): wake cannot combine with requires_tag — waking must not follow tag state; drop one of the two", i, sub.EntityID)
+		}
+		if sub.Wake && homeassistant.IsRegistryTarget(sub.EntityID) {
+			return nil, fmt.Errorf("subscriptions[%d] (entity_id=%q): wake needs the entity's event stream, and area/label/floor targets cannot feed the ingestion filter — use a concrete entity or glob", i, sub.EntityID)
 		}
 		// The transition log is a render feature; an ingest-only mode
 		// renders nothing, so the combination declares a log nobody

--- a/internal/runtime/loop/subscription_test.go
+++ b/internal/runtime/loop/subscription_test.go
@@ -481,3 +481,35 @@ func TestNormalizeSubscriptionsOnLoadRejectsRegistryTargetCapture(t *testing.T) 
 		t.Errorf("render registry target rejected at hydration: %v", err)
 	}
 }
+
+// TestNormalizeSubscriptionsOnLoadWakeCombos makes the #1211 wake
+// invariants uniform at JSON hydration: negatives are corrupt, the
+// tag gate cannot ride the wake feed, and registry targets cannot
+// wake (their members never reach the ingestion filter).
+func TestNormalizeSubscriptionsOnLoadWakeCombos(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 5, 12, 0, 0, 0, time.UTC)
+	if _, err := normalizeSubscriptionsOnLoad([]EntitySubscription{
+		{EntityID: "sensor.a", Wake: true, WakeDebounceSeconds: -1},
+	}, now); err == nil {
+		t.Error("negative wake debounce survived hydration")
+	}
+	if _, err := normalizeSubscriptionsOnLoad([]EntitySubscription{
+		{EntityID: "sensor.a", Wake: true, RequiresTag: "ranch_water"},
+	}, now); err == nil {
+		t.Error("wake+requires_tag survived hydration")
+	}
+	if _, err := normalizeSubscriptionsOnLoad([]EntitySubscription{
+		{EntityID: "area:office", Wake: true},
+	}, now); err == nil {
+		t.Error("wake on registry target survived hydration")
+	}
+	// The plain declaration stays legal, ingest-mode wake included
+	// (capture + wake with no render is coherent).
+	if _, err := normalizeSubscriptionsOnLoad([]EntitySubscription{
+		{EntityID: "binary_sensor.gate", Wake: true, WakeDebounceSeconds: 30, Mode: SubscriptionModeIngest},
+	}, now); err != nil {
+		t.Errorf("wake declaration rejected: %v", err)
+	}
+}

--- a/internal/state/awareness/watchlist_modes.go
+++ b/internal/state/awareness/watchlist_modes.go
@@ -51,7 +51,7 @@ func (s *WatchlistStore) IngestGlobs(now time.Time) ([]string, error) {
 		// unconditionally so the log is warm when the tag activates —
 		// only its rendering follows the gate.
 		modeFeeds := sub.FeedsIngest() && sub.RequiresTag == ""
-		if !modeFeeds && !sub.WantsTransitions() {
+		if !modeFeeds && !sub.WantsTransitions() && !sub.Wake {
 			continue
 		}
 		if ParseSubscriptionTarget(entityID).IsRegistryTarget() {
@@ -74,7 +74,7 @@ func (s *WatchlistStore) IngestGlobs(now time.Time) ([]string, error) {
 // Call before persisting; the returned error teaches the recovery
 // move.
 func CheckIngestCapacity(store *WatchlistStore, sub looppkg.EntitySubscription) error {
-	if store == nil || (!sub.FeedsIngest() && !sub.WantsTransitions()) {
+	if store == nil || (!sub.FeedsIngest() && !sub.WantsTransitions() && !sub.Wake) {
 		return nil
 	}
 	globs, err := store.IngestGlobs(time.Now())

--- a/internal/state/awareness/watchlist_store.go
+++ b/internal/state/awareness/watchlist_store.go
@@ -349,6 +349,8 @@ type subscriptionOptionsWire struct {
 	RequiresTag              string                                `json:"requires_tag,omitempty"`
 	Transitions              int                                   `json:"transitions,omitempty"`
 	TransitionsWindowSeconds int                                   `json:"transitions_window_seconds,omitempty"`
+	Wake                     bool                                  `json:"wake,omitempty"`
+	WakeDebounceSeconds      int                                   `json:"wake_debounce_seconds,omitempty"`
 	ExpiresAt                string                                `json:"expires_at,omitempty"`
 }
 
@@ -367,6 +369,9 @@ func marshalSubscriptionOptions(sub looppkg.EntitySubscription) ([]byte, error) 
 	if sub.Transitions < 0 || sub.TransitionsWindowSeconds < 0 {
 		return nil, fmt.Errorf("transitions and transitions_window_seconds must be >= 0, got %d/%d", sub.Transitions, sub.TransitionsWindowSeconds)
 	}
+	if sub.WakeDebounceSeconds < 0 {
+		return nil, fmt.Errorf("wake_debounce_seconds must be >= 0, got %d", sub.WakeDebounceSeconds)
+	}
 	wire := subscriptionOptionsWire{
 		History:                  append([]int(nil), sub.History...),
 		Forecast:                 forecast,
@@ -377,6 +382,8 @@ func marshalSubscriptionOptions(sub looppkg.EntitySubscription) ([]byte, error) 
 		RequiresTag:              strings.TrimSpace(sub.RequiresTag),
 		Transitions:              sub.Transitions,
 		TransitionsWindowSeconds: sub.TransitionsWindowSeconds,
+		Wake:                     sub.Wake,
+		WakeDebounceSeconds:      sub.WakeDebounceSeconds,
 	}
 	if wire.Include != nil && !wire.Include.Any() {
 		wire.Include = nil
@@ -402,6 +409,10 @@ func parseSubscriptionOptions(optsJSON string, addedAt time.Time) looppkg.Entity
 	sub.Include = wire.Include.Clone()
 	sub.SelfOnly = wire.SelfOnly
 	sub.RequiresTag = strings.TrimSpace(wire.RequiresTag)
+	sub.Wake = wire.Wake
+	if wire.WakeDebounceSeconds > 0 {
+		sub.WakeDebounceSeconds = wire.WakeDebounceSeconds
+	}
 	if wire.Transitions > 0 {
 		sub.Transitions = wire.Transitions
 	}

--- a/internal/state/awareness/watchlist_tool_provider.go
+++ b/internal/state/awareness/watchlist_tool_provider.go
@@ -152,6 +152,14 @@ func (w *WatchlistTools) Tools() []*tools.Tool {
 						"type":        "integer",
 						"description": "Bound the transition log to changes within this trailing window (seconds). Combine with transitions for window-filtered last-n, or set alone to render every retained change inside the window (still capped).",
 					},
+					"wake": map[string]any{
+						"type":        "boolean",
+						"description": "Wake the owning loop when this entity changes — debounced and coalesced, so a chattering sensor becomes one wake carrying the latest change, never a wakestorm. Requires owner (an always-visible subscription has nobody to wake). Capture follows automatically. Entity ids and globs only; incompatible with requires_tag.",
+					},
+					"wake_debounce_seconds": map[string]any{
+						"type":        "integer",
+						"description": "How long this subscription's changes coalesce before waking its loop (default a few seconds). A loop's effective cadence follows its twitchiest wake subscription — one wake drains everything pending.",
+					},
 					"include": tools.EntityMetadataIncludeParameter(),
 				},
 				"required": []string{"entity_id"},
@@ -261,6 +269,14 @@ func (w *WatchlistTools) handleAddEntitySubscription(ctx context.Context, args m
 	if transitions > maxTransitionsPerSubscription {
 		return "", fmt.Errorf("transitions is capped at %d per subscription — ask for fewer, or add transitions_window_seconds to bound by recency instead", maxTransitionsPerSubscription)
 	}
+	wake, _ := args["wake"].(bool)
+	wakeDebounce, err := watchlistIntArg(args["wake_debounce_seconds"], "wake_debounce_seconds")
+	if err != nil {
+		return "", err
+	}
+	if wakeDebounce < 0 {
+		return "", fmt.Errorf("wake_debounce_seconds must be >= 0")
+	}
 
 	sub := looppkg.EntitySubscription{
 		EntityID:                 entityID,
@@ -274,8 +290,23 @@ func (w *WatchlistTools) handleAddEntitySubscription(ctx context.Context, args m
 		RequiresTag:              requiresTag,
 		Transitions:              transitions,
 		TransitionsWindowSeconds: transitionsWindow,
+		Wake:                     wake,
+		WakeDebounceSeconds:      wakeDebounce,
 	}
 
+	if sub.Wake {
+		// The wake feed awakens the OWNING loop; the always-visible
+		// tier has nobody to wake.
+		if owner == "" {
+			return "", fmt.Errorf("wake awakens the owning loop, and an always-visible subscription has no owner — pass owner with the loop to wake, or use watch_entity from inside it")
+		}
+		if requiresTag != "" {
+			return "", fmt.Errorf("wake cannot combine with requires_tag — waking must not follow tag state; drop one of the two")
+		}
+		if ParseSubscriptionTarget(entityID).IsRegistryTarget() {
+			return "", fmt.Errorf("wake needs the entity's event stream, and area/label/floor targets cannot feed the ingestion filter — subscribe a concrete entity or glob to wake on")
+		}
+	}
 	if sub.WantsTransitions() {
 		// A transition log is a render feature; an ingest-only mode
 		// renders nothing, so the combination declares a log nobody
@@ -359,6 +390,13 @@ func (w *WatchlistTools) handleAddEntitySubscription(ctx context.Context, args m
 	}
 	if selfOnly {
 		msg += " (self_only: not inherited by descendant loops)"
+	}
+	if wake {
+		if wakeDebounce > 0 {
+			msg += fmt.Sprintf(" (wake: the loop wakes on change, coalesced over %ds)", wakeDebounce)
+		} else {
+			msg += " (wake: the loop wakes on change, debounced; capture follows automatically)"
+		}
 	}
 	if requiresTag != "" {
 		msg += fmt.Sprintf(" (renders only while tag %q is active)", requiresTag)
@@ -475,6 +513,12 @@ func (w *WatchlistTools) handleListEntitySubscriptions(ctx context.Context, args
 		}
 		if row.TransitionsWindowSeconds > 0 {
 			item["transitions_window_seconds"] = row.TransitionsWindowSeconds
+		}
+		if row.Wake {
+			item["wake"] = true
+		}
+		if row.WakeDebounceSeconds > 0 {
+			item["wake_debounce_seconds"] = row.WakeDebounceSeconds
 		}
 		if row.TTLSeconds > 0 && !row.AddedAt.IsZero() {
 			expiresAt := row.AddedAt.Add(time.Duration(row.TTLSeconds) * time.Second)

--- a/internal/state/awareness/watchlist_tool_provider_test.go
+++ b/internal/state/awareness/watchlist_tool_provider_test.go
@@ -795,3 +795,79 @@ func TestAddEntitySubscription_TransitionOptions(t *testing.T) {
 		t.Fatalf("registry-target error = %v, want filter teaching", err)
 	}
 }
+
+// TestAddEntitySubscription_WakeOptions covers the #1211 boundary:
+// wake needs an owner, refuses the tag gate and registry targets,
+// round-trips onto the loop's spec, and surfaces in the list.
+func TestAddEntitySubscription_WakeOptions(t *testing.T) {
+	p, store, mutator := setupWatchlistProvider(t)
+
+	if _, err := p.handleAddEntitySubscription(context.Background(), map[string]any{
+		"entity_id": "binary_sensor.gate",
+		"wake":      true,
+	}); err == nil || !strings.Contains(err.Error(), "owner") {
+		t.Fatalf("ownerless wake error = %v, want owner teaching", err)
+	}
+	if _, err := p.handleAddEntitySubscription(context.Background(), map[string]any{
+		"entity_id":    "binary_sensor.gate",
+		"owner":        "watcher",
+		"wake":         true,
+		"requires_tag": "ranch_water",
+	}); err == nil || !strings.Contains(err.Error(), "tag state") {
+		t.Fatalf("wake+requires_tag error = %v, want tag-state teaching", err)
+	}
+	if _, err := p.handleAddEntitySubscription(context.Background(), map[string]any{
+		"entity_id": "area:office",
+		"owner":     "watcher",
+		"wake":      true,
+	}); err == nil || !strings.Contains(err.Error(), "ingestion filter") {
+		t.Fatalf("wake+registry-target error = %v, want filter teaching", err)
+	}
+
+	result, err := p.handleAddEntitySubscription(context.Background(), map[string]any{
+		"entity_id":             "binary_sensor.gate",
+		"owner":                 "watcher",
+		"wake":                  true,
+		"wake_debounce_seconds": 30,
+	})
+	if err != nil {
+		t.Fatalf("wake add: %v", err)
+	}
+	if !strings.Contains(result, "wake") {
+		t.Fatalf("result = %q, want wake acknowledgement", result)
+	}
+	subs := mutator.subs["watcher"]
+	if len(subs) != 1 || !subs[0].Wake || subs[0].WakeDebounceSeconds != 30 {
+		t.Fatalf("loop subs = %+v, want wake options on the spec", subs)
+	}
+
+	// List surfaces wake rows (simulating the post-persist mirror).
+	if err := store.Upsert("watcher", subs[0]); err != nil {
+		t.Fatalf("mirror upsert: %v", err)
+	}
+	raw, err := p.handleListEntitySubscriptions(context.Background(), map[string]any{})
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	var payload struct {
+		Items []struct {
+			Wake                bool `json:"wake"`
+			WakeDebounceSeconds int  `json:"wake_debounce_seconds"`
+		} `json:"items"`
+	}
+	if err := json.Unmarshal([]byte(raw), &payload); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(payload.Items) != 1 || !payload.Items[0].Wake || payload.Items[0].WakeDebounceSeconds != 30 {
+		t.Fatalf("list items = %+v, want wake surfaced", payload.Items)
+	}
+
+	// Wake rows occupy the derived-capture path.
+	globs, err := store.IngestGlobs(time.Now())
+	if err != nil {
+		t.Fatalf("IngestGlobs: %v", err)
+	}
+	if !slices.Equal(globs, []string{"binary_sensor.gate"}) {
+		t.Fatalf("IngestGlobs = %v, want wake-derived entry", globs)
+	}
+}

--- a/internal/tools/loop_create_tool.go
+++ b/internal/tools/loop_create_tool.go
@@ -550,6 +550,14 @@ func thaneLoopCreateSchema() map[string]any {
 							"type":        "integer",
 							"description": "Bound the transition log to changes within this trailing window (seconds); combine with transitions or set alone (still capped).",
 						},
+						"wake": map[string]any{
+							"type":        "boolean",
+							"description": "Wake this loop when the entity changes — debounced and coalesced; capture follows automatically. Entity ids and globs only; incompatible with requires_tag.",
+						},
+						"wake_debounce_seconds": map[string]any{
+							"type":        "integer",
+							"description": "How long changes coalesce before waking (default a few seconds).",
+						},
 						"include": EntityMetadataIncludeParameter(),
 					},
 					"required": []string{"entity_id"},

--- a/internal/tools/loop_intent_tools.go
+++ b/internal/tools/loop_intent_tools.go
@@ -93,6 +93,8 @@ func curateEntitiesToSubscriptions(entities []curateEntity, addedAt time.Time) [
 			RequiresTag:              e.RequiresTag,
 			Transitions:              e.Transitions,
 			TransitionsWindowSeconds: e.TransitionsWindowSeconds,
+			Wake:                     e.Wake,
+			WakeDebounceSeconds:      e.WakeDebounceSeconds,
 		})
 	}
 	return out
@@ -111,6 +113,8 @@ type curateEntity struct {
 	RequiresTag              string
 	Transitions              int
 	TransitionsWindowSeconds int
+	Wake                     bool
+	WakeDebounceSeconds      int
 }
 
 // parseEntityList decodes an entity-subscription array into a typed
@@ -242,11 +246,34 @@ func parseEntityList(fieldName string, raw any) ([]curateEntity, error) {
 		if (ent.Transitions > 0 || ent.TransitionsWindowSeconds > 0) && ent.Mode == looppkg.SubscriptionModeIngest {
 			return nil, fmt.Errorf("%s[%d]: a transition log renders into context, but mode ingest never renders — drop the transition options, or use mode render or both", fieldName, i)
 		}
+		if rawWake, present := obj["wake"]; present && rawWake != nil {
+			wake, ok := rawWake.(bool)
+			if !ok {
+				return nil, fmt.Errorf("%s[%d].wake: must be a boolean, got %T", fieldName, i, rawWake)
+			}
+			ent.Wake = wake
+		}
+		if rawWakeDebounce, present := obj["wake_debounce_seconds"]; present {
+			n, err := coerceInt(rawWakeDebounce)
+			if err != nil {
+				return nil, fmt.Errorf("%s[%d].wake_debounce_seconds: %w", fieldName, i, err)
+			}
+			if n < 0 {
+				return nil, fmt.Errorf("%s[%d].wake_debounce_seconds: must be >= 0", fieldName, i)
+			}
+			ent.WakeDebounceSeconds = n
+		}
+		if ent.Wake && ent.RequiresTag != "" {
+			return nil, fmt.Errorf("%s[%d]: wake cannot combine with requires_tag — waking must not follow tag state", fieldName, i)
+		}
 		// Registry targets (area:/label:/floor:) cannot feed the
 		// ingestion filter, so capture-dependent options on them would
 		// silently do nothing (Copilot #1215) — same rejection every
 		// other authoring door applies.
 		if homeassistant.IsRegistryTarget(ent.EntityID) {
+			if ent.Wake {
+				return nil, fmt.Errorf("%s[%d]: wake needs the entity's event stream, and area/label/floor targets cannot feed the ingestion filter — use a concrete entity or glob", fieldName, i)
+			}
 			if ent.Transitions > 0 || ent.TransitionsWindowSeconds > 0 {
 				return nil, fmt.Errorf("%s[%d]: a transition log needs the entity's event stream, and area/label/floor targets cannot feed the ingestion filter — subscribe a concrete entity or glob for transitions", fieldName, i)
 			}

--- a/internal/tools/loop_spec_schema.go
+++ b/internal/tools/loop_spec_schema.go
@@ -129,6 +129,8 @@ func loopSpecSchema(description string) map[string]any {
 						"requires_tag":               map[string]any{"type": "string", "description": "Optional capability tag gating visibility: renders only while the tag is active. Render-only — incompatible with mode ingest/both; the combination is rejected."},
 						"transitions":                map[string]any{"type": "integer", "description": "Render the entity's last n observed state changes ({from, to, ago}, class-aware); declaring a log feeds the entity into state-change capture automatically. Capped; incompatible with mode ingest."},
 						"transitions_window_seconds": map[string]any{"type": "integer", "description": "Bound the transition log to a trailing window in seconds; usable with or without transitions (still capped)."},
+						"wake":                       map[string]any{"type": "boolean", "description": "Wake the owning loop when the entity changes — debounced/coalesced via the shared queue; capture derives automatically. Incompatible with requires_tag and registry targets."},
+						"wake_debounce_seconds":      map[string]any{"type": "integer", "description": "Coalescing window before the wake fires; the loop's cadence follows its twitchiest wake subscription."},
 					},
 				},
 			},

--- a/talents/awareness-trailhead.md
+++ b/talents/awareness-trailhead.md
@@ -50,9 +50,20 @@ Choose the next move deliberately:
   happened to THIS entity" (survives the shared window's churn),
   `history` summaries answer "what has it been doing" (numeric trends
   over windows), and the shared recent-state-changes window answers
-  "what's been happening around the house." For "act the moment it
-  changes," that's a wake concern — use the event-driven wiring, not a
-  render option.
+  "what's been happening around the house."
+- Pass `wake: true` when a loop should *act* on change, not just see
+  it next iteration: the owning loop is awakened with a
+  `{entity, from, to, ago}` event — debounced and coalesced, so a
+  chattering sensor becomes one wake carrying the latest change,
+  never a wakestorm. `wake_debounce_seconds` sets how long changes
+  coalesce (a loop's cadence follows its twitchiest wake
+  subscription); capture follows automatically. Wake needs an owning
+  loop (`owner`, or `watch_entity` from inside one). Boundary: this
+  covers simple native triggers — "wake me when this entity changes."
+  Compound conditions, zone dwell, and template triggers belong to
+  the HA-automation→MQTT pipeline (`mqtt_wake_add` + an HA
+  automation); both deliver through the same queue, so pick by where
+  the condition logic lives, not by delivery mechanics.
 - Add `include` metadata flags when area, owning device, HA labels, or
   descriptions would make the subscribed state easier to interpret; use
   `visibility` when hidden/enabled salience matters, and read


### PR DESCRIPTION
Closes #1211 — the final phase of #1208. Builds on #1212 (the unified model), #1215 (derived capture), and #1216 (the WakeOnEnqueue seam).

## The payoff feed: declare wake, and the loop acts on change

A loop-owned subscription can now declare `wake: true`: when the watched entity changes, the owning loop is awakened with a `{entity, from, to, ago}` event in the class-aware vocabulary — a garage bay wakes its loop with closed→open, not off→on — delivered through the shared loopqueue chassis. This is the feed the whole arc was building toward: render answers "what is it now," the transition log answers "what just happened," history answers "what has it been doing," and wake answers "tell me the moment it changes." The declaration rides the unified `EntitySubscription` (`wake` + `wake_debounce_seconds`) and is expressible from every door — `add_entity_subscription` with `owner`, `watch_entity` from inside the loop, `thane_loop_create.entities`, and the spec schema.

Born with the wakestorm discipline, per the issue: changes enqueue durable, entity-deduped records into the owner's `sub-wake:` partition (latest change wins while a wake is pending), and #1216's debounced seam drains a coalesced batch — a chattering sensor becomes one wake carrying its freshest transition, never an iteration per flap. `ago` is rendered at delivery time, not ingress, so a record that waited out a debounce (or survived a crash — the boot sweep rides the same worker slot MQTT's does) reports how stale it actually is. Per-consumer debounce is the minimum positive ask among the loop's wake subscriptions — one wake drains everything pending, so the twitchiest governs the shared cadence, and the godoc plus talent say so plainly. `maxWait` scales at 4× the derived window so chatter can't starve the drain.

## One chassis, now with two riders

The drain/deliver/sweep machinery MQTT proved out in #1216 is extracted into a shared `queuedWakeDispatcher` — prefix-parameterized partitions, per-partition serialized drains, ack-and-drop delivery parity, boot sweep — with one addition: a per-delivery `decorate` hook, which is exactly the seam the wake payload's delivery-relative `ago` needed. MQTT becomes a thin ingress over the shared component with behavior byte-identical to what merged yesterday (its full test suite passes untouched apart from field-path renames). The two riders keep disjoint partition namespaces (`mqtt-wake:` / `sub-wake:`), so neither can cross-drain the other.

The feeder taps the same filtered, rate-limited state stream as the state window and person tracker — wake subscriptions derive their entities into the ingestion filter (and count against the ingest cap), so their changes are guaranteed to arrive at the tap, and the upstream rate limiter is honored for free. The wake index rebuilds on the same signal as the ingestion filter, so every registry mutation — tool writes, spec mirrors, definition deletes, the boot compile — retunes both together.

## The invariants hold at every door

Uniformly at tool boundaries and JSON hydration, per the pattern this arc converged on: wake requires an owner (the always-visible tier has nobody to wake — the teaching error points at `owner` and `watch_entity`); wake refuses `requires_tag` (waking must not follow tag state, #1213's boundary extended); wake refuses registry targets (their members never reach the filter). Globs wake per matching concrete entity. Container-owned, global, and system rows are additionally skipped at index build as backstops for declarations arriving by other routes. Ingest-mode wake is deliberately legal — capture plus wake with no render is a coherent posture.

The talent now completes the four-feeds picture and states the #1183 boundary the issue asked for: subscription-wake covers simple native change triggers; compound conditions, zone dwell, and template triggers belong to the HA-automation→MQTT pipeline — both drain the same queue, so the choice is about where the condition logic lives, not delivery mechanics.

## Test plan

- [x] `just ci` green locally (run unpiped)
- [x] End-to-end: change → enqueue → debounced drain → bus envelope with class-aware `{entity, from, to, ago}`, drained-clean partition
- [x] Wakestorm discipline: burst coalesces to one wake with the latest transition; per-consumer debounce derivation (twitchiest wins, maxWait scales); deregistration when wake subscriptions go away
- [x] Guards: glob matching, container/global/system index backstops, owner/requires_tag/registry-target rejections at boundaries and hydration, wake rows in `IngestGlobs` + capacity
- [x] Chassis extraction: full MQTT dispatcher suite passes unchanged on the shared component, all concurrency tests under `-race`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
