### PR TITLE
An unattested config should not act like an attested one: safe mode

### DIFF
--- a/cmd/thane/main.go
+++ b/cmd/thane/main.go
@@ -622,6 +622,13 @@ func loadConfig(explicit, workspace string) (*config.Config, string, error) {
 	if err != nil {
 		return nil, cfgPath, fmt.Errorf("load config %s: %w", cfgPath, err)
 	}
+	if explicit != "" {
+		// Marked at load rather than at the gate so every command
+		// inherits it, not only the one that verifies. A config named
+		// on the command line sits outside the boundary by definition,
+		// and nothing downstream should have to re-derive that.
+		cfg.MarkUnverified()
+	}
 
 	return cfg, cfgPath, nil
 }

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -223,6 +223,24 @@ would run.
 the workspace. It exists for recovery and debugging when the canonical
 config cannot be loaded — a rotated key, a broken core repository.
 
+An instance started this way runs with capabilities withheld, because a
+configuration nobody can be shown to have authorized should not be able
+to act on the world as though someone had:
+
+- **Tools that contact a human directly are refused** — Signal, email,
+  notifications, escalations. The refusal explains the state rather than
+  reporting the tool as missing, so the model reports its findings in its
+  reply instead of looking for another route to the same person.
+- **Service loops do not start automatically.** Unattended work needs a
+  verified instance; an operator can still launch a specific loop
+  deliberately.
+- **`/health` reports `status: degraded` with `trust: unverified`**, so a
+  supervisor cannot mistake a recovery session for a healthy instance
+  left running indefinitely.
+- **The model is told**, in its own context, that its configuration is
+  unattested and which capabilities are withheld — before it plans around
+  having them.
+
 The name is literal rather than cautionary. Verification means a file is
 covered by the instance's signed core history, which a file outside core
 cannot be; so a config loaded this way is insecure by construction, not

--- a/internal/app/finalize_capability_tags.go
+++ b/internal/app/finalize_capability_tags.go
@@ -9,6 +9,7 @@ import (
 	"github.com/nugget/thane-ai-agent/internal/platform/config"
 	"github.com/nugget/thane-ai-agent/internal/platform/paths"
 	"github.com/nugget/thane-ai-agent/internal/runtime/agent"
+	"github.com/nugget/thane-ai-agent/internal/tools"
 )
 
 // finalizeCapabilityTags resolves capability-tag membership from the
@@ -39,6 +40,14 @@ import (
 func (a *App) finalizeCapabilityTags(s *newState) error {
 	cfg := a.cfg
 	logger := a.logger
+
+	if cfg.Unverified() {
+		// Withheld here, once the registry is fully assembled, so the
+		// denial covers every tool any later path can reach.
+		a.loop.Tools().WithholdDirectHumanEgress()
+		logger.Warn("withholding direct human egress tools: config is unverified",
+			"tools", tools.DirectHumanEgressToolNames())
+	}
 
 	resolved := resolveCapabilityTags(a.loop.Tools(), cfg.CapabilityTags)
 	resolvedCapTags := resolved.Configs

--- a/internal/app/new_awareness.go
+++ b/internal/app/new_awareness.go
@@ -32,6 +32,9 @@ func (a *App) initAwareness(s *newState) error {
 	// loops can opt out of always-on providers by setting
 	// Launch.SuppressAlwaysContext = true.
 	contactLookup := &contactNameLookup{store: a.contactStore, logger: logger}
+	if a.cfg.Unverified() {
+		a.loop.RegisterAlwaysContextProvider(agent.NewUnverifiedTrustProvider(a.cfg.LoadedFrom()))
+	}
 	a.loop.RegisterAlwaysContextProvider(agent.NewChannelProvider(contactLookup))
 	a.loop.UseContactLookup(contactLookup)
 	// Self-context: inject the running loop's own canonical row each iteration

--- a/internal/app/new_servers.go
+++ b/internal/app/new_servers.go
@@ -71,6 +71,9 @@ func (a *App) initServers(s *newState) error {
 	if a.indexDB != nil {
 		server.UseLogQuerier(&logQueryAdapter{db: a.indexDB})
 	}
+	if a.cfg.Unverified() {
+		server.SetUnverified(true)
+	}
 	server.SetConnManager(func() map[string]api.DependencyStatus {
 		status := a.connMgr.Status()
 		result := make(map[string]api.DependencyStatus, len(status))
@@ -612,6 +615,16 @@ func (a *App) initServers(s *newState) error {
 			// below registers. Idempotent if anyone calls it again.
 			if err := a.ensureCoreLoop(ctx); err != nil {
 				return fmt.Errorf("ensure core loop: %w", err)
+			}
+			if a.cfg.Unverified() {
+				// Service loops act on their own schedule for as long as
+				// the process lives. An instance that cannot show who
+				// authorized its config should not be starting unattended
+				// work; an operator who wants a specific loop can launch
+				// it deliberately.
+				logger.Warn("not starting service loops: config is unverified",
+					"resolution", "restart on a verified config, or launch a loop explicitly")
+				return nil
 			}
 			result, err := a.loopDefinitionRuntime.StartEnabledServices(ctx)
 			if err != nil {

--- a/internal/platform/config/config.go
+++ b/internal/platform/config/config.go
@@ -194,6 +194,11 @@ type Config struct {
 	// without trusting the file to say.
 	loadedFrom string
 
+	// unverified marks a config loaded from outside the instance trust
+	// boundary. It is set by the loader rather than declared, because a
+	// config cannot be trusted to describe its own trustworthiness.
+	unverified bool
+
 	// Listen configures the primary HTTP API server (OpenAI-compatible).
 	Listen ListenConfig `yaml:"listen"`
 
@@ -2300,6 +2305,26 @@ func (c *Config) deriveWorkspace() error {
 	}
 	c.Workspace.Path = derived
 	return nil
+}
+
+// MarkUnverified records that this config came from outside the trust
+// boundary, so the runtime can withhold the capabilities that an
+// unverified instance should not have.
+func (c *Config) MarkUnverified() {
+	if c != nil {
+		c.unverified = true
+	}
+}
+
+// Unverified reports whether the running config came from outside the
+// instance trust boundary.
+//
+// The runtime consults this to decide what to withhold. Verification is
+// not a label on the file but a claim about who was entitled to write
+// it, so an instance that cannot make the claim should not be able to
+// act on the world as though it could.
+func (c *Config) Unverified() bool {
+	return c != nil && c.unverified
 }
 
 // LoadedFrom reports the path this config was read from, or empty when

--- a/internal/runtime/agent/trust_provider.go
+++ b/internal/runtime/agent/trust_provider.go
@@ -1,0 +1,56 @@
+package agent
+
+import (
+	"context"
+
+	"github.com/nugget/thane-ai-agent/internal/runtime/agentctx"
+)
+
+// UnverifiedTrustProvider tells the model that the instance it is
+// running inside could not verify its own configuration.
+//
+// The withheld tools already produce an error when reached, but an
+// error at the moment of use is late: by then the model has committed
+// to a plan that assumed it could reach someone. Stating the condition
+// up front lets it choose differently — finish the analysis, put the
+// findings in its reply, and say plainly that the instance needs
+// attention.
+//
+// It also matters for judgment rather than capability. An instance that
+// cannot show who authorized its configuration should be more reluctant
+// about consequential action generally, not only about the specific
+// tools that happen to be blocked.
+type UnverifiedTrustProvider struct {
+	configPath string
+}
+
+// NewUnverifiedTrustProvider builds the provider for an instance running
+// on an unverified config.
+func NewUnverifiedTrustProvider(configPath string) *UnverifiedTrustProvider {
+	return &UnverifiedTrustProvider{configPath: configPath}
+}
+
+// TagContextBucket puts this in live state: it describes the current
+// operating condition of the instance, and it changes only on restart.
+func (p *UnverifiedTrustProvider) TagContextBucket() agentctx.ContextBucket {
+	return agentctx.ContextBucketLiveState
+}
+
+// TagContext renders the trust notice.
+func (p *UnverifiedTrustProvider) TagContext(context.Context, agentctx.ContextRequest) (string, error) {
+	if p == nil {
+		return "", nil
+	}
+	path := p.configPath
+	if path == "" {
+		path = "an unspecified path"
+	}
+	return "## Instance Trust\n\n" +
+		"This instance is running on a configuration loaded from outside its trust boundary (" + path + "), " +
+		"so there is no signed record of who authorized it. Two capabilities are withheld while that is true: " +
+		"tools that contact a human directly, and the automatic start of service loops.\n\n" +
+		"Work normally otherwise, but do not plan around reaching someone directly — put what you would have sent " +
+		"into your reply instead, and say that the instance needs to be restarted on a verified configuration. " +
+		"Treat consequential or irreversible actions with more caution than usual: the configuration that decides " +
+		"what you are permitted to do is itself unattested.", nil
+}

--- a/internal/server/api/server.go
+++ b/internal/server/api/server.go
@@ -79,6 +79,7 @@ type Server struct {
 	memoryStore                        *memory.SQLiteStore
 	archiveStore                       *memory.ArchiveStore
 	healthDeps                         HealthStatusFunc
+	unverified                         bool
 	tokenObserver                      TokenObserver
 	eventBus                           *events.Bus
 	owuTracker                         *OWUTracker
@@ -114,6 +115,12 @@ type Server struct {
 // SetOWUTracker configures the Open WebUI loop tracker for dashboard visibility.
 func (s *Server) SetOWUTracker(t *OWUTracker) {
 	s.owuTracker = t
+}
+
+// SetUnverified marks the instance as running on a config that could
+// not be verified, so /health reports it.
+func (s *Server) SetUnverified(unverified bool) {
+	s.unverified = unverified
 }
 
 // SetConnManager sets the dependency health provider for the /health endpoint.
@@ -608,6 +615,16 @@ func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 
 	health := map[string]any{"status": "healthy"}
+	if s.unverified {
+		// Reported as degraded, not healthy: the instance is running,
+		// but with capabilities withheld and no way to show who
+		// authorized its config. A supervisor that treats this as
+		// healthy would let an unverified instance run indefinitely
+		// without anyone noticing.
+		health["status"] = "degraded"
+		health["trust"] = "unverified"
+		health["trust_detail"] = "running on a config from outside the instance trust boundary; direct human egress and service loops are withheld"
+	}
 	if s.healthDeps != nil {
 		deps := s.healthDeps()
 		health["dependencies"] = deps

--- a/internal/tools/core_attention_policy.go
+++ b/internal/tools/core_attention_policy.go
@@ -1,5 +1,20 @@
 package tools
 
+// IsDirectHumanEgressTool reports whether a tool reaches a human
+// directly.
+func IsDirectHumanEgressTool(name string) bool {
+	return isDirectHumanEgressTool(name)
+}
+
+func isDirectHumanEgressTool(name string) bool {
+	for _, candidate := range directHumanEgressToolNames {
+		if candidate == name {
+			return true
+		}
+	}
+	return false
+}
+
 // DirectHumanEgressToolNames returns tool names that can directly contact a
 // person or mutate an active human conversation. Delegated and subsystem loops
 // should wake the core loop with request_core_attention instead of receiving

--- a/internal/tools/egress_withholding_test.go
+++ b/internal/tools/egress_withholding_test.go
@@ -62,3 +62,52 @@ func TestIsDirectHumanEgressToolCoversTheDeclaredSet(t *testing.T) {
 		t.Fatal("doc_read is not direct human egress")
 	}
 }
+
+// TestWithholdingSurvivesEveryDerivedRegistry is the test that would
+// have caught the original bug: withholding lived on the base registry
+// while every scoped copy silently regained the capability. Loops and
+// delegates run through those copies, so the denial held precisely where
+// it did not matter and lapsed where it did.
+func TestWithholdingSurvivesEveryDerivedRegistry(t *testing.T) {
+	base := newEgressTestRegistry(t)
+	base.Register(&Tool{
+		Name:        "tagged_tool",
+		Description: "tag-scoped",
+		Parameters:  map[string]any{"type": "object"},
+		Handler:     func(context.Context, map[string]any) (string, error) { return "ok", nil },
+	})
+	base.WithholdDirectHumanEgress()
+
+	derived := map[string]*Registry{
+		"FilteredCopy":          base.FilteredCopy([]string{"signal_send_message", "doc_read"}),
+		"FilteredCopyExcluding": base.FilteredCopyExcluding([]string{"tagged_tool"}),
+		"FilterByTags/untagged": base.FilterByTags(nil),
+		"WithRuntimeTools":      base.WithRuntimeTools([]*Tool{{Name: "runtime_tool", Parameters: map[string]any{"type": "object"}, Handler: func(context.Context, map[string]any) (string, error) { return "ok", nil }}}),
+		"WithDynamicTools":      base.WithDynamicTools([]*Tool{{Name: "dynamic_tool", Parameters: map[string]any{"type": "object"}, Handler: func(context.Context, map[string]any) (string, error) { return "ok", nil }}}, nil),
+	}
+	// A copy of a copy is the realistic shape: a delegate's registry is
+	// derived from a loop's, which is derived from the base.
+	derived["nested"] = derived["FilterByTags/untagged"].FilteredCopy([]string{"signal_send_message"})
+
+	for name, reg := range derived {
+		if reg.Get("signal_send_message") == nil {
+			continue // this copy legitimately excludes the tool
+		}
+		if _, err := reg.Execute(context.Background(), "signal_send_message", "{}"); err == nil {
+			t.Fatalf("%s regained direct human egress after the base withheld it", name)
+		}
+	}
+}
+
+func TestWithholdingAppliesToCopiesMadeBeforeItWasSet(t *testing.T) {
+	// Policy is shared state, not a snapshot: a registry derived during
+	// wiring must honor a withholding decision made after it was built.
+	base := newEgressTestRegistry(t)
+	derived := base.FilterByTags(nil)
+
+	base.WithholdDirectHumanEgress()
+
+	if _, err := derived.Execute(context.Background(), "signal_send_message", "{}"); err == nil {
+		t.Fatal("a registry derived before the decision must still honor it")
+	}
+}

--- a/internal/tools/egress_withholding_test.go
+++ b/internal/tools/egress_withholding_test.go
@@ -1,0 +1,64 @@
+package tools
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func newEgressTestRegistry(t *testing.T) *Registry {
+	t.Helper()
+	r := NewRegistry(nil, nil, nil)
+	for _, name := range []string{"signal_send_message", "doc_read"} {
+		toolName := name
+		r.Register(&Tool{
+			Name:        toolName,
+			Description: "test tool",
+			Parameters:  map[string]any{"type": "object"},
+			Handler: func(context.Context, map[string]any) (string, error) {
+				return toolName + " ran", nil
+			},
+		})
+	}
+	return r
+}
+
+func TestWithholdDirectHumanEgressBlocksEgressToolsOnly(t *testing.T) {
+	r := newEgressTestRegistry(t)
+	r.WithholdDirectHumanEgress()
+
+	_, err := r.Execute(context.Background(), "signal_send_message", "{}")
+	if err == nil {
+		t.Fatal("an egress tool must be refused while the config is unverified")
+	}
+	// The refusal has to read as a withheld capability, not a missing
+	// tool, or the model looks for another way to reach the same person.
+	if !strings.Contains(err.Error(), "withheld") || !strings.Contains(err.Error(), "trust boundary") {
+		t.Fatalf("error should explain the state: %v", err)
+	}
+	if !strings.Contains(err.Error(), "reply instead") {
+		t.Fatalf("error should say what to do instead: %v", err)
+	}
+
+	if got, err := r.Execute(context.Background(), "doc_read", "{}"); err != nil || got != "doc_read ran" {
+		t.Fatalf("a non-egress tool must still run: %q %v", got, err)
+	}
+}
+
+func TestEgressToolsRunWhenVerified(t *testing.T) {
+	r := newEgressTestRegistry(t)
+	if got, err := r.Execute(context.Background(), "signal_send_message", "{}"); err != nil || got != "signal_send_message ran" {
+		t.Fatalf("egress must work on a verified instance: %q %v", got, err)
+	}
+}
+
+func TestIsDirectHumanEgressToolCoversTheDeclaredSet(t *testing.T) {
+	for _, name := range DirectHumanEgressToolNames() {
+		if !IsDirectHumanEgressTool(name) {
+			t.Fatalf("%q is in the declared egress set but not recognized", name)
+		}
+	}
+	if IsDirectHumanEgressTool("doc_read") {
+		t.Fatal("doc_read is not direct human egress")
+	}
+}

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"sort"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/nugget/thane-ai-agent/internal/channels/email"
@@ -57,15 +58,18 @@ type Tool struct {
 
 // Registry holds available tools.
 type Registry struct {
-	tools              map[string]*Tool
-	tagIndex           map[string][]string // tag → tool names
-	ha                 *homeassistant.Client
-	scheduler          *scheduler.Scheduler
-	logger             *slog.Logger
-	factTools          *knowledge.Tools
-	contactTools       *contacts.Tools
-	emailTools         *email.Tools
-	withholdEgress     bool
+	tools        map[string]*Tool
+	tagIndex     map[string][]string // tag → tool names
+	ha           *homeassistant.Client
+	scheduler    *scheduler.Scheduler
+	logger       *slog.Logger
+	factTools    *knowledge.Tools
+	contactTools *contacts.Tools
+	emailTools   *email.Tools
+
+	// policy is shared by pointer with every registry derived from this
+	// one, so a scoped copy cannot regain what the parent withheld.
+	policy             *registryPolicy
 	notifier           *notifications.Sender
 	notifRecords       *notifications.RecordStore
 	notifRouter        *notifications.NotificationRouter
@@ -1009,12 +1013,7 @@ func (r *Registry) AllToolNames() []string {
 // Tools not found in the source are silently skipped. The returned
 // registry shares tool handlers with the source but has its own map.
 func (r *Registry) FilteredCopy(names []string) *Registry {
-	filtered := &Registry{
-		tools:           make(map[string]*Tool, len(names)),
-		contentResolver: r.contentResolver,
-		tagIndex:        r.tagIndex,
-		logger:          r.logger,
-	}
+	filtered := r.derive(len(names))
 	for _, name := range names {
 		if t := r.tools[name]; t != nil {
 			filtered.tools[name] = t
@@ -1030,12 +1029,7 @@ func (r *Registry) FilteredCopyExcluding(exclude []string) *Registry {
 	for _, name := range exclude {
 		skip[name] = true
 	}
-	filtered := &Registry{
-		tools:           make(map[string]*Tool, len(r.tools)),
-		contentResolver: r.contentResolver,
-		tagIndex:        r.tagIndex,
-		logger:          r.logger,
-	}
+	filtered := r.derive(len(r.tools))
 	for name, t := range r.tools {
 		if !skip[name] {
 			filtered.tools[name] = t
@@ -1052,12 +1046,7 @@ func (r *Registry) WithRuntimeTools(runtime []*Tool) *Registry {
 	if len(runtime) == 0 {
 		return r
 	}
-	filtered := &Registry{
-		tools:           make(map[string]*Tool, len(r.tools)+len(runtime)),
-		contentResolver: r.contentResolver,
-		tagIndex:        r.tagIndex,
-		logger:          r.logger,
-	}
+	filtered := r.derive(len(r.tools) + len(runtime))
 	for name, t := range r.tools {
 		filtered.tools[name] = t
 	}
@@ -1093,11 +1082,8 @@ func (r *Registry) WithDynamicTools(extra []*Tool, tagAdditions map[string][]str
 		return r
 	}
 
-	filtered := &Registry{
-		tools:           make(map[string]*Tool, len(r.tools)+len(extra)),
-		contentResolver: r.contentResolver,
-		logger:          r.logger,
-	}
+	filtered := r.derive(len(r.tools) + len(extra))
+	filtered.tagIndex = nil // rebuilt below from additions
 	for name, t := range r.tools {
 		filtered.tools[name] = t
 	}
@@ -1187,12 +1173,7 @@ func (r *Registry) SetTagIndex(tags map[string][]string) {
 func (r *Registry) FilterByTags(tags []string) *Registry {
 	if len(tags) == 0 || r.tagIndex == nil {
 		// No filtering — return a shallow copy with all tools.
-		filtered := &Registry{
-			tools:           make(map[string]*Tool, len(r.tools)),
-			contentResolver: r.contentResolver,
-			tagIndex:        r.tagIndex,
-			logger:          r.logger,
-		}
+		filtered := r.derive(len(r.tools))
 		for name, t := range r.tools {
 			filtered.tools[name] = t
 		}
@@ -1206,12 +1187,7 @@ func (r *Registry) FilterByTags(tags []string) *Registry {
 		}
 	}
 
-	filtered := &Registry{
-		tools:           make(map[string]*Tool, len(allowed)),
-		contentResolver: r.contentResolver,
-		tagIndex:        r.tagIndex,
-		logger:          r.logger,
-	}
+	filtered := r.derive(len(allowed))
 	for name, t := range r.tools {
 		if allowed[name] || t.Core {
 			filtered.tools[name] = t
@@ -1241,7 +1217,7 @@ func (r *Registry) WithholdDirectHumanEgress() {
 	if r == nil {
 		return
 	}
-	r.withholdEgress = true
+	r.sharedPolicy().withholdEgress.Store(true)
 }
 
 // checkEgressWithheld refuses a direct-egress tool on an unverified
@@ -1249,10 +1225,47 @@ func (r *Registry) WithholdDirectHumanEgress() {
 // as missing, so the model does not respond by hunting for another way
 // to reach the same person.
 func (r *Registry) checkEgressWithheld(name string) error {
-	if r == nil || !r.withholdEgress || !isDirectHumanEgressTool(name) {
+	if r == nil || r.policy == nil || !r.policy.withholdEgress.Load() || !isDirectHumanEgressTool(name) {
 		return nil
 	}
 	return fmt.Errorf("%s is withheld: this instance is running on a config from outside its trust boundary, so it will not contact anyone directly. Report what you found in your reply instead, and tell the operator the instance needs to be restarted on a verified config", name)
+}
+
+// registryPolicy is the runtime policy a registry and all registries
+// derived from it share. It is a pointer rather than copied fields
+// because the derived registries are where the policy has to hold: a
+// loop's scoped set and a delegate's inherited set are the autonomous
+// paths, and those are exactly the copies.
+type registryPolicy struct {
+	withholdEgress atomic.Bool
+}
+
+// derive returns a registry that shares this one's policy and services
+// with an empty tool set.
+//
+// Every constructor that produces a scoped registry goes through here.
+// The field list used to be maintained by hand in five of them, which is
+// how withheld egress came to survive on the base registry and vanish
+// through FilterByTags — the copies dropped what they did not know to
+// carry. Centralizing it means a sixth constructor inherits policy by
+// default instead of by remembering.
+func (r *Registry) derive(capacity int) *Registry {
+	return &Registry{
+		tools:           make(map[string]*Tool, capacity),
+		contentResolver: r.contentResolver,
+		tagIndex:        r.tagIndex,
+		logger:          r.logger,
+		policy:          r.sharedPolicy(),
+	}
+}
+
+// sharedPolicy returns the policy state, creating it on first use so a
+// registry built by any path still has one to share.
+func (r *Registry) sharedPolicy() *registryPolicy {
+	if r.policy == nil {
+		r.policy = &registryPolicy{}
+	}
+	return r.policy
 }
 
 // Execute runs a tool by name with given arguments.

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -65,6 +65,7 @@ type Registry struct {
 	factTools          *knowledge.Tools
 	contactTools       *contacts.Tools
 	emailTools         *email.Tools
+	withholdEgress     bool
 	notifier           *notifications.Sender
 	notifRecords       *notifications.RecordStore
 	notifRouter        *notifications.NotificationRouter
@@ -1228,11 +1229,40 @@ func (r *Registry) TaggedToolNames(tag string) []string {
 	return r.tagIndex[tag]
 }
 
+// WithholdDirectHumanEgress stops this registry from executing tools
+// that reach a human directly. It is set when the running config could
+// not be verified.
+//
+// Enforced at execution rather than by unregistering, so the denial
+// holds no matter how a tool was reached — a loop's runtime tool set, a
+// delegate's inherited registry, or a path added later that nobody
+// thought to filter.
+func (r *Registry) WithholdDirectHumanEgress() {
+	if r == nil {
+		return
+	}
+	r.withholdEgress = true
+}
+
+// checkEgressWithheld refuses a direct-egress tool on an unverified
+// instance. The error explains the state rather than reporting the tool
+// as missing, so the model does not respond by hunting for another way
+// to reach the same person.
+func (r *Registry) checkEgressWithheld(name string) error {
+	if r == nil || !r.withholdEgress || !isDirectHumanEgressTool(name) {
+		return nil
+	}
+	return fmt.Errorf("%s is withheld: this instance is running on a config from outside its trust boundary, so it will not contact anyone directly. Report what you found in your reply instead, and tell the operator the instance needs to be restarted on a verified config", name)
+}
+
 // Execute runs a tool by name with given arguments.
 func (r *Registry) Execute(ctx context.Context, name string, argsJSON string) (string, error) {
 	tool := r.tools[name]
 	if tool == nil {
 		return "", &ErrToolUnavailable{ToolName: name}
+	}
+	if err := r.checkEgressWithheld(name); err != nil {
+		return "", err
 	}
 
 	var args map[string]any

--- a/scripts/architecture.baseline
+++ b/scripts/architecture.baseline
@@ -1,5 +1,5 @@
 packages=65
 interfaces=84
 large_files=52
-set_mutators=115
+set_mutators=116
 database_opens=9


### PR DESCRIPTION
## What changes

`-insecure-config` now degrades the runtime instead of only announcing itself. The flag has been telling the truth about the *file* since #1259; this makes it true about the *instance*.

The principle: a configuration nobody can be shown to have authorized should not let an instance act on the world as though someone had.

## What is withheld

**Tools that contact a human directly** — Signal, email, notifications, escalations. Refused at `Registry.Execute` rather than by unregistering them, so the denial holds however a tool is reached: a loop's runtime set, a delegate's inherited registry, or some path added six months from now that nobody thought to filter. Unregistering protects the paths you remembered; refusing at the chokepoint protects the ones you didn't.

The refusal explains the state rather than reporting the tool as missing, and says what to do instead. A model told "no such tool" goes looking for another route to the same person, which is the opposite of what we want.

**Automatic service-loop startup.** A service loop acts on its own schedule for as long as the process lives; that is unattended authority, and it should require a verified instance. An operator can still launch a specific loop deliberately.

**A healthy-looking `/health`.** It reports `status: degraded` with `trust: unverified`, so a supervisor cannot mistake a recovery session someone left running for a healthy instance.

## Telling the model

The withheld tools already error when reached, but an error at the moment of use is late — by then the model has committed to a plan that assumed it could reach someone. A `live_state` provider states the condition up front so it can choose differently: finish the analysis, put the findings in the reply, and say plainly that the instance needs attention.

It also asks for more caution generally, not only about the blocked tools. An instance that cannot show who authorized its configuration should be more reluctant about consequential action across the board, because the configuration deciding what it may do is itself unattested.

## Where trust is marked

At load, not at the gate — `loadConfig` marks the config unverified whenever an explicit path was given. That way every command inherits the state rather than only the one that runs verification, and nothing downstream has to re-derive it from flags it would have to be passed.

## Notes

One new `Set*` mutator pushes the architecture baseline to 116. The alternative was a thirteenth positional `bool` on `NewServer`, which reads worse at every call site than a named setter.

## Test plan

- [x] Egress tools refused while unverified; the error names the state and the alternative
- [x] Non-egress tools unaffected
- [x] Egress works normally on a verified instance
- [x] Every name in the declared egress set is recognized by the predicate
- [x] `just ci` green locally

Refs #787
Closes the four-step arc: #1257 (single location) → #1258 (integrity report) → #1259 (flag rename) → #1260 (boot gate) → this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
