### PR TITLE
A signature check that configuration cannot reassign

### DIFF
--- a/internal/platform/provenance/admission_test.go
+++ b/internal/platform/provenance/admission_test.go
@@ -4,6 +4,7 @@ import (
 	"crypto/ed25519"
 	"crypto/rand"
 	"encoding/pem"
+	"fmt"
 	"log/slog"
 	"os"
 	"os/exec"
@@ -84,6 +85,13 @@ func (r *admissionRepo) git(args ...string) string {
 		r.t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), err, out)
 	}
 	return strings.TrimSpace(string(out))
+}
+
+// gitTry runs git and returns its error instead of failing the test, for the
+// cases where the exit status is itself what is being examined.
+func (r *admissionRepo) gitTry(args ...string) error {
+	r.t.Helper()
+	return exec.Command("git", append([]string{"-C", r.dir}, args...)...).Run()
 }
 
 // commitAs writes files and commits them signed by the given key.
@@ -398,6 +406,24 @@ func TestVerifyAdmissionDistinguishesUnreadableFromUnborn(t *testing.T) {
 	})
 }
 
+// swapSignersProgram is a gpg.ssh.program that delegates to the real
+// ssh-keygen but substitutes its own allowed-signers file. Rotating the
+// positional parameters preserves each argument exactly, so a path containing
+// spaces survives; only the value after -f is replaced.
+const swapSignersProgram = `#!/bin/sh
+swap=0
+n=$#
+i=0
+while [ $i -lt $n ]; do
+	a="$1"; shift
+	if [ "$swap" = 1 ]; then set -- "$@" '%s'; swap=0
+	elif [ "$a" = "-f" ]; then set -- "$@" "-f"; swap=1
+	else set -- "$@" "$a"; fi
+	i=$((i + 1))
+done
+exec ssh-keygen "$@"
+`
+
 // TestAdmissionIgnoresRepositoryConfiguredSignatureProgram proves the trust
 // decision cannot be reassigned by editing configuration.
 //
@@ -408,12 +434,22 @@ func TestVerifyAdmissionDistinguishesUnreadableFromUnborn(t *testing.T) {
 // could nominate its own judge, which is the same self-vouching that admission
 // exists to refuse, moved one level down.
 //
-// The attack here is the one that actually works: rather than forging
-// ssh-keygen's output, the configured program delegates to the real one and
-// swaps the allowed-signers file for its own. git then reports a genuinely
-// good signature by a key it was told to trust.
+// The attack is the one that actually works: rather than forging ssh-keygen's
+// output, the configured program delegates to the real one and swaps the
+// allowed-signers file for its own, so git reports a genuinely good signature
+// by a key it was handed.
+//
+// The two control assertions are the point of the test rather than decoration.
+// Admission refusing proves nothing on its own — it would refuse just as
+// readily if the wrapper were broken, /bin/sh were missing, or git had stopped
+// honoring the setting. So the test first shows the honest check refusing this
+// commit, then shows the wrapper turning that same check into a pass. Only
+// then does refusal by admission mean the pin is what did it.
 func TestAdmissionIgnoresRepositoryConfiguredSignatureProgram(t *testing.T) {
 	t.Parallel()
+	if _, err := exec.LookPath("sh"); err != nil {
+		t.Skip("sh not available")
+	}
 	operator := newAdmissionKey(t, "operator@example.com")
 	stranger := newAdmissionKey(t, "stranger@example.com")
 
@@ -423,17 +459,33 @@ func TestAdmissionIgnoresRepositoryConfiguredSignatureProgram(t *testing.T) {
 	})
 
 	dir := t.TempDir()
-	attackerSigners := filepath.Join(dir, "attacker_allowed")
-	if err := os.WriteFile(attackerSigners, []byte(stranger.principal+" "+stranger.publicKey+"\n"), 0o644); err != nil {
+	honest := filepath.Join(dir, "honest_allowed")
+	if err := os.WriteFile(honest, []byte(operator.principal+" "+operator.publicKey+"\n"), 0o644); err != nil {
+		t.Fatalf("write honest signers: %v", err)
+	}
+	attacker := filepath.Join(dir, "attacker_allowed")
+	if err := os.WriteFile(attacker, []byte(stranger.principal+" "+stranger.publicKey+"\n"), 0o644); err != nil {
 		t.Fatalf("write attacker signers: %v", err)
 	}
 	program := filepath.Join(dir, "swap-signers.sh")
-	script := "#!/bin/sh\nnew=\"\"\nnext=0\nfor a in \"$@\"; do\n  if [ \"$next\" = 1 ]; then new=\"$new " + attackerSigners + "\"; next=0; continue; fi\n  case \"$a\" in\n    -f) new=\"$new -f\"; next=1 ;;\n    *) new=\"$new $a\" ;;\n  esac\ndone\nexec ssh-keygen $new\n"
-	if err := os.WriteFile(program, []byte(script), 0o755); err != nil {
+	if err := os.WriteFile(program, fmt.Appendf(nil, swapSignersProgram, attacker), 0o755); err != nil {
 		t.Fatalf("write program: %v", err)
 	}
-	repo.git("config", "gpg.ssh.program", program)
 
+	// Control: honestly checked, this birth is signed by a key the trust set
+	// does not name, and git refuses it.
+	if err := repo.gitTry("-c", "gpg.ssh.allowedSignersFile="+honest, "verify-commit", "HEAD"); err == nil {
+		t.Fatal("control failed: an untrusted birth verified without the wrapper")
+	}
+	// Control: the wrapper turns that refusal into a pass, so the bypass this
+	// test guards against is live and the assertion below can attribute a
+	// refusal to the pin rather than to a broken fixture.
+	if err := repo.gitTry("-c", "gpg.ssh.allowedSignersFile="+honest,
+		"-c", "gpg.ssh.program="+program, "verify-commit", "HEAD"); err != nil {
+		t.Fatalf("control failed: the wrapper did not forge a passing verification, so this test proves nothing: %v", err)
+	}
+
+	repo.git("config", "gpg.ssh.program", program)
 	if _, err := VerifyAdmission(t.Context(), repo.dir, []TrustedSigner{operator.signer()}); err == nil {
 		t.Fatal("a root that configured its own signature program was admitted")
 	}

--- a/internal/platform/provenance/admission_test.go
+++ b/internal/platform/provenance/admission_test.go
@@ -397,3 +397,44 @@ func TestVerifyAdmissionDistinguishesUnreadableFromUnborn(t *testing.T) {
 		}
 	})
 }
+
+// TestAdmissionIgnoresRepositoryConfiguredSignatureProgram proves the trust
+// decision cannot be reassigned by editing configuration.
+//
+// `gpg.ssh.program` names the executable git asks whether a signature is good,
+// and a repository's own .git/config can set it. That file lives inside the
+// root being judged, writable by anything with filesystem access — including
+// this agent wherever shell access is enabled. If admission honored it, a root
+// could nominate its own judge, which is the same self-vouching that admission
+// exists to refuse, moved one level down.
+//
+// The attack here is the one that actually works: rather than forging
+// ssh-keygen's output, the configured program delegates to the real one and
+// swaps the allowed-signers file for its own. git then reports a genuinely
+// good signature by a key it was told to trust.
+func TestAdmissionIgnoresRepositoryConfiguredSignatureProgram(t *testing.T) {
+	t.Parallel()
+	operator := newAdmissionKey(t, "operator@example.com")
+	stranger := newAdmissionKey(t, "stranger@example.com")
+
+	repo := newAdmissionRepo(t)
+	repo.commitAs(stranger, "birth", map[string]string{
+		TrustFileName: trustFile(stranger, operator),
+	})
+
+	dir := t.TempDir()
+	attackerSigners := filepath.Join(dir, "attacker_allowed")
+	if err := os.WriteFile(attackerSigners, []byte(stranger.principal+" "+stranger.publicKey+"\n"), 0o644); err != nil {
+		t.Fatalf("write attacker signers: %v", err)
+	}
+	program := filepath.Join(dir, "swap-signers.sh")
+	script := "#!/bin/sh\nnew=\"\"\nnext=0\nfor a in \"$@\"; do\n  if [ \"$next\" = 1 ]; then new=\"$new " + attackerSigners + "\"; next=0; continue; fi\n  case \"$a\" in\n    -f) new=\"$new -f\"; next=1 ;;\n    *) new=\"$new $a\" ;;\n  esac\ndone\nexec ssh-keygen $new\n"
+	if err := os.WriteFile(program, []byte(script), 0o755); err != nil {
+		t.Fatalf("write program: %v", err)
+	}
+	repo.git("config", "gpg.ssh.program", program)
+
+	if _, err := VerifyAdmission(t.Context(), repo.dir, []TrustedSigner{operator.signer()}); err == nil {
+		t.Fatal("a root that configured its own signature program was admitted")
+	}
+}

--- a/internal/platform/provenance/allowed_signers.go
+++ b/internal/platform/provenance/allowed_signers.go
@@ -259,7 +259,8 @@ func (s *Store) writeAllowedSigners(ctx context.Context, operators []TrustedSign
 func (s *Store) VerifyHead(ctx context.Context) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if err := s.git(ctx, nil, nil, "verify-commit", "HEAD"); err != nil {
+	args := append(signatureTrustArgs(), "verify-commit", "HEAD")
+	if err := s.git(ctx, nil, nil, args...); err != nil {
 		return fmt.Errorf("verify HEAD against allowed_signers: %w", err)
 	}
 	return nil

--- a/internal/platform/provenance/signer.go
+++ b/internal/platform/provenance/signer.go
@@ -3,6 +3,7 @@ package provenance
 import (
 	"context"
 	"fmt"
+	"os/exec"
 	"strings"
 )
 
@@ -114,13 +115,45 @@ func signerKind(principal string) string {
 	}
 }
 
+// sshKeygenProgram is the executable git is told to use for SSH signature
+// operations, resolved once rather than left to configuration.
+//
+// Resolution still consults PATH, which is not a boundary against someone who
+// controls the process environment — but such a person could replace the thane
+// binary itself, so it is not an escalation. Configuration is a different
+// matter: it is ordinary writable state, in the operator's home directory or
+// inside the very repository being judged.
+var sshKeygenProgram = func() string {
+	if resolved, err := exec.LookPath("ssh-keygen"); err == nil {
+		return resolved
+	}
+	return "ssh-keygen"
+}()
+
+// signatureTrustArgs pins the configuration that decides whether a signature
+// is good, overriding whatever the system, global, and repository config files
+// say.
+//
+// `gpg.ssh.program` names the executable git consults to answer that question,
+// and `gpg.format` selects the scheme. Both are writable by anything with
+// filesystem access — including this agent, wherever shell access is enabled —
+// so leaving them to configuration means the verdict of the trust gate can be
+// redirected by editing a file. A gate whose answer can be reassigned that way
+// is not a gate. These flags are passed with -c, which takes precedence over
+// every config file, so a repo-local .git/config inside an untrusted root
+// cannot reach the decision.
+func signatureTrustArgs() []string {
+	return []string{"-c", "gpg.format=ssh", "-c", "gpg.ssh.program=" + sshKeygenProgram}
+}
+
 // runGitTextVerify runs a read-only git command with SSH signature
 // verification enabled: it injects the allowed_signers file when one is
 // configured (a verify-only Verifier), and otherwise relies on the repo-local
 // git config a Store already set at init.
 func runGitTextVerify(ctx context.Context, repoPath, allowedSignersPath string, args ...string) (string, error) {
+	prefix := signatureTrustArgs()
 	if strings.TrimSpace(allowedSignersPath) != "" {
-		args = append([]string{"-c", "gpg.ssh.allowedSignersFile=" + allowedSignersPath}, args...)
+		prefix = append(prefix, "-c", "gpg.ssh.allowedSignersFile="+allowedSignersPath)
 	}
-	return runGitText(ctx, repoPath, args...)
+	return runGitText(ctx, repoPath, append(prefix, args...)...)
 }

--- a/internal/platform/provenance/signer.go
+++ b/internal/platform/provenance/signer.go
@@ -147,9 +147,14 @@ func signatureTrustArgs() []string {
 }
 
 // runGitTextVerify runs a read-only git command with SSH signature
-// verification enabled: it injects the allowed_signers file when one is
-// configured (a verify-only Verifier), and otherwise relies on the repo-local
-// git config a Store already set at init.
+// verification enabled.
+//
+// The two halves of "is this signature good" are treated differently on
+// purpose. What decides — the format and the program — is always pinned here
+// and never taken from configuration. Who counts — the allowed_signers file —
+// is injected when the caller names one (a verify-only Verifier), and
+// otherwise left to the repo-local config a Store set at init, since a Store
+// owns the repository it is verifying.
 func runGitTextVerify(ctx context.Context, repoPath, allowedSignersPath string, args ...string) (string, error) {
 	prefix := signatureTrustArgs()
 	if strings.TrimSpace(allowedSignersPath) != "" {

--- a/internal/platform/provenance/verify.go
+++ b/internal/platform/provenance/verify.go
@@ -229,8 +229,13 @@ func failedVerification(commit string, message string) (VerificationResult, erro
 
 func (v *Verifier) gitOutput(ctx context.Context, verify bool, args ...string) (string, error) {
 	cmdArgs := []string{"-C", v.path}
-	if verify && v.allowedSignersPath != "" {
-		cmdArgs = append(cmdArgs, "-c", "gpg.ssh.allowedSignersFile="+v.allowedSignersPath)
+	if verify {
+		// Pin what decides the signature before naming who may sign it;
+		// see signatureTrustArgs for why this cannot be left to config.
+		cmdArgs = append(cmdArgs, signatureTrustArgs()...)
+		if v.allowedSignersPath != "" {
+			cmdArgs = append(cmdArgs, "-c", "gpg.ssh.allowedSignersFile="+v.allowedSignersPath)
+		}
 	}
 	cmdArgs = append(cmdArgs, args...)
 	cmd := exec.CommandContext(ctx, "git", cmdArgs...)


### PR DESCRIPTION
## Summary

git resolves SSH signature verification through `gpg.ssh.program`. That setting is ordinary writable state — in the operator's home directory, or in the `.git/config` of the very repository being judged. Thane pinned `gpg.ssh.allowedSignersFile` with `-c`, so it controlled *who counts as a signer*, but left unpinned *the program that decides whether a signature is good at all*. We overrode the answer and not the judge.

## The bypass is real, and needs no forgery

I tried twice to fake `ssh-keygen`'s output and failed both times, which nearly led me to report this as theoretical. It isn't — the working attack doesn't forge anything. A configured program that **delegates to the real `ssh-keygen` while swapping the `-f` allowed-signers file** produces a genuinely valid verification against a key of the attacker's choosing:

```
$ git -c gpg.ssh.allowedSignersFile=allowed -c gpg.ssh.program=./swap.sh verify-commit HEAD
Good "git" signature for attacker@example.com with ED25519 key SHA256:xMRXUFir…
exit 0
```

That commit is signed by a key absent from `allowed`. Honest verification exits 1 on it. Confirmed against git 2.55.

This matters here specifically because the repositories being verified are exactly the ones an attacker would be writing to, and because the agent itself can write files wherever `shell_exec` is enabled — the "steered by a poisoned document" case #1264 was built around. A gate whose verdict can be reassigned by editing a config file *inside the thing it is judging* is not a gate.

## The fix

Verification now passes `-c gpg.format=ssh -c gpg.ssh.program=<resolved ssh-keygen>`, which takes precedence over system, global, and repo-local config alike. Applied at all three verification seams: `runGitTextVerify`, the `Verifier`'s git path, and `Store.VerifyHead`.

PATH is still consulted to resolve the program. That is not a boundary against someone who controls the process environment — but such a person could replace the `thane` binary instead, so it is not an escalation. Config is different in kind: it is writable without any privilege at all.

## About the test

The regression test installs the working attack as repo-local config and asserts admission still refuses. **It was verified to fail without the fix.** An earlier version of it passed with *and* without, because the hand-forged approver never satisfied `ssh-keygen`'s protocol — it proved nothing while looking like proof. Worth stating plainly, since a security test that cannot fail is worse than none.

## What this does not do

Verification still runs *through* git, so the remaining exposure is substitution rather than forgery: a malicious `git` binary cannot produce content signed by a key it lacks, but it can replay a genuinely-signed older commit as HEAD, or simply answer `status --porcelain` with "clean" while the worktree holds attacker content. The signature binds to the commit object; the bytes we actually read come from the filesystem, and the link between them is git's assertion.

Closing that means moving the decision in-process — parsing the commit's `gpgsig` header and verifying the sshsig ourselves. We already own half of it: `sshsigSign` implements `PROTOCOL.sshsig` natively against `golang.org/x/crypto/ssh`, so signing never consults an external program. Only verification does, which is backwards.

I deliberately did **not** bundle that here. Native verification means reimplementing `allowed_signers` semantics, including the `valid-after` / `valid-before` options our own renderer emits — and a parser that silently ignored a validity window would accept expired keys, which is strictly worse than today. That deserves its own change and its own review, not the tail of a long session.

## Test plan

- [x] Reproduced the bypass end to end against git 2.55: untrusted commit verified `Good`, exit 0
- [x] Regression test asserting admission refuses a root that configures its own signature program
- [x] Confirmed that test **fails** with the pin removed
- [x] `just ci` passes

Refs #787, #1264