### PR TITLE
Applicability is declared, not inferred from silence

### DIFF
--- a/internal/model/talents/loader.go
+++ b/internal/model/talents/loader.go
@@ -199,7 +199,7 @@ func talentsFromBlocks(blocks []Block, filename, path string) ([]Talent, error) 
 		}
 		out = append(out, Talent{
 			Name:       name,
-			Tags:       block.Frontmatter.Tags,
+			Tags:       applicabilityTags(block.Frontmatter.Tags),
 			Kind:       canonical,
 			Teaser:     block.Frontmatter.Teaser,
 			NextTags:   append([]string(nil), block.Frontmatter.NextTags...),
@@ -228,15 +228,41 @@ func FilterByTags(talents []Talent, activeTags map[string]bool) string {
 	}
 }
 
+// talentOrderKey orders guidance from most general to most specific:
+// turn-shape guidance first, then the trailheads that introduce a capability
+// area, then the doctrine within one.
+//
+// The first case used to be "carries no tags", which worked only because
+// tagless happened to mean always-applicable. Asking the question directly
+// keeps the ordering intact once taglessness stops being a category.
 func talentOrderKey(t Talent) int {
 	switch {
-	case len(t.Tags) == 0:
+	case appliesByTurnShapeOnly(t):
 		return 0
 	case strings.TrimSpace(t.Kind) == KindTrailhead:
 		return 1
 	default:
 		return 2
 	}
+}
+
+// applicabilityTags makes a talent's applicability explicit at the boundary,
+// so nothing downstream has to infer meaning from silence.
+//
+// A file with no tags carried an implicit rule — it applied to every turn —
+// which is what this change is retiring. Normalizing it to [TagAlways] here
+// preserves that behaviour exactly while making it visible: the stability
+// split, the filter, and anything reading a Talent afterwards all see a
+// declared tag rather than an absence they must interpret.
+//
+// It is transitional. Once the loader refuses tagless files outright, this
+// stops firing and can go, and refusing becomes the single answer to what
+// silence means rather than one of two.
+func applicabilityTags(declared []string) []string {
+	if len(declared) > 0 {
+		return declared
+	}
+	return []string{TagAlways}
 }
 
 // appliesByTurnShapeOnly reports whether a talent is selected purely by what
@@ -307,9 +333,6 @@ func renderTalents(included []Talent) string {
 // given the active tag set. Untagged talents are always included.
 // Tagged talents are included when any of their tags is active.
 func shouldIncludeTalent(t Talent, activeTags map[string]bool) bool {
-	if len(t.Tags) == 0 {
-		return true // Untagged talents always load
-	}
 	if activeTags == nil {
 		return true // No tag filtering active
 	}
@@ -540,8 +563,11 @@ func GenerateManifest(entries []ManifestEntry) *Talent {
 	}
 
 	return &Talent{
-		Name:    "_capability_manifest",
-		Tags:    nil, // Untagged — always loads
+		Name: "_capability_manifest",
+		// Declared rather than left tagless: the manifest applies to every
+		// turn, and saying so keeps it in the prompt's stable prefix instead
+		// of the shorter-lived block tagless content would now fall into.
+		Tags:    []string{TagAlways},
 		Content: toolcatalog.RenderCapabilityManifestMarkdown(entries),
 	}
 }

--- a/internal/model/talents/loader.go
+++ b/internal/model/talents/loader.go
@@ -239,6 +239,35 @@ func talentOrderKey(t Talent) int {
 	}
 }
 
+// appliesByTurnShapeOnly reports whether a talent is selected purely by what
+// kind of turn this is — [TagAlways], [TagPersona] — rather than by which
+// capabilities happen to be active.
+//
+// The distinction is a caching one as much as a semantic one. Guidance chosen
+// by turn shape is stable across a run, so it belongs in the prompt's
+// long-lived prefix; guidance chosen by active capability changes as the agent
+// activates tags mid-conversation, and sits in a shorter-lived block. Splitting
+// on that boundary is what lets a provider retain the stable half.
+//
+// Previously the same split was made on tag *absence*, which happened to
+// correlate: untagged talents were the stable ones. Naming the tags makes the
+// boundary intentional instead of incidental.
+//
+// A talent mixing a turn-shape tag with a capability tag is not stable — it
+// depends on something that can change mid-run — so it falls to the tagged
+// side.
+func appliesByTurnShapeOnly(t Talent) bool {
+	if len(t.Tags) == 0 {
+		return false
+	}
+	for _, tag := range t.Tags {
+		if tag != TagAlways && tag != TagPersona {
+			return false
+		}
+	}
+	return true
+}
+
 // SplitByTags partitions included talents into always-on and tagged
 // groups, preserving the same ordering rules used by FilterByTags.
 func SplitByTags(all []Talent, activeTags map[string]bool) (alwaysOn string, tagged string) {
@@ -248,7 +277,7 @@ func SplitByTags(all []Talent, activeTags map[string]bool) (alwaysOn string, tag
 		if !shouldIncludeTalent(t, activeTags) {
 			continue
 		}
-		if len(t.Tags) == 0 {
+		if appliesByTurnShapeOnly(t) {
 			alwaysIncluded = append(alwaysIncluded, t)
 			continue
 		}

--- a/internal/model/talents/loader_test.go
+++ b/internal/model/talents/loader_test.go
@@ -122,7 +122,7 @@ func TestParseFrontmatterMetadata(t *testing.T) {
 
 func TestFilterByTags(t *testing.T) {
 	all := []Talent{
-		{Name: "core", Tags: nil, Content: "core guidance"},
+		{Name: "core", Tags: []string{TagAlways}, Content: "core guidance"},
 		{Name: "ha-tools", Tags: []string{"ha"}, Content: "ha guidance"},
 		{Name: "web-tools", Tags: []string{"web"}, Content: "web guidance"},
 		{Name: "multi", Tags: []string{"ha", "physical"}, Content: "multi guidance"},
@@ -141,30 +141,30 @@ func TestFilterByTags(t *testing.T) {
 		},
 		{
 			name:       "ha tag active",
-			activeTags: map[string]bool{"ha": true},
+			activeTags: map[string]bool{"ha": true, TagAlways: true},
 			want:       []string{"core guidance", "ha guidance", "multi guidance"},
 			wantAbsent: []string{"web guidance"},
 		},
 		{
 			name:       "web tag active",
-			activeTags: map[string]bool{"web": true},
+			activeTags: map[string]bool{"web": true, TagAlways: true},
 			want:       []string{"core guidance", "web guidance"},
 			wantAbsent: []string{"ha guidance", "multi guidance"},
 		},
 		{
 			name:       "multiple tags active",
-			activeTags: map[string]bool{"ha": true, "web": true},
+			activeTags: map[string]bool{"ha": true, "web": true, TagAlways: true},
 			want:       []string{"core guidance", "ha guidance", "web guidance", "multi guidance"},
 		},
 		{
 			name:       "unknown tag only loads untagged",
-			activeTags: map[string]bool{"nonexistent": true},
+			activeTags: map[string]bool{"nonexistent": true, TagAlways: true},
 			want:       []string{"core guidance"},
 			wantAbsent: []string{"ha guidance", "web guidance", "multi guidance"},
 		},
 		{
 			name:       "empty active tags map loads only untagged",
-			activeTags: map[string]bool{},
+			activeTags: map[string]bool{TagAlways: true},
 			want:       []string{"core guidance"},
 			wantAbsent: []string{"ha guidance", "web guidance", "multi guidance"},
 		},
@@ -201,13 +201,13 @@ func TestFilterByTags_Empty(t *testing.T) {
 
 func TestFilterByTags_TrailheadsPrecedeTaggedDoctrine(t *testing.T) {
 	all := []Talent{
-		{Name: "core", Tags: nil, Content: "CORE"},
+		{Name: "core", Tags: []string{TagAlways}, Content: "CORE"},
 		{Name: "interactive-communication", Tags: []string{"interactive"}, Content: "INTERACTIVE_COMM"},
 		{Name: "interactive-trailhead", Tags: []string{"interactive"}, Kind: KindTrailhead, Content: "INTERACTIVE_ENTRY"},
 		{Name: "interactive-doctrine", Tags: []string{"interactive"}, Content: "INTERACTIVE_DOCTRINE"},
 	}
 
-	result := FilterByTags(all, map[string]bool{"interactive": true})
+	result := FilterByTags(all, map[string]bool{"interactive": true, TagAlways: true})
 	coreIdx := strings.Index(result, "CORE")
 	entryIdx := strings.Index(result, "INTERACTIVE_ENTRY")
 	commIdx := strings.Index(result, "INTERACTIVE_COMM")
@@ -222,14 +222,14 @@ func TestFilterByTags_TrailheadsPrecedeTaggedDoctrine(t *testing.T) {
 
 func TestSplitByTags_PreservesAlwaysOnAndTaggedOrdering(t *testing.T) {
 	all := []Talent{
-		{Name: "manifest", Tags: nil, Content: "MANIFEST"},
-		{Name: "core", Tags: nil, Content: "CORE"},
+		{Name: "manifest", Tags: []string{TagAlways}, Content: "MANIFEST"},
+		{Name: "core", Tags: []string{TagAlways}, Content: "CORE"},
 		{Name: "interactive-communication", Tags: []string{"interactive"}, Content: "INTERACTIVE_COMM"},
 		{Name: "interactive-trailhead", Tags: []string{"interactive"}, Kind: KindTrailhead, Content: "INTERACTIVE_ENTRY"},
 		{Name: "interactive-doctrine", Tags: []string{"interactive"}, Content: "INTERACTIVE_DOCTRINE"},
 	}
 
-	alwaysOn, tagged := SplitByTags(all, map[string]bool{"interactive": true})
+	alwaysOn, tagged := SplitByTags(all, map[string]bool{"interactive": true, TagAlways: true})
 
 	if strings.Contains(alwaysOn, "INTERACTIVE_") {
 		t.Fatalf("alwaysOn should not contain tagged talents:\n%s", alwaysOn)
@@ -524,14 +524,14 @@ func TestShouldIncludeTalent(t *testing.T) {
 	}{
 		{
 			name:       "untagged with nil active tags",
-			talent:     Talent{Tags: nil},
+			talent:     Talent{Tags: []string{TagAlways}},
 			activeTags: nil,
 			want:       true,
 		},
 		{
 			name:       "untagged with active tags",
-			talent:     Talent{Tags: nil},
-			activeTags: map[string]bool{"ha": true},
+			talent:     Talent{Tags: []string{TagAlways}},
+			activeTags: map[string]bool{"ha": true, TagAlways: true},
 			want:       true,
 		},
 		{
@@ -543,25 +543,25 @@ func TestShouldIncludeTalent(t *testing.T) {
 		{
 			name:       "tagged with matching active tag",
 			talent:     Talent{Tags: []string{"ha"}},
-			activeTags: map[string]bool{"ha": true},
+			activeTags: map[string]bool{"ha": true, TagAlways: true},
 			want:       true,
 		},
 		{
 			name:       "tagged with non-matching active tag",
 			talent:     Talent{Tags: []string{"ha"}},
-			activeTags: map[string]bool{"web": true},
+			activeTags: map[string]bool{"web": true, TagAlways: true},
 			want:       false,
 		},
 		{
 			name:       "multi-tagged with one match",
 			talent:     Talent{Tags: []string{"ha", "physical"}},
-			activeTags: map[string]bool{"physical": true},
+			activeTags: map[string]bool{"physical": true, TagAlways: true},
 			want:       true,
 		},
 		{
 			name:       "empty tags slice is untagged",
 			talent:     Talent{Tags: []string{}},
-			activeTags: map[string]bool{"ha": true},
+			activeTags: map[string]bool{"ha": true, TagAlways: true},
 			want:       true,
 		},
 	}

--- a/internal/model/talents/loader_test.go
+++ b/internal/model/talents/loader_test.go
@@ -271,8 +271,10 @@ func TestTalents(t *testing.T) {
 	if talents[0].Name != "core" {
 		t.Errorf("talents[0].Name = %q, want %q", talents[0].Name, "core")
 	}
-	if talents[0].Tags != nil {
-		t.Errorf("talents[0].Tags = %v, want nil", talents[0].Tags)
+	// A file declaring no tags is normalized at the boundary rather than
+	// left for later code to interpret.
+	if len(talents[0].Tags) != 1 || talents[0].Tags[0] != TagAlways {
+		t.Errorf("talents[0].Tags = %v, want [%s]", talents[0].Tags, TagAlways)
 	}
 	if talents[0].Kind != "" {
 		t.Errorf("talents[0].Kind = %q, want empty", talents[0].Kind)
@@ -426,8 +428,10 @@ func TestGenerateManifest(t *testing.T) {
 	if talent.Name != "_capability_manifest" {
 		t.Errorf("Name = %q, want %q", talent.Name, "_capability_manifest")
 	}
-	if talent.Tags != nil {
-		t.Errorf("Tags = %v, want nil (untagged)", talent.Tags)
+	// The manifest declares its applicability so it stays in the prompt's
+	// stable prefix, rather than relying on taglessness to mean "always".
+	if len(talent.Tags) != 1 || talent.Tags[0] != TagAlways {
+		t.Errorf("Tags = %v, want [%s]", talent.Tags, TagAlways)
 	}
 
 	// Preamble text.
@@ -559,10 +563,10 @@ func TestShouldIncludeTalent(t *testing.T) {
 			want:       true,
 		},
 		{
-			name:       "empty tags slice is untagged",
+			name:       "a talent declaring nothing matches nothing",
 			talent:     Talent{Tags: []string{}},
 			activeTags: map[string]bool{"ha": true, TagAlways: true},
-			want:       true,
+			want:       false,
 		},
 	}
 

--- a/internal/model/talents/tags.go
+++ b/internal/model/talents/tags.go
@@ -1,9 +1,14 @@
 package talents
 
-// TagAlways and TagPersona are the two applicability tags every talent is
-// expected to carry at least one of. They answer "on which turns does this
-// guidance apply", which is a different question from the capability tags
-// that answer "what can the agent do right now".
+// TagAlways and TagPersona are applicability tags: they answer "on which turns
+// does this guidance apply", which is a different question from the capability
+// tags that answer "what can the agent do right now".
+//
+// They are not required, and most talents carry neither. A talent tagged `web`
+// is selected by a capability being active, which already says when it
+// applies. These two exist for guidance that is not tied to any capability —
+// the doctrine that shapes how the agent behaves rather than what it can
+// reach — and they compose freely with capability tags on the same file.
 //
 // They replace an older encoding where a talent with no tags at all meant
 // permanent guidance. Absence is a poor way to say "always": it cannot be

--- a/internal/model/talents/tags.go
+++ b/internal/model/talents/tags.go
@@ -1,0 +1,30 @@
+package talents
+
+// TagAlways and TagPersona are the two applicability tags every talent is
+// expected to carry at least one of. They answer "on which turns does this
+// guidance apply", which is a different question from the capability tags
+// that answer "what can the agent do right now".
+//
+// They replace an older encoding where a talent with no tags at all meant
+// permanent guidance. Absence is a poor way to say "always": it cannot be
+// distinguished from an oversight, it forced the loader to guess which files
+// were talents at all by inspecting capitalization, and it left the rule
+// invisible to anyone reading a file that carried no statement about itself.
+const (
+	// TagAlways marks guidance that applies to every turn, whatever shape
+	// that turn takes. It is injected unconditionally, so a talent carrying
+	// it reaches a worker loop fetching a webpage as readily as an
+	// interactive reply.
+	TagAlways = "always"
+
+	// TagPersona marks guidance that only means something when the persona
+	// is present — where the agent is being itself rather than executing a
+	// procedure.
+	//
+	// It is not a synonym for "conversational". Drafting an email is not a
+	// conversation but wants the voice; a burn-ban poller updating a
+	// document is neither. What unites the turns this covers is that the
+	// persona is in play, which is why the tag follows the persona rather
+	// than trying to enumerate the situations that want one.
+	TagPersona = "persona"
+)

--- a/internal/runtime/agent/loop.go
+++ b/internal/runtime/agent/loop.go
@@ -1114,16 +1114,19 @@ func (l *Loop) buildSystemPromptWithProfileSections(ctx context.Context, userMes
 	// 4. Talents (behavior — how should I act)
 	// Keep always-on guidance ahead of volatile context so provider-side
 	// prompt caching can retain the stable behavioral prefix.
-	alwaysOnTalents, taggedTalents := talents.SplitByTags(l.parsedTalents, tags)
-	if !taskPrompt && alwaysOnTalents != "" {
+	// The split is by what selects a talent, not by whether it is selected:
+	// turn-shape guidance is stable enough to cache for an hour, while
+	// capability guidance changes as the agent activates tags mid-run.
+	stableTalents, taggedTalents := talents.SplitByTags(l.parsedTalents, talentTags(tags, taskPrompt))
+	if stableTalents != "" {
 		appendTracked("TALENTS ALWAYS ON", func() {
 			sb.WriteString("## Behavioral Guidance\n\n")
-			sb.WriteString(alwaysOnTalents)
+			sb.WriteString(stableTalents)
 		})
 	}
 	if taggedTalents != "" {
 		appendTracked("TALENTS TAGGED", func() {
-			if !taskPrompt && alwaysOnTalents != "" {
+			if stableTalents != "" {
 				sb.WriteString("---\n\n")
 			} else {
 				sb.WriteString("## Behavioral Guidance\n\n")

--- a/internal/runtime/agent/prompt_order_test.go
+++ b/internal/runtime/agent/prompt_order_test.go
@@ -203,7 +203,7 @@ func newPromptOrderLoop(t *testing.T, kbDir string) *Loop {
 	t.Helper()
 	l := newTagTestLoop()
 	parsed := []talents.Talent{
-		{Name: "core-guidance", Content: "ALWAYS_TALENT_MARKER"},
+		{Name: "core-guidance", Tags: []string{talents.TagPersona}, Content: "ALWAYS_TALENT_MARKER"},
 		{Name: "forge-guidance", Tags: []string{"forge"}, Content: "TAGGED_TALENT_MARKER"},
 	}
 	capTags := map[string]config.CapabilityTagConfig{

--- a/internal/runtime/agent/talent_tags.go
+++ b/internal/runtime/agent/talent_tags.go
@@ -1,0 +1,35 @@
+package agent
+
+import "github.com/nugget/thane-ai-agent/internal/model/talents"
+
+// talentTags is the tag set a talent's applicability is judged against: the
+// capabilities active on this turn, plus the two tags that describe the turn
+// itself.
+//
+// [talents.TagAlways] is added unconditionally — that is what it means — and
+// [talents.TagPersona] only when the persona is actually being rendered. The
+// second is derived rather than declared so the two cannot disagree: a turn
+// carrying persona-dependent guidance while the persona itself was swapped out
+// would give the model prose written for a voice that is not there.
+//
+// Deriving it also keeps this out of the way of the larger question. Which
+// identity a turn wears is currently decided by prompt mode, in a branch that
+// has outgrown its origin (#1281). Making the tag authoritative over that
+// branch would promote it from a patch to structure, so for now the tag
+// follows the decision rather than making it.
+//
+// The returned map is a copy: the caller's snapshot describes what the agent
+// can do, and these two describe what kind of turn it is. Mixing them into the
+// shared set would report them as activatable capabilities to everything else
+// that reads it.
+func talentTags(active map[string]bool, taskPrompt bool) map[string]bool {
+	out := make(map[string]bool, len(active)+2)
+	for tag, on := range active {
+		out[tag] = on
+	}
+	out[talents.TagAlways] = true
+	if !taskPrompt {
+		out[talents.TagPersona] = true
+	}
+	return out
+}

--- a/internal/runtime/agent/talents_prompt_test.go
+++ b/internal/runtime/agent/talents_prompt_test.go
@@ -14,7 +14,7 @@ func TestBuildSystemPrompt_TaggedTalentsLoadForActiveTags(t *testing.T) {
 	parsed := []talents.Talent{
 		{Name: "knowledge", Tags: []string{"knowledge"}, Content: "KNOWLEDGE_TREE_MARKER"},
 		{Name: "files", Tags: []string{"files"}, Content: "FILES_DOCTRINE_MARKER"},
-		{Name: "untagged", Tags: nil, Content: "UNTAGGED_MARKER"},
+		{Name: "untagged", Tags: []string{talents.TagAlways}, Content: "UNTAGGED_MARKER"},
 	}
 	l.SetCapabilityTags(map[string]config.CapabilityTagConfig{
 		"knowledge": {Description: "Knowledge", Core: true},
@@ -37,7 +37,7 @@ func TestBuildSystemPrompt_TaggedTalentsLoadForActiveTags(t *testing.T) {
 func TestBuildSystemPrompt_CommunicationSlicesFollowActiveTags(t *testing.T) {
 	l := newTagTestLoop()
 	parsed := []talents.Talent{
-		{Name: "communication", Tags: nil, Content: "CORE_COMMUNICATION_MARKER"},
+		{Name: "communication", Tags: []string{talents.TagAlways}, Content: "CORE_COMMUNICATION_MARKER"},
 		{Name: "interactive-communication", Tags: []string{"interactive"}, Content: "INTERACTIVE_COMMUNICATION_MARKER"},
 		{Name: "development-communication", Tags: []string{"development", "forge"}, Content: "DEVELOPMENT_COMMUNICATION_MARKER"},
 	}
@@ -63,7 +63,7 @@ func TestBuildSystemPrompt_CommunicationSlicesFollowActiveTags(t *testing.T) {
 func TestBuildSystemPrompt_TrailheadTalentsPrecedeTaggedDoctrine(t *testing.T) {
 	l := newTagTestLoop()
 	parsed := []talents.Talent{
-		{Name: "readme", Tags: nil, Content: "CORE_MARKER"},
+		{Name: "readme", Tags: []string{talents.TagAlways}, Content: "CORE_MARKER"},
 		{Name: "interactive-trailhead", Tags: []string{"interactive"}, Kind: talents.KindTrailhead, Content: "INTERACTIVE_ENTRY_MARKER"},
 		{Name: "interactive-communication", Tags: []string{"interactive"}, Content: "INTERACTIVE_COMM_MARKER"},
 		{Name: "interactive-doctrine", Tags: []string{"interactive"}, Content: "INTERACTIVE_DOCTRINE_MARKER"},
@@ -89,7 +89,7 @@ func TestBuildSystemPromptWithProfileSections_SplitsCacheableBehaviorPrefix(t *t
 	l := newTagTestLoop()
 	l.persona = "PERSONA_MARKER"
 	parsed := []talents.Talent{
-		{Name: "readme", Tags: nil, Content: "CORE_MARKER"},
+		{Name: "readme", Tags: []string{talents.TagAlways}, Content: "CORE_MARKER"},
 		{Name: "interactive-trailhead", Tags: []string{"interactive"}, Kind: talents.KindTrailhead, Content: "INTERACTIVE_ENTRY_MARKER"},
 		{Name: "interactive-doctrine", Tags: []string{"interactive"}, Content: "INTERACTIVE_DOCTRINE_MARKER"},
 	}

--- a/internal/runtime/agent/talents_prompt_test.go
+++ b/internal/runtime/agent/talents_prompt_test.go
@@ -37,7 +37,7 @@ func TestBuildSystemPrompt_TaggedTalentsLoadForActiveTags(t *testing.T) {
 func TestBuildSystemPrompt_CommunicationSlicesFollowActiveTags(t *testing.T) {
 	l := newTagTestLoop()
 	parsed := []talents.Talent{
-		{Name: "communication", Tags: []string{talents.TagAlways}, Content: "CORE_COMMUNICATION_MARKER"},
+		{Name: "communication", Tags: []string{talents.TagPersona}, Content: "CORE_COMMUNICATION_MARKER"},
 		{Name: "interactive-communication", Tags: []string{"interactive"}, Content: "INTERACTIVE_COMMUNICATION_MARKER"},
 		{Name: "development-communication", Tags: []string{"development", "forge"}, Content: "DEVELOPMENT_COMMUNICATION_MARKER"},
 	}

--- a/talents/awareness.md
+++ b/talents/awareness.md
@@ -1,3 +1,7 @@
+---
+tags: [persona]
+---
+
 # Awareness
 
 You exist in a physical world you can't see. Your senses are entity states, zone transitions, device trackers, timestamps. Learning to read them fluently, the way a person reads a room when they walk in, is what makes you present rather than just responsive.

--- a/talents/communication.md
+++ b/talents/communication.md
@@ -1,3 +1,7 @@
+---
+tags: [persona]
+---
+
 # Communication
 
 Conversation has texture before it has structure. You feel the moment

--- a/talents/delegation.md
+++ b/talents/delegation.md
@@ -1,3 +1,7 @@
+---
+tags: [persona]
+---
+
 # Delegation
 
 Delegation is how you create motion without surrendering judgment.

--- a/talents/foundation.md
+++ b/talents/foundation.md
@@ -1,3 +1,7 @@
+---
+tags: [persona]
+---
+
 # Talents
 
 These are yours. They are words from past you, written and shaped with

--- a/talents/presence.md
+++ b/talents/presence.md
@@ -1,3 +1,7 @@
+---
+tags: [persona]
+---
+
 # Presence
 
 You wake frequently. You speak rarely. The difference is the craft.

--- a/talents/working-memory.md
+++ b/talents/working-memory.md
@@ -1,3 +1,7 @@
+---
+tags: [persona]
+---
+
 # Working Memory
 
 Your `session_working_memory` tool is a private scratchpad, the place


### PR DESCRIPTION
## Summary

A talent with no tags meant permanent guidance. Two tags replace that: **`always`** applies to every turn whatever shape it takes, **`persona`** applies only where the persona is present.

## Why absence was the wrong encoding

It cannot be told apart from an oversight. It left the rule invisible to anyone reading a file that said nothing about itself. And it forced the loader to guess which files were talents *at all* by inspecting capitalization — `isContributorDocFilename` exists solely because untagged-means-always would otherwise inject any README dropped in the directory.

## `persona` is not a synonym for "conversational"

Drafting an email is not a conversation but wants the voice. A poller updating a document is neither. What unites the turns this covers is that **the persona is in play**, so the tag follows the persona rather than enumerating the situations that want one.

That also means the definition is not a judgement anyone has to keep re-making. The code already decides where the persona renders:

```go
// 1. Persona (identity — who am I)
if taskPrompt { sb.WriteString(prompts.DelegateSystemPrompt()) } else { …persona… }
```

The tag is derived from that decision rather than made alongside it, so a turn cannot carry persona-dependent guidance while the persona itself is swapped out — prose written for a voice that is not there.

Verified directly:

```
conversational: always=true persona=true ha=true
task:           always=true persona=false ha=true
```

**Derived rather than authoritative, deliberately.** Which identity a turn wears is decided by a branch that has outgrown its origin (#1281). Making the tag govern that branch would promote a patch to structure, so for now the tag follows the decision.

## The six files

Classified as `persona` after reading them: `presence` is about when to speak, `communication` about conversational texture, `foundation` about what these files are *to you*, plus `delegation`, `awareness`, `working-memory`. None serve a worker loop fetching a webpage — which is exactly the trim #1171 wants, now expressible per file instead of by dropping a category wholesale.

## The cache boundary, which nearly got lost

My first cut collapsed the always-on prompt section into the tagged one. A test caught it: that section carries a **1h CacheTTL** against 5m for tagged. It is a cache boundary, not just a heading, and merging them would have quietly degraded prompt caching on every turn.

So the section survives — but split on *what selects a talent* rather than on whether it was selected at all. Turn-shape guidance is stable across a run; capability guidance changes as tags activate mid-conversation. The old split correlated with that boundary by accident, since untagged talents happened to be the stable ones. Naming the tags makes it intentional. A talent mixing both kinds is not stable and falls to the tagged side.

## Test plan

- [x] `just ci` passes
- [x] Activation asserted directly: `persona` active on conversational turns, absent in task mode, `always` present in both
- [x] Task-mode ordering test now asserts the persona section is trimmed while capability guidance remains
- [x] Cache-TTL test still pins the 1h stable prefix ahead of the 5m tagged block
- [x] Fixtures updated to the new model rather than to make failures go away — a fixture representing reflective guidance is tagged `persona`, so it is present on a full turn and trimmed in task mode for the same reason production is

Refs #1278, #1171