### PR TITLE
A second door to journaling that forced everyone to choose

### DIFF
--- a/docs/model-facing-tools.md
+++ b/docs/model-facing-tools.md
@@ -197,8 +197,8 @@ layer.
 
 Some tools exist only because a specific loop run declared a narrow
 interface. Loop-declared document outputs are the current example:
-`replace_output_<name>` replaces one maintained document, while
-`append_output_<name>` appends to one journal document.
+`replace_output_<name>` replaces one maintained document, and
+`publish_output_<name>` writes every projection of a tiered one.
 
 Do not register these tools globally or ask the model to discover the
 underlying file path. Generate them from the loop spec, advertise them

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -240,9 +240,9 @@ or signed deltas like `-604800s`.
 
 Loop-declared document output tools are request-scoped and do not appear
 in the global catalog above. When a loop declares an output, Thane
-generates a tool such as `replace_output_metacognitive_state`,
-`append_output_daily_notes`, or — for a maintained document that declares
-`tiers` — `publish_output_office_status`, only for that loop run. These tools route through managed document roots, so
+generates a tool such as `replace_output_metacognitive_state` or — for a
+maintained document that declares `tiers` — `publish_output_office_status`,
+only for that loop run. These tools route through managed document roots, so
 root policy, indexing, and provenance remain centralized instead of
 being reimplemented in each loop prompt.
 

--- a/docs/understanding/agent-loop.md
+++ b/docs/understanding/agent-loop.md
@@ -115,8 +115,9 @@ Output shapes available today:
 
 - **Maintained document** outputs replace the whole current document
   through a generated `replace_output_<name>` tool.
-- **Journal document** outputs append a timestamped entry through a
-  generated `append_output_<name>` tool.
+- **Working notes** outputs are the loop's private current thinking,
+  rewritten through a generated `replace_output_<name>` tool and never
+  projected into search, context, or any other consumer surface.
 - **Tiered maintained document** outputs — a maintained document that
   declares `tiers` — publish condensed projections alongside the full
   body through a generated `publish_output_<name>` tool, one argument

--- a/docs/understanding/document-roots.md
+++ b/docs/understanding/document-roots.md
@@ -400,8 +400,8 @@ runtime tools:
 
 - `replace_output_<name>` for a maintained document that should be
   rewritten as a complete current state.
-- `append_output_<name>` for a journal document, or for a working-notes
-  document, that should receive new entries over time.
+- `replace_output_<name>` for a working-notes document, which holds the
+  loop's current thinking and is rewritten rather than accumulated.
 - `publish_output_<name>` for a maintained document that declares
   `tiers`: one typed argument per published projection
   (`status_line`, `teaser`, `digest`) plus the full body, written

--- a/internal/app/loop_output_publish_test.go
+++ b/internal/app/loop_output_publish_test.go
@@ -27,11 +27,9 @@ func tieredSpec() looppkg.Spec {
 				Tiers: []looppkg.OutputTier{looppkg.OutputTierStatusLine, looppkg.OutputTierTeaser},
 			},
 			{
-				Name:          "office notes",
-				Type:          looppkg.OutputTypeWorkingNotes,
-				Ref:           "core:office-notes.md",
-				JournalWindow: "month",
-				MaxWindows:    6,
+				Name: "office notes",
+				Type: looppkg.OutputTypeWorkingNotes,
+				Ref:  "core:office-notes.md",
 			},
 		},
 	}
@@ -276,35 +274,6 @@ func firstFrontmatterValue(doc *documents.DocumentRecord, key string) string {
 		return values[0]
 	}
 	return ""
-}
-
-func TestJournalOutputDoesNotClaimInternalAudience(t *testing.T) {
-	t.Parallel()
-
-	store, _ := newLoopOutputDocumentStore(t)
-	app := &App{documentStore: store}
-	spec := tieredSpec()
-	spec.Outputs = []looppkg.OutputSpec{{
-		Name:          "office journal",
-		Type:          looppkg.OutputTypeJournalDocument,
-		Ref:           "core:office-journal.md",
-		JournalWindow: "day",
-	}}
-	hydrated, err := app.hydrateLoopOutputs(spec)
-	if err != nil {
-		t.Fatalf("hydrateLoopOutputs: %v", err)
-	}
-	appendJournal := findRuntimeTool(t, hydrated, "append_output_office_journal")
-	if _, err := appendJournal.Handler(context.Background(), map[string]any{"entry": "Ordinary entry."}); err != nil {
-		t.Fatalf("append journal handler: %v", err)
-	}
-	doc, err := store.Read(context.Background(), "core:office-journal.md")
-	if err != nil {
-		t.Fatalf("Read journal: %v", err)
-	}
-	if got := firstFrontmatterValue(doc, "audience"); got != "" {
-		t.Fatalf("a published journal must carry no audience stamp, got %q", got)
-	}
 }
 
 func TestTieredOutputContextAdvertisesProjections(t *testing.T) {

--- a/internal/app/loop_outputs.go
+++ b/internal/app/loop_outputs.go
@@ -18,7 +18,6 @@ import (
 
 const (
 	loopOutputContentBytes = 16 * 1024
-	loopOutputRecentBytes  = 8 * 1024
 )
 
 type loopOutputContext struct {
@@ -26,31 +25,24 @@ type loopOutputContext struct {
 }
 
 type loopOutputContextEntry struct {
-	Name             string             `json:"name"`
-	Type             string             `json:"type"`
-	Mode             string             `json:"mode"`
-	Ref              string             `json:"ref"`
-	Purpose          string             `json:"purpose,omitempty"`
-	ToolName         string             `json:"tool_name"`
-	Interface        string             `json:"interface"`
-	Policy           string             `json:"policy"`
-	Exists           bool               `json:"exists"`
-	Title            string             `json:"title,omitempty"`
-	UpdatedDelta     string             `json:"updated_delta,omitempty"`
-	Content          string             `json:"content,omitempty"`
-	RecentContent    string             `json:"recent_content,omitempty"`
-	Truncated        bool               `json:"truncated,omitempty"`
-	BytesShown       int                `json:"bytes_shown,omitempty"`
-	BytesTotal       int                `json:"bytes_total,omitempty"`
-	UnavailableError string             `json:"unavailable_error,omitempty"`
-	Journal          *loopOutputJournal `json:"journal,omitempty"`
-	Tiers            []string           `json:"tiers,omitempty"`
-	Audience         string             `json:"audience,omitempty"`
-}
-
-type loopOutputJournal struct {
-	Window     string `json:"window,omitempty"`
-	MaxWindows int    `json:"max_windows,omitempty"`
+	Name             string   `json:"name"`
+	Type             string   `json:"type"`
+	Mode             string   `json:"mode"`
+	Ref              string   `json:"ref"`
+	Purpose          string   `json:"purpose,omitempty"`
+	ToolName         string   `json:"tool_name"`
+	Interface        string   `json:"interface"`
+	Policy           string   `json:"policy"`
+	Exists           bool     `json:"exists"`
+	Title            string   `json:"title,omitempty"`
+	UpdatedDelta     string   `json:"updated_delta,omitempty"`
+	Content          string   `json:"content,omitempty"`
+	Truncated        bool     `json:"truncated,omitempty"`
+	BytesShown       int      `json:"bytes_shown,omitempty"`
+	BytesTotal       int      `json:"bytes_total,omitempty"`
+	UnavailableError string   `json:"unavailable_error,omitempty"`
+	Tiers            []string `json:"tiers,omitempty"`
+	Audience         string   `json:"audience,omitempty"`
 }
 
 // hydrateLoopOutputs is the universal "make this spec runtime-ready"
@@ -130,39 +122,6 @@ func buildLoopOutputTools(store *documents.Store, outputs []looppkg.OutputSpec) 
 					return marshalLoopOutputToolResult(result)
 				},
 			})
-		case looppkg.OutputModeAppend:
-			out = append(out, looppkg.RuntimeTool{
-				Name:               output.ToolName(),
-				Description:        appendOutputDescription(output),
-				SkipContentResolve: true,
-				Parameters: map[string]any{
-					"type": "object",
-					"properties": map[string]any{
-						"entry": map[string]any{
-							"type":        "string",
-							"description": "Journal entry content to append.",
-						},
-					},
-					"required": []string{"entry"},
-				},
-				Handler: func(ctx context.Context, args map[string]any) (string, error) {
-					entry, _ := args["entry"].(string)
-					if strings.TrimSpace(entry) == "" {
-						return "", fmt.Errorf("entry is required")
-					}
-					result, err := store.JournalUpdate(ctx, documents.JournalUpdateArgs{
-						Ref:         output.Ref,
-						Entry:       entry,
-						Window:      output.JournalWindow,
-						MaxWindows:  output.MaxWindows,
-						Frontmatter: loopOutputAudienceFrontmatter(output),
-					})
-					if err != nil {
-						return "", err
-					}
-					return marshalLoopOutputToolResult(result)
-				},
-			})
 		}
 	}
 	return out
@@ -191,12 +150,6 @@ func renderLoopOutputContextWithNow(ctx context.Context, store *documents.Store,
 		for _, field := range output.TierFields() {
 			entry.Tiers = append(entry.Tiers, field.Key)
 		}
-		if output.Type == looppkg.OutputTypeJournalDocument {
-			entry.Journal = &loopOutputJournal{
-				Window:     output.JournalWindow,
-				MaxWindows: output.MaxWindows,
-			}
-		}
 		doc, err := store.Read(ctx, output.Ref)
 		if err != nil {
 			if strings.Contains(err.Error(), "document not found") || errors.Is(err, os.ErrNotExist) {
@@ -218,8 +171,6 @@ func renderLoopOutputContextWithNow(ctx context.Context, store *documents.Store,
 			// The head, not the tail: a loop rewriting its current
 			// thinking needs to see what it is replacing.
 			entry.Content, entry.Truncated, entry.BytesShown, entry.BytesTotal = truncateLoopOutputText(doc.Body, loopOutputContentBytes, false)
-		case looppkg.OutputTypeJournalDocument:
-			entry.RecentContent, entry.Truncated, entry.BytesShown, entry.BytesTotal = truncateLoopOutputText(doc.Body, loopOutputRecentBytes, true)
 		}
 		payload.Outputs = append(payload.Outputs, entry)
 	}
@@ -266,8 +217,6 @@ func outputInterfaceDescription(output looppkg.OutputSpec) string {
 	switch output.EffectiveMode() {
 	case looppkg.OutputModeReplace:
 		return "Call " + output.ToolName() + " with complete replacement markdown content for this maintained document."
-	case looppkg.OutputModeAppend:
-		return "Call " + output.ToolName() + " with one new journal entry; do not rewrite old entries."
 	default:
 		return "Use the generated output tool for this declaration."
 	}
@@ -305,11 +254,6 @@ func replaceOutputDescription(output looppkg.OutputSpec) string {
 // the loop has to interpret.
 func workingNotesDescription(output looppkg.OutputSpec) string {
 	return fmt.Sprintf("Rewrite this loop's working notes %q at %s — its private thinking, carried from turn to turn. Hold what you currently believe: working theories, what an experiment is showing so far, what you expect to happen next, what you are unsure of and what would settle it. Replace the whole body each time so it stays a current view rather than a log; drop what you no longer think and keep what still holds. No consumer surface reads it — it stays out of search results and out of other loops' context — so write what would clutter or mislead a published document.", output.Name, output.Ref)
-}
-
-// appendOutputDescription frames an append-mode output for the model.
-func appendOutputDescription(output looppkg.OutputSpec) string {
-	return fmt.Sprintf("Append to the loop-declared journal output %q at %s. Pass only the new journal entry; Thane stamps, windows, prunes, indexes, and applies root policy.", output.Name, output.Ref)
 }
 
 func truncateLoopOutputText(s string, maxBytes int, tail bool) (string, bool, int, int) {

--- a/internal/app/loop_outputs_test.go
+++ b/internal/app/loop_outputs_test.go
@@ -33,11 +33,9 @@ func TestHydrateLoopOutputsBuildsScopedToolsAndContext(t *testing.T) {
 				Purpose: "Current metacognitive state.",
 			},
 			{
-				Name:          "metacognitive_journal",
-				Type:          looppkg.OutputTypeJournalDocument,
-				Ref:           "core:metacognitive-journal.md",
-				JournalWindow: "day",
-				MaxWindows:    2,
+				Name: "metacognitive_notes",
+				Type: looppkg.OutputTypeWorkingNotes,
+				Ref:  "core:metacognitive-notes.md",
 			},
 		},
 	}
@@ -52,7 +50,7 @@ func TestHydrateLoopOutputsBuildsScopedToolsAndContext(t *testing.T) {
 	if hydrated.RuntimeTools[0].Name != "replace_output_metacognitive_state" {
 		t.Fatalf("RuntimeTools[0].Name = %q", hydrated.RuntimeTools[0].Name)
 	}
-	if hydrated.RuntimeTools[1].Name != "append_output_metacognitive_journal" {
+	if hydrated.RuntimeTools[1].Name != "replace_output_metacognitive_notes" {
 		t.Fatalf("RuntimeTools[1].Name = %q", hydrated.RuntimeTools[1].Name)
 	}
 	for _, tool := range hydrated.RuntimeTools {
@@ -76,17 +74,17 @@ func TestHydrateLoopOutputsBuildsScopedToolsAndContext(t *testing.T) {
 	}
 
 	_, err = hydrated.RuntimeTools[1].Handler(context.Background(), map[string]any{
-		"entry": "Observed quiet conditions.",
+		"body": "Current view: conditions are quiet and the trend holds.",
 	})
 	if err != nil {
-		t.Fatalf("append output handler: %v", err)
+		t.Fatalf("notes handler: %v", err)
 	}
-	journal, err := os.ReadFile(filepath.Join(coreDir, "metacognitive-journal.md"))
+	notes, err := os.ReadFile(filepath.Join(coreDir, "metacognitive-notes.md"))
 	if err != nil {
-		t.Fatalf("ReadFile journal: %v", err)
+		t.Fatalf("ReadFile notes: %v", err)
 	}
-	if !strings.Contains(string(journal), "Observed quiet conditions.") {
-		t.Fatalf("journal = %s, want appended entry", string(journal))
+	if !strings.Contains(string(notes), "conditions are quiet") {
+		t.Fatalf("notes = %s, want the rewritten body", string(notes))
 	}
 
 	ctx, err := hydrated.OutputContextBuilder(context.Background(), hydrated.Outputs)
@@ -96,9 +94,9 @@ func TestHydrateLoopOutputsBuildsScopedToolsAndContext(t *testing.T) {
 	for _, want := range []string{
 		"Declared Durable Outputs",
 		"replace_output_metacognitive_state",
-		"append_output_metacognitive_journal",
+		"replace_output_metacognitive_notes",
 		"Everything is calm.",
-		"Observed quiet conditions.",
+		"conditions are quiet",
 	} {
 		if !strings.Contains(ctx, want) {
 			t.Fatalf("output context missing %q:\n%s", want, ctx)

--- a/internal/runtime/loop/output.go
+++ b/internal/runtime/loop/output.go
@@ -16,9 +16,6 @@ const (
 	// OutputTypeMaintainedDocument describes a document the loop owns
 	// as a current complete state.
 	OutputTypeMaintainedDocument OutputType = "maintained_document"
-	// OutputTypeJournalDocument describes an append-only journal
-	// document maintained by the loop.
-	OutputTypeJournalDocument OutputType = "journal_document"
 	// OutputTypeWorkingNotes describes a loop's private thinking:
 	// maintained like its published document and internal-audience by
 	// default, never projected into consumer surfaces.
@@ -38,8 +35,6 @@ type OutputMode string
 const (
 	// OutputModeReplace requires complete replacement content.
 	OutputModeReplace OutputMode = "replace"
-	// OutputModeAppend requires append-only journal entries.
-	OutputModeAppend OutputMode = "append"
 )
 
 // OutputTier names one declared fidelity level in a tiered output's
@@ -87,12 +82,6 @@ type OutputSpec struct {
 	Mode OutputMode `yaml:"mode,omitempty" json:"mode,omitempty"`
 	// Purpose is optional model-facing guidance for this output.
 	Purpose string `yaml:"purpose,omitempty" json:"purpose,omitempty"`
-	// JournalWindow is the default rolling window for journal outputs:
-	// day, week, or month. Empty uses the document layer default.
-	JournalWindow string `yaml:"journal_window,omitempty" json:"journal_window,omitempty"`
-	// MaxWindows caps retained journal windows. Zero uses the document
-	// layer default for the selected window.
-	MaxWindows int `yaml:"max_windows,omitempty" json:"max_windows,omitempty"`
 	// Tiers declares the published projection ladder for a maintained
 	// document: which of status_line, teaser, and digest the loop
 	// publishes alongside the full body. Empty means untiered. The
@@ -132,8 +121,6 @@ func (o OutputSpec) EffectiveMode() OutputMode {
 	switch o.Type {
 	case OutputTypeMaintainedDocument:
 		return OutputModeReplace
-	case OutputTypeJournalDocument:
-		return OutputModeAppend
 	case OutputTypeWorkingNotes:
 		return OutputModeReplace
 	default:
@@ -164,8 +151,6 @@ func (o OutputSpec) ToolName() string {
 	switch o.EffectiveMode() {
 	case OutputModeReplace:
 		return "replace_output_" + safeOutputToolSuffix(o.Name)
-	case OutputModeAppend:
-		return "append_output_" + safeOutputToolSuffix(o.Name)
 	default:
 		return "write_output_" + safeOutputToolSuffix(o.Name)
 	}
@@ -193,7 +178,7 @@ func (o OutputSpec) Validate() error {
 		return err
 	}
 	switch o.Type {
-	case OutputTypeMaintainedDocument, OutputTypeJournalDocument, OutputTypeWorkingNotes:
+	case OutputTypeMaintainedDocument, OutputTypeWorkingNotes:
 	default:
 		return fmt.Errorf("unsupported type %q", o.Type)
 	}
@@ -202,10 +187,6 @@ func (o OutputSpec) Validate() error {
 	case OutputModeReplace:
 		if o.Type != OutputTypeMaintainedDocument && o.Type != OutputTypeWorkingNotes {
 			return fmt.Errorf("mode %q is only valid for types %q and %q", mode, OutputTypeMaintainedDocument, OutputTypeWorkingNotes)
-		}
-	case OutputModeAppend:
-		if o.Type != OutputTypeJournalDocument {
-			return fmt.Errorf("mode %q is only valid for type %q", mode, OutputTypeJournalDocument)
 		}
 	default:
 		return fmt.Errorf("unsupported mode %q", mode)
@@ -216,13 +197,10 @@ func (o OutputSpec) Validate() error {
 		return fmt.Errorf("unsupported audience %q; use %q or %q", o.Audience, OutputAudiencePublished, OutputAudienceInternal)
 	}
 	if o.Type == OutputTypeWorkingNotes && o.Audience == OutputAudiencePublished {
-		return fmt.Errorf("audience %q contradicts type %q; working notes are internal by definition — declare a journal_document instead for a published journal", OutputAudiencePublished, OutputTypeWorkingNotes)
+		return fmt.Errorf("audience %q contradicts type %q; working notes are a loop's private thinking — declare a maintained_document for anything a reader should see", OutputAudiencePublished, OutputTypeWorkingNotes)
 	}
 	if err := validateOutputTiers(o); err != nil {
 		return err
-	}
-	if o.MaxWindows < 0 {
-		return fmt.Errorf("max_windows must be >= 0")
 	}
 	return nil
 }
@@ -279,7 +257,7 @@ func validateOutputs(outputs []OutputSpec) error {
 			// journal can declare journal_document with
 			// audience: internal, which carries no such implicit target.
 			if workingNotes != "" {
-				return fmt.Errorf("outputs[%d]: loop already declares the working_notes output %q; a loop has one private log, so declare additional private journals as journal_document with audience: %q", i, workingNotes, OutputAudienceInternal)
+				return fmt.Errorf("outputs[%d]: loop already declares the working_notes output %q; a loop has one place for its current thinking, so put it all there — for an additional private document declare a maintained_document with audience: %q", i, workingNotes, OutputAudienceInternal)
 			}
 			workingNotes = output.Name
 		}

--- a/internal/runtime/loop/output.go
+++ b/internal/runtime/loop/output.go
@@ -253,8 +253,8 @@ func validateOutputs(outputs []OutputSpec) error {
 			// One private log per loop: the note argument on a tiered
 			// publish writes to "the" working notes, and a second
 			// declaration would make that target an arbitrary pick
-			// between two documents. A loop that wants another private
-			// journal can declare journal_document with
+			// between two documents. A loop that wants a second private
+			// document can declare a maintained_document with
 			// audience: internal, which carries no such implicit target.
 			if workingNotes != "" {
 				return fmt.Errorf("outputs[%d]: loop already declares the working_notes output %q; a loop has one place for its current thinking, so put it all there — for an additional private document declare a maintained_document with audience: %q", i, workingNotes, OutputAudienceInternal)

--- a/internal/runtime/loop/output_test.go
+++ b/internal/runtime/loop/output_test.go
@@ -23,25 +23,6 @@ func TestOutputSpecValidateAndToolName(t *testing.T) {
 			wantTool: "replace_output_metacognitive_state",
 		},
 		{
-			name: "journal document defaults append",
-			output: OutputSpec{
-				Name: "service-journal",
-				Type: OutputTypeJournalDocument,
-				Ref:  "core:service-journal.md",
-			},
-			wantTool: "append_output_service_journal",
-		},
-		{
-			name: "invalid mode for type",
-			output: OutputSpec{
-				Name: "state",
-				Type: OutputTypeMaintainedDocument,
-				Ref:  "core:state.md",
-				Mode: OutputModeAppend,
-			},
-			wantErr: true,
-		},
-		{
 			name: "missing ref",
 			output: OutputSpec{
 				Name: "state",
@@ -98,16 +79,6 @@ func TestOutputSpecValidateAndToolName(t *testing.T) {
 			wantTool: "replace_output_ranch_notes",
 		},
 		{
-			name: "working notes reject append mode",
-			output: OutputSpec{
-				Name: "ranch notes",
-				Type: OutputTypeWorkingNotes,
-				Ref:  "core:ranch-notes.md",
-				Mode: OutputModeAppend,
-			},
-			wantErr: true,
-		},
-		{
 			name: "working notes rejects published audience",
 			output: OutputSpec{
 				Name:     "ranch notes",
@@ -116,16 +87,6 @@ func TestOutputSpecValidateAndToolName(t *testing.T) {
 				Audience: OutputAudiencePublished,
 			},
 			wantErr: true,
-		},
-		{
-			name: "journal accepts explicit internal audience",
-			output: OutputSpec{
-				Name:     "private journal",
-				Type:     OutputTypeJournalDocument,
-				Ref:      "core:private-journal.md",
-				Audience: OutputAudienceInternal,
-			},
-			wantTool: "append_output_private_journal",
 		},
 		{
 			name: "unknown audience rejected",
@@ -188,16 +149,6 @@ func TestOutputSpecValidateAndToolName(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "tiers on journal rejected",
-			output: OutputSpec{
-				Name:  "service journal",
-				Type:  OutputTypeJournalDocument,
-				Ref:   "core:service-journal.md",
-				Tiers: []OutputTier{OutputTierStatusLine},
-			},
-			wantErr: true,
-		},
-		{
 			name: "tiers on working notes rejected",
 			output: OutputSpec{
 				Name:  "ranch notes",
@@ -251,18 +202,8 @@ func TestOutputSpecEffectiveAudience(t *testing.T) {
 			want:   OutputAudiencePublished,
 		},
 		{
-			name:   "journal defaults published",
-			output: OutputSpec{Type: OutputTypeJournalDocument},
-			want:   OutputAudiencePublished,
-		},
-		{
 			name:   "working notes default internal",
 			output: OutputSpec{Type: OutputTypeWorkingNotes},
-			want:   OutputAudienceInternal,
-		},
-		{
-			name:   "explicit audience wins",
-			output: OutputSpec{Type: OutputTypeJournalDocument, Audience: OutputAudienceInternal},
 			want:   OutputAudienceInternal,
 		},
 	}

--- a/internal/runtime/loop/output_tiers_test.go
+++ b/internal/runtime/loop/output_tiers_test.go
@@ -285,15 +285,15 @@ func TestValidateOutputsRejectsSecondWorkingNotes(t *testing.T) {
 	if err == nil {
 		t.Fatal("ValidatePersistable() error = nil for two working_notes outputs, want error")
 	}
-	if !strings.Contains(err.Error(), "one private log") {
-		t.Fatalf("error = %v, want it to explain the single-log rule", err)
+	if !strings.Contains(err.Error(), "one place for its current thinking") {
+		t.Fatalf("error = %v, want it to explain the single-notes rule", err)
 	}
 
 	// The escape hatch the error names must actually validate.
 	spec.Outputs[1] = OutputSpec{
-		Name:     "shop journal",
-		Type:     OutputTypeJournalDocument,
-		Ref:      "core:shop-journal.md",
+		Name:     "shop log",
+		Type:     OutputTypeMaintainedDocument,
+		Ref:      "core:shop-log.md",
 		Audience: OutputAudienceInternal,
 	}
 	if err := spec.ValidatePersistable(); err != nil {

--- a/internal/tools/loop_create_dryrun_test.go
+++ b/internal/tools/loop_create_dryrun_test.go
@@ -25,7 +25,6 @@ func TestThaneLoopCreateDryRunWritesNothing(t *testing.T) {
 		"sleep_min": "10m",
 		"sleep_max": "30m",
 		"output": map[string]any{
-			"mode":     "maintain",
 			"document": "kb:dashboards/dry-run-probe.md",
 		},
 		"dry_run": true,

--- a/internal/tools/loop_create_fluency_test.go
+++ b/internal/tools/loop_create_fluency_test.go
@@ -48,7 +48,7 @@ func curateArgs(extra map[string]any) map[string]any {
 		"sleep_min": "10m",
 		"sleep_max": "30m",
 	}
-	output := map[string]any{"mode": "maintain", "document": "kb:dashboards/closet.md"}
+	output := map[string]any{"document": "kb:dashboards/closet.md"}
 	for k, v := range extra {
 		output[k] = v
 	}
@@ -165,36 +165,20 @@ func TestGuidedCreateTierInputShapes(t *testing.T) {
 	})
 }
 
-// TestGuidedCreateRefusesTiersOnJournal keeps the two document shapes
-// distinct: a journal appends dated entries and has no current state to
-// project.
-func TestGuidedCreateRefusesTiersOnJournal(t *testing.T) {
-	rig := newCurateTestRig(t)
-	args := curateArgs(map[string]any{"mode": "journal", "tiers": []any{"status_line"}})
-	args["dry_run"] = true
-	if _, err := rig.tool.Handler(context.Background(), args); err == nil {
-		t.Fatal("tiers on a journal output should be refused")
-	}
-}
-
 // TestGuidedCreateAlwaysDerivesNotes pins that the notes surface is not
 // a choice. An opt-in every caller should take is a default in the wrong
 // position, and the cost of an unused one is a single context-block line
 // — nothing is scaffolded until the loop writes to it.
 func TestGuidedCreateAlwaysDerivesNotes(t *testing.T) {
-	for _, mode := range []string{"maintain", "journal"} {
-		t.Run(mode, func(t *testing.T) {
-			spec, result := dryRunSpec(t, curateArgs(map[string]any{"mode": mode}))
-			if len(spec.Outputs) != 2 {
-				t.Fatalf("outputs = %d, want the document plus its notes", len(spec.Outputs))
-			}
-			if spec.Outputs[1].Type != looppkg.OutputTypeWorkingNotes {
-				t.Errorf("second output = %q, want working_notes", spec.Outputs[1].Type)
-			}
-			if result["working_notes_document"] == nil {
-				t.Error("the derived notes document must be reported, not silently created")
-			}
-		})
+	spec, result := dryRunSpec(t, curateArgs(nil))
+	if len(spec.Outputs) != 2 {
+		t.Fatalf("outputs = %d, want the document plus its notes", len(spec.Outputs))
+	}
+	if spec.Outputs[1].Type != looppkg.OutputTypeWorkingNotes {
+		t.Errorf("second output = %q, want working_notes", spec.Outputs[1].Type)
+	}
+	if result["working_notes_document"] == nil {
+		t.Error("the derived notes document must be reported, not silently created")
 	}
 }
 

--- a/internal/tools/loop_create_tool.go
+++ b/internal/tools/loop_create_tool.go
@@ -175,7 +175,6 @@ type executingLoopPlan struct {
 	replace     bool
 	hasOutput   bool
 	documentRef string
-	outputMode  string
 	title       string
 	outputTool  string
 	notesRef    string
@@ -229,7 +228,6 @@ func (r *Registry) planExecutingLoop(args map[string]any, name, intent string, o
 		outputs     []looppkg.OutputSpec
 		outputSpec  looppkg.OutputSpec
 		documentRef string
-		outputMode  string
 		title       string
 		hasOutput   bool
 		tiers       []looppkg.OutputTier
@@ -237,11 +235,7 @@ func (r *Registry) planExecutingLoop(args map[string]any, name, intent string, o
 	)
 	if raw, ok := args["output"].(map[string]any); ok && raw != nil {
 		hasOutput = true
-		outputMode, _ = raw["mode"].(string)
 		documentRef, _ = raw["document"].(string)
-		if outputMode != "journal" && outputMode != "maintain" {
-			return nil, fmt.Errorf("output.mode must be \"journal\" or \"maintain\"")
-		}
 		if strings.TrimSpace(documentRef) == "" {
 			return nil, fmt.Errorf("output.document is required when output is set (e.g. \"kb:dashboards/foo.md\")")
 		}
@@ -256,10 +250,7 @@ func (r *Registry) planExecutingLoop(args map[string]any, name, intent string, o
 		if err != nil {
 			return nil, err
 		}
-		if len(tiers) > 0 && outputMode != "maintain" {
-			return nil, fmt.Errorf("output.tiers apply to a maintained document; got mode %q", outputMode)
-		}
-		outputSpec = buildCurateOutputSpec(name, documentRef, outputMode, intent, tiers)
+		outputSpec = buildCurateOutputSpec(name, documentRef, intent, tiers)
 		outputs = []looppkg.OutputSpec{outputSpec}
 
 		// Every document-owning loop gets a notes surface. It is not a
@@ -284,7 +275,7 @@ func (r *Registry) planExecutingLoop(args map[string]any, name, intent string, o
 
 	task := intent
 	if hasOutput {
-		task = buildCurateTask(intent, documentRef, outputMode, outputSpec.ToolName(), len(tiers) > 0)
+		task = buildCurateTask(intent, documentRef, outputSpec.ToolName(), len(tiers) > 0)
 	}
 
 	now := time.Now().UTC()
@@ -324,7 +315,6 @@ func (r *Registry) planExecutingLoop(args map[string]any, name, intent string, o
 		replace:     replace,
 		hasOutput:   hasOutput,
 		documentRef: documentRef,
-		outputMode:  outputMode,
 		title:       title,
 		outputTool:  outputSpec.ToolName(),
 		notesRef:    notesRef,
@@ -366,7 +356,7 @@ func (r *Registry) createLoopExecuting(ctx context.Context, args map[string]any,
 		return ldMarshalToolJSON(result)
 	}
 
-	hasOutput, documentRef, outputMode, title := plan.hasOutput, plan.documentRef, plan.outputMode, plan.title
+	hasOutput, documentRef, title := plan.hasOutput, plan.documentRef, plan.title
 	replace, warnings, envelope, now := plan.replace, plan.warnings, plan.envelope, plan.createdAt
 	entityCount, outputTool := plan.entityCount, plan.outputTool
 	parentName, tags := spec.ParentName, spec.Tags
@@ -384,11 +374,10 @@ func (r *Registry) createLoopExecuting(ctx context.Context, args map[string]any,
 				return "", fmt.Errorf("derived working-notes document %q already exists; pass replace=true, or use loop_definition_set to place the notes elsewhere", plan.notesRef)
 			}
 		}
-		body := renderScaffoldBody(outputMode, title, intent)
+		body := renderScaffoldBody(title, intent)
 		frontmatter := map[string][]string{
 			"loop_definition_name": {name},
 			"loop_intent":          {intent},
-			"output_mode":          {outputMode},
 			"created":              {now.Format(time.RFC3339)},
 		}
 		if op == looppkg.OperationService {
@@ -425,7 +414,6 @@ func (r *Registry) createLoopExecuting(ctx context.Context, args map[string]any,
 	}
 	if hasOutput {
 		result["document_path"] = documentRef
-		result["output_mode"] = outputMode
 		result["output_tool"] = outputTool
 		if plan.notesRef != "" {
 			result["working_notes_document"] = plan.notesRef
@@ -602,11 +590,6 @@ func thaneLoopCreateSchema() map[string]any {
 				"type":        "object",
 				"description": "Optional managed document this loop maintains (service/event_driven only). Scaffolded with ownership frontmatter before launch.",
 				"properties": map[string]any{
-					"mode": map[string]any{
-						"type":        "string",
-						"enum":        []string{"journal", "maintain"},
-						"description": "journal = append a dated entry each cycle; maintain = idempotent rewrite each cycle.",
-					},
 					"document": map[string]any{
 						"type":        "string",
 						"description": "Managed-root document ref, e.g. \"kb:dashboards/pr-watchlist.md\" or \"core:journal/decisions.md\".",

--- a/internal/tools/loop_create_tool.go
+++ b/internal/tools/loop_create_tool.go
@@ -31,7 +31,7 @@ func (r *Registry) registerThaneLoopCreate() {
 			"\"service\" = a recurring loop that self-paces within a sleep envelope (requires sleep_min and sleep_max); " +
 			"\"event_driven\" = a quiescent handler with no timer that runs only when an external trigger wakes it — give it an entity subscription with wake: true (wakes on that entity's changes), point a feed/forge subscription or an MQTT wake at it, or have another loop notify it; without at least one trigger it never runs; " +
 			"\"container\" = a non-executing node that groups loops and shares its tags with descendants; like every operation it requires intent, takes the optional parent_name and tags, and rejects execution/output fields (sleep knobs, output, entities, instructions, etc.). " +
-			"output (service/event_driven only) declares a managed markdown document the loop maintains — \"journal\" appends a dated entry each cycle, \"maintain\" rewrites it idempotently, and a maintain output that declares tiers publishes condensed projections alongside the body instead — and is scaffolded with ownership frontmatter before launch; omit it for a loop that acts without maintaining a document. " +
+			"output (service/event_driven only) declares a managed markdown document the loop maintains, rewriting it each cycle to reflect current state; declaring tiers publishes condensed projections alongside the body instead. It is scaffolded with ownership frontmatter before launch, and comes with a private working-notes document for the loop's own thinking. Omit it for a loop that acts without maintaining a document. " +
 			"parent_name nests the loop under a container by name, inheriting its tags and subscriptions. " +
 			"entities are Home Assistant subscriptions surfaced into the loop's context each iteration; an entry with wake: true ALSO wakes the loop when that entity changes (debounced/coalesced) — for a service loop an early wake, for an event_driven loop a primary trigger. " +
 			"Returns the loop definition name, loop_id, and the canonical loop row; plus output_tool/document_path when a document was declared, tiers when it declared any, and working_notes_document — every document-owning loop is given a private notes surface beside its document, so its reasoning has somewhere to go that is not what it publishes. If the loop lands at the root but an existing container declares tags it shares, the result also carries a non-blocking placement_advisory suggesting where it might nest (see loop_containers).",
@@ -601,10 +601,10 @@ func thaneLoopCreateSchema() map[string]any {
 					"tiers": map[string]any{
 						"type":        "array",
 						"items":       map[string]any{"type": "string", "enum": []string{"status_line", "teaser", "digest"}},
-						"description": "maintain mode only. Publish condensed projections alongside the full body, so each consumer takes the length it can afford — an ambient row takes status_line, a search snippet takes teaser, a digest row takes digest. Declaring these swaps the loop's generated tool from replace_output_* to publish_output_*, which takes one argument per projection. Declare them whenever anything other than this loop will read the document.",
+						"description": "Publish condensed projections alongside the full body, so each consumer takes the length it can afford — an ambient row takes status_line, a search snippet takes teaser, a digest row takes digest. Declaring these swaps the loop's generated tool from replace_output_* to publish_output_*, which takes one argument per projection. Declare them whenever anything other than this loop will read the document.",
 					},
 				},
-				"required": []string{"mode", "document"},
+				"required": []string{"document"},
 			},
 			"entities": map[string]any{
 				"type":        "array",

--- a/internal/tools/loop_intent_tools.go
+++ b/internal/tools/loop_intent_tools.go
@@ -346,22 +346,15 @@ func coerceInt(v any) (int, error) {
 // and injects current-document context into each iteration prompt — so
 // the model gets a typed write surface and "what's already there?"
 // answered without re-reading the doc itself.
-func buildCurateOutputSpec(name, docRef, outputMode, intent string, tiers []looppkg.OutputTier) looppkg.OutputSpec {
-	out := looppkg.OutputSpec{
+func buildCurateOutputSpec(name, docRef, intent string, tiers []looppkg.OutputTier) looppkg.OutputSpec {
+	return looppkg.OutputSpec{
 		Name:    name,
 		Ref:     docRef,
 		Purpose: intent,
 		Tiers:   tiers,
+		Type:    looppkg.OutputTypeMaintainedDocument,
+		Mode:    looppkg.OutputModeReplace,
 	}
-	switch outputMode {
-	case "journal":
-		out.Type = looppkg.OutputTypeJournalDocument
-		out.Mode = looppkg.OutputModeAppend
-	case "maintain":
-		out.Type = looppkg.OutputTypeMaintainedDocument
-		out.Mode = looppkg.OutputModeReplace
-	}
-	return out
 }
 
 // buildCurateTask renders the per-iteration task prompt for a
@@ -373,17 +366,10 @@ func buildCurateOutputSpec(name, docRef, outputMode, intent string, tiers []loop
 // construction (see [loop.Loop.buildTaskTurn]), so it doesn't appear
 // here. Kept short and shape-clear so the model can act without
 // re-reading the loop's own definition.
-func buildCurateTask(intent, docRef, outputMode, outputToolName string, tiered bool) string {
-	var verb string
-	switch {
-	case outputMode == "journal":
-		verb = "Append a dated entry to"
-	case tiered:
+func buildCurateTask(intent, docRef, outputToolName string, tiered bool) string {
+	verb := "Update the body of"
+	if tiered {
 		verb = "Publish the current state of"
-	case outputMode == "maintain":
-		verb = "Update the body of"
-	default:
-		verb = "Update"
 	}
 	var sb strings.Builder
 	sb.WriteString(intent)
@@ -394,41 +380,24 @@ func buildCurateTask(intent, docRef, outputMode, outputToolName string, tiered b
 	sb.WriteString(". Write through the declared output tool ")
 	sb.WriteString(outputToolName)
 	sb.WriteString(". ")
-	switch outputMode {
-	case "journal":
-		// Append-only: the recent tail in the context block is enough; the
-		// model never needs the full history to write a new entry.
-		sb.WriteString("Recent entries are surfaced in the Declared Durable Outputs context block above; no separate read is needed before appending.")
-	case "maintain":
-		// Complete-replacement: the context block shows the document head,
-		// possibly truncated at 16 KiB (see loopOutputContentBytes in
-		// app.loop_outputs). The model MUST notice the `truncated` flag and
-		// read the full document before replacing, or it will silently drop
-		// everything past the truncation boundary.
-		sb.WriteString("The current document body is shown in the Declared Durable Outputs context block above. If that entry is marked `truncated: true`, read the full document with doc_read before replacing — the output tool overwrites the entire body.")
-	default:
-		sb.WriteString("The document's current contents are surfaced in the Declared Durable Outputs context block above.")
-	}
+	// Complete-replacement: the context block shows the document head,
+	// possibly truncated at 16 KiB (see loopOutputContentBytes in
+	// app.loop_outputs). The model MUST notice the `truncated` flag and
+	// read the full document before replacing, or it will silently drop
+	// everything past the truncation boundary.
+	sb.WriteString("The current document body is shown in the Declared Durable Outputs context block above. If that entry is marked `truncated: true`, read the full document with doc_read before replacing — the output tool overwrites the entire body.")
 	return sb.String()
 }
 
 // renderScaffoldBody returns the initial markdown body for the output
-// document. Two templates today (journal, maintain); the Phase 2/3
-// rollout will add investigation, digest, and freeform.
-func renderScaffoldBody(outputMode, title, intent string) string {
+// document.
+func renderScaffoldBody(title, intent string) string {
 	var sb strings.Builder
 	fmt.Fprintf(&sb, "# %s\n\n", title)
 	fmt.Fprintf(&sb, "*%s*\n\n", intent)
-	switch outputMode {
-	case "journal":
-		sb.WriteString("*This document is maintained by a service loop. Each cycle appends a dated entry below.*\n\n")
-		sb.WriteString("## Entries\n\n")
-		sb.WriteString("_(awaiting first cycle)_\n")
-	case "maintain":
-		sb.WriteString("*This document is maintained by a service loop. Each cycle rewrites the body to reflect the current snapshot.*\n\n")
-		sb.WriteString("## Current State\n\n")
-		sb.WriteString("_(awaiting first cycle)_\n")
-	}
+	sb.WriteString("*This document is maintained by a service loop. Each cycle rewrites the body to reflect the current snapshot.*\n\n")
+	sb.WriteString("## Current State\n\n")
+	sb.WriteString("_(awaiting first cycle)_\n")
 	return sb.String()
 }
 

--- a/internal/tools/loop_intent_tools.go
+++ b/internal/tools/loop_intent_tools.go
@@ -342,7 +342,8 @@ func coerceInt(v any) (int, error) {
 
 // buildCurateOutputSpec converts the intent-shaped output argument into
 // a declared OutputSpec on the loop. Once declared, the hydration layer
-// generates a scoped mutation tool (replace_output_* / append_output_*)
+// generates a scoped mutation tool (replace_output_*, or publish_output_*
+// when the output declares tiers)
 // and injects current-document context into each iteration prompt — so
 // the model gets a typed write surface and "what's already there?"
 // answered without re-reading the doc itself.

--- a/internal/tools/loop_intent_tools_test.go
+++ b/internal/tools/loop_intent_tools_test.go
@@ -193,7 +193,7 @@ func TestThaneCurate_RejectsInvalidKnobs(t *testing.T) {
 		return map[string]any{
 			"name": "knob_test", "intent": "track stuff", "operation": "service",
 			"sleep_min": "5m", "sleep_max": "30m",
-			"output": map[string]any{"mode": "maintain", "document": "kb:knob.md"},
+			"output": map[string]any{"document": "kb:knob.md"},
 		}
 	}
 	cases := []struct {
@@ -278,7 +278,6 @@ func TestThaneCurate_EndToEnd(t *testing.T) {
 		"sleep_min": "54m",
 		"sleep_max": "66m",
 		"output": map[string]any{
-			"mode":     "maintain",
 			"document": "kb:dashboards/pr-watchlist.md",
 			"title":    "PR Watchlist",
 		},
@@ -304,9 +303,6 @@ func TestThaneCurate_EndToEnd(t *testing.T) {
 	}
 	if resp["loop_definition_name"] != "test_pr_watchlist" {
 		t.Errorf("loop_definition_name = %v, want test_pr_watchlist", resp["loop_definition_name"])
-	}
-	if resp["output_mode"] != "maintain" {
-		t.Errorf("output_mode = %v, want maintain", resp["output_mode"])
 	}
 	if resp["output_tool"] != "replace_output_test_pr_watchlist" {
 		t.Errorf("output_tool = %v, want replace_output_test_pr_watchlist", resp["output_tool"])
@@ -446,9 +442,6 @@ func TestThaneCurate_EndToEnd(t *testing.T) {
 	if !strings.Contains(doc, "test_pr_watchlist") {
 		t.Errorf("scaffold missing loop name in frontmatter:\n%s", doc)
 	}
-	if !strings.Contains(doc, "output_mode") {
-		t.Errorf("scaffold missing output_mode frontmatter:\n%s", doc)
-	}
 	rawDoc, err := os.ReadFile(filepath.Join(kbDir, "dashboards", "pr-watchlist.md"))
 	if err != nil {
 		t.Fatalf("read raw scaffold doc: %v", err)
@@ -522,7 +515,6 @@ func TestThaneCurate_RefusesToClobber(t *testing.T) {
 		"sleep_min": "54m",
 		"sleep_max": "66m",
 		"output": map[string]any{
-			"mode":     "journal",
 			"document": "kb:journal/existing.md",
 		},
 	})
@@ -594,7 +586,6 @@ func TestThaneCurate_RefusesToClobberDocument(t *testing.T) {
 		"sleep_min": "54m",
 		"sleep_max": "66m",
 		"output": map[string]any{
-			"mode":     "maintain",
 			"document": "kb:notes/existing.md",
 		},
 	})
@@ -612,100 +603,6 @@ func TestThaneCurate_RefusesToClobberDocument(t *testing.T) {
 	}
 	if !strings.Contains(doc, "Do not overwrite") {
 		t.Errorf("pre-existing document was modified despite refusal:\n%s", doc)
-	}
-}
-
-// TestThaneCurate_JournalDeclaresAppendOutput verifies that journal-mode
-// loops carry a journal_document OutputSpec with append mode, so the
-// hydration layer generates an append_output_* scoped tool instead of
-// the replace_output_* tool used by maintain-mode loops.
-func TestThaneCurate_JournalDeclaresAppendOutput(t *testing.T) {
-	t.Parallel()
-
-	tempDir := t.TempDir()
-	kbDir := filepath.Join(tempDir, "kb")
-	if err := mkdirAllForTest(kbDir); err != nil {
-		t.Fatalf("mkdir kb: %v", err)
-	}
-	db, err := database.OpenMemory()
-	if err != nil {
-		t.Fatalf("open memory db: %v", err)
-	}
-	t.Cleanup(func() { _ = db.Close() })
-
-	docStore, err := documents.NewStore(db, map[string]string{"kb": kbDir}, nil)
-	if err != nil {
-		t.Fatalf("documents.NewStore: %v", err)
-	}
-	docTools := documents.NewTools(docStore)
-
-	defRegistry, err := looppkg.NewDefinitionRegistry(nil)
-	if err != nil {
-		t.Fatalf("NewDefinitionRegistry: %v", err)
-	}
-	reg := NewEmptyRegistry()
-	reg.ConfigureLoopIntentTools(LoopIntentToolDeps{
-		DocTools:    docTools,
-		Registry:    defRegistry,
-		PersistSpec: func(_ looppkg.Spec, _ time.Time) error { return nil },
-		CommitSpec:  upsertCommitSpec(defRegistry),
-		LaunchDefinition: func(_ context.Context, _ string, _ looppkg.Launch) (looppkg.LaunchResult, error) {
-			return looppkg.LaunchResult{LoopID: "loop-journal-1"}, nil
-		},
-	})
-
-	tool := reg.Get("thane_loop_create")
-	if _, err := tool.Handler(context.Background(), map[string]any{
-		"name":      "release_journal",
-		"intent":    "Capture forge releases as a dated log.",
-		"operation": "service",
-		"sleep_min": "54m",
-		"sleep_max": "66m",
-		"output": map[string]any{
-			"mode":     "journal",
-			"document": "kb:journal/releases.md",
-		},
-	}); err != nil {
-		t.Fatalf("thane_loop_create handler: %v", err)
-	}
-
-	snap := defRegistry.Snapshot()
-	var found *looppkg.DefinitionSnapshot
-	for i := range snap.Definitions {
-		if snap.Definitions[i].Spec.Name == "release_journal" {
-			found = &snap.Definitions[i]
-			break
-		}
-	}
-	if found == nil {
-		t.Fatal("definition not registered")
-	}
-	if len(found.Spec.Outputs) != 2 {
-		t.Fatalf("Outputs len = %d, want 2 (the journal plus its notes)", len(found.Spec.Outputs))
-	}
-	out := found.Spec.Outputs[0]
-	if out.Type != looppkg.OutputTypeJournalDocument {
-		t.Errorf("Type = %q, want journal_document", out.Type)
-	}
-	if out.Mode != looppkg.OutputModeAppend {
-		t.Errorf("Mode = %q, want append", out.Mode)
-	}
-	if got, want := out.ToolName(), "append_output_release_journal"; got != want {
-		t.Errorf("ToolName = %q, want %q", got, want)
-	}
-	if !strings.Contains(found.Spec.Task, "append_output_release_journal") {
-		t.Errorf("task prompt should reference scoped output tool, got: %s", found.Spec.Task)
-	}
-	// Journal mode is append-only: the recent tail in the context block
-	// is enough, so the prompt should explicitly say no separate read is
-	// needed before appending.
-	if !strings.Contains(found.Spec.Task, "no separate read") {
-		t.Errorf("journal-mode task prompt should reassure no read needed, got: %s", found.Spec.Task)
-	}
-	// Conversely, journal mode must NOT carry the maintain-mode truncation
-	// warning — appending doesn't need the full history.
-	if strings.Contains(found.Spec.Task, "truncated") {
-		t.Errorf("journal-mode task prompt should not carry maintain-mode truncation warning, got: %s", found.Spec.Task)
 	}
 }
 
@@ -764,7 +661,6 @@ func TestThaneCurate_InstructionsFlowToProfile(t *testing.T) {
 		"sleep_max":    "30m",
 		"instructions": "  " + steering + "  ", // whitespace trimmed
 		"output": map[string]any{
-			"mode":     "maintain",
 			"document": "kb:dashboards/rack.md",
 		},
 	}); err != nil {
@@ -840,7 +736,6 @@ func TestThaneCurate_InstructionsOmitted(t *testing.T) {
 		"sleep_min": "5m",
 		"sleep_max": "30m",
 		"output": map[string]any{
-			"mode":     "maintain",
 			"document": "kb:dashboards/no-inst.md",
 		},
 	}); err != nil {
@@ -944,7 +839,6 @@ func TestThaneCurate_PersistsSubscriptions(t *testing.T) {
 		"sleep_min": "21h",
 		"sleep_max": "27h",
 		"output": map[string]any{
-			"mode":     "journal",
 			"document": "kb:home/hvac.md",
 		},
 		"entities": []any{
@@ -1011,7 +905,6 @@ func TestThaneCurate_ReplaceOverwritesSubscriptions(t *testing.T) {
 			"sleep_min": "21h",
 			"sleep_max": "27h",
 			"output": map[string]any{
-				"mode":     "journal",
 				"document": "kb:home/hvac.md",
 			},
 		}
@@ -1067,7 +960,6 @@ func TestThaneCurate_RejectsDuplicateEntityID(t *testing.T) {
 		"sleep_min": "54m",
 		"sleep_max": "66m",
 		"output": map[string]any{
-			"mode":     "journal",
 			"document": "kb:dup.md",
 		},
 		"entities": []any{
@@ -1100,7 +992,6 @@ func TestThaneCurate_RejectsFractionalInteger(t *testing.T) {
 		"sleep_min": "54m",
 		"sleep_max": "66m",
 		"output": map[string]any{
-			"mode":     "journal",
 			"document": "kb:frac.md",
 		},
 		"entities": []any{
@@ -1126,7 +1017,6 @@ func TestThaneCurate_RejectsFractionalInteger(t *testing.T) {
 		"sleep_min": "54m",
 		"sleep_max": "66m",
 		"output": map[string]any{
-			"mode":     "journal",
 			"document": "kb:whole.md",
 		},
 		"entities": []any{

--- a/internal/tools/loop_spec_schema.go
+++ b/internal/tools/loop_spec_schema.go
@@ -186,7 +186,7 @@ func loopOutputSpecSchema() map[string]any {
 				"description": "Who may see this output's content. published (default) allows projection into search results, context injection, and ambient surfaces; internal keeps it to this loop's own context and explicit reads by ref. working_notes outputs are internal automatically. Internal is context hygiene, not secrecy: operators and the archive still see the document.",
 			},
 			"ref":     map[string]any{"type": "string", "description": "Managed document ref, e.g. \"core:metacognitive.md\" or \"kb:dashboards/x.md\". Stored verbatim — not resolved to content."},
-			"mode":    map[string]any{"type": "string", "enum": []string{"replace", "append"}, "description": "Write mode; defaults from type when omitted (maintained→replace, journal and working_notes→append). A tiered maintained_document publishes projections instead, so leave this unset there."},
+			"mode":    map[string]any{"type": "string", "enum": []string{"replace"}, "description": "Write mode. Both output types are rewritten each cycle, so this defaults correctly when omitted and there is no reason to set it. A tiered maintained_document publishes projections instead."},
 			"purpose": map[string]any{"type": "string", "description": "Optional model-facing guidance describing what this output is for."},
 		},
 	}

--- a/internal/tools/loop_spec_schema.go
+++ b/internal/tools/loop_spec_schema.go
@@ -174,7 +174,7 @@ func loopOutputSpecSchema() map[string]any {
 		"type": "object",
 		"properties": map[string]any{
 			"name": map[string]any{"type": "string", "description": "Stable semantic name for this output within the loop."},
-			"type": map[string]any{"type": "string", "enum": []string{"maintained_document", "journal_document", "working_notes"}, "description": "maintained_document = idempotent rewrite each cycle; journal_document = append-only dated entries; working_notes = this loop's private process log, append-only and never projected into any consumer surface (use it for how the understanding is evolving — drift, refinement, the reasoning behind a change)."},
+			"type": map[string]any{"type": "string", "enum": []string{"maintained_document", "working_notes"}, "description": "maintained_document = the loop rewrites it each cycle to reflect current state; working_notes = the same, but private — the loop's current thinking, never projected into search, context, or any other consumer surface. Use working_notes for working theories, what an experiment is showing, and what you expect next; use a maintained_document for what a reader should see. For an append-only dated record, journal a document directly with the doc tools rather than declaring it as an output."},
 			"tiers": map[string]any{
 				"type":        "array",
 				"items":       map[string]any{"type": "string", "enum": []string{"status_line", "teaser", "digest"}},
@@ -185,11 +185,9 @@ func loopOutputSpecSchema() map[string]any {
 				"enum":        []string{"published", "internal"},
 				"description": "Who may see this output's content. published (default) allows projection into search results, context injection, and ambient surfaces; internal keeps it to this loop's own context and explicit reads by ref. working_notes outputs are internal automatically. Internal is context hygiene, not secrecy: operators and the archive still see the document.",
 			},
-			"ref":            map[string]any{"type": "string", "description": "Managed document ref, e.g. \"core:metacognitive.md\" or \"kb:dashboards/x.md\". Stored verbatim — not resolved to content."},
-			"mode":           map[string]any{"type": "string", "enum": []string{"replace", "append"}, "description": "Write mode; defaults from type when omitted (maintained→replace, journal and working_notes→append). A tiered maintained_document publishes projections instead, so leave this unset there."},
-			"purpose":        map[string]any{"type": "string", "description": "Optional model-facing guidance describing what this output is for."},
-			"journal_window": map[string]any{"type": "string", "enum": []string{"day", "week", "month"}, "description": "Rolling window for append-mode outputs (journal_document and working_notes); empty uses the document-layer default."},
-			"max_windows":    map[string]any{"type": "integer", "description": "Cap on retained windows for append-mode outputs; 0 uses the document-layer default. Windows beyond the cap are pruned from the document — the archive and the root's revision history keep them."},
+			"ref":     map[string]any{"type": "string", "description": "Managed document ref, e.g. \"core:metacognitive.md\" or \"kb:dashboards/x.md\". Stored verbatim — not resolved to content."},
+			"mode":    map[string]any{"type": "string", "enum": []string{"replace", "append"}, "description": "Write mode; defaults from type when omitted (maintained→replace, journal and working_notes→append). A tiered maintained_document publishes projections instead, so leave this unset there."},
+			"purpose": map[string]any{"type": "string", "description": "Optional model-facing guidance describing what this output is for."},
 		},
 	}
 }

--- a/internal/tools/loop_spec_schema_parity_test.go
+++ b/internal/tools/loop_spec_schema_parity_test.go
@@ -144,3 +144,44 @@ func TestSpecFieldsNotOfferedStayReal(t *testing.T) {
 		}
 	}
 }
+
+// TestSchemasRequireOnlyDefinedProperties catches the half-removal that
+// prompted it: `mode` was deleted from thane_loop_create's output object
+// and left in its `required` list, so a schema-aware caller had to send
+// a field the schema did not define or fail validation — no answer was
+// correct. A required key with no property is internally inconsistent
+// and mechanically checkable, which makes it the reviewer's job only
+// until it is a test's.
+func TestSchemasRequireOnlyDefinedProperties(t *testing.T) {
+	for name, schema := range map[string]map[string]any{
+		"loopSpecSchema":        loopSpecSchema("parity"),
+		"thaneLoopCreateSchema": thaneLoopCreateSchema(),
+	} {
+		t.Run(name, func(t *testing.T) {
+			checkRequiredAreDefined(t, name, schema)
+		})
+	}
+}
+
+// checkRequiredAreDefined walks nested objects and array items, because
+// the offending list was two levels down inside output.
+func checkRequiredAreDefined(t *testing.T, path string, node map[string]any) {
+	t.Helper()
+
+	props, _ := node["properties"].(map[string]any)
+	if required, ok := node["required"].([]string); ok {
+		for _, key := range required {
+			if _, defined := props[key]; !defined {
+				t.Errorf("%s requires %q but defines no such property", path, key)
+			}
+		}
+	}
+	for key, child := range props {
+		if obj, ok := child.(map[string]any); ok {
+			checkRequiredAreDefined(t, path+"."+key, obj)
+			if items, ok := obj["items"].(map[string]any); ok {
+				checkRequiredAreDefined(t, path+"."+key+"[]", items)
+			}
+		}
+	}
+}

--- a/talents/loops-examples.md
+++ b/talents/loops-examples.md
@@ -59,32 +59,28 @@ name: loops_examples_curate
 tags: [loops_examples_curate]
 kind: trailhead
 teaser: "Recurring service loops that maintain a managed document over time."
-next_tags: [loops_examples_curate_dashboard, loops_examples_curate_journal, loops_examples_curate_circle]
+next_tags: [loops_examples_curate_dashboard, loops_examples_curate_circle]
 ---
 
 # Curate
 
 A service loop is self-paced and recurring. It may maintain a managed
 markdown document, but need not — omit outputs entirely for a service
-loop that just does recurring work. When it does own one, three
-questions decide the shape:
+loop that just does recurring work. A document-owning
+loop rewrites its document each cycle to reflect current state, and gets
+a private working-notes document alongside it for what it currently
+believes. Two questions decide the rest:
 
-1. **Does each cycle replace the document or append to it?**
-   - Replace (idempotent rewrite) → activate
-     `loops_examples_curate_dashboard`
-   - Append a dated entry → activate `loops_examples_curate_journal`
-
-2. **Will anyone else consult this?** A loop whose value is being read
+1. **Will anyone else consult this?** A loop whose value is being read
    by other turns, other loops, or an ambient surface should declare
    `tiers` so each reader takes the length it can afford. That needs the
    full spec: author it with `loop_definition_set` and start it with
    `loop_definition_launch`. A loop nobody reads but its owner can stay
    untiered on the shorter front door.
 
-3. **Does the loop need to escalate decisions to you, or accept new
+2. **Does the loop need to escalate decisions to you, or accept new
    focus when you adjust its scope?**
    - Yes (bi-directional) → activate `loops_examples_curate_circle`
-     after picking dashboard or journal
 
 ## The sleep envelope is the one judgment call
 
@@ -201,40 +197,6 @@ its reasoning are one call.
 
 Published projections carry current state, not the story of how it got
 there. Keeping those apart is what lets the document stay short.
-
----
-name: loops_examples_curate_journal
-tags: [loops_examples_curate_journal]
-kind: trailhead
-teaser: "Append a dated entry to a journal document each cycle."
----
-
-# Curate: Journal (journal mode)
-
-Use `mode: journal` when each cycle adds a *new entry* and prior
-entries are preserved. Research notes, decision logs, daily digests.
-The generated output tool is `append_output_<loop_name>` — it writes a
-new dated section without touching prior entries.
-
-```json
-{
-  "name": "burn_ban_monitor",
-  "intent": "Check the Comal County fire marshal site for the current burn ban status. Note any changes from the prior entry; otherwise note 'no change.'",
-  "operation": "service",
-  "sleep_min": "1h",
-  "sleep_max": "6h",
-  "output": {
-    "document": "kb:journals/burn-ban.md",
-    "mode": "journal",
-    "title": "Burn Ban Status Journal"
-  },
-  "tags": ["web"]
-}
-```
-
-Journal mode is right when continuity matters — you want to look back
-at the trail. Dashboard mode is right when only "right now" matters
-and yesterday's state is just noise.
 
 ---
 name: loops_examples_curate_circle

--- a/talents/loops.md
+++ b/talents/loops.md
@@ -12,8 +12,8 @@ A service loop's `sleep_min` and `sleep_max` set the envelope it
 self-paces inside. Its outputs declare what it owns — optional, since a
 service loop can act without maintaining a document — and when an output
 is declared the running loop writes through a generated tool named for
-it: `replace_output_*` for a whole-document rewrite, `append_output_*`
-for a journal entry, `publish_output_*` when the output declares tiers.
+it: `replace_output_*` for a whole-document rewrite, or
+`publish_output_*` when the output declares tiers.
 If a maintained output is marked `truncated` in Declared Durable
 Outputs, read the full document before replacing it.
 
@@ -47,21 +47,25 @@ Declare `status_line` for any tiered output; add `teaser` when the
 output is something others search or link to, and `digest` when a
 reader should be able to act without opening the document.
 
-## Where the reasoning goes
+## Where the thinking goes
 
-Published projections carry current state, not the story of how it got
-there. A curating loop should also declare a `working_notes` output: its
-private process log, append-only, invisible to every consumer surface —
-out of search results, out of other loops' context. Use it for how the
-understanding is evolving: what changed and why, what drifted, what was
-refined, what a future turn should know. Revision history already
-records *what* changed; working notes are for *why*.
+What a loop publishes is current state. What it *thinks* — working
+theories, what an experiment is showing so far, what it expects next,
+what it is unsure of and what would settle it — belongs in its
+`working_notes` output: a private document, invisible to every consumer
+surface, out of search results and out of other loops' context.
 
-The smooth path is the `note` argument on `publish_output_*`: publish
-the projections and record the reasoning in the same call, so the
-timeline accumulates as a side effect of the work instead of a chore.
-`append_output_*` on the notes output writes an entry on its own when
-there is something to record without a publish.
+Notes are rewritten, not accumulated. They hold what you believe now,
+not a record of what you used to believe, so carry forward what still
+holds and drop what you no longer think. A log of superseded theories is
+not a place to keep a theory: the next turn would have to reconstruct
+your present view by reading its own history, which is the difficulty
+these exist to remove.
+
+The smooth path is the `notes` argument on `publish_output_*`: publish
+the projections and restate your current thinking in the same call, so
+the two never drift apart. The notes output's own `replace_output_*`
+writes them when your thinking changes without a publish.
 
 Choose stream wiring by attention cost:
 


### PR DESCRIPTION
Step 2 of the plan amended onto #1250, revising **decision 4** — which deferred journals rather than removing them.

**496 deletions against 116 insertions.**

## Why they no longer earn a type

With git-backed document roots, `doc_history` and `doc_diff` read the same sequence with diffs and attribution. #1277 already retired the metacognitive iteration log on exactly that argument.

The honest counter was **context injection**: a journal's recent tail arrived in the loop's context every turn, where history costs tool calls and does not persist in the prompt. That was a real advantage, and it dissolved when working notes became a maintained document — a loop's current thinking is already in context, and the reason to accumulate dated entries went with it.

**Journaling itself is untouched.** The document layer keeps `JournalUpdate` and its windowing, so a loop that genuinely wants an append-only dated record journals a document directly. What goes is the second door: an output type that wrapped the same capability and made every declaration choose a mode.

## The mode choice goes with it

`thane_loop_create`'s `output` no longer takes `mode`. There was one answer left, and a field with a single valid value teaches nothing while still inviting a wrong guess. The task builder, the scaffold template, and the result payload lose their journal branches too — `output_mode` was reporting a constant.

`JournalWindow` and `MaxWindows` leave `OutputSpec`: they described a wrap only journals did.

The single-notes rule's escape hatch changed with them. It said *"declare a journal_document with audience: internal"*; it now points at a `maintained_document`, which is what it should have said the moment notes stopped being a journal.

## Production impact is one loop

`continuity_thread` declares a `journal_document`. Its stored spec will fail validation on load — **warned and skipped, not fatal**, by the safety net in `loop_definition_store` that exists for exactly this (#1068). It keeps running until the next restart, and the record stays persisted for repair.

Worth deciding before deploy rather than after: its intent is *"the part of her that holds the thread of the relationship while he's away, and gets to want to reach him first"*. That reads like working notes wearing a journal costume — but converting it to `working_notes` makes it **internal**, which changes who can see it. A `maintained_document` keeps its current audience and changes only how it accumulates. That is a product call, not a mechanical migration.

## Teaching

Model-facing first: `loops.md` gains a rewritten *Where the thinking goes* section, and `loops-examples.md` loses its journal node — which collapses the curate decision tree from three questions to two, since replace-or-append is no longer a question. Then the four operator docs that described `append_output_*`.

## Test plan

- [x] `just ci` green locally
- [x] Journal cases removed from the output validation tables rather than converted, since the shape they assert no longer exists
- [x] The single-notes escape hatch test now exercises the `maintained_document` it names, so the error and the test agree
- [x] `TestRepoTrailheadNextTagsResolve` still passes — the retired example node is gone from its parent's `next_tags`
- [x] `grep` confirms no `append_output` or `journal_document` reference survives in talents or docs
- [ ] Prod: decide `continuity_thread`'s new shape, then repair its stored spec

Amends decision 4 of #1250.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
