### PR TITLE
docs(release): audit the toolchain pins and recipes as a release step

### DIFF
--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -176,6 +176,49 @@ same fix after a release ships is migration work.
   - [ ] Premium/ops/assist semantics still match operator expectations
   - [ ] Dynamic model-registry overlays reviewed for any temporary canary-only policy changes
   - [ ] MCP server configuration verifies the right tools will land in the intended tags/toolboxes
+- [ ] **Toolchain and recipe audit**
+
+  Pinned tools exist for reproducibility, not preservation. A pin ages
+  silently: the canonical example is vacuum, pinned at v0.29.5 while
+  its schema-validation race
+  ([#1078](https://github.com/nugget/thane-ai-agent/issues/1078))
+  flaked the CI gate for weeks — upstream shipped three releases in
+  that window, and nobody looked, because no release step said to
+  look. Workarounds are the second half of the same failure: a retry
+  loop, a timeout bump, or a lint suppression written against a tool's
+  bug outlives the bug unless something forces the question. Running
+  this audit once per release is what makes "periodically" automatic.
+
+  - [ ] **Enumerate and bump the pins.** The homes:
+        [`tools/go.mod`](../tools/go.mod) — golangci-lint and vacuum,
+        the hermetic dev tools `just ci` runs — plus the `go`
+        directives in [`go.mod`](../go.mod) and `tools/go.mod`, and
+        the action pins in
+        [`.github/workflows/`](../.github/workflows/). Check each
+        upstream for newer releases and read the changelogs
+        specifically for fixes to problems we have worked around.
+        Bump deliberately: one tool per commit, full `just ci` after
+        each — a linter bump that surfaces new findings is
+        pre-release work by definition, cheap here and a
+        merge-blocker later.
+  - [ ] **Re-justify tool workarounds after each bump.** Every retry
+        loop, timeout flag, and `//nolint` written against a tool bug
+        was built for a specific version of that tool. After a bump,
+        test whether the workaround is still needed and delete it
+        when it isn't. The `lint-openapi` retry guard is the standing
+        example: once the upstream race is fixed, the retry is three
+        lines of ceremony hiding the fact that the problem is gone.
+  - [ ] **Audit the build/ci/deploy recipes against reality.** Walk
+        the `build`, `test`, and `deploy` groups in the
+        [`justfile`](../justfile) and ask of each recipe: does this
+        still describe how the thing actually happens? Deployment
+        reality drifts fastest — the launchd/systemd `service-*`
+        recipes describe supervisor paths that production no longer
+        uses (the companion app owns the prod lifecycle), and a
+        recipe that silently stopped being the real path is worse
+        than a deleted one. Prune what is dead, mark what is
+        dev-only, and confirm the `ci` recipe's step list still
+        matches the gate GitHub Actions runs.
 - [ ] **Code surface hygiene**
   - [ ] New code paths use inherited/component loggers, not ad-hoc `slog.Default()` where request or subsystem context matters
 


### PR DESCRIPTION
## Pins age silently; the checklist now forces the question

The release checklist audits code, docs, config, and model surfaces — but nothing in it ever asked whether the tools that *enforce* those audits were themselves current. That gap has a fresh, concrete cost: vacuum has been pinned at v0.29.5 since the #1060 capstone made `lint-openapi` a fail-severity gate, its schema-validation race (#1078) has been flaking that gate ever since — mitigated with a retry loop and generous timeouts rather than fixed — and upstream shipped v0.29.9, v0.29.10, and v0.30.0 in the meantime. Nobody looked, because no release step said to look. The operator hit a 1/100 💀 collapse on a local `just ci` this morning, which is what surfaced the whole story.

This adds a **Toolchain and recipe audit** to the Phase 1 pre-release audits, with three teeth:

- **Enumerate and bump the pins.** Names the actual homes — `tools/go.mod` (golangci-lint, vacuum), the `go` directives, the workflow action pins — and sets the discipline: read upstream changelogs specifically for fixes to problems we've worked around, bump one tool per commit, full `just ci` after each. A linter bump that surfaces new findings is pre-release work by definition: cheap in Phase 1, a merge-blocker later.
- **Re-justify tool workarounds after each bump.** Every retry loop, timeout flag, and `//nolint` written against a tool bug was built for a specific version of that tool, and outlives the bug unless something forces the question. The `lint-openapi` retry guard is the standing example — once the upstream race is fixed, the retry is ceremony hiding that the problem is gone.
- **Audit the build/ci/deploy recipes against reality.** Walk the justfile's `build`/`test`/`deploy` groups asking of each recipe whether it still describes how the thing actually happens. Deployment drifts fastest: the launchd/systemd `service-*` recipes describe supervisor paths production no longer uses (the companion app owns the prod lifecycle), and a recipe that silently stopped being the real path is worse than a deleted one.

Running the audit once per release is what makes "periodically update the pinned tools" automatic rather than aspirational — the cadence rides an existing ritual instead of relying on someone remembering.

The doc change deliberately does not itself bump vacuum; that's the first *execution* of the new checklist item, best done as its own PR where the flake-rate measurement can justify retiring the retry guard alongside the bump.

## Test plan

- [x] `just ci` green locally (link-check validates the new relative links)

Refs #1078

🤖 Generated with [Claude Code](https://claude.com/claude-code)
