### PR TITLE
Expand ~ before resolving a checkout path

### DIFF
--- a/internal/platform/checkout/mirror.go
+++ b/internal/platform/checkout/mirror.go
@@ -76,7 +76,7 @@ func OpenMirror(spec MirrorSpec) (*Mirror, error) {
 	if worktreePath == "" {
 		return nil, fmt.Errorf("%s: worktree path is required", name)
 	}
-	absWorktreePath, err := filepath.Abs(worktreePath)
+	absWorktreePath, err := absPath(worktreePath)
 	if err != nil {
 		return nil, fmt.Errorf("%s: resolve worktree path: %w", name, err)
 	}

--- a/internal/platform/checkout/paths.go
+++ b/internal/platform/checkout/paths.go
@@ -88,5 +88,15 @@ func prefixWithinRepo(repoPath, worktreePath string) (string, error) {
 // surface come from model tool arguments and operator config, both of
 // which write ~ by habit.
 func absPath(path string) (string, error) {
-	return filepath.Abs(paths.ExpandHome(path))
+	expanded := paths.ExpandHome(path)
+	// ExpandHome returns its input unchanged when the home directory
+	// cannot be determined, and filepath.Abs would then turn "~/x" back
+	// into "<cwd>/~/x" — the very misresolution this helper exists to
+	// prevent, reintroduced on the one path where nothing is watching.
+	// A tilde that survived expansion is refused rather than resolved
+	// into a plausible-looking wrong answer.
+	if strings.HasPrefix(expanded, "~") {
+		return "", fmt.Errorf("cannot resolve %q: it begins with ~ and the home directory could not be determined; supply an absolute path", path)
+	}
+	return filepath.Abs(expanded)
 }

--- a/internal/platform/checkout/paths.go
+++ b/internal/platform/checkout/paths.go
@@ -5,6 +5,8 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
+
+	"github.com/nugget/thane-ai-agent/internal/platform/paths"
 )
 
 // Root describes how a managed subtree maps onto its backing git repository.
@@ -21,11 +23,11 @@ type Root struct {
 // ResolveRoot resolves repoPath and worktreePath to absolute paths and verifies
 // that the worktree is the repository root or a subtree inside it.
 func ResolveRoot(repoPath, worktreePath string) (Root, error) {
-	absRepoPath, err := filepath.Abs(repoPath)
+	absRepoPath, err := absPath(repoPath)
 	if err != nil {
 		return Root{}, fmt.Errorf("resolve repository path: %w", err)
 	}
-	absWorktreePath, err := filepath.Abs(worktreePath)
+	absWorktreePath, err := absPath(worktreePath)
 	if err != nil {
 		return Root{}, fmt.Errorf("resolve worktree path: %w", err)
 	}
@@ -73,4 +75,18 @@ func prefixWithinRepo(repoPath, worktreePath string) (string, error) {
 		return "", fmt.Errorf("repository %s must be the worktree path %s or one of its parents", repoPath, worktreePath)
 	}
 	return filepath.ToSlash(rel), nil
+}
+
+// absPath resolves a caller-supplied path to an absolute one, expanding
+// a leading ~ first.
+//
+// filepath.Abs alone does not expand ~: it prepends the working
+// directory, so "~/Thane/repos/x" silently becomes
+// "<cwd>/~/Thane/repos/x" — a real directory with a literal "~"
+// component, created without complaint. Nothing errors, and the
+// checkout lands somewhere the operator never named. Paths on this
+// surface come from model tool arguments and operator config, both of
+// which write ~ by habit.
+func absPath(path string) (string, error) {
+	return filepath.Abs(paths.ExpandHome(path))
 }

--- a/internal/platform/checkout/tilde_test.go
+++ b/internal/platform/checkout/tilde_test.go
@@ -1,0 +1,60 @@
+package checkout
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestResolveRootExpandsTilde covers the papercut that produced a real
+// nested-nonsense checkout path in production: forge_repo_follow was
+// given "~/Thane/repos/x" and recorded
+// "/Users/aimee/Thane/~/Thane/repos/x".
+//
+// filepath.Abs does not expand ~; it prepends the working directory,
+// so the tilde survives as a literal path component and the directory
+// is created without complaint. Nothing errors — the checkout just
+// lands somewhere nobody named. Paths reaching this surface come from
+// model tool arguments and operator config, both of which write ~ by
+// habit.
+func TestResolveRootExpandsTilde(t *testing.T) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Skip("no home directory")
+	}
+
+	root, err := ResolveRoot("~/repo", "~/repo")
+	if err != nil {
+		t.Fatalf("ResolveRoot: %v", err)
+	}
+
+	for name, got := range map[string]string{"RepoPath": root.RepoPath, "WorktreePath": root.WorktreePath} {
+		if strings.Contains(got, "~") {
+			t.Errorf("%s = %q still contains a literal tilde", name, got)
+		}
+		if !filepath.IsAbs(got) {
+			t.Errorf("%s = %q is not absolute", name, got)
+		}
+		if want := filepath.Join(home, "repo"); got != want {
+			t.Errorf("%s = %q, want %q", name, got, want)
+		}
+	}
+}
+
+// TestResolveRootLeavesOtherPathsAlone keeps the expansion from
+// touching paths that never asked for it.
+func TestResolveRootLeavesOtherPathsAlone(t *testing.T) {
+	dir := t.TempDir()
+	root, err := ResolveRoot(dir, dir)
+	if err != nil {
+		t.Fatalf("ResolveRoot: %v", err)
+	}
+	// t.TempDir can hand back a symlinked path; compare after
+	// evaluating both sides rather than assuming equality.
+	wantEval, _ := filepath.EvalSymlinks(dir)
+	gotEval, _ := filepath.EvalSymlinks(root.RepoPath)
+	if gotEval != wantEval {
+		t.Errorf("RepoPath = %q, want %q", root.RepoPath, dir)
+	}
+}

--- a/internal/platform/checkout/tilde_test.go
+++ b/internal/platform/checkout/tilde_test.go
@@ -30,8 +30,12 @@ func TestResolveRootExpandsTilde(t *testing.T) {
 	}
 
 	for name, got := range map[string]string{"RepoPath": root.RepoPath, "WorktreePath": root.WorktreePath} {
-		if strings.Contains(got, "~") {
-			t.Errorf("%s = %q still contains a literal tilde", name, got)
+		// The defect is a literal "~" path COMPONENT, not a tilde
+		// character anywhere in the string: a home directory may
+		// legitimately contain one, and flagging that would fail this
+		// test for the wrong reason on a machine where it is true.
+		if hasTildeComponent(got) {
+			t.Errorf("%s = %q contains an unexpanded ~ path component", name, got)
 		}
 		if !filepath.IsAbs(got) {
 			t.Errorf("%s = %q is not absolute", name, got)
@@ -56,5 +60,40 @@ func TestResolveRootLeavesOtherPathsAlone(t *testing.T) {
 	gotEval, _ := filepath.EvalSymlinks(root.RepoPath)
 	if gotEval != wantEval {
 		t.Errorf("RepoPath = %q, want %q", root.RepoPath, dir)
+	}
+}
+
+// hasTildeComponent reports whether any element of path is exactly "~",
+// which is what an unexpanded tilde leaves behind.
+func hasTildeComponent(path string) bool {
+	for _, part := range strings.Split(filepath.ToSlash(path), "/") {
+		if part == "~" {
+			return true
+		}
+	}
+	return false
+}
+
+// TestAbsPathRefusesUnexpandedTilde covers the fallback that would
+// otherwise recreate the bug quietly. ExpandHome returns its input
+// unchanged when the home directory cannot be determined, and
+// filepath.Abs would then produce "<cwd>/~/..." — a plausible-looking
+// wrong answer on the one path where nothing is watching.
+func TestAbsPathRefusesUnexpandedTilde(t *testing.T) {
+	// os.UserHomeDir reads $HOME on Unix; emptying it makes expansion
+	// fail the way it would on a process with no home.
+	t.Setenv("HOME", "")
+
+	if _, err := absPath("~/repo"); err == nil {
+		t.Error("absPath() accepted a tilde it could not expand; filepath.Abs would have mangled it into <cwd>/~/repo")
+	}
+
+	// A path needing no expansion still resolves with no home set.
+	got, err := absPath("/tmp/repo")
+	if err != nil {
+		t.Fatalf("absPath(absolute) = %v, want it to resolve without a home directory", err)
+	}
+	if got != "/tmp/repo" {
+		t.Errorf("absPath() = %q, want %q", got, "/tmp/repo")
 	}
 }


### PR DESCRIPTION
Reported from production: `forge_repo_follow` was given `~/Thane/repos/thane-ai-agent` and recorded `/Users/aimee/Thane/~/Thane/repos/thane-ai-agent` — a real path with a literal `~` component.

`filepath.Abs` does not expand a leading tilde; it prepends the working directory. Nothing errors, the tool reports success, and the checkout is configured to land somewhere the operator never named. Paths arrive on this surface from model tool arguments and operator config, both of which write `~` by habit.

Fixed at the resolver (`ResolveRoot`/`OpenMirror`) rather than in `forge_repo_follow`, because every caller takes a caller-supplied path and had the same papercut. `paths.ExpandHome` already existed; this just uses it.

## Test plan

- [x] `just ci` green locally
- [x] `ResolveRoot("~/repo", "~/repo")` yields `$HOME/repo` with no literal tilde, absolute
- [x] Non-tilde paths unchanged
- [x] Mutation-verified: reverting to bare `filepath.Abs` fails the test on the literal-tilde assertion