### PR TITLE
A corpus reaches the prompt because policy says it may: per-root context declarations

### DIFF
--- a/examples/config.example.yaml
+++ b/examples/config.example.yaml
@@ -264,6 +264,10 @@ roots:
       # tag. It is a coarse companion to per-document tags: cheap to
       # enforce, and the right shape when an entire corpus is only
       # relevant while a capability is active.
+      # 
+      # It applies to injection only, so it requires inject: tagged.
+      # Gating search the same way would need the document store to see
+      # active capability tags, which it deliberately does not.
       requires_tag: ""
   kb:
     # Path is the directory the root resolves to. Supports ~
@@ -380,6 +384,10 @@ roots:
       # tag. It is a coarse companion to per-document tags: cheap to
       # enforce, and the right shape when an entire corpus is only
       # relevant while a capability is active.
+      # 
+      # It applies to injection only, so it requires inject: tagged.
+      # Gating search the same way would need the document store to see
+      # active capability tags, which it deliberately does not.
       requires_tag: ""
   scratchpad:
     # Path is the directory the root resolves to. Supports ~
@@ -442,6 +450,10 @@ roots:
       # tag. It is a coarse companion to per-document tags: cheap to
       # enforce, and the right shape when an entire corpus is only
       # relevant while a capability is active.
+      # 
+      # It applies to injection only, so it requires inject: tagged.
+      # Gating search the same way would need the document store to see
+      # active capability tags, which it deliberately does not.
       requires_tag: ""
 #
 # (optional) Paths is the legacy directory-mapping block. Replaced by roots:.

--- a/examples/config.example.yaml
+++ b/examples/config.example.yaml
@@ -250,6 +250,21 @@ roots:
       # never confers trust, which comes only from signature verification
       # against the out-of-tree trust_anchor. Ignored unless Enabled.
       remote: null
+    # Context governs how this root's documents may reach a model:
+    # whether they can be injected into a prompt and how they surface
+    # in search. Omit to keep the legacy behavior for this root.
+    context:
+      # Inject controls prompt-assembly eligibility: "none" (default for
+      # a root that declares a context policy) or "tagged".
+      inject: ""
+      # Search controls search visibility: "default", "on_request", or
+      # "never".
+      search: ""
+      # RequiresTag optionally gates the whole root behind one capability
+      # tag. It is a coarse companion to per-document tags: cheap to
+      # enforce, and the right shape when an entire corpus is only
+      # relevant while a capability is active.
+      requires_tag: ""
   kb:
     # Path is the directory the root resolves to. Supports ~
     # expansion at resolver construction time. For the reserved
@@ -351,6 +366,21 @@ roots:
           # Token is an https personal access token. Documented, but SSH is the
           # recommended transport.
           token: ""
+    # Context governs how this root's documents may reach a model:
+    # whether they can be injected into a prompt and how they surface
+    # in search. Omit to keep the legacy behavior for this root.
+    context:
+      # Inject controls prompt-assembly eligibility: "none" (default for
+      # a root that declares a context policy) or "tagged".
+      inject: tagged
+      # Search controls search visibility: "default", "on_request", or
+      # "never".
+      search: default
+      # RequiresTag optionally gates the whole root behind one capability
+      # tag. It is a coarse companion to per-document tags: cheap to
+      # enforce, and the right shape when an entire corpus is only
+      # relevant while a capability is active.
+      requires_tag: ""
   scratchpad:
     # Path is the directory the root resolves to. Supports ~
     # expansion at resolver construction time. For the reserved
@@ -398,6 +428,21 @@ roots:
       # never confers trust, which comes only from signature verification
       # against the out-of-tree trust_anchor. Ignored unless Enabled.
       remote: null
+    # Context governs how this root's documents may reach a model:
+    # whether they can be injected into a prompt and how they surface
+    # in search. Omit to keep the legacy behavior for this root.
+    context:
+      # Inject controls prompt-assembly eligibility: "none" (default for
+      # a root that declares a context policy) or "tagged".
+      inject: ""
+      # Search controls search visibility: "default", "on_request", or
+      # "never".
+      search: ""
+      # RequiresTag optionally gates the whole root behind one capability
+      # tag. It is a coarse companion to per-document tags: cheap to
+      # enforce, and the right shape when an entire corpus is only
+      # relevant while a capability is active.
+      requires_tag: ""
 #
 # (optional) Paths is the legacy directory-mapping block. Replaced by roots:.
 # paths: {}

--- a/internal/app/document_roots.go
+++ b/internal/app/document_roots.go
@@ -280,6 +280,11 @@ func documentRootPolicyFromConfig(rootCfg config.DocumentRootConfig) documents.R
 		policy.Git.VerifySignatures = documents.VerificationMode(verify)
 	}
 	policy.Git.RepoPath = strings.TrimSpace(gitCfg.RepoPath)
+	policy.Context = documents.RootContextPolicy{
+		Inject:      strings.TrimSpace(rootCfg.Context.Inject),
+		Search:      strings.TrimSpace(rootCfg.Context.Search),
+		RequiresTag: strings.TrimSpace(rootCfg.Context.RequiresTag),
+	}
 	return policy
 }
 

--- a/internal/app/document_roots.go
+++ b/internal/app/document_roots.go
@@ -124,12 +124,22 @@ func (a *App) buildDocumentStoreOptions(documentRoots map[string]string, resolve
 	if logger == nil {
 		logger = slog.Default()
 	}
+	// Resolve injection eligibility once, here, so the assembler and the
+	// document store report the same answer. Without this the store
+	// would derive its own from an empty policy and tell the model
+	// "inject: none" about the very root that injects under the legacy
+	// fallback — a description that contradicts runtime behavior.
+	legacyInject := legacyInjectRoot(a.cfg)
+
 	for root, rootCfg := range a.cfg.DocRoots {
 		root = strings.TrimSuffix(strings.TrimSpace(root), ":")
 		if root == "" {
 			continue
 		}
 		policy := documentRootPolicyFromConfig(rootCfg)
+		if root == legacyInject {
+			policy.Context.Inject = documents.RootInjectTagged
+		}
 
 		rootPath, ok := documentRoots[root]
 		if !ok {
@@ -257,6 +267,25 @@ func bootstrapMissingRootDirectory(root string, resolver *paths.Resolver, logger
 	}
 	logger.Info("bootstrapping new document root", "root", root, "path", absPath)
 	return absPath, nil
+}
+
+// legacyInjectRoot returns the root that injects by historical default
+// when no root declares a context policy, or empty once any policy is
+// declared. Before roots could declare eligibility, tagged articles in
+// the kb root were scanned into every prompt; that behavior is preserved
+// until an operator states an intent, and naming it here keeps the
+// preserved behavior visible to the model rather than implicit in the
+// assembler's wiring.
+func legacyInjectRoot(cfg *config.Config) string {
+	if cfg == nil {
+		return ""
+	}
+	for _, policy := range cfg.DocRoots {
+		if policy.Context.Declared() {
+			return ""
+		}
+	}
+	return "kb"
 }
 
 func documentRootPolicyFromConfig(rootCfg config.DocumentRootConfig) documents.RootPolicy {

--- a/internal/app/finalize_capability_tags.go
+++ b/internal/app/finalize_capability_tags.go
@@ -2,9 +2,12 @@ package app
 
 import (
 	"context"
+	"log/slog"
 
 	"github.com/nugget/thane-ai-agent/internal/integrations/forge"
 	"github.com/nugget/thane-ai-agent/internal/model/talents"
+	"github.com/nugget/thane-ai-agent/internal/platform/config"
+	"github.com/nugget/thane-ai-agent/internal/platform/paths"
 	"github.com/nugget/thane-ai-agent/internal/runtime/agent"
 )
 
@@ -118,12 +121,13 @@ func (a *App) finalizeCapabilityTags(s *newState) error {
 	}
 
 	tagCtxAssembler := agent.NewTagContextAssembler(agent.TagContextAssemblerConfig{
-		CapTags:  resolvedCapTags,
-		KBDir:    kbDir,
-		Resolver: s.resolver,
-		Verifier: contextVerifier,
-		HAInject: a.loop.HAInject(),
-		Logger:   logger.With("component", "tag_context"),
+		CapTags:     resolvedCapTags,
+		KBDir:       kbDir,
+		InjectRoots: injectionEligibleRoots(cfg, s.resolver, logger),
+		Resolver:    s.resolver,
+		Verifier:    contextVerifier,
+		HAInject:    a.loop.HAInject(),
+		Logger:      logger.With("component", "tag_context"),
 	})
 
 	// Wire the assembler before tag context providers register so the
@@ -198,4 +202,47 @@ func (a *App) finalizeCapabilityTags(s *newState) error {
 	)
 
 	return nil
+}
+
+// injectionEligibleRoots resolves the roots whose tagged documents may
+// be injected into a prompt. It returns nil when no root declares a
+// context policy, which keeps the legacy single-kb scan in force so an
+// existing config assembles context exactly as before.
+//
+// Injection is declared, never inferred: a corpus can place text into a
+// system prompt without anyone asking for it, so a root reaches the
+// prompt only because policy says it may. That matters most for a root
+// synced from a remote Thane does not control, where the frontmatter a
+// document carries is not evidence of anything.
+func injectionEligibleRoots(cfg *config.Config, resolver *paths.Resolver, logger *slog.Logger) map[string]agent.InjectRoot {
+	if cfg == nil || resolver == nil {
+		return nil
+	}
+	declared := false
+	for _, policy := range cfg.DocRoots {
+		if policy.Context.Declared() {
+			declared = true
+			break
+		}
+	}
+	if !declared {
+		return nil
+	}
+
+	eligible := make(map[string]agent.InjectRoot)
+	for name, policy := range cfg.DocRoots {
+		if policy.Context.EffectiveInject() != config.RootInjectTagged {
+			continue
+		}
+		dir, err := resolver.Resolve(name + ":")
+		if err != nil {
+			logger.Warn("root declares tagged injection but does not resolve to a directory",
+				"root", name, "error", err)
+			continue
+		}
+		eligible[name] = agent.InjectRoot{Dir: dir, RequiresTag: policy.Context.RequiresTag}
+	}
+	logger.Info("context injection policy resolved",
+		"injection_eligible_roots", len(eligible))
+	return eligible
 }

--- a/internal/platform/config/config.go
+++ b/internal/platform/config/config.go
@@ -895,6 +895,103 @@ type RootEntry struct {
 	// Git configures optional git-backed write provenance for this
 	// root. Same fields as the legacy doc_roots[name].git block.
 	Git DocumentRootGitConfig `yaml:"git,omitempty"`
+
+	// Context governs how this root's documents may reach a model:
+	// whether they can be injected into a prompt and how they surface
+	// in search. Omit to keep the legacy behavior for this root.
+	Context RootContextPolicy `yaml:"context,omitempty"`
+}
+
+// Root context policy values. Injection is the narrower and more
+// consequential of the two: a root that may inject can place text into a
+// system prompt without anyone asking for it, so eligibility is declared
+// per root rather than inferred from a document's own frontmatter.
+const (
+	// RootInjectNone keeps every document in this root out of prompt
+	// assembly. It is the safe default for any root Thane does not
+	// author, and for any root synced from somewhere Thane does not
+	// control.
+	RootInjectNone = "none"
+	// RootInjectTagged lets a document whose frontmatter tags match an
+	// active capability tag inject as tagged guidance.
+	RootInjectTagged = "tagged"
+
+	// RootSearchDefault includes the root in unscoped document search.
+	RootSearchDefault = "default"
+	// RootSearchOnRequest keeps the root out of unscoped search but
+	// reachable when a query names it. Large foreign corpora want this:
+	// searchable on purpose, never drowning an open-ended query.
+	RootSearchOnRequest = "on_request"
+	// RootSearchNever excludes the root from document search entirely.
+	RootSearchNever = "never"
+)
+
+// RootContextPolicy declares how one document root may reach a model.
+// It sits beside the storage policy (authoring, git, signing) because it
+// answers the same class of question — how is this corpus governed — at
+// the same granularity, and because a corpus is the only place the
+// answer can be given for documents Thane does not own and cannot
+// annotate.
+type RootContextPolicy struct {
+	// Inject controls prompt-assembly eligibility: "none" (default for
+	// a root that declares a context policy) or "tagged".
+	Inject string `yaml:"inject,omitempty"`
+
+	// Search controls search visibility: "default", "on_request", or
+	// "never".
+	Search string `yaml:"search,omitempty"`
+
+	// RequiresTag optionally gates the whole root behind one capability
+	// tag. It is a coarse companion to per-document tags: cheap to
+	// enforce, and the right shape when an entire corpus is only
+	// relevant while a capability is active.
+	RequiresTag string `yaml:"requires_tag,omitempty"`
+}
+
+// Declared reports whether this root states a context policy at all.
+// An undeclared policy keeps the root's historical behavior so an
+// existing config does not silently change how context is assembled.
+func (p RootContextPolicy) Declared() bool {
+	return p.Inject != "" || p.Search != "" || p.RequiresTag != ""
+}
+
+// EffectiveInject resolves the injection policy. A root that declares a
+// context policy without naming inject gets "none": declaring policy is
+// an act of governance, and the safe reading of an unstated answer is
+// that the corpus stays out of the prompt.
+func (p RootContextPolicy) EffectiveInject() string {
+	if p.Inject == "" {
+		return RootInjectNone
+	}
+	return p.Inject
+}
+
+// EffectiveSearch resolves the search policy, defaulting to full
+// visibility. Search is a pull: the model asked, so the conservative
+// default is the useful one.
+func (p RootContextPolicy) EffectiveSearch() string {
+	if p.Search == "" {
+		return RootSearchDefault
+	}
+	return p.Search
+}
+
+// Validate checks the declared policy values.
+func (p RootContextPolicy) Validate(rootName string) error {
+	switch p.Inject {
+	case "", RootInjectNone, RootInjectTagged:
+	default:
+		return fmt.Errorf("roots.%s.context.inject must be %q or %q, got %q", rootName, RootInjectNone, RootInjectTagged, p.Inject)
+	}
+	switch p.Search {
+	case "", RootSearchDefault, RootSearchOnRequest, RootSearchNever:
+	default:
+		return fmt.Errorf("roots.%s.context.search must be %q, %q, or %q, got %q", rootName, RootSearchDefault, RootSearchOnRequest, RootSearchNever, p.Search)
+	}
+	if p.RequiresTag != "" && p.EffectiveInject() == RootInjectNone && p.EffectiveSearch() == RootSearchNever {
+		return fmt.Errorf("roots.%s.context.requires_tag has no effect when the root neither injects nor is searchable", rootName)
+	}
+	return nil
 }
 
 // UnmarshalYAML accepts either the bare-string shorthand or the full
@@ -946,6 +1043,9 @@ type DocumentRootConfig struct {
 
 	// Git configures optional git-backed write provenance for this root.
 	Git DocumentRootGitConfig `yaml:"git,omitempty"`
+
+	// Context governs how this root's documents may reach a model.
+	Context RootContextPolicy `yaml:"context,omitempty"`
 }
 
 // DocumentRootGitConfig configures git-backed provenance for one
@@ -2269,6 +2369,7 @@ func (c *Config) normalizeRoots() error {
 					Indexing:  entry.Indexing,
 					Authoring: entry.Authoring,
 					Git:       entry.Git,
+					Context:   entry.Context,
 				}
 			}
 		}
@@ -2293,6 +2394,9 @@ func entryHasPolicy(entry RootEntry) bool {
 		return true
 	}
 	if strings.TrimSpace(entry.Authoring) != "" {
+		return true
+	}
+	if entry.Context.Declared() {
 		return true
 	}
 	g := entry.Git
@@ -2851,6 +2955,9 @@ func (c *Config) validateDocRoots() error {
 		case "", "managed", "read_only", "restricted":
 		default:
 			return fmt.Errorf("doc_roots.%s.authoring %q must be one of [managed, read_only, restricted]", root, policy.Authoring)
+		}
+		if err := policy.Context.Validate(root); err != nil {
+			return err
 		}
 		git := policy.Git
 		switch strings.TrimSpace(git.VerifySignatures) {

--- a/internal/platform/config/config.go
+++ b/internal/platform/config/config.go
@@ -945,6 +945,10 @@ type RootContextPolicy struct {
 	// tag. It is a coarse companion to per-document tags: cheap to
 	// enforce, and the right shape when an entire corpus is only
 	// relevant while a capability is active.
+	//
+	// It applies to injection only, so it requires inject: tagged.
+	// Gating search the same way would need the document store to see
+	// active capability tags, which it deliberately does not.
 	RequiresTag string `yaml:"requires_tag,omitempty"`
 }
 
@@ -988,8 +992,12 @@ func (p RootContextPolicy) Validate(rootName string) error {
 	default:
 		return fmt.Errorf("roots.%s.context.search must be %q, %q, or %q, got %q", rootName, RootSearchDefault, RootSearchOnRequest, RootSearchNever, p.Search)
 	}
-	if p.RequiresTag != "" && p.EffectiveInject() == RootInjectNone && p.EffectiveSearch() == RootSearchNever {
-		return fmt.Errorf("roots.%s.context.requires_tag has no effect when the root neither injects nor is searchable", rootName)
+	// requires_tag gates prompt injection only. Search runs below the
+	// capability layer — the document store has no view of which tags
+	// are active — so accepting the field on a root that does not inject
+	// would silently do nothing, which is worse than refusing it.
+	if p.RequiresTag != "" && p.EffectiveInject() != RootInjectTagged {
+		return fmt.Errorf("roots.%s.context.requires_tag gates prompt injection and requires inject: %q (got %q); it does not gate search, because search does not see active capability tags", rootName, RootInjectTagged, p.EffectiveInject())
 	}
 	return nil
 }

--- a/internal/platform/config/config_root_context_test.go
+++ b/internal/platform/config/config_root_context_test.go
@@ -1,0 +1,68 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRootContextPolicyValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		policy  RootContextPolicy
+		wantErr string
+	}{
+		{name: "empty policy is valid", policy: RootContextPolicy{}},
+		{name: "tagged injection", policy: RootContextPolicy{Inject: RootInjectTagged}},
+		{name: "on request search", policy: RootContextPolicy{Search: RootSearchOnRequest}},
+		{
+			name:    "unknown inject rejected",
+			policy:  RootContextPolicy{Inject: "always"},
+			wantErr: "context.inject",
+		},
+		{
+			name:    "unknown search rejected",
+			policy:  RootContextPolicy{Search: "sometimes"},
+			wantErr: "context.search",
+		},
+		{
+			name:   "requires_tag with tagged injection",
+			policy: RootContextPolicy{Inject: RootInjectTagged, RequiresTag: "devops"},
+		},
+		{
+			name:    "requires_tag without injection rejected",
+			policy:  RootContextPolicy{Search: RootSearchOnRequest, RequiresTag: "devops"},
+			wantErr: "requires_tag gates prompt injection",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.policy.Validate("vault")
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("Validate() error = %v, want nil", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("Validate() error = %v, want it to mention %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestRootContextPolicyEffectiveDefaults(t *testing.T) {
+	var p RootContextPolicy
+	if got := p.EffectiveInject(); got != RootInjectNone {
+		t.Fatalf("EffectiveInject() = %q, want none", got)
+	}
+	if got := p.EffectiveSearch(); got != RootSearchDefault {
+		t.Fatalf("EffectiveSearch() = %q, want default", got)
+	}
+	if p.Declared() {
+		t.Fatal("an empty policy must not report itself as declared")
+	}
+	if !(RootContextPolicy{Search: RootSearchNever}).Declared() {
+		t.Fatal("a policy naming search must report as declared")
+	}
+}

--- a/internal/platform/config/example.go
+++ b/internal/platform/config/example.go
@@ -110,8 +110,16 @@ func ExampleConfig() *Config {
 		Roots: map[string]RootEntry{
 			"generated": {Path: "./generated"},
 			"kb": {
-				Path:      "./knowledge",
-				Indexing:  &docRootIndexing,
+				Path:     "./knowledge",
+				Indexing: &docRootIndexing,
+				// The knowledge base is the one corpus whose tagged
+				// articles are meant to reach the prompt. Every other
+				// root stays out unless it says otherwise, so a corpus
+				// can only inject because policy allows it.
+				Context: RootContextPolicy{
+					Inject: RootInjectTagged,
+					Search: RootSearchDefault,
+				},
 				Authoring: "managed",
 				Git: DocumentRootGitConfig{
 					Enabled:          true,

--- a/internal/runtime/agent/tag_context.go
+++ b/internal/runtime/agent/tag_context.go
@@ -42,10 +42,13 @@ import (
 // assembler. The assembler is safe for concurrent use after
 // construction.
 type TagContextAssembler struct {
-	capTags  map[string]config.CapabilityTagConfig
-	kbDir    string
-	resolver *paths.Resolver
-	verifier interface {
+	capTags map[string]config.CapabilityTagConfig
+	kbDir   string
+	// injectRoots is the declared injection-eligible root set. Nil means
+	// no policy was declared and the legacy single-kbDir scan applies.
+	injectRoots map[string]InjectRoot
+	resolver    *paths.Resolver
+	verifier    interface {
 		VerifyRef(ctx context.Context, ref string, consumer string) error
 		VerifyPath(ctx context.Context, path string, consumer string) error
 	}
@@ -93,9 +96,15 @@ type KBMenuHint struct {
 // TagContextAssemblerConfig holds the construction parameters for a
 // TagContextAssembler.
 type TagContextAssemblerConfig struct {
-	CapTags  map[string]config.CapabilityTagConfig
-	KBDir    string          // resolved kb: directory; empty skips scanning
-	Resolver *paths.Resolver // managed document root resolver; nil falls back to KBDir for kb: refs
+	CapTags map[string]config.CapabilityTagConfig
+	KBDir   string // resolved kb: directory; empty skips scanning
+	// InjectRoots are the roots whose tagged documents may inject, as
+	// resolved directories keyed by root name. When non-nil it replaces
+	// KBDir entirely: injection eligibility is declared per root in
+	// config rather than fixed to the kb root, so a corpus reaches the
+	// prompt only because policy says it may.
+	InjectRoots map[string]InjectRoot
+	Resolver    *paths.Resolver // managed document root resolver; nil falls back to KBDir for kb: refs
 	// Verifier is an optional managed-root verifier for context refs and
 	// tagged articles.
 	Verifier interface {
@@ -118,31 +127,78 @@ func NewTagContextAssembler(cfg TagContextAssemblerConfig) *TagContextAssembler 
 		cfg.Logger = slog.Default()
 	}
 	return &TagContextAssembler{
-		capTags:  cfg.CapTags,
-		kbDir:    cfg.KBDir,
-		resolver: cfg.Resolver,
-		verifier: cfg.Verifier,
-		haInject: cfg.HAInject,
-		logger:   cfg.Logger,
+		capTags:     cfg.CapTags,
+		kbDir:       cfg.KBDir,
+		injectRoots: cfg.InjectRoots,
+		resolver:    cfg.Resolver,
+		verifier:    cfg.Verifier,
+		haInject:    cfg.HAInject,
+		logger:      cfg.Logger,
 	}
 }
 
-// loadKBArticles returns the current list of tag-aware KB articles by
-// scanning kbDir fresh. Scan errors are logged and the call returns an
-// empty slice, matching the prior constructor behavior. Callers that
-// need a stable snapshot within a single operation (e.g., Build) call
-// this once and iterate the result locally.
+// InjectRoot is one injection-eligible document root: the directory to
+// scan, and the optional capability tag that must be active before any
+// of its documents are considered at all.
+type InjectRoot struct {
+	Dir         string
+	RequiresTag string
+}
+
+// loadKBArticles returns the current list of tag-aware articles from
+// every injection-eligible root, scanned fresh. Scan errors are logged
+// per root and skipped rather than failing the whole assembly, so one
+// unreadable corpus cannot silence the others. Callers that need a
+// stable snapshot within a single operation (e.g., Build) call this once
+// and iterate the result locally.
+//
+// When no injection policy is declared, this falls back to the single
+// legacy kbDir scan so an existing config keeps assembling context
+// exactly as it did before roots could declare eligibility.
 func (a *TagContextAssembler) loadKBArticles() []kbArticle {
-	if a.kbDir == "" {
-		return nil
+	if a.injectRoots == nil {
+		if a.kbDir == "" {
+			return nil
+		}
+		articles, err := scanKBArticles(a.kbDir)
+		if err != nil {
+			a.logger.Warn("failed to scan KB directory for tagged articles",
+				"dir", a.kbDir, "error", err)
+			return nil
+		}
+		return articles
 	}
-	articles, err := scanKBArticles(a.kbDir)
-	if err != nil {
-		a.logger.Warn("failed to scan KB directory for tagged articles",
-			"dir", a.kbDir, "error", err)
-		return nil
+
+	names := make([]string, 0, len(a.injectRoots))
+	for name := range a.injectRoots {
+		names = append(names, name)
 	}
-	return articles
+	sort.Strings(names) // deterministic order across turns
+
+	var all []kbArticle
+	for _, name := range names {
+		root := a.injectRoots[name]
+		if root.Dir == "" {
+			continue
+		}
+		articles, err := scanKBArticles(root.Dir)
+		if err != nil {
+			a.logger.Warn("failed to scan injection-eligible root for tagged articles",
+				"root", name, "dir", root.Dir, "error", err)
+			continue
+		}
+		if root.RequiresTag != "" {
+			// A root-level gate is coarser than per-document tags: the
+			// whole corpus stays invisible until the capability is
+			// active, which is expressed by stamping the requirement
+			// onto each article's all-of set.
+			for i := range articles {
+				articles[i].TagsAll = append(articles[i].TagsAll, root.RequiresTag)
+			}
+		}
+		all = append(all, articles...)
+	}
+	return all
 }
 
 // RegisterTaggedProvider associates a provider with one capability

--- a/internal/runtime/agent/tag_context_test.go
+++ b/internal/runtime/agent/tag_context_test.go
@@ -1101,3 +1101,57 @@ func TestKBArticleTags_CountsTagsAll(t *testing.T) {
 		t.Errorf("unexpected extra tags in counts: %v", counts)
 	}
 }
+
+func TestBuildSystemPrompt_InjectRootsGovernEligibility(t *testing.T) {
+	kbDir := t.TempDir()
+	vaultDir := t.TempDir()
+	os.WriteFile(filepath.Join(kbDir, "guide.md"),
+		[]byte("---\ntags: [forge]\n---\n# Guide\nEligible guidance."), 0644)
+	os.WriteFile(filepath.Join(vaultDir, "notes.md"),
+		[]byte("---\ntags: [forge]\n---\n# Notes\nIneligible vault content."), 0644)
+
+	l := newTagTestLoop()
+	capTags := map[string]config.CapabilityTagConfig{
+		"forge": {Description: "Code generation", Tools: []string{"forge_run"}, Core: true},
+	}
+	// Only kb declares tagged injection; the vault root is present on
+	// disk with identically tagged content but is not eligible.
+	l.SetTagContextAssembler(NewTagContextAssembler(TagContextAssemblerConfig{
+		CapTags:     capTags,
+		KBDir:       kbDir,
+		InjectRoots: map[string]InjectRoot{"kb": {Dir: kbDir}},
+		Logger:      l.logger,
+	}))
+	l.SetCapabilityTags(capTags, nil)
+
+	prompt := l.buildSystemPrompt(testCtxForLoop(l), "hello")
+	if !strings.Contains(prompt, "Eligible guidance.") {
+		t.Error("an injection-eligible root's tagged article should inject")
+	}
+	if strings.Contains(prompt, "Ineligible vault content.") {
+		t.Error("a root that does not declare injection must not reach the prompt")
+	}
+}
+
+func TestBuildSystemPrompt_InjectRootRequiresTagGatesWholeRoot(t *testing.T) {
+	kbDir := t.TempDir()
+	os.WriteFile(filepath.Join(kbDir, "guide.md"),
+		[]byte("---\ntags: [forge]\n---\n# Guide\nGated corpus content."), 0644)
+
+	l := newTagTestLoop()
+	capTags := map[string]config.CapabilityTagConfig{
+		"forge": {Description: "Code generation", Tools: []string{"forge_run"}, Core: true},
+	}
+	// The article's own tag is active, but the root demands a second
+	// capability that is not.
+	l.SetTagContextAssembler(NewTagContextAssembler(TagContextAssemblerConfig{
+		CapTags:     capTags,
+		InjectRoots: map[string]InjectRoot{"kb": {Dir: kbDir, RequiresTag: "devops"}},
+		Logger:      l.logger,
+	}))
+	l.SetCapabilityTags(capTags, nil)
+
+	if prompt := l.buildSystemPrompt(testCtxForLoop(l), "hello"); strings.Contains(prompt, "Gated corpus content.") {
+		t.Error("requires_tag should keep the whole root out until its capability is active")
+	}
+}

--- a/internal/state/documents/policy.go
+++ b/internal/state/documents/policy.go
@@ -40,9 +40,46 @@ const (
 // RootPolicy describes indexing, authoring, and integrity policy for a
 // managed document root.
 type RootPolicy struct {
-	Indexing  bool          `json:"indexing"`
-	Authoring AuthoringMode `json:"authoring"`
-	Git       RootGitPolicy `json:"git,omitempty"`
+	Indexing  bool              `json:"indexing"`
+	Authoring AuthoringMode     `json:"authoring"`
+	Git       RootGitPolicy     `json:"git,omitempty"`
+	Context   RootContextPolicy `json:"context,omitempty"`
+}
+
+// Root context policy values, mirroring the config surface. Injection
+// eligibility is per root because a corpus is the only place the answer
+// can be given for documents Thane does not own and cannot annotate.
+const (
+	RootInjectNone      = "none"
+	RootInjectTagged    = "tagged"
+	RootSearchDefault   = "default"
+	RootSearchOnRequest = "on_request"
+	RootSearchNever     = "never"
+)
+
+// RootContextPolicy describes how a root's documents may reach a model:
+// whether they can be injected into a prompt, and how they surface in
+// search.
+type RootContextPolicy struct {
+	Inject      string `json:"inject,omitempty"`
+	Search      string `json:"search,omitempty"`
+	RequiresTag string `json:"requires_tag,omitempty"`
+}
+
+// EffectiveInject resolves injection eligibility, defaulting to none.
+func (p RootContextPolicy) EffectiveInject() string {
+	if p.Inject == "" {
+		return RootInjectNone
+	}
+	return p.Inject
+}
+
+// EffectiveSearch resolves search visibility, defaulting to full.
+func (p RootContextPolicy) EffectiveSearch() string {
+	if p.Search == "" {
+		return RootSearchDefault
+	}
+	return p.Search
 }
 
 // RootGitPolicy describes git-backed provenance policy for a managed
@@ -60,6 +97,18 @@ type RootPolicySummary struct {
 	Indexing  bool                 `json:"indexing"`
 	Authoring AuthoringMode        `json:"authoring"`
 	Git       RootGitPolicySummary `json:"git"`
+	// Context tells the model how this corpus reaches it: whether
+	// documents here can appear in a prompt unbidden, and whether an
+	// unscoped search will look here. Always emitted so the model can
+	// tell "no results" from "not searched by default".
+	Context RootContextSummary `json:"context"`
+}
+
+// RootContextSummary is the model-facing form of [RootContextPolicy].
+type RootContextSummary struct {
+	Inject      string `json:"inject"`
+	Search      string `json:"search"`
+	RequiresTag string `json:"requires_tag,omitempty"`
 }
 
 // RootGitPolicySummary is the model-facing form of [RootGitPolicy].
@@ -242,6 +291,11 @@ func (s *Store) rootPolicySummary(root string) RootPolicySummary {
 			SignCommits:      policy.Git.SignCommits,
 			VerifySignatures: policy.Git.VerifySignatures,
 			Revisions:        s.rootReviser(root) != nil,
+		},
+		Context: RootContextSummary{
+			Inject:      policy.Context.EffectiveInject(),
+			Search:      policy.Context.EffectiveSearch(),
+			RequiresTag: policy.Context.RequiresTag,
 		},
 	}
 }

--- a/internal/state/documents/query.go
+++ b/internal/state/documents/query.go
@@ -203,11 +203,17 @@ func (s *Store) Search(ctx context.Context, q SearchQuery) ([]DocumentSummary, e
 		score int
 	}
 	includeInternal := q.IncludeInternal || audienceExplicitlyFiltered(q)
+	// A root named in the query is being searched deliberately, so
+	// on_request visibility is satisfied by the naming itself.
+	rootNamed := q.Root != ""
 	var matches []scored
 	for rows.Next() {
 		var doc DocumentSummary
 		if err := scanDocument(rows, &doc); err != nil {
 			return nil, fmt.Errorf("scan search result: %w", err)
+		}
+		if !s.rootSearchable(doc.Root, rootNamed) {
+			continue
 		}
 		if !includeInternal && isInternalAudienceDocument(doc.Frontmatter) {
 			continue

--- a/internal/state/documents/query.go
+++ b/internal/state/documents/query.go
@@ -174,6 +174,19 @@ func (s *Store) Search(ctx context.Context, q SearchQuery) ([]DocumentSummary, e
 		where = append(where, `(rel_path = ? OR rel_path LIKE ?)`)
 		args = append(args, q.PathPrefix, q.PathPrefix+"/%")
 	}
+	// Exclude roots the context policy keeps out of this search in SQL
+	// rather than after scanning. The point of on_request visibility is
+	// that a large foreign corpus costs nothing when it was not asked
+	// for, which is not true if its rows are still fetched, decoded, and
+	// scored before being discarded.
+	if excluded := s.searchExcludedRoots(q.Root); len(excluded) > 0 {
+		placeholders := make([]string, len(excluded))
+		for i, root := range excluded {
+			placeholders[i] = "?"
+			args = append(args, root)
+		}
+		where = append(where, `root NOT IN (`+strings.Join(placeholders, ", ")+`)`)
+	}
 	if q.Query != "" {
 		like := "%" + q.Query + "%"
 		where = append(where, `(LOWER(title) LIKE ? OR LOWER(summary) LIKE ? OR LOWER(rel_path) LIKE ? OR LOWER(tags_json) LIKE ?)`)
@@ -203,17 +216,11 @@ func (s *Store) Search(ctx context.Context, q SearchQuery) ([]DocumentSummary, e
 		score int
 	}
 	includeInternal := q.IncludeInternal || audienceExplicitlyFiltered(q)
-	// A root named in the query is being searched deliberately, so
-	// on_request visibility is satisfied by the naming itself.
-	rootNamed := q.Root != ""
 	var matches []scored
 	for rows.Next() {
 		var doc DocumentSummary
 		if err := scanDocument(rows, &doc); err != nil {
 			return nil, fmt.Errorf("scan search result: %w", err)
-		}
-		if !s.rootSearchable(doc.Root, rootNamed) {
-			continue
 		}
 		if !includeInternal && isInternalAudienceDocument(doc.Frontmatter) {
 			continue

--- a/internal/state/documents/query_helpers.go
+++ b/internal/state/documents/query_helpers.go
@@ -89,6 +89,25 @@ func audienceExplicitlyFiltered(q SearchQuery) bool {
 	return false
 }
 
+// rootSearchable reports whether a root's documents may appear in this
+// search. A root set to on_request stays out of an unscoped query but is
+// fully reachable once the query names it — the shape a large foreign
+// corpus wants, where the documents are worth having but would drown an
+// open-ended search.
+func (s *Store) rootSearchable(root string, rootNamed bool) bool {
+	if s == nil {
+		return true
+	}
+	switch s.rootPolicy(normalizeRootName(root)).Context.EffectiveSearch() {
+	case RootSearchNever:
+		return false
+	case RootSearchOnRequest:
+		return rootNamed
+	default:
+		return true
+	}
+}
+
 func normalizeSearchFrontmatter(in map[string][]string) map[string][]string {
 	if len(in) == 0 {
 		return nil

--- a/internal/state/documents/query_helpers.go
+++ b/internal/state/documents/query_helpers.go
@@ -1,6 +1,9 @@
 package documents
 
-import "strings"
+import (
+	"sort"
+	"strings"
+)
 
 func hasFrontmatterKeys(frontmatter map[string][]string, keys []string) bool {
 	if len(keys) == 0 {
@@ -89,23 +92,35 @@ func audienceExplicitlyFiltered(q SearchQuery) bool {
 	return false
 }
 
-// rootSearchable reports whether a root's documents may appear in this
-// search. A root set to on_request stays out of an unscoped query but is
-// fully reachable once the query names it — the shape a large foreign
+// searchExcludedRoots returns the roots whose documents must not appear
+// in a search, given the root the query named (empty for an unscoped
+// search). A root set to on_request stays out of an unscoped query but
+// is fully reachable once the query names it — the shape a large foreign
 // corpus wants, where the documents are worth having but would drown an
 // open-ended search.
-func (s *Store) rootSearchable(root string, rootNamed bool) bool {
+//
+// The result feeds a SQL NOT IN clause so an excluded corpus is never
+// fetched, decoded, or scored: a root that was not asked for should cost
+// nothing, which is not true of a filter applied after the scan. Order
+// is deterministic to keep the generated query stable across calls.
+func (s *Store) searchExcludedRoots(namedRoot string) []string {
 	if s == nil {
-		return true
+		return nil
 	}
-	switch s.rootPolicy(normalizeRootName(root)).Context.EffectiveSearch() {
-	case RootSearchNever:
-		return false
-	case RootSearchOnRequest:
-		return rootNamed
-	default:
-		return true
+	named := normalizeRootName(namedRoot)
+	var excluded []string
+	for _, root := range s.allRoots() {
+		switch s.rootPolicy(root).Context.EffectiveSearch() {
+		case RootSearchNever:
+			excluded = append(excluded, root)
+		case RootSearchOnRequest:
+			if named != root {
+				excluded = append(excluded, root)
+			}
+		}
 	}
+	sort.Strings(excluded)
+	return excluded
 }
 
 func normalizeSearchFrontmatter(in map[string][]string) map[string][]string {

--- a/internal/state/documents/query_root_context_test.go
+++ b/internal/state/documents/query_root_context_test.go
@@ -1,0 +1,118 @@
+package documents
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/nugget/thane-ai-agent/internal/platform/database"
+)
+
+// newContextPolicyStore builds a two-root store where the second root
+// carries a declared search policy.
+func newContextPolicyStore(t *testing.T, search string) *Store {
+	t.Helper()
+
+	rootDir := t.TempDir()
+	kbDir := filepath.Join(rootDir, "kb")
+	vaultDir := filepath.Join(rootDir, "vault")
+	for _, dir := range []string{kbDir, vaultDir} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("MkdirAll: %v", err)
+		}
+	}
+	write := func(dir, name, body string) {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(body), 0o644); err != nil {
+			t.Fatalf("WriteFile: %v", err)
+		}
+	}
+	write(kbDir, "climate.md", "---\ntitle: Climate\n---\n\nClimate notes.")
+	write(vaultDir, "climate.md", "---\ntitle: Climate Vault\n---\n\nClimate vault notes.")
+
+	db, err := database.OpenMemory()
+	if err != nil {
+		t.Fatalf("OpenMemory: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+
+	store, err := NewStoreWithOptions(db, map[string]string{"kb": kbDir, "vault": vaultDir}, nil, StoreOptions{
+		RootPolicies: map[string]RootPolicy{
+			"vault": {Indexing: true, Authoring: AuthoringManaged, Context: RootContextPolicy{Search: search}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewStoreWithOptions: %v", err)
+	}
+	return store
+}
+
+func searchRootSet(t *testing.T, store *Store, q SearchQuery) map[string]bool {
+	t.Helper()
+	results, err := store.Search(context.Background(), q)
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	roots := map[string]bool{}
+	for _, doc := range results {
+		roots[doc.Root] = true
+	}
+	return roots
+}
+
+func TestSearchOnRequestRootExcludedFromUnscopedSearch(t *testing.T) {
+	t.Parallel()
+
+	store := newContextPolicyStore(t, RootSearchOnRequest)
+	roots := searchRootSet(t, store, SearchQuery{Query: "climate", Limit: 10})
+	if !roots["kb"] {
+		t.Fatalf("default-visibility root missing from unscoped search: %v", roots)
+	}
+	if roots["vault"] {
+		t.Fatalf("on_request root leaked into unscoped search: %v", roots)
+	}
+}
+
+func TestSearchOnRequestRootReachableWhenNamed(t *testing.T) {
+	t.Parallel()
+
+	store := newContextPolicyStore(t, RootSearchOnRequest)
+	roots := searchRootSet(t, store, SearchQuery{Root: "vault", Query: "climate", Limit: 10})
+	if !roots["vault"] {
+		t.Fatalf("naming an on_request root should search it: %v", roots)
+	}
+}
+
+func TestSearchNeverRootExcludedEvenWhenNamed(t *testing.T) {
+	t.Parallel()
+
+	store := newContextPolicyStore(t, RootSearchNever)
+	if roots := searchRootSet(t, store, SearchQuery{Root: "vault", Query: "climate", Limit: 10}); len(roots) != 0 {
+		t.Fatalf("never-searchable root returned results even when named: %v", roots)
+	}
+}
+
+func TestSearchUndeclaredPolicyKeepsFullVisibility(t *testing.T) {
+	t.Parallel()
+
+	store := newContextPolicyStore(t, "")
+	roots := searchRootSet(t, store, SearchQuery{Query: "climate", Limit: 10})
+	if !roots["kb"] || !roots["vault"] {
+		t.Fatalf("an undeclared policy must not change search visibility: %v", roots)
+	}
+}
+
+func TestRootPolicySummaryReportsContext(t *testing.T) {
+	t.Parallel()
+
+	store := newContextPolicyStore(t, RootSearchOnRequest)
+	summary := store.rootPolicySummary("vault")
+	if summary.Context.Search != RootSearchOnRequest {
+		t.Fatalf("summary search = %q, want on_request", summary.Context.Search)
+	}
+	// Defaults are emitted rather than omitted so the model can tell
+	// "will not inject" from "policy unknown".
+	if summary.Context.Inject != RootInjectNone {
+		t.Fatalf("summary inject = %q, want none", summary.Context.Inject)
+	}
+}

--- a/internal/state/documents/query_root_context_test.go
+++ b/internal/state/documents/query_root_context_test.go
@@ -116,3 +116,23 @@ func TestRootPolicySummaryReportsContext(t *testing.T) {
 		t.Fatalf("summary inject = %q, want none", summary.Context.Inject)
 	}
 }
+
+func TestSearchExcludedRootsDrivesSQLNotPostFilter(t *testing.T) {
+	t.Parallel()
+
+	store := newContextPolicyStore(t, RootSearchOnRequest)
+	// An unscoped search excludes the on_request root before the query
+	// runs, so its rows are never fetched, decoded, or scored.
+	if got := store.searchExcludedRoots(""); len(got) != 1 || got[0] != "vault" {
+		t.Fatalf("searchExcludedRoots(\"\") = %v, want [vault]", got)
+	}
+	// Naming it lifts the exclusion entirely.
+	if got := store.searchExcludedRoots("vault"); len(got) != 0 {
+		t.Fatalf("searchExcludedRoots(\"vault\") = %v, want empty", got)
+	}
+	// A never-searchable root stays excluded even when named.
+	never := newContextPolicyStore(t, RootSearchNever)
+	if got := never.searchExcludedRoots("vault"); len(got) != 1 || got[0] != "vault" {
+		t.Fatalf("never-searchable root should stay excluded when named, got %v", got)
+	}
+}


### PR DESCRIPTION
## What changes for an operator

A document root can now say how its documents are allowed to reach a model, next to where it already says who may write them and how they are signed:

```yaml
roots:
  knowledge:
    path: ./knowledge
    context:
      inject: tagged        # tagged documents may enter the prompt
      search: default
  nuggetvault:
    path: ~/Obsidian/Vault
    context:
      inject: none          # never reaches the prompt
      search: on_request    # reachable when named, never drowns an open query
```

Until now, injection eligibility was a hardcoded property of exactly one root: the tagged-article scan read a single resolved `kb:` directory. A tagged document in `kb:` could reach the system prompt; an identically tagged document in `projects:` or a mounted Obsidian vault could not, no matter what anyone wanted — and neither fact was expressible in config.

## Why this belongs on the root

Roots already carry `authoring`, `git`, and signing policy. Those all answer one question — how is this corpus governed — and context behavior is the same question at the same granularity. It was the only governance dimension living in Go instead of config.

Three things follow that per-document frontmatter cannot do. A five-hundred-document corpus shouldn't need five hundred frontmatter declarations to say "reference material, never injected." **Foreign corpora cannot be annotated at all** — you cannot add frontmatter to someone's Obsidian vault to keep it out of your prompt, so the root is the only place that answer can live. And "which corpora can reach my system prompt?" becomes answerable by reading config rather than scanning every document in every root.

## Injection is declared, never inferred

The safety property is the reason to do this now rather than later. A corpus that may inject can place text into a system prompt without anyone asking for it. `projects:` syncs **bidirectionally** from a remote every sixty seconds — today that is harmless only because injection is hardwired to `kb:`. The moment eligibility generalizes, anyone who can push to that remote could land text in the prompt by writing the right frontmatter.

So eligibility is never inferred from a document's own tags. A root reaches the prompt because policy says it may, and `inject` defaults to `none` for any root that declares a context policy at all. `requires_tag` adds a coarse companion to per-document tags: an entire corpus stays invisible until its capability is active, which is the cheap right shape when a whole vault is only relevant during devops work.

## Nothing moves under an existing config

A root that declares no context policy keeps its historical behavior exactly — the legacy single-`kb` scan stays in force, and all roots stay searchable. Policy is opt-in, so a deploy does not silently change how any prompt is assembled.

`doc_roots` now reports the effective policy for each root, including the defaults rather than omitting them, so the model can distinguish "searched and found nothing" from "not searched by default, name it explicitly."

## Where this is heading

This is a prerequisite for the relevance-triggered injection in #1250 phase 3 — matching an inbound request against the curated corpus and injecting what fits. Without root policy that feature matches against everything, including three Obsidian vaults and the scratchpad, and the fix for that is not a smarter matcher but a declaration of which corpora may volunteer themselves into context.

## Test plan

- [x] `on_request` root excluded from unscoped search, reachable when named
- [x] `never` root excluded even when named
- [x] Undeclared policy leaves search visibility unchanged
- [x] Only injection-eligible roots inject; an identically tagged document elsewhere does not
- [x] `requires_tag` keeps a whole root out until its capability is active
- [x] `doc_roots` reports effective policy including defaults
- [x] `just ci` green locally

Refs #787

🤖 Generated with [Claude Code](https://claude.com/claude-code)
