### PR TITLE
Seed signers that a repository cannot withdraw

### DIFF
--- a/cmd/thane/main.go
+++ b/cmd/thane/main.go
@@ -454,6 +454,7 @@ func gateOnCoreIntegrity(ctx context.Context, logger *slog.Logger, cfg *config.C
 	}
 	report, err := coreintegrity.Run(ctx, cfg.Workspace.Path, coreintegrity.Options{
 		ConfigFileName: config.ConfigFileName,
+		SeedSigners:    app.CoreSeedSigners(cfg),
 	})
 	if err != nil {
 		return fmt.Errorf("check core integrity: %w", err)

--- a/cmd/thane/validate.go
+++ b/cmd/thane/validate.go
@@ -201,6 +201,7 @@ func checkCoreIntegrity(cfg *config.Config, configPath, workspacePath string) *c
 	}
 	report, err := coreintegrity.Run(context.Background(), workspace, coreintegrity.Options{
 		ConfigFileName: config.ConfigFileName,
+		SeedSigners:    app.CoreSeedSigners(cfg),
 	})
 	if err != nil {
 		return nil

--- a/internal/app/document_root_admission.go
+++ b/internal/app/document_root_admission.go
@@ -209,3 +209,23 @@ func CheckRootAdmission(ctx context.Context, cfg *config.Config) []RootAdmission
 	}
 	return out
 }
+
+// CoreSeedSigners returns the seed set declared for the core root.
+//
+// Core integrity is checked before — and sometimes instead of — building
+// document roots, so it cannot reach the per-root wiring that hands every
+// other root its seeds. Without this the seed floor would hold for every root
+// except the one holding the config, which is the root an operator most needs
+// to be able to repair.
+func CoreSeedSigners(cfg *config.Config) []provenance.TrustedSigner {
+	if cfg == nil {
+		return nil
+	}
+	for name, rootCfg := range cfg.DocRoots {
+		if strings.TrimSuffix(strings.TrimSpace(name), ":") != "core" {
+			continue
+		}
+		return buildTrustedSigners(rootCfg.SeedSigners, rootCfg.Git.AllowedSigners)
+	}
+	return nil
+}

--- a/internal/app/document_roots.go
+++ b/internal/app/document_roots.go
@@ -192,7 +192,7 @@ func (a *App) buildDocumentStoreOptions(documentRoots map[string]string, resolve
 
 		var verifier *documentRootProvenanceVerifier
 		if policy.Git.Enabled && policy.Git.VerifySignatures != documents.VerificationNone {
-			v, err := a.newDocumentRootProvenanceVerifier(root, rootPath, rootCfg.Git, resolver)
+			v, err := a.newDocumentRootProvenanceVerifier(root, rootPath, rootCfg, resolver)
 			if err != nil {
 				if policy.Git.VerifySignatures == documents.VerificationRequired {
 					return documents.StoreOptions{}, fmt.Errorf("doc_roots.%s verify_signatures=required but verifier unavailable: %w", root, err)
@@ -380,7 +380,8 @@ func (a *App) newDocumentRootProvenanceWriter(root, rootPath string, rootCfg con
 	return &documentRootProvenanceWriter{checkout: signed}, nil
 }
 
-func (a *App) newDocumentRootProvenanceVerifier(root, rootPath string, gitCfg config.DocumentRootGitConfig, resolver *paths.Resolver) (*documentRootProvenanceVerifier, error) {
+func (a *App) newDocumentRootProvenanceVerifier(root, rootPath string, rootCfg config.DocumentRootConfig, resolver *paths.Resolver) (*documentRootProvenanceVerifier, error) {
+	gitCfg := rootCfg.Git
 	absRepoPath, absRootPath, err := resolveRootPaths(root, rootPath, gitCfg, resolver)
 	if err != nil {
 		return nil, err
@@ -393,6 +394,7 @@ func (a *App) newDocumentRootProvenanceVerifier(root, rootPath string, gitCfg co
 		Name:         "doc_roots." + root + ".git",
 		WorktreePath: absRootPath,
 		RepoPath:     absRepoPath,
+		SeedSigners:  buildTrustedSigners(rootCfg.SeedSigners, gitCfg.AllowedSigners),
 		Logger:       logger.With("component", "document_root_verifier", "root", root),
 	})
 	if err != nil {

--- a/internal/platform/checkout/verify.go
+++ b/internal/platform/checkout/verify.go
@@ -22,6 +22,10 @@ type VerifySpec struct {
 	// RepoPath optionally points at the backing git repository. Empty means the
 	// worktree path itself is the repository.
 	RepoPath string
+	// SeedSigners are the keys entitled to establish this root. They remain
+	// able to sign it permanently, so verification falls back to them when the
+	// root's own trust file does not vouch for a commit.
+	SeedSigners []provenance.TrustedSigner
 	// Logger receives setup logs. Nil uses slog.Default.
 	Logger *slog.Logger
 }
@@ -65,7 +69,7 @@ func OpenVerified(ctx context.Context, spec VerifySpec) (*Verified, error) {
 	if err := ConfigureRepoLocalAllowedSigners(ctx, name, root.RepoPath, logger); err != nil {
 		return nil, err
 	}
-	verifier, err := provenance.NewVerifier(root.RepoPath, logger, provenance.Options{})
+	verifier, err := provenance.NewVerifier(root.RepoPath, logger, provenance.Options{SeedSigners: spec.SeedSigners})
 	if err != nil {
 		return nil, fmt.Errorf("%s: initialize verifier: %w", name, err)
 	}

--- a/internal/platform/coreintegrity/coreintegrity.go
+++ b/internal/platform/coreintegrity/coreintegrity.go
@@ -4,13 +4,17 @@
 // no uncommitted changes to tracked files.
 //
 // Signature verification resolves signers from core's own
-// .allowed_signers. That is sufficient while core has no remote: an
-// attacker who can rewrite the signer list already has local write
-// access and does not need to forge anything. It stops being sufficient
-// the moment core syncs from somewhere, because then someone who can
-// push could rewrite the config and the list of who may sign it in one
-// commit — so an out-of-tree anchor is a prerequisite for giving core a
-// remote, not for this check.
+// .allowed_signers, plus the seed signers config declares for core. The
+// seed set is the out-of-tree anchor: it lives in configuration rather
+// than in the repository being judged, so a commit signed by a seed is
+// trusted whether or not core's own trust file still lists it. That is
+// what keeps a polluted trust file from locking out the operator
+// entitled to repair it.
+//
+// The seed set is absent when the config could not be loaded, and then
+// the in-tree file is the only answer available — which is the right
+// degradation, since these checks exist partly to explain why a config
+// would not load.
 //
 // The checks live here rather than inside the boot path so one
 // definition serves both `thane validate`, which reports, and the boot
@@ -125,6 +129,20 @@ func gitignoreKeyMaterialLines() []string {
 type Options struct {
 	// ConfigFileName is the runtime config's name inside core.
 	ConfigFileName string
+
+	// SeedSigners are the keys config declares entitled to establish core.
+	// They remain able to sign it permanently, so a config commit signed by
+	// one is trusted even when core's own trust file has stopped listing it.
+	//
+	// Without this the floor would hold everywhere except the root that needs
+	// it most: a polluted trust file in core would fail config_signed, serve
+	// would refuse, and the operator entitled to repair core would be locked
+	// out of the instance by the very key that entitles them.
+	//
+	// Empty is normal rather than exceptional — these checks must also run when
+	// the config could not be loaded at all, and then there is no declared seed
+	// set to consult and the in-tree file is the only answer available.
+	SeedSigners []provenance.TrustedSigner
 }
 
 // Run evaluates every core integrity requirement for a workspace and
@@ -148,7 +166,7 @@ func Run(ctx context.Context, workspace string, opts Options) (Report, error) {
 		ConfigPath: filepath.Join(corePath, configName),
 	}
 
-	c := checker{ctx: ctx, core: corePath, configName: configName}
+	c := checker{ctx: ctx, core: corePath, configName: configName, seedSigners: opts.SeedSigners}
 
 	// Every check appears in every report, including the ones a failed
 	// prerequisite made unrunnable. A check that vanishes is
@@ -166,9 +184,10 @@ func Run(ctx context.Context, workspace string, opts Options) (Report, error) {
 }
 
 type checker struct {
-	ctx        context.Context
-	core       string
-	configName string
+	ctx         context.Context
+	core        string
+	configName  string
+	seedSigners []provenance.TrustedSigner
 }
 
 func (c checker) git(args ...string) (string, error) {
@@ -364,7 +383,7 @@ func (c checker) configSigned(r *Report, configOK bool) {
 		return
 	}
 
-	verifier, err := provenance.NewVerifier(c.core, slog.New(slog.DiscardHandler), provenance.Options{})
+	verifier, err := provenance.NewVerifier(c.core, slog.New(slog.DiscardHandler), provenance.Options{SeedSigners: c.seedSigners})
 	if err != nil {
 		r.Checks = append(r.Checks, Check{Name: "config_signed", Status: StatusFail,
 			Detail: "cannot resolve the trusted signer set: " + err.Error(),

--- a/internal/platform/coreintegrity/coreintegrity_test.go
+++ b/internal/platform/coreintegrity/coreintegrity_test.go
@@ -7,13 +7,15 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/nugget/thane-ai-agent/internal/platform/provenance"
 )
 
 // signCore gives a core repository an SSH signing identity and the
 // matching .allowed_signers, so commits made afterwards verify the way
 // a real instance's do. Returns nothing: every later commit in the test
 // is signed by construction.
-func signCore(t *testing.T, dir string) {
+func signCore(t *testing.T, dir string) string {
 	t.Helper()
 	keyPath := filepath.Join(t.TempDir(), "signing_ed25519")
 	cmd := exec.Command("ssh-keygen", "-q", "-t", "ed25519", "-N", "", "-C", "test@example.com", "-f", keyPath)
@@ -39,6 +41,7 @@ func signCore(t *testing.T, dir string) {
 			t.Fatalf("git %v: %v\n%s", args, err, out)
 		}
 	}
+	return strings.TrimSpace(string(pub))
 }
 
 func gitInit(t *testing.T, dir string) {
@@ -440,4 +443,55 @@ func TestCoreRepositoryDistinguishesUnreadableFromAbsent(t *testing.T) {
 			t.Fatalf("detail should say git could not read the repository, got %q", check.Detail)
 		}
 	})
+}
+
+// TestConfigSignedFallsBackToSeedSigners is the seed floor applied to core.
+//
+// Everywhere else, a seed signer keeps its authority over a root no matter what
+// the root's own trust file later says. Core has to behave the same way or the
+// guarantee inverts exactly where it matters most: a trust file that stopped
+// listing the operator would fail config_signed, serve would refuse, and the
+// person entitled to repair core would be locked out of the instance by the
+// very key that entitles them.
+func TestConfigSignedFallsBackToSeedSigners(t *testing.T) {
+	t.Parallel()
+
+	workspace, core := newCore(t)
+	gitInit(t, core)
+	publicKey := signCore(t, core)
+	if err := os.WriteFile(filepath.Join(core, ".gitignore"), []byte("*.key\n"), 0o644); err != nil {
+		t.Fatalf("write gitignore: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(core, "config.yaml"), []byte("listen:\n  port: 8080\n"), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	gitCommitAll(t, core, "adopt config into core")
+
+	// The trust file stops listing the key that signed everything here. The
+	// edit is itself signed by that key, so this is a legitimate operation
+	// rather than an attack — the question is what happens to the signer's
+	// authority afterwards.
+	if err := os.WriteFile(filepath.Join(core, ".allowed_signers"), []byte("someone-else@example.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGYFzshHIX3K8OkSRKXRsSNyYDH7zAatbEFX7dW74evA\n"), 0o644); err != nil {
+		t.Fatalf("rewrite allowed signers: %v", err)
+	}
+	gitCommitAll(t, core, "drop the founding key from the trust file")
+
+	// Control: with no declared seed set there is no floor to stand on, and
+	// core's own trust file no longer vouches for its history.
+	if got := checkByName(t, run(t, workspace), "config_signed"); got.Status != StatusFail {
+		t.Fatalf("control failed: config_signed = %s without seeds, so the floor is untested", got.Status)
+	}
+
+	report, err := Run(t.Context(), workspace, Options{
+		SeedSigners: []provenance.TrustedSigner{{
+			Principal: "test@example.com",
+			PublicKey: publicKey,
+		}},
+	})
+	if err != nil {
+		t.Fatalf("Run with seeds: %v", err)
+	}
+	if got := checkByName(t, report, "config_signed"); got.Status != StatusPass {
+		t.Fatalf("config_signed = %s (%s), want pass: a declared seed signer must keep its authority over core", got.Status, got.Detail)
+	}
 }

--- a/internal/platform/coreintegrity/coreintegrity_test.go
+++ b/internal/platform/coreintegrity/coreintegrity_test.go
@@ -13,8 +13,8 @@ import (
 
 // signCore gives a core repository an SSH signing identity and the
 // matching .allowed_signers, so commits made afterwards verify the way
-// a real instance's do. Returns nothing: every later commit in the test
-// is signed by construction.
+// a real instance's do. Returns the public key, so a test can declare it
+// as a seed signer; every later commit in the test is signed by construction.
 func signCore(t *testing.T, dir string) string {
 	t.Helper()
 	keyPath := filepath.Join(t.TempDir(), "signing_ed25519")

--- a/internal/platform/provenance/admission.go
+++ b/internal/platform/provenance/admission.go
@@ -3,6 +3,7 @@ package provenance
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -150,6 +151,30 @@ func trustedBySeed(ctx context.Context, repoPath string, seeds []TrustedSigner, 
 	defer cleanup()
 	_, err = runGitTextVerify(ctx, repoPath, seedFile, "verify-commit", commit)
 	return err == nil
+}
+
+// logSeedFloorUsed records that a commit was trusted by the seed floor rather
+// than by the root's own trust file.
+//
+// The floor is a recovery mechanism, not a normal path: reaching it means the
+// in-tree .allowed_signers has stopped vouching for history it previously
+// covered. Succeeding silently would hide exactly the condition the floor
+// exists to survive, and would defeat the boot-time round-trip that
+// [Store.VerifyHead] performs — whose whole purpose is to surface a malformed
+// or polluted trust file early rather than let it emerge later as a puzzling
+// read failure.
+//
+// Both repairs are legitimate, so the message names both rather than assuming
+// which one the operator meant.
+func logSeedFloorUsed(logger *slog.Logger, repoPath, commit string) {
+	if logger == nil {
+		return
+	}
+	logger.Warn("commit trusted by the seed floor; this root's own .allowed_signers no longer vouches for it",
+		"repo", repoPath,
+		"commit", shortCommit(commit),
+		"remedy", "restore the seed signer to .allowed_signers, or remove it from seed_signers if dropping it was intended",
+	)
 }
 
 // rootCommits returns every parentless commit reachable from HEAD.

--- a/internal/platform/provenance/admission.go
+++ b/internal/platform/provenance/admission.go
@@ -124,6 +124,34 @@ func attributionHint(ctx context.Context, repoPath, commit string) string {
 	}
 }
 
+// trustedBySeed reports whether a commit is signed by one of the root's
+// declared seed signers.
+//
+// This is the floor: seed signers are entitled to sign a root permanently, and
+// nothing inside the repository can withdraw that. Without it the guarantee the
+// design leads with — that a seed key can always re-assert control over a root
+// whose .allowed_signers has been polluted — is not true, because verification
+// reads only the in-tree file and an edit to that file could remove the very
+// key needed to repair it.
+//
+// It is consulted only after in-tree verification has already failed, so the
+// ordinary path costs nothing and the fallback runs on a signature the root
+// itself does not vouch for. A missing or unreadable seed set is not an error
+// here: it simply means there is no floor to stand on, and the in-tree failure
+// stands as the answer.
+func trustedBySeed(ctx context.Context, repoPath string, seeds []TrustedSigner, commit string) bool {
+	if len(seeds) == 0 || strings.TrimSpace(commit) == "" {
+		return false
+	}
+	seedFile, cleanup, err := materializeSeedSigners(seeds)
+	if err != nil {
+		return false
+	}
+	defer cleanup()
+	_, err = runGitTextVerify(ctx, repoPath, seedFile, "verify-commit", commit)
+	return err == nil
+}
+
 // rootCommits returns every parentless commit reachable from HEAD.
 //
 // The three ways this can fail are deliberately not collapsed. A repository

--- a/internal/platform/provenance/admission_test.go
+++ b/internal/platform/provenance/admission_test.go
@@ -1,6 +1,7 @@
 package provenance
 
 import (
+	"bytes"
 	"crypto/ed25519"
 	"crypto/rand"
 	"encoding/pem"
@@ -602,5 +603,61 @@ func TestVerifierFallsBackToTheSeedFloor(t *testing.T) {
 	}
 	if result, _ := wrongFloor.VerifyFile(t.Context(), "notes.md"); result.Trusted() {
 		t.Fatal("a floor of keys that signed nothing here still admitted the commit")
+	}
+}
+
+// TestSeedFloorWarnsWhenItRescuesAVerification pins the signal rather than the
+// verdict.
+//
+// The floor makes a polluted trust file survivable, which is the point — but
+// surviving silently would hide the pollution. Store.VerifyHead exists as a
+// boot-time round-trip precisely to surface a malformed or polluted trust file
+// early, so a floor that quietly rescued it would defeat the check it passes
+// through.
+func TestSeedFloorWarnsWhenItRescuesAVerification(t *testing.T) {
+	t.Parallel()
+	operator := newAdmissionKey(t, "operator@example.com")
+	agent := newAdmissionKey(t, AgentPrincipal)
+
+	repo := newAdmissionRepo(t)
+	repo.commitAs(operator, "birth", map[string]string{
+		TrustFileName: trustFile(operator, agent),
+	})
+	repo.commitAs(operator, "drop the operator from the trust file", map[string]string{
+		TrustFileName: trustFile(agent),
+	})
+
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+
+	verifier, err := NewVerifier(repo.dir, logger, Options{
+		SeedSigners: []TrustedSigner{operator.signer()},
+	})
+	if err != nil {
+		t.Fatalf("NewVerifier: %v", err)
+	}
+	result, _ := verifier.VerifyTree(t.Context(), "")
+	if !result.Trusted() {
+		t.Fatalf("the seed floor should have rescued this verification: %s", result.Message)
+	}
+	if logged := buf.String(); !strings.Contains(logged, "seed floor") {
+		t.Fatalf("the floor rescued a verification without warning; operators would never learn the trust file is polluted:\n%s", logged)
+	}
+
+	// The ordinary path must stay quiet, or the warning means nothing.
+	buf.Reset()
+	healthy := newAdmissionRepo(t)
+	healthy.commitAs(operator, "birth", map[string]string{
+		TrustFileName: trustFile(operator),
+	})
+	quiet, err := NewVerifier(healthy.dir, logger, Options{SeedSigners: []TrustedSigner{operator.signer()}})
+	if err != nil {
+		t.Fatalf("NewVerifier: %v", err)
+	}
+	if result, _ := quiet.VerifyTree(t.Context(), ""); !result.Trusted() {
+		t.Fatalf("control failed: a healthy root should verify against its own trust file: %s", result.Message)
+	}
+	if logged := buf.String(); strings.Contains(logged, "seed floor") {
+		t.Fatalf("a healthy root warned about the seed floor, so the signal is noise:\n%s", logged)
 	}
 }

--- a/internal/platform/provenance/admission_test.go
+++ b/internal/platform/provenance/admission_test.go
@@ -511,3 +511,96 @@ func TestAdmissionIgnoresRepositoryConfiguredSignatureProgram(t *testing.T) {
 		t.Fatal("a root that configured its own signature program was admitted")
 	}
 }
+
+// TestSeedSignerRemainsTrustedAfterRemovalFromTrustFile is the floor.
+//
+// A seed signer is entitled to sign a root permanently, and nothing inside the
+// repository can withdraw that. Without it the recovery guarantee this design
+// leads with is false: verification reads only the in-tree trust file, so an
+// edit to that file could remove the very key needed to repair it, and the
+// root would be unrecoverable by exactly the person entitled to recover it.
+func TestSeedSignerRemainsTrustedAfterRemovalFromTrustFile(t *testing.T) {
+	t.Parallel()
+	operator := newAdmissionKey(t, "operator@example.com")
+	agent := newAdmissionKey(t, AgentPrincipal)
+
+	repo := newAdmissionRepo(t)
+	repo.commitAs(operator, "birth", map[string]string{
+		TrustFileName: trustFile(operator, agent),
+	})
+	// The trust file is edited to drop the operator — the pollution the floor
+	// exists to survive. The commit doing it is signed by the operator, so it
+	// is a legitimate edit rather than an attack; the point is what happens to
+	// the operator's own authority afterwards.
+	repo.commitAs(operator, "drop the operator from the trust file", map[string]string{
+		TrustFileName: trustFile(agent),
+	})
+
+	seeds := []TrustedSigner{operator.signer()}
+
+	// Control: the root's own trust file no longer vouches for HEAD, so
+	// in-tree verification alone refuses it.
+	if err := repo.gitTry("-c", "gpg.ssh.allowedSignersFile="+filepath.Join(repo.dir, TrustFileName),
+		"verify-commit", "HEAD"); err == nil {
+		t.Fatal("control failed: the in-tree file still vouches for HEAD, so the floor is untested")
+	}
+
+	if !trustedBySeed(t.Context(), repo.dir, seeds, "HEAD") {
+		t.Fatal("a seed signer lost the ability to sign after being removed from the in-tree trust file")
+	}
+
+	// And a key that was never a seed gains nothing from the fallback.
+	stranger := newAdmissionKey(t, "stranger@example.com")
+	if trustedBySeed(t.Context(), repo.dir, []TrustedSigner{stranger.signer()}, "HEAD") {
+		t.Fatal("the floor admitted a commit signed by a key that is not a declared seed")
+	}
+}
+
+// TestVerifierFallsBackToTheSeedFloor exercises the wiring rather than the
+// helper: a Verifier constructed with a root's seed set accepts a commit the
+// root's own trust file has stopped vouching for, and still refuses one no
+// declared key signed.
+func TestVerifierFallsBackToTheSeedFloor(t *testing.T) {
+	t.Parallel()
+	operator := newAdmissionKey(t, "operator@example.com")
+	agent := newAdmissionKey(t, AgentPrincipal)
+
+	repo := newAdmissionRepo(t)
+	repo.commitAs(operator, "birth", map[string]string{
+		TrustFileName: trustFile(operator, agent),
+	})
+	repo.commitAs(operator, "drop the operator, leave a document behind", map[string]string{
+		TrustFileName: trustFile(agent),
+		"notes.md":    "written while the operator was still listed",
+	})
+
+	withoutFloor, err := NewVerifier(repo.dir, slog.New(slog.DiscardHandler), Options{})
+	if err != nil {
+		t.Fatalf("NewVerifier: %v", err)
+	}
+	if result, _ := withoutFloor.VerifyFile(t.Context(), "notes.md"); result.Trusted() {
+		t.Fatal("control failed: the in-tree file still vouches for HEAD, so the floor is untested")
+	}
+
+	withFloor, err := NewVerifier(repo.dir, slog.New(slog.DiscardHandler), Options{
+		SeedSigners: []TrustedSigner{operator.signer()},
+	})
+	if err != nil {
+		t.Fatalf("NewVerifier with seeds: %v", err)
+	}
+	result, err := withFloor.VerifyFile(t.Context(), "notes.md")
+	if !result.Trusted() {
+		t.Fatalf("seed-signed commit was refused despite the declared floor: %v (%s)", err, result.Message)
+	}
+
+	stranger := newAdmissionKey(t, "stranger@example.com")
+	wrongFloor, err := NewVerifier(repo.dir, slog.New(slog.DiscardHandler), Options{
+		SeedSigners: []TrustedSigner{stranger.signer()},
+	})
+	if err != nil {
+		t.Fatalf("NewVerifier with unrelated seeds: %v", err)
+	}
+	if result, _ := wrongFloor.VerifyFile(t.Context(), "notes.md"); result.Trusted() {
+		t.Fatal("a floor of keys that signed nothing here still admitted the commit")
+	}
+}

--- a/internal/platform/provenance/allowed_signers.go
+++ b/internal/platform/provenance/allowed_signers.go
@@ -261,7 +261,11 @@ func (s *Store) VerifyHead(ctx context.Context) error {
 	defer s.mu.Unlock()
 	args := append(signatureTrustArgs(), "verify-commit", "HEAD")
 	if err := s.git(ctx, nil, nil, args...); err != nil {
-		return fmt.Errorf("verify HEAD against allowed_signers: %w", err)
+		// A seed signer may always sign this root, whatever the in-tree file
+		// currently says — see trustedBySeed.
+		if !trustedBySeed(ctx, s.path, s.seedSigners, "HEAD") {
+			return fmt.Errorf("verify HEAD against allowed_signers: %w", err)
+		}
 	}
 	return nil
 }

--- a/internal/platform/provenance/allowed_signers.go
+++ b/internal/platform/provenance/allowed_signers.go
@@ -266,6 +266,7 @@ func (s *Store) VerifyHead(ctx context.Context) error {
 		if !trustedBySeed(ctx, s.path, s.seedSigners, "HEAD") {
 			return fmt.Errorf("verify HEAD against allowed_signers: %w", err)
 		}
+		logSeedFloorUsed(s.logger, s.path, "HEAD")
 	}
 	return nil
 }

--- a/internal/platform/provenance/verify.go
+++ b/internal/platform/provenance/verify.go
@@ -44,6 +44,7 @@ type Verifier struct {
 	mu                 sync.Mutex
 	path               string
 	allowedSignersPath string
+	seedSigners        []TrustedSigner
 	logger             *slog.Logger
 }
 
@@ -79,6 +80,7 @@ func NewVerifier(path string, logger *slog.Logger, opts Options) (*Verifier, err
 	return &Verifier{
 		path:               absPath,
 		allowedSignersPath: allowedSignersPath,
+		seedSigners:        opts.SeedSigners,
 		logger:             logger,
 	}, nil
 }
@@ -163,11 +165,15 @@ func (v *Verifier) verifyPathspec(ctx context.Context, pathspec string, requireT
 	}
 
 	if out, err := v.gitOutput(ctx, true, "verify-commit", commit); err != nil {
-		msg := strings.TrimSpace(out)
-		if msg == "" {
-			msg = err.Error()
+		// The root's own trust file does not vouch for this commit. Fall back
+		// to the seed set, which the root cannot withdraw — see trustedBySeed.
+		if !trustedBySeed(ctx, v.path, v.seedSigners, commit) {
+			msg := strings.TrimSpace(out)
+			if msg == "" {
+				msg = err.Error()
+			}
+			return failedVerification(commit, "commit signature verification failed: "+msg)
 		}
-		return failedVerification(commit, "commit signature verification failed: "+msg)
 	}
 
 	return VerificationResult{

--- a/internal/platform/provenance/verify.go
+++ b/internal/platform/provenance/verify.go
@@ -174,6 +174,7 @@ func (v *Verifier) verifyPathspec(ctx context.Context, pathspec string, requireT
 			}
 			return failedVerification(commit, "commit signature verification failed: "+msg)
 		}
+		logSeedFloorUsed(v.logger, v.path, commit)
 	}
 
 	return VerificationResult{


### PR DESCRIPTION
## Summary

#1264 leads with a recovery guarantee: *a seed key can always re-assert control over a root whose `.allowed_signers` has been polluted.* It wasn't true. Verification read the root's in-tree trust file and nothing else, so an edit to that file could remove the very key needed to repair it — and the root became unrecoverable by exactly the person entitled to recover it.

Admission (#1267) gated **establishment**. Nothing kept the floor afterwards. This closes that.

## How it works

Verification falls back to the declared seed set when the root's own trust file does not vouch for a commit. Composition rather than replacement: the in-tree file still delegates to whoever it names, and a seed keeps its authority whether or not the file still lists it.

The fallback runs *only after* in-tree verification has already failed, so the ordinary path costs nothing extra and the extra check happens on a signature the root itself does not vouch for. An empty seed set means there is no floor to stand on, and the in-tree failure stands as the answer.

Deliberately **not** implemented as an invariant check ("the trust file must still list every seed"). That would refuse the root outright, which is the opposite of what the guarantee is for — recovery requires that the seed still *works* on a polluted root, not that a polluted root is rejected until repaired out of band.

## Core needed explicit wiring, or the guarantee inverted where it matters most

`coreintegrity` builds its own verifier and cannot reach the per-root plumbing that hands every other root its seeds. So without this, a polluted trust file in core would fail `config_signed`, `serve` would refuse with exit 78, and the operator would be locked out of the instance by the same key that entitles them to fix it — the floor holding everywhere except the one root that holds the config.

`Options` now carries core's declared seeds, supplied by both callers that have a loaded config. When the config could not load there are no seeds and the in-tree file is the only answer available, which is the right degradation for checks that exist partly to explain why a config would not load.

The package doc claimed an out-of-tree anchor was still a prerequisite for giving core a remote. `seed_signers` *is* that anchor, so the comment is corrected rather than left describing the world before #1266.

## About the tests

Each assertion is paired with a control proving the in-tree file has genuinely stopped vouching for the commit. Without that, a test asserting "the floor accepts this" could pass on a fixture where the in-tree file still accepted it and the fallback never ran — proof of nothing. Verified by unwiring the floor and confirming each test fails:

```
config_signed = fail (... No principal matched.), want pass:
a declared seed signer must keep its authority over core
```

## Test plan

- [x] Seed signer still trusted after being removed from the in-tree trust file, with a control showing in-tree verification refuses it
- [x] A key that was never a seed gains nothing from the fallback
- [x] `Verifier` wiring exercised end to end, not just the helper
- [x] `coreintegrity` `config_signed` falls back to core's declared seeds, with a no-seeds control
- [x] Each test confirmed to fail with the floor unwired
- [x] `just ci` passes

Refs #1264