### PR TITLE
feat(awareness): the always-visible tier belongs to core

### DIFF
--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -81,8 +81,8 @@ These tools load on every turn regardless of active tags.
 
 | Tool | Description |
 |------|-------------|
-| `add_entity_subscription` | Subscribe to an HA entity. Ownership is a parameter: no `owner` = always-visible; `owner: <loop name>` lands on that loop's spec. |
-| `list_entity_subscriptions` | List the whole subscription registry: always-visible, loop-owned, and system-seeded rows, each with its owner. |
+| `add_entity_subscription` | Subscribe to an HA entity. Ownership is a parameter: no `owner` (or `core`) = always-visible, owned by the root container; `owner: <loop name>` lands on that loop's spec. |
+| `list_entity_subscriptions` | List the whole subscription registry: core-owned (always-visible), loop-owned, and system-seeded rows, each with its owner. |
 | `remove_entity_subscription` | Remove a subscription; `owner` addresses a loop's own entry, system rows are config-owned and refuse removal. |
 
 Subscription expiry is reported as `expires_delta`, not a raw timestamp,
@@ -112,6 +112,12 @@ state-change ingestion filter automatically, with per-entity bounded
 retention behind the shared window — so `mode: ingest` is never needed
 for it. Entity ids and globs only; complementary to `history` (numeric
 trend summaries) rather than a replacement.
+
+The always-visible tier belongs to `core`: the root container's
+subscriptions render in every context (conversations are de facto
+core's context), stored as core-owned registry rows — core has no
+persisted spec by design, so the rows themselves are the source of
+truth and the orphan sweep treats `core` (like `system`) as reserved.
 
 A loop-owned subscription may declare `wake: true`: the owning loop is
 awakened when the entity changes, with the event delivered as

--- a/internal/app/loop_definition_store.go
+++ b/internal/app/loop_definition_store.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/nugget/thane-ai-agent/internal/platform/opstate"
 	looppkg "github.com/nugget/thane-ai-agent/internal/runtime/loop"
+	"github.com/nugget/thane-ai-agent/internal/state/awareness"
 )
 
 const loopDefinitionRegistryNamespace = "loop_definition_registry"
@@ -194,8 +195,11 @@ func (a *App) deletePersistedLoopDefinition(name string) error {
 		}
 	}
 	// Reap the definition's mirrored registry rows. Best-effort: the
-	// startup orphan sweep catches any miss.
-	if a.watchlistStore != nil && strings.TrimSpace(name) != "" {
+	// startup orphan sweep catches any miss. Reserved owners (core's
+	// always-visible tier, the system floor) are never a definition's
+	// mirror and must not be reaped by a name collision.
+	if a.watchlistStore != nil && strings.TrimSpace(name) != "" &&
+		name != awareness.OwnerCore && name != awareness.OwnerSystem {
 		if err := a.watchlistStore.RemoveAllForOwner(name); err != nil {
 			a.logger.Warn("failed to remove mirrored subscription rows for deleted definition",
 				"name", name, "error", err)

--- a/internal/app/loop_subscription_compile.go
+++ b/internal/app/loop_subscription_compile.go
@@ -33,11 +33,13 @@ func (a *App) compileLoopSubscriptions() error {
 			if name == "" {
 				continue
 			}
-			if name == awareness.OwnerSystem {
-				// The reserved system owner holds runtime-seeded rows;
-				// a definition squatting on the name must not clobber
-				// them (and could not be told apart from them later).
-				a.logger.Warn("loop definition name collides with the reserved system owner — its subscriptions are not mirrored into the registry",
+			if name == awareness.OwnerSystem || name == awareness.OwnerCore {
+				// Reserved owners: system holds runtime-seeded rows,
+				// and core's rows are the always-visible tier whose
+				// source of truth is the registry itself (core has no
+				// persisted definition by design, #1208). A definition
+				// squatting on either name must not clobber them.
+				a.logger.Warn("loop definition name collides with a reserved subscription owner — its subscriptions are not mirrored into the registry",
 					"name", name)
 				continue
 			}
@@ -54,7 +56,9 @@ func (a *App) compileLoopSubscriptions() error {
 		return errors.Join(errs...)
 	}
 	for _, owner := range owners {
-		if owner == awareness.OwnerSystem {
+		if owner == awareness.OwnerSystem || owner == awareness.OwnerCore {
+			// Reserved owners have no definition behind them by
+			// design; their rows are never orphans.
 			continue
 		}
 		if _, ok := known[owner]; ok {
@@ -95,7 +99,7 @@ func (a *App) mirrorLoopSubscriptions(spec looppkg.Spec) {
 		return
 	}
 	name := strings.TrimSpace(spec.Name)
-	if name == "" || name == awareness.OwnerSystem {
+	if name == "" || name == awareness.OwnerSystem || name == awareness.OwnerCore {
 		return
 	}
 	if err := a.watchlistStore.ReplaceOwner(name, spec.Subscriptions); err != nil {

--- a/internal/app/loop_subscription_compile_test.go
+++ b/internal/app/loop_subscription_compile_test.go
@@ -65,8 +65,9 @@ func TestCompileLoopSubscriptions_MirrorsAndSweepsOrphans(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("seed system row: %v", err)
 	}
-	// Global rows are untouched by definition compilation.
-	if err := a.watchlistStore.Upsert("", looppkg.EntitySubscription{EntityID: "sensor.always_on"}); err != nil {
+	// Core-owned rows (the always-visible tier) are untouched by
+	// definition compilation and survive the sweep as a reserved owner.
+	if err := a.watchlistStore.Upsert(awareness.OwnerCore, looppkg.EntitySubscription{EntityID: "sensor.always_on"}); err != nil {
 		t.Fatalf("seed global row: %v", err)
 	}
 
@@ -85,7 +86,7 @@ func TestCompileLoopSubscriptions_MirrorsAndSweepsOrphans(t *testing.T) {
 	want := map[string]string{
 		"sensor.kitchen_temp": "kitchen-watcher",
 		"person.alice":        awareness.OwnerSystem,
-		"sensor.always_on":    "",
+		"sensor.always_on":    awareness.OwnerCore,
 	}
 	if len(got) != len(want) {
 		t.Fatalf("registry rows = %v, want %v", got, want)

--- a/internal/app/subscription_wake.go
+++ b/internal/app/subscription_wake.go
@@ -118,9 +118,11 @@ func (f *subscriptionWakeFeeder) Rebuild() {
 			continue
 		}
 		owner := strings.TrimSpace(row.Owner)
-		if owner == "" || owner == awareness.OwnerSystem {
-			// Nobody to wake: the tool boundaries reject these, this
-			// is the backstop for rows arriving by other routes.
+		if owner == "" || owner == awareness.OwnerSystem || owner == awareness.OwnerCore {
+			// Nobody to wake: core is a container that never iterates
+			// and the system floor is runtime plumbing. The tool
+			// boundaries reject these; this is the backstop for rows
+			// arriving by other routes.
 			continue
 		}
 		if awareness.ParseSubscriptionTarget(row.EntityID).IsRegistryTarget() {

--- a/internal/app/subscription_wake_test.go
+++ b/internal/app/subscription_wake_test.go
@@ -167,7 +167,7 @@ func TestSubscriptionWakeGlobAndIndexGuards(t *testing.T) {
 		t.Fatalf("upsert glob: %v", err)
 	}
 	// Backstop rows that must be ignored: global, system, container-owned.
-	if err := store.Upsert("", looppkg.EntitySubscription{EntityID: "sensor.global", Wake: true}); err != nil {
+	if err := store.Upsert(awareness.OwnerCore, looppkg.EntitySubscription{EntityID: "sensor.global", Wake: true}); err != nil {
 		t.Fatalf("upsert global: %v", err)
 	}
 	if err := store.Upsert(awareness.OwnerSystem, looppkg.EntitySubscription{EntityID: "person.alice", Wake: true, Mode: looppkg.SubscriptionModeIngest}); err != nil {

--- a/internal/platform/config/config.go
+++ b/internal/platform/config/config.go
@@ -2137,6 +2137,27 @@ func rejectRetiredKeys(data []byte) error {
 			if err := rejectRetiredMCPKeys(valueNode); err != nil {
 				return err
 			}
+		case "homeassistant":
+			if err := rejectRetiredHomeAssistantKeys(valueNode); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// rejectRetiredHomeAssistantKeys rejects the legacy
+// homeassistant.subscribe block, retired when the state-watch
+// ingestion filter became registry-derived (#1192): silently ignoring
+// it would let a deploy quietly change what gets captured, since the
+// old entity_globs no longer feed the filter.
+func rejectRetiredHomeAssistantKeys(node *yaml.Node) error {
+	if node == nil || node.Kind != yaml.MappingNode {
+		return nil
+	}
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		if node.Content[i].Value == "subscribe" {
+			return fmt.Errorf("homeassistant.subscribe was retired: state-change capture now derives from the subscription registry (ingest/transitions/wake subscriptions plus person.track — the old entity_globs no longer feed the filter). Move rate_limit_per_minute to homeassistant.ingest_rate_limit_per_minute, re-declare any globs you still want as ingest-mode subscriptions after boot, and delete the subscribe: block")
 		}
 	}
 	return nil

--- a/internal/platform/config/config_test.go
+++ b/internal/platform/config/config_test.go
@@ -1608,3 +1608,30 @@ func TestApplyDefaults_ArchivistZeroFloatsArePreserved(t *testing.T) {
 		t.Errorf("SupervisorProbability = %v, want explicit 0.0 to survive applyDefaults", cfg.Archivist.SupervisorProbability)
 	}
 }
+
+// TestLoad_RetiredHomeAssistantSubscribeRejected guards the #1192
+// ingestion-registry cutover: yaml.v3 silently ignores the retired
+// homeassistant.subscribe block, so a config still carrying
+// entity_globs would boot with a quietly different capture set. Load
+// must fail fast teaching the registry-derived replacement.
+func TestLoad_RetiredHomeAssistantSubscribeRejected(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	os.WriteFile(path, []byte(`
+homeassistant:
+  url: http://ha.local:8123
+  subscribe:
+    entity_globs:
+      - person.*
+      - binary_sensor.*door*
+    rate_limit_per_minute: 30
+`), 0600)
+
+	_, err := Load(path)
+	if err == nil {
+		t.Fatal("expected Load to reject homeassistant.subscribe block")
+	}
+	if !strings.Contains(err.Error(), "homeassistant.subscribe") || !strings.Contains(err.Error(), "ingest_rate_limit_per_minute") {
+		t.Errorf("error %q should name the retired block and the replacement", err)
+	}
+}

--- a/internal/state/awareness/glob_subscription_test.go
+++ b/internal/state/awareness/glob_subscription_test.go
@@ -29,7 +29,7 @@ func globTestHA() *fakeHA {
 
 func TestProvider_GlobSubscriptionExpands(t *testing.T) {
 	p, store := setupTestProvider(t, globTestHA())
-	if err := store.Upsert("", looppkg.EntitySubscription{EntityID: "binary_sensor.*door*"}); err != nil {
+	if err := store.Upsert(OwnerCore, looppkg.EntitySubscription{EntityID: "binary_sensor.*door*"}); err != nil {
 		t.Fatalf("add glob: %v", err)
 	}
 
@@ -55,7 +55,7 @@ func TestProvider_GlobSubscriptionExpands(t *testing.T) {
 func TestProvider_GlobSubscriptionCapAndTruncation(t *testing.T) {
 	p, store := setupTestProvider(t, globTestHA())
 	p.SetMaxGlobExpansion(2)
-	if err := store.Upsert("", looppkg.EntitySubscription{EntityID: "binary_sensor.*"}); err != nil { // matches 3
+	if err := store.Upsert(OwnerCore, looppkg.EntitySubscription{EntityID: "binary_sensor.*"}); err != nil { // matches 3
 		t.Fatalf("add glob: %v", err)
 	}
 
@@ -78,7 +78,7 @@ func TestProvider_GlobSubscriptionCapAndTruncation(t *testing.T) {
 
 func TestProvider_GlobSubscriptionEmptyIsSilent(t *testing.T) {
 	p, store := setupTestProvider(t, globTestHA())
-	if err := store.Upsert("", looppkg.EntitySubscription{EntityID: "climate.*"}); err != nil { // matches nothing
+	if err := store.Upsert(OwnerCore, looppkg.EntitySubscription{EntityID: "climate.*"}); err != nil { // matches nothing
 		t.Fatalf("add glob: %v", err)
 	}
 
@@ -95,7 +95,7 @@ func TestProvider_GlobSubscriptionFetchErrorMarker(t *testing.T) {
 	ha := globTestHA()
 	ha.statesErr = errors.New("HA unavailable")
 	p, store := setupTestProvider(t, ha)
-	if err := store.Upsert("", looppkg.EntitySubscription{EntityID: "binary_sensor.*door*"}); err != nil {
+	if err := store.Upsert(OwnerCore, looppkg.EntitySubscription{EntityID: "binary_sensor.*door*"}); err != nil {
 		t.Fatalf("add glob: %v", err)
 	}
 
@@ -141,10 +141,10 @@ func TestExpandGlobSubscription_ExcludesAlreadyVisible(t *testing.T) {
 
 func TestProvider_GlobAndConcreteMix(t *testing.T) {
 	p, store := setupTestProvider(t, globTestHA())
-	if err := store.Upsert("", looppkg.EntitySubscription{EntityID: "light.hall"}); err != nil { // concrete
+	if err := store.Upsert(OwnerCore, looppkg.EntitySubscription{EntityID: "light.hall"}); err != nil { // concrete
 		t.Fatalf("add concrete: %v", err)
 	}
-	if err := store.Upsert("", looppkg.EntitySubscription{EntityID: "binary_sensor.*door*"}); err != nil { // glob
+	if err := store.Upsert(OwnerCore, looppkg.EntitySubscription{EntityID: "binary_sensor.*door*"}); err != nil { // glob
 		t.Fatalf("add glob: %v", err)
 	}
 

--- a/internal/state/awareness/loop_subscription_provider.go
+++ b/internal/state/awareness/loop_subscription_provider.go
@@ -17,9 +17,9 @@ import (
 // at render time by reading the current loop_id from context and
 // walking the live registry's ancestor chain.
 //
-// Always-visible entities (those subscribed with no loop scope) are
-// still emitted by [WatchlistProvider]; this provider only covers
-// loop- and container-scoped subscriptions.
+// Always-visible entities (core-owned rows) are still emitted by
+// [WatchlistProvider]; this provider only covers loop- and
+// container-scoped subscriptions.
 type LoopSubscriptionProvider struct {
 	loops            *looppkg.Registry
 	store            *WatchlistStore
@@ -101,7 +101,7 @@ func (p *LoopSubscriptionProvider) TagContext(ctx context.Context, req agentctx.
 	// would add an HA fetch and a redundant prompt block; the
 	// always-visible rendering wins because it would appear in
 	// every loop's context anyway. We use
-	// [WatchlistStore.GlobalEntityGates] (bounded IN-clause query,
+	// [WatchlistStore.CoreEntityGates] (bounded IN-clause query,
 	// no TTL cleanup writes) so the dedup check costs one indexed
 	// scan over the loop's own candidate list rather than a full
 	// always-visible scan + cleanup pass — the cleanup is left to
@@ -115,7 +115,7 @@ func (p *LoopSubscriptionProvider) TagContext(ctx context.Context, req agentctx.
 		for _, sub := range subs {
 			candidates = append(candidates, sub.EntityID)
 		}
-		gates, err := p.store.GlobalEntityGates(candidates)
+		gates, err := p.store.CoreEntityGates(candidates)
 		if err != nil {
 			p.logger.Warn("loop subscription provider could not enumerate always-visible store",
 				"error", err,

--- a/internal/state/awareness/loop_subscription_provider_test.go
+++ b/internal/state/awareness/loop_subscription_provider_test.go
@@ -56,7 +56,7 @@ func TestLoopSubscriptionProviderSkipsAlwaysVisibleEntities(t *testing.T) {
 	p, store, reg, _ := setupLoopSubProvider(t)
 
 	// Always-visible subscription via the store (owner "").
-	if err := store.Upsert("", looppkg.EntitySubscription{EntityID: "sensor.shared"}); err != nil {
+	if err := store.Upsert(OwnerCore, looppkg.EntitySubscription{EntityID: "sensor.shared"}); err != nil {
 		t.Fatalf("seed always-visible: %v", err)
 	}
 
@@ -167,7 +167,7 @@ func TestLoopSubscriptionProviderDedupIgnoresGatedOffGlobalRows(t *testing.T) {
 	p, store, reg, _ := setupLoopSubProvider(t)
 
 	// Always-visible row gated on a tag.
-	if err := store.Upsert("", looppkg.EntitySubscription{EntityID: "sensor.shared", RequiresTag: "ranch_water"}); err != nil {
+	if err := store.Upsert(OwnerCore, looppkg.EntitySubscription{EntityID: "sensor.shared", RequiresTag: "ranch_water"}); err != nil {
 		t.Fatalf("seed gated global: %v", err)
 	}
 
@@ -265,7 +265,7 @@ func TestLoopSubscriptionProviderGatedLeafShadowsUngatedAncestor(t *testing.T) {
 // TestLoopSubscriptionProviderDedupIgnoresNonRenderingGlobalRows pins
 // the Copilot finding on #1214: an always-visible row that never
 // renders — ingest-only mode — must not suppress a loop's own render
-// of the same entity. Before GlobalEntityGates filtered on
+// of the same entity. Before CoreEntityGates filtered on
 // RendersState, the entity would silently vanish from loop context
 // whenever the global tier used it for capture only.
 func TestLoopSubscriptionProviderDedupIgnoresNonRenderingGlobalRows(t *testing.T) {
@@ -275,7 +275,7 @@ func TestLoopSubscriptionProviderDedupIgnoresNonRenderingGlobalRows(t *testing.T
 
 	// Global row that feeds capture only; WatchlistProvider never
 	// renders it.
-	if err := store.Upsert("", looppkg.EntitySubscription{
+	if err := store.Upsert(OwnerCore, looppkg.EntitySubscription{
 		EntityID: "sensor.shared",
 		Mode:     looppkg.SubscriptionModeIngest,
 	}); err != nil {
@@ -306,7 +306,7 @@ func TestLoopSubscriptionProviderDedupIgnoresNonRenderingGlobalRows(t *testing.T
 	}
 
 	// mode both DOES render globally, so the dedup must apply.
-	if err := store.Upsert("", looppkg.EntitySubscription{
+	if err := store.Upsert(OwnerCore, looppkg.EntitySubscription{
 		EntityID: "sensor.shared",
 		Mode:     looppkg.SubscriptionModeBoth,
 	}); err != nil {

--- a/internal/state/awareness/subscription_target_test.go
+++ b/internal/state/awareness/subscription_target_test.go
@@ -105,7 +105,7 @@ func setupRegistryProvider(t *testing.T, ha *fakeHARegistry) (*WatchlistProvider
 func TestRegistryTarget_AreaExpandsWithInheritance(t *testing.T) {
 	ha := officeRegistry()
 	p, store := setupRegistryProvider(t, ha)
-	if err := store.Upsert("", looppkg.EntitySubscription{EntityID: "area:office"}); err != nil {
+	if err := store.Upsert(OwnerCore, looppkg.EntitySubscription{EntityID: "area:office"}); err != nil {
 		t.Fatalf("add area target: %v", err)
 	}
 	got, err := p.TagContext(context.Background(), agentctx.ContextRequest{})
@@ -128,7 +128,7 @@ func TestRegistryTarget_LabelAndFloor(t *testing.T) {
 
 	// Label: both office entities carry "critical" (one direct, one via device).
 	p, store := setupRegistryProvider(t, ha)
-	if err := store.Upsert("", looppkg.EntitySubscription{EntityID: "label:critical"}); err != nil {
+	if err := store.Upsert(OwnerCore, looppkg.EntitySubscription{EntityID: "label:critical"}); err != nil {
 		t.Fatalf("add: %v", err)
 	}
 	got, _ := p.TagContext(context.Background(), agentctx.ContextRequest{})
@@ -138,7 +138,7 @@ func TestRegistryTarget_LabelAndFloor(t *testing.T) {
 
 	// Floor: main covers office + garage, so all three entities.
 	p2, store2 := setupRegistryProvider(t, ha)
-	if err := store2.Upsert("", looppkg.EntitySubscription{EntityID: "floor:main"}); err != nil {
+	if err := store2.Upsert(OwnerCore, looppkg.EntitySubscription{EntityID: "floor:main"}); err != nil {
 		t.Fatalf("add: %v", err)
 	}
 	got2, _ := p2.TagContext(context.Background(), agentctx.ContextRequest{})
@@ -152,7 +152,7 @@ func TestRegistryTarget_LabelAndFloor(t *testing.T) {
 func TestRegistryTarget_UnknownAreaIsSilent(t *testing.T) {
 	ha := officeRegistry()
 	p, store := setupRegistryProvider(t, ha)
-	if err := store.Upsert("", looppkg.EntitySubscription{EntityID: "area:atrium"}); err != nil {
+	if err := store.Upsert(OwnerCore, looppkg.EntitySubscription{EntityID: "area:atrium"}); err != nil {
 		t.Fatalf("add: %v", err)
 	}
 	got, err := p.TagContext(context.Background(), agentctx.ContextRequest{})
@@ -169,7 +169,7 @@ func TestRegistryTarget_NoRegistryClientMarksUnavailable(t *testing.T) {
 	ha := officeRegistry()
 	// setupTestProvider does NOT wire the registry client.
 	p, store := setupTestProvider(t, ha)
-	if err := store.Upsert("", looppkg.EntitySubscription{EntityID: "area:office"}); err != nil {
+	if err := store.Upsert(OwnerCore, looppkg.EntitySubscription{EntityID: "area:office"}); err != nil {
 		t.Fatalf("add: %v", err)
 	}
 	got, err := p.TagContext(context.Background(), agentctx.ContextRequest{})

--- a/internal/state/awareness/watchlist_expansion_test.go
+++ b/internal/state/awareness/watchlist_expansion_test.go
@@ -99,7 +99,7 @@ func TestAddEntitySubscription_ZeroMemberTargetFlagged(t *testing.T) {
 	}
 	// Flagged, not rejected — the subscription is still recorded so it can
 	// pick up members later (the point of a registry-tracking target).
-	rows, err := store.ListOwner("")
+	rows, err := store.ListOwner(OwnerCore)
 	if err != nil {
 		t.Fatalf("list: %v", err)
 	}
@@ -153,7 +153,7 @@ func TestAddEntitySubscription_NoRegistryClientNoPreview(t *testing.T) {
 	if strings.Contains(result, "Currently matches") {
 		t.Errorf("result = %q, want no expansion clause without a registry client", result)
 	}
-	rows, err := store.ListOwner("")
+	rows, err := store.ListOwner(OwnerCore)
 	if err != nil {
 		t.Fatalf("list: %v", err)
 	}
@@ -232,7 +232,7 @@ func TestAddEntitySubscription_PreviewFailureIsSurfaced(t *testing.T) {
 	}
 	// The subscription still records — a transient read failure shouldn't
 	// lose the intent.
-	rows, err := store.ListOwner("")
+	rows, err := store.ListOwner(OwnerCore)
 	if err != nil {
 		t.Fatalf("list: %v", err)
 	}

--- a/internal/state/awareness/watchlist_ingest_test.go
+++ b/internal/state/awareness/watchlist_ingest_test.go
@@ -40,11 +40,11 @@ func TestIngestGlobs(t *testing.T) {
 		owner string
 		sub   looppkg.EntitySubscription
 	}{
-		{"", looppkg.EntitySubscription{EntityID: "binary_sensor.*_door", Mode: looppkg.SubscriptionModeIngest}},
-		{"", looppkg.EntitySubscription{EntityID: "lock.front", Mode: looppkg.SubscriptionModeBoth}},
-		{"", looppkg.EntitySubscription{EntityID: "sensor.render_only"}},
+		{OwnerCore, looppkg.EntitySubscription{EntityID: "binary_sensor.*_door", Mode: looppkg.SubscriptionModeIngest}},
+		{OwnerCore, looppkg.EntitySubscription{EntityID: "lock.front", Mode: looppkg.SubscriptionModeBoth}},
+		{OwnerCore, looppkg.EntitySubscription{EntityID: "sensor.render_only"}},
 		// Expired ingest row drops out of the rebuild.
-		{"", looppkg.EntitySubscription{EntityID: "sensor.expired", Mode: looppkg.SubscriptionModeIngest, TTLSeconds: 1, AddedAt: now}},
+		{OwnerCore, looppkg.EntitySubscription{EntityID: "sensor.expired", Mode: looppkg.SubscriptionModeIngest, TTLSeconds: 1, AddedAt: now}},
 		// Loop-owned ingest rows feed the filter too — #1209 widened the
 		// read from the always-visible tier to every owner.
 		{"alice", looppkg.EntitySubscription{EntityID: "sensor.loop_owned", Mode: looppkg.SubscriptionModeIngest}},
@@ -80,13 +80,13 @@ func TestIngestGlobs(t *testing.T) {
 // field) and an explicit render row are indistinguishable.
 func TestSubscriptionModeRoundTrip(t *testing.T) {
 	store := newIngestStore(t)
-	if err := store.Upsert("", looppkg.EntitySubscription{EntityID: "sensor.a", Mode: looppkg.SubscriptionModeIngest}); err != nil {
+	if err := store.Upsert(OwnerCore, looppkg.EntitySubscription{EntityID: "sensor.a", Mode: looppkg.SubscriptionModeIngest}); err != nil {
 		t.Fatalf("add: %v", err)
 	}
-	if err := store.Upsert("", looppkg.EntitySubscription{EntityID: "sensor.b"}); err != nil {
+	if err := store.Upsert(OwnerCore, looppkg.EntitySubscription{EntityID: "sensor.b"}); err != nil {
 		t.Fatalf("add plain: %v", err)
 	}
-	rows, err := store.ListOwner("")
+	rows, err := store.ListOwner(OwnerCore)
 	if err != nil {
 		t.Fatalf("list: %v", err)
 	}
@@ -211,14 +211,14 @@ func TestIngestCap(t *testing.T) {
 // posture the store has always had.
 func TestUnknownStoredModeDecodesAsRender(t *testing.T) {
 	store := newIngestStore(t)
-	if err := store.Upsert("", looppkg.EntitySubscription{EntityID: "sensor.future"}); err != nil {
+	if err := store.Upsert(OwnerCore, looppkg.EntitySubscription{EntityID: "sensor.future"}); err != nil {
 		t.Fatalf("add: %v", err)
 	}
 	if _, err := store.db.Exec(
 		`UPDATE watched_entity_subscriptions SET options = '{"mode":"telepathy"}' WHERE entity_id = 'sensor.future'`); err != nil {
 		t.Fatalf("plant unknown mode: %v", err)
 	}
-	rows, err := store.ListOwner("")
+	rows, err := store.ListOwner(OwnerCore)
 	if err != nil {
 		t.Fatalf("list: %v", err)
 	}
@@ -234,10 +234,10 @@ func TestUnknownStoredModeDecodesAsRender(t *testing.T) {
 // watchlist context provider must skip them.
 func TestWatchlistProviderSkipsIngestOnlyRows(t *testing.T) {
 	store := newIngestStore(t)
-	if err := store.Upsert("", looppkg.EntitySubscription{EntityID: "sensor.ingest_only", Mode: looppkg.SubscriptionModeIngest}); err != nil {
+	if err := store.Upsert(OwnerCore, looppkg.EntitySubscription{EntityID: "sensor.ingest_only", Mode: looppkg.SubscriptionModeIngest}); err != nil {
 		t.Fatalf("add: %v", err)
 	}
-	rows, err := store.ListOwner("")
+	rows, err := store.ListOwner(OwnerCore)
 	if err != nil {
 		t.Fatalf("list: %v", err)
 	}
@@ -265,7 +265,7 @@ func TestWatchlistProviderSkipsIngestOnlyRows(t *testing.T) {
 func TestIngestGlobsDerivesFromTransitionLogs(t *testing.T) {
 	store := newIngestStore(t)
 
-	if err := store.Upsert("", looppkg.EntitySubscription{
+	if err := store.Upsert(OwnerCore, looppkg.EntitySubscription{
 		EntityID:    "binary_sensor.garage_bay_3",
 		Transitions: 5,
 	}); err != nil {
@@ -287,7 +287,7 @@ func TestIngestGlobsDerivesFromTransitionLogs(t *testing.T) {
 		t.Fatalf("upsert gated mode row: %v", err)
 	}
 	// Plain render row: no capture.
-	if err := store.Upsert("", looppkg.EntitySubscription{EntityID: "sensor.render_only"}); err != nil {
+	if err := store.Upsert(OwnerCore, looppkg.EntitySubscription{EntityID: "sensor.render_only"}); err != nil {
 		t.Fatalf("upsert render row: %v", err)
 	}
 

--- a/internal/state/awareness/watchlist_lastknown_test.go
+++ b/internal/state/awareness/watchlist_lastknown_test.go
@@ -167,7 +167,7 @@ func TestProvider_UnavailableEntitySurfacesLastKnownGood(t *testing.T) {
 	}
 
 	p, store := setupTestProvider(t, ha)
-	if err := store.Upsert("", looppkg.EntitySubscription{EntityID: "binary_sensor.front_door"}); err != nil {
+	if err := store.Upsert(OwnerCore, looppkg.EntitySubscription{EntityID: "binary_sensor.front_door"}); err != nil {
 		t.Fatalf("add: %v", err)
 	}
 

--- a/internal/state/awareness/watchlist_provider.go
+++ b/internal/state/awareness/watchlist_provider.go
@@ -85,11 +85,13 @@ func (p *WatchlistProvider) SetRegistryClient(registries HARegistryClient) {
 // use a markdown line with state and unit. All timestamps use delta
 // format per #458.
 func (p *WatchlistProvider) TagContext(ctx context.Context, req agentctx.ContextRequest) (string, error) {
-	// Always-visible entities only. Loop-owned rows are rendered by
-	// [LoopSubscriptionProvider] after walking the ancestor chain, and
-	// system-owned rows (the person-entity ingestion floor) never
-	// render — they are ingest-mode by construction.
-	rows, err := p.store.ListOwner("")
+	// The always-visible tier is core's subscriptions (#1208): core is
+	// the root container and every context is de facto core's context.
+	// Loop-owned rows are rendered by [LoopSubscriptionProvider] after
+	// walking the ancestor chain, and system-owned rows (the
+	// person-entity ingestion floor) never render — they are
+	// ingest-mode by construction.
+	rows, err := p.store.ListOwner(looppkg.CoreLoopName)
 	if err != nil {
 		return "", fmt.Errorf("list watched entities: %w", err)
 	}

--- a/internal/state/awareness/watchlist_provider_test.go
+++ b/internal/state/awareness/watchlist_provider_test.go
@@ -119,7 +119,7 @@ func TestProvider_RendersIncludedEntityMetadata(t *testing.T) {
 		Labels:      true,
 		Description: true,
 	}
-	if err := store.Upsert("", looppkg.EntitySubscription{EntityID: state.EntityID, Include: &include}); err != nil {
+	if err := store.Upsert(OwnerCore, looppkg.EntitySubscription{EntityID: state.EntityID, Include: &include}); err != nil {
 		t.Fatalf("Upsert: %v", err)
 	}
 	p.SetRegistryClient(&fakeRegistries{
@@ -183,7 +183,7 @@ func TestProvider_SingleEntity(t *testing.T) {
 	}
 
 	p, store := setupTestProvider(t, ha)
-	if err := store.Upsert("", looppkg.EntitySubscription{EntityID: "sensor.office_temperature"}); err != nil {
+	if err := store.Upsert(OwnerCore, looppkg.EntitySubscription{EntityID: "sensor.office_temperature"}); err != nil {
 		t.Fatalf("add: %v", err)
 	}
 
@@ -215,7 +215,7 @@ func TestProvider_EntityFetchFailure(t *testing.T) {
 	}
 
 	p, store := setupTestProvider(t, ha)
-	if err := store.Upsert("", looppkg.EntitySubscription{EntityID: "sensor.broken"}); err != nil {
+	if err := store.Upsert(OwnerCore, looppkg.EntitySubscription{EntityID: "sensor.broken"}); err != nil {
 		t.Fatalf("add: %v", err)
 	}
 
@@ -266,10 +266,10 @@ func TestProvider_MultipleEntities(t *testing.T) {
 	}
 
 	p, store := setupTestProvider(t, ha)
-	if err := store.Upsert("", looppkg.EntitySubscription{EntityID: "sensor.temperature"}); err != nil {
+	if err := store.Upsert(OwnerCore, looppkg.EntitySubscription{EntityID: "sensor.temperature"}); err != nil {
 		t.Fatalf("add: %v", err)
 	}
-	if err := store.Upsert("", looppkg.EntitySubscription{EntityID: "binary_sensor.door"}); err != nil {
+	if err := store.Upsert(OwnerCore, looppkg.EntitySubscription{EntityID: "binary_sensor.door"}); err != nil {
 		t.Fatalf("add: %v", err)
 	}
 
@@ -305,7 +305,7 @@ func TestProvider_NoFriendlyName(t *testing.T) {
 	}
 
 	p, store := setupTestProvider(t, ha)
-	if err := store.Upsert("", looppkg.EntitySubscription{EntityID: "sensor.raw"}); err != nil {
+	if err := store.Upsert(OwnerCore, looppkg.EntitySubscription{EntityID: "sensor.raw"}); err != nil {
 		t.Fatalf("add: %v", err)
 	}
 
@@ -352,7 +352,7 @@ func TestProvider_IncludesNumericHistorySummaries(t *testing.T) {
 	}
 
 	p, store := setupTestProvider(t, ha)
-	if err := store.Upsert("", looppkg.EntitySubscription{EntityID: "sensor.office_temperature", History: []int{24 * 60 * 60}}); err != nil {
+	if err := store.Upsert(OwnerCore, looppkg.EntitySubscription{EntityID: "sensor.office_temperature", History: []int{24 * 60 * 60}}); err != nil {
 		t.Fatalf("Upsert: %v", err)
 	}
 
@@ -419,7 +419,7 @@ func TestProvider_IncludesWeatherForecastWhenSubscribed(t *testing.T) {
 	}
 
 	p, store := setupTestProvider(t, ha)
-	if err := store.Upsert("", looppkg.EntitySubscription{EntityID: "weather.home", Forecast: "hourly"}); err != nil {
+	if err := store.Upsert(OwnerCore, looppkg.EntitySubscription{EntityID: "weather.home", Forecast: "hourly"}); err != nil {
 		t.Fatalf("Upsert: %v", err)
 	}
 
@@ -479,7 +479,7 @@ func TestProvider_ForecastFetchFailureSurfacesUnavailableMarker(t *testing.T) {
 	}
 
 	p, store := setupTestProvider(t, ha)
-	if err := store.Upsert("", looppkg.EntitySubscription{EntityID: "weather.home", Forecast: "daily"}); err != nil {
+	if err := store.Upsert(OwnerCore, looppkg.EntitySubscription{EntityID: "weather.home", Forecast: "daily"}); err != nil {
 		t.Fatalf("Upsert: %v", err)
 	}
 
@@ -566,7 +566,7 @@ func TestProvider_IncludesDiscreteHistorySummaries(t *testing.T) {
 	}
 
 	p, store := setupTestProvider(t, ha)
-	if err := store.Upsert("", looppkg.EntitySubscription{EntityID: "binary_sensor.front_door", History: []int{24 * 60 * 60}}); err != nil {
+	if err := store.Upsert(OwnerCore, looppkg.EntitySubscription{EntityID: "binary_sensor.front_door", History: []int{24 * 60 * 60}}); err != nil {
 		t.Fatalf("Upsert: %v", err)
 	}
 
@@ -625,7 +625,7 @@ func TestProvider_DiscreteHistoryUsesDeviceClassLabels(t *testing.T) {
 	}
 
 	p, store := setupTestProvider(t, ha)
-	if err := store.Upsert("", looppkg.EntitySubscription{EntityID: "binary_sensor.front_door", History: []int{24 * 60 * 60}}); err != nil {
+	if err := store.Upsert(OwnerCore, looppkg.EntitySubscription{EntityID: "binary_sensor.front_door", History: []int{24 * 60 * 60}}); err != nil {
 		t.Fatalf("Upsert: %v", err)
 	}
 
@@ -692,10 +692,10 @@ func TestWatchlistProviderHonorsRequiresTag(t *testing.T) {
 	}}
 	p, store := setupTestProvider(t, ha)
 
-	if err := store.Upsert("", looppkg.EntitySubscription{EntityID: "sensor.plain"}); err != nil {
+	if err := store.Upsert(OwnerCore, looppkg.EntitySubscription{EntityID: "sensor.plain"}); err != nil {
 		t.Fatalf("upsert plain: %v", err)
 	}
-	if err := store.Upsert("", looppkg.EntitySubscription{EntityID: "sensor.lensed", RequiresTag: "ranch_water"}); err != nil {
+	if err := store.Upsert(OwnerCore, looppkg.EntitySubscription{EntityID: "sensor.lensed", RequiresTag: "ranch_water"}); err != nil {
 		t.Fatalf("upsert lensed: %v", err)
 	}
 
@@ -749,7 +749,7 @@ func TestWatchlistProviderRendersTransitionLog(t *testing.T) {
 	}}
 	p, store := setupTestProvider(t, ha)
 
-	if err := store.Upsert("", looppkg.EntitySubscription{
+	if err := store.Upsert(OwnerCore, looppkg.EntitySubscription{
 		EntityID:    "binary_sensor.garage_bay_3",
 		Transitions: 2,
 	}); err != nil {

--- a/internal/state/awareness/watchlist_schema.go
+++ b/internal/state/awareness/watchlist_schema.go
@@ -25,5 +25,20 @@ var watchlistSchema = database.Schema{
 		// rename is a no-op on fresh databases and on every run after
 		// the first.
 		database.ColumnRename{Table: "watched_entity_subscriptions", From: "scope", To: "owner"},
+		// The former global tier (owner '') belongs to core (#1208's
+		// closing decision): core is the root container and every
+		// context is de facto core's context, so the anonymous tier
+		// was a second name for the same thing. UPDATE OR IGNORE
+		// re-homes rows; a collision with an existing core row keeps
+		// the core row and the DELETE clears the leftover. Both steps
+		// are idempotent no-ops once no '' rows remain.
+		database.Raw{
+			Description: "re-home global-tier subscription rows onto core",
+			SQL:         `UPDATE OR IGNORE watched_entity_subscriptions SET owner = 'core' WHERE owner = ''`,
+		},
+		database.Raw{
+			Description: "drop global-tier rows that collided with core rows",
+			SQL:         `DELETE FROM watched_entity_subscriptions WHERE owner = ''`,
+		},
 	},
 }

--- a/internal/state/awareness/watchlist_schema.go
+++ b/internal/state/awareness/watchlist_schema.go
@@ -5,9 +5,10 @@ import "github.com/nugget/thane-ai-agent/internal/platform/database"
 // watchlistSchema declares the watched_entity_subscriptions table: the
 // one subscription registry, keyed by (owner, entity_id). The legacy
 // watched_entities migration was retired in #776; the scope→owner
-// rename (#1209) retired the tag-scoped tier — the column now names
-// the owning loop (” = always-visible, [OwnerSystem] = runtime-seeded)
-// instead of a capability-tag scope.
+// rename (#1209) retired the tag-scoped tier — the column names the
+// owning loop ([OwnerCore] = the always-visible tier, [OwnerSystem] =
+// runtime-seeded) instead of a capability-tag scope; #1208's closing
+// steps below re-home the formerly anonymous tier onto core.
 var watchlistSchema = database.Schema{
 	Name: "awareness/watchlist",
 	Steps: []database.MigrationStep{

--- a/internal/state/awareness/watchlist_schema.go
+++ b/internal/state/awareness/watchlist_schema.go
@@ -26,19 +26,15 @@ var watchlistSchema = database.Schema{
 		// rename is a no-op on fresh databases and on every run after
 		// the first.
 		database.ColumnRename{Table: "watched_entity_subscriptions", From: "scope", To: "owner"},
-		// The former global tier (owner '') belongs to core (#1208's
-		// closing decision): core is the root container and every
-		// context is de facto core's context, so the anonymous tier
-		// was a second name for the same thing. UPDATE OR IGNORE
-		// re-homes rows; a collision with an existing core row keeps
-		// the core row and the DELETE clears the leftover. Both steps
-		// are idempotent no-ops once no '' rows remain.
+		// The former global tier (empty owner) belongs to core
+		// (#1208's closing decision) — but its legacy rows are NOT
+		// migrated: the owner chose to re-evaluate the subscription
+		// set by hand rather than carry old choices forward
+		// mechanically, so the anonymous tier is simply cleared.
+		// Idempotent: once no empty-owner rows remain (the store
+		// refuses to write them), this is a permanent no-op.
 		database.Raw{
-			Description: "re-home global-tier subscription rows onto core",
-			SQL:         `UPDATE OR IGNORE watched_entity_subscriptions SET owner = 'core' WHERE owner = ''`,
-		},
-		database.Raw{
-			Description: "drop global-tier rows that collided with core rows",
+			Description: "clear the retired anonymous subscription tier",
 			SQL:         `DELETE FROM watched_entity_subscriptions WHERE owner = ''`,
 		},
 	},

--- a/internal/state/awareness/watchlist_store.go
+++ b/internal/state/awareness/watchlist_store.go
@@ -24,16 +24,16 @@ const OwnerSystem = "system"
 // container and every context is de facto core's context, so the
 // formerly anonymous global tier — rows persisted with an empty owner
 // before #1208's closing decision — collapsed into rows core owns
-// directly. Core has no persisted
-// definition by design — the bootstrap owns its lifecycle — so unlike
-// other loop owners these rows are the source of truth themselves,
-// mutated store-direct by the tools rather than compiled from a spec;
-// the spec mirror and orphan sweep skip this owner accordingly.
+// directly. Core has no persisted definition by design (the bootstrap
+// owns its lifecycle), so unlike other loop owners these rows are the
+// source of truth themselves, mutated store-direct by the tools
+// rather than compiled from a spec; the spec mirror and orphan sweep
+// skip this owner accordingly.
 const OwnerCore = looppkg.CoreLoopName
 
 // SubscriptionRow is one persisted registry entry: an owner plus the
-// unified subscription declaration. Owner ” means always-visible (the
-// global tier every turn renders), [OwnerSystem] marks runtime-seeded
+// unified subscription declaration. [OwnerCore] is the always-visible
+// tier every context renders, [OwnerSystem] marks runtime-seeded
 // rows, and any other value is the owning loop's definition name —
 // loop rows are compiled from Spec.Subscriptions and replaced whenever
 // the spec persists.
@@ -99,8 +99,8 @@ func (s *WatchlistStore) Remove(owner, entityID string) error {
 
 // RemoveAllForOwner deletes every subscription row belonging to the
 // given owner. Used when the owning loop definition is deleted and by
-// [WatchlistStore.ReplaceOwner]. The global tier (owner ”) is never
-// bulk-deleted; owner is required.
+// [WatchlistStore.ReplaceOwner]. Owner is required — there is no
+// anonymous tier left to address.
 func (s *WatchlistStore) RemoveAllForOwner(owner string) error {
 	owner = strings.TrimSpace(owner)
 	if owner == "" {
@@ -166,9 +166,11 @@ func (s *WatchlistStore) ReplaceOwner(owner string, subs []looppkg.EntitySubscri
 	return nil
 }
 
-// Owners returns the distinct owners present in the registry,
-// excluding the global tier (”). Consumed by the startup orphan sweep
-// to find rows whose owning definition no longer exists.
+// Owners returns the distinct owners present in the registry
+// (defensively excluding any legacy empty-owner rows, which the
+// schema migration re-homes onto [OwnerCore]). Consumed by the
+// startup orphan sweep to find rows whose owning definition no
+// longer exists; reserved owners are the sweep's concern to skip.
 func (s *WatchlistStore) Owners() ([]string, error) {
 	rows, err := s.db.Query(
 		`SELECT DISTINCT owner FROM watched_entity_subscriptions WHERE owner != '' ORDER BY owner ASC`)
@@ -197,8 +199,8 @@ func (s *WatchlistStore) ListAll() ([]SubscriptionRow, error) {
 }
 
 // ListOwner returns the active subscription rows for one owner in
-// insertion order; ” selects the always-visible global tier. Expired
-// rows are reaped as a side effect.
+// insertion order; [OwnerCore] selects the always-visible tier.
+// Expired rows are reaped as a side effect.
 func (s *WatchlistStore) ListOwner(owner string) ([]SubscriptionRow, error) {
 	return s.scanActiveSubscriptions(
 		`SELECT entity_id, owner, added_at, options FROM watched_entity_subscriptions

--- a/internal/state/awareness/watchlist_store.go
+++ b/internal/state/awareness/watchlist_store.go
@@ -353,10 +353,7 @@ func (s *WatchlistStore) subscriptionCount() (int, error) {
 // subscriptionOptionsWire is the options-blob JSON shape. It carries
 // the declaration fields of [looppkg.EntitySubscription] that don't
 // have their own column; entity_id, owner, and added_at live on the
-// row. ExpiresAt is decode-only: pre-#1209 rows persisted an absolute
-// expiry instead of ttl_seconds, and the shim in
-// parseSubscriptionOptions converts it back against the row's
-// added_at so old TTLs keep counting down unchanged.
+// row.
 type subscriptionOptionsWire struct {
 	History                  []int                                 `json:"history,omitempty"`
 	Forecast                 string                                `json:"forecast,omitempty"`
@@ -369,7 +366,6 @@ type subscriptionOptionsWire struct {
 	TransitionsWindowSeconds int                                   `json:"transitions_window_seconds,omitempty"`
 	Wake                     bool                                  `json:"wake,omitempty"`
 	WakeDebounceSeconds      int                                   `json:"wake_debounce_seconds,omitempty"`
-	ExpiresAt                string                                `json:"expires_at,omitempty"`
 }
 
 func marshalSubscriptionOptions(sub looppkg.EntitySubscription) ([]byte, error) {
@@ -445,19 +441,6 @@ func parseSubscriptionOptions(optsJSON string, addedAt time.Time) looppkg.Entity
 	}
 	if wire.TTLSeconds > 0 {
 		sub.TTLSeconds = wire.TTLSeconds
-	} else if wire.ExpiresAt != "" {
-		// Legacy absolute-expiry row: recover the TTL against the
-		// row's added_at anchor. An expiry at or before added_at
-		// (clock skew, an already-elapsed row) maps to a 1-second
-		// TTL so the expiry sweep reaps it on this pass instead of
-		// resurrecting it as immortal.
-		if ts, err := time.Parse(time.RFC3339, wire.ExpiresAt); err == nil {
-			ttl := int(ts.UTC().Sub(addedAt).Seconds())
-			if ttl <= 0 {
-				ttl = 1
-			}
-			sub.TTLSeconds = ttl
-		}
 	}
 	return sub
 }

--- a/internal/state/awareness/watchlist_store.go
+++ b/internal/state/awareness/watchlist_store.go
@@ -20,6 +20,16 @@ import (
 // mutation; the configuration is their source of truth.
 const OwnerSystem = "system"
 
+// OwnerCore is the owner of the always-visible tier: core is the root
+// container and every context is de facto core's context, so the
+// formerly anonymous global tier (owner ”) collapsed into rows core
+// owns directly (#1208's closing decision). Core has no persisted
+// definition by design — the bootstrap owns its lifecycle — so unlike
+// other loop owners these rows are the source of truth themselves,
+// mutated store-direct by the tools rather than compiled from a spec;
+// the spec mirror and orphan sweep skip this owner accordingly.
+const OwnerCore = looppkg.CoreLoopName
+
 // SubscriptionRow is one persisted registry entry: an owner plus the
 // unified subscription declaration. Owner ” means always-visible (the
 // global tier every turn renders), [OwnerSystem] marks runtime-seeded
@@ -47,7 +57,12 @@ func NewWatchlistStore(db *sql.DB, logger *slog.Logger) (*WatchlistStore, error)
 // Upsert inserts or replaces the subscription for (owner, entity_id).
 // A zero AddedAt is stamped with the current time so TTL countdown is
 // always anchored; re-upserting an entity restarts its TTL window.
+// Owner is required: the anonymous tier collapsed into [OwnerCore],
+// so an ownerless row has no meaning left.
 func (s *WatchlistStore) Upsert(owner string, sub looppkg.EntitySubscription) error {
+	if strings.TrimSpace(owner) == "" {
+		return fmt.Errorf("owner is required (the always-visible tier is %q)", OwnerCore)
+	}
 	if strings.TrimSpace(sub.EntityID) == "" {
 		return fmt.Errorf("entity_id is required")
 	}
@@ -191,8 +206,8 @@ func (s *WatchlistStore) ListOwner(owner string) ([]SubscriptionRow, error) {
 	)
 }
 
-// GlobalEntityGates returns, for each candidate whose always-visible
-// row (owner=”) can render at all — state-rendering mode, not expired
+// CoreEntityGates returns, for each candidate whose always-visible
+// row (owner [OwnerCore]) can render at all — state-rendering mode, not expired
 // — that row's RequiresTag gate ("" for an ungated row). Rows that
 // never render (ingest-only, elapsed TTL) are omitted entirely, so
 // they cannot suppress a loop-scoped render of the same entity;
@@ -206,7 +221,7 @@ func (s *WatchlistStore) ListOwner(owner string) ([]SubscriptionRow, error) {
 // the always-visible [WatchlistProvider]'s own pass so we don't
 // double-write deletes. Returns an empty (non-nil) map when
 // candidates is empty.
-func (s *WatchlistStore) GlobalEntityGates(candidates []string) (map[string]string, error) {
+func (s *WatchlistStore) CoreEntityGates(candidates []string) (map[string]string, error) {
 	out := make(map[string]string, len(candidates))
 	if len(candidates) == 0 {
 		return out, nil
@@ -232,7 +247,7 @@ func (s *WatchlistStore) GlobalEntityGates(candidates []string) (map[string]stri
 	placeholders := strings.Repeat("?,", len(args))
 	placeholders = placeholders[:len(placeholders)-1]
 	query := `SELECT entity_id, added_at, options FROM watched_entity_subscriptions
-		 WHERE owner = '' AND entity_id IN (` + placeholders + `)`
+		 WHERE owner = '` + OwnerCore + `' AND entity_id IN (` + placeholders + `)`
 	rows, err := s.db.Query(query, args...)
 	if err != nil {
 		return nil, err

--- a/internal/state/awareness/watchlist_store.go
+++ b/internal/state/awareness/watchlist_store.go
@@ -22,8 +22,9 @@ const OwnerSystem = "system"
 
 // OwnerCore is the owner of the always-visible tier: core is the root
 // container and every context is de facto core's context, so the
-// formerly anonymous global tier (owner ”) collapsed into rows core
-// owns directly (#1208's closing decision). Core has no persisted
+// formerly anonymous global tier — rows persisted with an empty owner
+// before #1208's closing decision — collapsed into rows core owns
+// directly. Core has no persisted
 // definition by design — the bootstrap owns its lifecycle — so unlike
 // other loop owners these rows are the source of truth themselves,
 // mutated store-direct by the tools rather than compiled from a spec;
@@ -247,8 +248,8 @@ func (s *WatchlistStore) CoreEntityGates(candidates []string) (map[string]string
 	placeholders := strings.Repeat("?,", len(args))
 	placeholders = placeholders[:len(placeholders)-1]
 	query := `SELECT entity_id, added_at, options FROM watched_entity_subscriptions
-		 WHERE owner = '` + OwnerCore + `' AND entity_id IN (` + placeholders + `)`
-	rows, err := s.db.Query(query, args...)
+		 WHERE owner = ? AND entity_id IN (` + placeholders + `)`
+	rows, err := s.db.Query(query, append([]any{OwnerCore}, args...)...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/state/awareness/watchlist_store_test.go
+++ b/internal/state/awareness/watchlist_store_test.go
@@ -2,7 +2,6 @@ package awareness
 
 import (
 	"database/sql"
-	"encoding/json"
 	"slices"
 	"strings"
 	"testing"
@@ -277,44 +276,6 @@ func TestStore_ExpiredRowsAreReapedOnScan(t *testing.T) {
 	}
 }
 
-// TestStore_LegacyExpiresAtShim covers pre-#1209 rows whose options
-// blob carried an absolute expires_at instead of ttl_seconds: a
-// still-live expiry keeps counting down against the added_at column,
-// and an elapsed one is reaped on the next scan.
-func TestStore_LegacyExpiresAtShim(t *testing.T) {
-	store := setupTestStore(t)
-
-	insertLegacy := func(entityID, expiresAt string) {
-		t.Helper()
-		optsJSON, err := json.Marshal(map[string]any{"expires_at": expiresAt})
-		if err != nil {
-			t.Fatalf("marshal legacy options: %v", err)
-		}
-		if _, err := store.db.Exec(
-			`INSERT INTO watched_entity_subscriptions (entity_id, owner, added_at, options) VALUES (?, 'core', ?, ?)`,
-			entityID, time.Now().UTC().Add(-time.Minute), string(optsJSON),
-		); err != nil {
-			t.Fatalf("insert legacy row: %v", err)
-		}
-	}
-
-	insertLegacy("sensor.legacy_live", time.Now().UTC().Add(time.Hour).Format(time.RFC3339))
-	insertLegacy("sensor.legacy_elapsed", time.Now().UTC().Add(-time.Minute).Format(time.RFC3339))
-
-	rows, err := store.ListOwner(OwnerCore)
-	if err != nil {
-		t.Fatalf("ListOwner: %v", err)
-	}
-	if len(rows) != 1 || rows[0].EntityID != "sensor.legacy_live" {
-		t.Fatalf("rows = %+v, want only sensor.legacy_live to survive", rows)
-	}
-	// Recovered TTL ≈ expires_at − added_at ≈ 61 minutes; assert the
-	// order of magnitude rather than an exact second to stay clock-safe.
-	if rows[0].TTLSeconds < 3600 || rows[0].TTLSeconds > 3780 {
-		t.Errorf("recovered ttl = %ds, want ~3660s", rows[0].TTLSeconds)
-	}
-}
-
 // TestStore_MigratesLegacyScopeColumn proves the scope→owner column
 // rename lands on a database created with the pre-#1209 schema and
 // that its rows stay readable afterwards.
@@ -334,8 +295,11 @@ func TestStore_MigratesLegacyScopeColumn(t *testing.T) {
 	)`); err != nil {
 		t.Fatalf("create legacy table: %v", err)
 	}
+	// Seed under a NAMED owner: anonymous-tier rows are deliberately
+	// cleared (not migrated) by the #1208 closing step, so the rename
+	// mechanics are proven on a row that survives.
 	if _, err := db.Exec(
-		`INSERT INTO watched_entity_subscriptions (entity_id, scope, options) VALUES ('sensor.pre_rename', '', '{}')`,
+		`INSERT INTO watched_entity_subscriptions (entity_id, scope, options) VALUES ('sensor.pre_rename', 'kitchen-watcher', '{}')`,
 	); err != nil {
 		t.Fatalf("insert legacy row: %v", err)
 	}
@@ -345,8 +309,12 @@ func TestStore_MigratesLegacyScopeColumn(t *testing.T) {
 		t.Fatalf("new store over legacy schema: %v", err)
 	}
 
-	if ids := globalEntityIDs(t, store); !slices.Equal(ids, []string{"sensor.pre_rename"}) {
-		t.Errorf("post-migration ids = %v, want [sensor.pre_rename]", ids)
+	rows, err := store.ListOwner("kitchen-watcher")
+	if err != nil {
+		t.Fatalf("ListOwner: %v", err)
+	}
+	if len(rows) != 1 || rows[0].EntityID != "sensor.pre_rename" {
+		t.Errorf("post-migration rows = %+v, want [sensor.pre_rename] under the renamed owner column", rows)
 	}
 
 	// A second migration pass must be a no-op.
@@ -440,19 +408,19 @@ func TestStore_CoreEntityGates(t *testing.T) {
 	}
 }
 
-// TestStore_MigratesGlobalTierOntoCore proves the #1208 closing
-// migration: rows persisted under the anonymous global tier (”) are
-// re-homed onto core at store open, with a collision against an
-// existing core row resolved in the core row's favor.
-func TestStore_MigratesGlobalTierOntoCore(t *testing.T) {
+// TestStore_ClearsRetiredAnonymousTier proves the #1208 closing
+// posture: legacy empty-owner rows are deliberately NOT migrated onto
+// core — the owner re-evaluates the subscription set by hand — so the
+// schema migration clears them, leaves genuine core rows untouched,
+// and is a no-op on every subsequent open.
+func TestStore_ClearsRetiredAnonymousTier(t *testing.T) {
 	db, err := sql.Open("sqlite-thane", ":memory:")
 	if err != nil {
 		t.Fatalf("open db: %v", err)
 	}
 	t.Cleanup(func() { db.Close() })
 
-	// Pre-#1208 shape: the table with '' rows, one of which collides
-	// with a core-owned row.
+	// Pre-#1208 shape: anonymous-tier rows alongside a core-owned row.
 	if _, err := db.Exec(`CREATE TABLE watched_entity_subscriptions (
 		entity_id TEXT NOT NULL,
 		owner     TEXT NOT NULL DEFAULT '',
@@ -462,18 +430,18 @@ func TestStore_MigratesGlobalTierOntoCore(t *testing.T) {
 	)`); err != nil {
 		t.Fatalf("create legacy table: %v", err)
 	}
-	seed := func(entity, owner, options string) {
-		t.Helper()
+	for _, row := range [][2]string{
+		{"sensor.legacy_one", ""},
+		{"sensor.legacy_two", ""},
+		{"sensor.kept", "core"},
+	} {
 		if _, err := db.Exec(
-			`INSERT INTO watched_entity_subscriptions (entity_id, owner, options) VALUES (?, ?, ?)`,
-			entity, owner, options,
+			`INSERT INTO watched_entity_subscriptions (entity_id, owner) VALUES (?, ?)`,
+			row[0], row[1],
 		); err != nil {
-			t.Fatalf("seed %s/%s: %v", owner, entity, err)
+			t.Fatalf("seed %s: %v", row[0], err)
 		}
 	}
-	seed("sensor.plain", "", "{}")
-	seed("sensor.collide", "", `{"history":[600]}`)
-	seed("sensor.collide", "core", `{"history":[3600]}`)
 
 	store, err := NewWatchlistStore(db, nil)
 	if err != nil {
@@ -484,29 +452,17 @@ func TestStore_MigratesGlobalTierOntoCore(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ListOwner(core): %v", err)
 	}
-	byEntity := make(map[string][]int, len(rows))
-	for _, row := range rows {
-		byEntity[row.EntityID] = row.History
+	if len(rows) != 1 || rows[0].EntityID != "sensor.kept" {
+		t.Fatalf("core rows = %+v, want only the pre-existing core row", rows)
 	}
-	if len(byEntity) != 2 {
-		t.Fatalf("core rows = %v, want re-homed plain + surviving collide", byEntity)
-	}
-	if _, ok := byEntity["sensor.plain"]; !ok {
-		t.Error("sensor.plain not re-homed onto core")
-	}
-	if h := byEntity["sensor.collide"]; len(h) != 1 || h[0] != 3600 {
-		t.Errorf("collision history = %v, want the core row (3600) to win", h)
-	}
-
-	// No anonymous rows remain, and a second open is a no-op.
 	var leftover int
 	if err := db.QueryRow(`SELECT COUNT(*) FROM watched_entity_subscriptions WHERE owner = ''`).Scan(&leftover); err != nil {
 		t.Fatalf("count leftovers: %v", err)
 	}
 	if leftover != 0 {
-		t.Errorf("leftover '' rows = %d, want 0", leftover)
+		t.Errorf("leftover anonymous rows = %d, want cleared", leftover)
 	}
 	if _, err := NewWatchlistStore(db, nil); err != nil {
-		t.Fatalf("re-migrate: %v", err)
+		t.Fatalf("re-open: %v", err)
 	}
 }

--- a/internal/state/awareness/watchlist_store_test.go
+++ b/internal/state/awareness/watchlist_store_test.go
@@ -29,7 +29,7 @@ func setupTestStore(t *testing.T) *WatchlistStore {
 
 func globalEntityIDs(t *testing.T, store *WatchlistStore) []string {
 	t.Helper()
-	rows, err := store.ListOwner("")
+	rows, err := store.ListOwner(OwnerCore)
 	if err != nil {
 		t.Fatalf("ListOwner(\"\"): %v", err)
 	}
@@ -55,11 +55,11 @@ func TestStore_ListEmpty(t *testing.T) {
 func TestStore_UpsertAndListPreservesInsertionOrder(t *testing.T) {
 	store := setupTestStore(t)
 
-	if err := store.Upsert("", looppkg.EntitySubscription{EntityID: "sensor.office_temperature"}); err != nil {
+	if err := store.Upsert(OwnerCore, looppkg.EntitySubscription{EntityID: "sensor.office_temperature"}); err != nil {
 		t.Fatalf("upsert: %v", err)
 	}
 	// Distinct AddedAt so ORDER BY added_at is deterministic.
-	if err := store.Upsert("", looppkg.EntitySubscription{
+	if err := store.Upsert(OwnerCore, looppkg.EntitySubscription{
 		EntityID: "binary_sensor.front_door",
 		AddedAt:  time.Now().UTC().Add(time.Second),
 	}); err != nil {
@@ -75,17 +75,17 @@ func TestStore_UpsertAndListPreservesInsertionOrder(t *testing.T) {
 func TestStore_UpsertReplacesInsteadOfDuplicating(t *testing.T) {
 	store := setupTestStore(t)
 
-	if err := store.Upsert("", looppkg.EntitySubscription{EntityID: "sensor.temperature"}); err != nil {
+	if err := store.Upsert(OwnerCore, looppkg.EntitySubscription{EntityID: "sensor.temperature"}); err != nil {
 		t.Fatalf("upsert: %v", err)
 	}
-	if err := store.Upsert("", looppkg.EntitySubscription{
+	if err := store.Upsert(OwnerCore, looppkg.EntitySubscription{
 		EntityID: "sensor.temperature",
 		History:  []int{600},
 	}); err != nil {
 		t.Fatalf("re-upsert: %v", err)
 	}
 
-	rows, err := store.ListOwner("")
+	rows, err := store.ListOwner(OwnerCore)
 	if err != nil {
 		t.Fatalf("ListOwner: %v", err)
 	}
@@ -147,17 +147,17 @@ func TestStore_UpsertRoundTripsUnifiedOptions(t *testing.T) {
 func TestStore_UpsertRejectsInvalidOptions(t *testing.T) {
 	store := setupTestStore(t)
 
-	if err := store.Upsert("", looppkg.EntitySubscription{EntityID: "weather.home", Forecast: "monthly"}); err == nil {
+	if err := store.Upsert(OwnerCore, looppkg.EntitySubscription{EntityID: "weather.home", Forecast: "monthly"}); err == nil {
 		t.Fatal("expected invalid forecast error")
 	} else if !strings.Contains(err.Error(), "forecast must be one of") {
 		t.Fatalf("error = %q, want forecast validation", err.Error())
 	}
 
-	if err := store.Upsert("", looppkg.EntitySubscription{EntityID: "sensor.a", Mode: "firehose"}); err == nil {
+	if err := store.Upsert(OwnerCore, looppkg.EntitySubscription{EntityID: "sensor.a", Mode: "firehose"}); err == nil {
 		t.Fatal("expected invalid mode error")
 	}
 
-	if err := store.Upsert("", looppkg.EntitySubscription{EntityID: ""}); err == nil {
+	if err := store.Upsert(OwnerCore, looppkg.EntitySubscription{EntityID: ""}); err == nil {
 		t.Fatal("expected entity_id required error")
 	}
 }
@@ -165,7 +165,7 @@ func TestStore_UpsertRejectsInvalidOptions(t *testing.T) {
 func TestStore_RemoveIsOwnerExact(t *testing.T) {
 	store := setupTestStore(t)
 
-	if err := store.Upsert("", looppkg.EntitySubscription{EntityID: "sensor.battery"}); err != nil {
+	if err := store.Upsert(OwnerCore, looppkg.EntitySubscription{EntityID: "sensor.battery"}); err != nil {
 		t.Fatalf("upsert global: %v", err)
 	}
 	if err := store.Upsert("battery-watcher", looppkg.EntitySubscription{EntityID: "sensor.battery"}); err != nil {
@@ -225,10 +225,10 @@ func TestStore_ReplaceOwnerIsAtomicAndSkipsExpired(t *testing.T) {
 	}
 }
 
-func TestStore_OwnersExcludesGlobalTier(t *testing.T) {
+func TestStore_OwnersListsReservedAndLoopOwners(t *testing.T) {
 	store := setupTestStore(t)
 
-	if err := store.Upsert("", looppkg.EntitySubscription{EntityID: "sensor.global"}); err != nil {
+	if err := store.Upsert(OwnerCore, looppkg.EntitySubscription{EntityID: "sensor.global"}); err != nil {
 		t.Fatalf("upsert: %v", err)
 	}
 	if err := store.Upsert("loop-b", looppkg.EntitySubscription{EntityID: "sensor.b"}); err != nil {
@@ -242,8 +242,10 @@ func TestStore_OwnersExcludesGlobalTier(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Owners: %v", err)
 	}
-	if !slices.Equal(owners, []string{"loop-b", OwnerSystem}) {
-		t.Errorf("owners = %v, want [loop-b system]", owners)
+	// Core appears like any other owner post-#1208; the orphan sweep
+	// is what treats it (and system) as reserved.
+	if !slices.Equal(owners, []string{OwnerCore, "loop-b", OwnerSystem}) {
+		t.Errorf("owners = %v, want [core loop-b system]", owners)
 	}
 }
 
@@ -289,7 +291,7 @@ func TestStore_LegacyExpiresAtShim(t *testing.T) {
 			t.Fatalf("marshal legacy options: %v", err)
 		}
 		if _, err := store.db.Exec(
-			`INSERT INTO watched_entity_subscriptions (entity_id, owner, added_at, options) VALUES (?, '', ?, ?)`,
+			`INSERT INTO watched_entity_subscriptions (entity_id, owner, added_at, options) VALUES (?, 'core', ?, ?)`,
 			entityID, time.Now().UTC().Add(-time.Minute), string(optsJSON),
 		); err != nil {
 			t.Fatalf("insert legacy row: %v", err)
@@ -299,7 +301,7 @@ func TestStore_LegacyExpiresAtShim(t *testing.T) {
 	insertLegacy("sensor.legacy_live", time.Now().UTC().Add(time.Hour).Format(time.RFC3339))
 	insertLegacy("sensor.legacy_elapsed", time.Now().UTC().Add(-time.Minute).Format(time.RFC3339))
 
-	rows, err := store.ListOwner("")
+	rows, err := store.ListOwner(OwnerCore)
 	if err != nil {
 		t.Fatalf("ListOwner: %v", err)
 	}
@@ -353,21 +355,21 @@ func TestStore_MigratesLegacyScopeColumn(t *testing.T) {
 	}
 }
 
-// TestStore_GlobalEntityGates covers the narrow dedup lookup used by
+// TestStore_CoreEntityGates covers the narrow dedup lookup used by
 // [LoopSubscriptionProvider]: it must return only the candidates
 // present in the always-visible (owner=”) tier — each with its
 // RequiresTag gate so the caller can ignore gated-off rows — ignore
 // owned rows for the same entity_id, and skip the TTL cleanup side
 // effect that [ListOwner] performs.
-func TestStore_GlobalEntityGates(t *testing.T) {
+func TestStore_CoreEntityGates(t *testing.T) {
 	store := setupTestStore(t)
 
 	// Global ungated → present with an empty gate.
-	if err := store.Upsert("", looppkg.EntitySubscription{EntityID: "sensor.always_on"}); err != nil {
+	if err := store.Upsert(OwnerCore, looppkg.EntitySubscription{EntityID: "sensor.always_on"}); err != nil {
 		t.Fatalf("upsert: %v", err)
 	}
 	// Global gated → present with its gate exposed.
-	if err := store.Upsert("", looppkg.EntitySubscription{EntityID: "sensor.lensed", RequiresTag: "ranch_water"}); err != nil {
+	if err := store.Upsert(OwnerCore, looppkg.EntitySubscription{EntityID: "sensor.lensed", RequiresTag: "ranch_water"}); err != nil {
 		t.Fatalf("upsert gated: %v", err)
 	}
 	// Loop-owned → NOT in the always-visible set even though the
@@ -377,10 +379,10 @@ func TestStore_GlobalEntityGates(t *testing.T) {
 	}
 	// Rows that never render must not appear at all: ingest-only mode
 	// and elapsed TTL (Copilot #1214).
-	if err := store.Upsert("", looppkg.EntitySubscription{EntityID: "sensor.capture_only", Mode: looppkg.SubscriptionModeIngest}); err != nil {
+	if err := store.Upsert(OwnerCore, looppkg.EntitySubscription{EntityID: "sensor.capture_only", Mode: looppkg.SubscriptionModeIngest}); err != nil {
 		t.Fatalf("upsert ingest-only: %v", err)
 	}
-	if err := store.Upsert("", looppkg.EntitySubscription{
+	if err := store.Upsert(OwnerCore, looppkg.EntitySubscription{
 		EntityID:   "sensor.elapsed",
 		TTLSeconds: 60,
 		AddedAt:    time.Now().UTC().Add(-time.Hour),
@@ -388,7 +390,7 @@ func TestStore_GlobalEntityGates(t *testing.T) {
 		t.Fatalf("upsert elapsed: %v", err)
 	}
 
-	gates, err := store.GlobalEntityGates([]string{
+	gates, err := store.CoreEntityGates([]string{
 		"sensor.always_on",
 		"sensor.lensed",
 		"sensor.owned_only",
@@ -397,7 +399,7 @@ func TestStore_GlobalEntityGates(t *testing.T) {
 		"sensor.unknown",
 	})
 	if err != nil {
-		t.Fatalf("GlobalEntityGates: %v", err)
+		t.Fatalf("CoreEntityGates: %v", err)
 	}
 	if gate, ok := gates["sensor.always_on"]; !ok || gate != "" {
 		t.Errorf("sensor.always_on gate = %q,%v, want present and ungated", gate, ok)
@@ -419,9 +421,9 @@ func TestStore_GlobalEntityGates(t *testing.T) {
 	}
 
 	// Empty candidate list returns an empty (non-nil) map.
-	empty, err := store.GlobalEntityGates(nil)
+	empty, err := store.CoreEntityGates(nil)
 	if err != nil {
-		t.Fatalf("GlobalEntityGates(nil): %v", err)
+		t.Fatalf("CoreEntityGates(nil): %v", err)
 	}
 	if empty == nil || len(empty) != 0 {
 		t.Errorf("want empty non-nil map, got %#v", empty)
@@ -429,11 +431,82 @@ func TestStore_GlobalEntityGates(t *testing.T) {
 
 	// Duplicates and empty strings in the candidate list are
 	// tolerated (deduped + filtered before the SQL IN clause).
-	gates2, err := store.GlobalEntityGates([]string{"sensor.always_on", "sensor.always_on", ""})
+	gates2, err := store.CoreEntityGates([]string{"sensor.always_on", "sensor.always_on", ""})
 	if err != nil {
-		t.Fatalf("GlobalEntityGates dedup: %v", err)
+		t.Fatalf("CoreEntityGates dedup: %v", err)
 	}
 	if len(gates2) != 1 {
 		t.Errorf("want exactly 1 entry after dedup, got %v", gates2)
+	}
+}
+
+// TestStore_MigratesGlobalTierOntoCore proves the #1208 closing
+// migration: rows persisted under the anonymous global tier (”) are
+// re-homed onto core at store open, with a collision against an
+// existing core row resolved in the core row's favor.
+func TestStore_MigratesGlobalTierOntoCore(t *testing.T) {
+	db, err := sql.Open("sqlite-thane", ":memory:")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+
+	// Pre-#1208 shape: the table with '' rows, one of which collides
+	// with a core-owned row.
+	if _, err := db.Exec(`CREATE TABLE watched_entity_subscriptions (
+		entity_id TEXT NOT NULL,
+		owner     TEXT NOT NULL DEFAULT '',
+		added_at  TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+		options   TEXT NOT NULL DEFAULT '{}',
+		PRIMARY KEY (owner, entity_id)
+	)`); err != nil {
+		t.Fatalf("create legacy table: %v", err)
+	}
+	seed := func(entity, owner, options string) {
+		t.Helper()
+		if _, err := db.Exec(
+			`INSERT INTO watched_entity_subscriptions (entity_id, owner, options) VALUES (?, ?, ?)`,
+			entity, owner, options,
+		); err != nil {
+			t.Fatalf("seed %s/%s: %v", owner, entity, err)
+		}
+	}
+	seed("sensor.plain", "", "{}")
+	seed("sensor.collide", "", `{"history":[600]}`)
+	seed("sensor.collide", "core", `{"history":[3600]}`)
+
+	store, err := NewWatchlistStore(db, nil)
+	if err != nil {
+		t.Fatalf("new store over legacy tier: %v", err)
+	}
+
+	rows, err := store.ListOwner(OwnerCore)
+	if err != nil {
+		t.Fatalf("ListOwner(core): %v", err)
+	}
+	byEntity := make(map[string][]int, len(rows))
+	for _, row := range rows {
+		byEntity[row.EntityID] = row.History
+	}
+	if len(byEntity) != 2 {
+		t.Fatalf("core rows = %v, want re-homed plain + surviving collide", byEntity)
+	}
+	if _, ok := byEntity["sensor.plain"]; !ok {
+		t.Error("sensor.plain not re-homed onto core")
+	}
+	if h := byEntity["sensor.collide"]; len(h) != 1 || h[0] != 3600 {
+		t.Errorf("collision history = %v, want the core row (3600) to win", h)
+	}
+
+	// No anonymous rows remain, and a second open is a no-op.
+	var leftover int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM watched_entity_subscriptions WHERE owner = ''`).Scan(&leftover); err != nil {
+		t.Fatalf("count leftovers: %v", err)
+	}
+	if leftover != 0 {
+		t.Errorf("leftover '' rows = %d, want 0", leftover)
+	}
+	if _, err := NewWatchlistStore(db, nil); err != nil {
+		t.Fatalf("re-migrate: %v", err)
 	}
 }

--- a/internal/state/awareness/watchlist_tool_provider.go
+++ b/internal/state/awareness/watchlist_tool_provider.go
@@ -99,13 +99,13 @@ func retiredTagsError(param string) error {
 func (w *WatchlistTools) Tools() []*tools.Tool {
 	ownerParam := map[string]any{
 		"type":        "string",
-		"description": "Who owns the subscription. Omit for an always-visible subscription (appears on every turn — your own field of view). Pass a loop definition name to subscribe that loop instead: the entry lands on its spec's subscriptions and follows the loop's lifecycle. From inside a loop's own turn, prefer watch_entity (no name needed). The reserved owner \"system\" is read-only (runtime-seeded rows such as the person-presence ingestion floor, configured via person.track).",
+		"description": "Who owns the subscription. Omit (or pass \"core\") for an always-visible subscription: it lands on core — the root container whose context every turn shares — and appears everywhere. Pass a loop definition name to subscribe that loop instead: the entry lands on its spec's subscriptions and follows the loop's lifecycle. From inside a loop's own turn, prefer watch_entity (no name needed). The reserved owner \"system\" is read-only (runtime-seeded rows such as the person-presence ingestion floor, configured via person.track).",
 	}
 	return []*tools.Tool{
 		{
 			Name: "add_entity_subscription",
 			Description: "Subscribe to a Home Assistant entity so its live state is injected into the model's context. " +
-				"Without owner this adds an always-visible subscription: the entity appears on every turn — this is how you, or a conversation, watch an entity in your own field of view. " +
+				"Without owner this adds an always-visible subscription owned by core (the root container whose context every turn shares): the entity appears on every turn — this is how you, or a conversation, watch an entity in your own field of view. " +
 				"With owner set to a loop definition name, the subscription lands on that loop's spec instead; from inside a loop's own turn use watch_entity. " +
 				"Use ttl_seconds for subscriptions that should expire after a bounded task. Use history to include historical state snapshots at specific intervals. Use forecast for weather entities when future weather context is needed. " +
 				"When Home Assistant is connected, a glob or area/label/floor target reports how many entities it currently matches (with a sample) — and flags a zero-member expansion, which almost always means a typo'd id or an empty group.",
@@ -176,7 +176,7 @@ func (w *WatchlistTools) Tools() []*tools.Tool {
 				"properties": map[string]any{
 					"owner": map[string]any{
 						"type":        "string",
-						"description": "Optional owner filter: \"\" is not a valid filter value (omit the parameter to list everything); pass a loop definition name, or \"system\" for runtime-seeded rows.",
+						"description": "Optional owner filter: omit the parameter to list everything; pass \"core\" for the always-visible tier, a loop definition name, or \"system\" for runtime-seeded rows.",
 					},
 					"entity_id": map[string]any{
 						"type":        "string",
@@ -221,6 +221,12 @@ func (w *WatchlistTools) handleAddEntitySubscription(ctx context.Context, args m
 	if owner == OwnerSystem {
 		return "", fmt.Errorf("owner %q is reserved for runtime-seeded rows (the person-presence ingestion floor, configured via person.track) and cannot be written by tools; omit owner for an always-visible subscription or name a loop", OwnerSystem)
 	}
+	// The anonymous always-visible tier collapsed into core (#1208):
+	// omitted owner means core, and core routes store-direct — it has
+	// no persisted definition for the spec-mutation path to edit.
+	if owner == "" {
+		owner = OwnerCore
+	}
 
 	history, err := parseWatchlistHistoryArg(args["history"])
 	if err != nil {
@@ -251,8 +257,8 @@ func (w *WatchlistTools) handleAddEntitySubscription(ctx context.Context, args m
 		return "", err
 	}
 	selfOnly, _ := args["self_only"].(bool)
-	if selfOnly && owner == "" {
-		return "", fmt.Errorf("self_only shapes container inheritance and applies to loop-owned subscriptions only; pass owner with a container loop's name, or drop self_only for an always-visible subscription")
+	if selfOnly && owner == OwnerCore {
+		return "", fmt.Errorf("self_only has no effect on core's subscriptions — they render in every context by definition; pass owner with another container's name, or drop self_only")
 	}
 	requiresTag := strings.TrimSpace(stringArg(args, "requires_tag"))
 	transitions, err := watchlistIntArg(args["transitions"], "transitions")
@@ -295,10 +301,11 @@ func (w *WatchlistTools) handleAddEntitySubscription(ctx context.Context, args m
 	}
 
 	if sub.Wake {
-		// The wake feed awakens the OWNING loop; the always-visible
-		// tier has nobody to wake.
-		if owner == "" {
-			return "", fmt.Errorf("wake awakens the owning loop, and an always-visible subscription has no owner — pass owner with the loop to wake, or use watch_entity from inside it")
+		// The wake feed awakens the OWNING loop; core is the root
+		// container and never iterates, so a core-owned wake would
+		// fire into the void.
+		if owner == OwnerCore {
+			return "", fmt.Errorf("wake awakens the owning loop, and core is a container that never iterates — pass owner with the executing loop to wake, or use watch_entity from inside it")
 		}
 		if requiresTag != "" {
 			return "", fmt.Errorf("wake cannot combine with requires_tag — waking must not follow tag state; drop one of the two")
@@ -340,7 +347,7 @@ func (w *WatchlistTools) handleAddEntitySubscription(ctx context.Context, args m
 		return "", err
 	}
 
-	if owner != "" {
+	if owner != OwnerCore {
 		if w.loopMutator == nil {
 			return "", fmt.Errorf("loop-owned subscriptions are not available in this runtime; omit owner for an always-visible subscription")
 		}
@@ -353,7 +360,9 @@ func (w *WatchlistTools) handleAddEntitySubscription(ctx context.Context, args m
 			return "", err
 		}
 	} else {
-		if err := w.store.Upsert("", sub); err != nil {
+		// Core rows are the source of truth themselves — core has no
+		// persisted spec by design, so the store write IS the mutation.
+		if err := w.store.Upsert(OwnerCore, sub); err != nil {
 			return "", fmt.Errorf("add to watchlist: %w", err)
 		}
 		// Explicit ingest modes and transition-log derivation both
@@ -364,7 +373,7 @@ func (w *WatchlistTools) handleAddEntitySubscription(ctx context.Context, args m
 	}
 
 	msg := fmt.Sprintf("Now watching %s", entityID)
-	if owner != "" {
+	if owner != OwnerCore {
 		msg = fmt.Sprintf("Loop %q is now watching %s", owner, entityID)
 	}
 	switch mode {
@@ -489,7 +498,7 @@ func (w *WatchlistTools) handleListEntitySubscriptions(ctx context.Context, args
 			"entity_id":      row.EntityID,
 			"owner":          row.Owner,
 			"mode":           mode,
-			"always_visible": row.Owner == "",
+			"always_visible": row.Owner == OwnerCore,
 		}
 		if len(row.History) > 0 {
 			item["history"] = append([]int(nil), row.History...)
@@ -571,10 +580,13 @@ func (w *WatchlistTools) handleRemoveEntitySubscription(ctx context.Context, arg
 	}
 
 	owner := strings.TrimSpace(stringArg(args, "owner"))
+	if owner == "" {
+		owner = OwnerCore
+	}
 	switch {
 	case owner == OwnerSystem:
 		return "", fmt.Errorf("system-owned rows are seeded from configuration (person.track) and re-appear at the next startup; change the configuration instead of removing them here")
-	case owner != "":
+	case owner != OwnerCore:
 		// The mutator persists the spec, and the app's persist hook
 		// re-mirrors the registry and rebuilds the ingestion filter —
 		// no onIngestChange here or the filter would rebuild twice.
@@ -587,7 +599,7 @@ func (w *WatchlistTools) handleRemoveEntitySubscription(ctx context.Context, arg
 			return "", err
 		}
 	default:
-		if err := w.store.Remove("", entityID); err != nil {
+		if err := w.store.Remove(OwnerCore, entityID); err != nil {
 			return "", fmt.Errorf("remove from watchlist: %w", err)
 		}
 		// Unconditional for global removes: the handler doesn't know
@@ -598,7 +610,7 @@ func (w *WatchlistTools) handleRemoveEntitySubscription(ctx context.Context, arg
 		}
 	}
 	w.logger.Info("entity subscription removed", "entity_id", entityID, "owner", owner)
-	if owner != "" {
+	if owner != OwnerCore {
 		return fmt.Sprintf("Loop %q stopped watching %s.", owner, entityID), nil
 	}
 	return fmt.Sprintf("Stopped watching %s.", entityID), nil

--- a/internal/state/awareness/watchlist_tool_provider_test.go
+++ b/internal/state/awareness/watchlist_tool_provider_test.go
@@ -125,7 +125,7 @@ func TestAddEntitySubscription_Success(t *testing.T) {
 		t.Errorf("result = %q, want to contain 'watching'", result)
 	}
 
-	rows, err := store.ListOwner("")
+	rows, err := store.ListOwner(OwnerCore)
 	if err != nil {
 		t.Fatalf("ListOwner: %v", err)
 	}
@@ -157,7 +157,7 @@ func TestAddEntitySubscription_WithTTLHistoryAndInclude(t *testing.T) {
 		t.Fatalf("result = %q, want include text", result)
 	}
 
-	rows, err := store.ListOwner("")
+	rows, err := store.ListOwner(OwnerCore)
 	if err != nil {
 		t.Fatalf("ListOwner: %v", err)
 	}
@@ -385,7 +385,7 @@ func TestAddEntitySubscription_ForecastNoneClearsExistingOption(t *testing.T) {
 		t.Fatalf("result = %q, want forecast clearing note", result)
 	}
 
-	rows, err := store.ListOwner("")
+	rows, err := store.ListOwner(OwnerCore)
 	if err != nil {
 		t.Fatalf("ListOwner: %v", err)
 	}
@@ -403,7 +403,7 @@ func TestAddEntitySubscription_ForecastNoneClearsExistingOption(t *testing.T) {
 func TestListEntitySubscriptions_WholeTruth(t *testing.T) {
 	p, store, _ := setupWatchlistProvider(t)
 
-	if err := store.Upsert("", looppkg.EntitySubscription{EntityID: "sensor.always_on"}); err != nil {
+	if err := store.Upsert(OwnerCore, looppkg.EntitySubscription{EntityID: "sensor.always_on"}); err != nil {
 		t.Fatalf("upsert global: %v", err)
 	}
 	if err := store.Upsert("battery-watcher", looppkg.EntitySubscription{
@@ -456,8 +456,8 @@ func TestListEntitySubscriptions_WholeTruth(t *testing.T) {
 			ExpiresDelta  string
 		}{item.Owner, item.Mode, item.AlwaysVisible, item.ExpiresDelta}
 	}
-	if got := byEntity["sensor.always_on"]; got.Owner != "" || !got.AlwaysVisible || got.Mode != "render" {
-		t.Errorf("sensor.always_on = %+v, want global render row", got)
+	if got := byEntity["sensor.always_on"]; got.Owner != OwnerCore || !got.AlwaysVisible || got.Mode != "render" {
+		t.Errorf("sensor.always_on = %+v, want core-owned always-visible render row", got)
 	}
 	if got := byEntity["sensor.battery"]; got.Owner != "battery-watcher" || got.AlwaysVisible || got.ExpiresDelta == "" {
 		t.Errorf("sensor.battery = %+v, want owned row with expiry", got)
@@ -503,7 +503,7 @@ func TestRemoveEntitySubscription_MissingEntityID(t *testing.T) {
 func TestRemoveEntitySubscription_Success(t *testing.T) {
 	p, store, _ := setupWatchlistProvider(t)
 
-	if err := store.Upsert("", looppkg.EntitySubscription{EntityID: "sensor.temperature"}); err != nil {
+	if err := store.Upsert(OwnerCore, looppkg.EntitySubscription{EntityID: "sensor.temperature"}); err != nil {
 		t.Fatalf("upsert: %v", err)
 	}
 
@@ -517,7 +517,7 @@ func TestRemoveEntitySubscription_Success(t *testing.T) {
 		t.Errorf("result = %q, want to contain entity_id", result)
 	}
 
-	rows, err := store.ListOwner("")
+	rows, err := store.ListOwner(OwnerCore)
 	if err != nil {
 		t.Fatalf("ListOwner: %v", err)
 	}
@@ -530,7 +530,7 @@ func TestRemoveEntitySubscription_OwnerRoutesToLoopMutator(t *testing.T) {
 	p, store, mutator := setupWatchlistProvider(t)
 
 	// A same-named global row must survive an owner-routed remove.
-	if err := store.Upsert("", looppkg.EntitySubscription{EntityID: "sensor.battery"}); err != nil {
+	if err := store.Upsert(OwnerCore, looppkg.EntitySubscription{EntityID: "sensor.battery"}); err != nil {
 		t.Fatalf("upsert global: %v", err)
 	}
 	mutator.subs = map[string][]looppkg.EntitySubscription{
@@ -649,7 +649,7 @@ func TestAddEntitySubscription_RequiresTag(t *testing.T) {
 		t.Fatalf("result = %q, want gate acknowledgement", result)
 	}
 
-	rows, err := store.ListOwner("")
+	rows, err := store.ListOwner(OwnerCore)
 	if err != nil {
 		t.Fatalf("ListOwner: %v", err)
 	}

--- a/internal/state/awareness/watchlist_unavailable_test.go
+++ b/internal/state/awareness/watchlist_unavailable_test.go
@@ -311,7 +311,7 @@ func TestProvider_UnavailableEnrichmentEndToEnd(t *testing.T) {
 	p, store := setupTestProvider(t, ha)
 	p.SetRegistryClient(regs)
 
-	if err := store.Upsert("", looppkg.EntitySubscription{EntityID: "binary_sensor.front_door"}); err != nil {
+	if err := store.Upsert(OwnerCore, looppkg.EntitySubscription{EntityID: "binary_sensor.front_door"}); err != nil {
 		t.Fatalf("add: %v", err)
 	}
 

--- a/talents/awareness-trailhead.md
+++ b/talents/awareness-trailhead.md
@@ -14,10 +14,12 @@ turn.
 Choose the next move deliberately:
 
 - Use `list_entity_subscriptions` to see the whole subscription
-  registry — every row carries its `owner`: `""` is the always-visible
-  tier (your own field of view), a loop name is that loop's own watch
-  set, and `system` marks runtime-seeded rows like the person-presence
-  ingestion floor (configured via `person.track`, read-only here).
+  registry — every row carries its `owner`: `core` is the
+  always-visible tier (core is the root container, and every context
+  is core's context — this is your own field of view), a loop name is
+  that loop's own watch set, and `system` marks runtime-seeded rows
+  like the person-presence ingestion floor (configured via
+  `person.track`, read-only here).
 - Use `add_entity_subscription` when a room, device, person, or live state
   should auto-load while the work continues. The `entity_id` accepts more
   than a single entity: a glob (`binary_sensor.*door*`, `*_temperature`)


### PR DESCRIPTION
Closes #1208 — the arc's last open decision, settled by the owner: the global tier of subscriptions belongs to core, which is de facto the same thing.

## Two names for one thing become one name

The always-visible tier was the registry's anonymous owner (`''`): rows that render in every context because every context — conversations included — is ultimately core's context. That's precisely what "core's subscriptions" means, so the tier collapses into rows owned by `core`, and the vocabulary stops maintaining a distinction the architecture never had. Legacy anonymous-tier rows are deliberately NOT migrated — the owner re-evaluates the production subscription set by hand rather than carrying old choices forward mechanically — so a single idempotent step clears the retired tier, and the store now requires an owner on every write, and the render/dedup/list surfaces read the core tier by name: the `### Watched Entities` block is core's subscriptions, the loop provider's double-render dedup consults `CoreEntityGates`, and `always_visible` in list output means `owner == "core"`.

## The shape follows core's own design

The obvious implementation — compile core's rows from a persisted core spec, like every loop owner — would have been wrong, and the code said so before I could make the mistake: core is deliberately implicit, with no definition in the registry ("the bootstrap owns its lifecycle entirely," for stated reasons about operators not curating the root). So this is the *lighter* collapse: core's rows are the source of truth themselves, mutated store-direct by the tools — exactly the posture the system floor already holds, where config is truth. Omitted owner (or an explicit `core`) routes through today's store-direct path; the spec-mutation path remains reserved for real definitions.

That choice demands guards, and they're the meat of the diff: the spec mirror and the boot orphan sweep now treat `core` as reserved alongside `system` — without that, the sweep would see core-owned rows with no definition behind them and consciously bury the entire always-visible tier as orphans. The definition-delete reap refuses reserved names, a definition squatting on the name `core` is warned and never mirrored, and the wake feeder backstop-skips core rows.

## Semantics that sharpened rather than changed

Two teaching errors got more honest. `wake` with no owner used to say "an always-visible subscription has no owner"; now that ownerless means core, the error explains the real obstacle — core is a container that never iterates, so name the executing loop you want woken. `self_only` on the always-visible tier is rejected as meaningless with the reason stated: core's rows render in every context by definition, so there is nothing to withhold from descendants. Everything else — `requires_tag` gating, transition logs, TTLs, forecast, the ingest cap — works on core rows exactly as it did on the anonymous tier, because they are the same rows.

## Test plan

- [x] `just ci` green locally (run unpiped)
- [x] Migration posture: the retired anonymous tier is cleared (not re-homed), core rows survive, idempotent re-open; scope→owner rename proven on a named-owner row
- [x] Reserved-owner guards: compile pass leaves core rows standing while orphans die; mirror refuses a core-named definition; feeder skips core rows
- [x] Tool routing: ownerless and explicit-core adds/removes go store-direct; loop names still route through the spec mutator; `always_visible`/owner surfaces updated
- [x] Full render/dedup suites re-based onto the core tier and passing

Prod note for the deploy that carries this: the legacy always-visible rows are CLEARED at first store open, per the no-migration decision — the always-visible tier starts empty and gets re-authored deliberately. The expires_at decode shim (whose only consumers were those rows) is removed with them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


