### PR TITLE
feat(mqtt): adopt HA device-based discovery with history-preserving migration

### DIFF
--- a/internal/app/new_servers.go
+++ b/internal/app/new_servers.go
@@ -477,8 +477,6 @@ func (a *App) initServers(s *newState) error {
 					UniqueID:            mqttInstanceID + "_" + suffix,
 					StateTopic:          a.mqttPub.StateTopic(suffix),
 					JsonAttributesTopic: a.mqttPub.AttributesTopic(suffix),
-					AvailabilityTopic:   a.mqttPub.AvailabilityTopic(),
-					Device:              a.mqttPub.Device(),
 					Icon:                "mdi:access-point",
 				},
 			})
@@ -530,8 +528,6 @@ func (a *App) initServers(s *newState) error {
 			Prefix:            a.mqttPub.ObjectIDPrefix(),
 			StateTopicFn:      a.mqttPub.StateTopic,
 			AttributesTopicFn: a.mqttPub.AttributesTopic,
-			AvailabilityTopic: a.mqttPub.AvailabilityTopic(),
-			Device:            a.mqttPub.Device(),
 		}
 
 		a.mqttPub.RegisterSensors(telBuilder.StaticSensors())

--- a/internal/channels/mqtt/device.go
+++ b/internal/channels/mqtt/device.go
@@ -2,41 +2,77 @@ package mqtt
 
 import "github.com/nugget/thane-ai-agent/internal/platform/buildinfo"
 
-// DeviceInfo holds the Home Assistant device registry fields shared
-// across all MQTT discovery config payloads. Every sensor entity
-// published by this instance references the same device block so HA
-// groups them under a single device page.
+// DeviceInfo is the device block of the device-based MQTT discovery
+// payload — the Home Assistant device registry identity every component
+// published by this instance hangs off. One block describes the whole
+// device; it appears once, at the payload root.
 type DeviceInfo struct {
 	Identifiers  []string `json:"identifiers"`
 	Name         string   `json:"name"`
 	Manufacturer string   `json:"manufacturer"`
 	Model        string   `json:"model"`
 	SWVersion    string   `json:"sw_version"`
+	SerialNumber string   `json:"serial_number,omitempty"`
 }
 
-// SensorConfig is the JSON payload for an HA MQTT sensor discovery
-// message. It is published (retained) to the discovery topic on every
-// broker (re-)connect.
+// OriginInfo is the origin block of the discovery payload — it names
+// the software that published the discovery message so an operator can
+// tell where a discovered device came from. Home Assistant asks for it
+// on every discovery payload.
+type OriginInfo struct {
+	Name       string `json:"name"`
+	SWVersion  string `json:"sw_version,omitempty"`
+	SupportURL string `json:"support_url,omitempty"`
+}
+
+// SensorConfig is one component entry in the device-based discovery
+// payload — a single HA sensor entity. Device identity and availability
+// live at the payload root shared by every component, so a component
+// carries only what is entity-specific. Platform is required by HA for
+// every component; the publisher defaults an empty value to "sensor".
 type SensorConfig struct {
-	Name                string     `json:"name"`
-	ObjectID            string     `json:"object_id,omitempty"`
-	HasEntityName       bool       `json:"has_entity_name,omitempty"`
-	UniqueID            string     `json:"unique_id"`
-	StateTopic          string     `json:"state_topic"`
-	AvailabilityTopic   string     `json:"availability_topic"`
-	JsonAttributesTopic string     `json:"json_attributes_topic,omitempty"`
-	Device              DeviceInfo `json:"device"`
-	Icon                string     `json:"icon,omitempty"`
-	UnitOfMeasurement   string     `json:"unit_of_measurement,omitempty"`
-	StateClass          string     `json:"state_class,omitempty"`
-	ValueTemplate       string     `json:"value_template,omitempty"`
-	EntityCategory      string     `json:"entity_category,omitempty"`
+	Platform            string `json:"platform"`
+	Name                string `json:"name"`
+	ObjectID            string `json:"object_id,omitempty"`
+	HasEntityName       bool   `json:"has_entity_name,omitempty"`
+	UniqueID            string `json:"unique_id"`
+	StateTopic          string `json:"state_topic"`
+	JsonAttributesTopic string `json:"json_attributes_topic,omitempty"`
+	Icon                string `json:"icon,omitempty"`
+	DeviceClass         string `json:"device_class,omitempty"`
+	UnitOfMeasurement   string `json:"unit_of_measurement,omitempty"`
+	StateClass          string `json:"state_class,omitempty"`
+	ValueTemplate       string `json:"value_template,omitempty"`
+	EntityCategory      string `json:"entity_category,omitempty"`
+}
+
+// availabilityEntry is one entry of the shared availability list. The
+// list form is HA's current convention; payload_available defaults to
+// "online" and payload_not_available to "offline", which is exactly
+// what the publisher emits, so only the topic needs stating.
+type availabilityEntry struct {
+	Topic string `json:"topic"`
+}
+
+// deviceDiscoveryConfig is the single retained payload published to
+// <discovery_prefix>/device/<device>/config — HA's device-based
+// discovery format (recommended since 2024.11). It replaces the legacy
+// one-retained-message-per-entity layout: the device block, origin
+// block, and availability list appear once, and every entity is an
+// entry in Components keyed by its stable entity suffix. Full-name keys
+// are used throughout; HA documents the abbreviated forms (dev/o/cmps)
+// as optional.
+type deviceDiscoveryConfig struct {
+	Device       DeviceInfo              `json:"device"`
+	Origin       OriginInfo              `json:"origin"`
+	Availability []availabilityEntry     `json:"availability"`
+	Components   map[string]SensorConfig `json:"components"`
 }
 
 // NewDeviceInfo creates a DeviceInfo from the persistent instance ID
 // and the human-readable device name. The instance ID is used as the
-// primary HA device identifier (stable across renames); the device
-// name appears in the HA UI.
+// primary HA device identifier (stable across renames) and doubles as
+// the serial number; the device name appears in the HA UI.
 func NewDeviceInfo(instanceID, deviceName string) DeviceInfo {
 	return DeviceInfo{
 		Identifiers:  []string{instanceID},
@@ -44,5 +80,16 @@ func NewDeviceInfo(instanceID, deviceName string) DeviceInfo {
 		Manufacturer: "Hollow Oak",
 		Model:        "Thane AI Agent",
 		SWVersion:    buildinfo.Version,
+		SerialNumber: instanceID,
+	}
+}
+
+// NewOriginInfo creates the origin block identifying this thane build
+// as the discovery publisher.
+func NewOriginInfo() OriginInfo {
+	return OriginInfo{
+		Name:       "Thane AI Agent",
+		SWVersion:  buildinfo.Version,
+		SupportURL: "https://github.com/nugget/thane-ai-agent",
 	}
 }

--- a/internal/channels/mqtt/publisher.go
+++ b/internal/channels/mqtt/publisher.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/url"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -53,6 +54,7 @@ type Publisher struct {
 	cfg            config.MQTTConfig
 	instanceID     string
 	device         DeviceInfo
+	origin         OriginInfo
 	tokens         *DailyTokens
 	stats          StatsSource
 	logger         *slog.Logger
@@ -62,6 +64,13 @@ type Publisher struct {
 	mu             sync.Mutex
 	dynamicSensors []DynamicSensor
 	dynamicTopics  func() []string // returns extra topics to subscribe on (re-)connect
+
+	// migrated tracks entity suffixes whose legacy per-component
+	// discovery topic has been migrated (marker published, then
+	// cleared) this process. A suffix is recorded only after its clear
+	// publish succeeded, so a failed pass retries on the next
+	// (re-)connect.
+	migrated map[string]bool
 }
 
 // New creates a Publisher but does not connect. Call [Publisher.Start]
@@ -76,9 +85,11 @@ func New(cfg config.MQTTConfig, instanceID string, tokens *DailyTokens, stats St
 		cfg:        cfg,
 		instanceID: instanceID,
 		device:     NewDeviceInfo(instanceID, cfg.DeviceName),
+		origin:     NewOriginInfo(),
 		tokens:     tokens,
 		stats:      stats,
 		logger:     logger,
+		migrated:   make(map[string]bool),
 	}
 }
 
@@ -170,15 +181,12 @@ func (p *Publisher) EnsureSensor(ctx context.Context, sensor DynamicSensor) erro
 	if cm == nil {
 		return fmt.Errorf("mqtt publisher not connected")
 	}
-	p.publishSensorDiscovery(ctx, cm, sensor.EntitySuffix, sensor.Config)
+	// Device-based discovery describes the whole device in one payload,
+	// so a new component means republishing it — which also runs the
+	// legacy-topic migration for this suffix if an older binary ever
+	// published it per-component.
+	p.publishDiscovery(ctx, cm)
 	return nil
-}
-
-// Device returns the HA device info shared across all sensors published
-// by this publisher instance. Useful for callers building [DynamicSensor]
-// configs that reference the same HA device.
-func (p *Publisher) Device() DeviceInfo {
-	return p.device
 }
 
 // PublishDynamicState publishes the state and optional JSON attributes
@@ -448,7 +456,19 @@ func (p *Publisher) AttributesTopic(entity string) string {
 	return p.baseTopic() + "/" + entity + "/attributes"
 }
 
-func (p *Publisher) discoveryTopic(component, entity string) string {
+// deviceDiscoveryTopic is the single retained config topic for HA's
+// device-based discovery: one payload describes the device and every
+// component on it.
+func (p *Publisher) deviceDiscoveryTopic() string {
+	return p.cfg.DiscoveryPrefix + "/device/" + p.cfg.DeviceName + "/config"
+}
+
+// legacyDiscoveryTopic is the pre-2024.11 per-component discovery topic
+// (one retained config per entity). Kept only for the migration sweep:
+// markers and cleanup are published here so previously discovered
+// entities move to the device-based payload with their registry
+// entries, customizations, and history intact.
+func (p *Publisher) legacyDiscoveryTopic(component, entity string) string {
 	return p.cfg.DiscoveryPrefix + "/" + component + "/" + p.cfg.DeviceName + "/" + entity + "/config"
 }
 
@@ -460,35 +480,30 @@ type sensorDef struct {
 }
 
 func (p *Publisher) sensorDefinitions() []sensorDef {
-	avail := p.AvailabilityTopic()
 	prefix := p.ObjectIDPrefix()
 	return []sensorDef{
 		{
 			entitySuffix: "uptime",
 			config: SensorConfig{
-				Name:              "Uptime",
-				ObjectID:          prefix + "uptime",
-				HasEntityName:     true,
-				UniqueID:          p.instanceID + "_uptime",
-				StateTopic:        p.StateTopic("uptime"),
-				AvailabilityTopic: avail,
-				Device:            p.device,
-				Icon:              "mdi:clock-outline",
-				EntityCategory:    "diagnostic",
+				Name:           "Uptime",
+				ObjectID:       prefix + "uptime",
+				HasEntityName:  true,
+				UniqueID:       p.instanceID + "_uptime",
+				StateTopic:     p.StateTopic("uptime"),
+				Icon:           "mdi:clock-outline",
+				EntityCategory: "diagnostic",
 			},
 		},
 		{
 			entitySuffix: "version",
 			config: SensorConfig{
-				Name:              "Version",
-				ObjectID:          prefix + "version",
-				HasEntityName:     true,
-				UniqueID:          p.instanceID + "_version",
-				StateTopic:        p.StateTopic("version"),
-				AvailabilityTopic: avail,
-				Device:            p.device,
-				Icon:              "mdi:tag",
-				EntityCategory:    "diagnostic",
+				Name:           "Version",
+				ObjectID:       prefix + "version",
+				HasEntityName:  true,
+				UniqueID:       p.instanceID + "_version",
+				StateTopic:     p.StateTopic("version"),
+				Icon:           "mdi:tag",
+				EntityCategory: "diagnostic",
 			},
 		},
 		{
@@ -499,8 +514,6 @@ func (p *Publisher) sensorDefinitions() []sensorDef {
 				HasEntityName:     true,
 				UniqueID:          p.instanceID + "_tokens_today",
 				StateTopic:        p.StateTopic("tokens_today"),
-				AvailabilityTopic: avail,
-				Device:            p.device,
 				Icon:              "mdi:counter",
 				StateClass:        "measurement",
 				UnitOfMeasurement: "tokens",
@@ -509,72 +522,169 @@ func (p *Publisher) sensorDefinitions() []sensorDef {
 		{
 			entitySuffix: "last_request",
 			config: SensorConfig{
-				Name:              "Last Request",
-				ObjectID:          prefix + "last_request",
-				HasEntityName:     true,
-				UniqueID:          p.instanceID + "_last_request",
-				StateTopic:        p.StateTopic("last_request"),
-				AvailabilityTopic: avail,
-				Device:            p.device,
-				Icon:              "mdi:clock-check",
-				EntityCategory:    "diagnostic",
+				Name:           "Last Request",
+				ObjectID:       prefix + "last_request",
+				HasEntityName:  true,
+				UniqueID:       p.instanceID + "_last_request",
+				StateTopic:     p.StateTopic("last_request"),
+				Icon:           "mdi:clock-check",
+				EntityCategory: "diagnostic",
 			},
 		},
 		{
 			entitySuffix: "default_model",
 			config: SensorConfig{
-				Name:              "Default Model",
-				ObjectID:          prefix + "default_model",
-				HasEntityName:     true,
-				UniqueID:          p.instanceID + "_default_model",
-				StateTopic:        p.StateTopic("default_model"),
-				AvailabilityTopic: avail,
-				Device:            p.device,
-				Icon:              "mdi:brain",
-				EntityCategory:    "diagnostic",
+				Name:           "Default Model",
+				ObjectID:       prefix + "default_model",
+				HasEntityName:  true,
+				UniqueID:       p.instanceID + "_default_model",
+				StateTopic:     p.StateTopic("default_model"),
+				Icon:           "mdi:brain",
+				EntityCategory: "diagnostic",
 			},
 		},
 	}
 }
 
+// migrateDiscoveryPayload is HA's documented trigger for moving an
+// entity from per-component to device-based discovery: published
+// (retained) to the legacy config topic, it unloads the discovered
+// entity while KEEPING its registry entry, customizations, and history,
+// so the device-based payload can reclaim the same unique_id.
+var migrateDiscoveryPayload = []byte(`{"migrate_discovery":true}`)
+
+// publishDiscovery publishes the device-based discovery payload and,
+// for any entity suffix seen for the first time this process, performs
+// HA's documented legacy migration around it: migrate marker to the
+// legacy topic, then the device payload, then an empty retained payload
+// clearing the legacy topic. The sweep is idempotent — once the legacy
+// topics are empty a later pass has nothing to mark — and self-heals
+// the rollback case where an older binary re-littered them.
 func (p *Publisher) publishDiscovery(ctx context.Context, cm *autopaho.ConnectionManager) {
-	// Static (built-in) sensors.
-	for _, s := range p.sensorDefinitions() {
-		p.publishSensorDiscovery(ctx, cm, s.entitySuffix, s.config)
+	components := p.snapshotComponents()
+	pending := p.unmigratedSuffixes(components)
+
+	marked := make([]string, 0, len(pending))
+	for _, suffix := range pending {
+		topic := p.legacyDiscoveryTopic("sensor", suffix)
+		if err := p.publishRetained(ctx, cm, topic, migrateDiscoveryPayload); err != nil {
+			p.logger.Warn("mqtt legacy discovery migrate marker failed",
+				"entity", suffix, "topic", topic, "error", err)
+			continue
+		}
+		marked = append(marked, suffix)
+	}
+	if len(marked) > 0 {
+		p.logger.Info("mqtt legacy discovery migration started",
+			"entities", len(marked))
 	}
 
-	// Dynamic sensors registered by external packages.
-	p.mu.Lock()
-	dynCopy := make([]DynamicSensor, len(p.dynamicSensors))
-	copy(dynCopy, p.dynamicSensors)
-	p.mu.Unlock()
-
-	for _, ds := range dynCopy {
-		p.publishSensorDiscovery(ctx, cm, ds.EntitySuffix, ds.Config)
-	}
-}
-
-func (p *Publisher) publishSensorDiscovery(ctx context.Context, cm *autopaho.ConnectionManager, entitySuffix string, cfg SensorConfig) {
-	topic := p.discoveryTopic("sensor", entitySuffix)
-	payload, err := json.Marshal(cfg)
-	if err != nil {
-		p.logger.Error("mqtt marshal discovery payload",
-			"entity", entitySuffix, "error", err)
+	if err := p.publishDeviceDiscovery(ctx, cm, components); err != nil {
+		// Nothing is recorded as migrated: the next (re-)connect
+		// re-marks and re-publishes, and HA sits on the retained
+		// markers (registry entries intact) until it does.
 		return
 	}
 
-	if _, err := cm.Publish(ctx, &paho.Publish{
+	cleared := 0
+	for _, suffix := range marked {
+		topic := p.legacyDiscoveryTopic("sensor", suffix)
+		if err := p.publishRetained(ctx, cm, topic, nil); err != nil {
+			p.logger.Warn("mqtt legacy discovery cleanup failed",
+				"entity", suffix, "topic", topic, "error", err)
+			continue
+		}
+		p.markMigrated(suffix)
+		cleared++
+	}
+	if cleared > 0 {
+		p.logger.Info("mqtt legacy discovery migrated to device-based",
+			"entities", cleared)
+	}
+}
+
+// snapshotComponents assembles the full component map — static
+// definitions plus dynamic registrations — with Platform defaulted, as
+// one device-based discovery payload's Components block.
+func (p *Publisher) snapshotComponents() map[string]SensorConfig {
+	components := make(map[string]SensorConfig)
+	for _, s := range p.sensorDefinitions() {
+		components[s.entitySuffix] = s.config
+	}
+	p.mu.Lock()
+	for _, ds := range p.dynamicSensors {
+		components[ds.EntitySuffix] = ds.Config
+	}
+	p.mu.Unlock()
+	for suffix, c := range components {
+		if c.Platform == "" {
+			c.Platform = "sensor"
+			components[suffix] = c
+		}
+	}
+	return components
+}
+
+// unmigratedSuffixes returns the component suffixes whose legacy
+// discovery topic has not yet been migrated this process, sorted for
+// deterministic publish order.
+func (p *Publisher) unmigratedSuffixes(components map[string]SensorConfig) []string {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	pending := make([]string, 0, len(components))
+	for suffix := range components {
+		if !p.migrated[suffix] {
+			pending = append(pending, suffix)
+		}
+	}
+	sort.Strings(pending)
+	return pending
+}
+
+// markMigrated records a suffix whose legacy topic was marked and then
+// cleared successfully.
+func (p *Publisher) markMigrated(suffix string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.migrated[suffix] = true
+}
+
+// publishDeviceDiscovery publishes the single retained device-based
+// discovery payload describing this device and every component on it.
+func (p *Publisher) publishDeviceDiscovery(ctx context.Context, cm *autopaho.ConnectionManager, components map[string]SensorConfig) error {
+	cfg := deviceDiscoveryConfig{
+		Device:       p.device,
+		Origin:       p.origin,
+		Availability: []availabilityEntry{{Topic: p.AvailabilityTopic()}},
+		Components:   components,
+	}
+	payload, err := json.Marshal(cfg)
+	if err != nil {
+		p.logger.Error("mqtt marshal device discovery payload", "error", err)
+		return err
+	}
+
+	topic := p.deviceDiscoveryTopic()
+	if err := p.publishRetained(ctx, cm, topic, payload); err != nil {
+		p.logger.Warn("mqtt device discovery publish failed",
+			"topic", topic, "components", len(components), "error", err)
+		return err
+	}
+	p.logger.Debug("mqtt device discovery published",
+		"topic", topic, "components", len(components))
+	return nil
+}
+
+// publishRetained publishes a retained QoS-1 message; a nil payload
+// clears the retained message from the topic.
+func (p *Publisher) publishRetained(ctx context.Context, cm *autopaho.ConnectionManager, topic string, payload []byte) error {
+	_, err := cm.Publish(ctx, &paho.Publish{
 		Topic:   topic,
 		Payload: payload,
 		QoS:     1,
 		Retain:  true,
-	}); err != nil {
-		p.logger.Warn("mqtt discovery publish failed",
-			"entity", entitySuffix, "topic", topic, "error", err)
-	} else {
-		p.logger.Debug("mqtt discovery published",
-			"entity", entitySuffix, "topic", topic)
-	}
+	})
+	return err
 }
 
 func (p *Publisher) publishAvailability(ctx context.Context, cm *autopaho.ConnectionManager, status string) {

--- a/internal/channels/mqtt/publisher_test.go
+++ b/internal/channels/mqtt/publisher_test.go
@@ -84,6 +84,19 @@ func TestNewDeviceInfo(t *testing.T) {
 	if info.Model != "Thane AI Agent" {
 		t.Errorf("Model = %q, want %q", info.Model, "Thane AI Agent")
 	}
+	if info.SerialNumber != "test-instance-id" {
+		t.Errorf("SerialNumber = %q, want %q", info.SerialNumber, "test-instance-id")
+	}
+}
+
+func TestNewOriginInfo(t *testing.T) {
+	origin := NewOriginInfo()
+	if origin.Name != "Thane AI Agent" {
+		t.Errorf("Name = %q, want %q", origin.Name, "Thane AI Agent")
+	}
+	if origin.SupportURL == "" {
+		t.Error("SupportURL is empty — HA surfaces it on the device page")
+	}
 }
 
 func TestPublisher_TopicPaths(t *testing.T) {
@@ -102,7 +115,8 @@ func TestPublisher_TopicPaths(t *testing.T) {
 		{"baseTopic", p.baseTopic(), "thane/aimee-thane"},
 		{"AvailabilityTopic", p.AvailabilityTopic(), "thane/aimee-thane/availability"},
 		{"StateTopic uptime", p.StateTopic("uptime"), "thane/aimee-thane/uptime/state"},
-		{"discoveryTopic sensor uptime", p.discoveryTopic("sensor", "uptime"), "homeassistant/sensor/aimee-thane/uptime/config"},
+		{"deviceDiscoveryTopic", p.deviceDiscoveryTopic(), "homeassistant/device/aimee-thane/config"},
+		{"legacyDiscoveryTopic sensor uptime", p.legacyDiscoveryTopic("sensor", "uptime"), "homeassistant/sensor/aimee-thane/uptime/config"},
 	}
 
 	for _, tt := range tests {
@@ -162,13 +176,6 @@ func TestPublisher_SensorDefinitions(t *testing.T) {
 			}
 		}
 
-		// Every sensor should reference the availability topic.
-		wantAvail := "thane/test-thane/availability"
-		if d.config.AvailabilityTopic != wantAvail {
-			t.Errorf("sensor %s: AvailabilityTopic = %q, want %q",
-				d.entitySuffix, d.config.AvailabilityTopic, wantAvail)
-		}
-
 		// Every sensor should have a unique ID based on instance ID.
 		if !strings.HasPrefix(d.config.UniqueID, "instance-123_") {
 			t.Errorf("sensor %s: UniqueID = %q, should start with %q",
@@ -188,11 +195,6 @@ func TestPublisher_SensorDefinitions(t *testing.T) {
 		if !d.config.HasEntityName {
 			t.Errorf("sensor %s: HasEntityName = false, want true",
 				d.entitySuffix)
-		}
-
-		// Every sensor should reference the device.
-		if len(d.config.Device.Identifiers) == 0 {
-			t.Errorf("sensor %s: Device.Identifiers is empty", d.entitySuffix)
 		}
 	}
 
@@ -310,20 +312,108 @@ func TestPublisher_AttributesTopic(t *testing.T) {
 	}
 }
 
-func TestPublisher_DeviceGetter(t *testing.T) {
+// TestPublisher_SnapshotComponents pins the assembly of the
+// device-based discovery Components block: static and dynamic sensors
+// merge into one map keyed by suffix, a dynamic registration can
+// override a static suffix, and the required per-component platform is
+// defaulted to "sensor" when a caller leaves it empty.
+func TestPublisher_SnapshotComponents(t *testing.T) {
 	cfg := config.MQTTConfig{
 		Broker:          "mqtt://localhost:1883",
-		DeviceName:      "test-device",
+		DeviceName:      "test-thane",
 		DiscoveryPrefix: "homeassistant",
 	}
-	p := New(cfg, "instance-abc", NewDailyTokens(time.UTC), nil, nil)
+	p := New(cfg, "instance-123", NewDailyTokens(time.UTC), nil, nil)
+	p.RegisterSensors([]DynamicSensor{
+		{EntitySuffix: "nugget_ap", Config: SensorConfig{Name: "Nugget AP", UniqueID: "instance-123_nugget_ap"}},
+		{EntitySuffix: "uptime", Config: SensorConfig{Name: "Uptime Override", UniqueID: "instance-123_uptime"}},
+	})
 
-	dev := p.Device()
-	if dev.Name != "test-device" {
-		t.Errorf("Device().Name = %q, want %q", dev.Name, "test-device")
+	components := p.snapshotComponents()
+
+	wantCount := len(p.sensorDefinitions()) + 1 // uptime overridden, nugget_ap added
+	if len(components) != wantCount {
+		t.Errorf("components = %d, want %d", len(components), wantCount)
 	}
-	if len(dev.Identifiers) != 1 || dev.Identifiers[0] != "instance-abc" {
-		t.Errorf("Device().Identifiers = %v, want [instance-abc]", dev.Identifiers)
+	if got := components["uptime"].Name; got != "Uptime Override" {
+		t.Errorf("dynamic registration should override static suffix: Name = %q", got)
+	}
+	for suffix, c := range components {
+		if c.Platform != "sensor" {
+			t.Errorf("component %s: Platform = %q, want defaulted \"sensor\"", suffix, c.Platform)
+		}
+	}
+}
+
+// TestPublisher_MigrationBookkeeping pins the once-per-process legacy
+// migration accounting: every suffix starts pending (sorted), and only
+// an explicit markMigrated (recorded after a successful clear publish)
+// removes it from later sweeps.
+func TestPublisher_MigrationBookkeeping(t *testing.T) {
+	cfg := config.MQTTConfig{
+		Broker:          "mqtt://localhost:1883",
+		DeviceName:      "test-thane",
+		DiscoveryPrefix: "homeassistant",
+	}
+	p := New(cfg, "instance-123", NewDailyTokens(time.UTC), nil, nil)
+
+	components := map[string]SensorConfig{
+		"b_sensor": {}, "a_sensor": {}, "c_sensor": {},
+	}
+	pending := p.unmigratedSuffixes(components)
+	if len(pending) != 3 || pending[0] != "a_sensor" || pending[2] != "c_sensor" {
+		t.Errorf("pending = %v, want sorted [a_sensor b_sensor c_sensor]", pending)
+	}
+
+	p.markMigrated("b_sensor")
+	pending = p.unmigratedSuffixes(components)
+	if len(pending) != 2 || pending[0] != "a_sensor" || pending[1] != "c_sensor" {
+		t.Errorf("pending after markMigrated = %v, want [a_sensor c_sensor]", pending)
+	}
+}
+
+// TestDeviceDiscoveryConfig_PayloadShape pins the wire format of the
+// device-based discovery payload: the full-name root keys HA documents
+// (device/origin/availability/components), the origin block content,
+// and the required per-component platform.
+func TestDeviceDiscoveryConfig_PayloadShape(t *testing.T) {
+	cfg := deviceDiscoveryConfig{
+		Device:       NewDeviceInfo("instance-abc", "test-device"),
+		Origin:       NewOriginInfo(),
+		Availability: []availabilityEntry{{Topic: "thane/test-device/availability"}},
+		Components: map[string]SensorConfig{
+			"uptime": {Platform: "sensor", Name: "Uptime", UniqueID: "instance-abc_uptime", StateTopic: "thane/test-device/uptime/state"},
+		},
+	}
+	data, err := json.Marshal(cfg)
+	if err != nil {
+		t.Fatalf("Marshal error: %v", err)
+	}
+
+	var decoded map[string]any
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("Unmarshal error: %v", err)
+	}
+	for _, key := range []string{"device", "origin", "availability", "components"} {
+		if _, ok := decoded[key]; !ok {
+			t.Errorf("payload missing root key %q:\n%s", key, data)
+		}
+	}
+
+	origin, _ := decoded["origin"].(map[string]any)
+	if origin["name"] != "Thane AI Agent" || origin["support_url"] == "" {
+		t.Errorf("origin block incomplete: %#v", origin)
+	}
+
+	device, _ := decoded["device"].(map[string]any)
+	if device["serial_number"] != "instance-abc" {
+		t.Errorf("device.serial_number = %#v, want instance-abc", device["serial_number"])
+	}
+
+	components, _ := decoded["components"].(map[string]any)
+	uptime, _ := components["uptime"].(map[string]any)
+	if uptime["platform"] != "sensor" {
+		t.Errorf("component platform = %#v, want \"sensor\"", uptime["platform"])
 	}
 }
 
@@ -352,12 +442,11 @@ func TestPublisher_ObjectIDPrefix(t *testing.T) {
 func TestSensorConfig_JsonAttributesTopic(t *testing.T) {
 	// With JsonAttributesTopic set.
 	cfg := SensorConfig{
+		Platform:            "sensor",
 		Name:                "Test",
 		UniqueID:            "test_1",
 		StateTopic:          "thane/test/state",
-		AvailabilityTopic:   "thane/test/availability",
 		JsonAttributesTopic: "thane/test/attributes",
-		Device:              DeviceInfo{Identifiers: []string{"id"}, Name: "d"},
 	}
 	data, err := json.Marshal(cfg)
 	if err != nil {

--- a/internal/platform/telemetry/publisher_test.go
+++ b/internal/platform/telemetry/publisher_test.go
@@ -48,8 +48,6 @@ func testBuilder() *SensorBuilder {
 		Prefix:            "thane_test_",
 		StateTopicFn:      func(s string) string { return "thane/test/" + s + "/state" },
 		AttributesTopicFn: func(s string) string { return "thane/test/" + s + "/attributes" },
-		AvailabilityTopic: "thane/test/availability",
-		Device:            mqtt.DeviceInfo{Name: "test"},
 	}
 }
 

--- a/internal/platform/telemetry/sensors.go
+++ b/internal/platform/telemetry/sensors.go
@@ -7,15 +7,15 @@ import (
 )
 
 // SensorBuilder constructs Home Assistant MQTT sensor definitions for
-// telemetry metrics. It uses topic and device info from the MQTT
-// publisher to produce correctly namespaced discovery payloads.
+// telemetry metrics. It uses topic helpers from the MQTT publisher to
+// produce correctly namespaced component configs; device identity and
+// availability are shared at the discovery-payload root, so components
+// carry neither.
 type SensorBuilder struct {
 	InstanceID        string
 	Prefix            string // HA object_id prefix, e.g. "aimee_thane_"
 	StateTopicFn      func(string) string
 	AttributesTopicFn func(string) string
-	AvailabilityTopic string
-	Device            mqtt.DeviceInfo
 }
 
 // sensorSpec describes a single telemetry sensor for registration.
@@ -110,14 +110,12 @@ func (b *SensorBuilder) LoopSensors(loopName string) []mqtt.DynamicSensor {
 // buildSensor constructs a DynamicSensor from a spec.
 func (b *SensorBuilder) buildSensor(s sensorSpec) mqtt.DynamicSensor {
 	cfg := mqtt.SensorConfig{
-		Name:              s.name,
-		ObjectID:          b.Prefix + s.suffix,
-		HasEntityName:     true,
-		UniqueID:          b.InstanceID + "_" + s.suffix,
-		StateTopic:        b.StateTopicFn(s.suffix),
-		AvailabilityTopic: b.AvailabilityTopic,
-		Device:            b.Device,
-		Icon:              s.icon,
+		Name:          s.name,
+		ObjectID:      b.Prefix + s.suffix,
+		HasEntityName: true,
+		UniqueID:      b.InstanceID + "_" + s.suffix,
+		StateTopic:    b.StateTopicFn(s.suffix),
+		Icon:          s.icon,
 	}
 	if s.unit != "" {
 		cfg.UnitOfMeasurement = s.unit


### PR DESCRIPTION
Closes #1339.

Thane's MQTT discovery was the one surface where it writes into Home Assistant that still spoke the pre-2024.11 dialect — one retained config message per sensor, each repeating the same device block and availability topic, no `origin` block, no serial number, no per-component `platform`. On the production instance that is ~73 retained messages describing one device. This PR moves the publisher to HA's device-based discovery and, more importantly, gets there without costing the device its history.

## The new payload

One retained config at `<prefix>/device/<device>/config`: the device block (now carrying `serial_number` — the instance id, its natural value), an `origin` block naming this thane build as the publisher, shared `availability` in list form, and every sensor as an entry in `components` tagged `platform: "sensor"`. Full-name keys throughout — HA documents the abbreviated forms as optional, and a payload thane owns should be readable. `SensorConfig` becomes a pure component config: `AvailabilityTopic` and `Device` disappear (both live at the payload root now), which also deletes the plumbing that threaded those two values through `telemetry.SensorBuilder` and the AP-presence sensor construction; `Platform` and `DeviceClass` join it, with `Platform` defaulted by the publisher so no call site changes.

## The migration is the real work

Deleting the legacy retained configs outright makes HA remove the entities *and their registry entries*, so the re-discovered device would come back with fresh entities — customizations gone, history orphaned. HA documents a three-step migration that avoids this, and the publisher performs it itself because deploys are unattended: publish `{"migrate_discovery": true}` (retained) to each legacy per-component topic, which unloads the discovered entity while keeping its registry entry; publish the device-based payload, whose components reclaim the same `unique_id`s; then clear each legacy topic with an empty retained payload.

The bookkeeping is deliberately conservative. A suffix is recorded as migrated only after its clear publish succeeds, so an interrupted pass (broker drop mid-sequence) re-marks and re-publishes on the next reconnect rather than stranding a retained migrate marker. The sweep is per-suffix-per-process: after the first successful migration the legacy topics are empty and later passes have nothing to do, and a rollback-then-redeploy (old binary re-litters the legacy topics) self-heals on the next new-binary start. Runtime-registered sensors get the same treatment — per-loop telemetry sensors arrive via `EnsureSensor` after startup, and their legacy topics may exist from a previous binary's run, so the migrate-then-clear runs the first time this process sees a suffix, not just at boot. Each phase logs (`migration started` / `migrated to device-based` with counts) so the deploy can be verified from the logs.

## Test plan

- [x] `just ci` green locally
- [x] New: device payload wire shape — root keys `device`/`origin`/`availability`/`components`, origin content, `serial_number`, per-component `platform` (`TestDeviceDiscoveryConfig_PayloadShape`)
- [x] New: component assembly — static + dynamic merge, dynamic overrides static suffix, `platform` defaulted (`TestPublisher_SnapshotComponents`)
- [x] New: migration bookkeeping — sorted pending set, `markMigrated` removes from later sweeps (`TestPublisher_MigrationBookkeeping`)
- [x] Updated: topic paths (`device/` topic + legacy topic kept for migration), device info (serial number), origin block, slimmed `SensorConfig` marshalling
- [ ] Post-deploy on the production device: entities keep their entity_ids and customizations, legacy `sensor/.../config` topics end empty, logs show the two migration phases

🤖 Generated with [Claude Code](https://claude.com/claude-code)
