### PR TITLE
A definition document that will not parse should fail at validate, not on the host

### DIFF
--- a/cmd/thane/main.go
+++ b/cmd/thane/main.go
@@ -545,6 +545,14 @@ func runServe(ctx context.Context, stdout io.Writer, stderr io.Writer, configPat
 	if err != nil {
 		stopSignals()
 		cancel()
+		// A failure in the authored content of the core root — a loop
+		// definition that does not parse — is not resolved by starting
+		// again. Marking it terminal stops the supervisor rather than
+		// letting it re-read the same document until someone notices.
+		var authoring *app.CoreAuthoringError
+		if errors.As(err, &authoring) {
+			return terminal(err)
+		}
 		return err
 	}
 	// LIFO ordering: cancel fires first (stops goroutines), then Close

--- a/cmd/thane/validate.go
+++ b/cmd/thane/validate.go
@@ -385,10 +385,17 @@ func writeValidateJSON(w io.Writer, cfgPath string, cfg *config.Config, loadErr 
 
 // indentBlock prefixes every line of s, so a multi-line error stays
 // visibly part of the entry it belongs to.
+//
+// It prefixes and nothing else. An earlier version trimmed each line
+// first, which is the same mistake as trimming porcelain output: a yaml
+// decode error indents its own detail lines under the message they
+// belong to, and flattening that throws away structure the error author
+// put there deliberately. Only the trailing newline goes, and only so
+// the caller's own newline does not double.
 func indentBlock(s, prefix string) string {
 	lines := strings.Split(strings.TrimRight(s, "\n"), "\n")
 	for i, line := range lines {
-		lines[i] = prefix + strings.TrimSpace(line)
+		lines[i] = prefix + line
 	}
 	return strings.Join(lines, "\n")
 }

--- a/cmd/thane/validate.go
+++ b/cmd/thane/validate.go
@@ -40,20 +40,22 @@ func runValidate(w io.Writer, configPath, workspacePath, outputFmt string) error
 	// Admission needs a loaded config to know which roots exist and whose
 	// signatures may establish them, so it only runs once the config parses.
 	var admission []app.RootAdmission
+	var coreLoops []app.CoreLoopDefinition
 	if loadErr == nil {
 		admission = app.CheckRootAdmission(context.Background(), cfg)
+		coreLoops = app.CheckCoreLoopDefinitions(cfg)
 	}
 	if outputFmt == "json" {
 		// Always emit JSON to stdout, even on failure — scripts may
 		// want the structured error. The error is still returned so
 		// the exit code reflects validity.
-		if err := writeValidateJSON(w, cfgPath, cfg, loadErr, integrity, admission); err != nil {
+		if err := writeValidateJSON(w, cfgPath, cfg, loadErr, integrity, admission, coreLoops); err != nil {
 			return err
 		}
 		if loadErr != nil {
 			return terminal(loadErr)
 		}
-		return firstError(integrityError(integrity), admissionError(admission))
+		return firstError(integrityError(integrity), admissionError(admission), coreLoopError(coreLoops))
 	}
 	if loadErr != nil {
 		// Config could not load, but the integrity report is often the
@@ -74,7 +76,68 @@ func runValidate(w io.Writer, configPath, workspacePath, outputFmt string) error
 		fmt.Fprintln(w)
 		writeAdmissionText(w, admission)
 	}
-	return firstError(integrityError(integrity), admissionError(admission))
+	if len(coreLoops) > 0 {
+		fmt.Fprintln(w)
+		writeCoreLoopText(w, coreLoops)
+	}
+	return firstError(integrityError(integrity), admissionError(admission), coreLoopError(coreLoops))
+}
+
+// coreLoopError converts a definition document that will not parse into
+// the error that stops `thane validate && thane serve`.
+//
+// Warnings deliberately do not produce one. A loop that hangs in the
+// wrong place still runs, and a check that refuses to certify a working
+// instance is one an operator learns to skip.
+func coreLoopError(definitions []app.CoreLoopDefinition) error {
+	var bad []string
+	for _, definition := range definitions {
+		if !definition.OK() {
+			bad = append(bad, definition.File)
+		}
+	}
+	if len(bad) == 0 {
+		return nil
+	}
+	return terminal(fmt.Errorf("core loop definitions failed to load: %s (see the report above; thane serve will refuse to start)",
+		strings.Join(bad, ", ")))
+}
+
+// writeCoreLoopText prints the per-document report. A failing document
+// prints its whole parse error: these errors already name the file and
+// the field, and that detail is the entire repair.
+func writeCoreLoopText(w io.Writer, definitions []app.CoreLoopDefinition) {
+	failed := 0
+	for _, definition := range definitions {
+		if !definition.OK() {
+			failed++
+		}
+	}
+	if failed == 0 {
+		fmt.Fprintf(w, "✓ Core loop definitions: %d\n", len(definitions))
+	} else {
+		fmt.Fprintf(w, "✗ Core loop definitions: %d of %d failed to load\n", failed, len(definitions))
+	}
+	for _, definition := range definitions {
+		if !definition.OK() {
+			// Indented as a block: a yaml decode error runs to several
+			// lines, and unindented continuations read as a new section
+			// rather than as the rest of this file's failure.
+			fmt.Fprintf(w, "  ✗ %s\n%s\n", definition.File, indentBlock(definition.Err.Error(), "      "))
+			continue
+		}
+		parent := definition.ParentName
+		if parent == "" {
+			parent = "(root)"
+		}
+		fmt.Fprintf(w, "  ✓ %-24s %s → %s\n", definition.File, definition.Name, parent)
+		if len(definition.Tools) > 0 {
+			fmt.Fprintf(w, "      tools: %s\n", strings.Join(definition.Tools, ", "))
+		}
+		for _, warning := range definition.Warnings {
+			fmt.Fprintf(w, "      ! %s\n", warning)
+		}
+	}
 }
 
 // firstError returns the first non-nil error, so validate reports every
@@ -256,7 +319,7 @@ func writeValidateText(w io.Writer, cfg *config.Config) {
 
 // writeValidateJSON emits the structured validation report. cfg may be
 // nil when load failed; loadErr is non-nil when validation failed.
-func writeValidateJSON(w io.Writer, cfgPath string, cfg *config.Config, loadErr error, integrity *coreintegrity.Report, admission []app.RootAdmission) error {
+func writeValidateJSON(w io.Writer, cfgPath string, cfg *config.Config, loadErr error, integrity *coreintegrity.Report, admission []app.RootAdmission, coreLoops []app.CoreLoopDefinition) error {
 	type rootAdmissionJSON struct {
 		Root     string `json:"root"`
 		RepoPath string `json:"repo_path,omitempty"`
@@ -283,17 +346,19 @@ func writeValidateJSON(w io.Writer, cfgPath string, cfg *config.Config, loadErr 
 	// for scripts piping into jq — even discovery-failure cases get
 	// a path field, possibly empty.
 	result := struct {
-		Path      string                `json:"path"`
-		Valid     bool                  `json:"valid"`
-		Error     string                `json:"error,omitempty"`
-		Summary   map[string]any        `json:"summary,omitempty"`
-		Integrity *coreintegrity.Report `json:"integrity,omitempty"`
-		Roots     []rootAdmissionJSON   `json:"root_admission,omitempty"`
+		Path      string                   `json:"path"`
+		Valid     bool                     `json:"valid"`
+		Error     string                   `json:"error,omitempty"`
+		Summary   map[string]any           `json:"summary,omitempty"`
+		Integrity *coreintegrity.Report    `json:"integrity,omitempty"`
+		Roots     []rootAdmissionJSON      `json:"root_admission,omitempty"`
+		CoreLoops []app.CoreLoopDefinition `json:"core_loop_definitions,omitempty"`
 	}{
 		Path:      cfgPath,
 		Valid:     loadErr == nil,
 		Integrity: integrity,
 		Roots:     roots,
+		CoreLoops: coreLoops,
 	}
 	if loadErr != nil {
 		result.Error = loadErr.Error()
@@ -316,4 +381,14 @@ func writeValidateJSON(w io.Writer, cfgPath string, cfg *config.Config, loadErr 
 	enc := json.NewEncoder(w)
 	enc.SetIndent("", "  ")
 	return enc.Encode(result)
+}
+
+// indentBlock prefixes every line of s, so a multi-line error stays
+// visibly part of the entry it belongs to.
+func indentBlock(s, prefix string) string {
+	lines := strings.Split(strings.TrimRight(s, "\n"), "\n")
+	for i, line := range lines {
+		lines[i] = prefix + strings.TrimSpace(line)
+	}
+	return strings.Join(lines, "\n")
 }

--- a/cmd/thane/validate_test.go
+++ b/cmd/thane/validate_test.go
@@ -416,3 +416,15 @@ func TestRunValidate_ReportsCoreLoopDefinitions(t *testing.T) {
 		t.Fatalf("report should name the loop the document defines:\n%s", out)
 	}
 }
+
+// TestIndentBlockPreservesInteriorStructure guards against re-trimming.
+// A yaml decode error indents its detail lines under the message they
+// belong to; flattening them discards structure the error author put
+// there, which is the same mistake as trimming porcelain columns.
+func TestIndentBlockPreservesInteriorStructure(t *testing.T) {
+	got := indentBlock("yaml: unmarshal errors:\n  line 40: field sleep_mim not found\n", "      ")
+	want := "      yaml: unmarshal errors:\n        line 40: field sleep_mim not found"
+	if got != want {
+		t.Errorf("indentBlock() =\n%q\nwant\n%q", got, want)
+	}
+}

--- a/cmd/thane/validate_test.go
+++ b/cmd/thane/validate_test.go
@@ -313,3 +313,106 @@ func TestAdmissionReporting(t *testing.T) {
 		})
 	}
 }
+
+// TestCoreLoopReporting covers the mapping from what a definition
+// document did to what an operator sees and what the exit code says.
+// The parsing itself is tested against the real loader in internal/app;
+// what matters here is that a document which will not load stops
+// `validate && serve` while a document that merely hangs in the wrong
+// place does not — since that is exactly how serve treats them.
+func TestCoreLoopReporting(t *testing.T) {
+	broken := errors.New("metacognitive.md: field not_a_field not found in type loop.Spec")
+
+	tests := []struct {
+		name        string
+		definitions []app.CoreLoopDefinition
+		wantErr     bool
+		wantOut     []string
+	}{
+		{
+			name: "loadable documents report their generated tools",
+			definitions: []app.CoreLoopDefinition{{
+				File:       "metacognitive.md",
+				Name:       "metacognitive",
+				ParentName: "cognition",
+				Tools:      []string{"publish_output_metacognitive_state"},
+			}},
+			wantOut: []string{"✓ Core loop definitions: 1", "metacognitive → cognition", "publish_output_metacognitive_state"},
+		},
+		{
+			name: "a document that will not load fails the guard",
+			definitions: []app.CoreLoopDefinition{{
+				File:  "metacognitive.md",
+				Err:   broken,
+				Error: broken.Error(),
+			}},
+			wantErr: true,
+			wantOut: []string{"✗ Core loop definitions: 1 of 1 failed", "not_a_field"},
+		},
+		{
+			name: "a warning is printed but certifies",
+			definitions: []app.CoreLoopDefinition{{
+				File:     "metacognitive.md",
+				Name:     "metacognitive",
+				Warnings: []string{"declares no parent_name, so this core service loop will hang at the graph root"},
+			}},
+			wantOut: []string{"metacognitive → (root)", "! declares no parent_name"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			writeCoreLoopText(&buf, tt.definitions)
+			err := coreLoopError(tt.definitions)
+
+			switch {
+			case tt.wantErr && err == nil:
+				t.Fatal("a document that will not load must fail validate; serve refuses over it")
+			case tt.wantErr && exitCodeFor(err) != ExitTerminal:
+				t.Fatalf("exit code = %d, want %d — editing the document is the only fix", exitCodeFor(err), ExitTerminal)
+			case !tt.wantErr && err != nil:
+				t.Fatalf("coreLoopError = %v, want nil", err)
+			}
+			for _, want := range tt.wantOut {
+				if !strings.Contains(buf.String(), want) {
+					t.Errorf("output missing %q:\n%s", want, buf.String())
+				}
+			}
+		})
+	}
+}
+
+// TestRunValidate_ReportsCoreLoopDefinitions is the end-to-end half:
+// a definition document in the workspace's core root reaches the report
+// without the operator naming it. This is the check that was missing —
+// before it, a malformed document was discovered by a boot on the host
+// it was installed to.
+func TestRunValidate_ReportsCoreLoopDefinitions(t *testing.T) {
+	workspace := t.TempDir()
+	loopsDir := filepath.Join(workspace, "core", "loops")
+	if err := os.MkdirAll(loopsDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(workspace, "core", "config.yaml"), []byte(minimalValidConfig), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	document := "# Ranch\n\n## Spec\n\n```yaml\nname: ranch_watch\nenabled: true\noperation: service\nsleep_min: 15m\nsleep_max: 12h\nsleep_default: 1h\njitter: 0.2\n```\n\n## Task\n\nWatch.\n"
+	if err := os.WriteFile(filepath.Join(loopsDir, "ranch.md"), []byte(document), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	var buf bytes.Buffer
+	// core is not a git repository here, so integrity fails and validate
+	// returns that error first. The loop report is still printed, which
+	// is what this asserts: sections report independently.
+	_ = runValidate(&buf, "", workspace, "text")
+
+	out := buf.String()
+	if !strings.Contains(out, "Core loop definitions") {
+		t.Fatalf("a workspace instance with core/loops should get a definition report:\n%s", out)
+	}
+	if !strings.Contains(out, "ranch_watch") {
+		t.Fatalf("report should name the loop the document defines:\n%s", out)
+	}
+}

--- a/internal/app/core_loop_report.go
+++ b/internal/app/core_loop_report.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"sort"
@@ -68,6 +69,13 @@ type CoreLoopDefinition struct {
 // OK reports whether this document would load at boot.
 func (d CoreLoopDefinition) OK() bool { return d.Err == nil }
 
+// newFailedCoreLoopReport builds an entry for something that never got
+// as far as parsing. Err and Error carry the same value: one is what
+// callers branch on, the other is what the JSON report renders.
+func newFailedCoreLoopReport(file string, err error) CoreLoopDefinition {
+	return CoreLoopDefinition{File: file, Err: err, Error: err.Error()}
+}
+
 // CheckCoreLoopDefinitions reads every definition document under
 // <core>/loops and reports what each one would produce.
 //
@@ -101,15 +109,31 @@ func CheckCoreLoopDefinitions(cfg *config.Config) []CoreLoopDefinition {
 	dir = filepath.Join(dir, coreLoopsDirName)
 	entries, err := os.ReadDir(dir)
 	if err != nil {
-		return nil
+		// A missing directory is ordinary and reports nothing. Anything
+		// else — unreadable, a permissions problem, a broken mount — is
+		// a finding: the loader refuses to boot over it, so a pre-flight
+		// check that stayed silent would certify a directory serve
+		// cannot read.
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return []CoreLoopDefinition{newFailedCoreLoopReport(coreLoopsDirName, fmt.Errorf("read %s: %w", dir, err))}
 	}
 
 	names := make([]string, 0, len(entries))
+	// Recorded rather than skipped. The loader refuses a symlink here —
+	// it would read content from outside the signed root while looking
+	// like part of it — so passing over one would let this check
+	// certify a directory serve is about to reject.
+	irregular := make(map[string]os.FileMode, len(entries))
 	for _, entry := range entries {
 		if entry.IsDir() || !strings.EqualFold(filepath.Ext(entry.Name()), ".md") {
 			continue
 		}
 		names = append(names, entry.Name())
+		if !entry.Type().IsRegular() {
+			irregular[entry.Name()] = entry.Type()
+		}
 	}
 	sort.Strings(names)
 
@@ -119,6 +143,10 @@ func CheckCoreLoopDefinitions(cfg *config.Config) []CoreLoopDefinition {
 
 	results := make([]CoreLoopDefinition, 0, len(names))
 	for _, name := range names {
+		if mode, bad := irregular[name]; bad {
+			results = append(results, newFailedCoreLoopReport(name, errNotRegularCoreLoopFile(filepath.Join(dir, name), mode)))
+			continue
+		}
 		result := CoreLoopDefinition{File: name}
 		spec, err := decodeCoreLoopDefinition(filepath.Join(dir, name))
 		if err != nil {

--- a/internal/app/core_loop_report.go
+++ b/internal/app/core_loop_report.go
@@ -1,0 +1,166 @@
+package app
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/nugget/thane-ai-agent/internal/platform/config"
+	looppkg "github.com/nugget/thane-ai-agent/internal/runtime/loop"
+)
+
+// CoreAuthoringError marks a boot failure caused by authored content in
+// the core root rather than by the environment around it.
+//
+// The distinction decides whether a supervisor should retry. A database
+// that will not open, a model endpoint that is unreachable, a port
+// already bound — those resolve on their own or after something else
+// changes, and restarting is the right response. A loop definition that
+// does not parse resolves only when a person edits the document, and
+// every restart between now and then re-reads the same bytes and fails
+// the same way. Retrying it is a crash loop with the appearance of
+// activity.
+type CoreAuthoringError struct{ Err error }
+
+func (e *CoreAuthoringError) Error() string { return e.Err.Error() }
+
+func (e *CoreAuthoringError) Unwrap() error { return e.Err }
+
+// coreAuthoring wraps err as authored-content failure, or returns nil
+// for a nil error so call sites can wrap unconditionally.
+func coreAuthoring(err error) error {
+	if err == nil {
+		return nil
+	}
+	return &CoreAuthoringError{Err: err}
+}
+
+// CoreLoopDefinition is one definition document as a pre-flight check
+// sees it: what loaded, what it declares, and what is worth saying about
+// it before the loop ever runs.
+type CoreLoopDefinition struct {
+	// File is the document's base name, which is how every parse error
+	// this package raises identifies it.
+	File string `json:"file"`
+	// Name is the loop the document defines, empty when it did not parse.
+	Name string `json:"name,omitempty"`
+	// ParentName is where the loop will hang in the graph. Empty means
+	// the root, which for a core service loop is almost always a mistake
+	// and gets a warning below.
+	ParentName string `json:"parent_name,omitempty"`
+	// Tools are the output tools this definition generates, which is the
+	// most direct evidence that a facet or working-notes declaration
+	// landed the way its author meant.
+	Tools []string `json:"tools,omitempty"`
+	// SleepMin and SleepMax report the self-pacing envelope.
+	SleepMin time.Duration `json:"sleep_min,omitempty"`
+	SleepMax time.Duration `json:"sleep_max,omitempty"`
+	// Warnings are advisory: the document loaded and the loop will run.
+	Warnings []string `json:"warnings,omitempty"`
+	// Err is the parse failure, which serve would refuse to start over.
+	Err error `json:"-"`
+	// Error carries Err for the JSON report.
+	Error string `json:"error,omitempty"`
+}
+
+// OK reports whether this document would load at boot.
+func (d CoreLoopDefinition) OK() bool { return d.Err == nil }
+
+// CheckCoreLoopDefinitions reads every definition document under
+// <core>/loops and reports what each one would produce.
+//
+// It differs from [loadCoreLoopDefinitions] in one deliberate way: that
+// function stops at the first bad document, because a boot with a
+// definition silently absent is worse than a boot that refuses. This one
+// parses every document and reports all of them, because an operator
+// fixing a directory wants the whole list rather than one error at a
+// time. The two are checking the same contract for different audiences,
+// and the parser they share is what keeps them honest.
+//
+// A core with no loops directory returns nil: an install that defines no
+// loops in its root is ordinary, not a finding.
+func CheckCoreLoopDefinitions(cfg *config.Config) []CoreLoopDefinition {
+	if cfg == nil {
+		return nil
+	}
+	// Paths first, then the derivation. Boot reads Paths["core"], but
+	// that map is assembled inside App.New and a pre-flight check runs
+	// with nothing but a loaded config. The two cannot disagree —
+	// documentRootPaths overwrites any configured core entry with this
+	// same derivation — so falling back to it reports on the directory
+	// serve would read rather than on nothing at all.
+	dir := strings.TrimSpace(cfg.Paths["core"])
+	if dir == "" {
+		dir = strings.TrimSpace(cfg.CoreRoot())
+	}
+	if dir == "" {
+		return nil
+	}
+	dir = filepath.Join(dir, coreLoopsDirName)
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil
+	}
+
+	names := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.EqualFold(filepath.Ext(entry.Name()), ".md") {
+			continue
+		}
+		names = append(names, entry.Name())
+	}
+	sort.Strings(names)
+
+	// Reported rather than merely counted: two documents defining one
+	// loop is a boot failure, and the operator needs to know which two.
+	definedIn := make(map[string]string, len(names))
+
+	results := make([]CoreLoopDefinition, 0, len(names))
+	for _, name := range names {
+		result := CoreLoopDefinition{File: name}
+		spec, err := decodeCoreLoopDefinition(filepath.Join(dir, name))
+		if err != nil {
+			result.Err = err
+			result.Error = err.Error()
+			results = append(results, result)
+			continue
+		}
+		result.Name = strings.TrimSpace(spec.Name)
+		result.ParentName = spec.ParentName
+		result.SleepMin, result.SleepMax = spec.SleepMin, spec.SleepMax
+		for _, output := range spec.Outputs {
+			result.Tools = append(result.Tools, output.ToolName())
+		}
+		if other, dup := definedIn[result.Name]; dup {
+			result.Warnings = append(result.Warnings,
+				"defines the loop "+result.Name+", which "+other+" also defines; one document is one loop, and this directory will not load")
+		}
+		definedIn[result.Name] = name
+		result.Warnings = append(result.Warnings, coreLoopDefinitionWarnings(spec)...)
+		results = append(results, result)
+	}
+	return results
+}
+
+// coreLoopDefinitionWarnings collects the advisory findings for one
+// parsed definition: the general authoring warnings every persistable
+// spec is checked against, plus the one that only applies to a document
+// in the core root.
+func coreLoopDefinitionWarnings(spec looppkg.Spec) []string {
+	var warnings []string
+	if _, isCoreService := coreServiceLoopByName[strings.TrimSpace(spec.Name)]; isCoreService && strings.TrimSpace(spec.ParentName) == "" {
+		// The built-in path parents these three under cognition after
+		// building the spec, and a document takes precedence over that
+		// path entirely — so a document that says nothing about its
+		// parent does not inherit the default, it lands at the root.
+		// Silent re-parenting empties the container an operator can see
+		// and gives no sign why.
+		warnings = append(warnings, "declares no parent_name, so this core service loop will hang at the graph root rather than under "+cognitionContainerName+"; a definition document does not inherit the built-in parent")
+	}
+	for _, warning := range looppkg.BuildDefinitionWarnings(spec) {
+		warnings = append(warnings, warning.Message)
+	}
+	return warnings
+}

--- a/internal/app/core_loop_report_test.go
+++ b/internal/app/core_loop_report_test.go
@@ -2,6 +2,8 @@ package app
 
 import (
 	"errors"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -196,5 +198,58 @@ func TestMalformedDefinitionIsAuthoringNotEnvironment(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "broken.md") {
 		t.Errorf("err = %v, want the file named", err)
+	}
+}
+
+// TestCoreLoopReportSurfacesAnUnreadableDirectory covers the gap between
+// "no loops here" and "cannot tell". The loader refuses to boot over a
+// directory it cannot read; a report that returned nothing for the same
+// condition would certify an instance about to be rejected, which is the
+// exact drift this check exists to close.
+func TestCoreLoopReportSurfacesAnUnreadableDirectory(t *testing.T) {
+	core := writeCoreLoop(t, map[string]string{"metacognitive.md": facetedCoreLoop})
+	dir := filepath.Join(core, coreLoopsDirName)
+	if err := os.Chmod(dir, 0o000); err != nil {
+		t.Skipf("cannot remove read permission: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(dir, 0o755) })
+	if _, err := os.ReadDir(dir); err == nil {
+		t.Skip("directory is still readable (running as root?)")
+	}
+
+	if _, err := loadCoreLoopDefinitions(core); err == nil {
+		t.Fatal("loadCoreLoopDefinitions accepted an unreadable directory")
+	}
+	reports := CheckCoreLoopDefinitions(coreLoopConfig(core))
+	if len(reports) != 1 || reports[0].OK() {
+		t.Fatalf("reports = %#v, want one failure for the unreadable directory", reports)
+	}
+}
+
+// TestCoreLoopReportRefusesASymlinkTheLoaderRefuses mirrors the loader's
+// regular-file rule. A symlink here reads content from outside the
+// signed root while looking like part of it, which is the one thing a
+// definition living in core is meant to rule out — so the check that
+// runs before a boot has to refuse exactly what the boot refuses.
+func TestCoreLoopReportRefusesASymlinkTheLoaderRefuses(t *testing.T) {
+	core := writeCoreLoop(t, map[string]string{"metacognitive.md": facetedCoreLoop})
+	outside := filepath.Join(t.TempDir(), "elsewhere.md")
+	if err := os.WriteFile(outside, []byte(facetedCoreLoop), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	link := filepath.Join(core, coreLoopsDirName, "smuggled.md")
+	if err := os.Symlink(outside, link); err != nil {
+		t.Skipf("cannot create symlink: %v", err)
+	}
+
+	if _, err := loadCoreLoopDefinitions(core); err == nil {
+		t.Fatal("loadCoreLoopDefinitions accepted a symlinked definition")
+	}
+	report := findCoreLoopReport(t, CheckCoreLoopDefinitions(coreLoopConfig(core)), "smuggled.md")
+	if report.OK() {
+		t.Fatal("the report certifies a symlink the loader refuses")
+	}
+	if !strings.Contains(report.Error, "not a regular file") {
+		t.Errorf("error = %q, want the loader's own refusal", report.Error)
 	}
 }

--- a/internal/app/core_loop_report_test.go
+++ b/internal/app/core_loop_report_test.go
@@ -1,0 +1,200 @@
+package app
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/nugget/thane-ai-agent/internal/platform/config"
+)
+
+// facetedCoreLoop declares the write interface a curator loop gets: a
+// faceted maintained document and the private notes beside it. The
+// report exists so an author can see, before a restart, that those two
+// declarations produced the two tools they meant.
+const facetedCoreLoop = "# Metacognitive\n\n" +
+	"## Spec\n\n" +
+	"```yaml\n" +
+	"name: metacognitive\n" +
+	"parent_name: cognition\n" +
+	"enabled: true\n" +
+	"operation: service\n" +
+	"sleep_min: 15m\n" +
+	"sleep_max: 1h\n" +
+	"sleep_default: 30m\n" +
+	"jitter: 0.2\n" +
+	"outputs:\n" +
+	"    - name: metacognitive_state\n" +
+	"      type: maintained_document\n" +
+	"      ref: core:metacognitive.md\n" +
+	"      facets:\n" +
+	"        - name: status_line\n" +
+	"          format: plain\n" +
+	"        - digest\n" +
+	"    - name: metacognitive_notes\n" +
+	"      type: working_notes\n" +
+	"      ref: core:metacognitive-notes.md\n" +
+	"```\n\n" +
+	"## Task\n\nWatch.\n"
+
+// coreLoopConfig builds the config as boot sees it, with the core root
+// already resolved into the path map. The other half — a config that has
+// only been loaded, where the report derives the path itself — is
+// covered end to end in cmd/thane.
+func coreLoopConfig(core string) *config.Config {
+	return &config.Config{Paths: map[string]string{"core": core}}
+}
+
+func findCoreLoopReport(t *testing.T, reports []CoreLoopDefinition, file string) CoreLoopDefinition {
+	t.Helper()
+	for _, report := range reports {
+		if report.File == file {
+			return report
+		}
+	}
+	t.Fatalf("%s is absent from the report: %#v", file, reports)
+	return CoreLoopDefinition{}
+}
+
+// TestCoreLoopReportNamesWhatTheDocumentProduces is the point of the
+// pre-flight check: the declaration an author writes is one thing and
+// the tools the loop gets is another, and only the second one is
+// evidence the facet block landed.
+func TestCoreLoopReportNamesWhatTheDocumentProduces(t *testing.T) {
+	core := writeCoreLoop(t, map[string]string{"metacognitive.md": facetedCoreLoop})
+
+	report := findCoreLoopReport(t, CheckCoreLoopDefinitions(coreLoopConfig(core)), "metacognitive.md")
+	if !report.OK() {
+		t.Fatalf("report.Err = %v, want a clean load", report.Err)
+	}
+	if report.Name != "metacognitive" || report.ParentName != "cognition" {
+		t.Errorf("name/parent = %q/%q, want metacognitive/cognition", report.Name, report.ParentName)
+	}
+	want := []string{"publish_output_metacognitive_state", "replace_output_metacognitive_notes"}
+	if strings.Join(report.Tools, ",") != strings.Join(want, ",") {
+		t.Errorf("tools = %v, want %v — a faceted output publishes and its notes replace", report.Tools, want)
+	}
+	if len(report.Warnings) != 0 {
+		t.Errorf("warnings = %v, want none", report.Warnings)
+	}
+}
+
+// TestCoreLoopReportCoversEveryDocument is where the report and the
+// loader deliberately differ. The loader stops at the first bad file
+// because booting with a definition silently absent is worse than
+// refusing; the report keeps going because an operator repairing a
+// directory should not have to rerun it once per mistake.
+func TestCoreLoopReportCoversEveryDocument(t *testing.T) {
+	core := writeCoreLoop(t, map[string]string{
+		"aaa_broken.md": "# Broken\n\n## Spec\n\n```yaml\nname: broken\nnot_a_field: 1\n```\n",
+		"zzz_good.md":   facetedCoreLoop,
+	})
+
+	if _, err := loadCoreLoopDefinitions(core); err == nil {
+		t.Fatal("loadCoreLoopDefinitions accepted a malformed document")
+	}
+
+	reports := CheckCoreLoopDefinitions(coreLoopConfig(core))
+	if len(reports) != 2 {
+		t.Fatalf("reported %d documents, want both: %#v", len(reports), reports)
+	}
+	broken := findCoreLoopReport(t, reports, "aaa_broken.md")
+	if broken.OK() {
+		t.Error("the malformed document reports as loadable")
+	}
+	if !strings.Contains(broken.Error, "not_a_field") {
+		t.Errorf("error = %q, want it to name the unrecognized key", broken.Error)
+	}
+	if good := findCoreLoopReport(t, reports, "zzz_good.md"); !good.OK() {
+		t.Errorf("a valid document was reported bad because another failed: %v", good.Err)
+	}
+}
+
+// TestCoreLoopReportWarnsOnAnUnparentedCoreLoop covers the trap the
+// report was written for. The built-in path parents ego, metacognitive,
+// and archivist under cognition after building the spec, and a document
+// replaces that path entirely — so a document that says nothing about
+// its parent does not inherit the default, it moves the loop to the
+// root, and nothing about a successful boot says so.
+func TestCoreLoopReportWarnsOnAnUnparentedCoreLoop(t *testing.T) {
+	core := writeCoreLoop(t, map[string]string{
+		"metacognitive.md": strings.Replace(facetedCoreLoop, "parent_name: cognition\n", "", 1),
+	})
+
+	report := findCoreLoopReport(t, CheckCoreLoopDefinitions(coreLoopConfig(core)), "metacognitive.md")
+	if !report.OK() {
+		t.Fatalf("report.Err = %v; the document is valid, just unparented", report.Err)
+	}
+	if len(report.Warnings) == 0 {
+		t.Fatal("an unparented core service loop produced no warning")
+	}
+	if !strings.Contains(report.Warnings[0], cognitionContainerName) {
+		t.Errorf("warning = %q, want it to name the parent that was not inherited", report.Warnings[0])
+	}
+}
+
+// TestCoreLoopReportLeavesAnOrdinaryLoopUnparented is the other half.
+// Only the core service loops have a parent they are expected to
+// inherit; warning about every root-level definition would train an
+// operator to ignore the one that matters.
+func TestCoreLoopReportLeavesAnOrdinaryLoopUnparented(t *testing.T) {
+	core := writeCoreLoop(t, map[string]string{"ranch.md": minimalCoreLoop})
+
+	report := findCoreLoopReport(t, CheckCoreLoopDefinitions(coreLoopConfig(core)), "ranch.md")
+	for _, warning := range report.Warnings {
+		if strings.Contains(warning, "parent_name") {
+			t.Errorf("warning = %q, want no parent warning for an ordinary loop", warning)
+		}
+	}
+}
+
+// TestCoreLoopReportFlagsTwoDocumentsForOneLoop names both files. The
+// loader refuses this directory, and "one document is one loop" is not
+// actionable without knowing which two collided.
+func TestCoreLoopReportFlagsTwoDocumentsForOneLoop(t *testing.T) {
+	core := writeCoreLoop(t, map[string]string{
+		"a_metacognitive.md": facetedCoreLoop,
+		"b_metacognitive.md": facetedCoreLoop,
+	})
+
+	report := findCoreLoopReport(t, CheckCoreLoopDefinitions(coreLoopConfig(core)), "b_metacognitive.md")
+	if len(report.Warnings) == 0 || !strings.Contains(report.Warnings[0], "a_metacognitive.md") {
+		t.Errorf("warnings = %v, want the other file named", report.Warnings)
+	}
+}
+
+// TestCoreLoopReportIsSilentWithoutADirectory keeps the check from
+// inventing a finding. An install that defines no loops in its root is
+// ordinary.
+func TestCoreLoopReportIsSilentWithoutADirectory(t *testing.T) {
+	if reports := CheckCoreLoopDefinitions(coreLoopConfig(t.TempDir())); reports != nil {
+		t.Errorf("reports = %#v, want nil for a core with no loops directory", reports)
+	}
+	if reports := CheckCoreLoopDefinitions(&config.Config{}); reports != nil {
+		t.Errorf("reports = %#v, want nil when no core root is configured", reports)
+	}
+}
+
+// TestMalformedDefinitionIsAuthoringNotEnvironment is what stops the
+// crash loop. thane-agent-macos restarts the binary when it exits
+// non-zero, and a document that does not parse produces the identical
+// failure on every attempt — so the error has to be distinguishable
+// from the transient kind before the CLI can decide to stop.
+func TestMalformedDefinitionIsAuthoringNotEnvironment(t *testing.T) {
+	core := writeCoreLoop(t, map[string]string{
+		"broken.md": "# Broken\n\n## Spec\n\n```yaml\nname: broken\nnot_a_field: 1\n```\n",
+	})
+	app := &App{cfg: coreLoopConfig(core)}
+
+	_, err := app.buildLoopDefinitionBaseSpecs()
+	if err == nil {
+		t.Fatal("buildLoopDefinitionBaseSpecs accepted a malformed document")
+	}
+	var authoring *CoreAuthoringError
+	if !errors.As(err, &authoring) {
+		t.Fatalf("err = %v (%T), want a CoreAuthoringError so the CLI can exit terminally", err, err)
+	}
+	if !strings.Contains(err.Error(), "broken.md") {
+		t.Errorf("err = %v, want the file named", err)
+	}
+}

--- a/internal/app/loop_definition_hydration.go
+++ b/internal/app/loop_definition_hydration.go
@@ -15,9 +15,13 @@ func (a *App) buildLoopDefinitionBaseSpecs() ([]looppkg.Spec, error) {
 	// appends only what is not already declared, so a definition living
 	// in the signed core root takes precedence over the same-named
 	// built-in without needing a rule of its own.
+	// Wrapped as authored content: a definition that does not parse is
+	// fixed by editing the document, never by starting again, so the CLI
+	// exits terminally instead of leaving a supervisor to retry the same
+	// bytes forever.
 	coreDefinitions, err := loadCoreLoopDefinitions(a.cfg.Paths["core"])
 	if err != nil {
-		return nil, fmt.Errorf("core loop definitions: %w", err)
+		return nil, coreAuthoring(fmt.Errorf("core loop definitions: %w", err))
 	}
 	baseDefinitions := append(coreDefinitions, a.cfg.Loops.Definitions...)
 	seen := make(map[string]struct{}, len(baseDefinitions))

--- a/internal/app/loop_definitions_core_dir.go
+++ b/internal/app/loop_definitions_core_dir.go
@@ -97,7 +97,7 @@ func loadCoreLoopDefinitions(corePath string) ([]looppkg.Spec, error) {
 		// out. Refused loudly rather than skipped: a definition silently
 		// absent is how a loop stops existing without anyone noticing.
 		if !entry.Type().IsRegular() {
-			return nil, fmt.Errorf("%s is not a regular file (%s); a loop definition must be a file in the signed root, not a link to content outside it", filepath.Join(dir, entry.Name()), entry.Type())
+			return nil, errNotRegularCoreLoopFile(filepath.Join(dir, entry.Name()), entry.Type())
 		}
 		names = append(names, entry.Name())
 	}
@@ -123,6 +123,15 @@ func loadCoreLoopDefinitions(corePath string) ([]looppkg.Spec, error) {
 		specs = append(specs, spec)
 	}
 	return specs, nil
+}
+
+// errNotRegularCoreLoopFile is the refusal both the loader and the
+// pre-flight report raise for a symlink or device node among the
+// definitions. Shared rather than written twice: the report exists to
+// predict what the loader will do, and two copies of a rule are two
+// rules the moment one of them is edited.
+func errNotRegularCoreLoopFile(path string, mode os.FileMode) error {
+	return fmt.Errorf("%s is not a regular file (%s); a loop definition must be a file in the signed root, not a link to content outside it", path, mode)
 }
 
 // decodeCoreLoopDefinition reads one definition document.

--- a/internal/platform/coreintegrity/coreintegrity.go
+++ b/internal/platform/coreintegrity/coreintegrity.go
@@ -334,7 +334,7 @@ func (c checker) configTracked(r *Report, headOK bool) bool {
 	}
 	if _, err := c.git("cat-file", "-e", "HEAD:"+c.configName); err != nil {
 		r.Checks = append(r.Checks, Check{Name: "config_committed", Status: StatusFail,
-			Detail: c.configName + " is not committed in core, so the running config has no change history",
+			Detail: c.configName + " is not committed in core, so the config on disk has no change history",
 			Fix:    "git -C " + c.core + " add " + c.configName + " && git -C " + c.core + " commit -S -m 'adopt runtime config into core'"})
 		return false
 	}
@@ -357,8 +357,13 @@ func (c checker) coreClean(r *Report, headOK bool) {
 		return
 	}
 	if out != "" {
+		// "on disk" rather than "running": this package serves both the
+		// boot gate, where something is about to run, and `thane
+		// validate`, where nothing is. A detail that assumes a live
+		// process is false for half its readers, and it is false exactly
+		// when an operator is checking a host before starting it.
 		r.Checks = append(r.Checks, Check{Name: "core_clean", Status: StatusFail,
-			Detail: "core has uncommitted changes to tracked files, so what is running differs from what is signed:\n" + indent(out),
+			Detail: "core has uncommitted changes to tracked files, so what is on disk differs from what is signed:\n" + indent(out),
 			Fix:    "review with: git -C " + c.core + " diff, then commit them: git -C " + c.core + " commit -aS -m 'core update'"})
 		return
 	}
@@ -366,7 +371,7 @@ func (c checker) coreClean(r *Report, headOK bool) {
 		Detail: "no uncommitted changes to tracked files"})
 }
 
-// configSigned verifies that the running config is covered by a commit
+// configSigned verifies that the config in core is covered by a commit
 // signed by a key the instance trusts. This is the check the others
 // exist to make meaningful: history without signatures records what
 // changed but not who was entitled to change it.
@@ -386,7 +391,7 @@ func (c checker) configSigned(r *Report, configOK bool) {
 
 	if status, err := c.git("status", "--porcelain", "--", c.configName); err == nil && strings.TrimSpace(status) != "" {
 		r.Checks = append(r.Checks, Check{Name: "config_signed", Status: StatusFail,
-			Detail: c.configName + " has uncommitted changes, so the running config is not the one any signature covers",
+			Detail: c.configName + " has uncommitted changes, so the config on disk is not the one any signature covers",
 			Fix:    "git -C " + c.core + " add " + c.configName + " && git -C " + c.core + " commit -S -m 'update runtime config'"})
 		return
 	}

--- a/internal/platform/coreintegrity/coreintegrity.go
+++ b/internal/platform/coreintegrity/coreintegrity.go
@@ -200,7 +200,15 @@ func (c checker) git(args ...string) (string, error) {
 		}
 		return "", err
 	}
-	return strings.TrimSpace(string(out)), nil
+	// Only the trailing newline git appends, never leading whitespace.
+	// In `status --porcelain` the first two characters are the staged and
+	// unstaged columns, so a leading space is data: " M path" is modified
+	// in the working tree and "M  path" is staged. Trimming it turned the
+	// first entry of every dirty report into a claim about the index that
+	// was not true, and did it to exactly one line, so the only symptom
+	// was a column that did not line up. Callers wanting a scalar trim
+	// their own value.
+	return strings.TrimRight(string(out), "\n"), nil
 }
 
 func (c checker) coreDirectory(r *Report) bool {

--- a/internal/platform/coreintegrity/coreintegrity_test.go
+++ b/internal/platform/coreintegrity/coreintegrity_test.go
@@ -495,3 +495,61 @@ func TestConfigSignedFallsBackToSeedSigners(t *testing.T) {
 		t.Fatalf("config_signed = %s (%s), want pass: a declared seed signer must keep its authority over core", got.Status, got.Detail)
 	}
 }
+
+// TestCoreCleanPreservesPorcelainStatusColumns guards a report that
+// misstated the thing it exists to report.
+//
+// `git status --porcelain` puts the staged state in column one and the
+// working-tree state in column two, so " M path" is an unstaged edit and
+// "M  path" is a staged one. The output was trimmed as a whole, which
+// removed the leading space of the first entry only — turning one file
+// per report into a claim about the index that was not true, while every
+// other entry stayed correct. A misaligned column was the only symptom.
+func TestCoreCleanPreservesPorcelainStatusColumns(t *testing.T) {
+	workspace, core := newCore(t)
+	gitInit(t, core)
+	if err := os.WriteFile(filepath.Join(core, ".gitignore"), []byte("*.key\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(core, "config.yaml"), []byte("listen:\n  port: 8080\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	// Two tracked files so the report has a first entry and a second one
+	// to compare it against; the bug was invisible with only one.
+	first := filepath.Join(core, "aaa.md")
+	second := filepath.Join(core, "bbb.md")
+	for _, path := range []string{first, second} {
+		if err := os.WriteFile(path, []byte("before\n"), 0o644); err != nil {
+			t.Fatalf("WriteFile: %v", err)
+		}
+	}
+	gitCommitAll(t, core, "core baseline")
+	for _, path := range []string{first, second} {
+		if err := os.WriteFile(path, []byte("after\n"), 0o644); err != nil {
+			t.Fatalf("WriteFile: %v", err)
+		}
+	}
+
+	got := checkByName(t, run(t, workspace), "core_clean")
+	if got.Status != StatusFail {
+		t.Fatalf("edited tracked files must fail core_clean: %+v", got)
+	}
+	// Both files are unstaged, so both must carry the identical
+	// two-column prefix. Compared after stripping the report's own
+	// indent, because a Contains check would match the trimmed line
+	// against the indent's trailing space and pass either way.
+	const reportIndent = "      "
+	lines := strings.Split(got.Detail, "\n")[1:]
+	if len(lines) != 2 {
+		t.Fatalf("expected one line per edited file, got:\n%s", got.Detail)
+	}
+	for _, line := range lines {
+		entry, ok := strings.CutPrefix(line, reportIndent)
+		if !ok {
+			t.Fatalf("line is not indented into the report: %q", line)
+		}
+		if !strings.HasPrefix(entry, " M ") {
+			t.Errorf("entry = %q, want the porcelain unstaged prefix %q; a trimmed leading column reports a working-tree edit as staged", entry, " M ")
+		}
+	}
+}


### PR DESCRIPTION
Loop definitions moved into the core root in #1310/#1311, and the check that reads them did not move with them. `thane validate` covers config, integrity, and root admission; the documents under `<core>/loops` are parsed for the first time by `thane serve`, on whatever machine the document was installed to. Checking this branch's own metacognitive rewrite meant writing a throwaway test harness against the unexported parser, which is the tell.

Two failures, one theme: an operator should learn about a bad document before it reaches a host, and failing that, the host should stop rather than spin.

## Validate reports the directory

Every document under `<core>/loops`: the loop it defines, where it will hang in the graph, and the output tools it generates.

```
✗ Core loop definitions: 1 of 3 failed to load
  ✓ archivist.md             archivist → cognition
      tools: replace_output_archivist_state
  ✗ ego.md
      ego.md: yaml: unmarshal errors:
      line 40: field sleep_mim not found in type loop.Spec
  ✓ metacognitive.md         metacognitive → (root)
      tools: publish_output_metacognitive_state, replace_output_metacognitive_notes
      ! declares no parent_name, so this core service loop will hang at the graph root rather than under cognition; a definition document does not inherit the built-in parent
```

The tool names are the part worth printing. A `facets` block is a declaration, and `publish_output_metacognitive_state` appearing where `replace_output_*` used to be is the only direct evidence it landed.

The report parses every file where the loader stops at the first bad one. That is deliberate on both sides: a boot must refuse rather than run with a definition silently absent, and an operator repairing a directory should not have to rerun the check once per mistake. They share the parser, so they cannot drift on what "valid" means.

## A malformed definition at boot is terminal

`app.New`'s error returned bare — exit 1 — which tells thane-agent-macos to try again. Every retry re-reads the same bytes and fails the same way: a crash loop with the appearance of activity. `CoreAuthoringError` marks the class the environment cannot fix. A database that will not open resolves on its own; a document that does not parse resolves when someone edits it.

## The parent warning

`buildLoopDefinitionBaseSpecs` parents ego, metacognitive, and archivist under `cognition` only on the built-in path. A document takes precedence over that path entirely, so a document that says nothing about its parent does not inherit the default — it moves the loop to the graph root, and a successful boot gives no sign. Production's three documents carry no `parent_name` today, so the next release would have emptied the cognition container.

Warnings do not fail the guard. A loop hanging in the wrong place still runs, and a check that refuses to certify a working instance is one an operator learns to skip.

## Test plan

- [x] `just ci` clean, no architecture drift
- [x] Faceted document reports both generated tools; ordinary loop reports neither a parent warning nor a false positive
- [x] One bad document among three does not hide the other two
- [x] Malformed definition surfaces as `CoreAuthoringError` from the real boot path and exits 78
- [x] Smoke-tested against production's three definition documents on a temp workspace, clean and failing

Refs #1086