### PR TITLE
Admission: a root proves its birth before its history counts

### DIFF
--- a/cmd/thane/validate.go
+++ b/cmd/thane/validate.go
@@ -5,8 +5,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"sort"
 	"strings"
 
+	"github.com/nugget/thane-ai-agent/internal/app"
 	"github.com/nugget/thane-ai-agent/internal/platform/config"
 	"github.com/nugget/thane-ai-agent/internal/platform/coreintegrity"
 )
@@ -35,17 +37,23 @@ func runValidate(w io.Writer, configPath, workspacePath, outputFmt string) error
 	if cfgPath == "" {
 		cfgPath = configPath
 	}
+	// Admission needs a loaded config to know which roots exist and whose
+	// signatures may establish them, so it only runs once the config parses.
+	var admission []app.RootAdmission
+	if loadErr == nil {
+		admission = app.CheckRootAdmission(context.Background(), cfg)
+	}
 	if outputFmt == "json" {
 		// Always emit JSON to stdout, even on failure — scripts may
 		// want the structured error. The error is still returned so
 		// the exit code reflects validity.
-		if err := writeValidateJSON(w, cfgPath, cfg, loadErr, integrity); err != nil {
+		if err := writeValidateJSON(w, cfgPath, cfg, loadErr, integrity, admission); err != nil {
 			return err
 		}
 		if loadErr != nil {
 			return terminal(loadErr)
 		}
-		return integrityError(integrity)
+		return firstError(integrityError(integrity), admissionError(admission))
 	}
 	if loadErr != nil {
 		// Config could not load, but the integrity report is often the
@@ -62,7 +70,80 @@ func runValidate(w io.Writer, configPath, workspacePath, outputFmt string) error
 		fmt.Fprintln(w)
 		writeIntegrityText(w, *integrity)
 	}
-	return integrityError(integrity)
+	if len(admission) > 0 {
+		fmt.Fprintln(w)
+		writeAdmissionText(w, admission)
+	}
+	return firstError(integrityError(integrity), admissionError(admission))
+}
+
+// firstError returns the first non-nil error, so validate reports every
+// section it can and still exits on the earliest thing serve would refuse
+// over.
+func firstError(errs ...error) error {
+	for _, err := range errs {
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// admissionError converts failing root admission into the error that stops
+// `thane validate && thane serve`.
+//
+// Only roots under verify_signatures: required produce it. That is not
+// leniency — it mirrors what serve does, which is refuse on required and log
+// on warn. Failing here for a warn root would make validate stricter than the
+// gate it reports on, which breaks the guard just as surely as being more
+// permissive.
+func admissionError(results []app.RootAdmission) error {
+	var fatal []string
+	for _, result := range results {
+		if result.Fatal() {
+			fatal = append(fatal, result.Root)
+		}
+	}
+	if len(fatal) == 0 {
+		return nil
+	}
+	sort.Strings(fatal)
+	return terminal(fmt.Errorf("document root admission failed for %s (see the report above; thane serve will refuse to start)",
+		strings.Join(fatal, ", ")))
+}
+
+// writeAdmissionText prints the per-root admission report. A root that fails
+// prints the full reason rather than a summary, because admission failures are
+// repaired from the detail — which key signed, and what to declare.
+func writeAdmissionText(w io.Writer, results []app.RootAdmission) {
+	sort.Slice(results, func(i, j int) bool { return results[i].Root < results[j].Root })
+
+	admitted := true
+	names := make([]string, 0, len(results))
+	for _, result := range results {
+		names = append(names, result.Root)
+		if !result.Admitted() {
+			admitted = false
+		}
+	}
+	if admitted {
+		fmt.Fprintf(w, "✓ Root admission: %s\n", strings.Join(names, ", "))
+		return
+	}
+	fmt.Fprint(w, "✗ Root admission\n\n")
+	for _, result := range results {
+		if result.Admitted() {
+			fmt.Fprintf(w, "  ✓ %s\n", result.Root)
+			continue
+		}
+		marker := "✗"
+		if !result.Fatal() {
+			// A warn root is reported without claiming serve will refuse,
+			// because it will not.
+			marker = "!"
+		}
+		fmt.Fprintf(w, "  %s %s (%s)\n      %s\n", marker, result.Root, result.Mode, result.Err)
+	}
 }
 
 // integrityError converts a failing report into the error that makes
@@ -174,7 +255,29 @@ func writeValidateText(w io.Writer, cfg *config.Config) {
 
 // writeValidateJSON emits the structured validation report. cfg may be
 // nil when load failed; loadErr is non-nil when validation failed.
-func writeValidateJSON(w io.Writer, cfgPath string, cfg *config.Config, loadErr error, integrity *coreintegrity.Report) error {
+func writeValidateJSON(w io.Writer, cfgPath string, cfg *config.Config, loadErr error, integrity *coreintegrity.Report, admission []app.RootAdmission) error {
+	type rootAdmissionJSON struct {
+		Root     string `json:"root"`
+		RepoPath string `json:"repo_path,omitempty"`
+		Mode     string `json:"mode"`
+		Admitted bool   `json:"admitted"`
+		Error    string `json:"error,omitempty"`
+	}
+	roots := make([]rootAdmissionJSON, 0, len(admission))
+	for _, entry := range admission {
+		row := rootAdmissionJSON{
+			Root:     entry.Root,
+			RepoPath: entry.RepoPath,
+			Mode:     string(entry.Mode),
+			Admitted: entry.Admitted(),
+		}
+		if entry.Err != nil {
+			row.Error = entry.Err.Error()
+		}
+		roots = append(roots, row)
+	}
+	sort.Slice(roots, func(i, j int) bool { return roots[i].Root < roots[j].Root })
+
 	// Path always emits (no omitempty) so the JSON schema is stable
 	// for scripts piping into jq — even discovery-failure cases get
 	// a path field, possibly empty.
@@ -184,10 +287,12 @@ func writeValidateJSON(w io.Writer, cfgPath string, cfg *config.Config, loadErr 
 		Error     string                `json:"error,omitempty"`
 		Summary   map[string]any        `json:"summary,omitempty"`
 		Integrity *coreintegrity.Report `json:"integrity,omitempty"`
+		Roots     []rootAdmissionJSON   `json:"root_admission,omitempty"`
 	}{
 		Path:      cfgPath,
 		Valid:     loadErr == nil,
 		Integrity: integrity,
+		Roots:     roots,
 	}
 	if loadErr != nil {
 		result.Error = loadErr.Error()

--- a/cmd/thane/validate_test.go
+++ b/cmd/thane/validate_test.go
@@ -3,10 +3,14 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/nugget/thane-ai-agent/internal/app"
+	"github.com/nugget/thane-ai-agent/internal/state/documents"
 )
 
 // minimalValidConfig returns the smallest config.yaml body that parses
@@ -245,5 +249,67 @@ func TestRunValidate_IntegrityReportForWorkspaceInstance(t *testing.T) {
 	// give the command that fixes it.
 	if !strings.Contains(out, "core_repository") || !strings.Contains(out, "git -C") {
 		t.Fatalf("report should name the failing check and its fix:\n%s", out)
+	}
+}
+
+// TestAdmissionReporting covers the mapping from admission outcomes to what
+// an operator sees and what the exit code says. The decision itself is tested
+// against the real boot path in internal/app; what matters here is that a
+// required failure stops `validate && serve` while a warn failure does not,
+// since that is exactly how serve treats them.
+func TestAdmissionReporting(t *testing.T) {
+	refused := errors.New("root commit is not signed by a declared seed signer")
+
+	tests := []struct {
+		name      string
+		results   []app.RootAdmission
+		wantErr   bool
+		wantLines []string
+	}{
+		{
+			name: "all admitted",
+			results: []app.RootAdmission{
+				{Root: "projects", Mode: documents.VerificationRequired, Applicable: true},
+				{Root: "kb", Mode: documents.VerificationRequired, Applicable: true},
+			},
+			wantLines: []string{"✓ Root admission: kb, projects"},
+		},
+		{
+			name: "required failure is fatal",
+			results: []app.RootAdmission{
+				{Root: "kb", Mode: documents.VerificationRequired, Applicable: true, Err: refused},
+				{Root: "projects", Mode: documents.VerificationRequired, Applicable: true},
+			},
+			wantErr:   true,
+			wantLines: []string{"✗ Root admission", "✗ kb (required)", "✓ projects", refused.Error()},
+		},
+		{
+			name: "warn failure reports without refusing",
+			results: []app.RootAdmission{
+				{Root: "kb", Mode: documents.VerificationWarn, Applicable: true, Err: refused},
+			},
+			wantLines: []string{"! kb (warn)", refused.Error()},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := admissionError(tc.results)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("admissionError = %v, want error: %v", err, tc.wantErr)
+			}
+			if err != nil && exitCodeFor(err) != ExitTerminal {
+				t.Fatalf("admission failure should exit %d, got %d", ExitTerminal, exitCodeFor(err))
+			}
+
+			var buf bytes.Buffer
+			writeAdmissionText(&buf, tc.results)
+			out := buf.String()
+			for _, want := range tc.wantLines {
+				if !strings.Contains(out, want) {
+					t.Fatalf("report missing %q:\n%s", want, out)
+				}
+			}
+		})
 	}
 }

--- a/docs/operating/configuration.md
+++ b/docs/operating/configuration.md
@@ -258,9 +258,20 @@ read-only root must live elsewhere, also include that directory in
 signed git commit. By default the root itself is the repository; set
 `git.repo_path` when several roots live under one larger repo. Thane
 uses the repository-local `.allowed_signers` file for SSH signature
-verification. For signer-backed roots, Thane creates that file from the
-configured signing key when it is missing; after that, the file itself is
-the trust configuration surface.
+verification. Thane creates that file once, when the root is first
+established, from the agent key plus the root's declared `seed_signers`;
+after that the file is the root's own trust surface and config never
+rewrites it.
+
+A root that signs commits must declare `seed_signers` — the keys
+entitled to establish it. At boot, a git-backed root under
+`verify_signatures: warn` or `required` must prove its birth is
+attributable to one of them, and that every change to `.allowed_signers`
+was signed by one of them. A root founded by the agent must therefore
+declare `thane@provenance.local` with the public half of its
+`git.signing_key`; omitting that principal is how a root declares that
+the agent may not establish or amend it. Failures report through the
+root's own `verify_signatures` policy and name the `admission` check.
 
 `git.verify_signatures` controls read-side enforcement. `none` disables
 checks, `warn` logs and reports verification failures without blocking,

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -72,8 +72,18 @@ thane -o json validate | jq .             # structured report for scripting
 
 Text mode prints a one-line confirmation plus a short structural summary
 (default model, resource/model/root counts, MCP server count, which
-optional integrations are configured). JSON mode emits `{path, valid,
-error, summary}` and exits non-zero on failure.
+optional integrations are configured), then the core integrity report and
+per-root admission. JSON mode emits `{path, valid, error, summary,
+integrity, root_admission}` and exits non-zero on failure.
+
+Admission is reported for every git-backed root that declares seed
+signers and verifies signatures, so a root whose history no declared key
+can account for is visible before a deploy rather than after. A failing
+root under `verify_signatures: required` exits non-zero, matching what
+`serve` refuses over; a failing root under `warn` is reported without
+affecting the exit code, matching what `serve` merely logs. See
+[Document Roots](../understanding/document-roots.md) for what admission
+checks and how to repair a refusal.
 
 ### `thane ask`
 
@@ -164,6 +174,12 @@ The refusal names each failing check and the command that fixes it, and
 `thane validate` prints the same report without starting anything. The
 gate applies to `serve` rather than every subcommand because `serve` is
 what runs unattended.
+
+`serve` also refuses when a document root's history is not admitted by
+the seed signers declared for it — a separate question from core
+integrity, covered under [Document
+Roots](../understanding/document-roots.md). `validate` reports that too,
+from the same code the gate uses, so the two cannot answer differently.
 
 Signers resolve from core's own `.allowed_signers`. That is sufficient
 while core has no remote — an attacker who can rewrite the signer list

--- a/docs/understanding/document-roots.md
+++ b/docs/understanding/document-roots.md
@@ -196,9 +196,9 @@ At boot, every git-backed root that declares seed signers and sets
 3. **A trust file only seeds have touched.** Every commit that created or
    changed `.allowed_signers` is signed by a declared seed signer.
 
-All three are checked against a rendered seed-only signers file, never
-the root's in-tree one. Otherwise a commit that added a key could be
-validated by the very entry it introduced.
+Only seed signers satisfy these three rules. The root's own
+`.allowed_signers` gets no say in them — if it did, a commit that added a
+key could be validated by the very entry it introduced.
 
 Keys the trust file delegates to may sign ordinary content. Only a seed
 signer may widen the trust file itself, so a delegated key cannot

--- a/docs/understanding/document-roots.md
+++ b/docs/understanding/document-roots.md
@@ -272,6 +272,22 @@ is the alternative, and for a corpus behind a bidirectional remote it is
 almost never the right one — declaring who actually founded the root is
 the honest record.
 
+You do not have to discover this by watching a deploy fail. `thane
+validate` reports admission for every root, and exits non-zero when a
+`required` root would be refused, so `thane validate && thane serve`
+remains a real guard:
+
+```
+✓ Root admission: core, kb, projects
+```
+
+Roots under `warn` are listed with a `!` rather than a `✗`, because serve
+logs those and starts anyway; validate does not invent strictness the
+gate does not have. Validate never creates anything, so a signing root
+whose directory does not exist yet is simply absent from the report —
+serve would create and birth-commit it, and there is no history to judge
+until it does.
+
 ### Read-side enforcement
 
 Signature-required roots are the place for high-integrity authored

--- a/docs/understanding/document-roots.md
+++ b/docs/understanding/document-roots.md
@@ -143,6 +143,8 @@ The current policy fields are:
 - `git.verify_signatures`: sets the consumer policy: `none`, `warn`,
   or `required`.
 
+### Signed roots
+
 Signature verification always uses the repository-local
 `.allowed_signers` file. Thane creates it once, when a signed root is
 first established, from the agent key plus that root's declared
@@ -164,8 +166,8 @@ roots:
 
 After that the file is the root's own trust surface and config never
 rewrites it. Adding signers is done by editing and committing
-`.allowed_signers` through trusted history — a change signed by a key
-the root already trusts.
+`.allowed_signers` — a change that must be signed by one of the root's
+seed signers.
 
 `seed_signers` is declared per root rather than once for the instance,
 because roots have different trust domains. The keys entitled to sign a
@@ -173,6 +175,104 @@ corpus synced from a remote should not automatically be entitled to sign
 the config that decides what the whole system trusts. A root that signs
 its commits must declare seed signers, since signed history nobody
 decided to admit is a signature without a claim behind it.
+
+### What admission checks
+
+Asking only "is this commit signed by a key in `.allowed_signers`?" lets
+a repository vouch for itself, because whoever wrote that file also chose
+what it says. Admission is the question that comes first, and it is the
+one question a root cannot answer in its own favor — seed signers live in
+config, outside the repository they govern.
+
+At boot, every git-backed root that declares seed signers and sets
+`verify_signatures` to `warn` or `required` must satisfy three rules:
+
+1. **One birth.** The root has exactly one parentless commit. A history
+   grafted from two independent roots is refused; admitting it because
+   one of those births checks out would let the other in through the side
+   door.
+2. **An attributable birth.** That commit is signed by a declared seed
+   signer.
+3. **A trust file only seeds have touched.** Every commit that created or
+   changed `.allowed_signers` is signed by a declared seed signer.
+
+All three are checked against a rendered seed-only signers file, never
+the root's in-tree one. Otherwise a commit that added a key could be
+validated by the very entry it introduced.
+
+Keys the trust file delegates to may sign ordinary content. Only a seed
+signer may widen the trust file itself, so a delegated key cannot
+delegate further. That is deliberately stricter than the general case: it
+forbids one collaborator admitting the next. The reason is soundness
+rather than convenience. "Signed by a key trusted at the time" only means
+something relative to a commit's own ancestry, and roots that sync
+bidirectionally can merge — so a permissive walk that ordered commits by
+date would judge a key added on a side branch as trusted earlier than it
+really was. The strict rule is order-independent, which makes it correct
+on every history shape rather than only the linear ones. Transitive
+delegation can arrive later as ancestry-aware composition, with this rule
+as its degenerate case.
+
+The pleasant side effect is that admission is cheap. With no chain to
+follow, the cost is one signature check for the birth plus one per
+trust-file change — on a corpus of several thousand commits that is
+typically a handful of checks rather than thousands.
+
+### Declaring the agent
+
+A root Thane creates is born signed by the agent's own key, so an
+agent-founded root is admitted only if it declares the agent:
+
+```yaml
+    seed_signers:
+      - principal: thane@provenance.local
+        key: "ssh-ed25519 AAAA..."   # public half of git.signing_key
+        label: "Self"
+```
+
+Omitting it is how a root says its own agent may not establish or amend
+it. That is the intended shape for `core`: an operator founds it, the
+agent writes content into it, and the agent cannot rewrite the trust
+surface of the root holding the config that decides what the instance
+trusts.
+
+Be precise about what that buys. Where the agent has shell access it can
+still *write* config; what it cannot do is produce a valid signature for
+the change, so the boot gate refuses and names the failing check. This is
+detection, not prevention — and detection is the property worth having,
+because the realistic failure is not a deliberate adversary but an agent
+steered by a poisoned document into "helpfully" relaxing a check. That
+drift is silent by nature. A refusal at boot makes it loud.
+
+Because a birth is the one thing no later commit can repair, Thane
+refuses to *create* a root whose seed signers omit the agent — while the
+repository is still empty and the remedy is a config line rather than a
+history rewrite.
+
+### When admission fails
+
+A failed root reports through the same `verify_signatures` policy as
+every other check: `required` refuses to start, `warn` logs and
+continues. The message names the check and, in the common case, who
+actually signed:
+
+```
+doc_roots.kb admission boot verification: the root commit 7c939f595ac9
+of /srv/thane/knowledge is not signed by a declared seed signer, so this
+root's birth is unattributed: it was signed by thane@provenance.local,
+the agent's own key — declare that principal in this root's seed_signers
+if the agent is entitled to establish it, or re-establish the root with a
+commit signed by a declared seed
+```
+
+The usual cause is a root founded before its seed set was declared, or
+one founded by the agent at an instance that never declared the agent.
+Both are config fixes. Rewriting history to install a different founder
+is the alternative, and for a corpus behind a bidirectional remote it is
+almost never the right one — declaring who actually founded the root is
+the honest record.
+
+### Read-side enforcement
 
 Signature-required roots are the place for high-integrity authored
 knowledge, such as owner-tagged knowledge articles. When verification

--- a/docs/understanding/trust-architecture.md
+++ b/docs/understanding/trust-architecture.md
@@ -37,6 +37,40 @@ This is a foundation, not the full peer-trust system. Peer CA exchange,
 delegation certificates, inherited-trust policy enforcement, and transport
 mTLS still need dedicated runtime paths.
 
+### Document Root Admission
+
+**Status: Implemented**
+
+A signed document root is not trusted merely because its commits carry
+signatures. Before any of its history counts, the root must prove its
+birth: it has exactly one parentless commit, that commit is signed by a
+key declared in config as one of the root's `seed_signers`, and every
+commit that has ever changed the in-tree `.allowed_signers` was signed by
+such a key too.
+
+The structural point is where the answer comes from. Verifying against a
+root's own `.allowed_signers` lets the repository vouch for itself, since
+whoever wrote that file also chose what it says. Seed signers live in
+config, outside the repository they govern, so admission is the one
+question a root cannot answer in its own favor. Checks run against a
+rendered seed-only signers file for the same reason — a commit that added
+a key must not be validated by the entry it introduced.
+
+This makes hardening a config expression rather than a code path. A root
+that omits the agent principal from its seed signers is one the agent may
+not establish or amend; that is the intended shape for `core`, which
+holds the config deciding what the instance trusts. Where the agent has
+shell access it can still write that config, but it cannot sign the
+change, so the boot gate refuses and names `admission`. Detection, not
+prevention — which is the right property, because the realistic failure
+is an agent steered by a poisoned document rather than a deliberate
+adversary, and that drift is otherwise silent.
+
+Admission runs for every git-backed root under `verify_signatures: warn`
+or `required`, including roots Thane only reads and never writes to —
+those carry entirely foreign history, so they are where it matters most.
+See [Document Roots](document-roots.md) for the operator-facing detail.
+
 ### Trust Zones
 
 **Status: Implemented**

--- a/docs/understanding/trust-architecture.md
+++ b/docs/understanding/trust-architecture.md
@@ -52,9 +52,9 @@ The structural point is where the answer comes from. Verifying against a
 root's own `.allowed_signers` lets the repository vouch for itself, since
 whoever wrote that file also chose what it says. Seed signers live in
 config, outside the repository they govern, so admission is the one
-question a root cannot answer in its own favor. Checks run against a
-rendered seed-only signers file for the same reason — a commit that added
-a key must not be validated by the entry it introduced.
+question a root cannot answer in its own favor. Nothing but the seed set
+counts here: the in-tree file is excluded from admission entirely, or a
+commit that added a key could be validated by the entry it introduced.
 
 This makes hardening a config expression rather than a code path. A root
 that omits the agent principal from its seed signers is one the agent may

--- a/examples/config.example.yaml
+++ b/examples/config.example.yaml
@@ -233,12 +233,14 @@ roots:
       # SigningKey is the SSH private key used to sign managed commits.
       # Supports ~ expansion at startup.
       signing_key: ""
-      # AllowedSigners lists operator SSH public keys trusted to sign
-      # commits in this root, in addition to the shared
-      # signing.allowed_signers set and the agent's own (always-trusted,
-      # unremovable) key. This only extends the trust set for one root; it
-      # never replaces or removes from it. Use it to let an operator
-      # co-author a signed root.
+      # AllowedSigners is the older spelling of this root's seed signers
+      # and is merged with roots.<name>.seed_signers, which is where new
+      # configs should declare them.
+      # 
+      # Both feed the same set, so keys listed here also govern admission:
+      # they can establish the root and amend its .allowed_signers. That
+      # is more authority than the name suggests, which is why the
+      # seed_signers spelling exists.
       allowed_signers: []
       # Remote optionally makes this root a full git citizen that fetches,
       # verifies, and (in bidirectional mode) pushes against a shared remote.
@@ -274,6 +276,24 @@ roots:
     # Declared per root rather than shared, so the keys that may sign a
     # corpus synced from a remote are not automatically the keys that
     # may sign the config deciding what the whole system trusts.
+    # 
+    # They are also what the root is admitted against at startup. A
+    # signed root must have been born in a commit one of these keys
+    # signed, and every later change to its .allowed_signers must carry
+    # a seed signer's signature too. Keys the trust file delegates to
+    # may sign ordinary content but cannot widen the trust file itself,
+    # so trust only ever grows by a decision recorded here.
+    # 
+    # Admission deliberately does not consult the root's own trust file.
+    # A repository that vouched for its own trust surface would decide
+    # its own admission, since whoever wrote that file also chose what
+    # it says.
+    # 
+    # The agent's own key is not implicitly entitled. A root Thane
+    # creates is born signed by the agent, so such a root must list
+    # thane@provenance.local here — and a root that omits it, such as a
+    # core established by an operator, is one the agent cannot
+    # establish or re-establish on its own.
     seed_signers: []
   kb:
     # Path is the directory the root resolves to. Supports ~
@@ -308,12 +328,14 @@ roots:
       # SigningKey is the SSH private key used to sign managed commits.
       # Supports ~ expansion at startup.
       signing_key: ~/.ssh/id_ed25519
-      # AllowedSigners lists operator SSH public keys trusted to sign
-      # commits in this root, in addition to the shared
-      # signing.allowed_signers set and the agent's own (always-trusted,
-      # unremovable) key. This only extends the trust set for one root; it
-      # never replaces or removes from it. Use it to let an operator
-      # co-author a signed root.
+      # AllowedSigners is the older spelling of this root's seed signers
+      # and is merged with roots.<name>.seed_signers, which is where new
+      # configs should declare them.
+      # 
+      # Both feed the same set, so keys listed here also govern admission:
+      # they can establish the root and amend its .allowed_signers. That
+      # is more authority than the name suggests, which is why the
+      # seed_signers spelling exists.
       allowed_signers:
         - # Principal is the OpenSSH signer identity, conventionally an email
           # such as "alice@example.com". Required. It must not contain
@@ -403,6 +425,24 @@ roots:
     # Declared per root rather than shared, so the keys that may sign a
     # corpus synced from a remote are not automatically the keys that
     # may sign the config deciding what the whole system trusts.
+    # 
+    # They are also what the root is admitted against at startup. A
+    # signed root must have been born in a commit one of these keys
+    # signed, and every later change to its .allowed_signers must carry
+    # a seed signer's signature too. Keys the trust file delegates to
+    # may sign ordinary content but cannot widen the trust file itself,
+    # so trust only ever grows by a decision recorded here.
+    # 
+    # Admission deliberately does not consult the root's own trust file.
+    # A repository that vouched for its own trust surface would decide
+    # its own admission, since whoever wrote that file also chose what
+    # it says.
+    # 
+    # The agent's own key is not implicitly entitled. A root Thane
+    # creates is born signed by the agent, so such a root must list
+    # thane@provenance.local here — and a root that omits it, such as a
+    # core established by an operator, is one the agent cannot
+    # establish or re-establish on its own.
     seed_signers:
       - # Principal is the OpenSSH signer identity, conventionally an email
         # such as "alice@example.com". Required. It must not contain
@@ -456,12 +496,14 @@ roots:
       # SigningKey is the SSH private key used to sign managed commits.
       # Supports ~ expansion at startup.
       signing_key: ""
-      # AllowedSigners lists operator SSH public keys trusted to sign
-      # commits in this root, in addition to the shared
-      # signing.allowed_signers set and the agent's own (always-trusted,
-      # unremovable) key. This only extends the trust set for one root; it
-      # never replaces or removes from it. Use it to let an operator
-      # co-author a signed root.
+      # AllowedSigners is the older spelling of this root's seed signers
+      # and is merged with roots.<name>.seed_signers, which is where new
+      # configs should declare them.
+      # 
+      # Both feed the same set, so keys listed here also govern admission:
+      # they can establish the root and amend its .allowed_signers. That
+      # is more authority than the name suggests, which is why the
+      # seed_signers spelling exists.
       allowed_signers: []
       # Remote optionally makes this root a full git citizen that fetches,
       # verifies, and (in bidirectional mode) pushes against a shared remote.
@@ -497,6 +539,24 @@ roots:
     # Declared per root rather than shared, so the keys that may sign a
     # corpus synced from a remote are not automatically the keys that
     # may sign the config deciding what the whole system trusts.
+    # 
+    # They are also what the root is admitted against at startup. A
+    # signed root must have been born in a commit one of these keys
+    # signed, and every later change to its .allowed_signers must carry
+    # a seed signer's signature too. Keys the trust file delegates to
+    # may sign ordinary content but cannot widen the trust file itself,
+    # so trust only ever grows by a decision recorded here.
+    # 
+    # Admission deliberately does not consult the root's own trust file.
+    # A repository that vouched for its own trust surface would decide
+    # its own admission, since whoever wrote that file also chose what
+    # it says.
+    # 
+    # The agent's own key is not implicitly entitled. A root Thane
+    # creates is born signed by the agent, so such a root must list
+    # thane@provenance.local here — and a root that omits it, such as a
+    # core established by an operator, is one the agent cannot
+    # establish or re-establish on its own.
     seed_signers: []
 #
 # (optional) Paths is the legacy directory-mapping block. Replaced by roots:.

--- a/internal/app/document_root_admission.go
+++ b/internal/app/document_root_admission.go
@@ -1,0 +1,74 @@
+package app
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"path/filepath"
+	"strings"
+
+	"github.com/nugget/thane-ai-agent/internal/platform/checkout"
+	"github.com/nugget/thane-ai-agent/internal/platform/config"
+	"github.com/nugget/thane-ai-agent/internal/platform/paths"
+	"github.com/nugget/thane-ai-agent/internal/platform/provenance"
+	"github.com/nugget/thane-ai-agent/internal/state/documents"
+)
+
+// resolveRootPaths resolves a document root's worktree and its backing
+// repository to absolute paths, and confirms the repository actually contains
+// the worktree.
+//
+// It lives beside admission because admission made it the third caller. The
+// writer, the verifier, and admission must all name the same repository, and
+// three copies of this were three chances for one of them to judge a different
+// one than the others.
+func resolveRootPaths(root, rootPath string, gitCfg config.DocumentRootGitConfig, resolver *paths.Resolver) (repo, worktree string, err error) {
+	repoPath := strings.TrimSpace(gitCfg.RepoPath)
+	if repoPath == "" {
+		repoPath = rootPath
+	} else {
+		repoPath = resolvePath(repoPath, resolver)
+	}
+	absRepoPath, err := filepath.Abs(repoPath)
+	if err != nil {
+		return "", "", fmt.Errorf("resolve doc_roots.%s.git.repo_path: %w", root, err)
+	}
+	absRootPath, err := filepath.Abs(rootPath)
+	if err != nil {
+		return "", "", fmt.Errorf("resolve document root %s path: %w", root, err)
+	}
+	if _, err := checkout.ResolveRoot(absRepoPath, absRootPath); err != nil {
+		return "", "", fmt.Errorf("doc_roots.%s.git.repo_path: %w", root, err)
+	}
+	return absRepoPath, absRootPath, nil
+}
+
+// verifyRootAdmission checks that a git-backed root's history is admitted by
+// the seed signers config declares for it, then maps the outcome onto the
+// root's own verification policy — the same mapping the other boot checks use,
+// so a root has one answer to "how strict is this".
+//
+// A root declaring no seed signers is neither admitted nor refused: there is
+// nothing to check against. Config already refuses the combination where that
+// silence would matter, a root that signs commits while naming no one entitled
+// to establish it.
+func (a *App) verifyRootAdmission(root, rootPath string, rootCfg config.DocumentRootConfig, mode documents.VerificationMode, resolver *paths.Resolver, logger *slog.Logger) error {
+	if !rootCfg.Git.Enabled {
+		return nil
+	}
+	switch mode {
+	case documents.VerificationRequired, documents.VerificationWarn:
+	default:
+		return nil
+	}
+	seeds := buildTrustedSigners(rootCfg.SeedSigners, rootCfg.Git.AllowedSigners)
+	if len(seeds) == 0 {
+		return nil
+	}
+	repoPath, _, err := resolveRootPaths(root, rootPath, rootCfg.Git, resolver)
+	if err != nil {
+		return err
+	}
+	_, admitErr := provenance.VerifyAdmission(context.Background(), repoPath, seeds)
+	return applyBootVerification(mode, root, "admission", admitErr, logger)
+}

--- a/internal/app/document_root_admission.go
+++ b/internal/app/document_root_admission.go
@@ -43,6 +43,122 @@ func resolveRootPaths(root, rootPath string, gitCfg config.DocumentRootGitConfig
 	return absRepoPath, absRootPath, nil
 }
 
+// documentRootPaths returns the path prefixes for this instance's document
+// roots, with the reserved core root forced to the location derived from
+// workspace.path.
+//
+// core is what makes this worth centralizing. It carries policy under
+// roots.core but never a path, so it is simply absent from cfg.Paths as
+// loaded and appears only once derived. Any caller that enumerates roots
+// without this step silently omits it — which for a per-root check means
+// reporting on every root except the one holding the config that decides what
+// the instance trusts. Boot derives core before building its resolver;
+// anything that wants boot's answer has to derive it the same way, which is
+// why this is a function rather than a step each caller remembers.
+//
+// The returned map is a copy. Creating the core directory is left to the
+// caller, so read-only callers stay read-only.
+func documentRootPaths(cfg *config.Config, logger *slog.Logger) map[string]string {
+	out := make(map[string]string, len(cfg.Paths)+1)
+	for name, path := range cfg.Paths {
+		out[name] = path
+	}
+	derivedCore := ""
+	if cfg.Workspace.Path != "" {
+		derivedCore = coreRootPath(cfg.Workspace.Path)
+	}
+	if derivedCore == "" {
+		return out
+	}
+	for name, path := range out {
+		if strings.TrimSuffix(name, ":") != "core" {
+			continue
+		}
+		if strings.TrimSpace(path) != derivedCore && logger != nil {
+			logger.Info("ignoring configured core path; core root is derived from workspace.path",
+				"configured_key", name,
+				"configured_path", path,
+				"derived_path", derivedCore,
+			)
+		}
+		delete(out, name)
+	}
+	out["core"] = derivedCore
+	return out
+}
+
+// RootAdmission is one root's admission outcome.
+type RootAdmission struct {
+	// Root is the configured root name, without its trailing colon.
+	Root string
+	// RepoPath is the repository admission judged, empty when it never ran.
+	RepoPath string
+	// Mode is the root's verify_signatures policy, which decides whether a
+	// failure refuses the instance or only logs.
+	Mode documents.VerificationMode
+	// Applicable is false for roots admission does not govern: those without
+	// git, without signature verification, or declaring no seed signers.
+	Applicable bool
+	// Err is the admission failure, nil when the root is admitted.
+	Err error
+}
+
+// Admitted reports whether this root passed, treating roots admission does
+// not govern as passing.
+func (r RootAdmission) Admitted() bool { return r.Err == nil }
+
+// Fatal reports whether this outcome is one `thane serve` refuses to start
+// over — a failure under a root that requires verification.
+func (r RootAdmission) Fatal() bool {
+	return r.Err != nil && r.Mode == documents.VerificationRequired
+}
+
+// admissionSeeds returns the seed set a root must be admitted against and
+// whether admission governs it at all.
+//
+// This predicate has exactly one definition on purpose. It decides both what
+// boot refuses over and what `thane validate` reports, and those two answering
+// differently is the specific way this feature would rot: an operator would
+// see a clean report and then watch the instance refuse to start, or worse,
+// see a clean report because the reporting path quietly considered fewer roots
+// than the gate does.
+func admissionSeeds(rootCfg config.DocumentRootConfig, mode documents.VerificationMode) ([]provenance.TrustedSigner, bool) {
+	if !rootCfg.Git.Enabled {
+		return nil, false
+	}
+	switch mode {
+	case documents.VerificationRequired, documents.VerificationWarn:
+	default:
+		return nil, false
+	}
+	seeds := buildTrustedSigners(rootCfg.SeedSigners, rootCfg.Git.AllowedSigners)
+	if len(seeds) == 0 {
+		return nil, false
+	}
+	return seeds, true
+}
+
+// checkRootAdmission is the single evaluation of one root's admission. Boot
+// calls it and maps the result onto policy; `thane validate` calls it and
+// prints the result. Neither re-derives the question.
+func checkRootAdmission(ctx context.Context, root, rootPath string, rootCfg config.DocumentRootConfig, mode documents.VerificationMode, resolver *paths.Resolver) RootAdmission {
+	out := RootAdmission{Root: root, Mode: mode}
+	seeds, applicable := admissionSeeds(rootCfg, mode)
+	if !applicable {
+		return out
+	}
+	out.Applicable = true
+
+	repoPath, _, err := resolveRootPaths(root, rootPath, rootCfg.Git, resolver)
+	if err != nil {
+		out.Err = err
+		return out
+	}
+	out.RepoPath = repoPath
+	_, out.Err = provenance.VerifyAdmission(ctx, repoPath, seeds)
+	return out
+}
+
 // verifyRootAdmission checks that a git-backed root's history is admitted by
 // the seed signers config declares for it, then maps the outcome onto the
 // root's own verification policy — the same mapping the other boot checks use,
@@ -53,22 +169,43 @@ func resolveRootPaths(root, rootPath string, gitCfg config.DocumentRootGitConfig
 // silence would matter, a root that signs commits while naming no one entitled
 // to establish it.
 func (a *App) verifyRootAdmission(root, rootPath string, rootCfg config.DocumentRootConfig, mode documents.VerificationMode, resolver *paths.Resolver, logger *slog.Logger) error {
-	if !rootCfg.Git.Enabled {
+	result := checkRootAdmission(context.Background(), root, rootPath, rootCfg, mode, resolver)
+	return applyBootVerification(mode, root, "admission", result.Err, logger)
+}
+
+// CheckRootAdmission evaluates admission for every configured document root,
+// for `thane validate` to report before an operator deploys.
+//
+// It reaches boot's answer by walking boot's path: the same root enumeration
+// (buildDocumentRoots), the same policy derivation
+// (documentRootPolicyFromConfig), the same predicate (admissionSeeds), and the
+// same check (checkRootAdmission). The one deliberate difference is that
+// validate never creates anything, so a signing root whose directory does not
+// exist yet is absent from the enumeration rather than bootstrapped — serve
+// would create and birth-commit it, so reporting it as unadmitted would be a
+// false alarm about a root that does not exist to judge.
+func CheckRootAdmission(ctx context.Context, cfg *config.Config) []RootAdmission {
+	if cfg == nil || len(cfg.DocRoots) == 0 {
 		return nil
 	}
-	switch mode {
-	case documents.VerificationRequired, documents.VerificationWarn:
-	default:
-		return nil
+	resolver := paths.New(documentRootPaths(cfg, nil))
+	documentRoots := buildDocumentRoots(resolver)
+
+	out := make([]RootAdmission, 0, len(cfg.DocRoots))
+	for root, rootCfg := range cfg.DocRoots {
+		root = strings.TrimSuffix(strings.TrimSpace(root), ":")
+		if root == "" {
+			continue
+		}
+		mode := documentRootPolicyFromConfig(rootCfg).Git.VerifySignatures
+		if _, applicable := admissionSeeds(rootCfg, mode); !applicable {
+			continue
+		}
+		rootPath, ok := documentRoots[root]
+		if !ok {
+			continue
+		}
+		out = append(out, checkRootAdmission(ctx, root, rootPath, rootCfg, mode, resolver))
 	}
-	seeds := buildTrustedSigners(rootCfg.SeedSigners, rootCfg.Git.AllowedSigners)
-	if len(seeds) == 0 {
-		return nil
-	}
-	repoPath, _, err := resolveRootPaths(root, rootPath, rootCfg.Git, resolver)
-	if err != nil {
-		return err
-	}
-	_, admitErr := provenance.VerifyAdmission(context.Background(), repoPath, seeds)
-	return applyBootVerification(mode, root, "admission", admitErr, logger)
+	return out
 }

--- a/internal/app/document_root_admission_test.go
+++ b/internal/app/document_root_admission_test.go
@@ -1,0 +1,237 @@
+package app
+
+import (
+	"log/slog"
+	"testing"
+
+	"github.com/nugget/thane-ai-agent/internal/platform/config"
+	"github.com/nugget/thane-ai-agent/internal/platform/paths"
+	"github.com/nugget/thane-ai-agent/internal/platform/provenance"
+)
+
+// foundAgentRoot establishes a signed root the way Thane does — born and
+// signed by the agent's own key — and returns where it lives plus the keys
+// involved. Every case below starts from this same repository, so what varies
+// between them is only the config being judged, never the history.
+func foundAgentRoot(t *testing.T) (rootPath, signingKey string, agentSeed, strangerSeed []config.AllowedSigner) {
+	t.Helper()
+	rootPath = t.TempDir()
+	signingKey, agentPublicKey := writeTestSigningKey(t)
+	_, strangerPublicKey := writeTestSigningKey(t)
+
+	agentSeed = []config.AllowedSigner{{Principal: provenance.AgentPrincipal, Key: agentPublicKey}}
+	strangerSeed = []config.AllowedSigner{{Principal: "stranger@example.com", Key: strangerPublicKey}}
+
+	resolver := paths.New(map[string]string{"kb": rootPath})
+	founder := &App{
+		logger: slog.Default(),
+		cfg: &config.Config{
+			Paths: map[string]string{"kb": rootPath},
+			DocRoots: map[string]config.DocumentRootConfig{
+				"kb": {
+					SeedSigners: agentSeed,
+					Git: config.DocumentRootGitConfig{
+						Enabled:          true,
+						SignCommits:      true,
+						VerifySignatures: "required",
+						SigningKey:       signingKey,
+					},
+				},
+			},
+		},
+	}
+	if _, err := founder.buildDocumentStoreOptions(buildDocumentRoots(resolver), resolver); err != nil {
+		t.Fatalf("founding the fixture root: %v", err)
+	}
+	return rootPath, signingKey, agentSeed, strangerSeed
+}
+
+// TestRootAdmissionReportMatchesBoot is the anti-drift trap for this feature.
+//
+// `thane validate` exists to answer "will serve start?", and it earns that
+// only while its report and the boot gate reach the same verdict. They share
+// the predicate, the policy derivation, and the check itself — but sharing is
+// a property of today's code, not a guarantee about tomorrow's. So rather than
+// assert what each path returns, this drives both real paths over the same
+// repository and asserts they agree. Edit the eligibility rule in one place
+// and forget the other, and this fails.
+func TestRootAdmissionReportMatchesBoot(t *testing.T) {
+	rootPath, signingKey, agentSeed, strangerSeed := foundAgentRoot(t)
+
+	tests := []struct {
+		name string
+		root config.DocumentRootConfig
+		// wantRefused is what both paths must conclude: boot returns an
+		// error and the report marks the root unadmitted, or neither does.
+		wantRefused bool
+	}{
+		{
+			name: "founder declared",
+			root: config.DocumentRootConfig{
+				SeedSigners: agentSeed,
+				Git: config.DocumentRootGitConfig{
+					Enabled: true, SignCommits: true,
+					VerifySignatures: "required", SigningKey: signingKey,
+				},
+			},
+		},
+		{
+			name: "founder not declared",
+			root: config.DocumentRootConfig{
+				SeedSigners: strangerSeed,
+				Git: config.DocumentRootGitConfig{
+					Enabled: true, SignCommits: true,
+					VerifySignatures: "required", SigningKey: signingKey,
+				},
+			},
+			wantRefused: true,
+		},
+		{
+			name: "verify only, founder not declared",
+			root: config.DocumentRootConfig{
+				SeedSigners: strangerSeed,
+				Git: config.DocumentRootGitConfig{
+					Enabled: true, VerifySignatures: "required",
+				},
+			},
+			wantRefused: true,
+		},
+		{
+			name: "no seed signers declared",
+			root: config.DocumentRootConfig{
+				Git: config.DocumentRootGitConfig{
+					Enabled: true, VerifySignatures: "required",
+				},
+			},
+		},
+		{
+			name: "verification disabled",
+			root: config.DocumentRootConfig{
+				SeedSigners: strangerSeed,
+				Git: config.DocumentRootGitConfig{
+					Enabled: true, VerifySignatures: "none",
+				},
+			},
+		},
+		{
+			name: "git disabled",
+			root: config.DocumentRootConfig{
+				SeedSigners: strangerSeed,
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &config.Config{
+				Paths:    map[string]string{"kb": rootPath},
+				DocRoots: map[string]config.DocumentRootConfig{"kb": tc.root},
+			}
+			instance := &App{logger: slog.Default(), cfg: cfg}
+			resolver := paths.New(cfg.Paths)
+
+			_, bootErr := instance.buildDocumentStoreOptions(buildDocumentRoots(resolver), resolver)
+			bootRefused := bootErr != nil
+
+			reportRefused := false
+			for _, result := range CheckRootAdmission(t.Context(), cfg) {
+				if !result.Admitted() {
+					reportRefused = true
+				}
+			}
+
+			if bootRefused != reportRefused {
+				t.Fatalf("validate and boot disagree: boot refused=%v (%v), report refused=%v",
+					bootRefused, bootErr, reportRefused)
+			}
+			if bootRefused != tc.wantRefused {
+				t.Fatalf("refused = %v, want %v (boot error: %v)", bootRefused, tc.wantRefused, bootErr)
+			}
+		})
+	}
+}
+
+// TestCheckRootAdmissionSkipsUnestablishedRoots pins the one place validate
+// deliberately differs from boot: a signing root whose directory does not
+// exist yet is one serve would create and birth-commit, so reporting it as
+// unadmitted would be a false alarm about a root there is nothing to judge.
+func TestCheckRootAdmissionSkipsUnestablishedRoots(t *testing.T) {
+	signingKey, agentPublicKey := writeTestSigningKey(t)
+	missing := t.TempDir() + "/not-created-yet"
+
+	cfg := &config.Config{
+		Paths: map[string]string{"kb": missing},
+		DocRoots: map[string]config.DocumentRootConfig{
+			"kb": {
+				SeedSigners: []config.AllowedSigner{{
+					Principal: provenance.AgentPrincipal, Key: agentPublicKey,
+				}},
+				Git: config.DocumentRootGitConfig{
+					Enabled: true, SignCommits: true,
+					VerifySignatures: "required", SigningKey: signingKey,
+				},
+			},
+		},
+	}
+	if results := CheckRootAdmission(t.Context(), cfg); len(results) != 0 {
+		t.Fatalf("CheckRootAdmission = %+v, want no results for a root that does not exist yet", results)
+	}
+}
+
+// TestRootAdmissionCoversTheReservedCoreRoot guards the root that is easiest
+// to lose. core carries policy under roots.core but never a path, so it is
+// absent from cfg.Paths as loaded and appears only after being derived from
+// workspace.path. An enumeration that skips that derivation reports on every
+// root except the one holding the config — and reports success while doing it.
+func TestRootAdmissionCoversTheReservedCoreRoot(t *testing.T) {
+	workspace := t.TempDir()
+	signingKey, agentPublicKey := writeTestSigningKey(t)
+	_, strangerPublicKey := writeTestSigningKey(t)
+
+	coreRoot := func(seeds []config.AllowedSigner) *config.Config {
+		return &config.Config{
+			Workspace: config.WorkspaceConfig{Path: workspace},
+			DocRoots: map[string]config.DocumentRootConfig{
+				"core": {
+					SeedSigners: seeds,
+					Git: config.DocumentRootGitConfig{
+						Enabled:          true,
+						SignCommits:      true,
+						VerifySignatures: "required",
+						SigningKey:       signingKey,
+					},
+				},
+			},
+		}
+	}
+	bootstrap := func(cfg *config.Config) error {
+		instance := &App{logger: slog.Default(), cfg: cfg}
+		resolver := paths.New(documentRootPaths(cfg, nil))
+		_, err := instance.buildDocumentStoreOptions(buildDocumentRoots(resolver), resolver)
+		return err
+	}
+
+	agentSeed := []config.AllowedSigner{{Principal: provenance.AgentPrincipal, Key: agentPublicKey}}
+	founded := coreRoot(agentSeed)
+	if err := bootstrap(founded); err != nil {
+		t.Fatalf("founding core: %v", err)
+	}
+
+	results := CheckRootAdmission(t.Context(), coreRoot(agentSeed))
+	if len(results) != 1 || results[0].Root != "core" {
+		t.Fatalf("CheckRootAdmission = %+v, want one entry for core", results)
+	}
+	if !results[0].Admitted() {
+		t.Fatalf("core founded by its declared seed should be admitted: %v", results[0].Err)
+	}
+
+	// Now disagree with history, and confirm both paths say so.
+	stranger := coreRoot([]config.AllowedSigner{{Principal: "stranger@example.com", Key: strangerPublicKey}})
+	if err := bootstrap(stranger); err == nil {
+		t.Fatal("boot should refuse a core whose founder is not a declared seed")
+	}
+	results = CheckRootAdmission(t.Context(), stranger)
+	if len(results) != 1 || results[0].Admitted() {
+		t.Fatalf("validate should report core unadmitted, got %+v", results)
+	}
+}

--- a/internal/app/document_roots.go
+++ b/internal/app/document_roots.go
@@ -366,7 +366,15 @@ func (a *App) newDocumentRootProvenanceWriter(root, rootPath string, rootCfg con
 	mode := documents.VerificationMode(strings.TrimSpace(gitCfg.VerifySignatures))
 	switch mode {
 	case documents.VerificationRequired, documents.VerificationWarn:
-		if err := applyBootVerification(mode, root, signed.VerifyHead(context.Background()), logger); err != nil {
+		// Admission runs first because it is the prior question. VerifyHead
+		// asks whether the tip is signed by a key this root trusts; admission
+		// asks whether this root was entitled to arrive at that trust set at
+		// all. Reporting a passing HEAD for a root whose birth is
+		// unattributed would answer the smaller question and hide the larger.
+		if err := applyBootVerification(mode, root, "admission", signed.VerifyAdmission(context.Background()), logger); err != nil {
+			return nil, err
+		}
+		if err := applyBootVerification(mode, root, "allowed_signers", signed.VerifyHead(context.Background()), logger); err != nil {
 			return nil, err
 		}
 	}
@@ -413,20 +421,24 @@ func (a *App) newDocumentRootProvenanceVerifier(root, rootPath string, gitCfg co
 	return &documentRootProvenanceVerifier{verifier: verified.Verifier, prefix: verified.Prefix}, nil
 }
 
-// applyBootVerification maps a boot-time VerifyHead result onto the root's
+// applyBootVerification maps one boot-time check's result onto the root's
 // verification policy: a required root fails to construct, a warn root logs and
 // continues, and any other mode is a no-op. A nil verifyErr is always a no-op,
-// so callers can pass the VerifyHead result directly.
-func applyBootVerification(mode documents.VerificationMode, root string, verifyErr error, logger *slog.Logger) error {
+// so callers can pass a check's result directly.
+//
+// check names the requirement that failed ("admission", "allowed_signers"), so
+// an operator reading the refusal knows which question came back wrong — the
+// two ask different things and are repaired differently.
+func applyBootVerification(mode documents.VerificationMode, root, check string, verifyErr error, logger *slog.Logger) error {
 	if verifyErr == nil {
 		return nil
 	}
 	switch mode {
 	case documents.VerificationRequired:
-		return fmt.Errorf("doc_roots.%s allowed_signers boot verification: %w", root, verifyErr)
+		return fmt.Errorf("doc_roots.%s %s boot verification: %w", root, check, verifyErr)
 	case documents.VerificationWarn:
-		logger.Warn("document root allowed_signers boot verification failed",
-			"root", root, "error", verifyErr)
+		logger.Warn("document root boot verification failed",
+			"root", root, "check", check, "error", verifyErr)
 		return nil
 	default:
 		return nil

--- a/internal/app/document_roots.go
+++ b/internal/app/document_roots.go
@@ -176,6 +176,20 @@ func (a *App) buildDocumentStoreOptions(documentRoots map[string]string, resolve
 			writer = w
 		}
 
+		// Admission asks whether this root's history was ever entitled to
+		// exist. That is prior to anything either the writer or the verifier
+		// does with it, and it does not depend on whether this instance
+		// writes to the root — a corpus Thane only reads, pulled from a
+		// remote, carries entirely foreign history and is precisely where an
+		// unattributable birth matters most. So it runs here, once per root,
+		// rather than inside whichever constructor happens to be built.
+		//
+		// It follows the writer because a root Thane creates has no history
+		// to judge until BootstrapBirthCommit has made one.
+		if err := a.verifyRootAdmission(root, rootPath, rootCfg, policy.Git.VerifySignatures, resolver, logger); err != nil {
+			return documents.StoreOptions{}, err
+		}
+
 		var verifier *documentRootProvenanceVerifier
 		if policy.Git.Enabled && policy.Git.VerifySignatures != documents.VerificationNone {
 			v, err := a.newDocumentRootProvenanceVerifier(root, rootPath, rootCfg.Git, resolver)
@@ -325,22 +339,9 @@ func (a *App) newDocumentRootProvenanceWriter(root, rootPath string, rootCfg con
 	}
 	signingKey = resolvePath(signingKey, resolver)
 
-	repoPath := strings.TrimSpace(gitCfg.RepoPath)
-	if repoPath == "" {
-		repoPath = rootPath
-	} else {
-		repoPath = resolvePath(repoPath, resolver)
-	}
-	absRepoPath, err := filepath.Abs(repoPath)
+	absRepoPath, absRootPath, err := resolveRootPaths(root, rootPath, gitCfg, resolver)
 	if err != nil {
-		return nil, fmt.Errorf("resolve doc_roots.%s.git.repo_path: %w", root, err)
-	}
-	absRootPath, err := filepath.Abs(rootPath)
-	if err != nil {
-		return nil, fmt.Errorf("resolve document root %s path: %w", root, err)
-	}
-	if _, err := checkout.ResolveRoot(absRepoPath, absRootPath); err != nil {
-		return nil, fmt.Errorf("doc_roots.%s.git.repo_path: %w", root, err)
+		return nil, err
 	}
 	logger := a.logger
 	if logger == nil {
@@ -366,14 +367,6 @@ func (a *App) newDocumentRootProvenanceWriter(root, rootPath string, rootCfg con
 	mode := documents.VerificationMode(strings.TrimSpace(gitCfg.VerifySignatures))
 	switch mode {
 	case documents.VerificationRequired, documents.VerificationWarn:
-		// Admission runs first because it is the prior question. VerifyHead
-		// asks whether the tip is signed by a key this root trusts; admission
-		// asks whether this root was entitled to arrive at that trust set at
-		// all. Reporting a passing HEAD for a root whose birth is
-		// unattributed would answer the smaller question and hide the larger.
-		if err := applyBootVerification(mode, root, "admission", signed.VerifyAdmission(context.Background()), logger); err != nil {
-			return nil, err
-		}
 		if err := applyBootVerification(mode, root, "allowed_signers", signed.VerifyHead(context.Background()), logger); err != nil {
 			return nil, err
 		}
@@ -388,22 +381,9 @@ func (a *App) newDocumentRootProvenanceWriter(root, rootPath string, rootCfg con
 }
 
 func (a *App) newDocumentRootProvenanceVerifier(root, rootPath string, gitCfg config.DocumentRootGitConfig, resolver *paths.Resolver) (*documentRootProvenanceVerifier, error) {
-	repoPath := strings.TrimSpace(gitCfg.RepoPath)
-	if repoPath == "" {
-		repoPath = rootPath
-	} else {
-		repoPath = resolvePath(repoPath, resolver)
-	}
-	absRepoPath, err := filepath.Abs(repoPath)
+	absRepoPath, absRootPath, err := resolveRootPaths(root, rootPath, gitCfg, resolver)
 	if err != nil {
-		return nil, fmt.Errorf("resolve doc_roots.%s.git.repo_path: %w", root, err)
-	}
-	absRootPath, err := filepath.Abs(rootPath)
-	if err != nil {
-		return nil, fmt.Errorf("resolve document root %s path: %w", root, err)
-	}
-	if _, err := checkout.ResolveRoot(absRepoPath, absRootPath); err != nil {
-		return nil, fmt.Errorf("doc_roots.%s.git.repo_path: %w", root, err)
+		return nil, err
 	}
 	logger := a.logger
 	if logger == nil {

--- a/internal/app/document_roots_test.go
+++ b/internal/app/document_roots_test.go
@@ -321,6 +321,83 @@ func TestBuildDocumentStoreOptionsVerifierUsesRepoLocalAllowedSigners(t *testing
 	}
 }
 
+// TestBuildDocumentStoreOptionsAdmitsVerifyOnlyRoots covers the root shape
+// that has no writer at all: git-backed and verified, but never committed to
+// by this instance. Its history is entirely foreign, which is the case
+// admission exists for — so a birth its declared seeds cannot attribute has to
+// be refused even though nothing here will ever write to it.
+func TestBuildDocumentStoreOptionsAdmitsVerifyOnlyRoots(t *testing.T) {
+	targetPath := t.TempDir()
+	signingKey, agentPublicKey := writeTestSigningKey(t)
+	_, strangerPublicKey := writeTestSigningKey(t)
+
+	agentSeed := []config.AllowedSigner{{
+		Principal: provenance.AgentPrincipal,
+		Key:       agentPublicKey,
+	}}
+
+	resolver := paths.New(map[string]string{"kb": targetPath})
+	app := &App{
+		logger: slog.Default(),
+		cfg: &config.Config{
+			DocRoots: map[string]config.DocumentRootConfig{
+				"kb": {
+					SeedSigners: agentSeed,
+					Git: config.DocumentRootGitConfig{
+						Enabled:          true,
+						SignCommits:      true,
+						VerifySignatures: "required",
+						SigningKey:       signingKey,
+					},
+				},
+			},
+		},
+	}
+	if _, err := app.buildDocumentStoreOptions(buildDocumentRoots(resolver), resolver); err != nil {
+		t.Fatalf("founding the root: %v", err)
+	}
+
+	// The same repository, now read-only to this instance and seeded with a
+	// key that had nothing to do with founding it.
+	app.cfg.DocRoots["kb"] = config.DocumentRootConfig{
+		SeedSigners: []config.AllowedSigner{{
+			Principal: "stranger@example.com",
+			Key:       strangerPublicKey,
+		}},
+		Git: config.DocumentRootGitConfig{
+			Enabled:          true,
+			SignCommits:      false,
+			VerifySignatures: "required",
+		},
+	}
+	_, err := app.buildDocumentStoreOptions(buildDocumentRoots(resolver), resolver)
+	if err == nil {
+		t.Fatal("verify-only root with an unattributable birth was admitted")
+	}
+	if !strings.Contains(err.Error(), "admission") {
+		t.Fatalf("error = %v, want it to name the admission check", err)
+	}
+
+	// Naming the founder admits the same unchanged history, so the refusal
+	// above is the seed set disagreeing with the repository rather than
+	// verify-only roots failing unconditionally.
+	app.cfg.DocRoots["kb"] = config.DocumentRootConfig{
+		SeedSigners: agentSeed,
+		Git: config.DocumentRootGitConfig{
+			Enabled:          true,
+			SignCommits:      false,
+			VerifySignatures: "required",
+		},
+	}
+	opts, err := app.buildDocumentStoreOptions(buildDocumentRoots(resolver), resolver)
+	if err != nil {
+		t.Fatalf("verify-only root founded by a declared seed: %v", err)
+	}
+	if opts.RootVerifiers["kb"] == nil {
+		t.Fatal("admitted verify-only root should still get a verifier")
+	}
+}
+
 // TestBuildDocumentStoreOptionsNonBootstrapMissingDirStillErrors
 // preserves the original behavior for non-bootstrap configs: a
 // missing directory without git+sign_commits stays an error, since

--- a/internal/app/document_roots_test.go
+++ b/internal/app/document_roots_test.go
@@ -365,13 +365,16 @@ func TestApplyBootVerification(t *testing.T) {
 		{"required + success is a no-op", documents.VerificationRequired, nil, false},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			err := applyBootVerification(tc.mode, "kb", tc.verErr, logger)
+			err := applyBootVerification(tc.mode, "kb", "admission", tc.verErr, logger)
 			if tc.wantErr {
 				if err == nil {
 					t.Fatal("applyBootVerification = nil, want error")
 				}
 				if !strings.Contains(err.Error(), "kb") {
 					t.Fatalf("error %q should name the root", err)
+				}
+				if !strings.Contains(err.Error(), "admission") {
+					t.Fatalf("error %q should name the failing check", err)
 				}
 				return
 			}

--- a/internal/app/new_agent.go
+++ b/internal/app/new_agent.go
@@ -31,25 +31,8 @@ func (a *App) initAgentLoop(s *newState) error {
 	// before constructing the agent loop so they can be passed via
 	// LoopOptions instead of post-construction setters.
 	if cfg.Workspace.Path != "" {
-		if cfg.Paths == nil {
-			cfg.Paths = make(map[string]string)
-		}
-		derivedCore := coreRootPath(cfg.Workspace.Path)
-		for k, v := range cfg.Paths {
-			if strings.TrimSuffix(k, ":") != "core" {
-				continue
-			}
-			if strings.TrimSpace(v) != derivedCore {
-				logger.Info("ignoring configured core path; core root is derived from workspace.path",
-					"configured_key", k,
-					"configured_path", v,
-					"derived_path", derivedCore,
-				)
-			}
-			delete(cfg.Paths, k)
-		}
-		cfg.Paths["core"] = derivedCore
-		if err := os.MkdirAll(derivedCore, 0o755); err != nil {
+		cfg.Paths = documentRootPaths(cfg, logger)
+		if err := os.MkdirAll(cfg.Paths["core"], 0o755); err != nil {
 			return fmt.Errorf("create core document root: %w", err)
 		}
 	}

--- a/internal/platform/checkout/signed.go
+++ b/internal/platform/checkout/signed.go
@@ -48,6 +48,11 @@ type Signed struct {
 	// Store is the provenance engine for this checkout — the write,
 	// sync, and history surface callers use once the checkout is open.
 	Store *provenance.Store
+
+	// seedSigners is the declared set retained for admission. It is kept
+	// rather than re-derived because admission must ask config, not the
+	// repository, whose signatures may establish this root.
+	seedSigners []provenance.TrustedSigner
 }
 
 // OpenSigned opens or initializes a signed checkout, creates a birth commit
@@ -111,7 +116,7 @@ func OpenSigned(ctx context.Context, spec SignedSpec) (*Signed, error) {
 		"worktree", root.WorktreePath,
 		"prefix", root.Prefix,
 	)
-	return &Signed{Name: name, Root: root, Store: store}, nil
+	return &Signed{Name: name, Root: root, Store: store, seedSigners: spec.SeedSigners}, nil
 }
 
 func withDefaultTimeout(ctx context.Context) (context.Context, context.CancelFunc) {
@@ -122,6 +127,28 @@ func withDefaultTimeout(ctx context.Context) (context.Context, context.CancelFun
 		return ctx, func() {}
 	}
 	return context.WithTimeout(ctx, DefaultBootstrapTimeout)
+}
+
+// VerifyAdmission confirms the checkout's history is admitted by its declared
+// seed signers: founded by one, and with its trust file only ever changed by
+// one. It answers a different question from [Signed.VerifyHead], which asks
+// whether the current tip is signed by someone the root already trusts —
+// a check the root's own history gets to define the terms of.
+//
+// A checkout with no declared seed signers is not admitted and not refused:
+// admission has nothing to check against, so the caller's signature policy is
+// left to decide what an unseeded signed root means.
+func (c *Signed) VerifyAdmission(ctx context.Context) error {
+	if c == nil || c.Store == nil {
+		return fmt.Errorf("signed checkout is not configured")
+	}
+	if len(c.seedSigners) == 0 {
+		return nil
+	}
+	ctx, cancel := withDefaultTimeout(ctx)
+	defer cancel()
+	_, err := provenance.VerifyAdmission(ctx, c.Store.Path(), c.seedSigners)
+	return err
 }
 
 // VerifyHead confirms that the checkout HEAD verifies against its trust set.

--- a/internal/platform/checkout/signed.go
+++ b/internal/platform/checkout/signed.go
@@ -48,11 +48,6 @@ type Signed struct {
 	// Store is the provenance engine for this checkout — the write,
 	// sync, and history surface callers use once the checkout is open.
 	Store *provenance.Store
-
-	// seedSigners is the declared set retained for admission. It is kept
-	// rather than re-derived because admission must ask config, not the
-	// repository, whose signatures may establish this root.
-	seedSigners []provenance.TrustedSigner
 }
 
 // OpenSigned opens or initializes a signed checkout, creates a birth commit
@@ -116,7 +111,7 @@ func OpenSigned(ctx context.Context, spec SignedSpec) (*Signed, error) {
 		"worktree", root.WorktreePath,
 		"prefix", root.Prefix,
 	)
-	return &Signed{Name: name, Root: root, Store: store, seedSigners: spec.SeedSigners}, nil
+	return &Signed{Name: name, Root: root, Store: store}, nil
 }
 
 func withDefaultTimeout(ctx context.Context) (context.Context, context.CancelFunc) {
@@ -127,28 +122,6 @@ func withDefaultTimeout(ctx context.Context) (context.Context, context.CancelFun
 		return ctx, func() {}
 	}
 	return context.WithTimeout(ctx, DefaultBootstrapTimeout)
-}
-
-// VerifyAdmission confirms the checkout's history is admitted by its declared
-// seed signers: founded by one, and with its trust file only ever changed by
-// one. It answers a different question from [Signed.VerifyHead], which asks
-// whether the current tip is signed by someone the root already trusts —
-// a check the root's own history gets to define the terms of.
-//
-// A checkout with no declared seed signers is not admitted and not refused:
-// admission has nothing to check against, so the caller's signature policy is
-// left to decide what an unseeded signed root means.
-func (c *Signed) VerifyAdmission(ctx context.Context) error {
-	if c == nil || c.Store == nil {
-		return fmt.Errorf("signed checkout is not configured")
-	}
-	if len(c.seedSigners) == 0 {
-		return nil
-	}
-	ctx, cancel := withDefaultTimeout(ctx)
-	defer cancel()
-	_, err := provenance.VerifyAdmission(ctx, c.Store.Path(), c.seedSigners)
-	return err
 }
 
 // VerifyHead confirms that the checkout HEAD verifies against its trust set.

--- a/internal/platform/checkout/signed_test.go
+++ b/internal/platform/checkout/signed_test.go
@@ -42,18 +42,23 @@ func writeSigningKey(t *testing.T, name string) (privPath, pub string) {
 
 func TestOpenSignedBootstrapsAndReconciles(t *testing.T) {
 	worktree := t.TempDir()
-	signingKey, _ := writeSigningKey(t, "checkout-test")
+	signingKey, agentPublic := writeSigningKey(t, "checkout-test")
 	_, operatorPublic := writeSigningKey(t, "operator-test")
 
 	signed, err := OpenSigned(t.Context(), SignedSpec{
 		Name:           "kb",
 		WorktreePath:   worktree,
 		SigningKeyPath: signingKey,
-		SeedSigners: []provenance.TrustedSigner{{
-			Principal: "operator@example.com",
-			PublicKey: operatorPublic,
-			Comment:   "operator laptop",
-		}},
+		SeedSigners: []provenance.TrustedSigner{
+			// The agent makes the birth commit here, so it is entitled to
+			// establish this root alongside the operator.
+			{Principal: provenance.AgentPrincipal, PublicKey: agentPublic},
+			{
+				Principal: "operator@example.com",
+				PublicKey: operatorPublic,
+				Comment:   "operator laptop",
+			},
+		},
 		Logger: slog.Default(),
 	})
 	if err != nil {

--- a/internal/platform/config/config.go
+++ b/internal/platform/config/config.go
@@ -997,6 +997,24 @@ type RootEntry struct {
 	// Declared per root rather than shared, so the keys that may sign a
 	// corpus synced from a remote are not automatically the keys that
 	// may sign the config deciding what the whole system trusts.
+	//
+	// They are also what the root is admitted against at startup. A
+	// signed root must have been born in a commit one of these keys
+	// signed, and every later change to its .allowed_signers must carry
+	// a seed signer's signature too. Keys the trust file delegates to
+	// may sign ordinary content but cannot widen the trust file itself,
+	// so trust only ever grows by a decision recorded here.
+	//
+	// Admission deliberately does not consult the root's own trust file.
+	// A repository that vouched for its own trust surface would decide
+	// its own admission, since whoever wrote that file also chose what
+	// it says.
+	//
+	// The agent's own key is not implicitly entitled. A root Thane
+	// creates is born signed by the agent, so such a root must list
+	// thane@provenance.local here — and a root that omits it, such as a
+	// core established by an operator, is one the agent cannot
+	// establish or re-establish on its own.
 	SeedSigners []AllowedSigner `yaml:"seed_signers,omitempty"`
 }
 
@@ -1153,7 +1171,8 @@ type DocumentRootConfig struct {
 	// Context governs how this root's documents may reach a model.
 	Context RootContextPolicy `yaml:"context,omitempty"`
 
-	// SeedSigners are the keys entitled to establish this root.
+	// SeedSigners are the keys entitled to establish this root, and the
+	// set its history is admitted against at startup.
 	SeedSigners []AllowedSigner `yaml:"seed_signers,omitempty"`
 }
 
@@ -1182,12 +1201,14 @@ type DocumentRootGitConfig struct {
 	// Supports ~ expansion at startup.
 	SigningKey string `yaml:"signing_key,omitempty"`
 
-	// AllowedSigners lists operator SSH public keys trusted to sign
-	// commits in this root, in addition to the shared
-	// signing.allowed_signers set and the agent's own (always-trusted,
-	// unremovable) key. This only extends the trust set for one root; it
-	// never replaces or removes from it. Use it to let an operator
-	// co-author a signed root.
+	// AllowedSigners is the older spelling of this root's seed signers
+	// and is merged with roots.<name>.seed_signers, which is where new
+	// configs should declare them.
+	//
+	// Both feed the same set, so keys listed here also govern admission:
+	// they can establish the root and amend its .allowed_signers. That
+	// is more authority than the name suggests, which is why the
+	// seed_signers spelling exists.
 	AllowedSigners []AllowedSigner `yaml:"allowed_signers,omitempty"`
 
 	// Remote optionally makes this root a full git citizen that fetches,

--- a/internal/platform/coreintegrity/coreintegrity.go
+++ b/internal/platform/coreintegrity/coreintegrity.go
@@ -213,10 +213,29 @@ func (c checker) coreRepository(r *Report, coreOK bool) bool {
 			Detail: "core directory is missing"})
 		return false
 	}
-	if out, err := c.git("rev-parse", "--is-inside-work-tree"); err == nil && out == "true" {
+	out, err := c.git("rev-parse", "--is-inside-work-tree")
+	if err == nil && strings.TrimSpace(out) == "true" {
 		r.Checks = append(r.Checks, Check{Name: "core_repository", Status: StatusPass,
 			Detail: "core is a git repository"})
 		return true
+	}
+	// A core that has a .git directory git nonetheless refuses to read is a
+	// different failure with a different fix, and "git init" is actively
+	// wrong advice for it: the repository exists and its history is intact.
+	// The common cause is ownership — git refuses a repository owned by
+	// another user — which produces an error mentioning nothing about
+	// repositories being absent. Reporting that as "core is not a git
+	// repository" sends an operator to re-initialize a core that is fine.
+	if _, statErr := os.Stat(filepath.Join(c.core, ".git")); statErr == nil {
+		detail := "core has a .git directory but git cannot read it as a repository"
+		if err != nil {
+			detail += ": " + err.Error()
+		}
+		r.Checks = append(r.Checks, Check{Name: "core_repository", Status: StatusFail,
+			Detail: detail,
+			Fix: "check that " + filepath.Join(c.core, ".git") + " is intact and owned by the user Thane runs as" +
+				" — do not run 'git init', which would discard a history that is still there"})
+		return false
 	}
 	r.Checks = append(r.Checks, Check{Name: "core_repository", Status: StatusFail,
 		Detail: "core is not a git repository, so its contents carry no history and cannot be signed",

--- a/internal/platform/coreintegrity/coreintegrity_test.go
+++ b/internal/platform/coreintegrity/coreintegrity_test.go
@@ -390,3 +390,54 @@ func TestUncommittedConfigGetsStagingFix(t *testing.T) {
 		t.Fatalf("amending a commit that does not contain the change would waste the operator's one careful attempt: %q", got.Fix)
 	}
 }
+
+// TestCoreRepositoryDistinguishesUnreadableFromAbsent guards against the
+// report telling an operator to re-initialize a core whose history is intact.
+//
+// git refuses a repository it will not read for reasons that have nothing to
+// do with the repository being absent — ownership is the one seen in
+// production — and the previous wording turned every such failure into "core
+// is not a git repository" with "git init" as the fix. Following that advice
+// on a healthy core discards its history.
+func TestCoreRepositoryDistinguishesUnreadableFromAbsent(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no repository at all", func(t *testing.T) {
+		t.Parallel()
+		workspace := t.TempDir()
+		if err := os.MkdirAll(filepath.Join(workspace, "core"), 0o755); err != nil {
+			t.Fatalf("MkdirAll: %v", err)
+		}
+		check := checkByName(t, run(t, workspace), "core_repository")
+		if check.Status != StatusFail {
+			t.Fatalf("core_repository = %s, want fail", check.Status)
+		}
+		if !strings.HasPrefix(check.Fix, "git -C ") || !strings.HasSuffix(check.Fix, " init") {
+			t.Fatalf("a genuinely absent repository should still be fixed by init, got %q", check.Fix)
+		}
+	})
+
+	t.Run("present but unreadable", func(t *testing.T) {
+		t.Parallel()
+		workspace := t.TempDir()
+		// An empty .git stands in for the shape that matters: something is
+		// there, and git will not read it.
+		if err := os.MkdirAll(filepath.Join(workspace, "core", ".git"), 0o755); err != nil {
+			t.Fatalf("MkdirAll: %v", err)
+		}
+		report := run(t, workspace)
+		check := checkByName(t, report, "core_repository")
+		if check.Status != StatusFail {
+			t.Fatalf("core_repository = %s, want fail", check.Status)
+		}
+		if strings.HasPrefix(check.Fix, "git -C ") && strings.HasSuffix(check.Fix, " init") {
+			t.Fatalf("must not advise init when .git is present: %q", check.Fix)
+		}
+		if !strings.Contains(check.Fix, "do not run") {
+			t.Fatalf("fix should warn against init explicitly, got %q", check.Fix)
+		}
+		if !strings.Contains(check.Detail, "cannot read it") {
+			t.Fatalf("detail should say git could not read the repository, got %q", check.Detail)
+		}
+	})
+}

--- a/internal/platform/provenance/admission.go
+++ b/internal/platform/provenance/admission.go
@@ -125,17 +125,33 @@ func attributionHint(ctx context.Context, repoPath, commit string) string {
 }
 
 // rootCommits returns every parentless commit reachable from HEAD.
+//
+// The three ways this can fail are deliberately not collapsed. A repository
+// with no commits yet is a finding the caller states in those words; a
+// directory git cannot read as a work tree is an operational fault; and a
+// rev-list that fails on a readable repository is neither. Reporting the
+// second as "no commit history" would describe a permission or ownership
+// problem as an empty history and send an operator to re-establish a root
+// whose history is perfectly intact — the failure mode is not hypothetical,
+// since a repository owned by another user makes git refuse every command
+// with an error that has nothing to do with commits.
 func rootCommits(ctx context.Context, repoPath string) ([]string, error) {
 	out, err := runGitText(ctx, repoPath, "rev-list", "--max-parents=0", "HEAD")
-	if err != nil {
-		// An unborn HEAD is reported as a finding by the caller, not as an
-		// operational fault, so distinguish it from a broken repository.
-		if _, headErr := runGitText(ctx, repoPath, "rev-parse", "--verify", "HEAD"); headErr != nil {
-			return nil, nil
-		}
-		return nil, fmt.Errorf("list root commits of %s: %w", repoPath, err)
+	if err == nil {
+		return nonEmptyLines(out), nil
 	}
-	return nonEmptyLines(out), nil
+
+	inside, repoErr := runGitText(ctx, repoPath, "rev-parse", "--is-inside-work-tree")
+	switch {
+	case repoErr != nil:
+		return nil, fmt.Errorf("read git repository at %s: %w", repoPath, repoErr)
+	case strings.TrimSpace(inside) != "true":
+		return nil, fmt.Errorf("%s is not a git work tree, so it has no history to admit", repoPath)
+	}
+	if _, headErr := runGitText(ctx, repoPath, "rev-parse", "--verify", "HEAD"); headErr != nil {
+		return nil, nil
+	}
+	return nil, fmt.Errorf("list root commits of %s: %w", repoPath, err)
 }
 
 // trustFileCommits returns every commit that created or changed the in-tree

--- a/internal/platform/provenance/admission.go
+++ b/internal/platform/provenance/admission.go
@@ -1,0 +1,240 @@
+package provenance
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// TrustFileName is the repo-relative path of a root's in-tree trust file —
+// the record of which keys the root itself vouches for.
+const TrustFileName = ".allowed_signers"
+
+// AdmissionReport records what admission observed, so a caller can log or
+// display the attribution rather than only the verdict.
+type AdmissionReport struct {
+	// RootCommit is the repository's single parentless commit.
+	RootCommit string
+	// TrustFileCommits are the commits that created or changed the in-tree
+	// trust file, newest first.
+	TrustFileCommits []string
+}
+
+// VerifyAdmission checks a repository's history from first principles: that
+// its birth is attributable to a key someone declared entitled to establish
+// it, and that every change to its trust file since was made by such a key.
+//
+// The two rules are one idea. A signature only means something if someone
+// decided whose signatures count, and the in-tree trust file cannot answer
+// that about itself — a repository that vouches for its own trust surface
+// establishes nothing, because whoever wrote the file also chose what it says.
+// Seed signers come from configuration, outside the repository they govern, so
+// admission is the one question a root cannot answer in its own favor.
+//
+// Verification runs against a rendered seed-only allowed_signers file rather
+// than the repository's own, so a commit that added a key to the in-tree file
+// cannot be validated by the very entry it introduced.
+//
+// Delegation is deliberately strict for now: keys added to the in-tree file
+// may sign ordinary content, but only a seed signer may change the file
+// itself. A delegated key cannot delegate further. That forbids a legitimate
+// pattern — a collaborator admitting the next collaborator — and the cost is
+// visible and recoverable when it bites, whereas a permissive chain that
+// proves unsound is neither.
+func VerifyAdmission(ctx context.Context, repoPath string, seeds []TrustedSigner) (AdmissionReport, error) {
+	var report AdmissionReport
+
+	if len(seeds) == 0 {
+		return report, fmt.Errorf("no seed signers are declared for %s, so nothing decides whose signatures may establish it; list the entitled keys under roots.<name>.seed_signers", repoPath)
+	}
+
+	seedFile, cleanup, err := materializeSeedSigners(seeds)
+	if err != nil {
+		return report, err
+	}
+	defer cleanup()
+
+	roots, err := rootCommits(ctx, repoPath)
+	if err != nil {
+		return report, err
+	}
+	switch {
+	case len(roots) == 0:
+		return report, fmt.Errorf("%s has no commit history, so its birth cannot be attributed", repoPath)
+	case len(roots) > 1:
+		// Independent histories joined by a merge each carry their own
+		// birth. Admitting the repository because one of them checks out
+		// would let an unattributable history in through the side door.
+		return report, fmt.Errorf("%s has %d parentless commits (%s), so it carries grafted history with more than one birth; a root must descend from a single admitted commit",
+			repoPath, len(roots), strings.Join(roots, ", "))
+	}
+	report.RootCommit = roots[0]
+
+	if err := verifyAgainstSeeds(ctx, repoPath, seedFile, report.RootCommit); err != nil {
+		return report, fmt.Errorf("the root commit %s of %s is not signed by a declared seed signer, so this root's birth is unattributed%s",
+			shortCommit(report.RootCommit), repoPath, attributionHint(ctx, repoPath, report.RootCommit))
+	}
+
+	report.TrustFileCommits, err = trustFileCommits(ctx, repoPath)
+	if err != nil {
+		return report, err
+	}
+	for _, commit := range report.TrustFileCommits {
+		if err := verifyAgainstSeeds(ctx, repoPath, seedFile, commit); err != nil {
+			return report, fmt.Errorf("commit %s of %s changed %s without a declared seed signer's signature, so the root's trust surface was widened by someone not entitled to widen it%s",
+				shortCommit(commit), repoPath, TrustFileName, attributionHint(ctx, repoPath, commit))
+		}
+	}
+
+	return report, nil
+}
+
+// attributionHint appends who git says actually signed a commit, and what to
+// do about it. It is diagnostic only and never affects the verdict, which is
+// decided against the seed file alone.
+//
+// The overwhelmingly common refusal is a root the agent founded for an
+// instance that did not declare the agent entitled to found it. Without the
+// principal in the message that reads as a mysterious signature failure; with
+// it, the fix is one config line and the operator can see whether granting it
+// is what they want.
+func attributionHint(ctx context.Context, repoPath, commit string) string {
+	// Ask against the root's own trust file: it is the only place likely to
+	// name the signer, and naming is all this is for.
+	inTree := filepath.Join(repoPath, TrustFileName)
+	if err := validateAllowedSignersFile(inTree); err != nil {
+		inTree = ""
+	}
+	signer, err := signerFor(ctx, repoPath, inTree, commit)
+	if err != nil {
+		return ""
+	}
+	switch {
+	case signer.Kind == SignerKindAgent:
+		return fmt.Sprintf(": it was signed by %s, the agent's own key — declare that principal in this root's seed_signers if the agent is entitled to establish it, or re-establish the root with a commit signed by a declared seed",
+			signer.Principal)
+	case signer.Principal != "":
+		return fmt.Sprintf(": it was signed by %s, which this root does not declare as a seed signer", signer.Principal)
+	case signer.Reason != "":
+		return ": " + signer.Reason
+	default:
+		return ""
+	}
+}
+
+// rootCommits returns every parentless commit reachable from HEAD.
+func rootCommits(ctx context.Context, repoPath string) ([]string, error) {
+	out, err := runGitText(ctx, repoPath, "rev-list", "--max-parents=0", "HEAD")
+	if err != nil {
+		// An unborn HEAD is reported as a finding by the caller, not as an
+		// operational fault, so distinguish it from a broken repository.
+		if _, headErr := runGitText(ctx, repoPath, "rev-parse", "--verify", "HEAD"); headErr != nil {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("list root commits of %s: %w", repoPath, err)
+	}
+	return nonEmptyLines(out), nil
+}
+
+// trustFileCommits returns every commit that created or changed the in-tree
+// trust file.
+//
+// --full-history is load-bearing: git's default history simplification drops
+// commits whose change to a path did not survive into the merge result, which
+// is exactly where an unentitled edit would hide.
+func trustFileCommits(ctx context.Context, repoPath string) ([]string, error) {
+	out, err := runGitText(ctx, repoPath, "log", "--full-history", "--format=%H", "--", TrustFileName)
+	if err != nil {
+		return nil, fmt.Errorf("list %s history of %s: %w", TrustFileName, repoPath, err)
+	}
+	return nonEmptyLines(out), nil
+}
+
+// verifyAgainstSeeds checks one commit's signature against the seed set alone.
+func verifyAgainstSeeds(ctx context.Context, repoPath, seedFile, commit string) error {
+	if _, err := runGitTextVerify(ctx, repoPath, seedFile, "verify-commit", commit); err != nil {
+		return err
+	}
+	return nil
+}
+
+// materializeSeedSigners renders the seed set to a temporary allowed_signers
+// file for git to verify against, and returns a cleanup func.
+//
+// It is deliberately not written inside the repository. A trust surface stored
+// where the repository can reach it is one more thing a write to that
+// repository could change, and admission exists precisely to be the check no
+// repository content can influence.
+func materializeSeedSigners(seeds []TrustedSigner) (string, func(), error) {
+	content, err := RenderSeedSigners(seeds)
+	if err != nil {
+		return "", nil, fmt.Errorf("render seed signers: %w", err)
+	}
+	if strings.TrimSpace(content) == "" {
+		return "", nil, fmt.Errorf("seed signers rendered to an empty trust set")
+	}
+
+	file, err := os.CreateTemp("", "thane-seed-signers-*")
+	if err != nil {
+		return "", nil, fmt.Errorf("create seed signers file: %w", err)
+	}
+	name := file.Name()
+	cleanup := func() { _ = os.Remove(name) }
+
+	if err := file.Chmod(0o600); err != nil {
+		file.Close()
+		cleanup()
+		return "", nil, fmt.Errorf("secure seed signers file: %w", err)
+	}
+	if _, err := file.WriteString(content); err != nil {
+		file.Close()
+		cleanup()
+		return "", nil, fmt.Errorf("write seed signers file: %w", err)
+	}
+	if err := file.Close(); err != nil {
+		cleanup()
+		return "", nil, fmt.Errorf("close seed signers file: %w", err)
+	}
+	return name, cleanup, nil
+}
+
+// seedsInclude reports whether publicKey is one of the declared seed signers,
+// comparing canonical key blobs so a trailing comment or stray whitespace
+// cannot make an entitled key look absent.
+func seedsInclude(seeds []TrustedSigner, publicKey string) (bool, error) {
+	target, err := canonicalKeyBlob(publicKey)
+	if err != nil {
+		return false, fmt.Errorf("agent signing key: %w", err)
+	}
+	for _, seed := range seeds {
+		blob, err := canonicalKeyBlob(seed.PublicKey)
+		if err != nil {
+			return false, fmt.Errorf("seed signer %q: %w", strings.TrimSpace(seed.Principal), err)
+		}
+		if blob == target {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func nonEmptyLines(out string) []string {
+	var lines []string
+	for line := range strings.SplitSeq(strings.TrimSpace(out), "\n") {
+		if line = strings.TrimSpace(line); line != "" {
+			lines = append(lines, line)
+		}
+	}
+	return lines
+}
+
+// shortCommit abbreviates a hash for operator-facing messages, where the full
+// forty characters crowd out the sentence around them.
+func shortCommit(commit string) string {
+	if len(commit) > 12 {
+		return commit[:12]
+	}
+	return commit
+}

--- a/internal/platform/provenance/admission_test.go
+++ b/internal/platform/provenance/admission_test.go
@@ -360,3 +360,40 @@ func TestVerifyAdmissionIgnoresTheRepositoryOwnTrustFile(t *testing.T) {
 		t.Fatalf("VerifyAdmission() error = %v, want unattributed-birth refusal", err)
 	}
 }
+
+// TestVerifyAdmissionDistinguishesUnreadableFromUnborn keeps a directory git
+// cannot read as a work tree from being reported as an empty history.
+//
+// The two need different repairs and only one of them involves history. An
+// operator told "no commit history" about a root whose commits are intact and
+// merely unreadable — wrong owner, wrong permissions, not a repository at all
+// — is being pointed at a rewrite they must not perform.
+func TestVerifyAdmissionDistinguishesUnreadableFromUnborn(t *testing.T) {
+	t.Parallel()
+	key := newAdmissionKey(t, "operator@example.com")
+
+	t.Run("not a repository", func(t *testing.T) {
+		t.Parallel()
+		_, err := VerifyAdmission(t.Context(), t.TempDir(), []TrustedSigner{key.signer()})
+		if err == nil {
+			t.Fatal("VerifyAdmission() = nil, want a refusal for a non-repository")
+		}
+		if strings.Contains(err.Error(), "no commit history") {
+			t.Fatalf("a directory that is not a repository must not be reported as an empty history: %v", err)
+		}
+		// git exits non-zero rather than printing "false" here, so the
+		// wrapper carries git's own reason through instead of inventing one.
+		if !strings.Contains(err.Error(), "read git repository") {
+			t.Fatalf("VerifyAdmission() error = %v, want it to report a repository that could not be read", err)
+		}
+	})
+
+	t.Run("repository with no commits", func(t *testing.T) {
+		t.Parallel()
+		repo := newAdmissionRepo(t)
+		_, err := VerifyAdmission(t.Context(), repo.dir, []TrustedSigner{key.signer()})
+		if err == nil || !strings.Contains(err.Error(), "no commit history") {
+			t.Fatalf("VerifyAdmission() error = %v, want it to report no commit history", err)
+		}
+	})
+}

--- a/internal/platform/provenance/admission_test.go
+++ b/internal/platform/provenance/admission_test.go
@@ -1,0 +1,362 @@
+package provenance
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/pem"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"golang.org/x/crypto/ssh"
+)
+
+// admissionKey is one identity a test can commit as: a private key on disk for
+// git to sign with, and its public half for a seed declaration.
+type admissionKey struct {
+	principal string
+	privPath  string
+	publicKey string
+}
+
+func (k admissionKey) signer() TrustedSigner {
+	return TrustedSigner{Principal: k.principal, PublicKey: k.publicKey}
+}
+
+func newAdmissionKey(t *testing.T, principal string) admissionKey {
+	t.Helper()
+	publicKey, privateKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate %s key: %v", principal, err)
+	}
+	sshPub, err := ssh.NewPublicKey(publicKey)
+	if err != nil {
+		t.Fatalf("encode %s public key: %v", principal, err)
+	}
+	block, err := ssh.MarshalPrivateKey(privateKey, principal)
+	if err != nil {
+		t.Fatalf("marshal %s private key: %v", principal, err)
+	}
+	privPath := filepath.Join(t.TempDir(), "id_ed25519")
+	if err := os.WriteFile(privPath, pem.EncodeToMemory(block), 0o600); err != nil {
+		t.Fatalf("write %s private key: %v", principal, err)
+	}
+	return admissionKey{
+		principal: principal,
+		privPath:  privPath,
+		publicKey: strings.TrimSpace(string(ssh.MarshalAuthorizedKey(sshPub))),
+	}
+}
+
+// admissionRepo is a git repository tests drive directly, so a commit can be
+// attributed to any key rather than only to the Store's own signer. Real roots
+// acquire history both ways — the agent writes through the Store, an operator
+// commits by hand — and admission has to judge the result either way.
+type admissionRepo struct {
+	t   *testing.T
+	dir string
+}
+
+func newAdmissionRepo(t *testing.T) *admissionRepo {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	if _, err := exec.LookPath("ssh-keygen"); err != nil {
+		t.Skip("ssh-keygen not available")
+	}
+	r := &admissionRepo{t: t, dir: t.TempDir()}
+	r.git("init", "-b", "main")
+	r.git("config", "gpg.format", "ssh")
+	r.git("config", "user.name", "Test")
+	r.git("config", "user.email", "test@example.com")
+	return r
+}
+
+func (r *admissionRepo) git(args ...string) string {
+	r.t.Helper()
+	cmd := exec.Command("git", append([]string{"-C", r.dir}, args...)...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		r.t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), err, out)
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// commitAs writes files and commits them signed by the given key.
+func (r *admissionRepo) commitAs(key admissionKey, message string, files map[string]string) {
+	r.t.Helper()
+	for name, content := range files {
+		path := filepath.Join(r.dir, name)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			r.t.Fatalf("mkdir for %s: %v", name, err)
+		}
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			r.t.Fatalf("write %s: %v", name, err)
+		}
+	}
+	r.git("add", "-A")
+	r.git("-c", "user.signingkey="+key.privPath, "commit", "-S", "-m", message)
+}
+
+// trustFile renders an in-tree trust file listing the given keys. Its contents
+// only matter to admission as a thing that changed; what admission judges is
+// who signed the change.
+func trustFile(keys ...admissionKey) string {
+	var b strings.Builder
+	for _, k := range keys {
+		b.WriteString(k.principal + " " + k.publicKey + "\n")
+	}
+	return b.String()
+}
+
+func TestVerifyAdmission(t *testing.T) {
+	t.Parallel()
+
+	operator := newAdmissionKey(t, "operator@example.com")
+	agent := newAdmissionKey(t, AgentPrincipal)
+	stranger := newAdmissionKey(t, "stranger@example.com")
+
+	for _, tc := range []struct {
+		name string
+		// build lays down the repository's history.
+		build func(r *admissionRepo)
+		// seeds is what config declares for the root.
+		seeds []TrustedSigner
+		// want is a fragment of the expected refusal; empty means admitted.
+		want string
+	}{
+		{
+			name: "founded by a declared seed signer",
+			build: func(r *admissionRepo) {
+				r.commitAs(operator, "birth", map[string]string{
+					TrustFileName: trustFile(operator),
+					"mission.md":  "why we are here",
+				})
+			},
+			seeds: []TrustedSigner{operator.signer()},
+		},
+		{
+			name: "founded by the agent where the agent is a declared seed",
+			build: func(r *admissionRepo) {
+				r.commitAs(agent, "birth", map[string]string{
+					TrustFileName: trustFile(agent),
+				})
+			},
+			seeds: []TrustedSigner{agent.signer()},
+		},
+		{
+			name: "founded by the agent where it is not declared",
+			build: func(r *admissionRepo) {
+				r.commitAs(agent, "birth", map[string]string{
+					TrustFileName: trustFile(agent, operator),
+				})
+			},
+			seeds: []TrustedSigner{operator.signer()},
+			want:  "birth is unattributed",
+		},
+		{
+			// The in-tree file trusting a key cannot be what makes that key
+			// able to found the root — otherwise every root admits itself.
+			name: "founded by a key the in-tree file trusts but config does not",
+			build: func(r *admissionRepo) {
+				r.commitAs(stranger, "birth", map[string]string{
+					TrustFileName: trustFile(stranger, operator),
+				})
+			},
+			seeds: []TrustedSigner{operator.signer()},
+			want:  "birth is unattributed",
+		},
+		{
+			name: "content commits from a delegated key are not admission's business",
+			build: func(r *admissionRepo) {
+				r.commitAs(operator, "birth", map[string]string{
+					TrustFileName: trustFile(operator, stranger),
+				})
+				r.commitAs(stranger, "ordinary work", map[string]string{
+					"notes.md": "delegated content",
+				})
+			},
+			seeds: []TrustedSigner{operator.signer()},
+		},
+		{
+			name: "trust file widened by a delegated key",
+			build: func(r *admissionRepo) {
+				r.commitAs(operator, "birth", map[string]string{
+					TrustFileName: trustFile(operator, stranger),
+				})
+				r.commitAs(stranger, "add a friend", map[string]string{
+					TrustFileName: trustFile(operator, stranger, agent),
+				})
+			},
+			seeds: []TrustedSigner{operator.signer()},
+			want:  "without a declared seed signer's signature",
+		},
+		{
+			name: "trust file amended by a seed signer",
+			build: func(r *admissionRepo) {
+				r.commitAs(operator, "birth", map[string]string{
+					TrustFileName: trustFile(operator),
+				})
+				r.commitAs(operator, "delegate to a collaborator", map[string]string{
+					TrustFileName: trustFile(operator, stranger),
+				})
+			},
+			seeds: []TrustedSigner{operator.signer()},
+		},
+		{
+			name: "grafted history carrying a second birth",
+			build: func(r *admissionRepo) {
+				r.commitAs(operator, "birth", map[string]string{
+					TrustFileName: trustFile(operator),
+				})
+				// An orphan branch is a second, independently born history;
+				// merging it smuggles its commits in behind an admitted root.
+				r.git("checkout", "--orphan", "smuggled")
+				r.git("rm", "-rf", ".")
+				r.commitAs(stranger, "unrelated birth", map[string]string{
+					"payload.md": "arrived without admission",
+				})
+				r.git("checkout", "main")
+				r.git("-c", "user.signingkey="+operator.privPath,
+					"merge", "--allow-unrelated-histories", "--no-ff", "-S", "-m", "merge", "smuggled")
+			},
+			seeds: []TrustedSigner{operator.signer()},
+			want:  "more than one birth",
+		},
+		{
+			name: "no seed signers declared",
+			build: func(r *admissionRepo) {
+				r.commitAs(operator, "birth", map[string]string{
+					TrustFileName: trustFile(operator),
+				})
+			},
+			seeds: nil,
+			want:  "no seed signers are declared",
+		},
+		{
+			name:  "repository with no commits",
+			build: func(r *admissionRepo) {},
+			seeds: []TrustedSigner{operator.signer()},
+			want:  "no commit history",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			repo := newAdmissionRepo(t)
+			tc.build(repo)
+
+			_, err := VerifyAdmission(t.Context(), repo.dir, tc.seeds)
+			if tc.want == "" {
+				if err != nil {
+					t.Fatalf("VerifyAdmission() = %v, want admitted", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("VerifyAdmission() = nil, want refusal containing %q", tc.want)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("VerifyAdmission() error = %v, want containing %q", err, tc.want)
+			}
+		})
+	}
+}
+
+// TestVerifyAdmissionReportsWhatItChecked confirms the report carries the
+// attribution, not just the verdict, so callers can log which commits the
+// verdict rests on.
+func TestVerifyAdmissionReportsWhatItChecked(t *testing.T) {
+	t.Parallel()
+	operator := newAdmissionKey(t, "operator@example.com")
+	repo := newAdmissionRepo(t)
+	repo.commitAs(operator, "birth", map[string]string{TrustFileName: trustFile(operator)})
+	repo.commitAs(operator, "delegate", map[string]string{TrustFileName: trustFile(operator, operator)})
+
+	report, err := VerifyAdmission(t.Context(), repo.dir, []TrustedSigner{operator.signer()})
+	if err != nil {
+		t.Fatalf("VerifyAdmission() = %v, want admitted", err)
+	}
+	if report.RootCommit == "" {
+		t.Fatal("report.RootCommit is empty, want the parentless commit")
+	}
+	if len(report.TrustFileCommits) != 2 {
+		t.Fatalf("report.TrustFileCommits = %v, want both commits that touched %s", report.TrustFileCommits, TrustFileName)
+	}
+}
+
+// TestBootstrapBirthCommitRefusesToCreateAnInadmissibleRoot covers the state
+// that would otherwise be unrecoverable: the agent founding a root whose seed
+// set does not entitle it. Nothing committed later can fix a birth, so the
+// refusal has to happen before the birth exists.
+func TestBootstrapBirthCommitRefusesToCreateAnInadmissibleRoot(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	operator := newAdmissionKey(t, "operator@example.com")
+
+	store, err := NewWithOptions(t.TempDir(), testSigner(t), slog.New(slog.DiscardHandler), Options{
+		SeedSigners: []TrustedSigner{operator.signer()},
+	})
+	if err != nil {
+		t.Fatalf("NewWithOptions: %v", err)
+	}
+
+	err = store.BootstrapBirthCommit(t.Context())
+	if err == nil {
+		t.Fatal("BootstrapBirthCommit = nil, want refusal to found an inadmissible root")
+	}
+	if !strings.Contains(err.Error(), "could never be admitted") {
+		t.Fatalf("BootstrapBirthCommit error = %v, want a born-inadmissible refusal", err)
+	}
+}
+
+// TestBootstrapBirthCommitFoundsARootThatAdmitsTheAgent is the other half:
+// declaring the agent is what makes an agent-founded root legitimate.
+func TestBootstrapBirthCommitFoundsARootThatAdmitsTheAgent(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	signer := testSigner(t)
+	seeds := []TrustedSigner{{Principal: AgentPrincipal, PublicKey: signer.PublicKey()}}
+
+	dir := t.TempDir()
+	store, err := NewWithOptions(dir, signer, slog.New(slog.DiscardHandler), Options{SeedSigners: seeds})
+	if err != nil {
+		t.Fatalf("NewWithOptions: %v", err)
+	}
+	if err := store.BootstrapBirthCommit(t.Context()); err != nil {
+		t.Fatalf("BootstrapBirthCommit: %v", err)
+	}
+
+	if _, err := VerifyAdmission(t.Context(), dir, seeds); err != nil {
+		t.Fatalf("VerifyAdmission of a freshly founded root = %v, want admitted", err)
+	}
+}
+
+// TestVerifyAdmissionIgnoresTheRepositoryOwnTrustFile is the regression guard
+// for the mistake this whole check exists to prevent: a repository must not be
+// able to make itself admissible by listing a key in its own trust file.
+func TestVerifyAdmissionIgnoresTheRepositoryOwnTrustFile(t *testing.T) {
+	t.Parallel()
+	operator := newAdmissionKey(t, "operator@example.com")
+	stranger := newAdmissionKey(t, "stranger@example.com")
+
+	repo := newAdmissionRepo(t)
+	repo.commitAs(stranger, "birth", map[string]string{
+		// The strongest possible self-endorsement: the founder writes itself
+		// into the trust file in the very commit being judged.
+		TrustFileName: trustFile(stranger),
+	})
+
+	_, err := VerifyAdmission(t.Context(), repo.dir, []TrustedSigner{operator.signer()})
+	if err == nil {
+		t.Fatal("VerifyAdmission() = nil, want refusal: a root cannot admit itself")
+	}
+	if !strings.Contains(err.Error(), "birth is unattributed") {
+		t.Fatalf("VerifyAdmission() error = %v, want unattributed-birth refusal", err)
+	}
+}

--- a/internal/platform/provenance/allowed_signers.go
+++ b/internal/platform/provenance/allowed_signers.go
@@ -110,6 +110,11 @@ func RenderSeedSigners(seeds []TrustedSigner) (string, error) {
 // holding it, so an entry claiming that key under a different principal is
 // caught. An entry that restates a reserved key under its own principal is
 // dropped rather than repeated.
+//
+// Errors name a plain "signer" because this renders both the operator set and
+// the seed set. Saying "operator" here would report a malformed seed signer as
+// an operator problem and send the reader to the wrong config block; the
+// calling function supplies which set it was rendering.
 func renderSignerSet(signers []TrustedSigner, reserved map[string]string) ([]string, error) {
 	type entry struct {
 		principal string
@@ -126,7 +131,7 @@ func renderSignerSet(signers []TrustedSigner, reserved map[string]string) ([]str
 	for i, s := range signers {
 		blob, err := canonicalKeyBlob(s.PublicKey)
 		if err != nil {
-			return nil, fmt.Errorf("operator signer %d (%s): %w", i, strings.TrimSpace(s.Principal), err)
+			return nil, fmt.Errorf("signer %d (%s): %w", i, strings.TrimSpace(s.Principal), err)
 		}
 		principal := strings.TrimSpace(s.Principal)
 		if prev, ok := seen[blob]; ok {
@@ -138,12 +143,12 @@ func renderSignerSet(signers []TrustedSigner, reserved map[string]string) ([]str
 			if prev == principal {
 				continue
 			}
-			return nil, fmt.Errorf("operator signer %q duplicates the key already trusted for %q", principal, prev)
+			return nil, fmt.Errorf("signer %q duplicates the key already trusted for %q", principal, prev)
 		}
 		seen[blob] = principal
 		line, err := renderSignerLine(principal, blob, s.Comment, s.ValidAfter, s.ValidBefore)
 		if err != nil {
-			return nil, fmt.Errorf("operator signer %q: %w", principal, err)
+			return nil, fmt.Errorf("signer %q: %w", principal, err)
 		}
 		out = append(out, entry{principal: principal, blob: blob, line: line})
 	}

--- a/internal/platform/provenance/allowed_signers.go
+++ b/internal/platform/provenance/allowed_signers.go
@@ -42,61 +42,29 @@ type TrustedSigner struct {
 // file that trusts the agent key plus the operator keys, deterministically.
 //
 // The agent key is the unremovable trust anchor: it is always emitted first,
-// under [AgentPrincipal], and an operator entry whose public key equals the
-// agent key is rejected — that is a principal-spoof that would let another
-// identity ride the agent's own key. Operator keys are canonicalized (comment
-// and whitespace stripped for identity), deduplicated by key blob, and sorted
-// by (principal, blob) so the rendered file never churns across boots when the
-// configured set is unchanged. The returned content ends with a trailing
-// newline and is safe to compare byte-for-byte for drift detection.
+// under [AgentPrincipal]. An operator entry may name that same key under
+// [AgentPrincipal] — that is how a root declares the agent entitled to
+// establish it — and collapses into the implicit line rather than repeating
+// it. The same key under any *other* principal is refused: that is a
+// principal-spoof that would let another identity ride the agent's own key.
+//
+// Operator keys are canonicalized (comment and whitespace stripped for
+// identity), deduplicated by key blob, and sorted by (principal, blob) so the
+// rendered file never churns across boots when the configured set is
+// unchanged. The returned content ends with a trailing newline and is safe to
+// compare byte-for-byte for drift detection.
 func RenderAllowedSigners(agentPublicKey string, operators []TrustedSigner) (string, error) {
 	agentBlob, err := canonicalKeyBlob(agentPublicKey)
 	if err != nil {
 		return "", fmt.Errorf("agent signing key: %w", err)
 	}
 
-	type entry struct {
-		principal string
-		blob      string
-		line      string
+	// The agent line is emitted first and unconditionally, so its blob is
+	// already claimed before any operator entry is considered.
+	lines, err := renderSignerSet(operators, map[string]string{agentBlob: AgentPrincipal})
+	if err != nil {
+		return "", err
 	}
-	// seen maps a canonical key blob to the principal that first claimed
-	// it, so a key reused under a second principal is caught.
-	seen := map[string]string{agentBlob: AgentPrincipal}
-	others := make([]entry, 0, len(operators))
-	for i, s := range operators {
-		blob, err := canonicalKeyBlob(s.PublicKey)
-		if err != nil {
-			return "", fmt.Errorf("operator signer %d (%s): %w", i, strings.TrimSpace(s.Principal), err)
-		}
-		principal := strings.TrimSpace(s.Principal)
-		if blob == agentBlob {
-			return "", fmt.Errorf("operator signer %q uses the agent's own signing key; the agent key is trusted implicitly and must not be listed", principal)
-		}
-		if prev, ok := seen[blob]; ok {
-			// The same key under the same principal collapses silently:
-			// this is the benign case where a key is listed in both the
-			// shared block and a root's own list (the sets union). The
-			// same key under a *different* principal is a spoof and is
-			// refused.
-			if prev == principal {
-				continue
-			}
-			return "", fmt.Errorf("operator signer %q duplicates the key already trusted for %q", principal, prev)
-		}
-		seen[blob] = principal
-		line, err := renderSignerLine(principal, blob, s.Comment, s.ValidAfter, s.ValidBefore)
-		if err != nil {
-			return "", fmt.Errorf("operator signer %q: %w", principal, err)
-		}
-		others = append(others, entry{principal: principal, blob: blob, line: line})
-	}
-	sort.Slice(others, func(i, j int) bool {
-		if others[i].principal != others[j].principal {
-			return others[i].principal < others[j].principal
-		}
-		return others[i].blob < others[j].blob
-	})
 
 	agentLine, err := renderSignerLine(AgentPrincipal, agentBlob, "", "", "")
 	if err != nil {
@@ -105,11 +73,91 @@ func RenderAllowedSigners(agentPublicKey string, operators []TrustedSigner) (str
 	var b strings.Builder
 	b.WriteString(agentLine)
 	b.WriteByte('\n')
-	for _, e := range others {
-		b.WriteString(e.line)
+	for _, line := range lines {
+		b.WriteString(line)
 		b.WriteByte('\n')
 	}
 	return b.String(), nil
+}
+
+// RenderSeedSigners produces an allowed_signers file containing exactly the
+// declared seed signers and nothing else — in particular, no implicit agent
+// line.
+//
+// That omission is the whole point. Admission asks whether a repository's
+// birth is attributable to a key someone deliberately entitled, and the agent
+// key is trusted implicitly everywhere else. Rendering it here too would make
+// every agent-founded root self-admitting and quietly delete the property that
+// an instance can be configured so its own agent cannot establish or amend the
+// root holding its config.
+func RenderSeedSigners(seeds []TrustedSigner) (string, error) {
+	lines, err := renderSignerSet(seeds, nil)
+	if err != nil {
+		return "", err
+	}
+	var b strings.Builder
+	for _, line := range lines {
+		b.WriteString(line)
+		b.WriteByte('\n')
+	}
+	return b.String(), nil
+}
+
+// renderSignerSet canonicalizes, deduplicates, and sorts signer entries into
+// allowed_signers lines.
+//
+// reserved maps a key blob the caller has already emitted to the principal
+// holding it, so an entry claiming that key under a different principal is
+// caught. An entry that restates a reserved key under its own principal is
+// dropped rather than repeated.
+func renderSignerSet(signers []TrustedSigner, reserved map[string]string) ([]string, error) {
+	type entry struct {
+		principal string
+		blob      string
+		line      string
+	}
+	// seen maps a canonical key blob to the principal that first claimed
+	// it, so a key reused under a second principal is caught.
+	seen := make(map[string]string, len(signers)+len(reserved))
+	for blob, principal := range reserved {
+		seen[blob] = principal
+	}
+	out := make([]entry, 0, len(signers))
+	for i, s := range signers {
+		blob, err := canonicalKeyBlob(s.PublicKey)
+		if err != nil {
+			return nil, fmt.Errorf("operator signer %d (%s): %w", i, strings.TrimSpace(s.Principal), err)
+		}
+		principal := strings.TrimSpace(s.Principal)
+		if prev, ok := seen[blob]; ok {
+			// The same key under the same principal collapses silently:
+			// this is the benign case where a key is listed in more than
+			// one place that feeds the same set, or names the agent key
+			// under the agent's own principal. The same key under a
+			// *different* principal is a spoof and is refused.
+			if prev == principal {
+				continue
+			}
+			return nil, fmt.Errorf("operator signer %q duplicates the key already trusted for %q", principal, prev)
+		}
+		seen[blob] = principal
+		line, err := renderSignerLine(principal, blob, s.Comment, s.ValidAfter, s.ValidBefore)
+		if err != nil {
+			return nil, fmt.Errorf("operator signer %q: %w", principal, err)
+		}
+		out = append(out, entry{principal: principal, blob: blob, line: line})
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].principal != out[j].principal {
+			return out[i].principal < out[j].principal
+		}
+		return out[i].blob < out[j].blob
+	})
+	lines := make([]string, 0, len(out))
+	for _, e := range out {
+		lines = append(lines, e.line)
+	}
+	return lines, nil
 }
 
 // SeedAllowedSigners establishes this repository's trust set once — the agent

--- a/internal/platform/provenance/allowed_signers_test.go
+++ b/internal/platform/provenance/allowed_signers_test.go
@@ -96,10 +96,10 @@ func TestRenderAllowedSigners_Rejections(t *testing.T) {
 		want  string
 	}{
 		{
-			name:  "operator reuses agent key",
+			name:  "operator reuses agent key under another principal",
 			agent: testAgentKey,
 			ops:   []TrustedSigner{{Principal: "evil@example.com", PublicKey: testAgentKey}},
-			want:  "agent's own signing key",
+			want:  "duplicates the key already trusted",
 		},
 		{
 			name:  "duplicate operator key under two principals",
@@ -161,13 +161,63 @@ func TestRenderAllowedSigners_Rejections(t *testing.T) {
 
 // TestRenderAllowedSigners_CanonicalizesComments confirms that keys differing
 // only by trailing comment are treated as identical (so a comment can't slip a
-// duplicate past dedup, and the agent-key check can't be evaded by appending a
-// comment).
+// duplicate past dedup, and the agent-key spoof check can't be evaded by
+// appending a comment).
 func TestRenderAllowedSigners_CanonicalizesComments(t *testing.T) {
 	t.Parallel()
 	_, err := RenderAllowedSigners(testAgentKey, []TrustedSigner{{Principal: "evil@example.com", PublicKey: testAgentKey + " looks-different"}})
-	if err == nil || !strings.Contains(err.Error(), "agent's own signing key") {
-		t.Fatalf("RenderAllowedSigners() error = %v, want agent-key rejection despite comment", err)
+	if err == nil || !strings.Contains(err.Error(), "duplicates the key already trusted") {
+		t.Fatalf("RenderAllowedSigners() error = %v, want agent-key spoof rejection despite comment", err)
+	}
+}
+
+// TestRenderAllowedSigners_AcceptsAgentPrincipal confirms a root may declare
+// the agent key entitled to establish it. The rendered file is unchanged —
+// the agent line is already emitted implicitly — but the declaration has to be
+// accepted, because refusing it is what would make an agent-founded root
+// impossible to admit.
+func TestRenderAllowedSigners_AcceptsAgentPrincipal(t *testing.T) {
+	t.Parallel()
+	withAgent, err := RenderAllowedSigners(testAgentKey, []TrustedSigner{{Principal: AgentPrincipal, PublicKey: testAgentKey}})
+	if err != nil {
+		t.Fatalf("RenderAllowedSigners() with agent principal = %v, want nil", err)
+	}
+	withoutAgent, err := RenderAllowedSigners(testAgentKey, nil)
+	if err != nil {
+		t.Fatalf("RenderAllowedSigners() bare = %v, want nil", err)
+	}
+	if withAgent != withoutAgent {
+		t.Fatalf("declaring the agent key changed the rendered file:\n got %q\nwant %q", withAgent, withoutAgent)
+	}
+}
+
+// TestRenderSeedSigners_OmitsImplicitAgentKey is the property admission rests
+// on: the seed file must contain only what config declared, so an
+// agent-founded root cannot admit itself.
+func TestRenderSeedSigners_OmitsImplicitAgentKey(t *testing.T) {
+	t.Parallel()
+	got, err := RenderSeedSigners([]TrustedSigner{{Principal: "alice@example.com", PublicKey: testAliceKey}})
+	if err != nil {
+		t.Fatalf("RenderSeedSigners() = %v, want nil", err)
+	}
+	if strings.Contains(got, AgentPrincipal) {
+		t.Fatalf("RenderSeedSigners() = %q, want no implicit %s line", got, AgentPrincipal)
+	}
+	if !strings.Contains(got, "alice@example.com") {
+		t.Fatalf("RenderSeedSigners() = %q, want the declared seed", got)
+	}
+}
+
+// TestRenderSeedSigners_KeepsDeclaredAgentKey confirms the agent is entitled
+// where — and only where — config says so.
+func TestRenderSeedSigners_KeepsDeclaredAgentKey(t *testing.T) {
+	t.Parallel()
+	got, err := RenderSeedSigners([]TrustedSigner{{Principal: AgentPrincipal, PublicKey: testAgentKey}})
+	if err != nil {
+		t.Fatalf("RenderSeedSigners() = %v, want nil", err)
+	}
+	if !strings.Contains(got, AgentPrincipal) {
+		t.Fatalf("RenderSeedSigners() = %q, want the declared agent seed", got)
 	}
 }
 
@@ -199,7 +249,12 @@ func TestSeedAllowedSignersWritesOnceAndThenLeavesTheRootAlone(t *testing.T) {
 	}
 	dir := t.TempDir()
 	signer := testSigner(t)
-	ops := []TrustedSigner{{Principal: "alice@example.com", PublicKey: testAliceKey, Comment: "Alice laptop"}}
+	// The agent signs the birth commit, so it has to be among the keys
+	// entitled to establish the root or the root is born inadmissible.
+	ops := []TrustedSigner{
+		{Principal: AgentPrincipal, PublicKey: signer.PublicKey()},
+		{Principal: "alice@example.com", PublicKey: testAliceKey, Comment: "Alice laptop"},
+	}
 	s, err := NewWithOptions(dir, signer, slog.Default(), Options{SeedSigners: ops})
 	if err != nil {
 		t.Fatalf("NewWithOptions: %v", err)

--- a/internal/platform/provenance/git.go
+++ b/internal/platform/provenance/git.go
@@ -42,6 +42,22 @@ func (s *Store) BootstrapBirthCommit(ctx context.Context) error {
 		return nil
 	}
 
+	// The commit about to be created is this root's birth, and it will carry
+	// the agent's signature. If the declared seed set does not include the
+	// agent key, the root is inadmissible from its very first commit — a
+	// state no later commit can repair, because the birth is the thing being
+	// judged. Refuse while the repository is still empty and the remedy is a
+	// config line rather than a history rewrite.
+	if len(s.seedSigners) > 0 {
+		admits, err := seedsInclude(s.seedSigners, s.signer.PublicKey())
+		if err != nil {
+			return fmt.Errorf("birth commit: %w", err)
+		}
+		if !admits {
+			return fmt.Errorf("birth commit: this root's seed signers do not include the agent key, so the commit it is about to sign could never be admitted; declare %s with the agent's public key in this root's seed_signers, or establish the root by hand with a commit signed by a declared seed", AgentPrincipal)
+		}
+	}
+
 	gitignorePath := filepath.Join(s.path, ".gitignore")
 	if _, err := os.Stat(gitignorePath); err != nil {
 		if !errors.Is(err, os.ErrNotExist) {


### PR DESCRIPTION
## Summary

Verification asked the wrong question first. It checked whether a commit was signed by a key in the root's own `.allowed_signers` — a question the root gets to answer about itself, since whoever wrote that file also chose what it says. Nothing consulted the seed signers config declares, so a repository could arrive with any history at all and vouch for it. #1264's first rule, that a root's birth must be attributable, was written down and unimplemented.

This adds the check that runs before the others: `provenance.VerifyAdmission`. A root's single parentless commit must be signed by a declared seed signer, and every later commit touching `.allowed_signers` must be too. Verification runs against a rendered seed-only file rather than the in-tree one, so a commit that added a key cannot be validated by the entry it introduced.

## The rules, and one that is deliberately too strict

Keys the trust file delegates to may sign ordinary content. Only a seed signer may widen the trust file itself. That forbids a legitimate pattern — a collaborator admitting the next collaborator — and it is a real cost, not a hidden one. It is also visible and recoverable the moment it bites, where a permissive delegation chain that turns out to be unsound is neither. The historical walk a transitive model needs is deferred until the strict rule actually hurts.

The consequence worth naming: this deletes the "expensive historical walk" #1264 anticipated. With no chain to follow, admission is a fixed number of `verify-commit` calls — one for the birth, one per trust-file change. On production's largest root that is two checks across 4,360 commits.

## The agent stops being implicitly entitled

`RenderAllowedSigners` used to refuse any entry naming the agent's own key, on the grounds that it is trusted implicitly. Under admission that refusal is the wrong shape: a root Thane creates is *born* signed by the agent, so if the agent can never be declared, no agent-founded root can ever be admitted.

So the agent key becomes declarable under its own principal, and the seed file omits the implicit agent line entirely. Declaring `thane@provenance.local` is how an agent-founded root is admitted; omitting it is how an instance says its own agent may not establish the root that holds its config. That is the hardening property from #1264 turning into a config expression rather than a code path.

The failure this creates has to be caught early, because a birth is the one thing no later commit can repair. `BootstrapBirthCommit` now refuses to create a root whose seeds do not include the agent, while the repository is still empty and the remedy is a config line rather than a history rewrite. Two existing tests were creating exactly that state — a root with an operator seed and an agent-signed birth — and now declare their founder honestly.

## Failure behavior

Admission maps onto the root's existing `verify_signatures` policy: `required` refuses to construct the root, `warn` logs and continues. Reusing that rather than inventing a second policy keeps one answer to "how strict is this root".

It runs *ahead* of the existing HEAD check. `VerifyHead` asks whether the tip is signed by a key the root already trusts; admission asks whether the root was entitled to arrive at that trust set at all. Reporting a passing HEAD for a root with an unattributed birth would answer the smaller question and hide the larger one. The refusal names which check failed, since the two are repaired differently — a failed HEAD check is usually a malformed signer line, a failed admission is a history and a config that disagree about who founded this corpus.

Because the most likely refusal by far is an agent-founded root at an instance that did not declare the agent, the error carries the attribution: it names the principal git says signed the birth, and says what to declare. That diagnostic reads the in-tree file, never the verdict — the verdict is decided against the seed file alone.

## Every git-backed root, not only the ones we write to

Admission first landed inside the writer, so it ran only where this instance signs commits. A root declaring `git.enabled` and `verify_signatures` but not `sign_commits` — a corpus Thane reads and verifies but never writes to — got a verifier and no admission check at all. That is the shape where the check matters most: such a root's history was produced entirely elsewhere, so falling back to the in-tree file means trusting exactly the self-vouching record this PR exists to stop trusting.

It now runs once per root in the dispatch, between the writer and the verifier. After the writer, because a root Thane creates has no history to judge until `BootstrapBirthCommit` has made one; before the verifier, because a verifier built over an unattributed history is the thing being prevented. `checkout.Signed.VerifyAdmission` goes away along with its retained seed set — admission is a question about a repository and a config, not about whether we happen to hold a writer for it.

Resolving a root's backing repository was already duplicated between the writer and the verifier, and admission would have made a third copy of it. It is now one helper, and both it and admission live in their own file: the additions took `document_roots.go` past the 500-line architecture threshold, and moving the trust plumbing out reads better than raising the baseline.

## Production migration — this is deploy-blocking for `kb` and `projects`

Verified against the live roots by replicating exactly what admission does (a seed-only trust file holding the declared operator key, then `verify-commit` on each root commit):

| Root | Root commit | Signed by | Verdict |
|---|---|---|---|
| `core` | `08eb7e953a6e` | `contact@nugget.info` | **ADMITTED** |
| `knowledge` | `7c939f595ac9` | `thane@provenance.local` | **REFUSED** |
| `projects` | `a5b88ad08b45` | `thane@provenance.local` | **REFUSED** |

`kb` and `projects` were founded by the agent and both had their trust file amended by the agent as well (`projects` via the old `reconcile allowed_signers` writer). Production declares only `contact@nugget.info` as their seed, so both fail admission once this lands.

The fix is a config change, not a history rewrite: add `thane@provenance.local` with the agent's public key to `roots.kb.seed_signers` and `roots.projects.seed_signers`. That is the honest statement of what happened — the agent did found those roots. Rewriting 4,360 commits behind a bidirectional remote to make an operator the founder is the alternative, and it is not a good one.

`core` needs nothing. It was re-established by hand this session with an operator-signed birth, which is exactly the shape that lets it omit the agent from its seed set — so the agent cannot establish or re-establish the root holding the config.

## What this does not do

- **Seeds are not yet a permanent floor.** Content verification still resolves from the in-tree file alone, so a seed signer removed from it can no longer sign. The recovery guarantee in #1264 needs verification-time composition of seed + in-tree, which is a separate change to how the `Store` and `Verifier` resolve their trust surface.
- **`thane init` still declares no seed signers at all**, so a fresh instance's core is not admitted against anything — #1264's third open question, untouched here.

## Documentation

`docs/understanding/document-roots.md` gains the operator account: the three rules, why they are checked against a rendered seed-only file, why strict delegation is the sound choice rather than the lazy one, how to declare the agent for a root it founded, and what a refusal looks like with the fix. It also corrects a line that had gone stale — amending `.allowed_signers` was described as "a change signed by a key the root already trusts", which strict delegation no longer allows.

`docs/understanding/trust-architecture.md` gets the structural summary alongside the other implemented enforcement, and `docs/operating/configuration.md`'s account of `.allowed_signers` is brought up to date.

## `thane validate` reports it

Validate is documented as the pre-flight check for serve, so it has to fail on everything serve refuses over. Admission was not among them, which meant an operator could read a clean report and then watch the instance refuse to start — in exactly the deploy scripts that trust validate most.

It now reports admission per root and exits non-zero when a root under `verify_signatures: required` would be refused. A root under `warn` is reported without affecting the exit code, because serve logs those and starts; validate must not invent strictness the gate does not have.

```
✓ Root admission: core, kb, projects
```

The real risk in this shape is two code paths that agree today and drift tomorrow, so the report re-derives nothing: boot and validate share the enumeration, the policy derivation, the eligibility predicate, and the check. The only remaining difference is deliberate — validate creates nothing, so a signing root whose directory does not exist yet is absent from the report rather than called unadmitted, since serve would create and birth-commit it.

**That drift was not hypothetical, and the first version of this had it.** `core` carries policy under `roots.core` but never a path; boot derives it into `cfg.Paths` before building its resolver. Reporting from the config as loaded therefore covered every root *except* the one holding the config — and reported success while doing it, against production, where it printed `✓ Root admission: kb, projects`. The derivation is now one function both paths call.

The guard is a test rather than a runtime flag. Making validate call `buildDocumentStoreOptions` outright would close the gap completely, but that path mkdirs roots, runs `git init`, rewrites `.git/config`, and can create a birth commit; a no-mutate mode threaded through `checkout` and `provenance` would add a second behavior to the write path, where a bug would make validate lie about the very thing it certifies. So the trap lives in a test that drives *both* real paths over the same repository and asserts they agree — and it was verified to fail by injecting a plausible divergence before being kept.

## Diagnosing the failure that actually happened

Two error paths conflated "git could not read this" with "there is nothing here", and both produced a diagnosis whose repair is wrong.

`rootCommits` treated any `rev-parse --verify HEAD` failure as an unborn HEAD, so a path that was not a repository — or was one git refused to read — surfaced as "no commit history, so its birth cannot be attributed". The three cases are now distinct, and only a genuine unborn HEAD becomes that finding.

The same conflation lived in `coreintegrity.coreRepository`, where it was worse: every unreadable core reported "core is not a git repository" with `git init` as the fix, and running that on a core whose `.git` is present abandons the history the gate exists to verify. **Production hit this today** — core's `.git` was owned by a different user than the one Thane runs as, git refused with `detected dubious ownership`, and the report said the repository did not exist and should be initialized. The history was intact the whole time; the fix was a `chown`. A core with a `.git` git will not read now carries git's own reason and a fix naming ownership, with an explicit warning not to run init. A core with no repository at all still gets init, which is correct for it.

## Test plan

- [x] `just ci` passes locally
- [x] Table-driven admission tests: seed-founded, agent-founded with and without the declaration, founded by a key only the in-tree file trusts, delegated content commits, trust file widened by a delegated key, trust file amended by a seed, grafted history with two births, no seeds declared, no commits
- [x] Regression guard that a root cannot admit itself by writing the founder into its own trust file in the very commit being judged
- [x] Born-inadmissible refusal, and its inverse — a root declaring the agent is founded and admitted
- [x] Verify-only root (`sign_commits: false`) refused when its founder is not a declared seed, and admitted over the same unchanged history once it is
- [x] Boot/validate agreement table across six root shapes, confirmed to fail when a divergence is injected
- [x] Reserved `core` root regression: founded, admitted, then refused by both paths when its seed set disagrees
- [x] `thane validate` against production reports `✓ Root admission: core, kb, projects`, exit 0
- [x] Unreadable/non-repository paths report git's reason rather than "no commit history"; unborn HEAD still does
- [x] `core_repository` advises init only when no repository exists, and warns against it when `.git` is present
- [x] `thane init` then `thane validate` on a fresh workspace still reports `✓ Core integrity`, exit 0
- [x] Admission replicated against the three live production roots (table above)

Refs #1264



