### PR TITLE
fix(introspection): the boot record outlasts the startup write burst

### DIFF
--- a/internal/app/new_introspection.go
+++ b/internal/app/new_introspection.go
@@ -41,9 +41,10 @@ func (a *App) initIntrospectionJournal() {
 	a.deferWorker("loop-event-recorder", func(ctx context.Context) error {
 		// One boot row per process start, stamped with build identity —
 		// what makes deploy boundaries and restart storms computable.
-		if err := journal.RecordBoot(ctx, buildinfo.Version, buildinfo.GitCommit); err != nil {
-			a.logger.Warn("boot record failed", "error", err)
-		}
+		// Retried from its own goroutine: boot is the worst moment to
+		// write to logs.db (the indexer's startup burst can outlast the
+		// 5s busy timeout), and this row must not lose that race.
+		journal.RecordBootWithRetry(ctx, buildinfo.Version, buildinfo.GitCommit, a.logger)
 		go recorder.Run(ctx)
 		return nil
 	})

--- a/internal/state/introspection/health_test.go
+++ b/internal/state/introspection/health_test.go
@@ -264,6 +264,42 @@ func TestRuntimeLampInformsWithoutJudging(t *testing.T) {
 	}
 }
 
+// TestRecordBootRetryingOutlastsTransientFailure pins the production
+// lesson: the boot row must survive the startup write burst, so a
+// failed attempt retries instead of surrendering the deploy story.
+func TestRecordBootRetryingOutlastsTransientFailure(t *testing.T) {
+	j := newTestJournal(t)
+	ctx := context.Background()
+
+	// Happy path: lands on the first attempt.
+	j.recordBootRetrying(ctx, "v0.10.3", "abc", nil, 3, time.Millisecond)
+	boots, err := j.RecentBoots(ctx, 5)
+	if err != nil || len(boots) != 1 {
+		t.Fatalf("boots = %v (%v), want exactly one", boots, err)
+	}
+
+	// Bounded failure: a closed database never accepts the row, and the
+	// retry loop must exit on its budget rather than spin forever.
+	closed := newTestJournal(t)
+	// Closing the handle under the journal makes every attempt fail.
+	if err := closedDB(closed).Close(); err != nil {
+		t.Fatal(err)
+	}
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		closed.recordBootRetrying(ctx, "v0.10.3", "abc", nil, 3, time.Millisecond)
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("retry loop did not respect its attempt budget")
+	}
+}
+
+// closedDB exposes the journal's handle for the failure-path test.
+func closedDB(j *Journal) interface{ Close() error } { return j.db }
+
 // TestJournalBootRoundTrip covers the boot journal itself.
 func TestJournalBootRoundTrip(t *testing.T) {
 	j := newTestJournal(t)

--- a/internal/state/introspection/health_test.go
+++ b/internal/state/introspection/health_test.go
@@ -265,40 +265,87 @@ func TestRuntimeLampInformsWithoutJudging(t *testing.T) {
 }
 
 // TestRecordBootRetryingOutlastsTransientFailure pins the production
-// lesson: the boot row must survive the startup write burst, so a
-// failed attempt retries instead of surrendering the deploy story.
+// lesson: the boot row must survive the startup write burst. The
+// fail-then-succeed transition is the case that matters — early
+// attempts fail, the contention clears, and exactly one row lands,
+// carrying the instant the retrying STARTED rather than the instant
+// the write finally won.
 func TestRecordBootRetryingOutlastsTransientFailure(t *testing.T) {
 	j := newTestJournal(t)
 	ctx := context.Background()
 
-	// Happy path: lands on the first attempt.
-	j.recordBootRetrying(ctx, "v0.10.3", "abc", nil, 3, time.Millisecond)
-	boots, err := j.RecentBoots(ctx, 5)
-	if err != nil || len(boots) != 1 {
-		t.Fatalf("boots = %v (%v), want exactly one", boots, err)
+	// Manufacture a deterministic transient failure: capture the table's
+	// DDL, drop it (every insert now errors), and restore it mid-retry.
+	var ddl string
+	if err := j.db.QueryRowContext(ctx,
+		`SELECT sql FROM sqlite_master WHERE name = 'loop_events'`).Scan(&ddl); err != nil {
+		t.Fatalf("capture ddl: %v", err)
+	}
+	if _, err := j.db.ExecContext(ctx, `DROP TABLE loop_events`); err != nil {
+		t.Fatalf("drop: %v", err)
 	}
 
-	// Bounded failure: a closed database never accepts the row, and the
-	// retry loop must exit on its budget rather than spin forever.
-	closed := newTestJournal(t)
-	// Closing the handle under the journal makes every attempt fail.
-	if err := closedDB(closed).Close(); err != nil {
-		t.Fatal(err)
-	}
+	before := time.Now()
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		closed.recordBootRetrying(ctx, "v0.10.3", "abc", nil, 3, time.Millisecond)
+		j.recordBootRetrying(ctx, "v0.10.3", "abc", nil, 50, 20*time.Millisecond)
 	}()
+
+	// Let a few attempts fail before the "contention" clears.
+	time.Sleep(70 * time.Millisecond)
+	restoredAt := time.Now()
+	if _, err := j.db.ExecContext(ctx, ddl); err != nil {
+		t.Fatalf("restore: %v", err)
+	}
 	select {
 	case <-done:
 	case <-time.After(5 * time.Second):
+		t.Fatal("retry loop never recovered after the failure cleared")
+	}
+
+	boots, err := j.RecentBoots(ctx, 5)
+	if err != nil || len(boots) != 1 {
+		t.Fatalf("boots = %v (%v), want exactly one row after recovery", boots, err)
+	}
+	// The recorded instant is the boot, not the lock acquisition: it
+	// must predate the moment the table came back.
+	if boots[0].At.Before(before.Add(-time.Second)) || boots[0].At.After(restoredAt) {
+		t.Errorf("boot at = %v, want the retry start (before %v), not the eventual write time", boots[0].At, restoredAt)
+	}
+
+	// Bounded failure: a permanently dead database exhausts the attempt
+	// budget rather than spinning forever.
+	dead := newTestJournal(t)
+	if err := dead.db.Close(); err != nil {
+		t.Fatal(err)
+	}
+	deadDone := make(chan struct{})
+	go func() {
+		defer close(deadDone)
+		dead.recordBootRetrying(ctx, "v0.10.3", "abc", nil, 3, time.Millisecond)
+	}()
+	select {
+	case <-deadDone:
+	case <-time.After(5 * time.Second):
 		t.Fatal("retry loop did not respect its attempt budget")
 	}
-}
 
-// closedDB exposes the journal's handle for the failure-path test.
-func closedDB(j *Journal) interface{ Close() error } { return j.db }
+	// Window exhaustion: an expired deadline ends the loop even with
+	// attempts remaining (the production wrapper bounds lifetime this way).
+	expired, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
+	defer cancel()
+	windowDone := make(chan struct{})
+	go func() {
+		defer close(windowDone)
+		dead.recordBootRetrying(expired, "v0.10.3", "abc", nil, 1000, time.Millisecond)
+	}()
+	select {
+	case <-windowDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("retry loop ignored its window deadline")
+	}
+}
 
 // TestJournalBootRoundTrip covers the boot journal itself.
 func TestJournalBootRoundTrip(t *testing.T) {

--- a/internal/state/introspection/loop_events.go
+++ b/internal/state/introspection/loop_events.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"strings"
@@ -335,8 +336,16 @@ type BootRecord struct {
 
 // RecordBoot journals one process start with its build identity.
 func (j *Journal) RecordBoot(ctx context.Context, version, commit string) error {
+	return j.recordBootAt(ctx, time.Now(), version, commit)
+}
+
+// recordBootAt persists the boot row with an explicit instant, so a
+// retried record carries the time the process started rather than the
+// time the write finally won the lock — that instant feeds the deploy
+// boundary, the boot timeline, and the 24h count.
+func (j *Journal) recordBootAt(ctx context.Context, at time.Time, version, commit string) error {
 	return j.record(ctx, []LoopEvent{{
-		At:   time.Now(),
+		At:   at,
 		Kind: KindThaneBoot,
 		Detail: map[string]any{
 			"version": version,
@@ -349,31 +358,48 @@ func (j *Journal) RecordBoot(ctx context.Context, version, commit string) error 
 // logs.db — the log indexer is absorbing the startup burst, and on a
 // large database that contention can outlast the connection's 5s busy
 // timeout (observed in production on first deploy: SQLITE_BUSY on the
-// very row this journal exists to guarantee). Twenty attempts at 3s
-// spacing rides out a full minute of contention.
+// very row this journal exists to guarantee). Each failed attempt can
+// itself block for the busy timeout before the 3s wait, so the window
+// bounds the goroutine's true lifetime where the attempt count alone
+// would not.
 const (
 	bootRecordAttempts = 20
 	bootRecordSpacing  = 3 * time.Second
+	bootRecordWindow   = 3 * time.Minute
 )
 
 // RecordBootWithRetry journals the boot record from its own goroutine,
 // out-stubborning the startup write burst: it retries until the row
-// lands, the context ends, or the attempt budget is spent (warned — a
-// missing boot row silently breaks deploy detection, so giving up must
-// be loud). Called once from the app wiring as the recorder comes up.
+// lands, the retry window closes, or the attempt budget is spent —
+// either exhaustion is warned, because a missing boot row silently
+// breaks deploy detection, so giving up must be loud. The recorded
+// instant is captured before the first attempt, so a late-landing row
+// still says when the process started. Called once from the app wiring
+// as the recorder comes up.
 func (j *Journal) RecordBootWithRetry(ctx context.Context, version, commit string, logger *slog.Logger) {
-	go j.recordBootRetrying(ctx, version, commit, logger, bootRecordAttempts, bootRecordSpacing)
+	go func() {
+		retryCtx, cancel := context.WithTimeout(ctx, bootRecordWindow)
+		defer cancel()
+		j.recordBootRetrying(retryCtx, version, commit, logger, bootRecordAttempts, bootRecordSpacing)
+	}()
 }
 
 // recordBootRetrying is the synchronous body of RecordBootWithRetry,
-// with pacing injectable for tests.
+// with pacing injectable for tests. A deadline on ctx is the retry
+// window and its exhaustion warns; a plain cancellation is process
+// shutdown and exits quietly.
 func (j *Journal) recordBootRetrying(ctx context.Context, version, commit string, logger *slog.Logger, attempts int, spacing time.Duration) {
 	if logger == nil {
 		logger = slog.Default()
 	}
+	bootAt := time.Now()
+	surrender := func(lastErr error, attempt int) {
+		logger.Warn("boot record failed after retries; deploy detection will miss this boot",
+			"attempts", attempt, "error", lastErr)
+	}
 	var lastErr error
 	for attempt := 1; attempt <= attempts; attempt++ {
-		if err := j.RecordBoot(ctx, version, commit); err == nil {
+		if err := j.recordBootAt(ctx, bootAt, version, commit); err == nil {
 			if attempt > 1 {
 				logger.Info("boot record landed after retries", "attempts", attempt)
 			}
@@ -383,12 +409,14 @@ func (j *Journal) recordBootRetrying(ctx context.Context, version, commit string
 		}
 		select {
 		case <-ctx.Done():
+			if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+				surrender(lastErr, attempt)
+			}
 			return
 		case <-time.After(spacing):
 		}
 	}
-	logger.Warn("boot record failed after retries; deploy detection will miss this boot",
-		"attempts", attempts, "error", lastErr)
+	surrender(lastErr, attempts)
 }
 
 // RecentBoots returns the newest boot records, newest first, bounded by

--- a/internal/state/introspection/loop_events.go
+++ b/internal/state/introspection/loop_events.go
@@ -333,8 +333,7 @@ type BootRecord struct {
 	Commit  string
 }
 
-// RecordBoot journals one process start with its build identity. Called
-// once from the app wiring as the recorder comes up.
+// RecordBoot journals one process start with its build identity.
 func (j *Journal) RecordBoot(ctx context.Context, version, commit string) error {
 	return j.record(ctx, []LoopEvent{{
 		At:   time.Now(),
@@ -344,6 +343,52 @@ func (j *Journal) RecordBoot(ctx context.Context, version, commit string) error 
 			"commit":  commit,
 		},
 	}})
+}
+
+// Boot-record retry pacing. Boot is the single worst moment to write to
+// logs.db — the log indexer is absorbing the startup burst, and on a
+// large database that contention can outlast the connection's 5s busy
+// timeout (observed in production on first deploy: SQLITE_BUSY on the
+// very row this journal exists to guarantee). Twenty attempts at 3s
+// spacing rides out a full minute of contention.
+const (
+	bootRecordAttempts = 20
+	bootRecordSpacing  = 3 * time.Second
+)
+
+// RecordBootWithRetry journals the boot record from its own goroutine,
+// out-stubborning the startup write burst: it retries until the row
+// lands, the context ends, or the attempt budget is spent (warned — a
+// missing boot row silently breaks deploy detection, so giving up must
+// be loud). Called once from the app wiring as the recorder comes up.
+func (j *Journal) RecordBootWithRetry(ctx context.Context, version, commit string, logger *slog.Logger) {
+	go j.recordBootRetrying(ctx, version, commit, logger, bootRecordAttempts, bootRecordSpacing)
+}
+
+// recordBootRetrying is the synchronous body of RecordBootWithRetry,
+// with pacing injectable for tests.
+func (j *Journal) recordBootRetrying(ctx context.Context, version, commit string, logger *slog.Logger, attempts int, spacing time.Duration) {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	var lastErr error
+	for attempt := 1; attempt <= attempts; attempt++ {
+		if err := j.RecordBoot(ctx, version, commit); err == nil {
+			if attempt > 1 {
+				logger.Info("boot record landed after retries", "attempts", attempt)
+			}
+			return
+		} else {
+			lastErr = err
+		}
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(spacing):
+		}
+	}
+	logger.Warn("boot record failed after retries; deploy detection will miss this boot",
+		"attempts", attempts, "error", lastErr)
 }
 
 // RecentBoots returns the newest boot records, newest first, bounded by

--- a/internal/state/introspection/loop_events_recorder.go
+++ b/internal/state/introspection/loop_events_recorder.go
@@ -94,9 +94,16 @@ func NewRecorder(journal *Journal, bus *events.Bus, retention time.Duration, log
 	return &Recorder{journal: journal, bus: bus, retention: retention, logger: logger}
 }
 
+// recorderFirstPruneAfter delays the first prune past the startup write
+// burst: pruning fights the log indexer for the write lock at exactly
+// the moment the indexer is busiest, and a failed first prune is pure
+// noise — the daily tick covers the hygiene either way.
+const recorderFirstPruneAfter = 5 * time.Minute
+
 // Run consumes the bus until ctx is cancelled, flushing batches on
-// size or interval and pruning the journal daily. Run it in a
-// goroutine; it owns its subscription and unsubscribes on exit.
+// size or interval and pruning the journal daily (first prune deferred
+// past the startup burst). Run it in a goroutine; it owns its
+// subscription and unsubscribes on exit.
 func (r *Recorder) Run(ctx context.Context) {
 	ch := r.bus.Subscribe(recorderBufSize)
 	defer r.bus.Unsubscribe(ch)
@@ -105,6 +112,8 @@ func (r *Recorder) Run(ctx context.Context) {
 	defer flushTicker.Stop()
 	pruneTicker := time.NewTicker(recorderPruneEvery)
 	defer pruneTicker.Stop()
+	firstPrune := time.NewTimer(recorderFirstPruneAfter)
+	defer firstPrune.Stop()
 
 	batch := make([]LoopEvent, 0, recorderFlushCount)
 	flush := func() {
@@ -122,7 +131,6 @@ func (r *Recorder) Run(ctx context.Context) {
 		batch = batch[:0]
 	}
 
-	r.prune(ctx)
 	for {
 		select {
 		case <-ctx.Done():
@@ -137,6 +145,8 @@ func (r *Recorder) Run(ctx context.Context) {
 			}
 		case <-flushTicker.C:
 			flush()
+		case <-firstPrune.C:
+			r.prune(ctx)
 		case <-pruneTicker.C:
 			r.prune(ctx)
 		}


### PR DESCRIPTION
Found live within minutes of prod's first deploy of the #1341/#1350 work, which is exactly what the machinery was for — except the finding was about the machinery itself. The journal recorded 1003 loop events flawlessly, but the one row the deploy story depends on was missing: `boot record failed: database is locked (SQLITE_BUSY)`, and the recorder's initial prune failed the same way seconds later.

The cause is timing, not configuration. `database.Open` does set a 5-second busy timeout, but boot is the single worst moment to write to logs.db — the log indexer is absorbing the startup burst, and on production's 5.9 GB database that contention outlasted five full seconds. The recorder's *batched* writes all succeeded because batching retries by nature every two seconds; the two one-shot writes fired once at peak contention and surrendered. The sandbox smoke test couldn't have caught it: a fresh logs.db has no burst to lose to.

The fix makes the boot record as stubborn as its purpose requires: `RecordBootWithRetry` runs from its own goroutine (never delaying startup of subsequent workers) and retries up to twenty times at three-second spacing — a full minute — logging recovery when it lands late, and warning loudly on surrender, because a silently missing boot row breaks deploy detection for the whole version window. The recorder's first prune moves from boot to five minutes in: it was fighting the indexer for the write lock at exactly the wrong moment, and a failed first prune is pure noise the daily tick covers anyway.

## Test plan
- [x] Retry body lands the row on first attempt (happy path)
- [x] Bounded failure: a dead database exhausts the attempt budget and exits rather than spinning
- [x] Recorder loop restructure (deferred first prune) leaves the existing end-to-end recorder test green
- [x] `just ci` green

Refs #1341

🤖 Generated with [Claude Code](https://claude.com/claude-code)