### PR TITLE
A root can say its documents must all be classified

### DIFF
--- a/examples/config.example.yaml
+++ b/examples/config.example.yaml
@@ -268,6 +268,14 @@ roots:
       # Gating search the same way would need the document store to see
       # active capability tags, which it deliberately does not.
       requires_tag: ""
+      # Untagged decides what a document carrying no tags means in this
+      # root: "ignore" (default) skips it, "refuse" makes it an error.
+      # 
+      # Refusing matters where the documents are load-bearing. Guidance
+      # that shapes every turn should not be able to go missing quietly
+      # because someone forgot a frontmatter line — the instance should
+      # name the file and stop, the way it does for an uncommitted one.
+      untagged: ""
     # SeedSigners are the keys entitled to establish this root. They
     # seed its .allowed_signers at birth and are not re-applied after,
     # because from then on the root's own file is its record of whom it
@@ -417,6 +425,14 @@ roots:
       # Gating search the same way would need the document store to see
       # active capability tags, which it deliberately does not.
       requires_tag: ""
+      # Untagged decides what a document carrying no tags means in this
+      # root: "ignore" (default) skips it, "refuse" makes it an error.
+      # 
+      # Refusing matters where the documents are load-bearing. Guidance
+      # that shapes every turn should not be able to go missing quietly
+      # because someone forgot a frontmatter line — the instance should
+      # name the file and stop, the way it does for an uncommitted one.
+      untagged: ""
     # SeedSigners are the keys entitled to establish this root. They
     # seed its .allowed_signers at birth and are not re-applied after,
     # because from then on the root's own file is its record of whom it
@@ -531,6 +547,14 @@ roots:
       # Gating search the same way would need the document store to see
       # active capability tags, which it deliberately does not.
       requires_tag: ""
+      # Untagged decides what a document carrying no tags means in this
+      # root: "ignore" (default) skips it, "refuse" makes it an error.
+      # 
+      # Refusing matters where the documents are load-bearing. Guidance
+      # that shapes every turn should not be able to go missing quietly
+      # because someone forgot a frontmatter line — the instance should
+      # name the file and stop, the way it does for an uncommitted one.
+      untagged: ""
     # SeedSigners are the keys entitled to establish this root. They
     # seed its .allowed_signers at birth and are not re-applied after,
     # because from then on the root's own file is its record of whom it

--- a/internal/app/document_roots.go
+++ b/internal/app/document_roots.go
@@ -327,6 +327,7 @@ func documentRootPolicyFromConfig(rootCfg config.DocumentRootConfig) documents.R
 		Inject:      strings.TrimSpace(rootCfg.Context.Inject),
 		Search:      strings.TrimSpace(rootCfg.Context.Search),
 		RequiresTag: strings.TrimSpace(rootCfg.Context.RequiresTag),
+		Untagged:    strings.TrimSpace(rootCfg.Context.Untagged),
 	}
 	return policy
 }

--- a/internal/app/finalize_capability_tags.go
+++ b/internal/app/finalize_capability_tags.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 
 	"github.com/nugget/thane-ai-agent/internal/integrations/forge"
@@ -129,10 +130,20 @@ func (a *App) finalizeCapabilityTags(s *newState) error {
 		contextVerifier = a.documentStore
 	}
 
+	injectRoots := injectionEligibleRoots(cfg, s.resolver, logger)
+	// Enforce the refusal here rather than only at scan time. A root that
+	// refuses unclassified content is saying its documents are load-bearing,
+	// and a per-turn warning about one of them going missing is the quiet
+	// failure the policy exists to prevent — the instance should decline to
+	// run and name the file, the way it declines an uncommitted one.
+	if err := agent.CheckUnclassifiedDocuments(injectRoots); err != nil {
+		return fmt.Errorf("document root refuses unclassified content: %w", err)
+	}
+
 	tagCtxAssembler := agent.NewTagContextAssembler(agent.TagContextAssemblerConfig{
 		CapTags:     resolvedCapTags,
 		KBDir:       kbDir,
-		InjectRoots: injectionEligibleRoots(cfg, s.resolver, logger),
+		InjectRoots: injectRoots,
 		Resolver:    s.resolver,
 		Verifier:    contextVerifier,
 		HAInject:    a.loop.HAInject(),
@@ -249,7 +260,11 @@ func injectionEligibleRoots(cfg *config.Config, resolver *paths.Resolver, logger
 				"root", name, "error", err)
 			continue
 		}
-		eligible[name] = agent.InjectRoot{Dir: dir, RequiresTag: policy.Context.RequiresTag}
+		eligible[name] = agent.InjectRoot{
+			Dir:         dir,
+			RequiresTag: policy.Context.RequiresTag,
+			Untagged:    policy.Context.EffectiveUntagged(),
+		}
 	}
 	logger.Info("context injection policy resolved",
 		"injection_eligible_roots", len(eligible))

--- a/internal/platform/config/config.go
+++ b/internal/platform/config/config.go
@@ -1040,6 +1040,21 @@ const (
 	RootSearchOnRequest = "on_request"
 	// RootSearchNever excludes the root from document search entirely.
 	RootSearchNever = "never"
+
+	// RootUntaggedIgnore skips a document carrying no tags. It is the
+	// default, and it is what every injecting root has always done.
+	RootUntaggedIgnore = "ignore"
+	// RootUntaggedRefuse makes a tagless document an error naming the
+	// file, for a root whose contents must all be classified.
+	//
+	// The alternative to refusing is guessing, and the guess has already
+	// proven brittle: the talent loader treats a tagless file as
+	// permanent guidance, which forced a heuristic excluding filenames
+	// that begin with a capital so a README would not be injected into
+	// every prompt. Capitalization is not a semantic. A root that
+	// refuses says which file is unclassified instead of inferring an
+	// answer from its name.
+	RootUntaggedRefuse = "refuse"
 )
 
 // RootContextPolicy declares how one document root may reach a model.
@@ -1066,6 +1081,15 @@ type RootContextPolicy struct {
 	// Gating search the same way would need the document store to see
 	// active capability tags, which it deliberately does not.
 	RequiresTag string `yaml:"requires_tag,omitempty"`
+
+	// Untagged decides what a document carrying no tags means in this
+	// root: "ignore" (default) skips it, "refuse" makes it an error.
+	//
+	// Refusing matters where the documents are load-bearing. Guidance
+	// that shapes every turn should not be able to go missing quietly
+	// because someone forgot a frontmatter line — the instance should
+	// name the file and stop, the way it does for an uncommitted one.
+	Untagged string `yaml:"untagged,omitempty"`
 }
 
 // Declared reports whether this root states a context policy at all.
@@ -1096,6 +1120,15 @@ func (p RootContextPolicy) EffectiveSearch() string {
 	return p.Search
 }
 
+// EffectiveUntagged resolves what a tagless document means here,
+// defaulting to skipping it.
+func (p RootContextPolicy) EffectiveUntagged() string {
+	if p.Untagged == "" {
+		return RootUntaggedIgnore
+	}
+	return p.Untagged
+}
+
 // Validate checks the declared policy values.
 func (p RootContextPolicy) Validate(rootName string) error {
 	switch p.Inject {
@@ -1107,6 +1140,18 @@ func (p RootContextPolicy) Validate(rootName string) error {
 	case "", RootSearchDefault, RootSearchOnRequest, RootSearchNever:
 	default:
 		return fmt.Errorf("roots.%s.context.search must be %q, %q, or %q, got %q", rootName, RootSearchDefault, RootSearchOnRequest, RootSearchNever, p.Search)
+	}
+	switch p.Untagged {
+	case "", RootUntaggedIgnore, RootUntaggedRefuse:
+	default:
+		return fmt.Errorf("roots.%s.context.untagged must be %q or %q, got %q", rootName, RootUntaggedIgnore, RootUntaggedRefuse, p.Untagged)
+	}
+	if p.Untagged == RootUntaggedRefuse && p.EffectiveInject() != RootInjectTagged {
+		// Refusing tagless documents is a statement about what may
+		// inject. On a root that never injects it would reject files
+		// for failing to qualify for something they were never eligible
+		// for, which reads as a broken config rather than a policy.
+		return fmt.Errorf("roots.%s.context.untagged is %q but the root does not inject; set inject: %q or drop the untagged policy", rootName, RootUntaggedRefuse, RootInjectTagged)
 	}
 	// requires_tag gates prompt injection only. Search runs below the
 	// capability layer — the document store has no view of which tags

--- a/internal/runtime/agent/tag_context.go
+++ b/internal/runtime/agent/tag_context.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -15,6 +16,7 @@ import (
 	"github.com/nugget/thane-ai-agent/internal/platform/config"
 	"github.com/nugget/thane-ai-agent/internal/platform/paths"
 	"github.com/nugget/thane-ai-agent/internal/runtime/agentctx"
+	"github.com/nugget/thane-ai-agent/internal/state/documents"
 )
 
 // TagContextAssembler builds typed prompt context sections from three
@@ -141,8 +143,36 @@ func NewTagContextAssembler(cfg TagContextAssemblerConfig) *TagContextAssembler 
 // scan, and the optional capability tag that must be active before any
 // of its documents are considered at all.
 type InjectRoot struct {
+	// Untagged is what a tagless document means here: [documents.RootUntaggedIgnore]
+	// skips it, [documents.RootUntaggedRefuse] surfaces it as a fault.
+	Untagged    string
 	Dir         string
 	RequiresTag string
+}
+
+// CheckUnclassifiedDocuments reports the first root that refuses tagless
+// documents and contains one, so startup can decline rather than discover it
+// a turn at a time.
+//
+// The per-turn scan surfaces the same fault, but only as a log line on a root
+// whose articles were then dropped — which is guidance going missing with a
+// warning, the shape this policy exists to end.
+func CheckUnclassifiedDocuments(roots map[string]InjectRoot) error {
+	names := make([]string, 0, len(roots))
+	for name := range roots {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		root := roots[name]
+		if root.Dir == "" || root.Untagged != documents.RootUntaggedRefuse {
+			continue
+		}
+		if _, err := scanKBArticles(root.Dir, root.Untagged); err != nil {
+			return fmt.Errorf("roots.%s: %w", name, err)
+		}
+	}
+	return nil
 }
 
 // loadKBArticles returns the current list of tag-aware articles from
@@ -160,7 +190,7 @@ func (a *TagContextAssembler) loadKBArticles() []kbArticle {
 		if a.kbDir == "" {
 			return nil
 		}
-		articles, err := scanKBArticles(a.kbDir)
+		articles, err := scanKBArticles(a.kbDir, documents.RootUntaggedIgnore)
 		if err != nil {
 			a.logger.Warn("failed to scan KB directory for tagged articles",
 				"dir", a.kbDir, "error", err)
@@ -181,7 +211,7 @@ func (a *TagContextAssembler) loadKBArticles() []kbArticle {
 		if root.Dir == "" {
 			continue
 		}
-		articles, err := scanKBArticles(root.Dir)
+		articles, err := scanKBArticles(root.Dir, root.Untagged)
 		if err != nil {
 			a.logger.Warn("failed to scan injection-eligible root for tagged articles",
 				"root", name, "dir", root.Dir, "error", err)
@@ -726,10 +756,17 @@ func isTrailheadKind(kind string) bool {
 // scanKBArticles walks the KB directory for .md files with tags:
 // frontmatter. Only top-level and one-level-deep files are scanned
 // (matching typical KB layouts like kb:dossiers/foo.md).
-func scanKBArticles(dir string) ([]kbArticle, error) {
+//
+// untagged decides what a tagless file means here. Skipping is right for a
+// corpus where most documents are reference material and only some are
+// injectable. Refusing is right where every document is meant to be
+// classified: there, a missing frontmatter line is guidance silently going
+// absent, and the root would rather name the file than guess.
+func scanKBArticles(dir, untagged string) ([]kbArticle, error) {
 	var articles []kbArticle
+	var unclassified []string
 
-	err := filepath.WalkDir(dir, func(path string, d os.DirEntry, err error) error {
+	err := filepath.WalkDir(dir, func(path string, d os.DirEntry, err error) error { //nolint:revive // walk closure
 		if err != nil {
 			return nil // skip unreadable entries
 		}
@@ -752,7 +789,14 @@ func scanKBArticles(dir string) ([]kbArticle, error) {
 
 		meta, _ := talents.ParseFrontmatterMetadata(string(data))
 		if len(meta.Tags) == 0 && len(meta.TagsAll) == 0 {
-			return nil // untagged KB articles are not auto-loaded
+			if untagged == documents.RootUntaggedRefuse {
+				if rel, relErr := filepath.Rel(dir, path); relErr == nil {
+					unclassified = append(unclassified, rel)
+				} else {
+					unclassified = append(unclassified, path)
+				}
+			}
+			return nil // untagged documents are not auto-loaded
 		}
 		if strings.EqualFold(strings.TrimSpace(meta.Audience), "internal") {
 			// The #1250 audience contract: an internal-audience document
@@ -778,6 +822,11 @@ func scanKBArticles(dir string) ([]kbArticle, error) {
 	})
 	if err != nil {
 		return nil, err
+	}
+	if len(unclassified) > 0 {
+		sort.Strings(unclassified)
+		return nil, fmt.Errorf("%d document(s) in %s carry no tags and this root refuses unclassified content: %s",
+			len(unclassified), dir, strings.Join(unclassified, ", "))
 	}
 
 	// Sort for deterministic ordering.

--- a/internal/runtime/agent/tag_context_test.go
+++ b/internal/runtime/agent/tag_context_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/nugget/thane-ai-agent/internal/model/talents"
 	"github.com/nugget/thane-ai-agent/internal/platform/config"
 	"github.com/nugget/thane-ai-agent/internal/runtime/agentctx"
+	"github.com/nugget/thane-ai-agent/internal/state/documents"
 	"github.com/nugget/thane-ai-agent/internal/tools"
 )
 
@@ -1153,5 +1154,42 @@ func TestBuildSystemPrompt_InjectRootRequiresTagGatesWholeRoot(t *testing.T) {
 
 	if prompt := l.buildSystemPrompt(testCtxForLoop(l), "hello"); strings.Contains(prompt, "Gated corpus content.") {
 		t.Error("requires_tag should keep the whole root out until its capability is active")
+	}
+}
+
+// TestUnclassifiedDocumentsRefusedAtStartup covers the policy that makes
+// guidance unable to go missing quietly.
+//
+// A root declaring its documents load-bearing gets a named file and a refusal,
+// rather than a warning about a root whose articles were then dropped — which
+// is the same silent absence with extra steps.
+func TestUnclassifiedDocumentsRefusedAtStartup(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "tagged.md"), []byte("---\ntags: [home]\n---\n\nguidance\n"), 0o644); err != nil {
+		t.Fatalf("write tagged: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "forgot-the-frontmatter.md"), []byte("# just prose\n"), 0o644); err != nil {
+		t.Fatalf("write untagged: %v", err)
+	}
+
+	// Ignoring is the historical behaviour and must stay silent.
+	if err := CheckUnclassifiedDocuments(map[string]InjectRoot{
+		"kb": {Dir: dir, Untagged: documents.RootUntaggedIgnore},
+	}); err != nil {
+		t.Fatalf("an ignoring root should tolerate untagged files: %v", err)
+	}
+
+	err := CheckUnclassifiedDocuments(map[string]InjectRoot{
+		"talents": {Dir: dir, Untagged: documents.RootUntaggedRefuse},
+	})
+	if err == nil {
+		t.Fatal("a refusing root accepted an unclassified document")
+	}
+	if !strings.Contains(err.Error(), "forgot-the-frontmatter.md") {
+		t.Fatalf("refusal must name the file so it can be fixed, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "talents") {
+		t.Fatalf("refusal must name the root, got: %v", err)
 	}
 }

--- a/internal/state/documents/policy.go
+++ b/internal/state/documents/policy.go
@@ -55,6 +55,8 @@ const (
 	RootSearchDefault   = "default"
 	RootSearchOnRequest = "on_request"
 	RootSearchNever     = "never"
+	RootUntaggedIgnore  = "ignore"
+	RootUntaggedRefuse  = "refuse"
 )
 
 // RootContextPolicy describes how a root's documents may reach a model:
@@ -64,6 +66,7 @@ type RootContextPolicy struct {
 	Inject      string `json:"inject,omitempty"`
 	Search      string `json:"search,omitempty"`
 	RequiresTag string `json:"requires_tag,omitempty"`
+	Untagged    string `json:"untagged,omitempty"`
 }
 
 // EffectiveInject resolves injection eligibility, defaulting to none.
@@ -72,6 +75,16 @@ func (p RootContextPolicy) EffectiveInject() string {
 		return RootInjectNone
 	}
 	return p.Inject
+}
+
+// EffectiveUntagged resolves what a tagless document means in this root,
+// defaulting to skipping it — which is what every injecting root has
+// always done.
+func (p RootContextPolicy) EffectiveUntagged() string {
+	if p.Untagged == "" {
+		return RootUntaggedIgnore
+	}
+	return p.Untagged
 }
 
 // EffectiveSearch resolves search visibility, defaulting to full.

--- a/internal/state/documents/policy.go
+++ b/internal/state/documents/policy.go
@@ -122,6 +122,12 @@ type RootContextSummary struct {
 	Inject      string `json:"inject"`
 	Search      string `json:"search"`
 	RequiresTag string `json:"requires_tag,omitempty"`
+	// Untagged says what a document carrying no tags means here. It is
+	// emitted always rather than only when refusing, because it changes
+	// what counts as a valid write: authoring a tagless document into a
+	// refusing root produces an instance that declines to start. A rule
+	// the model is held to but cannot see is one it will break.
+	Untagged string `json:"untagged"`
 }
 
 // RootGitPolicySummary is the model-facing form of [RootGitPolicy].
@@ -309,6 +315,7 @@ func (s *Store) rootPolicySummary(root string) RootPolicySummary {
 			Inject:      policy.Context.EffectiveInject(),
 			Search:      policy.Context.EffectiveSearch(),
 			RequiresTag: policy.Context.RequiresTag,
+			Untagged:    policy.Context.EffectiveUntagged(),
 		},
 	}
 }

--- a/internal/state/documents/policy_test.go
+++ b/internal/state/documents/policy_test.go
@@ -355,3 +355,30 @@ func newPolicyStoreWithOptions(t *testing.T, policies map[string]RootPolicy, wri
 	}
 	return store, kbDir
 }
+
+// TestRootSummaryTellsTheModelWhatUntaggedMeans keeps a rule the model is held
+// to from being invisible to it.
+//
+// The model authors documents into these roots. A root that refuses tagless
+// content will not start once one exists, so a model that cannot see the
+// policy will eventually write the document that stops the instance.
+func TestRootSummaryTellsTheModelWhatUntaggedMeans(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name   string
+		policy RootContextPolicy
+		want   string
+	}{
+		{name: "declared refusal", policy: RootContextPolicy{Inject: RootInjectTagged, Untagged: RootUntaggedRefuse}, want: RootUntaggedRefuse},
+		{name: "silent default", policy: RootContextPolicy{Inject: RootInjectTagged}, want: RootUntaggedIgnore},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			store := &Store{rootPolicies: map[string]RootPolicy{"kb": {Context: tc.policy}}}
+			got := store.rootPolicySummary("kb")
+			if got.Context.Untagged != tc.want {
+				t.Fatalf("summary untagged = %q, want %q", got.Context.Untagged, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

A tagless document means two different things depending on which loader reads the directory. The KB scanner skips it. The talent loader treats it as permanent guidance.

`roots.<name>.context.untagged` makes that a policy instead of an accident: `ignore` skips (today's behaviour for every injecting root, and the default), `refuse` makes a tagless document an error naming the file.

## The guess this replaces

The talent loader already carries a workaround, and its own comment says why:

```go
// Without this filter the loader's "untagged talents always load" rule
// would inject every repo's README straight into the prompt.
func isContributorDocFilename(name string) bool {
	return name != "" && name[0] >= 'A' && name[0] <= 'Z'
}
```

A leading capital means "not a talent". That rule is load-bearing — it is the only thing keeping `README.md` out of every conversational system prompt — and it is doing semantics with capitalization. `HomeAssistant.md` would be silently excluded. A `notes.md` dropped in the directory would be silently injected as behavioural guidance. Neither failure says anything.

It exists because *untagged* had to be inferred rather than declared. A root that can refuse tagless documents does not need the guess.

## Writing down what already happens

`ignore` is not new behaviour, and adding it as a value is half the point. Today the two behaviours are not policy at all — they are consequences of which loader happened to read the directory. Naming them makes a root's behaviour legible from its config rather than from the call graph, which is the same move as the rest of this arc.

## Enforced at startup, not just at scan time

The per-turn path surfaces the same fault, but only as a log line about a root whose articles were then dropped — guidance going missing with a warning attached, which is the shape this policy exists to end. So `CheckUnclassifiedDocuments` runs during capability-tag finalization and returns an error:

```
document root refuses unclassified content: roots.talents: 1 document(s) in
/…/core/talents carry no tags and this root refuses unclassified content:
forgot-the-frontmatter.md
```

An instance that refuses names the file and declines to run, in the voice it already uses for an uncommitted document or an unattributed root.

`refuse` is rejected at config validation on a root that does not inject, since it would otherwise reject files for failing to qualify for something they were never eligible for — a broken config reading as a policy.

## What this is for

#1278 needs it. Folding talents into ordinary tagged-root injection would otherwise silently drop the seven untagged talents that currently shape every conversational turn — `foundation`, `communication`, `delegation`, `awareness`, `presence`, `working-memory`. With `refuse` on that root, an unclassified talent cannot exist to be dropped, so the collapse stops depending on migration order to be safe.

Nothing sets `refuse` yet. It lands before the roots that need it, so the guarantee is in place when they arrive rather than shortly after.

## Test plan

- [x] `just ci` passes
- [x] A refusing root reports the offending filename and the root name
- [x] An ignoring root tolerates the same directory silently, so the default is unchanged
- [x] Config validation rejects `refuse` on a root that does not inject

Refs #1278