### PR TITLE
feat(loop): attribute every wake to its cause

### DIFF
--- a/internal/platform/events/bus.go
+++ b/internal/platform/events/bus.go
@@ -109,7 +109,9 @@ const (
 	KindLoopTopology = "loop_topology"
 	// KindLoopIterationStart signals the beginning of a loop iteration.
 	// Data: loop_id, loop_name, conversation_id, supervisor,
-	// supervisor_trigger, attempt, signal_envelopes.
+	// supervisor_trigger, attempt, signal_envelopes, mailbox_items,
+	// wake_reason (what woke the loop: timer, mailbox, subscription,
+	// manual, ...), and wake_source when the wake carried a sender.
 	KindLoopIterationStart = "loop_iteration_start"
 	// KindLoopIterationComplete signals the end of a loop iteration.
 	// Data: loop_id, loop_name, model, input_tokens, output_tokens,

--- a/internal/runtime/loop/config.go
+++ b/internal/runtime/loop/config.go
@@ -608,6 +608,19 @@ type Status struct {
 	// cadence, which a lifetime iteration count cannot stand in for on a
 	// loop that keeps changing its own interval.
 	WakesLast24h int `json:"wakes_last_24h,omitempty"`
+	// LastWakeReason attributes the most recent iteration start: what
+	// actually woke the loop (timer, mailbox, subscription, manual
+	// loop_wake, ...). Empty before the first iteration. See
+	// [WakeReason] for the vocabulary.
+	LastWakeReason WakeReason `json:"last_wake_reason,omitempty"`
+	// LastWakeSource is the sender/producer identity behind
+	// LastWakeReason when the wake carried one (a loop_wake caller, a
+	// wake dispatcher name, a mailbox key prefix); empty otherwise.
+	LastWakeSource string `json:"last_wake_source,omitempty"`
+	// WakeReasons24h histograms the trailing day's iteration starts by
+	// wake reason — the attribution companion to WakesLast24h. Nil when
+	// no wakes are retained in the window.
+	WakeReasons24h map[string]int `json:"wake_reasons_24h,omitempty"`
 	// Iterations is the total number of completed (successful) iterations.
 	Iterations int `json:"iterations"`
 	// Attempts is the total number of iteration attempts (including failures).

--- a/internal/runtime/loop/loop.go
+++ b/internal/runtime/loop/loop.go
@@ -236,13 +236,27 @@ type Loop struct {
 	lastSleptFor     time.Duration
 	lastSleptPlanned time.Duration
 
-	// wakeTimes is the trailing-24h record of iteration start instants,
-	// oldest first. It answers "how often have I actually been running"
-	// — a number a self-pacing loop needs and cannot derive from a
-	// lifetime iteration count, because the interval it chose has been
-	// changing the whole time. Pruned on append; see maxWakeHistory for
-	// what a sub-minute poller does to it.
-	wakeTimes []time.Time
+	// wakeHistory is the trailing-24h record of iteration starts,
+	// oldest first, each carrying its wake reason. It answers "how
+	// often have I actually been running, and why" — numbers a
+	// self-pacing loop needs and cannot derive from a lifetime
+	// iteration count, because the interval it chose has been
+	// changing the whole time. Pruned on append; see maxWakeHistory
+	// for what a sub-minute poller does to it.
+	wakeHistory []wakeRecord
+
+	// pendingWakeCauses records content-detached wake pokes (mailbox
+	// enqueues, retained-row re-wakes, external nudges, retune
+	// returns) between iterations, appended under l.mu at the poke
+	// site and drained by [Loop.beginIterationWake]. Notification
+	// envelopes are not recorded here; they classify themselves at
+	// drain time. Capped at maxPendingWakeCauses, drop-newest.
+	pendingWakeCauses []wakeCause
+
+	// lastWakeAttr is the resolved attribution of the most recent
+	// iteration start — why the loop last woke, and who woke it when
+	// the wake carried a sender. Zero before the first iteration.
+	lastWakeAttr WakeAttribution
 
 	// lastSupervisorAt is when the most recent successful supervisor turn
 	// ran, the wall-clock companion to lastSupervisorIter. Iterations-ago
@@ -748,6 +762,9 @@ func (l *Loop) Status() Status {
 		SleptFor:              l.lastSleptFor,
 		SleptPlanned:          l.lastSleptPlanned,
 		WakesLast24h:          l.wakesInWindowLocked(time.Now()),
+		LastWakeReason:        l.lastWakeAttr.Reason,
+		LastWakeSource:        l.lastWakeAttr.Source,
+		WakeReasons24h:        l.wakeReasonsInWindowLocked(time.Now()),
 		Iterations:            l.iterations,
 		Attempts:              l.attempts,
 		TotalInputTokens:      l.totalInputTokens,
@@ -1289,6 +1306,14 @@ func (l *Loop) run(ctx context.Context) {
 		defer cancel()
 	}
 
+	// wakeInterrupted carries the most recent timer sleep's outcome to
+	// the next iteration's wake attribution: true when a wakeCh poke cut
+	// the sleep short. It is a low-priority attribution input — drained
+	// content and recorded causes explain a wake first — and exists so a
+	// coalesced token whose content was consumed elsewhere reads as an
+	// unexplained early wake rather than masquerading as the timer.
+	wakeInterrupted := false
+
 	// --- INITIAL SLEEP (timer-driven loops only) ---
 	// On fresh startup, timer-driven loops sleep before their first
 	// iteration instead of firing immediately. The delay is jittered
@@ -1318,13 +1343,15 @@ func (l *Loop) run(ctx context.Context) {
 			"duration", initialSleep.Round(time.Second),
 		)
 
-		if !l.sleep(ctx, initialSleep) {
+		ok, interrupted := l.sleep(ctx, initialSleep)
+		if !ok {
 			logger.Debug("loop stopped during initial sleep",
 				"phase", "initial_sleep",
 			)
 			l.emitStopped()
 			return
 		}
+		wakeInterrupted = interrupted
 	}
 
 	for {
@@ -1418,7 +1445,7 @@ func (l *Loop) run(ctx context.Context) {
 					"consecutive_errors", consecutiveErrors,
 					"backoff", backoff.Round(time.Second),
 				)
-				if !l.sleep(ctx, backoff) {
+				if ok, _ := l.sleep(ctx, backoff); !ok {
 					logger.Debug("loop stopped during wait backoff",
 						"phase", "wait_backoff",
 						"backoff", backoff.Round(time.Second),
@@ -1503,10 +1530,11 @@ func (l *Loop) run(ctx context.Context) {
 		iterStartTime := time.Now()
 		// Recorded before dispatch, unlike lastWakeAt below, so the turn
 		// being built can count itself. A no-op iteration still consumed a
-		// wake, so this does not share lastWakeAt's no-op skip.
-		l.mu.Lock()
-		l.recordWakeLocked(iterStartTime)
-		l.mu.Unlock()
+		// wake, so this does not share lastWakeAt's no-op skip. The same
+		// call resolves WHY the iteration is starting, from the drained
+		// signals/mailbox content plus the recorded poke causes.
+		wakeAttr := l.beginIterationWake(iterStartTime, signals, mailboxItems, event, wakeInterrupted, attemptCount == 0)
+		wakeInterrupted = false
 
 		// Dispatch: Handler runs directly; otherwise build an agent
 		// turn and let the loop runtime execute it.
@@ -1521,20 +1549,25 @@ func (l *Loop) run(ctx context.Context) {
 		// Transition to processing and emit iteration_start before
 		// dispatching work so the dashboard sees activity immediately.
 		l.setState(StateProcessing)
+		iterStartData := map[string]any{
+			"loop_id":            l.id,
+			"loop_name":          l.config.Name,
+			"conversation_id":    convID,
+			"supervisor":         isSupervisor,
+			"supervisor_trigger": string(supervisorTrigger),
+			"attempt":            attemptCount + 1,
+			"signal_envelopes":   len(signals),
+			"mailbox_items":      len(mailboxItems),
+			"wake_reason":        string(wakeAttr.Reason),
+		}
+		if wakeAttr.Source != "" {
+			iterStartData["wake_source"] = wakeAttr.Source
+		}
 		l.publishEvent(events.Event{
 			Timestamp: time.Now(),
 			Source:    events.SourceLoop,
 			Kind:      events.KindLoopIterationStart,
-			Data: map[string]any{
-				"loop_id":            l.id,
-				"loop_name":          l.config.Name,
-				"conversation_id":    convID,
-				"supervisor":         isSupervisor,
-				"supervisor_trigger": string(supervisorTrigger),
-				"attempt":            attemptCount + 1,
-				"signal_envelopes":   len(signals),
-				"mailbox_items":      len(mailboxItems),
-			},
+			Data:      iterStartData,
 		})
 		iterLog.Debug("loop iteration starting")
 
@@ -1950,12 +1983,14 @@ func (l *Loop) run(ctx context.Context) {
 
 			iterLog.Debug("loop sleeping", "duration", sleep.Round(time.Second))
 
-			if !l.sleep(ctx, sleep) {
+			ok, interrupted := l.sleep(ctx, sleep)
+			if !ok {
 				logger.Debug("loop stopped during sleep",
 					"phase", "sleep",
 				)
 				break
 			}
+			wakeInterrupted = interrupted
 		} else if l.config.WaitFunc == nil && err != nil && mailboxErr == nil && len(mailboxItems) > 0 && l.hasAttemptsRemaining() {
 			// OperationEventDriven with a failed turn and un-acked
 			// mailbox rows: waitForWake would block until the next
@@ -1974,7 +2009,7 @@ func (l *Loop) run(ctx context.Context) {
 				"backoff", backoff.Round(time.Second),
 				"retained_items", len(mailboxItems),
 			)
-			if !l.sleep(ctx, backoff) {
+			if ok, _ := l.sleep(ctx, backoff); !ok {
 				logger.Debug("loop stopped during mailbox retry backoff",
 					"phase", "mailbox_backoff",
 				)

--- a/internal/runtime/loop/loop_view.go
+++ b/internal/runtime/loop/loop_view.go
@@ -82,6 +82,16 @@ type LoopView struct {
 	// counting the one in flight — the cadence actually achieved, as
 	// against the SleepEnvelope's permitted one.
 	WakesLast24h *int `json:"wakes_last_24h"`
+	// LastWakeReason attributes the most recent iteration start (timer,
+	// mailbox, subscription, manual, ...), and LastWakeSource names the
+	// sender when the wake carried one. Null before the first iteration
+	// and on stored-only rows.
+	LastWakeReason *string `json:"last_wake_reason"`
+	LastWakeSource *string `json:"last_wake_source,omitempty"`
+	// WakeReasons24h histograms the trailing day's wakes by reason — how
+	// the achieved cadence decomposes into self-chosen timer wakes versus
+	// externally driven ones. Omitted when the window is empty.
+	WakeReasons24h map[string]int `json:"wake_reasons_24h,omitempty"`
 
 	// ---- economics (%CPU / %MEM / TIME) ----
 	Iterations        *int `json:"iterations"`
@@ -395,6 +405,15 @@ func applyLiveTelemetry(v *LoopView, s Status, now time.Time) {
 	}
 	wakes := s.WakesLast24h
 	v.WakesLast24h = &wakes
+	if s.LastWakeReason != "" {
+		reason := string(s.LastWakeReason)
+		v.LastWakeReason = &reason
+		if s.LastWakeSource != "" {
+			source := s.LastWakeSource
+			v.LastWakeSource = &source
+		}
+	}
+	v.WakeReasons24h = s.WakeReasons24h
 
 	// Token economics — left nil for handler-only loops, which run no LLM
 	// iterations and have no token metrics (a literal 0 would read as a real

--- a/internal/runtime/loop/loop_view_test.go
+++ b/internal/runtime/loop/loop_view_test.go
@@ -400,6 +400,42 @@ func TestLoopViewResolver_FromStatus_CadenceSelfKnowledge(t *testing.T) {
 	}
 }
 
+// TestLoopViewResolver_FromStatus_WakeAttribution pins the projection of
+// wake attribution: reason and source ride the row when the loop has
+// woken at least once, and the trailing-day histogram decomposes the
+// achieved cadence by cause. A loop with no wakes yet keeps every
+// attribution field null rather than inventing a reason.
+func TestLoopViewResolver_FromStatus_WakeAttribution(t *testing.T) {
+	now := time.Date(2026, 8, 11, 12, 0, 0, 0, time.UTC)
+	r := NewLoopViewResolver(nil, nil, now)
+
+	v := r.FromStatus(Status{
+		ID: "lp_arch", Name: "archivist", State: State("processing"),
+		LastWakeReason: WakeReasonMailbox,
+		LastWakeSource: "session",
+		WakeReasons24h: map[string]int{"mailbox": 12, "timer": 3},
+		Config:         Config{Operation: OperationService},
+	})
+	if v.LastWakeReason == nil || *v.LastWakeReason != "mailbox" {
+		t.Errorf("LastWakeReason = %v, want mailbox", v.LastWakeReason)
+	}
+	if v.LastWakeSource == nil || *v.LastWakeSource != "session" {
+		t.Errorf("LastWakeSource = %v, want session", v.LastWakeSource)
+	}
+	if v.WakeReasons24h["mailbox"] != 12 || v.WakeReasons24h["timer"] != 3 {
+		t.Errorf("WakeReasons24h = %v, want mailbox:12 timer:3", v.WakeReasons24h)
+	}
+
+	fresh := r.FromStatus(Status{
+		ID: "lp_new", Name: "fresh", State: State("sleeping"),
+		Config: Config{Operation: OperationService},
+	})
+	if fresh.LastWakeReason != nil || fresh.LastWakeSource != nil || fresh.WakeReasons24h != nil {
+		t.Errorf("pre-first-wake row must keep attribution null, got reason=%v source=%v histogram=%v",
+			fresh.LastWakeReason, fresh.LastWakeSource, fresh.WakeReasons24h)
+	}
+}
+
 // TestLoopViewResolver_FromStatus_SupervisorRecencyInBothUnits pins the
 // pair: turns-back answers "has my recent work been reviewed", time-ago
 // answers "how long since" — different questions on a loop whose interval

--- a/internal/runtime/loop/mailbox.go
+++ b/internal/runtime/loop/mailbox.go
@@ -305,6 +305,10 @@ func (l *Loop) enqueueMailbox(ctx context.Context, keyPrefix string, payload []b
 		ItemID:       item.ID,
 		PendingItems: pending,
 	}
+	// The drained item carries no producer label, so record the enqueue
+	// key prefix as the wake source before poking; the next iteration's
+	// attribution corroborates it against the items it actually drains.
+	l.recordWakeCauseLocked(wakeCause{reason: WakeReasonMailbox, source: keyPrefix})
 	select {
 	case l.wakeCh <- struct{}{}:
 	default:
@@ -391,10 +395,16 @@ func (l *Loop) wakeIfMailboxNonEmpty(ctx context.Context) {
 	if depth == 0 {
 		return
 	}
-	l.pokeWake()
+	l.pokeWake(wakeCause{reason: WakeReasonMailboxRetry, source: "retained"})
 }
 
-func (l *Loop) pokeWake() {
+// pokeWake records why the wake is being requested, then signals the
+// coalescing wake channel. Every caller states its cause so the next
+// iteration's attribution never has to guess who poked.
+func (l *Loop) pokeWake(cause wakeCause) {
+	l.mu.Lock()
+	l.recordWakeCauseLocked(cause)
+	l.mu.Unlock()
 	select {
 	case l.wakeCh <- struct{}{}:
 	default:

--- a/internal/runtime/loop/registry_signal.go
+++ b/internal/runtime/loop/registry_signal.go
@@ -42,7 +42,7 @@ func (r *Registry) WakeLoop(ctx context.Context, id string) error {
 	if l == nil {
 		return fmt.Errorf("loop %q not found", id)
 	}
-	l.pokeWake()
+	l.pokeWake(wakeCause{reason: WakeReasonMailbox, source: "external"})
 	return nil
 }
 

--- a/internal/runtime/loop/signals.go
+++ b/internal/runtime/loop/signals.go
@@ -388,7 +388,12 @@ func (l *Loop) waitForEvent(ctx context.Context) (any, error) {
 	}
 }
 
-func (l *Loop) sleep(ctx context.Context, d time.Duration) bool {
+// sleep blocks for d unless woken early. It returns ok=false when the
+// context was cancelled (the loop should exit), and interrupted=true
+// when a wakeCh poke — not the timer — ended the sleep, which feeds the
+// next iteration's wake attribution as the lowest-priority signal that
+// the wake was not the loop's own cadence.
+func (l *Loop) sleep(ctx context.Context, d time.Duration) (ok, interrupted bool) {
 	// Record the scheduled wake instant so loop_status can report when the
 	// loop next fires; clear it on wake so a processing loop never reports a
 	// stale deadline. A wakeCh notification can cut the sleep short — this is
@@ -418,12 +423,12 @@ func (l *Loop) sleep(ctx context.Context, d time.Duration) bool {
 		select {
 		case <-ctx.Done():
 			timer.Stop()
-			return false
+			return false, false
 		case <-timer.C:
-			return true
+			return true, false
 		case <-l.wakeCh:
 			timer.Stop()
-			return true
+			return true, true
 		case <-l.retuneCh:
 			timer.Stop()
 			// Promote the pending retune and re-clamp this sleep as if
@@ -447,6 +452,12 @@ func (l *Loop) sleep(ctx context.Context, d time.Duration) bool {
 			deadline = start.Add(nd)
 			l.sleepUntil = deadline
 			l.currentSleep = nd
+			overdue := !time.Now().Before(deadline)
+			if overdue {
+				// The edited envelope made this sleep overdue: the loop
+				// wakes now, and the retune is what woke it.
+				l.recordWakeCauseLocked(wakeCause{reason: WakeReasonRetune})
+			}
 			l.mu.Unlock()
 			if promoted {
 				l.deps.Logger.Info("loop retune applied",
@@ -455,8 +466,8 @@ func (l *Loop) sleep(ctx context.Context, d time.Duration) bool {
 					"resleep", nd.Round(time.Second).String(),
 				)
 			}
-			if !time.Now().Before(deadline) {
-				return true
+			if overdue {
+				return true, true
 			}
 		}
 	}

--- a/internal/runtime/loop/wake_history.go
+++ b/internal/runtime/loop/wake_history.go
@@ -2,19 +2,28 @@ package loop
 
 import "time"
 
-// wakeHistoryWindow is the span [Loop.wakeTimes] retains. Twenty-four
+// wakeHistoryWindow is the span [Loop.wakeHistory] retains. Twenty-four
 // hours is the window a loop reasons in when it asks whether its current
 // cadence is proportionate — long enough to cover a full day/night cycle
 // of household activity, short enough that a rate change shows up.
 const wakeHistoryWindow = 24 * time.Hour
 
-// maxWakeHistory caps the retained instants so the ring cannot grow
+// maxWakeHistory caps the retained records so the ring cannot grow
 // without bound. A loop with a cognitive cadence never approaches it: at
 // the tightest core envelope (a 15m floor) a day holds 96 wakes. Only a
 // sub-minute handler poller saturates it, and those loops run no model
 // turn, so the undercount it would cause never reaches a prompt — it
 // would only clip the operator-facing count in loop_status.
 const maxWakeHistory = 2048
+
+// wakeRecord is one retained iteration start: when it began and what
+// woke it. The reason rides the ring so the trailing-day histogram in
+// [Loop.wakeReasonsInWindowLocked] answers "who has been waking this
+// loop" without consulting the persistent event journal.
+type wakeRecord struct {
+	at     time.Time
+	reason WakeReason
+}
 
 // recordWakeLocked appends an iteration start and drops everything that
 // has fallen out of the window. Called with l.mu held.
@@ -23,41 +32,60 @@ const maxWakeHistory = 2048
 // mid-turn sees itself included — "this is my 48th turn today", not "I
 // had 47 before this one". The former is the number a loop is actually
 // deciding against.
-func (l *Loop) recordWakeLocked(at time.Time) {
-	l.wakeTimes = append(l.wakeTimes, at)
+func (l *Loop) recordWakeLocked(at time.Time, reason WakeReason) {
+	l.wakeHistory = append(l.wakeHistory, wakeRecord{at: at, reason: reason})
 	l.pruneWakeHistoryLocked(at)
 }
 
-// pruneWakeHistoryLocked drops instants older than the window, then
+// pruneWakeHistoryLocked drops records older than the window, then
 // enforces the hard cap. Called with l.mu held.
 func (l *Loop) pruneWakeHistoryLocked(now time.Time) {
 	cutoff := now.Add(-wakeHistoryWindow)
 	keep := 0
-	for keep < len(l.wakeTimes) && l.wakeTimes[keep].Before(cutoff) {
+	for keep < len(l.wakeHistory) && l.wakeHistory[keep].at.Before(cutoff) {
 		keep++
 	}
 	if keep > 0 {
-		l.wakeTimes = append(l.wakeTimes[:0], l.wakeTimes[keep:]...)
+		l.wakeHistory = append(l.wakeHistory[:0], l.wakeHistory[keep:]...)
 	}
-	if over := len(l.wakeTimes) - maxWakeHistory; over > 0 {
-		l.wakeTimes = append(l.wakeTimes[:0], l.wakeTimes[over:]...)
+	if over := len(l.wakeHistory) - maxWakeHistory; over > 0 {
+		l.wakeHistory = append(l.wakeHistory[:0], l.wakeHistory[over:]...)
 	}
 }
 
-// wakesInWindowLocked counts the retained instants inside the window as
+// wakesInWindowLocked counts the retained records inside the window as
 // of now. Called with l.mu held.
 //
-// It counts rather than trusting len(l.wakeTimes) because the slice is
+// It counts rather than trusting len(l.wakeHistory) because the slice is
 // only pruned when a wake is appended: a loop that has been sleeping for
 // a day would otherwise report the wakes it had before that sleep.
 func (l *Loop) wakesInWindowLocked(now time.Time) int {
 	cutoff := now.Add(-wakeHistoryWindow)
 	count := 0
-	for i := len(l.wakeTimes) - 1; i >= 0; i-- {
-		if l.wakeTimes[i].Before(cutoff) {
+	for i := len(l.wakeHistory) - 1; i >= 0; i-- {
+		if l.wakeHistory[i].at.Before(cutoff) {
 			break
 		}
 		count++
 	}
 	return count
+}
+
+// wakeReasonsInWindowLocked histograms the retained records inside the
+// window by reason, as of now. Returns nil when the window is empty so
+// callers can omit the field entirely. String-keyed for direct JSON
+// serialization on [Status]. Called with l.mu held.
+func (l *Loop) wakeReasonsInWindowLocked(now time.Time) map[string]int {
+	cutoff := now.Add(-wakeHistoryWindow)
+	var counts map[string]int
+	for i := len(l.wakeHistory) - 1; i >= 0; i-- {
+		if l.wakeHistory[i].at.Before(cutoff) {
+			break
+		}
+		if counts == nil {
+			counts = make(map[string]int)
+		}
+		counts[string(l.wakeHistory[i].reason)]++
+	}
+	return counts
 }

--- a/internal/runtime/loop/wake_history_test.go
+++ b/internal/runtime/loop/wake_history_test.go
@@ -15,13 +15,13 @@ func TestWakeHistoryCountsTheTrailingDay(t *testing.T) {
 		now.Add(-2 * time.Hour),
 		now,
 	} {
-		l.recordWakeLocked(at)
+		l.recordWakeLocked(at, WakeReasonTimer)
 	}
 	if got := l.wakesInWindowLocked(now); got != 3 {
 		t.Errorf("wakes in window = %d, want 3", got)
 	}
-	if len(l.wakeTimes) != 3 {
-		t.Errorf("retained %d instants, want the pruned 3", len(l.wakeTimes))
+	if len(l.wakeHistory) != 3 {
+		t.Errorf("retained %d records, want the pruned 3", len(l.wakeHistory))
 	}
 }
 
@@ -32,8 +32,8 @@ func TestWakeHistoryCountsTheTrailingDay(t *testing.T) {
 func TestWakeHistoryAgesOutWithoutANewWake(t *testing.T) {
 	start := time.Date(2026, 7, 27, 12, 0, 0, 0, time.UTC)
 	l := &Loop{}
-	l.recordWakeLocked(start)
-	l.recordWakeLocked(start.Add(time.Hour))
+	l.recordWakeLocked(start, WakeReasonTimer)
+	l.recordWakeLocked(start.Add(time.Hour), WakeReasonTimer)
 
 	if got := l.wakesInWindowLocked(start.Add(2 * time.Hour)); got != 2 {
 		t.Fatalf("wakes shortly after = %d, want 2", got)
@@ -49,15 +49,47 @@ func TestWakeHistoryDropsOldestPastTheCap(t *testing.T) {
 	// Every instant is inside the window, so only the hard cap can bound
 	// the slice — this is the sub-minute-poller case.
 	for i := range maxWakeHistory + 100 {
-		l.recordWakeLocked(now.Add(time.Duration(i) * time.Second))
+		l.recordWakeLocked(now.Add(time.Duration(i)*time.Second), WakeReasonTimer)
 	}
-	if len(l.wakeTimes) != maxWakeHistory {
-		t.Fatalf("retained %d instants, want the cap %d", len(l.wakeTimes), maxWakeHistory)
+	if len(l.wakeHistory) != maxWakeHistory {
+		t.Fatalf("retained %d records, want the cap %d", len(l.wakeHistory), maxWakeHistory)
 	}
 	// The newest survive: a truncated history should still describe the
 	// recent past rather than a stale prefix of it.
 	newest := now.Add(time.Duration(maxWakeHistory+99) * time.Second)
-	if got := l.wakeTimes[len(l.wakeTimes)-1]; !got.Equal(newest) {
+	if got := l.wakeHistory[len(l.wakeHistory)-1].at; !got.Equal(newest) {
 		t.Errorf("newest retained instant = %v, want %v", got, newest)
+	}
+}
+
+// TestWakeReasonHistogramWindows mirrors the count semantics: the
+// histogram covers only the trailing day as of the asked-for instant,
+// and an empty window reports nil so callers can omit the field.
+func TestWakeReasonHistogramWindows(t *testing.T) {
+	now := time.Date(2026, 7, 27, 12, 0, 0, 0, time.UTC)
+	l := &Loop{}
+	l.recordWakeLocked(now.Add(-30*time.Hour), WakeReasonManual) // outside the window
+	l.recordWakeLocked(now.Add(-23*time.Hour), WakeReasonTimer)
+	l.recordWakeLocked(now.Add(-2*time.Hour), WakeReasonMailbox)
+	l.recordWakeLocked(now.Add(-1*time.Hour), WakeReasonMailbox)
+	l.recordWakeLocked(now, WakeReasonSubscription)
+
+	got := l.wakeReasonsInWindowLocked(now)
+	want := map[string]int{
+		"timer":        1,
+		"mailbox":      2,
+		"subscription": 1,
+	}
+	if len(got) != len(want) {
+		t.Fatalf("histogram = %v, want %v", got, want)
+	}
+	for reason, count := range want {
+		if got[reason] != count {
+			t.Errorf("histogram[%s] = %d, want %d", reason, got[reason], count)
+		}
+	}
+
+	if got := l.wakeReasonsInWindowLocked(now.Add(48 * time.Hour)); got != nil {
+		t.Errorf("histogram two days later = %v, want nil", got)
 	}
 }

--- a/internal/runtime/loop/wake_reason.go
+++ b/internal/runtime/loop/wake_reason.go
@@ -1,0 +1,224 @@
+package loop
+
+import (
+	"time"
+
+	"github.com/nugget/thane-ai-agent/internal/channels/messages"
+)
+
+// WakeReason classifies why a loop iteration began. Every iteration
+// start resolves exactly one reason, chosen by
+// [resolveWakeAttribution]; the value flows onto [Status],
+// [LoopView], the loop_iteration_start event, and the trailing-24h
+// wake ring so cadence questions ("who keeps waking this loop?") are
+// answerable without correlating event logs by hand.
+type WakeReason string
+
+const (
+	// WakeReasonTimer is an ordinary scheduled wake: the sleep
+	// deadline expired and nothing else claimed the iteration.
+	WakeReasonTimer WakeReason = "timer"
+
+	// WakeReasonStartup is the first iteration after boot, reached
+	// through the jittered initial sleep rather than a self-chosen
+	// cadence. Distinguished from timer so a restart-heavy day does
+	// not read as the loop's own rhythm.
+	WakeReasonStartup WakeReason = "startup"
+
+	// WakeReasonNotify is an inter-loop control notification
+	// (request_core_attention, poller signals, and other
+	// [Registry.NotifyLoop] traffic) that does not classify as
+	// manual or subscription. Source carries the sender identity.
+	WakeReasonNotify WakeReason = "notify"
+
+	// WakeReasonManual is a directed loop_wake tool call. Source
+	// carries the caller identity so "who keeps poking this loop"
+	// is a recorded fact.
+	WakeReasonManual WakeReason = "manual"
+
+	// WakeReasonSubscription is an event-source wake: a structured
+	// event batch delivered by a wake dispatcher (entity
+	// subscriptions, MQTT wake topics, and future event sources).
+	// Source names the dispatcher, e.g. "subscription_wake" or
+	// "mqtt_wake".
+	WakeReasonSubscription WakeReason = "subscription"
+
+	// WakeReasonMailbox is fresh durable data-plane input: an item
+	// was enqueued to the loop's mailbox and the enqueue woke the
+	// loop. Source carries the enqueue key prefix (the producer's
+	// readable label) when known, or "external" for a bare
+	// [Registry.WakeLoop] nudge toward already-durable work.
+	WakeReasonMailbox WakeReason = "mailbox"
+
+	// WakeReasonMailboxRetry is a re-wake for retained rows: a
+	// prior turn left mailbox items undelivered (drain cap, failed
+	// turn, boot backlog) and the runtime re-armed the wake so they
+	// retry.
+	WakeReasonMailboxRetry WakeReason = "mailbox_retry"
+
+	// WakeReasonRetune is a mid-sleep spec retune whose edited
+	// envelope made the current sleep deadline overdue, waking the
+	// loop immediately.
+	WakeReasonRetune WakeReason = "retune"
+
+	// WakeReasonEvent is a WaitFunc payload delivery on a legacy
+	// channel-reader loop.
+	WakeReasonEvent WakeReason = "event"
+)
+
+// WakeAttribution is the resolved cause of one iteration start.
+// Reason is always set once the first iteration begins; Source is
+// the sender/producer identity when the wake carried one and empty
+// otherwise.
+type WakeAttribution struct {
+	Reason WakeReason `json:"reason"`
+	Source string     `json:"source,omitempty"`
+}
+
+// wakeCause is one recorded content-detached wake poke, appended
+// under l.mu at the poke site and drained by the next iteration's
+// [Loop.beginIterationWake]. Only pokes whose cause is not
+// recoverable from drained content are recorded: mailbox enqueues
+// (the drained item does not carry its producer label), retained-row
+// re-wakes, external nudges, and retune-overdue returns.
+// Notification envelopes are NOT recorded here — they are classified
+// from the drained envelopes themselves, which is authoritative for
+// exactly the content the iteration processes.
+type wakeCause struct {
+	reason WakeReason
+	source string
+}
+
+// maxPendingWakeCauses bounds the recorded pokes between iterations.
+// The first cause after a drain is the one that actually woke the
+// loop; later ones are pile-on, so overflow drops the newest.
+const maxPendingWakeCauses = 8
+
+// recordWakeCauseLocked appends one poke cause. Called with l.mu held.
+func (l *Loop) recordWakeCauseLocked(c wakeCause) {
+	if len(l.pendingWakeCauses) >= maxPendingWakeCauses {
+		return
+	}
+	l.pendingWakeCauses = append(l.pendingWakeCauses, c)
+}
+
+// classifyNotifyWake maps one drained notification envelope to its
+// wake attribution. The payload kind is the wire-level discriminator:
+// "loop_wake" is the directed wake tool, "event_source" is the shape
+// every wake dispatcher builds via [messages.NewEventSourceEnvelope];
+// anything else is ordinary inter-loop notification traffic.
+func classifyNotifyWake(env messages.Envelope) WakeAttribution {
+	payload, _ := decodeLoopNotifyPayload(env.Payload)
+	switch payload.Kind {
+	case "loop_wake":
+		return WakeAttribution{Reason: WakeReasonManual, Source: env.From.Name}
+	case "event_source":
+		return WakeAttribution{Reason: WakeReasonSubscription, Source: env.From.Name}
+	default:
+		return WakeAttribution{Reason: WakeReasonNotify, Source: env.From.Name}
+	}
+}
+
+// Attribution precedence ranks. Content the iteration actually
+// drained outranks recorded pokes, and control-plane outranks
+// data-plane, so an iteration that processes both a notification and
+// mailbox items attributes to the notification while the event data
+// still counts both.
+const (
+	wakeRankManual       = 60
+	wakeRankSubscription = 50
+	wakeRankNotify       = 40
+	wakeRankEvent        = 35
+	wakeRankMailbox      = 30
+	wakeRankMailboxRetry = 20
+	wakeRankRetune       = 15
+	wakeRankMailboxNoRec = 10
+)
+
+// resolveWakeAttribution decides why an iteration is starting.
+//
+// Deterministic precedence: drained notification envelopes (manual >
+// subscription > notify) beat a WaitFunc event payload, which beats
+// mailbox causes (fresh enqueue > retained-row retry, and both
+// require drained items so a poke that raced past this iteration's
+// drain cannot claim it), which beat a retune-overdue return. With
+// nothing to attribute, an interrupted sleep or an event-driven wake
+// is an honest "notify/unknown" (a coalesced token whose content was
+// consumed elsewhere), the first timer iteration after boot is
+// "startup", and everything else is the timer.
+func resolveWakeAttribution(causes []wakeCause, signals []messages.Envelope, mailboxItems []MailboxItem, event any, interrupted, firstIteration, eventDriven bool) WakeAttribution {
+	best := WakeAttribution{}
+	bestRank := 0
+	consider := func(a WakeAttribution, rank int) {
+		if rank > bestRank {
+			best = a
+			bestRank = rank
+		}
+	}
+
+	for _, env := range signals {
+		attr := classifyNotifyWake(env)
+		switch attr.Reason {
+		case WakeReasonManual:
+			consider(attr, wakeRankManual)
+		case WakeReasonSubscription:
+			consider(attr, wakeRankSubscription)
+		default:
+			consider(attr, wakeRankNotify)
+		}
+	}
+
+	if event != nil {
+		if _, isNotifyPoke := event.(notifyWakeEvent); !isNotifyPoke {
+			consider(WakeAttribution{Reason: WakeReasonEvent}, wakeRankEvent)
+		}
+	}
+
+	if len(mailboxItems) > 0 {
+		// Items are present, so a mailbox-family cause is corroborated.
+		// Without any recorded cause the items still explain the wake
+		// (their poke was consumed by an earlier iteration that hit the
+		// drain cap), just without a producer label.
+		consider(WakeAttribution{Reason: WakeReasonMailbox}, wakeRankMailboxNoRec)
+		for _, c := range causes {
+			switch c.reason {
+			case WakeReasonMailbox:
+				consider(WakeAttribution{Reason: WakeReasonMailbox, Source: c.source}, wakeRankMailbox)
+			case WakeReasonMailboxRetry:
+				consider(WakeAttribution{Reason: WakeReasonMailboxRetry, Source: c.source}, wakeRankMailboxRetry)
+			}
+		}
+	}
+
+	for _, c := range causes {
+		if c.reason == WakeReasonRetune {
+			consider(WakeAttribution{Reason: WakeReasonRetune}, wakeRankRetune)
+		}
+	}
+
+	if bestRank > 0 {
+		return best
+	}
+	if interrupted || eventDriven {
+		return WakeAttribution{Reason: WakeReasonNotify, Source: "unknown"}
+	}
+	if firstIteration {
+		return WakeAttribution{Reason: WakeReasonStartup}
+	}
+	return WakeAttribution{Reason: WakeReasonTimer}
+}
+
+// beginIterationWake stamps the attribution for the iteration
+// beginning at, drains the recorded poke causes, and records the wake
+// in the trailing-24h ring — one critical section, so a Status
+// snapshot can never observe a wake without its reason.
+func (l *Loop) beginIterationWake(at time.Time, signals []messages.Envelope, mailboxItems []MailboxItem, event any, interrupted, firstIteration bool) WakeAttribution {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	causes := l.pendingWakeCauses
+	l.pendingWakeCauses = nil
+	attr := resolveWakeAttribution(causes, signals, mailboxItems, event, interrupted, firstIteration, l.isEventDriven())
+	l.lastWakeAttr = attr
+	l.recordWakeLocked(at, attr.Reason)
+	return attr
+}

--- a/internal/runtime/loop/wake_reason_test.go
+++ b/internal/runtime/loop/wake_reason_test.go
@@ -1,6 +1,7 @@
 package loop
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -157,18 +158,24 @@ func TestBeginIterationWakeDrainsCausesAndStampsState(t *testing.T) {
 }
 
 // TestWakeCauseCapDropsNewest: the first cause after a drain is the one
-// that actually woke the loop, so overflow keeps the oldest.
+// that actually woke the loop, so overflow keeps the oldest. Every
+// inserted cause carries a distinct source so a regression that drops
+// the oldest instead of the newest cannot slip past the assertions.
 func TestWakeCauseCapDropsNewest(t *testing.T) {
 	l := &Loop{}
 	l.mu.Lock()
 	defer l.mu.Unlock()
 	for i := 0; i < maxPendingWakeCauses+3; i++ {
-		l.recordWakeCauseLocked(wakeCause{reason: WakeReasonMailbox, source: "first-wins"})
+		l.recordWakeCauseLocked(wakeCause{reason: WakeReasonMailbox, source: fmt.Sprintf("cause-%d", i)})
 	}
 	if len(l.pendingWakeCauses) != maxPendingWakeCauses {
 		t.Fatalf("retained %d causes, want the cap %d", len(l.pendingWakeCauses), maxPendingWakeCauses)
 	}
-	if l.pendingWakeCauses[0].source != "first-wins" {
-		t.Errorf("oldest cause dropped; want first-wins retained")
+	if got := l.pendingWakeCauses[0].source; got != "cause-0" {
+		t.Errorf("oldest cause = %q, want cause-0 retained", got)
+	}
+	wantNewest := fmt.Sprintf("cause-%d", maxPendingWakeCauses-1)
+	if got := l.pendingWakeCauses[len(l.pendingWakeCauses)-1].source; got != wantNewest {
+		t.Errorf("newest retained cause = %q, want %s (overflow past the cap dropped)", got, wantNewest)
 	}
 }

--- a/internal/runtime/loop/wake_reason_test.go
+++ b/internal/runtime/loop/wake_reason_test.go
@@ -1,0 +1,174 @@
+package loop
+
+import (
+	"testing"
+	"time"
+
+	"github.com/nugget/thane-ai-agent/internal/channels/messages"
+)
+
+func notifyEnvelope(kind, fromName string) messages.Envelope {
+	return messages.Envelope{
+		From:    messages.Identity{Name: fromName},
+		Payload: messages.LoopNotifyPayload{Kind: kind},
+	}
+}
+
+func TestResolveWakeAttribution(t *testing.T) {
+	item := MailboxItem{ID: "signal:abc", EnqueuedAt: time.Now()}
+
+	tests := []struct {
+		name           string
+		causes         []wakeCause
+		signals        []messages.Envelope
+		mailboxItems   []MailboxItem
+		event          any
+		interrupted    bool
+		firstIteration bool
+		eventDriven    bool
+		want           WakeAttribution
+	}{
+		{
+			name:         "manual loop_wake outranks everything",
+			signals:      []messages.Envelope{notifyEnvelope("event_source", "subscription_wake"), notifyEnvelope("loop_wake", "core")},
+			causes:       []wakeCause{{reason: WakeReasonMailbox, source: "signal"}},
+			mailboxItems: []MailboxItem{item},
+			want:         WakeAttribution{Reason: WakeReasonManual, Source: "core"},
+		},
+		{
+			name:    "event_source envelope classifies as subscription",
+			signals: []messages.Envelope{notifyEnvelope("event_source", "mqtt_wake")},
+			want:    WakeAttribution{Reason: WakeReasonSubscription, Source: "mqtt_wake"},
+		},
+		{
+			name:    "ordinary notification names its sender",
+			signals: []messages.Envelope{notifyEnvelope("core_attention", "ranch_climate_watch")},
+			want:    WakeAttribution{Reason: WakeReasonNotify, Source: "ranch_climate_watch"},
+		},
+		{
+			name:         "signals outrank mailbox content in the same wake",
+			signals:      []messages.Envelope{notifyEnvelope("core_attention", "archivist")},
+			causes:       []wakeCause{{reason: WakeReasonMailbox, source: "signal"}},
+			mailboxItems: []MailboxItem{item},
+			want:         WakeAttribution{Reason: WakeReasonNotify, Source: "archivist"},
+		},
+		{
+			name:  "waitfunc payload attributes as event",
+			event: struct{ payload string }{"tick"},
+			want:  WakeAttribution{Reason: WakeReasonEvent},
+		},
+		{
+			name:    "notify poke sentinel is not an event",
+			event:   notifyWakeEvent{},
+			signals: []messages.Envelope{notifyEnvelope("core_attention", "poller")},
+			want:    WakeAttribution{Reason: WakeReasonNotify, Source: "poller"},
+		},
+		{
+			name:         "fresh mailbox cause carries the producer label",
+			causes:       []wakeCause{{reason: WakeReasonMailbox, source: "signal"}},
+			mailboxItems: []MailboxItem{item},
+			want:         WakeAttribution{Reason: WakeReasonMailbox, Source: "signal"},
+		},
+		{
+			name:         "fresh enqueue outranks a retained-row retry",
+			causes:       []wakeCause{{reason: WakeReasonMailboxRetry, source: "retained"}, {reason: WakeReasonMailbox, source: "signal"}},
+			mailboxItems: []MailboxItem{item},
+			want:         WakeAttribution{Reason: WakeReasonMailbox, Source: "signal"},
+		},
+		{
+			name:         "retry-only causes attribute as mailbox_retry",
+			causes:       []wakeCause{{reason: WakeReasonMailboxRetry, source: "retained"}},
+			mailboxItems: []MailboxItem{item},
+			want:         WakeAttribution{Reason: WakeReasonMailboxRetry, Source: "retained"},
+		},
+		{
+			name:         "items with no recorded cause still read as mailbox",
+			mailboxItems: []MailboxItem{item},
+			want:         WakeAttribution{Reason: WakeReasonMailbox},
+		},
+		{
+			name:   "mailbox cause without drained items cannot claim the wake",
+			causes: []wakeCause{{reason: WakeReasonMailbox, source: "signal"}},
+			want:   WakeAttribution{Reason: WakeReasonTimer},
+		},
+		{
+			name:   "retune-overdue return attributes as retune",
+			causes: []wakeCause{{reason: WakeReasonRetune}},
+			want:   WakeAttribution{Reason: WakeReasonRetune},
+		},
+		{
+			name:        "interrupted sleep with nothing drained is an unexplained notify",
+			interrupted: true,
+			want:        WakeAttribution{Reason: WakeReasonNotify, Source: "unknown"},
+		},
+		{
+			name:        "event-driven wake with nothing drained is an unexplained notify",
+			eventDriven: true,
+			want:        WakeAttribution{Reason: WakeReasonNotify, Source: "unknown"},
+		},
+		{
+			name:           "first timer iteration after boot is startup",
+			firstIteration: true,
+			want:           WakeAttribution{Reason: WakeReasonStartup},
+		},
+		{
+			name: "unremarkable wake is the timer",
+			want: WakeAttribution{Reason: WakeReasonTimer},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := resolveWakeAttribution(tt.causes, tt.signals, tt.mailboxItems, tt.event, tt.interrupted, tt.firstIteration, tt.eventDriven)
+			if got != tt.want {
+				t.Errorf("resolveWakeAttribution = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestBeginIterationWakeDrainsCausesAndStampsState covers the one
+// critical section: recorded causes are consumed exactly once, the
+// attribution lands on lastWakeAttr, and the wake ring records the
+// resolved reason.
+func TestBeginIterationWakeDrainsCausesAndStampsState(t *testing.T) {
+	l := &Loop{}
+	l.mu.Lock()
+	l.recordWakeCauseLocked(wakeCause{reason: WakeReasonMailbox, source: "signal"})
+	l.mu.Unlock()
+
+	at := time.Date(2026, 8, 11, 9, 0, 0, 0, time.UTC)
+	attr := l.beginIterationWake(at, nil, []MailboxItem{{ID: "signal:1"}}, nil, false, false)
+	if want := (WakeAttribution{Reason: WakeReasonMailbox, Source: "signal"}); attr != want {
+		t.Fatalf("attribution = %+v, want %+v", attr, want)
+	}
+
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.lastWakeAttr != attr {
+		t.Errorf("lastWakeAttr = %+v, want %+v", l.lastWakeAttr, attr)
+	}
+	if len(l.pendingWakeCauses) != 0 {
+		t.Errorf("pending causes not drained: %+v", l.pendingWakeCauses)
+	}
+	if len(l.wakeHistory) != 1 || l.wakeHistory[0].reason != WakeReasonMailbox {
+		t.Errorf("wake ring = %+v, want one mailbox record", l.wakeHistory)
+	}
+}
+
+// TestWakeCauseCapDropsNewest: the first cause after a drain is the one
+// that actually woke the loop, so overflow keeps the oldest.
+func TestWakeCauseCapDropsNewest(t *testing.T) {
+	l := &Loop{}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	for i := 0; i < maxPendingWakeCauses+3; i++ {
+		l.recordWakeCauseLocked(wakeCause{reason: WakeReasonMailbox, source: "first-wins"})
+	}
+	if len(l.pendingWakeCauses) != maxPendingWakeCauses {
+		t.Fatalf("retained %d causes, want the cap %d", len(l.pendingWakeCauses), maxPendingWakeCauses)
+	}
+	if l.pendingWakeCauses[0].source != "first-wins" {
+		t.Errorf("oldest cause dropped; want first-wins retained")
+	}
+}


### PR DESCRIPTION
First PR of the metacog pivot arc (#1341). A loop's status has always been able to say it woke 40 times yesterday; nothing recorded why, or who sent the wake. That gap is what made the curator wake-storm a log-archaeology exercise, and it is the first thing an internal-operations observer needs answered as a recorded fact.

Every iteration start now resolves a `WakeAttribution{reason, source}`. The design splits the evidence in two. Notification envelopes classify themselves at drain time by wire shape — payload kind `loop_wake` is a directed manual wake (source = the caller), `event_source` is a dispatcher batch (source = `subscription_wake` / `mqtt_wake`), anything else is ordinary inter-loop notify traffic — so the classification is authoritative for exactly the content the iteration processes, with no name-list coupling to the app layer. Content-detached pokes, which a drained item cannot explain, record a `wakeCause` under the loop lock at the poke site: a mailbox enqueue records its key prefix as the producer label, a retained-row re-wake records `mailbox_retry`, a bare `Registry.WakeLoop` nudge records `mailbox/external`, and a retune whose edited envelope made the sleep overdue records `retune`. The next iteration drains those causes in the same critical section that records the wake ring entry, and corroborates mailbox causes against the items it actually drained, so a poke that raced past this iteration's drain cannot claim it.

Precedence is deterministic and content-first: manual > subscription > notify > WaitFunc event > fresh mailbox > mailbox_retry > retune. With nothing to attribute, an interrupted sleep — `sleep()` now reports whether a wakeCh poke cut it short — or an event-driven wake reads as an honest `notify/unknown` rather than masquerading as the timer, the first timer iteration after boot is `startup` (a restart-heavy day should not read as the loop's chosen rhythm), and everything else is the timer.

The attribution flows onto every surface that will need it downstream: `Status.last_wake_reason` / `last_wake_source` plus a `wake_reasons_24h` histogram (the wake ring now carries reasons), the canonical `LoopView` row (null before the first wake, per its live-field convention), and the `loop_iteration_start` event payload — which is the seam the arc's upcoming persistent loop-event journal will read, so post-incident wake forensics stop depending on process lifetime.

## Test plan

- [x] `resolveWakeAttribution` precedence matrix (16 cases: envelope classification, content-vs-cause corroboration, race fallbacks, startup/timer defaults)
- [x] Wake ring reason histogram windows and ages out with the existing count semantics
- [x] `beginIterationWake` drains causes exactly once, stamps `lastWakeAttr`, records the ring entry in one critical section
- [x] Cause cap keeps the oldest poke (the one that actually woke the loop)
- [x] LoopView projection: attribution fields ride the row when present, stay null pre-first-wake
- [x] `just ci` green

Refs #1341

🤖 Generated with [Claude Code](https://claude.com/claude-code)
