### PR TITLE
A facet may be cut for a surface instead of a reader

### DIFF
--- a/internal/app/loop_output_publish.go
+++ b/internal/app/loop_output_publish.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/nugget/thane-ai-agent/internal/model/outputtargets"
 	looppkg "github.com/nugget/thane-ai-agent/internal/runtime/loop"
 	"github.com/nugget/thane-ai-agent/internal/state/documents"
 )
@@ -34,14 +35,7 @@ func buildFacetPublishTool(store *documents.Store, output looppkg.OutputSpec, no
 	properties := make(map[string]any, len(fields)+1)
 	required := make([]string, 0, len(fields))
 	for _, field := range fields {
-		description := field.Guidance + looppkg.FormatGuidance(field.Format)
-		if field.MaxRunes > 0 {
-			description = fmt.Sprintf("%s Maximum %d characters.", description, field.MaxRunes)
-		}
-		properties[field.Key] = map[string]any{
-			"type":        "string",
-			"description": description,
-		}
+		properties[field.Key] = facetArgumentSchema(field)
 		required = append(required, field.Key)
 	}
 	if notes != nil {
@@ -61,7 +55,7 @@ func buildFacetPublishTool(store *documents.Store, output looppkg.OutputSpec, no
 			"required":   required,
 		},
 		Handler: func(ctx context.Context, args map[string]any) (string, error) {
-			payload, err := facetPayloadFromArgs(output, args)
+			payload, err := output.FacetPayloadFromArgs(args)
 			if err != nil {
 				return "", err
 			}
@@ -100,6 +94,36 @@ func buildFacetPublishTool(store *documents.Store, output looppkg.OutputSpec, no
 	}
 }
 
+// facetArgumentSchema returns the JSON-Schema fragment for one publish
+// argument.
+//
+// A reading projection is a string with a budget. A target facet is not:
+// the surface it is cut for has named slots with their own types and
+// limits, so the argument is that slot object, taken whole from the
+// registry. The model then fills a watch complication by naming its
+// slots rather than by hand-encoding JSON into a string — the shape is
+// something it can be told, so it is.
+func facetArgumentSchema(field looppkg.FacetField) map[string]any {
+	if field.Target != "" {
+		if target, ok := outputtargets.Lookup(field.Target); ok {
+			schema := target.Schema()
+			schema["description"] = fmt.Sprintf(
+				"The %s. %s Every publish replaces the whole set: slots you omit are cleared. %s",
+				target.Title, target.Summary, target.Binding,
+			)
+			return schema
+		}
+	}
+	description := field.Guidance + looppkg.FormatGuidance(field.Format)
+	if field.MaxRunes > 0 {
+		description = fmt.Sprintf("%s Maximum %d characters.", description, field.MaxRunes)
+	}
+	return map[string]any{
+		"type":        "string",
+		"description": description,
+	}
+}
+
 // facetPublishDescription frames the publish interface for the model:
 // what it owns, that structure is not the model's job, and that the
 // projections move together.
@@ -116,34 +140,6 @@ func facetPublishDescription(output looppkg.OutputSpec, notes *looppkg.OutputSpe
 		description += " Pass notes to rewrite this loop's private working notes in the same call — what you currently believe, not an entry about this change."
 	}
 	return description
-}
-
-// facetPayloadFromArgs reads the publish arguments into a payload,
-// rejecting a non-string value with the argument name rather than
-// silently treating it as empty.
-func facetPayloadFromArgs(output looppkg.OutputSpec, args map[string]any) (looppkg.FacetPayload, error) {
-	var payload looppkg.FacetPayload
-	for _, field := range output.FacetFields() {
-		raw, present := args[field.Key]
-		if !present {
-			continue
-		}
-		value, ok := raw.(string)
-		if !ok {
-			return looppkg.FacetPayload{}, fmt.Errorf("%s must be a string", field.Key)
-		}
-		switch field.Key {
-		case "status_line":
-			payload.StatusLine = value
-		case "teaser":
-			payload.Teaser = value
-		case "digest":
-			payload.Digest = value
-		case "full":
-			payload.Full = value
-		}
-	}
-	return payload, nil
 }
 
 // writeLoopWorkingNotes replaces a working-notes body, stamping the

--- a/internal/app/loop_output_target_test.go
+++ b/internal/app/loop_output_target_test.go
@@ -1,0 +1,185 @@
+package app
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	looppkg "github.com/nugget/thane-ai-agent/internal/runtime/loop"
+	"github.com/nugget/thane-ai-agent/internal/state/documents"
+)
+
+const testTargetID = "apple_watch.rectangular"
+
+// targetedSpec declares a status line plus one rendering surface.
+func targetedSpec() looppkg.Spec {
+	return looppkg.Spec{
+		Name:       "ranch_office",
+		Enabled:    true,
+		Task:       "Curate the office domain.",
+		Operation:  looppkg.OperationService,
+		Completion: looppkg.CompletionNone,
+		Outputs: []looppkg.OutputSpec{
+			{
+				Name: "office status",
+				Type: looppkg.OutputTypeMaintainedDocument,
+				Ref:  "core:office.md",
+				Facets: []looppkg.FacetSpec{
+					{Name: looppkg.OutputFacetStatusLine},
+					{Target: testTargetID},
+				},
+			},
+		},
+	}
+}
+
+func targetPublishTool(t *testing.T, app *App) looppkg.RuntimeTool {
+	t.Helper()
+	hydrated, err := app.hydrateLoopOutputs(targetedSpec())
+	if err != nil {
+		t.Fatalf("hydrateLoopOutputs: %v", err)
+	}
+	return findRuntimeTool(t, hydrated, "publish_output_office_status")
+}
+
+// TestTargetFacetArgumentIsTheSlotObject is what declaring a target buys
+// over a bare json facet: the model is offered the surface's actual
+// slots, typed and bounded, instead of a string it has to encode by hand.
+func TestTargetFacetArgumentIsTheSlotObject(t *testing.T) {
+	t.Parallel()
+
+	store, _ := newLoopOutputDocumentStore(t)
+	publish := targetPublishTool(t, &App{documentStore: store})
+
+	properties, _ := publish.Parameters["properties"].(map[string]any)
+	arg, ok := properties["apple_watch_rectangular"].(map[string]any)
+	if !ok {
+		t.Fatalf("publish tool has no apple_watch_rectangular argument; properties = %v", properties)
+	}
+	if arg["type"] != "object" {
+		t.Errorf("target argument type = %v, want object", arg["type"])
+	}
+	slots, _ := arg["properties"].(map[string]any)
+	for _, name := range []string{"value", "title", "subtitle", "fraction", "gauge_color"} {
+		if _, ok := slots[name]; !ok {
+			t.Errorf("target argument is missing the %q slot", name)
+		}
+	}
+	// The budget has to reach the model, or it learns the limit by being
+	// rejected.
+	value, _ := slots["value"].(map[string]any)
+	if value["maxLength"] != 12 {
+		t.Errorf("value slot maxLength = %v, want the registry's 12", value["maxLength"])
+	}
+	if !strings.Contains(arg["description"].(string), "slots you omit are cleared") {
+		t.Errorf("target argument description does not say a publish replaces the whole set: %v", arg["description"])
+	}
+}
+
+func TestPublishWritesCanonicalSlotsIntoTheDocument(t *testing.T) {
+	t.Parallel()
+
+	store, coreDir := newLoopOutputDocumentStore(t)
+	publish := targetPublishTool(t, &App{documentStore: store})
+
+	if _, err := publish.Handler(context.Background(), map[string]any{
+		"status_line": "Printer online; 2 packages waiting.",
+		"full":        "# Office\n\nTwo packages.",
+		"apple_watch_rectangular": map[string]any{
+			"value":       "  2 pkg  ",
+			"title":       "Office",
+			"fraction":    0.5,
+			"gauge_color": "3fb950",
+		},
+	}); err != nil {
+		t.Fatalf("publish handler: %v", err)
+	}
+
+	raw, err := os.ReadFile(filepath.Join(coreDir, "office.md"))
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	written := string(raw)
+	if !strings.Contains(written, "## Apple Watch rectangular complication") {
+		t.Fatalf("document is missing the target section:\n%s", written)
+	}
+
+	payload := targetedSpec().Outputs[0].ParseFacetDocument(mustBody(t, store, "core:office.md"))
+	var slots map[string]any
+	if err := json.Unmarshal([]byte(payload.Targets[testTargetID]), &slots); err != nil {
+		t.Fatalf("stored slots are not JSON: %v\n%s", err, payload.Targets[testTargetID])
+	}
+	// Normalization is what the store keeps: trimmed text, canonical hex.
+	if slots["value"] != "2 pkg" {
+		t.Errorf("stored value = %q, want the trimmed form", slots["value"])
+	}
+	if slots["gauge_color"] != "#3FB950" {
+		t.Errorf("stored gauge_color = %q, want the canonical #RRGGBB form", slots["gauge_color"])
+	}
+	if slots["fraction"] != 0.5 {
+		t.Errorf("stored fraction = %v, want 0.5", slots["fraction"])
+	}
+}
+
+func TestPublishRejectsSlotValuesTheSurfaceCannotRender(t *testing.T) {
+	t.Parallel()
+
+	store, coreDir := newLoopOutputDocumentStore(t)
+	publish := targetPublishTool(t, &App{documentStore: store})
+
+	_, err := publish.Handler(context.Background(), map[string]any{
+		"status_line": "All clear.",
+		"full":        "Body.",
+		"apple_watch_rectangular": map[string]any{
+			"value": "a headline far too long for the slot",
+		},
+	})
+	if err == nil {
+		t.Fatal("publish handler error = nil for an over-budget slot, want an error")
+	}
+	for _, want := range []string{"apple_watch_rectangular", "value", "at most 12"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error = %v, want it to mention %q", err, want)
+		}
+	}
+
+	// Nothing was written: a rejected publish must not leave a document
+	// holding half a payload.
+	if _, err := os.Stat(filepath.Join(coreDir, "office.md")); !os.IsNotExist(err) {
+		t.Errorf("a rejected publish wrote the document anyway (stat err = %v)", err)
+	}
+}
+
+// TestPublishAcceptsAStringEncodedSlotObject covers the model families
+// that send a nested object as its JSON text rather than as an object.
+func TestPublishAcceptsAStringEncodedSlotObject(t *testing.T) {
+	t.Parallel()
+
+	store, _ := newLoopOutputDocumentStore(t)
+	publish := targetPublishTool(t, &App{documentStore: store})
+
+	if _, err := publish.Handler(context.Background(), map[string]any{
+		"status_line":             "All clear.",
+		"full":                    "Body.",
+		"apple_watch_rectangular": `{"value":"2 pkg","title":"Office"}`,
+	}); err != nil {
+		t.Fatalf("publish handler: %v", err)
+	}
+
+	payload := targetedSpec().Outputs[0].ParseFacetDocument(mustBody(t, store, "core:office.md"))
+	if !strings.Contains(payload.Targets[testTargetID], `"value": "2 pkg"`) {
+		t.Fatalf("string-encoded slots did not land: %q", payload.Targets[testTargetID])
+	}
+}
+
+func mustBody(t *testing.T, store *documents.Store, ref string) string {
+	t.Helper()
+	doc, err := store.Read(context.Background(), ref)
+	if err != nil {
+		t.Fatalf("Read(%s): %v", ref, err)
+	}
+	return doc.Body
+}

--- a/internal/model/outputtargets/normalize.go
+++ b/internal/model/outputtargets/normalize.go
@@ -33,11 +33,59 @@ type Payload struct {
 // not carry values forward from a previous payload, because the tool
 // contract is a full replacement.
 func (t Target) Normalize(args map[string]any) (Payload, error) {
-	if err := t.rejectUnknownSlots(args); err != nil {
+	slots, err := t.NormalizeSlots(args)
+	if err != nil {
 		return Payload{}, err
 	}
 
-	payload := Payload{Attributes: make(map[string]any, len(t.Slots))}
+	payload := Payload{Attributes: make(map[string]any, len(slots))}
+	for _, slot := range t.Slots {
+		value, ok := slots[slot.Name]
+		if !ok {
+			continue
+		}
+		if slot.Primary {
+			// validate guarantees the primary slot is text, so this
+			// assertion cannot fail for a registered target.
+			payload.State, _ = value.(string)
+			continue
+		}
+		payload.Attributes[slot.Name] = value
+	}
+
+	if payload.State == "" {
+		// Unreachable for a registered target (validate guarantees a
+		// required primary slot, and NormalizeSlots rejects a missing
+		// required slot), but a sink publishing an empty state would
+		// produce an entity HA renders as "unknown" — fail here instead.
+		return Payload{}, fmt.Errorf("target %q produced no state value", t.ID)
+	}
+	if len(payload.Attributes) == 0 {
+		payload.Attributes = nil
+	}
+	return payload, nil
+}
+
+// NormalizeSlots validates raw tool arguments and returns the canonical
+// slot values, keyed by slot name.
+//
+// It is the half of [Target.Normalize] that a store wants rather than a
+// sink: slot values keep which slot each one filled, so they can be
+// re-normalized for any binding later, while a [Payload] has already
+// collapsed them into one state and a bag of attributes. Canonical here
+// means what normalization is allowed to change — whitespace trimmed,
+// color hex uppercased — so two callers sending the same values in
+// different spellings store the same thing.
+//
+// A cleared slot (absent, null, or blank text) is absent from the result
+// rather than present and empty, so a caller can tell "not set" from
+// "set to nothing" without consulting the target.
+func (t Target) NormalizeSlots(args map[string]any) (map[string]any, error) {
+	if err := t.rejectUnknownSlots(args); err != nil {
+		return nil, err
+	}
+
+	slots := make(map[string]any, len(t.Slots))
 	for _, slot := range t.Slots {
 		raw, present := args[slot.Name]
 		// An explicit JSON null is how some model families spell "leave
@@ -47,62 +95,47 @@ func (t Target) Normalize(args map[string]any) (Payload, error) {
 		}
 		if !present {
 			if slot.Required {
-				return Payload{}, fmt.Errorf("slot %q is required for target %q but was not supplied; %s", slot.Name, t.ID, slot.Description)
+				return nil, fmt.Errorf("slot %q is required for target %q but was not supplied; %s", slot.Name, t.ID, slot.Description)
 			}
 			continue
 		}
 
 		// Each kind is handled in its own branch rather than through a
-		// common any-returning helper: only text slots can be primary
-		// or blank-and-therefore-cleared, and routing every kind through
-		// one signature would mean type-asserting that back out.
+		// common any-returning helper: only text slots can be
+		// blank-and-therefore-cleared, and routing every kind through one
+		// signature would mean type-asserting that back out.
 		switch slot.Kind {
 		case SlotKindText:
 			text, err := slot.normalizeText(raw)
 			if err != nil {
-				return Payload{}, fmt.Errorf("slot %q: %w", slot.Name, err)
+				return nil, fmt.Errorf("slot %q: %w", slot.Name, err)
 			}
 			if text == "" {
 				if slot.Required {
-					return Payload{}, fmt.Errorf("slot %q is required for target %q but was empty after trimming whitespace", slot.Name, t.ID)
+					return nil, fmt.Errorf("slot %q is required for target %q but was empty after trimming whitespace", slot.Name, t.ID)
 				}
 				// An optional slot explicitly set to blank means "clear
 				// it", which is the same as omitting it.
 				continue
 			}
-			if slot.Primary {
-				payload.State = text
-				continue
-			}
-			payload.Attributes[slot.Name] = text
+			slots[slot.Name] = text
 		case SlotKindFraction:
 			fraction, err := slot.normalizeFraction(raw)
 			if err != nil {
-				return Payload{}, fmt.Errorf("slot %q: %w", slot.Name, err)
+				return nil, fmt.Errorf("slot %q: %w", slot.Name, err)
 			}
-			payload.Attributes[slot.Name] = fraction
+			slots[slot.Name] = fraction
 		case SlotKindColor:
 			color, err := slot.normalizeColor(raw)
 			if err != nil {
-				return Payload{}, fmt.Errorf("slot %q: %w", slot.Name, err)
+				return nil, fmt.Errorf("slot %q: %w", slot.Name, err)
 			}
-			payload.Attributes[slot.Name] = color
+			slots[slot.Name] = color
 		default:
-			return Payload{}, fmt.Errorf("slot %q: unsupported slot kind %q", slot.Name, slot.Kind)
+			return nil, fmt.Errorf("slot %q: unsupported slot kind %q", slot.Name, slot.Kind)
 		}
 	}
-
-	if payload.State == "" {
-		// Unreachable for a registered target (validate guarantees a
-		// required primary slot, and the required check above fires
-		// first), but a sink publishing an empty state would produce an
-		// entity HA renders as "unknown" — fail here instead.
-		return Payload{}, fmt.Errorf("target %q produced no state value", t.ID)
-	}
-	if len(payload.Attributes) == 0 {
-		payload.Attributes = nil
-	}
-	return payload, nil
+	return slots, nil
 }
 
 // rejectUnknownSlots fails on any argument key the target does not

--- a/internal/model/outputtargets/target.go
+++ b/internal/model/outputtargets/target.go
@@ -85,6 +85,14 @@ func (t Target) Slot(name string) (Slot, bool) {
 	return Slot{}, false
 }
 
+// ArgKey returns the target's ID in a form usable where a dot is not
+// allowed — a tool argument name, a document section key, an MQTT topic
+// segment. The registry guarantees these stay unique across targets, so
+// a consumer may key on it as safely as on the ID itself.
+func (t Target) ArgKey() string {
+	return strings.ReplaceAll(t.ID, ".", "_")
+}
+
 // SlotNames returns every slot name in render order, for error messages
 // that need to enumerate the valid parameters.
 func (t Target) SlotNames() []string {
@@ -102,6 +110,11 @@ func (t Target) SlotNames() []string {
 func (t Target) validate() error {
 	if strings.TrimSpace(t.ID) == "" {
 		return fmt.Errorf("target id is required")
+	}
+	if strings.TrimSpace(t.Title) == "" {
+		// The title is how a consumer names this surface to a reader, so
+		// an empty one is a target that renders as a blank heading.
+		return fmt.Errorf("target %q has no title", t.ID)
 	}
 	if len(t.Slots) == 0 {
 		return fmt.Errorf("target %q declares no slots", t.ID)
@@ -152,6 +165,13 @@ var registry = func() map[string]Target {
 		appleWatchCircular,
 	}
 	out := make(map[string]Target, len(targets))
+	// Titles and arg keys are identities too: a consumer renders a target
+	// by title and keys arguments by ArgKey, so a collision in either
+	// would make two distinct surfaces indistinguishable downstream. They
+	// are checked here, where the registry is the only place that can
+	// introduce one.
+	titles := make(map[string]string, len(targets))
+	argKeys := make(map[string]string, len(targets))
 	for _, target := range targets {
 		if err := target.validate(); err != nil {
 			panic("outputtargets: invalid built-in target: " + err.Error())
@@ -159,6 +179,14 @@ var registry = func() map[string]Target {
 		if _, dup := out[target.ID]; dup {
 			panic("outputtargets: duplicate built-in target id " + target.ID)
 		}
+		if other, dup := titles[strings.ToLower(target.Title)]; dup {
+			panic("outputtargets: targets " + other + " and " + target.ID + " share the title " + target.Title)
+		}
+		if other, dup := argKeys[target.ArgKey()]; dup {
+			panic("outputtargets: targets " + other + " and " + target.ID + " share the arg key " + target.ArgKey())
+		}
+		titles[strings.ToLower(target.Title)] = target.ID
+		argKeys[target.ArgKey()] = target.ID
 		out[target.ID] = target
 	}
 	return out

--- a/internal/model/outputtargets/target_test.go
+++ b/internal/model/outputtargets/target_test.go
@@ -73,20 +73,25 @@ func TestTargetValidateRejectsMalformed(t *testing.T) {
 			want:   "target id is required",
 		},
 		{
-			name:   "no slots",
+			name:   "no title",
 			target: Target{ID: "x"},
+			want:   "has no title",
+		},
+		{
+			name:   "no slots",
+			target: Target{ID: "x", Title: "X"},
 			want:   "declares no slots",
 		},
 		{
 			name: "no primary",
-			target: Target{ID: "x", Slots: []Slot{
+			target: Target{ID: "x", Title: "X", Slots: []Slot{
 				{Name: "value", Kind: SlotKindText, MaxRunes: 4},
 			}},
 			want: "exactly one is required",
 		},
 		{
 			name: "two primaries",
-			target: Target{ID: "x", Slots: []Slot{
+			target: Target{ID: "x", Title: "X", Slots: []Slot{
 				{Name: "a", Kind: SlotKindText, MaxRunes: 4, Required: true, Primary: true},
 				{Name: "b", Kind: SlotKindText, MaxRunes: 4, Required: true, Primary: true},
 			}},
@@ -94,7 +99,7 @@ func TestTargetValidateRejectsMalformed(t *testing.T) {
 		},
 		{
 			name: "duplicate slot",
-			target: Target{ID: "x", Slots: []Slot{
+			target: Target{ID: "x", Title: "X", Slots: []Slot{
 				{Name: "a", Kind: SlotKindText, MaxRunes: 4, Required: true, Primary: true},
 				{Name: "a", Kind: SlotKindText, MaxRunes: 4},
 			}},
@@ -102,28 +107,28 @@ func TestTargetValidateRejectsMalformed(t *testing.T) {
 		},
 		{
 			name: "text slot without budget",
-			target: Target{ID: "x", Slots: []Slot{
+			target: Target{ID: "x", Title: "X", Slots: []Slot{
 				{Name: "a", Kind: SlotKindText, Required: true, Primary: true},
 			}},
 			want: "needs a positive max_runes",
 		},
 		{
 			name: "non-text primary",
-			target: Target{ID: "x", Slots: []Slot{
+			target: Target{ID: "x", Title: "X", Slots: []Slot{
 				{Name: "a", Kind: SlotKindFraction, Required: true, Primary: true},
 			}},
 			want: "must be text",
 		},
 		{
 			name: "optional primary",
-			target: Target{ID: "x", Slots: []Slot{
+			target: Target{ID: "x", Title: "X", Slots: []Slot{
 				{Name: "a", Kind: SlotKindText, MaxRunes: 4, Primary: true},
 			}},
 			want: "must be required",
 		},
 		{
 			name: "budget on a color slot",
-			target: Target{ID: "x", Slots: []Slot{
+			target: Target{ID: "x", Title: "X", Slots: []Slot{
 				{Name: "a", Kind: SlotKindText, MaxRunes: 4, Required: true, Primary: true},
 				{Name: "tint", Kind: SlotKindColor, MaxRunes: 7},
 			}},
@@ -131,7 +136,7 @@ func TestTargetValidateRejectsMalformed(t *testing.T) {
 		},
 		{
 			name: "unknown kind",
-			target: Target{ID: "x", Slots: []Slot{
+			target: Target{ID: "x", Title: "X", Slots: []Slot{
 				{Name: "a", Kind: SlotKindText, MaxRunes: 4, Required: true, Primary: true},
 				{Name: "b", Kind: SlotKind("mystery")},
 			}},

--- a/internal/runtime/loop/facet_spec.go
+++ b/internal/runtime/loop/facet_spec.go
@@ -35,15 +35,39 @@ const (
 // case is a name and nothing else — `facets: [status_line, teaser]`
 // stays readable, and an author who needs an attribute reaches for the
 // longer form only on the facet that needs it.
+//
+// A facet is identified either by [FacetSpec.Name] — one of the reading
+// projections, cut for surfaces that show prose at different sizes — or
+// by [FacetSpec.Target], cut for a surface that shows no prose at all.
+// The two are alternatives rather than a name with a modifier: a watch
+// complication is not a longer status line, it is a different face.
 type FacetSpec struct {
-	// Name is which face this is: status_line, teaser, or digest.
-	Name OutputFacet `yaml:"name" json:"name"`
-	// Format is how the value is encoded. Empty means markdown.
+	// Name is which reading projection this is: status_line, teaser, or
+	// digest. Empty when Target is set.
+	Name OutputFacet `yaml:"name,omitempty" json:"name,omitempty"`
+	// Target is the registered [outputtargets] surface this facet is cut
+	// for, such as "apple_watch.rectangular". The surface's slots, their
+	// budgets, and their validation all come from the registry, so an
+	// author declares where the value goes and nothing about its shape.
+	Target string `yaml:"target,omitempty" json:"target,omitempty"`
+	// Format is how the value is encoded. Empty means markdown, or json
+	// for a target facet, whose value is always a slot object.
 	Format FacetFormat `yaml:"format,omitempty" json:"format,omitempty"`
 }
 
-// EffectiveFormat resolves the declared format, defaulting to markdown.
+// IsTarget reports whether this facet is cut for a registered surface
+// rather than for reading.
+func (f FacetSpec) IsTarget() bool {
+	return strings.TrimSpace(f.Target) != ""
+}
+
+// EffectiveFormat resolves the declared format. A target facet is always
+// json — its value is a slot object the registry defines — and every
+// other facet defaults to markdown.
 func (f FacetSpec) EffectiveFormat() FacetFormat {
+	if f.IsTarget() {
+		return FacetFormatJSON
+	}
 	if f.Format == "" {
 		return FacetFormatMarkdown
 	}
@@ -88,9 +112,11 @@ func (f *FacetSpec) UnmarshalYAML(unmarshal func(any) error) error {
 }
 
 // MarshalJSON writes the short form when nothing but the name is set, so
-// a round trip does not inflate every declaration into an object.
+// a round trip does not inflate every declaration into an object. A
+// target facet always takes the object form: its identity lives in a
+// field the short form cannot carry.
 func (f FacetSpec) MarshalJSON() ([]byte, error) {
-	if f.Format == "" {
+	if f.Format == "" && !f.IsTarget() {
 		return json.Marshal(string(f.Name))
 	}
 	type facetSpecWire FacetSpec

--- a/internal/runtime/loop/output.go
+++ b/internal/runtime/loop/output.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"strings"
 	"unicode"
+
+	"github.com/nugget/thane-ai-agent/internal/model/outputtargets"
 )
 
 const maxOutputToolNameLength = 64
@@ -220,12 +222,24 @@ func validateOutputFacets(o OutputSpec) error {
 		return fmt.Errorf("facets declare published projections, but audience is %q; an internal output has no consumers to cut a facet for", OutputAudienceInternal)
 	}
 	seen := make(map[OutputFacet]struct{}, len(o.Facets))
+	seenTargets := make(map[string]struct{}, len(o.Facets))
 	hasStatusLine := false
 	for i, facet := range o.Facets {
+		if facet.IsTarget() {
+			if err := validateTargetFacet(i, facet); err != nil {
+				return err
+			}
+			id := strings.TrimSpace(facet.Target)
+			if _, dup := seenTargets[id]; dup {
+				return fmt.Errorf("facets[%d]: duplicate target %q; one facet is one face, and a surface cannot be shown two different values at once", i, id)
+			}
+			seenTargets[id] = struct{}{}
+			continue
+		}
 		switch facet.Name {
 		case OutputFacetStatusLine, OutputFacetTeaser, OutputFacetDigest:
 		default:
-			return fmt.Errorf("facets[%d]: unsupported facet %q; use %q, %q, or %q (the full body is the document itself, not a declared facet)", i, facet.Name, OutputFacetStatusLine, OutputFacetTeaser, OutputFacetDigest)
+			return fmt.Errorf("facets[%d]: unsupported facet %q; use %q, %q, or %q for reading projections, or {\"target\": \"...\"} for a rendering surface (the full body is the document itself, not a declared facet)", i, facet.Name, OutputFacetStatusLine, OutputFacetTeaser, OutputFacetDigest)
 		}
 		if _, ok := validFacetFormats[facet.EffectiveFormat()]; !ok {
 			return fmt.Errorf("facets[%d]: unsupported format %q for %q; use %q, %q, or %q", i, facet.Format, facet.Name, FacetFormatMarkdown, FacetFormatPlain, FacetFormatJSON)
@@ -240,6 +254,24 @@ func validateOutputFacets(o OutputSpec) error {
 	}
 	if !hasStatusLine {
 		return fmt.Errorf("facets must include %q; the ambient one-line projection is the one every surface can take (teaser and digest are optional)", OutputFacetStatusLine)
+	}
+	return nil
+}
+
+// validateTargetFacet checks a facet cut for a rendering surface. The
+// registry owns everything about the surface itself, so what is checked
+// here is only that the declaration points at a real one and does not
+// also try to be a reading projection.
+func validateTargetFacet(i int, facet FacetSpec) error {
+	id := strings.TrimSpace(facet.Target)
+	if facet.Name != "" {
+		return fmt.Errorf("facets[%d]: declares both name %q and target %q; a facet is one face — a rendering surface is not a variant of a reading projection, so declare them as separate facets", i, facet.Name, id)
+	}
+	if facet.Format != "" && facet.Format != FacetFormatJSON {
+		return fmt.Errorf("facets[%d]: target %q declares format %q, but a target facet is always %q — its value is the surface's slot object, not prose", i, id, facet.Format, FacetFormatJSON)
+	}
+	if _, ok := outputtargets.Lookup(id); !ok {
+		return fmt.Errorf("facets[%d]: unknown target %q; registered targets are %s", i, id, strings.Join(outputtargets.IDs(), ", "))
 	}
 	return nil
 }

--- a/internal/runtime/loop/output_facets.go
+++ b/internal/runtime/loop/output_facets.go
@@ -3,8 +3,11 @@ package loop
 import (
 	"encoding/json"
 	"fmt"
+	"sort"
 	"strings"
 	"unicode/utf8"
+
+	"github.com/nugget/thane-ai-agent/internal/model/outputtargets"
 )
 
 // Rune budgets for the published projection facets. They are display
@@ -29,6 +32,12 @@ type FacetPayload struct {
 	Teaser     string
 	Digest     string
 	Full       string
+	// Targets holds the slot object published to each declared target
+	// facet, keyed by target ID and JSON-encoded exactly as it is stored
+	// in the document. The slots are the canonical content: what a sink
+	// publishes is derived from them by the registry, so the document
+	// keeps what the model wrote rather than what a binding made of it.
+	Targets map[string]string
 }
 
 // FacetField describes one publishable field of a faceted output, as the
@@ -46,25 +55,36 @@ type FacetField struct {
 	// Format is how this facet's value is encoded. Empty on the full
 	// body, which is always markdown.
 	Format FacetFormat
+	// Target is the registered surface this field fills, empty for a
+	// reading projection. A field that names one takes its arguments,
+	// budgets, and validation from the registry rather than from the
+	// contract here, so a consumer must ask the registry what it accepts.
+	Target string
 }
 
 // facetSection binds one projection to its canonical document section and
 // its budget.
 type facetSection struct {
 	// Facet is the declared facet this section publishes, or empty for
-	// the always-present full projection.
+	// the always-present full projection and for target sections.
 	Facet   OutputFacet
 	Field   FacetField
 	Heading string
-	value   func(*FacetPayload) *string
+	get     func(FacetPayload) string
+	set     func(*FacetPayload, string)
 }
 
-// facetSections is the single source of truth for the publish tool's
-// schema, the payload validator, the document renderer, and the parser
-// that reads a rendered document back — so those four cannot drift
-// apart. Order is the canonical ladder order; declaration order in a
+// readingSections and fullSection are the single source of truth for the
+// publish tool's schema, the payload validator, the document renderer,
+// and the parser that reads a rendered document back — so those four
+// cannot drift apart. Order here is canonical; declaration order in a
 // spec's facets list carries no meaning.
-var facetSections = []facetSection{
+//
+// They are split because a spec's section table is assembled rather than
+// fixed: target facets land between the reading projections and the full
+// body, near the machine-readable end and ahead of the document's
+// substance.
+var readingSections = []facetSection{
 	{
 		Facet:   OutputFacetStatusLine,
 		Heading: "Status Line",
@@ -74,7 +94,8 @@ var facetSections = []facetSection{
 			SingleLine: true,
 			Guidance:   "One standalone line of current state, no line breaks. Reads as an ambient status: what is true right now. This is the only thing some surfaces show, so it must stand alone without the document around it.",
 		},
-		value: func(p *FacetPayload) *string { return &p.StatusLine },
+		get: func(p FacetPayload) string { return p.StatusLine },
+		set: func(p *FacetPayload, v string) { p.StatusLine = v },
 	},
 	{
 		Facet:   OutputFacetTeaser,
@@ -84,7 +105,8 @@ var facetSections = []facetSection{
 			MaxRunes: teaserMaxRunes,
 			Guidance: "One short paragraph on why a reader would open this document right now. Surfaces as the snippet in search results and cross-references, so write the hook — the reason to look — rather than a compressed summary.",
 		},
-		value: func(p *FacetPayload) *string { return &p.Teaser },
+		get: func(p FacetPayload) string { return p.Teaser },
+		set: func(p *FacetPayload, v string) { p.Teaser = v },
 	},
 	{
 		Facet:   OutputFacetDigest,
@@ -94,44 +116,71 @@ var facetSections = []facetSection{
 			MaxRunes: digestMaxRunes,
 			Guidance: "A standalone summary carrying enough substance to act on without opening the full document. Surfaces in subscription rows and periodic digests.",
 		},
-		value: func(p *FacetPayload) *string { return &p.Digest },
-	},
-	{
-		Heading: "Details",
-		Field: FacetField{
-			Key:      "full",
-			Guidance: "The complete current state in markdown. This is what a reader opens when the digest is not enough. Always required: it is the document's substance, and the other projections are views of it.",
-		},
-		value: func(p *FacetPayload) *string { return &p.Full },
+		get: func(p FacetPayload) string { return p.Digest },
+		set: func(p *FacetPayload, v string) { p.Digest = v },
 	},
 }
 
-// FacetFields returns the fields a faceted output publishes, in canonical
-// ladder order: each declared facet, then the always-present full
-// projection. Every returned field is required at publish time —
-// optionality lives in the declaration (a spec may declare only
-// status_line), not in the write.
-func (o OutputSpec) FacetFields() []FacetField {
+var fullSection = facetSection{
+	Heading: "Details",
+	Field: FacetField{
+		Key:      "full",
+		Guidance: "The complete current state in markdown. This is what a reader opens when the digest is not enough. Always required: it is the document's substance, and the other projections are views of it.",
+	},
+	get: func(p FacetPayload) string { return p.Full },
+	set: func(p *FacetPayload, v string) { p.Full = v },
+}
+
+// sections returns this output's section table in render order: each
+// declared reading projection, each declared target, then the
+// always-present full body.
+func (o OutputSpec) sections() []facetSection {
 	if len(o.Facets) == 0 {
 		return nil
 	}
 	declared := make(map[OutputFacet]FacetSpec, len(o.Facets))
+	targets := make([]string, 0, len(o.Facets))
 	for _, facet := range o.Facets {
-		declared[facet.Name] = facet
-	}
-	fields := make([]FacetField, 0, len(o.Facets)+1)
-	for _, section := range facetSections {
-		// The full body is always published and is never declared, so it
-		// carries the contract's own format rather than a facet's.
-		if section.Facet == "" {
-			fields = append(fields, section.Field)
+		if facet.IsTarget() {
+			targets = append(targets, strings.TrimSpace(facet.Target))
 			continue
 		}
-		if facet, ok := declared[section.Facet]; ok {
-			field := section.Field
-			field.Format = facet.EffectiveFormat()
-			fields = append(fields, field)
+		declared[facet.Name] = facet
+	}
+
+	sections := make([]facetSection, 0, len(o.Facets)+1)
+	for _, section := range readingSections {
+		facet, ok := declared[section.Facet]
+		if !ok {
+			continue
 		}
+		section.Field.Format = facet.EffectiveFormat()
+		sections = append(sections, section)
+	}
+	// Sorted by ID so the document's section order is a property of the
+	// spec's content rather than of the order an author happened to type.
+	sort.Strings(targets)
+	for _, id := range targets {
+		if section, ok := targetSection(id); ok {
+			sections = append(sections, section)
+		}
+	}
+	return append(sections, fullSection)
+}
+
+// FacetFields returns the fields a faceted output publishes, in canonical
+// order: each declared facet, then the always-present full projection.
+// Every returned field is required at publish time — optionality lives in
+// the declaration (a spec may declare only status_line), not in the
+// write.
+func (o OutputSpec) FacetFields() []FacetField {
+	sections := o.sections()
+	if len(sections) == 0 {
+		return nil
+	}
+	fields := make([]FacetField, 0, len(sections))
+	for _, section := range sections {
+		fields = append(fields, section.Field)
 	}
 	return fields
 }
@@ -150,12 +199,10 @@ func (o OutputSpec) ValidateFacetPayload(payload FacetPayload) error {
 	if !o.HasFacets() {
 		return fmt.Errorf("output %q does not declare facets", o.Name)
 	}
-	for _, field := range o.FacetFields() {
-		section, ok := facetSectionByKey(field.Key)
-		if !ok {
-			continue
-		}
-		value := strings.TrimSpace(*section.value(&payload))
+	sections := o.sections()
+	for _, section := range sections {
+		field := section.Field
+		value := strings.TrimSpace(section.get(payload))
 		if value == "" {
 			return fmt.Errorf("%s is required; every declared projection is published together so they cannot describe different moments", field.Key)
 		}
@@ -170,7 +217,7 @@ func (o OutputSpec) ValidateFacetPayload(payload FacetPayload) error {
 				return fmt.Errorf("%s is %d characters and the limit is %d; tighten it rather than letting it be cut, because a clipped projection reads as a fragment with no sign that anything is missing", field.Key, runes, field.MaxRunes)
 			}
 		}
-		if heading, found := firstReservedFacetHeading(value); found {
+		if heading, found := reservedHeadingIn(sections, value); found {
 			return fmt.Errorf("%s contains the reserved section heading %q; the facet headings are rendered automatically from the contract, so publish only the content beneath them", field.Key, heading)
 		}
 	}
@@ -182,26 +229,14 @@ func (o OutputSpec) ValidateFacetPayload(payload FacetPayload) error {
 // structure so the model never authors the section convention and the
 // document stays parseable back into a payload.
 func (o OutputSpec) RenderFacetDocument(payload FacetPayload) string {
-	fields := o.FacetFields()
-	published := make(map[string]struct{}, len(fields))
-	for _, field := range fields {
-		published[field.Key] = struct{}{}
-	}
-	formats := make(map[string]FacetFormat, len(fields))
-	for _, field := range fields {
-		formats[field.Key] = field.Format
-	}
-
-	blocks := make([]string, 0, len(fields))
-	for _, section := range facetSections {
-		if _, ok := published[section.Field.Key]; !ok {
-			continue
-		}
-		value := strings.TrimSpace(*section.value(&payload))
+	sections := o.sections()
+	blocks := make([]string, 0, len(sections))
+	for _, section := range sections {
+		value := strings.TrimSpace(section.get(payload))
 		if value == "" {
 			continue
 		}
-		if formats[section.Field.Key] == FacetFormatJSON {
+		if section.Field.Format == FacetFormatJSON {
 			value = jsonFence + "\n" + value + "\n" + fenceClose
 		}
 		blocks = append(blocks, "## "+section.Heading+"\n\n"+value)
@@ -220,13 +255,14 @@ func (o OutputSpec) RenderFacetDocument(payload FacetPayload) string {
 // into the faceted contract without losing its content. Content ahead of
 // the first recognized heading is folded into Full for the same reason.
 func (o OutputSpec) ParseFacetDocument(body string) FacetPayload {
+	sections := o.sections()
 	var payload FacetPayload
 	var preamble []string
 	current := ""
-	collected := make(map[string][]string, len(facetSections))
+	collected := make(map[string][]string, len(sections))
 
 	for _, line := range strings.Split(body, "\n") {
-		if heading, ok := reservedFacetHeadingOf(line); ok {
+		if heading, ok := reservedHeadingOf(sections, line); ok {
 			current = heading
 			continue
 		}
@@ -237,27 +273,21 @@ func (o OutputSpec) ParseFacetDocument(body string) FacetPayload {
 		collected[current] = append(collected[current], line)
 	}
 
-	// Only a field this output declared as json is unfenced. A markdown
-	// facet whose content legitimately opens with a fenced JSON example
-	// would otherwise come back with that fence eaten — the parser cannot
-	// tell an example from an encoding without being told which is which.
-	jsonFields := make(map[string]bool, len(o.Facets))
-	for _, field := range o.FacetFields() {
-		if field.Format == FacetFormatJSON {
-			jsonFields[field.Key] = true
-		}
-	}
-
-	for _, section := range facetSections {
+	for _, section := range sections {
 		lines, ok := collected[section.Heading]
 		if !ok {
 			continue
 		}
 		value := strings.TrimSpace(strings.Join(lines, "\n"))
-		if jsonFields[section.Field.Key] {
+		// Only a field this output declared as json is unfenced. A
+		// markdown facet whose content legitimately opens with a fenced
+		// JSON example would otherwise come back with that fence eaten —
+		// the parser cannot tell an example from an encoding without
+		// being told which is which.
+		if section.Field.Format == FacetFormatJSON {
 			value = unfence(value)
 		}
-		*section.value(&payload) = value
+		section.set(&payload, value)
 	}
 
 	if leading := strings.TrimSpace(strings.Join(preamble, "\n")); leading != "" {
@@ -270,26 +300,16 @@ func (o OutputSpec) ParseFacetDocument(body string) FacetPayload {
 	return payload
 }
 
-// facetSectionByKey looks up the section table entry for a field key.
-func facetSectionByKey(key string) (facetSection, bool) {
-	for _, section := range facetSections {
-		if section.Field.Key == key {
-			return section, true
-		}
-	}
-	return facetSection{}, false
-}
-
-// reservedFacetHeadingOf reports the canonical heading a line declares,
-// if the line is exactly one of the contract's H2 section headings.
-// Deeper headings inside a projection are ordinary content.
-func reservedFacetHeadingOf(line string) (string, bool) {
+// reservedHeadingOf reports the canonical heading a line declares, if the
+// line is exactly one of this output's H2 section headings. Deeper
+// headings inside a projection are ordinary content.
+func reservedHeadingOf(sections []facetSection, line string) (string, bool) {
 	trimmed := strings.TrimSpace(line)
 	if !strings.HasPrefix(trimmed, "## ") {
 		return "", false
 	}
 	text := strings.TrimSpace(strings.TrimPrefix(trimmed, "## "))
-	for _, section := range facetSections {
+	for _, section := range sections {
 		if strings.EqualFold(text, section.Heading) {
 			return section.Heading, true
 		}
@@ -297,13 +317,13 @@ func reservedFacetHeadingOf(line string) (string, bool) {
 	return "", false
 }
 
-// firstReservedFacetHeading finds a reserved section heading inside
+// reservedHeadingIn finds one of this output's section headings inside
 // projection content. Such a line would be read back as a section
 // boundary, silently moving content between projections, so publishing
 // is refused instead.
-func firstReservedFacetHeading(value string) (string, bool) {
+func reservedHeadingIn(sections []facetSection, value string) (string, bool) {
 	for _, line := range strings.Split(value, "\n") {
-		if heading, ok := reservedFacetHeadingOf(line); ok {
+		if heading, ok := reservedHeadingOf(sections, line); ok {
 			return "## " + heading, true
 		}
 	}
@@ -325,6 +345,26 @@ func validateFacetFormat(field FacetField, value string) error {
 	}
 	if !json.Valid([]byte(value)) {
 		return fmt.Errorf("%s declares format %q but the value is not valid JSON; a consumer that asked for json cannot read prose", field.Key, FacetFormatJSON)
+	}
+	if field.Target == "" {
+		return nil
+	}
+	// A target facet's value is a slot object the registry defines, so
+	// valid JSON is only the first half of the check: the registry
+	// decides whether these are the right slots, within their budgets.
+	// Running it here rather than only at the tool boundary means a
+	// payload assembled any other way — a repair, a migration, a seeded
+	// document — meets the same contract the surface does.
+	target, ok := outputtargets.Lookup(field.Target)
+	if !ok {
+		return fmt.Errorf("%s is cut for target %q, which is not registered; valid targets are %s", field.Key, field.Target, strings.Join(outputtargets.IDs(), ", "))
+	}
+	var slots map[string]any
+	if err := json.Unmarshal([]byte(value), &slots); err != nil {
+		return fmt.Errorf("%s must be a JSON object of slot values for target %q: %w", field.Key, field.Target, err)
+	}
+	if _, err := target.Normalize(slots); err != nil {
+		return fmt.Errorf("%s: %w", field.Key, err)
 	}
 	return nil
 }

--- a/internal/runtime/loop/output_facets_test.go
+++ b/internal/runtime/loop/output_facets_test.go
@@ -1,6 +1,7 @@
 package loop
 
 import (
+	"reflect"
 	"strings"
 	"testing"
 )
@@ -219,7 +220,7 @@ func TestFacetDocumentRoundTrip(t *testing.T) {
 				t.Fatalf("payload should be valid: %v", err)
 			}
 			got := tt.output.ParseFacetDocument(tt.output.RenderFacetDocument(tt.payload))
-			if got != tt.payload {
+			if !reflect.DeepEqual(got, tt.payload) {
 				t.Fatalf("round trip changed the payload:\ngot  %#v\nwant %#v", got, tt.payload)
 			}
 		})

--- a/internal/runtime/loop/target_facet.go
+++ b/internal/runtime/loop/target_facet.go
@@ -1,0 +1,130 @@
+package loop
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/nugget/thane-ai-agent/internal/model/outputtargets"
+)
+
+// Facets cut for a rendering surface rather than for a reader.
+//
+// A reading projection is prose with a budget, and the contract in
+// output_facets.go says everything there is to say about it. A target
+// facet says almost nothing itself: the surface it is cut for is
+// registered in [outputtargets], and its slots, their types, their
+// budgets, and the words the model reads all come from there. What lives
+// here is only the seam — how a registered surface becomes a section of
+// the document, and how the arguments that fill it become the value that
+// is stored.
+
+// targetSection builds the section for a facet cut for a registered
+// surface. Everything about it — the heading, the argument name, what
+// the model is told, what its values must satisfy — comes from the
+// registry, so adding a surface adds no code here.
+//
+// An unregistered ID yields no section. Spec validation rejects one at
+// declaration and on every load, so reaching this with an unknown ID
+// means a target was removed from the registry beneath a stored spec;
+// the loop then fails validation loudly rather than publishing a section
+// nothing can consume.
+func targetSection(id string) (facetSection, bool) {
+	target, ok := outputtargets.Lookup(id)
+	if !ok {
+		return facetSection{}, false
+	}
+	return facetSection{
+		Heading: target.Title,
+		Field: FacetField{
+			Key:      target.ArgKey(),
+			Format:   FacetFormatJSON,
+			Target:   target.ID,
+			Guidance: target.Summary,
+		},
+		get: func(p FacetPayload) string { return p.Targets[target.ID] },
+		set: func(p *FacetPayload, v string) {
+			if p.Targets == nil {
+				p.Targets = make(map[string]string, 1)
+			}
+			p.Targets[target.ID] = v
+		},
+	}, true
+}
+
+// FacetPayloadFromArgs reads publish-tool arguments into a payload.
+//
+// It lives with the contract rather than with the tool that calls it,
+// because turning arguments into a payload is the same question as what
+// a facet accepts: a reading projection takes a string, and a target
+// facet takes the surface's slot object, normalized by the registry
+// before it is stored. A second reading of those arguments anywhere else
+// would be a second answer.
+//
+// A missing argument is left empty rather than rejected here, so
+// [OutputSpec.ValidateFacetPayload] reports every omission at once
+// instead of one per attempt.
+func (o OutputSpec) FacetPayloadFromArgs(args map[string]any) (FacetPayload, error) {
+	var payload FacetPayload
+	for _, section := range o.sections() {
+		field := section.Field
+		raw, present := args[field.Key]
+		if !present {
+			continue
+		}
+		if field.Target != "" {
+			slots, err := targetSlotsFromArg(field, raw)
+			if err != nil {
+				return FacetPayload{}, err
+			}
+			section.set(&payload, slots)
+			continue
+		}
+		value, ok := raw.(string)
+		if !ok {
+			return FacetPayload{}, fmt.Errorf("%s must be a string", field.Key)
+		}
+		section.set(&payload, value)
+	}
+	return payload, nil
+}
+
+// targetSlotsFromArg turns one target facet's argument into the JSON slot
+// object stored in the document.
+//
+// The slots the model sent are what is kept, not the payload a sink would
+// derive from them: the document is the canonical store, and a stored
+// slot set can be re-normalized for any binding, while a stored binding
+// payload has already thrown away which slot each value came from.
+// Normalization still runs, because a value that cannot be published is
+// one the model should hear about now rather than at the far end.
+func targetSlotsFromArg(field FacetField, raw any) (string, error) {
+	target, ok := outputtargets.Lookup(field.Target)
+	if !ok {
+		return "", fmt.Errorf("%s is cut for target %q, which is not registered", field.Key, field.Target)
+	}
+	slots, ok := raw.(map[string]any)
+	if !ok {
+		// Some model families send a nested object as its JSON text.
+		// Accepting that costs one branch and saves a turn.
+		text, isText := raw.(string)
+		if !isText {
+			return "", fmt.Errorf("%s must be an object of slot values for %s; valid slots are %s", field.Key, target.Title, strings.Join(target.SlotNames(), ", "))
+		}
+		if err := json.Unmarshal([]byte(text), &slots); err != nil {
+			return "", fmt.Errorf("%s must be an object of slot values for %s, and the string sent is not JSON either: %w", field.Key, target.Title, err)
+		}
+	}
+	canonical, err := target.NormalizeSlots(slots)
+	if err != nil {
+		return "", fmt.Errorf("%s: %w", field.Key, err)
+	}
+	// Encoded from the canonical slot map rather than echoed, so the
+	// document holds one spelling of a given payload regardless of key
+	// order, stray whitespace, or hex casing on the way in.
+	encoded, err := json.MarshalIndent(canonical, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("%s: %w", field.Key, err)
+	}
+	return string(encoded), nil
+}

--- a/internal/runtime/loop/target_facet_test.go
+++ b/internal/runtime/loop/target_facet_test.go
@@ -1,0 +1,273 @@
+package loop
+
+import (
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/nugget/thane-ai-agent/internal/model/outputtargets"
+)
+
+const testTargetID = "apple_watch.rectangular"
+
+// targetedOutput declares status_line plus one target facet, the shape a
+// loop takes when it feeds both a reader and a rendering surface.
+func targetedOutput(targets ...string) OutputSpec {
+	facets := []FacetSpec{{Name: OutputFacetStatusLine}}
+	for _, id := range targets {
+		facets = append(facets, FacetSpec{Target: id})
+	}
+	return OutputSpec{
+		Name:   "office status",
+		Type:   OutputTypeMaintainedDocument,
+		Ref:    "core:office.md",
+		Facets: facets,
+	}
+}
+
+func TestTargetFacetTakesItsFieldFromTheRegistry(t *testing.T) {
+	target, ok := outputtargets.Lookup(testTargetID)
+	if !ok {
+		t.Fatalf("Lookup(%q) failed; the test target is no longer registered", testTargetID)
+	}
+
+	fields := targetedOutput(testTargetID).FacetFields()
+	var got FacetField
+	for _, field := range fields {
+		if field.Target == testTargetID {
+			got = field
+		}
+	}
+	if got.Key != target.ArgKey() {
+		t.Fatalf("target field key = %q, want the registry's arg key %q", got.Key, target.ArgKey())
+	}
+	if got.Format != FacetFormatJSON {
+		t.Errorf("target field format = %q, want json — its value is a slot object", got.Format)
+	}
+	// A target facet carries no rune budget of its own: the slots have
+	// their own, and one on the encoded object would be a second limit
+	// nothing agreed to.
+	if got.MaxRunes != 0 {
+		t.Errorf("target field MaxRunes = %d, want 0", got.MaxRunes)
+	}
+}
+
+func TestTargetFacetSectionsSitAheadOfTheBody(t *testing.T) {
+	out := targetedOutput("apple_watch.circular", "apple_watch.rectangular")
+	keys := make([]string, 0, 4)
+	for _, field := range out.FacetFields() {
+		keys = append(keys, field.Key)
+	}
+	// Sorted by target ID, not by declaration order, and always before
+	// the document's substance.
+	want := []string{"status_line", "apple_watch_circular", "apple_watch_rectangular", "full"}
+	if !reflect.DeepEqual(keys, want) {
+		t.Fatalf("field order = %v, want %v", keys, want)
+	}
+}
+
+func TestTargetFacetRoundTripsThroughTheDocument(t *testing.T) {
+	out := targetedOutput(testTargetID)
+	payload := FacetPayload{
+		StatusLine: "Printer online; 2 packages waiting.",
+		Full:       "# Office\n\nDetail.",
+		Targets: map[string]string{
+			testTargetID: `{"value":"2 pkg","title":"Office","fraction":0.5}`,
+		},
+	}
+	if err := out.ValidateFacetPayload(payload); err != nil {
+		t.Fatalf("payload should be publishable: %v", err)
+	}
+
+	body := out.RenderFacetDocument(payload)
+	if !strings.Contains(body, "## Apple Watch rectangular complication") {
+		t.Fatalf("target section missing its heading:\n%s", body)
+	}
+	if !strings.Contains(body, "```json") {
+		t.Fatalf("target section is not fenced:\n%s", body)
+	}
+
+	got := out.ParseFacetDocument(body)
+	if !reflect.DeepEqual(got, payload) {
+		t.Fatalf("round trip changed the payload:\ngot  %#v\nwant %#v", got, payload)
+	}
+}
+
+// TestTargetFacetPayloadIsCheckedAgainstTheRegistry is the point of
+// declaring a target rather than a bare json facet: the registry's slot
+// rules apply to the stored value, not only to the tool call that
+// produced it.
+func TestTargetFacetPayloadIsCheckedAgainstTheRegistry(t *testing.T) {
+	tests := []struct {
+		name    string
+		slots   string
+		wantErr string
+	}{
+		{
+			name:    "over-budget slot",
+			slots:   `{"value":"a very long headline that will not fit"}`,
+			wantErr: "renders at most 12",
+		},
+		{
+			name:    "unknown slot",
+			slots:   `{"value":"ok","headline":"nope"}`,
+			wantErr: "has no slot named",
+		},
+		{
+			name:    "missing required slot",
+			slots:   `{"title":"Office"}`,
+			wantErr: `slot "value" is required`,
+		},
+		{
+			name:    "fraction out of range",
+			slots:   `{"value":"ok","fraction":4}`,
+			wantErr: "between 0.0 and 1.0",
+		},
+		{
+			name:    "malformed color",
+			slots:   `{"value":"ok","gauge_color":"greenish"}`,
+			wantErr: "six-digit hex",
+		},
+		{
+			name:    "not an object",
+			slots:   `["value"]`,
+			wantErr: "must be a JSON object of slot values",
+		},
+		{
+			name:    "not json at all",
+			slots:   `2 packages waiting`,
+			wantErr: "not valid JSON",
+		},
+	}
+
+	out := targetedOutput(testTargetID)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := out.ValidateFacetPayload(FacetPayload{
+				StatusLine: "All clear.",
+				Full:       "Body.",
+				Targets:    map[string]string{testTargetID: tt.slots},
+			})
+			if err == nil {
+				t.Fatalf("ValidateFacetPayload() error = nil, want %q", tt.wantErr)
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("error = %v, want it to mention %q", err, tt.wantErr)
+			}
+			// Whatever went wrong, the model has to know which argument
+			// to fix; a slot-level message with no field name does not
+			// say that.
+			if !strings.Contains(err.Error(), "apple_watch_rectangular") {
+				t.Errorf("error = %v, want it to name the publish argument", err)
+			}
+		})
+	}
+}
+
+func TestValidateOutputFacetsOnTargets(t *testing.T) {
+	tests := []struct {
+		name    string
+		facets  []FacetSpec
+		wantErr string
+	}{
+		{
+			name:   "status line plus a target",
+			facets: []FacetSpec{{Name: OutputFacetStatusLine}, {Target: testTargetID}},
+		},
+		{
+			name:    "unknown target",
+			facets:  []FacetSpec{{Name: OutputFacetStatusLine}, {Target: "casio.f91w"}},
+			wantErr: "unknown target",
+		},
+		{
+			name:    "name and target together",
+			facets:  []FacetSpec{{Name: OutputFacetStatusLine}, {Name: OutputFacetDigest, Target: testTargetID}},
+			wantErr: "declares both name",
+		},
+		{
+			name:    "non-json format on a target",
+			facets:  []FacetSpec{{Name: OutputFacetStatusLine}, {Target: testTargetID, Format: FacetFormatPlain}},
+			wantErr: "always \"json\"",
+		},
+		{
+			name:   "json format on a target is redundant but honest",
+			facets: []FacetSpec{{Name: OutputFacetStatusLine}, {Target: testTargetID, Format: FacetFormatJSON}},
+		},
+		{
+			name:    "the same target twice",
+			facets:  []FacetSpec{{Name: OutputFacetStatusLine}, {Target: testTargetID}, {Target: testTargetID}},
+			wantErr: "duplicate target",
+		},
+		{
+			name:   "two different targets",
+			facets: []FacetSpec{{Name: OutputFacetStatusLine}, {Target: testTargetID}, {Target: "apple_watch.circular"}},
+		},
+		{
+			name:    "a target does not satisfy the status line requirement",
+			facets:  []FacetSpec{{Target: testTargetID}},
+			wantErr: "must include \"status_line\"",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out := OutputSpec{Name: "office status", Type: OutputTypeMaintainedDocument, Ref: "core:office.md", Facets: tt.facets}
+			err := validateOutputFacets(out)
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("validateOutputFacets() error = %v, want nil", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("validateOutputFacets() error = nil, want %q", tt.wantErr)
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("error = %v, want it to mention %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// TestTargetFacetSurvivesSpecSerialization guards the declaration itself:
+// a spec is stored as JSON, so a target that does not survive the round
+// trip would come back as a facet with no identity.
+func TestTargetFacetSurvivesSpecSerialization(t *testing.T) {
+	original := targetedOutput(testTargetID)
+	encoded, err := json.Marshal(original)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	var decoded OutputSpec
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if !reflect.DeepEqual(decoded.Facets, original.Facets) {
+		t.Fatalf("facets did not survive:\ngot  %#v\nwant %#v\nwire: %s", decoded.Facets, original.Facets, encoded)
+	}
+	// The short form is for a bare name; a target has to keep its object.
+	if !strings.Contains(string(encoded), `"target":"`+testTargetID+`"`) {
+		t.Errorf("encoded spec lost the target field: %s", encoded)
+	}
+}
+
+// TestNoTargetTitleCollidesWithAReservedHeading protects the parser: a
+// target section is found by its title, so a title equal to one of the
+// contract's own headings would make two sections indistinguishable and
+// silently merge their content.
+func TestNoTargetTitleCollidesWithAReservedHeading(t *testing.T) {
+	reserved := make([]string, 0, len(readingSections)+1)
+	for _, section := range readingSections {
+		reserved = append(reserved, section.Heading)
+	}
+	reserved = append(reserved, fullSection.Heading)
+
+	for _, target := range outputtargets.All() {
+		for _, heading := range reserved {
+			if strings.EqualFold(target.Title, heading) {
+				t.Errorf("target %q is titled %q, which collides with the reserved section heading %q", target.ID, target.Title, heading)
+			}
+		}
+	}
+}

--- a/internal/tools/loop_create_tool.go
+++ b/internal/tools/loop_create_tool.go
@@ -598,11 +598,7 @@ func thaneLoopCreateSchema() map[string]any {
 						"type":        "string",
 						"description": "Optional human title for the document. Defaults to the loop name.",
 					},
-					"facets": map[string]any{
-						"type":        "array",
-						"items":       map[string]any{"type": "string", "enum": []string{"status_line", "teaser", "digest"}},
-						"description": "Publish condensed projections alongside the full body, so each consumer takes the length it can afford — an ambient row takes status_line, a search snippet takes teaser, a digest row takes digest. Declaring these swaps the loop's generated tool from replace_output_* to publish_output_*, which takes one argument per projection. Declare them whenever anything other than this loop will read the document.",
-					},
+					"facets": loopFacetsSchema(),
 				},
 				"required": []string{"document"},
 			},

--- a/internal/tools/loop_intent_tools.go
+++ b/internal/tools/loop_intent_tools.go
@@ -2,6 +2,7 @@ package tools
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
 	"time"
@@ -505,48 +506,59 @@ func parseDurationArg(args map[string]any, key string) (d time.Duration, present
 	return d, true, nil
 }
 
-// parseOutputFacets reads the declared projection ladder from the guided
-// tool's output argument. Unknown names are refused rather than dropped:
-// a facet that is silently ignored produces a loop that publishes fewer
-// projections than its author asked for, and nothing says so.
+// parseOutputFacets reads the declared facets from the guided tool's
+// output argument.
+//
+// It decodes through [looppkg.FacetSpec] rather than reading the shapes
+// itself, so the guided path accepts exactly what the raw path does: a
+// bare name, a name with a format, or a rendering target. A second
+// parser here would be a second answer to "what is a facet", and the two
+// would drift the first time either grew a field.
+//
+// Validation is left to the spec: an unknown facet has to be refused
+// rather than dropped — a facet silently ignored produces a loop
+// publishing fewer projections than its author asked for, with nothing
+// saying so — and validateOutputFacets already refuses it with the
+// message that names the alternatives.
 func parseOutputFacets(raw any) ([]looppkg.FacetSpec, error) {
 	if raw == nil {
 		return nil, nil
 	}
-
-	// A decoded tool call yields []any; a Go caller is likelier to build
-	// []string. Both are accepted, and a non-string element is named by
-	// index and type rather than coerced — an element coerced to "" would
-	// be reported as an empty facet name, which describes the symptom
-	// instead of the mistake.
-	var names []string
+	// Normalized to []any so each element can be decoded — and reported —
+	// on its own. A single decode of the whole array would name the type
+	// that failed but not which entry it was, and an author reading
+	// "cannot unmarshal number" has to count facets by hand to find it.
+	var items []any
 	switch v := raw.(type) {
-	case []string:
-		names = v
 	case []any:
-		names = make([]string, 0, len(v))
-		for i, item := range v {
-			name, ok := item.(string)
-			if !ok {
-				return nil, fmt.Errorf("output.facets[%d] is %T; facet names are strings — status_line, teaser, or digest", i, item)
-			}
-			names = append(names, name)
+		items = v
+	case []string:
+		items = make([]any, 0, len(v))
+		for _, name := range v {
+			items = append(items, name)
 		}
+	case []looppkg.FacetSpec:
+		return v, nil
 	default:
-		return nil, fmt.Errorf("output.facets must be an array of facet names, got %T", raw)
+		return nil, fmt.Errorf("output.facets must be an array of facets, got %T", raw)
 	}
 
-	out := make([]looppkg.FacetSpec, 0, len(names))
-	for _, name := range names {
-		facet := looppkg.OutputFacet(strings.TrimSpace(name))
-		switch facet {
-		case looppkg.OutputFacetStatusLine, looppkg.OutputFacetTeaser, looppkg.OutputFacetDigest:
-			out = append(out, looppkg.FacetSpec{Name: facet})
-		default:
-			return nil, fmt.Errorf("output.facets %q is not a projection; use status_line, teaser, or digest", name)
+	// Each element round-trips through JSON to reach FacetSpec's own
+	// decoder; a decoded tool call is already the product of one, so this
+	// costs an encode on a list that is at most a handful of entries.
+	facets := make([]looppkg.FacetSpec, 0, len(items))
+	for i, item := range items {
+		encoded, err := json.Marshal(item)
+		if err != nil {
+			return nil, fmt.Errorf("output.facets[%d]: %w", i, err)
 		}
+		var facet looppkg.FacetSpec
+		if err := json.Unmarshal(encoded, &facet); err != nil {
+			return nil, fmt.Errorf("output.facets[%d] is %T: a facet is a name (status_line, teaser, digest), an object with a name and a format, or an object with a target", i, item)
+		}
+		facets = append(facets, facet)
 	}
-	return out, nil
+	return facets, nil
 }
 
 // buildWorkingNotesSpec derives the private log that sits beside a

--- a/internal/tools/loop_spec_schema.go
+++ b/internal/tools/loop_spec_schema.go
@@ -1,5 +1,12 @@
 package tools
 
+import (
+	"fmt"
+	"strings"
+
+	"github.com/nugget/thane-ai-agent/internal/model/outputtargets"
+)
+
 // loopSpecSchema returns the JSON-Schema description of the agent-facing
 // loop-definition spec object, shared by loop_definition_set,
 // loop_definition_lint, and spawn_loop. Until this existed those tools
@@ -168,30 +175,59 @@ func loopProfileSchema(description string) map[string]any {
 	}
 }
 
+// loopFacetsSchema describes an output's facets array.
+//
+// The target enum is read from the registry rather than written out
+// here, so a surface added there is declarable the same day without a
+// second edit — and the model is never offered a target that does not
+// exist.
+func loopFacetsSchema() map[string]any {
+	targets := outputtargets.All()
+	descriptions := make([]string, 0, len(targets))
+	ids := make([]string, 0, len(targets))
+	for _, target := range targets {
+		ids = append(ids, target.ID)
+		descriptions = append(descriptions, fmt.Sprintf("%s = %s", target.ID, target.Summary))
+	}
+
+	return map[string]any{
+		"type": "array",
+		"items": map[string]any{
+			"oneOf": []any{
+				map[string]any{"type": "string", "enum": []string{"status_line", "teaser", "digest"}},
+				map[string]any{
+					"type": "object",
+					"properties": map[string]any{
+						"name":   map[string]any{"type": "string", "enum": []string{"status_line", "teaser", "digest"}},
+						"format": map[string]any{"type": "string", "enum": []string{"markdown", "plain", "json"}, "description": "How this facet is encoded. markdown (default) suits a document section; plain has no markup and is safe to speak aloud or show where nothing renders; json is for consumers that are code, and a non-JSON value is rejected."},
+					},
+					"required": []string{"name"},
+				},
+				map[string]any{
+					"type": "object",
+					"properties": map[string]any{
+						"target": map[string]any{
+							"type":        "string",
+							"enum":        ids,
+							"description": "The rendering surface this facet is cut for. " + strings.Join(descriptions, " "),
+						},
+					},
+					"required": []string{"target"},
+				},
+			},
+		},
+		"description": "The facets this output publishes alongside its full body — views of the same understanding, each cut for a surface rather than shortened from the one above. Declaring any swaps the generated tool from replace_output_* to publish_output_*, which takes one typed argument per facet. status_line is required whenever facets are declared; teaser and digest are optional. A facet is either a reading projection (a bare name, or an object with a name and a format) or a rendering surface (an object with a target), never both: a watch complication is not a longer status line, it is a different face, and its argument is the surface's own named slots rather than prose. Order carries no meaning.",
+	}
+}
+
 // loopOutputSpecSchema describes one entry in a spec's outputs array.
 func loopOutputSpecSchema() map[string]any {
 	return map[string]any{
 		"type": "object",
 		"properties": map[string]any{
-			"name": map[string]any{"type": "string", "description": "Stable semantic name for this output within the loop."},
-			"type": map[string]any{"type": "string", "enum": []string{"maintained_document", "working_notes"}, "description": "maintained_document = the loop rewrites it each cycle to reflect current state; working_notes = the same, but private — the loop's current thinking, never projected into search, context, or any other consumer surface. Use working_notes for working theories, what an experiment is showing, and what you expect next; use a maintained_document for what a reader should see. For an append-only dated record, journal a document directly with the doc tools rather than declaring it as an output."},
-			"facets": map[string]any{
-				"type": "array",
-				"items": map[string]any{
-					"oneOf": []any{
-						map[string]any{"type": "string", "enum": []string{"status_line", "teaser", "digest"}},
-						map[string]any{
-							"type": "object",
-							"properties": map[string]any{
-								"name":   map[string]any{"type": "string", "enum": []string{"status_line", "teaser", "digest"}},
-								"format": map[string]any{"type": "string", "enum": []string{"markdown", "plain", "json"}, "description": "How this facet is encoded. markdown (default) suits a document section; plain has no markup and is safe to speak aloud or show where nothing renders; json is for consumers that are code, and a non-JSON value is rejected."},
-							},
-							"required": []string{"name"},
-						},
-					},
-				},
-				"description": "The facets this output publishes alongside its full body — condensed views of the same understanding, each cut for a surface rather than shortened from the one above. Declaring any swaps the generated tool from replace_output_* to publish_output_*, which takes one typed argument per facet. status_line is required whenever facets are declared; teaser and digest are optional. Write a bare name for the default encoding, or an object to set a format. Order carries no meaning.",
-			},
+			"name":   map[string]any{"type": "string", "description": "Stable semantic name for this output within the loop."},
+			"type":   map[string]any{"type": "string", "enum": []string{"maintained_document", "working_notes"}, "description": "maintained_document = the loop rewrites it each cycle to reflect current state; working_notes = the same, but private — the loop's current thinking, never projected into search, context, or any other consumer surface. Use working_notes for working theories, what an experiment is showing, and what you expect next; use a maintained_document for what a reader should see. For an append-only dated record, journal a document directly with the doc tools rather than declaring it as an output."},
+			"facets": loopFacetsSchema(),
 			"audience": map[string]any{
 				"type":        "string",
 				"enum":        []string{"published", "internal"},

--- a/internal/tools/talent_example_spec_test.go
+++ b/internal/tools/talent_example_spec_test.go
@@ -3,9 +3,12 @@ package tools
 import (
 	"encoding/json"
 	"os"
+	"reflect"
 	"regexp"
 	"strings"
 	"testing"
+
+	looppkg "github.com/nugget/thane-ai-agent/internal/runtime/loop"
 )
 
 // TestTalentExampleSpecValidates decodes the loop spec published in the
@@ -51,9 +54,27 @@ func TestTalentExampleSpecValidates(t *testing.T) {
 		t.Fatalf("outputs = %d, want 2 (faceted document + working notes)", len(decoded.Outputs))
 	}
 	faceted := decoded.Outputs[0]
-	if len(faceted.Facets) != 3 {
-		t.Errorf("facets = %v, want three projections", faceted.Facets)
+	// The example teaches both kinds of facet, so it has to carry both:
+	// every reading projection, and at least one rendering target whose
+	// slots the publish sample fills.
+	var reading []looppkg.OutputFacet
+	var targets []string
+	for _, facet := range faceted.Facets {
+		if facet.IsTarget() {
+			targets = append(targets, facet.Target)
+			continue
+		}
+		reading = append(reading, facet.Name)
 	}
+	wantReading := []looppkg.OutputFacet{looppkg.OutputFacetStatusLine, looppkg.OutputFacetTeaser, looppkg.OutputFacetDigest}
+	if !reflect.DeepEqual(reading, wantReading) {
+		t.Errorf("reading projections = %v, want %v", reading, wantReading)
+	}
+	if len(targets) == 0 {
+		t.Fatal("the example declares no target facet, but its prose teaches one")
+	}
+
+	assertExamplePublishSampleIsValid(t, node[start:], faceted)
 	if got := faceted.ToolName(); !strings.HasPrefix(got, "publish_output_") {
 		t.Errorf("generated tool = %q, want publish_output_* — the example claims it swaps", got)
 	}
@@ -71,4 +92,57 @@ func TestTalentExampleSpecValidates(t *testing.T) {
 	if !hasDocuments {
 		t.Error("a loop that owns documents needs the documents tag to reach doc_read")
 	}
+}
+
+// assertExamplePublishSampleIsValid runs the example's publish payload
+// through the same validation a real call meets.
+//
+// The spec and the sample are taught together, so a sample that would be
+// rejected teaches a call that fails — and the target slots are exactly
+// where that is easy to get wrong, because their budgets live in the
+// registry rather than in this file.
+func assertExamplePublishSampleIsValid(t *testing.T, section string, output looppkg.OutputSpec) {
+	t.Helper()
+
+	blocks := regexp.MustCompile("(?s)```json\n(.*?)```").FindAllStringSubmatch(section, -1)
+	if len(blocks) < 2 {
+		t.Fatalf("expected a spec block and a publish block, found %d", len(blocks))
+	}
+	var args map[string]any
+	if err := json.Unmarshal([]byte(blocks[1][1]), &args); err != nil {
+		t.Fatalf("publish sample does not parse: %v", err)
+	}
+
+	// Every declared field has to be present: a publish carries the whole
+	// payload, so a sample missing one would be rejected in practice.
+	for _, field := range output.FacetFields() {
+		if _, ok := args[field.Key]; !ok {
+			t.Errorf("publish sample is missing the %q argument", field.Key)
+		}
+	}
+	for key := range args {
+		if key == "notes" {
+			continue
+		}
+		if _, ok := facetFieldByKey(output, key); !ok {
+			t.Errorf("publish sample passes %q, which this output does not declare", key)
+		}
+	}
+
+	payload, err := output.FacetPayloadFromArgs(args)
+	if err != nil {
+		t.Fatalf("publish sample does not decode: %v", err)
+	}
+	if err := output.ValidateFacetPayload(payload); err != nil {
+		t.Fatalf("publish sample would be rejected: %v", err)
+	}
+}
+
+func facetFieldByKey(output looppkg.OutputSpec, key string) (looppkg.FacetField, bool) {
+	for _, field := range output.FacetFields() {
+		if field.Key == key {
+			return field, true
+		}
+	}
+	return looppkg.FacetField{}, false
 }

--- a/talents/loops-examples.md
+++ b/talents/loops-examples.md
@@ -147,7 +147,7 @@ takes the same spec and catches mistakes before anything persists.
       "name": "closet_state",
       "type": "maintained_document",
       "ref": "kb:dashboards/server-closet.md",
-      "facets": ["status_line", "teaser", "digest"],
+      "facets": ["status_line", "teaser", "digest", {"target": "apple_watch.rectangular"}],
       "purpose": "Current state of the server closet for anyone who asks."
     },
     {
@@ -173,11 +173,26 @@ the section headings; they are rendered for you.
   "status_line": "Closet 21.4°C, 38% RH, UPS on mains, dehumidifier idle.",
   "teaser": "Server closet is stable. Temperature and humidity have held inside normal range for six hours; the UPS is on mains power with a full charge, and the dehumidifier has not needed to run since morning.",
   "digest": "Environment: 21.4°C (range 20.8–22.1 over 24h), 38% RH, both comfortably inside bounds...",
-  "full": "# Server Closet\n\n## Environment\n\n..."
+  "full": "# Server Closet\n\n## Environment\n\n...",
+  "apple_watch_rectangular": {
+    "value": "21.4°C",
+    "title": "Server Closet",
+    "subtitle": "38% RH, stable",
+    "bottom_text": "UPS on mains",
+    "fraction": 0.38
+  }
 }
 ```
 
-Each projection has a rune budget — 120 for `status_line`, 500 for
+The last one is a facet cut for a surface rather than a reader. Its
+argument is the complication's own slots, not prose: four short lines
+and a gauge fill, each with a budget the schema tells you. Note what it
+is *not* — it is not the status line shortened. "Closet 21.4°C, 38% RH,
+UPS on mains, dehumidifier idle" is a good sentence and a bad
+complication; the slots let the same reading land as a reading rather
+than as a clipped sentence.
+
+Each reading projection has a rune budget — 120 for `status_line`, 500 for
 `teaser`, 2048 for `digest` — and an over-budget value is rejected
 rather than trimmed, because a clipped projection reads as a fragment
 with no sign that anything is missing. Write to the budget, not near it.
@@ -189,11 +204,14 @@ The digest is enough to act on without opening it.
 
 ## Where the reasoning goes
 
-The `working_notes` output is the loop's private log — internal by
-construction, never projected into search or another loop's context. Put
-the reasoning there: what changed and why, what drifted, what was
-refined. `publish_output_*` takes a `note` argument, so a publish and
-its reasoning are one call.
+The `working_notes` output holds this loop's current thinking —
+internal by construction, never projected into search or another loop's
+context. Put your present view there: what you believe is happening,
+what you are watching, what would change your mind. Rewrite it rather
+than appending to it, so the next turn reads a position instead of
+reconstructing one from a history of superseded ones. `publish_output_*`
+takes a `notes` argument, so a publish and the thinking behind it are
+one call.
 
 Published projections carry current state, not the story of how it got
 there. Keeping those apart is what lets the document stay short.

--- a/talents/loops.md
+++ b/talents/loops.md
@@ -47,6 +47,38 @@ Declare `status_line` for any faceted output; add `teaser` when the
 output is something others search or link to, and `digest` when a
 reader should be able to act without opening the document.
 
+## Facets cut for a surface that shows no prose
+
+`status_line`, `teaser`, and `digest` are all cut for readers, differing
+only in how much room the reader has. A watch complication is not the
+next size down that ladder: it has four short lines, a gauge that wants
+a number between 0 and 1, and no place for a sentence at all. Writing
+prose short enough to survive it produces something that reads badly
+everywhere and renders badly there.
+
+So declare that surface as its own facet, by target rather than by name:
+
+```json
+"facets": ["status_line", "teaser", {"target": "apple_watch.rectangular"}]
+```
+
+A target facet's argument on `publish_output_*` is not a string. It is
+the surface's own named slots — `value`, `title`, `subtitle`,
+`fraction` — each with its own type and its own budget, described to you
+in the tool schema. Fill the slots; the encoding, the section in the
+document, and the wiring to whatever renders it are not your problem.
+
+Two things follow from the slots being real. The budgets are small and
+enforced, so a value over its limit is rejected with the limit named
+rather than trimmed to fit — twelve characters means a number and a
+unit, not an abbreviated sentence. And every publish replaces the whole
+slot set, so a slot you omit is cleared: send the complete current state
+each time, exactly as you already do for the reading projections.
+
+Declare a target when something outside Thane renders this loop's state
+on a fixed surface. Declare only reading projections when it does not —
+an unfilled complication is worse than an absent one.
+
 ## Where the thinking goes
 
 What a loop publishes is current state. What it *thinks* — working


### PR DESCRIPTION
`status_line`, `teaser`, and `digest` are all cut for readers, differing only in how much room the reader has. A watch complication is not the next size down that ladder — it has four short lines, a gauge wanting a number between 0 and 1, and nowhere to put a sentence, so prose short enough to survive it reads badly everywhere and renders badly there. Asking a loop to write one more projection was asking the wrong question, and the answer is that a facet is a face cut for a viewing angle, not a length.

So a facet is now identified either by name or by target, and the two are alternatives rather than a name with a modifier:

```json
"facets": ["status_line", "teaser", {"target": "apple_watch.rectangular"}]
```

Everything about that surface comes from the `outputtargets` registry, which has been sitting in the tree without a caller since #1253 and is what this PR finally plugs in. The section heading, the publish argument name, the slot types and budgets, the words the model reads before it writes, and the validation its values must pass are all read from the registry — so adding a surface adds no code in the loop package at all, and the schema can never offer a target that does not exist.

## The argument is the slots, not a string

This is what declaring a target buys over declaring a bare `format: json` facet. The model fills `value`, `title`, `subtitle`, `fraction` — each typed, each carrying its own budget in the tool schema — instead of hand-encoding JSON into a text field and learning the limits by being rejected. `Target.Schema()` and `Target.Normalize()` get their first callers here, which is the shape they were written for.

`Normalize` runs on the way in, and `ValidateFacetPayload` runs it again on any payload assembled another way, so a repair, a migration, or a seeded document meets the same contract a tool call does rather than a weaker one.

## What the document stores

The canonical slot map: trimmed text, uppercased hex, sorted keys, rendered as a fenced JSON section under the surface's own heading. Slots rather than the payload a sink would derive from them — a stored payload has already thrown away which slot each value came from, and the document is the store every binding is re-seeded from after a restart.

## Three seams unified rather than duplicated

- The section table became **per-spec**. Render, parse, validate, and the tool schema still read from one source now that the table is assembled rather than fixed, which is the property that kept those four from drifting in the first place.
- `thane_loop_create`'s facets parser now decodes through `FacetSpec` instead of its own string-only reading, so the guided path accepts exactly what the raw path does. It still reports the failing element by index — decoding the array in one shot loses that, and an author reading `cannot unmarshal number` should not have to count facets by hand.
- Turning publish arguments into a payload moved from `internal/app` into the contract itself. That is what lets the talent gate below check the taught sample against the real code rather than a copy of it.

## The teaching gate

`TestTalentExampleSpecValidates` already decoded the worked example's spec. It now also decodes and validates the example's **publish sample** through the real path: an over-budget slot or a missing projection in the talent fails the build instead of teaching a call that fails. Verified by mutation in both directions.

`talents/loops.md` gains a section on facets cut for a non-prose surface, and the worked example in `talents/loops-examples.md` declares and fills one. That example's stale working-notes paragraph (still describing notes as an append-only log, and naming a `note` argument that is spelled `notes`) is corrected in passing.

## Test plan

- [x] `just ci` green
- [x] Registry validation is real: removing the `Normalize` call fails 5 of 7 subtests in `TestTargetFacetPayloadIsCheckedAgainstTheRegistry` — the other two are caught earlier by the JSON check, which is correct
- [x] Talent gate is real: an over-budget `value` slot and a removed `teaser` argument each fail `TestTalentExampleSpecValidates`
- [x] Target facets round-trip through the rendered document, including alongside reading projections
- [x] A rejected publish writes nothing
- [x] Spec serialization keeps the target (the short form is for a bare name only)
- [x] `TestNoTargetTitleCollidesWithAReservedHeading` guards the parser against a target titled like a contract heading
- [ ] Declare a target facet on a live loop and confirm the complication renders — needs the MQTT/HA binding, which is the next piece

`output_facets.go` crossed the 500-line architecture threshold, so the target seam moved to its own `target_facet.go` rather than the baseline moving.

Refs #1250