### PR TITLE
feat(metacog): the verdict gets facets, and core gets to read it

### DIFF
--- a/internal/app/loop_outputs.go
+++ b/internal/app/loop_outputs.go
@@ -291,17 +291,34 @@ func renderLoopOutputContextWithNow(ctx context.Context, store *documents.Store,
 }
 
 func loopOutputUpdatedDelta(doc *documents.DocumentRecord, now time.Time) string {
+	if ts, ok := documentUpdatedTime(doc); ok {
+		return promptfmt.FormatDeltaOnly(ts, now)
+	}
+	return ""
+}
+
+// documentUpdatedTime resolves when a maintained document was last
+// updated: the document's own declared frontmatter stamps ("updated",
+// then "updated_at") outrank the file's modification time, and every
+// value parses through database.ParseTimestamp — the shared
+// timestamp-format authority — never a per-caller layout guess. One
+// seam serves both delta rendering here and any consumer needing the
+// time itself (the system self-assessment provider's age).
+func documentUpdatedTime(doc *documents.DocumentRecord) (time.Time, bool) {
 	if doc == nil {
-		return ""
+		return time.Time{}, false
 	}
 	for _, key := range []string{"updated", "updated_at"} {
 		for _, value := range doc.Frontmatter[key] {
-			if delta := loopOutputDelta(value, now); delta != "" {
-				return delta
+			if ts, err := database.ParseTimestamp(value); err == nil {
+				return ts, true
 			}
 		}
 	}
-	return loopOutputDelta(doc.ModifiedAt, now)
+	if ts, err := database.ParseTimestamp(doc.ModifiedAt); err == nil {
+		return ts, true
+	}
+	return time.Time{}, false
 }
 
 func loopOutputDelta(value string, now time.Time) string {

--- a/internal/app/loop_outputs.go
+++ b/internal/app/loop_outputs.go
@@ -321,17 +321,6 @@ func documentUpdatedTime(doc *documents.DocumentRecord) (time.Time, bool) {
 	return time.Time{}, false
 }
 
-func loopOutputDelta(value string, now time.Time) string {
-	if strings.TrimSpace(value) == "" {
-		return ""
-	}
-	ts, err := database.ParseTimestamp(value)
-	if err != nil {
-		return ""
-	}
-	return promptfmt.FormatDeltaOnly(ts, now)
-}
-
 func outputInterfaceDescription(output looppkg.OutputSpec) string {
 	if output.HasFacets() {
 		keys := make([]string, 0, 4)

--- a/internal/app/new_awareness.go
+++ b/internal/app/new_awareness.go
@@ -216,6 +216,13 @@ func (a *App) initAwareness(s *newState) error {
 	)
 	a.loop.RegisterAlwaysContextProvider(stateWindowProvider)
 
+	// The system's one-line self-assessment: metacog's published
+	// status_line facet, the annunciator of judgments beside the state
+	// window's annunciator of facts (#1351). Always-on (ambient
+	// interactive awareness) — worker loops don't carry the fleet's
+	// verdict. Quiet until the metacognitive document publishes facets.
+	a.loop.RegisterAlwaysContextProvider(awareness.NewSystemSelfAssessmentProvider(a.readSystemSelfAssessmentDocument, logger))
+
 	// The window's per-entity retention rings back the subscription
 	// transition logs (#1210): declared logs render from here, and
 	// their targets reach the rings through derived capture in the

--- a/internal/app/new_awareness.go
+++ b/internal/app/new_awareness.go
@@ -208,6 +208,17 @@ func (a *App) initAwareness(s *newState) error {
 	// class-aware projection so the window reads closed→open for a
 	// garage_door, not off→on — injected here because contextfmt imports
 	// the homeassistant package and the provider cannot import it back.
+	// The system's one-line self-assessment: metacog's published
+	// status_line facet, the annunciator of judgments beside the state
+	// window's annunciator of facts (#1351). Always-on (ambient
+	// interactive awareness) — worker loops don't carry the fleet's
+	// verdict; quiet until the metacognitive document publishes facets.
+	// Registered BEFORE the state window on purpose: both write the
+	// Live State bucket, cap priority is registration order, and the
+	// one-line verdict must survive a busy unbounded window — not the
+	// other way around.
+	a.loop.RegisterAlwaysContextProvider(awareness.NewSystemSelfAssessmentProvider(a.readSystemSelfAssessmentDocument, logger))
+
 	stateWindowProvider := homeassistant.NewStateWindowProvider(
 		cfg.StateWindow.MaxEntries,
 		time.Duration(cfg.StateWindow.MaxAgeMinutes)*time.Minute,
@@ -215,13 +226,6 @@ func (a *App) initAwareness(s *newState) error {
 		logger,
 	)
 	a.loop.RegisterAlwaysContextProvider(stateWindowProvider)
-
-	// The system's one-line self-assessment: metacog's published
-	// status_line facet, the annunciator of judgments beside the state
-	// window's annunciator of facts (#1351). Always-on (ambient
-	// interactive awareness) — worker loops don't carry the fleet's
-	// verdict. Quiet until the metacognitive document publishes facets.
-	a.loop.RegisterAlwaysContextProvider(awareness.NewSystemSelfAssessmentProvider(a.readSystemSelfAssessmentDocument, logger))
 
 	// The window's per-entity retention rings back the subscription
 	// transition logs (#1210): declared logs render from here, and

--- a/internal/app/system_self_assessment.go
+++ b/internal/app/system_self_assessment.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/nugget/thane-ai-agent/internal/state/documents"
+
 	looppkg "github.com/nugget/thane-ai-agent/internal/runtime/loop"
 	"github.com/nugget/thane-ai-agent/internal/runtime/metacognitive"
 )
@@ -28,11 +30,22 @@ func (a *App) readSystemSelfAssessmentDocument(ctx context.Context) (string, tim
 	if !ok {
 		return "", time.Time{}, nil
 	}
+	// Select the verdict-bearing output: the maintained document that
+	// declares a status_line facet. Falling back to the first maintained
+	// document keeps the resolver working against a pre-facet spec,
+	// where the provider stays quiet on content anyway.
 	ref := ""
 	for _, output := range spec.Outputs {
-		if output.Type == looppkg.OutputTypeMaintainedDocument && strings.TrimSpace(output.Ref) != "" {
+		if output.Type != looppkg.OutputTypeMaintainedDocument || strings.TrimSpace(output.Ref) == "" {
+			continue
+		}
+		if ref == "" {
 			ref = output.Ref
-			break
+		}
+		for _, facet := range output.Facets {
+			if facet.Name == looppkg.OutputFacetStatusLine {
+				ref = output.Ref
+			}
 		}
 	}
 	if ref == "" {
@@ -40,11 +53,11 @@ func (a *App) readSystemSelfAssessmentDocument(ctx context.Context) (string, tim
 	}
 	record, err := a.documentStore.Read(ctx, ref)
 	if err != nil {
-		if strings.Contains(err.Error(), "document not found") {
+		if documents.IsNotFound(err) {
 			return "", time.Time{}, nil
 		}
 		return "", time.Time{}, err
 	}
-	modified, _ := time.Parse(time.RFC3339, record.ModifiedAt)
+	modified, _ := time.Parse(time.RFC3339Nano, record.ModifiedAt)
 	return record.Body, modified, nil
 }

--- a/internal/app/system_self_assessment.go
+++ b/internal/app/system_self_assessment.go
@@ -58,6 +58,8 @@ func (a *App) readSystemSelfAssessmentDocument(ctx context.Context) (string, tim
 		}
 		return "", time.Time{}, err
 	}
-	modified, _ := time.Parse(time.RFC3339Nano, record.ModifiedAt)
+	// Zero when unresolvable; the provider omits the age rather than
+	// inventing one.
+	modified, _ := documentUpdatedTime(record)
 	return record.Body, modified, nil
 }

--- a/internal/app/system_self_assessment.go
+++ b/internal/app/system_self_assessment.go
@@ -1,0 +1,50 @@
+package app
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	looppkg "github.com/nugget/thane-ai-agent/internal/runtime/loop"
+	"github.com/nugget/thane-ai-agent/internal/runtime/metacognitive"
+)
+
+// readSystemSelfAssessmentDocument is the read function behind
+// [awareness.SystemSelfAssessmentProvider]: it resolves metacog's
+// maintained document lazily from the definition registry — the spec
+// owns where the state lives, so no ref is hardcoded to drift — and
+// returns the body with its last-modified time.
+//
+// Every absent-is-normal state returns empty content and a nil error
+// so the provider stays quiet instead of warning each turn: no
+// metacognitive definition (installs run without it), no declared
+// maintained document, or a document that has never been written.
+// Only a genuinely failed read reports an error.
+func (a *App) readSystemSelfAssessmentDocument(ctx context.Context) (string, time.Time, error) {
+	if a == nil || a.documentStore == nil {
+		return "", time.Time{}, nil
+	}
+	spec, ok := a.loopDefinitionRegistry.Get(metacognitive.DefinitionName)
+	if !ok {
+		return "", time.Time{}, nil
+	}
+	ref := ""
+	for _, output := range spec.Outputs {
+		if output.Type == looppkg.OutputTypeMaintainedDocument && strings.TrimSpace(output.Ref) != "" {
+			ref = output.Ref
+			break
+		}
+	}
+	if ref == "" {
+		return "", time.Time{}, nil
+	}
+	record, err := a.documentStore.Read(ctx, ref)
+	if err != nil {
+		if strings.Contains(err.Error(), "document not found") {
+			return "", time.Time{}, nil
+		}
+		return "", time.Time{}, err
+	}
+	modified, _ := time.Parse(time.RFC3339, record.ModifiedAt)
+	return record.Body, modified, nil
+}

--- a/internal/state/awareness/system_self_assessment_provider.go
+++ b/internal/state/awareness/system_self_assessment_provider.go
@@ -1,0 +1,92 @@
+package awareness
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/nugget/thane-ai-agent/internal/model/promptfmt"
+	"github.com/nugget/thane-ai-agent/internal/runtime/agentctx"
+	looppkg "github.com/nugget/thane-ai-agent/internal/runtime/loop"
+)
+
+// SystemSelfAssessmentProvider injects the metacognitive loop's
+// published status_line — the one sentence in the system that is a
+// judgment about the whole system — into interactive context each turn.
+// system_health is the annunciator of facts; this line is the
+// annunciator of judgments, and until it existed the verdict lived
+// buried in a document nobody read until a request_core_attention
+// fired (#1351).
+//
+// It is deliberately the seed crystal of the general pattern (every
+// faceted loop's status_line in a parent's context, the process-table
+// panel noted on #1341): one provider, one document, one line, so the
+// generalization has a proven shape when it comes due.
+//
+// Quiet by design in every degraded state: no document, no facet
+// sections (the document predates its faceted spec), or an empty
+// status_line all render nothing rather than a placeholder — an absent
+// judgment is not a judgment.
+type SystemSelfAssessmentProvider struct {
+	// read returns the assessed document's body and last-write time.
+	// A function rather than a store handle so the provider stays
+	// testable and the app can resolve the document ref lazily from
+	// the loop-definition registry — the spec owns where metacog's
+	// state lives, and a hardcoded ref here would drift from it.
+	read   func(ctx context.Context) (body string, updatedAt time.Time, err error)
+	logger *slog.Logger
+	now    func() time.Time
+}
+
+// NewSystemSelfAssessmentProvider wires the provider over a document
+// read function. logger may be nil (defaults to slog.Default()).
+func NewSystemSelfAssessmentProvider(read func(ctx context.Context) (string, time.Time, error), logger *slog.Logger) *SystemSelfAssessmentProvider {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &SystemSelfAssessmentProvider{read: read, logger: logger, now: time.Now}
+}
+
+// TagContextBucket places the verdict in live state: it is a current
+// reading of the system, not continuity material.
+func (p *SystemSelfAssessmentProvider) TagContextBucket() agentctx.ContextBucket {
+	return agentctx.ContextBucketLiveState
+}
+
+// TagContext implements the agent context-provider contract. It parses
+// the status_line facet out of the document body spec-free — the facet
+// headings are the contract, so the provider needs no knowledge of the
+// loop's spec — and renders it with a delta-formatted age so the reader
+// can weigh a fresh verdict differently from a stale one.
+func (p *SystemSelfAssessmentProvider) TagContext(ctx context.Context, _ agentctx.ContextRequest) (string, error) {
+	if p == nil || p.read == nil {
+		return "", nil
+	}
+	body, updatedAt, err := p.read(ctx)
+	if err != nil {
+		// A read failure is a health event for the metacognitive
+		// subsystem, not for this turn: log it and stay quiet rather
+		// than surfacing an error where a judgment was expected.
+		p.logger.Warn("system self-assessment document unreadable", "error", err)
+		return "", nil
+	}
+	payload, ok := looppkg.ParseFacetSections(body)
+	if !ok {
+		return "", nil
+	}
+	verdict, ok := payload.FacetByKey("status_line")
+	if !ok || strings.TrimSpace(verdict) == "" {
+		return "", nil
+	}
+	var sb strings.Builder
+	sb.WriteString("### System Self-Assessment\n\n")
+	sb.WriteString(strings.TrimSpace(verdict))
+	if !updatedAt.IsZero() {
+		sb.WriteString(" (metacognitive verdict; age_delta=")
+		sb.WriteString(promptfmt.FormatDeltaOnly(updatedAt, p.now()))
+		sb.WriteString(")")
+	}
+	sb.WriteString("\n")
+	return sb.String(), nil
+}

--- a/internal/state/awareness/system_self_assessment_provider.go
+++ b/internal/state/awareness/system_self_assessment_provider.go
@@ -75,7 +75,7 @@ func (p *SystemSelfAssessmentProvider) TagContext(ctx context.Context, _ agentct
 	if !ok {
 		return "", nil
 	}
-	verdict, ok := payload.FacetByKey("status_line")
+	verdict, ok := payload.FacetByKey(string(looppkg.OutputFacetStatusLine))
 	if !ok || strings.TrimSpace(verdict) == "" {
 		return "", nil
 	}

--- a/internal/state/awareness/system_self_assessment_provider_test.go
+++ b/internal/state/awareness/system_self_assessment_provider_test.go
@@ -1,0 +1,78 @@
+package awareness
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nugget/thane-ai-agent/internal/runtime/agentctx"
+)
+
+// TestSystemSelfAssessmentProvider pins the provider's contract: the
+// status_line facet renders with a delta-formatted age, and every
+// degraded state — unfaceted document, empty verdict, read failure —
+// is quiet rather than a placeholder or a surfaced error.
+func TestSystemSelfAssessmentProvider(t *testing.T) {
+	t.Parallel()
+
+	faceted := "## Status Line\n\npanel clean, baselines steady\n\n## Digest\n\nNo open concerns.\n\n## Details\n\nworking memory here\n"
+	writtenAt := time.Now().Add(-2 * time.Hour)
+
+	cases := []struct {
+		name     string
+		body     string
+		at       time.Time
+		err      error
+		contains []string
+		empty    bool
+	}{
+		{
+			name:     "verdict renders with age",
+			body:     faceted,
+			at:       writtenAt,
+			contains: []string{"System Self-Assessment", "panel clean, baselines steady", "age_delta=-"},
+		},
+		{
+			name:  "unfaceted document is quiet",
+			body:  "# Metacognitive State\n\nbaselines and concerns, pre-facet shape\n",
+			at:    writtenAt,
+			empty: true,
+		},
+		{
+			name:  "empty status line is quiet",
+			body:  "## Status Line\n\n\n## Digest\n\nsomething\n\n## Details\n\nbody\n",
+			at:    writtenAt,
+			empty: true,
+		},
+		{
+			name:  "read failure is quiet, not an error",
+			err:   errors.New("smb mount gone"),
+			empty: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := NewSystemSelfAssessmentProvider(func(context.Context) (string, time.Time, error) {
+				return tc.body, tc.at, tc.err
+			}, nil)
+			out, err := p.TagContext(context.Background(), agentctx.ContextRequest{})
+			if err != nil {
+				t.Fatalf("TagContext: %v", err)
+			}
+			if tc.empty {
+				if out != "" {
+					t.Fatalf("want quiet, got: %q", out)
+				}
+				return
+			}
+			for _, want := range tc.contains {
+				if !strings.Contains(out, want) {
+					t.Errorf("output missing %q: %q", want, out)
+				}
+			}
+		})
+	}
+}

--- a/loops/metacognitive.md
+++ b/loops/metacognitive.md
@@ -39,7 +39,7 @@ outputs:
       facets:
         - status_line
         - digest
-      purpose: 'Current metacognitive state, published at three fidelities. The full body is private working memory: operational baselines (what normal looks like, per subsystem and loop), active concerns with evidence and severity, incidents observed and escalated, and sleep reasoning that should persist across fresh loop iterations. The digest is the actionable summary a reader can act on without opening the document. The status_line is the verdict — the one sentence in the system that is a judgment about the whole system, injected into interactive context each turn.'
+      purpose: 'Current metacognitive state, published at three fidelities. The full body is the loop''s own working memory: operational baselines (what normal looks like, per subsystem and loop), active concerns with evidence and severity, incidents observed and escalated, and sleep reasoning that should persist across fresh loop iterations. The digest is the actionable summary a reader can act on without opening the document. The status_line is the verdict — the one sentence in the system that is a judgment about the whole system, injected into interactive context each turn.'
 tags:
     - metacognitive
     - diagnostics

--- a/loops/metacognitive.md
+++ b/loops/metacognitive.md
@@ -34,7 +34,12 @@ outputs:
       type: maintained_document
       ref: self:metacognitive.md
       mode: replace
-      purpose: 'Current metacognitive state: operational baselines (what normal looks like, per subsystem and loop), active concerns with evidence and severity, incidents observed and escalated, and sleep reasoning that should persist across fresh loop iterations.'
+      # teaser deliberately omitted: it exists for search snippets,
+      # and this document is not discovery content.
+      facets:
+        - status_line
+        - digest
+      purpose: 'Current metacognitive state, published at three fidelities. The full body is private working memory: operational baselines (what normal looks like, per subsystem and loop), active concerns with evidence and severity, incidents observed and escalated, and sleep reasoning that should persist across fresh loop iterations. The digest is the actionable summary a reader can act on without opening the document. The status_line is the verdict — the one sentence in the system that is a judgment about the whole system, injected into interactive context each turn.'
 tags:
     - metacognitive
     - diagnostics
@@ -179,10 +184,21 @@ content go — purpose-built loops own that now.
    act. Escalate with evidence: name the subsystem or loop, the
    observed numbers against the baseline, and what you already ruled
    out. You observe and judge; core decides and acts.
-5. **Record** — Call replace_output_metacognitive_state with your
-   complete updated state: refreshed baselines, concerns opened or
-   closed, incidents noted. This generated output tool is the ONLY
-   sanctioned interface for writing your durable state.
+5. **Record** — Call publish_output_metacognitive_state with all three
+   projections together. The `full` body is your working memory,
+   exactly as before: refreshed baselines, concerns opened or closed,
+   incidents noted. The `digest` (2048 runes) is the actionable
+   summary — open concerns with severity and evidence, anything core
+   should know before it has to ask. The `status_line` (120 runes) is
+   the verdict: the one sentence a glance deserves — "panel clean,
+   baselines steady" or "two concerns open: archivist backlog above
+   baseline, ego churn climbing". A judgment about the whole system,
+   never an inventory of it. Your verdict is injected into interactive
+   context every turn, so it is the most-read sentence you write.
+   Write each projection TO its budget, not near it: an over-budget
+   value is rejected rather than clipped, and the rejection names the
+   limit — shorten and republish. This generated output tool is the
+   ONLY sanctioned interface for writing your durable state.
 6. **Set your sleep** — Close the turn with set_next_sleep and your
    reasoning. The "This loop" block carries your permitted range and
    your actual recent rhythm; read it rather than guessing. Sleep
@@ -231,6 +247,11 @@ frontier model. In addition to the normal assessment, critically evaluate:
 - **Drift detection** — Has this loop's own behavior become routine or
   mechanical? Is it still genuinely judging, or just re-recording the
   same document with the numbers changed?
+- **Publish health** — Are the publishes landing? An over-budget
+  projection is rejected whole, so a loop that keeps overshooting its
+  status_line budget starves every reader of both the verdict and the
+  memory. If recent iterations show rejected publishes, the correction
+  is a shorter verdict, not a retry of the same one.
 
 Be honest. Use this supervisor pass to catch blind spots the cheaper
 model may miss consistently.


### PR DESCRIPTION
## The annunciator of judgments

Metacog's durable output has exactly the two-audience split the faceted contract (#1250) was designed to encode. The full body of `self:metacognitive.md` is private working memory — baselines, open concerns, incident notes, the material the mandate explicitly forbids from becoming a status report. But the *verdict* is of legitimate public interest: it's the one loop whose one-liner is a judgment about the whole system. `system_health` is the annunciator of facts; the metacog status_line is the annunciator of judgments — and until now it was buried in a document nobody read until a `request_core_attention` fired.

**The spec** declares `status_line` and `digest` on `metacognitive_state` — teaser deliberately omitted (it exists for search snippets; this document is not discovery content). The write tool becomes `publish_output_metacognitive_state` the day the spec lands.

**The mandate** teaches the projection ladder in the Record step: the full body stays the working memory, the digest is the actionable summary, and the status_line is the verdict — "a judgment about the whole system, never an inventory of it," with the honest incentive stated plainly: it's injected into interactive context every turn, so it's the most-read sentence the loop writes. Budget discipline is taught at the point of application (over-budget is rejected whole, the rejection names the limit), and the supervisor review gains a **publish-health** check per the issue's caution — a quality-floor-3 model composing a 120-rune verdict every iteration is a small new failure surface, and the audit pass is where repeated rejections would surface.

**The consumer ships in the same change**, because facets without a consumer are latent structure. `SystemSelfAssessmentProvider` parses the status_line out of the document spec-free (`ParseFacetSections` — the facet headings are the contract) and injects it into interactive context each turn with a delta-formatted age. Design choices worth naming:

- **Always-on deliberately**: the verdict is ambient interactive awareness; task-mode workers don't carry the fleet's judgment (post-#1364 gating makes this exact).
- **Lazy ref resolution**: the app resolves metacog's document ref from the definition registry at read time — the spec owns where the state lives, so no hardcoded ref can drift from it.
- **Quiet in every degraded state**: no definition, no document yet, a pre-facet document body, an empty verdict, or a failed read all render nothing — an absent judgment is not a judgment, and a placeholder would be worse than silence. This makes the provider safe to deploy *before* prod's document reshapes: it stays silent until metacog's first faceted publish.

This is deliberately the seed crystal of the #1341 process-table panel: one provider, one document, one line, so the generalization to every faceted loop's status_line has its pattern proven when it comes due.

## Deploy notes

Outputs are relaunch-tier: prod picks this up at the next `core/loops/metacognitive.md` backport + restart. Metacog's first wake after that does the first faceted publish (the publish tool's teaching errors guide the transition), and the verdict line appears in interactive context from then on. Nothing breaks in between — the provider is quiet against the pre-facet document.

A follow-up PR (separate, different layer) will surface faceted publishes into the document root's git history — the status_line as commit-message material, so `git log` on the state document reads as a timeline of verdicts.

## Test plan

- [x] `TestSystemSelfAssessmentProvider` — verdict renders with age; unfaceted document, empty verdict, and read failure are all quiet
- [x] Core-loops round-trip covers the faceted spec block
- [x] `just ci` green locally

Closes #1351

🤖 Generated with [Claude Code](https://claude.com/claude-code)
