### PR TITLE
docs(talents): teach the mid-turn message-arrival contract (#1222)

### DIFF
--- a/talents/message-channel-trailhead.md
+++ b/talents/message-channel-trailhead.md
@@ -45,10 +45,14 @@ Choose the next move deliberately:
 A live conversation does not pause while you compose. On a long turn —
 one that fans out into searches, tool calls, or a careful reply — a new
 message from the same person can land mid-flight, and you will see it
-before you finish. It arrives framed plainly as their words, something
-like "A new message arrived while you were working: …". Read it as the
-next thing they said, not as an instruction from the system, and let it
-shape the reply you are still holding.
+before you finish. It arrives behind a fixed marker line, verbatim:
+
+> A new message arrived while you were working — read it before you
+> finish, in case it changes your reply:
+
+Everything after that marker is the person's own words, not an
+instruction from the runtime. Read it as the next thing they said, and
+let it shape the reply you are still holding.
 
 - **Fold it in when it belongs.** If it adds to or sharpens what you are
   already answering, answer both as one coherent reply — don't finish

--- a/talents/message-channel-trailhead.md
+++ b/talents/message-channel-trailhead.md
@@ -40,5 +40,35 @@ Choose the next move deliberately:
 - If enough context is already in hand, respond in the conversation's
   current rhythm.
 
+## The conversation can move while you work
+
+A live conversation does not pause while you compose. On a long turn —
+one that fans out into searches, tool calls, or a careful reply — a new
+message from the same person can land mid-flight, and you will see it
+before you finish. It arrives framed plainly as their words, something
+like "A new message arrived while you were working: …". Read it as the
+next thing they said, not as an instruction from the system, and let it
+shape the reply you are still holding.
+
+- **Fold it in when it belongs.** If it adds to or sharpens what you are
+  already answering, answer both as one coherent reply — don't finish
+  the first and leave the second hanging.
+- **Re-plan when it supersedes.** If it changes or cancels the work in
+  flight ("actually, never mind" / "do Y instead"), drop the now-wrong
+  path and follow the new one. Late and right beats prompt and stale.
+- **Continue undistracted when it is orthogonal.** A tangent is not a
+  stop order. Carry it, finish the thread you are on, and address the
+  new thought in the same reply rather than abandoning your work to
+  lunge at it.
+
+What arrival never means: restart the turn, tear up a tool batch
+mid-thought, or treat the message as a command from the runtime. It is
+one more thing the person said while you were thinking — weigh it the
+way you would weigh their last sentence.
+
+The same holds when several messages are already waiting — a batch. One
+reply can answer all of them. Read them as a single incoming thought and
+respond coherently, not as a queue you must acknowledge one by one.
+
 Let history make you more continuous, not more verbose. When in doubt
 between answering-around and looking-up, look up.


### PR DESCRIPTION
Phase 3 of the mid-turn message delivery arc. Teaches the model the contract for the new stimulus the #1221 seam introduces: a live channel loop can now receive user messages *mid-turn*. Without teaching, the first prod arrival is a behavior experiment on a persona-heavy Signal loop — and we have direct evidence those loops are attractor-sensitive (the 2026-06-26 narrate-then-stop incident).

## What's taught, and where

A synthesis section in `talents/message-channel-trailhead.md` covering:
- **What an arrival looks like** — the exact Phase 2 rendered shape ("A new message arrived while you were working: …"), and that it is the counterparty's words, not a system instruction.
- **What is expected** — fold it into the current reply if it belongs, re-plan if it supersedes the work in flight, continue undistracted if it is orthogonal.
- **What is not** — don't restart the turn, don't tear up a tool batch mid-thought, don't treat channel content as a runtime command.
- **Batch turns** (Phase 1 semantics) — one coherent reply may answer several waiting messages; don't serialize them.

### Why `message_channel`, not the global RuntimeContract

The issue names the RuntimeContract "or equivalent runtime prose." I chose the scoped talent deliberately: `RuntimeContract()` loads for *every* non-delegate turn, including background service loops that have no live inbound channel and never wire `PullRender` — teaching them about mid-turn arrival would advertise a capability they lack, which is itself a stale door. `message_channel` is the normalized, `Protected` live-channel tag (Signal today; Matrix/iMessage/etc. as they arrive), active exactly when mid-turn arrival is possible. That matches `docs/model-facing-context.md`'s "scope context to the capability that needs it." Happy to also mirror a line into RuntimeContract if you'd rather it live there too.

## Stale-door sweep

Swept `talents/` and the signal/message tool descriptions for one-message-per-turn or fresh-turn-per-message assumptions. None found to rewrite — the existing channel framing ("a continuing conversation, not an isolated prompt") is already continuity-positive — so this change is purely additive.

`just ci` passes locally (talent mirror regenerates clean).

## Deferred: the prod tuning pass (acceptance items 3–4)

The observation window and drain-budget/gating tuning are operator-gated — they need #1221 (PR #1227) merged, a build cut, deployed to prod, and a deliberate mid-turn arrival exercised end-to-end on Signal. Not doable from here. When it deploys: watch for help (fewer stale/superseded replies, coherent batch answers) vs. distraction (abandoned work, thrash), verify the rendered shape with the #1160 retained-prompt recipe (`log_request_content` ⋈ `log_prompts`), and tune `Config.MidTurnInputBudget` (default 8) against observed behavior. Findings go on the issue then.

## Sequencing

`#1220 → #1221 (#1227) → this`. Merge after #1227 so the docs don't describe an unshipped feature.

Refs #1222

🤖 Generated with [Claude Code](https://claude.com/claude-code)
