### PR TITLE
Give mid-turn-injected messages a structured provenance flag

### DIFF
--- a/internal/runtime/agent/loop.go
+++ b/internal/runtime/agent/loop.go
@@ -165,6 +165,11 @@ type Response struct {
 type MemoryStore interface {
 	GetMessages(conversationID string) []memory.Message
 	AddMessage(conversationID, role, content string) error
+	// AddMidTurnMessage records a user message that arrived mid-turn and was
+	// merged into the in-flight turn (#1230), tagging the record so consumers
+	// identify the injection structurally rather than by substring-matching
+	// the rendered arrival marker.
+	AddMidTurnMessage(conversationID, role, content string) error
 	GetTokenCount(conversationID string) int
 	Clear(conversationID string) error
 	Stats() map[string]any
@@ -2148,7 +2153,7 @@ func (l *Loop) Run(ctx context.Context, req *Request, stream StreamCallback) (re
 				if m.Role != "user" || m.Content == "" {
 					continue
 				}
-				if err := l.memory.AddMessage(convID, "user", m.Content); err != nil {
+				if err := l.memory.AddMidTurnMessage(convID, "user", m.Content); err != nil {
 					logging.Logger(pctx).Warn("failed to record mid-turn input in conversation store",
 						"conversation_id", convID, "error", err)
 				}

--- a/internal/runtime/agent/midturn_wrapper_test.go
+++ b/internal/runtime/agent/midturn_wrapper_test.go
@@ -1,0 +1,63 @@
+package agent
+
+import (
+	"context"
+	"testing"
+
+	"github.com/nugget/thane-ai-agent/internal/model/llm"
+	"github.com/nugget/thane-ai-agent/internal/state/memory"
+)
+
+// TestPullInputWrapper_TagsMidTurnInput pins the feature's reason for existing:
+// the Run-side PullInput wrapper must persist a mid-turn-merged message via
+// AddMidTurnMessage (mid_turn=true), not the plain AddMessage. Without this,
+// reverting the wrapper to AddMessage passes every other test while silently
+// defeating #1230 (consumers fall back to substring-matching the arrival
+// marker). The mock records which variant was used via Message.MidTurn.
+func TestPullInputWrapper_TagsMidTurnInput(t *testing.T) {
+	// Two text responses: the first turn finalizes, the closure poll injects a
+	// mid-turn message and the turn continues, the second finalizes when the
+	// poll comes back empty. A spare third guards against an extra poll.
+	mock := &mockLLM{
+		responses: []*llm.ChatResponse{
+			{Model: "test-model", Message: llm.Message{Role: "assistant", Content: "ok"}, InputTokens: 10, OutputTokens: 5},
+			{Model: "test-model", Message: llm.Message{Role: "assistant", Content: "done"}, InputTokens: 10, OutputTokens: 5},
+			{Model: "test-model", Message: llm.Message{Role: "assistant", Content: "done"}, InputTokens: 10, OutputTokens: 5},
+		},
+	}
+	loop := buildTestLoop(mock, nil)
+	mm := loop.memory.(*mockMem)
+
+	pulls := 0
+	_, err := loop.Run(context.Background(), &Request{
+		ConversationID: "conv-1",
+		Messages:       []Message{{Role: "user", Content: "run the front-door diagnostic and report back"}},
+		PullInput: func(context.Context) []llm.Message {
+			pulls++
+			if pulls == 1 {
+				return []llm.Message{{Role: "user", Content: "mid-turn arrival"}}
+			}
+			return nil
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if pulls == 0 {
+		t.Fatal("PullInput was never polled — the wrapper never fired, so the assertion below is vacuous")
+	}
+
+	var found *memory.Message
+	for i := range mm.msgs["conv-1"] {
+		if mm.msgs["conv-1"][i].Content == "mid-turn arrival" {
+			found = &mm.msgs["conv-1"][i]
+			break
+		}
+	}
+	if found == nil {
+		t.Fatal("mid-turn message was not recorded in the conversation store")
+	}
+	if !found.MidTurn {
+		t.Error("mid-turn message recorded without MidTurn=true — the wrapper used AddMessage, not AddMidTurnMessage")
+	}
+}

--- a/internal/runtime/agent/orchestrator_tools_test.go
+++ b/internal/runtime/agent/orchestrator_tools_test.go
@@ -60,6 +60,10 @@ func (m *mockMem) AddMessage(id, role, content string) error {
 	m.msgs[id] = append(m.msgs[id], memory.Message{Role: role, Content: content})
 	return nil
 }
+func (m *mockMem) AddMidTurnMessage(id, role, content string) error {
+	m.msgs[id] = append(m.msgs[id], memory.Message{Role: role, Content: content, MidTurn: true})
+	return nil
+}
 func (m *mockMem) GetTokenCount(string) int { return 0 }
 func (m *mockMem) Clear(id string) error    { m.msgs[id] = nil; return nil }
 func (m *mockMem) Stats() map[string]any    { return nil }

--- a/internal/server/openapi/native.yaml
+++ b/internal/server/openapi/native.yaml
@@ -2469,6 +2469,16 @@ components:
           readOnly: true
           description: Identifier of the tool call this message responds to, for tool-result messages.
           example: call_019e7469
+        mid_turn:
+          type: boolean
+          readOnly: true
+          description: >-
+            True when this user message arrived mid-turn and was merged into an
+            in-flight turn at an iteration boundary, rather than opening its own
+            turn. Omitted when false. The structured signal for a mid-turn
+            injection — consumers should key on this rather than substring-match
+            the channel-rendered arrival marker in the content.
+          example: true
         archived_at:
           type: string
           format: date-time

--- a/internal/state/memory/midturn_provenance_test.go
+++ b/internal/state/memory/midturn_provenance_test.go
@@ -1,0 +1,113 @@
+package memory
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestMidTurnMessageRoundTrip verifies the mid_turn provenance flag survives a
+// write/read cycle through the SQLite store on both read paths, and that an
+// ordinary message is never flagged (#1230): the structured contract that
+// replaces substring-matching the rendered arrival marker.
+func TestMidTurnMessageRoundTrip(t *testing.T) {
+	store := newWindowStore(t, 100)
+
+	if err := store.AddMessage("conv-1", "user", "ordinary"); err != nil {
+		t.Fatalf("AddMessage: %v", err)
+	}
+	if err := store.AddMidTurnMessage("conv-1", "user", "mid-turn arrival"); err != nil {
+		t.Fatalf("AddMidTurnMessage: %v", err)
+	}
+
+	check := func(path string, msgs []Message) {
+		byContent := make(map[string]Message, len(msgs))
+		for _, m := range msgs {
+			byContent[m.Content] = m
+		}
+		if _, ok := byContent["ordinary"]; !ok {
+			t.Fatalf("%s: ordinary message missing", path)
+		}
+		if byContent["ordinary"].MidTurn {
+			t.Errorf("%s: ordinary message flagged mid_turn", path)
+		}
+		if !byContent["mid-turn arrival"].MidTurn {
+			t.Errorf("%s: mid-turn message not flagged mid_turn", path)
+		}
+	}
+	check("GetMessages", store.GetMessages("conv-1"))
+	check("GetAllMessages", store.GetAllMessages("conv-1"))
+}
+
+// TestMidTurnMessageNullLegacyRow pins the read paths against a row whose
+// mid_turn is NULL — the shape a legacy row would take if the additive
+// migration ever lost its DEFAULT 0. Scanning NULL into an int errors, and the
+// read loops drop such rows on scan error, so without COALESCE(mid_turn, 0)
+// this would silently lose the message from the conversation window.
+func TestMidTurnMessageNullLegacyRow(t *testing.T) {
+	store := newWindowStore(t, 100)
+	base := time.Now().Add(-time.Hour).Truncate(time.Second)
+	if _, err := store.db.Exec(`
+		INSERT INTO messages (id, conversation_id, role, content, timestamp, token_count, mid_turn)
+		VALUES ('legacy', 'conv-1', 'user', 'legacy null row', ?, 5, NULL)
+	`, base); err != nil {
+		t.Fatalf("insert NULL row: %v", err)
+	}
+
+	find := func(path string, msgs []Message) {
+		for _, m := range msgs {
+			if m.Content == "legacy null row" {
+				if m.MidTurn {
+					t.Errorf("%s: NULL mid_turn read as true, want false", path)
+				}
+				return
+			}
+		}
+		t.Fatalf("%s: NULL-mid_turn row dropped from the read (silent message loss)", path)
+	}
+	find("GetMessages", store.GetMessages("conv-1"))
+	find("GetAllMessages", store.GetAllMessages("conv-1"))
+}
+
+// TestMidTurnMessageInMemoryParity confirms the in-memory Store honors the same
+// AddMidTurnMessage contract as the SQLite store.
+func TestMidTurnMessageInMemoryParity(t *testing.T) {
+	s := NewStore(100)
+	if err := s.AddMessage("c", "user", "ordinary"); err != nil {
+		t.Fatalf("AddMessage: %v", err)
+	}
+	if err := s.AddMidTurnMessage("c", "user", "mid"); err != nil {
+		t.Fatalf("AddMidTurnMessage: %v", err)
+	}
+	byContent := make(map[string]Message)
+	for _, m := range s.GetMessages("c") {
+		byContent[m.Content] = m
+	}
+	if byContent["ordinary"].MidTurn {
+		t.Errorf("ordinary message flagged mid_turn")
+	}
+	if !byContent["mid"].MidTurn {
+		t.Errorf("mid-turn message not flagged mid_turn")
+	}
+}
+
+// TestMidTurnMessageJSONContract locks the wire shape the conversation API
+// (writeJSON of memory.Conversation) exposes: mid_turn is present only when
+// true, so ordinary messages stay unchanged for existing consumers.
+func TestMidTurnMessageJSONContract(t *testing.T) {
+	on, err := json.Marshal(Message{Role: "user", Content: "x", MidTurn: true})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !strings.Contains(string(on), `"mid_turn":true`) {
+		t.Errorf("mid_turn=true not surfaced in JSON: %s", on)
+	}
+	off, err := json.Marshal(Message{Role: "user", Content: "x"})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(off), "mid_turn") {
+		t.Errorf("mid_turn should be omitted when false (omitempty): %s", off)
+	}
+}

--- a/internal/state/memory/schema.go
+++ b/internal/state/memory/schema.go
@@ -38,6 +38,7 @@ var schema = database.Schema{
 				archived_at TIMESTAMP,
 				archive_reason TEXT,
 				iteration_index INTEGER,
+				mid_turn INTEGER DEFAULT 0,
 				FOREIGN KEY (conversation_id) REFERENCES conversations(id) ON DELETE CASCADE
 			)`,
 		},
@@ -113,6 +114,7 @@ var schema = database.Schema{
 		database.ColumnAdd{Table: "messages", Column: "archived_at", Typedef: "TIMESTAMP"},
 		database.ColumnAdd{Table: "messages", Column: "archive_reason", Typedef: "TEXT"},
 		database.ColumnAdd{Table: "messages", Column: "iteration_index", Typedef: "INTEGER"},
+		database.ColumnAdd{Table: "messages", Column: "mid_turn", Typedef: "INTEGER DEFAULT 0"},
 		database.ColumnAdd{Table: "tool_calls", Column: "session_id", Typedef: "TEXT"},
 		database.ColumnAdd{Table: "tool_calls", Column: "status", Typedef: "TEXT DEFAULT 'active' CHECK (status IN ('active', 'archived'))"},
 		database.ColumnAdd{Table: "tool_calls", Column: "archived_at", Typedef: "TIMESTAMP"},

--- a/internal/state/memory/sqlite.go
+++ b/internal/state/memory/sqlite.go
@@ -128,6 +128,18 @@ func (s *SQLiteStore) GetOrCreateConversation(id string) (*Conversation, error) 
 
 // AddMessage adds a message to a conversation.
 func (s *SQLiteStore) AddMessage(conversationID, role, content string) error {
+	return s.addMessage(conversationID, role, content, false)
+}
+
+// AddMidTurnMessage adds a message that arrived mid-turn and was merged into
+// an in-flight turn (#1230), tagging the row so consumers can identify the
+// injection from the structured record rather than substring-matching the
+// channel-rendered arrival marker in the content.
+func (s *SQLiteStore) AddMidTurnMessage(conversationID, role, content string) error {
+	return s.addMessage(conversationID, role, content, true)
+}
+
+func (s *SQLiteStore) addMessage(conversationID, role, content string, midTurn bool) error {
 	now := time.Now()
 	msgID, err := uuid.NewV7()
 	if err != nil {
@@ -140,11 +152,16 @@ func (s *SQLiteStore) AddMessage(conversationID, role, content string) error {
 		return err
 	}
 
+	midTurnVal := 0
+	if midTurn {
+		midTurnVal = 1
+	}
+
 	// Insert message
 	_, err = s.db.Exec(`
-		INSERT INTO messages (id, conversation_id, role, content, timestamp, token_count)
-		VALUES (?, ?, ?, ?, ?, ?)
-	`, msgID.String(), conversationID, role, content, now, llm.EstimateTokens(content))
+		INSERT INTO messages (id, conversation_id, role, content, timestamp, token_count, mid_turn)
+		VALUES (?, ?, ?, ?, ?, ?, ?)
+	`, msgID.String(), conversationID, role, content, now, llm.EstimateTokens(content), midTurnVal)
 	if err != nil {
 		return fmt.Errorf("insert message: %w", err)
 	}
@@ -181,15 +198,15 @@ func (s *SQLiteStore) AddMessage(conversationID, role, content string) error {
 func (s *SQLiteStore) GetMessages(conversationID string) []Message {
 	rows, err := s.db.Query(`
 		WITH recent AS (
-			SELECT id, role, content, timestamp
+			SELECT id, role, content, timestamp, COALESCE(mid_turn, 0) AS mid_turn
 			FROM messages
 			WHERE conversation_id = ? AND status = 'active'
 			ORDER BY timestamp DESC, id DESC
 			LIMIT ?
 		)
-		SELECT id, role, content, timestamp FROM recent
+		SELECT id, role, content, timestamp, mid_turn FROM recent
 		UNION
-		SELECT id, role, content, timestamp
+		SELECT id, role, content, timestamp, COALESCE(mid_turn, 0)
 		FROM messages
 		WHERE conversation_id = ? AND status = 'active' AND role = 'system'
 		  AND content LIKE ? || '%'
@@ -203,9 +220,11 @@ func (s *SQLiteStore) GetMessages(conversationID string) []Message {
 	var messages []Message
 	for rows.Next() {
 		var m Message
-		if err := rows.Scan(&m.ID, &m.Role, &m.Content, &m.Timestamp); err != nil {
+		var midTurn int
+		if err := rows.Scan(&m.ID, &m.Role, &m.Content, &m.Timestamp, &midTurn); err != nil {
 			continue
 		}
+		m.MidTurn = midTurn != 0
 		messages = append(messages, m)
 	}
 
@@ -437,7 +456,7 @@ func (s *SQLiteStore) BindConversationChannel(conversationID string, binding *Ch
 // Includes tool call data for full-fidelity archiving — never lose primary sources.
 func (s *SQLiteStore) GetAllMessages(conversationID string) []Message {
 	rows, err := s.db.Query(`
-		SELECT id, role, content, timestamp, tool_calls, tool_call_id
+		SELECT id, role, content, timestamp, tool_calls, tool_call_id, COALESCE(mid_turn, 0)
 		FROM messages
 		WHERE conversation_id = ?
 		ORDER BY timestamp ASC
@@ -451,7 +470,8 @@ func (s *SQLiteStore) GetAllMessages(conversationID string) []Message {
 	for rows.Next() {
 		var m Message
 		var toolCalls, toolCallID sql.NullString
-		if err := rows.Scan(&m.ID, &m.Role, &m.Content, &m.Timestamp, &toolCalls, &toolCallID); err != nil {
+		var midTurn int
+		if err := rows.Scan(&m.ID, &m.Role, &m.Content, &m.Timestamp, &toolCalls, &toolCallID, &midTurn); err != nil {
 			continue
 		}
 		if toolCalls.Valid {
@@ -460,6 +480,7 @@ func (s *SQLiteStore) GetAllMessages(conversationID string) []Message {
 		if toolCallID.Valid {
 			m.ToolCallID = toolCallID.String
 		}
+		m.MidTurn = midTurn != 0
 		messages = append(messages, m)
 	}
 

--- a/internal/state/memory/store.go
+++ b/internal/state/memory/store.go
@@ -48,6 +48,11 @@ type Message struct {
 	ToolCallID     string    `json:"tool_call_id,omitempty"`   // Tool call ID (tool response messages)
 	ArchivedAt     time.Time `json:"archived_at,omitzero"`     // When the message was archived
 	ArchiveReason  string    `json:"archive_reason,omitempty"` // Why: compaction, reset, shutdown, import
+	// MidTurn marks a user message that arrived mid-turn and was merged into
+	// an in-flight turn at an iteration boundary (#1221/#1230), rather than
+	// opening its own turn. The structured contract that replaces
+	// substring-matching the channel-rendered arrival marker.
+	MidTurn bool `json:"mid_turn,omitempty"`
 }
 
 // Conversation holds the state of a single conversation.
@@ -114,6 +119,17 @@ func (s *Store) GetOrCreateConversation(id string) *Conversation {
 
 // AddMessage adds a message to a conversation.
 func (s *Store) AddMessage(conversationID string, role, content string) error {
+	return s.addMessage(conversationID, role, content, false)
+}
+
+// AddMidTurnMessage adds a message that arrived mid-turn and was merged into
+// an in-flight turn (#1230), tagging it so consumers can identify the
+// injection without substring-matching the rendered arrival marker.
+func (s *Store) AddMidTurnMessage(conversationID string, role, content string) error {
+	return s.addMessage(conversationID, role, content, true)
+}
+
+func (s *Store) addMessage(conversationID string, role, content string, midTurn bool) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -136,6 +152,7 @@ func (s *Store) AddMessage(conversationID string, role, content string) error {
 		Role:      role,
 		Content:   content,
 		Timestamp: time.Now(),
+		MidTurn:   midTurn,
 	})
 	conv.UpdatedAt = time.Now()
 


### PR DESCRIPTION
Item 4 of #1230 — the one real design decision in the arc, resolved toward the clean contract.

## The problem

Mid-turn-merged user messages (#1221) are persisted as **plain user messages**. The only trace that one was injected mid-turn is the channel-rendered arrival marker sitting in the message *content* — so any consumer wanting to identify an injection has to substring-match render-layer prose. That's the exact fragility the #1229 review flagged, and it's worse than it looks: the marker is **channel-specific** (Signal's `renderPulledMailbox`) and has already been reworded once, so matching it couples every consumer to one channel's wording and breaks silently the moment a second channel injects differently.

## The contract

A structured, channel-agnostic `mid_turn` flag on the message record:

- **Schema** — `messages` gains a `mid_turn` column via an additive `ColumnAdd` migration (`DEFAULT 0`, the same pattern as `status`/`iteration_index`). `memory.Message` gains `MidTurn bool` with `json:"mid_turn,omitempty"` — present only when true, so ordinary messages are byte-identical for existing consumers.
- **Write** — a new `AddMidTurnMessage` on both stores and the agent `MemoryStore` interface; the Run-side `PullInput` wrapper records mid-turn arrivals through it instead of `AddMessage`.
- **Read** — `GetMessages` and `GetAllMessages` select the flag, wrapped in `COALESCE(mid_turn, 0)` (see below).
- **API** — `/v1/conversations/{id}` surfaces it automatically (`GetConversation → GetMessages → writeJSON`); documented on the OpenAPI `ConversationMessage` schema.

The events from #1232/#1233 already carried mid-turn provenance for *observability* consumers (SSE, timeline); this closes the gap for the *transcript/API* consumer that reads the message array directly.

## Two things an adversarial review caught (both fixed before this opened)

- **The wrapper wasn't tested end-to-end.** Reverting the one production call site from `AddMidTurnMessage` back to `AddMessage` passed the entire suite — the feature's reason for existing was unverified. Added an agent-package test that drives `Loop.Run` with a live `PullInput` and asserts the recorded message has `MidTurn=true`; confirmed it **fails** on that exact revert.
- **A NULL could silently drop a message.** Both read loops scan `mid_turn` into an `int` and `continue` (drop the row) on scan error. `DEFAULT 0` keeps legacy rows at `0` today, but if that default were ever lost, legacy rows would read `NULL`, error the scan, and vanish from the window — silent message loss. `COALESCE(mid_turn, 0)` makes NULL read as `false` (semantically correct anyway), and a test inserts a NULL row and asserts it survives both read paths.

## Tests

Store round-trip on both read paths, in-memory-store parity, the JSON wire contract (present when true / omitted when false), the NULL-legacy-row read, and the end-to-end wrapper test.

`just ci` green.

## Scope

The `mid_turn` contract lives on the **conversation store record** (the transcript). The `/v1/requests/{id}` retained-prompt snapshot is a separate subsystem and is intentionally out of scope here.

This closes acceptance item 4. Remaining in #1230: item 5 (web-console timeline rendering) and #1232's deferred `phase` field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)