### PR TITLE
feat(loops): make removal verbs say what they did to the live layer

### DIFF
--- a/internal/app/loop_definition_runtime.go
+++ b/internal/app/loop_definition_runtime.go
@@ -32,12 +32,7 @@ type loopDefinitionBootstrapResult struct {
 // participate in startup hydration. Request/reply and background-task
 // operations are transient and are explicitly excluded.
 func isDurableDefinitionOperation(op looppkg.Operation) bool {
-	switch op {
-	case looppkg.OperationService, looppkg.OperationContainer, looppkg.OperationEventDriven:
-		return true
-	default:
-		return false
-	}
+	return op.IsDurableDefinition()
 }
 
 // loopDefinitionRuntime bridges durable loop definitions into the live

--- a/internal/runtime/loop/spec.go
+++ b/internal/runtime/loop/spec.go
@@ -69,6 +69,24 @@ const (
 	OperationEventDriven Operation = "event_driven"
 )
 
+// IsDurableDefinition reports whether a stored definition with this
+// operation is one the reconciler keeps RUNNING while its policy is
+// active — service, container, and event_driven definitions are
+// converged toward "present in the live registry"; transient
+// operations (request_reply, background_task) are launched on demand
+// and never resurrected. This is the single predicate behind both the
+// reconciler's convergence decision and the stop_loop warning that a
+// stop will not stick, so the two cannot disagree about which loops
+// come back.
+func (op Operation) IsDurableDefinition() bool {
+	switch op {
+	case OperationService, OperationContainer, OperationEventDriven:
+		return true
+	default:
+		return false
+	}
+}
+
 // CoreLoopName is the well-known name reserved for the singleton
 // structural root container. Auto-created at startup if absent;
 // orphan loops default-parent to it; cannot be stopped via the

--- a/internal/tools/loop_definition_mutation_tools.go
+++ b/internal/tools/loop_definition_mutation_tools.go
@@ -122,11 +122,16 @@ func (r *Registry) handleLoopDefinitionDelete(ctx context.Context, args map[stri
 		"name":       name,
 	}
 	// Report the live outcome as verified fact, not intent: re-check the
-	// registry after reconcile rather than assuming the stop landed.
+	// registry after reconcile rather than assuming the stop landed —
+	// and when no live registry is wired, say the check could not run
+	// rather than dressing an unchecked absence up as a verified one.
 	switch {
+	case r.loopIntentDeps.LiveRegistry == nil:
+		result["live_outcome_unverified"] = true
+		result["live_outcome_note"] = "no live loop registry is wired in this runtime, so whether a running instance existed could not be checked — verify with loop_status"
 	case !wasRunning:
 		result["no_running_loop"] = true
-	case r.loopIntentDeps.LiveRegistry != nil && r.loopIntentDeps.LiveRegistry.GetByName(name) == nil:
+	case r.loopIntentDeps.LiveRegistry.GetByName(name) == nil:
 		result["running_loop_stopped"] = map[string]any{
 			"loop_id":    liveBefore.ID,
 			"iterations": liveBefore.Iterations,

--- a/internal/tools/loop_definition_mutation_tools.go
+++ b/internal/tools/loop_definition_mutation_tools.go
@@ -83,6 +83,22 @@ func (r *Registry) handleLoopDefinitionDelete(ctx context.Context, args map[stri
 	// removes them transitively. No watchlist-store wipe needed —
 	// that path was for the old scope_tag indirection.
 
+	// Capture the live instance BEFORE the delete so the result can
+	// report what happened to it. Deleting a durable definition stops
+	// its running loop (reconcile below converges the registry), and a
+	// result silent about that half invites two failure modes at once:
+	// a model that believes delete is definition-layer bookkeeping and
+	// goes hunting for a second verb, and a model that reports a kill
+	// nobody can verify against the transcript.
+	var liveBefore looppkg.Status
+	wasRunning := false
+	if r.loopIntentDeps.LiveRegistry != nil {
+		if live := r.loopIntentDeps.LiveRegistry.GetByName(name); live != nil {
+			liveBefore = live.Status()
+			wasRunning = true
+		}
+	}
+
 	if r.deletePersistedLoopDefinition != nil {
 		if err := r.deletePersistedLoopDefinition(name); err != nil {
 			return "", fmt.Errorf("delete persisted loop definition: %w", err)
@@ -104,6 +120,33 @@ func (r *Registry) handleLoopDefinitionDelete(ctx context.Context, args map[stri
 		"status":     "ok",
 		"generation": view.Generation,
 		"name":       name,
+	}
+	// Report the live outcome as verified fact, not intent: re-check the
+	// registry after reconcile rather than assuming the stop landed.
+	switch {
+	case !wasRunning:
+		result["no_running_loop"] = true
+	case r.loopIntentDeps.LiveRegistry != nil && r.loopIntentDeps.LiveRegistry.GetByName(name) == nil:
+		result["running_loop_stopped"] = map[string]any{
+			"loop_id":    liveBefore.ID,
+			"iterations": liveBefore.Iterations,
+		}
+	default:
+		result["running_loop_still_live"] = map[string]any{
+			"loop_id": liveBefore.ID,
+			"note":    "the definition is deleted but this instance did not stop during reconcile; stop it with stop_loop and verify with loop_status",
+		}
+	}
+	// The loop's documents are not deleted with it — they may hold value
+	// the owner wants kept. Listing them makes that a decision instead
+	// of a surprise when they are found later, ownerless.
+	if len(existing.Spec.Outputs) > 0 {
+		refs := make([]string, 0, len(existing.Spec.Outputs))
+		for _, output := range existing.Spec.Outputs {
+			refs = append(refs, output.Ref)
+		}
+		result["declared_outputs_left_in_place"] = refs
+		result["outputs_note"] = "the loop's documents were NOT deleted; remove them with doc_delete if they should not outlive the loop"
 	}
 	// Cascade: a runtime MQTT wake subscription can target this loop and
 	// would be orphaned by the delete (it isn't part of the loop's spec).

--- a/internal/tools/loop_definition_tools.go
+++ b/internal/tools/loop_definition_tools.go
@@ -242,7 +242,7 @@ func (r *Registry) registerLoopDefinitionTools() {
 
 	r.Register(&Tool{
 		Name:        "loop_definition_delete",
-		Description: "Delete one dynamic loop definition from the persistent loops overlay. Config-owned definitions are immutable and cannot be deleted.",
+		Description: "Remove a durable loop: deletes the stored definition AND stops its running instance — one verb, both layers, with the result reporting the live outcome as verified fact (running_loop_stopped, or no_running_loop). The loop's declared output documents are NOT deleted; the result lists what was left in place so keeping or removing them is a deliberate decision (doc_delete if unwanted). Config-owned definitions are immutable and cannot be deleted. To stop a loop while keeping its definition, use loop_definition_set_policy state=paused instead.",
 		Parameters: map[string]any{
 			"type": "object",
 			"properties": map[string]any{

--- a/internal/tools/loop_definition_tools.go
+++ b/internal/tools/loop_definition_tools.go
@@ -242,7 +242,7 @@ func (r *Registry) registerLoopDefinitionTools() {
 
 	r.Register(&Tool{
 		Name:        "loop_definition_delete",
-		Description: "Remove a durable loop: deletes the stored definition AND stops its running instance — one verb, both layers, with the result reporting the live outcome as verified fact (running_loop_stopped, or no_running_loop). The loop's declared output documents are NOT deleted; the result lists what was left in place so keeping or removing them is a deliberate decision (doc_delete if unwanted). Config-owned definitions are immutable and cannot be deleted. To stop a loop while keeping its definition, use loop_definition_set_policy state=paused instead.",
+		Description: "Remove a durable loop: deletes the stored definition AND stops its running instance — one verb, both layers, with the result reporting the live outcome as verified fact: running_loop_stopped, no_running_loop, or running_loop_still_live with recovery steps if the instance survived reconcile (treat that as an incomplete removal, not a success). The loop's declared output documents are NOT deleted; the result lists what was left in place so keeping or removing them is a deliberate decision (doc_delete if unwanted). Config-owned definitions are immutable and cannot be deleted. To stop a loop while keeping its definition, use loop_definition_set_policy state=paused instead.",
 		Parameters: map[string]any{
 			"type": "object",
 			"properties": map[string]any{

--- a/internal/tools/loop_removal_pola_test.go
+++ b/internal/tools/loop_removal_pola_test.go
@@ -213,3 +213,68 @@ func TestStopLoopWithoutDefinitionHasNoFlag(t *testing.T) {
 		t.Errorf("no definition exists; no flag should be raised: %v", result)
 	}
 }
+
+// TestLoopDefinitionDeleteUnverifiedWithoutLiveRegistry pins the honest
+// degradation: a runtime with no live registry cannot check whether an
+// instance existed, and must say the check could not run instead of
+// dressing an unchecked absence up as a verified no_running_loop.
+func TestLoopDefinitionDeleteUnverifiedWithoutLiveRegistry(t *testing.T) {
+	deps := newTestLoopDefinitionDeps(t)
+	if err := deps.defs.Upsert(looppkg.Spec{
+		Name:       "unwired_watch",
+		Enabled:    true,
+		Task:       "Watch without a live registry.",
+		Operation:  looppkg.OperationService,
+		Completion: looppkg.CompletionNone,
+	}, time.Now()); err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+	result := runDelete(t, deps, "unwired_watch")
+	if result["live_outcome_unverified"] != true {
+		t.Fatalf("nil live registry must report the live outcome as unverified: %v", result)
+	}
+	for _, forbidden := range []string{"no_running_loop", "running_loop_stopped", "running_loop_still_live"} {
+		if _, present := result[forbidden]; present {
+			t.Errorf("%s claims a verification that never ran: %v", forbidden, result)
+		}
+	}
+}
+
+// TestStopLoopTransientDefinitionHasNoFlag pins the durable gate on the
+// resurrection warning: the reconciler never relaunches a transient
+// operation (it launches on demand), so an active background_task
+// definition must not trigger the will_relaunch wolf-cry.
+func TestStopLoopTransientDefinitionHasNoFlag(t *testing.T) {
+	deps := newTestLoopRuntimeDeps(t)
+	defs, err := looppkg.NewDefinitionRegistry(nil)
+	if err != nil {
+		t.Fatalf("NewDefinitionRegistry: %v", err)
+	}
+	if err := defs.Upsert(looppkg.Spec{
+		Name:       "mqtt_bridge",
+		Enabled:    true,
+		Task:       "Bridge MQTT events.",
+		Operation:  looppkg.OperationBackgroundTask,
+		Completion: looppkg.CompletionChannel,
+	}, time.Now()); err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+	deps.reg.ConfigureLoopDefinitionTools(LoopDefinitionToolDeps{
+		Registry: defs,
+		View: func() *looppkg.DefinitionRegistryView {
+			return looppkg.BuildDefinitionRegistryView(defs.Snapshot(), nil)
+		},
+	})
+
+	out, err := deps.reg.Get("stop_loop").Handler(context.Background(), map[string]any{"name": "mqtt_bridge"})
+	if err != nil {
+		t.Fatalf("stop_loop: %v", err)
+	}
+	var result map[string]any
+	if err := json.Unmarshal([]byte(out), &result); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if _, present := result["definition_active"]; present {
+		t.Errorf("transient definitions are never resurrected; no flag should be raised: %v", result)
+	}
+}

--- a/internal/tools/loop_removal_pola_test.go
+++ b/internal/tools/loop_removal_pola_test.go
@@ -1,0 +1,215 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	looppkg "github.com/nugget/thane-ai-agent/internal/runtime/loop"
+)
+
+// removalHarness is the delete-path rig: the shared definition harness
+// plus a live registry, with an overlay definition that declares
+// outputs and a running instance registered under the same name — the
+// exact shape of the prod incident this file's tests exist to prevent
+// recurring.
+func removalHarness(t *testing.T, reconcileStops bool) (*testLoopDefinitionDeps, *looppkg.Registry) {
+	t.Helper()
+	deps := newTestLoopDefinitionDeps(t)
+	live := looppkg.NewRegistry()
+	deps.reg.ConfigureLoopIntentTools(LoopIntentToolDeps{
+		Registry:   deps.defs,
+		CommitSpec: upsertCommitSpec(deps.defs),
+		LaunchDefinition: func(context.Context, string, looppkg.Launch) (looppkg.LaunchResult, error) {
+			return looppkg.LaunchResult{}, nil
+		},
+		LiveRegistry: live,
+	})
+	if reconcileStops {
+		// Convergence stand-in: the real reconciler stops a loop whose
+		// definition vanished; here that is a deregister.
+		deps.reg.reconcileLoopDefinition = func(_ context.Context, name string) error {
+			if l := live.GetByName(name); l != nil {
+				live.Deregister(l.ID())
+			}
+			return nil
+		}
+	}
+
+	if err := deps.defs.Upsert(looppkg.Spec{
+		Name:       "office_watch",
+		Enabled:    true,
+		Task:       "Watch the office.",
+		Operation:  looppkg.OperationService,
+		Completion: looppkg.CompletionNone,
+		Outputs: []looppkg.OutputSpec{
+			{Name: "office_watch", Type: looppkg.OutputTypeMaintainedDocument, Ref: "projects:home/office.md"},
+			{Name: "office_watch_notes", Type: looppkg.OutputTypeWorkingNotes, Ref: "projects:home/office-notes.md"},
+		},
+	}, time.Now()); err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+	registerRunningLoop(t, live, "office_watch")
+	return deps, live
+}
+
+func runDelete(t *testing.T, deps *testLoopDefinitionDeps, name string) map[string]any {
+	t.Helper()
+	out, err := deps.reg.Get("loop_definition_delete").Handler(context.Background(), map[string]any{"name": name})
+	if err != nil {
+		t.Fatalf("loop_definition_delete: %v", err)
+	}
+	var result map[string]any
+	if err := json.Unmarshal([]byte(out), &result); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	return result
+}
+
+// TestLoopDefinitionDeleteReportsStoppedInstance pins the result's live
+// half: the delete stopped a running instance and SAYS so, as verified
+// fact (the registry was re-checked after reconcile), with the loop's
+// documents listed as deliberately left behind. A result silent about
+// the live layer is how a phantom kill goes unnoticed.
+func TestLoopDefinitionDeleteReportsStoppedInstance(t *testing.T) {
+	deps, live := removalHarness(t, true)
+	result := runDelete(t, deps, "office_watch")
+
+	stopped, ok := result["running_loop_stopped"].(map[string]any)
+	if !ok {
+		t.Fatalf("result missing running_loop_stopped: %v", result)
+	}
+	if stopped["loop_id"] == "" || stopped["loop_id"] == nil {
+		t.Errorf("stopped instance should carry its loop_id: %v", stopped)
+	}
+	if live.GetByName("office_watch") != nil {
+		t.Error("live loop survived the delete in the converged harness")
+	}
+	refs, ok := result["declared_outputs_left_in_place"].([]any)
+	if !ok || len(refs) != 2 {
+		t.Fatalf("declared_outputs_left_in_place = %v, want both refs", result["declared_outputs_left_in_place"])
+	}
+	note, _ := result["outputs_note"].(string)
+	if !strings.Contains(note, "NOT deleted") {
+		t.Errorf("outputs_note should say the documents were kept: %q", note)
+	}
+}
+
+// TestLoopDefinitionDeleteReportsSurvivor pins the honest-failure path:
+// if reconcile does not converge the instance away, the result says the
+// loop is STILL LIVE and teaches the recovery, instead of reporting a
+// clean delete that leaves a haunting.
+func TestLoopDefinitionDeleteReportsSurvivor(t *testing.T) {
+	deps, live := removalHarness(t, false)
+	result := runDelete(t, deps, "office_watch")
+
+	survivor, ok := result["running_loop_still_live"].(map[string]any)
+	if !ok {
+		t.Fatalf("result missing running_loop_still_live: %v", result)
+	}
+	note, _ := survivor["note"].(string)
+	if !strings.Contains(note, "stop_loop") || !strings.Contains(note, "loop_status") {
+		t.Errorf("survivor note should teach the recovery: %q", note)
+	}
+	if live.GetByName("office_watch") == nil {
+		t.Fatal("harness invariant: the no-converge rig should leave the loop live")
+	}
+}
+
+// TestLoopDefinitionDeleteReportsNoRunningLoop pins the quiet case: a
+// definition with no live instance says so, so absence reads as
+// verified rather than unmentioned.
+func TestLoopDefinitionDeleteReportsNoRunningLoop(t *testing.T) {
+	deps := newTestLoopDefinitionDeps(t)
+	live := looppkg.NewRegistry()
+	deps.reg.ConfigureLoopIntentTools(LoopIntentToolDeps{
+		Registry:   deps.defs,
+		CommitSpec: upsertCommitSpec(deps.defs),
+		LaunchDefinition: func(context.Context, string, looppkg.Launch) (looppkg.LaunchResult, error) {
+			return looppkg.LaunchResult{}, nil
+		},
+		LiveRegistry: live,
+	})
+	if err := deps.defs.Upsert(looppkg.Spec{
+		Name:       "quiet_watch",
+		Enabled:    true,
+		Task:       "Watch quietly.",
+		Operation:  looppkg.OperationService,
+		Completion: looppkg.CompletionNone,
+	}, time.Now()); err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+	result := runDelete(t, deps, "quiet_watch")
+	if result["no_running_loop"] != true {
+		t.Errorf("result should report no_running_loop, got %v", result)
+	}
+	if _, present := result["declared_outputs_left_in_place"]; present {
+		t.Errorf("no outputs declared, none should be reported: %v", result)
+	}
+}
+
+// TestStopLoopFlagsActiveDefinition pins the resurrection trap: a stop
+// of a loop whose durable definition is still active is temporary — the
+// reconciler relaunches it — and the result must say so and name the
+// durable doors. Without the stamp, "stop the loop" produces a loop
+// that comes back later, unexplained.
+func TestStopLoopFlagsActiveDefinition(t *testing.T) {
+	deps := newTestLoopRuntimeDeps(t)
+	defs, err := looppkg.NewDefinitionRegistry(nil)
+	if err != nil {
+		t.Fatalf("NewDefinitionRegistry: %v", err)
+	}
+	if err := defs.Upsert(looppkg.Spec{
+		Name:       "battery_watch",
+		Enabled:    true,
+		Task:       "Watch batteries.",
+		Operation:  looppkg.OperationService,
+		Completion: looppkg.CompletionNone,
+	}, time.Now()); err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+	deps.reg.ConfigureLoopDefinitionTools(LoopDefinitionToolDeps{
+		Registry: defs,
+		View: func() *looppkg.DefinitionRegistryView {
+			return looppkg.BuildDefinitionRegistryView(defs.Snapshot(), nil)
+		},
+	})
+
+	out, err := deps.reg.Get("stop_loop").Handler(context.Background(), map[string]any{"name": "battery_watch"})
+	if err != nil {
+		t.Fatalf("stop_loop: %v", err)
+	}
+	var result map[string]any
+	if err := json.Unmarshal([]byte(out), &result); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if result["definition_active"] != true {
+		t.Fatalf("stop of an active durable definition must be flagged: %v", result)
+	}
+	warn, _ := result["will_relaunch"].(string)
+	for _, want := range []string{"reconciler", "paused", "loop_definition_delete"} {
+		if !strings.Contains(warn, want) {
+			t.Errorf("will_relaunch should teach %q: %q", want, warn)
+		}
+	}
+}
+
+// TestStopLoopWithoutDefinitionHasNoFlag pins the boundary: an ad hoc
+// loop with no stored definition stops for good, and the result carries
+// no resurrection warning to cry wolf about.
+func TestStopLoopWithoutDefinitionHasNoFlag(t *testing.T) {
+	deps := newTestLoopRuntimeDeps(t)
+	out, err := deps.reg.Get("stop_loop").Handler(context.Background(), map[string]any{"name": "battery_watch"})
+	if err != nil {
+		t.Fatalf("stop_loop: %v", err)
+	}
+	var result map[string]any
+	if err := json.Unmarshal([]byte(out), &result); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if _, present := result["definition_active"]; present {
+		t.Errorf("no definition exists; no flag should be raised: %v", result)
+	}
+}

--- a/internal/tools/loop_runtime_tools.go
+++ b/internal/tools/loop_runtime_tools.go
@@ -128,7 +128,7 @@ func (r *Registry) registerLoopRuntimeTools() {
 
 	r.Register(&Tool{
 		Name:        "stop_loop",
-		Description: "Stop one currently running loop by loop_id or exact name. Prefer loop_id when available. If name is ambiguous, the tool returns the candidate IDs so you can retry precisely.",
+		Description: "Stop one currently running loop by loop_id or exact name. Prefer loop_id when available. If name is ambiguous, the tool returns the candidate IDs so you can retry precisely. Instance-tier only: for a loop with an ACTIVE durable definition this stop is temporary — the reconciler relaunches it at the next boot, commit, or schedule transition (the result flags this). A durable stop is loop_definition_set_policy state=paused; removal is loop_definition_delete, which stops the running instance itself.",
 		Parameters: map[string]any{
 			"type": "object",
 			"properties": map[string]any{
@@ -344,12 +344,33 @@ func (r *Registry) handleStopLoop(_ context.Context, args map[string]any) (strin
 	if err != nil {
 		return "", err
 	}
-	return ldMarshalToolJSON(map[string]any{
+	result := map[string]any{
 		"status": "ok",
 		// status is the pre-stop snapshot; project it to the canonical row so
 		// stop_loop returns the same loop shape as every other surface (#1106 B2).
 		"loop": r.loopViewFromStatus(status),
-	})
+	}
+	// Stopping an instance whose durable definition is still active is
+	// temporary by design: the reconciler relaunches it at the next
+	// boot, definition commit, or condition-schedule transition. That
+	// convergence is correct machinery, but a stop that quietly undoes
+	// itself reads as a haunting — say so in the result, with the doors
+	// that actually express durable intent.
+	if r.loopDefinitionRegistry != nil {
+		if snapshot := r.loopDefinitionRegistry.Snapshot(); snapshot != nil {
+			for _, def := range snapshot.Definitions {
+				if def.Name != status.Name {
+					continue
+				}
+				if def.PolicyState == looppkg.DefinitionPolicyStateActive {
+					result["definition_active"] = true
+					result["will_relaunch"] = "this loop's durable definition is still active, so the reconciler will relaunch it (next boot, definition commit, or schedule transition) — use loop_definition_set_policy state=paused to keep it stopped, or loop_definition_delete to remove it"
+				}
+				break
+			}
+		}
+	}
+	return ldMarshalToolJSON(result)
 }
 
 func clampLoopListLimit(raw, def, max int) int {

--- a/internal/tools/loop_runtime_tools.go
+++ b/internal/tools/loop_runtime_tools.go
@@ -362,7 +362,11 @@ func (r *Registry) handleStopLoop(_ context.Context, args map[string]any) (strin
 				if def.Name != status.Name {
 					continue
 				}
-				if def.PolicyState == looppkg.DefinitionPolicyStateActive {
+				// Only durable operations are converged toward "running"
+				// by the reconciler; a transient definition (background
+				// task, request_reply) is launched on demand and never
+				// resurrected, so warning there would cry wolf.
+				if def.PolicyState == looppkg.DefinitionPolicyStateActive && def.Spec.Operation.IsDurableDefinition() {
 					result["definition_active"] = true
 					result["will_relaunch"] = "this loop's durable definition is still active, so the reconciler will relaunch it (next boot, definition commit, or schedule transition) — use loop_definition_set_policy state=paused to keep it stopped, or loop_definition_delete to remove it"
 				}

--- a/talents/loops.md
+++ b/talents/loops.md
@@ -233,5 +233,36 @@ Two consequences worth holding:
   (`loop_reparent` each, or `stop_loop` them), then relaunch the
   container. That's why re-tagging a busy container is churn.
 
+## Removing a loop
+
+Match the verb to how dead you want it:
+
+- **Gone** — `loop_definition_delete` is the one removal verb: it
+  deletes the stored definition AND stops the running instance, and
+  its result reports the live outcome — the stopped instance, or that
+  none was running. There is no second step for the loop itself.
+- **Kept but stopped** — `loop_definition_set_policy state=paused`.
+  The definition survives, the instance stops, and it stays stopped
+  across restarts until you set it active again.
+- **`stop_loop` alone is instance-tier and temporary** for any loop
+  whose durable definition is active: the reconciler relaunches it at
+  the next boot, commit, or schedule transition. That convergence is
+  the machinery working — a durable definition means "this loop should
+  be running" — so express durable intent through the definition
+  (pause or delete), not the instance.
+
+The loop's documents outlive it. Deleting a loop leaves its declared
+outputs in place — the delete result lists them — because the
+understanding a curator built may be worth keeping after the curation
+stops. Whether they stay is a separate, deliberate decision:
+`doc_delete` them if they should not survive the loop. Deleting a
+document while its loop still runs does nothing durable — the next
+wake rewrites it; stop the loop first.
+
+Report a kill only after verifying it: the delete result's
+stopped-instance report is that verification, and `loop_status` on the
+name confirms independently. A removal narrated but never verified is
+how a loop haunts its owner.
+
 When you need concrete JSON launch patterns, activate `loops_examples`
 and adapt the closest recipe minimally.


### PR DESCRIPTION
## A removal you can't verify is a removal you can't trust

Prod, last night: asked to remove the failed office watcher, the agent deleted its output document, reported the loop dead ("definition and running instance both"), and the same live instance ran three more iterations through the morning — resurrecting the deleted document at every wake — until the owner noticed and asked what was going on. The eventual real cleanup (stop → verify → delete definition → delete docs) worked first try.

The forensics exonerate the mechanical chain: `loop_definition_delete` reconciles the running instance away, and has since the durable-commit chokepoint landed. The event archive shows the removal turn simply never issued it — a phantom kill, narrated but not performed. And that is still a tooling failure, because the tool surface made the phantom easy to tell and impossible to catch: the delete verb's description spoke pure definition-layer bookkeeping with no hint it also stops the instance, and its result — `{status: ok, generation, name}` — said nothing about the live layer at all. Nobody, model or operator, could distinguish a real kill from a claimed one by reading the transcript.

There's a second trap in the same family, and it is very likely the earlier occurrences of "the loop came back": `stop_loop` on a loop whose durable definition is still active is temporary by design. `ReconcileAllDefinitions` runs at boot, after every definition commit, and at every condition-schedule transition — and it relaunches any stopped instance whose definition says it should be running. Correct convergence machinery that reads as a haunting, because neither the description nor the result breathed a word of it.

## What changes

**`loop_definition_delete` reports the live outcome as verified fact.** The handler captures the running instance before the delete and re-checks the registry after reconcile, so the result states what actually happened rather than what was intended: `running_loop_stopped: {loop_id, iterations}`, or `no_running_loop`, or — honestly — `running_loop_still_live` with the recovery steps when convergence didn't land. The description now leads with the real contract: one verb, both layers. The result also lists `declared_outputs_left_in_place`: the loop's documents are deliberately not deleted (a curator's accumulated understanding may outlive the curation), and naming them turns "the docs are still there" from a later surprise into an immediate decision.

**`stop_loop` names its own impermanence.** The description says instance-tier stops of active durable definitions are temporary and points at the doors that express durable intent (`loop_definition_set_policy state=paused`, `loop_definition_delete`); the result stamps `definition_active: true` plus a `will_relaunch` warning whenever the stop won't stick. No refusal — the stop-then-relaunch idiom stays legal, and the resurrection is the reconciler doing its job — but it stops being a secret.

**The doctrine gains the removal section it never had.** "Changing a loop that's already running" taught retune and relaunch; removal wasn't taught at all. The new section gives the decision frame — gone (`loop_definition_delete`, one verb, both layers), kept-but-stopped (policy paused), and why `stop_loop` alone doesn't durably express either intent — plus the two lessons this incident paid for: deleting a document under a live loop does nothing durable (the next wake rewrites it; stop the loop first), and a kill is reported only after verification, because a removal narrated but never verified is how a loop haunts its owner.

## Verification

- New tests: delete reporting across all three live outcomes (stopped-and-verified, no-instance, survivor-with-recovery), output-refs listing, and the stop_loop stamp both present (active definition) and absent (ad hoc loop, no wolf-crying).
- The talent-corpus gate caught a result field written tool-shaped in the doctrine prose — reworded; `just ci` green locally.

Deploy note: `talents/loops.md` joins the staged backport set in the owner's docroots checkout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
