### PR TITLE
docs: teach tag-driven doc injection and how to change a running loop

### DIFF
--- a/internal/tools/loop_create_tool.go
+++ b/internal/tools/loop_create_tool.go
@@ -566,7 +566,7 @@ func thaneLoopCreateSchema() map[string]any {
 			"tags": map[string]any{
 				"type":        "array",
 				"items":       map[string]any{"type": "string"},
-				"description": "Optional capability tags. For containers, every descendant inherits them; for executing loops, they scope the loop's tool surface. Omit to use only core tags.",
+				"description": "Optional capability tags. Each tag binds two things into the loop: its tool surface, AND every KB doc whose frontmatter carries that tag (injected into the loop's context each wake). For containers, every descendant inherits them; for executing loops, they scope the tool surface and pull in tagged knowledge. A knowledge-only tag (no tools, just docs) works too and needs no catalog entry. Omit to use only core tags.",
 			},
 			"instructions": map[string]any{
 				"type":        "string",

--- a/talents/loops-tagging.md
+++ b/talents/loops-tagging.md
@@ -4,12 +4,46 @@ tags: [loops]
 
 # Loop tagging
 
-When you launch a loop, the `tags` array decides what tools its
-iterations can reach. Get the tag set right and the loop has exactly
+When you launch a loop, the `tags` array decides what its
+iterations can reach — both the tools they can call and the tagged
+knowledge they carry. Get the tag set right and the loop has exactly
 what it needs; get it wrong and you've either starved the loop (no
 relevant tools) or distracted it with menus it doesn't need. Tagging
 is the single most consequential field on a loop launch after the
 sleep envelope.
+
+## Tags carry two things: a tool surface and a knowledge bundle
+
+A tag is a binding, and it binds two independent things into any loop
+that activates it:
+
+- **A tool surface** — the catalog tools under that tag, which the
+  rest of this talent is about.
+- **A knowledge bundle** — every KB article whose frontmatter `tags:`
+  includes that tag, injected into the loop's context in full, every
+  wake. This is how a loop *learns* something durable — a plant
+  primer, a doctrine, a house map — instead of re-deriving it each
+  cycle or being handed it inline.
+
+A tag can carry tools and no docs (`web`), docs and no tools, or both.
+A purpose-built tag like `hor-house-hvac` can be pure knowledge: no
+tools of its own, but tagging a doc with it and activating it on a
+loop injects that one doc into that one loop. A knowledge-only tag
+needs no catalog entry — the match is purely frontmatter `tags:`
+against the loop's active tags. (A tool-surface tag must be a real
+registered tag; see the tag-as-label anti-pattern below.)
+
+To route a specific document into specific loops:
+
+1. Put a dedicated tag on the doc's frontmatter — `tags:
+   [hor-house-hvac]`. Use `tags_all:` instead when the loop must
+   carry *all* listed tags before the doc loads.
+2. Put that same tag in the `tags` of exactly the loop definitions
+   that should read it.
+
+The doc then injects into those loops and nowhere else, and re-scans
+every turn — edit the frontmatter or the body and the change
+propagates without a restart.
 
 ## What's always there
 
@@ -73,6 +107,14 @@ which loop family is doing the launching:
   no `awareness`, no actual server-watching capability). The loop
   still runs, but it runs blind. Use a real tag name; the catalog is
   the source of truth.
+
+- **Routing a doc through a broad capability tag.** Tagging a
+  document with `ha` to "get it into the climate loops" injects it
+  into *every* loop that activates `ha` — and into your own core loop
+  the moment you open the home trailhead. Broad tags leak; a
+  purpose-built tag aims. When a doc is for a specific set of loops,
+  give it its own tag and activate that tag only where the knowledge
+  belongs.
 
 - **Over-tagging "just in case."** Every tag you add pulls in its
   full tool surface, its trailhead/doctrine talents, and any KB

--- a/talents/loops-tagging.md
+++ b/talents/loops-tagging.md
@@ -20,18 +20,21 @@ that activates it:
 - **A tool surface** — the catalog tools under that tag, which the
   rest of this talent is about.
 - **A knowledge bundle** — every KB article whose frontmatter `tags:`
-  includes that tag, injected into the loop's context in full, every
-  wake. This is how a loop *learns* something durable — a plant
-  primer, a doctrine, a house map — instead of re-deriving it each
-  cycle or being handed it inline.
+  includes that tag, injected into the loop's context each wake
+  (subject to a per-bucket size cap — an oversized article is
+  truncated with a marker rather than dropped silently). This is how a
+  loop *learns* something durable — a plant primer, a doctrine, a
+  house map — instead of re-deriving it each cycle or being handed it
+  inline.
 
 A tag can carry tools and no docs (`web`), docs and no tools, or both.
 A purpose-built tag like `hor-house-hvac` can be pure knowledge: no
 tools of its own, but tagging a doc with it and activating it on a
 loop injects that one doc into that one loop. A knowledge-only tag
 needs no catalog entry — the match is purely frontmatter `tags:`
-against the loop's active tags. (A tool-surface tag must be a real
-registered tag; see the tag-as-label anti-pattern below.)
+against the loop's active tags. (Only the tool-surface half needs
+registration; a tag that just routes knowledge does not — see the
+tag-as-label anti-pattern below.)
 
 To route a specific document into specific loops:
 

--- a/talents/loops.md
+++ b/talents/loops.md
@@ -107,5 +107,34 @@ muddle them and the loop drifts.
   script through unstructured input, that's the signal — a loop
   with interpretive instructions handles it more durably.
 
+## Changing a loop that's already running
+
+A running loop carries the config it launched with. Editing its
+stored definition doesn't reach the live instance — the edit waits
+in the overlay until the loop relaunches. Which verb you reach for
+depends on what changed:
+
+- **Scalars** (sleep envelope, quality floor) —
+  `loop_definition_update` promotes the value into the running loop
+  at its next turn boundary. No relaunch, no lost iteration.
+- **Structure** (tags, entity subscriptions, parent, model) — these
+  bind at launch, so they take effect only on a full relaunch:
+  `stop_loop` then `loop_definition_launch`, or `loop_reparent` for a
+  parent change (it does the stop-and-relaunch for you). A process
+  restart relaunches everything from its stored definition.
+
+Two consequences worth holding:
+
+- **Inheritance resolves at launch, not continuously.** Re-tag a
+  container that's already running and neither it nor its live
+  children carry the new tag until they relaunch — the container to
+  pick up its own new tag, then the children to inherit it. Plan a
+  container's shared tags up front when you can.
+- **A container with live children can't be stopped in place.** Its
+  descendants resolve their home from its current launch, so stopping
+  it would strand them. Move or stop the children first
+  (`loop_reparent` each, or `stop_loop` them), then relaunch the
+  container. That's why re-tagging a busy container is churn.
+
 When you need concrete JSON launch patterns, activate `loops_examples`
 and adapt the closest recipe minimally.

--- a/talents/loops.md
+++ b/talents/loops.md
@@ -109,19 +109,24 @@ muddle them and the loop drifts.
 
 ## Changing a loop that's already running
 
-A running loop carries the config it launched with. Editing its
-stored definition doesn't reach the live instance — the edit waits
-in the overlay until the loop relaunches. Which verb you reach for
-depends on what changed:
+A running loop carries the config it launched with. Whether an edit
+reaches the live instance or waits for a relaunch depends on the tool
+you use, not just the field:
 
-- **Scalars** (sleep envelope, quality floor) —
-  `loop_definition_update` promotes the value into the running loop
-  at its next turn boundary. No relaunch, no lost iteration.
-- **Structure** (tags, entity subscriptions, parent, model) — these
-  bind at launch, so they take effect only on a full relaunch:
-  `stop_loop` then `loop_definition_launch`, or `loop_reparent` for a
-  parent change (it does the stop-and-relaunch for you). A process
-  restart relaunches everything from its stored definition.
+- **Retune it live** — task, model, instructions, sleep envelope,
+  quality floor, supervisor, max_iter all promote into the running
+  loop via `loop_definition_update` at its next turn boundary. No
+  relaunch, no lost iteration.
+- **Change its watch set live** — entity subscriptions have their own
+  door: `add_entity_subscription` / `remove_entity_subscription` with
+  `owner` set to the loop's name edit one watch entry in place, also
+  without a relaunch.
+- **Relaunch-tier changes** — tags and parent bind at launch, so they
+  take effect only on a full relaunch: `stop_loop` then
+  `loop_definition_launch`, or `loop_reparent` for a parent change (it
+  does the stop-and-relaunch for you). A wholesale spec rewrite via
+  `loop_definition_set`, or a process restart, relaunches from the
+  stored definition too.
 
 Two consequences worth holding:
 


### PR DESCRIPTION
Two model-facing teaching gaps surfaced while standing up the `model_bench` climate loops — the same session that exposed #1224. Both are talent-only; no code behavior changes.

## Tags inject documents, not just tools

`talents/loops-tagging.md` taught only the tool-surface half of what a tag does. Live, that led the model to first tag a doc with plain frontmatter labels (`hvac`, `climate`) that surface nothing, then with the broad `ha` capability tag — which injects the doc into *every* loop that activates `ha`, including the core loop. The mechanism it was missing (confirmed in `tag_context.go`): a tag also carries a **knowledge bundle** — every KB article whose frontmatter `tags:` intersects the loop's active tags is injected into context each wake, re-scanned every turn, and a knowledge-only purpose tag needs no catalog entry at all.

This PR adds that half:
- A new section, *"Tags carry two things: a tool surface and a knowledge bundle,"* with the two-step recipe for routing one doc into a specific set of loops (dedicated tag on the doc + that tag in those loop definitions).
- A new anti-pattern, *"Routing a doc through a broad capability tag,"* naming the `ha`-leaks-everywhere trap directly: broad tags leak, purpose-built tags aim.
- The intro sentence now says tags decide what a loop can reach — *both* the tools it calls and the tagged knowledge it carries.
- The `thane_loop_create` `tags` param description (the model's decision-time surface) now names the KB-injection half too, instead of describing tags as tool-surface-only — this was the stale door that had the model reach for the broad `ha` tag. Brings the create front-door in line with `loop_spec_schema.go`, which already said "KB exposure."

## Changing a loop that's already running

`talents/loops.md` never framed the decision the model kept fumbling: a running loop keeps the config it launched with, so editing its stored definition doesn't reach the live instance until it relaunches. New *"Changing a loop that's already running"* section states the rule — **scalars** (sleep, quality floor) retune live via `loop_definition_update`; **structure** (tags, subscriptions, parent, model) binds at launch and needs a full relaunch — plus the two consequences the model hit experimentally: inheritance resolves at launch (re-tagging a container means relaunching it and its children), and a container with live children can't be stopped in place. The relevant tool descriptions (`loop_definition_set`, `loop_reparent`) already carry these mechanics; this adds the missing *decision frame* in the doctrine.

## Scope

- Talents plus the paired `thane_loop_create` tool-description tweak (the model's decision-time surface for gap 2). The generated talent mirror under `internal/model/talents/defaults` is regenerated by `just ci` (gitignored), so it's not in the diff.
- Gap 1 from the #1224 review (launch verbs killing loops at turn end) is a code fix, not a doc gap — it lands in #1225, not here.

`just ci` passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
