### PR TITLE
fix(loops): detach launched loops from the caller's request context

### DIFF
--- a/internal/runtime/loop/registry.go
+++ b/internal/runtime/loop/registry.go
@@ -900,7 +900,20 @@ func (r *Registry) Launch(ctx context.Context, launch Launch, deps Deps) (Launch
 
 	cfg := l.config
 	detached := spec.Operation != OperationRequestReply
-	if err := r.startLoop(ctx, spec.Name, l, cfg.Setup, detached); err != nil {
+	// A detached loop outlives the call that launched it, so its run
+	// goroutine must not inherit the caller's cancellation. When the launch
+	// comes from an interactive turn, ctx is cancelled the moment that turn
+	// ends — which killed the loop mid initial-sleep, before its first
+	// iteration ever ran (#1224). Sever the caller's cancellation and
+	// deadline while preserving request-scoped values; the detached loop's
+	// lifetime is then bounded only by Stop/ShutdownAll via its own cancel.
+	// request_reply launches stay attached: the caller blocks on the result
+	// below and its cancellation must still propagate.
+	startCtx := ctx
+	if detached {
+		startCtx = context.WithoutCancel(ctx)
+	}
+	if err := r.startLoop(startCtx, spec.Name, l, cfg.Setup, detached); err != nil {
 		return LaunchResult{}, err
 	}
 

--- a/internal/runtime/loop/registry_test.go
+++ b/internal/runtime/loop/registry_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"slices"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -373,15 +374,27 @@ func TestRegistryLaunchDetachedSurvivesCallerCancel(t *testing.T) {
 		t.Fatal("Detached = false, want true")
 	}
 
-	// Cancel the launching context while the loop is still in its long
-	// initial sleep, then give the goroutine time to react.
-	time.Sleep(20 * time.Millisecond)
-	cancel()
-	time.Sleep(100 * time.Millisecond)
-
 	l := r.Get(result.LoopID)
 	if l == nil {
-		t.Fatal("detached loop was deregistered after caller context cancel; want still running")
+		t.Fatalf("Get(%q) = nil, want running loop", result.LoopID)
+	}
+
+	// Wait until the loop is parked in its (long) initial sleep — a
+	// deterministic proof it got past Start, rather than guessing with a
+	// fixed delay. SleepDefault is 5s, so it stays parked well past the
+	// window below.
+	waitForLoopState(t, l, StateSleeping)
+
+	// Cancel the launching context. Before the fix this cancelled the loop's
+	// run context and stopped it mid initial-sleep; after the fix the
+	// detached loop's lifetime is severed from the caller, so Done() must not
+	// fire.
+	cancel()
+	select {
+	case <-l.Done():
+		t.Fatal("detached loop stopped after caller context cancel; want still running")
+	case <-time.After(200 * time.Millisecond):
+		// Still parked in initial sleep — survived the caller's cancellation.
 	}
 	if st := l.Status(); st.State == StateStopped {
 		t.Fatalf("state = %v, want a live (sleeping) state after caller cancel", st.State)
@@ -403,6 +416,7 @@ func TestRegistryLaunchRequestReplyStillHonorsCallerCancel(t *testing.T) {
 
 	r := NewRegistry()
 	ctx, cancel := context.WithCancel(context.Background())
+	runner := &signalingCtxRunner{started: make(chan struct{})}
 
 	type launchOutcome struct {
 		result LaunchResult
@@ -417,12 +431,17 @@ func TestRegistryLaunchRequestReplyStillHonorsCallerCancel(t *testing.T) {
 				Operation:  OperationRequestReply,
 				Completion: CompletionReturn,
 			},
-		}, Deps{Runner: &ctxBlockingRunner{}})
+		}, Deps{Runner: runner})
 		done <- launchOutcome{result: res, err: err}
 	}()
 
-	// Cancel while the runner is blocked on ctx.Done(); Launch must return.
-	time.Sleep(20 * time.Millisecond)
+	// Cancel only once the runner is actually executing, so the test proves
+	// caller cancellation propagates rather than racing Launch's setup.
+	select {
+	case <-runner.started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("runner never started")
+	}
 	cancel()
 
 	select {
@@ -884,6 +903,20 @@ func (r *blockingRunner) Run(_ context.Context, _ RunRequest, _ StreamCallback) 
 type ctxBlockingRunner struct{}
 
 func (r *ctxBlockingRunner) Run(ctx context.Context, _ RunRequest, _ StreamCallback) (*RunResponse, error) {
+	<-ctx.Done()
+	return nil, ctx.Err()
+}
+
+// signalingCtxRunner closes started on its first Run call, then blocks until
+// the context is cancelled. It lets a test cancel exactly when the runner is
+// executing, instead of racing a fixed sleep against Launch's setup.
+type signalingCtxRunner struct {
+	started chan struct{}
+	once    sync.Once
+}
+
+func (r *signalingCtxRunner) Run(ctx context.Context, _ RunRequest, _ StreamCallback) (*RunResponse, error) {
+	r.once.Do(func() { close(r.started) })
 	<-ctx.Done()
 	return nil, ctx.Err()
 }

--- a/internal/runtime/loop/registry_test.go
+++ b/internal/runtime/loop/registry_test.go
@@ -344,6 +344,97 @@ func TestRegistryLaunchBackgroundTaskDetaches(t *testing.T) {
 	t.Fatalf("loop %q still registered after completion", result.LoopID)
 }
 
+// TestRegistryLaunchDetachedSurvivesCallerCancel is the #1224 regression: a
+// detached loop (service here) launched from a cancellable context must not die
+// when that context is cancelled. Before the fix, the run goroutine inherited
+// the caller's context, so an interactive turn ending cancelled the loop mid
+// initial-sleep — iterations=0, gone before it ever ran.
+func TestRegistryLaunchDetachedSurvivesCallerCancel(t *testing.T) {
+	t.Parallel()
+
+	r := NewRegistry()
+	ctx, cancel := context.WithCancel(context.Background())
+
+	result, err := r.Launch(ctx, Launch{
+		Spec: Spec{
+			Name:         "detached-survives-cancel",
+			Task:         "test",
+			Operation:    OperationService,
+			SleepMin:     1 * time.Second,
+			SleepMax:     5 * time.Second,
+			SleepDefault: 5 * time.Second,
+			Jitter:       Float64Ptr(0),
+		},
+	}, Deps{Runner: &noopRunner{}})
+	if err != nil {
+		t.Fatalf("Launch: %v", err)
+	}
+	if !result.Detached {
+		t.Fatal("Detached = false, want true")
+	}
+
+	// Cancel the launching context while the loop is still in its long
+	// initial sleep, then give the goroutine time to react.
+	time.Sleep(20 * time.Millisecond)
+	cancel()
+	time.Sleep(100 * time.Millisecond)
+
+	l := r.Get(result.LoopID)
+	if l == nil {
+		t.Fatal("detached loop was deregistered after caller context cancel; want still running")
+	}
+	if st := l.Status(); st.State == StateStopped {
+		t.Fatalf("state = %v, want a live (sleeping) state after caller cancel", st.State)
+	}
+
+	// Explicit stop still works via the loop's own cancel, independent of
+	// the (already-cancelled) caller context.
+	if err := r.StopLoop(result.LoopID); err != nil {
+		t.Fatalf("StopLoop: %v", err)
+	}
+}
+
+// TestRegistryLaunchRequestReplyStillHonorsCallerCancel guards the other half
+// of the #1224 fix: request_reply launches are synchronous — the caller blocks
+// on the result — so cancelling the caller's context must still abort them.
+// Only detached operations sever the caller's cancellation.
+func TestRegistryLaunchRequestReplyStillHonorsCallerCancel(t *testing.T) {
+	t.Parallel()
+
+	r := NewRegistry()
+	ctx, cancel := context.WithCancel(context.Background())
+
+	type launchOutcome struct {
+		result LaunchResult
+		err    error
+	}
+	done := make(chan launchOutcome, 1)
+	go func() {
+		res, err := r.Launch(ctx, Launch{
+			Spec: Spec{
+				Name:       "request-reply-honors-cancel",
+				Task:       "test",
+				Operation:  OperationRequestReply,
+				Completion: CompletionReturn,
+			},
+		}, Deps{Runner: &ctxBlockingRunner{}})
+		done <- launchOutcome{result: res, err: err}
+	}()
+
+	// Cancel while the runner is blocked on ctx.Done(); Launch must return.
+	time.Sleep(20 * time.Millisecond)
+	cancel()
+
+	select {
+	case out := <-done:
+		if !errors.Is(out.err, context.Canceled) {
+			t.Fatalf("Launch error = %v, want context canceled", out.err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("request_reply Launch did not return after caller context cancel")
+	}
+}
+
 func TestRegistryLaunchBackgroundTaskDeliversConversationCompletion(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## What this fixes

`Registry.Launch` handed the caller's `ctx` straight to the loop's run goroutine for every operation, so a *detached* loop's entire lifetime hung off the call that launched it. When that call is an interactive turn, the turn's context is cancelled the instant the turn ends, and the loop is killed mid initial-sleep — before its first iteration ever runs, leaving `iterations=0` and nothing in the loop's own history to explain why it vanished. That is why `loop_definition_launch` and `spawn_loop` (and the delegate's `background_task` path, i.e. `thane_assign`) could never stand up a durable loop from a Signal turn, while the *committing* verbs — `thane_loop_create`, `loop_definition_set`, `loop_reparent` — worked: those spawn through reconcile on the detached `serviceContext`, not the caller's context. One registry, two context lifetimes for the same kind of loop, decided entirely by which door it came in through. Full write-up in #1224.

## The change

The fix lives at the one chokepoint where the detached-vs-synchronous decision is already made. For detached operations (`service`, `background_task`, `event_driven`), the loop's run context is now derived with `context.WithoutCancel(ctx)` — the caller's cancellation and deadline are severed while request-scoped values are preserved. `request_reply` launches are untouched: the caller blocks on the result and its cancellation must still propagate. Because the fix is at `Registry.Launch`, it covers every current and future caller uniformly rather than patching each tool handler.

Shutdown is unaffected: `Loop.Stop` and `ShutdownAll` cancel through the loop's own `l.cancel` (the `WithCancel` wrapper created in `Start`), which has never depended on the parent context. Detaching the caller's context removes only the unwanted cancellation source, not the runtime's control over the loop's life.

## Tests

Two regression tests, one per half of the contract:

- `TestRegistryLaunchDetachedSurvivesCallerCancel` — launches a service loop under a cancellable context, cancels it during initial sleep, and asserts the loop is still registered and not stopped. Verified to fail without the fix (`detached loop was deregistered after caller context cancel`) and pass with it.
- `TestRegistryLaunchRequestReplyStillHonorsCallerCancel` — guards against over-reach: a `request_reply` launch must still abort when the caller's context is cancelled.

`just ci` passes locally.

## Follow-up (separate)

The model-facing documentation gaps this exposed — the durable-vs-ephemeral seam in `talents/loops.md`, and the `loop_definition_launch`/`spawn_loop` descriptions promising persistence without qualification — are real but deliberately left out of this change so it stays a single logical fix. Production `ranch_climate_watch` was a casualty of this bug (down since 2026-07-05T23:32Z); restoring it is an operational step, not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
