### PR TITLE
Give the core-child service loops a pollers container

### DIFF
--- a/internal/app/loop_definition_builtins.go
+++ b/internal/app/loop_definition_builtins.go
@@ -32,7 +32,28 @@ const (
 const (
 	cognitionContainerName     = "cognition"
 	homeAssistantContainerName = "home-assistant"
+	pollersContainerName       = "pollers"
 )
+
+// Each predicate is the exact enablement gate for the pollers-container
+// member(s) it names. The container appears iff at least one is true, and the
+// members below use the same predicates — so the gate and its members cannot
+// drift into an empty container or a member orphaned under a missing parent.
+func unifiPollerEnabled(cfg *config.Config) bool {
+	return cfg.Unifi.Configured() && len(cfg.Person.Track) > 0
+}
+
+func emailServicesEnabled(cfg *config.Config) bool {
+	return cfg.Email.Configured() && cfg.Email.PollIntervalSec > 0
+}
+
+func forgePollerEnabled(cfg *config.Config) bool {
+	return cfg.Forge.Configured() && cfg.Forge.SubscriptionCheckInterval > 0
+}
+
+func mediaServicesEnabled(cfg *config.Config) bool {
+	return cfg.Media.FeedCheckInterval > 0
+}
 
 // builtInContainerDefinitionSpecs returns the built-in grouping containers,
 // each gated so an empty container never appears: cognition when any core
@@ -50,6 +71,10 @@ func builtInContainerDefinitionSpecs(cfg *config.Config) []looppkg.Spec {
 	if cfg.HomeAssistant.Configured() || cfg.MQTT.Configured() {
 		specs = append(specs, containerSpec(homeAssistantContainerName,
 			"Home Assistant integration: state watching, MQTT transport, and telemetry."))
+	}
+	if unifiPollerEnabled(cfg) || emailServicesEnabled(cfg) || forgePollerEnabled(cfg) || mediaServicesEnabled(cfg) {
+		specs = append(specs, containerSpec(pollersContainerName,
+			"Outward integration services: presence, email, code-forge, and media-feed pollers and their triage handlers."))
 	}
 
 	return specs
@@ -72,11 +97,12 @@ func builtInServiceDefinitionSpecs(cfg *config.Config) []looppkg.Spec {
 
 	var specs []looppkg.Spec
 
-	if cfg.Unifi.Configured() && len(cfg.Person.Track) > 0 {
+	if unifiPollerEnabled(cfg) {
 		pollInterval := time.Duration(cfg.Unifi.PollIntervalSec) * time.Second
 		specs = append(specs, looppkg.Spec{
 			Name:         unifiPollerDefinitionName,
 			Enabled:      true,
+			ParentName:   pollersContainerName,
 			Task:         "Poll UniFi device locations and update room presence state.",
 			Operation:    looppkg.OperationService,
 			Completion:   looppkg.CompletionNone,
@@ -106,7 +132,7 @@ func builtInServiceDefinitionSpecs(cfg *config.Config) []looppkg.Spec {
 		})
 	}
 
-	if cfg.Email.Configured() && cfg.Email.PollIntervalSec > 0 {
+	if emailServicesEnabled(cfg) {
 		// Default landing zone for new-mail wakes when an operator
 		// hasn't pointed the poller at a custom handler. Event-driven
 		// so the loop sits idle on wakeCh until the poller delivers
@@ -120,6 +146,7 @@ func builtInServiceDefinitionSpecs(cfg *config.Config) []looppkg.Spec {
 		specs = append(specs, looppkg.Spec{
 			Name:       email.DefaultHandlerLoopName,
 			Enabled:    true,
+			ParentName: pollersContainerName,
 			Task:       "Triage incoming email wakes. Each event carries a sender trust-zone tag — owner/trusted/household/known/stranger — use it to adapt: owners get direct responses, trusted senders get reviewed action, strangers get a low-cost classify-and-defer pass. Read with email_read when a message warrants a deeper look, reply via email_reply or send a fresh message via email_send, file or trash with email_move when handled, and notify the owner about anything that genuinely needs attention.",
 			Operation:  looppkg.OperationEventDriven,
 			Completion: looppkg.CompletionNone,
@@ -147,6 +174,7 @@ func builtInServiceDefinitionSpecs(cfg *config.Config) []looppkg.Spec {
 		specs = append(specs, looppkg.Spec{
 			Name:         emailPollerDefinitionName,
 			Enabled:      true,
+			ParentName:   pollersContainerName,
 			Task:         "Poll configured email accounts for new inbound mail and dispatch event-source wakes to the configured handler loop.",
 			Operation:    looppkg.OperationService,
 			Completion:   looppkg.CompletionNone,
@@ -161,11 +189,12 @@ func builtInServiceDefinitionSpecs(cfg *config.Config) []looppkg.Spec {
 		})
 	}
 
-	if cfg.Forge.Configured() && cfg.Forge.SubscriptionCheckInterval > 0 {
+	if forgePollerEnabled(cfg) {
 		pollInterval := time.Duration(cfg.Forge.SubscriptionCheckInterval) * time.Second
 		specs = append(specs, looppkg.Spec{
 			Name:         forgeSubPollerDefinitionName,
 			Enabled:      true,
+			ParentName:   pollersContainerName,
 			Task:         "Poll followed code forge repositories for release and commit events.",
 			Operation:    looppkg.OperationService,
 			Completion:   looppkg.CompletionNone,
@@ -181,7 +210,7 @@ func builtInServiceDefinitionSpecs(cfg *config.Config) []looppkg.Spec {
 		})
 	}
 
-	if cfg.Media.FeedCheckInterval > 0 {
+	if mediaServicesEnabled(cfg) {
 		// Default landing zone for media feed wakes when an operator
 		// hasn't pointed media_follow's wake_loop at a custom handler.
 		// Event-driven so the loop sits idle on wakeCh until the
@@ -189,6 +218,7 @@ func builtInServiceDefinitionSpecs(cfg *config.Config) []looppkg.Spec {
 		specs = append(specs, looppkg.Spec{
 			Name:       media.DefaultHandlerLoopName,
 			Enabled:    true,
+			ParentName: pollersContainerName,
 			Task:       "Triage media feed wake events: inspect each entry's trust_zone metadata, fetch and analyze worthwhile content with media_transcript and media_save_analysis, then notify the owner about anything noteworthy.",
 			Operation:  looppkg.OperationEventDriven,
 			Completion: looppkg.CompletionNone,
@@ -214,6 +244,7 @@ func builtInServiceDefinitionSpecs(cfg *config.Config) []looppkg.Spec {
 		specs = append(specs, looppkg.Spec{
 			Name:         mediaFeedPollerDefinitionName,
 			Enabled:      true,
+			ParentName:   pollersContainerName,
 			Task:         "Poll followed media feeds for new entries and dispatch analysis when needed.",
 			Operation:    looppkg.OperationService,
 			Completion:   looppkg.CompletionNone,

--- a/internal/app/loop_definition_hydration_test.go
+++ b/internal/app/loop_definition_hydration_test.go
@@ -284,6 +284,21 @@ func TestBuildLoopDefinitionBaseSpecs_GroupingContainers(t *testing.T) {
 		PublishIntervalSec: 60,
 		Telemetry:          config.TelemetryConfig{Enabled: true, Interval: 60},
 	}
+	// Enable the pollers members so the pollers container and its members appear.
+	cfg.Unifi = config.UnifiConfig{URL: "https://unifi.local", APIKey: "key", PollIntervalSec: 30}
+	cfg.Person = config.PersonConfig{Track: []string{"person.dan"}}
+	cfg.Email = emailcfg.Config{
+		PollIntervalSec: 300,
+		Accounts: []emailcfg.AccountConfig{{
+			Name: "personal",
+			IMAP: emailcfg.IMAPConfig{Host: "imap.example.com", Username: "dan@example.com"},
+		}},
+	}
+	cfg.Media = config.MediaConfig{FeedCheckInterval: 600}
+	cfg.Forge = forge.Config{
+		SubscriptionCheckInterval: 900,
+		Accounts:                  []forge.AccountConfig{{Name: "github", Provider: "github", Token: "token"}},
+	}
 
 	a := &App{cfg: cfg}
 	specs, err := a.buildLoopDefinitionBaseSpecs()
@@ -296,7 +311,7 @@ func TestBuildLoopDefinitionBaseSpecs_GroupingContainers(t *testing.T) {
 	}
 
 	// Containers exist and are inert grouping containers.
-	for _, name := range []string{cognitionContainerName, homeAssistantContainerName} {
+	for _, name := range []string{cognitionContainerName, homeAssistantContainerName, pollersContainerName} {
 		s, ok := byName[name]
 		if !ok {
 			t.Errorf("grouping container %q missing from base specs", name)
@@ -318,6 +333,17 @@ func TestBuildLoopDefinitionBaseSpecs_GroupingContainers(t *testing.T) {
 	for _, name := range []string{haStateWatcherDefinitionName, mqttPublisherDefinitionName, telemetryDefinitionName, mqtt.DefaultHandlerLoopName} {
 		if got := byName[name].ParentName; got != homeAssistantContainerName {
 			t.Errorf("%s ParentName = %q, want %q", name, got, homeAssistantContainerName)
+		}
+	}
+
+	// Pollers members nest under the pollers container — the four pollers and
+	// the two triage handlers that used to hang off core directly.
+	for _, name := range []string{
+		unifiPollerDefinitionName, emailPollerDefinitionName, emailcfg.DefaultHandlerLoopName,
+		forgeSubPollerDefinitionName, mediaFeedPollerDefinitionName, media.DefaultHandlerLoopName,
+	} {
+		if got := byName[name].ParentName; got != pollersContainerName {
+			t.Errorf("%s ParentName = %q, want %q", name, got, pollersContainerName)
 		}
 	}
 }
@@ -351,6 +377,15 @@ func TestBuiltInContainerDefinitionSpecs_Gating(t *testing.T) {
 	}))
 	if !ha[homeAssistantContainerName] {
 		t.Error("home-assistant container missing when MQTT configured")
+	}
+
+	// The pollers container appears when any of its members is enabled (media
+	// is the simplest gate — a positive feed-check interval, no Configured()).
+	pol := names(builtInContainerDefinitionSpecs(&config.Config{
+		Media: config.MediaConfig{FeedCheckInterval: 600},
+	}))
+	if !pol[pollersContainerName] {
+		t.Error("pollers container missing when a poller integration is configured")
 	}
 }
 

--- a/internal/app/loop_definition_hydration_test.go
+++ b/internal/app/loop_definition_hydration_test.go
@@ -322,30 +322,29 @@ func TestBuildLoopDefinitionBaseSpecs_GroupingContainers(t *testing.T) {
 		}
 	}
 
-	// Cognition members nest under the cognition container.
-	for _, name := range []string{ego.DefinitionName, metacognitive.DefinitionName, archivist.DefinitionName} {
-		if got := byName[name].ParentName; got != cognitionContainerName {
-			t.Errorf("%s ParentName = %q, want %q", name, got, cognitionContainerName)
+	// assertNested checks each member exists and nests under container. The
+	// presence check keeps a missing member reported as such rather than as a
+	// misleading empty-ParentName mismatch.
+	assertNested := func(container string, names ...string) {
+		t.Helper()
+		for _, name := range names {
+			s, ok := byName[name]
+			if !ok {
+				t.Errorf("member %q missing from base specs", name)
+				continue
+			}
+			if s.ParentName != container {
+				t.Errorf("%s ParentName = %q, want %q", name, s.ParentName, container)
+			}
 		}
 	}
 
-	// Home Assistant members nest under the home-assistant container.
-	for _, name := range []string{haStateWatcherDefinitionName, mqttPublisherDefinitionName, telemetryDefinitionName, mqtt.DefaultHandlerLoopName} {
-		if got := byName[name].ParentName; got != homeAssistantContainerName {
-			t.Errorf("%s ParentName = %q, want %q", name, got, homeAssistantContainerName)
-		}
-	}
-
-	// Pollers members nest under the pollers container — the four pollers and
-	// the two triage handlers that used to hang off core directly.
-	for _, name := range []string{
+	assertNested(cognitionContainerName, ego.DefinitionName, metacognitive.DefinitionName, archivist.DefinitionName)
+	assertNested(homeAssistantContainerName, haStateWatcherDefinitionName, mqttPublisherDefinitionName, telemetryDefinitionName, mqtt.DefaultHandlerLoopName)
+	// The four pollers and the two triage handlers that used to hang off core.
+	assertNested(pollersContainerName,
 		unifiPollerDefinitionName, emailPollerDefinitionName, emailcfg.DefaultHandlerLoopName,
-		forgeSubPollerDefinitionName, mediaFeedPollerDefinitionName, media.DefaultHandlerLoopName,
-	} {
-		if got := byName[name].ParentName; got != pollersContainerName {
-			t.Errorf("%s ParentName = %q, want %q", name, got, pollersContainerName)
-		}
-	}
+		forgeSubPollerDefinitionName, mediaFeedPollerDefinitionName, media.DefaultHandlerLoopName)
 }
 
 // TestBuiltInContainerDefinitionSpecs_Gating guards the container gating:


### PR DESCRIPTION
Per your steer, this is the simple version of #1035 — no producer-binding abstraction, just the graph-balance fix.

## The imbalance

Six service loops hung **directly off `core`**, while `cognition` and `home-assistant` already gather their members under a container. The graph read lopsided:

- `unifi-poller` (network presence)
- `email-poller` + `email-default-handler`
- `forge-subscription-poller`
- `media-feed-poller` + `media-default-handler`

Everything else already had a home (`cognition`, `home-assistant`, or the dynamic `channels` container); these were the leftovers on core.

## The change

Add a `pollers` grouping container — an inert `Operation=container` under core, exactly like the existing two — and parent all six under it via `ParentName`. That's it: a balanced graph where loops don't live off core directly.

**Drift-proofing:** the container is gated so it only appears when ≥1 member is enabled, and four shared predicates (`unifiPollerEnabled` / `emailServicesEnabled` / `forgePollerEnabled` / `mediaServicesEnabled`) drive *both* the container gate and the member `if`s — so they can't drift into an empty container or a member orphaned under a missing parent.

**No further wiring:** containers render by `Operation`, not name, so the web console and the `loop_containers` / placement-advisory tooling pick `pollers` up automatically (verified: nothing hardcodes the built-in container set).

## Tests

`TestBuildLoopDefinitionBaseSpecs_GroupingContainers` now asserts the six members nest under `pollers`; `TestBuiltInContainerDefinitionSpecs_Gating` asserts the container appears when a poller integration is configured (and the bare-config check already covers its absence). `just ci` green.

## Scope note

Both default-handlers (`email-default-handler`, `media-default-handler`) ride under `pollers` alongside their pollers so nothing's left on core — flag if you'd rather the two event-driven handlers not sit under a "pollers" label. The producer-binding + policy-attachment items from the issue's written rescope are **not** in here; this delivers the container/graph-balance goal you clarified as the actual target. Close #1035 on merge if that was the whole intent, or keep it open for the rest.

Refs #1035

🤖 Generated with [Claude Code](https://claude.com/claude-code)