### PR TITLE
Both doors computed 'is the running loop stale' separately

### DIFF
--- a/internal/tools/loop_create_tool.go
+++ b/internal/tools/loop_create_tool.go
@@ -334,18 +334,16 @@ func (r *Registry) createLoopExecuting(ctx context.Context, args map[string]any,
 // instance's own operation, which replace may have diverged from), or the
 // result reads as if the new spec is live.
 func (r *Registry) commitAndLaunchLoop(ctx context.Context, spec looppkg.Spec) (result looppkg.LaunchResult, reused *looppkg.Loop, err error) {
-	deps := r.loopIntentDeps
-	prior := r.runningLoopByName(spec.Name)
-	updatedAt := time.Now().UTC()
-	if err := commitSpecThroughChokepoint(ctx, deps.CommitSpec, deps.Registry, spec, updatedAt); err != nil {
+	stale, err := r.persistLoopSpec(ctx, spec)
+	if err != nil {
 		return looppkg.LaunchResult{}, nil, err
 	}
-	res, err := deps.LaunchDefinition(ctx, spec.Name, looppkg.Launch{})
+	res, err := r.loopIntentDeps.LaunchDefinition(ctx, spec.Name, looppkg.Launch{})
 	if err != nil {
 		return looppkg.LaunchResult{}, nil, fmt.Errorf("launch loop %q: %w", spec.Name, err)
 	}
-	if prior != nil && res.LoopID == prior.ID() {
-		return res, prior, nil
+	if stale != nil && res.LoopID == stale.ID() {
+		return res, stale, nil
 	}
 	return res, nil, nil
 }

--- a/internal/tools/loop_definition_mutation_tools.go
+++ b/internal/tools/loop_definition_mutation_tools.go
@@ -18,23 +18,8 @@ func (r *Registry) handleLoopDefinitionSet(ctx context.Context, args map[string]
 	if err != nil {
 		return "", err
 	}
-	snapshot, err := currentLoopDefinitionSnapshot(r)
+	stale, err := r.persistLoopSpec(ctx, spec)
 	if err != nil {
-		return "", err
-	}
-	if _, _, err := ensureDefinitionMutable(snapshot, spec.Name); err != nil {
-		return "", err
-	}
-	// Captured before the commit: the commit's reconcile can SPAWN an absent
-	// active definition, and a loop that is live only after the commit runs
-	// the just-written spec — only an instance that survived the commit is
-	// stale.
-	prior := r.runningLoopByName(spec.Name)
-	updatedAt := time.Now().UTC()
-	// Single durable commit (persist + upsert + reconcile). Fall back to a
-	// bare overlay upsert when no commit hook is wired so a registry-only
-	// configuration still works.
-	if err := commitSpecThroughChokepoint(ctx, r.commitLoopDefinitionSpec, r.loopDefinitionRegistry, spec, updatedAt); err != nil {
 		return "", err
 	}
 	view, err := currentLoopDefinitionView(r)
@@ -50,16 +35,12 @@ func (r *Registry) handleLoopDefinitionSet(ctx context.Context, args map[string]
 		"generation": view.Generation,
 		"definition": def,
 	}
-	// The reconcile's stop branch clears the other direction: a loop the
-	// commit stopped (spec made non-durable or ineligible) is gone by now and
-	// correctly gets no notice. The notice recipe keys off the LIVE
-	// instance's operation, not the just-written spec's — set can rewrite
-	// operation while the running loop keeps its old shape, and the relaunch
-	// guidance must match what is actually running.
-	if prior != nil {
-		if after := r.runningLoopByName(spec.Name); after != nil && after.ID() == prior.ID() {
-			result["notice"] = staleRunningLoopNotice(spec.Name, after.Operation())
-		}
+	// The notice keys off the LIVE instance's operation, not the
+	// just-written spec's — set can rewrite operation while the running loop
+	// keeps its old shape, and the relaunch guidance must match what is
+	// actually running.
+	if stale != nil {
+		result["notice"] = staleRunningLoopNotice(spec.Name, stale.Operation())
 	}
 	return ldMarshalToolJSON(result)
 }

--- a/internal/tools/loop_definition_persist.go
+++ b/internal/tools/loop_definition_persist.go
@@ -1,0 +1,84 @@
+package tools
+
+import (
+	"context"
+	"time"
+
+	looppkg "github.com/nugget/thane-ai-agent/internal/runtime/loop"
+)
+
+// setSharedLoopDeps records the two dependencies both loop tool families
+// receive — the definition registry and the durable commit hook — which
+// persistLoopSpec reads from one place. App hands the same objects to
+// each (a.loopDefinitionRegistry and a.commitLoopDefinition).
+//
+// The definition family is authoritative: it owns these tools, so a
+// value it supplies wins. It no longer clears them by passing nil,
+// because a nil registry reaching persistLoopSpec would skip the
+// config-owned guard rather than enforce it.
+func (r *Registry) setSharedLoopDeps(registry *looppkg.DefinitionRegistry, commit func(context.Context, looppkg.Spec, time.Time) error) {
+	if registry != nil {
+		r.loopDefinitionRegistry = registry
+	}
+	if commit != nil {
+		r.commitLoopDefinitionSpec = commit
+	}
+}
+
+// fallbackSharedLoopDeps supplies the same two dependencies only when
+// nothing has yet. The Core front door is registered unconditionally, so
+// a configuration that wires it without the gated definition family must
+// still reach a real registry — otherwise the guard it depends on is
+// silently absent in exactly the configuration that has the fewest other
+// checks.
+func (r *Registry) fallbackSharedLoopDeps(registry *looppkg.DefinitionRegistry, commit func(context.Context, looppkg.Spec, time.Time) error) {
+	if r.loopDefinitionRegistry == nil {
+		r.loopDefinitionRegistry = registry
+	}
+	if r.commitLoopDefinitionSpec == nil {
+		r.commitLoopDefinitionSpec = commit
+	}
+}
+
+// persistLoopSpec is the single path from a validated Spec to a stored
+// loop definition: refuse config-owned names, commit through the durable
+// chokepoint, and report whether a running instance survived the commit
+// still carrying its launched-time config.
+//
+// That last return is the reason this is one function rather than two.
+// A commit's reconcile can SPAWN an absent active definition, so a loop
+// that is live only after the commit is already running the spec just
+// written — only an instance that existed beforehand and kept its ID is
+// stale. Both callers have to say so, in their own vocabulary:
+// loop_definition_set as a notice on the result, the guided create path
+// as the reused loop it returns. Neither is free to get it wrong,
+// because a result that omits it reads as though the new spec were live
+// when the loop is still running the old one.
+//
+// Callers keep their own result shaping and their own additional policy
+// — the guided path's replace flag, its refusal to convert an executing
+// loop into a container — because those are caller rules rather than
+// registry invariants.
+func (r *Registry) persistLoopSpec(ctx context.Context, spec looppkg.Spec) (*looppkg.Loop, error) {
+	snapshot, err := currentLoopDefinitionSnapshot(r)
+	if err != nil {
+		return nil, err
+	}
+	if _, _, err := ensureDefinitionMutable(snapshot, spec.Name); err != nil {
+		return nil, err
+	}
+
+	// Captured before the commit, for the reason in the doc comment.
+	prior := r.runningLoopByName(spec.Name)
+
+	if err := commitSpecThroughChokepoint(ctx, r.commitLoopDefinitionSpec, r.loopDefinitionRegistry, spec, time.Now().UTC()); err != nil {
+		return nil, err
+	}
+	if prior == nil {
+		return nil, nil
+	}
+	if after := r.runningLoopByName(spec.Name); after != nil && after.ID() == prior.ID() {
+		return after, nil
+	}
+	return nil, nil
+}

--- a/internal/tools/loop_definition_tools.go
+++ b/internal/tools/loop_definition_tools.go
@@ -41,9 +41,8 @@ type LoopDefinitionToolDeps struct {
 // ConfigureLoopDefinitionTools stores the runtime dependencies needed by
 // the loop-definition tool family and registers the tools.
 func (r *Registry) ConfigureLoopDefinitionTools(deps LoopDefinitionToolDeps) {
-	r.loopDefinitionRegistry = deps.Registry
+	r.setSharedLoopDeps(deps.Registry, deps.CommitSpec)
 	r.loopDefinitionView = deps.View
-	r.commitLoopDefinitionSpec = deps.CommitSpec
 	r.deletePersistedLoopDefinition = deps.DeleteSpec
 	r.persistLoopDefinitionPolicy = deps.PersistPolicy
 	r.deletePersistedLoopDefinitionPolicy = deps.DeletePolicy

--- a/internal/tools/loop_intent_tools.go
+++ b/internal/tools/loop_intent_tools.go
@@ -64,6 +64,9 @@ func (r *Registry) ConfigureLoopIntentTools(deps LoopIntentToolDeps) {
 		return
 	}
 	r.loopIntentDeps = deps
+
+	r.fallbackSharedLoopDeps(deps.Registry, deps.CommitSpec)
+
 	r.registerThaneLoopCreate()
 }
 


### PR DESCRIPTION
Second step of the collapse from #1287. #1292 unified the config-owned guard; this takes the commit and the stale-instance detection, leaving one path from a validated Spec to a stored definition.

## The stale question is why these belong together

Both doors did the same three things in their own way: refuse config-owned names, commit through the durable chokepoint, and work out whether a running instance survived the commit still carrying its launched-time config.

That third one is the subtle one, and it was computed twice. A commit's reconcile can *spawn* an absent active definition, so a loop that is live only after the commit is already running the spec just written — only an instance that existed beforehand and kept its ID is stale. `loop_definition_set` expressed the answer as a `notice` on its result; the guided path expressed it as a `reused` loop it returned. Same question, two derivations, two vocabularies.

Getting it wrong is not cosmetic: a result that omits it reads as though the new spec were live while the loop is still running the old one. That is #1152 in its most confusing form, and it is exactly the kind of thing that stays correct in both copies right up until it doesn't.

`persistLoopSpec` now answers all three. Callers keep what genuinely differs — their result shape, and their own policy. The guided path's `replace` flag and its refusal to convert an executing loop into a container stay caller-side, because those are caller rules rather than registry invariants.

## Collapsing the read forced the wiring question

Both tool families receive the same registry and the same commit hook — app wires `a.loopDefinitionRegistry` and `a.commitLoopDefinition` into each, unconditionally, in the same function. `persistLoopSpec` reads them from the definition-tool fields, which means a configuration registering only the Core front door would have reached the persist path with a nil registry and **skipped the config-owned guard rather than enforced it**. The test suite surfaced this immediately, which is the argument for having done the guard first.

The resolution keeps the original asymmetry rather than inventing a new one: the definition family is authoritative and its values win; the intent family fills the fields only when nothing has. Neither clears them by passing nil, because the failure mode of a cleared registry is a silently absent guard.

## Test plan

- [x] `just ci` green locally
- [x] **Every existing test passes unmodified** — no test was edited to accommodate the refactor, which is what makes "no behaviour change" checkable rather than asserted
- [x] The stale-notice suites now exercise one implementation from both callers: `TestLoopDefinitionSetNoticeWhenLoopRunning`, `TestLoopDefinitionSetNoNoticeWhenCommitSpawnsTheLoop` (the spawn case that must *not* report stale), and `TestThaneCreateReplaceRunningLoopFlagsStaleConfig` from the guided side
- [x] Full repo suite green
- [x] Wiring asymmetry verified against `new_channels.go`: both families are configured unconditionally with identical dependencies, so production order cannot matter

Refs #1287

🤖 Generated with [Claude Code](https://claude.com/claude-code)
