### PR TITLE
Talents move inside the trust boundary

### DIFF
--- a/cmd/thane/init.go
+++ b/cmd/thane/init.go
@@ -119,8 +119,9 @@ func runInit(w io.Writer, dir string, opts initOptions) error {
 
 	fmt.Fprintf(w, "Initializing Thane workspace in %s\n", absDir)
 
-	// Create directory structure.
-	for _, sub := range []string{"db", "talents"} {
+	// Create directory structure. Talents are not among these: they live
+	// inside core now, and arrive as part of its birth commit.
+	for _, sub := range []string{"db"} {
 		p := filepath.Join(absDir, sub)
 		if err := os.MkdirAll(p, 0o755); err != nil {
 			return fmt.Errorf("create %s: %w", sub, err)
@@ -137,23 +138,9 @@ func runInit(w io.Writer, dir string, opts initOptions) error {
 		return err
 	}
 
-	// Write talent files from embedded defaults.
-	err = fs.WalkDir(talents.DefaultFiles, "defaults", func(path string, d fs.DirEntry, err error) error {
-		if err != nil || d.IsDir() {
-			return err
-		}
-		name := filepath.Base(path)
-		if !strings.HasSuffix(name, ".md") {
-			return nil
-		}
-		data, err := talents.DefaultFiles.ReadFile(path)
-		if err != nil {
-			return fmt.Errorf("read embedded %s: %w", name, err)
-		}
-		return writeIfMissing(w, filepath.Join(absDir, "talents", name), data, 0o644)
-	})
+	bundledTalents, err := bundledTalentFiles()
 	if err != nil {
-		return fmt.Errorf("deploy talents: %w", err)
+		return err
 	}
 
 	ctx := context.Background()
@@ -161,12 +148,13 @@ func runInit(w io.Writer, dir string, opts initOptions) error {
 	if err != nil {
 		return err
 	}
-	result, err := identity.BootstrapCore(ctx, filepath.Join(absDir, "core"), filepath.Base(absDir), operator, slog.Default())
+	result, err := identity.BootstrapCore(ctx, filepath.Join(absDir, "core"), filepath.Base(absDir), operator, bundledTalents, slog.Default())
 	if err != nil {
 		return fmt.Errorf("bootstrap core identity: %w", err)
 	}
 	if result.Created {
 		fmt.Fprintf(w, "  ✓ %s (core identity, signing %s)\n", result.CoreDir, result.SigningKeyFingerprint)
+		fmt.Fprintf(w, "  ✓ %d talents, signed as part of core's birth\n", len(bundledTalents))
 		describeCorePosture(w, result, why)
 	} else {
 		fmt.Fprintf(w, "  · %s (core identity exists, skipping)\n", result.CoreDir)
@@ -268,4 +256,34 @@ func runInitCommand(stdout, stderr io.Writer, args []string) error {
 		dir = fs.Arg(0)
 	}
 	return runInit(stdout, dir, opts)
+}
+
+// bundledTalentFiles reads the talent set compiled into the binary, keyed by
+// the repo-relative path it takes inside core.
+//
+// They are handed to the birth commit rather than written to disk first, so a
+// fresh instance never has a moment where its behaviour definitions exist
+// unsigned. That also means they are covered by the operator key when one
+// founds the instance, rather than by whoever commits next.
+func bundledTalentFiles() (map[string]string, error) {
+	out := make(map[string]string)
+	err := fs.WalkDir(talents.DefaultFiles, "defaults", func(path string, d fs.DirEntry, err error) error {
+		if err != nil || d.IsDir() {
+			return err
+		}
+		name := filepath.Base(path)
+		if !strings.HasSuffix(name, ".md") {
+			return nil
+		}
+		data, err := talents.DefaultFiles.ReadFile(path)
+		if err != nil {
+			return fmt.Errorf("read embedded %s: %w", name, err)
+		}
+		out["talents/"+name] = string(data)
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("collect bundled talents: %w", err)
+	}
+	return out, nil
 }

--- a/cmd/thane/init_test.go
+++ b/cmd/thane/init_test.go
@@ -375,6 +375,7 @@ func TestInitFlagErrorsGoToStderr(t *testing.T) {
 // that same key covers them.
 func TestInitDeploysTalentsIntoCoresBirthCommit(t *testing.T) {
 	t.Parallel()
+	requireGit(t)
 	dir := t.TempDir()
 	var buf bytes.Buffer
 	if err := runInit(&buf, dir, initOptions{SelfSigned: true}); err != nil {

--- a/cmd/thane/init_test.go
+++ b/cmd/thane/init_test.go
@@ -38,7 +38,7 @@ func TestRunInit_FreshDirectory(t *testing.T) {
 	out := buf.String()
 
 	// Verify directory structure.
-	for _, sub := range []string{"core", "db", "talents"} {
+	for _, sub := range []string{"core", "db", filepath.Join("core", "talents")} {
 		info, err := os.Stat(filepath.Join(dir, sub))
 		if err != nil {
 			t.Errorf("expected directory %s: %v", sub, err)
@@ -65,8 +65,9 @@ func TestRunInit_FreshDirectory(t *testing.T) {
 		t.Errorf("persona.md permissions = %o, want 0644", got)
 	}
 
-	// Verify at least one talent file was deployed.
-	entries, err := os.ReadDir(filepath.Join(dir, "talents"))
+	// Verify at least one talent file was deployed. They live inside core,
+	// so they arrive through its birth commit rather than as loose files.
+	entries, err := os.ReadDir(filepath.Join(dir, "core", "talents"))
 	if err != nil {
 		t.Fatalf("read talents dir: %v", err)
 	}
@@ -362,5 +363,41 @@ func TestInitFlagErrorsGoToStderr(t *testing.T) {
 	}
 	if !strings.Contains(stderr.String(), "no-such-flag") {
 		t.Fatalf("stderr should carry the flag failure, got:\n%s", stderr.String())
+	}
+}
+
+// TestInitDeploysTalentsIntoCoresBirthCommit pins where talents live and when
+// they become attested.
+//
+// They arrive as part of the birth commit rather than being written to disk
+// first, so a fresh instance never has a moment where its behaviour
+// definitions exist unsigned — and when an operator key founds the instance,
+// that same key covers them.
+func TestInitDeploysTalentsIntoCoresBirthCommit(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	var buf bytes.Buffer
+	if err := runInit(&buf, dir, initOptions{SelfSigned: true}); err != nil {
+		t.Fatalf("runInit: %v", err)
+	}
+
+	entries, err := os.ReadDir(filepath.Join(dir, "core", "talents"))
+	if err != nil {
+		t.Fatalf("talents should live inside core: %v", err)
+	}
+	if len(entries) == 0 {
+		t.Fatal("no talents deployed into core")
+	}
+	if _, err := os.Stat(filepath.Join(dir, "talents")); !os.IsNotExist(err) {
+		t.Fatalf("talents must not also be deployed beside core: %v", err)
+	}
+
+	// The whole point: core is clean afterwards, so the instance can start.
+	out, err := exec.Command("git", "-C", filepath.Join(dir, "core"), "status", "--porcelain").Output()
+	if err != nil {
+		t.Fatalf("git status: %v", err)
+	}
+	if strings.TrimSpace(string(out)) != "" {
+		t.Fatalf("core should be clean after init, got:\n%s", out)
 	}
 }

--- a/examples/config.example.yaml
+++ b/examples/config.example.yaml
@@ -599,11 +599,6 @@ shell_exec:
 # Keep this separate from human-authored and model-authored
 # document roots. Default: "./db".
 data_dir: ./db
-# TalentsDir is the directory containing talent markdown files that
-# extend the system prompt. In higher-integrity deployments, this is
-# a curated managed root rather than a scratch workspace.
-# Default: "./talents".
-talents_dir: ./talents
 #
 # (optional) Archive configures session archive behavior.
 # archive:

--- a/internal/platform/config/config.go
+++ b/internal/platform/config/config.go
@@ -298,11 +298,14 @@ type Config struct {
 	// document roots. Default: "./db".
 	DataDir string `yaml:"data_dir"`
 
-	// TalentsDir is the directory containing talent markdown files that
-	// extend the system prompt. In higher-integrity deployments, this is
-	// a curated managed root rather than a scratch workspace.
-	// Default: "./talents".
-	TalentsDir string `yaml:"talents_dir"`
+	// TalentsDir is the directory holding the talent markdown that extends
+	// the system prompt.
+	//
+	// Derived as {workspace}/core/talents, never authored: talents steer
+	// every turn, so they carry the same signed history and the same
+	// cleanliness rule as the prompts beside them. Declaring it is refused
+	// with the migration — see [rejectRetiredKeys].
+	TalentsDir string `yaml:"-"`
 
 	// Archive configures session archive behavior.
 	Archive ArchiveConfig `yaml:"archive"`
@@ -1676,8 +1679,8 @@ func (c CapabilityTagConfig) Validate(tagName string, builtin bool) error {
 // Path and cannot escape it.
 type WorkspaceConfig struct {
 	// Path is the root directory for file operations: the writable
-	// parent holding Thane-owned roots such as core/, talents/,
-	// knowledge/, generated/, and scratchpad/.
+	// parent holding Thane-owned roots such as core/, knowledge/,
+	// generated/, and scratchpad/.
 	//
 	// It is derived, never authored. A config lives at
 	// {workspace}/core/config.yaml, so it states its workspace by
@@ -2494,6 +2497,8 @@ func rejectRetiredKeys(data []byte) error {
 			if err := rejectRetiredSigningKeys(valueNode); err != nil {
 				return err
 			}
+		case "talents_dir":
+			return fmt.Errorf("config declares talents_dir, which is now derived as {workspace}/core/talents rather than authored. Talents steer every turn, so they belong under the same signed history as the prompts beside them: move the directory into core (mv <talents_dir> {workspace}/core/talents), commit it, and remove the talents_dir: line")
 		case "curator":
 			return fmt.Errorf("config has top-level curator: section, which was renamed to archivist: when the loop became a self-paced queue consumer. Rename it (the field shape is unchanged) and re-load")
 		case "workspace":
@@ -2736,7 +2741,16 @@ func (c *Config) applyDefaults() {
 		c.DataDir = "./db"
 	}
 	if c.TalentsDir == "" {
-		c.TalentsDir = "./talents"
+		// Derived, never authored: talents live inside core so they carry the
+		// same signed history and the same cleanliness rule as the prompts
+		// they sit beside. Falls back to a relative path only when there is no
+		// workspace to derive from, which is the in-memory-config case tests
+		// and one-shot commands use.
+		if root := c.CoreRoot(); root != "" {
+			c.TalentsDir = filepath.Join(root, "talents")
+		} else {
+			c.TalentsDir = "./talents"
+		}
 	}
 	if c.Models.OllamaURL == "" && len(c.Models.Resources) == 0 {
 		c.Models.OllamaURL = "http://localhost:11434"

--- a/internal/platform/identity/bootstrap.go
+++ b/internal/platform/identity/bootstrap.go
@@ -77,7 +77,12 @@ func operatorPrincipal(operator *OperatorSigner) string {
 // Private key material is written under core/ with 0600 permissions and
 // ignored by git. Public key material, the channel CA certificate, and
 // core/config.yaml are committed together as the signed birth commit.
-func BootstrapCore(ctx context.Context, coreDir, instanceName string, operator *OperatorSigner, logger *slog.Logger) (*BootstrapResult, error) {
+// birthFiles are additional repo-relative files to include in the birth
+// commit. The talent set travels this way: talents steer every turn, so an
+// instance whose behaviour definitions are covered by the same operator
+// signature that founds it is attested from its first moment rather than from
+// whenever someone remembers to commit them.
+func BootstrapCore(ctx context.Context, coreDir, instanceName string, operator *OperatorSigner, birthFiles map[string]string, logger *slog.Logger) (*BootstrapResult, error) {
 	absCoreDir, err := filepath.Abs(coreDir)
 	if err != nil {
 		return nil, fmt.Errorf("resolve core dir: %w", err)
@@ -156,13 +161,23 @@ func BootstrapCore(ctx context.Context, coreDir, instanceName string, operator *
 		return nil, err
 	}
 
-	if err := signed.Store.WriteFiles(ctx, map[string]string{
+	birth := map[string]string{
 		".gitignore":         coreGitIgnore,
 		".allowed_signers":   trustSurface,
 		SigningPublicKeyFile: signing.Public,
 		ChannelCACertFile:    string(channelCA.Certificate),
 		CoreConfigFile:       string(policy),
-	}, "bootstrap core identity"); err != nil {
+	}
+	for name, content := range birthFiles {
+		// Identity files win: a caller cannot displace the trust surface or
+		// the config by naming them, which would make the birth commit
+		// describe an instance other than the one being created.
+		if _, reserved := birth[name]; reserved {
+			return nil, fmt.Errorf("birth file %q collides with core identity material", name)
+		}
+		birth[name] = content
+	}
+	if err := signed.Store.WriteFiles(ctx, birth, "bootstrap core identity"); err != nil {
 		return nil, err
 	}
 

--- a/internal/platform/identity/bootstrap_test.go
+++ b/internal/platform/identity/bootstrap_test.go
@@ -31,7 +31,7 @@ func TestBootstrapCoreCreatesSignedBirthCommit(t *testing.T) {
 	clearUmask(t)
 
 	coreDir := filepath.Join(t.TempDir(), "core")
-	result, err := BootstrapCore(t.Context(), coreDir, "pocket", nil, nil)
+	result, err := BootstrapCore(t.Context(), coreDir, "pocket", nil, nil, nil)
 	if err != nil {
 		t.Fatalf("BootstrapCore: %v", err)
 	}
@@ -113,10 +113,10 @@ func TestBootstrapCoreSkipsCompleteIdentity(t *testing.T) {
 	requireGit(t)
 
 	coreDir := filepath.Join(t.TempDir(), "core")
-	if _, err := BootstrapCore(t.Context(), coreDir, "pocket", nil, nil); err != nil {
+	if _, err := BootstrapCore(t.Context(), coreDir, "pocket", nil, nil, nil); err != nil {
 		t.Fatalf("first BootstrapCore: %v", err)
 	}
-	result, err := BootstrapCore(t.Context(), coreDir, "pocket", nil, nil)
+	result, err := BootstrapCore(t.Context(), coreDir, "pocket", nil, nil, nil)
 	if err != nil {
 		t.Fatalf("second BootstrapCore: %v", err)
 	}
@@ -137,7 +137,7 @@ func TestBootstrapCoreRejectsPartialIdentity(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if _, err := BootstrapCore(t.Context(), coreDir, "pocket", nil, nil); err == nil {
+	if _, err := BootstrapCore(t.Context(), coreDir, "pocket", nil, nil, nil); err == nil {
 		t.Fatal("BootstrapCore partial identity returned nil, want error")
 	}
 }
@@ -148,7 +148,7 @@ func TestBootstrapCoreRollsBackFailedBirthCommit(t *testing.T) {
 	coreDir := filepath.Join(t.TempDir(), "core")
 	ctx, cancel := context.WithCancel(t.Context())
 	cancel()
-	if _, err := BootstrapCore(ctx, coreDir, "pocket", nil, nil); err == nil {
+	if _, err := BootstrapCore(ctx, coreDir, "pocket", nil, nil, nil); err == nil {
 		t.Fatal("BootstrapCore with canceled context returned nil, want error")
 	}
 
@@ -167,7 +167,7 @@ func TestBootstrapCoreRollsBackFailedBirthCommit(t *testing.T) {
 		}
 	}
 
-	if _, err := BootstrapCore(t.Context(), coreDir, "pocket", nil, nil); err != nil {
+	if _, err := BootstrapCore(t.Context(), coreDir, "pocket", nil, nil, nil); err != nil {
 		t.Fatalf("BootstrapCore after rollback: %v", err)
 	}
 }

--- a/internal/platform/identity/operator_test.go
+++ b/internal/platform/identity/operator_test.go
@@ -99,7 +99,7 @@ func TestBootstrapCoreAnchorsToAnOperatorKey(t *testing.T) {
 	}
 
 	coreDir := filepath.Join(t.TempDir(), "core")
-	result, err := BootstrapCore(t.Context(), coreDir, "pocket", operator, nil)
+	result, err := BootstrapCore(t.Context(), coreDir, "pocket", operator, nil, nil)
 	if err != nil {
 		t.Fatalf("BootstrapCore: %v", err)
 	}
@@ -137,7 +137,7 @@ func TestBootstrapCoreAnchorsToAnOperatorKey(t *testing.T) {
 func TestBootstrapCoreSelfSignedIsAdmissible(t *testing.T) {
 	t.Parallel()
 	coreDir := filepath.Join(t.TempDir(), "core")
-	result, err := BootstrapCore(t.Context(), coreDir, "pocket", nil, nil)
+	result, err := BootstrapCore(t.Context(), coreDir, "pocket", nil, nil, nil)
 	if err != nil {
 		t.Fatalf("BootstrapCore: %v", err)
 	}

--- a/internal/platform/provenance/provenance.go
+++ b/internal/platform/provenance/provenance.go
@@ -363,6 +363,18 @@ func validateFilename(filename string) error {
 	if cleaned == ".." || strings.HasPrefix(cleaned, ".."+string(filepath.Separator)) {
 		return fmt.Errorf("path traversal not allowed: %s", filename)
 	}
+	// Nothing may write into the repository's own metadata. A managed write
+	// that lands in .git/ is not a document — it is a change to the machinery
+	// that judges documents. .git/hooks/pre-commit is the sharpest case, since
+	// it executes on the very next commit, and .git/config is where a
+	// repository would otherwise get to nominate its own signature program.
+	//
+	// This lives here rather than at any one caller because every write —
+	// managed document, birth commit, loop output — passes through this
+	// check, and a guard at one entrance is a guard on one entrance.
+	if first, _, _ := strings.Cut(filepath.ToSlash(cleaned), "/"); strings.EqualFold(first, ".git") {
+		return fmt.Errorf("writes into the repository's own git metadata are not allowed: %s", filename)
+	}
 	return nil
 }
 

--- a/internal/platform/provenance/provenance_test.go
+++ b/internal/platform/provenance/provenance_test.go
@@ -398,3 +398,33 @@ func TestStoreFilePath(t *testing.T) {
 		t.Errorf("FilePath = %q, want %q", got, want)
 	}
 }
+
+// TestValidateFilenameRejectsGitMetadata keeps managed writes out of the
+// repository's own machinery.
+//
+// A write landing in .git/ is not a document — it changes the thing that
+// judges documents. .git/hooks/pre-commit is the sharpest case: it executes on
+// the very next commit, so a single accepted write would run arbitrary code
+// during the commit meant to record it. .git/config is where a repository
+// would otherwise nominate its own signature program, which is the redirection
+// #1270 pinned at the other end.
+func TestValidateFilenameRejectsGitMetadata(t *testing.T) {
+	t.Parallel()
+	for _, name := range []string{
+		".git/config",
+		".git/hooks/pre-commit",
+		".GIT/config",
+		"./.git/config",
+	} {
+		if err := validateFilename(name); err == nil {
+			t.Errorf("validateFilename(%q) = nil, want refusal", name)
+		}
+	}
+	// The dotfiles a root legitimately carries must still be writable, or the
+	// guard would break the trust surface it exists to protect.
+	for _, name := range []string{".gitignore", ".allowed_signers", "talents/loops.md", "notes/.gitkeep"} {
+		if err := validateFilename(name); err != nil {
+			t.Errorf("validateFilename(%q) = %v, want allowed", name, err)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

`talents_dir` named a directory outside every trust boundary the instance has. Talents steer model behaviour on **every turn** — the trust profile of the prompts beside them — yet production's talent root is not a git repository at all: hand-edited in place, re-read each turn, untouched by deploys.

That shape has already cost something. The live set drifted from the repo badly enough to need a byte-level reconciliation, and nothing detected it; every talent PR still needs a manual backport that nothing verifies happened.

The location is now derived as `{workspace}/core/talents`, so talents carry core's signed history and core's cleanliness rule.

This is the **relocation** half of #1278. Talents still load through their own loader; folding that into ordinary tagged-root injection is the second half, and is much easier once the files have settled where they belong.

## Derived, not deprecated

A declared `talents_dir` is refused with the move it needs, following `workspace.path`:

```
config declares talents_dir, which is now derived as {workspace}/core/talents
rather than authored. Talents steer every turn, so they belong under the same
signed history as the prompts beside them: move the directory into core
(mv <talents_dir> {workspace}/core/talents), commit it, and remove the
talents_dir: line
```

Deprecating it instead would leave a config able to name a directory outside core — the hole open, while appearing configured. The field is `yaml:"-"` now, so it is neither authored nor emitted into the generated example, which previously advertised a key that would be rejected on load.

## Signed from the first commit

`thane init` hands the bundled set to core's birth commit rather than writing it to disk first:

```
✓ .../core (core identity, signing SHA256:/+docvVmIrNV8QS3iEezHSUjiPyFNZ/zKI9cOiD79F0)
✓ 37 talents, signed as part of core's birth
```

So a fresh instance never has a moment where its behaviour definitions exist unsigned — and when an operator key founds the instance (#1272), that same key covers the talents. An instance attested from its first commit rather than from whenever someone remembers to commit.

`BootstrapCore` now takes the extra files for that commit and refuses any colliding with identity material, so a caller cannot displace the trust surface or the config by naming them.

## What this means for an operator

A talent edit becomes a commit, and an uncommitted talent stops the instance at the next boot exactly as an uncommitted `config.yaml` does. That is the decision rather than a side effect: nothing in core is exempt from `core_clean`, and a talent exempted from it would be inside the trust boundary in name only.

It also ends the repo→prod backport problem structurally. Drift is now a dirty root that announces itself at the next restart, instead of something discovered months later by comparing bytes.

## Test plan

- [x] `just ci` passes
- [x] `thane init` deploys 37 talents into `core/talents/`, all inside the birth commit, core clean afterwards
- [x] Nothing deployed beside core — asserted, since a stray copy would be the unsigned set winning
- [x] A declared `talents_dir` is refused with the migration text, verified against a real workspace
- [x] Generated example no longer emits the retired key

Refs #1278, #787