### PR TITLE
The document says where the loop belongs

### DIFF
--- a/internal/app/coreloop_docs_parity_test.go
+++ b/internal/app/coreloop_docs_parity_test.go
@@ -57,8 +57,10 @@ func TestCoreLoopDocsMatchTheGoSpecs(t *testing.T) {
 			if err != nil {
 				t.Fatalf("decodeCoreLoopDefinition: %v", err)
 			}
-			// ParentName is applied by the caller, not carried by either
-			// source, so it is not part of what the document owns.
+			// The document carries parent_name and the Go builder never
+			// did, so this one field is expected to differ. It is checked
+			// against the boot path in
+			// TestBuiltInSpecsNowComeFromTheShippedDocuments instead.
 			got.ParentName = tt.want.ParentName
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Fatalf("document and Go spec disagree.\nfrom document: %#v\nfrom Go:       %#v", got, tt.want)
@@ -137,8 +139,9 @@ func TestBuiltInSpecsNowComeFromTheShippedDocuments(t *testing.T) {
 			if err != nil {
 				t.Fatalf("decodeCoreLoopDefinition: %v", err)
 			}
-			// ParentName is applied by the caller after the spec is built.
-			want.ParentName = got.ParentName
+			if got.ParentName != cognitionContainerName {
+				t.Errorf("parent_name = %q, want %q from the document itself — nothing assigns it afterwards", got.ParentName, cognitionContainerName)
+			}
 			if !reflect.DeepEqual(got, want) {
 				t.Fatalf("the booted spec is not the shipped document's:\ngot  %#v\nwant %#v", got, want)
 			}

--- a/internal/app/loop_definition_builtins.go
+++ b/internal/app/loop_definition_builtins.go
@@ -58,13 +58,15 @@ func mediaServicesEnabled(cfg *config.Config) bool {
 // builtInContainerDefinitionSpecs returns the built-in grouping containers,
 // each gated so an empty container never appears: cognition when any core
 // cognition loop is enabled, home-assistant when HA or MQTT is configured.
-func builtInContainerDefinitionSpecs(cfg *config.Config) []looppkg.Spec {
+// declared is the set of loop names an operator or the core root has
+// already defined, so a container's gate can match its members'.
+func builtInContainerDefinitionSpecs(cfg *config.Config, declared map[string]struct{}) []looppkg.Spec {
 	if cfg == nil {
 		return nil
 	}
 	var specs []looppkg.Spec
 
-	if cfg.Metacognitive.Enabled || cfg.Ego.Enabled || cfg.Archivist.Enabled {
+	if anyCoreServiceLoopWanted(cfg, declared) {
 		specs = append(specs, containerSpec(cognitionContainerName,
 			"Core cognition loops: reflection, identity, and memory."))
 	}
@@ -78,6 +80,33 @@ func builtInContainerDefinitionSpecs(cfg *config.Config) []looppkg.Spec {
 	}
 
 	return specs
+}
+
+// anyCoreServiceLoopWanted reports whether any core service loop will be
+// registered: enabled in config, or defined by a document in the core
+// root. It is the gate for their container, and it has to be exactly the
+// condition buildLoopDefinitionBaseSpecs applies to the members.
+//
+// Config enablement alone was wrong, and became reachable once the
+// documents started declaring parent_name. A definition document is
+// authoritative whether or not config enables its loop, so a
+// config-disabled, document-defined loop named a container that was
+// never built — and an unresolvable parent is dropped with a warning and
+// default-parented to the graph root, which is the silent re-parenting
+// the declared field exists to prevent, arriving through another door.
+//
+// Derived from coreServiceLoops rather than naming the three, so a
+// fourth core loop is covered by existing.
+func anyCoreServiceLoopWanted(cfg *config.Config, declared map[string]struct{}) bool {
+	for _, reg := range coreServiceLoops {
+		if reg.ConfigEnabled(cfg) {
+			return true
+		}
+		if _, ok := declared[reg.Name]; ok {
+			return true
+		}
+	}
+	return false
 }
 
 // containerSpec builds an inert grouping-container definition under core.

--- a/internal/app/loop_definition_hydration.go
+++ b/internal/app/loop_definition_hydration.go
@@ -56,9 +56,11 @@ func (a *App) buildLoopDefinitionBaseSpecs() ([]looppkg.Spec, error) {
 			if err != nil {
 				return nil, fmt.Errorf("%s definition: %w", reg.Name, err)
 			}
-			// The core cognition loops (ego, metacognitive, archivist) live
-			// under the cognition container.
-			spec.ParentName = cognitionContainerName
+			// Parent comes from the document, like everything else about
+			// these loops. It used to be assigned here, which meant a
+			// definition read from core skipped this line and silently
+			// landed at the graph root — the document owned every field
+			// but the one saying where the loop belongs.
 			baseDefinitions = appendMissingDefinition(baseDefinitions, seen, spec)
 		}
 	}

--- a/internal/app/loop_definition_hydration.go
+++ b/internal/app/loop_definition_hydration.go
@@ -30,7 +30,7 @@ func (a *App) buildLoopDefinitionBaseSpecs() ([]looppkg.Spec, error) {
 	}
 	// Grouping containers first, so member loops resolve their ParentName to
 	// a container that's already registered.
-	for _, spec := range builtInContainerDefinitionSpecs(a.cfg) {
+	for _, spec := range builtInContainerDefinitionSpecs(a.cfg, seen) {
 		baseDefinitions = appendMissingDefinition(baseDefinitions, seen, spec)
 	}
 	for _, spec := range builtInServiceDefinitionSpecs(a.cfg) {

--- a/internal/app/loop_definition_hydration_test.go
+++ b/internal/app/loop_definition_hydration_test.go
@@ -365,16 +365,16 @@ func TestBuiltInContainerDefinitionSpecs_Gating(t *testing.T) {
 		return m
 	}
 
-	bare := names(builtInContainerDefinitionSpecs(&config.Config{}))
+	bare := names(builtInContainerDefinitionSpecsForTest(&config.Config{}))
 	if len(bare) != 0 {
 		t.Errorf("bare config seeded a gated container, want none: %v", bare)
 	}
 
-	if cog := names(builtInContainerDefinitionSpecs(coreServiceTestConfig())); !cog[cognitionContainerName] {
+	if cog := names(builtInContainerDefinitionSpecsForTest(coreServiceTestConfig())); !cog[cognitionContainerName] {
 		t.Error("cognition container missing when core loops enabled")
 	}
 
-	ha := names(builtInContainerDefinitionSpecs(&config.Config{
+	ha := names(builtInContainerDefinitionSpecsForTest(&config.Config{
 		MQTT: config.MQTTConfig{Broker: "mqtt://b:1883", DeviceName: "d"},
 	}))
 	if !ha[homeAssistantContainerName] {
@@ -383,7 +383,7 @@ func TestBuiltInContainerDefinitionSpecs_Gating(t *testing.T) {
 
 	// The pollers container appears when any of its members is enabled (media
 	// is the simplest gate — a positive feed-check interval, no Configured()).
-	pol := names(builtInContainerDefinitionSpecs(&config.Config{
+	pol := names(builtInContainerDefinitionSpecsForTest(&config.Config{
 		Media: config.MediaConfig{FeedCheckInterval: 600},
 	}))
 	if !pol[pollersContainerName] {
@@ -511,4 +511,10 @@ func TestHydrateLoopDefinitionSpec_HAStateWatcher(t *testing.T) {
 	if handled != 1 {
 		t.Fatalf("handled = %d, want 1", handled)
 	}
+}
+
+// builtInContainerDefinitionSpecsForTest covers the cases that care only
+// about config, leaving the declared set empty.
+func builtInContainerDefinitionSpecsForTest(cfg *config.Config) []looppkg.Spec {
+	return builtInContainerDefinitionSpecs(cfg, nil)
 }

--- a/internal/app/loop_definitions_core_dir_test.go
+++ b/internal/app/loop_definitions_core_dir_test.go
@@ -529,3 +529,54 @@ func TestCoreDefinitionKeepsItsDeclaredParent(t *testing.T) {
 		t.Errorf("%q is absent, so the declared parent resolves to nothing", cognitionContainerName)
 	}
 }
+
+// TestConfigDisabledDocumentLoopStillGetsItsContainer covers the gap
+// declaring parent_name opened.
+//
+// A definition document is authoritative whether or not config enables
+// its loop, but the container was gated on config enablement alone. So a
+// loop disabled in config and defined by a document named a parent that
+// was never built — and an unresolvable parent_name is dropped with a
+// warning and default-parented to the graph root, which is the silent
+// re-parenting the declared field exists to prevent.
+func TestConfigDisabledDocumentLoopStillGetsItsContainer(t *testing.T) {
+	core := writeCoreLoop(t, map[string]string{
+		"metacognitive.md": strings.NewReplacer(
+			"name: ranch_watch", "name: metacognitive\nparent_name: "+cognitionContainerName,
+		).Replace(minimalCoreLoop),
+	})
+	// Every core service loop disabled: the document is the only reason
+	// this loop exists at all.
+	disabled := testServiceLoopConfig()
+	disabled.Enabled = false
+	app := &App{cfg: &config.Config{
+		Paths:         map[string]string{"core": core},
+		Metacognitive: disabled,
+		Ego:           disabled,
+		Archivist:     disabled,
+	}}
+
+	specs, err := app.buildLoopDefinitionBaseSpecs()
+	if err != nil {
+		t.Fatalf("buildLoopDefinitionBaseSpecs: %v", err)
+	}
+	var loop looppkg.Spec
+	container := false
+	for _, spec := range specs {
+		switch spec.Name {
+		case "metacognitive":
+			loop = spec
+		case cognitionContainerName:
+			container = true
+		}
+	}
+	if loop.Name == "" {
+		t.Fatal("the document defines the loop, so it must be registered even with config disabled")
+	}
+	if loop.ParentName != cognitionContainerName {
+		t.Fatalf("parent_name = %q, want %q", loop.ParentName, cognitionContainerName)
+	}
+	if !container {
+		t.Errorf("%q is absent, so the declared parent resolves to nothing and the loop silently lands at the root", cognitionContainerName)
+	}
+}

--- a/internal/app/loop_definitions_core_dir_test.go
+++ b/internal/app/loop_definitions_core_dir_test.go
@@ -486,3 +486,46 @@ func TestSecondYAMLDocumentInTheSpecBlockIsRefused(t *testing.T) {
 		t.Errorf("error = %v, want it to explain the stray separator", err)
 	}
 }
+
+// TestCoreDefinitionKeepsItsDeclaredParent is what makes the parent a
+// document field rather than a Go assignment. Nothing adds a parent
+// after the spec is built any more, so if the document's value did not
+// survive into the base definitions, ego would boot at the graph root
+// with nothing saying so — which is exactly the failure the assignment
+// used to hide.
+//
+// The container it names is appended after it, and that is fine: startup
+// topologically orders containers before services, so position in this
+// slice does not decide parenting.
+func TestCoreDefinitionKeepsItsDeclaredParent(t *testing.T) {
+	core := writeCoreLoop(t, map[string]string{
+		"ego.md": strings.NewReplacer(
+			"name: ranch_watch", "name: ego\nparent_name: "+cognitionContainerName,
+		).Replace(minimalCoreLoop),
+	})
+	app := &App{cfg: &config.Config{
+		Paths: map[string]string{"core": core},
+		Ego:   testServiceLoopConfig(),
+	}}
+
+	specs, err := app.buildLoopDefinitionBaseSpecs()
+	if err != nil {
+		t.Fatalf("buildLoopDefinitionBaseSpecs: %v", err)
+	}
+	var ego looppkg.Spec
+	container := false
+	for _, spec := range specs {
+		switch spec.Name {
+		case "ego":
+			ego = spec
+		case cognitionContainerName:
+			container = true
+		}
+	}
+	if ego.ParentName != cognitionContainerName {
+		t.Errorf("parent_name = %q, want the document's %q", ego.ParentName, cognitionContainerName)
+	}
+	if !container {
+		t.Errorf("%q is absent, so the declared parent resolves to nothing", cognitionContainerName)
+	}
+}

--- a/loops/archivist.md
+++ b/loops/archivist.md
@@ -9,6 +9,7 @@ tags: [loops]
 
 ```yaml
 name: archivist
+parent_name: cognition
 enabled: true
 profile:
     quality_floor: 5

--- a/loops/ego.md
+++ b/loops/ego.md
@@ -9,6 +9,7 @@ tags: [loops]
 
 ```yaml
 name: ego
+parent_name: cognition
 enabled: true
 profile:
     quality_floor: 5

--- a/loops/metacognitive.md
+++ b/loops/metacognitive.md
@@ -9,6 +9,7 @@ tags: [loops]
 
 ```yaml
 name: metacognitive
+parent_name: cognition
 enabled: true
 profile:
     quality_floor: 3


### PR DESCRIPTION
Follow-up to #1315, which added a warning for this. The warning is the right safety net for a hand-authored document and the wrong fix for a shipped one.

## The asymmetry

ego, metacognitive, and archivist take every field from their shipped document except one. Their parent was assigned in Go, after the spec was built, on the branch that appends a built-in:

```go
spec, err := reg.DefinitionSpec(a)
spec.ParentName = cognitionContainerName
```

A definition read from `<core>/loops` sets `hasDefinition`, never reaches that branch, and lands at the graph root. The document owned everything about the loop except where it sits.

The failure is silent, which is what makes this a breaking change rather than another guard. The loop boots, runs, and does its work. The only evidence is a cognition container that used to have three children and now has none, and nothing connects that to the file someone edited. A default the documents cannot see is a default they cannot be read against.

`parent_name: cognition` now lives in the three documents and nothing assigns it afterwards. An operator who copies a shipped document to override it gets the parent along with everything else — which is what the copy already implied.

## Breaking

Anyone who has already written a `<core>/loops` document for one of these three without a `parent_name` had that loop move to the root at the previous release, and it stays there until the field is added. `thane validate` names it, from #1315.

## The parity tests split on this field

Honestly, rather than by normalizing it away. `TestCoreLoopDocsMatchTheGoSpecs` still excludes `ParentName` — the Go builders never carried one — and now says why. `TestBuiltInSpecsNowComeFromTheShippedDocuments` asserts it positively instead of copying `got` onto `want`, because that test can actually observe whether the document's value survived. It fails when the field is stripped from a shipped document; the normalized version could not.

## Test plan

- [x] `just ci` clean, no architecture drift, generated mirror regenerated
- [x] Removing `parent_name` from a shipped document fails the boot-path parity test with the field named
- [x] A core-defined loop keeps its declared parent even though the container it names is appended after it — startup topologically orders containers before services, so slice position does not decide parenting
- [x] Production's three documents already carry the field explicitly, so this changes nothing for that instance

Refs #1086