### PR TITLE
fix(archivist): the definition document is the single enablement gate

### DIFF
--- a/internal/app/archivist_session_close_wake.go
+++ b/internal/app/archivist_session_close_wake.go
@@ -101,13 +101,13 @@ func (a *App) enqueueSessionCloseWork(ctx context.Context, sessionID, conversati
 // few-minutes latency advantage is irrelevant to the hourly, self-paced
 // archivist. One gate, not two (issue #1024).
 //
-// Skipped when archivist.enabled is false or the queue is absent: there is no
-// consumer, so don't accumulate work.
+// Skipped when the archivist definition is absent or disabled, or the queue
+// is missing: there is no consumer, so don't accumulate work.
 func (a *App) wireSessionCloseToArchivistQueue() {
 	if a == nil || a.archiveStore == nil || a.loopQueue == nil {
 		return
 	}
-	if a.cfg == nil || !a.cfg.Archivist.Enabled {
+	if !a.archivistDefinitionEnabled() {
 		return
 	}
 	if a.summaryWorker == nil {
@@ -124,4 +124,24 @@ func (a *App) wireSessionCloseToArchivistQueue() {
 			"loop", archivist.DefinitionName,
 		)
 	}
+}
+
+// archivistDefinitionEnabled reports whether the archivist's effective loop
+// definition exists and is enabled — the single gate for wiring the
+// session-close producer. The definition document (core/loops/archivist.md,
+// or the shipped default) is the same declaration that makes the loop run,
+// so the producer wires exactly when a consumer exists. The legacy
+// config.yaml `archivist.enabled` flag is deliberately not consulted: the
+// definition made it a second switch for the same loop, and the two could
+// only disagree silently — a running archivist whose queue never fills.
+//
+// Runtime policy (paused/inactive) is also deliberately not consulted: a
+// pause is temporary, and work accumulated while paused is exactly what the
+// resumed loop should drain. Only the durable declaration decides.
+func (a *App) archivistDefinitionEnabled() bool {
+	if a == nil {
+		return false
+	}
+	spec, ok := a.loopDefinitionRegistry.Get(archivist.DefinitionName)
+	return ok && spec.Enabled
 }

--- a/internal/app/archivist_session_close_wake_test.go
+++ b/internal/app/archivist_session_close_wake_test.go
@@ -4,12 +4,73 @@ import (
 	"context"
 	"testing"
 
+	"github.com/nugget/thane-ai-agent/internal/platform/config"
 	"github.com/nugget/thane-ai-agent/internal/platform/database"
 	"github.com/nugget/thane-ai-agent/internal/runtime/archivist"
+	looppkg "github.com/nugget/thane-ai-agent/internal/runtime/loop"
 	"github.com/nugget/thane-ai-agent/internal/state/loopqueue"
 
 	_ "modernc.org/sqlite"
 )
+
+// TestArchivistDefinitionEnabledGatesQueueWiring pins the single-gate
+// contract: the session-close producer wires exactly when the archivist's
+// effective loop definition exists and is enabled. The legacy config flag
+// must be irrelevant — before this gate existed, config said whether the
+// queue filled while the definition said whether the loop ran, and the two
+// could disagree in only one direction: silently.
+func TestArchivistDefinitionEnabledGatesQueueWiring(t *testing.T) {
+	archivistSpec := func(enabled bool) looppkg.Spec {
+		return looppkg.Spec{
+			Name:      archivist.DefinitionName,
+			Enabled:   enabled,
+			Task:      "archive things",
+			Operation: looppkg.OperationService,
+		}
+	}
+	registryWith := func(t *testing.T, specs ...looppkg.Spec) *looppkg.DefinitionRegistry {
+		t.Helper()
+		reg, err := looppkg.NewDefinitionRegistry(specs)
+		if err != nil {
+			t.Fatalf("NewDefinitionRegistry: %v", err)
+		}
+		return reg
+	}
+
+	t.Run("enabled definition wires, config flag not consulted", func(t *testing.T) {
+		a := &App{
+			loopDefinitionRegistry: registryWith(t, archivistSpec(true)),
+			// The legacy flag says off; the definition says on. The
+			// definition wins because it is the same declaration that
+			// runs the loop.
+			cfg: &config.Config{},
+		}
+		if !a.archivistDefinitionEnabled() {
+			t.Error("enabled definition should gate the wiring on, regardless of config.archivist.enabled")
+		}
+	})
+
+	t.Run("disabled definition does not wire", func(t *testing.T) {
+		a := &App{loopDefinitionRegistry: registryWith(t, archivistSpec(false))}
+		if a.archivistDefinitionEnabled() {
+			t.Error("disabled definition should gate the wiring off")
+		}
+	})
+
+	t.Run("absent definition does not wire", func(t *testing.T) {
+		a := &App{loopDefinitionRegistry: registryWith(t)}
+		if a.archivistDefinitionEnabled() {
+			t.Error("absent definition should gate the wiring off")
+		}
+	})
+
+	t.Run("nil registry does not wire", func(t *testing.T) {
+		a := &App{}
+		if a.archivistDefinitionEnabled() {
+			t.Error("nil registry should gate the wiring off")
+		}
+	})
+}
 
 func newQueueTestApp(t *testing.T) (*App, *loopqueue.Store) {
 	t.Helper()


### PR DESCRIPTION
## One loop, one switch

Since the metacog pivot made the definition documents authoritative, the legacy `ego:` / `metacognitive:` / `archivist:` config sections have been dead weight — `HydrateSpec` ignores them, `applyDefaults` backfills them, and the documents carry identical values. All except one field: `config.archivist.enabled` still gated `wireSessionCloseToArchivistQueue`, the producer that feeds closed sessions into the archivist's work queue.

That made the archivist a loop with two switches: the definition document decided whether it *runs*, the config flag decided whether its queue *fills*. Two switches for one loop can only disagree silently, and in the worst direction — an operator who removes the legacy config section (reasonable, given everything else in it is dead) gets an archivist that keeps waking on its timer, finds an empty queue, sleeps, and quietly stops producing dossiers. No error anywhere; just an ever-quieter archivist. This was found during the config-cleanup audit for exactly that planned removal.

Now `wireSessionCloseToArchivistQueue` asks the definition registry whether an enabled archivist definition exists — the same declaration that starts the loop — so the producer wires exactly when a consumer exists. Two deliberate non-consultations, both documented in the Godoc: the legacy config flag (no longer read anywhere), and runtime policy — a pause is temporary, and work accumulated while paused is exactly what the resumed loop should drain. Only the durable declaration decides.

`TestArchivistDefinitionEnabledGatesQueueWiring` pins the contract in all four directions: enabled definition wires (with the config flag explicitly set off, proving irrelevance), disabled doesn't, absent doesn't, nil registry doesn't.

## Operator consequence

After this deploys, the `archivist:` section in production `config.yaml` is fully removable, like its `ego:` and `metacognitive:` siblings — no `enabled: true` stub needed. Removal ordering matters in the usual direction: config trim only after this binary is running.

## Test plan

- [x] `TestArchivistDefinitionEnabledGatesQueueWiring` — all four gate directions
- [x] Existing session-close enqueue/filter tests unaffected
- [x] `just ci` green locally

Refs #1024

🤖 Generated with [Claude Code](https://claude.com/claude-code)
