### PR TITLE
A leaf that promises its neighbor is always in the room

### DIFF
--- a/talents/memory.md
+++ b/talents/memory.md
@@ -235,6 +235,6 @@ section is the *operational* documentation; that one is the craft.
   not stored facts.
 - For the *craft* of writing session working memory (tone, arc,
   texture rather than action notes), the
-  [`working-memory.md`](working-memory.md) foundation talent loads
-  on every turn already; this leaf carries only the operational
-  read/write semantics.
+  [`working-memory.md`](working-memory.md) foundation talent carries
+  it, and loads wherever the persona is present; this leaf carries
+  only the operational read/write semantics.


### PR DESCRIPTION
Moving foundation prose onto `persona` changed a fact that one talent had already written down. `memory.md` closes with a cross-reference telling the model that the `working-memory.md` foundation talent "loads on every turn already, so this leaf carries only the operational read/write semantics." That was accurate while foundation prose was tagless and unconditional. It carries `persona` now, so it loads where the persona is present and nowhere else, and the sentence became a promise the corpus no longer keeps.

This is the failure mode worth being fussy about. A stale statement in an operator doc misleads someone who can go and check; a stale statement in the corpus misleads the reader who is *deciding what to do* and has no way to verify that its neighbor is in the room. The sentence does not merely describe the craft talent — it explains why this leaf omits the craft, which means on a persona-less turn the model gets the operational half, is told the other half is already present, and has no reason to look for it.

Nothing else in the corpus makes this claim. I checked every "every turn" and "loads on" phrasing across the 38 talents: the rest are about sensor membership re-resolving, loop prompts seeing the document body, and working-memory *content* being injected into the system prompt — all different mechanisms, all still true.

## Test plan

- [x] `just ci` green locally
- [x] Swept the corpus for the same shape of claim (`every turn`, `each turn`, `always present`, `already loaded`, `loads on`) — this was the only stale one
- [x] Confirmed `working-memory.md` is tagged `persona`, so the replacement wording is accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)
