### PR TITLE
feat(loops): outputs on the canonical row, fidelity negotiation at /v1

### DIFF
--- a/internal/app/new_servers.go
+++ b/internal/app/new_servers.go
@@ -53,6 +53,9 @@ func (a *App) initServers(s *newState) error {
 	server.SetArchiveStore(a.archiveStore)
 	server.UseContactStore(a.contactStore)
 	server.UseLoopDefinitionRegistry(a.loopDefinitionRegistry)
+	if a.documentStore != nil {
+		server.UseDocumentReader(a.documentStore.Read)
+	}
 	server.ConfigureLoopDefinitionView(a.loopDefinitionView)
 	server.ConfigureLoopDefinitionPersistence(a.commitLoopDefinition, a.deletePersistedLoopDefinition)
 	server.ConfigureLoopDefinitionLifecycle(

--- a/internal/runtime/loop/loop_view.go
+++ b/internal/runtime/loop/loop_view.go
@@ -65,6 +65,14 @@ type LoopView struct {
 	NextWakeDelta        *string `json:"next_wake_delta"`
 	CurrentSleepDuration *string `json:"current_sleep_duration"`
 	PolicyUpdatedDelta   *string `json:"policy_updated_delta"`
+	// Outputs are the durable documents this loop declares, projected
+	// from the same spec on a stored definition and a live loop: name,
+	// document ref, the generated write tool, and the facets the
+	// contract declares — enough for a consumer to know what the loop
+	// publishes and which projection levels doc_read can pull, without
+	// fetching the definition (#1250). Configuration, not telemetry.
+	Outputs []LoopViewOutput `json:"outputs,omitempty"`
+
 	// SleepEnvelope is the cadence this loop is allowed to choose within.
 	// It is configuration rather than telemetry, so it is present on a
 	// stored definition as well as a live loop; null on anything with no
@@ -258,6 +266,42 @@ func (r LoopViewResolver) WithMailboxPending(byName map[string]int) LoopViewReso
 	return r
 }
 
+// LoopViewOutput is one declared durable output on a LoopView row: the
+// projection of an OutputSpec that consumers of the canonical loop row
+// need — identity, where it lands, how it is written, and which facet
+// levels are declared — without the write-side detail (mode, purpose
+// prose) the definition itself carries.
+type LoopViewOutput struct {
+	Name     string   `json:"name"`
+	Type     string   `json:"type"`
+	Ref      string   `json:"ref"`
+	ToolName string   `json:"tool_name,omitempty"`
+	Facets   []string `json:"facets,omitempty"`
+	Audience string   `json:"audience,omitempty"`
+}
+
+// loopViewOutputs projects a spec's declared outputs into view rows.
+func loopViewOutputs(outputs []OutputSpec) []LoopViewOutput {
+	if len(outputs) == 0 {
+		return nil
+	}
+	views := make([]LoopViewOutput, 0, len(outputs))
+	for _, output := range outputs {
+		view := LoopViewOutput{
+			Name:     output.Name,
+			Type:     string(output.Type),
+			Ref:      output.Ref,
+			ToolName: output.ToolName(),
+			Audience: string(output.EffectiveAudience()),
+		}
+		for _, facet := range output.Facets {
+			view.Facets = append(view.Facets, string(facet.Name))
+		}
+		views = append(views, view)
+	}
+	return views
+}
+
 // NewLoopViewResolver builds the id/name/parent/child indexes once from the
 // full status batch (so parent_name and child_count stay accurate even when
 // the displayed rows are filtered) and captures a single clock for all
@@ -326,6 +370,7 @@ func (r LoopViewResolver) FromStatus(s Status) LoopView {
 		Ancestry:   r.ancestry(s.ID),
 		ChildCount: r.childCount[s.ID],
 		Supervisor: s.Config.Supervisor,
+		Outputs:    loopViewOutputs(s.Config.Outputs),
 		// EventDriven is set from the live Status in applyLiveTelemetry.
 	}
 	if pn := r.nameByID[s.ParentID]; pn != "" {
@@ -571,6 +616,7 @@ func (r DefinitionViewResolver) FromDefinition(snap DefinitionSnapshot, eligibil
 		ChildCount:  r.childCount[snap.Name],
 		EventDriven: op == OperationEventDriven,
 		Supervisor:  spec.Supervisor,
+		Outputs:     loopViewOutputs(spec.Outputs),
 
 		PolicyState:  string(snap.PolicyState),
 		PolicySource: string(snap.PolicySource),

--- a/internal/server/api/loop_outputs.go
+++ b/internal/server/api/loop_outputs.go
@@ -82,18 +82,32 @@ func (s *Server) handleLoopOutputGet(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	payload, faceted := looppkg.ParseFacetSections(record.Body)
+	// The declared contract gates every representation: this endpoint
+	// is addressed by an output name on a definition, so what it serves
+	// is what that definition declares. A hand-edited body that happens
+	// to contain a reserved heading is content, not contract — parsed
+	// sections count only when the spec declared facets.
+	payload, sectioned := looppkg.ParseFacetSections(record.Body)
+	faceted := sectioned && output.HasFacets()
+	declared := make(map[string]bool, len(output.Facets))
+	for _, facet := range output.Facets {
+		declared[string(facet.Name)] = true
+	}
+
+	// Negotiated response: the representation depends on Accept, so
+	// caches must key on it.
+	w.Header().Set("Vary", "Accept")
 	accept := strings.ToLower(r.Header.Get("Accept"))
 	switch {
 	case strings.Contains(accept, "text/plain"):
 		verdict := ""
-		if faceted {
+		if faceted && declared[string(looppkg.OutputFacetStatusLine)] {
 			if line, ok := payload.FacetByKey(string(looppkg.OutputFacetStatusLine)); ok {
 				verdict = strings.TrimSpace(line)
 			}
 		}
 		if verdict == "" {
-			s.errorResponse(w, http.StatusNotAcceptable, "output "+outputName+" has published no status_line; available representations: application/json, text/markdown")
+			s.errorResponse(w, http.StatusNotAcceptable, "output "+outputName+" declares or has published no status_line; available representations: application/json, text/markdown")
 			return
 		}
 		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
@@ -109,10 +123,7 @@ func (s *Server) handleLoopOutputGet(w http.ResponseWriter, r *http.Request) {
 		if faceted {
 			out.Full = payload.Full
 			facets := make(map[string]string)
-			for _, key := range looppkg.FacetKeys() {
-				if key == "full" {
-					continue
-				}
+			for key := range declared {
 				if value, ok := payload.FacetByKey(key); ok && strings.TrimSpace(value) != "" {
 					facets[key] = value
 				}

--- a/internal/server/api/loop_outputs.go
+++ b/internal/server/api/loop_outputs.go
@@ -1,0 +1,130 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"strings"
+
+	looppkg "github.com/nugget/thane-ai-agent/internal/runtime/loop"
+	"github.com/nugget/thane-ai-agent/internal/state/documents"
+)
+
+// DocumentReader is the narrow document dependency the loop-output
+// endpoint needs: read one managed document by ref. A function rather
+// than the store so the API server stays decoupled from the documents
+// package's write surface and tests can stub a document in one line.
+type DocumentReader func(ctx context.Context, ref string) (*documents.DocumentRecord, error)
+
+// UseDocumentReader wires the managed-document read function that
+// backs GET /v1/loops/{name}/outputs/{output}.
+func (s *Server) UseDocumentReader(read DocumentReader) {
+	s.documentRead = read
+}
+
+// loopOutputJSON is the typed representation of one loop output: the
+// contract's fields as fields, never section markup. Facet keys absent
+// from the document are omitted rather than sent empty.
+type loopOutputJSON struct {
+	Loop       string            `json:"loop"`
+	Output     string            `json:"output"`
+	Ref        string            `json:"ref"`
+	ModifiedAt string            `json:"modified_at,omitempty"`
+	Facets     map[string]string `json:"facets,omitempty"`
+	Full       string            `json:"full"`
+}
+
+// handleLoopOutputGet serves one declared loop output at the fidelity
+// the caller's Accept header asks for — the #1250 read surface at the
+// HTTP boundary. text/plain returns the status_line alone (speakable,
+// no markup); application/json returns the typed contract;
+// text/markdown (and any other Accept, including none) returns the
+// document body. A plain-text request against a document that has
+// published no status_line is 406 with the available representations
+// named, because inventing a one-liner would misrepresent the loop.
+func (s *Server) handleLoopOutputGet(w http.ResponseWriter, r *http.Request) {
+	if s.loopDefinitionRegistry == nil {
+		s.errorResponse(w, http.StatusServiceUnavailable, "loop definition registry not configured")
+		return
+	}
+	if s.documentRead == nil {
+		s.errorResponse(w, http.StatusServiceUnavailable, "document reader not configured")
+		return
+	}
+	name := strings.TrimSpace(r.PathValue("name"))
+	outputName := strings.TrimSpace(r.PathValue("output"))
+	if name == "" || outputName == "" {
+		s.errorResponse(w, http.StatusBadRequest, "loop name and output name are required")
+		return
+	}
+	spec, ok := s.loopDefinitionRegistry.Get(name)
+	if !ok {
+		s.errorResponse(w, http.StatusNotFound, (&looppkg.UnknownDefinitionError{Name: name}).Error())
+		return
+	}
+	var output *looppkg.OutputSpec
+	for i := range spec.Outputs {
+		if spec.Outputs[i].Name == outputName {
+			output = &spec.Outputs[i]
+			break
+		}
+	}
+	if output == nil {
+		s.errorResponse(w, http.StatusNotFound, "loop "+name+" declares no output named "+outputName)
+		return
+	}
+	record, err := s.documentRead(r.Context(), output.Ref)
+	if err != nil {
+		if documents.IsNotFound(err) {
+			s.errorResponse(w, http.StatusNotFound, "output document "+output.Ref+" has not been written yet")
+			return
+		}
+		s.errorResponse(w, http.StatusInternalServerError, "read output document: "+err.Error())
+		return
+	}
+
+	payload, faceted := looppkg.ParseFacetSections(record.Body)
+	accept := strings.ToLower(r.Header.Get("Accept"))
+	switch {
+	case strings.Contains(accept, "text/plain"):
+		verdict := ""
+		if faceted {
+			if line, ok := payload.FacetByKey(string(looppkg.OutputFacetStatusLine)); ok {
+				verdict = strings.TrimSpace(line)
+			}
+		}
+		if verdict == "" {
+			s.errorResponse(w, http.StatusNotAcceptable, "output "+outputName+" has published no status_line; available representations: application/json, text/markdown")
+			return
+		}
+		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+		_, _ = w.Write([]byte(verdict + "\n"))
+	case strings.Contains(accept, "application/json"):
+		out := loopOutputJSON{
+			Loop:       name,
+			Output:     outputName,
+			Ref:        output.Ref,
+			ModifiedAt: record.ModifiedAt,
+			Full:       record.Body,
+		}
+		if faceted {
+			out.Full = payload.Full
+			facets := make(map[string]string)
+			for _, key := range looppkg.FacetKeys() {
+				if key == "full" {
+					continue
+				}
+				if value, ok := payload.FacetByKey(key); ok && strings.TrimSpace(value) != "" {
+					facets[key] = value
+				}
+			}
+			if len(facets) > 0 {
+				out.Facets = facets
+			}
+		}
+		w.Header().Set("Content-Type", "application/json")
+		writeJSON(w, out, s.logger)
+	default:
+		w.Header().Set("Content-Type", "text/markdown; charset=utf-8")
+		_, _ = w.Write([]byte(record.Body))
+	}
+}

--- a/internal/server/api/loop_outputs_test.go
+++ b/internal/server/api/loop_outputs_test.go
@@ -1,0 +1,97 @@
+package api
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	looppkg "github.com/nugget/thane-ai-agent/internal/runtime/loop"
+	"github.com/nugget/thane-ai-agent/internal/state/documents"
+)
+
+// TestHandleLoopOutputGetNegotiatesFidelity pins the #1250 HTTP read
+// surface: text/plain is the status_line alone, application/json is
+// the typed contract, anything else is the document body — and a
+// plain-text request against a verdict-less document is 406 with the
+// alternatives named, never an invented one-liner.
+func TestHandleLoopOutputGetNegotiatesFidelity(t *testing.T) {
+	t.Parallel()
+
+	reg, err := looppkg.NewDefinitionRegistry([]looppkg.Spec{{
+		Name:      "metacognitive",
+		Enabled:   true,
+		Task:      "watch the watchers",
+		Operation: looppkg.OperationService,
+		Outputs: []looppkg.OutputSpec{{
+			Name: "metacognitive_state",
+			Type: looppkg.OutputTypeMaintainedDocument,
+			Ref:  "self:metacognitive.md",
+			Facets: []looppkg.FacetSpec{
+				{Name: looppkg.OutputFacetStatusLine},
+				{Name: looppkg.OutputFacetDigest},
+			},
+		}},
+	}})
+	if err != nil {
+		t.Fatalf("NewDefinitionRegistry: %v", err)
+	}
+
+	body := "## Status Line\n\npanel clean, baselines steady\n\n## Digest\n\nNo open concerns.\n\n## Details\n\nworking memory\n"
+	s := &Server{logger: slog.Default()}
+	s.UseLoopDefinitionRegistry(reg)
+	s.UseDocumentReader(func(_ context.Context, ref string) (*documents.DocumentRecord, error) {
+		if ref != "self:metacognitive.md" {
+			t.Fatalf("read unexpected ref %q", ref)
+		}
+		return &documents.DocumentRecord{Ref: ref, Body: body, ModifiedAt: time.Now().UTC().Format(time.RFC3339Nano)}, nil
+	})
+
+	get := func(accept string) *httptest.ResponseRecorder {
+		req := httptest.NewRequest(http.MethodGet, "/v1/loops/metacognitive/outputs/metacognitive_state", nil)
+		if accept != "" {
+			req.Header.Set("Accept", accept)
+		}
+		req.SetPathValue("name", "metacognitive")
+		req.SetPathValue("output", "metacognitive_state")
+		rec := httptest.NewRecorder()
+		s.handleLoopOutputGet(rec, req)
+		return rec
+	}
+
+	plain := get("text/plain")
+	if plain.Code != http.StatusOK || strings.TrimSpace(plain.Body.String()) != "panel clean, baselines steady" {
+		t.Errorf("text/plain = %d %q, want the bare status_line", plain.Code, plain.Body.String())
+	}
+
+	typed := get("application/json")
+	if typed.Code != http.StatusOK {
+		t.Fatalf("application/json status = %d", typed.Code)
+	}
+	for _, want := range []string{`"status_line":"panel clean, baselines steady"`, `"No open concerns."`, `"full":"working memory`} {
+		if !strings.Contains(typed.Body.String(), want) {
+			t.Errorf("json body missing %s:\n%s", want, typed.Body.String())
+		}
+	}
+	if strings.Contains(typed.Body.String(), "## Status Line") {
+		t.Errorf("json body carries section markup:\n%s", typed.Body.String())
+	}
+
+	markdown := get("")
+	if markdown.Code != http.StatusOK || !strings.Contains(markdown.Body.String(), "## Status Line") {
+		t.Errorf("default representation should be the document body: %d %q", markdown.Code, markdown.Body.String())
+	}
+
+	// A verdict-less document refuses the plain representation.
+	body = "# State\n\nno facets yet\n"
+	refused := get("text/plain")
+	if refused.Code != http.StatusNotAcceptable {
+		t.Errorf("plain against verdict-less document = %d, want 406", refused.Code)
+	}
+	if !strings.Contains(refused.Body.String(), "application/json") {
+		t.Errorf("406 should name the available representations: %q", refused.Body.String())
+	}
+}

--- a/internal/server/api/loop_outputs_test.go
+++ b/internal/server/api/loop_outputs_test.go
@@ -66,6 +66,9 @@ func TestHandleLoopOutputGetNegotiatesFidelity(t *testing.T) {
 	if plain.Code != http.StatusOK || strings.TrimSpace(plain.Body.String()) != "panel clean, baselines steady" {
 		t.Errorf("text/plain = %d %q, want the bare status_line", plain.Code, plain.Body.String())
 	}
+	if plain.Header().Get("Vary") != "Accept" {
+		t.Errorf("negotiated response missing Vary: Accept")
+	}
 
 	typed := get("application/json")
 	if typed.Code != http.StatusOK {
@@ -83,6 +86,38 @@ func TestHandleLoopOutputGetNegotiatesFidelity(t *testing.T) {
 	markdown := get("")
 	if markdown.Code != http.StatusOK || !strings.Contains(markdown.Body.String(), "## Status Line") {
 		t.Errorf("default representation should be the document body: %d %q", markdown.Code, markdown.Body.String())
+	}
+
+	// An undeclared contract refuses too: a body whose author typed a
+	// reserved heading into a facet-less output is content, not
+	// contract (#1372 review).
+	regUndeclared, err := looppkg.NewDefinitionRegistry([]looppkg.Spec{{
+		Name:      "plainloop",
+		Enabled:   true,
+		Task:      "keep a document",
+		Operation: looppkg.OperationService,
+		Outputs: []looppkg.OutputSpec{{
+			Name: "notes",
+			Type: looppkg.OutputTypeMaintainedDocument,
+			Ref:  "self:notes.md",
+		}},
+	}})
+	if err != nil {
+		t.Fatalf("NewDefinitionRegistry (undeclared): %v", err)
+	}
+	s2 := &Server{logger: slog.Default()}
+	s2.UseLoopDefinitionRegistry(regUndeclared)
+	s2.UseDocumentReader(func(context.Context, string) (*documents.DocumentRecord, error) {
+		return &documents.DocumentRecord{Ref: "self:notes.md", Body: "## Status Line\n\nan impostor verdict\n\n## Details\n\nbody\n"}, nil
+	})
+	reqU := httptest.NewRequest(http.MethodGet, "/v1/loops/plainloop/outputs/notes", nil)
+	reqU.Header.Set("Accept", "text/plain")
+	reqU.SetPathValue("name", "plainloop")
+	reqU.SetPathValue("output", "notes")
+	recU := httptest.NewRecorder()
+	s2.handleLoopOutputGet(recU, reqU)
+	if recU.Code != http.StatusNotAcceptable {
+		t.Errorf("undeclared contract served text/plain: %d %q", recU.Code, recU.Body.String())
 	}
 
 	// A verdict-less document refuses the plain representation.

--- a/internal/server/api/server.go
+++ b/internal/server/api/server.go
@@ -89,6 +89,7 @@ type Server struct {
 	modelRegistry                      *fleet.Registry
 	contactStore                       *contacts.Store
 	loopDefinitionRegistry             *looppkg.DefinitionRegistry
+	documentRead                       DocumentReader
 	loopDefinitionView                 func() *looppkg.DefinitionRegistryView
 	loopRegistry                       LoopStatusReader
 	logQuerier                         LogQuerier
@@ -485,6 +486,7 @@ func (s *Server) Start(ctx context.Context) error {
 	// Loop definition registry endpoints
 	mux.HandleFunc("GET /v1/loop-definitions", s.handleLoopDefinitions)
 	mux.HandleFunc("GET /v1/loop-definitions/{name}", s.handleLoopDefinitionGet)
+	mux.HandleFunc("GET /v1/loops/{name}/outputs/{output}", s.handleLoopOutputGet)
 	mux.HandleFunc("POST /v1/loop-definitions", s.handleLoopDefinitionSet)
 	mux.HandleFunc("DELETE /v1/loop-definitions/{name}", s.handleLoopDefinitionDelete)
 	mux.HandleFunc("POST /v1/loop-definitions/policy", s.handleLoopDefinitionPolicySet)

--- a/internal/server/openapi/native.yaml
+++ b/internal/server/openapi/native.yaml
@@ -2106,6 +2106,7 @@ components:
           example: self:metacognitive.md
         modified_at:
           type: string
+          format: date-time
           description: Document modification timestamp.
           example: "2026-08-12T18:45:06.195768Z"
         facets:

--- a/internal/server/openapi/native.yaml
+++ b/internal/server/openapi/native.yaml
@@ -432,6 +432,51 @@ paths:
       responses:
         "204": { description: Deleted. }
         "404": { $ref: "#/components/responses/NotFound" }
+  /v1/loops/{name}/outputs/{output}:
+    get:
+      tags: [Loop Definitions]
+      operationId: getLoopOutput
+      summary: Read one declared loop output at a negotiated fidelity
+      description: >-
+        Serves the named loop's declared output document at the fidelity the
+        Accept header asks for. text/plain returns the published status_line
+        alone (speakable, no markup; 406 when the document has published no
+        status_line). application/json returns the typed contract — the
+        published facets as fields plus the full body. text/markdown, or any
+        other Accept, returns the document body.
+      x-thane-scope: definitions:read
+      parameters:
+        - name: name
+          in: path
+          required: true
+          schema: { type: string }
+          description: Loop definition name.
+        - name: output
+          in: path
+          required: true
+          schema: { type: string }
+          description: Declared output name on that definition.
+      responses:
+        "200":
+          description: The output at the negotiated fidelity.
+          content:
+            text/plain:
+              schema: { type: string }
+              example: "panel clean, baselines steady"
+            application/json:
+              schema: { $ref: "#/components/schemas/LoopOutput" }
+            text/markdown:
+              schema: { type: string }
+              example: "## Status Line\n\npanel clean, baselines steady\n\n## Details\n\n..."
+        "404": { $ref: "#/components/responses/NotFound" }
+        "406":
+          description: >-
+            The requested representation is not published — a text/plain
+            request against a document with no status_line. The error names
+            the available representations.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
   /v1/loop-definitions/{name}/launch:
     post:
       tags: [Loop Definitions]
@@ -2040,6 +2085,38 @@ components:
             eligibility: { eligible: true }
             warnings: []
             loop: { name: cota_weekend_observer, operation: service, running: true, state: processing, iterations: 142, effective_tags: [{ tag: messaging, from: self }] }
+    LoopOutput:
+      type: object
+      description: >-
+        One declared loop output in its typed representation: the published
+        facets as fields (absent keys were not published) and the full body.
+      required: [loop, output, ref, full]
+      properties:
+        loop:
+          type: string
+          description: Loop definition name.
+          example: metacognitive
+        output:
+          type: string
+          description: Declared output name.
+          example: metacognitive_state
+        ref:
+          type: string
+          description: Managed document ref the output lands in.
+          example: self:metacognitive.md
+        modified_at:
+          type: string
+          description: Document modification timestamp.
+          example: "2026-08-12T18:45:06.195768Z"
+        facets:
+          type: object
+          additionalProperties: { type: string }
+          description: Published projections keyed by facet (status_line, teaser, digest).
+          example: { status_line: "panel clean, baselines steady" }
+        full:
+          type: string
+          description: The full body — the Details section of a faceted document, the whole body otherwise.
+          example: "Baselines and open concerns..."
     DefinitionView:
       type: object
       description: >-


### PR DESCRIPTION
## The contract reaches the HTTP boundary

The last of #1250's re-grounded scope — the read surfaces outside the document itself — and with it the issue closes.

**Outputs on LoopView.** The canonical loop row — live and stored, both projectors — now carries the declared outputs: name, ref, generated tool, declared facets, audience. A consumer of `loop_status` or the definitions API learns what a loop publishes and which projection levels `doc_read` can pull without fetching the definition. Configuration, not telemetry, so it rides both row sources identically.

**`GET /v1/loops/{name}/outputs/{output}`** is the issue's customer walkthrough made literal, negotiated on `Accept`:

| Accept | Returns |
|---|---|
| `text/plain` | The published status_line alone — speakable, no markup. **406** with alternatives named when no verdict is published: inventing a one-liner would misrepresent the loop. |
| `application/json` | The typed contract: published facets as fields, `full` as the body — never section markup. |
| `text/markdown` / anything else | The document body. |

The API server gains a deliberately narrow `DocumentReader` dependency — one read function, not the store — and the route ships documented in the native OpenAPI spec with examples (the two deterministic vacuum errors this PR's first gate run caught were missing examples on the new media types and schema — fixed, not retried past).

With this, #1250 closes on its re-grounded terms: publish (#1254), store (#1251), read (#1307, #1371), inject (#1370, #1365), and now the row and the wire. The outward motion — HA/MQTT bindings, complications, facet-change wakes — lives in #1356 for v0.10.4.

## Test plan
- [x] `TestHandleLoopOutputGetNegotiatesFidelity` — all three representations, the 406 contract, no section markup in JSON
- [x] Loop-view suites green with outputs on both projectors
- [x] OpenAPI parity + vacuum clean (91/A native, 99/A+ compat)
- [x] `just ci` green locally

Closes #1250

🤖 Generated with [Claude Code](https://claude.com/claude-code)