### PR TITLE
fix(documents): fold hyphen impostors beside the space impostors

### DIFF
--- a/internal/state/documents/activity_test.go
+++ b/internal/state/documents/activity_test.go
@@ -67,26 +67,39 @@ func newActivityStore(t *testing.T, files map[string]string, reviser RootReviser
 	return store
 }
 
-// TestWriteNormalizesHyphenImpostors extends the fold to the second
-// observed family (prod metacognitive.md, 2026-08-12): U+2011
+// TestMutationPathsNormalizeHyphenImpostors extends the fold to the
+// second observed family (prod metacognitive.md, 2026-08-12): U+2011
 // non-breaking hyphens written by one author and churned to plain
-// hyphens by the next — eighteen invisible diff lines in a single
-// revision. U+2010 folds as the visually identical sibling. En and em
+// hyphens by the next â eighteen invisible diff lines in a single
+// revision. U+2010 folds as the visually identical sibling; en and em
 // dashes are visible, intended typography and must survive untouched.
-func TestWriteNormalizesHyphenImpostors(t *testing.T) {
+// Every mutation path is pinned â Write, Edit, and JournalUpdate all
+// normalize â because the space fold's review taught this exact
+// lesson once already: a chokepoint invariant tested on one door is a
+// regression waiting behind the others.
+func TestMutationPathsNormalizeHyphenImpostors(t *testing.T) {
 	store := newActivityStore(t, map[string]string{"state.md": "# state\n"}, nil)
 	ctx := t.Context()
+
+	assertClean := func(step string) {
+		t.Helper()
+		rec, err := store.Read(ctx, "self:state.md")
+		if err != nil {
+			t.Fatalf("%s read: %v", step, err)
+		}
+		if strings.ContainsAny(rec.Body, "‐‑") {
+			t.Errorf("%s: stored body retains hyphen impostors: %q", step, rec.Body)
+		}
+	}
 
 	body := "quality‑floor 3; hvac‐gym — healthy – stable"
 	if _, err := store.Write(ctx, WriteArgs{Ref: "self:state.md", Body: &body}); err != nil {
 		t.Fatalf("write: %v", err)
 	}
+	assertClean("write")
 	rec, err := store.Read(ctx, "self:state.md")
 	if err != nil {
 		t.Fatalf("read: %v", err)
-	}
-	if strings.ContainsAny(rec.Body, "‐‑") {
-		t.Errorf("stored body retains hyphen impostors: %q", rec.Body)
 	}
 	if !strings.Contains(rec.Body, "quality-floor 3; hvac-gym") {
 		t.Errorf("normalized body = %q, want plain hyphens", rec.Body)
@@ -94,6 +107,16 @@ func TestWriteNormalizesHyphenImpostors(t *testing.T) {
 	if !strings.Contains(rec.Body, "— healthy – stable") {
 		t.Errorf("intended en/em dashes were mangled: %q", rec.Body)
 	}
+
+	if _, err := store.Edit(ctx, EditArgs{Ref: "self:state.md", Mode: "append_body", Body: "cross‑check pending"}); err != nil {
+		t.Fatalf("edit: %v", err)
+	}
+	assertClean("edit")
+
+	if _, err := store.JournalUpdate(ctx, JournalUpdateArgs{Ref: "self:state.md", Entry: "re‑verified"}); err != nil {
+		t.Fatalf("journal: %v", err)
+	}
+	assertClean("journal")
 }
 
 // TestWriteNormalizesSpaceArtifacts pins the tokenizer-artifact fold:

--- a/internal/state/documents/activity_test.go
+++ b/internal/state/documents/activity_test.go
@@ -67,6 +67,35 @@ func newActivityStore(t *testing.T, files map[string]string, reviser RootReviser
 	return store
 }
 
+// TestWriteNormalizesHyphenImpostors extends the fold to the second
+// observed family (prod metacognitive.md, 2026-08-12): U+2011
+// non-breaking hyphens written by one author and churned to plain
+// hyphens by the next — eighteen invisible diff lines in a single
+// revision. U+2010 folds as the visually identical sibling. En and em
+// dashes are visible, intended typography and must survive untouched.
+func TestWriteNormalizesHyphenImpostors(t *testing.T) {
+	store := newActivityStore(t, map[string]string{"state.md": "# state\n"}, nil)
+	ctx := t.Context()
+
+	body := "quality‑floor 3; hvac‐gym — healthy – stable"
+	if _, err := store.Write(ctx, WriteArgs{Ref: "self:state.md", Body: &body}); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	rec, err := store.Read(ctx, "self:state.md")
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if strings.ContainsAny(rec.Body, "‐‑") {
+		t.Errorf("stored body retains hyphen impostors: %q", rec.Body)
+	}
+	if !strings.Contains(rec.Body, "quality-floor 3; hvac-gym") {
+		t.Errorf("normalized body = %q, want plain hyphens", rec.Body)
+	}
+	if !strings.Contains(rec.Body, "— healthy – stable") {
+		t.Errorf("intended en/em dashes were mangled: %q", rec.Body)
+	}
+}
+
 // TestWriteNormalizesSpaceArtifacts pins the tokenizer-artifact fold:
 // the non-breaking space variants gpt-oss emits (U+202F, U+00A0) are
 // stored as plain spaces on every mutation path, so alternating

--- a/internal/state/documents/mutate.go
+++ b/internal/state/documents/mutate.go
@@ -126,30 +126,41 @@ func (s *Store) Read(ctx context.Context, ref string) (*DocumentRecord, error) {
 	return record, nil
 }
 
-// normalizeSpaceArtifacts folds the non-breaking space variants some
-// model tokenizers emit (U+00A0, U+202F narrow no-break) into plain
-// spaces before a document write. Observed live 2026-08-11 on prod's
-// metacognitive.md: gpt-oss:120b writes narrow no-break spaces where
-// a frontier model writes plain ones, so alternating authors churned
-// dozens of invisibly-changed diff lines per revision and broke plain
-// text search against the stored body. Deliberately conservative:
+// normalizeGlyphArtifacts folds the invisible-difference impostors
+// some model tokenizers emit into their plain equivalents before a
+// document write. Two families, both observed live on prod's
+// metacognitive.md: the no-break space variants (U+00A0, U+202F
+// narrow no-break — gpt-oss:120b, 2026-08-11) and the hyphen
+// impostors (U+2011 non-breaking hyphen, eighteen of which churned in
+// a single revision when a frontier model replaced them with plain
+// hyphens, 2026-08-12; U+2010 rides along as its visually identical
+// sibling). Alternating authors otherwise churn dozens of
+// invisibly-changed diff lines per revision and break plain-text
+// search against the stored body. Deliberately conservative: en and
+// em dashes are visible, intended typography and are never folded;
 // zero-width characters are left alone (emoji sequences depend on
-// them) — only the two space impostors are folded.
-var spaceArtifactReplacer = strings.NewReplacer("\u00a0", " ", "\u202f", " ")
+// them). Only impostors — characters indistinguishable from their
+// plain form at reading distance — are folded.
+var glyphArtifactReplacer = strings.NewReplacer(
+	"\u00a0", " ", "\u202f", " ",
+	"\u2010", "-", "\u2011", "-",
+)
 
-func normalizeSpaceArtifacts(s string) string {
-	if !strings.ContainsAny(s, "\u00a0\u202f") {
+const glyphArtifactSet = "\u00a0\u202f\u2010\u2011"
+
+func normalizeGlyphArtifacts(s string) string {
+	if !strings.ContainsAny(s, glyphArtifactSet) {
 		return s
 	}
-	return spaceArtifactReplacer.Replace(s)
+	return glyphArtifactReplacer.Replace(s)
 }
 
 func (s *Store) Write(ctx context.Context, args WriteArgs) (*MutationResult, error) {
 	if args.Body != nil {
-		normalized := normalizeSpaceArtifacts(*args.Body)
+		normalized := normalizeGlyphArtifacts(*args.Body)
 		args.Body = &normalized
 	}
-	args.JournalEntry = normalizeSpaceArtifacts(args.JournalEntry)
+	args.JournalEntry = normalizeGlyphArtifacts(args.JournalEntry)
 	root, relPath, err := parseRef(args.Ref)
 	if err != nil {
 		return nil, err
@@ -209,7 +220,7 @@ func (s *Store) Write(ctx context.Context, args WriteArgs) (*MutationResult, err
 }
 
 func (s *Store) Edit(ctx context.Context, args EditArgs) (*MutationResult, error) {
-	args.Body = normalizeSpaceArtifacts(args.Body)
+	args.Body = normalizeGlyphArtifacts(args.Body)
 	root, relPath, err := parseRef(args.Ref)
 	if err != nil {
 		return nil, err
@@ -278,7 +289,7 @@ func (s *Store) Edit(ctx context.Context, args EditArgs) (*MutationResult, error
 }
 
 func (s *Store) JournalUpdate(ctx context.Context, args JournalUpdateArgs) (*MutationResult, error) {
-	args.Entry = normalizeSpaceArtifacts(args.Entry)
+	args.Entry = normalizeGlyphArtifacts(args.Entry)
 	root, relPath, err := parseRef(args.Ref)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## The same disease in a new organ

Last night's space-artifact fold (#1355 arc) was deliberately conservative: two space impostors, nothing else. Tonight metacog's first faceted publish in production churned **eighteen U+2011 non-breaking hyphens** out of `self:metacognitive.md` in a single revision (commit 458b2b83) — one model author writes `quality‑floor`, the next writes `quality-floor`, and the diff bleeds invisible changes while plain-text search for `quality-floor` misses the stored body entirely. Same model-differential behavior, same costs, same chokepoint.

U+2011 joins the fold, with U+2010 (HYPHEN) as its visually identical sibling. The codepoint census of the triggering commit also showed en/em dash movement — those are **deliberately not folded**: they're visible, intended typography (the added lines' em dashes were authored on purpose), and the Godoc now states the classification rule so the next family gets judged consistently: *only impostors — characters indistinguishable from their plain form at reading distance — are folded.*

`TestWriteNormalizesHyphenImpostors` pins both directions in one body: impostors fold, intended dashes survive.

## Test plan
- [x] New hyphen-impostor regression beside the existing space test
- [x] En/em dash preservation asserted in the same body
- [x] `just ci` green locally

Refs #1355

🤖 Generated with [Claude Code](https://claude.com/claude-code)