### PR TITLE
Internal means internal: doc_search excludes audience-internal documents by default (#1250 phase 1, documents)

### DIFF
--- a/internal/model/talents/loader.go
+++ b/internal/model/talents/loader.go
@@ -60,6 +60,11 @@ type Frontmatter struct {
 	Kind     string
 	Teaser   string
 	NextTags []string
+	// Audience carries the document-layer audience convention (#1250):
+	// "internal" marks a private working surface that must not inject
+	// into model context even when tagged. Parsed here so the KB
+	// article scanner can honor it; meaningless on talents themselves.
+	Audience string
 }
 
 // Block represents a single parsed frontmatter + content pair from a
@@ -461,6 +466,10 @@ func parseFrontmatterLines(frontmatter string) Frontmatter {
 			meta.Teaser = value
 		case strings.HasPrefix(line, "next_tags:"):
 			meta.NextTags = parseFrontmatterTagList(strings.TrimPrefix(line, "next_tags:"))
+		case strings.HasPrefix(line, "audience:"):
+			value := strings.TrimSpace(strings.TrimPrefix(line, "audience:"))
+			value = strings.Trim(value, `"'`)
+			meta.Audience = value
 		default:
 			continue
 		}

--- a/internal/model/talents/loader.go
+++ b/internal/model/talents/loader.go
@@ -323,8 +323,8 @@ func ParseFrontmatterMetadata(raw string) (Frontmatter, string) {
 // "---" lines and is followed by the body content up to the next
 // node boundary (or EOF). A node boundary is a "---" line followed by
 // a recognized frontmatter key (name, tags, tags_all, kind, teaser,
-// next_tags); a "---" followed by anything else stays as body content
-// (a markdown horizontal rule).
+// next_tags, audience); a "---" followed by anything else stays as body
+// content (a markdown horizontal rule).
 //
 // Single-node files (the historical shape) return a length-1 slice.
 // Multi-node files return one [Block] per node. Returns a length-1
@@ -431,7 +431,7 @@ func splitAtNextNodeBoundary(body string) (content, remainder string) {
 // markdown horizontal rule (followed by prose or a different key).
 func isFrontmatterKey(key string) bool {
 	switch key {
-	case "name", "tags", "tags_all", "kind", "teaser", "next_tags":
+	case "name", "tags", "tags_all", "kind", "teaser", "next_tags", "audience":
 		return true
 	default:
 		return false

--- a/internal/runtime/agent/tag_context.go
+++ b/internal/runtime/agent/tag_context.go
@@ -698,6 +698,14 @@ func scanKBArticles(dir string) ([]kbArticle, error) {
 		if len(meta.Tags) == 0 && len(meta.TagsAll) == 0 {
 			return nil // untagged KB articles are not auto-loaded
 		}
+		if strings.EqualFold(strings.TrimSpace(meta.Audience), "internal") {
+			// The #1250 audience contract: an internal-audience document
+			// is a private working surface (loop working notes, process
+			// logs). Tags on it must not turn it into injected guidance —
+			// doc_search already excludes it, and this scanner is the
+			// other injection path.
+			return nil
+		}
 
 		canonicalKind, _ := talents.CanonicalKind(meta.Kind)
 		talents.WarnIfKindAlias(path, meta.Kind)

--- a/internal/runtime/agent/tag_context_test.go
+++ b/internal/runtime/agent/tag_context_test.go
@@ -87,6 +87,38 @@ func TestBuildSystemPrompt_TagContextIncluded(t *testing.T) {
 	}
 }
 
+func TestBuildSystemPrompt_InternalAudienceKBArticleExcluded(t *testing.T) {
+	kbDir := t.TempDir()
+	os.WriteFile(filepath.Join(kbDir, "guide.md"),
+		[]byte("---\ntags: [forge]\n---\n# Guide\nPublished guidance."), 0644)
+	os.WriteFile(filepath.Join(kbDir, "notes.md"),
+		[]byte("---\ntags: [forge]\naudience: internal\n---\n# Notes\nPrivate process narration."), 0644)
+
+	l := newTagTestLoop()
+	capTags := map[string]config.CapabilityTagConfig{
+		"forge": {
+			Description: "Code generation",
+			Tools:       []string{"forge_run"},
+			Core:        true,
+		},
+	}
+	l.SetTagContextAssembler(NewTagContextAssembler(TagContextAssemblerConfig{
+		CapTags: capTags,
+		KBDir:   kbDir,
+		Logger:  l.logger,
+	}))
+	l.SetCapabilityTags(capTags, nil)
+
+	prompt := l.buildSystemPrompt(testCtxForLoop(l), "hello")
+
+	if !strings.Contains(prompt, "Published guidance.") {
+		t.Error("system prompt should contain the published tagged article")
+	}
+	if strings.Contains(prompt, "Private process narration.") {
+		t.Error("system prompt must not contain an internal-audience article, even when tagged")
+	}
+}
+
 func TestBuildSystemPrompt_TagContextInactiveExcluded(t *testing.T) {
 	kbDir := t.TempDir()
 	os.WriteFile(filepath.Join(kbDir, "arch.md"),

--- a/internal/state/documents/contracts.go
+++ b/internal/state/documents/contracts.go
@@ -45,4 +45,7 @@ type SearchQuery struct {
 	ModifiedAfter   *time.Time          `json:"-"`
 	ModifiedBefore  *time.Time          `json:"-"`
 	Limit           int                 `json:"limit,omitempty"`
+	// IncludeInternal includes internal-audience documents (frontmatter
+	// audience: internal), which default search excludes.
+	IncludeInternal bool `json:"include_internal,omitempty"`
 }

--- a/internal/state/documents/query.go
+++ b/internal/state/documents/query.go
@@ -202,11 +202,15 @@ func (s *Store) Search(ctx context.Context, q SearchQuery) ([]DocumentSummary, e
 		doc   DocumentSummary
 		score int
 	}
+	includeInternal := q.IncludeInternal || audienceExplicitlyFiltered(q)
 	var matches []scored
 	for rows.Next() {
 		var doc DocumentSummary
 		if err := scanDocument(rows, &doc); err != nil {
 			return nil, fmt.Errorf("scan search result: %w", err)
+		}
+		if !includeInternal && isInternalAudienceDocument(doc.Frontmatter) {
+			continue
 		}
 		if !hasAllTags(doc.Tags, q.Tags) {
 			continue

--- a/internal/state/documents/query_helpers.go
+++ b/internal/state/documents/query_helpers.go
@@ -50,6 +50,45 @@ func containsAnyFold(have, want []string) bool {
 	return false
 }
 
+// audienceFrontmatterKey and audienceInternalValue are the documents-layer
+// half of the #1250 audience contract: a document whose frontmatter
+// declares audience: internal is a private working surface (loop working
+// notes, process logs) rather than published content.
+const (
+	audienceFrontmatterKey = "audience"
+	audienceInternalValue  = "internal"
+)
+
+// isInternalAudienceDocument reports whether a document declares itself
+// internal-audience via frontmatter. Search excludes internal documents
+// by default so process narration never leaks into consumer contexts
+// through a search hit; explicit reads by ref are unaffected.
+func isInternalAudienceDocument(frontmatter map[string][]string) bool {
+	for _, value := range frontmatter[audienceFrontmatterKey] {
+		if strings.EqualFold(strings.TrimSpace(value), audienceInternalValue) {
+			return true
+		}
+	}
+	return false
+}
+
+// audienceExplicitlyFiltered reports whether the caller's own filters
+// name the audience key. An explicit audience filter is a deliberate
+// selection, so the default internal exclusion steps aside instead of
+// silently emptying the result. Callers pass the query after frontmatter
+// normalization, so the key lookup is lowercase-safe.
+func audienceExplicitlyFiltered(q SearchQuery) bool {
+	if len(q.Frontmatter[audienceFrontmatterKey]) > 0 {
+		return true
+	}
+	for _, key := range q.FrontmatterKeys {
+		if strings.EqualFold(strings.TrimSpace(key), audienceFrontmatterKey) {
+			return true
+		}
+	}
+	return false
+}
+
 func normalizeSearchFrontmatter(in map[string][]string) map[string][]string {
 	if len(in) == 0 {
 		return nil

--- a/internal/state/documents/query_internal_audience_test.go
+++ b/internal/state/documents/query_internal_audience_test.go
@@ -1,0 +1,110 @@
+package documents
+
+import (
+	"context"
+	"testing"
+)
+
+// seedAudienceSearchDocs writes one published and one internal-audience
+// document that both match the query text "climate".
+func seedAudienceSearchDocs(t *testing.T) *Store {
+	t.Helper()
+	store, _ := newMutationStore(t)
+	ctx := context.Background()
+
+	if _, err := store.Write(ctx, WriteArgs{
+		Ref:   "kb:climate/status.md",
+		Title: "Climate Status",
+		Body:  stringPtr("# Climate Status\n\nPublished state."),
+	}); err != nil {
+		t.Fatalf("Write published: %v", err)
+	}
+	if _, err := store.Write(ctx, WriteArgs{
+		Ref:         "kb:climate/notes.md",
+		Title:       "Climate Working Notes",
+		Frontmatter: map[string][]string{"audience": {"internal"}},
+		Body:        stringPtr("# Climate Working Notes\n\nProcess narration."),
+	}); err != nil {
+		t.Fatalf("Write internal: %v", err)
+	}
+	return store
+}
+
+func searchRefs(t *testing.T, store *Store, q SearchQuery) map[string]bool {
+	t.Helper()
+	results, err := store.Search(context.Background(), q)
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	refs := make(map[string]bool, len(results))
+	for _, doc := range results {
+		refs[doc.Ref] = true
+	}
+	return refs
+}
+
+func TestSearchExcludesInternalAudienceByDefault(t *testing.T) {
+	t.Parallel()
+
+	store := seedAudienceSearchDocs(t)
+	refs := searchRefs(t, store, SearchQuery{Root: "kb", Query: "climate", Limit: 10})
+	if !refs["kb:climate/status.md"] {
+		t.Fatalf("published doc missing from default search: %v", refs)
+	}
+	if refs["kb:climate/notes.md"] {
+		t.Fatalf("internal doc leaked into default search: %v", refs)
+	}
+}
+
+func TestSearchIncludeInternalFlagIncludesInternal(t *testing.T) {
+	t.Parallel()
+
+	store := seedAudienceSearchDocs(t)
+	refs := searchRefs(t, store, SearchQuery{Root: "kb", Query: "climate", Limit: 10, IncludeInternal: true})
+	if !refs["kb:climate/status.md"] || !refs["kb:climate/notes.md"] {
+		t.Fatalf("include_internal search missing docs: %v", refs)
+	}
+}
+
+func TestSearchExplicitAudienceFilterBypassesExclusion(t *testing.T) {
+	t.Parallel()
+
+	store := seedAudienceSearchDocs(t)
+
+	// Filtering on the audience value is a deliberate selection: the
+	// default exclusion must not silently empty the result.
+	refs := searchRefs(t, store, SearchQuery{
+		Root:        "kb",
+		Frontmatter: map[string][]string{"audience": {"internal"}},
+		Limit:       10,
+	})
+	if !refs["kb:climate/notes.md"] {
+		t.Fatalf("explicit audience-value filter did not surface internal doc: %v", refs)
+	}
+	if refs["kb:climate/status.md"] {
+		t.Fatalf("audience filter matched a published doc without the key: %v", refs)
+	}
+
+	// Requiring the audience key to be present behaves the same way.
+	refs = searchRefs(t, store, SearchQuery{
+		Root:            "kb",
+		FrontmatterKeys: []string{"audience"},
+		Limit:           10,
+	})
+	if !refs["kb:climate/notes.md"] {
+		t.Fatalf("audience frontmatter_keys filter did not surface internal doc: %v", refs)
+	}
+}
+
+func TestSearchInternalReadByRefUnaffected(t *testing.T) {
+	t.Parallel()
+
+	store := seedAudienceSearchDocs(t)
+	doc, err := store.Read(context.Background(), "kb:climate/notes.md")
+	if err != nil {
+		t.Fatalf("Read internal by ref: %v", err)
+	}
+	if doc.Title != "Climate Working Notes" {
+		t.Fatalf("Read internal doc = %#v, want working notes", doc)
+	}
+}

--- a/internal/state/documents/tools.go
+++ b/internal/state/documents/tools.go
@@ -57,6 +57,7 @@ type SearchArgs struct {
 	ModifiedAfter   string              `json:"modified_after,omitempty"`
 	ModifiedBefore  string              `json:"modified_before,omitempty"`
 	Limit           int                 `json:"limit,omitempty"`
+	IncludeInternal bool                `json:"include_internal,omitempty"`
 }
 
 // RefArgs identifies one managed document by canonical semantic ref.
@@ -143,6 +144,7 @@ func (t *Tools) Search(ctx context.Context, args SearchArgs) (string, error) {
 		Frontmatter:     args.Frontmatter,
 		FrontmatterKeys: args.FrontmatterKeys,
 		Limit:           clampLimit(args.Limit, 20, 100),
+		IncludeInternal: args.IncludeInternal,
 	}
 	now := nowUTC()
 	if args.ModifiedAfter != "" {

--- a/internal/tools/document_tools.go
+++ b/internal/tools/document_tools.go
@@ -168,7 +168,7 @@ func RegisterDocumentTools(r *Registry, dt *documents.Tools) {
 
 	r.Register(&Tool{
 		Name:        "doc_search",
-		Description: "Search indexed markdown documents by root, path prefix, query text, tags, frontmatter filters, and modified-time bounds. Returns compact document summaries with canonical refs like `kb:article.md` and modified-time delta fields like `-3600s`, not full bodies.",
+		Description: "Search indexed markdown documents by root, path prefix, query text, tags, frontmatter filters, and modified-time bounds. Returns compact document summaries with canonical refs like `kb:article.md` and modified-time delta fields like `-3600s`, not full bodies. Documents whose frontmatter declares `audience: internal` (private working surfaces such as loop working notes) are excluded by default; set include_internal true, or filter on the audience key explicitly, to see them.",
 		Parameters: map[string]any{
 			"type": "object",
 			"properties": map[string]any{
@@ -225,6 +225,10 @@ func RegisterDocumentTools(r *Registry, dt *documents.Tools) {
 					"type":        "integer",
 					"description": "Maximum number of results to return (default 20, max 100).",
 				},
+				"include_internal": map[string]any{
+					"type":        "boolean",
+					"description": "Include internal-audience documents (frontmatter `audience: internal`), which are excluded by default. Default false.",
+				},
 			},
 		},
 		Handler: func(ctx context.Context, args map[string]any) (string, error) {
@@ -236,6 +240,7 @@ func RegisterDocumentTools(r *Registry, dt *documents.Tools) {
 			frontmatterKeys := documentStringSliceArg(args["frontmatter_keys"])
 			modifiedAfter, _ := args["modified_after"].(string)
 			modifiedBefore, _ := args["modified_before"].(string)
+			includeInternal, _ := args["include_internal"].(bool)
 			limit := numericArg(args["limit"], 20, 100)
 			return dt.Search(ctx, documents.SearchArgs{
 				Root:            root,
@@ -247,6 +252,7 @@ func RegisterDocumentTools(r *Registry, dt *documents.Tools) {
 				ModifiedAfter:   modifiedAfter,
 				ModifiedBefore:  modifiedBefore,
 				Limit:           limit,
+				IncludeInternal: includeInternal,
 			})
 		},
 	})


### PR DESCRIPTION
## What this is

The document-layer half of #1250's audience contract, second of the phase-1 stack (after #1251, independent of it in code). It makes `audience: internal` *true* at the search boundary before anything can author it: a document whose frontmatter declares `audience: internal` is a private working surface — loop working notes, process logs — and `doc_search` now excludes it by default. Sequencing is the point: when the typed publish tool starts stamping notes documents in the next PR, the exclusion is already standing, so there is no interval where "internal" is a label without a mechanism.

## The contract

Internal means context hygiene, not secrecy. Nothing here is access control: `doc_read` by ref is untouched (a deliberate ref is a deliberate act), operators see the files, the archive keeps them. What changes is the accidental path — a search hit surfacing process narration into a consuming context that never asked for it.

Two deliberate escape hatches, both taught in the `doc_search` description:

- `include_internal: true` includes internal documents explicitly.
- A caller whose own filters name the audience key — `frontmatter: {audience: [internal]}` or `frontmatter_keys: [audience]` — has made a deliberate selection, so the default exclusion steps aside instead of silently emptying the result. This is the model-facing-tools rule about distinguishing empty results from selection problems: a search *for* internal docs that returned nothing because of a hidden default would be exactly the un-teachable miss that doctrine forbids.

## Both injection paths, not one

An audit against the refined #1250 design found that `doc_search` was only half the promise: the tagged-KB context scanner walks the kb directory itself, so an internal document carrying `tags:` frontmatter would still have injected as tagged guidance. The scanner now honors the audience key too (the talents frontmatter parser learns it), with a prompt-level test proving a tagged internal article stays out while its published sibling injects.

## Mechanics

`SearchQuery` grows `IncludeInternal`; the exclusion is one skip in the existing scan loop in `Store.Search`, using frontmatter already carried by every indexed row — no schema change, no new persistence. The helpers (`isInternalAudienceDocument`, `audienceExplicitlyFiltered`) live with the other query predicates and are case-insensitive on the value, lowercase-safe on the key (search frontmatter filters are already normalized). `doc_search` gains the `include_internal` parameter and a description that teaches the convention and both escape hatches.

## Test plan

- [x] Default search excludes an internal-audience doc and keeps published siblings
- [x] A tagged internal-audience KB article is excluded from tagged-guidance injection; its published sibling still injects
- [x] `include_internal: true` includes both
- [x] Explicit audience-value filter and audience-key filter each surface internal docs without the flag
- [x] `doc_read` by ref unaffected
- [x] `just ci` green locally

Refs #1250

🤖 Generated with [Claude Code](https://claude.com/claude-code)
