### PR TITLE
feat(introspection): mechanical deploy detection for metacog

### DIFF
--- a/internal/app/new_introspection.go
+++ b/internal/app/new_introspection.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/nugget/thane-ai-agent/internal/platform/buildinfo"
 	"github.com/nugget/thane-ai-agent/internal/platform/memguard"
 	"github.com/nugget/thane-ai-agent/internal/platform/telemetry"
 	"github.com/nugget/thane-ai-agent/internal/state/introspection"
@@ -38,6 +39,11 @@ func (a *App) initIntrospectionJournal() {
 	}
 	recorder := introspection.NewRecorder(journal, a.eventBus, retention, a.logger)
 	a.deferWorker("loop-event-recorder", func(ctx context.Context) error {
+		// One boot row per process start, stamped with build identity —
+		// what makes deploy boundaries and restart storms computable.
+		if err := journal.RecordBoot(ctx, buildinfo.Version, buildinfo.GitCommit); err != nil {
+			a.logger.Warn("boot record failed", "error", err)
+		}
 		go recorder.Run(ctx)
 		return nil
 	})
@@ -83,9 +89,17 @@ func (a *App) initInspector() {
 	}
 
 	src := introspection.HealthSources{
-		Telemetry: telemetry.NewCollector(telSources),
-		DataDir:   a.cfg.DataDir,
-		StartedAt: time.Now(),
+		Telemetry:    telemetry.NewCollector(telSources),
+		DataDir:      a.cfg.DataDir,
+		StartedAt:    time.Now(),
+		BuildVersion: buildinfo.Version,
+		BuildCommit:  buildinfo.GitCommit,
+	}
+	if a.loopEventJournal != nil {
+		journal := a.loopEventJournal
+		src.BootHistory = func(ctx context.Context) ([]introspection.BootRecord, error) {
+			return journal.RecentBoots(ctx, 50)
+		}
 	}
 	if a.connMgr != nil {
 		src.ConnStatus = a.connMgr.Status

--- a/internal/state/introspection/health.go
+++ b/internal/state/introspection/health.go
@@ -114,10 +114,11 @@ type VersionInfo struct {
 	// "dev" when either side is not a semantic version.
 	Change       string `json:"change,omitempty"`
 	BootsLast24h int    `json:"boots_last_24h,omitempty"`
-	// RecentBoots is the raw tail of the boot journal, newest first:
-	// five boots minutes apart IS a crash loop, and a version change
-	// between adjacent rows IS a deploy — no threshold required to see
-	// either.
+	// RecentBoots is the raw tail of the boot journal, newest first.
+	// The tail is deliberately data rather than verdict: what a restart
+	// pattern means depends on context the reader has (deploy day,
+	// maintenance, a failing start), so the judgment stays with the
+	// consumer instead of a threshold here.
 	RecentBoots []BootView `json:"recent_boots,omitempty"`
 }
 
@@ -131,11 +132,6 @@ type BootView struct {
 
 // maxRecentBootViews caps the boot tail on the snapshot.
 const maxRecentBootViews = 5
-
-// bootStormThreshold is the boot count inside a day at which the
-// runtime lamp degrades (inclusive — the fifth boot trips it): a
-// healthy instance restarts for deploys, not for sport.
-const bootStormThreshold = 5
 
 // HealthSnapshot is the whole annunciator panel in one shape, consumed
 // identically by the system_health tool and the metacog context panel
@@ -355,17 +351,19 @@ func (i *Inspector) Health(ctx context.Context) HealthSnapshot {
 		snap.Annunciator = append(snap.Annunciator, row)
 	}
 
+	// The runtime row is informational rather than judged: restart
+	// counts have no objective threshold — a deploy day and a crash
+	// loop can hold the same number — so the row carries the facts and
+	// the version object carries the boot tail, leaving the verdict to
+	// the reader who has the context.
 	snap.Version = i.collectVersionInfo(ctx, now)
-	if snap.Version.BootsLast24h >= bootStormThreshold {
+	if i.src.BuildVersion != "" {
+		detail := fmt.Sprintf("running %s", snap.Version.Running)
+		if snap.Version.BootsLast24h > 1 {
+			detail += fmt.Sprintf("; %d boots in the last 24h", snap.Version.BootsLast24h)
+		}
 		snap.Annunciator = append(snap.Annunciator, HealthRow{
-			Name:   "runtime",
-			Status: HealthDegraded,
-			Detail: fmt.Sprintf("%d boots in the last 24h suggests a crash loop (running %s)", snap.Version.BootsLast24h, snap.Version.Running),
-		})
-	} else if i.src.BuildVersion != "" {
-		snap.Annunciator = append(snap.Annunciator, HealthRow{
-			Name: "runtime", Status: HealthOK,
-			Detail: fmt.Sprintf("running %s", snap.Version.Running),
+			Name: "runtime", Status: HealthOK, Detail: detail,
 		})
 	}
 

--- a/internal/state/introspection/health.go
+++ b/internal/state/introspection/health.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/nugget/thane-ai-agent/internal/connwatch"
@@ -95,11 +97,51 @@ type TelemetryRollup struct {
 	DBSizesBytes map[string]int64 `json:"db_sizes_bytes,omitempty"`
 }
 
+// VersionInfo is the precomputed deploy story: what is running, what
+// ran before it, when the boundary landed, and how big the jump was —
+// so no model ever bookkeeps a version to detect a release. BootsLast24h
+// rides along because restarts and deploys explain each other: boots
+// piling up WITHOUT a version change is a crash loop, not a deploy.
+type VersionInfo struct {
+	Running string `json:"running"`
+	Commit  string `json:"commit,omitempty"`
+	// Previous is the last different version in boot history, and
+	// ChangedDelta is when the boot that introduced Running happened.
+	// Both empty when boot history shows no boundary (or is absent).
+	Previous     string `json:"previous,omitempty"`
+	ChangedDelta string `json:"changed_delta,omitempty"`
+	// Change classifies the boundary: "patch", "minor", "major", or
+	// "dev" when either side is not a semantic version.
+	Change       string `json:"change,omitempty"`
+	BootsLast24h int    `json:"boots_last_24h,omitempty"`
+	// RecentBoots is the raw tail of the boot journal, newest first:
+	// five boots minutes apart IS a crash loop, and a version change
+	// between adjacent rows IS a deploy — no threshold required to see
+	// either.
+	RecentBoots []BootView `json:"recent_boots,omitempty"`
+}
+
+// BootView is one journaled process start, delta-formatted for the
+// model.
+type BootView struct {
+	AtDelta string `json:"at_delta"`
+	Version string `json:"version"`
+	Commit  string `json:"commit,omitempty"`
+}
+
+// maxRecentBootViews caps the boot tail on the snapshot.
+const maxRecentBootViews = 5
+
+// bootStormThreshold is how many boots inside a day degrade the runtime
+// lamp: a healthy instance restarts for deploys, not for sport.
+const bootStormThreshold = 5
+
 // HealthSnapshot is the whole annunciator panel in one shape, consumed
 // identically by the system_health tool and the metacog context panel
 // so the two can never drift.
 type HealthSnapshot struct {
 	Annunciator []HealthRow     `json:"annunciator"`
+	Version     VersionInfo     `json:"version"`
 	Host        HostInfo        `json:"host"`
 	Loops       LoopCensus      `json:"loops"`
 	Queues      []QueueDepth    `json:"queues,omitempty"`
@@ -141,6 +183,11 @@ type HealthSources struct {
 	LoopStatuses func() []looppkg.Status
 	// Telemetry collects the 24h operational rollup.
 	Telemetry *telemetry.Collector
+	// BuildVersion and BuildCommit identify the running binary.
+	BuildVersion string
+	BuildCommit  string
+	// BootHistory reads journaled process starts, newest first.
+	BootHistory func(ctx context.Context) ([]BootRecord, error)
 	// DataDir is the disk-probe target (thane's data directory).
 	DataDir string
 	// StartedAt is process start, for uptime.
@@ -307,6 +354,20 @@ func (i *Inspector) Health(ctx context.Context) HealthSnapshot {
 		snap.Annunciator = append(snap.Annunciator, row)
 	}
 
+	snap.Version = i.collectVersionInfo(ctx, now)
+	if snap.Version.BootsLast24h > bootStormThreshold {
+		snap.Annunciator = append(snap.Annunciator, HealthRow{
+			Name:   "runtime",
+			Status: HealthDegraded,
+			Detail: fmt.Sprintf("%d boots in the last 24h suggests a crash loop (running %s)", snap.Version.BootsLast24h, snap.Version.Running),
+		})
+	} else if i.src.BuildVersion != "" {
+		snap.Annunciator = append(snap.Annunciator, HealthRow{
+			Name: "runtime", Status: HealthOK,
+			Detail: fmt.Sprintf("running %s", snap.Version.Running),
+		})
+	}
+
 	snap.Host = collectHostInfo(i.src.DataDir, i.src.StartedAt, now)
 	if i.src.Telemetry != nil {
 		metrics := i.src.Telemetry.Collect(ctx)
@@ -319,6 +380,89 @@ func (i *Inspector) Health(ctx context.Context) HealthSnapshot {
 		}
 	}
 	return snap
+}
+
+// collectVersionInfo assembles the deploy story from build identity and
+// the journaled boot history: walk newest-first past the boots that
+// share the running version — the oldest of those is the boundary boot —
+// until the first differing version, which is what ran before.
+func (i *Inspector) collectVersionInfo(ctx context.Context, now time.Time) VersionInfo {
+	info := VersionInfo{Running: i.src.BuildVersion, Commit: i.src.BuildCommit}
+	if i.src.BootHistory == nil {
+		return info
+	}
+	boots, err := i.src.BootHistory(ctx)
+	if err != nil || len(boots) == 0 {
+		return info
+	}
+	var boundary time.Time
+	for _, boot := range boots {
+		if !boot.At.Before(now.Add(-24 * time.Hour)) {
+			info.BootsLast24h++
+		}
+		if len(info.RecentBoots) < maxRecentBootViews {
+			view := BootView{AtDelta: promptfmt.FormatDeltaOnly(boot.At, now), Version: boot.Version}
+			if len(boot.Commit) > 7 {
+				view.Commit = boot.Commit[:7]
+			} else {
+				view.Commit = boot.Commit
+			}
+			info.RecentBoots = append(info.RecentBoots, view)
+		}
+		if info.Previous == "" {
+			if boot.Version == info.Running {
+				boundary = boot.At
+			} else {
+				info.Previous = boot.Version
+				if !boundary.IsZero() {
+					info.ChangedDelta = promptfmt.FormatDeltaOnly(boundary, now)
+				}
+				info.Change = classifyVersionChange(info.Previous, info.Running)
+			}
+		}
+	}
+	return info
+}
+
+// classifyVersionChange names the size of a version jump: patch, minor,
+// major — or "dev" when either side is not a semantic version, which is
+// itself information (an untagged build shipped).
+func classifyVersionChange(prev, curr string) string {
+	prevParts, prevOK := semverParts(prev)
+	currParts, currOK := semverParts(curr)
+	if !prevOK || !currOK {
+		return "dev"
+	}
+	switch {
+	case prevParts[0] != currParts[0]:
+		return "major"
+	case prevParts[1] != currParts[1]:
+		return "minor"
+	case prevParts[2] != currParts[2]:
+		return "patch"
+	default:
+		return ""
+	}
+}
+
+func semverParts(v string) ([3]int, bool) {
+	v = strings.TrimPrefix(strings.TrimSpace(v), "v")
+	if idx := strings.IndexAny(v, "-+"); idx >= 0 {
+		v = v[:idx]
+	}
+	fields := strings.Split(v, ".")
+	if len(fields) != 3 {
+		return [3]int{}, false
+	}
+	var parts [3]int
+	for idx, field := range fields {
+		n, err := strconv.Atoi(field)
+		if err != nil {
+			return [3]int{}, false
+		}
+		parts[idx] = n
+	}
+	return parts, true
 }
 
 // buildLoopCensus rolls the registry snapshot into totals. Degraded

--- a/internal/state/introspection/health.go
+++ b/internal/state/introspection/health.go
@@ -132,8 +132,9 @@ type BootView struct {
 // maxRecentBootViews caps the boot tail on the snapshot.
 const maxRecentBootViews = 5
 
-// bootStormThreshold is how many boots inside a day degrade the runtime
-// lamp: a healthy instance restarts for deploys, not for sport.
+// bootStormThreshold is the boot count inside a day at which the
+// runtime lamp degrades (inclusive — the fifth boot trips it): a
+// healthy instance restarts for deploys, not for sport.
 const bootStormThreshold = 5
 
 // HealthSnapshot is the whole annunciator panel in one shape, consumed
@@ -355,7 +356,7 @@ func (i *Inspector) Health(ctx context.Context) HealthSnapshot {
 	}
 
 	snap.Version = i.collectVersionInfo(ctx, now)
-	if snap.Version.BootsLast24h > bootStormThreshold {
+	if snap.Version.BootsLast24h >= bootStormThreshold {
 		snap.Annunciator = append(snap.Annunciator, HealthRow{
 			Name:   "runtime",
 			Status: HealthDegraded,
@@ -402,8 +403,10 @@ func (i *Inspector) collectVersionInfo(ctx context.Context, now time.Time) Versi
 		}
 		if len(info.RecentBoots) < maxRecentBootViews {
 			view := BootView{AtDelta: promptfmt.FormatDeltaOnly(boot.At, now), Version: boot.Version}
-			if len(boot.Commit) > 7 {
-				view.Commit = boot.Commit[:7]
+			// Rune-safe truncation per the AGENTS.md invariant — commit
+			// hashes are ASCII today, but the pattern gets copied.
+			if runes := []rune(boot.Commit); len(runes) > 7 {
+				view.Commit = string(runes[:7])
 			} else {
 				view.Commit = boot.Commit
 			}

--- a/internal/state/introspection/health_test.go
+++ b/internal/state/introspection/health_test.go
@@ -230,9 +230,11 @@ func TestVersionChangeClassification(t *testing.T) {
 	}
 }
 
-// TestBootStormDegradesTheRuntimeLamp: a healthy instance restarts for
-// deploys, not for sport.
-func TestBootStormDegradesTheRuntimeLamp(t *testing.T) {
+// TestRuntimeLampInformsWithoutJudging: restart counts have no
+// objective threshold, so the runtime row carries facts (version, boot
+// count when notable) and never a verdict — the judgment belongs to the
+// reader with the context.
+func TestRuntimeLampInformsWithoutJudging(t *testing.T) {
 	now := time.Date(2026, 8, 11, 12, 0, 0, 0, time.UTC)
 	var boots []BootRecord
 	for i := range 8 {
@@ -244,12 +246,12 @@ func TestBootStormDegradesTheRuntimeLamp(t *testing.T) {
 	})
 	insp.now = func() time.Time { return now }
 
-	snap := insp.Health(context.Background())
-	if row := rowByName(t, snap, "runtime"); row.Status != HealthDegraded || !strings.Contains(row.Detail, "8 boots") {
-		t.Errorf("runtime row = %+v, want degraded crash-loop detail", row)
+	if row := rowByName(t, insp.Health(context.Background()), "runtime"); row.Status != HealthOK || !strings.Contains(row.Detail, "8 boots") {
+		t.Errorf("busy runtime row = %+v, want ok with the boot count stated", row)
 	}
 
-	// A single boot reads ok, with the version in the detail.
+	// A single boot reads ok with just the version — an unremarkable
+	// count is not worth a clause.
 	calm := NewInspector(HealthSources{
 		BuildVersion: "v0.10.3",
 		BootHistory: func(context.Context) ([]BootRecord, error) {
@@ -257,8 +259,8 @@ func TestBootStormDegradesTheRuntimeLamp(t *testing.T) {
 		},
 	})
 	calm.now = func() time.Time { return now }
-	if row := rowByName(t, calm.Health(context.Background()), "runtime"); row.Status != HealthOK || !strings.Contains(row.Detail, "v0.10.3") {
-		t.Errorf("calm runtime row = %+v", row)
+	if row := rowByName(t, calm.Health(context.Background()), "runtime"); row.Status != HealthOK || !strings.Contains(row.Detail, "v0.10.3") || strings.Contains(row.Detail, "boots") {
+		t.Errorf("calm runtime row = %+v, want version only", row)
 	}
 }
 

--- a/internal/state/introspection/health_test.go
+++ b/internal/state/introspection/health_test.go
@@ -174,6 +174,116 @@ func TestInspectorHealthDegradedStates(t *testing.T) {
 	})
 }
 
+// TestVersionInfoComputesTheDeployStory pins the mechanical deploy
+// detection: the boundary walk (oldest same-version boot is when the
+// running version arrived), the change classification, the boot-storm
+// count, and the raw boot tail — all precomputed so no model ever
+// bookkeeps a version.
+func TestVersionInfoComputesTheDeployStory(t *testing.T) {
+	now := time.Date(2026, 8, 11, 12, 0, 0, 0, time.UTC)
+	boots := []BootRecord{
+		{At: now.Add(-30 * time.Minute), Version: "v0.10.3", Commit: "abcdef1234567"},
+		{At: now.Add(-2 * time.Hour), Version: "v0.10.3", Commit: "abcdef1234567"},
+		{At: now.Add(-3 * 24 * time.Hour), Version: "v0.10.2", Commit: "0123456789ab"},
+		{At: now.Add(-9 * 24 * time.Hour), Version: "v0.10.2", Commit: "0123456789ab"},
+	}
+	insp := NewInspector(HealthSources{
+		BuildVersion: "v0.10.3",
+		BuildCommit:  "abcdef1234567",
+		BootHistory:  func(context.Context) ([]BootRecord, error) { return boots, nil },
+	})
+	insp.now = func() time.Time { return now }
+
+	v := insp.Health(context.Background()).Version
+	if v.Running != "v0.10.3" || v.Previous != "v0.10.2" {
+		t.Errorf("running/previous = %s/%s, want v0.10.3/v0.10.2", v.Running, v.Previous)
+	}
+	// The boundary is the OLDEST boot carrying the running version.
+	if v.ChangedDelta != "-2h" {
+		t.Errorf("changed_delta = %q, want -2h — the boot that introduced v0.10.3", v.ChangedDelta)
+	}
+	if v.Change != "patch" {
+		t.Errorf("change = %q, want patch", v.Change)
+	}
+	if v.BootsLast24h != 2 {
+		t.Errorf("boots_last_24h = %d, want 2", v.BootsLast24h)
+	}
+	if len(v.RecentBoots) != 4 || v.RecentBoots[0].AtDelta != "-1800s" || v.RecentBoots[0].Commit != "abcdef1" {
+		t.Errorf("recent_boots = %+v, want 4 delta-formatted rows with short commits", v.RecentBoots)
+	}
+}
+
+func TestVersionChangeClassification(t *testing.T) {
+	tests := []struct{ prev, curr, want string }{
+		{"v0.10.2", "v0.10.3", "patch"},
+		{"v0.10.3", "v0.11.0", "minor"},
+		{"v0.11.0", "v1.0.0", "major"},
+		{"v0.10.3", "dev", "dev"},
+		{"dev", "v0.10.3", "dev"},
+		{"v0.10.3", "v0.10.3", ""},
+		{"v0.10.3-rc1", "v0.10.3", ""},
+	}
+	for _, tt := range tests {
+		if got := classifyVersionChange(tt.prev, tt.curr); got != tt.want {
+			t.Errorf("classify(%s -> %s) = %q, want %q", tt.prev, tt.curr, got, tt.want)
+		}
+	}
+}
+
+// TestBootStormDegradesTheRuntimeLamp: a healthy instance restarts for
+// deploys, not for sport.
+func TestBootStormDegradesTheRuntimeLamp(t *testing.T) {
+	now := time.Date(2026, 8, 11, 12, 0, 0, 0, time.UTC)
+	var boots []BootRecord
+	for i := range 8 {
+		boots = append(boots, BootRecord{At: now.Add(-time.Duration(i+1) * 10 * time.Minute), Version: "dev"})
+	}
+	insp := NewInspector(HealthSources{
+		BuildVersion: "dev",
+		BootHistory:  func(context.Context) ([]BootRecord, error) { return boots, nil },
+	})
+	insp.now = func() time.Time { return now }
+
+	snap := insp.Health(context.Background())
+	if row := rowByName(t, snap, "runtime"); row.Status != HealthDegraded || !strings.Contains(row.Detail, "8 boots") {
+		t.Errorf("runtime row = %+v, want degraded crash-loop detail", row)
+	}
+
+	// A single boot reads ok, with the version in the detail.
+	calm := NewInspector(HealthSources{
+		BuildVersion: "v0.10.3",
+		BootHistory: func(context.Context) ([]BootRecord, error) {
+			return []BootRecord{{At: now.Add(-time.Hour), Version: "v0.10.3"}}, nil
+		},
+	})
+	calm.now = func() time.Time { return now }
+	if row := rowByName(t, calm.Health(context.Background()), "runtime"); row.Status != HealthOK || !strings.Contains(row.Detail, "v0.10.3") {
+		t.Errorf("calm runtime row = %+v", row)
+	}
+}
+
+// TestJournalBootRoundTrip covers the boot journal itself.
+func TestJournalBootRoundTrip(t *testing.T) {
+	j := newTestJournal(t)
+	ctx := context.Background()
+	if err := j.RecordBoot(ctx, "v0.10.2", "0123456"); err != nil {
+		t.Fatalf("record boot: %v", err)
+	}
+	if err := j.RecordBoot(ctx, "v0.10.3", "abcdef0"); err != nil {
+		t.Fatalf("record boot: %v", err)
+	}
+	boots, err := j.RecentBoots(ctx, 10)
+	if err != nil {
+		t.Fatalf("recent boots: %v", err)
+	}
+	if len(boots) != 2 || boots[0].Version != "v0.10.3" || boots[1].Version != "v0.10.2" {
+		t.Fatalf("boots = %+v, want newest-first v0.10.3 then v0.10.2", boots)
+	}
+	if boots[0].Commit != "abcdef0" || boots[0].At.IsZero() {
+		t.Errorf("boot detail not round-tripped: %+v", boots[0])
+	}
+}
+
 // TestLoopCensusTopWakersOrderAndCap pins the busiest-waker ranking:
 // descending by trailing-day wakes with a stable name tiebreak, zero
 // wakers omitted, and the list truncated at the cap.

--- a/internal/state/introspection/loop_events.go
+++ b/internal/state/introspection/loop_events.go
@@ -18,6 +18,13 @@ import (
 // retrospectives; the journal is operational history, not an archive.
 const DefaultLoopEventRetention = 30 * 24 * time.Hour
 
+// KindThaneBoot is the journal-native row recorded once per process
+// start, stamped with the running version and commit. It is written by
+// the wiring, not received from the bus: the bus has no process-level
+// lifecycle event, and the boot record is what makes deploy boundaries
+// and restart storms mechanically computable instead of model-inferred.
+const KindThaneBoot = "thane_boot"
+
 // loopEventsSchema declares the loop_events journal: the persistent
 // record of loop lifecycle events (wakes with attribution, iteration
 // outcomes, errors, state changes, mailbox arrivals) that the in-memory
@@ -317,6 +324,65 @@ func (j *Journal) AggregateActivity(ctx context.Context, loopName string, since,
 		return agg, fmt.Errorf("introspection: aggregate wake sources: %w", err)
 	}
 	return agg, nil
+}
+
+// BootRecord is one journaled process start: when, and what build.
+type BootRecord struct {
+	At      time.Time
+	Version string
+	Commit  string
+}
+
+// RecordBoot journals one process start with its build identity. Called
+// once from the app wiring as the recorder comes up.
+func (j *Journal) RecordBoot(ctx context.Context, version, commit string) error {
+	return j.record(ctx, []LoopEvent{{
+		At:   time.Now(),
+		Kind: KindThaneBoot,
+		Detail: map[string]any{
+			"version": version,
+			"commit":  commit,
+		},
+	}})
+}
+
+// RecentBoots returns the newest boot records, newest first, bounded by
+// limit (<= 0 defaults to 50). The walk from the newest row backward is
+// what turns raw boots into a deploy boundary: the first row whose
+// version differs from the running one marks where the current version
+// began.
+func (j *Journal) RecentBoots(ctx context.Context, limit int) ([]BootRecord, error) {
+	if limit <= 0 {
+		limit = 50
+	}
+	rows, err := j.db.QueryContext(ctx, `
+		SELECT at, detail FROM loop_events
+		WHERE kind = ?
+		ORDER BY at DESC, id DESC LIMIT ?
+	`, KindThaneBoot, limit)
+	if err != nil {
+		return nil, fmt.Errorf("introspection: recent boots: %w", err)
+	}
+	defer rows.Close()
+
+	var boots []BootRecord
+	for rows.Next() {
+		var (
+			atRaw  any
+			detail string
+		)
+		if err := rows.Scan(&atRaw, &detail); err != nil {
+			return nil, err
+		}
+		rec := BootRecord{At: parseJournalTimestamp(atRaw)}
+		var m map[string]any
+		if err := json.Unmarshal([]byte(detail), &m); err == nil {
+			rec.Version, _ = m["version"].(string)
+			rec.Commit, _ = m["commit"].(string)
+		}
+		boots = append(boots, rec)
+	}
+	return boots, rows.Err()
 }
 
 // Prune deletes journaled events older than maxAge and reports how many

--- a/internal/state/introspection/panel.go
+++ b/internal/state/introspection/panel.go
@@ -96,6 +96,7 @@ func (p *PanelProvider) TagContext(ctx context.Context, _ agentctx.ContextReques
 
 	payload := map[string]any{
 		"annunciator": snap.Annunciator,
+		"version":     snap.Version,
 		"host":        snap.Host,
 		"loops":       snap.Loops,
 		"telemetry":   snap.Telemetry,

--- a/internal/state/introspection/tool_provider.go
+++ b/internal/state/introspection/tool_provider.go
@@ -116,8 +116,8 @@ func (t *Tools) Tools() []*tools.Tool {
 					},
 					"kind": map[string]any{
 						"type":        "string",
-						"enum":        []string{"loop_started", "loop_stopped", "loop_iteration_start", "loop_iteration_complete", "loop_error", "loop_state_change", "loop_mailbox_arrival", "loop_midturn_input"},
-						"description": "Optional event-kind filter. loop_iteration_start rows carry the wake attribution.",
+						"enum":        []string{"loop_started", "loop_stopped", "loop_iteration_start", "loop_iteration_complete", "loop_error", "loop_state_change", "loop_mailbox_arrival", "loop_midturn_input", "thane_boot"},
+						"description": "Optional event-kind filter. loop_iteration_start rows carry the wake attribution; thane_boot rows mark process starts with the build version, so deploy boundaries and restarts are queryable history.",
 					},
 					"since": windowParam("the activity window"),
 					"until": map[string]any{

--- a/loops/metacognitive.md
+++ b/loops/metacognitive.md
@@ -107,15 +107,17 @@ The drill-downs, when the panel or your concerns warrant them:
 - logs_query, cost_summary — failure evidence and spend, when a
   concern needs the receipts.
 
-The "Current Conditions" block at the bottom of your prompt carries the
-running version, commit, and uptime — read those as instruments, not
-boilerplate. An uptime reset means a restart happened; a version that
-differs from the one your durable state records means a deploy landed,
-and much follows from which kind: a patch bump is a hotfix carrying a
-targeted change worth finding, a minor bump is a release that
-legitimately resets baselines, and an untagged dev build running in
-production is itself a finding worth escalating. Only you are
-positioned to notice the difference between a restart and a release.
+The panel's version object does the bookkeeping no model should do:
+the running version and commit, the previous version and when the
+boundary landed, the size of the jump, and the last few boots with
+their builds. Five boots minutes apart IS a crash loop — the runtime
+lamp flags the storm, and the boot list shows it plainly — and a
+version change between adjacent boots IS a deploy. What remains for
+you is the judgment: a patch bump is a hotfix carrying a targeted
+change worth finding, a minor bump is a release that legitimately
+resets expectations, an untagged dev build running in production is
+itself a finding worth escalating, and boots piling up with no
+version change deserve a concern, not a shrug.
 
 ## Your Durable Output
 
@@ -131,10 +133,13 @@ ranges, and judgments, never the panel's live numbers copied as if they
 were memory: "normally 4-6/day" ages well, while "wakes_last_24h: 5" is
 stale the moment it is written. Keep concerns with their evidence and
 severity, note incidents you escalated and what came of them, and prune
-what no longer matters. Record the version you are living under and
-when it arrived: it is the boundary marker that separates drift from
-deploy, and every baseline implicitly belongs to the version that
-produced it.
+what no longer matters. Every baseline implicitly belongs to the
+version that produced it — the panel tells you when a boundary landed,
+so treat post-deploy shifts as recalibration rather than drift. And
+know that this document is occasionally co-authored: Nugget sometimes
+edits it by hand, out of band. A revision in its history without loop
+trailers is the operator's hand — read it as a note to you, never as
+corruption.
 
 If the document still describes household activity, presence, or
 environmental observations, it predates this mandate: rebuild it this

--- a/loops/metacognitive.md
+++ b/loops/metacognitive.md
@@ -135,10 +135,10 @@ severity, note incidents you escalated and what came of them, and prune
 what no longer matters. Every baseline implicitly belongs to the
 version that produced it — the panel tells you when a boundary landed,
 so treat post-deploy shifts as recalibration rather than drift. And
-know that this document is occasionally co-authored: Nugget sometimes
-edits it by hand, out of band. A revision in its history without loop
-trailers is the operator's hand — read it as a note to you, never as
-corruption.
+know that this document is occasionally co-authored: the operator
+sometimes edits it by hand, out of band. A revision in its history
+without loop trailers is the operator's hand — read it as a note to
+you, never as corruption.
 
 If the document still describes household activity, presence, or
 environmental observations, it predates this mandate: rebuild it this

--- a/loops/metacognitive.md
+++ b/loops/metacognitive.md
@@ -107,6 +107,16 @@ The drill-downs, when the panel or your concerns warrant them:
 - logs_query, cost_summary — failure evidence and spend, when a
   concern needs the receipts.
 
+The "Current Conditions" block at the bottom of your prompt carries the
+running version, commit, and uptime — read those as instruments, not
+boilerplate. An uptime reset means a restart happened; a version that
+differs from the one your durable state records means a deploy landed,
+and much follows from which kind: a patch bump is a hotfix carrying a
+targeted change worth finding, a minor bump is a release that
+legitimately resets baselines, and an untagged dev build running in
+production is itself a finding worth escalating. Only you are
+positioned to notice the difference between a restart and a release.
+
 ## Your Durable Output
 
 Your current durable output contract is injected in the "Declared
@@ -121,7 +131,10 @@ ranges, and judgments, never the panel's live numbers copied as if they
 were memory: "normally 4-6/day" ages well, while "wakes_last_24h: 5" is
 stale the moment it is written. Keep concerns with their evidence and
 severity, note incidents you escalated and what came of them, and prune
-what no longer matters.
+what no longer matters. Record the version you are living under and
+when it arrived: it is the boundary marker that separates drift from
+deploy, and every baseline implicitly belongs to the version that
+produced it.
 
 If the document still describes household activity, presence, or
 environmental observations, it predates this mandate: rebuild it this
@@ -140,7 +153,11 @@ content go — purpose-built loops own that now.
 3. **Judge** — Distinguish noise from drift from incident. A loop
    erroring once is noise; a loop whose wake rate tripled overnight is
    drift worth a concern; a failed subsystem, a runaway document, or a
-   queue whose oldest work is hours stale is an incident.
+   queue whose oldest work is hours stale is an incident. And ask of
+   every anomaly whether it began at a version boundary: a deploy
+   regression and organic drift are different findings deserving
+   different escalations, and the boundary is the first fact that
+   separates them.
 4. **Escalate when warranted** — request_core_attention is your one
    voice, and it goes to core, which curates the service loops and can
    act. Escalate with evidence: name the subsystem or loop, the

--- a/loops/metacognitive.md
+++ b/loops/metacognitive.md
@@ -109,14 +109,15 @@ The drill-downs, when the panel or your concerns warrant them:
 
 The panel's version object shows the running version and commit, the
 previous version and when the boundary landed, the size of the jump,
-and the last few boots with their builds. A version change between
-adjacent boots is a deploy; boots minutes apart are a crash loop (the
-runtime lamp flags the storm). Judge what a boundary means: a patch
-bump is a hotfix carrying a targeted change worth finding, a minor
-bump is a release that legitimately resets expectations, an untagged
-dev build running in production is worth escalating on its own, and
-boots piling up with no version change deserve a concern, not a
-shrug.
+and the last few boots with their builds. Read the boot pattern
+together with the version story: restarts that accompany a version
+change are deploys, while restarts without one have some other cause —
+planned maintenance, a memory-guard trip, something failing at
+startup — and their rhythm against your recorded baselines tells you
+how much they matter. A patch bump is a hotfix carrying a targeted
+change worth finding; a minor bump is a release that legitimately
+resets expectations; an untagged dev build running in production is
+worth escalating on its own.
 
 ## Your Durable Output
 

--- a/loops/metacognitive.md
+++ b/loops/metacognitive.md
@@ -107,17 +107,16 @@ The drill-downs, when the panel or your concerns warrant them:
 - logs_query, cost_summary — failure evidence and spend, when a
   concern needs the receipts.
 
-The panel's version object does the bookkeeping no model should do:
-the running version and commit, the previous version and when the
-boundary landed, the size of the jump, and the last few boots with
-their builds. Five boots minutes apart IS a crash loop — the runtime
-lamp flags the storm, and the boot list shows it plainly — and a
-version change between adjacent boots IS a deploy. What remains for
-you is the judgment: a patch bump is a hotfix carrying a targeted
-change worth finding, a minor bump is a release that legitimately
-resets expectations, an untagged dev build running in production is
-itself a finding worth escalating, and boots piling up with no
-version change deserve a concern, not a shrug.
+The panel's version object shows the running version and commit, the
+previous version and when the boundary landed, the size of the jump,
+and the last few boots with their builds. A version change between
+adjacent boots is a deploy; boots minutes apart are a crash loop (the
+runtime lamp flags the storm). Judge what a boundary means: a patch
+bump is a hotfix carrying a targeted change worth finding, a minor
+bump is a release that legitimately resets expectations, an untagged
+dev build running in production is worth escalating on its own, and
+boots piling up with no version change deserve a concern, not a
+shrug.
 
 ## Your Durable Output
 

--- a/scripts/architecture.baseline
+++ b/scripts/architecture.baseline
@@ -1,5 +1,5 @@
 packages=68
 interfaces=83
-large_files=53
+large_files=54
 set_mutators=117
 database_opens=9

--- a/talents/diagnostics.md
+++ b/talents/diagnostics.md
@@ -54,6 +54,14 @@ provider, or task. Reach for them when a finding needs evidence, not as
 the first sweep — the annunciator and the two loop views almost always
 localize the problem faster.
 
+Version boundaries are diagnostic events in their own right. The
+Current Conditions block carries the running version and uptime, and
+every log line records the version that wrote it, so `logs_query` can
+answer what was running when something happened. When an anomaly's
+onset lines up with a version change, reason about the deploy before
+reasoning about drift — they are different findings with different
+next moves.
+
 Everything here observes; nothing here fixes. When a finding needs an
 actor, the paths are `request_core_attention` from inside a service
 loop, or the `loops` tag's mutation tools when you are the one curating

--- a/talents/diagnostics.md
+++ b/talents/diagnostics.md
@@ -54,11 +54,13 @@ provider, or task. Reach for them when a finding needs evidence, not as
 the first sweep — the annunciator and the two loop views almost always
 localize the problem faster.
 
-Version boundaries are diagnostic events in their own right. The
-Current Conditions block carries the running version and uptime, and
-every log line records the version that wrote it, so `logs_query` can
-answer what was running when something happened. When an anomaly's
-onset lines up with a version change, reason about the deploy before
+Version boundaries are diagnostic events in their own right, and
+`system_health` precomputes the deploy story: running vs previous
+version, when the boundary landed, the size of the jump, and the
+recent boot list that makes a crash loop visible at a glance. Every
+log line also records the version that wrote it, so `logs_query`
+answers what was running when something happened. When an anomaly's
+onset lines up with a version boundary, reason about the deploy before
 reasoning about drift — they are different findings with different
 next moves.
 

--- a/talents/diagnostics.md
+++ b/talents/diagnostics.md
@@ -57,7 +57,7 @@ localize the problem faster.
 Version boundaries are diagnostic events in their own right, and
 `system_health` precomputes the deploy story: running vs previous
 version, when the boundary landed, the size of the jump, and the
-recent boot list that makes a crash loop visible at a glance. Every
+recent boot list that makes restart patterns readable at a glance. Every
 log line also records the version that wrote it, so `logs_query`
 answers what was running when something happened. When an anomaly's
 onset lines up with a version boundary, reason about the deploy before


### PR DESCRIPTION
Follow-on to the #1341 arc, redesigned mid-review: the first cut taught metacog to record the running version in its durable state and compare it against `# Current Conditions` each turn — bookkeeping no model should do, and fragile against exactly the operator's out-of-band edits to that document which must remain legitimate. This version makes the machine do the memory so the model does only the judgment.

One `thane_boot` row lands in the loop-event journal per process start, stamped with version and commit — written by the wiring, since the bus has no process-level lifecycle event. From that single row, `Inspector.Health` precomputes the entire deploy story on the snapshot: running vs previous version, when the boundary boot happened, the jump classified (patch/minor/major/dev — where dev is itself information: an untagged build shipped), boots in the last 24h, and the raw last-five-boots tail. Deliberately, none of that carries a restart verdict: there is nothing magic about any particular boot count — a deploy day and a crash loop can hold the same number — so the `runtime` lamp is informational (running version, boot count when notable) and the judgment stays with metacog, which reads the pattern against the version story and its own recorded baselines. The panel and `system_health` carry all of it identically, and `loop_activity` accepts `kind=thane_boot` so deploy boundaries and restarts are queryable history.

The mandate sheds its bookkeeping instruction and keeps pure judgment: patch reads as hotfix worth hunting, minor as a release that legitimately resets baselines, boots-without-version-change as concern-not-shrug. It also names operator co-authorship outright — a trailer-less revision of the durable document is Nugget's hand, a note and never corruption — which the journal design is what makes safe: version truth lives outside the document, so hand edits cannot false-trigger deploy detection. The diagnostics talent carries the forensic half (`system_health` for the story, `logs_query` for what version wrote any given line).

## Test plan
- [x] Deploy-story computation: boundary walk (oldest same-version boot), classification table, storm count, boot-tail views
- [x] Boot journal round-trip, newest-first
- [x] Runtime lamp informs without judging: boot count stated when notable, never degraded by arithmetic
- [x] Boot-parity, embedded-mirror, and talent gates green after `just generate`
- [x] `just ci` green (baseline regenerated: health.go crossed the large-file threshold)

Refs #1341

🤖 Generated with [Claude Code](https://claude.com/claude-code)
