### PR TITLE
An empty search is not an absent fact: teach the model to read root context policy

### DIFF
--- a/talents/documents.md
+++ b/talents/documents.md
@@ -174,8 +174,11 @@ Each root reports a `context` block:
 - `inject: "tagged"` — tagged documents here can enter your context on
   their own. `inject: "none"` means nothing here ever appears unbidden,
   so anything you need from it you must go and read.
-- `requires_tag` — the whole root stays invisible until that capability
-  tag is active.
+- `requires_tag` — documents here inject only while that capability tag
+  is active. It constrains injection alone: search never consults active
+  tags, so a root gated this way is still searchable right now, and
+  skipping it because its tag is inactive would blind you to content
+  that is sitting there.
 
 So the funnel has a precondition: when a search comes back empty and the
 answer plausibly lives in a corpus you did not name, check `doc_roots`

--- a/talents/documents.md
+++ b/talents/documents.md
@@ -155,14 +155,43 @@ answer to that step's question.
 
 When you don't know which managed root holds the answer, `doc_roots`
 returns each indexed root with document counts, top tags, top
-directories, and recent examples:
+directories, recent examples, and — the part worth reading before you
+search — how that root reaches you:
 
 ```json
 {}
 ```
 
-Skip when you already know the right root (most queries about people
-go to `dossiers`, most network/infra notes go to `kb`, etc.).
+Each root reports a `context` block:
+
+- `search: "default"` — included in an unscoped `doc_search`.
+- `search: "on_request"` — **only searched when you name the root.** A
+  large foreign corpus is usually set this way so it doesn't drown open
+  queries. If you search without naming it and find nothing, you have
+  not learned that the content is absent; you have learned that the one
+  place likely to hold it was never looked at.
+- `search: "never"` — not searchable at all.
+- `inject: "tagged"` — tagged documents here can enter your context on
+  their own. `inject: "none"` means nothing here ever appears unbidden,
+  so anything you need from it you must go and read.
+- `requires_tag` — the whole root stays invisible until that capability
+  tag is active.
+
+So the funnel has a precondition: when a search comes back empty and the
+answer plausibly lives in a corpus you did not name, check `doc_roots`
+and search that root explicitly before concluding the thing does not
+exist. Reporting "there is no record of X" on the strength of a search
+that never looked is the failure mode this block exists to prevent.
+
+Separately, documents whose frontmatter marks them `audience: internal`
+— loop working notes, process logs — stay out of results by default.
+Pass `include_internal: true` when you specifically want them; they hold
+reasoning about how an understanding evolved rather than the current
+state.
+
+Skip this step when you already know the right root (most queries about
+people go to `dossiers`, most network/infra notes go to `kb`, etc.) —
+but not when a previous search surprised you by finding nothing.
 
 ## Step 2 — browse like a phone tree
 


### PR DESCRIPTION
Roots gained a context policy in #1255 and `doc_roots` reports it, but `talents/documents.md` still described that tool's pre-#1255 output. The model gets a signal nobody taught it to read — the stale-door failure, on a door we opened ourselves five PRs ago.

**The half that has consequences is search visibility.** A root set to `search: on_request` is excluded from an unscoped `doc_search`. A model that does not know that reads an empty result as an absent fact and reports "there is no record of X" — on the strength of a search that never looked at the one corpus likely to hold it. That is a false negative wearing the costume of a finding, and it is exactly the failure a large foreign corpus like a mounted Obsidian vault would produce.

So the talent now states the policy fields plainly and makes the recovery a step in the funnel: when a search surprises you by finding nothing, check `doc_roots` and search the unnamed root explicitly before concluding the thing does not exist.

It also teaches that `audience: internal` documents are excluded by default and what `include_internal` is for — working notes hold the reasoning behind how an understanding changed, which is occasionally exactly what you want and never what you want by accident.

Talent change, so it needs the usual manual prod backport after merge.

Refs #1250 #787

🤖 Generated with [Claude Code](https://claude.com/claude-code)