### PR TITLE
A silent stream error, and a window too small to answer in

### DIFF
--- a/internal/model/fleet/providers/lmstudio.go
+++ b/internal/model/fleet/providers/lmstudio.go
@@ -247,6 +247,7 @@ func (c *LMStudioClient) handleStreaming(ctx context.Context, requestedModel str
 		usage          lmStudioUsage
 		toolAcc        = make(map[int]*lmStudioToolAccumulator)
 		done           bool
+		chunks         int
 	)
 
 	processEvent := func(data string) error {
@@ -256,11 +257,19 @@ func (c *LMStudioClient) handleStreaming(ctx context.Context, requestedModel str
 		if data == "[DONE]" {
 			return io.EOF
 		}
+		// An error frame decodes cleanly into lmStudioChatResponse — every
+		// field it carries is unknown to that type — so it would otherwise
+		// pass through as a chunk contributing nothing, turning an upstream
+		// failure into a silently empty completion. Check for it first.
+		if errText := lmStudioStreamErrorText(data); errText != "" {
+			return fmt.Errorf("stream error: %s", errText)
+		}
 
 		var chunk lmStudioChatResponse
 		if err := json.Unmarshal([]byte(data), &chunk); err != nil {
 			return fmt.Errorf("decode stream chunk: %w", err)
 		}
+		chunks++
 		if chunk.Model != "" {
 			model = chunk.Model
 		}
@@ -331,6 +340,14 @@ func (c *LMStudioClient) handleStreaming(ctx context.Context, requestedModel str
 		if err := processEvent(strings.Join(eventLines, "\n")); err != nil && err != io.EOF {
 			return nil, err
 		}
+	}
+
+	// A stream that carried no chunks at all never produced a completion,
+	// however cleanly it closed. Reporting success here would hand the
+	// caller a well-formed zero-token response and hide the failure; the
+	// non-streaming path rejects its equivalent for the same reason.
+	if chunks == 0 {
+		return nil, fmt.Errorf("LM Studio returned an empty stream for model %q", requestedModel)
 	}
 
 	toolCalls, err := decodeLMStudioToolCalls(toolAcc)

--- a/internal/model/fleet/providers/lmstudio_test.go
+++ b/internal/model/fleet/providers/lmstudio_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -600,5 +601,92 @@ func TestLMStudioChatStream_DefaultsAssistantRoleWhenStreamOmitsIt(t *testing.T)
 	}
 	if len(resp.Message.ToolCalls) != 1 {
 		t.Fatalf("len(tool_calls) = %d, want 1", len(resp.Message.ToolCalls))
+	}
+}
+
+// The failure this guards against was observed in production: LM Studio
+// answers a streaming request it cannot serve with HTTP 200 and an
+// `event: error` frame, where the non-streaming call would have answered
+// 400. The frame decodes cleanly into lmStudioChatResponse, so before this
+// was handled the upstream failure surfaced as a successful zero-token
+// completion and the agent's context-reload recovery never fired.
+func TestLMStudioChatStream_SurfacesErrorFrame(t *testing.T) {
+	t.Parallel()
+
+	const upstream = "The number of tokens to keep from the initial prompt is greater than the context length. Try to load the model with a larger context length, or provide a shorter input"
+
+	tests := []struct {
+		name string
+		body string
+	}{
+		{
+			name: "event error frame with object payload",
+			body: "event: error\ndata: {\"error\":{\"message\":" + strconv.Quote(upstream) + "},\"message\":" + strconv.Quote(upstream) + "}\n\n",
+		},
+		{
+			name: "data frame with string payload",
+			body: "data: {\"error\":" + strconv.Quote(upstream) + "}\n\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "text/event-stream")
+				fmt.Fprint(w, tt.body)
+			}))
+			defer srv.Close()
+
+			client := NewLMStudioClient(srv.URL, "", nil)
+			resp, err := client.ChatStream(context.Background(), "qwen/qwen3-coder-next",
+				[]llm.Message{{Role: "user", Content: "summarize the repository"}}, nil,
+				func(llm.StreamEvent) {})
+			if err == nil {
+				t.Fatalf("ChatStream() error = nil, want stream error (resp = %+v)", resp)
+			}
+			if !strings.Contains(err.Error(), upstream) {
+				t.Fatalf("ChatStream() error = %q, want it to carry the upstream text verbatim", err)
+			}
+		})
+	}
+}
+
+// A stream can also close cleanly having delivered nothing at all. That is
+// not a completion either, and reporting success would hand the caller a
+// well-formed zero-token response.
+func TestLMStudioChatStream_ChunklessStreamErrors(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		body string
+	}{
+		{name: "empty body", body: ""},
+		{name: "done with no chunks", body: "data: [DONE]\n\n"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "text/event-stream")
+				fmt.Fprint(w, tt.body)
+			}))
+			defer srv.Close()
+
+			client := NewLMStudioClient(srv.URL, "", nil)
+			_, err := client.ChatStream(context.Background(), "qwen/qwen3-coder-next",
+				[]llm.Message{{Role: "user", Content: "summarize the repository"}}, nil,
+				func(llm.StreamEvent) {})
+			if err == nil {
+				t.Fatal("ChatStream() error = nil, want empty stream error")
+			}
+			if !strings.Contains(err.Error(), "empty stream") {
+				t.Fatalf("ChatStream() error = %q, want empty stream message", err)
+			}
+		})
 	}
 }

--- a/internal/model/fleet/providers/lmstudio_wire.go
+++ b/internal/model/fleet/providers/lmstudio_wire.go
@@ -91,6 +91,44 @@ type lmStudioChatResponse struct {
 	Usage   *lmStudioUsage       `json:"usage,omitempty"`
 }
 
+// lmStudioStreamErrorText returns the human-readable failure LM Studio
+// encoded in an SSE data frame, or "" when the frame is an ordinary chunk.
+//
+// A streaming request that LM Studio cannot serve does not fail the way its
+// non-streaming sibling does. The non-streaming call answers 4xx with the
+// reason in the body; the streaming call answers HTTP 200, opens the stream,
+// and delivers the reason as an `event: error` frame. Both shapes of the
+// `error` field are accepted: a bare string (as the 4xx body uses) and an
+// object carrying `message` (as the stream frame uses).
+func lmStudioStreamErrorText(data string) string {
+	var probe struct {
+		Error   json.RawMessage `json:"error"`
+		Message string          `json:"message"`
+	}
+	if err := json.Unmarshal([]byte(data), &probe); err != nil {
+		return ""
+	}
+	if len(probe.Error) == 0 || string(probe.Error) == "null" {
+		return ""
+	}
+
+	var text string
+	if err := json.Unmarshal(probe.Error, &text); err == nil && strings.TrimSpace(text) != "" {
+		return strings.TrimSpace(text)
+	}
+
+	var object struct {
+		Message string `json:"message"`
+	}
+	if err := json.Unmarshal(probe.Error, &object); err == nil && strings.TrimSpace(object.Message) != "" {
+		return strings.TrimSpace(object.Message)
+	}
+	if strings.TrimSpace(probe.Message) != "" {
+		return strings.TrimSpace(probe.Message)
+	}
+	return "LM Studio reported an unspecified stream error"
+}
+
 type lmStudioChatChoice struct {
 	Index        int                      `json:"index"`
 	Message      *lmStudioMessageResponse `json:"message,omitempty"`

--- a/internal/runtime/agent/context_sizing.go
+++ b/internal/runtime/agent/context_sizing.go
@@ -1,0 +1,69 @@
+package agent
+
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/nugget/thane-ai-agent/internal/model/llm"
+)
+
+// Context-window arithmetic. These estimates answer two different questions
+// and are deliberately not the same number: how much context a request will
+// occupy (used to pick a model and to report usage), and how large a window
+// to ask a runner to load for it (which must also cover the tool schemas and
+// leave room to generate into).
+
+const estimatedImageContextTokens = 1536
+
+// reservedOutputContextTokens is the generation headroom folded into any
+// context window Thane asks a runner to load. Thane sends no max_tokens, so
+// this is a judgement call rather than a derived bound: enough room for a
+// long answer or a burst of tool calls, small enough to stay well inside the
+// advertised maximum of the local models this applies to.
+const reservedOutputContextTokens = 4096
+
+func estimateLLMMessagesContextTokens(msgs []llm.Message) int {
+	total := 0
+	for _, msg := range msgs {
+		total += roughTokenCount(msg.Content)
+		total += len(msg.Images) * estimatedImageContextTokens
+	}
+	return total
+}
+
+// estimateToolDefsContextTokens approximates what the tool schemas cost in
+// the context window. They are marshalled the way they travel on the wire
+// because that is what the runner tokenizes: a full agent tool surface is
+// tens of kilobytes of JSON schema, large enough to overrun a window sized
+// from the messages alone.
+func estimateToolDefsContextTokens(toolDefs []map[string]any) int {
+	if len(toolDefs) == 0 {
+		return 0
+	}
+	encoded, err := json.Marshal(toolDefs)
+	if err != nil {
+		return 0
+	}
+	return roughTokenCount(string(encoded))
+}
+
+// estimateLoadContextTokens sizes the context window to ask a runner for
+// when the runner loads a model at a caller-chosen size, as LM Studio does.
+//
+// It counts everything that has to fit: the messages, the tool schemas sent
+// beside them, and headroom to generate into. Prompt and completion share
+// one loaded window, so a window sized to the prompt alone is already full
+// when the first token is generated.
+func estimateLoadContextTokens(msgs []llm.Message, toolDefs []map[string]any) int {
+	return estimateLLMMessagesContextTokens(msgs) +
+		estimateToolDefsContextTokens(toolDefs) +
+		reservedOutputContextTokens
+}
+
+func roughTokenCount(s string) int {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return 0
+	}
+	return (len(s) + 3) / 4
+}

--- a/internal/runtime/agent/context_sizing.go
+++ b/internal/runtime/agent/context_sizing.go
@@ -27,6 +27,29 @@ func estimateLLMMessagesContextTokens(msgs []llm.Message) int {
 	for _, msg := range msgs {
 		total += roughTokenCount(msg.Content)
 		total += len(msg.Images) * estimatedImageContextTokens
+		total += estimateMessageToolCallTokens(msg)
+	}
+	return total
+}
+
+// estimateMessageToolCallTokens counts what a message carries besides its
+// text. Providers serialize a call's id, function name and JSON arguments
+// into the message itself, and a tool result carries the id it answers, so a
+// conversation several tool-calling iterations deep occupies considerably
+// more of the window than its prose suggests.
+func estimateMessageToolCallTokens(msg llm.Message) int {
+	total := roughTokenCount(msg.ToolCallID)
+	for _, tc := range msg.ToolCalls {
+		total += roughTokenCount(tc.ID)
+		total += roughTokenCount(tc.Function.Name)
+		if len(tc.Function.Arguments) == 0 {
+			continue
+		}
+		encoded, err := json.Marshal(tc.Function.Arguments)
+		if err != nil {
+			continue
+		}
+		total += roughTokenCount(string(encoded))
 	}
 	return total
 }
@@ -47,17 +70,30 @@ func estimateToolDefsContextTokens(toolDefs []map[string]any) int {
 	return roughTokenCount(string(encoded))
 }
 
-// estimateLoadContextTokens sizes the context window to ask a runner for
-// when the runner loads a model at a caller-chosen size, as LM Studio does.
+// estimateRequestContextTokens estimates what a request will occupy: the
+// messages, and the tool schemas that travel beside them. This is the size a
+// deployment has to be able to hold for the request to be servable at all,
+// and so it is the size to judge a deployment's compatibility against.
+func estimateRequestContextTokens(msgs []llm.Message, toolDefs []map[string]any) int {
+	return estimateLLMMessagesContextTokens(msgs) + estimateToolDefsContextTokens(toolDefs)
+}
+
+// desiredLoadContextTokens turns the size a request requires into the size
+// worth loading for it: room to generate an answer as well, and never more
+// than the deployment can hold.
 //
-// It counts everything that has to fit: the messages, the tool schemas sent
-// beside them, and headroom to generate into. Prompt and completion share
-// one loaded window, so a window sized to the prompt alone is already full
-// when the first token is generated.
-func estimateLoadContextTokens(msgs []llm.Message, toolDefs []map[string]any) int {
-	return estimateLLMMessagesContextTokens(msgs) +
-		estimateToolDefsContextTokens(toolDefs) +
-		reservedOutputContextTokens
+// Headroom is a preference, not a requirement. Prompt and completion share
+// one loaded window, so a window sized to the prompt exactly is full at the
+// first generated token — but a model that can hold the prompt and less than
+// the full headroom can still answer, and asking for headroom must never be
+// what makes such a request look impossible. That is why this is applied
+// when choosing a load size and not when judging compatibility.
+func desiredLoadContextTokens(requiredTokens, maxContextWindow int) int {
+	desired := requiredTokens + reservedOutputContextTokens
+	if maxContextWindow > 0 && desired > maxContextWindow {
+		return maxContextWindow
+	}
+	return desired
 }
 
 func roughTokenCount(s string) int {

--- a/internal/runtime/agent/loop.go
+++ b/internal/runtime/agent/loop.go
@@ -1991,10 +1991,11 @@ func (l *Loop) Run(ctx context.Context, req *Request, stream StreamCallback) (re
 		}
 	} else {
 		rebuildSystemPromptForModel(model)
-		// This value is handed to runners that load a model at the size we
-		// ask for, so it has to cover the tool schemas and the generation
-		// headroom too — not just the messages.
-		contextSize = estimateLoadContextTokens(llmMessages, visibleTools.List())
+		// What the request requires, tool schemas included — not just the
+		// messages. Generation headroom is added when a load size is chosen,
+		// so that wanting room to answer never makes a servable request look
+		// incompatible here.
+		contextSize = estimateRequestContextTokens(llmMessages, visibleTools.List())
 		if _, prepErr := l.maybePrepareExplicitModel(ctx, model, needsTools, needsStreaming, needsImages, contextSize); prepErr != nil {
 			return nil, prepErr
 		}

--- a/internal/runtime/agent/loop.go
+++ b/internal/runtime/agent/loop.go
@@ -1991,7 +1991,10 @@ func (l *Loop) Run(ctx context.Context, req *Request, stream StreamCallback) (re
 		}
 	} else {
 		rebuildSystemPromptForModel(model)
-		contextSize = estimateLLMMessagesContextTokens(llmMessages)
+		// This value is handed to runners that load a model at the size we
+		// ask for, so it has to cover the tool schemas and the generation
+		// headroom too — not just the messages.
+		contextSize = estimateLoadContextTokens(llmMessages, visibleTools.List())
 		if _, prepErr := l.maybePrepareExplicitModel(ctx, model, needsTools, needsStreaming, needsImages, contextSize); prepErr != nil {
 			return nil, prepErr
 		}

--- a/internal/runtime/agent/model_selection.go
+++ b/internal/runtime/agent/model_selection.go
@@ -12,8 +12,6 @@ import (
 	"github.com/nugget/thane-ai-agent/internal/model/router"
 )
 
-const estimatedImageContextTokens = 1536
-
 // IncompatibleModelError reports that an explicit deployment cannot
 // satisfy the request's required capabilities.
 type IncompatibleModelError struct {
@@ -286,23 +284,6 @@ func messagesNeedImages(msgs []Message) bool {
 		}
 	}
 	return false
-}
-
-func estimateLLMMessagesContextTokens(msgs []llm.Message) int {
-	total := 0
-	for _, msg := range msgs {
-		total += roughTokenCount(msg.Content)
-		total += len(msg.Images) * estimatedImageContextTokens
-	}
-	return total
-}
-
-func roughTokenCount(s string) int {
-	s = strings.TrimSpace(s)
-	if s == "" {
-		return 0
-	}
-	return (len(s) + 3) / 4
 }
 
 func isLMStudioLoadedContextError(err error) bool {

--- a/internal/runtime/agent/model_selection.go
+++ b/internal/runtime/agent/model_selection.go
@@ -134,7 +134,12 @@ func (l *Loop) maybePrepareExplicitModel(ctx context.Context, ref string, needsT
 	if dep.ResourcePolicyState == fleet.DeploymentPolicyStateInactive {
 		return false, nil
 	}
-	if !fleet.CanExpandLoadedContext(dep, contextSize) {
+	// contextSize is what the request requires; the window worth loading for
+	// it also holds the answer. Headroom is folded in here rather than by the
+	// caller because the same figure feeds preflight, which must judge the
+	// deployment on the requirement alone.
+	loadSize := desiredLoadContextTokens(contextSize, dep.MaxContextWindow)
+	if !fleet.CanExpandLoadedContext(dep, loadSize) {
 		return false, nil
 	}
 	if needsTools {
@@ -152,7 +157,7 @@ func (l *Loop) maybePrepareExplicitModel(ctx context.Context, ref string, needsT
 		return false, nil
 	}
 
-	prep, err := l.modelRuntime.PrepareExplicitModel(ctx, dep.ID, contextSize)
+	prep, err := l.modelRuntime.PrepareExplicitModel(ctx, dep.ID, loadSize)
 	if err != nil {
 		return false, err
 	}

--- a/internal/runtime/agent/model_selection_test.go
+++ b/internal/runtime/agent/model_selection_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -884,7 +885,12 @@ func TestRun_ExplicitModelRetriesProviderContextErrorAfterLMStudioLoad(t *testin
 
 func TestRun_ExplicitModelRetriesProviderContextErrorAfterRegistryRefresh(t *testing.T) {
 	var mu sync.Mutex
-	loadedContext := 4096
+	// Start loaded well above what estimateLoadContextTokens will size this
+	// request at, so selection-time preparation sees a window that already
+	// fits and issues no explicit load. That is the case this test is about:
+	// the estimate says the request fits, the runner disagrees anyway, and
+	// recovery has to notice the reload and retry against it.
+	loadedContext := 32768
 	chatCalls := 0
 	loadCalls := 0
 
@@ -1279,5 +1285,50 @@ func TestRun_RoutedImageRequestRejectsWhenNoEligibleImageCapableDeploymentExists
 	}
 	if len(mock.calls) != 0 {
 		t.Fatalf("llm calls = %d, want 0 when routing rejects", len(mock.calls))
+	}
+}
+
+// Sizing a loaded context window from the messages alone is what put a
+// production loop into a nudge-and-fallback cycle: the window was loaded at
+// exactly the estimated prompt size, and the tool schemas that travel beside
+// the prompt pushed the real request past it every time.
+func TestEstimateLoadContextTokens_CountsToolsAndHeadroom(t *testing.T) {
+	t.Parallel()
+
+	msgs := []llm.Message{
+		{Role: "system", Content: strings.Repeat("a", 4000)},
+		{Role: "user", Content: strings.Repeat("b", 400)},
+	}
+	toolDefs := make([]map[string]any, 0, 62)
+	for i := range 62 {
+		toolDefs = append(toolDefs, map[string]any{
+			"type": "function",
+			"function": map[string]any{
+				"name":        fmt.Sprintf("tool_%02d", i),
+				"description": "Performs an operation on the target resource.",
+				"parameters": map[string]any{
+					"type": "object",
+					"properties": map[string]any{
+						"target": map[string]any{"type": "string", "description": "Resource identifier."},
+					},
+					"required": []string{"target"},
+				},
+			},
+		})
+	}
+
+	messagesOnly := estimateLLMMessagesContextTokens(msgs)
+	withTools := estimateLoadContextTokens(msgs, toolDefs)
+
+	if got := estimateLoadContextTokens(msgs, nil); got != messagesOnly+reservedOutputContextTokens {
+		t.Fatalf("estimateLoadContextTokens(msgs, nil) = %d, want %d", got, messagesOnly+reservedOutputContextTokens)
+	}
+	if withTools <= messagesOnly+reservedOutputContextTokens {
+		t.Fatalf("estimateLoadContextTokens() = %d, want it to exceed messages+headroom (%d) once tools are attached",
+			withTools, messagesOnly+reservedOutputContextTokens)
+	}
+	if withTools <= messagesOnly {
+		t.Fatalf("estimateLoadContextTokens() = %d, must never size a window at or below the prompt estimate %d",
+			withTools, messagesOnly)
 	}
 }

--- a/internal/runtime/agent/model_selection_test.go
+++ b/internal/runtime/agent/model_selection_test.go
@@ -1292,7 +1292,7 @@ func TestRun_RoutedImageRequestRejectsWhenNoEligibleImageCapableDeploymentExists
 // production loop into a nudge-and-fallback cycle: the window was loaded at
 // exactly the estimated prompt size, and the tool schemas that travel beside
 // the prompt pushed the real request past it every time.
-func TestEstimateLoadContextTokens_CountsToolsAndHeadroom(t *testing.T) {
+func TestEstimateRequestContextTokens_CountsToolSchemas(t *testing.T) {
 	t.Parallel()
 
 	msgs := []llm.Message{
@@ -1318,17 +1318,128 @@ func TestEstimateLoadContextTokens_CountsToolsAndHeadroom(t *testing.T) {
 	}
 
 	messagesOnly := estimateLLMMessagesContextTokens(msgs)
-	withTools := estimateLoadContextTokens(msgs, toolDefs)
+	if got := estimateRequestContextTokens(msgs, nil); got != messagesOnly {
+		t.Fatalf("estimateRequestContextTokens(msgs, nil) = %d, want %d", got, messagesOnly)
+	}
+	if got := estimateRequestContextTokens(msgs, toolDefs); got <= messagesOnly {
+		t.Fatalf("estimateRequestContextTokens() = %d, want it to exceed the messages-only estimate %d once tools are attached",
+			got, messagesOnly)
+	}
+}
 
-	if got := estimateLoadContextTokens(msgs, nil); got != messagesOnly+reservedOutputContextTokens {
-		t.Fatalf("estimateLoadContextTokens(msgs, nil) = %d, want %d", got, messagesOnly+reservedOutputContextTokens)
+// Tool-call metadata is part of the message on the wire — the call id, the
+// function name, and the JSON arguments — so a conversation that has been
+// calling tools holds more context than its prose accounts for.
+func TestEstimateLLMMessagesContextTokens_CountsToolCallMetadata(t *testing.T) {
+	t.Parallel()
+
+	plain := []llm.Message{
+		{Role: "user", Content: "check the sensor"},
+		{Role: "assistant", Content: ""},
+		{Role: "tool", Content: "ok"},
 	}
-	if withTools <= messagesOnly+reservedOutputContextTokens {
-		t.Fatalf("estimateLoadContextTokens() = %d, want it to exceed messages+headroom (%d) once tools are attached",
-			withTools, messagesOnly+reservedOutputContextTokens)
+
+	call := llm.ToolCall{ID: "call_9f2c1ab4"}
+	call.Function.Name = "archive_search"
+	call.Function.Arguments = map[string]any{
+		"query": strings.Repeat("a long historical search argument ", 200),
+		"limit": 50,
 	}
-	if withTools <= messagesOnly {
-		t.Fatalf("estimateLoadContextTokens() = %d, must never size a window at or below the prompt estimate %d",
-			withTools, messagesOnly)
+	withCalls := []llm.Message{
+		{Role: "user", Content: "check the sensor"},
+		{Role: "assistant", Content: "", ToolCalls: []llm.ToolCall{call}},
+		{Role: "tool", Content: "ok", ToolCallID: "call_9f2c1ab4"},
+	}
+
+	base := estimateLLMMessagesContextTokens(plain)
+	got := estimateLLMMessagesContextTokens(withCalls)
+
+	// The arguments alone are ~6800 characters, so the gap must be large;
+	// counting only the ids and names would be a near-invisible difference.
+	if got-base < 1000 {
+		t.Fatalf("estimate with tool calls = %d, without = %d (gap %d), want the serialized arguments counted",
+			got, base, got-base)
+	}
+}
+
+// Headroom is a preference. Adding it to the figure that judges
+// compatibility would reject requests a model can actually serve — a 7000
+// token request on an 8192 token model is servable, and must not be turned
+// away for wanting 4096 tokens of room on top.
+func TestDesiredLoadContextTokens_ClampsToMaxAndStaysAPreference(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		required int
+		max      int
+		want     int
+	}{
+		{name: "headroom fits", required: 20000, max: 262144, want: 20000 + reservedOutputContextTokens},
+		{name: "headroom clamped to max", required: 7000, max: 8192, want: 8192},
+		{name: "required already at max", required: 8192, max: 8192, want: 8192},
+		{name: "unknown max leaves headroom", required: 7000, max: 0, want: 7000 + reservedOutputContextTokens},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := desiredLoadContextTokens(tt.required, tt.max); got != tt.want {
+				t.Fatalf("desiredLoadContextTokens(%d, %d) = %d, want %d", tt.required, tt.max, got, tt.want)
+			}
+		})
+	}
+}
+
+// Preflight judges a deployment on what the request requires, not on what
+// would be comfortable. A model whose window holds the request but not the
+// request plus generation headroom can still answer, and must not be
+// rejected before the provider is ever called — a rejection here also skips
+// the provider-error and tool-removal recovery paths downstream.
+func TestRun_ExplicitModelPreflightDoesNotRequireOutputHeadroom(t *testing.T) {
+	mock := &mockLLM{
+		responses: []*llm.ChatResponse{
+			{
+				Model:       "gemma-local",
+				Message:     llm.Message{Role: "assistant", Content: "ok"},
+				InputTokens: 100, OutputTokens: 2,
+			},
+		},
+	}
+	loop := buildTestLoop(mock, nil)
+	cfg := &config.Config{
+		Models: config.ModelsConfig{
+			Default: "gemma-local",
+			Resources: map[string]config.ModelServerConfig{
+				"local": {URL: "http://localhost:11434", Provider: "ollama"},
+			},
+			Available: []config.ModelConfig{
+				{Name: "gemma-local", Resource: "local"},
+			},
+		},
+	}
+	loop.UseModelRegistry(testModelRegistryFromConfig(t, cfg))
+
+	userMessage := "please inspect the loaded memory timeline"
+	reqMessages := []Message{{Role: "user", Content: userMessage}}
+	prompt, sections := loop.buildSystemPromptWithProfileSections(context.Background(), userMessage, loop.modelInteractionProfileForModel("gemma-local"))
+	required := estimateRequestContextTokens(
+		buildInitialLLMMessages(prompt, sections, nil, reqMessages, "default", time.Time{}),
+		loop.tools.List(),
+	)
+
+	// A window that fits the request exactly, and cannot fit the headroom.
+	cfg.Models.Available[0].ContextWindow = required
+	loop.UseModelRegistry(testModelRegistryFromConfig(t, cfg))
+
+	_, err := loop.Run(context.Background(), &Request{
+		Model:    "gemma-local",
+		Messages: reqMessages,
+	}, nil)
+	if err != nil {
+		t.Fatalf("Run() error = %v, want the request served on a window that fits it", err)
+	}
+	if len(mock.calls) == 0 {
+		t.Fatal("llm calls = 0, want the provider reached rather than preflight-rejected")
 	}
 }


### PR DESCRIPTION
## What happened

The loop `thane_dev_watcher` asked `centro/qwen/qwen3-coder-next` for a turn and got nothing back: `input_tokens 0`, `output_tokens 0`, no error. Thane nudged the model, sent the same request again, got the same nothing, and returned a fallback. Request `r_875964d7e344387d`, 2026-08-14T21:18:11Z.

centro was healthy throughout. It listed its models seconds earlier, loaded the requested one on demand, and answered the inference request with HTTP 200 in 241ms. Two hundred and forty-one milliseconds is not a turn — it is a refusal, and Thane read it as an answer.

In fourteen days centro has been called exactly twice. Both calls are the two failures in that one request. It has never returned a successful completion.

## Why the failure was invisible

LM Studio does not report a streaming failure the way it reports the non-streaming one. Asked to serve a request it cannot, the non-streaming call answers `400` with the reason in the body. The streaming call answers `200`, opens the stream, and delivers the reason as an `event: error` frame.

That frame decodes cleanly into `lmStudioChatResponse`. Every field it carries — `error`, `message` — is unknown to that type, so `encoding/json` discards all of it and yields a zero-valued chunk with no choices. The parser accumulated nothing from it, reached the end of the body, and built a well-formed response with empty content and zero usage. No error anywhere.

What makes this expensive rather than merely wrong is that Thane already knows how to recover from this precise failure. `isLMStudioLoadedContextError` matches the message. `maybeRetryExplicitModelAfterProviderContextError` reloads the deployment at its full advertised window and retries. That machinery is reachable only when the provider returns an error — so it worked on the `400` path and was dead on the streaming path, which is the one production uses. The recovery existed, was correct, and never ran.

## Why the request was too big in the first place

The model was loaded, 27 seconds before the call, at a context length of **12732** — a number Thane chose. It came from `estimateLLMMessagesContextTokens`, which counts message text and images and nothing else, handed to LM Studio as the window to load.

Two things that were not counted still had to fit in it.

The tool schemas were the larger omission: 62 tool definitions travel beside the prompt and the runner tokenizes them the same way, tens of kilobytes of JSON. And then the answer, because prompt and completion share one loaded window — so a window sized to the prompt exactly is already full at the first generated token. There is no prompt size for which that arithmetic works.

That is why centro failed on every attempt rather than intermittently, and why the nudge could not help: the retry was the same oversized request into the same undersized window.

## The changes

**`fix(lmstudio)`** — parse the error frame and fail the call with the upstream text intact, so the recovery written for this failure can see it. Also refuse a stream that carried no chunks at all: however cleanly it closed, it never produced a completion, and the non-streaming path already rejects its equivalent.

**`fix(agent)`** — count the tool schemas as they go on the wire and add explicit generation headroom, in a new `estimateLoadContextTokens` used where a window is being sized to be loaded. The messages-only estimate keeps its name and its other callers: usage accounting and routing ask a different question and should not silently inherit this answer.

Either change alone fixes centro. The first makes the failure recoverable; the second stops it happening. Both are worth having — the estimate is an estimate, and the recovery is what catches the times it is wrong.

The sizing helpers move to `context_sizing.go` unchanged, having grown into a distinct concern and pushed `model_selection.go` over the large-file threshold.

## Verified against production

Reproduced directly against centro, from the prod host, before and after:

- Simple request, no tools → streams fine. centro is not broken.
- Prompt of ~20k tokens → `HTTP 200` + `event: error` frame. Same request non-streaming → `HTTP 400` with the same message. This is the asymmetry.
- Prompt estimated at 11500 tokens against the loaded 12732 window: **without** tools it streams content; **with** 62 tool schemas attached it returns the error frame. This is the overflow, isolated to the tool payload.

## Test plan

- [x] `just ci` passes locally
- [x] New: error frame surfaces as an error carrying the upstream text, for both the object and bare-string shapes of the `error` field
- [x] New: a chunkless stream (empty body, and `[DONE]` with no chunks) is an error
- [x] New: `estimateLoadContextTokens` exceeds the messages-only estimate once tools are attached, and never sizes a window at or below the prompt
- [x] `TestRun_ExplicitModelRetriesProviderContextErrorAfterRegistryRefresh` still exercises the reactive path — its fixture now starts loaded above the selection-time estimate, so no proactive load preempts the case it is testing
- [ ] Confirm on prod after deploy that a centro turn completes

## Note on the earlier event

The empty response at 19:34:19Z that looked like a second instance of this was the `archivist` loop, not centro — no LM Studio call in that request at all. It ran at ~43k input tokens, got one empty iteration, and recovered on the nudge. That is the narrate-then-stop attractor and is unrelated to anything here.
