### PR TITLE
feat(introspection): the process's own complaints reach the panel

### DIFF
--- a/internal/app/new_introspection.go
+++ b/internal/app/new_introspection.go
@@ -117,6 +117,7 @@ func (a *App) initInspector() {
 	}
 	if a.indexHandler != nil {
 		src.IndexStats = a.indexHandler.Stats
+		src.LogSeverity = a.indexHandler.SeveritySnapshot
 	}
 	if a.syncRegistry != nil {
 		src.SyncStates = a.syncRegistry.All

--- a/internal/platform/logging/indexer.go
+++ b/internal/platform/logging/indexer.go
@@ -68,6 +68,118 @@ type indexShared struct {
 	once        sync.Once    // guards Close
 	dropped     atomic.Uint64
 	writeErrors atomic.Uint64
+
+	// Severity tally: ambient awareness of WARN-and-worse records,
+	// kept in memory at the Handle seam so surfacing "the process has
+	// been complaining" never costs a query against the multi-GB index
+	// those records land in. Guarded by sevMu; see SeveritySnapshot.
+	sevMu      sync.Mutex
+	sevWarns   uint64
+	sevErrors  uint64
+	sevBuckets [severityBucketCount]severityBucket
+	sevRing    []SeverityRecord // newest last, capped at severityRingCap
+}
+
+// severityBucket is one minute of WARN/ERROR counts in the rolling
+// hour window. Minute is the unix-minute the bucket currently holds;
+// a write into a bucket from a different minute resets it, so stale
+// buckets age out lazily without a ticker.
+type severityBucket struct {
+	minute int64
+	warns  uint32
+	errors uint32
+}
+
+const (
+	severityBucketCount = 60
+	severityRingCap     = 48
+	severityMsgMaxRunes = 200
+)
+
+// SeverityRecord is one retained WARN-or-worse record, projected for
+// ambient display: when, how bad, where from, and what it said.
+type SeverityRecord struct {
+	At     time.Time
+	Level  string
+	Source string // loop name or subsystem when the record carried one
+	Msg    string
+}
+
+// SeveritySummary tallies WARN-and-worse records since boot and over
+// the trailing hour, with the newest samples. It is the push-side
+// companion to logs_query: rates and samples for ambient perception,
+// the index for drill-down.
+type SeveritySummary struct {
+	WarnsSinceBoot  uint64
+	ErrorsSinceBoot uint64
+	WarnsLastHour   int
+	ErrorsLastHour  int
+	Recent          []SeverityRecord // newest first
+}
+
+// noteSeverity records one WARN-or-worse entry into the tally.
+func (s *indexShared) noteSeverity(entry indexEntry, level slog.Level) {
+	rec := SeverityRecord{At: entry.Timestamp, Level: entry.Level, Msg: entry.Msg}
+	if runes := []rune(rec.Msg); len(runes) > severityMsgMaxRunes {
+		rec.Msg = string(runes[:severityMsgMaxRunes]) + "…"
+	}
+	if entry.LoopName != "" {
+		rec.Source = entry.LoopName
+	} else if entry.Subsystem != "" {
+		rec.Source = entry.Subsystem
+	}
+	minute := entry.Timestamp.Unix() / 60
+	idx := minute % severityBucketCount
+	if idx < 0 {
+		idx += severityBucketCount
+	}
+
+	s.sevMu.Lock()
+	defer s.sevMu.Unlock()
+	bucket := &s.sevBuckets[idx]
+	if bucket.minute != minute {
+		*bucket = severityBucket{minute: minute}
+	}
+	if level >= slog.LevelError {
+		s.sevErrors++
+		bucket.errors++
+	} else {
+		s.sevWarns++
+		bucket.warns++
+	}
+	s.sevRing = append(s.sevRing, rec)
+	if len(s.sevRing) > severityRingCap {
+		s.sevRing = s.sevRing[len(s.sevRing)-severityRingCap:]
+	}
+}
+
+// SeveritySnapshot returns the current severity tally. Nil-safe; the
+// trailing-hour counts are computed from the minute buckets as of now,
+// so a quiet hour reads zero even though the boot totals persist.
+func (h *IndexHandler) SeveritySnapshot() SeveritySummary {
+	if h == nil || h.shared == nil {
+		return SeveritySummary{}
+	}
+	s := h.shared
+	nowMinute := time.Now().Unix() / 60
+
+	s.sevMu.Lock()
+	defer s.sevMu.Unlock()
+	sum := SeveritySummary{
+		WarnsSinceBoot:  s.sevWarns,
+		ErrorsSinceBoot: s.sevErrors,
+	}
+	for _, bucket := range s.sevBuckets {
+		if bucket.minute > 0 && nowMinute-bucket.minute < severityBucketCount {
+			sum.WarnsLastHour += int(bucket.warns)
+			sum.ErrorsLastHour += int(bucket.errors)
+		}
+	}
+	sum.Recent = make([]SeverityRecord, len(s.sevRing))
+	for i, rec := range s.sevRing {
+		sum.Recent[len(s.sevRing)-1-i] = rec
+	}
+	return sum
 }
 
 // indexEntry is the set of fields written to SQLite for one log record.
@@ -163,6 +275,14 @@ func (h *IndexHandler) Handle(ctx context.Context, r slog.Record) error {
 	if len(extras) > 0 {
 		b, _ := json.Marshal(extras)
 		entry.Attrs = string(b)
+	}
+
+	// Tally WARN-and-worse for ambient severity awareness, after attr
+	// classification so the record's loop/subsystem attribution rides
+	// along. Independent of the async index path: a dropped index write
+	// must not also lose the tally.
+	if r.Level >= slog.LevelWarn {
+		h.shared.noteSeverity(entry, r.Level)
 	}
 
 	// Non-blocking send under a read lock so Close() cannot close the

--- a/internal/platform/logging/indexer_test.go
+++ b/internal/platform/logging/indexer_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"strings"
 	"testing"
 	"time"
 
@@ -962,5 +963,73 @@ func TestQueryBySession(t *testing.T) {
 	}
 	if len(entries) != 0 {
 		t.Errorf("unknown session: got %d entries, want 0", len(entries))
+	}
+}
+
+// TestIndexHandlerSeverityTally pins the ambient severity tally: WARN
+// and worse are counted since boot and per trailing hour, the ring
+// keeps newest-first samples with loop/subsystem attribution, and INFO
+// never registers. All in-memory — the point is that ambient severity
+// awareness costs no query against the index.
+func TestIndexHandlerSeverityTally(t *testing.T) {
+	db := openTestDB(t)
+	inner := slog.NewJSONHandler(discardWriter{}, &slog.HandlerOptions{Level: slog.LevelDebug})
+	h := NewIndexHandler(inner, db)
+	defer h.Close()
+
+	logger := slog.New(h)
+	logger.Info("routine chatter", "subsystem", "email")
+	logger.Warn("retention degraded", "subsystem", "logging")
+	logger.Error("probe exploded", "loop_name", "archivist")
+	logger.Warn("second complaint", "subsystem", "mqtt")
+
+	sum := h.SeveritySnapshot()
+	if sum.WarnsSinceBoot != 2 || sum.ErrorsSinceBoot != 1 {
+		t.Errorf("since-boot = %d warns / %d errors, want 2/1", sum.WarnsSinceBoot, sum.ErrorsSinceBoot)
+	}
+	if sum.WarnsLastHour != 2 || sum.ErrorsLastHour != 1 {
+		t.Errorf("last-hour = %d warns / %d errors, want 2/1", sum.WarnsLastHour, sum.ErrorsLastHour)
+	}
+	if len(sum.Recent) != 3 {
+		t.Fatalf("recent = %d samples, want 3 (INFO must not register)", len(sum.Recent))
+	}
+	// Newest first, with attribution: the loop name wins over subsystem
+	// when both concepts exist on a record.
+	if sum.Recent[0].Msg != "second complaint" || sum.Recent[0].Level != "WARN" || sum.Recent[0].Source != "mqtt" {
+		t.Errorf("recent[0] = %+v, want the newest warn from mqtt", sum.Recent[0])
+	}
+	if sum.Recent[1].Msg != "probe exploded" || sum.Recent[1].Source != "archivist" {
+		t.Errorf("recent[1] = %+v, want the archivist error", sum.Recent[1])
+	}
+
+	// Nil-safety mirrors Stats().
+	var nilH *IndexHandler
+	if got := nilH.SeveritySnapshot(); got.WarnsSinceBoot != 0 || len(got.Recent) != 0 {
+		t.Errorf("nil handler snapshot = %+v, want zero", got)
+	}
+}
+
+// TestSeverityRingCapsAndTruncates: the ring keeps the newest records
+// past the cap, and pathological messages are rune-truncated.
+func TestSeverityRingCapsAndTruncates(t *testing.T) {
+	db := openTestDB(t)
+	inner := slog.NewJSONHandler(discardWriter{}, nil)
+	h := NewIndexHandler(inner, db)
+	defer h.Close()
+
+	logger := slog.New(h)
+	long := strings.Repeat("x", severityMsgMaxRunes+50)
+	for i := 0; i < severityRingCap+10; i++ {
+		logger.Warn(fmt.Sprintf("warn-%03d %s", i, long))
+	}
+	sum := h.SeveritySnapshot()
+	if len(sum.Recent) != severityRingCap {
+		t.Fatalf("ring = %d, want the cap %d", len(sum.Recent), severityRingCap)
+	}
+	if !strings.HasPrefix(sum.Recent[0].Msg, fmt.Sprintf("warn-%03d", severityRingCap+9)) {
+		t.Errorf("recent[0] = %q, want the newest warn", sum.Recent[0].Msg)
+	}
+	if len([]rune(sum.Recent[0].Msg)) > severityMsgMaxRunes+1 {
+		t.Errorf("message not truncated: %d runes", len([]rune(sum.Recent[0].Msg)))
 	}
 }

--- a/internal/state/introspection/health.go
+++ b/internal/state/introspection/health.go
@@ -133,12 +133,36 @@ type BootView struct {
 // maxRecentBootViews caps the boot tail on the snapshot.
 const maxRecentBootViews = 5
 
+// LogActivity is the process's own complaint stream, precomputed:
+// WARN-and-worse rates plus the newest samples. Data, not verdict — a
+// dozen warnings during a deploy and a dozen during a quiet afternoon
+// mean different things, and the reader has the context.
+type LogActivity struct {
+	ErrorsLastHour  int         `json:"errors_last_hour"`
+	WarnsLastHour   int         `json:"warns_last_hour"`
+	ErrorsSinceBoot uint64      `json:"errors_since_boot"`
+	WarnsSinceBoot  uint64      `json:"warns_since_boot"`
+	Recent          []LogSample `json:"recent,omitempty"`
+}
+
+// LogSample is one recent WARN-or-worse record, delta-formatted.
+type LogSample struct {
+	Delta  string `json:"delta"`
+	Level  string `json:"level"`
+	Source string `json:"source,omitempty"`
+	Msg    string `json:"msg"`
+}
+
+// maxLogSamples caps the recent-sample list on the snapshot.
+const maxLogSamples = 6
+
 // HealthSnapshot is the whole annunciator panel in one shape, consumed
 // identically by the system_health tool and the metacog context panel
 // so the two can never drift.
 type HealthSnapshot struct {
 	Annunciator []HealthRow     `json:"annunciator"`
 	Version     VersionInfo     `json:"version"`
+	LogActivity LogActivity     `json:"log_activity"`
 	Host        HostInfo        `json:"host"`
 	Loops       LoopCensus      `json:"loops"`
 	Queues      []QueueDepth    `json:"queues,omitempty"`
@@ -172,6 +196,8 @@ type HealthSources struct {
 	BusDropped func() uint64
 	// IndexStats reports log-index loss counters.
 	IndexStats func() logging.IndexStats
+	// LogSeverity reports the WARN-and-worse tally and recent samples.
+	LogSeverity func() logging.SeveritySummary
 	// SyncStates reports document-root remote sync state.
 	SyncStates func() []checkout.SyncState
 	// QueueStats reports live work-queue backlog per partition.
@@ -365,6 +391,27 @@ func (i *Inspector) Health(ctx context.Context) HealthSnapshot {
 		snap.Annunciator = append(snap.Annunciator, HealthRow{
 			Name: "runtime", Status: HealthOK, Detail: detail,
 		})
+	}
+
+	if i.src.LogSeverity != nil {
+		sev := i.src.LogSeverity()
+		snap.LogActivity = LogActivity{
+			ErrorsLastHour:  sev.ErrorsLastHour,
+			WarnsLastHour:   sev.WarnsLastHour,
+			ErrorsSinceBoot: sev.ErrorsSinceBoot,
+			WarnsSinceBoot:  sev.WarnsSinceBoot,
+		}
+		for _, rec := range sev.Recent {
+			if len(snap.LogActivity.Recent) >= maxLogSamples {
+				break
+			}
+			snap.LogActivity.Recent = append(snap.LogActivity.Recent, LogSample{
+				Delta:  promptfmt.FormatDeltaOnly(rec.At, now),
+				Level:  rec.Level,
+				Source: rec.Source,
+				Msg:    rec.Msg,
+			})
+		}
 	}
 
 	snap.Host = collectHostInfo(i.src.DataDir, i.src.StartedAt, now)

--- a/internal/state/introspection/health.go
+++ b/internal/state/introspection/health.go
@@ -147,10 +147,10 @@ type LogActivity struct {
 
 // LogSample is one recent WARN-or-worse record, delta-formatted.
 type LogSample struct {
-	Delta  string `json:"delta"`
-	Level  string `json:"level"`
-	Source string `json:"source,omitempty"`
-	Msg    string `json:"msg"`
+	AtDelta string `json:"at_delta"`
+	Level   string `json:"level"`
+	Source  string `json:"source,omitempty"`
+	Msg     string `json:"msg"`
 }
 
 // maxLogSamples caps the recent-sample list on the snapshot.
@@ -406,10 +406,10 @@ func (i *Inspector) Health(ctx context.Context) HealthSnapshot {
 				break
 			}
 			snap.LogActivity.Recent = append(snap.LogActivity.Recent, LogSample{
-				Delta:  promptfmt.FormatDeltaOnly(rec.At, now),
-				Level:  rec.Level,
-				Source: rec.Source,
-				Msg:    rec.Msg,
+				AtDelta: promptfmt.FormatDeltaOnly(rec.At, now),
+				Level:   rec.Level,
+				Source:  rec.Source,
+				Msg:     rec.Msg,
 			})
 		}
 	}

--- a/internal/state/introspection/health_test.go
+++ b/internal/state/introspection/health_test.go
@@ -205,7 +205,7 @@ func TestLogActivityRidesTheSnapshot(t *testing.T) {
 	if len(la.Recent) != maxLogSamples {
 		t.Fatalf("samples = %d, want capped at %d", len(la.Recent), maxLogSamples)
 	}
-	if la.Recent[0].Delta != "-60s" || la.Recent[0].Source != "mqtt" || la.Recent[0].Msg != "complaint 0" {
+	if la.Recent[0].AtDelta != "-60s" || la.Recent[0].Source != "mqtt" || la.Recent[0].Msg != "complaint 0" {
 		t.Errorf("samples[0] = %+v, want the newest delta-formatted", la.Recent[0])
 	}
 }

--- a/internal/state/introspection/health_test.go
+++ b/internal/state/introspection/health_test.go
@@ -2,6 +2,7 @@ package introspection
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -172,6 +173,41 @@ func TestInspectorHealthDegradedStates(t *testing.T) {
 			t.Errorf("empty sources produced rows: %+v", snap.Annunciator)
 		}
 	})
+}
+
+// TestLogActivityRidesTheSnapshot: the severity tally lands on the
+// snapshot delta-formatted and sample-capped — data for the panel and
+// system_health, with no judged lamp attached.
+func TestLogActivityRidesTheSnapshot(t *testing.T) {
+	now := time.Date(2026, 8, 11, 12, 0, 0, 0, time.UTC)
+	var recent []logging.SeverityRecord
+	for i := range maxLogSamples + 4 {
+		recent = append(recent, logging.SeverityRecord{
+			At: now.Add(-time.Duration(i+1) * time.Minute), Level: "WARN",
+			Source: "mqtt", Msg: fmt.Sprintf("complaint %d", i),
+		})
+	}
+	insp := NewInspector(HealthSources{
+		LogSeverity: func() logging.SeveritySummary {
+			return logging.SeveritySummary{
+				WarnsSinceBoot: 40, ErrorsSinceBoot: 3,
+				WarnsLastHour: 12, ErrorsLastHour: 1,
+				Recent: recent,
+			}
+		},
+	})
+	insp.now = func() time.Time { return now }
+
+	la := insp.Health(context.Background()).LogActivity
+	if la.WarnsLastHour != 12 || la.ErrorsSinceBoot != 3 {
+		t.Errorf("rates = %+v", la)
+	}
+	if len(la.Recent) != maxLogSamples {
+		t.Fatalf("samples = %d, want capped at %d", len(la.Recent), maxLogSamples)
+	}
+	if la.Recent[0].Delta != "-60s" || la.Recent[0].Source != "mqtt" || la.Recent[0].Msg != "complaint 0" {
+		t.Errorf("samples[0] = %+v, want the newest delta-formatted", la.Recent[0])
+	}
 }
 
 // TestVersionInfoComputesTheDeployStory pins the mechanical deploy

--- a/internal/state/introspection/panel.go
+++ b/internal/state/introspection/panel.go
@@ -95,11 +95,12 @@ func (p *PanelProvider) TagContext(ctx context.Context, _ agentctx.ContextReques
 	snap := p.inspector.Health(ctx)
 
 	payload := map[string]any{
-		"annunciator": snap.Annunciator,
-		"version":     snap.Version,
-		"host":        snap.Host,
-		"loops":       snap.Loops,
-		"telemetry":   snap.Telemetry,
+		"annunciator":  snap.Annunciator,
+		"version":      snap.Version,
+		"log_activity": snap.LogActivity,
+		"host":         snap.Host,
+		"loops":        snap.Loops,
+		"telemetry":    snap.Telemetry,
 	}
 	if len(snap.Queues) > 0 {
 		payload["queues"] = snap.Queues

--- a/loops/metacognitive.md
+++ b/loops/metacognitive.md
@@ -81,7 +81,8 @@ more.
 The "Internal Operations Panel" block in your context is refreshed
 every iteration: the subsystem annunciator (each row ok, degraded, or
 failed, with the reason precomputed), the loop census with its busiest
-wakers, work-queue depths, flagged runaway documents, host vitals, and
+wakers, work-queue depths, flagged runaway documents, host vitals, the
+process's own recent warnings and errors with their hourly rates, and
 the day's request/error/latency rollup. Read it first. It costs you
 nothing and it is the same data the drill-down tools return, so
 anything alarming in the panel can be investigated without re-checking

--- a/talents/diagnostics.md
+++ b/talents/diagnostics.md
@@ -50,9 +50,10 @@ document already carries the read family without any tag).
 
 `logs_query` and `cost_summary` carry the receipts: failure evidence
 scoped by loop, subsystem, or request, and spend grouped by model,
-provider, or task. Reach for them when a finding needs evidence, not as
-the first sweep — the annunciator and the two loop views almost always
-localize the problem faster.
+provider, or task. The `system_health` snapshot already surfaces the
+newest warnings and errors with their hourly rates, so reach for
+`logs_query` when a sample there needs its full story — not as the
+first sweep.
 
 Version boundaries are diagnostic events in their own right, and
 `system_health` precomputes the deploy story: running vs previous


### PR DESCRIPTION
Production observation after the #1341 deploy: thane emits WARN- and ERROR-level records that flow into logs.db where `logs_query` can pull them — but nothing surfaces them ambiently, so metacog only learns the process has been complaining if it happens to ask. For the loop whose whole mandate is noticing, the process's own complaint stream was a blind spot.

The tally lives at the one seam every slog record already crosses — the index handler's `Handle` — as pure in-memory state: since-boot counters, a rolling per-minute hour window (lazy bucket reset, no ticker), and a newest-first ring of 48 samples carrying each record's loop/subsystem attribution and rune-capped message. In-memory is the point: ambient severity awareness must never cost a query against the multi-GB index those records land in (the same 5.9 GB table that ate the boot record in #1353). The tally is also independent of the async index path, so a dropped index write cannot lose the count.

`HealthSnapshot` gains `log_activity` — hourly rates, boot totals, and the six newest samples delta-formatted — rendered identically by the metacog panel and `system_health`. Per the data-not-verdict doctrine from the boot-pattern discussion, there is deliberately no judged lamp: a dozen warnings during a deploy and a dozen during a quiet afternoon mean different things, and the reader has the baselines. The mandate's perception list names the stream, and the diagnostics talent re-routes `logs_query` to drill-down duty now that the first sweep is ambient.

## Test plan
- [x] Handler tally end-to-end through a real slog pipeline: INFO ignored, WARN/ERROR counted, newest-first ring with loop-over-subsystem attribution, nil-safety
- [x] Ring caps at 48 keeping newest; messages rune-truncated
- [x] Snapshot projection: delta-formatted, sample-capped, rates carried
- [x] Boot-parity, embedded-mirror, and talent gates green after `just generate`
- [x] `just ci` green

Refs #1341

🤖 Generated with [Claude Code](https://claude.com/claude-code)