### PR TITLE
feat(introspection): health inspector, doc-activity summarizer, host probes

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -12,6 +12,7 @@ import (
 	"io"
 	"log/slog"
 	"sync"
+	"sync/atomic"
 
 	"github.com/nugget/thane-ai-agent/internal/channels/email"
 	"github.com/nugget/thane-ai-agent/internal/channels/messages"
@@ -226,10 +227,13 @@ type App struct {
 	eventBus *events.Bus
 
 	// Introspection: persistent loop-event journal (nil when logs.db is
-	// unavailable) and the live memory guard (nil unless enabled; set in
-	// Serve). Both feed the internal-operations observability surfaces.
+	// unavailable), the health inspector behind system_health and the
+	// metacog panel, and the live memory guard (atomic because Serve
+	// stores it after New while tool goroutines read it). All feed the
+	// internal-operations observability surfaces.
 	loopEventJournal *introspection.Journal
-	memGuard         *memguard.Guard
+	inspector        *introspection.Inspector
+	memGuard         atomic.Pointer[memguard.Guard]
 
 	// Inter-component message bus
 	messageBus *messages.Bus

--- a/internal/app/new.go
+++ b/internal/app/new.go
@@ -115,6 +115,9 @@ func New(ctx context.Context, cfg *config.Config, logger *slog.Logger, stdout io
 	if err := a.initChannels(s); err != nil {
 		return nil, err
 	}
+	// The health inspector reads everything above lazily; it must exist
+	// before initAwareness so context providers can render from it.
+	a.initInspector()
 	if err := a.initAwareness(s); err != nil {
 		return nil, err
 	}

--- a/internal/app/new_introspection.go
+++ b/internal/app/new_introspection.go
@@ -2,8 +2,13 @@ package app
 
 import (
 	"context"
+	"path/filepath"
+	"time"
 
+	"github.com/nugget/thane-ai-agent/internal/platform/memguard"
+	"github.com/nugget/thane-ai-agent/internal/platform/telemetry"
 	"github.com/nugget/thane-ai-agent/internal/state/introspection"
+	"github.com/nugget/thane-ai-agent/internal/state/loopqueue"
 )
 
 // initIntrospectionJournal wires the persistent loop-event journal: a
@@ -31,4 +36,78 @@ func (a *App) initIntrospectionJournal() {
 		go recorder.Run(ctx)
 		return nil
 	})
+}
+
+// telemetryDBPaths names the SQLite files the telemetry collector sizes.
+// Shared by the MQTT telemetry publisher and the health inspector so the
+// two report the same databases.
+func (a *App) telemetryDBPaths() map[string]string {
+	cfg := a.cfg
+	dbPaths := map[string]string{
+		"main":  filepath.Join(cfg.DataDir, "thane.db"),
+		"usage": filepath.Join(cfg.DataDir, "usage.db"),
+	}
+	if logDir := cfg.Logging.DirPath(); logDir != "" {
+		dbPaths["logs"] = filepath.Join(logDir, "logs.db")
+	}
+	if cfg.Attachments.StoreDir != "" {
+		dbPaths["attachments"] = filepath.Join(cfg.DataDir, "attachments.db")
+	}
+	return dbPaths
+}
+
+// initInspector wires the health inspector — the single assembler
+// behind the system_health tool and the metacog context panel. Every
+// source closure is nil-safe and reads live App state at call time, so
+// components that come up later (the memory guard is stored in Serve)
+// or never (no remote doc roots) degrade to absent rows rather than
+// wiring errors. The telemetry collector here is deliberately separate
+// from the MQTT publisher's: that one only exists when MQTT telemetry
+// is enabled, and health must not depend on MQTT.
+func (a *App) initInspector() {
+	telSources := telemetry.Sources{
+		LoopRegistry: a.loopRegistry,
+		UsageStore:   a.usageStore,
+		ArchiveStore: a.archiveStore,
+		LogsDB:       a.indexDB,
+		DBPaths:      a.telemetryDBPaths(),
+		Logger:       a.logger,
+	}
+	if a.attachmentStore != nil {
+		telSources.AttachmentSource = a.attachmentStore
+	}
+
+	src := introspection.HealthSources{
+		Telemetry: telemetry.NewCollector(telSources),
+		DataDir:   a.cfg.DataDir,
+		StartedAt: time.Now(),
+	}
+	if a.connMgr != nil {
+		src.ConnStatus = a.connMgr.Status
+	}
+	src.MemGuard = func() (memguard.Reading, bool) {
+		guard := a.memGuard.Load()
+		if guard == nil {
+			return memguard.Reading{}, false
+		}
+		return guard.Reading(), true
+	}
+	if a.eventBus != nil {
+		src.BusDropped = a.eventBus.DroppedCount
+	}
+	if a.indexHandler != nil {
+		src.IndexStats = a.indexHandler.Stats
+	}
+	if a.syncRegistry != nil {
+		src.SyncStates = a.syncRegistry.All
+	}
+	if a.loopQueue != nil {
+		src.QueueStats = func(ctx context.Context) ([]loopqueue.ConsumerPending, error) {
+			return a.loopQueue.PendingStats(ctx)
+		}
+	}
+	if a.loopRegistry != nil {
+		src.LoopStatuses = a.loopRegistry.Statuses
+	}
+	a.inspector = introspection.NewInspector(src)
 }

--- a/internal/app/new_servers.go
+++ b/internal/app/new_servers.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"path/filepath"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -532,16 +531,7 @@ func (a *App) initServers(s *newState) error {
 
 		a.mqttPub.RegisterSensors(telBuilder.StaticSensors())
 
-		dbPaths := map[string]string{
-			"main":  filepath.Join(cfg.DataDir, "thane.db"),
-			"usage": filepath.Join(cfg.DataDir, "usage.db"),
-		}
-		if logDir := cfg.Logging.DirPath(); logDir != "" {
-			dbPaths["logs"] = filepath.Join(logDir, "logs.db")
-		}
-		if cfg.Attachments.StoreDir != "" {
-			dbPaths["attachments"] = filepath.Join(cfg.DataDir, "attachments.db")
-		}
+		dbPaths := a.telemetryDBPaths()
 
 		telSources := telemetry.Sources{
 			LoopRegistry: a.loopRegistry,

--- a/internal/app/serve.go
+++ b/internal/app/serve.go
@@ -66,8 +66,8 @@ func (a *App) Serve(ctx context.Context) error {
 			Interval:    time.Duration(a.cfg.MemoryGuard.IntervalSeconds) * time.Second,
 		}, a.logger)
 		// Stored on the App so observability surfaces (system_health) can
-		// read live memory against the limits; nil when the guard is off.
-		a.memGuard = guard
+		// read live memory against the limits; unset when the guard is off.
+		a.memGuard.Store(guard)
 		go guard.Start(ctx)
 	}
 

--- a/internal/state/documents/activity.go
+++ b/internal/state/documents/activity.go
@@ -1,0 +1,278 @@
+package documents
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+)
+
+// ActivityQuery bounds one root's revision-churn report.
+type ActivityQuery struct {
+	// Root names the document root to report on. Required; the root must
+	// keep revision history (be git-backed).
+	Root string
+	// Since is the window start. Required.
+	Since time.Time
+	// Limit caps the documents in the report (default 20, max 100).
+	// Flagged documents sort first, so the cap cannot hide a runaway.
+	Limit int
+	// RevisionThreshold flags a document with at least this many
+	// in-window revisions (default 8).
+	RevisionThreshold int
+}
+
+const (
+	defaultActivityLimit     = 20
+	maxActivityLimit         = 100
+	defaultRevisionThreshold = 8
+	// activityHistoryPage bounds the per-document history read. A
+	// document with more in-window revisions than this reports the page
+	// size as its count — far past any sane threshold, so the flag has
+	// long since tripped.
+	activityHistoryPage = 100
+)
+
+// ActivityAuthor attributes a share of one document's in-window
+// revisions. Author is the writing loop's ID from the commit trailers,
+// or "manual" for revisions with no authorship block — which were, by
+// definition, not written by a loop.
+type ActivityAuthor struct {
+	Author    string `json:"author"`
+	Model     string `json:"model,omitempty"`
+	Revisions int    `json:"revisions"`
+}
+
+// DocumentActivity is one document's churn over the window.
+type DocumentActivity struct {
+	Ref            string           `json:"ref"`
+	Revisions      int              `json:"revisions"`
+	LinesAdded     int              `json:"lines_added"`
+	LinesRemoved   int              `json:"lines_removed"`
+	NetLineDelta   int              `json:"net_line_delta"`
+	SizeBytes      int64            `json:"size_bytes"`
+	WordCount      int              `json:"word_count"`
+	LastRevisionAt time.Time        `json:"-"`
+	Authors        []ActivityAuthor `json:"authors,omitempty"`
+	Flagged        bool             `json:"flagged,omitempty"`
+	FlagReason     string           `json:"flag_reason,omitempty"`
+}
+
+// ActivityReport is one root's churn summary: which documents changed
+// in the window, how much, and by whose hand — flagged runaways first.
+type ActivityReport struct {
+	Root      string             `json:"root"`
+	Threshold int                `json:"revision_threshold"`
+	Documents []DocumentActivity `json:"documents"`
+	// Total counts documents with in-window revisions before the limit
+	// clipped; Truncated marks the clip explicitly.
+	Total     int  `json:"total"`
+	Truncated bool `json:"truncated,omitempty"`
+}
+
+// Activity reports revision churn across one root's documents since the
+// window start. It reads the index first (a document whose file mtime
+// predates the window is skipped before any git subprocess runs), pulls
+// each active document's in-window history, and computes the window's
+// net line delta with a single spanning diff per document — from the
+// revision in force at window start to HEAD — rather than a diff per
+// revision.
+func (s *Store) Activity(ctx context.Context, q ActivityQuery) (*ActivityReport, error) {
+	root := normalizeRootName(q.Root)
+	if root == "" {
+		return nil, fmt.Errorf("activity requires a root; known roots: %s", strings.Join(s.allRoots(), ", "))
+	}
+	if _, known := s.roots[root]; !known {
+		return nil, fmt.Errorf("unknown root %q; known roots: %s", root, strings.Join(s.allRoots(), ", "))
+	}
+	reviser := s.rootReviser(root)
+	if reviser == nil {
+		return nil, fmt.Errorf("root %q keeps no revision history; revision-backed roots: %s",
+			root, strings.Join(s.reviserRoots(), ", "))
+	}
+	if q.Since.IsZero() {
+		return nil, fmt.Errorf("activity requires a window start (since)")
+	}
+	limit := q.Limit
+	if limit <= 0 {
+		limit = defaultActivityLimit
+	}
+	if limit > maxActivityLimit {
+		limit = maxActivityLimit
+	}
+	threshold := q.RevisionThreshold
+	if threshold <= 0 {
+		threshold = defaultRevisionThreshold
+	}
+
+	if err := s.Refresh(ctx); err != nil {
+		return nil, err
+	}
+
+	// Candidate pre-filter on the index: file mtime inside the window
+	// (with one second of slack — modified_at is RFC3339Nano text, whose
+	// lexicographic order is only second-exact across precision changes).
+	// This is what bounds the git subprocess count.
+	cutoff := q.Since.Add(-time.Second).UTC().Format(time.RFC3339Nano)
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT rel_path, size_bytes, word_count
+		FROM indexed_documents
+		WHERE root = ? AND modified_at >= ?
+		ORDER BY rel_path ASC
+	`, root, cutoff)
+	if err != nil {
+		return nil, fmt.Errorf("list active documents for root %q: %w", root, err)
+	}
+	defer rows.Close()
+
+	type candidate struct {
+		relPath   string
+		sizeBytes int64
+		wordCount int
+	}
+	var candidates []candidate
+	for rows.Next() {
+		var c candidate
+		if err := rows.Scan(&c.relPath, &c.sizeBytes, &c.wordCount); err != nil {
+			return nil, err
+		}
+		candidates = append(candidates, c)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	report := &ActivityReport{Root: root, Threshold: threshold}
+	for _, c := range candidates {
+		activity, err := s.documentActivity(ctx, reviser, root, c.relPath, q.Since, threshold)
+		if err != nil {
+			return nil, err
+		}
+		if activity == nil {
+			continue // no in-window revisions (mtime was touch-only or index slack)
+		}
+		activity.SizeBytes = c.sizeBytes
+		activity.WordCount = c.wordCount
+		report.Documents = append(report.Documents, *activity)
+	}
+
+	// Flagged first, then busiest, then stable name order.
+	sort.SliceStable(report.Documents, func(i, j int) bool {
+		a, b := report.Documents[i], report.Documents[j]
+		if a.Flagged != b.Flagged {
+			return a.Flagged
+		}
+		if a.Revisions != b.Revisions {
+			return a.Revisions > b.Revisions
+		}
+		return a.Ref < b.Ref
+	})
+	report.Total = len(report.Documents)
+	if len(report.Documents) > limit {
+		report.Documents = report.Documents[:limit]
+		report.Truncated = true
+	}
+	return report, nil
+}
+
+// documentActivity computes one document's in-window churn, or nil when
+// the window holds no revisions.
+func (s *Store) documentActivity(ctx context.Context, reviser RootReviser, root, relPath string, since time.Time, threshold int) (*DocumentActivity, error) {
+	listing, err := reviser.History(ctx, relPath, RevisionQuery{Limit: activityHistoryPage})
+	if err != nil {
+		return nil, fmt.Errorf("history for %s:%s: %w", root, relPath, err)
+	}
+	var inWindow []RevisionRef
+	for _, rev := range listing.Revisions {
+		if rev.Timestamp.Before(since) {
+			break // newest-first: everything past here predates the window
+		}
+		inWindow = append(inWindow, rev)
+	}
+	if len(inWindow) == 0 {
+		return nil, nil
+	}
+
+	activity := &DocumentActivity{
+		Ref:            root + ":" + relPath,
+		Revisions:      len(inWindow),
+		LastRevisionAt: inWindow[0].Timestamp,
+		Authors:        aggregateActivityAuthors(inWindow),
+	}
+
+	// One spanning diff: from the revision in force at window start to
+	// HEAD. A document born inside the window has no such base; fall
+	// back to its oldest in-window revision, which undercounts by the
+	// birth commit's own additions — a known, bounded skew.
+	base := ""
+	if len(inWindow) < len(listing.Revisions) {
+		base = listing.Revisions[len(inWindow)].Commit
+	} else if len(inWindow) > 1 {
+		base = inWindow[len(inWindow)-1].Commit
+	}
+	if base != "" {
+		diff, err := reviser.Diff(ctx, relPath, base, "HEAD", "stat")
+		if err != nil {
+			return nil, fmt.Errorf("diff for %s:%s: %w", root, relPath, err)
+		}
+		activity.LinesAdded = diff.Added
+		activity.LinesRemoved = diff.Removed
+		activity.NetLineDelta = diff.Added - diff.Removed
+	}
+
+	if activity.Revisions >= threshold {
+		activity.Flagged = true
+		activity.FlagReason = fmt.Sprintf("%d revisions in the window meets the runaway threshold %d", activity.Revisions, threshold)
+	}
+	return activity, nil
+}
+
+// maxActivityAuthors caps the per-document attribution list.
+const maxActivityAuthors = 5
+
+func aggregateActivityAuthors(revs []RevisionRef) []ActivityAuthor {
+	counts := make(map[string]*ActivityAuthor)
+	var order []string
+	for _, rev := range revs {
+		author := rev.Trailers[TrailerLoopID]
+		if author == "" {
+			author = "manual"
+		}
+		entry, seen := counts[author]
+		if !seen {
+			entry = &ActivityAuthor{Author: author}
+			counts[author] = entry
+			order = append(order, author)
+		}
+		entry.Revisions++
+		if entry.Model == "" {
+			entry.Model = rev.Trailers[TrailerModel]
+		}
+	}
+	authors := make([]ActivityAuthor, 0, len(order))
+	for _, key := range order {
+		authors = append(authors, *counts[key])
+	}
+	sort.SliceStable(authors, func(i, j int) bool {
+		if authors[i].Revisions != authors[j].Revisions {
+			return authors[i].Revisions > authors[j].Revisions
+		}
+		return authors[i].Author < authors[j].Author
+	})
+	if len(authors) > maxActivityAuthors {
+		authors = authors[:maxActivityAuthors]
+	}
+	return authors
+}
+
+// reviserRoots lists the roots that keep revision history, for the
+// teaching error when a caller names one that does not.
+func (s *Store) reviserRoots() []string {
+	var roots []string
+	for root := range s.rootRevisers {
+		roots = append(roots, root)
+	}
+	sort.Strings(roots)
+	return roots
+}

--- a/internal/state/documents/activity_test.go
+++ b/internal/state/documents/activity_test.go
@@ -1,0 +1,215 @@
+package documents
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nugget/thane-ai-agent/internal/platform/database"
+)
+
+// recordingReviser serves canned per-file history/diffs and records the
+// diff base so tests can pin the spanning-diff selection.
+type recordingReviser struct {
+	listings  map[string]RevisionListing
+	diffs     map[string]RevisionDiff
+	diffBases map[string]string
+}
+
+func (r *recordingReviser) Resolve(context.Context, string, string) (RevisionRef, error) {
+	return RevisionRef{}, nil
+}
+
+func (r *recordingReviser) History(_ context.Context, filename string, _ RevisionQuery) (RevisionListing, error) {
+	return r.listings[filename], nil
+}
+
+func (r *recordingReviser) Diff(_ context.Context, filename, from, _, _ string) (RevisionDiff, error) {
+	if r.diffBases == nil {
+		r.diffBases = make(map[string]string)
+	}
+	r.diffBases[filename] = from
+	return r.diffs[filename], nil
+}
+
+func (r *recordingReviser) Content(context.Context, string, string) (RevisionContent, error) {
+	return RevisionContent{}, nil
+}
+
+func newActivityStore(t *testing.T, files map[string]string, reviser RootReviser) *Store {
+	t.Helper()
+	dir := t.TempDir()
+	for name, body := range files {
+		path := filepath.Join(dir, name)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	db, err := database.OpenMemory()
+	if err != nil {
+		t.Fatalf("OpenMemory: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	revisers := map[string]RootReviser{}
+	if reviser != nil {
+		revisers["self"] = reviser
+	}
+	store, err := NewStoreWithOptions(db, map[string]string{"self": dir}, nil, StoreOptions{RootRevisers: revisers})
+	if err != nil {
+		t.Fatalf("NewStoreWithOptions: %v", err)
+	}
+	return store
+}
+
+func TestActivityErrorsTeachTheNextMove(t *testing.T) {
+	store := newActivityStore(t, map[string]string{"ego.md": "# ego\n"}, &recordingReviser{})
+
+	if _, err := store.Activity(t.Context(), ActivityQuery{Root: "nope", Since: time.Now().Add(-time.Hour)}); err == nil || !strings.Contains(err.Error(), "known roots") {
+		t.Errorf("unknown-root error must name the known roots, got %v", err)
+	}
+
+	bare := newActivityStore(t, map[string]string{"a.md": "# a\n"}, nil)
+	if _, err := bare.Activity(t.Context(), ActivityQuery{Root: "self", Since: time.Now().Add(-time.Hour)}); err == nil || !strings.Contains(err.Error(), "keeps no revision history") {
+		t.Errorf("revision-less root error must teach which roots qualify, got %v", err)
+	}
+}
+
+func TestActivityReportsChurnFlagsAndAuthors(t *testing.T) {
+	now := time.Now().UTC()
+	loopRev := func(age time.Duration, commit, loopID, model string) RevisionRef {
+		return RevisionRef{
+			Commit: commit, Short: commit[:4], Timestamp: now.Add(-age),
+			Trailers: map[string]string{TrailerLoopID: loopID, TrailerModel: model},
+		}
+	}
+	manualRev := func(age time.Duration, commit string) RevisionRef {
+		return RevisionRef{Commit: commit, Short: commit[:4], Timestamp: now.Add(-age)}
+	}
+
+	reviser := &recordingReviser{
+		listings: map[string]RevisionListing{
+			// ego.md: three in-window loop revisions plus one older —
+			// the older one is the spanning-diff base.
+			"ego.md": {Revisions: []RevisionRef{
+				loopRev(1*time.Hour, "aaaa1111", "lp_ego", "haiku"),
+				loopRev(5*time.Hour, "bbbb2222", "lp_ego", "haiku"),
+				manualRev(9*time.Hour, "cccc3333"),
+				loopRev(72*time.Hour, "dddd4444", "lp_ego", "haiku"), // outside the window
+			}},
+			// notes.md: quiet — nothing in the window despite a fresh mtime.
+			"notes.md": {Revisions: []RevisionRef{manualRev(72*time.Hour, "eeee5555")}},
+		},
+		diffs: map[string]RevisionDiff{
+			"ego.md": {Added: 120, Removed: 40},
+		},
+	}
+	store := newActivityStore(t, map[string]string{
+		"ego.md":   "# ego\ncontent\n",
+		"notes.md": "# notes\n",
+	}, reviser)
+
+	report, err := store.Activity(t.Context(), ActivityQuery{
+		Root:              "self",
+		Since:             now.Add(-24 * time.Hour),
+		RevisionThreshold: 3,
+	})
+	if err != nil {
+		t.Fatalf("activity: %v", err)
+	}
+	if report.Total != 1 || len(report.Documents) != 1 {
+		t.Fatalf("report = %+v, want exactly ego.md (notes.md has no in-window revisions)", report)
+	}
+
+	doc := report.Documents[0]
+	if doc.Ref != "self:ego.md" || doc.Revisions != 3 {
+		t.Errorf("doc = %s with %d revisions, want self:ego.md with 3", doc.Ref, doc.Revisions)
+	}
+	if doc.LinesAdded != 120 || doc.LinesRemoved != 40 || doc.NetLineDelta != 80 {
+		t.Errorf("line math = +%d/-%d net %d, want +120/-40 net 80", doc.LinesAdded, doc.LinesRemoved, doc.NetLineDelta)
+	}
+	if doc.SizeBytes <= 0 {
+		t.Errorf("size_bytes not joined from the index: %+v", doc)
+	}
+	if !doc.Flagged || !strings.Contains(doc.FlagReason, "3 revisions") {
+		t.Errorf("threshold 3 with 3 revisions must flag, got %+v", doc)
+	}
+	// The spanning diff runs from the newest revision OLDER than the
+	// window — the state in force at window start.
+	if base := reviser.diffBases["ego.md"]; base != "dddd4444" {
+		t.Errorf("diff base = %q, want the pre-window revision dddd4444", base)
+	}
+	// Authors: the loop twice, the hand-written revision as "manual".
+	if len(doc.Authors) != 2 || doc.Authors[0].Author != "lp_ego" || doc.Authors[0].Revisions != 2 || doc.Authors[0].Model != "haiku" {
+		t.Errorf("authors = %+v, want lp_ego(haiku)x2 leading", doc.Authors)
+	}
+	if doc.Authors[1].Author != "manual" || doc.Authors[1].Revisions != 1 {
+		t.Errorf("authors[1] = %+v, want manual x1", doc.Authors[1])
+	}
+}
+
+func TestActivityDocBornInWindowFallsBackToOldestRevision(t *testing.T) {
+	now := time.Now().UTC()
+	reviser := &recordingReviser{
+		listings: map[string]RevisionListing{
+			"fresh.md": {Revisions: []RevisionRef{
+				{Commit: "aaaa1111", Short: "aaaa", Timestamp: now.Add(-time.Hour)},
+				{Commit: "bbbb2222", Short: "bbbb", Timestamp: now.Add(-2 * time.Hour)},
+			}},
+		},
+		diffs: map[string]RevisionDiff{"fresh.md": {Added: 10}},
+	}
+	store := newActivityStore(t, map[string]string{"fresh.md": "# fresh\n"}, reviser)
+
+	report, err := store.Activity(t.Context(), ActivityQuery{Root: "self", Since: now.Add(-24 * time.Hour)})
+	if err != nil {
+		t.Fatalf("activity: %v", err)
+	}
+	if len(report.Documents) != 1 || report.Documents[0].Revisions != 2 {
+		t.Fatalf("report = %+v, want fresh.md with 2 revisions", report)
+	}
+	if base := reviser.diffBases["fresh.md"]; base != "bbbb2222" {
+		t.Errorf("diff base = %q, want the oldest in-window revision", base)
+	}
+}
+
+func TestActivityTruncatesFlaggedFirst(t *testing.T) {
+	now := time.Now().UTC()
+	listings := map[string]RevisionListing{}
+	files := map[string]string{}
+	// quiet-1..3 have one in-window revision; busy.md has nine.
+	for _, name := range []string{"quiet-1.md", "quiet-2.md", "quiet-3.md"} {
+		files[name] = "# q\n"
+		listings[name] = RevisionListing{Revisions: []RevisionRef{
+			{Commit: "aaaa0000", Short: "aaaa", Timestamp: now.Add(-time.Hour)},
+		}}
+	}
+	files["busy.md"] = "# b\n"
+	var busy []RevisionRef
+	for i := range 9 {
+		busy = append(busy, RevisionRef{
+			Commit: "bbbb000" + string(rune('0'+i)), Short: "bbbb",
+			Timestamp: now.Add(-time.Duration(i+1) * time.Hour),
+		})
+	}
+	listings["busy.md"] = RevisionListing{Revisions: busy}
+
+	store := newActivityStore(t, files, &recordingReviser{listings: listings})
+	report, err := store.Activity(t.Context(), ActivityQuery{
+		Root: "self", Since: now.Add(-24 * time.Hour), Limit: 2,
+	})
+	if err != nil {
+		t.Fatalf("activity: %v", err)
+	}
+	if report.Total != 4 || !report.Truncated || len(report.Documents) != 2 {
+		t.Fatalf("report total=%d truncated=%v len=%d, want 4/true/2", report.Total, report.Truncated, len(report.Documents))
+	}
+	if report.Documents[0].Ref != "self:busy.md" || !report.Documents[0].Flagged {
+		t.Errorf("flagged runaway must survive the cap, got %+v", report.Documents[0])
+	}
+}

--- a/internal/state/introspection/disk_other.go
+++ b/internal/state/introspection/disk_other.go
@@ -1,0 +1,11 @@
+//go:build !darwin && !linux
+
+package introspection
+
+import "errors"
+
+// diskFree is unsupported off darwin/linux; the host snapshot simply
+// omits disk numbers there.
+func diskFree(string) (free, total uint64, err error) {
+	return 0, 0, errors.New("disk stats unsupported on this platform")
+}

--- a/internal/state/introspection/disk_unix.go
+++ b/internal/state/introspection/disk_unix.go
@@ -1,0 +1,17 @@
+//go:build darwin || linux
+
+package introspection
+
+import "syscall"
+
+// diskFree reports free and total bytes on the filesystem holding path.
+// The uint64 conversions normalize the platform difference: Bsize is
+// uint32 on darwin and int64 on linux, so one file compiles on both.
+func diskFree(path string) (free, total uint64, err error) {
+	var st syscall.Statfs_t
+	if err := syscall.Statfs(path, &st); err != nil {
+		return 0, 0, err
+	}
+	bsize := uint64(st.Bsize)
+	return uint64(st.Bavail) * bsize, uint64(st.Blocks) * bsize, nil
+}

--- a/internal/state/introspection/health.go
+++ b/internal/state/introspection/health.go
@@ -282,10 +282,13 @@ func (i *Inspector) Health(ctx context.Context) HealthSnapshot {
 		statuses := i.src.LoopStatuses()
 		snap.Loops = buildLoopCensus(statuses)
 		row := HealthRow{Name: "loops", Status: HealthOK,
-			Detail: fmt.Sprintf("%d running", snap.Loops.Total)}
+			Detail: fmt.Sprintf("%d loops in the fleet, none degraded", snap.Loops.Total)}
 		if snap.Loops.Degraded > 0 {
 			row.Status = HealthDegraded
 			row.Detail = fmt.Sprintf("%d of %d loops degraded: %v", snap.Loops.Degraded, snap.Loops.Total, snap.Loops.DegradedLoops)
+			if snap.Loops.DegradedTruncated {
+				row.Detail += fmt.Sprintf(" (+%d more)", snap.Loops.Degraded-len(snap.Loops.DegradedLoops))
+			}
 		}
 		snap.Annunciator = append(snap.Annunciator, row)
 	}

--- a/internal/state/introspection/health.go
+++ b/internal/state/introspection/health.go
@@ -1,0 +1,331 @@
+package introspection
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/nugget/thane-ai-agent/internal/connwatch"
+	"github.com/nugget/thane-ai-agent/internal/model/promptfmt"
+	"github.com/nugget/thane-ai-agent/internal/platform/checkout"
+	"github.com/nugget/thane-ai-agent/internal/platform/logging"
+	"github.com/nugget/thane-ai-agent/internal/platform/memguard"
+	"github.com/nugget/thane-ai-agent/internal/platform/provenance"
+	"github.com/nugget/thane-ai-agent/internal/platform/telemetry"
+	looppkg "github.com/nugget/thane-ai-agent/internal/runtime/loop"
+	"github.com/nugget/thane-ai-agent/internal/state/loopqueue"
+)
+
+// Annunciator row statuses. Three values, not a gradient: a row is
+// healthy, degraded but operating, or failed. Detail carries the why.
+const (
+	HealthOK       = "ok"
+	HealthDegraded = "degraded"
+	HealthFailed   = "failed"
+)
+
+// queueBacklogStaleAfter is how old a partition's oldest pending item
+// may grow before the queue_backlog row degrades: an hour of unclaimed
+// work means the consumer is not keeping up or not running.
+const queueBacklogStaleAfter = time.Hour
+
+// HealthRow is one annunciator lamp: a subsystem, its status, and a
+// precomputed detail sentence — the model never derives health from raw
+// numbers.
+type HealthRow struct {
+	Name      string `json:"name"`
+	Status    string `json:"status"`
+	Detail    string `json:"detail,omitempty"`
+	LastCheck string `json:"last_check,omitempty"` // delta, e.g. "-42s"
+}
+
+// HostInfo is the stdlib-only host snapshot: process shape and the disk
+// under the data directory. No gopsutil — everything here comes from
+// runtime, syscall, and os.
+type HostInfo struct {
+	UptimeDelta   string `json:"uptime_delta,omitempty"`
+	Goroutines    int    `json:"goroutines"`
+	GOMAXPROCS    int    `json:"gomaxprocs"`
+	DiskFreeBytes int64  `json:"disk_free_bytes,omitempty"`
+	DiskUsedPct   int    `json:"disk_used_pct,omitempty"`
+}
+
+// LoopCensus is the fleet rollup: totals by state plus the degraded
+// loops by name, capped with an explicit remainder.
+type LoopCensus struct {
+	Total             int            `json:"total"`
+	ByState           map[string]int `json:"by_state,omitempty"`
+	Degraded          int            `json:"degraded"`
+	DegradedLoops     []string       `json:"degraded_loops,omitempty"`
+	DegradedTruncated bool           `json:"degraded_truncated,omitempty"`
+}
+
+// maxCensusDegradedNames caps the degraded-loop name list on the census.
+const maxCensusDegradedNames = 10
+
+// QueueDepth is one work-queue partition's live backlog.
+type QueueDepth struct {
+	Consumer  string `json:"consumer"`
+	Pending   int    `json:"pending"`
+	OldestAge string `json:"oldest_age,omitempty"` // duration, e.g. "42m"
+}
+
+// TelemetryRollup is the 24h operational summary drawn from the
+// telemetry collector.
+type TelemetryRollup struct {
+	Requests24h  int              `json:"requests_24h"`
+	Errors24h    int              `json:"errors_24h"`
+	LatencyP50Ms int              `json:"latency_p50_ms,omitempty"`
+	LatencyP95Ms int              `json:"latency_p95_ms,omitempty"`
+	DBSizesBytes map[string]int64 `json:"db_sizes_bytes,omitempty"`
+}
+
+// HealthSnapshot is the whole annunciator panel in one shape, consumed
+// identically by the system_health tool and the metacog context panel
+// so the two can never drift.
+type HealthSnapshot struct {
+	Annunciator []HealthRow     `json:"annunciator"`
+	Host        HostInfo        `json:"host"`
+	Loops       LoopCensus      `json:"loops"`
+	Queues      []QueueDepth    `json:"queues,omitempty"`
+	Telemetry   TelemetryRollup `json:"telemetry"`
+}
+
+// Degraded lists the annunciator rows that are not ok — the panel's
+// summary line and the escalation trigger both read from this.
+func (s HealthSnapshot) Degraded() []HealthRow {
+	var rows []HealthRow
+	for _, row := range s.Annunciator {
+		if row.Status != HealthOK {
+			rows = append(rows, row)
+		}
+	}
+	return rows
+}
+
+// HealthSources are the live feeds the Inspector reads. Every field is
+// optional (nil-safe): an unwired source simply contributes no rows, so
+// the Inspector works identically in production, tests, and reduced
+// configurations.
+type HealthSources struct {
+	// ConnStatus reports per-service reachability (connwatch).
+	ConnStatus func() map[string]connwatch.ServiceStatus
+	// MemGuard reports live memory against the guard's limits; ok=false
+	// means the guard is not running (disabled by config).
+	MemGuard func() (memguard.Reading, bool)
+	// BusDropped is the operational event bus's cumulative dropped-
+	// delivery count.
+	BusDropped func() uint64
+	// IndexStats reports log-index loss counters.
+	IndexStats func() logging.IndexStats
+	// SyncStates reports document-root remote sync state.
+	SyncStates func() []checkout.SyncState
+	// QueueStats reports live work-queue backlog per partition.
+	QueueStats func(ctx context.Context) ([]loopqueue.ConsumerPending, error)
+	// LoopStatuses snapshots the loop registry.
+	LoopStatuses func() []looppkg.Status
+	// Telemetry collects the 24h operational rollup.
+	Telemetry *telemetry.Collector
+	// DataDir is the disk-probe target (thane's data directory).
+	DataDir string
+	// StartedAt is process start, for uptime.
+	StartedAt time.Time
+}
+
+// Inspector assembles HealthSnapshots from the wired sources. It is the
+// single source of truth for internal-operations health; every
+// model-facing surface renders from its output.
+type Inspector struct {
+	src HealthSources
+	now func() time.Time
+}
+
+// NewInspector builds an Inspector over src.
+func NewInspector(src HealthSources) *Inspector {
+	return &Inspector{src: src, now: time.Now}
+}
+
+// Health assembles the annunciator panel. It never fails: a source that
+// errors becomes a degraded row carrying the error text, because "the
+// probe broke" is itself a health finding.
+func (i *Inspector) Health(ctx context.Context) HealthSnapshot {
+	now := i.now()
+	snap := HealthSnapshot{}
+
+	// External connections, one lamp per watched service, name-sorted.
+	if i.src.ConnStatus != nil {
+		statuses := i.src.ConnStatus()
+		names := make([]string, 0, len(statuses))
+		for name := range statuses {
+			names = append(names, name)
+		}
+		sort.Strings(names)
+		for _, name := range names {
+			st := statuses[name]
+			row := HealthRow{Name: "conn:" + name, Status: HealthOK}
+			if !st.LastCheck.IsZero() {
+				row.LastCheck = promptfmt.FormatDeltaOnly(st.LastCheck, now)
+			}
+			if !st.Ready {
+				row.Status = HealthFailed
+				row.Detail = st.LastError
+				if row.Detail == "" {
+					row.Detail = "not ready"
+				}
+			}
+			snap.Annunciator = append(snap.Annunciator, row)
+		}
+	}
+
+	// Memory guard: ok below soft, degraded past soft, failed once the
+	// hard limit tripped. Reported as disabled (still ok) when unwired —
+	// an off guard is a config choice, not an incident.
+	if i.src.MemGuard != nil {
+		if reading, running := i.src.MemGuard(); running {
+			row := HealthRow{
+				Name:   "memory_guard",
+				Status: HealthOK,
+				Detail: fmt.Sprintf("%dMB in use of %dMB soft / %dMB hard", reading.CurrentMB, reading.SoftMB, reading.HardMB),
+			}
+			switch {
+			case reading.Tripped:
+				row.Status = HealthFailed
+				row.Detail = fmt.Sprintf("hard limit tripped at %dMB; restart pending or imminent", reading.HardMB)
+			case reading.SoftMB > 0 && reading.CurrentMB >= reading.SoftMB:
+				row.Status = HealthDegraded
+				row.Detail = fmt.Sprintf("%dMB in use exceeds the %dMB soft limit (hard limit %dMB)", reading.CurrentMB, reading.SoftMB, reading.HardMB)
+			}
+			snap.Annunciator = append(snap.Annunciator, row)
+		} else {
+			snap.Annunciator = append(snap.Annunciator, HealthRow{
+				Name: "memory_guard", Status: HealthOK, Detail: "disabled by config",
+			})
+		}
+	}
+
+	// Event bus: any dropped delivery since boot degrades the row —
+	// something was slow enough to lose observability data.
+	if i.src.BusDropped != nil {
+		row := HealthRow{Name: "event_bus", Status: HealthOK}
+		if dropped := i.src.BusDropped(); dropped > 0 {
+			row.Status = HealthDegraded
+			row.Detail = fmt.Sprintf("%d subscriber deliveries dropped since boot", dropped)
+		}
+		snap.Annunciator = append(snap.Annunciator, row)
+	}
+
+	// Log index: dropped records or write errors mean logs_query
+	// completeness degraded.
+	if i.src.IndexStats != nil {
+		stats := i.src.IndexStats()
+		row := HealthRow{Name: "log_index", Status: HealthOK}
+		if stats.DroppedRecords > 0 || stats.WriteErrors > 0 {
+			row.Status = HealthDegraded
+			row.Detail = fmt.Sprintf("%d records dropped, %d write errors since boot", stats.DroppedRecords, stats.WriteErrors)
+		}
+		snap.Annunciator = append(snap.Annunciator, row)
+	}
+
+	// Document-root sync: clean/fast-forwarded/pushed are healthy;
+	// diverged/blocked/remote_behind degrade; an errored pass fails.
+	if i.src.SyncStates != nil {
+		for _, st := range i.src.SyncStates() {
+			row := HealthRow{Name: "doc_sync:" + st.Name, Status: HealthOK}
+			if !st.LastSyncAt.IsZero() {
+				row.LastCheck = promptfmt.FormatDeltaOnly(st.LastSyncAt, now)
+			}
+			switch {
+			case !st.OK:
+				row.Status = HealthFailed
+				row.Detail = st.Detail
+			case st.Outcome == provenance.SyncDiverged, st.Outcome == provenance.SyncBlocked, st.Outcome == provenance.SyncRemoteBehind:
+				row.Status = HealthDegraded
+				row.Detail = fmt.Sprintf("%s: %s", st.Outcome, st.Detail)
+			}
+			snap.Annunciator = append(snap.Annunciator, row)
+		}
+	}
+
+	// Work queue backlog: a partition whose oldest pending item has aged
+	// past the threshold degrades the row — the consumer is not keeping up.
+	if i.src.QueueStats != nil {
+		row := HealthRow{Name: "queue_backlog", Status: HealthOK}
+		stats, err := i.src.QueueStats(ctx)
+		if err != nil {
+			row.Status = HealthDegraded
+			row.Detail = fmt.Sprintf("backlog probe failed: %v", err)
+		} else {
+			var stale []string
+			for _, cp := range stats {
+				depth := QueueDepth{Consumer: cp.Consumer, Pending: cp.Pending}
+				if !cp.OldestEnqueuedAt.IsZero() {
+					age := now.Sub(cp.OldestEnqueuedAt)
+					depth.OldestAge = promptfmt.FormatDuration(age.Round(time.Second))
+					if age > queueBacklogStaleAfter {
+						stale = append(stale, fmt.Sprintf("%s (oldest %s)", cp.Consumer, depth.OldestAge))
+					}
+				}
+				snap.Queues = append(snap.Queues, depth)
+			}
+			if len(stale) > 0 {
+				row.Status = HealthDegraded
+				row.Detail = fmt.Sprintf("pending work older than %s in: %v", promptfmt.FormatDuration(queueBacklogStaleAfter), stale)
+			}
+		}
+		snap.Annunciator = append(snap.Annunciator, row)
+	}
+
+	// Loop fleet: the census plus one lamp that degrades when any loop
+	// is errored.
+	if i.src.LoopStatuses != nil {
+		statuses := i.src.LoopStatuses()
+		snap.Loops = buildLoopCensus(statuses)
+		row := HealthRow{Name: "loops", Status: HealthOK,
+			Detail: fmt.Sprintf("%d running", snap.Loops.Total)}
+		if snap.Loops.Degraded > 0 {
+			row.Status = HealthDegraded
+			row.Detail = fmt.Sprintf("%d of %d loops degraded: %v", snap.Loops.Degraded, snap.Loops.Total, snap.Loops.DegradedLoops)
+		}
+		snap.Annunciator = append(snap.Annunciator, row)
+	}
+
+	snap.Host = collectHostInfo(i.src.DataDir, i.src.StartedAt, now)
+	if i.src.Telemetry != nil {
+		metrics := i.src.Telemetry.Collect(ctx)
+		snap.Telemetry = TelemetryRollup{
+			Requests24h:  metrics.Requests24h,
+			Errors24h:    metrics.Errors24h,
+			LatencyP50Ms: int(metrics.LatencyP50Ms),
+			LatencyP95Ms: int(metrics.LatencyP95Ms),
+			DBSizesBytes: metrics.DBSizes,
+		}
+	}
+	return snap
+}
+
+// buildLoopCensus rolls the registry snapshot into totals. Degraded
+// matches loop_status's own definition: consecutive errors or an error
+// state.
+func buildLoopCensus(statuses []looppkg.Status) LoopCensus {
+	census := LoopCensus{Total: len(statuses)}
+	for _, st := range statuses {
+		state := string(st.State)
+		if state == "" {
+			state = "running"
+		}
+		if census.ByState == nil {
+			census.ByState = make(map[string]int)
+		}
+		census.ByState[state]++
+		if st.ConsecutiveErrors > 0 || st.State == looppkg.StateError {
+			census.Degraded++
+			if len(census.DegradedLoops) < maxCensusDegradedNames {
+				census.DegradedLoops = append(census.DegradedLoops, st.Name)
+			} else {
+				census.DegradedTruncated = true
+			}
+		}
+	}
+	return census
+}

--- a/internal/state/introspection/health_test.go
+++ b/internal/state/introspection/health_test.go
@@ -1,0 +1,175 @@
+package introspection
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nugget/thane-ai-agent/internal/connwatch"
+	"github.com/nugget/thane-ai-agent/internal/platform/checkout"
+	"github.com/nugget/thane-ai-agent/internal/platform/logging"
+	"github.com/nugget/thane-ai-agent/internal/platform/memguard"
+	"github.com/nugget/thane-ai-agent/internal/platform/provenance"
+	looppkg "github.com/nugget/thane-ai-agent/internal/runtime/loop"
+	"github.com/nugget/thane-ai-agent/internal/state/loopqueue"
+)
+
+func rowByName(t *testing.T, snap HealthSnapshot, name string) HealthRow {
+	t.Helper()
+	for _, row := range snap.Annunciator {
+		if row.Name == name {
+			return row
+		}
+	}
+	t.Fatalf("no annunciator row named %q in %+v", name, snap.Annunciator)
+	return HealthRow{}
+}
+
+func TestInspectorHealthAssemblesAnnunciator(t *testing.T) {
+	now := time.Date(2026, 8, 11, 12, 0, 0, 0, time.UTC)
+	insp := NewInspector(HealthSources{
+		ConnStatus: func() map[string]connwatch.ServiceStatus {
+			return map[string]connwatch.ServiceStatus{
+				"homeassistant": {Name: "homeassistant", Ready: true, LastCheck: now.Add(-30 * time.Second)},
+				"signal":        {Name: "signal", Ready: false, LastCheck: now.Add(-time.Minute), LastError: "connection refused"},
+			}
+		},
+		MemGuard: func() (memguard.Reading, bool) {
+			return memguard.Reading{CurrentMB: 412, SoftMB: 1536, HardMB: 3072}, true
+		},
+		BusDropped: func() uint64 { return 0 },
+		IndexStats: func() logging.IndexStats { return logging.IndexStats{} },
+		SyncStates: func() []checkout.SyncState {
+			return []checkout.SyncState{
+				{Name: "core", OK: true, Outcome: provenance.SyncClean, LastSyncAt: now.Add(-5 * time.Minute)},
+				{Name: "self", OK: true, Outcome: provenance.SyncDiverged, Detail: "local and remote both moved", LastSyncAt: now.Add(-5 * time.Minute)},
+			}
+		},
+		QueueStats: func(context.Context) ([]loopqueue.ConsumerPending, error) {
+			return []loopqueue.ConsumerPending{
+				{Consumer: "archivist", Pending: 3, OldestEnqueuedAt: now.Add(-10 * time.Minute)},
+				{Consumer: "core", Pending: 1, OldestEnqueuedAt: now.Add(-3 * time.Hour)},
+			}, nil
+		},
+		LoopStatuses: func() []looppkg.Status {
+			return []looppkg.Status{
+				{Name: "core", State: looppkg.State("processing")},
+				{Name: "archivist", State: looppkg.State("sleeping"), ConsecutiveErrors: 2, LastError: "boom"},
+			}
+		},
+		StartedAt: now.Add(-48 * time.Hour),
+	})
+	insp.now = func() time.Time { return now }
+
+	snap := insp.Health(context.Background())
+
+	// Connections: one lamp each, failure carries the error and check age.
+	if row := rowByName(t, snap, "conn:homeassistant"); row.Status != HealthOK || row.LastCheck != "-30s" {
+		t.Errorf("homeassistant row = %+v, want ok checked -30s", row)
+	}
+	if row := rowByName(t, snap, "conn:signal"); row.Status != HealthFailed || row.Detail != "connection refused" {
+		t.Errorf("signal row = %+v, want failed with the probe error", row)
+	}
+
+	// Memory guard under soft limit reads ok with the precomputed sentence.
+	if row := rowByName(t, snap, "memory_guard"); row.Status != HealthOK || !strings.Contains(row.Detail, "412MB in use of 1536MB soft") {
+		t.Errorf("memory_guard row = %+v", row)
+	}
+
+	// Doc sync: clean is ok; diverged degrades with outcome + detail.
+	if row := rowByName(t, snap, "doc_sync:core"); row.Status != HealthOK {
+		t.Errorf("core sync row = %+v, want ok", row)
+	}
+	if row := rowByName(t, snap, "doc_sync:self"); row.Status != HealthDegraded || !strings.Contains(row.Detail, "diverged") {
+		t.Errorf("self sync row = %+v, want degraded diverged", row)
+	}
+
+	// Queue backlog: the 3h-old core item exceeds the 1h threshold.
+	if row := rowByName(t, snap, "queue_backlog"); row.Status != HealthDegraded || !strings.Contains(row.Detail, "core") {
+		t.Errorf("queue_backlog row = %+v, want degraded naming core", row)
+	}
+	if len(snap.Queues) != 2 || snap.Queues[0].Consumer != "archivist" || snap.Queues[0].Pending != 3 {
+		t.Errorf("queues = %+v", snap.Queues)
+	}
+
+	// Loop census: archivist's consecutive errors degrade the fleet lamp.
+	if row := rowByName(t, snap, "loops"); row.Status != HealthDegraded || !strings.Contains(row.Detail, "archivist") {
+		t.Errorf("loops row = %+v, want degraded naming archivist", row)
+	}
+	if snap.Loops.Total != 2 || snap.Loops.Degraded != 1 || snap.Loops.ByState["processing"] != 1 {
+		t.Errorf("census = %+v", snap.Loops)
+	}
+
+	// Host: uptime delta present, goroutines counted.
+	if snap.Host.UptimeDelta == "" || snap.Host.Goroutines <= 0 {
+		t.Errorf("host = %+v", snap.Host)
+	}
+
+	// Degraded() gathers exactly the not-ok rows.
+	degraded := snap.Degraded()
+	names := make([]string, 0, len(degraded))
+	for _, row := range degraded {
+		names = append(names, row.Name)
+	}
+	want := []string{"conn:signal", "doc_sync:self", "queue_backlog", "loops"}
+	if len(degraded) != len(want) {
+		t.Errorf("degraded rows = %v, want %v", names, want)
+	}
+}
+
+func TestInspectorHealthDegradedStates(t *testing.T) {
+	now := time.Date(2026, 8, 11, 12, 0, 0, 0, time.UTC)
+
+	t.Run("memory guard past soft limit degrades, tripped fails", func(t *testing.T) {
+		reading := memguard.Reading{CurrentMB: 1700, SoftMB: 1536, HardMB: 3072}
+		insp := NewInspector(HealthSources{MemGuard: func() (memguard.Reading, bool) { return reading, true }})
+		insp.now = func() time.Time { return now }
+		if row := rowByName(t, insp.Health(context.Background()), "memory_guard"); row.Status != HealthDegraded {
+			t.Errorf("past-soft row = %+v, want degraded", row)
+		}
+		reading.Tripped = true
+		if row := rowByName(t, insp.Health(context.Background()), "memory_guard"); row.Status != HealthFailed {
+			t.Errorf("tripped row = %+v, want failed", row)
+		}
+	})
+
+	t.Run("disabled guard is ok with a disabled detail", func(t *testing.T) {
+		insp := NewInspector(HealthSources{MemGuard: func() (memguard.Reading, bool) { return memguard.Reading{}, false }})
+		if row := rowByName(t, insp.Health(context.Background()), "memory_guard"); row.Status != HealthOK || row.Detail != "disabled by config" {
+			t.Errorf("disabled row = %+v", row)
+		}
+	})
+
+	t.Run("bus drops and index loss degrade their rows", func(t *testing.T) {
+		insp := NewInspector(HealthSources{
+			BusDropped: func() uint64 { return 7 },
+			IndexStats: func() logging.IndexStats { return logging.IndexStats{WriteErrors: 2} },
+		})
+		snap := insp.Health(context.Background())
+		if row := rowByName(t, snap, "event_bus"); row.Status != HealthDegraded || !strings.Contains(row.Detail, "7") {
+			t.Errorf("event_bus row = %+v", row)
+		}
+		if row := rowByName(t, snap, "log_index"); row.Status != HealthDegraded || !strings.Contains(row.Detail, "2 write errors") {
+			t.Errorf("log_index row = %+v", row)
+		}
+	})
+
+	t.Run("a failed queue probe is itself a health finding", func(t *testing.T) {
+		insp := NewInspector(HealthSources{
+			QueueStats: func(context.Context) ([]loopqueue.ConsumerPending, error) {
+				return nil, context.DeadlineExceeded
+			},
+		})
+		if row := rowByName(t, insp.Health(context.Background()), "queue_backlog"); row.Status != HealthDegraded || !strings.Contains(row.Detail, "probe failed") {
+			t.Errorf("probe-failure row = %+v", row)
+		}
+	})
+
+	t.Run("unwired sources contribute no rows", func(t *testing.T) {
+		snap := NewInspector(HealthSources{}).Health(context.Background())
+		if len(snap.Annunciator) != 0 {
+			t.Errorf("empty sources produced rows: %+v", snap.Annunciator)
+		}
+	})
+}

--- a/internal/state/introspection/host.go
+++ b/internal/state/introspection/host.go
@@ -1,6 +1,7 @@
 package introspection
 
 import (
+	"math"
 	"runtime"
 	"time"
 
@@ -10,7 +11,9 @@ import (
 // collectHostInfo assembles the stdlib-only host snapshot. Disk numbers
 // come from the platform probe in disk_unix.go and are omitted (zero)
 // when the probe is unsupported or fails — absence, not a fake zero
-// disk.
+// disk. The percentage math runs in float64 and both outputs are
+// clamped, so an oversized or inconsistent probe result (free > total,
+// counts past int64) degrades to a sane value instead of wrapping.
 func collectHostInfo(dataDir string, startedAt, now time.Time) HostInfo {
 	info := HostInfo{
 		Goroutines: runtime.NumGoroutine(),
@@ -21,8 +24,16 @@ func collectHostInfo(dataDir string, startedAt, now time.Time) HostInfo {
 	}
 	if dataDir != "" {
 		if free, total, err := diskFree(dataDir); err == nil && total > 0 {
-			info.DiskFreeBytes = int64(free)
-			info.DiskUsedPct = int((total - free) * 100 / total)
+			if free > total {
+				free = total
+			}
+			if free > math.MaxInt64 {
+				info.DiskFreeBytes = math.MaxInt64
+			} else {
+				info.DiskFreeBytes = int64(free)
+			}
+			pct := int(float64(total-free) / float64(total) * 100)
+			info.DiskUsedPct = min(max(pct, 0), 100)
 		}
 	}
 	return info

--- a/internal/state/introspection/host.go
+++ b/internal/state/introspection/host.go
@@ -1,0 +1,29 @@
+package introspection
+
+import (
+	"runtime"
+	"time"
+
+	"github.com/nugget/thane-ai-agent/internal/model/promptfmt"
+)
+
+// collectHostInfo assembles the stdlib-only host snapshot. Disk numbers
+// come from the platform probe in disk_unix.go and are omitted (zero)
+// when the probe is unsupported or fails — absence, not a fake zero
+// disk.
+func collectHostInfo(dataDir string, startedAt, now time.Time) HostInfo {
+	info := HostInfo{
+		Goroutines: runtime.NumGoroutine(),
+		GOMAXPROCS: runtime.GOMAXPROCS(0),
+	}
+	if !startedAt.IsZero() {
+		info.UptimeDelta = promptfmt.FormatDeltaOnly(startedAt, now)
+	}
+	if dataDir != "" {
+		if free, total, err := diskFree(dataDir); err == nil && total > 0 {
+			info.DiskFreeBytes = int64(free)
+			info.DiskUsedPct = int((total - free) * 100 / total)
+		}
+	}
+	return info
+}


### PR DESCRIPTION
Fourth PR of the metacog pivot arc (#1341), stacked on #1344. This is the annunciator panel's assembler — the single source of truth both the `system_health` tool (next PR) and the metacog context panel (capstone PR) will render from, so a tool result and a context block can never tell different stories about the same subsystem.

`Inspector.Health(ctx)` produces one `HealthSnapshot` from the signals exploration found computed-but-unrouted. Each connwatch-watched service gets a lamp (ready → ok; otherwise failed with the probe's own error and a last-check delta). The memory guard reads ok below its soft limit, degraded past it, failed once the hard limit has tripped — and reports "disabled by config" as an ok row when unwired, because an off guard is a choice, not an incident. The event bus's cumulative drop count and the log index's loss counters degrade their rows when nonzero (observability loss is a finding about observability). Document-root sync states map their outcomes: clean/fast-forwarded/pushed are healthy, diverged/blocked/remote_behind degrade with the outcome and detail, an errored pass fails. The work-queue row degrades when any partition's oldest pending item has aged past an hour — the "consumer is not keeping up" signal — and the snapshot carries per-partition depths alongside. The loop census rolls the registry into totals by state plus degraded loops by name (capped, with an explicit truncation marker), using `loop_status`'s own degraded definition. Design rule throughout: every source is optional and nil-safe, all status logic lives in Go with a precomputed detail sentence per row, and a probe that errors becomes a degraded row carrying the error text — the probe breaking is itself a health finding, never a tool failure.

Host stats are stdlib-only per house preference: goroutines, GOMAXPROCS, uptime delta, and disk free/used from a build-tagged `syscall.Statfs` whose `uint64` conversions absorb the darwin/linux `Bsize` type difference.

`documents.Store.Activity` is the runaway-document detector the ego.md incidents have been waiting for: per-root revision churn over a window. It pre-filters candidates on the index's file mtime so quiet documents cost no git subprocess, counts in-window revisions from one history page, and computes net line math with a single spanning diff per document — from the revision in force at window start to HEAD, falling back to the oldest in-window revision for documents born inside the window (a known, bounded undercount). Authorship comes from the commit trailers; a revision with no authorship block reports as `manual`, which is itself informative. Documents at or past the revision threshold flag with a precomputed reason, and flagged documents sort first so the report cap can never hide a runaway. Errors teach: an unknown root names the known roots, a revision-less root names the roots that qualify.

Wiring: `initInspector` builds `HealthSources` over live App state with its own telemetry collector — the existing one is constructed only inside the MQTT-telemetry block, and health must not depend on MQTT — with the dbPaths map hoisted into a shared `telemetryDBPaths` helper both consumers use. The memguard field from #1344 becomes an `atomic.Pointer` since `Serve` stores it after `New` while tool goroutines will read it.

## Test plan

- [x] Annunciator assembly across all seven source families, with per-row status/detail assertions
- [x] Degradation ladder: memguard soft/tripped/disabled, bus drops, index loss, stale queue backlog, degraded loop census
- [x] Failed queue probe becomes a degraded row, not an error
- [x] Unwired sources contribute no rows
- [x] Activity: churn/flag/author aggregation, spanning-diff base selection (pre-window revision; born-in-window fallback), flagged-first truncation, teaching errors
- [x] `just ci` green

Refs #1341

🤖 Generated with [Claude Code](https://claude.com/claude-code)
