### PR TITLE
A revision should say which mind wrote it

### DIFF
--- a/internal/app/corepaths.go
+++ b/internal/app/corepaths.go
@@ -4,6 +4,10 @@ import (
 	"github.com/nugget/thane-ai-agent/internal/platform/config"
 )
 
+// coreDocumentRoot is the reserved name of the core document root, whose path
+// is always derived from the workspace rather than configured.
+const coreDocumentRoot = "core"
+
 func coreRootPath(workspacePath string) string {
 	cfg := config.Config{
 		Workspace: config.WorkspaceConfig{Path: workspacePath},

--- a/internal/app/document_root_reviser.go
+++ b/internal/app/document_root_reviser.go
@@ -106,6 +106,7 @@ func revisionRefFromProvenance(rev provenance.Revision) documents.RevisionRef {
 		Index:     rev.Index,
 		Timestamp: rev.Timestamp,
 		Message:   rev.Message,
+		Trailers:  rev.Trailers,
 	}
 	if rev.Signer != nil {
 		s := revisionSignerFromProvenance(*rev.Signer)

--- a/internal/app/document_root_trailers.go
+++ b/internal/app/document_root_trailers.go
@@ -1,0 +1,73 @@
+package app
+
+import (
+	"context"
+	"strconv"
+	"strings"
+
+	"github.com/nugget/thane-ai-agent/internal/platform/provenance"
+	"github.com/nugget/thane-ai-agent/internal/state/documents"
+	"github.com/nugget/thane-ai-agent/internal/tools"
+)
+
+// withTurnProvenance appends the current turn's identifying facts to a commit
+// message as git trailers. Every git-backed root write funnels through this
+// writer, so this is the one place that can record which model wrote a
+// revision, under which loop, session, and request.
+//
+// These facts are only knowable at write time. Recovering them afterwards
+// means joining the conversation store against the request log and hoping both
+// retained the window, which is why they are committed here instead: a root
+// whose history names the mind behind each revision is better evidence than
+// one that leaves the reader to reconstruct it.
+//
+// The trailers are written into the message rather than attached as notes so
+// that the commit signature covers them.
+func (w *documentRootProvenanceWriter) withTurnProvenance(ctx context.Context, message string) string {
+	trailers := make([]string, 0, 8)
+	add := func(key, value string) {
+		if value = strings.TrimSpace(value); value != "" {
+			trailers = append(trailers, key+": "+value)
+		}
+	}
+
+	add(documents.TrailerModel, tools.ModelFromContext(ctx))
+	add(documents.TrailerLoopID, tools.LoopIDFromContext(ctx))
+	// ConversationIDFromContext reports "default" outside a conversation, which
+	// identifies nothing worth committing.
+	if conversationID := tools.ConversationIDFromContext(ctx); conversationID != "default" {
+		add(documents.TrailerConversation, conversationID)
+	}
+	add(documents.TrailerSession, tools.SessionIDFromContext(ctx))
+	add(documents.TrailerRequest, tools.RequestIDFromContext(ctx))
+	add(documents.TrailerToolCall, tools.ToolCallIDFromContext(ctx))
+	if iteration, ok := tools.IterationIndexFromContext(ctx); ok {
+		add(documents.TrailerIteration, strconv.Itoa(iteration))
+	}
+	add(documents.TrailerCoreHead, w.coreHeadAt(ctx))
+
+	if len(trailers) == 0 {
+		return message
+	}
+	return strings.TrimRight(message, "\n") + "\n\n" + strings.Join(trailers, "\n") + "\n"
+}
+
+// coreHeadAt reports the core root's HEAD so a revision records which identity
+// snapshot produced it. What Thane wrote is only fully legible beside the
+// axioms, persona, mission, and talents it was working from, and those live in
+// a root that moves independently of this one. Pinning core's commit here is
+// what lets a reader recover that pairing years later.
+//
+// Empty on core's own writes, where it would restate the parent commit, and
+// empty when core has no history or cannot be read — this is enrichment, and
+// failing to read it must never fail the write that carries it.
+func (w *documentRootProvenanceWriter) coreHeadAt(ctx context.Context) string {
+	if w == nil || w.corePath == "" || w.root == coreDocumentRoot {
+		return ""
+	}
+	head, err := provenance.HeadCommit(ctx, w.corePath)
+	if err != nil {
+		return ""
+	}
+	return head
+}

--- a/internal/app/document_root_trailers_test.go
+++ b/internal/app/document_root_trailers_test.go
@@ -1,0 +1,122 @@
+package app
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/nugget/thane-ai-agent/internal/state/documents"
+	"github.com/nugget/thane-ai-agent/internal/tools"
+)
+
+// A commit message is the only place a document root can say which turn
+// produced a revision, so these cases pin what survives the trip: the facts
+// that were present, in trailer form, without disturbing the subject a caller
+// wrote.
+func TestWithTurnProvenance(t *testing.T) {
+	fullTurn := func(ctx context.Context) context.Context {
+		ctx = tools.WithModel(ctx, "gpt-oss:120b")
+		ctx = tools.WithLoopID(ctx, "loop-abc")
+		ctx = tools.WithConversationID(ctx, "loop-metacognitive-1-123")
+		ctx = tools.WithSessionID(ctx, "sess-1")
+		ctx = tools.WithRequestID(ctx, "r_deadbeef")
+		ctx = tools.WithToolCallID(ctx, "tc-1")
+		return tools.WithIterationIndex(ctx, 3)
+	}
+
+	tests := []struct {
+		name    string
+		writer  *documentRootProvenanceWriter
+		ctx     func(context.Context) context.Context
+		message string
+		want    map[string]string
+		absent  []string
+	}{
+		{
+			name:    "records every fact the turn carried",
+			writer:  &documentRootProvenanceWriter{root: "self"},
+			ctx:     fullTurn,
+			message: "doc_write self:metacognitive.md",
+			want: map[string]string{
+				documents.TrailerModel:        "gpt-oss:120b",
+				documents.TrailerLoopID:       "loop-abc",
+				documents.TrailerConversation: "loop-metacognitive-1-123",
+				documents.TrailerSession:      "sess-1",
+				documents.TrailerRequest:      "r_deadbeef",
+				documents.TrailerToolCall:     "tc-1",
+				documents.TrailerIteration:    "3",
+			},
+		},
+		{
+			name:    "a turn that knows nothing leaves the message alone",
+			writer:  &documentRootProvenanceWriter{root: "self"},
+			ctx:     func(ctx context.Context) context.Context { return ctx },
+			message: "doc_write self:metacognitive.md",
+			want:    map[string]string{},
+		},
+		{
+			name:   "the default conversation identifies nothing and is omitted",
+			writer: &documentRootProvenanceWriter{root: "self"},
+			ctx: func(ctx context.Context) context.Context {
+				return tools.WithModel(ctx, "gpt-oss:120b")
+			},
+			message: "doc_write self:ego.md",
+			want:    map[string]string{documents.TrailerModel: "gpt-oss:120b"},
+			absent:  []string{documents.TrailerConversation},
+		},
+		{
+			name:    "core does not restate its own parent commit",
+			writer:  &documentRootProvenanceWriter{root: coreDocumentRoot, corePath: t.TempDir()},
+			ctx:     fullTurn,
+			message: "doc_write core:axioms.md",
+			absent:  []string{documents.TrailerCoreHead},
+		},
+		{
+			name:    "an unreadable core costs the trailer, not the write",
+			writer:  &documentRootProvenanceWriter{root: "self", corePath: "/nonexistent/core"},
+			ctx:     fullTurn,
+			message: "doc_write self:ego.md",
+			absent:  []string{documents.TrailerCoreHead},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.writer.withTurnProvenance(tc.ctx(context.Background()), tc.message)
+
+			subject, _, _ := strings.Cut(got, "\n")
+			if subject != tc.message {
+				t.Errorf("subject rewritten: got %q, want %q", subject, tc.message)
+			}
+			trailers := parseTrailerBlock(t, got)
+			for key, want := range tc.want {
+				if trailers[key] != want {
+					t.Errorf("trailer %s: got %q, want %q", key, trailers[key], want)
+				}
+			}
+			for _, key := range tc.absent {
+				if value, ok := trailers[key]; ok {
+					t.Errorf("trailer %s should be absent, got %q", key, value)
+				}
+			}
+			if len(tc.want) == 0 && len(tc.absent) == 0 && got != tc.message {
+				t.Errorf("message with no facts to add was modified: %q", got)
+			}
+		})
+	}
+}
+
+// A trailer block only means anything if git would parse it as one, so read it
+// back the way git does rather than trusting how it was written.
+func parseTrailerBlock(t *testing.T, message string) map[string]string {
+	t.Helper()
+	trailers := make(map[string]string)
+	for _, line := range strings.Split(strings.TrimSpace(message), "\n") {
+		key, value, ok := strings.Cut(line, ": ")
+		if !ok || !strings.HasPrefix(key, "Thane-") {
+			continue
+		}
+		trailers[key] = strings.TrimSpace(value)
+	}
+	return trailers
+}

--- a/internal/app/document_roots.go
+++ b/internal/app/document_roots.go
@@ -18,6 +18,13 @@ import (
 
 type documentRootProvenanceWriter struct {
 	checkout *checkout.Signed
+	// root is the document root's configured name, used to suppress the core
+	// HEAD trailer on core's own writes, where it would only restate the
+	// parent commit git already records.
+	root string
+	// corePath is the core root's repository, read at write time to record
+	// which identity snapshot was in force. Empty disables the trailer.
+	corePath string
 }
 
 type documentRootProvenanceVerifier struct {
@@ -30,7 +37,7 @@ func (w *documentRootProvenanceWriter) Write(ctx context.Context, filename, cont
 	if err != nil {
 		return err
 	}
-	return store.Write(ctx, w.storeFilename(filename), content, message)
+	return store.Write(ctx, w.storeFilename(filename), content, w.withTurnProvenance(ctx, message))
 }
 
 func (w *documentRootProvenanceWriter) Delete(ctx context.Context, filename, message string) error {
@@ -38,7 +45,7 @@ func (w *documentRootProvenanceWriter) Delete(ctx context.Context, filename, mes
 	if err != nil {
 		return err
 	}
-	return store.Delete(ctx, w.storeFilename(filename), message)
+	return store.Delete(ctx, w.storeFilename(filename), w.withTurnProvenance(ctx, message))
 }
 
 func (w *documentRootProvenanceWriter) storeFilename(filename string) string {
@@ -378,7 +385,11 @@ func (a *App) newDocumentRootProvenanceWriter(root, rootPath string, rootCfg con
 		"repo", signed.Store.Path(),
 		"prefix", signed.Prefix,
 	)
-	return &documentRootProvenanceWriter{checkout: signed}, nil
+	return &documentRootProvenanceWriter{
+		checkout: signed,
+		root:     root,
+		corePath: coreRootPath(a.cfg.Workspace.Path),
+	}, nil
 }
 
 func (a *App) newDocumentRootProvenanceVerifier(root, rootPath string, rootCfg config.DocumentRootConfig, resolver *paths.Resolver) (*documentRootProvenanceVerifier, error) {

--- a/internal/platform/provenance/git.go
+++ b/internal/platform/provenance/git.go
@@ -378,3 +378,18 @@ func (s *Store) gitWithEnv(ctx context.Context, env []string, stdin *bytes.Reade
 
 	return nil
 }
+
+// HeadCommit reports the full commit hash at repoPath's HEAD. It returns an
+// error when the path is not a git repository or carries no commits yet, so a
+// caller recording HEAD as context can distinguish "no history" from a hash.
+func HeadCommit(ctx context.Context, repoPath string) (string, error) {
+	out, err := runGitText(ctx, repoPath, "rev-parse", "--verify", "--quiet", "HEAD^{commit}")
+	if err != nil {
+		return "", fmt.Errorf("resolve HEAD of %s: %w", repoPath, err)
+	}
+	head := strings.TrimSpace(out)
+	if head == "" {
+		return "", fmt.Errorf("resolve HEAD of %s: no commits", repoPath)
+	}
+	return head, nil
+}

--- a/internal/platform/provenance/git.go
+++ b/internal/platform/provenance/git.go
@@ -383,6 +383,11 @@ func (s *Store) gitWithEnv(ctx context.Context, env []string, stdin *bytes.Reade
 // error when the path is not a git repository or carries no commits yet, so a
 // caller recording HEAD as context can distinguish "no history" from a hash.
 func HeadCommit(ctx context.Context, repoPath string) (string, error) {
+	if _, ok := ctx.Deadline(); !ok {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, gitTimeout)
+		defer cancel()
+	}
 	out, err := runGitText(ctx, repoPath, "rev-parse", "--verify", "--quiet", "HEAD^{commit}")
 	if err != nil {
 		return "", fmt.Errorf("resolve HEAD of %s: %w", repoPath, err)

--- a/internal/platform/provenance/reader.go
+++ b/internal/platform/provenance/reader.go
@@ -53,6 +53,12 @@ type Revision struct {
 	Timestamp time.Time
 	// Message is the commit subject.
 	Message string
+	// Trailers are the commit message's git trailers, keyed by trailer name.
+	// Writes made through a document root carry the turn that produced them
+	// here — the model, loop, session, and request — so a reader can attribute
+	// a revision without joining against the conversation store. Nil when the
+	// commit carries none.
+	Trailers map[string]string
 	// Signer describes who signed this revision, populated only when
 	// [RevisionOptions.WithSigners] is set; nil otherwise.
 	Signer *CommitSigner
@@ -217,7 +223,7 @@ func describeRevision(ctx context.Context, repoPath, filename, commit, selector 
 	if commit == "" {
 		return Revision{}, fmt.Errorf("no revision of %s at or before %q", filename, selector)
 	}
-	meta, err := runGitText(ctx, repoPath, "log", "-1", "--format=%H%x00%aI%x00%s", commit)
+	meta, err := runGitText(ctx, repoPath, "log", "-1", "--format=%H%x00%aI%x00%s%x00"+trailerFormat, commit)
 	if err != nil {
 		return Revision{}, fmt.Errorf("describe revision %s: %w", shorten(commit), err)
 	}
@@ -352,7 +358,7 @@ func readRevisions(ctx context.Context, repoPath, allowedSignersPath, filename s
 	// Fold signature attribution into the same log call when requested, so a
 	// page costs one git invocation rather than one verify per revision.
 	// Fetch one extra entry to detect whether an older page exists.
-	format := "%H%x00%aI%x00%s"
+	format := "%H%x00%aI%x00%s%x00" + trailerFormat
 	logArgs := func() []string {
 		return []string{"log", "--format=" + format, fmt.Sprintf("-n%d", limit+1), "--end-of-options", start, "--", filename}
 	}
@@ -401,34 +407,6 @@ func readRevisions(ctx context.Context, repoPath, allowedSignersPath, filename s
 		page.Revisions = append(page.Revisions, revs[i])
 	}
 	return page, nil
-}
-
-// parseRevisionLine parses a log line "hash\x00RFC3339\x00subject", optionally
-// followed by "\x00%G?\x00%GS\x00%GF" when withSigner is set.
-func parseRevisionLine(line string, withSigner bool) (Revision, error) {
-	fields := 3
-	if withSigner {
-		fields = 6
-	}
-	parts := strings.SplitN(line, "\x00", fields)
-	if len(parts) < 3 {
-		return Revision{}, fmt.Errorf("malformed revision line %q", line)
-	}
-	t, err := time.Parse(time.RFC3339, parts[1])
-	if err != nil {
-		return Revision{}, fmt.Errorf("parse revision timestamp %q: %w", parts[1], err)
-	}
-	rev := Revision{
-		Commit:    parts[0],
-		Short:     shorten(parts[0]),
-		Timestamp: t,
-		Message:   parts[2],
-	}
-	if withSigner && len(parts) == 6 {
-		cs := parseCommitSigner(parts[3], parts[4], parts[5])
-		rev.Signer = &cs
-	}
-	return rev, nil
 }
 
 func shorten(hash string) string {

--- a/internal/platform/provenance/reader_trailers_test.go
+++ b/internal/platform/provenance/reader_trailers_test.go
@@ -1,0 +1,83 @@
+package provenance
+
+import (
+	"testing"
+)
+
+// Trailers reach the reader as one unfolded, separator-joined line, because a
+// revision log line must stay a line. These cases pin what that line is allowed
+// to contain and what must never become a phantom trailer.
+func TestParseTrailers(t *testing.T) {
+	tests := []struct {
+		name     string
+		rendered string
+		want     map[string]string
+	}{
+		{
+			name: "no trailers stays nil so absence is distinguishable",
+		},
+		{
+			name:     "whitespace only is not a trailer",
+			rendered: "   \n  ",
+		},
+		{
+			name:     "a single trailer",
+			rendered: "Thane-Model: gpt-oss:120b",
+			want:     map[string]string{"Thane-Model": "gpt-oss:120b"},
+		},
+		{
+			name:     "separator-joined trailers split cleanly",
+			rendered: "Thane-Model: gpt-oss:120b" + trailerSeparator + "Thane-Iteration: 3",
+			want: map[string]string{
+				"Thane-Model":     "gpt-oss:120b",
+				"Thane-Iteration": "3",
+			},
+		},
+		{
+			name:     "a value containing a colon survives intact",
+			rendered: "Thane-Request: r_abc" + trailerSeparator + "Thane-Model: lmstudio/qwen:3.5",
+			want: map[string]string{
+				"Thane-Request": "r_abc",
+				"Thane-Model":   "lmstudio/qwen:3.5",
+			},
+		},
+		{
+			name:     "an entry with no colon is skipped, not guessed at",
+			rendered: "not a trailer" + trailerSeparator + "Thane-Model: gpt-oss:120b",
+			want:     map[string]string{"Thane-Model": "gpt-oss:120b"},
+		},
+		{
+			name:     "an empty key or value is not a fact",
+			rendered: ": orphaned" + trailerSeparator + "Thane-Session:  " + trailerSeparator + "Thane-Model: m",
+			want:     map[string]string{"Thane-Model": "m"},
+		},
+		{
+			name:     "trailers a future build never heard of are still returned",
+			rendered: "Reconstructed-From: thane.db tool_calls" + trailerSeparator + "Thane-Model: m",
+			want: map[string]string{
+				"Reconstructed-From": "thane.db tool_calls",
+				"Thane-Model":        "m",
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := parseTrailers(tc.rendered)
+			if len(tc.want) == 0 {
+				if got != nil {
+					t.Fatalf("expected nil for %q, got %v", tc.rendered, got)
+				}
+				return
+			}
+			if len(got) != len(tc.want) {
+				t.Fatalf("trailer count: got %v, want %v", got, tc.want)
+			}
+			for key, want := range tc.want {
+				if got[key] != want {
+					t.Errorf("trailer %s: got %q, want %q", key, got[key], want)
+				}
+			}
+		})
+	}
+}

--- a/internal/platform/provenance/revisionparse.go
+++ b/internal/platform/provenance/revisionparse.go
@@ -1,0 +1,74 @@
+package provenance
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+// trailerFormat renders a commit's trailers onto a single line: only the
+// trailer block, folded continuations joined, entries separated by
+// trailerSeparator.
+const trailerFormat = "%(trailers:only=true,unfold=true,separator=%x1f)"
+
+// trailerSeparator divides trailers within one log line. A unit separator
+// cannot appear in a trailer git is willing to parse.
+const trailerSeparator = "\x1f"
+
+// parseTrailers turns git's rendered trailer block into a keyed map. A trailer
+// git recognised always has a colon; anything else is skipped rather than
+// guessed at. Returns nil when the commit carries no trailers, so the absence
+// stays distinguishable from an empty set.
+func parseTrailers(rendered string) map[string]string {
+	rendered = strings.TrimSpace(rendered)
+	if rendered == "" {
+		return nil
+	}
+	var trailers map[string]string
+	for _, entry := range strings.Split(rendered, trailerSeparator) {
+		key, value, ok := strings.Cut(entry, ":")
+		if !ok {
+			continue
+		}
+		key, value = strings.TrimSpace(key), strings.TrimSpace(value)
+		if key == "" || value == "" {
+			continue
+		}
+		if trailers == nil {
+			trailers = make(map[string]string)
+		}
+		trailers[key] = value
+	}
+	return trailers
+}
+
+// parseRevisionLine parses a log line
+// "hash\x00RFC3339\x00subject\x00trailers", optionally followed by
+// "\x00%G?\x00%GS\x00%GF" when withSigner is set. Trailers arrive unfolded and
+// joined by trailerSeparator so one commit stays one line.
+func parseRevisionLine(line string, withSigner bool) (Revision, error) {
+	fields := 4
+	if withSigner {
+		fields = 7
+	}
+	parts := strings.SplitN(line, "\x00", fields)
+	if len(parts) < 4 {
+		return Revision{}, fmt.Errorf("malformed revision line %q", line)
+	}
+	t, err := time.Parse(time.RFC3339, parts[1])
+	if err != nil {
+		return Revision{}, fmt.Errorf("parse revision timestamp %q: %w", parts[1], err)
+	}
+	rev := Revision{
+		Commit:    parts[0],
+		Short:     shorten(parts[0]),
+		Timestamp: t,
+		Message:   parts[2],
+		Trailers:  parseTrailers(parts[3]),
+	}
+	if withSigner && len(parts) == 7 {
+		cs := parseCommitSigner(parts[4], parts[5], parts[6])
+		rev.Signer = &cs
+	}
+	return rev, nil
+}

--- a/internal/platform/provenance/revisionparse_git_test.go
+++ b/internal/platform/provenance/revisionparse_git_test.go
@@ -1,0 +1,100 @@
+package provenance
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+// The trailer contract spans two systems: git renders the trailer block, and
+// this package parses it back. Unit-testing the parser against strings we wrote
+// ourselves proves only that we agree with ourselves, so this drives a real
+// commit through real git and reads it back the way the document tools do.
+func TestTrailersSurviveARealCommit(t *testing.T) {
+	dir := initRepo(t)
+	writeDoc(t, dir, "body\n")
+	runGit(t, dir, "add", "doc.md")
+	runGit(t, dir, "commit", "-q", "-m",
+		"doc_write self:metacognitive.md\n\n"+
+			"Thane-Model: gpt-oss:120b\n"+
+			"Thane-Iteration: 3\n"+
+			"Thane-Core-Head: 9dedd7e3b03c3a392bd25d09dd7f597862382c17\n"+
+			"Reconstructed-From: thane.db tool_calls\n")
+
+	page, err := readRevisions(context.Background(), dir, "", "doc.md", RevisionOptions{})
+	if err != nil {
+		t.Fatalf("readRevisions: %v", err)
+	}
+	if len(page.Revisions) != 1 {
+		t.Fatalf("got %d revisions, want 1", len(page.Revisions))
+	}
+	rev := page.Revisions[0]
+
+	// The subject must survive untouched — trailers ride along with the message,
+	// they do not consume it.
+	if rev.Message != "doc_write self:metacognitive.md" {
+		t.Errorf("subject = %q, want the message the writer passed", rev.Message)
+	}
+	// Reconstructed-From is here on purpose: a trailer this build does not know
+	// must still reach the reader, or the tool becomes a worse witness than git.
+	want := map[string]string{
+		"Thane-Model":        "gpt-oss:120b",
+		"Thane-Iteration":    "3",
+		"Thane-Core-Head":    "9dedd7e3b03c3a392bd25d09dd7f597862382c17",
+		"Reconstructed-From": "thane.db tool_calls",
+	}
+	for key, value := range want {
+		if rev.Trailers[key] != value {
+			t.Errorf("trailer %s = %q, want %q (parsed: %v)", key, rev.Trailers[key], value, rev.Trailers)
+		}
+	}
+}
+
+// A commit carrying no trailers must report none rather than an empty map, so a
+// caller can tell "not written by a loop" from "written with nothing to say".
+func TestARevisionWithoutTrailersReportsNone(t *testing.T) {
+	dir := initRepo(t)
+	writeDoc(t, dir, "body\n")
+	runGit(t, dir, "add", "doc.md")
+	runGit(t, dir, "commit", "-q", "-m", "hand-authored change")
+
+	page, err := readRevisions(context.Background(), dir, "", "doc.md", RevisionOptions{})
+	if err != nil {
+		t.Fatalf("readRevisions: %v", err)
+	}
+	if got := page.Revisions[0].Trailers; got != nil {
+		t.Errorf("Trailers = %v, want nil", got)
+	}
+}
+
+func TestHeadCommitReportsAResolvableHash(t *testing.T) {
+	head, err := HeadCommit(context.Background(), initRepo(t))
+	if err != nil {
+		t.Fatalf("HeadCommit: %v", err)
+	}
+	if len(head) != 40 {
+		t.Errorf("HeadCommit = %q, want a full 40-character hash", head)
+	}
+}
+
+// A root that exists but has no history yet must error rather than report an
+// empty hash, so a caller recording HEAD can tell the two apart.
+func TestHeadCommitErrorsWithoutHistory(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	dir := t.TempDir()
+	runGit(t, dir, "-c", "init.defaultBranch=main", "init")
+	if _, err := HeadCommit(context.Background(), dir); err == nil {
+		t.Error("expected an error for a repository with no commits")
+	}
+}
+
+func writeDoc(t *testing.T, dir, content string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, "doc.md"), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/runtime/agent/loop.go
+++ b/internal/runtime/agent/loop.go
@@ -2292,6 +2292,10 @@ func (l *Loop) Run(ctx context.Context, req *Request, stream StreamCallback) (re
 			toolCtx = tools.WithToolCallID(toolCtx, toolCallIDStr)
 			toolCtx = tools.WithIterationIndex(toolCtx, i)
 			toolCtx = tools.WithRequestID(toolCtx, requestID)
+			liveStreamMu.Lock()
+			iterationModel := liveStreamModel
+			liveStreamMu.Unlock()
+			toolCtx = tools.WithModel(toolCtx, iterationModel)
 			if lid := loop.LoopIDFromContext(ctx); lid != "" {
 				toolCtx = tools.WithLoopID(toolCtx, lid)
 			} else if lid := req.RoutingFactors["loop_id"]; lid != "" {

--- a/internal/state/documents/revision.go
+++ b/internal/state/documents/revision.go
@@ -27,6 +27,29 @@ type RootReviser interface {
 	Content(ctx context.Context, filename, selector string) (RevisionContent, error)
 }
 
+// Commit trailer names recorded on writes that pass through a git-backed
+// document root. They are declared here, beside the revision types that
+// project them, so the writer emitting a trailer and the reader naming it
+// cannot drift apart.
+//
+// These describe the turn that produced a revision. History written by hand
+// carries none of them, which is itself informative: a revision with no
+// authorship block was not written by a loop.
+const (
+	TrailerModel        = "Thane-Model"
+	TrailerLoopID       = "Thane-Loop-Id"
+	TrailerConversation = "Thane-Conversation"
+	TrailerSession      = "Thane-Session"
+	TrailerRequest      = "Thane-Request"
+	TrailerToolCall     = "Thane-Tool-Call"
+	TrailerIteration    = "Thane-Iteration"
+	// TrailerCoreHead pins the core root's HEAD at the moment of the write, so a
+	// revision can be read beside the axioms, persona, mission, and talents that
+	// were in force when it was made. Absent on core's own history, where the
+	// parent commit already says it.
+	TrailerCoreHead = "Thane-Core-Head"
+)
+
 // RevisionQuery bounds a [RootReviser.History] page.
 type RevisionQuery struct {
 	// Limit caps the page size; non-positive means the implementation default.
@@ -50,6 +73,12 @@ type RevisionRef struct {
 	Timestamp time.Time
 	// Message is the commit subject.
 	Message string
+	// Trailers are the commit's git trailers, keyed by trailer name. A write
+	// made by a loop records the turn behind it here — which model, loop,
+	// session, and request — so history can be attributed without joining
+	// against the conversation store. Nil when the commit carries none, which
+	// is the normal case for revisions written by hand.
+	Trailers map[string]string
 	// Signer describes who signed this revision, when populated.
 	Signer *RevisionSigner
 }

--- a/internal/state/documents/revision_tools.go
+++ b/internal/state/documents/revision_tools.go
@@ -174,6 +174,7 @@ func (t *Tools) At(ctx context.Context, args AtArgs) (string, error) {
 	parsed := parseMarkdownDocumentParts(relPath, meta, body)
 	now := nowUTC()
 	rev := content.Revision
+	revAuthored, revTrailers := splitRevisionTrailers(rev.Trailers)
 	out := modelRevisionAt{
 		Ref:          args.Ref,
 		Rev:          rev.Short,
@@ -182,6 +183,8 @@ func (t *Tools) At(ctx context.Context, args AtArgs) (string, error) {
 		Age:          promptfmt.FormatDeltaOnly(rev.Timestamp, now),
 		VerifyStatus: revisionVerifyStatus(rev.Signer),
 		Signer:       toModelRevisionSigner(rev.Signer),
+		AuthoredBy:   revAuthored,
+		Trailers:     revTrailers,
 		Title:        parsed.Title,
 		Frontmatter:  modelFrontmatter(parsed.Frontmatter, now),
 		Outline:      parsed.Sections,
@@ -197,12 +200,34 @@ func (t *Tools) At(ctx context.Context, args AtArgs) (string, error) {
 }
 
 type modelRevision struct {
-	Rev       string               `json:"rev"`
-	Index     int                  `json:"index"`
-	Timestamp string               `json:"timestamp"`
-	Age       string               `json:"age,omitempty"`
-	Message   string               `json:"message,omitempty"`
-	Signer    *modelRevisionSigner `json:"signer,omitempty"`
+	Rev        string                   `json:"rev"`
+	Index      int                      `json:"index"`
+	Timestamp  string                   `json:"timestamp"`
+	Age        string                   `json:"age,omitempty"`
+	Message    string                   `json:"message,omitempty"`
+	Signer     *modelRevisionSigner     `json:"signer,omitempty"`
+	AuthoredBy *modelRevisionAuthorship `json:"authored_by,omitempty"`
+	Trailers   map[string]string        `json:"trailers,omitempty"`
+}
+
+// modelRevisionAuthorship names the turn that produced a revision. Absent when
+// the revision was not written by a loop — a hand-authored commit carries no
+// authorship, and that absence is worth reading rather than hiding.
+//
+// The signer says which key vouched for a revision; this says which mind
+// composed it. They answer different questions and a root that reports both is
+// materially better evidence than one reporting either alone.
+type modelRevisionAuthorship struct {
+	Model        string `json:"model,omitempty"`
+	LoopID       string `json:"loop_id,omitempty"`
+	Conversation string `json:"conversation,omitempty"`
+	Session      string `json:"session,omitempty"`
+	Request      string `json:"request,omitempty"`
+	ToolCall     string `json:"tool_call,omitempty"`
+	Iteration    string `json:"iteration,omitempty"`
+	// CoreHead pins the core root's commit at the time of the write, so this
+	// revision can be read beside the identity and talents that produced it.
+	CoreHead string `json:"core_head,omitempty"`
 }
 
 type modelRevisionSigner struct {
@@ -231,29 +256,74 @@ type modelDiff struct {
 }
 
 type modelRevisionAt struct {
-	Ref            string               `json:"ref"`
-	Rev            string               `json:"rev"`
-	Index          int                  `json:"index"`
-	Timestamp      string               `json:"timestamp"`
-	Age            string               `json:"age,omitempty"`
-	VerifyStatus   string               `json:"verify_status"`
-	Signer         *modelRevisionSigner `json:"signer,omitempty"`
-	Title          string               `json:"title,omitempty"`
-	Frontmatter    map[string][]string  `json:"frontmatter,omitempty"`
-	Outline        []Section            `json:"outline,omitempty"`
-	Body           string               `json:"body,omitempty"`
-	UnverifiedBody string               `json:"unverified_body,omitempty"`
+	Ref            string                   `json:"ref"`
+	Rev            string                   `json:"rev"`
+	Index          int                      `json:"index"`
+	Timestamp      string                   `json:"timestamp"`
+	Age            string                   `json:"age,omitempty"`
+	VerifyStatus   string                   `json:"verify_status"`
+	Signer         *modelRevisionSigner     `json:"signer,omitempty"`
+	AuthoredBy     *modelRevisionAuthorship `json:"authored_by,omitempty"`
+	Trailers       map[string]string        `json:"trailers,omitempty"`
+	Title          string                   `json:"title,omitempty"`
+	Frontmatter    map[string][]string      `json:"frontmatter,omitempty"`
+	Outline        []Section                `json:"outline,omitempty"`
+	Body           string                   `json:"body,omitempty"`
+	UnverifiedBody string                   `json:"unverified_body,omitempty"`
 }
 
 func toModelRevision(r RevisionRef, now time.Time) modelRevision {
+	authored, rest := splitRevisionTrailers(r.Trailers)
 	return modelRevision{
-		Rev:       r.Short,
-		Index:     r.Index,
-		Timestamp: r.Timestamp.UTC().Format(time.RFC3339),
-		Age:       promptfmt.FormatDeltaOnly(r.Timestamp, now),
-		Message:   r.Message,
-		Signer:    toModelRevisionSigner(r.Signer),
+		Rev:        r.Short,
+		Index:      r.Index,
+		Timestamp:  r.Timestamp.UTC().Format(time.RFC3339),
+		Age:        promptfmt.FormatDeltaOnly(r.Timestamp, now),
+		Message:    r.Message,
+		Signer:     toModelRevisionSigner(r.Signer),
+		AuthoredBy: authored,
+		Trailers:   rest,
 	}
+}
+
+// splitRevisionTrailers promotes the trailers Thane writes into a named
+// authorship block and returns whatever else the commit carried unchanged.
+// Nothing is dropped: a reconstructed history or an operator's own convention
+// puts trailers here that this build has never heard of, and silently eating
+// them would make the tool a worse witness than plain `git log`.
+func splitRevisionTrailers(trailers map[string]string) (*modelRevisionAuthorship, map[string]string) {
+	if len(trailers) == 0 {
+		return nil, nil
+	}
+	authored := modelRevisionAuthorship{
+		Model:        trailers[TrailerModel],
+		LoopID:       trailers[TrailerLoopID],
+		Conversation: trailers[TrailerConversation],
+		Session:      trailers[TrailerSession],
+		Request:      trailers[TrailerRequest],
+		ToolCall:     trailers[TrailerToolCall],
+		Iteration:    trailers[TrailerIteration],
+		CoreHead:     trailers[TrailerCoreHead],
+	}
+	promoted := map[string]bool{
+		TrailerModel: true, TrailerLoopID: true, TrailerConversation: true,
+		TrailerSession: true, TrailerRequest: true, TrailerToolCall: true,
+		TrailerIteration: true, TrailerCoreHead: true,
+	}
+	var rest map[string]string
+	for key, value := range trailers {
+		if promoted[key] {
+			continue
+		}
+		if rest == nil {
+			rest = make(map[string]string)
+		}
+		rest[key] = value
+	}
+	if authored == (modelRevisionAuthorship{}) {
+		return nil, rest
+	}
+	return &authored, rest
 }
 
 func toModelRevisionSigner(s *RevisionSigner) *modelRevisionSigner {

--- a/internal/tools/context.go
+++ b/internal/tools/context.go
@@ -19,6 +19,7 @@ const loopIDKey contextKey = "loop_id"
 const channelBindingKey contextKey = "channel_binding"
 const inheritableCapabilityTagsKey contextKey = "inheritable_capability_tags"
 const requestIDKey contextKey = "request_id"
+const modelKey contextKey = "model"
 
 // WithConversationID adds the conversation ID to the context.
 func WithConversationID(ctx context.Context, id string) context.Context {
@@ -46,6 +47,27 @@ func WithRequestID(ctx context.Context, id string) context.Context {
 func RequestIDFromContext(ctx context.Context) string {
 	if id, ok := ctx.Value(requestIDKey).(string); ok {
 		return id
+	}
+	return ""
+}
+
+// WithModel adds the model serving the current iteration to the context, so a
+// tool can record which model authored a side effect. A document root commits
+// this alongside the write: which mind held a thought is a fact about that
+// thought, and it is only knowable here.
+func WithModel(ctx context.Context, model string) context.Context {
+	if model == "" {
+		return ctx
+	}
+	return context.WithValue(ctx, modelKey, model)
+}
+
+// ModelFromContext extracts the model serving the current iteration, or "" when
+// none is set (e.g. outside a model turn). The model can change between
+// iterations of one turn, so this reflects the iteration, not the request.
+func ModelFromContext(ctx context.Context) string {
+	if model, ok := ctx.Value(modelKey).(string); ok {
+		return model
 	}
 	return ""
 }

--- a/internal/tools/document_tools.go
+++ b/internal/tools/document_tools.go
@@ -60,7 +60,7 @@ func RegisterDocumentTools(r *Registry, dt *documents.Tools) {
 
 	r.Register(&Tool{
 		Name:                 "doc_history",
-		Description:          "List the revision history of one managed document by semantic ref like `kb:network/vlans.md`, newest first. Only git-backed roots have history — `doc_roots` reports `revisions: true` for those. Each revision has a short `rev` hash (feed it to `doc_diff`/`doc_at`), an `index` (0 is newest), an `age` delta plus absolute `timestamp`, the commit message, and a `signer` (`verified`, `principal`, `kind`: agent or operator). Paginate older by passing `before` set to the returned `next_before`.",
+		Description:          "List the revision history of one managed document by semantic ref like `kb:network/vlans.md`, newest first. Only git-backed roots have history — `doc_roots` reports `revisions: true` for those. Each revision has a short `rev` hash (feed it to `doc_diff`/`doc_at`), an `index` (0 is newest), an `age` delta plus absolute `timestamp`, the commit message, and a `signer` (`verified`, `principal`, `kind`: agent or operator). Revisions written by a loop also carry `authored_by`: the `model` that composed them, plus `loop_id`, `conversation`, `session`, `request`, `tool_call`, `iteration`, and `core_head` — the core root's commit at the time, which pins the axioms, persona, mission, and talents that revision was written under. A revision with no `authored_by` was not written by a loop. Paginate older by passing `before` set to the returned `next_before`.",
 		ContentResolveExempt: []string{"ref", "before"},
 		Parameters: map[string]any{
 			"type": "object",
@@ -113,7 +113,7 @@ func RegisterDocumentTools(r *Registry, dt *documents.Tools) {
 
 	r.Register(&Tool{
 		Name:                 "doc_at",
-		Description:          "Recall one managed document's content as of a past revision. `rev` accepts a `rev` hash from `doc_history`, `HEAD`/`latest` (default), an RFC3339 timestamp, or a delta like `-7d`. Returns the frontmatter, outline, and body as of that revision, plus `verify_status` and the `signer`. When the revision is not trusted, the content is returned under `unverified_body` instead of `body`.",
+		Description:          "Recall one managed document's content as of a past revision. `rev` accepts a `rev` hash from `doc_history`, `HEAD`/`latest` (default), an RFC3339 timestamp, or a delta like `-7d`. Returns the frontmatter, outline, and body as of that revision, plus `verify_status` and the `signer`. When the revision was written by a loop, `authored_by` names the `model` that composed it and the `core_head` it was written under, so you can recall what you thought alongside what you were at the time. When the revision is not trusted, the content is returned under `unverified_body` instead of `body`.",
 		ContentResolveExempt: []string{"ref", "rev"},
 		Parameters: map[string]any{
 			"type": "object",


### PR DESCRIPTION
## Why

A document root already records that a revision happened and who signed it. It does not record who *composed* it, and those are different questions: a signature says a key vouched for the bytes, not that a particular model held the thought.

This became concrete while reconstructing Aimée's history. Attributing five months of loop writes to the models that produced them meant joining `thane.db` against the archived request log and hoping both had retained the window — 89.7% coverage, and only because the logs happened to survive. Every one of those facts was sitting in the tool context at the moment of the write, and none of it reached the commit.

## Where

Every git-backed root write funnels through `documentRootProvenanceWriter`, so that is the one place that can see both the turn and the commit. `Store.Write` already took its message as a free string, so the provenance layer is unchanged and no other caller moves.

The one thing missing from context was the model, so `tools.WithModel` joins the accessors already stamped in `OnBeforeToolExec`.

## What lands in a commit

```
doc_write self:metacognitive.md

Thane-Model: gpt-oss:120b
Thane-Loop-Id: loop-abc
Thane-Conversation: loop-metacognitive-668-1784726270870
Thane-Session: 019f89fc-4b2a-7c8e-9915-a2036904df23
Thane-Request: r_9700fbdd8fbc67c7
Thane-Tool-Call: 019f89fb-3c96-7add-8763-51c88b8b5b8e
Thane-Iteration: 3
Thane-Core-Head: 9dedd7e3b03c3a392bd25d09dd7f597862382c17
```

Trailers rather than git notes, deliberately: a note is not covered by the commit signature, and this is meant to be evidence. Absent facts are omitted rather than emitted empty, so a hand-authored commit is still trailer-free and legible as such.

**`Thane-Core-Head`** pins core's HEAD at the moment of the write. What Thane wrote is only fully legible beside the axioms, persona, mission, and talents it was working from, and those live in a root that moves independently. Core's own writes omit it, where it would only restate the parent commit git already records. Failing to read it costs the trailer, never the write.

## What reads it

`doc_history` and `doc_at` surface an `authored_by` block beside the existing `signer`. Trailers this build does not recognise pass through untouched under `trailers` — a reconstructed history carries its own conventions, and silently eating them would make the tools a worse witness than plain `git log`.

## Test plan

- [x] `just ci` clean, `large_files` back to baseline without a bump (the new concerns moved into their own files rather than growing the ones they came from)
- [x] Table-driven coverage of trailer rendering, including the `default` conversation, core's self-suppression, and an unreadable core
- [x] Trailer parsing: separator-joined, values containing colons, malformed entries, unknown keys
- [x] Round-trip through **real git** — rendered by `git commit`, parsed back by the reader — because unit tests over strings we wrote ourselves only prove we agree with ourselves
- [x] A commit with no trailers reports `nil`, not an empty map, so "not written by a loop" stays distinguishable

Refs #1318