### PR TITLE
The heading the model couldn't stop repeating: in-flight repair for doubled section headings in doc_edit

### DIFF
--- a/internal/state/documents/mutate_helpers.go
+++ b/internal/state/documents/mutate_helpers.go
@@ -282,7 +282,7 @@ func findSection(sections []Section, selector, heading string) (Section, bool) {
 // heading level is ignored because the duplicate often arrives at the
 // wrong depth.
 func stripLeadingDuplicateHeading(content string, names ...string) string {
-	line, rest, _ := strings.Cut(strings.TrimLeft(content, "\n"), "\n")
+	line, rest, _ := strings.Cut(strings.TrimLeft(content, "\r\n"), "\n")
 	candidate := strings.TrimSpace(line)
 	hashes := 0
 	for hashes < len(candidate) && candidate[hashes] == '#' {
@@ -297,7 +297,7 @@ func stripLeadingDuplicateHeading(content string, names ...string) string {
 			continue
 		}
 		if strings.EqualFold(text, name) || slugify(text) == slugify(name) {
-			return strings.TrimLeft(rest, "\n")
+			return strings.TrimLeft(rest, "\r\n")
 		}
 	}
 	return content

--- a/internal/state/documents/mutate_helpers.go
+++ b/internal/state/documents/mutate_helpers.go
@@ -177,6 +177,7 @@ func upsertDocumentSection(body, selector, heading string, level int, content st
 	if level <= 0 || level > 6 {
 		level = 2
 	}
+	content = stripLeadingDuplicateHeading(content, heading, selector)
 	lines := strings.Split(trimDocumentBody(body), "\n")
 	if len(lines) == 1 && lines[0] == "" {
 		lines = nil
@@ -270,6 +271,36 @@ func findSection(sections []Section, selector, heading string) (Section, bool) {
 		}
 	}
 	return Section{}, false
+}
+
+// stripLeadingDuplicateHeading removes a redundant heading line from
+// section content. Models frequently repeat the target section's heading
+// as the first line of an upsert_section body even though
+// renderSectionBlock adds the heading itself, doubling it on disk. The
+// line is dropped only when it is an ATX heading whose text matches the
+// resolved heading or selector (case-insensitive or slug-equal); the
+// heading level is ignored because the duplicate often arrives at the
+// wrong depth.
+func stripLeadingDuplicateHeading(content string, names ...string) string {
+	line, rest, _ := strings.Cut(strings.TrimLeft(content, "\n"), "\n")
+	candidate := strings.TrimSpace(line)
+	hashes := 0
+	for hashes < len(candidate) && candidate[hashes] == '#' {
+		hashes++
+	}
+	if hashes == 0 || hashes > 6 || hashes == len(candidate) || candidate[hashes] != ' ' {
+		return content
+	}
+	text := strings.TrimSpace(candidate[hashes:])
+	for _, name := range names {
+		if name == "" {
+			continue
+		}
+		if strings.EqualFold(text, name) || slugify(text) == slugify(name) {
+			return strings.TrimLeft(rest, "\n")
+		}
+	}
+	return content
 }
 
 func renderSectionBlock(level int, heading, content string) string {

--- a/internal/state/documents/mutate_test.go
+++ b/internal/state/documents/mutate_test.go
@@ -152,6 +152,18 @@ func TestStripLeadingDuplicateHeading(t *testing.T) {
 			want:    "",
 		},
 		{
+			name:    "crlf duplicate stripped",
+			content: "## Observations\r\n\r\nFresh note.",
+			names:   []string{"Observations"},
+			want:    "Fresh note.",
+		},
+		{
+			name:    "crlf blank line before duplicate stripped",
+			content: "\r\n## Observations\r\nFresh note.",
+			names:   []string{"Observations"},
+			want:    "Fresh note.",
+		},
+		{
 			name:    "empty content unchanged",
 			content: "",
 			names:   []string{"Observations"},

--- a/internal/state/documents/mutate_test.go
+++ b/internal/state/documents/mutate_test.go
@@ -94,6 +94,118 @@ func TestStoreEditUpsertSectionPreservesCreated(t *testing.T) {
 	}
 }
 
+func TestStripLeadingDuplicateHeading(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		content string
+		names   []string
+		want    string
+	}{
+		{
+			name:    "exact duplicate stripped",
+			content: "## Observations\n\nFresh note.",
+			names:   []string{"Observations"},
+			want:    "Fresh note.",
+		},
+		{
+			name:    "case insensitive duplicate stripped",
+			content: "## OBSERVATIONS\n\nFresh note.",
+			names:   []string{"Observations"},
+			want:    "Fresh note.",
+		},
+		{
+			name:    "wrong level duplicate stripped",
+			content: "# Observations\nFresh note.",
+			names:   []string{"Observations"},
+			want:    "Fresh note.",
+		},
+		{
+			name:    "slug match against selector stripped",
+			content: "## Current Status\n\nAll clear.",
+			names:   []string{"", "current-status"},
+			want:    "All clear.",
+		},
+		{
+			name:    "different heading preserved",
+			content: "### Background\n\nDetail.",
+			names:   []string{"Observations"},
+			want:    "### Background\n\nDetail.",
+		},
+		{
+			name:    "plain first line preserved",
+			content: "Observations of note.\n\nMore.",
+			names:   []string{"Observations"},
+			want:    "Observations of note.\n\nMore.",
+		},
+		{
+			name:    "hash without space is not a heading",
+			content: "#Observations\n\nMore.",
+			names:   []string{"Observations"},
+			want:    "#Observations\n\nMore.",
+		},
+		{
+			name:    "heading only becomes empty",
+			content: "## Observations",
+			names:   []string{"Observations"},
+			want:    "",
+		},
+		{
+			name:    "empty content unchanged",
+			content: "",
+			names:   []string{"Observations"},
+			want:    "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := stripLeadingDuplicateHeading(tt.content, tt.names...); got != tt.want {
+				t.Fatalf("stripLeadingDuplicateHeading(%q, %v) = %q, want %q", tt.content, tt.names, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestStoreEditUpsertSectionStripsDuplicateHeading(t *testing.T) {
+	t.Parallel()
+
+	store, _ := newMutationStore(t)
+	ctx := context.Background()
+
+	_, err := store.Write(ctx, WriteArgs{
+		Ref:   "kb:status.md",
+		Title: "Status",
+		Body:  stringPtr("# Status\n\nBase body."),
+	})
+	if err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	_, err = store.Edit(ctx, EditArgs{
+		Ref:     "kb:status.md",
+		Mode:    "upsert_section",
+		Section: "Observations",
+		Body:    "## Observations\n\nFresh note.",
+	})
+	if err != nil {
+		t.Fatalf("Edit: %v", err)
+	}
+
+	after, err := store.Read(ctx, "kb:status.md")
+	if err != nil {
+		t.Fatalf("Read after edit: %v", err)
+	}
+	if got := strings.Count(after.Body, "## Observations"); got != 1 {
+		t.Fatalf("edited body = %q, want exactly one Observations heading, got %d", after.Body, got)
+	}
+	if !strings.Contains(after.Body, "Fresh note.") {
+		t.Fatalf("edited body = %q, want section content preserved", after.Body)
+	}
+}
+
 func TestStoreJournalUpdatePrunesOldWindows(t *testing.T) {
 	t.Parallel()
 

--- a/internal/tools/document_mutation_tools.go
+++ b/internal/tools/document_mutation_tools.go
@@ -101,7 +101,7 @@ func registerDocumentMutationTools(r *Registry, dt *documents.Tools) {
 				},
 				"body": map[string]any{
 					"type":        "string",
-					"description": "Markdown text for the edit — the same parameter name doc_write uses. For the body modes this is the document's new body (whole or appended/prepended text); for upsert_section it is only that one section's text — never the whole document.",
+					"description": "Markdown text for the edit — the same parameter name doc_write uses. For the body modes this is the document's new body (whole or appended/prepended text); for upsert_section it is only that one section's text — never the whole document, and never the section's heading line (the heading is rendered automatically from `section`/`heading`; a leading duplicate heading line is stripped).",
 				},
 				"section": map[string]any{
 					"type":        "string",

--- a/scripts/architecture.baseline
+++ b/scripts/architecture.baseline
@@ -1,5 +1,5 @@
 packages=64
 interfaces=84
-large_files=51
+large_files=52
 set_mutators=115
 database_opens=9

--- a/talents/documents.md
+++ b/talents/documents.md
@@ -315,9 +315,11 @@ section-level upsert/delete.
 Section edits target by heading text or slug. The upsert mode inserts
 if the section is missing, replaces if present; the delete mode removes
 the named section entirely. In section modes, `body` carries only that
-one section's text — never the whole document; the rest of the document
-is untouched. (For whole-document rewrites, `body` is the full new
-document body, same as `doc_write`.)
+one section's text — never the whole document, and never the section's
+heading line: the heading is rendered automatically from `section` and
+`heading`, so repeating it in `body` would double it. The rest of the
+document is untouched. (For whole-document rewrites, `body` is the full
+new document body, same as `doc_write`.)
 
 ## Rolling journal — `doc_journal_update`
 


### PR DESCRIPTION
## The symptom

Production documents maintained through `doc_edit(mode=upsert_section)` regularly accumulate doubled headings — `## Observations` immediately followed by `## Observations` again. The model includes the section's heading line as the first line of `body`, and since `renderSectionBlock` unconditionally prepends the heading it renders from `section`/`heading`, both copies land on disk.

## Why the model keeps doing it

The contract was ambiguous at every door the model reads. The `body` parameter description said upsert_section takes "only that one section's text" without saying whether that text includes the heading line, and the documents talent modeled a correct call but never stated the rule. A model that just read the section back (heading included) and is now writing it forward has every reason to round-trip the heading. This is the classic replace-the-section-including-or-excluding-its-heading ambiguity, and we had silently picked "excluding" without telling anyone.

## The fix: repair in flight, then teach

`upsertDocumentSection` now strips a leading duplicate heading from the content before rendering: when the first line is an ATX heading whose text matches the resolved heading or selector — case-insensitive or slug-equal, at any level, since the duplicate often arrives at the wrong depth — the line is dropped. A first line that is a *different* heading (a legitimate subsection) or plain text passes through untouched. The repair lives at the shared chokepoint, so the journal-window path and the section-intake path inherit the same protection for free; the section-transfer path already fed heading-stripped content and is unaffected.

Both model-facing doors now state the contract explicitly: the `doc_edit` schema's `body` description and the documents talent both say the heading is rendered automatically from `section`/`heading` and must never be included in `body`.

## Notes

The new helper pushes `mutate_helpers.go` to 505 lines, crossing the architecture gate's 500-line large-file threshold; the baseline was regenerated via `scripts/architecture.sh update` to accept the intentional growth.

Prod loads talents live from `talents_dir`, so the `talents/documents.md` change needs the usual manual backport after merge.

## Test plan

- [x] Table-driven unit coverage for the strip helper: exact/case-insensitive/wrong-level/slug matches stripped; different headings, plain text, and `#hashtag`-style non-headings preserved; heading-only and empty content handled
- [x] End-to-end `Store.Edit` test proving a body that includes the heading yields exactly one heading on disk
- [x] `just ci` green locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)