### PR TITLE
There was no moment when the spec existed but nothing had been written

### DIFF
--- a/internal/tools/loop_create_dryrun_test.go
+++ b/internal/tools/loop_create_dryrun_test.go
@@ -1,0 +1,122 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/nugget/thane-ai-agent/internal/state/documents"
+)
+
+// TestThaneLoopCreateDryRunWritesNothing pins the property the whole
+// mode exists for. A dry run answers "what would you build" — if it
+// scaffolds the document or commits the definition, it has answered by
+// building it, and the caller cannot inspect a derived spec without
+// accepting it.
+func TestThaneLoopCreateDryRunWritesNothing(t *testing.T) {
+	rig := newCurateTestRig(t)
+	ctx := context.Background()
+
+	args := map[string]any{
+		"name":      "dry_run_probe",
+		"intent":    "Watch something and keep a document current.",
+		"operation": "service",
+		"sleep_min": "10m",
+		"sleep_max": "30m",
+		"output": map[string]any{
+			"mode":     "maintain",
+			"document": "kb:dashboards/dry-run-probe.md",
+		},
+		"dry_run": true,
+	}
+	out, err := rig.tool.Handler(ctx, args)
+	if err != nil {
+		t.Fatalf("dry run: %v", err)
+	}
+
+	var result map[string]any
+	if err := json.Unmarshal([]byte(out), &result); err != nil {
+		t.Fatalf("decode result: %v", err)
+	}
+	if result["status"] != "dry_run" {
+		t.Errorf("status = %v, want dry_run", result["status"])
+	}
+	if result["spec"] == nil {
+		t.Fatal("dry run must return the spec it would have committed")
+	}
+	if _, ok := result["loop_id"]; ok {
+		t.Error("dry run reported a loop_id, so something launched")
+	}
+
+	// Nothing committed.
+	if snap := rig.defRegistry.Snapshot(); snap != nil {
+		for _, def := range snap.Definitions {
+			if def.Name == "dry_run_probe" {
+				t.Error("dry run committed a loop definition")
+			}
+		}
+	}
+	// Nothing scaffolded.
+	if _, err := rig.docTools.Read(ctx, documents.RefArgs{Ref: "kb:dashboards/dry-run-probe.md"}); err == nil {
+		t.Error("dry run scaffolded the output document")
+	}
+
+	// The returned spec must be the real thing, not a summary: same shape
+	// loop_definition_set would accept, so a caller can adjust one field
+	// and hand it straight over.
+	specJSON, err := json.Marshal(result["spec"])
+	if err != nil {
+		t.Fatalf("re-marshal spec: %v", err)
+	}
+	var specArg map[string]any
+	if err := json.Unmarshal(specJSON, &specArg); err != nil {
+		t.Fatalf("spec is not an object: %v", err)
+	}
+	decoded, err := decodeLoopSpecArg(map[string]any{"spec": specArg}, "spec")
+	if err != nil {
+		t.Fatalf("dry-run spec does not decode through loop_definition_set's path: %v", err)
+	}
+	if err := decoded.ValidatePersistable(); err != nil {
+		t.Fatalf("dry-run spec does not validate: %v", err)
+	}
+	if decoded.Name != "dry_run_probe" || len(decoded.Outputs) != 1 {
+		t.Errorf("round-tripped spec lost detail: name=%q outputs=%d", decoded.Name, len(decoded.Outputs))
+	}
+	if !strings.HasPrefix(decoded.Outputs[0].ToolName(), "replace_output_") {
+		t.Errorf("output tool = %q, want replace_output_* for maintain mode", decoded.Outputs[0].ToolName())
+	}
+}
+
+// TestThaneLoopCreateDryRunContainer covers the operation most likely to
+// be forgotten. A flag honoured by two of three operations and silently
+// ignored by the third would create the very thing the caller asked to
+// preview.
+func TestThaneLoopCreateDryRunContainer(t *testing.T) {
+	rig := newCurateTestRig(t)
+	ctx := context.Background()
+
+	out, err := rig.tool.Handler(ctx, map[string]any{
+		"name":      "dry_run_container",
+		"intent":    "Group the ranch watchers.",
+		"operation": "container",
+		"dry_run":   true,
+	})
+	if err != nil {
+		t.Fatalf("dry run: %v", err)
+	}
+	var result map[string]any
+	if err := json.Unmarshal([]byte(out), &result); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if result["status"] != "dry_run" || result["spec"] == nil {
+		t.Fatalf("container dry run = %v, want a dry_run status and a spec", result)
+	}
+	if snap := rig.defRegistry.Snapshot(); snap != nil {
+		for _, def := range snap.Definitions {
+			if def.Name == "dry_run_container" {
+				t.Error("container dry run committed a definition")
+			}
+		}
+	}
+}

--- a/internal/tools/loop_create_tool.go
+++ b/internal/tools/loop_create_tool.go
@@ -38,7 +38,7 @@ func (r *Registry) registerThaneLoopCreate() {
 		ContentResolveExempt: []string{
 			"name", "intent", "operation", "parent_name", "output", "entities", "tags",
 			"instructions", "sleep_min", "sleep_max", "sleep_default", "jitter",
-			"quality_floor", "exclude_tools", "metadata", "replace",
+			"quality_floor", "exclude_tools", "metadata", "replace", "dry_run",
 		},
 		Parameters: thaneLoopCreateSchema(),
 		Handler:    r.handleThaneLoopCreate,
@@ -114,6 +114,17 @@ func (r *Registry) createLoopContainer(ctx context.Context, args map[string]any,
 		return "", fmt.Errorf("derived container spec invalid: %w", err)
 	}
 
+	// Containers honour dry_run for the same reason executing loops do, and
+	// because a flag that works for two of three operations and is silently
+	// ignored by the third is worse than one that does not exist.
+	if dryRun, _ := args["dry_run"].(bool); dryRun {
+		return ldMarshalToolJSON(map[string]any{
+			"status":   "dry_run",
+			"spec":     spec,
+			"warnings": looppkg.BuildDefinitionWarnings(spec),
+		})
+	}
+
 	launchResult, reused, err := r.commitAndLaunchLoop(ctx, spec)
 	if err != nil {
 		return "", err
@@ -149,11 +160,37 @@ func (r *Registry) createLoopContainer(ctx context.Context, args map[string]any,
 // createLoopExecuting builds and launches a service or event_driven loop. The
 // service path requires a sleep envelope; the event_driven path rejects one (it
 // has no timer). An output document is optional for both.
-func (r *Registry) createLoopExecuting(ctx context.Context, args map[string]any, name, intent string, op looppkg.Operation) (string, error) {
+// executingLoopPlan is everything createLoopExecuting derives from its
+// arguments before anything is written: the spec it would persist, plus
+// the scaffolding and reporting details the spec itself does not carry.
+//
+// Separating derivation from writes is what lets dry_run answer "what
+// would you build" without creating a document or a definition, and it
+// is what makes the inference this tool is growing testable without a
+// registry standing behind it.
+type executingLoopPlan struct {
+	spec     looppkg.Spec
+	warnings []looppkg.DefinitionWarning
+
+	replace     bool
+	hasOutput   bool
+	documentRef string
+	outputMode  string
+	title       string
+	outputTool  string
+	entityCount int
+	envelope    sleepEnvelope
+	createdAt   time.Time
+}
+
+// planExecutingLoop derives the plan without writing anything. It reads
+// registry state — whether this name is taken, whether the named parent
+// exists — because those decide whether a plan is possible at all.
+func (r *Registry) planExecutingLoop(args map[string]any, name, intent string, op looppkg.Operation) (*executingLoopPlan, error) {
 	deps := r.loopIntentDeps
 	if op == looppkg.OperationEventDriven {
 		if err := rejectArgsForOperation(args, op, "sleep_min", "sleep_max", "sleep_default", "jitter"); err != nil {
-			return "", err
+			return nil, err
 		}
 	}
 
@@ -164,15 +201,15 @@ func (r *Registry) createLoopExecuting(ctx context.Context, args map[string]any,
 
 	qualityFloor, err := parseLoopCreateQualityFloor(args)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	metadata, err := parseLoopCreateMetadata(args)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	entities, err := parseEntityList("entities", args["entities"])
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	excludeTools := loopCreateExcludeTools(args)
 
@@ -180,7 +217,7 @@ func (r *Registry) createLoopExecuting(ctx context.Context, args map[string]any,
 	if op == looppkg.OperationService {
 		envelope, err = parseSleepEnvelope(args)
 		if err != nil {
-			return "", err
+			return nil, err
 		}
 	}
 
@@ -200,29 +237,29 @@ func (r *Registry) createLoopExecuting(ctx context.Context, args map[string]any,
 		outputMode, _ = raw["mode"].(string)
 		documentRef, _ = raw["document"].(string)
 		if outputMode != "journal" && outputMode != "maintain" {
-			return "", fmt.Errorf("output.mode must be \"journal\" or \"maintain\"")
+			return nil, fmt.Errorf("output.mode must be \"journal\" or \"maintain\"")
 		}
 		if strings.TrimSpace(documentRef) == "" {
-			return "", fmt.Errorf("output.document is required when output is set (e.g. \"kb:dashboards/foo.md\")")
+			return nil, fmt.Errorf("output.document is required when output is set (e.g. \"kb:dashboards/foo.md\")")
 		}
 		title, _ = raw["title"].(string)
 		if strings.TrimSpace(title) == "" {
 			title = name
 		}
 		if deps.DocTools == nil {
-			return "", fmt.Errorf("output document requested but the document store is not configured")
+			return nil, fmt.Errorf("output document requested but the document store is not configured")
 		}
 		outputSpec = buildCurateOutputSpec(name, documentRef, outputMode, intent)
 		outputs = []looppkg.OutputSpec{outputSpec}
 	}
 
 	if _, found, err := ensureDefinitionMutable(deps.Registry.Snapshot(), name); err != nil {
-		return "", err
+		return nil, err
 	} else if found && !replace {
-		return "", fmt.Errorf("loop definition %q already exists; pass replace=true to overwrite", name)
+		return nil, fmt.Errorf("loop definition %q already exists; pass replace=true to overwrite", name)
 	}
 	if err := r.resolveLoopParent(parentName); err != nil {
-		return "", err
+		return nil, err
 	}
 
 	task := intent
@@ -257,9 +294,48 @@ func (r *Registry) createLoopExecuting(ctx context.Context, args map[string]any,
 		spec.Jitter = &jitter
 	}
 	if err := spec.ValidatePersistable(); err != nil {
-		return "", fmt.Errorf("derived spec invalid: %w", err)
+		return nil, fmt.Errorf("derived spec invalid: %w", err)
 	}
 	warnings := looppkg.BuildDefinitionWarnings(spec)
+
+	return &executingLoopPlan{
+		spec:        spec,
+		warnings:    warnings,
+		replace:     replace,
+		hasOutput:   hasOutput,
+		documentRef: documentRef,
+		outputMode:  outputMode,
+		title:       title,
+		outputTool:  outputSpec.ToolName(),
+		entityCount: len(entities),
+		envelope:    envelope,
+		createdAt:   now,
+	}, nil
+}
+
+func (r *Registry) createLoopExecuting(ctx context.Context, args map[string]any, name, intent string, op looppkg.Operation) (string, error) {
+	deps := r.loopIntentDeps
+	plan, err := r.planExecutingLoop(args, name, intent, op)
+	if err != nil {
+		return "", err
+	}
+	spec := plan.spec
+
+	// dry_run stops here, before the document is scaffolded and before
+	// anything is committed: the answer to "what would you build" must not
+	// build it.
+	if dryRun, _ := args["dry_run"].(bool); dryRun {
+		return ldMarshalToolJSON(map[string]any{
+			"status":   "dry_run",
+			"spec":     spec,
+			"warnings": plan.warnings,
+		})
+	}
+
+	hasOutput, documentRef, outputMode, title := plan.hasOutput, plan.documentRef, plan.outputMode, plan.title
+	replace, warnings, envelope, now := plan.replace, plan.warnings, plan.envelope, plan.createdAt
+	entityCount, outputTool := plan.entityCount, plan.outputTool
+	parentName, tags := spec.ParentName, spec.Tags
 
 	if hasOutput {
 		if _, readErr := deps.DocTools.Read(ctx, documents.RefArgs{Ref: documentRef}); readErr == nil && !replace {
@@ -297,7 +373,7 @@ func (r *Registry) createLoopExecuting(ctx context.Context, args map[string]any,
 		"loop_id":              launchResult.LoopID,
 		"operation":            string(op),
 		"parent_name":          parentName,
-		"entity_subscriptions": len(entities),
+		"entity_subscriptions": entityCount,
 		"warnings":             warnings,
 	}
 	if reused != nil {
@@ -307,7 +383,7 @@ func (r *Registry) createLoopExecuting(ctx context.Context, args map[string]any,
 	if hasOutput {
 		result["document_path"] = documentRef
 		result["output_mode"] = outputMode
-		result["output_tool"] = outputSpec.ToolName()
+		result["output_tool"] = outputTool
 	}
 	if op == looppkg.OperationService {
 		result["sleep_envelope"] = map[string]any{
@@ -589,6 +665,10 @@ func thaneLoopCreateSchema() map[string]any {
 				"type":                 "object",
 				"additionalProperties": map[string]any{"type": "string"},
 				"description":          "Optional opaque string-keyed metadata stored on the loop definition (service/event_driven).",
+			},
+			"dry_run": map[string]any{
+				"type":        "boolean",
+				"description": "Return the loop spec this call would create, without creating anything: no document is scaffolded, no definition is committed, nothing launches. Use it to inspect or adjust the derived spec before committing, or to hand the spec to loop_definition_set yourself when you want to change a field this tool does not expose.",
 			},
 			"replace": map[string]any{
 				"type":        "boolean",


### PR DESCRIPTION
Third step from #1287. The guided path now has a point at which it has produced a loop spec and not yet committed anything — which is the seam everything else in this arc needs.

## Why the seam did not exist

`createLoopExecuting` was one 170-line function that parsed arguments, resolved the parent, checked the name, built the spec, scaffolded the document, committed, launched, and shaped the result. Deriving and writing were the same act. There was nowhere to stand between them, so there was no way to ask what the tool would build without letting it build.

`planExecutingLoop` is that point. It does everything up to and including the spec and its warnings, and writes nothing. `createLoopExecuting` is now plan-then-write.

## dry_run

Returns the spec. No document scaffolded, no definition committed, nothing launched — the answer to "what would you build" must not build it, and the test asserts each of those absences rather than trusting the structure.

Containers honour the flag as well. A flag respected by two of three operations and silently ignored by the third would create precisely the thing the caller asked to preview, which is the failure mode this whole arc keeps finding.

## The returned spec is currency, not a summary

This is the part worth checking rather than asserting, so the test does: it takes the spec out of the dry-run result, marshals it back, and runs it through `decodeLoopSpecArg` — the same decoder `loop_definition_set` uses — then validates it and confirms the output tool name survived.

That makes the two doors compose instead of compete. A caller that disagrees with one derived field can adjust it and hand the whole spec to `loop_definition_set`, rather than abandoning the guided path and authoring a spec from scratch to change one value. It is the first concrete instance of the currency framing from #1287 actually holding.

## What it unlocks

Inference is the next step, and inference is only reviewable if it can be tested. With this seam, "these arguments produce this spec" is a table test with no registry behind it — which is the difference between container placement and document-root selection being *reviewable* and being observable only in production, where a wrong root means commit spam in a signed history.

## Test plan

- [x] `just ci` green locally
- [x] Dry run returns `status: dry_run` and a spec, and reports no `loop_id`
- [x] Nothing committed: the definition registry has no such name afterwards
- [x] Nothing scaffolded: the output document does not exist afterwards
- [x] The returned spec round-trips through `decodeLoopSpecArg` and `ValidatePersistable`, keeps its name and outputs, and yields the expected `replace_output_*` tool
- [x] Container dry run covered separately, since that is the path most likely to be forgotten
- [x] Every pre-existing test passes unmodified — the extraction is behaviour-preserving on the write path

Refs #1287

🤖 Generated with [Claude Code](https://claude.com/claude-code)
