### PR TITLE
feat(loops): output.initial seeds the first publish at create time

### DIFF
--- a/internal/tools/loop_create_fluency_test.go
+++ b/internal/tools/loop_create_fluency_test.go
@@ -376,3 +376,250 @@ func TestGuidedCreateFailsClosedOnUnreadableOutputDoc(t *testing.T) {
 		t.Errorf("error should name the ref, got: %v", err)
 	}
 }
+
+// seededArgs is curateArgs with a full-ladder facet declaration and a
+// complete output.initial seed.
+func seededArgs(initial map[string]any) map[string]any {
+	return curateArgs(map[string]any{
+		"facets":  []any{"status_line", "digest"},
+		"initial": initial,
+	})
+}
+
+// TestGuidedCreateSeedsFirstPublish pins the create-time seed: the
+// creating model has just surveyed the domain, and the loop inheriting
+// the document may run on a smaller model, so output.initial becomes a
+// real first publish — rendered through the same contract the publish
+// tool uses — instead of a placeholder skeleton.
+func TestGuidedCreateSeedsFirstPublish(t *testing.T) {
+	rig := newCurateTestRig(t)
+	ctx := context.Background()
+
+	out, err := rig.tool.Handler(ctx, seededArgs(map[string]any{
+		"status_line": "Closet 21.4°C, UPS on mains.",
+		"digest":      "Environment stable all afternoon; dehumidifier idle.",
+		"full":        "Temperature 21.4°C and steady. UPS on mains, full charge.",
+		"notes":       "Starting theory: the UPS fan dominates the noise floor.",
+	}))
+	if err != nil {
+		t.Fatalf("thane_loop_create: %v", err)
+	}
+	var result map[string]any
+	if err := json.Unmarshal([]byte(out), &result); err != nil {
+		t.Fatalf("decode result: %v", err)
+	}
+	if result["document_state"] != "seeded" {
+		t.Errorf("document_state = %v, want seeded", result["document_state"])
+	}
+	if result["working_notes_state"] != "seeded" {
+		t.Errorf("working_notes_state = %v, want seeded", result["working_notes_state"])
+	}
+
+	doc, err := rig.docTools.Read(ctx, documents.RefArgs{Ref: "kb:dashboards/closet.md"})
+	if err != nil {
+		t.Fatalf("read seeded doc: %v", err)
+	}
+	for _, want := range []string{
+		"## Status Line", "Closet 21.4°C, UPS on mains.",
+		"## Digest", "dehumidifier idle",
+		"## Details", "full charge",
+	} {
+		if !strings.Contains(doc, want) {
+			t.Errorf("seeded document missing %q:\n%s", want, doc)
+		}
+	}
+	if strings.Contains(doc, "awaiting first cycle") {
+		t.Errorf("seeded document still carries placeholders:\n%s", doc)
+	}
+	notes, err := rig.docTools.Read(ctx, documents.RefArgs{Ref: "kb:dashboards/closet-notes.md"})
+	if err != nil {
+		t.Fatalf("read seeded notes: %v", err)
+	}
+	if !strings.Contains(notes, "UPS fan dominates") {
+		t.Errorf("notes seed missing:\n%s", notes)
+	}
+}
+
+// TestGuidedCreateSeedValidation pins that a seed passes the loop's own
+// publish contract — a seed the publish tool would refuse must not
+// become the document's first state, and the errors teach the same
+// corrections.
+func TestGuidedCreateSeedValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		initial map[string]any
+		wantErr string
+	}{
+		{
+			name: "missing declared facet",
+			initial: map[string]any{
+				"status_line": "One line.",
+				"full":        "Body.",
+			},
+			wantErr: "digest",
+		},
+		{
+			name: "over budget status line",
+			initial: map[string]any{
+				"status_line": strings.Repeat("x", 121),
+				"digest":      "Fine.",
+				"full":        "Fine.",
+			},
+			wantErr: "limit is 120",
+		},
+		{
+			name: "reserved heading inside content",
+			initial: map[string]any{
+				"status_line": "One line.",
+				"digest":      "Fine.",
+				"full":        "## Digest\n\nsmuggled section",
+			},
+			wantErr: "reserved section heading",
+		},
+		{
+			name:    "unknown key refused, not dropped",
+			initial: map[string]any{"summary": "nope"},
+			wantErr: "output.initial.summary",
+		},
+		{
+			name:    "teaser not declared by this output",
+			initial: map[string]any{"teaser": "undeclared"},
+			wantErr: "output.initial.teaser",
+		},
+		{
+			name:    "empty notes",
+			initial: map[string]any{"notes": "   "},
+			wantErr: "output.initial.notes is empty",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rig := newCurateTestRig(t)
+			_, err := rig.tool.Handler(context.Background(), seededArgs(tt.initial))
+			if err == nil {
+				t.Fatal("invalid seed should refuse")
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("error = %v, want it to mention %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// TestGuidedCreateSeedNotesOnly pins the half-seed: a starting theory
+// without a first publish leaves the document on its placeholder
+// skeleton while the notes open with a belief to revise.
+func TestGuidedCreateSeedNotesOnly(t *testing.T) {
+	rig := newCurateTestRig(t)
+	ctx := context.Background()
+
+	out, err := rig.tool.Handler(ctx, seededArgs(map[string]any{
+		"notes": "Watch whether the light sensor earns its keep.",
+	}))
+	if err != nil {
+		t.Fatalf("thane_loop_create: %v", err)
+	}
+	var result map[string]any
+	if err := json.Unmarshal([]byte(out), &result); err != nil {
+		t.Fatalf("decode result: %v", err)
+	}
+	if result["document_state"] != "scaffolded" {
+		t.Errorf("document_state = %v, want scaffolded", result["document_state"])
+	}
+	if result["working_notes_state"] != "seeded" {
+		t.Errorf("working_notes_state = %v, want seeded", result["working_notes_state"])
+	}
+	doc, err := rig.docTools.Read(ctx, documents.RefArgs{Ref: "kb:dashboards/closet.md"})
+	if err != nil {
+		t.Fatalf("read doc: %v", err)
+	}
+	if !strings.Contains(doc, "awaiting first cycle") {
+		t.Errorf("notes-only seed should leave the document scaffold:\n%s", doc)
+	}
+}
+
+// TestGuidedCreateSeedUnfacetedTakesFullOnly pins the unfaceted shape:
+// the document's whole body rides the full key, and projection keys are
+// refused because this declaration publishes none.
+func TestGuidedCreateSeedUnfacetedTakesFullOnly(t *testing.T) {
+	rig := newCurateTestRig(t)
+	ctx := context.Background()
+
+	out, err := rig.tool.Handler(ctx, curateArgs(map[string]any{
+		"initial": map[string]any{"full": "# Closet\n\nFirst complete body."},
+	}))
+	if err != nil {
+		t.Fatalf("thane_loop_create: %v", err)
+	}
+	var result map[string]any
+	if err := json.Unmarshal([]byte(out), &result); err != nil {
+		t.Fatalf("decode result: %v", err)
+	}
+	if result["document_state"] != "seeded" {
+		t.Errorf("document_state = %v, want seeded", result["document_state"])
+	}
+	doc, err := rig.docTools.Read(ctx, documents.RefArgs{Ref: "kb:dashboards/closet.md"})
+	if err != nil {
+		t.Fatalf("read doc: %v", err)
+	}
+	if !strings.Contains(doc, "First complete body.") {
+		t.Errorf("unfaceted seed body missing:\n%s", doc)
+	}
+
+	rig2 := newCurateTestRig(t)
+	_, err = rig2.tool.Handler(ctx, curateArgs(map[string]any{
+		"initial": map[string]any{"status_line": "no ladder declared"},
+	}))
+	if err == nil || !strings.Contains(err.Error(), "output.initial.status_line") {
+		t.Errorf("projection seed on an unfaceted output should refuse by key, got: %v", err)
+	}
+}
+
+// TestGuidedCreateSeedRefusesExistingDocument pins the conflict
+// direction: an existing document's accumulated state wins over
+// create-time content, and dropping the seed silently would leave the
+// caller believing content was published that never landed.
+func TestGuidedCreateSeedRefusesExistingDocument(t *testing.T) {
+	rig := newCurateTestRig(t)
+	ctx := context.Background()
+
+	if _, err := rig.tool.Handler(ctx, curateArgs(map[string]any{"facets": []any{"status_line", "digest"}})); err != nil {
+		t.Fatalf("first create: %v", err)
+	}
+	args := seededArgs(map[string]any{
+		"status_line": "Fresh.",
+		"digest":      "Fresh.",
+		"full":        "Fresh.",
+	})
+	args["replace"] = true
+	_, err := rig.tool.Handler(ctx, args)
+	if err == nil {
+		t.Fatal("seed against an existing document should refuse")
+	}
+	if !strings.Contains(err.Error(), "current state wins") {
+		t.Errorf("error should explain the preserve-wins rule, got: %v", err)
+	}
+}
+
+// TestGuidedCreateSeedDryRunWritesNothing pins that a valid seed still
+// respects dry_run's whole reason to exist.
+func TestGuidedCreateSeedDryRunWritesNothing(t *testing.T) {
+	rig := newCurateTestRig(t)
+	ctx := context.Background()
+
+	args := seededArgs(map[string]any{
+		"status_line": "One line.",
+		"digest":      "Enough to act on.",
+		"full":        "Everything.",
+		"notes":       "A theory.",
+	})
+	args["dry_run"] = true
+	if _, err := rig.tool.Handler(ctx, args); err != nil {
+		t.Fatalf("dry run with seed: %v", err)
+	}
+	for _, ref := range []string{"kb:dashboards/closet.md", "kb:dashboards/closet-notes.md"} {
+		if _, err := rig.docTools.Read(ctx, documents.RefArgs{Ref: ref}); err == nil {
+			t.Errorf("dry run wrote %s", ref)
+		}
+	}
+}

--- a/internal/tools/loop_create_tool.go
+++ b/internal/tools/loop_create_tool.go
@@ -476,7 +476,7 @@ func (r *Registry) createLoopExecuting(ctx context.Context, args map[string]any,
 			return "", err
 		}
 		if docExists && !replace {
-			return "", fmt.Errorf("output document %q already exists; pass replace=true to overwrite", documentRef)
+			return "", fmt.Errorf("output document %q already exists; pass replace=true to replace the loop definition and adopt the document — its body is preserved, only its ownership frontmatter refreshes", documentRef)
 		}
 		// A seed against an existing document is a conflict to surface, not
 		// resolve: the document's accumulated state wins over create-time
@@ -496,7 +496,7 @@ func (r *Registry) createLoopExecuting(ctx context.Context, args map[string]any,
 				return "", err
 			}
 			if notesExists && !replace {
-				return "", fmt.Errorf("derived working-notes document %q already exists; pass replace=true, or use loop_definition_set to place the notes elsewhere", plan.notesRef)
+				return "", fmt.Errorf("derived working-notes document %q already exists; pass replace=true to adopt it with its body preserved, or use loop_definition_set to place the notes elsewhere", plan.notesRef)
 			}
 			if plan.seedNotes != "" && notesExists {
 				return "", fmt.Errorf("working-notes document %q already exists, so the loop's own thinking wins over output.initial.notes — drop the notes seed", plan.notesRef)

--- a/internal/tools/loop_create_tool.go
+++ b/internal/tools/loop_create_tool.go
@@ -31,7 +31,7 @@ func (r *Registry) registerThaneLoopCreate() {
 			"\"service\" = a recurring loop that self-paces within a sleep envelope (requires sleep_min and sleep_max); " +
 			"\"event_driven\" = a quiescent handler with no timer that runs only when an external trigger wakes it — give it an entity subscription with wake: true (wakes on that entity's changes), point a feed/forge subscription or an MQTT wake at it, or have another loop notify it; without at least one trigger it never runs; " +
 			"\"container\" = a non-executing node that groups loops and shares its tags with descendants; like every operation it requires intent, takes the optional parent_name and tags, and rejects execution/output fields (sleep knobs, output, entities, instructions, etc.). " +
-			"output (service/event_driven only) declares a managed markdown document the loop maintains, rewriting it each cycle to reflect current state; declaring facets publishes condensed projections alongside the body instead. It comes with a private working-notes document for the loop's own thinking, and both documents are scaffolded with ownership frontmatter before launch — a faceted output's scaffold carries the exact section skeleton its publish tool fills, so the loop's first iteration sees the shape it is expected to produce. A document that already exists is preserved rather than re-scaffolded (document_state / working_notes_state in the result report which happened). Omit output for a loop that acts without maintaining a document. " +
+			"output (service/event_driven only) declares a managed markdown document the loop maintains, rewriting it each cycle to reflect current state; declaring facets publishes condensed projections alongside the body instead. It comes with a private working-notes document for the loop's own thinking, and both documents are scaffolded with ownership frontmatter before launch — a faceted output's scaffold carries the exact section skeleton its publish tool fills, so the loop's first iteration sees the shape it is expected to produce. Better than the placeholder skeleton: output.initial authors the first publish at create time from the survey you just did (same arguments as the publish tool; see the parameter). A document that already exists is preserved rather than re-scaffolded or seeded (document_state / working_notes_state in the result report which happened). Omit output for a loop that acts without maintaining a document. " +
 			"parent_name nests the loop under a container by name, inheriting its tags and subscriptions. " +
 			"entities are Home Assistant subscriptions surfaced into the loop's context each iteration; an entry with wake: true ALSO wakes the loop when that entity changes (debounced/coalesced) — for a service loop an early wake, for an event_driven loop a primary trigger. " +
 			"Returns the loop definition name, loop_id, and the canonical loop row; plus output_tool/document_path when a document was declared, facets when it declared any, and working_notes_document — every document-owning loop is given a private notes surface beside its document, so its reasoning has somewhere to go that is not what it publishes. If the loop lands at the root but an existing container declares tags it shares, the result also carries a non-blocking placement_advisory suggesting where it might nest (see loop_containers).",
@@ -181,6 +181,14 @@ type executingLoopPlan struct {
 	entityCount int
 	envelope    sleepEnvelope
 	createdAt   time.Time
+
+	// seedDocument marks that output.initial carried a first publish for
+	// the maintained document; seedPayload holds it, already validated
+	// against the output's own facet contract. seedNotes is the initial
+	// working-notes body, empty when not seeded.
+	seedDocument bool
+	seedPayload  looppkg.FacetPayload
+	seedNotes    string
 }
 
 // planExecutingLoop derives the plan without writing anything. It reads
@@ -225,13 +233,16 @@ func (r *Registry) planExecutingLoop(args map[string]any, name, intent string, o
 	// managed OutputSpec + a curate-style task; otherwise the loop's per-iteration
 	// task is its intent.
 	var (
-		outputs     []looppkg.OutputSpec
-		outputSpec  looppkg.OutputSpec
-		documentRef string
-		title       string
-		hasOutput   bool
-		facets      []looppkg.FacetSpec
-		notesRef    string
+		outputs      []looppkg.OutputSpec
+		outputSpec   looppkg.OutputSpec
+		documentRef  string
+		title        string
+		hasOutput    bool
+		facets       []looppkg.FacetSpec
+		notesRef     string
+		seedDocument bool
+		seedPayload  looppkg.FacetPayload
+		seedNotes    string
 	)
 	if raw, ok := args["output"].(map[string]any); ok && raw != nil {
 		hasOutput = true
@@ -262,6 +273,11 @@ func (r *Registry) planExecutingLoop(args map[string]any, name, intent string, o
 		notesSpec := buildWorkingNotesSpec(name, documentRef, intent)
 		outputs = append(outputs, notesSpec)
 		notesRef = notesSpec.Ref
+
+		seedPayload, seedNotes, seedDocument, err = parseOutputInitial(raw["initial"], outputSpec)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	if _, found, err := ensureDefinitionMutable(deps.Registry.Snapshot(), name); err != nil {
@@ -310,18 +326,108 @@ func (r *Registry) planExecutingLoop(args map[string]any, name, intent string, o
 	warnings := looppkg.BuildDefinitionWarnings(spec)
 
 	return &executingLoopPlan{
-		spec:        spec,
-		warnings:    warnings,
-		replace:     replace,
-		hasOutput:   hasOutput,
-		documentRef: documentRef,
-		title:       title,
-		outputTool:  outputSpec.ToolName(),
-		notesRef:    notesRef,
-		entityCount: len(entities),
-		envelope:    envelope,
-		createdAt:   now,
+		spec:         spec,
+		warnings:     warnings,
+		replace:      replace,
+		hasOutput:    hasOutput,
+		documentRef:  documentRef,
+		title:        title,
+		outputTool:   outputSpec.ToolName(),
+		notesRef:     notesRef,
+		entityCount:  len(entities),
+		envelope:     envelope,
+		createdAt:    now,
+		seedDocument: seedDocument,
+		seedPayload:  seedPayload,
+		seedNotes:    seedNotes,
 	}, nil
+}
+
+// parseOutputInitial reads output.initial — a first publish authored at
+// create time, in the same argument shape as the loop's generated
+// publish tool. The creating model has just surveyed the domain and the
+// loop inheriting the document may run on a smaller model, so the
+// content is worth capturing while that context exists; the contract
+// stays the loop's own (a faceted seed passes the full facet
+// validation, budgets and all), so a seed can never teach the first
+// wake a shape a correct publish would not produce.
+//
+// Unknown keys are refused rather than dropped — a seed key that
+// silently vanishes is content the author believes was published.
+func parseOutputInitial(raw any, output looppkg.OutputSpec) (payload looppkg.FacetPayload, notes string, seedsDocument bool, err error) {
+	if raw == nil {
+		return looppkg.FacetPayload{}, "", false, nil
+	}
+	initial, ok := raw.(map[string]any)
+	if !ok {
+		return looppkg.FacetPayload{}, "", false, fmt.Errorf("output.initial must be an object with the publish tool's arguments, got %T", raw)
+	}
+	if len(initial) == 0 {
+		return looppkg.FacetPayload{}, "", false, nil
+	}
+
+	documentKeys := []string{"full"}
+	if output.HasFacets() {
+		documentKeys = documentKeys[:0]
+		for _, field := range output.FacetFields() {
+			documentKeys = append(documentKeys, field.Key)
+		}
+	}
+	allowed := map[string]bool{"notes": true}
+	for _, key := range documentKeys {
+		allowed[key] = true
+	}
+	for key := range initial {
+		if !allowed[key] {
+			return looppkg.FacetPayload{}, "", false, fmt.Errorf("output.initial.%s is not part of this output's publish shape; this declaration takes %s, plus notes", key, strings.Join(documentKeys, ", "))
+		}
+	}
+
+	if rawNotes, present := initial["notes"]; present {
+		s, ok := rawNotes.(string)
+		if !ok {
+			return looppkg.FacetPayload{}, "", false, fmt.Errorf("output.initial.notes must be a string, got %T", rawNotes)
+		}
+		if strings.TrimSpace(s) == "" {
+			return looppkg.FacetPayload{}, "", false, fmt.Errorf("output.initial.notes is empty; pass the loop's starting thinking or omit the key")
+		}
+		notes = s
+	}
+
+	seedsDocument = false
+	for _, key := range documentKeys {
+		if _, present := initial[key]; present {
+			seedsDocument = true
+			break
+		}
+	}
+	if !seedsDocument {
+		return looppkg.FacetPayload{}, notes, false, nil
+	}
+
+	if output.HasFacets() {
+		payload, err = output.FacetPayloadFromArgs(initial)
+		if err != nil {
+			return looppkg.FacetPayload{}, "", false, fmt.Errorf("output.initial: %w", err)
+		}
+		// The whole declared ladder or nothing: a partial seed would
+		// publish projections describing different moments, exactly what
+		// the publish tool exists to prevent.
+		if err := output.ValidateFacetPayload(payload); err != nil {
+			return looppkg.FacetPayload{}, "", false, fmt.Errorf("output.initial: %w", err)
+		}
+		return payload, notes, true, nil
+	}
+
+	full, ok := initial["full"].(string)
+	if !ok {
+		return looppkg.FacetPayload{}, "", false, fmt.Errorf("output.initial.full must be a string, got %T", initial["full"])
+	}
+	if strings.TrimSpace(full) == "" {
+		return looppkg.FacetPayload{}, "", false, fmt.Errorf("output.initial.full is empty; pass the document's first complete body or omit the key")
+	}
+	payload.Full = full
+	return payload, notes, true, nil
 }
 
 func (r *Registry) createLoopExecuting(ctx context.Context, args map[string]any, name, intent string, op looppkg.Operation) (string, error) {
@@ -372,6 +478,13 @@ func (r *Registry) createLoopExecuting(ctx context.Context, args map[string]any,
 		if docExists && !replace {
 			return "", fmt.Errorf("output document %q already exists; pass replace=true to overwrite", documentRef)
 		}
+		// A seed against an existing document is a conflict to surface, not
+		// resolve: the document's accumulated state wins over create-time
+		// content, and silently dropping the seed would leave the caller
+		// believing content was published that never landed anywhere.
+		if plan.seedDocument && docExists {
+			return "", fmt.Errorf("output document %q already exists, so its current state wins over output.initial — drop initial, or let the running loop republish through %s", documentRef, outputTool)
+		}
 		// The notes ref is derived rather than supplied, so a collision is
 		// something the caller never chose and would not expect: appending a
 		// loop's private reasoning onto an unrelated document is worse than
@@ -384,6 +497,9 @@ func (r *Registry) createLoopExecuting(ctx context.Context, args map[string]any,
 			}
 			if notesExists && !replace {
 				return "", fmt.Errorf("derived working-notes document %q already exists; pass replace=true, or use loop_definition_set to place the notes elsewhere", plan.notesRef)
+			}
+			if plan.seedNotes != "" && notesExists {
+				return "", fmt.Errorf("working-notes document %q already exists, so the loop's own thinking wins over output.initial.notes — drop the notes seed", plan.notesRef)
 			}
 		}
 
@@ -401,16 +517,28 @@ func (r *Registry) createLoopExecuting(ctx context.Context, args map[string]any,
 		// an iteration on the loop, and blowing away the state its
 		// predecessor accumulated would hand the next iteration a
 		// placeholder where its carried belief used to be. Only the
-		// ownership frontmatter is refreshed.
+		// ownership frontmatter is refreshed. A fresh document gets the
+		// seed when output.initial carried one — a real first publish,
+		// authored while the creating model still holds the survey that
+		// justified the loop — and the placeholder skeleton otherwise.
 		documentState, notesState = "scaffolded", "scaffolded"
 		writeArgs := documents.WriteArgs{
 			Ref:         documentRef,
 			Title:       title,
 			Frontmatter: frontmatter,
 		}
-		if docExists {
+		switch {
+		case docExists:
 			documentState = "preserved_existing"
-		} else {
+		case plan.seedDocument:
+			frontmatter["created"] = []string{now.Format(time.RFC3339)}
+			body := plan.seedPayload.Full
+			if outputSpec.HasFacets() {
+				body = outputSpec.RenderFacetDocument(plan.seedPayload)
+			}
+			writeArgs.Body = &body
+			documentState = "seeded"
+		default:
 			frontmatter["created"] = []string{now.Format(time.RFC3339)}
 			body := renderOutputScaffoldBody(outputSpec, title, intent)
 			writeArgs.Body = &body
@@ -430,9 +558,15 @@ func (r *Registry) createLoopExecuting(ctx context.Context, args map[string]any,
 				Title:       title + " — Working Notes",
 				Frontmatter: notesFrontmatter,
 			}
-			if notesExists {
+			switch {
+			case notesExists:
 				notesState = "preserved_existing"
-			} else {
+			case plan.seedNotes != "":
+				notesFrontmatter["created"] = []string{now.Format(time.RFC3339)}
+				notesBody := plan.seedNotes
+				notesArgs.Body = &notesBody
+				notesState = "seeded"
+			default:
 				notesFrontmatter["created"] = []string{now.Format(time.RFC3339)}
 				notesBody := renderWorkingNotesScaffoldBody(name)
 				notesArgs.Body = &notesBody
@@ -687,6 +821,17 @@ func thaneLoopCreateSchema() map[string]any {
 						"type":        "array",
 						"items":       map[string]any{"type": "string", "enum": []string{"status_line", "teaser", "digest"}},
 						"description": "Publish condensed projections alongside the full body, so each consumer takes the length it can afford — an ambient row takes status_line, a search snippet takes teaser, a digest row takes digest. Declaring these swaps the loop's generated tool from replace_output_* to publish_output_*, which takes one argument per projection. Declare them whenever anything other than this loop will read the document.",
+					},
+					"initial": map[string]any{
+						"type":        "object",
+						"description": "Optional first publish, written at create time in the same argument shape as the loop's generated publish tool: one key per declared facet plus full (all together, same budgets — over-budget values are rejected with the limit named), or just full for an unfaceted document; notes seeds the private working notes with your starting theory. You have just surveyed this domain, and the loop inheriting the document may run on a smaller model — author the first publish from what you observed instead of leaving a placeholder; the loop revises from live state at its first wake. Refused when the document already exists.",
+						"properties": map[string]any{
+							"status_line": map[string]any{"type": "string"},
+							"teaser":      map[string]any{"type": "string"},
+							"digest":      map[string]any{"type": "string"},
+							"full":        map[string]any{"type": "string"},
+							"notes":       map[string]any{"type": "string"},
+						},
 					},
 				},
 				"required": []string{"document"},

--- a/talents/loops-examples.md
+++ b/talents/loops-examples.md
@@ -125,7 +125,12 @@ blind truncation of it.
 `thane_loop_create` builds this shape directly: declare the facets on
 its `output` argument and the working notes are derived for you, with
 both documents scaffolded before launch — the faceted one with the
-exact section skeleton its publish tool fills. The full spec below is
+exact section skeleton its publish tool fills. If you have just
+surveyed the domain, pass `output.initial` (the publish tool's
+arguments: the declared facets plus `full`, and `notes` for your
+starting theory) so the document opens on a real first publish in your
+voice rather than placeholders — the loop revises it from live state
+at its first wake. The full spec below is
 the same loop authored by hand, for when you need a field the front
 door does not expose (several published documents, a facet's format,
 notes placed somewhere specific). Lint first on that path —

--- a/talents/loops-trailhead.md
+++ b/talents/loops-trailhead.md
@@ -42,11 +42,12 @@ hoc one does not.
 takes one output document, can declare its facets, and always gives the
 loop a private working-notes document alongside. Both documents are
 scaffolded before launch — a faceted one with the exact section
-skeleton its publish tool fills — and a document that already exists
-is preserved, never re-scaffolded. Pass `dry_run: true` to preview the
-derived spec without building anything. Reach for
-`loop_definition_set` when a loop needs more than one published document
-or a field the front door does not expose.
+skeleton its publish tool fills — and `output.initial` upgrades the
+scaffold to a real first publish authored from the survey you just
+did. A document that already exists is preserved, never re-scaffolded.
+Pass `dry_run: true` to preview the derived spec without building
+anything. Reach for `loop_definition_set` when a loop needs more than
+one published document or a field the front door does not expose.
 
 ## Where to go next
 

--- a/talents/loops.md
+++ b/talents/loops.md
@@ -51,6 +51,18 @@ under each heading, so the body a loop sees on its first wake is
 already the shape a correct publish produces. Fill the placeholders;
 do not invent structure around them.
 
+Better than a placeholder: seed the first publish. At create time you
+have just surveyed the domain — read the neighbors, checked the live
+entities, heard what the loop should be about — and the loop
+inheriting the document may run on a smaller model. `output.initial`
+takes the same arguments as the publish tool and becomes the
+document's first published state; the loop revises it from live state
+at its first wake. Seed `notes` in the same object with your starting
+theory — which signals look sharp, what you expect, what would change
+your mind — so the loop's private thinking opens with a belief to
+revise instead of a blank page. Author the seed from what you actually
+observed; when you have observed nothing, leave the placeholders.
+
 Declare `status_line` for any faceted output; add `teaser` when the
 output is something others search or link to, and `digest` when a
 reader should be able to act without opening the document.


### PR DESCRIPTION
## Spend the frontier inference while you have it

Follow-up to #1327, which taught `thane_loop_create` to scaffold declared outputs with the shape a correct publish produces. This PR asks the next question: why hand the first wake a placeholder at all, when the model doing the creating is usually the strongest inference the loop will ever have pointed at its domain?

Create time is a peculiar moment. The creating model — a frontier model in an interactive turn, in practice — has just done the survey that justified the loop: read the neighboring documents, pulled the live entities, heard the owner describe in their own words what the document should feel like. The loop that inherits the document typically runs on a smaller local model (`gpt-oss:120b` in prod), and it will never again have that interactive context available. Yesterday's `office_lab_scene` creation showed the shape of the loss exactly: the creating model ended its turn knowing "you're at the desk right now, 29.7°C, room clean" — and wrote none of it down, offering instead to wake the loop so the smaller model could rediscover it.

`output.initial` captures that moment: an optional first publish, authored at create time, in the publish tool's own argument shape.

## The contract stays the loop's contract

The seed is not a second write path. It takes one key per declared facet plus `full` (or `full` alone for an unfaceted document), and it passes through `FacetPayloadFromArgs` → `ValidateFacetPayload` — the whole declared ladder or nothing, the same rune budgets, the same reserved-heading refusal, the same teaching errors the publish tool gives the running loop. Unknown keys are refused rather than dropped, for the same reason the facet parser refuses them: a seed key that silently vanishes is content its author believes was published. A valid seed renders through `RenderFacetDocument`, so the first wake sees exactly what a prior publish would have left — which is the point. The anchoring cuts in the loop's favor: every subsequent wake pattern-matches against the document in its context block, so the frontier model sets the register and the smaller model maintains it. That division of labor runs in the direction that actually works.

`notes` in the same object seeds the private working notes — the quieter but arguably higher-leverage half. The creator's starting theory (which signals look sharp, what to watch, what would change its mind) currently has nowhere to live except `instructions`, where it fossilizes into permanent steering. Seeded notes hand it over as what the notes contract says notes are: a current belief the loop is allowed to revise. A notes-only seed is legal and leaves the document on its placeholder skeleton.

## Conflicts refuse loudly

A seed against an existing document (reachable only via `replace=true`, since #1327 made preservation the rule) is an error, not a quiet drop: the document's accumulated state wins over create-time content, and a silently discarded seed is a phantom publish. Same for `initial.notes` against existing notes. The result's `document_state` / `working_notes_state` gain a `seeded` value beside `scaffolded` / `preserved_existing`, and `dry_run` validates a seed without writing anything — an invalid seed is an authoring mistake the preview should catch.

## Teaching

Tool description and schema teach the moment, not just the mechanics: *you have just surveyed this domain, and the loop inheriting the document may run on a smaller model — author the first publish from what you observed.* The doctrine adds the guardrail in the same breath: from what you *actually observed* — when you have observed nothing, leave the placeholders. Trailhead and the loops-examples dashboard recipe pick up the same door.

## Verification

- New tests: full seed render + result states, contract-validation table (missing facet, over budget, reserved heading, unknown key, undeclared facet, empty notes), notes-only seed, unfaceted full-only shape, seed-vs-existing refusal, dry-run writes nothing.
- `just ci` green locally.

Deploy note: the three talent edits need the usual `core/talents` backport; staged copies in the owner's docroots checkout will be refreshed alongside #1327's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
