### PR TITLE
feat(documents): faceted writes annotate their own commits

### DIFF
--- a/internal/platform/provenance/provenance.go
+++ b/internal/platform/provenance/provenance.go
@@ -256,7 +256,7 @@ func (s *Store) Write(ctx context.Context, filename, content, message string) er
 		s.logger.Info("provenance file committed",
 			"file", filename,
 			"bytes", len(content),
-			"message", message,
+			"message", messageSubject(message),
 		)
 	}
 
@@ -303,7 +303,7 @@ func (s *Store) WriteFiles(ctx context.Context, files map[string]string, message
 	if committed {
 		s.logger.Info("provenance files committed",
 			"files", filenames,
-			"message", message,
+			"message", messageSubject(message),
 		)
 	}
 
@@ -341,7 +341,7 @@ func (s *Store) Delete(ctx context.Context, filename, message string) error {
 	if committed {
 		s.logger.Info("provenance file deletion committed",
 			"file", filename,
-			"message", message,
+			"message", messageSubject(message),
 		)
 	}
 	return nil
@@ -403,4 +403,16 @@ func (s *Store) History(ctx context.Context, filename string) (*FileHistory, err
 // (e.g., for size checks or passing to other subsystems).
 func (s *Store) FilePath(filename string) string {
 	return filepath.Join(s.path, filename)
+}
+
+// messageSubject reduces a commit message to its subject line for
+// logging. Messages may legitimately carry multi-line bodies — faceted
+// document writes put the digest there — and a log line is a summary
+// surface, not a transcript: the subject identifies the commit, and
+// the full message lives in the repository it describes.
+func messageSubject(message string) string {
+	if i := strings.IndexByte(message, '\n'); i >= 0 {
+		return message[:i]
+	}
+	return message
 }

--- a/internal/state/documents/mutate_policy.go
+++ b/internal/state/documents/mutate_policy.go
@@ -5,7 +5,10 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
+
+	looppkg "github.com/nugget/thane-ai-agent/internal/runtime/loop"
 )
 
 func (s *Store) writeDocumentFile(ctx context.Context, root, relPath, raw string) error {
@@ -17,7 +20,7 @@ func (s *Store) writeDocumentFile(ctx context.Context, root, relPath, raw string
 		return err
 	}
 	if writer := s.rootWriter(root); writer != nil {
-		if err := writer.Write(ctx, relPath, raw, documentMutationMessage("doc_write", root, relPath)); err != nil {
+		if err := writer.Write(ctx, relPath, raw, documentWriteMessage("doc_write", root, relPath, raw)); err != nil {
 			return fmt.Errorf("write document through root policy: %w", err)
 		}
 		if err := s.refreshDocumentWrite(ctx, root, relPath); err != nil {
@@ -103,4 +106,46 @@ func (s *Store) ensureRootAuthoringAllowed(root string) error {
 
 func documentMutationMessage(action, root, relPath string) string {
 	return action + " " + makeRef(root, relPath)
+}
+
+// facetSubjectMaxRunes clamps a status_line borrowed into a commit
+// subject. Published projections are already budgeted below this, so
+// the clamp only fires on content that arrived through a non-publish
+// write (doc_write can put anything under a reserved heading) — and a
+// commit subject is annotation, not the content itself, so clipping
+// here is honest where clipping a projection would not be.
+const facetSubjectMaxRunes = 120
+
+// documentWriteMessage composes the commit message for a document
+// write. For an unfaceted document it is the same mechanical subject
+// documentMutationMessage produces. When the content carries facet
+// sections, the message borrows them: the status_line joins the
+// subject — so the root's git log reads as a timeline of the
+// document's own one-line verdicts — and the digest becomes the commit
+// body, the actionable summary at the moment of the write. No writer
+// cooperation is needed: the facet headings are the contract, so every
+// write of a faceted document gets this regardless of which tool or
+// author produced it.
+func documentWriteMessage(action, root, relPath, raw string) string {
+	subject := documentMutationMessage(action, root, relPath)
+	_, body := splitFrontmatter(raw)
+	payload, ok := looppkg.ParseFacetSections(body)
+	if !ok {
+		return subject
+	}
+	if verdict, ok := payload.FacetByKey("status_line"); ok {
+		if line := strings.TrimSpace(verdict); line != "" {
+			line = strings.Join(strings.Fields(line), " ")
+			if runes := []rune(line); len(runes) > facetSubjectMaxRunes {
+				line = string(runes[:facetSubjectMaxRunes-1]) + "…"
+			}
+			subject += " — " + line
+		}
+	}
+	if digest, ok := payload.FacetByKey("digest"); ok {
+		if summary := strings.TrimSpace(digest); summary != "" {
+			subject += "\n\n" + summary
+		}
+	}
+	return subject
 }

--- a/internal/state/documents/mutate_policy_message_test.go
+++ b/internal/state/documents/mutate_policy_message_test.go
@@ -47,16 +47,11 @@ func TestDocumentWriteMessageBorrowsFacets(t *testing.T) {
 		}
 	})
 
-	t.Run("empty status_line stays mechanical", func(t *testing.T) {
+	t.Run("empty status_line stays mechanical, digest still becomes the body", func(t *testing.T) {
 		raw := "## Status Line\n\n\n## Digest\n\nsummary\n\n## Details\n\nbody\n"
 		msg := documentWriteMessage("doc_write", "kb", "x.md", raw)
-		if !strings.HasPrefix(msg, "doc_write kb:x.md\n\n") && msg != "doc_write kb:x.md" {
-			if !strings.Contains(msg, "summary") {
-				t.Fatalf("message = %q", msg)
-			}
-		}
-		if strings.Contains(strings.SplitN(msg, "\n", 2)[0], "—") {
-			t.Fatalf("empty verdict must not decorate the subject: %q", msg)
+		if msg != "doc_write kb:x.md\n\nsummary" {
+			t.Fatalf("message = %q, want undecorated subject with digest body", msg)
 		}
 	})
 }

--- a/internal/state/documents/mutate_policy_message_test.go
+++ b/internal/state/documents/mutate_policy_message_test.go
@@ -1,0 +1,62 @@
+package documents
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestDocumentWriteMessageBorrowsFacets pins the commit-message
+// contract: a faceted document's status_line joins the subject and its
+// digest becomes the body, so the root's git log reads as a timeline
+// of the document's own verdicts; an unfaceted document keeps the
+// plain mechanical subject; and a runaway status_line (possible only
+// through non-publish writes) is clamped rather than allowed to
+// swallow the subject line.
+func TestDocumentWriteMessageBorrowsFacets(t *testing.T) {
+	t.Parallel()
+
+	t.Run("unfaceted document keeps the mechanical subject", func(t *testing.T) {
+		msg := documentWriteMessage("doc_write", "self", "metacognitive.md", "---\ntitle: X\n---\n# State\n\nprose\n")
+		if msg != "doc_write self:metacognitive.md" {
+			t.Fatalf("message = %q", msg)
+		}
+	})
+
+	t.Run("status_line joins the subject, digest becomes the body", func(t *testing.T) {
+		raw := "---\ntitle: X\n---\n## Status Line\n\npanel clean, baselines steady\n\n## Digest\n\nNo open concerns; archivist backlog nominal.\n\n## Details\n\nworking memory\n"
+		msg := documentWriteMessage("doc_write", "self", "metacognitive.md", raw)
+		lines := strings.SplitN(msg, "\n", 3)
+		if lines[0] != "doc_write self:metacognitive.md — panel clean, baselines steady" {
+			t.Fatalf("subject = %q", lines[0])
+		}
+		if !strings.Contains(msg, "\n\nNo open concerns; archivist backlog nominal.") {
+			t.Fatalf("digest missing from body: %q", msg)
+		}
+	})
+
+	t.Run("multi-line status_line flattens, oversize clamps", func(t *testing.T) {
+		long := strings.Repeat("verdict ", 40) // ~320 runes
+		raw := "## Status Line\n\n" + long + "\n\n## Details\n\nbody\n"
+		msg := documentWriteMessage("doc_write", "kb", "x.md", raw)
+		subject := strings.SplitN(msg, "\n", 2)[0]
+		if got := len([]rune(subject)); got > len([]rune("doc_write kb:x.md — "))+facetSubjectMaxRunes {
+			t.Fatalf("subject not clamped: %d runes: %q", got, subject)
+		}
+		if !strings.HasSuffix(subject, "…") {
+			t.Fatalf("clamped subject should mark the clip: %q", subject)
+		}
+	})
+
+	t.Run("empty status_line stays mechanical", func(t *testing.T) {
+		raw := "## Status Line\n\n\n## Digest\n\nsummary\n\n## Details\n\nbody\n"
+		msg := documentWriteMessage("doc_write", "kb", "x.md", raw)
+		if !strings.HasPrefix(msg, "doc_write kb:x.md\n\n") && msg != "doc_write kb:x.md" {
+			if !strings.Contains(msg, "summary") {
+				t.Fatalf("message = %q", msg)
+			}
+		}
+		if strings.Contains(strings.SplitN(msg, "\n", 2)[0], "—") {
+			t.Fatalf("empty verdict must not decorate the subject: %q", msg)
+		}
+	})
+}


### PR DESCRIPTION
## The log learns to say what the write meant

A git-backed document root keeps a perfect history of every maintained document — and its log reads `doc_write self:metacognitive.md` over and over: a timeline of writes with the meaning stripped out. For a faceted document the meaning is sitting in the content itself. The status_line *is* the one-line summary of this revision; the digest *is* its body text.

`documentWriteMessage` borrows them at the write chokepoint. When the content being committed carries facet sections, the status_line joins the commit subject (`doc_write self:metacognitive.md — panel clean, baselines steady`) and the digest becomes the commit body. Unfaceted documents keep the plain mechanical subject, byte-identical to today. No new argument is threaded and no writer cooperates — the facet headings are the contract, so every write of a faceted document gets this whichever tool or author produced it. Once #1365 lands and metacog publishes faceted, `git log --oneline` on the state document becomes a timeline of the system's verdicts; the same falls out free for every future faceted document.

Design notes:

- **The mechanical prefix stays.** Subjects remain greppable by action and ref; the verdict is appended, not substituted, so nothing that reads the log today changes its parsing.
- **One clamp, deliberately unlike the facet budgets.** Published projections are rejected-not-clipped at their budgets, but `doc_write` can put anything under a reserved heading, and a commit subject is annotation rather than content — a runaway borrowed line clips at the status_line budget with an ellipsis instead of swallowing the subject. Multi-line verdicts flatten to one line first.
- **Layering, stated rather than hidden**: this is the documents package's first import of `internal/runtime/loop` (parse-only, no cycle — neither package imported the other before). If a third consumer of the facet-section format appears, the parse helpers likely deserve a home below both packages.

## Test plan

- [x] `TestDocumentWriteMessageBorrowsFacets` — unfaceted unchanged, verdict-in-subject + digest-in-body, multi-line flattening, oversize clamping with visible ellipsis, empty verdict undecorated
- [x] `just ci` green locally

Refs #1351 (the metacog faceting this pairs with, #1365)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

