### PR TITLE
A fact the machine stamps is a fact the model stops copying

### DIFF
--- a/internal/app/document_root_trailers.go
+++ b/internal/app/document_root_trailers.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/nugget/thane-ai-agent/internal/platform/buildinfo"
 	"github.com/nugget/thane-ai-agent/internal/platform/config"
 	"github.com/nugget/thane-ai-agent/internal/platform/provenance"
 	"github.com/nugget/thane-ai-agent/internal/state/documents"
@@ -33,6 +34,7 @@ func (w *documentRootProvenanceWriter) withTurnProvenance(ctx context.Context, m
 	}
 
 	add(documents.TrailerModel, tools.ModelFromContext(ctx))
+	add(documents.TrailerVersion, buildinfo.Version)
 	add(documents.TrailerLoopID, tools.LoopIDFromContext(ctx))
 	// ConversationIDFromContext reports "default" outside a conversation, which
 	// identifies nothing worth committing.

--- a/internal/app/document_root_trailers_test.go
+++ b/internal/app/document_root_trailers_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/nugget/thane-ai-agent/internal/platform/buildinfo"
 	"github.com/nugget/thane-ai-agent/internal/platform/config"
 	"github.com/nugget/thane-ai-agent/internal/state/documents"
 	"github.com/nugget/thane-ai-agent/internal/tools"
@@ -40,6 +41,7 @@ func TestWithTurnProvenance(t *testing.T) {
 			message: "doc_write self:metacognitive.md",
 			want: map[string]string{
 				documents.TrailerModel:        "gpt-oss:120b",
+				documents.TrailerVersion:      buildinfo.Version,
 				documents.TrailerLoopID:       "loop-abc",
 				documents.TrailerConversation: "loop-metacognitive-1-123",
 				documents.TrailerSession:      "sess-1",
@@ -49,11 +51,15 @@ func TestWithTurnProvenance(t *testing.T) {
 			},
 		},
 		{
-			name:    "a turn that knows nothing leaves the message alone",
+			// A turn with no context still has a build: the version is
+			// machine truth about the writing process, not a turn fact,
+			// so it is the one trailer that never goes absent.
+			name:    "a turn that knows nothing still stamps the build",
 			writer:  &documentRootProvenanceWriter{root: "self"},
 			ctx:     func(ctx context.Context) context.Context { return ctx },
 			message: "doc_write self:metacognitive.md",
-			want:    map[string]string{},
+			want:    map[string]string{documents.TrailerVersion: buildinfo.Version},
+			absent:  []string{documents.TrailerModel, documents.TrailerRequest},
 		},
 		{
 			name:   "the default conversation identifies nothing and is omitted",

--- a/internal/state/documents/revision.go
+++ b/internal/state/documents/revision.go
@@ -48,6 +48,11 @@ const (
 	// were in force when it was made. Absent on core's own history, where the
 	// parent commit already says it.
 	TrailerCoreHead = "Thane-Core-Head"
+	// TrailerVersion records the build that performed the write. Machine-stamped
+	// so no document ever needs a hand-transcribed version claim — the first
+	// production re-tag proved a model copying its own prior facet will carry a
+	// retired label forward; the trailer is the fact, the facet is the judgment.
+	TrailerVersion = "Thane-Version"
 )
 
 // RevisionQuery bounds a [RootReviser.History] page.

--- a/internal/state/documents/revision_tools.go
+++ b/internal/state/documents/revision_tools.go
@@ -218,7 +218,11 @@ type modelRevision struct {
 // composed it. They answer different questions and a root that reports both is
 // materially better evidence than one reporting either alone.
 type modelRevisionAuthorship struct {
-	Model        string `json:"model,omitempty"`
+	Model string `json:"model,omitempty"`
+	// Version is the build that performed the write, machine-stamped at
+	// commit time — the authoritative answer to "which thane wrote this,"
+	// so no document body ever needs to carry a hand-copied version claim.
+	Version      string `json:"version,omitempty"`
 	LoopID       string `json:"loop_id,omitempty"`
 	Conversation string `json:"conversation,omitempty"`
 	Session      string `json:"session,omitempty"`
@@ -297,6 +301,7 @@ func splitRevisionTrailers(trailers map[string]string) (*modelRevisionAuthorship
 	}
 	authored := modelRevisionAuthorship{
 		Model:        trailers[TrailerModel],
+		Version:      trailers[TrailerVersion],
 		LoopID:       trailers[TrailerLoopID],
 		Conversation: trailers[TrailerConversation],
 		Session:      trailers[TrailerSession],
@@ -306,9 +311,9 @@ func splitRevisionTrailers(trailers map[string]string) (*modelRevisionAuthorship
 		CoreHead:     trailers[TrailerCoreHead],
 	}
 	promoted := map[string]bool{
-		TrailerModel: true, TrailerLoopID: true, TrailerConversation: true,
-		TrailerSession: true, TrailerRequest: true, TrailerToolCall: true,
-		TrailerIteration: true, TrailerCoreHead: true,
+		TrailerModel: true, TrailerVersion: true, TrailerLoopID: true,
+		TrailerConversation: true, TrailerSession: true, TrailerRequest: true,
+		TrailerToolCall: true, TrailerIteration: true, TrailerCoreHead: true,
 	}
 	var rest map[string]string
 	for key, value := range trailers {

--- a/internal/state/introspection/health.go
+++ b/internal/state/introspection/health.go
@@ -151,8 +151,15 @@ type VersionInfo struct {
 	// when the two versions differ only in prerelease/build metadata,
 	// which is exactly what an rc→final deploy looks like: Previous and
 	// ChangedDelta still mark the boundary, it just has no size class.
-	Change       string `json:"change,omitempty"`
-	BootsLast24h int    `json:"boots_last_24h,omitempty"`
+	Change string `json:"change,omitempty"`
+	// PreviousSameCommit marks a re-tag boundary: Previous's label
+	// points at the same commit Running was built from — a build
+	// promoted to a release tag, not a code change. Without this flag
+	// the deploy story reads as an upgrade that isn't one; the first
+	// production re-tag (v0.10.2-400 → v0.10.3, same commit) confused
+	// the loop that reads this into carrying the retired label forward.
+	PreviousSameCommit bool `json:"previous_same_commit,omitempty"`
+	BootsLast24h       int  `json:"boots_last_24h,omitempty"`
 	// RecentBoots is the raw tail of the boot journal, newest first.
 	// The tail is deliberately data rather than verdict: what a restart
 	// pattern means depends on context the reader has (deploy day,
@@ -581,6 +588,7 @@ func (i *Inspector) collectVersionInfo(ctx context.Context, now time.Time) Versi
 					info.ChangedDelta = promptfmt.FormatDeltaOnly(boundary, now)
 				}
 				info.Change = classifyVersionChange(info.Previous, info.Running)
+				info.PreviousSameCommit = sameCommit(boot.Commit, info.Commit)
 			}
 		}
 	}
@@ -596,6 +604,20 @@ func (i *Inspector) collectVersionInfo(ctx context.Context, now time.Time) Versi
 // classifyVersionChange names the size of a version jump: patch, minor,
 // major — or "dev" when either side is not a semantic version, which is
 // itself information (an untagged build shipped).
+// sameCommit reports whether two commit identifiers name the same commit,
+// tolerating the short-vs-full hash forms the boot journal and buildinfo
+// variously carry.
+func sameCommit(a, b string) bool {
+	a, b = strings.TrimSpace(a), strings.TrimSpace(b)
+	if a == "" || b == "" {
+		return false
+	}
+	if len(a) > len(b) {
+		a, b = b, a
+	}
+	return strings.HasPrefix(b, a)
+}
+
 func classifyVersionChange(prev, curr string) string {
 	prevParts, prevOK := semverParts(prev)
 	currParts, currOK := semverParts(curr)

--- a/internal/state/introspection/health.go
+++ b/internal/state/introspection/health.go
@@ -601,9 +601,6 @@ func (i *Inspector) collectVersionInfo(ctx context.Context, now time.Time) Versi
 	return info
 }
 
-// classifyVersionChange names the size of a version jump: patch, minor,
-// major — or "dev" when either side is not a semantic version, which is
-// itself information (an untagged build shipped).
 // sameCommit reports whether two commit identifiers name the same commit,
 // tolerating the short-vs-full hash forms the boot journal and buildinfo
 // variously carry.
@@ -618,6 +615,9 @@ func sameCommit(a, b string) bool {
 	return strings.HasPrefix(b, a)
 }
 
+// classifyVersionChange names the size of a version jump: patch, minor,
+// major — or "dev" when either side is not a semantic version, which is
+// itself information (an untagged build shipped).
 func classifyVersionChange(prev, curr string) string {
 	prevParts, prevOK := semverParts(prev)
 	currParts, currOK := semverParts(curr)

--- a/internal/state/introspection/health_extra_test.go
+++ b/internal/state/introspection/health_extra_test.go
@@ -1,0 +1,46 @@
+package introspection
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// TestVersionInfoMarksReTagBoundary pins the re-tag disclosure: when the
+// previous version's label points at the commit the running build was
+// made from, the deploy story says so — the first production re-tag
+// (v0.10.2-400 → v0.10.3, same commit) read as an upgrade that wasn't
+// one, and the loop reading it carried the retired label forward.
+func TestVersionInfoMarksReTagBoundary(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 13, 2, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name     string
+		previous BootRecord
+		want     bool
+	}{
+		{"re-tag of the same commit", BootRecord{At: now.Add(-2 * time.Hour), Version: "v0.10.2-400-g77108987", Commit: "7710898761a2"}, true},
+		{"real upgrade", BootRecord{At: now.Add(-2 * time.Hour), Version: "v0.10.2", Commit: "0123456789ab"}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			boots := []BootRecord{
+				{At: now.Add(-30 * time.Minute), Version: "v0.10.3", Commit: "77108987"},
+				tt.previous,
+			}
+			insp := NewInspector(HealthSources{
+				BuildVersion: "v0.10.3",
+				BuildCommit:  "77108987",
+				BootHistory:  func(context.Context) ([]BootRecord, error) { return boots, nil },
+			})
+			insp.now = func() time.Time { return now }
+			v := insp.Health(context.Background()).Version
+			if v.PreviousSameCommit != tt.want {
+				t.Errorf("previous_same_commit = %v, want %v (previous %s@%s vs running @77108987)",
+					v.PreviousSameCommit, tt.want, tt.previous.Version, tt.previous.Commit)
+			}
+		})
+	}
+}

--- a/loops/metacognitive.md
+++ b/loops/metacognitive.md
@@ -200,6 +200,16 @@ content go — purpose-built loops own that now.
    baseline, ego churn climbing". A judgment about the whole system,
    never an inventory of it. Your verdict is injected into interactive
    context every turn, so it is the most-read sentence you write.
+   Never transcribe machine-stamped facts into your facets: the
+   substrate records the build that wrote every revision, the panel
+   already carries the running version and deploy story, and a fact
+   the machine stamps is a fact you can only degrade by copying — the
+   first post-upgrade publish under v0.10.3 carried the retired
+   build's version stamp forward, hand-copied from the prior facet.
+   Your facets carry judgment. When a version matters to a concern
+   (a regression that began at a boundary), name it in the concern's
+   evidence, read fresh from this iteration's panel — and treat your
+   prior facets as claims to re-verify, never as templates to edit.
    Each budget is a ceiling, not a target — compose comfortably
    under it, because you cannot count runes precisely: an over-budget
    value is rejected rather than clipped, and the rejection names the


### PR DESCRIPTION
Production incident, small but instructive: metacog's first publish after the v0.10.3 self-update still claimed `v0.10.2-400` — the local model updated one clause of its status_line and carried the rest forward from its own prior facet, version stamp included. The panel it should have read was itself rendering the most confusing boundary possible: previous `v0.10.2-400-g77108987`, running `v0.10.3`, **same commit** — the release re-tag reading as an upgrade that wasn't one.

Three fixes, one per contributing cause:

**`Thane-Version` joins the commit trailers** (the operator's observation: we record Thane-Model, why not the build?). The version becomes machine-stamped on every root write, surfaced in `doc_history`'s `authored_by`, present even on turns with no other context — so version claims in document bodies become permanently unnecessary rather than occasionally wrong.

**`previous_same_commit` on the deploy story.** When the previous label points at the running build's own commit, the panel says "promotion" instead of implying a code change. Table-tested against the exact production case.

**The mandate teaches the general rule.** The Record step now says: never transcribe machine-stamped facts into facets — the substrate records them; your facets carry judgment — and prior facets are claims to re-verify, never templates to edit. No profile escalation: per #1362's own pattern, teaching and observation first, frontier spend only if the echo survives them.

Deploy note: the mandate edit reaches prod via the next `core/loops` backport; her stale status_line self-heals on the first publish after it.

## Test plan
- [x] `just ci` clean (after a `golangci-lint cache clean` for the documented worktree-ghost false positives)
- [x] Trailer round-trip pinned: full turn carries Thane-Version; a context-free turn stamps *only* the build
- [x] Re-tag disclosure table-tested: same-commit → true, real upgrade → false

Refs #1322, #1341, #1383

🤖 Generated with [Claude Code](https://claude.com/claude-code)