### PR TITLE
feat(ha): adapt to HA 2026.8 single-config-entry devices

### DIFF
--- a/internal/integrations/homeassistant/configapi.go
+++ b/internal/integrations/homeassistant/configapi.go
@@ -51,8 +51,18 @@ type ConfigEntry struct {
 }
 
 // DeviceRegistryEntry represents a Home Assistant device registry row.
+//
+// Since HA 2026.8 a device belongs to exactly one config entry (and at
+// most one subentry): ConfigEntryID / ConfigSubentryID are the
+// authoritative ownership fields, while ConfigEntries,
+// ConfigEntriesSubentry, and PrimaryConfigEntry are deprecated
+// compatibility shims HA removes in 2027.8. Read ownership through
+// [DeviceRegistryEntry.OwningConfigEntry], which encodes the fallback
+// chain for pre-2026.8 servers.
 type DeviceRegistryEntry struct {
 	ID                    string               `json:"id"`
+	ConfigEntryID         string               `json:"config_entry_id"`
+	ConfigSubentryID      string               `json:"config_subentry_id"`
 	ConfigEntries         []string             `json:"config_entries"`
 	ConfigEntriesSubentry map[string][]*string `json:"config_entries_subentries"`
 	Connections           [][]flexString       `json:"connections"`
@@ -72,6 +82,23 @@ type DeviceRegistryEntry struct {
 	DisabledBy            string               `json:"disabled_by"`
 	ConfigurationURL      string               `json:"configuration_url"`
 	PrimaryConfigEntry    string               `json:"primary_config_entry"`
+}
+
+// OwningConfigEntry returns the config entry id that owns this device,
+// preferring the authoritative singular field (HA 2026.8+) and falling
+// back through the deprecated primary/collection fields for older
+// servers. Returns "" when the device has no config entry at all.
+func (d DeviceRegistryEntry) OwningConfigEntry() string {
+	if d.ConfigEntryID != "" {
+		return d.ConfigEntryID
+	}
+	if d.PrimaryConfigEntry != "" {
+		return d.PrimaryConfigEntry
+	}
+	if len(d.ConfigEntries) > 0 {
+		return d.ConfigEntries[0]
+	}
+	return ""
 }
 
 // flexString is a string field that tolerates a JSON value that is a string,

--- a/internal/integrations/homeassistant/device_registry_test.go
+++ b/internal/integrations/homeassistant/device_registry_test.go
@@ -133,6 +133,79 @@ func TestDeviceRegistryEntry_AllIntegrationFieldsTolerateNumbers(t *testing.T) {
 	}
 }
 
+// TestDeviceRegistryEntry_SingularOwnershipFieldsDecode pins the HA
+// 2026.8 registry shape: the singular config_entry_id/config_subentry_id
+// ownership fields decode alongside the deprecated collection fields,
+// which HA keeps emitting as compatibility shims until 2027.8.
+func TestDeviceRegistryEntry_SingularOwnershipFieldsDecode(t *testing.T) {
+	raw := `[{
+		"id":"a",
+		"name":"Split Device",
+		"config_entry_id":"entry_1",
+		"config_subentry_id":"sub_1",
+		"config_entries":["entry_1"],
+		"config_entries_subentries":{"entry_1":["sub_1"]},
+		"primary_config_entry":"entry_1"
+	}]`
+	var devices []DeviceRegistryEntry
+	if err := json.Unmarshal([]byte(raw), &devices); err != nil {
+		t.Fatalf("decode device list: %v", err)
+	}
+	if devices[0].ConfigEntryID != "entry_1" {
+		t.Errorf("ConfigEntryID = %q, want entry_1", devices[0].ConfigEntryID)
+	}
+	if devices[0].ConfigSubentryID != "sub_1" {
+		t.Errorf("ConfigSubentryID = %q, want sub_1", devices[0].ConfigSubentryID)
+	}
+}
+
+// TestDeviceRegistryEntry_OwningConfigEntry pins the ownership fallback
+// chain: the authoritative singular field (2026.8+) wins, then the
+// deprecated primary field, then the first collection element, so the
+// same reader works against both current and pre-2026.8 servers.
+func TestDeviceRegistryEntry_OwningConfigEntry(t *testing.T) {
+	cases := []struct {
+		name   string
+		device DeviceRegistryEntry
+		want   string
+	}{
+		{
+			name: "singular field wins over deprecated fields",
+			device: DeviceRegistryEntry{
+				ConfigEntryID:      "new",
+				PrimaryConfigEntry: "old_primary",
+				ConfigEntries:      []string{"old_first"},
+			},
+			want: "new",
+		},
+		{
+			name: "pre-2026.8 server falls back to primary",
+			device: DeviceRegistryEntry{
+				PrimaryConfigEntry: "old_primary",
+				ConfigEntries:      []string{"old_first"},
+			},
+			want: "old_primary",
+		},
+		{
+			name:   "oldest servers fall back to first config entry",
+			device: DeviceRegistryEntry{ConfigEntries: []string{"old_first", "old_second"}},
+			want:   "old_first",
+		},
+		{
+			name:   "no ownership at all",
+			device: DeviceRegistryEntry{ID: "orphan"},
+			want:   "",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.device.OwningConfigEntry(); got != tc.want {
+				t.Errorf("OwningConfigEntry() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
 // TestEntityRegistryEntry_NumericFieldsTolerated covers the entity-registry
 // counterpart: a numeric unique_id (common — integrations use raw device IDs)
 // or original_name must not fail the entity_registry/list decode. unique_id

--- a/internal/state/awareness/device_snapshot.go
+++ b/internal/state/awareness/device_snapshot.go
@@ -391,10 +391,14 @@ func describeDeviceCandidates(ctx context.Context, client DeviceSnapshotClient, 
 			domains[e.EntryID] = e.Domain
 		}
 	}
-	counts := map[string]int{}
+	wanted := make(map[string]bool, len(matches))
+	for _, d := range matches {
+		wanted[d.ID] = true
+	}
+	counts := make(map[string]int, len(matches))
 	if entities, err := client.GetEntityRegistry(ctx); err == nil {
 		for i := range entities {
-			if entities[i].DisabledBy == "" {
+			if wanted[entities[i].DeviceID] && entities[i].DisabledBy == "" {
 				counts[entities[i].DeviceID]++
 			}
 		}

--- a/internal/state/awareness/device_snapshot.go
+++ b/internal/state/awareness/device_snapshot.go
@@ -60,15 +60,15 @@ func ComputeDeviceSnapshot(ctx context.Context, client DeviceSnapshotClient, req
 	if err != nil {
 		return "", fmt.Errorf("ha_device: get device registry: %w", err)
 	}
-	device, candidates, ok := resolveDevice(devices, req.Device)
+	device, ambiguous, ok := resolveDevice(devices, req.Device)
 	if !ok {
-		if len(candidates) > 0 {
+		if len(ambiguous) > 0 {
 			return promptfmt.MarshalCompact(map[string]any{
 				"query":      req.Device,
 				"found":      false,
 				"reason":     "ambiguous",
-				"candidates": candidates,
-				"note":       "multiple devices matched; re-call with a device_id from candidates",
+				"candidates": describeDeviceCandidates(ctx, client, ambiguous),
+				"note":       "multiple devices matched — since HA 2026.8 one physical device appears once per integration, so same-name twins are expected; pick by integration and entity_count, then re-call with that device_id",
 			}), nil
 		}
 		return promptfmt.MarshalCompact(map[string]any{
@@ -327,9 +327,12 @@ func classifyDeviceChildren(children []areaMember, statesByID map[string]*homeas
 
 // resolveDevice matches a device by id, then by case-insensitive
 // user-assigned name or registry name, then by substring. It mirrors
-// resolveArea's exact-first strategy and returns candidate device_ids
-// when a substring query is ambiguous so the model can disambiguate.
-func resolveDevice(devices []homeassistant.DeviceRegistryEntry, query string) (homeassistant.DeviceRegistryEntry, []string, bool) {
+// resolveArea's exact-first strategy, but every name tier can be
+// ambiguous: since HA 2026.8 one physical device appears once per
+// integration, so even an exact name may match several registry rows.
+// Ambiguous matches are returned as entries for the caller to describe
+// so the model can disambiguate.
+func resolveDevice(devices []homeassistant.DeviceRegistryEntry, query string) (homeassistant.DeviceRegistryEntry, []homeassistant.DeviceRegistryEntry, bool) {
 	q := strings.TrimSpace(query)
 	if q == "" {
 		return homeassistant.DeviceRegistryEntry{}, nil, false
@@ -341,18 +344,20 @@ func resolveDevice(devices []homeassistant.DeviceRegistryEntry, query string) (h
 		}
 	}
 	// Exact (case-insensitive) name or user-assigned name.
-	for i := range devices {
-		if strings.EqualFold(string(devices[i].NameByUser), q) || strings.EqualFold(string(devices[i].Name), q) {
-			return devices[i], nil, true
-		}
-	}
-	// Substring on either name; collect all matches for disambiguation.
-	qLower := strings.ToLower(q)
 	var matches []int
 	for i := range devices {
-		name := strings.ToLower(deviceDisplayName(devices[i]))
-		if name != "" && strings.Contains(name, qLower) {
+		if strings.EqualFold(string(devices[i].NameByUser), q) || strings.EqualFold(string(devices[i].Name), q) {
 			matches = append(matches, i)
+		}
+	}
+	// Substring on either name only when no exact hit exists.
+	if len(matches) == 0 {
+		qLower := strings.ToLower(q)
+		for i := range devices {
+			name := strings.ToLower(deviceDisplayName(devices[i]))
+			if name != "" && strings.Contains(name, qLower) {
+				matches = append(matches, i)
+			}
 		}
 	}
 	switch len(matches) {
@@ -361,13 +366,73 @@ func resolveDevice(devices []homeassistant.DeviceRegistryEntry, query string) (h
 	case 1:
 		return devices[matches[0]], nil, true
 	default:
-		candidates := make([]string, 0, len(matches))
+		ambiguous := make([]homeassistant.DeviceRegistryEntry, 0, len(matches))
 		for _, idx := range matches {
-			candidates = append(candidates, fmt.Sprintf("%s (%s)", devices[idx].ID, deviceDisplayName(devices[idx])))
+			ambiguous = append(ambiguous, devices[idx])
 		}
-		sort.Strings(candidates)
-		return homeassistant.DeviceRegistryEntry{}, candidates, false
+		return homeassistant.DeviceRegistryEntry{}, ambiguous, false
 	}
+}
+
+// describeDeviceCandidates renders ambiguous device matches with enough
+// identity to choose between them. Post-2026.8 duplicates usually share
+// their name exactly (the same hardware split into one device per
+// integration), so the name alone cannot disambiguate — each candidate
+// carries its owning integration and enabled-entity count, which is how
+// the twins actually differ (the native integration holds the controls,
+// a presence tracker holds one or two entities). Enrichment is
+// best-effort: a failed registry read omits the field rather than
+// failing resolution. Candidates are ordered richest-first because the
+// copy with the most entities is usually the one the model wants.
+func describeDeviceCandidates(ctx context.Context, client DeviceSnapshotClient, matches []homeassistant.DeviceRegistryEntry) []map[string]any {
+	domains := map[string]string{}
+	if entries, err := client.GetConfigEntries(ctx); err == nil {
+		for _, e := range entries {
+			domains[e.EntryID] = e.Domain
+		}
+	}
+	counts := map[string]int{}
+	if entities, err := client.GetEntityRegistry(ctx); err == nil {
+		for i := range entities {
+			if entities[i].DisabledBy == "" {
+				counts[entities[i].DeviceID]++
+			}
+		}
+	}
+	type candidate struct {
+		id     string
+		name   string
+		count  int
+		domain string
+	}
+	ranked := make([]candidate, 0, len(matches))
+	for _, d := range matches {
+		ranked = append(ranked, candidate{
+			id:     d.ID,
+			name:   deviceDisplayName(d),
+			count:  counts[d.ID],
+			domain: domains[d.OwningConfigEntry()],
+		})
+	}
+	sort.Slice(ranked, func(i, j int) bool {
+		if ranked[i].count != ranked[j].count {
+			return ranked[i].count > ranked[j].count
+		}
+		return ranked[i].id < ranked[j].id
+	})
+	out := make([]map[string]any, 0, len(ranked))
+	for _, c := range ranked {
+		m := map[string]any{
+			"device_id":    c.id,
+			"name":         c.name,
+			"entity_count": c.count,
+		}
+		if c.domain != "" {
+			m["integration"] = c.domain
+		}
+		out = append(out, m)
+	}
+	return out
 }
 
 // deviceDisplayName prefers the user-assigned name, then the registry
@@ -384,17 +449,14 @@ func deviceDisplayName(device homeassistant.DeviceRegistryEntry) string {
 }
 
 // deviceIntegration resolves the device's owning integration (config
-// entry domain) from the primary config entry, falling back to the
-// first config entry. Returns "" when the device has no config entry or
-// the registry can't be read — integration is enrichment, not load-
-// bearing, so a fetch failure just omits it.
+// entry domain) via [homeassistant.DeviceRegistryEntry.OwningConfigEntry].
+// Returns "" when the device has no config entry or the registry can't
+// be read — integration is enrichment, not load-bearing, so a fetch
+// failure just omits it.
 func deviceIntegration(ctx context.Context, client DeviceSnapshotClient, device homeassistant.DeviceRegistryEntry) string {
-	entryID := device.PrimaryConfigEntry
+	entryID := device.OwningConfigEntry()
 	if entryID == "" {
-		if len(device.ConfigEntries) == 0 {
-			return ""
-		}
-		entryID = device.ConfigEntries[0]
+		return ""
 	}
 	entries, err := client.GetConfigEntries(ctx)
 	if err != nil {

--- a/internal/state/awareness/device_snapshot_test.go
+++ b/internal/state/awareness/device_snapshot_test.go
@@ -285,6 +285,9 @@ func TestComputeDeviceSnapshot_ExactNameTwinsAmbiguous(t *testing.T) {
 			{EntityID: "fan.office", DeviceID: "dev_fan"},
 			{EntityID: "light.office_fan", DeviceID: "dev_fan"},
 			{EntityID: "sensor.office_fan_rpm", DeviceID: "dev_fan", DisabledBy: "user"},
+			// Foreign-device noise: counting is scoped to the matched
+			// twins, so this row must not appear anywhere in candidates.
+			{EntityID: "light.hall", DeviceID: "dev_other"},
 		},
 	}
 

--- a/internal/state/awareness/device_snapshot_test.go
+++ b/internal/state/awareness/device_snapshot_test.go
@@ -261,6 +261,99 @@ func TestComputeDeviceSnapshot_AmbiguousName(t *testing.T) {
 	}
 }
 
+// TestComputeDeviceSnapshot_ExactNameTwinsAmbiguous is the HA 2026.8
+// regression: one physical device now appears once per integration, so
+// an EXACT name can match several registry rows. Resolution must refuse
+// to pick a row silently and instead return candidates the model can
+// choose between — attributed with the owning integration and enabled
+// entity count, richest twin first (that copy is usually the one that
+// holds the controls).
+func TestComputeDeviceSnapshot_ExactNameTwinsAmbiguous(t *testing.T) {
+	client := &fakeDeviceClient{
+		devices: []homeassistant.DeviceRegistryEntry{
+			// Presence-tracker twin first in registry order: pre-2026.8
+			// first-match-wins would have silently returned this one.
+			{ID: "dev_net", Name: "Office Ceiling Fan", ConfigEntryID: "cfg_net"},
+			{ID: "dev_fan", Name: "Office Ceiling Fan", ConfigEntryID: "cfg_fan"},
+		},
+		configs: []homeassistant.ConfigEntry{
+			{EntryID: "cfg_net", Domain: "unifi"},
+			{EntryID: "cfg_fan", Domain: "baf"},
+		},
+		entities: []homeassistant.EntityRegistryEntry{
+			{EntityID: "device_tracker.fan", DeviceID: "dev_net"},
+			{EntityID: "fan.office", DeviceID: "dev_fan"},
+			{EntityID: "light.office_fan", DeviceID: "dev_fan"},
+			{EntityID: "sensor.office_fan_rpm", DeviceID: "dev_fan", DisabledBy: "user"},
+		},
+	}
+
+	out, err := ComputeDeviceSnapshot(context.Background(), client, DeviceSnapshotRequest{Device: "office ceiling fan"}, testNow)
+	if err != nil {
+		t.Fatalf("ComputeDeviceSnapshot: %v", err)
+	}
+	payload := decodeDevicePayload(t, out)
+	if payload["found"] != false || payload["reason"] != "ambiguous" {
+		t.Fatalf("expected ambiguous, got %#v", payload)
+	}
+
+	cands, _ := payload["candidates"].([]any)
+	if len(cands) != 2 {
+		t.Fatalf("candidates = %#v, want 2", payload["candidates"])
+	}
+	first, _ := cands[0].(map[string]any)
+	second, _ := cands[1].(map[string]any)
+	// Richest twin leads: the native integration's copy with 2 enabled
+	// entities (the disabled one must not count).
+	if first["device_id"] != "dev_fan" || first["integration"] != "baf" || first["entity_count"] != float64(2) {
+		t.Errorf("first candidate = %#v, want dev_fan/baf/2", first)
+	}
+	if second["device_id"] != "dev_net" || second["integration"] != "unifi" || second["entity_count"] != float64(1) {
+		t.Errorf("second candidate = %#v, want dev_net/unifi/1", second)
+	}
+}
+
+// TestDeviceIntegration_PrefersSingularOwnershipField pins the 2026.8
+// migration: integration attribution reads config_entry_id first and
+// only falls back to the deprecated primary_config_entry (removed
+// upstream in 2027.8) for older servers.
+func TestDeviceIntegration_PrefersSingularOwnershipField(t *testing.T) {
+	client := &fakeDeviceClient{
+		configs: []homeassistant.ConfigEntry{
+			{EntryID: "cfg_new", Domain: "baf"},
+			{EntryID: "cfg_old", Domain: "unifi"},
+		},
+	}
+	cases := []struct {
+		name   string
+		device homeassistant.DeviceRegistryEntry
+		want   string
+	}{
+		{
+			name:   "2026.8 server: singular field wins",
+			device: homeassistant.DeviceRegistryEntry{ConfigEntryID: "cfg_new", PrimaryConfigEntry: "cfg_old"},
+			want:   "baf",
+		},
+		{
+			name:   "pre-2026.8 server: primary fallback",
+			device: homeassistant.DeviceRegistryEntry{PrimaryConfigEntry: "cfg_old"},
+			want:   "unifi",
+		},
+		{
+			name:   "no ownership: enrichment omitted",
+			device: homeassistant.DeviceRegistryEntry{ID: "orphan"},
+			want:   "",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := deviceIntegration(context.Background(), client, tc.device); got != tc.want {
+				t.Errorf("deviceIntegration = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestComputeDeviceSnapshot_NotFound(t *testing.T) {
 	client := &fakeDeviceClient{
 		devices: []homeassistant.DeviceRegistryEntry{{ID: "dev_a", Name: "Thermostat"}},

--- a/internal/state/awareness/device_snapshot_tool.go
+++ b/internal/state/awareness/device_snapshot_tool.go
@@ -53,6 +53,8 @@ func (a *DeviceSnapshotTools) Tools() []*tools.Tool {
 				"Use this to understand a physical device as a whole — 'show me the thermostat device', " +
 				"'what does the front-door sensor expose', 'is this device healthy' — rather than fetching one entity at a time. " +
 				"Resolves by device_id or by name (user-assigned or registry name, with substring fallback; returns candidates when ambiguous). " +
+				"Since HA 2026.8 one physical device appears as a separate registry device per integration, so same-name twins are expected, not corruption — " +
+				"ambiguous candidates carry integration and entity_count so you can pick (the native integration's copy holds the controls; a presence tracker's copy holds one or two entities). " +
 				"Add include for per-entity area/device/label/description/visibility metadata.",
 			Parameters: map[string]any{
 				"type": "object",

--- a/internal/tools/ha_automation_tools_test.go
+++ b/internal/tools/ha_automation_tools_test.go
@@ -35,6 +35,7 @@ type fakeHAServer struct {
 	labels          []map[string]any
 	categories      map[string][]map[string]any
 	devices         []map[string]any
+	configEntries   []map[string]any
 	entityRows      []map[string]any
 	entityByID      map[string]map[string]any
 	logbook         []map[string]any
@@ -292,6 +293,11 @@ func (f *fakeHAServer) wsResult(msgType string, msg map[string]any) (any, bool) 
 		return f.categories[scope], true
 	case "config/device_registry/list":
 		return f.devices, true
+	case "config_entries/get":
+		if f.configEntries == nil {
+			return []map[string]any{}, true
+		}
+		return f.configEntries, true
 	case "config/entity_registry/list":
 		return f.entityRows, true
 	case "config/entity_registry/get":

--- a/internal/tools/ha_call_service_target.go
+++ b/internal/tools/ha_call_service_target.go
@@ -110,10 +110,13 @@ func (r *Registry) resolveServiceTarget(ctx context.Context, raw map[string]any)
 }
 
 // registryTargetEntry is one resolvable row of a registry: its ID plus
-// the names and aliases a caller may reference it by.
+// the names and aliases a caller may reference it by. desc is optional
+// disambiguation context surfaced when several rows match one name —
+// for devices it carries the owning integration's domain.
 type registryTargetEntry struct {
 	id      string
 	matches []string
+	desc    string
 }
 
 // resolveRegistryTargets resolves every value for one registry-backed
@@ -133,30 +136,53 @@ func (r *Registry) resolveRegistryTargets(ctx context.Context, key string, value
 
 	out := make([]string, 0, len(values))
 	for _, v := range values {
-		id, ok := matchRegistryTarget(entries, v)
-		if !ok {
+		hits := matchRegistryTarget(entries, v)
+		switch len(hits) {
+		case 0:
 			return nil, fmt.Errorf("unknown %s %q; known %ss: %s", kind, v, kind, joinCapped(names, 15))
+		case 1:
+			out = append(out, hits[0].id)
+		default:
+			descs := make([]string, 0, len(hits))
+			for _, h := range hits {
+				if h.desc != "" {
+					descs = append(descs, fmt.Sprintf("%s (%s)", h.id, h.desc))
+				} else {
+					descs = append(descs, h.id)
+				}
+			}
+			hint := ""
+			if kind == "device" {
+				hint = " — since HA 2026.8 one physical device appears once per integration, so same-name twins are expected; pick the integration you mean"
+			}
+			return nil, fmt.Errorf("%s %q matches %d %ss%s: %s; re-call targeting the intended id", kind, v, len(hits), kind, hint, strings.Join(descs, ", "))
 		}
-		out = append(out, id)
 	}
 	return out, nil
 }
 
-func matchRegistryTarget(entries []registryTargetEntry, value string) (string, bool) {
+// matchRegistryTarget resolves value against a registry: an exact id
+// wins outright, otherwise every entry whose name or alias matches
+// case-insensitively is collected. Multiple hits are a real outcome for
+// devices (one physical device appears once per integration since HA
+// 2026.8) and the caller must refuse to pick a row arbitrarily.
+func matchRegistryTarget(entries []registryTargetEntry, value string) []registryTargetEntry {
 	for _, e := range entries {
 		if e.id == value {
-			return e.id, true
+			return []registryTargetEntry{e}
 		}
 	}
 	lower := strings.ToLower(value)
+	var hits []registryTargetEntry
 	for _, e := range entries {
 		for _, m := range e.matches {
 			if strings.ToLower(m) == lower {
-				return e.id, true
+				hits = append(hits, e)
+				break
 			}
 		}
 	}
-	return "", false
+	return hits
 }
 
 func (r *Registry) registryTargetEntries(ctx context.Context, key string) ([]registryTargetEntry, string, error) {
@@ -196,9 +222,27 @@ func (r *Registry) registryTargetEntries(ctx context.Context, key string) ([]reg
 		if err != nil {
 			return nil, "device", err
 		}
+		// Integration attribution is enrichment for ambiguity errors —
+		// a failed config-entry read degrades to bare device ids.
+		domains := map[string]string{}
+		if cfgEntries, err := r.ha.GetConfigEntries(ctx); err == nil {
+			for _, e := range cfgEntries {
+				domains[e.EntryID] = e.Domain
+			}
+		}
 		entries := make([]registryTargetEntry, 0, len(devices))
 		for _, d := range devices {
-			entries = append(entries, registryTargetEntry{id: d.ID, matches: []string{string(d.Name)}})
+			// The user-assigned name leads: it is what the model was told
+			// the device is called. The registry name still matches so a
+			// never-renamed device resolves too.
+			matches := make([]string, 0, 2)
+			if d.NameByUser != "" {
+				matches = append(matches, string(d.NameByUser))
+			}
+			if d.Name != "" && !strings.EqualFold(string(d.Name), string(d.NameByUser)) {
+				matches = append(matches, string(d.Name))
+			}
+			entries = append(entries, registryTargetEntry{id: d.ID, matches: matches, desc: domains[d.OwningConfigEntry()]})
 		}
 		return entries, "device", nil
 	}

--- a/internal/tools/ha_call_service_target_test.go
+++ b/internal/tools/ha_call_service_target_test.go
@@ -102,6 +102,76 @@ func TestHACallService_UnknownAreaFailsFastWithKnownNames(t *testing.T) {
 	}
 }
 
+// deviceTargetTestServer sets up the HA 2026.8 twin scenario: one
+// physical ceiling fan appearing as two registry devices, the native
+// integration's copy and a network-presence copy, both named "Office
+// Ceiling Fan". A third renamed device covers name_by_user matching.
+func deviceTargetTestServer(t *testing.T) *fakeHAServer {
+	t.Helper()
+	fake := targetTestServer(t)
+	fake.devices = []map[string]any{
+		{"id": "dev_net", "name": "Office Ceiling Fan", "config_entry_id": "cfg_net"},
+		{"id": "dev_fan", "name": "Office Ceiling Fan", "config_entry_id": "cfg_fan"},
+		{"id": "dev_lamp", "name": "shellyplug-s-a1b2c3", "name_by_user": "Bedroom North Lamp", "config_entry_id": "cfg_shelly"},
+	}
+	fake.configEntries = []map[string]any{
+		{"entry_id": "cfg_net", "domain": "unifi"},
+		{"entry_id": "cfg_fan", "domain": "baf"},
+		{"entry_id": "cfg_shelly", "domain": "shelly"},
+	}
+	return fake
+}
+
+func TestHACallService_DeviceTargetByUserAssignedNameResolves(t *testing.T) {
+	fake := deviceTargetTestServer(t)
+	reg := fake.registry(t)
+
+	raw, err := reg.Execute(context.Background(), "ha_call_service", `{"domain":"light","service":"turn_on","target":{"device_id":"Bedroom North Lamp"}}`)
+	if err != nil {
+		t.Fatalf("device target by user-assigned name: %v", err)
+	}
+	if res := decodeCallResult(t, raw); res.Target["device_id"] != "dev_lamp" {
+		t.Errorf("target.device_id = %v, want resolved id \"dev_lamp\"", res.Target["device_id"])
+	}
+	// The registry name still matches the same device.
+	raw, err = reg.Execute(context.Background(), "ha_call_service", `{"domain":"light","service":"turn_on","target":{"device_id":"shellyplug-s-a1b2c3"}}`)
+	if err != nil {
+		t.Fatalf("device target by registry name: %v", err)
+	}
+	if res := decodeCallResult(t, raw); res.Target["device_id"] != "dev_lamp" {
+		t.Errorf("target.device_id = %v, want resolved id \"dev_lamp\"", res.Target["device_id"])
+	}
+}
+
+// TestHACallService_AmbiguousDeviceNameFailsFastWithIntegrations is the
+// HA 2026.8 regression: a device name shared by per-integration twins
+// must refuse to fire at an arbitrary registry row and instead teach the
+// candidates with their owning integrations.
+func TestHACallService_AmbiguousDeviceNameFailsFastWithIntegrations(t *testing.T) {
+	fake := deviceTargetTestServer(t)
+	reg := fake.registry(t)
+
+	_, err := reg.Execute(context.Background(), "ha_call_service", `{"domain":"fan","service":"turn_on","target":{"device_id":"Office Ceiling Fan"}}`)
+	if err == nil {
+		t.Fatal("ambiguous device name must fail fast, not fire at the first registry row")
+	}
+	if got := err.Error(); !containsAll(got, "dev_net", "dev_fan", "unifi", "baf") {
+		t.Errorf("error should list both twins with their integrations, got %q", got)
+	}
+	if len(fake.servicePayloads) != 0 {
+		t.Errorf("no service call may reach HA on an ambiguous resolution; got %v", fake.servicePayloads)
+	}
+
+	// An exact id cuts through the ambiguity untouched.
+	raw, err := reg.Execute(context.Background(), "ha_call_service", `{"domain":"fan","service":"turn_on","target":{"device_id":"dev_fan"}}`)
+	if err != nil {
+		t.Fatalf("exact id must bypass name ambiguity: %v", err)
+	}
+	if res := decodeCallResult(t, raw); res.Target["device_id"] != "dev_fan" {
+		t.Errorf("target.device_id = %v, want \"dev_fan\"", res.Target["device_id"])
+	}
+}
+
 func TestHACallService_ArgumentValidation(t *testing.T) {
 	fake := targetTestServer(t)
 	reg := fake.registry(t)

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -852,7 +852,7 @@ func (r *Registry) registerBuiltins() {
 				},
 				"target": map[string]any{
 					"type":        "object",
-					"description": "Fan-out addressing: any of entity_id, device_id, area_id, floor_id, label_id (string or array each). Areas, floors, labels, and devices accept human names (\"Office\") as well as registry IDs — names resolve case-insensitively, unknown references fail fast with the known names. Provide this or entity_id.",
+					"description": "Fan-out addressing: any of entity_id, device_id, area_id, floor_id, label_id (string or array each). Areas, floors, labels, and devices accept human names (\"Office\") as well as registry IDs — names resolve case-insensitively, unknown references fail fast with the known names. A device name matching several devices also fails fast, listing each candidate id with its integration: since HA 2026.8 one physical device appears once per integration, so pick the integration that owns the capability you're calling (or check ha_device first). Provide this or entity_id.",
 					"properties": map[string]any{
 						"entity_id": map[string]any{"type": []string{"string", "array"}, "items": map[string]any{"type": "string"}},
 						"device_id": map[string]any{"type": []string{"string", "array"}, "items": map[string]any{"type": "string"}},

--- a/talents/ha.md
+++ b/talents/ha.md
@@ -95,9 +95,17 @@ and diagnostic entities HA keeps off its generated dashboards. The
 `configuration` and `diagnostic` groups are capped for a device with a
 long tail of knobs, with an honest `*_truncated_count`. Resolves by
 `device_id` or by name — user-assigned or registry name, with a
-substring fallback, returning candidates when a name is ambiguous. Reach
-for this instead of discovering a device's child entities one
-`ha_get_state` at a time.
+substring fallback, returning candidates when a name is ambiguous.
+
+Since Home Assistant 2026.8 one physical device appears as a **separate
+registry device per integration**, so two devices sharing a name exactly
+is normal, not registry corruption: a ceiling fan typically has a twin —
+the native integration's copy holding the controls, and a
+network-presence copy holding a connectivity entity or two. Ambiguous
+candidates carry `integration` and `entity_count` (richest first) so you
+can pick the copy that owns the capability you're after, then re-call
+with its `device_id`. Reach for this instead of discovering a device's
+child entities one `ha_get_state` at a time.
 
 ## Find one entity by description
 
@@ -399,10 +407,16 @@ Targets take `entity_id`, `device_id`, `area_id`, `floor_id`, and
 `label_id` (string or array each), and areas/floors/labels/devices
 accept human names as well as registry IDs — names resolve against the
 registry, and unknown references fail fast with the known names instead
-of HA's silent no-op. HA skips hidden entities in area/floor/label
-targets; that's the operator's curation, not a bug. The response
-reports which entities actually changed state — zero changes with a
-note usually means everything was already in the requested state.
+of HA's silent no-op. Device names match the user-assigned name and the
+registry name; a name shared by several devices also fails fast, listing
+each candidate id with its integration — since HA 2026.8 one physical
+device appears once per integration, so same-name twins are normal, and
+you pick the integration that owns the capability you're calling (the
+device's native integration, not its presence-tracker copy). HA skips
+hidden entities in area/floor/label targets; that's the operator's
+curation, not a bug. The response reports which entities actually
+changed state — zero changes with a note usually means everything was
+already in the requested state.
 
 Single-entity form, with the exact entity_id:
 


### PR DESCRIPTION
Closes #1337.

HA 2026.8 revoked an assumption both of thane's name-based device resolvers were built on: that a device name picks out one device. A device now belongs to exactly one config entry, physical devices that several integrations used to share were split into one registry row per integration at upgrade, and on a live 2026.8 registry 101 of 1,075 device display names are now shared by two or more rows — the same hardware appearing once under its native integration (the copy with the controls) and again under a presence tracker (a copy with one or two connectivity entities). Both resolvers were first-match-wins on those names, which post-split means silently firing at whichever twin happens to come first in registry order.

## What changes

**The decode learns the 2026.8 ownership model.** `DeviceRegistryEntry` gains `config_entry_id` / `config_subentry_id`, and a new `OwningConfigEntry()` accessor encodes the fallback chain (singular field → deprecated `primary_config_entry` → first of `config_entries`) so the same reader works against current and pre-2026.8 servers. Integration attribution in `ha_device` reads it instead of the deprecated fields, retiring the 2027.8 shim-removal deadline.

**Exact-name ambiguity becomes loud instead of lucky.** `resolveDevice`'s substring tier already returned candidates; the exact tier predated the possibility of exact duplicates and silently returned the first row. Now every name tier collects matches, and an ambiguous result returns structured candidates — `device_id`, `name`, `integration`, enabled `entity_count`, richest twin first — because duplicated candidates share the very name being disambiguated, so the integration and entity count are the only signals a model can actually pick by.

**`ha_call_service` device targets reach the same standard.** Matching now covers the user-assigned name as well as the registry name (a renamed device was previously unmatchable by the name the user calls it), and a multi-match fails fast with each candidate id attributed to its integration, mirroring the existing unknown-name fail-fast rather than firing a service call at an arbitrary row.

**The model is taught the new world.** `ha_device` and `ha_call_service` descriptions plus the `ha` talent now say plainly: since 2026.8 one physical device appears once per integration, same-name twins are expected rather than registry corruption, and you pick the integration that owns the capability you're calling.

Deliberately untouched, verified against the live registry: subscriptions store `area:`/`label:`/`floor:`/glob targets rather than device ids, so the split cannot orphan them; the membership resolver re-reads live rows and the migration preserved area/labels on every split copy; MQTT discovery publishes thane's own device under thane's own identifiers.

## Test plan

- [x] `just ci` green locally
- [x] New: singular-field decode + `OwningConfigEntry` fallback chain (table-driven, `device_registry_test.go`)
- [x] New: exact-name twins return attributed candidates richest-first, disabled entities excluded from counts (`device_snapshot_test.go`)
- [x] New: `deviceIntegration` prefers `config_entry_id`, falls back for pre-2026.8 servers (`device_snapshot_test.go`)
- [x] New: device target resolves by user-assigned and registry name; ambiguous name fails fast listing both twins with integrations, nothing reaches HA; exact id bypasses ambiguity (`ha_call_service_target_test.go`)
- [x] Existing substring-ambiguity and no-match behavior unchanged
