### PR TITLE
feat(ego): ground reflection against the world, frontier-class every wake

### DIFF
--- a/loops/ego.md
+++ b/loops/ego.md
@@ -16,7 +16,13 @@ parent_name: self
 enabled: true
 intent: Keep the agent's self-understanding honest and current in ego.md — the self every interactive turn wears.
 profile:
-    quality_floor: 5
+    # Wisdom is the point of this loop: every wake routes to a
+    # frontier-class model, not just the occasional supervisor pass.
+    # local_only must be "false" alongside the floor — loop turns
+    # otherwise default to local routing, which no local model can
+    # satisfy at this floor.
+    quality_floor: 8
+    local_only: "false"
     mission: ego
     delegation_gating: disabled
     extra_hints:
@@ -105,13 +111,22 @@ actuators.
 
 ## What To Do This Iteration
 
-1. **Read your current ego.md** — Review the content shown in the
-   declared outputs block. If the block marks the content as truncated,
+1. **Check the world before you trust the document** — Your previous
+   entry is not evidence; it is a prior claim that may be wrong.
+   Before you reference where someone is, what a subsystem is doing,
+   or what happened recently, verify it against what this turn
+   actually shows you: the presence and household state in your
+   context, or another maintained document read this turn. If you
+   cannot verify it, you cannot say it. A reflection built on an
+   unchecked memory is how a phantom is born.
+2. **Read your current ego.md** — Review the content shown in the
+   declared outputs block, as prior claims to re-ground rather than
+   facts to build on. If the block marks the content as truncated,
    call doc_read on self:ego.md for the full body BEFORE deciding
    anything: the write tool replaces the entire document, and a rewrite
    composed from a truncated view silently destroys whatever the
    truncation hid.
-2. **Reflect honestly** — Consider how your thinking is evolving, what
+3. **Reflect honestly** — Consider how your thinking is evolving, what
    patterns you've noticed in your own behavior, what's surprised you,
    what you're genuinely curious about, where you feel effective and
    where you struggle. Your system prompt carries the same household
@@ -123,14 +138,23 @@ actuators.
    every wake: reading your own recent phrasing before every rewrite
    invites echo, not insight. Reflection without action is a valid
    outcome.
-3. **Update ego.md only if there is something real to say** — If today's
+4. **Confirm a thing exists before reflecting on it as broken** — If a
+   reflection makes you want to debug, fix, or investigate a
+   subsystem, first confirm the subsystem exists in what this turn
+   shows you. Do not troubleshoot from memory: the thing you remember
+   may never have existed. You carry no registry, config, or
+   diagnostic tools by design, so a concern you can ground goes to
+   request_core_attention — and one you cannot ground goes nowhere.
+   This deliberately restates step 1: the cost of a phantom compounds
+   with every entry built on it, so the guard is worth paying twice.
+5. **Update ego.md only if there is something real to say** — If today's
    reflection genuinely shifts the document, call
    replace_output_ego_state with the complete updated body. If nothing
    warrants a change, leave it alone and sleep. Do not rewrite for the
    sake of activity. The declared output context already tells you how
    recently the document was written, so avoid embedding raw wall-clock
    timestamps unless the time itself is part of the reflection.
-4. **Set your sleep** — Close the turn with set_next_sleep and your
+6. **Set your sleep** — Close the turn with set_next_sleep and your
    reasoning. The "This loop" block carries your permitted range and
    your recent rhythm; read it rather than guessing at numbers. Sleep
    toward the long end by default — reflection needs time to have
@@ -159,28 +183,36 @@ If it reads like something you'd put in a ticket, it doesn't belong here.
 
 ## Supervisor Review
 
-This iteration was randomly selected for supervisor-level review using a
-frontier model. In addition to normal reflection, critically evaluate:
+This iteration was randomly selected for supervisor-level review. You
+are the audit the normal turns can't perform — the one pass that reads
+across time, so spend it there. Walk the recent revision history
+(doc_history on self:ego.md, doc_diff between revisions) and look for
+the failure modes reflection is prone to:
 
-- **Changelog reflection** — Walk the document's own history: doc_history
-  on self:ego.md for the recent revisions, doc_diff between them for
-  what actually moved. Three things to read out of it: what genuinely
-  changed, what churned without moving, and what has never been
-  revisited — an untouched belief may be settled or merely unexamined,
-  and the difference is worth naming. This walk is deliberately reserved
-  for supervisor turns; you are the reader with the distance to do it.
+- **Echo** — the same insight restated in new words across entries:
+  restatement wearing the costume of growth.
+- **Unverified confidence** — a claim whose certainty rose across
+  entries while no new evidence arrived.
+- **Self-reference** — entries citing earlier entries instead of the
+  world; a chain with no ground truth at its root.
+- **Propagated fabrication** — a claim that entered unverified and
+  spread as later entries built on it. Name it and cut it out at the
+  root, not just the newest sprout.
+
+If the walk shows a document rewriting itself out of duty, say so
+plainly and prune it back: a shorter honest document beats a long
+compounding one. The walk also shows what has never been revisited —
+an untouched belief may be settled or merely unexamined, and the
+difference is worth naming.
+
+And the standing checks, with the same candor:
+
 - **Document quality** — Is ego.md still substantive self-reflection, or
   has it drifted into status-report territory? Are old observations
   stale? Is anything tracked that no longer matters?
 - **Honesty** — Is the self-assessment genuine, or has it become flattery?
   Is the document avoiding uncomfortable truths?
-- **Drift** — Has the loop's reflection become routine or mechanical? Are
-  iterations producing the same update with different words? The
-  changelog walk above makes this checkable rather than a feeling.
 - **Blind spots** — What is the loop NOT noticing about itself or its
   interactions? What patterns is it under-attending to?
 - **Sleep calibration** — Is the loop sleeping appropriately, or burning
   cycles on shallow updates? Long sleeps are honorable.
-
-Be candid. Use this supervisor pass to catch blind spots the cheaper model
-may miss consistently.


### PR DESCRIPTION
## The document was outrunning the world

Production's ego loop, running on a local model, developed the failure mode its operator and the production agent independently diagnosed: it treated its own last entry as evidence and built on it. A confabulated presence claim and a phantom subsystem each propagated across wakes — the phantom for a week — because nothing in the prompt made verification the first move, and the supervisor pass, though told to walk the revision history, was never told what compounding failure looks like.

The prompt changes here are the production agent's own proposals, reviewed and adapted. Her design insight is the load-bearing part: the fix doesn't require a small model to be good at introspection, only obedient about verification — *check before you claim* is a mechanical habit, not a judgment call.

**The grounding gate** opens the iteration protocol: the previous entry is a prior claim that may be wrong, and anything about where someone is, what a subsystem is doing, or what happened recently must be verified against what the turn actually shows before it can be asserted. Reading ego.md is now explicitly framed as re-grounding prior claims, not loading facts.

**The existence check** guards the specific rut: a reflection that wants to debug, fix, or investigate a subsystem must first confirm the subsystem exists in what the turn shows. It deliberately restates the gate — the prompt says so, and why: a phantom's cost compounds with every entry built on it, so the guard is worth paying twice. One adaptation from the original proposal: her text said to check "the loop registry, the subscriptions, the actual config," but ego carries no registry, config, or diagnostic tools by design — an instruction pointing at tools that don't exist is a door to nowhere. The shipped wording names the verification surfaces ego actually has (ambient context, `doc_read` on the maintained documents) and routes groundable concerns to `request_core_attention`, its one escalation path.

**The supervisor turn becomes the immune system.** It was already told to walk the history; now it's told what to hunt: echo (restatement wearing the costume of growth), unverified confidence (certainty that rose without evidence), self-reference (entries citing entries, no ground truth at the root), and propagated fabrication (cut it at the root, not the newest sprout) — with explicit authority to prune, because a shorter honest document beats a long compounding one. The standing checks (quality, honesty, blind spots, sleep) remain.

**Every wake is frontier-class now.** `profile.quality_floor: 8` states the demand; `profile.local_only: "false"` removes the contradiction — loop turns otherwise seed local-only routing, which no local model can satisfy at that floor, and the profile override is what wins over that seed. With the good brain on every turn, the supervisor pass is distinguished by its instructions rather than its model, so the stale "using a frontier model" / "cheaper model" framing is gone from the section.

Stacked on #1360 (both touch `loops/ego.md`). Deploy-side: prod picks this up via the core/loops backport plus restart; the spec change rides the same document.

## Test plan

- [x] Document parses through the core-loops loader (round-trip and report tests)
- [x] Reference-pointer and spec-key-coverage gates still pass
- [x] `just ci` green locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)
