### PR TITLE
The archive closes over v0.10.3

### DIFF
--- a/docs/releases/README.md
+++ b/docs/releases/README.md
@@ -6,7 +6,8 @@ This directory is Thane's durable release record. Each `v*.md` file contains the
 
 | Published (UTC) | Release | Release label | Sources |
 |---|---|---|---|
-| 2026-07-07 @ 17:17 <!-- epoch: 1783444649 --> | [v0.10.2 — The Native Home Assistant Release](v0.10.2.md) | Latest | [GitHub](https://github.com/nugget/thane-ai-agent/releases/tag/v0.10.2) |
+| 2026-08-13 @ 01:19 <!-- epoch: 1786583998 --> | [v0.10.3 — The Trust Boundary Release](v0.10.3.md) | Latest | [GitHub](https://github.com/nugget/thane-ai-agent/releases/tag/v0.10.3) |
+| 2026-07-07 @ 17:17 <!-- epoch: 1783444649 --> | [v0.10.2 — The Native Home Assistant Release](v0.10.2.md) | &nbsp; | [GitHub](https://github.com/nugget/thane-ai-agent/releases/tag/v0.10.2) |
 | 2026-07-02 @ 21:01 <!-- epoch: 1783026096 --> | [v0.10.1 — The Provenance Release](v0.10.1.md) | &nbsp; | [GitHub](https://github.com/nugget/thane-ai-agent/releases/tag/v0.10.1) |
 | 2026-06-30 @ 18:20 <!-- epoch: 1782843633 --> | [v0.10.0 — The Loop Corpus Release](v0.10.0.md) | &nbsp; | [GitHub](https://github.com/nugget/thane-ai-agent/releases/tag/v0.10.0) |
 | 2026-06-26 @ 02:36 <!-- epoch: 1782441378 --> | [v0.10.0-rc.1](v0.10.0-rc.1.md) | Pre-release | [GitHub](https://github.com/nugget/thane-ai-agent/releases/tag/v0.10.0-rc.1) |

--- a/docs/releases/manifest.json
+++ b/docs/releases/manifest.json
@@ -9,6 +9,66 @@
   },
   "releases": [
     {
+      "tag_name": "v0.10.3",
+      "name": "v0.10.3 — The Trust Boundary Release",
+      "github_release_id": 369613441,
+      "github_node_id": "RE_kwDORJaKbM4WB9qB",
+      "source_url": "https://github.com/nugget/thane-ai-agent/releases/tag/v0.10.3",
+      "api_url": "https://api.github.com/repos/nugget/thane-ai-agent/releases/369613441",
+      "author": "nugget",
+      "created_at": "2026-08-13T00:58:44Z",
+      "published_at": "2026-08-13T01:19:58Z",
+      "updated_at": "2026-08-13T01:19:58Z",
+      "target_commitish": "771089876a11273c4bc6310fa0395455d6456a67",
+      "prerelease": false,
+      "draft": false,
+      "immutable": true,
+      "archived_file": "v0.10.3.md",
+      "archived_file_sha256": "27cc3e42b990fab626e6a81931bb3f3e7ccf3b9c26ff6da791377030bc3b67c3",
+      "assets": [
+        {
+          "browser_download_url": "https://github.com/nugget/thane-ai-agent/releases/download/v0.10.3/thane_0.10.3_checksums.txt",
+          "content_type": "text/plain; charset=utf-8",
+          "digest": "sha256:a2fcd881c3e359a83c2c770feee185c4dba8248126fe3a96f29f7ed467e6cc42",
+          "download_count": 0,
+          "name": "thane_0.10.3_checksums.txt",
+          "size": 388
+        },
+        {
+          "browser_download_url": "https://github.com/nugget/thane-ai-agent/releases/download/v0.10.3/thane_0.10.3_darwin_amd64.pkg",
+          "content_type": "application/octet-stream",
+          "digest": "sha256:bd9d8ccea09137e2deb1855a376c45bdf63271b3ea2de25090ccd706afaf6f3d",
+          "download_count": 0,
+          "name": "thane_0.10.3_darwin_amd64.pkg",
+          "size": 19626164
+        },
+        {
+          "browser_download_url": "https://github.com/nugget/thane-ai-agent/releases/download/v0.10.3/thane_0.10.3_darwin_arm64.pkg",
+          "content_type": "application/octet-stream",
+          "digest": "sha256:713786a89a26ad0e47085c81cc21b8387c48e4f5b77887ea13321b211ac2890a",
+          "download_count": 0,
+          "name": "thane_0.10.3_darwin_arm64.pkg",
+          "size": 18155784
+        },
+        {
+          "browser_download_url": "https://github.com/nugget/thane-ai-agent/releases/download/v0.10.3/thane_0.10.3_linux_amd64.tar.gz",
+          "content_type": "application/x-gtar",
+          "digest": "sha256:cc4ab5e46477225d7ac4d5e5090467447ec26a9c68866bfcb1d9db8cbf93bf17",
+          "download_count": 0,
+          "name": "thane_0.10.3_linux_amd64.tar.gz",
+          "size": 18814256
+        },
+        {
+          "browser_download_url": "https://github.com/nugget/thane-ai-agent/releases/download/v0.10.3/thane_0.10.3_linux_arm64.tar.gz",
+          "content_type": "application/x-gtar",
+          "digest": "sha256:bb5744a872dba9da9ec41a6153dc627ba340604a7c0d3bf3dbd778f6168fe02a",
+          "download_count": 0,
+          "name": "thane_0.10.3_linux_arm64.tar.gz",
+          "size": 17449586
+        }
+      ]
+    },
+    {
       "tag_name": "v0.2.0",
       "name": "v0.2.0",
       "github_release_id": 285037993,

--- a/docs/releases/v0.10.3.md
+++ b/docs/releases/v0.10.3.md
@@ -119,6 +119,6 @@ This upgrade rearranges where things live; prepare the workspace before deployin
 
 ---
 
-**360 files changed, 34,776 insertions, 3,862 deletions across 103 pull requests.**
+**370 files changed, 36,635 insertions, 4,453 deletions across 104 pull requests.**
 
 **Full Changelog**: https://github.com/nugget/thane-ai-agent/compare/v0.10.2...v0.10.3


### PR DESCRIPTION
The normal post-publication commit per the docs/releases archival contract: manifest entry with the live release identity and asset digests, index row with the published timestamp, Latest label moved. The stats footer is corrected to the true tag range (370 files, +36,635/−4,453, 104 PRs) — the published release body was updated identically via gh release edit, so file and release stay in sync; the manifest digest covers the corrected file.

## Test plan
- [x] just ci clean
- [x] manifest entry schema matches prior entries; archived_file_sha256 recomputed after the stats fix
- [x] release body on GitHub re-synced from the corrected file (H1 stripped per contract)

Refs #1305

🤖 Generated with [Claude Code](https://claude.com/claude-code)