### PR TITLE
feat(router): consume resource health in routing decisions

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -83,9 +83,12 @@ type App struct {
 	llmClient             llm.Client
 	ollamaClients         map[string]*modelproviders.OllamaClient
 	resourceHealthClients map[string]fleet.ResourceHealthClient
-	modelRuntime          *fleet.Runtime
-	modelCatalog          *fleet.Catalog
-	modelRegistry         *fleet.Registry
+	// resourceWatchers holds the connwatch watcher per model resource so
+	// the router's readiness probe can consult live health at route time.
+	resourceWatchers map[string]*connwatch.Watcher
+	modelRuntime     *fleet.Runtime
+	modelCatalog     *fleet.Catalog
+	modelRegistry    *fleet.Registry
 
 	// Core subsystems
 	mem                       *memory.SQLiteStore

--- a/internal/app/new_stores.go
+++ b/internal/app/new_stores.go
@@ -273,6 +273,7 @@ func (a *App) initStores(s *newState) error {
 		a.ha.SetWatcher(haWatcher)
 	}
 
+	a.resourceWatchers = make(map[string]*connwatch.Watcher, len(a.resourceHealthClients))
 	for _, res := range a.modelCatalog.Resources {
 		res := res
 		client, ok := a.resourceHealthClients[res.ID]
@@ -294,6 +295,7 @@ func (a *App) initStores(s *newState) error {
 			Logger:  logger.With("resource", res.ID, "provider", res.Provider),
 		})
 		c.AttachWatcher(resourceWatcher)
+		a.resourceWatchers[res.ID] = resourceWatcher
 	}
 
 	if a.modelRuntime != nil && a.modelRuntime.InventoryClientCount() > 0 {
@@ -345,6 +347,23 @@ func (a *App) initStores(s *newState) error {
 	routerCfg := a.modelRegistry.Catalog().RouterConfig(1000)
 	rtr := router.NewRouter(logger, routerCfg)
 	a.rtr = rtr
+
+	// Let scoring consult live resource health so routing steers away
+	// from runners connwatch already knows are down. Resources without a
+	// watcher (anthropic) and watchers that haven't completed their first
+	// probe yet report ready — unknown is optimistic, only a confirmed-
+	// down resource is penalized.
+	rtr.SetResourceReadiness(func(resourceID string) bool {
+		w, ok := a.resourceWatchers[resourceID]
+		if !ok || w == nil {
+			return true
+		}
+		if w.Status().LastCheck.IsZero() {
+			return true
+		}
+		return w.IsReady()
+	})
+
 	logger.Info("model router initialized",
 		"models", len(routerCfg.Models),
 		"default", routerCfg.DefaultModel,

--- a/internal/model/router/failure_class.go
+++ b/internal/model/router/failure_class.go
@@ -1,0 +1,87 @@
+package router
+
+import (
+	"context"
+	"errors"
+	"net"
+	"strings"
+	"syscall"
+)
+
+// Cooldown reason strings produced by [ClassifyResourceFailure] and
+// surfaced through [ResourceHealth.CooldownReason].
+const (
+	// CooldownReasonTimeout marks a resource that accepted a request but
+	// timed out or reported overload while serving it.
+	CooldownReasonTimeout = "recent timeout"
+
+	// CooldownReasonConnection marks a resource that could not be
+	// reached at all: DNS failure, connection refused, or no route.
+	CooldownReasonConnection = "recent connection failure"
+)
+
+// ClassifyResourceFailure maps a request error to the cooldown reason
+// it merits, or "" when the failure says nothing about resource health
+// (caller cancellation, application-level errors). Callers pass the
+// result directly to [Router.RecordFailure].
+//
+// Connection-class failures matter as much as timeouts: a runner whose
+// hostname stopped resolving fails in milliseconds, and before this
+// classification existed those fast failures never cooled the resource,
+// so routing re-selected the dead runner indefinitely.
+func ClassifyResourceFailure(err error) string {
+	if err == nil {
+		return ""
+	}
+
+	// Caller-driven cancellation is not a statement about the resource.
+	if errors.Is(err, context.Canceled) {
+		return ""
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return CooldownReasonTimeout
+	}
+
+	var dnsErr *net.DNSError
+	if errors.As(err, &dnsErr) {
+		return CooldownReasonConnection
+	}
+
+	var errno syscall.Errno
+	if errors.As(err, &errno) {
+		switch errno {
+		case syscall.ECONNREFUSED, syscall.ECONNRESET,
+			syscall.EHOSTUNREACH, syscall.ENETUNREACH:
+			return CooldownReasonConnection
+		}
+	}
+
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return CooldownReasonTimeout
+	}
+
+	var opErr *net.OpError
+	if errors.As(err, &opErr) && opErr.Op == "dial" {
+		return CooldownReasonConnection
+	}
+
+	// String fallbacks for errors that crossed a non-wrapping boundary
+	// (provider adapters, upstream HTTP bodies). "overloaded" and "529"
+	// are Anthropic's overload signals; treat them like timeouts so the
+	// resource gets breathing room.
+	msg := strings.ToLower(err.Error())
+	switch {
+	case strings.Contains(msg, "timeout"),
+		strings.Contains(msg, "overloaded"),
+		strings.Contains(msg, "529"):
+		return CooldownReasonTimeout
+	case strings.Contains(msg, "no such host"),
+		strings.Contains(msg, "connection refused"),
+		strings.Contains(msg, "connection reset"),
+		strings.Contains(msg, "no route to host"),
+		strings.Contains(msg, "network is unreachable"):
+		return CooldownReasonConnection
+	}
+	return ""
+}

--- a/internal/model/router/failure_class_test.go
+++ b/internal/model/router/failure_class_test.go
@@ -1,0 +1,79 @@
+package router
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"syscall"
+	"testing"
+)
+
+func TestClassifyResourceFailure(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{"nil", nil, ""},
+		{"canceled", context.Canceled, ""},
+		{"wrapped canceled", fmt.Errorf("chat: %w", context.Canceled), ""},
+		{"deadline exceeded", context.DeadlineExceeded, CooldownReasonTimeout},
+		{
+			"dns no such host",
+			fmt.Errorf("request failed: %w", &net.OpError{
+				Op:  "dial",
+				Net: "tcp",
+				Err: &net.DNSError{Err: "no such host", Name: "spark-a23e.example.net", IsNotFound: true},
+			}),
+			CooldownReasonConnection,
+		},
+		{
+			"connection refused",
+			fmt.Errorf("request failed: %w", &net.OpError{
+				Op:  "dial",
+				Net: "tcp",
+				Err: &os.SyscallError{Syscall: "connect", Err: syscall.ECONNREFUSED},
+			}),
+			CooldownReasonConnection,
+		},
+		{
+			"host unreachable",
+			fmt.Errorf("request failed: %w", &net.OpError{
+				Op:  "dial",
+				Net: "tcp",
+				Err: &os.SyscallError{Syscall: "connect", Err: syscall.EHOSTUNREACH},
+			}),
+			CooldownReasonConnection,
+		},
+		{
+			"connection reset mid-request",
+			fmt.Errorf("request failed: %w", &net.OpError{
+				Op:  "read",
+				Net: "tcp",
+				Err: &os.SyscallError{Syscall: "read", Err: syscall.ECONNRESET},
+			}),
+			CooldownReasonConnection,
+		},
+		// Errors that crossed a non-wrapping boundary arrive as strings.
+		{"stringified no such host", errors.New(`API error: dial tcp: lookup spark: no such host`), CooldownReasonConnection},
+		{"stringified refused", errors.New("upstream: connection refused"), CooldownReasonConnection},
+		{"client timeout string", errors.New("request failed: Client.Timeout exceeded while awaiting headers"), CooldownReasonTimeout},
+		{"anthropic overloaded", errors.New("API error 529: overloaded_error"), CooldownReasonTimeout},
+		// Application-level failures say nothing about resource health.
+		{"http 400", errors.New("API error 400: invalid request"), ""},
+		{"plain error", errors.New("model produced no output"), ""},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := ClassifyResourceFailure(tc.err); got != tc.want {
+				t.Fatalf("ClassifyResourceFailure(%v) = %q, want %q", tc.err, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/model/router/readiness_test.go
+++ b/internal/model/router/readiness_test.go
@@ -1,0 +1,149 @@
+package router
+
+import (
+	"context"
+	"log/slog"
+	"slices"
+	"strings"
+	"testing"
+)
+
+// readinessTestConfig models the prod shape that motivated readiness
+// scoring: a free local runner on one resource and a paid cloud model,
+// with the caller applying the summarizer's local-first factors.
+func readinessTestConfig() Config {
+	return Config{
+		DefaultModel: "gpt-oss:120b",
+		LocalFirst:   true,
+		Models: []Model{
+			{
+				Name:          "gpt-oss:120b",
+				UpstreamModel: "gpt-oss:120b",
+				Provider:      "ollama",
+				ResourceID:    "spark",
+				Server:        "spark",
+				SupportsTools: true,
+				ContextWindow: 131072,
+				Speed:         6,
+				Quality:       8,
+				CostTier:      0,
+			},
+			{
+				Name:          "claude-sonnet-4-6",
+				UpstreamModel: "claude-sonnet-4-6",
+				Provider:      "anthropic",
+				ResourceID:    "anthropic",
+				SupportsTools: true,
+				ContextWindow: 1000000,
+				Speed:         7,
+				Quality:       8,
+				CostTier:      2,
+			},
+		},
+		MaxAuditLog: 10,
+	}
+}
+
+func summarizerRequest() Request {
+	return Request{
+		Query:    "session metadata generation",
+		Priority: PriorityBackground,
+		RoutingFactors: map[string]string{
+			FactorMission:      "background",
+			FactorLocalOnly:    "true",
+			FactorQualityFloor: "7",
+		},
+	}
+}
+
+func TestUnreachableResourceLosesToPaidModelUnderLocalOnly(t *testing.T) {
+	t.Parallel()
+
+	r := NewRouter(slog.Default(), readinessTestConfig())
+	r.SetResourceReadiness(func(resourceID string) bool {
+		return resourceID != "spark"
+	})
+
+	model, decision := r.Route(context.Background(), summarizerRequest())
+	if model != "claude-sonnet-4-6" {
+		t.Fatalf("Route() with spark down selected %q, want claude-sonnet-4-6 (scores: %v)",
+			model, decision.Scores)
+	}
+	if !slices.Contains(decision.RulesMatched, "resource_unreachable_gpt-oss:120b") {
+		t.Fatalf("RulesMatched missing resource_unreachable marker: %v", decision.RulesMatched)
+	}
+}
+
+func TestReadyResourceKeepsLocalPreference(t *testing.T) {
+	t.Parallel()
+
+	r := NewRouter(slog.Default(), readinessTestConfig())
+	r.SetResourceReadiness(func(string) bool { return true })
+
+	model, decision := r.Route(context.Background(), summarizerRequest())
+	if model != "gpt-oss:120b" {
+		t.Fatalf("Route() with all resources up selected %q, want gpt-oss:120b (scores: %v)",
+			model, decision.Scores)
+	}
+	for _, rule := range decision.RulesMatched {
+		if strings.HasPrefix(rule, "resource_unreachable_") {
+			t.Fatalf("unexpected unreachable marker with all resources ready: %v", decision.RulesMatched)
+		}
+	}
+}
+
+func TestNilReadinessFuncIsNeutral(t *testing.T) {
+	t.Parallel()
+
+	r := NewRouter(slog.Default(), readinessTestConfig())
+
+	model, _ := r.Route(context.Background(), summarizerRequest())
+	if model != "gpt-oss:120b" {
+		t.Fatalf("Route() without readiness func selected %q, want gpt-oss:120b", model)
+	}
+}
+
+func TestAllResourcesUnreachableStillSelectsAModel(t *testing.T) {
+	t.Parallel()
+
+	r := NewRouter(slog.Default(), readinessTestConfig())
+	r.SetResourceReadiness(func(string) bool { return false })
+
+	model, decision := r.Route(context.Background(), summarizerRequest())
+	if model == "" {
+		t.Fatal("Route() with all resources down returned empty model")
+	}
+	if decision.NoEligible {
+		t.Fatal("readiness must stay a soft penalty, not an eligibility filter")
+	}
+}
+
+func TestConnectionFailureCoolsResourceAndSurfacesReason(t *testing.T) {
+	t.Parallel()
+
+	r := NewRouter(slog.Default(), readinessTestConfig())
+
+	model, decision := r.Route(context.Background(), summarizerRequest())
+	if model != "gpt-oss:120b" {
+		t.Fatalf("Route() selected %q, want gpt-oss:120b", model)
+	}
+
+	r.RecordFailure(decision.RequestID, 12, 0, CooldownReasonConnection)
+
+	if until := r.resourceCooldownDeadline("spark"); until.IsZero() {
+		t.Fatal("connection-class failure did not cool the resource")
+	}
+	health := r.GetStats().ResourceHealth["spark"]
+	if health.CooldownReason != CooldownReasonConnection {
+		t.Fatalf("CooldownReason = %q, want %q", health.CooldownReason, CooldownReasonConnection)
+	}
+
+	// A cooled local resource must also lose to the paid alternative —
+	// the -300 cooldown penalty has to dominate local-first bonuses plus
+	// the -200 local_only paid penalty in this profile.
+	nextModel, nextDecision := r.Route(context.Background(), summarizerRequest())
+	if nextModel != "claude-sonnet-4-6" {
+		t.Fatalf("Route() after cooldown selected %q, want claude-sonnet-4-6 (scores: %v)",
+			nextModel, nextDecision.Scores)
+	}
+}

--- a/internal/model/router/router.go
+++ b/internal/model/router/router.go
@@ -139,8 +139,11 @@ type Config struct {
 
 // ResourceReadinessFunc reports whether a provider resource is currently
 // reachable. Wired from connwatch at app init so routing can steer away
-// from runners the health layer already knows are down. A nil func (or
-// an unknown resource ID) is treated as ready.
+// from runners the health layer already knows are down. A nil func
+// treats every resource as ready; otherwise the func decides each ID,
+// and implementations should stay optimistic about resources they do
+// not recognize (the app wiring reports ready for resources without a
+// watcher).
 type ResourceReadinessFunc func(resourceID string) bool
 
 // resourceCooldownState is one resource's transient request-plane
@@ -662,7 +665,7 @@ func (r *Router) selectModel(cfg Config, req Request, decision *Decision) string
 		// failing), preserving down < cooled < healthy ordering.
 		if until := r.resourceCooldownDeadline(m.ResourceID); !until.IsZero() && now.Before(until) {
 			score -= 300
-			rulesMatched = append(rulesMatched, "resource_timeout_cooldown_"+m.Name)
+			rulesMatched = append(rulesMatched, "resource_cooldown_"+m.Name)
 		}
 		if !r.resourceReady(m.ResourceID) {
 			score -= 500

--- a/internal/model/router/router.go
+++ b/internal/model/router/router.go
@@ -137,16 +137,56 @@ type Config struct {
 	MaxAuditLog  int     // How many decisions to keep in memory
 }
 
+// ResourceReadinessFunc reports whether a provider resource is currently
+// reachable. Wired from connwatch at app init so routing can steer away
+// from runners the health layer already knows are down. A nil func (or
+// an unknown resource ID) is treated as ready.
+type ResourceReadinessFunc func(resourceID string) bool
+
+// resourceCooldownState is one resource's transient request-plane
+// cooldown: routing avoids the resource until the deadline passes, and
+// the reason is surfaced through Stats.ResourceHealth.
+type resourceCooldownState struct {
+	Until  time.Time
+	Reason string
+}
+
 // Router selects models based on request characteristics.
 type Router struct {
 	logger *slog.Logger
 	config Config
 
-	mu                    sync.RWMutex
-	auditLog              []Decision
-	stats                 Stats
-	experienceVersion     int64
-	resourceCooldownUntil map[string]time.Time
+	mu                sync.RWMutex
+	auditLog          []Decision
+	stats             Stats
+	experienceVersion int64
+	resourceCooldown  map[string]resourceCooldownState
+	resourceReadiness ResourceReadinessFunc
+}
+
+// SetResourceReadiness installs the readiness probe used to penalize
+// deployments on unreachable resources during scoring. Intended to be
+// called once during app wiring, before the router serves traffic.
+func (r *Router) SetResourceReadiness(fn ResourceReadinessFunc) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.resourceReadiness = fn
+}
+
+// resourceReady reports whether the named resource is reachable
+// according to the installed readiness probe. Defaults to ready when no
+// probe is installed or the resource ID is blank.
+func (r *Router) resourceReady(resourceID string) bool {
+	if strings.TrimSpace(resourceID) == "" {
+		return true
+	}
+	r.mu.RLock()
+	fn := r.resourceReadiness
+	r.mu.RUnlock()
+	if fn == nil {
+		return true
+	}
+	return fn(resourceID)
 }
 
 func cloneModels(in []Model) []Model {
@@ -216,11 +256,13 @@ func NewRouter(logger *slog.Logger, config Config) *Router {
 			ResourceCounts:   make(map[string]int64),
 			DeploymentStats:  make(map[string]DeploymentStats),
 		},
-		resourceCooldownUntil: make(map[string]time.Time),
+		resourceCooldown: make(map[string]resourceCooldownState),
 	}
 }
 
-const resourceTimeoutCooldown = 2 * time.Minute
+// resourceCooldownDuration is how long routing avoids a resource after
+// a cooldown-worthy failure (timeout, overload, or connection failure).
+const resourceCooldownDuration = 2 * time.Minute
 
 // ContextWindowForModel returns the context window size for the named
 // model. If the model is not found in the router's configuration, it
@@ -608,9 +650,23 @@ func (r *Router) selectModel(cfg Config, req Request, decision *Decision) string
 			}
 		}
 
+		// Resource health penalties. Both are soft penalties rather than
+		// disqualifiers so that routing still returns a best-effort pick
+		// when every resource is impaired. The magnitudes are chosen
+		// against the rest of the scoring table: positive bonuses stack to
+		// at most ~+145, and FactorLocalOnly penalizes paid models -200,
+		// so a penalty must exceed ~350 to guarantee a dead local runner
+		// loses to a live paid model even under local-first pressure.
+		// Cooldown (one bad request, self-expiring) stays gentler than
+		// unreachable (the health layer actively probing the runner and
+		// failing), preserving down < cooled < healthy ordering.
 		if until := r.resourceCooldownDeadline(m.ResourceID); !until.IsZero() && now.Before(until) {
-			score -= 100
+			score -= 300
 			rulesMatched = append(rulesMatched, "resource_timeout_cooldown_"+m.Name)
+		}
+		if !r.resourceReady(m.ResourceID) {
+			score -= 500
+			rulesMatched = append(rulesMatched, "resource_unreachable_"+m.Name)
 		}
 
 		if delta, reasons := experienceScore(r.deploymentExperience(m.Name), req); delta != 0 {
@@ -678,7 +734,7 @@ func (r *Router) RecordOutcome(requestID string, latencyMs int64, tokensUsed int
 				r.stats.SuccessCount++
 				meta.Successes++
 				if resource != "" {
-					delete(r.resourceCooldownUntil, resource)
+					delete(r.resourceCooldown, resource)
 				}
 			} else {
 				r.stats.FailureCount++
@@ -697,8 +753,11 @@ func (r *Router) RecordOutcome(requestID string, latencyMs int64, tokensUsed int
 
 // RecordFailure updates a failed routing outcome and optionally applies
 // a temporary resource cooldown so automatic routing can avoid a runner
-// that is timing out on real chat traffic.
-func (r *Router) RecordFailure(requestID string, latencyMs int64, tokensUsed int, resourceTimeout bool) {
+// that is failing on real chat traffic. cooldownReason carries the
+// failure class from [ClassifyResourceFailure] (e.g. "recent timeout",
+// "recent connection failure"); an empty string records the failure
+// without cooling the resource.
+func (r *Router) RecordFailure(requestID string, latencyMs int64, tokensUsed int, cooldownReason string) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
@@ -720,8 +779,11 @@ func (r *Router) RecordFailure(requestID string, latencyMs int64, tokensUsed int
 			meta.AvgTokensUsed = weightedAverage(meta.AvgTokensUsed, outcomes, int64(tokensUsed))
 			r.stats.DeploymentStats[model] = meta
 
-			if resourceTimeout && resource != "" {
-				r.resourceCooldownUntil[resource] = time.Now().Add(resourceTimeoutCooldown)
+			if cooldownReason != "" && resource != "" {
+				r.resourceCooldown[resource] = resourceCooldownState{
+					Until:  time.Now().Add(resourceCooldownDuration),
+					Reason: cooldownReason,
+				}
 			}
 			r.experienceVersion++
 			break
@@ -789,7 +851,7 @@ func (r *Router) GetStats() Stats {
 		FailureCount:     r.stats.FailureCount,
 		ProviderCounts:   cloneInt64Map(r.stats.ProviderCounts),
 		ResourceCounts:   cloneInt64Map(r.stats.ResourceCounts),
-		ResourceHealth:   activeResourceHealthSnapshot(r.resourceCooldownUntil, time.Now()),
+		ResourceHealth:   activeResourceHealthSnapshot(r.resourceCooldown, time.Now()),
 		DeploymentStats:  cloneDeploymentStatsMap(r.stats.DeploymentStats),
 	}
 }
@@ -828,21 +890,21 @@ func (r *Router) resourceCooldownDeadline(resource string) time.Time {
 	}
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	return r.resourceCooldownUntil[resource]
+	return r.resourceCooldown[resource].Until
 }
 
-func activeResourceHealthSnapshot(in map[string]time.Time, now time.Time) map[string]ResourceHealth {
+func activeResourceHealthSnapshot(in map[string]resourceCooldownState, now time.Time) map[string]ResourceHealth {
 	if len(in) == 0 {
 		return nil
 	}
 	out := make(map[string]ResourceHealth)
-	for resource, until := range in {
-		if until.IsZero() || !until.After(now) {
+	for resource, cd := range in {
+		if cd.Until.IsZero() || !cd.Until.After(now) {
 			continue
 		}
 		out[resource] = ResourceHealth{
-			CooldownUntil:  until,
-			CooldownReason: "recent timeout",
+			CooldownUntil:  cd.Until,
+			CooldownReason: cd.Reason,
 		}
 	}
 	if len(out) == 0 {

--- a/internal/model/router/router_test.go
+++ b/internal/model/router/router_test.go
@@ -680,7 +680,7 @@ func TestRecordFailureTimeoutCoolsResourceAndShiftsRouting(t *testing.T) {
 		t.Fatalf("Route() selected %q, want %q", model, "edge-primary/qwen3:8b")
 	}
 
-	r.RecordFailure(decision.RequestID, 5000, 0, true)
+	r.RecordFailure(decision.RequestID, 5000, 0, CooldownReasonTimeout)
 
 	stats := r.GetStats()
 	depStats := stats.DeploymentStats["edge-primary/qwen3:8b"]
@@ -735,7 +735,7 @@ func TestRecordFailureWithoutTimeoutDoesNotCoolResource(t *testing.T) {
 		t.Fatalf("Route() selected %q, want %q", model, "edge/qwen3:8b")
 	}
 
-	r.RecordFailure(decision.RequestID, 250, 0, false)
+	r.RecordFailure(decision.RequestID, 250, 0, "")
 
 	if until := r.resourceCooldownDeadline("edge"); !until.IsZero() {
 		t.Fatalf("resource cooldown unexpectedly set: %v", until)
@@ -774,7 +774,10 @@ func TestRecordOutcomeSuccessClearsResourceCooldown(t *testing.T) {
 		t.Fatalf("Route() selected %q, want %q", model, "edge/qwen3:8b")
 	}
 
-	r.resourceCooldownUntil["edge"] = time.Now().Add(time.Minute)
+	r.resourceCooldown["edge"] = resourceCooldownState{
+		Until:  time.Now().Add(time.Minute),
+		Reason: CooldownReasonTimeout,
+	}
 	r.RecordOutcome(decision.RequestID, 120, 600, true)
 
 	if until := r.resourceCooldownDeadline("edge"); !until.IsZero() {
@@ -786,9 +789,9 @@ func TestGetStatsIncludesOnlyActiveResourceHealth(t *testing.T) {
 	t.Parallel()
 
 	now := time.Now()
-	stats := activeResourceHealthSnapshot(map[string]time.Time{
-		"edge":  now.Add(2 * time.Minute),
-		"stale": now.Add(-time.Second),
+	stats := activeResourceHealthSnapshot(map[string]resourceCooldownState{
+		"edge":  {Until: now.Add(2 * time.Minute), Reason: CooldownReasonConnection},
+		"stale": {Until: now.Add(-time.Second), Reason: CooldownReasonTimeout},
 		"blank": {},
 	}, now)
 
@@ -799,8 +802,8 @@ func TestGetStatsIncludesOnlyActiveResourceHealth(t *testing.T) {
 	if !ok {
 		t.Fatal("missing active resource health for edge")
 	}
-	if health.CooldownReason != "recent timeout" {
-		t.Fatalf("CooldownReason = %q, want %q", health.CooldownReason, "recent timeout")
+	if health.CooldownReason != CooldownReasonConnection {
+		t.Fatalf("CooldownReason = %q, want %q", health.CooldownReason, CooldownReasonConnection)
 	}
 	if !health.CooldownUntil.After(now) {
 		t.Fatalf("CooldownUntil = %v, want future time", health.CooldownUntil)

--- a/internal/runtime/agent/loop.go
+++ b/internal/runtime/agent/loop.go
@@ -1657,7 +1657,7 @@ func (l *Loop) Run(ctx context.Context, req *Request, stream StreamCallback) (re
 		if err != nil {
 			// Record failed outcome
 			if l.router != nil && liteDecision != nil {
-				l.router.RecordFailure(liteDecision.RequestID, time.Since(startTime).Milliseconds(), 0, isTimeout(err))
+				l.router.RecordFailure(liteDecision.RequestID, time.Since(startTime).Milliseconds(), 0, router.ClassifyResourceFailure(err))
 			}
 			return nil, fmt.Errorf("lightweight completion: %w", err)
 		}
@@ -2446,7 +2446,7 @@ func (l *Loop) Run(ctx context.Context, req *Request, stream StreamCallback) (re
 	if err != nil {
 		if l.router != nil && routerDecision != nil {
 			latency := time.Since(startTime).Milliseconds()
-			l.router.RecordFailure(routerDecision.RequestID, latency, l.memory.GetTokenCount(convID), isTimeout(err))
+			l.router.RecordFailure(routerDecision.RequestID, latency, l.memory.GetTokenCount(convID), router.ClassifyResourceFailure(err))
 		}
 		return nil, err
 	}

--- a/internal/state/memory/summarizer.go
+++ b/internal/state/memory/summarizer.go
@@ -384,7 +384,7 @@ func (w *SummarizerWorker) summarizeSession(ctx context.Context, sess *Session) 
 		hints[router.FactorModelPreference] = w.config.ModelPreference
 	}
 
-	model, _ := w.router.Route(ctx, router.Request{
+	model, decision := w.router.Route(ctx, router.Request{
 		Query:          "session metadata generation",
 		Priority:       router.PriorityBackground,
 		RoutingFactors: hints,
@@ -408,8 +408,17 @@ func (w *SummarizerWorker) summarizeSession(ctx context.Context, sess *Session) 
 	prompt := prompts.MetadataPrompt(transcript)
 	msgs := []llm.Message{{Role: "user", Content: prompt}}
 
+	chatStart := time.Now()
 	resp, err := w.llmClient.Chat(ctx, model, msgs, nil)
 	if err != nil {
+		// Report the failure so the router can cool the resource and
+		// steer later sessions elsewhere. Without this, an unreachable
+		// runner gets re-selected for every session in the backlog.
+		if decision != nil {
+			w.router.RecordFailure(decision.RequestID,
+				time.Since(chatStart).Milliseconds(), 0,
+				router.ClassifyResourceFailure(err))
+		}
 		w.logger.Warn("failed to generate session metadata",
 			"session", ShortID(sess.ID),
 			"model", model,
@@ -419,6 +428,11 @@ func (w *SummarizerWorker) summarizeSession(ctx context.Context, sess *Session) 
 		// consumed router budget, and the caller should still
 		// rate-limit before the next session.
 		return true
+	}
+	if decision != nil {
+		w.router.RecordOutcome(decision.RequestID,
+			time.Since(chatStart).Milliseconds(),
+			resp.InputTokens+resp.OutputTokens, true)
 	}
 
 	meta, title, tags := parseMetadataResponse(resp.Message.Content, toolUsage, w.logger)

--- a/internal/state/memory/summarizer_test.go
+++ b/internal/state/memory/summarizer_test.go
@@ -825,3 +825,105 @@ func TestWorker_ArchivistEnqueueFailureStillSummarizes(t *testing.T) {
 		t.Error("enqueue failure must not block metadata generation; expected an LLM call, got 0")
 	}
 }
+
+// unreachableLLMClient fails the way a dead runner does: a fast
+// connection-class error rather than an application-level one.
+type unreachableLLMClient struct {
+	calls atomic.Int64
+}
+
+func (m *unreachableLLMClient) Chat(_ context.Context, _ string, _ []llm.Message, _ []map[string]any) (*llm.ChatResponse, error) {
+	m.calls.Add(1)
+	return nil, fmt.Errorf("request failed: Post \"http://spark.example:11434/api/chat\": dial tcp: lookup spark.example: no such host")
+}
+
+func (m *unreachableLLMClient) ChatStream(ctx context.Context, model string, msgs []llm.Message, tools []map[string]any, _ llm.StreamCallback) (*llm.ChatResponse, error) {
+	return m.Chat(ctx, model, msgs, tools)
+}
+
+func (m *unreachableLLMClient) Ping(_ context.Context) error { return nil }
+
+// newResourceTestRouter is newTestRouter with a resource identity so
+// cooldown assertions have a resource to look up.
+func newResourceTestRouter() *router.Router {
+	return router.NewRouter(slog.Default(), router.Config{
+		DefaultModel: "test-model",
+		Models: []router.Model{
+			{
+				Name:       "test-model",
+				Provider:   "ollama",
+				ResourceID: "test-resource",
+				Quality:    5,
+				Speed:      8,
+				CostTier:   0,
+			},
+		},
+	})
+}
+
+// The summarizer must report Chat outcomes to the router: successes so
+// cooldowns clear, failures so an unreachable runner cools down instead
+// of being re-selected for every session in the backlog.
+func TestSummarizeSessionReportsRouterOutcomes(t *testing.T) {
+	cfg := SummarizerConfig{
+		Interval:     time.Hour,
+		Timeout:      10 * time.Second,
+		PauseBetween: 1 * time.Millisecond,
+		BatchSize:    10,
+	}
+
+	t.Run("success records outcome", func(t *testing.T) {
+		store := newTestStore(t)
+		rtr := newResourceTestRouter()
+		sess := createUnsummarizedSession(t, store, "conv-outcome-ok")
+		w := NewSummarizerWorker(store, &mockLLMClient{}, rtr, slog.Default(), cfg)
+
+		w.summarizeSession(context.Background(), sess)
+
+		stats := rtr.GetStats()
+		if stats.SuccessCount != 1 {
+			t.Fatalf("SuccessCount = %d, want 1", stats.SuccessCount)
+		}
+		if stats.FailureCount != 0 {
+			t.Fatalf("FailureCount = %d, want 0", stats.FailureCount)
+		}
+	})
+
+	t.Run("connection failure records failure and cools resource", func(t *testing.T) {
+		store := newTestStore(t)
+		rtr := newResourceTestRouter()
+		sess := createUnsummarizedSession(t, store, "conv-outcome-down")
+		w := NewSummarizerWorker(store, &unreachableLLMClient{}, rtr, slog.Default(), cfg)
+
+		w.summarizeSession(context.Background(), sess)
+
+		stats := rtr.GetStats()
+		if stats.FailureCount != 1 {
+			t.Fatalf("FailureCount = %d, want 1", stats.FailureCount)
+		}
+		health, ok := stats.ResourceHealth["test-resource"]
+		if !ok {
+			t.Fatalf("resource not cooled after connection failure; ResourceHealth = %#v", stats.ResourceHealth)
+		}
+		if health.CooldownReason != router.CooldownReasonConnection {
+			t.Fatalf("CooldownReason = %q, want %q", health.CooldownReason, router.CooldownReasonConnection)
+		}
+	})
+
+	t.Run("application error records failure without cooldown", func(t *testing.T) {
+		store := newTestStore(t)
+		rtr := newResourceTestRouter()
+		sess := createUnsummarizedSession(t, store, "conv-outcome-apperr")
+		w := NewSummarizerWorker(store, &failingLLMClient{}, rtr, slog.Default(), cfg)
+
+		w.summarizeSession(context.Background(), sess)
+
+		stats := rtr.GetStats()
+		if stats.FailureCount != 1 {
+			t.Fatalf("FailureCount = %d, want 1", stats.FailureCount)
+		}
+		if len(stats.ResourceHealth) != 0 {
+			t.Fatalf("application-level failure must not cool resources; ResourceHealth = %#v", stats.ResourceHealth)
+		}
+	})
+}

--- a/internal/tools/model_registry_tools.go
+++ b/internal/tools/model_registry_tools.go
@@ -201,7 +201,7 @@ func (r *Registry) registerModelRegistryTools() {
 
 	r.Register(&Tool{
 		Name:        "model_route_explain",
-		Description: "Explain how Thane would route a hypothetical request right now using the live registry, live learned experience, and live transient cooldown state. Returns the chosen deployment plus rejected candidates and reasons without mutating router stats or audit history.",
+		Description: "Explain how Thane would route a hypothetical request right now using the live registry, live learned experience, live transient cooldown state, and live resource reachability (deployments on runners the health layer reports down are heavily penalized — look for resource_unreachable_* in rules_matched). Returns the chosen deployment plus rejected candidates and reasons without mutating router stats or audit history.",
 		Parameters: map[string]any{
 			"type": "object",
 			"properties": map[string]any{

--- a/scripts/architecture.baseline
+++ b/scripts/architecture.baseline
@@ -1,5 +1,5 @@
 packages=67
 interfaces=83
 large_files=53
-set_mutators=116
+set_mutators=117
 database_opens=9


### PR DESCRIPTION
First PR of the #1334 arc. During the 2026-07-30 router-swap outage, connwatch marked `ollama:spark` down within a minute and probed it faithfully every 60 seconds — while the request plane, deaf to that signal, kept routing traffic at the dead runner all afternoon (306 doomed requests in one observed hour, most from the session-metadata summarizer whose `local_only` factors exist precisely to prefer that runner). The health machinery below routing was sound; nothing above it listened. This PR closes that loop from three directions.

## Routing scoring consults live readiness

`Router.SetResourceReadiness` installs a probe wired from the connwatch watchers at app init. A deployment on a confirmed-down resource takes a **−500** scoring penalty. The magnitude is arithmetic, not vibes: positive bonuses stack to at most ~+145 and `FactorLocalOnly` penalizes paid models −200, so anything weaker than ~350 can leave a dead local runner still beating a live paid model under local-first pressure — which is exactly the failure mode we watched in prod. The penalty is soft rather than an eligibility filter, so a fully-down fleet still yields a best-effort selection instead of an error. Unknown state (no watcher — anthropic; first probe pending — boot) reads as ready: only a confirmed-down resource is penalized. Decisions carry a `resource_unreachable_*` marker in `rules_matched`, and `model_route_explain`'s description now teaches the new dimension.

## Cooldowns engage on connection-class failures

Cooldowns previously triggered only when the failure string-matched a timeout. A runner whose hostname stops resolving fails in *milliseconds* — so the fast failures that most clearly indicate a dead resource never cooled it. `ClassifyResourceFailure` now maps request errors to a cooldown reason: DNS, connection refused/reset, and unreachable-host errors cool the resource just like timeouts and Anthropic overload signals, while caller cancellation and application-level errors stay neutral. `RecordFailure` takes the reason string in place of the old bool, cooldown entries carry their reason into `Stats.ResourceHealth` (visible via the model-registry tools), and the cooldown penalty rises from −100 to −300 — the old value could never actually divert traffic under `local_only`, by the same arithmetic as above. Ordering is preserved: down (−500) < cooled (−300) < healthy.

## The summarizer reports outcomes

The component that hammered the dead runner hardest routed through the router but never told it what happened. It now records successes and failures (with classification) against its routing decisions, so its failures cool the resource and steer the rest of the backlog elsewhere. Graceful degradation follows from the factors it already sets: with the local runner down, quality floor 7 lands on a paid model rather than silently producing nothing. The compactor and media summarizer share this gap at smaller blast radius; noted in #1334, deliberately out of scope here.

## Testing

- `readiness_test.go` reproduces the prod shape: local `gpt-oss:120b` on `spark` vs paid sonnet under the summarizer's exact factors — down-resource loses, up-resource keeps local preference, nil func is neutral, all-down still selects.
- `failure_class_test.go` covers the classifier table: wrapped `*net.DNSError`, `ECONNREFUSED`/`EHOSTUNREACH`/`ECONNRESET` via `net.OpError`, stringified variants that crossed non-wrapping boundaries, timeout/overload/529, and the must-stay-neutral cases (cancellation, HTTP 400, plain errors).
- Summarizer tests assert both directions: connection failure → `FailureCount` + cooldown with reason; application error → failure without cooldown; success → `SuccessCount`.
- `just ci` green (architecture baseline regenerated for the one new mutator).

## Test plan

- [x] Router unit tests: readiness penalties, cooldown reasons, classifier table
- [x] Summarizer outcome-reporting tests (success / connection failure / application error)
- [x] Full `just ci` gate locally
- [ ] Prod validation after deploy: take spark offline, confirm summarizer sessions fail over to a paid model within one cooldown window and `model_registry_summary` shows the cooldown reason

Refs #1334

🤖 Generated with [Claude Code](https://claude.com/claude-code)
