### PR TITLE
One publish, every projection: the tiered output tool and working notes (#1250 phase 1)

### DIFF
--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -239,10 +239,10 @@ or signed deltas like `-604800s`.
 | `doc_journal_update` | Append or update a journal-style entry. |
 
 Loop-declared document output tools are request-scoped and do not appear
-in the global catalog above. When a loop declares a maintained document
-or journal document output, Thane generates tools such as
-`replace_output_metacognitive_state` or `append_output_daily_notes` only
-for that loop run. These tools route through managed document roots, so
+in the global catalog above. When a loop declares an output, Thane
+generates a tool such as `replace_output_metacognitive_state`,
+`append_output_daily_notes`, or — for a maintained document that declares
+`tiers` — `publish_output_office_status`, only for that loop run. These tools route through managed document roots, so
 root policy, indexing, and provenance remain centralized instead of
 being reimplemented in each loop prompt.
 

--- a/docs/understanding/agent-loop.md
+++ b/docs/understanding/agent-loop.md
@@ -111,12 +111,22 @@ definition. A declared output is an explicit contract: this loop is
 responsible for maintaining or appending to this document, and Thane
 generates the narrow tool surface for that job at runtime.
 
-Two output shapes exist today:
+Output shapes available today:
 
 - **Maintained document** outputs replace the whole current document
   through a generated `replace_output_<name>` tool.
 - **Journal document** outputs append a timestamped entry through a
   generated `append_output_<name>` tool.
+- **Tiered maintained document** outputs — a maintained document that
+  declares `tiers` — publish condensed projections alongside the full
+  body through a generated `publish_output_<name>` tool, one argument
+  per projection. Thane renders the document's sections, enforces a
+  per-projection size budget, and can parse the document back into the
+  projections it was published from.
+- **Working notes** outputs are a loop's private append-only process
+  log. They are internal-audience: excluded from document search and
+  from tagged-guidance injection, though the operator and the archive
+  still see them.
 
 The same declaration also feeds context assembly. Each turn receives a
 `Declared Durable Outputs` block with the output name, document root

--- a/docs/understanding/document-roots.md
+++ b/docs/understanding/document-roots.md
@@ -266,8 +266,13 @@ runtime tools:
 
 - `replace_output_<name>` for a maintained document that should be
   rewritten as a complete current state.
-- `append_output_<name>` for a journal document that should receive new
-  entries over time.
+- `append_output_<name>` for a journal document, or for a working-notes
+  document, that should receive new entries over time.
+- `publish_output_<name>` for a maintained document that declares
+  `tiers`: one typed argument per published projection
+  (`status_line`, `teaser`, `digest`) plus the full body, written
+  together in a single call. Thane renders the document sections from
+  the payload, so the loop supplies content and never structure.
 
 The loop sees a matching context block with the current document content
 or recent journal tail, so the document itself remains the durable source

--- a/internal/app/loop_output_publish.go
+++ b/internal/app/loop_output_publish.go
@@ -172,9 +172,9 @@ func loopOutputAudienceFrontmatter(output looppkg.OutputSpec) map[string][]strin
 	}
 }
 
-// findWorkingNotesOutput returns the loop's internal-audience journal
-// output, if it declared one. A loop may declare at most one working
-// notes surface; the first is used when several are present.
+// findWorkingNotesOutput returns the loop's working-notes output, if it
+// declared one. Spec validation permits at most one, so the first match
+// is the only match.
 func findWorkingNotesOutput(outputs []looppkg.OutputSpec) *looppkg.OutputSpec {
 	for i := range outputs {
 		if outputs[i].Type == looppkg.OutputTypeWorkingNotes {

--- a/internal/app/loop_output_publish.go
+++ b/internal/app/loop_output_publish.go
@@ -1,0 +1,185 @@
+package app
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	looppkg "github.com/nugget/thane-ai-agent/internal/runtime/loop"
+	"github.com/nugget/thane-ai-agent/internal/state/documents"
+)
+
+// Frontmatter keys stamped on loop-managed documents. audience is the
+// document layer's projection gate (an internal document stays out of
+// search results and tagged-guidance injection); managed_by records
+// which generated tool owns the document's structure, so a later edit
+// arriving through a general document tool can be pointed back at the
+// owning interface instead of silently competing with it.
+const (
+	loopOutputAudienceKey  = "audience"
+	loopOutputManagedByKey = "managed_by"
+)
+
+// buildTieredPublishTool generates the publish interface for one tiered
+// maintained document. The tool advertises one typed argument per
+// declared projection plus the full body, validates the whole payload
+// before writing anything, and renders the document itself — the model
+// supplies content, never structure.
+//
+// notes is the loop's declared working-notes output when it has one.
+// Its presence adds the optional note argument, so the argument exists
+// only when there is somewhere for the note to land.
+func buildTieredPublishTool(store *documents.Store, output looppkg.OutputSpec, notes *looppkg.OutputSpec) looppkg.RuntimeTool {
+	fields := output.TierFields()
+	properties := make(map[string]any, len(fields)+1)
+	required := make([]string, 0, len(fields))
+	for _, field := range fields {
+		description := field.Guidance
+		if field.MaxRunes > 0 {
+			description = fmt.Sprintf("%s Maximum %d characters.", description, field.MaxRunes)
+		}
+		properties[field.Key] = map[string]any{
+			"type":        "string",
+			"description": description,
+		}
+		required = append(required, field.Key)
+	}
+	if notes != nil {
+		properties["note"] = map[string]any{
+			"type":        "string",
+			"description": fmt.Sprintf("Optional: why this publish changed what it changed. Appended as a timestamped entry to this loop's working notes (%s) in the same call — the private record of how this understanding evolved, which no consumer surface reads. Revision history already records what changed; this is for why.", notes.Ref),
+		}
+	}
+
+	return looppkg.RuntimeTool{
+		Name:               output.ToolName(),
+		Description:        tieredPublishDescription(output, notes),
+		SkipContentResolve: true,
+		Parameters: map[string]any{
+			"type":       "object",
+			"properties": properties,
+			"required":   required,
+		},
+		Handler: func(ctx context.Context, args map[string]any) (string, error) {
+			payload, err := tierPayloadFromArgs(output, args)
+			if err != nil {
+				return "", err
+			}
+			if err := output.ValidateTierPayload(payload); err != nil {
+				return "", err
+			}
+			body := output.RenderTierDocument(payload)
+			result, err := store.Write(ctx, documents.WriteArgs{
+				Ref:  output.Ref,
+				Body: &body,
+				Frontmatter: map[string][]string{
+					loopOutputAudienceKey:  {string(output.EffectiveAudience())},
+					loopOutputManagedByKey: {output.ToolName()},
+				},
+			})
+			if err != nil {
+				return "", err
+			}
+
+			published := map[string]any{"published": result}
+			if note, _ := args["note"].(string); strings.TrimSpace(note) != "" && notes != nil {
+				noteResult, noteErr := appendLoopWorkingNote(ctx, store, *notes, note)
+				switch {
+				case noteErr != nil:
+					// The document publish already succeeded, so this is
+					// not a failed call to retry: report the partial
+					// outcome instead of an error that would invite a
+					// duplicate publish.
+					published["note_error"] = fmt.Sprintf("%s was published, but the working note was not recorded: %v", output.Ref, noteErr)
+				default:
+					published["note_recorded"] = noteResult
+				}
+			}
+			return marshalLoopOutputToolResult(published)
+		},
+	}
+}
+
+// tieredPublishDescription frames the publish interface for the model:
+// what it owns, that structure is not the model's job, and that the
+// projections move together.
+func tieredPublishDescription(output looppkg.OutputSpec, notes *looppkg.OutputSpec) string {
+	keys := make([]string, 0, 4)
+	for _, field := range output.TierFields() {
+		keys = append(keys, field.Key)
+	}
+	description := fmt.Sprintf(
+		"Publish the loop-declared output %q at %s. Pass every projection in one call (%s): they are written together so no reader sees one projection describing a state another has moved past. Section structure and headings are rendered automatically — pass only the content of each projection, never its heading. Each projection has its own size budget and an over-budget value is rejected rather than trimmed.",
+		output.Name, output.Ref, strings.Join(keys, ", "),
+	)
+	if notes != nil {
+		description += " Pass note to record why this publish changed what it changed into the loop's working notes."
+	}
+	return description
+}
+
+// tierPayloadFromArgs reads the publish arguments into a payload,
+// rejecting a non-string value with the argument name rather than
+// silently treating it as empty.
+func tierPayloadFromArgs(output looppkg.OutputSpec, args map[string]any) (looppkg.TierPayload, error) {
+	var payload looppkg.TierPayload
+	for _, field := range output.TierFields() {
+		raw, present := args[field.Key]
+		if !present {
+			continue
+		}
+		value, ok := raw.(string)
+		if !ok {
+			return looppkg.TierPayload{}, fmt.Errorf("%s must be a string", field.Key)
+		}
+		switch field.Key {
+		case "status_line":
+			payload.StatusLine = value
+		case "teaser":
+			payload.Teaser = value
+		case "digest":
+			payload.Digest = value
+		case "full":
+			payload.Full = value
+		}
+	}
+	return payload, nil
+}
+
+// appendLoopWorkingNote appends one entry to a working-notes output,
+// stamping the audience that keeps it out of consumer surfaces.
+func appendLoopWorkingNote(ctx context.Context, store *documents.Store, notes looppkg.OutputSpec, entry string) (*documents.MutationResult, error) {
+	return store.JournalUpdate(ctx, documents.JournalUpdateArgs{
+		Ref:         notes.Ref,
+		Entry:       entry,
+		Window:      notes.JournalWindow,
+		MaxWindows:  notes.MaxWindows,
+		Frontmatter: loopOutputAudienceFrontmatter(notes),
+	})
+}
+
+// loopOutputAudienceFrontmatter returns the audience stamp for an
+// output's document, or nil when the output is published (the document
+// layer's default). Stamping internal is what makes an internal
+// declaration real: the exclusion in search and tagged-guidance
+// injection reads this key, not the loop spec.
+func loopOutputAudienceFrontmatter(output looppkg.OutputSpec) map[string][]string {
+	if output.EffectiveAudience() != looppkg.OutputAudienceInternal {
+		return nil
+	}
+	return map[string][]string{
+		loopOutputAudienceKey: {string(looppkg.OutputAudienceInternal)},
+	}
+}
+
+// findWorkingNotesOutput returns the loop's internal-audience journal
+// output, if it declared one. A loop may declare at most one working
+// notes surface; the first is used when several are present.
+func findWorkingNotesOutput(outputs []looppkg.OutputSpec) *looppkg.OutputSpec {
+	for i := range outputs {
+		if outputs[i].Type == looppkg.OutputTypeWorkingNotes {
+			return &outputs[i]
+		}
+	}
+	return nil
+}

--- a/internal/app/loop_output_publish_test.go
+++ b/internal/app/loop_output_publish_test.go
@@ -1,0 +1,350 @@
+package app
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	looppkg "github.com/nugget/thane-ai-agent/internal/runtime/loop"
+	"github.com/nugget/thane-ai-agent/internal/state/documents"
+)
+
+func tieredSpec() looppkg.Spec {
+	return looppkg.Spec{
+		Name:       "ranch_office",
+		Enabled:    true,
+		Task:       "Curate the office domain.",
+		Operation:  looppkg.OperationService,
+		Completion: looppkg.CompletionNone,
+		Outputs: []looppkg.OutputSpec{
+			{
+				Name:  "office status",
+				Type:  looppkg.OutputTypeMaintainedDocument,
+				Ref:   "core:office.md",
+				Tiers: []looppkg.OutputTier{looppkg.OutputTierStatusLine, looppkg.OutputTierTeaser},
+			},
+			{
+				Name:          "office notes",
+				Type:          looppkg.OutputTypeWorkingNotes,
+				Ref:           "core:office-notes.md",
+				JournalWindow: "month",
+				MaxWindows:    6,
+			},
+		},
+	}
+}
+
+func findRuntimeTool(t *testing.T, spec looppkg.Spec, name string) looppkg.RuntimeTool {
+	t.Helper()
+	for _, tool := range spec.RuntimeTools {
+		if tool.Name == name {
+			return tool
+		}
+	}
+	t.Fatalf("runtime tool %q not generated; got %d tools", name, len(spec.RuntimeTools))
+	return looppkg.RuntimeTool{}
+}
+
+func TestTieredOutputGeneratesPublishToolWithTypedProjections(t *testing.T) {
+	t.Parallel()
+
+	store, _ := newLoopOutputDocumentStore(t)
+	app := &App{documentStore: store}
+
+	hydrated, err := app.hydrateLoopOutputs(tieredSpec())
+	if err != nil {
+		t.Fatalf("hydrateLoopOutputs: %v", err)
+	}
+
+	publish := findRuntimeTool(t, hydrated, "publish_output_office_status")
+	props, _ := publish.Parameters["properties"].(map[string]any)
+	for _, key := range []string{"status_line", "teaser", "full", "note"} {
+		if _, ok := props[key]; !ok {
+			t.Fatalf("publish tool schema missing %q argument; got %v", key, props)
+		}
+	}
+	if _, ok := props["digest"]; ok {
+		t.Fatal("publish tool advertises digest, which this output does not declare")
+	}
+
+	required, _ := publish.Parameters["required"].([]string)
+	if strings.Join(required, ",") != "status_line,teaser,full" {
+		t.Fatalf("required = %v, want the declared projections and full but not note", required)
+	}
+	if !strings.Contains(props["status_line"].(map[string]any)["description"].(string), "120 characters") {
+		t.Fatalf("status_line description should state its budget: %v", props["status_line"])
+	}
+}
+
+func TestPublishToolWithoutWorkingNotesOmitsNoteArgument(t *testing.T) {
+	t.Parallel()
+
+	store, _ := newLoopOutputDocumentStore(t)
+	app := &App{documentStore: store}
+	spec := tieredSpec()
+	spec.Outputs = spec.Outputs[:1] // drop the working-notes declaration
+
+	hydrated, err := app.hydrateLoopOutputs(spec)
+	if err != nil {
+		t.Fatalf("hydrateLoopOutputs: %v", err)
+	}
+	publish := findRuntimeTool(t, hydrated, "publish_output_office_status")
+	props, _ := publish.Parameters["properties"].(map[string]any)
+	if _, ok := props["note"]; ok {
+		t.Fatal("note argument advertised with no working-notes output to receive it")
+	}
+}
+
+func TestPublishToolRendersDocumentAndStampsFrontmatter(t *testing.T) {
+	t.Parallel()
+
+	store, coreDir := newLoopOutputDocumentStore(t)
+	app := &App{documentStore: store}
+	hydrated, err := app.hydrateLoopOutputs(tieredSpec())
+	if err != nil {
+		t.Fatalf("hydrateLoopOutputs: %v", err)
+	}
+	publish := findRuntimeTool(t, hydrated, "publish_output_office_status")
+
+	if _, err := publish.Handler(context.Background(), map[string]any{
+		"status_line": "Printer online; 2 packages waiting.",
+		"teaser":      "The desk is clear but two deliveries need signing.",
+		"full":        "# Office\n\n### Deliveries\n\nTwo packages.",
+	}); err != nil {
+		t.Fatalf("publish handler: %v", err)
+	}
+
+	raw, err := os.ReadFile(filepath.Join(coreDir, "office.md"))
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	written := string(raw)
+	for _, want := range []string{
+		"## Status Line",
+		"Printer online; 2 packages waiting.",
+		"## Teaser",
+		"## Details",
+	} {
+		if !strings.Contains(written, want) {
+			t.Fatalf("published document missing %q:\n%s", want, written)
+		}
+	}
+
+	// The document is the canonical store: parsing it back must yield
+	// exactly what was published.
+	doc, err := store.Read(context.Background(), "core:office.md")
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if got := firstFrontmatterValue(doc, "audience"); got != "published" {
+		t.Fatalf("audience frontmatter = %q, want published", got)
+	}
+	if got := firstFrontmatterValue(doc, "managed_by"); got != "publish_output_office_status" {
+		t.Fatalf("managed_by frontmatter = %q, want the publish tool name", got)
+	}
+	payload := looppkg.ParseTierDocument(doc.Body)
+	if payload.StatusLine != "Printer online; 2 packages waiting." {
+		t.Fatalf("re-parsed status line = %q", payload.StatusLine)
+	}
+	if payload.Full != "# Office\n\n### Deliveries\n\nTwo packages." {
+		t.Fatalf("re-parsed full = %q", payload.Full)
+	}
+}
+
+func TestPublishToolRejectsOverBudgetWithoutWriting(t *testing.T) {
+	t.Parallel()
+
+	store, coreDir := newLoopOutputDocumentStore(t)
+	app := &App{documentStore: store}
+	hydrated, err := app.hydrateLoopOutputs(tieredSpec())
+	if err != nil {
+		t.Fatalf("hydrateLoopOutputs: %v", err)
+	}
+	publish := findRuntimeTool(t, hydrated, "publish_output_office_status")
+
+	_, err = publish.Handler(context.Background(), map[string]any{
+		"status_line": strings.Repeat("x", 200),
+		"teaser":      "Fine.",
+		"full":        "Fine.",
+	})
+	if err == nil {
+		t.Fatal("publish handler error = nil for an over-budget status line")
+	}
+	if !strings.Contains(err.Error(), "the limit is 120") {
+		t.Fatalf("error should teach the budget: %v", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(coreDir, "office.md")); !os.IsNotExist(statErr) {
+		t.Fatal("a rejected publish must not write the document")
+	}
+}
+
+func TestPublishToolNoteAppendsInternalWorkingNotes(t *testing.T) {
+	t.Parallel()
+
+	store, coreDir := newLoopOutputDocumentStore(t)
+	app := &App{documentStore: store}
+	hydrated, err := app.hydrateLoopOutputs(tieredSpec())
+	if err != nil {
+		t.Fatalf("hydrateLoopOutputs: %v", err)
+	}
+	publish := findRuntimeTool(t, hydrated, "publish_output_office_status")
+
+	result, err := publish.Handler(context.Background(), map[string]any{
+		"status_line": "Printer online.",
+		"teaser":      "Nothing needs attention.",
+		"full":        "# Office\n\nAll quiet.",
+		"note":        "Dropped the delivery warning — both packages were signed for at 14:20.",
+	})
+	if err != nil {
+		t.Fatalf("publish handler: %v", err)
+	}
+	if !strings.Contains(result, "note_recorded") {
+		t.Fatalf("result should report the recorded note: %s", result)
+	}
+
+	raw, err := os.ReadFile(filepath.Join(coreDir, "office-notes.md"))
+	if err != nil {
+		t.Fatalf("ReadFile notes: %v", err)
+	}
+	notes := string(raw)
+	if !strings.Contains(notes, "both packages were signed for") {
+		t.Fatalf("working notes missing the entry:\n%s", notes)
+	}
+	// The audience stamp is what makes the notes document invisible to
+	// search and tagged-guidance injection.
+	notesDoc, err := store.Read(context.Background(), "core:office-notes.md")
+	if err != nil {
+		t.Fatalf("Read notes: %v", err)
+	}
+	if got := firstFrontmatterValue(notesDoc, "audience"); got != "internal" {
+		t.Fatalf("working notes audience = %q, want internal:\n%s", got, notes)
+	}
+
+	// The note must not leak into the published document.
+	published, err := os.ReadFile(filepath.Join(coreDir, "office.md"))
+	if err != nil {
+		t.Fatalf("ReadFile published: %v", err)
+	}
+	if strings.Contains(string(published), "signed for at 14:20") {
+		t.Fatalf("note content leaked into the published document:\n%s", string(published))
+	}
+}
+
+func TestWorkingNotesAppendToolStampsInternalAudience(t *testing.T) {
+	t.Parallel()
+
+	store, _ := newLoopOutputDocumentStore(t)
+	app := &App{documentStore: store}
+	hydrated, err := app.hydrateLoopOutputs(tieredSpec())
+	if err != nil {
+		t.Fatalf("hydrateLoopOutputs: %v", err)
+	}
+	appendNotes := findRuntimeTool(t, hydrated, "append_output_office_notes")
+	if !strings.Contains(appendNotes.Description, "private process log") {
+		t.Fatalf("working-notes tool should frame itself as private: %q", appendNotes.Description)
+	}
+
+	if _, err := appendNotes.Handler(context.Background(), map[string]any{
+		"entry": "Reconsidered the trough threshold.",
+	}); err != nil {
+		t.Fatalf("append notes handler: %v", err)
+	}
+	doc, err := store.Read(context.Background(), "core:office-notes.md")
+	if err != nil {
+		t.Fatalf("Read notes: %v", err)
+	}
+	if got := firstFrontmatterValue(doc, "audience"); got != "internal" {
+		t.Fatalf("direct working-notes append missing the internal stamp: audience = %q", got)
+	}
+}
+
+// firstFrontmatterValue reads one indexed frontmatter value — the same
+// shape the document layer's audience exclusion reads, rather than the
+// rendered YAML text.
+func firstFrontmatterValue(doc *documents.DocumentRecord, key string) string {
+	if doc == nil {
+		return ""
+	}
+	if values := doc.Frontmatter[key]; len(values) > 0 {
+		return values[0]
+	}
+	return ""
+}
+
+func TestJournalOutputDoesNotClaimInternalAudience(t *testing.T) {
+	t.Parallel()
+
+	store, _ := newLoopOutputDocumentStore(t)
+	app := &App{documentStore: store}
+	spec := tieredSpec()
+	spec.Outputs = []looppkg.OutputSpec{{
+		Name:          "office journal",
+		Type:          looppkg.OutputTypeJournalDocument,
+		Ref:           "core:office-journal.md",
+		JournalWindow: "day",
+	}}
+	hydrated, err := app.hydrateLoopOutputs(spec)
+	if err != nil {
+		t.Fatalf("hydrateLoopOutputs: %v", err)
+	}
+	appendJournal := findRuntimeTool(t, hydrated, "append_output_office_journal")
+	if _, err := appendJournal.Handler(context.Background(), map[string]any{"entry": "Ordinary entry."}); err != nil {
+		t.Fatalf("append journal handler: %v", err)
+	}
+	doc, err := store.Read(context.Background(), "core:office-journal.md")
+	if err != nil {
+		t.Fatalf("Read journal: %v", err)
+	}
+	if got := firstFrontmatterValue(doc, "audience"); got != "" {
+		t.Fatalf("a published journal must carry no audience stamp, got %q", got)
+	}
+}
+
+func TestTieredOutputContextAdvertisesProjections(t *testing.T) {
+	t.Parallel()
+
+	store, _ := newLoopOutputDocumentStore(t)
+	app := &App{documentStore: store}
+	hydrated, err := app.hydrateLoopOutputs(tieredSpec())
+	if err != nil {
+		t.Fatalf("hydrateLoopOutputs: %v", err)
+	}
+
+	block, err := hydrated.OutputContextBuilder(context.Background(), hydrated.Outputs)
+	if err != nil {
+		t.Fatalf("OutputContextBuilder: %v", err)
+	}
+	for _, want := range []string{
+		"publish_output_office_status",
+		`"status_line"`,
+		`"audience": "published"`,
+		`"audience": "internal"`,
+	} {
+		if !strings.Contains(block, want) {
+			t.Fatalf("output context missing %q:\n%s", want, block)
+		}
+	}
+}
+
+func TestPublishToolRejectsNonStringProjection(t *testing.T) {
+	t.Parallel()
+
+	store, _ := newLoopOutputDocumentStore(t)
+	app := &App{documentStore: store}
+	hydrated, err := app.hydrateLoopOutputs(tieredSpec())
+	if err != nil {
+		t.Fatalf("hydrateLoopOutputs: %v", err)
+	}
+	publish := findRuntimeTool(t, hydrated, "publish_output_office_status")
+
+	_, err = publish.Handler(context.Background(), map[string]any{
+		"status_line": 42,
+		"teaser":      "Fine.",
+		"full":        "Fine.",
+	})
+	if err == nil || !strings.Contains(err.Error(), "status_line must be a string") {
+		t.Fatalf("error = %v, want a typed argument error naming status_line", err)
+	}
+}

--- a/internal/app/loop_output_publish_test.go
+++ b/internal/app/loop_output_publish_test.go
@@ -348,3 +348,30 @@ func TestPublishToolRejectsNonStringProjection(t *testing.T) {
 		t.Fatalf("error = %v, want a typed argument error naming status_line", err)
 	}
 }
+
+func TestTieredOutputContextReportsPublishMode(t *testing.T) {
+	t.Parallel()
+
+	store, _ := newLoopOutputDocumentStore(t)
+	app := &App{documentStore: store}
+	hydrated, err := app.hydrateLoopOutputs(tieredSpec())
+	if err != nil {
+		t.Fatalf("hydrateLoopOutputs: %v", err)
+	}
+	block, err := hydrated.OutputContextBuilder(context.Background(), hydrated.Outputs)
+	if err != nil {
+		t.Fatalf("OutputContextBuilder: %v", err)
+	}
+	// A tiered output advertises publish_output_*, so pairing it with
+	// the spec-level replace mode would describe a call that does not
+	// exist for this output.
+	if !strings.Contains(block, `"mode": "publish"`) {
+		t.Fatalf("tiered output context should report publish mode:\n%s", block)
+	}
+	if strings.Contains(block, `"mode": "replace"`) {
+		t.Fatalf("tiered output context still reports replace mode:\n%s", block)
+	}
+	if !strings.Contains(block, `"mode": "append"`) {
+		t.Fatalf("working-notes output should still report append mode:\n%s", block)
+	}
+}

--- a/internal/app/loop_outputs.go
+++ b/internal/app/loop_outputs.go
@@ -174,7 +174,7 @@ func renderLoopOutputContextWithNow(ctx context.Context, store *documents.Store,
 		entry := loopOutputContextEntry{
 			Name:      output.Name,
 			Type:      string(output.Type),
-			Mode:      string(output.EffectiveMode()),
+			Mode:      loopOutputContextMode(output),
 			Ref:       output.Ref,
 			Purpose:   output.Purpose,
 			ToolName:  output.ToolName(),
@@ -261,6 +261,20 @@ func outputInterfaceDescription(output looppkg.OutputSpec) string {
 	default:
 		return "Use the generated output tool for this declaration."
 	}
+}
+
+// loopOutputContextMode reports the write interface the model actually
+// has for this output. A tiered output's spec-level mode is still
+// replace — tiers are the only declaration, so there is no authorable
+// publish mode to contradict — but its generated tool takes projections
+// rather than a document body. Reporting the spec mode here would pair
+// "publish_output_*" with "mode: replace" in the same context block and
+// leave the model to guess which one describes the call it should make.
+func loopOutputContextMode(output looppkg.OutputSpec) string {
+	if output.IsTiered() {
+		return "publish"
+	}
+	return string(output.EffectiveMode())
 }
 
 // appendOutputDescription frames an append-mode output for the model.

--- a/internal/app/loop_outputs.go
+++ b/internal/app/loop_outputs.go
@@ -44,6 +44,8 @@ type loopOutputContextEntry struct {
 	BytesTotal       int                `json:"bytes_total,omitempty"`
 	UnavailableError string             `json:"unavailable_error,omitempty"`
 	Journal          *loopOutputJournal `json:"journal,omitempty"`
+	Tiers            []string           `json:"tiers,omitempty"`
+	Audience         string             `json:"audience,omitempty"`
 }
 
 type loopOutputJournal struct {
@@ -76,8 +78,15 @@ func buildLoopOutputTools(store *documents.Store, outputs []looppkg.OutputSpec) 
 		return nil
 	}
 	out := make([]looppkg.RuntimeTool, 0, len(outputs))
+	notes := findWorkingNotesOutput(outputs)
 	for _, output := range outputs {
 		output := output
+		if output.IsTiered() {
+			// A tiered output's interface is a set of typed projections,
+			// so it gets the publish tool instead of a body-blob replace.
+			out = append(out, buildTieredPublishTool(store, output, notes))
+			continue
+		}
 		switch output.EffectiveMode() {
 		case looppkg.OutputModeReplace:
 			out = append(out, looppkg.RuntimeTool{
@@ -118,7 +127,7 @@ func buildLoopOutputTools(store *documents.Store, outputs []looppkg.OutputSpec) 
 		case looppkg.OutputModeAppend:
 			out = append(out, looppkg.RuntimeTool{
 				Name:               output.ToolName(),
-				Description:        fmt.Sprintf("Append to the loop-declared journal output %q at %s. Pass only the new journal entry; Thane stamps, windows, prunes, indexes, and applies root policy.", output.Name, output.Ref),
+				Description:        appendOutputDescription(output),
 				SkipContentResolve: true,
 				Parameters: map[string]any{
 					"type": "object",
@@ -136,10 +145,11 @@ func buildLoopOutputTools(store *documents.Store, outputs []looppkg.OutputSpec) 
 						return "", fmt.Errorf("entry is required")
 					}
 					result, err := store.JournalUpdate(ctx, documents.JournalUpdateArgs{
-						Ref:        output.Ref,
-						Entry:      entry,
-						Window:     output.JournalWindow,
-						MaxWindows: output.MaxWindows,
+						Ref:         output.Ref,
+						Entry:       entry,
+						Window:      output.JournalWindow,
+						MaxWindows:  output.MaxWindows,
+						Frontmatter: loopOutputAudienceFrontmatter(output),
 					})
 					if err != nil {
 						return "", err
@@ -170,6 +180,10 @@ func renderLoopOutputContextWithNow(ctx context.Context, store *documents.Store,
 			ToolName:  output.ToolName(),
 			Policy:    "Write only through the generated output tool. The managed document root handles path safety, indexing, provenance, and signature policy.",
 			Interface: outputInterfaceDescription(output),
+			Audience:  string(output.EffectiveAudience()),
+		}
+		for _, field := range output.TierFields() {
+			entry.Tiers = append(entry.Tiers, field.Key)
 		}
 		if output.Type == looppkg.OutputTypeJournalDocument || output.Type == looppkg.OutputTypeWorkingNotes {
 			entry.Journal = &loopOutputJournal{
@@ -232,6 +246,13 @@ func loopOutputDelta(value string, now time.Time) string {
 }
 
 func outputInterfaceDescription(output looppkg.OutputSpec) string {
+	if output.IsTiered() {
+		keys := make([]string, 0, 4)
+		for _, field := range output.TierFields() {
+			keys = append(keys, field.Key)
+		}
+		return "Call " + output.ToolName() + " with every projection in one call (" + strings.Join(keys, ", ") + "). Headings are rendered for you; each projection has its own size budget."
+	}
 	switch output.EffectiveMode() {
 	case looppkg.OutputModeReplace:
 		return "Call " + output.ToolName() + " with complete replacement markdown content for this maintained document."
@@ -240,6 +261,18 @@ func outputInterfaceDescription(output looppkg.OutputSpec) string {
 	default:
 		return "Use the generated output tool for this declaration."
 	}
+}
+
+// appendOutputDescription frames an append-mode output for the model.
+// Working notes get their own framing: the value of a private process
+// log is that it holds the reasoning a published document should not
+// carry, and a model that thinks it is writing another public surface
+// will not write that.
+func appendOutputDescription(output looppkg.OutputSpec) string {
+	if output.Type == looppkg.OutputTypeWorkingNotes {
+		return fmt.Sprintf("Append to this loop's working notes %q at %s — the loop's private process log. Record how the understanding is evolving: what changed and why, what drifted, what was refined, what is worth remembering later. No consumer surface reads it: it stays out of search results and out of other loops' context, so write the reasoning that would clutter a published document. Pass only the new entry; Thane stamps, windows, prunes, and indexes.", output.Name, output.Ref)
+	}
+	return fmt.Sprintf("Append to the loop-declared journal output %q at %s. Pass only the new journal entry; Thane stamps, windows, prunes, indexes, and applies root policy.", output.Name, output.Ref)
 }
 
 func truncateLoopOutputText(s string, maxBytes int, tail bool) (string, bool, int, int) {

--- a/internal/runtime/loop/output.go
+++ b/internal/runtime/loop/output.go
@@ -258,9 +258,22 @@ func validateOutputTiers(o OutputSpec) error {
 func validateOutputs(outputs []OutputSpec) error {
 	seenNames := make(map[string]struct{}, len(outputs))
 	seenTools := make(map[string]struct{}, len(outputs))
+	workingNotes := ""
 	for i, output := range outputs {
 		if err := output.Validate(); err != nil {
 			return fmt.Errorf("outputs[%d]: %w", i, err)
+		}
+		if output.Type == OutputTypeWorkingNotes {
+			// One private log per loop: the note argument on a tiered
+			// publish writes to "the" working notes, and a second
+			// declaration would make that target an arbitrary pick
+			// between two documents. A loop that wants another private
+			// journal can declare journal_document with
+			// audience: internal, which carries no such implicit target.
+			if workingNotes != "" {
+				return fmt.Errorf("outputs[%d]: loop already declares the working_notes output %q; a loop has one private log, so declare additional private journals as journal_document with audience: %q", i, workingNotes, OutputAudienceInternal)
+			}
+			workingNotes = output.Name
 		}
 		nameKey := strings.ToLower(strings.TrimSpace(output.Name))
 		if _, exists := seenNames[nameKey]; exists {

--- a/internal/runtime/loop/output.go
+++ b/internal/runtime/loop/output.go
@@ -146,8 +146,13 @@ func (o OutputSpec) EffectiveAudience() OutputAudience {
 }
 
 // ToolName returns the scoped mutation tool name generated for this
-// output declaration.
+// output declaration. A tiered output gets a publish verb rather than a
+// replace verb because its interface is a set of typed projections, not
+// a document body.
 func (o OutputSpec) ToolName() string {
+	if o.IsTiered() {
+		return "publish_output_" + safeOutputToolSuffix(o.Name)
+	}
 	switch o.EffectiveMode() {
 	case OutputModeReplace:
 		return "replace_output_" + safeOutputToolSuffix(o.Name)

--- a/internal/runtime/loop/output_test.go
+++ b/internal/runtime/loop/output_test.go
@@ -135,14 +135,14 @@ func TestOutputSpecValidateAndToolName(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "tiered maintained document valid",
+			name: "tiered maintained document publishes projections",
 			output: OutputSpec{
 				Name:  "ranch status",
 				Type:  OutputTypeMaintainedDocument,
 				Ref:   "core:ranch.md",
 				Tiers: []OutputTier{OutputTierStatusLine, OutputTierTeaser, OutputTierDigest},
 			},
-			wantTool: "replace_output_ranch_status",
+			wantTool: "publish_output_ranch_status",
 		},
 		{
 			name: "status line alone anchors the ladder",
@@ -152,7 +152,7 @@ func TestOutputSpecValidateAndToolName(t *testing.T) {
 				Ref:   "core:ranch.md",
 				Tiers: []OutputTier{OutputTierStatusLine},
 			},
-			wantTool: "replace_output_ranch_status",
+			wantTool: "publish_output_ranch_status",
 		},
 		{
 			name: "tiers without status line rejected",
@@ -371,8 +371,8 @@ func TestSpecJSONRoundTripIncludesOutputs(t *testing.T) {
 	if len(got.Outputs) != 2 {
 		t.Fatalf("Outputs len = %d, want 2", len(got.Outputs))
 	}
-	if got.Outputs[0].ToolName() != "replace_output_status" {
-		t.Fatalf("output tool = %q, want replace_output_status", got.Outputs[0].ToolName())
+	if got.Outputs[0].ToolName() != "publish_output_status" {
+		t.Fatalf("output tool = %q, want publish_output_status for a tiered output", got.Outputs[0].ToolName())
 	}
 	if len(got.Outputs[0].Tiers) != 2 || got.Outputs[0].Tiers[0] != OutputTierStatusLine {
 		t.Fatalf("round-tripped tiers = %v, want [status_line teaser]", got.Outputs[0].Tiers)

--- a/internal/runtime/loop/output_tiers.go
+++ b/internal/runtime/loop/output_tiers.go
@@ -1,0 +1,277 @@
+package loop
+
+import (
+	"fmt"
+	"strings"
+	"unicode/utf8"
+)
+
+// Rune budgets for the published projection tiers. They are display
+// budgets, not storage limits: each one is the size at which that
+// projection still fits the surfaces that consume it — a fleet overview
+// row, a search snippet, a subscription digest. Overflow is rejected
+// rather than clipped, because a clipped projection is an unreadable
+// fragment with nothing to signal that anything was dropped.
+const (
+	statusLineMaxRunes = 120
+	teaserMaxRunes     = 500
+	digestMaxRunes     = 2048
+)
+
+// TierPayload is one complete published projection set for a tiered
+// maintained document. Every publish carries the whole payload: a
+// rendered document shows exactly the last publish, so a partially
+// updated payload would leave one projection describing a state the
+// others have moved past.
+type TierPayload struct {
+	StatusLine string
+	Teaser     string
+	Digest     string
+	Full       string
+}
+
+// TierField describes one publishable field of a tiered output, as the
+// generated publish tool advertises it to the model.
+type TierField struct {
+	// Key is the tool argument name.
+	Key string
+	// MaxRunes is the display budget in runes; zero is unbounded.
+	MaxRunes int
+	// SingleLine marks a field that must not contain line breaks.
+	SingleLine bool
+	// Guidance is the model-facing description of what this field is
+	// for and where it surfaces.
+	Guidance string
+}
+
+// tierSection binds one projection to its canonical document section and
+// its budget.
+type tierSection struct {
+	// Tier is the declared tier this section publishes, or empty for
+	// the always-present full projection.
+	Tier    OutputTier
+	Field   TierField
+	Heading string
+	value   func(*TierPayload) *string
+}
+
+// tierSections is the single source of truth for the publish tool's
+// schema, the payload validator, the document renderer, and the parser
+// that reads a rendered document back — so those four cannot drift
+// apart. Order is the canonical ladder order; declaration order in a
+// spec's tiers list carries no meaning.
+var tierSections = []tierSection{
+	{
+		Tier:    OutputTierStatusLine,
+		Heading: "Status Line",
+		Field: TierField{
+			Key:        "status_line",
+			MaxRunes:   statusLineMaxRunes,
+			SingleLine: true,
+			Guidance:   "One standalone line of current state, no line breaks. Reads as an ambient status: what is true right now. This is the only thing some surfaces show, so it must stand alone without the document around it.",
+		},
+		value: func(p *TierPayload) *string { return &p.StatusLine },
+	},
+	{
+		Tier:    OutputTierTeaser,
+		Heading: "Teaser",
+		Field: TierField{
+			Key:      "teaser",
+			MaxRunes: teaserMaxRunes,
+			Guidance: "One short paragraph on why a reader would open this document right now. Surfaces as the snippet in search results and cross-references, so write the hook — the reason to look — rather than a compressed summary.",
+		},
+		value: func(p *TierPayload) *string { return &p.Teaser },
+	},
+	{
+		Tier:    OutputTierDigest,
+		Heading: "Digest",
+		Field: TierField{
+			Key:      "digest",
+			MaxRunes: digestMaxRunes,
+			Guidance: "A standalone summary carrying enough substance to act on without opening the full document. Surfaces in subscription rows and periodic digests.",
+		},
+		value: func(p *TierPayload) *string { return &p.Digest },
+	},
+	{
+		Heading: "Details",
+		Field: TierField{
+			Key:      "full",
+			Guidance: "The complete current state in markdown. This is what a reader opens when the digest is not enough. Always required: it is the document's substance, and the other projections are views of it.",
+		},
+		value: func(p *TierPayload) *string { return &p.Full },
+	},
+}
+
+// TierFields returns the fields a tiered output publishes, in canonical
+// ladder order: each declared tier, then the always-present full
+// projection. Every returned field is required at publish time —
+// optionality lives in the declaration (a spec may declare only
+// status_line), not in the write.
+func (o OutputSpec) TierFields() []TierField {
+	if len(o.Tiers) == 0 {
+		return nil
+	}
+	declared := make(map[OutputTier]struct{}, len(o.Tiers))
+	for _, tier := range o.Tiers {
+		declared[tier] = struct{}{}
+	}
+	fields := make([]TierField, 0, len(o.Tiers)+1)
+	for _, section := range tierSections {
+		if section.Tier == "" {
+			fields = append(fields, section.Field)
+			continue
+		}
+		if _, ok := declared[section.Tier]; ok {
+			fields = append(fields, section.Field)
+		}
+	}
+	return fields
+}
+
+// IsTiered reports whether this output publishes through the tiered
+// projection contract rather than a whole-body replacement.
+func (o OutputSpec) IsTiered() bool {
+	return o.Type == OutputTypeMaintainedDocument && len(o.Tiers) > 0
+}
+
+// ValidateTierPayload checks one payload against the output's declared
+// ladder. Errors name the field, the limit, and the observed size so the
+// model can correct the offending projection in one more attempt without
+// re-deriving the whole payload.
+func (o OutputSpec) ValidateTierPayload(payload TierPayload) error {
+	if !o.IsTiered() {
+		return fmt.Errorf("output %q does not declare tiers", o.Name)
+	}
+	for _, field := range o.TierFields() {
+		section, ok := tierSectionByKey(field.Key)
+		if !ok {
+			continue
+		}
+		value := strings.TrimSpace(*section.value(&payload))
+		if value == "" {
+			return fmt.Errorf("%s is required; every declared projection is published together so they cannot describe different moments", field.Key)
+		}
+		if field.SingleLine && strings.ContainsAny(value, "\r\n") {
+			return fmt.Errorf("%s must be a single line with no line breaks; it renders as one row on surfaces that show nothing else", field.Key)
+		}
+		if field.MaxRunes > 0 {
+			if runes := utf8.RuneCountInString(value); runes > field.MaxRunes {
+				return fmt.Errorf("%s is %d characters and the limit is %d; tighten it rather than letting it be cut, because a clipped projection reads as a fragment with no sign that anything is missing", field.Key, runes, field.MaxRunes)
+			}
+		}
+		if heading, found := firstReservedTierHeading(value); found {
+			return fmt.Errorf("%s contains the reserved section heading %q; the tier headings are rendered automatically from the contract, so publish only the content beneath them", field.Key, heading)
+		}
+	}
+	return nil
+}
+
+// RenderTierDocument renders a payload as the canonical document body:
+// one H2 section per published projection, in ladder order. Go owns this
+// structure so the model never authors the section convention and the
+// document stays parseable back into a payload.
+func (o OutputSpec) RenderTierDocument(payload TierPayload) string {
+	fields := o.TierFields()
+	published := make(map[string]struct{}, len(fields))
+	for _, field := range fields {
+		published[field.Key] = struct{}{}
+	}
+	blocks := make([]string, 0, len(fields))
+	for _, section := range tierSections {
+		if _, ok := published[section.Field.Key]; !ok {
+			continue
+		}
+		value := strings.TrimSpace(*section.value(&payload))
+		if value == "" {
+			continue
+		}
+		blocks = append(blocks, "## "+section.Heading+"\n\n"+value)
+	}
+	return strings.Join(blocks, "\n\n")
+}
+
+// ParseTierDocument reads a rendered document body back into a payload.
+// It is the inverse of [OutputSpec.RenderTierDocument] and the reason
+// the document is the canonical store: any derived binding — an
+// ambient rail, a published entity, a remote display — can be re-seeded
+// from the document alone after a restart.
+//
+// A body with no recognized tier sections parses entirely into Full,
+// which is what lets an existing untiered maintained document be adopted
+// into the tiered contract without losing its content. Content ahead of
+// the first recognized heading is folded into Full for the same reason.
+func ParseTierDocument(body string) TierPayload {
+	var payload TierPayload
+	var preamble []string
+	current := ""
+	collected := make(map[string][]string, len(tierSections))
+
+	for _, line := range strings.Split(body, "\n") {
+		if heading, ok := reservedTierHeadingOf(line); ok {
+			current = heading
+			continue
+		}
+		if current == "" {
+			preamble = append(preamble, line)
+			continue
+		}
+		collected[current] = append(collected[current], line)
+	}
+
+	for _, section := range tierSections {
+		lines, ok := collected[section.Heading]
+		if !ok {
+			continue
+		}
+		*section.value(&payload) = strings.TrimSpace(strings.Join(lines, "\n"))
+	}
+
+	if leading := strings.TrimSpace(strings.Join(preamble, "\n")); leading != "" {
+		if payload.Full == "" {
+			payload.Full = leading
+		} else {
+			payload.Full = leading + "\n\n" + payload.Full
+		}
+	}
+	return payload
+}
+
+// tierSectionByKey looks up the section table entry for a field key.
+func tierSectionByKey(key string) (tierSection, bool) {
+	for _, section := range tierSections {
+		if section.Field.Key == key {
+			return section, true
+		}
+	}
+	return tierSection{}, false
+}
+
+// reservedTierHeadingOf reports the canonical heading a line declares,
+// if the line is exactly one of the contract's H2 section headings.
+// Deeper headings inside a projection are ordinary content.
+func reservedTierHeadingOf(line string) (string, bool) {
+	trimmed := strings.TrimSpace(line)
+	if !strings.HasPrefix(trimmed, "## ") {
+		return "", false
+	}
+	text := strings.TrimSpace(strings.TrimPrefix(trimmed, "## "))
+	for _, section := range tierSections {
+		if strings.EqualFold(text, section.Heading) {
+			return section.Heading, true
+		}
+	}
+	return "", false
+}
+
+// firstReservedTierHeading finds a reserved section heading inside
+// projection content. Such a line would be read back as a section
+// boundary, silently moving content between projections, so publishing
+// is refused instead.
+func firstReservedTierHeading(value string) (string, bool) {
+	for _, line := range strings.Split(value, "\n") {
+		if heading, ok := reservedTierHeadingOf(line); ok {
+			return "## " + heading, true
+		}
+	}
+	return "", false
+}

--- a/internal/runtime/loop/output_tiers_test.go
+++ b/internal/runtime/loop/output_tiers_test.go
@@ -1,0 +1,270 @@
+package loop
+
+import (
+	"strings"
+	"testing"
+)
+
+func tieredOutput(tiers ...OutputTier) OutputSpec {
+	return OutputSpec{
+		Name:  "ranch status",
+		Type:  OutputTypeMaintainedDocument,
+		Ref:   "core:ranch.md",
+		Tiers: tiers,
+	}
+}
+
+func TestOutputSpecTierFieldsFollowCanonicalOrder(t *testing.T) {
+	tests := []struct {
+		name   string
+		output OutputSpec
+		want   []string
+	}{
+		{
+			name:   "full ladder",
+			output: tieredOutput(OutputTierStatusLine, OutputTierTeaser, OutputTierDigest),
+			want:   []string{"status_line", "teaser", "digest", "full"},
+		},
+		{
+			name:   "status line only still gets full",
+			output: tieredOutput(OutputTierStatusLine),
+			want:   []string{"status_line", "full"},
+		},
+		{
+			name:   "declaration order is ignored",
+			output: tieredOutput(OutputTierDigest, OutputTierStatusLine),
+			want:   []string{"status_line", "digest", "full"},
+		},
+		{
+			name:   "untiered output has no fields",
+			output: OutputSpec{Name: "state", Type: OutputTypeMaintainedDocument, Ref: "core:state.md"},
+			want:   nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fields := tt.output.TierFields()
+			got := make([]string, 0, len(fields))
+			for _, field := range fields {
+				got = append(got, field.Key)
+			}
+			if strings.Join(got, ",") != strings.Join(tt.want, ",") {
+				t.Fatalf("TierFields() keys = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestValidateTierPayload(t *testing.T) {
+	full := tieredOutput(OutputTierStatusLine, OutputTierTeaser, OutputTierDigest)
+	good := TierPayload{
+		StatusLine: "Sensors nominal; gate closed.",
+		Teaser:     "Two troughs trending low since the heat spike.",
+		Digest:     "Water levels are holding except troughs 2 and 5.",
+		Full:       "# Ranch\n\n### Water\n\nDetail.",
+	}
+
+	tests := []struct {
+		name    string
+		output  OutputSpec
+		payload TierPayload
+		wantErr string
+	}{
+		{name: "complete payload", output: full, payload: good},
+		{
+			name:    "missing declared tier",
+			output:  full,
+			payload: TierPayload{StatusLine: good.StatusLine, Digest: good.Digest, Full: good.Full},
+			wantErr: "teaser is required",
+		},
+		{
+			name:    "missing full",
+			output:  full,
+			payload: TierPayload{StatusLine: good.StatusLine, Teaser: good.Teaser, Digest: good.Digest},
+			wantErr: "full is required",
+		},
+		{
+			name:    "undeclared tier is not required",
+			output:  tieredOutput(OutputTierStatusLine),
+			payload: TierPayload{StatusLine: good.StatusLine, Full: good.Full},
+		},
+		{
+			name:    "status line rejects newline",
+			output:  full,
+			payload: TierPayload{StatusLine: "One line\nTwo line", Teaser: good.Teaser, Digest: good.Digest, Full: good.Full},
+			wantErr: "single line",
+		},
+		{
+			name:    "over budget status line rejected",
+			output:  full,
+			payload: TierPayload{StatusLine: strings.Repeat("a", statusLineMaxRunes+1), Teaser: good.Teaser, Digest: good.Digest, Full: good.Full},
+			wantErr: "the limit is 120",
+		},
+		{
+			name:    "budget counts runes not bytes",
+			output:  full,
+			payload: TierPayload{StatusLine: strings.Repeat("é", statusLineMaxRunes), Teaser: good.Teaser, Digest: good.Digest, Full: good.Full},
+		},
+		{
+			name:    "over budget teaser rejected",
+			output:  full,
+			payload: TierPayload{StatusLine: good.StatusLine, Teaser: strings.Repeat("b", teaserMaxRunes+1), Digest: good.Digest, Full: good.Full},
+			wantErr: "the limit is 500",
+		},
+		{
+			name:    "full is unbounded",
+			output:  full,
+			payload: TierPayload{StatusLine: good.StatusLine, Teaser: good.Teaser, Digest: good.Digest, Full: strings.Repeat("c", digestMaxRunes*4)},
+		},
+		{
+			name:    "reserved heading in projection rejected",
+			output:  full,
+			payload: TierPayload{StatusLine: good.StatusLine, Teaser: good.Teaser, Digest: "## Details\n\nsneaky", Full: good.Full},
+			wantErr: "reserved section heading",
+		},
+		{
+			name:    "deeper heading inside full is content",
+			output:  full,
+			payload: TierPayload{StatusLine: good.StatusLine, Teaser: good.Teaser, Digest: good.Digest, Full: "### Teaser\n\nA subsection named like a tier is fine."},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.output.ValidateTierPayload(tt.payload)
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("ValidateTierPayload() error = %v, want nil", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("ValidateTierPayload() error = nil, want %q", tt.wantErr)
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("ValidateTierPayload() error = %v, want it to mention %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidateTierPayloadRejectsUntieredOutput(t *testing.T) {
+	out := OutputSpec{Name: "state", Type: OutputTypeMaintainedDocument, Ref: "core:state.md"}
+	if err := out.ValidateTierPayload(TierPayload{Full: "body"}); err == nil {
+		t.Fatal("ValidateTierPayload() error = nil for an untiered output, want error")
+	}
+}
+
+func TestRenderTierDocumentUsesCanonicalSections(t *testing.T) {
+	out := tieredOutput(OutputTierStatusLine, OutputTierTeaser)
+	body := out.RenderTierDocument(TierPayload{
+		StatusLine: "All clear.",
+		Teaser:     "Nothing needs attention today.",
+		Digest:     "This tier is not declared and must not render.",
+		Full:       "Everything is fine.",
+	})
+
+	want := "## Status Line\n\nAll clear.\n\n## Teaser\n\nNothing needs attention today.\n\n## Details\n\nEverything is fine."
+	if body != want {
+		t.Fatalf("RenderTierDocument() =\n%q\nwant\n%q", body, want)
+	}
+}
+
+// TestTierDocumentRoundTrip is the guarantee the whole storage decision
+// rests on: the rendered document is the canonical store, so any derived
+// binding can be re-seeded by parsing it back.
+func TestTierDocumentRoundTrip(t *testing.T) {
+	tests := []struct {
+		name    string
+		output  OutputSpec
+		payload TierPayload
+	}{
+		{
+			name:   "full ladder",
+			output: tieredOutput(OutputTierStatusLine, OutputTierTeaser, OutputTierDigest),
+			payload: TierPayload{
+				StatusLine: "Sensors nominal; 2 waters below 40%.",
+				Teaser:     "Two troughs trending low since yesterday's heat spike.",
+				Digest:     "Troughs 2 and 5 are below 40%.\n\nRefill likely needed by Friday.",
+				Full:       "# Ranch Office\n\n### Water\n\nTrough detail.\n\n### Power\n\nStable.",
+			},
+		},
+		{
+			name:   "status line only",
+			output: tieredOutput(OutputTierStatusLine),
+			payload: TierPayload{
+				StatusLine: "All clear.",
+				Full:       "Nothing of note.",
+			},
+		},
+		{
+			name:   "multibyte content survives",
+			output: tieredOutput(OutputTierStatusLine, OutputTierTeaser),
+			payload: TierPayload{
+				StatusLine: "Café météo: stable — 21°C.",
+				Teaser:     "Les capteurs sont à jour.",
+				Full:       "Détails complets.",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := tt.output.ValidateTierPayload(tt.payload); err != nil {
+				t.Fatalf("payload should be valid: %v", err)
+			}
+			got := ParseTierDocument(tt.output.RenderTierDocument(tt.payload))
+			if got != tt.payload {
+				t.Fatalf("round trip changed the payload:\ngot  %#v\nwant %#v", got, tt.payload)
+			}
+		})
+	}
+}
+
+func TestParseTierDocumentAdoptsUntieredBody(t *testing.T) {
+	// An existing maintained document being adopted into the tiered
+	// contract has no recognized sections; its whole body is the full
+	// projection rather than being lost.
+	body := "# Ranch Office\n\nEverything written before tiers existed."
+	got := ParseTierDocument(body)
+	if got.Full != body {
+		t.Fatalf("Full = %q, want the whole legacy body", got.Full)
+	}
+	if got.StatusLine != "" || got.Teaser != "" || got.Digest != "" {
+		t.Fatalf("legacy body should not populate projections: %#v", got)
+	}
+}
+
+func TestParseTierDocumentFoldsPreambleIntoFull(t *testing.T) {
+	body := "Stray lead paragraph.\n\n## Status Line\n\nAll clear.\n\n## Details\n\nBody proper."
+	got := ParseTierDocument(body)
+	if got.StatusLine != "All clear." {
+		t.Fatalf("StatusLine = %q", got.StatusLine)
+	}
+	if got.Full != "Stray lead paragraph.\n\nBody proper." {
+		t.Fatalf("Full = %q, want preamble folded ahead of the details body", got.Full)
+	}
+}
+
+func TestParseTierDocumentAcceptsHeadingCaseDrift(t *testing.T) {
+	// An operator hand-editing the document may not match our casing.
+	got := ParseTierDocument("## status line\n\nAll clear.\n\n## DETAILS\n\nBody.")
+	if got.StatusLine != "All clear." || got.Full != "Body." {
+		t.Fatalf("case-insensitive heading match failed: %#v", got)
+	}
+}
+
+func TestTieredOutputToolNameUsesPublishVerb(t *testing.T) {
+	tiered := tieredOutput(OutputTierStatusLine)
+	if got := tiered.ToolName(); got != "publish_output_ranch_status" {
+		t.Fatalf("tiered ToolName() = %q, want publish_output_ranch_status", got)
+	}
+	untiered := OutputSpec{Name: "ranch status", Type: OutputTypeMaintainedDocument, Ref: "core:ranch.md"}
+	if got := untiered.ToolName(); got != "replace_output_ranch_status" {
+		t.Fatalf("untiered ToolName() = %q, want replace_output_ranch_status", got)
+	}
+	if len(tiered.ToolName()) > maxOutputToolNameLength {
+		t.Fatalf("publish tool name exceeds the tool-name budget: %q", tiered.ToolName())
+	}
+}

--- a/internal/runtime/loop/output_tiers_test.go
+++ b/internal/runtime/loop/output_tiers_test.go
@@ -268,3 +268,35 @@ func TestTieredOutputToolNameUsesPublishVerb(t *testing.T) {
 		t.Fatalf("publish tool name exceeds the tool-name budget: %q", tiered.ToolName())
 	}
 }
+
+func TestValidateOutputsRejectsSecondWorkingNotes(t *testing.T) {
+	spec := Spec{
+		Name:       "curator",
+		Enabled:    true,
+		Task:       "Curate.",
+		Operation:  OperationService,
+		Completion: CompletionNone,
+		Outputs: []OutputSpec{
+			{Name: "office notes", Type: OutputTypeWorkingNotes, Ref: "core:office-notes.md"},
+			{Name: "shop notes", Type: OutputTypeWorkingNotes, Ref: "core:shop-notes.md"},
+		},
+	}
+	err := spec.ValidatePersistable()
+	if err == nil {
+		t.Fatal("ValidatePersistable() error = nil for two working_notes outputs, want error")
+	}
+	if !strings.Contains(err.Error(), "one private log") {
+		t.Fatalf("error = %v, want it to explain the single-log rule", err)
+	}
+
+	// The escape hatch the error names must actually validate.
+	spec.Outputs[1] = OutputSpec{
+		Name:     "shop journal",
+		Type:     OutputTypeJournalDocument,
+		Ref:      "core:shop-journal.md",
+		Audience: OutputAudienceInternal,
+	}
+	if err := spec.ValidatePersistable(); err != nil {
+		t.Fatalf("ValidatePersistable() with an internal journal alongside working notes: %v", err)
+	}
+}

--- a/internal/tools/loop_spec_schema.go
+++ b/internal/tools/loop_spec_schema.go
@@ -54,7 +54,7 @@ func loopSpecSchema(description string) map[string]any {
 			"supervisor_profile": loopProfileSchema("Overlay applied on supervisor turns (e.g. a higher quality_floor and review-specific instructions). Any field set here wins over profile; unset fields fall back to profile."),
 			"outputs": map[string]any{
 				"type":        "array",
-				"description": "Durable documents this loop maintains through scoped runtime tools (replace_output_*/append_output_*).",
+				"description": "Durable documents this loop owns, each exposed as a scoped runtime tool: whole-document rewrites (replace_output_*), journal appends (append_output_*), and tiered publishes (publish_output_*).",
 				"items":       loopOutputSpecSchema(),
 			},
 			"tags": map[string]any{
@@ -173,13 +173,23 @@ func loopOutputSpecSchema() map[string]any {
 	return map[string]any{
 		"type": "object",
 		"properties": map[string]any{
-			"name":           map[string]any{"type": "string", "description": "Stable semantic name for this output within the loop."},
-			"type":           map[string]any{"type": "string", "enum": []string{"maintained_document", "journal_document"}, "description": "maintained_document = idempotent rewrite each cycle; journal_document = append-only dated entries."},
+			"name": map[string]any{"type": "string", "description": "Stable semantic name for this output within the loop."},
+			"type": map[string]any{"type": "string", "enum": []string{"maintained_document", "journal_document", "working_notes"}, "description": "maintained_document = idempotent rewrite each cycle; journal_document = append-only dated entries; working_notes = this loop's private process log, append-only and never projected into any consumer surface (use it for how the understanding is evolving — drift, refinement, the reasoning behind a change)."},
+			"tiers": map[string]any{
+				"type":        "array",
+				"items":       map[string]any{"type": "string", "enum": []string{"status_line", "teaser", "digest"}},
+				"description": "Published projection ladder for a maintained_document: which condensed views this output curates alongside its full body. Declaring tiers swaps the generated tool from replace_output_* to publish_output_*, which takes one typed argument per projection. status_line is required when tiers are declared; teaser and digest are optional. Consumers pick the projection that fits their surface — an ambient row takes status_line, a search snippet takes teaser, a digest row takes digest — so a tiered output is read at a fraction of the cost of the full document. Order here carries no meaning.",
+			},
+			"audience": map[string]any{
+				"type":        "string",
+				"enum":        []string{"published", "internal"},
+				"description": "Who may see this output's content. published (default) allows projection into search results, context injection, and ambient surfaces; internal keeps it to this loop's own context and explicit reads by ref. working_notes outputs are internal automatically. Internal is context hygiene, not secrecy: operators and the archive still see the document.",
+			},
 			"ref":            map[string]any{"type": "string", "description": "Managed document ref, e.g. \"core:metacognitive.md\" or \"kb:dashboards/x.md\". Stored verbatim — not resolved to content."},
-			"mode":           map[string]any{"type": "string", "enum": []string{"replace", "append"}, "description": "Write mode; defaults from type when omitted (maintained→replace, journal→append)."},
+			"mode":           map[string]any{"type": "string", "enum": []string{"replace", "append"}, "description": "Write mode; defaults from type when omitted (maintained→replace, journal and working_notes→append). A tiered maintained_document publishes projections instead, so leave this unset there."},
 			"purpose":        map[string]any{"type": "string", "description": "Optional model-facing guidance describing what this output is for."},
-			"journal_window": map[string]any{"type": "string", "enum": []string{"day", "week", "month"}, "description": "Rolling window for journal outputs; empty uses the document-layer default."},
-			"max_windows":    map[string]any{"type": "integer", "description": "Cap on retained journal windows; 0 uses the document-layer default."},
+			"journal_window": map[string]any{"type": "string", "enum": []string{"day", "week", "month"}, "description": "Rolling window for append-mode outputs (journal_document and working_notes); empty uses the document-layer default."},
+			"max_windows":    map[string]any{"type": "integer", "description": "Cap on retained windows for append-mode outputs; 0 uses the document-layer default. Windows beyond the cap are pruned from the document — the archive and the root's revision history keep them."},
 		},
 	}
 }

--- a/talents/loops.md
+++ b/talents/loops.md
@@ -22,9 +22,51 @@ For recurring document work, prefer `thane_loop_create` with
 the running loop self-paces inside, its `output` declares the state owner
 (now optional — a service loop can run without maintaining a document),
 and when a document is declared the running loop writes through generated
-output tools such as `replace_output_*` or `append_output_*`. If a
-maintained output is marked `truncated` in Declared Durable Outputs, read
-the full document before replacing it.
+output tools such as `replace_output_*`, `append_output_*`, or
+`publish_output_*`. If a maintained output is marked `truncated` in
+Declared Durable Outputs, read the full document before replacing it.
+
+## Who reads this output?
+
+A loop that curates an understanding others consult — the state of a
+domain, a watchlist, a standing summary — should declare `tiers` on its
+maintained document. The loop then curates condensed views of its own
+work alongside the full body, and each consuming surface takes the one
+it can afford: an ambient overview row takes `status_line`, a search
+snippet takes `teaser`, a digest row takes `digest`, and a reader who
+wants everything opens the document. Without tiers, every consumer pays
+for the whole document or gets a blind truncation of it, so a curator
+whose value is being *consulted often* is the case for declaring them.
+
+Declaring tiers changes the write interface: instead of
+`replace_output_*` taking a document body, the loop gets
+`publish_output_*` taking one argument per projection. Pass them all in
+one call — they are written together so no reader ever sees a status
+line describing a state the details have moved past. Do not write the
+section headings; they are rendered for you. Each projection has a size
+budget, and an over-budget value is rejected rather than trimmed,
+because a clipped teaser reads as a fragment with no sign that anything
+is missing. Write to the budget rather than near it.
+
+Declare `status_line` for any tiered output; add `teaser` when the
+output is something others search or link to, and `digest` when a
+reader should be able to act without opening the document.
+
+## Where the reasoning goes
+
+Published projections carry current state, not the story of how it got
+there. A curating loop should also declare a `working_notes` output: its
+private process log, append-only, invisible to every consumer surface —
+out of search results, out of other loops' context. Use it for how the
+understanding is evolving: what changed and why, what drifted, what was
+refined, what a future turn should know. Revision history already
+records *what* changed; working notes are for *why*.
+
+The smooth path is the `note` argument on `publish_output_*`: publish
+the projections and record the reasoning in the same call, so the
+timeline accumulates as a side effect of the work instead of a chore.
+`append_output_*` on the notes output writes an entry on its own when
+there is something to record without a publish.
 
 Choose stream wiring by attention cost:
 


### PR DESCRIPTION
## What a curating loop can do now

A loop that owns an understanding — the state of the office, a watchlist, a standing summary — can declare the condensed views it curates, and publish them all in one call:

```
publish_output_office_status(
  status_line: "Printer online; 2 packages waiting.",
  teaser:      "The desk is clear but two deliveries need signing.",
  full:        "…the whole picture…",
  note:        "Dropped the delivery warning — both packages were signed for at 14:20."
)
```

Everything moves together, so no reader ever sees a status line describing a state the details have moved past. Each projection has a size budget enforced at the call, with an error that says how to recover: *status_line is 200 characters and the limit is 120; tighten it rather than letting it be cut.* Rejecting beats trimming here — a clipped teaser reads as a fragment with nothing to signal that anything is missing, which is worse than no teaser at all.

The model writes content, never structure. It does not name a section, does not remember a heading convention, and cannot double one — the #1249 lesson as architecture rather than a repair.

That last argument, `note`, is the one I expect to matter most in daily use: it records *why* the understanding changed into the loop's private working notes as a side effect of publishing, rather than as a chore to remember afterward. Revision history already tells you what changed. This is the lab notebook.

## Working notes become real

A `working_notes` output now stamps `audience: internal` on its document — the frontmatter that the search exclusion and the tagged-guidance scanner already honor since #1252. Until this PR that declaration was a label with no mechanism behind it; now a loop's process log genuinely stays out of every consumer surface while remaining ordinary, readable, archived markdown for you. A published journal is deliberately left unstamped.

The tool that writes them says what they are for — "record how the understanding is evolving: what changed and why, what drifted, what was refined" — because a model that thinks it is writing another public surface will not write the reasoning that makes a private log worth having.

## The document is still the document

On disk this is markdown with `## Status Line` / `## Teaser` / `## Details` sections, exactly the convention we ran by hand in production. Go renders it and parses it back, and the round trip is tested. That is what makes the document the canonical store rather than a rendering artifact: when phase 4 binds these projections to entities and displays, every derived surface can be re-seeded from the document alone after a restart.

A document with no recognized sections parses entirely into `full`, so an existing maintained document can adopt the contract without losing what it already holds.

## Teaching

The loops talent gains two decision frames — *who reads this output* (when to declare tiers, and what each projection is for) and *where the reasoning goes* (working notes, and the `note` shortcut). The loop spec schema advertises `tiers`, `audience`, and `working_notes`. Three operator docs that enumerated "two output shapes" are corrected, along with two schema descriptions that had gone stale the moment `working_notes` existed.

`talents/loops.md` changed, so this needs the usual manual prod backport after merge.

## Test plan

- [x] Render/parse round-trip across full ladder, minimal ladder, and multibyte content
- [x] Budgets counted in runes, not bytes; over-budget rejected and nothing written
- [x] Reserved section headings inside a projection rejected; deeper headings pass through as content
- [x] Every declared projection required at publish; undeclared ones neither required nor advertised
- [x] `note` appends to working notes and does not leak into the published document
- [x] `audience: internal` stamped by both the note path and a direct append; published journals unstamped
- [x] `managed_by` stamped for the future edit-redirect guardrail
- [x] Publish tool omits `note` entirely when the loop declares no working notes
- [x] `just ci` green locally

Refs #1250

🤖 Generated with [Claude Code](https://claude.com/claude-code)
