### PR TITLE
A bare string has nowhere to say what a face is made of

### DIFF
--- a/internal/app/loop_output_publish.go
+++ b/internal/app/loop_output_publish.go
@@ -34,7 +34,7 @@ func buildFacetPublishTool(store *documents.Store, output looppkg.OutputSpec, no
 	properties := make(map[string]any, len(fields)+1)
 	required := make([]string, 0, len(fields))
 	for _, field := range fields {
-		description := field.Guidance
+		description := field.Guidance + looppkg.FormatGuidance(field.Format)
 		if field.MaxRunes > 0 {
 			description = fmt.Sprintf("%s Maximum %d characters.", description, field.MaxRunes)
 		}

--- a/internal/app/loop_output_publish_test.go
+++ b/internal/app/loop_output_publish_test.go
@@ -24,7 +24,7 @@ func facetedSpec() looppkg.Spec {
 				Name:   "office status",
 				Type:   looppkg.OutputTypeMaintainedDocument,
 				Ref:    "core:office.md",
-				Facets: []looppkg.OutputFacet{looppkg.OutputFacetStatusLine, looppkg.OutputFacetTeaser},
+				Facets: []looppkg.FacetSpec{{Name: looppkg.OutputFacetStatusLine}, {Name: looppkg.OutputFacetTeaser}},
 			},
 			{
 				Name: "office notes",

--- a/internal/app/loop_outputs.go
+++ b/internal/app/loop_outputs.go
@@ -296,7 +296,7 @@ func cloneLoopOutputs(src []looppkg.OutputSpec) []looppkg.OutputSpec {
 	dst := make([]looppkg.OutputSpec, len(src))
 	copy(dst, src)
 	for i := range dst {
-		dst[i].Facets = append([]looppkg.OutputFacet(nil), src[i].Facets...)
+		dst[i].Facets = append([]looppkg.FacetSpec(nil), src[i].Facets...)
 	}
 	return dst
 }

--- a/internal/app/loop_outputs_test.go
+++ b/internal/app/loop_outputs_test.go
@@ -109,11 +109,11 @@ func TestCloneLoopOutputsDeepCopiesFacets(t *testing.T) {
 		Name:   "ranch status",
 		Type:   looppkg.OutputTypeMaintainedDocument,
 		Ref:    "kb:ranch.md",
-		Facets: []looppkg.OutputFacet{looppkg.OutputFacetStatusLine, looppkg.OutputFacetTeaser},
+		Facets: []looppkg.FacetSpec{{Name: looppkg.OutputFacetStatusLine}, {Name: looppkg.OutputFacetTeaser}},
 	}}
 	dst := cloneLoopOutputs(src)
-	dst[0].Facets[1] = looppkg.OutputFacetDigest
-	if src[0].Facets[1] != looppkg.OutputFacetTeaser {
+	dst[0].Facets[1] = looppkg.FacetSpec{Name: looppkg.OutputFacetDigest}
+	if src[0].Facets[1].Name != looppkg.OutputFacetTeaser {
 		t.Fatalf("cloneLoopOutputs shares Facets backing array: src mutated to %q", src[0].Facets[1])
 	}
 }

--- a/internal/runtime/loop/facet_spec.go
+++ b/internal/runtime/loop/facet_spec.go
@@ -1,0 +1,103 @@
+package loop
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// FacetFormat describes how a facet's value is encoded, which decides
+// what a surface can do with it.
+//
+// Format is a facet property rather than a binding one: it is part of
+// how the face is cut, not where it is mounted. A binding then checks
+// its own capacity against the facet's format and budget — an entity
+// state that holds 255 characters can carry a status_line and cannot
+// carry a digest — so a mismatch is refused where it is declared rather
+// than truncated where it is displayed.
+type FacetFormat string
+
+const (
+	// FacetFormatMarkdown is prose with structure. The default, and what
+	// a document section wants.
+	FacetFormatMarkdown FacetFormat = "markdown"
+	// FacetFormatPlain is prose with no markup, safe to speak aloud or
+	// drop into a surface that renders nothing.
+	FacetFormatPlain FacetFormat = "plain"
+	// FacetFormatJSON is a structured value, for consumers that are code
+	// rather than readers.
+	FacetFormatJSON FacetFormat = "json"
+)
+
+// FacetSpec declares one facet and how it is cut.
+//
+// It decodes from either a bare name or an object, because the common
+// case is a name and nothing else — `facets: [status_line, teaser]`
+// stays readable, and an author who needs an attribute reaches for the
+// longer form only on the facet that needs it.
+type FacetSpec struct {
+	// Name is which face this is: status_line, teaser, or digest.
+	Name OutputFacet `yaml:"name" json:"name"`
+	// Format is how the value is encoded. Empty means markdown.
+	Format FacetFormat `yaml:"format,omitempty" json:"format,omitempty"`
+}
+
+// EffectiveFormat resolves the declared format, defaulting to markdown.
+func (f FacetSpec) EffectiveFormat() FacetFormat {
+	if f.Format == "" {
+		return FacetFormatMarkdown
+	}
+	return f.Format
+}
+
+// UnmarshalJSON accepts either "status_line" or {"name":"status_line"}.
+func (f *FacetSpec) UnmarshalJSON(data []byte) error {
+	trimmed := strings.TrimSpace(string(data))
+	if strings.HasPrefix(trimmed, `"`) {
+		var name string
+		if err := json.Unmarshal(data, &name); err != nil {
+			return err
+		}
+		*f = FacetSpec{Name: OutputFacet(name)}
+		return nil
+	}
+	// A named type breaks the recursion into this method.
+	type facetSpecWire FacetSpec
+	var wire facetSpecWire
+	if err := json.Unmarshal(data, &wire); err != nil {
+		return fmt.Errorf("facet must be a name or an object with a name: %w", err)
+	}
+	*f = FacetSpec(wire)
+	return nil
+}
+
+// UnmarshalYAML mirrors UnmarshalJSON for config-authored specs.
+func (f *FacetSpec) UnmarshalYAML(unmarshal func(any) error) error {
+	var name string
+	if err := unmarshal(&name); err == nil {
+		*f = FacetSpec{Name: OutputFacet(name)}
+		return nil
+	}
+	type facetSpecWire FacetSpec
+	var wire facetSpecWire
+	if err := unmarshal(&wire); err != nil {
+		return fmt.Errorf("facet must be a name or a mapping with a name: %w", err)
+	}
+	*f = FacetSpec(wire)
+	return nil
+}
+
+// MarshalJSON writes the short form when nothing but the name is set, so
+// a round trip does not inflate every declaration into an object.
+func (f FacetSpec) MarshalJSON() ([]byte, error) {
+	if f.Format == "" {
+		return json.Marshal(string(f.Name))
+	}
+	type facetSpecWire FacetSpec
+	return json.Marshal(facetSpecWire(f))
+}
+
+// validFacetFormats gates the enum in one place.
+var validFacetFormats = map[FacetFormat]struct{}{
+	FacetFormatMarkdown: {}, FacetFormatPlain: {}, FacetFormatJSON: {},
+}

--- a/internal/runtime/loop/facet_spec_test.go
+++ b/internal/runtime/loop/facet_spec_test.go
@@ -1,0 +1,85 @@
+package loop
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestFacetSpecDecodesBothShapes pins the sugar. The common declaration
+// is a bare name, and an author should only reach for the object form on
+// the one facet that needs an attribute — otherwise every spec pays for
+// a field almost none of them set.
+func TestFacetSpecDecodesBothShapes(t *testing.T) {
+	var got []FacetSpec
+	if err := json.Unmarshal([]byte(`["status_line",{"name":"teaser","format":"plain"}]`), &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("facets = %d, want 2", len(got))
+	}
+	if got[0].Name != OutputFacetStatusLine || got[0].Format != "" {
+		t.Errorf("bare name decoded as %+v", got[0])
+	}
+	if got[0].EffectiveFormat() != FacetFormatMarkdown {
+		t.Errorf("an undeclared format should resolve to markdown, got %q", got[0].EffectiveFormat())
+	}
+	if got[1].Name != OutputFacetTeaser || got[1].Format != FacetFormatPlain {
+		t.Errorf("object form decoded as %+v", got[1])
+	}
+}
+
+// TestFacetSpecMarshalsShortWhenPlain keeps a round trip from inflating
+// every declaration into an object it did not start as.
+func TestFacetSpecMarshalsShortWhenPlain(t *testing.T) {
+	data, err := json.Marshal([]FacetSpec{
+		{Name: OutputFacetStatusLine},
+		{Name: OutputFacetDigest, Format: FacetFormatJSON},
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if want := `["status_line",{"name":"digest","format":"json"}]`; string(data) != want {
+		t.Errorf("marshal = %s, want %s", data, want)
+	}
+}
+
+// TestFacetFormatValidation covers the enum and the one format that can
+// actually be checked.
+func TestFacetFormatValidation(t *testing.T) {
+	out := OutputSpec{
+		Name: "status", Type: OutputTypeMaintainedDocument, Ref: "kb:s.md",
+		Facets: []FacetSpec{{Name: OutputFacetStatusLine, Format: "yaml"}},
+	}
+	if err := out.Validate(); err == nil {
+		t.Error("an unsupported format should be refused at declaration")
+	}
+
+	out.Facets = []FacetSpec{{Name: OutputFacetStatusLine, Format: FacetFormatJSON}}
+	if err := out.Validate(); err != nil {
+		t.Fatalf("json is a supported format: %v", err)
+	}
+
+	// json is the one format a consumer cannot recover from being wrong
+	// about, so it is the one enforced at publish.
+	err := out.ValidateFacetPayload(FacetPayload{StatusLine: `not json`, Full: "body"})
+	if err == nil {
+		t.Fatal("prose in a json facet should be refused")
+	}
+	if err := out.ValidateFacetPayload(FacetPayload{StatusLine: `{"ok":true}`, Full: "body"}); err != nil {
+		t.Errorf("valid JSON should pass: %v", err)
+	}
+}
+
+// TestFacetFormatShapesGuidance checks that a declared format reaches
+// the model rather than only the validator — a rule enforced but never
+// explained is one the model learns by failing.
+func TestFacetFormatShapesGuidance(t *testing.T) {
+	if g := FormatGuidance(FacetFormatMarkdown); g != "" {
+		t.Errorf("the default format should add nothing, got %q", g)
+	}
+	for _, f := range []FacetFormat{FacetFormatPlain, FacetFormatJSON} {
+		if FormatGuidance(f) == "" {
+			t.Errorf("format %q should explain itself to the model", f)
+		}
+	}
+}

--- a/internal/runtime/loop/facet_spec_test.go
+++ b/internal/runtime/loop/facet_spec_test.go
@@ -28,9 +28,12 @@ func TestFacetSpecDecodesBothShapes(t *testing.T) {
 	}
 }
 
-// TestFacetSpecMarshalsShortWhenPlain keeps a round trip from inflating
-// every declaration into an object it did not start as.
-func TestFacetSpecMarshalsShortWhenPlain(t *testing.T) {
+// TestFacetSpecMarshalsBareNameWhenNoAttributes keeps a round trip from
+// inflating every declaration into an object it did not start as.
+//
+// Named for the absence of attributes rather than for "plain", which is
+// a format in this package and would read as the subject of the test.
+func TestFacetSpecMarshalsBareNameWhenNoAttributes(t *testing.T) {
 	data, err := json.Marshal([]FacetSpec{
 		{Name: OutputFacetStatusLine},
 		{Name: OutputFacetDigest, Format: FacetFormatJSON},

--- a/internal/runtime/loop/output.go
+++ b/internal/runtime/loop/output.go
@@ -37,9 +37,9 @@ const (
 	OutputModeReplace OutputMode = "replace"
 )
 
-// OutputFacet names one declared fidelity level in a faceted output's
-// set of facets a maintained document publishes. The full body is not a facet: it is the
-// document body itself.
+// OutputFacet names one face a maintained document publishes. The full
+// body is not a facet: it is the document itself, and the facets are
+// views of it.
 type OutputFacet string
 
 const (
@@ -89,7 +89,7 @@ type OutputSpec struct {
 	// the ladder's order is fixed by the contract itself
 	// (status_line → teaser → digest); renderers and consumers use that
 	// canonical order and must not read anything into declaration order.
-	Facets []OutputFacet `yaml:"facets,omitempty" json:"facets,omitempty"`
+	Facets []FacetSpec `yaml:"facets,omitempty" json:"facets,omitempty"`
 	// Audience overrides which surfaces may project this output. Empty
 	// defaults from Type: working_notes is internal, every other type
 	// is published.
@@ -222,16 +222,19 @@ func validateOutputFacets(o OutputSpec) error {
 	seen := make(map[OutputFacet]struct{}, len(o.Facets))
 	hasStatusLine := false
 	for i, facet := range o.Facets {
-		switch facet {
+		switch facet.Name {
 		case OutputFacetStatusLine, OutputFacetTeaser, OutputFacetDigest:
 		default:
-			return fmt.Errorf("facets[%d]: unsupported facet %q; use %q, %q, or %q (the full body is the document itself, not a declared facet)", i, facet, OutputFacetStatusLine, OutputFacetTeaser, OutputFacetDigest)
+			return fmt.Errorf("facets[%d]: unsupported facet %q; use %q, %q, or %q (the full body is the document itself, not a declared facet)", i, facet.Name, OutputFacetStatusLine, OutputFacetTeaser, OutputFacetDigest)
 		}
-		if _, dup := seen[facet]; dup {
-			return fmt.Errorf("facets[%d]: duplicate facet %q", i, facet)
+		if _, ok := validFacetFormats[facet.EffectiveFormat()]; !ok {
+			return fmt.Errorf("facets[%d]: unsupported format %q for %q; use %q, %q, or %q", i, facet.Format, facet.Name, FacetFormatMarkdown, FacetFormatPlain, FacetFormatJSON)
 		}
-		seen[facet] = struct{}{}
-		if facet == OutputFacetStatusLine {
+		if _, dup := seen[facet.Name]; dup {
+			return fmt.Errorf("facets[%d]: duplicate facet %q", i, facet.Name)
+		}
+		seen[facet.Name] = struct{}{}
+		if facet.Name == OutputFacetStatusLine {
 			hasStatusLine = true
 		}
 	}
@@ -282,7 +285,7 @@ func cloneOutputs(src []OutputSpec) []OutputSpec {
 	dst := make([]OutputSpec, len(src))
 	copy(dst, src)
 	for i := range dst {
-		dst[i].Facets = append([]OutputFacet(nil), src[i].Facets...)
+		dst[i].Facets = append([]FacetSpec(nil), src[i].Facets...)
 	}
 	return dst
 }

--- a/internal/runtime/loop/output_facets.go
+++ b/internal/runtime/loop/output_facets.go
@@ -1,6 +1,7 @@
 package loop
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 	"unicode/utf8"
@@ -42,6 +43,9 @@ type FacetField struct {
 	// Guidance is the model-facing description of what this field is
 	// for and where it surfaces.
 	Guidance string
+	// Format is how this facet's value is encoded. Empty on the full
+	// body, which is always markdown.
+	Format FacetFormat
 }
 
 // facetSection binds one projection to its canonical document section and
@@ -111,18 +115,22 @@ func (o OutputSpec) FacetFields() []FacetField {
 	if len(o.Facets) == 0 {
 		return nil
 	}
-	declared := make(map[OutputFacet]struct{}, len(o.Facets))
+	declared := make(map[OutputFacet]FacetSpec, len(o.Facets))
 	for _, facet := range o.Facets {
-		declared[facet] = struct{}{}
+		declared[facet.Name] = facet
 	}
 	fields := make([]FacetField, 0, len(o.Facets)+1)
 	for _, section := range facetSections {
+		// The full body is always published and is never declared, so it
+		// carries the contract's own format rather than a facet's.
 		if section.Tier == "" {
 			fields = append(fields, section.Field)
 			continue
 		}
-		if _, ok := declared[section.Tier]; ok {
-			fields = append(fields, section.Field)
+		if facet, ok := declared[section.Tier]; ok {
+			field := section.Field
+			field.Format = facet.EffectiveFormat()
+			fields = append(fields, field)
 		}
 	}
 	return fields
@@ -150,6 +158,9 @@ func (o OutputSpec) ValidateFacetPayload(payload FacetPayload) error {
 		value := strings.TrimSpace(*section.value(&payload))
 		if value == "" {
 			return fmt.Errorf("%s is required; every declared projection is published together so they cannot describe different moments", field.Key)
+		}
+		if err := validateFacetFormat(field, value); err != nil {
+			return err
 		}
 		if field.SingleLine && strings.ContainsAny(value, "\r\n") {
 			return fmt.Errorf("%s must be a single line with no line breaks; it renders as one row on surfaces that show nothing else", field.Key)
@@ -274,4 +285,40 @@ func firstReservedTierHeading(value string) (string, bool) {
 		}
 	}
 	return "", false
+}
+
+// validateFacetFormat enforces what a declared format actually promises
+// a consumer.
+//
+// Only json is mechanically checkable, and it is the one worth checking:
+// a consumer that declared it is code, and code given prose fails at the
+// far end where nothing can explain why. plain is advisory — markdown is
+// a spectrum rather than a grammar, and rejecting a stray asterisk would
+// cost more than the surfaces gain — so it shapes the guidance a model
+// reads instead of the value it may send.
+func validateFacetFormat(field FacetField, value string) error {
+	if field.Format != FacetFormatJSON {
+		return nil
+	}
+	if !json.Valid([]byte(value)) {
+		return fmt.Errorf("%s declares format %q but the value is not valid JSON; a consumer that asked for json cannot read prose", field.Key, FacetFormatJSON)
+	}
+	return nil
+}
+
+// FormatGuidance returns the sentence appended to a facet's model-facing
+// description when its format is anything but the markdown default.
+//
+// A rule that is enforced but never explained is one the model learns by
+// failing, so the format that shapes validation also shapes the
+// description the model reads before it writes.
+func FormatGuidance(format FacetFormat) string {
+	switch format {
+	case FacetFormatPlain:
+		return " Write plain text with no markdown: this is spoken aloud or shown somewhere that renders nothing, so asterisks and backticks are read out."
+	case FacetFormatJSON:
+		return " Emit valid JSON, not prose: this is read by code rather than a person, and a non-JSON value is rejected."
+	default:
+		return ""
+	}
 }

--- a/internal/runtime/loop/output_facets_test.go
+++ b/internal/runtime/loop/output_facets_test.go
@@ -5,7 +5,11 @@ import (
 	"testing"
 )
 
-func facetedOutput(facets ...OutputFacet) OutputSpec {
+func facetedOutput(names ...OutputFacet) OutputSpec {
+	facets := make([]FacetSpec, 0, len(names))
+	for _, name := range names {
+		facets = append(facets, FacetSpec{Name: name})
+	}
 	return OutputSpec{
 		Name:   "ranch status",
 		Type:   OutputTypeMaintainedDocument,

--- a/internal/runtime/loop/output_test.go
+++ b/internal/runtime/loop/output_test.go
@@ -104,7 +104,7 @@ func TestOutputSpecValidateAndToolName(t *testing.T) {
 				Name:   "ranch status",
 				Type:   OutputTypeMaintainedDocument,
 				Ref:    "core:ranch.md",
-				Facets: []OutputFacet{OutputFacetStatusLine, OutputFacetTeaser, OutputFacetDigest},
+				Facets: []FacetSpec{{Name: OutputFacetStatusLine}, {Name: OutputFacetTeaser}, {Name: OutputFacetDigest}},
 			},
 			wantTool: "publish_output_ranch_status",
 		},
@@ -114,7 +114,7 @@ func TestOutputSpecValidateAndToolName(t *testing.T) {
 				Name:   "ranch status",
 				Type:   OutputTypeMaintainedDocument,
 				Ref:    "core:ranch.md",
-				Facets: []OutputFacet{OutputFacetStatusLine},
+				Facets: []FacetSpec{{Name: OutputFacetStatusLine}},
 			},
 			wantTool: "publish_output_ranch_status",
 		},
@@ -124,7 +124,7 @@ func TestOutputSpecValidateAndToolName(t *testing.T) {
 				Name:   "ranch status",
 				Type:   OutputTypeMaintainedDocument,
 				Ref:    "core:ranch.md",
-				Facets: []OutputFacet{OutputFacetTeaser, OutputFacetDigest},
+				Facets: []FacetSpec{{Name: OutputFacetTeaser}, {Name: OutputFacetDigest}},
 			},
 			wantErr: true,
 		},
@@ -134,7 +134,7 @@ func TestOutputSpecValidateAndToolName(t *testing.T) {
 				Name:   "ranch status",
 				Type:   OutputTypeMaintainedDocument,
 				Ref:    "core:ranch.md",
-				Facets: []OutputFacet{OutputFacetStatusLine, OutputFacet("hud")},
+				Facets: []FacetSpec{{Name: OutputFacetStatusLine}, {Name: OutputFacet("hud")}},
 			},
 			wantErr: true,
 		},
@@ -144,7 +144,7 @@ func TestOutputSpecValidateAndToolName(t *testing.T) {
 				Name:   "ranch status",
 				Type:   OutputTypeMaintainedDocument,
 				Ref:    "core:ranch.md",
-				Facets: []OutputFacet{OutputFacetStatusLine, OutputFacetStatusLine},
+				Facets: []FacetSpec{{Name: OutputFacetStatusLine}, {Name: OutputFacetStatusLine}},
 			},
 			wantErr: true,
 		},
@@ -154,7 +154,7 @@ func TestOutputSpecValidateAndToolName(t *testing.T) {
 				Name:   "ranch notes",
 				Type:   OutputTypeWorkingNotes,
 				Ref:    "core:ranch-notes.md",
-				Facets: []OutputFacet{OutputFacetStatusLine},
+				Facets: []FacetSpec{{Name: OutputFacetStatusLine}},
 			},
 			wantErr: true,
 		},
@@ -165,7 +165,7 @@ func TestOutputSpecValidateAndToolName(t *testing.T) {
 				Type:     OutputTypeMaintainedDocument,
 				Ref:      "core:hypotheses.md",
 				Audience: OutputAudienceInternal,
-				Facets:   []OutputFacet{OutputFacetStatusLine},
+				Facets:   []FacetSpec{{Name: OutputFacetStatusLine}},
 			},
 			wantErr: true,
 		},
@@ -222,11 +222,11 @@ func TestCloneOutputsDeepCopiesFacets(t *testing.T) {
 		Name:   "ranch status",
 		Type:   OutputTypeMaintainedDocument,
 		Ref:    "core:ranch.md",
-		Facets: []OutputFacet{OutputFacetStatusLine, OutputFacetTeaser},
+		Facets: []FacetSpec{{Name: OutputFacetStatusLine}, {Name: OutputFacetTeaser}},
 	}}
 	dst := cloneOutputs(src)
-	dst[0].Facets[1] = OutputFacetDigest
-	if src[0].Facets[1] != OutputFacetTeaser {
+	dst[0].Facets[1] = FacetSpec{Name: OutputFacetDigest}
+	if src[0].Facets[1].Name != OutputFacetTeaser {
 		t.Fatalf("cloneOutputs shares Facets backing array: src mutated to %q", src[0].Facets[1])
 	}
 }
@@ -287,7 +287,7 @@ func TestSpecJSONRoundTripIncludesOutputs(t *testing.T) {
 				Type:    OutputTypeMaintainedDocument,
 				Ref:     "generated:status.md",
 				Purpose: "Current status.",
-				Facets:  []OutputFacet{OutputFacetStatusLine, OutputFacetTeaser},
+				Facets:  []FacetSpec{{Name: OutputFacetStatusLine}, {Name: OutputFacetTeaser}},
 			},
 			{
 				Name: "notes",
@@ -318,7 +318,7 @@ func TestSpecJSONRoundTripIncludesOutputs(t *testing.T) {
 	if got.Outputs[0].ToolName() != "publish_output_status" {
 		t.Fatalf("output tool = %q, want publish_output_status for a faceted output", got.Outputs[0].ToolName())
 	}
-	if len(got.Outputs[0].Facets) != 2 || got.Outputs[0].Facets[0] != OutputFacetStatusLine {
+	if len(got.Outputs[0].Facets) != 2 || got.Outputs[0].Facets[0].Name != OutputFacetStatusLine {
 		t.Fatalf("round-tripped facets = %v, want [status_line teaser]", got.Outputs[0].Facets)
 	}
 	if got.Outputs[1].EffectiveAudience() != OutputAudienceInternal {

--- a/internal/tools/loop_create_fluency_test.go
+++ b/internal/tools/loop_create_fluency_test.go
@@ -134,7 +134,7 @@ func TestGuidedCreateTierInputShapes(t *testing.T) {
 		if err != nil {
 			t.Fatalf("[]string: %v", err)
 		}
-		if len(got) != 2 || got[0] != looppkg.OutputFacetStatusLine {
+		if len(got) != 2 || got[0].Name != looppkg.OutputFacetStatusLine {
 			t.Errorf("facets = %v", got)
 		}
 	})

--- a/internal/tools/loop_create_tool.go
+++ b/internal/tools/loop_create_tool.go
@@ -230,7 +230,7 @@ func (r *Registry) planExecutingLoop(args map[string]any, name, intent string, o
 		documentRef string
 		title       string
 		hasOutput   bool
-		facets      []looppkg.OutputFacet
+		facets      []looppkg.FacetSpec
 		notesRef    string
 	)
 	if raw, ok := args["output"].(map[string]any); ok && raw != nil {

--- a/internal/tools/loop_intent_tools.go
+++ b/internal/tools/loop_intent_tools.go
@@ -347,7 +347,7 @@ func coerceInt(v any) (int, error) {
 // and injects current-document context into each iteration prompt — so
 // the model gets a typed write surface and "what's already there?"
 // answered without re-reading the doc itself.
-func buildCurateOutputSpec(name, docRef, intent string, facets []looppkg.OutputFacet) looppkg.OutputSpec {
+func buildCurateOutputSpec(name, docRef, intent string, facets []looppkg.FacetSpec) looppkg.OutputSpec {
 	return looppkg.OutputSpec{
 		Name:    name,
 		Ref:     docRef,
@@ -509,7 +509,7 @@ func parseDurationArg(args map[string]any, key string) (d time.Duration, present
 // tool's output argument. Unknown names are refused rather than dropped:
 // a facet that is silently ignored produces a loop that publishes fewer
 // projections than its author asked for, and nothing says so.
-func parseOutputFacets(raw any) ([]looppkg.OutputFacet, error) {
+func parseOutputFacets(raw any) ([]looppkg.FacetSpec, error) {
 	if raw == nil {
 		return nil, nil
 	}
@@ -536,12 +536,12 @@ func parseOutputFacets(raw any) ([]looppkg.OutputFacet, error) {
 		return nil, fmt.Errorf("output.facets must be an array of facet names, got %T", raw)
 	}
 
-	out := make([]looppkg.OutputFacet, 0, len(names))
+	out := make([]looppkg.FacetSpec, 0, len(names))
 	for _, name := range names {
-		tier := looppkg.OutputFacet(strings.TrimSpace(name))
-		switch tier {
+		facet := looppkg.OutputFacet(strings.TrimSpace(name))
+		switch facet {
 		case looppkg.OutputFacetStatusLine, looppkg.OutputFacetTeaser, looppkg.OutputFacetDigest:
-			out = append(out, tier)
+			out = append(out, looppkg.FacetSpec{Name: facet})
 		default:
 			return nil, fmt.Errorf("output.facets %q is not a projection; use status_line, teaser, or digest", name)
 		}

--- a/internal/tools/loop_spec_schema.go
+++ b/internal/tools/loop_spec_schema.go
@@ -176,9 +176,21 @@ func loopOutputSpecSchema() map[string]any {
 			"name": map[string]any{"type": "string", "description": "Stable semantic name for this output within the loop."},
 			"type": map[string]any{"type": "string", "enum": []string{"maintained_document", "working_notes"}, "description": "maintained_document = the loop rewrites it each cycle to reflect current state; working_notes = the same, but private — the loop's current thinking, never projected into search, context, or any other consumer surface. Use working_notes for working theories, what an experiment is showing, and what you expect next; use a maintained_document for what a reader should see. For an append-only dated record, journal a document directly with the doc tools rather than declaring it as an output."},
 			"facets": map[string]any{
-				"type":        "array",
-				"items":       map[string]any{"type": "string", "enum": []string{"status_line", "teaser", "digest"}},
-				"description": "The facets this output publishes alongside its full body: which condensed views this output curates alongside its full body. Declaring facets swaps the generated tool from replace_output_* to publish_output_*, which takes one typed argument per projection. status_line is required when facets are declared; teaser and digest are optional. Consumers pick the projection that fits their surface — an ambient row takes status_line, a search snippet takes teaser, a digest row takes digest — so a faceted output is read at a fraction of the cost of the full document. Order here carries no meaning.",
+				"type": "array",
+				"items": map[string]any{
+					"oneOf": []any{
+						map[string]any{"type": "string", "enum": []string{"status_line", "teaser", "digest"}},
+						map[string]any{
+							"type": "object",
+							"properties": map[string]any{
+								"name":   map[string]any{"type": "string", "enum": []string{"status_line", "teaser", "digest"}},
+								"format": map[string]any{"type": "string", "enum": []string{"markdown", "plain", "json"}, "description": "How this facet is encoded. markdown (default) suits a document section; plain has no markup and is safe to speak aloud or show where nothing renders; json is for consumers that are code, and a non-JSON value is rejected."},
+							},
+							"required": []string{"name"},
+						},
+					},
+				},
+				"description": "The facets this output publishes alongside its full body — condensed views of the same understanding, each cut for a surface rather than shortened from the one above. Declaring any swaps the generated tool from replace_output_* to publish_output_*, which takes one typed argument per facet. status_line is required whenever facets are declared; teaser and digest are optional. Write a bare name for the default encoding, or an object to set a format. Order carries no meaning.",
 			},
 			"audience": map[string]any{
 				"type":        "string",


### PR DESCRIPTION
Step 4 of the plan on #1250, and the prerequisite for the bindings after it.

## Why now rather than with the bindings

An HA entity state holds 255 characters. So a binding has to know a facet's **format and budget** to refuse a `digest` where it declares the binding, rather than truncating it on a wall display — which is #1250's own requirement that *"this facet doesn't fit that binding is a lint error at declaration, not silent truncation."*

A bare string has nowhere to put that. `FacetSpec` is the shape change that lets the next step be additive instead of another migration.

## Both shapes decode

```yaml
facets:
  - status_line                 # what almost every declaration is
  - name: digest
    format: json                # only where an attribute is needed
```

Marshalling is symmetric — a facet with no attributes writes back as a bare name, so a round trip does not inflate a spec into objects it never was.

## format, and what it actually does

`markdown` by default; `plain` for surfaces that render nothing or speak aloud; `json` for consumers that are code.

**Only `json` is enforced**, and that asymmetry is deliberate. It is the one a consumer cannot recover from being wrong about: code handed prose fails at the far end, where nothing is left to explain why. Markdown is a spectrum rather than a grammar, and rejecting a stray asterisk in a `plain` facet would cost more than the speaking surfaces gain — so `plain` shapes what the model is told rather than what it may send.

**And a declared format changes the description before it changes the validator.** A rule that is enforced but never explained is one the model learns by failing, so `FormatGuidance` appends the reason to the facet's model-facing description in the publish tool.

## Test plan

- [x] `just ci` green locally
- [x] Both declaration shapes decode, and an undeclared format resolves to markdown
- [x] Marshalling stays short for an attribute-free facet, so round trips do not inflate specs
- [x] An unsupported format is refused at declaration; `json` is refused at publish when the value is not JSON, and accepted when it is
- [x] `FormatGuidance` returns nothing for the default and something for each non-default, so the model is told what the validator will check
- [x] Full suite green; every changed file is loop-output surface — checked by listing the diff rather than grepping the result
- [x] No production loop declares a facet, so nothing stored migrates

Refs #1250

🤖 Generated with [Claude Code](https://claude.com/claude-code)
