### PR TITLE
fix(loops): the shipped documents finally load at boot

### DIFF
--- a/internal/app/coreloop_docs_parity_test.go
+++ b/internal/app/coreloop_docs_parity_test.go
@@ -123,3 +123,46 @@ func TestEmbeddedDocumentsMatchTheRepoSources(t *testing.T) {
 		}
 	}
 }
+
+// TestCoreLoopDocumentsLoadWithoutPopulatedPaths is the regression test
+// for the boot-ordering defect found in production 2026-08-12: the
+// definition registry is built before App wiring populates Paths, so a
+// loader reading only Paths["core"] sees an empty string and silently
+// no-ops. The legacy config enabled flags masked this by seeding the
+// embedded defaults; the day the last flag was removed, ego,
+// metacognitive, archivist, and their self container vanished from a
+// healthy-looking boot. The loader must resolve the core root with the
+// same workspace fallback the validate pre-flight uses — this test is
+// tonight's production shape: no Paths, no enabled flags, a real
+// document on disk that must load anyway.
+func TestCoreLoopDocumentsLoadWithoutPopulatedPaths(t *testing.T) {
+	workspace := t.TempDir()
+	loopsDir := filepath.Join(workspace, "core", "loops")
+	if err := os.MkdirAll(loopsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	doc := "# Watch\n\n## Spec\n\n```yaml\nname: doc_defined_watch\nenabled: true\noperation: service\nsleep_min: 5m0s\nsleep_max: 1h0m0s\nsleep_default: 10m0s\n```\n\n## Task\n\nWatch something.\n"
+	if err := os.WriteFile(filepath.Join(loopsDir, "watch.md"), []byte(doc), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.Config{}
+	cfg.Workspace.Path = workspace
+	// Paths deliberately nil and every legacy enabled flag deliberately
+	// false: nothing may seed but the document itself.
+	app := &App{cfg: cfg}
+
+	specs, err := app.buildLoopDefinitionBaseSpecs()
+	if err != nil {
+		t.Fatalf("buildLoopDefinitionBaseSpecs: %v", err)
+	}
+	found := false
+	for _, spec := range specs {
+		if spec.Name == "doc_defined_watch" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("document-defined loop did not load without populated Paths; specs: %d", len(specs))
+	}
+}

--- a/internal/app/loop_definition_hydration.go
+++ b/internal/app/loop_definition_hydration.go
@@ -19,9 +19,33 @@ func (a *App) buildLoopDefinitionBaseSpecs() ([]looppkg.Spec, error) {
 	// fixed by editing the document, never by starting again, so the CLI
 	// exits terminally instead of leaving a supervisor to retry the same
 	// bytes forever.
-	coreDefinitions, err := loadCoreLoopDefinitions(a.cfg.Paths["core"])
+	// The core path resolves with the same fallback the validate
+	// pre-flight uses: Paths["core"] when App wiring has populated it,
+	// the workspace derivation otherwise. The fallback is load-bearing
+	// at boot, not just in pre-flight — the definition registry is
+	// built before the document roots populate Paths, so reading the
+	// map alone means reading an empty string: the loader silently
+	// no-ops, and the shipped documents never take effect. Production
+	// ran that way undetected for as long as the legacy config enabled
+	// flags existed to seed the embedded defaults instead; the day the
+	// last flag was removed, all three reflective loops and their
+	// container vanished from a healthy-looking boot.
+	corePath := strings.TrimSpace(a.cfg.Paths["core"])
+	if corePath == "" {
+		corePath = strings.TrimSpace(a.cfg.CoreRoot())
+	}
+	coreDefinitions, err := loadCoreLoopDefinitions(corePath)
 	if err != nil {
 		return nil, coreAuthoring(fmt.Errorf("core loop definitions: %w", err))
+	}
+	// Count and source are forensics the next silent absence deserves:
+	// a boot that loaded zero core documents should say so where the
+	// registry-initialized event is read.
+	if a.logger != nil {
+		a.logger.Info("core loop definitions loaded",
+			"dir", corePath,
+			"count", len(coreDefinitions),
+		)
 	}
 	baseDefinitions := append(coreDefinitions, a.cfg.Loops.Definitions...)
 	seen := make(map[string]struct{}, len(baseDefinitions))


### PR DESCRIPTION
## The documents never actually loaded

Small and damning in equal measure: `loadCoreLoopDefinitions` has silently no-opped on **every production boot** since the shipped documents became the definitions. It reads `Paths["core"]`, but the definition registry is built before App wiring populates that map — production's boot events show `loop_definition_registry_initialized` at 18:44:54 and the core root's `signed_checkout_enabled` at 18:44:55 — so the loader saw an empty string and returned nil, politely, exactly as designed for installs with no core root.

What masked it: the legacy config `enabled:` flags seeded the three loops from the **embedded** defaults, which track the same repo the documents ship from — so every boot *looked* correct, byte for byte, including operator overrides that happened to match main. Today the last flag (`archivist.enabled`) left production config, and the mask came off: ego, metacognitive, archivist, and their `self` container vanished from a healthy-looking boot (config definitions 15 → 11 across the deploy boundary). Meanwhile `thane validate` on the same host kept reporting all three documents parse — because the pre-flight resolves the core root with a workspace fallback *precisely because* "that map is assembled inside App.New," per its own comment. The bug was documented in the code that didn't have it.

**The fix**: boot resolves the path the way validate always has — `Paths["core"]` when populated, `CoreRoot()` (the workspace derivation) otherwise — and the load is loud where the silence hid: an INFO line records directory and document count beside the registry-initialized event, so a boot that loads zero core documents finally says so. The regression test is tonight's production shape exactly: no `Paths`, no enabled flags, a real document on disk that must load anyway.

**Recovery note**: the interim operator remedy (re-adding `enabled:` stubs to production config to reseed from embedded defaults) is deliberately not taken — this fix restores the documents' authority instead of re-masking its absence. Deploying this release brings all three loops back with their backported content, facets included, and re-arms the archivist's definition-gated queue wiring in the same boot.

## Test plan

- [x] `TestCoreLoopDocumentsLoadWithoutPopulatedPaths` — the production failure shape, now loading
- [x] Existing parity/report/hydration suites unchanged and green
- [x] `just ci` green locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)
