### PR TITLE
Ego writes to self, and the prompt reads it there

### DIFF
--- a/docs/operating/configuration.md
+++ b/docs/operating/configuration.md
@@ -298,9 +298,10 @@ talents_dir: ~/Thane/talents
 
 See [Context Layers](../understanding/context-layers.md) for how these
 fit into the system prompt. The workspace derives the protected
-`core` root; `core/axioms.md`, `core/persona.md`, `core/ego.md`, and
+`core` and `self` roots; `core/axioms.md`, `core/persona.md`, and
 `core/mission.md` are picked up by the runtime without a separate
-inject-file list.
+inject-file list, as is `self/ego.md` — what Thane has made of them,
+read beside them but written under the agent's own signer policy.
 
 ## Scheduler
 

--- a/docs/reference/event-sources.md
+++ b/docs/reference/event-sources.md
@@ -79,7 +79,7 @@ Cron-style scheduling stored in SQLite. Each task defines:
 
 Custom tasks can be created via the `task_schedule` tool. Built-in
 recurring work runs as service loop definitions instead — for
-example, the `ego` loop maintains `core/ego.md` with bounded voluntary
+example, the `ego` loop maintains `self/ego.md` with bounded voluntary
 sleep and supervisor randomization, and the `email-poller` loop drives
 IMAP polling.
 

--- a/docs/understanding/architecture.md
+++ b/docs/understanding/architecture.md
@@ -162,7 +162,7 @@ was learned empirically, not theorized.
 **Persona** is identity: who the agent is, its voice and values.
 **Mission** is durable operational framing, when `core/mission.md`
 exists. **Core context** publishes curated knowledge and continuity such
-as `core/ego.md` and supplemental configured files as stable prompt
+as `self/ego.md` and supplemental configured files as stable prompt
 sections.
 **Current conditions** are awareness: time, environment, active state.
 **Talents** are behavior: how the agent should act in specific

--- a/docs/understanding/context-layers.md
+++ b/docs/understanding/context-layers.md
@@ -59,7 +59,7 @@ only when those tags are active.
 **Purpose:** Knowledge — what the agent *knows*.
 
 Core context publishes curated reference material such as
-`core/mission.md`, `core/ego.md`, and supplemental configured context
+`core/mission.md`, `self/ego.md`, and supplemental configured context
 files as stable prompt sections. These files are read fresh each turn,
 verified when managed-root policy applies, capped with explicit
 truncation markers, and suppressed for task-focused delegate runs.

--- a/docs/understanding/document-roots.md
+++ b/docs/understanding/document-roots.md
@@ -434,14 +434,21 @@ it moves when the operator moves it.
 
 `self` is what Thane makes of that — its self-concept, its running
 observations, its memory of its own work. The core service loops maintain it:
-`self:metacognitive.md` and `self:archivist.md` today. It wants the same
-integrity treatment as `core` — signed history, admission, verification — under
-its own signer set, because the agent is its author.
+`self:metacognitive.md`, `self:archivist.md`, and `self:ego.md`. It wants the
+same integrity treatment as `core` — signed history, admission, verification —
+under its own signer set, because the agent is its author.
 
-`core:ego.md` has not moved yet. The ego loop writes it and the interactive
-agent injects it, but that injection reads through a provenance store scoped to
-`core` rather than through a path, so relocating it is a rewiring rather than a
-change of reference.
+`self:ego.md` is the case worth understanding, because it is injected into the
+interactive agent's system prompt beside axioms, persona, and mission, and the
+colocation makes it read as though it shared their authority. It does not.
+Those three are what the operator declares Thane to be; `ego.md` is what Thane
+has made of that. They are read together because that is where the reflection
+is useful, and they are written under different signer policies because they
+answer to different authorities.
+
+That distinction is why the injection had to follow the document rather than
+stay pointed at `core`: an ego loop writing to one root while the prompt reads
+another leaves the agent composing self-reflection it never reads back.
 
 Both are derived rather than declared because the core service loops write
 `self` on every install. A root an operator had to remember to declare would

--- a/docs/understanding/glossary.md
+++ b/docs/understanding/glossary.md
@@ -176,7 +176,7 @@ a frontier model to catch blind spots.
 
 ### Ego Loop
 
-A long-cycle self-reflection loop that maintains `core/ego.md` — the
+A long-cycle self-reflection loop that maintains `self/ego.md` — the
 agent's own evolving notes on how its thinking is changing, what
 patterns it observes in itself, and honest self-assessment. Runs as a
 service loop with bounded voluntary sleep, supervisor randomization,

--- a/examples/config.example.yaml
+++ b/examples/config.example.yaml
@@ -161,10 +161,11 @@ embeddings:
   # falls back to the default model resource/provider selection.
   baseurl: ""
 # Workspace configures the agent's sandboxed file system access.
-# The workspace root is also the anchor for Thane's fixed core
-# document root at {workspace.path}/core, which holds canonical
-# always-on files at stable locations such as axioms.md, persona.md,
-# ego.md, mission.md, and metacognitive.md.
+# The workspace root is also the anchor for Thane's two derived
+# document roots. {workspace.path}/core holds what the operator
+# declares Thane to be — axioms.md, persona.md, mission.md — and
+# {workspace.path}/self holds what Thane has made of that, written
+# by the core service loops: ego.md, metacognitive.md, archivist.md.
 workspace:
   # ReadOnlyDirs are additional directories the agent can read from
   # but not write to. Useful for compatibility or reference roots that
@@ -1186,7 +1187,7 @@ compaction:
 #     quality_floor: 8
 #
 # Ego configures the self-reflection loop. When enabled, a long-cycle
-# service loop maintains core/ego.md via a declared maintained-document
+# service loop maintains self/ego.md via a declared maintained-document
 # output, with supervisor randomization for periodic frontier review.
 # Defaults: min_sleep 30m, max_sleep 24h, default_sleep 6h, jitter 0.2,
 # supervisor_probability 0.2, router.quality_floor 5 (supervisor 8).

--- a/internal/app/corepaths.go
+++ b/internal/app/corepaths.go
@@ -10,3 +10,10 @@ func coreFilePath(workspacePath, name string) string {
 	}
 	return cfg.CoreFile(name)
 }
+
+func selfFilePath(workspacePath, name string) string {
+	cfg := config.Config{
+		Workspace: config.WorkspaceConfig{Path: workspacePath},
+	}
+	return cfg.SelfFile(name)
+}

--- a/internal/app/ego_root_test.go
+++ b/internal/app/ego_root_test.go
@@ -1,0 +1,51 @@
+package app
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// The ego loop writes self:ego.md and the interactive agent injects ego.md
+// beside axioms, persona, and mission. Those two facts are wired in different
+// files, and when they disagree the failure is silent: the loop keeps writing,
+// the prompt section simply stops appearing, and the agent composes
+// self-reflection it never reads back.
+//
+// So this pins the pairing rather than the path. axioms, persona, and mission
+// are what the operator declares Thane to be and resolve under core; ego.md is
+// what Thane has made of that and resolves under self.
+func TestCorePromptFilesResolveUnderTheRootThatOwnsThem(t *testing.T) {
+	const workspace = "/tmp/workspace"
+
+	tests := []struct {
+		name     string
+		got      string
+		wantRoot string
+	}{
+		{"axioms is declared by the operator", coreFilePath(workspace, "axioms.md"), "core"},
+		{"persona is declared by the operator", coreFilePath(workspace, "persona.md"), "core"},
+		{"mission is declared by the operator", coreFilePath(workspace, "mission.md"), "core"},
+		{"ego is written by the agent", selfFilePath(workspace, "ego.md"), "self"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			wantDir := filepath.Join(workspace, tc.wantRoot)
+			if dir := filepath.Dir(tc.got); dir != wantDir {
+				t.Errorf("resolved to %s, want a file under %s", tc.got, wantDir)
+			}
+		})
+	}
+}
+
+// A workspace-less config must not synthesize a path, or startup verification
+// would be handed a relative path that resolves against the process working
+// directory rather than failing honestly.
+func TestSelfFilePathIsEmptyWithoutAWorkspace(t *testing.T) {
+	if got := selfFilePath("", "ego.md"); got != "" {
+		t.Errorf("selfFilePath with no workspace = %q, want empty", got)
+	}
+	if got := selfFilePath("/tmp/workspace", ""); got != "" {
+		t.Errorf("selfFilePath with no name = %q, want empty", got)
+	}
+}

--- a/internal/app/loop_definition_builtins.go
+++ b/internal/app/loop_definition_builtins.go
@@ -32,11 +32,10 @@ const (
 //
 // selfContainerName deliberately matches [config.SelfRootName]. The
 // loops in this container are the loops whose subject is Thane itself,
-// and the self root is where that writing is headed: metacognitive and
-// archivist write it today, ego still writes core:ego.md until its
-// provenance-backed injection is rewired (#1318). One name covers one
-// idea — a reader seeing `parent: self` beside an output ref of
-// `self:metacognitive.md` is looking at two views of the same thing.
+// and the self root is where all three of them write: metacognitive,
+// archivist, and ego. One name covers one idea — a reader seeing
+// `parent: self` beside an output ref of `self:metacognitive.md` is
+// looking at two views of the same thing.
 // They stay separate constants because a loop container and a document
 // root are different namespaces, and renaming one should not silently
 // rename the other.

--- a/internal/app/new_agent.go
+++ b/internal/app/new_agent.go
@@ -52,15 +52,23 @@ func (a *App) initAgentLoop(s *newState) error {
 	}
 	s.resolver = resolver
 
-	// Resolve fixed core prompt files if a workspace is configured. The
-	// core context provider reads them fresh on every turn, so paths are
-	// enough at startup.
+	// Resolve the fixed prompt files if a workspace is configured. The core
+	// context provider reads them fresh on every turn, so paths are enough at
+	// startup.
+	//
+	// ego.md reads from self, not core, and is the one file here that does.
+	// Axioms, persona, and mission are what the operator declares Thane to be;
+	// ego.md is what Thane has made of that, so it is written by a loop and
+	// lives under the agent's own signer policy. It is injected beside them
+	// because that is where it is useful to read, not because it shares their
+	// authority — and the injection has to follow the document, or the ego loop
+	// writes into a root nothing reads back.
 	var axiomsFile, personaFile, missionFile, egoFile string
 	if cfg.Workspace.Path != "" {
 		axiomsFile = resolvePath(coreFilePath(cfg.Workspace.Path, "axioms.md"), nil)
 		personaFile = resolvePath(coreFilePath(cfg.Workspace.Path, "persona.md"), nil)
 		missionFile = resolvePath(coreFilePath(cfg.Workspace.Path, "mission.md"), nil)
-		egoFile = resolvePath(coreFilePath(cfg.Workspace.Path, "ego.md"), nil)
+		egoFile = resolvePath(selfFilePath(cfg.Workspace.Path, "ego.md"), nil)
 	}
 
 	s.resolvedCorePromptFiles = corePromptFilesForStartupVerification(logger, axiomsFile, personaFile, missionFile, egoFile)

--- a/internal/model/prompts/ego.go
+++ b/internal/model/prompts/ego.go
@@ -14,8 +14,8 @@ writer.
 ## Your Durable Output
 
 Your current durable output contract is injected in the "Declared Durable
-Outputs" block. That block shows core:ego.md when it exists and names
-the generated replacement tool for the document.
+Outputs" block. It names the document you maintain and the generated tool
+that writes it.
 
 ## What To Do This Iteration
 

--- a/internal/platform/config/config.go
+++ b/internal/platform/config/config.go
@@ -3616,6 +3616,20 @@ func (c *Config) CoreFile(name string) string {
 	return filepath.Join(root, name)
 }
 
+// SelfFile returns the absolute-or-relative path to a named file in the
+// fixed self document root. When workspace.path is unset, SelfFile returns
+// the empty string.
+func (c *Config) SelfFile(name string) string {
+	if strings.TrimSpace(name) == "" {
+		return ""
+	}
+	root := c.SelfRoot()
+	if root == "" {
+		return ""
+	}
+	return filepath.Join(root, name)
+}
+
 func (c *Config) validateLoops() error {
 	if c.Loops.MaxRunning < 0 {
 		return fmt.Errorf("loops.max_running must be >= 0, got %d", c.Loops.MaxRunning)

--- a/internal/platform/config/config.go
+++ b/internal/platform/config/config.go
@@ -243,10 +243,11 @@ type Config struct {
 	Embeddings EmbeddingsConfig `yaml:"embeddings"`
 
 	// Workspace configures the agent's sandboxed file system access.
-	// The workspace root is also the anchor for Thane's fixed core
-	// document root at {workspace.path}/core, which holds canonical
-	// always-on files at stable locations such as axioms.md, persona.md,
-	// ego.md, mission.md, and metacognitive.md.
+	// The workspace root is also the anchor for Thane's two derived
+	// document roots. {workspace.path}/core holds what the operator
+	// declares Thane to be — axioms.md, persona.md, mission.md — and
+	// {workspace.path}/self holds what Thane has made of that, written
+	// by the core service loops: ego.md, metacognitive.md, archivist.md.
 	Workspace WorkspaceConfig `yaml:"workspace"`
 
 	// Roots is the unified document-root config. Each entry names one
@@ -438,7 +439,7 @@ type Config struct {
 	Metacognitive MetacognitiveConfig `yaml:"metacognitive"`
 
 	// Ego configures the self-reflection loop. When enabled, a long-cycle
-	// service loop maintains core/ego.md via a declared maintained-document
+	// service loop maintains self/ego.md via a declared maintained-document
 	// output, with supervisor randomization for periodic frontier review.
 	// Defaults: min_sleep 30m, max_sleep 24h, default_sleep 6h, jitter 0.2,
 	// supervisor_probability 0.2, router.quality_floor 5 (supervisor 8).
@@ -2276,7 +2277,7 @@ type MetacognitiveConfig = ServiceLoopConfig
 
 // EgoConfig configures the self-reflection ego loop. The loop runs as a
 // service loop: bounded voluntary sleep, supervisor randomization, and a
-// declared maintained-document output at core/ego.md. Replaces the legacy
+// declared maintained-document output at self/ego.md. Replaces the legacy
 // periodic_reflection scheduled task. Defaults: min_sleep 30m, max_sleep
 // 24h, default_sleep 6h, jitter 0.2, supervisor_probability 0.2,
 // router.quality_floor 5 (supervisor 8).

--- a/internal/runtime/ego/ego.go
+++ b/internal/runtime/ego/ego.go
@@ -97,7 +97,7 @@ func DefinitionSpec(cfg Config) loop.Spec {
 			{
 				Name:    "ego_state",
 				Type:    loop.OutputTypeMaintainedDocument,
-				Ref:     "core:ego.md",
+				Ref:     "self:ego.md",
 				Mode:    loop.OutputModeReplace,
 				Purpose: "Self-reflection written by the ego loop, for the agent: how the agent's thinking is evolving, behavioral patterns it notices in itself, observations about its relationships, genuine open questions, and honest self-assessment. Read every turn via the agent's core context. NOT a task list, status report, or operational notes.",
 			},

--- a/internal/runtime/ego/ego.go
+++ b/internal/runtime/ego/ego.go
@@ -1,5 +1,5 @@
 // Package ego implements the self-reflection loop that maintains
-// core/ego.md. It runs as a service loop: each iteration is a fresh
+// self/ego.md. It runs as a service loop: each iteration is a fresh
 // conversation with bounded voluntary sleep, supervisor randomization
 // for periodic frontier review, and a declared maintained-document
 // output that pins ego.md to the loop.

--- a/internal/runtime/ego/ego_test.go
+++ b/internal/runtime/ego/ego_test.go
@@ -91,8 +91,12 @@ func TestDefinitionSpec_Outputs(t *testing.T) {
 		t.Fatalf("Outputs len = %d, want 1", len(spec.Outputs))
 	}
 	out := spec.Outputs[0]
-	if out.Ref != "core:ego.md" {
-		t.Errorf("Outputs[0].Ref = %q, want core:ego.md", out.Ref)
+	// self, not core: ego.md is what Thane has made of what the operator
+	// declared, so it is written under the agent's own signer policy. The
+	// interactive agent's injection resolves the same root, and the two have
+	// to agree or the loop writes where nothing reads.
+	if out.Ref != "self:ego.md" {
+		t.Errorf("Outputs[0].Ref = %q, want self:ego.md", out.Ref)
 	}
 	if out.Type != loop.OutputTypeMaintainedDocument {
 		t.Errorf("Outputs[0].Type = %q, want maintained_document", out.Type)

--- a/loops/ego.md
+++ b/loops/ego.md
@@ -22,7 +22,7 @@ completion: none
 outputs:
     - name: ego_state
       type: maintained_document
-      ref: core:ego.md
+      ref: self:ego.md
       mode: replace
       purpose: 'Self-reflection written by the ego loop, for the agent: how the agent''s thinking is evolving, behavioral patterns it notices in itself, observations about its relationships, genuine open questions, and honest self-assessment. Read every turn via the agent''s core context. NOT a task list, status report, or operational notes.'
 tags:
@@ -71,8 +71,8 @@ writer.
 ## Your Durable Output
 
 Your current durable output contract is injected in the "Declared Durable
-Outputs" block. That block shows core:ego.md when it exists and names
-the generated replacement tool for the document.
+Outputs" block. It names the document you maintain and the generated tool
+that writes it.
 
 ## What To Do This Iteration
 


### PR DESCRIPTION
## Why

#1321 moved `metacognitive` and `archivist` to the `self` root and deliberately left `ego` behind, on the grounds that its injection "reads back through a core-scoped `provenance.Store` with revision history, not through a path, so moving it is a rewiring rather than a ref change."

That turned out to overstate it. `LoopOptions.ProvenanceStore` is never populated by the app, so `readEgo` has always taken the plain-path branch and `readEgoFromProvenance` is unreached in the current wiring. The path was the only thing that had to move.

## The failure mode this closes

The loop's output ref lives in `internal/runtime/ego/ego.go` and `loops/ego.md`; the injection path lives in `internal/app/new_agent.go`. Nothing connects them. Change one and the other keeps working — silently, and wrongly:

- the ego loop writes `self/ego.md` on its own schedule
- the interactive agent reads `core/ego.md`, finds nothing, and drops the section
- no error, no warning; the agent simply stops reading back what it writes

That is the one failure a self-reflection document cannot survive, so `TestCorePromptFilesResolveUnderTheRootThatOwnsThem` pins the pairing rather than the paths: axioms, persona, and mission resolve under `core`; `ego.md` resolves under `self`.

## Why ego is the odd one out

`ego.md` is injected beside axioms, persona, and mission, and the colocation makes it read as though it shared their authority. It does not. Those three are what the operator *declares* Thane to be. `ego.md` is what Thane has *made* of that — written by a loop, on the agent's schedule, under the agent's own signer set.

They are read together because that is where the reflection is useful. They are written under different policies because they answer to different authorities. `verifyStartupReads` needs no change: `store.VerifyPath` resolves the owning root from the path, so verification follows the document automatically.

## Stale doors

Both the ego prompt (`internal/model/prompts/ego.go`) and the shipped loop document still told the model its output was `core:ego.md` — the same sentence #1321 already cleaned in metacognitive and archivist. Six operator documents still named `core/ego.md`. All corrected; `document-roots.md` now explains the authority distinction rather than saying the move hasn't happened.

## Test plan

- [x] `just ci` clean, no architecture drift, generated mirror regenerated
- [x] New test pins each prompt file to the root that owns it, and that a workspace-less config yields no path rather than a relative one
- [x] `internal/runtime/ego` spec test updated with the reasoning inline
- [x] Loop-document/Go-spec parity holds for all three service loops
- [x] Swept for remaining `core:ego.md` / `core/ego.md` references across prompts, loop docs, and docs

## Breaking

`ego.md` moves from `core` to `self`. An existing install starts the ego loop with an empty document unless the file is moved across. No automatic migration, for the reason #1321 gave: a boot-time copy would write into `core`, which is the direction this work exists to close.

Refs #1318