### PR TITLE
An instance that can name who founded it

### DIFF
--- a/cmd/thane/init.go
+++ b/cmd/thane/init.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	_ "embed"
 	"errors"
+	"flag"
 	"fmt"
 	"io"
 	"io/fs"
@@ -53,7 +54,64 @@ var interactionsSchemaV1JSON []byte
 // runInit initializes a Thane working directory with bundled defaults.
 // It creates the directory structure and writes default config, persona,
 // and talent files. Existing files are never overwritten.
-func runInit(w io.Writer, dir string) error {
+// initOptions carries the operator's answer to "who founds this instance".
+type initOptions struct {
+	// OperatorKey is an explicit private key path. Empty means discover one
+	// from the operator's git configuration.
+	OperatorKey string
+	// OperatorPrincipal overrides the identity the key signs as.
+	OperatorPrincipal string
+	// SelfSigned skips the search entirely and founds core with the agent's
+	// own key, for an operator who has decided that is what they want.
+	SelfSigned bool
+}
+
+// resolveOperatorSigner decides which key founds core, and explains the
+// choice.
+//
+// An explicit key is an instruction rather than a preference, so failing to
+// load one is an error: silently falling back to a self-signed core after
+// being handed a key would produce a weaker instance than the operator asked
+// for, and say nothing about it.
+func resolveOperatorSigner(ctx context.Context, opts initOptions) (*identity.OperatorSigner, string, error) {
+	if opts.SelfSigned {
+		return nil, "asked for a self-signed core", nil
+	}
+	if strings.TrimSpace(opts.OperatorKey) != "" {
+		signer, err := identity.LoadOperatorSigner(ctx, opts.OperatorKey, opts.OperatorPrincipal)
+		if err != nil {
+			return nil, "", fmt.Errorf("operator key: %w", err)
+		}
+		return signer, "", nil
+	}
+	signer, why := identity.DiscoverOperatorSigner(ctx, opts.OperatorPrincipal)
+	return signer, why, nil
+}
+
+// describeCorePosture tells the operator which of the two shapes they got, in
+// the vocabulary they already have from TLS.
+//
+// A self-signed core is not a failure and is not presented as one — it works,
+// and for a single-operator instance it may be all anyone wants. What it must
+// not do is arrive silently, because the property it gives up is the one an
+// operator would assume they had: that the agent cannot re-establish the root
+// holding its own config.
+func describeCorePosture(w io.Writer, result *identity.BootstrapResult, why string) {
+	if !result.SelfSigned {
+		fmt.Fprintf(w, "  ✓ core anchored to %s — the agent can write to core but cannot re-establish it\n", result.OperatorPrincipal)
+		return
+	}
+	fmt.Fprintln(w, "  ! core is self-signed: its only seed signer is this instance's own agent key,")
+	fmt.Fprintln(w, "    so nothing outside the instance attests to it and the agent could re-establish")
+	fmt.Fprintln(w, "    the root that holds its config.")
+	if why != "" {
+		fmt.Fprintf(w, "    Why: %s.\n", why)
+	}
+	fmt.Fprintln(w, "    To anchor it to a key you hold, re-initialize an empty workspace with:")
+	fmt.Fprintln(w, "      thane init -operator-key ~/.ssh/id_ed25519 <dir>")
+}
+
+func runInit(w io.Writer, dir string, opts initOptions) error {
 	absDir, err := filepath.Abs(dir)
 	if err != nil {
 		return fmt.Errorf("resolve path: %w", err)
@@ -98,12 +156,18 @@ func runInit(w io.Writer, dir string) error {
 		return fmt.Errorf("deploy talents: %w", err)
 	}
 
-	result, err := identity.BootstrapCore(context.Background(), filepath.Join(absDir, "core"), filepath.Base(absDir), slog.Default())
+	ctx := context.Background()
+	operator, why, err := resolveOperatorSigner(ctx, opts)
+	if err != nil {
+		return err
+	}
+	result, err := identity.BootstrapCore(ctx, filepath.Join(absDir, "core"), filepath.Base(absDir), operator, slog.Default())
 	if err != nil {
 		return fmt.Errorf("bootstrap core identity: %w", err)
 	}
 	if result.Created {
 		fmt.Fprintf(w, "  ✓ %s (core identity, signing %s)\n", result.CoreDir, result.SigningKeyFingerprint)
+		describeCorePosture(w, result, why)
 	} else {
 		fmt.Fprintf(w, "  · %s (core identity exists, skipping)\n", result.CoreDir)
 	}
@@ -175,4 +239,30 @@ func writeIfMissing(w io.Writer, path string, data []byte, mode os.FileMode) err
 	}
 	fmt.Fprintf(w, "  ✓ %s\n", path)
 	return nil
+}
+
+// runInitCommand parses `thane init`'s own flags.
+//
+// The flags exist as much for wrapper installers as for people: a GUI front
+// end can ask "which key is yours?" in whatever way suits it and pass the
+// answer here, instead of asking someone at first run to reason about trust
+// roots.
+func runInitCommand(w io.Writer, args []string) error {
+	fs := flag.NewFlagSet("init", flag.ContinueOnError)
+	fs.SetOutput(w)
+	var opts initOptions
+	fs.StringVar(&opts.OperatorKey, "operator-key", "",
+		"private SSH key that founds core, making the instance answerable to its holder (default: from git's user.signingkey)")
+	fs.StringVar(&opts.OperatorPrincipal, "operator-principal", "",
+		"identity the operator key signs as (default: git's user.email)")
+	fs.BoolVar(&opts.SelfSigned, "self-signed", false,
+		"found core with the instance's own agent key, without looking for an operator key")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	dir := "."
+	if fs.NArg() > 0 {
+		dir = fs.Arg(0)
+	}
+	return runInit(w, dir, opts)
 }

--- a/cmd/thane/init.go
+++ b/cmd/thane/init.go
@@ -247,9 +247,12 @@ func writeIfMissing(w io.Writer, path string, data []byte, mode os.FileMode) err
 // end can ask "which key is yours?" in whatever way suits it and pass the
 // answer here, instead of asking someone at first run to reason about trust
 // roots.
-func runInitCommand(w io.Writer, args []string) error {
+func runInitCommand(stdout, stderr io.Writer, args []string) error {
 	fs := flag.NewFlagSet("init", flag.ContinueOnError)
-	fs.SetOutput(w)
+	// Parse failures and usage are terminal, and run() puts terminal output on
+	// stderr. Sending them to stdout would interleave them with the progress
+	// report a caller may be parsing.
+	fs.SetOutput(stderr)
 	var opts initOptions
 	fs.StringVar(&opts.OperatorKey, "operator-key", "",
 		"private SSH key that founds core, making the instance answerable to its holder (default: from git's user.signingkey)")
@@ -264,5 +267,5 @@ func runInitCommand(w io.Writer, args []string) error {
 	if fs.NArg() > 0 {
 		dir = fs.Arg(0)
 	}
-	return runInit(w, dir, opts)
+	return runInit(stdout, dir, opts)
 }

--- a/cmd/thane/init_test.go
+++ b/cmd/thane/init_test.go
@@ -346,3 +346,21 @@ func TestWriteIfMissing_CreateError(t *testing.T) {
 		t.Errorf("error = %q, want it to mention 'create'", err)
 	}
 }
+
+// TestInitFlagErrorsGoToStderr holds init to run()'s contract: terminal output
+// belongs on stderr. Usage text mixed into stdout would interleave with the
+// progress report a caller may be parsing, and would do it precisely when
+// something already went wrong.
+func TestInitFlagErrorsGoToStderr(t *testing.T) {
+	t.Parallel()
+	var stdout, stderr bytes.Buffer
+	if err := runInitCommand(&stdout, &stderr, []string{"-no-such-flag"}); err == nil {
+		t.Fatal("an unknown flag should fail")
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("flag failure wrote to stdout:\n%s", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "no-such-flag") {
+		t.Fatalf("stderr should carry the flag failure, got:\n%s", stderr.String())
+	}
+}

--- a/cmd/thane/init_test.go
+++ b/cmd/thane/init_test.go
@@ -31,7 +31,7 @@ func TestRunInit_FreshDirectory(t *testing.T) {
 	dir := t.TempDir()
 	var buf bytes.Buffer
 
-	if err := runInit(&buf, dir); err != nil {
+	if err := runInit(&buf, dir, initOptions{SelfSigned: true}); err != nil {
 		t.Fatalf("runInit failed: %v", err)
 	}
 
@@ -165,7 +165,7 @@ func TestRunInit_ArchiveBootstrapIdempotent(t *testing.T) {
 	dir := t.TempDir()
 	var buf bytes.Buffer
 
-	if err := runInit(&buf, dir); err != nil {
+	if err := runInit(&buf, dir, initOptions{SelfSigned: true}); err != nil {
 		t.Fatalf("first runInit: %v", err)
 	}
 
@@ -180,7 +180,7 @@ func TestRunInit_ArchiveBootstrapIdempotent(t *testing.T) {
 	}
 
 	buf.Reset()
-	if err := runInit(&buf, dir); err != nil {
+	if err := runInit(&buf, dir, initOptions{SelfSigned: true}); err != nil {
 		t.Fatalf("second runInit: %v", err)
 	}
 
@@ -210,7 +210,7 @@ func TestRunInit_SkipsExistingFiles(t *testing.T) {
 	var buf bytes.Buffer
 
 	// First run: create everything.
-	if err := runInit(&buf, dir); err != nil {
+	if err := runInit(&buf, dir, initOptions{SelfSigned: true}); err != nil {
 		t.Fatalf("first runInit failed: %v", err)
 	}
 
@@ -228,7 +228,7 @@ func TestRunInit_SkipsExistingFiles(t *testing.T) {
 
 	// Second run: should skip existing files.
 	buf.Reset()
-	if err := runInit(&buf, dir); err != nil {
+	if err := runInit(&buf, dir, initOptions{SelfSigned: true}); err != nil {
 		t.Fatalf("second runInit failed: %v", err)
 	}
 

--- a/cmd/thane/main.go
+++ b/cmd/thane/main.go
@@ -199,11 +199,7 @@ func run(ctx context.Context, stdout io.Writer, stderr io.Writer, args []string)
 	case "serve":
 		return runServe(ctx, stdout, stderr, configPath, workspacePath)
 	case "init":
-		dir := "."
-		if len(cmdArgs) > 0 {
-			dir = cmdArgs[0]
-		}
-		return runInit(stdout, dir)
+		return runInitCommand(stdout, cmdArgs)
 	case "validate":
 		return runValidate(stdout, configPath, workspacePath, outputFmt)
 	case "ask":

--- a/cmd/thane/main.go
+++ b/cmd/thane/main.go
@@ -199,7 +199,7 @@ func run(ctx context.Context, stdout io.Writer, stderr io.Writer, args []string)
 	case "serve":
 		return runServe(ctx, stdout, stderr, configPath, workspacePath)
 	case "init":
-		return runInitCommand(stdout, cmdArgs)
+		return runInitCommand(stdout, stderr, cmdArgs)
 	case "validate":
 		return runValidate(stdout, configPath, workspacePath, outputFmt)
 	case "ask":

--- a/internal/platform/identity/bootstrap.go
+++ b/internal/platform/identity/bootstrap.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/nugget/thane-ai-agent/internal/platform/checkout"
+	"github.com/nugget/thane-ai-agent/internal/platform/provenance"
 	"gopkg.in/yaml.v3"
 )
 
@@ -38,13 +39,45 @@ type BootstrapResult struct {
 	CoreDir               string
 	SigningKeyFingerprint string
 	ChannelCAFingerprint  string
+	// SelfSigned reports that core's only seed signer is the instance's own
+	// agent key, so nothing outside the instance attests to it and the agent
+	// can re-establish the root holding its config.
+	SelfSigned bool
+	// OperatorPrincipal names the operator key core was anchored to, empty
+	// when SelfSigned.
+	OperatorPrincipal string
+}
+
+// coreTrustSurface renders core's in-tree trust file.
+//
+// The operator is listed alongside the agent rather than instead of it: the
+// seed set decides who may establish the root, while this file decides who may
+// sign its contents, and the agent has to keep writing ego.md and
+// metacognitive.md after an operator founds the root. Keeping the two distinct
+// is what makes the anchored shape usable rather than merely strict.
+func coreTrustSurface(agentPublicKey string, operator *OperatorSigner) (string, error) {
+	var operators []provenance.TrustedSigner
+	if operator != nil {
+		operators = append(operators, provenance.TrustedSigner{
+			Principal: operator.Principal,
+			PublicKey: operator.PublicKey,
+		})
+	}
+	return provenance.RenderAllowedSigners(agentPublicKey, operators)
+}
+
+func operatorPrincipal(operator *OperatorSigner) string {
+	if operator == nil {
+		return ""
+	}
+	return operator.Principal
 }
 
 // BootstrapCore initializes the core trust root for a Thane instance.
 // Private key material is written under core/ with 0600 permissions and
 // ignored by git. Public key material, the channel CA certificate, and
 // core/config.yaml are committed together as the signed birth commit.
-func BootstrapCore(ctx context.Context, coreDir, instanceName string, logger *slog.Logger) (*BootstrapResult, error) {
+func BootstrapCore(ctx context.Context, coreDir, instanceName string, operator *OperatorSigner, logger *slog.Logger) (*BootstrapResult, error) {
 	absCoreDir, err := filepath.Abs(coreDir)
 	if err != nil {
 		return nil, fmt.Errorf("resolve core dir: %w", err)
@@ -95,10 +128,18 @@ func BootstrapCore(ctx context.Context, coreDir, instanceName string, logger *sl
 		return nil, err
 	}
 
+	// The birth commit is signed by whoever seeds the root, which is the whole
+	// point of the operator key: a seed set naming the operator while the agent
+	// signs the birth produces a root admission refuses, so the key that will
+	// be declared has to be the key that founds it.
+	birthKey := filepath.Join(absCoreDir, SigningPrivateKeyFile)
+	if operator != nil {
+		birthKey = operator.PrivateKeyPath
+	}
 	signed, err := checkout.OpenSigned(ctx, checkout.SignedSpec{
 		Name:            "core.identity",
 		WorktreePath:    absCoreDir,
-		SigningKeyPath:  filepath.Join(absCoreDir, SigningPrivateKeyFile),
+		SigningKeyPath:  birthKey,
 		SkipBirthCommit: true,
 		Logger:          logger.With("component", "core_identity_checkout"),
 	})
@@ -106,14 +147,18 @@ func BootstrapCore(ctx context.Context, coreDir, instanceName string, logger *sl
 		return nil, fmt.Errorf("open core identity checkout: %w", err)
 	}
 
-	policy, err := renderCoreConfig(instanceName, now, signing, channelCA)
+	trustSurface, err := coreTrustSurface(signing.Public, operator)
+	if err != nil {
+		return nil, err
+	}
+	policy, err := renderCoreConfig(instanceName, now, signing, channelCA, operator)
 	if err != nil {
 		return nil, err
 	}
 
 	if err := signed.Store.WriteFiles(ctx, map[string]string{
 		".gitignore":         coreGitIgnore,
-		".allowed_signers":   fmt.Sprintf("thane@provenance.local %s\n", strings.TrimSpace(signing.Public)),
+		".allowed_signers":   trustSurface,
 		SigningPublicKeyFile: signing.Public,
 		ChannelCACertFile:    string(channelCA.Certificate),
 		CoreConfigFile:       string(policy),
@@ -127,6 +172,8 @@ func BootstrapCore(ctx context.Context, coreDir, instanceName string, logger *sl
 		CoreDir:               absCoreDir,
 		SigningKeyFingerprint: signing.Fingerprint,
 		ChannelCAFingerprint:  channelCA.Fingerprint,
+		SelfSigned:            operator == nil,
+		OperatorPrincipal:     operatorPrincipal(operator),
 	}, nil
 }
 
@@ -209,12 +256,13 @@ func writePrivateFile(path string, data []byte) error {
 }
 
 type coreConfig struct {
-	Version     int              `yaml:"version"`
-	GeneratedAt string           `yaml:"generated_at"`
-	Identity    identityPolicy   `yaml:"identity"`
-	Trust       trustPolicy      `yaml:"trust"`
-	Delegation  delegationPolicy `yaml:"delegation"`
-	Channels    channelPolicy    `yaml:"channels"`
+	Version     int                       `yaml:"version"`
+	GeneratedAt string                    `yaml:"generated_at"`
+	Identity    identityPolicy            `yaml:"identity"`
+	Trust       trustPolicy               `yaml:"trust"`
+	Delegation  delegationPolicy          `yaml:"delegation"`
+	Channels    channelPolicy             `yaml:"channels"`
+	Roots       map[string]coreRootPolicy `yaml:"roots,omitempty"`
 }
 
 type identityPolicy struct {
@@ -253,8 +301,44 @@ type channelPolicy struct {
 	AllowedKeyTypes []string `yaml:"allowed_key_types"`
 }
 
-func renderCoreConfig(instanceName string, generatedAt time.Time, signing *SigningKeyPair, ca *CertificateAuthority) ([]byte, error) {
+// coreRootPolicy carries the seed declaration for core in the generated
+// config. Only seed_signers is emitted: everything else about core's policy is
+// the operator's to author, but the seed set has to exist from birth or
+// admission has nothing to judge the root against.
+type coreRootPolicy struct {
+	SeedSigners []coreSeedSigner `yaml:"seed_signers,omitempty"`
+}
+
+type coreSeedSigner struct {
+	Principal string `yaml:"principal"`
+	Key       string `yaml:"key"`
+	Label     string `yaml:"label,omitempty"`
+}
+
+// coreSeedDeclaration names who may establish core.
+//
+// An anchored core declares the operator alone, which is what makes the agent
+// unable to found or re-found the root holding its own config. A self-signed
+// core declares the agent, because something has to be declared — a root with
+// no seed set is governed by nothing, which is the state this exists to end.
+func coreSeedDeclaration(signing *SigningKeyPair, operator *OperatorSigner) coreRootPolicy {
+	if operator != nil {
+		return coreRootPolicy{SeedSigners: []coreSeedSigner{{
+			Principal: operator.Principal,
+			Key:       strings.TrimSpace(operator.PublicKey),
+			Label:     "operator",
+		}}}
+	}
+	return coreRootPolicy{SeedSigners: []coreSeedSigner{{
+		Principal: provenance.AgentPrincipal,
+		Key:       strings.TrimSpace(signing.Public),
+		Label:     "self-signed",
+	}}}
+}
+
+func renderCoreConfig(instanceName string, generatedAt time.Time, signing *SigningKeyPair, ca *CertificateAuthority, operator *OperatorSigner) ([]byte, error) {
 	cfg := coreConfig{
+		Roots:       map[string]coreRootPolicy{"core": coreSeedDeclaration(signing, operator)},
 		Version:     1,
 		GeneratedAt: generatedAt.Format(time.RFC3339),
 		Identity: identityPolicy{

--- a/internal/platform/identity/bootstrap_test.go
+++ b/internal/platform/identity/bootstrap_test.go
@@ -31,7 +31,7 @@ func TestBootstrapCoreCreatesSignedBirthCommit(t *testing.T) {
 	clearUmask(t)
 
 	coreDir := filepath.Join(t.TempDir(), "core")
-	result, err := BootstrapCore(t.Context(), coreDir, "pocket", nil)
+	result, err := BootstrapCore(t.Context(), coreDir, "pocket", nil, nil)
 	if err != nil {
 		t.Fatalf("BootstrapCore: %v", err)
 	}
@@ -113,10 +113,10 @@ func TestBootstrapCoreSkipsCompleteIdentity(t *testing.T) {
 	requireGit(t)
 
 	coreDir := filepath.Join(t.TempDir(), "core")
-	if _, err := BootstrapCore(t.Context(), coreDir, "pocket", nil); err != nil {
+	if _, err := BootstrapCore(t.Context(), coreDir, "pocket", nil, nil); err != nil {
 		t.Fatalf("first BootstrapCore: %v", err)
 	}
-	result, err := BootstrapCore(t.Context(), coreDir, "pocket", nil)
+	result, err := BootstrapCore(t.Context(), coreDir, "pocket", nil, nil)
 	if err != nil {
 		t.Fatalf("second BootstrapCore: %v", err)
 	}
@@ -137,7 +137,7 @@ func TestBootstrapCoreRejectsPartialIdentity(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if _, err := BootstrapCore(t.Context(), coreDir, "pocket", nil); err == nil {
+	if _, err := BootstrapCore(t.Context(), coreDir, "pocket", nil, nil); err == nil {
 		t.Fatal("BootstrapCore partial identity returned nil, want error")
 	}
 }
@@ -148,7 +148,7 @@ func TestBootstrapCoreRollsBackFailedBirthCommit(t *testing.T) {
 	coreDir := filepath.Join(t.TempDir(), "core")
 	ctx, cancel := context.WithCancel(t.Context())
 	cancel()
-	if _, err := BootstrapCore(ctx, coreDir, "pocket", nil); err == nil {
+	if _, err := BootstrapCore(ctx, coreDir, "pocket", nil, nil); err == nil {
 		t.Fatal("BootstrapCore with canceled context returned nil, want error")
 	}
 
@@ -167,7 +167,7 @@ func TestBootstrapCoreRollsBackFailedBirthCommit(t *testing.T) {
 		}
 	}
 
-	if _, err := BootstrapCore(t.Context(), coreDir, "pocket", nil); err != nil {
+	if _, err := BootstrapCore(t.Context(), coreDir, "pocket", nil, nil); err != nil {
 		t.Fatalf("BootstrapCore after rollback: %v", err)
 	}
 }

--- a/internal/platform/identity/operator.go
+++ b/internal/platform/identity/operator.go
@@ -133,9 +133,19 @@ func fileExists(path string) bool {
 	return err == nil && info.Mode().IsRegular()
 }
 
+// expandHome resolves a leading ~ against this process's own home directory.
+//
+// Only "~" and "~/…" are expanded. A "~other/…" form names a different user's
+// home, which this cannot resolve — and quietly treating it as a path under
+// *our* home would turn ~alice/.ssh/id_ed25519 into $HOME/alice/.ssh/id_ed25519
+// and then report that file as missing, sending the reader to look for a
+// typo that is not there. Refusing names the actual limitation.
 func expandHome(path string) (string, error) {
 	if path == "" || !strings.HasPrefix(path, "~") {
 		return path, nil
+	}
+	if path != "~" && !strings.HasPrefix(path, "~/") {
+		return "", fmt.Errorf("%s names another user's home directory, which cannot be resolved here; give an absolute path", path)
 	}
 	home, err := os.UserHomeDir()
 	if err != nil {

--- a/internal/platform/identity/operator.go
+++ b/internal/platform/identity/operator.go
@@ -1,0 +1,156 @@
+package identity
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/nugget/thane-ai-agent/internal/platform/provenance"
+)
+
+// OperatorSigner is a key held by a person rather than by the instance.
+//
+// Founding core with one is what anchors an instance to someone outside
+// itself. Without it core is self-signed: it works, and it is honest about
+// what it is, but nothing external attests to it and the agent can
+// re-establish the root that holds its own config.
+type OperatorSigner struct {
+	// Principal is the allowed_signers identity, conventionally an email.
+	Principal string
+	// PublicKey is the key in authorized_keys form, for the trust file and
+	// the seed declaration.
+	PublicKey string
+	// PrivateKeyPath is the key core's birth commit is signed with. It is
+	// required: a key that can only be declared and not signed with would
+	// produce a root whose birth no declared seed signed, which admission
+	// refuses — an instance that initializes cleanly and then refuses to
+	// serve.
+	PrivateKeyPath string
+}
+
+// LoadOperatorSigner resolves an operator key from a private key path.
+//
+// The principal is the identity the key signs as. It falls back to git's
+// user.email because that is what the operator already curates, and an
+// allowed_signers entry needs a name whether or not anyone chose one for this
+// purpose.
+func LoadOperatorSigner(ctx context.Context, keyPath, principal string) (*OperatorSigner, error) {
+	expanded, err := expandHome(strings.TrimSpace(keyPath))
+	if err != nil {
+		return nil, err
+	}
+	if expanded == "" {
+		return nil, fmt.Errorf("no operator key path given")
+	}
+	signer, err := provenance.NewSSHFileSigner(expanded)
+	if err != nil {
+		return nil, err
+	}
+	if principal = strings.TrimSpace(principal); principal == "" {
+		principal = gitConfigValue(ctx, "user.email")
+	}
+	if principal == "" {
+		return nil, fmt.Errorf("cannot name the operator key's identity: set git's user.email, or pass -operator-principal")
+	}
+	return &OperatorSigner{
+		Principal:      principal,
+		PublicKey:      signer.PublicKey(),
+		PrivateKeyPath: expanded,
+	}, nil
+}
+
+// DiscoverOperatorSigner resolves an operator key from the operator's own git
+// configuration, so an instance anchors itself without anyone being asked to
+// think about trust roots on first run.
+//
+// It returns a reason rather than an error when it finds nothing usable.
+// Failing to discover a key is the ordinary case on a machine that does not
+// sign commits, and it produces a self-signed core rather than a failed setup
+// — but the operator should be told which of the several reasons applied,
+// because each has a different remedy and only some are worth acting on.
+func DiscoverOperatorSigner(ctx context.Context, principal string) (*OperatorSigner, string) {
+	if _, err := exec.LookPath("git"); err != nil {
+		return nil, "git is not installed, so there is no operator configuration to read"
+	}
+	switch format := gitConfigValue(ctx, "gpg.format"); {
+	case format == "":
+		return nil, "git is not configured to sign commits with an SSH key (gpg.format is unset)"
+	case !strings.EqualFold(format, "ssh"):
+		return nil, fmt.Sprintf("git signs commits with %s rather than ssh, so user.signingkey is not an SSH key", format)
+	}
+	raw := gitConfigValue(ctx, "user.signingkey")
+	if raw == "" {
+		return nil, "git config names no user.signingkey"
+	}
+	keyPath, why := signableKeyPath(raw)
+	if keyPath == "" {
+		return nil, why
+	}
+	signer, err := LoadOperatorSigner(ctx, keyPath, principal)
+	if err != nil {
+		return nil, err.Error()
+	}
+	return signer, ""
+}
+
+// signableKeyPath maps a user.signingkey value onto a private key this process
+// can actually sign with, or explains why it cannot.
+//
+// The distinction matters more than it looks. git is happy to sign with a key
+// it only knows the public half of, because it hands the work to an agent or a
+// helper program. Founding core happens here, in this process, from a file — so
+// a value that git signs with perfectly well may still be unusable, and saying
+// so is better than a confusing failure later.
+func signableKeyPath(raw string) (path, why string) {
+	raw = strings.TrimSpace(raw)
+	if strings.HasPrefix(raw, "key::") {
+		return "", "user.signingkey is a literal public key, which cannot sign anything on its own"
+	}
+	expanded, err := expandHome(raw)
+	if err != nil {
+		return "", err.Error()
+	}
+	// A .pub value is the common shape, and the private half conventionally
+	// sits beside it under the same name.
+	if strings.HasSuffix(expanded, ".pub") {
+		private := strings.TrimSuffix(expanded, ".pub")
+		if fileExists(private) {
+			return private, ""
+		}
+		return "", fmt.Sprintf("user.signingkey names the public key %s and no private key sits beside it", expanded)
+	}
+	if !fileExists(expanded) {
+		return "", fmt.Sprintf("user.signingkey names %s, which does not exist", expanded)
+	}
+	return expanded, ""
+}
+
+func fileExists(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && info.Mode().IsRegular()
+}
+
+func expandHome(path string) (string, error) {
+	if path == "" || !strings.HasPrefix(path, "~") {
+		return path, nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve home directory for %s: %w", path, err)
+	}
+	return filepath.Join(home, strings.TrimPrefix(strings.TrimPrefix(path, "~"), "/")), nil
+}
+
+// gitConfigValue reads one git configuration value, treating every failure as
+// absence: this is discovery, and a missing key, an unreadable config, and a
+// git that will not run are all the same answer to the caller.
+func gitConfigValue(ctx context.Context, key string) string {
+	out, err := exec.CommandContext(ctx, "git", "config", "--get", key).Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}

--- a/internal/platform/identity/operator_test.go
+++ b/internal/platform/identity/operator_test.go
@@ -1,0 +1,150 @@
+package identity
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nugget/thane-ai-agent/internal/platform/provenance"
+)
+
+func writeOperatorKey(t *testing.T, dir, comment string) string {
+	t.Helper()
+	if _, err := exec.LookPath("ssh-keygen"); err != nil {
+		t.Skip("ssh-keygen not available")
+	}
+	path := filepath.Join(dir, "id_ed25519")
+	cmd := exec.Command("ssh-keygen", "-q", "-t", "ed25519", "-N", "", "-C", comment, "-f", path)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Skipf("ssh-keygen failed: %v\n%s", err, out)
+	}
+	return path
+}
+
+// TestSignableKeyPath covers the shapes a user.signingkey can take, because
+// git accepts several that this process cannot sign with. git hands signing to
+// an agent or a helper; founding core reads a private key from disk. A value
+// that works perfectly for `git commit -S` may still be unusable here, and the
+// operator deserves to be told which case they are in rather than left with a
+// confusing failure.
+func TestSignableKeyPath(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	private := writeOperatorKey(t, dir, "operator@example.com")
+
+	for _, tc := range []struct {
+		name    string
+		raw     string
+		want    string
+		wantWhy string
+	}{
+		{name: "private key path", raw: private, want: private},
+		{name: "public key beside its private half", raw: private + ".pub", want: private},
+		{
+			name:    "literal public key",
+			raw:     "key::ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAA",
+			wantWhy: "cannot sign",
+		},
+		{
+			name:    "public key with no private half",
+			raw:     filepath.Join(dir, "orphan.pub"),
+			wantWhy: "no private key sits beside it",
+		},
+		{
+			name:    "path that does not exist",
+			raw:     filepath.Join(dir, "absent"),
+			wantWhy: "does not exist",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, why := signableKeyPath(tc.raw)
+			if got != tc.want {
+				t.Fatalf("signableKeyPath(%q) = %q, want %q", tc.raw, got, tc.want)
+			}
+			if tc.wantWhy != "" && !strings.Contains(why, tc.wantWhy) {
+				t.Fatalf("reason = %q, want it to mention %q", why, tc.wantWhy)
+			}
+			if tc.wantWhy == "" && why != "" {
+				t.Fatalf("usable key still reported a reason: %q", why)
+			}
+		})
+	}
+}
+
+// TestBootstrapCoreAnchorsToAnOperatorKey proves the anchored posture end to
+// end, and specifically that the operator's key is the one that *signs* the
+// birth.
+//
+// Declaring a seed without signing with it is the failure this design exists
+// to avoid: init would succeed and the first serve would refuse, because
+// admission judges the birth against the declared seed set.
+func TestBootstrapCoreAnchorsToAnOperatorKey(t *testing.T) {
+	t.Parallel()
+	keyDir := t.TempDir()
+	keyPath := writeOperatorKey(t, keyDir, "operator@example.com")
+	operator, err := LoadOperatorSigner(t.Context(), keyPath, "operator@example.com")
+	if err != nil {
+		t.Fatalf("LoadOperatorSigner: %v", err)
+	}
+
+	coreDir := filepath.Join(t.TempDir(), "core")
+	result, err := BootstrapCore(t.Context(), coreDir, "pocket", operator, nil)
+	if err != nil {
+		t.Fatalf("BootstrapCore: %v", err)
+	}
+	if result.SelfSigned || result.OperatorPrincipal != "operator@example.com" {
+		t.Fatalf("result = %+v, want an anchored core naming the operator", result)
+	}
+
+	// Admission is the real assertion: it verifies the birth against the
+	// declared seed set alone, which is exactly what a declare-without-signing
+	// mistake would fail.
+	if _, err := provenance.VerifyAdmission(t.Context(), coreDir, []provenance.TrustedSigner{{
+		Principal: operator.Principal,
+		PublicKey: operator.PublicKey,
+	}}); err != nil {
+		t.Fatalf("an operator-founded core should be admitted by its own seed: %v", err)
+	}
+
+	// The agent stays able to sign core's contents: the seed set decides who
+	// may establish the root, the trust file decides who may write in it.
+	trust, err := os.ReadFile(filepath.Join(coreDir, ".allowed_signers"))
+	if err != nil {
+		t.Fatalf("read trust file: %v", err)
+	}
+	if !strings.Contains(string(trust), provenance.AgentPrincipal) {
+		t.Fatalf("trust file should still name the agent so it can write core:\n%s", trust)
+	}
+	if !strings.Contains(string(trust), "operator@example.com") {
+		t.Fatalf("trust file should name the operator:\n%s", trust)
+	}
+}
+
+// TestBootstrapCoreSelfSignedIsAdmissible checks the fallback is a real
+// posture rather than a broken one: a self-signed core must still be governed
+// by admission, which means declaring the agent as its own seed.
+func TestBootstrapCoreSelfSignedIsAdmissible(t *testing.T) {
+	t.Parallel()
+	coreDir := filepath.Join(t.TempDir(), "core")
+	result, err := BootstrapCore(t.Context(), coreDir, "pocket", nil, nil)
+	if err != nil {
+		t.Fatalf("BootstrapCore: %v", err)
+	}
+	if !result.SelfSigned {
+		t.Fatal("a core founded without an operator key should report itself self-signed")
+	}
+
+	agentKey, err := os.ReadFile(filepath.Join(coreDir, SigningPublicKeyFile))
+	if err != nil {
+		t.Fatalf("read agent public key: %v", err)
+	}
+	if _, err := provenance.VerifyAdmission(t.Context(), coreDir, []provenance.TrustedSigner{{
+		Principal: provenance.AgentPrincipal,
+		PublicKey: strings.TrimSpace(string(agentKey)),
+	}}); err != nil {
+		t.Fatalf("a self-signed core should be admitted by its own agent seed: %v", err)
+	}
+}

--- a/internal/platform/identity/operator_test.go
+++ b/internal/platform/identity/operator_test.go
@@ -57,6 +57,14 @@ func TestSignableKeyPath(t *testing.T) {
 			raw:     filepath.Join(dir, "absent"),
 			wantWhy: "does not exist",
 		},
+		{
+			// Silently rewriting this under our own home would report a
+			// missing file and send the reader hunting for a typo that is
+			// not there.
+			name:    "another user's home",
+			raw:     "~someone/.ssh/id_ed25519",
+			wantWhy: "another user's home directory",
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()


### PR DESCRIPTION
## Summary

A fresh instance was admitted against nothing. `thane init` declared no `seed_signers` at all, so the root holding the config had no set of keys entitled to establish it, and admission had nothing to judge it against. This is the last unbuilt item on #1264.

`thane init` now founds core with an **operator key** — defaulted from the operator's own git configuration, overridable with `-operator-key`, and skippable with `-self-signed`.

## The key that gets declared is the key that signs the birth

This is the constraint that shapes everything else. Declaring `seed_signers: [operator]` while the *agent* signs the birth produces a root that initializes cleanly and then refuses to serve, because admission judges the birth against the declared set. So the argument has to supply a key this process can sign with, not merely one to name.

That makes discovery narrower than it first looks, and each narrowing has its own remedy — so the fallback explains which one applied rather than failing quietly:

| user.signingkey | outcome |
|---|---|
| private key path | anchored |
| `.pub` with the private half beside it | anchored |
| `key::ssh-ed25519 …` literal | self-signed — "cannot sign anything on its own" |
| `.pub` with no private half | self-signed — "no private key sits beside it" |
| passphrase-protected | self-signed — the loader says so |
| `gpg.format` unset or `openpgp` | self-signed — "user.signingkey is not an SSH key" |

git signs happily with most of those by handing the work to an agent. Founding core happens here, in-process, from a file.

## Self-signed, in the vocabulary operators already have

Where no signable key is found, core is **self-signed**, and the term is borrowed on purpose: anyone with TLS experience already knows what a self-signed thing is worth. It works, and it is admissible — the agent is declared as its own seed rather than leaving the root ungoverned, which was the state this issue set out to end. What init will not do is let it arrive silently:

```
! core is self-signed: its only seed signer is this instance's own agent key,
  so nothing outside the instance attests to it and the agent could re-establish
  the root that holds its config.
  Why: git is not configured to sign commits with an SSH key (gpg.format is unset).
  To anchor it to a key you hold, re-initialize an empty workspace with:
    thane init -operator-key ~/.ssh/id_ed25519 <dir>
```

An explicitly supplied key that cannot be loaded is an **error**, not a fallback. Being handed a key and quietly producing a weaker instance than was asked for is the one outcome that should never be silent.

## The two shapes

| | in-tree `.allowed_signers` | `roots.core.seed_signers` | birth signed by |
|---|---|---|---|
| Anchored | agent + operator | operator | operator |
| Self-signed | agent | agent | agent |

The anchored row is the posture production reached by hand. The agent still signs `ego.md` and `metacognitive.md` because the trust file names it; it cannot found or re-found core because the seed set does not. Keeping the seed set and the trust set distinct is what makes the hardened shape usable rather than merely strict.

The flags also exist for wrapper installers: `thane-agent-macos` can ask "which key is yours?" however suits it and pass the answer, instead of asking someone at first run to reason about trust roots.

## Known boundary

`init` declares core's seed set, and the boot gate verifies core's config against it. Per-root *admission* additionally governs core only once the operator enables git verification for that root, since admission is scoped by `verify_signatures` like every other root. Emitting a full git policy for core at init is a larger behavioral change to what a fresh instance does, and belongs in its own change.

## Test plan

- [x] Table over every `user.signingkey` shape, asserting both the resolved path and the reason given when there isn't one
- [x] Anchored core verified by running **admission** against the declared seed — the assertion a declare-without-signing mistake would fail
- [x] Anchored core still lists the agent in `.allowed_signers`, so it can write core afterwards
- [x] Self-signed core is admissible under its own agent seed rather than ungoverned
- [x] Both postures exercised end to end via the built binary; `thane validate` exits 0 on each
- [x] Existing init tests pass `-self-signed` so they cannot read the developer's real git config
- [x] `just ci` passes

Refs #1264