### PR TITLE
feat(loops): emit loop_midturn_input event so the mid-turn merge is observable

### DIFF
--- a/internal/platform/events/bus.go
+++ b/internal/platform/events/bus.go
@@ -138,6 +138,11 @@ const (
 	// loop iteration. Data: loop_id, loop_name, model, input_tokens,
 	// output_tokens.
 	KindLoopLLMResponse = "loop_llm_response"
+	// KindLoopMidTurnInput signals that newly-arrived conversation input was
+	// merged into a live turn at an iteration boundary (#1230, the mid-turn
+	// delivery arc #1220–#1222). Data: loop_id, loop_name, conversation_id,
+	// count (messages merged this pull).
+	KindLoopMidTurnInput = "loop_midturn_input"
 )
 
 // Event represents a single operational event published by a component.

--- a/internal/runtime/loop/loop.go
+++ b/internal/runtime/loop/loop.go
@@ -1636,7 +1636,7 @@ func (l *Loop) run(ctx context.Context) {
 					// request-base merge can wipe it). Items it delivers are
 					// acked with the wake batch at turn end.
 					if turn.PullRender != nil && l.deps.Mailbox != nil {
-						req.PullInput = l.buildMailboxPullInput(mailboxItems, &midTurnPulled, turn.PullRender)
+						req.PullInput = l.buildMailboxPullInput(convID, mailboxItems, &midTurnPulled, turn.PullRender)
 					}
 					runCtx, runCancel := mergeTurnRunContext(iterCtx, turn.RunContext)
 					result, turnResp, turnErr = l.runAgentTurn(runCtx, req, turn.Stream, iterStart, isSupervisor, supervisorTrigger)

--- a/internal/runtime/loop/mailbox.go
+++ b/internal/runtime/loop/mailbox.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/nugget/thane-ai-agent/internal/model/llm"
+	"github.com/nugget/thane-ai-agent/internal/platform/events"
 	"github.com/nugget/thane-ai-agent/internal/state/loopqueue"
 )
 
@@ -73,8 +74,11 @@ func (l *Loop) midTurnInputBudget() int {
 // returns the rendered messages. Returns nil once the budget is spent or
 // nothing new is pending, which the engine reads as "no mid-turn input." Items
 // left over from a capped pull stay pending for the next pull or post-turn
-// re-wake.
+// re-wake. Each delivering pull publishes a KindLoopMidTurnInput event (#1230)
+// so the merge is visible on the loop event stream, not just in the retained
+// prompt. convID names the conversation the merge belongs to.
 func (l *Loop) buildMailboxPullInput(
+	convID string,
 	wakeBatch []MailboxItem,
 	pulled *[]MailboxItem,
 	render func(context.Context, []MailboxItem) []llm.Message,
@@ -118,8 +122,30 @@ func (l *Loop) buildMailboxPullInput(
 			delivered[it.ID] = true
 		}
 		*pulled = append(*pulled, fresh...)
+		l.publishMidTurnInput(convID, len(fresh))
 		return rendered
 	}
+}
+
+// publishMidTurnInput emits a KindLoopMidTurnInput event for one delivering
+// pull of the mid-turn merge (#1230), so the loop event stream and archive
+// record that input was folded into a live turn — and how much — instead of it
+// being visible only by finding the rendered marker in a retained prompt.
+func (l *Loop) publishMidTurnInput(convID string, count int) {
+	if l.deps.EventBus == nil || count <= 0 {
+		return
+	}
+	l.deps.EventBus.Publish(events.Event{
+		Timestamp: time.Now(),
+		Source:    events.SourceLoop,
+		Kind:      events.KindLoopMidTurnInput,
+		Data: map[string]any{
+			"loop_id":         l.id,
+			"loop_name":       l.config.Name,
+			"conversation_id": convID,
+			"count":           count,
+		},
+	})
 }
 
 type mailboxItemsContextKey struct{}

--- a/internal/runtime/loop/mailbox_test.go
+++ b/internal/runtime/loop/mailbox_test.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/nugget/thane-ai-agent/internal/model/llm"
+	"github.com/nugget/thane-ai-agent/internal/platform/events"
 )
 
 // TestBuildMailboxPullInputDeltaGatesAndBudgets exercises the #1221 loop-side
@@ -45,7 +47,7 @@ func TestBuildMailboxPullInputDeltaGatesAndBudgets(t *testing.T) {
 	}
 
 	var pulled []MailboxItem
-	pull := l.buildMailboxPullInput(wakeBatch, &pulled, render)
+	pull := l.buildMailboxPullInput("conv-test", wakeBatch, &pulled, render)
 
 	// Nothing new beyond the wake batch → nil (never re-present delivered).
 	if got := pull(ctx); got != nil {
@@ -108,7 +110,7 @@ func TestBuildMailboxPullInputCapsItemsPerPull(t *testing.T) {
 		return out
 	}
 	var pulled []MailboxItem
-	pull := l.buildMailboxPullInput(nil, &pulled, render)
+	pull := l.buildMailboxPullInput("conv-test", nil, &pulled, render)
 
 	overflow := 3
 	total := maxMidTurnItemsPerPull + overflow
@@ -133,6 +135,70 @@ func TestBuildMailboxPullInputCapsItemsPerPull(t *testing.T) {
 	}
 	if len(pulled) != total {
 		t.Fatalf("ack accumulator = %d, want %d (all delivered across pulls)", len(pulled), total)
+	}
+}
+
+// TestBuildMailboxPullInputPublishesMidTurnEvent verifies that a delivering
+// pull emits a loop_midturn_input event (#1230) with Source=loop so it reaches
+// /v1/loops/events and the archive, and that an empty pull publishes nothing.
+func TestBuildMailboxPullInputPublishesMidTurnEvent(t *testing.T) {
+	t.Parallel()
+
+	bus := events.New()
+	ch := bus.Subscribe(8)
+	defer bus.Unsubscribe(ch)
+
+	mailbox := newTestMailbox(t)
+	l := mustNew(t, Config{Name: "pull-evt", Task: "t", MidTurnInputBudget: 4},
+		Deps{Runner: &noopRunner{}, Mailbox: mailbox, EventBus: bus})
+	ctx := context.Background()
+
+	render := func(_ context.Context, items []MailboxItem) []llm.Message {
+		out := make([]llm.Message, len(items))
+		for i, it := range items {
+			out[i] = llm.Message{Role: "user", Content: string(it.Payload)}
+		}
+		return out
+	}
+	var pulled []MailboxItem
+	pull := l.buildMailboxPullInput("conv-42", nil, &pulled, render)
+
+	if _, err := mailbox.Enqueue(ctx, l.Name(), "test", []byte("hello")); err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+	if got := pull(ctx); len(got) != 1 {
+		t.Fatalf("pull delivered %d, want 1", len(got))
+	}
+
+	select {
+	case evt := <-ch:
+		if evt.Kind != events.KindLoopMidTurnInput {
+			t.Fatalf("event kind = %q, want %q", evt.Kind, events.KindLoopMidTurnInput)
+		}
+		if evt.Source != events.SourceLoop {
+			t.Errorf("event source = %q, want loop (so /v1/loops/events forwards it)", evt.Source)
+		}
+		if evt.Data["conversation_id"] != "conv-42" {
+			t.Errorf("conversation_id = %v, want conv-42", evt.Data["conversation_id"])
+		}
+		if evt.Data["count"] != 1 {
+			t.Errorf("count = %v, want 1", evt.Data["count"])
+		}
+		if evt.Data["loop_name"] != "pull-evt" {
+			t.Errorf("loop_name = %v, want pull-evt", evt.Data["loop_name"])
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("no loop_midturn_input event published for a delivering pull")
+	}
+
+	// A pull that delivers nothing must not publish an event.
+	if got := pull(ctx); got != nil {
+		t.Fatalf("second pull delivered %v, want nil (nothing new)", got)
+	}
+	select {
+	case evt := <-ch:
+		t.Fatalf("unexpected event on an empty pull: %+v", evt)
+	case <-time.After(100 * time.Millisecond):
 	}
 }
 

--- a/internal/runtime/loop/mailbox_test.go
+++ b/internal/runtime/loop/mailbox_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"testing"
-	"time"
 
 	"github.com/nugget/thane-ai-agent/internal/model/llm"
 	"github.com/nugget/thane-ai-agent/internal/platform/events"
@@ -170,6 +169,9 @@ func TestBuildMailboxPullInputPublishesMidTurnEvent(t *testing.T) {
 		t.Fatalf("pull delivered %d, want 1", len(got))
 	}
 
+	// Bus.Publish is synchronous (it sends to subscriber channels in the
+	// caller's goroutine), so a delivering pull has already buffered the event
+	// by the time it returns — a non-blocking receive suffices, no waiting.
 	select {
 	case evt := <-ch:
 		if evt.Kind != events.KindLoopMidTurnInput {
@@ -187,7 +189,7 @@ func TestBuildMailboxPullInputPublishesMidTurnEvent(t *testing.T) {
 		if evt.Data["loop_name"] != "pull-evt" {
 			t.Errorf("loop_name = %v, want pull-evt", evt.Data["loop_name"])
 		}
-	case <-time.After(2 * time.Second):
+	default:
 		t.Fatal("no loop_midturn_input event published for a delivering pull")
 	}
 
@@ -198,7 +200,7 @@ func TestBuildMailboxPullInputPublishesMidTurnEvent(t *testing.T) {
 	select {
 	case evt := <-ch:
 		t.Fatalf("unexpected event on an empty pull: %+v", evt)
-	case <-time.After(100 * time.Millisecond):
+	default:
 	}
 }
 


### PR DESCRIPTION
First step of #1230 — the enabler that unblocks the rest.

## The gap

The mid-turn message merge (#1220–#1222) ships and works, but it's invisible to every operator surface. The seam only logs via `iterLog.Info`, which doesn't even reach the events archive — so `/v1/loops/events` (the console's live SSE feed), the archive (forensics), and any per-turn timeline are all blind to it. Confirming a real merge during the #1222 close-out meant reverse-engineering a 47-message array from `/v1/requests/{id}`, because the signal existed nowhere structured.

## The change

Publish a new `KindLoopMidTurnInput` ("loop_midturn_input") event from the loop's `buildMailboxPullInput` closure on each *delivering* pull, carrying `{loop_id, loop_name, conversation_id, count}`.

- It goes out with `Source: loop`, so the existing SSE handler (`internal/server/api/loops.go` — forwards by source, not kind) and the archiver pick it up with **no further wiring**.
- The merge is detected in the loop layer — a runtime/orchestration concern, not an LLM-streaming one — so it's published directly like other loop lifecycle events (`iteration_start`, `sleep_start`), rather than threaded through the deliberately bus-agnostic iterate engine or polluting the `llm.Kind` stream kinds.
- This also closes the forensics blind spot: the next time we want to confirm mid-turn behavior, it's one event, not a message-array spelunk.

## Deferred (within #1230)

A `phase` field distinguishing a tool-boundary merge from a closure hold-open. The loop's single `PullInput` closure can't tell which poll site called it without threading the site through the callback signature — a clean mechanical follow-up if the timeline (item 5) wants the distinction. Everything else stays as ranked follow-ups: mailbox-arrival event (2), `midturn_merged` tally on `iteration_complete` (3), the `mid_turn` provenance decision (4), and the console timeline rendering (5).

## Test

`TestBuildMailboxPullInputPublishesMidTurnEvent` asserts a delivering pull publishes exactly one `Source=loop` event with the conversation and count, and that an empty pull publishes nothing. `just ci` green.

Refs #1230