### PR TITLE
The document's history is the iteration log

### DIFF
--- a/internal/app/core_service_loops.go
+++ b/internal/app/core_service_loops.go
@@ -2,7 +2,6 @@ package app
 
 import (
 	"fmt"
-	"path/filepath"
 
 	"github.com/nugget/thane-ai-agent/internal/platform/config"
 	"github.com/nugget/thane-ai-agent/internal/runtime/archivist"
@@ -90,12 +89,7 @@ var metacognitiveRegistration = coreServiceRegistration{
 		if a.metacogCfg == nil {
 			return looppkg.Spec{}, fmt.Errorf("metacognitive definition requires metacognitive config")
 		}
-		stateFileName := filepath.Base(a.metacogCfg.StateFile)
-		stateFilePath := coreFilePath(a.cfg.Workspace.Path, stateFileName)
-		return metacognitive.HydrateSpec(spec, *a.metacogCfg, metacognitive.Opts{
-			StateFilePath: stateFilePath,
-			StateFileName: stateFileName,
-		}), nil
+		return metacognitive.HydrateSpec(spec, *a.metacogCfg), nil
 	},
 }
 

--- a/internal/app/loop_definition_hydration_test.go
+++ b/internal/app/loop_definition_hydration_test.go
@@ -421,13 +421,14 @@ func TestCoreServiceRegistrationHydrate(t *testing.T) {
 			if spec.TaskBuilder != nil {
 				t.Error("Hydrate should not attach a TaskBuilder; the prompt is the declarative spec Task")
 			}
-			// metacognitive is the only core loop with a remaining runtime
-			// hook: the PostIterate iteration-log writer (which needs the
-			// resolved state-file path). ego and archivist are hook-free
-			// here — the archivist's work-queue tools are attached later, at
-			// app hydration, not by this registration closure.
-			if reg.Name == "metacognitive" && spec.PostIterate == nil {
-				t.Error("metacognitive Hydrate should attach the PostIterate iteration-log writer")
+			// No core loop attaches a runtime hook here any more. The
+			// metacognitive iteration-log writer was the last one, and it
+			// appended telemetry to the very document whose signed history
+			// now records the same iterations far better. The archivist's
+			// work-queue tools are attached later, at app hydration, not by
+			// this registration closure.
+			if spec.PostIterate != nil {
+				t.Errorf("%s Hydrate should not attach a PostIterate hook", reg.Name)
 			}
 		})
 	}

--- a/internal/runtime/metacognitive/metacognitive.go
+++ b/internal/runtime/metacognitive/metacognitive.go
@@ -14,29 +14,20 @@
 // [loop.Spec.SupervisorProfile] on its normal routing.
 //
 // The loop lifecycle is managed by the [loop] package. This loop is
-// declarative: the per-iteration prompt is the spec Task plus the
-// supervisor-turn [loop.Spec.SupervisorProfile] Instructions. The only
-// runtime-only hook is the PostIterate iteration-log writer, which
-// [HydrateSpec] attaches to a durable loop definition.
+// declarative and attaches no runtime hooks: the per-iteration prompt is
+// the spec Task plus the supervisor-turn [loop.Spec.SupervisorProfile]
+// Instructions, and the state document is written only by the model,
+// through the declared output — the same shape as the ego loop.
 package metacognitive
 
 import (
-	"context"
-	"errors"
 	"fmt"
-	"io/fs"
-	"log/slog"
-	"os"
-	"path/filepath"
-	"reflect"
-	"sort"
 	"strings"
 	"time"
 
 	"github.com/nugget/thane-ai-agent/internal/model/prompts"
 	"github.com/nugget/thane-ai-agent/internal/model/router"
 	"github.com/nugget/thane-ai-agent/internal/platform/config"
-	"github.com/nugget/thane-ai-agent/internal/platform/logging"
 	"github.com/nugget/thane-ai-agent/internal/runtime/loop"
 	"github.com/nugget/thane-ai-agent/internal/tools"
 )
@@ -45,41 +36,9 @@ import (
 // metacognitive service.
 const DefinitionName = "metacognitive"
 
-// iterationLogRetention is the number of iteration log blocks to keep
-// when pruning. Oldest beyond this limit are removed.
-const iterationLogRetention = 5
-
-// iterationLogPrefix is the HTML comment prefix used for iteration log
-// blocks. Used for scanning/pruning.
-const iterationLogPrefix = "<!-- iteration_log:"
-
 // stateFileName is the fixed filename of the metacognitive state
 // document. The app runtime places it under workspace/core.
 const stateFileName = "metacognitive.md"
-
-// ProvenanceWriter is the subset of [provenance.Store] needed by the
-// metacognitive loop for committing state file updates.
-type ProvenanceWriter interface {
-	Read(filename string) (string, error)
-	Write(ctx context.Context, filename, content, message string) error
-}
-
-// hasProvenanceWriter guards against typed-nil interfaces such as a
-// nil *provenance.Store assigned to ProvenanceWriter. A plain store !=
-// nil check is insufficient in that case and can lead to nil receiver
-// panics at call time.
-func hasProvenanceWriter(store ProvenanceWriter) bool {
-	if store == nil {
-		return false
-	}
-	v := reflect.ValueOf(store)
-	switch v.Kind() {
-	case reflect.Pointer, reflect.Map, reflect.Slice, reflect.Interface, reflect.Func:
-		return !v.IsNil()
-	default:
-		return true
-	}
-}
 
 // Config holds the parsed metacognitive loop configuration with
 // time.Duration fields (as opposed to the YAML string representation
@@ -134,27 +93,6 @@ func derefFloat(p *float64, def float64) float64 {
 		return def
 	}
 	return *p
-}
-
-// Opts holds options for [BuildLoopConfig] that are not part of [Config].
-type Opts struct {
-	// WorkspacePath is the absolute path to the workspace directory.
-	// Used only as a fallback when ProvenanceStore is nil.
-	WorkspacePath string
-
-	// StateFilePath is the resolved absolute path to the state file.
-	// When a provenance store is configured, this points inside the
-	// store; otherwise it falls back to workspace-relative resolution.
-	StateFilePath string
-
-	// ProvenanceStore, when non-nil, is used by the iteration logger
-	// to commit state file updates with SSH signatures.
-	ProvenanceStore ProvenanceWriter
-
-	// StateFileName is the bare filename (e.g. "metacognitive.md") used
-	// for provenance store reads and writes. Ignored when ProvenanceStore
-	// is nil.
-	StateFileName string
 }
 
 // DefinitionSpec returns the persistable loop definition for the
@@ -212,20 +150,13 @@ func supervisorProfile(qualityFloor int) *router.LoopProfile {
 	return p
 }
 
-// HydrateSpec attaches the one remaining runtime-only hook the
-// metacognitive service needs from a durable loop definition: the
-// PostIterate iteration-log writer, which appends a provenance-signed
-// telemetry block to the state document each cycle and needs the
-// resolved state-file path from opts. The prompt itself is declarative
-// (the spec Task and SupervisorProfile.Instructions).
-func HydrateSpec(spec loop.Spec, _ Config, opts Opts) loop.Spec {
+// HydrateSpec fills in what a durable loop definition cannot carry.
+// That is now only the name: the prompt is declarative (the spec Task
+// and SupervisorProfile.Instructions), and nothing runtime-side writes
+// the state document.
+func HydrateSpec(spec loop.Spec, _ Config) loop.Spec {
 	if strings.TrimSpace(spec.Name) == "" {
 		spec.Name = DefinitionName
-	}
-	spec.PostIterate = func(ctx context.Context, result loop.IterationResult) error {
-		log := logging.Logger(ctx)
-		appendIterationLog(ctx, log, opts.StateFilePath, opts.ProvenanceStore, opts.StateFileName, &result)
-		return nil
 	}
 	return spec
 }
@@ -246,170 +177,3 @@ var metacogExcludeTools = append([]string{
 	// the `loops` capability metacognition can't activate.
 	"thane_loop_create",
 }, tools.DirectHumanEgressToolNames()...)
-
-// appendIterationLog appends an HTML comment summary block to the state
-// file after a successful iteration. Old logs beyond
-// [iterationLogRetention] are pruned. This is best-effort: errors are
-// logged but never disrupt the loop.
-//
-// When store is non-nil, reads and writes go through the provenance
-// store (committed with SSH signatures). When nil, direct file I/O is
-// used at statePath.
-func appendIterationLog(ctx context.Context, log *slog.Logger, statePath string, store ProvenanceWriter, stateFileName string, result *loop.IterationResult) {
-	// Read the full file (uncapped) to avoid truncation on rewrite.
-	var content string
-	if hasProvenanceWriter(store) {
-		existing, err := store.Read(stateFileName)
-		if err != nil && !os.IsNotExist(err) {
-			log.Warn("failed to read state file from provenance for iteration log, skipping append",
-				"error", err,
-			)
-			return
-		}
-		content = existing
-	} else {
-		data, err := os.ReadFile(statePath)
-		if err != nil {
-			if !errors.Is(err, fs.ErrNotExist) {
-				log.Warn("failed to read state file for iteration log, skipping append",
-					"error", err,
-				)
-				return
-			}
-			// File doesn't exist yet — start with empty content.
-		} else {
-			content = string(data)
-		}
-	}
-
-	// Prune old iteration logs before appending.
-	content = pruneIterationLogs(content, iterationLogRetention)
-
-	// Format tools_called as "[tool_a x3, tool_b x1]".
-	toolsList := formatToolsUsed(result.ToolsUsed)
-
-	logBlock := fmt.Sprintf(
-		"\n%s conversation=%s model=%s supervisor=%v\n"+
-			"     timestamp=%s elapsed=%s\n"+
-			"     tools_called=%s\n"+
-			"     tokens_in=%d tokens_out=%d sleep_set=%s -->\n",
-		iterationLogPrefix,
-		result.ConvID,
-		result.Model,
-		result.Supervisor,
-		time.Now().UTC().Format(time.RFC3339),
-		result.Elapsed.Round(time.Second),
-		toolsList,
-		result.InputTokens,
-		result.OutputTokens,
-		result.Sleep.Round(time.Second),
-	)
-
-	fullContent := content + logBlock
-
-	if hasProvenanceWriter(store) {
-		if err := store.Write(ctx, stateFileName, fullContent, "iteration-log"); err != nil {
-			log.Warn("failed to commit iteration log to provenance",
-				"error", err,
-			)
-		}
-		return
-	}
-
-	// Fallback: direct file I/O.
-	// Ensure the parent directory exists (state file may be in a subdir).
-	if err := os.MkdirAll(filepath.Dir(statePath), 0o755); err != nil {
-		log.Warn("failed to create directory for iteration log",
-			"error", err,
-		)
-		return
-	}
-	if err := os.WriteFile(statePath, []byte(fullContent), 0o644); err != nil {
-		log.Warn("failed to append iteration log",
-			"error", err,
-		)
-	}
-}
-
-// formatToolsUsed formats a map[string]int as "[tool_a x3, tool_b]".
-// Tools with a count of 1 omit the multiplier.
-func formatToolsUsed(tools map[string]int) string {
-	if len(tools) == 0 {
-		return "[]"
-	}
-
-	// Sort for deterministic output.
-	names := make([]string, 0, len(tools))
-	for name := range tools {
-		names = append(names, name)
-	}
-	sort.Strings(names)
-
-	var parts []string
-	for _, name := range names {
-		count := tools[name]
-		if count > 1 {
-			parts = append(parts, fmt.Sprintf("%s x%d", name, count))
-		} else {
-			parts = append(parts, name)
-		}
-	}
-	return "[" + strings.Join(parts, ", ") + "]"
-}
-
-// pruneIterationLogs removes old iteration log blocks from content,
-// keeping the last keepN blocks. Each block is removed individually so
-// any non-log content interleaved between blocks is preserved. Returns
-// the pruned content. This is a pure function for easy testing.
-func pruneIterationLogs(content string, keepN int) string {
-	// Find all iteration log block positions.
-	var positions []int
-	searchFrom := 0
-	for {
-		idx := strings.Index(content[searchFrom:], iterationLogPrefix)
-		if idx < 0 {
-			break
-		}
-		positions = append(positions, searchFrom+idx)
-		searchFrom += idx + len(iterationLogPrefix)
-	}
-
-	if len(positions) <= keepN {
-		return content
-	}
-
-	// Remove the oldest blocks individually, preserving content between them.
-	removeCount := len(positions) - keepN
-	var result strings.Builder
-	currentPos := 0
-
-	for i := 0; i < removeCount; i++ {
-		blockPos := positions[i]
-
-		// Include a preceding newline in the removal if present.
-		blockStart := blockPos
-		if blockStart > 0 && content[blockStart-1] == '\n' {
-			blockStart--
-		}
-
-		// Write any content between the previous position and this block.
-		if currentPos < blockStart {
-			result.WriteString(content[currentPos:blockStart])
-		}
-
-		// Find the end of this block: "-->\n".
-		endMarker := strings.Index(content[blockPos:], "-->\n")
-		if endMarker < 0 {
-			// Malformed block — treat as running to end of content.
-			currentPos = len(content)
-			break
-		}
-		currentPos = blockPos + endMarker + len("-->\n")
-	}
-
-	// Append any remaining content after the last removed block.
-	if currentPos < len(content) {
-		result.WriteString(content[currentPos:])
-	}
-	return result.String()
-}

--- a/internal/runtime/metacognitive/metacognitive_test.go
+++ b/internal/runtime/metacognitive/metacognitive_test.go
@@ -1,11 +1,6 @@
 package metacognitive
 
 import (
-	"context"
-	"fmt"
-	"log/slog"
-	"os"
-	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -90,242 +85,11 @@ func TestParseConfig_InvalidDuration(t *testing.T) {
 	}
 }
 
-// --- appendIterationLog tests ---
-
-func TestAppendIterationLog(t *testing.T) {
-	tmpDir := t.TempDir()
-	statePath := filepath.Join(tmpDir, "metacognitive.md")
-
-	// Write an initial state file.
-	initial := "## Current Sense\nAll quiet.\n"
-	if err := os.WriteFile(statePath, []byte(initial), 0o644); err != nil {
-		t.Fatalf("write state: %v", err)
-	}
-
-	result := &loop.IterationResult{
-		ConvID:       "metacog-12345",
-		Model:        "llama3:8b",
-		InputTokens:  12000,
-		OutputTokens: 500,
-		ToolsUsed:    map[string]int{"ha_get_state": 3, "replace_output_metacognitive_state": 1},
-		Elapsed:      3*time.Minute + 12*time.Second,
-		Supervisor:   false,
-		Sleep:        8 * time.Minute,
-	}
-
-	appendIterationLog(context.Background(), slog.Default(), statePath, nil, "", result)
-
-	data, err := os.ReadFile(statePath)
-	if err != nil {
-		t.Fatalf("read state: %v", err)
-	}
-	s := string(data)
-
-	// Verify the original content is preserved.
-	if !strings.Contains(s, "All quiet.") {
-		t.Error("original content should be preserved")
-	}
-
-	// Verify log block fields.
-	if !strings.Contains(s, "<!-- iteration_log:") {
-		t.Error("should contain iteration_log prefix")
-	}
-	if !strings.Contains(s, "conversation=metacog-12345") {
-		t.Error("should contain conversation ID")
-	}
-	if !strings.Contains(s, "model=llama3:8b") {
-		t.Error("should contain model name")
-	}
-	if !strings.Contains(s, "supervisor=false") {
-		t.Error("should contain supervisor flag")
-	}
-	if !strings.Contains(s, "tokens_in=12000") {
-		t.Error("should contain input tokens")
-	}
-	if !strings.Contains(s, "tokens_out=500") {
-		t.Error("should contain output tokens")
-	}
-	if !strings.Contains(s, "sleep_set=8m0s") {
-		t.Error("should contain sleep duration")
-	}
-	if !strings.Contains(s, "ha_get_state x3") {
-		t.Error("should contain tools with counts")
-	}
-	if !strings.Contains(s, "replace_output_metacognitive_state") {
-		t.Error("should contain tool names")
-	}
-	if !strings.Contains(s, "elapsed=3m12s") {
-		t.Error("should contain elapsed time")
-	}
-}
-
-func TestAppendIterationLog_NoStateFile(t *testing.T) {
-	tmpDir := t.TempDir()
-	statePath := filepath.Join(tmpDir, "metacognitive.md")
-
-	result := &loop.IterationResult{
-		ConvID:       "metacog-first",
-		Model:        "test-model",
-		InputTokens:  100,
-		OutputTokens: 50,
-		Elapsed:      time.Second,
-		Sleep:        5 * time.Minute,
-	}
-
-	appendIterationLog(context.Background(), slog.Default(), statePath, nil, "", result)
-
-	data, err := os.ReadFile(statePath)
-	if err != nil {
-		t.Fatalf("read state: %v", err)
-	}
-	s := string(data)
-
-	if !strings.Contains(s, "<!-- iteration_log:") {
-		t.Error("log block should be written even when no state file existed")
-	}
-	if !strings.Contains(s, "conversation=metacog-first") {
-		t.Error("should contain conversation ID")
-	}
-}
-
-type panicProvenanceWriter struct{}
-
-func (*panicProvenanceWriter) Read(string) (string, error) {
-	panic("unexpected provenance read")
-}
-
-func (*panicProvenanceWriter) Write(context.Context, string, string, string) error {
-	panic("unexpected provenance write")
-}
-
-func TestAppendIterationLog_TypedNilProvenanceWriterFallsBackToFileIO(t *testing.T) {
-	tmpDir := t.TempDir()
-	statePath := filepath.Join(tmpDir, "metacognitive.md")
-	if err := os.WriteFile(statePath, []byte("## Current Sense\nStill here.\n"), 0o644); err != nil {
-		t.Fatalf("write state: %v", err)
-	}
-
-	var store ProvenanceWriter = (*panicProvenanceWriter)(nil)
-	result := &loop.IterationResult{
-		ConvID:       "metacog-typed-nil",
-		Model:        "llama3:8b",
-		InputTokens:  111,
-		OutputTokens: 22,
-		Elapsed:      2 * time.Second,
-		Sleep:        3 * time.Minute,
-	}
-
-	appendIterationLog(context.Background(), slog.Default(), statePath, store, "metacognitive.md", result)
-
-	data, err := os.ReadFile(statePath)
-	if err != nil {
-		t.Fatalf("read state: %v", err)
-	}
-	if !strings.Contains(string(data), "conversation=metacog-typed-nil") {
-		t.Error("iteration log should still be appended via direct file I/O")
-	}
-}
-
-// --- pruneIterationLogs tests ---
-
-func TestPruneIterationLogs_NoLogs(t *testing.T) {
-	content := "## Current Sense\nAll quiet.\n\n<!-- metacognitive: iteration=x updated=y -->\n"
-	got := pruneIterationLogs(content, 5)
-	if got != content {
-		t.Errorf("content with no iteration logs should be unchanged\ngot: %q\nwant: %q", got, content)
-	}
-}
-
-func TestPruneIterationLogs_UnderLimit(t *testing.T) {
-	var sb strings.Builder
-	sb.WriteString("## State\n")
-	for i := 0; i < 3; i++ {
-		fmt.Fprintf(&sb, "\n<!-- iteration_log: conversation=c%d model=m supervisor=false\n     tokens_in=100 tokens_out=50 -->\n", i)
-	}
-	content := sb.String()
-
-	got := pruneIterationLogs(content, 5)
-	if got != content {
-		t.Error("content with fewer logs than limit should be unchanged")
-	}
-}
-
-func TestPruneIterationLogs_AtLimit(t *testing.T) {
-	var sb strings.Builder
-	sb.WriteString("## State\n")
-	for i := 0; i < 5; i++ {
-		fmt.Fprintf(&sb, "\n<!-- iteration_log: conversation=c%d model=m supervisor=false\n     tokens_in=100 tokens_out=50 -->\n", i)
-	}
-	content := sb.String()
-
-	got := pruneIterationLogs(content, 5)
-	if got != content {
-		t.Error("content with exactly limit logs should be unchanged")
-	}
-}
-
-func TestPruneIterationLogs_OverLimit(t *testing.T) {
-	var sb strings.Builder
-	sb.WriteString("## State\nSome content.\n")
-	for i := 0; i < 8; i++ {
-		fmt.Fprintf(&sb, "\n<!-- iteration_log: conversation=c%d model=m supervisor=false\n     tokens_in=100 tokens_out=50 -->\n", i)
-	}
-	content := sb.String()
-
-	got := pruneIterationLogs(content, 5)
-
-	// Should contain last 5 (c3..c7) but not first 3 (c0..c2).
-	for i := 0; i < 3; i++ {
-		if strings.Contains(got, fmt.Sprintf("conversation=c%d", i)) {
-			t.Errorf("pruned content should not contain conversation=c%d", i)
-		}
-	}
-	for i := 3; i < 8; i++ {
-		if !strings.Contains(got, fmt.Sprintf("conversation=c%d", i)) {
-			t.Errorf("pruned content should contain conversation=c%d", i)
-		}
-	}
-
-	// Original non-log content should be preserved.
-	if !strings.Contains(got, "Some content.") {
-		t.Error("non-log content should be preserved")
-	}
-}
-
-// --- formatToolsUsed tests ---
-
-func TestFormatToolsUsed_Empty(t *testing.T) {
-	got := formatToolsUsed(nil)
-	if got != "[]" {
-		t.Errorf("formatToolsUsed(nil) = %q, want %q", got, "[]")
-	}
-}
-
-func TestFormatToolsUsed_Sorted(t *testing.T) {
-	toolsMap := map[string]int{
-		"set_next_sleep":                     1,
-		"ha_get_state":                       3,
-		"replace_output_metacognitive_state": 1,
-	}
-	got := formatToolsUsed(toolsMap)
-
-	// Should be sorted alphabetically.
-	if got != "[ha_get_state x3, replace_output_metacognitive_state, set_next_sleep]" {
-		t.Errorf("formatToolsUsed = %q, want sorted with counts", got)
-	}
-}
-
 // --- Hydrated spec/config projection tests ---
 
 func TestHydratedSpec(t *testing.T) {
-	tmpDir := t.TempDir()
 	cfg := testConfig()
-	opts := Opts{
-		WorkspacePath: tmpDir,
-		StateFilePath: filepath.Join(tmpDir, cfg.StateFile),
-	}
-
-	spec := HydrateSpec(DefinitionSpec(cfg), cfg, opts)
+	spec := HydrateSpec(DefinitionSpec(cfg), cfg)
 	if spec.Name != "metacognitive" {
 		t.Errorf("Name = %q, want metacognitive", spec.Name)
 	}
@@ -373,41 +137,9 @@ func TestDefinitionSpecPersistable(t *testing.T) {
 	}
 }
 
-func TestHydrateSpecAttachesLoopRuntimeHooks(t *testing.T) {
-	tmpDir := t.TempDir()
-	cfg := testConfig()
-	opts := Opts{
-		WorkspacePath: tmpDir,
-		StateFilePath: filepath.Join(tmpDir, cfg.StateFile),
-		StateFileName: cfg.StateFile,
-	}
-
-	spec := HydrateSpec(DefinitionSpec(cfg), cfg, opts)
-	// Declarative prompt: no TaskBuilder. The one runtime hook hydration
-	// attaches is the PostIterate iteration-log writer.
-	if spec.TaskBuilder != nil {
-		t.Fatal("metacognitive loop is declarative; HydrateSpec should attach no TaskBuilder")
-	}
-	if !strings.Contains(spec.Task, "Metacognitive loop iteration") {
-		t.Error("spec.Task should be the metacognitive base prompt")
-	}
-	if spec.PostIterate == nil {
-		t.Fatal("PostIterate (iteration-log writer) should be set after hydration")
-	}
-	if spec.Setup != nil {
-		t.Fatal("HydrateSpec should not attach app-level setup hooks")
-	}
-}
-
 func TestHydratedConfig(t *testing.T) {
-	tmpDir := t.TempDir()
 	cfg := testConfig()
-	opts := Opts{
-		WorkspacePath: tmpDir,
-		StateFilePath: filepath.Join(tmpDir, cfg.StateFile),
-	}
-
-	spec := HydrateSpec(DefinitionSpec(cfg), cfg, opts)
+	spec := HydrateSpec(DefinitionSpec(cfg), cfg)
 	lc := spec.ToConfig()
 
 	if lc.Name != "metacognitive" {
@@ -431,8 +163,8 @@ func TestHydratedConfig(t *testing.T) {
 	if !strings.Contains(lc.Task, "Metacognitive loop iteration") {
 		t.Error("lc.Task should be the metacognitive base prompt")
 	}
-	if lc.PostIterate == nil {
-		t.Error("PostIterate should be set")
+	if lc.PostIterate != nil {
+		t.Error("metacognitive attaches no PostIterate hook; its iteration history is the state document's own signed history")
 	}
 	// Profile-derived routing factors (mission/source) and DelegationGating
 	// are applied by the live loop at request time via Profile.RequestOptions,
@@ -452,14 +184,8 @@ func TestHydratedConfig(t *testing.T) {
 }
 
 func TestHydratedConfig_Task(t *testing.T) {
-	tmpDir := t.TempDir()
 	cfg := testConfig()
-	opts := Opts{
-		WorkspacePath: tmpDir,
-		StateFilePath: filepath.Join(tmpDir, cfg.StateFile),
-	}
-
-	spec := HydrateSpec(DefinitionSpec(cfg), cfg, opts)
+	spec := HydrateSpec(DefinitionSpec(cfg), cfg)
 	lc := spec.ToConfig()
 
 	// The prompt is now a static Task (no TaskBuilder); current state
@@ -475,44 +201,6 @@ func TestHydratedConfig_Task(t *testing.T) {
 	}
 	if strings.Contains(lc.Task, "does not exist yet") {
 		t.Error("Task should not carry the old first-iteration placeholder")
-	}
-}
-
-func TestHydratedConfig_PostIterate(t *testing.T) {
-	tmpDir := t.TempDir()
-	cfg := testConfig()
-	statePath := filepath.Join(tmpDir, cfg.StateFile)
-	opts := Opts{
-		WorkspacePath: tmpDir,
-		StateFilePath: statePath,
-	}
-
-	spec := HydrateSpec(DefinitionSpec(cfg), cfg, opts)
-	lc := spec.ToConfig()
-
-	result := loop.IterationResult{
-		ConvID:       "metacog-post-test",
-		Model:        "test-model",
-		InputTokens:  100,
-		OutputTokens: 50,
-		Elapsed:      time.Second,
-		Sleep:        5 * time.Minute,
-	}
-
-	err := lc.PostIterate(context.Background(), result)
-	if err != nil {
-		t.Fatalf("PostIterate: %v", err)
-	}
-
-	// Verify state file was written with iteration log.
-	data, err := os.ReadFile(statePath)
-	if err != nil {
-		t.Fatalf("read state: %v", err)
-	}
-	s := string(data)
-
-	if !strings.Contains(s, "conversation=metacog-post-test") {
-		t.Error("PostIterate should append iteration log with conversation ID")
 	}
 }
 


### PR DESCRIPTION
## Summary

The metacognitive loop appended a telemetry block — timestamp, elapsed, tools used, tokens, sleep — to `core/metacognitive.md` after every iteration. That writer is gone. The need it served is served better by the signed history the document now carries: `doc_history` reads the same sequence with diffs and attribution, without parsing HTML comments back out of prose.

## It also had to go, because it was breaking production

`Opts.ProvenanceStore` was never wired anywhere outside tests — `grep -rn "ProvenanceStore:" --include='*.go'` returns nothing in production code. So `hasProvenanceWriter` was always false, and the branch commented `// Fallback: direct file I/O.` was the *only* path. Every iteration left `core` with an uncommitted change.

Once the boot gate landed, that made the next restart fail. Production hit exactly this today:

| | |
|---|---|
| 20:17:56 | `doc_write core:metacognitive.md` — committed, signed |
| 20:19:11 | file mtime, 75s later — uncommitted |

Not a shutdown race, as first suspected: a separate write, a minute after the committed one, that never intended to commit. The behaviour is months old — the standalone `provenance/` repo it once committed to last received an `iteration-log` on **2026-04-06** — but a dirty core only became fatal recently. An old silent write turned into a startup refusal.

Worth noting the same evidence clears the wiring that was under suspicion: that 20:17:56 commit is a real loop write landing as a signed commit in core, which nobody had yet observed.

## Why not just wire the store

It was the other option and the wrong one. It would put a signed commit titled `iteration-log` into core every 15–60 minutes forever, burying the trust boundary's history under its least interesting content. The old provenance repo showed where that leads: 101 of its last 200 commits were exactly that. And it would carry a vestige of the pre-core arrangement into whatever #1250 unifies.

The block was also a category error. `metacognitive.md` is working notes — what the loop thinks. Elapsed and token counts are operational metrics — how it ran. Every field already exists in structured form (`elapsed_ms` and `no_op` on `loop_iteration_complete`, `sleep_duration` on `loop_sleep_start`, tokens in `usage_records`, calls in `tool_calls`), joinable by loop and conversation id. The prose block was a denormalized copy stitched into the wrong document.

## What this leaves

Exactly the ego loop's shape. Both declare one output ref and let the model be its only author; `internal/runtime/ego/` contains no write path at all, and now neither does metacognitive. `HydrateSpec` fills in the name and nothing else, matching `ego.HydrateSpec` line for line.

Two loops that always described themselves the same way now behave the same way, which is one fewer shape for the tiered output contract to absorb.

Net **-576 lines**: the writer, its pruner, `formatToolsUsed`, the `ProvenanceWriter` interface, `hasProvenanceWriter`, the whole `Opts` type, and their tests.

## About the test that pinned this

`TestCoreServiceRegistrationHydrate` asserted metacognitive *must* attach a `PostIterate` hook. It is inverted rather than deleted — no core loop attaches one, and reintroducing a runtime-side writer to a model-authored document should have to argue with a test first.

## Test plan

- [x] `just ci` passes
- [x] Registration test now asserts no core loop attaches a `PostIterate`
- [x] `HydrateSpec` projection asserts the state document has no runtime writer
- [x] No orphaned references: `iterationLogPrefix`, `iterationLogRetention`, and `pruneIterationLogs` all removed

Refs #1250