### PR TITLE
The framing changed; the machinery never knew about it

### DIFF
--- a/internal/channels/mqtt/publisher.go
+++ b/internal/channels/mqtt/publisher.go
@@ -135,6 +135,45 @@ func (p *Publisher) RegisterSensors(sensors []DynamicSensor) {
 	p.dynamicSensors = append(p.dynamicSensors, sensors...)
 }
 
+// EnsureSensor registers one dynamic sensor and publishes its discovery
+// config immediately, so an entity created after [Publisher.Start] shows
+// up in Home Assistant without waiting for the next reconnect. This is
+// the runtime counterpart to [Publisher.RegisterSensors], which only
+// takes effect at connect time.
+//
+// Re-registering an existing EntitySuffix replaces that definition
+// instead of appending a duplicate, so callers that cannot cheaply track
+// whether they have registered yet may call this before every publish.
+// It returns an error when the broker connection is not up; the
+// registration is still recorded and will be published on the next
+// reconnect.
+func (p *Publisher) EnsureSensor(ctx context.Context, sensor DynamicSensor) error {
+	if strings.TrimSpace(sensor.EntitySuffix) == "" {
+		return fmt.Errorf("mqtt: sensor entity suffix is required")
+	}
+
+	p.mu.Lock()
+	replaced := false
+	for i := range p.dynamicSensors {
+		if p.dynamicSensors[i].EntitySuffix == sensor.EntitySuffix {
+			p.dynamicSensors[i] = sensor
+			replaced = true
+			break
+		}
+	}
+	if !replaced {
+		p.dynamicSensors = append(p.dynamicSensors, sensor)
+	}
+	p.mu.Unlock()
+
+	cm := p.getCM()
+	if cm == nil {
+		return fmt.Errorf("mqtt publisher not connected")
+	}
+	p.publishSensorDiscovery(ctx, cm, sensor.EntitySuffix, sensor.Config)
+	return nil
+}
+
 // Device returns the HA device info shared across all sensors published
 // by this publisher instance. Useful for callers building [DynamicSensor]
 // configs that reference the same HA device.

--- a/internal/model/outputtargets/apple_watch.go
+++ b/internal/model/outputtargets/apple_watch.go
@@ -1,0 +1,118 @@
+package outputtargets
+
+// Apple Watch complication targets.
+//
+// Slot names mirror the companion app's own vocabulary (title, subtitle,
+// value, bottom_text) so an operator wiring the complication editor sees
+// the same words in both places. The rune budgets are deliberately
+// tighter than what the widget will technically accept: watchOS shrinks
+// and then truncates overflowing text, and the accessoryRectangular slot
+// on the Modular Ultra face clips earlier than on other faces, so a
+// budget that fits everywhere beats one that fits the roomiest face.
+//
+// Colors are published as ordinary attributes because an entity-sourced
+// complication cannot template its colors — only a template-sourced one
+// can. Both bindings read the same entity, so the operator picks the
+// tier they want without Thane publishing anything differently.
+
+const appleWatchColorNote = "Ignored unless the complication is template-sourced and reads this attribute in its color template. watchOS also renders on-face complications in the face's accent palette, so expect full fidelity in the Smart Stack and a tinted approximation on the watch face itself."
+
+var appleWatchRectangular = Target{
+	ID:      "apple_watch.rectangular",
+	Title:   "Apple Watch rectangular complication",
+	Summary: "The four-line accessoryRectangular complication: the large middle slot of the Modular Ultra face, and the wide slot on Modular and Infograph Modular. Renders an icon, a title line, a subtitle line, a value (as a progress-bar thumb when a fraction is set), and a bottom line. Nothing wraps — every line is one line, shrunk to fit and then clipped.",
+	Binding: "Published as an MQTT sensor. In the companion app's complication builder choose the Rectangular size and an Entity source pointing at this sensor, then bind slots with {value} for the state and {attr:title} / {attr:subtitle} / {attr:bottom_text} for the rest. Set the progress bar's minimum to 0 and maximum to 1 to consume {attr:fraction}.",
+	Icon:    "mdi:watch-variant",
+	Slots: []Slot{
+		{
+			Name:        "value",
+			Kind:        SlotKindText,
+			Description: "The headline value and the sensor's state. Renders as the label inside the progress-bar thumb when a fraction is set, otherwise as its own line. Keep it to a number and a unit — this is the shortest slot on the target.",
+			Required:    true,
+			MaxRunes:    12,
+			Primary:     true,
+		},
+		{
+			Name:        "title",
+			Kind:        SlotKindText,
+			Description: "First line, semibold. What this complication is about — a name or label, not a sentence.",
+			MaxRunes:    18,
+		},
+		{
+			Name:        "subtitle",
+			Kind:        SlotKindText,
+			Description: "Second line, dimmed. Secondary context for the title: a qualifier, a comparison, or a second reading.",
+			MaxRunes:    22,
+		},
+		{
+			Name:        "bottom_text",
+			Kind:        SlotKindText,
+			Description: "Last line, dimmed. Trailing detail such as a freshness note or a next-event hint. Hidden by default in the complication editor; the operator opts in.",
+			MaxRunes:    22,
+		},
+		{
+			Name:        "fraction",
+			Kind:        SlotKindFraction,
+			Description: "Progress-bar fill from 0.0 (empty) to 1.0 (full). Normalize the underlying reading yourself — the bar has no notion of your units. Omit when there is nothing meaningful to fill.",
+		},
+		{
+			Name:        "gauge_color",
+			Kind:        SlotKindColor,
+			Description: "Progress-bar tint as #RRGGBB. " + appleWatchColorNote,
+		},
+		{
+			Name:        "icon_color",
+			Kind:        SlotKindColor,
+			Description: "Icon tint as #RRGGBB. " + appleWatchColorNote,
+		},
+		{
+			Name:        "text_color",
+			Kind:        SlotKindColor,
+			Description: "Text tint as #RRGGBB. " + appleWatchColorNote,
+		},
+	},
+}
+
+var appleWatchCircular = Target{
+	ID:      "apple_watch.circular",
+	Title:   "Apple Watch circular complication",
+	Summary: "The small round accessoryCircular complication: a gauge ring around a center that holds an icon, a value, and optionally a name. It is the smallest target here — assume roughly a half-dozen characters are legible, and that the ring carries more information than the text does.",
+	Binding: "Published as an MQTT sensor. In the companion app's complication builder choose the Circular size and an Entity source pointing at this sensor, then bind {value} for the state and {attr:title} for the name slot. Set the gauge's minimum to 0 and maximum to 1 to consume {attr:fraction}, and pick the open-arc or capacity-ring style there.",
+	Icon:    "mdi:watch-variant",
+	Slots: []Slot{
+		{
+			Name:        "value",
+			Kind:        SlotKindText,
+			Description: "The center value and the sensor's state. This is a glanceable scalar: a number, a percentage, a two-letter status. Long strings shrink until they are unreadable rather than wrapping.",
+			Required:    true,
+			MaxRunes:    6,
+			Primary:     true,
+		},
+		{
+			Name:        "title",
+			Kind:        SlotKindText,
+			Description: "Optional name under the value. Hidden by default on circular because the center is small — supply it only when the value alone is ambiguous, and keep it to one short word.",
+			MaxRunes:    8,
+		},
+		{
+			Name:        "fraction",
+			Kind:        SlotKindFraction,
+			Description: "Gauge ring fill from 0.0 (empty) to 1.0 (full). On this target the ring is the primary signal; prefer setting it whenever the value is numeric.",
+		},
+		{
+			Name:        "gauge_color",
+			Kind:        SlotKindColor,
+			Description: "Gauge ring tint as #RRGGBB. " + appleWatchColorNote,
+		},
+		{
+			Name:        "icon_color",
+			Kind:        SlotKindColor,
+			Description: "Icon tint as #RRGGBB. " + appleWatchColorNote,
+		},
+		{
+			Name:        "text_color",
+			Kind:        SlotKindColor,
+			Description: "Value text tint as #RRGGBB. " + appleWatchColorNote,
+		},
+	},
+}

--- a/internal/model/outputtargets/doc.go
+++ b/internal/model/outputtargets/doc.go
@@ -1,0 +1,53 @@
+// Package outputtargets defines the slotted rendering surfaces a loop
+// may publish to.
+//
+// A maintained document asks the model for prose. A slotted surface —
+// an Apple Watch complication, a compact display, a status tile — asks
+// instead for a small set of named, budgeted values, because it has
+// fixed geometry: four lines of about twenty characters, a gauge wanting
+// a number in [0,1]. So the contract is fixed too: named slots, one
+// primary slot, per-slot type and size limits.
+//
+// # Landed ahead of its consumer
+//
+// This package has no caller yet. It was written for #1253, which
+// modelled a slotted surface as a third loop output type with its own
+// tool verb. #1250 replaced that framing: a slotted surface is not a
+// third kind of output but another facet of one — a face cut for a
+// surface that renders no prose — and the machinery here becomes the
+// shared validation core the facet contract already needed.
+//
+// The registry survived that change untouched because it never knew
+// about loops: it describes surfaces and the values they hold, and the
+// question of who publishes to them lives entirely elsewhere. Rebuilding
+// it to say the same things in a different caller's vocabulary would
+// have been waste, so it is preserved here while the facet binding that
+// consumes it is designed.
+//
+// # Why a registry
+//
+// Targets live in code rather than operator config so the budgets and
+// validators that make a target real are compile-checked and testable.
+// Adding a surface is adding a [Target] value to the registry in this
+// package; nothing downstream changes. A consumer validates a declared
+// target ID against [Lookup], turns [Target.Schema] into the arguments a
+// model is offered and [Target.Normalize] into what checks them, and
+// publishes the resulting [Payload].
+//
+// # Slots and the primary slot
+//
+// Every target has exactly one slot marked primary. The primary slot's
+// value becomes the [Payload] state — the single scalar a consuming
+// surface reads first (for the MQTT sink, the sensor's state). Remaining
+// slots become payload attributes. This split is what lets a downstream
+// binding stay trivial: the headline value needs no attribute lookup.
+//
+// # Validation teaches
+//
+// [Target.Normalize] rejects rather than repairs. A slot over its rune
+// budget, a fraction outside [0,1], or an unparseable color returns an
+// error naming the slot, the limit, and what arrived, so a delegate can
+// fix it in one more call instead of guessing. The exception is
+// whitespace trimming and color-hex casing, which are canonicalization
+// rather than a change of meaning.
+package outputtargets

--- a/internal/model/outputtargets/example_test.go
+++ b/internal/model/outputtargets/example_test.go
@@ -1,0 +1,54 @@
+package outputtargets_test
+
+import (
+	"fmt"
+
+	"github.com/nugget/thane-ai-agent/internal/model/outputtargets"
+)
+
+// The primary usage pattern: resolve a declared target, validate the
+// model's slot values against it, and publish the resulting payload.
+func ExampleTarget_Normalize() {
+	target, ok := outputtargets.Lookup("apple_watch.circular")
+	if !ok {
+		return
+	}
+
+	payload, err := target.Normalize(map[string]any{
+		"value":       "64%",
+		"fraction":    0.64,
+		"gauge_color": "3fb950",
+	})
+	if err != nil {
+		fmt.Println("rejected:", err)
+		return
+	}
+
+	fmt.Println("state:", payload.State)
+	fmt.Println("fraction:", payload.Attributes["fraction"])
+	fmt.Println("gauge_color:", payload.Attributes["gauge_color"])
+	// Output:
+	// state: 64%
+	// fraction: 0.64
+	// gauge_color: #3FB950
+}
+
+// An over-budget value is rejected with an error a delegate can act on
+// in one more call, rather than truncated into something unreadable.
+func ExampleTarget_Normalize_overBudget() {
+	target, _ := outputtargets.Lookup("apple_watch.circular")
+	if _, err := target.Normalize(map[string]any{"value": "1013 hPa"}); err != nil {
+		fmt.Println(err)
+	}
+	// Output:
+	// slot "value": is 8 characters but this slot renders at most 6; shorten it rather than relying on truncation (got "1013 hPa")
+}
+
+func ExampleIDs() {
+	for _, id := range outputtargets.IDs() {
+		fmt.Println(id)
+	}
+	// Output:
+	// apple_watch.circular
+	// apple_watch.rectangular
+}

--- a/internal/model/outputtargets/normalize.go
+++ b/internal/model/outputtargets/normalize.go
@@ -129,7 +129,7 @@ func (t Target) rejectUnknownSlots(args map[string]any) error {
 func (s Slot) normalizeText(raw any) (string, error) {
 	text, ok := raw.(string)
 	if !ok {
-		return "", fmt.Errorf("expected a string, got %T (%v)", raw, raw)
+		return "", fmt.Errorf("expected a string, got %T (%s)", raw, preview(raw))
 	}
 	text = strings.TrimSpace(text)
 	if i := strings.IndexFunc(text, isDisplayControl); i >= 0 {
@@ -138,7 +138,7 @@ func (s Slot) normalizeText(raw any) (string, error) {
 	// Rune count, not len: a budget measured in bytes would reject
 	// legitimate accented or emoji values that fit the display fine.
 	if count := utf8.RuneCountInString(text); count > s.MaxRunes {
-		return "", fmt.Errorf("is %d characters but this slot renders at most %d; shorten it rather than relying on truncation (got %q)", count, s.MaxRunes, text)
+		return "", fmt.Errorf("is %d characters but this slot renders at most %d; shorten it rather than relying on truncation (got %s)", count, s.MaxRunes, preview(text))
 	}
 	return text, nil
 }
@@ -147,7 +147,7 @@ func (s Slot) normalizeText(raw any) (string, error) {
 func (s Slot) normalizeFraction(raw any) (float64, error) {
 	value, ok := coerceFloat(raw)
 	if !ok {
-		return 0, fmt.Errorf("expected a number between 0.0 and 1.0, got %T (%v)", raw, raw)
+		return 0, fmt.Errorf("expected a number between 0.0 and 1.0, got %T (%s)", raw, preview(raw))
 	}
 	if value < 0 || value > 1 {
 		return 0, fmt.Errorf("is %v but must be between 0.0 and 1.0; normalize it first, e.g. (value - minimum) / (maximum - minimum) clamped to the range", value)
@@ -159,12 +159,12 @@ func (s Slot) normalizeFraction(raw any) (float64, error) {
 func (s Slot) normalizeColor(raw any) (string, error) {
 	text, ok := raw.(string)
 	if !ok {
-		return "", fmt.Errorf("expected an \"#RRGGBB\" hex color string, got %T (%v)", raw, raw)
+		return "", fmt.Errorf("expected an \"#RRGGBB\" hex color string, got %T (%s)", raw, preview(raw))
 	}
 	trimmed := strings.TrimSpace(text)
 	trimmed = strings.TrimPrefix(trimmed, "#")
 	if len(trimmed) != 6 || !isHex(trimmed) {
-		return "", fmt.Errorf("must be a six-digit hex color like \"#3FB950\"; got %q", text)
+		return "", fmt.Errorf("must be a six-digit hex color like \"#3FB950\"; got %s", preview(text))
 	}
 	return "#" + strings.ToUpper(trimmed), nil
 }
@@ -217,4 +217,21 @@ func quoteAll(values []string) []string {
 		out[i] = strconv.Quote(value)
 	}
 	return out
+}
+
+// preview bounds a model-supplied value before it enters an error.
+//
+// Slot values arrive from tool arguments, so their size is decided by
+// the model rather than by this package. An error that echoes the whole
+// value lands in the log and in the model's next turn, where a runaway
+// string costs context at the exact moment something is already going
+// wrong. Enough to recognise what was sent is enough to fix it.
+func preview(raw any) string {
+	const max = 80
+	text := fmt.Sprintf("%v", raw)
+	if utf8.RuneCountInString(text) <= max {
+		return fmt.Sprintf("%q", text)
+	}
+	runes := []rune(text)
+	return fmt.Sprintf("%q… (%d characters)", string(runes[:max]), len(runes))
 }

--- a/internal/model/outputtargets/normalize.go
+++ b/internal/model/outputtargets/normalize.go
@@ -1,0 +1,220 @@
+package outputtargets
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+)
+
+// Payload is a validated slot set ready for a sink to publish.
+type Payload struct {
+	// State is the primary slot's value: the single scalar the
+	// consuming surface reads without an attribute lookup.
+	State string `json:"state"`
+	// Attributes holds every other supplied slot, keyed by slot name.
+	// Text and color slots carry strings; fraction slots carry float64.
+	Attributes map[string]any `json:"attributes,omitempty"`
+}
+
+// Normalize validates raw tool arguments against the target's slots and
+// returns the payload to publish.
+//
+// It rejects rather than repairs: an unknown key, a missing required
+// slot, an over-budget string, an out-of-range fraction, or a malformed
+// color each return an error naming the slot and the constraint. The only
+// values it changes are surrounding whitespace (trimmed) and color hex
+// casing (upper, with a leading "#"), neither of which changes meaning.
+//
+// Omitting an optional slot is how a caller clears it — Normalize does
+// not carry values forward from a previous payload, because the tool
+// contract is a full replacement.
+func (t Target) Normalize(args map[string]any) (Payload, error) {
+	if err := t.rejectUnknownSlots(args); err != nil {
+		return Payload{}, err
+	}
+
+	payload := Payload{Attributes: make(map[string]any, len(t.Slots))}
+	for _, slot := range t.Slots {
+		raw, present := args[slot.Name]
+		// An explicit JSON null is how some model families spell "leave
+		// this one out"; treat it as absence rather than a type error.
+		if raw == nil {
+			present = false
+		}
+		if !present {
+			if slot.Required {
+				return Payload{}, fmt.Errorf("slot %q is required for target %q but was not supplied; %s", slot.Name, t.ID, slot.Description)
+			}
+			continue
+		}
+
+		// Each kind is handled in its own branch rather than through a
+		// common any-returning helper: only text slots can be primary
+		// or blank-and-therefore-cleared, and routing every kind through
+		// one signature would mean type-asserting that back out.
+		switch slot.Kind {
+		case SlotKindText:
+			text, err := slot.normalizeText(raw)
+			if err != nil {
+				return Payload{}, fmt.Errorf("slot %q: %w", slot.Name, err)
+			}
+			if text == "" {
+				if slot.Required {
+					return Payload{}, fmt.Errorf("slot %q is required for target %q but was empty after trimming whitespace", slot.Name, t.ID)
+				}
+				// An optional slot explicitly set to blank means "clear
+				// it", which is the same as omitting it.
+				continue
+			}
+			if slot.Primary {
+				payload.State = text
+				continue
+			}
+			payload.Attributes[slot.Name] = text
+		case SlotKindFraction:
+			fraction, err := slot.normalizeFraction(raw)
+			if err != nil {
+				return Payload{}, fmt.Errorf("slot %q: %w", slot.Name, err)
+			}
+			payload.Attributes[slot.Name] = fraction
+		case SlotKindColor:
+			color, err := slot.normalizeColor(raw)
+			if err != nil {
+				return Payload{}, fmt.Errorf("slot %q: %w", slot.Name, err)
+			}
+			payload.Attributes[slot.Name] = color
+		default:
+			return Payload{}, fmt.Errorf("slot %q: unsupported slot kind %q", slot.Name, slot.Kind)
+		}
+	}
+
+	if payload.State == "" {
+		// Unreachable for a registered target (validate guarantees a
+		// required primary slot, and the required check above fires
+		// first), but a sink publishing an empty state would produce an
+		// entity HA renders as "unknown" — fail here instead.
+		return Payload{}, fmt.Errorf("target %q produced no state value", t.ID)
+	}
+	if len(payload.Attributes) == 0 {
+		payload.Attributes = nil
+	}
+	return payload, nil
+}
+
+// rejectUnknownSlots fails on any argument key the target does not
+// define, listing the valid slots. A silently dropped key looks to the
+// model like a slot that renders nothing.
+func (t Target) rejectUnknownSlots(args map[string]any) error {
+	var unknown []string
+	for key := range args {
+		if _, ok := t.Slot(key); !ok {
+			unknown = append(unknown, key)
+		}
+	}
+	if len(unknown) == 0 {
+		return nil
+	}
+	sort.Strings(unknown)
+	return fmt.Errorf(
+		"target %q has no slot named %s; valid slots are %s",
+		t.ID, strings.Join(quoteAll(unknown), ", "), strings.Join(quoteAll(t.SlotNames()), ", "),
+	)
+}
+
+// normalizeText trims and length-checks a text slot value.
+func (s Slot) normalizeText(raw any) (string, error) {
+	text, ok := raw.(string)
+	if !ok {
+		return "", fmt.Errorf("expected a string, got %T (%v)", raw, raw)
+	}
+	text = strings.TrimSpace(text)
+	if i := strings.IndexFunc(text, isDisplayControl); i >= 0 {
+		return "", fmt.Errorf("contains a control character at offset %d; this slot renders as a single line of text", i)
+	}
+	// Rune count, not len: a budget measured in bytes would reject
+	// legitimate accented or emoji values that fit the display fine.
+	if count := utf8.RuneCountInString(text); count > s.MaxRunes {
+		return "", fmt.Errorf("is %d characters but this slot renders at most %d; shorten it rather than relying on truncation (got %q)", count, s.MaxRunes, text)
+	}
+	return text, nil
+}
+
+// normalizeFraction range-checks a gauge fill value.
+func (s Slot) normalizeFraction(raw any) (float64, error) {
+	value, ok := coerceFloat(raw)
+	if !ok {
+		return 0, fmt.Errorf("expected a number between 0.0 and 1.0, got %T (%v)", raw, raw)
+	}
+	if value < 0 || value > 1 {
+		return 0, fmt.Errorf("is %v but must be between 0.0 and 1.0; normalize it first, e.g. (value - minimum) / (maximum - minimum) clamped to the range", value)
+	}
+	return value, nil
+}
+
+// normalizeColor canonicalizes a hex color to "#RRGGBB".
+func (s Slot) normalizeColor(raw any) (string, error) {
+	text, ok := raw.(string)
+	if !ok {
+		return "", fmt.Errorf("expected an \"#RRGGBB\" hex color string, got %T (%v)", raw, raw)
+	}
+	trimmed := strings.TrimSpace(text)
+	trimmed = strings.TrimPrefix(trimmed, "#")
+	if len(trimmed) != 6 || !isHex(trimmed) {
+		return "", fmt.Errorf("must be a six-digit hex color like \"#3FB950\"; got %q", text)
+	}
+	return "#" + strings.ToUpper(trimmed), nil
+}
+
+// coerceFloat accepts the numeric shapes a tool call can arrive in: JSON
+// decodes to float64 by default and to json.Number under a UseNumber
+// decoder, and some model families emit numbers as quoted strings.
+func coerceFloat(raw any) (float64, bool) {
+	switch v := raw.(type) {
+	case float64:
+		return v, true
+	case float32:
+		return float64(v), true
+	case int:
+		return float64(v), true
+	case int64:
+		return float64(v), true
+	case json.Number:
+		parsed, err := v.Float64()
+		return parsed, err == nil
+	case string:
+		parsed, err := strconv.ParseFloat(strings.TrimSpace(v), 64)
+		return parsed, err == nil
+	default:
+		return 0, false
+	}
+}
+
+func isHex(s string) bool {
+	for _, r := range s {
+		switch {
+		case r >= '0' && r <= '9', r >= 'a' && r <= 'f', r >= 'A' && r <= 'F':
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+// isDisplayControl reports whether r would break a single-line display.
+// Newlines and tabs are the realistic offenders, but the whole control
+// range is rejected: none of it renders on a complication.
+func isDisplayControl(r rune) bool {
+	return unicode.IsControl(r)
+}
+
+func quoteAll(values []string) []string {
+	out := make([]string, len(values))
+	for i, value := range values {
+		out[i] = strconv.Quote(value)
+	}
+	return out
+}

--- a/internal/model/outputtargets/normalize_test.go
+++ b/internal/model/outputtargets/normalize_test.go
@@ -1,0 +1,210 @@
+package outputtargets
+
+import (
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func testTarget() Target {
+	return Target{
+		ID:    "test.surface",
+		Title: "Test surface",
+		Slots: []Slot{
+			{Name: "value", Kind: SlotKindText, MaxRunes: 6, Required: true, Primary: true, Description: "Headline."},
+			{Name: "title", Kind: SlotKindText, MaxRunes: 10, Description: "Label."},
+			{Name: "fraction", Kind: SlotKindFraction, Description: "Fill."},
+			{Name: "tint", Kind: SlotKindColor, Description: "Color."},
+		},
+	}
+}
+
+func TestNormalizeSuccess(t *testing.T) {
+	tests := []struct {
+		name string
+		args map[string]any
+		want Payload
+	}{
+		{
+			name: "primary only",
+			args: map[string]any{"value": "72F"},
+			want: Payload{State: "72F"},
+		},
+		{
+			name: "all slots",
+			args: map[string]any{"value": "72F", "title": "Office", "fraction": 0.5, "tint": "#3fb950"},
+			want: Payload{State: "72F", Attributes: map[string]any{"title": "Office", "fraction": 0.5, "tint": "#3FB950"}},
+		},
+		{
+			name: "whitespace trimmed",
+			args: map[string]any{"value": "  72F  ", "title": "\tOffice\t"},
+			want: Payload{State: "72F", Attributes: map[string]any{"title": "Office"}},
+		},
+		{
+			name: "color without leading hash",
+			args: map[string]any{"value": "72F", "tint": "3fb950"},
+			want: Payload{State: "72F", Attributes: map[string]any{"tint": "#3FB950"}},
+		},
+		{
+			name: "fraction as json.Number",
+			args: map[string]any{"value": "72F", "fraction": json.Number("0.25")},
+			want: Payload{State: "72F", Attributes: map[string]any{"fraction": 0.25}},
+		},
+		{
+			name: "fraction as string",
+			args: map[string]any{"value": "72F", "fraction": "1"},
+			want: Payload{State: "72F", Attributes: map[string]any{"fraction": float64(1)}},
+		},
+		{
+			name: "fraction as int",
+			args: map[string]any{"value": "72F", "fraction": 0},
+			want: Payload{State: "72F", Attributes: map[string]any{"fraction": float64(0)}},
+		},
+		{
+			name: "explicit null clears an optional slot",
+			args: map[string]any{"value": "72F", "title": nil},
+			want: Payload{State: "72F"},
+		},
+		{
+			name: "blank optional text clears the slot",
+			args: map[string]any{"value": "72F", "title": "   "},
+			want: Payload{State: "72F"},
+		},
+		{
+			name: "multibyte value inside the rune budget",
+			args: map[string]any{"value": "🌡22°C"},
+			want: Payload{State: "🌡22°C"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := testTarget().Normalize(tt.args)
+			if err != nil {
+				t.Fatalf("Normalize: %v", err)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("Normalize = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNormalizeErrorsTeach(t *testing.T) {
+	tests := []struct {
+		name string
+		args map[string]any
+		want []string
+	}{
+		{
+			name: "unknown slot lists the valid ones",
+			args: map[string]any{"value": "72F", "subtitle": "nope"},
+			want: []string{`no slot named "subtitle"`, `"value"`, `"fraction"`},
+		},
+		{
+			name: "missing required slot",
+			args: map[string]any{"title": "Office"},
+			want: []string{`slot "value" is required`},
+		},
+		{
+			name: "required slot blank after trimming",
+			args: map[string]any{"value": "  "},
+			want: []string{`slot "value" is required`, "empty after trimming"},
+		},
+		{
+			name: "text over budget names the limit and the value",
+			args: map[string]any{"value": "1234567"},
+			want: []string{"is 7 characters", "at most 6", `"1234567"`},
+		},
+		{
+			name: "text with a newline",
+			args: map[string]any{"value": "72F\nx"},
+			want: []string{"control character", "single line"},
+		},
+		{
+			name: "text of the wrong type",
+			args: map[string]any{"value": 72},
+			want: []string{"expected a string"},
+		},
+		{
+			name: "fraction out of range explains normalization",
+			args: map[string]any{"value": "72F", "fraction": 42.0},
+			want: []string{"must be between 0.0 and 1.0", "(value - minimum)"},
+		},
+		{
+			name: "fraction of the wrong type",
+			args: map[string]any{"value": "72F", "fraction": true},
+			want: []string{"expected a number between 0.0 and 1.0"},
+		},
+		{
+			name: "malformed color",
+			args: map[string]any{"value": "72F", "tint": "greenish"},
+			want: []string{"six-digit hex color", `"greenish"`},
+		},
+		{
+			name: "short color",
+			args: map[string]any{"value": "72F", "tint": "#fff"},
+			want: []string{"six-digit hex color"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := testTarget().Normalize(tt.args)
+			if err == nil {
+				t.Fatal("expected an error")
+			}
+			for _, want := range tt.want {
+				if !strings.Contains(err.Error(), want) {
+					t.Errorf("error %q does not contain %q", err, want)
+				}
+			}
+		})
+	}
+}
+
+func TestNormalizeRejectsRatherThanTruncates(t *testing.T) {
+	// The budget is a contract with the display, not a suggestion: a
+	// silently shortened value would render as a mystery on the watch.
+	_, err := testTarget().Normalize(map[string]any{"value": "1234567"})
+	if err == nil {
+		t.Fatal("expected an over-budget value to be rejected")
+	}
+	if strings.Contains(err.Error(), "truncat") && !strings.Contains(err.Error(), "rather than relying on truncation") {
+		t.Fatalf("error should not imply truncation happened: %q", err)
+	}
+}
+
+func TestNormalizeAgainstRegisteredTargets(t *testing.T) {
+	rectangular, ok := Lookup("apple_watch.rectangular")
+	if !ok {
+		t.Fatal("apple_watch.rectangular is not registered")
+	}
+	payload, err := rectangular.Normalize(map[string]any{
+		"value":       "64%",
+		"title":       "Battery",
+		"subtitle":    "House bank",
+		"bottom_text": "charging",
+		"fraction":    0.64,
+		"gauge_color": "#3FB950",
+	})
+	if err != nil {
+		t.Fatalf("Normalize: %v", err)
+	}
+	if payload.State != "64%" {
+		t.Fatalf("state = %q, want %q", payload.State, "64%")
+	}
+	if payload.Attributes["fraction"] != 0.64 {
+		t.Fatalf("fraction attribute = %v", payload.Attributes["fraction"])
+	}
+	if _, present := payload.Attributes["value"]; present {
+		t.Fatal("the primary slot must be the state, not also an attribute")
+	}
+
+	circular, ok := Lookup("apple_watch.circular")
+	if !ok {
+		t.Fatal("apple_watch.circular is not registered")
+	}
+	if _, err := circular.Normalize(map[string]any{"value": "1013 hPa"}); err == nil {
+		t.Fatal("expected the circular target to reject a value well over its budget")
+	}
+}

--- a/internal/model/outputtargets/normalize_test.go
+++ b/internal/model/outputtargets/normalize_test.go
@@ -5,6 +5,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"unicode/utf8"
 )
 
 func testTarget() Target {
@@ -206,5 +207,34 @@ func TestNormalizeAgainstRegisteredTargets(t *testing.T) {
 	}
 	if _, err := circular.Normalize(map[string]any{"value": "1013 hPa"}); err == nil {
 		t.Fatal("expected the circular target to reject a value well over its budget")
+	}
+}
+
+// TestPreviewBoundsModelSuppliedValues pins the size of an error, not
+// its wording. Slot values arrive from tool arguments, so a runaway
+// string would otherwise be echoed into the log and into the model's
+// next turn — spending context at the exact moment something is already
+// going wrong.
+func TestPreviewBoundsModelSuppliedValues(t *testing.T) {
+	huge := strings.Repeat("é", 5000)
+	slot := Slot{Name: "title", Kind: SlotKindText, MaxRunes: 18}
+
+	_, err := slot.normalizeText(huge)
+	if err == nil {
+		t.Fatal("an over-budget value should be refused")
+	}
+	if n := utf8.RuneCountInString(err.Error()); n > 300 {
+		t.Errorf("error is %d characters; a bounded preview should keep it short", n)
+	}
+	if !strings.Contains(err.Error(), "5000 characters") {
+		t.Errorf("the error should say how much arrived: %v", err)
+	}
+
+	// A short value is still quoted in full — the bound exists for the
+	// runaway case, not to make ordinary errors vaguer.
+	if _, err := slot.normalizeText("a value that is merely too long for this slot"); err == nil {
+		t.Fatal("expected refusal")
+	} else if !strings.Contains(err.Error(), "merely too long") {
+		t.Errorf("a short value should appear in full: %v", err)
 	}
 }

--- a/internal/model/outputtargets/schema.go
+++ b/internal/model/outputtargets/schema.go
@@ -1,0 +1,74 @@
+package outputtargets
+
+import "fmt"
+
+// Schema returns the JSON-Schema parameter object for a tool that fills
+// this target's slots: one property per slot, typed and bounded by the
+// slot's kind, with the required slots listed.
+//
+// The schema is advisory in the same sense as the loop spec schema — it
+// does not set additionalProperties:false, because rejecting an unknown
+// key silently at the provider layer teaches the model nothing.
+// [Target.Normalize] rejects unknown keys with an error that names the
+// valid slots instead.
+func (t Target) Schema() map[string]any {
+	properties := make(map[string]any, len(t.Slots))
+	required := make([]string, 0, len(t.Slots))
+	for _, slot := range t.Slots {
+		properties[slot.Name] = slot.schema()
+		if slot.Required {
+			required = append(required, slot.Name)
+		}
+	}
+	schema := map[string]any{
+		"type":       "object",
+		"properties": properties,
+	}
+	if len(required) > 0 {
+		schema["required"] = required
+	}
+	return schema
+}
+
+// schema returns the JSON-Schema fragment for one slot.
+func (s Slot) schema() map[string]any {
+	switch s.Kind {
+	case SlotKindText:
+		return map[string]any{
+			"type":        "string",
+			"maxLength":   s.MaxRunes,
+			"description": fmt.Sprintf("%s Maximum %d characters — over-budget values are rejected, not truncated.", s.Description, s.MaxRunes),
+		}
+	case SlotKindFraction:
+		return map[string]any{
+			"type":        "number",
+			"minimum":     0,
+			"maximum":     1,
+			"description": s.Description,
+		}
+	case SlotKindColor:
+		return map[string]any{
+			"type":        "string",
+			"pattern":     "^#?[0-9A-Fa-f]{6}$",
+			"description": s.Description + " Format: \"#RRGGBB\".",
+		}
+	default:
+		// Unreachable for registered targets: Target.validate rejects
+		// unknown kinds before a target enters the registry. Kept so a
+		// future kind that skips a schema case fails loudly in review
+		// rather than advertising an untyped parameter to the model.
+		return map[string]any{"description": s.Description}
+	}
+}
+
+// ToolDescription returns the model-facing description for the
+// request-scoped tool that fills this target, framed for one named
+// output. The caller supplies the output name and the entity the payload
+// lands on so the model can tell two declarations of the same target
+// apart.
+func (t Target) ToolDescription(outputName, entityID string) string {
+	return fmt.Sprintf(
+		"Set the loop-declared structured output %q, rendered as %s. %s Every call replaces the whole payload: slots you omit are cleared, so send the complete current state each time. Published to %s. %s",
+		outputName, t.Title, t.Summary, entityID, t.Binding,
+	)
+}

--- a/internal/model/outputtargets/schema.go
+++ b/internal/model/outputtargets/schema.go
@@ -50,7 +50,7 @@ func (s Slot) schema() map[string]any {
 		return map[string]any{
 			"type":        "string",
 			"pattern":     "^#?[0-9A-Fa-f]{6}$",
-			"description": s.Description + " Format: \"#RRGGBB\".",
+			"description": s.Description + " A six-digit hex colour, case-insensitive, with or without a leading \"#\" — stored as \"#RRGGBB\".",
 		}
 	default:
 		// Unreachable for registered targets: Target.validate rejects

--- a/internal/model/outputtargets/schema_test.go
+++ b/internal/model/outputtargets/schema_test.go
@@ -1,0 +1,98 @@
+package outputtargets
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestSchemaShapesEverySlot(t *testing.T) {
+	schema := testTarget().Schema()
+	if schema["type"] != "object" {
+		t.Fatalf("schema type = %v", schema["type"])
+	}
+
+	properties, ok := schema["properties"].(map[string]any)
+	if !ok {
+		t.Fatalf("properties is %T", schema["properties"])
+	}
+	if len(properties) != 4 {
+		t.Fatalf("expected 4 properties, got %d", len(properties))
+	}
+
+	required, ok := schema["required"].([]string)
+	if !ok {
+		t.Fatalf("required is %T", schema["required"])
+	}
+	if !reflect.DeepEqual(required, []string{"value"}) {
+		t.Fatalf("required = %v, want [value]", required)
+	}
+
+	value := properties["value"].(map[string]any)
+	if value["type"] != "string" {
+		t.Fatalf("value type = %v", value["type"])
+	}
+	if value["maxLength"] != 6 {
+		t.Fatalf("value maxLength = %v, want 6", value["maxLength"])
+	}
+	if desc, _ := value["description"].(string); !strings.Contains(desc, "Maximum 6 characters") {
+		t.Fatalf("value description does not state the budget: %q", desc)
+	}
+
+	fraction := properties["fraction"].(map[string]any)
+	if fraction["type"] != "number" || fraction["minimum"] != 0 || fraction["maximum"] != 1 {
+		t.Fatalf("fraction schema = %v", fraction)
+	}
+
+	tint := properties["tint"].(map[string]any)
+	if tint["type"] != "string" {
+		t.Fatalf("tint type = %v", tint["type"])
+	}
+	if pattern, _ := tint["pattern"].(string); pattern == "" {
+		t.Fatal("color slot has no pattern")
+	}
+}
+
+func TestSchemaIsAdvisory(t *testing.T) {
+	// Matching loopSpecSchema: no additionalProperties:false, so a
+	// provider never silently rejects a key. Normalize is what teaches.
+	for _, target := range All() {
+		if _, present := target.Schema()["additionalProperties"]; present {
+			t.Errorf("target %q sets additionalProperties; unknown keys are rejected by Normalize with a teaching error instead", target.ID)
+		}
+	}
+}
+
+func TestSchemaCoversRegisteredTargets(t *testing.T) {
+	for _, target := range All() {
+		schema := target.Schema()
+		properties, ok := schema["properties"].(map[string]any)
+		if !ok {
+			t.Fatalf("target %q has no properties", target.ID)
+		}
+		for _, slot := range target.Slots {
+			property, present := properties[slot.Name]
+			if !present {
+				t.Errorf("target %q slot %q missing from schema", target.ID, slot.Name)
+				continue
+			}
+			fragment := property.(map[string]any)
+			if fragment["type"] == nil {
+				t.Errorf("target %q slot %q has an untyped schema fragment", target.ID, slot.Name)
+			}
+		}
+	}
+}
+
+func TestToolDescriptionNamesOutputAndEntity(t *testing.T) {
+	target, ok := Lookup("apple_watch.rectangular")
+	if !ok {
+		t.Fatal("apple_watch.rectangular is not registered")
+	}
+	description := target.ToolDescription("watch_status", "sensor.thane_watch_status")
+	for _, want := range []string{"watch_status", "sensor.thane_watch_status", "replaces the whole payload"} {
+		if !strings.Contains(description, want) {
+			t.Errorf("description missing %q: %s", want, description)
+		}
+	}
+}

--- a/internal/model/outputtargets/target.go
+++ b/internal/model/outputtargets/target.go
@@ -1,0 +1,193 @@
+package outputtargets
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// SlotKind classifies what a slot accepts and how it is validated.
+type SlotKind string
+
+const (
+	// SlotKindText is a short display string constrained by
+	// [Slot.MaxRunes].
+	SlotKindText SlotKind = "text"
+	// SlotKindFraction is a number in [0.0, 1.0] driving a gauge, ring,
+	// or progress bar fill.
+	SlotKindFraction SlotKind = "fraction"
+	// SlotKindColor is an "#RRGGBB" hex color.
+	SlotKindColor SlotKind = "color"
+)
+
+// Slot is one named position in a target's layout.
+type Slot struct {
+	// Name is the slot identifier. It is both the tool parameter name
+	// and the payload attribute key, so it stays lower_snake_case.
+	Name string `json:"name"`
+	// Kind selects the validation rules applied to this slot's value.
+	Kind SlotKind `json:"kind"`
+	// Description is model-facing: what this slot renders as on the
+	// target surface, in enough detail to choose a good value.
+	Description string `json:"description"`
+	// Required marks a slot the target cannot render without. The
+	// primary slot is always required.
+	Required bool `json:"required,omitempty"`
+	// MaxRunes bounds a text slot's length in runes (not bytes). Zero
+	// means unbounded and is only valid for non-text kinds.
+	MaxRunes int `json:"max_runes,omitempty"`
+	// Primary marks the slot whose value becomes the payload state
+	// rather than an attribute. Exactly one slot per target sets it.
+	Primary bool `json:"primary,omitempty"`
+}
+
+// Target is one renderable surface with a fixed slot layout.
+type Target struct {
+	// ID is the stable identifier a loop output declares, such as
+	// "apple_watch.rectangular".
+	ID string `json:"id"`
+	// Title is the human-readable target name for operator surfaces.
+	Title string `json:"title"`
+	// Summary tells the model what this surface is and what shape of
+	// content survives on it.
+	Summary string `json:"summary"`
+	// Binding explains how the consuming surface reads the published
+	// payload, so the operator wiring is discoverable from the contract
+	// rather than from tribal knowledge.
+	Binding string `json:"binding"`
+	// Icon is the Material Design Icons name published with the sink's
+	// entity registration. Empty leaves the sink default.
+	Icon string `json:"icon,omitempty"`
+	// Slots are the target's positions in render order.
+	Slots []Slot `json:"slots"`
+}
+
+// PrimarySlot returns the slot whose value becomes the payload state.
+// Every registered target has one; the zero [Slot] and false are
+// returned for a target that does not, which [Target.validate] rejects at
+// registration.
+func (t Target) PrimarySlot() (Slot, bool) {
+	for _, slot := range t.Slots {
+		if slot.Primary {
+			return slot, true
+		}
+	}
+	return Slot{}, false
+}
+
+// Slot returns the named slot.
+func (t Target) Slot(name string) (Slot, bool) {
+	for _, slot := range t.Slots {
+		if slot.Name == name {
+			return slot, true
+		}
+	}
+	return Slot{}, false
+}
+
+// SlotNames returns every slot name in render order, for error messages
+// that need to enumerate the valid parameters.
+func (t Target) SlotNames() []string {
+	names := make([]string, 0, len(t.Slots))
+	for _, slot := range t.Slots {
+		names = append(names, slot.Name)
+	}
+	return names
+}
+
+// validate reports whether a target is internally coherent. It runs at
+// package init over the built-in registry, so a malformed target is a
+// build-time-adjacent failure (the first test or process start) rather
+// than a runtime surprise in a loop handler.
+func (t Target) validate() error {
+	if strings.TrimSpace(t.ID) == "" {
+		return fmt.Errorf("target id is required")
+	}
+	if len(t.Slots) == 0 {
+		return fmt.Errorf("target %q declares no slots", t.ID)
+	}
+	seen := make(map[string]struct{}, len(t.Slots))
+	primaries := 0
+	for _, slot := range t.Slots {
+		if strings.TrimSpace(slot.Name) == "" {
+			return fmt.Errorf("target %q has a slot with no name", t.ID)
+		}
+		if _, dup := seen[slot.Name]; dup {
+			return fmt.Errorf("target %q declares duplicate slot %q", t.ID, slot.Name)
+		}
+		seen[slot.Name] = struct{}{}
+		switch slot.Kind {
+		case SlotKindText:
+			if slot.MaxRunes <= 0 {
+				return fmt.Errorf("target %q slot %q is text and needs a positive max_runes", t.ID, slot.Name)
+			}
+		case SlotKindFraction, SlotKindColor:
+			if slot.MaxRunes != 0 {
+				return fmt.Errorf("target %q slot %q is %s and must not set max_runes", t.ID, slot.Name, slot.Kind)
+			}
+		default:
+			return fmt.Errorf("target %q slot %q has unsupported kind %q", t.ID, slot.Name, slot.Kind)
+		}
+		if slot.Primary {
+			primaries++
+			if slot.Kind != SlotKindText {
+				return fmt.Errorf("target %q primary slot %q must be text; the payload state is a scalar string", t.ID, slot.Name)
+			}
+			if !slot.Required {
+				return fmt.Errorf("target %q primary slot %q must be required", t.ID, slot.Name)
+			}
+		}
+	}
+	if primaries != 1 {
+		return fmt.Errorf("target %q declares %d primary slots; exactly one is required", t.ID, primaries)
+	}
+	return nil
+}
+
+// registry holds every built-in target keyed by ID. It is populated once
+// at init and never mutated, so no lock is needed for the read paths.
+var registry = func() map[string]Target {
+	targets := []Target{
+		appleWatchRectangular,
+		appleWatchCircular,
+	}
+	out := make(map[string]Target, len(targets))
+	for _, target := range targets {
+		if err := target.validate(); err != nil {
+			panic("outputtargets: invalid built-in target: " + err.Error())
+		}
+		if _, dup := out[target.ID]; dup {
+			panic("outputtargets: duplicate built-in target id " + target.ID)
+		}
+		out[target.ID] = target
+	}
+	return out
+}()
+
+// Lookup returns the registered target with the given ID.
+func Lookup(id string) (Target, bool) {
+	target, ok := registry[strings.TrimSpace(id)]
+	return target, ok
+}
+
+// IDs returns every registered target ID in sorted order. Callers use it
+// to enumerate valid choices in schemas and in errors that reject an
+// unknown target.
+func IDs() []string {
+	ids := make([]string, 0, len(registry))
+	for id := range registry {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	return ids
+}
+
+// All returns every registered target sorted by ID.
+func All() []Target {
+	ids := IDs()
+	targets := make([]Target, 0, len(ids))
+	for _, id := range ids {
+		targets = append(targets, registry[id])
+	}
+	return targets
+}

--- a/internal/model/outputtargets/target_test.go
+++ b/internal/model/outputtargets/target_test.go
@@ -1,0 +1,167 @@
+package outputtargets
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRegistryTargetsAreCoherent(t *testing.T) {
+	targets := All()
+	if len(targets) == 0 {
+		t.Fatal("registry is empty")
+	}
+	for _, target := range targets {
+		if err := target.validate(); err != nil {
+			t.Errorf("target %q: %v", target.ID, err)
+		}
+		if strings.TrimSpace(target.Summary) == "" {
+			t.Errorf("target %q has no summary; the model needs to know what surface it is filling", target.ID)
+		}
+		if strings.TrimSpace(target.Binding) == "" {
+			t.Errorf("target %q has no binding text; the operator wiring would be undiscoverable", target.ID)
+		}
+		for _, slot := range target.Slots {
+			if strings.TrimSpace(slot.Description) == "" {
+				t.Errorf("target %q slot %q has no description", target.ID, slot.Name)
+			}
+			if slot.Name != strings.ToLower(slot.Name) {
+				t.Errorf("target %q slot %q must be lower_snake_case: it is both a tool parameter and an attribute key", target.ID, slot.Name)
+			}
+		}
+	}
+}
+
+func TestLookup(t *testing.T) {
+	tests := []struct {
+		name string
+		id   string
+		want bool
+	}{
+		{name: "registered", id: "apple_watch.rectangular", want: true},
+		{name: "surrounding whitespace tolerated", id: "  apple_watch.circular  ", want: true},
+		{name: "unknown", id: "apple_watch.trapezoid", want: false},
+		{name: "empty", id: "", want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, ok := Lookup(tt.id)
+			if ok != tt.want {
+				t.Fatalf("Lookup(%q) ok = %v, want %v", tt.id, ok, tt.want)
+			}
+		})
+	}
+}
+
+func TestIDsSorted(t *testing.T) {
+	ids := IDs()
+	for i := 1; i < len(ids); i++ {
+		if ids[i-1] > ids[i] {
+			t.Fatalf("IDs not sorted: %v", ids)
+		}
+	}
+}
+
+func TestTargetValidateRejectsMalformed(t *testing.T) {
+	tests := []struct {
+		name   string
+		target Target
+		want   string
+	}{
+		{
+			name:   "no id",
+			target: Target{Slots: []Slot{{Name: "value", Kind: SlotKindText, MaxRunes: 4, Required: true, Primary: true}}},
+			want:   "target id is required",
+		},
+		{
+			name:   "no slots",
+			target: Target{ID: "x"},
+			want:   "declares no slots",
+		},
+		{
+			name: "no primary",
+			target: Target{ID: "x", Slots: []Slot{
+				{Name: "value", Kind: SlotKindText, MaxRunes: 4},
+			}},
+			want: "exactly one is required",
+		},
+		{
+			name: "two primaries",
+			target: Target{ID: "x", Slots: []Slot{
+				{Name: "a", Kind: SlotKindText, MaxRunes: 4, Required: true, Primary: true},
+				{Name: "b", Kind: SlotKindText, MaxRunes: 4, Required: true, Primary: true},
+			}},
+			want: "declares 2 primary slots",
+		},
+		{
+			name: "duplicate slot",
+			target: Target{ID: "x", Slots: []Slot{
+				{Name: "a", Kind: SlotKindText, MaxRunes: 4, Required: true, Primary: true},
+				{Name: "a", Kind: SlotKindText, MaxRunes: 4},
+			}},
+			want: "duplicate slot",
+		},
+		{
+			name: "text slot without budget",
+			target: Target{ID: "x", Slots: []Slot{
+				{Name: "a", Kind: SlotKindText, Required: true, Primary: true},
+			}},
+			want: "needs a positive max_runes",
+		},
+		{
+			name: "non-text primary",
+			target: Target{ID: "x", Slots: []Slot{
+				{Name: "a", Kind: SlotKindFraction, Required: true, Primary: true},
+			}},
+			want: "must be text",
+		},
+		{
+			name: "optional primary",
+			target: Target{ID: "x", Slots: []Slot{
+				{Name: "a", Kind: SlotKindText, MaxRunes: 4, Primary: true},
+			}},
+			want: "must be required",
+		},
+		{
+			name: "budget on a color slot",
+			target: Target{ID: "x", Slots: []Slot{
+				{Name: "a", Kind: SlotKindText, MaxRunes: 4, Required: true, Primary: true},
+				{Name: "tint", Kind: SlotKindColor, MaxRunes: 7},
+			}},
+			want: "must not set max_runes",
+		},
+		{
+			name: "unknown kind",
+			target: Target{ID: "x", Slots: []Slot{
+				{Name: "a", Kind: SlotKindText, MaxRunes: 4, Required: true, Primary: true},
+				{Name: "b", Kind: SlotKind("mystery")},
+			}},
+			want: "unsupported kind",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.target.validate()
+			if err == nil {
+				t.Fatal("expected an error")
+			}
+			if !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("error %q does not contain %q", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestPrimarySlotIsTheState(t *testing.T) {
+	for _, target := range All() {
+		slot, ok := target.PrimarySlot()
+		if !ok {
+			t.Fatalf("target %q has no primary slot", target.ID)
+		}
+		if slot.Name != "value" {
+			// Not a hard requirement of the model, but every target so
+			// far names its primary slot "value"; a divergence should be
+			// a deliberate decision rather than a typo.
+			t.Errorf("target %q primary slot is %q, expected the conventional \"value\"", target.ID, slot.Name)
+		}
+	}
+}

--- a/scripts/architecture.baseline
+++ b/scripts/architecture.baseline
@@ -1,5 +1,5 @@
-packages=65
-interfaces=84
+packages=66
+interfaces=83
 large_files=52
 set_mutators=116
 database_opens=9


### PR DESCRIPTION
#1253 built a working slot registry and then #1250 replaced the design around it. This preserves the part that survived.

## What survived, and why it could

The registry describes **surfaces and the values they hold**: named slots, per-slot kinds and rune budgets, one designated primary, and a single definition producing the argument schema, the validator, and the contract a model reads. It never knew about loops — who publishes to a surface lives entirely elsewhere.

That is why it survived a change to the framing above it. It imports **only stdlib**, and it compiles and passes its own tests against current `main` with no edits at all. I checked that before proposing this rather than after: copied the nine files onto main, ran the package tests, green.

Rebuilding it to say the same things in a different caller's vocabulary would have been waste. ~940 lines of registry plus ~475 of tests.

**`EnsureSensor` comes too**, and it applies as a pure addition — main simply lacks those 39 lines. It is needed regardless of how the binding is shaped: loops hydrate long after `Publisher.Start`, and `RegisterSensors` only takes effect at connect time, so an entity created at hydration would not reach Home Assistant until the next reconnect.

## What did not survive

`structured_payload` as a third output type, `set_output_*` as its own verb, and the wiring in `output.go` / `loop_outputs.go` / `loop_output_structured.go`. Those are precisely the files that would conflict with main after the facets rename and the journal removal — the conflicts and the discards turned out to be the same set.

## Deliberately unwired, and one knowingly stale string

The binding that consumes this is the next change, and it has a genuine open question: whether a slotted surface is **a facet whose format is target-shaped**, or **a binding that maps existing facets onto slots**. The second is what #1250 says; the first is what a gauge wanting a number in `[0,1]` seems to need, since no prose facet supplies one. Landing the registry first makes that change small enough to argue about on its merits instead of bundling it with 1,200 lines.

`Target.Schema` still describes a `set_output_*` verb from the superseded design. It reaches no model today because nothing calls it, and rewriting it now would mean guessing the verb the binding will use — so it is flagged here as work the consumer owes rather than quietly left.

## Test plan

- [x] `just ci` green locally
- [x] The registry's own suite passes unmodified on main — the salvage required no edits to the package
- [x] `EnsureSensor` applies as a pure addition; the mqtt package's tests pass
- [x] Architecture baseline regenerated via `scripts/architecture.sh update` for the new package (65 → 66)
- [x] Every file in this diff is the new package, the mqtt addition, or the baseline — verified by listing the diff rather than grepping it

Refs #1250, #1253

🤖 Generated with [Claude Code](https://claude.com/claude-code)
