### PR TITLE
fix(context): a task-mode worker sheds the ambient self, not its eyes

### DIFF
--- a/docs/reference/loop-definitions.md
+++ b/docs/reference/loop-definitions.md
@@ -47,7 +47,7 @@ validation from `loop_definition_lint` before anything persists.)
 
 | Key | Meaning |
 |---|---|
-| `prompt_mode` | `full` (default) wears the complete identity — persona, ego, axioms, always-on context. `task` is the compact worker prompt for mechanical maintainer/watcher/poller loops; it keeps tagged guidance, the task, and current conditions while shedding the identity. Loops that reflect on the agent or speak in its voice stay `full` |
+| `prompt_mode` | `full` (default) wears the complete identity — persona, ego, axioms, always-on context. `task` is the compact worker prompt for mechanical maintainer/watcher/poller loops; it keeps tagged guidance, the loop's declared subscriptions and self view, the task, and current conditions while shedding the identity. Loops that reflect on the agent or speak in its voice stay `full` |
 | `profile` | Routing and request shaping: `model` (pin a model), `quality_floor` (minimum model rating 1–10), `mission` (context profile), `local_only` / `prefer_speed` (`"true"`/`"false"` strings), `delegation_gating` (`disabled` gives direct tool access), `exclude_tools`, `instructions` (self-only text prepended to every iteration's task), `extra_hints` (free-form routing hints) |
 
 ## Operation and completion

--- a/internal/app/new_awareness.go
+++ b/internal/app/new_awareness.go
@@ -42,8 +42,10 @@ func (a *App) initAwareness(s *newState) error {
 	// so it is self-aware — id/state/parent/intent/cadence/effective-tags —
 	// without a loop_status tool call (#1106 B3). One provider serves every
 	// non-container loop; it resolves the current loop from the iteration's
-	// loop_id.
-	a.loop.RegisterAlwaysContextProvider(agent.NewLoopSelfContextProvider(a.loopViewByID))
+	// loop_id. Loop-scoped, not always-on: this is the loop's own
+	// operational context, which a task-mode worker keeps while shedding
+	// the ambient identity (#1363).
+	a.loop.RegisterLoopScopedContextProvider(agent.NewLoopSelfContextProvider(a.loopViewByID))
 	a.loop.RegisterAlwaysContextProvider(agent.NewChannelOverviewProvider(agent.ChannelOverviewConfig{
 		Loops:  &channelLoopAdapter{registry: a.loopRegistry},
 		Phones: &contactPhoneResolver{store: a.contactStore},
@@ -140,14 +142,16 @@ func (a *App) initAwareness(s *newState) error {
 		watchlistProvider.SetRegistryClient(a.ha)
 		a.loop.RegisterAlwaysContextProvider(watchlistProvider)
 
-		// One always-on provider walks the loop registry's ancestor
-		// chain on each iteration to assemble effective subscriptions
-		// for the current loop. Per-tag watchlist providers are gone —
-		// the structural parent/child binding from container loops
-		// replaces the scope_tag indirection.
+		// One provider walks the loop registry's ancestor chain on each
+		// iteration to assemble effective subscriptions for the current
+		// loop. Per-tag watchlist providers are gone — the structural
+		// parent/child binding from container loops replaces the
+		// scope_tag indirection. Loop-scoped, not always-on: a loop's
+		// declared watch set is its eyes, and a task-mode worker keeps
+		// its eyes while shedding the ambient identity (#1363).
 		loopSubProvider = awareness.NewLoopSubscriptionProvider(a.loopRegistry, watchlistStore, a.ha, logger)
 		loopSubProvider.SetRegistryClient(a.ha)
-		a.loop.RegisterAlwaysContextProvider(loopSubProvider)
+		a.loop.RegisterLoopScopedContextProvider(loopSubProvider)
 
 		logger.Info("entity watchlist context enabled")
 	}

--- a/internal/runtime/agent/loop.go
+++ b/internal/runtime/agent/loop.go
@@ -301,13 +301,17 @@ type Loop struct {
 	// before SetTagContextAssembler is called. SetTagContextAssembler
 	// drains them into the assembler at wiring time. After that, the
 	// pending fields are nil and Register* calls forward directly.
-	pendingProvidersMu         sync.Mutex
-	pendingTagProviders        map[string]TagContextProvider
-	pendingAlwaysProviders     []TagContextProvider
-	pendingLoopScopedProviders []TagContextProvider
+	// Always-on and loop-scoped registrations stage in one interleaved
+	// list for the same reason the assembler holds them in one: order
+	// is prompt order, and the drain must not regroup the classes.
+	pendingProvidersMu    sync.Mutex
+	pendingTagProviders   map[string]TagContextProvider
+	pendingGatedProviders []gatedContextProvider
 
 	// tagContextAssembler builds typed context sections from tagged KB
-	// articles, tagged providers, and always-on providers.
+	// articles, tagged providers, and the gated providers (always-on
+	// ambient context plus loop-scoped subscriptions/self view, each
+	// class behind its own ContextRequest gate).
 	// Set via SetTagContextAssembler; nil disables tag context.
 	tagContextAssembler *TagContextAssembler
 
@@ -473,7 +477,7 @@ func (l *Loop) RegisterAlwaysContextProvider(p TagContextProvider) {
 		l.tagContextAssembler.RegisterAlwaysProvider(p)
 		return
 	}
-	l.pendingAlwaysProviders = append(l.pendingAlwaysProviders, p)
+	l.pendingGatedProviders = append(l.pendingGatedProviders, gatedContextProvider{provider: p})
 	l.pendingProvidersMu.Unlock()
 }
 
@@ -494,7 +498,7 @@ func (l *Loop) RegisterLoopScopedContextProvider(p TagContextProvider) {
 		l.tagContextAssembler.RegisterLoopScopedProvider(p)
 		return
 	}
-	l.pendingLoopScopedProviders = append(l.pendingLoopScopedProviders, p)
+	l.pendingGatedProviders = append(l.pendingGatedProviders, gatedContextProvider{provider: p, loopScoped: true})
 	l.pendingProvidersMu.Unlock()
 }
 
@@ -637,11 +641,9 @@ func (l *Loop) ConfigureChannelDelegation(w ChannelDelegationWiring) {
 func (l *Loop) SetTagContextAssembler(a *TagContextAssembler) {
 	l.pendingProvidersMu.Lock()
 	pendingTagged := l.pendingTagProviders
-	pendingAlways := l.pendingAlwaysProviders
-	pendingLoopScoped := l.pendingLoopScopedProviders
+	pendingGated := l.pendingGatedProviders
 	l.pendingTagProviders = nil
-	l.pendingAlwaysProviders = nil
-	l.pendingLoopScopedProviders = nil
+	l.pendingGatedProviders = nil
 	l.tagContextAssembler = a
 	l.pendingProvidersMu.Unlock()
 
@@ -651,11 +653,12 @@ func (l *Loop) SetTagContextAssembler(a *TagContextAssembler) {
 	for tag, p := range pendingTagged {
 		a.RegisterTaggedProvider(tag, p)
 	}
-	for _, p := range pendingAlways {
-		a.RegisterAlwaysProvider(p)
-	}
-	for _, p := range pendingLoopScoped {
-		a.RegisterLoopScopedProvider(p)
+	for _, gp := range pendingGated {
+		if gp.loopScoped {
+			a.RegisterLoopScopedProvider(gp.provider)
+		} else {
+			a.RegisterAlwaysProvider(gp.provider)
+		}
 	}
 }
 
@@ -670,11 +673,10 @@ func (l *Loop) contextAssemblerForPrompt() *TagContextAssembler {
 	for tag, p := range l.pendingTagProviders {
 		pendingTagged[tag] = p
 	}
-	pendingAlways := append([]TagContextProvider(nil), l.pendingAlwaysProviders...)
-	pendingLoopScoped := append([]TagContextProvider(nil), l.pendingLoopScopedProviders...)
+	pendingGated := append([]gatedContextProvider(nil), l.pendingGatedProviders...)
 	l.pendingProvidersMu.Unlock()
 
-	if len(pendingTagged) == 0 && len(pendingAlways) == 0 && len(pendingLoopScoped) == 0 {
+	if len(pendingTagged) == 0 && len(pendingGated) == 0 {
 		return nil
 	}
 	assembler = NewTagContextAssembler(TagContextAssemblerConfig{
@@ -684,11 +686,12 @@ func (l *Loop) contextAssemblerForPrompt() *TagContextAssembler {
 	for tag, p := range pendingTagged {
 		assembler.RegisterTaggedProvider(tag, p)
 	}
-	for _, p := range pendingAlways {
-		assembler.RegisterAlwaysProvider(p)
-	}
-	for _, p := range pendingLoopScoped {
-		assembler.RegisterLoopScopedProvider(p)
+	for _, gp := range pendingGated {
+		if gp.loopScoped {
+			assembler.RegisterLoopScopedProvider(gp.provider)
+		} else {
+			assembler.RegisterAlwaysProvider(gp.provider)
+		}
 	}
 	return assembler
 }

--- a/internal/runtime/agent/loop.go
+++ b/internal/runtime/agent/loop.go
@@ -301,9 +301,10 @@ type Loop struct {
 	// before SetTagContextAssembler is called. SetTagContextAssembler
 	// drains them into the assembler at wiring time. After that, the
 	// pending fields are nil and Register* calls forward directly.
-	pendingProvidersMu     sync.Mutex
-	pendingTagProviders    map[string]TagContextProvider
-	pendingAlwaysProviders []TagContextProvider
+	pendingProvidersMu         sync.Mutex
+	pendingTagProviders        map[string]TagContextProvider
+	pendingAlwaysProviders     []TagContextProvider
+	pendingLoopScopedProviders []TagContextProvider
 
 	// tagContextAssembler builds typed context sections from tagged KB
 	// articles, tagged providers, and always-on providers.
@@ -476,6 +477,27 @@ func (l *Loop) RegisterAlwaysContextProvider(p TagContextProvider) {
 	l.pendingProvidersMu.Unlock()
 }
 
+// RegisterLoopScopedContextProvider adds a provider to the loop-scoped
+// bucket: the running loop's own operational context (declared entity
+// subscriptions, its "This loop" self view). Loop-scoped providers fire
+// on every loop turn regardless of prompt mode — a task-mode worker
+// sheds the ambient identity but keeps its own eyes — and are
+// suppressed only where SuppressAlwaysContext is set (delegate runs).
+// Same staging semantics as [Loop.RegisterTagContextProvider].
+func (l *Loop) RegisterLoopScopedContextProvider(p TagContextProvider) {
+	if p == nil {
+		return
+	}
+	l.pendingProvidersMu.Lock()
+	if l.tagContextAssembler != nil {
+		l.pendingProvidersMu.Unlock()
+		l.tagContextAssembler.RegisterLoopScopedProvider(p)
+		return
+	}
+	l.pendingLoopScopedProviders = append(l.pendingLoopScopedProviders, p)
+	l.pendingProvidersMu.Unlock()
+}
+
 // The setters below remain for test convenience and for callers that
 // need to mutate a single field after construction. Production wiring
 // in internal/app/* goes through [LoopOptions] at construction and the
@@ -616,8 +638,10 @@ func (l *Loop) SetTagContextAssembler(a *TagContextAssembler) {
 	l.pendingProvidersMu.Lock()
 	pendingTagged := l.pendingTagProviders
 	pendingAlways := l.pendingAlwaysProviders
+	pendingLoopScoped := l.pendingLoopScopedProviders
 	l.pendingTagProviders = nil
 	l.pendingAlwaysProviders = nil
+	l.pendingLoopScopedProviders = nil
 	l.tagContextAssembler = a
 	l.pendingProvidersMu.Unlock()
 
@@ -629,6 +653,9 @@ func (l *Loop) SetTagContextAssembler(a *TagContextAssembler) {
 	}
 	for _, p := range pendingAlways {
 		a.RegisterAlwaysProvider(p)
+	}
+	for _, p := range pendingLoopScoped {
+		a.RegisterLoopScopedProvider(p)
 	}
 }
 
@@ -644,9 +671,10 @@ func (l *Loop) contextAssemblerForPrompt() *TagContextAssembler {
 		pendingTagged[tag] = p
 	}
 	pendingAlways := append([]TagContextProvider(nil), l.pendingAlwaysProviders...)
+	pendingLoopScoped := append([]TagContextProvider(nil), l.pendingLoopScopedProviders...)
 	l.pendingProvidersMu.Unlock()
 
-	if len(pendingTagged) == 0 && len(pendingAlways) == 0 {
+	if len(pendingTagged) == 0 && len(pendingAlways) == 0 && len(pendingLoopScoped) == 0 {
 		return nil
 	}
 	assembler = NewTagContextAssembler(TagContextAssemblerConfig{
@@ -658,6 +686,9 @@ func (l *Loop) contextAssemblerForPrompt() *TagContextAssembler {
 	}
 	for _, p := range pendingAlways {
 		assembler.RegisterAlwaysProvider(p)
+	}
+	for _, p := range pendingLoopScoped {
+		assembler.RegisterLoopScopedProvider(p)
 	}
 	return assembler
 }
@@ -1155,20 +1186,26 @@ func (l *Loop) buildSystemPromptWithProfileSections(ctx context.Context, userMes
 	}
 
 	// 7. Typed context buckets (capability knowledge + ambient context).
-	// TagContextAssembler walks tagged KB articles, tagged providers, and
-	// always-on providers, then returns named buckets so durable guidance,
-	// continuity, related context, and live state are not flattened into
-	// one generic section. Always-on providers are gated by IncludeAlways:
-	// main loop runs include them; delegate runs (which set
-	// req.SuppressAlwaysContext via the loops launch) do not.
+	// TagContextAssembler walks tagged KB articles, tagged providers,
+	// always-on providers, and loop-scoped providers, then returns named
+	// buckets so durable guidance, continuity, related context, and live
+	// state are not flattened into one generic section. The two gated
+	// sources answer different questions: IncludeAlways admits the
+	// ambient experiential context and drops on task-mode and delegate
+	// runs alike; IncludeLoopScoped admits the running loop's own
+	// subscriptions and self view, which task mode keeps — a worker
+	// sheds the ambient self, not its eyes — and only delegate runs
+	// (req.SuppressAlwaysContext via the loops launch) drop.
 	if assembler := l.contextAssemblerForPrompt(); assembler != nil {
 		haCtx, haCancel := context.WithTimeout(ctx, 2*time.Second)
 		defer haCancel()
 
+		suppressAlways := tools.SuppressAlwaysContextFromContext(ctx)
 		req := ContextRequest{
-			UserMessage:   userMessage,
-			ActiveTags:    tags,
-			IncludeAlways: !taskPrompt && !tools.SuppressAlwaysContextFromContext(ctx),
+			UserMessage:       userMessage,
+			ActiveTags:        tags,
+			IncludeAlways:     !taskPrompt && !suppressAlways,
+			IncludeLoopScoped: !suppressAlways,
 		}
 		for _, contextSection := range assembler.BuildSections(haCtx, req) {
 			title := contextSection.Bucket.Title()

--- a/internal/runtime/agent/prompt_order_test.go
+++ b/internal/runtime/agent/prompt_order_test.go
@@ -53,6 +53,10 @@ func TestBuildSystemPromptSections_FullPromptUsesInvertedPyramidOrder(t *testing
 		content: "CONTINUITY_MARKER",
 		bucket:  agentctx.ContextBucketContinuity,
 	})
+	l.RegisterLoopScopedContextProvider(&mockTagProvider{
+		content: "LOOP_SCOPED_MARKER",
+		bucket:  agentctx.ContextBucketLiveState,
+	})
 
 	_, sections := l.buildSystemPromptWithProfileSections(
 		testCtxForLoop(l),
@@ -85,6 +89,7 @@ func TestBuildSystemPromptSections_FullPromptUsesInvertedPyramidOrder(t *testing
 	assertPromptSectionContains(t, sections, "TAGGED GUIDANCE", "TAGGED_GUIDANCE_MARKER")
 	assertPromptSectionContains(t, sections, "CONTINUITY CONTEXT", "CONTINUITY_MARKER")
 	assertPromptSectionContains(t, sections, "LIVE STATE", "LIVE_STATE_MARKER")
+	assertPromptSectionContains(t, sections, "LIVE STATE", "LOOP_SCOPED_MARKER")
 }
 
 func TestBuildSystemPromptSections_TaskPromptUsesCompactOrder(t *testing.T) {
@@ -126,6 +131,13 @@ func TestBuildSystemPromptSections_TaskPromptUsesCompactOrder(t *testing.T) {
 		content: "CONTINUITY_MARKER",
 		bucket:  agentctx.ContextBucketContinuity,
 	})
+	// Loop-scoped context is the #1363 regression guard: a task-mode
+	// worker sheds the ambient bucket (asserted absent below) but must
+	// keep its own subscriptions and self view.
+	l.RegisterLoopScopedContextProvider(&mockTagProvider{
+		content: "LOOP_SCOPED_MARKER",
+		bucket:  agentctx.ContextBucketLiveState,
+	})
 
 	ctx := agentctx.WithPromptMode(testCtxForLoop(l), agentctx.PromptModeTask)
 	_, sections := l.buildSystemPromptWithProfileSections(
@@ -154,6 +166,7 @@ func TestBuildSystemPromptSections_TaskPromptUsesCompactOrder(t *testing.T) {
 	)
 	assertPromptSectionContains(t, sections, "TAGGED GUIDANCE", "TAGGED_GUIDANCE_MARKER")
 	assertPromptSectionContains(t, sections, "LIVE STATE", "LIVE_STATE_MARKER")
+	assertPromptSectionContains(t, sections, "LIVE STATE", "LOOP_SCOPED_MARKER")
 }
 
 func TestBuildSystemPromptSections_CoreFileBudgetTruncation(t *testing.T) {

--- a/internal/runtime/agent/tag_context.go
+++ b/internal/runtime/agent/tag_context.go
@@ -28,17 +28,27 @@ import (
 //  2. Tagged live providers — [TagContextProvider] implementations
 //     registered against a specific capability tag via
 //     [Loop.RegisterTagContextProvider]. Filtered by ActiveTags.
-//  3. Always-on providers — [TagContextProvider] implementations
-//     registered via [Loop.RegisterAlwaysContextProvider]. Gated by
-//     ContextRequest.IncludeAlways: main loop runs include them,
-//     delegate runs do not.
+//  3. Gated providers — [TagContextProvider] implementations that
+//     render every turn their gate admits, held in one list in
+//     registration order. Always-on registrations
+//     ([Loop.RegisterAlwaysContextProvider]) carry the ambient
+//     experiential context and render under
+//     ContextRequest.IncludeAlways; loop-scoped registrations
+//     ([Loop.RegisterLoopScopedContextProvider]) carry the running
+//     loop's own subscriptions and self view and render under
+//     ContextRequest.IncludeLoopScoped. The two gates are independent:
+//     full-mode loop turns set both, task-mode turns set only
+//     loop-scoped, delegate runs set neither.
 //
 // Each rendered bucket has its own 64 KB cap and truncation marker.
-// Tagged vs always is encoded as where each source registered, not as
-// a separate code path. KB articles and explicit context refs flow
-// through the optional managed-root signature verifier. Providers that
-// read disk-managed material are responsible for applying their own
-// verification before returning model-facing content.
+// A provider's class is encoded as how it registered, not as a
+// separate code path — one interleaved list preserves registration
+// order across classes, so a prompt's within-bucket ordering never
+// depends on which gates happen to be open. KB articles and explicit
+// context refs flow through the optional managed-root signature
+// verifier. Providers that read disk-managed material are responsible
+// for applying their own verification before returning model-facing
+// content.
 //
 // Both the main agent loop and delegate executor share a single
 // assembler. The assembler is safe for concurrent use after
@@ -57,10 +67,21 @@ type TagContextAssembler struct {
 	haInject homeassistant.StateFetcher // nil-safe — delegates pass nil
 	logger   *slog.Logger
 
-	mu                  sync.Mutex
-	tagProviders        map[string]TagContextProvider
-	alwaysProviders     []TagContextProvider
-	loopScopedProviders []TagContextProvider
+	mu           sync.Mutex
+	tagProviders map[string]TagContextProvider
+	// gatedProviders holds always-on and loop-scoped providers in one
+	// list, in registration order. One list rather than two because
+	// order is prompt order: within a bucket, providers render in the
+	// sequence they registered, whichever class they belong to.
+	gatedProviders []gatedContextProvider
+}
+
+// gatedContextProvider pairs a provider with the request gate that
+// admits it: loop-scoped providers render under IncludeLoopScoped,
+// everything else under IncludeAlways.
+type gatedContextProvider struct {
+	provider   TagContextProvider
+	loopScoped bool
 }
 
 // TagContextBucketer lets a context provider choose the prompt bucket
@@ -261,24 +282,24 @@ func (a *TagContextAssembler) RegisterAlwaysProvider(p TagContextProvider) {
 	}
 	a.mu.Lock()
 	defer a.mu.Unlock()
-	a.alwaysProviders = append(a.alwaysProviders, p)
+	a.gatedProviders = append(a.gatedProviders, gatedContextProvider{provider: p})
 }
 
-// RegisterLoopScopedProvider adds a provider to the loop-scoped bucket:
+// RegisterLoopScopedProvider adds a provider to the loop-scoped class:
 // context that belongs to the running loop itself — its declared entity
 // subscriptions, its own self view — rather than to the ambient
-// experience the always-on bucket carries. The split exists because the
+// experience the always-on class carries. The split exists because the
 // two are gated differently (ContextRequest.IncludeLoopScoped vs
 // IncludeAlways): a task-mode worker keeps its own operational context
-// while shedding the ambient self. Order is preserved across
-// registrations.
+// while shedding the ambient self. Registration order is preserved
+// across both classes — it is prompt order within a bucket.
 func (a *TagContextAssembler) RegisterLoopScopedProvider(p TagContextProvider) {
 	if a == nil || p == nil {
 		return
 	}
 	a.mu.Lock()
 	defer a.mu.Unlock()
-	a.loopScopedProviders = append(a.loopScopedProviders, p)
+	a.gatedProviders = append(a.gatedProviders, gatedContextProvider{provider: p, loopScoped: true})
 }
 
 // TaggedProviders returns a snapshot of the registered tag→provider
@@ -317,13 +338,12 @@ func (a *TagContextAssembler) Build(ctx context.Context, req agentctx.ContextReq
 }
 
 // BuildSections assembles typed context sections for the request. The
-// single internal pipeline walks four sources in order — KB articles,
-// tagged providers, always-on providers, loop-scoped providers. The
-// last two carry independent gates: always-on providers render under
-// req.IncludeAlways (full-mode main-loop runs), loop-scoped providers
-// under req.IncludeLoopScoped (every loop turn regardless of prompt
-// mode; delegates suppress both). Returns nil when no source produces
-// content.
+// single internal pipeline walks three sources in order — KB articles,
+// tagged providers, then the gated providers (always-on and
+// loop-scoped interleaved in registration order, each admitted by its
+// own gate: req.IncludeAlways for ambient context, req.IncludeLoopScoped
+// for the running loop's own subscriptions and self view). Returns nil
+// when no source produces content.
 func (a *TagContextAssembler) BuildSections(ctx context.Context, req agentctx.ContextRequest) []agentctx.ContextSection {
 	if a == nil {
 		return nil
@@ -334,8 +354,7 @@ func (a *TagContextAssembler) BuildSections(ctx context.Context, req agentctx.Co
 	for k, v := range a.tagProviders {
 		tagProviders[k] = v
 	}
-	alwaysProviders := append([]TagContextProvider(nil), a.alwaysProviders...)
-	loopScopedProviders := append([]TagContextProvider(nil), a.loopScopedProviders...)
+	gatedProviders := append([]gatedContextProvider(nil), a.gatedProviders...)
 	a.mu.Unlock()
 
 	seen := make(map[string]bool)
@@ -401,54 +420,44 @@ func (a *TagContextAssembler) BuildSections(ctx context.Context, req agentctx.Co
 		}
 	}
 
-	// Source 3: Always-on providers, gated by IncludeAlways. Delegate
-	// runs pass IncludeAlways=false to skip ambient context (presence,
-	// episodic memory, working memory, notification history, etc.)
-	// that the bounded child task does not need; task-mode loop runs
-	// skip it too, as part of shedding the identity stack.
-	if req.IncludeAlways {
-		for _, p := range alwaysProviders {
-			content, err := p.TagContext(ctx, req)
-			if err != nil {
-				a.logger.Warn("always context provider failed", "error", err)
+	// Source 3: Gated providers — always-on and loop-scoped — walked
+	// as one list in registration order, each entry admitted by its
+	// own gate. Always-on entries carry ambient experiential context
+	// (presence, episodic memory, notification history, etc.) and
+	// render under IncludeAlways: full-mode loop turns only.
+	// Loop-scoped entries carry the running loop's own operational
+	// context (declared subscriptions, the "This loop" self view) and
+	// render under IncludeLoopScoped: every loop turn regardless of
+	// prompt mode — a task-mode worker sheds the ambient self, not its
+	// eyes. Delegate runs open neither gate. The single interleaved
+	// walk keeps full-mode prompts byte-identical to the pre-split
+	// ordering and keeps bucket-cap priority a property of
+	// registration order, not of class.
+	for _, gp := range gatedProviders {
+		if gp.loopScoped {
+			if !req.IncludeLoopScoped {
 				continue
 			}
-			if content == "" {
-				continue
-			}
-			bucket := providerContextBucket(p, agentctx.ContextBucketContinuity)
-			if acc.append(bucket, []byte(content)) {
-				a.logger.Warn("tag context bucket limit reached",
-					"bucket", string(bucket), "bucket_title", bucket.Title(),
-					"source", "always_provider", "limit_bytes", maxTagContextBytes)
-			}
+		} else if !req.IncludeAlways {
+			continue
 		}
-	}
-
-	// Source 4: Loop-scoped providers, gated by IncludeLoopScoped —
-	// the running loop's own operational context (declared entity
-	// subscriptions, the "This loop" self view). Deliberately
-	// independent of IncludeAlways: a task-mode worker sheds the
-	// ambient self above but keeps its own eyes and its own envelope.
-	// Rendered after the always bucket so full-mode prompts keep their
-	// established ordering (always-visible watchlist before loop
-	// subscriptions).
-	if req.IncludeLoopScoped {
-		for _, p := range loopScopedProviders {
-			content, err := p.TagContext(ctx, req)
-			if err != nil {
-				a.logger.Warn("loop-scoped context provider failed", "error", err)
-				continue
-			}
-			if content == "" {
-				continue
-			}
-			bucket := providerContextBucket(p, agentctx.ContextBucketLiveState)
-			if acc.append(bucket, []byte(content)) {
-				a.logger.Warn("tag context bucket limit reached",
-					"bucket", string(bucket), "bucket_title", bucket.Title(),
-					"source", "loop_scoped_provider", "limit_bytes", maxTagContextBytes)
-			}
+		defaultBucket, source := agentctx.ContextBucketContinuity, "always_provider"
+		if gp.loopScoped {
+			defaultBucket, source = agentctx.ContextBucketLiveState, "loop_scoped_provider"
+		}
+		content, err := gp.provider.TagContext(ctx, req)
+		if err != nil {
+			a.logger.Warn("gated context provider failed", "source", source, "error", err)
+			continue
+		}
+		if content == "" {
+			continue
+		}
+		bucket := providerContextBucket(gp.provider, defaultBucket)
+		if acc.append(bucket, []byte(content)) {
+			a.logger.Warn("tag context bucket limit reached",
+				"bucket", string(bucket), "bucket_title", bucket.Title(),
+				"source", source, "limit_bytes", maxTagContextBytes)
 		}
 	}
 

--- a/internal/runtime/agent/tag_context.go
+++ b/internal/runtime/agent/tag_context.go
@@ -57,9 +57,10 @@ type TagContextAssembler struct {
 	haInject homeassistant.StateFetcher // nil-safe — delegates pass nil
 	logger   *slog.Logger
 
-	mu              sync.Mutex
-	tagProviders    map[string]TagContextProvider
-	alwaysProviders []TagContextProvider
+	mu                  sync.Mutex
+	tagProviders        map[string]TagContextProvider
+	alwaysProviders     []TagContextProvider
+	loopScopedProviders []TagContextProvider
 }
 
 // TagContextBucketer lets a context provider choose the prompt bucket
@@ -263,6 +264,23 @@ func (a *TagContextAssembler) RegisterAlwaysProvider(p TagContextProvider) {
 	a.alwaysProviders = append(a.alwaysProviders, p)
 }
 
+// RegisterLoopScopedProvider adds a provider to the loop-scoped bucket:
+// context that belongs to the running loop itself — its declared entity
+// subscriptions, its own self view — rather than to the ambient
+// experience the always-on bucket carries. The split exists because the
+// two are gated differently (ContextRequest.IncludeLoopScoped vs
+// IncludeAlways): a task-mode worker keeps its own operational context
+// while shedding the ambient self. Order is preserved across
+// registrations.
+func (a *TagContextAssembler) RegisterLoopScopedProvider(p TagContextProvider) {
+	if a == nil || p == nil {
+		return
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.loopScopedProviders = append(a.loopScopedProviders, p)
+}
+
 // TaggedProviders returns a snapshot of the registered tag→provider
 // map. Used by callers that need to inspect what's wired (e.g., the
 // capability surface builder).
@@ -299,10 +317,13 @@ func (a *TagContextAssembler) Build(ctx context.Context, req agentctx.ContextReq
 }
 
 // BuildSections assembles typed context sections for the request. The
-// single internal pipeline walks three sources in order — KB articles,
-// tagged providers, always-on providers. Always-on providers are gated
-// by req.IncludeAlways; main loop runs include them, delegate runs do
-// not. Returns nil when no source produces content.
+// single internal pipeline walks four sources in order — KB articles,
+// tagged providers, always-on providers, loop-scoped providers. The
+// last two carry independent gates: always-on providers render under
+// req.IncludeAlways (full-mode main-loop runs), loop-scoped providers
+// under req.IncludeLoopScoped (every loop turn regardless of prompt
+// mode; delegates suppress both). Returns nil when no source produces
+// content.
 func (a *TagContextAssembler) BuildSections(ctx context.Context, req agentctx.ContextRequest) []agentctx.ContextSection {
 	if a == nil {
 		return nil
@@ -314,6 +335,7 @@ func (a *TagContextAssembler) BuildSections(ctx context.Context, req agentctx.Co
 		tagProviders[k] = v
 	}
 	alwaysProviders := append([]TagContextProvider(nil), a.alwaysProviders...)
+	loopScopedProviders := append([]TagContextProvider(nil), a.loopScopedProviders...)
 	a.mu.Unlock()
 
 	seen := make(map[string]bool)
@@ -382,7 +404,8 @@ func (a *TagContextAssembler) BuildSections(ctx context.Context, req agentctx.Co
 	// Source 3: Always-on providers, gated by IncludeAlways. Delegate
 	// runs pass IncludeAlways=false to skip ambient context (presence,
 	// episodic memory, working memory, notification history, etc.)
-	// that the bounded child task does not need.
+	// that the bounded child task does not need; task-mode loop runs
+	// skip it too, as part of shedding the identity stack.
 	if req.IncludeAlways {
 		for _, p := range alwaysProviders {
 			content, err := p.TagContext(ctx, req)
@@ -398,6 +421,33 @@ func (a *TagContextAssembler) BuildSections(ctx context.Context, req agentctx.Co
 				a.logger.Warn("tag context bucket limit reached",
 					"bucket", string(bucket), "bucket_title", bucket.Title(),
 					"source", "always_provider", "limit_bytes", maxTagContextBytes)
+			}
+		}
+	}
+
+	// Source 4: Loop-scoped providers, gated by IncludeLoopScoped —
+	// the running loop's own operational context (declared entity
+	// subscriptions, the "This loop" self view). Deliberately
+	// independent of IncludeAlways: a task-mode worker sheds the
+	// ambient self above but keeps its own eyes and its own envelope.
+	// Rendered after the always bucket so full-mode prompts keep their
+	// established ordering (always-visible watchlist before loop
+	// subscriptions).
+	if req.IncludeLoopScoped {
+		for _, p := range loopScopedProviders {
+			content, err := p.TagContext(ctx, req)
+			if err != nil {
+				a.logger.Warn("loop-scoped context provider failed", "error", err)
+				continue
+			}
+			if content == "" {
+				continue
+			}
+			bucket := providerContextBucket(p, agentctx.ContextBucketLiveState)
+			if acc.append(bucket, []byte(content)) {
+				a.logger.Warn("tag context bucket limit reached",
+					"bucket", string(bucket), "bucket_title", bucket.Title(),
+					"source", "loop_scoped_provider", "limit_bytes", maxTagContextBytes)
 			}
 		}
 	}

--- a/internal/runtime/agent/tag_context_test.go
+++ b/internal/runtime/agent/tag_context_test.go
@@ -673,6 +673,53 @@ func TestTagContextAssembler_BuildSectionsBuckets(t *testing.T) {
 	}
 }
 
+// TestTagContextAssembler_LoopScopedGating pins the #1363 split: the
+// loop-scoped bucket renders under IncludeLoopScoped independently of
+// IncludeAlways. Task-mode loop turns are the case the split exists
+// for — the worker sheds ambient experiential context but keeps its
+// own subscriptions and self view — and a delegate run (both gates
+// off) renders neither.
+func TestTagContextAssembler_LoopScopedGating(t *testing.T) {
+	build := func(includeAlways, includeLoopScoped bool) string {
+		a := NewTagContextAssembler(TagContextAssemblerConfig{})
+		a.RegisterAlwaysProvider(&mockTagProvider{
+			content: "AMBIENT_SELF",
+			bucket:  agentctx.ContextBucketRelated,
+		})
+		a.RegisterLoopScopedProvider(&mockTagProvider{
+			content: "LOOP_EYES",
+			bucket:  agentctx.ContextBucketLiveState,
+		})
+		var out strings.Builder
+		for _, s := range a.BuildSections(context.Background(), agentctx.ContextRequest{
+			IncludeAlways:     includeAlways,
+			IncludeLoopScoped: includeLoopScoped,
+		}) {
+			out.WriteString(s.Content)
+			out.WriteString("\n")
+		}
+		return out.String()
+	}
+
+	fullMode := build(true, true)
+	if !strings.Contains(fullMode, "AMBIENT_SELF") || !strings.Contains(fullMode, "LOOP_EYES") {
+		t.Errorf("full mode should render both buckets, got: %q", fullMode)
+	}
+
+	taskMode := build(false, true)
+	if strings.Contains(taskMode, "AMBIENT_SELF") {
+		t.Errorf("task mode should shed the ambient bucket, got: %q", taskMode)
+	}
+	if !strings.Contains(taskMode, "LOOP_EYES") {
+		t.Errorf("task mode must keep the loop-scoped bucket — a worker sheds the ambient self, not its eyes; got: %q", taskMode)
+	}
+
+	delegate := build(false, false)
+	if strings.Contains(delegate, "AMBIENT_SELF") || strings.Contains(delegate, "LOOP_EYES") {
+		t.Errorf("a delegate run should render neither bucket, got: %q", delegate)
+	}
+}
+
 func TestTagContextAssembler_TaggedProviderOrderIsStable(t *testing.T) {
 	a := NewTagContextAssembler(TagContextAssemblerConfig{})
 	a.RegisterTaggedProvider("zulu", &mockTagProvider{content: "ZULU_PROVIDER"})

--- a/internal/runtime/agent/tag_context_test.go
+++ b/internal/runtime/agent/tag_context_test.go
@@ -720,6 +720,38 @@ func TestTagContextAssembler_LoopScopedGating(t *testing.T) {
 	}
 }
 
+// TestTagContextAssembler_GatedProvidersKeepRegistrationOrder pins the
+// interleaving contract: always-on and loop-scoped providers render in
+// registration order within a bucket, whichever class each belongs to.
+// The split into two gates must not regroup full-mode prompts — before
+// the split, production registered the loop self view between two
+// ambient providers and the subscriptions before the state window, and
+// that ordering (and its bucket-cap priority) has to survive.
+func TestTagContextAssembler_GatedProvidersKeepRegistrationOrder(t *testing.T) {
+	a := NewTagContextAssembler(TagContextAssemblerConfig{})
+	a.RegisterAlwaysProvider(&mockTagProvider{content: "FIRST_AMBIENT", bucket: agentctx.ContextBucketLiveState})
+	a.RegisterLoopScopedProvider(&mockTagProvider{content: "THEN_LOOP", bucket: agentctx.ContextBucketLiveState})
+	a.RegisterAlwaysProvider(&mockTagProvider{content: "LAST_AMBIENT", bucket: agentctx.ContextBucketLiveState})
+
+	sections := a.BuildSections(context.Background(), agentctx.ContextRequest{
+		IncludeAlways:     true,
+		IncludeLoopScoped: true,
+	})
+	if len(sections) != 1 {
+		t.Fatalf("BuildSections returned %d sections, want 1: %#v", len(sections), sections)
+	}
+	content := sections[0].Content
+	first := strings.Index(content, "FIRST_AMBIENT")
+	then := strings.Index(content, "THEN_LOOP")
+	last := strings.Index(content, "LAST_AMBIENT")
+	if first == -1 || then == -1 || last == -1 {
+		t.Fatalf("missing marker in bucket content: %q", content)
+	}
+	if first > then || then > last {
+		t.Errorf("bucket content regrouped by class instead of registration order: %q", content)
+	}
+}
+
 func TestTagContextAssembler_TaggedProviderOrderIsStable(t *testing.T) {
 	a := NewTagContextAssembler(TagContextAssemblerConfig{})
 	a.RegisterTaggedProvider("zulu", &mockTagProvider{content: "ZULU_PROVIDER"})

--- a/internal/runtime/agentctx/request.go
+++ b/internal/runtime/agentctx/request.go
@@ -41,9 +41,24 @@ type promptModeKey struct{}
 // delegate runs that should see only tag-scoped context appropriate
 // to the bounded child task.
 type ContextRequest struct {
-	UserMessage   string
-	ActiveTags    map[string]bool
+	UserMessage string
+	ActiveTags  map[string]bool
+
+	// IncludeAlways admits the ambient experiential bucket: presence,
+	// episodic memory, working memory, notification history, and the
+	// other continuity context an interactive turn wears. Full-mode
+	// main-loop runs set it; task-mode runs and delegate runs do not.
 	IncludeAlways bool
+
+	// IncludeLoopScoped admits the running loop's own operational
+	// context: its declared entity subscriptions and its "This loop"
+	// self view. Independent of IncludeAlways because the two answer
+	// different questions — a task-mode worker sheds the ambient self
+	// but still needs its own eyes and its own envelope. Every loop
+	// turn sets it regardless of prompt mode; delegate runs (which
+	// suppress always-context) leave it off, since a bounded child has
+	// no subscriptions and no envelope worth rendering.
+	IncludeLoopScoped bool
 }
 
 // ContextBucket names the model-facing section class for generated

--- a/internal/runtime/loop/spec.go
+++ b/internal/runtime/loop/spec.go
@@ -174,8 +174,10 @@ type Spec struct {
 	// the always-on ambient context. "task" is the compact worker
 	// prompt: the persona is swapped for a bounded worker preamble and
 	// the rest of that layer is shed, while always-tagged talents,
-	// tagged guidance, active tags, the Task, and current conditions
-	// all remain. The convention (#1171): mechanical
+	// tagged guidance, active tags, the loop's declared subscriptions
+	// and self view, the Task, and current conditions all remain (a
+	// worker sheds the ambient self, not its eyes — #1363). The
+	// convention (#1171): mechanical
 	// maintainer/watcher/poller loops declare "task"; reflective loops —
 	// any loop whose job is judgment about the agent itself — declare
 	// "full". A per-launch [Launch.PromptMode] overrides this default

--- a/internal/state/awareness/loop_subscription_provider.go
+++ b/internal/state/awareness/loop_subscription_provider.go
@@ -110,8 +110,15 @@ func (p *LoopSubscriptionProvider) TagContext(ctx context.Context, req agentctx.
 	// Defensive: if the store query errors, log and continue
 	// without the filter (better to double-render than to break
 	// context entirely).
+	//
+	// Gated on IncludeAlways because "already visible" is a claim
+	// about THIS turn's prompt: [WatchlistProvider] rides the
+	// always-on bucket, so on a task-mode turn it renders nothing
+	// and nothing suppresses — otherwise an entity subscribed both
+	// always-visible and loop-scoped would be emitted by neither
+	// provider (#1363 review).
 	alreadyVisible := make(map[string]struct{})
-	if p.store != nil && len(subs) > 0 {
+	if req.IncludeAlways && p.store != nil && len(subs) > 0 {
 		candidates := make([]string, 0, len(subs))
 		for _, sub := range subs {
 			candidates = append(candidates, sub.EntityID)

--- a/internal/state/awareness/loop_subscription_provider.go
+++ b/internal/state/awareness/loop_subscription_provider.go
@@ -77,8 +77,9 @@ func (p *LoopSubscriptionProvider) SetRegistryClient(registries HARegistryClient
 // and renders the effective subscription list. Returns empty string
 // when no loop_id is bound to ctx, the loop is no longer registered,
 // or the effective list is empty — each is a normal quiescent state,
-// not an error. Registered as an always-on provider via
-// [agent.Loop.RegisterAlwaysContextProvider].
+// not an error. Registered as a loop-scoped provider via
+// [agent.Loop.RegisterLoopScopedContextProvider]: the watch set is the
+// loop's own operational context, rendered in every prompt mode.
 func (p *LoopSubscriptionProvider) TagContext(ctx context.Context, req agentctx.ContextRequest) (string, error) {
 	if p.loops == nil {
 		return "", nil

--- a/internal/state/awareness/loop_subscription_provider_test.go
+++ b/internal/state/awareness/loop_subscription_provider_test.go
@@ -78,7 +78,7 @@ func TestLoopSubscriptionProviderSkipsAlwaysVisibleEntities(t *testing.T) {
 	}
 
 	ctx := looppkg.WithLoopIDForTest(context.Background(), leaf.ID())
-	out, err := p.TagContext(ctx, agentctx.ContextRequest{})
+	out, err := p.TagContext(ctx, agentctx.ContextRequest{IncludeAlways: true})
 	if err != nil {
 		t.Fatalf("TagContext: %v", err)
 	}
@@ -90,6 +90,22 @@ func TestLoopSubscriptionProviderSkipsAlwaysVisibleEntities(t *testing.T) {
 	}
 	if strings.Contains(out, "sensor.shared") {
 		t.Errorf("loop-scoped render leaked sensor.shared (already always-visible): %q", out)
+	}
+
+	// Task mode is the inverse case (#1363 review): the always-visible
+	// WatchlistProvider does not render when IncludeAlways is false, so
+	// "already visible" is no longer true and nothing may suppress —
+	// otherwise the overlapping entity would be emitted by neither
+	// provider and the loop would go blind to it.
+	taskOut, err := p.TagContext(ctx, agentctx.ContextRequest{IncludeAlways: false, IncludeLoopScoped: true})
+	if err != nil {
+		t.Fatalf("TagContext (task mode): %v", err)
+	}
+	if !strings.Contains(taskOut, "sensor.shared") {
+		t.Errorf("task-mode render must include sensor.shared — the watchlist is not rendering, so nothing is 'already visible': %q", taskOut)
+	}
+	if !strings.Contains(taskOut, "sensor.loop") {
+		t.Errorf("task-mode render missing sensor.loop: %q", taskOut)
 	}
 
 	// The output-text check above is what enforces the dedup;
@@ -136,7 +152,7 @@ func TestLoopSubscriptionProviderHonorsRequiresTag(t *testing.T) {
 
 	ctx := looppkg.WithLoopIDForTest(context.Background(), leaf.ID())
 
-	out, err := p.TagContext(ctx, agentctx.ContextRequest{})
+	out, err := p.TagContext(ctx, agentctx.ContextRequest{IncludeAlways: true})
 	if err != nil {
 		t.Fatalf("TagContext (tag off): %v", err)
 	}
@@ -147,7 +163,7 @@ func TestLoopSubscriptionProviderHonorsRequiresTag(t *testing.T) {
 		t.Errorf("ungated subscription missing: %q", out)
 	}
 
-	out, err = p.TagContext(ctx, agentctx.ContextRequest{ActiveTags: map[string]bool{"ranch_water": true}})
+	out, err = p.TagContext(ctx, agentctx.ContextRequest{IncludeAlways: true, ActiveTags: map[string]bool{"ranch_water": true}})
 	if err != nil {
 		t.Fatalf("TagContext (tag on): %v", err)
 	}
@@ -188,7 +204,7 @@ func TestLoopSubscriptionProviderDedupIgnoresGatedOffGlobalRows(t *testing.T) {
 
 	// Tag off: the global tier renders nothing for the entity, so the
 	// loop's own subscription must show it.
-	out, err := p.TagContext(ctx, agentctx.ContextRequest{})
+	out, err := p.TagContext(ctx, agentctx.ContextRequest{IncludeAlways: true})
 	if err != nil {
 		t.Fatalf("TagContext (tag off): %v", err)
 	}
@@ -197,7 +213,7 @@ func TestLoopSubscriptionProviderDedupIgnoresGatedOffGlobalRows(t *testing.T) {
 	}
 
 	// Tag on: the global tier renders it, so the loop must dedup.
-	out, err = p.TagContext(ctx, agentctx.ContextRequest{ActiveTags: map[string]bool{"ranch_water": true}})
+	out, err = p.TagContext(ctx, agentctx.ContextRequest{IncludeAlways: true, ActiveTags: map[string]bool{"ranch_water": true}})
 	if err != nil {
 		t.Fatalf("TagContext (tag on): %v", err)
 	}
@@ -245,7 +261,7 @@ func TestLoopSubscriptionProviderGatedLeafShadowsUngatedAncestor(t *testing.T) {
 	}
 	ctx := looppkg.WithLoopIDForTest(context.Background(), leaf.ID())
 
-	out, err := p.TagContext(ctx, agentctx.ContextRequest{})
+	out, err := p.TagContext(ctx, agentctx.ContextRequest{IncludeAlways: true})
 	if err != nil {
 		t.Fatalf("TagContext (tag off): %v", err)
 	}
@@ -253,7 +269,7 @@ func TestLoopSubscriptionProviderGatedLeafShadowsUngatedAncestor(t *testing.T) {
 		t.Errorf("shadowed entity rendered while the leaf's gate is closed; first-wins should include conditions: %q", out)
 	}
 
-	out, err = p.TagContext(ctx, agentctx.ContextRequest{ActiveTags: map[string]bool{"ranch_water": true}})
+	out, err = p.TagContext(ctx, agentctx.ContextRequest{IncludeAlways: true, ActiveTags: map[string]bool{"ranch_water": true}})
 	if err != nil {
 		t.Fatalf("TagContext (tag on): %v", err)
 	}
@@ -297,7 +313,7 @@ func TestLoopSubscriptionProviderDedupIgnoresNonRenderingGlobalRows(t *testing.T
 	}
 	ctx := looppkg.WithLoopIDForTest(context.Background(), leaf.ID())
 
-	out, err := p.TagContext(ctx, agentctx.ContextRequest{})
+	out, err := p.TagContext(ctx, agentctx.ContextRequest{IncludeAlways: true})
 	if err != nil {
 		t.Fatalf("TagContext: %v", err)
 	}
@@ -312,7 +328,7 @@ func TestLoopSubscriptionProviderDedupIgnoresNonRenderingGlobalRows(t *testing.T
 	}); err != nil {
 		t.Fatalf("upgrade to both: %v", err)
 	}
-	out, err = p.TagContext(ctx, agentctx.ContextRequest{})
+	out, err = p.TagContext(ctx, agentctx.ContextRequest{IncludeAlways: true})
 	if err != nil {
 		t.Fatalf("TagContext (both): %v", err)
 	}

--- a/internal/tools/loop_create_tool.go
+++ b/internal/tools/loop_create_tool.go
@@ -937,7 +937,7 @@ func thaneLoopCreateSchema() map[string]any {
 			"prompt_mode": map[string]any{
 				"type":        "string",
 				"enum":        []string{"full", "task"},
-				"description": "Optional system-prompt shape (service/event_driven). \"task\" is the compact worker prompt: it sheds the reflective identity layer while keeping tagged guidance, the task, and current conditions — right for mechanical maintainer/watcher/poller loops, where identity prose is the largest single prompt cost. Omit (or set \"full\") for loops that reflect on the agent or compose messages in its voice. Changeable later, live, via loop_definition_update.",
+				"description": "Optional system-prompt shape (service/event_driven). \"task\" is the compact worker prompt: it sheds the reflective identity layer while keeping tagged guidance, the loop's declared subscriptions and self view, the task, and current conditions — right for mechanical maintainer/watcher/poller loops, where identity prose is the largest single prompt cost. Omit (or set \"full\") for loops that reflect on the agent or compose messages in its voice. Changeable later, live, via loop_definition_update.",
 			},
 			"sleep_min": map[string]any{
 				"type":        "string",

--- a/internal/tools/loop_spec_schema.go
+++ b/internal/tools/loop_spec_schema.go
@@ -46,7 +46,7 @@ func loopSpecSchema(description string) map[string]any {
 			"prompt_mode": map[string]any{
 				"type":        "string",
 				"enum":        []string{"full", "task"},
-				"description": "System-prompt shape for every iteration. \"task\" is the compact worker prompt: it sheds the reflective identity layer — axioms, persona, ego, mission, persona-tagged talents, always-on ambient context; the largest single prompt cost in a background loop — while keeping always-tagged talents, tagged guidance, active tags, the task, and current conditions. Declare \"task\" for mechanical maintainer/watcher/poller loops (fetch a source, check a state, update a document). Leave unset (or \"full\") for any loop whose job needs the identity: reflection or self-assessment, or composing messages in the agent's own voice. Editable live via loop_definition_update.",
+				"description": "System-prompt shape for every iteration. \"task\" is the compact worker prompt: it sheds the reflective identity layer — axioms, persona, ego, mission, persona-tagged talents, always-on ambient context; the largest single prompt cost in a background loop — while keeping always-tagged talents, tagged guidance, active tags, the loop's declared subscriptions and self view, the task, and current conditions. Declare \"task\" for mechanical maintainer/watcher/poller loops (fetch a source, check a state, update a document). Leave unset (or \"full\") for any loop whose job needs the identity: reflection or self-assessment, or composing messages in the agent's own voice. Editable live via loop_definition_update.",
 			},
 			"supervisor": map[string]any{
 				"type":        "boolean",

--- a/talents/loops.md
+++ b/talents/loops.md
@@ -206,8 +206,9 @@ muddle them and the loop drifts.
   persona, ego, persona-tagged talents, always-on ambient context),
   which is the largest single prompt cost in a background loop and
   pure latency on a local model. The worker keeps its always-tagged
-  talents, its tagged guidance, its task, and current conditions — it
-  sheds only the self it was never using. Leave the field unset for a
+  talents, its tagged guidance, its declared subscriptions and its own
+  loop context, its task, and current conditions — it sheds only the
+  self it was never using, never its eyes. Leave the field unset for a
   loop whose work needs the identity: reflection or judgment about
   the agent itself, or composing messages in the agent's own voice.
   The mode is per-loop and never inherited; when in doubt, leave it


### PR DESCRIPTION
## A task-mode worker sheds the ambient self, not its eyes

The production audit ahead of the #1171 rollout found that `prompt_mode: task` sheds more than the identity stack: `LoopSubscriptionProvider` — the provider that renders a loop's declared entity subscriptions — and `LoopSelfContextProvider` — the "### This loop" sleep-envelope block — both live in the always-on ambient bucket, and task mode drops the whole bucket. Flip any subscription-bearing watcher and it wakes blind: `ranch_climate_watch` unable to see its 25 climate entities while its instructions still say "read the current sensor values," which for the small local models these loops route to is a confabulation seed rather than an error. Full write-up in #1363.

The bucket conflated two things under one gate. Ambient *experiential* context — presence, episodic memory, working memory, notification history — is the interactive agent's continuity, and shedding it is exactly what task mode and delegate runs both want. Loop-scoped *operational* context is not ambience; it landed in the bucket only because it isn't tag-gated and the bucket was the one home for "renders every turn." Task mode was tuned for delegates — no subscriptions, no envelope — and nobody re-audited the bucket when self-paced service loops became task-mode candidates.

**The fix splits the gate.** `ContextRequest.IncludeLoopScoped` admits a fourth assembler source — loop-scoped providers — independent of `IncludeAlways`:

| Run shape | `IncludeAlways` | `IncludeLoopScoped` |
|---|---|---|
| Full-mode loop turn | ✓ | ✓ |
| Task-mode loop turn | — | ✓ |
| Delegate run (`SuppressAlwaysContext`) | — | — |

`LoopSubscriptionProvider` and `LoopSelfContextProvider` move to the new class (registration, staging, and rebuild paths all mirrored). `StateWindowProvider` was checked and stays ambient — it ignores loop context entirely.

**Review round (68b9fa7d).** Copilot caught three real gaps, one of which had this description overclaiming. The always-visible dedup in `LoopSubscriptionProvider` now follows the gate — "already visible" is a claim about this turn's prompt, so on a task-mode turn (watchlist not rendering) nothing suppresses, where before an entity subscribed both always-visible and loop-scoped would have been emitted by *neither* provider. And the original two-list render order was not byte-stable as first claimed: it regrouped full-mode live-state content and demoted the loop's watch set in bucket-cap priority. The assembler now holds one interleaved list of gated providers in registration order (staging drain mirrored), so full-mode prompts are genuinely byte-identical to pre-split and cap priority follows registration order, not class — pinned by a cross-class ordering test and a task-mode overlap regression. The assembler and Loop GoDoc contracts now describe the class.

The teaching moves with the truth: every `prompt_mode` surface (Spec Godoc, shared spec schema, `thane_loop_create`, the loop-definitions reference, the loops doctrine) now says the worker keeps its declared subscriptions and self view — removing the one honest reason to avoid task mode on a watcher.

**This unblocks the #1171 rollout**: after this deploys, the subscription-bearing prod watchers (`door_lock_batteries`, `ranch_climate_watch`, `office_watch`, burn-ban) can flip to `prompt_mode: task` per the audit's sequencing, not just the zero-subscription `canyon_lake_watch` pilot.

## Test plan

- [x] `TestTagContextAssembler_LoopScopedGating` — the three run shapes above, at the assembler
- [x] Task-mode prompt-order test now asserts loop-scoped content present while ambient content stays absent (the regression this PR exists to prevent)
- [x] Full-mode prompt-order test asserts both buckets and unchanged section order
- [x] `just ci` green locally

Closes #1363
Refs #1171

🤖 Generated with [Claude Code](https://claude.com/claude-code)

