### PR TITLE
Tests that report the code, not the laptop

### DIFF
--- a/internal/app/main_test.go
+++ b/internal/app/main_test.go
@@ -1,0 +1,24 @@
+package app
+
+import (
+	"os"
+	"testing"
+)
+
+// TestMain detaches git from the developer's own configuration for every test
+// in this package.
+//
+// These tests create signed repositories and verify signatures, and both sides
+// read `gpg.ssh.program`. A developer whose global config points that at a
+// managed signer — 1Password's is the common one — hands it test keys it has
+// never seen, and the suite fails for reasons that have nothing to do with the
+// code. Ambient `commit.gpgsign`, hooks, and templates are the same class of
+// problem. Each test repository configures what it needs locally, so nothing
+// ambient should reach it.
+//
+// See internal/platform/provenance for the fuller account.
+func TestMain(m *testing.M) {
+	os.Setenv("GIT_CONFIG_GLOBAL", os.DevNull)
+	os.Setenv("GIT_CONFIG_SYSTEM", os.DevNull)
+	os.Exit(m.Run())
+}

--- a/internal/platform/checkout/main_test.go
+++ b/internal/platform/checkout/main_test.go
@@ -1,0 +1,24 @@
+package checkout
+
+import (
+	"os"
+	"testing"
+)
+
+// TestMain detaches git from the developer's own configuration for every test
+// in this package.
+//
+// These tests create signed repositories and verify signatures, and both sides
+// read `gpg.ssh.program`. A developer whose global config points that at a
+// managed signer — 1Password's is the common one — hands it test keys it has
+// never seen, and the suite fails for reasons that have nothing to do with the
+// code. Ambient `commit.gpgsign`, hooks, and templates are the same class of
+// problem. Each test repository configures what it needs locally, so nothing
+// ambient should reach it.
+//
+// See internal/platform/provenance for the fuller account.
+func TestMain(m *testing.M) {
+	os.Setenv("GIT_CONFIG_GLOBAL", os.DevNull)
+	os.Setenv("GIT_CONFIG_SYSTEM", os.DevNull)
+	os.Exit(m.Run())
+}

--- a/internal/platform/coreintegrity/main_test.go
+++ b/internal/platform/coreintegrity/main_test.go
@@ -1,0 +1,24 @@
+package coreintegrity
+
+import (
+	"os"
+	"testing"
+)
+
+// TestMain detaches git from the developer's own configuration for every test
+// in this package.
+//
+// These tests create signed repositories and verify signatures, and both sides
+// read `gpg.ssh.program`. A developer whose global config points that at a
+// managed signer — 1Password's is the common one — hands it test keys it has
+// never seen, and the suite fails for reasons that have nothing to do with the
+// code. Ambient `commit.gpgsign`, hooks, and templates are the same class of
+// problem. Each test repository configures what it needs locally, so nothing
+// ambient should reach it.
+//
+// See internal/platform/provenance for the fuller account.
+func TestMain(m *testing.M) {
+	os.Setenv("GIT_CONFIG_GLOBAL", os.DevNull)
+	os.Setenv("GIT_CONFIG_SYSTEM", os.DevNull)
+	os.Exit(m.Run())
+}

--- a/internal/platform/identity/main_test.go
+++ b/internal/platform/identity/main_test.go
@@ -1,0 +1,24 @@
+package identity
+
+import (
+	"os"
+	"testing"
+)
+
+// TestMain detaches git from the developer's own configuration for every test
+// in this package.
+//
+// These tests create signed repositories and verify signatures, and both sides
+// read `gpg.ssh.program`. A developer whose global config points that at a
+// managed signer — 1Password's is the common one — hands it test keys it has
+// never seen, and the suite fails for reasons that have nothing to do with the
+// code. Ambient `commit.gpgsign`, hooks, and templates are the same class of
+// problem. Each test repository configures what it needs locally, so nothing
+// ambient should reach it.
+//
+// See internal/platform/provenance for the fuller account.
+func TestMain(m *testing.M) {
+	os.Setenv("GIT_CONFIG_GLOBAL", os.DevNull)
+	os.Setenv("GIT_CONFIG_SYSTEM", os.DevNull)
+	os.Exit(m.Run())
+}

--- a/internal/platform/provenance/admission_test.go
+++ b/internal/platform/provenance/admission_test.go
@@ -51,6 +51,27 @@ func newAdmissionKey(t *testing.T, principal string) admissionKey {
 	}
 }
 
+// TestMain detaches every git invocation in this package from whatever
+// configuration the developer running the tests happens to have — both the
+// tests' own commits and the ones the code under test makes.
+//
+// These tests sign with git itself rather than through the Store, which is the
+// point: admission has to judge history an operator committed by hand, not
+// only history the agent wrote. But that means a global `gpg.ssh.program`
+// applies, and the common one is 1Password's signer, which gets handed a test
+// key it has never seen and refuses the commit. Verification reads the same
+// setting, so a machine configured that way fails on both sides. Ambient
+// `commit.gpgsign`, hooks, and commit templates are the same class of problem.
+//
+// Each test repository configures everything it needs locally, so the fix is
+// to let nothing else in. Without it the suite passes or fails according to
+// whose laptop it runs on, which is worse than either result on its own.
+func TestMain(m *testing.M) {
+	os.Setenv("GIT_CONFIG_GLOBAL", os.DevNull)
+	os.Setenv("GIT_CONFIG_SYSTEM", os.DevNull)
+	os.Exit(m.Run())
+}
+
 // admissionRepo is a git repository tests drive directly, so a commit can be
 // attributed to any key rather than only to the Store's own signer. Real roots
 // acquire history both ways — the agent writes through the Store, an operator


### PR DESCRIPTION
## Summary

`just ci` passed or failed according to whose machine it ran on. Tests across five packages create signed git repositories and verify signatures, and both operations read `gpg.ssh.program`. A developer whose global config points that at a managed signer — 1Password's is the common one — hands it freshly generated test keys it has never seen, and git refuses: `invalid ssh public key` when signing, `bad signature` when verifying.

Nothing about that is a finding. It reports the machine rather than the code, and it reports it as a wall of failures across packages the developer never touched, which is the most expensive possible way to say "your git config differs from mine".

## Why it went unnoticed

Claude Code sessions on this repo run with `GIT_CONFIG_GLOBAL` pointed at a dedicated config that sets no `gpg.ssh.program`, so the suite was hermetic there by accident and nowhere else. The failure is invisible from one side of the fence and total from the other.

It surfaced now because #1267 added tests that sign with **git itself** rather than through the `Store` — deliberately, since admission has to judge history an operator committed by hand, not only history the agent wrote. But the blast radius is wider than those tests: verification reads the same setting, so every package that checks a signature was already exposed. `internal/app`, `coreintegrity`, `identity`, and `checkout` were all failing too, on tests that predate this week.

## The fix

Each test repository already configures locally everything it needs, so nothing ambient should reach it. A `TestMain` per affected package points `GIT_CONFIG_GLOBAL` and `GIT_CONFIG_SYSTEM` at `/dev/null`, which also closes the door on ambient `commit.gpgsign`, hooks, and commit templates — a class the suite had begun defending against case by case, with scattered `-c commit.gpgsign=false` flags at individual call sites.

Doing it in `TestMain` rather than in a helper matters: it covers the git commands the *code under test* runs, not just the ones the tests run themselves. Verification failures came from the production path, so a helper wrapping only test invocations would have fixed signing and left verification broken.

## Worth a separate look

Thane signs commits through its own `sshsig` path but verifies by shelling out to `git verify-commit`, which honors `gpg.ssh.program`. On a machine configured with a managed signer, an instance can therefore fail to verify signatures it just wrote — fail-closed, but reported as `bad signature`, which points at the history rather than at the config. Production is unaffected (no such signer configured there), so this is not urgent, but the asymmetry is real and the diagnostic is misleading in exactly the way #1267 spent effort fixing elsewhere. Happy to file it.

## Test plan

- [x] Reproduced the reported failure with a global config setting `gpg.ssh.program`, matching the symptoms exactly
- [x] Confirmed five packages fail that way: `provenance`, `app`, `coreintegrity`, `identity`, `checkout`
- [x] Full `go test ./...` passes under that same hostile config
- [x] `just ci` passes normally