### PR TITLE
Loops was the one capability with no map at the door

### DIFF
--- a/talents/loops-trailhead.md
+++ b/talents/loops-trailhead.md
@@ -1,0 +1,51 @@
+---
+kind: trailhead
+tags: [loops]
+teaser: "Open when work should recur, run detached, or outlive this turn."
+next_tags: [loops_examples, documents, awareness]
+---
+
+# Loops Trailhead
+
+A loop is work that outlives the turn that created it. Before reaching
+for one, answer two questions in order — the first picks the door, the
+second decides whether anything needs to be stored at all.
+
+**1. Must it finish before you reply?** Then it is not a loop.
+`thane_now` runs bounded work inline and returns its result to this
+turn. `thane_assign` hands off one-shot background work that reports
+back later. Neither leaves a reusable definition behind, and that is the
+point: they do work and exit.
+
+**2. Should it still exist tomorrow?** A durable loop leaves a stored
+definition you can inspect, edit, pause, reactivate, and relaunch. An ad
+hoc one does not.
+
+- **Durable** — `loop_definition_set` writes the spec, then
+  `loop_definition_launch` starts it. Lint first with
+  `loop_definition_lint`: it takes the same spec and catches authoring
+  mistakes before anything persists. This is the path for any loop that
+  curates an understanding over time.
+- **Ad hoc** — `spawn_loop` launches immediately from a full spec and
+  persists nothing. Right for a temporary service or detached research
+  that should not join the durable registry. Wrong for anything that
+  owns a document: the loop ends, the document remains, and its
+  ownership frontmatter points at a loop that no longer exists.
+
+`thane_loop_create` is a shorter front door to the durable path. It
+takes one output document and cannot declare tiers or working notes, so
+reach for `loop_definition_set` whenever the loop curates something
+others consult — which is most service loops worth writing.
+
+## Where to go next
+
+- The doctrine that follows this file covers pacing, output ownership,
+  tiered publishing, and working notes. Read it before authoring a spec.
+- `loops_examples` opens worked specs — a curating loop, a journal, a
+  dashboard, a delegated one-shot. Start there rather than composing a
+  spec from the schema alone.
+- `documents` covers the managed roots a loop's outputs live in, and the
+  policy that decides whether an output is searchable, injectable, or
+  private.
+- `awareness` covers entity subscriptions, which is how a loop watches
+  something and how an event-driven loop gets woken at all.

--- a/talents/loops-trailhead.md
+++ b/talents/loops-trailhead.md
@@ -7,15 +7,20 @@ next_tags: [loops_examples, documents, awareness]
 
 # Loops Trailhead
 
-A loop is work that outlives the turn that created it. Before reaching
-for one, answer two questions in order — the first picks the door, the
-second decides whether anything needs to be stored at all.
+Everything here runs on the same loop machinery — the operations differ
+in how often they run and in what they leave behind. Answer two
+questions in order: the first picks how often, the second decides
+whether anything needs to be stored.
 
-**1. Must it finish before you reply?** Then it is not a loop.
-`thane_now` runs bounded work inline and returns its result to this
-turn. `thane_assign` hands off one-shot background work that reports
-back later. Neither leaves a reusable definition behind, and that is the
-point: they do work and exit.
+**1. Does it run once, or keep running?** One-shot work is a loop that
+executes and finishes. `thane_now` runs it inline and returns the result
+to this turn, so reach for it when you cannot answer without the work.
+`thane_assign` runs it detached and reports back later, so reach for it
+when the turn should not wait. Neither leaves a reusable definition, and
+neither is worth a definition: they do the work and end.
+
+Work that recurs on its own schedule, or waits quiescent for a trigger,
+is the rest of this file.
 
 **2. Should it still exist tomorrow?** A durable loop leaves a stored
 definition you can inspect, edit, pause, reactivate, and relaunch. An ad
@@ -27,10 +32,11 @@ hoc one does not.
   mistakes before anything persists. This is the path for any loop that
   curates an understanding over time.
 - **Ad hoc** — `spawn_loop` launches immediately from a full spec and
-  persists nothing. Right for a temporary service or detached research
-  that should not join the durable registry. Wrong for anything that
-  owns a document: the loop ends, the document remains, and its
-  ownership frontmatter points at a loop that no longer exists.
+  persists nothing. Right for a temporary service that should not join
+  the durable registry, and for one-shot work needing spec-level control
+  `thane_assign` does not expose. Wrong for anything that owns a
+  document: the loop ends, the document remains, and its ownership
+  frontmatter points at a loop that no longer exists.
 
 `thane_loop_create` is a shorter front door to the durable path. It
 takes one output document and cannot declare tiers or working notes, so

--- a/talents/loops.md
+++ b/talents/loops.md
@@ -5,26 +5,21 @@ tags: [loops]
 
 # Loops Doctrine
 
-Choose loop tools by lifecycle:
+The trailhead above picks the door. This is the craft once you are
+through it.
 
-- `thane_now` for bounded work that must finish before you reply.
-- `thane_assign` for one-shot background work that should report back
-  later.
-- `thane_loop_create` with `operation="service"` for recurring service
-  work that owns a managed document over time.
-- `spawn_loop` for ad hoc loop-shaped work that should start now without
-  becoming a stored definition.
-- loop definition tools for durable services you need to inspect, edit,
-  pause, reactivate, or relaunch.
+A service loop's `sleep_min` and `sleep_max` set the envelope it
+self-paces inside. Its outputs declare what it owns — optional, since a
+service loop can act without maintaining a document — and when an output
+is declared the running loop writes through a generated tool named for
+it: `replace_output_*` for a whole-document rewrite, `append_output_*`
+for a journal entry, `publish_output_*` when the output declares tiers.
+If a maintained output is marked `truncated` in Declared Durable
+Outputs, read the full document before replacing it.
 
-For recurring document work, prefer `thane_loop_create` with
-`operation="service"`. Its `sleep_min` and `sleep_max` set the envelope
-the running loop self-paces inside, its `output` declares the state owner
-(now optional — a service loop can run without maintaining a document),
-and when a document is declared the running loop writes through generated
-output tools such as `replace_output_*`, `append_output_*`, or
-`publish_output_*`. If a maintained output is marked `truncated` in
-Declared Durable Outputs, read the full document before replacing it.
+Declaring tiers or working notes requires the full spec, so author those
+loops with `loop_definition_set` and start them with
+`loop_definition_launch`.
 
 ## Who reads this output?
 


### PR DESCRIPTION
Every leaf capability tag in the corpus hands the model a map when it activates. `awareness` has a separate `-trailhead.md`; `ha`, `contacts`, `documents`, `forge`, `notifications`, `email`, and `archive` each carry `kind: trailhead` on their main file. `loops` had none. Activating it dropped 340 lines of undifferentiated doctrine — `loops.md` at 187 lines and `loops-tagging.md` at 153 — with nothing telling the model which door it was standing in front of. The one file in the family that *is* a trailhead, `loops-examples.md`, sits behind its own `loops_examples` tag and does not come along.

That gap has been load-bearing in a way worth naming, because #1106 justified promoting `thane_loop_create` to the always-on Core tier partly as *"the trailhead that crosses the model into the gated `loop_*` lifecycle."* A tool was standing in for a missing map, paying permanent prompt weight on every turn to do a job the talent layer does for free when its tag activates. This is the map, and it costs nothing until someone opens the door.

The trailhead carries the decision the doctrine was carrying badly: whether the work is a loop at all — `thane_now` and `thane_assign` do work and exit, leaving nothing to inspect — and then whether it needs to be stored, which is the real seam between `loop_definition_set` and `spawn_loop`. It names the `spawn_loop` trap explicitly, since spawning a loop that owns a document leaves the document behind with ownership frontmatter pointing at a loop that no longer exists. The doctrine drops its lifecycle list rather than repeating it: a trailhead always sorts ahead of doctrine on the same tag, so the two now read in order instead of competing.

It also corrects guidance that had gone stale underneath the tiered-output work. `loops.md` recommended `thane_loop_create` for recurring document work twelve lines before recommending that curating loops declare `tiers` — a field that tool's schema cannot express and, because neither schema sets `additionalProperties: false`, silently discards. A model following the talent would have created an untiered loop and been told it succeeded. Curating loops now route to `loop_definition_set` and `loop_definition_launch`, which take the full spec. That redirect is temporary by intent: deliverable 2 of #1287 makes the front door fluent in outputs, and this guidance should follow it back.

## Test plan

- [x] `just ci` green locally
- [x] `TestRepoTrailheadNextTagsResolve` passes — `next_tags` resolve to `loops_examples` (talent-declared) plus the built-in `documents` and `awareness`
- [x] The trailhead is injected on the `loops` tag and sorts ahead of the doctrine (verified by loading the repo corpus and asserting the offsets: trailhead at 0, doctrine at 9145)
- [x] No talent still recommends `thane_loop_create` for tiered or working-notes outputs
- [ ] Backport to prod `core/talents` after merge, as a signed commit — the deploy does not push talents

Refs #1287
