### PR TITLE
v0.10.2 pre-release doc fixes

### DIFF
--- a/docs/operating/configuration.md
+++ b/docs/operating/configuration.md
@@ -55,10 +55,18 @@ runs entirely on local models.
 homeassistant:
   url: http://homeassistant.local:8123
   token: your_long_lived_access_token
+  ingest_rate_limit_per_minute: 12  # optional: cap on state-change events ingested per entity per minute
+  # registry_cache_ttl and floor_alias are also optional — see homeassistant.md
 ```
 
-Both fields are required. The token needs access to the entities and
-services you want Thane to interact with. See
+`url` and `token` are required; the token needs access to the entities and
+services you want Thane to interact with.
+
+As of v0.10.2 the former `homeassistant.subscribe` block is retired — a stale
+`subscribe:` key will fail the boot. Its `rate_limit_per_minute` moved to the
+top-level `ingest_rate_limit_per_minute`, and entity globs are no longer a
+config concept: they are runtime ingest-mode subscriptions, declared with
+`add_entity_subscription` (or the model's `watch_entity`) after boot. See
 [Home Assistant](homeassistant.md) for setup details.
 
 ## MQTT

--- a/docs/prompt-tool-pruning-strategy.md
+++ b/docs/prompt-tool-pruning-strategy.md
@@ -309,9 +309,8 @@ For model-facing copy inside the document itself:
 
 Some capability families are real on one deployment but weak, absent, or
 shaped differently elsewhere. `pocket` is the obvious current example:
-its Home Assistant MCP bridge, MQTT wake plumbing, host-local ops
-surface, and older local tag aliases are not universal truths for every
-Thane runtime.
+its MQTT wake plumbing, host-local ops surface, and older local tag
+aliases are not universal truths for every Thane runtime.
 
 The working convention should be:
 

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -163,12 +163,15 @@ becoming default context clutter.
 | `ha_history` | Recorder trend for one entity over a lookback window: numeric min/max/start/end/delta/trend or a discrete change summary, optionally trending a numeric attribute instead of the state. |
 | `ha_home_snapshot` | Curated whole-home overview: anomalies, security/openings, presence, climate (energy optional), salience-first with an at-a-glance summary and a quiet status, plus optional per-entity metadata. |
 | `ha_call_service` | Direct HA service invocation. |
+| `ha_list_services` | List available HA services with per-field detail; feeds `ha_automation_create` action authoring. |
 | `ha_registry_search` | Search the entity/device/area registry. |
 | `ha_automation_list` | List automations with recent activation counts. |
 | `ha_automation_get` | Retrieve one automation's configuration. |
 | `ha_automation_create` | Create a new automation. |
 | `ha_automation_update` | Modify an existing automation. |
 | `ha_automation_delete` | Delete an automation. |
+| `ha_automation_traces` | Fetch execution traces for an automation — step-by-step debugging of why it did or didn't fire. |
+| `ha_automation_vocabulary` | Enumerate the 2026.7 trigger/condition identifiers usable in `ha_automation_create` config blocks. |
 
 ## `notifications` — delivery, escalation, and actionable responses
 


### PR DESCRIPTION
Pre-release doc-accuracy fixes from the v0.10.2 focused §1 audit (config-drift / docs / upgrade-notes pass). All three verified against the current tree.

- **`reference/tools.md`** — added the three shipped HA tools missing from the table: `ha_list_services`, `ha_automation_traces`, `ha_automation_vocabulary` (the 2026.7 native-first additions, #1187–#1200). Code has 23 `ha_*` tools; the doc listed 20.
- **`prompt-tool-pruning-strategy.md`** — dropped pocket's "Home Assistant MCP bridge" from the live-capability example; ha-mcp was retired in #1200 (native-first is the only HA path), and this was the last non-historical stale mention.
- **`operating/configuration.md`** — the `homeassistant` block documented only `url`/`token`; added `ingest_rate_limit_per_minute` (the destination the retired-`subscribe` boot error points to) plus a one-paragraph migration note.

Part of the v0.10.2 release prep. The audit's headline: **no config edit is needed at deploy** — the live prod config is already migrated (`subscribe:` commented, `ingest_rate_limit_per_minute` present, ha-mcp unplugged). The real deploy actions are operator-side (a 3-file talent backport and re-authoring the always-visible HA subscription tier), tracked separately for the cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)