### PR TITLE
Each root founds its own trust: seed signers replace the shared list

### DIFF
--- a/docs/understanding/document-roots.md
+++ b/docs/understanding/document-roots.md
@@ -144,11 +144,35 @@ The current policy fields are:
   or `required`.
 
 Signature verification always uses the repository-local
-`.allowed_signers` file. For signer-backed roots, Thane creates that
-file from the configured signing key when it is missing; after that, the
-file itself is the trust configuration surface. Adding additional
-signers should be done by editing and committing `.allowed_signers`
-through trusted history.
+`.allowed_signers` file. Thane creates it once, when a signed root is
+first established, from the agent key plus that root's declared
+`seed_signers`:
+
+```yaml
+roots:
+  knowledge:
+    path: ./knowledge
+    seed_signers:
+      - principal: alice@example.com
+        key: "ssh-ed25519 AAAA..."
+        label: "Alice laptop"
+    git:
+      enabled: true
+      sign_commits: true
+      signing_key: ~/.ssh/id_ed25519
+```
+
+After that the file is the root's own trust surface and config never
+rewrites it. Adding signers is done by editing and committing
+`.allowed_signers` through trusted history — a change signed by a key
+the root already trusts.
+
+`seed_signers` is declared per root rather than once for the instance,
+because roots have different trust domains. The keys entitled to sign a
+corpus synced from a remote should not automatically be entitled to sign
+the config that decides what the whole system trusts. A root that signs
+its commits must declare seed signers, since signed history nobody
+decided to admit is a signature without a claim behind it.
 
 Signature-required roots are the place for high-integrity authored
 knowledge, such as owner-tagged knowledge articles. When verification

--- a/examples/config.example.yaml
+++ b/examples/config.example.yaml
@@ -266,6 +266,15 @@ roots:
       # Gating search the same way would need the document store to see
       # active capability tags, which it deliberately does not.
       requires_tag: ""
+    # SeedSigners are the keys entitled to establish this root. They
+    # seed its .allowed_signers at birth and are not re-applied after,
+    # because from then on the root's own file is its record of whom it
+    # trusts.
+    # 
+    # Declared per root rather than shared, so the keys that may sign a
+    # corpus synced from a remote are not automatically the keys that
+    # may sign the config deciding what the whole system trusts.
+    seed_signers: []
   kb:
     # Path is the directory the root resolves to. Supports ~
     # expansion at resolver construction time. For the reserved
@@ -386,6 +395,34 @@ roots:
       # Gating search the same way would need the document store to see
       # active capability tags, which it deliberately does not.
       requires_tag: ""
+    # SeedSigners are the keys entitled to establish this root. They
+    # seed its .allowed_signers at birth and are not re-applied after,
+    # because from then on the root's own file is its record of whom it
+    # trusts.
+    # 
+    # Declared per root rather than shared, so the keys that may sign a
+    # corpus synced from a remote are not automatically the keys that
+    # may sign the config deciding what the whole system trusts.
+    seed_signers:
+      - # Principal is the OpenSSH signer identity, conventionally an email
+        # such as "alice@example.com". Required. It must not contain
+        # whitespace or control characters — the allowed_signers format is
+        # space-delimited, so either would corrupt the line or smuggle a
+        # second entry.
+        principal: alice@example.com
+        # Key is the SSH public key in authorized_keys form, such as
+        # "ssh-ed25519 AAAA...". Required. It must parse as a valid public
+        # key.
+        key: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGyUStZXWURqF4b7IWfSTz2W6zYz5JnXrKbcuPfGAmUo
+        # Label is an optional human note rendered as the key's trailing
+        # comment. It must not contain control characters.
+        label: Alice laptop
+        # ValidAfter and ValidBefore optionally bound when the key is trusted.
+        # Each is an RFC3339 timestamp; when both are set, ValidAfter must be
+        # strictly before ValidBefore. Enforcement is delegated to OpenSSH at
+        # verify time; thane does not yet surface expiry.
+        valid_after: ""
+        valid_before: ""
   scratchpad:
     # Path is the directory the root resolves to. Supports ~
     # expansion at resolver construction time. For the reserved
@@ -452,6 +489,15 @@ roots:
       # Gating search the same way would need the document store to see
       # active capability tags, which it deliberately does not.
       requires_tag: ""
+    # SeedSigners are the keys entitled to establish this root. They
+    # seed its .allowed_signers at birth and are not re-applied after,
+    # because from then on the root's own file is its record of whom it
+    # trusts.
+    # 
+    # Declared per root rather than shared, so the keys that may sign a
+    # corpus synced from a remote are not automatically the keys that
+    # may sign the config deciding what the whole system trusts.
+    seed_signers: []
 #
 # (optional) Paths is the legacy directory-mapping block. Replaced by roots:.
 # paths: {}
@@ -923,32 +969,7 @@ compaction:
 #   signing_key: ~/.ssh/id_ed25519
 #
 # (optional) Signing declares the operator-managed set of SSH public keys trusted
-# signing:
-#   AllowedSigners lists SSH public keys trusted to sign commits across
-#   all signing roots. Each entry is an operator identity; a root may
-#   add more via its git.allowed_signers. The agent's own key is
-#   implicit and unremovable, so this list never needs — and must not
-#   include — it.
-#   allowed_signers:
-#     - # Principal is the OpenSSH signer identity, conventionally an email
-#       such as "alice@example.com". Required. It must not contain
-#       whitespace or control characters — the allowed_signers format is
-#       space-delimited, so either would corrupt the line or smuggle a
-#       second entry.
-#       principal: alice@example.com
-#       Key is the SSH public key in authorized_keys form, such as
-#       "ssh-ed25519 AAAA...". Required. It must parse as a valid public
-#       key.
-#       key: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGyUStZXWURqF4b7IWfSTz2W6zYz5JnXrKbcuPfGAmUo
-#       Label is an optional human note rendered as the key's trailing
-#       comment. It must not contain control characters.
-#       label: Alice laptop
-#       ValidAfter and ValidBefore optionally bound when the key is trusted.
-#       Each is an RFC3339 timestamp; when both are set, ValidAfter must be
-#       strictly before ValidBefore. Enforcement is delegated to OpenSSH at
-#       verify time; thane does not yet surface expiry.
-#       valid_after: ""
-#       valid_before: ""
+# signing: {}
 #
 # (optional) StateWindow configures the rolling window of recent Home Assistant
 # state_window:

--- a/examples/config.example.yaml
+++ b/examples/config.example.yaml
@@ -968,7 +968,7 @@ compaction:
 #   Supports ~ expansion. Example: ~/.ssh/id_ed25519
 #   signing_key: ~/.ssh/id_ed25519
 #
-# (optional) Signing declares the operator-managed set of SSH public keys trusted
+# (optional) Signing is a placeholder for future instance-wide signing settings.
 # signing: {}
 #
 # (optional) StateWindow configures the rolling window of recent Home Assistant

--- a/internal/app/document_roots.go
+++ b/internal/app/document_roots.go
@@ -169,7 +169,7 @@ func (a *App) buildDocumentStoreOptions(documentRoots map[string]string, resolve
 		// ready yet.
 		var writer *documentRootProvenanceWriter
 		if policy.Git.Enabled && policy.Git.SignCommits {
-			w, err := a.newDocumentRootProvenanceWriter(root, rootPath, rootCfg.Git, resolver)
+			w, err := a.newDocumentRootProvenanceWriter(root, rootPath, rootCfg, resolver)
 			if err != nil {
 				return documents.StoreOptions{}, err
 			}
@@ -317,7 +317,8 @@ func documentRootPolicyFromConfig(rootCfg config.DocumentRootConfig) documents.R
 	return policy
 }
 
-func (a *App) newDocumentRootProvenanceWriter(root, rootPath string, gitCfg config.DocumentRootGitConfig, resolver *paths.Resolver) (*documentRootProvenanceWriter, error) {
+func (a *App) newDocumentRootProvenanceWriter(root, rootPath string, rootCfg config.DocumentRootConfig, resolver *paths.Resolver) (*documentRootProvenanceWriter, error) {
+	gitCfg := rootCfg.Git
 	signingKey := strings.TrimSpace(gitCfg.SigningKey)
 	if signingKey == "" {
 		return nil, fmt.Errorf("doc_roots.%s.git.signing_key is required for signed document root commits", root)
@@ -350,7 +351,7 @@ func (a *App) newDocumentRootProvenanceWriter(root, rootPath string, gitCfg conf
 		WorktreePath:   absRootPath,
 		RepoPath:       absRepoPath,
 		SigningKeyPath: signingKey,
-		TrustedSigners: buildTrustedSigners(a.cfg.Signing.AllowedSigners, gitCfg.AllowedSigners),
+		SeedSigners:    buildTrustedSigners(rootCfg.SeedSigners, gitCfg.AllowedSigners),
 		Logger:         logger.With("component", "document_root_provenance", "root", root),
 	})
 	if err != nil {

--- a/internal/platform/checkout/signed.go
+++ b/internal/platform/checkout/signed.go
@@ -10,7 +10,7 @@ import (
 	"github.com/nugget/thane-ai-agent/internal/platform/provenance"
 )
 
-// DefaultBootstrapTimeout bounds checkout birth-commit and trust reconciliation
+// DefaultBootstrapTimeout bounds checkout birth-commit and trust seeding
 // work. It matches the provenance package's own git startup timeout.
 const DefaultBootstrapTimeout = 30 * time.Second
 
@@ -29,9 +29,10 @@ type SignedSpec struct {
 	// re-applied afterwards: the root's own .allowed_signers is its record
 	// of whom it trusts from then on.
 	SeedSigners []provenance.TrustedSigner
-	// SkipBirthCommit leaves the first commit to the caller. Use this when the
-	// domain needs its own birth commit contents; TrustedSigners must be empty
-	// because trust reconciliation requires an existing signed HEAD.
+	// SkipBirthCommit leaves the first commit to the caller. Use this when
+	// the domain needs its own birth commit contents; SeedSigners must be
+	// empty, since those contents include the trust file and would
+	// overwrite the seed.
 	SkipBirthCommit bool
 	// Logger receives setup logs. Nil uses slog.Default.
 	Logger *slog.Logger
@@ -50,7 +51,8 @@ type Signed struct {
 }
 
 // OpenSigned opens or initializes a signed checkout, creates a birth commit
-// when needed, and reconciles its repo-local allowed_signers file.
+// when needed, and seeds its repo-local allowed_signers file on first
+// establishment.
 func OpenSigned(ctx context.Context, spec SignedSpec) (*Signed, error) {
 	ctx, cancel := withDefaultTimeout(ctx)
 	defer cancel()
@@ -63,7 +65,11 @@ func OpenSigned(ctx context.Context, spec SignedSpec) (*Signed, error) {
 		return nil, fmt.Errorf("%s: worktree path is required", name)
 	}
 	if spec.SkipBirthCommit && len(spec.SeedSigners) > 0 {
-		return nil, fmt.Errorf("%s: trusted signers require a birth commit before reconciliation", name)
+		// A caller that owns the birth contents writes its own
+		// .allowed_signers, which would overwrite the seeded one without
+		// saying so. Refuse the combination rather than discard a trust
+		// set the caller believed they had declared.
+		return nil, fmt.Errorf("%s: seed signers cannot be combined with SkipBirthCommit, because the caller's own birth contents overwrite the seeded trust set", name)
 	}
 	signingKey := strings.TrimSpace(spec.SigningKeyPath)
 	if signingKey == "" {

--- a/internal/platform/checkout/signed.go
+++ b/internal/platform/checkout/signed.go
@@ -25,8 +25,10 @@ type SignedSpec struct {
 	RepoPath string
 	// SigningKeyPath is the SSH private key used for signed commits.
 	SigningKeyPath string
-	// TrustedSigners are operator signing keys added to the repo-local trust set.
-	TrustedSigners []provenance.TrustedSigner
+	// SeedSigners establish this root's trust set at birth. They are not
+	// re-applied afterwards: the root's own .allowed_signers is its record
+	// of whom it trusts from then on.
+	SeedSigners []provenance.TrustedSigner
 	// SkipBirthCommit leaves the first commit to the caller. Use this when the
 	// domain needs its own birth commit contents; TrustedSigners must be empty
 	// because trust reconciliation requires an existing signed HEAD.
@@ -60,7 +62,7 @@ func OpenSigned(ctx context.Context, spec SignedSpec) (*Signed, error) {
 	if strings.TrimSpace(spec.WorktreePath) == "" {
 		return nil, fmt.Errorf("%s: worktree path is required", name)
 	}
-	if spec.SkipBirthCommit && len(spec.TrustedSigners) > 0 {
+	if spec.SkipBirthCommit && len(spec.SeedSigners) > 0 {
 		return nil, fmt.Errorf("%s: trusted signers require a birth commit before reconciliation", name)
 	}
 	signingKey := strings.TrimSpace(spec.SigningKeyPath)
@@ -84,7 +86,9 @@ func OpenSigned(ctx context.Context, spec SignedSpec) (*Signed, error) {
 	if logger == nil {
 		logger = slog.Default()
 	}
-	store, err := provenance.New(root.RepoPath, signer, logger)
+	store, err := provenance.NewWithOptions(root.RepoPath, signer, logger, provenance.Options{
+		SeedSigners: spec.SeedSigners,
+	})
 	if err != nil {
 		return nil, fmt.Errorf("%s: initialize provenance store: %w", name, err)
 	}
@@ -92,9 +96,6 @@ func OpenSigned(ctx context.Context, spec SignedSpec) (*Signed, error) {
 	if !spec.SkipBirthCommit {
 		if err := store.BootstrapBirthCommit(ctx); err != nil {
 			return nil, fmt.Errorf("%s: bootstrap birth commit: %w", name, err)
-		}
-		if _, err := store.ReconcileAllowedSigners(ctx, spec.TrustedSigners); err != nil {
-			return nil, fmt.Errorf("%s: reconcile allowed_signers: %w", name, err)
 		}
 	}
 

--- a/internal/platform/checkout/signed_test.go
+++ b/internal/platform/checkout/signed_test.go
@@ -120,7 +120,7 @@ func TestOpenSignedCanLeaveBirthCommitToCaller(t *testing.T) {
 	}
 }
 
-func TestOpenSignedRejectsDeferredBirthWithTrustedSigners(t *testing.T) {
+func TestOpenSignedRejectsDeferredBirthWithSeedSigners(t *testing.T) {
 	worktree := t.TempDir()
 	signingKey, _ := writeSigningKey(t, "checkout-test")
 	_, operatorPublic := writeSigningKey(t, "operator-test")
@@ -136,10 +136,10 @@ func TestOpenSignedRejectsDeferredBirthWithTrustedSigners(t *testing.T) {
 		}},
 	})
 	if err == nil {
-		t.Fatal("OpenSigned() error = nil, want trusted signer guard")
+		t.Fatal("OpenSigned() error = nil, want the seed-signer guard")
 	}
-	if !strings.Contains(err.Error(), "trusted signers require a birth commit") {
-		t.Fatalf("error = %v, want trusted signer guard", err)
+	if !strings.Contains(err.Error(), "overwrite the seeded trust set") {
+		t.Fatalf("error = %v, want the seed-signer guard", err)
 	}
 }
 

--- a/internal/platform/checkout/signed_test.go
+++ b/internal/platform/checkout/signed_test.go
@@ -49,7 +49,7 @@ func TestOpenSignedBootstrapsAndReconciles(t *testing.T) {
 		Name:           "kb",
 		WorktreePath:   worktree,
 		SigningKeyPath: signingKey,
-		TrustedSigners: []provenance.TrustedSigner{{
+		SeedSigners: []provenance.TrustedSigner{{
 			Principal: "operator@example.com",
 			PublicKey: operatorPublic,
 			Comment:   "operator laptop",
@@ -130,7 +130,7 @@ func TestOpenSignedRejectsDeferredBirthWithTrustedSigners(t *testing.T) {
 		WorktreePath:    worktree,
 		SigningKeyPath:  signingKey,
 		SkipBirthCommit: true,
-		TrustedSigners: []provenance.TrustedSigner{{
+		SeedSigners: []provenance.TrustedSigner{{
 			Principal: "operator@example.com",
 			PublicKey: operatorPublic,
 		}},

--- a/internal/platform/config/config.go
+++ b/internal/platform/config/config.go
@@ -394,13 +394,11 @@ type Config struct {
 	// {workspace.path}/core rather than from this store.
 	Provenance ProvenanceConfig `yaml:"provenance"`
 
-	// Signing declares the operator-managed set of SSH public keys trusted
-	// to sign commits in git-backed document roots, in addition to the
-	// agent's own generated signing key (which is always trusted and can
-	// never be removed). These shared keys apply to every signing root; a
-	// root may extend the set with its own git.allowed_signers. Keys live
-	// only here in config and are never reachable by a model loop. This is
-	// the trust gate that lets an operator co-author a signed root.
+	// Signing is a placeholder for future instance-wide signing settings.
+	// It no longer holds a trust set: signing keys are declared per root
+	// as roots.<name>.seed_signers, so the keys entitled to sign a corpus
+	// shared over a remote are not automatically entitled to sign the
+	// config that decides what the whole system trusts.
 	Signing SigningConfig `yaml:"signing"`
 
 	// StateWindow configures the rolling window of recent Home Assistant

--- a/internal/platform/config/config.go
+++ b/internal/platform/config/config.go
@@ -927,14 +927,12 @@ func (c ProvenanceConfig) Configured() bool {
 // own signing key — which is always trusted and can never be removed — to
 // form the trust set that signature verification checks against. Keys are
 // operator-only: they live in config and are never exposed to a model.
-type SigningConfig struct {
-	// AllowedSigners lists SSH public keys trusted to sign commits across
-	// all signing roots. Each entry is an operator identity; a root may
-	// add more via its git.allowed_signers. The agent's own key is
-	// implicit and unremovable, so this list never needs — and must not
-	// include — it.
-	AllowedSigners []AllowedSigner `yaml:"allowed_signers,omitempty"`
-}
+// SigningConfig is retained for future instance-wide signing settings.
+// The trust set itself is declared per root as seed_signers, because
+// roots have different trust domains: the config that decides what the
+// system trusts and a corpus shared over a remote should not draw their
+// signers from one list.
+type SigningConfig struct{}
 
 // AllowedSigner is one trusted signing identity: an SSH public key bound to
 // a principal, with an optional label and validity window. It renders to
@@ -992,6 +990,16 @@ type RootEntry struct {
 	// whether they can be injected into a prompt and how they surface
 	// in search. Omit to keep the legacy behavior for this root.
 	Context RootContextPolicy `yaml:"context,omitempty"`
+
+	// SeedSigners are the keys entitled to establish this root. They
+	// seed its .allowed_signers at birth and are not re-applied after,
+	// because from then on the root's own file is its record of whom it
+	// trusts.
+	//
+	// Declared per root rather than shared, so the keys that may sign a
+	// corpus synced from a remote are not automatically the keys that
+	// may sign the config deciding what the whole system trusts.
+	SeedSigners []AllowedSigner `yaml:"seed_signers,omitempty"`
 }
 
 // Root context policy values. Injection is the narrower and more
@@ -1146,6 +1154,9 @@ type DocumentRootConfig struct {
 
 	// Context governs how this root's documents may reach a model.
 	Context RootContextPolicy `yaml:"context,omitempty"`
+
+	// SeedSigners are the keys entitled to establish this root.
+	SeedSigners []AllowedSigner `yaml:"seed_signers,omitempty"`
 }
 
 // DocumentRootGitConfig configures git-backed provenance for one
@@ -2412,6 +2423,23 @@ func LoadWithWorkspace(path, fallbackWorkspace string) (*Config, error) {
 // sets it believes they have pointed the instance somewhere, and the
 // instance would run from a different directory without saying so. The
 // error names the two things that actually decide the workspace now.
+// rejectRetiredSigningKeys refuses the instance-wide signer list.
+//
+// Silently dropping it would leave every signed root with no declared
+// trust set while the operator believed they had configured one — the
+// failure this whole change exists to make impossible.
+func rejectRetiredSigningKeys(signing *yaml.Node) error {
+	if signing == nil || signing.Kind != yaml.MappingNode {
+		return nil
+	}
+	for i := 0; i+1 < len(signing.Content); i += 2 {
+		if signing.Content[i].Value == "allowed_signers" {
+			return fmt.Errorf("config declares signing.allowed_signers, which is now per root. Move each key to roots.<name>.seed_signers for the roots it should be able to establish — declaring it once for every root is what let a key trusted for a shared corpus also sign the config that decides what the system trusts")
+		}
+	}
+	return nil
+}
+
 func rejectRetiredWorkspaceKeys(workspace *yaml.Node) error {
 	if workspace == nil || workspace.Kind != yaml.MappingNode {
 		return nil
@@ -2443,6 +2471,10 @@ func rejectRetiredKeys(data []byte) error {
 		switch keyNode.Value {
 		case "platform":
 			return fmt.Errorf("config has top-level platform: section, which was renamed to companion: in v0.9.x. Rename it (the field shape is unchanged) and re-load")
+		case "signing":
+			if err := rejectRetiredSigningKeys(valueNode); err != nil {
+				return err
+			}
 		case "curator":
 			return fmt.Errorf("config has top-level curator: section, which was renamed to archivist: when the loop became a self-paced queue consumer. Rename it (the field shape is unchanged) and re-load")
 		case "workspace":
@@ -2586,10 +2618,11 @@ func (c *Config) normalizeRoots() error {
 			}
 			if entryHasPolicy(entry) {
 				c.DocRoots[trimmed] = DocumentRootConfig{
-					Indexing:  entry.Indexing,
-					Authoring: entry.Authoring,
-					Git:       entry.Git,
-					Context:   entry.Context,
+					Indexing:    entry.Indexing,
+					Authoring:   entry.Authoring,
+					Git:         entry.Git,
+					Context:     entry.Context,
+					SeedSigners: entry.SeedSigners,
 				}
 			}
 		}
@@ -2617,6 +2650,9 @@ func entryHasPolicy(entry RootEntry) bool {
 		return true
 	}
 	if entry.Context.Declared() {
+		return true
+	}
+	if len(entry.SeedSigners) > 0 {
 		return true
 	}
 	g := entry.Git
@@ -3268,9 +3304,23 @@ func isSSHGitURL(url string) bool {
 	return slash < 0 || colon < slash
 }
 
-// validateSigning checks the shared operator allowed-signers block.
+// validateSigning checks each root's declared seed signers, and that a
+// root which signs its commits declares who may establish it.
 func (c *Config) validateSigning() error {
-	return validateAllowedSigners("signing.allowed_signers", c.Signing.AllowedSigners)
+	for root, policy := range c.DocRoots {
+		root = strings.TrimSuffix(strings.TrimSpace(root), ":")
+		label := "roots." + root + ".seed_signers"
+		if err := validateAllowedSigners(label, policy.SeedSigners); err != nil {
+			return err
+		}
+		// A root that signs its history without saying who may establish
+		// it has signed history with no admission: verification would
+		// confirm a signature without anyone having decided whose.
+		if policy.Git.Enabled && policy.Git.SignCommits && len(policy.SeedSigners) == 0 {
+			return fmt.Errorf("roots.%s signs commits but declares no seed_signers; list the keys entitled to establish this root", root)
+		}
+	}
+	return nil
 }
 
 // validateAllowedSigners validates a list of trusted signing keys, prefixing

--- a/internal/platform/config/config_test.go
+++ b/internal/platform/config/config_test.go
@@ -1111,6 +1111,9 @@ roots:
   secure:
     path: ./secure
     indexing: false
+    seed_signers:
+      - principal: alice@example.com
+        key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGyUStZXWURqF4b7IWfSTz2W6zYz5JnXrKbcuPfGAmUo"
     git:
       enabled: true
       sign_commits: true

--- a/internal/platform/config/example.go
+++ b/internal/platform/config/example.go
@@ -110,7 +110,12 @@ func ExampleConfig() *Config {
 		Roots: map[string]RootEntry{
 			"generated": {Path: "./generated"},
 			"kb": {
-				Path:     "./knowledge",
+				Path: "./knowledge",
+				SeedSigners: []AllowedSigner{{
+					Principal: "alice@example.com",
+					Key:       "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGyUStZXWURqF4b7IWfSTz2W6zYz5JnXrKbcuPfGAmUo",
+					Label:     "Alice laptop",
+				}},
 				Indexing: &docRootIndexing,
 				// The knowledge base is the one corpus whose tagged
 				// articles are meant to reach the prompt. Every other
@@ -285,14 +290,6 @@ func ExampleConfig() *Config {
 		Provenance: ProvenanceConfig{
 			Path:       "~/Thane/core",
 			SigningKey: "~/.ssh/id_ed25519",
-		},
-
-		Signing: SigningConfig{
-			AllowedSigners: []AllowedSigner{{
-				Principal: "alice@example.com",
-				Key:       "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGyUStZXWURqF4b7IWfSTz2W6zYz5JnXrKbcuPfGAmUo",
-				Label:     "Alice laptop",
-			}},
 		},
 
 		Loops: LoopsConfig{

--- a/internal/platform/config/signing_test.go
+++ b/internal/platform/config/signing_test.go
@@ -133,15 +133,33 @@ func TestValidateAllowedSigners(t *testing.T) {
 	}
 }
 
-// TestValidate_SigningBlockWired confirms the shared signing.allowed_signers
-// block is reached by Config.Validate and labels errors with its path.
-func TestValidate_SigningBlockWired(t *testing.T) {
+// TestValidate_SeedSignersWired confirms a root's seed_signers are reached
+// by Config.Validate and labelled with the root they belong to — which is
+// the point of declaring them per root rather than once.
+func TestValidate_SeedSignersWired(t *testing.T) {
 	t.Parallel()
 	cfg := Default()
-	cfg.Signing = SigningConfig{AllowedSigners: []AllowedSigner{{Principal: "alice example", Key: testSignerKeyAlice}}}
+	cfg.DocRoots = map[string]DocumentRootConfig{
+		"kb": {SeedSigners: []AllowedSigner{{Principal: "alice example", Key: testSignerKeyAlice}}},
+	}
 	err := cfg.Validate()
-	if err == nil || !strings.Contains(err.Error(), "signing.allowed_signers[0].principal") {
-		t.Fatalf("Validate() = %v, want signing.allowed_signers[0].principal error", err)
+	if err == nil || !strings.Contains(err.Error(), "roots.kb.seed_signers[0].principal") {
+		t.Fatalf("Validate() = %v, want roots.kb.seed_signers[0].principal error", err)
+	}
+}
+
+// TestValidate_SignedRootRequiresSeedSigners covers the rule that keeps
+// signing meaningful: a root that signs its history without declaring who
+// may establish it has signatures nobody decided to trust.
+func TestValidate_SignedRootRequiresSeedSigners(t *testing.T) {
+	t.Parallel()
+	cfg := Default()
+	cfg.DocRoots = map[string]DocumentRootConfig{
+		"kb": {Git: DocumentRootGitConfig{Enabled: true, SignCommits: true, SigningKey: "~/.ssh/id_ed25519"}},
+	}
+	err := cfg.Validate()
+	if err == nil || !strings.Contains(err.Error(), "declares no seed_signers") {
+		t.Fatalf("Validate() = %v, want a missing seed_signers error", err)
 	}
 }
 
@@ -159,14 +177,21 @@ func TestValidate_PerRootAllowedSignersWired(t *testing.T) {
 	}
 }
 
-// TestValidate_ValidAllowedSignersPass confirms a well-formed shared block and
-// per-root block validate cleanly end-to-end.
+// TestValidate_ValidAllowedSignersPass confirms well-formed seed and
+// per-root git blocks validate cleanly end-to-end, and that two roots can
+// hold different trust sets — the property a single shared list could not
+// express.
 func TestValidate_ValidAllowedSignersPass(t *testing.T) {
 	t.Parallel()
 	cfg := Default()
-	cfg.Signing = SigningConfig{AllowedSigners: []AllowedSigner{{Principal: "alice@example.com", Key: testSignerKeyAlice, Label: "Alice laptop"}}}
 	cfg.DocRoots = map[string]DocumentRootConfig{
-		"kb": {Git: DocumentRootGitConfig{AllowedSigners: []AllowedSigner{{Principal: "bob@example.com", Key: testSignerKeyBob}}}},
+		"kb": {
+			SeedSigners: []AllowedSigner{{Principal: "alice@example.com", Key: testSignerKeyAlice, Label: "Alice laptop"}},
+			Git:         DocumentRootGitConfig{AllowedSigners: []AllowedSigner{{Principal: "bob@example.com", Key: testSignerKeyBob}}},
+		},
+		"core": {
+			SeedSigners: []AllowedSigner{{Principal: "alice@example.com", Key: testSignerKeyAlice, Label: "Alice laptop"}},
+		},
 	}
 	if err := cfg.Validate(); err != nil {
 		t.Fatalf("Validate() = %v, want nil", err)

--- a/internal/platform/provenance/allowed_signers.go
+++ b/internal/platform/provenance/allowed_signers.go
@@ -112,19 +112,44 @@ func RenderAllowedSigners(agentPublicKey string, operators []TrustedSigner) (str
 	return b.String(), nil
 }
 
-// ReconcileAllowedSigners renders this repository's trust set — the agent key
-// plus the given operator signers — and, when it differs from the repo's
-// current .allowed_signers, writes it and makes a signed commit so the tracked
-// trust surface stays clean and covered by signed history. It reports whether
-// a commit was made and is idempotent: an unchanged set is a no-op with no
-// commit, so it can run on every boot without churning history.
+// SeedAllowedSigners establishes this repository's trust set once — the agent
+// key plus the root's declared seed signers — and leaves it alone thereafter.
+// It reports whether it wrote and committed the file.
+//
+// Seeding rather than reconciling is the difference between config being a
+// root's origin and config being its permanent authority. A root's
+// .allowed_signers is that root's own record of whom it trusts, extended by
+// commits signed with keys it already trusts. Rewriting it from config on
+// every boot would mean one instance's config silently redefines who may sign
+// a corpus shared with others, and would collapse every root into whatever
+// the widest list says.
+//
+// An existing file is left alone even when it differs from config. That is
+// the point rather than a limitation: divergence is the root exercising its
+// own delegation, not drift to be corrected.
 //
 // The repository must already have a HEAD, so call it after
 // [Store.BootstrapBirthCommit]. Rendering enforces the trust invariants
 // (agent key unremovable and never reused by an operator, no principal-spoof
 // duplicates), so a config that violates them fails here rather than silently
 // weakening verification.
-func (s *Store) ReconcileAllowedSigners(ctx context.Context, operators []TrustedSigner) (bool, error) {
+func (s *Store) SeedAllowedSigners(ctx context.Context, seed []TrustedSigner) (bool, error) {
+	if s.allowedSignersPath != "" {
+		return false, fmt.Errorf("SeedAllowedSigners: store verifies against an external allowed_signers file (%s); in-tree seeding does not apply", s.allowedSignersPath)
+	}
+	s.mu.Lock()
+	_, statErr := os.Stat(filepath.Join(s.path, ".allowed_signers"))
+	s.mu.Unlock()
+	switch {
+	case statErr == nil:
+		return false, nil
+	case !errors.Is(statErr, os.ErrNotExist):
+		return false, fmt.Errorf("stat .allowed_signers: %w", statErr)
+	}
+	return s.writeAllowedSigners(ctx, seed)
+}
+
+func (s *Store) writeAllowedSigners(ctx context.Context, operators []TrustedSigner) (bool, error) {
 	// This reconcile writes and commits the repo-local trust file. When the
 	// Store verifies against an external allowed_signers file, that file is
 	// not in the worktree and cannot be committed — reconciling the

--- a/internal/platform/provenance/allowed_signers_test.go
+++ b/internal/platform/provenance/allowed_signers_test.go
@@ -188,31 +188,34 @@ func TestRenderAllowedSigners_CollapsesSamePrincipalDuplicate(t *testing.T) {
 	}
 }
 
-// TestReconcileAllowedSignersCommitsUnionAndIsIdempotent covers the full I/O
-// path: rendering the agent+operator union into the repo's .allowed_signers,
-// committing it as signed history, keeping HEAD verifiable, and doing nothing
-// on an unchanged set.
-func TestReconcileAllowedSignersCommitsUnionAndIsIdempotent(t *testing.T) {
+// TestSeedAllowedSignersWritesOnceAndThenLeavesTheRootAlone covers the full
+// I/O path: rendering the agent+seed union into the repo's .allowed_signers,
+// committing it as signed history, keeping HEAD verifiable, and then never
+// touching the file again — including when config later disagrees with it,
+// which is the root exercising its own delegation rather than drift.
+func TestSeedAllowedSignersWritesOnceAndThenLeavesTheRootAlone(t *testing.T) {
 	if _, err := exec.LookPath("git"); err != nil {
 		t.Skip("git not available")
 	}
 	dir := t.TempDir()
 	signer := testSigner(t)
-	s, err := New(dir, signer, slog.Default())
+	ops := []TrustedSigner{{Principal: "alice@example.com", PublicKey: testAliceKey, Comment: "Alice laptop"}}
+	s, err := NewWithOptions(dir, signer, slog.Default(), Options{SeedSigners: ops})
 	if err != nil {
-		t.Fatalf("New: %v", err)
+		t.Fatalf("NewWithOptions: %v", err)
 	}
 	if err := s.BootstrapBirthCommit(t.Context()); err != nil {
 		t.Fatalf("BootstrapBirthCommit: %v", err)
 	}
 
-	ops := []TrustedSigner{{Principal: "alice@example.com", PublicKey: testAliceKey, Comment: "Alice laptop"}}
-	changed, err := s.ReconcileAllowedSigners(t.Context(), ops)
+	// The seed landed when the repository was established; asking again
+	// must not rewrite it.
+	changed, err := s.SeedAllowedSigners(t.Context(), ops)
 	if err != nil {
-		t.Fatalf("ReconcileAllowedSigners: %v", err)
+		t.Fatalf("SeedAllowedSigners: %v", err)
 	}
-	if !changed {
-		t.Fatal("first reconcile changed = false, want true")
+	if changed {
+		t.Fatal("seeding an established root changed = true, want false")
 	}
 
 	got, err := os.ReadFile(filepath.Join(dir, ".allowed_signers"))
@@ -229,27 +232,27 @@ func TestReconcileAllowedSignersCommitsUnionAndIsIdempotent(t *testing.T) {
 	// HEAD (the reconcile commit) must still verify against the rendered
 	// trust file — the agent key that signed it is in the file.
 	if err := s.git(t.Context(), nil, nil, "verify-commit", "HEAD"); err != nil {
-		t.Fatalf("verify-commit HEAD after reconcile: %v", err)
+		t.Fatalf("verify-commit HEAD after seed: %v", err)
 	}
 
 	// Idempotent: an unchanged set makes no commit and does not move HEAD.
 	before := headHash(t, s)
-	changed, err = s.ReconcileAllowedSigners(t.Context(), ops)
+	changed, err = s.SeedAllowedSigners(t.Context(), ops)
 	if err != nil {
-		t.Fatalf("second ReconcileAllowedSigners: %v", err)
+		t.Fatalf("second SeedAllowedSigners: %v", err)
 	}
 	if changed {
-		t.Fatal("second reconcile changed = true, want false (idempotent)")
+		t.Fatal("second seed changed = true, want false — an existing trust set is the root's own")
 	}
 	if after := headHash(t, s); after != before {
-		t.Fatalf("HEAD moved on idempotent reconcile: %s -> %s", before, after)
+		t.Fatalf("HEAD moved on re-seed: %s -> %s", before, after)
 	}
 }
 
-// TestReconcileAllowedSignersRejectsExternalTrustFile confirms the in-tree
+// TestSeedAllowedSignersRejectsExternalTrustFile confirms the in-tree
 // reconcile refuses to run when the Store verifies against an external
 // allowed_signers file it could not commit anyway.
-func TestReconcileAllowedSignersRejectsExternalTrustFile(t *testing.T) {
+func TestSeedAllowedSignersRejectsExternalTrustFile(t *testing.T) {
 	if _, err := exec.LookPath("git"); err != nil {
 		t.Skip("git not available")
 	}
@@ -263,7 +266,7 @@ func TestReconcileAllowedSignersRejectsExternalTrustFile(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewWithOptions: %v", err)
 	}
-	_, err = s.ReconcileAllowedSigners(t.Context(), []TrustedSigner{{Principal: "alice@example.com", PublicKey: testAliceKey}})
+	_, err = s.SeedAllowedSigners(t.Context(), []TrustedSigner{{Principal: "alice@example.com", PublicKey: testAliceKey}})
 	if err == nil || !strings.Contains(err.Error(), "external allowed_signers") {
 		t.Fatalf("ReconcileAllowedSigners error = %v, want external-file rejection", err)
 	}
@@ -310,4 +313,76 @@ func headHash(t *testing.T, s *Store) string {
 		t.Fatalf("rev-parse HEAD: %v", err)
 	}
 	return strings.TrimSpace(buf.String())
+}
+
+// TestSeedSignersLandAtRepositoryCreation is the property the whole model
+// rests on: a root's trust surface is established once, from its own
+// declared seed, and is not the shared list that every other root drew
+// from.
+func TestSeedSignersLandAtRepositoryCreation(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	dir := t.TempDir()
+	seed := []TrustedSigner{{Principal: "alice@example.com", PublicKey: testAliceKey, Comment: "Alice laptop"}}
+	if _, err := NewWithOptions(dir, testSigner(t), slog.Default(), Options{SeedSigners: seed}); err != nil {
+		t.Fatalf("NewWithOptions: %v", err)
+	}
+
+	body, err := os.ReadFile(filepath.Join(dir, ".allowed_signers"))
+	if err != nil {
+		t.Fatalf("read .allowed_signers: %v", err)
+	}
+	got := string(body)
+	if !strings.Contains(got, "alice@example.com") {
+		t.Fatalf(".allowed_signers should carry the seed signer at creation:\n%s", got)
+	}
+	if !strings.Contains(got, AgentPrincipal) {
+		t.Fatalf(".allowed_signers should still carry the agent key:\n%s", got)
+	}
+}
+
+// TestSeedIsNotReappliedAfterTheRootDiverges covers the case that
+// separates seeding from reconciling: once a root's own file says
+// something config does not, config does not win. Divergence is the root
+// exercising its delegation, not drift.
+func TestSeedIsNotReappliedAfterTheRootDiverges(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	dir := t.TempDir()
+	signer := testSigner(t)
+	s, err := NewWithOptions(dir, signer, slog.Default(), Options{})
+	if err != nil {
+		t.Fatalf("NewWithOptions: %v", err)
+	}
+	if err := s.BootstrapBirthCommit(t.Context()); err != nil {
+		t.Fatalf("BootstrapBirthCommit: %v", err)
+	}
+
+	// A key config never mentioned, added the way a root legitimately
+	// extends its own trust.
+	path := filepath.Join(dir, ".allowed_signers")
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	delegated := string(body) + "carol@example.com " + testAliceKey + "\n"
+	if err := os.WriteFile(path, []byte(delegated), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	if _, err := s.SeedAllowedSigners(t.Context(), []TrustedSigner{
+		{Principal: "alice@example.com", PublicKey: testAliceKey},
+	}); err != nil {
+		t.Fatalf("SeedAllowedSigners: %v", err)
+	}
+
+	after, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read after: %v", err)
+	}
+	if !strings.Contains(string(after), "carol@example.com") {
+		t.Fatalf("the root's own delegation was overwritten from config:\n%s", string(after))
+	}
 }

--- a/internal/platform/provenance/allowed_signers_test.go
+++ b/internal/platform/provenance/allowed_signers_test.go
@@ -229,7 +229,7 @@ func TestSeedAllowedSignersWritesOnceAndThenLeavesTheRootAlone(t *testing.T) {
 		t.Fatalf("operator line missing or malformed:\n%s", got)
 	}
 
-	// HEAD (the reconcile commit) must still verify against the rendered
+	// HEAD (the seed commit) must still verify against the rendered
 	// trust file — the agent key that signed it is in the file.
 	if err := s.git(t.Context(), nil, nil, "verify-commit", "HEAD"); err != nil {
 		t.Fatalf("verify-commit HEAD after seed: %v", err)
@@ -249,8 +249,8 @@ func TestSeedAllowedSignersWritesOnceAndThenLeavesTheRootAlone(t *testing.T) {
 	}
 }
 
-// TestSeedAllowedSignersRejectsExternalTrustFile confirms the in-tree
-// reconcile refuses to run when the Store verifies against an external
+// TestSeedAllowedSignersRejectsExternalTrustFile confirms in-tree seeding
+// refuses to run when the Store verifies against an external
 // allowed_signers file it could not commit anyway.
 func TestSeedAllowedSignersRejectsExternalTrustFile(t *testing.T) {
 	if _, err := exec.LookPath("git"); err != nil {

--- a/internal/platform/provenance/git.go
+++ b/internal/platform/provenance/git.go
@@ -117,8 +117,15 @@ func (s *Store) ensureRepo() error {
 			if err != nil {
 				return fmt.Errorf("render seed allowed_signers: %w", err)
 			}
-			if err := os.WriteFile(allowedPath, []byte(allowedSigners), 0o644); err != nil {
+			// Rename-based, and re-validated after: a plain write leaves a
+			// window between the not-exist check above and the write in
+			// which a symlink can be dropped in, redirecting the file that
+			// decides which signatures count to somewhere outside the repo.
+			if err := atomicWriteFile(allowedPath, []byte(allowedSigners), 0o644); err != nil {
 				return fmt.Errorf("write .allowed_signers: %w", err)
+			}
+			if err := validateAllowedSignersFile(allowedPath); err != nil {
+				return fmt.Errorf("seed .allowed_signers: %w", err)
 			}
 		}
 	} else if err := validateAllowedSignersFile(allowedPath); err != nil {

--- a/internal/platform/provenance/git.go
+++ b/internal/platform/provenance/git.go
@@ -108,10 +108,15 @@ func (s *Store) ensureRepo() error {
 			if !errors.Is(err, os.ErrNotExist) {
 				return err
 			}
-			// Bootstrap .allowed_signers with the signer's public
-			// key when this repository does not already define its
-			// own trust surface.
-			allowedSigners := fmt.Sprintf("thane@provenance.local %s\n", s.signer.PublicKey())
+			// Establish this repository's trust surface: the agent key
+			// plus the seed signers entitled to found this root. It is
+			// written once, here, and never rewritten from config —
+			// afterwards the file is the root's own record, extended by
+			// commits signed with keys it already trusts.
+			allowedSigners, err := RenderAllowedSigners(s.signer.PublicKey(), s.seedSigners)
+			if err != nil {
+				return fmt.Errorf("render seed allowed_signers: %w", err)
+			}
 			if err := os.WriteFile(allowedPath, []byte(allowedSigners), 0o644); err != nil {
 				return fmt.Errorf("write .allowed_signers: %w", err)
 			}

--- a/internal/platform/provenance/provenance.go
+++ b/internal/platform/provenance/provenance.go
@@ -157,6 +157,7 @@ type Store struct {
 	signer             Signer
 	logger             *slog.Logger
 	allowedSignersPath string
+	seedSigners        []TrustedSigner
 }
 
 // Options configures optional provenance store behavior.
@@ -165,6 +166,12 @@ type Options struct {
 	// existing OpenSSH allowed signers file. Empty writes a
 	// repository-local .allowed_signers file containing the signing key.
 	AllowedSignersPath string
+
+	// SeedSigners are the keys entitled to establish this repository.
+	// They are written into .allowed_signers alongside the agent key
+	// when the file is first created, and never applied again — a root
+	// that already has a trust surface owns it.
+	SeedSigners []TrustedSigner
 }
 
 // New creates a [Store] backed by a git repository at path. If the
@@ -201,6 +208,7 @@ func NewWithOptions(path string, signer Signer, logger *slog.Logger, opts Option
 		signer:             signer,
 		logger:             logger,
 		allowedSignersPath: allowedSignersPath,
+		seedSigners:        opts.SeedSigners,
 	}
 
 	if err := s.ensureRepo(); err != nil {


### PR DESCRIPTION
First implementation slice of #1264.

## What changes

`signing.allowed_signers` is gone. Each root declares `seed_signers`, and a root that signs its commits must declare them:

```yaml
roots:
  knowledge:
    path: ./knowledge
    seed_signers:
      - principal: alice@example.com
        key: "ssh-ed25519 AAAA..."
    git:
      enabled: true
      sign_commits: true
      signing_key: ~/.ssh/id_ed25519
```

## Why the shared list had to go

Production has `kb:` and `projects:` syncing **bidirectionally** from a remote, and `core:` holding the config that sets `verify_signatures`. Under one list, adding a collaborator so they could push to a shared corpus also made them a valid signer for the file that decides what the entire system trusts.

That wasn't hypothetical — it was live in a config we were about to deploy, and it surfaced while bringing core up to the boot gate's requirements.

## Seeding, not reconciling

A root's `.allowed_signers` is now written **once**, when the repository is established, from the agent key plus that root's seed signers. Config never rewrites it again.

An existing file is left alone even when config disagrees with it. That's the point rather than a limitation: divergence is the root exercising its own delegation, not drift to be corrected. Rewriting from config on every boot would mean one instance's config silently redefines who may sign a corpus shared with others.

**The seed had to move into repository creation.** My first cut called a seed step after the birth commit, and a test immediately showed it always no-opping — `ensureRepo` already wrote the trust file with the agent key alone, and reconciliation was what added operators afterward. Founding a root *with* its seed is also the truer shape than founding it and then amending it.

## On the verbosity

Operator keys now repeat across signed roots. That repetition is doing work: it makes visible at a glance that adding a key to one corpus does not touch another. A single list hides exactly the relationship that mattered here.

## Deliberately not in this PR

Two properties from the design are absent, and I'd rather name them than let the PR imply completeness:

- **Seed signers are not yet a permanent floor.** Nothing prevents a root's own file from later dropping one.
- **The root commit is not verified against the seed set.** Admission is not yet gated.

Both need verification-time composition of seed plus in-tree signers, rather than the creation-time seeding this PR does, so they're the natural second slice.

## Test plan

- [x] Seed signers land in `.allowed_signers` at repository creation, alongside the agent key
- [x] A root that has diverged is not overwritten from config — a delegated key config never mentioned survives
- [x] Re-seeding an established root is a no-op
- [x] `seed_signers` validation is labelled per root
- [x] A signed root without seed signers is rejected
- [x] Two roots can hold different trust sets — the property one list could not express
- [x] `signing.allowed_signers` is rejected with a message naming the replacement
- [x] `just ci` green locally

Refs #1264 #787

🤖 Generated with [Claude Code](https://claude.com/claude-code)