### PR TITLE
feat: mid-turn input merge — PullInput engine seam delivers new messages into a live turn (#1221)

### DIFF
--- a/internal/app/adapters.go
+++ b/internal/app/adapters.go
@@ -1075,6 +1075,7 @@ func compileLoopAgentRequest(req looppkg.Request) *agent.Request {
 		InitialTags:           append([]string(nil), req.InitialTags...),
 		RuntimeTags:           append([]string(nil), req.RuntimeTags...),
 		RuntimeTools:          compileLoopRuntimeTools(req.RuntimeTools),
+		PullInput:             req.PullInput,
 		MaxIterations:         req.MaxIterations,
 		MaxOutputTokens:       req.MaxOutputTokens,
 		ToolTimeout:           req.ToolTimeout,

--- a/internal/channels/messaging/signal/bridge.go
+++ b/internal/channels/messaging/signal/bridge.go
@@ -777,9 +777,11 @@ func (b *Bridge) prepareSignalMailboxTurn(ctx context.Context, sender string, it
 	turn := b.agentTurnMessages(scaffold.convID, scaffold.channelBinding, msgs, scaffold.opts, summary)
 	// Mid-turn input merge (#1221): let the loop pull messages that arrive
 	// while this turn is composing, rendered in channel voice. The loop owns
-	// delta-gating, the drain budget, and the ack; this only renders.
+	// delta-gating, the drain budget, and the ack; this only renders. Close
+	// over the scaffold already built for this turn so repeated pulls don't
+	// rebuild it (and re-persist the conversation binding) each time.
 	turn.PullRender = func(rctx context.Context, items []loop.MailboxItem) []llm.Message {
-		return b.renderPulledMailbox(rctx, sender, items)
+		return b.renderPulledMailbox(rctx, scaffold, items)
 	}
 	return turn, nil
 }
@@ -865,11 +867,11 @@ func (b *Bridge) prepareSignalTurnScaffold(sender string) signalTurnScaffold {
 // content that landed while the model was mid-work, so it is presented as
 // channel input, never in a system voice. The loop supplies only fresh,
 // delta-gated items; this method does not touch the mailbox or ack.
-func (b *Bridge) renderPulledMailbox(ctx context.Context, sender string, items []loop.MailboxItem) []llm.Message {
+func (b *Bridge) renderPulledMailbox(ctx context.Context, scaffold signalTurnScaffold, items []loop.MailboxItem) []llm.Message {
 	if len(items) == 0 {
 		return nil
 	}
-	scaffold := b.prepareSignalTurnScaffold(sender)
+	sender := scaffold.sender
 	out := make([]llm.Message, 0, len(items))
 	for _, item := range items {
 		var env Envelope

--- a/internal/channels/messaging/signal/bridge.go
+++ b/internal/channels/messaging/signal/bridge.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/nugget/thane-ai-agent/internal/channels/messages"
+	"github.com/nugget/thane-ai-agent/internal/model/llm"
 	"github.com/nugget/thane-ai-agent/internal/model/prompts"
 	"github.com/nugget/thane-ai-agent/internal/model/router"
 	"github.com/nugget/thane-ai-agent/internal/platform/config"
@@ -773,7 +774,14 @@ func (b *Bridge) prepareSignalMailboxTurn(ctx context.Context, sender string, it
 		}
 		scaffold.opts = b.requestOptions(sender, hints)
 	}
-	return b.agentTurnMessages(scaffold.convID, scaffold.channelBinding, msgs, scaffold.opts, summary), nil
+	turn := b.agentTurnMessages(scaffold.convID, scaffold.channelBinding, msgs, scaffold.opts, summary)
+	// Mid-turn input merge (#1221): let the loop pull messages that arrive
+	// while this turn is composing, rendered in channel voice. The loop owns
+	// delta-gating, the drain budget, and the ack; this only renders.
+	turn.PullRender = func(rctx context.Context, items []loop.MailboxItem) []llm.Message {
+		return b.renderPulledMailbox(rctx, sender, items)
+	}
+	return turn, nil
 }
 
 func (b *Bridge) prepareLoopNotificationTurn(ctx context.Context, sender string, envs []messages.Envelope) (*loop.AgentTurn, error) {
@@ -847,6 +855,44 @@ func (b *Bridge) prepareSignalTurnScaffold(sender string) signalTurnScaffold {
 			"sender": sender,
 		}),
 	}
+}
+
+// renderPulledMailbox renders mailbox items that arrived mid-turn into
+// channel-voice user messages for the #1221 mid-turn input merge. It reuses
+// renderEnvelope (so attachment processing, reaction handling, and
+// last-inbound bookkeeping still run exactly once per item), then wraps the
+// rendered text in explicit provenance framing: this is sender-controlled
+// content that landed while the model was mid-work, so it is presented as
+// channel input, never in a system voice. The loop supplies only fresh,
+// delta-gated items; this method does not touch the mailbox or ack.
+func (b *Bridge) renderPulledMailbox(ctx context.Context, sender string, items []loop.MailboxItem) []llm.Message {
+	if len(items) == 0 {
+		return nil
+	}
+	scaffold := b.prepareSignalTurnScaffold(sender)
+	out := make([]llm.Message, 0, len(items))
+	for _, item := range items {
+		var env Envelope
+		if err := json.Unmarshal(item.Payload, &env); err != nil {
+			b.logger.Warn("signal mid-turn mailbox item decode failed, skipping",
+				"sender", sender, "item_id", item.ID, "error", err)
+			continue
+		}
+		msg, _, ok, err := b.renderEnvelope(ctx, scaffold, &env)
+		if err != nil {
+			b.logger.Warn("signal mid-turn mailbox item render failed, skipping",
+				"sender", sender, "item_id", item.ID, "error", err)
+			continue
+		}
+		if !ok || strings.TrimSpace(msg.Content) == "" {
+			continue
+		}
+		out = append(out, llm.Message{
+			Role:    "user",
+			Content: "A new message arrived while you were working — read it before you finish, in case it changes your reply:\n\n" + msg.Content,
+		})
+	}
+	return out
 }
 
 func (b *Bridge) renderEnvelope(ctx context.Context, scaffold signalTurnScaffold, env *Envelope) (loop.Message, map[string]any, bool, error) {

--- a/internal/channels/messaging/signal/bridge_test.go
+++ b/internal/channels/messaging/signal/bridge_test.go
@@ -432,6 +432,51 @@ func TestBridge_PrepareSignalMailboxTurnRendersEachEnvelopeAsMessage(t *testing.
 	}
 }
 
+func TestBridge_MailboxTurnWiresChannelVoicePullRender(t *testing.T) {
+	bridge, _, _, _ := bridgeHelper(t)
+
+	mkItem := func(message string, ts int64) loop.MailboxItem {
+		t.Helper()
+		env := &Envelope{
+			Source:      "+15551234567",
+			SourceName:  "Alice",
+			Timestamp:   ts,
+			DataMessage: &DataMessage{Timestamp: ts, Message: message},
+		}
+		payload, err := json.Marshal(env)
+		if err != nil {
+			t.Fatalf("marshal envelope: %v", err)
+		}
+		return loop.MailboxItem{ID: fmt.Sprintf("signal:%d", ts), Payload: payload}
+	}
+
+	turn, err := bridge.prepareSignalMailboxTurn(context.Background(), "+15551234567",
+		[]loop.MailboxItem{mkItem("original question", 1700000000000)}, nil)
+	if err != nil {
+		t.Fatalf("prepareSignalMailboxTurn: %v", err)
+	}
+	if turn.PullRender == nil {
+		t.Fatal("mailbox turn did not wire PullRender for mid-turn input (#1221)")
+	}
+
+	// A message that arrives mid-turn renders as a channel-voice user message
+	// carrying explicit provenance — never a system voice.
+	msgs := turn.PullRender(context.Background(),
+		[]loop.MailboxItem{mkItem("actually, never mind", 1700000002000)})
+	if len(msgs) != 1 {
+		t.Fatalf("PullRender returned %d messages, want 1", len(msgs))
+	}
+	if msgs[0].Role != "user" {
+		t.Errorf("role = %q, want user", msgs[0].Role)
+	}
+	if !strings.Contains(msgs[0].Content, "arrived while you were working") {
+		t.Errorf("content missing provenance framing: %q", msgs[0].Content)
+	}
+	if !strings.Contains(msgs[0].Content, "actually, never mind") {
+		t.Errorf("content missing the message body: %q", msgs[0].Content)
+	}
+}
+
 func TestBridge_PrepareSignalMailboxTurnSkipsInvalidItems(t *testing.T) {
 	bridge, _, _, _ := bridgeHelper(t)
 

--- a/internal/runtime/agent/loop.go
+++ b/internal/runtime/agent/loop.go
@@ -46,26 +46,27 @@ type Message struct {
 
 // Request represents an incoming agent request.
 type Request struct {
-	Messages         []Message              `json:"messages"`
-	Model            string                 `json:"model,omitempty"`
-	ConversationID   string                 `json:"conversation_id,omitempty"`
-	ChannelBinding   *memory.ChannelBinding `json:"channel_binding,omitempty"`
-	RoutingFactors   map[string]string      `json:"routing_factors,omitempty"`   // Caller-supplied routing factors the router weights (see router.Factor* constants)
-	DelegationGating string                 `json:"delegation_gating,omitempty"` // Typed feature switch: "disabled" gives the model direct access to all tools instead of the orchestrator-and-delegate gating pattern
-	SkipContext      bool                   `json:"-"`                           // Skip memory, tools, and context injection (for lightweight completions)
-	AllowedTools     []string               `json:"-"`                           // Optional allowlist of tools visible for this run
-	ExcludeTools     []string               `json:"-"`                           // Tool names to exclude from this run (e.g., lifecycle tools for recurring wakes)
-	SkipTagFilter    bool                   `json:"-"`                           // Bypass capability tag filtering (for self-scoping contexts like metacognitive)
-	InitialTags      []string               `json:"-"`                           // Tags to activate at Run start (carried forward from previous loop iterations)
-	RuntimeTags      []string               `json:"-"`                           // Trusted runtime-asserted tags pinned for this run only
-	RuntimeTools     []*tools.Tool          `json:"-"`                           // Request-scoped tools visible only to this run
-	MaxIterations    int                    `json:"-"`                           // Optional per-request iteration cap (0 = default)
-	MaxOutputTokens  int                    `json:"-"`                           // Optional output-token budget across all iterations (0 = unlimited)
-	ToolTimeout      time.Duration          `json:"-"`                           // Optional per-tool timeout (0 = no extra timeout)
-	UsageRole        string                 `json:"-"`                           // Optional usage role override (e.g., "delegate")
-	UsageTaskName    string                 `json:"-"`                           // Optional usage task name override
-	FallbackContent  string                 `json:"-"`                           // Optional static fallback text when the run yields no content
-	PromptMode       agentctx.PromptMode    `json:"-"`                           // Optional system-prompt shape override.
+	Messages         []Message                           `json:"messages"`
+	Model            string                              `json:"model,omitempty"`
+	ConversationID   string                              `json:"conversation_id,omitempty"`
+	ChannelBinding   *memory.ChannelBinding              `json:"channel_binding,omitempty"`
+	RoutingFactors   map[string]string                   `json:"routing_factors,omitempty"`   // Caller-supplied routing factors the router weights (see router.Factor* constants)
+	DelegationGating string                              `json:"delegation_gating,omitempty"` // Typed feature switch: "disabled" gives the model direct access to all tools instead of the orchestrator-and-delegate gating pattern
+	SkipContext      bool                                `json:"-"`                           // Skip memory, tools, and context injection (for lightweight completions)
+	AllowedTools     []string                            `json:"-"`                           // Optional allowlist of tools visible for this run
+	ExcludeTools     []string                            `json:"-"`                           // Tool names to exclude from this run (e.g., lifecycle tools for recurring wakes)
+	SkipTagFilter    bool                                `json:"-"`                           // Bypass capability tag filtering (for self-scoping contexts like metacognitive)
+	InitialTags      []string                            `json:"-"`                           // Tags to activate at Run start (carried forward from previous loop iterations)
+	RuntimeTags      []string                            `json:"-"`                           // Trusted runtime-asserted tags pinned for this run only
+	RuntimeTools     []*tools.Tool                       `json:"-"`                           // Request-scoped tools visible only to this run
+	PullInput        func(context.Context) []llm.Message `json:"-"`                           // Polled at each iteration boundary and at closure to merge newly-arrived input into the live turn (#1221); nil disables
+	MaxIterations    int                                 `json:"-"`                           // Optional per-request iteration cap (0 = default)
+	MaxOutputTokens  int                                 `json:"-"`                           // Optional output-token budget across all iterations (0 = unlimited)
+	ToolTimeout      time.Duration                       `json:"-"`                           // Optional per-tool timeout (0 = no extra timeout)
+	UsageRole        string                              `json:"-"`                           // Optional usage role override (e.g., "delegate")
+	UsageTaskName    string                              `json:"-"`                           // Optional usage task name override
+	FallbackContent  string                              `json:"-"`                           // Optional static fallback text when the run yields no content
+	PromptMode       agentctx.PromptMode                 `json:"-"`                           // Optional system-prompt shape override.
 
 	// SystemPrompt, when non-empty, replaces the output of
 	// buildSystemPrompt(). Used by callers that assemble their own
@@ -2129,6 +2130,30 @@ func (l *Loop) Run(ctx context.Context, req *Request, stream StreamCallback) (re
 
 		CheckBudget: func(totalOut int) bool {
 			return req.MaxOutputTokens > 0 && totalOut >= req.MaxOutputTokens
+		},
+
+		// Mid-turn input merge (#1221): the loop builds req.PullInput over
+		// its mailbox (delta-gating, drain budget, ack); nil for runs with no
+		// live inbound source (delegates, HTTP completions), leaving engine
+		// behavior unchanged. Wrap it to record each injected user message in
+		// the conversation store at injection time — the same lifecycle point
+		// the opening user message is stored — so the persisted transcript
+		// matches the engine's message array (user → work → user → assistant).
+		PullInput: func(pctx context.Context) []llm.Message {
+			if req.PullInput == nil {
+				return nil
+			}
+			pulled := req.PullInput(pctx)
+			for _, m := range pulled {
+				if m.Role != "user" || m.Content == "" {
+					continue
+				}
+				if err := l.memory.AddMessage(convID, "user", m.Content); err != nil {
+					logging.Logger(pctx).Warn("failed to record mid-turn input in conversation store",
+						"conversation_id", convID, "error", err)
+				}
+			}
+			return pulled
 		},
 
 		Executor: &iterate.DirectExecutor{

--- a/internal/runtime/iterate/config.go
+++ b/internal/runtime/iterate/config.go
@@ -107,6 +107,18 @@ type Config struct {
 	// Nil means all tools are available.
 	CheckToolAvail func(name string) bool
 
+	// PullInput is polled at the top of each iteration — after any prior
+	// iteration's tool results are appended, before this iteration's LLM
+	// call — so it can never split a tool_use/tool_result pair. A non-empty
+	// return is appended verbatim as user-role messages and the iteration
+	// proceeds with them in context. This is the seam that merges
+	// newly-arrived conversation input into a live turn (#1221): a long
+	// tool-heavy turn becomes aware of messages that arrive while it works.
+	// Nil disables mid-turn input. The callback owns delta-gating (return
+	// only what is new) and any per-turn drain budget (return empty once
+	// spent); the engine appends whatever it returns without inspection.
+	PullInput func(ctx context.Context) []llm.Message
+
 	// NormalizeToolCall can rewrite or repair a model-emitted tool call
 	// before availability checks and execution. Use it for runtime
 	// compatibility shims such as aliasing common hallucinated names to

--- a/internal/runtime/iterate/engine.go
+++ b/internal/runtime/iterate/engine.go
@@ -52,6 +52,22 @@ func (e *Engine) Run(ctx context.Context, cfg Config, messages []llm.Message) (*
 		iterLog := log.With("iter", i)
 		iterCtx := logging.WithLogger(ctx, iterLog)
 
+		// --- Mid-turn input merge (#1221) ---
+		// Poll for newly-arrived conversation content at the iteration
+		// boundary. This runs after any prior iteration appended its
+		// tool_use/tool_result pair (that append completes before the
+		// `continue` that returns here), and before this iteration's LLM
+		// call, so the pair is never split. The callback delta-gates and
+		// budget-caps its own output; the engine appends it verbatim as
+		// user-role messages so the model sees the new input this call.
+		if cfg.PullInput != nil {
+			if pulled := cfg.PullInput(iterCtx); len(pulled) > 0 {
+				messages = append(messages, pulled...)
+				iterLog.Info("merged mid-turn input into live turn",
+					"pulled_messages", len(pulled))
+			}
+		}
+
 		// Get tool definitions for this iteration.
 		var toolDefs []map[string]any
 		if cfg.ToolDefs != nil {

--- a/internal/runtime/iterate/engine.go
+++ b/internal/runtime/iterate/engine.go
@@ -440,6 +440,29 @@ func (e *Engine) Run(ctx context.Context, cfg Config, messages []llm.Message) (*
 			// treats it as ExhaustNoOutput).
 		}
 
+		// --- Closure-time input merge (#1221) ---
+		// The model produced a complete reply and is about to end the turn.
+		// If new conversation input arrived while it was composing, fold that
+		// reply into history, append the new input, and keep the turn alive
+		// for one more iteration instead of shipping an answer the next
+		// message may already supersede. This is the second PullInput poll
+		// site: it reaches the zero-tool-call conversational case the
+		// top-of-iteration poll cannot, since a text-only reply has no later
+		// boundary. OnTextResponse is deliberately NOT fired here — this is
+		// not the turn's final reply, so memory/fact-extraction waits for the
+		// real close. The callback's shared per-turn drain budget bounds how
+		// many times a turn can be held open; the remainder rides the
+		// immediate post-turn re-wake.
+		if cfg.PullInput != nil && llmResp.Message.Content != "" {
+			if pulled := cfg.PullInput(iterCtx); len(pulled) > 0 {
+				messages = append(messages, llmResp.Message)
+				messages = append(messages, pulled...)
+				iterLog.Info("held turn open for input arriving at closure",
+					"pulled_messages", len(pulled))
+				continue
+			}
+		}
+
 		// Append the final assistant message before firing OnTextResponse
 		// so the callback receives a complete message history.
 		messages = append(messages, llmResp.Message)

--- a/internal/runtime/iterate/engine_test.go
+++ b/internal/runtime/iterate/engine_test.go
@@ -335,6 +335,76 @@ func TestEngine_PullInputNeverSplitsMultiToolBatch(t *testing.T) {
 	}
 }
 
+func TestEngine_PullInputHoldsTurnOpenAtClosure(t *testing.T) {
+	// A zero-tool-call conversational turn: the model produces a complete
+	// reply, but new input arrived while it composed. The closure poll keeps
+	// the turn alive for one more iteration rather than shipping a reply the
+	// new message supersedes.
+	mock := &mockLLM{
+		responses: []*llm.ChatResponse{
+			textResponse("Sure, I'll look into that."),
+			textResponse("Done — and I also handled Y."),
+		},
+	}
+	exec := &mockExecutor{}
+	cfg := baseCfg(mock, exec)
+
+	injected := llm.Message{Role: "user", Content: "Actually, also do Y"}
+	var polls int
+	cfg.PullInput = func(context.Context) []llm.Message {
+		polls++
+		// Poll 1: top of iter 0 (nothing yet). Poll 2: closure of iter 0's
+		// text reply (new input arrived). Poll 3: top of iter 1 (delta-gated
+		// empty). Poll 4: closure of iter 1 (nothing → turn ends).
+		if polls == 2 {
+			return []llm.Message{injected}
+		}
+		return nil
+	}
+
+	engine := &Engine{}
+	result, err := engine.Run(context.Background(), cfg, baseMessages())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(mock.calls) != 2 {
+		t.Fatalf("LLM calls = %d, want 2 (turn held open at closure)", len(mock.calls))
+	}
+	if result.Content != "Done — and I also handled Y." {
+		t.Errorf("final content = %q, want the continuation reply", result.Content)
+	}
+
+	// The second call saw the interim reply folded into history, then the
+	// injected input as the latest user message.
+	sent := mock.calls[1].Messages
+	if last := sent[len(sent)-1]; last.Role != "user" || last.Content != injected.Content {
+		t.Errorf("injected message not last on 2nd call: %+v", last)
+	}
+	if prev := sent[len(sent)-2]; prev.Role != "assistant" || prev.Content != "Sure, I'll look into that." {
+		t.Errorf("interim assistant reply missing before injection: %+v", prev)
+	}
+}
+
+func TestEngine_PullInputAtClosureNoInputEndsTurn(t *testing.T) {
+	// With nothing queued, the closure poll must not hold the turn open —
+	// a normal text reply ends the turn in a single iteration.
+	mock := &mockLLM{responses: []*llm.ChatResponse{textResponse("All done.")}}
+	cfg := baseCfg(mock, &mockExecutor{})
+	cfg.PullInput = func(context.Context) []llm.Message { return nil }
+
+	engine := &Engine{}
+	result, err := engine.Run(context.Background(), cfg, baseMessages())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(mock.calls) != 1 {
+		t.Fatalf("LLM calls = %d, want 1 (turn ends when nothing queued)", len(mock.calls))
+	}
+	if result.Content != "All done." {
+		t.Errorf("content = %q", result.Content)
+	}
+}
+
 func TestEngine_NormalizeToolCallPersistsNormalizedMessage(t *testing.T) {
 	mock := &mockLLM{
 		responses: []*llm.ChatResponse{

--- a/internal/runtime/iterate/engine_test.go
+++ b/internal/runtime/iterate/engine_test.go
@@ -227,6 +227,114 @@ func TestEngine_MultipleToolCalls(t *testing.T) {
 	}
 }
 
+func TestEngine_PullInputMergesMidTurn(t *testing.T) {
+	mock := &mockLLM{
+		responses: []*llm.ChatResponse{
+			toolCallResponse(makeToolCall("search", map[string]any{"q": "test"})),
+			textResponse("Answered with the new context."),
+		},
+	}
+	exec := &mockExecutor{results: map[string]string{"search": "result data"}}
+	cfg := baseCfg(mock, exec)
+
+	injected := llm.Message{Role: "user", Content: "New message from Alice, arrived while you were working: change of plans"}
+	var polls int
+	cfg.PullInput = func(context.Context) []llm.Message {
+		polls++
+		// Poll 1 is the top of iteration 0 (nothing new yet); poll 2 is the
+		// top of iteration 1, after the search tool result was appended.
+		if polls == 2 {
+			return []llm.Message{injected}
+		}
+		return nil
+	}
+
+	engine := &Engine{}
+	result, err := engine.Run(context.Background(), cfg, baseMessages())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Content != "Answered with the new context." {
+		t.Errorf("content = %q", result.Content)
+	}
+	if len(mock.calls) != 2 {
+		t.Fatalf("LLM calls = %d, want 2", len(mock.calls))
+	}
+
+	// The injected message must reach the model on the second LLM call,
+	// positioned immediately after the tool result — the tool_use/tool_result
+	// pair is never split.
+	sent := mock.calls[1].Messages
+	last := sent[len(sent)-1]
+	if last.Role != "user" || last.Content != injected.Content {
+		t.Errorf("last message on 2nd LLM call = %+v, want the injected user message", last)
+	}
+	if prev := sent[len(sent)-2]; prev.Role != "tool" {
+		t.Errorf("message before injection = %q, want tool result", prev.Role)
+	}
+
+	// The interleave order survives into the final history.
+	var found bool
+	for _, m := range result.Messages {
+		if m.Role == "user" && m.Content == injected.Content {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("injected message missing from final history: %+v", result.Messages)
+	}
+}
+
+func TestEngine_PullInputNeverSplitsMultiToolBatch(t *testing.T) {
+	mock := &mockLLM{
+		responses: []*llm.ChatResponse{
+			toolCallResponse(
+				makeToolCall("search", map[string]any{"q": "a"}),
+				makeToolCall("read", map[string]any{"path": "/x"}),
+			),
+			textResponse("done"),
+		},
+	}
+	exec := &mockExecutor{results: map[string]string{"search": "found", "read": "contents"}}
+	cfg := baseCfg(mock, exec)
+
+	injected := llm.Message{Role: "user", Content: "New message from Bob, arrived while you were working"}
+	var polls int
+	cfg.PullInput = func(context.Context) []llm.Message {
+		polls++
+		if polls == 2 {
+			return []llm.Message{injected}
+		}
+		return nil
+	}
+
+	engine := &Engine{}
+	if _, err := engine.Run(context.Background(), cfg, baseMessages()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// On the second LLM call, the assistant tool_use message must be
+	// immediately followed by BOTH of its tool results, with the injected
+	// user message only after them — nothing interleaved into the batch.
+	sent := mock.calls[1].Messages
+	asstIdx := -1
+	for i, m := range sent {
+		if m.Role == "assistant" && len(m.ToolCalls) == 2 {
+			asstIdx = i
+			break
+		}
+	}
+	if asstIdx == -1 || asstIdx+2 >= len(sent) {
+		t.Fatalf("expected assistant tool batch followed by its results, got %+v", sent)
+	}
+	if sent[asstIdx+1].Role != "tool" || sent[asstIdx+2].Role != "tool" {
+		t.Errorf("tool_use not immediately followed by its two tool results: %+v", sent[asstIdx:])
+	}
+	if last := sent[len(sent)-1]; last.Role != "user" || last.Content != injected.Content {
+		t.Errorf("injected message not positioned after both tool results: %+v", last)
+	}
+}
+
 func TestEngine_NormalizeToolCallPersistsNormalizedMessage(t *testing.T) {
 	mock := &mockLLM{
 		responses: []*llm.ChatResponse{

--- a/internal/runtime/loop/agent_turn.go
+++ b/internal/runtime/loop/agent_turn.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/nugget/thane-ai-agent/internal/channels/messages"
+	"github.com/nugget/thane-ai-agent/internal/model/llm"
 )
 
 // TurnInput is the loop wake context passed to a [TurnBuilder]. It is
@@ -74,6 +75,14 @@ type AgentTurn struct {
 	// snapshot and completion event. Values should stay small because
 	// they travel through dashboard/event payloads.
 	Summary map[string]any
+
+	// PullRender renders mailbox items that arrive mid-turn into channel-
+	// voice user messages for the #1221 mid-turn input merge. A builder
+	// backed by a live inbound channel (e.g. Signal) sets it; the loop wraps
+	// it in a delta-gated, budget-capped PullInput over its mailbox and wires
+	// that into the turn. Nil (the default) means the turn takes no mid-turn
+	// input — its reply is composed from the wake snapshot alone.
+	PullRender func(ctx context.Context, items []MailboxItem) []llm.Message
 }
 
 // TurnResultSink receives the model response and error for a single

--- a/internal/runtime/loop/config.go
+++ b/internal/runtime/loop/config.go
@@ -214,6 +214,12 @@ type Config struct {
 	// explicitly disable jitter.
 	Jitter *float64
 
+	// MidTurnInputBudget caps how many times a single turn may pull
+	// newly-arrived mailbox input mid-flight (#1221). Zero uses
+	// [defaultMidTurnInputBudget]. Only meaningful for loops with a live
+	// inbound channel that sets AgentTurn.PullRender.
+	MidTurnInputBudget int
+
 	// MaxDuration is the maximum wall-clock time the loop may run.
 	// Zero means unlimited.
 	MaxDuration time.Duration

--- a/internal/runtime/loop/loop.go
+++ b/internal/runtime/loop/loop.go
@@ -61,6 +61,14 @@ type Request struct {
 	// progress reporting.
 	OnProgress func(kind string, data map[string]any) `yaml:"-" json:"-"`
 
+	// PullInput, when set, is polled by the runner's engine at every
+	// iteration boundary and at turn closure to merge newly-arrived
+	// conversation input into this live turn (#1221). The loop builds it
+	// over its mailbox with delta-gating and a drain budget; the engine
+	// appends whatever it returns as user-role messages. Nil disables
+	// mid-turn input. Runtime-only.
+	PullInput func(ctx context.Context) []llm.Message `yaml:"-" json:"-"`
+
 	MaxIterations   int                 `yaml:"max_iterations,omitempty" json:"max_iterations,omitempty"`
 	MaxOutputTokens int                 `yaml:"max_output_tokens,omitempty" json:"max_output_tokens,omitempty"`
 	ToolTimeout     time.Duration       `yaml:"tool_timeout,omitempty" json:"tool_timeout,omitempty"`
@@ -1473,6 +1481,10 @@ func (l *Loop) run(ctx context.Context) {
 		var err error
 		var handlerSummary map[string]any
 		var noOp bool
+		// midTurnPulled collects mailbox items delivered into the live turn
+		// after the wake snapshot (#1221) so the turn-end ack covers them
+		// alongside the wake batch.
+		var midTurnPulled []MailboxItem
 		// Transition to processing and emit iteration_start before
 		// dispatching work so the dashboard sees activity immediately.
 		l.setState(StateProcessing)
@@ -1617,6 +1629,15 @@ func (l *Loop) run(ctx context.Context) {
 						l.currentConvID = convID
 						l.mu.Unlock()
 					}
+					// Mid-turn input merge (#1221): when the builder supplied a
+					// channel renderer and this loop has a mailbox, wire a
+					// delta-gated, budget-capped PullInput over the mailbox onto
+					// the prepared request (set here, after preparation, so no
+					// request-base merge can wipe it). Items it delivers are
+					// acked with the wake batch at turn end.
+					if turn.PullRender != nil && l.deps.Mailbox != nil {
+						req.PullInput = l.buildMailboxPullInput(mailboxItems, &midTurnPulled, turn.PullRender)
+					}
 					runCtx, runCancel := mergeTurnRunContext(iterCtx, turn.RunContext)
 					result, turnResp, turnErr = l.runAgentTurn(runCtx, req, turn.Stream, iterStart, isSupervisor, supervisorTrigger)
 					runCancel()
@@ -1641,11 +1662,18 @@ func (l *Loop) run(ctx context.Context) {
 			}
 		}
 
-		if mailboxErr == nil && len(mailboxItems) > 0 && err == nil && (result != nil || noOp) {
-			if ackErr := l.AckMailbox(ctx, mailboxItems); ackErr != nil {
+		// Ack the wake batch plus anything merged mid-turn (#1221) at the
+		// same lifecycle point — turn end, only on a clean turn — so a crash
+		// mid-turn leaves every delivered item pending for redelivery.
+		ackItems := mailboxItems
+		if len(midTurnPulled) > 0 {
+			ackItems = append(append([]MailboxItem(nil), mailboxItems...), midTurnPulled...)
+		}
+		if mailboxErr == nil && len(ackItems) > 0 && err == nil && (result != nil || noOp) {
+			if ackErr := l.AckMailbox(ctx, ackItems); ackErr != nil {
 				iterLog.Warn("loop mailbox ack failed",
 					"error", ackErr,
-					"items", len(mailboxItems),
+					"items", len(ackItems),
 				)
 			}
 			l.wakeIfMailboxNonEmpty(ctx)

--- a/internal/runtime/loop/mailbox.go
+++ b/internal/runtime/loop/mailbox.go
@@ -44,11 +44,17 @@ type MailboxReceipt struct {
 const maxMailboxItemsPerWake = 16
 
 // defaultMidTurnInputBudget caps how many times a single turn may pull
-// newly-arrived mailbox input mid-flight (#1221). Bounding pulls — not items
-// — keeps turn boundaries reachable under continuous inbound flow (#1152):
-// once spent, the remainder rides the buffered-wakeCh immediate re-wake.
-// Override per loop via Config.MidTurnInputBudget.
+// newly-arrived mailbox input mid-flight (#1221). Bounding pulls keeps turn
+// boundaries reachable under continuous inbound flow (#1152): once spent, the
+// remainder rides the buffered-wakeCh immediate re-wake. Override per loop via
+// Config.MidTurnInputBudget.
 const defaultMidTurnInputBudget = 8
+
+// maxMidTurnItemsPerPull bounds how many fresh items a single pull injects, so
+// a large pending backlog can't blow up prompt size or per-iteration
+// render/store work in one shot. The overflow stays pending for the next pull
+// (within budget) or the post-turn re-wake. Matches the wake drain cap.
+const maxMidTurnItemsPerPull = maxMailboxItemsPerWake
 
 func (l *Loop) midTurnInputBudget() int {
 	if l.config.MidTurnInputBudget > 0 {
@@ -60,11 +66,14 @@ func (l *Loop) midTurnInputBudget() int {
 // buildMailboxPullInput returns a PullInput closure over this loop's mailbox
 // for the #1221 mid-turn input merge. Each call peeks pending items, skips any
 // already delivered this turn — the wake batch plus prior pulls (delta-gating,
-// so content is never re-presented) — caps the number of pulls per turn
-// (drain budget), renders the fresh items via render (channel voice), appends
-// them to *pulled so the turn-end ack covers them, and returns the rendered
-// messages. Returns nil once the budget is spent or nothing new is pending,
-// which the engine reads as "no mid-turn input."
+// so content is never re-presented) — takes at most maxMidTurnItemsPerPull
+// fresh items (bounding prompt growth and render/store work per pull), caps the
+// number of pulls per turn (drain budget), renders those items via render
+// (channel voice), appends them to *pulled so the turn-end ack covers them, and
+// returns the rendered messages. Returns nil once the budget is spent or
+// nothing new is pending, which the engine reads as "no mid-turn input." Items
+// left over from a capped pull stay pending for the next pull or post-turn
+// re-wake.
 func (l *Loop) buildMailboxPullInput(
 	wakeBatch []MailboxItem,
 	pulled *[]MailboxItem,
@@ -89,8 +98,12 @@ func (l *Loop) buildMailboxPullInput(
 		}
 		var fresh []MailboxItem
 		for _, it := range items {
-			if !delivered[it.ID] {
-				fresh = append(fresh, it)
+			if delivered[it.ID] {
+				continue
+			}
+			fresh = append(fresh, it)
+			if len(fresh) >= maxMidTurnItemsPerPull {
+				break // bound prompt growth and render/store work per pull
 			}
 		}
 		if len(fresh) == 0 {

--- a/internal/runtime/loop/mailbox.go
+++ b/internal/runtime/loop/mailbox.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/nugget/thane-ai-agent/internal/model/llm"
 	"github.com/nugget/thane-ai-agent/internal/state/loopqueue"
 )
 
@@ -41,6 +42,72 @@ type MailboxReceipt struct {
 }
 
 const maxMailboxItemsPerWake = 16
+
+// defaultMidTurnInputBudget caps how many times a single turn may pull
+// newly-arrived mailbox input mid-flight (#1221). Bounding pulls — not items
+// — keeps turn boundaries reachable under continuous inbound flow (#1152):
+// once spent, the remainder rides the buffered-wakeCh immediate re-wake.
+// Override per loop via Config.MidTurnInputBudget.
+const defaultMidTurnInputBudget = 8
+
+func (l *Loop) midTurnInputBudget() int {
+	if l.config.MidTurnInputBudget > 0 {
+		return l.config.MidTurnInputBudget
+	}
+	return defaultMidTurnInputBudget
+}
+
+// buildMailboxPullInput returns a PullInput closure over this loop's mailbox
+// for the #1221 mid-turn input merge. Each call peeks pending items, skips any
+// already delivered this turn — the wake batch plus prior pulls (delta-gating,
+// so content is never re-presented) — caps the number of pulls per turn
+// (drain budget), renders the fresh items via render (channel voice), appends
+// them to *pulled so the turn-end ack covers them, and returns the rendered
+// messages. Returns nil once the budget is spent or nothing new is pending,
+// which the engine reads as "no mid-turn input."
+func (l *Loop) buildMailboxPullInput(
+	wakeBatch []MailboxItem,
+	pulled *[]MailboxItem,
+	render func(context.Context, []MailboxItem) []llm.Message,
+) func(context.Context) []llm.Message {
+	delivered := make(map[string]bool, len(wakeBatch))
+	for _, it := range wakeBatch {
+		delivered[it.ID] = true
+	}
+	budget := l.midTurnInputBudget()
+	pulls := 0
+
+	return func(ctx context.Context) []llm.Message {
+		if pulls >= budget {
+			return nil
+		}
+		items, err := l.DrainMailbox(ctx, 0) // peek all pending; delta-gate below
+		if err != nil {
+			l.deps.Logger.Warn("mid-turn mailbox peek failed",
+				"loop_id", l.id, "loop_name", l.config.Name, "error", err)
+			return nil
+		}
+		var fresh []MailboxItem
+		for _, it := range items {
+			if !delivered[it.ID] {
+				fresh = append(fresh, it)
+			}
+		}
+		if len(fresh) == 0 {
+			return nil
+		}
+		rendered := render(ctx, fresh)
+		if len(rendered) == 0 {
+			return nil
+		}
+		pulls++
+		for _, it := range fresh {
+			delivered[it.ID] = true
+		}
+		*pulled = append(*pulled, fresh...)
+		return rendered
+	}
+}
 
 type mailboxItemsContextKey struct{}
 

--- a/internal/runtime/loop/mailbox_test.go
+++ b/internal/runtime/loop/mailbox_test.go
@@ -2,6 +2,7 @@ package loop
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/nugget/thane-ai-agent/internal/model/llm"
@@ -85,6 +86,53 @@ func TestBuildMailboxPullInputDeltaGatesAndBudgets(t *testing.T) {
 	// (mid-1, mid-2, mid-3) — the budget-blocked mid-4 is not.
 	if len(pulled) != 3 {
 		t.Fatalf("ack accumulator = %d, want 3 (mid-1, mid-2, mid-3)", len(pulled))
+	}
+}
+
+// TestBuildMailboxPullInputCapsItemsPerPull confirms a single pull injects at
+// most maxMidTurnItemsPerPull items even with a larger backlog, so prompt size
+// and render/store work stay bounded; the remainder rides the next pull.
+func TestBuildMailboxPullInputCapsItemsPerPull(t *testing.T) {
+	t.Parallel()
+
+	mailbox := newTestMailbox(t)
+	l := mustNew(t, Config{Name: "pull-cap", Task: "t", MidTurnInputBudget: 8},
+		Deps{Runner: &noopRunner{}, Mailbox: mailbox})
+	ctx := context.Background()
+
+	render := func(_ context.Context, items []MailboxItem) []llm.Message {
+		out := make([]llm.Message, len(items))
+		for i, it := range items {
+			out[i] = llm.Message{Role: "user", Content: string(it.Payload)}
+		}
+		return out
+	}
+	var pulled []MailboxItem
+	pull := l.buildMailboxPullInput(nil, &pulled, render)
+
+	overflow := 3
+	total := maxMidTurnItemsPerPull + overflow
+	for i := 0; i < total; i++ {
+		if _, err := mailbox.Enqueue(ctx, l.Name(), "test", []byte(fmt.Sprintf("m%02d", i))); err != nil {
+			t.Fatalf("enqueue: %v", err)
+		}
+	}
+
+	first := pull(ctx)
+	if len(first) != maxMidTurnItemsPerPull {
+		t.Fatalf("first pull delivered %d, want per-pull cap %d", len(first), maxMidTurnItemsPerPull)
+	}
+	// FIFO: the oldest items came first.
+	if first[0].Content != "m00" {
+		t.Errorf("first item = %q, want oldest (m00)", first[0].Content)
+	}
+
+	second := pull(ctx)
+	if len(second) != overflow {
+		t.Fatalf("second pull delivered %d, want the %d remainder", len(second), overflow)
+	}
+	if len(pulled) != total {
+		t.Fatalf("ack accumulator = %d, want %d (all delivered across pulls)", len(pulled), total)
 	}
 }
 

--- a/internal/runtime/loop/mailbox_test.go
+++ b/internal/runtime/loop/mailbox_test.go
@@ -1,0 +1,101 @@
+package loop
+
+import (
+	"context"
+	"testing"
+
+	"github.com/nugget/thane-ai-agent/internal/model/llm"
+)
+
+// TestBuildMailboxPullInputDeltaGatesAndBudgets exercises the #1221 loop-side
+// PullInput mechanics: it delivers only newly-arrived items (delta-gating
+// against the wake batch and prior pulls), accumulates delivered items for the
+// turn-end ack, and stops pulling once the configurable drain budget is spent —
+// the guarantee that a turn under continuous inbound flow still terminates.
+func TestBuildMailboxPullInputDeltaGatesAndBudgets(t *testing.T) {
+	t.Parallel()
+
+	mailbox := newTestMailbox(t)
+	l := mustNew(t, Config{
+		Name:               "pull-test",
+		Task:               "t",
+		MidTurnInputBudget: 2,
+	}, Deps{Runner: &noopRunner{}, Mailbox: mailbox})
+
+	ctx := context.Background()
+	enq := func(s string) MailboxItem {
+		it, err := mailbox.Enqueue(ctx, l.Name(), "test", []byte(s))
+		if err != nil {
+			t.Fatalf("enqueue %q: %v", s, err)
+		}
+		return it
+	}
+
+	// The wake batch is peeked-and-rendered at wake; the closure must treat it
+	// as already delivered.
+	wakeBatch := []MailboxItem{enq("wake-1"), enq("wake-2")}
+
+	render := func(_ context.Context, items []MailboxItem) []llm.Message {
+		out := make([]llm.Message, 0, len(items))
+		for _, it := range items {
+			out = append(out, llm.Message{Role: "user", Content: string(it.Payload)})
+		}
+		return out
+	}
+
+	var pulled []MailboxItem
+	pull := l.buildMailboxPullInput(wakeBatch, &pulled, render)
+
+	// Nothing new beyond the wake batch → nil (never re-present delivered).
+	if got := pull(ctx); got != nil {
+		t.Fatalf("first pull = %+v, want nil (wake batch delta-gated)", got)
+	}
+
+	enq("mid-1")
+	enq("mid-2")
+
+	// Budget pull #1: both fresh items, in order.
+	got := pull(ctx)
+	if len(got) != 2 || got[0].Content != "mid-1" || got[1].Content != "mid-2" {
+		t.Fatalf("second pull = %+v, want [mid-1 mid-2]", got)
+	}
+	if len(pulled) != 2 {
+		t.Fatalf("ack accumulator = %d, want 2 after first delivering pull", len(pulled))
+	}
+
+	// Re-poll with nothing new → nil (delta-gated against prior pulls).
+	if got := pull(ctx); got != nil {
+		t.Fatalf("third pull = %+v, want nil (already delivered)", got)
+	}
+
+	// Budget pull #2.
+	enq("mid-3")
+	if got := pull(ctx); len(got) != 1 || got[0].Content != "mid-3" {
+		t.Fatalf("fourth pull = %+v, want [mid-3]", got)
+	}
+
+	// Budget spent (2 delivering pulls): further arrivals do not extend the
+	// turn — they ride the post-turn re-wake instead.
+	enq("mid-4")
+	if got := pull(ctx); got != nil {
+		t.Fatalf("fifth pull = %+v, want nil (drain budget exhausted)", got)
+	}
+
+	// Everything delivered mid-turn is accumulated for the single turn-end ack
+	// (mid-1, mid-2, mid-3) — the budget-blocked mid-4 is not.
+	if len(pulled) != 3 {
+		t.Fatalf("ack accumulator = %d, want 3 (mid-1, mid-2, mid-3)", len(pulled))
+	}
+}
+
+// TestBuildMailboxPullInputDefaultBudget confirms the zero-value budget falls
+// back to the package default rather than blocking all pulls.
+func TestBuildMailboxPullInputDefaultBudget(t *testing.T) {
+	t.Parallel()
+
+	l := mustNew(t, Config{Name: "pull-default", Task: "t"},
+		Deps{Runner: &noopRunner{}, Mailbox: newTestMailbox(t)})
+	if got := l.midTurnInputBudget(); got != defaultMidTurnInputBudget {
+		t.Fatalf("midTurnInputBudget() = %d, want default %d", got, defaultMidTurnInputBudget)
+	}
+}


### PR DESCRIPTION
Phase 2 of the mid-turn message delivery arc. Depends on the Phase 1 mailbox (#1220, merged). This makes a long, tool-heavy turn *aware of messages that arrive while it works*, so it stops shipping answers that are already stale or superseded.

## The engine seam (bus-agnostic)

`iterate.Config` gains a `PullInput func(ctx) []llm.Message` callback with **two poll sites**:

1. **Top of each iteration** — after the prior iteration's tool_use/tool_result pair is appended, before the next LLM call, so a tool pair is never split. This catches input during tool-heavy work.
2. **At closure** — when the model returns a text-only reply and is about to finalize, poll once more. If new input arrived, fold the reply into history, append the input, and continue for one more iteration instead of ending. This reaches the zero-tool conversational case the top-of-iteration poll can't — the "honest limitation" the issue documented — and is arguably the more valuable half for an interactive Signal loop.

Fold-into-final: the interim reply is never delivered (the runner sends only the returned `Result`, after `Run` returns) and `OnTextResponse` doesn't fire for it, so memory/fact-extraction still runs once, on the true close. Nil `PullInput` leaves every existing caller unchanged. The consecutive-user-message shape is already proven — `convertToAnthropic` emits one user message per tool result, so multi-tool batches produce consecutive user messages in prod today.

## Loop wiring (delta-gating, budget, ack, store)

`PullInput` threads `loop.Request → loopAdapter → agent.Request → iterate.Config`. The loop builds the closure over its mailbox (`Loop.buildMailboxPullInput`): peek pending, **delta-gate** against the wake batch and prior pulls (never re-present), cap by a configurable **drain budget** (`Config.MidTurnInputBudget`, default 8) so a turn under continuous inbound flow still terminates — the remainder rides the buffered-`wakeCh` immediate re-wake — and accumulate delivered items so the **single turn-end ack** covers the wake batch plus every mid-turn pull. A crash mid-turn leaves everything pending for redelivery.

**Store interleaving:** the runner wraps `PullInput` to record each injected user message in the conversation store at injection time — the same lifecycle point the opening user message is stored — so the persisted transcript matches the engine's message array.

**Provenance:** rendering is delegated to a channel-supplied `AgentTurn.PullRender`, keeping the loop bus-agnostic. The Signal bridge renders mid-turn arrivals in channel voice with explicit provenance ("A new message arrived while you were working …"), reusing `renderEnvelope` so attachment processing and last-inbound bookkeeping run once per item.

## Tests

- Engine: mid-turn merge reaches the model after the tool result; multi-tool batch integrity (tool_use immediately followed by both results, injection only after); closure holds a turn open for late input; closure with nothing queued ends the turn in one iteration.
- Loop: delta-gating + drain-budget cap + ack accumulation; default-budget fallback.
- Signal: channel-voice `PullRender` shape and provenance framing.

`just ci` passes locally.

## Scope / sequencing

The dedicated model-teaching synthesis is Phase 3 (#1222), so tool-description prose is intentionally light here. `#1220 → this → #1222`.

Closes #1221

🤖 Generated with [Claude Code](https://claude.com/claude-code)
