### PR TITLE
feat(loopqueue): journal completions at the Ack chokepoint

### DIFF
--- a/internal/app/new_stores.go
+++ b/internal/app/new_stores.go
@@ -140,6 +140,30 @@ func (a *App) initStores(s *newState) error {
 	}
 	a.loopQueue = loopQueue
 
+	// Daily prune for the completions journal Ack writes — the audit
+	// trail is bounded by age, mirroring the log-index pruner's shape.
+	a.deferWorker("loop-queue-completions-pruner", func(ctx context.Context) error {
+		go func() {
+			ticker := time.NewTicker(24 * time.Hour)
+			defer ticker.Stop()
+			for {
+				if deleted, err := loopQueue.PruneCompletions(ctx, loopqueue.DefaultCompletionRetention); err != nil {
+					if ctx.Err() == nil {
+						logger.Warn("loop queue completions prune failed", "error", err)
+					}
+				} else if deleted > 0 {
+					logger.Info("pruned loop queue completions", "deleted", deleted)
+				}
+				select {
+				case <-ctx.Done():
+					return
+				case <-ticker.C:
+				}
+			}
+		}()
+		return nil
+	})
+
 	// --- Home Assistant client ---
 	// Optional but central. Without it, HA-related tools are unavailable
 	// and Thane operates as a general-purpose agent.

--- a/internal/state/loopqueue/queue_schema.go
+++ b/internal/state/loopqueue/queue_schema.go
@@ -31,5 +31,30 @@ var queueSchema = database.Schema{
 			SQL: `CREATE INDEX IF NOT EXISTS idx_loop_queue_drain
 				ON loop_queue (consumer_loop, status, priority DESC, enqueued_at ASC)`,
 		},
+		database.TableCreate{
+			Table: "loop_queue_completions",
+			// The audit trail Ack would otherwise erase: one row per
+			// acknowledged item, written in the same transaction as the
+			// DELETE, so consumer throughput, wait latency, and recent
+			// outcomes are queryable facts instead of log archaeology.
+			// A coalescing re-Enqueue is deliberately NOT a completion —
+			// it restates the same pending work in place. Rows are
+			// pruned by age via [Store.PruneCompletions].
+			SQL: `CREATE TABLE IF NOT EXISTS loop_queue_completions (
+				id            INTEGER PRIMARY KEY AUTOINCREMENT,
+				consumer_loop TEXT NOT NULL,
+				dedup_key     TEXT NOT NULL,
+				priority      INTEGER NOT NULL DEFAULT 0,
+				enqueued_at   TIMESTAMP NOT NULL,
+				acked_at      TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+			)`,
+		},
+		database.IndexCreate{
+			Name: "idx_loop_queue_completions_consumer",
+			// Supports per-consumer recent-completions queries and the
+			// age-based prune.
+			SQL: `CREATE INDEX IF NOT EXISTS idx_loop_queue_completions_consumer
+				ON loop_queue_completions (consumer_loop, acked_at DESC)`,
+		},
 	},
 }

--- a/internal/state/loopqueue/queue_schema.go
+++ b/internal/state/loopqueue/queue_schema.go
@@ -51,10 +51,18 @@ var queueSchema = database.Schema{
 		},
 		database.IndexCreate{
 			Name: "idx_loop_queue_completions_consumer",
-			// Supports per-consumer recent-completions queries and the
-			// age-based prune.
+			// Supports per-consumer recent-completions queries.
 			SQL: `CREATE INDEX IF NOT EXISTS idx_loop_queue_completions_consumer
 				ON loop_queue_completions (consumer_loop, acked_at DESC)`,
+		},
+		database.IndexCreate{
+			Name: "idx_loop_queue_completions_acked",
+			// Leads with acked_at for the queries that filter on the
+			// window alone — the daily prune and the cross-consumer
+			// completion stats — which the consumer-led index above
+			// cannot serve.
+			SQL: `CREATE INDEX IF NOT EXISTS idx_loop_queue_completions_acked
+				ON loop_queue_completions (acked_at)`,
 		},
 	},
 }

--- a/internal/state/loopqueue/queue_stats.go
+++ b/internal/state/loopqueue/queue_stats.go
@@ -1,0 +1,195 @@
+package loopqueue
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// DefaultCompletionRetention is how long journaled completions are kept
+// before the daily prune removes them. Thirty days covers a full
+// month-scale incident retrospective; anything older belongs to the log
+// pipeline, not a hot audit table on thane.db.
+const DefaultCompletionRetention = 30 * 24 * time.Hour
+
+// ConsumerPending summarizes one partition's live backlog: how many
+// items are pending and how long the oldest has been waiting.
+type ConsumerPending struct {
+	Consumer         string
+	Pending          int
+	OldestEnqueuedAt time.Time
+}
+
+// PendingStats returns the live backlog per consumer partition, sorted
+// by consumer name for deterministic output. Partitions with no pending
+// work do not appear.
+func (s *Store) PendingStats(ctx context.Context) ([]ConsumerPending, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT consumer_loop, COUNT(*), MIN(enqueued_at)
+		FROM loop_queue
+		WHERE status = ?
+		GROUP BY consumer_loop
+		ORDER BY consumer_loop ASC
+	`, StatusPending)
+	if err != nil {
+		return nil, fmt.Errorf("loopqueue: pending stats: %w", err)
+	}
+	defer rows.Close()
+
+	var stats []ConsumerPending
+	for rows.Next() {
+		var (
+			cp        ConsumerPending
+			oldestRaw any
+		)
+		if err := rows.Scan(&cp.Consumer, &cp.Pending, &oldestRaw); err != nil {
+			return nil, err
+		}
+		cp.OldestEnqueuedAt = parseQueueTimestamp(oldestRaw)
+		stats = append(stats, cp)
+	}
+	return stats, rows.Err()
+}
+
+// PendingCounts returns pending depth keyed by consumer partition —
+// the join shape loop views use to attach mailbox depth to a loop row.
+// Partitions with no pending work are absent from the map.
+func (s *Store) PendingCounts(ctx context.Context) (map[string]int, error) {
+	stats, err := s.PendingStats(ctx)
+	if err != nil {
+		return nil, err
+	}
+	counts := make(map[string]int, len(stats))
+	for _, cp := range stats {
+		counts[cp.Consumer] = cp.Pending
+	}
+	return counts, nil
+}
+
+// Completion is one journaled acknowledgment: what was completed, for
+// whom, and how long it waited between enqueue and ack.
+type Completion struct {
+	Consumer   string
+	DedupKey   string
+	Priority   int
+	EnqueuedAt time.Time
+	AckedAt    time.Time
+}
+
+// Waited is the enqueue→ack span, floored at zero so clock skew in
+// stored timestamps can never report a negative wait.
+func (c Completion) Waited() time.Duration {
+	d := c.AckedAt.Sub(c.EnqueuedAt)
+	if d < 0 {
+		return 0
+	}
+	return d
+}
+
+// RecentCompletions returns journaled acks newest-first, optionally
+// scoped to one consumer partition, bounded by since and limit
+// (limit <= 0 defaults to 20).
+func (s *Store) RecentCompletions(ctx context.Context, consumer string, since time.Time, limit int) ([]Completion, error) {
+	if limit <= 0 {
+		limit = 20
+	}
+	query := `
+		SELECT consumer_loop, dedup_key, priority, enqueued_at, acked_at
+		FROM loop_queue_completions
+		WHERE acked_at >= ?`
+	args := []any{since.UTC()}
+	consumer = strings.TrimSpace(consumer)
+	if consumer != "" {
+		query += ` AND consumer_loop = ?`
+		args = append(args, consumer)
+	}
+	query += ` ORDER BY acked_at DESC, id DESC LIMIT ?`
+	args = append(args, limit)
+
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("loopqueue: recent completions: %w", err)
+	}
+	defer rows.Close()
+
+	var completions []Completion
+	for rows.Next() {
+		var (
+			c           Completion
+			enqueuedRaw any
+			ackedRaw    any
+		)
+		if err := rows.Scan(&c.Consumer, &c.DedupKey, &c.Priority, &enqueuedRaw, &ackedRaw); err != nil {
+			return nil, err
+		}
+		c.EnqueuedAt = parseQueueTimestamp(enqueuedRaw)
+		c.AckedAt = parseQueueTimestamp(ackedRaw)
+		completions = append(completions, c)
+	}
+	return completions, rows.Err()
+}
+
+// CompletionStats aggregates one consumer's journaled acks over a
+// window: count and the average/max enqueue→ack wait.
+type CompletionStats struct {
+	Consumer string
+	Count    int
+	AvgWait  time.Duration
+	MaxWait  time.Duration
+}
+
+// CompletionStatsSince aggregates journaled acks per consumer since the
+// given instant, sorted by consumer name. The wait math runs in SQL
+// (julianday spans) so callers never re-derive it; negative spans from
+// skewed stored timestamps clamp to zero.
+func (s *Store) CompletionStatsSince(ctx context.Context, since time.Time) ([]CompletionStats, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT consumer_loop,
+			COUNT(*),
+			AVG(MAX((julianday(acked_at) - julianday(enqueued_at)) * 86400.0, 0)),
+			MAX(MAX((julianday(acked_at) - julianday(enqueued_at)) * 86400.0, 0))
+		FROM loop_queue_completions
+		WHERE acked_at >= ?
+		GROUP BY consumer_loop
+		ORDER BY consumer_loop ASC
+	`, since.UTC())
+	if err != nil {
+		return nil, fmt.Errorf("loopqueue: completion stats: %w", err)
+	}
+	defer rows.Close()
+
+	var stats []CompletionStats
+	for rows.Next() {
+		var (
+			cs      CompletionStats
+			avgSecs float64
+			maxSecs float64
+		)
+		if err := rows.Scan(&cs.Consumer, &cs.Count, &avgSecs, &maxSecs); err != nil {
+			return nil, err
+		}
+		cs.AvgWait = time.Duration(avgSecs * float64(time.Second))
+		cs.MaxWait = time.Duration(maxSecs * float64(time.Second))
+		stats = append(stats, cs)
+	}
+	return stats, rows.Err()
+}
+
+// PruneCompletions deletes journaled completions older than maxAge and
+// reports how many rows were removed. Called from the app's daily
+// maintenance worker; the journal is an audit trail, not history —
+// long-term forensics belong to the log pipeline.
+func (s *Store) PruneCompletions(ctx context.Context, maxAge time.Duration) (int64, error) {
+	if maxAge <= 0 {
+		return 0, fmt.Errorf("loopqueue: prune requires a positive max age")
+	}
+	cutoff := time.Now().UTC().Add(-maxAge)
+	res, err := s.db.ExecContext(ctx,
+		`DELETE FROM loop_queue_completions WHERE acked_at < ?`, cutoff,
+	)
+	if err != nil {
+		return 0, fmt.Errorf("loopqueue: prune completions: %w", err)
+	}
+	return res.RowsAffected()
+}

--- a/internal/state/loopqueue/queue_stats_test.go
+++ b/internal/state/loopqueue/queue_stats_test.go
@@ -1,0 +1,197 @@
+package loopqueue
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func completionCount(t *testing.T, s *Store, consumer string) int {
+	t.Helper()
+	var n int
+	query := `SELECT COUNT(*) FROM loop_queue_completions`
+	args := []any{}
+	if consumer != "" {
+		query += ` WHERE consumer_loop = ?`
+		args = append(args, consumer)
+	}
+	if err := s.db.QueryRowContext(context.Background(), query, args...).Scan(&n); err != nil {
+		t.Fatalf("count completions: %v", err)
+	}
+	return n
+}
+
+func TestAckJournalsExactlyOnce(t *testing.T) {
+	s := newTestStore(t)
+	ctx := t.Context()
+
+	if err := s.Enqueue(ctx, "archivist", "session:a", 3, []byte(`{}`)); err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+	if err := s.Ack(ctx, "archivist", "session:a"); err != nil {
+		t.Fatalf("ack: %v", err)
+	}
+	if got := completionCount(t, s, "archivist"); got != 1 {
+		t.Fatalf("completions after ack = %d, want 1", got)
+	}
+
+	// Re-acking the same key is idempotent for the queue AND for the
+	// journal: no phantom completion rows, no double-counted throughput.
+	if err := s.Ack(ctx, "archivist", "session:a"); err != nil {
+		t.Fatalf("re-ack: %v", err)
+	}
+	if got := completionCount(t, s, "archivist"); got != 1 {
+		t.Errorf("completions after re-ack = %d, want 1", got)
+	}
+
+	comps, err := s.RecentCompletions(ctx, "archivist", time.Now().Add(-time.Hour), 10)
+	if err != nil {
+		t.Fatalf("recent completions: %v", err)
+	}
+	if len(comps) != 1 {
+		t.Fatalf("recent completions = %d rows, want 1", len(comps))
+	}
+	c := comps[0]
+	if c.Consumer != "archivist" || c.DedupKey != "session:a" || c.Priority != 3 {
+		t.Errorf("completion = %+v, want archivist/session:a priority 3", c)
+	}
+	if c.EnqueuedAt.IsZero() || c.AckedAt.IsZero() {
+		t.Errorf("completion timestamps not recorded: %+v", c)
+	}
+	if c.Waited() < 0 {
+		t.Errorf("waited = %v, want >= 0", c.Waited())
+	}
+}
+
+// TestCoalesceIsNotACompletion pins the deliberate decision: a
+// re-Enqueue on the same dedup key refreshes the pending item in place
+// and must not appear in the journal — otherwise a chatty producer
+// reads as consumer throughput.
+func TestCoalesceIsNotACompletion(t *testing.T) {
+	s := newTestStore(t)
+	ctx := t.Context()
+
+	for range 5 {
+		if err := s.Enqueue(ctx, "archivist", "entity:sensor.x", 0, []byte(`{}`)); err != nil {
+			t.Fatalf("enqueue: %v", err)
+		}
+	}
+	if got := completionCount(t, s, "archivist"); got != 0 {
+		t.Errorf("completions after coalescing enqueues = %d, want 0", got)
+	}
+	if n, _ := s.PendingCount(ctx, "archivist"); n != 1 {
+		t.Errorf("pending after coalescing enqueues = %d, want 1", n)
+	}
+}
+
+func TestPendingStatsGroupsAndFindsOldest(t *testing.T) {
+	s := newTestStore(t)
+	ctx := t.Context()
+
+	if err := s.Enqueue(ctx, "archivist", "session:1", 0, nil); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Enqueue(ctx, "archivist", "session:2", 0, nil); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.Append(ctx, "core", "signal", 0, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	stats, err := s.PendingStats(ctx)
+	if err != nil {
+		t.Fatalf("pending stats: %v", err)
+	}
+	if len(stats) != 2 {
+		t.Fatalf("stats = %+v, want 2 partitions", stats)
+	}
+	// Sorted by consumer name: archivist before core.
+	if stats[0].Consumer != "archivist" || stats[0].Pending != 2 {
+		t.Errorf("stats[0] = %+v, want archivist pending 2", stats[0])
+	}
+	if stats[1].Consumer != "core" || stats[1].Pending != 1 {
+		t.Errorf("stats[1] = %+v, want core pending 1", stats[1])
+	}
+	if stats[0].OldestEnqueuedAt.IsZero() {
+		t.Errorf("oldest enqueued_at not parsed")
+	}
+
+	counts, err := s.PendingCounts(ctx)
+	if err != nil {
+		t.Fatalf("pending counts: %v", err)
+	}
+	if counts["archivist"] != 2 || counts["core"] != 1 {
+		t.Errorf("counts = %v, want archivist:2 core:1", counts)
+	}
+}
+
+func TestCompletionStatsAggregatesPerConsumer(t *testing.T) {
+	s := newTestStore(t)
+	ctx := t.Context()
+
+	for _, key := range []string{"session:1", "session:2"} {
+		if err := s.Enqueue(ctx, "archivist", key, 0, nil); err != nil {
+			t.Fatal(err)
+		}
+		if err := s.Ack(ctx, "archivist", key); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	stats, err := s.CompletionStatsSince(ctx, time.Now().Add(-time.Hour))
+	if err != nil {
+		t.Fatalf("completion stats: %v", err)
+	}
+	if len(stats) != 1 {
+		t.Fatalf("stats = %+v, want 1 consumer", stats)
+	}
+	if stats[0].Consumer != "archivist" || stats[0].Count != 2 {
+		t.Errorf("stats[0] = %+v, want archivist count 2", stats[0])
+	}
+	if stats[0].AvgWait < 0 || stats[0].MaxWait < stats[0].AvgWait {
+		t.Errorf("wait math inconsistent: avg=%v max=%v", stats[0].AvgWait, stats[0].MaxWait)
+	}
+
+	// A window that starts after the acks sees nothing.
+	later, err := s.CompletionStatsSince(ctx, time.Now().Add(time.Hour))
+	if err != nil {
+		t.Fatalf("completion stats (future window): %v", err)
+	}
+	if len(later) != 0 {
+		t.Errorf("future-window stats = %+v, want none", later)
+	}
+}
+
+func TestPruneCompletionsIsAgeBased(t *testing.T) {
+	s := newTestStore(t)
+	ctx := t.Context()
+
+	if err := s.Enqueue(ctx, "archivist", "session:old", 0, nil); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Ack(ctx, "archivist", "session:old"); err != nil {
+		t.Fatal(err)
+	}
+	// Backdate the journal row two days so a one-day retention removes it.
+	if _, err := s.db.ExecContext(ctx,
+		`UPDATE loop_queue_completions SET acked_at = ? WHERE dedup_key = 'session:old'`,
+		time.Now().UTC().Add(-48*time.Hour),
+	); err != nil {
+		t.Fatalf("backdate: %v", err)
+	}
+
+	deleted, err := s.PruneCompletions(ctx, 24*time.Hour)
+	if err != nil {
+		t.Fatalf("prune: %v", err)
+	}
+	if deleted != 1 {
+		t.Errorf("pruned %d rows, want 1", deleted)
+	}
+	if got := completionCount(t, s, ""); got != 0 {
+		t.Errorf("completions after prune = %d, want 0", got)
+	}
+
+	if _, err := s.PruneCompletions(ctx, 0); err == nil {
+		t.Errorf("prune with zero max age must refuse rather than delete everything")
+	}
+}

--- a/internal/state/loopqueue/queue_store.go
+++ b/internal/state/loopqueue/queue_store.go
@@ -278,19 +278,55 @@ func (s *Store) MoveConsumer(ctx context.Context, from, to string) error {
 	return nil
 }
 
-// Ack removes a completed item from consumerLoop's partition. A missing
-// (consumerLoop, dedupKey) is a no-op (idempotent).
+// Ack removes a completed item from consumerLoop's partition and
+// journals the completion — consumer, key, priority, and the
+// enqueued→acked span — in the same transaction as the DELETE, so the
+// record is exact and a crash can never leave a phantom completion. A
+// missing (consumerLoop, dedupKey) is a no-op (idempotent) and journals
+// nothing: re-acking an already-acked item must not double-count
+// throughput.
 func (s *Store) Ack(ctx context.Context, consumerLoop, dedupKey string) error {
 	consumerLoop = strings.TrimSpace(consumerLoop)
 	dedupKey = strings.TrimSpace(dedupKey)
 	if consumerLoop == "" || dedupKey == "" {
 		return fmt.Errorf("loopqueue: consumer_loop and dedup_key are required")
 	}
-	_, err := s.db.ExecContext(ctx,
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("loopqueue: ack %s/%s: %w", consumerLoop, dedupKey, err)
+	}
+	defer tx.Rollback() //nolint:errcheck // no-op after commit
+
+	var (
+		priority    int
+		enqueuedRaw any
+	)
+	err = tx.QueryRowContext(ctx,
+		`SELECT priority, enqueued_at FROM loop_queue WHERE consumer_loop = ? AND dedup_key = ?`,
+		consumerLoop, dedupKey,
+	).Scan(&priority, &enqueuedRaw)
+	if err == sql.ErrNoRows {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("loopqueue: ack %s/%s: %w", consumerLoop, dedupKey, err)
+	}
+	if _, err := tx.ExecContext(ctx,
 		`DELETE FROM loop_queue WHERE consumer_loop = ? AND dedup_key = ?`,
 		consumerLoop, dedupKey,
-	)
-	return err
+	); err != nil {
+		return fmt.Errorf("loopqueue: ack %s/%s: %w", consumerLoop, dedupKey, err)
+	}
+	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO loop_queue_completions (consumer_loop, dedup_key, priority, enqueued_at, acked_at)
+		VALUES (?, ?, ?, ?, CURRENT_TIMESTAMP)
+	`, consumerLoop, dedupKey, priority, enqueuedRaw); err != nil {
+		return fmt.Errorf("loopqueue: journal completion %s/%s: %w", consumerLoop, dedupKey, err)
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("loopqueue: ack %s/%s: %w", consumerLoop, dedupKey, err)
+	}
+	return nil
 }
 
 // Consumers returns the distinct consumer partitions that currently

--- a/internal/state/loopqueue/queue_store.go
+++ b/internal/state/loopqueue/queue_store.go
@@ -15,6 +15,7 @@ package loopqueue
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"log/slog"
 	"strings"
@@ -305,17 +306,29 @@ func (s *Store) Ack(ctx context.Context, consumerLoop, dedupKey string) error {
 		`SELECT priority, enqueued_at FROM loop_queue WHERE consumer_loop = ? AND dedup_key = ?`,
 		consumerLoop, dedupKey,
 	).Scan(&priority, &enqueuedRaw)
-	if err == sql.ErrNoRows {
+	if errors.Is(err, sql.ErrNoRows) {
 		return nil
 	}
 	if err != nil {
 		return fmt.Errorf("loopqueue: ack %s/%s: %w", consumerLoop, dedupKey, err)
 	}
-	if _, err := tx.ExecContext(ctx,
+	res, err := tx.ExecContext(ctx,
 		`DELETE FROM loop_queue WHERE consumer_loop = ? AND dedup_key = ?`,
 		consumerLoop, dedupKey,
-	); err != nil {
+	)
+	if err != nil {
 		return fmt.Errorf("loopqueue: ack %s/%s: %w", consumerLoop, dedupKey, err)
+	}
+	// Journal only when this transaction actually removed the row. Two
+	// concurrent Acks of the same key can both pass the SELECT before
+	// serializing on the write; the loser's DELETE affects zero rows,
+	// and journaling it anyway would double-count throughput.
+	deleted, err := res.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("loopqueue: ack %s/%s: %w", consumerLoop, dedupKey, err)
+	}
+	if deleted == 0 {
+		return nil
 	}
 	if _, err := tx.ExecContext(ctx, `
 		INSERT INTO loop_queue_completions (consumer_loop, dedup_key, priority, enqueued_at, acked_at)


### PR DESCRIPTION
Second PR of the metacog pivot arc (#1341), stacked on #1342. The archivist's work queue deletes items on Ack, which means completed work leaves no trace: the question "what has the archivist actually been doing, and is anything stuck" — a core piece of the re-scoped metacog's audit mandate — was unanswerable from the queue itself.

Ack now journals every acknowledgment into a `loop_queue_completions` table on thane.db: consumer, dedup key, priority, and the enqueued→acked span. The journal write happens in the same transaction as the DELETE, which is the whole reason it lives next to `loop_queue` rather than in logs.db — the record is exact by construction, a crash can never leave a phantom completion, and an idempotent re-ack (row already gone) journals nothing so throughput is never double-counted. One decision is pinned by test: a coalescing re-Enqueue is NOT a completion. The ON CONFLICT refresh restates the same pending work in place, and journaling it would let a chatty producer masquerade as consumer throughput; the `queue_status` tool's description will say so explicitly when it lands.

The read side adds the APIs the arc's later PRs consume: `PendingStats` / `PendingCounts` (live backlog per partition with oldest-item age — the number that has been computed-but-unrouted since the mailbox landed), `RecentCompletions`, `CompletionStatsSince` (count and average/max wait, computed in SQL via julianday spans with negative-skew clamping so no caller re-derives latency math), and an age-based `PruneCompletions` (30-day default) driven by a new daily app worker mirroring the log-index pruner's shape. Time parameters bind `time.Time` directly per the `SQLiteTimestampLayout` doctrine, keeping bound cutoffs lexically comparable with `CURRENT_TIMESTAMP`-written rows.

## Test plan

- [x] Ack journals exactly once; re-ack journals nothing (idempotency preserved for queue and journal)
- [x] Coalescing Enqueue produces zero journal rows and one pending item
- [x] PendingStats grouping, name-sorted determinism, oldest-age parse
- [x] CompletionStatsSince aggregation math and window edges
- [x] Age-based prune deletes only past-retention rows; zero/negative retention refused
- [x] `just ci` green

Refs #1341

🤖 Generated with [Claude Code](https://claude.com/claude-code)
