### PR TITLE
An unmigrated talent root announces itself: the last gaps in #787

### DIFF
--- a/docs/operating/configuration.md
+++ b/docs/operating/configuration.md
@@ -292,9 +292,20 @@ operator guide.
 
 ## Persona & Talents
 
-```yaml
-talents_dir: ~/Thane/talents
-```
+Talents have no config key. They load from `{workspace}/core/talents/`,
+a location derived from the workspace rather than authored, so the
+prose that steers model behavior every turn is covered by the same
+signed history and cleanliness rule as the config beside it. Editing a
+talent means committing it: an uncommitted talent file fails the boot
+gate exactly as an uncommitted `config.yaml` does, and every talent
+must declare `tags:` (`always`, `persona`, or the capability tags that
+select it).
+
+A config that still declares the retired `talents_dir` key is rejected
+at load with the migration recipe: move the directory into core
+(`mv <talents_dir> {workspace}/core/talents`), commit it, and remove
+the `talents_dir:` line. An instance that skips the move boots with an
+empty talent set and a startup warning naming the missing directory.
 
 See [Context Layers](../understanding/context-layers.md) for how these
 fit into the system prompt. The workspace derives the protected

--- a/docs/operating/getting-started.md
+++ b/docs/operating/getting-started.md
@@ -32,24 +32,30 @@ This builds a platform-specific binary into `dist/`. Cross-compile with
 
 ## Initialize
 
-Set up the `~/Thane` directory with config, talents, persona, and a local
+Set up the `~/Thane` workspace with config, talents, persona, and a local
 cryptographic identity:
 
 ```bash
-just init
+just init ~/Thane
 ```
 
-This bootstraps `~/Thane/core` as the instance trust root: a generated
-Ed25519 signing key, an internal channel CA, and a signed git birth commit
-containing the public identity material, `core/config.yaml`, and the
-bundled talents under `core/talents/`. A reference `config.yaml` and
-`persona.md` are also written at the workspace root.
+(`just init` with no argument bootstraps a repo-local `Thane/` directory,
+the development workspace `just serve` runs against.)
 
-The runtime reads `~/Thane/core/config.yaml` and nothing else. It is
-covered by core's signed history, so commit after editing — `thane serve`
-refuses to start on an uncommitted config, and `thane validate` names the
-fix for anything the boot gate would reject. Apply the settings below
-there.
+This runs `thane init`, which bootstraps `core/` inside the workspace as
+the instance trust root: a generated Ed25519 signing key, an internal
+channel CA, and a signed git birth commit containing the public identity
+material, `core/config.yaml`, and the bundled talents under
+`core/talents/`. A reference `config.yaml` and `persona.md` are also
+written at the workspace root.
+
+In normal operation the runtime reads `core/config.yaml` from the
+workspace and nothing else (`-insecure-config` exists as a recovery path
+for loading a file from outside the trust boundary, at the cost of a
+degraded runtime). The config is covered by core's signed history, so
+commit after editing — `thane serve` refuses to start on an uncommitted
+config, and `thane validate` names the fix for anything the boot gate
+would reject. Apply the settings below there.
 
 **Required settings:**
 

--- a/docs/operating/getting-started.md
+++ b/docs/operating/getting-started.md
@@ -39,11 +39,17 @@ cryptographic identity:
 just init
 ```
 
-This creates `~/Thane/config.yaml`, copies talent files, sets up the
-persona, and bootstraps `~/Thane/core` as the instance trust root. The core
-root contains a generated Ed25519 signing key, an internal channel CA, and a
-signed git birth commit containing the public identity material and
-`core/config.yaml`. Edit `~/Thane/config.yaml` for your setup.
+This bootstraps `~/Thane/core` as the instance trust root: a generated
+Ed25519 signing key, an internal channel CA, and a signed git birth commit
+containing the public identity material, `core/config.yaml`, and the
+bundled talents under `core/talents/`. A reference `config.yaml` and
+`persona.md` are also written at the workspace root.
+
+The runtime reads `~/Thane/core/config.yaml` and nothing else. It is
+covered by core's signed history, so commit after editing — `thane serve`
+refuses to start on an uncommitted config, and `thane validate` names the
+fix for anything the boot gate would reject. Apply the settings below
+there.
 
 **Required settings:**
 

--- a/internal/app/verify_startup_reads.go
+++ b/internal/app/verify_startup_reads.go
@@ -55,16 +55,25 @@ func (a *App) loadTalents(ctx context.Context, verifier talents.VerifyPathFunc) 
 	if err != nil {
 		return nil, fmt.Errorf("load talents: %w", err)
 	}
-	if len(parsedTalents) > 0 {
-		names := make([]string, 0, len(parsedTalents))
-		for _, talent := range parsedTalents {
-			names = append(names, talent.Name)
-		}
-		logger := a.logger
-		if logger == nil {
-			logger = slog.Default()
-		}
-		logger.Info("talents loaded", "dir", a.cfg.TalentsDir, "count", len(parsedTalents), "talents", names)
+	logger := a.logger
+	if logger == nil {
+		logger = slog.Default()
 	}
+	if len(parsedTalents) == 0 {
+		// The loader treats a missing directory as an empty set, so zero
+		// talents here is indistinguishable from a talents directory that
+		// was never migrated into core (#787) — and booting without any
+		// behavioral guidance is exactly the silent total loss the
+		// per-file skip notices exist to prevent. Boot proceeds, loudly.
+		logger.Warn("no talents loaded; the model runs without behavioral guidance",
+			"dir", a.cfg.TalentsDir,
+			"hint", "talents live in {workspace}/core/talents — if this instance predates talents-in-core, move the old talents directory there and commit it")
+		return parsedTalents, nil
+	}
+	names := make([]string, 0, len(parsedTalents))
+	for _, talent := range parsedTalents {
+		names = append(names, talent.Name)
+	}
+	logger.Info("talents loaded", "dir", a.cfg.TalentsDir, "count", len(parsedTalents), "talents", names)
 	return parsedTalents, nil
 }

--- a/internal/app/verify_startup_reads.go
+++ b/internal/app/verify_startup_reads.go
@@ -63,9 +63,11 @@ func (a *App) loadTalents(ctx context.Context, verifier talents.VerifyPathFunc) 
 		// The loader treats a missing directory as an empty set, so zero
 		// talents here is indistinguishable from a talents directory that
 		// was never migrated into core (#787) — and booting without any
-		// behavioral guidance is exactly the silent total loss the
-		// per-file skip notices exist to prevent. Boot proceeds, loudly.
-		logger.Warn("no talents loaded; the model runs without behavioral guidance",
+		// talent guidance is exactly the silent total loss the per-file
+		// skip notices exist to prevent. Boot proceeds, loudly. (Core
+		// prompt files — axioms, persona, mission — load separately and
+		// are unaffected.)
+		logger.Warn("no talents loaded; the model runs without talent guidance",
 			"dir", a.cfg.TalentsDir,
 			"hint", "talents live in {workspace}/core/talents — if this instance predates talents-in-core, move the old talents directory there and commit it")
 		return parsedTalents, nil

--- a/internal/app/verify_startup_reads_test.go
+++ b/internal/app/verify_startup_reads_test.go
@@ -3,6 +3,7 @@ package app
 import (
 	"context"
 	"errors"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -232,6 +233,53 @@ func TestLoadTalents_BlocksUnsignedTalent(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "load talents") {
 		t.Fatalf("error = %v, want load talents wrapper", err)
+	}
+}
+
+// TestLoadTalents_EmptyOrMissingDirWarns guards the unmigrated-instance
+// case from #787: the loader treats a missing talents directory as an
+// empty set, so an install whose talents never moved into core would
+// otherwise boot with zero behavioral guidance and zero log output.
+// Boot must proceed (an intentionally talent-less instance is legal)
+// but the empty set must be announced.
+func TestLoadTalents_EmptyOrMissingDirWarns(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		dir  func(t *testing.T) string
+	}{
+		{"missing dir", func(t *testing.T) string {
+			return filepath.Join(t.TempDir(), "core", "talents")
+		}},
+		{"empty dir", func(t *testing.T) string {
+			return t.TempDir()
+		}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var buf strings.Builder
+			logger := slog.New(slog.NewTextHandler(&buf, nil))
+			dir := tt.dir(t)
+
+			a := &App{cfg: &config.Config{TalentsDir: dir}, logger: logger}
+			parsed, err := a.loadTalents(context.Background(), nil)
+			if err != nil {
+				t.Fatalf("empty talent set must not fail boot; got %v", err)
+			}
+			if len(parsed) != 0 {
+				t.Fatalf("expected zero talents, got %d", len(parsed))
+			}
+			out := buf.String()
+			if !strings.Contains(out, "level=WARN") || !strings.Contains(out, "no talents loaded") {
+				t.Errorf("expected WARN about empty talent set, got log output: %q", out)
+			}
+			if !strings.Contains(out, dir) {
+				t.Errorf("warning should name the talents dir %q, got: %q", dir, out)
+			}
+		})
 	}
 }
 

--- a/internal/platform/config/config_test.go
+++ b/internal/platform/config/config_test.go
@@ -232,6 +232,27 @@ curator:
 	}
 }
 
+// TestLoad_RetiredTalentsDirIsRejected guards the talents-into-core move
+// (#787, #1279): talent location is derived as {workspace}/core/talents,
+// and a config that still declares talents_dir must fail fast with the
+// migration recipe rather than silently loading behavior definitions
+// from outside the trust boundary.
+func TestLoad_RetiredTalentsDirIsRejected(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	os.WriteFile(path, []byte(`
+talents_dir: /srv/thane/talents
+`), 0600)
+
+	_, err := Load(path)
+	if err == nil {
+		t.Fatal("expected Load to reject talents_dir")
+	}
+	if !strings.Contains(err.Error(), "talents_dir") || !strings.Contains(err.Error(), "core/talents") {
+		t.Errorf("error %q should mention talents_dir and the core/talents destination", err)
+	}
+}
+
 // TestLoad_RetiredCapabilityToolsKeyRejected guards the capability_tag
 // schema redesign: the legacy tools: replace-list was retired in favor
 // of the additive include:/exclude: pair. Load must fail with an

--- a/justfile
+++ b/justfile
@@ -316,35 +316,14 @@ service-status:
 service-status:
     @launchctl list info.nugget.thane 2>/dev/null || echo "Service not loaded"
 
-# Bootstrap a working directory from repo sources (config, talents, persona)
+# Bootstrap a workspace via thane init (core trust root, signed birth commit)
 [group('deploy')]
-init dir="Thane":
+init dir="Thane": build
     #!/usr/bin/env sh
     set -e
-    mkdir -p "{{dir}}/db" "{{dir}}/talents"
-    if [ ! -f "{{dir}}/config.yaml" ]; then
-        cp examples/config.example.yaml "{{dir}}/config.yaml"
-        echo "Created {{dir}}/config.yaml — edit with your settings"
-    else
-        echo "{{dir}}/config.yaml already exists, skipping"
-    fi
-    for f in talents/*.md; do
-        [ -f "$f" ] && cp -n "$f" "{{dir}}/talents/" 2>/dev/null || true
-    done
-    echo "Copied talents to {{dir}}/talents/"
-    if [ ! -f "{{dir}}/persona.md" ]; then
-        if [ -f persona.md ]; then
-            cp persona.md "{{dir}}/persona.md"
-        elif [ -f examples/persona.example.md ]; then
-            cp examples/persona.example.md "{{dir}}/persona.md"
-        fi
-        echo "Created {{dir}}/persona.md — customize your agent's personality"
-    else
-        echo "{{dir}}/persona.md already exists, skipping"
-    fi
+    ./dist/thane-{{host_os}}-{{host_arch}} init "{{dir}}"
     echo ""
-    echo "Working directory ready: {{dir}}/"
-    echo "  1. Edit config:  $EDITOR {{dir}}/config.yaml"
+    echo "  1. Edit config:  $EDITOR {{dir}}/core/config.yaml  (commit after editing)"
     echo "  2. Run:          just serve"
 
 # Build from main branch and deploy to ~/Thane (ensures clean release metadata)
@@ -419,7 +398,7 @@ deploy-macos host target_arch=host_arch version="" remote_pkg_dir="/tmp/thane-re
 # Build and run from the local Thane/ working directory (for development)
 [group('operations')]
 serve: build
-    cd Thane && ../dist/thane-{{host_os}}-{{host_arch}} serve
+    cd Thane && ../dist/thane-{{host_os}}-{{host_arch}} serve -workspace .
 
 # Tail live service logs (default: dev workdir). Follows the events
 # dataset and rolls to the next HH.jsonl segment automatically. Waits


### PR DESCRIPTION
A review of #787 against main found the arc substantively complete — config authority landed in #1255–#1263, per-root trust in #1264–#1272, and talents moved inside the boundary in #1279–#1286 — but three edges survived, and one of them was actively pointing operators at a boot failure.

**The docs still taught the fatal key.** The Persona & Talents section of `configuration.md` consisted of a yaml example declaring `talents_dir: ~/Thane/talents` — the exact config that #1279 now rejects at load. The section now describes the derived `core/talents` location, the commit-to-edit workflow, and the migration recipe. `getting-started.md` had the same era problem one layer down: it told operators to edit `~/Thane/config.yaml`, a file the runtime stopped reading in #1257; it now points at `core/config.yaml` and says why committing is part of editing.

**An unmigrated instance failed silently, in the exact shape the arc exists to prevent.** A config that declared `talents_dir` gets #1279's teaching rejection — but an instance that relied on the old `./talents` default derives `{core}/talents`, finds nothing, and booted with zero talents and zero log output, because the loader treats a missing directory as an empty set and the "talents loaded" line only fired when the count was positive. That is the silent-total-loss failure mode #1285's per-file skip notices were written against, happening to the whole set. `loadTalents` now warns when the set is empty, naming the directory and the migration destination. Boot still proceeds — a talent-less instance is legal — it just can no longer be an accident nobody hears.

**Neither case had a test.** `TestLoad_RetiredTalentsDirIsRejected` joins the existing retired-key family beside the `platform:` and `curator:` guards, and `TestLoadTalents_EmptyOrMissingDirWarns` covers both the missing and the empty directory.

With these, every item on #787's "done means" list is either shipped or has a recorded disposition (detailed in a closing comment on the issue): the migration command became the rejection error's inline recipe, and live reload was retired rather than kept — a talent edit is a signed commit plus restart.

## Test plan

- [x] `go test ./internal/app/ -run TestLoadTalents` — new warn test passes alongside the existing verification-blocking test
- [x] `go test ./internal/platform/config/ -run TestLoad_Retired` — rejection test passes with the existing family
- [x] `just ci` clean locally

Closes #787

🤖 Generated with [Claude Code](https://claude.com/claude-code)