### PR TITLE
A file that cannot be named cannot be verified: config loads only from core

### DIFF
--- a/cmd/thane/caps.go
+++ b/cmd/thane/caps.go
@@ -22,10 +22,10 @@ import (
 // view, the CLI just formats it. This keeps the CLI free of any
 // resolver bootstrap and guarantees it shows the same shape the web
 // UI sees.
-func runCaps(ctx context.Context, stdout io.Writer, configPath, outputFmt string, args []string) error {
+func runCaps(ctx context.Context, stdout io.Writer, configPath, workspacePath, outputFmt string, args []string) error {
 	tag, includeExcluded := parseCapsArgs(args)
 
-	cfg, _, err := loadConfig(configPath)
+	cfg, _, err := loadConfig(configPath, workspacePath)
 	if err != nil {
 		return fmt.Errorf("load config: %w", err)
 	}

--- a/cmd/thane/main.go
+++ b/cmd/thane/main.go
@@ -3,7 +3,7 @@
 // It exposes an OpenAI-compatible API, an optional Ollama-compatible API
 // (for Home Assistant integration), and a CLI for one-shot queries and
 // document ingestion. Configuration is loaded from a single YAML file
-// discovered automatically (see [config.DefaultSearchPaths]).
+// loaded from {workspace}/core/config.yaml (see [config.FindConfig]).
 //
 // Usage:
 //
@@ -79,6 +79,7 @@ func run(ctx context.Context, stdout io.Writer, stderr io.Writer, args []string)
 	// concurrently from tests. Our argument surface is small enough that
 	// manual parsing is clearer than bringing in a CLI framework.
 	var configPath string
+	var workspacePath string
 	var outputFmt string // "text" (default) or "json"
 	var command string
 	var cmdArgs []string
@@ -90,6 +91,11 @@ func run(ctx context.Context, stdout io.Writer, stderr io.Writer, args []string)
 			i++ // skip the value
 		case strings.HasPrefix(args[i], "-config="):
 			configPath = strings.TrimPrefix(args[i], "-config=")
+		case args[i] == "-workspace" && i+1 < len(args):
+			workspacePath = args[i+1]
+			i++ // skip the value
+		case strings.HasPrefix(args[i], "-workspace="):
+			workspacePath = strings.TrimPrefix(args[i], "-workspace=")
 		case (args[i] == "-o" || args[i] == "--output") && i+1 < len(args):
 			outputFmt = args[i+1]
 			i++
@@ -121,7 +127,7 @@ func run(ctx context.Context, stdout io.Writer, stderr io.Writer, args []string)
 
 	switch command {
 	case "serve":
-		return runServe(ctx, stdout, stderr, configPath)
+		return runServe(ctx, stdout, stderr, configPath, workspacePath)
 	case "init":
 		dir := "."
 		if len(cmdArgs) > 0 {
@@ -129,23 +135,23 @@ func run(ctx context.Context, stdout io.Writer, stderr io.Writer, args []string)
 		}
 		return runInit(stdout, dir)
 	case "validate":
-		return runValidate(stdout, configPath, outputFmt)
+		return runValidate(stdout, configPath, workspacePath, outputFmt)
 	case "ask":
 		if len(cmdArgs) == 0 {
 			return fmt.Errorf("usage: thane ask <question>")
 		}
-		return runAsk(ctx, stdout, stderr, configPath, cmdArgs)
+		return runAsk(ctx, stdout, stderr, configPath, workspacePath, cmdArgs)
 	case "ingest":
 		if len(cmdArgs) == 0 {
 			return fmt.Errorf("usage: thane ingest <file.md>")
 		}
-		return runIngest(ctx, stdout, stderr, configPath, cmdArgs[0])
+		return runIngest(ctx, stdout, stderr, configPath, workspacePath, cmdArgs[0])
 	case "version":
 		return runVersion(stdout, outputFmt)
 	case "health":
 		return runHealth(ctx, stdout, cmdArgs)
 	case "caps":
-		return runCaps(ctx, stdout, configPath, outputFmt, cmdArgs)
+		return runCaps(ctx, stdout, configPath, workspacePath, outputFmt, cmdArgs)
 	case "":
 		return printUsage(stdout)
 	default:
@@ -218,12 +224,16 @@ func printUsage(w io.Writer) error {
 	fmt.Fprintln(w, "  version      Show version information")
 	fmt.Fprintln(w)
 	fmt.Fprintln(w, "Flags:")
-	fmt.Fprintln(w, "  -config <path>    Path to config file (default: auto-discover)")
+	fmt.Fprintln(w, "  -workspace <dir>  Instance workspace (default: ~/Thane)")
+	fmt.Fprintln(w, "  -config <path>    Load config from an exact path instead of the")
+	fmt.Fprintln(w, "                    workspace; for recovery only")
 	fmt.Fprintln(w, "  -o, --output fmt  Output format: text (default) or json")
 	fmt.Fprintln(w)
-	fmt.Fprintln(w, "Config search order:")
-	fmt.Fprintln(w, "  ./config.yaml, ~/Thane/config.yaml, ~/.config/thane/config.yaml,")
-	fmt.Fprintln(w, "  /config/config.yaml, /usr/local/etc/thane/config.yaml, /etc/thane/config.yaml")
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "Config location:")
+	fmt.Fprintln(w, "  <workspace>/core/config.yaml — the only location Thane loads.")
+	fmt.Fprintln(w, "  Config lives inside core so it can be signed and version-controlled;")
+	fmt.Fprintln(w, "  it decides what the rest of the system trusts.")
 	return nil
 }
 
@@ -231,12 +241,12 @@ func printUsage(w io.Writer) error {
 // minimal agent (in-memory conversation store, no router, no scheduler)
 // and processes a single question, printing the response to stdout.
 // Useful for quick smoke tests and debugging without starting the server.
-func runAsk(ctx context.Context, stdout io.Writer, stderr io.Writer, configPath string, args []string) error {
+func runAsk(ctx context.Context, stdout io.Writer, stderr io.Writer, configPath, workspacePath string, args []string) error {
 	logger := newLogger(stdout, slog.LevelInfo, "text")
 
 	question := strings.Join(args, " ")
 
-	cfg, cfgPath, err := loadConfig(configPath)
+	cfg, cfgPath, err := loadConfig(configPath, workspacePath)
 	if err != nil {
 		return err
 	}
@@ -291,11 +301,11 @@ func runAsk(ctx context.Context, stdout io.Writer, stderr io.Writer, configPath 
 // runIngest handles the "thane ingest <file.md>" subcommand. It parses
 // a markdown document into discrete facts and stores them in the fact
 // database, optionally generating embeddings for semantic search.
-func runIngest(ctx context.Context, stdout io.Writer, stderr io.Writer, configPath string, filePath string) error {
+func runIngest(ctx context.Context, stdout io.Writer, stderr io.Writer, configPath, workspacePath string, filePath string) error {
 	logger := newLogger(stdout, slog.LevelInfo, "text")
 	logger.Info("ingesting markdown document", "file", filePath)
 
-	cfg, _, err := loadConfig(configPath)
+	cfg, _, err := loadConfig(configPath, workspacePath)
 	if err != nil {
 		return err
 	}
@@ -347,11 +357,11 @@ func runIngest(ctx context.Context, stdout io.Writer, stderr io.Writer, configPa
 //  2. A shutdown checkpoint is persisted (conversations, facts, tasks)
 //  3. HTTP servers drain in-flight requests
 //  4. Database connections and the scheduler are closed via defers
-func runServe(ctx context.Context, stdout io.Writer, stderr io.Writer, configPath string) error {
+func runServe(ctx context.Context, stdout io.Writer, stderr io.Writer, configPath, workspacePath string) error {
 	logger := newLogger(stdout, slog.LevelInfo, "text")
 	logger.Info("starting Thane", "version", buildinfo.Version, "commit", buildinfo.GitCommit, "branch", buildinfo.GitBranch, "built", buildinfo.BuildTime)
 
-	cfg, cfgPath, err := loadConfig(configPath)
+	cfg, cfgPath, err := loadConfig(configPath, workspacePath)
 	if err != nil {
 		return err
 	}
@@ -464,12 +474,12 @@ func newLogger(w io.Writer, level slog.Level, format string) *slog.Logger {
 	)
 }
 
-// loadConfig locates and parses the YAML configuration file. If explicit
-// is non-empty, that exact path is used (and must exist). Otherwise,
-// [config.FindConfig] searches the default locations. Returns the parsed
-// config, the path that was loaded, and any error.
-func loadConfig(explicit string) (*config.Config, string, error) {
-	cfgPath, err := config.FindConfig(explicit)
+// loadConfig parses the runtime configuration. Without an explicit
+// path it loads the one canonical location, {workspace}/core/config.yaml,
+// so the file the rest of the system trusts always has a fixed name.
+// Returns the parsed config, the path that was loaded, and any error.
+func loadConfig(explicit, workspace string) (*config.Config, string, error) {
+	cfgPath, err := config.FindConfig(explicit, workspace)
 	if err != nil {
 		return nil, "", err
 	}

--- a/cmd/thane/validate.go
+++ b/cmd/thane/validate.go
@@ -22,8 +22,8 @@ import (
 // short structural summary. Mode "json" emits a single object with
 // path, valid, error (if any), and summary fields, suitable for
 // piping into jq.
-func runValidate(w io.Writer, configPath, outputFmt string) error {
-	cfg, cfgPath, loadErr := loadConfig(configPath)
+func runValidate(w io.Writer, configPath, workspacePath, outputFmt string) error {
+	cfg, cfgPath, loadErr := loadConfig(configPath, workspacePath)
 	// When discovery fails before a path is resolved, fall back to
 	// the operator's explicit -config value so the JSON report still
 	// names the file that was at fault. Stays empty when neither

--- a/cmd/thane/validate_test.go
+++ b/cmd/thane/validate_test.go
@@ -40,7 +40,7 @@ func TestRunValidate_HappyPath(t *testing.T) {
 	path := writeConfig(t, minimalValidConfig)
 	var buf bytes.Buffer
 
-	if err := runValidate(&buf, path, "text"); err != nil {
+	if err := runValidate(&buf, path, "", "text"); err != nil {
 		t.Fatalf("runValidate: %v", err)
 	}
 
@@ -58,7 +58,7 @@ func TestRunValidate_HappyPath(t *testing.T) {
 
 func TestRunValidate_MissingFile(t *testing.T) {
 	var buf bytes.Buffer
-	err := runValidate(&buf, "/nonexistent/path/config.yaml", "text")
+	err := runValidate(&buf, "/nonexistent/path/config.yaml", "", "text")
 	if err == nil {
 		t.Fatal("expected error for missing file, got nil")
 	}
@@ -73,7 +73,7 @@ func TestRunValidate_ParseError(t *testing.T) {
 	path := writeConfig(t, "models:\n  default: [this isn't a string\n")
 	var buf bytes.Buffer
 
-	err := runValidate(&buf, path, "text")
+	err := runValidate(&buf, path, "", "text")
 	if err == nil {
 		t.Fatal("expected parse error, got nil")
 	}
@@ -92,7 +92,7 @@ channel_tags:
 	path := writeConfig(t, body)
 	var buf bytes.Buffer
 
-	err := runValidate(&buf, path, "text")
+	err := runValidate(&buf, path, "", "text")
 	if err == nil {
 		t.Fatal("expected semantic error for undefined tag reference, got nil")
 	}
@@ -105,7 +105,7 @@ func TestRunValidate_JSONHappyPath(t *testing.T) {
 	path := writeConfig(t, minimalValidConfig)
 	var buf bytes.Buffer
 
-	if err := runValidate(&buf, path, "json"); err != nil {
+	if err := runValidate(&buf, path, "", "json"); err != nil {
 		t.Fatalf("runValidate: %v", err)
 	}
 
@@ -141,7 +141,7 @@ func TestRunValidate_JSONDiscoveryFailure(t *testing.T) {
 	const explicit = "/nonexistent/never-going-to-exist.yaml"
 	var buf bytes.Buffer
 
-	err := runValidate(&buf, explicit, "json")
+	err := runValidate(&buf, explicit, "", "json")
 	if err == nil {
 		t.Fatal("expected error for missing file, got nil")
 	}
@@ -179,7 +179,7 @@ channel_tags:
 	path := writeConfig(t, body)
 	var buf bytes.Buffer
 
-	err := runValidate(&buf, path, "json")
+	err := runValidate(&buf, path, "", "json")
 	if err == nil {
 		t.Fatal("expected error from runValidate, got nil")
 	}

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -19,7 +19,9 @@ Commands:
   version      Show version information
 
 Flags:
-  -config <path>    Path to config file (default: auto-discover)
+  -workspace <dir>  Instance workspace (default: ~/Thane)
+  -config <path>    Load config from an exact path instead of the
+                    workspace; for recovery only
   -o, --output fmt  Output format: text (default) or json
 ```
 
@@ -120,17 +122,39 @@ thane health http://127.0.0.1:8080/health
 Print version, commit hash, build time, and branch information. Version is
 injected at build time via ldflags.
 
-## Config Auto-Discovery
+## Config Location
 
-If no `-config` flag is provided, Thane searches these paths in order:
+Thane loads its runtime configuration from exactly one place:
 
-1. `./config.yaml`
-2. `~/Thane/config.yaml`
-3. `~/.config/thane/config.yaml`
-4. `/config/config.yaml`
-5. `/usr/local/etc/thane/config.yaml`
-6. `/etc/thane/config.yaml`
+```
+<workspace>/core/config.yaml
+```
 
-The first file found is used. See
-[Configuration](../operating/configuration.md) for what goes in the config
-file.
+The workspace defaults to `~/Thane` and is set with `-workspace`. There is
+no search path.
+
+That is deliberate. The config decides what the rest of the system
+trusts: it sets `verify_signatures`, names the allowed-signers source,
+chooses model endpoints, and points every document root at a path. A
+config found by probing several locations would make the trust anchor
+depend on the working directory, and a file that cannot be named cannot
+be verified. Living inside `core` means the config is git-tracked and
+signed like everything else in the trust boundary.
+
+`workspace.path` is derived from the config's own location rather than
+declared. A config that declares one contradicting where it was loaded
+from is rejected, since that disagreement means the instance's roots,
+state, and identity would point somewhere other than the directory the
+config came from.
+
+If no config exists at the canonical path but one is found at a
+pre-core location, Thane refuses to start and prints the exact commands
+to move and commit it.
+
+### Recovery
+
+`-config <path>` loads a config from an exact path, bypassing the
+workspace. It exists for recovery and debugging when the canonical
+config cannot be loaded — a rotated key, a broken core repository — and
+the config it loads is not covered by the trust boundary.
+

--- a/internal/platform/config/config.go
+++ b/internal/platform/config/config.go
@@ -59,8 +59,18 @@ const ConfigFileName = "config.yaml"
 // moved inside the trust boundary. They are no longer loaded; they are
 // probed only so a failure to find the real config can say where the old
 // one is and how to move it.
-func legacyConfigLocations() []string {
-	paths := []string{ConfigFileName}
+//
+// The instance's own workspace comes first. That is where an existing
+// instance's config actually sits, and it is the one location the fixed
+// list cannot express: a workspace given with -workspace matches neither
+// the working directory nor ~/Thane, so without it the migration
+// instructions would go missing in precisely the case that needs them.
+func legacyConfigLocations(workspace string) []string {
+	var paths []string
+	if abs, err := ExpandWorkspace(workspace); err == nil {
+		paths = append(paths, filepath.Join(abs, ConfigFileName))
+	}
+	paths = append(paths, ConfigFileName)
 	if home, err := os.UserHomeDir(); err == nil {
 		paths = append(paths,
 			filepath.Join(home, "Thane", ConfigFileName),
@@ -137,7 +147,7 @@ func FindConfig(explicit, workspace string) (string, error) {
 		return canonical, nil
 	}
 
-	if legacy := firstExistingLegacyConfig(); legacy != "" {
+	if legacy := firstExistingLegacyConfig(workspace); legacy != "" {
 		coreDir := filepath.Dir(canonical)
 		return "", fmt.Errorf(
 			"no config at %s\n\nA config still exists at the pre-core location %s. Thane now loads config only from inside the instance trust boundary, so it can be signed and version-controlled. Move it and commit it:\n\n  mkdir -p %s\n  git -C %s init    # if core is not a repo yet\n  mv %s %s\n  git -C %s add %s && git -C %s commit -S -m 'adopt runtime config into core'",
@@ -155,8 +165,8 @@ func FindConfig(explicit, workspace string) (string, error) {
 
 // firstExistingLegacyConfig reports the first pre-core config location
 // that still holds a file, or empty when none do.
-func firstExistingLegacyConfig() string {
-	for _, p := range legacyConfigLocations() {
+func firstExistingLegacyConfig(workspace string) string {
+	for _, p := range legacyConfigLocations(workspace) {
 		if _, err := os.Stat(p); err == nil {
 			abs, absErr := filepath.Abs(p)
 			if absErr != nil {

--- a/internal/platform/config/config.go
+++ b/internal/platform/config/config.go
@@ -47,40 +47,81 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-// DefaultSearchPaths returns the ordered list of paths that [FindConfig]
-// checks when no explicit path is provided. The first existing file wins.
-//
-// The search order is:
-//   - ./config.yaml (project directory / working directory)
-//   - ~/Thane/config.yaml (macOS role account convention)
-//   - ~/.config/thane/config.yaml (XDG user config)
-//   - /config/config.yaml (container convention)
-//   - /usr/local/etc/thane/config.yaml (macOS/BSD local sysconfig)
-//   - /etc/thane/config.yaml (system-wide)
+// DefaultWorkspace is the workspace directory used when none is given
+// on the command line. It matches the role-account convention the
+// installer and the packaged deployment both use.
+const DefaultWorkspace = "~/Thane"
 
-// searchPathsFunc is the function used to generate search paths.
-// Overridden in tests to avoid finding real config files on the host.
-var searchPathsFunc = DefaultSearchPaths
+// ConfigFileName is the fixed name of the runtime config inside core.
+const ConfigFileName = "config.yaml"
 
-func DefaultSearchPaths() []string {
-	paths := []string{"config.yaml"}
-
+// legacyConfigLocations are the paths Thane searched before the config
+// moved inside the trust boundary. They are no longer loaded; they are
+// probed only so a failure to find the real config can say where the old
+// one is and how to move it.
+func legacyConfigLocations() []string {
+	paths := []string{ConfigFileName}
 	if home, err := os.UserHomeDir(); err == nil {
-		paths = append(paths, filepath.Join(home, "Thane", "config.yaml"))
-		paths = append(paths, filepath.Join(home, ".config", "thane", "config.yaml"))
+		paths = append(paths,
+			filepath.Join(home, "Thane", ConfigFileName),
+			filepath.Join(home, ".config", "thane", ConfigFileName),
+		)
 	}
-
-	paths = append(paths, "/config/config.yaml")
-	paths = append(paths, "/usr/local/etc/thane/config.yaml")
-	paths = append(paths, "/etc/thane/config.yaml")
-	return paths
+	return append(paths,
+		filepath.Join("/config", ConfigFileName),
+		filepath.Join("/usr/local/etc/thane", ConfigFileName),
+		filepath.Join("/etc/thane", ConfigFileName),
+	)
 }
 
-// FindConfig locates a configuration file. If explicit is non-empty, that
-// exact path must exist or an error is returned. Otherwise, the paths from
-// [DefaultSearchPaths] are tried in order, and the first that exists is
-// returned. Returns an error if no config file can be found.
-func FindConfig(explicit string) (string, error) {
+// ExpandWorkspace resolves a workspace argument to an absolute path,
+// expanding a leading ~ and defaulting when empty.
+func ExpandWorkspace(workspace string) (string, error) {
+	workspace = strings.TrimSpace(workspace)
+	if workspace == "" {
+		workspace = DefaultWorkspace
+	}
+	if workspace == "~" || strings.HasPrefix(workspace, "~/") {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("cannot expand %q: no home directory: %w", workspace, err)
+		}
+		workspace = filepath.Join(home, strings.TrimPrefix(strings.TrimPrefix(workspace, "~"), "/"))
+	}
+	abs, err := filepath.Abs(workspace)
+	if err != nil {
+		return "", fmt.Errorf("cannot resolve workspace %q: %w", workspace, err)
+	}
+	return abs, nil
+}
+
+// ConfigPathForWorkspace returns the one location Thane loads runtime
+// config from: {workspace}/core/config.yaml.
+//
+// There is deliberately no search. The config names the allowed-signers
+// source, sets verify_signatures, chooses model endpoints, and points
+// every document root at a path — so it decides what the rest of the
+// system is willing to trust. A trust anchor discovered by probing the
+// filesystem is not an anchor: whichever file is found first becomes
+// authoritative, and the answer changes with the working directory. One
+// derived location means the config always has a name, which is the
+// precondition for verifying it.
+func ConfigPathForWorkspace(workspace string) (string, error) {
+	abs, err := ExpandWorkspace(workspace)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(abs, "core", ConfigFileName), nil
+}
+
+// FindConfig returns the config path for a workspace, or the explicit
+// path when one is given (the unverified-config escape hatch, whose
+// caller is responsible for degrading the runtime accordingly).
+//
+// When the canonical config is absent, the error names any config left
+// at a legacy location and gives the exact commands to adopt it, so the
+// migration is one unambiguous step rather than a hunt.
+func FindConfig(explicit, workspace string) (string, error) {
 	if explicit != "" {
 		if _, err := os.Stat(explicit); err != nil {
 			return "", fmt.Errorf("config file not found: %s", explicit)
@@ -88,13 +129,43 @@ func FindConfig(explicit string) (string, error) {
 		return explicit, nil
 	}
 
-	for _, p := range searchPathsFunc() {
-		if _, err := os.Stat(p); err == nil {
-			return p, nil
-		}
+	canonical, err := ConfigPathForWorkspace(workspace)
+	if err != nil {
+		return "", err
+	}
+	if _, err := os.Stat(canonical); err == nil {
+		return canonical, nil
 	}
 
-	return "", fmt.Errorf("no config file found (searched: %v)", DefaultSearchPaths())
+	if legacy := firstExistingLegacyConfig(); legacy != "" {
+		coreDir := filepath.Dir(canonical)
+		return "", fmt.Errorf(
+			"no config at %s\n\nA config still exists at the pre-core location %s. Thane now loads config only from inside the instance trust boundary, so it can be signed and version-controlled. Move it and commit it:\n\n  mkdir -p %s\n  git -C %s init    # if core is not a repo yet\n  mv %s %s\n  git -C %s add %s && git -C %s commit -S -m 'adopt runtime config into core'",
+			canonical, legacy,
+			coreDir,
+			coreDir,
+			legacy, canonical,
+			coreDir, ConfigFileName, coreDir,
+		)
+	}
+
+	return "", fmt.Errorf("no config at %s (run 'thane init %s' to create one, or pass -workspace to point at a different instance)",
+		canonical, filepath.Dir(filepath.Dir(canonical)))
+}
+
+// firstExistingLegacyConfig reports the first pre-core config location
+// that still holds a file, or empty when none do.
+func firstExistingLegacyConfig() string {
+	for _, p := range legacyConfigLocations() {
+		if _, err := os.Stat(p); err == nil {
+			abs, absErr := filepath.Abs(p)
+			if absErr != nil {
+				return p
+			}
+			return abs
+		}
+	}
+	return ""
 }
 
 // Config is the top-level configuration structure for the Thane agent,
@@ -107,6 +178,12 @@ func FindConfig(explicit string) (string, error) {
 // need empty-string checks or fallback logic. See [Config.applyDefaults]
 // for the defaulting rules and [Config.Validate] for consistency checks.
 type Config struct {
+	// loadedFrom is the path this config was read from. It is not a
+	// configurable value — it records provenance, and workspace.path is
+	// derived from it, so the runtime knows where its instance lives
+	// without trusting the file to say.
+	loadedFrom string
+
 	// Listen configures the primary HTTP API server (OpenAI-compatible).
 	Listen ListenConfig `yaml:"listen"`
 
@@ -2172,6 +2249,59 @@ type StateWindowConfig struct {
 //     shape).
 //  5. Apply defaults via [Config.applyDefaults].
 //  6. Validate via [Config.Validate].
+//
+// deriveWorkspace sets workspace.path from the config's own location
+// rather than trusting the file to describe where it lives.
+//
+// A config at {workspace}/core/config.yaml already states its workspace
+// by sitting there, so a declared workspace.path can only agree or lie.
+// Deriving it removes a field that could point the instance's roots,
+// state, and identity somewhere other than the directory the config was
+// loaded from — and a declared value that disagrees is rejected rather
+// than silently overridden, because the disagreement itself means one of
+// the two is wrong in a way the operator needs to see.
+func (c *Config) deriveWorkspace() error {
+	if c.loadedFrom == "" {
+		return nil
+	}
+	abs, err := filepath.Abs(c.loadedFrom)
+	if err != nil {
+		return fmt.Errorf("resolve config path %q: %w", c.loadedFrom, err)
+	}
+	coreDir := filepath.Dir(abs)
+	if filepath.Base(coreDir) != "core" {
+		// A config outside core — the recovery escape hatch, or a
+		// minimal config for a one-shot command — keeps whatever it
+		// declared, including nothing. An absent workspace is already a
+		// handled state: the features that need one say so when they
+		// are configured.
+		return nil
+	}
+	derived := filepath.Dir(coreDir)
+
+	if declared := strings.TrimSpace(c.Workspace.Path); declared != "" {
+		declaredAbs, err := ExpandWorkspace(declared)
+		if err != nil {
+			return err
+		}
+		if declaredAbs != derived {
+			return fmt.Errorf("workspace.path %q does not match the directory this config was loaded from (%s); remove workspace.path — it is derived from the config location", declared, derived)
+		}
+	}
+	c.Workspace.Path = derived
+	return nil
+}
+
+// LoadedFrom reports the path this config was read from, or empty when
+// it was not produced by [Load]. The integrity gate needs it to verify
+// the file it is actually running on.
+func (c *Config) LoadedFrom() string {
+	if c == nil {
+		return ""
+	}
+	return c.loadedFrom
+}
+
 func Load(path string) (*Config, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
@@ -2186,6 +2316,11 @@ func Load(path string) (*Config, error) {
 
 	cfg := &Config{}
 	if err := yaml.Unmarshal([]byte(expanded), cfg); err != nil {
+		return nil, err
+	}
+	cfg.loadedFrom = path
+
+	if err := cfg.deriveWorkspace(); err != nil {
 		return nil, err
 	}
 

--- a/internal/platform/config/config_test.go
+++ b/internal/platform/config/config_test.go
@@ -51,18 +51,68 @@ func TestFindConfig_LoadsFromWorkspaceCore(t *testing.T) {
 }
 
 func TestFindConfig_IgnoresConfigOutsideCore(t *testing.T) {
-	// A config beside core is not a fallback. Loading it would put the
-	// file that defines the trust policy outside the trust boundary.
+	// A config beside core is not a fallback — loading it would put the
+	// file that defines the trust policy outside the trust boundary —
+	// but it is the likeliest thing an upgrading instance has, so the
+	// failure has to hand back a usable migration instead of just
+	// refusing. Asserting only that this errors would pass even when the
+	// guidance goes missing.
 	workspace := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(workspace, "core"), 0o755); err != nil {
 		t.Fatalf("MkdirAll: %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(workspace, "config.yaml"), []byte("listen:\n  port: 8080\n"), 0o600); err != nil {
+	legacy := filepath.Join(workspace, "config.yaml")
+	if err := os.WriteFile(legacy, []byte("listen:\n  port: 8080\n"), 0o600); err != nil {
 		t.Fatalf("WriteFile: %v", err)
 	}
 
-	if _, err := FindConfig("", workspace); err == nil {
+	_, err := FindConfig("", workspace)
+	if err == nil {
 		t.Fatal("FindConfig should not fall back to a config outside core")
+	}
+	got := err.Error()
+	canonical := filepath.Join(workspace, "core", "config.yaml")
+	for _, want := range []string{
+		canonical, // where the config must end up
+		legacy,    // where it is now
+		"mv " + legacy + " " + canonical,
+		"commit -S",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("migration guidance missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestFindConfig_LegacyProbeFindsWorkspaceConfigFromAnyCWD(t *testing.T) {
+	// The workspace-adjacent config is the one location the fixed legacy
+	// list cannot express: with -workspace pointing somewhere that is
+	// neither the working directory nor ~/Thane, probing only those would
+	// lose the migration instructions exactly when they are needed.
+	workspace := t.TempDir()
+	legacy := filepath.Join(workspace, "config.yaml")
+	if err := os.WriteFile(legacy, []byte("listen:\n  port: 8080\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	// Run from an unrelated directory so a CWD-relative probe cannot be
+	// what finds it.
+	elsewhere := t.TempDir()
+	orig, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd: %v", err)
+	}
+	if err := os.Chdir(elsewhere); err != nil {
+		t.Fatalf("Chdir: %v", err)
+	}
+	t.Cleanup(func() { os.Chdir(orig) })
+
+	_, err = FindConfig("", workspace)
+	if err == nil {
+		t.Fatal("FindConfig should error when only a pre-core config exists")
+	}
+	if !strings.Contains(err.Error(), legacy) {
+		t.Fatalf("error should name the workspace-adjacent legacy config:\n%s", err)
 	}
 }
 

--- a/internal/platform/config/config_test.go
+++ b/internal/platform/config/config_test.go
@@ -14,7 +14,7 @@ func TestFindConfig_Explicit(t *testing.T) {
 	path := filepath.Join(dir, "test.yaml")
 	os.WriteFile(path, []byte("listen:\n  port: 9999\n"), 0600)
 
-	got, err := FindConfig(path)
+	got, err := FindConfig(path, "")
 	if err != nil {
 		t.Fatalf("FindConfig(%q) error: %v", path, err)
 	}
@@ -24,45 +24,56 @@ func TestFindConfig_Explicit(t *testing.T) {
 }
 
 func TestFindConfig_ExplicitMissing(t *testing.T) {
-	_, err := FindConfig("/nonexistent/config.yaml")
+	_, err := FindConfig("/nonexistent/config.yaml", "")
 	if err == nil {
 		t.Fatal("FindConfig with missing explicit path should error")
 	}
 }
 
-func TestFindConfig_SearchPath(t *testing.T) {
-	// When no config exists anywhere, should error.
-	// Override searchPathsFunc to avoid finding real config files
-	// on developer/deploy machines (~/Thane/config.yaml,
-	// /usr/local/etc/thane/config.yaml, etc.).
-	dir := t.TempDir()
-	orig := searchPathsFunc
-	searchPathsFunc = func() []string {
-		return []string{filepath.Join(dir, "config.yaml")}
+func TestFindConfig_LoadsFromWorkspaceCore(t *testing.T) {
+	workspace := t.TempDir()
+	coreDir := filepath.Join(workspace, "core")
+	if err := os.MkdirAll(coreDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
 	}
-	defer func() { searchPathsFunc = orig }()
+	want := filepath.Join(coreDir, "config.yaml")
+	if err := os.WriteFile(want, []byte("listen:\n  port: 8080\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
 
-	_, err := FindConfig("")
-	if err == nil {
-		t.Fatal("FindConfig(\"\") with no config files should error")
+	got, err := FindConfig("", workspace)
+	if err != nil {
+		t.Fatalf("FindConfig: %v", err)
+	}
+	if got != want {
+		t.Fatalf("FindConfig() = %q, want %q", got, want)
 	}
 }
 
-func TestFindConfig_CWD(t *testing.T) {
-	dir := t.TempDir()
-	path := filepath.Join(dir, "config.yaml")
-	os.WriteFile(path, []byte("listen:\n  port: 8080\n"), 0600)
-
-	orig, _ := os.Getwd()
-	os.Chdir(dir)
-	defer os.Chdir(orig)
-
-	got, err := FindConfig("")
-	if err != nil {
-		t.Fatalf("FindConfig(\"\") error: %v", err)
+func TestFindConfig_IgnoresConfigOutsideCore(t *testing.T) {
+	// A config beside core is not a fallback. Loading it would put the
+	// file that defines the trust policy outside the trust boundary.
+	workspace := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(workspace, "core"), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
 	}
-	if got != "config.yaml" {
-		t.Errorf("FindConfig(\"\") = %q, want %q", got, "config.yaml")
+	if err := os.WriteFile(filepath.Join(workspace, "config.yaml"), []byte("listen:\n  port: 8080\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	if _, err := FindConfig("", workspace); err == nil {
+		t.Fatal("FindConfig should not fall back to a config outside core")
+	}
+}
+
+func TestFindConfig_MissingConfigNamesTheWorkspace(t *testing.T) {
+	workspace := t.TempDir()
+	_, err := FindConfig("", workspace)
+	if err == nil {
+		t.Fatal("FindConfig with no config should error")
+	}
+	if !strings.Contains(err.Error(), filepath.Join(workspace, "core", "config.yaml")) {
+		t.Fatalf("error should name the canonical path: %v", err)
 	}
 }
 

--- a/internal/platform/config/workspace_derivation_test.go
+++ b/internal/platform/config/workspace_derivation_test.go
@@ -1,0 +1,111 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeCoreConfig(t *testing.T, body string) (workspace, path string) {
+	t.Helper()
+	workspace = t.TempDir()
+	coreDir := filepath.Join(workspace, "core")
+	if err := os.MkdirAll(coreDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	path = filepath.Join(coreDir, "config.yaml")
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	return workspace, path
+}
+
+func TestLoadDerivesWorkspaceFromCoreLocation(t *testing.T) {
+	workspace, path := writeCoreConfig(t, "listen:\n  port: 8080\n")
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.Workspace.Path != workspace {
+		t.Fatalf("Workspace.Path = %q, want the config's own workspace %q", cfg.Workspace.Path, workspace)
+	}
+	if cfg.LoadedFrom() != path {
+		t.Fatalf("LoadedFrom() = %q, want %q", cfg.LoadedFrom(), path)
+	}
+}
+
+func TestLoadAcceptsMatchingDeclaredWorkspace(t *testing.T) {
+	workspace := t.TempDir()
+	coreDir := filepath.Join(workspace, "core")
+	if err := os.MkdirAll(coreDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	path := filepath.Join(coreDir, "config.yaml")
+	body := "listen:\n  port: 8080\nworkspace:\n  path: " + workspace + "\n"
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load with a matching declaration should succeed: %v", err)
+	}
+	if cfg.Workspace.Path != workspace {
+		t.Fatalf("Workspace.Path = %q, want %q", cfg.Workspace.Path, workspace)
+	}
+}
+
+func TestLoadRejectsConflictingDeclaredWorkspace(t *testing.T) {
+	// A config states its workspace by sitting in it. A declaration that
+	// disagrees would point roots, state, and identity somewhere other
+	// than where the file lives — so the disagreement is surfaced rather
+	// than silently resolved either way.
+	workspace := t.TempDir()
+	elsewhere := t.TempDir()
+	coreDir := filepath.Join(workspace, "core")
+	if err := os.MkdirAll(coreDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	path := filepath.Join(coreDir, "config.yaml")
+	body := "listen:\n  port: 8080\nworkspace:\n  path: " + elsewhere + "\n"
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	_, err := Load(path)
+	if err == nil {
+		t.Fatal("Load should reject a workspace.path that contradicts the config location")
+	}
+	if !strings.Contains(err.Error(), "derived from the config location") {
+		t.Fatalf("error should explain the derivation: %v", err)
+	}
+}
+
+func TestConfigPathForWorkspace(t *testing.T) {
+	got, err := ConfigPathForWorkspace("/srv/thane")
+	if err != nil {
+		t.Fatalf("ConfigPathForWorkspace: %v", err)
+	}
+	if want := filepath.Join("/srv/thane", "core", "config.yaml"); got != want {
+		t.Fatalf("ConfigPathForWorkspace() = %q, want %q", got, want)
+	}
+}
+
+func TestExpandWorkspaceDefaultsAndExpands(t *testing.T) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Skip("no home directory")
+	}
+	got, err := ExpandWorkspace("")
+	if err != nil {
+		t.Fatalf("ExpandWorkspace: %v", err)
+	}
+	if want := filepath.Join(home, "Thane"); got != want {
+		t.Fatalf("ExpandWorkspace(\"\") = %q, want %q", got, want)
+	}
+	if got, err = ExpandWorkspace("~/Elsewhere"); err != nil || got != filepath.Join(home, "Elsewhere") {
+		t.Fatalf("ExpandWorkspace(\"~/Elsewhere\") = %q, %v", got, err)
+	}
+}


### PR DESCRIPTION
## What changes

Thane loads runtime config from exactly one place:

```
<workspace>/core/config.yaml
```

The workspace comes from `-workspace` and defaults to `~/Thane`. The six-location search path is gone.

This replaces #1256, which merely *preferred* core and warned. That would have left the flexible search in place as something to remove later, and a warning phase people learn to ignore is not a migration.

## Why a search path was the wrong shape for this file

The config decides what the rest of the system is willing to trust. It sets `verify_signatures`, names the allowed-signers source, chooses model endpoints, and points every document root at a path — including the roots that, as of #1255, may inject text into a system prompt.

An attacker who controls the config never has to defeat signature verification; they can switch it off, or repoint `kb:` at a directory they own. So every downstream check is bootstrapped from this one file, which makes it the trust anchor whether or not we treat it as one.

A trust anchor discovered by probing six locations, first match wins, is not an anchor. The effective config depended on the working directory, whoever could write `./config.yaml` won, and "which config is this instance running?" had no fixed answer. **A file that cannot be named cannot be verified** — so naming it is the precondition for the signature and history gates that follow, not merely tidier.

## Workspace is derived, not declared

`workspace.path` used to live inside the file we were trying to locate, which is circular. Now it is derived from where the config actually is: a config at `X/core/config.yaml` establishes `X` as the workspace by sitting there.

That removes a field that could lie. A declared `workspace.path` could only agree with the load path or contradict it, and a contradiction would send roots, state, and identity somewhere other than the directory the config came from. A matching declaration is accepted for compatibility; a conflicting one is rejected with an error saying to remove the field. A config outside core keeps whatever it declared, including nothing.

One knob of ambient input instead of six, and it also covers the deployment shapes the search path existed for: a container runs `-workspace /data`, a system service runs `-workspace /var/lib/thane`.

## Migration is one unambiguous step

When the canonical config is absent but one is found at a pre-core location, startup fails and prints the exact commands:

```
no config at /Users/aimee/Thane/core/config.yaml

A config still exists at the pre-core location /Users/aimee/Thane/config.yaml.
Thane now loads config only from inside the instance trust boundary, so it can
be signed and version-controlled. Move it and commit it:

  mkdir -p /Users/aimee/Thane/core
  git -C /Users/aimee/Thane/core init    # if core is not a repo yet
  mv /Users/aimee/Thane/config.yaml /Users/aimee/Thane/core/config.yaml
  git -C ... add config.yaml && git -C ... commit -S -m 'adopt runtime config into core'
```

A config sitting beside core is never a fallback, because falling back to it would put the file that defines the trust policy outside the trust boundary — the exact thing this change exists to prevent.

## Recovery

`-config <path>` still loads an exact path, for when the canonical config cannot be loaded at all: a rotated key, a broken core repository. It is deliberately outside the trust boundary, and the runtime degradation that should accompany it (no egress, no writes to signed roots, no autonomous loops) lands with the verification gate, since there is nothing yet to degrade *from*.

## What comes next

This is the first of four. Next is `thane validate` as a full integrity report — every check the boot gate will run, with the command that fixes each failure — because most bad days here are "why won't it start?" rather than "I need a degraded runtime." Then the boot-time verification gate itself, then safe mode.

## Test plan

- [x] Config loads from `{workspace}/core/config.yaml`
- [x] A config beside core is not a fallback
- [x] Missing config names the canonical path; the pre-core case prints the migration commands
- [x] Workspace derived from the config's location; matching declaration accepted; conflicting declaration rejected
- [x] `-config` still loads an exact path; a config outside core keeps its declared workspace, or none
- [x] `ExpandWorkspace` defaults to `~/Thane` and expands `~`
- [x] `just ci` green locally

Refs #787

🤖 Generated with [Claude Code](https://claude.com/claude-code)
