### PR TITLE
A missing core or self is a validate failure, not an omission

### DIFF
--- a/internal/app/document_root_admission.go
+++ b/internal/app/document_root_admission.go
@@ -101,6 +101,43 @@ func documentRootPaths(cfg *config.Config, logger *slog.Logger) map[string]strin
 	return out
 }
 
+// missingDerivedRoot reports a derived root that does not exist on disk.
+//
+// For a declared root, silence is right: validate creates nothing, and serve
+// bootstraps a missing signing root and births it, so calling it unadmitted
+// would be a false alarm about a root that does not exist to judge.
+//
+// That reasoning does not carry to core and self. Serve signs the birth commit
+// it creates with the root's own signing key, and admission then demands that
+// commit be signed by a declared seed signer. Where the two differ — the common
+// case for a derived root, whose seed signers name the operator while its
+// signing key is the agent's — the bootstrap is guaranteed to produce a root
+// serve immediately refuses. Staying quiet there does not avoid a false alarm;
+// it withholds the true one, and leaves `thane validate && thane serve`
+// reporting ready for an instance that cannot start.
+//
+// The operator's alternative is worse still: noticing a root's absence from a
+// list of the roots that are present.
+func missingDerivedRoot(cfg *config.Config, root string, mode documents.VerificationMode) (RootAdmission, bool) {
+	if !config.IsDerivedRootName(root) {
+		return RootAdmission{}, false
+	}
+	path := cfg.CoreRoot()
+	if root == config.SelfRootName {
+		path = cfg.SelfRoot()
+	}
+	return RootAdmission{
+		Root:       root,
+		RepoPath:   path,
+		Mode:       mode,
+		Applicable: true,
+		Err: fmt.Errorf("%s does not exist at %s, and it is derived from the workspace rather than declared, so there is no path to correct. "+
+			"serve would create it and sign its birth commit with roots.%s.git.signing_key, which admission then refuses unless that key is one of roots.%s.seed_signers. "+
+			"fix: restore it from its remote with `git clone <roots.%s.git.remote.url> %s`, or establish it with `thane init` when this is a new instance",
+			root, path, root, root, root, path),
+	}, true
+}
+
 // RootAdmission is one root's admission outcome.
 type RootAdmission struct {
 	// Root is the configured root name, without its trailing colon.
@@ -194,10 +231,13 @@ func (a *App) verifyRootAdmission(root, rootPath string, rootCfg config.Document
 // (buildDocumentRoots), the same policy derivation
 // (documentRootPolicyFromConfig), the same predicate (admissionSeeds), and the
 // same check (checkRootAdmission). The one deliberate difference is that
-// validate never creates anything, so a signing root whose directory does not
-// exist yet is absent from the enumeration rather than bootstrapped — serve
-// would create and birth-commit it, so reporting it as unadmitted would be a
-// false alarm about a root that does not exist to judge.
+// validate never creates anything, so a declared signing root whose directory
+// does not exist yet is absent from the enumeration rather than bootstrapped —
+// serve would create and birth-commit it, so reporting it as unadmitted would
+// be a false alarm about a root that does not exist to judge.
+//
+// core and self are the exception, for the reason [missingDerivedRoot] gives:
+// the bootstrap serve would perform is the very thing admission then refuses.
 func CheckRootAdmission(ctx context.Context, cfg *config.Config) []RootAdmission {
 	if cfg == nil || len(cfg.DocRoots) == 0 {
 		return nil
@@ -217,6 +257,9 @@ func CheckRootAdmission(ctx context.Context, cfg *config.Config) []RootAdmission
 		}
 		rootPath, ok := documentRoots[root]
 		if !ok {
+			if missing, reportable := missingDerivedRoot(cfg, root, mode); reportable {
+				out = append(out, missing)
+			}
 			continue
 		}
 		out = append(out, checkRootAdmission(ctx, root, rootPath, rootCfg, mode, resolver))

--- a/internal/app/document_root_admission.go
+++ b/internal/app/document_root_admission.go
@@ -126,15 +126,25 @@ func missingDerivedRoot(cfg *config.Config, root string, mode documents.Verifica
 	if root == config.SelfRootName {
 		path = cfg.SelfRoot()
 	}
+	// RepoPath stays empty: it reports the repository admission judged, and
+	// admission never ran here. Naming a directory that does not exist would
+	// tell a script reading validate --json that there was a repo to inspect.
+	// The path belongs in the error, where it reads as the thing that is
+	// absent rather than the thing that was checked.
+	//
+	// The config keys are named without a top-level prefix on purpose. This
+	// check is driven by cfg.DocRoots, which is populated from either the
+	// current roots: shape or the legacy doc_roots: one, and an operator on
+	// the legacy shape searching for "roots.self" finds nothing. Naming the
+	// fields is accurate under both.
 	return RootAdmission{
 		Root:       root,
-		RepoPath:   path,
 		Mode:       mode,
 		Applicable: true,
 		Err: fmt.Errorf("%s does not exist at %s, and it is derived from the workspace rather than declared, so there is no path to correct. "+
-			"serve would create it and sign its birth commit with roots.%s.git.signing_key, which admission then refuses unless that key is one of roots.%s.seed_signers. "+
-			"fix: restore it from its remote with `git clone <roots.%s.git.remote.url> %s`, or establish it with `thane init` when this is a new instance",
-			root, path, root, root, root, path),
+			"serve would create it and sign its birth commit with this root's git.signing_key, which admission then refuses unless that key is one of its seed_signers. "+
+			"fix: restore it from its remote with `git clone <the root's git.remote.url> %s`, or establish it with `thane init` when this is a new instance",
+			root, path, path),
 	}, true
 }
 

--- a/internal/app/document_root_missing_test.go
+++ b/internal/app/document_root_missing_test.go
@@ -1,0 +1,104 @@
+package app
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nugget/thane-ai-agent/internal/platform/config"
+)
+
+// A derived root that is not on disk has to be reported, not skipped. Serve
+// would create it and sign its birth commit with the agent key, and admission
+// then refuses that commit because the root's seed signers name the operator —
+// so silence here would let `thane validate && thane serve` report ready for an
+// instance that cannot start. The operator's only other signal is noticing an
+// absence from a list of what is present, which is not a signal.
+func TestCheckRootAdmissionReportsMissingDerivedRoots(t *testing.T) {
+	workspace := t.TempDir()
+	_, operatorKey := writeTestSigningKey(t)
+
+	signedRoot := func() config.DocumentRootConfig {
+		return config.DocumentRootConfig{
+			SeedSigners: []config.AllowedSigner{
+				{Principal: "operator@example.com", Key: operatorKey},
+			},
+			Git: config.DocumentRootGitConfig{
+				Enabled:          true,
+				SignCommits:      true,
+				VerifySignatures: "required",
+			},
+		}
+	}
+
+	cfg := &config.Config{
+		Workspace: config.WorkspaceConfig{Path: workspace},
+		DocRoots: map[string]config.DocumentRootConfig{
+			config.CoreRootName: signedRoot(),
+			config.SelfRootName: signedRoot(),
+		},
+	}
+
+	results := CheckRootAdmission(context.Background(), cfg)
+
+	byRoot := make(map[string]RootAdmission, len(results))
+	for _, r := range results {
+		byRoot[r.Root] = r
+	}
+
+	for _, root := range []string{config.CoreRootName, config.SelfRootName} {
+		t.Run(root, func(t *testing.T) {
+			got, ok := byRoot[root]
+			if !ok {
+				t.Fatalf("%s is missing from disk but absent from the admission report", root)
+			}
+			if got.Admitted() {
+				t.Errorf("%s does not exist yet but was reported admitted", root)
+			}
+			if !got.Fatal() {
+				t.Errorf("%s is verify_signatures=required, so its absence must refuse serve", root)
+			}
+			// The report is what an operator repairs from, so it has to name
+			// the path and a way out rather than only stating the problem.
+			if want := filepath.Join(workspace, root); !strings.Contains(got.Err.Error(), want) {
+				t.Errorf("error should name the derived path %s, got: %v", want, got.Err)
+			}
+			if !strings.Contains(got.Err.Error(), "git clone") || !strings.Contains(got.Err.Error(), "thane init") {
+				t.Errorf("error should teach both recovery paths, got: %v", got.Err)
+			}
+		})
+	}
+}
+
+// A declared root is different: validate creates nothing, serve bootstraps and
+// births it, and the birth is admissible because nothing has narrowed who may
+// sign it. Reporting that would be a false alarm about a root that does not
+// exist to judge, so the existing silence stays.
+func TestCheckRootAdmissionStaysQuietAboutMissingDeclaredRoots(t *testing.T) {
+	workspace := t.TempDir()
+	_, operatorKey := writeTestSigningKey(t)
+
+	cfg := &config.Config{
+		Workspace: config.WorkspaceConfig{Path: workspace},
+		Paths:     map[string]string{"kb": filepath.Join(workspace, "does-not-exist")},
+		DocRoots: map[string]config.DocumentRootConfig{
+			"kb": {
+				SeedSigners: []config.AllowedSigner{
+					{Principal: "operator@example.com", Key: operatorKey},
+				},
+				Git: config.DocumentRootGitConfig{
+					Enabled:          true,
+					SignCommits:      true,
+					VerifySignatures: "required",
+				},
+			},
+		},
+	}
+
+	for _, r := range CheckRootAdmission(context.Background(), cfg) {
+		if r.Root == "kb" {
+			t.Errorf("a missing declared root should not be reported, got: %+v", r)
+		}
+	}
+}

--- a/internal/app/document_root_missing_test.go
+++ b/internal/app/document_root_missing_test.go
@@ -67,6 +67,18 @@ func TestCheckRootAdmissionReportsMissingDerivedRoots(t *testing.T) {
 			if !strings.Contains(got.Err.Error(), "git clone") || !strings.Contains(got.Err.Error(), "thane init") {
 				t.Errorf("error should teach both recovery paths, got: %v", got.Err)
 			}
+			// RepoPath reports the repository admission judged, and admission
+			// never ran. Populating it with a directory that does not exist
+			// would tell a script reading validate --json otherwise.
+			if got.RepoPath != "" {
+				t.Errorf("RepoPath = %q, want empty for a root that was never judged", got.RepoPath)
+			}
+			// cfg.DocRoots is fed by either the current roots: shape or the
+			// legacy doc_roots: one, so a fully-qualified key would be wrong
+			// for half of readers.
+			if strings.Contains(got.Err.Error(), "roots."+root) {
+				t.Errorf("error should name config fields without a top-level prefix, got: %v", got.Err)
+			}
 		})
 	}
 }

--- a/internal/platform/config/config.go
+++ b/internal/platform/config/config.go
@@ -2682,7 +2682,7 @@ func (c *Config) normalizeRoots() error {
 			// core: and self: are reserved — their paths are always
 			// derived from workspace.path. Allow declaring either in
 			// roots: solely to set policy; ignore any path provided.
-			if isDerivedRootName(trimmed) {
+			if IsDerivedRootName(trimmed) {
 				if pathValue != "" && !entryHasPolicy(entry) {
 					slog.Default().Warn("config: derived root path is ignored (it comes from workspace.path); declare this root only when setting policy",
 						"root", trimmed, "path", entry.Path)
@@ -3572,9 +3572,14 @@ func (c *Config) CoreRoot() string {
 	return filepath.Join(c.Workspace.Path, "core")
 }
 
-// isDerivedRootName reports whether a root takes its path from the
+// IsDerivedRootName reports whether a root takes its path from the
 // workspace rather than from roots:.
-func isDerivedRootName(name string) bool {
+//
+// The derived roots are load-bearing in a way declared roots are not: the
+// instance's own configuration lives in one and its core service loops write
+// the other on every install. Callers that need to treat "this root is missing"
+// as a problem rather than a preference use this to tell the two apart.
+func IsDerivedRootName(name string) bool {
 	return name == CoreRootName || name == SelfRootName
 }
 


### PR DESCRIPTION
## The bug

`thane validate` printed a fully clean report — `✓ Config valid`, `✓ Core integrity`, `✓ Root admission: HOR, HPDE, core, kb, projects` — for a workspace where `self` did not exist. The only signal was that `self` was *absent from a list of the roots that were present*, which asks the operator to notice a negative space. Serve then refused to start.

This was hit for real while migrating production onto a `self` root.

## Why the existing behaviour was right, and where it stops being right

`CheckRootAdmission` deliberately skips roots whose directory is absent, and says so:

> validate never creates anything, so a signing root whose directory does not exist yet is absent from the enumeration rather than bootstrapped — serve would create and birth-commit it, so reporting it as unadmitted would be a false alarm about a root that does not exist to judge.

That reasoning is sound for a **declared** root: serve bootstraps it, the birth is admissible because nothing has narrowed who may sign it, and warning would be noise.

It does not carry to **core and self**. Serve signs the birth commit with the root's own `git.signing_key`, and admission then demands that commit be signed by a declared `seed_signer`. For a derived root those two usually differ — seed signers name the operator, the signing key is the agent's — so the bootstrap serve would perform is *guaranteed* to produce a root serve immediately refuses. Silence there doesn't avoid a false alarm; it withholds the true one, and breaks the `thane validate && thane serve` guard the file's own comments care about.

## The change

Derived roots stop being skipped. The report already carries per-root failures with fix lines, so this flows through it rather than adding a section — no new plumbing in the text writer, the JSON writer, or the error path.

The error names the derived path and both ways out, since a derived root has no `path:` to correct:

```
self does not exist at /Users/aimee/Thane/self, and it is derived from the
workspace rather than declared, so there is no path to correct. serve would
create it and sign its birth commit with roots.self.git.signing_key, which
admission then refuses unless that key is one of roots.self.seed_signers.
fix: restore it from its remote with `git clone <roots.self.git.remote.url>
/Users/aimee/Thane/self`, or establish it with `thane init` when this is a
new instance
```

`isDerivedRootName` is exported as `config.IsDerivedRootName` so the app layer can make the distinction the config layer already draws.

## Test plan

- [x] `just ci` clean, no architecture drift
- [x] Missing `core` and missing `self` are both reported, both fatal under `verify_signatures: required`, and the error names the path plus both recovery paths
- [x] A missing **declared** root is still skipped — the original reasoning is preserved and pinned by its own test, so this can't drift into warning about every unbuilt root

## Note

This makes validate stricter on a workspace that has been `thane init`-ed but never served, since `self` is created on first serve. That is the honest report — the instance genuinely cannot start until the root exists — and it's the same fresh-install bootstrap question already tracked for pre-1.0.

Refs #1318