### PR TITLE
fix(lmstudio): always emit message content so LM Studio doesn't 400 on empty

### DIFF
--- a/internal/model/fleet/providers/lmstudio_test.go
+++ b/internal/model/fleet/providers/lmstudio_test.go
@@ -173,17 +173,33 @@ func TestToLMStudioMessages_EmptyContentIsEmittedNotOmitted(t *testing.T) {
 	if err != nil {
 		t.Fatalf("marshal: %v", err)
 	}
-	got := string(b)
 
-	// Every message — including the empty-content ones — must carry a content field.
-	if n := strings.Count(got, `"content":`); n != len(msgs) {
-		t.Fatalf("content field count = %d, want %d (one per message)\njson: %s", n, len(msgs), got)
+	// Inspect the actual top-level message objects rather than substring-matching
+	// the whole payload — a "content" key nested inside tool-call arguments must
+	// not be mistaken for a message-level content field.
+	var decoded []map[string]json.RawMessage
+	if err := json.Unmarshal(b, &decoded); err != nil {
+		t.Fatalf("unmarshal wire: %v", err)
 	}
-	if !strings.Contains(got, `"role":"assistant","content":""`) {
-		t.Errorf("assistant tool-call message must carry empty-string content, got: %s", got)
+	if len(decoded) != len(msgs) {
+		t.Fatalf("decoded %d messages, want %d", len(decoded), len(msgs))
 	}
-	if !strings.Contains(got, `"role":"tool","content":""`) {
-		t.Errorf("tool result must carry empty-string content, got: %s", got)
+	for i, m := range decoded {
+		raw, ok := m["content"]
+		if !ok {
+			t.Errorf("message %d (role %q) has no content field — LM Studio 400s on this", i, msgs[i].Role)
+			continue
+		}
+		// The empty-content assistant tool-call and tool result must serialize an
+		// empty string, not a dropped field or a JSON null.
+		if msgs[i].Content == "" {
+			var s string
+			if err := json.Unmarshal(raw, &s); err != nil {
+				t.Errorf("message %d (role %q) content is not a string: %s", i, msgs[i].Role, raw)
+			} else if s != "" {
+				t.Errorf("message %d (role %q) content = %q, want empty string", i, msgs[i].Role, s)
+			}
+		}
 	}
 }
 

--- a/internal/model/fleet/providers/lmstudio_test.go
+++ b/internal/model/fleet/providers/lmstudio_test.go
@@ -146,6 +146,47 @@ func TestLMStudioListModelInfos_FallsBackToOpenAIEndpoint(t *testing.T) {
 	}
 }
 
+func TestToLMStudioMessages_EmptyContentIsEmittedNotOmitted(t *testing.T) {
+	t.Parallel()
+
+	// An assistant message carrying only tool_calls and a tool result with
+	// empty output must still serialize a `content` field. Omitting it (the
+	// prior behavior: unset `any` + `omitempty`) made LM Studio reject the
+	// request with 400 "content field must be a string or an array of
+	// objects".
+	var tc llm.ToolCall
+	tc.ID = "tc1"
+	tc.Function.Name = "replace_output_climate_bench_qwen"
+	tc.Function.Arguments = map[string]any{"body": "..."}
+
+	msgs := []llm.Message{
+		{Role: "user", Content: "update the doc"},
+		{Role: "assistant", Content: "", ToolCalls: []llm.ToolCall{tc}}, // tool call, no text
+		{Role: "tool", Content: "", ToolCallID: "tc1"},                  // empty tool result
+	}
+
+	wire, err := toLMStudioMessages(msgs)
+	if err != nil {
+		t.Fatalf("toLMStudioMessages: %v", err)
+	}
+	b, err := json.Marshal(wire)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	got := string(b)
+
+	// Every message — including the empty-content ones — must carry a content field.
+	if n := strings.Count(got, `"content":`); n != len(msgs) {
+		t.Fatalf("content field count = %d, want %d (one per message)\njson: %s", n, len(msgs), got)
+	}
+	if !strings.Contains(got, `"role":"assistant","content":""`) {
+		t.Errorf("assistant tool-call message must carry empty-string content, got: %s", got)
+	}
+	if !strings.Contains(got, `"role":"tool","content":""`) {
+		t.Errorf("tool result must carry empty-string content, got: %s", got)
+	}
+}
+
 func TestLMStudioChat_NonStreamingToolCalls(t *testing.T) {
 	t.Parallel()
 

--- a/internal/model/fleet/providers/lmstudio_wire.go
+++ b/internal/model/fleet/providers/lmstudio_wire.go
@@ -225,7 +225,14 @@ func toLMStudioMessages(msgs []llm.Message) ([]lmStudioMessage, error) {
 				})
 			}
 			wire.Content = parts
-		case m.Content != "":
+		default:
+			// Always emit content as a string, even when empty. Leaving it
+			// unset makes `content,omitempty` drop the field, and strict
+			// OpenAI-compatible servers such as LM Studio then reject the
+			// message with "content field must be a string or an array of
+			// objects" — which bites assistant messages that carry only
+			// tool_calls and tool results with empty output. The ollama
+			// adapter already always sets content; this keeps parity.
 			wire.Content = m.Content
 		}
 		if len(m.ToolCalls) > 0 {


### PR DESCRIPTION
## The bug

A live loop (`climate_bench_qwen`, the qwen bench arm) started failing mid-turn with:

> `API error 400: {"error":"Invalid 'content': 'content' field must be a string or an array of objects.."}`

`toLMStudioMessages` only assigned `wire.Content` when the message had non-empty text or an image; otherwise it left `Content` as an unset `any`. With `json:"content,omitempty"` the field is then **dropped entirely**, and LM Studio's OpenAI-compatible endpoint rejects a message with no `content` — for assistant messages that carry *only* `tool_calls` (no accompanying text) and for tool results with empty output.

The neutralize check shows exactly this — without the fix the wire is:
```json
[{"role":"user","content":"..."},
 {"role":"assistant","tool_calls":[...]},        // no content field
 {"role":"tool","tool_call_id":"tc1"}]           // no content field
```

**Why now / why intermittent:** it depends on whether the model emitted text alongside its tool call, so only *some* turns fail. It surfaced because the qwen arm just started routing through the **lmstudio** provider — the **ollama** adapter already sets `Content: m.Content` unconditionally, which is why the spark/ollama (gpt-oss) arm never hit it. Not related to the mid-turn `#1221` work (inert for a service loop with no `PullRender`).

## The fix

Always emit `content` as a string (empty when there's no text) for non-image messages, matching the ollama adapter. `omitempty` keeps an interface holding `""` (verified in the test — it serializes `"content":""`).

## Test

`TestToLMStudioMessages_EmptyContentIsEmittedNotOmitted` builds an assistant-tool-call message with empty content and an empty tool result, and asserts both serialize a `content` field. Confirmed it fails without the fix and passes with it; `just ci` green.

## Deploy note

This is a code fix, so prod needs a build+deploy to pick it up. Until then the qwen bench arm will keep intermittently 400ing on pure-tool-call turns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)