### PR TITLE
feat(loops): scaffold declared outputs with the shape the first turn must fill

### DIFF
--- a/internal/app/loop_output_publish.go
+++ b/internal/app/loop_output_publish.go
@@ -9,15 +9,13 @@ import (
 	"github.com/nugget/thane-ai-agent/internal/state/documents"
 )
 
-// Frontmatter keys stamped on loop-managed documents. audience is the
-// document layer's projection gate (an internal document stays out of
-// search results and tagged-guidance injection); managed_by records
-// which generated tool owns the document's structure, so a later edit
-// arriving through a general document tool can be pointed back at the
-// owning interface instead of silently competing with it.
+// Frontmatter keys stamped on loop-managed documents. The contract
+// package owns the names (the create-time scaffold stamps the same
+// keys); see the [looppkg.OutputAudienceFrontmatterKey] doc for what
+// each key does.
 const (
-	loopOutputAudienceKey  = "audience"
-	loopOutputManagedByKey = "managed_by"
+	loopOutputAudienceKey  = looppkg.OutputAudienceFrontmatterKey
+	loopOutputManagedByKey = looppkg.OutputManagedByFrontmatterKey
 )
 
 // buildFacetPublishTool generates the publish interface for one faceted
@@ -70,12 +68,9 @@ func buildFacetPublishTool(store *documents.Store, output looppkg.OutputSpec, no
 			}
 			body := output.RenderFacetDocument(payload)
 			result, err := store.Write(ctx, documents.WriteArgs{
-				Ref:  output.Ref,
-				Body: &body,
-				Frontmatter: map[string][]string{
-					loopOutputAudienceKey:  {string(output.EffectiveAudience())},
-					loopOutputManagedByKey: {output.ToolName()},
-				},
+				Ref:         output.Ref,
+				Body:        &body,
+				Frontmatter: loopOutputFrontmatter(output),
 			})
 			if err != nil {
 				return "", err
@@ -125,21 +120,22 @@ func writeLoopWorkingNotes(ctx context.Context, store *documents.Store, notes lo
 	return store.Write(ctx, documents.WriteArgs{
 		Ref:         notes.Ref,
 		Body:        &body,
-		Frontmatter: loopOutputAudienceFrontmatter(notes),
+		Frontmatter: loopOutputFrontmatter(notes),
 	})
 }
 
-// loopOutputAudienceFrontmatter returns the audience stamp for an
-// output's document, or nil when the output is published (the document
-// layer's default). Stamping internal is what makes an internal
-// declaration real: the exclusion in search and tagged-guidance
-// injection reads this key, not the loop spec.
-func loopOutputAudienceFrontmatter(output looppkg.OutputSpec) map[string][]string {
-	if output.EffectiveAudience() != looppkg.OutputAudienceInternal {
-		return nil
-	}
+// loopOutputFrontmatter returns the ownership stamp for an output's
+// document, applied on every write rather than only the first. Stamping
+// the audience is what makes an internal declaration real: the
+// exclusion in search and tagged-guidance injection reads this key off
+// the document, not the loop spec, so a rewrite that dropped it would
+// quietly publish the loop's private thinking. managed_by rides along
+// so an edit arriving through a general document tool can be pointed
+// back at the owning interface.
+func loopOutputFrontmatter(output looppkg.OutputSpec) map[string][]string {
 	return map[string][]string{
-		loopOutputAudienceKey: {string(looppkg.OutputAudienceInternal)},
+		loopOutputAudienceKey:  {string(output.EffectiveAudience())},
+		loopOutputManagedByKey: {output.ToolName()},
 	}
 }
 

--- a/internal/app/loop_outputs.go
+++ b/internal/app/loop_outputs.go
@@ -114,7 +114,7 @@ func buildLoopOutputTools(store *documents.Store, outputs []looppkg.OutputSpec) 
 						// reads this key off the document, so a rewrite that
 						// dropped it would quietly publish the loop's private
 						// thinking.
-						Frontmatter: loopOutputAudienceFrontmatter(output),
+						Frontmatter: loopOutputFrontmatter(output),
 					})
 					if err != nil {
 						return "", err

--- a/internal/app/loop_outputs.go
+++ b/internal/app/loop_outputs.go
@@ -3,9 +3,7 @@ package app
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
-	"os"
 	"strings"
 	"time"
 	"unicode/utf8"
@@ -152,7 +150,7 @@ func renderLoopOutputContextWithNow(ctx context.Context, store *documents.Store,
 		}
 		doc, err := store.Read(ctx, output.Ref)
 		if err != nil {
-			if strings.Contains(err.Error(), "document not found") || errors.Is(err, os.ErrNotExist) {
+			if documents.IsNotFound(err) {
 				entry.Exists = false
 				payload.Outputs = append(payload.Outputs, entry)
 				continue

--- a/internal/runtime/loop/output.go
+++ b/internal/runtime/loop/output.go
@@ -54,6 +54,23 @@ const (
 	OutputFacetDigest OutputFacet = "digest"
 )
 
+// Frontmatter keys stamped on loop-managed documents wherever one is
+// written — the create-time scaffold and every later output-tool write.
+// audience is the document layer's projection gate (an internal
+// document stays out of search results and tagged-guidance injection);
+// managed_by records which generated tool owns the document's
+// structure, so an edit arriving through a general document tool can be
+// pointed back at the owning interface instead of silently competing
+// with it.
+const (
+	// OutputAudienceFrontmatterKey carries the output's effective
+	// audience on the document itself.
+	OutputAudienceFrontmatterKey = "audience"
+	// OutputManagedByFrontmatterKey names the generated output tool
+	// that owns the document.
+	OutputManagedByFrontmatterKey = "managed_by"
+)
+
 // OutputAudience describes which surfaces may project an output's
 // content.
 type OutputAudience string

--- a/internal/runtime/loop/output_facets.go
+++ b/internal/runtime/loop/output_facets.go
@@ -56,7 +56,12 @@ type facetSection struct {
 	Facet   OutputFacet
 	Field   FacetField
 	Heading string
-	value   func(*FacetPayload) *string
+	// scaffoldHint is the short phrase rendered under this section's
+	// heading in a pre-first-publish scaffold — a compressed cue of what
+	// belongs there, sized for a placeholder rather than for teaching
+	// (the publish tool's Guidance carries the full contract).
+	scaffoldHint string
+	value        func(*FacetPayload) *string
 }
 
 // facetSections is the single source of truth for the publish tool's
@@ -74,7 +79,8 @@ var facetSections = []facetSection{
 			SingleLine: true,
 			Guidance:   "One standalone line of current state, no line breaks. Reads as an ambient status: what is true right now. This is the only thing some surfaces show, so it must stand alone without the document around it.",
 		},
-		value: func(p *FacetPayload) *string { return &p.StatusLine },
+		scaffoldHint: "one standalone line of what is true right now",
+		value:        func(p *FacetPayload) *string { return &p.StatusLine },
 	},
 	{
 		Facet:   OutputFacetTeaser,
@@ -84,7 +90,8 @@ var facetSections = []facetSection{
 			MaxRunes: teaserMaxRunes,
 			Guidance: "One short paragraph on why a reader would open this document right now. Surfaces as the snippet in search results and cross-references, so write the hook — the reason to look — rather than a compressed summary.",
 		},
-		value: func(p *FacetPayload) *string { return &p.Teaser },
+		scaffoldHint: "why a reader would open this document right now",
+		value:        func(p *FacetPayload) *string { return &p.Teaser },
 	},
 	{
 		Facet:   OutputFacetDigest,
@@ -94,7 +101,8 @@ var facetSections = []facetSection{
 			MaxRunes: digestMaxRunes,
 			Guidance: "A standalone summary carrying enough substance to act on without opening the full document. Surfaces in subscription rows and periodic digests.",
 		},
-		value: func(p *FacetPayload) *string { return &p.Digest },
+		scaffoldHint: "a summary with enough substance to act on",
+		value:        func(p *FacetPayload) *string { return &p.Digest },
 	},
 	{
 		Heading: "Details",
@@ -102,7 +110,8 @@ var facetSections = []facetSection{
 			Key:      "full",
 			Guidance: "The complete current state in markdown. This is what a reader opens when the digest is not enough. Always required: it is the document's substance, and the other projections are views of it.",
 		},
-		value: func(p *FacetPayload) *string { return &p.Full },
+		scaffoldHint: "the complete current state",
+		value:        func(p *FacetPayload) *string { return &p.Full },
 	},
 }
 
@@ -207,6 +216,39 @@ func (o OutputSpec) RenderFacetDocument(payload FacetPayload) string {
 		blocks = append(blocks, "## "+section.Heading+"\n\n"+value)
 	}
 	return strings.Join(blocks, "\n\n")
+}
+
+// RenderFacetScaffold renders the pre-first-publish body for a faceted
+// output: the same section skeleton [OutputSpec.RenderFacetDocument]
+// will produce, with an awaiting-first-cycle placeholder under each
+// heading. The first iteration sees this body in its Declared Durable
+// Outputs context, so the scaffold showing the exact shape a correct
+// publish produces is what stops that turn from inventing a structure
+// of its own. Rendering goes through the real renderer rather than a
+// copy so the scaffold cannot drift from the published form.
+func (o OutputSpec) RenderFacetScaffold() string {
+	var payload FacetPayload
+	for _, field := range o.FacetFields() {
+		section, ok := facetSectionByKey(field.Key)
+		if !ok {
+			continue
+		}
+		*section.value(&payload) = facetScaffoldPlaceholder(field, section.scaffoldHint)
+	}
+	return o.RenderFacetDocument(payload)
+}
+
+// facetScaffoldPlaceholder builds one section's placeholder. A json
+// facet gets a valid-JSON placeholder because its section renders
+// inside a json fence, where prose reads as damage.
+func facetScaffoldPlaceholder(field FacetField, hint string) string {
+	if field.Format == FacetFormatJSON {
+		return `{"awaiting_first_cycle": true}`
+	}
+	if field.MaxRunes > 0 {
+		return fmt.Sprintf("_(awaiting first cycle — %s, ≤%d characters)_", hint, field.MaxRunes)
+	}
+	return fmt.Sprintf("_(awaiting first cycle — %s)_", hint)
 }
 
 // ParseFacetDocument reads a rendered document body back into a payload.

--- a/internal/runtime/loop/output_facets_test.go
+++ b/internal/runtime/loop/output_facets_test.go
@@ -1,6 +1,7 @@
 package loop
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 )
@@ -302,5 +303,104 @@ func TestValidateOutputsRejectsSecondWorkingNotes(t *testing.T) {
 	}
 	if err := spec.ValidatePersistable(); err != nil {
 		t.Fatalf("ValidatePersistable() with an internal journal alongside working notes: %v", err)
+	}
+}
+
+// TestRenderFacetScaffold pins the pre-first-publish body to the exact
+// shape a correct publish produces: the declared section skeleton in
+// ladder order, one placeholder per section. The first iteration reads
+// this body from its output context, so a scaffold shaped differently
+// from a published document would teach that turn the wrong form.
+func TestRenderFacetScaffold(t *testing.T) {
+	tests := []struct {
+		name         string
+		output       OutputSpec
+		wantHeadings []string
+		wantAbsent   []string
+	}{
+		{
+			name:         "every facet renders the whole ladder",
+			output:       facetedOutput(OutputFacetStatusLine, OutputFacetTeaser, OutputFacetDigest),
+			wantHeadings: []string{"## Status Line", "## Teaser", "## Digest", "## Details"},
+		},
+		{
+			name:         "status line only still scaffolds full",
+			output:       facetedOutput(OutputFacetStatusLine),
+			wantHeadings: []string{"## Status Line", "## Details"},
+			wantAbsent:   []string{"## Teaser", "## Digest"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body := tt.output.RenderFacetScaffold()
+			last := -1
+			for _, heading := range tt.wantHeadings {
+				idx := strings.Index(body, heading)
+				if idx < 0 {
+					t.Fatalf("scaffold missing %q:\n%s", heading, body)
+				}
+				if idx < last {
+					t.Fatalf("scaffold headings out of ladder order:\n%s", body)
+				}
+				last = idx
+			}
+			for _, heading := range tt.wantAbsent {
+				if strings.Contains(body, heading) {
+					t.Errorf("scaffold has undeclared section %q:\n%s", heading, body)
+				}
+			}
+			if !strings.Contains(body, "awaiting first cycle") {
+				t.Errorf("scaffold placeholders missing awaiting-first-cycle marker:\n%s", body)
+			}
+		})
+	}
+}
+
+// TestRenderFacetScaffoldRoundTrips confirms the scaffold parses back
+// through the same reader a published document does, with a placeholder
+// in every declared projection — a consumer asking for status_line
+// before the first cycle gets an honest placeholder, not an empty
+// string or a parse failure.
+func TestRenderFacetScaffoldRoundTrips(t *testing.T) {
+	output := facetedOutput(OutputFacetStatusLine, OutputFacetTeaser, OutputFacetDigest)
+	payload, found := ParseFacetSections(output.RenderFacetScaffold())
+	if !found {
+		t.Fatal("scaffold did not parse as a faceted document")
+	}
+	for key, value := range map[string]string{
+		"status_line": payload.StatusLine,
+		"teaser":      payload.Teaser,
+		"digest":      payload.Digest,
+		"full":        payload.Full,
+	} {
+		if !strings.Contains(value, "awaiting first cycle") {
+			t.Errorf("%s placeholder = %q, want awaiting-first-cycle text", key, value)
+		}
+	}
+	// Budgeted placeholders must respect their own budgets: a scaffold
+	// that overflows its facet would be rejected if republished.
+	if err := output.ValidateFacetPayload(payload); err != nil {
+		t.Errorf("scaffold payload fails its own contract: %v", err)
+	}
+}
+
+// TestRenderFacetScaffoldJSONFacet pins the json-format placeholder:
+// the section renders inside a json fence, so the placeholder must be
+// valid JSON rather than prose.
+func TestRenderFacetScaffoldJSONFacet(t *testing.T) {
+	output := OutputSpec{
+		Name:   "feed state",
+		Type:   OutputTypeMaintainedDocument,
+		Ref:    "core:feed.md",
+		Facets: []FacetSpec{{Name: OutputFacetStatusLine, Format: FacetFormatJSON}},
+	}
+	body := output.RenderFacetScaffold()
+	if !strings.Contains(body, "```json") {
+		t.Fatalf("json facet scaffold missing fence:\n%s", body)
+	}
+	payload := output.ParseFacetDocument(body)
+	if !json.Valid([]byte(payload.StatusLine)) {
+		t.Errorf("json facet placeholder is not valid JSON: %q", payload.StatusLine)
 	}
 }

--- a/internal/state/documents/mutate.go
+++ b/internal/state/documents/mutate.go
@@ -2,6 +2,7 @@ package documents
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -83,6 +84,21 @@ type MutationResult struct {
 	SizeBytes   int64    `json:"size_bytes"`
 	Section     string   `json:"section,omitempty"`
 	Window      string   `json:"window,omitempty"`
+}
+
+// IsNotFound reports whether err means the document does not exist, as
+// opposed to a read that failed — an unknown root, a provenance
+// verification failure, or an IO error. Callers probing for existence
+// must distinguish the two: treating a failed read as "absent" turns a
+// transient fault into a decision to overwrite whatever is actually
+// there. The match is on the error string because the not-found errors
+// in this package are minted as strings; this helper is the one place
+// that knows their shape.
+func IsNotFound(err error) bool {
+	if err == nil {
+		return false
+	}
+	return errors.Is(err, os.ErrNotExist) || strings.Contains(err.Error(), "document not found")
 }
 
 func (s *Store) Read(ctx context.Context, ref string) (*DocumentRecord, error) {

--- a/internal/tools/loop_create_dryrun_test.go
+++ b/internal/tools/loop_create_dryrun_test.go
@@ -56,9 +56,12 @@ func TestThaneLoopCreateDryRunWritesNothing(t *testing.T) {
 			}
 		}
 	}
-	// Nothing scaffolded.
+	// Nothing scaffolded — the derived notes document included.
 	if _, err := rig.docTools.Read(ctx, documents.RefArgs{Ref: "kb:dashboards/dry-run-probe.md"}); err == nil {
 		t.Error("dry run scaffolded the output document")
+	}
+	if _, err := rig.docTools.Read(ctx, documents.RefArgs{Ref: "kb:dashboards/dry-run-probe-notes.md"}); err == nil {
+		t.Error("dry run scaffolded the working-notes document")
 	}
 
 	// The returned spec must be the real thing, not a summary: same shape

--- a/internal/tools/loop_create_fluency_test.go
+++ b/internal/tools/loop_create_fluency_test.go
@@ -353,3 +353,26 @@ func TestGuidedCreateReplacePreservesDocuments(t *testing.T) {
 		t.Errorf("replace clobbered the working notes:\n%s", notes)
 	}
 }
+
+// TestGuidedCreateFailsClosedOnUnreadableOutputDoc pins the existence
+// probe's failure direction. The probe's answer decides between
+// scaffolding and preserving, so a read that fails for any reason
+// other than not-found — unknown root, provenance verification, IO —
+// must stop the create: misread as "absent", it would scaffold over
+// whatever is actually there.
+func TestGuidedCreateFailsClosedOnUnreadableOutputDoc(t *testing.T) {
+	rig := newCurateTestRig(t)
+	args := curateArgs(nil)
+	args["output"] = map[string]any{"document": "vault:dashboards/closet.md"}
+
+	_, err := rig.tool.Handler(context.Background(), args)
+	if err == nil {
+		t.Fatal("an unreadable output ref should refuse, not scaffold")
+	}
+	if !strings.Contains(err.Error(), "inspect output document") {
+		t.Errorf("error should name the failed probe, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "vault:dashboards/closet.md") {
+		t.Errorf("error should name the ref, got: %v", err)
+	}
+}

--- a/internal/tools/loop_create_fluency_test.go
+++ b/internal/tools/loop_create_fluency_test.go
@@ -124,11 +124,11 @@ func TestGuidedCreateRefusesUnknownFacet(t *testing.T) {
 	}
 }
 
-// TestGuidedCreateTierInputShapes covers the two array forms a caller can
+// TestGuidedCreateFacetInputShapes covers the two array forms a caller can
 // present and the element that is neither. A non-string coerced to ""
 // would be reported as an empty facet name, which names the symptom
 // rather than the mistake.
-func TestGuidedCreateTierInputShapes(t *testing.T) {
+func TestGuidedCreateFacetInputShapes(t *testing.T) {
 	t.Run("[]string is accepted", func(t *testing.T) {
 		got, err := parseOutputFacets([]string{"status_line", "digest"})
 		if err != nil {

--- a/internal/tools/loop_create_fluency_test.go
+++ b/internal/tools/loop_create_fluency_test.go
@@ -167,8 +167,8 @@ func TestGuidedCreateTierInputShapes(t *testing.T) {
 
 // TestGuidedCreateAlwaysDerivesNotes pins that the notes surface is not
 // a choice. An opt-in every caller should take is a default in the wrong
-// position, and the cost of an unused one is a single context-block line
-// — nothing is scaffolded until the loop writes to it.
+// position, and the cost of an unused one is a scaffolded stub and a
+// context-block line saying it exists.
 func TestGuidedCreateAlwaysDerivesNotes(t *testing.T) {
 	spec, result := dryRunSpec(t, curateArgs(nil))
 	if len(spec.Outputs) != 2 {
@@ -208,3 +208,148 @@ func TestGuidedCreateRefusesNotesCollision(t *testing.T) {
 }
 
 func strPtr(s string) *string { return &s }
+
+// TestGuidedCreateScaffoldsFacetSkeleton pins what the loop's first
+// iteration sees: a faceted output's scaffold is the exact section
+// skeleton its publish tool fills, stamped with the same ownership
+// frontmatter every later publish re-stamps. A scaffold shaped unlike a
+// published document would teach the first turn the wrong form.
+func TestGuidedCreateScaffoldsFacetSkeleton(t *testing.T) {
+	rig := newCurateTestRig(t)
+	ctx := context.Background()
+
+	args := curateArgs(map[string]any{"facets": []any{"status_line", "digest"}})
+	out, err := rig.tool.Handler(ctx, args)
+	if err != nil {
+		t.Fatalf("thane_loop_create: %v", err)
+	}
+	var result map[string]any
+	if err := json.Unmarshal([]byte(out), &result); err != nil {
+		t.Fatalf("decode result: %v", err)
+	}
+	if result["document_state"] != "scaffolded" {
+		t.Errorf("document_state = %v, want scaffolded", result["document_state"])
+	}
+
+	doc, err := rig.docTools.Read(ctx, documents.RefArgs{Ref: "kb:dashboards/closet.md"})
+	if err != nil {
+		t.Fatalf("read scaffold: %v", err)
+	}
+	for _, want := range []string{
+		"## Status Line", "## Digest", "## Details",
+		"awaiting first cycle",
+		`"audience"`, `"published"`,
+		`"managed_by"`, `"publish_output_closet_guardian"`,
+	} {
+		if !strings.Contains(doc, want) {
+			t.Errorf("faceted scaffold missing %q:\n%s", want, doc)
+		}
+	}
+	// Undeclared sections must not appear: a heading the publish tool
+	// will never fill reads as structure the loop should maintain.
+	if strings.Contains(doc, "## Teaser") {
+		t.Errorf("scaffold has undeclared Teaser section:\n%s", doc)
+	}
+	if strings.Contains(doc, "Current State") {
+		t.Errorf("faceted scaffold should not carry the unfaceted body shape:\n%s", doc)
+	}
+}
+
+// TestGuidedCreateScaffoldsWorkingNotes pins that the derived notes
+// document exists before the first cycle, marked internal from birth —
+// the audience gate reads the document, not the spec, so a notes doc
+// that only became internal on its first write would sit readable in
+// search until the loop got around to thinking.
+func TestGuidedCreateScaffoldsWorkingNotes(t *testing.T) {
+	rig := newCurateTestRig(t)
+	ctx := context.Background()
+
+	out, err := rig.tool.Handler(ctx, curateArgs(map[string]any{"facets": []any{"status_line"}}))
+	if err != nil {
+		t.Fatalf("thane_loop_create: %v", err)
+	}
+	var result map[string]any
+	if err := json.Unmarshal([]byte(out), &result); err != nil {
+		t.Fatalf("decode result: %v", err)
+	}
+	if result["working_notes_state"] != "scaffolded" {
+		t.Errorf("working_notes_state = %v, want scaffolded", result["working_notes_state"])
+	}
+
+	doc, err := rig.docTools.Read(ctx, documents.RefArgs{Ref: "kb:dashboards/closet-notes.md"})
+	if err != nil {
+		t.Fatalf("read notes scaffold: %v", err)
+	}
+	for _, want := range []string{
+		`"audience"`, `"internal"`,
+		`"managed_by"`, `"replace_output_closet_guardian_notes"`,
+		"loop_definition_name",
+		"awaiting first cycle",
+	} {
+		if !strings.Contains(doc, want) {
+			t.Errorf("notes scaffold missing %q:\n%s", want, doc)
+		}
+	}
+}
+
+// TestGuidedCreateReplacePreservesDocuments pins the destructive edge of
+// replace=true. Re-creating a definition is an iteration on the loop,
+// not on its accumulated state: the maintained document carries the
+// loop's current belief and the notes carry its private thinking, and a
+// spec tweak that silently reset both to placeholders would destroy
+// exactly what the next iteration needs most.
+func TestGuidedCreateReplacePreservesDocuments(t *testing.T) {
+	rig := newCurateTestRig(t)
+	ctx := context.Background()
+
+	if _, err := rig.tool.Handler(ctx, curateArgs(map[string]any{"facets": []any{"status_line"}})); err != nil {
+		t.Fatalf("first create: %v", err)
+	}
+	// The loop has "run": both documents now hold real state.
+	docBody := "## Status Line\n\nCloset nominal.\n\n## Details\n\nAccumulated belief."
+	notesBody := "Current theory: the UPS fan is the noise."
+	for ref, body := range map[string]string{
+		"kb:dashboards/closet.md":       docBody,
+		"kb:dashboards/closet-notes.md": notesBody,
+	} {
+		body := body
+		if _, err := rig.docTools.Write(ctx, documents.WriteArgs{Ref: ref, Body: &body}); err != nil {
+			t.Fatalf("simulate loop write to %s: %v", ref, err)
+		}
+	}
+
+	args := curateArgs(map[string]any{"facets": []any{"status_line"}})
+	args["replace"] = true
+	out, err := rig.tool.Handler(ctx, args)
+	if err != nil {
+		t.Fatalf("replace create: %v", err)
+	}
+	var result map[string]any
+	if err := json.Unmarshal([]byte(out), &result); err != nil {
+		t.Fatalf("decode result: %v", err)
+	}
+	if result["document_state"] != "preserved_existing" {
+		t.Errorf("document_state = %v, want preserved_existing", result["document_state"])
+	}
+	if result["working_notes_state"] != "preserved_existing" {
+		t.Errorf("working_notes_state = %v, want preserved_existing", result["working_notes_state"])
+	}
+
+	doc, err := rig.docTools.Read(ctx, documents.RefArgs{Ref: "kb:dashboards/closet.md"})
+	if err != nil {
+		t.Fatalf("read document after replace: %v", err)
+	}
+	if !strings.Contains(doc, "Accumulated belief.") {
+		t.Errorf("replace clobbered the maintained document:\n%s", doc)
+	}
+	if strings.Contains(doc, "awaiting first cycle") {
+		t.Errorf("replace re-scaffolded the maintained document:\n%s", doc)
+	}
+	notes, err := rig.docTools.Read(ctx, documents.RefArgs{Ref: "kb:dashboards/closet-notes.md"})
+	if err != nil {
+		t.Fatalf("read notes after replace: %v", err)
+	}
+	if !strings.Contains(notes, "UPS fan") {
+		t.Errorf("replace clobbered the working notes:\n%s", notes)
+	}
+}

--- a/internal/tools/loop_create_tool.go
+++ b/internal/tools/loop_create_tool.go
@@ -31,7 +31,7 @@ func (r *Registry) registerThaneLoopCreate() {
 			"\"service\" = a recurring loop that self-paces within a sleep envelope (requires sleep_min and sleep_max); " +
 			"\"event_driven\" = a quiescent handler with no timer that runs only when an external trigger wakes it — give it an entity subscription with wake: true (wakes on that entity's changes), point a feed/forge subscription or an MQTT wake at it, or have another loop notify it; without at least one trigger it never runs; " +
 			"\"container\" = a non-executing node that groups loops and shares its tags with descendants; like every operation it requires intent, takes the optional parent_name and tags, and rejects execution/output fields (sleep knobs, output, entities, instructions, etc.). " +
-			"output (service/event_driven only) declares a managed markdown document the loop maintains, rewriting it each cycle to reflect current state; declaring facets publishes condensed projections alongside the body instead. It is scaffolded with ownership frontmatter before launch, and comes with a private working-notes document for the loop's own thinking. Omit it for a loop that acts without maintaining a document. " +
+			"output (service/event_driven only) declares a managed markdown document the loop maintains, rewriting it each cycle to reflect current state; declaring facets publishes condensed projections alongside the body instead. It comes with a private working-notes document for the loop's own thinking, and both documents are scaffolded with ownership frontmatter before launch — a faceted output's scaffold carries the exact section skeleton its publish tool fills, so the loop's first iteration sees the shape it is expected to produce. A document that already exists is preserved rather than re-scaffolded (document_state / working_notes_state in the result report which happened). Omit output for a loop that acts without maintaining a document. " +
 			"parent_name nests the loop under a container by name, inheriting its tags and subscriptions. " +
 			"entities are Home Assistant subscriptions surfaced into the loop's context each iteration; an entry with wake: true ALSO wakes the loop when that entity changes (debounced/coalesced) — for a service loop an early wake, for an event_driven loop a primary trigger. " +
 			"Returns the loop definition name, loop_id, and the canonical loop row; plus output_tool/document_path when a document was declared, facets when it declared any, and working_notes_document — every document-owning loop is given a private notes surface beside its document, so its reasoning has somewhere to go that is not what it publishes. If the loop lands at the root but an existing container declares tags it shares, the result also carries a non-blocking placement_advisory suggesting where it might nest (see loop_containers).",
@@ -257,8 +257,8 @@ func (r *Registry) planExecutingLoop(args map[string]any, name, intent string, o
 		// choice worth offering: a loop that publishes has reasoning that
 		// should not be published, and an opt-in that every caller should
 		// take is just a default in the wrong position. The cost of an
-		// unused one is a single context-block line saying it exists —
-		// nothing is scaffolded until the loop writes to it.
+		// unused one is a scaffolded stub and a context-block line saying
+		// it exists.
 		notesSpec := buildWorkingNotesSpec(name, documentRef, intent)
 		outputs = append(outputs, notesSpec)
 		notesRef = notesSpec.Ref
@@ -361,36 +361,84 @@ func (r *Registry) createLoopExecuting(ctx context.Context, args map[string]any,
 	entityCount, outputTool := plan.entityCount, plan.outputTool
 	parentName, tags := spec.ParentName, spec.Tags
 
+	var documentState, notesState string
 	if hasOutput {
-		if _, readErr := deps.DocTools.Read(ctx, documents.RefArgs{Ref: documentRef}); readErr == nil && !replace {
-			return "", fmt.Errorf("output document %q already exists; pass replace=true to overwrite", documentRef)
+		outputSpec, notesSpec := declaredOutputSpecs(spec.Outputs)
+
+		docExists := false
+		if _, readErr := deps.DocTools.Read(ctx, documents.RefArgs{Ref: documentRef}); readErr == nil {
+			if !replace {
+				return "", fmt.Errorf("output document %q already exists; pass replace=true to overwrite", documentRef)
+			}
+			docExists = true
 		}
 		// The notes ref is derived rather than supplied, so a collision is
 		// something the caller never chose and would not expect: appending a
 		// loop's private reasoning onto an unrelated document is worse than
 		// refusing to start.
-		if plan.notesRef != "" && !replace {
+		notesExists := false
+		if plan.notesRef != "" {
 			if _, readErr := deps.DocTools.Read(ctx, documents.RefArgs{Ref: plan.notesRef}); readErr == nil {
-				return "", fmt.Errorf("derived working-notes document %q already exists; pass replace=true, or use loop_definition_set to place the notes elsewhere", plan.notesRef)
+				if !replace {
+					return "", fmt.Errorf("derived working-notes document %q already exists; pass replace=true, or use loop_definition_set to place the notes elsewhere", plan.notesRef)
+				}
+				notesExists = true
 			}
 		}
-		body := renderScaffoldBody(title, intent)
+
 		frontmatter := map[string][]string{
-			"loop_definition_name": {name},
-			"loop_intent":          {intent},
-			"created":              {now.Format(time.RFC3339)},
+			"loop_definition_name":                {name},
+			"loop_intent":                         {intent},
+			looppkg.OutputAudienceFrontmatterKey:  {string(outputSpec.EffectiveAudience())},
+			looppkg.OutputManagedByFrontmatterKey: {outputSpec.ToolName()},
 		}
 		if op == looppkg.OperationService {
 			frontmatter["sleep_min"] = []string{envelope.sleepMin.String()}
 			frontmatter["sleep_max"] = []string{envelope.sleepMax.String()}
 		}
-		if _, err := deps.DocTools.Write(ctx, documents.WriteArgs{
+		// An existing document keeps its body: a re-created definition is
+		// an iteration on the loop, and blowing away the state its
+		// predecessor accumulated would hand the next iteration a
+		// placeholder where its carried belief used to be. Only the
+		// ownership frontmatter is refreshed.
+		documentState, notesState = "scaffolded", "scaffolded"
+		writeArgs := documents.WriteArgs{
 			Ref:         documentRef,
 			Title:       title,
-			Body:        &body,
 			Frontmatter: frontmatter,
-		}); err != nil {
+		}
+		if docExists {
+			documentState = "preserved_existing"
+		} else {
+			frontmatter["created"] = []string{now.Format(time.RFC3339)}
+			body := renderOutputScaffoldBody(outputSpec, title, intent)
+			writeArgs.Body = &body
+		}
+		if _, err := deps.DocTools.Write(ctx, writeArgs); err != nil {
 			return "", fmt.Errorf("scaffold output document: %w", err)
+		}
+
+		if notesSpec != nil {
+			notesFrontmatter := map[string][]string{
+				"loop_definition_name":                {name},
+				looppkg.OutputAudienceFrontmatterKey:  {string(notesSpec.EffectiveAudience())},
+				looppkg.OutputManagedByFrontmatterKey: {notesSpec.ToolName()},
+			}
+			notesArgs := documents.WriteArgs{
+				Ref:         notesSpec.Ref,
+				Title:       title + " — Working Notes",
+				Frontmatter: notesFrontmatter,
+			}
+			if notesExists {
+				notesState = "preserved_existing"
+			} else {
+				notesFrontmatter["created"] = []string{now.Format(time.RFC3339)}
+				notesBody := renderWorkingNotesScaffoldBody(name)
+				notesArgs.Body = &notesBody
+			}
+			if _, err := deps.DocTools.Write(ctx, notesArgs); err != nil {
+				return "", fmt.Errorf("scaffold working-notes document: %w", err)
+			}
 		}
 	}
 
@@ -415,8 +463,10 @@ func (r *Registry) createLoopExecuting(ctx context.Context, args map[string]any,
 	if hasOutput {
 		result["document_path"] = documentRef
 		result["output_tool"] = outputTool
+		result["document_state"] = documentState
 		if plan.notesRef != "" {
 			result["working_notes_document"] = plan.notesRef
+			result["working_notes_state"] = notesState
 		}
 		if len(spec.Outputs) > 0 && len(spec.Outputs[0].Facets) > 0 {
 			result["facets"] = spec.Outputs[0].Facets
@@ -545,6 +595,22 @@ func parseLoopCreateMetadata(args map[string]any) (map[string]string, error) {
 		out[k] = s
 	}
 	return out, nil
+}
+
+// declaredOutputSpecs splits a created loop's outputs into the
+// maintained document and its derived working notes, by type rather
+// than by position so the scaffold cannot silently bind to the wrong
+// declaration if the build order ever changes.
+func declaredOutputSpecs(outputs []looppkg.OutputSpec) (doc looppkg.OutputSpec, notes *looppkg.OutputSpec) {
+	for i := range outputs {
+		switch outputs[i].Type {
+		case looppkg.OutputTypeMaintainedDocument:
+			doc = outputs[i]
+		case looppkg.OutputTypeWorkingNotes:
+			notes = &outputs[i]
+		}
+	}
+	return doc, notes
 }
 
 // loopCreateExcludeTools layers operator-provided exclusions on top of the

--- a/internal/tools/loop_create_tool.go
+++ b/internal/tools/loop_create_tool.go
@@ -365,12 +365,12 @@ func (r *Registry) createLoopExecuting(ctx context.Context, args map[string]any,
 	if hasOutput {
 		outputSpec, notesSpec := declaredOutputSpecs(spec.Outputs)
 
-		docExists := false
-		if _, readErr := deps.DocTools.Read(ctx, documents.RefArgs{Ref: documentRef}); readErr == nil {
-			if !replace {
-				return "", fmt.Errorf("output document %q already exists; pass replace=true to overwrite", documentRef)
-			}
-			docExists = true
+		docExists, err := declaredDocumentExists(ctx, deps.DocTools, documentRef)
+		if err != nil {
+			return "", err
+		}
+		if docExists && !replace {
+			return "", fmt.Errorf("output document %q already exists; pass replace=true to overwrite", documentRef)
 		}
 		// The notes ref is derived rather than supplied, so a collision is
 		// something the caller never chose and would not expect: appending a
@@ -378,11 +378,12 @@ func (r *Registry) createLoopExecuting(ctx context.Context, args map[string]any,
 		// refusing to start.
 		notesExists := false
 		if plan.notesRef != "" {
-			if _, readErr := deps.DocTools.Read(ctx, documents.RefArgs{Ref: plan.notesRef}); readErr == nil {
-				if !replace {
-					return "", fmt.Errorf("derived working-notes document %q already exists; pass replace=true, or use loop_definition_set to place the notes elsewhere", plan.notesRef)
-				}
-				notesExists = true
+			notesExists, err = declaredDocumentExists(ctx, deps.DocTools, plan.notesRef)
+			if err != nil {
+				return "", err
+			}
+			if notesExists && !replace {
+				return "", fmt.Errorf("derived working-notes document %q already exists; pass replace=true, or use loop_definition_set to place the notes elsewhere", plan.notesRef)
 			}
 		}
 
@@ -595,6 +596,24 @@ func parseLoopCreateMetadata(args map[string]any) (map[string]string, error) {
 		out[k] = s
 	}
 	return out, nil
+}
+
+// declaredDocumentExists probes whether a declared output document is
+// already present, distinguishing absence from a failed read. The
+// answer decides between scaffolding and preserving, so a read that
+// fails for any other reason — unknown root, provenance verification,
+// IO — must stop the create: misreading it as "absent" would scaffold
+// over whatever is actually there.
+func declaredDocumentExists(ctx context.Context, docTools *documents.Tools, ref string) (bool, error) {
+	_, err := docTools.Read(ctx, documents.RefArgs{Ref: ref})
+	switch {
+	case err == nil:
+		return true, nil
+	case documents.IsNotFound(err):
+		return false, nil
+	default:
+		return false, fmt.Errorf("inspect output document %q: %w", ref, err)
+	}
 }
 
 // declaredOutputSpecs splits a created loop's outputs into the

--- a/internal/tools/loop_intent_tools.go
+++ b/internal/tools/loop_intent_tools.go
@@ -390,6 +390,33 @@ func buildCurateTask(intent, docRef, outputToolName string, faceted bool) string
 	return sb.String()
 }
 
+// renderOutputScaffoldBody returns the initial body for a declared
+// output document. A faceted output scaffolds the exact section
+// skeleton its publish tool will fill: the first iteration sees this
+// body in its Declared Durable Outputs context, and a scaffold shaped
+// like a correct publish is the strongest cue for the form that turn
+// should produce. An unfaceted maintained document has no
+// framework-owned structure, so its scaffold shows a reasonable
+// whole-body shape instead.
+func renderOutputScaffoldBody(output looppkg.OutputSpec, title, intent string) string {
+	if output.HasFacets() {
+		return output.RenderFacetScaffold()
+	}
+	return renderScaffoldBody(title, intent)
+}
+
+// renderWorkingNotesScaffoldBody returns the initial body for the
+// private working-notes document beside a declared output. One
+// orienting line, then a placeholder: the register belongs to the
+// notes tool descriptions, and a scaffold that lectured would be the
+// first thing every wake re-reads until the loop replaces it.
+func renderWorkingNotesScaffoldBody(loopName string) string {
+	return fmt.Sprintf(
+		"*Private working notes for the `%s` loop — current thinking, rewritten whole as it changes. No consumer surface reads this document.*\n\n_(awaiting first cycle)_\n",
+		loopName,
+	)
+}
+
 // renderScaffoldBody returns the initial markdown body for the output
 // document.
 func renderScaffoldBody(title, intent string) string {

--- a/scripts/architecture.baseline
+++ b/scripts/architecture.baseline
@@ -1,5 +1,5 @@
 packages=67
 interfaces=83
-large_files=52
+large_files=53
 set_mutators=116
 database_opens=9

--- a/talents/loops-examples.md
+++ b/talents/loops-examples.md
@@ -75,7 +75,7 @@ believes. Two questions decide the rest:
    by other turns, other loops, or an ambient surface should declare
    `facets` so each reader takes the length it can afford.
    `thane_loop_create` declares them directly on its `output` argument;
-   a loop nobody reads but its owner can stay untiered.
+   a loop nobody reads but its owner needs no facets at all.
 
 2. **Does the loop need to escalate decisions to you, or accept new
    focus when you adjust its scope?**

--- a/talents/loops-examples.md
+++ b/talents/loops-examples.md
@@ -73,10 +73,9 @@ believes. Two questions decide the rest:
 
 1. **Will anyone else consult this?** A loop whose value is being read
    by other turns, other loops, or an ambient surface should declare
-   `facets` so each reader takes the length it can afford. That needs the
-   full spec: author it with `loop_definition_set` and start it with
-   `loop_definition_launch`. A loop nobody reads but its owner can stay
-   untiered on the shorter front door.
+   `facets` so each reader takes the length it can afford.
+   `thane_loop_create` declares them directly on its `output` argument;
+   a loop nobody reads but its owner can stay untiered.
 
 2. **Does the loop need to escalate decisions to you, or accept new
    focus when you adjust its scope?**
@@ -123,9 +122,15 @@ takes `digest`, and a reader who wants everything opens the document.
 Without facets every consumer pays for the whole document or gets a
 blind truncation of it.
 
-Facets need the full spec, so author this with `loop_definition_set` and
-start it with `loop_definition_launch`. Lint first — `loop_definition_lint`
-takes the same spec and catches mistakes before anything persists.
+`thane_loop_create` builds this shape directly: declare the facets on
+its `output` argument and the working notes are derived for you, with
+both documents scaffolded before launch — the faceted one with the
+exact section skeleton its publish tool fills. The full spec below is
+the same loop authored by hand, for when you need a field the front
+door does not expose (several published documents, a facet's format,
+notes placed somewhere specific). Lint first on that path —
+`loop_definition_lint` takes the same spec and catches mistakes before
+anything persists.
 
 ```json
 {

--- a/talents/loops-trailhead.md
+++ b/talents/loops-trailhead.md
@@ -40,7 +40,11 @@ hoc one does not.
 
 `thane_loop_create` is a shorter front door to the durable path. It
 takes one output document, can declare its facets, and always gives the
-loop a private working-notes document alongside. Reach for
+loop a private working-notes document alongside. Both documents are
+scaffolded before launch — a faceted one with the exact section
+skeleton its publish tool fills — and a document that already exists
+is preserved, never re-scaffolded. Pass `dry_run: true` to preview the
+derived spec without building anything. Reach for
 `loop_definition_set` when a loop needs more than one published document
 or a field the front door does not expose.
 

--- a/talents/loops.md
+++ b/talents/loops.md
@@ -17,9 +17,11 @@ it: `replace_output_*` for a whole-document rewrite, or
 If a maintained output is marked `truncated` in Declared Durable
 Outputs, read the full document before replacing it.
 
-Declaring facets or working notes requires the full spec, so author those
-loops with `loop_definition_set` and start them with
-`loop_definition_launch`.
+`thane_loop_create` declares facets directly and derives the working
+notes itself; reach for `loop_definition_set` +
+`loop_definition_launch` only when a loop needs what the front door
+does not expose — several published documents, a facet's format, or
+notes placed somewhere specific.
 
 ## Who reads this output?
 
@@ -42,6 +44,12 @@ section headings; they are rendered for you. Each projection has a size
 budget, and an over-budget value is rejected rather than trimmed,
 because a clipped teaser reads as a fragment with no sign that anything
 is missing. Write to the budget rather than near it.
+
+A faceted document created through `thane_loop_create` arrives
+scaffolded: its section skeleton is pre-rendered with a placeholder
+under each heading, so the body a loop sees on its first wake is
+already the shape a correct publish produces. Fill the placeholders;
+do not invent structure around them.
 
 Declare `status_line` for any faceted output; add `teaser` when the
 output is something others search or link to, and `digest` when a


### PR DESCRIPTION
## The first turn is the customer

When `thane_loop_create` declares a defined output, the loop's first iteration wakes to a Declared Durable Outputs context block showing the document body — and until now, that body was a generic stub: an H1, the intent in italics, a `## Current State` heading the publish tool will never render. For a faceted output this scaffold was actively wrong: the first publish replaces it with the contract's section ladder, so the one document shape the framework showed the loop before its first write was a shape no correct publish ever produces. The working-notes document fared worse — it simply didn't exist until the loop first wrote to it, its declared ref dangling in the context block as `exists: false`.

We watched this land in production yesterday: the first faceted curator loop (`office_lab_scene`, built unaided through the trailheads) launched against a scaffold shaped nothing like what its `publish_output_*` tool will write. The loop will recover — the tool schema teaches the projections — but the strongest cue a first turn gets is the document in front of it, and we were spending that cue teaching the wrong form.

## What changes

**Faceted outputs scaffold as their published shape.** `RenderFacetScaffold` renders the declared section skeleton — `## Status Line`, `## Teaser`, `## Digest`, `## Details`, exactly the sections the loop declared and in ladder order — with an awaiting-first-cycle placeholder under each heading carrying that facet's purpose and budget ("_awaiting first cycle — one standalone line of what is true right now, ≤120 characters_"). It renders through `RenderFacetDocument` itself, making the scaffold a fifth consumer of the `facetSections` single-source-of-truth table alongside the schema, validator, renderer, and parser: it cannot drift from the published form. The scaffold parses back through `ParseFacetSections`, so a consumer asking for `status_line` before the first cycle gets an honest placeholder rather than an empty string, and it validates against its own facet contract. A json-format facet gets a valid-JSON placeholder, because its section renders inside a fence where prose reads as damage.

**The working-notes document exists from birth.** It is scaffolded beside the main document with one orienting line and a placeholder — and stamped `audience: internal` at creation. That stamp is the load-bearing part: the projection gate reads the document, not the loop spec, so a notes doc that only became internal on its first write would sit readable in search until the loop got around to thinking.

**Ownership frontmatter is stamped once, everywhere.** `audience` and `managed_by` move to the `loop` package as exported constants, and a shared `loopOutputFrontmatter` helper now serves the create-time scaffold, the facet publish tool, the whole-body replace tool, and working-notes writes. Notes writes gain the `managed_by` stamp the main document already had, so any document a loop owns can point a stray `doc_write` back at its owning interface.

**`replace=true` stops destroying loop state.** Previously, re-creating a definition with `replace=true` re-scaffolded the output document — overwriting the maintained document's accumulated belief with a placeholder. With notes now scaffolded too, that behavior would have erased the loop's private thinking on every spec tweak. Instead, an existing document is preserved: its body is untouched and only the ownership frontmatter refreshes. The result reports which happened via `document_state` / `working_notes_state` (`scaffolded` | `preserved_existing`), so the caller never has to guess.

## Teaching

Per the shipping rules in docs/model-facing-tools.md, the teaching rides in the same PR: the `thane_loop_create` description now explains the scaffold and the preserve-on-replace contract; `loops.md` teaches that a faceted document arrives pre-scaffolded ("fill the placeholders; do not invent structure around them"); `loops-trailhead.md` adds the scaffold and the `dry_run` preview to the front-door paragraph.

Two stale doors also come out. `loops.md` and `loops-examples.md` both still claimed that declaring facets *requires* the full `loop_definition_set` spec — false since #1287 gave the front door facets, and exactly the kind of stale routing that sends a model down the hand-authored path where nothing scaffolds and nothing derives the notes for it. The worked full-spec example in `loops-examples.md` stays, reframed as what it really is now: the door for fields the front door does not expose (several published documents, a facet's format, custom notes placement).

## Verification

- New tests: scaffold skeleton/ladder-order/placeholder rendering, parse round-trip, self-validation, json-facet placeholder (`internal/runtime/loop`); faceted scaffold + frontmatter stamps, notes scaffold + internal-from-birth, replace-preserves-documents, dry-run scaffolds nothing including notes (`internal/tools`).
- `just ci` green locally (architecture baseline bumped one large-file slot: `output_facets.go` crossed 500 lines absorbing the scaffold renderer, which belongs in the contract file by design).

Deploy note: talents live in prod's signed `core/talents` root and are not pushed by deploy — the three talent edits here need the usual backport (cp + signed commit) when this ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
