### PR TITLE
fix(loops): a faceted document's own context carries its authored projections

### DIFF
--- a/internal/app/loop_outputs.go
+++ b/internal/app/loop_outputs.go
@@ -289,9 +289,16 @@ func renderLoopOutputContextWithNow(ctx context.Context, store *documents.Store,
 				// as goes in, so a republish is mechanical.
 				payload := output.ParseFacetDocument(doc.Body)
 				projections := make(map[string]string)
-				for _, field := range output.FacetFields() {
-					if value, ok := payload.FacetByKey(field.Key); ok && strings.TrimSpace(value) != "" {
-						projections[field.Key] = value
+				// Declared facets only — FacetFields() appends the
+				// always-published full field, and full is exactly what
+				// must NOT ride here: it is unbudgeted, and its home is
+				// the byte-capped content below. Duplicating it under
+				// projections would reintroduce the unbounded growth
+				// this split exists to end.
+				for _, facet := range output.Facets {
+					key := string(facet.Name)
+					if value, ok := payload.FacetByKey(key); ok && strings.TrimSpace(value) != "" {
+						projections[key] = value
 					}
 				}
 				if len(projections) > 0 {

--- a/internal/app/loop_outputs.go
+++ b/internal/app/loop_outputs.go
@@ -41,7 +41,14 @@ type loopOutputContextEntry struct {
 	BytesTotal       int      `json:"bytes_total,omitempty"`
 	UnavailableError string   `json:"unavailable_error,omitempty"`
 	Facets           []string `json:"facets,omitempty"`
-	Audience         string   `json:"audience,omitempty"`
+	// Projections carries the published facet values verbatim for a
+	// faceted document — each is budget-capped by contract, so they
+	// ride whole. Content then holds only the full/Details body, which
+	// is where the byte budget belongs: before this split, the entire
+	// rendered document was blindly byte-truncated even though authored
+	// projections existed precisely so no reader has to do that (#1250).
+	Projections map[string]string `json:"projections,omitempty"`
+	Audience    string            `json:"audience,omitempty"`
 }
 
 // hydrateLoopOutputs is the universal "make this spec runtime-ready"
@@ -275,6 +282,26 @@ func renderLoopOutputContextWithNow(ctx context.Context, store *documents.Store,
 		entry.UpdatedDelta = loopOutputUpdatedDelta(doc, now)
 		switch output.Type {
 		case looppkg.OutputTypeMaintainedDocument:
+			if _, faceted := looppkg.ParseFacetSections(doc.Body); faceted && output.HasFacets() {
+				// The loop's own context mirrors its publish tool's
+				// argument shape: each authored projection whole, the
+				// Details body under the byte budget. Same shape out
+				// as goes in, so a republish is mechanical.
+				payload := output.ParseFacetDocument(doc.Body)
+				projections := make(map[string]string)
+				for _, field := range output.FacetFields() {
+					if value, ok := payload.FacetByKey(field.Key); ok && strings.TrimSpace(value) != "" {
+						projections[field.Key] = value
+					}
+				}
+				if len(projections) > 0 {
+					entry.Projections = projections
+				}
+				entry.Content, entry.Truncated, entry.BytesShown, entry.BytesTotal = truncateLoopOutputText(payload.Full, loopOutputContentBytes, false)
+				break
+			}
+			// A pre-facet body (declared facets, first publish pending)
+			// keeps the legacy whole-body path.
 			entry.Content, entry.Truncated, entry.BytesShown, entry.BytesTotal = truncateLoopOutputText(doc.Body, loopOutputContentBytes, false)
 		case looppkg.OutputTypeWorkingNotes:
 			// The head, not the tail: a loop rewriting its current

--- a/internal/app/loop_outputs_test.go
+++ b/internal/app/loop_outputs_test.go
@@ -168,6 +168,66 @@ Everything is calm.
 	}
 }
 
+func TestRenderLoopOutputContextUsesAuthoredProjections(t *testing.T) {
+	t.Parallel()
+
+	store, coreDir := newLoopOutputDocumentStore(t)
+	now := time.Date(2026, 8, 12, 20, 0, 0, 0, time.UTC)
+	facetedSpec := looppkg.OutputSpec{
+		Name:    "metacognitive_state",
+		Type:    looppkg.OutputTypeMaintainedDocument,
+		Ref:     "core:metacognitive.md",
+		Purpose: "Current metacognitive state.",
+		Facets: []looppkg.FacetSpec{
+			{Name: looppkg.OutputFacetStatusLine},
+			{Name: looppkg.OutputFacetDigest},
+		},
+	}
+
+	raw := "## Status Line\n\npanel clean, baselines steady\n\n## Digest\n\nNo open concerns.\n\n## Details\n\nthe working memory body\n"
+	if err := os.WriteFile(filepath.Join(coreDir, "metacognitive.md"), []byte(raw), 0o644); err != nil {
+		t.Fatalf("write metacognitive.md: %v", err)
+	}
+
+	ctx, err := renderLoopOutputContextWithNow(context.Background(), store, []looppkg.OutputSpec{facetedSpec}, now)
+	if err != nil {
+		t.Fatalf("renderLoopOutputContextWithNow: %v", err)
+	}
+	// The authored projections ride whole under their own key, and the
+	// content field carries only the Details body — never a blind byte
+	// slice of the rendered document (#1250).
+	if !strings.Contains(ctx, `"projections"`) {
+		t.Fatalf("faceted output context missing projections:\n%s", ctx)
+	}
+	if !strings.Contains(ctx, "panel clean, baselines steady") || !strings.Contains(ctx, "No open concerns.") {
+		t.Fatalf("projections missing authored values:\n%s", ctx)
+	}
+	if !strings.Contains(ctx, "the working memory body") {
+		t.Fatalf("content missing the Details body:\n%s", ctx)
+	}
+	if strings.Contains(ctx, `## Status Line`) {
+		t.Fatalf("content should not carry the rendered section structure:\n%s", ctx)
+	}
+
+	// A pre-facet body under a faceted spec — declared facets, first
+	// publish pending — keeps the legacy whole-body path so the loop
+	// still sees the document it must carry into that first publish.
+	preFacet := "# State\n\nbaselines and concerns, pre-facet shape\n"
+	if err := os.WriteFile(filepath.Join(coreDir, "metacognitive.md"), []byte(preFacet), 0o644); err != nil {
+		t.Fatalf("rewrite metacognitive.md: %v", err)
+	}
+	ctx, err = renderLoopOutputContextWithNow(context.Background(), store, []looppkg.OutputSpec{facetedSpec}, now)
+	if err != nil {
+		t.Fatalf("renderLoopOutputContextWithNow (pre-facet): %v", err)
+	}
+	if strings.Contains(ctx, `"projections"`) {
+		t.Fatalf("pre-facet document must not invent projections:\n%s", ctx)
+	}
+	if !strings.Contains(ctx, "baselines and concerns, pre-facet shape") {
+		t.Fatalf("pre-facet content missing body:\n%s", ctx)
+	}
+}
+
 func TestHydrateLoopOutputsRequiresDocumentStore(t *testing.T) {
 	t.Parallel()
 

--- a/internal/app/loop_outputs_test.go
+++ b/internal/app/loop_outputs_test.go
@@ -208,6 +208,12 @@ func TestRenderLoopOutputContextUsesAuthoredProjections(t *testing.T) {
 	if strings.Contains(ctx, `## Status Line`) {
 		t.Fatalf("content should not carry the rendered section structure:\n%s", ctx)
 	}
+	// full is unbudgeted and lives only in content; a "full" key under
+	// projections would smuggle the whole Details body past the byte
+	// budget (the regression review caught in the first draft).
+	if strings.Contains(ctx, `"full":`) {
+		t.Fatalf("projections must not carry the full body:\n%s", ctx)
+	}
 
 	// A pre-facet body under a faceted spec — declared facets, first
 	// publish pending — keeps the legacy whole-body path so the loop


### PR DESCRIPTION
## The one guaranteed reader was still slicing bytes

#1250's re-grounded scope names this as the phase-3 item that turned from aspiration into liability: `renderLoopOutputContextWithNow` byte-truncated the whole rendered document into the owning loop's context. Before facets that was tolerable; after, an authored `status_line` and `digest` exist precisely so no reader has to slice bytes — and the one reader guaranteed to look every wake was still getting a blind 16KB slice of section headings and all.

A faceted document's context entry now mirrors its publish tool's argument shape: each authored projection rides whole under a `projections` map (budget-capped by contract, so always small), and `content` carries only the full/Details body — where the byte budget and `truncated` flags belong. Same shape out as goes in, so a republish is mechanical: the loop reads the exact fields it must write.

A pre-facet body under a faceted spec (declared facets, first publish pending — exactly the transition prod's metacog performed tonight) keeps the legacy whole-body path, so nothing regresses mid-migration.

Remaining for #1250 after this: the search pair (teaser as snippet + facets advertised per hit) and the LoopView/`/v1` content-negotiation surface.

## Test plan
- [x] `TestRenderLoopOutputContextUsesAuthoredProjections` — projections whole, content is Details-only, no section structure in content, pre-facet fallback intact
- [x] Existing freshness/hydration suites green
- [x] `just ci` green locally

Refs #1250

🤖 Generated with [Claude Code](https://claude.com/claude-code)