### PR TITLE
A config states its workspace by sitting in it: retire workspace.path

### DIFF
--- a/cmd/thane/main.go
+++ b/cmd/thane/main.go
@@ -623,7 +623,16 @@ func loadConfig(explicit, workspace string) (*config.Config, string, error) {
 	// and be judged against an instance the operator never mentioned.
 	fallbackWorkspace := ""
 	if strings.TrimSpace(workspace) != "" {
-		fallbackWorkspace, _ = config.ExpandWorkspace(workspace)
+		// An unresolvable -workspace is reported here rather than
+		// swallowed. Falling back to empty would leave the instance
+		// running with no workspace at all — file tools disabled — and
+		// surface later as something that looks unrelated to the flag
+		// that caused it.
+		resolved, wErr := config.ExpandWorkspace(workspace)
+		if wErr != nil {
+			return nil, "", terminal(wErr)
+		}
+		fallbackWorkspace = resolved
 	}
 	cfg, err := config.LoadWithWorkspace(cfgPath, fallbackWorkspace)
 	if err != nil {

--- a/cmd/thane/main.go
+++ b/cmd/thane/main.go
@@ -618,7 +618,14 @@ func loadConfig(explicit, workspace string) (*config.Config, string, error) {
 		return nil, "", err
 	}
 
-	cfg, err := config.Load(cfgPath)
+	// The fallback applies only when a workspace was actually named. If
+	// it defaulted, an out-of-core config would silently adopt ~/Thane
+	// and be judged against an instance the operator never mentioned.
+	fallbackWorkspace := ""
+	if strings.TrimSpace(workspace) != "" {
+		fallbackWorkspace, _ = config.ExpandWorkspace(workspace)
+	}
+	cfg, err := config.LoadWithWorkspace(cfgPath, fallbackWorkspace)
 	if err != nil {
 		return nil, cfgPath, fmt.Errorf("load config %s: %w", cfgPath, err)
 	}

--- a/cmd/thane/main_test.go
+++ b/cmd/thane/main_test.go
@@ -140,3 +140,31 @@ func TestGateRefusalIsTerminal(t *testing.T) {
 		t.Fatalf("a refusal to start should exit %d so supervisors stop retrying, got %d", ExitTerminal, exitCodeFor(err))
 	}
 }
+
+func TestLoadConfig_WorkspaceFallbackRequiresAnExplicitWorkspace(t *testing.T) {
+	// A defaulted workspace must not be adopted by a config loaded from
+	// somewhere else: the instance at ~/Thane has nothing to do with a
+	// file the operator named on the command line.
+	dir := t.TempDir()
+	loose := filepath.Join(dir, "rescue.yaml")
+	if err := os.WriteFile(loose, []byte(minimalValidConfig), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	cfg, _, err := loadConfig(loose, "")
+	if err != nil {
+		t.Fatalf("loadConfig: %v", err)
+	}
+	if cfg.Workspace.Path != "" {
+		t.Fatalf("Workspace.Path = %q, want empty when no workspace was named", cfg.Workspace.Path)
+	}
+
+	// Naming one is what makes the fallback apply.
+	cfg, _, err = loadConfig(loose, dir)
+	if err != nil {
+		t.Fatalf("loadConfig with explicit workspace: %v", err)
+	}
+	if cfg.Workspace.Path != dir {
+		t.Fatalf("Workspace.Path = %q, want the named workspace %q", cfg.Workspace.Path, dir)
+	}
+}

--- a/cmd/thane/main_test.go
+++ b/cmd/thane/main_test.go
@@ -168,3 +168,23 @@ func TestLoadConfig_WorkspaceFallbackRequiresAnExplicitWorkspace(t *testing.T) {
 		t.Fatalf("Workspace.Path = %q, want the named workspace %q", cfg.Workspace.Path, dir)
 	}
 }
+
+func TestLoadConfig_UnresolvableWorkspaceIsReported(t *testing.T) {
+	// Swallowing this would leave the instance running with no workspace
+	// — file tools disabled — and surface later as something that looks
+	// unrelated to the flag that caused it.
+	t.Setenv("HOME", "")
+	dir := t.TempDir()
+	loose := filepath.Join(dir, "rescue.yaml")
+	if err := os.WriteFile(loose, []byte(minimalValidConfig), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	_, _, err := loadConfig(loose, "~/nowhere")
+	if err == nil {
+		t.Skip("home directory still resolvable in this environment")
+	}
+	if exitCodeFor(err) != ExitTerminal {
+		t.Fatalf("an unresolvable -workspace should exit %d, got %d", ExitTerminal, exitCodeFor(err))
+	}
+}

--- a/cmd/thane/validate.go
+++ b/cmd/thane/validate.go
@@ -93,7 +93,18 @@ func integrityError(report *coreintegrity.Report) error {
 // a question the operator did not ask, and would do it while they are
 // looking at a different file entirely.
 func checkCoreIntegrity(cfg *config.Config, configPath, workspacePath string) *coreintegrity.Report {
-	workspace := workspacePath
+	// The flag is expanded before use. Taking it raw would check a
+	// literal "~" directory whenever the shell did not expand it for us,
+	// while the config had already loaded from the correct path — a
+	// report about somewhere the instance does not live.
+	workspace := ""
+	if strings.TrimSpace(workspacePath) != "" {
+		resolved, err := config.ExpandWorkspace(workspacePath)
+		if err != nil {
+			return nil
+		}
+		workspace = resolved
+	}
 	if workspace == "" && cfg != nil {
 		workspace = cfg.Workspace.Path
 	}

--- a/docs/operating/configuration.md
+++ b/docs/operating/configuration.md
@@ -191,9 +191,6 @@ Where SQLite databases live (`thane.db`, `facts.db`). Defaults to
 ## Document Roots
 
 ```yaml
-workspace:
-  path: ~/Thane
-
 roots:
   kb:
     path: ~/Thane/knowledge
@@ -245,9 +242,6 @@ corpora, and use file tools such as `file_read`, `file_search`, and
 `file_grep` with the root prefix:
 
 ```yaml
-workspace:
-  path: ~/Thane
-
 roots:
   thanecode:
     path: ~/Thane/checkouts/thane
@@ -288,13 +282,11 @@ operator guide.
 ## Persona & Talents
 
 ```yaml
-workspace:
-  path: ~/Thane
 talents_dir: ~/Thane/talents
 ```
 
 See [Context Layers](../understanding/context-layers.md) for how these
-fit into the system prompt. `workspace.path` derives the protected
+fit into the system prompt. The workspace derives the protected
 `core` root; `core/axioms.md`, `core/persona.md`, `core/ego.md`, and
 `core/mission.md` are picked up by the runtime without a separate
 inject-file list.

--- a/docs/understanding/document-roots.md
+++ b/docs/understanding/document-roots.md
@@ -72,9 +72,6 @@ one of Thane's managed local document collections.
 Example:
 
 ```yaml
-workspace:
-  path: ~/Thane
-
 roots:
   kb: ~/Thane/knowledge
   scratchpad: ~/Thane/scratchpad
@@ -120,9 +117,6 @@ document corpora. For a forge-maintained local checkout, use a read-only
 root with indexing disabled:
 
 ```yaml
-workspace:
-  path: ~/Thane
-
 roots:
   thanecode:
     path: ~/Thane/checkouts/thane

--- a/examples/config.example.yaml
+++ b/examples/config.example.yaml
@@ -166,11 +166,6 @@ embeddings:
 # always-on files at stable locations such as axioms.md, persona.md,
 # ego.md, mission.md, and metacognitive.md.
 workspace:
-  # Path is the root directory for file operations. If empty, file
-  # tools are disabled entirely. In multi-root setups, this should be
-  # the common writable parent that contains Thane-owned roots such as
-  # core/, talents/, knowledge/, generated/, and scratchpad/.
-  path: ""
   # ReadOnlyDirs are additional directories the agent can read from
   # but not write to. Useful for compatibility or reference roots that
   # must remain outside Thane's writable authority, such as a legacy

--- a/internal/platform/config/config.go
+++ b/internal/platform/config/config.go
@@ -1645,11 +1645,16 @@ func (c CapabilityTagConfig) Validate(tagName string, builtin bool) error {
 // directory. All paths passed to file tools are resolved relative to
 // Path and cannot escape it.
 type WorkspaceConfig struct {
-	// Path is the root directory for file operations. If empty, file
-	// tools are disabled entirely. In multi-root setups, this should be
-	// the common writable parent that contains Thane-owned roots such as
-	// core/, talents/, knowledge/, generated/, and scratchpad/.
-	Path string `yaml:"path"`
+	// Path is the root directory for file operations: the writable
+	// parent holding Thane-owned roots such as core/, talents/,
+	// knowledge/, generated/, and scratchpad/.
+	//
+	// It is derived, never authored. A config lives at
+	// {workspace}/core/config.yaml, so it states its workspace by
+	// sitting there; a declared value could only agree or drift, and it
+	// made the file describe one machine's layout. A config loaded from
+	// outside a core takes the workspace from the -workspace flag.
+	Path string `yaml:"-"`
 
 	// ReadOnlyDirs are additional directories the agent can read from
 	// but not write to. Useful for compatibility or reference roots that
@@ -2286,24 +2291,13 @@ func (c *Config) deriveWorkspace() error {
 	coreDir := filepath.Dir(abs)
 	if filepath.Base(coreDir) != "core" {
 		// A config outside core — the recovery escape hatch, or a
-		// minimal config for a one-shot command — keeps whatever it
-		// declared, including nothing. An absent workspace is already a
-		// handled state: the features that need one say so when they
-		// are configured.
+		// minimal config for a one-shot command — has no location to
+		// derive from. The caller supplies the workspace from the
+		// -workspace flag, or leaves it unset; an absent workspace is
+		// already a handled state, and the features needing one say so.
 		return nil
 	}
-	derived := filepath.Dir(coreDir)
-
-	if declared := strings.TrimSpace(c.Workspace.Path); declared != "" {
-		declaredAbs, err := ExpandWorkspace(declared)
-		if err != nil {
-			return err
-		}
-		if declaredAbs != derived {
-			return fmt.Errorf("workspace.path %q does not match the directory this config was loaded from (%s); remove workspace.path — it is derived from the config location", declared, derived)
-		}
-	}
-	c.Workspace.Path = derived
+	c.Workspace.Path = filepath.Dir(coreDir)
 	return nil
 }
 
@@ -2347,7 +2341,20 @@ func (c *Config) CoreConfigPath() string {
 	return filepath.Join(c.CoreRoot(), "config.yaml")
 }
 
+// Load reads and parses a config whose workspace is derived from its own
+// location.
 func Load(path string) (*Config, error) {
+	return LoadWithWorkspace(path, "")
+}
+
+// LoadWithWorkspace reads a config, falling back to the given workspace
+// when the config's location cannot supply one — which happens only for
+// a config loaded from outside any core, where the -workspace flag is
+// the sole remaining source. A derived workspace always wins: the
+// config's own location is the more trustworthy of the two, and a
+// fallback that could override it would reintroduce the drift that
+// retiring workspace.path removed.
+func LoadWithWorkspace(path, fallbackWorkspace string) (*Config, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
@@ -2367,6 +2374,9 @@ func Load(path string) (*Config, error) {
 
 	if err := cfg.deriveWorkspace(); err != nil {
 		return nil, err
+	}
+	if strings.TrimSpace(cfg.Workspace.Path) == "" && strings.TrimSpace(fallbackWorkspace) != "" {
+		cfg.Workspace.Path = strings.TrimSpace(fallbackWorkspace)
 	}
 
 	if err := cfg.normalizeRoots(); err != nil {
@@ -2396,6 +2406,24 @@ func Load(path string) (*Config, error) {
 // by include/exclude) and mcp.servers[].default_tags (renamed to
 // tags). Each retired key gets a specific message pointing the
 // operator at the new shape.
+// rejectRetiredWorkspaceKeys refuses a declared workspace.path.
+//
+// Silently ignoring it would be worse than refusing: an operator who
+// sets it believes they have pointed the instance somewhere, and the
+// instance would run from a different directory without saying so. The
+// error names the two things that actually decide the workspace now.
+func rejectRetiredWorkspaceKeys(workspace *yaml.Node) error {
+	if workspace == nil || workspace.Kind != yaml.MappingNode {
+		return nil
+	}
+	for i := 0; i+1 < len(workspace.Content); i += 2 {
+		if workspace.Content[i].Value == "path" {
+			return fmt.Errorf("config declares workspace.path, which is now derived from the config's own location ({workspace}/core/config.yaml) rather than authored. Remove the path: line — keep the rest of the workspace: block — and select a different instance with the -workspace flag instead")
+		}
+	}
+	return nil
+}
+
 func rejectRetiredKeys(data []byte) error {
 	var doc yaml.Node
 	if err := yaml.Unmarshal(data, &doc); err != nil {
@@ -2417,6 +2445,10 @@ func rejectRetiredKeys(data []byte) error {
 			return fmt.Errorf("config has top-level platform: section, which was renamed to companion: in v0.9.x. Rename it (the field shape is unchanged) and re-load")
 		case "curator":
 			return fmt.Errorf("config has top-level curator: section, which was renamed to archivist: when the loop became a self-paced queue consumer. Rename it (the field shape is unchanged) and re-load")
+		case "workspace":
+			if err := rejectRetiredWorkspaceKeys(valueNode); err != nil {
+				return err
+			}
 		case "capability_tags":
 			if err := rejectRetiredCapabilityTagKeys(valueNode); err != nil {
 				return err

--- a/internal/platform/config/example.go
+++ b/internal/platform/config/example.go
@@ -164,9 +164,7 @@ func ExampleConfig() *Config {
 			DefaultTimeoutSec: 30,
 		},
 
-		Workspace: WorkspaceConfig{
-			Path: "",
-		},
+		Workspace: WorkspaceConfig{},
 
 		Embeddings: EmbeddingsConfig{
 			Enabled: false,

--- a/internal/platform/config/workspace_derivation_test.go
+++ b/internal/platform/config/workspace_derivation_test.go
@@ -36,53 +36,6 @@ func TestLoadDerivesWorkspaceFromCoreLocation(t *testing.T) {
 	}
 }
 
-func TestLoadAcceptsMatchingDeclaredWorkspace(t *testing.T) {
-	workspace := t.TempDir()
-	coreDir := filepath.Join(workspace, "core")
-	if err := os.MkdirAll(coreDir, 0o755); err != nil {
-		t.Fatalf("MkdirAll: %v", err)
-	}
-	path := filepath.Join(coreDir, "config.yaml")
-	body := "listen:\n  port: 8080\nworkspace:\n  path: " + workspace + "\n"
-	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
-		t.Fatalf("WriteFile: %v", err)
-	}
-
-	cfg, err := Load(path)
-	if err != nil {
-		t.Fatalf("Load with a matching declaration should succeed: %v", err)
-	}
-	if cfg.Workspace.Path != workspace {
-		t.Fatalf("Workspace.Path = %q, want %q", cfg.Workspace.Path, workspace)
-	}
-}
-
-func TestLoadRejectsConflictingDeclaredWorkspace(t *testing.T) {
-	// A config states its workspace by sitting in it. A declaration that
-	// disagrees would point roots, state, and identity somewhere other
-	// than where the file lives — so the disagreement is surfaced rather
-	// than silently resolved either way.
-	workspace := t.TempDir()
-	elsewhere := t.TempDir()
-	coreDir := filepath.Join(workspace, "core")
-	if err := os.MkdirAll(coreDir, 0o755); err != nil {
-		t.Fatalf("MkdirAll: %v", err)
-	}
-	path := filepath.Join(coreDir, "config.yaml")
-	body := "listen:\n  port: 8080\nworkspace:\n  path: " + elsewhere + "\n"
-	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
-		t.Fatalf("WriteFile: %v", err)
-	}
-
-	_, err := Load(path)
-	if err == nil {
-		t.Fatal("Load should reject a workspace.path that contradicts the config location")
-	}
-	if !strings.Contains(err.Error(), "derived from the config location") {
-		t.Fatalf("error should explain the derivation: %v", err)
-	}
-}
-
 func TestConfigPathForWorkspace(t *testing.T) {
 	got, err := ConfigPathForWorkspace("/srv/thane")
 	if err != nil {
@@ -107,5 +60,66 @@ func TestExpandWorkspaceDefaultsAndExpands(t *testing.T) {
 	}
 	if got, err = ExpandWorkspace("~/Elsewhere"); err != nil || got != filepath.Join(home, "Elsewhere") {
 		t.Fatalf("ExpandWorkspace(\"~/Elsewhere\") = %q, %v", got, err)
+	}
+}
+
+func TestLoadRejectsDeclaredWorkspacePath(t *testing.T) {
+	// Silently ignoring it would be worse than refusing: an operator who
+	// sets it believes they pointed the instance somewhere, and it would
+	// run from a different directory without saying so.
+	_, path := writeCoreConfig(t, "listen:\n  port: 8080\nworkspace:\n  path: /somewhere/else\n")
+
+	_, err := Load(path)
+	if err == nil {
+		t.Fatal("a declared workspace.path must be rejected")
+	}
+	for _, want := range []string{"derived", "-workspace"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error should mention %q: %v", want, err)
+		}
+	}
+}
+
+func TestLoadKeepsTheRestOfTheWorkspaceBlock(t *testing.T) {
+	workspace, path := writeCoreConfig(t,
+		"listen:\n  port: 8080\nworkspace:\n  read_only_dirs:\n    - /srv/reference\n")
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("read_only_dirs is still real config: %v", err)
+	}
+	if cfg.Workspace.Path != workspace {
+		t.Fatalf("Workspace.Path = %q, want the derived %q", cfg.Workspace.Path, workspace)
+	}
+	if len(cfg.Workspace.ReadOnlyDirs) != 1 || cfg.Workspace.ReadOnlyDirs[0] != "/srv/reference" {
+		t.Fatalf("ReadOnlyDirs = %v, want it preserved", cfg.Workspace.ReadOnlyDirs)
+	}
+}
+
+func TestLoadWithWorkspaceFallsBackOnlyOutsideCore(t *testing.T) {
+	// Outside a core there is nothing to derive from, so the flag is the
+	// only source left.
+	dir := t.TempDir()
+	loose := filepath.Join(dir, "rescue.yaml")
+	if err := os.WriteFile(loose, []byte("listen:\n  port: 8080\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	cfg, err := LoadWithWorkspace(loose, "/srv/thane")
+	if err != nil {
+		t.Fatalf("LoadWithWorkspace: %v", err)
+	}
+	if cfg.Workspace.Path != "/srv/thane" {
+		t.Fatalf("Workspace.Path = %q, want the fallback", cfg.Workspace.Path)
+	}
+
+	// Inside a core the derived value wins, or the fallback would
+	// reintroduce the drift that retiring workspace.path removed.
+	workspace, corePath := writeCoreConfig(t, "listen:\n  port: 8080\n")
+	cfg, err = LoadWithWorkspace(corePath, "/srv/somewhere-else")
+	if err != nil {
+		t.Fatalf("LoadWithWorkspace: %v", err)
+	}
+	if cfg.Workspace.Path != workspace {
+		t.Fatalf("Workspace.Path = %q, want the derived %q to win over the fallback", cfg.Workspace.Path, workspace)
 	}
 }

--- a/talents/documents.md
+++ b/talents/documents.md
@@ -155,14 +155,43 @@ answer to that step's question.
 
 When you don't know which managed root holds the answer, `doc_roots`
 returns each indexed root with document counts, top tags, top
-directories, and recent examples:
+directories, recent examples, and — the part worth reading before you
+search — how that root reaches you:
 
 ```json
 {}
 ```
 
-Skip when you already know the right root (most queries about people
-go to `dossiers`, most network/infra notes go to `kb`, etc.).
+Each root reports a `context` block:
+
+- `search: "default"` — included in an unscoped `doc_search`.
+- `search: "on_request"` — **only searched when you name the root.** A
+  large foreign corpus is usually set this way so it doesn't drown open
+  queries. If you search without naming it and find nothing, you have
+  not learned that the content is absent; you have learned that the one
+  place likely to hold it was never looked at.
+- `search: "never"` — not searchable at all.
+- `inject: "tagged"` — tagged documents here can enter your context on
+  their own. `inject: "none"` means nothing here ever appears unbidden,
+  so anything you need from it you must go and read.
+- `requires_tag` — the whole root stays invisible until that capability
+  tag is active.
+
+So the funnel has a precondition: when a search comes back empty and the
+answer plausibly lives in a corpus you did not name, check `doc_roots`
+and search that root explicitly before concluding the thing does not
+exist. Reporting "there is no record of X" on the strength of a search
+that never looked is the failure mode this block exists to prevent.
+
+Separately, documents whose frontmatter marks them `audience: internal`
+— loop working notes, process logs — stay out of results by default.
+Pass `include_internal: true` when you specifically want them; they hold
+reasoning about how an understanding evolved rather than the current
+state.
+
+Skip this step when you already know the right root (most queries about
+people go to `dossiers`, most network/infra notes go to `kb`, etc.) —
+but not when a previous search surprised you by finding nothing.
 
 ## Step 2 — browse like a phone tree
 


### PR DESCRIPTION
## The prompt for this

Trying to validate production from a workstation failed with:

```
workspace.path "/Users/aimee/Thane" does not match the directory this
config was loaded from (/Volumes/Thane)
```

Both are the same file. The config hardcoded a path that is correct only on the host, so it could not be inspected from anywhere else — and it had no need to state a path at all, since it lives at `{workspace}/core/config.yaml` and thereby says where it is by sitting there.

## What changes

`workspace.path` is no longer authorable. It is derived from the config's own location, and a config declaring it is **rejected at load** with a message naming `-workspace` for the case it was probably trying to serve.

Rejected rather than ignored, deliberately. An operator who sets it believes they have pointed the instance somewhere; silently ignoring it would run from a different directory without saying so — a worse failure than refusing, because it looks like it worked.

**Only `path` is retired.** `read_only_dirs` is genuine configuration with no other source, so the `workspace:` block stays. There is a test pinning that distinction, because "remove workspace.path" reads like "remove the workspace block" and the next cleanup pass should not take both.

## The fallback, and why it is narrow

A config loaded through `-insecure-config` from outside any core has no location to derive from, so `LoadWithWorkspace` accepts the `-workspace` value as a fallback.

It applies **only when a workspace was actually named**. My first cut used the resolved default, and the tests caught it: a rescue config from `/tmp` silently adopted `~/Thane` and got judged against an instance the operator never mentioned. Derived always beats the fallback too — otherwise retiring the field would have bought nothing, just moved where the lie could enter.

## Notes

A constructor variant (`LoadWithWorkspace`) rather than a setter. The architecture gate flagged `SetWorkspacePath` as the second new `Set*` mutator this session, which is the drift that guardrail exists to catch; with only one non-test call site the constructor was the better shape anyway, since the workspace is an input to loading rather than a mutation after it.

Also removed from the generated example config — which was shipping `path: ""` to every new instance — and from five YAML examples across the operator docs, replaced by one explanation where the workspace is introduced.

## Test plan

- [x] A declared `workspace.path` is rejected; the error names the derivation and `-workspace`
- [x] `read_only_dirs` survives and the workspace is still derived
- [x] Fallback applies outside a core when named; derived wins inside one
- [x] A defaulted workspace is not adopted by an unrelated explicit config
- [x] `just ci` green locally

Refs #787

🤖 Generated with [Claude Code](https://claude.com/claude-code)