### PR TITLE
A loop definition is a document in the core root

### DIFF
--- a/internal/app/loop_definition_hydration.go
+++ b/internal/app/loop_definition_hydration.go
@@ -11,7 +11,15 @@ import (
 )
 
 func (a *App) buildLoopDefinitionBaseSpecs() ([]looppkg.Spec, error) {
-	baseDefinitions := append([]looppkg.Spec(nil), a.cfg.Loops.Definitions...)
+	// Core-defined loops come first because first wins: everything below
+	// appends only what is not already declared, so a definition living
+	// in the signed core root takes precedence over the same-named
+	// built-in without needing a rule of its own.
+	coreDefinitions, err := loadCoreLoopDefinitions(a.cfg.Paths["core"])
+	if err != nil {
+		return nil, fmt.Errorf("core loop definitions: %w", err)
+	}
+	baseDefinitions := append(coreDefinitions, a.cfg.Loops.Definitions...)
 	seen := make(map[string]struct{}, len(baseDefinitions))
 	for _, def := range baseDefinitions {
 		seen[strings.TrimSpace(def.Name)] = struct{}{}

--- a/internal/app/loop_definitions_core_dir.go
+++ b/internal/app/loop_definitions_core_dir.go
@@ -1,0 +1,148 @@
+package app
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	looppkg "github.com/nugget/thane-ai-agent/internal/runtime/loop"
+	"github.com/nugget/thane-ai-agent/internal/tools"
+	"gopkg.in/yaml.v3"
+)
+
+// coreLoopsDirName is the subdirectory of the core document root holding
+// operator-authored loop definitions, one spec per YAML file.
+const coreLoopsDirName = "loops"
+
+// excludeToolsDirectHumanEgress expands to every direct human-egress
+// tool name at load.
+//
+// The list is decided in Go — a tool becomes human-egress by what it
+// does, not by an operator remembering to add it — so a YAML file that
+// spelled the names out would be a copy that goes stale the first time
+// one is added. The token says the intent instead, which is also what a
+// reader of the spec needs to know.
+//
+// The "group:" prefix rather than a sigil: YAML reserves @ and ` as
+// indicators, so a token starting with one is a parse error unless
+// quoted, and a marker that silently requires quoting is a trap laid for
+// whoever writes the next definition. A colon with no following space is
+// an ordinary plain scalar, and no tool name contains one.
+const excludeToolsDirectHumanEgress = "group:direct_human_egress"
+
+// loadCoreLoopDefinitions reads every loop definition declared under
+// <core>/loops.
+//
+// These are authoritative. A core-defined loop is part of the signed
+// root the agent boots from, so the file is the definition: it wins over
+// the built-in spec of the same name, and it is re-read every boot
+// rather than seeded once. An operator editing the YAML and restarting
+// is the supported way to change one, and a runtime edit that the file
+// does not agree with does not survive.
+//
+// A missing directory is not an error — an install with no core-defined
+// loops is ordinary — but a file that is present and unreadable is,
+// because the alternative is booting with a definition silently absent.
+func loadCoreLoopDefinitions(corePath string) ([]looppkg.Spec, error) {
+	if strings.TrimSpace(corePath) == "" {
+		return nil, nil
+	}
+	dir := filepath.Join(corePath, coreLoopsDirName)
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read %s: %w", dir, err)
+	}
+
+	names := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		switch strings.ToLower(filepath.Ext(entry.Name())) {
+		case ".yaml", ".yml":
+			names = append(names, entry.Name())
+		}
+	}
+	// Sorted so the definition order a boot produces is a property of the
+	// directory rather than of the filesystem's enumeration order.
+	sort.Strings(names)
+
+	specs := make([]looppkg.Spec, 0, len(names))
+	seen := make(map[string]string, len(names))
+	for _, name := range names {
+		path := filepath.Join(dir, name)
+		spec, err := decodeCoreLoopDefinition(path)
+		if err != nil {
+			return nil, err
+		}
+		if other, dup := seen[spec.Name]; dup {
+			return nil, fmt.Errorf("%s and %s both define the loop %q; one file is one loop", other, name, spec.Name)
+		}
+		seen[spec.Name] = name
+		specs = append(specs, spec)
+	}
+	return specs, nil
+}
+
+// decodeCoreLoopDefinition reads one spec file, refusing anything it
+// cannot fully account for.
+//
+// KnownFields is on because a misspelled key in a definition file is
+// otherwise invisible: the loop boots, the setting the operator wrote
+// does nothing, and the only evidence is behaviour that never changes.
+func decodeCoreLoopDefinition(path string) (looppkg.Spec, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return looppkg.Spec{}, fmt.Errorf("open %s: %w", path, err)
+	}
+	defer func() { _ = file.Close() }()
+
+	decoder := yaml.NewDecoder(file)
+	decoder.KnownFields(true)
+	var spec looppkg.Spec
+	if err := decoder.Decode(&spec); err != nil {
+		return looppkg.Spec{}, fmt.Errorf("%s: %w", filepath.Base(path), err)
+	}
+
+	spec.ExcludeTools = expandExcludeToolTokens(spec.ExcludeTools)
+	if err := spec.ValidatePersistable(); err != nil {
+		return looppkg.Spec{}, fmt.Errorf("%s: %w", filepath.Base(path), err)
+	}
+	return spec, nil
+}
+
+// expandExcludeToolTokens replaces symbolic exclusions with the names
+// they stand for, leaving ordinary tool names untouched and dropping
+// duplicates an expansion may introduce.
+func expandExcludeToolTokens(excludes []string) []string {
+	if len(excludes) == 0 {
+		return excludes
+	}
+	out := make([]string, 0, len(excludes))
+	seen := make(map[string]struct{}, len(excludes))
+	add := func(name string) {
+		if name = strings.TrimSpace(name); name == "" {
+			return
+		}
+		if _, dup := seen[name]; dup {
+			return
+		}
+		seen[name] = struct{}{}
+		out = append(out, name)
+	}
+	for _, exclude := range excludes {
+		if strings.TrimSpace(exclude) == excludeToolsDirectHumanEgress {
+			for _, name := range tools.DirectHumanEgressToolNames() {
+				add(name)
+			}
+			continue
+		}
+		add(exclude)
+	}
+	return out
+}

--- a/internal/app/loop_definitions_core_dir.go
+++ b/internal/app/loop_definitions_core_dir.go
@@ -1,7 +1,9 @@
 package app
 
 import (
+	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"sort"
@@ -88,6 +90,14 @@ func loadCoreLoopDefinitions(corePath string) ([]looppkg.Spec, error) {
 		if entry.IsDir() || !strings.EqualFold(filepath.Ext(entry.Name()), ".md") {
 			continue
 		}
+		// Regular files only. A symlink here would read content from
+		// outside the signed root while looking like part of it, which is
+		// the one thing a definition living in core is supposed to rule
+		// out. Refused loudly rather than skipped: a definition silently
+		// absent is how a loop stops existing without anyone noticing.
+		if !entry.Type().IsRegular() {
+			return nil, fmt.Errorf("%s is not a regular file (%s); a loop definition must be a file in the signed root, not a link to content outside it", filepath.Join(dir, entry.Name()), entry.Type())
+		}
 		names = append(names, entry.Name())
 	}
 	// Sorted so the definition order a boot produces is a property of the
@@ -101,10 +111,14 @@ func loadCoreLoopDefinitions(corePath string) ([]looppkg.Spec, error) {
 		if err != nil {
 			return nil, err
 		}
-		if other, dup := seen[spec.Name]; dup {
-			return nil, fmt.Errorf("%s and %s both define the loop %q; one document is one loop", other, name, spec.Name)
+		// Keyed on the trimmed name because that is what everything
+		// downstream keys on: "ego" and "ego " are two entries here and
+		// one loop by the time they reach the registry.
+		key := strings.TrimSpace(spec.Name)
+		if other, dup := seen[key]; dup {
+			return nil, fmt.Errorf("%s and %s both define the loop %q; one document is one loop", other, name, key)
 		}
-		seen[spec.Name] = name
+		seen[key] = name
 		specs = append(specs, spec)
 	}
 	return specs, nil
@@ -183,19 +197,37 @@ func decodeCoreLoopSpecYAML(specYAML, file string) (looppkg.Spec, error) {
 	if err := decoder.Decode(&spec); err != nil {
 		return looppkg.Spec{}, fmt.Errorf("%s: %w", file, err)
 	}
+	// A stray "---" inside the fence starts a second YAML document, and
+	// everything after it would be dropped without a word. That is the
+	// same silence KnownFields exists to prevent, so it is refused the
+	// same way.
+	var extra looppkg.Spec
+	if err := decoder.Decode(&extra); !errors.Is(err, io.EOF) {
+		return looppkg.Spec{}, fmt.Errorf("%s: the spec block holds more than one yaml document; a stray \"---\" splits it, and everything after the first document would be ignored", file)
+	}
 	return spec, nil
 }
 
-// splitCoreLoopSections collects the document's top-level sections by
-// heading. Anything before the first heading — frontmatter, a title, a
-// lead paragraph — is not a section and is ignored, which is what lets
-// these be ordinary documents carrying ordinary metadata.
+// splitCoreLoopSections collects the document's reserved sections.
+// Anything before the first one — frontmatter, a title, a lead paragraph
+// — is not a section and is ignored, which is what lets these be
+// ordinary documents carrying ordinary metadata.
 //
-// Only "## " delimits. A deeper heading inside a prompt is that prompt's
-// own structure, and prompts have plenty of it.
+// Only an H2 whose text is exactly a reserved name delimits. A prompt is
+// a document in its own right and uses H2 freely: the three being ported
+// carry seventeen between them, "## Guidelines" and "## What To Do This
+// Iteration" among them. Treating every "## " as a boundary would shred
+// each prompt into fragments at load, so the rule is the one the facet
+// contract already uses — a heading is structure only if the contract
+// named it, and everything else is content.
+//
+// Fenced blocks are skipped for the same reason at one remove: a prompt
+// may quote a markdown example, and a "## Spec" line inside it is a
+// quotation rather than a section.
 func splitCoreLoopSections(raw string) map[string]string {
 	sections := make(map[string]string, 3)
 	current := ""
+	fenced := false
 	var lines []string
 	flush := func() {
 		if current != "" {
@@ -204,10 +236,16 @@ func splitCoreLoopSections(raw string) map[string]string {
 		lines = nil
 	}
 	for _, line := range strings.Split(raw, "\n") {
-		if heading, ok := strings.CutPrefix(strings.TrimSpace(line), "## "); ok {
-			flush()
-			current = strings.TrimSpace(heading)
-			continue
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "```") {
+			fenced = !fenced
+		}
+		if !fenced {
+			if heading, ok := reservedCoreLoopHeading(trimmed); ok {
+				flush()
+				current = heading
+				continue
+			}
 		}
 		if current != "" {
 			lines = append(lines, line)
@@ -215,6 +253,23 @@ func splitCoreLoopSections(raw string) map[string]string {
 	}
 	flush()
 	return sections
+}
+
+// reservedCoreLoopHeading reports the section a line opens, if the line
+// is an H2 naming one. Matching is case-insensitive because an author
+// hand-writing the document should not have to match our capitalization.
+func reservedCoreLoopHeading(trimmed string) (string, bool) {
+	text, ok := strings.CutPrefix(trimmed, "## ")
+	if !ok {
+		return "", false
+	}
+	text = strings.TrimSpace(text)
+	for _, heading := range []string{coreLoopSpecHeading, coreLoopTaskHeading, coreLoopSupervisorHeading} {
+		if strings.EqualFold(text, heading) {
+			return heading, true
+		}
+	}
+	return "", false
 }
 
 // unfenceYAML unwraps a fenced block, reporting whether the section was

--- a/internal/app/loop_definitions_core_dir.go
+++ b/internal/app/loop_definitions_core_dir.go
@@ -7,20 +7,47 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/nugget/thane-ai-agent/internal/model/router"
 	looppkg "github.com/nugget/thane-ai-agent/internal/runtime/loop"
 	"github.com/nugget/thane-ai-agent/internal/tools"
 	"gopkg.in/yaml.v3"
 )
 
 // coreLoopsDirName is the subdirectory of the core document root holding
-// operator-authored loop definitions, one spec per YAML file.
+// operator-authored loop definitions, one loop per markdown document.
 const coreLoopsDirName = "loops"
+
+// Reserved section headings in a loop definition document.
+//
+// A definition is a markdown document because that is what the rest of
+// this corpus already is: talents, dossiers, and every managed document
+// take this shape, core is already a document root, and an agent tuning
+// its own prompt should reach for the document tools it already has
+// rather than a format invented for this one job.
+//
+// The spec rides a fenced yaml block under its own heading rather than
+// in frontmatter, for two reasons. The document layer flattens
+// frontmatter to map[string][]string, so nested fields — an output's
+// facets, a profile, a subscription list — would survive on disk and be
+// quietly mangled by anything that wrote frontmatter back. And a fence
+// that gets clobbered fails to parse, naming its file, where flattened
+// frontmatter yields a spec that parses and is wrong. Loud beats silent
+// when the thing at stake is how a loop thinks.
+//
+// The heading is what makes the fence unambiguous: a prompt may
+// legitimately contain a yaml example — the archivist's teaches
+// structure — and only the fence under this heading is read.
+const (
+	coreLoopSpecHeading       = "Spec"
+	coreLoopTaskHeading       = "Task"
+	coreLoopSupervisorHeading = "Supervisor Review"
+)
 
 // excludeToolsDirectHumanEgress expands to every direct human-egress
 // tool name at load.
 //
 // The list is decided in Go — a tool becomes human-egress by what it
-// does, not by an operator remembering to add it — so a YAML file that
+// does, not by an author remembering to add it — so a definition that
 // spelled the names out would be a copy that goes stale the first time
 // one is added. The token says the intent instead, which is also what a
 // reader of the spec needs to know.
@@ -32,15 +59,13 @@ const coreLoopsDirName = "loops"
 // an ordinary plain scalar, and no tool name contains one.
 const excludeToolsDirectHumanEgress = "group:direct_human_egress"
 
-// loadCoreLoopDefinitions reads every loop definition declared under
-// <core>/loops.
+// loadCoreLoopDefinitions reads every loop definition under <core>/loops.
 //
 // These are authoritative. A core-defined loop is part of the signed
-// root the agent boots from, so the file is the definition: it wins over
-// the built-in spec of the same name, and it is re-read every boot
-// rather than seeded once. An operator editing the YAML and restarting
-// is the supported way to change one, and a runtime edit that the file
-// does not agree with does not survive.
+// root the agent boots from, so the document is the definition: it wins
+// over the built-in spec of the same name, and it is re-read every boot
+// rather than seeded once. An operator or agent edits the document and
+// restarts.
 //
 // A missing directory is not an error — an install with no core-defined
 // loops is ordinary — but a file that is present and unreadable is,
@@ -60,13 +85,10 @@ func loadCoreLoopDefinitions(corePath string) ([]looppkg.Spec, error) {
 
 	names := make([]string, 0, len(entries))
 	for _, entry := range entries {
-		if entry.IsDir() {
+		if entry.IsDir() || !strings.EqualFold(filepath.Ext(entry.Name()), ".md") {
 			continue
 		}
-		switch strings.ToLower(filepath.Ext(entry.Name())) {
-		case ".yaml", ".yml":
-			names = append(names, entry.Name())
-		}
+		names = append(names, entry.Name())
 	}
 	// Sorted so the definition order a boot produces is a property of the
 	// directory rather than of the filesystem's enumeration order.
@@ -75,13 +97,12 @@ func loadCoreLoopDefinitions(corePath string) ([]looppkg.Spec, error) {
 	specs := make([]looppkg.Spec, 0, len(names))
 	seen := make(map[string]string, len(names))
 	for _, name := range names {
-		path := filepath.Join(dir, name)
-		spec, err := decodeCoreLoopDefinition(path)
+		spec, err := decodeCoreLoopDefinition(filepath.Join(dir, name))
 		if err != nil {
 			return nil, err
 		}
 		if other, dup := seen[spec.Name]; dup {
-			return nil, fmt.Errorf("%s and %s both define the loop %q; one file is one loop", other, name, spec.Name)
+			return nil, fmt.Errorf("%s and %s both define the loop %q; one document is one loop", other, name, spec.Name)
 		}
 		seen[spec.Name] = name
 		specs = append(specs, spec)
@@ -89,31 +110,133 @@ func loadCoreLoopDefinitions(corePath string) ([]looppkg.Spec, error) {
 	return specs, nil
 }
 
-// decodeCoreLoopDefinition reads one spec file, refusing anything it
-// cannot fully account for.
-//
-// KnownFields is on because a misspelled key in a definition file is
-// otherwise invisible: the loop boots, the setting the operator wrote
-// does nothing, and the only evidence is behaviour that never changes.
+// decodeCoreLoopDefinition reads one definition document.
 func decodeCoreLoopDefinition(path string) (looppkg.Spec, error) {
-	file, err := os.Open(path)
+	file := filepath.Base(path)
+	raw, err := os.ReadFile(path)
 	if err != nil {
-		return looppkg.Spec{}, fmt.Errorf("open %s: %w", path, err)
+		return looppkg.Spec{}, fmt.Errorf("read %s: %w", file, err)
 	}
-	defer func() { _ = file.Close() }()
 
-	decoder := yaml.NewDecoder(file)
-	decoder.KnownFields(true)
-	var spec looppkg.Spec
-	if err := decoder.Decode(&spec); err != nil {
-		return looppkg.Spec{}, fmt.Errorf("%s: %w", filepath.Base(path), err)
+	sections := splitCoreLoopSections(string(raw))
+	specBlock, ok := sections[coreLoopSpecHeading]
+	if !ok {
+		return looppkg.Spec{}, fmt.Errorf("%s: no %q section; a loop definition carries its spec in a yaml block under that heading", file, "## "+coreLoopSpecHeading)
+	}
+	specYAML, ok := unfenceYAML(specBlock)
+	if !ok {
+		return looppkg.Spec{}, fmt.Errorf("%s: the %q section is not a single ```yaml block; the spec is fenced so prose and machine-readable content stay distinguishable", file, "## "+coreLoopSpecHeading)
+	}
+
+	spec, err := decodeCoreLoopSpecYAML(specYAML, file)
+	if err != nil {
+		return looppkg.Spec{}, err
+	}
+	if err := adoptCoreLoopProse(&spec, sections, file); err != nil {
+		return looppkg.Spec{}, err
 	}
 
 	spec.ExcludeTools = expandExcludeToolTokens(spec.ExcludeTools)
 	if err := spec.ValidatePersistable(); err != nil {
-		return looppkg.Spec{}, fmt.Errorf("%s: %w", filepath.Base(path), err)
+		return looppkg.Spec{}, fmt.Errorf("%s: %w", file, err)
 	}
 	return spec, nil
+}
+
+// adoptCoreLoopProse moves the document's prose sections onto the spec.
+//
+// Declaring one in both places is refused rather than resolved: a silent
+// precedence rule means an author edits the prompt they can read and the
+// loop keeps running the one they cannot.
+func adoptCoreLoopProse(spec *looppkg.Spec, sections map[string]string, file string) error {
+	if task := strings.TrimSpace(sections[coreLoopTaskHeading]); task != "" {
+		if strings.TrimSpace(spec.Task) != "" {
+			return fmt.Errorf("%s: task is set in the spec block and in a %q section; declare it once — the section is the one meant for prose", file, "## "+coreLoopTaskHeading)
+		}
+		spec.Task = task
+	}
+	if instructions := strings.TrimSpace(sections[coreLoopSupervisorHeading]); instructions != "" {
+		// A definition may declare the section without declaring a
+		// supervisor_profile at all, which is the ordinary case: the
+		// overlay exists to carry these instructions.
+		if spec.SupervisorProfile == nil {
+			spec.SupervisorProfile = &router.LoopProfile{}
+		}
+		if strings.TrimSpace(spec.SupervisorProfile.Instructions) != "" {
+			return fmt.Errorf("%s: supervisor instructions are set in the spec block and in a %q section; declare them once — the section is the one meant for prose", file, "## "+coreLoopSupervisorHeading)
+		}
+		spec.SupervisorProfile.Instructions = instructions
+	}
+	return nil
+}
+
+// decodeCoreLoopSpecYAML decodes the fenced spec, refusing anything it
+// cannot fully account for.
+//
+// KnownFields is on because a misspelled key is otherwise invisible: the
+// loop boots, the setting its author wrote does nothing, and the only
+// evidence is behaviour that never changes.
+func decodeCoreLoopSpecYAML(specYAML, file string) (looppkg.Spec, error) {
+	decoder := yaml.NewDecoder(strings.NewReader(specYAML))
+	decoder.KnownFields(true)
+	var spec looppkg.Spec
+	if err := decoder.Decode(&spec); err != nil {
+		return looppkg.Spec{}, fmt.Errorf("%s: %w", file, err)
+	}
+	return spec, nil
+}
+
+// splitCoreLoopSections collects the document's top-level sections by
+// heading. Anything before the first heading — frontmatter, a title, a
+// lead paragraph — is not a section and is ignored, which is what lets
+// these be ordinary documents carrying ordinary metadata.
+//
+// Only "## " delimits. A deeper heading inside a prompt is that prompt's
+// own structure, and prompts have plenty of it.
+func splitCoreLoopSections(raw string) map[string]string {
+	sections := make(map[string]string, 3)
+	current := ""
+	var lines []string
+	flush := func() {
+		if current != "" {
+			sections[current] = strings.TrimSpace(strings.Join(lines, "\n"))
+		}
+		lines = nil
+	}
+	for _, line := range strings.Split(raw, "\n") {
+		if heading, ok := strings.CutPrefix(strings.TrimSpace(line), "## "); ok {
+			flush()
+			current = strings.TrimSpace(heading)
+			continue
+		}
+		if current != "" {
+			lines = append(lines, line)
+		}
+	}
+	flush()
+	return sections
+}
+
+// unfenceYAML unwraps a fenced block, reporting whether the section was
+// one. A value carrying an interior close is refused: unwrapping it
+// would splice two blocks into one.
+func unfenceYAML(section string) (string, bool) {
+	trimmed := strings.TrimSpace(section)
+	opener := ""
+	for _, candidate := range []string{"```yaml", "```yml", "```"} {
+		if strings.HasPrefix(trimmed, candidate) {
+			opener = candidate
+			break
+		}
+	}
+	if opener == "" || !strings.HasSuffix(trimmed, "```") {
+		return "", false
+	}
+	inner := strings.TrimSuffix(strings.TrimPrefix(trimmed, opener), "```")
+	if strings.Contains(inner, "```") {
+		return "", false
+	}
+	return inner, true
 }
 
 // expandExcludeToolTokens replaces symbolic exclusions with the names

--- a/internal/app/loop_definitions_core_dir_test.go
+++ b/internal/app/loop_definitions_core_dir_test.go
@@ -29,18 +29,29 @@ func writeCoreLoop(t *testing.T, files map[string]string) string {
 	return core
 }
 
-const minimalCoreLoop = `name: ranch_watch
-enabled: true
-task: Watch the ranch.
-intent: Keep ranch conditions legible.
-operation: service
-completion: none
-sleep_min: 15m
-sleep_max: 12h
-`
+// minimalCoreLoop is a definition document in the shape an operator or
+// agent authors: ordinary frontmatter, the spec in a fenced block under
+// its heading, the prompt as prose.
+const minimalCoreLoop = "---\n" +
+	"title: Ranch Watch\n" +
+	"tags: [loops]\n" +
+	"---\n\n" +
+	"# Ranch Watch\n\n" +
+	"## Spec\n\n" +
+	"```yaml\n" +
+	"name: ranch_watch\n" +
+	"enabled: true\n" +
+	"intent: Keep ranch conditions legible.\n" +
+	"operation: service\n" +
+	"completion: none\n" +
+	"sleep_min: 15m\n" +
+	"sleep_max: 12h\n" +
+	"```\n\n" +
+	"## Task\n\n" +
+	"Watch the ranch.\n"
 
 func TestCoreLoopDefinitionsLoadFromYAML(t *testing.T) {
-	specs, err := loadCoreLoopDefinitions(writeCoreLoop(t, map[string]string{"ranch.yaml": minimalCoreLoop}))
+	specs, err := loadCoreLoopDefinitions(writeCoreLoop(t, map[string]string{"ranch.md": minimalCoreLoop}))
 	if err != nil {
 		t.Fatalf("loadCoreLoopDefinitions: %v", err)
 	}
@@ -76,13 +87,13 @@ func TestMissingCoreLoopsDirectoryIsNotAnError(t *testing.T) {
 // changes.
 func TestMisspelledKeyIsRefused(t *testing.T) {
 	core := writeCoreLoop(t, map[string]string{
-		"ranch.yaml": minimalCoreLoop + "sleep_maximum: 4h\n",
+		"ranch.md": strings.Replace(minimalCoreLoop, "sleep_max: 12h", "sleep_max: 12h\nsleep_maximum: 4h", 1),
 	})
 	_, err := loadCoreLoopDefinitions(core)
 	if err == nil {
 		t.Fatal("loadCoreLoopDefinitions error = nil for an unknown key")
 	}
-	for _, want := range []string{"ranch.yaml", "sleep_maximum"} {
+	for _, want := range []string{"ranch.md", "sleep_maximum"} {
 		if !strings.Contains(err.Error(), want) {
 			t.Errorf("error = %v, want it to mention %q", err, want)
 		}
@@ -93,28 +104,28 @@ func TestInvalidCoreLoopNamesItsFile(t *testing.T) {
 	// One bad file among several has to be identifiable, or an operator
 	// is left bisecting a directory.
 	core := writeCoreLoop(t, map[string]string{
-		"good.yaml": minimalCoreLoop,
-		"bad.yaml":  "name: broken\nenabled: true\ntask: Do a thing.\noperation: nonsense\n",
+		"good.md": minimalCoreLoop,
+		"bad.md":  strings.Replace(minimalCoreLoop, "operation: service", "operation: nonsense", 1),
 	})
 	_, err := loadCoreLoopDefinitions(core)
 	if err == nil {
 		t.Fatal("loadCoreLoopDefinitions error = nil for an invalid spec")
 	}
-	if !strings.Contains(err.Error(), "bad.yaml") {
+	if !strings.Contains(err.Error(), "bad.md") {
 		t.Errorf("error = %v, want it to name the offending file", err)
 	}
 }
 
 func TestTwoFilesCannotDefineTheSameLoop(t *testing.T) {
 	core := writeCoreLoop(t, map[string]string{
-		"a.yaml": minimalCoreLoop,
-		"b.yaml": minimalCoreLoop,
+		"a.md": minimalCoreLoop,
+		"b.md": minimalCoreLoop,
 	})
 	_, err := loadCoreLoopDefinitions(core)
 	if err == nil {
 		t.Fatal("loadCoreLoopDefinitions error = nil for a duplicate loop name")
 	}
-	for _, want := range []string{"a.yaml", "b.yaml", "ranch_watch"} {
+	for _, want := range []string{"a.md", "b.md", "ranch_watch"} {
 		if !strings.Contains(err.Error(), want) {
 			t.Errorf("error = %v, want it to mention %q", err, want)
 		}
@@ -127,7 +138,7 @@ func TestTwoFilesCannotDefineTheSameLoop(t *testing.T) {
 // added.
 func TestDirectHumanEgressTokenExpands(t *testing.T) {
 	core := writeCoreLoop(t, map[string]string{
-		"ranch.yaml": minimalCoreLoop + "exclude_tools:\n  - exec\n  - " + excludeToolsDirectHumanEgress + "\n",
+		"ranch.md": strings.Replace(minimalCoreLoop, "sleep_max: 12h", "sleep_max: 12h\nexclude_tools:\n  - exec\n  - "+excludeToolsDirectHumanEgress, 1),
 	})
 	specs, err := loadCoreLoopDefinitions(core)
 	if err != nil {
@@ -190,7 +201,7 @@ func TestExcludeTokenNeedsNoQuoting(t *testing.T) {
 	}
 	// Written bare, exactly as an operator would.
 	core := writeCoreLoop(t, map[string]string{
-		"ranch.yaml": minimalCoreLoop + "exclude_tools:\n  - " + excludeToolsDirectHumanEgress + "\n",
+		"ranch.md": strings.Replace(minimalCoreLoop, "sleep_max: 12h", "sleep_max: 12h\nexclude_tools:\n  - "+excludeToolsDirectHumanEgress, 1),
 	})
 	if _, err := loadCoreLoopDefinitions(core); err != nil {
 		t.Fatalf("an unquoted token did not parse: %v", err)
@@ -203,15 +214,12 @@ func TestExcludeTokenNeedsNoQuoting(t *testing.T) {
 // edits the file and restarts gets what the file says.
 func TestCoreDefinitionWinsOverTheBuiltIn(t *testing.T) {
 	core := writeCoreLoop(t, map[string]string{
-		"ego.yaml": `name: ego
-enabled: true
-intent: Overridden by the operator.
-task: Reflect, but differently.
-operation: service
-completion: none
-sleep_min: 1h
-sleep_max: 6h
-`,
+		"ego.md": strings.NewReplacer(
+			"name: ranch_watch", "name: ego",
+			"intent: Keep ranch conditions legible.", "intent: Overridden by the operator.",
+			"sleep_min: 15m", "sleep_min: 1h",
+			"Watch the ranch.", "Reflect, but differently.",
+		).Replace(minimalCoreLoop),
 	})
 	app := &App{cfg: &config.Config{
 		Paths: map[string]string{"core": core},
@@ -275,5 +283,106 @@ func testServiceLoopConfig() config.ServiceLoopConfig {
 		MinSleep:     "15m",
 		MaxSleep:     "12h",
 		DefaultSleep: "1h",
+	}
+}
+
+// TestProseSectionsBecomeThePrompts is the point of the format: the
+// prompt is markdown in a markdown document, not a string escaped into a
+// data structure.
+func TestProseSectionsBecomeThePrompts(t *testing.T) {
+	doc := strings.Replace(minimalCoreLoop,
+		"## Task\n\nWatch the ranch.\n",
+		"## Task\n\nWatch the ranch.\n\n### What to look at\n\nThe things that matter.\n\n## Supervisor Review\n\nReview it harder.\n", 1)
+	specs, err := loadCoreLoopDefinitions(writeCoreLoop(t, map[string]string{"ranch.md": doc}))
+	if err != nil {
+		t.Fatalf("loadCoreLoopDefinitions: %v", err)
+	}
+	spec := specs[0]
+	// A deeper heading inside a prompt is that prompt's own structure.
+	if !strings.Contains(spec.Task, "### What to look at") {
+		t.Errorf("task lost its subsection: %q", spec.Task)
+	}
+	if strings.Contains(spec.Task, "Review it harder") {
+		t.Errorf("task swallowed the next section: %q", spec.Task)
+	}
+	if spec.SupervisorProfile.Instructions != "Review it harder." {
+		t.Errorf("supervisor instructions = %q", spec.SupervisorProfile.Instructions)
+	}
+}
+
+// TestYAMLExampleInAProseSectionIsNotTheSpec is why the fence needs a
+// heading. Prompts teach structure, so one may legitimately contain a
+// yaml block; only the one under "## Spec" is the definition.
+func TestYAMLExampleInAProseSectionIsNotTheSpec(t *testing.T) {
+	doc := strings.Replace(minimalCoreLoop,
+		"Watch the ranch.\n",
+		"Watch the ranch. Publish like this:\n\n```yaml\nname: not_the_spec\noperation: nonsense\n```\n", 1)
+	specs, err := loadCoreLoopDefinitions(writeCoreLoop(t, map[string]string{"ranch.md": doc}))
+	if err != nil {
+		t.Fatalf("an example block in prose broke the load: %v", err)
+	}
+	if specs[0].Name != "ranch_watch" {
+		t.Fatalf("name = %q, want the spec section's — an example was read as the definition", specs[0].Name)
+	}
+	if !strings.Contains(specs[0].Task, "name: not_the_spec") {
+		t.Errorf("the example was stripped out of the prompt: %q", specs[0].Task)
+	}
+}
+
+func TestMissingOrUnfencedSpecSectionIsRefused(t *testing.T) {
+	tests := []struct {
+		name    string
+		doc     string
+		wantErr string
+	}{
+		{
+			name:    "no spec section",
+			doc:     "---\ntitle: X\n---\n\n## Task\n\nDo a thing.\n",
+			wantErr: "no \"## Spec\" section",
+		},
+		{
+			name:    "spec section is prose",
+			doc:     strings.Replace(minimalCoreLoop, "```yaml\nname: ranch_watch", "name: ranch_watch", 1),
+			wantErr: "not a single ```yaml block",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := loadCoreLoopDefinitions(writeCoreLoop(t, map[string]string{"ranch.md": tt.doc}))
+			if err == nil {
+				t.Fatalf("loadCoreLoopDefinitions error = nil, want %q", tt.wantErr)
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("error = %v, want it to mention %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// TestTaskDeclaredTwiceIsRefused: a silent precedence rule means an
+// author edits the prompt they can read and the loop keeps running the
+// one they cannot.
+func TestTaskDeclaredTwiceIsRefused(t *testing.T) {
+	doc := strings.Replace(minimalCoreLoop, "sleep_max: 12h", "sleep_max: 12h\ntask: The hidden one.", 1)
+	_, err := loadCoreLoopDefinitions(writeCoreLoop(t, map[string]string{"ranch.md": doc}))
+	if err == nil {
+		t.Fatal("loadCoreLoopDefinitions error = nil for a task declared in both places")
+	}
+	if !strings.Contains(err.Error(), "declare it once") {
+		t.Errorf("error = %v, want it to say to declare it once", err)
+	}
+}
+
+// TestSpecInFrontmatterIsIgnored guards the choice itself: frontmatter
+// is ordinary document metadata here, so a spec key there must not be
+// read as part of the definition.
+func TestSpecInFrontmatterIsIgnored(t *testing.T) {
+	doc := strings.Replace(minimalCoreLoop, "tags: [loops]", "tags: [loops]\nsleep_min: 99h", 1)
+	specs, err := loadCoreLoopDefinitions(writeCoreLoop(t, map[string]string{"ranch.md": doc}))
+	if err != nil {
+		t.Fatalf("loadCoreLoopDefinitions: %v", err)
+	}
+	if specs[0].SleepMin != 15*time.Minute {
+		t.Errorf("sleep_min = %v, want the spec block's 15m — frontmatter is document metadata, not spec", specs[0].SleepMin)
 	}
 }

--- a/internal/app/loop_definitions_core_dir_test.go
+++ b/internal/app/loop_definitions_core_dir_test.go
@@ -249,7 +249,7 @@ func TestCoreDefinitionWinsOverTheBuiltIn(t *testing.T) {
 }
 
 // TestBuiltInStillAppliesWithoutAFile is the other half: the override is
-// opt-in per loop, so an install with no ego.yaml still gets an ego.
+// opt-in per loop, so an install with no ego.md still gets an ego.
 func TestBuiltInStillAppliesWithoutAFile(t *testing.T) {
 	app := &App{cfg: &config.Config{
 		Paths: map[string]string{"core": t.TempDir()},
@@ -384,5 +384,105 @@ func TestSpecInFrontmatterIsIgnored(t *testing.T) {
 	}
 	if specs[0].SleepMin != 15*time.Minute {
 		t.Errorf("sleep_min = %v, want the spec block's 15m — frontmatter is document metadata, not spec", specs[0].SleepMin)
+	}
+}
+
+// TestRealPromptHeadingsSurvive is the case that would have broken the
+// port. The three prompts being moved carry seventeen H2 headings
+// between them, so a splitter that treated every "## " as a boundary
+// would shred each one into fragments at load.
+func TestRealPromptHeadingsSurvive(t *testing.T) {
+	prompt := strings.Join([]string{
+		"Ego loop iteration.",
+		"",
+		"## Your Durable Output",
+		"",
+		"Your contract is injected above.",
+		"",
+		"## What To Do This Iteration",
+		"",
+		"1. Read your current ego.md",
+		"2. Reflect honestly",
+		"",
+		"## Guidelines",
+		"",
+		"Quality of thought matters more than coverage.",
+	}, "\n")
+	doc := strings.Replace(minimalCoreLoop, "Watch the ranch.\n", prompt+"\n", 1)
+
+	specs, err := loadCoreLoopDefinitions(writeCoreLoop(t, map[string]string{"ranch.md": doc}))
+	if err != nil {
+		t.Fatalf("loadCoreLoopDefinitions: %v", err)
+	}
+	if specs[0].Task != prompt {
+		t.Fatalf("the prompt was shredded at its own headings:\n got %q\nwant %q", specs[0].Task, prompt)
+	}
+}
+
+// TestReservedHeadingInsideAFenceIsQuoted covers a prompt that teaches
+// this very format — a plausible thing for these prompts to do.
+func TestReservedHeadingInsideAFenceIsQuoted(t *testing.T) {
+	prompt := "Write a definition like this:\n\n```markdown\n## Spec\n\nname: example\n\n## Task\n\nDo the thing.\n```\n\nThen restart."
+	doc := strings.Replace(minimalCoreLoop, "Watch the ranch.\n", prompt+"\n", 1)
+
+	specs, err := loadCoreLoopDefinitions(writeCoreLoop(t, map[string]string{"ranch.md": doc}))
+	if err != nil {
+		t.Fatalf("loadCoreLoopDefinitions: %v", err)
+	}
+	if specs[0].Name != "ranch_watch" {
+		t.Errorf("name = %q — a quoted heading was read as a section", specs[0].Name)
+	}
+	if !strings.Contains(specs[0].Task, "## Task") || !strings.Contains(specs[0].Task, "Then restart.") {
+		t.Errorf("the quoted example did not survive intact: %q", specs[0].Task)
+	}
+}
+
+func TestSymlinkedDefinitionIsRefused(t *testing.T) {
+	// A symlink reads content from outside the signed root while looking
+	// like part of it, which is the one thing a core definition rules out.
+	core := writeCoreLoop(t, map[string]string{"ranch.md": minimalCoreLoop})
+	outside := filepath.Join(t.TempDir(), "elsewhere.md")
+	if err := os.WriteFile(outside, []byte(minimalCoreLoop), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	link := filepath.Join(core, coreLoopsDirName, "sneaky.md")
+	if err := os.Symlink(outside, link); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+
+	_, err := loadCoreLoopDefinitions(core)
+	if err == nil {
+		t.Fatal("loadCoreLoopDefinitions error = nil for a symlinked definition")
+	}
+	if !strings.Contains(err.Error(), "sneaky.md") || !strings.Contains(err.Error(), "not a regular file") {
+		t.Errorf("error = %v, want it to name the entry and why it was refused", err)
+	}
+}
+
+func TestDuplicateNamesAreComparedTrimmed(t *testing.T) {
+	// "ego" and "ego " are two entries here and one loop downstream.
+	padded := strings.Replace(minimalCoreLoop, "name: ranch_watch", `name: "ranch_watch "`, 1)
+	_, err := loadCoreLoopDefinitions(writeCoreLoop(t, map[string]string{
+		"a.md": minimalCoreLoop,
+		"b.md": padded,
+	}))
+	if err == nil {
+		t.Fatal("loadCoreLoopDefinitions error = nil for names differing only in whitespace")
+	}
+	if !strings.Contains(err.Error(), "both define the loop") {
+		t.Errorf("error = %v, want the duplicate-loop error", err)
+	}
+}
+
+func TestSecondYAMLDocumentInTheSpecBlockIsRefused(t *testing.T) {
+	// A stray "---" starts a second document; everything after it would
+	// be dropped without a word.
+	doc := strings.Replace(minimalCoreLoop, "sleep_max: 12h", "sleep_max: 12h\n---\nname: ignored", 1)
+	_, err := loadCoreLoopDefinitions(writeCoreLoop(t, map[string]string{"ranch.md": doc}))
+	if err == nil {
+		t.Fatal("loadCoreLoopDefinitions error = nil for a two-document spec block")
+	}
+	if !strings.Contains(err.Error(), "more than one yaml document") {
+		t.Errorf("error = %v, want it to explain the stray separator", err)
 	}
 }

--- a/internal/app/loop_definitions_core_dir_test.go
+++ b/internal/app/loop_definitions_core_dir_test.go
@@ -1,0 +1,279 @@
+package app
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nugget/thane-ai-agent/internal/platform/config"
+	looppkg "github.com/nugget/thane-ai-agent/internal/runtime/loop"
+	"github.com/nugget/thane-ai-agent/internal/tools"
+)
+
+// writeCoreLoop puts one definition file in <core>/loops and returns the
+// core root, which is what the loader is given.
+func writeCoreLoop(t *testing.T, files map[string]string) string {
+	t.Helper()
+	core := t.TempDir()
+	dir := filepath.Join(core, coreLoopsDirName)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	for name, body := range files {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(body), 0o644); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+	return core
+}
+
+const minimalCoreLoop = `name: ranch_watch
+enabled: true
+task: Watch the ranch.
+intent: Keep ranch conditions legible.
+operation: service
+completion: none
+sleep_min: 15m
+sleep_max: 12h
+`
+
+func TestCoreLoopDefinitionsLoadFromYAML(t *testing.T) {
+	specs, err := loadCoreLoopDefinitions(writeCoreLoop(t, map[string]string{"ranch.yaml": minimalCoreLoop}))
+	if err != nil {
+		t.Fatalf("loadCoreLoopDefinitions: %v", err)
+	}
+	if len(specs) != 1 {
+		t.Fatalf("loaded %d specs, want 1", len(specs))
+	}
+	spec := specs[0]
+	if spec.Name != "ranch_watch" || spec.Intent != "Keep ranch conditions legible." {
+		t.Fatalf("decoded spec = %#v", spec)
+	}
+	if spec.SleepMin != 15*time.Minute {
+		t.Errorf("sleep_min = %v, want 15m — a duration string has to survive the decode", spec.SleepMin)
+	}
+}
+
+func TestMissingCoreLoopsDirectoryIsNotAnError(t *testing.T) {
+	// An install with no core-defined loops is ordinary.
+	specs, err := loadCoreLoopDefinitions(t.TempDir())
+	if err != nil {
+		t.Fatalf("loadCoreLoopDefinitions: %v", err)
+	}
+	if len(specs) != 0 {
+		t.Fatalf("loaded %d specs from an absent directory", len(specs))
+	}
+	if specs, err = loadCoreLoopDefinitions(""); err != nil || specs != nil {
+		t.Fatalf("empty core path: specs = %v, err = %v", specs, err)
+	}
+}
+
+// TestMisspelledKeyIsRefused is why KnownFields is on. A typo that
+// decodes to nothing produces a loop that boots, ignores the setting the
+// operator wrote, and offers no evidence beyond behaviour that never
+// changes.
+func TestMisspelledKeyIsRefused(t *testing.T) {
+	core := writeCoreLoop(t, map[string]string{
+		"ranch.yaml": minimalCoreLoop + "sleep_maximum: 4h\n",
+	})
+	_, err := loadCoreLoopDefinitions(core)
+	if err == nil {
+		t.Fatal("loadCoreLoopDefinitions error = nil for an unknown key")
+	}
+	for _, want := range []string{"ranch.yaml", "sleep_maximum"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error = %v, want it to mention %q", err, want)
+		}
+	}
+}
+
+func TestInvalidCoreLoopNamesItsFile(t *testing.T) {
+	// One bad file among several has to be identifiable, or an operator
+	// is left bisecting a directory.
+	core := writeCoreLoop(t, map[string]string{
+		"good.yaml": minimalCoreLoop,
+		"bad.yaml":  "name: broken\nenabled: true\ntask: Do a thing.\noperation: nonsense\n",
+	})
+	_, err := loadCoreLoopDefinitions(core)
+	if err == nil {
+		t.Fatal("loadCoreLoopDefinitions error = nil for an invalid spec")
+	}
+	if !strings.Contains(err.Error(), "bad.yaml") {
+		t.Errorf("error = %v, want it to name the offending file", err)
+	}
+}
+
+func TestTwoFilesCannotDefineTheSameLoop(t *testing.T) {
+	core := writeCoreLoop(t, map[string]string{
+		"a.yaml": minimalCoreLoop,
+		"b.yaml": minimalCoreLoop,
+	})
+	_, err := loadCoreLoopDefinitions(core)
+	if err == nil {
+		t.Fatal("loadCoreLoopDefinitions error = nil for a duplicate loop name")
+	}
+	for _, want := range []string{"a.yaml", "b.yaml", "ranch_watch"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error = %v, want it to mention %q", err, want)
+		}
+	}
+}
+
+// TestDirectHumanEgressTokenExpands is the one exclusion a YAML file
+// cannot spell out honestly: which tools reach a human is decided by
+// what they do, so a written-out list goes stale the first time one is
+// added.
+func TestDirectHumanEgressTokenExpands(t *testing.T) {
+	core := writeCoreLoop(t, map[string]string{
+		"ranch.yaml": minimalCoreLoop + "exclude_tools:\n  - exec\n  - " + excludeToolsDirectHumanEgress + "\n",
+	})
+	specs, err := loadCoreLoopDefinitions(core)
+	if err != nil {
+		t.Fatalf("loadCoreLoopDefinitions: %v", err)
+	}
+	got := specs[0].ExcludeTools
+	if len(got) == 0 || got[0] != "exec" {
+		t.Fatalf("exclude_tools = %v, want the literal entry kept in place", got)
+	}
+	egress := tools.DirectHumanEgressToolNames()
+	if len(egress) == 0 {
+		t.Fatal("no direct human egress tools registered; this test proves nothing")
+	}
+	for _, name := range egress {
+		if !slicesContain(got, name) {
+			t.Errorf("exclude_tools = %v, want it to contain %q", got, name)
+		}
+	}
+	if slicesContain(got, excludeToolsDirectHumanEgress) {
+		t.Errorf("the token survived into the spec: %v", got)
+	}
+}
+
+func TestExpandExcludeToolTokensDropsDuplicates(t *testing.T) {
+	egress := tools.DirectHumanEgressToolNames()
+	if len(egress) == 0 {
+		t.Skip("no direct human egress tools registered")
+	}
+	// The same name arriving both literally and by expansion must not
+	// produce two entries.
+	got := expandExcludeToolTokens([]string{egress[0], excludeToolsDirectHumanEgress})
+	count := 0
+	for _, name := range got {
+		if name == egress[0] {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Fatalf("%q appears %d times in %v, want once", egress[0], count, got)
+	}
+}
+
+func slicesContain(haystack []string, needle string) bool {
+	for _, item := range haystack {
+		if item == needle {
+			return true
+		}
+	}
+	return false
+}
+
+// TestExcludeTokenNeedsNoQuoting is a property of the token's spelling
+// rather than of the expansion: YAML reserves @ and ` as indicator
+// characters, so a token starting with one is a parse error unless the
+// author remembers to quote it. A marker that fails only when written
+// the obvious way is worse than no marker.
+func TestExcludeTokenNeedsNoQuoting(t *testing.T) {
+	if strings.ContainsAny(excludeToolsDirectHumanEgress[:1], "@`*&!|>%?-,[]{}#'\"") {
+		t.Fatalf("token %q starts with a reserved YAML indicator; it cannot be written unquoted", excludeToolsDirectHumanEgress)
+	}
+	// Written bare, exactly as an operator would.
+	core := writeCoreLoop(t, map[string]string{
+		"ranch.yaml": minimalCoreLoop + "exclude_tools:\n  - " + excludeToolsDirectHumanEgress + "\n",
+	})
+	if _, err := loadCoreLoopDefinitions(core); err != nil {
+		t.Fatalf("an unquoted token did not parse: %v", err)
+	}
+}
+
+// TestCoreDefinitionWinsOverTheBuiltIn is the authority rule. A loop
+// defined in the signed core root is the definition — the built-in Go
+// spec of the same name is a default, not a floor — so an operator who
+// edits the file and restarts gets what the file says.
+func TestCoreDefinitionWinsOverTheBuiltIn(t *testing.T) {
+	core := writeCoreLoop(t, map[string]string{
+		"ego.yaml": `name: ego
+enabled: true
+intent: Overridden by the operator.
+task: Reflect, but differently.
+operation: service
+completion: none
+sleep_min: 1h
+sleep_max: 6h
+`,
+	})
+	app := &App{cfg: &config.Config{
+		Paths: map[string]string{"core": core},
+		Ego:   testServiceLoopConfig(),
+	}}
+
+	specs, err := app.buildLoopDefinitionBaseSpecs()
+	if err != nil {
+		t.Fatalf("buildLoopDefinitionBaseSpecs: %v", err)
+	}
+
+	var found []looppkg.Spec
+	for _, spec := range specs {
+		if spec.Name == "ego" {
+			found = append(found, spec)
+		}
+	}
+	if len(found) != 1 {
+		t.Fatalf("ego appears %d times, want exactly once — the built-in must not be appended alongside", len(found))
+	}
+	if found[0].Task != "Reflect, but differently." {
+		t.Errorf("task = %q, want the file's — the built-in won", found[0].Task)
+	}
+	if found[0].SleepMin != time.Hour {
+		t.Errorf("sleep_min = %v, want the file's 1h", found[0].SleepMin)
+	}
+}
+
+// TestBuiltInStillAppliesWithoutAFile is the other half: the override is
+// opt-in per loop, so an install with no ego.yaml still gets an ego.
+func TestBuiltInStillAppliesWithoutAFile(t *testing.T) {
+	app := &App{cfg: &config.Config{
+		Paths: map[string]string{"core": t.TempDir()},
+		Ego:   testServiceLoopConfig(),
+	}}
+	specs, err := app.buildLoopDefinitionBaseSpecs()
+	if err != nil {
+		t.Fatalf("buildLoopDefinitionBaseSpecs: %v", err)
+	}
+	for _, spec := range specs {
+		if spec.Name == "ego" {
+			if spec.Task == "" {
+				t.Error("built-in ego has no task")
+			}
+			return
+		}
+	}
+	t.Fatal("ego is absent with no core file and ego enabled")
+}
+
+// testServiceLoopConfig is a valid ego/metacog/archivist config block.
+//
+// It is needed even when the definition comes from a file: the core
+// service registrations still parse and cache their config block so
+// Hydrate has something to run against. That coupling is why the config
+// blocks cannot be dropped until the Go registrations are, and it is the
+// next step in this migration rather than a property worth keeping.
+func testServiceLoopConfig() config.ServiceLoopConfig {
+	return config.ServiceLoopConfig{
+		Enabled:      true,
+		MinSleep:     "15m",
+		MaxSleep:     "12h",
+		DefaultSleep: "1h",
+	}
+}


### PR DESCRIPTION
First of three, toward moving ego / metacognitive / archivist out of Go and into `core/loops/`, so they can be edited without a build and live inside the signed root the agent boots from.

## The format

A definition is a **markdown document**: ordinary frontmatter, the spec in a fenced yaml block under `## Spec`, the prompts as prose sections.

````markdown
---
title: Ego
tags: [loops]
---

## Spec

```yaml
name: ego
operation: service
outputs: [...]
```

## Task

Ego loop iteration. ...

## Supervisor Review

...
````

This is the house format — talents, dossiers, and every managed document already take this shape, and `core` is already a document root. So an agent tuning its own prompt reaches for `doc_edit` on `core:loops/ego.md`, with no tooling invented for this one job. Parse-only: Go never writes these, so there is no render half to keep in sync.

## Why the spec is fenced rather than frontmatter

Frontmatter looked like the obvious home and is the worse one, for a reason that only shows up under failure.

The document layer flattens frontmatter to `map[string][]string`. Nested fields — an output's `facets`, a `profile`, a `subscriptions` list — would sit correctly on disk and be quietly mangled by anything that wrote frontmatter back. **That failure is silent: the spec still parses, and it is wrong.** A clobbered fence fails to parse and names its file. Loud beats silent when the thing at stake is how a loop thinks.

It also leaves frontmatter free to be ordinary document metadata, which is what the doc layer is actually good at, and it reuses the convention #1304 just established — machine-readable content inside a markdown document lives in a fence.

**The heading is what makes the fence unambiguous.** Prompts teach structure, so one may legitimately contain a yaml example — the archivist's does — and only the fence under `## Spec` is read. `TestYAMLExampleInAProseSectionIsNotTheSpec` covers exactly that.

## Other decisions

**Declaring a prompt twice is refused**, not resolved by precedence. A silent rule means an author edits the prompt they can read while the loop keeps running the one they cannot.

**`KnownFields` is on.** A misspelled key is refused rather than ignored — otherwise the loop boots, the setting its author wrote does nothing, and the only evidence is behaviour that never changes.

**Errors name their file.** One bad definition among several otherwise leaves an operator bisecting a directory.

**`exclude_tools` understands `group:direct_human_egress`.** That set is decided in Go — a tool is human-egress by what it *does*, not by an author remembering to list it — so a written-out list goes stale the first time one is added. The prefix is `group:` rather than a sigil because YAML reserves `@` and backtick as indicators: an unquoted `@direct_human_egress` is a parse error, and a marker that only works when you remember to quote it is a trap. `TestExcludeTokenNeedsNoQuoting` exists solely to hold that line.

## The migration turned out small

Worth recording, since the assumption going in was difficult integration with ancient implementations:

- Both `HydrateSpec` functions are **no-ops except defaulting the name**. Their own comments say the loops are already fully declarative.
- `core_service_loops.go` already abstracts all three identically; `EgoConfig` and `ArchivistConfig` are both `= ServiceLoopConfig`.
- `Spec` already carries 38 yaml tags, and `buildLoopDefinitionBaseSpecs` already implements first-wins with operator override.

So this is not a new loader. It is a directory feeding the list that already existed, read first so the existing rule makes it authoritative.

## Test plan

- [x] `just ci` green
- [x] Dropping core definitions from the base list fails `TestCoreDefinitionWinsOverTheBuiltIn` (mutation: falls back to the built-in prompt)
- [x] Relaxing the `## ` heading rule fails both the prose and the yaml-example tests (mutation)
- [x] A yaml example inside a prompt is not read as the spec, and survives into the prompt
- [x] Prose sections become Task and `SupervisorProfile.Instructions`; deeper headings inside them are left alone
- [x] A spec key in frontmatter is ignored — frontmatter is document metadata here
- [x] A missing or unfenced `## Spec` section is refused, by name
- [x] A prompt declared in both places is refused
- [x] Misspelled key refused; invalid spec names its file; two documents defining one loop refused
- [x] Egress token expands, drops duplicates, parses **unquoted**
- [x] A loop with no core document still gets its built-in
- [x] Duration strings (`15m`) survive the decode

## Not yet moved

Nothing. ego, metacognitive, and archivist still come from Go, and there are **six** prompt constants between them rather than three — each has a base template *and* supervisor instructions, 345 lines total.

Their config blocks are also still parsed even when a document overrides them, because `Hydrate` runs against a cached config. Removing that coupling is what lets `ego:` / `metacognitive:` / `archivist:` leave `config.yaml`, and it is PR 2.

## Next

2. Move the three into `core/loops/*.md`, with a test that deep-compares the loaded spec against the Go `DefinitionSpec` before deleting it — so "did the port change anything" is answered mechanically. Then the registrations and config blocks go.
3. Declare facets on all three, and update the prompts, which currently teach `replace_output_*`.

Refs #1086
