### PR TITLE
docs(loops): the shipped documents carry the whole spec surface as reference

### DIFF
--- a/docs/reference/loop-definitions.md
+++ b/docs/reference/loop-definitions.md
@@ -1,0 +1,93 @@
+# Loop Definition Documents
+
+A core loop definition is a markdown document: the yaml spec block
+carries the machine-readable configuration, and prose sections carry
+the prompts. The shipped defaults live in [`loops/`](../../loops/) and
+are embedded into the binary at build time; an operator overrides one
+by placing a document of the same name in `<core>/loops/`, which wins
+and is re-read at every boot. Loops declared under `loops.definitions`
+in config.yaml use the same spec schema, minus the prose sections.
+
+The parser is strict on purpose: an unknown or misspelled key refuses
+the boot loudly rather than silently doing nothing. Run
+`thane validate` after editing — it parses the config and every
+definition document, reporting all problems at once — before
+restarting.
+
+## The document format
+
+Three H2 headings are reserved; every other heading is ordinary prose
+the parser ignores.
+
+| Section | Carries |
+|---|---|
+| `## Spec` | One fenced yaml block — the keys documented below |
+| `## Task` | The per-iteration prompt (the spec key `task` exists, but a document declaring both is refused — the section is the home for prose) |
+| `## Supervisor Review` | Extra instructions prepended on supervisor turns — the prose home for `supervisor_profile.instructions`, same both-declared-is-refused rule |
+
+## Identity and placement
+
+| Key | Meaning |
+|---|---|
+| `name` | Unique definition name; required. Everything downstream keys on it |
+| `intent` | One-sentence statement of why the loop exists; surfaced by the loop tools. Distinct from the task, which says what to do each wake |
+| `enabled` | Whether the definition auto-starts under runtime lifecycle management |
+| `parent_name` | Container to nest under, by name; the loop inherits the container's tags and subscriptions at launch. Omit for top-level |
+| `parent_id` | Runtime-assigned at launch; never authored — use `parent_name` |
+| `metadata` | Opaque string-to-string tags for correlation and audit; never interpreted as configuration |
+
+## Prompt shape
+
+| Key | Meaning |
+|---|---|
+| `prompt_mode` | `full` (default) wears the complete identity — persona, ego, axioms, always-on context. `task` is the compact worker prompt for mechanical maintainer/watcher/poller loops; it keeps tagged guidance, the task, and current conditions while shedding the identity. Loops that reflect on the agent or speak in its voice stay `full` |
+| `profile` | Routing and request shaping: `model` (pin a model), `quality_floor` (minimum model rating 1–10), `mission` (context profile), `local_only` / `prefer_speed` (`"true"`/`"false"` strings), `delegation_gating` (`disabled` gives direct tool access), `exclude_tools`, `instructions` (self-only text prepended to every iteration's task), `extra_hints` (free-form routing hints) |
+
+## Operation and completion
+
+| Key | Meaning |
+|---|---|
+| `operation` | `service` = perpetual, self-paced within the sleep envelope; `event_driven` = quiescent, wakes only on triggers (no timer fields allowed); `background_task` = detached one-shot; `request_reply` = synchronous one-shot; `container` = non-executing grouping node (execution-shaped keys are refused) |
+| `completion` | Where a result is delivered: `none` (the service-loop default), `return`, `conversation`, or `channel`. Mainly for one-shot operations |
+
+## Pacing and lifetime
+
+| Key | Meaning |
+|---|---|
+| `sleep_min` | Tightest interval between iterations (Go duration, e.g. `15m`); `set_next_sleep` can never wake sooner |
+| `sleep_max` | Loosest interval (e.g. `12h`) |
+| `sleep_default` | Initial sleep before the loop self-adjusts; must sit inside the envelope |
+| `jitter` | Sleep randomization factor in [0, 1]; `0.2` varies sleep by ±20% |
+| `max_duration` | Wall-clock lifetime cap (Go duration); omit for unbounded |
+| `max_iter` | Lifetime iteration cap; omit for unbounded |
+| `on_retrigger` | Behavior when triggered while already running: `single` (ignore), `restart`, `queue`, `spawn` |
+| `conditions` | Eligibility constraints — a `schedule` with `timezone` and day/time `windows`; empty means always eligible |
+
+## Outputs
+
+| Key | Meaning |
+|---|---|
+| `outputs` | Durable documents the loop maintains through generated tools. Entry keys: `name`, `type` (`maintained_document`, or `working_notes` for the loop-private variant), `ref` (managed document ref like `self:ego.md`), `mode` (`replace`), `purpose` (model-facing guidance), `facets` (`status_line` / `teaser` / `digest` projections; declaring any swaps the write tool to `publish_output_*`), `audience` (`published` or `internal`) |
+
+## Watching
+
+| Key | Meaning |
+|---|---|
+| `subscriptions` | Entities rendered into context every iteration. Entry keys: `entity_id` (an id, glob, or `area:`/`label:`/`floor:` target), `history` (context windows in seconds), `forecast` (for `weather.*` entities), `ttl_seconds`, `mode` (`render` / `ingest` / `both`), `self_only` (containers: keep out of descendants), `requires_tag`, `transitions` and `transitions_window_seconds` (recent state-change log), `wake` and `wake_debounce_seconds` (wake the loop on change, debounced) |
+
+## Supervisor turns
+
+| Key | Meaning |
+|---|---|
+| `supervisor` | Enable the per-wake Bernoulli trial that promotes an iteration to a more capable model |
+| `supervisor_prob` | Probability of a supervisor turn per wake, in [0, 1] |
+| `supervisor_profile` | Overlay applied on supervisor turns — same keys as `profile`; set fields win, unset fields fall back. Its `instructions` are carried by the `## Supervisor Review` section |
+
+## Tools and routing
+
+| Key | Meaning |
+|---|---|
+| `tags` | Capability tags activated at iteration 0: tool surface, tagged knowledge, tagged context |
+| `exclude_tools` | Tool names to deny. The token `group:direct_human_egress` expands to every direct human-messaging tool, so the list cannot go stale as tools are added |
+| `routing_factors` | Open-ended string map of router scoring inputs; prefer the named `profile` fields for well-known knobs |
+| `delegation_gating` | Top-level form of the same switch as `profile.delegation_gating`; prefer the profile form |

--- a/docs/reference/loop-definitions.md
+++ b/docs/reference/loop-definitions.md
@@ -1,23 +1,30 @@
-# Loop Definition Documents
+# Loop Definitions
 
-A core loop definition is a markdown document: the yaml spec block
-carries the machine-readable configuration, and prose sections carry
-the prompts. The shipped defaults live in [`loops/`](../../loops/) and
-are embedded into the binary at build time; an operator overrides one
-by placing a document of the same name in `<core>/loops/`, which wins
-and is re-read at every boot. Loops declared under `loops.definitions`
-in config.yaml use the same spec schema, minus the prose sections.
+A loop definition describes one loop — its identity, prompt shape,
+pacing, outputs, and watches. One spec schema underlies every way a
+definition comes to exist: the definition documents in a core root,
+the `loops.definitions` list in config.yaml, and the specs the agent
+authors itself through `thane_loop_create` and `loop_definition_set`.
+This page documents that schema.
 
-The parser is strict on purpose: an unknown or misspelled key refuses
+A definition document is self-contained by design — nothing in it is
+specific to one install except the entities it watches — so a document
+written for one Thane can run on another. The shipped documents in
+[`loops/`](../../loops/) are reference implementations of the form:
+embedded into the binary as defaults, overridden by a document of the
+same name in `<core>/loops/`, and re-read at every boot.
+
+## The document form
+
+A definition document is markdown: one fenced yaml block carries the
+spec, and prose sections carry the prompts. Three H2 headings are
+reserved; every other heading is ordinary prose the parser ignores.
+The parser is strict on purpose — an unknown or misspelled key refuses
 the boot loudly rather than silently doing nothing. Run
 `thane validate` after editing — it parses the config and every
 definition document, reporting all problems at once — before
-restarting.
-
-## The document format
-
-Three H2 headings are reserved; every other heading is ordinary prose
-the parser ignores.
+restarting. (Specs authored through the loop tools get the same
+validation from `loop_definition_lint` before anything persists.)
 
 | Section | Carries |
 |---|---|

--- a/internal/app/core_loop_reference_test.go
+++ b/internal/app/core_loop_reference_test.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"os"
 	"reflect"
 	"strings"
 	"testing"
@@ -9,19 +10,26 @@ import (
 	looppkg "github.com/nugget/thane-ai-agent/internal/runtime/loop"
 )
 
-// TestShippedCoreLoopDocumentsReferenceEverySpecKey pins the operator
-// contract the shipped definition documents carry: their spec blocks
-// double as the reference for the whole authorable surface, so every
-// yaml key on [looppkg.Spec] must appear in each document — live, or as
-// a commented reference line. The document loader refuses unknown keys,
-// which makes the documents the only place an operator can see the
-// accepted key names without reading Go; a Spec field that ships
-// without a reference line is invisible exactly where an operator
-// would look for it. Adding a field to Spec fails this test until the
-// shipped documents mention it.
-func TestShippedCoreLoopDocumentsReferenceEverySpecKey(t *testing.T) {
+// loopDefinitionsReferencePath is the operator-facing reference for the
+// loop definition document format, relative to this package.
+const loopDefinitionsReferencePath = "../../docs/reference/loop-definitions.md"
+
+// TestLoopDefinitionsReferenceCoversEverySpecKey pins the reference
+// contract: docs/reference/loop-definitions.md documents the whole
+// authorable spec surface. The document loader refuses unknown keys, so
+// the accepted key names are discoverable nowhere except that reference
+// — a Spec field it doesn't mention is invisible exactly where an
+// operator would look. Adding a field to Spec fails this test until the
+// reference documents it (backticked, the doc's convention for key
+// names) in the same PR.
+func TestLoopDefinitionsReferenceCoversEverySpecKey(t *testing.T) {
+	raw, err := os.ReadFile(loopDefinitionsReferencePath)
+	if err != nil {
+		t.Fatalf("read reference doc: %v", err)
+	}
+	doc := string(raw)
+
 	typ := reflect.TypeOf(looppkg.Spec{})
-	var keys []string
 	for i := 0; i < typ.NumField(); i++ {
 		field := typ.Field(i)
 		tag := strings.Split(field.Tag.Get("yaml"), ",")[0]
@@ -31,9 +39,18 @@ func TestShippedCoreLoopDocumentsReferenceEverySpecKey(t *testing.T) {
 		if tag == "" {
 			t.Fatalf("Spec.%s has no yaml tag; authorable fields need one, runtime-only fields need yaml:\"-\"", field.Name)
 		}
-		keys = append(keys, tag)
+		if !strings.Contains(doc, "`"+tag+"`") {
+			t.Errorf("docs/reference/loop-definitions.md does not document spec key %q; every authorable Spec field must appear there, backticked", tag)
+		}
 	}
+}
 
+// TestShippedCoreLoopDocumentsPointAtTheReference keeps the pointer
+// honest: each shipped definition document opens its spec block with a
+// comment naming the reference, so an operator editing an override
+// knows where the full surface is documented without reading Go. A
+// document that drops the pointer strands its next editor.
+func TestShippedCoreLoopDocumentsPointAtTheReference(t *testing.T) {
 	entries, err := coreloops.Documents.ReadDir("defaults")
 	if err != nil {
 		t.Fatalf("read embedded defaults: %v", err)
@@ -49,23 +66,8 @@ func TestShippedCoreLoopDocumentsReferenceEverySpecKey(t *testing.T) {
 		if err != nil {
 			t.Fatalf("read %s: %v", entry.Name(), err)
 		}
-		doc := string(raw)
-		for _, key := range keys {
-			// task is not a spec-block key in these documents: the
-			// "## Task" section carries the prompt, and declaring both
-			// is refused by the loader. The section heading is what
-			// satisfies the reference obligation — a reference line
-			// documenting a key the same file forbids would only
-			// confuse.
-			if key == "task" {
-				if !strings.Contains(doc, "## Task") {
-					t.Errorf("%s: no \"## Task\" section; the task belongs there, not in the spec block", entry.Name())
-				}
-				continue
-			}
-			if !strings.Contains(doc, key+":") {
-				t.Errorf("%s: spec key %q is neither set nor referenced; add it to the spec block's reference comment so operators can see the full surface", entry.Name(), key)
-			}
+		if !strings.Contains(string(raw), "docs/reference/loop-definitions.md") {
+			t.Errorf("%s: spec block does not point at docs/reference/loop-definitions.md; the pointer is how an operator finds the full key reference", entry.Name())
 		}
 	}
 }

--- a/internal/app/core_loop_reference_test.go
+++ b/internal/app/core_loop_reference_test.go
@@ -51,6 +51,18 @@ func TestShippedCoreLoopDocumentsReferenceEverySpecKey(t *testing.T) {
 		}
 		doc := string(raw)
 		for _, key := range keys {
+			// task is not a spec-block key in these documents: the
+			// "## Task" section carries the prompt, and declaring both
+			// is refused by the loader. The section heading is what
+			// satisfies the reference obligation — a reference line
+			// documenting a key the same file forbids would only
+			// confuse.
+			if key == "task" {
+				if !strings.Contains(doc, "## Task") {
+					t.Errorf("%s: no \"## Task\" section; the task belongs there, not in the spec block", entry.Name())
+				}
+				continue
+			}
 			if !strings.Contains(doc, key+":") {
 				t.Errorf("%s: spec key %q is neither set nor referenced; add it to the spec block's reference comment so operators can see the full surface", entry.Name(), key)
 			}

--- a/internal/app/core_loop_reference_test.go
+++ b/internal/app/core_loop_reference_test.go
@@ -1,0 +1,59 @@
+package app
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/nugget/thane-ai-agent/internal/app/coreloops"
+	looppkg "github.com/nugget/thane-ai-agent/internal/runtime/loop"
+)
+
+// TestShippedCoreLoopDocumentsReferenceEverySpecKey pins the operator
+// contract the shipped definition documents carry: their spec blocks
+// double as the reference for the whole authorable surface, so every
+// yaml key on [looppkg.Spec] must appear in each document — live, or as
+// a commented reference line. The document loader refuses unknown keys,
+// which makes the documents the only place an operator can see the
+// accepted key names without reading Go; a Spec field that ships
+// without a reference line is invisible exactly where an operator
+// would look for it. Adding a field to Spec fails this test until the
+// shipped documents mention it.
+func TestShippedCoreLoopDocumentsReferenceEverySpecKey(t *testing.T) {
+	typ := reflect.TypeOf(looppkg.Spec{})
+	var keys []string
+	for i := 0; i < typ.NumField(); i++ {
+		field := typ.Field(i)
+		tag := strings.Split(field.Tag.Get("yaml"), ",")[0]
+		if tag == "-" {
+			continue
+		}
+		if tag == "" {
+			t.Fatalf("Spec.%s has no yaml tag; authorable fields need one, runtime-only fields need yaml:\"-\"", field.Name)
+		}
+		keys = append(keys, tag)
+	}
+
+	entries, err := coreloops.Documents.ReadDir("defaults")
+	if err != nil {
+		t.Fatalf("read embedded defaults: %v", err)
+	}
+	if len(entries) == 0 {
+		t.Fatal("no embedded core loop documents; run go generate ./internal/app/coreloops/")
+	}
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".md") {
+			continue
+		}
+		raw, err := coreloops.Documents.ReadFile("defaults/" + entry.Name())
+		if err != nil {
+			t.Fatalf("read %s: %v", entry.Name(), err)
+		}
+		doc := string(raw)
+		for _, key := range keys {
+			if !strings.Contains(doc, key+":") {
+				t.Errorf("%s: spec key %q is neither set nor referenced; add it to the spec block's reference comment so operators can see the full surface", entry.Name(), key)
+			}
+		}
+	}
+}

--- a/internal/app/core_loop_reference_test.go
+++ b/internal/app/core_loop_reference_test.go
@@ -48,8 +48,12 @@ func TestLoopDefinitionsReferenceCoversEverySpecKey(t *testing.T) {
 // TestShippedCoreLoopDocumentsPointAtTheReference keeps the pointer
 // honest: each shipped definition document opens its spec block with a
 // comment naming the reference, so an operator editing an override
-// knows where the full surface is documented without reading Go. A
-// document that drops the pointer strands its next editor.
+// knows where the full surface is documented without reading Go. The
+// position is the contract, not just the presence — a pointer buried
+// in prose or below the keys is not where an editing eye starts — so
+// the check parses the ## Spec fence with the loader's own section
+// helpers and requires the reference path inside the block's leading
+// comment lines.
 func TestShippedCoreLoopDocumentsPointAtTheReference(t *testing.T) {
 	entries, err := coreloops.Documents.ReadDir("defaults")
 	if err != nil {
@@ -66,8 +70,27 @@ func TestShippedCoreLoopDocumentsPointAtTheReference(t *testing.T) {
 		if err != nil {
 			t.Fatalf("read %s: %v", entry.Name(), err)
 		}
-		if !strings.Contains(string(raw), "docs/reference/loop-definitions.md") {
-			t.Errorf("%s: spec block does not point at docs/reference/loop-definitions.md; the pointer is how an operator finds the full key reference", entry.Name())
+		specSection, ok := splitCoreLoopSections(string(raw))[coreLoopSpecHeading]
+		if !ok {
+			t.Errorf("%s: no %q section", entry.Name(), "## "+coreLoopSpecHeading)
+			continue
+		}
+		specYAML, ok := unfenceYAML(specSection)
+		if !ok {
+			t.Errorf("%s: the %q section is not a single yaml fence", entry.Name(), "## "+coreLoopSpecHeading)
+			continue
+		}
+		var lead []string
+		for _, line := range strings.Split(specYAML, "\n") {
+			trimmed := strings.TrimSpace(line)
+			if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+				lead = append(lead, trimmed)
+				continue
+			}
+			break
+		}
+		if !strings.Contains(strings.Join(lead, "\n"), "docs/reference/loop-definitions.md") {
+			t.Errorf("%s: the spec block does not open with a comment pointing at docs/reference/loop-definitions.md; the pointer is how an operator finds the full key reference, and its place is the top of the block", entry.Name())
 		}
 	}
 }

--- a/loops/archivist.md
+++ b/loops/archivist.md
@@ -97,12 +97,6 @@ metadata:
 # outputs: entries also accept facets (status_line/teaser/digest),
 #   audience (published|internal), purpose; type working_notes is the
 #   loop-private variant.
-#
-# Legacy config.yaml names translate as: min_sleep/max_sleep/
-#   default_sleep -> sleep_min/sleep_max/sleep_default;
-#   supervisor_probability -> supervisor_prob; router.quality_floor ->
-#   profile.quality_floor; supervisor_router.quality_floor ->
-#   supervisor_profile.quality_floor.
 # --------------------------------------------------------------------
 ```
 

--- a/loops/archivist.md
+++ b/loops/archivist.md
@@ -67,6 +67,43 @@ supervisor_profile:
 metadata:
     category: service
     subsystem: archivist
+# --- Spec key reference --------------------------------------------
+# The keys above are this loop's live configuration; the keys below
+# are the rest of the accepted surface, listed so an operator editing
+# an override sees every option without reading Go. The parser refuses
+# unknown keys — a typo fails the boot loudly, so run `thane validate`
+# before restarting. Comments are ignored.
+#
+# intent: ""             # one-sentence purpose, shown by the loop tools
+# task: ""               # not set here — the "## Task" section below
+#                        # carries the prompt; declaring both is refused
+# subscriptions: []      # entities rendered each turn; entry keys:
+#                        #   entity_id, history, forecast, ttl_seconds,
+#                        #   mode, self_only, requires_tag, transitions,
+#                        #   transitions_window_seconds, wake,
+#                        #   wake_debounce_seconds
+# conditions: {}         # eligibility, e.g. schedule: timezone + windows
+# max_duration: 1h       # wall-clock lifetime cap; omit = unbounded
+# max_iter: 100          # lifetime iteration cap; omit = unbounded
+# on_retrigger: single   # single | restart | queue | spawn
+# routing_factors: {}    # open-ended router hints (string map)
+# delegation_gating: ""  # top-level form; prefer profile.delegation_gating
+# parent_id: ""          # runtime-assigned at launch; author parent_name
+#
+# profile: also accepts model, local_only, prefer_speed, instructions,
+#   exclude_tools, extra_hints. supervisor_profile: accepts the same
+#   keys; its instructions are carried by the "## Supervisor Review"
+#   section of this document (declaring both is refused).
+# outputs: entries also accept facets (status_line/teaser/digest),
+#   audience (published|internal), purpose; type working_notes is the
+#   loop-private variant.
+#
+# Legacy config.yaml names translate as: min_sleep/max_sleep/
+#   default_sleep -> sleep_min/sleep_max/sleep_default;
+#   supervisor_probability -> supervisor_prob; router.quality_floor ->
+#   profile.quality_floor; supervisor_router.quality_floor ->
+#   supervisor_profile.quality_floor.
+# --------------------------------------------------------------------
 ```
 
 ## Task

--- a/loops/archivist.md
+++ b/loops/archivist.md
@@ -11,6 +11,7 @@ tags: [loops]
 name: archivist
 parent_name: self
 enabled: true
+intent: Turn the accumulated flow of memory — archive, sessions, facts, contacts — into coherent subject dossiers, self-paced from a durable work queue.
 profile:
     quality_floor: 5
     mission: archivist
@@ -18,8 +19,11 @@ profile:
     extra_hints:
         source: archivist
 operation: service
-# Reflective loop: wears the full identity stack by design. This pin
-# guards against any future default that trims service loops (#1171).
+# "full" keeps the complete identity — persona, ego, axioms, the
+# always-on context — in this loop's prompt. This loop's work is the
+# agent's own self, which is exactly what the compact "task" worker
+# prompt strips away, so the mode is pinned here rather than left to
+# any default.
 prompt_mode: full
 completion: none
 outputs:
@@ -74,9 +78,6 @@ metadata:
 # unknown keys — a typo fails the boot loudly, so run `thane validate`
 # before restarting. Comments are ignored.
 #
-# intent: ""             # one-sentence purpose, shown by the loop tools
-# task: ""               # not set here — the "## Task" section below
-#                        # carries the prompt; declaring both is refused
 # subscriptions: []      # entities rendered each turn; entry keys:
 #                        #   entity_id, history, forecast, ttl_seconds,
 #                        #   mode, self_only, requires_tag, transitions,

--- a/loops/archivist.md
+++ b/loops/archivist.md
@@ -8,6 +8,9 @@ tags: [loops]
 ## Spec
 
 ```yaml
+# Every key this block accepts is documented in
+# docs/reference/loop-definitions.md. Unknown keys refuse the boot —
+# run `thane validate` after editing.
 name: archivist
 parent_name: self
 enabled: true
@@ -71,34 +74,6 @@ supervisor_profile:
 metadata:
     category: service
     subsystem: archivist
-# --- Spec key reference --------------------------------------------
-# The keys above are this loop's live configuration; the keys below
-# are the rest of the accepted surface, listed so an operator editing
-# an override sees every option without reading Go. The parser refuses
-# unknown keys — a typo fails the boot loudly, so run `thane validate`
-# before restarting. Comments are ignored.
-#
-# subscriptions: []      # entities rendered each turn; entry keys:
-#                        #   entity_id, history, forecast, ttl_seconds,
-#                        #   mode, self_only, requires_tag, transitions,
-#                        #   transitions_window_seconds, wake,
-#                        #   wake_debounce_seconds
-# conditions: {}         # eligibility, e.g. schedule: timezone + windows
-# max_duration: 1h       # wall-clock lifetime cap; omit = unbounded
-# max_iter: 100          # lifetime iteration cap; omit = unbounded
-# on_retrigger: single   # single | restart | queue | spawn
-# routing_factors: {}    # open-ended router hints (string map)
-# delegation_gating: ""  # top-level form; prefer profile.delegation_gating
-# parent_id: ""          # runtime-assigned at launch; author parent_name
-#
-# profile: also accepts model, local_only, prefer_speed, instructions,
-#   exclude_tools, extra_hints. supervisor_profile: accepts the same
-#   keys; its instructions are carried by the "## Supervisor Review"
-#   section of this document (declaring both is refused).
-# outputs: entries also accept facets (status_line/teaser/digest),
-#   audience (published|internal), purpose; type working_notes is the
-#   loop-private variant.
-# --------------------------------------------------------------------
 ```
 
 ## Task

--- a/loops/ego.md
+++ b/loops/ego.md
@@ -8,6 +8,9 @@ tags: [loops]
 ## Spec
 
 ```yaml
+# Every key this block accepts is documented in
+# docs/reference/loop-definitions.md. Unknown keys refuse the boot —
+# run `thane validate` after editing.
 name: ego
 parent_name: self
 enabled: true
@@ -64,34 +67,6 @@ supervisor_profile:
 metadata:
     category: service
     subsystem: ego
-# --- Spec key reference --------------------------------------------
-# The keys above are this loop's live configuration; the keys below
-# are the rest of the accepted surface, listed so an operator editing
-# an override sees every option without reading Go. The parser refuses
-# unknown keys — a typo fails the boot loudly, so run `thane validate`
-# before restarting. Comments are ignored.
-#
-# subscriptions: []      # entities rendered each turn; entry keys:
-#                        #   entity_id, history, forecast, ttl_seconds,
-#                        #   mode, self_only, requires_tag, transitions,
-#                        #   transitions_window_seconds, wake,
-#                        #   wake_debounce_seconds
-# conditions: {}         # eligibility, e.g. schedule: timezone + windows
-# max_duration: 1h       # wall-clock lifetime cap; omit = unbounded
-# max_iter: 100          # lifetime iteration cap; omit = unbounded
-# on_retrigger: single   # single | restart | queue | spawn
-# routing_factors: {}    # open-ended router hints (string map)
-# delegation_gating: ""  # top-level form; prefer profile.delegation_gating
-# parent_id: ""          # runtime-assigned at launch; author parent_name
-#
-# profile: also accepts model, local_only, prefer_speed, instructions,
-#   exclude_tools, extra_hints. supervisor_profile: accepts the same
-#   keys; its instructions are carried by the "## Supervisor Review"
-#   section of this document (declaring both is refused).
-# outputs: entries also accept facets (status_line/teaser/digest),
-#   audience (published|internal), purpose; type working_notes is the
-#   loop-private variant.
-# --------------------------------------------------------------------
 ```
 
 ## Task

--- a/loops/ego.md
+++ b/loops/ego.md
@@ -11,6 +11,7 @@ tags: [loops]
 name: ego
 parent_name: self
 enabled: true
+intent: Keep the agent's self-understanding honest and current in ego.md — the self every interactive turn wears.
 profile:
     quality_floor: 5
     mission: ego
@@ -18,8 +19,11 @@ profile:
     extra_hints:
         source: ego
 operation: service
-# Reflective loop: wears the full identity stack by design. This pin
-# guards against any future default that trims service loops (#1171).
+# "full" keeps the complete identity — persona, ego, axioms, the
+# always-on context — in this loop's prompt. This loop's work is the
+# agent's own self, which is exactly what the compact "task" worker
+# prompt strips away, so the mode is pinned here rather than left to
+# any default.
 prompt_mode: full
 completion: none
 outputs:
@@ -67,9 +71,6 @@ metadata:
 # unknown keys — a typo fails the boot loudly, so run `thane validate`
 # before restarting. Comments are ignored.
 #
-# intent: ""             # one-sentence purpose, shown by the loop tools
-# task: ""               # not set here — the "## Task" section below
-#                        # carries the prompt; declaring both is refused
 # subscriptions: []      # entities rendered each turn; entry keys:
 #                        #   entity_id, history, forecast, ttl_seconds,
 #                        #   mode, self_only, requires_tag, transitions,

--- a/loops/ego.md
+++ b/loops/ego.md
@@ -90,12 +90,6 @@ metadata:
 # outputs: entries also accept facets (status_line/teaser/digest),
 #   audience (published|internal), purpose; type working_notes is the
 #   loop-private variant.
-#
-# Legacy config.yaml names translate as: min_sleep/max_sleep/
-#   default_sleep -> sleep_min/sleep_max/sleep_default;
-#   supervisor_probability -> supervisor_prob; router.quality_floor ->
-#   profile.quality_floor; supervisor_router.quality_floor ->
-#   supervisor_profile.quality_floor.
 # --------------------------------------------------------------------
 ```
 

--- a/loops/ego.md
+++ b/loops/ego.md
@@ -60,6 +60,43 @@ supervisor_profile:
 metadata:
     category: service
     subsystem: ego
+# --- Spec key reference --------------------------------------------
+# The keys above are this loop's live configuration; the keys below
+# are the rest of the accepted surface, listed so an operator editing
+# an override sees every option without reading Go. The parser refuses
+# unknown keys — a typo fails the boot loudly, so run `thane validate`
+# before restarting. Comments are ignored.
+#
+# intent: ""             # one-sentence purpose, shown by the loop tools
+# task: ""               # not set here — the "## Task" section below
+#                        # carries the prompt; declaring both is refused
+# subscriptions: []      # entities rendered each turn; entry keys:
+#                        #   entity_id, history, forecast, ttl_seconds,
+#                        #   mode, self_only, requires_tag, transitions,
+#                        #   transitions_window_seconds, wake,
+#                        #   wake_debounce_seconds
+# conditions: {}         # eligibility, e.g. schedule: timezone + windows
+# max_duration: 1h       # wall-clock lifetime cap; omit = unbounded
+# max_iter: 100          # lifetime iteration cap; omit = unbounded
+# on_retrigger: single   # single | restart | queue | spawn
+# routing_factors: {}    # open-ended router hints (string map)
+# delegation_gating: ""  # top-level form; prefer profile.delegation_gating
+# parent_id: ""          # runtime-assigned at launch; author parent_name
+#
+# profile: also accepts model, local_only, prefer_speed, instructions,
+#   exclude_tools, extra_hints. supervisor_profile: accepts the same
+#   keys; its instructions are carried by the "## Supervisor Review"
+#   section of this document (declaring both is refused).
+# outputs: entries also accept facets (status_line/teaser/digest),
+#   audience (published|internal), purpose; type working_notes is the
+#   loop-private variant.
+#
+# Legacy config.yaml names translate as: min_sleep/max_sleep/
+#   default_sleep -> sleep_min/sleep_max/sleep_default;
+#   supervisor_probability -> supervisor_prob; router.quality_floor ->
+#   profile.quality_floor; supervisor_router.quality_floor ->
+#   supervisor_profile.quality_floor.
+# --------------------------------------------------------------------
 ```
 
 ## Task

--- a/loops/metacognitive.md
+++ b/loops/metacognitive.md
@@ -11,6 +11,7 @@ tags: [loops]
 name: metacognitive
 parent_name: self
 enabled: true
+intent: Watch the system's own operation — loops, queues, documents, spend — against recorded baselines, and escalate evidenced drift or incidents to core.
 profile:
     quality_floor: 3
     mission: metacognitive
@@ -18,8 +19,11 @@ profile:
     extra_hints:
         source: metacognitive
 operation: service
-# Reflective loop: wears the full identity stack by design. This pin
-# guards against any future default that trims service loops (#1171).
+# "full" keeps the complete identity — persona, ego, axioms, the
+# always-on context — in this loop's prompt. This loop's work is the
+# agent's own self, which is exactly what the compact "task" worker
+# prompt strips away, so the mode is pinned here rather than left to
+# any default.
 prompt_mode: full
 completion: none
 outputs:
@@ -68,9 +72,6 @@ metadata:
 # unknown keys — a typo fails the boot loudly, so run `thane validate`
 # before restarting. Comments are ignored.
 #
-# intent: ""             # one-sentence purpose, shown by the loop tools
-# task: ""               # not set here — the "## Task" section below
-#                        # carries the prompt; declaring both is refused
 # subscriptions: []      # entities rendered each turn; entry keys:
 #                        #   entity_id, history, forecast, ttl_seconds,
 #                        #   mode, self_only, requires_tag, transitions,

--- a/loops/metacognitive.md
+++ b/loops/metacognitive.md
@@ -8,6 +8,9 @@ tags: [loops]
 ## Spec
 
 ```yaml
+# Every key this block accepts is documented in
+# docs/reference/loop-definitions.md. Unknown keys refuse the boot —
+# run `thane validate` after editing.
 name: metacognitive
 parent_name: self
 enabled: true
@@ -65,34 +68,6 @@ supervisor_profile:
 metadata:
     category: service
     subsystem: metacognitive
-# --- Spec key reference --------------------------------------------
-# The keys above are this loop's live configuration; the keys below
-# are the rest of the accepted surface, listed so an operator editing
-# an override sees every option without reading Go. The parser refuses
-# unknown keys — a typo fails the boot loudly, so run `thane validate`
-# before restarting. Comments are ignored.
-#
-# subscriptions: []      # entities rendered each turn; entry keys:
-#                        #   entity_id, history, forecast, ttl_seconds,
-#                        #   mode, self_only, requires_tag, transitions,
-#                        #   transitions_window_seconds, wake,
-#                        #   wake_debounce_seconds
-# conditions: {}         # eligibility, e.g. schedule: timezone + windows
-# max_duration: 1h       # wall-clock lifetime cap; omit = unbounded
-# max_iter: 100          # lifetime iteration cap; omit = unbounded
-# on_retrigger: single   # single | restart | queue | spawn
-# routing_factors: {}    # open-ended router hints (string map)
-# delegation_gating: ""  # top-level form; prefer profile.delegation_gating
-# parent_id: ""          # runtime-assigned at launch; author parent_name
-#
-# profile: also accepts model, local_only, prefer_speed, instructions,
-#   exclude_tools, extra_hints. supervisor_profile: accepts the same
-#   keys; its instructions are carried by the "## Supervisor Review"
-#   section of this document (declaring both is refused).
-# outputs: entries also accept facets (status_line/teaser/digest),
-#   audience (published|internal), purpose; type working_notes is the
-#   loop-private variant.
-# --------------------------------------------------------------------
 ```
 
 ## Task

--- a/loops/metacognitive.md
+++ b/loops/metacognitive.md
@@ -61,6 +61,43 @@ supervisor_profile:
 metadata:
     category: service
     subsystem: metacognitive
+# --- Spec key reference --------------------------------------------
+# The keys above are this loop's live configuration; the keys below
+# are the rest of the accepted surface, listed so an operator editing
+# an override sees every option without reading Go. The parser refuses
+# unknown keys — a typo fails the boot loudly, so run `thane validate`
+# before restarting. Comments are ignored.
+#
+# intent: ""             # one-sentence purpose, shown by the loop tools
+# task: ""               # not set here — the "## Task" section below
+#                        # carries the prompt; declaring both is refused
+# subscriptions: []      # entities rendered each turn; entry keys:
+#                        #   entity_id, history, forecast, ttl_seconds,
+#                        #   mode, self_only, requires_tag, transitions,
+#                        #   transitions_window_seconds, wake,
+#                        #   wake_debounce_seconds
+# conditions: {}         # eligibility, e.g. schedule: timezone + windows
+# max_duration: 1h       # wall-clock lifetime cap; omit = unbounded
+# max_iter: 100          # lifetime iteration cap; omit = unbounded
+# on_retrigger: single   # single | restart | queue | spawn
+# routing_factors: {}    # open-ended router hints (string map)
+# delegation_gating: ""  # top-level form; prefer profile.delegation_gating
+# parent_id: ""          # runtime-assigned at launch; author parent_name
+#
+# profile: also accepts model, local_only, prefer_speed, instructions,
+#   exclude_tools, extra_hints. supervisor_profile: accepts the same
+#   keys; its instructions are carried by the "## Supervisor Review"
+#   section of this document (declaring both is refused).
+# outputs: entries also accept facets (status_line/teaser/digest),
+#   audience (published|internal), purpose; type working_notes is the
+#   loop-private variant.
+#
+# Legacy config.yaml names translate as: min_sleep/max_sleep/
+#   default_sleep -> sleep_min/sleep_max/sleep_default;
+#   supervisor_probability -> supervisor_prob; router.quality_floor ->
+#   profile.quality_floor; supervisor_router.quality_floor ->
+#   supervisor_profile.quality_floor.
+# --------------------------------------------------------------------
 ```
 
 ## Task

--- a/loops/metacognitive.md
+++ b/loops/metacognitive.md
@@ -91,12 +91,6 @@ metadata:
 # outputs: entries also accept facets (status_line/teaser/digest),
 #   audience (published|internal), purpose; type working_notes is the
 #   loop-private variant.
-#
-# Legacy config.yaml names translate as: min_sleep/max_sleep/
-#   default_sleep -> sleep_min/sleep_max/sleep_default;
-#   supervisor_probability -> supervisor_prob; router.quality_floor ->
-#   profile.quality_floor; supervisor_router.quality_floor ->
-#   supervisor_profile.quality_floor.
 # --------------------------------------------------------------------
 ```
 


### PR DESCRIPTION
## One reference document, three pointers

A core loop definition document is the authoritative home for its loop's configuration — and the loader enforces that authority with `KnownFields`, refusing any key it doesn't recognize. The combination creates a discoverability trap: the spec block only shows the keys it uses, unknown keys can't be probed by experiment (a guess refuses the boot), and the full accepted surface lives nowhere but the Go struct. The trap sprang in production this week, when an operator reasonably read a document as missing options it actually carried under different names.

The first draft answered with a commented appendix in each document's spec block. Review reshaped it into something better: the reference lives **once**, as a real document — [`docs/reference/loop-definitions.md`](../blob/docs/loop-spec-reference/docs/reference/loop-definitions.md) — where tables can carry what yaml comments cramped: the reserved-section contract (`## Spec` / `## Task` / `## Supervisor Review`, and the both-declared-is-refused rules), every top-level key grouped by concern, the nested option sets on `profile` / `outputs` / `subscriptions`, and the strictness story (`thane validate` reports every problem at once). Each shipped document opens its spec block with a three-line pointer to it.

Review also made the shipped documents themselves speak for the reader who wasn't present for their history:

- **`intent` is populated for real** on all three loops — it's a first-class field the loop tools surface, and the distribution's own graph should be self-describing.
- **No forbidden-key documentation** — the draft's `task: ""` reference line (a key the same file refuses when the `## Task` section exists) is gone; the section is self-evident.
- **The `prompt_mode` pin comment explains itself** — what `full` keeps, why this loop's work needs it, why it's pinned — without coined taxonomy or issue-number homework. The legacy config-name translation table went the same way: history belongs in commit messages, not reference.

The drift gate follows the content: `TestLoopDefinitionsReferenceCoversEverySpecKey` reflects over `Spec`'s yaml tags and fails when the reference document misses an authorable key, and `TestShippedCoreLoopDocumentsPointAtTheReference` keeps the pointer present in every shipped document. A new `Spec` field still can't ship undocumented, and a document can't quietly strand its next editor.

Operator note: prod's `core/loops/` overrides are currently byte-identical to the pre-#1358 shipped spec blocks; adopting these documents wholesale in the next backport picks up the pointer, the populated intents, and the `prompt_mode: full` pins in one move.

## Test plan

- [x] `TestLoopDefinitionsReferenceCoversEverySpecKey` — every authorable `Spec` yaml key appears in the reference doc
- [x] `TestShippedCoreLoopDocumentsPointAtTheReference` — every embedded document carries the pointer
- [x] Existing core-loop loader/parity tests still parse the documents
- [x] `just ci` green locally (link-check validates the new document's links)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
