### PR TITLE
Guard the core writer that keeps the boot gate satisfiable

### DIFF
--- a/internal/app/document_roots_test.go
+++ b/internal/app/document_roots_test.go
@@ -533,15 +533,8 @@ func TestDocumentRootProvenanceReviser(t *testing.T) {
 func TestBuildDocumentStoreOptionsWiresCoreWriter(t *testing.T) {
 	t.Parallel()
 
+	signingKey, _ := writeTestSigningKey(t)
 	coreDir := t.TempDir()
-	keyPath := filepath.Join(coreDir, "identity", "signing_ed25519")
-	if err := os.MkdirAll(filepath.Dir(keyPath), 0o755); err != nil {
-		t.Fatalf("MkdirAll: %v", err)
-	}
-	if out, err := exec.Command("ssh-keygen", "-q", "-t", "ed25519", "-N", "", "-f", keyPath).CombinedOutput(); err != nil {
-		t.Skipf("ssh-keygen unavailable: %v\n%s", err, out)
-	}
-
 	app := &App{cfg: &config.Config{
 		DocRoots: map[string]config.DocumentRootConfig{
 			"core": {
@@ -549,7 +542,7 @@ func TestBuildDocumentStoreOptionsWiresCoreWriter(t *testing.T) {
 				Git: config.DocumentRootGitConfig{
 					Enabled:     true,
 					SignCommits: true,
-					SigningKey:  keyPath,
+					SigningKey:  signingKey,
 					RepoPath:    coreDir,
 				},
 			},

--- a/internal/app/document_roots_test.go
+++ b/internal/app/document_roots_test.go
@@ -520,3 +520,50 @@ func TestDocumentRootProvenanceReviser(t *testing.T) {
 		t.Fatalf("diff counts = +%d/-%d, want +2/-0", diff.Added, diff.Removed)
 	}
 }
+
+// TestBuildDocumentStoreOptionsWiresCoreWriter covers the case that
+// makes core survivable as a signed root.
+//
+// core holds documents the agent rewrites on its own schedule — ego,
+// metacognitive, archivist state. The boot gate requires core to have no
+// uncommitted changes, so unless those writes commit as they happen, the
+// first loop iteration after a start makes the next start impossible.
+// Declaring core under roots: with sign_commits is what closes that, and
+// this asserts the writer is actually wired rather than silently absent.
+func TestBuildDocumentStoreOptionsWiresCoreWriter(t *testing.T) {
+	t.Parallel()
+
+	coreDir := t.TempDir()
+	keyPath := filepath.Join(coreDir, "identity", "signing_ed25519")
+	if err := os.MkdirAll(filepath.Dir(keyPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if out, err := exec.Command("ssh-keygen", "-q", "-t", "ed25519", "-N", "", "-f", keyPath).CombinedOutput(); err != nil {
+		t.Skipf("ssh-keygen unavailable: %v\n%s", err, out)
+	}
+
+	app := &App{cfg: &config.Config{
+		DocRoots: map[string]config.DocumentRootConfig{
+			"core": {
+				Authoring: "managed",
+				Git: config.DocumentRootGitConfig{
+					Enabled:     true,
+					SignCommits: true,
+					SigningKey:  keyPath,
+					RepoPath:    coreDir,
+				},
+			},
+		},
+	}}
+
+	opts, err := app.buildDocumentStoreOptions(map[string]string{"core": coreDir}, nil)
+	if err != nil {
+		t.Fatalf("buildDocumentStoreOptions: %v", err)
+	}
+	if opts.RootWriters["core"] == nil {
+		t.Fatal("core declared with sign_commits must get a writer, or its documents never commit and the boot gate fails on the next start")
+	}
+	if !opts.RootPolicies["core"].Git.Enabled {
+		t.Fatalf("core git policy = %#v, want enabled", opts.RootPolicies["core"].Git)
+	}
+}


### PR DESCRIPTION
Production now declares `roots.core` with `sign_commits`, because core holds documents the agent rewrites on its own schedule — `ego.md`, `metacognitive.md`, `archivist.md` — and the boot gate requires core to have no uncommitted changes. Without a committing writer, the first loop iteration after a start makes the next start impossible.

That wiring was verified by hand during the production repair. This is the standing guard, so it cannot silently go missing.

Writing it was also worth it for what it taught: my first two attempts failed on `signing_key is required for signed document root commits` and then on the key file not existing — which is the config shape production actually needs, not merely `sign_commits: true`.

Refs #787

🤖 Generated with [Claude Code](https://claude.com/claude-code)