### PR TITLE
A follow that asks for a checkout gets a checkout

### DIFF
--- a/docs/operating/configuration.md
+++ b/docs/operating/configuration.md
@@ -249,6 +249,13 @@ roots:
     authoring: read_only
 ```
 
+A checkout only stays maintained while repository polling runs.
+`forge_repo_follow` performs the initial clone itself, so the tree
+exists as soon as the follow succeeds, but it is the subscription
+poller that refreshes it — set `forge.subscription_check_interval` to
+a positive number of seconds, or the root above silently serves the
+snapshot taken when it was first followed.
+
 With that configuration, `thanecode:internal/app/new.go` resolves to the
 maintained checkout. Keep checkout roots under `workspace.path`; if a
 read-only root must live elsewhere, also include that directory in

--- a/docs/reference/event-sources.md
+++ b/docs/reference/event-sources.md
@@ -105,13 +105,13 @@ as a read-only mirror checkout by the poller before event delivery. That
 path must be empty or an existing Thane-owned mirror checkout; non-empty
 directories and unmarked git checkouts are refused.
 
-The poller is the only thing that populates a checkout, so
-`local_checkout` requires polling: when `forge.subscription_check_interval`
-is unset or zero the follow is refused rather than recording a path
-nothing will ever create. A subscription without a checkout is still
-accepted under that setting, but it is inert until polling is enabled —
-it wakes no loop and syncs nothing — and the tool says so in its
-response.
+`forge_repo_follow` performs the initial clone itself, so a checkout
+exists on disk when the call returns; a clone that fails fails the
+call rather than storing a path nothing will ever create. The poller
+keeps it current thereafter. With `forge.subscription_check_interval`
+unset or zero the checkout is still created and accurate as of that
+moment, but nothing refreshes it and the subscription wakes no loop —
+the tool says so in its response.
 
 Unlike legacy pollers that start a fresh generic conversation, forge
 subscriptions require `wake_loop`. New `release` and `commit` events are

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -381,11 +381,12 @@ an existing loop, usually one created with `thane_loop_create`
 poller syncs that checkout before delivering repository events. The path
 must be empty or an existing Thane-owned mirror checkout; non-empty
 directories and unmarked git checkouts are refused. Unfollowing leaves
-the checkout on disk. Because the poller is the only thing that
-populates a checkout, `local_checkout` is refused when
-`forge.subscription_check_interval` is unset or zero; a subscription
-without one is still accepted there but stays inert until polling is
-enabled, and says so in its response.
+the checkout on disk. The follow performs the initial clone itself, so
+the working tree exists when the call returns and a failed clone fails
+the call rather than storing a path that never appears. With
+`forge.subscription_check_interval` unset or zero the checkout is still
+created and is accurate as of that moment, but nothing refreshes it and
+the subscription wakes no loop; the response says so.
 
 ## `scheduler` — time-based tasks
 

--- a/internal/integrations/forge/follow_real_clone_test.go
+++ b/internal/integrations/forge/follow_real_clone_test.go
@@ -32,6 +32,7 @@ func TestFollowReallyClonesWorkingTree(t *testing.T) {
 	// A real upstream with one commit on main.
 	upstream := t.TempDir()
 	git(upstream, "init", "-q", "-b", "main")
+	git(upstream, "config", "commit.gpgsign", "false")
 	if err := os.WriteFile(filepath.Join(upstream, "README.md"), []byte("hello\n"), 0o644); err != nil {
 		t.Fatalf("WriteFile: %v", err)
 	}

--- a/internal/integrations/forge/follow_real_clone_test.go
+++ b/internal/integrations/forge/follow_real_clone_test.go
@@ -1,0 +1,87 @@
+package forge
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+// TestFollowReallyClonesWorkingTree exercises the unstubbed path
+// against a local git remote. Every other follow test stubs the
+// syncer, which would keep passing if the real wiring were wrong — and
+// "the tool said ok but no directory appeared" is precisely the bug
+// being fixed, so at least one test has to look at the disk.
+func TestFollowReallyClonesWorkingTree(t *testing.T) {
+	t.Parallel()
+
+	git := func(dir string, args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		cmd.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@example.com",
+			"GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@example.com")
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+
+	// A real upstream with one commit on main.
+	upstream := t.TempDir()
+	git(upstream, "init", "-q", "-b", "main")
+	if err := os.WriteFile(filepath.Join(upstream, "README.md"), []byte("hello\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	git(upstream, "add", "README.md")
+	git(upstream, "commit", "-qm", "initial")
+
+	provider := &mockProvider{
+		name: "test",
+		getRepositoryResult: &Repository{
+			FullName:      "owner/repo",
+			DefaultBranch: "main",
+			URL:           "https://example.invalid/owner/repo",
+			CloneURL:      upstream, // a local path is a valid git remote
+		},
+	}
+	tools := newTestTools(provider, "owner")
+	tools.subscriptions = newTestSubscriptionStore(t)
+	enablePollingForTest(tools.service)
+
+	dest := filepath.Join(t.TempDir(), "checkout")
+	raw, err := tools.HandleRepoFollow(context.Background(), map[string]any{
+		"repo":           "repo",
+		"branch":         "main",
+		"local_checkout": dest,
+		"wake_loop":      map[string]any{"name": "repo_curator"},
+	})
+	if err != nil {
+		t.Fatalf("HandleRepoFollow: %v", err)
+	}
+
+	// The working tree must exist with real content, not just a path.
+	content, err := os.ReadFile(filepath.Join(dest, "README.md"))
+	if err != nil {
+		t.Fatalf("checkout has no working tree: %v", err)
+	}
+	if string(content) != "hello\n" {
+		t.Errorf("README.md = %q, want the upstream content", content)
+	}
+
+	var resp struct {
+		SubscriptionID string `json:"subscription_id"`
+	}
+	if err := json.Unmarshal([]byte(raw), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	stored, err := tools.subscriptions.Get(resp.SubscriptionID)
+	if err != nil {
+		t.Fatalf("subscription not persisted: %v", err)
+	}
+	if stored.LastSyncedSHA == "" {
+		t.Error("LastSyncedSHA empty; the first poll would re-report the whole history as new")
+	}
+}

--- a/internal/integrations/forge/main_test.go
+++ b/internal/integrations/forge/main_test.go
@@ -1,0 +1,23 @@
+package forge
+
+import (
+	"os"
+	"testing"
+)
+
+// TestMain detaches git from the developer's own configuration for
+// every test in this package.
+//
+// The follow tests clone real repositories, so ambient
+// `commit.gpgsign`, `gpg.ssh.program`, hooks, and templates all reach
+// them. A developer whose global config points signing at a managed
+// signer — 1Password's is the common one — fails this suite for
+// reasons that have nothing to do with the code under test. Each
+// fixture configures what it needs locally.
+//
+// Mirrors internal/platform/checkout, which learned this the same way.
+func TestMain(m *testing.M) {
+	os.Setenv("GIT_CONFIG_GLOBAL", os.DevNull)
+	os.Setenv("GIT_CONFIG_SYSTEM", os.DevNull)
+	os.Exit(m.Run())
+}

--- a/internal/integrations/forge/subscription_tool_provider.go
+++ b/internal/integrations/forge/subscription_tool_provider.go
@@ -43,7 +43,7 @@ func (t *Tools) subscriptionToolDefinitions() []*toolpkg.Tool {
 					},
 					"local_checkout": map[string]any{
 						"type":        "string",
-						"description": "Optional absolute or working-directory-relative path to keep as a read-only mirror checkout. Requires repository polling: the poller is the only thing that populates this path, so the call is refused when forge.subscription_check_interval is unset or zero. The path must be empty or an existing Thane-owned mirror checkout; non-empty directories and unmarked git checkouts are refused. The subscription poller syncs this path before waking the loop and leaves it on disk when unfollowed.",
+						"description": "Optional absolute or working-directory-relative path to keep as a read-only mirror checkout. The follow clones into this path before returning, so the working tree exists when the call succeeds and a failed clone fails the call. The poller keeps it current afterwards; with polling disabled it is created but never refreshed. The path must be empty or an existing Thane-owned mirror checkout; non-empty directories and unmarked git checkouts are refused. The subscription poller syncs this path before waking the loop and leaves it on disk when unfollowed.",
 					},
 					"wake_loop": forgeWakeLoopDefinition(),
 				},

--- a/internal/integrations/forge/subscriptions.go
+++ b/internal/integrations/forge/subscriptions.go
@@ -131,6 +131,43 @@ func SubscriptionID(account, repo, branch string, target messages.LoopWakeTarget
 	return hex.EncodeToString(h[:6])
 }
 
+// CheckAdmission reports whether sub would be accepted by [Add],
+// without writing anything.
+//
+// It exists so a caller can find out before doing something it cannot
+// take back. forge_repo_follow clones a working tree for a requested
+// local_checkout, and Mirror.Sync resets that tree hard — discarding
+// local modifications by design. Learning about a duplicate ID or a
+// full subscription table only after that reset means a rejected
+// follow can still have destroyed a directory it then declines to
+// track. Add re-runs these checks itself; this is an early look, not
+// a substitute.
+func (s *SubscriptionStore) CheckAdmission(sub ProjectSubscription) error {
+	if s == nil || s.state == nil {
+		return fmt.Errorf("nil opstate store")
+	}
+	return s.checkAdmission(sub)
+}
+
+func (s *SubscriptionStore) checkAdmission(sub ProjectSubscription) error {
+	if err := validateSubscription(sub); err != nil {
+		return err
+	}
+	ids, err := s.loadIndex()
+	if err != nil {
+		return fmt.Errorf("load subscription index: %w", err)
+	}
+	for _, id := range ids {
+		if id == sub.ID {
+			return fmt.Errorf("subscription %q already exists", sub.ID)
+		}
+	}
+	if len(ids) >= s.maxItems {
+		return fmt.Errorf("forge subscription limit reached (%d/%d)", len(ids), s.maxItems)
+	}
+	return nil
+}
+
 // Add persists a new subscription and appends it to the index.
 func (s *SubscriptionStore) Add(sub ProjectSubscription) error {
 	if s.state == nil {
@@ -143,17 +180,12 @@ func (s *SubscriptionStore) Add(sub ProjectSubscription) error {
 		sub.CreatedAt = time.Now().UTC()
 	}
 
+	if err := s.checkAdmission(sub); err != nil {
+		return err
+	}
 	ids, err := s.loadIndex()
 	if err != nil {
 		return fmt.Errorf("load subscription index: %w", err)
-	}
-	for _, id := range ids {
-		if id == sub.ID {
-			return fmt.Errorf("subscription %q already exists", sub.ID)
-		}
-	}
-	if len(ids) >= s.maxItems {
-		return fmt.Errorf("forge subscription limit reached (%d/%d)", len(ids), s.maxItems)
 	}
 
 	if err := s.write(sub); err != nil {

--- a/internal/integrations/forge/subscriptions_checkout_test.go
+++ b/internal/integrations/forge/subscriptions_checkout_test.go
@@ -37,6 +37,14 @@ func TestHandleRepoFollowStoresLocalCheckout(t *testing.T) {
 	tools.subscriptions = store
 	// A local checkout is only meaningful when the poller runs.
 	enablePollingForTest(tools.service)
+	// The follow now creates the checkout; stub the clone so these
+	// tests keep exercising subscription bookkeeping rather than git.
+	syncedPath := ""
+	tools.checkoutSync = func(_ context.Context, sub ProjectSubscription) (string, error) {
+		syncedPath = sub.CheckoutPath
+		return "synced-head", nil
+	}
+	_ = syncedPath
 
 	raw, err := tools.HandleRepoFollow(context.Background(), map[string]any{
 		"repo":           "repo",
@@ -148,6 +156,14 @@ func TestHandleRepoFollowRejectsLocalCheckoutWithoutCloneURL(t *testing.T) {
 	tools.subscriptions = store
 	// A local checkout is only meaningful when the poller runs.
 	enablePollingForTest(tools.service)
+	// The follow now creates the checkout; stub the clone so these
+	// tests keep exercising subscription bookkeeping rather than git.
+	syncedPath := ""
+	tools.checkoutSync = func(_ context.Context, sub ProjectSubscription) (string, error) {
+		syncedPath = sub.CheckoutPath
+		return "synced-head", nil
+	}
+	_ = syncedPath
 
 	_, err := tools.HandleRepoFollow(context.Background(), map[string]any{
 		"repo":           "repo",

--- a/internal/integrations/forge/subscriptions_polling_test.go
+++ b/internal/integrations/forge/subscriptions_polling_test.go
@@ -3,6 +3,7 @@ package forge
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"strings"
 	"testing"
 )
@@ -34,33 +35,6 @@ func newPollingTestTools(t *testing.T, pollingEnabled bool) *Tools {
 		enablePollingForTest(tools.service)
 	}
 	return tools
-}
-
-// TestFollowRefusesCheckoutWhenPollingDisabled covers a promise the
-// site cannot keep. A local checkout is populated by the subscription
-// poller and by nothing else, so with polling disabled the argument
-// names a directory that will never exist. Production hit exactly
-// this: forge_repo_follow returned ok, recorded the path, and no
-// working tree ever appeared — indistinguishable, from the outside,
-// from a clone that failed.
-func TestFollowRefusesCheckoutWhenPollingDisabled(t *testing.T) {
-	t.Parallel()
-
-	tools := newPollingTestTools(t, false)
-	_, err := tools.HandleRepoFollow(context.Background(), map[string]any{
-		"repo":           "repo",
-		"branch":         "main",
-		"local_checkout": t.TempDir(),
-		"wake_loop":      map[string]any{"name": "repo_curator"},
-	})
-	if err == nil {
-		t.Fatal("HandleRepoFollow() accepted a checkout that nothing will populate")
-	}
-	for _, want := range []string{"polling is disabled", "subscription_check_interval", "without local_checkout"} {
-		if !strings.Contains(err.Error(), want) {
-			t.Errorf("error = %q\nmissing %q", err.Error(), want)
-		}
-	}
 }
 
 // TestFollowWarnsWhenSubscriptionIsInert keeps the bare subscription
@@ -130,5 +104,132 @@ func TestFollowSilentWhenPollingLive(t *testing.T) {
 	}
 	if resp.Warning != "" {
 		t.Errorf("warning = %q, want none when polling is live", resp.Warning)
+	}
+}
+
+// TestFollowCreatesTheCheckoutItPromises is the behavior the tool
+// always implied and never delivered. checkout.OpenMirror is lazy by
+// contract — it resolves a path and touches no disk, which is right
+// for building many mirrors at startup and wrong for a caller who
+// just asked for a working tree. Nothing created the checkout until
+// the first poll, and where polling is disabled, never: production
+// followed a repository, got ok back, and found no directory.
+func TestFollowCreatesTheCheckoutItPromises(t *testing.T) {
+	t.Parallel()
+
+	tools := newPollingTestTools(t, true)
+	var synced ProjectSubscription
+	tools.checkoutSync = func(_ context.Context, sub ProjectSubscription) (string, error) {
+		synced = sub
+		return "deadbeef", nil
+	}
+
+	dir := t.TempDir()
+	raw, err := tools.HandleRepoFollow(context.Background(), map[string]any{
+		"repo":           "repo",
+		"branch":         "main",
+		"local_checkout": dir,
+		"wake_loop":      map[string]any{"name": "repo_curator"},
+	})
+	if err != nil {
+		t.Fatalf("HandleRepoFollow: %v", err)
+	}
+	if synced.CheckoutPath == "" {
+		t.Fatal("follow returned without creating the checkout it was asked for")
+	}
+	if synced.CheckoutRemoteURL == "" || synced.Branch != "main" {
+		t.Errorf("sync got an underspecified subscription: %+v", synced)
+	}
+
+	// The head the initial sync reported is recorded, so the first poll
+	// compares against reality instead of re-reporting the whole
+	// history as new.
+	var resp struct {
+		SubscriptionID string `json:"subscription_id"`
+		LocalCheckout  string `json:"local_checkout"`
+	}
+	if err := json.Unmarshal([]byte(raw), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	stored, err := tools.subscriptions.Get(resp.SubscriptionID)
+	if err != nil {
+		t.Fatalf("subscription not persisted: %v", err)
+	}
+	if stored.LastSyncedSHA != "deadbeef" {
+		t.Errorf("LastSyncedSHA = %q, want the initial sync head", stored.LastSyncedSHA)
+	}
+	if resp.LocalCheckout == "" {
+		t.Error("response omits the checkout path")
+	}
+}
+
+// TestFollowDoesNotPersistWhenCheckoutFails keeps the failure honest.
+// A subscription pointing at a checkout that could not be made is the
+// phantom path this whole fix exists to remove, so a failed clone
+// fails the call rather than persisting a promise.
+func TestFollowDoesNotPersistWhenCheckoutFails(t *testing.T) {
+	t.Parallel()
+
+	tools := newPollingTestTools(t, true)
+	tools.checkoutSync = func(_ context.Context, _ ProjectSubscription) (string, error) {
+		return "", errors.New("remote: Repository not found")
+	}
+
+	_, err := tools.HandleRepoFollow(context.Background(), map[string]any{
+		"repo":           "repo",
+		"branch":         "main",
+		"local_checkout": t.TempDir(),
+		"wake_loop":      map[string]any{"name": "repo_curator"},
+	})
+	if err == nil {
+		t.Fatal("HandleRepoFollow() reported success after the checkout failed")
+	}
+	if !strings.Contains(err.Error(), "create local checkout") {
+		t.Errorf("error = %q, want it to name the checkout as the failure", err)
+	}
+	subs, listErr := tools.subscriptions.List()
+	if listErr != nil {
+		t.Fatalf("List: %v", listErr)
+	}
+	if len(subs) != 0 {
+		t.Errorf("stored %d subscriptions after a failed checkout; want none", len(subs))
+	}
+}
+
+// TestFollowCreatesCheckoutEvenWithPollingDisabled covers the case
+// production actually hit. The checkout is made now and is accurate
+// now; what polling adds is that it keeps up. Refusing outright (the
+// previous behavior) denied a caller something the tool can plainly
+// do, so the caveat moved into the warning.
+func TestFollowCreatesCheckoutEvenWithPollingDisabled(t *testing.T) {
+	t.Parallel()
+
+	tools := newPollingTestTools(t, false)
+	called := false
+	tools.checkoutSync = func(_ context.Context, _ ProjectSubscription) (string, error) {
+		called = true
+		return "deadbeef", nil
+	}
+
+	raw, err := tools.HandleRepoFollow(context.Background(), map[string]any{
+		"repo":           "repo",
+		"branch":         "main",
+		"local_checkout": t.TempDir(),
+		"wake_loop":      map[string]any{"name": "repo_curator"},
+	})
+	if err != nil {
+		t.Fatalf("HandleRepoFollow: %v", err)
+	}
+	if !called {
+		t.Error("checkout was not created when polling is disabled")
+	}
+	var resp struct {
+		Warning string `json:"warning"`
+	}
+	if err := json.Unmarshal([]byte(raw), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !strings.Contains(resp.Warning, "will not refresh") {
+		t.Errorf("warning = %q, want it to say the checkout will not stay current", resp.Warning)
 	}
 }

--- a/internal/integrations/forge/subscriptions_polling_test.go
+++ b/internal/integrations/forge/subscriptions_polling_test.go
@@ -233,3 +233,53 @@ func TestFollowCreatesCheckoutEvenWithPollingDisabled(t *testing.T) {
 		t.Errorf("warning = %q, want it to say the checkout will not stay current", resp.Warning)
 	}
 }
+
+// TestSubscriptionListingWarnsWhenInert covers the reader who did not
+// create these rows. The listing is where someone goes to find out
+// whether a subscription is working, and without the caveat there it
+// shows a healthy-looking set of records that will never fire.
+func TestSubscriptionListingWarnsWhenInert(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name        string
+		polling     bool
+		wantWarning bool
+	}{
+		{name: "polling disabled warns", polling: false, wantWarning: true},
+		{name: "polling live stays quiet", polling: true, wantWarning: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			tools := newPollingTestTools(t, tc.polling)
+			tools.checkoutSync = func(_ context.Context, _ ProjectSubscription) (string, error) {
+				return "deadbeef", nil
+			}
+			if _, err := tools.HandleRepoFollow(context.Background(), map[string]any{
+				"repo":          "repo",
+				"track_commits": true,
+				"wake_loop":     map[string]any{"name": "repo_curator"},
+			}); err != nil {
+				t.Fatalf("HandleRepoFollow: %v", err)
+			}
+
+			raw, err := tools.HandleRepoSubscriptions(context.Background(), nil)
+			if err != nil {
+				t.Fatalf("HandleRepoSubscriptions: %v", err)
+			}
+			var resp struct {
+				Count   int    `json:"count"`
+				Warning string `json:"warning"`
+			}
+			if err := json.Unmarshal([]byte(raw), &resp); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			if resp.Count != 1 {
+				t.Fatalf("count = %d, want the stored subscription listed", resp.Count)
+			}
+			if got := resp.Warning != ""; got != tc.wantWarning {
+				t.Errorf("warning present = %v, want %v (warning=%q)", got, tc.wantWarning, resp.Warning)
+			}
+		})
+	}
+}

--- a/internal/integrations/forge/subscriptions_polling_test.go
+++ b/internal/integrations/forge/subscriptions_polling_test.go
@@ -283,3 +283,46 @@ func TestSubscriptionListingWarnsWhenInert(t *testing.T) {
 		})
 	}
 }
+
+// TestFollowDoesNotTouchDiskWhenRejected covers the ordering that made
+// a rejected follow destructive. Mirror.Sync resets the working tree
+// hard, discarding local modifications by design, so running it before
+// the store agrees to take the subscription meant a duplicate ID or a
+// full table could wipe a directory and then decline to track it.
+func TestFollowDoesNotTouchDiskWhenRejected(t *testing.T) {
+	t.Parallel()
+
+	tools := newPollingTestTools(t, true)
+	syncCalls := 0
+	tools.checkoutSync = func(_ context.Context, _ ProjectSubscription) (string, error) {
+		syncCalls++
+		return "deadbeef", nil
+	}
+
+	args := map[string]any{
+		"repo":           "repo",
+		"branch":         "main",
+		"local_checkout": t.TempDir(),
+		"wake_loop":      map[string]any{"name": "repo_curator"},
+	}
+
+	if _, err := tools.HandleRepoFollow(context.Background(), args); err != nil {
+		t.Fatalf("first follow: %v", err)
+	}
+	if syncCalls != 1 {
+		t.Fatalf("syncCalls = %d after the first follow, want 1", syncCalls)
+	}
+
+	// The same repo/branch/wake target yields the same subscription ID,
+	// so this is refused as a duplicate.
+	_, err := tools.HandleRepoFollow(context.Background(), args)
+	if err == nil {
+		t.Fatal("duplicate follow succeeded")
+	}
+	if !strings.Contains(err.Error(), "already exists") {
+		t.Errorf("error = %q, want the duplicate refusal", err)
+	}
+	if syncCalls != 1 {
+		t.Errorf("syncCalls = %d; the rejected follow reset a working tree it then refused to track", syncCalls)
+	}
+}

--- a/internal/integrations/forge/tools.go
+++ b/internal/integrations/forge/tools.go
@@ -23,6 +23,13 @@ type Tools struct {
 	logger        *slog.Logger
 	subscriptions *SubscriptionStore
 	loopResolver  messages.LoopResolver
+
+	// checkoutSync performs the initial mirror sync when a follow
+	// requests a local checkout. Injectable so tests can exercise the
+	// follow path without a network clone; production uses the same
+	// syncer the poller does, so the checkout a follow creates and the
+	// one the poller maintains are made by identical code.
+	checkoutSync func(context.Context, ProjectSubscription) (string, error)
 }
 
 // NewTools creates standalone forge tools backed by the given manager. New
@@ -43,6 +50,7 @@ func newTools(service *Service, opLog *OperationLog, logger *slog.Logger, subscr
 		opLog:         opLog,
 		logger:        logger,
 		subscriptions: subscriptions,
+		checkoutSync:  mirrorSubscriptionCheckoutSyncer{logger: logger}.Sync,
 	}
 }
 

--- a/internal/integrations/forge/tools_subscriptions.go
+++ b/internal/integrations/forge/tools_subscriptions.go
@@ -55,6 +55,12 @@ type repoSubscriptionEntry struct {
 type repoSubscriptionsResponse struct {
 	Count         int                     `json:"count"`
 	Subscriptions []repoSubscriptionEntry `json:"subscriptions"`
+
+	// Warning repeats the inert-subscription caveat on the listing.
+	// A reader who did not make these rows has no other way to learn
+	// that none of them will fire, and the listing is where someone
+	// goes to find out whether a subscription is working.
+	Warning string `json:"warning,omitempty"`
 }
 
 type repoUnfollowResponse struct {
@@ -180,6 +186,10 @@ func (t *Tools) HandleRepoFollow(ctx context.Context, args map[string]any) (stri
 	// Synced before the record is stored: a subscription pointing at a
 	// checkout that could not be made is the phantom path this fixes,
 	// so a failed clone fails the call instead of persisting a promise.
+	// Doing it here also keeps the failure attached to the moment that
+	// can act on it — the caller still holds the repository, the path,
+	// and the reason it asked. Deferred to the first poll, the same
+	// error surfaces hours later in a loop that knows none of that.
 	if strings.TrimSpace(sub.CheckoutPath) != "" && t.checkoutSync != nil {
 		head, err := t.checkoutSync(ctx, sub)
 		if err != nil {
@@ -193,6 +203,19 @@ func (t *Tools) HandleRepoFollow(ctx context.Context, args map[string]any) (stri
 	}
 
 	t.recordOp("forge_repo_follow", acct, repo, sub.ID)
+	// The agent gets this in its response; the operator gets it here.
+	// Whoever set subscription_check_interval to zero is not the one
+	// reading tool output, and a subscription that quietly does nothing
+	// is exactly what they would want to know they just created.
+	if warning := subscriptionInertWarning(t.service); warning != "" && t.logger != nil {
+		t.logger.Warn("forge subscription created while repository polling is disabled",
+			"subscription_id", sub.ID,
+			"repo", sub.Repo,
+			"account", sub.Account,
+			"local_checkout", sub.CheckoutPath,
+			"detail", warning)
+	}
+
 	return marshalResponse(repoFollowResponse{
 		SubscriptionID: sub.ID,
 		Account:        sub.Account,
@@ -291,6 +314,7 @@ func (t *Tools) HandleRepoSubscriptions(ctx context.Context, _ map[string]any) (
 	return marshalResponse(repoSubscriptionsResponse{
 		Count:         len(entries),
 		Subscriptions: entries,
+		Warning:       subscriptionInertWarning(t.service),
 	})
 }
 

--- a/internal/integrations/forge/tools_subscriptions.go
+++ b/internal/integrations/forge/tools_subscriptions.go
@@ -103,17 +103,6 @@ func (t *Tools) HandleRepoFollow(ctx context.Context, args map[string]any) (stri
 	checkoutRemoteURL := ""
 	subscriptionID := SubscriptionID(acct, repo, branch, wakeTarget)
 	if localCheckout != "" {
-		// A local checkout is populated by the subscription poller, so
-		// with polling disabled this argument promises a directory
-		// nothing will ever create. Refused rather than recorded: the
-		// operator goes looking for a working tree, finds nothing, and
-		// has no way to tell a missing clone from a broken one. The
-		// bare subscription is still allowed below with a warning,
-		// because a record that becomes live when polling is enabled
-		// is different from a path that silently never appears.
-		if !t.service.SubscriptionPollingEnabled() {
-			return "", fmt.Errorf("local_checkout cannot be honored: repository polling is disabled at this site (forge.subscription_check_interval is unset or zero), and the checkout is only ever populated by the poller. Set subscription_check_interval to enable polling, or follow the repository without local_checkout")
-		}
 		if branch == "" {
 			return "", fmt.Errorf("local_checkout requires branch because repository %s has no default branch; set branch", repo)
 		}
@@ -178,6 +167,25 @@ func (t *Tools) HandleRepoFollow(ctx context.Context, args map[string]any) (stri
 			sub.LastCommit = commits[0].SHA
 			sub.LatestCommit = commitTitle(commits[0])
 		}
+	}
+
+	// Asking for a local checkout is asking for a working tree, so the
+	// follow makes one rather than filing an intention. OpenMirror is
+	// lazy by contract — it resolves a path and touches no disk, which
+	// is right for constructing many mirrors at startup and wrong here
+	// — so nothing created the checkout until the first poll, and where
+	// polling is disabled, never. Production followed a repository,
+	// got ok, and found no directory.
+	//
+	// Synced before the record is stored: a subscription pointing at a
+	// checkout that could not be made is the phantom path this fixes,
+	// so a failed clone fails the call instead of persisting a promise.
+	if strings.TrimSpace(sub.CheckoutPath) != "" && t.checkoutSync != nil {
+		head, err := t.checkoutSync(ctx, sub)
+		if err != nil {
+			return "", fmt.Errorf("create local checkout at %s: %w", sub.CheckoutPath, err)
+		}
+		sub.LastSyncedSHA = head
 	}
 
 	if err := t.subscriptions.Add(sub); err != nil {
@@ -317,5 +325,5 @@ func subscriptionInertWarning(service *Service) string {
 	if service.SubscriptionPollingEnabled() {
 		return ""
 	}
-	return "Stored, but inert: repository polling is disabled at this site (forge.subscription_check_interval is unset or zero), so this subscription will not wake any loop or sync anything until an operator enables it. The record persists and becomes live at that point."
+	return "Stored, but inert: repository polling is disabled at this site (forge.subscription_check_interval is unset or zero), so this subscription will not wake any loop until an operator enables it. Any local checkout was created now and is current as of this moment, but it will not refresh. The record persists and becomes live when polling is enabled."
 }

--- a/internal/integrations/forge/tools_subscriptions.go
+++ b/internal/integrations/forge/tools_subscriptions.go
@@ -190,6 +190,16 @@ func (t *Tools) HandleRepoFollow(ctx context.Context, args map[string]any) (stri
 	// can act on it — the caller still holds the repository, the path,
 	// and the reason it asked. Deferred to the first poll, the same
 	// error surfaces hours later in a loop that knows none of that.
+	// Nothing irreversible before the store agrees to take this. A
+	// duplicate ID or a full table would otherwise be discovered after
+	// the clone, and Mirror.Sync resets the tree hard — so a rejected
+	// follow could destroy a working directory it then declines to
+	// track. Add re-checks; this is the early look that keeps the
+	// destructive step from running first.
+	if err := t.subscriptions.CheckAdmission(sub); err != nil {
+		return "", err
+	}
+
 	if strings.TrimSpace(sub.CheckoutPath) != "" && t.checkoutSync != nil {
 		head, err := t.checkoutSync(ctx, sub)
 		if err != nil {
@@ -314,7 +324,7 @@ func (t *Tools) HandleRepoSubscriptions(ctx context.Context, _ map[string]any) (
 	return marshalResponse(repoSubscriptionsResponse{
 		Count:         len(entries),
 		Subscriptions: entries,
-		Warning:       subscriptionInertWarning(t.service),
+		Warning:       subscriptionListingInertWarning(t.service, len(entries)),
 	})
 }
 
@@ -345,6 +355,19 @@ func repositoryCheckoutRemoteURL(meta *Repository) string {
 // loop on new releases and commits, and syncs any local checkout. With
 // polling disabled the record is durable and correct and completely
 // silent, which is the shape most likely to be mistaken for working.
+// subscriptionListingInertWarning is the listing's version of the
+// caveat. It differs from the follow's in two ways that matter to a
+// reader: a listed checkout reflects its last successful sync rather
+// than this moment, and an empty listing has nothing to caveat — a
+// warning attached to zero rows (an account filter matching nothing,
+// say) describes a problem the reader does not have.
+func subscriptionListingInertWarning(service *Service, listed int) string {
+	if listed == 0 || service.SubscriptionPollingEnabled() {
+		return ""
+	}
+	return "Repository polling is disabled at this site (forge.subscription_check_interval is unset or zero), so none of these subscriptions will wake a loop, and any local checkout reflects its last successful sync rather than the current remote. The records persist and become live when polling is enabled."
+}
+
 func subscriptionInertWarning(service *Service) string {
 	if service.SubscriptionPollingEnabled() {
 		return ""


### PR DESCRIPTION
Root cause of the production report where `forge_repo_follow` returned ok with a `local_checkout` and no directory ever appeared. It was a scope gap, not a bug in anything that ran.

## Why nothing created it

`checkout.OpenMirror` is lazy by contract — its own doc comment says the repository "is created lazily by `Mirror.Sync` so callers can construct mirrors during startup without touching disk until the first sync pass." That is correct for building many mirrors at boot, and wrong for `forge_repo_follow`, whose caller is asking for a working tree *now*.

The follow validated the path, recorded the subscription, and returned. Nothing in that path creates a directory. The first poller pass would have — but polling is disabled at that site, so never. Both halves had to be true to produce silence, which is why the earlier investigation stopped at the polling half.

## What changed

The follow performs the initial sync itself, using the same syncer the poller uses, so the tree a follow creates and the tree the poller maintains are made by identical code. It syncs *before* storing: a subscription pointing at a checkout that could not be made is the phantom path this whole thread was about, so a failed clone fails the call rather than persisting a promise. The resulting head is recorded, so the first poll compares against reality instead of re-reporting the entire history as new.

## This retires the refusal from #1392

#1392 refused `local_checkout` when polling was disabled. That was the right shape for a tool that *could not* create checkouts — don't promise what the site can't deliver — and it is the wrong shape now that it can. What polling adds is not existence but freshness, so the caveat moved into the warning: created and accurate now, will not refresh until polling is enabled. Docs and the tool schema updated to match.

## Test plan

- [x] `just ci` green locally
- [x] Follow creates the checkout, records `LastSyncedSHA`, and passes a fully-specified subscription to the syncer
- [x] A failed clone fails the call and persists nothing
- [x] Checkout is created with polling disabled, with a "will not refresh" warning
- [x] **One test clones a real local git repo and reads the file off disk** — every stubbed test would keep passing if the wiring were wrong, and "said ok, no directory" is the bug
- [x] Mutation-verified: removing the sync call fails three tests