### PR TITLE
Render mid-turn merges on the live turn timeline

### DIFF
--- a/internal/runtime/loop/config.go
+++ b/internal/runtime/loop/config.go
@@ -541,6 +541,11 @@ type IterationSnapshot struct {
 	// "random" (Bernoulli win) from "forced" (notification-driven)
 	// without re-deriving the cause from event logs.
 	SupervisorTrigger SupervisorTrigger `json:"supervisor_trigger,omitempty"`
+	// MidTurnMerged is the number of mailbox messages folded into this turn
+	// mid-flight (#1230); zero for an ordinary turn. Carried on the snapshot
+	// (not just the live event) so the history/reload path renders the
+	// "folded N messages" badge identically to a live-watching client.
+	MidTurnMerged int `json:"midturn_merged,omitempty"`
 	// Error holds the error message if the iteration failed.
 	Error string `json:"error,omitempty"`
 	// StartedAt is when the iteration began.

--- a/internal/runtime/loop/loop.go
+++ b/internal/runtime/loop/loop.go
@@ -1779,6 +1779,9 @@ func (l *Loop) run(ctx context.Context) {
 				snap.ContextWindow = result.ContextWindow
 				snap.ElapsedMs = result.Elapsed.Milliseconds()
 				snap.CompletedAt = time.Now()
+				// Same per-turn total the iteration_complete event carries, so
+				// the persisted snapshot renders the "folded N" badge on reload.
+				snap.MidTurnMerged = len(midTurnPulled)
 
 				// Deep copy ToolsUsed so the snapshot is independent
 				// of any caller-held references.

--- a/internal/runtime/loop/mailbox_test.go
+++ b/internal/runtime/loop/mailbox_test.go
@@ -377,6 +377,16 @@ drained:
 	if got := complete.Data["midturn_merged"]; got != 1 {
 		t.Fatalf("midturn_merged = %v (%T), want 1", got, got)
 	}
+
+	// The persisted snapshot must carry the same tally so the history/reload
+	// path renders the "folded N" badge, not just live-watching clients (#1230).
+	iters := l.Status().RecentIterations
+	if len(iters) == 0 {
+		t.Fatal("no recent iterations recorded")
+	}
+	if iters[0].MidTurnMerged != 1 {
+		t.Errorf("snapshot MidTurnMerged = %d, want 1", iters[0].MidTurnMerged)
+	}
 }
 
 // TestBuildMailboxPullInputDefaultBudget confirms the zero-value budget falls

--- a/internal/server/web/static/data/loops.js
+++ b/internal/server/web/static/data/loops.js
@@ -291,7 +291,7 @@ export function createLoopStore({ client, events } = {}) {
       const statuses = await client.get('/loops');
       const serverIds = new Set();
       const transient = [
-        '_iterStartTs', '_liveTools', '_liveModel', '_llmContext',
+        '_iterStartTs', '_liveTools', '_liveModel', '_llmContext', '_midturnLive',
         '_supervisor', '_currentConvID', '_currentRequestID', '_lastModel', '_lastSupervisor',
         '_delegate', '_delegateId', '_delegateTask', '_delegateProfile',
         '_delegateGuidance', '_delegateTags', '_delegateIterations',

--- a/internal/server/web/static/shared.js
+++ b/internal/server/web/static/shared.js
@@ -1204,6 +1204,26 @@ function buildLiveCard(loop) {
     card.appendChild(ul);
   }
 
+  // Mid-turn arrivals/merges (#1230): messages that landed while this turn was
+  // composing and were folded in at an iteration boundary.
+  const midturn = loop._midturnLive || [];
+  if (midturn.length > 0) {
+    const mtUl = document.createElement('ul');
+    mtUl.className = 'live-tools';
+    for (const m of midturn) {
+      const li = document.createElement('li');
+      li.className = 'live-tool live-tool--midturn';
+      if (m.phase === 'merged') {
+        const n = m.count || 1;
+        li.textContent = '⤵ merged ' + n + (n === 1 ? ' message' : ' messages') + ' into the turn';
+      } else {
+        li.textContent = '↳ message arrived while working';
+      }
+      mtUl.appendChild(li);
+    }
+    card.appendChild(mtUl);
+  }
+
   return card;
 }
 
@@ -1402,6 +1422,14 @@ function buildPastCard(snap, handlerOnly, idx, startExpanded) {
     body.appendChild(supEl);
   }
 
+  // Mid-turn merge badge (#1230): how many messages this turn folded in.
+  if (snap.midturn_merged > 0) {
+    const mtEl = document.createElement('span');
+    mtEl.className = 'iter-card__midturn-badge';
+    mtEl.textContent = '\u2935 folded ' + snap.midturn_merged + (snap.midturn_merged === 1 ? ' message' : ' messages');
+    body.appendChild(mtEl);
+  }
+
   // Timestamp.
   if (snap.completed_at) {
     const ts = document.createElement('div');
@@ -1495,6 +1523,7 @@ function clearLiveTelemetry(loop) {
   loop._liveModel = '';
   loop._llmContext = null;
   loop._currentRequestID = '';
+  loop._midturnLive = [];
 }
 
 // ---------------------------------------------------------------------------
@@ -1533,6 +1562,11 @@ function applyLoopEventToLoop(evt, ctx) {
       loop._liveTools = [];
       loop._liveModel = '';
       loop._llmContext = null;
+      // NB: do NOT reset _midturnLive here. It is cleared at turn end
+      // (clearLiveTelemetry on iteration_complete / leaving 'processing'), and
+      // the backend can emit loop_mailbox_arrival during turn prep — after
+      // currentConvID is set but before iteration_start — so resetting here
+      // would erase a legitimate arrival for the turn now starting (#1230).
       loop._iterStartTs = Date.now();
       return null;
 
@@ -1591,6 +1625,7 @@ function applyLoopEventToLoop(evt, ctx) {
         completed_at: evt.ts,
         summary: d.summary || null,
         delegate_calls: delegateCalls.length > 0 ? delegateCalls : null,
+        midturn_merged: d.midturn_merged || 0,
       };
       clearLiveTelemetry(loop);
       return { snapshot: snap };
@@ -1672,6 +1707,19 @@ function applyLoopEventToLoop(evt, ctx) {
       loop._liveModel = d.model || '';
       loop._currentRequestID = d.request_id || loop._currentRequestID || '';
       if (!loop._iterStartTs) loop._iterStartTs = Date.now();
+      return null;
+
+    case 'loop_mailbox_arrival':
+      // A message landed while this turn was composing (#1230); it will be
+      // merged at the next iteration boundary. Show it on the live timeline.
+      if (!loop._midturnLive) loop._midturnLive = [];
+      loop._midturnLive.push({ phase: 'arrived' });
+      return null;
+
+    case 'loop_midturn_input':
+      // Newly-arrived input was merged into the live turn (#1230).
+      if (!loop._midturnLive) loop._midturnLive = [];
+      loop._midturnLive.push({ phase: 'merged', count: d.count || 0 });
       return null;
 
     case 'loop_sleep_start': {

--- a/internal/server/web/static/shared.js
+++ b/internal/server/web/static/shared.js
@@ -1214,7 +1214,7 @@ function buildLiveCard(loop) {
       const li = document.createElement('li');
       li.className = 'live-tool live-tool--midturn';
       if (m.phase === 'merged') {
-        const n = m.count || 1;
+        const n = Number.isFinite(m.count) ? m.count : 0;
         li.textContent = '⤵ merged ' + n + (n === 1 ? ' message' : ' messages') + ' into the turn';
       } else {
         li.textContent = '↳ message arrived while working';
@@ -1719,7 +1719,7 @@ function applyLoopEventToLoop(evt, ctx) {
     case 'loop_midturn_input':
       // Newly-arrived input was merged into the live turn (#1230).
       if (!loop._midturnLive) loop._midturnLive = [];
-      loop._midturnLive.push({ phase: 'merged', count: d.count || 0 });
+      loop._midturnLive.push({ phase: 'merged', count: Number.isFinite(d.count) ? d.count : 0 });
       return null;
 
     case 'loop_sleep_start': {

--- a/internal/server/web/static/style.css
+++ b/internal/server/web/static/style.css
@@ -811,6 +811,7 @@ body.resize-col *, body.resize-row * { cursor: inherit; user-select: none; }
 .live-tool--running { border-left-color: var(--accent); }
 .live-tool--done { border-left-color: var(--green); }
 .live-tool--error { border-left-color: var(--red); }
+.live-tool--midturn { border-left-color: var(--blue); color: var(--text-secondary); font-family: var(--font-mono); font-size: 12px; }
 .live-tool__head { display: flex; align-items: baseline; gap: 8px; }
 .live-tool__name { font-family: var(--font-mono); font-size: 12px; color: var(--text-primary); }
 .live-tool__status { font-size: 10px; text-transform: uppercase; letter-spacing: 0.04em; color: var(--text-muted); }
@@ -1872,6 +1873,12 @@ body.resize-col .schema-card__fade {
   display: inline-block;
   font-size: 0.6rem;
   color: var(--purple);
+}
+.iter-card__midturn-badge {
+  display: inline-block;
+  margin-left: 8px;
+  font-size: 0.6rem;
+  color: var(--blue);
 }
 .iter-card__timestamp {
   color: var(--text-muted);


### PR DESCRIPTION
Item 5 of #1230 — the payoff, and the last of the acceptance list. The backend arc (#1232 merge event, #1233 arrival event + tally, #1235 provenance flag) built the data; this makes a live turn's most interesting move legible on the web console's per-turn timeline instead of buried in a retained prompt.

## What renders

- **Completed turn** — a blue **"folded N messages"** badge on the iteration card (from the turn's `midturn_merged` tally), beside the supervisor badge.
- **Live turn** — a distinct marker as each message **arrives mid-flight** ("↳ message arrived while working") and **merges** ("⤵ merged N into the turn"), styled like the live tool entries but with their own blue accent so they read as continuity, not tool activity.

The shared reducer (`applyLoopEventToLoop`) gains `loop_mailbox_arrival` / `loop_midturn_input` cases feeding a per-turn `_midturnLive` list; `loop_iteration_complete` carries the tally onto the client snapshot. Styling reuses the existing `.live-tool` / badge conventions.

## Persisted-snapshot parity (adversarial-review finding)

The badge would otherwise be **live-only**: a client that reloads or joins late seeds its history from `/v1/loops` `recent_iterations`, and the persisted `IterationSnapshot` didn't carry the tally — so the identical turn showed the badge for a live watcher but not after a refresh. Fixed by adding `MidTurnMerged` to `IterationSnapshot` (json `midturn_merged`), populated from the same `len(midTurnPulled)` the event uses. `TestIterationCompleteCarriesMidTurnMergedTally` now asserts the buffered snapshot, not just the event.

## Two more review fixes folded in before open

- **`refetch()` wiped the markers mid-turn.** `_midturnLive` wasn't in the transient-preservation list, so any *sibling* loop's event (which triggers a full `/v1/loops` refetch) silently erased the arrival/merge markers of a loop still mid-turn, while preserving every other live field. Added `_midturnLive` to the list.
- **`iteration_start` erased a legitimate arrival.** The backend sets `currentConvID` during turn prep (so it can emit `loop_mailbox_arrival`) *before* it publishes `iteration_start`. Resetting `_midturnLive` on `iteration_start` dropped an arrival that landed in that window. Moved the clearing off `iteration_start` entirely — it already happens at turn end via `clearLiveTelemetry` (on `iteration_complete` / leaving `processing`), so between-turn state stays clean without eating the new turn's first arrival.

## Verification

Rendered both surfaces in the UI harness (`uiharness-nvp`) from mock snapshots and confirmed the badge and markers match the console's visual language; JS syntax-checked, no console errors, `just ci` green. Screenshot below.

_(Harness screenshot attached in the review thread — the completed card shows "↓ folded 2 messages"; the live card shows "↳ message arrived while working" and "⤵ merged 2 messages into the turn".)_

## Scope / remaining

This closes the acceptance list (items 1–5). Not in this PR: item 6 (a sweep for any tool/talent prose that claims mid-turn delivery is unobservable — likely a no-op, worth a quick check before closing #1230) and #1232's deferred `phase` field (tool-boundary vs closure hold-open) if a future timeline wants that distinction.

Refs #1230

🤖 Generated with [Claude Code](https://claude.com/claude-code)
