### PR TITLE
Say "not found" when a document is not found

### DIFF
--- a/internal/app/document_roots.go
+++ b/internal/app/document_roots.go
@@ -74,9 +74,16 @@ func (v *documentRootProvenanceVerifier) storeFilename(filename string) string {
 }
 
 func documentSignatureVerificationFromProvenance(result provenance.VerificationResult) documents.SignatureVerification {
+	// Three outcomes, not two. Collapsing "could not check" into
+	// "failed" is what made a killed git subprocess read as a signature
+	// problem, and the document layer words its refusal differently for
+	// each — so the distinction has to survive this boundary.
 	status := documents.SignatureFailed
-	if result.Status == provenance.VerificationTrusted {
+	switch result.Status {
+	case provenance.VerificationTrusted:
 		status = documents.SignatureTrusted
+	case provenance.VerificationUnavailable:
+		status = documents.SignatureUnavailable
 	}
 	return documents.SignatureVerification{
 		Status:  status,

--- a/internal/platform/provenance/verify.go
+++ b/internal/platform/provenance/verify.go
@@ -24,6 +24,14 @@ const (
 	// VerificationFailed means the path could not be tied to trusted
 	// signed history.
 	VerificationFailed VerificationStatus = "failed"
+
+	// VerificationUnavailable marks a check that could not be
+	// completed — git was killed, timed out, or could not be run at
+	// all. It is deliberately not [VerificationFailed]: a check that
+	// did not finish says nothing about whether the content is
+	// trustworthy, and reporting the two identically sends a reader
+	// hunting for a trust problem that may not exist.
+	VerificationUnavailable VerificationStatus = "unavailable"
 )
 
 // VerificationResult summarizes one provenance verification check.
@@ -139,14 +147,14 @@ func (v *Verifier) verifyPathspec(ctx context.Context, pathspec string, requireT
 		statusArgs = append(statusArgs, v.statusExclusions(target)...)
 	}
 	if status, err := v.gitOutput(ctx, false, statusArgs...); err != nil {
-		return failedVerification("", fmt.Sprintf("git status failed: %v", err))
+		return unavailableVerification("", fmt.Sprintf("git status failed: %v", err))
 	} else if strings.TrimSpace(status) != "" {
 		return failedVerification("", "worktree has uncommitted changes for "+target)
 	}
 
 	var commit string
 	if out, err := v.gitOutput(ctx, false, "rev-parse", "--verify", "HEAD^{commit}"); err != nil {
-		return failedVerification("", fmt.Sprintf("git HEAD lookup failed: %v", err))
+		return unavailableVerification("", fmt.Sprintf("git HEAD lookup failed: %v", err))
 	} else {
 		commit = strings.TrimSpace(out)
 	}
@@ -157,7 +165,7 @@ func (v *Verifier) verifyPathspec(ctx context.Context, pathspec string, requireT
 	if requireTracked {
 		out, err := v.gitOutput(ctx, false, "ls-tree", "-r", "--name-only", "HEAD", "--", pathspec)
 		if err != nil {
-			return failedVerification(commit, fmt.Sprintf("git tracked-file lookup failed: %v", err))
+			return unavailableVerification(commit, fmt.Sprintf("git tracked-file lookup failed: %v", err))
 		}
 		if !pathspecListed(out, pathspec) {
 			return failedVerification(commit, "file is not tracked in HEAD: "+pathspec)
@@ -228,6 +236,20 @@ func pathspecIncludes(target, candidate string) bool {
 func failedVerification(commit string, message string) (VerificationResult, error) {
 	result := VerificationResult{
 		Status:  VerificationFailed,
+		Commit:  commit,
+		Message: strings.TrimSpace(message),
+	}
+	return result, errors.New(result.Message)
+}
+
+// unavailableVerification reports that the check could not be run to a
+// verdict. The distinction from [failedVerification] is the whole
+// point: "we asked git and it said no" and "we could not ask git" lead
+// a reader to opposite places, and collapsing them costs a forensic
+// detour every time the host is briefly unwell.
+func unavailableVerification(commit string, message string) (VerificationResult, error) {
+	result := VerificationResult{
+		Status:  VerificationUnavailable,
 		Commit:  commit,
 		Message: strings.TrimSpace(message),
 	}

--- a/internal/platform/provenance/verify.go
+++ b/internal/platform/provenance/verify.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"syscall"
 )
 
 // VerificationStatus describes whether git history currently vouches for
@@ -173,9 +174,25 @@ func (v *Verifier) verifyPathspec(ctx context.Context, pathspec string, requireT
 	}
 
 	if out, err := v.gitOutput(ctx, true, "verify-commit", commit); err != nil {
+		// git verify-commit exits non-zero for a bad or absent signature,
+		// which is a verdict, and also when the process is killed or the
+		// deadline expires, which is not. Only the first belongs in the
+		// seed fallback: running trustedBySeed under a dead context asks
+		// a question that cannot be answered and reads the silence as a
+		// no. Production reported exactly this as "commit signature
+		// verification failed: signal: killed".
+		if interrupted, why := executionInterrupted(ctx, err); interrupted {
+			return unavailableVerification(commit, "commit signature verification could not complete: "+why)
+		}
+
 		// The root's own trust file does not vouch for this commit. Fall back
 		// to the seed set, which the root cannot withdraw — see trustedBySeed.
 		if !trustedBySeed(ctx, v.path, v.seedSigners, commit) {
+			// The fallback itself can be cut short. A seed check that
+			// never finished is not a seed check that said no.
+			if interrupted, why := executionInterrupted(ctx, nil); interrupted {
+				return unavailableVerification(commit, "seed-signer fallback could not complete: "+why)
+			}
 			msg := strings.TrimSpace(out)
 			if msg == "" {
 				msg = err.Error()
@@ -295,4 +312,35 @@ func (v *Verifier) gitOutput(ctx context.Context, verify bool, args ...string) (
 	}
 	combined := strings.TrimSpace(strings.Join([]string{stdout.String(), stderr.String()}, "\n"))
 	return combined, nil
+}
+
+// executionInterrupted reports whether err (or the context) shows that
+// a git invocation was prevented from reaching a verdict, and returns a
+// short reason for the message.
+//
+// The distinction is the whole point of [VerificationUnavailable]. A
+// non-zero exit from git is an answer — a bad signature, an untracked
+// path — and must stay [VerificationFailed]. A process killed by a
+// signal, or a context that expired, produced no answer at all, and
+// reporting that as a failed signature sends the reader hunting a
+// trust problem that may not exist.
+func executionInterrupted(ctx context.Context, err error) (bool, string) {
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return true, ctxErr.Error()
+	}
+	if err == nil {
+		return false, ""
+	}
+	if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
+		return true, err.Error()
+	}
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		// A signal means something killed git mid-flight; an ordinary
+		// non-zero exit code means git decided.
+		if status, ok := exitErr.Sys().(syscall.WaitStatus); ok && status.Signaled() {
+			return true, exitErr.Error()
+		}
+	}
+	return false, ""
 }

--- a/internal/platform/provenance/verify_interrupted_test.go
+++ b/internal/platform/provenance/verify_interrupted_test.go
@@ -1,0 +1,167 @@
+package provenance
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// TestExecutionInterrupted separates a verdict from a non-answer. This
+// is the discrimination the whole unavailable status rests on: git
+// exiting non-zero because a signature is bad is an answer and must
+// stay a failure, while git being killed or a context expiring
+// produced no answer at all.
+func TestExecutionInterrupted(t *testing.T) {
+	t.Parallel()
+
+	// A real signal-killed process, rather than a hand-built error, so
+	// the test tracks what exec actually returns.
+	killed := func(t *testing.T) error {
+		t.Helper()
+		cmd := exec.Command("sh", "-c", "kill -9 $$")
+		err := cmd.Run()
+		if err == nil {
+			t.Skip("could not produce a signal-killed process")
+		}
+		return err
+	}
+
+	// An ordinary non-zero exit — what verify-commit does for a bad
+	// signature.
+	verdict := func(t *testing.T) error {
+		t.Helper()
+		err := exec.Command("sh", "-c", "exit 1").Run()
+		if err == nil {
+			t.Skip("could not produce a non-zero exit")
+		}
+		return err
+	}
+
+	t.Run("signal-killed git is not a verdict", func(t *testing.T) {
+		t.Parallel()
+		got, why := executionInterrupted(context.Background(), killed(t))
+		if !got {
+			t.Errorf("executionInterrupted() = false for a signal-killed process; it would be reported as a failed signature")
+		}
+		if why == "" {
+			t.Error("no reason recorded for the interruption")
+		}
+	})
+
+	t.Run("non-zero exit is a verdict", func(t *testing.T) {
+		t.Parallel()
+		if got, _ := executionInterrupted(context.Background(), verdict(t)); got {
+			t.Error("executionInterrupted() = true for an ordinary non-zero exit; a bad signature would stop being reported as one")
+		}
+	})
+
+	t.Run("expired context is not a verdict", func(t *testing.T) {
+		t.Parallel()
+		ctx, cancel := context.WithTimeout(context.Background(), time.Nanosecond)
+		defer cancel()
+		<-ctx.Done()
+		if got, _ := executionInterrupted(ctx, nil); !got {
+			t.Error("executionInterrupted() = false for an expired context")
+		}
+	})
+
+	t.Run("wrapped deadline error is not a verdict", func(t *testing.T) {
+		t.Parallel()
+		if got, _ := executionInterrupted(context.Background(), errors.New("git: "+context.DeadlineExceeded.Error())); got {
+			t.Log("string-shaped deadline errors are not detected; only wrapped ones are")
+		}
+		wrapped := errors.Join(errors.New("git verify-commit"), context.DeadlineExceeded)
+		if got, _ := executionInterrupted(context.Background(), wrapped); !got {
+			t.Error("executionInterrupted() = false for a wrapped DeadlineExceeded")
+		}
+	})
+
+	t.Run("clean run is not interrupted", func(t *testing.T) {
+		t.Parallel()
+		if got, _ := executionInterrupted(context.Background(), nil); got {
+			t.Error("executionInterrupted() = true with no error and a live context")
+		}
+	})
+}
+
+// TestUnavailableVerificationIsNotFailed pins the two constructors
+// apart. They both refuse, and only one of them means the content is
+// suspect.
+func TestUnavailableVerificationIsNotFailed(t *testing.T) {
+	t.Parallel()
+
+	unavailable, err := unavailableVerification("abc123", "git was killed")
+	if err == nil {
+		t.Fatal("unavailableVerification returned no error; callers would treat the read as trusted")
+	}
+	if unavailable.Status != VerificationUnavailable {
+		t.Errorf("Status = %q, want %q", unavailable.Status, VerificationUnavailable)
+	}
+	if unavailable.Trusted() {
+		t.Error("an unavailable verification must never read as trusted")
+	}
+
+	failed, _ := failedVerification("abc123", "bad signature")
+	if failed.Status != VerificationFailed {
+		t.Errorf("Status = %q, want %q", failed.Status, VerificationFailed)
+	}
+	if failed.Status == unavailable.Status {
+		t.Error("failed and unavailable collapsed into one status")
+	}
+}
+
+// TestVerifyKeepsBadSignatureAsFailed is the other half of the
+// distinction, end to end against a real repository. An unsigned
+// commit is a verdict: git ran, git decided, and the content is not
+// covered by trusted history. Classifying that as "unavailable" would
+// undo the fix in the dangerous direction — it would tell a reader
+// that a genuinely untrusted root was merely unreachable.
+func TestVerifyKeepsBadSignatureAsFailed(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	git := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		cmd.Env = append(cmd.Environ(),
+			"GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@example.com",
+			"GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@example.com")
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	git("init", "-q", "-b", "main")
+	// The verifier requires a repo-local allowed-signers file; an empty
+	// one vouches for nobody, which is what makes the commit below a
+	// clean untrusted verdict rather than a configuration error.
+	if err := os.WriteFile(filepath.Join(dir, ".allowed_signers"), nil, 0o644); err != nil {
+		t.Fatalf("WriteFile signers: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "doc.md"), []byte("body\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	git("add", ".allowed_signers", "doc.md")
+	git("commit", "-qm", "unsigned")
+
+	v, err := NewVerifier(dir, nil, Options{})
+	if err != nil {
+		t.Fatalf("NewVerifier: %v", err)
+	}
+
+	result, err := v.VerifyFile(context.Background(), "doc.md")
+	if err == nil {
+		t.Fatal("Verify() accepted an unsigned commit")
+	}
+	if result.Status != VerificationFailed {
+		t.Errorf("Status = %q, want %q — a completed verdict must not be reported as unavailable",
+			result.Status, VerificationFailed)
+	}
+	if result.Trusted() {
+		t.Error("unsigned commit reported as trusted")
+	}
+}

--- a/internal/state/documents/mutate.go
+++ b/internal/state/documents/mutate.go
@@ -106,14 +106,28 @@ func (s *Store) Read(ctx context.Context, ref string) (*DocumentRecord, error) {
 	if err != nil {
 		return nil, err
 	}
-	if err := s.verifyDocumentForConsumer(ctx, root, relPath, "doc_read"); err != nil {
-		return nil, err
-	}
+	// Existence is settled before trust. This function already answers
+	// "document not found" correctly — it simply never reached those
+	// branches, because verification ran first and a path that was
+	// never written answers "file is not tracked in HEAD". That reads
+	// as a signature problem and sends the reader to check signers,
+	// policy, and root health, all of which are fine; production spent
+	// real forensic effort there for documents that did not exist.
+	//
+	// Only the read path is reordered. The shared verifier still runs
+	// first for writes and injection, where a not-yet-existing file
+	// must be checked rather than waved through — skipping policy for
+	// absent paths would be a bypass, not a courtesy. No content is
+	// served ahead of the trust check either: resolving a path reads
+	// nothing, and readDocumentFile still runs after verification.
 	absPath, err := s.resolveDocumentPath(root, relPath)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil, fmt.Errorf("document not found: %s", ref)
 		}
+		return nil, err
+	}
+	if err := s.verifyDocumentForConsumer(ctx, root, relPath, "doc_read"); err != nil {
 		return nil, err
 	}
 	record, _, _, err := s.readDocumentFile(absPath, root, relPath)

--- a/internal/state/documents/policy.go
+++ b/internal/state/documents/policy.go
@@ -149,11 +149,21 @@ const (
 	// SignatureTrusted means the checked content is clean and covered by
 	// trusted signed git history.
 	SignatureTrusted SignatureStatus = "trusted"
-	// SignatureFailed means signature policy could not verify the checked
-	// content.
+	// SignatureFailed means verification ran and returned a verdict the
+	// policy rejects: an absent or untrusted signature, a dirty
+	// worktree, content not covered by signed history. The check
+	// completed; the content did not pass it.
 	SignatureFailed SignatureStatus = "failed"
-	// SignatureUnavailable means signature verification was requested but
-	// no verifier could be configured.
+	// SignatureUnavailable means verification could not reach a verdict.
+	// That covers both configuration (verification is required but no
+	// verifier could be built) and execution (git was killed, timed
+	// out, or the caller's context expired mid-check).
+	//
+	// It is deliberately distinct from [SignatureFailed]. Both refuse
+	// the content — failing closed is the point of a trust boundary —
+	// but they mean opposite things about the content itself, and a
+	// reader told "failed" for a killed subprocess goes hunting a trust
+	// problem that may not exist.
 	SignatureUnavailable SignatureStatus = "unavailable"
 )
 

--- a/internal/state/documents/read_absence_test.go
+++ b/internal/state/documents/read_absence_test.go
@@ -1,0 +1,108 @@
+package documents
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nugget/thane-ai-agent/internal/platform/database"
+)
+
+func newRequiredRootStore(t *testing.T) (*Store, string) {
+	t.Helper()
+
+	kbDir := filepath.Join(t.TempDir(), "kb")
+	if err := os.MkdirAll(kbDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	db, err := database.OpenMemory()
+	if err != nil {
+		t.Fatalf("OpenMemory: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+
+	store, err := NewStoreWithOptions(db, map[string]string{"kb": kbDir}, nil, StoreOptions{
+		RootPolicies: map[string]RootPolicy{"kb": {
+			Indexing:  true,
+			Authoring: AuthoringManaged,
+			Git:       RootGitPolicy{Enabled: true, VerifySignatures: VerificationRequired},
+		}},
+		RootVerifiers: map[string]RootVerifier{"kb": fakeRootVerifier{}},
+	})
+	if err != nil {
+		t.Fatalf("NewStoreWithOptions: %v", err)
+	}
+	return store, kbDir
+}
+
+// TestReadMissingDocumentReportsNotFound covers the confusion that cost
+// production real forensic time. Reading a document that was never
+// written used to report "blocked by signature policy: file is not
+// tracked in HEAD", which reads as a trust problem and sends the reader
+// to check signers, policy, and root health — all of which were fine.
+// Absence is not a trust verdict, and the answer must say so.
+func TestReadMissingDocumentReportsNotFound(t *testing.T) {
+	t.Parallel()
+
+	store, _ := newRequiredRootStore(t)
+
+	_, err := store.Read(context.Background(), "kb:never/written.md")
+	if err == nil {
+		t.Fatal("Read() of a missing document succeeded")
+	}
+	if !IsNotFound(err) {
+		t.Errorf("IsNotFound(%v) = false; callers cannot distinguish absence from a fault", err)
+	}
+	if strings.Contains(err.Error(), "signature policy") {
+		t.Errorf("error = %q, want absence reported as absence, not as a trust failure", err)
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("error = %q, want it to say the document was not found", err)
+	}
+}
+
+// TestReadStillVerifiesDocumentsThatExist is the other half: the
+// reordering must not become a way to skip verification. A file that is
+// present but untrusted is still refused, and still says why.
+func TestReadStillVerifiesDocumentsThatExist(t *testing.T) {
+	t.Parallel()
+
+	store, kbDir := newRequiredRootStore(t)
+	present := filepath.Join(kbDir, "present.md")
+	if err := os.WriteFile(present, []byte("---\ntitle: Present\n---\n\nbody\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	_, err := store.Read(context.Background(), "kb:present.md")
+	if err == nil {
+		t.Fatal("Read() served an untrusted document from a required-mode root")
+	}
+	if !strings.Contains(err.Error(), "blocked by signature policy") {
+		t.Errorf("error = %q, want the signature policy refusal for content that exists", err)
+	}
+	if IsNotFound(err) {
+		t.Errorf("error = %q, want a trust failure rather than an absence", err)
+	}
+}
+
+// TestVerifyPathStillBlocksMissingFilesInRequiredRoots pins the
+// property I nearly broke while fixing the read path. VerifyPath also
+// guards new-file writes: a path that does not exist yet must still be
+// checked, or writing to an unwritten path would skip policy entirely.
+// The read-side reordering is deliberately scoped to reads for exactly
+// this reason.
+func TestVerifyPathStillBlocksMissingFilesInRequiredRoots(t *testing.T) {
+	t.Parallel()
+
+	store, kbDir := newRequiredRootStore(t)
+
+	err := store.VerifyPath(context.Background(), filepath.Join(kbDir, "subdir", "new-file.md"), "file_tools_write")
+	if err == nil {
+		t.Fatal("VerifyPath() waved through a missing file in a required root — that is a write bypass")
+	}
+	if !strings.Contains(err.Error(), "blocked by signature policy") {
+		t.Errorf("error = %q, want the policy block preserved for the write path", err)
+	}
+}

--- a/internal/state/documents/verification.go
+++ b/internal/state/documents/verification.go
@@ -218,6 +218,15 @@ func (s *Store) handleVerificationFailure(root, relPath, consumer string, result
 		s.logger.Warn("document root signature verification warning", fields...)
 		return nil
 	}
+	// A check that could not run is not a check that failed. Both still
+	// refuse the read — failing closed is the point of a trust boundary
+	// — but they send the reader to different places, and saying
+	// "blocked by signature policy" when git was killed buys an
+	// investigation into signers and history that were never involved.
+	if result.Status == SignatureUnavailable {
+		return fmt.Errorf("document %s:%s could not be verified for %s (refused because this root requires verification, not because the content failed it): %s",
+			root, relPath, consumer, message)
+	}
 	return fmt.Errorf("document %s:%s blocked by signature policy for %s: %s", root, relPath, consumer, message)
 }
 


### PR DESCRIPTION
Production reported `doc_read` failures as `blocked by signature policy: file is not tracked in HEAD` for documents that did not exist. The roots were healthy, the signers were right, the history was clean — the file had simply never been written. The message sent every reader to check trust configuration first, which is the most expensive place to look and the one place nothing was wrong. It cost real forensic time, twice.

## Absence is not a trust verdict

`Store.Read` already answers `document not found` correctly. It never reached those branches, because verification ran first and git — asked about a path that was never written — truthfully reports it is not tracked in HEAD. The read path now settles existence before trust.

**Scoped to reads deliberately.** `VerifyPath` also guards new-file writes, where a not-yet-existing file *must* still be checked. My first version of this fix skipped verification whenever a file was absent, which would have let a write to an unwritten path bypass policy entirely — the existing tests caught it. A test now pins that property directly, so the next attempt meets it as a wall rather than a surprise.

No content is served ahead of the trust check: resolving a path reads nothing, and `readDocumentFile` still runs after verification.

## "Could not check" is not "checked and failed"

Git being killed or timing out mid-verification now yields `VerificationUnavailable` rather than `VerificationFailed`, and the document layer words that refusal differently. The read is still refused — failing closed is the point of a trust boundary — but it says the content could not be verified rather than implying it was verified and found wanting.

Those two send a reader to opposite places. A host briefly under load should not read as a compromised root. Production saw both `signal: killed` and `context deadline exceeded` inside this message.

## Test plan

- [x] `just ci` green locally
- [x] Missing document reports not-found; `IsNotFound` recognizes it; the message no longer says "signature policy"
- [x] A document that exists but is untrusted is still refused with the policy message, and is *not* reported as absent
- [x] `VerifyPath` still blocks missing files in required roots — the write-bypass guard
- [x] Mutation-verified: restoring the original ordering fails the absence test