### PR TITLE
fix(documents): fold tokenizer space artifacts at the write chokepoint

### DIFF
--- a/internal/state/documents/activity_test.go
+++ b/internal/state/documents/activity_test.go
@@ -67,6 +67,41 @@ func newActivityStore(t *testing.T, files map[string]string, reviser RootReviser
 	return store
 }
 
+// TestWriteNormalizesSpaceArtifacts pins the tokenizer-artifact fold:
+// the non-breaking space variants gpt-oss emits (U+202F, U+00A0) are
+// stored as plain spaces on every mutation path, so alternating
+// authors cannot churn invisible diffs or break text search.
+func TestWriteNormalizesSpaceArtifacts(t *testing.T) {
+	store := newActivityStore(t, map[string]string{"state.md": "# state\n"}, nil)
+	ctx := t.Context()
+
+	body := "wakes\u202fper\u00a0day: 4\u202f-\u202f6"
+	if _, err := store.Write(ctx, WriteArgs{Ref: "self:state.md", Body: &body}); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	rec, err := store.Read(ctx, "self:state.md")
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if strings.ContainsAny(rec.Body, "\u00a0\u202f") {
+		t.Errorf("stored body retains space artifacts: %q", rec.Body)
+	}
+	if !strings.Contains(rec.Body, "wakes per day: 4 - 6") {
+		t.Errorf("normalized body = %q, want plain spaces", rec.Body)
+	}
+
+	if _, err := store.JournalUpdate(ctx, JournalUpdateArgs{Ref: "self:state.md", Entry: "checked\u202fagain"}); err != nil {
+		t.Fatalf("journal: %v", err)
+	}
+	rec, err = store.Read(ctx, "self:state.md")
+	if err != nil {
+		t.Fatalf("re-read: %v", err)
+	}
+	if strings.ContainsAny(rec.Body, "\u00a0\u202f") {
+		t.Errorf("journal path retains space artifacts: %q", rec.Body)
+	}
+}
+
 func TestActivityErrorsTeachTheNextMove(t *testing.T) {
 	store := newActivityStore(t, map[string]string{"ego.md": "# ego\n"}, &recordingReviser{})
 

--- a/internal/state/documents/activity_test.go
+++ b/internal/state/documents/activity_test.go
@@ -100,6 +100,20 @@ func TestWriteNormalizesSpaceArtifacts(t *testing.T) {
 	if strings.ContainsAny(rec.Body, "\u00a0\u202f") {
 		t.Errorf("journal path retains space artifacts: %q", rec.Body)
 	}
+
+	if _, err := store.Edit(ctx, EditArgs{Ref: "self:state.md", Mode: "append_body", Body: "appended\u00a0note"}); err != nil {
+		t.Fatalf("edit: %v", err)
+	}
+	rec, err = store.Read(ctx, "self:state.md")
+	if err != nil {
+		t.Fatalf("post-edit read: %v", err)
+	}
+	if strings.ContainsAny(rec.Body, "\u00a0\u202f") {
+		t.Errorf("edit path retains space artifacts: %q", rec.Body)
+	}
+	if !strings.Contains(rec.Body, "appended note") {
+		t.Errorf("edited body = %q, want plain-space append", rec.Body)
+	}
 }
 
 func TestActivityErrorsTeachTheNextMove(t *testing.T) {

--- a/internal/state/documents/mutate.go
+++ b/internal/state/documents/mutate.go
@@ -126,7 +126,28 @@ func (s *Store) Read(ctx context.Context, ref string) (*DocumentRecord, error) {
 	return record, nil
 }
 
+// normalizeSpaceArtifacts folds the non-breaking space variants some
+// model tokenizers emit (U+00A0, U+202F narrow no-break) into plain
+// spaces before a document write. Observed live 2026-08-11 on prod's
+// metacognitive.md: gpt-oss:120b writes narrow no-break spaces where
+// a frontier model writes plain ones, so alternating authors churned
+// dozens of invisibly-changed diff lines per revision and broke plain
+// text search against the stored body. Deliberately conservative:
+// zero-width characters are left alone (emoji sequences depend on
+// them) — only the two space impostors are folded.
+func normalizeSpaceArtifacts(s string) string {
+	if !strings.ContainsAny(s, "\u00a0\u202f") {
+		return s
+	}
+	return strings.NewReplacer("\u00a0", " ", "\u202f", " ").Replace(s)
+}
+
 func (s *Store) Write(ctx context.Context, args WriteArgs) (*MutationResult, error) {
+	if args.Body != nil {
+		normalized := normalizeSpaceArtifacts(*args.Body)
+		args.Body = &normalized
+	}
+	args.JournalEntry = normalizeSpaceArtifacts(args.JournalEntry)
 	root, relPath, err := parseRef(args.Ref)
 	if err != nil {
 		return nil, err
@@ -186,6 +207,7 @@ func (s *Store) Write(ctx context.Context, args WriteArgs) (*MutationResult, err
 }
 
 func (s *Store) Edit(ctx context.Context, args EditArgs) (*MutationResult, error) {
+	args.Body = normalizeSpaceArtifacts(args.Body)
 	root, relPath, err := parseRef(args.Ref)
 	if err != nil {
 		return nil, err
@@ -254,6 +276,7 @@ func (s *Store) Edit(ctx context.Context, args EditArgs) (*MutationResult, error
 }
 
 func (s *Store) JournalUpdate(ctx context.Context, args JournalUpdateArgs) (*MutationResult, error) {
+	args.Entry = normalizeSpaceArtifacts(args.Entry)
 	root, relPath, err := parseRef(args.Ref)
 	if err != nil {
 		return nil, err

--- a/internal/state/documents/mutate.go
+++ b/internal/state/documents/mutate.go
@@ -135,11 +135,13 @@ func (s *Store) Read(ctx context.Context, ref string) (*DocumentRecord, error) {
 // text search against the stored body. Deliberately conservative:
 // zero-width characters are left alone (emoji sequences depend on
 // them) — only the two space impostors are folded.
+var spaceArtifactReplacer = strings.NewReplacer("\u00a0", " ", "\u202f", " ")
+
 func normalizeSpaceArtifacts(s string) string {
 	if !strings.ContainsAny(s, "\u00a0\u202f") {
 		return s
 	}
-	return strings.NewReplacer("\u00a0", " ", "\u202f", " ").Replace(s)
+	return spaceArtifactReplacer.Replace(s)
 }
 
 func (s *Store) Write(ctx context.Context, args WriteArgs) (*MutationResult, error) {

--- a/scripts/architecture.baseline
+++ b/scripts/architecture.baseline
@@ -1,5 +1,5 @@
 packages=68
 interfaces=83
-large_files=54
+large_files=55
 set_mutators=117
 database_opens=9


### PR DESCRIPTION
Found by the operator reading production's self-root history: commit diffs full of weird escape-looking churn, which turned out to be U+202F narrow no-break spaces standing where plain spaces belong. The forensics were quick with the revision trailers: gpt-oss:120b writes French-typography no-break spaces (typically around numbers and units — its training data's unit-spacing leaking into output), a frontier model writes plain ones, and metacognitive.md alternates authors — the kickoff note was clean, the gpt-oss iterations carried 18-20 artifacts, the Opus supervisor rewrite dropped to zero, and the next gpt-oss turn brought 20 back. Every alternation churned dozens of invisibly-changed diff lines, inflating `doc_activity` line math and breaking plain-text search against the stored body ('20 m' with a narrow space will not match a grep for '20 m'). Not the #1101 amplification class — counts were stable, not doubling — but the same family of invisible-byte document rot.

`normalizeSpaceArtifacts` folds U+00A0 and U+202F to plain spaces at the store's mutation chokepoint — Write (body + journal entry), Edit, and JournalUpdate — which the loop output publish tools also route through, so whichever model writes, the stored bytes are stable. Deliberately conservative: zero-width characters are untouched (emoji ZWJ sequences depend on them); only the two space impostors fold. One meta-lesson made it into the test design: the artifact inputs are spelled as visible \u escapes, because raw invisible bytes in source literals are precisely the fragility this bug teaches — an earlier draft of this very fix had them raw and they survived two rounds of tooling undetected.

## Test plan
- [x] Write path: body with U+202F/U+00A0 stores with plain spaces; journal path likewise
- [x] Full documents suite green (existing byte-exactness expectations unaffected)
- [x] `just ci` green (baseline: activity_test.go crossed the large-file threshold)

Refs #1341

🤖 Generated with [Claude Code](https://claude.com/claude-code)