### PR TITLE
feat(loops): add structured payload output tier with rendering targets

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -30,6 +30,8 @@ complete onboarding guide for Home Assistant users.
   prompt is assembled from persona, talents, knowledge, and session state
 - **[Document Roots](understanding/document-roots.md)** — How `paths:`
   becomes named local document collections that Thane can keep track of
+- **[Defined Outputs](understanding/defined-outputs.md)** — How a loop
+  declares what it owns, and the tiers between a document and a display
 - **[Trust Architecture](understanding/trust-architecture.md)** — Safety
   through structural enforcement, not prompt compliance
 - **[Glossary](understanding/glossary.md)** — Canonical definitions for

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -238,13 +238,20 @@ or signed deltas like `-604800s`.
 | `doc_move_section` | Move one named section into another document. |
 | `doc_journal_update` | Append or update a journal-style entry. |
 
-Loop-declared document output tools are request-scoped and do not appear
-in the global catalog above. When a loop declares a maintained document
-or journal document output, Thane generates tools such as
+Loop-declared output tools are request-scoped and do not appear in the
+global catalog above. When a loop declares a maintained document or
+journal document output, Thane generates tools such as
 `replace_output_metacognitive_state` or `append_output_daily_notes` only
 for that loop run. These tools route through managed document roots, so
 root policy, indexing, and provenance remain centralized instead of
 being reimplemented in each loop prompt.
+
+A loop can also declare a `structured_payload` output naming a rendering
+target, which generates a `set_output_<name>` tool whose schema is that
+target's slot contract — named slots with types and character budgets
+instead of a free-text body. Those payloads publish as Home Assistant
+entities rather than documents. See
+[Defined Outputs](../understanding/defined-outputs.md).
 
 ## `email` — inbox traffic
 

--- a/docs/understanding/agent-loop.md
+++ b/docs/understanding/agent-loop.md
@@ -111,19 +111,29 @@ definition. A declared output is an explicit contract: this loop is
 responsible for maintaining or appending to this document, and Thane
 generates the narrow tool surface for that job at runtime.
 
-Two output shapes exist today:
+Three output shapes exist today:
 
 - **Maintained document** outputs replace the whole current document
   through a generated `replace_output_<name>` tool.
 - **Journal document** outputs append a timestamped entry through a
   generated `append_output_<name>` tool.
+- **Structured payload** outputs fill the named slots of a rendering
+  target — an Apple Watch complication, say — through a generated
+  `set_output_<name>` tool whose schema is that target's slot contract.
+  The payload publishes as a Home Assistant entity rather than a
+  document.
 
 The same declaration also feeds context assembly. Each turn receives a
-`Declared Durable Outputs` block with the output name, document root
-reference, generated tool name, current content or recent journal tail,
-and any truncation markers. The model should use those generated tools
-instead of generic file tools; the document root owns path safety,
-indexing, provenance, and signature policy.
+`Declared Durable Outputs` block with the output name, destination
+reference, generated tool name, and the current state of the output:
+document content or a recent journal tail with truncation markers, or a
+structured target's slot contract and last published payload. The model
+should use those generated tools instead of generic file tools; the
+output's backend owns the write policy — path safety, indexing,
+provenance, and signature policy for documents; slot budgets and entity
+publishing for structured payloads.
+
+See [Defined Outputs](defined-outputs.md) for the full contract.
 
 ## Capability Tags
 

--- a/docs/understanding/defined-outputs.md
+++ b/docs/understanding/defined-outputs.md
@@ -1,0 +1,145 @@
+# Defined Outputs
+
+A loop that produces something durable declares it. The declaration is
+the contract: it names what the loop owns, generates the only tool the
+loop may write through, and puts the current state of that output into
+every iteration's context.
+
+```yaml
+outputs:
+  - name: metacognitive_state
+    type: maintained_document
+    ref: core:metacognitive.md
+  - name: watch_status
+    type: structured_payload
+    target: apple_watch.rectangular
+    ref: mqtt:watch_status
+```
+
+Those two entries generate `replace_output_metacognitive_state` and
+`set_output_watch_status`. Both are request-scoped — they exist only for
+that loop's runs, never in the global tool registry — so a loop's write
+surface is exactly as wide as what it declared.
+
+## Tiers
+
+Outputs come in tiers, chosen by who reads the result.
+
+| Type | Mode | Tool | For |
+|---|---|---|---|
+| `maintained_document` | `replace` | `replace_output_*` | A reader who wants the whole picture, rewritten each cycle |
+| `journal_document` | `append` | `append_output_*` | A reader who wants the history, appended to and never rewritten |
+| `structured_payload` | `set` | `set_output_*` | A *display* with fixed geometry and no room for prose |
+
+The document tiers write markdown into a managed document root, where
+path safety, indexing, provenance, and root policy already live. The
+structured tier writes named slot values to a rendering surface.
+
+## Structured payloads
+
+A display is not a document. An Apple Watch complication has four lines
+of perhaps twenty characters each, a gauge that wants a number between
+zero and one, and no capacity for a paragraph that got a little long. So
+the structured tier does not ask the model for text — it asks for slots.
+
+A `structured_payload` output names a **target**: an entry in the target
+registry (`internal/model/outputtargets`) describing one renderable
+surface. The target defines the slots, their types, their size budgets,
+and which slot is primary. That definition becomes three things at once:
+
+- the JSON schema the generated `set_output_*` tool advertises, so the
+  model sees `title (string, max 18 characters)` rather than a free-text
+  field;
+- the validator the handler runs, which **rejects** an over-budget or
+  malformed value with an error naming the slot and the limit;
+- the slot contract rendered into the loop's context each iteration,
+  alongside whatever was last published.
+
+Rejection is deliberate. A truncated string on a watch face is an
+unreadable fragment with no indication that anything was dropped, and a
+loop that never learns its budgets will overrun them forever. The only
+values the layer changes are surrounding whitespace and color hex casing.
+
+Every call replaces the whole payload. A slot the model omits is
+cleared, because the surface shows exactly the last payload — there is no
+partial-update form for a thing with no history.
+
+### Registered targets
+
+| Target | Surface |
+|---|---|
+| `apple_watch.rectangular` | The four-line `accessoryRectangular` complication: the large middle slot of the Modular Ultra face and the wide slot on Modular. Slots: `value`, `title`, `subtitle`, `bottom_text`, `fraction`, plus gauge/icon/text colors |
+| `apple_watch.circular` | The small round `accessoryCircular` complication: a gauge ring around a compact center. Slots: `value`, `title`, `fraction`, plus gauge/icon/text colors |
+
+Adding a target is adding a `Target` value to that package. Targets live
+in code rather than config so their budgets and validators are
+compile-checked and covered by tests; nothing in the loop layer, the tool
+generation path, or the sink changes when a new one lands.
+
+## Where the payload goes
+
+Structured payloads publish over MQTT as Home Assistant discovery
+sensors. The `ref` names the sink and the entity suffix:
+
+```yaml
+ref: mqtt:watch_status     # → sensor.<device_name>_watch_status
+```
+
+The primary slot becomes the sensor's **state**; every other slot becomes
+a **JSON attribute**. That split is what keeps the downstream binding
+trivial — the headline value needs no attribute lookup.
+
+MQTT must be configured. A loop that declares a structured payload
+without it fails hydration with a configuration error rather than
+starting up with a tool that could never publish.
+
+### Binding a watch complication
+
+With `sensor.thane_watch_status` published, the Home Assistant companion
+app on iOS renders it:
+
+1. Settings → Companion app → Apple Watch → Complications.
+2. Add a complication, choose the size matching your target
+   (Rectangular or Circular), and choose an **Entity** source pointing at
+   the sensor.
+3. Bind the slots: `{value}` reads the state, `{attr:title}`,
+   `{attr:subtitle}`, and `{attr:bottom_text}` read the attributes.
+4. For the gauge or progress bar, set minimum `0` and maximum `1` so it
+   consumes `{attr:fraction}` directly.
+
+An entity-sourced complication refreshes on the watch itself, so the
+readout stays current without the phone in range. It cannot template its
+colors, though — for those, use a template-sourced complication whose
+color fields read the same attributes:
+`{{ state_attr('sensor.thane_watch_status', 'gauge_color') }}`.
+
+Colors are best-effort by nature: watchOS renders on-face complications
+in the watch face's own accent palette, so expect full fidelity in the
+Smart Stack and a tinted approximation on the face itself. The gauge's
+*fill level* is the reliable signal there, not its hue.
+
+## What the loop sees
+
+Every iteration gets a **Declared Durable Outputs** context block. For a
+document output it carries the current body (truncated with an explicit
+marker when it exceeds the budget). For a structured payload it carries
+the target's full slot contract — names, kinds, budgets, descriptions —
+the entity ID, and the last payload this process published, with a
+freshness delta.
+
+The contract is repeated in full each iteration on purpose. The model is
+choosing values against fixed geometry, and a budget it cannot see is a
+budget it will overrun.
+
+When nothing has been published yet, the block says so explicitly and
+notes that the surface may still be showing a payload from before the
+last restart. The last-published record is in-process only; MQTT retains
+the payload on the broker, so a restarted Thane has a display it has not
+written to yet.
+
+## See also
+
+- [Document Roots](document-roots.md) — where document-tier outputs land
+- [The Agent Loop](agent-loop.md) — how loops run and self-pace
+- [Model-Facing Tools](../model-facing-tools.md) — why runtime-scoped
+  tools stay runtime-scoped

--- a/docs/understanding/document-roots.md
+++ b/docs/understanding/document-roots.md
@@ -269,6 +269,11 @@ runtime tools:
 - `append_output_<name>` for a journal document that should receive new
   entries over time.
 
+A loop can also declare outputs that are not documents at all — slotted
+payloads rendered by an external display, which publish as Home Assistant
+entities and never touch a root. See
+[Defined Outputs](defined-outputs.md).
+
 The loop sees a matching context block with the current document content
 or recent journal tail, so the document itself remains the durable source
 of truth. The generated tools still write through document roots. That

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -144,6 +144,12 @@ type App struct {
 	mqttInstanceID string
 	mqttSubStore   *mqtt.SubscriptionStore
 
+	// Structured loop outputs (slotted payloads published as HA
+	// entities). Built on first use because loop hydration can run
+	// before the MQTT wiring exists; see App.structuredOutputSink.
+	structuredOutputs     *mqttStructuredOutputSink
+	structuredOutputsOnce sync.Once
+
 	// Notifications
 	notifSender             *notifications.Sender
 	notifRecords            *notifications.RecordStore

--- a/internal/app/loop_output_structured.go
+++ b/internal/app/loop_output_structured.go
@@ -1,0 +1,174 @@
+package app
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/nugget/thane-ai-agent/internal/channels/mqtt"
+	"github.com/nugget/thane-ai-agent/internal/model/outputtargets"
+)
+
+// structuredOutputBinding is one loop-declared structured payload output
+// resolved to the entity it publishes to. It travels from spec hydration
+// into the generated tool handler so the handler needs no access to the
+// loop spec.
+type structuredOutputBinding struct {
+	// EntitySuffix is the ref's suffix: the MQTT topic segment and the
+	// tail of the Home Assistant object ID.
+	EntitySuffix string
+	// Label is the human-readable entity name, taken from the output
+	// declaration so an operator can tell two complications apart in
+	// the Home Assistant UI.
+	Label string
+	// Target is the resolved slot contract.
+	Target outputtargets.Target
+}
+
+// structuredOutputSnapshot records the most recent successful publish for
+// one binding.
+type structuredOutputSnapshot struct {
+	Payload outputtargets.Payload `json:"payload"`
+	At      time.Time             `json:"at"`
+}
+
+// structuredOutputSink publishes validated slot payloads to the surface
+// that renders them. It is an interface so the tool builder can be tested
+// without a broker, and so a second sink (a different transport, a
+// different rendering surface) can be added without touching the tool
+// generation path.
+type structuredOutputSink interface {
+	// Publish sends one complete payload, registering the entity if the
+	// sink has not seen it before.
+	Publish(ctx context.Context, binding structuredOutputBinding, payload outputtargets.Payload) error
+	// EntityID returns the identifier the payload lands on, for tool
+	// descriptions and model-facing context. It must be answerable
+	// before the first publish.
+	EntityID(entitySuffix string) string
+	// Last returns the most recent successful publish, if this process
+	// has made one.
+	Last(entitySuffix string) (structuredOutputSnapshot, bool)
+}
+
+// mqttStructuredOutputSink publishes payloads as Home Assistant MQTT
+// discovery sensors: the primary slot becomes the sensor state and the
+// remaining slots become its JSON attributes.
+//
+// The publisher is resolved on each call rather than captured at
+// construction because loop hydration can run before the MQTT server
+// wiring assigns App.mqttPub. A payload published before the broker
+// connection is up fails loudly — the alternative, silently buffering
+// it, would leave a complication showing stale data with nothing in the
+// logs to explain why.
+type mqttStructuredOutputSink struct {
+	app *App
+
+	mu   sync.Mutex
+	last map[string]structuredOutputSnapshot
+	// now is a clock seam for tests; nil uses time.Now.
+	now func() time.Time
+}
+
+// structuredOutputSink returns the process-wide sink, or nil when MQTT
+// is not configured. A nil return is what makes hydration reject a
+// structured payload declaration with a configuration error instead of
+// registering a tool that could never publish.
+func (a *App) structuredOutputSink() structuredOutputSink {
+	if a == nil || a.cfg == nil || !a.cfg.MQTT.Configured() {
+		return nil
+	}
+	a.structuredOutputsOnce.Do(func() {
+		a.structuredOutputs = &mqttStructuredOutputSink{
+			app:  a,
+			last: make(map[string]structuredOutputSnapshot),
+		}
+	})
+	return a.structuredOutputs
+}
+
+func (s *mqttStructuredOutputSink) clock() time.Time {
+	if s.now != nil {
+		return s.now()
+	}
+	return time.Now()
+}
+
+// EntityID derives the Home Assistant entity ID from the configured
+// device name, so it is answerable before the publisher exists and
+// before the first payload is sent.
+func (s *mqttStructuredOutputSink) EntityID(entitySuffix string) string {
+	if s == nil || s.app == nil || s.app.cfg == nil {
+		return ""
+	}
+	return "sensor." + mqtt.ObjectIDPrefix(s.app.cfg.MQTT.DeviceName) + entitySuffix
+}
+
+func (s *mqttStructuredOutputSink) Last(entitySuffix string) (structuredOutputSnapshot, bool) {
+	if s == nil {
+		return structuredOutputSnapshot{}, false
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	snapshot, ok := s.last[entitySuffix]
+	return snapshot, ok
+}
+
+func (s *mqttStructuredOutputSink) Publish(ctx context.Context, binding structuredOutputBinding, payload outputtargets.Payload) error {
+	if s == nil || s.app == nil {
+		return fmt.Errorf("structured output sink is not configured")
+	}
+	publisher := s.app.mqttPub
+	if publisher == nil {
+		return fmt.Errorf("MQTT publishing is not running yet, so %s cannot be updated; retry on a later iteration", s.EntityID(binding.EntitySuffix))
+	}
+
+	if err := publisher.EnsureSensor(ctx, s.sensorConfig(publisher, binding)); err != nil {
+		return fmt.Errorf("register %s with the MQTT broker: %w", s.EntityID(binding.EntitySuffix), err)
+	}
+
+	var attributes []byte
+	if len(payload.Attributes) > 0 {
+		encoded, err := json.Marshal(payload.Attributes)
+		if err != nil {
+			return fmt.Errorf("marshal structured output attributes: %w", err)
+		}
+		attributes = encoded
+	} else {
+		// An explicit empty object clears attributes left over from a
+		// previous richer payload. Sending nothing would retain them,
+		// and the tool contract promises omitted slots are cleared.
+		attributes = []byte("{}")
+	}
+
+	if err := publisher.PublishDynamicState(ctx, binding.EntitySuffix, payload.State, attributes); err != nil {
+		return fmt.Errorf("publish %s: %w", s.EntityID(binding.EntitySuffix), err)
+	}
+
+	s.mu.Lock()
+	s.last[binding.EntitySuffix] = structuredOutputSnapshot{Payload: payload, At: s.clock()}
+	s.mu.Unlock()
+	return nil
+}
+
+// sensorConfig builds the discovery payload for a binding. It is rebuilt
+// on every publish rather than cached because EnsureSensor replaces by
+// suffix, which keeps a renamed or retargeted output from stranding a
+// stale discovery config in Home Assistant.
+func (s *mqttStructuredOutputSink) sensorConfig(publisher *mqtt.Publisher, binding structuredOutputBinding) mqtt.DynamicSensor {
+	return mqtt.DynamicSensor{
+		EntitySuffix: binding.EntitySuffix,
+		Config: mqtt.SensorConfig{
+			Name:                binding.Label,
+			ObjectID:            publisher.ObjectIDPrefix() + binding.EntitySuffix,
+			HasEntityName:       true,
+			UniqueID:            s.app.mqttInstanceID + "_" + binding.EntitySuffix,
+			StateTopic:          publisher.StateTopic(binding.EntitySuffix),
+			JsonAttributesTopic: publisher.AttributesTopic(binding.EntitySuffix),
+			AvailabilityTopic:   publisher.AvailabilityTopic(),
+			Device:              publisher.Device(),
+			Icon:                binding.Target.Icon,
+		},
+	}
+}

--- a/internal/app/loop_output_structured_test.go
+++ b/internal/app/loop_output_structured_test.go
@@ -1,0 +1,280 @@
+package app
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nugget/thane-ai-agent/internal/model/outputtargets"
+	"github.com/nugget/thane-ai-agent/internal/platform/config"
+	looppkg "github.com/nugget/thane-ai-agent/internal/runtime/loop"
+)
+
+// fakeStructuredOutputSink records publishes instead of reaching a
+// broker, so the tool-generation path is testable without MQTT.
+type fakeStructuredOutputSink struct {
+	entityID  string
+	publishes []fakeStructuredPublish
+	last      map[string]structuredOutputSnapshot
+	err       error
+}
+
+type fakeStructuredPublish struct {
+	binding structuredOutputBinding
+	payload outputtargets.Payload
+}
+
+func (f *fakeStructuredOutputSink) Publish(_ context.Context, binding structuredOutputBinding, payload outputtargets.Payload) error {
+	if f.err != nil {
+		return f.err
+	}
+	f.publishes = append(f.publishes, fakeStructuredPublish{binding: binding, payload: payload})
+	if f.last == nil {
+		f.last = make(map[string]structuredOutputSnapshot)
+	}
+	f.last[binding.EntitySuffix] = structuredOutputSnapshot{
+		Payload: payload,
+		At:      time.Date(2026, 7, 26, 12, 0, 0, 0, time.UTC),
+	}
+	return nil
+}
+
+func (f *fakeStructuredOutputSink) EntityID(entitySuffix string) string {
+	if f.entityID != "" {
+		return f.entityID
+	}
+	return "sensor.thane_" + entitySuffix
+}
+
+func (f *fakeStructuredOutputSink) Last(entitySuffix string) (structuredOutputSnapshot, bool) {
+	snapshot, ok := f.last[entitySuffix]
+	return snapshot, ok
+}
+
+func structuredOutputSpec() looppkg.OutputSpec {
+	return looppkg.OutputSpec{
+		Name:    "watch_status",
+		Type:    looppkg.OutputTypeStructuredPayload,
+		Ref:     "mqtt:watch_status",
+		Target:  "apple_watch.rectangular",
+		Purpose: "Household status on the watch face.",
+	}
+}
+
+func TestBuildStructuredOutputToolAdvertisesTheSlotContract(t *testing.T) {
+	t.Parallel()
+
+	sink := &fakeStructuredOutputSink{}
+	tool, err := buildStructuredOutputTool(sink, structuredOutputSpec())
+	if err != nil {
+		t.Fatalf("buildStructuredOutputTool: %v", err)
+	}
+
+	if tool.Name != "set_output_watch_status" {
+		t.Fatalf("tool name = %q", tool.Name)
+	}
+	if !tool.SkipContentResolve {
+		t.Fatal("slot text must not be run through content resolution")
+	}
+	for _, want := range []string{"watch_status", "sensor.thane_watch_status", "Apple Watch rectangular"} {
+		if !strings.Contains(tool.Description, want) {
+			t.Errorf("description missing %q: %s", want, tool.Description)
+		}
+	}
+
+	properties, ok := tool.Parameters["properties"].(map[string]any)
+	if !ok {
+		t.Fatalf("parameters have no properties: %#v", tool.Parameters)
+	}
+	for _, slot := range []string{"value", "title", "subtitle", "bottom_text", "fraction", "gauge_color"} {
+		if _, present := properties[slot]; !present {
+			t.Errorf("schema is missing slot %q", slot)
+		}
+	}
+}
+
+func TestStructuredOutputToolPublishesNormalizedPayload(t *testing.T) {
+	t.Parallel()
+
+	sink := &fakeStructuredOutputSink{}
+	tool, err := buildStructuredOutputTool(sink, structuredOutputSpec())
+	if err != nil {
+		t.Fatalf("buildStructuredOutputTool: %v", err)
+	}
+
+	result, err := tool.Handler(context.Background(), map[string]any{
+		"value":       " 64% ",
+		"title":       "Battery",
+		"fraction":    0.64,
+		"gauge_color": "3fb950",
+	})
+	if err != nil {
+		t.Fatalf("handler: %v", err)
+	}
+
+	if len(sink.publishes) != 1 {
+		t.Fatalf("publishes = %d, want 1", len(sink.publishes))
+	}
+	published := sink.publishes[0]
+	if published.binding.EntitySuffix != "watch_status" {
+		t.Fatalf("entity suffix = %q", published.binding.EntitySuffix)
+	}
+	if published.binding.Label != "watch_status" {
+		t.Fatalf("label = %q", published.binding.Label)
+	}
+	if published.payload.State != "64%" {
+		t.Fatalf("state = %q, want trimmed %q", published.payload.State, "64%")
+	}
+	if published.payload.Attributes["gauge_color"] != "#3FB950" {
+		t.Fatalf("gauge_color = %v, want canonicalized", published.payload.Attributes["gauge_color"])
+	}
+
+	var decoded structuredOutputToolResult
+	if err := json.Unmarshal([]byte(result), &decoded); err != nil {
+		t.Fatalf("unmarshal result: %v", err)
+	}
+	if decoded.EntityID != "sensor.thane_watch_status" {
+		t.Fatalf("result entity_id = %q", decoded.EntityID)
+	}
+	if decoded.Target != "apple_watch.rectangular" {
+		t.Fatalf("result target = %q", decoded.Target)
+	}
+	if decoded.State != "64%" {
+		t.Fatalf("result state = %q", decoded.State)
+	}
+}
+
+func TestStructuredOutputToolRejectsBeforePublishing(t *testing.T) {
+	t.Parallel()
+
+	sink := &fakeStructuredOutputSink{}
+	tool, err := buildStructuredOutputTool(sink, structuredOutputSpec())
+	if err != nil {
+		t.Fatalf("buildStructuredOutputTool: %v", err)
+	}
+
+	tests := []struct {
+		name string
+		args map[string]any
+		want string
+	}{
+		{name: "missing required slot", args: map[string]any{"title": "Battery"}, want: `slot "value" is required`},
+		{name: "over budget", args: map[string]any{"value": "1234567890123"}, want: "at most 12"},
+		{name: "unknown slot", args: map[string]any{"value": "64%", "icon": "mdi:battery"}, want: "no slot named"},
+		{name: "fraction out of range", args: map[string]any{"value": "64%", "fraction": 64}, want: "between 0.0 and 1.0"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := tool.Handler(context.Background(), tt.args); err == nil {
+				t.Fatal("expected an error")
+			} else if !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("error = %v, want it to contain %q", err, tt.want)
+			}
+		})
+	}
+
+	if len(sink.publishes) != 0 {
+		t.Fatalf("a rejected payload reached the sink: %d publishes", len(sink.publishes))
+	}
+}
+
+func TestStructuredOutputToolSurfacesSinkFailure(t *testing.T) {
+	t.Parallel()
+
+	sink := &fakeStructuredOutputSink{err: fmt.Errorf("broker unreachable")}
+	tool, err := buildStructuredOutputTool(sink, structuredOutputSpec())
+	if err != nil {
+		t.Fatalf("buildStructuredOutputTool: %v", err)
+	}
+	if _, err := tool.Handler(context.Background(), map[string]any{"value": "64%"}); err == nil {
+		t.Fatal("expected the sink failure to reach the model")
+	} else if !strings.Contains(err.Error(), "broker unreachable") {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestBuildStructuredOutputToolRequiresSinkAndTarget(t *testing.T) {
+	t.Parallel()
+
+	if _, err := buildStructuredOutputTool(nil, structuredOutputSpec()); err == nil {
+		t.Fatal("expected an error without a sink")
+	}
+
+	unknown := structuredOutputSpec()
+	unknown.Target = "apple_watch.trapezoid"
+	_, err := buildStructuredOutputTool(&fakeStructuredOutputSink{}, unknown)
+	if err == nil {
+		t.Fatal("expected an error for an unknown target")
+	}
+	if !strings.Contains(err.Error(), "registered targets are") {
+		t.Fatalf("error should enumerate the valid targets: %v", err)
+	}
+}
+
+func TestHydrateLoopOutputsRequiresMQTTForStructuredPayloads(t *testing.T) {
+	t.Parallel()
+
+	app := &App{cfg: &config.Config{}}
+	spec := looppkg.Spec{
+		Name:       "watchface",
+		Enabled:    true,
+		Task:       "Drive the watch face.",
+		Operation:  looppkg.OperationService,
+		Completion: looppkg.CompletionNone,
+		Outputs:    []looppkg.OutputSpec{structuredOutputSpec()},
+	}
+
+	_, err := app.hydrateLoopOutputs(spec)
+	if err == nil {
+		t.Fatal("expected hydration to fail without MQTT configured")
+	}
+	if !strings.Contains(err.Error(), "MQTT publishing is not configured") {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestStructuredOutputContextTeachesTheContract(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 26, 14, 0, 0, 0, time.UTC)
+	sink := &fakeStructuredOutputSink{}
+	output := structuredOutputSpec()
+
+	rendered, err := renderLoopOutputContextWithNow(context.Background(), nil, sink, []looppkg.OutputSpec{output}, now)
+	if err != nil {
+		t.Fatalf("renderLoopOutputContextWithNow: %v", err)
+	}
+	for _, want := range []string{
+		`"tool_name": "set_output_watch_status"`,
+		`"id": "apple_watch.rectangular"`,
+		`"entity_id": "sensor.thane_watch_status"`,
+		`"max_runes": 12`,
+		"nothing published from this process yet",
+	} {
+		if !strings.Contains(rendered, want) {
+			t.Errorf("context missing %q:\n%s", want, rendered)
+		}
+	}
+
+	// After a publish the context should show what landed and how long
+	// ago, so the next iteration can decide whether to rewrite.
+	if err := sink.Publish(context.Background(), structuredOutputBinding{EntitySuffix: "watch_status"}, outputtargets.Payload{
+		State:      "64%",
+		Attributes: map[string]any{"title": "Battery"},
+	}); err != nil {
+		t.Fatalf("seed publish: %v", err)
+	}
+
+	rendered, err = renderLoopOutputContextWithNow(context.Background(), nil, sink, []looppkg.OutputSpec{output}, now)
+	if err != nil {
+		t.Fatalf("renderLoopOutputContextWithNow: %v", err)
+	}
+	for _, want := range []string{`"state": "64%"`, `"last_published_delta": "-2h"`} {
+		if !strings.Contains(rendered, want) {
+			t.Errorf("context missing %q:\n%s", want, rendered)
+		}
+	}
+}

--- a/internal/app/loop_outputs.go
+++ b/internal/app/loop_outputs.go
@@ -10,6 +10,7 @@ import (
 	"time"
 	"unicode/utf8"
 
+	"github.com/nugget/thane-ai-agent/internal/model/outputtargets"
 	"github.com/nugget/thane-ai-agent/internal/model/promptfmt"
 	"github.com/nugget/thane-ai-agent/internal/platform/database"
 	looppkg "github.com/nugget/thane-ai-agent/internal/runtime/loop"
@@ -44,6 +45,25 @@ type loopOutputContextEntry struct {
 	BytesTotal       int                `json:"bytes_total,omitempty"`
 	UnavailableError string             `json:"unavailable_error,omitempty"`
 	Journal          *loopOutputJournal `json:"journal,omitempty"`
+	// Target carries the slot contract for structured payload outputs
+	// and is absent for document outputs.
+	Target *loopOutputTargetContext `json:"target,omitempty"`
+}
+
+// loopOutputTargetContext is the model-facing view of a structured
+// payload output: what surface it renders on, which slots exist with
+// what budgets, where the payload lands, and what was last sent.
+type loopOutputTargetContext struct {
+	ID                 string                 `json:"id"`
+	Title              string                 `json:"title,omitempty"`
+	Summary            string                 `json:"summary,omitempty"`
+	Binding            string                 `json:"binding,omitempty"`
+	EntityID           string                 `json:"entity_id,omitempty"`
+	Slots              []outputtargets.Slot   `json:"slots,omitempty"`
+	LastPublished      *outputtargets.Payload `json:"last_published,omitempty"`
+	LastPublishedDelta string                 `json:"last_published_delta,omitempty"`
+	LastPublishedNote  string                 `json:"last_published_note,omitempty"`
+	Unavailable        string                 `json:"unavailable,omitempty"`
 }
 
 type loopOutputJournal struct {
@@ -59,25 +79,55 @@ type loopOutputJournal struct {
 // every spec the registry produces.
 func (a *App) hydrateLoopOutputs(spec looppkg.Spec) (looppkg.Spec, error) {
 	if len(spec.Outputs) > 0 {
-		if a == nil || a.documentStore == nil {
-			return looppkg.Spec{}, fmt.Errorf("loop %q declares outputs but managed document roots are not configured", spec.Name)
-		}
 		outputs := cloneLoopOutputs(spec.Outputs)
-		spec.RuntimeTools = append(spec.RuntimeTools, buildLoopOutputTools(a.documentStore, outputs)...)
+
+		// Each output tier needs its own backend. Check only the tiers
+		// this spec actually declares, so a loop publishing a watch
+		// complication does not require document roots and vice versa.
+		var sink structuredOutputSink
+		for _, output := range outputs {
+			switch output.Type {
+			case looppkg.OutputTypeStructuredPayload:
+				if sink = a.structuredOutputSink(); sink == nil {
+					return looppkg.Spec{}, fmt.Errorf("loop %q declares structured payload output %q but MQTT publishing is not configured; structured outputs render through Home Assistant entities", spec.Name, output.Name)
+				}
+			default:
+				if a == nil || a.documentStore == nil {
+					return looppkg.Spec{}, fmt.Errorf("loop %q declares outputs but managed document roots are not configured", spec.Name)
+				}
+			}
+		}
+
+		runtimeTools, err := buildLoopOutputTools(a.documentStore, sink, outputs)
+		if err != nil {
+			return looppkg.Spec{}, fmt.Errorf("loop %q: %w", spec.Name, err)
+		}
+		spec.RuntimeTools = append(spec.RuntimeTools, runtimeTools...)
 		spec.OutputContextBuilder = func(ctx context.Context, _ []looppkg.OutputSpec) (string, error) {
-			return renderLoopOutputContextWithNow(ctx, a.documentStore, outputs, time.Now())
+			return renderLoopOutputContextWithNow(ctx, a.documentStore, sink, outputs, time.Now())
 		}
 	}
 	return a.hydrateLoopFocusTools(spec)
 }
 
-func buildLoopOutputTools(store *documents.Store, outputs []looppkg.OutputSpec) []looppkg.RuntimeTool {
-	if store == nil || len(outputs) == 0 {
-		return nil
+func buildLoopOutputTools(store *documents.Store, sink structuredOutputSink, outputs []looppkg.OutputSpec) ([]looppkg.RuntimeTool, error) {
+	if len(outputs) == 0 {
+		return nil, nil
 	}
 	out := make([]looppkg.RuntimeTool, 0, len(outputs))
 	for _, output := range outputs {
 		output := output
+		if output.EffectiveMode() == looppkg.OutputModeSet {
+			tool, err := buildStructuredOutputTool(sink, output)
+			if err != nil {
+				return nil, err
+			}
+			out = append(out, tool)
+			continue
+		}
+		if store == nil {
+			return nil, fmt.Errorf("output %q requires a document store", output.Name)
+		}
 		switch output.EffectiveMode() {
 		case looppkg.OutputModeReplace:
 			out = append(out, looppkg.RuntimeTool{
@@ -149,11 +199,86 @@ func buildLoopOutputTools(store *documents.Store, outputs []looppkg.OutputSpec) 
 			})
 		}
 	}
-	return out
+	return out, nil
 }
 
-func renderLoopOutputContextWithNow(ctx context.Context, store *documents.Store, outputs []looppkg.OutputSpec, now time.Time) (string, error) {
-	if store == nil || len(outputs) == 0 {
+// buildStructuredOutputTool generates the request-scoped tool for one
+// structured payload declaration. The tool's parameter schema is the
+// target's slot contract, so the model is taught the exact slots, types,
+// and size budgets of the surface it is filling instead of being handed a
+// free-text field and left to guess what fits.
+func buildStructuredOutputTool(sink structuredOutputSink, output looppkg.OutputSpec) (looppkg.RuntimeTool, error) {
+	if sink == nil {
+		return looppkg.RuntimeTool{}, fmt.Errorf("output %q requires a structured output sink", output.Name)
+	}
+	binding, err := structuredOutputBindingFor(output)
+	if err != nil {
+		return looppkg.RuntimeTool{}, err
+	}
+	entityID := sink.EntityID(binding.EntitySuffix)
+
+	return looppkg.RuntimeTool{
+		Name:        output.ToolName(),
+		Description: binding.Target.ToolDescription(output.Name, entityID),
+		// Slot values are literal display text: a value that happens to
+		// look like a document ref must reach the watch face as typed,
+		// not as the content it resembles.
+		SkipContentResolve: true,
+		Parameters:         binding.Target.Schema(),
+		Handler: func(ctx context.Context, args map[string]any) (string, error) {
+			payload, err := binding.Target.Normalize(args)
+			if err != nil {
+				return "", err
+			}
+			if err := sink.Publish(ctx, binding, payload); err != nil {
+				return "", err
+			}
+			return marshalLoopOutputToolResult(structuredOutputToolResult{
+				Output:     output.Name,
+				Target:     binding.Target.ID,
+				EntityID:   entityID,
+				State:      payload.State,
+				Attributes: payload.Attributes,
+			})
+		},
+	}, nil
+}
+
+// structuredOutputToolResult is what the model sees after a successful
+// publish: the entity it can now bind to, plus the exact payload that
+// landed, so a later iteration can diff against it without a read tool.
+type structuredOutputToolResult struct {
+	Output     string         `json:"output"`
+	Target     string         `json:"target"`
+	EntityID   string         `json:"entity_id"`
+	State      string         `json:"state"`
+	Attributes map[string]any `json:"attributes,omitempty"`
+}
+
+// structuredOutputBindingFor resolves a declaration into the binding its
+// handler publishes with. [looppkg.OutputSpec.Validate] already enforces
+// both halves, so a failure here means a spec persisted before the
+// current validation rules — worth an explicit error rather than a loop
+// that starts with a silently missing output tool.
+func structuredOutputBindingFor(output looppkg.OutputSpec) (structuredOutputBinding, error) {
+	target, ok := outputtargets.Lookup(output.Target)
+	if !ok {
+		return structuredOutputBinding{}, fmt.Errorf("output %q names unknown target %q; registered targets are %s", output.Name, output.Target, strings.Join(outputtargets.IDs(), ", "))
+	}
+	_, suffix, found := strings.Cut(output.Ref, ":")
+	suffix = strings.TrimSpace(suffix)
+	if !found || suffix == "" {
+		return structuredOutputBinding{}, fmt.Errorf("output %q has ref %q; structured payload outputs need a ref of the form mqtt:<entity_suffix>", output.Name, output.Ref)
+	}
+	return structuredOutputBinding{
+		EntitySuffix: suffix,
+		Label:        output.Name,
+		Target:       target,
+	}, nil
+}
+
+func renderLoopOutputContextWithNow(ctx context.Context, store *documents.Store, sink structuredOutputSink, outputs []looppkg.OutputSpec, now time.Time) (string, error) {
+	if len(outputs) == 0 {
 		return "", nil
 	}
 	if now.IsZero() {
@@ -170,6 +295,17 @@ func renderLoopOutputContextWithNow(ctx context.Context, store *documents.Store,
 			ToolName:  output.ToolName(),
 			Policy:    "Write only through the generated output tool. The managed document root handles path safety, indexing, provenance, and signature policy.",
 			Interface: outputInterfaceDescription(output),
+		}
+		if output.Type == looppkg.OutputTypeStructuredPayload {
+			entry.Policy = "Write only through the generated output tool. Every call replaces the whole payload — omitted slots are cleared — and slot budgets are enforced, not truncated."
+			entry.Target = structuredOutputTargetContext(output, sink, now)
+			payload.Outputs = append(payload.Outputs, entry)
+			continue
+		}
+		if store == nil {
+			entry.UnavailableError = "managed document roots are not configured"
+			payload.Outputs = append(payload.Outputs, entry)
+			continue
 		}
 		if output.Type == looppkg.OutputTypeJournalDocument {
 			entry.Journal = &loopOutputJournal{
@@ -203,7 +339,46 @@ func renderLoopOutputContextWithNow(ctx context.Context, store *documents.Store,
 	if err != nil {
 		return "", fmt.Errorf("marshal loop output context: %w", err)
 	}
-	return "## Declared Durable Outputs\n\nThese are this loop's official durable document outputs. Use the generated output tools below instead of generic file tools; write policy belongs to the document root, not to the prompt.\n\n```json\n" + string(data) + "\n```", nil
+	return "## Declared Durable Outputs\n\nThese are this loop's official durable outputs — documents it maintains and rendered surfaces it drives. Use the generated output tools below instead of generic file tools; write policy belongs to the output's backend, not to the prompt.\n\n```json\n" + string(data) + "\n```", nil
+}
+
+// structuredOutputTargetContext renders the slot contract for a
+// structured payload output, plus whatever this process last published to
+// it. The contract is included in full on every iteration: the model is
+// choosing values against fixed geometry, and a budget it cannot see is a
+// budget it will overrun.
+func structuredOutputTargetContext(output looppkg.OutputSpec, sink structuredOutputSink, now time.Time) *loopOutputTargetContext {
+	target, ok := outputtargets.Lookup(output.Target)
+	if !ok {
+		return &loopOutputTargetContext{ID: output.Target, Unavailable: "target is not registered in this build"}
+	}
+	entry := &loopOutputTargetContext{
+		ID:      target.ID,
+		Title:   target.Title,
+		Summary: target.Summary,
+		Binding: target.Binding,
+		Slots:   target.Slots,
+	}
+	if sink == nil {
+		entry.Unavailable = "no structured output sink is configured"
+		return entry
+	}
+	binding, err := structuredOutputBindingFor(output)
+	if err != nil {
+		entry.Unavailable = err.Error()
+		return entry
+	}
+	entry.EntityID = sink.EntityID(binding.EntitySuffix)
+	if snapshot, published := sink.Last(binding.EntitySuffix); published {
+		entry.LastPublished = &snapshot.Payload
+		entry.LastPublishedDelta = promptfmt.FormatDeltaOnly(snapshot.At, now)
+	} else {
+		// Absence is ambiguous — never published, or published before a
+		// restart cleared the in-process record — and the difference
+		// changes whether re-publishing is redundant. Say which.
+		entry.LastPublishedNote = "nothing published from this process yet; the surface may still be showing a payload from before the last restart"
+	}
+	return entry
 }
 
 func loopOutputUpdatedDelta(doc *documents.DocumentRecord, now time.Time) string {
@@ -237,6 +412,8 @@ func outputInterfaceDescription(output looppkg.OutputSpec) string {
 		return "Call " + output.ToolName() + " with complete replacement markdown content for this maintained document."
 	case looppkg.OutputModeAppend:
 		return "Call " + output.ToolName() + " with one new journal entry; do not rewrite old entries."
+	case looppkg.OutputModeSet:
+		return "Call " + output.ToolName() + " with the complete slot set for this surface; omitted slots are cleared, not preserved."
 	default:
 		return "Use the generated output tool for this declaration."
 	}

--- a/internal/app/loop_outputs_test.go
+++ b/internal/app/loop_outputs_test.go
@@ -124,7 +124,7 @@ Everything is calm.
 		t.Fatalf("write metacognitive.md: %v", err)
 	}
 
-	ctx, err := renderLoopOutputContextWithNow(context.Background(), store, []looppkg.OutputSpec{
+	ctx, err := renderLoopOutputContextWithNow(context.Background(), store, nil, []looppkg.OutputSpec{
 		{
 			Name:    "metacognitive_state",
 			Type:    looppkg.OutputTypeMaintainedDocument,

--- a/internal/channels/mqtt/publisher.go
+++ b/internal/channels/mqtt/publisher.go
@@ -135,6 +135,45 @@ func (p *Publisher) RegisterSensors(sensors []DynamicSensor) {
 	p.dynamicSensors = append(p.dynamicSensors, sensors...)
 }
 
+// EnsureSensor registers one dynamic sensor and publishes its discovery
+// config immediately, so an entity created after [Publisher.Start] shows
+// up in Home Assistant without waiting for the next reconnect. This is
+// the runtime counterpart to [Publisher.RegisterSensors], which only
+// takes effect at connect time.
+//
+// Re-registering an existing EntitySuffix replaces that definition
+// instead of appending a duplicate, so callers that cannot cheaply track
+// whether they have registered yet may call this before every publish.
+// It returns an error when the broker connection is not up; the
+// registration is still recorded and will be published on the next
+// reconnect.
+func (p *Publisher) EnsureSensor(ctx context.Context, sensor DynamicSensor) error {
+	if strings.TrimSpace(sensor.EntitySuffix) == "" {
+		return fmt.Errorf("mqtt: sensor entity suffix is required")
+	}
+
+	p.mu.Lock()
+	replaced := false
+	for i := range p.dynamicSensors {
+		if p.dynamicSensors[i].EntitySuffix == sensor.EntitySuffix {
+			p.dynamicSensors[i] = sensor
+			replaced = true
+			break
+		}
+	}
+	if !replaced {
+		p.dynamicSensors = append(p.dynamicSensors, sensor)
+	}
+	p.mu.Unlock()
+
+	cm := p.getCM()
+	if cm == nil {
+		return fmt.Errorf("mqtt publisher not connected")
+	}
+	p.publishSensorDiscovery(ctx, cm, sensor.EntitySuffix, sensor.Config)
+	return nil
+}
+
 // Device returns the HA device info shared across all sensors published
 // by this publisher instance. Useful for callers building [DynamicSensor]
 // configs that reference the same HA device.
@@ -381,7 +420,16 @@ func (p *Publisher) setCM(cm *autopaho.ConnectionManager) {
 // so this prefix ensures entities like sensor.aimee_thane_uptime
 // instead of sensor.uptime.
 func (p *Publisher) ObjectIDPrefix() string {
-	return strings.ReplaceAll(p.cfg.DeviceName, "-", "_") + "_"
+	return ObjectIDPrefix(p.cfg.DeviceName)
+}
+
+// ObjectIDPrefix returns the Home Assistant object ID prefix for a device
+// name. It is exported alongside the [Publisher] method so callers that
+// need to predict an entity ID before a publisher exists — for example
+// while describing a not-yet-published entity to a model — derive it from
+// the same rule instead of reimplementing the transformation.
+func ObjectIDPrefix(deviceName string) string {
+	return strings.ReplaceAll(deviceName, "-", "_") + "_"
 }
 
 // --- Topic helpers ---

--- a/internal/model/outputtargets/apple_watch.go
+++ b/internal/model/outputtargets/apple_watch.go
@@ -1,0 +1,118 @@
+package outputtargets
+
+// Apple Watch complication targets.
+//
+// Slot names mirror the companion app's own vocabulary (title, subtitle,
+// value, bottom_text) so an operator wiring the complication editor sees
+// the same words in both places. The rune budgets are deliberately
+// tighter than what the widget will technically accept: watchOS shrinks
+// and then truncates overflowing text, and the accessoryRectangular slot
+// on the Modular Ultra face clips earlier than on other faces, so a
+// budget that fits everywhere beats one that fits the roomiest face.
+//
+// Colors are published as ordinary attributes because an entity-sourced
+// complication cannot template its colors — only a template-sourced one
+// can. Both bindings read the same entity, so the operator picks the
+// tier they want without Thane publishing anything differently.
+
+const appleWatchColorNote = "Ignored unless the complication is template-sourced and reads this attribute in its color template. watchOS also renders on-face complications in the face's accent palette, so expect full fidelity in the Smart Stack and a tinted approximation on the watch face itself."
+
+var appleWatchRectangular = Target{
+	ID:      "apple_watch.rectangular",
+	Title:   "Apple Watch rectangular complication",
+	Summary: "The four-line accessoryRectangular complication: the large middle slot of the Modular Ultra face, and the wide slot on Modular and Infograph Modular. Renders an icon, a title line, a subtitle line, a value (as a progress-bar thumb when a fraction is set), and a bottom line. Nothing wraps — every line is one line, shrunk to fit and then clipped.",
+	Binding: "Published as an MQTT sensor. In the companion app's complication builder choose the Rectangular size and an Entity source pointing at this sensor, then bind slots with {value} for the state and {attr:title} / {attr:subtitle} / {attr:bottom_text} for the rest. Set the progress bar's minimum to 0 and maximum to 1 to consume {attr:fraction}.",
+	Icon:    "mdi:watch-variant",
+	Slots: []Slot{
+		{
+			Name:        "value",
+			Kind:        SlotKindText,
+			Description: "The headline value and the sensor's state. Renders as the label inside the progress-bar thumb when a fraction is set, otherwise as its own line. Keep it to a number and a unit — this is the shortest slot on the target.",
+			Required:    true,
+			MaxRunes:    12,
+			Primary:     true,
+		},
+		{
+			Name:        "title",
+			Kind:        SlotKindText,
+			Description: "First line, semibold. What this complication is about — a name or label, not a sentence.",
+			MaxRunes:    18,
+		},
+		{
+			Name:        "subtitle",
+			Kind:        SlotKindText,
+			Description: "Second line, dimmed. Secondary context for the title: a qualifier, a comparison, or a second reading.",
+			MaxRunes:    22,
+		},
+		{
+			Name:        "bottom_text",
+			Kind:        SlotKindText,
+			Description: "Last line, dimmed. Trailing detail such as a freshness note or a next-event hint. Hidden by default in the complication editor; the operator opts in.",
+			MaxRunes:    22,
+		},
+		{
+			Name:        "fraction",
+			Kind:        SlotKindFraction,
+			Description: "Progress-bar fill from 0.0 (empty) to 1.0 (full). Normalize the underlying reading yourself — the bar has no notion of your units. Omit when there is nothing meaningful to fill.",
+		},
+		{
+			Name:        "gauge_color",
+			Kind:        SlotKindColor,
+			Description: "Progress-bar tint as #RRGGBB. " + appleWatchColorNote,
+		},
+		{
+			Name:        "icon_color",
+			Kind:        SlotKindColor,
+			Description: "Icon tint as #RRGGBB. " + appleWatchColorNote,
+		},
+		{
+			Name:        "text_color",
+			Kind:        SlotKindColor,
+			Description: "Text tint as #RRGGBB. " + appleWatchColorNote,
+		},
+	},
+}
+
+var appleWatchCircular = Target{
+	ID:      "apple_watch.circular",
+	Title:   "Apple Watch circular complication",
+	Summary: "The small round accessoryCircular complication: a gauge ring around a center that holds an icon, a value, and optionally a name. It is the smallest target here — assume roughly a half-dozen characters are legible, and that the ring carries more information than the text does.",
+	Binding: "Published as an MQTT sensor. In the companion app's complication builder choose the Circular size and an Entity source pointing at this sensor, then bind {value} for the state and {attr:title} for the name slot. Set the gauge's minimum to 0 and maximum to 1 to consume {attr:fraction}, and pick the open-arc or capacity-ring style there.",
+	Icon:    "mdi:watch-variant",
+	Slots: []Slot{
+		{
+			Name:        "value",
+			Kind:        SlotKindText,
+			Description: "The center value and the sensor's state. This is a glanceable scalar: a number, a percentage, a two-letter status. Long strings shrink until they are unreadable rather than wrapping.",
+			Required:    true,
+			MaxRunes:    6,
+			Primary:     true,
+		},
+		{
+			Name:        "title",
+			Kind:        SlotKindText,
+			Description: "Optional name under the value. Hidden by default on circular because the center is small — supply it only when the value alone is ambiguous, and keep it to one short word.",
+			MaxRunes:    8,
+		},
+		{
+			Name:        "fraction",
+			Kind:        SlotKindFraction,
+			Description: "Gauge ring fill from 0.0 (empty) to 1.0 (full). On this target the ring is the primary signal; prefer setting it whenever the value is numeric.",
+		},
+		{
+			Name:        "gauge_color",
+			Kind:        SlotKindColor,
+			Description: "Gauge ring tint as #RRGGBB. " + appleWatchColorNote,
+		},
+		{
+			Name:        "icon_color",
+			Kind:        SlotKindColor,
+			Description: "Icon tint as #RRGGBB. " + appleWatchColorNote,
+		},
+		{
+			Name:        "text_color",
+			Kind:        SlotKindColor,
+			Description: "Value text tint as #RRGGBB. " + appleWatchColorNote,
+		},
+	},
+}

--- a/internal/model/outputtargets/doc.go
+++ b/internal/model/outputtargets/doc.go
@@ -1,0 +1,38 @@
+// Package outputtargets defines the slotted rendering targets a loop may
+// declare as a structured output.
+//
+// A structured output is the non-document tier of the loop output
+// contract in [github.com/nugget/thane-ai-agent/internal/runtime/loop]. A
+// maintained document asks the model for prose; a structured output asks
+// it for a small set of named, budgeted values that a specific external
+// surface renders. The surface — an Apple Watch complication, a compact
+// display, a status tile — has fixed geometry, so the contract is fixed
+// too: named slots, one primary slot, per-slot type and size limits.
+//
+// # Why a registry
+//
+// Targets live in code rather than operator config so the budgets and
+// validators that make a target real are compile-checked and testable.
+// Adding a tier is adding a [Target] value to the registry in this
+// package; nothing downstream changes. The loop layer validates a
+// declared target ID against [Lookup], the app layer turns [Target.Schema]
+// into a request-scoped tool and [Target.Normalize] into that tool's
+// handler, and the sink publishes the resulting [Payload].
+//
+// # Slots and the primary slot
+//
+// Every target has exactly one slot marked primary. The primary slot's
+// value becomes the [Payload] state — the single scalar a consuming
+// surface reads first (for the MQTT sink, the sensor's state). Remaining
+// slots become payload attributes. This split is what lets a downstream
+// binding stay trivial: the headline value needs no attribute lookup.
+//
+// # Validation teaches
+//
+// [Target.Normalize] rejects rather than repairs. A slot over its rune
+// budget, a fraction outside [0,1], or an unparseable color returns an
+// error naming the slot, the limit, and what arrived, so a delegate can
+// fix it in one more call instead of guessing. The exception is
+// whitespace trimming and color-hex casing, which are canonicalization
+// rather than a change of meaning.
+package outputtargets

--- a/internal/model/outputtargets/example_test.go
+++ b/internal/model/outputtargets/example_test.go
@@ -1,0 +1,54 @@
+package outputtargets_test
+
+import (
+	"fmt"
+
+	"github.com/nugget/thane-ai-agent/internal/model/outputtargets"
+)
+
+// The primary usage pattern: resolve a declared target, validate the
+// model's slot values against it, and publish the resulting payload.
+func ExampleTarget_Normalize() {
+	target, ok := outputtargets.Lookup("apple_watch.circular")
+	if !ok {
+		return
+	}
+
+	payload, err := target.Normalize(map[string]any{
+		"value":       "64%",
+		"fraction":    0.64,
+		"gauge_color": "3fb950",
+	})
+	if err != nil {
+		fmt.Println("rejected:", err)
+		return
+	}
+
+	fmt.Println("state:", payload.State)
+	fmt.Println("fraction:", payload.Attributes["fraction"])
+	fmt.Println("gauge_color:", payload.Attributes["gauge_color"])
+	// Output:
+	// state: 64%
+	// fraction: 0.64
+	// gauge_color: #3FB950
+}
+
+// An over-budget value is rejected with an error a delegate can act on
+// in one more call, rather than truncated into something unreadable.
+func ExampleTarget_Normalize_overBudget() {
+	target, _ := outputtargets.Lookup("apple_watch.circular")
+	if _, err := target.Normalize(map[string]any{"value": "1013 hPa"}); err != nil {
+		fmt.Println(err)
+	}
+	// Output:
+	// slot "value": is 8 characters but this slot renders at most 6; shorten it rather than relying on truncation (got "1013 hPa")
+}
+
+func ExampleIDs() {
+	for _, id := range outputtargets.IDs() {
+		fmt.Println(id)
+	}
+	// Output:
+	// apple_watch.circular
+	// apple_watch.rectangular
+}

--- a/internal/model/outputtargets/normalize.go
+++ b/internal/model/outputtargets/normalize.go
@@ -1,0 +1,220 @@
+package outputtargets
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+)
+
+// Payload is a validated slot set ready for a sink to publish.
+type Payload struct {
+	// State is the primary slot's value: the single scalar the
+	// consuming surface reads without an attribute lookup.
+	State string `json:"state"`
+	// Attributes holds every other supplied slot, keyed by slot name.
+	// Text and color slots carry strings; fraction slots carry float64.
+	Attributes map[string]any `json:"attributes,omitempty"`
+}
+
+// Normalize validates raw tool arguments against the target's slots and
+// returns the payload to publish.
+//
+// It rejects rather than repairs: an unknown key, a missing required
+// slot, an over-budget string, an out-of-range fraction, or a malformed
+// color each return an error naming the slot and the constraint. The only
+// values it changes are surrounding whitespace (trimmed) and color hex
+// casing (upper, with a leading "#"), neither of which changes meaning.
+//
+// Omitting an optional slot is how a caller clears it — Normalize does
+// not carry values forward from a previous payload, because the tool
+// contract is a full replacement.
+func (t Target) Normalize(args map[string]any) (Payload, error) {
+	if err := t.rejectUnknownSlots(args); err != nil {
+		return Payload{}, err
+	}
+
+	payload := Payload{Attributes: make(map[string]any, len(t.Slots))}
+	for _, slot := range t.Slots {
+		raw, present := args[slot.Name]
+		// An explicit JSON null is how some model families spell "leave
+		// this one out"; treat it as absence rather than a type error.
+		if raw == nil {
+			present = false
+		}
+		if !present {
+			if slot.Required {
+				return Payload{}, fmt.Errorf("slot %q is required for target %q but was not supplied; %s", slot.Name, t.ID, slot.Description)
+			}
+			continue
+		}
+
+		// Each kind is handled in its own branch rather than through a
+		// common any-returning helper: only text slots can be primary
+		// or blank-and-therefore-cleared, and routing every kind through
+		// one signature would mean type-asserting that back out.
+		switch slot.Kind {
+		case SlotKindText:
+			text, err := slot.normalizeText(raw)
+			if err != nil {
+				return Payload{}, fmt.Errorf("slot %q: %w", slot.Name, err)
+			}
+			if text == "" {
+				if slot.Required {
+					return Payload{}, fmt.Errorf("slot %q is required for target %q but was empty after trimming whitespace", slot.Name, t.ID)
+				}
+				// An optional slot explicitly set to blank means "clear
+				// it", which is the same as omitting it.
+				continue
+			}
+			if slot.Primary {
+				payload.State = text
+				continue
+			}
+			payload.Attributes[slot.Name] = text
+		case SlotKindFraction:
+			fraction, err := slot.normalizeFraction(raw)
+			if err != nil {
+				return Payload{}, fmt.Errorf("slot %q: %w", slot.Name, err)
+			}
+			payload.Attributes[slot.Name] = fraction
+		case SlotKindColor:
+			color, err := slot.normalizeColor(raw)
+			if err != nil {
+				return Payload{}, fmt.Errorf("slot %q: %w", slot.Name, err)
+			}
+			payload.Attributes[slot.Name] = color
+		default:
+			return Payload{}, fmt.Errorf("slot %q: unsupported slot kind %q", slot.Name, slot.Kind)
+		}
+	}
+
+	if payload.State == "" {
+		// Unreachable for a registered target (validate guarantees a
+		// required primary slot, and the required check above fires
+		// first), but a sink publishing an empty state would produce an
+		// entity HA renders as "unknown" — fail here instead.
+		return Payload{}, fmt.Errorf("target %q produced no state value", t.ID)
+	}
+	if len(payload.Attributes) == 0 {
+		payload.Attributes = nil
+	}
+	return payload, nil
+}
+
+// rejectUnknownSlots fails on any argument key the target does not
+// define, listing the valid slots. A silently dropped key looks to the
+// model like a slot that renders nothing.
+func (t Target) rejectUnknownSlots(args map[string]any) error {
+	var unknown []string
+	for key := range args {
+		if _, ok := t.Slot(key); !ok {
+			unknown = append(unknown, key)
+		}
+	}
+	if len(unknown) == 0 {
+		return nil
+	}
+	sort.Strings(unknown)
+	return fmt.Errorf(
+		"target %q has no slot named %s; valid slots are %s",
+		t.ID, strings.Join(quoteAll(unknown), ", "), strings.Join(quoteAll(t.SlotNames()), ", "),
+	)
+}
+
+// normalizeText trims and length-checks a text slot value.
+func (s Slot) normalizeText(raw any) (string, error) {
+	text, ok := raw.(string)
+	if !ok {
+		return "", fmt.Errorf("expected a string, got %T (%v)", raw, raw)
+	}
+	text = strings.TrimSpace(text)
+	if i := strings.IndexFunc(text, isDisplayControl); i >= 0 {
+		return "", fmt.Errorf("contains a control character at offset %d; this slot renders as a single line of text", i)
+	}
+	// Rune count, not len: a budget measured in bytes would reject
+	// legitimate accented or emoji values that fit the display fine.
+	if count := utf8.RuneCountInString(text); count > s.MaxRunes {
+		return "", fmt.Errorf("is %d characters but this slot renders at most %d; shorten it rather than relying on truncation (got %q)", count, s.MaxRunes, text)
+	}
+	return text, nil
+}
+
+// normalizeFraction range-checks a gauge fill value.
+func (s Slot) normalizeFraction(raw any) (float64, error) {
+	value, ok := coerceFloat(raw)
+	if !ok {
+		return 0, fmt.Errorf("expected a number between 0.0 and 1.0, got %T (%v)", raw, raw)
+	}
+	if value < 0 || value > 1 {
+		return 0, fmt.Errorf("is %v but must be between 0.0 and 1.0; normalize it first, e.g. (value - minimum) / (maximum - minimum) clamped to the range", value)
+	}
+	return value, nil
+}
+
+// normalizeColor canonicalizes a hex color to "#RRGGBB".
+func (s Slot) normalizeColor(raw any) (string, error) {
+	text, ok := raw.(string)
+	if !ok {
+		return "", fmt.Errorf("expected an \"#RRGGBB\" hex color string, got %T (%v)", raw, raw)
+	}
+	trimmed := strings.TrimSpace(text)
+	trimmed = strings.TrimPrefix(trimmed, "#")
+	if len(trimmed) != 6 || !isHex(trimmed) {
+		return "", fmt.Errorf("must be a six-digit hex color like \"#3FB950\"; got %q", text)
+	}
+	return "#" + strings.ToUpper(trimmed), nil
+}
+
+// coerceFloat accepts the numeric shapes a tool call can arrive in: JSON
+// decodes to float64 by default and to json.Number under a UseNumber
+// decoder, and some model families emit numbers as quoted strings.
+func coerceFloat(raw any) (float64, bool) {
+	switch v := raw.(type) {
+	case float64:
+		return v, true
+	case float32:
+		return float64(v), true
+	case int:
+		return float64(v), true
+	case int64:
+		return float64(v), true
+	case json.Number:
+		parsed, err := v.Float64()
+		return parsed, err == nil
+	case string:
+		parsed, err := strconv.ParseFloat(strings.TrimSpace(v), 64)
+		return parsed, err == nil
+	default:
+		return 0, false
+	}
+}
+
+func isHex(s string) bool {
+	for _, r := range s {
+		switch {
+		case r >= '0' && r <= '9', r >= 'a' && r <= 'f', r >= 'A' && r <= 'F':
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+// isDisplayControl reports whether r would break a single-line display.
+// Newlines and tabs are the realistic offenders, but the whole control
+// range is rejected: none of it renders on a complication.
+func isDisplayControl(r rune) bool {
+	return unicode.IsControl(r)
+}
+
+func quoteAll(values []string) []string {
+	out := make([]string, len(values))
+	for i, value := range values {
+		out[i] = strconv.Quote(value)
+	}
+	return out
+}

--- a/internal/model/outputtargets/normalize_test.go
+++ b/internal/model/outputtargets/normalize_test.go
@@ -1,0 +1,210 @@
+package outputtargets
+
+import (
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func testTarget() Target {
+	return Target{
+		ID:    "test.surface",
+		Title: "Test surface",
+		Slots: []Slot{
+			{Name: "value", Kind: SlotKindText, MaxRunes: 6, Required: true, Primary: true, Description: "Headline."},
+			{Name: "title", Kind: SlotKindText, MaxRunes: 10, Description: "Label."},
+			{Name: "fraction", Kind: SlotKindFraction, Description: "Fill."},
+			{Name: "tint", Kind: SlotKindColor, Description: "Color."},
+		},
+	}
+}
+
+func TestNormalizeSuccess(t *testing.T) {
+	tests := []struct {
+		name string
+		args map[string]any
+		want Payload
+	}{
+		{
+			name: "primary only",
+			args: map[string]any{"value": "72F"},
+			want: Payload{State: "72F"},
+		},
+		{
+			name: "all slots",
+			args: map[string]any{"value": "72F", "title": "Office", "fraction": 0.5, "tint": "#3fb950"},
+			want: Payload{State: "72F", Attributes: map[string]any{"title": "Office", "fraction": 0.5, "tint": "#3FB950"}},
+		},
+		{
+			name: "whitespace trimmed",
+			args: map[string]any{"value": "  72F  ", "title": "\tOffice\t"},
+			want: Payload{State: "72F", Attributes: map[string]any{"title": "Office"}},
+		},
+		{
+			name: "color without leading hash",
+			args: map[string]any{"value": "72F", "tint": "3fb950"},
+			want: Payload{State: "72F", Attributes: map[string]any{"tint": "#3FB950"}},
+		},
+		{
+			name: "fraction as json.Number",
+			args: map[string]any{"value": "72F", "fraction": json.Number("0.25")},
+			want: Payload{State: "72F", Attributes: map[string]any{"fraction": 0.25}},
+		},
+		{
+			name: "fraction as string",
+			args: map[string]any{"value": "72F", "fraction": "1"},
+			want: Payload{State: "72F", Attributes: map[string]any{"fraction": float64(1)}},
+		},
+		{
+			name: "fraction as int",
+			args: map[string]any{"value": "72F", "fraction": 0},
+			want: Payload{State: "72F", Attributes: map[string]any{"fraction": float64(0)}},
+		},
+		{
+			name: "explicit null clears an optional slot",
+			args: map[string]any{"value": "72F", "title": nil},
+			want: Payload{State: "72F"},
+		},
+		{
+			name: "blank optional text clears the slot",
+			args: map[string]any{"value": "72F", "title": "   "},
+			want: Payload{State: "72F"},
+		},
+		{
+			name: "multibyte value inside the rune budget",
+			args: map[string]any{"value": "🌡22°C"},
+			want: Payload{State: "🌡22°C"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := testTarget().Normalize(tt.args)
+			if err != nil {
+				t.Fatalf("Normalize: %v", err)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("Normalize = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNormalizeErrorsTeach(t *testing.T) {
+	tests := []struct {
+		name string
+		args map[string]any
+		want []string
+	}{
+		{
+			name: "unknown slot lists the valid ones",
+			args: map[string]any{"value": "72F", "subtitle": "nope"},
+			want: []string{`no slot named "subtitle"`, `"value"`, `"fraction"`},
+		},
+		{
+			name: "missing required slot",
+			args: map[string]any{"title": "Office"},
+			want: []string{`slot "value" is required`},
+		},
+		{
+			name: "required slot blank after trimming",
+			args: map[string]any{"value": "  "},
+			want: []string{`slot "value" is required`, "empty after trimming"},
+		},
+		{
+			name: "text over budget names the limit and the value",
+			args: map[string]any{"value": "1234567"},
+			want: []string{"is 7 characters", "at most 6", `"1234567"`},
+		},
+		{
+			name: "text with a newline",
+			args: map[string]any{"value": "72F\nx"},
+			want: []string{"control character", "single line"},
+		},
+		{
+			name: "text of the wrong type",
+			args: map[string]any{"value": 72},
+			want: []string{"expected a string"},
+		},
+		{
+			name: "fraction out of range explains normalization",
+			args: map[string]any{"value": "72F", "fraction": 42.0},
+			want: []string{"must be between 0.0 and 1.0", "(value - minimum)"},
+		},
+		{
+			name: "fraction of the wrong type",
+			args: map[string]any{"value": "72F", "fraction": true},
+			want: []string{"expected a number between 0.0 and 1.0"},
+		},
+		{
+			name: "malformed color",
+			args: map[string]any{"value": "72F", "tint": "greenish"},
+			want: []string{"six-digit hex color", `"greenish"`},
+		},
+		{
+			name: "short color",
+			args: map[string]any{"value": "72F", "tint": "#fff"},
+			want: []string{"six-digit hex color"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := testTarget().Normalize(tt.args)
+			if err == nil {
+				t.Fatal("expected an error")
+			}
+			for _, want := range tt.want {
+				if !strings.Contains(err.Error(), want) {
+					t.Errorf("error %q does not contain %q", err, want)
+				}
+			}
+		})
+	}
+}
+
+func TestNormalizeRejectsRatherThanTruncates(t *testing.T) {
+	// The budget is a contract with the display, not a suggestion: a
+	// silently shortened value would render as a mystery on the watch.
+	_, err := testTarget().Normalize(map[string]any{"value": "1234567"})
+	if err == nil {
+		t.Fatal("expected an over-budget value to be rejected")
+	}
+	if strings.Contains(err.Error(), "truncat") && !strings.Contains(err.Error(), "rather than relying on truncation") {
+		t.Fatalf("error should not imply truncation happened: %q", err)
+	}
+}
+
+func TestNormalizeAgainstRegisteredTargets(t *testing.T) {
+	rectangular, ok := Lookup("apple_watch.rectangular")
+	if !ok {
+		t.Fatal("apple_watch.rectangular is not registered")
+	}
+	payload, err := rectangular.Normalize(map[string]any{
+		"value":       "64%",
+		"title":       "Battery",
+		"subtitle":    "House bank",
+		"bottom_text": "charging",
+		"fraction":    0.64,
+		"gauge_color": "#3FB950",
+	})
+	if err != nil {
+		t.Fatalf("Normalize: %v", err)
+	}
+	if payload.State != "64%" {
+		t.Fatalf("state = %q, want %q", payload.State, "64%")
+	}
+	if payload.Attributes["fraction"] != 0.64 {
+		t.Fatalf("fraction attribute = %v", payload.Attributes["fraction"])
+	}
+	if _, present := payload.Attributes["value"]; present {
+		t.Fatal("the primary slot must be the state, not also an attribute")
+	}
+
+	circular, ok := Lookup("apple_watch.circular")
+	if !ok {
+		t.Fatal("apple_watch.circular is not registered")
+	}
+	if _, err := circular.Normalize(map[string]any{"value": "1013 hPa"}); err == nil {
+		t.Fatal("expected the circular target to reject a value well over its budget")
+	}
+}

--- a/internal/model/outputtargets/schema.go
+++ b/internal/model/outputtargets/schema.go
@@ -1,0 +1,74 @@
+package outputtargets
+
+import "fmt"
+
+// Schema returns the JSON-Schema parameter object for a tool that fills
+// this target's slots: one property per slot, typed and bounded by the
+// slot's kind, with the required slots listed.
+//
+// The schema is advisory in the same sense as the loop spec schema — it
+// does not set additionalProperties:false, because rejecting an unknown
+// key silently at the provider layer teaches the model nothing.
+// [Target.Normalize] rejects unknown keys with an error that names the
+// valid slots instead.
+func (t Target) Schema() map[string]any {
+	properties := make(map[string]any, len(t.Slots))
+	required := make([]string, 0, len(t.Slots))
+	for _, slot := range t.Slots {
+		properties[slot.Name] = slot.schema()
+		if slot.Required {
+			required = append(required, slot.Name)
+		}
+	}
+	schema := map[string]any{
+		"type":       "object",
+		"properties": properties,
+	}
+	if len(required) > 0 {
+		schema["required"] = required
+	}
+	return schema
+}
+
+// schema returns the JSON-Schema fragment for one slot.
+func (s Slot) schema() map[string]any {
+	switch s.Kind {
+	case SlotKindText:
+		return map[string]any{
+			"type":        "string",
+			"maxLength":   s.MaxRunes,
+			"description": fmt.Sprintf("%s Maximum %d characters — over-budget values are rejected, not truncated.", s.Description, s.MaxRunes),
+		}
+	case SlotKindFraction:
+		return map[string]any{
+			"type":        "number",
+			"minimum":     0,
+			"maximum":     1,
+			"description": s.Description,
+		}
+	case SlotKindColor:
+		return map[string]any{
+			"type":        "string",
+			"pattern":     "^#?[0-9A-Fa-f]{6}$",
+			"description": s.Description + " Format: \"#RRGGBB\".",
+		}
+	default:
+		// Unreachable for registered targets: Target.validate rejects
+		// unknown kinds before a target enters the registry. Kept so a
+		// future kind that skips a schema case fails loudly in review
+		// rather than advertising an untyped parameter to the model.
+		return map[string]any{"description": s.Description}
+	}
+}
+
+// ToolDescription returns the model-facing description for the
+// request-scoped tool that fills this target, framed for one named
+// output. The caller supplies the output name and the entity the payload
+// lands on so the model can tell two declarations of the same target
+// apart.
+func (t Target) ToolDescription(outputName, entityID string) string {
+	return fmt.Sprintf(
+		"Set the loop-declared structured output %q, rendered as %s. %s Every call replaces the whole payload: slots you omit are cleared, so send the complete current state each time. Published to %s. %s",
+		outputName, t.Title, t.Summary, entityID, t.Binding,
+	)
+}

--- a/internal/model/outputtargets/schema_test.go
+++ b/internal/model/outputtargets/schema_test.go
@@ -1,0 +1,98 @@
+package outputtargets
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestSchemaShapesEverySlot(t *testing.T) {
+	schema := testTarget().Schema()
+	if schema["type"] != "object" {
+		t.Fatalf("schema type = %v", schema["type"])
+	}
+
+	properties, ok := schema["properties"].(map[string]any)
+	if !ok {
+		t.Fatalf("properties is %T", schema["properties"])
+	}
+	if len(properties) != 4 {
+		t.Fatalf("expected 4 properties, got %d", len(properties))
+	}
+
+	required, ok := schema["required"].([]string)
+	if !ok {
+		t.Fatalf("required is %T", schema["required"])
+	}
+	if !reflect.DeepEqual(required, []string{"value"}) {
+		t.Fatalf("required = %v, want [value]", required)
+	}
+
+	value := properties["value"].(map[string]any)
+	if value["type"] != "string" {
+		t.Fatalf("value type = %v", value["type"])
+	}
+	if value["maxLength"] != 6 {
+		t.Fatalf("value maxLength = %v, want 6", value["maxLength"])
+	}
+	if desc, _ := value["description"].(string); !strings.Contains(desc, "Maximum 6 characters") {
+		t.Fatalf("value description does not state the budget: %q", desc)
+	}
+
+	fraction := properties["fraction"].(map[string]any)
+	if fraction["type"] != "number" || fraction["minimum"] != 0 || fraction["maximum"] != 1 {
+		t.Fatalf("fraction schema = %v", fraction)
+	}
+
+	tint := properties["tint"].(map[string]any)
+	if tint["type"] != "string" {
+		t.Fatalf("tint type = %v", tint["type"])
+	}
+	if pattern, _ := tint["pattern"].(string); pattern == "" {
+		t.Fatal("color slot has no pattern")
+	}
+}
+
+func TestSchemaIsAdvisory(t *testing.T) {
+	// Matching loopSpecSchema: no additionalProperties:false, so a
+	// provider never silently rejects a key. Normalize is what teaches.
+	for _, target := range All() {
+		if _, present := target.Schema()["additionalProperties"]; present {
+			t.Errorf("target %q sets additionalProperties; unknown keys are rejected by Normalize with a teaching error instead", target.ID)
+		}
+	}
+}
+
+func TestSchemaCoversRegisteredTargets(t *testing.T) {
+	for _, target := range All() {
+		schema := target.Schema()
+		properties, ok := schema["properties"].(map[string]any)
+		if !ok {
+			t.Fatalf("target %q has no properties", target.ID)
+		}
+		for _, slot := range target.Slots {
+			property, present := properties[slot.Name]
+			if !present {
+				t.Errorf("target %q slot %q missing from schema", target.ID, slot.Name)
+				continue
+			}
+			fragment := property.(map[string]any)
+			if fragment["type"] == nil {
+				t.Errorf("target %q slot %q has an untyped schema fragment", target.ID, slot.Name)
+			}
+		}
+	}
+}
+
+func TestToolDescriptionNamesOutputAndEntity(t *testing.T) {
+	target, ok := Lookup("apple_watch.rectangular")
+	if !ok {
+		t.Fatal("apple_watch.rectangular is not registered")
+	}
+	description := target.ToolDescription("watch_status", "sensor.thane_watch_status")
+	for _, want := range []string{"watch_status", "sensor.thane_watch_status", "replaces the whole payload"} {
+		if !strings.Contains(description, want) {
+			t.Errorf("description missing %q: %s", want, description)
+		}
+	}
+}

--- a/internal/model/outputtargets/target.go
+++ b/internal/model/outputtargets/target.go
@@ -1,0 +1,193 @@
+package outputtargets
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// SlotKind classifies what a slot accepts and how it is validated.
+type SlotKind string
+
+const (
+	// SlotKindText is a short display string constrained by
+	// [Slot.MaxRunes].
+	SlotKindText SlotKind = "text"
+	// SlotKindFraction is a number in [0.0, 1.0] driving a gauge, ring,
+	// or progress bar fill.
+	SlotKindFraction SlotKind = "fraction"
+	// SlotKindColor is an "#RRGGBB" hex color.
+	SlotKindColor SlotKind = "color"
+)
+
+// Slot is one named position in a target's layout.
+type Slot struct {
+	// Name is the slot identifier. It is both the tool parameter name
+	// and the payload attribute key, so it stays lower_snake_case.
+	Name string `json:"name"`
+	// Kind selects the validation rules applied to this slot's value.
+	Kind SlotKind `json:"kind"`
+	// Description is model-facing: what this slot renders as on the
+	// target surface, in enough detail to choose a good value.
+	Description string `json:"description"`
+	// Required marks a slot the target cannot render without. The
+	// primary slot is always required.
+	Required bool `json:"required,omitempty"`
+	// MaxRunes bounds a text slot's length in runes (not bytes). Zero
+	// means unbounded and is only valid for non-text kinds.
+	MaxRunes int `json:"max_runes,omitempty"`
+	// Primary marks the slot whose value becomes the payload state
+	// rather than an attribute. Exactly one slot per target sets it.
+	Primary bool `json:"primary,omitempty"`
+}
+
+// Target is one renderable surface with a fixed slot layout.
+type Target struct {
+	// ID is the stable identifier a loop output declares, such as
+	// "apple_watch.rectangular".
+	ID string `json:"id"`
+	// Title is the human-readable target name for operator surfaces.
+	Title string `json:"title"`
+	// Summary tells the model what this surface is and what shape of
+	// content survives on it.
+	Summary string `json:"summary"`
+	// Binding explains how the consuming surface reads the published
+	// payload, so the operator wiring is discoverable from the contract
+	// rather than from tribal knowledge.
+	Binding string `json:"binding"`
+	// Icon is the Material Design Icons name published with the sink's
+	// entity registration. Empty leaves the sink default.
+	Icon string `json:"icon,omitempty"`
+	// Slots are the target's positions in render order.
+	Slots []Slot `json:"slots"`
+}
+
+// PrimarySlot returns the slot whose value becomes the payload state.
+// Every registered target has one; the zero [Slot] and false are
+// returned for a target that does not, which [Target.validate] rejects at
+// registration.
+func (t Target) PrimarySlot() (Slot, bool) {
+	for _, slot := range t.Slots {
+		if slot.Primary {
+			return slot, true
+		}
+	}
+	return Slot{}, false
+}
+
+// Slot returns the named slot.
+func (t Target) Slot(name string) (Slot, bool) {
+	for _, slot := range t.Slots {
+		if slot.Name == name {
+			return slot, true
+		}
+	}
+	return Slot{}, false
+}
+
+// SlotNames returns every slot name in render order, for error messages
+// that need to enumerate the valid parameters.
+func (t Target) SlotNames() []string {
+	names := make([]string, 0, len(t.Slots))
+	for _, slot := range t.Slots {
+		names = append(names, slot.Name)
+	}
+	return names
+}
+
+// validate reports whether a target is internally coherent. It runs at
+// package init over the built-in registry, so a malformed target is a
+// build-time-adjacent failure (the first test or process start) rather
+// than a runtime surprise in a loop handler.
+func (t Target) validate() error {
+	if strings.TrimSpace(t.ID) == "" {
+		return fmt.Errorf("target id is required")
+	}
+	if len(t.Slots) == 0 {
+		return fmt.Errorf("target %q declares no slots", t.ID)
+	}
+	seen := make(map[string]struct{}, len(t.Slots))
+	primaries := 0
+	for _, slot := range t.Slots {
+		if strings.TrimSpace(slot.Name) == "" {
+			return fmt.Errorf("target %q has a slot with no name", t.ID)
+		}
+		if _, dup := seen[slot.Name]; dup {
+			return fmt.Errorf("target %q declares duplicate slot %q", t.ID, slot.Name)
+		}
+		seen[slot.Name] = struct{}{}
+		switch slot.Kind {
+		case SlotKindText:
+			if slot.MaxRunes <= 0 {
+				return fmt.Errorf("target %q slot %q is text and needs a positive max_runes", t.ID, slot.Name)
+			}
+		case SlotKindFraction, SlotKindColor:
+			if slot.MaxRunes != 0 {
+				return fmt.Errorf("target %q slot %q is %s and must not set max_runes", t.ID, slot.Name, slot.Kind)
+			}
+		default:
+			return fmt.Errorf("target %q slot %q has unsupported kind %q", t.ID, slot.Name, slot.Kind)
+		}
+		if slot.Primary {
+			primaries++
+			if slot.Kind != SlotKindText {
+				return fmt.Errorf("target %q primary slot %q must be text; the payload state is a scalar string", t.ID, slot.Name)
+			}
+			if !slot.Required {
+				return fmt.Errorf("target %q primary slot %q must be required", t.ID, slot.Name)
+			}
+		}
+	}
+	if primaries != 1 {
+		return fmt.Errorf("target %q declares %d primary slots; exactly one is required", t.ID, primaries)
+	}
+	return nil
+}
+
+// registry holds every built-in target keyed by ID. It is populated once
+// at init and never mutated, so no lock is needed for the read paths.
+var registry = func() map[string]Target {
+	targets := []Target{
+		appleWatchRectangular,
+		appleWatchCircular,
+	}
+	out := make(map[string]Target, len(targets))
+	for _, target := range targets {
+		if err := target.validate(); err != nil {
+			panic("outputtargets: invalid built-in target: " + err.Error())
+		}
+		if _, dup := out[target.ID]; dup {
+			panic("outputtargets: duplicate built-in target id " + target.ID)
+		}
+		out[target.ID] = target
+	}
+	return out
+}()
+
+// Lookup returns the registered target with the given ID.
+func Lookup(id string) (Target, bool) {
+	target, ok := registry[strings.TrimSpace(id)]
+	return target, ok
+}
+
+// IDs returns every registered target ID in sorted order. Callers use it
+// to enumerate valid choices in schemas and in errors that reject an
+// unknown target.
+func IDs() []string {
+	ids := make([]string, 0, len(registry))
+	for id := range registry {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	return ids
+}
+
+// All returns every registered target sorted by ID.
+func All() []Target {
+	ids := IDs()
+	targets := make([]Target, 0, len(ids))
+	for _, id := range ids {
+		targets = append(targets, registry[id])
+	}
+	return targets
+}

--- a/internal/model/outputtargets/target_test.go
+++ b/internal/model/outputtargets/target_test.go
@@ -1,0 +1,167 @@
+package outputtargets
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRegistryTargetsAreCoherent(t *testing.T) {
+	targets := All()
+	if len(targets) == 0 {
+		t.Fatal("registry is empty")
+	}
+	for _, target := range targets {
+		if err := target.validate(); err != nil {
+			t.Errorf("target %q: %v", target.ID, err)
+		}
+		if strings.TrimSpace(target.Summary) == "" {
+			t.Errorf("target %q has no summary; the model needs to know what surface it is filling", target.ID)
+		}
+		if strings.TrimSpace(target.Binding) == "" {
+			t.Errorf("target %q has no binding text; the operator wiring would be undiscoverable", target.ID)
+		}
+		for _, slot := range target.Slots {
+			if strings.TrimSpace(slot.Description) == "" {
+				t.Errorf("target %q slot %q has no description", target.ID, slot.Name)
+			}
+			if slot.Name != strings.ToLower(slot.Name) {
+				t.Errorf("target %q slot %q must be lower_snake_case: it is both a tool parameter and an attribute key", target.ID, slot.Name)
+			}
+		}
+	}
+}
+
+func TestLookup(t *testing.T) {
+	tests := []struct {
+		name string
+		id   string
+		want bool
+	}{
+		{name: "registered", id: "apple_watch.rectangular", want: true},
+		{name: "surrounding whitespace tolerated", id: "  apple_watch.circular  ", want: true},
+		{name: "unknown", id: "apple_watch.trapezoid", want: false},
+		{name: "empty", id: "", want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, ok := Lookup(tt.id)
+			if ok != tt.want {
+				t.Fatalf("Lookup(%q) ok = %v, want %v", tt.id, ok, tt.want)
+			}
+		})
+	}
+}
+
+func TestIDsSorted(t *testing.T) {
+	ids := IDs()
+	for i := 1; i < len(ids); i++ {
+		if ids[i-1] > ids[i] {
+			t.Fatalf("IDs not sorted: %v", ids)
+		}
+	}
+}
+
+func TestTargetValidateRejectsMalformed(t *testing.T) {
+	tests := []struct {
+		name   string
+		target Target
+		want   string
+	}{
+		{
+			name:   "no id",
+			target: Target{Slots: []Slot{{Name: "value", Kind: SlotKindText, MaxRunes: 4, Required: true, Primary: true}}},
+			want:   "target id is required",
+		},
+		{
+			name:   "no slots",
+			target: Target{ID: "x"},
+			want:   "declares no slots",
+		},
+		{
+			name: "no primary",
+			target: Target{ID: "x", Slots: []Slot{
+				{Name: "value", Kind: SlotKindText, MaxRunes: 4},
+			}},
+			want: "exactly one is required",
+		},
+		{
+			name: "two primaries",
+			target: Target{ID: "x", Slots: []Slot{
+				{Name: "a", Kind: SlotKindText, MaxRunes: 4, Required: true, Primary: true},
+				{Name: "b", Kind: SlotKindText, MaxRunes: 4, Required: true, Primary: true},
+			}},
+			want: "declares 2 primary slots",
+		},
+		{
+			name: "duplicate slot",
+			target: Target{ID: "x", Slots: []Slot{
+				{Name: "a", Kind: SlotKindText, MaxRunes: 4, Required: true, Primary: true},
+				{Name: "a", Kind: SlotKindText, MaxRunes: 4},
+			}},
+			want: "duplicate slot",
+		},
+		{
+			name: "text slot without budget",
+			target: Target{ID: "x", Slots: []Slot{
+				{Name: "a", Kind: SlotKindText, Required: true, Primary: true},
+			}},
+			want: "needs a positive max_runes",
+		},
+		{
+			name: "non-text primary",
+			target: Target{ID: "x", Slots: []Slot{
+				{Name: "a", Kind: SlotKindFraction, Required: true, Primary: true},
+			}},
+			want: "must be text",
+		},
+		{
+			name: "optional primary",
+			target: Target{ID: "x", Slots: []Slot{
+				{Name: "a", Kind: SlotKindText, MaxRunes: 4, Primary: true},
+			}},
+			want: "must be required",
+		},
+		{
+			name: "budget on a color slot",
+			target: Target{ID: "x", Slots: []Slot{
+				{Name: "a", Kind: SlotKindText, MaxRunes: 4, Required: true, Primary: true},
+				{Name: "tint", Kind: SlotKindColor, MaxRunes: 7},
+			}},
+			want: "must not set max_runes",
+		},
+		{
+			name: "unknown kind",
+			target: Target{ID: "x", Slots: []Slot{
+				{Name: "a", Kind: SlotKindText, MaxRunes: 4, Required: true, Primary: true},
+				{Name: "b", Kind: SlotKind("mystery")},
+			}},
+			want: "unsupported kind",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.target.validate()
+			if err == nil {
+				t.Fatal("expected an error")
+			}
+			if !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("error %q does not contain %q", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestPrimarySlotIsTheState(t *testing.T) {
+	for _, target := range All() {
+		slot, ok := target.PrimarySlot()
+		if !ok {
+			t.Fatalf("target %q has no primary slot", target.ID)
+		}
+		if slot.Name != "value" {
+			// Not a hard requirement of the model, but every target so
+			// far names its primary slot "value"; a divergence should be
+			// a deliberate decision rather than a typo.
+			t.Errorf("target %q primary slot is %q, expected the conventional \"value\"", target.ID, slot.Name)
+		}
+	}
+}

--- a/internal/runtime/loop/output.go
+++ b/internal/runtime/loop/output.go
@@ -5,9 +5,25 @@ import (
 	"fmt"
 	"strings"
 	"unicode"
+
+	"github.com/nugget/thane-ai-agent/internal/model/outputtargets"
 )
 
-const maxOutputToolNameLength = 64
+const (
+	maxOutputToolNameLength = 64
+
+	// structuredPayloadSinkMQTT is the only ref sink a structured
+	// payload output can address today. It is a named constant so the
+	// error text and the check cannot drift apart, and so adding a
+	// second sink is a visible change here rather than a new string
+	// literal somewhere else.
+	structuredPayloadSinkMQTT = "mqtt"
+
+	// maxStructuredPayloadSuffixLength bounds the entity suffix. Home
+	// Assistant tolerates far longer entity IDs, but a complication
+	// binding is typed by hand into the companion app.
+	maxStructuredPayloadSuffixLength = 48
+)
 
 // OutputType names a durable output contract declared by a loop.
 type OutputType string
@@ -19,6 +35,11 @@ const (
 	// OutputTypeJournalDocument describes an append-only journal
 	// document maintained by the loop.
 	OutputTypeJournalDocument OutputType = "journal_document"
+	// OutputTypeStructuredPayload describes a slotted payload rendered
+	// by an external surface rather than written as a document. The
+	// surface is named by [OutputSpec.Target] and its slot contract
+	// lives in the outputtargets registry.
+	OutputTypeStructuredPayload OutputType = "structured_payload"
 )
 
 // OutputMode describes the allowed write mode for a loop output.
@@ -29,6 +50,10 @@ const (
 	OutputModeReplace OutputMode = "replace"
 	// OutputModeAppend requires append-only journal entries.
 	OutputModeAppend OutputMode = "append"
+	// OutputModeSet requires a complete slot set on every write. It has
+	// no partial-update form: a rendered surface shows exactly the last
+	// payload, so an omitted slot is a cleared slot.
+	OutputModeSet OutputMode = "set"
 )
 
 // OutputSpec declares one durable document surface a loop is allowed to
@@ -39,8 +64,16 @@ type OutputSpec struct {
 	Name string `yaml:"name" json:"name"`
 	// Type identifies the output behavior, such as maintained_document.
 	Type OutputType `yaml:"type" json:"type"`
-	// Ref is the managed document ref, such as core:metacognitive.md.
+	// Ref addresses the destination in the form sink:path. Document
+	// outputs use a managed document ref such as core:metacognitive.md;
+	// structured payload outputs use mqtt:<entity_suffix>, which
+	// becomes a Home Assistant sensor entity.
 	Ref string `yaml:"ref" json:"ref"`
+	// Target names the rendering target for a structured payload
+	// output, such as apple_watch.rectangular. It selects the slot
+	// contract the generated tool advertises and validates against, and
+	// must be empty for document outputs.
+	Target string `yaml:"target,omitempty" json:"target,omitempty"`
 	// Mode is the write mode. It defaults from Type when omitted.
 	Mode OutputMode `yaml:"mode,omitempty" json:"mode,omitempty"`
 	// Purpose is optional model-facing guidance for this output.
@@ -80,6 +113,8 @@ func (o OutputSpec) EffectiveMode() OutputMode {
 		return OutputModeReplace
 	case OutputTypeJournalDocument:
 		return OutputModeAppend
+	case OutputTypeStructuredPayload:
+		return OutputModeSet
 	default:
 		return ""
 	}
@@ -93,6 +128,8 @@ func (o OutputSpec) ToolName() string {
 		return "replace_output_" + safeOutputToolSuffix(o.Name)
 	case OutputModeAppend:
 		return "append_output_" + safeOutputToolSuffix(o.Name)
+	case OutputModeSet:
+		return "set_output_" + safeOutputToolSuffix(o.Name)
 	default:
 		return "write_output_" + safeOutputToolSuffix(o.Name)
 	}
@@ -120,9 +157,12 @@ func (o OutputSpec) Validate() error {
 		return err
 	}
 	switch o.Type {
-	case OutputTypeMaintainedDocument, OutputTypeJournalDocument:
+	case OutputTypeMaintainedDocument, OutputTypeJournalDocument, OutputTypeStructuredPayload:
 	default:
 		return fmt.Errorf("unsupported type %q", o.Type)
+	}
+	if err := o.validateTarget(); err != nil {
+		return err
 	}
 	mode := o.EffectiveMode()
 	switch mode {
@@ -134,11 +174,64 @@ func (o OutputSpec) Validate() error {
 		if o.Type != OutputTypeJournalDocument {
 			return fmt.Errorf("mode %q is only valid for type %q", mode, OutputTypeJournalDocument)
 		}
+	case OutputModeSet:
+		if o.Type != OutputTypeStructuredPayload {
+			return fmt.Errorf("mode %q is only valid for type %q", mode, OutputTypeStructuredPayload)
+		}
 	default:
 		return fmt.Errorf("unsupported mode %q", mode)
 	}
 	if o.MaxWindows < 0 {
 		return fmt.Errorf("max_windows must be >= 0")
+	}
+	return nil
+}
+
+// validateTarget enforces the target/type pairing and, for a structured
+// payload, that the declared target actually exists and the ref names the
+// sink that can render it. A target ID typo is otherwise invisible until
+// wake time, when the loop discovers it has no output tool at all.
+func (o OutputSpec) validateTarget() error {
+	target := strings.TrimSpace(o.Target)
+	if o.Type != OutputTypeStructuredPayload {
+		if target != "" {
+			return fmt.Errorf("target %q is only valid for type %q; document outputs render through the document layer", o.Target, OutputTypeStructuredPayload)
+		}
+		return nil
+	}
+	if target == "" {
+		return fmt.Errorf("target is required for type %q; choose one of %s", OutputTypeStructuredPayload, strings.Join(outputtargets.IDs(), ", "))
+	}
+	if _, ok := outputtargets.Lookup(target); !ok {
+		return fmt.Errorf("unknown target %q; registered targets are %s", o.Target, strings.Join(outputtargets.IDs(), ", "))
+	}
+	return validateStructuredPayloadRef(o.Ref)
+}
+
+// validateStructuredPayloadRef checks that a structured payload ref names
+// a supported sink and a usable entity suffix. The suffix travels into an
+// MQTT topic path and a Home Assistant entity ID, so the grammar is the
+// intersection of what both accept rather than what either tolerates.
+func validateStructuredPayloadRef(ref string) error {
+	sink, suffix, _ := strings.Cut(strings.TrimSpace(ref), ":")
+	sink = strings.TrimSpace(sink)
+	suffix = strings.TrimSpace(suffix)
+	if sink != structuredPayloadSinkMQTT {
+		return fmt.Errorf("ref %q must address the %q sink for type %q (for example %s:watch_status)", ref, structuredPayloadSinkMQTT, OutputTypeStructuredPayload, structuredPayloadSinkMQTT)
+	}
+	if len(suffix) > maxStructuredPayloadSuffixLength {
+		return fmt.Errorf("ref entity suffix %q is %d characters; keep it to %d or fewer", suffix, len(suffix), maxStructuredPayloadSuffixLength)
+	}
+	for i, r := range suffix {
+		switch {
+		case r >= 'a' && r <= 'z':
+		case r >= '0' && r <= '9', r == '_':
+			if i == 0 {
+				return fmt.Errorf("ref entity suffix %q must start with a lowercase letter", suffix)
+			}
+		default:
+			return fmt.Errorf("ref entity suffix %q contains unsupported character %q; use lowercase letters, digits, and underscores so it is valid in both an MQTT topic and a Home Assistant entity ID", suffix, r)
+		}
 	}
 	return nil
 }

--- a/internal/runtime/loop/output_test.go
+++ b/internal/runtime/loop/output_test.go
@@ -210,3 +210,151 @@ func TestSpecValidateRejectsDuplicateOutputToolNames(t *testing.T) {
 		t.Fatalf("error = %v, want duplicate generated tool", err)
 	}
 }
+
+func TestOutputSpecStructuredPayload(t *testing.T) {
+	tests := []struct {
+		name     string
+		output   OutputSpec
+		wantTool string
+		wantErr  string
+	}{
+		{
+			name: "valid declaration defaults to set mode",
+			output: OutputSpec{
+				Name:   "Watch Status",
+				Type:   OutputTypeStructuredPayload,
+				Ref:    "mqtt:watch_status",
+				Target: "apple_watch.rectangular",
+			},
+			wantTool: "set_output_watch_status",
+		},
+		{
+			name: "explicit set mode",
+			output: OutputSpec{
+				Name:   "watch_status",
+				Type:   OutputTypeStructuredPayload,
+				Ref:    "mqtt:watch_status",
+				Target: "apple_watch.circular",
+				Mode:   OutputModeSet,
+			},
+			wantTool: "set_output_watch_status",
+		},
+		{
+			name: "missing target enumerates the registered ones",
+			output: OutputSpec{
+				Name: "watch_status",
+				Type: OutputTypeStructuredPayload,
+				Ref:  "mqtt:watch_status",
+			},
+			wantErr: "apple_watch.rectangular",
+		},
+		{
+			name: "unknown target",
+			output: OutputSpec{
+				Name:   "watch_status",
+				Type:   OutputTypeStructuredPayload,
+				Ref:    "mqtt:watch_status",
+				Target: "apple_watch.trapezoid",
+			},
+			wantErr: "unknown target",
+		},
+		{
+			name: "target on a document output",
+			output: OutputSpec{
+				Name:   "state",
+				Type:   OutputTypeMaintainedDocument,
+				Ref:    "core:state.md",
+				Target: "apple_watch.circular",
+			},
+			wantErr: "is only valid for type",
+		},
+		{
+			name: "document ref for a structured payload",
+			output: OutputSpec{
+				Name:   "watch_status",
+				Type:   OutputTypeStructuredPayload,
+				Ref:    "core:watch.md",
+				Target: "apple_watch.circular",
+			},
+			wantErr: `must address the "mqtt" sink`,
+		},
+		{
+			name: "entity suffix with unsupported characters",
+			output: OutputSpec{
+				Name:   "watch_status",
+				Type:   OutputTypeStructuredPayload,
+				Ref:    "mqtt:Watch-Status",
+				Target: "apple_watch.circular",
+			},
+			wantErr: "unsupported character",
+		},
+		{
+			name: "entity suffix starting with a digit",
+			output: OutputSpec{
+				Name:   "watch_status",
+				Type:   OutputTypeStructuredPayload,
+				Ref:    "mqtt:1watch",
+				Target: "apple_watch.circular",
+			},
+			wantErr: "must start with a lowercase letter",
+		},
+		{
+			name: "set mode on a document output",
+			output: OutputSpec{
+				Name: "state",
+				Type: OutputTypeMaintainedDocument,
+				Ref:  "core:state.md",
+				Mode: OutputModeSet,
+			},
+			wantErr: "is only valid for type",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.output.Validate()
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("Validate() error = nil, want %q", tt.wantErr)
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("Validate() error = %v, want it to contain %q", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Validate() error = %v", err)
+			}
+			if got := tt.output.ToolName(); got != tt.wantTool {
+				t.Fatalf("ToolName() = %q, want %q", got, tt.wantTool)
+			}
+			if got := tt.output.EffectiveMode(); got != OutputModeSet {
+				t.Fatalf("EffectiveMode() = %q, want %q", got, OutputModeSet)
+			}
+		})
+	}
+}
+
+func TestOutputSpecStructuredPayloadRoundTrips(t *testing.T) {
+	original := OutputSpec{
+		Name:   "watch_status",
+		Type:   OutputTypeStructuredPayload,
+		Ref:    "mqtt:watch_status",
+		Target: "apple_watch.rectangular",
+	}
+	encoded, err := json.Marshal(original)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !strings.Contains(string(encoded), `"target":"apple_watch.rectangular"`) {
+		t.Fatalf("target missing from JSON: %s", encoded)
+	}
+
+	var decoded OutputSpec
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if decoded != original {
+		t.Fatalf("round trip = %#v, want %#v", decoded, original)
+	}
+}

--- a/internal/tools/loop_spec_schema.go
+++ b/internal/tools/loop_spec_schema.go
@@ -1,5 +1,7 @@
 package tools
 
+import "github.com/nugget/thane-ai-agent/internal/model/outputtargets"
+
 // loopSpecSchema returns the JSON-Schema description of the agent-facing
 // loop-definition spec object, shared by loop_definition_set,
 // loop_definition_lint, and spawn_loop. Until this existed those tools
@@ -54,7 +56,7 @@ func loopSpecSchema(description string) map[string]any {
 			"supervisor_profile": loopProfileSchema("Overlay applied on supervisor turns (e.g. a higher quality_floor and review-specific instructions). Any field set here wins over profile; unset fields fall back to profile."),
 			"outputs": map[string]any{
 				"type":        "array",
-				"description": "Durable documents this loop maintains through scoped runtime tools (replace_output_*/append_output_*).",
+				"description": "Durable outputs this loop owns, each exposed as a scoped runtime tool: documents it maintains (replace_output_*/append_output_*) and rendered surfaces it drives (set_output_*).",
 				"items":       loopOutputSpecSchema(),
 			},
 			"tags": map[string]any{
@@ -174,9 +176,10 @@ func loopOutputSpecSchema() map[string]any {
 		"type": "object",
 		"properties": map[string]any{
 			"name":           map[string]any{"type": "string", "description": "Stable semantic name for this output within the loop."},
-			"type":           map[string]any{"type": "string", "enum": []string{"maintained_document", "journal_document"}, "description": "maintained_document = idempotent rewrite each cycle; journal_document = append-only dated entries."},
-			"ref":            map[string]any{"type": "string", "description": "Managed document ref, e.g. \"core:metacognitive.md\" or \"kb:dashboards/x.md\". Stored verbatim — not resolved to content."},
-			"mode":           map[string]any{"type": "string", "enum": []string{"replace", "append"}, "description": "Write mode; defaults from type when omitted (maintained→replace, journal→append)."},
+			"type":           map[string]any{"type": "string", "enum": []string{"maintained_document", "journal_document", "structured_payload"}, "description": "maintained_document = idempotent rewrite each cycle; journal_document = append-only dated entries; structured_payload = named slots rendered by an external surface (requires target)."},
+			"ref":            map[string]any{"type": "string", "description": "Destination as sink:path. Documents use a managed ref, e.g. \"core:metacognitive.md\" or \"kb:dashboards/x.md\". Structured payloads use \"mqtt:<entity_suffix>\" (lowercase letters, digits, underscores), which becomes a Home Assistant sensor. Stored verbatim — not resolved to content."},
+			"target":         map[string]any{"type": "string", "enum": outputtargets.IDs(), "description": "Rendering target for structured_payload outputs; selects the slot contract the generated set_output_* tool advertises and enforces. Omit for document outputs."},
+			"mode":           map[string]any{"type": "string", "enum": []string{"replace", "append", "set"}, "description": "Write mode; defaults from type when omitted (maintained→replace, journal→append, structured_payload→set)."},
 			"purpose":        map[string]any{"type": "string", "description": "Optional model-facing guidance describing what this output is for."},
 			"journal_window": map[string]any{"type": "string", "enum": []string{"day", "week", "month"}, "description": "Rolling window for journal outputs; empty uses the document-layer default."},
 			"max_windows":    map[string]any{"type": "integer", "description": "Cap on retained journal windows; 0 uses the document-layer default."},

--- a/scripts/architecture.baseline
+++ b/scripts/architecture.baseline
@@ -1,5 +1,5 @@
-packages=64
-interfaces=84
+packages=65
+interfaces=85
 large_files=52
 set_mutators=115
 database_opens=9

--- a/talents/loops.md
+++ b/talents/loops.md
@@ -26,6 +26,31 @@ output tools such as `replace_output_*` or `append_output_*`. If a
 maintained output is marked `truncated` in Declared Durable Outputs, read
 the full document before replacing it.
 
+Choose the output tier by who reads the result:
+
+- **`maintained_document`** — a reader who wants the whole picture. Prose
+  and structure, rewritten idempotently each cycle.
+- **`journal_document`** — a reader who wants the history. Append-only
+  dated entries; never rewrite what is already there.
+- **`structured_payload`** — a *display* that has no room for prose. The
+  declaration names a `target` (an entry in the target registry, such as
+  `apple_watch.rectangular`), and the generated `set_output_*` tool
+  advertises that target's exact slots, types, and character budgets.
+  The payload lands on a Home Assistant entity the display binds to.
+
+A structured payload is a full replacement every call: slots you omit are
+cleared, not preserved, so send the complete current state each time. The
+budgets are enforced rather than truncated — an over-budget value comes
+back as an error naming the limit, because a silently shortened string
+becomes an unreadable fragment on a watch face. Write for the geometry:
+the slot descriptions in Declared Durable Outputs say what each position
+renders as and how much of it survives.
+
+Do not reach for a structured payload to store something. It is a display
+surface with no history — the last payload is all there is. When the same
+work needs both a durable record and a glanceable readout, declare two
+outputs and write both.
+
 Choose stream wiring by attention cost:
 
 - Use entity subscriptions for ambient state the loop should see on its


### PR DESCRIPTION
## Summary

Loop outputs had two tiers and both were documents — `maintained_document` asks the model for a complete rewrite, `journal_document` for an appended entry, and both hand it a free-text body. That is the wrong shape for a *display*. An Apple Watch complication has four lines of roughly twenty characters, a gauge that wants a number in `[0,1]`, and no capacity for a paragraph that ran a little long.

This adds `structured_payload` as a third tier, built so it is one of many rather than a one-off.

A declaration names a **target** from a new registry (`internal/model/outputtargets`) describing one renderable surface: named slots, their kinds, their rune budgets, and which slot is primary. That single definition becomes three things at once:

- the JSON schema the generated `set_output_*` tool advertises, so the model sees `title (string, max 18 characters)` rather than a free-text field;
- the validator the handler runs;
- the slot contract rendered into the loop's context each iteration, alongside the last published payload.

**Validation rejects rather than repairs.** An over-budget string on a watch face is an unreadable fragment with nothing to signal that anything was dropped, so the handler returns an error naming the slot and the limit. Only whitespace and color-hex casing are canonicalized. Every call replaces the whole payload — a surface with no history has no meaningful partial update.

**Payloads publish over MQTT as Home Assistant discovery sensors:** the primary slot becomes the state, the rest become JSON attributes, which keeps the downstream binding trivial. An entity-sourced complication then refreshes on the watch itself without the phone in range.

Two targets ship — `apple_watch.rectangular` and `apple_watch.circular`. Adding a third is adding a `Target` value; the loop layer, tool generation, and sink are unchanged.

```yaml
outputs:
  - name: watch_status
    type: structured_payload
    target: apple_watch.rectangular
    ref: mqtt:watch_status      # → sensor.<device>_watch_status
```

Supporting changes: `mqtt.Publisher` gains `EnsureSensor` for runtime discovery registration (loops hydrate long after `Start`, where `RegisterSensors` no longer takes effect), and `ObjectIDPrefix` is exported as a function so an entity ID can be predicted before a publisher exists.

Teaching pass per `docs/model-facing-tools.md`: the loop spec output schema, the `loops` talent, the `agent-loop` and `document-roots` docs that said only two shapes exist, the tool reference, and a new `docs/understanding/defined-outputs.md`.

## Test Plan

- [x] `just ci` passes locally
- [x] New/changed behavior has test coverage
- [x] Manual verification (describe what you checked):

`just ci` is clean through `fmt-check`, `mod-tidy-check`, `config-generate-check`, `architecture-check`, `lint` (0 issues), and `lint-openapi`. `link-check` skipped locally (lychee not on PATH; CI enforces it).

`just test` leaves 24 failures, all of which reproduce identically on a clean `main` checkout — commit-signing tests (SSH allowed-signers not configured in this container) and one root-user permission test (`TestStoreMoveRestoresOverwrittenDestinationWhenSourceRemovalFails`, where a chmod-denied directory does not block root). Verified by diffing the failure sets with and without this branch: identical, 24 vs 24. This change introduces no new failures.

New coverage:

- `internal/model/outputtargets` — registry coherence (every target has a summary, binding text, exactly one required text primary slot, lower_snake_case slot names), `validate` rejection table, schema shape and advisory-ness, `Normalize` success and teaching-error tables including multibyte budgets, `json.Number`/string/int fraction coercion, explicit-null clearing, and runnable `Example` tests.
- `internal/runtime/loop` — `structured_payload` validation: mode/type pairing, missing and unknown target, target on a document output, document ref for a structured payload, entity-suffix grammar, and JSON round-tripping of the new `target` field.
- `internal/app` — tool generation against a fake sink: schema advertises every slot, payload normalization reaches the sink canonicalized, rejected payloads never reach the sink, sink failures surface to the model, hydration fails without MQTT configured, and the context block carries the contract plus last-published state and freshness delta.

## Checklist

- [x] Commits are signed
- [x] Commit messages use conventional format (`feat:`, `fix:`, etc.)
- [ ] Related issue referenced (`Refs #NNN` or `Closes #NNN`) — no existing issue found for this work
- [x] Impacted documentation updated (`docs/`, `AGENTS.md`, config examples, CLI help)
- [x] No new third-party dependencies without discussion

## Notes for review

- **Colors are best-effort by design.** An entity-sourced complication cannot template its colors — only a template-sourced one can, reading the same attributes. And watchOS renders on-face complications in the face's accent palette, so expect full fidelity in the Smart Stack and a tinted approximation on the face itself. The slot descriptions say this; the gauge *fill level* is the reliable on-face signal.
- **The last-published record is in-process only.** MQTT retains the payload on the broker, so a restarted Thane has a display it has not written to yet. The context block says so explicitly rather than leaving the absence ambiguous.
- **Rune budgets are deliberately tighter than what the widget accepts.** The `accessoryRectangular` slot on the Modular Ultra face clips earlier than on other faces, so the budgets target "fits everywhere" over "fits the roomiest face."
- `scripts/architecture.baseline` bumped for the new package (64→65) and the sink interface (84→85).

---
_Generated by [Claude Code](https://claude.ai/code/session_01BW8rCYUvE4PgnMAupvxeXb)_