### PR TITLE
Silence about applicability gets one answer, not two

### DIFF
--- a/docs/talent-authoring.md
+++ b/docs/talent-authoring.md
@@ -21,11 +21,16 @@ option listed equally, no opinion taken, no decision easier.
 ### Foundation prose (always on)
 
 `foundation.md`, `presence.md`, `awareness.md`, `communication.md`,
-`delegation.md`, `working-memory.md`. No frontmatter, no tags. The
+`delegation.md`, `working-memory.md`, each tagged `persona`. The
 content is identity — how the model should *be* across every turn,
 regardless of what it's doing. Concrete-tool guidance does not belong
 here; the right home for "use email_read when the message is worth
 reading" is the email-tagged doctrine talent, not foundation prose.
+
+Foundation prose declares its applicability like everything else: `always`
+for guidance that holds on every turn whatever its shape, `persona` for
+guidance that only means something where the persona is present. The six
+files above are `persona` because each speaks in or about the voice.
 
 Add a foundation talent rarely. Every line earns an always-on slot in
 the model's prompt forever. The bar is "this is who the model is,"
@@ -502,18 +507,22 @@ etc.), add it to the allowlist with a comment explaining why. The
 allowlist is short on purpose; every addition is a small architectural
 decision.
 
-The third safety net is `TestTalents_SkipsContributorDocs` in the
-loader tests — it pins the rule that **uppercase-leading** markdown
-files in the talents directory (`README.md`, `CONTRIBUTING.md`,
-`LICENSE.md`) are treated as contributor docs and skipped, not as
-talents. Without that filter, `talents/README.md` would silently
-inject into every model prompt forever.
+The third safety net is `TestTalents_SkipsDocsWithoutFrontmatter` in the
+loader tests — it pins the rule that a markdown file in the talents
+directory is a talent only if it opens with frontmatter. `README.md`,
+`CONTRIBUTING.md`, and a stray copy of this very guide are all skipped
+for the same reason: they declare nothing, so they are documents that
+happen to share a directory.
 
-The filter is filename-shape only: a lowercase-named markdown file
-that ends up inside `talents/` — say, a stray copy of this very guide
-named `talent-authoring.md` — would still load as an untagged
-always-on talent. Keep contributor docs uppercase-leading, or place
-them outside the directory.
+This used to be a guess about filenames — uppercase-leading meant
+contributor doc — which was needed only while a tagless file loaded
+unconditionally, making an undeclared README indistinguishable from
+guidance. Now that every talent declares when it applies, the
+declaration answers the question and capitalization means nothing. The
+companion rule is the one that makes it safe: a file that *does* open
+with frontmatter but declares no `tags:` is refused at load rather than
+assumed always-on, so the two failure directions are a skip and a loud
+error, never a silent injection.
 
 ## When you're stuck
 

--- a/internal/model/talents/loader.go
+++ b/internal/model/talents/loader.go
@@ -4,7 +4,6 @@ package talents
 import (
 	"context"
 	"fmt"
-	"log/slog"
 	"os"
 	"path/filepath"
 	"sort"
@@ -12,6 +11,7 @@ import (
 	"sync"
 
 	"github.com/nugget/thane-ai-agent/internal/model/toolcatalog"
+	"github.com/nugget/thane-ai-agent/internal/platform/logging"
 )
 
 // Loader handles talent file loading.
@@ -125,11 +125,15 @@ var skipNoticed sync.Map
 // silent and total: the file stays on disk, the loader says nothing, and the
 // model quietly stops receiving it. Naming the file is what makes the
 // difference between the two cases visible without refusing the harmless one.
-func noteSkippedUndeclared(path string) {
+//
+// It logs through the context logger rather than [slog.Default]: a notice
+// that lands in a different sink or format than the rest of the loop's logs
+// is not visible in the way this needs to be.
+func noteSkippedUndeclared(ctx context.Context, path string) {
 	if _, already := skipNoticed.LoadOrStore(path, struct{}{}); already {
 		return
 	}
-	slog.Default().Info("skipping markdown file in talents directory: no frontmatter, so not a talent",
+	logging.Logger(ctx).Info("skipping markdown file in talents directory: no frontmatter, so not a talent",
 		"path", path)
 }
 
@@ -171,17 +175,25 @@ func (l *Loader) TalentsVerified(ctx context.Context, verifier VerifyPathFunc, c
 		if err != nil {
 			return nil, fmt.Errorf("read talent %s: %w", f, err)
 		}
-		// A talent declares itself by opening with frontmatter. A .md file
-		// that doesn't is a human-facing doc sharing the directory — an
-		// authoring guide, a README — and is not guidance to inject. Asking
-		// the parser keeps this rule identical to the one it enforces rather
-		// than a second copy that can drift from it.
-		if _, _, ok := parseOneBlock(string(data)); !ok {
-			noteSkippedUndeclared(path)
+		// A talent declares itself by opening with a frontmatter delimiter. A
+		// .md file that doesn't is a human-facing doc sharing the directory —
+		// an authoring guide, a README — and is not guidance to inject.
+		raw := string(data)
+		if !opensWithFrontmatter(raw) {
+			noteSkippedUndeclared(ctx, path)
 			continue
 		}
+		// Past that point the file has declared itself, so a frontmatter
+		// block it cannot parse is an authoring error rather than a document.
+		// Silently skipping it here — or letting the lenient parser stop at
+		// the bad block and drop the rest of a multi-node file — would lose
+		// real guidance exactly as quietly as the rule above exists to
+		// prevent.
+		blocks, err := parseBlocksStrict(raw)
+		if err != nil {
+			return nil, fmt.Errorf("talent %s: %w", path, err)
+		}
 		filename := strings.TrimSuffix(f, ".md")
-		blocks := ParseFrontmatterBlocks(string(data))
 		fileTalents, err := talentsFromBlocks(blocks, filename, path)
 		if err != nil {
 			return nil, err
@@ -390,8 +402,41 @@ func ParseFrontmatterMetadata(raw string) (Frontmatter, string) {
 // Multi-node files return one [Block] per node. Returns a length-1
 // slice with the raw input as content when no frontmatter is found at
 // the file start — same fallback as the legacy single-block parser.
+// opensWithFrontmatter reports whether raw begins with a frontmatter
+// delimiter — the declaration that makes a markdown file a talent rather
+// than a document that happens to share the directory. It is deliberately
+// weaker than parsing: a file can open the declaration and still botch it,
+// and those two outcomes get different treatment.
+func opensWithFrontmatter(raw string) bool {
+	return strings.HasPrefix(raw, "---")
+}
+
+// parseBlocksStrict parses every frontmatter block in raw, refusing any it
+// cannot read rather than stopping where [ParseFrontmatterBlocks] would.
+//
+// The lenient parser breaks out of its loop at the first block that will
+// not parse and returns what it collected, which drops the remainder of a
+// multi-node file without a word. That is tolerable for opportunistic
+// scanning and wrong for loading guidance: a missing closing delimiter on
+// node three is an authoring mistake, not a decision to publish two nodes.
+func parseBlocksStrict(raw string) ([]Block, error) {
+	var blocks []Block
+	remaining := raw
+	for {
+		block, rest, ok := parseOneBlock(remaining)
+		if !ok {
+			return nil, fmt.Errorf("node %d has malformed frontmatter (missing closing --- delimiter?)", len(blocks)+1)
+		}
+		blocks = append(blocks, block)
+		if rest == "" {
+			return blocks, nil
+		}
+		remaining = rest
+	}
+}
+
 func ParseFrontmatterBlocks(raw string) []Block {
-	if !strings.HasPrefix(raw, "---") {
+	if !opensWithFrontmatter(raw) {
 		return []Block{{Content: raw}}
 	}
 	var blocks []Block
@@ -418,7 +463,7 @@ func ParseFrontmatterBlocks(raw string) []Block {
 // iteration), and ok=false when raw doesn't start with a frontmatter.
 // The content ends at the next node boundary or EOF.
 func parseOneBlock(raw string) (Block, string, bool) {
-	if !strings.HasPrefix(raw, "---") {
+	if !opensWithFrontmatter(raw) {
 		return Block{}, "", false
 	}
 	rest := raw[3:]

--- a/internal/model/talents/loader.go
+++ b/internal/model/talents/loader.go
@@ -4,10 +4,12 @@ package talents
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"sort"
 	"strings"
+	"sync"
 
 	"github.com/nugget/thane-ai-agent/internal/model/toolcatalog"
 )
@@ -30,7 +32,7 @@ func NewLoader(dir string) *Loader {
 // Talent represents a parsed talent file with optional tag metadata.
 type Talent struct {
 	Name       string   // Filename without .md extension
-	Tags       []string // Tags from YAML frontmatter (nil = untagged)
+	Tags       []string // Tags from YAML frontmatter; never empty, the loader refuses a talent that declares none
 	Kind       string   // Canonical frontmatter kind (for example [KindTrailhead]); empty for ordinary doctrine
 	Teaser     string   // Optional short menu copy for trailhead talents
 	NextTags   []string // Optional likely follow-on tags for trailhead talents
@@ -76,14 +78,14 @@ type Block struct {
 	Content     string
 }
 
-// listFiles returns a sorted slice of .md filenames in l.dir, excluding
-// files whose name begins with an uppercase ASCII letter. Talent
-// filenames follow a lowercase-with-hyphens convention (e.g.
-// loops-doctrine.md, awareness-trailhead.md); uppercase-leading names
-// like README.md, CONTRIBUTING.md, or LICENSE.md are contributor docs
-// that shouldn't load as model context. Without this filter the
-// loader's "untagged talents always load" rule would inject every
-// repo's README straight into the prompt.
+// listFiles returns a sorted slice of every .md filename in l.dir.
+//
+// Which of them are talents is not a question a filename can answer, so
+// this no longer tries: a file declares itself a talent by opening with
+// frontmatter, and [Loader.TalentsVerified] skips the ones that don't.
+// The previous filename-capitalization rule existed only because tagless
+// files loaded unconditionally, which made an undeclared README indis-
+// tinguishable from guidance; declared applicability retires the guess.
 //
 // Returns nil, nil when dir is unset or does not exist.
 func (l *Loader) listFiles() ([]string, error) {
@@ -102,23 +104,33 @@ func (l *Loader) listFiles() ([]string, error) {
 		if e.IsDir() || !strings.HasSuffix(e.Name(), ".md") {
 			continue
 		}
-		if isContributorDocFilename(e.Name()) {
-			continue
-		}
 		files = append(files, e.Name())
 	}
 	sort.Strings(files)
 	return files, nil
 }
 
-// isContributorDocFilename reports whether name belongs to a
-// contributor-facing markdown file that should not load as a talent.
-// The discriminator is the first byte: talents are all lowercase
-// (loops-doctrine.md, awareness-trailhead.md), so a leading uppercase
-// ASCII letter is a reliable signal that the file is a README,
-// CONTRIBUTING, LICENSE, or similar human-facing doc.
-func isContributorDocFilename(name string) bool {
-	return name != "" && name[0] >= 'A' && name[0] <= 'Z'
+// skipNoticed dedupes the undeclared-file notice by path, matching
+// [WarnIfKindAlias]: the loader re-reads the directory on every loop turn,
+// so an un-deduped line would repeat forever.
+var skipNoticed sync.Map
+
+// noteSkippedUndeclared reports, once per file per process, that a markdown
+// file in the talents directory was not loaded because it declares no
+// frontmatter.
+//
+// Skipping is the right outcome for a README, but it is also what an
+// operator sees if guidance loses its frontmatter — foundation prose whose
+// applicability tags were never backported, say. That failure is otherwise
+// silent and total: the file stays on disk, the loader says nothing, and the
+// model quietly stops receiving it. Naming the file is what makes the
+// difference between the two cases visible without refusing the harmless one.
+func noteSkippedUndeclared(path string) {
+	if _, already := skipNoticed.LoadOrStore(path, struct{}{}); already {
+		return
+	}
+	slog.Default().Info("skipping markdown file in talents directory: no frontmatter, so not a talent",
+		"path", path)
 }
 
 // Talents reads all .md files from the talents directory, parses their
@@ -159,6 +171,15 @@ func (l *Loader) TalentsVerified(ctx context.Context, verifier VerifyPathFunc, c
 		if err != nil {
 			return nil, fmt.Errorf("read talent %s: %w", f, err)
 		}
+		// A talent declares itself by opening with frontmatter. A .md file
+		// that doesn't is a human-facing doc sharing the directory — an
+		// authoring guide, a README — and is not guidance to inject. Asking
+		// the parser keeps this rule identical to the one it enforces rather
+		// than a second copy that can drift from it.
+		if _, _, ok := parseOneBlock(string(data)); !ok {
+			noteSkippedUndeclared(path)
+			continue
+		}
 		filename := strings.TrimSuffix(f, ".md")
 		blocks := ParseFrontmatterBlocks(string(data))
 		fileTalents, err := talentsFromBlocks(blocks, filename, path)
@@ -193,13 +214,16 @@ func talentsFromBlocks(blocks []Block, filename, path string) ([]Talent, error) 
 			return nil, fmt.Errorf("talent %s: duplicate node name %q within file", path, name)
 		}
 		seen[name] = true
+		if len(block.Frontmatter.Tags) == 0 {
+			return nil, fmt.Errorf("talent %s: node %q declares no tags; every talent must say when it applies — %q for every turn, %q where the persona is present, or the capability tags that select it", path, name, TagAlways, TagPersona)
+		}
 		canonical, deprecated := CanonicalKind(block.Frontmatter.Kind)
 		if deprecated {
 			aliasSeenInFile = true
 		}
 		out = append(out, Talent{
 			Name:       name,
-			Tags:       applicabilityTags(block.Frontmatter.Tags),
+			Tags:       append([]string(nil), block.Frontmatter.Tags...),
 			Kind:       canonical,
 			Teaser:     block.Frontmatter.Teaser,
 			NextTags:   append([]string(nil), block.Frontmatter.NextTags...),
@@ -214,8 +238,10 @@ func talentsFromBlocks(blocks []Block, filename, path string) ([]Talent, error) 
 }
 
 // FilterByTags returns the combined content of talents matching the
-// given active tags. Untagged talents are always included (they have
-// no tag restrictions). If activeTags is nil, all talents are included.
+// given active tags. Every talent declares the tags that select it, so
+// inclusion is always a match rather than an absence of restrictions;
+// [TagAlways] is in the active set on every turn. If activeTags is nil,
+// all talents are included.
 func FilterByTags(talents []Talent, activeTags map[string]bool) string {
 	alwaysOn, tagged := SplitByTags(talents, activeTags)
 	switch {
@@ -234,7 +260,7 @@ func FilterByTags(talents []Talent, activeTags map[string]bool) string {
 //
 // The first case used to be "carries no tags", which worked only because
 // tagless happened to mean always-applicable. Asking the question directly
-// keeps the ordering intact once taglessness stops being a category.
+// keeps the ordering intact now that taglessness is not a category at all.
 func talentOrderKey(t Talent) int {
 	switch {
 	case appliesByTurnShapeOnly(t):
@@ -244,25 +270,6 @@ func talentOrderKey(t Talent) int {
 	default:
 		return 2
 	}
-}
-
-// applicabilityTags makes a talent's applicability explicit at the boundary,
-// so nothing downstream has to infer meaning from silence.
-//
-// A file with no tags carried an implicit rule — it applied to every turn —
-// which is what this change is retiring. Normalizing it to [TagAlways] here
-// preserves that behaviour exactly while making it visible: the stability
-// split, the filter, and anything reading a Talent afterwards all see a
-// declared tag rather than an absence they must interpret.
-//
-// It is transitional. Once the loader refuses tagless files outright, this
-// stops firing and can go, and refusing becomes the single answer to what
-// silence means rather than one of two.
-func applicabilityTags(declared []string) []string {
-	if len(declared) > 0 {
-		return declared
-	}
-	return []string{TagAlways}
 }
 
 // appliesByTurnShapeOnly reports whether a talent is selected purely by what
@@ -330,8 +337,9 @@ func renderTalents(included []Talent) string {
 }
 
 // shouldIncludeTalent returns true if the talent should be included
-// given the active tag set. Untagged talents are always included.
-// Tagged talents are included when any of their tags is active.
+// given the active tag set: any one of its declared tags being active is
+// enough. A nil set disables filtering entirely (callers rendering every
+// talent, not a turn).
 func shouldIncludeTalent(t Talent, activeTags map[string]bool) bool {
 	if activeTags == nil {
 		return true // No tag filtering active
@@ -564,9 +572,8 @@ func GenerateManifest(entries []ManifestEntry) *Talent {
 
 	return &Talent{
 		Name: "_capability_manifest",
-		// Declared rather than left tagless: the manifest applies to every
-		// turn, and saying so keeps it in the prompt's stable prefix instead
-		// of the shorter-lived block tagless content would now fall into.
+		// Declared like any authored talent: the manifest applies to every
+		// turn, and saying so puts it in the prompt's stable prefix.
 		Tags:    []string{TagAlways},
 		Content: toolcatalog.RenderCapabilityManifestMarkdown(entries),
 	}

--- a/internal/model/talents/loader_test.go
+++ b/internal/model/talents/loader_test.go
@@ -10,6 +10,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/nugget/thane-ai-agent/internal/platform/logging"
 )
 
 func TestParseFrontmatter_Tags(t *testing.T) {
@@ -401,26 +403,85 @@ func TestTalents_NotesSkippedUndeclaredFile(t *testing.T) {
 	dir := t.TempDir()
 	writeFile(t, dir, "presence.md", "# Presence\n\nidentity prose that lost its frontmatter.")
 
+	// Through the context logger, not slog.Default: the notice has to land
+	// in the same sink as the rest of the loop's logs to be visible at all.
 	var buf bytes.Buffer
-	restore := slog.Default()
-	slog.SetDefault(slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
-	defer slog.SetDefault(restore)
+	ctx := logging.WithLogger(context.Background(),
+		slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
 
-	if _, err := NewLoader(dir).Talents(); err != nil {
-		t.Fatalf("Talents() error: %v", err)
+	if _, err := NewLoader(dir).TalentsVerified(ctx, nil, ""); err != nil {
+		t.Fatalf("TalentsVerified() error: %v", err)
 	}
 	if !strings.Contains(buf.String(), "presence.md") {
-		t.Errorf("skip notice should name the file; got: %s", buf.String())
+		t.Errorf("skip notice should reach the context logger and name the file; got: %s", buf.String())
 	}
 
 	// Deduped by path: the loader re-reads on every turn, and a line that
 	// repeated forever would be noise rather than a signal.
 	buf.Reset()
-	if _, err := NewLoader(dir).Talents(); err != nil {
-		t.Fatalf("Talents() second call: %v", err)
+	if _, err := NewLoader(dir).TalentsVerified(ctx, nil, ""); err != nil {
+		t.Fatalf("TalentsVerified() second call: %v", err)
 	}
 	if strings.Contains(buf.String(), "presence.md") {
 		t.Errorf("skip notice should fire once per path; got: %s", buf.String())
+	}
+}
+
+// TestTalents_RefusesMalformedFrontmatter separates the two ways a file can
+// fail to declare itself. Opening with no frontmatter is a document and gets
+// skipped; opening a frontmatter block and botching it is an authoring error
+// and must be refused, because skipping it would drop real guidance exactly
+// as quietly as the skip rule exists to prevent.
+//
+// The mid-file case is the sharper one: the lenient parser stops at the bad
+// node and returns the good ones, so a three-node talent silently becomes a
+// two-node talent with nothing logged anywhere.
+func TestTalents_RefusesMalformedFrontmatter(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		content string
+	}{
+		{
+			name:    "unclosed frontmatter at file start",
+			content: "---\ntags: [loops]\n# Body with no closing delimiter",
+		},
+		{
+			name:    "unclosed frontmatter on a later node",
+			content: "---\nname: first\ntags: [loops]\n---\n# First\n\n---\nname: second\ntags: [loops]\n# Second never closes",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			writeFile(t, dir, "broken.md", tc.content)
+
+			_, err := NewLoader(dir).Talents()
+			if err == nil {
+				t.Fatal("malformed frontmatter should be refused, not skipped")
+			}
+			if !strings.Contains(err.Error(), "broken.md") {
+				t.Errorf("error %q should name the file", err)
+			}
+		})
+	}
+}
+
+// TestTalents_HorizontalRuleStaysContent guards the blast radius of strict
+// parsing. A bare "---" in a talent body is a markdown horizontal rule, not
+// a node boundary, and refusing files over one would reject prose that has
+// always been legal.
+func TestTalents_HorizontalRuleStaysContent(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "rules.md", "---\ntags: [loops]\n---\n# Rules\n\nfirst part.\n\n---\n\nsecond part.")
+
+	got, err := NewLoader(dir).Talents()
+	if err != nil {
+		t.Fatalf("a horizontal rule in the body should load fine: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("len(talents) = %d, want 1 (the rule is not a node boundary)", len(got))
+	}
+	if !strings.Contains(got[0].Content, "second part") {
+		t.Errorf("content after the rule was dropped: %q", got[0].Content)
 	}
 }
 

--- a/internal/model/talents/loader_test.go
+++ b/internal/model/talents/loader_test.go
@@ -1,9 +1,11 @@
 package talents
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -157,13 +159,13 @@ func TestFilterByTags(t *testing.T) {
 			want:       []string{"core guidance", "ha guidance", "web guidance", "multi guidance"},
 		},
 		{
-			name:       "unknown tag only loads untagged",
+			name:       "unknown tag only loads always-on",
 			activeTags: map[string]bool{"nonexistent": true, TagAlways: true},
 			want:       []string{"core guidance"},
 			wantAbsent: []string{"ha guidance", "web guidance", "multi guidance"},
 		},
 		{
-			name:       "empty active tags map loads only untagged",
+			name:       "only always active loads only always-on",
 			activeTags: map[string]bool{TagAlways: true},
 			want:       []string{"core guidance"},
 			wantAbsent: []string{"ha guidance", "web guidance", "multi guidance"},
@@ -252,8 +254,8 @@ func TestSplitByTags_PreservesAlwaysOnAndTaggedOrdering(t *testing.T) {
 func TestTalents(t *testing.T) {
 	dir := t.TempDir()
 
-	// Write talent files with and without frontmatter.
-	writeFile(t, dir, "core.md", "# Core\nAlways loaded.")
+	// Write talent files across the applicability shapes.
+	writeFile(t, dir, "core.md", "---\ntags: ["+TagAlways+"]\n---\n# Core\nAlways loaded.")
 	writeFile(t, dir, "ha-tools.md", "---\nkind: trailhead\ntags: [ha]\nteaser: \"Open when the work touches home state.\"\nnext_tags: [awareness, notifications]\n---\n# HA Tools\nHome Assistant guidance.")
 	writeFile(t, dir, "web.md", "---\ntags: [web, remote]\n---\n# Web\nWeb guidance.")
 
@@ -271,8 +273,7 @@ func TestTalents(t *testing.T) {
 	if talents[0].Name != "core" {
 		t.Errorf("talents[0].Name = %q, want %q", talents[0].Name, "core")
 	}
-	// A file declaring no tags is normalized at the boundary rather than
-	// left for later code to interpret.
+	// Applicability is carried exactly as declared.
 	if len(talents[0].Tags) != 1 || talents[0].Tags[0] != TagAlways {
 		t.Errorf("talents[0].Tags = %v, want [%s]", talents[0].Tags, TagAlways)
 	}
@@ -346,25 +347,25 @@ func TestTalentsVerified_VerifiesBeforeRead(t *testing.T) {
 	}
 }
 
-// TestTalents_SkipsContributorDocs pins the loader's "skip
-// uppercase-leading .md files" rule. Without it, files like
-// README.md, CONTRIBUTING.md, and LICENSE.md would be parsed as
-// untagged talents and the always-on injection path would silently
-// pump contributor docs into every model prompt. Regression guard for
-// the bug Copilot caught on PR #912 — adding talents/README.md
-// without this filter would dump the authoring guide into context on
-// every turn.
-func TestTalents_SkipsContributorDocs(t *testing.T) {
+// TestTalents_SkipsDocsWithoutFrontmatter pins what separates a talent
+// from a plain document sharing the directory: frontmatter, not the
+// filename. This replaces the "skip uppercase-leading .md files" guess
+// the loader needed while tagless files loaded unconditionally (the bug
+// Copilot caught on PR #912, where adding talents/README.md dumped the
+// authoring guide into every prompt). The filename cases run in both
+// directions here, because a rule that still keyed on capitalization
+// would pass a test that only checked README.
+func TestTalents_SkipsDocsWithoutFrontmatter(t *testing.T) {
 	dir := t.TempDir()
 	for filename, content := range map[string]string{
-		// Talent files (lowercase-leading): should load.
+		// Declares frontmatter: a talent, whatever it is called.
 		"loops-doctrine.md":      "---\ntags: [loops]\n---\n# Loops",
-		"presence.md":            "# Presence\n\nposture prose.",
 		"awareness-trailhead.md": "---\nkind: trailhead\ntags: [awareness]\nteaser: \"...\"\nnext_tags: [ha]\n---\n# Awareness Trailhead",
-		// Contributor docs (uppercase-leading): should skip.
+		"README-doctrine.md":     "---\ntags: [" + TagAlways + "]\n---\n# Uppercase but declared",
+		// Declares nothing: a document, whatever it is called.
+		"presence.md":     "# Presence\n\nposture prose, no frontmatter.",
 		"README.md":       "# Authoring Guide\n\nThis describes how to write talents.",
 		"CONTRIBUTING.md": "# Contributing\n\nFork and submit a PR.",
-		"LICENSE.md":      "# License",
 	} {
 		if err := os.WriteFile(filepath.Join(dir, filename), []byte(content), 0o644); err != nil {
 			t.Fatalf("write %s: %v", filename, err)
@@ -379,15 +380,80 @@ func TestTalents_SkipsContributorDocs(t *testing.T) {
 	for _, talent := range talents {
 		loaded[talent.Name] = true
 	}
-	for _, want := range []string{"loops-doctrine", "presence", "awareness-trailhead"} {
+	for _, want := range []string{"loops-doctrine", "awareness-trailhead", "README-doctrine"} {
 		if !loaded[want] {
-			t.Errorf("expected to load talent %q, got %v", want, loaded)
+			t.Errorf("expected to load declared talent %q, got %v", want, loaded)
 		}
 	}
-	for _, skip := range []string{"README", "CONTRIBUTING", "LICENSE"} {
+	for _, skip := range []string{"presence", "README", "CONTRIBUTING"} {
 		if loaded[skip] {
-			t.Errorf("expected to skip contributor doc %q, but it loaded as a talent", skip)
+			t.Errorf("expected to skip undeclared document %q, but it loaded as a talent", skip)
 		}
+	}
+}
+
+// TestTalents_NotesSkippedUndeclaredFile covers the migration hazard in
+// the skip rule. Skipping is right for a README, but it is also what
+// happens to real guidance whose frontmatter was never backported — and
+// that loss is otherwise total and silent. The notice is what lets an
+// operator tell the two apart, so it has to name the file.
+func TestTalents_NotesSkippedUndeclaredFile(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "presence.md", "# Presence\n\nidentity prose that lost its frontmatter.")
+
+	var buf bytes.Buffer
+	restore := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	defer slog.SetDefault(restore)
+
+	if _, err := NewLoader(dir).Talents(); err != nil {
+		t.Fatalf("Talents() error: %v", err)
+	}
+	if !strings.Contains(buf.String(), "presence.md") {
+		t.Errorf("skip notice should name the file; got: %s", buf.String())
+	}
+
+	// Deduped by path: the loader re-reads on every turn, and a line that
+	// repeated forever would be noise rather than a signal.
+	buf.Reset()
+	if _, err := NewLoader(dir).Talents(); err != nil {
+		t.Fatalf("Talents() second call: %v", err)
+	}
+	if strings.Contains(buf.String(), "presence.md") {
+		t.Errorf("skip notice should fire once per path; got: %s", buf.String())
+	}
+}
+
+// TestTalents_RefusesDeclaredTalentWithoutTags is the other half of the
+// rule: a file that opens with frontmatter has declared itself guidance,
+// so silence about when it applies is an authoring error and not an
+// implicit "every turn". Refusing at load is what keeps the meaning of
+// silence from having two answers.
+func TestTalents_RefusesDeclaredTalentWithoutTags(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		content string
+	}{
+		{"no tags key", "---\nkind: trailhead\nteaser: \"...\"\n---\n# Orphan"},
+		{"empty tag list", "---\ntags: []\n---\n# Orphan"},
+		{"tagless node in multi-node file", "---\nname: first\ntags: [loops]\n---\n# First\n\n---\nname: second\n---\n# Second"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			writeFile(t, dir, "orphan.md", tc.content)
+
+			_, err := NewLoader(dir).Talents()
+			if err == nil {
+				t.Fatal("expected a talent declaring no tags to be refused")
+			}
+			// The message has to tell an operator what to write, since
+			// this surfaces as a boot failure on their instance.
+			for _, want := range []string{"orphan.md", "declares no tags", TagAlways, TagPersona} {
+				if !strings.Contains(err.Error(), want) {
+					t.Errorf("error %q should mention %q", err, want)
+				}
+			}
+		})
 	}
 }
 
@@ -527,13 +593,13 @@ func TestShouldIncludeTalent(t *testing.T) {
 		want       bool
 	}{
 		{
-			name:       "untagged with nil active tags",
+			name:       "always-on with nil active tags",
 			talent:     Talent{Tags: []string{TagAlways}},
 			activeTags: nil,
 			want:       true,
 		},
 		{
-			name:       "untagged with active tags",
+			name:       "always-on with active tags",
 			talent:     Talent{Tags: []string{TagAlways}},
 			activeTags: map[string]bool{"ha": true, TagAlways: true},
 			want:       true,

--- a/talents/README.md
+++ b/talents/README.md
@@ -13,6 +13,30 @@ authoritative `kind:` values are declared in
 README documents the authoring conventions — name your file right, choose the
 right shape, and the loader does the rest.
 
+## Every talent declares when it applies
+
+Frontmatter is what makes a file a talent. A `.md` file in this directory that
+opens with no frontmatter is not guidance and is never injected — that is how
+this README sits here safely, and it is the only rule that decides. The
+filename plays no part in it.
+
+A file that does declare frontmatter must declare `tags:`, and the loader
+refuses one that does not. Silence is not a shorthand for "every turn": an
+absent tag list cannot be told apart from an oversight, and a talent that says
+nothing about its own applicability leaves the rule invisible to whoever reads
+it next. Two tags answer the question directly:
+
+- `always` — applies to every turn, whatever shape it takes.
+- `persona` — applies only where the persona is present, where the agent is
+  being itself rather than executing a procedure. Not a synonym for
+  "conversational": drafting an email is not a conversation but wants the
+  voice.
+
+Anything else is a capability tag, and the talent loads when that capability is
+active. A talent tagged only `always` or `persona` is stable for the whole run
+and lands in the prompt's long-lived prefix; mixing either with a capability tag
+makes it changeable mid-run, so it moves to the shorter-lived block.
+
 ## The four kinds
 
 Talents fall into four shapes. The kind determines how the file's content gets
@@ -20,19 +44,21 @@ used at runtime; the filename and frontmatter together signal which kind.
 
 | Kind | Frontmatter | Filename | When it loads |
 |---|---|---|---|
-| **Foundation** | none | bare topic (e.g. `presence.md`) | Always — part of the base prompt |
+| **Foundation** | `tags: [always]` or `tags: [persona]` | bare topic (e.g. `presence.md`) | Every turn, or every turn wearing the persona |
 | **Trailhead** | `kind: trailhead` + `next_tags:` | `<tag>-trailhead.md` | When the tag activates; sorts first |
 | **Doctrine** | `tags: [...]` | `<tag>.md` (single per tag) or `<tag>-doctrine.md` | When the tag activates |
 | **Examples** | `tags: [...]`, often multi-node | `<tag>-examples.md` | When the tag activates |
 
 ### Foundation
 
-Identity, posture, and craft that should always reach the model. No
-frontmatter; the file body becomes part of the base prompt every turn. Six
-foundation files today: `foundation.md`, `presence.md`, `awareness.md`,
-`communication.md`, `delegation.md`, `working-memory.md`.
+Identity, posture, and craft that should reach the model on every turn it
+applies to. Six foundation files today — `foundation.md`, `presence.md`,
+`awareness.md`, `communication.md`, `delegation.md`, `working-memory.md` — all
+tagged `persona`, because each speaks in or about the voice.
 
-Add a foundation talent rarely. Every line earns its always-on slot.
+Add a foundation talent rarely. Every line earns its always-on slot, and that
+slot is a caching boundary as well as a prompt one: this content is what a
+provider retains across a run.
 
 ### Trailheads
 
@@ -116,7 +142,7 @@ The loader parses these keys (others are silently ignored):
 | Key | Type | Purpose |
 |---|---|---|
 | `name` | string | Per-talent identifier. Required in multi-node files; optional in single-node (falls back to filename). |
-| `tags` | `[string, ...]` | Tags that activate this talent. OR semantics. |
+| `tags` | `[string, ...]` | Required. Tags that activate this talent, OR semantics. `always` and `persona` declare turn-shape applicability; anything else is a capability tag. A talent declaring none is refused at load. |
 | `tags_all` | `[string, ...]` | Parsed but **not currently consulted for talent loading** — the talents loader only inspects `tags:` when deciding what to inject. `tags_all` is honored today for tagged KB articles (via the `tag_context` pipeline), where it composes AND-style with `tags:`. Leave it off talent frontmatter unless you're prepared to wire it through `Talent` and `FilterByTags` first. |
 | `kind` | `trailhead` or empty | Marks the file as a trailhead. The legacy `entry_point` value still loads with a deprecation warning. |
 | `teaser` | string | One-line summary shown when a parent menu surfaces this branch. Trailheads should set this. |


### PR DESCRIPTION
Declared applicability landed in #1278 with a transitional escape hatch. `applicabilityTags` normalized a file with no tags to `always`, which preserved the old behaviour exactly while making it visible downstream — a reasonable half-step, and its own comment said so: "Once the loader refuses tagless files outright, this stops firing and can go." The trouble with a half-step written that way is that nothing forces the second one. Silence kept two answers, the plumbing kept working, and the only thing scheduled to remove it was somebody remembering it was there.

So this takes the second step. A file that opens with frontmatter has declared itself guidance; declaring no tags is then an authoring error rather than an implicit "every turn", and the loader refuses it by name and points at `always` and `persona`. Nothing infers meaning from an absence anywhere in the path.

Retiring the inference also retires the guess that depended on it. `listFiles` skipped uppercase-leading filenames because tagless files loaded unconditionally, which left an undeclared `README.md` indistinguishable from doctrine — capitalization was standing in for a declaration nobody was making. Now the declaration exists, so it does the work: a `.md` file that opens with no frontmatter is a document that happens to share the directory, whatever it is called, and a talent is a talent whatever it is called. The loader asks the parser rather than re-implementing the rule, so there is one definition of what frontmatter is.

The one thing that deserved care is that skipping is silent, and silence is exactly wrong in one of the two cases it now covers. A README skipped quietly is correct. Foundation prose skipped quietly is a catastrophe: the file stays on disk, the loader says nothing, and the model simply stops receiving the identity prose. Those look identical from inside the loader, so it names every file it skips — once per path, matching the existing `WarnIfKindAlias` dedupe, because the directory is re-read on every loop turn.

## Operator impact

This is a breaking change for any hand-maintained talents directory, which is to say for prod. Every talent file must declare `tags:`. Note the two failure directions are different and only one of them is loud:

- A file with frontmatter but no `tags:` → refused, boot fails with the filename and the tags to choose from.
- A file with no frontmatter at all → skipped with an `INFO` naming it, and its content silently leaves the prompt.

The second is the one to watch on upgrade. Foundation prose authored before applicability tags — `foundation.md`, `presence.md`, `awareness.md`, `communication.md`, `delegation.md`, `working-memory.md` — has no frontmatter at all, so a directory that predates #1283 loses its identity prose with only that log line to say so. The repo's own copies are already tagged `persona`; a directory maintained by hand needs them backported before this deploys.

## Test plan

- [x] `just ci` green locally
- [x] Frontmatter, not filename, decides what loads — asserted in both directions, including an uppercase-named talent that loads and a lowercase-named document that does not (`TestTalents_SkipsDocsWithoutFrontmatter`)
- [x] A declared talent with no tags is refused, across a missing `tags:` key, an empty list, and one tagless node in a multi-node file; the error names the file and both applicability tags (`TestTalents_RefusesDeclaredTalentWithoutTags`)
- [x] A skipped undeclared file is named in the log, once per path (`TestTalents_NotesSkippedUndeclaredFile`)
- [x] Malformed frontmatter is refused rather than skipped, at file start and on a later node, naming the file (`TestTalents_RefusesMalformedFrontmatter`)
- [x] A bare `---` horizontal rule in a body stays content under strict parsing (`TestTalents_HorizontalRuleStaysContent`)
- [x] The whole repo corpus parses strictly — 69 nodes, README skipped, nothing silently truncated today
- [x] Full suite green — no caller depended on the tagless-means-always normalization
- [ ] Prod: backport tagged foundation prose to the talents directory before deploying, then confirm boot logs no skip notices

## Docs

`talents/README.md` and `docs/talent-authoring.md` both still documented foundation prose as "no frontmatter, no tags" and the skip rule as filename capitalization. Both are corrected — a stale authoring guide is how the retired rule would have come back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

