### PR TITLE
Return the newest working-memory window, not the oldest

### DIFF
--- a/internal/app/new_stores.go
+++ b/internal/app/new_stores.go
@@ -357,6 +357,11 @@ func (a *App) initStores(s *newState) error {
 		TriggerRatio:         0.7, // Compact at 70% of MaxTokens
 		KeepRecent:           10,  // Preserve the last 10 messages verbatim
 		MinMessagesToCompact: 15,  // Don't bother compacting tiny conversations
+		// Count-aware trigger: keep the active set bounded below the store's
+		// read window (maxMessages=100, above) so short-message runs that
+		// stay under the token budget still compact — 20 rows of headroom
+		// absorb #1220 mid-turn mailbox bursts before the window would clip.
+		MaxActiveMessages: 80,
 	}
 
 	summarizeFunc := func(ctx context.Context, prompt string) (string, error) {

--- a/internal/state/memory/compaction.go
+++ b/internal/state/memory/compaction.go
@@ -17,6 +17,13 @@ type CompactionConfig struct {
 	TriggerRatio         float64 // Trigger compaction at this ratio (e.g., 0.7 = 70%)
 	KeepRecent           int     // Number of recent messages to always keep
 	MinMessagesToCompact int     // Minimum messages before considering compaction
+	// MaxActiveMessages triggers compaction when the active non-summary
+	// message count reaches this value, independent of tokens. The token
+	// gate alone misses a long run of SHORT messages, which can push the
+	// active count past the store's read window (maxMessages) while total
+	// tokens stay under MaxTokens*TriggerRatio — starving the model of
+	// recent context. 0 disables the count trigger (pure token-gated).
+	MaxActiveMessages int
 }
 
 // DefaultCompactionConfig returns sensible defaults.
@@ -26,6 +33,7 @@ func DefaultCompactionConfig() CompactionConfig {
 		TriggerRatio:         0.7,   // Trigger at 70% full
 		KeepRecent:           10,    // Keep last 10 messages
 		MinMessagesToCompact: 20,    // Don't compact tiny conversations
+		MaxActiveMessages:    0,     // Count trigger off by default; prod wires it
 	}
 }
 
@@ -38,6 +46,9 @@ const CompactionSummaryPrefix = "[Conversation Summary]"
 // CompactableStore is the interface for stores that support compaction.
 type CompactableStore interface {
 	GetTokenCount(conversationID string) int
+	// ActiveMessageCount is the active non-summary message count — the
+	// reducible set — backing the count-aware compaction trigger.
+	ActiveMessageCount(conversationID string) int
 	GetMessagesForCompaction(conversationID string, keep int) []Message
 	GetActiveCompactionSummaries(conversationID string) ([]Message, error)
 	// ApplyCompaction atomically marks compactedIDs compacted and
@@ -98,10 +109,21 @@ func (c *Compactor) CompactionThreshold() int {
 	return int(float64(c.config.MaxTokens) * c.config.TriggerRatio)
 }
 
-// NeedsCompaction checks if a conversation needs compaction.
+// NeedsCompaction checks if a conversation needs compaction. It fires on
+// either the token budget (the long-standing gate) or, when configured,
+// the active non-summary message count reaching MaxActiveMessages. The
+// count gate catches short-message overflow the token gate misses — the
+// exact precondition of the working-memory freeze — so the predicate is
+// a strict superset of the prior token-only behavior.
 func (c *Compactor) NeedsCompaction(conversationID string) bool {
-	tokenCount := c.store.GetTokenCount(conversationID)
-	return tokenCount > c.CompactionThreshold()
+	if c.store.GetTokenCount(conversationID) > c.CompactionThreshold() {
+		return true
+	}
+	if c.config.MaxActiveMessages > 0 &&
+		c.store.ActiveMessageCount(conversationID) >= c.config.MaxActiveMessages {
+		return true
+	}
+	return false
 }
 
 // tryAcquire marks the conversation as compacting, returning false when

--- a/internal/state/memory/compaction.go
+++ b/internal/state/memory/compaction.go
@@ -285,13 +285,22 @@ func formatCompactionSummary(messages []Message, summary string) string {
 func (c *Compactor) CompactionStats(conversationID string) map[string]any {
 	tokenCount := c.store.GetTokenCount(conversationID)
 	threshold := int(float64(c.config.MaxTokens) * c.config.TriggerRatio)
+	activeCount := c.store.ActiveMessageCount(conversationID)
+
+	// needs_compaction must reflect BOTH gates (token budget OR active
+	// count), matching NeedsCompaction — otherwise the stat lies whenever
+	// the count gate is the reason compaction fires.
+	needsToken := tokenCount > threshold
+	needsCount := c.config.MaxActiveMessages > 0 && activeCount >= c.config.MaxActiveMessages
 
 	return map[string]any{
-		"token_count":      tokenCount,
-		"max_tokens":       c.config.MaxTokens,
-		"trigger_at":       threshold,
-		"needs_compaction": tokenCount > threshold,
-		"ratio":            float64(tokenCount) / float64(c.config.MaxTokens),
+		"token_count":          tokenCount,
+		"max_tokens":           c.config.MaxTokens,
+		"trigger_at":           threshold,
+		"active_message_count": activeCount,
+		"max_active_messages":  c.config.MaxActiveMessages,
+		"needs_compaction":     needsToken || needsCount,
+		"ratio":                float64(tokenCount) / float64(c.config.MaxTokens),
 	}
 }
 

--- a/internal/state/memory/compaction_test.go
+++ b/internal/state/memory/compaction_test.go
@@ -264,4 +264,27 @@ func TestCompactionStats(t *testing.T) {
 	if stats["max_tokens"] != config.MaxTokens {
 		t.Errorf("Expected max_tokens %d, got %v", config.MaxTokens, stats["max_tokens"])
 	}
+	for _, k := range []string{"active_message_count", "max_active_messages", "needs_compaction"} {
+		if _, ok := stats[k]; !ok {
+			t.Errorf("stats missing key %q", k)
+		}
+	}
+
+	// needs_compaction must reflect the count gate even when tokens are
+	// well under the token threshold — otherwise the stat contradicts
+	// NeedsCompaction whenever the count trigger is what fires.
+	base := time.Now().Add(-time.Hour).Truncate(time.Second)
+	for i := 0; i < 8; i++ {
+		insertMessageAt(t, store, "conv-count", "user", "short", base.Add(time.Duration(i)*time.Minute))
+	}
+	countCompactor := NewCompactor(store, CompactionConfig{
+		MaxTokens: 1_000_000, TriggerRatio: 0.7, MaxActiveMessages: 5,
+	}, &SimpleSummarizer{}, slog.Default())
+	cs := countCompactor.CompactionStats("conv-count")
+	if cs["active_message_count"] != 8 {
+		t.Errorf("active_message_count = %v, want 8", cs["active_message_count"])
+	}
+	if cs["needs_compaction"] != true {
+		t.Errorf("needs_compaction = %v, want true (count gate fires under token threshold)", cs["needs_compaction"])
+	}
 }

--- a/internal/state/memory/sqlite.go
+++ b/internal/state/memory/sqlite.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/google/uuid"
@@ -18,6 +19,13 @@ type SQLiteStore struct {
 	db          *sql.DB
 	maxMessages int
 	logger      *slog.Logger
+
+	// clipWarnAt rate-limits the "read window clipped" warning per
+	// conversation. GetMessages returns at most maxMessages recent rows;
+	// a conversation whose active set exceeds that is read every turn, so
+	// an unthrottled warning would spam. Guarded by clipWarnMu.
+	clipWarnMu sync.Mutex
+	clipWarnAt map[string]time.Time
 }
 
 // NewSQLiteStore creates a new SQLite-backed store.
@@ -45,6 +53,7 @@ func NewSQLiteStoreWithLogger(dbPath string, maxMessages int, logger *slog.Logge
 		db:          db,
 		maxMessages: maxMessages,
 		logger:      logger,
+		clipWarnAt:  make(map[string]time.Time),
 	}
 
 	if err := store.migrate(); err != nil {
@@ -151,15 +160,41 @@ func (s *SQLiteStore) AddMessage(conversationID, role, content string) error {
 	return nil
 }
 
-// GetMessages retrieves messages for a conversation.
+// GetMessages retrieves the working-memory window for a conversation:
+// the newest maxMessages active rows plus every active compaction
+// summary, returned in chronological (ASC) order.
+//
+// The window is deliberately anchored to the NEWEST rows. A naive
+// `ORDER BY timestamp ASC LIMIT maxMessages` returns the OLDEST rows,
+// so once the active set exceeds maxMessages every newer message falls
+// outside the window and the model's context silently freezes at that
+// point (the amnesia bug). Compaction is token-gated and does not bound
+// the active message count, so a long run of short messages can push
+// the count past maxMessages while staying under the token threshold —
+// hence the newest-N window is load-bearing, not just tidy.
+//
+// Compaction summaries carry the compacted region's earliest timestamp
+// (ApplyCompaction), so they sort at the head of history and would fall
+// outside a naive newest-N window; the UNION arm force-includes them so
+// the model never loses its compacted past. UNION (set semantics) also
+// dedupes a summary that happens to land inside the newest-N window.
 func (s *SQLiteStore) GetMessages(conversationID string) []Message {
 	rows, err := s.db.Query(`
+		WITH recent AS (
+			SELECT id, role, content, timestamp
+			FROM messages
+			WHERE conversation_id = ? AND status = 'active'
+			ORDER BY timestamp DESC, id DESC
+			LIMIT ?
+		)
+		SELECT id, role, content, timestamp FROM recent
+		UNION
 		SELECT id, role, content, timestamp
 		FROM messages
-		WHERE conversation_id = ? AND status = 'active'
-		ORDER BY timestamp ASC
-		LIMIT ?
-	`, conversationID, s.maxMessages)
+		WHERE conversation_id = ? AND status = 'active' AND role = 'system'
+		  AND content LIKE ? || '%'
+		ORDER BY timestamp ASC, id ASC
+	`, conversationID, s.maxMessages, conversationID, CompactionSummaryPrefix)
 	if err != nil {
 		return []Message{}
 	}
@@ -174,7 +209,60 @@ func (s *SQLiteStore) GetMessages(conversationID string) []Message {
 		messages = append(messages, m)
 	}
 
+	// Observability: if the active set is larger than the window we just
+	// returned, we clipped older messages. A silent clip is exactly what
+	// hid the amnesia bug for so long — surface it (rate-limited). The
+	// COUNT is best-effort and never blocks history retrieval.
+	var activeTotal int
+	_ = s.db.QueryRow(`
+		SELECT COUNT(*) FROM messages
+		WHERE conversation_id = ? AND status = 'active'
+	`, conversationID).Scan(&activeTotal)
+	if activeTotal > len(messages) {
+		s.maybeWarnClip(conversationID, activeTotal, len(messages))
+	}
+
 	return messages
+}
+
+// maybeWarnClip emits a rate-limited warning when GetMessages returned
+// fewer rows than the conversation's active set — i.e. the read window
+// clipped older active messages. Throttled per-conversation so a hot
+// overflowing conversation (read every turn) does not spam the log.
+func (s *SQLiteStore) maybeWarnClip(conversationID string, activeTotal, returned int) {
+	if s.logger == nil {
+		return
+	}
+
+	s.clipWarnMu.Lock()
+	if last, ok := s.clipWarnAt[conversationID]; ok && time.Since(last) < 5*time.Minute {
+		s.clipWarnMu.Unlock()
+		return
+	}
+	s.clipWarnAt[conversationID] = time.Now()
+	s.clipWarnMu.Unlock()
+
+	s.logger.Warn("working-memory read window clipped older active messages",
+		"conversation_id", conversationID,
+		"active_total", activeTotal,
+		"returned", returned,
+		"max_messages", s.maxMessages,
+	)
+}
+
+// ActiveMessageCount returns the number of active non-system messages in
+// a conversation — the reducible set compaction can actually shrink
+// (GetMessagesForCompaction filters role != 'system' too). Feeds the
+// count-aware compaction trigger so a summary-only overflow can't spin
+// an unsatisfiable compaction loop.
+func (s *SQLiteStore) ActiveMessageCount(conversationID string) int {
+	var count int
+	_ = s.db.QueryRow(`
+		SELECT COUNT(*)
+		FROM messages
+		WHERE conversation_id = ? AND status = 'active' AND role != 'system'
+	`, conversationID).Scan(&count)
+	return count
 }
 
 // GetConversation retrieves a conversation by ID.
@@ -222,7 +310,19 @@ func (s *SQLiteStore) Clear(conversationID string) error {
 		return err
 	}
 
-	return tx.Commit()
+	if err := tx.Commit(); err != nil {
+		return err
+	}
+
+	// Evict the clip-warning rate-limit entry: delegate conversations use a
+	// fresh unique ID per invocation and Clear on finish, so without this
+	// the map would grow one stale entry per overflowing delegate for the
+	// life of the process.
+	s.clipWarnMu.Lock()
+	delete(s.clipWarnAt, conversationID)
+	s.clipWarnMu.Unlock()
+
+	return nil
 }
 
 // Stats returns memory statistics.

--- a/internal/state/memory/sqlite.go
+++ b/internal/state/memory/sqlite.go
@@ -209,17 +209,22 @@ func (s *SQLiteStore) GetMessages(conversationID string) []Message {
 		messages = append(messages, m)
 	}
 
-	// Observability: if the active set is larger than the window we just
-	// returned, we clipped older messages. A silent clip is exactly what
-	// hid the amnesia bug for so long — surface it (rate-limited). The
-	// COUNT is best-effort and never blocks history retrieval.
-	var activeTotal int
-	_ = s.db.QueryRow(`
-		SELECT COUNT(*) FROM messages
-		WHERE conversation_id = ? AND status = 'active'
-	`, conversationID).Scan(&activeTotal)
-	if activeTotal > len(messages) {
-		s.maybeWarnClip(conversationID, activeTotal, len(messages))
+	// Observability: a read may have clipped older active rows. Clipping is
+	// only possible when the window came back saturated — a result smaller
+	// than maxMessages means the whole active set fit (active > maxMessages
+	// would have filled the newest-N window), so skip the COUNT entirely in
+	// that common case. When it could have clipped, confirm with a
+	// best-effort COUNT and warn (rate-limited); the COUNT never blocks
+	// history retrieval. A silent clip is exactly what hid the amnesia bug.
+	if len(messages) >= s.maxMessages {
+		var activeTotal int
+		_ = s.db.QueryRow(`
+			SELECT COUNT(*) FROM messages
+			WHERE conversation_id = ? AND status = 'active'
+		`, conversationID).Scan(&activeTotal)
+		if activeTotal > len(messages) {
+			s.maybeWarnClip(conversationID, activeTotal, len(messages))
+		}
 	}
 
 	return messages

--- a/internal/state/memory/working_window_test.go
+++ b/internal/state/memory/working_window_test.go
@@ -1,0 +1,381 @@
+package memory
+
+import (
+	"bytes"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+)
+
+// insertActiveAt inserts a single active row with an explicit id and
+// timestamp — used where two rows must share a timestamp (the shared-id
+// helper insertMessageAt would collide on its ts-derived primary key).
+func insertActiveAt(t *testing.T, store *SQLiteStore, convID, id, role, content string, ts time.Time) {
+	t.Helper()
+	if _, err := store.db.Exec(`
+		INSERT INTO messages (id, conversation_id, role, content, timestamp, token_count, status)
+		VALUES (?, ?, ?, ?, ?, 100, 'active')
+	`, id, convID, role, content, ts); err != nil {
+		t.Fatalf("insert message: %v", err)
+	}
+}
+
+func newWindowStore(t *testing.T, maxMessages int) *SQLiteStore {
+	t.Helper()
+	store, err := NewSQLiteStore(t.TempDir()+"/window.db", maxMessages)
+	if err != nil {
+		t.Fatalf("NewSQLiteStore: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	if _, err := store.GetOrCreateConversation("conv-1"); err != nil {
+		t.Fatalf("GetOrCreateConversation: %v", err)
+	}
+	return store
+}
+
+// TestGetMessages_OverflowReturnsNewestNotOldest is the core freeze
+// regression guard: when the active set exceeds maxMessages, the window
+// must be the NEWEST rows, not the oldest. The old query returned the
+// oldest maxMessages, so context froze at that point forever.
+func TestGetMessages_OverflowReturnsNewestNotOldest(t *testing.T) {
+	store := newWindowStore(t, 5)
+	base := time.Now().Add(-time.Hour).Truncate(time.Second)
+	for i := 1; i <= 12; i++ {
+		insertActiveAt(t, store, "conv-1",
+			msgID(i), "user", msgContent(i), base.Add(time.Duration(i)*time.Minute))
+	}
+
+	got := store.GetMessages("conv-1")
+	if len(got) != 5 {
+		t.Fatalf("len = %d, want 5", len(got))
+	}
+	// Chronological ASC, newest window: m08..m12.
+	if got[0].Content != msgContent(8) {
+		t.Errorf("first = %q, want %q (newest window, not the frozen oldest)", got[0].Content, msgContent(8))
+	}
+	if got[len(got)-1].Content != msgContent(12) {
+		t.Errorf("last = %q, want %q (newest message)", got[len(got)-1].Content, msgContent(12))
+	}
+	for _, m := range got {
+		if m.Content == msgContent(1) {
+			t.Fatalf("oldest message m01 present — window is still frozen at the oldest rows")
+		}
+	}
+	assertAscending(t, got)
+}
+
+// TestGetMessages_OverflowPreservesCompactionSummary proves the
+// compaction summary (stamped at an OLD timestamp, outside a naive
+// newest-N window) is force-included even when the active set overflows.
+func TestGetMessages_OverflowPreservesCompactionSummary(t *testing.T) {
+	store := newWindowStore(t, 5)
+	base := time.Now().Add(-2 * time.Hour).Truncate(time.Second)
+
+	// Summary at the oldest position.
+	insertActiveAt(t, store, "conv-1", "summary-0", "system",
+		CompactionSummaryPrefix+"\n\ncondensed older history", base)
+
+	// 20 newer short dialogue rows (tokens stay well under any threshold).
+	for i := 1; i <= 20; i++ {
+		insertActiveAt(t, store, "conv-1",
+			msgID(i), "user", msgContent(i), base.Add(time.Duration(i)*time.Minute))
+	}
+
+	got := store.GetMessages("conv-1")
+	if len(got) != 6 { // 5 newest dialogue + 1 summary
+		t.Fatalf("len = %d, want 6 (5 newest + summary)", len(got))
+	}
+	if got[0].Role != "system" || !strings.HasPrefix(got[0].Content, CompactionSummaryPrefix) {
+		t.Fatalf("first row = %+v, want the compaction summary at the head", got[0])
+	}
+	summaries := 0
+	for _, m := range got {
+		if m.Role == "system" && strings.HasPrefix(m.Content, CompactionSummaryPrefix) {
+			summaries++
+		}
+	}
+	if summaries != 1 {
+		t.Errorf("summary count = %d, want exactly 1", summaries)
+	}
+	// The five dialogue rows must be the newest: m16..m20.
+	if got[len(got)-1].Content != msgContent(20) {
+		t.Errorf("last = %q, want %q", got[len(got)-1].Content, msgContent(20))
+	}
+	assertAscending(t, got)
+}
+
+// TestGetMessages_ExcludesCompactedRows pins the recent-CTE's
+// status='active' filter: a compacted original (replaced by a summary)
+// must never leak back into the working window, even when the active set
+// is under maxMessages and the newest-N reach extends back over it — the
+// normal post-compaction steady state.
+func TestGetMessages_ExcludesCompactedRows(t *testing.T) {
+	store := newWindowStore(t, 10)
+	base := time.Now().Add(-time.Hour).Truncate(time.Second)
+	// A raw row that compaction folded away (status='compacted'), at an
+	// old ts within the newest-N reach.
+	if _, err := store.db.Exec(`
+		INSERT INTO messages (id, conversation_id, role, content, timestamp, token_count, status)
+		VALUES ('compacted-orig', 'conv-1', 'user', 'raw row replaced by summary', ?, 100, 'compacted')
+	`, base.Add(1*time.Minute)); err != nil {
+		t.Fatalf("insert compacted: %v", err)
+	}
+	// Its replacement summary, plus live dialogue.
+	insertActiveAt(t, store, "conv-1", "sum", "system",
+		CompactionSummaryPrefix+"\n\nreplaces older history", base.Add(30*time.Second))
+	for i := 1; i <= 3; i++ {
+		insertActiveAt(t, store, "conv-1", msgID(i), "user", msgContent(i), base.Add(time.Duration(i+2)*time.Minute))
+	}
+
+	for _, m := range store.GetMessages("conv-1") {
+		if m.ID == "compacted-orig" {
+			t.Fatalf("compacted row leaked into working window: %+v", m)
+		}
+	}
+}
+
+// TestGetMessages_SummaryInsideWindowNotDuplicated guards against a
+// UNION-ALL regression: a summary that also falls inside the newest-N
+// window must appear exactly once.
+func TestGetMessages_SummaryInsideWindowNotDuplicated(t *testing.T) {
+	store := newWindowStore(t, 10)
+	base := time.Now().Add(-time.Hour).Truncate(time.Second)
+	insertActiveAt(t, store, "conv-1", "u1", "user", "u1", base.Add(1*time.Minute))
+	insertActiveAt(t, store, "conv-1", "u2", "user", "u2", base.Add(2*time.Minute))
+	insertActiveAt(t, store, "conv-1", "summary-recent", "system",
+		CompactionSummaryPrefix+"\n\nrecent summary", base.Add(3*time.Minute))
+	insertActiveAt(t, store, "conv-1", "u3", "user", "u3", base.Add(4*time.Minute))
+
+	got := store.GetMessages("conv-1")
+	if len(got) != 4 {
+		t.Fatalf("len = %d, want 4 (no duplicate summary)", len(got))
+	}
+	summaries := 0
+	for _, m := range got {
+		if strings.HasPrefix(m.Content, CompactionSummaryPrefix) {
+			summaries++
+		}
+	}
+	if summaries != 1 {
+		t.Errorf("summary count = %d, want 1 (UNION must dedupe)", summaries)
+	}
+	assertAscending(t, got)
+}
+
+// TestGetMessages_UnderMaxUnchanged confirms the common (non-overflow)
+// path is a behavioral no-op: every active row, chronological ASC.
+func TestGetMessages_UnderMaxUnchanged(t *testing.T) {
+	store := newWindowStore(t, 100)
+	base := time.Now().Add(-time.Hour).Truncate(time.Second)
+	roles := []string{"user", "assistant", "user", "assistant", "system", "user", "assistant", "user"}
+	for i, role := range roles {
+		insertActiveAt(t, store, "conv-1", msgID(i), role, msgContent(i), base.Add(time.Duration(i)*time.Minute))
+	}
+	got := store.GetMessages("conv-1")
+	if len(got) != len(roles) {
+		t.Fatalf("len = %d, want %d (all active rows)", len(got), len(roles))
+	}
+	assertAscending(t, got)
+}
+
+// TestGetMessages_SameTimestampTiebreakDeterministic simulates #1220's
+// rapid mid-turn mailbox inserts that collide on the wall clock. The id
+// tiebreak must make the window cut and display order stable.
+func TestGetMessages_SameTimestampTiebreakDeterministic(t *testing.T) {
+	store := newWindowStore(t, 3)
+	ts := time.Now().Add(-time.Hour).Truncate(time.Second)
+	// Six rows, identical timestamp, ascending ids (UUIDv7 is time-monotonic).
+	for i := 1; i <= 6; i++ {
+		insertActiveAt(t, store, "conv-1", msgID(i), "user", msgContent(i), ts)
+	}
+	first := store.GetMessages("conv-1")
+	second := store.GetMessages("conv-1")
+	if len(first) != 3 {
+		t.Fatalf("len = %d, want 3", len(first))
+	}
+	if !sameContents(first, second) {
+		t.Fatalf("nondeterministic window across calls: %v vs %v", contents(first), contents(second))
+	}
+	// Highest ids (latest inserts) win the window: m04, m05, m06.
+	want := []string{msgContent(4), msgContent(5), msgContent(6)}
+	if got := contents(first); !equalStrings(got, want) {
+		t.Errorf("window = %v, want %v (highest-id rows, ASC)", got, want)
+	}
+}
+
+// TestGetMessages_ClipWarnEmittedThenThrottled exercises the goal-3
+// observability signal: a clip warns once, then throttles; no clip stays
+// silent.
+func TestGetMessages_ClipWarnEmittedThenThrottled(t *testing.T) {
+	tests := []struct {
+		name        string
+		maxMessages int
+		rows        int
+		calls       int
+		wantWarns   int
+	}{
+		{name: "overflow warns once then throttles", maxMessages: 3, rows: 10, calls: 2, wantWarns: 1},
+		{name: "no overflow stays silent", maxMessages: 100, rows: 5, calls: 1, wantWarns: 0},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			logger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+			store, err := NewSQLiteStoreWithLogger(t.TempDir()+"/clip.db", tc.maxMessages, logger)
+			if err != nil {
+				t.Fatalf("NewSQLiteStoreWithLogger: %v", err)
+			}
+			t.Cleanup(func() { _ = store.Close() })
+			if _, err := store.GetOrCreateConversation("conv-1"); err != nil {
+				t.Fatalf("GetOrCreateConversation: %v", err)
+			}
+			base := time.Now().Add(-time.Hour).Truncate(time.Second)
+			for i := 1; i <= tc.rows; i++ {
+				insertActiveAt(t, store, "conv-1", msgID(i), "user", msgContent(i), base.Add(time.Duration(i)*time.Minute))
+			}
+			for range tc.calls {
+				_ = store.GetMessages("conv-1")
+			}
+			got := strings.Count(buf.String(), "read window clipped")
+			if got != tc.wantWarns {
+				t.Errorf("clip warnings = %d, want %d\nlog:\n%s", got, tc.wantWarns, buf.String())
+			}
+		})
+	}
+}
+
+// TestClear_EvictsClipWarnEntry pins that Clear() removes the clip-warn
+// rate-limit entry, so per-invocation delegate conversation IDs don't
+// leak map entries for the life of the process.
+func TestClear_EvictsClipWarnEntry(t *testing.T) {
+	store := newWindowStore(t, 3)
+	base := time.Now().Add(-time.Hour).Truncate(time.Second)
+	for i := 1; i <= 5; i++ {
+		insertActiveAt(t, store, "conv-1", msgID(i), "user", msgContent(i), base.Add(time.Duration(i)*time.Minute))
+	}
+	_ = store.GetMessages("conv-1") // overflow -> records a clip-warn entry
+
+	if _, ok := store.clipWarnAt["conv-1"]; !ok {
+		t.Fatalf("expected a clip-warn entry after an overflowing read")
+	}
+	if err := store.Clear("conv-1"); err != nil {
+		t.Fatalf("Clear: %v", err)
+	}
+	if _, ok := store.clipWarnAt["conv-1"]; ok {
+		t.Fatalf("clip-warn entry survived Clear() — map leaks per conversation")
+	}
+}
+
+// TestActiveMessageCount_ExcludesSystemAndCompacted proves the count
+// trigger measures only the reducible dialogue set.
+func TestActiveMessageCount_ExcludesSystemAndCompacted(t *testing.T) {
+	store := newWindowStore(t, 100)
+	base := time.Now().Add(-time.Hour).Truncate(time.Second)
+	insertActiveAt(t, store, "conv-1", "u1", "user", "u1", base.Add(1*time.Minute))
+	insertActiveAt(t, store, "conv-1", "a1", "assistant", "a1", base.Add(2*time.Minute))
+	insertActiveAt(t, store, "conv-1", "u2", "user", "u2", base.Add(3*time.Minute))
+	insertActiveAt(t, store, "conv-1", "a2", "assistant", "a2", base.Add(4*time.Minute))
+	// An active summary system row (excluded — role system).
+	insertActiveAt(t, store, "conv-1", "sum", "system", CompactionSummaryPrefix+"\n\nx", base)
+	// A compacted dialogue row (excluded — not active).
+	if _, err := store.db.Exec(`
+		INSERT INTO messages (id, conversation_id, role, content, timestamp, token_count, status)
+		VALUES ('old', 'conv-1', 'user', 'compacted away', ?, 100, 'compacted')
+	`, base.Add(-time.Minute)); err != nil {
+		t.Fatalf("insert compacted: %v", err)
+	}
+
+	if got := store.ActiveMessageCount("conv-1"); got != 4 {
+		t.Errorf("ActiveMessageCount = %d, want 4 (excludes system + compacted)", got)
+	}
+}
+
+// fakeCompactable isolates the two NeedsCompaction gates.
+type fakeCompactable struct {
+	tokens int
+	count  int
+}
+
+func (f fakeCompactable) GetTokenCount(string) int                       { return f.tokens }
+func (f fakeCompactable) ActiveMessageCount(string) int                  { return f.count }
+func (f fakeCompactable) GetMessagesForCompaction(string, int) []Message { return nil }
+func (f fakeCompactable) GetActiveCompactionSummaries(string) ([]Message, error) {
+	return nil, nil
+}
+func (f fakeCompactable) ApplyCompaction(string, []string, string, time.Time) error { return nil }
+
+func TestNeedsCompaction_TokenOrCountTrigger(t *testing.T) {
+	// threshold = 2000 * 0.5 = 1000; count trigger at 6.
+	cfg := CompactionConfig{MaxTokens: 2000, TriggerRatio: 0.5, MaxActiveMessages: 6}
+	tests := []struct {
+		name   string
+		tokens int
+		count  int
+		want   bool
+	}{
+		{name: "short-message overflow: low tokens, high count", tokens: 100, count: 9, want: true},
+		{name: "token overflow: high tokens, low count", tokens: 1500, count: 3, want: true},
+		{name: "neither: quiet conversation", tokens: 100, count: 3, want: false},
+		{name: "both", tokens: 1500, count: 9, want: true},
+		{name: "count at threshold boundary", tokens: 100, count: 6, want: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			c := NewCompactor(fakeCompactable{tokens: tc.tokens, count: tc.count}, cfg, nil, slog.Default())
+			if got := c.NeedsCompaction("conv-1"); got != tc.want {
+				t.Errorf("NeedsCompaction(tokens=%d,count=%d) = %v, want %v", tc.tokens, tc.count, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestNeedsCompaction_CountTriggerDisabledWhenZero(t *testing.T) {
+	cfg := CompactionConfig{MaxTokens: 2000, TriggerRatio: 0.5, MaxActiveMessages: 0}
+	c := NewCompactor(fakeCompactable{tokens: 100, count: 500}, cfg, nil, slog.Default())
+	if c.NeedsCompaction("conv-1") {
+		t.Errorf("NeedsCompaction = true, want false (MaxActiveMessages=0 disables the count gate)")
+	}
+}
+
+// --- small test helpers ---
+
+func msgID(i int) string      { return "id-" + pad2(i) }
+func msgContent(i int) string { return "m" + pad2(i) }
+func pad2(i int) string {
+	if i < 10 {
+		return "0" + string(rune('0'+i))
+	}
+	return string(rune('0'+i/10)) + string(rune('0'+i%10))
+}
+
+func assertAscending(t *testing.T, msgs []Message) {
+	t.Helper()
+	for i := 1; i < len(msgs); i++ {
+		if msgs[i].Timestamp.Before(msgs[i-1].Timestamp) {
+			t.Fatalf("messages not in ascending timestamp order at %d: %v before %v", i, msgs[i].Timestamp, msgs[i-1].Timestamp)
+		}
+	}
+}
+
+func contents(msgs []Message) []string {
+	out := make([]string, len(msgs))
+	for i, m := range msgs {
+		out[i] = m.Content
+	}
+	return out
+}
+
+func sameContents(a, b []Message) bool { return equalStrings(contents(a), contents(b)) }
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
## The one-line bug behind an evening of amnesia

`GetMessages` — the sole source of per-turn conversation history — returned the **oldest** `maxMessages` active rows, not the newest:

```sql
WHERE conversation_id = ? AND status = 'active'
ORDER BY timestamp ASC LIMIT ?     -- ASC + LIMIT = the OLDEST N
```

That query silently assumes a conversation's active set never exceeds `maxMessages` (100 in prod). The only thing upholding that invariant is compaction — and compaction is **token-gated only**. `NeedsCompaction` fires above `MaxTokens × TriggerRatio` (≈22,400 active tokens) and never looks at the message *count*.

So a long run of **short** messages — a late-night wind-down of brief back-and-forth texts — pushes the active count past 100 while total tokens stay far under the threshold. Compaction never fires. And past that point `GetMessages` returns rows 0–99 and drops every newer row. The model's context **freezes at the 100th-oldest message and never advances**, even as new messages keep inserting. The result is amnesia that presents as confused, hallucinated replies — the model answering as if from an old conversation, because it literally is.

## How it surfaced

A production Signal thread hit this live. It ran beautifully all evening, then — mid-conversation — every turn began building from a single frozen snapshot. The break was invisible for ~45 minutes because the frozen window happened to end on the same topic the conversation was still riding; the model kept improvising plausibly. It only turned into obvious nonsense the moment a turn required *remembering the turn before it*.

The #1220 mid-turn mailbox is what lit the fuse, not the fault itself: it records an extra `AddMessage` per mid-turn arrival, so the active count crosses 100 much faster than it used to. The defect is old and latent in the read query — #1220 just made a long-dormant landmine easy to step on. A process restart does **not** clear it: the overflowing rows are all still `status='active'` on disk, so the oldest-N window re-freezes on the next read.

## The fix, in three layers

**1 — Read side (load-bearing).** `GetMessages` now returns the **newest** `maxMessages` active rows `UNION` all active compaction summaries, re-sorted chronological `ASC` with a UUIDv7 `id` tiebreak. Summaries carry the compacted region's *earliest* timestamp, so a naive newest-N window would drop them — the `UNION` arm force-includes them so the model never loses its compacted past, and `UNION` (set semantics) dedupes a summary that also lands inside the window. The `id` tiebreak keeps the window cut deterministic under #1220's same-tick inserts. **This layer alone heals an already-frozen conversation on its very next turn** — no migration, no schema change.

**2 — Write side (defense in depth).** Compaction becomes count-aware. A new `ActiveMessageCount` (active, non-system) feeds a `CompactionConfig.MaxActiveMessages` trigger — prod wires **80**, leaving 20 rows of headroom under the 100-row read window for mailbox bursts. The token trigger is untouched; the predicate is a strict superset, so the active set now stays bounded and short-message runs compact *before* the window can ever clip. Default is `0` (off), preserving pure token-gated behavior everywhere else.

**3 — Observability.** A **rate-limited** (5-min per-conversation) warning fires whenever the read window clips older active rows. The *silence* is what let this run for 45 minutes in prod looking like the model had simply lost its mind. A recurrence now trips a loud, named signal.

## Tests

`internal/state/memory/working_window_test.go` (new):

- **Freeze reproduction** — 12 rows / window 5, asserts the newest window (`m08…m12`), not the frozen oldest. Fails on the pre-fix query.
- Summary **preserved under overflow** and **not duplicated** when inside the window.
- **Active-only** filter pinned — a `status='compacted'` original must not leak back into the window (a mutation dropping the filter otherwise passes everything).
- **id tiebreak** deterministic under same-timestamp inserts.
- **Clip warning** emitted once then throttled; silent when there's no clip; map entry **evicted on `Clear()`**.
- Count trigger fires on short-message overflow (low tokens, high count) and stays off when `MaxActiveMessages=0`; `ActiveMessageCount` excludes system + compacted rows.

This PR was designed and adversarially reviewed via multi-agent workflows; two confirmed review findings (the active-only test gap and a `clipWarnAt` eviction leak on the delegate path) are already folded in.

## Notes for the reviewer

- Steady state: the active set now oscillates roughly between `KeepRecent` and `MaxActiveMessages`, so `GetMessages` returns the recent tail and the window never clips in normal operation.
- The `messages_compacted` delta log at the compaction call site stays meaningful; its absolute `len(GetMessages)` values shift (now `min(active, max)+summaries` rather than a frozen 100) — a metric change, not a correctness one.
- Follow-up (not required here): hoist the `maxMessages=100` literal and `MaxActiveMessages=80` into a shared named constant so the read window and count trigger can't silently drift; and consider surfacing `MaxActiveMessages` in the YAML config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)