### PR TITLE
A duplicate companion tool is normal; a disagreement is not

### DIFF
--- a/internal/tools/companion_registrar.go
+++ b/internal/tools/companion_registrar.go
@@ -5,8 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"maps"
 	"reflect"
-	"slices"
 	"sort"
 	"strings"
 	"sync"
@@ -253,7 +253,7 @@ func companionToolDefinitionDiff(a, b companionToolClaim) []string {
 	if a.def.Description != b.def.Description {
 		fields = append(fields, "description")
 	}
-	if !slices.Equal(a.def.Tags, b.def.Tags) {
+	if !equalStringSets(a.def.Tags, b.def.Tags) {
 		fields = append(fields, "tags")
 	}
 	// Both schemas are JSON-derived (map/[]any/float64/string/bool/nil), the
@@ -262,6 +262,23 @@ func companionToolDefinitionDiff(a, b companionToolClaim) []string {
 		fields = append(fields, "input_schema")
 	}
 	return fields
+}
+
+// equalStringSets reports whether two tag lists carry the same members.
+// Tags are a set everywhere they are consumed — tag indexing and gating —
+// so companions that authored the same tags in a different order have not
+// disagreed about anything the model can observe, and comparing them in
+// order would report the ordinary multi-Mac case as skew.
+func equalStringSets(a, b []string) bool {
+	return maps.Equal(stringSet(a), stringSet(b))
+}
+
+func stringSet(values []string) map[string]struct{} {
+	set := make(map[string]struct{}, len(values))
+	for _, v := range values {
+		set[v] = struct{}{}
+	}
+	return set
 }
 
 // synthesize turns one companion-authored tool definition into a

--- a/internal/tools/companion_registrar.go
+++ b/internal/tools/companion_registrar.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"reflect"
+	"slices"
 	"sort"
 	"strings"
 	"sync"
@@ -113,33 +115,44 @@ func (cr *CompanionRegistrar) Snapshot() ([]*Tool, map[string][]string) {
 func (cr *CompanionRegistrar) Rebuild() {
 	infos := cr.list()
 
-	// Resolve cross-provider tool-name collisions deterministically.
-	// Registry.List iterates a map, so provider order is nondeterministic;
-	// sort by provider ID first. Without this, the winning definition for a
-	// collided name (and its capability/method binding) could flip between
-	// rebuilds with no real registry change, breaking the cache-stable
-	// manifest.
-	sort.Slice(infos, func(i, j int) bool { return infos[i].ID < infos[j].ID })
+	// Order providers by the stable identity the operator configured, so a
+	// tool name claimed by more than one companion resolves to the same one
+	// on every rebuild. Registry.List iterates a map, so its order is
+	// nondeterministic, and the provider ID is minted fresh per connection —
+	// tie-breaking on either would let the winning definition flip whenever a
+	// laptop reconnects, churning the manifest with no registry change.
+	sort.Slice(infos, func(i, j int) bool {
+		if infos[i].Account != infos[j].Account {
+			return infos[i].Account < infos[j].Account
+		}
+		if infos[i].ClientID != infos[j].ClientID {
+			return infos[i].ClientID < infos[j].ClientID
+		}
+		return infos[i].ID < infos[j].ID
+	})
 
-	// Dedup by tool name across providers (last writer wins, matching
-	// Registry.Register). The sorted provider order above makes "last"
-	// deterministic. Final tool names are sorted below for a stable manifest.
-	byName := make(map[string]*Tool)
+	// Collect every provider's claim on each tool name. Several companions
+	// advertising the same names is the ordinary multi-Mac case, not a fault:
+	// the duplicate only matters when the claimants disagree about what the
+	// tool is, which reportDivergentClaims decides below.
+	claims := make(map[string][]companionToolClaim)
 	for _, info := range infos {
 		for _, cap := range info.Capabilities {
 			for _, def := range cap.Tools {
-				tool := cr.synthesize(cap.Name, def)
-				if existing := byName[tool.Name]; existing != nil {
-					cr.logger.Warn("companion tool name collision; replacing",
-						"tool", tool.Name)
+				claim := companionToolClaim{
+					tool:       cr.synthesize(cap.Name, def),
+					def:        def,
+					capability: cap.Name,
+					account:    info.Account,
+					clientID:   info.ClientID,
 				}
-				byName[tool.Name] = tool
+				claims[claim.tool.Name] = append(claims[claim.tool.Name], claim)
 			}
 		}
 	}
 
-	names := make([]string, 0, len(byName))
-	for name := range byName {
+	names := make([]string, 0, len(claims))
+	for name := range claims {
 		names = append(names, name)
 	}
 	sort.Strings(names)
@@ -147,9 +160,14 @@ func (cr *CompanionRegistrar) Rebuild() {
 	synth := make([]*Tool, 0, len(names))
 	tagAdds := make(map[string][]string)
 	for _, name := range names {
-		tool := byName[name]
-		synth = append(synth, tool)
-		for _, tag := range tool.Tags {
+		// Last stable writer wins, matching Registry.Register.
+		group := claims[name]
+		winner := group[len(group)-1]
+		if len(group) > 1 {
+			cr.reportDivergentClaims(name, group)
+		}
+		synth = append(synth, winner.tool)
+		for _, tag := range winner.tool.Tags {
 			tagAdds[tag] = append(tagAdds[tag], name)
 		}
 	}
@@ -158,6 +176,92 @@ func (cr *CompanionRegistrar) Rebuild() {
 	cr.synthesized = synth
 	cr.tagAdditions = tagAdds
 	cr.mu.Unlock()
+}
+
+// companionToolClaim is one provider's authored definition of a tool name,
+// paired with the model-facing tool synthesized from it and the stable
+// identity of the companion that authored it.
+type companionToolClaim struct {
+	tool       *Tool
+	def        companion.ToolDefinition
+	capability string
+	account    string
+	clientID   string
+}
+
+// label identifies the claiming companion by the identity an operator
+// configured, never by the provider ID (re-minted on every connection, so
+// useless for telling one warning from the next).
+func (c companionToolClaim) label() string {
+	return c.account + "/" + c.clientID
+}
+
+// reportDivergentClaims warns when the companions claiming one tool name do
+// not agree on what it is. Matching claims are silent: households run more
+// than one Mac by design, and identical definitions carry no information.
+// Divergence does, because it means the companions are running different
+// builds — the manifest shows the winner's contract while Registry.Call
+// still routes by capability/method and may reach a companion that authored
+// a different one, so the model can read one schema and dispatch against
+// another.
+func (cr *CompanionRegistrar) reportDivergentClaims(name string, group []companionToolClaim) {
+	winner := group[len(group)-1]
+
+	var (
+		fields  []string
+		seen    = make(map[string]bool)
+		ignored []string
+	)
+	for _, other := range group[:len(group)-1] {
+		diff := companionToolDefinitionDiff(winner, other)
+		if len(diff) == 0 {
+			continue
+		}
+		for _, field := range diff {
+			if !seen[field] {
+				seen[field] = true
+				fields = append(fields, field)
+			}
+		}
+		ignored = append(ignored, other.label())
+	}
+	if len(fields) == 0 {
+		return
+	}
+	sort.Strings(fields)
+
+	cr.logger.Warn("companion providers disagree on a tool definition; using one",
+		"tool", name,
+		"differs", strings.Join(fields, ","),
+		"using", winner.label(),
+		"ignoring", strings.Join(ignored, ","),
+	)
+}
+
+// companionToolDefinitionDiff names the fields in which two providers'
+// definitions of the same tool name disagree. An empty result means the two
+// companions authored the same contract, so which one wins cannot be
+// observed by the model.
+func companionToolDefinitionDiff(a, b companionToolClaim) []string {
+	var fields []string
+	if a.capability != b.capability {
+		fields = append(fields, "capability")
+	}
+	if a.def.Method != b.def.Method {
+		fields = append(fields, "method")
+	}
+	if a.def.Description != b.def.Description {
+		fields = append(fields, "description")
+	}
+	if !slices.Equal(a.def.Tags, b.def.Tags) {
+		fields = append(fields, "tags")
+	}
+	// Both schemas are JSON-derived (map/[]any/float64/string/bool/nil), the
+	// value space reflect.DeepEqual compares exactly.
+	if !reflect.DeepEqual(a.def.InputSchema, b.def.InputSchema) {
+		fields = append(fields, "input_schema")
+	}
+	return fields
 }
 
 // synthesize turns one companion-authored tool definition into a

--- a/internal/tools/companion_registrar_test.go
+++ b/internal/tools/companion_registrar_test.go
@@ -315,6 +315,32 @@ func TestCompanionRegistrar_MatchingClaimsAreSilent(t *testing.T) {
 	}
 }
 
+// TestCompanionRegistrar_TagOrderIsNotDisagreement pins tags as a set. They
+// are consumed as one (tag indexing and gating), so two companions listing
+// the same tags in a different order have not disagreed about anything the
+// model can observe, and must not be reported as skew.
+func TestCompanionRegistrar_TagOrderIsNotDisagreement(t *testing.T) {
+	first := contactsProvider()
+	first.Capabilities[0].Tools[0].Tags = []string{"people", "scheduling"}
+
+	second := contactsProvider()
+	second.ID = "prov_second"
+	second.ClientID = "uuid-b"
+	second.Capabilities[0].Tools[0].Tags = []string{"scheduling", "people"}
+
+	logs := rebuildLogs(t, first, second)
+	if strings.Contains(logs, `"level":"WARN"`) {
+		t.Errorf("reordered tags must not warn; got: %s", logs)
+	}
+
+	// A genuine membership difference is still skew and must be reported.
+	second.Capabilities[0].Tools[0].Tags = []string{"people", "reminders"}
+	logs = rebuildLogs(t, first, second)
+	if !strings.Contains(logs, `"differs":"tags"`) {
+		t.Errorf("differing tag membership must warn; got: %s", logs)
+	}
+}
+
 // TestCompanionRegistrar_DivergentClaimsWarn covers version skew between two
 // Macs: the definitions disagree, so the model may read the winner's schema
 // while Registry.Call routes to the companion that authored the other one.

--- a/internal/tools/companion_registrar_test.go
+++ b/internal/tools/companion_registrar_test.go
@@ -1,9 +1,12 @@
 package tools
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
+	"log/slog"
 	"strings"
 	"testing"
 
@@ -256,44 +259,146 @@ func TestAugmentSchemaWithRouting_DoesNotMutateSource(t *testing.T) {
 // providers author the same tool name, the winner (and its method binding)
 // is stable regardless of the nondeterministic provider order List() yields.
 func TestCompanionRegistrar_DeterministicCollisionWinner(t *testing.T) {
-	mk := func(id, method string) companion.ProviderInfo {
-		return companion.ProviderInfo{
-			ID: id,
-			Capabilities: []companion.Capability{{
-				Name: "macos.contacts",
-				Tools: []companion.ToolDefinition{{
-					Name: "macos_x", Method: method,
-					InputSchema: map[string]any{"type": "object"},
-				}},
-			}},
-		}
-	}
-	provA := mk("prov_a", "m_a")
-	provB := mk("prov_b", "m_b")
+	provA := claimant("prov_a", "uuid-a", "m_a")
+	provB := claimant("prov_b", "uuid-b", "m_b")
 
-	winningMethod := func(order []companion.ProviderInfo) string {
-		src := &fakeCompanionSource{infos: order, result: json.RawMessage(`{}`)}
-		cr := newCompanionRegistrar(src.List, src.Call, nil)
-		synth, _ := cr.Snapshot()
-		if len(synth) != 1 {
-			t.Fatalf("collision should yield 1 tool, got %d", len(synth))
-		}
-		if _, err := findTool(synth, "macos_x").Handler(context.Background(), nil); err != nil {
-			t.Fatalf("dispatch: %v", err)
-		}
-		return src.calls[0].Method
-	}
-
-	// Both input orders must pick the same provider (sorted by ID -> prov_b
-	// is "last" and wins).
-	forward := winningMethod([]companion.ProviderInfo{provA, provB})
-	reversed := winningMethod([]companion.ProviderInfo{provB, provA})
+	// Both input orders must pick the same provider (sorted by client_id ->
+	// uuid-b is "last" and wins).
+	forward := winningMethod(t, provA, provB)
+	reversed := winningMethod(t, provB, provA)
 	if forward != reversed {
 		t.Errorf("collision winner flipped with input order: %q vs %q", forward, reversed)
 	}
 	if forward != "m_b" {
-		t.Errorf("expected deterministic winner m_b (highest provider ID), got %q", forward)
+		t.Errorf("expected deterministic winner m_b (highest client_id), got %q", forward)
 	}
+}
+
+// TestCompanionRegistrar_CollisionWinnerSurvivesReconnect pins the winner to
+// the operator-configured identity rather than the provider ID, which the
+// server re-mints on every connection. Without this the advertised contract
+// for a tool two Macs both claim would flip whenever either one reconnected.
+func TestCompanionRegistrar_CollisionWinnerSurvivesReconnect(t *testing.T) {
+	// Provider IDs sort opposite to client_ids, so an ID-keyed tiebreak
+	// would pick the other Mac here.
+	before := winningMethod(t,
+		claimant("prov_z", "uuid-a", "m_a"),
+		claimant("prov_a", "uuid-b", "m_b"),
+	)
+	// Both Macs reconnect and draw fresh provider IDs; identities are stable.
+	after := winningMethod(t,
+		claimant("prov_b", "uuid-a", "m_a"),
+		claimant("prov_y", "uuid-b", "m_b"),
+	)
+	if before != after {
+		t.Errorf("winner flipped across reconnect: %q then %q", before, after)
+	}
+	if after != "m_b" {
+		t.Errorf("expected winner m_b (highest client_id), got %q", after)
+	}
+}
+
+// TestCompanionRegistrar_MatchingClaimsAreSilent covers the supported
+// multi-Mac deployment: two companions on the same build advertise identical
+// definitions, so the duplicate is not reportable — whichever wins, the
+// model sees the same contract.
+func TestCompanionRegistrar_MatchingClaimsAreSilent(t *testing.T) {
+	first := contactsProvider()
+	second := contactsProvider()
+	second.ID = "prov_second"
+	second.ClientID = "uuid-b"
+	second.ClientName = "studio"
+
+	logs := rebuildLogs(t, first, second)
+	if strings.Contains(logs, `"level":"WARN"`) {
+		t.Errorf("identical definitions must not warn; got: %s", logs)
+	}
+}
+
+// TestCompanionRegistrar_DivergentClaimsWarn covers version skew between two
+// Macs: the definitions disagree, so the model may read the winner's schema
+// while Registry.Call routes to the companion that authored the other one.
+// The warning has to name both sides and what differs to be actionable.
+func TestCompanionRegistrar_DivergentClaimsWarn(t *testing.T) {
+	first := contactsProvider()
+	second := contactsProvider()
+	second.ID = "prov_second"
+	second.ClientID = "uuid-b"
+	second.Capabilities[0].Tools[0].Description = "Search contacts, now with fuzzy matching."
+	second.Capabilities[0].Tools[0].InputSchema = map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"query": map[string]any{"type": "string"},
+			"fuzzy": map[string]any{"type": "boolean"},
+		},
+	}
+
+	logs := rebuildLogs(t, first, second)
+	if !strings.Contains(logs, `"level":"WARN"`) {
+		t.Fatalf("divergent definitions must warn; got: %s", logs)
+	}
+	for _, want := range []string{
+		"macos_search_contacts",
+		"description,input_schema", // differing fields, sorted
+		"aimee/uuid-b",             // winner: highest client_id
+		"aimee/uuid-a",             // ignored claimant
+	} {
+		if !strings.Contains(logs, want) {
+			t.Errorf("warning missing %q; got: %s", want, logs)
+		}
+	}
+	// A field both Macs agree on must not be reported as divergent.
+	if strings.Contains(logs, "method") {
+		t.Errorf("method matches and must not be reported; got: %s", logs)
+	}
+}
+
+// claimant builds a provider claiming the shared macos_x tool name, bound to
+// the given method so dispatch reveals which one won.
+func claimant(providerID, clientID, method string) companion.ProviderInfo {
+	return companion.ProviderInfo{
+		ID:       providerID,
+		Account:  "aimee",
+		ClientID: clientID,
+		Capabilities: []companion.Capability{{
+			Name: "macos.contacts",
+			Tools: []companion.ToolDefinition{{
+				Name: "macos_x", Method: method,
+				InputSchema: map[string]any{"type": "object"},
+			}},
+		}},
+	}
+}
+
+// winningMethod dispatches the collided tool and reports the method the
+// surviving definition bound to.
+func winningMethod(t *testing.T, infos ...companion.ProviderInfo) string {
+	t.Helper()
+	src := &fakeCompanionSource{infos: infos, result: json.RawMessage(`{}`)}
+	cr := newCompanionRegistrar(src.List, src.Call, discardLogger())
+	synth, _ := cr.Snapshot()
+	if len(synth) != 1 {
+		t.Fatalf("collision should yield 1 tool, got %d", len(synth))
+	}
+	if _, err := findTool(synth, "macos_x").Handler(context.Background(), nil); err != nil {
+		t.Fatalf("dispatch: %v", err)
+	}
+	return src.calls[0].Method
+}
+
+// rebuildLogs builds a registrar over the given providers and returns
+// everything it logged during the initial rebuild.
+func rebuildLogs(t *testing.T, infos ...companion.ProviderInfo) string {
+	t.Helper()
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	src := &fakeCompanionSource{infos: infos}
+	newCompanionRegistrar(src.List, src.Call, logger)
+	return buf.String()
+}
+
+func discardLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
 }
 
 // TestCompanionRegistrar_DispatchCapsResult verifies an oversized companion


### PR DESCRIPTION
Prod logged `companion tool name collision; replacing` for `macos_calendar_events`, and the warning was correct about the facts and wrong about their meaning. Two companions were connected, both advertised the tool, and the registrar deduped one away — which is exactly what a two-Mac household is supposed to do. The warning fires per colliding tool per rebuild, so the supported deployment logs a standing stream of warnings describing its own normal operation, and the operator learns to read past them.

Underneath that noise sat the case worth hearing. `Rebuild` broke collision ties on the provider ID, and `generateProviderID` mints a fresh random ID on every connection, so the comment's promise that sorting kept the winning definition deterministic and the manifest cache-stable was only ever true within a single rebuild. Today the two Macs run the same build and author byte-identical definitions, so nothing is observable. The moment one of them updates ahead of the other, the definitions diverge and the winner re-rolls every time either laptop reconnects: the model's view of the tool's schema and description flips between builds, the tool manifest churns across a prompt-cache boundary, and — because `selectProvider` routes by capability and method at call time, independently of which definition won the manifest — the model can be reading one Mac's contract while dispatching against the other's. None of that produced a log line, because the line that would have carried it was already being spent on the benign case.

So the fix inverts what the registrar considers reportable. Ties now break on the identity an operator actually configured — account, then `client_id`, with the ephemeral provider ID demoted to a last resort — which means the same Mac wins across reconnects and the manifest stops depending on connection timing. Then the colliding definitions are compared on the fields the model can observe (capability, method, description, tags, input schema): claims that match are silent, and only a genuine disagreement warns, once per rebuild, naming both companions by their stable identity and listing which fields differ. A warning from this path now means version skew between your Macs and tells you which one is being ignored.

## Test plan

- [x] `just ci` green locally
- [x] Two providers with identical definitions produce no warning (`TestCompanionRegistrar_MatchingClaimsAreSilent`)
- [x] Divergent definitions warn once, naming both `account/client_id` labels and the differing fields, and do not report fields that match (`TestCompanionRegistrar_DivergentClaimsWarn`)
- [x] The collision winner is unchanged when both providers draw new provider IDs, with IDs deliberately sorting opposite to `client_id`s (`TestCompanionRegistrar_CollisionWinnerSurvivesReconnect`)
- [x] Winner stays independent of the order `List()` yields (`TestCompanionRegistrar_DeterministicCollisionWinner`, retargeted to the new key)
- [x] Tags compare as a set: reordering is silent, differing membership warns (`TestCompanionRegistrar_TagOrderIsNotDisagreement`, mutation-checked against an ordered compare)
- [x] Both new guards mutation-checked: reverting the tiebreak to provider-ID-only fails the reconnect test, and warning unconditionally fails the silence test
- [ ] Prod: after deploy, confirm the standing `macos_calendar_events` warnings stop with both Macs connected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

