### PR TITLE
The feature was available, its use case arrived, and both callers reached past it

### DIFF
--- a/examples/config.example.yaml
+++ b/examples/config.example.yaml
@@ -1326,7 +1326,6 @@ archivist:
 #       on_retrigger: 0
 #       routing_factors: {}
 #       delegation_gating: ""
-#       fallback_content: ""
 #       metadata:
 #         category: observer
 #       parent_id: ""

--- a/internal/runtime/loop/definition_warnings.go
+++ b/internal/runtime/loop/definition_warnings.go
@@ -110,7 +110,7 @@ var shadowableSpecFields = map[string]struct{}{
 	"sleep_default": {}, "jitter": {}, "max_duration": {}, "max_iter": {},
 	"supervisor": {}, "supervisor_prob": {}, "supervisor_profile": {},
 	"on_retrigger": {}, "routing_factors": {}, "delegation_gating": {},
-	"fallback_content": {}, "parent_name": {}, "parent_id": {},
+	"parent_name": {}, "parent_id": {},
 }
 
 // metadataShadowWarnings flags metadata keys that collide with a real

--- a/internal/runtime/loop/definition_warnings_test.go
+++ b/internal/runtime/loop/definition_warnings_test.go
@@ -1,6 +1,7 @@
 package loop
 
 import (
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -153,4 +154,41 @@ func TestBuildDefinitionWarnings_MetadataShadowDeterministicOrder(t *testing.T) 
 	if !strings.Contains(order[0], "parent_name") || !strings.Contains(order[1], "tags") {
 		t.Errorf("shadow warnings not deterministically sorted: %#v", order)
 	}
+}
+
+// TestShadowableSpecFieldsMatchWireTags keeps the shadow list from
+// drifting off the wire shape it describes.
+//
+// shadowableSpecFields is hand-maintained and specJSON is not, so the
+// two fall out of step in both directions and neither fails. A name left
+// behind after a field is removed warns that a metadata key shadows
+// something that no longer exists; a name never added lets a real
+// collision go unreported. Removing Spec.FallbackContent produced the
+// first of those, which is what prompted this.
+func TestShadowableSpecFieldsMatchWireTags(t *testing.T) {
+	wire := make(map[string]bool)
+	typ := reflect.TypeOf(specJSON{})
+	for i := 0; i < typ.NumField(); i++ {
+		field := typ.Field(i)
+		if !field.IsExported() {
+			continue
+		}
+		tag := field.Tag.Get("json")
+		if tag == "-" {
+			continue
+		}
+		name, _, _ := strings.Cut(tag, ",")
+		if name == "" {
+			name = field.Name
+		}
+		wire[name] = true
+	}
+
+	for name := range shadowableSpecFields {
+		if !wire[name] {
+			t.Errorf("shadowableSpecFields lists %q, which is not a specJSON field — a metadata key by that name would be warned about for shadowing something that does not exist", name)
+		}
+	}
+	// The reverse is not asserted: specJSON carries legacy compat keys
+	// that are deliberately outside the shadow set.
 }

--- a/internal/runtime/loop/launch.go
+++ b/internal/runtime/loop/launch.go
@@ -37,7 +37,6 @@ type Launch struct {
 	SkipContext       bool                     `yaml:"skip_context,omitempty" json:"skip_context,omitempty"`
 	SkipTagFilter     bool                     `yaml:"skip_tag_filter,omitempty" json:"skip_tag_filter,omitempty"`
 	SystemPrompt      string                   `yaml:"system_prompt,omitempty" json:"system_prompt,omitempty"`
-	FallbackContent   string                   `yaml:"fallback_content,omitempty" json:"fallback_content,omitempty"`
 	PromptMode        agentctx.PromptMode      `yaml:"prompt_mode,omitempty" json:"prompt_mode,omitempty"`
 	MaxIterations     int                      `yaml:"max_iterations,omitempty" json:"max_iterations,omitempty"`
 	MaxOutputTokens   int                      `yaml:"max_output_tokens,omitempty" json:"max_output_tokens,omitempty"`
@@ -71,7 +70,6 @@ type launchJSON struct {
 	SkipContext              bool                     `json:"skip_context,omitempty"`
 	SkipTagFilter            bool                     `json:"skip_tag_filter,omitempty"`
 	SystemPrompt             string                   `json:"system_prompt,omitempty"`
-	FallbackContent          string                   `json:"fallback_content,omitempty"`
 	PromptMode               agentctx.PromptMode      `json:"prompt_mode,omitempty"`
 	MaxIterations            int                      `json:"max_iterations,omitempty"`
 	MaxOutputTokens          int                      `json:"max_output_tokens,omitempty"`
@@ -99,7 +97,6 @@ func (l Launch) MarshalJSON() ([]byte, error) {
 		SkipContext:              l.SkipContext,
 		SkipTagFilter:            l.SkipTagFilter,
 		SystemPrompt:             l.SystemPrompt,
-		FallbackContent:          l.FallbackContent,
 		PromptMode:               l.PromptMode,
 		MaxIterations:            l.MaxIterations,
 		MaxOutputTokens:          l.MaxOutputTokens,
@@ -144,7 +141,6 @@ func (l *Launch) UnmarshalJSON(data []byte) error {
 		SkipContext:              wire.SkipContext,
 		SkipTagFilter:            wire.SkipTagFilter,
 		SystemPrompt:             wire.SystemPrompt,
-		FallbackContent:          wire.FallbackContent,
 		PromptMode:               wire.PromptMode,
 		MaxIterations:            wire.MaxIterations,
 		MaxOutputTokens:          wire.MaxOutputTokens,
@@ -182,7 +178,6 @@ func (l *Launch) HasOverrides() bool {
 		l.ParentID != "" ||
 		l.ConversationID != "" ||
 		l.SystemPrompt != "" ||
-		l.FallbackContent != "" ||
 		l.CompletionConversationID != "" ||
 		l.UsageRole != "" ||
 		l.UsageTaskName != "" ||
@@ -251,7 +246,6 @@ func (l *Launch) requestOverride() Request {
 		RoutingFactors:        cloneStringMap(l.RoutingFactors),
 		InitialTags:           append([]string(nil), l.InitialTags...),
 		OnProgress:            l.OnProgress,
-		FallbackContent:       l.FallbackContent,
 		MaxIterations:         l.MaxIterations,
 		MaxOutputTokens:       l.MaxOutputTokens,
 		ToolTimeout:           l.ToolTimeout,

--- a/internal/runtime/loop/launch_json_test.go
+++ b/internal/runtime/loop/launch_json_test.go
@@ -16,12 +16,11 @@ func TestLaunchMarshalJSONUsesDurationStrings(t *testing.T) {
 	t.Parallel()
 
 	data, err := json.Marshal(Launch{
-		Task:            "test launch",
-		RunTimeout:      2 * time.Minute,
-		ToolTimeout:     45 * time.Second,
-		AllowedTools:    []string{"ha_get_state"},
-		FallbackContent: "please try again",
-		PromptMode:      agentctx.PromptModeTask,
+		Task:         "test launch",
+		RunTimeout:   2 * time.Minute,
+		ToolTimeout:  45 * time.Second,
+		AllowedTools: []string{"ha_get_state"},
+		PromptMode:   agentctx.PromptModeTask,
 	})
 	if err != nil {
 		t.Fatalf("MarshalJSON: %v", err)
@@ -32,9 +31,6 @@ func TestLaunchMarshalJSONUsesDurationStrings(t *testing.T) {
 	}
 	if !strings.Contains(body, `"tool_timeout":"45s"`) {
 		t.Fatalf("marshal output missing string tool_timeout: %s", body)
-	}
-	if !strings.Contains(body, `"fallback_content":"please try again"`) {
-		t.Fatalf("marshal output missing fallback_content: %s", body)
 	}
 	if !strings.Contains(body, `"prompt_mode":"task"`) {
 		t.Fatalf("marshal output missing prompt_mode: %s", body)
@@ -63,9 +59,6 @@ func TestLaunchUnmarshalJSONParsesDurationStrings(t *testing.T) {
 	}
 	if launch.CompletionChannel == nil || launch.CompletionChannel.Channel != "owu" || launch.CompletionChannel.ConversationID != "conv-1" {
 		t.Fatalf("CompletionChannel = %#v", launch.CompletionChannel)
-	}
-	if launch.FallbackContent != "please try again" {
-		t.Fatalf("FallbackContent = %q, want %q", launch.FallbackContent, "please try again")
 	}
 	if launch.PromptMode != agentctx.PromptModeTask {
 		t.Fatalf("PromptMode = %q, want task", launch.PromptMode)
@@ -142,7 +135,6 @@ func TestLaunchHasOverrides(t *testing.T) {
 		{"conversation_id", func(l *Launch) { l.ConversationID = "c" }, "ConversationID"},
 		{"parent_id", func(l *Launch) { l.ParentID = "p" }, "ParentID"},
 		{"system_prompt", func(l *Launch) { l.SystemPrompt = "s" }, "SystemPrompt"},
-		{"fallback_content", func(l *Launch) { l.FallbackContent = "f" }, "FallbackContent"},
 		{"skip_context", func(l *Launch) { l.SkipContext = true }, "SkipContext"},
 		{"skip_tag_filter", func(l *Launch) { l.SkipTagFilter = true }, "SkipTagFilter"},
 		{"suppress_always_context", func(l *Launch) { l.SuppressAlwaysContext = true }, "SuppressAlwaysContext"},

--- a/internal/runtime/loop/loop.go
+++ b/internal/runtime/loop/loop.go
@@ -847,7 +847,7 @@ func (l *Loop) SetSubscriptions(subs []EntitySubscription) {
 // Beyond the structural fields, a handful of plain-data config scalars
 // are also deliberately NOT promoted because they sit outside the
 // retune tier: top-level exclude_tools, routing_factors,
-// delegation_gating, fallback_content, on_retrigger, intent (spec-level
+// delegation_gating, on_retrigger, intent (spec-level
 // fields owned by the full-replace path), and max_duration (compiled
 // into the run context's deadline at start). MaxIter IS promoted and
 // counts this instance's lifetime attempts: retuning it at or below the

--- a/internal/runtime/loop/spec.go
+++ b/internal/runtime/loop/spec.go
@@ -272,11 +272,6 @@ type Spec struct {
 	// Profile.DelegationGating for spec-level configuration.
 	DelegationGating string `yaml:"delegation_gating,omitempty" json:"delegation_gating,omitempty"`
 
-	// FallbackContent is static text used when the loop completes a
-	// request/reply run without any user-visible content. Interactive
-	// loops can set this to guarantee a reply.
-	FallbackContent string `yaml:"fallback_content,omitempty" json:"fallback_content,omitempty"`
-
 	// Setup is called by the registry spawn helpers after [New] or
 	// [NewFromSpec] but before [Loop.Start].
 	Setup func(l *Loop) `yaml:"-" json:"-"`
@@ -525,7 +520,6 @@ func (s *Spec) ToConfig() Config {
 		Handler:              ns.Handler,
 		RoutingFactors:       cloneStringMap(ns.RoutingFactors),
 		DelegationGating:     ns.DelegationGating,
-		FallbackContent:      ns.FallbackContent,
 		Setup:                ns.Setup,
 		RuntimeTools:         cloneRuntimeTools(ns.RuntimeTools),
 		OutputContextBuilder: ns.OutputContextBuilder,

--- a/internal/runtime/loop/spec_json.go
+++ b/internal/runtime/loop/spec_json.go
@@ -41,7 +41,6 @@ type specJSON struct {
 	OnRetrigger       string              `json:"on_retrigger,omitempty"`
 	RoutingFactors    map[string]string   `json:"routing_factors,omitempty"`
 	DelegationGating  string              `json:"delegation_gating,omitempty"`
-	FallbackContent   string              `json:"fallback_content,omitempty"`
 	Metadata          map[string]string   `json:"metadata,omitempty"`
 	ParentID          string              `json:"parent_id,omitempty"`
 	ParentName        string              `json:"parent_name,omitempty"`
@@ -90,7 +89,6 @@ func (s Spec) MarshalJSON() ([]byte, error) {
 		SupervisorProfile: s.SupervisorProfile,
 		RoutingFactors:    s.RoutingFactors,
 		DelegationGating:  s.DelegationGating,
-		FallbackContent:   s.FallbackContent,
 		Metadata:          s.Metadata,
 		ParentID:          s.ParentID,
 		ParentName:        s.ParentName,
@@ -171,7 +169,6 @@ func (s *Spec) UnmarshalJSON(data []byte) error {
 		OnRetrigger:      onRetrigger,
 		RoutingFactors:   cloneStringMap(wire.RoutingFactors),
 		DelegationGating: wire.DelegationGating,
-		FallbackContent:  wire.FallbackContent,
 		Metadata:         cloneStringMap(wire.Metadata),
 		ParentID:         wire.ParentID,
 		ParentName:       wire.ParentName,

--- a/internal/runtime/loop/spec_test.go
+++ b/internal/runtime/loop/spec_test.go
@@ -118,12 +118,11 @@ func TestSpecValidate(t *testing.T) {
 func TestSpecToConfigCopiesMutableFields(t *testing.T) {
 	jitter := 0.4
 	spec := &Spec{
-		Name:            "copy-test",
-		Task:            "Watch the room.",
-		Tags:            []string{"monitoring"},
-		ExcludeTools:    []string{"shell_exec"},
-		Jitter:          &jitter,
-		FallbackContent: "please try again",
+		Name:         "copy-test",
+		Task:         "Watch the room.",
+		Tags:         []string{"monitoring"},
+		ExcludeTools: []string{"shell_exec"},
+		Jitter:       &jitter,
 		RoutingFactors: map[string]string{
 			"source": "loop",
 		},
@@ -153,9 +152,6 @@ func TestSpecToConfigCopiesMutableFields(t *testing.T) {
 	}
 	if *spec.Jitter != 0.4 {
 		t.Fatalf("spec.Jitter mutated = %v", *spec.Jitter)
-	}
-	if cfg.FallbackContent != "please try again" {
-		t.Fatalf("cfg.FallbackContent = %q, want %q", cfg.FallbackContent, "please try again")
 	}
 }
 

--- a/internal/tools/loop_definition_tool_helpers.go
+++ b/internal/tools/loop_definition_tool_helpers.go
@@ -298,10 +298,6 @@ func loopLaunchOverrideProperties() map[string]any {
 			"additionalProperties": map[string]any{"type": "string"},
 			"description":          "Opaque string/string tags attached to the launched loop for correlation or audit. NOT used for routing, tools, budgets, or any runtime behavior. To pin a model, set spec.profile.model on the stored definition (or in the spec passed to spawn_loop). To override tools use \"allowed_tools\" / \"exclude_tools\". To override budgets use \"max_iterations\" / \"max_output_tokens\".",
 		},
-		"fallback_content": map[string]any{
-			"type":        "string",
-			"description": "Static fallback reply used if the nested agent run produces no content but the launch still needs a last-resort response.",
-		},
 		"tool_timeout": map[string]any{
 			"type":        "string",
 			"description": "Per-tool-call timeout for nested agent tool executions inside this loop. Use a Go duration string like \"30s\" or \"2m\".",

--- a/internal/tools/loop_spec_schema_parity_test.go
+++ b/internal/tools/loop_spec_schema_parity_test.go
@@ -104,12 +104,6 @@ var specFieldsNotOffered = map[string]string{
 
 	"delegation_gating": "the spec-level door is profile.delegation_gating, which the schema does offer; this top-level field is the runtime variant",
 	"routing_factors":   "request-routing internals; the authoring surface for routing is profile",
-
-	// Narrow but arguably authorable: an interactive loop can set it to
-	// guarantee a reply. Excluded because it only applies to
-	// request_reply runs, which neither guided door creates — thane_now
-	// owns that shape. Raised on #1287 rather than widened unilaterally.
-	"fallback_content": "applies only to request_reply runs, which the loop-authoring doors do not create",
 }
 
 // TestLoopOutputSpecSchemaCoversEveryField guards the nested declaration


### PR DESCRIPTION
Research from #1296, where `fallback_content` was the one uncovered `Spec` field that looked authorable rather than system-owned.

**Stacked on #1296** — it removes that PR's allowlist entry along with the field, and the staleness guard added there is what caught the entry going dead.

## Origin: extracted, not designed

`FallbackContent` arrived in `07970f0f`, the commit that created `internal/iterate` by consolidating duplicated iteration logic out of `agent/loop.go` and `delegate/delegate.go` — about 550 lines of it. It became a config knob because the two call sites being unified each carried their own fallback text, not because a per-loop setting was wanted. Refactor residue that reached the persisted spec.

## Nothing has ever set it

Not prod's config, not a talent, not `config.example.yaml` beyond a commented-out `# fallback_content: ""`. I checked where definitions actually persist — `operational_state` in `thane.db` — and it holds zero rows containing it; a whole-file scan of the database finds none either. So nothing migrates.

## The decisive evidence is avoidance, not disuse

The one plausible reason to want a per-loop override is an interactive surface needing something friendlier than a background job's message. That need arose. It was met by adding a second constant:

```go
EmptyResponseFallback            = "I processed your request but wasn't able to compose a response. Please try again."
InteractiveEmptyResponseFallback = "I hit a problem before I could finish that. Please try again."
```

and the Signal bridge and the OWU tracker apply it by setting `loop.Config` at spawn. The feature was available, its exact use case appeared, and both callers reached past it. That is stronger than an unused field — it is a field that lost a competition.

## What stays

The empty-response safety net is live machinery, and this deployment has needed it — the narrate-then-stop turns are exactly the shape it catches. Untouched: `loop.Config.FallbackContent` (what Signal and OWU set), `loop.Request` and `iterate.Config` carrying it to the engine, the engine's four fall-through sites, and both prompts constants.

Removed: the `Spec` field, its persisted JSON wire form, the `Launch` override, and the launch schema property the model could have set but never did.

## Test plan

- [x] `just ci` green locally
- [x] Prod checked before removal: zero occurrences in `operational_state` and zero in `thane.db` overall
- [x] Confirmed the exported `loop.FallbackContent(ctx)` getter has no consumer outside the package
- [x] Confirmed the live surfaces build `loop.Config`, not `Spec` — the removal cannot reach them
- [x] `config-generate-check` regenerated `examples/config.example.yaml`, dropping the commented placeholder
- [x] Test assertions covering the removed round-trip were deleted rather than weakened
- [x] #1296's `TestSpecFieldsNotOfferedStayReal` caught the stale allowlist entry, which is the first thing that guard has done

Refs #1287

🤖 Generated with [Claude Code](https://claude.com/claude-code)
