### PR TITLE
A file named HEAD in a document root must not refuse boot

### DIFF
--- a/cmd/thane/validate.go
+++ b/cmd/thane/validate.go
@@ -205,8 +205,25 @@ func writeAdmissionText(w io.Writer, results []app.RootAdmission) {
 			// because it will not.
 			marker = "!"
 		}
-		fmt.Fprintf(w, "  %s %s (%s)\n      %s\n", marker, result.Root, result.Mode, result.Err)
+		fmt.Fprintf(w, "  %s %s (%s)\n%s\n", marker, result.Root, result.Mode, indentDetail(result.Err.Error()))
 	}
+}
+
+// indentDetail renders a failure reason under a report entry, holding every
+// line at the entry's indent.
+//
+// Reasons that reach here are not always one line. Anything wrapping a git
+// failure carries git's stderr, which is often an error followed by usage
+// advice, and printed raw those continuation lines start at column zero — so
+// the report loses the shape that tells a reader which root each reason
+// belongs to, exactly when they are scanning it to find out what broke.
+func indentDetail(detail string) string {
+	const indent = "      "
+	lines := strings.Split(strings.TrimRight(detail, "\n"), "\n")
+	for i, line := range lines {
+		lines[i] = indent + strings.TrimRight(line, " \t")
+	}
+	return strings.Join(lines, "\n")
 }
 
 // integrityError converts a failing report into the error that makes

--- a/cmd/thane/validate.go
+++ b/cmd/thane/validate.go
@@ -205,25 +205,12 @@ func writeAdmissionText(w io.Writer, results []app.RootAdmission) {
 			// because it will not.
 			marker = "!"
 		}
-		fmt.Fprintf(w, "  %s %s (%s)\n%s\n", marker, result.Root, result.Mode, indentDetail(result.Err.Error()))
+		// Reasons here are not always one line: anything wrapping a git failure
+		// carries git's stderr, which is an error followed by usage advice, and
+		// printed raw those continuation lines start at column zero — losing the
+		// shape that says which root a reason belongs to.
+		fmt.Fprintf(w, "  %s %s (%s)\n%s\n", marker, result.Root, result.Mode, indentBlock(result.Err.Error(), "      "))
 	}
-}
-
-// indentDetail renders a failure reason under a report entry, holding every
-// line at the entry's indent.
-//
-// Reasons that reach here are not always one line. Anything wrapping a git
-// failure carries git's stderr, which is often an error followed by usage
-// advice, and printed raw those continuation lines start at column zero — so
-// the report loses the shape that tells a reader which root each reason
-// belongs to, exactly when they are scanning it to find out what broke.
-func indentDetail(detail string) string {
-	const indent = "      "
-	lines := strings.Split(strings.TrimRight(detail, "\n"), "\n")
-	for i, line := range lines {
-		lines[i] = indent + strings.TrimRight(line, " \t")
-	}
-	return strings.Join(lines, "\n")
 }
 
 // integrityError converts a failing report into the error that makes

--- a/cmd/thane/validate_test.go
+++ b/cmd/thane/validate_test.go
@@ -428,3 +428,37 @@ func TestIndentBlockPreservesInteriorStructure(t *testing.T) {
 		t.Errorf("indentBlock() =\n%q\nwant\n%q", got, want)
 	}
 }
+
+// A reason wrapping a git failure carries git's stderr, which is often an
+// error line followed by usage advice. Printed raw, those continuation lines
+// start at column zero and the report loses the indentation that tells a reader
+// which root each reason belongs to — precisely when they are scanning it to
+// find out what broke.
+func TestAdmissionReportIndentsEveryLineOfAReason(t *testing.T) {
+	multiline := errors.New("list root commits of /w/core: fatal: ambiguous argument 'HEAD': both revision and filename\n" +
+		"Use '--' to separate paths from revisions, like this:\n" +
+		"'git <command> [<revision>...] -- [<file>...]': exit status 128")
+
+	var buf bytes.Buffer
+	writeAdmissionText(&buf, []app.RootAdmission{
+		{Root: "core", Mode: documents.VerificationRequired, Applicable: true, Err: multiline},
+		{Root: "kb", Mode: documents.VerificationRequired, Applicable: true},
+	})
+
+	// The section header sits at column zero by design; everything under it
+	// belongs to a root and must stay indented beneath one.
+	lines := strings.Split(strings.TrimRight(buf.String(), "\n"), "\n")
+	for _, line := range lines[1:] {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		if !strings.HasPrefix(line, "  ") {
+			t.Errorf("line escapes the report's indentation: %q", line)
+		}
+	}
+	// The detail must still be present in full — indenting it is not a licence
+	// to drop the part that says what to do.
+	if !strings.Contains(buf.String(), "Use '--' to separate paths from revisions") {
+		t.Error("continuation lines were lost rather than indented")
+	}
+}

--- a/cmd/thane/validate_test.go
+++ b/cmd/thane/validate_test.go
@@ -462,3 +462,19 @@ func TestAdmissionReportIndentsEveryLineOfAReason(t *testing.T) {
 		t.Error("continuation lines were lost rather than indented")
 	}
 }
+
+// A reason that indents its own detail — a yaml decode error nesting lines
+// under the message they belong to — must keep that structure. Prefixing adds
+// depth; it must not flatten what the error's author put there.
+func TestAdmissionReportPreservesAReasonsOwnIndentation(t *testing.T) {
+	nested := errors.New("parse config: yaml: unmarshal errors:\n  line 12: cannot unmarshal !!str into int\n  line 19: field roots not found")
+
+	var buf bytes.Buffer
+	writeAdmissionText(&buf, []app.RootAdmission{
+		{Root: "core", Mode: documents.VerificationRequired, Applicable: true, Err: nested},
+	})
+
+	if !strings.Contains(buf.String(), "        line 12: cannot unmarshal") {
+		t.Errorf("the reason's own two-space nesting was flattened:\n%s", buf.String())
+	}
+}

--- a/internal/platform/provenance/admission.go
+++ b/internal/platform/provenance/admission.go
@@ -188,8 +188,16 @@ func logSeedFloorUsed(logger *slog.Logger, repoPath, commit string) {
 // whose history is perfectly intact — the failure mode is not hypothetical,
 // since a repository owned by another user makes git refuse every command
 // with an error that has nothing to do with commits.
+// rootCommits lists the repository's parentless commits.
+//
+// The trailing "--" is load-bearing. A document root is a directory an agent
+// writes files into, and a file named HEAD there makes the revision ambiguous
+// with a path — git then refuses with usage advice rather than an answer, and
+// admission reports it as though the history were unreadable. The separator
+// says everything before it is a revision, which is the same guard the read
+// surface already applies to every revision it passes.
 func rootCommits(ctx context.Context, repoPath string) ([]string, error) {
-	out, err := runGitText(ctx, repoPath, "rev-list", "--max-parents=0", "HEAD")
+	out, err := runGitText(ctx, repoPath, "rev-list", "--max-parents=0", "--end-of-options", "HEAD", "--")
 	if err == nil {
 		return nonEmptyLines(out), nil
 	}
@@ -201,7 +209,7 @@ func rootCommits(ctx context.Context, repoPath string) ([]string, error) {
 	case strings.TrimSpace(inside) != "true":
 		return nil, fmt.Errorf("%s is not a git work tree, so it has no history to admit", repoPath)
 	}
-	if _, headErr := runGitText(ctx, repoPath, "rev-parse", "--verify", "HEAD"); headErr != nil {
+	if _, headErr := runGitText(ctx, repoPath, "rev-parse", "--verify", "--end-of-options", "HEAD"); headErr != nil {
 		return nil, nil
 	}
 	return nil, fmt.Errorf("list root commits of %s: %w", repoPath, err)

--- a/internal/platform/provenance/admission.go
+++ b/internal/platform/provenance/admission.go
@@ -188,14 +188,15 @@ func logSeedFloorUsed(logger *slog.Logger, repoPath, commit string) {
 // whose history is perfectly intact — the failure mode is not hypothetical,
 // since a repository owned by another user makes git refuse every command
 // with an error that has nothing to do with commits.
-// rootCommits lists the repository's parentless commits.
 //
-// The trailing "--" is load-bearing. A document root is a directory an agent
-// writes files into, and a file named HEAD there makes the revision ambiguous
-// with a path — git then refuses with usage advice rather than an answer, and
-// admission reports it as though the history were unreadable. The separator
-// says everything before it is a revision, which is the same guard the read
-// surface already applies to every revision it passes.
+// The trailing "--" is load-bearing for the same reason. A document root is a
+// directory an agent writes files into, and a file named HEAD there makes the
+// revision ambiguous with a path — git then refuses with usage advice rather
+// than an answer, and this reports it as the fourth thing the distinctions
+// above exist to prevent: a root whose history is perfectly intact, refused
+// over a loose file beside it. The separator says everything before it is a
+// revision, which is the guard the read surface already applies to every
+// revision it passes.
 func rootCommits(ctx context.Context, repoPath string) ([]string, error) {
 	out, err := runGitText(ctx, repoPath, "rev-list", "--max-parents=0", "--end-of-options", "HEAD", "--")
 	if err == nil {

--- a/internal/platform/provenance/admission_pathspec_test.go
+++ b/internal/platform/provenance/admission_pathspec_test.go
@@ -1,0 +1,59 @@
+package provenance
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// A document root is a directory an agent writes files into, so a file whose
+// name collides with a revision is a question of when, not whether. Git refuses
+// an ambiguous argument with usage advice rather than an answer, and admission
+// reported that as though the history itself were unreadable — a root that
+// verifies perfectly well was refused at boot by a stray file beside it.
+func TestAdmissionSurvivesAFileNamedLikeARevision(t *testing.T) {
+	for _, name := range []string{"HEAD", "main"} {
+		t.Run(name, func(t *testing.T) {
+			dir := initRepo(t)
+			if err := os.WriteFile(filepath.Join(dir, name), []byte("not a ref\n"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+
+			commits, err := rootCommits(context.Background(), dir)
+			if err != nil {
+				t.Fatalf("rootCommits with a file named %q: %v", name, err)
+			}
+			if len(commits) != 1 {
+				t.Errorf("got %d root commits, want 1", len(commits))
+			}
+		})
+	}
+}
+
+// The same collision must not reach the trust-file history either, which is
+// walked by the third admission rule.
+func TestTrustFileHistorySurvivesTheSameCollision(t *testing.T) {
+	dir := initRepo(t)
+	if err := os.WriteFile(filepath.Join(dir, "HEAD"), []byte("not a ref\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := trustFileCommits(context.Background(), dir); err != nil {
+		t.Fatalf("trustFileCommits with a file named HEAD: %v", err)
+	}
+}
+
+// An empty repository still has to report "no history" rather than an error, so
+// the added separator must not turn the unborn-HEAD case into a failure.
+func TestRootCommitsStillReportsNoHistoryForAnEmptyRepo(t *testing.T) {
+	dir := t.TempDir()
+	runGit(t, dir, "-c", "init.defaultBranch=main", "init")
+
+	commits, err := rootCommits(context.Background(), dir)
+	if err != nil {
+		t.Fatalf("rootCommits on an empty repo: %v", err)
+	}
+	if len(commits) != 0 {
+		t.Errorf("got %d root commits, want none", len(commits))
+	}
+}


### PR DESCRIPTION
## What happened

A stray `git init --bare` left `HEAD`, `config`, `objects/` and friends in a production document root. Boot then refused:

```
doc_roots.self admission boot verification: list root commits of /Users/aimee/Thane/self:
fatal: ambiguous argument 'HEAD': both revision and filename
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]': exit status 128
```

The repository was entirely healthy. A loose file beside it was enough to refuse the instance, with an error that reads like corruption.

## Why it was reachable

Admission listed root commits with `rev-list --max-parents=0 HEAD` and no separator. A document root is a directory an agent writes files into, so a filename colliding with a revision is a question of when, not whether — `HEAD` here, but `main` does it too.

The read surface already takes this seriously: every revision `reader.go` passes is guarded with `--end-of-options` and a `--` separator, and `checkRevisionArg` rejects anything that could be mistaken for an option. Admission simply never got the same treatment, which is the gap rather than the design.

Measured, with a stray `HEAD` present:

| invocation | result |
|---|---|
| `rev-list --max-parents=0 HEAD` | **fails** |
| `rev-parse --is-inside-work-tree` | ok |
| `rev-parse --verify HEAD` | ok |
| `log … -- .allowed_signers` | ok — already separated |
| `rev-list --max-parents=0 --end-of-options HEAD --` | **ok** |

Exactly one call site was exposed. There is an irony in the recovery path: `rootCommits` catches the failure and probes with two `rev-parse` calls that both *succeed*, correctly concludes the repository is fine, and re-raises the original error — so the diagnosis was right and the message was git's usage text.

## The report shape

The second half of what an operator saw. Reasons wrapping a git failure carry git's stderr, which is an error line followed by usage advice, and the report printed it raw — continuation lines starting at column zero, so the indentation that says which root a reason belongs to was lost at exactly the moment someone is scanning the report to find out what broke. Reasons now hold the entry's indent, in full; nothing is truncated.

## Test plan

- [x] `just ci` clean, no architecture drift
- [x] Admission survives a root containing a file named `HEAD`, and one named `main`
- [x] Trust-file history survives the same collision
- [x] An empty repository still reports "no history" rather than an error — the separator must not turn unborn HEAD into a failure
- [x] **Mutation-checked**: reverting the separator fails the new test, so it pins the behaviour rather than describing it
- [x] Multi-line reasons stay inside the report's indentation, with the detail intact

Refs #1318