### PR TITLE
Complete the mid-turn event lifecycle: arrival + per-turn tally

### DIFF
--- a/internal/platform/events/bus.go
+++ b/internal/platform/events/bus.go
@@ -143,6 +143,14 @@ const (
 	// delivery arc #1220–#1222). Data: loop_id, loop_name, conversation_id,
 	// count (messages merged this pull).
 	KindLoopMidTurnInput = "loop_midturn_input"
+	// KindLoopMailboxArrival signals that a message landed in a loop's
+	// mailbox while the loop was already mid-iteration — a mid-turn arrival
+	// that will be merged into the in-flight turn at the next poll boundary
+	// (the arrival side of KindLoopMidTurnInput, #1230). Arrivals that wake an
+	// idle loop are the ordinary wake path (counted by loop_iteration_start's
+	// mailbox_items) and do not emit this. Data: loop_id, loop_name,
+	// conversation_id (the in-flight turn's), item_id, pending_items.
+	KindLoopMailboxArrival = "loop_mailbox_arrival"
 )
 
 // Event represents a single operational event published by a component.

--- a/internal/runtime/loop/loop.go
+++ b/internal/runtime/loop/loop.go
@@ -1825,6 +1825,11 @@ func (l *Loop) run(ctx context.Context) {
 					"tooling":         snap.Tooling,
 					"supervisor":      result.Supervisor,
 					"conversation_id": convID,
+					// Messages folded into this turn mid-flight (#1230): the
+					// per-turn total of every mid-turn mailbox pull, the datum
+					// for a "folded N messages" turn badge. 0 for an ordinary
+					// turn.
+					"midturn_merged": len(midTurnPulled),
 				}
 				if len(handlerSummary) > 0 {
 					eventData["summary"] = handlerSummary

--- a/internal/runtime/loop/mailbox.go
+++ b/internal/runtime/loop/mailbox.go
@@ -298,7 +298,6 @@ func (l *Loop) enqueueMailbox(ctx context.Context, keyPrefix string, payload []b
 	}
 
 	l.mu.Lock()
-	defer l.mu.Unlock()
 	receipt := MailboxReceipt{
 		LoopID:       loopID,
 		LoopName:     loopName,
@@ -314,6 +313,36 @@ func (l *Loop) enqueueMailbox(ctx context.Context, keyPrefix string, payload []b
 		receipt.WokeImmediately = true
 	} else {
 		receipt.QueuedForNextWake = true
+	}
+	// A turn is genuinely in flight exactly when currentConvID is set (set
+	// before StateProcessing, cleared at turn end). Gate the arrival event on
+	// that, not on the state enum: the startup (StatePending) and post-turn
+	// teardown (StateProcessing with currentConvID already cleared) windows are
+	// "not sleeping/waiting" yet have no turn to merge into, so a state-based
+	// gate would fire a spurious arrival carrying an empty conversation_id.
+	inFlightConvID := l.currentConvID
+	midTurnArrival := inFlightConvID != ""
+	l.mu.Unlock()
+
+	// Emit the arrival so "a message landed while the loop was working ->
+	// queued for merge" is observable on the loop event stream, not just the
+	// merge itself (KindLoopMidTurnInput). Published after releasing l.mu so
+	// the bus is never touched under the loop lock. Ordinary wake-path
+	// arrivals (idle loop) are already visible via loop_iteration_start's
+	// mailbox_items and are deliberately not doubled here (#1230).
+	if midTurnArrival {
+		l.publishEvent(events.Event{
+			Timestamp: time.Now(),
+			Source:    events.SourceLoop,
+			Kind:      events.KindLoopMailboxArrival,
+			Data: map[string]any{
+				"loop_id":         loopID,
+				"loop_name":       loopName,
+				"conversation_id": inFlightConvID,
+				"item_id":         item.ID,
+				"pending_items":   pending,
+			},
+		})
 	}
 	return receipt, nil
 }

--- a/internal/runtime/loop/mailbox_test.go
+++ b/internal/runtime/loop/mailbox_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/nugget/thane-ai-agent/internal/model/llm"
 	"github.com/nugget/thane-ai-agent/internal/platform/events"
@@ -201,6 +202,180 @@ func TestBuildMailboxPullInputPublishesMidTurnEvent(t *testing.T) {
 	case evt := <-ch:
 		t.Fatalf("unexpected event on an empty pull: %+v", evt)
 	default:
+	}
+}
+
+// TestEnqueueMailboxArrivalEventOnlyMidTurn verifies the arrival side of the
+// mid-turn observability story (#1230): a message that lands while the loop is
+// already processing publishes a loop_mailbox_arrival event, while one that
+// wakes an idle loop (the ordinary path, already visible via
+// loop_iteration_start's mailbox_items) publishes nothing.
+func TestEnqueueMailboxArrivalEventOnlyMidTurn(t *testing.T) {
+	t.Parallel()
+
+	bus := events.New()
+	ch := bus.Subscribe(8)
+	defer bus.Unsubscribe(ch)
+
+	mailbox := newTestMailbox(t)
+	l := mustNew(t, Config{Name: "arrival-evt", Task: "t"},
+		Deps{Runner: &noopRunner{}, Mailbox: mailbox, EventBus: bus})
+	ctx := context.Background()
+
+	setState := func(s State, conv string) {
+		l.mu.Lock()
+		l.started = true
+		l.stopped = false
+		l.state = s
+		l.currentConvID = conv
+		l.mu.Unlock()
+	}
+	drain := func() {
+		for {
+			select {
+			case <-ch:
+			default:
+				return
+			}
+		}
+	}
+
+	// A live turn is in flight (currentConvID set): the arrival is a genuine
+	// mid-turn merge and publishes an event naming the conversation and item.
+	setState(StateProcessing, "conv-mid")
+	if _, err := l.enqueueMailbox(ctx, "test", []byte("mid")); err != nil {
+		t.Fatalf("enqueue mid-turn: %v", err)
+	}
+	select {
+	case evt := <-ch:
+		if evt.Kind != events.KindLoopMailboxArrival {
+			t.Fatalf("kind = %q, want %q", evt.Kind, events.KindLoopMailboxArrival)
+		}
+		if evt.Source != events.SourceLoop {
+			t.Errorf("source = %q, want loop (so /v1/loops/events forwards it)", evt.Source)
+		}
+		if evt.Data["conversation_id"] != "conv-mid" {
+			t.Errorf("conversation_id = %v, want conv-mid", evt.Data["conversation_id"])
+		}
+		if s, _ := evt.Data["item_id"].(string); s == "" {
+			t.Errorf("item_id empty, want the enqueued item's id")
+		}
+		if evt.Data["loop_name"] != "arrival-evt" {
+			t.Errorf("loop_name = %v, want arrival-evt", evt.Data["loop_name"])
+		}
+	default:
+		t.Fatal("no loop_mailbox_arrival event for a mid-iteration enqueue")
+	}
+
+	// No in-flight turn (currentConvID empty): every such case is a wake-path
+	// arrival, not a mid-turn merge, and must publish nothing — including the
+	// startup (StatePending) and post-turn teardown (StateProcessing with the
+	// convID already cleared) windows, which the state enum alone cannot
+	// distinguish from a live turn.
+	noEvent := []struct {
+		name  string
+		state State
+	}{
+		{"idle waiting", StateWaiting},
+		{"idle sleeping", StateSleeping},
+		{"post-turn teardown", StateProcessing},
+		{"startup pending", StatePending},
+	}
+	for _, tc := range noEvent {
+		drain()
+		setState(tc.state, "")
+		if _, err := l.enqueueMailbox(ctx, "test", []byte("x")); err != nil {
+			t.Fatalf("%s: enqueue: %v", tc.name, err)
+		}
+		select {
+		case evt := <-ch:
+			t.Fatalf("%s: unexpected arrival event (state=%s, no in-flight turn): %+v", tc.name, tc.state, evt)
+		default:
+		}
+	}
+}
+
+// TestIterationCompleteCarriesMidTurnMergedTally drives a real mid-turn merge
+// through a live iteration and asserts the completed turn reports how many
+// messages it folded in (#1230 item 3) — the datum for a per-turn badge.
+func TestIterationCompleteCarriesMidTurnMergedTally(t *testing.T) {
+	t.Parallel()
+
+	bus := events.New()
+	ch := bus.Subscribe(32)
+	defer bus.Unsubscribe(ch)
+
+	mailbox := newTestMailbox(t)
+	const loopName = "midturn-tally"
+
+	render := func(_ context.Context, items []MailboxItem) []llm.Message {
+		out := make([]llm.Message, len(items))
+		for i, it := range items {
+			out[i] = llm.Message{Role: "user", Content: string(it.Payload)}
+		}
+		return out
+	}
+
+	// The runner stands in for the engine's poll: it enqueues a fresh item
+	// (not in the wake batch) and pulls it, folding one message into the turn,
+	// then returns a normal result.
+	runner := &turnCallbackRunner{fn: func(ctx context.Context, req RunRequest, _ StreamCallback) (*RunResponse, error) {
+		if _, err := mailbox.enqueue(ctx, loopName, "test", []byte("mid-turn arrival")); err != nil {
+			return nil, err
+		}
+		if req.PullInput != nil {
+			req.PullInput(ctx)
+		}
+		return &RunResponse{Content: "ok", Model: "m", FinishReason: "stop", InputTokens: 10, OutputTokens: 5, Iterations: 1}, nil
+	}}
+
+	l, err := New(Config{
+		Name:      loopName,
+		Operation: OperationEventDriven,
+		TurnBuilder: func(_ context.Context, _ TurnInput) (*AgentTurn, error) {
+			return &AgentTurn{
+				Request:    Request{Messages: []Message{{Role: "user", Content: "wake"}}},
+				PullRender: render,
+			}, nil
+		},
+		MaxIter: 1,
+	}, Deps{Runner: runner, Mailbox: mailbox, EventBus: bus})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	// The wake batch (one item), so the mid-turn arrival is genuinely fresh.
+	if _, err := mailbox.enqueue(context.Background(), loopName, "test", []byte("wake item")); err != nil {
+		t.Fatalf("enqueue wake: %v", err)
+	}
+	if err := l.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer l.Stop()
+	select {
+	case <-l.Done():
+	case <-time.After(3 * time.Second):
+		t.Fatal("loop did not finish")
+	}
+
+	var complete *events.Event
+	for {
+		select {
+		case evt := <-ch:
+			if evt.Kind == events.KindLoopIterationComplete && evt.Source == events.SourceLoop {
+				c := evt
+				complete = &c
+			}
+		default:
+			goto drained
+		}
+	}
+drained:
+	if complete == nil {
+		t.Fatal("missing loop_iteration_complete event")
+	}
+	if got := complete.Data["midturn_merged"]; got != 1 {
+		t.Fatalf("midturn_merged = %v (%T), want 1", got, got)
 	}
 }
 


### PR DESCRIPTION
Second and third steps of #1230, building on #1232's merge event. #1232 gave the mid-turn merge its middle frame (`loop_midturn_input`); this brackets it — the *arrival* before and the *tally* after — so a live turn's most interesting move is legible end-to-end on the event stream instead of only reconstructable from a retained prompt.

## What lands

**`loop_mailbox_arrival` (item 2).** When a message reaches a loop's mailbox *while a turn is in flight*, `enqueueMailbox` now publishes an arrival event carrying `{loop_id, loop_name, conversation_id, item_id, pending_items}`. The console can show "message landed while working → queued for merge," not just the merge. Arrivals that wake an idle loop stay silent — that's the ordinary path, already visible via `loop_iteration_start`'s `mailbox_items`.

**`midturn_merged` on `loop_iteration_complete` (item 3).** A completed turn now reports how many messages it folded in mid-flight (0 for an ordinary turn) — the natural datum for a "folded N messages into one reply" per-turn badge, which is where the per-turn timeline work (item 5) is headed.

Both go out `Source: loop`, so the SSE forwarder (`internal/server/api/loops.go`, forwards by source) and the archiver pick them up with **no further wiring** — the same seam #1232 used.

## The subtle part: gate on the turn, not the state enum

The obvious gate for "mid-turn arrival" is "loop isn't sleeping/waiting." That's wrong at two edges, both on the hot inbound path:

- **Post-turn teardown** — `currentConvID` is cleared at turn end while the loop is *still* `StateProcessing` through compaction, the `iteration_complete` publish, and `PostIterate` (an arbitrary, possibly slow callback). A message racing that window would fire an arrival event with an **empty `conversation_id`**.
- **Startup** — `started=true` is set before the run goroutine reaches its first `setState`, so a message arriving in that gap sees `StatePending` (neither sleeping nor waiting) on a loop that has never run a turn.

So the arrival event is gated on **`currentConvID != ""`** — which is set across exactly the mid-turn span and empty in both edge windows — guaranteeing the event only fires when there's a real turn to merge into and always carries a meaningful `conversation_id`. The receipt's existing `WokeImmediately`/`QueuedForNextWake` semantics are left untouched; only the event signal is decoupled onto the precise gate.

Both edges were caught by an adversarial review pass (confirmed medium + low) before this opened, and are pinned by tests.

## Tests

- `TestEnqueueMailboxArrivalEventOnlyMidTurn` — fires with an in-flight turn (asserts kind, `Source=loop`, `conversation_id`, `item_id`); stays silent across all four no-turn states: idle waiting, idle sleeping, **post-turn teardown**, and **startup pending**.
- `TestIterationCompleteCarriesMidTurnMergedTally` — drives a *real* merge (a runner that enqueues a fresh item mid-turn and pulls it) and asserts `midturn_merged == 1` on the completed turn's event.

`just ci` green.

## Deferred (still within #1230)

Items (4) the `mid_turn` provenance decision on the stored message record and (5) the web-console timeline rendering remain, plus #1232's deferred `phase` field (tool-boundary vs closure hold-open) if the timeline wants the distinction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)