### PR TITLE
The example an agent copies taught the untiered shape

### DIFF
--- a/internal/tools/talent_example_spec_test.go
+++ b/internal/tools/talent_example_spec_test.go
@@ -57,4 +57,18 @@ func TestTalentExampleSpecValidates(t *testing.T) {
 	if got := tiered.ToolName(); !strings.HasPrefix(got, "publish_output_") {
 		t.Errorf("generated tool = %q, want publish_output_* — the example claims it swaps", got)
 	}
+
+	// doc_read is gated behind the documents tag, and the example's own
+	// prose tells the loop to read its document when the injected body is
+	// truncated. A spec can validate perfectly and still describe a task
+	// its tag set cannot perform, so this is asserted rather than trusted.
+	var hasDocuments bool
+	for _, tag := range decoded.Tags {
+		if tag == "documents" {
+			hasDocuments = true
+		}
+	}
+	if !hasDocuments {
+		t.Error("a loop that owns documents needs the documents tag to reach doc_read")
+	}
 }

--- a/internal/tools/talent_example_spec_test.go
+++ b/internal/tools/talent_example_spec_test.go
@@ -1,0 +1,60 @@
+package tools
+
+import (
+	"encoding/json"
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// TestTalentExampleSpecValidates decodes the loop spec published in the
+// tiered curate example and runs it through the same decode-and-validate
+// path loop_definition_set uses.
+//
+// A worked example is what a model copies, so an example that would not
+// validate is worse than no example: it teaches a call that fails. This
+// one caught a missing task: on the first run.
+//
+// Deliberately targeted rather than sweeping every JSON block in the
+// file — the others are thane_loop_create arguments and publish
+// payloads, which are different shapes and would fail spec validation
+// for reasons that are not defects.
+func TestTalentExampleSpecValidates(t *testing.T) {
+	raw, err := os.ReadFile("../../talents/loops-examples.md")
+	if err != nil {
+		t.Fatalf("read talent: %v", err)
+	}
+	node := string(raw)
+	start := strings.Index(node, "# Curate: Dashboard (tiered publish)")
+	if start < 0 {
+		t.Fatal("tiered curate example not found")
+	}
+	block := regexp.MustCompile("(?s)```json\n(.*?)```").FindStringSubmatch(node[start:])
+	if block == nil {
+		t.Fatal("no json block in the example")
+	}
+
+	var spec map[string]any
+	if err := json.Unmarshal([]byte(block[1]), &spec); err != nil {
+		t.Fatalf("example json does not parse: %v", err)
+	}
+	decoded, err := decodeLoopSpecArg(map[string]any{"spec": spec}, "spec")
+	if err != nil {
+		t.Fatalf("example spec does not decode: %v", err)
+	}
+	if err := decoded.ValidatePersistable(); err != nil {
+		t.Fatalf("example spec does not validate: %v", err)
+	}
+
+	if len(decoded.Outputs) != 2 {
+		t.Fatalf("outputs = %d, want 2 (tiered document + working notes)", len(decoded.Outputs))
+	}
+	tiered := decoded.Outputs[0]
+	if len(tiered.Tiers) != 3 {
+		t.Errorf("tiers = %v, want three projections", tiered.Tiers)
+	}
+	if got := tiered.ToolName(); !strings.HasPrefix(got, "publish_output_") {
+		t.Errorf("generated tool = %q, want publish_output_* — the example claims it swaps", got)
+	}
+}

--- a/talents/loops-examples.md
+++ b/talents/loops-examples.md
@@ -2,7 +2,7 @@
 name: loops_examples
 tags: [loops_examples]
 kind: trailhead
-teaser: "Open when about to launch any loop-shaped work. Walks you to the right thane_* call."
+teaser: "Open when about to launch any loop-shaped work. Walks you to the right shape and the right door."
 next_tags: [loops_examples_curate, loops_examples_now, loops_examples_assign, loops_examples_advanced]
 ---
 
@@ -64,26 +64,31 @@ next_tags: [loops_examples_curate_dashboard, loops_examples_curate_journal, loop
 
 # Curate
 
-`thane_loop_create` with `operation: service` creates a self-paced
-recurring loop. A service loop can maintain a managed markdown document
-(via the optional `output`), but the document is no longer required —
-omit `output` for a service loop that just does recurring work. When it
-does own a document, two questions decide which sub-shape fits:
+A service loop is self-paced and recurring. It may maintain a managed
+markdown document, but need not — omit outputs entirely for a service
+loop that just does recurring work. When it does own one, three
+questions decide the shape:
 
 1. **Does each cycle replace the document or append to it?**
    - Replace (idempotent rewrite) → activate
      `loops_examples_curate_dashboard`
    - Append a dated entry → activate `loops_examples_curate_journal`
 
-2. **Does the loop need to escalate decisions to you, or accept new
+2. **Will anyone else consult this?** A loop whose value is being read
+   by other turns, other loops, or an ambient surface should declare
+   `tiers` so each reader takes the length it can afford. That needs the
+   full spec: author it with `loop_definition_set` and start it with
+   `loop_definition_launch`. A loop nobody reads but its owner can stay
+   untiered on the shorter front door.
+
+3. **Does the loop need to escalate decisions to you, or accept new
    focus when you adjust its scope?**
    - Yes (bi-directional) → activate `loops_examples_curate_circle`
      after picking dashboard or journal
 
 ## The sleep envelope is the one judgment call
 
-`thane_loop_create` with `operation: service` requires `sleep_min` and
-`sleep_max`. The loop self-paces inside that envelope via
+A service loop requires `sleep_min` and `sleep_max`. The loop self-paces inside that envelope via
 `set_next_sleep`, which is clamped to the bounds. Pick bounds to match
 the topic's metabolism:
 
@@ -106,41 +111,93 @@ the core tag set. A service loop watching HA entities needs at least
 name: loops_examples_curate_dashboard
 tags: [loops_examples_curate_dashboard]
 kind: trailhead
-teaser: "Maintain a single dashboard document idempotently each cycle."
+teaser: "Curate a domain others consult: one document, published at several fidelities."
 ---
 
-# Curate: Dashboard (maintain mode)
+# Curate: Dashboard (tiered publish)
 
-Use `mode: maintain` when the document should reflect *current state*,
-not history. Each cycle rewrites the body; the generated output tool is
-`replace_output_<loop_name>`.
+A loop that keeps an understanding current for other readers should
+publish it at more than one length. Declaring `tiers` on a maintained
+output curates condensed views alongside the full body, so an ambient
+row takes `status_line`, a search snippet takes `teaser`, a digest row
+takes `digest`, and a reader who wants everything opens the document.
+Without tiers every consumer pays for the whole document or gets a
+blind truncation of it.
+
+Tiers need the full spec, so author this with `loop_definition_set` and
+start it with `loop_definition_launch`. Lint first — `loop_definition_lint`
+takes the same spec and catches mistakes before anything persists.
 
 ```json
 {
   "name": "server_closet_guardian",
-  "intent": "Watch the server-closet environment and equipment health. Document trends. Surface UPS dropouts, dehumidifier failure, or temperature excursions that need attention.",
+  "intent": "Keep the current state of the server closet — environment, power, and equipment health — legible to anyone who asks, and surface excursions that need attention.",
+  "task": "Read the current sensor values and the document you maintain. If the state has moved materially, publish all projections together. If nothing has changed, publish nothing and record why in working notes.",
   "operation": "service",
   "sleep_min": "10m",
   "sleep_max": "30m",
-  "entities": [
+  "subscriptions": [
     {"entity_id": "sensor.server_closet_temperature"},
     {"entity_id": "sensor.server_closet_humidity"},
     {"entity_id": "sensor.ups_hor_rack_status"},
-    {"entity_id": "sensor.ups_hor_rack_battery_runtime"},
     {"entity_id": "switch.dehumidifier"}
   ],
-  "output": {
-    "document": "kb:dashboards/server-closet.md",
-    "mode": "maintain",
-    "title": "Server Closet Guardian"
-  },
-  "tags": ["home", "ha", "awareness"]
+  "tags": ["home", "ha", "awareness"],
+  "outputs": [
+    {
+      "name": "closet_state",
+      "type": "maintained_document",
+      "ref": "kb:dashboards/server-closet.md",
+      "tiers": ["status_line", "teaser", "digest"],
+      "purpose": "Current state of the server closet for anyone who asks."
+    },
+    {
+      "name": "notes",
+      "type": "working_notes",
+      "ref": "kb:dashboards/server-closet-notes.md"
+    }
+  ]
 }
 ```
 
-The loop's prompt sees the current document body each turn (truncated
-if oversized — in that case, read it with `doc_read` first), then the
-model rewrites the body via `replace_output_server_closet_guardian`.
+## Publishing
+
+Declaring tiers swaps the generated tool: instead of
+`replace_output_closet_state` taking a body, the loop gets
+`publish_output_closet_state` taking one argument per projection. Pass
+them all in one call — they are written together so no reader sees a
+status line describing a state the details have moved past. Do not write
+the section headings; they are rendered for you.
+
+```json
+{
+  "status_line": "Closet 21.4°C, 38% RH, UPS on mains, dehumidifier idle.",
+  "teaser": "Server closet is stable. Temperature and humidity have held inside normal range for six hours; the UPS is on mains power with a full charge, and the dehumidifier has not needed to run since morning.",
+  "digest": "Environment: 21.4°C (range 20.8–22.1 over 24h), 38% RH, both comfortably inside bounds...",
+  "full": "# Server Closet\n\n## Environment\n\n..."
+}
+```
+
+Each projection has a rune budget — 120 for `status_line`, 500 for
+`teaser`, 2048 for `digest` — and an over-budget value is rejected
+rather than trimmed, because a clipped projection reads as a fragment
+with no sign that anything is missing. Write to the budget, not near it.
+
+Think about what each length is *for* rather than truncating the one
+above it. The status line is a glance: what is true right now. The
+teaser is what a reader needs to decide whether to open the document.
+The digest is enough to act on without opening it.
+
+## Where the reasoning goes
+
+The `working_notes` output is the loop's private log — internal by
+construction, never projected into search or another loop's context. Put
+the reasoning there: what changed and why, what drifted, what was
+refined. `publish_output_*` takes a `note` argument, so a publish and
+its reasoning are one call.
+
+Published projections carry current state, not the story of how it got
+there. Keeping those apart is what lets the document stay short.
 
 ---
 name: loops_examples_curate_journal

--- a/talents/loops-examples.md
+++ b/talents/loops-examples.md
@@ -88,9 +88,12 @@ questions decide the shape:
 
 ## The sleep envelope is the one judgment call
 
-A service loop requires `sleep_min` and `sleep_max`. The loop self-paces inside that envelope via
-`set_next_sleep`, which is clamped to the bounds. Pick bounds to match
-the topic's metabolism:
+`thane_loop_create` requires `sleep_min` and `sleep_max`. The full spec
+does not — it defaults to 30s–5m, which is wrong for almost anything
+worth curating, and wrong quietly: the loop runs, just far too often.
+Set the envelope deliberately whichever door you use. The loop
+self-paces inside it via `set_next_sleep`, which is clamped to the
+bounds. Pick bounds to match the topic's metabolism:
 
 - UPS guardian: `[5m, 30m]`
 - Burn-ban monitor: `[1h, 6h]`
@@ -142,7 +145,7 @@ takes the same spec and catches mistakes before anything persists.
     {"entity_id": "sensor.ups_hor_rack_status"},
     {"entity_id": "switch.dehumidifier"}
   ],
-  "tags": ["home", "ha", "awareness"],
+  "tags": ["home", "ha", "awareness", "documents"],
   "outputs": [
     {
       "name": "closet_state",


### PR DESCRIPTION
Ask an agent to stand up a curating service loop and it will find `loops_examples_curate_dashboard` — teaser *"Maintain a single dashboard document idempotently each cycle"*, a worked `server_closet_guardian` that is the exact shape of the loops actually running in production. Then it will copy it, and get an untiered loop.

The examples corpus contained **zero** occurrences of `tiers`, `publish_output`, `status_line`, or `working_notes` across 595 lines. Phase 1 of #1250 shipped the contract and the tool and a teaching pass in `loops.md`, but the reference tree that models actually reach for was never brought along. Doctrine a hundred lines away does not compete with a worked example; the example wins, every time, because it is copyable.

So the canonical curating example is now the tiered one. It is authored as a spec for `loop_definition_set` rather than as `thane_loop_create` arguments — that front door cannot express `tiers` and, since neither schema sets `additionalProperties: false`, drops them silently. It declares both outputs a curating loop wants, the tiered document and the working notes, and shows the publish payload with all four projections including the always-present `full`.

The guidance it carries is about *purpose per length* rather than truncation: the status line is a glance at what is true now, the teaser is what a reader needs to decide whether to open the document, the digest is enough to act on without opening it. That framing matters more than the rune budgets, because a model that thinks in truncation will write three lengths of the same sentence and #1250's open question — whether `digest` survives contact or collapses into `teaser` — will get a false answer from the corpus rather than a real one from use.

The `loops_examples_curate` parent gains the question that decides tiers — *will anyone else consult this* — placed ahead of the replace-versus-append split, because it changes which tool authors the loop rather than which sub-shape applies. The root teaser lost its claim to walk you "to the right `thane_*` call", which stopped being true when the trailhead started routing durable work to the definition tools.

## A test, because an example that does not validate is worse than none

`TestTalentExampleSpecValidates` pulls the JSON out of the talent, decodes it through the same path `loop_definition_set` uses, validates it, and asserts the generated tool is `publish_output_*` — the swap the prose claims. It caught a missing `task:` on its first run, which is precisely the failure mode worth guarding: a model copying a confident-looking example into a call that errors.

It is deliberately targeted at this one block rather than sweeping every JSON fence in the file, since the others are `thane_loop_create` arguments and publish payloads — different shapes that would fail spec validation for reasons that are not defects.

## Test plan

- [x] `just ci` green locally
- [x] The example spec decodes, validates, yields two outputs, three declared tiers, and a `publish_output_*` tool name
- [x] Publish payload verified against the generated tool's real arguments — `full` is an always-present projection and every field is required, so the example passes all four
- [x] Budgets in the prose match the enforced constants (120 / 500 / 2048 runes)
- [x] `TestRepoTrailheadNextTagsResolve` still passes — no tag graph changes
- [ ] Backport to prod `core/talents` after merge, as a signed commit

Refs #1250

🤖 Generated with [Claude Code](https://claude.com/claude-code)
