### PR TITLE
fix(introspection): the census stops inviting metacog's first misread

### DIFF
--- a/internal/runtime/loop/loop_view.go
+++ b/internal/runtime/loop/loop_view.go
@@ -80,8 +80,12 @@ type LoopView struct {
 	LastSleepPlanned *string `json:"last_sleep_planned"`
 	// WakesLast24h is how many iterations began in the trailing day,
 	// counting the one in flight — the cadence actually achieved, as
-	// against the SleepEnvelope's permitted one.
-	WakesLast24h *int `json:"wakes_last_24h"`
+	// against the SleepEnvelope's permitted one. WakeWindow qualifies
+	// it: the ring is in-memory, so a loop younger than a day has only
+	// been counted for its lifetime, and the window says so rather than
+	// letting the count imply a full day's coverage.
+	WakesLast24h *int    `json:"wakes_last_24h"`
+	WakeWindow   *string `json:"wake_window,omitempty"`
 	// LastWakeReason attributes the most recent iteration start (timer,
 	// mailbox, subscription, manual, ...), and LastWakeSource names the
 	// sender when the wake carried one. Null before the first iteration
@@ -427,6 +431,12 @@ func applyLiveTelemetry(v *LoopView, s Status, now time.Time) {
 	}
 	wakes := s.WakesLast24h
 	v.WakesLast24h = &wakes
+	if !s.StartedAt.IsZero() {
+		if up := now.Sub(s.StartedAt); up > 0 && up < wakeHistoryWindow {
+			window := promptfmt.FormatDuration(up.Round(time.Second))
+			v.WakeWindow = &window
+		}
+	}
 	if s.LastWakeReason != "" {
 		reason := string(s.LastWakeReason)
 		v.LastWakeReason = &reason

--- a/internal/runtime/loop/loop_view_test.go
+++ b/internal/runtime/loop/loop_view_test.go
@@ -436,6 +436,32 @@ func TestLoopViewResolver_FromStatus_WakeAttribution(t *testing.T) {
 	}
 }
 
+// TestLoopViewResolver_FromStatus_WakeWindowHonesty: a loop younger
+// than the wake ring's day-long span reports the window its count
+// actually covers; a mature loop omits it, meaning the full day.
+func TestLoopViewResolver_FromStatus_WakeWindowHonesty(t *testing.T) {
+	now := time.Date(2026, 8, 11, 12, 0, 0, 0, time.UTC)
+	r := NewLoopViewResolver(nil, nil, now)
+
+	young := r.FromStatus(Status{
+		ID: "lp_y", Name: "young", State: State("sleeping"),
+		StartedAt: now.Add(-8 * time.Minute),
+		Config:    Config{Operation: OperationService},
+	})
+	if young.WakeWindow == nil || *young.WakeWindow != "8m" {
+		t.Errorf("young wake_window = %v, want 8m", young.WakeWindow)
+	}
+
+	mature := r.FromStatus(Status{
+		ID: "lp_m", Name: "mature", State: State("sleeping"),
+		StartedAt: now.Add(-48 * time.Hour),
+		Config:    Config{Operation: OperationService},
+	})
+	if mature.WakeWindow != nil {
+		t.Errorf("mature wake_window = %v, want omitted (full day)", mature.WakeWindow)
+	}
+}
+
 // TestLoopViewResolver_FromStatus_SupervisorRecencyInBothUnits pins the
 // pair: turns-back answers "has my recent work been reviewed", time-ago
 // answers "how long since" — different questions on a loop whose interval

--- a/internal/state/introspection/health.go
+++ b/internal/state/introspection/health.go
@@ -375,13 +375,18 @@ func (i *Inspector) Health(ctx context.Context) HealthSnapshot {
 		statuses := i.src.LoopStatuses()
 		snap.Loops = buildLoopCensus(statuses)
 		// Honest window: the in-memory wake ring only spans the uptime.
-		wakeWindow := 24 * time.Hour
+		// With no usable start time the window is unknown, and unknown
+		// is omitted — claiming "24h" there would be the same lie this
+		// field exists to prevent.
 		if !i.src.StartedAt.IsZero() {
-			if up := now.Sub(i.src.StartedAt); up > 0 && up < wakeWindow {
-				wakeWindow = up.Round(time.Second)
+			if up := now.Sub(i.src.StartedAt); up > 0 {
+				wakeWindow := 24 * time.Hour
+				if up < wakeWindow {
+					wakeWindow = up.Round(time.Second)
+				}
+				snap.Loops.WakeWindow = promptfmt.FormatDuration(wakeWindow)
 			}
 		}
-		snap.Loops.WakeWindow = promptfmt.FormatDuration(wakeWindow)
 		row := HealthRow{Name: "loops", Status: HealthOK,
 			Detail: fmt.Sprintf("%d loops in the fleet, none degraded", snap.Loops.Total)}
 		if snap.Loops.Degraded > 0 {

--- a/internal/state/introspection/health.go
+++ b/internal/state/introspection/health.go
@@ -62,10 +62,19 @@ type LoopCensus struct {
 	Degraded          int            `json:"degraded"`
 	DegradedLoops     []string       `json:"degraded_loops,omitempty"`
 	DegradedTruncated bool           `json:"degraded_truncated,omitempty"`
-	// TopWakers ranks loops by trailing-day iteration starts, busiest
-	// first. An outlier here against its usual rate is the wake-storm
-	// signal; loop_activity decomposes the why.
+	// TopWakers ranks loops by trailing-window iteration starts,
+	// busiest first. An outlier here against its usual rate is the
+	// wake-storm signal; loop_activity decomposes the why. Handler-only
+	// loops are excluded: a poller waking per event runs no model turn,
+	// and its counts would drown the cognitive loops this ranking
+	// exists to watch (production metacog misread exactly that on day
+	// one). Pollers stay visible in loop_status.
 	TopWakers []LoopWakeRate `json:"top_wakers,omitempty"`
+	// WakeWindow is the span the wake counts actually cover. The wake
+	// ring is in-memory, so after a restart the "trailing day" is only
+	// as long as the uptime — the field says so rather than letting the
+	// counts imply coverage they lack.
+	WakeWindow string `json:"wake_window,omitempty"`
 }
 
 // LoopWakeRate is one loop's achieved trailing-day cadence.
@@ -365,6 +374,14 @@ func (i *Inspector) Health(ctx context.Context) HealthSnapshot {
 	if i.src.LoopStatuses != nil {
 		statuses := i.src.LoopStatuses()
 		snap.Loops = buildLoopCensus(statuses)
+		// Honest window: the in-memory wake ring only spans the uptime.
+		wakeWindow := 24 * time.Hour
+		if !i.src.StartedAt.IsZero() {
+			if up := now.Sub(i.src.StartedAt); up > 0 && up < wakeWindow {
+				wakeWindow = up.Round(time.Second)
+			}
+		}
+		snap.Loops.WakeWindow = promptfmt.FormatDuration(wakeWindow)
 		row := HealthRow{Name: "loops", Status: HealthOK,
 			Detail: fmt.Sprintf("%d loops in the fleet, none degraded", snap.Loops.Total)}
 		if snap.Loops.Degraded > 0 {
@@ -535,7 +552,7 @@ func buildLoopCensus(statuses []looppkg.Status) LoopCensus {
 				census.DegradedTruncated = true
 			}
 		}
-		if st.WakesLast24h > 0 {
+		if st.WakesLast24h > 0 && !st.HandlerOnly {
 			census.TopWakers = append(census.TopWakers, LoopWakeRate{Name: st.Name, WakesLast24h: st.WakesLast24h})
 		}
 	}

--- a/internal/state/introspection/health_test.go
+++ b/internal/state/introspection/health_test.go
@@ -418,6 +418,10 @@ func TestLoopCensusTopWakersOrderAndCap(t *testing.T) {
 		{Name: "ticker", WakesLast24h: 7},
 		{Name: "pinger", WakesLast24h: 6},
 		{Name: "extra", WakesLast24h: 1},
+		// A handler poller wakes per event with no model turn; its count
+		// would bury every cognitive loop (prod's ha-state-watcher hit
+		// 459 in eight minutes and metacog misread it as a storm).
+		{Name: "ha-state-watcher", WakesLast24h: 459, HandlerOnly: true},
 	}
 	census := buildLoopCensus(statuses)
 
@@ -440,5 +444,32 @@ func TestLoopCensusTopWakersOrderAndCap(t *testing.T) {
 		if w.Name == "quiet" {
 			t.Errorf("zero-wake loop must not appear in top wakers")
 		}
+		if w.Name == "ha-state-watcher" {
+			t.Errorf("handler-only poller must not appear in top wakers")
+		}
+	}
+}
+
+// TestCensusWakeWindowIsHonest: after a restart the in-memory wake ring
+// only spans the uptime, and the census says so instead of letting the
+// counts imply a full day's coverage.
+func TestCensusWakeWindowIsHonest(t *testing.T) {
+	now := time.Date(2026, 8, 11, 12, 0, 0, 0, time.UTC)
+	young := NewInspector(HealthSources{
+		LoopStatuses: func() []looppkg.Status { return []looppkg.Status{{Name: "core"}} },
+		StartedAt:    now.Add(-8 * time.Minute),
+	})
+	young.now = func() time.Time { return now }
+	if got := young.Health(context.Background()).Loops.WakeWindow; got != "8m" {
+		t.Errorf("young wake_window = %q, want 8m", got)
+	}
+
+	mature := NewInspector(HealthSources{
+		LoopStatuses: func() []looppkg.Status { return []looppkg.Status{{Name: "core"}} },
+		StartedAt:    now.Add(-72 * time.Hour),
+	})
+	mature.now = func() time.Time { return now }
+	if got := mature.Health(context.Background()).Loops.WakeWindow; got != "24h" {
+		t.Errorf("mature wake_window = %q, want 24h", got)
 	}
 }

--- a/internal/state/introspection/health_test.go
+++ b/internal/state/introspection/health_test.go
@@ -472,4 +472,14 @@ func TestCensusWakeWindowIsHonest(t *testing.T) {
 	if got := mature.Health(context.Background()).Loops.WakeWindow; got != "24h" {
 		t.Errorf("mature wake_window = %q, want 24h", got)
 	}
+
+	// Unknown start time means unknown window — omitted, never a
+	// claimed "24h".
+	unwired := NewInspector(HealthSources{
+		LoopStatuses: func() []looppkg.Status { return []looppkg.Status{{Name: "core"}} },
+	})
+	unwired.now = func() time.Time { return now }
+	if got := unwired.Health(context.Background()).Loops.WakeWindow; got != "" {
+		t.Errorf("unwired wake_window = %q, want omitted", got)
+	}
 }


### PR DESCRIPTION
Production metacog's first durable state document (day one of the #1341 mandate) contained a confident and entirely wrong theory: ha-state-watcher's 459 wakes were 'inflated by the recent restart; treat counts within the first ~10 minutes of uptime as provisional.' The truth ran the other way. ha-state-watcher is a handler-only poller that wakes per HA event and runs no model turn — 459 wakes in eight minutes is its normal operating rate — and the distortion was that `wakes_last_24h` had been counting for eight minutes while its name promised a day, because the wake ring is in-memory and dies at restart. Handed a number claiming coverage it lacked, the model did the reasonable thing and invented a mechanism. That is the exact failure mode this surface exists to prevent, caught by its very first consumer.

Two fixes, both data-honesty rather than judgment. `TopWakers` now excludes handler-only loops: their counts are meaningless for wake-storm judgment (no model cost), and one poller buries every cognitive loop the ranking exists to watch — they remain fully visible in `loop_status`. And the wake counts now carry their true span: the census gains `wake_window` (process uptime capped at the day), and the per-loop `LoopView` row gains the same from its own start time, so a young loop's count reads as 'over 8m' instead of implying a day's coverage. Omitted when the window is genuinely the full day.

Stacked on #1354 (both touch the census). Refs #1341.

## Test plan
- [x] Handler-only poller with 459 wakes excluded from TopWakers; cognitive ordering unchanged
- [x] Census wake_window: '8m' at eight minutes uptime, '24h' once mature
- [x] LoopView wake_window: present for a young loop, omitted at full coverage
- [x] `just ci` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)