### PR TITLE
docs(loops): a facet budget is a ceiling, not a target

### DIFF
--- a/internal/app/loop_output_publish.go
+++ b/internal/app/loop_output_publish.go
@@ -34,7 +34,7 @@ func buildFacetPublishTool(store *documents.Store, output looppkg.OutputSpec, no
 	for _, field := range fields {
 		description := field.Guidance + looppkg.FormatGuidance(field.Format)
 		if field.MaxRunes > 0 {
-			description = fmt.Sprintf("%s Maximum %d characters.", description, field.MaxRunes)
+			description = fmt.Sprintf("%s Maximum %d characters — a ceiling, not a target; compose comfortably under it.", description, field.MaxRunes)
 		}
 		properties[field.Key] = map[string]any{
 			"type":        "string",

--- a/loops/metacognitive.md
+++ b/loops/metacognitive.md
@@ -195,7 +195,8 @@ content go — purpose-built loops own that now.
    baseline, ego churn climbing". A judgment about the whole system,
    never an inventory of it. Your verdict is injected into interactive
    context every turn, so it is the most-read sentence you write.
-   Write each projection TO its budget, not near it: an over-budget
+   Each budget is a ceiling, not a target — compose comfortably
+   under it, because you cannot count runes precisely: an over-budget
    value is rejected rather than clipped, and the rejection names the
    limit — shorten and republish. This generated output tool is the
    ONLY sanctioned interface for writing your durable state.

--- a/talents/loops-examples.md
+++ b/talents/loops-examples.md
@@ -204,7 +204,9 @@ the section headings; they are rendered for you.
 Each projection has a rune budget — 120 for `status_line`, 500 for
 `teaser`, 2048 for `digest` — and an over-budget value is rejected
 rather than trimmed, because a clipped projection reads as a fragment
-with no sign that anything is missing. Write to the budget, not near it.
+with no sign that anything is missing. The budget is a ceiling, not
+a target — compose comfortably under it; you cannot count runes
+precisely enough to graze a ceiling safely.
 
 Think about what each length is *for* rather than truncating the one
 above it. The status line is a glance: what is true right now. The

--- a/talents/loops.md
+++ b/talents/loops.md
@@ -55,7 +55,10 @@ line describing a state the details have moved past. Do not write the
 section headings; they are rendered for you. Each projection has a size
 budget, and an over-budget value is rejected rather than trimmed,
 because a clipped teaser reads as a fragment with no sign that anything
-is missing. Write to the budget rather than near it. The document body
+is missing. The budget is a ceiling, not a target: compose
+comfortably under it — a projection that needs every last rune is
+carrying too much, and you cannot count runes precisely enough to
+graze a ceiling safely. The document body
 itself has a 96 KiB ceiling on every owner write — the guarantee that
 what you write, you can always read back whole in one call. A rejection
 at the ceiling is not a retry prompt: the document has outgrown


### PR DESCRIPTION
## Taught by production's first faceted publish

Metacog's first publish failed at 123/120 runes, read the teaching error, tightened, and landed on attempt two — the #1250 recovery contract working verbatim in production. No mechanism change needed. But the first failure was partly our own teaching: three prose surfaces said *"write TO the budget, not near it"* — phrasing that meant "leave headroom" and reads as "aim at the number." The generated tool already states "Maximum 120 characters" at composition time, and the model overshot anyway, which is the real lesson: **a model cannot count runes precisely enough to graze a ceiling safely**, so teaching it to aim at the ceiling guarantees occasional scrapes.

All four surfaces now teach ceiling-not-target: the loops doctrine, the worked example, metacog's Record step, and the generated publish tool's per-facet descriptions — the sentence the composing model actually reads at the moment it matters, which now ends *"a ceiling, not a target; compose comfortably under it."*

## Test plan
- [x] Existing output/publish suites green
- [x] `just ci` green locally

Refs #1351

🤖 Generated with [Claude Code](https://claude.com/claude-code)