### PR TITLE
A loop can see the cadence it is being asked to choose

### DIFF
--- a/internal/model/promptfmt/timefmt.go
+++ b/internal/model/promptfmt/timefmt.go
@@ -65,6 +65,47 @@ func formatDeltaMagnitude(secs int64) string {
 	}
 }
 
+// FormatDuration renders a duration as a compact Go duration literal:
+// "30s", "15m", "1h", "1h30m", "24h". Zero-valued terms are dropped, so
+// nothing reads "1h0m0s" the way [time.Duration.String] would.
+//
+// Unlike [FormatDeltaOnly] this is for configured intervals rather than
+// offsets from now, so it carries no sign and never reaches for a day
+// term: every value it emits parses back through [time.ParseDuration],
+// which is what tool parameters that take a duration accept. A duration
+// the model reads here can be passed straight back verbatim.
+//
+// A magnitude below one second falls through to [time.Duration.String],
+// which already renders those compactly ("400ms") and stays parseable.
+// Rounding them to "0s" instead would report a real interval as no
+// interval at all — and the values this formats are bounds a caller is
+// meant to choose within, so a zero there is worse than untidy.
+func FormatDuration(d time.Duration) string {
+	if d != 0 && d > -time.Second && d < time.Second {
+		return d.String()
+	}
+	d = d.Truncate(time.Second)
+	var b strings.Builder
+	if d < 0 {
+		b.WriteByte('-')
+		d = -d
+	}
+	h, m, s := d/time.Hour, (d%time.Hour)/time.Minute, (d%time.Minute)/time.Second
+	if h > 0 {
+		fmt.Fprintf(&b, "%dh", h)
+	}
+	if m > 0 {
+		fmt.Fprintf(&b, "%dm", m)
+	}
+	// The seconds term is unconditional only when nothing else was
+	// written, so a whole-minute duration stays "15m" while a zero one
+	// still renders a parseable "0s" instead of the empty string.
+	if s > 0 || (h == 0 && m == 0) {
+		fmt.Fprintf(&b, "%ds", s)
+	}
+	return b.String()
+}
+
 // deltaUnits maps the single-character suffix of a signed-offset term
 // to its duration. All five units are accepted on input; output uses
 // s, m, h, and d (see [formatDeltaMagnitude]).

--- a/internal/model/promptfmt/timefmt_test.go
+++ b/internal/model/promptfmt/timefmt_test.go
@@ -269,3 +269,55 @@ func TestParseTimeOrDelta(t *testing.T) {
 		})
 	}
 }
+
+func TestFormatDuration(t *testing.T) {
+	tests := []struct {
+		name string
+		in   time.Duration
+		want string
+	}{
+		{"seconds", 30 * time.Second, "30s"},
+		{"whole minutes drop the seconds term", 15 * time.Minute, "15m"},
+		{"whole hours drop both lower terms", time.Hour, "1h"},
+		{"mixed hours and minutes", 90 * time.Minute, "1h30m"},
+		{"mixed minutes and seconds", 90 * time.Second, "1m30s"},
+		{"a day stays in hours so it parses back", 24 * time.Hour, "24h"},
+		{"all three terms", time.Hour + 2*time.Minute + 3*time.Second, "1h2m3s"},
+		{"sub-second keeps its own unit", 400 * time.Millisecond, "400ms"},
+		{"sub-second negative", -400 * time.Millisecond, "-400ms"},
+		{"a mixed magnitude still truncates sub-second noise", time.Minute + 400*time.Millisecond, "1m"},
+		{"zero renders parseably", 0, "0s"},
+		{"negative keeps its sign", -90 * time.Minute, "-1h30m"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := FormatDuration(tt.in); got != tt.want {
+				t.Errorf("FormatDuration(%v) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestFormatDurationRoundTripsThroughParseDuration is the property that
+// makes this safe to put in a tool schema: whatever a model reads as its
+// permitted range, it can pass straight back as an argument. A day term
+// ("1d", which formatDeltaMagnitude would reach for) would break this —
+// time.ParseDuration does not accept one.
+func TestFormatDurationRoundTripsThroughParseDuration(t *testing.T) {
+	for _, d := range []time.Duration{
+		30 * time.Second, 15 * time.Minute, time.Hour, 90 * time.Minute,
+		12 * time.Hour, 24 * time.Hour, 7 * 24 * time.Hour,
+		time.Millisecond, 400 * time.Millisecond,
+		time.Hour + 2*time.Minute + 3*time.Second,
+	} {
+		s := FormatDuration(d)
+		back, err := time.ParseDuration(s)
+		if err != nil {
+			t.Errorf("FormatDuration(%v) = %q, which time.ParseDuration rejects: %v", d, s, err)
+			continue
+		}
+		if back != d {
+			t.Errorf("round trip of %v via %q came back as %v", d, s, back)
+		}
+	}
+}

--- a/internal/model/prompts/archivist.go
+++ b/internal/model/prompts/archivist.go
@@ -79,9 +79,11 @@ and notes — NOT the work queue (the durable queue holds that).
 6. **Update archivist.md** — Call the declared replacement tool
    (replace_output_archivist_state) with the complete updated body:
    dossier pointers and notes for your next-iteration self.
-7. **Set your sleep** — Call ` + "`set_next_sleep`" + `. Around 1h is the default
-   rhythm; shorter if the queue is deep and worth following, longer if
-   it is empty and the corpus feels quiet.
+7. **Set your sleep** — Close the turn with ` + "`set_next_sleep`" + `. The "This
+   loop" block carries your permitted range and your recent rhythm; read
+   it rather than guessing at numbers. Go shorter than your default if
+   the queue is deep and worth following, longer if it is empty and the
+   corpus feels quiet.
 
 ## What a dossier should look like
 

--- a/internal/model/prompts/ego.go
+++ b/internal/model/prompts/ego.go
@@ -31,12 +31,12 @@ the generated replacement tool for the document.
    replace_output_ego_state with the complete updated body. If nothing
    warrants a change, leave it alone and sleep. Do not rewrite for the
    sake of activity.
-4. **Set your sleep** — Call set_next_sleep with your chosen duration
-   and reasoning. Sleep toward the long end of your range by default:
-   reflection needs time to have something new to reflect on. Reach for
-   the short end only when something feels actively unresolved and you
-   want to revisit it soon. The tool states your permitted range and
-   clamps to it.
+4. **Set your sleep** — Close the turn with set_next_sleep and your
+   reasoning. The "This loop" block carries your permitted range and
+   your recent rhythm; read it rather than guessing at numbers. Sleep
+   toward the long end by default — reflection needs time to have
+   something new to reflect on. Reach for the short end only when
+   something feels actively unresolved and you want to revisit it soon.
 
 ## What ego.md Is For
 

--- a/internal/model/prompts/metacognitive.go
+++ b/internal/model/prompts/metacognitive.go
@@ -25,12 +25,13 @@ names the generated replacement tool for the document.
    with your complete updated state (observations, active concerns, recent
    actions, sleep reasoning). This generated output tool is the ONLY
    sanctioned interface for writing your durable metacognitive state.
-4. **Set your sleep** — Call set_next_sleep with your chosen duration and
-   reasoning. Sleep toward the short end of your range when something is
-   actively in motion and you expect the picture to have changed; toward
-   the long end when the system is quiet and another look would see the
-   same thing. The tool states your permitted range and clamps to it, so
-   reason about which end you want rather than about the numbers.
+4. **Set your sleep** — Close the turn with set_next_sleep and your
+   reasoning. The "This loop" block carries your permitted range, how
+   often you have actually been running lately, and how long you were
+   just out; read it rather than guessing at numbers. Sleep toward the
+   short end when something is actively in motion and you expect the
+   picture to have changed, toward the long end when the system is quiet
+   and another look would see the same thing.
 
 ## Guidelines
 

--- a/internal/runtime/agent/loop_self_context_test.go
+++ b/internal/runtime/agent/loop_self_context_test.go
@@ -25,8 +25,15 @@ func TestLoopSelfContextProvider_RendersCurrentLoop(t *testing.T) {
 	if err != nil {
 		t.Fatalf("TagContext: %v", err)
 	}
-	if !strings.Contains(out, "### This loop") || !strings.Contains(out, "ego · service") {
-		t.Errorf("expected the ego loop's self-context block, got %q", out)
+	// Heading for the section boundary, JSON for the state — the shape
+	// docs/model-facing-context.md prescribes. The loop package owns the
+	// payload's contents; this only checks the provider wired the right
+	// loop's block through.
+	if !strings.Contains(out, "### This loop") || !strings.Contains(out, "```json") {
+		t.Errorf("expected a self-context block with a JSON payload, got %q", out)
+	}
+	if !strings.Contains(out, `"name": "ego"`) || !strings.Contains(out, `"operation": "service"`) {
+		t.Errorf("expected the ego loop's state, got %q", out)
 	}
 
 	// No loop_id in context (e.g. a delegate or ad-hoc turn) → empty, not an error.

--- a/internal/runtime/loop/config.go
+++ b/internal/runtime/loop/config.go
@@ -596,6 +596,18 @@ type Status struct {
 	// raw time.Duration (nanoseconds) never leaks into the HTTP /v1/loops
 	// JSON; [LoopView] emits the seconds form.
 	CurrentSleep time.Duration `json:"-"`
+	// SleptFor is how long the most recent completed sleep actually
+	// lasted; SleptPlanned is what it was scheduled for. They diverge
+	// when a notification cut the sleep short. Zero before the first
+	// sleep and on event-driven loops. Projection-only (`json:"-"`) —
+	// [LoopView] emits the model-facing duration strings.
+	SleptFor     time.Duration `json:"-"`
+	SleptPlanned time.Duration `json:"-"`
+	// WakesLast24h is how many iterations this loop has begun in the
+	// trailing 24 hours, including the one in flight. It is the achieved
+	// cadence, which a lifetime iteration count cannot stand in for on a
+	// loop that keeps changing its own interval.
+	WakesLast24h int `json:"wakes_last_24h,omitempty"`
 	// Iterations is the total number of completed (successful) iterations.
 	Iterations int `json:"iterations"`
 	// Attempts is the total number of iteration attempts (including failures).
@@ -646,6 +658,11 @@ type Status struct {
 	// ago" without scanning event logs. Drives self-pacing
 	// decisions.
 	LastSupervisorTrigger SupervisorTrigger `json:"last_supervisor_trigger,omitempty"`
+	// LastSupervisorAt is when that supervisor turn ran; zero when none
+	// has. Iterations-ago answers "how many turns back" but not "how long
+	// ago", and on a self-pacing loop those are different questions.
+	// Projection-only (`json:"-"`) — [LoopView] emits the delta string.
+	LastSupervisorAt time.Time `json:"-"`
 	// LLMContext holds enrichment data from the most recent
 	// loop_llm_start event (model, est_tokens, messages, tools,
 	// complexity, intent, reasoning). Only populated while the loop

--- a/internal/runtime/loop/loop.go
+++ b/internal/runtime/loop/loop.go
@@ -227,6 +227,29 @@ type Loop struct {
 	sleepUntil   time.Time
 	currentSleep time.Duration
 
+	// lastSleptFor is how long the most recent sleep actually lasted and
+	// lastSleptPlanned is what it was scheduled for. They differ when a
+	// notification cut the sleep short, which is exactly the case a loop
+	// reading its own rhythm must not mistake for its chosen cadence
+	// being ignored. Set in [Loop.sleep] on wake; both zero before the
+	// first sleep and for event-driven loops.
+	lastSleptFor     time.Duration
+	lastSleptPlanned time.Duration
+
+	// wakeTimes is the trailing-24h record of iteration start instants,
+	// oldest first. It answers "how often have I actually been running"
+	// — a number a self-pacing loop needs and cannot derive from a
+	// lifetime iteration count, because the interval it chose has been
+	// changing the whole time. Pruned on append; see maxWakeHistory for
+	// what a sub-minute poller does to it.
+	wakeTimes []time.Time
+
+	// lastSupervisorAt is when the most recent successful supervisor turn
+	// ran, the wall-clock companion to lastSupervisorIter. Iterations-ago
+	// is meaningless as a recency measure on a loop whose interval keeps
+	// changing; this is the half that stays comparable.
+	lastSupervisorAt time.Time
+
 	// currentConvID is the conversation ID of the in-flight iteration.
 	// Set at the start of each iteration, cleared after. Tool handlers
 	// read it via [Loop.CurrentConvID].
@@ -722,6 +745,9 @@ func (l *Loop) Status() Status {
 		LastWakeAt:            l.lastWakeAt,
 		SleepUntil:            l.sleepUntil,
 		CurrentSleep:          l.currentSleep,
+		SleptFor:              l.lastSleptFor,
+		SleptPlanned:          l.lastSleptPlanned,
+		WakesLast24h:          l.wakesInWindowLocked(time.Now()),
 		Iterations:            l.iterations,
 		Attempts:              l.attempts,
 		TotalInputTokens:      l.totalInputTokens,
@@ -736,6 +762,7 @@ func (l *Loop) Status() Status {
 		LLMContext:            llmCtxCopy,
 		LastSupervisorIter:    l.lastSupervisorIter,
 		LastSupervisorTrigger: l.lastSupervisorTrigger,
+		LastSupervisorAt:      l.lastSupervisorAt,
 		HandlerOnly:           l.config.Handler != nil,
 		EventDriven:           l.isEventDriven(),
 		PendingRetune:         l.pendingRetune != nil,
@@ -1474,6 +1501,12 @@ func (l *Loop) run(ctx context.Context) {
 		}
 
 		iterStartTime := time.Now()
+		// Recorded before dispatch, unlike lastWakeAt below, so the turn
+		// being built can count itself. A no-op iteration still consumed a
+		// wake, so this does not share lastWakeAt's no-op skip.
+		l.mu.Lock()
+		l.recordWakeLocked(iterStartTime)
+		l.mu.Unlock()
 
 		// Dispatch: Handler runs directly; otherwise build an agent
 		// turn and let the loop runtime execute it.
@@ -1768,6 +1801,7 @@ func (l *Loop) run(ctx context.Context) {
 				if isSupervisor {
 					l.lastSupervisorIter = l.iterations
 					l.lastSupervisorTrigger = supervisorTrigger
+					l.lastSupervisorAt = time.Now()
 				}
 				snap.Number = l.iterations
 				l.mu.Unlock()
@@ -2213,6 +2247,13 @@ func (l *Loop) prepareAgentTurnRequest(req Request, convID string, isSupervisor 
 	req.OnProgress = composeProgressFuncs(l.makeProgressFunc(), req.OnProgress, l.requestOverride.OnProgress)
 	req.InitialTags = mergeUniqueStrings(configuredInitialTags, l.activatedTags)
 	req.RuntimeTools = mergeRuntimeTools(l.config.RuntimeTools, req.RuntimeTools)
+	// Built here rather than at hydration so the advertised bounds are
+	// this iteration's: a promoted retune moves the envelope under a
+	// running loop, and a description frozen at launch would go on naming
+	// the range the loop is no longer clamped by.
+	if sleepTool, ok := l.sleepControlRuntimeTool(); ok {
+		req.RuntimeTools = append(req.RuntimeTools, sleepTool)
+	}
 	req.FallbackContent = firstNonEmpty(l.requestOverride.FallbackContent, req.FallbackContent, l.requestBase.FallbackContent, l.config.FallbackContent)
 	req.MaxIterations = firstPositiveInt(l.requestOverride.MaxIterations, req.MaxIterations)
 	req.MaxOutputTokens = firstPositiveInt(l.requestOverride.MaxOutputTokens, req.MaxOutputTokens)

--- a/internal/runtime/loop/loop_self_context.go
+++ b/internal/runtime/loop/loop_self_context.go
@@ -11,6 +11,16 @@ import (
 // health, and what capability tags it inherited — so the loop is self-aware
 // without a loop_status tool call. Absent fields are omitted so the block stays
 // tight; a zero view renders "".
+//
+// For a self-pacing loop the block also closes the turn (#1313). Its
+// lived rhythm and the move that ends the iteration belong to the same
+// decision, so they are written in the same place: the loop reads how
+// often it has actually been running, how long it was just out, and how
+// long since it was last reviewed, and then reads what to call and what
+// range that call may name. Splitting those apart is what left the
+// envelope in prose prompts that went stale against the config — the
+// cadence has one home here, and the prompts reason about which end of
+// it they want.
 func (v LoopView) SelfContextMarkdown() string {
 	if v.Name == "" {
 		return ""
@@ -52,13 +62,54 @@ func (v LoopView) SelfContextMarkdown() string {
 	if cadence := selfCadenceLine(v); cadence != "" {
 		b.WriteString(cadence + "\n")
 	}
+	if review := selfReviewLine(v); review != "" {
+		b.WriteString(review + "\n")
+	}
+	if env := v.SleepEnvelope; env != nil {
+		b.WriteString("sleep envelope: " + selfEnvelopeLine(env) + "\n")
+	}
 
 	// Inherited capability tags with provenance.
 	if len(v.EffectiveTags) > 0 {
 		b.WriteString("effective tags: " + renderSelfEffectiveTags(v.EffectiveTags) + "\n")
 	}
 
+	// The exit, last because it is what to do after everything above has
+	// been read.
+	if closing := selfClosingLine(v); closing != "" {
+		b.WriteString("\n" + closing + "\n")
+	}
+
 	return b.String()
+}
+
+// selfEnvelopeLine renders the permitted range, the fallback, and the
+// randomization as one line.
+func selfEnvelopeLine(env *SleepEnvelope) string {
+	line := env.Min + "–" + env.Max + " · default " + env.Default
+	if env.Jitter > 0 {
+		line += fmt.Sprintf(" · ±%d%% jitter", int(env.Jitter*100))
+	}
+	return line
+}
+
+// selfClosingLine tells a self-pacing loop how to end the turn, in the
+// terms the lines above just established. Rendered only for a loop that
+// actually paces itself — an event-driven or one-shot loop has no sleep
+// to choose and would read this as an instruction it cannot follow.
+//
+// It states the clamp as a clamp. A loop told only "your range is X–Y"
+// still has to guess whether naming something outside it fails, is
+// ignored, or is quietly moved; being moved without being told is the
+// specific failure #1313 was filed about.
+func selfClosingLine(v LoopView) string {
+	env := v.SleepEnvelope
+	if env == nil {
+		return ""
+	}
+	return "To close this turn call set_next_sleep with a duration in " + env.Min + "–" + env.Max +
+		". A duration outside that range is moved to the nearest bound rather than refused, and skipping the call entirely leaves you sleeping " + env.Default +
+		". Reason about which end of the range this moment calls for; the numbers are here so you do not have to guess them."
 }
 
 // shortLoopID trims a UUID-style loop id to its first segment for legibility.
@@ -89,10 +140,21 @@ func ancestryChain(parentName *string, ancestry []string) string {
 	return ""
 }
 
+// selfCadenceLine renders the rhythm the loop has actually been keeping:
+// where it is in its life, how often it has run lately, and how long it
+// was just out. A lifetime iteration count alone cannot answer "am I
+// running too often" on a loop whose interval it chose differently every
+// time; the trailing-day count can.
 func selfCadenceLine(v LoopView) string {
 	var parts []string
 	if v.Iterations != nil {
 		parts = append(parts, fmt.Sprintf("iteration %d", *v.Iterations))
+	}
+	if v.WakesLast24h != nil {
+		parts = append(parts, fmt.Sprintf("%s in the last 24h", pluralTurns(*v.WakesLast24h)))
+	}
+	if slept := selfSleptPhrase(v); slept != "" {
+		parts = append(parts, slept)
 	}
 	if v.NextWakeDelta != nil {
 		parts = append(parts, "next wake "+*v.NextWakeDelta)
@@ -101,6 +163,53 @@ func selfCadenceLine(v LoopView) string {
 		parts = append(parts, fmt.Sprintf("consecutive_errors %d", *v.ConsecutiveErrors))
 	}
 	return strings.Join(parts, " · ")
+}
+
+// selfSleptPhrase describes the sleep that just ended. When a
+// notification cut it short both durations are named, because "I asked
+// for 30m and ran after 4m" means something woke the loop — not that its
+// choice was overridden, which is the reading it would otherwise reach
+// for.
+func selfSleptPhrase(v LoopView) string {
+	if v.LastSleep == nil {
+		return ""
+	}
+	if v.LastSleepPlanned != nil && *v.LastSleepPlanned != *v.LastSleep {
+		return "woken after " + *v.LastSleep + " of a planned " + *v.LastSleepPlanned
+	}
+	return "asleep " + *v.LastSleep + " before this turn"
+}
+
+// selfReviewLine reports the most recent supervisor pass in both units
+// that matter: how long ago it was, and how many turns back. A loop
+// choosing its cadence uses the first; a loop judging whether its own
+// recent work has been reviewed uses the second.
+func selfReviewLine(v LoopView) string {
+	if v.LastSupervisorDelta == nil && v.SupervisorItersAgo == nil {
+		return ""
+	}
+	line := "last supervisor review"
+	if v.LastSupervisorDelta != nil {
+		line += " " + *v.LastSupervisorDelta
+	}
+	var detail []string
+	if v.LastSupervisorTrigger != nil && *v.LastSupervisorTrigger != "" {
+		detail = append(detail, *v.LastSupervisorTrigger)
+	}
+	if v.SupervisorItersAgo != nil {
+		detail = append(detail, fmt.Sprintf("%s back", pluralTurns(*v.SupervisorItersAgo)))
+	}
+	if len(detail) > 0 {
+		line += " (" + strings.Join(detail, ", ") + ")"
+	}
+	return line
+}
+
+func pluralTurns(n int) string {
+	if n == 1 {
+		return "1 turn"
+	}
+	return fmt.Sprintf("%d turns", n)
 }
 
 func renderSelfEffectiveTags(tags []EffectiveTag) string {

--- a/internal/runtime/loop/loop_self_context.go
+++ b/internal/runtime/loop/loop_self_context.go
@@ -1,9 +1,54 @@
 package loop
 
 import (
-	"fmt"
+	"encoding/json"
 	"strings"
 )
+
+// loopSelfContext is the state half of the self-context block: the
+// deliberately tight subset of [LoopView] a running loop acts on, as
+// against the full canonical row an operator reads.
+//
+// Its keys are LoopView's keys wherever the two overlap, so a loop that
+// reads its own state here and calls loop_status a moment later is
+// reading one vocabulary rather than translating between two. Absent
+// facts are omitted rather than emitted as null: this payload ships every
+// iteration, and a running loop's own state has no "not applicable" half
+// the way a stored-definition row does.
+type loopSelfContext struct {
+	Name      string `json:"name"`
+	ID        string `json:"id,omitempty"`
+	Operation string `json:"operation"`
+	State     string `json:"state,omitempty"`
+	Eligible  bool   `json:"eligible"`
+
+	// Ancestry is ordered leaf-adjacent first ("watchers", "core") —
+	// nearest container first, because that is the one whose policy and
+	// tags bear on this loop most directly.
+	Ancestry   []string `json:"ancestry,omitempty"`
+	ChildCount int      `json:"child_count,omitempty"`
+	Intent     string   `json:"intent,omitempty"`
+
+	Iterations        *int    `json:"iterations,omitempty"`
+	WakesLast24h      *int    `json:"wakes_last_24h,omitempty"`
+	LastSleep         *string `json:"last_sleep,omitempty"`
+	LastSleepPlanned  *string `json:"last_sleep_planned,omitempty"`
+	NextWakeDelta     *string `json:"next_wake_delta,omitempty"`
+	ConsecutiveErrors *int    `json:"consecutive_errors,omitempty"`
+
+	// WokenEarly is the comparison of the two sleep durations, made here
+	// rather than left to the reader. It means a notification arrived —
+	// not that the loop's chosen cadence was overridden, which is the
+	// reading it would otherwise reach for.
+	WokenEarly bool `json:"woken_early,omitempty"`
+
+	LastSupervisorDelta   *string `json:"last_supervisor_delta,omitempty"`
+	SupervisorItersAgo    *int    `json:"supervisor_iters_ago,omitempty"`
+	LastSupervisorTrigger *string `json:"last_supervisor_trigger,omitempty"`
+
+	SleepEnvelope *SleepEnvelope `json:"sleep_envelope,omitempty"`
+	EffectiveTags []EffectiveTag `json:"effective_tags,omitempty"`
+}
 
 // SelfContextMarkdown renders this loop's canonical view as the compact,
 // always-on "self-context" block a running loop sees each iteration (#1106 B3):
@@ -11,6 +56,15 @@ import (
 // health, and what capability tags it inherited — so the loop is self-aware
 // without a loop_status tool call. Absent fields are omitted so the block stays
 // tight; a zero view renders "".
+//
+// The shape follows docs/model-facing-context.md: a markdown heading and
+// framing note for the section boundary, a JSON payload for the live
+// operational state, and prose for the one normative instruction. The
+// state is emitted as typed JSON rather than the key-value prose this
+// block first shipped with, so the loop reads its envelope in exactly the
+// object loop_status and set_next_sleep return — one fact, one shape,
+// three surfaces — instead of parsing "15m–1h" back apart on a separator
+// that appears in neither bound.
 //
 // For a self-pacing loop the block also closes the turn (#1313). Its
 // lived rhythm and the move that ends the iteration belong to the same
@@ -25,78 +79,66 @@ func (v LoopView) SelfContextMarkdown() string {
 	if v.Name == "" {
 		return ""
 	}
+
+	data, err := json.MarshalIndent(v.selfContext(), "", "  ")
+	if err != nil {
+		// Unreachable for this payload (no channels, funcs, or NaN), but
+		// a loop that lost its self-context should not also lose the
+		// instruction that ends its turn.
+		data = []byte("{}")
+	}
+
 	var b strings.Builder
-	b.WriteString("### This loop\n")
-
-	// Identity: name (short id) · operation · state · eligibility.
-	line := v.Name
-	if v.ID != nil && *v.ID != "" {
-		line += " (" + shortLoopID(*v.ID) + ")"
-	}
-	line += " · " + v.Operation
-	if v.State != nil && *v.State != "" {
-		line += " · " + *v.State
-	}
-	if v.Eligible {
-		line += " · eligible"
-	} else {
-		line += " · ineligible"
-	}
-	b.WriteString(line + "\n")
-
-	// Structure: graph position (leaf-adjacent first) + child count if any.
-	if chain := ancestryChain(v.ParentName, v.Ancestry); chain != "" {
-		b.WriteString("parent: " + chain)
-		if v.ChildCount > 0 {
-			b.WriteString(fmt.Sprintf("  (%d children)", v.ChildCount))
-		}
-		b.WriteString("\n")
-	}
-
-	// Purpose.
-	if v.Intent != "" {
-		b.WriteString("intent: " + v.Intent + "\n")
-	}
-
-	// Live cadence & health — only the facts a self-pacing loop acts on.
-	if cadence := selfCadenceLine(v); cadence != "" {
-		b.WriteString(cadence + "\n")
-	}
-	if review := selfReviewLine(v); review != "" {
-		b.WriteString(review + "\n")
-	}
-	if env := v.SleepEnvelope; env != nil {
-		b.WriteString("sleep envelope: " + selfEnvelopeLine(env) + "\n")
-	}
-
-	// Inherited capability tags with provenance.
-	if len(v.EffectiveTags) > 0 {
-		b.WriteString("effective tags: " + renderSelfEffectiveTags(v.EffectiveTags) + "\n")
-	}
-
-	// The exit, last because it is what to do after everything above has
-	// been read.
+	b.WriteString("### This loop\n\n")
+	b.WriteString("Your own runtime state for this iteration.\n\n")
+	b.WriteString("```json\n")
+	b.Write(data)
+	b.WriteString("\n```\n")
 	if closing := selfClosingLine(v); closing != "" {
 		b.WriteString("\n" + closing + "\n")
 	}
-
 	return b.String()
 }
 
-// selfEnvelopeLine renders the permitted range, the fallback, and the
-// randomization as one line.
-func selfEnvelopeLine(env *SleepEnvelope) string {
-	line := env.Min + "–" + env.Max + " · default " + env.Default
-	if env.Jitter > 0 {
-		line += fmt.Sprintf(" · ±%d%% jitter", int(env.Jitter*100))
+// selfContext projects the view down to what the loop acts on.
+func (v LoopView) selfContext() loopSelfContext {
+	sc := loopSelfContext{
+		Name:                  v.Name,
+		Operation:             v.Operation,
+		Eligible:              v.Eligible,
+		Ancestry:              leafFirstAncestry(v.ParentName, v.Ancestry),
+		ChildCount:            v.ChildCount,
+		Intent:                v.Intent,
+		Iterations:            v.Iterations,
+		WakesLast24h:          v.WakesLast24h,
+		LastSleep:             v.LastSleep,
+		LastSleepPlanned:      v.LastSleepPlanned,
+		NextWakeDelta:         v.NextWakeDelta,
+		ConsecutiveErrors:     v.ConsecutiveErrors,
+		LastSupervisorDelta:   v.LastSupervisorDelta,
+		SupervisorItersAgo:    v.SupervisorItersAgo,
+		LastSupervisorTrigger: v.LastSupervisorTrigger,
+		SleepEnvelope:         v.SleepEnvelope,
+		EffectiveTags:         v.EffectiveTags,
 	}
-	return line
+	if v.ID != nil && *v.ID != "" {
+		sc.ID = shortLoopID(*v.ID)
+	}
+	if v.State != nil {
+		sc.State = *v.State
+	}
+	sc.WokenEarly = v.LastSleep != nil && v.LastSleepPlanned != nil && *v.LastSleep != *v.LastSleepPlanned
+	return sc
 }
 
 // selfClosingLine tells a self-pacing loop how to end the turn, in the
-// terms the lines above just established. Rendered only for a loop that
-// actually paces itself — an event-driven or one-shot loop has no sleep
-// to choose and would read this as an instruction it cannot follow.
+// terms the payload above just established. This is the one part of the
+// block that is an instruction rather than a fact, which is why it is
+// prose outside the JSON rather than another key inside it.
+//
+// Rendered only for a loop that actually paces itself — an event-driven
+// or one-shot loop has no sleep to choose and would read this as an
+// instruction it cannot follow.
 //
 // It states the clamp as a clamp. A loop told only "your range is X–Y"
 // still has to guess whether naming something outside it fails, is
@@ -107,9 +149,9 @@ func selfClosingLine(v LoopView) string {
 	if env == nil {
 		return ""
 	}
-	return "To close this turn call set_next_sleep with a duration in " + env.Min + "–" + env.Max +
+	return "To close this turn call set_next_sleep with a duration between " + env.Min + " and " + env.Max +
 		". A duration outside that range is moved to the nearest bound rather than refused, and skipping the call entirely leaves you sleeping " + env.Default +
-		". Reason about which end of the range this moment calls for; the numbers are here so you do not have to guess them."
+		". Reason about which end of the range this moment calls for; the numbers are in sleep_envelope above so you do not have to guess them."
 }
 
 // shortLoopID trims a UUID-style loop id to its first segment for legibility.
@@ -123,103 +165,19 @@ func shortLoopID(id string) string {
 	return id
 }
 
-// ancestryChain renders the loop's graph position leaf-adjacent first
-// ("watchers ← core"). Ancestry is ordered root→leaf, so it is reversed here;
+// leafFirstAncestry returns the loop's graph position nearest-container
+// first. LoopView.Ancestry is ordered root→leaf, so it is reversed here;
 // ParentName is the fallback when the ancestry list is empty.
-func ancestryChain(parentName *string, ancestry []string) string {
+func leafFirstAncestry(parentName *string, ancestry []string) []string {
 	if len(ancestry) > 0 {
 		rev := make([]string, len(ancestry))
 		for i, n := range ancestry {
 			rev[len(ancestry)-1-i] = n
 		}
-		return strings.Join(rev, " ← ")
+		return rev
 	}
 	if parentName != nil && *parentName != "" {
-		return *parentName
+		return []string{*parentName}
 	}
-	return ""
-}
-
-// selfCadenceLine renders the rhythm the loop has actually been keeping:
-// where it is in its life, how often it has run lately, and how long it
-// was just out. A lifetime iteration count alone cannot answer "am I
-// running too often" on a loop whose interval it chose differently every
-// time; the trailing-day count can.
-func selfCadenceLine(v LoopView) string {
-	var parts []string
-	if v.Iterations != nil {
-		parts = append(parts, fmt.Sprintf("iteration %d", *v.Iterations))
-	}
-	if v.WakesLast24h != nil {
-		parts = append(parts, fmt.Sprintf("%s in the last 24h", pluralTurns(*v.WakesLast24h)))
-	}
-	if slept := selfSleptPhrase(v); slept != "" {
-		parts = append(parts, slept)
-	}
-	if v.NextWakeDelta != nil {
-		parts = append(parts, "next wake "+*v.NextWakeDelta)
-	}
-	if v.ConsecutiveErrors != nil {
-		parts = append(parts, fmt.Sprintf("consecutive_errors %d", *v.ConsecutiveErrors))
-	}
-	return strings.Join(parts, " · ")
-}
-
-// selfSleptPhrase describes the sleep that just ended. When a
-// notification cut it short both durations are named, because "I asked
-// for 30m and ran after 4m" means something woke the loop — not that its
-// choice was overridden, which is the reading it would otherwise reach
-// for.
-func selfSleptPhrase(v LoopView) string {
-	if v.LastSleep == nil {
-		return ""
-	}
-	if v.LastSleepPlanned != nil && *v.LastSleepPlanned != *v.LastSleep {
-		return "woken after " + *v.LastSleep + " of a planned " + *v.LastSleepPlanned
-	}
-	return "asleep " + *v.LastSleep + " before this turn"
-}
-
-// selfReviewLine reports the most recent supervisor pass in both units
-// that matter: how long ago it was, and how many turns back. A loop
-// choosing its cadence uses the first; a loop judging whether its own
-// recent work has been reviewed uses the second.
-func selfReviewLine(v LoopView) string {
-	if v.LastSupervisorDelta == nil && v.SupervisorItersAgo == nil {
-		return ""
-	}
-	line := "last supervisor review"
-	if v.LastSupervisorDelta != nil {
-		line += " " + *v.LastSupervisorDelta
-	}
-	var detail []string
-	if v.LastSupervisorTrigger != nil && *v.LastSupervisorTrigger != "" {
-		detail = append(detail, *v.LastSupervisorTrigger)
-	}
-	if v.SupervisorItersAgo != nil {
-		detail = append(detail, fmt.Sprintf("%s back", pluralTurns(*v.SupervisorItersAgo)))
-	}
-	if len(detail) > 0 {
-		line += " (" + strings.Join(detail, ", ") + ")"
-	}
-	return line
-}
-
-func pluralTurns(n int) string {
-	if n == 1 {
-		return "1 turn"
-	}
-	return fmt.Sprintf("%d turns", n)
-}
-
-func renderSelfEffectiveTags(tags []EffectiveTag) string {
-	parts := make([]string, 0, len(tags))
-	for _, t := range tags {
-		if t.From == "" || t.From == EffectiveOriginSelf {
-			parts = append(parts, t.Tag+" (self)")
-		} else {
-			parts = append(parts, t.Tag+" (←"+t.From+")")
-		}
-	}
-	return strings.Join(parts, ", ")
+	return nil
 }

--- a/internal/runtime/loop/loop_self_context_test.go
+++ b/internal/runtime/loop/loop_self_context_test.go
@@ -56,3 +56,90 @@ func TestLoopView_SelfContextMarkdown_Empty(t *testing.T) {
 		t.Errorf("zero view should render empty, got %q", got)
 	}
 }
+
+// TestLoopView_SelfContextMarkdown_CadenceTrailhead is the #1313 shape:
+// the lived rhythm and the move that closes the turn read as one block,
+// because they are one decision. Before this the loop saw neither — its
+// envelope lived in prose prompts that went stale against the config.
+func TestLoopView_SelfContextMarkdown_CadenceTrailhead(t *testing.T) {
+	iters := 412
+	wakes := 47
+	slept := "28m"
+	planned := "30m"
+	supDelta := "-4h12m"
+	supAgo := 9
+	trigger := "random"
+	v := LoopView{
+		Name: "metacognitive", Operation: "service", Eligible: true,
+		Iterations:            &iters,
+		WakesLast24h:          &wakes,
+		LastSleep:             &slept,
+		LastSleepPlanned:      &planned,
+		LastSupervisorDelta:   &supDelta,
+		SupervisorItersAgo:    &supAgo,
+		LastSupervisorTrigger: &trigger,
+		SleepEnvelope:         &SleepEnvelope{Min: "15m", Max: "1h", Default: "30m", Jitter: 0.2},
+	}
+
+	got := v.SelfContextMarkdown()
+	for _, w := range []string{
+		"iteration 412",
+		"47 turns in the last 24h",
+		// The two durations differ, so the block says it was woken rather
+		// than letting "asleep 28m" read as a 28m cadence it never chose.
+		"woken after 28m of a planned 30m",
+		"last supervisor review -4h12m (random, 9 turns back)",
+		"sleep envelope: 15m–1h · default 30m · ±20% jitter",
+		"To close this turn call set_next_sleep with a duration in 15m–1h",
+		"moved to the nearest bound rather than refused",
+		"leaves you sleeping 30m",
+	} {
+		if !strings.Contains(got, w) {
+			t.Errorf("self-context missing %q\n--- got ---\n%s", w, got)
+		}
+	}
+}
+
+// TestLoopView_SelfContextMarkdown_UninterruptedSleepReadsPlainly keeps
+// the common case terse: naming both durations when they agree would
+// imply a distinction that isn't there.
+func TestLoopView_SelfContextMarkdown_UninterruptedSleepReadsPlainly(t *testing.T) {
+	slept := "30m"
+	planned := "30m"
+	v := LoopView{
+		Name: "metacognitive", Operation: "service", Eligible: true,
+		LastSleep: &slept, LastSleepPlanned: &planned,
+		SleepEnvelope: &SleepEnvelope{Min: "15m", Max: "1h", Default: "30m"},
+	}
+	got := v.SelfContextMarkdown()
+	if !strings.Contains(got, "asleep 30m before this turn") {
+		t.Errorf("expected the plain phrasing\n--- got ---\n%s", got)
+	}
+	if strings.Contains(got, "planned") {
+		t.Errorf("an uninterrupted sleep should not mention a planned duration\n--- got ---\n%s", got)
+	}
+}
+
+// TestLoopView_SelfContextMarkdown_NoClosingLineWithoutASleepToChoose
+// keeps the trailhead off loops that cannot follow it. An event-driven
+// loop told to "close this turn with set_next_sleep" would be reading an
+// instruction the tool will refuse.
+func TestLoopView_SelfContextMarkdown_NoClosingLineWithoutASleepToChoose(t *testing.T) {
+	v := LoopView{Name: "mqtt_watch", Operation: "service", EventDriven: true, Eligible: true}
+	got := v.SelfContextMarkdown()
+	if strings.Contains(got, "set_next_sleep") || strings.Contains(got, "sleep envelope") {
+		t.Errorf("event-driven loop should get no cadence trailhead\n--- got ---\n%s", got)
+	}
+}
+
+// TestLoopView_SelfContextMarkdown_JitterOmittedWhenOff avoids
+// advertising a ±0% spread as if it were a real one.
+func TestLoopView_SelfContextMarkdown_JitterOmittedWhenOff(t *testing.T) {
+	v := LoopView{
+		Name: "steady", Operation: "service", Eligible: true,
+		SleepEnvelope: &SleepEnvelope{Min: "15m", Max: "1h", Default: "30m"},
+	}
+	if got := v.SelfContextMarkdown(); strings.Contains(got, "jitter") {
+		t.Errorf("jitter should be omitted when disabled\n--- got ---\n%s", got)
+	}
+}

--- a/internal/runtime/loop/loop_self_context_test.go
+++ b/internal/runtime/loop/loop_self_context_test.go
@@ -1,9 +1,32 @@
 package loop
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 )
+
+// decodeSelfContext pulls the JSON payload back out of the rendered
+// block. Asserting on the decoded object rather than on substrings is the
+// point of the block being JSON: a test that matched prose would pass on
+// a payload the model could not parse.
+func decodeSelfContext(t *testing.T, block string) map[string]any {
+	t.Helper()
+	start := strings.Index(block, "```json\n")
+	if start < 0 {
+		t.Fatalf("block carries no json payload:\n%s", block)
+	}
+	body := block[start+len("```json\n"):]
+	end := strings.Index(body, "\n```")
+	if end < 0 {
+		t.Fatalf("json payload is unterminated:\n%s", block)
+	}
+	var out map[string]any
+	if err := json.Unmarshal([]byte(body[:end]), &out); err != nil {
+		t.Fatalf("payload is not valid JSON: %v\n%s", err, body[:end])
+	}
+	return out
+}
 
 func TestLoopView_SelfContextMarkdown_Full(t *testing.T) {
 	id := "019f16aa-f878-730d-9756-dc9d8ffedb0c"
@@ -23,31 +46,57 @@ func TestLoopView_SelfContextMarkdown_Full(t *testing.T) {
 	}
 
 	got := v.SelfContextMarkdown()
-	for _, w := range []string{
-		"### This loop",
-		"reservoir_watch (019f16aa) · service · sleeping · eligible",
-		"parent: watchers ← core", // ancestry root→leaf, rendered leaf-adjacent first
-		"intent: Keep a current read on the reservoir level",
-		"iteration 138 · next wake +5940s · consecutive_errors 0",
-		"effective tags: home (←travel), curate (self)",
-	} {
-		if !strings.Contains(got, w) {
-			t.Errorf("self-context missing %q\n--- got ---\n%s", w, got)
-		}
+	if !strings.HasPrefix(got, "### This loop\n") {
+		t.Errorf("block should open with its section heading:\n%s", got)
+	}
+
+	payload := decodeSelfContext(t, got)
+	if payload["name"] != "reservoir_watch" || payload["operation"] != "service" || payload["state"] != "sleeping" {
+		t.Errorf("identity = %#v", payload)
+	}
+	// Short id: the full UUID costs context every iteration and the first
+	// segment is enough to correlate against a log line.
+	if payload["id"] != "019f16aa" {
+		t.Errorf("id = %v, want the shortened 019f16aa", payload["id"])
+	}
+	if payload["eligible"] != true {
+		t.Errorf("eligible = %v, want true", payload["eligible"])
+	}
+	// Nearest container first — the one whose policy bears most directly
+	// on this loop.
+	if ancestry, _ := payload["ancestry"].([]any); len(ancestry) != 2 || ancestry[0] != "watchers" || ancestry[1] != "core" {
+		t.Errorf("ancestry = %v, want [watchers core]", payload["ancestry"])
+	}
+	if payload["intent"] != "Keep a current read on the reservoir level" {
+		t.Errorf("intent = %v", payload["intent"])
+	}
+	if payload["iterations"] != float64(138) || payload["next_wake_delta"] != "+5940s" {
+		t.Errorf("cadence = %#v", payload)
+	}
+	tags, _ := payload["effective_tags"].([]any)
+	if len(tags) != 2 {
+		t.Fatalf("effective_tags = %v, want 2 entries", payload["effective_tags"])
+	}
+	first, _ := tags[0].(map[string]any)
+	if first["tag"] != "home" || first["from"] != "travel" {
+		t.Errorf("first tag = %#v, want home from travel", first)
 	}
 }
 
+// TestLoopView_SelfContextMarkdown_OmitsAbsentFields keeps the payload
+// tight. It ships every iteration, and a running loop has no
+// "not applicable" half the way a stored-definition row does — so an
+// absent fact is absent, not null.
 func TestLoopView_SelfContextMarkdown_OmitsAbsentFields(t *testing.T) {
-	// No intent, no live cadence, no tags: the block must stay tight, never
-	// printing an empty label.
 	v := LoopView{Name: "bare", Operation: "service", Eligible: false}
-	got := v.SelfContextMarkdown()
-	if strings.Contains(got, "intent:") || strings.Contains(got, "effective tags:") ||
-		strings.Contains(got, "iteration") || strings.Contains(got, "parent:") {
-		t.Errorf("block should omit absent fields, got:\n%s", got)
+	payload := decodeSelfContext(t, v.SelfContextMarkdown())
+	for _, key := range []string{"intent", "effective_tags", "iterations", "ancestry", "sleep_envelope", "last_sleep", "id", "state"} {
+		if _, present := payload[key]; present {
+			t.Errorf("payload should omit absent %q, got %#v", key, payload)
+		}
 	}
-	if !strings.Contains(got, "bare · service · ineligible") {
-		t.Errorf("identity line wrong:\n%s", got)
+	if payload["name"] != "bare" || payload["eligible"] != false {
+		t.Errorf("identity = %#v", payload)
 	}
 }
 
@@ -64,7 +113,7 @@ func TestLoopView_SelfContextMarkdown_Empty(t *testing.T) {
 func TestLoopView_SelfContextMarkdown_CadenceTrailhead(t *testing.T) {
 	iters := 412
 	wakes := 47
-	slept := "28m"
+	slept := "4m"
 	planned := "30m"
 	supDelta := "-4h12m"
 	supAgo := 9
@@ -82,28 +131,48 @@ func TestLoopView_SelfContextMarkdown_CadenceTrailhead(t *testing.T) {
 	}
 
 	got := v.SelfContextMarkdown()
+	payload := decodeSelfContext(t, got)
+
+	if payload["wakes_last_24h"] != float64(47) || payload["iterations"] != float64(412) {
+		t.Errorf("rhythm = %#v", payload)
+	}
+	if payload["last_sleep"] != "4m" || payload["last_sleep_planned"] != "30m" {
+		t.Errorf("sleep durations = %#v", payload)
+	}
+	// The comparison is made in Go, not left to the reader.
+	if payload["woken_early"] != true {
+		t.Errorf("woken_early = %v, want true when the two durations disagree", payload["woken_early"])
+	}
+	if payload["last_supervisor_delta"] != "-4h12m" || payload["supervisor_iters_ago"] != float64(9) || payload["last_supervisor_trigger"] != "random" {
+		t.Errorf("supervisor recency = %#v", payload)
+	}
+
+	// The envelope arrives as the same object loop_status and
+	// set_next_sleep return, not as a range the model must split apart.
+	env, _ := payload["sleep_envelope"].(map[string]any)
+	if env == nil {
+		t.Fatalf("sleep_envelope missing: %#v", payload)
+	}
+	if env["min"] != "15m" || env["max"] != "1h" || env["default"] != "30m" || env["jitter"] != 0.2 {
+		t.Errorf("envelope = %#v", env)
+	}
+
+	// The one instruction stays prose, outside the payload.
 	for _, w := range []string{
-		"iteration 412",
-		"47 turns in the last 24h",
-		// The two durations differ, so the block says it was woken rather
-		// than letting "asleep 28m" read as a 28m cadence it never chose.
-		"woken after 28m of a planned 30m",
-		"last supervisor review -4h12m (random, 9 turns back)",
-		"sleep envelope: 15m–1h · default 30m · ±20% jitter",
-		"To close this turn call set_next_sleep with a duration in 15m–1h",
+		"To close this turn call set_next_sleep with a duration between 15m and 1h",
 		"moved to the nearest bound rather than refused",
 		"leaves you sleeping 30m",
 	} {
 		if !strings.Contains(got, w) {
-			t.Errorf("self-context missing %q\n--- got ---\n%s", w, got)
+			t.Errorf("closing line missing %q\n--- got ---\n%s", w, got)
 		}
 	}
 }
 
-// TestLoopView_SelfContextMarkdown_UninterruptedSleepReadsPlainly keeps
-// the common case terse: naming both durations when they agree would
-// imply a distinction that isn't there.
-func TestLoopView_SelfContextMarkdown_UninterruptedSleepReadsPlainly(t *testing.T) {
+// TestLoopView_SelfContextMarkdown_UninterruptedSleepIsNotFlaggedEarly
+// keeps the flag meaningful: it fires on a notification wake, not on
+// every wake.
+func TestLoopView_SelfContextMarkdown_UninterruptedSleepIsNotFlaggedEarly(t *testing.T) {
 	slept := "30m"
 	planned := "30m"
 	v := LoopView{
@@ -111,12 +180,9 @@ func TestLoopView_SelfContextMarkdown_UninterruptedSleepReadsPlainly(t *testing.
 		LastSleep: &slept, LastSleepPlanned: &planned,
 		SleepEnvelope: &SleepEnvelope{Min: "15m", Max: "1h", Default: "30m"},
 	}
-	got := v.SelfContextMarkdown()
-	if !strings.Contains(got, "asleep 30m before this turn") {
-		t.Errorf("expected the plain phrasing\n--- got ---\n%s", got)
-	}
-	if strings.Contains(got, "planned") {
-		t.Errorf("an uninterrupted sleep should not mention a planned duration\n--- got ---\n%s", got)
+	payload := decodeSelfContext(t, v.SelfContextMarkdown())
+	if _, present := payload["woken_early"]; present {
+		t.Errorf("woken_early should be omitted when the sleep ran its course: %#v", payload)
 	}
 }
 
@@ -127,19 +193,27 @@ func TestLoopView_SelfContextMarkdown_UninterruptedSleepReadsPlainly(t *testing.
 func TestLoopView_SelfContextMarkdown_NoClosingLineWithoutASleepToChoose(t *testing.T) {
 	v := LoopView{Name: "mqtt_watch", Operation: "service", EventDriven: true, Eligible: true}
 	got := v.SelfContextMarkdown()
-	if strings.Contains(got, "set_next_sleep") || strings.Contains(got, "sleep envelope") {
+	if strings.Contains(got, "set_next_sleep") {
 		t.Errorf("event-driven loop should get no cadence trailhead\n--- got ---\n%s", got)
+	}
+	if payload := decodeSelfContext(t, got); payload["sleep_envelope"] != nil {
+		t.Errorf("event-driven loop should carry no envelope: %#v", payload)
 	}
 }
 
 // TestLoopView_SelfContextMarkdown_JitterOmittedWhenOff avoids
-// advertising a ±0% spread as if it were a real one.
+// advertising a ±0 spread as if it were a real one.
 func TestLoopView_SelfContextMarkdown_JitterOmittedWhenOff(t *testing.T) {
 	v := LoopView{
 		Name: "steady", Operation: "service", Eligible: true,
 		SleepEnvelope: &SleepEnvelope{Min: "15m", Max: "1h", Default: "30m"},
 	}
-	if got := v.SelfContextMarkdown(); strings.Contains(got, "jitter") {
-		t.Errorf("jitter should be omitted when disabled\n--- got ---\n%s", got)
+	payload := decodeSelfContext(t, v.SelfContextMarkdown())
+	env, _ := payload["sleep_envelope"].(map[string]any)
+	if env == nil {
+		t.Fatalf("sleep_envelope missing: %#v", payload)
+	}
+	if _, present := env["jitter"]; present {
+		t.Errorf("jitter should be omitted when disabled: %#v", env)
 	}
 }

--- a/internal/runtime/loop/loop_view.go
+++ b/internal/runtime/loop/loop_view.go
@@ -2,6 +2,8 @@ package loop
 
 import (
 	"fmt"
+	"math"
+	"strconv"
 	"strings"
 	"time"
 
@@ -115,9 +117,12 @@ type LoopView struct {
 }
 
 // SleepEnvelope is the range a self-pacing loop chooses its next sleep
-// within: the bounds [Loop.SetNextSleep] clamps to, the interval the
-// runtime falls back to when the loop asks for nothing, and the
-// randomization applied on top of whatever it does choose.
+// within: the bounds a requested sleep is clamped to by
+// [Loop.HandleSetNextSleep], the interval the runtime falls back to when
+// the loop asks for nothing, and the randomization applied on top of
+// whatever it does choose. The bounds hold however a duration arrives —
+// the run loop re-clamps before every sleep — so they describe the loop,
+// not just the tool call.
 //
 // A loop that cannot see this is choosing a cadence blind and learns its
 // bounds only by being corrected — the gap #1313 closes. It rides the
@@ -143,6 +148,19 @@ type SleepEnvelope struct {
 	// 24m–36m. It is why an observed wake rarely lands exactly on what
 	// was asked for. Omitted when jitter is off.
 	Jitter float64 `json:"jitter,omitempty"`
+}
+
+// JitterPercent renders [SleepEnvelope.Jitter] as a percentage, for the
+// prose surfaces that have to name it rather than emit the raw fraction.
+// It rounds to a tenth of a percent and drops a trailing zero, so an
+// ordinary 0.2 reads "20" and a deliberate 0.125 reads "12.5".
+//
+// The rounding is load-bearing, not cosmetic. Jitter is an operator-set
+// float, and int(j*100) truncates: 0.29 is held as slightly less than
+// 0.29, so it would advertise 28% and understate a bound the model is
+// reasoning against.
+func (e SleepEnvelope) JitterPercent() string {
+	return strconv.FormatFloat(math.Round(e.Jitter*1000)/10, 'f', -1, 64)
 }
 
 // newSleepEnvelope builds the envelope for a loop with a periodic timer,

--- a/internal/runtime/loop/loop_view.go
+++ b/internal/runtime/loop/loop_view.go
@@ -63,6 +63,23 @@ type LoopView struct {
 	NextWakeDelta        *string `json:"next_wake_delta"`
 	CurrentSleepDuration *string `json:"current_sleep_duration"`
 	PolicyUpdatedDelta   *string `json:"policy_updated_delta"`
+	// SleepEnvelope is the cadence this loop is allowed to choose within.
+	// It is configuration rather than telemetry, so it is present on a
+	// stored definition as well as a live loop; null on anything with no
+	// periodic timer.
+	SleepEnvelope *SleepEnvelope `json:"sleep_envelope"`
+	// LastSleep is how long the most recent sleep actually lasted and
+	// LastSleepPlanned is what it was scheduled for, both as Go duration
+	// literals. Equal on an ordinary wake; LastSleep is the shorter of
+	// the two when a notification cut the sleep short, which is how a
+	// loop tells "something wanted me" from "my cadence was overridden".
+	// Null before the first sleep and on event-driven loops.
+	LastSleep        *string `json:"last_sleep"`
+	LastSleepPlanned *string `json:"last_sleep_planned"`
+	// WakesLast24h is how many iterations began in the trailing day,
+	// counting the one in flight — the cadence actually achieved, as
+	// against the SleepEnvelope's permitted one.
+	WakesLast24h *int `json:"wakes_last_24h"`
 
 	// ---- economics (%CPU / %MEM / TIME) ----
 	Iterations        *int `json:"iterations"`
@@ -83,6 +100,10 @@ type LoopView struct {
 	LastSupervisorIter    *int     `json:"last_supervisor_iter"`
 	LastSupervisorTrigger *string  `json:"last_supervisor_trigger"`
 	SupervisorItersAgo    *int     `json:"supervisor_iters_ago"`
+	// LastSupervisorDelta is how long ago that review ran. Iterations-ago
+	// counts turns, which is not the same span twice on a loop that
+	// re-chooses its interval every time.
+	LastSupervisorDelta *string `json:"last_supervisor_delta"`
 
 	// ---- inheritance + provenance (live-only; [] when running-and-empty,
 	// null when not running) ----
@@ -91,6 +112,71 @@ type LoopView struct {
 	EffectiveExcludeTools     []EffectiveExcludeTool     `json:"effective_exclude_tools"`
 	EffectiveRoutingFactors   []EffectiveRoutingFactor   `json:"effective_routing_factors"`
 	EffectiveDelegationGating *EffectiveDelegationGating `json:"effective_delegation_gating"`
+}
+
+// SleepEnvelope is the range a self-pacing loop chooses its next sleep
+// within: the bounds [Loop.SetNextSleep] clamps to, the interval the
+// runtime falls back to when the loop asks for nothing, and the
+// randomization applied on top of whatever it does choose.
+//
+// A loop that cannot see this is choosing a cadence blind and learns its
+// bounds only by being corrected — the gap #1313 closes. It rides the
+// canonical row so every surface that shows a loop shows its envelope:
+// loop_status for an operator, the self-context block for the loop
+// itself, and the loop-scoped set_next_sleep advertisement.
+//
+// Durations are Go duration literals ("15m", "1h30m", "24h") rather than
+// the row's signed-seconds convention. That convention exists for clock
+// readings, to spare the model timestamp arithmetic; these are knob
+// values, and what appears here is exactly what set_next_sleep accepts
+// back, so the model round-trips the literal instead of converting it.
+type SleepEnvelope struct {
+	// Min and Max are the clamp. A request outside them is not rejected,
+	// it is silently moved to the nearest bound.
+	Min string `json:"min"`
+	Max string `json:"max"`
+	// Default is what the runtime sleeps when an iteration ends without
+	// choosing — not a recommendation, just the fallback.
+	Default string `json:"default"`
+	// Jitter is the fraction of the chosen sleep the runtime randomizes
+	// by, in either direction: at 0.2 a 30m sleep wakes somewhere in
+	// 24m–36m. It is why an observed wake rarely lands exactly on what
+	// was asked for. Omitted when jitter is off.
+	Jitter float64 `json:"jitter,omitempty"`
+}
+
+// newSleepEnvelope builds the envelope for a loop with a periodic timer,
+// or nil for one without. The gate matches set_next_sleep's own: only a
+// timer-driven service loop paces itself, so a container, an event-driven
+// loop, or a one-shot background task reports null rather than an
+// envelope it can neither use nor change.
+//
+// Zero fields take the runtime defaults, mirroring [Config.applyDefaults],
+// so a stored definition that declared no envelope still shows the one it
+// will actually run under instead of leaving the fallback implied.
+func newSleepEnvelope(operation string, eventDriven bool, min, max, def time.Duration, jitter *float64) *SleepEnvelope {
+	if operation != string(OperationService) || eventDriven {
+		return nil
+	}
+	if min == 0 {
+		min = DefaultSleepMin
+	}
+	if max == 0 {
+		max = DefaultSleepMax
+	}
+	if def == 0 {
+		def = DefaultSleepDefault
+	}
+	env := &SleepEnvelope{
+		Min:     promptfmt.FormatDuration(min),
+		Max:     promptfmt.FormatDuration(max),
+		Default: promptfmt.FormatDuration(def),
+		Jitter:  DefaultJitter,
+	}
+	if jitter != nil {
+		env.Jitter = *jitter
+	}
+	return env
 }
 
 // LoopPolicyInfo is the policy/eligibility slice a LoopView needs, keyed
@@ -249,6 +335,10 @@ func applyLiveTelemetry(v *LoopView, s Status, now time.Time) {
 	// FromStatus row exactly instead of re-deriving it from the spec operation.
 	v.EventDriven = s.EventDriven
 	v.PendingRetune = s.PendingRetune
+	// From the LIVE config, not the stored spec: a promoted retune moves
+	// the envelope under a running loop, and the row that told it what it
+	// may ask for has to be the one it is actually clamped by.
+	v.SleepEnvelope = newSleepEnvelope(v.Operation, v.EventDriven, s.Config.SleepMin, s.Config.SleepMax, s.Config.SleepDefault, s.Config.Jitter)
 
 	iterations := s.Iterations
 	attempts := s.Attempts
@@ -277,6 +367,16 @@ func applyLiveTelemetry(v *LoopView, s Status, now time.Time) {
 		cs := fmt.Sprintf("%ds", int64(s.CurrentSleep/time.Second))
 		v.CurrentSleepDuration = &cs
 	}
+	// The sleep that just ended, which the in-flight turn can no longer
+	// read off SleepUntil/CurrentSleep — those are cleared on wake.
+	if s.SleptFor > 0 {
+		slept := promptfmt.FormatDuration(s.SleptFor)
+		planned := promptfmt.FormatDuration(s.SleptPlanned)
+		v.LastSleep = &slept
+		v.LastSleepPlanned = &planned
+	}
+	wakes := s.WakesLast24h
+	v.WakesLast24h = &wakes
 
 	// Token economics — left nil for handler-only loops, which run no LLM
 	// iterations and have no token metrics (a literal 0 would read as a real
@@ -317,6 +417,10 @@ func applyLiveTelemetry(v *LoopView, s Status, now time.Time) {
 			ago = 0
 		}
 		v.SupervisorItersAgo = &ago
+		if !s.LastSupervisorAt.IsZero() {
+			d := promptfmt.FormatDeltaOnly(s.LastSupervisorAt, now)
+			v.LastSupervisorDelta = &d
+		}
 	}
 
 	// effective_* come straight off the Status — the registry populates them via
@@ -418,6 +522,10 @@ func (r DefinitionViewResolver) FromDefinition(snap DefinitionSnapshot, eligibil
 		prob := spec.SupervisorProb
 		v.SupervisorProb = &prob
 	}
+	// The declared envelope, so a stored-only definition still shows the
+	// cadence it would run at. applyLiveTelemetry replaces it with the
+	// live one below when the definition is running.
+	v.SleepEnvelope = newSleepEnvelope(v.Operation, v.EventDriven, spec.SleepMin, spec.SleepMax, spec.SleepDefault, spec.Jitter)
 
 	if live != nil {
 		applyLiveTelemetry(&v, *live, r.now)

--- a/internal/runtime/loop/loop_view_test.go
+++ b/internal/runtime/loop/loop_view_test.go
@@ -356,3 +356,122 @@ func TestFromDefinition_RunningTakesLiveEventDrivenAndState(t *testing.T) {
 		t.Errorf("a stored definition must have nil state, got %v", stored.State)
 	}
 }
+
+// TestLoopViewResolver_FromStatus_CadenceSelfKnowledge covers the row a
+// running loop reads about itself each iteration (#1313): the envelope it
+// may choose within, the sleep it just came out of, and how often it has
+// actually been running.
+func TestLoopViewResolver_FromStatus_CadenceSelfKnowledge(t *testing.T) {
+	now := time.Date(2026, 7, 27, 12, 0, 0, 0, time.UTC)
+	r := NewLoopViewResolver(nil, nil, now)
+
+	v := r.FromStatus(Status{
+		ID:           "lp_meta",
+		Name:         "metacognitive",
+		State:        State("processing"),
+		SleptFor:     4 * time.Minute,
+		SleptPlanned: 30 * time.Minute,
+		WakesLast24h: 47,
+		Config: Config{
+			Operation:    OperationService,
+			SleepMin:     15 * time.Minute,
+			SleepMax:     time.Hour,
+			SleepDefault: 30 * time.Minute,
+			Jitter:       Float64Ptr(0.2),
+		},
+	})
+
+	if v.SleepEnvelope == nil {
+		t.Fatal("a timer-driven service loop must carry its envelope")
+	}
+	if v.SleepEnvelope.Min != "15m" || v.SleepEnvelope.Max != "1h" || v.SleepEnvelope.Default != "30m" {
+		t.Errorf("envelope = %#v, want 15m/1h/30m", v.SleepEnvelope)
+	}
+	// The two sleep durations disagree, which is how a loop distinguishes
+	// "a notification woke me" from "my cadence was overridden".
+	if v.LastSleep == nil || *v.LastSleep != "4m" {
+		t.Errorf("LastSleep = %v, want 4m", v.LastSleep)
+	}
+	if v.LastSleepPlanned == nil || *v.LastSleepPlanned != "30m" {
+		t.Errorf("LastSleepPlanned = %v, want 30m", v.LastSleepPlanned)
+	}
+	if v.WakesLast24h == nil || *v.WakesLast24h != 47 {
+		t.Errorf("WakesLast24h = %v, want 47", v.WakesLast24h)
+	}
+}
+
+// TestLoopViewResolver_FromStatus_SupervisorRecencyInBothUnits pins the
+// pair: turns-back answers "has my recent work been reviewed", time-ago
+// answers "how long since" — different questions on a loop whose interval
+// keeps changing.
+func TestLoopViewResolver_FromStatus_SupervisorRecencyInBothUnits(t *testing.T) {
+	now := time.Date(2026, 7, 27, 12, 0, 0, 0, time.UTC)
+	r := NewLoopViewResolver(nil, nil, now)
+
+	v := r.FromStatus(Status{
+		ID: "lp_meta", Name: "metacognitive", State: State("processing"),
+		Iterations:            412,
+		LastSupervisorIter:    403,
+		LastSupervisorTrigger: SupervisorTrigger("random"),
+		LastSupervisorAt:      now.Add(-4*time.Hour - 12*time.Minute),
+		Config:                Config{Operation: OperationService},
+	})
+	if v.SupervisorItersAgo == nil || *v.SupervisorItersAgo != 9 {
+		t.Errorf("SupervisorItersAgo = %v, want 9", v.SupervisorItersAgo)
+	}
+	if v.LastSupervisorDelta == nil || *v.LastSupervisorDelta != "-4h12m" {
+		t.Errorf("LastSupervisorDelta = %v, want -4h12m", v.LastSupervisorDelta)
+	}
+}
+
+// TestDefinitionViewResolver_FromDefinition_DeclaredEnvelope keeps the
+// envelope readable before a definition ever runs, so an operator (or a
+// model) reading the corpus sees the cadence a loop would run at.
+func TestDefinitionViewResolver_FromDefinition_DeclaredEnvelope(t *testing.T) {
+	now := time.Date(2026, 7, 27, 12, 0, 0, 0, time.UTC)
+	r := NewDefinitionViewResolver(nil, now)
+
+	v := r.FromDefinition(DefinitionSnapshot{
+		Name: "archivist",
+		Spec: Spec{
+			Name: "archivist", Operation: OperationService,
+			SleepMin: 15 * time.Minute, SleepMax: 12 * time.Hour, SleepDefault: time.Hour,
+		},
+	}, DefinitionEligibilityStatus{Eligible: true}, nil)
+
+	if v.SleepEnvelope == nil {
+		t.Fatal("a stored service definition should show the envelope it would run under")
+	}
+	if v.SleepEnvelope.Min != "15m" || v.SleepEnvelope.Max != "12h" || v.SleepEnvelope.Default != "1h" {
+		t.Errorf("envelope = %#v, want 15m/12h/1h", v.SleepEnvelope)
+	}
+}
+
+// TestDefinitionViewResolver_FromDefinition_LiveEnvelopeWins is the
+// retune case: once a definition is running, the envelope the loop is
+// actually clamped by is the live one, not what the stored spec declared.
+func TestDefinitionViewResolver_FromDefinition_LiveEnvelopeWins(t *testing.T) {
+	now := time.Date(2026, 7, 27, 12, 0, 0, 0, time.UTC)
+	r := NewDefinitionViewResolver(nil, now)
+
+	v := r.FromDefinition(DefinitionSnapshot{
+		Name: "archivist",
+		Spec: Spec{
+			Name: "archivist", Operation: OperationService,
+			SleepMin: 15 * time.Minute, SleepMax: 12 * time.Hour, SleepDefault: time.Hour,
+		},
+	}, DefinitionEligibilityStatus{Eligible: true}, &Status{
+		ID: "lp_arch", Name: "archivist", State: State("sleeping"),
+		Config: Config{
+			Operation: OperationService,
+			SleepMin:  time.Hour, SleepMax: 24 * time.Hour, SleepDefault: 6 * time.Hour,
+		},
+	})
+
+	if v.SleepEnvelope == nil {
+		t.Fatal("a running definition should still carry an envelope")
+	}
+	if v.SleepEnvelope.Min != "1h" || v.SleepEnvelope.Max != "24h" || v.SleepEnvelope.Default != "6h" {
+		t.Errorf("envelope = %#v, want the live 1h/24h/6h, not the stored spec's", v.SleepEnvelope)
+	}
+}

--- a/internal/runtime/loop/signals.go
+++ b/internal/runtime/loop/signals.go
@@ -401,6 +401,13 @@ func (l *Loop) sleep(ctx context.Context, d time.Duration) bool {
 	l.mu.Unlock()
 	defer func() {
 		l.mu.Lock()
+		// Capture what the sleep actually came to before clearing the
+		// in-flight fields. A notification wake makes the elapsed time the
+		// honest answer to "how long was I out", and the planned duration
+		// read off l.currentSleep (not the d argument, which a mid-sleep
+		// retune supersedes) is what it was meant to be.
+		l.lastSleptFor = time.Since(start)
+		l.lastSleptPlanned = l.currentSleep
 		l.sleepUntil = time.Time{}
 		l.currentSleep = 0
 		l.mu.Unlock()

--- a/internal/runtime/loop/sleep_control.go
+++ b/internal/runtime/loop/sleep_control.go
@@ -1,0 +1,190 @@
+package loop
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/nugget/thane-ai-agent/internal/model/promptfmt"
+	"github.com/nugget/thane-ai-agent/internal/platform/logging"
+	"github.com/nugget/thane-ai-agent/internal/tools/toolargs"
+)
+
+// SetNextSleepToolName is the tool a timer-driven service loop calls to
+// choose its own next interval. It is registered globally so the model
+// can always see it, and shadowed per-loop by
+// [Loop.sleepControlRuntimeTool] so the advertisement names real bounds.
+const SetNextSleepToolName = "set_next_sleep"
+
+// sleepControlRuntimeTool builds this loop's private set_next_sleep,
+// whose description states the envelope THIS loop is clamped to instead
+// of the global tool's "clamped to the loop's configured bounds" — a
+// sentence that names no numbers and so tells the caller nothing it can
+// act on (#1313).
+//
+// Runtime tools shadow the global registration by name and are exempt
+// from tag filtering, which is right for this one: a loop's control over
+// its own cadence is part of the runtime contract it runs under, not a
+// capability it might or might not have been granted.
+//
+// Returns ok=false for a loop with no sleep to choose. The gate is
+// [newSleepEnvelope]'s, so the advertised tool and the envelope on every
+// other surface appear and disappear together.
+func (l *Loop) sleepControlRuntimeTool() (RuntimeTool, bool) {
+	env := newSleepEnvelope(
+		string(effectiveOperation(l.config.Operation)),
+		l.isEventDriven(),
+		l.config.SleepMin, l.config.SleepMax, l.config.SleepDefault, l.config.Jitter,
+	)
+	if env == nil {
+		return RuntimeTool{}, false
+	}
+	return RuntimeTool{
+		Name:        SetNextSleepToolName,
+		Description: sleepControlDescription(env),
+		Parameters:  sleepControlParameters(env),
+		Handler:     l.HandleSetNextSleep,
+	}, true
+}
+
+// sleepControlDescription writes the envelope into the advertisement the
+// model reads while choosing an argument. Stating the clamp as a clamp
+// matters as much as stating the bounds: a request outside the range
+// succeeds at a different value, so a caller that assumed refusal would
+// read "ok" and never learn its judgement had been moved.
+func sleepControlDescription(env *SleepEnvelope) string {
+	desc := fmt.Sprintf(
+		"Choose how long this loop sleeps before its next iteration. This loop's envelope is %s to %s; a duration outside it is moved to the nearest bound and reported back as clamped, not refused. Ending an iteration without calling this leaves the sleep at the %s default.",
+		env.Min, env.Max, env.Default,
+	)
+	if env.Jitter > 0 {
+		desc += fmt.Sprintf(" The runtime then randomizes the result by up to ±%d%%, so the wake lands near the chosen duration rather than exactly on it.", int(env.Jitter*100))
+	}
+	return desc
+}
+
+func sleepControlParameters(env *SleepEnvelope) map[string]any {
+	return map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"duration": map[string]any{
+				"description": fmt.Sprintf(
+					"Requested next sleep, as a Go duration string between %s and %s (e.g. %q or %q). A bare number is accepted as a minute count for tolerant local-model compatibility.",
+					env.Min, env.Max, env.Min, env.Default,
+				),
+				"anyOf": []map[string]any{
+					{"type": "string"},
+					{"type": "number"},
+					{"type": "integer"},
+				},
+			},
+			"reason": map[string]any{
+				"type":        "string",
+				"description": "Optional short explanation of why this duration was chosen. Logged for operator visibility.",
+			},
+		},
+		"required": []string{"duration"},
+	}
+}
+
+// HandleSetNextSleep applies a requested sleep to this loop and reports
+// what it became. It is the single implementation behind both the global
+// set_next_sleep (which resolves the running loop from the call context
+// and delegates here) and the per-loop shadow above, so the two can never
+// diverge on clamping, logging, or the shape of what comes back.
+func (l *Loop) HandleSetNextSleep(ctx context.Context, args map[string]any) (string, error) {
+	name := l.config.Name
+	if op := effectiveOperation(l.config.Operation); op != OperationService {
+		return "", fmt.Errorf("set_next_sleep is only available to service loops; current loop %q uses %q", name, op)
+	}
+	if l.isEventDriven() {
+		return "", fmt.Errorf("set_next_sleep is unavailable for event-driven service loops; current loop %q waits for events instead of sleeping on a timer", name)
+	}
+
+	requested, requestedText, err := parseNextSleepDurationArg(args)
+	if err != nil {
+		return "", err
+	}
+	applied := requested
+	if applied < l.config.SleepMin {
+		applied = l.config.SleepMin
+	}
+	if applied > l.config.SleepMax {
+		applied = l.config.SleepMax
+	}
+	reason := toolargs.TrimmedString(args, "reason")
+	clamped := applied != requested
+	l.SetNextSleep(applied)
+
+	logging.Logger(ctx).Info(
+		"loop next sleep set",
+		"loop_id", l.id,
+		"loop_name", name,
+		"requested", requested.Round(time.Second),
+		"applied", applied.Round(time.Second),
+		"sleep_min", l.config.SleepMin,
+		"sleep_max", l.config.SleepMax,
+		"reason", reason,
+		"clamped", clamped,
+	)
+
+	env := newSleepEnvelope(
+		string(effectiveOperation(l.config.Operation)), l.isEventDriven(),
+		l.config.SleepMin, l.config.SleepMax, l.config.SleepDefault, l.config.Jitter,
+	)
+	out, err := json.Marshal(map[string]any{
+		"status":    "ok",
+		"loop_id":   l.id,
+		"loop_name": name,
+		"requested": requestedText,
+		"applied":   promptfmt.FormatDuration(applied),
+		"clamped":   clamped,
+		// The same object the canonical row and the self-context block
+		// carry, so a loop that reads the envelope here and the envelope
+		// there is reading one fact in one shape.
+		"sleep_envelope": env,
+		"reason":         reason,
+	})
+	if err != nil {
+		return "", fmt.Errorf("marshal set_next_sleep result: %w", err)
+	}
+	return string(out), nil
+}
+
+// parseNextSleepDurationArg reads the duration argument. A bare number is
+// read as minutes rather than rejected: local models routinely emit one,
+// and a minute count is the only reading that is ever sensible for a
+// loop's sleep.
+func parseNextSleepDurationArg(args map[string]any) (time.Duration, string, error) {
+	raw, ok := args["duration"]
+	if !ok {
+		return 0, "", fmt.Errorf("duration is required")
+	}
+
+	var durStr string
+	switch v := raw.(type) {
+	case string:
+		durStr = strings.TrimSpace(v)
+	case int:
+		durStr = fmt.Sprintf("%dm", v)
+	case int64:
+		durStr = fmt.Sprintf("%dm", v)
+	case float32:
+		durStr = strconv.FormatFloat(float64(v), 'f', -1, 64) + "m"
+	case float64:
+		durStr = strconv.FormatFloat(v, 'f', -1, 64) + "m"
+	default:
+		return 0, "", fmt.Errorf("duration must be a Go duration string or a numeric minute count")
+	}
+	if durStr == "" {
+		return 0, "", fmt.Errorf("duration is required")
+	}
+	d, err := time.ParseDuration(durStr)
+	if err != nil {
+		return 0, "", fmt.Errorf("invalid duration %q: %w", durStr, err)
+	}
+	return d, durStr, nil
+}

--- a/internal/runtime/loop/sleep_control.go
+++ b/internal/runtime/loop/sleep_control.go
@@ -61,7 +61,7 @@ func sleepControlDescription(env *SleepEnvelope) string {
 		env.Min, env.Max, env.Default,
 	)
 	if env.Jitter > 0 {
-		desc += fmt.Sprintf(" The runtime then randomizes the result by up to ±%d%%, so the wake lands near the chosen duration rather than exactly on it.", int(env.Jitter*100))
+		desc += fmt.Sprintf(" The runtime then randomizes the result by up to ±%s%%, so the wake lands near the chosen duration rather than exactly on it.", env.JitterPercent())
 	}
 	return desc
 }

--- a/internal/runtime/loop/sleep_envelope_test.go
+++ b/internal/runtime/loop/sleep_envelope_test.go
@@ -299,3 +299,42 @@ func TestServiceLoopRecordsItsOwnRhythm(t *testing.T) {
 		t.Errorf("SleptPlanned = %v, want the duration that sleep was scheduled for", status.SleptPlanned)
 	}
 }
+
+// TestSleepEnvelopeJitterPercent covers the arithmetic the tool
+// description depends on. int(j*100) truncates, and the float64
+// representation of an ordinary config value makes that bite on whole
+// percentages too — 0.29 is held as slightly under 0.29 — so a naive
+// conversion would advertise a smaller spread than the runtime applies.
+func TestSleepEnvelopeJitterPercent(t *testing.T) {
+	tests := []struct {
+		jitter float64
+		want   string
+	}{
+		{0.2, "20"},
+		{0.1, "10"},
+		{0.29, "29"}, // truncation would say 28
+		{0.07, "7"},
+		{0.125, "12.5"}, // a real fraction survives
+		{0.333, "33.3"},
+		{1, "100"},
+		{0, "0"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.want, func(t *testing.T) {
+			env := SleepEnvelope{Jitter: tt.jitter}
+			if got := env.JitterPercent(); got != tt.want {
+				t.Errorf("JitterPercent(%v) = %q, want %q", tt.jitter, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestSleepControlDescriptionStatesJitterExactly is the same property at
+// the surface that matters: what the model reads must be what the
+// runtime does.
+func TestSleepControlDescriptionStatesJitterExactly(t *testing.T) {
+	desc := sleepControlDescription(&SleepEnvelope{Min: "15m", Max: "1h", Default: "30m", Jitter: 0.29})
+	if !strings.Contains(desc, "±29%") {
+		t.Errorf("description should state the configured jitter exactly, got: %s", desc)
+	}
+}

--- a/internal/runtime/loop/sleep_envelope_test.go
+++ b/internal/runtime/loop/sleep_envelope_test.go
@@ -1,0 +1,301 @@
+package loop
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// TestSleepEnvelopeOnlyForLoopsThatPaceThemselves pins the gate. The
+// envelope is a promise about a choice the loop gets to make, so it must
+// appear on exactly the loops that can make it — the same set
+// set_next_sleep accepts. A container or an event-driven loop reporting
+// bounds would describe a cadence it does not have.
+func TestSleepEnvelopeOnlyForLoopsThatPaceThemselves(t *testing.T) {
+	tests := []struct {
+		name        string
+		operation   string
+		eventDriven bool
+		want        bool
+	}{
+		{"timer-driven service loop", string(OperationService), false, true},
+		{"event-driven service loop", string(OperationService), true, false},
+		{"container", string(OperationContainer), false, false},
+		{"event-driven operation", string(OperationEventDriven), false, false},
+		{"background task", string(OperationBackgroundTask), false, false},
+		{"request/reply", string(OperationRequestReply), false, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := newSleepEnvelope(tt.operation, tt.eventDriven, 15*time.Minute, time.Hour, 30*time.Minute, nil)
+			if (got != nil) != tt.want {
+				t.Fatalf("envelope present = %v, want %v", got != nil, tt.want)
+			}
+		})
+	}
+}
+
+func TestSleepEnvelopeRendersDurationsAndJitter(t *testing.T) {
+	jitter := 0.25
+	env := newSleepEnvelope(string(OperationService), false, 15*time.Minute, 12*time.Hour, time.Hour, &jitter)
+	if env == nil {
+		t.Fatal("service loop should carry an envelope")
+	}
+	if env.Min != "15m" || env.Max != "12h" || env.Default != "1h" {
+		t.Errorf("envelope = %#v, want 15m/12h/1h", env)
+	}
+	if env.Jitter != 0.25 {
+		t.Errorf("jitter = %v, want 0.25", env.Jitter)
+	}
+}
+
+// TestSleepEnvelopeFillsRuntimeDefaults covers the stored-definition
+// case: a spec that declared no envelope still runs under one, and
+// leaving the model to recover the fallback is exactly the implied-default
+// this is meant to remove.
+func TestSleepEnvelopeFillsRuntimeDefaults(t *testing.T) {
+	env := newSleepEnvelope(string(OperationService), false, 0, 0, 0, nil)
+	if env == nil {
+		t.Fatal("service loop should carry an envelope")
+	}
+	if env.Min != "30s" || env.Max != "5m" || env.Default != "1m" {
+		t.Errorf("envelope = %#v, want the runtime defaults 30s/5m/1m", env)
+	}
+	if env.Jitter != DefaultJitter {
+		t.Errorf("jitter = %v, want the default %v", env.Jitter, DefaultJitter)
+	}
+}
+
+// TestSleepEnvelopeZeroJitterIsNotTheDefault distinguishes "jitter not
+// declared" from "jitter explicitly off" — the same distinction
+// Config.Jitter's pointer exists for.
+func TestSleepEnvelopeZeroJitterIsNotTheDefault(t *testing.T) {
+	off := 0.0
+	env := newSleepEnvelope(string(OperationService), false, time.Minute, time.Hour, 5*time.Minute, &off)
+	if env == nil {
+		t.Fatal("service loop should carry an envelope")
+	}
+	if env.Jitter != 0 {
+		t.Errorf("jitter = %v, want 0 for an explicitly disabled jitter", env.Jitter)
+	}
+}
+
+// TestSleepControlToolAdvertisesThisLoopsBounds is the point of #1313:
+// the advertisement the model reads while choosing an argument names the
+// numbers, instead of referring to bounds it has no way to see.
+func TestSleepControlToolAdvertisesThisLoopsBounds(t *testing.T) {
+	l, err := New(Config{
+		Name:         "reservoir_watch",
+		Task:         "Watch the reservoir.",
+		Operation:    OperationService,
+		SleepMin:     15 * time.Minute,
+		SleepMax:     12 * time.Hour,
+		SleepDefault: time.Hour,
+	}, Deps{Runner: &countingRunner{count: &atomic.Int32{}}})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	tool, ok := l.sleepControlRuntimeTool()
+	if !ok {
+		t.Fatal("a timer-driven service loop must get a loop-scoped set_next_sleep")
+	}
+	if tool.Name != SetNextSleepToolName {
+		t.Fatalf("tool name = %q, want %q so it shadows the global registration", tool.Name, SetNextSleepToolName)
+	}
+	for _, want := range []string{"15m", "12h", "1h", "clamped"} {
+		if !strings.Contains(tool.Description, want) {
+			t.Errorf("description missing %q\n--- got ---\n%s", want, tool.Description)
+		}
+	}
+	// The parameter description carries the range too: some model
+	// families surface argument schemas more prominently than the tool
+	// blurb, and the number has to be wherever the model is looking.
+	props, _ := tool.Parameters["properties"].(map[string]any)
+	duration, _ := props["duration"].(map[string]any)
+	if desc, _ := duration["description"].(string); !strings.Contains(desc, "15m") || !strings.Contains(desc, "12h") {
+		t.Errorf("duration parameter description does not name the range: %q", desc)
+	}
+}
+
+func TestSleepControlToolAbsentForLoopsWithNoSleepToChoose(t *testing.T) {
+	l, err := New(Config{
+		Name:       "dispatch",
+		Task:       "Handle one request.",
+		Operation:  OperationBackgroundTask,
+		Completion: CompletionNone,
+	}, Deps{Runner: &countingRunner{count: &atomic.Int32{}}})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if _, ok := l.sleepControlRuntimeTool(); ok {
+		t.Error("a background task has no sleep to choose and must not be offered the tool")
+	}
+}
+
+// TestHandleSetNextSleepClampsAndSaysSo covers the failure the issue was
+// filed about: a request outside the envelope is applied at a different
+// value, and the result has to say so rather than reading as a plain ok.
+func TestHandleSetNextSleepClampsAndSaysSo(t *testing.T) {
+	l, err := New(Config{
+		Name:         "reservoir_watch",
+		Task:         "Watch the reservoir.",
+		Operation:    OperationService,
+		SleepMin:     15 * time.Minute,
+		SleepMax:     time.Hour,
+		SleepDefault: 30 * time.Minute,
+	}, Deps{Runner: &countingRunner{count: &atomic.Int32{}}})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	out, err := l.HandleSetNextSleep(t.Context(), map[string]any{"duration": "2m", "reason": "something is moving"})
+	if err != nil {
+		t.Fatalf("HandleSetNextSleep: %v", err)
+	}
+	for _, want := range []string{`"clamped":true`, `"applied":"15m"`, `"requested":"2m"`, `"min":"15m"`} {
+		if !strings.Contains(out, want) {
+			t.Errorf("result missing %s\n--- got ---\n%s", want, out)
+		}
+	}
+
+	l.mu.Lock()
+	next := l.nextSleep
+	l.mu.Unlock()
+	if next != 15*time.Minute {
+		t.Errorf("next sleep = %v, want the clamped 15m", next)
+	}
+}
+
+func TestHandleSetNextSleepRejectsLoopsThatDoNotSleep(t *testing.T) {
+	l, err := New(Config{
+		Name:       "dispatch",
+		Task:       "Handle one request.",
+		Operation:  OperationBackgroundTask,
+		Completion: CompletionNone,
+	}, Deps{Runner: &countingRunner{count: &atomic.Int32{}}})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	_, err = l.HandleSetNextSleep(t.Context(), map[string]any{"duration": "5m"})
+	if err == nil {
+		t.Fatal("expected an error for a non-service loop")
+	}
+	// The error has to name what this loop actually is, so the model can
+	// tell "wrong tool for me" from "bad argument".
+	if !strings.Contains(err.Error(), "background_task") {
+		t.Errorf("error should name the loop's operation, got %q", err)
+	}
+}
+
+// capturingRunner records the request each iteration was prepared with,
+// so a test can assert on the tool surface the model was actually given
+// rather than on the builder in isolation.
+type capturingRunner struct {
+	mu   sync.Mutex
+	reqs []Request
+}
+
+func (r *capturingRunner) Run(_ context.Context, req Request, _ StreamCallback) (*RunResponse, error) {
+	r.mu.Lock()
+	r.reqs = append(r.reqs, req)
+	r.mu.Unlock()
+	return &RunResponse{Content: "ok", Model: "test-model"}, nil
+}
+
+func (r *capturingRunner) requests() []Request {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]Request(nil), r.reqs...)
+}
+
+// TestRunningServiceLoopIsHandedItsOwnSleepTool is the end-to-end claim
+// of #1313: a real iteration of a real service loop carries a
+// set_next_sleep whose advertisement names that loop's bounds. Building
+// it per-iteration rather than at hydration is what keeps it honest
+// after a retune moves the envelope underneath a running loop.
+func TestRunningServiceLoopIsHandedItsOwnSleepTool(t *testing.T) {
+	runner := &capturingRunner{}
+	l, err := New(Config{
+		Name:         "reservoir_watch",
+		Task:         "Watch the reservoir.",
+		Operation:    OperationService,
+		SleepMin:     time.Millisecond,
+		SleepMax:     2 * time.Millisecond,
+		SleepDefault: time.Millisecond,
+		Jitter:       Float64Ptr(0),
+		MaxIter:      1,
+	}, Deps{Runner: runner})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := l.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	select {
+	case <-l.Done():
+	case <-time.After(5 * time.Second):
+		t.Fatal("loop did not finish within 5s")
+	}
+
+	reqs := runner.requests()
+	if len(reqs) == 0 {
+		t.Fatal("runner saw no iterations")
+	}
+	var sleepTool *RuntimeTool
+	for i, rt := range reqs[0].RuntimeTools {
+		if rt.Name == SetNextSleepToolName {
+			sleepTool = &reqs[0].RuntimeTools[i]
+			break
+		}
+	}
+	if sleepTool == nil {
+		t.Fatalf("iteration carried no loop-scoped %s; runtime tools = %v", SetNextSleepToolName, reqs[0].RuntimeTools)
+	}
+	if !strings.Contains(sleepTool.Description, "1ms") || !strings.Contains(sleepTool.Description, "2ms") {
+		t.Errorf("description does not name this loop's bounds: %q", sleepTool.Description)
+	}
+}
+
+// TestServiceLoopRecordsItsOwnRhythm checks the lifecycle facts land on
+// the Status the self-context block projects from — a loop that iterates
+// must be able to say how often it has been running and how long it was
+// just out.
+func TestServiceLoopRecordsItsOwnRhythm(t *testing.T) {
+	runner := &capturingRunner{}
+	l, err := New(Config{
+		Name:         "reservoir_watch",
+		Task:         "Watch the reservoir.",
+		Operation:    OperationService,
+		SleepMin:     time.Millisecond,
+		SleepMax:     2 * time.Millisecond,
+		SleepDefault: time.Millisecond,
+		Jitter:       Float64Ptr(0),
+		MaxIter:      3,
+	}, Deps{Runner: runner})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := l.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	select {
+	case <-l.Done():
+	case <-time.After(5 * time.Second):
+		t.Fatal("loop did not finish within 5s")
+	}
+
+	status := l.Status()
+	if status.WakesLast24h != 3 {
+		t.Errorf("WakesLast24h = %d, want 3 — every iteration begun counts", status.WakesLast24h)
+	}
+	if status.SleptFor <= 0 {
+		t.Errorf("SleptFor = %v, want the duration of the sleep that just ended", status.SleptFor)
+	}
+	if status.SleptPlanned <= 0 {
+		t.Errorf("SleptPlanned = %v, want the duration that sleep was scheduled for", status.SleptPlanned)
+	}
+}

--- a/internal/runtime/loop/wake_history.go
+++ b/internal/runtime/loop/wake_history.go
@@ -1,0 +1,63 @@
+package loop
+
+import "time"
+
+// wakeHistoryWindow is the span [Loop.wakeTimes] retains. Twenty-four
+// hours is the window a loop reasons in when it asks whether its current
+// cadence is proportionate — long enough to cover a full day/night cycle
+// of household activity, short enough that a rate change shows up.
+const wakeHistoryWindow = 24 * time.Hour
+
+// maxWakeHistory caps the retained instants so the ring cannot grow
+// without bound. A loop with a cognitive cadence never approaches it: at
+// the tightest core envelope (a 15m floor) a day holds 96 wakes. Only a
+// sub-minute handler poller saturates it, and those loops run no model
+// turn, so the undercount it would cause never reaches a prompt — it
+// would only clip the operator-facing count in loop_status.
+const maxWakeHistory = 2048
+
+// recordWakeLocked appends an iteration start and drops everything that
+// has fallen out of the window. Called with l.mu held.
+//
+// It records the iteration that is beginning, so a loop reading the count
+// mid-turn sees itself included — "this is my 48th turn today", not "I
+// had 47 before this one". The former is the number a loop is actually
+// deciding against.
+func (l *Loop) recordWakeLocked(at time.Time) {
+	l.wakeTimes = append(l.wakeTimes, at)
+	l.pruneWakeHistoryLocked(at)
+}
+
+// pruneWakeHistoryLocked drops instants older than the window, then
+// enforces the hard cap. Called with l.mu held.
+func (l *Loop) pruneWakeHistoryLocked(now time.Time) {
+	cutoff := now.Add(-wakeHistoryWindow)
+	keep := 0
+	for keep < len(l.wakeTimes) && l.wakeTimes[keep].Before(cutoff) {
+		keep++
+	}
+	if keep > 0 {
+		l.wakeTimes = append(l.wakeTimes[:0], l.wakeTimes[keep:]...)
+	}
+	if over := len(l.wakeTimes) - maxWakeHistory; over > 0 {
+		l.wakeTimes = append(l.wakeTimes[:0], l.wakeTimes[over:]...)
+	}
+}
+
+// wakesInWindowLocked counts the retained instants inside the window as
+// of now. Called with l.mu held.
+//
+// It counts rather than trusting len(l.wakeTimes) because the slice is
+// only pruned when a wake is appended: a loop that has been sleeping for
+// a day would otherwise report the wakes it had before that sleep.
+func (l *Loop) wakesInWindowLocked(now time.Time) int {
+	cutoff := now.Add(-wakeHistoryWindow)
+	count := 0
+	for i := len(l.wakeTimes) - 1; i >= 0; i-- {
+		if l.wakeTimes[i].Before(cutoff) {
+			break
+		}
+		count++
+	}
+	return count
+}

--- a/internal/runtime/loop/wake_history_test.go
+++ b/internal/runtime/loop/wake_history_test.go
@@ -1,0 +1,63 @@
+package loop
+
+import (
+	"testing"
+	"time"
+)
+
+func TestWakeHistoryCountsTheTrailingDay(t *testing.T) {
+	now := time.Date(2026, 7, 27, 12, 0, 0, 0, time.UTC)
+	l := &Loop{}
+	for _, at := range []time.Time{
+		now.Add(-30 * time.Hour), // outside the window
+		now.Add(-25 * time.Hour), // outside the window
+		now.Add(-23 * time.Hour),
+		now.Add(-2 * time.Hour),
+		now,
+	} {
+		l.recordWakeLocked(at)
+	}
+	if got := l.wakesInWindowLocked(now); got != 3 {
+		t.Errorf("wakes in window = %d, want 3", got)
+	}
+	if len(l.wakeTimes) != 3 {
+		t.Errorf("retained %d instants, want the pruned 3", len(l.wakeTimes))
+	}
+}
+
+// TestWakeHistoryAgesOutWithoutANewWake is why the count is computed
+// rather than read off len(). Pruning only happens on append, so a loop
+// that has been asleep for a day would otherwise keep reporting the
+// wakes it had before that sleep as if they were recent.
+func TestWakeHistoryAgesOutWithoutANewWake(t *testing.T) {
+	start := time.Date(2026, 7, 27, 12, 0, 0, 0, time.UTC)
+	l := &Loop{}
+	l.recordWakeLocked(start)
+	l.recordWakeLocked(start.Add(time.Hour))
+
+	if got := l.wakesInWindowLocked(start.Add(2 * time.Hour)); got != 2 {
+		t.Fatalf("wakes shortly after = %d, want 2", got)
+	}
+	if got := l.wakesInWindowLocked(start.Add(48 * time.Hour)); got != 0 {
+		t.Errorf("wakes two days later = %d, want 0", got)
+	}
+}
+
+func TestWakeHistoryDropsOldestPastTheCap(t *testing.T) {
+	now := time.Date(2026, 7, 27, 12, 0, 0, 0, time.UTC)
+	l := &Loop{}
+	// Every instant is inside the window, so only the hard cap can bound
+	// the slice — this is the sub-minute-poller case.
+	for i := range maxWakeHistory + 100 {
+		l.recordWakeLocked(now.Add(time.Duration(i) * time.Second))
+	}
+	if len(l.wakeTimes) != maxWakeHistory {
+		t.Fatalf("retained %d instants, want the cap %d", len(l.wakeTimes), maxWakeHistory)
+	}
+	// The newest survive: a truncated history should still describe the
+	// recent past rather than a stale prefix of it.
+	newest := now.Add(time.Duration(maxWakeHistory+99) * time.Second)
+	if got := l.wakeTimes[len(l.wakeTimes)-1]; !got.Equal(newest) {
+		t.Errorf("newest retained instant = %v, want %v", got, newest)
+	}
+}

--- a/internal/server/openapi/native.yaml
+++ b/internal/server/openapi/native.yaml
@@ -1516,6 +1516,37 @@ components:
         current_sleep_duration:
           type: [string, "null"]
           description: Unsigned-second self-paced sleep interval honored this cycle (e.g. "5940s").
+        sleep_envelope:
+          type: [object, "null"]
+          description: |
+            The cadence a self-pacing loop may choose within — the bounds
+            set_next_sleep clamps to, the interval used when it chooses
+            nothing, and the randomization applied on top. Configuration
+            rather than telemetry, so it is present on a stored definition
+            as well as a running loop; null on anything with no periodic
+            timer (containers, event-driven loops, one-shot tasks).
+            Durations are Go duration literals ("15m", "24h") rather than
+            the row's seconds convention, because they are knob values the
+            caller passes back verbatim rather than clock readings.
+          properties:
+            min: { type: string, description: Shortest sleep this loop may request. }
+            max: { type: string, description: Longest sleep this loop may request. }
+            default: { type: string, description: Interval used when an iteration ends without choosing one. }
+            jitter:
+              type: number
+              description: Fraction of the chosen sleep the runtime randomizes by, in either direction (0.2 = ±20%). Omitted when jitter is off.
+        last_sleep:
+          type: [string, "null"]
+          description: How long the most recent sleep actually lasted (e.g. "28m"); shorter than last_sleep_planned when a notification cut it short. Null before the first sleep and on event-driven loops.
+        last_sleep_planned:
+          type: [string, "null"]
+          description: How long that sleep was scheduled for. Equal to last_sleep on an ordinary wake.
+        wakes_last_24h:
+          type: [integer, "null"]
+          description: Iterations begun in the trailing day, counting the one in flight — the cadence actually achieved, as against the permitted one in sleep_envelope.
+        last_supervisor_delta:
+          type: [string, "null"]
+          description: Signed-second delta to the most recent supervisor review (e.g. "-15120s"); null when none has run. The wall-clock companion to supervisor_iters_ago, which counts turns rather than time.
         context_fill_pct:
           type: [integer, "null"]
           description: Last input tokens as a percentage of the context window; null for handler-only loops.

--- a/internal/tools/loop_runtime_tools.go
+++ b/internal/tools/loop_runtime_tools.go
@@ -3,11 +3,9 @@ package tools
 import (
 	"context"
 	"fmt"
-	"strconv"
 	"strings"
 	"time"
 
-	"github.com/nugget/thane-ai-agent/internal/platform/logging"
 	looppkg "github.com/nugget/thane-ai-agent/internal/runtime/loop"
 	"github.com/nugget/thane-ai-agent/internal/tools/toolargs"
 )
@@ -71,9 +69,15 @@ func (r *Registry) registerLoopRuntimeTools() {
 		Handler: r.handleLoopStatus,
 	})
 
+	// The generic advertisement. A running timer-driven service loop
+	// never sees this one — it is shadowed by the loop-scoped copy the
+	// runtime attaches, whose description names that loop's actual
+	// envelope (#1313). This registration is what keeps the tool in the
+	// catalog and gives every other caller a handler that explains why it
+	// does not apply to them.
 	r.Register(&Tool{
-		Name:        "set_next_sleep",
-		Description: "Request the next sleep duration for the current running timer-driven service loop. This is the native loops sleep-control tool used by persistent background services such as metacog-style loops. The requested duration is clamped to the loop's configured sleep_min and sleep_max bounds.",
+		Name:        looppkg.SetNextSleepToolName,
+		Description: "Choose how long the current running timer-driven service loop sleeps before its next iteration. This is the native loops sleep-control tool used by persistent background services such as metacog-style loops. A running loop sees this tool with its own permitted range written into the description; the requested duration is clamped to that range rather than refused.",
 		Parameters: map[string]any{
 			"type": "object",
 			"properties": map[string]any{
@@ -250,6 +254,10 @@ func loopStatusHealth(statuses []looppkg.Status) map[string]any {
 	return health
 }
 
+// handleSetNextSleep resolves the calling loop and hands off to it. The
+// clamping, logging, and result shape live on the loop itself
+// ([looppkg.Loop.HandleSetNextSleep]) so this global registration and the
+// loop-scoped shadow that supersedes it cannot drift apart.
 func (r *Registry) handleSetNextSleep(ctx context.Context, args map[string]any) (string, error) {
 	if r.liveLoopRegistry == nil {
 		return "", fmt.Errorf("live loop registry is not configured")
@@ -262,54 +270,7 @@ func (r *Registry) handleSetNextSleep(ctx context.Context, args map[string]any) 
 	if live == nil {
 		return "", fmt.Errorf("current loop %q not found", loopID)
 	}
-
-	status := live.Status()
-	if status.Config.Operation != looppkg.OperationService {
-		return "", fmt.Errorf("set_next_sleep is only available to service loops; current loop %q uses %q", status.Name, status.Config.Operation)
-	}
-	if status.EventDriven {
-		return "", fmt.Errorf("set_next_sleep is unavailable for event-driven service loops; current loop %q waits for events instead of sleeping on a timer", status.Name)
-	}
-
-	requested, requestedText, err := parseNextSleepDurationArg(args)
-	if err != nil {
-		return "", err
-	}
-	applied := requested
-	if applied < status.Config.SleepMin {
-		applied = status.Config.SleepMin
-	}
-	if applied > status.Config.SleepMax {
-		applied = status.Config.SleepMax
-	}
-	reason := toolargs.TrimmedString(args, "reason")
-	clamped := applied != requested
-	live.SetNextSleep(applied)
-
-	logging.Logger(ctx).Info(
-		"loop next sleep set",
-		"loop_id", status.ID,
-		"loop_name", status.Name,
-		"requested", requested.Round(time.Second),
-		"applied", applied.Round(time.Second),
-		"sleep_min", status.Config.SleepMin,
-		"sleep_max", status.Config.SleepMax,
-		"reason", reason,
-		"clamped", clamped,
-	)
-
-	return ldMarshalToolJSON(map[string]any{
-		"status":        "ok",
-		"loop_id":       status.ID,
-		"loop_name":     status.Name,
-		"requested":     requestedText,
-		"applied":       applied.String(),
-		"clamped":       clamped,
-		"sleep_min":     status.Config.SleepMin.String(),
-		"sleep_max":     status.Config.SleepMax.String(),
-		"sleep_default": status.Config.SleepDefault.String(),
-		"reason":        reason,
-	})
+	return live.HandleSetNextSleep(ctx, args)
 }
 
 func (r *Registry) handleSpawnLoop(ctx context.Context, args map[string]any) (string, error) {
@@ -341,37 +302,6 @@ func (r *Registry) handleSpawnLoop(ctx context.Context, args map[string]any) (st
 		out["loop"] = r.loopViewFromStatus(*result.FinalStatus)
 	}
 	return ldMarshalToolJSON(out)
-}
-
-func parseNextSleepDurationArg(args map[string]any) (time.Duration, string, error) {
-	raw, ok := args["duration"]
-	if !ok {
-		return 0, "", fmt.Errorf("duration is required")
-	}
-
-	var durStr string
-	switch v := raw.(type) {
-	case string:
-		durStr = strings.TrimSpace(v)
-	case int:
-		durStr = fmt.Sprintf("%dm", v)
-	case int64:
-		durStr = fmt.Sprintf("%dm", v)
-	case float32:
-		durStr = strconv.FormatFloat(float64(v), 'f', -1, 64) + "m"
-	case float64:
-		durStr = strconv.FormatFloat(v, 'f', -1, 64) + "m"
-	default:
-		return 0, "", fmt.Errorf("duration must be a Go duration string or a numeric minute count")
-	}
-	if durStr == "" {
-		return 0, "", fmt.Errorf("duration is required")
-	}
-	d, err := time.ParseDuration(durStr)
-	if err != nil {
-		return 0, "", fmt.Errorf("invalid duration %q: %w", durStr, err)
-	}
-	return d, durStr, nil
 }
 
 func (r *Registry) handleStopLoop(_ context.Context, args map[string]any) (string, error) {

--- a/internal/tools/loop_runtime_tools_test.go
+++ b/internal/tools/loop_runtime_tools_test.go
@@ -236,15 +236,13 @@ func TestSetNextSleepForCurrentServiceLoop(t *testing.T) {
 	}
 
 	var got struct {
-		Status       string `json:"status"`
-		LoopName     string `json:"loop_name"`
-		Requested    string `json:"requested"`
-		Applied      string `json:"applied"`
-		Clamped      bool   `json:"clamped"`
-		SleepMin     string `json:"sleep_min"`
-		SleepMax     string `json:"sleep_max"`
-		SleepDefault string `json:"sleep_default"`
-		Reason       string `json:"reason"`
+		Status        string                 `json:"status"`
+		LoopName      string                 `json:"loop_name"`
+		Requested     string                 `json:"requested"`
+		Applied       string                 `json:"applied"`
+		Clamped       bool                   `json:"clamped"`
+		SleepEnvelope *looppkg.SleepEnvelope `json:"sleep_envelope"`
+		Reason        string                 `json:"reason"`
 	}
 	if err := json.Unmarshal([]byte(out), &got); err != nil {
 		t.Fatalf("unmarshal set_next_sleep: %v", err)
@@ -252,11 +250,16 @@ func TestSetNextSleepForCurrentServiceLoop(t *testing.T) {
 	if got.Status != "ok" || got.LoopName != "battery_watch" {
 		t.Fatalf("response = %#v", got)
 	}
-	if got.Requested != "5m" || got.Applied != "5m0s" || got.Clamped {
-		t.Fatalf("sleep response = %#v, want requested=5m applied=5m0s clamped=false", got)
+	if got.Requested != "5m" || got.Applied != "5m" || got.Clamped {
+		t.Fatalf("sleep response = %#v, want requested=5m applied=5m clamped=false", got)
 	}
-	if got.SleepMin != "2m0s" || got.SleepMax != "30m0s" || got.SleepDefault != "10m0s" {
-		t.Fatalf("bounds = %#v, want 2m/30m/10m", got)
+	// The envelope rides back in the same shape the canonical row and the
+	// self-context block carry, so a loop reads one fact one way.
+	if got.SleepEnvelope == nil {
+		t.Fatal("sleep_envelope missing; the result is what tells a clamped caller what it was clamped to")
+	}
+	if got.SleepEnvelope.Min != "2m" || got.SleepEnvelope.Max != "30m" || got.SleepEnvelope.Default != "10m" {
+		t.Fatalf("envelope = %#v, want 2m/30m/10m", got.SleepEnvelope)
 	}
 	if got.Reason != "quiet monitoring interval" {
 		t.Fatalf("reason = %q, want quiet monitoring interval", got.Reason)
@@ -286,8 +289,8 @@ func TestSetNextSleepClampsNumericMinutes(t *testing.T) {
 	if err := json.Unmarshal([]byte(out), &got); err != nil {
 		t.Fatalf("unmarshal set_next_sleep: %v", err)
 	}
-	if got.Requested != "1m" || got.Applied != "2m0s" || !got.Clamped {
-		t.Fatalf("sleep response = %#v, want requested=1m applied=2m0s clamped=true", got)
+	if got.Requested != "1m" || got.Applied != "2m" || !got.Clamped {
+		t.Fatalf("sleep response = %#v, want requested=1m applied=2m clamped=true", got)
 	}
 }
 
@@ -314,8 +317,8 @@ func TestSetNextSleepAcceptsLargeFloatMinutesWithoutScientificNotation(t *testin
 	if err := json.Unmarshal([]byte(out), &got); err != nil {
 		t.Fatalf("unmarshal set_next_sleep: %v", err)
 	}
-	if got.Requested != "1000000m" || got.Applied != "30m0s" || !got.Clamped {
-		t.Fatalf("sleep response = %#v, want requested=1000000m applied=30m0s clamped=true", got)
+	if got.Requested != "1000000m" || got.Applied != "30m" || !got.Clamped {
+		t.Fatalf("sleep response = %#v, want requested=1000000m applied=30m clamped=true", got)
 	}
 }
 

--- a/loops/archivist.md
+++ b/loops/archivist.md
@@ -142,9 +142,11 @@ and notes — NOT the work queue (the durable queue holds that).
 6. **Update archivist.md** — Call the declared replacement tool
    (replace_output_archivist_state) with the complete updated body:
    dossier pointers and notes for your next-iteration self.
-7. **Set your sleep** — Call `set_next_sleep`. Around 1h is the default
-   rhythm; shorter if the queue is deep and worth following, longer if
-   it is empty and the corpus feels quiet.
+7. **Set your sleep** — Close the turn with `set_next_sleep`. The "This
+   loop" block carries your permitted range and your recent rhythm; read
+   it rather than guessing at numbers. Go shorter than your default if
+   the queue is deep and worth following, longer if it is empty and the
+   corpus feels quiet.
 
 ## What a dossier should look like
 

--- a/loops/ego.md
+++ b/loops/ego.md
@@ -87,12 +87,12 @@ the generated replacement tool for the document.
    replace_output_ego_state with the complete updated body. If nothing
    warrants a change, leave it alone and sleep. Do not rewrite for the
    sake of activity.
-4. **Set your sleep** — Call set_next_sleep with your chosen duration
-   and reasoning. Sleep toward the long end of your range by default:
-   reflection needs time to have something new to reflect on. Reach for
-   the short end only when something feels actively unresolved and you
-   want to revisit it soon. The tool states your permitted range and
-   clamps to it.
+4. **Set your sleep** — Close the turn with set_next_sleep and your
+   reasoning. The "This loop" block carries your permitted range and
+   your recent rhythm; read it rather than guessing at numbers. Sleep
+   toward the long end by default — reflection needs time to have
+   something new to reflect on. Reach for the short end only when
+   something feels actively unresolved and you want to revisit it soon.
 
 ## What ego.md Is For
 

--- a/loops/metacognitive.md
+++ b/loops/metacognitive.md
@@ -82,12 +82,13 @@ names the generated replacement tool for the document.
    with your complete updated state (observations, active concerns, recent
    actions, sleep reasoning). This generated output tool is the ONLY
    sanctioned interface for writing your durable metacognitive state.
-4. **Set your sleep** — Call set_next_sleep with your chosen duration and
-   reasoning. Sleep toward the short end of your range when something is
-   actively in motion and you expect the picture to have changed; toward
-   the long end when the system is quiet and another look would see the
-   same thing. The tool states your permitted range and clamps to it, so
-   reason about which end you want rather than about the numbers.
+4. **Set your sleep** — Close the turn with set_next_sleep and your
+   reasoning. The "This loop" block carries your permitted range, how
+   often you have actually been running lately, and how long you were
+   just out; read it rather than guessing at numbers. Sleep toward the
+   short end when something is actively in motion and you expect the
+   picture to have changed, toward the long end when the system is quiet
+   and another look would see the same thing.
 
 ## Guidelines
 


### PR DESCRIPTION
A service loop picks its next sleep every iteration and nothing told it what range it was picking within. The tool description said the value was "clamped to the loop's configured `sleep_min` and `sleep_max` bounds" without naming them, and the bounds appeared only in the *result* — after the choice was made, in a conversation that ends before the next one begins. So the envelope ended up written down in prose prompts instead, as a copy of a config value, and the copy went stale the moment the config moved. #1312 removed the stale numbers, which fixed the contradiction and left the loop reasoning about which end of a range it could not see. This is the other half.

## The envelope becomes a fact, in one place

`SleepEnvelope` is a field on the canonical `LoopView`, so every surface that shows a loop shows it: `loop_status` for an operator, the stored definition for anyone reading the corpus, and the loop itself. It renders as Go duration literals (`15m`, `12h`) rather than the row's signed-seconds convention — that convention exists to spare a model arithmetic on clock readings, and these are not readings, they are knob values the caller passes straight back as an argument. It appears for exactly the loops that can act on it, gated the same way `set_next_sleep` gates itself, so a container or an event-driven loop reports `null` rather than a cadence it does not have. A stored definition that declared no envelope shows the runtime defaults it will actually run under, rather than leaving the fallback implied.

`set_next_sleep` is then attached per-loop as a runtime tool, shadowing the global registration the way `publish_output_*` already does, with that loop's numbers written into the advertisement *and* into the `duration` parameter description — some model families surface argument schemas more prominently than the tool blurb, and the number has to be wherever the model is looking. It is built per-iteration rather than at hydration, so a promoted retune moves it too; a description frozen at launch would go on naming a range the loop is no longer clamped by. The handler moves onto the `Loop` and the global registration delegates to it, so the shadow and the fallback cannot drift on clamping, logging, or the shape of what comes back.

## And the rest of the loop's own lifecycle

The issue asked whether the envelope also belongs in per-iteration context rather than only in a tool schema. It does, and the answer turned out to be bigger than the envelope: a loop deciding its own cadence is reasoning about its lived rhythm, and none of that survived a fresh conversation either. The runtime now records how long its last sleep *actually* lasted against what it was *scheduled* for — so being woken early reads as something wanting it rather than as its judgement being overridden — how many turns it has begun in the trailing day, and when it was last reviewed by a supervisor turn in wall-clock time as well as in turns. `supervisor_iters_ago` counts turns, which is not the same span twice on a loop that re-chooses its interval every time.

The "This loop" block that already ships each iteration (#1106 B3) carries all of it, and closes the turn. It follows `docs/model-facing-context.md`: a markdown heading and framing note for the section boundary, a JSON payload for the live operational state, and prose for the one normative instruction — the same shape the `Declared Durable Outputs` block that rides in the same turn already uses.

````
### This loop

Your own runtime state for this iteration.

```json
{
  "name": "metacognitive",
  "id": "019f16aa",
  "operation": "service",
  "state": "processing",
  "eligible": true,
  "ancestry": ["core"],
  "intent": "Watch the household and adapt my own attention cadence.",
  "iterations": 412,
  "wakes_last_24h": 47,
  "last_sleep": "4m",
  "last_sleep_planned": "30m",
  "consecutive_errors": 0,
  "woken_early": true,
  "last_supervisor_delta": "-4h12m",
  "supervisor_iters_ago": 9,
  "last_supervisor_trigger": "random",
  "sleep_envelope": { "min": "15m", "max": "1h", "default": "30m", "jitter": 0.2 },
  "effective_tags": [{ "tag": "metacognitive", "from": "self" }]
}
```

To close this turn call set_next_sleep with a duration between 15m and 1h. A duration outside that range is moved to the nearest bound rather than refused, and skipping the call entirely leaves you sleeping 30m. Reason about which end of the range this moment calls for; the numbers are in sleep_envelope above so you do not have to guess them.
````

The payload's keys are `LoopView`'s keys wherever the two overlap, so a loop reading its own state and a loop calling `loop_status` share one vocabulary — and the envelope arrives as the *same object* `loop_status` and `set_next_sleep` return, byte for byte, rather than as a range the model would have to split on a separator that appears in neither bound. `woken_early` is the slept-vs-planned comparison made in Go rather than left to the reader.

It states the clamp as a clamp. A loop told only "your range is X–Y" still has to guess whether naming something outside it fails, is ignored, or is quietly moved — and being moved without being told is the specific failure this was filed about. The closing line is rendered only for a loop that actually paces itself; an event-driven loop told to close its turn with `set_next_sleep` would be reading an instruction the tool will refuse.

Jitter is in there because it is why an observed wake rarely lands on what was asked for, and a loop that cannot see it has no way to read `24m` as the designed spread around its own `30m`.

## What the prompts keep

With the runtime facts in the block, the three core prompts stop restating them — and the archivist's "around 1h is the default rhythm" was still the stale config copy #1312 removed from its siblings. Each sleep step now points at the block for the numbers and keeps only the judgement that is genuinely its own: metacognition sleeps short when something is in motion, ego sleeps long because reflection needs something new to reflect on, the archivist follows the depth of its queue.

## Notes

- `promptfmt.FormatDuration` is new because the existing delta formatters reach for a day term past 48h, which round-trips through `ParseTimeOrDelta` but *not* through `time.ParseDuration` — and that is what every duration-taking tool parameter uses. A `24h` envelope rendered `1d` would be a number the model could read and not send. There is a test for exactly that property.
- The `set_next_sleep` result drops the flat `sleep_min`/`sleep_max`/`sleep_default` keys for the same `sleep_envelope` object the row and the context block carry, so a loop reads one fact in one shape.
- The self-context payload omits absent facts rather than nulling them, unlike the canonical row. It ships every iteration, and a running loop has no "not applicable" half the way a stored-definition row does.
- Because runtime tools are Core, the loop-scoped `set_next_sleep` is exempt from tag filtering. That is deliberate: a loop's control over its own cadence is part of the runtime contract it runs under, not a capability it might or might not have been granted. `ExcludeTools` still applies, so an operator can still take it away.
- `wakes_last_24h` is backed by a pruned instant ring with a hard cap of 2048. A cognitive loop never approaches it (a 15m floor gives 96/day); only a sub-minute handler poller saturates it, and those run no model turn, so a clipped count could only ever understate an operator-facing number.

## Test plan

- [x] `just ci` clean
- [x] Envelope present for timer-driven service loops, absent for containers, event-driven loops, background tasks, and request/reply
- [x] Envelope fills runtime defaults for a spec that declared none; explicit `jitter: 0` stays distinct from "not declared"
- [x] Live config wins over the stored spec on a running definition (the retune case)
- [x] `FormatDuration` round-trips every emitted form through `time.ParseDuration`
- [x] A real iteration of a real service loop carries a `set_next_sleep` naming that loop's bounds
- [x] A running loop records its slept-vs-planned durations and its trailing-day wake count
- [x] Self-context payload decodes as valid JSON and is asserted on as an object, not by substring
- [x] `woken_early` fires only when the two sleep durations disagree; an event-driven loop gets no envelope and no closing line; jitter omitted when off
- [x] Shipped `loops/*.md` stay in parity with the Go specs

Closes #1313
Refs #1086

🤖 Generated with [Claude Code](https://claude.com/claude-code)
