### PR TITLE
feat(introspection): persistent loop-event journal on logs.db

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -35,6 +35,7 @@ import (
 	"github.com/nugget/thane-ai-agent/internal/platform/config"
 	"github.com/nugget/thane-ai-agent/internal/platform/events"
 	"github.com/nugget/thane-ai-agent/internal/platform/logging"
+	"github.com/nugget/thane-ai-agent/internal/platform/memguard"
 	"github.com/nugget/thane-ai-agent/internal/platform/opstate"
 	"github.com/nugget/thane-ai-agent/internal/platform/scheduler"
 	"github.com/nugget/thane-ai-agent/internal/platform/telemetry"
@@ -51,6 +52,7 @@ import (
 	"github.com/nugget/thane-ai-agent/internal/state/awareness"
 	"github.com/nugget/thane-ai-agent/internal/state/contacts"
 	"github.com/nugget/thane-ai-agent/internal/state/documents"
+	"github.com/nugget/thane-ai-agent/internal/state/introspection"
 	"github.com/nugget/thane-ai-agent/internal/state/knowledge"
 	"github.com/nugget/thane-ai-agent/internal/state/loopqueue"
 	"github.com/nugget/thane-ai-agent/internal/state/memory"
@@ -222,6 +224,12 @@ type App struct {
 
 	// Event bus
 	eventBus *events.Bus
+
+	// Introspection: persistent loop-event journal (nil when logs.db is
+	// unavailable) and the live memory guard (nil unless enabled; set in
+	// Serve). Both feed the internal-operations observability surfaces.
+	loopEventJournal *introspection.Journal
+	memGuard         *memguard.Guard
 
 	// Inter-component message bus
 	messageBus *messages.Bus

--- a/internal/app/new_introspection.go
+++ b/internal/app/new_introspection.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"context"
+	"time"
 
 	"github.com/nugget/thane-ai-agent/internal/state/introspection"
 )
@@ -23,9 +24,14 @@ func (a *App) initIntrospectionJournal() {
 	}
 	a.loopEventJournal = journal
 
-	// Reuse the log index's retention when configured; the journal's own
-	// default (30d) otherwise. Pure age-based either way.
-	retention := a.cfg.Logging.RetentionDaysDuration()
+	// Reuse the log index's retention only when the operator explicitly
+	// set one; otherwise pass zero so the recorder applies the journal's
+	// own default (30d) rather than inheriting the log index's implicit
+	// 7-day fallback. Pure age-based either way.
+	var retention time.Duration
+	if a.cfg.Logging.RetentionDays != nil {
+		retention = a.cfg.Logging.RetentionDaysDuration()
+	}
 	recorder := introspection.NewRecorder(journal, a.eventBus, retention, a.logger)
 	a.deferWorker("loop-event-recorder", func(ctx context.Context) error {
 		go recorder.Run(ctx)

--- a/internal/app/new_introspection.go
+++ b/internal/app/new_introspection.go
@@ -1,0 +1,34 @@
+package app
+
+import (
+	"context"
+
+	"github.com/nugget/thane-ai-agent/internal/state/introspection"
+)
+
+// initIntrospectionJournal wires the persistent loop-event journal: a
+// bus subscriber that records loop lifecycle events (wakes with
+// attribution, iteration outcomes, errors, state changes) into logs.db,
+// so post-incident questions like "who kept waking this loop" survive a
+// restart. Skipped quietly when logs.db or the event bus is
+// unavailable — the journal is observability, never a boot dependency.
+func (a *App) initIntrospectionJournal() {
+	if a.indexDB == nil || a.eventBus == nil {
+		return
+	}
+	journal, err := introspection.NewJournal(a.indexDB, a.logger)
+	if err != nil {
+		a.logger.Warn("loop event journal unavailable", "error", err)
+		return
+	}
+	a.loopEventJournal = journal
+
+	// Reuse the log index's retention when configured; the journal's own
+	// default (30d) otherwise. Pure age-based either way.
+	retention := a.cfg.Logging.RetentionDaysDuration()
+	recorder := introspection.NewRecorder(journal, a.eventBus, retention, a.logger)
+	a.deferWorker("loop-event-recorder", func(ctx context.Context) error {
+		go recorder.Run(ctx)
+		return nil
+	})
+}

--- a/internal/app/new_stores.go
+++ b/internal/app/new_stores.go
@@ -56,6 +56,7 @@ func (a *App) initStores(s *newState) error {
 	a.initMessageInfrastructure(logger)
 	a.initDatasetSinks()
 	a.initEventDropMonitor()
+	a.initIntrospectionJournal()
 
 	// --- Loop registry ---
 	// Tracks all persistent background loops (metacognitive, pollers,

--- a/internal/app/serve.go
+++ b/internal/app/serve.go
@@ -65,6 +65,9 @@ func (a *App) Serve(ctx context.Context) error {
 			ProfileDir:  profileDir,
 			Interval:    time.Duration(a.cfg.MemoryGuard.IntervalSeconds) * time.Second,
 		}, a.logger)
+		// Stored on the App so observability surfaces (system_health) can
+		// read live memory against the limits; nil when the guard is off.
+		a.memGuard = guard
 		go guard.Start(ctx)
 	}
 

--- a/internal/platform/memguard/memguard.go
+++ b/internal/platform/memguard/memguard.go
@@ -115,6 +115,33 @@ func New(cfg Config, logger *slog.Logger) *Guard {
 // is clean, so the supervising wrapper must see a non-zero exit and relaunch.
 func (g *Guard) Tripped() bool { return g.tripped.Load() }
 
+// Reading is one live snapshot of process memory against the guard's
+// thresholds — the observability face of the guard, consumed by the
+// system_health annunciator.
+type Reading struct {
+	CurrentMB int  // memory in use now, per the guard's own probe
+	SoftMB    int  // heap-profile threshold
+	HardMB    int  // graceful-restart threshold
+	Tripped   bool // hard limit was reached this process lifetime
+}
+
+// Reading takes a fresh memory measurement and returns it alongside the
+// configured limits and trip state. Nil-safe (a nil guard reads as
+// zero) and safe to call concurrently with the poller: the thresholds
+// are immutable after New, the trip flag is atomic, and the probe reads
+// runtime.MemStats without touching guard state.
+func (g *Guard) Reading() Reading {
+	if g == nil {
+		return Reading{}
+	}
+	return Reading{
+		CurrentMB: int(g.readMem() / mib),
+		SoftMB:    int(g.soft / mib),
+		HardMB:    int(g.hard / mib),
+		Tripped:   g.tripped.Load(),
+	}
+}
+
 // Start runs the guard until ctx is cancelled. Run it in a goroutine.
 func (g *Guard) Start(ctx context.Context) {
 	g.logger.Info("memory guard active",

--- a/internal/state/introspection/introspection.go
+++ b/internal/state/introspection/introspection.go
@@ -1,0 +1,12 @@
+// Package introspection projects thane's own internal operation into
+// model-facing views: the persistent loop-event journal behind
+// loop_activity, and (in later arc PRs) the subsystem annunciator panel
+// behind system_health and the metacog context panel.
+//
+// It exists because most of thane's operational signals were computed
+// but unrouted — visible to HTTP health endpoints or to nobody — while
+// the loop runtime's own event stream was ephemeral: a restart erased
+// exactly the evidence a post-incident investigation needs. This
+// package is the single source of truth those surfaces render from, so
+// a tool result and a context panel can never drift apart. (#1341)
+package introspection

--- a/internal/state/introspection/loop_events.go
+++ b/internal/state/introspection/loop_events.go
@@ -1,0 +1,350 @@
+package introspection
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/nugget/thane-ai-agent/internal/platform/database"
+)
+
+// DefaultLoopEventRetention bounds the journal by age when the logging
+// retention config does not. Thirty days covers month-scale incident
+// retrospectives; the journal is operational history, not an archive.
+const DefaultLoopEventRetention = 30 * 24 * time.Hour
+
+// loopEventsSchema declares the loop_events journal: the persistent
+// record of loop lifecycle events (wakes with attribution, iteration
+// outcomes, errors, state changes, mailbox arrivals) that the in-memory
+// event bus otherwise forgets at restart. Forward-only
+// (CREATE IF NOT EXISTS); rows are pruned by age.
+var loopEventsSchema = database.Schema{
+	Name: "introspection",
+	Steps: []database.MigrationStep{
+		database.TableCreate{
+			Table: "loop_events",
+			SQL: `CREATE TABLE IF NOT EXISTS loop_events (
+				id          INTEGER PRIMARY KEY AUTOINCREMENT,
+				at          TIMESTAMP NOT NULL,
+				loop_id     TEXT NOT NULL DEFAULT '',
+				loop_name   TEXT NOT NULL DEFAULT '',
+				kind        TEXT NOT NULL,
+				wake_reason TEXT NOT NULL DEFAULT '',
+				wake_source TEXT NOT NULL DEFAULT '',
+				detail      TEXT NOT NULL DEFAULT '{}'
+			)`,
+		},
+		database.IndexCreate{
+			Name: "idx_loop_events_at",
+			SQL: `CREATE INDEX IF NOT EXISTS idx_loop_events_at
+				ON loop_events (at)`,
+		},
+		database.IndexCreate{
+			Name: "idx_loop_events_loop",
+			SQL: `CREATE INDEX IF NOT EXISTS idx_loop_events_loop
+				ON loop_events (loop_name, at)`,
+		},
+		database.IndexCreate{
+			Name: "idx_loop_events_kind",
+			SQL: `CREATE INDEX IF NOT EXISTS idx_loop_events_kind
+				ON loop_events (kind, at)`,
+		},
+	},
+}
+
+// LoopEvent is one journaled loop lifecycle event. WakeReason and
+// WakeSource are populated on loop_iteration_start rows; Detail is the
+// bounded, whitelisted projection of the bus event's payload.
+type LoopEvent struct {
+	At         time.Time
+	LoopID     string
+	LoopName   string
+	Kind       string
+	WakeReason string
+	WakeSource string
+	Detail     map[string]any
+}
+
+// Journal is the durable store for loop lifecycle events, backed by a
+// table on logs.db next to the log index it complements.
+type Journal struct {
+	db *sql.DB
+}
+
+// NewJournal migrates the loop_events schema and returns the journal.
+func NewJournal(db *sql.DB, logger *slog.Logger) (*Journal, error) {
+	if db == nil {
+		return nil, fmt.Errorf("introspection: journal requires a database")
+	}
+	if err := database.Migrate(db, loopEventsSchema, logger); err != nil {
+		return nil, err
+	}
+	return &Journal{db: db}, nil
+}
+
+// record inserts a batch of events in one transaction. Called by the
+// recorder's flush; not exported because producers go through the bus,
+// never write the journal directly.
+func (j *Journal) record(ctx context.Context, events []LoopEvent) error {
+	if len(events) == 0 {
+		return nil
+	}
+	tx, err := j.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("introspection: record loop events: %w", err)
+	}
+	defer tx.Rollback() //nolint:errcheck // no-op after commit
+
+	stmt, err := tx.PrepareContext(ctx, `
+		INSERT INTO loop_events (at, loop_id, loop_name, kind, wake_reason, wake_source, detail)
+		VALUES (?, ?, ?, ?, ?, ?, ?)
+	`)
+	if err != nil {
+		return fmt.Errorf("introspection: record loop events: %w", err)
+	}
+	defer stmt.Close()
+
+	for _, ev := range events {
+		detail := "{}"
+		if len(ev.Detail) > 0 {
+			if blob, err := json.Marshal(ev.Detail); err == nil {
+				detail = string(blob)
+			}
+		}
+		if _, err := stmt.ExecContext(ctx,
+			ev.At.UTC(), ev.LoopID, ev.LoopName, ev.Kind, ev.WakeReason, ev.WakeSource, detail,
+		); err != nil {
+			return fmt.Errorf("introspection: record loop event %s/%s: %w", ev.LoopName, ev.Kind, err)
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("introspection: record loop events: %w", err)
+	}
+	return nil
+}
+
+// LoopEventQuery filters the journal. Zero-valued fields are
+// unrestricted; Limit <= 0 defaults to 50 and caps at 200 (matching the
+// logs_query convention).
+type LoopEventQuery struct {
+	LoopName string
+	Kind     string
+	Since    time.Time
+	Until    time.Time
+	Limit    int
+}
+
+const (
+	defaultLoopEventLimit = 50
+	maxLoopEventLimit     = 200
+)
+
+// Query returns journaled events matching q in chronological order.
+// The newest matching rows win when the limit clips (newest-first
+// select, reversed), so a capped result covers the most recent window
+// rather than a stale prefix.
+func (j *Journal) Query(ctx context.Context, q LoopEventQuery) ([]LoopEvent, error) {
+	limit := q.Limit
+	if limit <= 0 {
+		limit = defaultLoopEventLimit
+	}
+	if limit > maxLoopEventLimit {
+		limit = maxLoopEventLimit
+	}
+
+	query := `
+		SELECT at, loop_id, loop_name, kind, wake_reason, wake_source, detail
+		FROM loop_events
+		WHERE 1=1`
+	var args []any
+	if name := strings.TrimSpace(q.LoopName); name != "" {
+		query += ` AND loop_name = ?`
+		args = append(args, name)
+	}
+	if kind := strings.TrimSpace(q.Kind); kind != "" {
+		query += ` AND kind = ?`
+		args = append(args, kind)
+	}
+	if !q.Since.IsZero() {
+		query += ` AND at >= ?`
+		args = append(args, q.Since.UTC())
+	}
+	if !q.Until.IsZero() {
+		query += ` AND at <= ?`
+		args = append(args, q.Until.UTC())
+	}
+	query += ` ORDER BY at DESC, id DESC LIMIT ?`
+	args = append(args, limit)
+
+	rows, err := j.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("introspection: query loop events: %w", err)
+	}
+	defer rows.Close()
+
+	var out []LoopEvent
+	for rows.Next() {
+		var (
+			ev     LoopEvent
+			atRaw  any
+			detail string
+		)
+		if err := rows.Scan(&atRaw, &ev.LoopID, &ev.LoopName, &ev.Kind, &ev.WakeReason, &ev.WakeSource, &detail); err != nil {
+			return nil, err
+		}
+		ev.At = parseJournalTimestamp(atRaw)
+		if detail != "" && detail != "{}" {
+			var m map[string]any
+			if err := json.Unmarshal([]byte(detail), &m); err == nil {
+				ev.Detail = m
+			}
+		}
+		out = append(out, ev)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	// Reverse newest-first to chronological so callers read a timeline.
+	for i, jj := 0, len(out)-1; i < jj; i, jj = i+1, jj-1 {
+		out[i], out[jj] = out[jj], out[i]
+	}
+	return out, nil
+}
+
+// LoopActivityAggregate summarizes a window of journaled events for one
+// loop (or every loop when unscoped): wake volume and rate, the
+// wake-reason and wake-source decomposition, and outcome counts.
+type LoopActivityAggregate struct {
+	Wakes        int
+	WakesPerHour float64
+	ByReason     map[string]int
+	BySource     map[string]int
+	Errors       int
+	Completions  int
+	NoOps        int
+}
+
+// maxAggregateSources caps the by-source decomposition; sources beyond
+// the cap fold into an explicit "(other)" bucket rather than vanishing.
+const maxAggregateSources = 10
+
+// AggregateActivity computes the activity rollup for loopName (empty =
+// all loops) between since and until (zero until = now). All counting
+// runs in SQL; the caller never re-derives rates.
+func (j *Journal) AggregateActivity(ctx context.Context, loopName string, since, until time.Time) (LoopActivityAggregate, error) {
+	if until.IsZero() {
+		until = time.Now().UTC()
+	}
+	agg := LoopActivityAggregate{}
+
+	scope := ` AND at >= ? AND at <= ?`
+	scopeArgs := []any{since.UTC(), until.UTC()}
+	loopName = strings.TrimSpace(loopName)
+	if loopName != "" {
+		scope += ` AND loop_name = ?`
+		scopeArgs = append(scopeArgs, loopName)
+	}
+
+	countRow := func(where string, args ...any) (int, error) {
+		var n int
+		err := j.db.QueryRowContext(ctx,
+			`SELECT COUNT(*) FROM loop_events WHERE `+where+scope,
+			append(args, scopeArgs...)...,
+		).Scan(&n)
+		return n, err
+	}
+
+	var err error
+	if agg.Wakes, err = countRow(`kind = ?`, "loop_iteration_start"); err != nil {
+		return agg, fmt.Errorf("introspection: aggregate wakes: %w", err)
+	}
+	if agg.Errors, err = countRow(`kind = ?`, "loop_error"); err != nil {
+		return agg, fmt.Errorf("introspection: aggregate errors: %w", err)
+	}
+	if agg.Completions, err = countRow(`kind = ?`, "loop_iteration_complete"); err != nil {
+		return agg, fmt.Errorf("introspection: aggregate completions: %w", err)
+	}
+	if agg.NoOps, err = countRow(`kind = ? AND json_extract(detail, '$.no_op') = 1`, "loop_iteration_complete"); err != nil {
+		return agg, fmt.Errorf("introspection: aggregate no-ops: %w", err)
+	}
+
+	if hours := until.Sub(since).Hours(); hours > 0 {
+		agg.WakesPerHour = float64(agg.Wakes) / hours
+	}
+
+	groupCount := func(column string) (map[string]int, error) {
+		rows, err := j.db.QueryContext(ctx, `
+			SELECT `+column+`, COUNT(*) AS n
+			FROM loop_events
+			WHERE kind = ? AND `+column+` != ''`+scope+`
+			GROUP BY `+column+`
+			ORDER BY n DESC, `+column+` ASC
+		`, append([]any{"loop_iteration_start"}, scopeArgs...)...)
+		if err != nil {
+			return nil, err
+		}
+		defer rows.Close()
+		var counts map[string]int
+		for rows.Next() {
+			var (
+				key string
+				n   int
+			)
+			if err := rows.Scan(&key, &n); err != nil {
+				return nil, err
+			}
+			if counts == nil {
+				counts = make(map[string]int)
+			}
+			if len(counts) >= maxAggregateSources {
+				counts["(other)"] += n
+				continue
+			}
+			counts[key] += n
+		}
+		return counts, rows.Err()
+	}
+
+	if agg.ByReason, err = groupCount("wake_reason"); err != nil {
+		return agg, fmt.Errorf("introspection: aggregate wake reasons: %w", err)
+	}
+	if agg.BySource, err = groupCount("wake_source"); err != nil {
+		return agg, fmt.Errorf("introspection: aggregate wake sources: %w", err)
+	}
+	return agg, nil
+}
+
+// Prune deletes journaled events older than maxAge and reports how many
+// rows were removed. Deliberately pure age-based — unlike the log
+// index's level-gated prune, every journal row expires.
+func (j *Journal) Prune(ctx context.Context, maxAge time.Duration) (int64, error) {
+	if maxAge <= 0 {
+		return 0, fmt.Errorf("introspection: prune requires a positive max age")
+	}
+	cutoff := time.Now().UTC().Add(-maxAge)
+	res, err := j.db.ExecContext(ctx, `DELETE FROM loop_events WHERE at < ?`, cutoff)
+	if err != nil {
+		return 0, fmt.Errorf("introspection: prune loop events: %w", err)
+	}
+	return res.RowsAffected()
+}
+
+func parseJournalTimestamp(raw any) time.Time {
+	switch v := raw.(type) {
+	case time.Time:
+		return v
+	case string:
+		if ts, err := database.ParseTimestamp(v); err == nil {
+			return ts
+		}
+	case []byte:
+		if ts, err := database.ParseTimestamp(string(v)); err == nil {
+			return ts
+		}
+	}
+	return time.Time{}
+}

--- a/internal/state/introspection/loop_events.go
+++ b/internal/state/introspection/loop_events.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/nugget/thane-ai-agent/internal/platform/database"
+	"github.com/nugget/thane-ai-agent/internal/platform/events"
 )
 
 // DefaultLoopEventRetention bounds the journal by age when the logging
@@ -259,16 +260,16 @@ func (j *Journal) AggregateActivity(ctx context.Context, loopName string, since,
 	}
 
 	var err error
-	if agg.Wakes, err = countRow(`kind = ?`, "loop_iteration_start"); err != nil {
+	if agg.Wakes, err = countRow(`kind = ?`, events.KindLoopIterationStart); err != nil {
 		return agg, fmt.Errorf("introspection: aggregate wakes: %w", err)
 	}
-	if agg.Errors, err = countRow(`kind = ?`, "loop_error"); err != nil {
+	if agg.Errors, err = countRow(`kind = ?`, events.KindLoopError); err != nil {
 		return agg, fmt.Errorf("introspection: aggregate errors: %w", err)
 	}
-	if agg.Completions, err = countRow(`kind = ?`, "loop_iteration_complete"); err != nil {
+	if agg.Completions, err = countRow(`kind = ?`, events.KindLoopIterationComplete); err != nil {
 		return agg, fmt.Errorf("introspection: aggregate completions: %w", err)
 	}
-	if agg.NoOps, err = countRow(`kind = ? AND json_extract(detail, '$.no_op') = 1`, "loop_iteration_complete"); err != nil {
+	if agg.NoOps, err = countRow(`kind = ? AND json_extract(detail, '$.no_op') = 1`, events.KindLoopIterationComplete); err != nil {
 		return agg, fmt.Errorf("introspection: aggregate no-ops: %w", err)
 	}
 
@@ -283,7 +284,7 @@ func (j *Journal) AggregateActivity(ctx context.Context, loopName string, since,
 			WHERE kind = ? AND `+column+` != ''`+scope+`
 			GROUP BY `+column+`
 			ORDER BY n DESC, `+column+` ASC
-		`, append([]any{"loop_iteration_start"}, scopeArgs...)...)
+		`, append([]any{events.KindLoopIterationStart}, scopeArgs...)...)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/state/introspection/loop_events_recorder.go
+++ b/internal/state/introspection/loop_events_recorder.go
@@ -1,0 +1,208 @@
+package introspection
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/nugget/thane-ai-agent/internal/platform/events"
+)
+
+// persistedLoopEventKinds is the exact set of bus events the journal
+// retains: lifecycle and outcome, never the chatty per-tool/per-LLM
+// stream (loop_tool_start, loop_llm_response, sleep/wait transitions),
+// which would multiply row volume without adding audit value — that
+// granularity already lives in the log index and the archive.
+var persistedLoopEventKinds = map[string]bool{
+	events.KindLoopStarted:           true,
+	events.KindLoopStopped:           true,
+	events.KindLoopIterationStart:    true,
+	events.KindLoopIterationComplete: true,
+	events.KindLoopError:             true,
+	events.KindLoopStateChange:       true,
+	events.KindLoopMailboxArrival:    true,
+	events.KindLoopMidTurnInput:      true,
+}
+
+// detailWhitelist is the flat set of payload keys the journal retains
+// across all persisted kinds. Scalars only — bulk fields on the bus
+// event (tools_used, effective_tools, tooling, summary) are deliberately
+// dropped: the journal answers "what happened when", not "replay the
+// turn". One stable whitelist, not per-kind logic, so the stored shape
+// never depends on producer drift.
+var detailWhitelist = map[string]bool{
+	"conversation_id":    true,
+	"supervisor":         true,
+	"supervisor_trigger": true,
+	"attempt":            true,
+	"signal_envelopes":   true,
+	"mailbox_items":      true,
+	"model":              true,
+	"finish_reason":      true,
+	"request_id":         true,
+	"input_tokens":       true,
+	"output_tokens":      true,
+	"context_window":     true,
+	"elapsed_ms":         true,
+	"no_op":              true,
+	"midturn_merged":     true,
+	"error":              true,
+	"phase":              true,
+	"from":               true,
+	"to":                 true,
+	"event_seq":          true,
+	"parent_id":          true,
+	"item_id":            true,
+	"pending_items":      true,
+	"count":              true,
+}
+
+// maxDetailStringRunes bounds any single retained string value (error
+// messages are the realistic offender) so one pathological payload
+// cannot bloat the journal row.
+const maxDetailStringRunes = 512
+
+const (
+	recorderBufSize      = 256
+	recorderFlushCount   = 64
+	recorderFlushEvery   = 2 * time.Second
+	recorderPruneEvery   = 24 * time.Hour
+	recorderFlushTimeout = 10 * time.Second
+)
+
+// Recorder subscribes to the operational event bus and persists the
+// loop lifecycle stream into the journal. It never blocks the bus: the
+// bus drops deliveries to a full subscriber buffer by design (and
+// counts them via DroppedCount, which the annunciator surfaces), and
+// the recorder batches its writes so a burst costs one transaction.
+type Recorder struct {
+	journal   *Journal
+	bus       *events.Bus
+	retention time.Duration
+	logger    *slog.Logger
+}
+
+// NewRecorder wires a recorder over journal and bus. retention <= 0
+// takes DefaultLoopEventRetention.
+func NewRecorder(journal *Journal, bus *events.Bus, retention time.Duration, logger *slog.Logger) *Recorder {
+	if retention <= 0 {
+		retention = DefaultLoopEventRetention
+	}
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Recorder{journal: journal, bus: bus, retention: retention, logger: logger}
+}
+
+// Run consumes the bus until ctx is cancelled, flushing batches on
+// size or interval and pruning the journal daily. Run it in a
+// goroutine; it owns its subscription and unsubscribes on exit.
+func (r *Recorder) Run(ctx context.Context) {
+	ch := r.bus.Subscribe(recorderBufSize)
+	defer r.bus.Unsubscribe(ch)
+
+	flushTicker := time.NewTicker(recorderFlushEvery)
+	defer flushTicker.Stop()
+	pruneTicker := time.NewTicker(recorderPruneEvery)
+	defer pruneTicker.Stop()
+
+	batch := make([]LoopEvent, 0, recorderFlushCount)
+	flush := func() {
+		if len(batch) == 0 {
+			return
+		}
+		// Use a detached timeout context so the final flush on shutdown
+		// still lands: the run context is already cancelled by then.
+		flushCtx, cancel := context.WithTimeout(context.Background(), recorderFlushTimeout)
+		defer cancel()
+		if err := r.journal.record(flushCtx, batch); err != nil {
+			r.logger.Warn("loop event journal write failed",
+				"events", len(batch), "error", err)
+		}
+		batch = batch[:0]
+	}
+
+	r.prune(ctx)
+	for {
+		select {
+		case <-ctx.Done():
+			flush()
+			return
+		case ev := <-ch:
+			if row, ok := projectLoopEvent(ev); ok {
+				batch = append(batch, row)
+				if len(batch) >= recorderFlushCount {
+					flush()
+				}
+			}
+		case <-flushTicker.C:
+			flush()
+		case <-pruneTicker.C:
+			r.prune(ctx)
+		}
+	}
+}
+
+func (r *Recorder) prune(ctx context.Context) {
+	if deleted, err := r.journal.Prune(ctx, r.retention); err != nil {
+		if ctx.Err() == nil {
+			r.logger.Warn("loop event journal prune failed", "error", err)
+		}
+	} else if deleted > 0 {
+		r.logger.Info("pruned loop event journal", "deleted", deleted, "retention", r.retention)
+	}
+}
+
+// projectLoopEvent maps one bus event to its journal row, reporting
+// ok=false for kinds the journal does not retain.
+func projectLoopEvent(ev events.Event) (LoopEvent, bool) {
+	if !persistedLoopEventKinds[ev.Kind] {
+		return LoopEvent{}, false
+	}
+	row := LoopEvent{
+		At:   ev.Timestamp,
+		Kind: ev.Kind,
+	}
+	if row.At.IsZero() {
+		row.At = time.Now()
+	}
+	for key, value := range ev.Data {
+		switch key {
+		case "loop_id":
+			row.LoopID, _ = value.(string)
+		case "loop_name":
+			row.LoopName, _ = value.(string)
+		case "wake_reason":
+			row.WakeReason, _ = value.(string)
+		case "wake_source":
+			row.WakeSource, _ = value.(string)
+		default:
+			if !detailWhitelist[key] {
+				continue
+			}
+			if projected, ok := projectDetailValue(value); ok {
+				if row.Detail == nil {
+					row.Detail = make(map[string]any)
+				}
+				row.Detail[key] = projected
+			}
+		}
+	}
+	return row, true
+}
+
+// projectDetailValue keeps scalars (with strings rune-capped) and drops
+// everything else — maps and slices are bulk by definition here.
+func projectDetailValue(value any) (any, bool) {
+	switch v := value.(type) {
+	case string:
+		if runes := []rune(v); len(runes) > maxDetailStringRunes {
+			return string(runes[:maxDetailStringRunes]) + "…", true
+		}
+		return v, true
+	case bool, int, int32, int64, uint, uint32, uint64, float32, float64:
+		return v, true
+	default:
+		return nil, false
+	}
+}

--- a/internal/state/introspection/loop_events_test.go
+++ b/internal/state/introspection/loop_events_test.go
@@ -1,0 +1,267 @@
+package introspection
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nugget/thane-ai-agent/internal/platform/database"
+	"github.com/nugget/thane-ai-agent/internal/platform/events"
+
+	_ "modernc.org/sqlite"
+)
+
+func newTestJournal(t *testing.T) *Journal {
+	t.Helper()
+	db, err := database.OpenMemory()
+	if err != nil {
+		t.Fatalf("open memory db: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	j, err := NewJournal(db, nil)
+	if err != nil {
+		t.Fatalf("new journal: %v", err)
+	}
+	return j
+}
+
+func mustRecord(t *testing.T, j *Journal, evs ...LoopEvent) {
+	t.Helper()
+	if err := j.record(context.Background(), evs); err != nil {
+		t.Fatalf("record: %v", err)
+	}
+}
+
+func TestJournalQueryFiltersAndOrdersChronologically(t *testing.T) {
+	j := newTestJournal(t)
+	base := time.Date(2026, 8, 11, 8, 0, 0, 0, time.UTC)
+
+	mustRecord(t, j,
+		LoopEvent{At: base, LoopName: "archivist", Kind: "loop_iteration_start", WakeReason: "mailbox", WakeSource: "session"},
+		LoopEvent{At: base.Add(time.Minute), LoopName: "archivist", Kind: "loop_iteration_complete", Detail: map[string]any{"elapsed_ms": 1200}},
+		LoopEvent{At: base.Add(2 * time.Minute), LoopName: "ego", Kind: "loop_iteration_start", WakeReason: "timer"},
+		LoopEvent{At: base.Add(3 * time.Minute), LoopName: "archivist", Kind: "loop_error", Detail: map[string]any{"error": "boom"}},
+	)
+
+	got, err := j.Query(context.Background(), LoopEventQuery{LoopName: "archivist"})
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("archivist events = %d, want 3", len(got))
+	}
+	// Chronological: iteration_start first, error last.
+	if got[0].Kind != "loop_iteration_start" || got[2].Kind != "loop_error" {
+		t.Errorf("order = [%s %s %s], want chronological", got[0].Kind, got[1].Kind, got[2].Kind)
+	}
+	if got[0].WakeReason != "mailbox" || got[0].WakeSource != "session" {
+		t.Errorf("wake attribution not round-tripped: %+v", got[0])
+	}
+	if got[2].Detail["error"] != "boom" {
+		t.Errorf("detail not round-tripped: %+v", got[2].Detail)
+	}
+
+	// Kind + window filters compose.
+	windowed, err := j.Query(context.Background(), LoopEventQuery{
+		Kind:  "loop_iteration_start",
+		Since: base.Add(time.Minute),
+	})
+	if err != nil {
+		t.Fatalf("windowed query: %v", err)
+	}
+	if len(windowed) != 1 || windowed[0].LoopName != "ego" {
+		t.Errorf("windowed = %+v, want just ego's start", windowed)
+	}
+}
+
+func TestJournalQueryLimitKeepsNewest(t *testing.T) {
+	j := newTestJournal(t)
+	base := time.Date(2026, 8, 11, 8, 0, 0, 0, time.UTC)
+	var evs []LoopEvent
+	for i := range 10 {
+		evs = append(evs, LoopEvent{
+			At: base.Add(time.Duration(i) * time.Minute), LoopName: "core", Kind: "loop_iteration_start",
+		})
+	}
+	mustRecord(t, j, evs...)
+
+	got, err := j.Query(context.Background(), LoopEventQuery{Limit: 3})
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("limited query = %d rows, want 3", len(got))
+	}
+	// The newest rows win the cap, returned chronologically.
+	if !got[0].At.Equal(base.Add(7*time.Minute)) || !got[2].At.Equal(base.Add(9*time.Minute)) {
+		t.Errorf("limit kept %v..%v, want the newest three", got[0].At, got[2].At)
+	}
+}
+
+func TestJournalAggregateActivity(t *testing.T) {
+	j := newTestJournal(t)
+	base := time.Date(2026, 8, 11, 8, 0, 0, 0, time.UTC)
+
+	mustRecord(t, j,
+		LoopEvent{At: base, LoopName: "archivist", Kind: "loop_iteration_start", WakeReason: "mailbox", WakeSource: "session"},
+		LoopEvent{At: base.Add(time.Minute), LoopName: "archivist", Kind: "loop_iteration_complete", Detail: map[string]any{"no_op": true}},
+		LoopEvent{At: base.Add(2 * time.Minute), LoopName: "archivist", Kind: "loop_iteration_start", WakeReason: "mailbox", WakeSource: "session"},
+		LoopEvent{At: base.Add(3 * time.Minute), LoopName: "archivist", Kind: "loop_iteration_complete"},
+		LoopEvent{At: base.Add(4 * time.Minute), LoopName: "archivist", Kind: "loop_iteration_start", WakeReason: "timer"},
+		LoopEvent{At: base.Add(5 * time.Minute), LoopName: "archivist", Kind: "loop_error", Detail: map[string]any{"error": "x"}},
+		// Another loop inside the window must not leak into the scoped rollup.
+		LoopEvent{At: base.Add(6 * time.Minute), LoopName: "ego", Kind: "loop_iteration_start", WakeReason: "timer"},
+	)
+
+	agg, err := j.AggregateActivity(context.Background(), "archivist", base.Add(-time.Minute), base.Add(time.Hour))
+	if err != nil {
+		t.Fatalf("aggregate: %v", err)
+	}
+	if agg.Wakes != 3 {
+		t.Errorf("wakes = %d, want 3", agg.Wakes)
+	}
+	if agg.ByReason["mailbox"] != 2 || agg.ByReason["timer"] != 1 {
+		t.Errorf("by_reason = %v, want mailbox:2 timer:1", agg.ByReason)
+	}
+	if agg.BySource["session"] != 2 {
+		t.Errorf("by_source = %v, want session:2", agg.BySource)
+	}
+	if agg.Errors != 1 || agg.Completions != 2 || agg.NoOps != 1 {
+		t.Errorf("errors/completions/no_ops = %d/%d/%d, want 1/2/1", agg.Errors, agg.Completions, agg.NoOps)
+	}
+	if agg.WakesPerHour <= 0 {
+		t.Errorf("wakes_per_hour = %v, want > 0", agg.WakesPerHour)
+	}
+
+	// Unscoped rollup covers every loop.
+	all, err := j.AggregateActivity(context.Background(), "", base.Add(-time.Minute), base.Add(time.Hour))
+	if err != nil {
+		t.Fatalf("unscoped aggregate: %v", err)
+	}
+	if all.Wakes != 4 {
+		t.Errorf("unscoped wakes = %d, want 4", all.Wakes)
+	}
+}
+
+func TestJournalPruneIsAgeBased(t *testing.T) {
+	j := newTestJournal(t)
+	mustRecord(t, j,
+		LoopEvent{At: time.Now().UTC().Add(-48 * time.Hour), LoopName: "old", Kind: "loop_iteration_start"},
+		LoopEvent{At: time.Now().UTC(), LoopName: "new", Kind: "loop_iteration_start"},
+	)
+	deleted, err := j.Prune(context.Background(), 24*time.Hour)
+	if err != nil {
+		t.Fatalf("prune: %v", err)
+	}
+	if deleted != 1 {
+		t.Errorf("pruned %d, want 1", deleted)
+	}
+	left, err := j.Query(context.Background(), LoopEventQuery{})
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if len(left) != 1 || left[0].LoopName != "new" {
+		t.Errorf("surviving rows = %+v, want just the fresh one", left)
+	}
+	if _, err := j.Prune(context.Background(), 0); err == nil {
+		t.Errorf("prune with zero max age must refuse rather than delete everything")
+	}
+}
+
+func TestProjectLoopEventWhitelistsAndBounds(t *testing.T) {
+	long := strings.Repeat("x", maxDetailStringRunes+50)
+	row, ok := projectLoopEvent(events.Event{
+		Timestamp: time.Now(),
+		Kind:      events.KindLoopIterationComplete,
+		Data: map[string]any{
+			"loop_id":         "lp_1",
+			"loop_name":       "archivist",
+			"model":           "haiku",
+			"input_tokens":    1200,
+			"error":           long,
+			"tools_used":      map[string]int{"doc_read": 3}, // bulk: dropped
+			"effective_tools": []string{"a", "b"},            // bulk: dropped
+			"unknown_key":     "nope",                        // not whitelisted
+		},
+	})
+	if !ok {
+		t.Fatal("iteration_complete must be a persisted kind")
+	}
+	if row.LoopID != "lp_1" || row.LoopName != "archivist" {
+		t.Errorf("identity = %s/%s", row.LoopID, row.LoopName)
+	}
+	if row.Detail["model"] != "haiku" || row.Detail["input_tokens"] != 1200 {
+		t.Errorf("scalar whitelist not applied: %+v", row.Detail)
+	}
+	if _, present := row.Detail["tools_used"]; present {
+		t.Errorf("bulk map survived projection")
+	}
+	if _, present := row.Detail["unknown_key"]; present {
+		t.Errorf("non-whitelisted key survived projection")
+	}
+	if got := row.Detail["error"].(string); len([]rune(got)) > maxDetailStringRunes+1 {
+		t.Errorf("string value not capped: %d runes", len([]rune(got)))
+	}
+
+	if _, ok := projectLoopEvent(events.Event{Kind: events.KindLoopToolStart}); ok {
+		t.Errorf("chatty tool event must not be persisted")
+	}
+}
+
+// TestRecorderPersistsBusEvents runs the real subscribe→project→batch→
+// flush path: publish a mix of retained and chatty events, cancel, and
+// confirm the journal holds exactly the retained ones.
+func TestRecorderPersistsBusEvents(t *testing.T) {
+	j := newTestJournal(t)
+	bus := events.New()
+	rec := NewRecorder(j, bus, time.Hour, nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		rec.Run(ctx)
+	}()
+
+	// Give the subscription a moment to attach before publishing.
+	deadline := time.After(2 * time.Second)
+	for bus.SubscriberCount() == 0 {
+		select {
+		case <-deadline:
+			t.Fatal("recorder never subscribed")
+		case <-time.After(5 * time.Millisecond):
+		}
+	}
+
+	bus.Publish(events.Event{Timestamp: time.Now(), Kind: events.KindLoopIterationStart,
+		Data: map[string]any{"loop_name": "core", "wake_reason": "timer"}})
+	bus.Publish(events.Event{Timestamp: time.Now(), Kind: events.KindLoopToolStart,
+		Data: map[string]any{"loop_name": "core"}}) // chatty: dropped
+	bus.Publish(events.Event{Timestamp: time.Now(), Kind: events.KindLoopError,
+		Data: map[string]any{"loop_name": "core", "error": "boom"}})
+
+	// Cancelling forces the final flush; wait for Run to return before
+	// reading so the write has landed.
+	time.Sleep(50 * time.Millisecond) // let the recorder drain its channel
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("recorder did not stop")
+	}
+
+	rows, err := j.Query(context.Background(), LoopEventQuery{})
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("journal rows = %d, want 2 (start + error, not the tool event)", len(rows))
+	}
+	if rows[0].Kind != "loop_iteration_start" || rows[0].WakeReason != "timer" {
+		t.Errorf("rows[0] = %+v, want attributed iteration start", rows[0])
+	}
+	if rows[1].Kind != "loop_error" {
+		t.Errorf("rows[1] = %+v, want the error", rows[1])
+	}
+}

--- a/scripts/architecture.baseline
+++ b/scripts/architecture.baseline
@@ -1,4 +1,4 @@
-packages=67
+packages=68
 interfaces=83
 large_files=53
 set_mutators=117


### PR DESCRIPTION
Third PR of the metacog pivot arc (#1341), stacked on #1343. The loop runtime already narrates its life onto the operational event bus — but the bus is in-memory and lossy by design, so the stream dies with the process. A crash loop or restart erases exactly the evidence a post-incident investigation needs; the curator wake-storm retrospective was log archaeology for want of this journal.

The new `internal/state/introspection` package (the home for every cross-domain internal-operations projection this arc builds) adds a `loop_events` table on logs.db and a bus-subscriber `Recorder` that persists exactly eight lifecycle kinds: started, stopped, iteration start (carrying #1342's wake attribution in first-class `wake_reason`/`wake_source` columns), iteration complete, error, state change, mailbox arrival, and mid-turn input. The chatty per-tool/per-LLM stream is deliberately excluded — that granularity already lives in the log index and the archive, and journaling it would multiply row volume without audit value. Event payloads project through one flat scalar whitelist (bulk fields like `tools_used` are dropped; strings rune-capped) so the stored shape never depends on producer drift. The recorder batches (64 rows or 2 seconds per transaction), takes a detached timeout context for the final shutdown flush, and never blocks the bus — backpressure stays where it has always been, in the bus's own drop counter, which the arc's annunciator will surface. Retention is pure age-based (30-day default, or the log index's configured retention), deliberately not `logging.Prune`, which is level-gated and keeps INFO+ forever.

The read side is the substrate for the coming `loop_activity` tool: `Query` (loop/kind/window filters, newest-win limit reversed to a chronological timeline) and `AggregateActivity` (wakes, wakes/hour, by-reason and by-source decompositions with an explicit `(other)` overflow bucket rather than silent truncation, errors, completions, no-ops — all counted in SQL).

Two wiring changes ride along: memguard gains `Reading()` — live megabytes against the soft/hard limits plus trip state, nil-safe and race-free — and the App now retains the guard, which was previously a local variable in `Serve` whose measurements died with each poll tick. The architecture baseline moves for the new package (67→68).

## Test plan

- [x] Journal round-trip: filters compose, chronological order, wake attribution and detail survive
- [x] Limit keeps the newest rows (a capped result covers the recent window, not a stale prefix)
- [x] AggregateActivity counts wakes/errors/completions/no-ops, decomposes by reason and source, scopes by loop
- [x] Age-based prune; zero retention refused
- [x] Projection whitelist: bulk fields and unknown keys dropped, strings capped, chatty kinds rejected
- [x] Recorder end-to-end over a real bus: subscribe → project → batch → final flush on cancel
- [x] `just ci` green (architecture baseline regenerated)

Refs #1341

🤖 Generated with [Claude Code](https://claude.com/claude-code)
