### PR TITLE
A spec field the model is never told about fails nothing

### DIFF
--- a/internal/tools/loop_create_fluency_test.go
+++ b/internal/tools/loop_create_fluency_test.go
@@ -89,9 +89,10 @@ func TestGuidedCreateProducesTieredOutput(t *testing.T) {
 // shape. Notes are internal by construction, which is what keeps a
 // loop's reasoning out of what it publishes.
 func TestGuidedCreateWorkingNotes(t *testing.T) {
+	// No opt-in argument: the notes surface is unconditional, and passing a
+	// key the schema does not define would imply a flag that does not exist.
 	spec, result := dryRunSpec(t, curateArgs(map[string]any{
-		"tiers":         []any{"status_line"},
-		"working_notes": true,
+		"tiers": []any{"status_line"},
 	}))
 
 	if len(spec.Outputs) != 2 {

--- a/internal/tools/loop_spec_schema_parity_test.go
+++ b/internal/tools/loop_spec_schema_parity_test.go
@@ -9,19 +9,59 @@ import (
 	looppkg "github.com/nugget/thane-ai-agent/internal/runtime/loop"
 )
 
-// jsonFieldNames returns the wire names of a struct's exported fields,
-// skipping those the encoder omits.
+// jsonFieldNames returns the wire names encoding/json would use for a
+// struct's exported fields.
+//
+// Only `json:"-"` is omitted. An exported field with no json tag, or one
+// carrying only options like `json:",omitempty"`, is still encoded —
+// under its Go name — so treating those as absent would let exactly the
+// kind of field this gate exists to catch slip through it.
 func jsonFieldNames(t reflect.Type) []string {
 	out := make([]string, 0, t.NumField())
 	for i := 0; i < t.NumField(); i++ {
-		name, _, _ := strings.Cut(t.Field(i).Tag.Get("json"), ",")
-		if name == "" || name == "-" {
+		field := t.Field(i)
+		if !field.IsExported() {
 			continue
+		}
+		tag := field.Tag.Get("json")
+		if tag == "-" {
+			continue
+		}
+		name, _, _ := strings.Cut(tag, ",")
+		if name == "" {
+			name = field.Name
 		}
 		out = append(out, name)
 	}
 	sort.Strings(out)
 	return out
+}
+
+// TestJSONFieldNamesMatchesEncoder pins the helper against the encoder
+// it stands in for. The gate is only as good as its idea of which fields
+// are on the wire: a field carrying no json tag is still encoded, under
+// its Go name, and reading that as "absent" would let the gate skip
+// precisely the field it exists to catch.
+func TestJSONFieldNamesMatchesEncoder(t *testing.T) {
+	type sample struct {
+		Tagged   string `json:"tagged"`
+		OnlyOpts string `json:",omitempty"`
+		NoTag    string
+		Excluded string `json:"-"`
+		//nolint:unused // presence is the point: unexported fields are not encoded
+		unexported string
+	}
+
+	got := jsonFieldNames(reflect.TypeOf(sample{}))
+	want := []string{"NoTag", "OnlyOpts", "tagged"}
+	if len(got) != len(want) {
+		t.Fatalf("jsonFieldNames = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("jsonFieldNames = %v, want %v", got, want)
+		}
+	}
 }
 
 // TestLoopSpecSchemaCoversEveryField is the gate the loop spec did not

--- a/internal/tools/loop_spec_schema_parity_test.go
+++ b/internal/tools/loop_spec_schema_parity_test.go
@@ -1,0 +1,112 @@
+package tools
+
+import (
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+
+	looppkg "github.com/nugget/thane-ai-agent/internal/runtime/loop"
+)
+
+// jsonFieldNames returns the wire names of a struct's exported fields,
+// skipping those the encoder omits.
+func jsonFieldNames(t reflect.Type) []string {
+	out := make([]string, 0, t.NumField())
+	for i := 0; i < t.NumField(); i++ {
+		name, _, _ := strings.Cut(t.Field(i).Tag.Get("json"), ",")
+		if name == "" || name == "-" {
+			continue
+		}
+		out = append(out, name)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// TestLoopSpecSchemaCoversEveryField is the gate the loop spec did not
+// have. loopSpecSchema is hand-authored and Spec is not, so a field can
+// reach the struct, decode correctly, and never be mentioned to the
+// model — which is invisible rather than broken, and therefore does not
+// fail anything.
+//
+// This is the same failure shape as a native tool that is registered but
+// absent from the tool catalog, which TestNativeToolLiteralsAreCatalogued
+// already guards, and the same shape as thane_loop_create silently
+// dropping a tiers array it had no property for.
+//
+// The direction that matters is struct → schema. The reverse is checked
+// separately and more loosely, because the schema legitimately documents
+// keys the decoder accepts for backward compatibility.
+func TestLoopSpecSchemaCoversEveryField(t *testing.T) {
+	props := schemaProperties(t, loopSpecSchema("parity"))
+
+	for _, field := range jsonFieldNames(reflect.TypeOf(looppkg.Spec{})) {
+		if reason, deliberate := specFieldsNotOffered[field]; deliberate {
+			if reason == "" {
+				t.Errorf("Spec field %q is excluded with no reason recorded", field)
+			}
+			continue
+		}
+		if _, ok := props[field]; !ok {
+			t.Errorf("Spec field %q has no property in loopSpecSchema — it decodes but the model is never told it exists. Add a property, or record it in specFieldsNotOffered with the reason it is not the model's to set", field)
+		}
+	}
+}
+
+// specFieldsNotOffered records the Spec fields deliberately absent from
+// the model-facing schema, and why. The point of the map is that adding
+// a field to Spec now forces the choice to be made and written down,
+// rather than the field being invisible by default.
+var specFieldsNotOffered = map[string]string{
+	"parent_id": "runtime-only: set at launch, and live loop IDs change per launch, so the durable parent reference is parent_name",
+	"origin":    "provenance the system stamps, not authorship the model claims",
+
+	"delegation_gating": "the spec-level door is profile.delegation_gating, which the schema does offer; this top-level field is the runtime variant",
+	"routing_factors":   "request-routing internals; the authoring surface for routing is profile",
+
+	// Narrow but arguably authorable: an interactive loop can set it to
+	// guarantee a reply. Excluded because it only applies to
+	// request_reply runs, which neither guided door creates — thane_now
+	// owns that shape. Raised on #1287 rather than widened unilaterally.
+	"fallback_content": "applies only to request_reply runs, which the loop-authoring doors do not create",
+}
+
+// TestLoopOutputSpecSchemaCoversEveryField guards the nested declaration
+// where the gap actually bit: output.tiers reached OutputSpec before the
+// guided tool had anywhere to put it.
+func TestLoopOutputSpecSchemaCoversEveryField(t *testing.T) {
+	props := schemaProperties(t, loopSpecSchema("parity"))
+	outputs, ok := props["outputs"].(map[string]any)
+	if !ok {
+		t.Fatal("loopSpecSchema has no outputs property")
+	}
+	items, ok := outputs["items"].(map[string]any)
+	if !ok {
+		t.Fatal("outputs has no items schema")
+	}
+	itemProps := schemaProperties(t, items)
+
+	for _, field := range jsonFieldNames(reflect.TypeOf(looppkg.OutputSpec{})) {
+		if _, ok := itemProps[field]; !ok {
+			t.Errorf("OutputSpec field %q has no property in the outputs item schema — a loop can declare it and no model will know to", field)
+		}
+	}
+}
+
+// TestSpecFieldsNotOfferedStayReal keeps the allowlist from outliving
+// the fields it excuses. An entry for a field that no longer exists is
+// worse than none: it reads as a considered decision about something
+// that is not there, and it would silently excuse a future field that
+// happened to take the same name.
+func TestSpecFieldsNotOfferedStayReal(t *testing.T) {
+	actual := make(map[string]bool)
+	for _, f := range jsonFieldNames(reflect.TypeOf(looppkg.Spec{})) {
+		actual[f] = true
+	}
+	for field := range specFieldsNotOffered {
+		if !actual[field] {
+			t.Errorf("specFieldsNotOffered lists %q, which is no longer a Spec field", field)
+		}
+	}
+}


### PR DESCRIPTION
`loopSpecSchema` is hand-authored; `Spec` is not. So a field can reach the struct, decode correctly, and never be mentioned to the model — invisible rather than broken, and therefore failing nothing.

That is the same failure shape as a native tool registered but missing from the catalog, which `TestNativeToolLiteralsAreCatalogued` already guards. It is also the same shape, one level up, as `thane_loop_create` silently dropping a `tiers` array it had no property for.

The pattern was already in this repo, applied to the smaller type: `sharedLoopLaunchSchemaKeys` reflects over `Launch`'s json tags and `schemaProperties` sits right beside it. `Spec` and `OutputSpec` — the types that matter, and the ones growing fields as #1287 proceeds — had no equivalent.

## What it found

Five uncovered fields, and the interesting part is that four of them are correct:

| field | why it is withheld |
|---|---|
| `parent_id` | Set at launch, and live loop IDs change per launch — the durable reference is `parent_name` |
| `origin` | Provenance the system stamps, not authorship the model claims |
| `delegation_gating` | The spec-level door is `profile.delegation_gating`, which the schema does offer |
| `routing_factors` | Request-routing internals; `profile` is the authoring surface |

Rather than assert those away, they are recorded in `specFieldsNotOffered` **with the reason each is not the model's to set**. That inverts the default: adding a field to `Spec` now forces the choice and writes it down, instead of the field being invisible unless someone remembers to widen the schema.

## The fifth is a question for you

`fallback_content` — *"static text used when the loop completes a request/reply run without any user-visible content. Interactive loops can set this to guarantee a reply."*

That reads as genuinely authorable. It is excluded here because it only applies to `request_reply` runs, which neither loop-authoring door creates — `thane_now` owns that shape. But if a model authoring a `request_reply` spec through `loop_definition_set` should be able to guarantee a reply, the honest answer is a schema property rather than an allowlist entry. Raised rather than widened unilaterally, since it is prompt weight on a niche field.

## On generating the schema instead

Worth noting for the larger question: `gencfg` already does this for config — it extracts struct field doc comments via `go/ast`, joins them with `ExampleConfig` values, and emits a reference "that cannot drift from the code", gated by `config-generate-check`. So generation is demonstrably feasible here.

The catch is that schema descriptions and Go doc comments serve different readers. Godoc's `Tiers` comment explains that declaration order carries no meaning and why; the schema's explains when to declare tiers, what it swaps the generated tool to, and what it buys a consumer. Merging them would give both readers a paragraph half of which is not for them, on a surface where prompt space is not free.

So the tractable shape is generate the *structure* and hand-author the *prose*, with a gate on the join — which is what this PR is, minus the generation. That also happens to be an open decision on #1060 for the OpenAPI spec; same question, two surfaces, worth deciding once.

## Test plan

- [x] `just ci` green locally
- [x] Every `Spec` json field is either in the schema or recorded as deliberately withheld with a reason
- [x] Every `OutputSpec` json field is in the outputs item schema — this passes today, and is the nested declaration where the gap actually bit
- [x] An allowlist entry naming a field that no longer exists fails, so the list cannot outlive what it excuses or silently excuse a future field that reuses the name
- [x] An allowlist entry with an empty reason fails

Refs #1287

🤖 Generated with [Claude Code](https://claude.com/claude-code)
