### PR TITLE
docs: drop the stale CONVERSATION HISTORY row from the caching section table

### DIFF
--- a/docs/prompt-caching.md
+++ b/docs/prompt-caching.md
@@ -47,8 +47,11 @@ and regression tests.
 | `RELATED CONTEXT`       | volatile  | Request/wake-related retrieval providers. Query-sensitive. |
 | `LIVE STATE`            | volatile  | Current operational/world state providers. |
 | `CURRENT CONDITIONS`    | volatile  | Time, host, version, branch, and uptime. Changes every turn. |
-| `CONVERSATION HISTORY`  | volatile  | Append-only, but the latest turn must remain visible. |
 | `CONTEXT USAGE`         | volatile  | Per-turn token counts and request metadata. |
+
+Conversation history is not a system-prompt section: it rides in the
+`messages[]` array (PR #852), where providers with prefix caching cover
+it through the message-level cache breakpoints described below.
 
 Stable and semi-stable sections should appear before volatile sections.
 Volatile sections should not receive provider cache markers unless the


### PR DESCRIPTION
## Summary

Conversation history moved out of the system prompt and into the `messages[]` array in PR #852, but `docs/prompt-caching.md` still listed `CONVERSATION HISTORY` as a volatile system-prompt section. This was the one residue found when the 2026-07-07 v0.10.3 curation audit verified #738 as fully landed (the section is gone from prompt assembly and `TestBuildSystemPrompt_OmitsConversationHistory` enforces it).

The row is replaced with a pointer to the message-level cache breakpoints that actually cover history.

Refs #738

## Test plan

- [x] `just ci` passes locally
- [x] Verified no `CONVERSATION HISTORY` section exists in prompt assembly (`grep -rn 'CONVERSATION HISTORY' internal/` — only the omission test references it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)