### PR TITLE
feat(awareness): registry-target expansion honors HA visibility

### DIFF
--- a/internal/app/loop_focus_tools.go
+++ b/internal/app/loop_focus_tools.go
@@ -57,7 +57,7 @@ func buildLoopFocusToolsWithMutator(loopName string, mutator subscriptionMutator
 				"properties": map[string]any{
 					"entity_id": map[string]any{
 						"type":        "string",
-						"description": "The Home Assistant entity ID to watch (e.g., sensor.upstairs_temperature, weather.home), or a glob pattern (e.g., binary_sensor.*door*, *_temperature) to watch every matching entity, re-expanded live each turn (capped per turn).",
+						"description": "The Home Assistant entity ID to watch (e.g., sensor.upstairs_temperature, weather.home); a glob pattern (e.g., binary_sensor.*door*, *_temperature) to watch every matching entity, re-expanded live each turn (capped per turn); or an organizational target — area:<area_id>, label:<label_id>, floor:<floor_id> — watching that group's current members, re-resolved live so membership follows the home. Organizational expansion honors HA visibility: hidden and diagnostic/config members stay out by default (the owner's curation in HA is the filter), so watching a whole area is safe without inspecting it first.",
 					},
 					"history": map[string]any{
 						"type":        "array",
@@ -101,6 +101,14 @@ func buildLoopFocusToolsWithMutator(loopName string, mutator subscriptionMutator
 					"wake_debounce_seconds": map[string]any{
 						"type":        "integer",
 						"description": "How long changes coalesce before waking (default a few seconds); the loop's cadence follows its twitchiest wake subscription.",
+					},
+					"include_hidden": map[string]any{
+						"type":        "boolean",
+						"description": "Widen an area/label/floor target's expansion to members the owner hid in Home Assistant — a deliberate forensic watch. Registry targets only; a concrete entity or glob you name is always watched.",
+					},
+					"include_diagnostic": map[string]any{
+						"type":        "boolean",
+						"description": "Widen an area/label/floor target's expansion to diagnostic/config-category members the default expansion leaves out. Registry targets only.",
 					},
 					"include": tools.EntityMetadataIncludeParameter(),
 				},
@@ -163,6 +171,11 @@ func buildLoopFocusToolsWithMutator(loopName string, mutator subscriptionMutator
 				if wakeDebounce < 0 {
 					return "", fmt.Errorf("wake_debounce_seconds must be >= 0")
 				}
+				includeHidden, _ := args["include_hidden"].(bool)
+				includeDiagnostic, _ := args["include_diagnostic"].(bool)
+				if (includeHidden || includeDiagnostic) && !awareness.ParseSubscriptionTarget(entityID).IsRegistryTarget() {
+					return "", fmt.Errorf("include_hidden/include_diagnostic widen area/label/floor expansion only — a concrete entity or glob you name is always watched; drop the flag")
+				}
 				sub := looppkg.EntitySubscription{
 					EntityID:                 entityID,
 					History:                  history,
@@ -177,6 +190,8 @@ func buildLoopFocusToolsWithMutator(loopName string, mutator subscriptionMutator
 					TransitionsWindowSeconds: transitionsWindow,
 					Wake:                     wake,
 					WakeDebounceSeconds:      wakeDebounce,
+					IncludeHidden:            includeHidden,
+					IncludeDiagnostic:        includeDiagnostic,
 				}
 				if sub.Wake {
 					if sub.RequiresTag != "" {

--- a/internal/runtime/loop/subscription.go
+++ b/internal/runtime/loop/subscription.go
@@ -119,6 +119,23 @@ type EntitySubscription struct {
 	// slower ask here bounds only how fast THIS subscription's
 	// changes demand a wake.
 	WakeDebounceSeconds int `yaml:"wake_debounce_seconds,omitempty" json:"wake_debounce_seconds,omitempty"`
+
+	// IncludeHidden widens a registry target's expansion to members the
+	// owner has hidden in Home Assistant. Expansion honors HA
+	// visibility by default — hidden_by set means the owner curated the
+	// entity out of view — so this is the explicit door for a forensic
+	// watch. Meaningful only on area/label/floor targets: a concrete
+	// entity or glob you name is always watched, and the authoring
+	// doors refuse the flag there.
+	IncludeHidden bool `yaml:"include_hidden,omitempty" json:"include_hidden,omitempty"`
+
+	// IncludeDiagnostic widens a registry target's expansion to
+	// diagnostic- and config-category members (signal strengths,
+	// firmware toggles) that the default expansion leaves out for the
+	// same reason the area snapshot does: they are salient for
+	// forensics, noise for a watch. Registry targets only, like
+	// [EntitySubscription.IncludeHidden].
+	IncludeDiagnostic bool `yaml:"include_diagnostic,omitempty" json:"include_diagnostic,omitempty"`
 }
 
 // IsExpired reports whether this subscription's TTL has elapsed

--- a/internal/state/awareness/area_activity_tool.go
+++ b/internal/state/awareness/area_activity_tool.go
@@ -51,7 +51,10 @@ func (a *AreaActivityTools) Tools() []*tools.Tool {
 				"(lights on, climate running, media playing), then recent changes within the lookback window, then ambient " +
 				"baseline sensors (temperature, humidity), then the rest (capped), plus a cross-entity timeline of discrete " +
 				"transitions newest-first and counts of what was filtered out (disabled/hidden/diagnostic/config). Add include " +
-				"for per-entity area/device/label/description/visibility metadata.",
+				"for per-entity area/device/label/description/visibility metadata. When the survey turns into sustained " +
+				"attention, the area itself is subscribable: area:<area_id> as a subscription target (watch_entity, " +
+				"add_entity_subscription, thane_loop_create.entities) watches the same default-context members shown here, " +
+				"re-resolved live as the room changes.",
 			Parameters: map[string]any{
 				"type": "object",
 				"properties": map[string]any{

--- a/internal/state/awareness/registry_target_subscription.go
+++ b/internal/state/awareness/registry_target_subscription.go
@@ -62,7 +62,7 @@ func expandRegistryTargetSubscription(
 	}
 
 	matchedIDs := make([]string, 0)
-	for _, id := range resolver.members(target) {
+	for _, id := range resolver.members(target, sub.IncludeDiagnostic, sub.IncludeHidden) {
 		if _, skip := exclude[id]; skip {
 			continue
 		}

--- a/internal/state/awareness/subscription_target.go
+++ b/internal/state/awareness/subscription_target.go
@@ -148,9 +148,19 @@ func (m *membershipResolver) entityHasLabel(e *homeassistant.EntityRegistryEntry
 	return false
 }
 
-// members returns the sorted entity ids belonging to a registry target.
-func (m *membershipResolver) members(target SubscriptionTarget) []string {
+// members returns the sorted entity ids belonging to a registry target,
+// after the same salience filter the area and home snapshots apply:
+// disabled entities are always out, and hidden / diagnostic / config
+// entities are out unless the caller opts in. HA visibility is the
+// owner's curation of what the home presents, so an area/label/floor
+// subscription watching "the visible office" by default is honoring
+// that curation — and it is what makes subscribing a whole area safe
+// without inspecting its members first. Naming a hidden entity
+// concretely still watches it; the filter applies only to membership
+// this resolver infers.
+func (m *membershipResolver) members(target SubscriptionTarget, includeDiagnostic, includeHidden bool) []string {
 	var out []string
+	counts := areaFilterCounts{}
 	for id, e := range m.entitiesByID {
 		var match bool
 		switch target.Kind {
@@ -161,9 +171,13 @@ func (m *membershipResolver) members(target SubscriptionTarget) []string {
 		case TargetFloor:
 			match = m.areaToFloor[m.entityArea(e)] == target.Value && target.Value != ""
 		}
-		if match {
-			out = append(out, id)
+		if !match {
+			continue
 		}
+		if !keepAfterSalienceFilter(*e, includeDiagnostic, includeHidden, &counts) {
+			continue
+		}
+		out = append(out, id)
 	}
 	sort.Strings(out)
 	return out

--- a/internal/state/awareness/subscription_target_test.go
+++ b/internal/state/awareness/subscription_target_test.go
@@ -180,3 +180,108 @@ func TestRegistryTarget_NoRegistryClientMarksUnavailable(t *testing.T) {
 		t.Errorf("no registry client should mark the target unavailable, got:\n%s", got)
 	}
 }
+
+// salienceRegistry seeds an office whose registry carries one entity of
+// each salience class, all with live state, so filtering decisions are
+// attributable to the registry entry alone.
+func salienceRegistry() *fakeHARegistry {
+	mk := func(id, state string) *homeassistant.State {
+		return &homeassistant.State{EntityID: id, State: state}
+	}
+	f := &fakeHARegistry{}
+	f.states = map[string]*homeassistant.State{
+		"light.office_overhead":     mk("light.office_overhead", "on"),
+		"sensor.office_hidden_dev":  mk("sensor.office_hidden_dev", "13"),
+		"sensor.office_wifi_signal": mk("sensor.office_wifi_signal", "-61"),
+		"switch.office_led_config":  mk("switch.office_led_config", "off"),
+	}
+	f.entities = []homeassistant.EntityRegistryEntry{
+		{EntityID: "light.office_overhead", AreaID: "office"},
+		{EntityID: "sensor.office_hidden_dev", AreaID: "office", HiddenBy: "user"},
+		{EntityID: "sensor.office_wifi_signal", AreaID: "office", EntityCategory: "diagnostic"},
+		{EntityID: "switch.office_led_config", AreaID: "office", EntityCategory: "config"},
+	}
+	f.areas = []homeassistant.Area{{AreaID: "office", Name: "Office", FloorID: "main"}}
+	f.floors = []homeassistant.FloorRegistryEntry{{FloorID: "main", Name: "Main"}}
+	return f
+}
+
+// TestRegistryTarget_ExpansionHonorsVisibility pins the trust boundary
+// that makes subscribing a whole area safe without inspecting it: the
+// owner's HA curation is the filter. Hidden and diagnostic/config
+// members stay out of the default expansion; the include flags widen
+// it deliberately.
+func TestRegistryTarget_ExpansionHonorsVisibility(t *testing.T) {
+	tests := []struct {
+		name    string
+		sub     looppkg.EntitySubscription
+		wantIn  []string
+		wantOut []string
+	}{
+		{
+			name:    "default expansion is the visible, non-diagnostic office",
+			sub:     looppkg.EntitySubscription{EntityID: "area:office"},
+			wantIn:  []string{"light.office_overhead"},
+			wantOut: []string{"sensor.office_hidden_dev", "sensor.office_wifi_signal", "switch.office_led_config"},
+		},
+		{
+			name:    "include_hidden widens to hidden members only",
+			sub:     looppkg.EntitySubscription{EntityID: "area:office", IncludeHidden: true},
+			wantIn:  []string{"light.office_overhead", "sensor.office_hidden_dev"},
+			wantOut: []string{"sensor.office_wifi_signal", "switch.office_led_config"},
+		},
+		{
+			name:    "include_diagnostic widens to diagnostic and config members",
+			sub:     looppkg.EntitySubscription{EntityID: "area:office", IncludeDiagnostic: true},
+			wantIn:  []string{"light.office_overhead", "sensor.office_wifi_signal", "switch.office_led_config"},
+			wantOut: []string{"sensor.office_hidden_dev"},
+		},
+		{
+			name:   "both flags expand the whole registry membership",
+			sub:    looppkg.EntitySubscription{EntityID: "area:office", IncludeHidden: true, IncludeDiagnostic: true},
+			wantIn: []string{"light.office_overhead", "sensor.office_hidden_dev", "sensor.office_wifi_signal", "switch.office_led_config"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ha := salienceRegistry()
+			p, store := setupRegistryProvider(t, ha)
+			if err := store.Upsert(OwnerCore, tt.sub); err != nil {
+				t.Fatalf("add subscription: %v", err)
+			}
+			got, err := p.TagContext(context.Background(), agentctx.ContextRequest{})
+			if err != nil {
+				t.Fatalf("TagContext: %v", err)
+			}
+			for _, want := range tt.wantIn {
+				if !strings.Contains(got, want) {
+					t.Errorf("expansion should include %s:\n%s", want, got)
+				}
+			}
+			for _, unwanted := range tt.wantOut {
+				if strings.Contains(got, unwanted) {
+					t.Errorf("expansion should exclude %s:\n%s", unwanted, got)
+				}
+			}
+		})
+	}
+}
+
+// TestRegistryTarget_ConcreteHiddenEntityStillWatched pins the boundary
+// of the salience filter: it applies to membership the resolver infers,
+// never to an entity the author named. A concrete watch on a hidden
+// entity is deliberate.
+func TestRegistryTarget_ConcreteHiddenEntityStillWatched(t *testing.T) {
+	ha := salienceRegistry()
+	p, store := setupRegistryProvider(t, ha)
+	if err := store.Upsert(OwnerCore, looppkg.EntitySubscription{EntityID: "sensor.office_hidden_dev"}); err != nil {
+		t.Fatalf("add subscription: %v", err)
+	}
+	got, err := p.TagContext(context.Background(), agentctx.ContextRequest{})
+	if err != nil {
+		t.Fatalf("TagContext: %v", err)
+	}
+	if !strings.Contains(got, "sensor.office_hidden_dev") {
+		t.Errorf("a concretely named hidden entity must render:\n%s", got)
+	}
+}

--- a/internal/state/awareness/watchlist_expansion.go
+++ b/internal/state/awareness/watchlist_expansion.go
@@ -5,6 +5,7 @@ import (
 	"sort"
 
 	"github.com/nugget/thane-ai-agent/internal/integrations/homeassistant"
+	looppkg "github.com/nugget/thane-ai-agent/internal/runtime/loop"
 )
 
 // previewSampleSize is how many member ids a target-expansion preview
@@ -32,8 +33,10 @@ type targetExpansion struct {
 // target is a concrete entity_id that is its own membership and needs no
 // preview. Membership is registry truth, not state-filtered: a member
 // that is momentarily stateless is still a real member, and "matches
-// zero" is exactly the typo signal worth surfacing.
-func previewTargetExpansion(registries *renderRegistries, target SubscriptionTarget) (*targetExpansion, error) {
+// zero" is exactly the typo signal worth surfacing. The preview applies
+// the subscription's own salience flags, so the count it advertises is
+// the count that will render.
+func previewTargetExpansion(registries *renderRegistries, target SubscriptionTarget, sub looppkg.EntitySubscription) (*targetExpansion, error) {
 	if registries == nil {
 		return nil, nil
 	}
@@ -44,7 +47,7 @@ func previewTargetExpansion(registries *renderRegistries, target SubscriptionTar
 		if err != nil {
 			return nil, err
 		}
-		members = resolver.members(target)
+		members = resolver.members(target, sub.IncludeDiagnostic, sub.IncludeHidden)
 	case TargetGlob:
 		entities, err := registries.entities()
 		if err != nil {

--- a/internal/state/awareness/watchlist_store.go
+++ b/internal/state/awareness/watchlist_store.go
@@ -365,6 +365,8 @@ type subscriptionOptionsWire struct {
 	TransitionsWindowSeconds int                                   `json:"transitions_window_seconds,omitempty"`
 	Wake                     bool                                  `json:"wake,omitempty"`
 	WakeDebounceSeconds      int                                   `json:"wake_debounce_seconds,omitempty"`
+	IncludeHidden            bool                                  `json:"include_hidden,omitempty"`
+	IncludeDiagnostic        bool                                  `json:"include_diagnostic,omitempty"`
 }
 
 func marshalSubscriptionOptions(sub looppkg.EntitySubscription) ([]byte, error) {
@@ -397,6 +399,8 @@ func marshalSubscriptionOptions(sub looppkg.EntitySubscription) ([]byte, error) 
 		TransitionsWindowSeconds: sub.TransitionsWindowSeconds,
 		Wake:                     sub.Wake,
 		WakeDebounceSeconds:      sub.WakeDebounceSeconds,
+		IncludeHidden:            sub.IncludeHidden,
+		IncludeDiagnostic:        sub.IncludeDiagnostic,
 	}
 	if wire.Include != nil && !wire.Include.Any() {
 		wire.Include = nil
@@ -423,6 +427,8 @@ func parseSubscriptionOptions(optsJSON string, addedAt time.Time) looppkg.Entity
 	sub.SelfOnly = wire.SelfOnly
 	sub.RequiresTag = strings.TrimSpace(wire.RequiresTag)
 	sub.Wake = wire.Wake
+	sub.IncludeHidden = wire.IncludeHidden
+	sub.IncludeDiagnostic = wire.IncludeDiagnostic
 	if wire.WakeDebounceSeconds > 0 {
 		sub.WakeDebounceSeconds = wire.WakeDebounceSeconds
 	}

--- a/internal/state/awareness/watchlist_store_test.go
+++ b/internal/state/awareness/watchlist_store_test.go
@@ -143,6 +143,30 @@ func TestStore_UpsertRoundTripsUnifiedOptions(t *testing.T) {
 	}
 }
 
+func TestStore_UpsertRoundTripsSalienceFlags(t *testing.T) {
+	store := setupTestStore(t)
+	if err := store.Upsert(OwnerCore, looppkg.EntitySubscription{
+		EntityID:          "area:office",
+		IncludeHidden:     true,
+		IncludeDiagnostic: true,
+	}); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+	rows, err := store.ListOwner(OwnerCore)
+	if err != nil {
+		t.Fatalf("ListOwner: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 row, got %d", len(rows))
+	}
+	if !rows[0].IncludeHidden {
+		t.Error("include_hidden lost in round trip")
+	}
+	if !rows[0].IncludeDiagnostic {
+		t.Error("include_diagnostic lost in round trip")
+	}
+}
+
 func TestStore_UpsertRejectsInvalidOptions(t *testing.T) {
 	store := setupTestStore(t)
 

--- a/internal/state/awareness/watchlist_tool_provider.go
+++ b/internal/state/awareness/watchlist_tool_provider.go
@@ -114,7 +114,7 @@ func (w *WatchlistTools) Tools() []*tools.Tool {
 				"properties": map[string]any{
 					"entity_id": map[string]any{
 						"type":        "string",
-						"description": "What to subscribe to. Any of: a concrete entity ID (sensor.office_temperature); a glob (binary_sensor.*door*, *_temperature); or an organizational target — area:<area_id>, label:<label_id>, floor:<floor_id> (e.g. area:office) — which watches that group's current members, re-resolved live each turn so membership follows the home as devices move (capped per turn like globs). Use ha_registry_search to find area/label/floor IDs.",
+						"description": "What to subscribe to. Any of: a concrete entity ID (sensor.office_temperature); a glob (binary_sensor.*door*, *_temperature); or an organizational target — area:<area_id>, label:<label_id>, floor:<floor_id> (e.g. area:office) — which watches that group's current members, re-resolved live each turn so membership follows the home as devices move (capped per turn like globs). Organizational expansion honors HA visibility: members the owner hid, plus diagnostic/config-category entities, stay out by default — the owner's curation in HA is the filter, so subscribing a whole area is safe without inspecting it first (include_hidden / include_diagnostic widen it). Use ha_registry_search to find area/label/floor IDs.",
 					},
 					"owner": ownerParam,
 					"history": map[string]any{
@@ -159,6 +159,14 @@ func (w *WatchlistTools) Tools() []*tools.Tool {
 					"wake_debounce_seconds": map[string]any{
 						"type":        "integer",
 						"description": "How long this subscription's changes coalesce before waking its loop (default a few seconds). A loop's effective cadence follows its twitchiest wake subscription — one wake drains everything pending.",
+					},
+					"include_hidden": map[string]any{
+						"type":        "boolean",
+						"description": "Widen an area/label/floor target's expansion to members the owner hid in Home Assistant — a deliberate forensic watch. Default expansion honors HA visibility. Registry targets only; a concrete entity or glob you name is always watched.",
+					},
+					"include_diagnostic": map[string]any{
+						"type":        "boolean",
+						"description": "Widen an area/label/floor target's expansion to diagnostic/config-category members (signal strengths, firmware toggles) the default expansion leaves out. Registry targets only.",
 					},
 					"include": tools.EntityMetadataIncludeParameter(),
 				},
@@ -275,6 +283,14 @@ func (w *WatchlistTools) handleAddEntitySubscription(ctx context.Context, args m
 	if transitions > maxTransitionsPerSubscription {
 		return "", fmt.Errorf("transitions is capped at %d per subscription — ask for fewer, or add transitions_window_seconds to bound by recency instead", maxTransitionsPerSubscription)
 	}
+	includeHidden, _ := args["include_hidden"].(bool)
+	includeDiagnostic, _ := args["include_diagnostic"].(bool)
+	// The salience flags widen registry-target expansion; a concrete
+	// entity or glob you name is always watched, so the flag there is a
+	// misunderstanding worth correcting rather than ignoring.
+	if (includeHidden || includeDiagnostic) && !ParseSubscriptionTarget(entityID).IsRegistryTarget() {
+		return "", fmt.Errorf("include_hidden/include_diagnostic widen area/label/floor expansion only — a concrete entity or glob you name is always watched; drop the flag")
+	}
 	wake, _ := args["wake"].(bool)
 	wakeDebounce, err := watchlistIntArg(args["wake_debounce_seconds"], "wake_debounce_seconds")
 	if err != nil {
@@ -298,6 +314,8 @@ func (w *WatchlistTools) handleAddEntitySubscription(ctx context.Context, args m
 		TransitionsWindowSeconds: transitionsWindow,
 		Wake:                     wake,
 		WakeDebounceSeconds:      wakeDebounce,
+		IncludeHidden:            includeHidden,
+		IncludeDiagnostic:        includeDiagnostic,
 	}
 
 	if sub.Wake {
@@ -431,7 +449,7 @@ func (w *WatchlistTools) handleAddEntitySubscription(ctx context.Context, args m
 	// is almost always a typo'd id that would otherwise inject nothing
 	// forever. A concrete entity_id is its own membership and needs none.
 	if target := ParseSubscriptionTarget(entityID); target.Kind != TargetEntity {
-		exp, perr := previewTargetExpansion(newRenderRegistries(ctx, w.registry), target)
+		exp, perr := previewTargetExpansion(newRenderRegistries(ctx, w.registry), target, sub)
 		switch {
 		case perr != nil:
 			// The preview couldn't run (transient registry read failure).
@@ -536,7 +554,7 @@ func (w *WatchlistTools) handleListEntitySubscriptions(ctx context.Context, args
 		// Show each glob/registry target's current expansion so a
 		// silently-empty subscription is visible at a glance.
 		if target := ParseSubscriptionTarget(row.EntityID); target.Kind != TargetEntity {
-			if exp, err := previewTargetExpansion(registries, target); err != nil {
+			if exp, err := previewTargetExpansion(registries, target, row.EntitySubscription); err != nil {
 				// A failed read is marked, not omitted — an absent
 				// expansion would read as "not a registry target" rather
 				// than "couldn't resolve it this turn."

--- a/internal/tools/loop_create_fluency_test.go
+++ b/internal/tools/loop_create_fluency_test.go
@@ -623,3 +623,42 @@ func TestGuidedCreateSeedDryRunWritesNothing(t *testing.T) {
 		}
 	}
 }
+
+// TestGuidedCreateSalienceFlagsAreRegistryTargetOnly pins the guard on
+// the create door: the salience flags widen area/label/floor expansion,
+// so on a concrete entity they signal a misunderstanding the tool
+// should correct rather than ignore.
+func TestGuidedCreateSalienceFlagsAreRegistryTargetOnly(t *testing.T) {
+	t.Run("accepted on an area target", func(t *testing.T) {
+		entities, err := parseEntityList("entities", []any{
+			map[string]any{"entity_id": "area:office", "include_hidden": true, "include_diagnostic": true},
+		})
+		if err != nil {
+			t.Fatalf("area target with salience flags: %v", err)
+		}
+		if !entities[0].IncludeHidden || !entities[0].IncludeDiagnostic {
+			t.Errorf("flags not carried: %+v", entities[0])
+		}
+	})
+	t.Run("refused on a concrete entity", func(t *testing.T) {
+		_, err := parseEntityList("entities", []any{
+			map[string]any{"entity_id": "sensor.office_temperature", "include_hidden": true},
+		})
+		if err == nil {
+			t.Fatal("include_hidden on a concrete entity should refuse")
+		}
+		if !strings.Contains(err.Error(), "always watched") {
+			t.Errorf("error should teach the boundary, got: %v", err)
+		}
+	})
+	t.Run("flags land on the spec subscription", func(t *testing.T) {
+		spec, _ := dryRunSpec(t, map[string]any{
+			"name": "office_watch", "intent": "Watch the office.",
+			"operation": "service", "sleep_min": "10m", "sleep_max": "30m",
+			"entities": []any{map[string]any{"entity_id": "area:office", "include_diagnostic": true}},
+		})
+		if len(spec.Subscriptions) != 1 || !spec.Subscriptions[0].IncludeDiagnostic {
+			t.Errorf("subscription = %+v, want include_diagnostic carried", spec.Subscriptions)
+		}
+	})
+}

--- a/internal/tools/loop_create_tool.go
+++ b/internal/tools/loop_create_tool.go
@@ -838,13 +838,13 @@ func thaneLoopCreateSchema() map[string]any {
 			},
 			"entities": map[string]any{
 				"type":        "array",
-				"description": "Optional Home Assistant entity subscriptions surfaced into the loop's context each iteration. By default they provide context only; an entry with wake: true also wakes this loop when the entity changes (debounced/coalesced — the simple-change-trigger door; compound conditions stay HA-side via MQTT wakes). Container ancestors' subscriptions also cascade in.",
+				"description": "Optional Home Assistant entity subscriptions surfaced into the loop's context each iteration. By default they provide context only; an entry with wake: true also wakes this loop when the entity changes (debounced/coalesced — the simple-change-trigger door; compound conditions stay HA-side via MQTT wakes). Container ancestors' subscriptions also cascade in. For a loop monitoring a room or domain, prefer two layers: one area:<area_id> entry for ambient coverage (expansion honors HA visibility, so it is safe by default and tracks the room as devices move), plus the few sharp entities that carry wake, transitions, or history — hand-enumerating a whole room invites omissions an area target makes impossible.",
 				"items": map[string]any{
 					"type": "object",
 					"properties": map[string]any{
 						"entity_id": map[string]any{
 							"type":        "string",
-							"description": "Home Assistant entity ID (e.g. sensor.upstairs_temperature) or a glob (e.g. binary_sensor.*door*), re-expanded live each turn.",
+							"description": "Home Assistant entity ID (e.g. sensor.upstairs_temperature); a glob (e.g. binary_sensor.*door*), re-expanded live each turn; or an organizational target — area:<area_id>, label:<label_id>, floor:<floor_id> — watching that group's current members, re-resolved live. Organizational expansion honors HA visibility: hidden and diagnostic/config members stay out by default (include_hidden / include_diagnostic widen it).",
 						},
 						"history": map[string]any{
 							"type":        "array",
@@ -888,6 +888,14 @@ func thaneLoopCreateSchema() map[string]any {
 						"wake_debounce_seconds": map[string]any{
 							"type":        "integer",
 							"description": "How long changes coalesce before waking (default a few seconds).",
+						},
+						"include_hidden": map[string]any{
+							"type":        "boolean",
+							"description": "Widen an area/label/floor target's expansion to members the owner hid in Home Assistant — a deliberate forensic watch. Registry targets only; a concrete entity or glob you name is always watched.",
+						},
+						"include_diagnostic": map[string]any{
+							"type":        "boolean",
+							"description": "Widen an area/label/floor target's expansion to diagnostic/config-category members the default expansion leaves out. Registry targets only.",
 						},
 						"include": EntityMetadataIncludeParameter(),
 					},

--- a/internal/tools/loop_intent_tools.go
+++ b/internal/tools/loop_intent_tools.go
@@ -98,6 +98,8 @@ func curateEntitiesToSubscriptions(entities []curateEntity, addedAt time.Time) [
 			TransitionsWindowSeconds: e.TransitionsWindowSeconds,
 			Wake:                     e.Wake,
 			WakeDebounceSeconds:      e.WakeDebounceSeconds,
+			IncludeHidden:            e.IncludeHidden,
+			IncludeDiagnostic:        e.IncludeDiagnostic,
 		})
 	}
 	return out
@@ -118,6 +120,8 @@ type curateEntity struct {
 	TransitionsWindowSeconds int
 	Wake                     bool
 	WakeDebounceSeconds      int
+	IncludeHidden            bool
+	IncludeDiagnostic        bool
 }
 
 // parseEntityList decodes an entity-subscription array into a typed
@@ -265,6 +269,26 @@ func parseEntityList(fieldName string, raw any) ([]curateEntity, error) {
 				return nil, fmt.Errorf("%s[%d].wake_debounce_seconds: must be >= 0", fieldName, i)
 			}
 			ent.WakeDebounceSeconds = n
+		}
+		if rawIncludeHidden, present := obj["include_hidden"]; present && rawIncludeHidden != nil {
+			v, ok := rawIncludeHidden.(bool)
+			if !ok {
+				return nil, fmt.Errorf("%s[%d].include_hidden: must be a boolean, got %T", fieldName, i, rawIncludeHidden)
+			}
+			ent.IncludeHidden = v
+		}
+		if rawIncludeDiagnostic, present := obj["include_diagnostic"]; present && rawIncludeDiagnostic != nil {
+			v, ok := rawIncludeDiagnostic.(bool)
+			if !ok {
+				return nil, fmt.Errorf("%s[%d].include_diagnostic: must be a boolean, got %T", fieldName, i, rawIncludeDiagnostic)
+			}
+			ent.IncludeDiagnostic = v
+		}
+		// The salience flags widen registry-target expansion; a concrete
+		// entity or glob you name is always watched, so the flag there is
+		// a misunderstanding worth correcting rather than ignoring.
+		if (ent.IncludeHidden || ent.IncludeDiagnostic) && !homeassistant.IsRegistryTarget(ent.EntityID) {
+			return nil, fmt.Errorf("%s[%d]: include_hidden/include_diagnostic widen area/label/floor expansion only — a concrete entity or glob you name is always watched; drop the flag", fieldName, i)
 		}
 		if ent.Wake && ent.RequiresTag != "" {
 			return nil, fmt.Errorf("%s[%d]: wake cannot combine with requires_tag — waking must not follow tag state", fieldName, i)

--- a/talents/awareness-trailhead.md
+++ b/talents/awareness-trailhead.md
@@ -66,11 +66,19 @@ Mechanics that apply across all of the above:
   `label:<label_id>`, `floor:<floor_id>`. Prefer the organizational
   form when the intent is "watch the office," not "watch these specific
   sensors": membership re-resolves from the registry every turn, so it
-  follows the home as devices move. Subscribing to a glob or target
-  reports how many entities it matches right now, with a sample — a
-  zero-member expansion almost always means a typo'd id; fix it before
-  moving on. Registry targets are render-only (they cannot feed
-  capture or wake). Use `ha_registry_search` to find ids.
+  follows the home as devices move — and expansion honors HA
+  visibility, skipping hidden and diagnostic/config members, so the
+  owner's curation in HA is the filter and subscribing a whole area
+  needs no hesitation and no member-by-member inspection
+  (`include_hidden` / `include_diagnostic` widen it for a forensic
+  watch; a concrete id you name is always watched). Hand-enumerating a
+  room invites omissions an area target makes impossible; the pattern
+  for a room monitor is the area for coverage plus the few sharp
+  entities that carry `wake`, `transitions`, or `history`. Subscribing
+  to a glob or target reports how many entities it matches right now,
+  with a sample — a zero-member expansion almost always means a typo'd
+  id; fix it before moving on. Registry targets are render-only (they
+  cannot feed capture or wake). Use `ha_registry_search` to find ids.
 - Add `include` metadata flags when area, owning device, HA labels, or
   descriptions would make the state easier to interpret; use
   `visibility` when hidden/enabled salience matters, and read

--- a/talents/ha.md
+++ b/talents/ha.md
@@ -61,6 +61,13 @@ plus a transition timeline and counts of what was filtered out
 (disabled/hidden/diagnostic/config). Default-context entities only;
 pass `include_hidden` or `include_diagnostic` for a forensic pass.
 
+When the survey turns into sustained attention, the area itself is
+subscribable: `area:<area_id>` as a subscription target watches the
+same default-context members this tool shows (same visibility filter,
+same flags), re-resolved live as the room changes — so what you just
+surveyed is exactly what a loop will watch. See `awareness` for the
+subscription doors.
+
 ## Narrow to a device
 
 `ha_device` is the whole-device perception view — the native answer to

--- a/talents/loops-examples.md
+++ b/talents/loops-examples.md
@@ -146,10 +146,9 @@ anything persists.
   "sleep_min": "10m",
   "sleep_max": "30m",
   "subscriptions": [
-    {"entity_id": "sensor.server_closet_temperature"},
-    {"entity_id": "sensor.server_closet_humidity"},
-    {"entity_id": "sensor.ups_hor_rack_status"},
-    {"entity_id": "switch.dehumidifier"}
+    {"entity_id": "area:server_closet"},
+    {"entity_id": "sensor.server_closet_temperature", "history": [3600, 86400]},
+    {"entity_id": "sensor.ups_hor_rack_status", "transitions": 6}
   ],
   "tags": ["home", "ha", "awareness", "documents"],
   "outputs": [
@@ -168,6 +167,12 @@ anything persists.
   ]
 }
 ```
+
+The watch set is two layers: `area:server_closet` carries ambient
+coverage of everything the owner keeps visible there — expansion honors
+HA visibility and re-resolves live, so a sensor added to the closet next
+month appears without a spec edit — while the sharp entities carry the
+extras an area target cannot (history windows, transition logs, wake).
 
 ## Publishing
 

--- a/talents/loops.md
+++ b/talents/loops.md
@@ -103,6 +103,13 @@ Choose stream wiring by attention cost:
   parameter: omit `owner` and the same tools mutate your own
   always-visible subscription set instead — name the loop when the
   loop should carry the watch.
+  For a loop watching a room or domain, build the watch set in two
+  layers: one `area:<area_id>` entry for ambient coverage — expansion
+  honors HA visibility (hidden and diagnostic members stay out), so
+  subscribing the whole area is safe by default and tracks the room as
+  devices move — plus the few sharp entities carrying `wake`,
+  `transitions`, or `history`. Hand-enumerating a room invites
+  omissions an area target makes impossible.
   Add `include` metadata flags (`area`, `device`, `labels`,
   `description`, `visibility`, or `all`) when the loop needs
   physical-world context beside the live state, including HA's


### PR DESCRIPTION
## HA visibility becomes the trust boundary

Stacked on #1328. The common path into a defined-output curator loop is "monitor this room's sensors" — and the machinery for doing that well has existed since the unified-subscriptions arc: `area:<area_id>` is a valid subscription target, live-membership, re-resolved from the registry every render so it follows the home as devices move. Prod's first faceted loop didn't use it. It hand-enumerated eleven office entities, and its intent names *light* as a pillar of the room's condition while no light sensor made the list — one sat in the survey result the loop was built from. Hand-enumeration is where omissions live.

Two things kept the area target from being the obvious move, and this PR fixes both.

**The expansion didn't honor the owner's curation.** `area:office` matched every registry member — including entities the owner deliberately hid in Home Assistant, and the diagnostic/config noise HA itself relegates. An agent subscribing a whole area got the forensic tail along with the room, which made hesitation rational and member-by-member inspection the responsible move. Registry-target expansion now applies `keepAfterSalienceFilter` — the exact filter the area and home snapshots already share, gaining its third consumer rather than a copy: disabled members always out, hidden and diagnostic/config members out unless the subscription opts in. What the owner keeps visible in HA *is* the watch set. `include_hidden` / `include_diagnostic` remain as the explicit forensic doors, matching `get_area_activity`'s existing flags by name and meaning, and the add-time expansion preview applies the same flags so the count it advertises is the count that renders. The filter applies only to membership the resolver infers — a concretely named hidden entity is a deliberate watch and renders as always, and the authoring doors refuse the flags on anything but a registry target so a misplaced flag teaches instead of silently doing nothing.

**The doors were unlit.** `thane_loop_create.entities` taught "entity ID or a glob" and never mentioned organizational targets; `watch_entity`'s entity_id description didn't either. The model building a room monitor from the create door literally could not discover the form that makes omissions impossible. All four authoring doors now carry the targets, the visibility promise, and the flags: `thane_loop_create.entities`, `add_entity_subscription`, `watch_entity`, and hand-authored specs through the struct fields (round-tripped through the watchlist store's options blob).

## The pattern the talents now teach

For a room or domain monitor, build the watch set in two layers: one `area:<area_id>` entry for ambient coverage — safe by default, tracks the room — plus the few sharp concrete entities that carry what an area target structurally cannot: `wake` on the scene's live signal, `transitions` on presence, `history` on temperature. Wake stays concrete-entity correctly (registry targets can't feed the ingestion filter), so this two-layer shape is the whole answer to "how do wakes fit an area watch."

The teaching lands where the decisions happen: the awareness trailhead (organizational-target bullet gains the no-hesitation promise), the loops doctrine's stream-wiring section, the loops-examples dashboard recipe (its worked spec now demonstrates the two layers), and — closing the survey-to-subscribe chain the office loop fumbled — `ha.md` and `get_area_activity`'s own description now say the area you just surveyed is directly subscribable, watching the same default-context members the survey showed, same filter, same flags.

## Deploy safety

Checked prod before flipping the default: no existing loop definition subscribes a registry target, so no live subscription changes membership when this lands. Talent edits (`awareness-trailhead.md`, `ha.md`, `loops.md`, `loops-examples.md`) need the usual `core/talents` backport; the staged copies in the owner's docroots checkout are refreshed.

## Verification

- New tests: expansion visibility table (default / include_hidden / include_diagnostic / both), concretely-named-hidden-entity-still-renders boundary, watchlist-store round-trip of the flags, create-door flag acceptance + refusal + spec carriage.
- `just ci` green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
