### PR TITLE
docs(talents): model-first teaching pass for the subscription arc

### DIFF
--- a/docs/model-facing-tools.md
+++ b/docs/model-facing-tools.md
@@ -316,6 +316,38 @@ For example, if a tool expects an integer issue number, say `number
 If a delegate would need to ask itself "what do I try next?", the tool
 surface can probably be improved.
 
+## Shipping: the model is the user
+
+A functional change to a model-facing surface is not done when the
+code merges — it is done when the teaching ships. The habit to unlearn
+is treating documentation and UX as human-facing follow-up, as they
+historically were: these features are built *for the model*. The model
+is the user; the operator is the second audience. A teaching pass
+targets, in order:
+
+1. **Tool descriptions and schemas** — the surfaces the model reads at
+   decision time.
+2. **Talents** — the decision frames that route the model to the right
+   door before it reads any schema.
+3. **Cross-references at the borders** — the other talents and tool
+   descriptions that mention this capability's neighbors.
+4. **Operator docs** (`docs/`) — last, not first.
+
+Two failure modes deserve special vigilance:
+
+- **Stale doors are worse than missing docs.** When a new option
+  changes which door is the smooth path, re-read the OLD doors'
+  descriptions. A description that says "entities do NOT wake the
+  loop" after entities learned to wake doesn't just under-teach — it
+  actively routes the model around the feature it sits next to.
+- **Phased work accretes cafeteria bullets.** Shipping an arc PR by PR
+  appends per-feature guidance that is individually correct and
+  collectively frameless (see the anti-pattern catalog in
+  [tool-and-talent-audit.md](tool-and-talent-audit.md)). After an arc
+  completes, make a synthesis pass that restates the *decision frame*
+  — the questions the model should ask — with the per-option details
+  under it.
+
 ## Review Checklist
 
 Before merging a new or changed tool, ask:
@@ -331,6 +363,9 @@ Before merging a new or changed tool, ask:
 8. Would multi-account or multi-target ambiguity be obvious to recover?
 9. Is the output compact structure instead of human-oriented narrative?
 10. Are we preserving exact upstream state where exactness matters?
+11. Did the change make any OLDER tool description or talent stale —
+    especially one that now routes the model around this feature?
+12. Does a talent teach WHEN to reach for this, not just what it does?
 
 If those answers are good, the tool surface is probably on the right
 track.

--- a/internal/tools/loop_create_tool.go
+++ b/internal/tools/loop_create_tool.go
@@ -29,11 +29,11 @@ func (r *Registry) registerThaneLoopCreate() {
 		Description: "Create and launch a durable, reusable loop. This is the always-on front door for standing up recurring work; for the full lifecycle afterwards (inspect, edit, relaunch, reparent) activate the `loops` capability. " +
 			"operation is explicit and picks the kind: " +
 			"\"service\" = a recurring loop that self-paces within a sleep envelope (requires sleep_min and sleep_max); " +
-			"\"event_driven\" = a quiescent handler with no timer that runs only when an external trigger wakes it — point a feed/forge subscription or an MQTT wake at it, or have another loop notify it; wire that trigger separately after creating the loop, or it never runs; " +
+			"\"event_driven\" = a quiescent handler with no timer that runs only when an external trigger wakes it — give it an entity subscription with wake:true (wakes on that entity's changes), point a feed/forge subscription or an MQTT wake at it, or have another loop notify it; without at least one trigger it never runs; " +
 			"\"container\" = a non-executing node that groups loops and shares its tags with descendants; like every operation it requires intent, takes the optional parent_name and tags, and rejects execution/output fields (sleep knobs, output, entities, instructions, etc.). " +
 			"output (service/event_driven only) declares a managed markdown document the loop maintains — \"journal\" appends a dated entry each cycle, \"maintain\" rewrites it idempotently — and is scaffolded with ownership frontmatter before launch; omit it for a loop that acts without maintaining a document. " +
 			"parent_name nests the loop under a container by name, inheriting its tags and subscriptions. " +
-			"entities are Home Assistant subscriptions surfaced into the loop's context each iteration; they do NOT wake the loop (an event_driven loop's wake is wired separately). " +
+			"entities are Home Assistant subscriptions surfaced into the loop's context each iteration; an entry with wake:true ALSO wakes the loop when that entity changes (debounced/coalesced) — for a service loop an early wake, for an event_driven loop a primary trigger. " +
 			"Returns the loop definition name, loop_id, and the canonical loop row; plus output_tool/document_path when a document was declared. If the loop lands at the root but an existing container declares tags it shares, the result also carries a non-blocking placement_advisory suggesting where it might nest (see loop_containers).",
 		ContentResolveExempt: []string{
 			"name", "intent", "operation", "parent_name", "output", "entities", "tags",
@@ -507,7 +507,7 @@ func thaneLoopCreateSchema() map[string]any {
 			},
 			"entities": map[string]any{
 				"type":        "array",
-				"description": "Optional Home Assistant entity subscriptions surfaced into the loop's context each iteration. They provide context only and do NOT wake the loop — an event_driven loop's wake is wired separately (feed/forge/MQTT/inter-loop notification). Container ancestors' subscriptions also cascade in.",
+				"description": "Optional Home Assistant entity subscriptions surfaced into the loop's context each iteration. By default they provide context only; an entry with wake:true also wakes this loop when the entity changes (debounced/coalesced — the simple-change-trigger door; compound conditions stay HA-side via MQTT wakes). Container ancestors' subscriptions also cascade in.",
 				"items": map[string]any{
 					"type": "object",
 					"properties": map[string]any{

--- a/internal/tools/loop_create_tool.go
+++ b/internal/tools/loop_create_tool.go
@@ -29,11 +29,11 @@ func (r *Registry) registerThaneLoopCreate() {
 		Description: "Create and launch a durable, reusable loop. This is the always-on front door for standing up recurring work; for the full lifecycle afterwards (inspect, edit, relaunch, reparent) activate the `loops` capability. " +
 			"operation is explicit and picks the kind: " +
 			"\"service\" = a recurring loop that self-paces within a sleep envelope (requires sleep_min and sleep_max); " +
-			"\"event_driven\" = a quiescent handler with no timer that runs only when an external trigger wakes it — give it an entity subscription with wake:true (wakes on that entity's changes), point a feed/forge subscription or an MQTT wake at it, or have another loop notify it; without at least one trigger it never runs; " +
+			"\"event_driven\" = a quiescent handler with no timer that runs only when an external trigger wakes it — give it an entity subscription with wake: true (wakes on that entity's changes), point a feed/forge subscription or an MQTT wake at it, or have another loop notify it; without at least one trigger it never runs; " +
 			"\"container\" = a non-executing node that groups loops and shares its tags with descendants; like every operation it requires intent, takes the optional parent_name and tags, and rejects execution/output fields (sleep knobs, output, entities, instructions, etc.). " +
 			"output (service/event_driven only) declares a managed markdown document the loop maintains — \"journal\" appends a dated entry each cycle, \"maintain\" rewrites it idempotently — and is scaffolded with ownership frontmatter before launch; omit it for a loop that acts without maintaining a document. " +
 			"parent_name nests the loop under a container by name, inheriting its tags and subscriptions. " +
-			"entities are Home Assistant subscriptions surfaced into the loop's context each iteration; an entry with wake:true ALSO wakes the loop when that entity changes (debounced/coalesced) — for a service loop an early wake, for an event_driven loop a primary trigger. " +
+			"entities are Home Assistant subscriptions surfaced into the loop's context each iteration; an entry with wake: true ALSO wakes the loop when that entity changes (debounced/coalesced) — for a service loop an early wake, for an event_driven loop a primary trigger. " +
 			"Returns the loop definition name, loop_id, and the canonical loop row; plus output_tool/document_path when a document was declared. If the loop lands at the root but an existing container declares tags it shares, the result also carries a non-blocking placement_advisory suggesting where it might nest (see loop_containers).",
 		ContentResolveExempt: []string{
 			"name", "intent", "operation", "parent_name", "output", "entities", "tags",
@@ -507,7 +507,7 @@ func thaneLoopCreateSchema() map[string]any {
 			},
 			"entities": map[string]any{
 				"type":        "array",
-				"description": "Optional Home Assistant entity subscriptions surfaced into the loop's context each iteration. By default they provide context only; an entry with wake:true also wakes this loop when the entity changes (debounced/coalesced — the simple-change-trigger door; compound conditions stay HA-side via MQTT wakes). Container ancestors' subscriptions also cascade in.",
+				"description": "Optional Home Assistant entity subscriptions surfaced into the loop's context each iteration. By default they provide context only; an entry with wake: true also wakes this loop when the entity changes (debounced/coalesced — the simple-change-trigger door; compound conditions stay HA-side via MQTT wakes). Container ancestors' subscriptions also cascade in.",
 				"items": map[string]any{
 					"type": "object",
 					"properties": map[string]any{

--- a/talents/awareness-trailhead.md
+++ b/talents/awareness-trailhead.md
@@ -11,83 +11,75 @@ Awareness is for sustained attention. Use it when the same entity,
 device, person, room, or live provider will matter across more than one
 turn.
 
-Choose the next move deliberately:
+The working tool is the subscription: **loop-owned attention** on an
+entity, declared once, feeding whatever the attention is for. Every
+subscription answers three questions — decide all three deliberately:
 
-- Use `list_entity_subscriptions` to see the whole subscription
-  registry — every row carries its `owner`: `core` is the
-  always-visible tier (core is the root container, and every context
-  is core's context — this is your own field of view), a loop name is
-  that loop's own watch set, and `system` marks runtime-seeded rows
-  like the person-presence ingestion floor (configured via
-  `person.track`, read-only here).
-- Use `add_entity_subscription` when a room, device, person, or live state
-  should auto-load while the work continues. The `entity_id` accepts more
-  than a single entity: a glob (`binary_sensor.*door*`, `*_temperature`)
-  to follow entities by name, or an organizational target —
-  `area:<area_id>`, `label:<label_id>`, `floor:<floor_id>` (e.g.
-  `area:office`). Prefer the organizational form when the intent is
-  "watch the office," not "watch these specific sensors": its membership
-  is re-resolved from the registry every turn, so it follows the home —
-  move a device into the office and the `area:office` watch picks it up,
-  no re-authoring. When you subscribe to a glob or organizational target,
-  the result reports how many entities it matches right now, with a
-  sample — and flags a zero-member expansion, which almost always means a
-  typo'd id or an empty group. Read that back: if `area:office` was meant
-  to catch three sensors and matches zero, fix the id before moving on.
-  All expansions are capped per turn and report truncation when they
-  overflow; scope to a smaller area/label/floor rather than watching the
-  whole house. Use `ha_registry_search` to find area/label/floor IDs.
-- Pass `mode` to choose what a subscription feeds: `render` (default)
-  injects live state each turn; `ingest` feeds the recent-state-changes
-  window only — the entity's transitions appear there without spending
-  per-turn context on its full state; `both` does both. Ingest is the
-  right shape for "I want to notice when this changes" without carrying
-  it every turn. Ingest accepts entity ids and globs (not
-  area/label/floor targets), and the ingest registry is capped.
-- Pass `transitions` (and/or `transitions_window_seconds`) when the
-  entity's recent *changes* matter, not just its current state: the
-  rendered block gains its last-n transitions as `{from, to, ago}`,
-  and capture follows automatically — you never need `mode` for this.
-  Pick by question shape: the transition log answers "what just
-  happened to THIS entity" (survives the shared window's churn),
-  `history` summaries answer "what has it been doing" (numeric trends
-  over windows), and the shared recent-state-changes window answers
-  "what's been happening around the house."
-- Pass `wake: true` when a loop should *act* on change, not just see
-  it next iteration: the owning loop is awakened with a
-  `{entity, from, to, ago}` event — debounced and coalesced, so a
-  chattering sensor becomes one wake carrying the latest change,
-  never a wakestorm. `wake_debounce_seconds` sets how long changes
-  coalesce (a loop's cadence follows its twitchiest wake
-  subscription); capture follows automatically. Wake needs an owning
-  loop (`owner`, or `watch_entity` from inside one). Boundary: this
-  covers simple native triggers — "wake me when this entity changes."
-  Compound conditions, zone dwell, and template triggers belong to
-  the HA-automation→MQTT pipeline (`mqtt_wake_add` + an HA
-  automation); both deliver through the same queue, so pick by where
-  the condition logic lives, not by delivery mechanics.
+**1. Who carries it?** Ownership is the `owner` parameter on
+`add_entity_subscription` / `remove_entity_subscription`. Omit it (or
+say `core`) for your own always-visible field of view — core is the
+root container, and every context is core's context, so its
+subscriptions render everywhere. Name a loop to put the entry on that
+loop's spec instead, following its lifecycle; from inside a loop's own
+turn, `watch_entity` / `unwatch_entity` do the same with no name.
+Container-owned entries cascade to descendant loops unless marked
+`self_only`. Rows owned by `system` (the person-presence ingestion
+floor, from `person.track`) are read-only here.
+
+**2. What does it feed?** Three feeds compose on one declaration:
+
+- **Render** (the default): live state in the entity's block each
+  turn. Add `history` windows for numeric trends ("what has it been
+  doing"), or `transitions` / `transitions_window_seconds` for the
+  recent change log as `{from, to, ago}` ("what just happened" —
+  survives the shared recent-changes window's churn). The shared
+  window still answers "what's been happening around the house."
+- **Wake**: `wake: true` when the owning loop should *act* on change,
+  not just see it next iteration. The loop is awakened with a
+  `{entity, from, to, ago}` event — debounced and coalesced
+  (`wake_debounce_seconds`; a loop's cadence follows its twitchiest
+  wake subscription), so a chattering sensor becomes one wake carrying
+  the latest change, never a wakestorm. Wake needs an executing owner
+  loop — core is a container and cannot be woken. Boundary: this
+  covers "wake me when this entity changes"; compound conditions, zone
+  dwell, and template triggers belong to the HA-automation→MQTT
+  pipeline (`mqtt_wake_add`) — both deliver through the same queue, so
+  pick by where the condition logic lives.
+- **Capture** comes for free: declaring `transitions` or `wake`
+  automatically feeds the entity into state-change capture — you never
+  need `mode` for these. The only remaining use for `mode: ingest` is
+  capture WITHOUT any render or wake: the entity's changes appear in
+  the shared recent-changes window while spending no per-turn context.
+
+**3. What does it cost?** `requires_tag` gates rendering on a
+capability tag — the macro set: one tag activation surfaces a
+subject's tagged documents and its related entities together, and
+deactivation drops both (render-only; capture and wake never follow
+tag state). `ttl_seconds` auto-expires a bounded watch. Expansions and
+logs are capped and advertise truncation. And when the work is done,
+`remove_entity_subscription` — stale subscriptions are quiet clutter.
+
+Mechanics that apply across all of the above:
+
+- The `entity_id` accepts a concrete id, a glob (`binary_sensor.*door*`,
+  `*_temperature`), or an organizational target — `area:<area_id>`,
+  `label:<label_id>`, `floor:<floor_id>`. Prefer the organizational
+  form when the intent is "watch the office," not "watch these specific
+  sensors": membership re-resolves from the registry every turn, so it
+  follows the home as devices move. Subscribing to a glob or target
+  reports how many entities it matches right now, with a sample — a
+  zero-member expansion almost always means a typo'd id; fix it before
+  moving on. Registry targets are render-only (they cannot feed
+  capture or wake). Use `ha_registry_search` to find ids.
 - Add `include` metadata flags when area, owning device, HA labels, or
-  descriptions would make the subscribed state easier to interpret; use
+  descriptions would make the state easier to interpret; use
   `visibility` when hidden/enabled salience matters, and read
-  `visibility.context_role` as the quick default-vs-forensic hint. Area
-  metadata can carry the HA floor/building hierarchy too.
-- Pass `owner` to subscribe on behalf of a loop: the entry lands on
-  that loop's spec and follows its lifecycle (containers cascade
-  subscriptions to descendants unless the entry sets `self_only`).
-  From inside a loop's own turn, `watch_entity` does the same without
-  naming the loop.
-- Pass `requires_tag` to build a macro set: the subscription renders
-  only while that capability tag is active, so activating one tag
-  surfaces a subject's tagged documents and its related entities
-  together — and deactivating it drops both. The gate is render-only
-  (it cannot combine with `mode: ingest`/`both`) and is the exception,
-  not the default: an ungated subscription is the smooth path when the
-  entity should simply always be there.
-- Use `remove_entity_subscription` when the work is done. Stale
-  subscriptions are quiet clutter. The same `owner` addressing
-  applies.
-- If the work is a one-shot state check, use the currently visible HA or
-  context tool directly instead of subscribing first.
+  `visibility.context_role` as the quick default-vs-forensic hint.
+- Use `list_entity_subscriptions` to see the whole registry — every
+  row carries its `owner` (`core`, a loop name, or `system`), its
+  feeds, and its gates.
+- If the work is a one-shot state check, use the currently visible HA
+  or context tool directly instead of subscribing first.
 - If the next move is delivery, escalation, or interruption, activate
   `notifications`.
 

--- a/talents/loops-examples.md
+++ b/talents/loops-examples.md
@@ -235,17 +235,27 @@ when its scope should shift.
    `remove_entity_subscription` with the same `owner` to retire
    watches you no longer care about.
 
+For wakes on a *single entity's changes* — a door opening, a pump
+starting — the loop's own subscription is the trigger: `wake: true`
+on the entity entry (in `thane_loop_create.entities`, via
+`add_entity_subscription` with `owner`, or `watch_entity` from
+inside). No automation, no topic, debounced by default. Reach past
+this door only when the trigger logic can't be "this entity changed."
+
 For event-driven wakes (a new release on a repo, a new feed entry),
 producer tools like `forge_repo_follow` and `media_follow` take a
 `wake_loop` target so the service loop wakes on the event rather than
 its timer.
 
-For wakes triggered by *arbitrary external events* — most commonly
-an HA automation publishing an MQTT message — register the loop
-with `mqtt_wake_add` and pair it with an HA automation whose action
-publishes to the same topic. The two sides are independent
-artifacts that share only the topic string; the topic string IS
-the contract.
+For wakes triggered by *HA-side derived conditions* — compound
+triggers, zone dwell, templates, anything an HA automation decides —
+register the loop with `mqtt_wake_add` and pair it with an HA
+automation whose action publishes to the same topic. The two sides
+are independent artifacts that share only the topic string; the
+topic string IS the contract. (The worked example below is exactly
+this shape: the trigger is "presence transition AND morning AND
+entering the office," which is HA-automation logic, not a bare
+entity change.)
 
 ### Worked example: morning-briefing loop on Alice's office arrival
 

--- a/talents/loops.md
+++ b/talents/loops.md
@@ -40,9 +40,19 @@ Choose stream wiring by attention cost:
   physical-world context beside the live state, including HA's
   floor/building hierarchy and hidden/enabled salience. Use
   `visibility.context_role` as the quick default-vs-forensic hint.
-- Use event-source `wake_loop` targets when each event deserves an
-  immediate iteration. Producer tools such as `forge_repo_follow` and
-  `media_follow` own those subscriptions.
+- When the loop should *act* the moment an entity changes — not wait
+  for its next timer — the subscription itself is the trigger: add
+  `wake: true` to the entity entry (at creation or later). The loop
+  wakes with the change as a `{entity, from, to, ago}` event,
+  debounced and coalesced so a chattering sensor can't wakestorm it.
+  This is the first door for simple entity-change triggers; reach for
+  the HA-automation→MQTT pipeline (`mqtt_wake_add`) only when the
+  trigger logic is HA-side — compound conditions, zone dwell,
+  templates. Both deliver through the same queue.
+- Use event-source `wake_loop` targets when each event from a
+  *producer stream* deserves an immediate iteration. Producer tools
+  such as `forge_repo_follow` and `media_follow` own those
+  subscriptions.
 
 Treat running loops as bi-directional. A service loop can pull you in
 via `request_core_attention` when something deserves a decision; you


### PR DESCRIPTION
Follow-up to the #1208 arc; stacked on #1218 (merge that first — GitHub will retarget this to main).

## The model is the user, and we documented for the operator

The arc shipped six PRs of features built *for the model* — and taught them the way human-facing docs accrete: each PR appended its own bullet to the talent, updated the tools it touched, and moved on. The audit prompted by the owner's question found three concrete failures, one of them severe: `thane_loop_create` — the single most-traveled door for loop authoring — still said in three places that entities "do NOT wake the loop," two days after #1217 made `wake: true` on those same entities the primary trigger mechanism. That's the deadliest teaching failure mode: not missing documentation but a stale door that actively routes the model around the feature sitting next to it. A model following the front door's own words would wire an MQTT automation for a case one field now covers.

This PR is the teaching pass as a first-class deliverable, and it encodes the principle so the next arc doesn't repeat the pattern.

## What changed

**The front door tells the truth.** `thane_loop_create`'s description, its `event_driven` trigger list, and the entities schema all now teach that a subscription entry with `wake: true` wakes the loop — an early wake for a service loop, a primary trigger for an event-driven one — with the MQTT pipeline positioned as the compound-condition door, not the only door.

**The trailhead teaches the worldview, not the changelog.** Nine accreted bullets are restructured into the arc's actual decision frame: a subscription is loop-owned attention answering three questions — *who carries it* (owner: core / a loop / system), *what it feeds* (render with history and transition logs; wake; capture derived for free), *what it costs* (the `requires_tag` macro-set lens, TTLs, caps). `mode: ingest` is demoted from third billing to the one niche it still owns — capture with no render and no wake — instead of competing with `transitions` for the "I want to notice changes" intent the arc deliberately took away from it.

**The loops talent stops routing around the wake feed.** Its stream-wiring guidance now offers subscription wake as the first door for simple entity-change triggers, producer `wake_loop` streams for producer events, and MQTT for HA-side derivation — and loops-examples signposts that its own worked example (presence AND morning AND office-entry) is exactly the compound shape that justifies the MQTT pipeline, so the example teaches the boundary instead of silently modeling the heavyweight path.

**The principle outlives this PR.** `docs/model-facing-tools.md` gains a "Shipping: the model is the user" section — teaching pass ordered model-first (tool descriptions → talents → border cross-references → operator docs), with the two failure modes named (stale doors, cafeteria accretion) and two new review-checklist items: "did this change make any OLDER surface stale?" and "does a talent teach WHEN, not just what?"

## Test plan

- [x] `just ci` green locally (run unpiped — the talent corpus lints validate every tool reference in the restructured prose)
- [x] No functional changes: tool schemas, handlers, and behavior untouched; descriptions and talents only

🤖 Generated with [Claude Code](https://claude.com/claude-code)
