### PR TITLE
docs: drop the sunsetted Go Report Card badge from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 [![CI](https://github.com/nugget/thane-ai-agent/actions/workflows/ci.yml/badge.svg)](https://github.com/nugget/thane-ai-agent/actions/workflows/ci.yml)
 [![Go Reference](https://pkg.go.dev/badge/github.com/nugget/thane-ai-agent.svg)](https://pkg.go.dev/github.com/nugget/thane-ai-agent)
-[![Go Report Card](https://goreportcard.com/badge/github.com/nugget/thane-ai-agent)](https://goreportcard.com/report/github.com/nugget/thane-ai-agent)
 [![Go Version](https://img.shields.io/github/go-mod/go-version/nugget/thane-ai-agent)](go.mod)
 [![License](https://img.shields.io/github/license/nugget/thane-ai-agent)](LICENSE)
 [![Release](https://img.shields.io/github/v/release/nugget/thane-ai-agent)](https://github.com/nugget/thane-ai-agent/releases/latest)


### PR DESCRIPTION
goreportcard.com has been sunset by its maintainers — the site now carries a farewell notice in place of the grading service ([goreportcard.com](https://goreportcard.com/)), so the badge in the README badge row no longer renders a meaningful grade. This removes it; the remaining badges (CI, Go Reference, Go Version, License, Release) are untouched.

For anyone wanting a lint-quality badge in the future, [golangci/golangci-lint discussion #3431](https://github.com/golangci/golangci-lint/discussions/3431) covers the options for surfacing golangci-lint results as a repo badge — but this repo already runs golangci-lint in CI, so the CI badge covers it.

Docs-only change — no code affected. `just ci` passed locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)