### PR TITLE
feat(documents): search speaks in authored teasers and advertises facets

### DIFF
--- a/internal/state/documents/intake_similarity.go
+++ b/internal/state/documents/intake_similarity.go
@@ -11,7 +11,7 @@ import (
 
 func (s *Store) relatedIntakeDocuments(ctx context.Context, root string, args IntakeArgs, title string, tags []string) ([]IntakeRelatedDocument, error) {
 	rows, err := s.db.QueryContext(ctx,
-		`SELECT root, rel_path, title, summary, tags_json, frontmatter_json, modified_at, word_count
+		`SELECT root, rel_path, title, summary, facets_json, tags_json, frontmatter_json, modified_at, word_count
 		 FROM indexed_documents
 		 WHERE root = ?
 		 ORDER BY modified_at DESC, rel_path

--- a/internal/state/documents/parser.go
+++ b/internal/state/documents/parser.go
@@ -7,6 +7,8 @@ import (
 	"strconv"
 	"strings"
 	"unicode"
+
+	looppkg "github.com/nugget/thane-ai-agent/internal/runtime/loop"
 )
 
 var (
@@ -19,6 +21,7 @@ var (
 type parsedDocument struct {
 	Title       string
 	Summary     string
+	Facets      []string
 	WordCount   int
 	Tags        []string
 	Frontmatter map[string][]string
@@ -58,9 +61,41 @@ func parseMarkdownDocumentParts(name string, meta map[string][]string, body stri
 		title = base
 	}
 
+	// A faceted body carries its own authored snippet: the teaser is
+	// written for exactly this surface, the status_line is the authored
+	// fallback when no teaser is declared, and only an unfaceted body
+	// falls back to the derived first paragraph. The present facets ride
+	// along so a search hit can advertise which projections doc_read can
+	// pull (#1250).
+	summary := ""
+	var facets []string
+	if payload, faceted := looppkg.ParseFacetSections(body); faceted {
+		for _, key := range looppkg.FacetKeys() {
+			// full is every document's baseline and advertises nothing;
+			// the facet list exists to say which condensed projections
+			// doc_read can pull.
+			if key == "full" {
+				continue
+			}
+			if value, ok := payload.FacetByKey(key); ok && strings.TrimSpace(value) != "" {
+				facets = append(facets, key)
+			}
+		}
+		if teaser, ok := payload.FacetByKey(string(looppkg.OutputFacetTeaser)); ok && strings.TrimSpace(teaser) != "" {
+			summary = strings.TrimSpace(teaser)
+		} else if verdict, ok := payload.FacetByKey(string(looppkg.OutputFacetStatusLine)); ok && strings.TrimSpace(verdict) != "" {
+			summary = strings.TrimSpace(verdict)
+		} else {
+			summary = firstParagraph(payload.Full)
+		}
+	} else {
+		summary = firstParagraph(body)
+	}
+
 	return parsedDocument{
 		Title:       title,
-		Summary:     firstParagraph(body),
+		Summary:     summary,
+		Facets:      facets,
 		WordCount:   len(strings.Fields(body)),
 		Tags:        append([]string(nil), meta["tags"]...),
 		Frontmatter: meta,

--- a/internal/state/documents/query.go
+++ b/internal/state/documents/query.go
@@ -68,7 +68,7 @@ func (s *Store) Browse(ctx context.Context, root, prefix string, limit int) (*Br
 	}
 	prefix = trimPathPrefix(prefix)
 	args := []any{root}
-	query := `SELECT root, rel_path, title, summary, tags_json, frontmatter_json, modified_at, word_count
+	query := `SELECT root, rel_path, title, summary, facets_json, tags_json, frontmatter_json, modified_at, word_count
 		 FROM indexed_documents
 		 WHERE root = ?`
 	if prefix != "" {
@@ -162,7 +162,7 @@ func (s *Store) Search(ctx context.Context, q SearchQuery) ([]DocumentSummary, e
 
 	var args []any
 	var where []string
-	query := `SELECT root, rel_path, title, summary, tags_json, frontmatter_json, modified_at, word_count FROM indexed_documents`
+	query := `SELECT root, rel_path, title, summary, facets_json, tags_json, frontmatter_json, modified_at, word_count FROM indexed_documents`
 	if q.Root != "" {
 		if !rootExists(s.roots, q.Root) {
 			return nil, fmt.Errorf("unknown document root %q", q.Root)

--- a/internal/state/documents/query_facets_test.go
+++ b/internal/state/documents/query_facets_test.go
@@ -1,0 +1,70 @@
+package documents
+
+import (
+	"context"
+	"testing"
+)
+
+// TestSearchUsesAuthoredFacetsForSnippetAndAdvertisesThem pins the
+// #1250 read surface: a faceted document's search summary is its
+// authored teaser — or its status_line when no teaser is declared —
+// never a derived excerpt of the rendered sections, and the hit lists
+// the facets present so the next step is one deliberate doc_read with
+// level. An unfaceted document keeps the derived first paragraph and
+// advertises nothing.
+func TestSearchUsesAuthoredFacetsForSnippetAndAdvertisesThem(t *testing.T) {
+	store, _ := newMutationStore(t)
+	ctx := context.Background()
+
+	teasered := "## Status Line\n\nverdict line here\n\n## Teaser\n\nThe authored orangutan teaser, written for search snippets.\n\n## Details\n\nlong working memory body\n"
+	if _, err := store.Write(ctx, WriteArgs{Ref: "kb:zoo/teasered.md", Title: "Teasered", Body: stringPtr(teasered)}); err != nil {
+		t.Fatalf("write teasered: %v", err)
+	}
+	verdictOnly := "## Status Line\n\norangutan verdict, no teaser declared\n\n## Details\n\nbody\n"
+	if _, err := store.Write(ctx, WriteArgs{Ref: "kb:zoo/verdict.md", Title: "VerdictOnly", Body: stringPtr(verdictOnly)}); err != nil {
+		t.Fatalf("write verdict: %v", err)
+	}
+	plain := "# Plain\n\nA plain orangutan document with a first paragraph.\n"
+	if _, err := store.Write(ctx, WriteArgs{Ref: "kb:zoo/plain.md", Title: "Plain", Body: stringPtr(plain)}); err != nil {
+		t.Fatalf("write plain: %v", err)
+	}
+
+	results, err := store.Search(ctx, SearchQuery{Query: "orangutan"})
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	byRef := make(map[string]DocumentSummary, len(results))
+	for _, doc := range results {
+		byRef[doc.Ref] = doc
+	}
+
+	teaseredHit, ok := byRef["kb:zoo/teasered.md"]
+	if !ok {
+		t.Fatalf("teasered document missing from results: %v", byRef)
+	}
+	if teaseredHit.Summary != "The authored orangutan teaser, written for search snippets." {
+		t.Errorf("teasered summary = %q, want the authored teaser", teaseredHit.Summary)
+	}
+	if len(teaseredHit.Facets) != 2 || teaseredHit.Facets[0] != "status_line" || teaseredHit.Facets[1] != "teaser" {
+		t.Errorf("teasered facets = %v, want [status_line teaser]", teaseredHit.Facets)
+	}
+
+	verdictHit, ok := byRef["kb:zoo/verdict.md"]
+	if !ok {
+		t.Fatalf("verdict document missing from results: %v", byRef)
+	}
+	if verdictHit.Summary != "orangutan verdict, no teaser declared" {
+		t.Errorf("verdict summary = %q, want the status_line fallback", verdictHit.Summary)
+	}
+
+	plainHit, ok := byRef["kb:zoo/plain.md"]
+	if !ok {
+		t.Fatalf("plain document missing from results: %v", byRef)
+	}
+	if plainHit.Summary != "A plain orangutan document with a first paragraph." {
+		t.Errorf("plain summary = %q, want the derived first paragraph", plainHit.Summary)
+	}
+	if plainHit.Facets != nil {
+		t.Errorf("plain document advertises facets: %v", plainHit.Facets)
+	}
+}

--- a/internal/state/documents/refs.go
+++ b/internal/state/documents/refs.go
@@ -36,8 +36,12 @@ func makeRef(root, relPath string) string {
 func scanDocument(rows *sql.Rows, doc *DocumentSummary) error {
 	var tagsJSON string
 	var metaJSON string
-	if err := rows.Scan(&doc.Root, &doc.Path, &doc.Title, &doc.Summary, &tagsJSON, &metaJSON, &doc.ModifiedAt, &doc.WordCount); err != nil {
+	var facetsJSON string
+	if err := rows.Scan(&doc.Root, &doc.Path, &doc.Title, &doc.Summary, &facetsJSON, &tagsJSON, &metaJSON, &doc.ModifiedAt, &doc.WordCount); err != nil {
 		return err
+	}
+	if err := json.Unmarshal([]byte(facetsJSON), &doc.Facets); err != nil || len(doc.Facets) == 0 {
+		doc.Facets = nil
 	}
 	doc.Ref = makeRef(doc.Root, doc.Path)
 	if err := json.Unmarshal([]byte(tagsJSON), &doc.Tags); err != nil {

--- a/internal/state/documents/store.go
+++ b/internal/state/documents/store.go
@@ -40,11 +40,15 @@ type RootDocumentHint struct {
 
 // DocumentSummary is the compact search/browse view of a document.
 type DocumentSummary struct {
-	Root        string              `json:"root"`
-	Ref         string              `json:"ref"`
-	Path        string              `json:"path"`
-	Title       string              `json:"title"`
-	Summary     string              `json:"summary,omitempty"`
+	Root    string `json:"root"`
+	Ref     string `json:"ref"`
+	Path    string `json:"path"`
+	Title   string `json:"title"`
+	Summary string `json:"summary,omitempty"`
+	// Facets lists the projections present in the document body
+	// (status_line, teaser, digest), advertised on search hits so the
+	// next step — doc_read with level — is one deliberate call (#1250).
+	Facets      []string            `json:"facets,omitempty"`
 	Tags        []string            `json:"tags,omitempty"`
 	Frontmatter map[string][]string `json:"frontmatter,omitempty"`
 	ModifiedAt  string              `json:"modified_at"`
@@ -145,6 +149,7 @@ func (s *Store) migrate() error {
 		abs_path TEXT NOT NULL,
 		title TEXT NOT NULL DEFAULT '',
 		summary TEXT NOT NULL DEFAULT '',
+		facets_json TEXT NOT NULL DEFAULT '[]',
 		tags_json TEXT NOT NULL DEFAULT '[]',
 		frontmatter_json TEXT NOT NULL DEFAULT '{}',
 		links_json TEXT NOT NULL DEFAULT '[]',
@@ -169,8 +174,26 @@ func (s *Store) migrate() error {
 	);
 	CREATE INDEX IF NOT EXISTS idx_indexed_document_sections_doc ON indexed_document_sections(root, rel_path, ordinal);
 	`
-	_, err := s.db.Exec(schema)
-	return err
+	if _, err := s.db.Exec(schema); err != nil {
+		return err
+	}
+	// Upgrade path for indexes created before facets_json existed. The
+	// index is derived state, so the one-time purge after adding the
+	// column is the reindex trigger: Refresh repopulates every row with
+	// its facets on the next pass, rather than leaving pre-upgrade rows
+	// advertising nothing until their documents happen to change.
+	if _, err := s.db.Exec(`SELECT facets_json FROM indexed_documents LIMIT 1`); err != nil {
+		if _, err := s.db.Exec(`ALTER TABLE indexed_documents ADD COLUMN facets_json TEXT NOT NULL DEFAULT '[]'`); err != nil {
+			return fmt.Errorf("add facets_json column: %w", err)
+		}
+		if _, err := s.db.Exec(`DELETE FROM indexed_documents`); err != nil {
+			return fmt.Errorf("purge index for facets reindex: %w", err)
+		}
+		if _, err := s.db.Exec(`DELETE FROM indexed_document_sections`); err != nil {
+			return fmt.Errorf("purge section index for facets reindex: %w", err)
+		}
+	}
+	return nil
 }
 
 // Refresh incrementally refreshes all indexed roots.
@@ -345,6 +368,13 @@ func (s *Store) upsertFile(ctx context.Context, root, relPath string) error {
 	if err != nil {
 		return fmt.Errorf("marshal tags: %w", err)
 	}
+	if doc.Facets == nil {
+		doc.Facets = []string{}
+	}
+	facetsJSON, err := json.Marshal(doc.Facets)
+	if err != nil {
+		return fmt.Errorf("marshal facets: %w", err)
+	}
 	metaJSON, err := json.Marshal(doc.Frontmatter)
 	if err != nil {
 		return fmt.Errorf("marshal frontmatter: %w", err)
@@ -364,19 +394,20 @@ func (s *Store) upsertFile(ctx context.Context, root, relPath string) error {
 
 	if _, err := tx.ExecContext(ctx,
 		`INSERT INTO indexed_documents
-			(root, rel_path, abs_path, title, summary, tags_json, frontmatter_json, links_json, modified_at, size_bytes, word_count)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+			(root, rel_path, abs_path, title, summary, facets_json, tags_json, frontmatter_json, links_json, modified_at, size_bytes, word_count)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		 ON CONFLICT(root, rel_path) DO UPDATE SET
 		 	abs_path = excluded.abs_path,
 		 	title = excluded.title,
 		 	summary = excluded.summary,
+		 	facets_json = excluded.facets_json,
 		 	tags_json = excluded.tags_json,
 		 	frontmatter_json = excluded.frontmatter_json,
 		 	links_json = excluded.links_json,
 		 	modified_at = excluded.modified_at,
 		 	size_bytes = excluded.size_bytes,
 		 	word_count = excluded.word_count`,
-		root, relPath, absPath, doc.Title, doc.Summary, string(tagsJSON), string(metaJSON), string(linksJSON), modified, size, doc.WordCount,
+		root, relPath, absPath, doc.Title, doc.Summary, string(facetsJSON), string(tagsJSON), string(metaJSON), string(linksJSON), modified, size, doc.WordCount,
 	); err != nil {
 		return fmt.Errorf("upsert indexed document: %w", err)
 	}

--- a/internal/state/documents/store.go
+++ b/internal/state/documents/store.go
@@ -183,14 +183,29 @@ func (s *Store) migrate() error {
 	// its facets on the next pass, rather than leaving pre-upgrade rows
 	// advertising nothing until their documents happen to change.
 	if _, err := s.db.Exec(`SELECT facets_json FROM indexed_documents LIMIT 1`); err != nil {
-		if _, err := s.db.Exec(`ALTER TABLE indexed_documents ADD COLUMN facets_json TEXT NOT NULL DEFAULT '[]'`); err != nil {
+		// One transaction, deliberately: the probe above only fails
+		// while the column is absent, so a partial upgrade — column
+		// added, purge half done — would pass the probe on the next
+		// boot and never heal. Atomic means the upgrade either fully
+		// happened or fully retries.
+		tx, err := s.db.Begin()
+		if err != nil {
+			return fmt.Errorf("begin facets upgrade: %w", err)
+		}
+		defer func() {
+			_ = tx.Rollback()
+		}()
+		if _, err := tx.Exec(`ALTER TABLE indexed_documents ADD COLUMN facets_json TEXT NOT NULL DEFAULT '[]'`); err != nil {
 			return fmt.Errorf("add facets_json column: %w", err)
 		}
-		if _, err := s.db.Exec(`DELETE FROM indexed_documents`); err != nil {
+		if _, err := tx.Exec(`DELETE FROM indexed_documents`); err != nil {
 			return fmt.Errorf("purge index for facets reindex: %w", err)
 		}
-		if _, err := s.db.Exec(`DELETE FROM indexed_document_sections`); err != nil {
+		if _, err := tx.Exec(`DELETE FROM indexed_document_sections`); err != nil {
 			return fmt.Errorf("purge section index for facets reindex: %w", err)
+		}
+		if err := tx.Commit(); err != nil {
+			return fmt.Errorf("commit facets upgrade: %w", err)
 		}
 	}
 	return nil

--- a/internal/tools/document_tools.go
+++ b/internal/tools/document_tools.go
@@ -183,7 +183,7 @@ func RegisterDocumentTools(r *Registry, dt *documents.Tools) {
 
 	r.Register(&Tool{
 		Name:        "doc_search",
-		Description: "Search indexed markdown documents by root, path prefix, query text, tags, frontmatter filters, and modified-time bounds. Returns compact document summaries with canonical refs like `kb:article.md` and modified-time delta fields like `-3600s`, not full bodies. Documents whose frontmatter declares `audience: internal` (private working surfaces such as loop working notes) are excluded by default; set include_internal true, or filter on the audience key explicitly, to see them.",
+		Description: "Search indexed markdown documents by root, path prefix, query text, tags, frontmatter filters, and modified-time bounds. Returns compact document summaries with canonical refs like `kb:article.md` and modified-time delta fields like `-3600s`, not full bodies. A faceted document’s summary is its authored teaser (or status_line when no teaser is declared) rather than a derived excerpt, and the hit lists its available facets so the next step is one deliberate doc_read with level. Documents whose frontmatter declares `audience: internal` (private working surfaces such as loop working notes) are excluded by default; set include_internal true, or filter on the audience key explicitly, to see them.",
 		Parameters: map[string]any{
 			"type": "object",
 			"properties": map[string]any{


### PR DESCRIPTION
## The snippet the author already wrote

`doc_search`'s summary was a derived first paragraph — which for a faceted document meant an accidental excerpt of whatever section rendered first, while an authored teaser written for exactly this surface sat unused in the same body. This is #1250's read-surface pair:

- **Teaser as the snippet.** A faceted document's search summary is its authored teaser; the status_line stands in when no teaser is declared (metacog's deliberate shape); only unfaceted documents keep the derived first paragraph.
- **Facets advertised per hit.** Each result lists the projections present in the body — `full` excluded, since it's every document's baseline and advertises nothing — so the next step after a search is one deliberate `doc_read` with `level` instead of a blind full fetch.

Mechanics: facets ride the index as a `facets_json` column. The index is derived state, so the schema upgrade is an idempotent column-add plus a one-time row purge — the next refresh re-parses every document with its facets, rather than leaving pre-upgrade rows advertising nothing until their documents happen to change. `doc_search`'s description teaches the new contract at decision time.

One test-driven catch worth noting: the first draft's advertised-facets list included `full` via `FacetKeys()` — the same smuggling trap review caught on #1370's projections map — except this time my own test's exact-match assertion caught it before review did. Lesson compounding.

Remaining for #1250 after this: the LoopView/`/v1` content-negotiation surface.

## Test plan
- [x] `TestSearchUsesAuthoredFacetsForSnippetAndAdvertisesThem` — teaser snippet, status_line fallback, derived-paragraph fallback, facets advertised without `full`
- [x] Full documents suite green (index schema upgrade included)
- [x] `just ci` green locally

Refs #1250

🤖 Generated with [Claude Code](https://claude.com/claude-code)