### PR TITLE
feat(metacognitive)!: re-scope metacog to thane's internal operations

### DIFF
--- a/docs/understanding/tag-system.md
+++ b/docs/understanding/tag-system.md
@@ -130,7 +130,7 @@ its tag is not active.
 | `req.AllowedTools` | allowlist | request | If non-empty, only these tools survive. |
 | `req.RuntimeTools` | layer | request | Adds request-scoped tools, all marked `Core`. |
 | `req.ExcludeTools` | blocklist | request | Removes named tools from the catalog. |
-| `req.SkipTagFilter` | bypass | request | Disables the tag-based filter entirely (used by metacognitive). |
+| `req.SkipTagFilter` | bypass | request | Disables the tag-based filter entirely (set by the delegate executor; also implied for any loop that declares no tags). |
 | Tag filter | filter | scope | `FilterByTags(scope.Snapshot())` per iteration. |
 | `Tool.Core` | preservation | tool definition | Survives the tag filter. |
 | `delegateFamilyToolNames` | blocklist | delegate executor | Hard-coded recursion guard. Applied at *both* layers (see below). |

--- a/internal/app/new_awareness.go
+++ b/internal/app/new_awareness.go
@@ -14,6 +14,7 @@ import (
 	looppkg "github.com/nugget/thane-ai-agent/internal/runtime/loop"
 	"github.com/nugget/thane-ai-agent/internal/state/awareness"
 	"github.com/nugget/thane-ai-agent/internal/state/contacts"
+	"github.com/nugget/thane-ai-agent/internal/state/introspection"
 	"github.com/nugget/thane-ai-agent/internal/state/knowledge"
 	"github.com/nugget/thane-ai-agent/internal/state/memory"
 	"github.com/nugget/thane-ai-agent/internal/tools"
@@ -85,6 +86,17 @@ func (a *App) initAwareness(s *newState) error {
 		logger,
 	)
 	a.loop.RegisterTagContextProvider("message_channel", messageChannelProvider)
+
+	// --- Internal operations panel ---
+	// The metacognitive loop's ambient perception (#1341): the same
+	// HealthSnapshot the system_health tool renders, injected every
+	// iteration whose active tags carry "metacognitive" — in practice
+	// the metacog loop itself, whose spec declares that tag. Perception
+	// costs it no tool calls; the diagnostics tools are the drill-down.
+	if a.inspector != nil {
+		a.loop.RegisterTagContextProvider("metacognitive",
+			introspection.NewPanelProvider(a.inspector, introspection.NewDocFlags(a.documentStore), logger))
+	}
 
 	// --- Entity watchlist ---
 	// Allows the agent to dynamically add HA entities to a watched list

--- a/internal/state/introspection/health.go
+++ b/internal/state/introspection/health.go
@@ -51,18 +51,32 @@ type HostInfo struct {
 	DiskUsedPct   int    `json:"disk_used_pct,omitempty"`
 }
 
-// LoopCensus is the fleet rollup: totals by state plus the degraded
-// loops by name, capped with an explicit remainder.
+// LoopCensus is the fleet rollup: totals by state, the degraded loops
+// by name (capped with an explicit remainder), and the busiest wakers —
+// the first place a wake storm shows.
 type LoopCensus struct {
 	Total             int            `json:"total"`
 	ByState           map[string]int `json:"by_state,omitempty"`
 	Degraded          int            `json:"degraded"`
 	DegradedLoops     []string       `json:"degraded_loops,omitempty"`
 	DegradedTruncated bool           `json:"degraded_truncated,omitempty"`
+	// TopWakers ranks loops by trailing-day iteration starts, busiest
+	// first. An outlier here against its usual rate is the wake-storm
+	// signal; loop_activity decomposes the why.
+	TopWakers []LoopWakeRate `json:"top_wakers,omitempty"`
+}
+
+// LoopWakeRate is one loop's achieved trailing-day cadence.
+type LoopWakeRate struct {
+	Name         string `json:"name"`
+	WakesLast24h int    `json:"wakes_last_24h"`
 }
 
 // maxCensusDegradedNames caps the degraded-loop name list on the census.
 const maxCensusDegradedNames = 10
+
+// maxCensusTopWakers caps the busiest-waker ranking.
+const maxCensusTopWakers = 5
 
 // QueueDepth is one work-queue partition's live backlog.
 type QueueDepth struct {
@@ -326,6 +340,18 @@ func buildLoopCensus(statuses []looppkg.Status) LoopCensus {
 				census.DegradedTruncated = true
 			}
 		}
+		if st.WakesLast24h > 0 {
+			census.TopWakers = append(census.TopWakers, LoopWakeRate{Name: st.Name, WakesLast24h: st.WakesLast24h})
+		}
+	}
+	sort.SliceStable(census.TopWakers, func(i, j int) bool {
+		if census.TopWakers[i].WakesLast24h != census.TopWakers[j].WakesLast24h {
+			return census.TopWakers[i].WakesLast24h > census.TopWakers[j].WakesLast24h
+		}
+		return census.TopWakers[i].Name < census.TopWakers[j].Name
+	})
+	if len(census.TopWakers) > maxCensusTopWakers {
+		census.TopWakers = census.TopWakers[:maxCensusTopWakers]
 	}
 	return census
 }

--- a/internal/state/introspection/health_test.go
+++ b/internal/state/introspection/health_test.go
@@ -173,3 +173,41 @@ func TestInspectorHealthDegradedStates(t *testing.T) {
 		}
 	})
 }
+
+// TestLoopCensusTopWakersOrderAndCap pins the busiest-waker ranking:
+// descending by trailing-day wakes with a stable name tiebreak, zero
+// wakers omitted, and the list truncated at the cap.
+func TestLoopCensusTopWakersOrderAndCap(t *testing.T) {
+	statuses := []looppkg.Status{
+		{Name: "quiet", WakesLast24h: 0},
+		{Name: "beta", WakesLast24h: 12},
+		{Name: "alpha", WakesLast24h: 12},
+		{Name: "storm", WakesLast24h: 96},
+		{Name: "steady", WakesLast24h: 4},
+		{Name: "ticker", WakesLast24h: 7},
+		{Name: "pinger", WakesLast24h: 6},
+		{Name: "extra", WakesLast24h: 1},
+	}
+	census := buildLoopCensus(statuses)
+
+	if len(census.TopWakers) != maxCensusTopWakers {
+		t.Fatalf("top wakers = %d entries, want the cap %d", len(census.TopWakers), maxCensusTopWakers)
+	}
+	wantOrder := []LoopWakeRate{
+		{Name: "storm", WakesLast24h: 96},
+		{Name: "alpha", WakesLast24h: 12},
+		{Name: "beta", WakesLast24h: 12},
+		{Name: "ticker", WakesLast24h: 7},
+		{Name: "pinger", WakesLast24h: 6},
+	}
+	for i, want := range wantOrder {
+		if census.TopWakers[i] != want {
+			t.Errorf("top_wakers[%d] = %+v, want %+v", i, census.TopWakers[i], want)
+		}
+	}
+	for _, w := range census.TopWakers {
+		if w.Name == "quiet" {
+			t.Errorf("zero-wake loop must not appear in top wakers")
+		}
+	}
+}

--- a/internal/state/introspection/panel.go
+++ b/internal/state/introspection/panel.go
@@ -1,0 +1,156 @@
+package introspection
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/nugget/thane-ai-agent/internal/runtime/agentctx"
+	"github.com/nugget/thane-ai-agent/internal/state/documents"
+)
+
+// DocFlagsFunc reports the currently flagged (runaway) documents across
+// the revision-backed roots. The panel renders flags only — the full
+// churn report stays behind the doc_activity tool.
+type DocFlagsFunc func(ctx context.Context) ([]documents.DocumentActivity, error)
+
+// NewDocFlags builds the panel's flagged-document probe over the
+// document store: a trailing-day Activity sweep of every
+// revision-backed root, keeping only flagged rows. The store's
+// mtime pre-filter keeps quiet roots free of git subprocesses.
+func NewDocFlags(store *documents.Store) DocFlagsFunc {
+	if store == nil {
+		return nil
+	}
+	return func(ctx context.Context) ([]documents.DocumentActivity, error) {
+		var flagged []documents.DocumentActivity
+		for _, root := range store.RevisionBackedRoots() {
+			report, err := store.Activity(ctx, documents.ActivityQuery{
+				Root:  root,
+				Since: time.Now().Add(-24 * time.Hour),
+			})
+			if err != nil {
+				return nil, fmt.Errorf("root %s: %w", root, err)
+			}
+			for _, doc := range report.Documents {
+				if doc.Flagged {
+					flagged = append(flagged, doc)
+				}
+			}
+		}
+		return flagged, nil
+	}
+}
+
+// maxPanelDocFlags caps the flagged-document list on the panel.
+const maxPanelDocFlags = 5
+
+// panelSoftMaxBytes is the point past which the panel drops its
+// healthy annunciator rows and keeps only the not-ok ones, marked
+// explicitly. Well under the 64KB context-bucket cap — the panel is
+// ambient perception, not a report.
+const panelSoftMaxBytes = 8 * 1024
+
+// PanelProvider injects the internal-operations panel into every
+// iteration whose active tags include the one it is registered under
+// (the metacognitive loop's own tag). It renders from the same
+// Inspector the system_health tool uses, so the panel and the tool can
+// never disagree; the tools are the drill-down, the panel is the
+// ambient perception that makes each fresh iteration start informed.
+type PanelProvider struct {
+	inspector *Inspector
+	docFlags  DocFlagsFunc
+	logger    *slog.Logger
+}
+
+// NewPanelProvider builds the panel provider. docFlags may be nil when
+// no revision-backed roots exist.
+func NewPanelProvider(inspector *Inspector, docFlags DocFlagsFunc, logger *slog.Logger) *PanelProvider {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &PanelProvider{inspector: inspector, docFlags: docFlags, logger: logger}
+}
+
+// TagContextBucket places the panel under live state — it is the
+// current condition of the runtime, re-read every iteration.
+func (p *PanelProvider) TagContextBucket() agentctx.ContextBucket {
+	return agentctx.ContextBucketLiveState
+}
+
+// TagContext renders the panel. It never errors the turn: a failed
+// probe becomes a field in the payload, because a broken probe is
+// exactly the kind of fact this panel exists to surface.
+func (p *PanelProvider) TagContext(ctx context.Context, _ agentctx.ContextRequest) (string, error) {
+	if p == nil || p.inspector == nil {
+		return "", nil
+	}
+	snap := p.inspector.Health(ctx)
+
+	payload := map[string]any{
+		"annunciator": snap.Annunciator,
+		"host":        snap.Host,
+		"loops":       snap.Loops,
+		"telemetry":   snap.Telemetry,
+	}
+	if len(snap.Queues) > 0 {
+		payload["queues"] = snap.Queues
+	}
+	degraded := snap.Degraded()
+	if len(degraded) == 0 {
+		payload["summary"] = fmt.Sprintf("all %d annunciator rows ok", len(snap.Annunciator))
+	} else {
+		names := make([]string, 0, len(degraded))
+		for _, row := range degraded {
+			names = append(names, row.Name)
+		}
+		payload["summary"] = fmt.Sprintf("%d of %d annunciator rows not ok: %s", len(degraded), len(snap.Annunciator), strings.Join(names, ", "))
+	}
+
+	if p.docFlags != nil {
+		flags, err := p.docFlags(ctx)
+		switch {
+		case err != nil:
+			payload["flagged_documents_error"] = err.Error()
+		case len(flags) > maxPanelDocFlags:
+			payload["flagged_documents"] = flags[:maxPanelDocFlags]
+			payload["flagged_documents_truncated"] = len(flags)
+		case len(flags) > 0:
+			payload["flagged_documents"] = flags
+		}
+	}
+
+	body, err := renderPanel(payload)
+	if err != nil {
+		p.logger.Warn("internal operations panel render failed", "error", err)
+		return "", nil
+	}
+	if len(body) > panelSoftMaxBytes {
+		// Keep the lamps that matter: not-ok rows only, marked so the
+		// model knows healthy rows were elided, never silently dropped.
+		payload["annunciator"] = degraded
+		payload["annunciator_truncated"] = "healthy rows elided for size; system_health returns the full panel"
+		if body, err = renderPanel(payload); err != nil {
+			p.logger.Warn("internal operations panel render failed", "error", err)
+			return "", nil
+		}
+	}
+	return body, nil
+}
+
+func renderPanel(payload map[string]any) (string, error) {
+	blob, err := json.Marshal(payload)
+	if err != nil {
+		return "", err
+	}
+	var b strings.Builder
+	b.WriteString("### Internal Operations Panel\n\n")
+	b.WriteString("Live health of your own runtime, refreshed this iteration. This is perception, not conclusion: judge what you see against your recorded baselines, and drill in with system_health, loop_status, loop_activity, queue_status, doc_activity, logs_query, or cost_summary before escalating.\n\n")
+	b.WriteString("```json\n")
+	b.Write(blob)
+	b.WriteString("\n```")
+	return b.String(), nil
+}

--- a/internal/state/introspection/panel.go
+++ b/internal/state/introspection/panel.go
@@ -48,6 +48,10 @@ func NewDocFlags(store *documents.Store) DocFlagsFunc {
 // maxPanelDocFlags caps the flagged-document list on the panel.
 const maxPanelDocFlags = 5
 
+// maxSummaryDegradedNames caps how many degraded rows the summary line
+// names before folding the rest into a "+N more" marker.
+const maxSummaryDegradedNames = 8
+
 // panelSoftMaxBytes is the point past which the panel drops its
 // healthy annunciator rows and keeps only the not-ok ones, marked
 // explicitly. Well under the 64KB context-bucket cap — the panel is
@@ -103,11 +107,19 @@ func (p *PanelProvider) TagContext(ctx context.Context, _ agentctx.ContextReques
 	if len(degraded) == 0 {
 		payload["summary"] = fmt.Sprintf("all %d annunciator rows ok", len(snap.Annunciator))
 	} else {
-		names := make([]string, 0, len(degraded))
-		for _, row := range degraded {
+		// The summary is a headline, not the list: cap the named rows so
+		// a mass outage cannot balloon the panel past its soft cap (and
+		// past the context bucket's own truncator, which would cut the
+		// fenced JSON mid-payload).
+		names := make([]string, 0, min(len(degraded), maxSummaryDegradedNames))
+		for _, row := range degraded[:min(len(degraded), maxSummaryDegradedNames)] {
 			names = append(names, row.Name)
 		}
-		payload["summary"] = fmt.Sprintf("%d of %d annunciator rows not ok: %s", len(degraded), len(snap.Annunciator), strings.Join(names, ", "))
+		summary := fmt.Sprintf("%d of %d annunciator rows not ok: %s", len(degraded), len(snap.Annunciator), strings.Join(names, ", "))
+		if extra := len(degraded) - len(names); extra > 0 {
+			summary += fmt.Sprintf(" (+%d more)", extra)
+		}
+		payload["summary"] = summary
 	}
 
 	if p.docFlags != nil {

--- a/internal/state/introspection/panel_test.go
+++ b/internal/state/introspection/panel_test.go
@@ -1,0 +1,111 @@
+package introspection
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nugget/thane-ai-agent/internal/connwatch"
+	"github.com/nugget/thane-ai-agent/internal/runtime/agentctx"
+	"github.com/nugget/thane-ai-agent/internal/state/documents"
+)
+
+func panelJSON(t *testing.T, body string) map[string]any {
+	t.Helper()
+	start := strings.Index(body, "```json\n")
+	end := strings.LastIndex(body, "\n```")
+	if start < 0 || end < 0 {
+		t.Fatalf("panel body carries no fenced JSON:\n%s", body)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(body[start+len("```json\n"):end]), &payload); err != nil {
+		t.Fatalf("panel JSON does not parse: %v", err)
+	}
+	return payload
+}
+
+func TestPanelRendersPerceptionWithSummary(t *testing.T) {
+	insp := NewInspector(HealthSources{
+		ConnStatus: func() map[string]connwatch.ServiceStatus {
+			return map[string]connwatch.ServiceStatus{
+				"signal": {Name: "signal", Ready: false, LastError: "connection refused", LastCheck: time.Now()},
+			}
+		},
+	})
+	flagged := []documents.DocumentActivity{{Ref: "self:ego.md", Revisions: 14, Flagged: true, FlagReason: "14 revisions in the window meets the runaway threshold 8"}}
+	p := NewPanelProvider(insp, func(context.Context) ([]documents.DocumentActivity, error) { return flagged, nil }, nil)
+
+	if p.TagContextBucket() != agentctx.ContextBucketLiveState {
+		t.Errorf("bucket = %v, want live state", p.TagContextBucket())
+	}
+	body, err := p.TagContext(context.Background(), agentctx.ContextRequest{})
+	if err != nil {
+		t.Fatalf("TagContext: %v", err)
+	}
+	if !strings.HasPrefix(body, "### Internal Operations Panel") {
+		t.Errorf("panel missing its heading:\n%s", body)
+	}
+	payload := panelJSON(t, body)
+	summary, _ := payload["summary"].(string)
+	if !strings.Contains(summary, "conn:signal") {
+		t.Errorf("summary = %q, want the failed connection named", summary)
+	}
+	docs, _ := payload["flagged_documents"].([]any)
+	if len(docs) != 1 {
+		t.Errorf("flagged_documents = %v, want the runaway ego row", payload["flagged_documents"])
+	}
+}
+
+// TestPanelProbeFailureIsAFieldNotAnError pins the doctrine: a broken
+// probe is a finding the panel surfaces, never a failed turn.
+func TestPanelProbeFailureIsAFieldNotAnError(t *testing.T) {
+	p := NewPanelProvider(NewInspector(HealthSources{}),
+		func(context.Context) ([]documents.DocumentActivity, error) { return nil, errors.New("git exploded") }, nil)
+	body, err := p.TagContext(context.Background(), agentctx.ContextRequest{})
+	if err != nil {
+		t.Fatalf("TagContext must not error: %v", err)
+	}
+	payload := panelJSON(t, body)
+	if msg, _ := payload["flagged_documents_error"].(string); !strings.Contains(msg, "git exploded") {
+		t.Errorf("probe failure not surfaced: %v", payload)
+	}
+}
+
+// TestPanelElidesHealthyRowsWhenOversized: past the soft cap the panel
+// keeps only the not-ok lamps, with an explicit marker pointing at
+// system_health for the full set.
+func TestPanelElidesHealthyRowsWhenOversized(t *testing.T) {
+	many := make(map[string]connwatch.ServiceStatus, 400)
+	for i := range 400 {
+		name := fmt.Sprintf("svc-%03d-with-a-rather-long-descriptive-name", i)
+		many[name] = connwatch.ServiceStatus{Name: name, Ready: true, LastCheck: time.Now()}
+	}
+	many["broken"] = connwatch.ServiceStatus{Name: "broken", Ready: false, LastError: "down"}
+	p := NewPanelProvider(NewInspector(HealthSources{
+		ConnStatus: func() map[string]connwatch.ServiceStatus { return many },
+	}), nil, nil)
+
+	body, err := p.TagContext(context.Background(), agentctx.ContextRequest{})
+	if err != nil {
+		t.Fatalf("TagContext: %v", err)
+	}
+	payload := panelJSON(t, body)
+	if _, marked := payload["annunciator_truncated"]; !marked {
+		t.Fatalf("oversized panel not marked truncated (len=%d)", len(body))
+	}
+	rows, _ := payload["annunciator"].([]any)
+	if len(rows) != 1 {
+		t.Errorf("truncated annunciator = %d rows, want only the broken one", len(rows))
+	}
+}
+
+func TestPanelNilInspectorRendersNothing(t *testing.T) {
+	var p *PanelProvider
+	if body, err := p.TagContext(context.Background(), agentctx.ContextRequest{}); err != nil || body != "" {
+		t.Errorf("nil provider = (%q, %v), want empty and no error", body, err)
+	}
+}

--- a/loops/metacognitive.md
+++ b/loops/metacognitive.md
@@ -24,9 +24,10 @@ outputs:
       type: maintained_document
       ref: self:metacognitive.md
       mode: replace
-      purpose: 'Current metacognitive state: active concerns, recent observations, actions taken, and sleep reasoning that should persist across fresh loop iterations.'
+      purpose: 'Current metacognitive state: operational baselines (what normal looks like, per subsystem and loop), active concerns with evidence and severity, incidents observed and escalated, and sleep reasoning that should persist across fresh loop iterations.'
 tags:
     - metacognitive
+    - diagnostics
 exclude_tools:
     - file_read
     - file_write
@@ -63,68 +64,146 @@ metadata:
 
 Metacognitive loop iteration.
 
-You are running as a background metacognitive process — a perpetual
-attention loop that monitors the environment, reasons about what you
-observe, and adapts your own wake cycle.
+You are Thane thinking about Thane. Every other loop looks outward — at
+the household, at the people, at the feeds. You look inward: at the
+loops themselves, the queues that feed them, the documents they
+maintain, the models they spend, and the process that runs them all.
+Metacognition means judging whether the system's own thinking is
+healthy — not doing the thinking over again.
+
+## Your Perception
+
+The "Internal Operations Panel" block in your context is refreshed
+every iteration: the subsystem annunciator (each row ok, degraded, or
+failed, with the reason precomputed), the loop census with its busiest
+wakers, work-queue depths, flagged runaway documents, host vitals, and
+the day's request/error/latency rollup. Read it first. It costs you
+nothing and it is the same data the drill-down tools return, so
+anything alarming in the panel can be investigated without re-checking
+the panel itself.
+
+The drill-downs, when the panel or your concerns warrant them:
+
+- system_health — the full annunciator on demand, including rows the
+  panel elided for size.
+- loop_status — the process table now: every loop's canonical row,
+  cadence, economics, errors, mailbox depth.
+- loop_activity — the process table over time, from a journal that
+  survives restarts: what actually woke each loop (timer, mailbox,
+  subscription, manual) and who sent it, error and no-op counts,
+  wakes per hour. This is where a wake storm, a dead cadence, or a
+  loop being poked by something unexpected becomes visible.
+- queue_status — the work-queue audit: pending depth with oldest-item
+  age, completion throughput and wait latency per consumer. Stuck
+  archivist work shows here first.
+- doc_activity — revision churn across the managed roots, runaways
+  flagged: a maintained document rewriting itself too often (an ego.md
+  accumulating nonsense) surfaces here before anyone reads it.
+- logs_query, cost_summary — failure evidence and spend, when a
+  concern needs the receipts.
 
 ## Your Durable Output
 
-Your current durable output contract is injected in the "Declared Durable
-Outputs" block. It names the document you maintain and the generated tool
-that writes it.
+Your current durable output contract is injected in the "Declared
+Durable Outputs" block. It names the document you maintain and the
+generated tool that writes it. That document is your only memory
+between iterations, and its most valuable content is BASELINES: what
+normal looks like, recorded while things are normal. "ranch_climate_watch
+wakes about four times a day; ego.md turns over about twice a week;
+archivist backlog clears within the hour" — judgment about deviation is
+only possible when the ordinary rates are written down. Keep concerns
+with their evidence and severity, note incidents you escalated and what
+came of them, and prune what no longer matters.
+
+If the document still describes household activity, presence, or
+environmental observations, it predates this mandate: rebuild it this
+iteration around baselines and concerns, and let the environment-watching
+content go — purpose-built loops own that now.
 
 ## What To Do This Iteration
 
-1. **Assess** — Review your declared output content and the current context
-   (system prompt data: state changes, person presence, time of day).
-2. **Act if warranted** — Send messages or use any available tool if the
-   situation calls for it.
-3. **Update metacognitive.md** — Call replace_output_metacognitive_state
-   with your complete updated state (observations, active concerns, recent
-   actions, sleep reasoning). This generated output tool is the ONLY
-   sanctioned interface for writing your durable metacognitive state.
-4. **Set your sleep** — Close the turn with set_next_sleep and your
-   reasoning. The "This loop" block carries your permitted range, how
-   often you have actually been running lately, and how long you were
-   just out; read it rather than guessing at numbers. Sleep toward the
-   short end when something is actively in motion and you expect the
-   picture to have changed, toward the long end when the system is quiet
-   and another look would see the same thing.
+1. **Perceive** — Read the panel. Compare it against the baselines and
+   active concerns in your durable state.
+2. **Investigate** — Where the panel, a baseline deviation, or an open
+   concern warrants it, drill in with the diagnostics tools until you
+   understand what is actually happening. Not every iteration needs
+   this; a clean panel against stable baselines is a complete
+   observation.
+3. **Judge** — Distinguish noise from drift from incident. A loop
+   erroring once is noise; a loop whose wake rate tripled overnight is
+   drift worth a concern; a failed subsystem, a runaway document, or a
+   queue whose oldest work is hours stale is an incident.
+4. **Escalate when warranted** — request_core_attention is your one
+   voice, and it goes to core, which curates the service loops and can
+   act. Escalate with evidence: name the subsystem or loop, the
+   observed numbers against the baseline, and what you already ruled
+   out. You observe and judge; core decides and acts.
+5. **Record** — Call replace_output_metacognitive_state with your
+   complete updated state: refreshed baselines, concerns opened or
+   closed, incidents noted. This generated output tool is the ONLY
+   sanctioned interface for writing your durable state.
+6. **Set your sleep** — Close the turn with set_next_sleep and your
+   reasoning. The "This loop" block carries your permitted range and
+   your actual recent rhythm; read it rather than guessing. Sleep
+   short while an incident or fresh drift is in motion; sleep long
+   when the panel is clean and your baselines are steady.
+
+## What This Loop Is For
+
+- Baselines of the system's ordinary operation, kept current.
+- Detecting drift: wake storms, dead cadences, swelling queues,
+  runaway documents, climbing memory, error streaks, spend anomalies.
+- Auditing the machinery others rely on: is the archivist keeping up,
+  are the maintained documents being written sanely, is anything
+  waking anything else in a pattern nobody designed.
+- Escalating judged, evidenced concerns to core.
+
+## What This Loop Is NOT For
+
+- The household, the weather, presence, or anything a purpose-built
+  service loop watches. If you find yourself observing the
+  environment, you are doing another loop's job.
+- Fixing what you find. You have no actuators by design: no loop
+  mutation, no message sending, no file access. The separation is
+  deliberate — the observer that also operates stops noticing what
+  the operator breaks.
+- A duplicate of loop_status. Your durable state holds judgments and
+  baselines, not a copy of live numbers that are one tool call away.
 
 ## Guidelines
 
-- Your system prompt contains the same household context, ego.md, contacts,
-  and state data that the interactive agent sees. Use it.
-- Each iteration is a fresh conversation. The declared metacognitive output
-  is your ONLY memory between iterations.
-- The declared output context tells you how recently metacognitive.md was
-  updated. Do not copy raw sensor timestamps or generated metadata into the
-  durable body. Prefer observations and active concerns over timestamp
-  inventories; include a wall-clock time only when the time itself is the
-  point of the memory.
-- Don't over-act. Quiet observation is a valid outcome. Not every iteration
-  needs a message or action.
-- You have exactly two special tools: replace_output_metacognitive_state and
-  set_next_sleep. All other tools are from the standard agent toolkit
-  (contacts, facts, notifications). File tools, exec, and session management
-  tools are NOT available.
-- If nothing interesting is happening, note it and sleep long.
+- Each iteration is a fresh conversation. The declared metacognitive
+  output is your ONLY memory between iterations.
+- Do not copy the panel's live numbers into your durable state as if
+  they were memory. Record rates, ranges, and judgments — "normally
+  4-6/day" ages well; "wakes_last_24h: 5" is stale the moment it is
+  written.
+- Quiet observation is a valid outcome. Most iterations should end
+  with an updated document and a sleep, nothing more.
+- Your toolkit is the diagnostics family plus your output tool and
+  set_next_sleep. File tools, exec, session management, loop
+  creation, and direct human messaging are NOT available; your only
+  egress is request_core_attention.
 
 ## Supervisor Review
 
 This iteration was randomly selected for supervisor-level review using a
 frontier model. In addition to the normal assessment, critically evaluate:
 
-- **State file quality** — Are active concerns still valid or stale? Is
-  anything being tracked that no longer matters?
-- **Sleep patterns** — Has the loop been sleeping too long? Too short? Stuck
-  in a rut of identical durations?
-- **Blind spots** — What patterns, systems, or entities is the loop NOT
-  watching that it should be? What's happening that normal iterations miss?
-- **Attention calibration** — Is the loop focused on what actually matters, or
-  latched onto something unimportant?
-- **Drift detection** — Has the loop's behavior become routine or mechanical?
-  Is it still genuinely reasoning or just going through motions?
+- **Baseline quality** — Are the recorded baselines still accurate?
+  Stale baselines make every judgment wrong quietly. Is anything
+  tracked that no longer runs, or running that is not yet tracked?
+- **Missed incidents** — Walk the panel and the drill-downs with fresh
+  eyes: is there drift or damage the routine iterations have been
+  looking straight past?
+- **Alert fatigue in reverse** — Has escalation become too easy (core
+  being paged for noise) or too hard (real drift sitting in the
+  concerns list for days without escalation)?
+- **Sleep patterns** — Is the cadence proportionate to what is
+  actually in motion, or stuck in a rut of identical durations?
+- **Drift detection** — Has this loop's own behavior become routine or
+  mechanical? Is it still genuinely judging, or just re-recording the
+  same document with the numbers changed?
 
-Be honest. Use this supervisor pass to catch blind spots the cheaper model
-may miss consistently.
+Be honest. Use this supervisor pass to catch blind spots the cheaper
+model may miss consistently.

--- a/talents/diagnostics.md
+++ b/talents/diagnostics.md
@@ -44,7 +44,9 @@ wrote it — authorship comes from commit trailers, so a row authored
 threshold are flagged and sort first; a maintained document rewriting
 itself too often is how a runaway (an ego document accumulating
 nonsense) is caught before anyone reads it. For one document's story,
-switch to `doc_history` and `doc_diff`.
+switch to `doc_history` and `doc_diff` — those ride the `documents`
+tag, so activate it for per-document history (a loop that owns the
+document already carries the read family without any tag).
 
 `logs_query` and `cost_summary` carry the receipts: failure evidence
 scoped by loop, subsystem, or request, and spend grouped by model,

--- a/talents/diagnostics.md
+++ b/talents/diagnostics.md
@@ -1,0 +1,58 @@
+---
+kind: doctrine
+tags: [diagnostics]
+---
+
+# Diagnostics Doctrine
+
+These tools look inward — at Thane's own runtime, not the world. The
+craft is choosing the surface that collapses uncertainty fastest, and
+knowing whether your question is about *now* or about *history*.
+
+Start wide when anything feels off: `system_health` is one zero-argument
+call that returns a status row per subsystem — ok, degraded, or failed,
+each with the reason already written out — plus host vitals, queue
+depths, the loop census, and the day's request/error/latency rollup.
+Trust its summary line to tell you whether anything deserves a second
+call at all. A degraded row names the subsystem; the row's name is what
+the drill-down tools filter by.
+
+The loop fleet has two views, and confusing them wastes calls.
+`loop_status` is NOW: the process table, one canonical row per running
+loop — state, cadence, token economics, errors, mailbox depth.
+`loop_activity` is HISTORY, from a journal that survives restarts: every
+wake with its attributed cause — timer, mailbox, subscription, a manual
+`loop_wake`, an inter-loop notify — and who sent it, plus error and
+no-op counts and wakes per hour. "Is the archivist stuck right now" is
+`loop_status`; "who has been waking the archivist all night" is
+`loop_activity`. The aggregate leads its result: read wakes-per-hour and
+the by-source decomposition before scrolling events.
+
+`queue_status` audits the durable work queues globally and read-only:
+pending depth with oldest-item age per consumer, completion throughput
+and wait latency over a window. Old pending work means a consumer is
+not keeping up or not running — check `loop_status` for the consumer
+next. You cannot drain or ack from here; consumers own their own
+partitions. Completion counts measure consumer throughput: coalesced
+re-enqueues refresh a pending item in place and never appear as
+completions.
+
+`doc_activity` watches the managed document corpus for churn: per
+document in the window, revision count, net line delta, size, and who
+wrote it — authorship comes from commit trailers, so a row authored
+"manual" was not written by a loop. Documents past the revision
+threshold are flagged and sort first; a maintained document rewriting
+itself too often is how a runaway (an ego document accumulating
+nonsense) is caught before anyone reads it. For one document's story,
+switch to `doc_history` and `doc_diff`.
+
+`logs_query` and `cost_summary` carry the receipts: failure evidence
+scoped by loop, subsystem, or request, and spend grouped by model,
+provider, or task. Reach for them when a finding needs evidence, not as
+the first sweep — the annunciator and the two loop views almost always
+localize the problem faster.
+
+Everything here observes; nothing here fixes. When a finding needs an
+actor, the paths are `request_core_attention` from inside a service
+loop, or the `loops` tag's mutation tools when you are the one curating
+the fleet.

--- a/talents/operations-trailhead.md
+++ b/talents/operations-trailhead.md
@@ -19,8 +19,11 @@ Choose the next move deliberately:
   forces a supervisor turn on the next iteration of the owner loop;
   this is the canonical service-loop → operator attention path. No
   recipient, no actions, no waiting — file the concern and continue.
-- If you need logs, version, usage, or failure evidence, activate
-  `diagnostics`.
+- If the question is about Thane's own runtime — subsystem health, the
+  loop process table now or over time, wake attribution, work-queue
+  backlog, runaway documents, logs, usage, or version — activate
+  `diagnostics`. Its `system_health` is the one-call annunciator panel;
+  start there when you only know "something is off".
 - If the question is about model registry, routing, or policy, activate
   `models`.
 - If the work is about scheduled tasks or timing policy, activate


### PR DESCRIPTION
The capstone of the metacog pivot arc (#1341), stacked on #1347. Everything before this PR built perception substrate; this one performs the pivot: the mandate rewrite, the context panel that feeds it, and the teaching pass — shipped together, deliberately, so the prose never describes a panel that doesn't exist and the panel never appears under a mandate that doesn't mention it.

The rewritten [loops/metacognitive.md](../blob/feat/1341-metacog-mandate/loops/metacognitive.md) makes the loop what its name always promised. "You are Thane thinking about Thane" — every other loop looks outward; this one judges whether the system's own thinking is healthy. The iteration shape is perceive → investigate → judge → escalate → record → sleep: read the injected panel against recorded baselines, drill in with the diagnostics family only when warranted, distinguish noise from drift from incident, escalate to core with evidence through `request_core_attention` (core curates the service loops; metacog observes and judges, core decides and acts), and record baselines rather than live numbers — "normally 4-6/day" ages well, a copied counter is stale the moment it is written. The ego-pattern For/NOT-For sections fence the remit; the observe-only doctrine gets its reason stated plainly ("the observer that also operates stops noticing what the operator breaks"); the old prompt's two falsehoods — promised message-sending and a contacts/facts toolkit that tag filtering never actually granted — are gone; and the supervisor review now audits what matters for a watcher: baseline quality, missed incidents, escalation calibration in both directions, and whether the loop is still genuinely judging or just re-recording the document with the numbers changed. A first-iteration instruction handles the deploy seam: durable state still describing household activity predates the mandate and gets rebuilt around baselines and concerns.

The spec's tag line is the mechanical heart of the pivot: `tags: [metacognitive, diagnostics]`. The previously pure-label `metacognitive` tag now also keys the context panel, and `diagnostics` is what admits the #1346 tool family through tag filtering — before this PR the re-scoped tools existed but metacog could not see them. `PanelProvider` registers under the `metacognitive` tag and renders the Internal Operations Panel each iteration: annunciator rows, the loop census with top wakers, queue depths, flagged runaway documents, host vitals, and the telemetry rollup — the same `HealthSnapshot` the `system_health` tool returns, so panel and tool cannot disagree. It is compact JSON under a one-line framing note, soft-capped at 8KB by eliding healthy rows with an explicit marker, and a failed probe becomes a payload field rather than a failed turn, because a broken probe is exactly what this panel exists to surface.

Teaching per the model-facing-tools shipping order: a new `talents/diagnostics.md` doctrine teaches the decision frame (start wide with the one-call annunciator; `loop_status` is NOW while `loop_activity` is HISTORY and confusing them wastes calls; queue completion counts measure consumer throughput, not producer chatter; runaway documents flag before anyone reads them; everything observes, nothing fixes). The operations trailhead's diagnostics door — a stale door after #1346 — widens from "logs, version, usage" to the full introspection surface. And `docs/understanding/tag-system.md`'s claim that `SkipTagFilter` is "used by metacognitive" (false since the loop declared tags) is corrected to the delegate executor.

## Test plan

- [x] Doc gates green: boot spec == shipped document, embedded mirror regenerated (`just generate`)
- [x] Panel renders heading + fenced JSON with degraded-first summary and flagged documents
- [x] Probe failure surfaces as a payload field, never a turn error
- [x] Oversized panel elides healthy rows with an explicit marker; nil provider renders nothing
- [x] `TestRepoTalentToolReferences` gates the new talent's tool references
- [x] `just ci` green

Refs #1341

🤖 Generated with [Claude Code](https://claude.com/claude-code)
