### PR TITLE
Stop promising a checkout the site cannot populate

### DIFF
--- a/docs/reference/event-sources.md
+++ b/docs/reference/event-sources.md
@@ -105,6 +105,14 @@ as a read-only mirror checkout by the poller before event delivery. That
 path must be empty or an existing Thane-owned mirror checkout; non-empty
 directories and unmarked git checkouts are refused.
 
+The poller is the only thing that populates a checkout, so
+`local_checkout` requires polling: when `forge.subscription_check_interval`
+is unset or zero the follow is refused rather than recording a path
+nothing will ever create. A subscription without a checkout is still
+accepted under that setting, but it is inert until polling is enabled —
+it wakes no loop and syncs nothing — and the tool says so in its
+response.
+
 Unlike legacy pollers that start a fresh generic conversation, forge
 subscriptions require `wake_loop`. New `release` and `commit` events are
 delivered to the named loop as structured event-source notifications, so the

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -381,7 +381,11 @@ an existing loop, usually one created with `thane_loop_create`
 poller syncs that checkout before delivering repository events. The path
 must be empty or an existing Thane-owned mirror checkout; non-empty
 directories and unmarked git checkouts are refused. Unfollowing leaves
-the checkout on disk.
+the checkout on disk. Because the poller is the only thing that
+populates a checkout, `local_checkout` is refused when
+`forge.subscription_check_interval` is unset or zero; a subscription
+without one is still accepted there but stays inert until polling is
+enabled, and says so in its response.
 
 ## `scheduler` — time-based tasks
 

--- a/internal/integrations/forge/service.go
+++ b/internal/integrations/forge/service.go
@@ -147,6 +147,17 @@ func (s *Service) SubscriptionPollingEnabled() bool {
 	return s != nil && s.poller != nil
 }
 
+// EnableSubscriptionPollingForTest marks polling live without standing
+// up a real poller. Exported for tests in this package that exercise
+// behavior only meaningful when polling runs — a local checkout, for
+// instance, is populated by the poller and nothing else.
+func (s *Service) EnableSubscriptionPollingForTest(p *SubscriptionPoller) {
+	if s == nil {
+		return
+	}
+	s.poller = p
+}
+
 // CheckSubscriptions polls followed repositories and delivers any resulting
 // event wakes. Repository failures remain isolated by [SubscriptionPoller].
 func (s *Service) CheckSubscriptions(ctx context.Context) (int, error) {

--- a/internal/integrations/forge/service.go
+++ b/internal/integrations/forge/service.go
@@ -147,17 +147,6 @@ func (s *Service) SubscriptionPollingEnabled() bool {
 	return s != nil && s.poller != nil
 }
 
-// EnableSubscriptionPollingForTest marks polling live without standing
-// up a real poller. Exported for tests in this package that exercise
-// behavior only meaningful when polling runs — a local checkout, for
-// instance, is populated by the poller and nothing else.
-func (s *Service) EnableSubscriptionPollingForTest(p *SubscriptionPoller) {
-	if s == nil {
-		return
-	}
-	s.poller = p
-}
-
 // CheckSubscriptions polls followed repositories and delivers any resulting
 // event wakes. Repository failures remain isolated by [SubscriptionPoller].
 func (s *Service) CheckSubscriptions(ctx context.Context) (int, error) {

--- a/internal/integrations/forge/subscription_tool_provider.go
+++ b/internal/integrations/forge/subscription_tool_provider.go
@@ -43,7 +43,7 @@ func (t *Tools) subscriptionToolDefinitions() []*toolpkg.Tool {
 					},
 					"local_checkout": map[string]any{
 						"type":        "string",
-						"description": "Optional absolute or working-directory-relative path to keep as a read-only mirror checkout. The path must be empty or an existing Thane-owned mirror checkout; non-empty directories and unmarked git checkouts are refused. The subscription poller syncs this path before waking the loop and leaves it on disk when unfollowed.",
+						"description": "Optional absolute or working-directory-relative path to keep as a read-only mirror checkout. Requires repository polling: the poller is the only thing that populates this path, so the call is refused when forge.subscription_check_interval is unset or zero. The path must be empty or an existing Thane-owned mirror checkout; non-empty directories and unmarked git checkouts are refused. The subscription poller syncs this path before waking the loop and leaves it on disk when unfollowed.",
 					},
 					"wake_loop": forgeWakeLoopDefinition(),
 				},

--- a/internal/integrations/forge/subscriptions_checkout_test.go
+++ b/internal/integrations/forge/subscriptions_checkout_test.go
@@ -36,7 +36,7 @@ func TestHandleRepoFollowStoresLocalCheckout(t *testing.T) {
 	tools := newTestTools(provider, "owner")
 	tools.subscriptions = store
 	// A local checkout is only meaningful when the poller runs.
-	tools.service.EnableSubscriptionPollingForTest(&SubscriptionPoller{})
+	enablePollingForTest(tools.service)
 
 	raw, err := tools.HandleRepoFollow(context.Background(), map[string]any{
 		"repo":           "repo",
@@ -147,7 +147,7 @@ func TestHandleRepoFollowRejectsLocalCheckoutWithoutCloneURL(t *testing.T) {
 	tools := newTestTools(provider, "owner")
 	tools.subscriptions = store
 	// A local checkout is only meaningful when the poller runs.
-	tools.service.EnableSubscriptionPollingForTest(&SubscriptionPoller{})
+	enablePollingForTest(tools.service)
 
 	_, err := tools.HandleRepoFollow(context.Background(), map[string]any{
 		"repo":           "repo",

--- a/internal/integrations/forge/subscriptions_checkout_test.go
+++ b/internal/integrations/forge/subscriptions_checkout_test.go
@@ -35,6 +35,8 @@ func TestHandleRepoFollowStoresLocalCheckout(t *testing.T) {
 	}
 	tools := newTestTools(provider, "owner")
 	tools.subscriptions = store
+	// A local checkout is only meaningful when the poller runs.
+	tools.service.EnableSubscriptionPollingForTest(&SubscriptionPoller{})
 
 	raw, err := tools.HandleRepoFollow(context.Background(), map[string]any{
 		"repo":           "repo",
@@ -144,6 +146,8 @@ func TestHandleRepoFollowRejectsLocalCheckoutWithoutCloneURL(t *testing.T) {
 	}
 	tools := newTestTools(provider, "owner")
 	tools.subscriptions = store
+	// A local checkout is only meaningful when the poller runs.
+	tools.service.EnableSubscriptionPollingForTest(&SubscriptionPoller{})
 
 	_, err := tools.HandleRepoFollow(context.Background(), map[string]any{
 		"repo":           "repo",

--- a/internal/integrations/forge/subscriptions_polling_test.go
+++ b/internal/integrations/forge/subscriptions_polling_test.go
@@ -1,0 +1,114 @@
+package forge
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// newPollingTestTools builds follow-capable tools whose polling state
+// the caller chooses.
+func newPollingTestTools(t *testing.T, pollingEnabled bool) *Tools {
+	t.Helper()
+	provider := &mockProvider{
+		name: "test",
+		getRepositoryResult: &Repository{
+			FullName:      "owner/repo",
+			DefaultBranch: "main",
+			URL:           "https://github.com/owner/repo",
+			CloneURL:      "https://github.com/owner/repo.git",
+		},
+	}
+	tools := newTestTools(provider, "owner")
+	tools.subscriptions = newTestSubscriptionStore(t)
+	if pollingEnabled {
+		tools.service.EnableSubscriptionPollingForTest(&SubscriptionPoller{})
+	}
+	return tools
+}
+
+// TestFollowRefusesCheckoutWhenPollingDisabled covers a promise the
+// site cannot keep. A local checkout is populated by the subscription
+// poller and by nothing else, so with polling disabled the argument
+// names a directory that will never exist. Production hit exactly
+// this: forge_repo_follow returned ok, recorded the path, and no
+// working tree ever appeared — indistinguishable, from the outside,
+// from a clone that failed.
+func TestFollowRefusesCheckoutWhenPollingDisabled(t *testing.T) {
+	t.Parallel()
+
+	tools := newPollingTestTools(t, false)
+	_, err := tools.HandleRepoFollow(context.Background(), map[string]any{
+		"repo":           "repo",
+		"branch":         "main",
+		"local_checkout": t.TempDir(),
+		"wake_loop":      map[string]any{"name": "repo_curator"},
+	})
+	if err == nil {
+		t.Fatal("HandleRepoFollow() accepted a checkout that nothing will populate")
+	}
+	for _, want := range []string{"polling is disabled", "subscription_check_interval", "without local_checkout"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error = %q\nmissing %q", err.Error(), want)
+		}
+	}
+}
+
+// TestFollowWarnsWhenSubscriptionIsInert keeps the bare subscription
+// allowed — the record becomes live when an operator enables polling —
+// while refusing to let it pass as working. A caller told only "ok"
+// would reasonably expect wakes that cannot arrive.
+func TestFollowWarnsWhenSubscriptionIsInert(t *testing.T) {
+	t.Parallel()
+
+	tools := newPollingTestTools(t, false)
+	raw, err := tools.HandleRepoFollow(context.Background(), map[string]any{
+		"repo":          "repo",
+		"track_commits": true,
+		"wake_loop":     map[string]any{"name": "repo_curator"},
+	})
+	if err != nil {
+		t.Fatalf("HandleRepoFollow() = %v, want the subscription stored", err)
+	}
+	var resp struct {
+		SubscriptionID string `json:"subscription_id"`
+		Warning        string `json:"warning"`
+	}
+	if err := json.Unmarshal([]byte(raw), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if resp.SubscriptionID == "" {
+		t.Error("subscription was not stored")
+	}
+	for _, want := range []string{"inert", "subscription_check_interval"} {
+		if !strings.Contains(resp.Warning, want) {
+			t.Errorf("warning = %q\nmissing %q", resp.Warning, want)
+		}
+	}
+}
+
+// TestFollowSilentWhenPollingLive keeps the caveat off the ordinary
+// path — a warning that always fires is one nobody reads.
+func TestFollowSilentWhenPollingLive(t *testing.T) {
+	t.Parallel()
+
+	tools := newPollingTestTools(t, true)
+	raw, err := tools.HandleRepoFollow(context.Background(), map[string]any{
+		"repo":          "repo",
+		"track_commits": true,
+		"wake_loop":     map[string]any{"name": "repo_curator"},
+	})
+	if err != nil {
+		t.Fatalf("HandleRepoFollow: %v", err)
+	}
+	var resp struct {
+		Warning string `json:"warning"`
+	}
+	if err := json.Unmarshal([]byte(raw), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if resp.Warning != "" {
+		t.Errorf("warning = %q, want none when polling is live", resp.Warning)
+	}
+}

--- a/internal/integrations/forge/subscriptions_polling_test.go
+++ b/internal/integrations/forge/subscriptions_polling_test.go
@@ -7,6 +7,14 @@ import (
 	"testing"
 )
 
+// enablePollingForTest marks polling live without standing up a real
+// poller. It lives in a test file rather than on Service: production
+// has no reason to swap a configured poller after construction, and an
+// exported setter would let a caller silently disable one.
+func enablePollingForTest(s *Service) {
+	s.poller = &SubscriptionPoller{}
+}
+
 // newPollingTestTools builds follow-capable tools whose polling state
 // the caller chooses.
 func newPollingTestTools(t *testing.T, pollingEnabled bool) *Tools {
@@ -23,7 +31,7 @@ func newPollingTestTools(t *testing.T, pollingEnabled bool) *Tools {
 	tools := newTestTools(provider, "owner")
 	tools.subscriptions = newTestSubscriptionStore(t)
 	if pollingEnabled {
-		tools.service.EnableSubscriptionPollingForTest(&SubscriptionPoller{})
+		enablePollingForTest(tools.service)
 	}
 	return tools
 }
@@ -78,8 +86,20 @@ func TestFollowWarnsWhenSubscriptionIsInert(t *testing.T) {
 	if err := json.Unmarshal([]byte(raw), &resp); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
+	// Read it back rather than trusting the response: a returned ID
+	// proves the handler built a reply, not that anything persisted.
+	// Deleting the store write would leave a response-only assertion
+	// green, and "stored but inert" is precisely the behavior this
+	// test exists to protect.
 	if resp.SubscriptionID == "" {
-		t.Error("subscription was not stored")
+		t.Fatal("response carried no subscription id")
+	}
+	stored, err := tools.subscriptions.Get(resp.SubscriptionID)
+	if err != nil {
+		t.Fatalf("subscription %q was not persisted: %v", resp.SubscriptionID, err)
+	}
+	if stored.Repo == "" {
+		t.Errorf("persisted subscription is empty: %+v", stored)
 	}
 	for _, want := range []string{"inert", "subscription_check_interval"} {
 		if !strings.Contains(resp.Warning, want) {

--- a/internal/integrations/forge/tools_subscriptions.go
+++ b/internal/integrations/forge/tools_subscriptions.go
@@ -25,6 +25,13 @@ type repoFollowResponse struct {
 	LatestRelease  string                  `json:"latest_release,omitempty"`
 	LatestCommit   string                  `json:"latest_commit,omitempty"`
 	LastSyncedSHA  string                  `json:"last_synced_sha,omitempty"`
+
+	// Warning names a condition that makes this subscription inert.
+	// It is part of the success payload rather than an error because
+	// the record is real and becomes live the moment the condition is
+	// fixed — but a caller told only "ok" would reasonably expect
+	// wakes that will never arrive.
+	Warning string `json:"warning,omitempty"`
 }
 
 type repoSubscriptionEntry struct {
@@ -96,6 +103,17 @@ func (t *Tools) HandleRepoFollow(ctx context.Context, args map[string]any) (stri
 	checkoutRemoteURL := ""
 	subscriptionID := SubscriptionID(acct, repo, branch, wakeTarget)
 	if localCheckout != "" {
+		// A local checkout is populated by the subscription poller, so
+		// with polling disabled this argument promises a directory
+		// nothing will ever create. Refused rather than recorded: the
+		// operator goes looking for a working tree, finds nothing, and
+		// has no way to tell a missing clone from a broken one. The
+		// bare subscription is still allowed below with a warning,
+		// because a record that becomes live when polling is enabled
+		// is different from a path that silently never appears.
+		if !t.service.SubscriptionPollingEnabled() {
+			return "", fmt.Errorf("local_checkout cannot be honored: repository polling is disabled at this site (forge.subscription_check_interval is unset or zero), and the checkout is only ever populated by the poller. Set subscription_check_interval to enable polling, or follow the repository without local_checkout")
+		}
 		if branch == "" {
 			return "", fmt.Errorf("local_checkout requires branch because repository %s has no default branch; set branch", repo)
 		}
@@ -181,6 +199,7 @@ func (t *Tools) HandleRepoFollow(ctx context.Context, args map[string]any) (stri
 		LatestRelease:  sub.LatestRelease,
 		LatestCommit:   sub.LatestCommit,
 		LastSyncedSHA:  sub.LastSyncedSHA,
+		Warning:        subscriptionInertWarning(t.service),
 	})
 }
 
@@ -284,4 +303,19 @@ func repositoryCheckoutRemoteURL(meta *Repository) string {
 		return ""
 	}
 	return strings.TrimSpace(meta.CloneURL)
+}
+
+// subscriptionInertWarning returns the caveat to attach to a stored
+// subscription that cannot currently do anything, or "" when polling
+// is live.
+//
+// A subscription's only effect is delivered by the poller: it wakes a
+// loop on new releases and commits, and syncs any local checkout. With
+// polling disabled the record is durable and correct and completely
+// silent, which is the shape most likely to be mistaken for working.
+func subscriptionInertWarning(service *Service) string {
+	if service.SubscriptionPollingEnabled() {
+		return ""
+	}
+	return "Stored, but inert: repository polling is disabled at this site (forge.subscription_check_interval is unset or zero), so this subscription will not wake any loop or sync anything until an operator enables it. The record persists and becomes live at that point."
 }


### PR DESCRIPTION
Follow-up to the production report where `forge_repo_follow` returned ok with `local_checkout: /Users/aimee/Thane/repos/thane-ai-agent` and no working tree ever appeared.

## What was happening

Nothing was broken in the usual sense. The subscription was stored correctly and the path recorded exactly as given. It simply could not happen: a local checkout is populated by the subscription poller and by nothing else, and `forge.subscription_check_interval` is unset at that site, so polling is disabled and no poller loop exists. `OpenMirror` only validates and absolutizes the path — it does not clone.

That failure mode is worse than an error. From the outside it is indistinguishable from a clone that failed, which is where attention goes first, while the actual cause is a config key nobody was looking at.

Distinct from #1391, which fixed the tilde in that same path. This is why the directory would not have appeared even with the path spelled correctly.

## What changed

`local_checkout` is refused when polling is disabled, naming the key to set and offering the alternative. The bare subscription is still accepted — a record that becomes live the moment polling is enabled is a different thing from a path that silently never appears — but the response carries a `warning` saying it is inert, since a caller told only "ok" would reasonably expect wakes that cannot arrive.

The precedent is cc59189d, which rejects dynamic poller definitions under the same condition rather than registering something inert.

## Test plan

- [x] `just ci` green locally
- [x] Checkout refused with polling disabled; error names `subscription_check_interval` and the no-checkout alternative
- [x] Bare subscription still stored, with an inert warning
- [x] No warning on the ordinary path — a caveat that always fires is one nobody reads
- [x] Existing checkout tests now enable polling explicitly; they had been passing only in the configuration where a checkout means nothing