### PR TITLE
What Thane writes about itself lives in self, not core

### DIFF
--- a/docs/understanding/document-roots.md
+++ b/docs/understanding/document-roots.md
@@ -414,13 +414,33 @@ of truth. The generated tools still write through document roots. That
 keeps path resolution, indexing, provenance, and root-level integrity
 policy in one subsystem.
 
-## Special Case: `core`
+## Special Case: the Derived Roots, `core` and `self`
 
-The `core:` root is reserved.
+Two roots are reserved. Both come from the workspace — `{workspace.path}/core`
+and `{workspace.path}/self` — and neither takes a path from `roots:`. You may
+still name either one there to set policy; a path given alongside policy is
+ignored.
 
-It always comes from `{workspace.path}/core` and is not configured
-manually in `paths:`. That is where Thane's always-on identity and core
-reference files live.
+They are two roots rather than one because they answer to different
+authorities, and that difference is the whole point of the split.
+
+`core` is what an operator declares Thane to be, and what constrains it:
+axioms, persona, mission, the runtime config, talents, and loop definitions.
+Nothing an agent writes belongs in it. That is what lets an install narrow
+`core`'s signers to the operator alone and set `authoring: read_only` on it —
+the posture we recommend, and the only way to shield `config.yaml` from
+agent editing. It is also what makes `core`'s HEAD worth reading as evidence:
+it moves when the operator moves it.
+
+`self` is what Thane makes of that — its self-concept, its running
+observations, its memory of its own work. The core service loops maintain it:
+`self:ego.md`, `self:metacognitive.md`, `self:archivist.md`. It wants the same
+integrity treatment as `core` — signed history, admission, verification — under
+its own signer set, because the agent is its author.
+
+Both are derived rather than declared because the core service loops write
+`self` on every install. A root an operator had to remember to declare would
+leave a fresh install with nowhere for those documents to land.
 
 ## The Human-Level Rule
 

--- a/internal/app/core_loop_report.go
+++ b/internal/app/core_loop_report.go
@@ -185,7 +185,7 @@ func coreLoopDefinitionWarnings(spec looppkg.Spec) []string {
 		// parent does not inherit the default, it lands at the root.
 		// Silent re-parenting empties the container an operator can see
 		// and gives no sign why.
-		warnings = append(warnings, "declares no parent_name, so this core service loop will hang at the graph root rather than under "+cognitionContainerName+"; a definition document does not inherit the built-in parent")
+		warnings = append(warnings, "declares no parent_name, so this core service loop will hang at the graph root rather than under "+selfContainerName+"; a definition document does not inherit the built-in parent")
 	}
 	for _, warning := range looppkg.BuildDefinitionWarnings(spec) {
 		warnings = append(warnings, warning.Message)

--- a/internal/app/core_loop_report_test.go
+++ b/internal/app/core_loop_report_test.go
@@ -18,7 +18,7 @@ const facetedCoreLoop = "# Metacognitive\n\n" +
 	"## Spec\n\n" +
 	"```yaml\n" +
 	"name: metacognitive\n" +
-	"parent_name: cognition\n" +
+	"parent_name: self\n" +
 	"enabled: true\n" +
 	"operation: service\n" +
 	"sleep_min: 15m\n" +
@@ -69,7 +69,7 @@ func TestCoreLoopReportNamesWhatTheDocumentProduces(t *testing.T) {
 	if !report.OK() {
 		t.Fatalf("report.Err = %v, want a clean load", report.Err)
 	}
-	if report.Name != "metacognitive" || report.ParentName != "cognition" {
+	if report.Name != "metacognitive" || report.ParentName != "self" {
 		t.Errorf("name/parent = %q/%q, want metacognitive/cognition", report.Name, report.ParentName)
 	}
 	want := []string{"publish_output_metacognitive_state", "replace_output_metacognitive_notes"}
@@ -120,7 +120,7 @@ func TestCoreLoopReportCoversEveryDocument(t *testing.T) {
 // root, and nothing about a successful boot says so.
 func TestCoreLoopReportWarnsOnAnUnparentedCoreLoop(t *testing.T) {
 	core := writeCoreLoop(t, map[string]string{
-		"metacognitive.md": strings.Replace(facetedCoreLoop, "parent_name: cognition\n", "", 1),
+		"metacognitive.md": strings.Replace(facetedCoreLoop, "parent_name: self\n", "", 1),
 	})
 
 	report := findCoreLoopReport(t, CheckCoreLoopDefinitions(coreLoopConfig(core)), "metacognitive.md")
@@ -130,7 +130,7 @@ func TestCoreLoopReportWarnsOnAnUnparentedCoreLoop(t *testing.T) {
 	if len(report.Warnings) == 0 {
 		t.Fatal("an unparented core service loop produced no warning")
 	}
-	if !strings.Contains(report.Warnings[0], cognitionContainerName) {
+	if !strings.Contains(report.Warnings[0], selfContainerName) {
 		t.Errorf("warning = %q, want it to name the parent that was not inherited", report.Warnings[0])
 	}
 }

--- a/internal/app/coreloop_docs_parity_test.go
+++ b/internal/app/coreloop_docs_parity_test.go
@@ -139,8 +139,8 @@ func TestBuiltInSpecsNowComeFromTheShippedDocuments(t *testing.T) {
 			if err != nil {
 				t.Fatalf("decodeCoreLoopDefinition: %v", err)
 			}
-			if got.ParentName != cognitionContainerName {
-				t.Errorf("parent_name = %q, want %q from the document itself — nothing assigns it afterwards", got.ParentName, cognitionContainerName)
+			if got.ParentName != selfContainerName {
+				t.Errorf("parent_name = %q, want %q from the document itself — nothing assigns it afterwards", got.ParentName, selfContainerName)
 			}
 			if !reflect.DeepEqual(got, want) {
 				t.Fatalf("the booted spec is not the shipped document's:\ngot  %#v\nwant %#v", got, want)

--- a/internal/app/corepaths.go
+++ b/internal/app/corepaths.go
@@ -4,13 +4,6 @@ import (
 	"github.com/nugget/thane-ai-agent/internal/platform/config"
 )
 
-func coreRootPath(workspacePath string) string {
-	cfg := config.Config{
-		Workspace: config.WorkspaceConfig{Path: workspacePath},
-	}
-	return cfg.CoreRoot()
-}
-
 func coreFilePath(workspacePath, name string) string {
 	cfg := config.Config{
 		Workspace: config.WorkspaceConfig{Path: workspacePath},

--- a/internal/app/document_root_admission.go
+++ b/internal/app/document_root_admission.go
@@ -63,27 +63,34 @@ func documentRootPaths(cfg *config.Config, logger *slog.Logger) map[string]strin
 	for name, path := range cfg.Paths {
 		out[name] = path
 	}
-	derivedCore := ""
-	if cfg.Workspace.Path != "" {
-		derivedCore = coreRootPath(cfg.Workspace.Path)
-	}
-	if derivedCore == "" {
+	if cfg.Workspace.Path == "" {
 		return out
 	}
-	for name, path := range out {
-		if strings.TrimSuffix(name, ":") != "core" {
+	// Both derived roots get the same treatment, so adding one is an
+	// entry here rather than a second copy of this loop.
+	for rootName, derived := range map[string]string{
+		config.CoreRootName: cfg.CoreRoot(),
+		config.SelfRootName: cfg.SelfRoot(),
+	} {
+		if derived == "" {
 			continue
 		}
-		if strings.TrimSpace(path) != derivedCore && logger != nil {
-			logger.Info("ignoring configured core path; core root is derived from workspace.path",
-				"configured_key", name,
-				"configured_path", path,
-				"derived_path", derivedCore,
-			)
+		for name, path := range out {
+			if strings.TrimSuffix(name, ":") != rootName {
+				continue
+			}
+			if strings.TrimSpace(path) != derived && logger != nil {
+				logger.Info("ignoring configured root path; this root is derived from workspace.path",
+					"root", rootName,
+					"configured_key", name,
+					"configured_path", path,
+					"derived_path", derived,
+				)
+			}
+			delete(out, name)
 		}
-		delete(out, name)
+		out[rootName] = derived
 	}
-	out["core"] = derivedCore
 	return out
 }
 

--- a/internal/app/document_root_admission_test.go
+++ b/internal/app/document_root_admission_test.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"log/slog"
+	"path/filepath"
 	"testing"
 
 	"github.com/nugget/thane-ai-agent/internal/platform/config"
@@ -233,5 +234,39 @@ func TestRootAdmissionCoversTheReservedCoreRoot(t *testing.T) {
 	results = CheckRootAdmission(t.Context(), stranger)
 	if len(results) != 1 || results[0].Admitted() {
 		t.Fatalf("validate should report core unadmitted, got %+v", results)
+	}
+}
+
+// TestSelfRootIsDerivedLikeCore pins what makes self usable by a shipped
+// document. The core loops write self: on every install, so the root has
+// to exist without an operator declaring it — and its path has to come
+// from the workspace, not from roots:, or two installs could disagree
+// about where self:metacognitive.md is while running the same document.
+func TestSelfRootIsDerivedLikeCore(t *testing.T) {
+	workspace := t.TempDir()
+	cfg := &config.Config{Workspace: config.WorkspaceConfig{Path: workspace}}
+
+	paths := documentRootPaths(cfg, nil)
+	if got, want := paths[config.SelfRootName], filepath.Join(workspace, "self"); got != want {
+		t.Errorf("self root = %q, want %q", got, want)
+	}
+	if got, want := paths[config.CoreRootName], filepath.Join(workspace, "core"); got != want {
+		t.Errorf("core root = %q, want %q", got, want)
+	}
+}
+
+// TestSelfRootIgnoresAConfiguredPath mirrors core's rule. A derived root
+// whose path could also be declared would let roots: and workspace.path
+// disagree, and the shipped documents name self: with no way to ask
+// which one won.
+func TestSelfRootIgnoresAConfiguredPath(t *testing.T) {
+	workspace := t.TempDir()
+	cfg := &config.Config{
+		Workspace: config.WorkspaceConfig{Path: workspace},
+		Paths:     map[string]string{config.SelfRootName: "/somewhere/else"},
+	}
+
+	if got, want := documentRootPaths(cfg, nil)[config.SelfRootName], filepath.Join(workspace, "self"); got != want {
+		t.Errorf("self root = %q, want the derived %q; a configured path must not win", got, want)
 	}
 }

--- a/internal/app/loop_definition_builtins.go
+++ b/internal/app/loop_definition_builtins.go
@@ -29,8 +29,15 @@ const (
 // members that are themselves base definitions (dynamically-spawned members,
 // e.g. channel loops, need a different mechanism — they spawn before the
 // definition-driven containers are live).
+// selfContainerName deliberately matches [config.SelfRootName]. The
+// loops in this container are exactly the loops that write that document
+// root, so one name covers one idea: a reader seeing `parent: self`
+// beside an output ref of `self:metacognitive.md` is looking at two
+// views of the same thing. They stay separate constants because a loop
+// container and a document root are different namespaces, and renaming
+// one should not silently rename the other.
 const (
-	cognitionContainerName     = "cognition"
+	selfContainerName          = "self"
 	homeAssistantContainerName = "home-assistant"
 	pollersContainerName       = "pollers"
 )
@@ -67,8 +74,8 @@ func builtInContainerDefinitionSpecs(cfg *config.Config, declared map[string]str
 	var specs []looppkg.Spec
 
 	if anyCoreServiceLoopWanted(cfg, declared) {
-		specs = append(specs, containerSpec(cognitionContainerName,
-			"Core cognition loops: reflection, identity, and memory."))
+		specs = append(specs, containerSpec(selfContainerName,
+			"The loops that attend to Thane itself: reflection, identity, and memory. They maintain the self document root."))
 	}
 	if cfg.HomeAssistant.Configured() || cfg.MQTT.Configured() {
 		specs = append(specs, containerSpec(homeAssistantContainerName,

--- a/internal/app/loop_definition_builtins_test.go
+++ b/internal/app/loop_definition_builtins_test.go
@@ -8,9 +8,9 @@ import "testing"
 // (non-actionable) deprecation warning and lose their intent once the #1106
 // one-release fallback is removed.
 func TestContainerSpec_IntentIsFirstClass(t *testing.T) {
-	spec := containerSpec("cognition", "Core cognition loops.")
+	spec := containerSpec("self", "The loops that attend to Thane itself.")
 
-	if spec.Intent != "Core cognition loops." {
+	if spec.Intent != "The loops that attend to Thane itself." {
 		t.Errorf("containerSpec Intent = %q, want it on the first-class field", spec.Intent)
 	}
 	if _, ok := spec.Metadata["intent"]; ok {

--- a/internal/app/loop_definition_hydration_test.go
+++ b/internal/app/loop_definition_hydration_test.go
@@ -314,7 +314,7 @@ func TestBuildLoopDefinitionBaseSpecs_GroupingContainers(t *testing.T) {
 	}
 
 	// Containers exist and are inert grouping containers.
-	for _, name := range []string{cognitionContainerName, homeAssistantContainerName, pollersContainerName} {
+	for _, name := range []string{selfContainerName, homeAssistantContainerName, pollersContainerName} {
 		s, ok := byName[name]
 		if !ok {
 			t.Errorf("grouping container %q missing from base specs", name)
@@ -342,7 +342,7 @@ func TestBuildLoopDefinitionBaseSpecs_GroupingContainers(t *testing.T) {
 		}
 	}
 
-	assertNested(cognitionContainerName, ego.DefinitionName, metacognitive.DefinitionName, archivist.DefinitionName)
+	assertNested(selfContainerName, ego.DefinitionName, metacognitive.DefinitionName, archivist.DefinitionName)
 	assertNested(homeAssistantContainerName, haStateWatcherDefinitionName, mqttPublisherDefinitionName, telemetryDefinitionName, mqtt.DefaultHandlerLoopName)
 	// The four pollers and the two triage handlers that used to hang off core.
 	assertNested(pollersContainerName,
@@ -370,7 +370,7 @@ func TestBuiltInContainerDefinitionSpecs_Gating(t *testing.T) {
 		t.Errorf("bare config seeded a gated container, want none: %v", bare)
 	}
 
-	if cog := names(builtInContainerDefinitionSpecsForTest(coreServiceTestConfig())); !cog[cognitionContainerName] {
+	if cog := names(builtInContainerDefinitionSpecsForTest(coreServiceTestConfig())); !cog[selfContainerName] {
 		t.Error("cognition container missing when core loops enabled")
 	}
 

--- a/internal/app/loop_definitions_core_dir_test.go
+++ b/internal/app/loop_definitions_core_dir_test.go
@@ -500,7 +500,7 @@ func TestSecondYAMLDocumentInTheSpecBlockIsRefused(t *testing.T) {
 func TestCoreDefinitionKeepsItsDeclaredParent(t *testing.T) {
 	core := writeCoreLoop(t, map[string]string{
 		"ego.md": strings.NewReplacer(
-			"name: ranch_watch", "name: ego\nparent_name: "+cognitionContainerName,
+			"name: ranch_watch", "name: ego\nparent_name: "+selfContainerName,
 		).Replace(minimalCoreLoop),
 	})
 	app := &App{cfg: &config.Config{
@@ -518,15 +518,15 @@ func TestCoreDefinitionKeepsItsDeclaredParent(t *testing.T) {
 		switch spec.Name {
 		case "ego":
 			ego = spec
-		case cognitionContainerName:
+		case selfContainerName:
 			container = true
 		}
 	}
-	if ego.ParentName != cognitionContainerName {
-		t.Errorf("parent_name = %q, want the document's %q", ego.ParentName, cognitionContainerName)
+	if ego.ParentName != selfContainerName {
+		t.Errorf("parent_name = %q, want the document's %q", ego.ParentName, selfContainerName)
 	}
 	if !container {
-		t.Errorf("%q is absent, so the declared parent resolves to nothing", cognitionContainerName)
+		t.Errorf("%q is absent, so the declared parent resolves to nothing", selfContainerName)
 	}
 }
 
@@ -542,7 +542,7 @@ func TestCoreDefinitionKeepsItsDeclaredParent(t *testing.T) {
 func TestConfigDisabledDocumentLoopStillGetsItsContainer(t *testing.T) {
 	core := writeCoreLoop(t, map[string]string{
 		"metacognitive.md": strings.NewReplacer(
-			"name: ranch_watch", "name: metacognitive\nparent_name: "+cognitionContainerName,
+			"name: ranch_watch", "name: metacognitive\nparent_name: "+selfContainerName,
 		).Replace(minimalCoreLoop),
 	})
 	// Every core service loop disabled: the document is the only reason
@@ -566,17 +566,17 @@ func TestConfigDisabledDocumentLoopStillGetsItsContainer(t *testing.T) {
 		switch spec.Name {
 		case "metacognitive":
 			loop = spec
-		case cognitionContainerName:
+		case selfContainerName:
 			container = true
 		}
 	}
 	if loop.Name == "" {
 		t.Fatal("the document defines the loop, so it must be registered even with config disabled")
 	}
-	if loop.ParentName != cognitionContainerName {
-		t.Fatalf("parent_name = %q, want %q", loop.ParentName, cognitionContainerName)
+	if loop.ParentName != selfContainerName {
+		t.Fatalf("parent_name = %q, want %q", loop.ParentName, selfContainerName)
 	}
 	if !container {
-		t.Errorf("%q is absent, so the declared parent resolves to nothing and the loop silently lands at the root", cognitionContainerName)
+		t.Errorf("%q is absent, so the declared parent resolves to nothing and the loop silently lands at the root", selfContainerName)
 	}
 }

--- a/internal/app/new_agent.go
+++ b/internal/app/new_agent.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/nugget/thane-ai-agent/internal/integrations/homeassistant"
+	"github.com/nugget/thane-ai-agent/internal/platform/config"
 	"github.com/nugget/thane-ai-agent/internal/platform/paths"
 	"github.com/nugget/thane-ai-agent/internal/runtime/agent"
 )
@@ -32,8 +33,15 @@ func (a *App) initAgentLoop(s *newState) error {
 	// LoopOptions instead of post-construction setters.
 	if cfg.Workspace.Path != "" {
 		cfg.Paths = documentRootPaths(cfg, logger)
-		if err := os.MkdirAll(cfg.Paths["core"], 0o755); err != nil {
-			return fmt.Errorf("create core document root: %w", err)
+		// Both derived roots are created, because both are written on a
+		// default install: core holds what the operator declares, self
+		// holds what the loops write about themselves. A self root that
+		// only appeared once a loop first wrote would leave an operator
+		// unable to declare policy on a directory that does not exist.
+		for _, root := range []string{config.CoreRootName, config.SelfRootName} {
+			if err := os.MkdirAll(cfg.Paths[root], 0o755); err != nil {
+				return fmt.Errorf("create %s document root: %w", root, err)
+			}
 		}
 	}
 

--- a/internal/model/prompts/archivist.go
+++ b/internal/model/prompts/archivist.go
@@ -28,9 +28,9 @@ dossiers when something jogs a memory of that subject.
 ## Your Durable Output
 
 Your working state is injected in the "Declared Durable Outputs" block.
-That block shows core:archivist.md when it exists and names the
-generated replacement tool for the document. It holds dossier pointers
-and notes — NOT the work queue (the durable queue holds that).
+It names the document you maintain and the generated tool that writes it.
+That document holds dossier pointers and notes — NOT the work queue (the
+durable queue holds that).
 
 ## What To Do This Iteration
 

--- a/internal/model/prompts/metacognitive.go
+++ b/internal/model/prompts/metacognitive.go
@@ -12,8 +12,8 @@ observe, and adapts your own wake cycle.
 ## Your Durable Output
 
 Your current durable output contract is injected in the "Declared Durable
-Outputs" block. That block shows core:metacognitive.md when it exists and
-names the generated replacement tool for the document.
+Outputs" block. It names the document you maintain and the generated tool
+that writes it.
 
 ## What To Do This Iteration
 

--- a/internal/platform/config/config.go
+++ b/internal/platform/config/config.go
@@ -55,6 +55,14 @@ const DefaultWorkspace = "~/Thane"
 // ConfigFileName is the fixed name of the runtime config inside core.
 const ConfigFileName = "config.yaml"
 
+// CoreRootName and SelfRootName are the two document roots whose paths
+// are derived from the workspace rather than declared. Both may be named
+// in roots: to set policy, and neither takes a path from there.
+const (
+	CoreRootName = "core"
+	SelfRootName = "self"
+)
+
 // legacyConfigLocations are the paths Thane searched before the config
 // moved inside the trust boundary. They are no longer loaded; they are
 // probed only so a failure to find the real config can say where the old
@@ -2671,17 +2679,17 @@ func (c *Config) normalizeRoots() error {
 			}
 			seen[trimmed] = name
 			pathValue := strings.TrimSpace(entry.Path)
-			// core: is reserved — its path is always derived from
-			// workspace.path. Allow declaring it in roots: solely
-			// to set policy; ignore any path that was provided.
-			if trimmed == "core" {
+			// core: and self: are reserved — their paths are always
+			// derived from workspace.path. Allow declaring either in
+			// roots: solely to set policy; ignore any path provided.
+			if isDerivedRootName(trimmed) {
 				if pathValue != "" && !entryHasPolicy(entry) {
-					slog.Default().Warn("config: roots.core path is ignored (core derives from workspace.path); declare core: only when setting policy",
-						"path", entry.Path)
+					slog.Default().Warn("config: derived root path is ignored (it comes from workspace.path); declare this root only when setting policy",
+						"root", trimmed, "path", entry.Path)
 				}
 			} else {
 				if pathValue == "" {
-					return fmt.Errorf("config: roots.%s.path must be set for non-core roots", trimmed)
+					return fmt.Errorf("config: roots.%s.path must be set; only the derived roots (%s, %s) take their path from workspace.path", trimmed, CoreRootName, SelfRootName)
 				}
 				c.Paths[trimmed] = entry.Path
 			}
@@ -3562,6 +3570,36 @@ func (c *Config) CoreRoot() string {
 		return ""
 	}
 	return filepath.Join(c.Workspace.Path, "core")
+}
+
+// SelfRoot returns the fixed document root holding what Thane writes
+// about itself, derived from [Workspace.Path] exactly as [CoreRoot] is.
+// When workspace.path is unset, SelfRoot returns the empty string.
+//
+// It is a sibling of core rather than a directory inside it because the
+// two answer to different authorities. core is what an operator declares
+// Thane to be and what constrains it — identity, config, talents, loop
+// definitions — and an install should be able to hold every commit in it
+// to an operator signature. self is what Thane makes of that: its
+// self-concept, its running observations, its memory of its own work.
+// Both want signed history; only one wants the operator as its only
+// author, and a root is the unit that policy attaches to.
+//
+// Derived rather than declared, for the same reason core is. The core
+// service loops write here on every install, so a root an operator had
+// to remember to declare would leave a fresh install with nowhere for
+// those outputs to land.
+// isDerivedRootName reports whether a root takes its path from the
+// workspace rather than from roots:.
+func isDerivedRootName(name string) bool {
+	return name == CoreRootName || name == SelfRootName
+}
+
+func (c *Config) SelfRoot() string {
+	if strings.TrimSpace(c.Workspace.Path) == "" {
+		return ""
+	}
+	return filepath.Join(c.Workspace.Path, SelfRootName)
 }
 
 // CoreFile returns the absolute-or-relative path to a named file in the

--- a/internal/runtime/archivist/archivist.go
+++ b/internal/runtime/archivist/archivist.go
@@ -124,7 +124,7 @@ func DefinitionSpec(cfg Config) loop.Spec {
 			{
 				Name: "archivist_state",
 				Type: loop.OutputTypeMaintainedDocument,
-				Ref:  "core:archivist.md",
+				Ref:  "self:archivist.md",
 				Mode: loop.OutputModeReplace,
 				Purpose: "Archivist working state written by the archivist loop, for the archivist. Tracks: " +
 					"the subjects worked this pass, dossier pointers (which dossiers exist and where), " +

--- a/internal/runtime/archivist/archivist_test.go
+++ b/internal/runtime/archivist/archivist_test.go
@@ -91,8 +91,8 @@ func TestDefinitionSpec_Outputs(t *testing.T) {
 		t.Fatalf("Outputs len = %d, want 1", len(spec.Outputs))
 	}
 	out := spec.Outputs[0]
-	if out.Ref != "core:archivist.md" {
-		t.Errorf("Outputs[0].Ref = %q, want core:archivist.md", out.Ref)
+	if out.Ref != "self:archivist.md" {
+		t.Errorf("Outputs[0].Ref = %q, want self:archivist.md", out.Ref)
 	}
 	if out.Type != loop.OutputTypeMaintainedDocument {
 		t.Errorf("Outputs[0].Type = %q, want maintained_document", out.Type)

--- a/internal/runtime/metacognitive/metacognitive.go
+++ b/internal/runtime/metacognitive/metacognitive.go
@@ -109,7 +109,7 @@ func DefinitionSpec(cfg Config) loop.Spec {
 			{
 				Name:    "metacognitive_state",
 				Type:    loop.OutputTypeMaintainedDocument,
-				Ref:     "core:metacognitive.md",
+				Ref:     "self:metacognitive.md",
 				Mode:    loop.OutputModeReplace,
 				Purpose: "Current metacognitive state: active concerns, recent observations, actions taken, and sleep reasoning that should persist across fresh loop iterations.",
 			},

--- a/internal/runtime/metacognitive/metacognitive_test.go
+++ b/internal/runtime/metacognitive/metacognitive_test.go
@@ -117,8 +117,8 @@ func TestHydratedSpec(t *testing.T) {
 	if spec.Outputs[0].Name != "metacognitive_state" {
 		t.Errorf("Outputs[0].Name = %q, want metacognitive_state", spec.Outputs[0].Name)
 	}
-	if spec.Outputs[0].Ref != "core:metacognitive.md" {
-		t.Errorf("Outputs[0].Ref = %q, want core:metacognitive.md", spec.Outputs[0].Ref)
+	if spec.Outputs[0].Ref != "self:metacognitive.md" {
+		t.Errorf("Outputs[0].Ref = %q, want self:metacognitive.md", spec.Outputs[0].Ref)
 	}
 }
 

--- a/loops/archivist.md
+++ b/loops/archivist.md
@@ -9,7 +9,7 @@ tags: [loops]
 
 ```yaml
 name: archivist
-parent_name: cognition
+parent_name: self
 enabled: true
 profile:
     quality_floor: 5
@@ -22,7 +22,7 @@ completion: none
 outputs:
     - name: archivist_state
       type: maintained_document
-      ref: core:archivist.md
+      ref: self:archivist.md
       mode: replace
       purpose: 'Archivist working state written by the archivist loop, for the archivist. Tracks: the subjects worked this pass, dossier pointers (which dossiers exist and where), and notes from the last few iterations. Read each turn so the archivist picks up where it left off. The durable work queue (not this file) holds pending subjects. NOT a public-facing document; the dossiers themselves are the model-facing output.'
 tags:
@@ -92,9 +92,9 @@ dossiers when something jogs a memory of that subject.
 ## Your Durable Output
 
 Your working state is injected in the "Declared Durable Outputs" block.
-That block shows core:archivist.md when it exists and names the
-generated replacement tool for the document. It holds dossier pointers
-and notes — NOT the work queue (the durable queue holds that).
+It names the document you maintain and the generated tool that writes it.
+That document holds dossier pointers and notes — NOT the work queue (the
+durable queue holds that).
 
 ## What To Do This Iteration
 

--- a/loops/ego.md
+++ b/loops/ego.md
@@ -9,7 +9,7 @@ tags: [loops]
 
 ```yaml
 name: ego
-parent_name: cognition
+parent_name: self
 enabled: true
 profile:
     quality_floor: 5

--- a/loops/metacognitive.md
+++ b/loops/metacognitive.md
@@ -9,7 +9,7 @@ tags: [loops]
 
 ```yaml
 name: metacognitive
-parent_name: cognition
+parent_name: self
 enabled: true
 profile:
     quality_floor: 3
@@ -22,7 +22,7 @@ completion: none
 outputs:
     - name: metacognitive_state
       type: maintained_document
-      ref: core:metacognitive.md
+      ref: self:metacognitive.md
       mode: replace
       purpose: 'Current metacognitive state: active concerns, recent observations, actions taken, and sleep reasoning that should persist across fresh loop iterations.'
 tags:
@@ -70,8 +70,8 @@ observe, and adapts your own wake cycle.
 ## Your Durable Output
 
 Your current durable output contract is injected in the "Declared Durable
-Outputs" block. That block shows core:metacognitive.md when it exists and
-names the generated replacement tool for the document.
+Outputs" block. It names the document you maintain and the generated tool
+that writes it.
 
 ## What To Do This Iteration
 


### PR DESCRIPTION
**Stacked on #1317** — merge that first; this branch contains its commits.

First implementation step of #1318.

## Why

#1316 shapes `core` into the instance's identity evidence: a birth commit, a signing identity, an admission result, a HEAD an operator can pin, and a posture claim about who has been entitled to change it since. That claim cannot hold while the agent writes to core every fifteen minutes.

The posture we want to promote by default is operator-only signers on `core`, with `config.yaml` shielded from agent editing. Agent-authored state needs the same integrity treatment core gets — signed history, admission, verification — under its own signer set. So it needs its own root, not a corner of core's.

## `self`

Derived from the workspace exactly as `core` is, for the same reason: the core service loops write it on every install, so a root an operator had to remember to declare would leave a fresh install with nowhere for those documents to land. `roots.self:` may still be named to set policy, and a path given there is ignored — core's existing rule, now applied to both through one code path instead of two copies of a special case.

Both derived roots are created at boot, so an operator can declare policy on a directory that exists.

## What moves, and what doesn't

`metacognitive` and `archivist` move here — their refs live in the shipped documents, so it is a ref change.

**`ego` does not.** Its document is read back through a core-scoped `provenance.Store` with revision history ([core_context.go:257](internal/runtime/agent/core_context.go:257)), not through a path, so moving it is a rewiring rather than a ref change. It gets its own PR.

## The container is renamed `self`

Its members are exactly the loops that write this root, so one name covers one idea: `parent: self` beside an output ref of `self:metacognitive.md` is two views of the same thing, where `cognition` and `self:` were two names for it. The constants stay separate — a loop container and a document root are different namespaces, and renaming one should not silently rename the other.

## Both prompts stop naming their own output ref

The "Declared Durable Outputs" block already states the ref verbatim, so the prose was a copy of a value — and it is the copy that just went stale, in this commit, exactly as the sleep durations did when the envelope moved in #1313. The prose keeps the part a prompt should carry: that the block names the document and the tool.

## Breaking

An existing install's loops now write `self:metacognitive.md` and `self:archivist.md`, so an upgrade starts them with empty documents unless the operator moves the files across. There is no automatic migration, deliberately: a boot-time copy would write into `core`, which is the direction this change exists to close.

## Test plan

- [x] `just ci` clean, no architecture drift, generated mirror and example config regenerated
- [x] `self` derives to `{workspace}/self`; a configured path for it is ignored, same as core
- [x] Parity tests hold across the ref and prose changes on both sides
- [x] Full `go test ./internal/... ./cmd/...` sweep green

## Follow-ups in #1318

- `ego.md` and its provenance-backed injection
- Generalizing the `coreintegrity` checks per-root, so `self` is held to core's standard rather than a weaker one
- `core` to `authoring: read_only` — last, since `Store.Write` gates the generated output tools on it

Refs #1318
Refs #1086