### PR TITLE
A log of superseded theories is not a place to keep a theory

### DIFF
--- a/internal/app/loop_output_publish.go
+++ b/internal/app/loop_output_publish.go
@@ -45,9 +45,9 @@ func buildTieredPublishTool(store *documents.Store, output looppkg.OutputSpec, n
 		required = append(required, field.Key)
 	}
 	if notes != nil {
-		properties["note"] = map[string]any{
+		properties["notes"] = map[string]any{
 			"type":        "string",
-			"description": fmt.Sprintf("Optional: why this publish changed what it changed. Appended as a timestamped entry to this loop's working notes (%s) in the same call — the private record of how this understanding evolved, which no consumer surface reads. Revision history already records what changed; this is for why.", notes.Ref),
+			"description": fmt.Sprintf("Optional: your working notes (%s) as they now stand, rewritten in the same call — private thinking no consumer surface reads. Hold what you currently believe: theories, what an experiment is showing, what you expect next, what would change your mind. This replaces the whole body rather than adding to it, so carry forward what still holds and drop what you no longer think. Revision history already records what changed; this is for what you make of it.", notes.Ref),
 		}
 	}
 
@@ -82,8 +82,8 @@ func buildTieredPublishTool(store *documents.Store, output looppkg.OutputSpec, n
 			}
 
 			published := map[string]any{"published": result}
-			if note, _ := args["note"].(string); strings.TrimSpace(note) != "" && notes != nil {
-				noteResult, noteErr := appendLoopWorkingNote(ctx, store, *notes, note)
+			if note, _ := args["notes"].(string); strings.TrimSpace(note) != "" && notes != nil {
+				noteResult, noteErr := writeLoopWorkingNotes(ctx, store, *notes, note)
 				switch {
 				case noteErr != nil:
 					// The document publish already succeeded, so this is
@@ -146,14 +146,13 @@ func tierPayloadFromArgs(output looppkg.OutputSpec, args map[string]any) (looppk
 	return payload, nil
 }
 
-// appendLoopWorkingNote appends one entry to a working-notes output,
-// stamping the audience that keeps it out of consumer surfaces.
-func appendLoopWorkingNote(ctx context.Context, store *documents.Store, notes looppkg.OutputSpec, entry string) (*documents.MutationResult, error) {
-	return store.JournalUpdate(ctx, documents.JournalUpdateArgs{
+// writeLoopWorkingNotes replaces a working-notes body, stamping the
+// audience that keeps it out of consumer surfaces on every write —
+// notes hold a current view, so each one supersedes the last.
+func writeLoopWorkingNotes(ctx context.Context, store *documents.Store, notes looppkg.OutputSpec, body string) (*documents.MutationResult, error) {
+	return store.Write(ctx, documents.WriteArgs{
 		Ref:         notes.Ref,
-		Entry:       entry,
-		Window:      notes.JournalWindow,
-		MaxWindows:  notes.MaxWindows,
+		Body:        &body,
 		Frontmatter: loopOutputAudienceFrontmatter(notes),
 	})
 }

--- a/internal/app/loop_output_publish.go
+++ b/internal/app/loop_output_publish.go
@@ -27,8 +27,8 @@ const (
 // supplies content, never structure.
 //
 // notes is the loop's declared working-notes output when it has one.
-// Its presence adds the optional note argument, so the argument exists
-// only when there is somewhere for the note to land.
+// Its presence adds the optional notes argument, so the argument exists
+// only when there is somewhere for the notes to land.
 func buildTieredPublishTool(store *documents.Store, output looppkg.OutputSpec, notes *looppkg.OutputSpec) looppkg.RuntimeTool {
 	fields := output.TierFields()
 	properties := make(map[string]any, len(fields)+1)
@@ -90,9 +90,9 @@ func buildTieredPublishTool(store *documents.Store, output looppkg.OutputSpec, n
 					// not a failed call to retry: report the partial
 					// outcome instead of an error that would invite a
 					// duplicate publish.
-					published["note_error"] = fmt.Sprintf("%s was published, but the working note was not recorded: %v", output.Ref, noteErr)
+					published["notes_error"] = fmt.Sprintf("%s was published, but the working notes were not updated: %v", output.Ref, noteErr)
 				default:
-					published["note_recorded"] = noteResult
+					published["notes_written"] = noteResult
 				}
 			}
 			return marshalLoopOutputToolResult(published)
@@ -113,7 +113,7 @@ func tieredPublishDescription(output looppkg.OutputSpec, notes *looppkg.OutputSp
 		output.Name, output.Ref, strings.Join(keys, ", "),
 	)
 	if notes != nil {
-		description += " Pass note to record why this publish changed what it changed into the loop's working notes."
+		description += " Pass notes to rewrite this loop's private working notes in the same call — what you currently believe, not an entry about this change."
 	}
 	return description
 }

--- a/internal/app/loop_output_publish_test.go
+++ b/internal/app/loop_output_publish_test.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -60,7 +61,7 @@ func TestTieredOutputGeneratesPublishToolWithTypedProjections(t *testing.T) {
 
 	publish := findRuntimeTool(t, hydrated, "publish_output_office_status")
 	props, _ := publish.Parameters["properties"].(map[string]any)
-	for _, key := range []string{"status_line", "teaser", "full", "note"} {
+	for _, key := range []string{"status_line", "teaser", "full", "notes"} {
 		if _, ok := props[key]; !ok {
 			t.Fatalf("publish tool schema missing %q argument; got %v", key, props)
 		}
@@ -180,7 +181,7 @@ func TestPublishToolRejectsOverBudgetWithoutWriting(t *testing.T) {
 	}
 }
 
-func TestPublishToolNoteAppendsInternalWorkingNotes(t *testing.T) {
+func TestPublishToolNotesReplaceInternalWorkingNotes(t *testing.T) {
 	t.Parallel()
 
 	store, coreDir := newLoopOutputDocumentStore(t)
@@ -195,7 +196,7 @@ func TestPublishToolNoteAppendsInternalWorkingNotes(t *testing.T) {
 		"status_line": "Printer online.",
 		"teaser":      "Nothing needs attention.",
 		"full":        "# Office\n\nAll quiet.",
-		"note":        "Dropped the delivery warning — both packages were signed for at 14:20.",
+		"notes":       "Current view: both packages signed for at 14:20, so the delivery warning no longer applies. Watching whether the 14:00 sweep is early enough.",
 	})
 	if err != nil {
 		t.Fatalf("publish handler: %v", err)
@@ -209,8 +210,8 @@ func TestPublishToolNoteAppendsInternalWorkingNotes(t *testing.T) {
 		t.Fatalf("ReadFile notes: %v", err)
 	}
 	notes := string(raw)
-	if !strings.Contains(notes, "both packages were signed for") {
-		t.Fatalf("working notes missing the entry:\n%s", notes)
+	if !strings.Contains(notes, "both packages signed for at 14:20") {
+		t.Fatalf("working notes missing the current view:\n%s", notes)
 	}
 	// The audience stamp is what makes the notes document invisible to
 	// search and tagged-guidance injection.
@@ -232,7 +233,7 @@ func TestPublishToolNoteAppendsInternalWorkingNotes(t *testing.T) {
 	}
 }
 
-func TestWorkingNotesAppendToolStampsInternalAudience(t *testing.T) {
+func TestWorkingNotesToolStampsInternalAudience(t *testing.T) {
 	t.Parallel()
 
 	store, _ := newLoopOutputDocumentStore(t)
@@ -241,15 +242,19 @@ func TestWorkingNotesAppendToolStampsInternalAudience(t *testing.T) {
 	if err != nil {
 		t.Fatalf("hydrateLoopOutputs: %v", err)
 	}
-	appendNotes := findRuntimeTool(t, hydrated, "append_output_office_notes")
-	if !strings.Contains(appendNotes.Description, "private process log") {
-		t.Fatalf("working-notes tool should frame itself as private: %q", appendNotes.Description)
+	// Notes are rewritten, not appended: they hold what the loop
+	// currently believes rather than a history of what it used to.
+	notesTool := findRuntimeTool(t, hydrated, "replace_output_office_notes")
+	for _, want := range []string{"private thinking", "working theories", "current view"} {
+		if !strings.Contains(notesTool.Description, want) {
+			t.Fatalf("working-notes tool description missing %q: %q", want, notesTool.Description)
+		}
 	}
 
-	if _, err := appendNotes.Handler(context.Background(), map[string]any{
-		"entry": "Reconsidered the trough threshold.",
+	if _, err := notesTool.Handler(context.Background(), map[string]any{
+		"body": "Current theory: the trough threshold is too low overnight.",
 	}); err != nil {
-		t.Fatalf("append notes handler: %v", err)
+		t.Fatalf("notes handler: %v", err)
 	}
 	doc, err := store.Read(context.Background(), "core:office-notes.md")
 	if err != nil {
@@ -368,10 +373,72 @@ func TestTieredOutputContextReportsPublishMode(t *testing.T) {
 	if !strings.Contains(block, `"mode": "publish"`) {
 		t.Fatalf("tiered output context should report publish mode:\n%s", block)
 	}
-	if strings.Contains(block, `"mode": "replace"`) {
-		t.Fatalf("tiered output context still reports replace mode:\n%s", block)
+	// The notes output in the same block reports replace now, so this
+	// asserts per output rather than over the whole block.
+	var payload struct {
+		Outputs []struct {
+			Name string `json:"name"`
+			Mode string `json:"mode"`
+		} `json:"outputs"`
 	}
-	if !strings.Contains(block, `"mode": "append"`) {
-		t.Fatalf("working-notes output should still report append mode:\n%s", block)
+	// The block is markdown wrapping a JSON payload.
+	start := strings.Index(block, "{")
+	end := strings.LastIndex(block, "}")
+	if start < 0 || end <= start {
+		t.Fatalf("no JSON payload in context block:\n%s", block)
+	}
+	if err := json.Unmarshal([]byte(block[start:end+1]), &payload); err != nil {
+		t.Fatalf("decode context block: %v\n%s", err, block)
+	}
+	modes := map[string]string{}
+	for _, o := range payload.Outputs {
+		modes[o.Name] = o.Mode
+	}
+	if len(modes) != 2 {
+		t.Fatalf("expected the tiered document and its notes, got %v", modes)
+	}
+	for name, mode := range modes {
+		want := "publish"
+		if strings.Contains(name, "note") {
+			want = "replace"
+		}
+		if mode != want {
+			t.Errorf("output %q reports mode %q, want %q", name, mode, want)
+		}
+	}
+}
+
+// TestWorkingNotesRewriteKeepsAudienceStamp guards the regression this
+// change nearly shipped. Notes used to be written through the journal
+// path, which stamped the audience on every append. Switching them to a
+// maintained document routed them through the generic replace handler,
+// which wrote only a body — so the second write dropped the stamp that
+// keeps a loop's private thinking out of search and out of other loops'
+// context, and nothing failed.
+func TestWorkingNotesRewriteKeepsAudienceStamp(t *testing.T) {
+	t.Parallel()
+
+	store, _ := newLoopOutputDocumentStore(t)
+	app := &App{documentStore: store}
+	hydrated, err := app.hydrateLoopOutputs(tieredSpec())
+	if err != nil {
+		t.Fatalf("hydrateLoopOutputs: %v", err)
+	}
+	notesTool := findRuntimeTool(t, hydrated, "replace_output_office_notes")
+
+	for i, body := range []string{
+		"First view: the trough threshold looks too low overnight.",
+		"Revised: the threshold is fine, the sensor reports late.",
+	} {
+		if _, err := notesTool.Handler(context.Background(), map[string]any{"body": body}); err != nil {
+			t.Fatalf("write %d: %v", i, err)
+		}
+		doc, err := store.Read(context.Background(), "core:office-notes.md")
+		if err != nil {
+			t.Fatalf("read after write %d: %v", i, err)
+		}
+		if got := firstFrontmatterValue(doc, "audience"); got != "internal" {
+			t.Fatalf("write %d dropped the audience stamp: audience = %q", i, got)
+		}
 	}
 }

--- a/internal/app/loop_output_publish_test.go
+++ b/internal/app/loop_output_publish_test.go
@@ -201,7 +201,7 @@ func TestPublishToolNotesReplaceInternalWorkingNotes(t *testing.T) {
 	if err != nil {
 		t.Fatalf("publish handler: %v", err)
 	}
-	if !strings.Contains(result, "note_recorded") {
+	if !strings.Contains(result, "notes_written") {
 		t.Fatalf("result should report the recorded note: %s", result)
 	}
 
@@ -397,13 +397,14 @@ func TestTieredOutputContextReportsPublishMode(t *testing.T) {
 	if len(modes) != 2 {
 		t.Fatalf("expected the tiered document and its notes, got %v", modes)
 	}
-	for name, mode := range modes {
-		want := "publish"
-		if strings.Contains(name, "note") {
-			want = "replace"
-		}
-		if mode != want {
-			t.Errorf("output %q reports mode %q, want %q", name, mode, want)
+	// The fixture is fixed, so name the outputs rather than matching on a
+	// substring that any future output could collide with.
+	for name, want := range map[string]string{
+		"office status": "publish",
+		"office notes":  "replace",
+	} {
+		if modes[name] != want {
+			t.Errorf("output %q reports mode %q, want %q", name, modes[name], want)
 		}
 	}
 }

--- a/internal/app/loop_outputs.go
+++ b/internal/app/loop_outputs.go
@@ -91,7 +91,7 @@ func buildLoopOutputTools(store *documents.Store, outputs []looppkg.OutputSpec) 
 		case looppkg.OutputModeReplace:
 			out = append(out, looppkg.RuntimeTool{
 				Name:               output.ToolName(),
-				Description:        fmt.Sprintf("Replace the loop-declared maintained document output %q at %s. Pass the complete markdown body for the new current document state; root policy and indexing are handled by Thane.", output.Name, output.Ref),
+				Description:        replaceOutputDescription(output),
 				SkipContentResolve: true,
 				Parameters: map[string]any{
 					"type": "object",
@@ -117,6 +117,12 @@ func buildLoopOutputTools(store *documents.Store, outputs []looppkg.OutputSpec) 
 					result, err := store.Write(ctx, documents.WriteArgs{
 						Ref:  output.Ref,
 						Body: &content,
+						// Stamped on every write, not only the first: the
+						// exclusion in search and tagged-guidance injection
+						// reads this key off the document, so a rewrite that
+						// dropped it would quietly publish the loop's private
+						// thinking.
+						Frontmatter: loopOutputAudienceFrontmatter(output),
 					})
 					if err != nil {
 						return "", err
@@ -185,7 +191,7 @@ func renderLoopOutputContextWithNow(ctx context.Context, store *documents.Store,
 		for _, field := range output.TierFields() {
 			entry.Tiers = append(entry.Tiers, field.Key)
 		}
-		if output.Type == looppkg.OutputTypeJournalDocument || output.Type == looppkg.OutputTypeWorkingNotes {
+		if output.Type == looppkg.OutputTypeJournalDocument {
 			entry.Journal = &loopOutputJournal{
 				Window:     output.JournalWindow,
 				MaxWindows: output.MaxWindows,
@@ -208,7 +214,11 @@ func renderLoopOutputContextWithNow(ctx context.Context, store *documents.Store,
 		switch output.Type {
 		case looppkg.OutputTypeMaintainedDocument:
 			entry.Content, entry.Truncated, entry.BytesShown, entry.BytesTotal = truncateLoopOutputText(doc.Body, loopOutputContentBytes, false)
-		case looppkg.OutputTypeJournalDocument, looppkg.OutputTypeWorkingNotes:
+		case looppkg.OutputTypeWorkingNotes:
+			// The head, not the tail: a loop rewriting its current
+			// thinking needs to see what it is replacing.
+			entry.Content, entry.Truncated, entry.BytesShown, entry.BytesTotal = truncateLoopOutputText(doc.Body, loopOutputContentBytes, false)
+		case looppkg.OutputTypeJournalDocument:
 			entry.RecentContent, entry.Truncated, entry.BytesShown, entry.BytesTotal = truncateLoopOutputText(doc.Body, loopOutputRecentBytes, true)
 		}
 		payload.Outputs = append(payload.Outputs, entry)
@@ -277,15 +287,28 @@ func loopOutputContextMode(output looppkg.OutputSpec) string {
 	return string(output.EffectiveMode())
 }
 
-// appendOutputDescription frames an append-mode output for the model.
-// Working notes get their own framing: the value of a private process
-// log is that it holds the reasoning a published document should not
-// carry, and a model that thinks it is writing another public surface
-// will not write that.
-func appendOutputDescription(output looppkg.OutputSpec) string {
+// replaceOutputDescription frames a replace-mode output. Working notes
+// and a published document are both rewritten wholesale, but what
+// belongs in each is opposite, so they do not share framing.
+func replaceOutputDescription(output looppkg.OutputSpec) string {
 	if output.Type == looppkg.OutputTypeWorkingNotes {
-		return fmt.Sprintf("Append to this loop's working notes %q at %s — the loop's private process log. Record how the understanding is evolving: what changed and why, what drifted, what was refined, what is worth remembering later. No consumer surface reads it: it stays out of search results and out of other loops' context, so write the reasoning that would clutter a published document. Pass only the new entry; Thane stamps, windows, prunes, and indexes.", output.Name, output.Ref)
+		return workingNotesDescription(output)
 	}
+	return fmt.Sprintf("Replace the loop-declared maintained document output %q at %s. Pass the complete markdown body for the new current document state; root policy and indexing are handled by Thane.", output.Name, output.Ref)
+}
+
+// workingNotesDescription frames the loop's private thinking. What
+// belongs here is what a reader should never see, and a model that
+// thinks it is writing another public surface will not write it. The
+// instruction to rewrite rather than add is the load-bearing part:
+// notes that accumulate stop being a current view and become a history
+// the loop has to interpret.
+func workingNotesDescription(output looppkg.OutputSpec) string {
+	return fmt.Sprintf("Rewrite this loop's working notes %q at %s — its private thinking, carried from turn to turn. Hold what you currently believe: working theories, what an experiment is showing so far, what you expect to happen next, what you are unsure of and what would settle it. Replace the whole body each time so it stays a current view rather than a log; drop what you no longer think and keep what still holds. No consumer surface reads it — it stays out of search results and out of other loops' context — so write what would clutter or mislead a published document.", output.Name, output.Ref)
+}
+
+// appendOutputDescription frames an append-mode output for the model.
+func appendOutputDescription(output looppkg.OutputSpec) string {
 	return fmt.Sprintf("Append to the loop-declared journal output %q at %s. Pass only the new journal entry; Thane stamps, windows, prunes, indexes, and applies root policy.", output.Name, output.Ref)
 }
 

--- a/internal/runtime/loop/output.go
+++ b/internal/runtime/loop/output.go
@@ -19,10 +19,16 @@ const (
 	// OutputTypeJournalDocument describes an append-only journal
 	// document maintained by the loop.
 	OutputTypeJournalDocument OutputType = "journal_document"
-	// OutputTypeWorkingNotes describes a loop-private process journal:
-	// append-only like a journal document, internal-audience by default.
-	// It holds the loop's own timeline — drift, refinement, and curation
-	// rationale — and is never projected into consumer surfaces.
+	// OutputTypeWorkingNotes describes a loop's private thinking:
+	// maintained like its published document and internal-audience by
+	// default, never projected into consumer surfaces.
+	//
+	// It holds what the loop currently believes — working theories, the
+	// state of an experiment, what it expects next — and is rewritten as
+	// that changes rather than appended to. A loop that appends its
+	// theories has to reconstruct its own current view from a history of
+	// superseded ones every turn, which is the difficulty holding state
+	// across turns that this exists to remove, not a way to solve it.
 	OutputTypeWorkingNotes OutputType = "working_notes"
 )
 
@@ -126,8 +132,10 @@ func (o OutputSpec) EffectiveMode() OutputMode {
 	switch o.Type {
 	case OutputTypeMaintainedDocument:
 		return OutputModeReplace
-	case OutputTypeJournalDocument, OutputTypeWorkingNotes:
+	case OutputTypeJournalDocument:
 		return OutputModeAppend
+	case OutputTypeWorkingNotes:
+		return OutputModeReplace
 	default:
 		return ""
 	}
@@ -192,12 +200,12 @@ func (o OutputSpec) Validate() error {
 	mode := o.EffectiveMode()
 	switch mode {
 	case OutputModeReplace:
-		if o.Type != OutputTypeMaintainedDocument {
-			return fmt.Errorf("mode %q is only valid for type %q", mode, OutputTypeMaintainedDocument)
+		if o.Type != OutputTypeMaintainedDocument && o.Type != OutputTypeWorkingNotes {
+			return fmt.Errorf("mode %q is only valid for types %q and %q", mode, OutputTypeMaintainedDocument, OutputTypeWorkingNotes)
 		}
 	case OutputModeAppend:
-		if o.Type != OutputTypeJournalDocument && o.Type != OutputTypeWorkingNotes {
-			return fmt.Errorf("mode %q is only valid for types %q and %q", mode, OutputTypeJournalDocument, OutputTypeWorkingNotes)
+		if o.Type != OutputTypeJournalDocument {
+			return fmt.Errorf("mode %q is only valid for type %q", mode, OutputTypeJournalDocument)
 		}
 	default:
 		return fmt.Errorf("unsupported mode %q", mode)

--- a/internal/runtime/loop/output_test.go
+++ b/internal/runtime/loop/output_test.go
@@ -86,21 +86,24 @@ func TestOutputSpecValidateAndToolName(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "working notes defaults append",
+			// Notes hold what the loop currently believes, so it rewrites
+			// them rather than appending to a history it would have to
+			// re-read to find its own present view.
+			name: "working notes default to replace",
 			output: OutputSpec{
 				Name: "ranch notes",
 				Type: OutputTypeWorkingNotes,
 				Ref:  "core:ranch-notes.md",
 			},
-			wantTool: "append_output_ranch_notes",
+			wantTool: "replace_output_ranch_notes",
 		},
 		{
-			name: "working notes rejects replace mode",
+			name: "working notes reject append mode",
 			output: OutputSpec{
 				Name: "ranch notes",
 				Type: OutputTypeWorkingNotes,
 				Ref:  "core:ranch-notes.md",
-				Mode: OutputModeReplace,
+				Mode: OutputModeAppend,
 			},
 			wantErr: true,
 		},


### PR DESCRIPTION
Step 1 of the plan amended onto #1250. This revises **decision 5**, which defined `working_notes` as sugar over journal mode plus `audience: internal`.

## Why the shape was wrong

The need is a loop's cognitive state — working theories, what an experiment is showing so far, what it expects next. Loops have been observed struggling to hold exactly that from turn to turn.

An append-only log makes that harder, not easier. The loop has to re-read a growing history and reconstruct its present view from superseded ones, every turn. Append manufactures the problem it was meant to solve.

Production agrees, in the shape of the loops that would use it. `door_lock_batteries` — *"track the 1.5V-lithium-vs-NiMH battery-chemistry experiment, learn each lock's discharge curve"* — is a maintained hypothesis, not a diary. `continuity_thread` is holding a relationship's current state in a journal because there was nothing else to hold it in.

## What changed

Notes are a maintained document the loop rewrites. Same shape as its published document, opposite content — which is what makes the core symmetric: public substance and private thinking, with projections cut from both.

Everything else follows from that rather than being decided separately:

- The generated tool is `replace_output_*` and takes a `body`.
- Its description tells the loop to **carry forward what still holds and drop what it no longer thinks**. "Replace" on its own invites either a blank page or a verbatim copy; neither is a current view.
- The context block injects the **head** rather than the tail. A loop rewriting its thinking needs to see what it is replacing; an append-only log only ever needed its recent end.
- The publish tool's companion argument is `notes` rather than `note`, and replaces rather than appending a timestamped entry.
- Journal windowing stops describing notes, which never wrap.

## A regression this nearly shipped

Notes used to be written through the journal path, which stamped the internal audience on **every** append. Moving them to a maintained document routed them through the generic replace handler, which writes only a body.

So the second write would have dropped the stamp — and the stamp is the whole mechanism. Search exclusion and tagged-guidance injection read `audience` off the *document*, not off the loop spec. A loop's private thinking would have become searchable on its second update, silently, with the declaration still saying `internal`.

The stamp is now applied on every write, and the test writes twice and checks both. I confirmed it fails without the fix rather than trusting that it would.

## Test plan

- [x] `just ci` green locally
- [x] Working notes default to replace mode and reject append; the generated tool is `replace_output_*`
- [x] The tool description carries the rewrite-don't-accumulate instruction
- [x] The context block reports `replace` for notes and `publish` for the tiered document, asserted per output rather than across the block
- [x] Two consecutive rewrites both keep the internal audience stamp (`TestWorkingNotesRewriteKeepsAudienceStamp`), mutation-checked against removing the stamp
- [x] The publish companion argument replaces the notes body and keeps the stamp
- [x] Full repo suite green

Amends decision 5 of #1250.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
