### PR TITLE
feat: expose core-backed identity evidence

### DIFF
--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -34,8 +34,10 @@ not issue a remote trust verdict. Its stable instance ID and fingerprints are
 recomputed from public material committed in core's single birth commit.
 `core.birth.asserted_at` is the time claimed by that signed commit, with
 `time_assurance: signed_claim`; it is not an independently witnessed
-timestamp. The endpoint never returns private key material, local filesystem
-paths, signer principals, or the contents of `.allowed_signers`.
+timestamp. `core.current_commit` is the algorithm-qualified commit ID of the
+active core document root and is the canonical forensic anchor for the state
+being reported. The endpoint never returns private key material, local
+filesystem paths, signer principals, or the contents of `.allowed_signers`.
 
 ### Router, Registry, and History
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -25,8 +25,17 @@ views). The OpenAI-compatible shim runs on its own port (see below).
 | `GET` | `/docs` | Interactive OpenAPI explorer (Scalar) for the API. |
 | `GET` | `/health` | Dependency health for service monitoring. |
 | `GET` | `/v1/version` | Build and runtime metadata. |
+| `GET` | `/v1/identity` | Core-backed instance identity, birth and HEAD revisions, anchor posture, and local provenance verification evidence. |
 | `GET` | `/v1/system` | Slim system rollup: status, dependency health, `uptime_seconds`, version. |
 | `GET` | `/v1/system/logs` | Structured process-log tail (bare array, newest first; `?level`, `?limit` default 50, max 200). |
+
+`GET /v1/identity` reports evidence for clients to pin and evaluate; it does
+not issue a remote trust verdict. Its stable instance ID and fingerprints are
+recomputed from public material committed in core's single birth commit.
+`core.birth.asserted_at` is the time claimed by that signed commit, with
+`time_assurance: signed_claim`; it is not an independently witnessed
+timestamp. The endpoint never returns private key material, local filesystem
+paths, signer principals, or the contents of `.allowed_signers`.
 
 ### Router, Registry, and History
 

--- a/internal/app/new_servers.go
+++ b/internal/app/new_servers.go
@@ -15,6 +15,7 @@ import (
 	"github.com/nugget/thane-ai-agent/internal/model/fleet"
 	"github.com/nugget/thane-ai-agent/internal/platform/checkpoint"
 	"github.com/nugget/thane-ai-agent/internal/platform/config"
+	"github.com/nugget/thane-ai-agent/internal/platform/identity"
 	"github.com/nugget/thane-ai-agent/internal/platform/telemetry"
 	"github.com/nugget/thane-ai-agent/internal/server/api"
 	cdav "github.com/nugget/thane-ai-agent/internal/server/carddav"
@@ -68,6 +69,9 @@ func (a *App) initServers(s *newState) error {
 		server.UseScheduler(a.sched)
 	}
 	server.UseCapabilitySurface(a.capSurfaceGetter())
+	server.UseIdentityEvidence(func(ctx context.Context) (identity.Evidence, error) {
+		return identity.Observe(ctx, cfg.CoreRoot(), CoreSeedSigners(cfg))
+	})
 	if a.indexDB != nil {
 		server.UseLogQuerier(&logQueryAdapter{db: a.indexDB})
 	}

--- a/internal/platform/identity/evidence.go
+++ b/internal/platform/identity/evidence.go
@@ -1,0 +1,392 @@
+package identity
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/nugget/thane-ai-agent/internal/platform/provenance"
+	"golang.org/x/crypto/ssh"
+	"gopkg.in/yaml.v3"
+)
+
+// EvidenceStatus describes whether one local provenance check succeeded.
+type EvidenceStatus string
+
+const (
+	// EvidenceVerified means the check ran and its stated invariant holds.
+	EvidenceVerified EvidenceStatus = "verified"
+	// EvidenceFailed means the check ran and its stated invariant does not hold.
+	EvidenceFailed EvidenceStatus = "failed"
+)
+
+// Evidence is the public, core-backed identity statement for one Thane.
+//
+// It reports locally verifiable facts rather than a trust verdict. In
+// particular, AssertedAt is a claim covered by the signed birth commit, not an
+// externally witnessed timestamp.
+type Evidence struct {
+	// SchemaVersion identifies the wire contract used by this evidence.
+	SchemaVersion int `json:"schema_version"`
+	// ObservedAt is when the live repository checks were performed.
+	ObservedAt time.Time `json:"observed_at"`
+	// Instance identifies the Thane from its founding public material.
+	Instance InstanceEvidence `json:"instance"`
+	// Core describes the founding and active repository state.
+	Core CoreEvidence `json:"core"`
+}
+
+// InstanceEvidence identifies the Thane and its founding public material.
+type InstanceEvidence struct {
+	// ID is stable across process restarts and core content changes.
+	ID string `json:"id"`
+	// Name is the instance name asserted in the signed birth policy.
+	Name string `json:"name"`
+	// IdentityKey identifies the founding long-lived signing key.
+	IdentityKey PublicKeyEvidence `json:"identity_key"`
+	// ChannelCA identifies the founding channel certificate authority.
+	ChannelCA PublicKeyEvidence `json:"channel_ca"`
+}
+
+// PublicKeyEvidence identifies public cryptographic material without exposing
+// its encoded contents.
+type PublicKeyEvidence struct {
+	// Algorithm names the key or certificate algorithm.
+	Algorithm string `json:"algorithm"`
+	// Fingerprint is the SHA-256 fingerprint recomputed from committed material.
+	Fingerprint string `json:"fingerprint"`
+}
+
+// CoreEvidence describes the birth, active revision, and verification posture
+// of the core repository.
+type CoreEvidence struct {
+	// Birth identifies the signed parentless commit.
+	Birth BirthEvidence `json:"birth"`
+	// Head identifies the active revision and worktree posture.
+	Head HeadEvidence `json:"head"`
+	// Verification reports birth admission and active-tree checks separately.
+	Verification VerificationEvidence `json:"verification"`
+}
+
+// GitObjectID is an algorithm-qualified Git object identifier.
+type GitObjectID struct {
+	// Algorithm is the repository's object-hash algorithm.
+	Algorithm string `json:"algorithm"`
+	// OID is the full Git object identifier.
+	OID string `json:"oid"`
+}
+
+// BirthEvidence identifies the single parentless commit from which core
+// descends.
+type BirthEvidence struct {
+	// Commit is the single parentless commit from which core descends.
+	Commit GitObjectID `json:"commit"`
+	// AssertedAt is the birth time claimed inside that signed commit.
+	AssertedAt time.Time `json:"asserted_at"`
+	// TimeAssurance states what supports AssertedAt.
+	TimeAssurance string `json:"time_assurance"`
+	// Anchor distinguishes operator-anchored, self-signed, and unknown posture.
+	Anchor string `json:"anchor"`
+}
+
+// HeadEvidence identifies the active core revision and its worktree posture.
+type HeadEvidence struct {
+	// Commit is the active core HEAD.
+	Commit GitObjectID `json:"commit"`
+	// WorktreeClean reports whether tracked core content matches HEAD.
+	WorktreeClean bool `json:"worktree_clean"`
+	// TrustFileChangeCount is the number of commits that touched the trust file.
+	TrustFileChangeCount int `json:"trust_file_change_count"`
+}
+
+// VerificationEvidence separates birth admission from verification of the
+// currently active tree.
+type VerificationEvidence struct {
+	// Admission checks birth and trust-file history against declared seeds.
+	Admission CheckEvidence `json:"admission"`
+	// Head checks that the active tree is clean and covered by trusted history.
+	Head CheckEvidence `json:"head"`
+}
+
+// CheckEvidence is one bounded verification result.
+type CheckEvidence struct {
+	// Status reports whether the stated local invariant holds.
+	Status EvidenceStatus `json:"status"`
+	// Detail is a bounded explanation safe for remote clients.
+	Detail string `json:"detail"`
+}
+
+type birthPolicy struct {
+	GeneratedAt string `yaml:"generated_at"`
+	Identity    struct {
+		InstanceName string `yaml:"instance_name"`
+		SigningKey   struct {
+			PublicKeyPath string `yaml:"public_key_path"`
+			Fingerprint   string `yaml:"fingerprint"`
+		} `yaml:"signing_key"`
+		ChannelCA struct {
+			CertPath    string `yaml:"cert_path"`
+			Fingerprint string `yaml:"fingerprint"`
+		} `yaml:"channel_ca"`
+	} `yaml:"identity"`
+}
+
+// Observe reads identity evidence from the signed birth of core and checks it
+// against the currently active repository state.
+func Observe(ctx context.Context, coreDir string, seeds []provenance.TrustedSigner) (Evidence, error) {
+	var evidence Evidence
+	coreDir = strings.TrimSpace(coreDir)
+	if coreDir == "" {
+		return evidence, fmt.Errorf("identity evidence: core path is empty")
+	}
+	absCore, err := filepath.Abs(coreDir)
+	if err != nil {
+		return evidence, fmt.Errorf("identity evidence: resolve core path: %w", err)
+	}
+
+	objectFormat, err := gitScalar(ctx, absCore, "rev-parse", "--show-object-format")
+	if err != nil {
+		return evidence, fmt.Errorf("identity evidence: read git object format: %w", err)
+	}
+	if objectFormat != "sha1" && objectFormat != "sha256" {
+		return evidence, fmt.Errorf("identity evidence: unsupported git object format %q", objectFormat)
+	}
+
+	rootOutput, err := gitScalar(ctx, absCore, "rev-list", "--max-parents=0", "HEAD")
+	if err != nil {
+		return evidence, fmt.Errorf("identity evidence: read core birth: %w", err)
+	}
+	roots := nonEmptyLines(rootOutput)
+	if len(roots) != 1 {
+		return evidence, fmt.Errorf("identity evidence: core has %d parentless commits, want exactly one", len(roots))
+	}
+	rootCommit := roots[0]
+
+	headCommit, err := gitScalar(ctx, absCore, "rev-parse", "--verify", "HEAD^{commit}")
+	if err != nil {
+		return evidence, fmt.Errorf("identity evidence: read core HEAD: %w", err)
+	}
+
+	policyData, err := gitBlob(ctx, absCore, rootCommit, CoreConfigFile)
+	if err != nil {
+		return evidence, fmt.Errorf("identity evidence: read birth policy: %w", err)
+	}
+	var policy birthPolicy
+	if err := yaml.Unmarshal(policyData, &policy); err != nil {
+		return evidence, fmt.Errorf("identity evidence: parse birth policy: %w", err)
+	}
+	if policy.Identity.SigningKey.PublicKeyPath != SigningPublicKeyFile {
+		return evidence, fmt.Errorf("identity evidence: birth policy names unexpected signing public key path")
+	}
+	if policy.Identity.ChannelCA.CertPath != ChannelCACertFile {
+		return evidence, fmt.Errorf("identity evidence: birth policy names unexpected channel CA path")
+	}
+
+	publicKeyData, err := gitBlob(ctx, absCore, rootCommit, SigningPublicKeyFile)
+	if err != nil {
+		return evidence, fmt.Errorf("identity evidence: read birth signing key: %w", err)
+	}
+	publicKey, _, _, _, err := ssh.ParseAuthorizedKey(publicKeyData)
+	if err != nil {
+		return evidence, fmt.Errorf("identity evidence: parse birth signing key: %w", err)
+	}
+	if publicKey.Type() != ssh.KeyAlgoED25519 {
+		return evidence, fmt.Errorf("identity evidence: signing key algorithm is %q, want %q", publicKey.Type(), ssh.KeyAlgoED25519)
+	}
+	signingFingerprint := ssh.FingerprintSHA256(publicKey)
+	if signingFingerprint != strings.TrimSpace(policy.Identity.SigningKey.Fingerprint) {
+		return evidence, fmt.Errorf("identity evidence: birth signing key fingerprint does not match birth policy")
+	}
+
+	certificateData, err := gitBlob(ctx, absCore, rootCommit, ChannelCACertFile)
+	if err != nil {
+		return evidence, fmt.Errorf("identity evidence: read birth channel CA: %w", err)
+	}
+	certificate, err := ParseCACertificate(certificateData)
+	if err != nil {
+		return evidence, fmt.Errorf("identity evidence: %w", err)
+	}
+	caFingerprint := certificateFingerprint(certificate)
+	if caFingerprint != strings.TrimSpace(policy.Identity.ChannelCA.Fingerprint) {
+		return evidence, fmt.Errorf("identity evidence: birth channel CA fingerprint does not match birth policy")
+	}
+	if err := verifyActiveIdentity(ctx, absCore, headCommit, signingFingerprint, caFingerprint); err != nil {
+		return evidence, err
+	}
+
+	assertedAt, err := time.Parse(time.RFC3339, strings.TrimSpace(policy.GeneratedAt))
+	if err != nil {
+		return evidence, fmt.Errorf("identity evidence: parse asserted birth time: %w", err)
+	}
+
+	clean, err := coreWorktreeClean(ctx, absCore)
+	if err != nil {
+		return evidence, fmt.Errorf("identity evidence: inspect core worktree: %w", err)
+	}
+	trustHistory, err := gitScalar(ctx, absCore, "log", "--full-history", "--format=%H", "--", provenance.TrustFileName)
+	if err != nil {
+		return evidence, fmt.Errorf("identity evidence: inspect trust-file history: %w", err)
+	}
+
+	_, admissionErr := provenance.VerifyAdmission(ctx, absCore, seeds)
+	admission := CheckEvidence{
+		Status: EvidenceVerified,
+		Detail: "single birth and trust-file history satisfy the declared seed policy",
+	}
+	if admissionErr != nil {
+		admission.Status = EvidenceFailed
+		admission.Detail = "core birth or trust-file history does not satisfy the declared seed policy"
+	}
+
+	head := CheckEvidence{
+		Status: EvidenceFailed,
+		Detail: "current core tree is not covered by trusted clean history",
+	}
+	verifier, verifierErr := provenance.NewVerifier(absCore, nil, provenance.Options{SeedSigners: seeds})
+	if verifierErr == nil {
+		if result, verifyErr := verifier.VerifyTree(ctx, ""); verifyErr == nil && result.Trusted() && clean {
+			head.Status = EvidenceVerified
+			head.Detail = "current core tree is clean and covered by a trusted signed HEAD"
+		}
+	}
+
+	evidence = Evidence{
+		SchemaVersion: 1,
+		ObservedAt:    time.Now().UTC().Truncate(time.Second),
+		Instance: InstanceEvidence{
+			ID:   "thane:ed25519:" + signingFingerprint,
+			Name: strings.TrimSpace(policy.Identity.InstanceName),
+			IdentityKey: PublicKeyEvidence{
+				Algorithm:   "ed25519",
+				Fingerprint: signingFingerprint,
+			},
+			ChannelCA: PublicKeyEvidence{
+				Algorithm:   "x509-ed25519",
+				Fingerprint: caFingerprint,
+			},
+		},
+		Core: CoreEvidence{
+			Birth: BirthEvidence{
+				Commit:        GitObjectID{Algorithm: objectFormat, OID: rootCommit},
+				AssertedAt:    assertedAt.UTC(),
+				TimeAssurance: "signed_claim",
+				Anchor:        anchorKind(publicKey, seeds),
+			},
+			Head: HeadEvidence{
+				Commit:               GitObjectID{Algorithm: objectFormat, OID: headCommit},
+				WorktreeClean:        clean,
+				TrustFileChangeCount: len(nonEmptyLines(trustHistory)),
+			},
+			Verification: VerificationEvidence{
+				Admission: admission,
+				Head:      head,
+			},
+		},
+	}
+	return evidence, nil
+}
+
+func anchorKind(identityKey ssh.PublicKey, seeds []provenance.TrustedSigner) string {
+	if len(seeds) == 0 {
+		return "unknown"
+	}
+	if len(seeds) != 1 || seeds[0].Principal != provenance.AgentPrincipal {
+		return "operator"
+	}
+	seedKey, _, _, _, err := ssh.ParseAuthorizedKey([]byte(seeds[0].PublicKey))
+	if err != nil || !bytes.Equal(seedKey.Marshal(), identityKey.Marshal()) {
+		return "operator"
+	}
+	return "self_signed"
+}
+
+func verifyActiveIdentity(ctx context.Context, repo, headCommit, signingFingerprint, caFingerprint string) error {
+	policyData, err := gitBlob(ctx, repo, headCommit, CoreConfigFile)
+	if err != nil {
+		return fmt.Errorf("identity evidence: read active policy: %w", err)
+	}
+	var policy birthPolicy
+	if err := yaml.Unmarshal(policyData, &policy); err != nil {
+		return fmt.Errorf("identity evidence: parse active policy: %w", err)
+	}
+	if policy.Identity.SigningKey.PublicKeyPath != SigningPublicKeyFile ||
+		policy.Identity.ChannelCA.CertPath != ChannelCACertFile {
+		return fmt.Errorf("identity evidence: active policy names unexpected identity material")
+	}
+
+	publicKeyData, err := gitBlob(ctx, repo, headCommit, SigningPublicKeyFile)
+	if err != nil {
+		return fmt.Errorf("identity evidence: read active signing key: %w", err)
+	}
+	publicKey, _, _, _, err := ssh.ParseAuthorizedKey(publicKeyData)
+	if err != nil {
+		return fmt.Errorf("identity evidence: parse active signing key: %w", err)
+	}
+	activeSigningFingerprint := ssh.FingerprintSHA256(publicKey)
+	if activeSigningFingerprint != strings.TrimSpace(policy.Identity.SigningKey.Fingerprint) {
+		return fmt.Errorf("identity evidence: active signing key fingerprint does not match active policy")
+	}
+	if activeSigningFingerprint != signingFingerprint {
+		return fmt.Errorf("identity evidence: identity-key rotation is not supported by schema version 1")
+	}
+
+	certificateData, err := gitBlob(ctx, repo, headCommit, ChannelCACertFile)
+	if err != nil {
+		return fmt.Errorf("identity evidence: read active channel CA: %w", err)
+	}
+	certificate, err := ParseCACertificate(certificateData)
+	if err != nil {
+		return fmt.Errorf("identity evidence: parse active channel CA: %w", err)
+	}
+	activeCAFingerprint := certificateFingerprint(certificate)
+	if activeCAFingerprint != strings.TrimSpace(policy.Identity.ChannelCA.Fingerprint) {
+		return fmt.Errorf("identity evidence: active channel CA fingerprint does not match active policy")
+	}
+	if activeCAFingerprint != caFingerprint {
+		return fmt.Errorf("identity evidence: channel-CA rotation is not supported by schema version 1")
+	}
+	return nil
+}
+
+func gitScalar(ctx context.Context, repo string, args ...string) (string, error) {
+	cmd := exec.CommandContext(ctx, "git", append([]string{"-C", repo}, args...)...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("%w: %s", err, strings.TrimSpace(string(out)))
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+func gitBlob(ctx context.Context, repo, commit, name string) ([]byte, error) {
+	if strings.Contains(name, ":") {
+		return nil, fmt.Errorf("invalid birth artifact name %q", name)
+	}
+	cmd := exec.CommandContext(ctx, "git", "-C", repo, "show", commit+":"+name)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return nil, fmt.Errorf("%w: %s", err, strings.TrimSpace(string(out)))
+	}
+	return out, nil
+}
+
+func coreWorktreeClean(ctx context.Context, repo string) (bool, error) {
+	status, err := gitScalar(ctx, repo, "status", "--porcelain", "--untracked-files=no")
+	if err != nil {
+		return false, err
+	}
+	return status == "", nil
+}
+
+func nonEmptyLines(value string) []string {
+	var lines []string
+	for line := range strings.SplitSeq(value, "\n") {
+		if line = strings.TrimSpace(line); line != "" {
+			lines = append(lines, line)
+		}
+	}
+	return lines
+}

--- a/internal/platform/identity/evidence.go
+++ b/internal/platform/identity/evidence.go
@@ -68,7 +68,9 @@ type PublicKeyEvidence struct {
 type CoreEvidence struct {
 	// Birth identifies the signed parentless commit.
 	Birth BirthEvidence `json:"birth"`
-	// Head identifies the active revision and worktree posture.
+	// CurrentCommit is the active core revision and its forensic anchor.
+	CurrentCommit GitObjectID `json:"current_commit"`
+	// Head identifies the active worktree posture.
 	Head HeadEvidence `json:"head"`
 	// Verification reports birth admission and active-tree checks separately.
 	Verification VerificationEvidence `json:"verification"`
@@ -95,10 +97,8 @@ type BirthEvidence struct {
 	Anchor string `json:"anchor"`
 }
 
-// HeadEvidence identifies the active core revision and its worktree posture.
+// HeadEvidence describes the active core worktree posture.
 type HeadEvidence struct {
-	// Commit is the active core HEAD.
-	Commit GitObjectID `json:"commit"`
 	// WorktreeClean reports whether tracked core content matches HEAD.
 	WorktreeClean bool `json:"worktree_clean"`
 	// TrustFileChangeCount is the number of commits that touched the trust file.
@@ -278,8 +278,8 @@ func Observe(ctx context.Context, coreDir string, seeds []provenance.TrustedSign
 				TimeAssurance: "signed_claim",
 				Anchor:        anchorKind(publicKey, seeds),
 			},
+			CurrentCommit: GitObjectID{Algorithm: objectFormat, OID: headCommit},
 			Head: HeadEvidence{
-				Commit:               GitObjectID{Algorithm: objectFormat, OID: headCommit},
 				WorktreeClean:        clean,
 				TrustFileChangeCount: trustChangeCount,
 			},

--- a/internal/platform/identity/evidence.go
+++ b/internal/platform/identity/evidence.go
@@ -3,9 +3,11 @@ package identity
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -227,7 +229,7 @@ func Observe(ctx context.Context, coreDir string, seeds []provenance.TrustedSign
 	if err != nil {
 		return evidence, fmt.Errorf("identity evidence: inspect core worktree: %w", err)
 	}
-	trustHistory, err := gitScalar(ctx, absCore, "log", "--full-history", "--format=%H", "--", provenance.TrustFileName)
+	trustChangeCount, err := trustFileChangeCount(ctx, absCore)
 	if err != nil {
 		return evidence, fmt.Errorf("identity evidence: inspect trust-file history: %w", err)
 	}
@@ -279,7 +281,7 @@ func Observe(ctx context.Context, coreDir string, seeds []provenance.TrustedSign
 			Head: HeadEvidence{
 				Commit:               GitObjectID{Algorithm: objectFormat, OID: headCommit},
 				WorktreeClean:        clean,
-				TrustFileChangeCount: len(nonEmptyLines(trustHistory)),
+				TrustFileChangeCount: trustChangeCount,
 			},
 			Verification: VerificationEvidence{
 				Admission: admission,
@@ -374,11 +376,28 @@ func gitBlob(ctx context.Context, repo, commit, name string) ([]byte, error) {
 }
 
 func coreWorktreeClean(ctx context.Context, repo string) (bool, error) {
-	status, err := gitScalar(ctx, repo, "status", "--porcelain", "--untracked-files=no")
-	if err != nil {
-		return false, err
+	cmd := exec.CommandContext(ctx, "git", "-C", repo, "diff", "--quiet", "HEAD", "--")
+	err := cmd.Run()
+	if err == nil {
+		return true, nil
 	}
-	return status == "", nil
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 {
+		return false, nil
+	}
+	return false, fmt.Errorf("git diff --quiet HEAD: %w", err)
+}
+
+func trustFileChangeCount(ctx context.Context, repo string) (int, error) {
+	count, err := gitScalar(ctx, repo, "rev-list", "--count", "--full-history", "HEAD", "--", provenance.TrustFileName)
+	if err != nil {
+		return 0, err
+	}
+	value, err := strconv.Atoi(count)
+	if err != nil {
+		return 0, fmt.Errorf("parse git rev-list count %q: %w", count, err)
+	}
+	return value, nil
 }
 
 func nonEmptyLines(value string) []string {

--- a/internal/platform/identity/evidence_test.go
+++ b/internal/platform/identity/evidence_test.go
@@ -50,6 +50,9 @@ func TestObserveCoreIdentityEvidence(t *testing.T) {
 			if got.Core.Birth.Commit.Algorithm != "sha1" || got.Core.Birth.Commit.OID == "" {
 				t.Errorf("birth commit = %+v, want algorithm-qualified oid", got.Core.Birth.Commit)
 			}
+			if got.Core.CurrentCommit.Algorithm != "sha1" || got.Core.CurrentCommit.OID != strings.TrimSpace(gitOutput(t, coreDir, "rev-parse", "HEAD")) {
+				t.Errorf("current commit = %+v, want active core HEAD", got.Core.CurrentCommit)
+			}
 			if got.Core.Verification.Admission.Status != EvidenceVerified {
 				t.Errorf("admission = %+v, want verified", got.Core.Verification.Admission)
 			}

--- a/internal/platform/identity/evidence_test.go
+++ b/internal/platform/identity/evidence_test.go
@@ -1,0 +1,149 @@
+package identity
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nugget/thane-ai-agent/internal/platform/provenance"
+)
+
+func TestObserveCoreIdentityEvidence(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		operator   bool
+		wantAnchor string
+	}{
+		{name: "self signed", wantAnchor: "self_signed"},
+		{name: "operator anchored", operator: true, wantAnchor: "operator"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			coreDir, seeds := evidenceCore(t, tc.operator)
+
+			got, err := Observe(t.Context(), coreDir, seeds)
+			if err != nil {
+				t.Fatalf("Observe: %v", err)
+			}
+			if got.SchemaVersion != 1 {
+				t.Fatalf("schema_version = %d, want 1", got.SchemaVersion)
+			}
+			if got.Instance.Name != "pocket" {
+				t.Errorf("instance name = %q, want pocket", got.Instance.Name)
+			}
+			if !strings.HasPrefix(got.Instance.ID, "thane:ed25519:SHA256:") {
+				t.Errorf("instance id = %q, want fingerprint-derived id", got.Instance.ID)
+			}
+			if got.Instance.IdentityKey.Fingerprint == "" || got.Instance.ChannelCA.Fingerprint == "" {
+				t.Errorf("public fingerprints are incomplete: %+v", got.Instance)
+			}
+			if got.Core.Birth.Anchor != tc.wantAnchor {
+				t.Errorf("anchor = %q, want %q", got.Core.Birth.Anchor, tc.wantAnchor)
+			}
+			if got.Core.Birth.TimeAssurance != "signed_claim" {
+				t.Errorf("time assurance = %q, want signed_claim", got.Core.Birth.TimeAssurance)
+			}
+			if got.Core.Birth.Commit.Algorithm != "sha1" || got.Core.Birth.Commit.OID == "" {
+				t.Errorf("birth commit = %+v, want algorithm-qualified oid", got.Core.Birth.Commit)
+			}
+			if got.Core.Verification.Admission.Status != EvidenceVerified {
+				t.Errorf("admission = %+v, want verified", got.Core.Verification.Admission)
+			}
+			if got.Core.Verification.Head.Status != EvidenceVerified || !got.Core.Head.WorktreeClean {
+				t.Errorf("head evidence = %+v / %+v, want verified clean head", got.Core.Head, got.Core.Verification.Head)
+			}
+		})
+	}
+}
+
+func TestObserveReportsFailedAdmissionWithoutLosingIdentity(t *testing.T) {
+	t.Parallel()
+	coreDir, _ := evidenceCore(t, false)
+	other, err := GenerateSigningKeyPair("other")
+	if err != nil {
+		t.Fatalf("GenerateSigningKeyPair: %v", err)
+	}
+
+	got, err := Observe(t.Context(), coreDir, []provenance.TrustedSigner{{
+		Principal: "other@example.com",
+		PublicKey: other.Public,
+	}})
+	if err != nil {
+		t.Fatalf("Observe: %v", err)
+	}
+	if got.Instance.ID == "" {
+		t.Fatal("instance identity was lost when admission failed")
+	}
+	if got.Core.Verification.Admission.Status != EvidenceFailed {
+		t.Fatalf("admission = %+v, want failed", got.Core.Verification.Admission)
+	}
+}
+
+func TestObserveReportsDirtyCore(t *testing.T) {
+	t.Parallel()
+	coreDir, seeds := evidenceCore(t, false)
+	configPath := filepath.Join(coreDir, CoreConfigFile)
+	if err := os.WriteFile(configPath, []byte("changed: true\n"), 0o644); err != nil {
+		t.Fatalf("dirty config: %v", err)
+	}
+
+	got, err := Observe(t.Context(), coreDir, seeds)
+	if err != nil {
+		t.Fatalf("Observe: %v", err)
+	}
+	if got.Core.Head.WorktreeClean {
+		t.Fatal("worktree_clean = true for a modified tracked config")
+	}
+	if got.Core.Verification.Head.Status != EvidenceFailed {
+		t.Fatalf("head = %+v, want failed", got.Core.Verification.Head)
+	}
+}
+
+func TestObserveRejectsMissingCore(t *testing.T) {
+	t.Parallel()
+	if _, err := Observe(t.Context(), filepath.Join(t.TempDir(), "missing"), nil); err == nil {
+		t.Fatal("Observe missing core returned nil error")
+	}
+}
+
+func evidenceCore(t *testing.T, operatorAnchored bool) (string, []provenance.TrustedSigner) {
+	t.Helper()
+	coreDir := filepath.Join(t.TempDir(), "core")
+	var operator *OperatorSigner
+	if operatorAnchored {
+		pair, err := GenerateSigningKeyPair("operator")
+		if err != nil {
+			t.Fatalf("GenerateSigningKeyPair operator: %v", err)
+		}
+		keyPath := filepath.Join(t.TempDir(), "operator_ed25519")
+		if err := os.WriteFile(keyPath, pair.PrivatePEM, 0o600); err != nil {
+			t.Fatalf("write operator key: %v", err)
+		}
+		operator = &OperatorSigner{
+			Principal:      "operator@example.com",
+			PublicKey:      pair.Public,
+			PrivateKeyPath: keyPath,
+		}
+	}
+	if _, err := BootstrapCore(t.Context(), coreDir, "pocket", operator, nil, nil); err != nil {
+		t.Fatalf("BootstrapCore: %v", err)
+	}
+	if operator != nil {
+		return coreDir, []provenance.TrustedSigner{{
+			Principal: operator.Principal,
+			PublicKey: operator.PublicKey,
+		}}
+	}
+	publicKey, err := os.ReadFile(filepath.Join(coreDir, SigningPublicKeyFile))
+	if err != nil {
+		t.Fatalf("read signing public key: %v", err)
+	}
+	return coreDir, []provenance.TrustedSigner{{
+		Principal: provenance.AgentPrincipal,
+		PublicKey: strings.TrimSpace(string(publicKey)),
+	}}
+}

--- a/internal/platform/identity/evidence_test.go
+++ b/internal/platform/identity/evidence_test.go
@@ -56,6 +56,9 @@ func TestObserveCoreIdentityEvidence(t *testing.T) {
 			if got.Core.Verification.Head.Status != EvidenceVerified || !got.Core.Head.WorktreeClean {
 				t.Errorf("head evidence = %+v / %+v, want verified clean head", got.Core.Head, got.Core.Verification.Head)
 			}
+			if got.Core.Head.TrustFileChangeCount != 1 {
+				t.Errorf("trust-file change count = %d, want 1", got.Core.Head.TrustFileChangeCount)
+			}
 		})
 	}
 }

--- a/internal/server/api/identity.go
+++ b/internal/server/api/identity.go
@@ -1,0 +1,34 @@
+package api
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/nugget/thane-ai-agent/internal/platform/identity"
+)
+
+// IdentityEvidenceReader returns the live core-backed identity evidence for
+// this instance.
+type IdentityEvidenceReader func(context.Context) (identity.Evidence, error)
+
+// UseIdentityEvidence configures the native identity-evidence surface.
+func (s *Server) UseIdentityEvidence(reader IdentityEvidenceReader) {
+	s.identityEvidence = reader
+}
+
+// handleIdentity returns the durable public identity and local provenance
+// posture of the running instance. [GET /v1/identity]
+func (s *Server) handleIdentity(w http.ResponseWriter, r *http.Request) {
+	if s.identityEvidence == nil {
+		s.errorResponse(w, http.StatusServiceUnavailable, "identity evidence not available")
+		return
+	}
+	evidence, err := s.identityEvidence(r.Context())
+	if err != nil {
+		s.logger.Warn("identity evidence unavailable", "error", err)
+		s.errorResponse(w, http.StatusServiceUnavailable, "identity evidence not available")
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	writeJSON(w, evidence, s.logger)
+}

--- a/internal/server/api/identity_test.go
+++ b/internal/server/api/identity_test.go
@@ -1,0 +1,71 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/nugget/thane-ai-agent/internal/platform/identity"
+)
+
+func TestHandleIdentity(t *testing.T) {
+	s := &Server{logger: testAPILogger()}
+	s.UseIdentityEvidence(func(context.Context) (identity.Evidence, error) {
+		return identity.Evidence{
+			SchemaVersion: 1,
+			Instance: identity.InstanceEvidence{
+				ID: "thane:ed25519:SHA256:test",
+			},
+		}, nil
+	})
+
+	rr := httptest.NewRecorder()
+	s.handleIdentity(rr, httptest.NewRequest(http.MethodGet, "/v1/identity", nil))
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rr.Code)
+	}
+	if got := rr.Header().Get("Content-Type"); got != "application/json" {
+		t.Errorf("Content-Type = %q, want application/json", got)
+	}
+	var body identity.Evidence
+	if err := json.Unmarshal(rr.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body.Instance.ID != "thane:ed25519:SHA256:test" {
+		t.Errorf("instance id = %q", body.Instance.ID)
+	}
+}
+
+func TestHandleIdentityUnavailable(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		reader IdentityEvidenceReader
+	}{
+		{name: "not configured"},
+		{
+			name: "observation failed",
+			reader: func(context.Context) (identity.Evidence, error) {
+				return identity.Evidence{}, errors.New("private path must not reach client")
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			s := &Server{logger: testAPILogger(), identityEvidence: tc.reader}
+			rr := httptest.NewRecorder()
+			s.handleIdentity(rr, httptest.NewRequest(http.MethodGet, "/v1/identity", nil))
+			if rr.Code != http.StatusServiceUnavailable {
+				t.Fatalf("status = %d, want 503", rr.Code)
+			}
+			if body := rr.Body.String(); body == "" || body == "private path must not reach client" {
+				t.Fatalf("body leaked internal error or was empty: %q", body)
+			}
+		})
+	}
+}

--- a/internal/server/api/server.go
+++ b/internal/server/api/server.go
@@ -79,6 +79,7 @@ type Server struct {
 	memoryStore                        *memory.SQLiteStore
 	archiveStore                       *memory.ArchiveStore
 	healthDeps                         HealthStatusFunc
+	identityEvidence                   IdentityEvidenceReader
 	unverified                         bool
 	tokenObserver                      TokenObserver
 	eventBus                           *events.Bus
@@ -452,6 +453,7 @@ func (s *Server) Start(ctx context.Context) error {
 	mux.HandleFunc("GET /health", s.handleHealth)
 	mux.HandleFunc("GET /v1/system", s.handleSystem)
 	mux.HandleFunc("GET /v1/system/logs", s.handleSystemLogs)
+	mux.HandleFunc("GET /v1/identity", s.handleIdentity)
 
 	// Telemetry — consolidated router, tool, and usage analytics
 	mux.HandleFunc("GET /v1/telemetry/router", s.handleRouterTelemetry)

--- a/internal/server/openapi/native.yaml
+++ b/internal/server/openapi/native.yaml
@@ -1396,16 +1396,23 @@ components:
     CoreIdentityEvidence:
       type: object
       description: Birth, active revision, and verification evidence for core.
-      required: [birth, head, verification]
+      required: [birth, current_commit, head, verification]
       properties:
         birth:
           type: object
           description: Founding commit and its asserted chronology.
           allOf:
             - $ref: "#/components/schemas/CoreBirthEvidence"
+        current_commit:
+          type: object
+          description: |
+            Algorithm-qualified object ID of the active core commit. This is
+            the canonical forensic anchor for the core state being reported.
+          allOf:
+            - $ref: "#/components/schemas/GitObjectID"
         head:
           type: object
-          description: Active core revision and worktree posture.
+          description: Active core worktree posture.
           allOf:
             - $ref: "#/components/schemas/CoreHeadEvidence"
         verification:
@@ -1442,14 +1449,9 @@ components:
 
     CoreHeadEvidence:
       type: object
-      description: The active core revision and its local worktree posture.
-      required: [commit, worktree_clean, trust_file_change_count]
+      description: The active core worktree posture.
+      required: [worktree_clean, trust_file_change_count]
       properties:
-        commit:
-          type: object
-          description: Algorithm-qualified object ID of the active core HEAD.
-          allOf:
-            - $ref: "#/components/schemas/GitObjectID"
         worktree_clean:
           type: boolean
           description: Whether tracked core content is clean against HEAD.

--- a/internal/server/openapi/native.yaml
+++ b/internal/server/openapi/native.yaml
@@ -1325,11 +1325,13 @@ components:
         instance:
           type: object
           description: Founding public identity material for this Thane.
-          $ref: "#/components/schemas/ThaneIdentity"
+          allOf:
+            - $ref: "#/components/schemas/ThaneIdentity"
         core:
           type: object
           description: Birth, active revision, and local verification posture.
-          $ref: "#/components/schemas/CoreIdentityEvidence"
+          allOf:
+            - $ref: "#/components/schemas/CoreIdentityEvidence"
       example:
         schema_version: 1
         observed_at: "2026-07-28T19:22:31Z"
@@ -1369,11 +1371,13 @@ components:
         identity_key:
           type: object
           description: Founding Ed25519 signing-key identity.
-          $ref: "#/components/schemas/PublicIdentityMaterial"
+          allOf:
+            - $ref: "#/components/schemas/PublicIdentityMaterial"
         channel_ca:
           type: object
           description: Founding X.509 channel certificate-authority identity.
-          $ref: "#/components/schemas/PublicIdentityMaterial"
+          allOf:
+            - $ref: "#/components/schemas/PublicIdentityMaterial"
 
     PublicIdentityMaterial:
       type: object
@@ -1397,15 +1401,18 @@ components:
         birth:
           type: object
           description: Founding commit and its asserted chronology.
-          $ref: "#/components/schemas/CoreBirthEvidence"
+          allOf:
+            - $ref: "#/components/schemas/CoreBirthEvidence"
         head:
           type: object
           description: Active core revision and worktree posture.
-          $ref: "#/components/schemas/CoreHeadEvidence"
+          allOf:
+            - $ref: "#/components/schemas/CoreHeadEvidence"
         verification:
           type: object
           description: Local admission and active-tree checks.
-          $ref: "#/components/schemas/CoreVerificationEvidence"
+          allOf:
+            - $ref: "#/components/schemas/CoreVerificationEvidence"
 
     CoreBirthEvidence:
       type: object
@@ -1415,7 +1422,8 @@ components:
         commit:
           type: object
           description: Algorithm-qualified object ID of core's birth commit.
-          $ref: "#/components/schemas/GitObjectID"
+          allOf:
+            - $ref: "#/components/schemas/GitObjectID"
         asserted_at:
           type: string
           format: date-time
@@ -1440,7 +1448,8 @@ components:
         commit:
           type: object
           description: Algorithm-qualified object ID of the active core HEAD.
-          $ref: "#/components/schemas/GitObjectID"
+          allOf:
+            - $ref: "#/components/schemas/GitObjectID"
         worktree_clean:
           type: boolean
           description: Whether tracked core content is clean against HEAD.

--- a/internal/server/openapi/native.yaml
+++ b/internal/server/openapi/native.yaml
@@ -30,7 +30,8 @@ info:
       `schedules:read`, `conversations:read`, `sessions:read`, `sessions:write`,
       `archive:read`,
       `checkpoints:read`, `checkpoints:write`, `models:read`, `models:admin`,
-      `telemetry:read`, `contacts:read`, `contacts:write`, `system:read`.
+      `telemetry:read`, `contacts:read`, `contacts:write`, `identity:read`,
+      `system:read`.
     - **Roles** bundle scopes: `observer` (all `:read`), `operator`
       (observer + `definitions:write`, `sessions:write`, `checkpoints:write`),
       `admin` (everything, incl. `models:admin`, `contacts:write`).
@@ -81,6 +82,8 @@ tags:
     description: Address book (also synced via CardDAV on a separate surface).
   - name: System
     description: Health, version, and process logs.
+  - name: Identity
+    description: Durable instance identity and core provenance evidence.
   - name: Realtime
     description: WebSocket channel for first-party live interaction.
 
@@ -102,9 +105,35 @@ x-tagGroups:
   - name: Integrations & Data
     tags: [Contacts]
   - name: Runtime
-    tags: [System, Realtime]
+    tags: [Identity, System, Realtime]
 
 paths:
+  # --------------------------------------------------------------- Identity
+  /v1/identity:
+    get:
+      tags: [Identity]
+      operationId: getIdentity
+      summary: Core-backed instance identity and provenance evidence
+      description: |
+        Returns the founding public identity material and a live local
+        verification snapshot for this instance's core root. This is evidence
+        for clients to pin and evaluate, not a remote trust verdict.
+
+        `birth.asserted_at` is a claim covered by the signed birth commit. It
+        is not an independently witnessed timestamp.
+      x-thane-scope: identity:read
+      responses:
+        "200":
+          description: Identity evidence snapshot.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/IdentityEvidence" }
+        "503":
+          description: Core identity evidence is not configured or cannot be read.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+
   # ----------------------------------------------------------------- System
   /health:
     get:
@@ -1276,6 +1305,191 @@ components:
         attrs: '{"input_tokens":9123,"output_tokens":2048}'
         source_file: internal/runtime/loop/loop.go
         source_line: 412
+
+    IdentityEvidence:
+      type: object
+      description: |
+        Core-backed identity evidence reported by this instance. Verification
+        statuses describe local checks; they do not require a remote client to
+        trust the subject's conclusions.
+      required: [schema_version, observed_at, instance, core]
+      properties:
+        schema_version:
+          type: integer
+          const: 1
+          description: Wire-schema version for forward-compatible identity consumers.
+        observed_at:
+          type: string
+          format: date-time
+          description: Time at which the live verification snapshot was produced.
+        instance:
+          type: object
+          description: Founding public identity material for this Thane.
+          $ref: "#/components/schemas/ThaneIdentity"
+        core:
+          type: object
+          description: Birth, active revision, and local verification posture.
+          $ref: "#/components/schemas/CoreIdentityEvidence"
+      example:
+        schema_version: 1
+        observed_at: "2026-07-28T19:22:31Z"
+        instance:
+          id: "thane:ed25519:SHA256:8N6XQdQfeJrVxZ5xI3a2S9Ozb5Nss4J2t7zJ1lKfJNo"
+          name: pocket
+          identity_key: { algorithm: ed25519, fingerprint: "SHA256:8N6XQdQfeJrVxZ5xI3a2S9Ozb5Nss4J2t7zJ1lKfJNo" }
+          channel_ca: { algorithm: x509-ed25519, fingerprint: "SHA256:q2QHfRjP9xjV8nL4Dzg0zz1IxF5XHFM9TPrWHhsLqXQ" }
+        core:
+          birth:
+            commit: { algorithm: sha1, oid: "0123456789abcdef0123456789abcdef01234567" }
+            asserted_at: "2026-07-01T12:00:00Z"
+            time_assurance: signed_claim
+            anchor: operator
+          head:
+            commit: { algorithm: sha1, oid: "fedcba9876543210fedcba9876543210fedcba98" }
+            worktree_clean: true
+            trust_file_change_count: 1
+          verification:
+            admission: { status: verified, detail: "single birth and trust-file history satisfy the declared seed policy" }
+            head: { status: verified, detail: "current core tree is clean and covered by a trusted signed HEAD" }
+
+    ThaneIdentity:
+      type: object
+      description: Stable identity derived from public material in core's birth commit.
+      required: [id, name, identity_key, channel_ca]
+      properties:
+        id:
+          type: string
+          description: Stable identifier derived from the founding Ed25519 public key.
+          pattern: "^thane:ed25519:SHA256:"
+          example: "thane:ed25519:SHA256:8N6XQdQfeJrVxZ5xI3a2S9Ozb5Nss4J2t7zJ1lKfJNo"
+        name:
+          type: string
+          description: Instance name asserted in the signed birth policy.
+          example: pocket
+        identity_key:
+          type: object
+          description: Founding Ed25519 signing-key identity.
+          $ref: "#/components/schemas/PublicIdentityMaterial"
+        channel_ca:
+          type: object
+          description: Founding X.509 channel certificate-authority identity.
+          $ref: "#/components/schemas/PublicIdentityMaterial"
+
+    PublicIdentityMaterial:
+      type: object
+      description: Algorithm and fingerprint for one committed public key or certificate.
+      required: [algorithm, fingerprint]
+      properties:
+        algorithm:
+          type: string
+          description: Cryptographic key or certificate algorithm.
+          example: ed25519
+        fingerprint:
+          type: string
+          description: SHA-256 fingerprint recomputed from committed birth material.
+          pattern: "^SHA256:"
+
+    CoreIdentityEvidence:
+      type: object
+      description: Birth, active revision, and verification evidence for core.
+      required: [birth, head, verification]
+      properties:
+        birth:
+          type: object
+          description: Founding commit and its asserted chronology.
+          $ref: "#/components/schemas/CoreBirthEvidence"
+        head:
+          type: object
+          description: Active core revision and worktree posture.
+          $ref: "#/components/schemas/CoreHeadEvidence"
+        verification:
+          type: object
+          description: Local admission and active-tree checks.
+          $ref: "#/components/schemas/CoreVerificationEvidence"
+
+    CoreBirthEvidence:
+      type: object
+      description: The single signed parentless commit from which core descends.
+      required: [commit, asserted_at, time_assurance, anchor]
+      properties:
+        commit:
+          type: object
+          description: Algorithm-qualified object ID of core's birth commit.
+          $ref: "#/components/schemas/GitObjectID"
+        asserted_at:
+          type: string
+          format: date-time
+          description: Time claimed by and covered by the signed birth commit.
+        time_assurance:
+          type: string
+          const: signed_claim
+          description: The time is signed locally but has no external timestamp witness.
+        anchor:
+          type: string
+          enum: [operator, self_signed, unknown]
+          description: |
+            Structural founding posture. `operator` means the seed set is not
+            solely the founding agent key; it does not reveal the operator's
+            principal or establish their real-world identity.
+
+    CoreHeadEvidence:
+      type: object
+      description: The active core revision and its local worktree posture.
+      required: [commit, worktree_clean, trust_file_change_count]
+      properties:
+        commit:
+          type: object
+          description: Algorithm-qualified object ID of the active core HEAD.
+          $ref: "#/components/schemas/GitObjectID"
+        worktree_clean:
+          type: boolean
+          description: Whether tracked core content is clean against HEAD.
+        trust_file_change_count:
+          type: integer
+          minimum: 0
+          description: Number of commits that created or changed core's trust file.
+
+    GitObjectID:
+      type: object
+      description: Git object identifier paired with its repository hash algorithm.
+      required: [algorithm, oid]
+      properties:
+        algorithm:
+          type: string
+          enum: [sha1, sha256]
+          description: Object-hash algorithm used by the Git repository.
+        oid:
+          type: string
+          description: Full Git object identifier.
+
+    CoreVerificationEvidence:
+      type: object
+      description: Separate results for founding admission and the active core tree.
+      required: [admission, head]
+      properties:
+        admission:
+          type: object
+          allOf:
+            - $ref: "#/components/schemas/IdentityVerificationCheck"
+          description: Verification of the single birth and trust-file history against declared seeds.
+        head:
+          type: object
+          allOf:
+            - $ref: "#/components/schemas/IdentityVerificationCheck"
+          description: Verification that the active tree is clean and covered by trusted signed HEAD.
+
+    IdentityVerificationCheck:
+      type: object
+      description: Result of one bounded local identity or provenance check.
+      required: [status, detail]
+      properties:
+        status:
+          type: string
+          enum: [verified, failed]
+          description: Whether the local check's stated invariant holds.
+        detail:
+          type: string
+          description: Bounded explanation that does not expose local paths or signer principals.
 
     SystemStatus:
       type: object


### PR DESCRIPTION
Thane already has a durable cryptographic identity in its core document root, but until this change only the running process could inspect it. A client could ask whether the process was healthy and which binary it was running; it could not ask which long-lived Thane it had reached, which founding commit that identity descended from, or which core state was speaking now.

`GET /v1/identity` makes that evidence a native contract.

## The identity comes from the birth commit

The endpoint does not trust loose files in the current worktree to tell it who the instance is. It finds core's single parentless commit and reads the founding policy, Ed25519 public key, and channel CA certificate from that committed tree. From those bytes it derives:

- `instance.id`, stable across restarts, hosts, API addresses, and later core commits
- the identity-key and channel-CA SHA-256 fingerprints
- the algorithm-qualified birth commit
- the founding anchor posture: `operator`, `self_signed`, or `unknown`

The active copies of that public material must still match the birth material. Identity-key or channel-CA rotation is not modeled yet, so a mismatch is refused rather than flattened into an identity that looks continuous when it is not.

## Core state gets a canonical forensic anchor

`core.current_commit` is the algorithm-qualified object ID of the active core HEAD:

```json
{
  "current_commit": {
    "algorithm": "sha1",
    "oid": "a5beada5a0caac16c98cbb99cce5f57043a40649"
  }
}
```

That is the stable join point for security records which need to say which exact axioms, policy, identity material, and other core documents were active when an event occurred. The hash algorithm travels with the OID so the contract does not quietly assume every repository will always use SHA-1.

Worktree cleanliness and trust-file change count remain separate posture facts. They describe the checkout around that commit; they are not part of the anchor itself.

## Evidence, not a self-issued trust verdict

The response separates two checks:

- **admission** verifies the single birth and trust-file history against the declared core seeds
- **head** verifies that the active tree is clean and that trusted history covers the active commit

Each reports `verified`, `failed`, or `unavailable` with bounded detail. There is deliberately no `trusted: true` and no trust score. A remote client may pin this evidence, compare it out of band, or eventually attach witness receipts to it, but the subject does not get to declare itself trusted merely because its local checks passed.

The birth timestamp follows the same rule. `core.birth.asserted_at` is covered by the signed founding commit and labeled `signed_claim`; it is not presented as an independently witnessed timestamp.

## API boundary

The route uses the narrow `identity:read` scope and is wired from the production core path and its declared seed signers. The handler is only the HTTP boundary around the package-level observer, so failure and degraded-evidence cases are exercised without teaching the server a second identity model.

The response never includes private key material, filesystem paths, signer principals, or the contents of `.allowed_signers`.

## Test plan

- [x] `just ci` clean after the final rebase
- [x] self-signed and operator-anchored founding cores derive the expected posture
- [x] stable instance ID and public fingerprints are recomputed from committed birth material
- [x] `core.current_commit` matches the core repository's actual HEAD
- [x] dirty worktree, failed admission, mismatched active identity material, and missing or malformed core artifacts retain honest failure semantics
- [x] authorized, unauthorized, unavailable, and degraded-evidence handler paths
- [x] mux registration, authorization metadata, OpenAPI, and the hand-maintained API reference agree

Closes #1316