### PR TITLE
feat(loops): make prompt_mode a durable per-loop declaration

### DIFF
--- a/examples/config.example.yaml
+++ b/examples/config.example.yaml
@@ -1305,6 +1305,7 @@ archivist:
 #         exclude_tools: []
 #         extra_hints: {}
 #         instructions: Be concise and focus on high-signal observations.
+#       prompt_mode: task
 #       operation: service
 #       completion: none
 #       outputs: []

--- a/internal/platform/config/example.go
+++ b/internal/platform/config/example.go
@@ -7,6 +7,7 @@ import (
 	"github.com/nugget/thane-ai-agent/internal/integrations/forge"
 	"github.com/nugget/thane-ai-agent/internal/integrations/search"
 	"github.com/nugget/thane-ai-agent/internal/model/router"
+	"github.com/nugget/thane-ai-agent/internal/runtime/agentctx"
 	looppkg "github.com/nugget/thane-ai-agent/internal/runtime/loop"
 )
 
@@ -302,6 +303,9 @@ func ExampleConfig() *Config {
 					Intent:     "Keep a current read on office activity so notable changes surface without being asked.",
 					Operation:  looppkg.OperationService,
 					Completion: looppkg.CompletionNone,
+					// A mechanical watcher wants the compact worker
+					// prompt (#1171); reflective loops leave this unset.
+					PromptMode: agentctx.PromptModeTask,
 					Conditions: looppkg.Conditions{
 						Schedule: &looppkg.ScheduleCondition{
 							Timezone: "America/Chicago",

--- a/internal/runtime/loop/loop.go
+++ b/internal/runtime/loop/loop.go
@@ -2296,7 +2296,7 @@ func (l *Loop) prepareAgentTurnRequest(req Request, convID string, isSupervisor 
 	req.UsageRole = firstNonEmpty(l.requestOverride.UsageRole, req.UsageRole)
 	req.UsageTaskName = firstNonEmpty(l.requestOverride.UsageTaskName, req.UsageTaskName)
 	req.SystemPrompt = firstNonEmpty(l.requestOverride.SystemPrompt, req.SystemPrompt)
-	req.PromptMode = firstPromptMode(l.requestOverride.PromptMode, req.PromptMode)
+	req.PromptMode = firstPromptMode(l.requestOverride.PromptMode, req.PromptMode, l.requestBase.PromptMode)
 	req.SuppressAlwaysContext = l.requestOverride.SuppressAlwaysContext || req.SuppressAlwaysContext
 	return req, nil
 }

--- a/internal/runtime/loop/loop.go
+++ b/internal/runtime/loop/loop.go
@@ -1043,6 +1043,14 @@ func (l *Loop) promoteRetuneLocked() bool {
 	l.requestBase.InitialTags = prevBase.InitialTags
 	l.requestBase.RuntimeTools = prevBase.RuntimeTools
 	l.requestInstructions = spec.Profile.Instructions
+	// A retuned prompt mode must actually win: prepareAgentTurnRequest
+	// prefers the launch-time override, which would otherwise shadow
+	// the retune until relaunch — the same shadowing the task override
+	// above routes around. An empty retuned mode expresses no opinion
+	// and leaves any launch-time override in place.
+	if spec.PromptMode != "" {
+		l.requestOverride.PromptMode = ""
+	}
 	return true
 }
 

--- a/internal/runtime/loop/retune_test.go
+++ b/internal/runtime/loop/retune_test.go
@@ -301,6 +301,58 @@ func TestQueueRetunePromotesPromptMode(t *testing.T) {
 	}
 }
 
+// TestQueueRetunePromptModeVersusLaunchOverride pins the shadowing rule:
+// a launch-time prompt_mode override would otherwise outrank the retuned
+// spec forever (prepareAgentTurnRequest prefers the override), so a
+// retune that declares a mode clears the override — the same route the
+// task override takes — while a retune silent on prompt_mode leaves the
+// launch-time choice in place.
+func TestQueueRetunePromptModeVersusLaunchOverride(t *testing.T) {
+	t.Parallel()
+
+	newOverriddenLoop := func(t *testing.T) *Loop {
+		t.Helper()
+		l, err := NewFromLaunch(Launch{
+			Spec:       retuneSpec("old task", time.Minute, 0),
+			PromptMode: agentctx.PromptModeFull,
+		}, Deps{Runner: &noopRunner{}})
+		if err != nil {
+			t.Fatalf("NewFromLaunch: %v", err)
+		}
+		return l
+	}
+
+	t.Run("a declared retune mode clears the launch override", func(t *testing.T) {
+		l := newOverriddenLoop(t)
+		retuned := retuneSpec("old task", time.Minute, 0)
+		retuned.PromptMode = agentctx.PromptModeTask
+		if err := l.QueueRetune(retuned); err != nil {
+			t.Fatalf("QueueRetune: %v", err)
+		}
+		req, err := l.prepareAgentTurnRequest(Request{}, "conv-1", false)
+		if err != nil {
+			t.Fatalf("prepareAgentTurnRequest: %v", err)
+		}
+		if req.PromptMode != agentctx.PromptModeTask {
+			t.Errorf("PromptMode = %q, want task (retune wins over launch override)", req.PromptMode)
+		}
+	})
+
+	t.Run("a silent retune leaves the launch override in place", func(t *testing.T) {
+		l := newOverriddenLoop(t)
+		if err := l.QueueRetune(retuneSpec("old task", time.Minute, 0)); err != nil {
+			t.Fatalf("QueueRetune: %v", err)
+		}
+		req, err := l.prepareAgentTurnRequest(Request{}, "conv-1", false)
+		if err != nil {
+			t.Fatalf("prepareAgentTurnRequest: %v", err)
+		}
+		if req.PromptMode != agentctx.PromptModeFull {
+			t.Errorf("PromptMode = %q, want full (launch override preserved)", req.PromptMode)
+		}
+	})
+}
+
 // TestQueueRetuneRejectsOperationDrift guards against the drift trap: a
 // stored definition whose operation was rewritten (loop_definition_set never
 // relaunches) must not conform in place — an event-driven spec carries a zero

--- a/internal/runtime/loop/retune_test.go
+++ b/internal/runtime/loop/retune_test.go
@@ -6,6 +6,8 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/nugget/thane-ai-agent/internal/runtime/agentctx"
 )
 
 // These tests pin the retune conformance contract (#1153): a running loop
@@ -262,6 +264,40 @@ func TestQueueRetuneUnstartedLoopPromotesInline(t *testing.T) {
 	s := l.Status()
 	if s.Config.Task != "new task" || s.PendingRetune {
 		t.Errorf("unstarted loop: task=%q pending=%v, want inline promote", s.Config.Task, s.PendingRetune)
+	}
+}
+
+// TestQueueRetunePromotesPromptMode pins the #1171 rollout path: flipping
+// prompt_mode on a stored worker-loop definition reaches the live loop as
+// a retune — the requestBase rebuild in promoteRetuneLocked carries it —
+// so the trim needs no relaunch.
+func TestQueueRetunePromotesPromptMode(t *testing.T) {
+	t.Parallel()
+
+	l, err := New(Config{
+		Name:         "retune-target",
+		Task:         "old task",
+		SleepMin:     time.Minute,
+		SleepMax:     time.Minute,
+		SleepDefault: time.Minute,
+		Jitter:       Float64Ptr(0),
+	}, Deps{Runner: &noopRunner{}})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	retuned := retuneSpec("old task", time.Minute, 0)
+	retuned.PromptMode = agentctx.PromptModeTask
+	if err := l.QueueRetune(retuned); err != nil {
+		t.Fatalf("QueueRetune: %v", err)
+	}
+
+	req, err := l.prepareAgentTurnRequest(Request{}, "conv-1", false)
+	if err != nil {
+		t.Fatalf("prepareAgentTurnRequest: %v", err)
+	}
+	if req.PromptMode != agentctx.PromptModeTask {
+		t.Errorf("PromptMode after retune = %q, want task", req.PromptMode)
 	}
 }
 

--- a/internal/runtime/loop/spec.go
+++ b/internal/runtime/loop/spec.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/nugget/thane-ai-agent/internal/model/router"
+	"github.com/nugget/thane-ai-agent/internal/runtime/agentctx"
 )
 
 // Operation describes the runtime pattern a loop is expected to
@@ -166,6 +167,18 @@ type Spec struct {
 	// Profile shapes loop execution: routing hints, context-injection
 	// tags, tool exclusions, and related request-shaping guidance.
 	Profile router.LoopProfile `yaml:"profile,omitempty" json:"profile,omitempty"`
+
+	// PromptMode selects the system-prompt shape for every iteration of
+	// this loop. Empty or "full" wears the complete identity stack —
+	// axioms, persona, mission, ego, the always-on talents and ambient
+	// context. "task" is the compact worker prompt: it sheds that
+	// reflective layer while keeping tagged guidance, active tags, the
+	// Task, and current conditions. The convention (#1171): mechanical
+	// maintainer/watcher/poller loops declare "task"; reflective loops —
+	// any loop whose job is judgment about the agent itself — declare
+	// "full". A per-launch [Launch.PromptMode] overrides this default
+	// for one launch.
+	PromptMode agentctx.PromptMode `yaml:"prompt_mode,omitempty" json:"prompt_mode,omitempty"`
 
 	// Operation describes the runtime pattern expected for the loop.
 	Operation Operation `yaml:"operation,omitempty" json:"operation,omitempty"`
@@ -403,6 +416,9 @@ func (s *Spec) Validate() error {
 	if err := s.Profile.Validate(); err != nil {
 		return fmt.Errorf("loop: profile: %w", err)
 	}
+	if !s.PromptMode.Valid() {
+		return fmt.Errorf("loop: invalid prompt_mode %q; valid values are \"full\" and \"task\"", s.PromptMode)
+	}
 	if err := validateOutputs(s.Outputs); err != nil {
 		return fmt.Errorf("loop: %w", err)
 	}
@@ -461,6 +477,15 @@ func validateContainerShape(s *Spec) error {
 	// Supervisor and SupervisorProb must remain off.
 	// SupervisorProfile-only is OK — that's the inheritance vector
 	// the cascade walker uses.
+	//
+	// PromptMode is checked here rather than in the shared helper
+	// because [Config] has no such field: it shapes the per-iteration
+	// request, and containers never iterate, so a value here would be
+	// dead config — and prompt modes deliberately do not cascade
+	// (#1171: the mode is a per-loop declaration, never inherited).
+	if s.PromptMode != "" {
+		return fmt.Errorf("loop: container %q cannot set prompt_mode (containers never execute a turn, and prompt modes do not cascade to descendants)", s.Name)
+	}
 	return containerShape(
 		s.Name, s.Task,
 		s.TaskBuilder != nil, s.TurnBuilder != nil, s.Handler != nil, s.WaitFunc != nil, s.PostIterate != nil,
@@ -627,6 +652,7 @@ func (s *Spec) profileRequest() Request {
 		ExcludeTools:     opts.ExcludeTools,
 		InitialTags:      append([]string(nil), s.Tags...),
 		RuntimeTools:     cloneRuntimeTools(s.RuntimeTools),
+		PromptMode:       s.PromptMode,
 	}
 }
 

--- a/internal/runtime/loop/spec.go
+++ b/internal/runtime/loop/spec.go
@@ -170,10 +170,12 @@ type Spec struct {
 
 	// PromptMode selects the system-prompt shape for every iteration of
 	// this loop. Empty or "full" wears the complete identity stack —
-	// axioms, persona, mission, ego, the always-on talents and ambient
-	// context. "task" is the compact worker prompt: it sheds that
-	// reflective layer while keeping tagged guidance, active tags, the
-	// Task, and current conditions. The convention (#1171): mechanical
+	// axioms, persona, mission, ego, the persona-tagged talents, and
+	// the always-on ambient context. "task" is the compact worker
+	// prompt: the persona is swapped for a bounded worker preamble and
+	// the rest of that layer is shed, while always-tagged talents,
+	// tagged guidance, active tags, the Task, and current conditions
+	// all remain. The convention (#1171): mechanical
 	// maintainer/watcher/poller loops declare "task"; reflective loops —
 	// any loop whose job is judgment about the agent itself — declare
 	// "full". A per-launch [Launch.PromptMode] overrides this default

--- a/internal/runtime/loop/spec_json.go
+++ b/internal/runtime/loop/spec_json.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/nugget/thane-ai-agent/internal/model/router"
+	"github.com/nugget/thane-ai-agent/internal/runtime/agentctx"
 )
 
 type specJSON struct {
@@ -15,6 +16,7 @@ type specJSON struct {
 	Task           string               `json:"task,omitempty"`
 	Intent         string               `json:"intent,omitempty"`
 	Profile        any                  `json:"profile,omitempty"`
+	PromptMode     agentctx.PromptMode  `json:"prompt_mode,omitempty"`
 	Operation      Operation            `json:"operation,omitempty"`
 	Completion     Completion           `json:"completion,omitempty"`
 	Outputs        []OutputSpec         `json:"outputs,omitempty"`
@@ -71,6 +73,7 @@ func (s Spec) MarshalJSON() ([]byte, error) {
 		Task:              s.Task,
 		Intent:            s.Intent,
 		Profile:           s.Profile,
+		PromptMode:        s.PromptMode,
 		Operation:         s.Operation,
 		Completion:        s.Completion,
 		Outputs:           cloneOutputs(s.Outputs),
@@ -151,6 +154,7 @@ func (s *Spec) UnmarshalJSON(data []byte) error {
 		Enabled:          wire.Enabled,
 		Task:             wire.Task,
 		Intent:           wire.Intent,
+		PromptMode:       wire.PromptMode,
 		Operation:        wire.Operation,
 		Completion:       wire.Completion,
 		Outputs:          cloneOutputs(wire.Outputs),

--- a/internal/runtime/loop/spec_test.go
+++ b/internal/runtime/loop/spec_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/nugget/thane-ai-agent/internal/model/router"
+	"github.com/nugget/thane-ai-agent/internal/runtime/agentctx"
 )
 
 func TestSpecValidate(t *testing.T) {
@@ -111,6 +112,94 @@ func TestSpecValidate(t *testing.T) {
 		err := spec.Validate()
 		if err == nil || !strings.Contains(err.Error(), "jitter") {
 			t.Fatalf("Validate() error = %v, want jitter rejection", err)
+		}
+	})
+
+	t.Run("task prompt_mode on a service spec is valid", func(t *testing.T) {
+		spec := &Spec{
+			Name:         "worker",
+			Task:         "Check the site and update the document.",
+			Operation:    OperationService,
+			PromptMode:   agentctx.PromptModeTask,
+			SleepMin:     time.Minute,
+			SleepMax:     time.Hour,
+			SleepDefault: 10 * time.Minute,
+		}
+		if err := spec.Validate(); err != nil {
+			t.Fatalf("Validate() error = %v, want nil", err)
+		}
+	})
+
+	t.Run("invalid prompt_mode is rejected", func(t *testing.T) {
+		spec := &Spec{
+			Name:       "bad-prompt-mode",
+			Task:       "Do something.",
+			PromptMode: agentctx.PromptMode("everything"),
+		}
+		err := spec.Validate()
+		if err == nil || !strings.Contains(err.Error(), "prompt_mode") {
+			t.Fatalf("Validate() error = %v, want prompt_mode rejection", err)
+		}
+	})
+
+	t.Run("container rejects prompt_mode", func(t *testing.T) {
+		spec := &Spec{
+			Name:       "grouping",
+			Operation:  OperationContainer,
+			PromptMode: agentctx.PromptModeTask,
+		}
+		err := spec.Validate()
+		if err == nil || !strings.Contains(err.Error(), "prompt_mode") {
+			t.Fatalf("Validate() error = %v, want container prompt_mode rejection", err)
+		}
+	})
+}
+
+// TestSpecPromptModeReachesPreparedRequest pins the #1171 contract: a
+// durable definition's prompt_mode is the loop's per-iteration default,
+// and a per-launch override still wins over it.
+func TestSpecPromptModeReachesPreparedRequest(t *testing.T) {
+	t.Parallel()
+
+	spec := Spec{
+		Name:         "worker",
+		Task:         "Check the site and update the document.",
+		Operation:    OperationService,
+		Completion:   CompletionNone,
+		PromptMode:   agentctx.PromptModeTask,
+		SleepMin:     time.Minute,
+		SleepMax:     time.Hour,
+		SleepDefault: 10 * time.Minute,
+	}
+
+	t.Run("spec-level mode is the iteration default", func(t *testing.T) {
+		l, err := NewFromSpec(spec, Deps{Runner: &noopRunner{}})
+		if err != nil {
+			t.Fatalf("NewFromSpec: %v", err)
+		}
+		req, err := l.prepareAgentTurnRequest(Request{}, "conv-1", false)
+		if err != nil {
+			t.Fatalf("prepareAgentTurnRequest: %v", err)
+		}
+		if req.PromptMode != agentctx.PromptModeTask {
+			t.Errorf("PromptMode = %q, want task (from spec)", req.PromptMode)
+		}
+	})
+
+	t.Run("launch override wins over the spec default", func(t *testing.T) {
+		l, err := NewFromLaunch(Launch{
+			Spec:       spec,
+			PromptMode: agentctx.PromptModeFull,
+		}, Deps{Runner: &noopRunner{}})
+		if err != nil {
+			t.Fatalf("NewFromLaunch: %v", err)
+		}
+		req, err := l.prepareAgentTurnRequest(Request{}, "conv-1", false)
+		if err != nil {
+			t.Fatalf("prepareAgentTurnRequest: %v", err)
+		}
+		if req.PromptMode != agentctx.PromptModeFull {
+			t.Errorf("PromptMode = %q, want full (launch override)", req.PromptMode)
 		}
 	})
 }
@@ -284,6 +373,7 @@ func TestSpecJSONRoundTripUsesHumanFacingFields(t *testing.T) {
 		Task:       "Watch the office.",
 		Operation:  OperationService,
 		Completion: CompletionConversation,
+		PromptMode: agentctx.PromptModeTask,
 		Tags:       []string{"homeassistant"},
 		Profile: router.LoopProfile{
 			Mission:      "background",
@@ -313,7 +403,7 @@ func TestSpecJSONRoundTripUsesHumanFacingFields(t *testing.T) {
 		t.Fatalf("json.Marshal: %v", err)
 	}
 	gotJSON := string(data)
-	for _, want := range []string{`"enabled":true`, `"sleep_min":"5m0s"`, `"sleep_max":"30m0s"`, `"max_duration":"1h0m0s"`, `"on_retrigger":"restart"`, `"conditions":{"schedule":{"timezone":"America/Chicago"`, `"delegation_gating":"disabled"`, `"routing_factors":{"prefer_speed":"true"}`} {
+	for _, want := range []string{`"enabled":true`, `"prompt_mode":"task"`, `"sleep_min":"5m0s"`, `"sleep_max":"30m0s"`, `"max_duration":"1h0m0s"`, `"on_retrigger":"restart"`, `"conditions":{"schedule":{"timezone":"America/Chicago"`, `"delegation_gating":"disabled"`, `"routing_factors":{"prefer_speed":"true"}`} {
 		if !strings.Contains(gotJSON, want) {
 			t.Fatalf("json = %s, want substring %s", gotJSON, want)
 		}
@@ -340,6 +430,9 @@ func TestSpecJSONRoundTripUsesHumanFacingFields(t *testing.T) {
 	}
 	if got := roundTrip.RoutingFactors[router.FactorPreferSpeed]; got != "true" {
 		t.Fatalf("RoutingFactors[prefer_speed] = %q, want true", got)
+	}
+	if roundTrip.PromptMode != agentctx.PromptModeTask {
+		t.Fatalf("PromptMode = %q, want task", roundTrip.PromptMode)
 	}
 }
 

--- a/internal/tools/loop_create_fluency_test.go
+++ b/internal/tools/loop_create_fluency_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/nugget/thane-ai-agent/internal/runtime/agentctx"
 	looppkg "github.com/nugget/thane-ai-agent/internal/runtime/loop"
 	"github.com/nugget/thane-ai-agent/internal/state/documents"
 )
@@ -108,6 +109,53 @@ func TestGuidedCreateWorkingNotes(t *testing.T) {
 	if result["working_notes_document"] != "kb:dashboards/closet-notes.md" {
 		t.Errorf("result should name the notes document it created, got %v", result["working_notes_document"])
 	}
+}
+
+// TestGuidedCreatePromptMode covers the front door's half of the #1171
+// convention: an explicit "task" lands on the derived spec, and an
+// omitted argument stays empty — the runtime default is full, but only
+// a caller's explicit choice becomes a durable pin.
+func TestGuidedCreatePromptMode(t *testing.T) {
+	t.Run("explicit task mode lands on the spec", func(t *testing.T) {
+		args := curateArgs(nil)
+		args["prompt_mode"] = "task"
+		spec, _ := dryRunSpec(t, args)
+		if spec.PromptMode != agentctx.PromptModeTask {
+			t.Errorf("PromptMode = %q, want task", spec.PromptMode)
+		}
+	})
+
+	t.Run("omitted mode stays unset", func(t *testing.T) {
+		spec, _ := dryRunSpec(t, curateArgs(nil))
+		if spec.PromptMode != "" {
+			t.Errorf("PromptMode = %q, want empty (no silent pin)", spec.PromptMode)
+		}
+	})
+
+	t.Run("invalid mode is refused with a teaching error", func(t *testing.T) {
+		rig := newCurateTestRig(t)
+		args := curateArgs(nil)
+		args["prompt_mode"] = "compact"
+		args["dry_run"] = true
+		_, err := rig.tool.Handler(context.Background(), args)
+		if err == nil || !strings.Contains(err.Error(), "prompt_mode") {
+			t.Fatalf("err = %v, want prompt_mode rejection naming valid values", err)
+		}
+	})
+
+	t.Run("containers refuse the argument", func(t *testing.T) {
+		rig := newCurateTestRig(t)
+		_, err := rig.tool.Handler(context.Background(), map[string]any{
+			"name":        "grouping",
+			"intent":      "Group related loops.",
+			"operation":   "container",
+			"prompt_mode": "task",
+			"dry_run":     true,
+		})
+		if err == nil || !strings.Contains(err.Error(), "prompt_mode") {
+			t.Fatalf("err = %v, want container prompt_mode rejection", err)
+		}
+	})
 }
 
 // TestGuidedCreateRefusesUnknownFacet pins the failure direction. A facet

--- a/internal/tools/loop_create_tool.go
+++ b/internal/tools/loop_create_tool.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/nugget/thane-ai-agent/internal/model/router"
+	"github.com/nugget/thane-ai-agent/internal/runtime/agentctx"
 	looppkg "github.com/nugget/thane-ai-agent/internal/runtime/loop"
 	"github.com/nugget/thane-ai-agent/internal/state/documents"
 	"github.com/nugget/thane-ai-agent/internal/tools/toolargs"
@@ -33,12 +34,14 @@ func (r *Registry) registerThaneLoopCreate() {
 			"\"container\" = a non-executing node that groups loops and shares its tags with descendants; like every operation it requires intent, takes the optional parent_name and tags, and rejects execution/output fields (sleep knobs, output, entities, instructions, etc.). " +
 			"output (service/event_driven only) declares a managed markdown document the loop maintains, rewriting it each cycle to reflect current state; declaring facets publishes condensed projections alongside the body instead. It comes with a private working-notes document for the loop's own thinking, and both documents are scaffolded with ownership frontmatter before launch — a faceted output's scaffold carries the exact section skeleton its publish tool fills, so the loop's first iteration sees the shape it is expected to produce. Better than the placeholder skeleton: output.initial authors the first publish at create time from the survey you just did (same arguments as the publish tool; see the parameter). A document that already exists is preserved rather than re-scaffolded or seeded (document_state / working_notes_state in the result report which happened). Document-owning loops carry the read-side doc tools regardless of tags (doc_read — which returns this loop's own outputs whole, even when large — plus doc_outline/doc_section for paging other large documents, and doc_history/doc_diff/doc_at for revision history). Omit output for a loop that acts without maintaining a document. " +
 			"parent_name nests the loop under a container by name, inheriting its tags and subscriptions. " +
+			"prompt_mode picks the system-prompt shape: set \"task\" for a mechanical maintainer/watcher/poller (fetch a source, check a state, update a document) — the compact worker prompt drops the reflective identity stack, the largest single prompt cost in a background loop; leave it unset for a loop that reflects on the agent or composes messages in its voice. " +
 			"entities are Home Assistant subscriptions surfaced into the loop's context each iteration; an entry with wake: true ALSO wakes the loop when that entity changes (debounced/coalesced) — for a service loop an early wake, for an event_driven loop a primary trigger. " +
 			"Returns the loop definition name, loop_id, and the canonical loop row; plus output_tool/document_path when a document was declared, facets when it declared any, and working_notes_document — every document-owning loop is given a private notes surface beside its document, so its reasoning has somewhere to go that is not what it publishes. If the loop lands at the root but an existing container declares tags it shares, the result also carries a non-blocking placement_advisory suggesting where it might nest (see loop_containers).",
 		ContentResolveExempt: []string{
 			"name", "intent", "operation", "parent_name", "output", "entities", "tags",
 			"instructions", "sleep_min", "sleep_max", "sleep_default", "jitter",
 			"quality_floor", "exclude_tools", "metadata", "replace", "dry_run",
+			"prompt_mode",
 		},
 		Parameters: thaneLoopCreateSchema(),
 		Handler:    r.handleThaneLoopCreate,
@@ -76,7 +79,8 @@ func (r *Registry) handleThaneLoopCreate(ctx context.Context, args map[string]an
 func (r *Registry) createLoopContainer(ctx context.Context, args map[string]any, name, intent string) (string, error) {
 	if err := rejectArgsForOperation(args, looppkg.OperationContainer,
 		"output", "entities", "instructions", "quality_floor", "exclude_tools",
-		"sleep_min", "sleep_max", "sleep_default", "jitter", "metadata"); err != nil {
+		"sleep_min", "sleep_max", "sleep_default", "jitter", "metadata",
+		"prompt_mode"); err != nil {
 		return "", err
 	}
 
@@ -207,6 +211,18 @@ func (r *Registry) planExecutingLoop(args map[string]any, name, intent string, o
 	tags := parseLoopCreateTags(args)
 	instructions := toolargs.TrimmedString(args, "instructions")
 
+	// An omitted prompt_mode stays empty on the spec — the runtime
+	// default is full, but only a caller's explicit choice becomes a
+	// durable pin.
+	var promptMode agentctx.PromptMode
+	if raw := toolargs.TrimmedString(args, "prompt_mode"); raw != "" {
+		mode, err := agentctx.ParsePromptMode(raw)
+		if err != nil {
+			return nil, err
+		}
+		promptMode = mode
+	}
+
 	qualityFloor, err := parseLoopCreateQualityFloor(args)
 	if err != nil {
 		return nil, err
@@ -301,6 +317,7 @@ func (r *Registry) planExecutingLoop(args map[string]any, name, intent string, o
 		Task:          task,
 		Intent:        intent,
 		Operation:     op,
+		PromptMode:    promptMode,
 		Tags:          tags,
 		Outputs:       outputs,
 		Subscriptions: curateEntitiesToSubscriptions(entities, now),
@@ -916,6 +933,11 @@ func thaneLoopCreateSchema() map[string]any {
 			"instructions": map[string]any{
 				"type":        "string",
 				"description": "Optional steering text prepended to every iteration's task (service/event_driven). Persists on the spec's profile and shows in loop_definition_get.",
+			},
+			"prompt_mode": map[string]any{
+				"type":        "string",
+				"enum":        []string{"full", "task"},
+				"description": "Optional system-prompt shape (service/event_driven). \"task\" is the compact worker prompt: it sheds the reflective identity layer while keeping tagged guidance, the task, and current conditions — right for mechanical maintainer/watcher/poller loops, where identity prose is the largest single prompt cost. Omit (or set \"full\") for loops that reflect on the agent or compose messages in its voice. Changeable later, live, via loop_definition_update.",
 			},
 			"sleep_min": map[string]any{
 				"type":        "string",

--- a/internal/tools/loop_definition_tool_helpers.go
+++ b/internal/tools/loop_definition_tool_helpers.go
@@ -265,7 +265,7 @@ func loopLaunchOverrideProperties() map[string]any {
 		"prompt_mode": map[string]any{
 			"type":        "string",
 			"enum":        []string{"full", "task"},
-			"description": "Select the system-prompt shape. full is the normal Thane prompt. task is a compact worker prompt that suppresses full identity and always-on continuity context.",
+			"description": "Override the system-prompt shape for this launch only. full is the normal Thane prompt; task is a compact worker prompt that suppresses full identity and always-on continuity context. The durable default lives on spec.prompt_mode — set it there (via loop_definition_set or loop_definition_update) when the loop should always run this way; this override wins over the spec for one launch.",
 		},
 		"skip_context": map[string]any{
 			"type":        "boolean",

--- a/internal/tools/loop_definition_tools.go
+++ b/internal/tools/loop_definition_tools.go
@@ -173,7 +173,7 @@ func (r *Registry) registerLoopDefinitionTools() {
 
 	r.Register(&Tool{
 		Name:        "loop_definition_update",
-		Description: "Change a subset of fields on one existing dynamic loop definition in the persistent loops overlay, without resending the whole spec. Use this for incremental edits — enable supervisor, set supervisor_prob, rewrite the profile instructions, retune the sleep envelope, pin a model — instead of recomposing the entire definition with loop_definition_set. Pass name plus any subset of the editable fields below; every field you omit is preserved exactly. Config-owned definitions are immutable. Structural and list-valued fields (operation, completion, outputs, subscriptions, tags) are not editable here — use loop_definition_set to rewrite those; to move a loop use loop_reparent, and to change run state (active/paused) use loop_definition_set_policy. The edit is persisted immediately and applies live to a running loop: the next turn embodies it (a turn already in flight finishes under its previous config), and an in-flight sleep is re-clamped to an edited envelope, waking immediately if overdue. Structural rewrites via loop_definition_set still require a relaunch.",
+		Description: "Change a subset of fields on one existing dynamic loop definition in the persistent loops overlay, without resending the whole spec. Use this for incremental edits — enable supervisor, set supervisor_prob, rewrite the profile instructions, retune the sleep envelope, pin a model, flip prompt_mode — instead of recomposing the entire definition with loop_definition_set. Pass name plus any subset of the editable fields below; every field you omit is preserved exactly. Config-owned definitions are immutable. Structural and list-valued fields (operation, completion, outputs, subscriptions, tags) are not editable here — use loop_definition_set to rewrite those; to move a loop use loop_reparent, and to change run state (active/paused) use loop_definition_set_policy. The edit is persisted immediately and applies live to a running loop: the next turn embodies it (a turn already in flight finishes under its previous config), and an in-flight sleep is re-clamped to an edited envelope, waking immediately if overdue. Structural rewrites via loop_definition_set still require a relaunch.",
 		// Same literal-payload hazard as loop_definition_set/lint: the merged
 		// spec carries outputs[].ref strings, and the field values are stored
 		// verbatim. Universal prefix-to-content resolution would rewrite a real
@@ -205,6 +205,11 @@ func (r *Registry) registerLoopDefinitionTools() {
 				"mission": map[string]any{
 					"type":        "string",
 					"description": "Routing mission hint (spec.profile.mission), e.g. \"conversation\" or \"background\".",
+				},
+				"prompt_mode": map[string]any{
+					"type":        "string",
+					"enum":        []string{"full", "task"},
+					"description": "System-prompt shape for the loop's iterations (spec.prompt_mode). \"task\" = the compact worker prompt for mechanical maintainer/watcher/poller loops — it sheds the reflective identity stack, the largest single prompt cost in a background loop. \"full\" = the complete identity, for loops that reflect on the agent or speak in its voice. Applies live at the loop's next turn boundary.",
 				},
 				"supervisor": map[string]any{
 					"type":        "boolean",

--- a/internal/tools/loop_definition_update_tools.go
+++ b/internal/tools/loop_definition_update_tools.go
@@ -29,6 +29,7 @@ var loopDefinitionUpdateFields = map[string][]string{
 	"instructions":            {"profile", "instructions"},
 	"quality_floor":           {"profile", "quality_floor"},
 	"mission":                 {"profile", "mission"},
+	"prompt_mode":             {"prompt_mode"},
 	"supervisor":              {"supervisor"},
 	"supervisor_prob":         {"supervisor_prob"},
 	"supervisor_instructions": {"supervisor_profile", "instructions"},

--- a/internal/tools/loop_definition_update_tools_test.go
+++ b/internal/tools/loop_definition_update_tools_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/nugget/thane-ai-agent/internal/model/router"
+	"github.com/nugget/thane-ai-agent/internal/runtime/agentctx"
 	looppkg "github.com/nugget/thane-ai-agent/internal/runtime/loop"
 )
 
@@ -111,6 +112,34 @@ func TestLoopDefinitionUpdate_MergesAndPreserves(t *testing.T) {
 	fields, _ := env["updated_fields"].([]any)
 	if len(fields) != 5 {
 		t.Errorf("updated_fields = %v, want 5 entries", env["updated_fields"])
+	}
+}
+
+// TestLoopDefinitionUpdate_PromptMode covers the #1171 rollout path end
+// to end at the tool boundary: prompt_mode merges through the wire form,
+// persists on the stored spec, preserves its neighbors, and an invalid
+// value is refused by the same spec validation loop_definition_set uses.
+func TestLoopDefinitionUpdate_PromptMode(t *testing.T) {
+	deps := newTestLoopDefinitionDeps(t)
+	seedOverlayUpdateTarget(t, deps)
+
+	if _, err := updateTargetExec(t, deps, map[string]any{"prompt_mode": "task"}); err != nil {
+		t.Fatalf("loop_definition_update: %v", err)
+	}
+	got := deps.persisted["update_target"]
+	if got.PromptMode != agentctx.PromptModeTask {
+		t.Errorf("PromptMode = %q, want task", got.PromptMode)
+	}
+	if got.Task != "original task" || got.Profile.Mission != "background" {
+		t.Errorf("neighboring fields disturbed: task=%q mission=%q", got.Task, got.Profile.Mission)
+	}
+
+	_, err := updateTargetExec(t, deps, map[string]any{"prompt_mode": "compact"})
+	if err == nil || !strings.Contains(err.Error(), "prompt_mode") {
+		t.Fatalf("err = %v, want prompt_mode rejection", err)
+	}
+	if got := deps.persisted["update_target"]; got.PromptMode != agentctx.PromptModeTask {
+		t.Errorf("rejected update mutated the stored spec: PromptMode = %q", got.PromptMode)
 	}
 }
 

--- a/internal/tools/loop_spec_schema.go
+++ b/internal/tools/loop_spec_schema.go
@@ -46,7 +46,7 @@ func loopSpecSchema(description string) map[string]any {
 			"prompt_mode": map[string]any{
 				"type":        "string",
 				"enum":        []string{"full", "task"},
-				"description": "System-prompt shape for every iteration. \"task\" is the compact worker prompt: it sheds the reflective identity layer — axioms, persona, ego, mission, always-on talents and ambient context, the largest single prompt cost in a background loop — while keeping tagged guidance, active tags, the task, and current conditions. Declare \"task\" for mechanical maintainer/watcher/poller loops (fetch a source, check a state, update a document). Leave unset (or \"full\") for any loop whose job needs the identity: reflection or self-assessment, or composing messages in the agent's own voice. Editable live via loop_definition_update.",
+				"description": "System-prompt shape for every iteration. \"task\" is the compact worker prompt: it sheds the reflective identity layer — axioms, persona, ego, mission, persona-tagged talents, always-on ambient context; the largest single prompt cost in a background loop — while keeping always-tagged talents, tagged guidance, active tags, the task, and current conditions. Declare \"task\" for mechanical maintainer/watcher/poller loops (fetch a source, check a state, update a document). Leave unset (or \"full\") for any loop whose job needs the identity: reflection or self-assessment, or composing messages in the agent's own voice. Editable live via loop_definition_update.",
 			},
 			"supervisor": map[string]any{
 				"type":        "boolean",

--- a/internal/tools/loop_spec_schema.go
+++ b/internal/tools/loop_spec_schema.go
@@ -43,6 +43,11 @@ func loopSpecSchema(description string) map[string]any {
 				"description": "Runtime pattern. service = perpetual self-paced loop; event_driven = wakes only on subscription/tag events (no periodic sleep); background_task = detached one-shot; request_reply = synchronous; container = non-executing graph node.",
 			},
 			"profile": loopProfileSchema("Routing and request-shaping for normal (non-supervisor) iterations."),
+			"prompt_mode": map[string]any{
+				"type":        "string",
+				"enum":        []string{"full", "task"},
+				"description": "System-prompt shape for every iteration. \"task\" is the compact worker prompt: it sheds the reflective identity layer — axioms, persona, ego, mission, always-on talents and ambient context, the largest single prompt cost in a background loop — while keeping tagged guidance, active tags, the task, and current conditions. Declare \"task\" for mechanical maintainer/watcher/poller loops (fetch a source, check a state, update a document). Leave unset (or \"full\") for any loop whose job needs the identity: reflection or self-assessment, or composing messages in the agent's own voice. Editable live via loop_definition_update.",
+			},
 			"supervisor": map[string]any{
 				"type":        "boolean",
 				"description": "Enable periodic supervisor turns: a per-wake Bernoulli trial promotes the iteration to a more capable, non-local model.",

--- a/loops/archivist.md
+++ b/loops/archivist.md
@@ -18,6 +18,9 @@ profile:
     extra_hints:
         source: archivist
 operation: service
+# Reflective loop: wears the full identity stack by design. This pin
+# guards against any future default that trims service loops (#1171).
+prompt_mode: full
 completion: none
 outputs:
     - name: archivist_state

--- a/loops/ego.md
+++ b/loops/ego.md
@@ -18,6 +18,9 @@ profile:
     extra_hints:
         source: ego
 operation: service
+# Reflective loop: wears the full identity stack by design. This pin
+# guards against any future default that trims service loops (#1171).
+prompt_mode: full
 completion: none
 outputs:
     - name: ego_state

--- a/loops/metacognitive.md
+++ b/loops/metacognitive.md
@@ -18,6 +18,9 @@ profile:
     extra_hints:
         source: metacognitive
 operation: service
+# Reflective loop: wears the full identity stack by design. This pin
+# guards against any future default that trims service loops (#1171).
+prompt_mode: full
 completion: none
 outputs:
     - name: metacognitive_state

--- a/talents/loops-examples.md
+++ b/talents/loops-examples.md
@@ -143,6 +143,7 @@ anything persists.
   "intent": "Keep the current state of the server closet — environment, power, and equipment health — legible to anyone who asks, and surface excursions that need attention.",
   "task": "Read the current sensor values and the document you maintain. If the state has moved materially, publish all projections together. If nothing has changed, publish nothing and record why in working notes.",
   "operation": "service",
+  "prompt_mode": "task",
   "sleep_min": "10m",
   "sleep_max": "30m",
   "subscriptions": [
@@ -173,6 +174,13 @@ coverage of everything the owner keeps visible there — expansion honors
 HA visibility and re-resolves live, so a sensor added to the closet next
 month appears without a spec edit — while the sharp entities carry the
 extras an area target cannot (history windows, transition logs, wake).
+
+`prompt_mode: "task"` is right for a mechanical maintainer like this
+one: read sensors, judge drift, publish. The compact worker prompt
+sheds the reflective identity stack — the largest single prompt cost
+in a background loop — while keeping the tagged guidance and
+conditions the work actually uses. A loop that reflects on the agent
+or speaks to humans in its voice leaves the field unset.
 
 ## Publishing
 

--- a/talents/loops.md
+++ b/talents/loops.md
@@ -203,15 +203,15 @@ muddle them and the loop drifts.
   maintainer, watcher, or poller — fetch a source, check a state,
   update a document — should declare `prompt_mode: "task"`: the
   compact worker prompt sheds the reflective identity stack (axioms,
-  persona, ego, always-on talents and ambient context), which is the
-  largest single prompt cost in a background loop and pure latency on
-  a local model. The worker keeps its tagged guidance, its task, and
-  current conditions — it sheds only the self it was never using.
-  Leave the field unset for a loop whose work needs the identity:
-  reflection or judgment about the agent itself, or composing
-  messages in the agent's own voice. The mode is per-loop and never
-  inherited; when in doubt, leave it unset and trim later — it
-  retunes live via `loop_definition_update`.
+  persona, ego, persona-tagged talents, always-on ambient context),
+  which is the largest single prompt cost in a background loop and
+  pure latency on a local model. The worker keeps its always-tagged
+  talents, its tagged guidance, its task, and current conditions — it
+  sheds only the self it was never using. Leave the field unset for a
+  loop whose work needs the identity: reflection or judgment about
+  the agent itself, or composing messages in the agent's own voice.
+  The mode is per-loop and never inherited; when in doubt, leave it
+  unset and trim later — it retunes live via `loop_definition_update`.
 
 ## Changing a loop that's already running
 

--- a/talents/loops.md
+++ b/talents/loops.md
@@ -199,6 +199,20 @@ muddle them and the loop drifts.
   script through unstructured input, that's the signal — a loop
   with interpretive instructions handles it more durably.
 
+- **`prompt_mode` decides how much self the loop wears.** A mechanical
+  maintainer, watcher, or poller — fetch a source, check a state,
+  update a document — should declare `prompt_mode: "task"`: the
+  compact worker prompt sheds the reflective identity stack (axioms,
+  persona, ego, always-on talents and ambient context), which is the
+  largest single prompt cost in a background loop and pure latency on
+  a local model. The worker keeps its tagged guidance, its task, and
+  current conditions — it sheds only the self it was never using.
+  Leave the field unset for a loop whose work needs the identity:
+  reflection or judgment about the agent itself, or composing
+  messages in the agent's own voice. The mode is per-loop and never
+  inherited; when in doubt, leave it unset and trim later — it
+  retunes live via `loop_definition_update`.
+
 ## Changing a loop that's already running
 
 A running loop carries the config it launched with. Whether an edit
@@ -206,9 +220,9 @@ reaches the live instance or waits for a relaunch depends on the tool
 you use, not just the field:
 
 - **Retune it live** — task, model, instructions, sleep envelope,
-  quality floor, supervisor, max_iter all promote into the running
-  loop via `loop_definition_update` at its next turn boundary. No
-  relaunch, no lost iteration.
+  quality floor, prompt mode, supervisor, max_iter all promote into
+  the running loop via `loop_definition_update` at its next turn
+  boundary. No relaunch, no lost iteration.
 - **Change its watch set live** — entity subscriptions have their own
   door: `add_entity_subscription` / `remove_entity_subscription` with
   `owner` set to the loop's name edit one watch entry in place, also


### PR DESCRIPTION
## The definition could not say what the loop is

Worker loops wear the full interactive identity stack on every wake — axioms, persona, mission, ego, the always-on talents and ambient context. For a loop whose entire job is fetch-a-webpage-and-update-a-document, that is roughly 35KB of reflective prose with no bearing on the work, the largest always-on cost in a background loop's prompt, and per the #1160 audit the single biggest latency lever for local-model loop turns. The machinery to shed it has existed end to end since the delegate work: `buildSystemPromptWithProfileSections` gates the whole identity layer on a `PromptMode`, and `task` mode keeps exactly what a worker needs — tagged guidance, active tags, the Task, current conditions.

But #1171's re-grounded status turned out to be one step ahead of the code. It reads "none of them pins `prompt_mode` today (verified against main), so the guard is literally `prompt_mode: full` added to three spec blocks, gated by the existing round-trip test" — and that verification checked the wrong layer. `prompt_mode` was plumbed through `Launch` and `Request`, so a *launch* could override it for one run, but `loop.Spec` — the durable artifact that describes what a loop *is*, the thing the definition documents decode into and the overlay persists — had no such field. Adding `prompt_mode: full` to a definition document on main would not have been a one-line guard; it would have been a boot-refusing parse error, because the document loader decodes spec blocks with `KnownFields(true)` precisely so that unknown keys fail loudly. The issue's scoping instinct was right that this is small; it was wrong that it was zero mechanism.

## What this PR adds

**The durable field.** `Spec.PromptMode` (`prompt_mode` in yaml/json, mirrored through the `specJSON` wire) with validation that refuses anything but `full`/`task`, and a container-shape refusal: containers never execute a turn, and prompt modes deliberately do not cascade — the mode is a per-loop declaration, never inherited, which is the shape #1171 chose so no structural default can ever reach a loop that didn't declare it.

**The resolution order.** `profileRequest()` folds the spec's mode into the loop's `requestBase`, and the prepared turn request resolves launch override > per-turn request > spec default — the same precedence every other request-shaping field already follows.

**The live rollout path, for free.** `promoteRetuneLocked` already rebuilds `requestBase` from the spec on a retune, so `prompt_mode` joins the hot-swappable scalars: `loop_definition_update` now exposes it, and flipping it on a stored definition reaches the running loop at its next turn boundary. The prod rollout the issue scopes as an operator pass is one update call per worker loop — no relaunch, no lost iteration.

**The guard.** The three reflective core loops — ego, metacognitive, archivist — pin `prompt_mode: full` in their definition documents with a comment saying why. These are the loops the issue's hazard section is about: they are `Operation: service` like every mechanical poller, and their whole purpose is the identity the trim removes. The pin makes any future operation-derived default unable to touch them.

**The teaching.** Per the model-first convention, every surface the model reads at decision time carries the archetype frame — mechanical maintainer/watcher/poller loops declare `task`; loops that reflect on the agent or compose messages in its voice stay `full`:

- the shared spec schema (`loop_definition_set` / `loop_definition_lint` / `spawn_loop`),
- `loop_definition_update` (schema + description, as a live retune),
- `thane_loop_create` (new `prompt_mode` argument on the front door, rejected for containers, exempt from content resolution like its siblings),
- the launch override's description now points at `spec.prompt_mode` as the durable home instead of presenting itself as the only door,
- the loops doctrine talent (a "how much self does this loop wear" entry in Composing the loop, plus the retune-tier list) and the worked `server_closet_guardian` example, which now models the convention,
- the generated config example's `office_watch` — a mechanical watcher — now shows `prompt_mode: task`.

## What stays out, deliberately

No operation-derived default, no cascade, no third `service` mode, no `DelegateSystemPrompt` rewrite — all per the decision recorded in #1171. The accepted wart stands: `task` mode's worker prompt says "bounded task worker for another agent," which a self-directed maintainer is not; the loop's explicit Task instruction dominates behavior and the token savings outweigh the framing mismatch.

## Review round (69eafdce)

Copilot's review corrected the talent story and surfaced a real shadow. Task mode does not shed the always-on talents — `talentTags` activates `TagAlways` unconditionally and drops only `TagPersona` — so the Godoc, the shared spec schema, and the doctrine now name persona-tagged talents as what task mode sheds. And the live-retune promise had an exception: a launch-time `prompt_mode` override outranked the retuned spec until relaunch. Rather than caveat the docs, `promoteRetuneLocked` now clears the launch-time override when a retune declares a mode — the same route `taskOverride` already takes — while a retune silent on `prompt_mode` leaves the launch-time choice in place.

## Test plan

- [x] `Spec` JSON round-trip carries `prompt_mode` (extended `TestSpecJSONRoundTripUsesHumanFacingFields`)
- [x] Invalid `prompt_mode` refused by `Spec.Validate`; containers refuse the field outright
- [x] Spec-level mode reaches the prepared turn request; a launch override still wins (`TestSpecPromptModeReachesPreparedRequest`)
- [x] A retune promotes a `prompt_mode` flip into a live loop's request base (`TestQueueRetunePromotesPromptMode`)
- [x] A declared retune mode clears a launch-time override; a silent retune preserves it (`TestQueueRetunePromptModeVersusLaunchOverride`)
- [x] The guided front door: explicit `task` lands on the spec, omitted stays unset, invalid refused, containers refuse (`TestGuidedCreatePromptMode`)
- [x] The update tool persists `prompt_mode` through the wire merge and refuses invalid values without mutating the stored spec (`TestLoopDefinitionUpdate_PromptMode`)
- [x] The three pinned definition documents parse and round-trip through the core-loops loader
- [x] `just ci` green locally

## After merge

The deploy-side half of #1171 remains an operator pass: `loop_definition_update` with `prompt_mode: "task"` on each prod worker loop (burn-ban poller and friends), and the usual signed talents backport carries the doctrine edits. The issue stays open until prod is rolled.

Refs #1171

🤖 Generated with [Claude Code](https://claude.com/claude-code)

