### PR TITLE
Bind the run context, not just the prompt context

### DIFF
--- a/internal/runtime/agent/bindings_seam_test.go
+++ b/internal/runtime/agent/bindings_seam_test.go
@@ -1,0 +1,91 @@
+package agent
+
+import (
+	"context"
+	"testing"
+
+	"github.com/nugget/thane-ai-agent/internal/model/llm"
+	"github.com/nugget/thane-ai-agent/internal/platform/config"
+	"github.com/nugget/thane-ai-agent/internal/runtime/agentctx"
+	looppkg "github.com/nugget/thane-ai-agent/internal/runtime/loop"
+)
+
+// recordingBindingProvider is a tag context provider that records the
+// binding it observed on every invocation.
+type recordingBindingProvider struct {
+	seen []string
+}
+
+func (p *recordingBindingProvider) TagContextBucket() agentctx.ContextBucket {
+	return agentctx.ContextBucketLiveState
+}
+
+func (p *recordingBindingProvider) TagContext(ctx context.Context, _ agentctx.ContextRequest) (string, error) {
+	p.seen = append(p.seen, looppkg.BindingFromContext(ctx, looppkg.BindingForgeAccount))
+	return "bound=" + looppkg.BindingFromContext(ctx, looppkg.BindingForgeAccount), nil
+}
+
+// TestRequestBindingsReachContextProvidersEveryIteration runs an actual
+// agent request through the transport seam, which no other binding test
+// does — they exercise the context helper and the forge service
+// directly, so a broken stamp leaves them all green.
+//
+// It caught a real production defect. The prompt is not built once:
+// OnIterationStart rebuilds it on every iteration after the first, from
+// the iteration context rather than the local promptCtx that carried
+// the stamp. Binding only promptCtx narrowed iteration 0 and handed
+// back the full account list from iteration 1 onward, so a bound loop
+// was shown a credential its own tool calls would refuse.
+func TestRequestBindingsReachContextProvidersEveryIteration(t *testing.T) {
+	// Two responses: the first with a tool call so the run continues to
+	// a second iteration, which is where the rebuild happens.
+	mock := &mockLLM{
+		responses: []*llm.ChatResponse{
+			{
+				Model:       "test-model",
+				Message:     llm.Message{Role: "assistant", ToolCalls: []llm.ToolCall{newToolCall("c1", "base_tool")}},
+				InputTokens: 100, OutputTokens: 10,
+			},
+			{
+				Model:       "test-model",
+				Message:     llm.Message{Role: "assistant", Content: "Done."},
+				InputTokens: 100, OutputTokens: 10,
+			},
+		},
+	}
+
+	loop := buildTestLoop(mock, []string{"base_tool"})
+	loop.SetCapabilityTags(map[string]config.CapabilityTagConfig{
+		"forge": {Description: "Forge", Tools: []string{"base_tool"}, Core: true},
+	}, nil)
+
+	provider := &recordingBindingProvider{}
+	loop.RegisterTagContextProvider("forge", provider)
+
+	if _, err := loop.Run(context.Background(), &Request{
+		Messages:    []Message{{Role: "user", Content: "go"}},
+		InitialTags: []string{"forge"},
+		Bindings:    map[string]string{looppkg.BindingForgeAccount: "github-readonly"},
+	}, nil); err != nil {
+		t.Fatalf("Run() error: %v", err)
+	}
+
+	if len(provider.seen) == 0 {
+		t.Fatal("context provider was never invoked; the test cannot observe the seam")
+	}
+	for i, got := range provider.seen {
+		if got != "github-readonly" {
+			t.Errorf("provider invocation %d saw binding %q, want %q — the stamp did not reach this prompt build",
+				i, got, "github-readonly")
+		}
+	}
+	t.Logf("provider invoked %d times, all bound", len(provider.seen))
+}
+
+// newToolCall builds a tool call with the nested Function shape.
+func newToolCall(id, name string) llm.ToolCall {
+	tc := llm.ToolCall{ID: id}
+	tc.Function.Name = name
+	tc.Function.Arguments = map[string]any{}
+	return tc
+}

--- a/internal/runtime/agent/loop.go
+++ b/internal/runtime/agent/loop.go
@@ -1844,12 +1844,18 @@ func (l *Loop) Run(ctx context.Context, req *Request, stream StreamCallback) (re
 	// context providers (e.g. working memory) can scope their output.
 	// Propagate request hints so channel-aware providers can adapt.
 	ctx = agentctx.WithPromptMode(ctx, req.PromptMode)
+	// Stamped on the run context, not just the prompt context, because
+	// the prompt is built more than once: OnIterationStart rebuilds it
+	// on every iteration after the first, from the iteration context
+	// rather than this function's local promptCtx. Binding only
+	// promptCtx narrowed iteration 0 and silently handed back the full
+	// account list from iteration 1 onward — the model was told about
+	// a credential its own tool calls would refuse, which is the
+	// painted door this narrowing exists to remove. Everything derived
+	// from ctx now inherits it.
+	ctx = loop.WithBindings(ctx, req.Bindings)
 	promptCtx := tools.WithConversationID(ctx, convID)
 	promptCtx = tools.WithHints(promptCtx, req.RoutingFactors)
-	// Bound here as well as on tool calls: a context block that
-	// advertises a resource the tools will refuse teaches the model a
-	// door that is painted on.
-	promptCtx = loop.WithBindings(promptCtx, req.Bindings)
 	promptCtx = tools.WithChannelBinding(promptCtx, channelBinding)
 	promptCtx = tools.WithSuppressAlwaysContext(promptCtx, req.SuppressAlwaysContext)
 


### PR DESCRIPTION
Found by spot-checking the production deploy of #1388, not by a test.

metacognitive's injected forge block listed **both** accounts with no `bound` marker, while `/v1/loops` reported its binding present and active (`effective_bindings: [{forge_account: github-readonly, from: self}]`). The narrowing was simply not reaching the prompt.

## Cause

The prompt is not built once. `OnIterationStart` rebuilds it on every iteration after the first — so capability context reflects tags activated mid-run — and it rebuilds from the *iteration* context rather than the local `promptCtx` that carried the binding stamp. Iteration 0 narrowed correctly; iteration 1 onward silently handed back the full account list. That is why the deployed behavior looked like the feature had never shipped.

Stamping the run context instead means everything derived from it — prompt context, iteration context, and the rebuild — inherits the binding.

## Scope: tools were never affected

`OnBeforeToolExec` re-stamps from `req.Bindings` directly, so a bound loop could not have reached another account. Enforcement held. What broke is the honesty of the prompt: the loop was shown a credential its own tool calls would refuse — the painted door the narrowing exists to remove. Real, but not an escape.

## The test

`TestRequestBindingsReachContextProvidersEveryIteration` runs an actual request through the transport seam, which nothing else did — every other binding test exercises the context helper or the forge service directly, so a broken stamp left them all green. It asserts the binding on *every* provider invocation, not just the first. Reverting the fix fails it on the second invocation, which is exactly the iteration production was serving.

## Note

This failure mode was predicted in review of #1388 as a suppressed comment: *"none runs an agent request through this transport seam. Dropping either the prompt-context stamp here or the per-tool stamp later would leave the existing tests green while making the boundary advisory."* I did not act on it because the thread carried no `comment_id`. That was the wrong call, and this is the consequence.

## Test plan

- [x] `just ci` green locally
- [x] New seam test passes; reverting the one-line fix fails it on invocation 2
- [x] Verified against production: loop view showed the binding active while the injected block showed both accounts unnarrowed

Refs #1386