### PR TITLE
Holding the only writer slot for five hundred statements

### DIFF
--- a/internal/platform/logging/archiver.go
+++ b/internal/platform/logging/archiver.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/nugget/thane-ai-agent/internal/platform/database"
@@ -168,22 +169,44 @@ func (a *Archiver) processBatch(ctx context.Context, ids []string, archiveDir st
 
 // deleteBatch removes the given request IDs from log_request_content
 // and log_tool_content in a single transaction.
+//
+// Both tables are cleared with one statement each rather than a
+// statement per ID. SQLite in WAL mode admits exactly one writer, and
+// this transaction holds that slot for its whole duration while the
+// live logging path is still writing to the same file. Issuing
+// 2×archiveBatchSize statements held the write lock long enough to push
+// concurrent writers past their five-second busy timeout, which
+// surfaced as SQLITE_BUSY under the "content archive failed" warning
+// during backfill runs — and because the JSONL is flushed before the
+// delete, a failed batch is re-archived on the next pass as duplicate
+// lines. Two statements keep the lock held for as long as the delete
+// actually needs.
 func (a *Archiver) deleteBatch(ctx context.Context, ids []string) error {
+	if len(ids) == 0 {
+		return nil
+	}
+
+	// One placeholder per ID; archiveBatchSize is far below SQLite's
+	// variable limit, and fetchBatch is what bounds the slice.
+	placeholders := strings.TrimPrefix(strings.Repeat(",?", len(ids)), ",")
+	args := make([]any, len(ids))
+	for i, id := range ids {
+		args[i] = id
+	}
+
 	tx, err := a.db.BeginTx(ctx, nil)
 	if err != nil {
 		return fmt.Errorf("begin delete tx: %w", err)
 	}
 	defer tx.Rollback() //nolint:errcheck
 
-	for _, id := range ids {
-		if _, err := tx.ExecContext(ctx,
-			`DELETE FROM log_tool_content WHERE request_id = ?`, id); err != nil {
-			return fmt.Errorf("delete tool rows for %s: %w", id, err)
-		}
-		if _, err := tx.ExecContext(ctx,
-			`DELETE FROM log_request_content WHERE request_id = ?`, id); err != nil {
-			return fmt.Errorf("delete request row for %s: %w", id, err)
-		}
+	if _, err := tx.ExecContext(ctx,
+		`DELETE FROM log_tool_content WHERE request_id IN (`+placeholders+`)`, args...); err != nil {
+		return fmt.Errorf("delete tool rows for %d requests: %w", len(ids), err)
+	}
+	if _, err := tx.ExecContext(ctx,
+		`DELETE FROM log_request_content WHERE request_id IN (`+placeholders+`)`, args...); err != nil {
+		return fmt.Errorf("delete request rows for %d requests: %w", len(ids), err)
 	}
 
 	return tx.Commit()

--- a/internal/platform/logging/archiver.go
+++ b/internal/platform/logging/archiver.go
@@ -188,7 +188,7 @@ func (a *Archiver) deleteBatch(ctx context.Context, ids []string) error {
 
 	// One placeholder per ID; archiveBatchSize is far below SQLite's
 	// variable limit, and fetchBatch is what bounds the slice.
-	placeholders := strings.TrimPrefix(strings.Repeat(",?", len(ids)), ",")
+	placeholders := strings.TrimRight(strings.Repeat("?,", len(ids)), ",")
 	args := make([]any, len(ids))
 	for i, id := range ids {
 		args[i] = id

--- a/internal/platform/logging/archiver_test.go
+++ b/internal/platform/logging/archiver_test.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
+	"fmt"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -231,5 +232,50 @@ func TestMonthKeyFor(t *testing.T) {
 		if got != tc.want {
 			t.Errorf("monthKeyFor(%q) = %q, want %q", tc.input, got, tc.want)
 		}
+	}
+}
+
+// TestArchiver_DeleteBatchClearsFullBatch exercises deleteBatch at the
+// size a real run produces. The per-ID loop it replaced held SQLite's
+// single WAL writer slot for 2×archiveBatchSize statements, long enough
+// to push concurrent writers past their busy timeout; a full-size batch
+// also proves the IN-list stays inside SQLite's variable limit, which a
+// two-row fixture would never reach.
+func TestArchiver_DeleteBatchClearsFullBatch(t *testing.T) {
+	db := openTestDB(t)
+	ctx := context.Background()
+
+	ids := make([]string, archiveBatchSize)
+	for i := range ids {
+		ids[i] = fmt.Sprintf("req-%03d", i)
+		if _, err := db.Exec(
+			`INSERT INTO log_request_content (request_id, user_content, model, created_at)
+			 VALUES (?, 'u', 'test', ?)`, ids[i], "2026-01-01T00:00:00Z"); err != nil {
+			t.Fatalf("insert request %s: %v", ids[i], err)
+		}
+		if _, err := db.Exec(
+			`INSERT INTO log_tool_content (request_id, iteration_index, tool_name, arguments, result, created_at)
+			 VALUES (?, 0, 'x', '{}', 'ok', ?)`, ids[i], "2026-01-01T00:00:00Z"); err != nil {
+			t.Fatalf("insert tool row %s: %v", ids[i], err)
+		}
+	}
+
+	if err := NewArchiver(db, t.TempDir(), slog.Default()).deleteBatch(ctx, ids); err != nil {
+		t.Fatalf("deleteBatch: %v", err)
+	}
+
+	for _, table := range []string{"log_request_content", "log_tool_content"} {
+		var n int
+		if err := db.QueryRow(`SELECT COUNT(*) FROM ` + table).Scan(&n); err != nil {
+			t.Fatalf("count %s: %v", table, err)
+		}
+		if n != 0 {
+			t.Errorf("%s: %d rows survived the batch delete, want 0", table, n)
+		}
+	}
+
+	// Empty batches must not build a degenerate `IN ()` statement.
+	if err := NewArchiver(db, t.TempDir(), slog.Default()).deleteBatch(ctx, nil); err != nil {
+		t.Errorf("empty batch should be a no-op, got %v", err)
 	}
 }


### PR DESCRIPTION
Production logged `content archive failed ... delete tool rows for r_b5a6112ea9011bb0: database is locked (5) (SQLITE_BUSY)` while working through the historical backfill, with a `before:` of late April.

`deleteBatch` opened one transaction and then issued a `DELETE` per table per request ID — two statements for every ID in the batch, so 500 for a full one. SQLite in WAL mode admits exactly one writer at a time, and that transaction holds the slot from `BeginTx` to `Commit` while the live logging path is still writing to the same file. Five seconds is the whole budget a concurrent writer has before `busy_timeout(5000)` gives up, and a 500-statement transaction over a backlog is not hard-pressed to exceed it. The warning names the archiver, but the archiver is as likely to be the one waiting: whichever writer arrives second is the one that fails.

Both tables are now cleared with one `IN`-list statement each. The lock is held for as long as the delete needs rather than for as long as it takes Go to iterate. `archiveBatchSize` is 250, far below SQLite's variable limit, and `fetchBatch` is what bounds the slice — so the list size is already governed upstream.

## The cost was not a skipped prune

This is the part worth reading. `processBatch` flushes the JSONL files *before* touching the database, deliberately, so that an interruption between the two cannot lose data. The tradeoff is stated in the type comment: rows written but not deleted get re-archived on the next run as duplicate lines, which the comment reasonably calls harmless when the cause is an occasional crash.

`SQLITE_BUSY` under write contention is not an occasional crash. It is a recurring condition during exactly the workload — backfill — that produces the largest batches and the heaviest concurrent write pressure. Every one of these warnings meant up to 250 requests written to a monthly file that were then written to it again. The duplicates are in the archive, not the database, so nothing is lost; but `archive_search` over those months is now counting some requests more than once.

Worth a follow-up decision, out of scope here: whether the monthly files should be deduplicated by `request_id`, or whether the write phase should become idempotent so a repeat is a no-op rather than an append.

## What this does not change

`database.Open` sets `busy_timeout(5000)` and WAL but never calls `SetMaxOpenConns`, so Go hands out an unbounded pool and multiple goroutines contend as independent writers where SQLite permits one. Serialising the pool would remove the contention class entirely rather than shortening it, but it is a global change to every store in the system and it would serialise reads too — that deserves its own change and its own reasoning, not a rider on a bug fix.

## Test plan

- [x] `just ci` green locally
- [x] New `TestArchiver_DeleteBatchClearsFullBatch` builds a full `archiveBatchSize` batch and asserts both tables are emptied — a full-size batch is what provoked the lock hold, and it is also what proves the `IN`-list stays inside SQLite's variable limit
- [x] Empty-batch case asserted, so a nil slice cannot build a degenerate `IN ()`
- [x] Existing archiver tests unchanged and passing — the old per-ID shape satisfied all of them, which is why the regression needed a new one
- [ ] Prod: confirm `content archive failed` stops recurring on the next archive run after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)
