### PR TITLE
fix: synthesize missing LM Studio tool call IDs

### DIFF
--- a/internal/model/fleet/providers/lmstudio.go
+++ b/internal/model/fleet/providers/lmstudio.go
@@ -366,7 +366,9 @@ func (c *LMStudioClient) handleStreaming(ctx context.Context, requestedModel str
 	result.Message.Role = normalizeLMStudioMessageRole(role)
 	result.Message.Content = contentBuilder.String()
 	result.Message.ToolCalls = toolCalls
-	applyTextToolFallback(result, validToolNames)
+	if err := applyTextToolFallback(result, validToolNames); err != nil {
+		return nil, err
+	}
 
 	c.logger.Debug("stream complete",
 		"model", result.Model,
@@ -407,7 +409,9 @@ func (c *LMStudioClient) chatResponseFromWire(wire *lmStudioChatResponse, validT
 	result.Message.Role = normalizeLMStudioMessageRole(wire.Choices[0].Message.Role)
 	result.Message.Content = lmStudioContentText(wire.Choices[0].Message.Content)
 	result.Message.ToolCalls = toolCalls
-	applyTextToolFallback(result, validToolNames)
+	if err := applyTextToolFallback(result, validToolNames); err != nil {
+		return nil, err
+	}
 	if strings.TrimSpace(result.Message.Content) == "" && len(result.Message.ToolCalls) == 0 {
 		return nil, fmt.Errorf("LM Studio returned an empty assistant completion for model %q", wire.Model)
 	}

--- a/internal/model/fleet/providers/lmstudio_test.go
+++ b/internal/model/fleet/providers/lmstudio_test.go
@@ -204,6 +204,33 @@ func TestToLMStudioMessages_EmptyContentIsEmittedNotOmitted(t *testing.T) {
 	}
 }
 
+func TestDecodeLMStudioToolCalls_SynthesizesUniqueMissingIDs(t *testing.T) {
+	t.Parallel()
+
+	calls, err := decodeLMStudioToolCalls(map[int]*lmStudioToolAccumulator{
+		0: {Name: "first"},
+		1: {Name: "second"},
+		2: {ID: "runner_call_3", Name: "third"},
+	})
+	if err != nil {
+		t.Fatalf("decodeLMStudioToolCalls() error = %v", err)
+	}
+	if len(calls) != 3 {
+		t.Fatalf("tool calls = %d, want 3", len(calls))
+	}
+	for i := range 2 {
+		if !strings.HasPrefix(calls[i].ID, "call_") {
+			t.Errorf("tool call %d ID = %q, want generated call_ prefix", i, calls[i].ID)
+		}
+	}
+	if calls[0].ID == calls[1].ID {
+		t.Errorf("generated tool call IDs are not unique: %q", calls[0].ID)
+	}
+	if calls[2].ID != "runner_call_3" {
+		t.Errorf("runner-supplied tool call ID = %q, want runner_call_3", calls[2].ID)
+	}
+}
+
 func TestLMStudioChat_NonStreamingToolCalls(t *testing.T) {
 	t.Parallel()
 
@@ -268,6 +295,9 @@ func TestLMStudioChat_NonStreamingToolCalls(t *testing.T) {
 	}
 	if len(resp.Message.ToolCalls) != 1 {
 		t.Fatalf("len(tool_calls) = %d, want 1", len(resp.Message.ToolCalls))
+	}
+	if got := resp.Message.ToolCalls[0].ID; got != "call_1" {
+		t.Fatalf("tool ID = %q, want call_1", got)
 	}
 	if got := resp.Message.ToolCalls[0].Function.Name; got != "ha_get_state" {
 		t.Fatalf("tool name = %q, want ha_get_state", got)
@@ -542,6 +572,9 @@ func TestLMStudioChatStream_ContentAndToolCalls(t *testing.T) {
 	}
 	if len(resp.Message.ToolCalls) != 1 {
 		t.Fatalf("len(tool_calls) = %d, want 1", len(resp.Message.ToolCalls))
+	}
+	if got := resp.Message.ToolCalls[0].ID; got != "call_1" {
+		t.Fatalf("tool ID = %q, want call_1", got)
 	}
 	if got := resp.Message.ToolCalls[0].Function.Name; got != "ha_get_state" {
 		t.Fatalf("tool name = %q, want ha_get_state", got)

--- a/internal/model/fleet/providers/lmstudio_test.go
+++ b/internal/model/fleet/providers/lmstudio_test.go
@@ -231,6 +231,28 @@ func TestDecodeLMStudioToolCalls_SynthesizesUniqueMissingIDs(t *testing.T) {
 	}
 }
 
+func TestApplyTextToolFallback_SynthesizesMissingID(t *testing.T) {
+	t.Parallel()
+
+	resp := &llm.ChatResponse{
+		Message: llm.Message{
+			Content: `{"name":"echo","arguments":{"text":"probe"}}`,
+		},
+	}
+	if err := applyTextToolFallback(resp, []string{"echo"}); err != nil {
+		t.Fatalf("applyTextToolFallback() error = %v", err)
+	}
+	if len(resp.Message.ToolCalls) != 1 {
+		t.Fatalf("tool calls = %d, want 1", len(resp.Message.ToolCalls))
+	}
+	if got := resp.Message.ToolCalls[0].ID; !strings.HasPrefix(got, "call_") {
+		t.Fatalf("tool call ID = %q, want generated call_ prefix", got)
+	}
+	if resp.Message.Content != "" {
+		t.Fatalf("content = %q, want empty after text fallback", resp.Message.Content)
+	}
+}
+
 func TestLMStudioChat_NonStreamingToolCalls(t *testing.T) {
 	t.Parallel()
 

--- a/internal/model/fleet/providers/lmstudio_wire.go
+++ b/internal/model/fleet/providers/lmstudio_wire.go
@@ -410,6 +410,17 @@ func lmStudioContentText(v any) string {
 	}
 }
 
-func applyTextToolFallback(resp *llm.ChatResponse, validToolNames []string) {
+func applyTextToolFallback(resp *llm.ChatResponse, validToolNames []string) error {
+	if resp == nil {
+		return nil
+	}
 	llm.ApplyTextToolCallFallback(resp, validToolNames, llm.DefaultToolCallTextProfile())
+	for i := range resp.Message.ToolCalls {
+		id, err := ensureLMStudioToolCallID(resp.Message.ToolCalls[i].ID)
+		if err != nil {
+			return err
+		}
+		resp.Message.ToolCalls[i].ID = id
+	}
+	return nil
 }

--- a/internal/model/fleet/providers/lmstudio_wire.go
+++ b/internal/model/fleet/providers/lmstudio_wire.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/google/uuid"
 	"github.com/nugget/thane-ai-agent/internal/model/llm"
 )
 
@@ -323,12 +324,31 @@ func decodeLMStudioToolCalls(accs map[int]*lmStudioToolAccumulator) ([]llm.ToolC
 		if err != nil {
 			return nil, err
 		}
-		call := llm.ToolCall{ID: acc.ID}
+		callID, err := ensureLMStudioToolCallID(acc.ID)
+		if err != nil {
+			return nil, err
+		}
+		call := llm.ToolCall{ID: callID}
 		call.Function.Name = acc.Name
 		call.Function.Arguments = args
 		out = append(out, call)
 	}
 	return out, nil
+}
+
+// ensureLMStudioToolCallID repairs a runner omission before the assistant
+// message enters iteration history. LM Studio rejects that same historical
+// tool call on the next request when its id is empty, even though its Qwen
+// parser can produce tool calls without assigning one.
+func ensureLMStudioToolCallID(id string) (string, error) {
+	if strings.TrimSpace(id) != "" {
+		return id, nil
+	}
+	generated, err := uuid.NewV7()
+	if err != nil {
+		return "", fmt.Errorf("generate fallback LM Studio tool call ID: %w", err)
+	}
+	return "call_" + generated.String(), nil
 }
 
 func decodeLMStudioToolCallsFromSlice(in []lmStudioToolCallDelta) ([]llm.ToolCall, error) {

--- a/internal/runtime/iterate/lmstudio_roundtrip_test.go
+++ b/internal/runtime/iterate/lmstudio_roundtrip_test.go
@@ -32,6 +32,43 @@ type lmStudioFollowUpToolCall struct {
 func TestLMStudioMissingToolCallIDRoundTrip(t *testing.T) {
 	t.Parallel()
 
+	tests := []struct {
+		name       string
+		firstDelta map[string]any
+	}{
+		{
+			name: "structured tool call",
+			firstDelta: map[string]any{
+				"role": "assistant",
+				"tool_calls": []any{map[string]any{
+					"index": 0,
+					"type":  "function",
+					"function": map[string]any{
+						"name":      "echo",
+						"arguments": `{"text":"probe"}`,
+					},
+				}},
+			},
+		},
+		{
+			name: "text tool fallback",
+			firstDelta: map[string]any{
+				"role":    "assistant",
+				"content": `{"name":"echo","arguments":{"text":"probe"}}`,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			testLMStudioMissingToolCallIDRoundTrip(t, tt.firstDelta)
+		})
+	}
+}
+
+func testLMStudioMissingToolCallIDRoundTrip(t *testing.T, firstDelta map[string]any) {
+	t.Helper()
+
 	var requestCount atomic.Int32
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var req lmStudioFollowUpRequest
@@ -55,23 +92,13 @@ func TestLMStudioMissingToolCallIDRoundTrip(t *testing.T) {
 
 		switch requestCount.Add(1) {
 		case 1:
-			// Qwen tool parsing can produce a valid call without the id that
-			// LM Studio later requires when the call returns in history.
+			// Qwen can produce either a structured or text-parsed tool call
+			// without the ID LM Studio later requires in iteration history.
 			writeChunk(map[string]any{
 				"model": "qwen/qwen3-coder-next",
 				"choices": []any{map[string]any{
 					"index": 0,
-					"delta": map[string]any{
-						"role": "assistant",
-						"tool_calls": []any{map[string]any{
-							"index": 0,
-							"type":  "function",
-							"function": map[string]any{
-								"name":      "echo",
-								"arguments": `{"text":"probe"}`,
-							},
-						}},
-					},
+					"delta": firstDelta,
 				}},
 				"usage": map[string]any{"prompt_tokens": 12, "completion_tokens": 4},
 			})

--- a/internal/runtime/iterate/lmstudio_roundtrip_test.go
+++ b/internal/runtime/iterate/lmstudio_roundtrip_test.go
@@ -1,0 +1,147 @@
+package iterate_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/nugget/thane-ai-agent/internal/model/fleet/providers"
+	"github.com/nugget/thane-ai-agent/internal/model/llm"
+	"github.com/nugget/thane-ai-agent/internal/runtime/iterate"
+)
+
+type lmStudioFollowUpRequest struct {
+	Stream   bool                      `json:"stream"`
+	Messages []lmStudioFollowUpMessage `json:"messages"`
+}
+
+type lmStudioFollowUpMessage struct {
+	Role       string                     `json:"role"`
+	ToolCallID string                     `json:"tool_call_id"`
+	ToolCalls  []lmStudioFollowUpToolCall `json:"tool_calls"`
+}
+
+type lmStudioFollowUpToolCall struct {
+	ID string `json:"id"`
+}
+
+func TestLMStudioMissingToolCallIDRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	var requestCount atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req lmStudioFollowUpRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		if !req.Stream {
+			t.Fatal("expected streaming request")
+		}
+
+		w.Header().Set("Content-Type", "text/event-stream")
+		flusher := w.(http.Flusher)
+		writeChunk := func(chunk any) {
+			data, err := json.Marshal(chunk)
+			if err != nil {
+				t.Fatalf("marshal chunk: %v", err)
+			}
+			fmt.Fprintf(w, "data: %s\n\n", data)
+			flusher.Flush()
+		}
+
+		switch requestCount.Add(1) {
+		case 1:
+			// Qwen tool parsing can produce a valid call without the id that
+			// LM Studio later requires when the call returns in history.
+			writeChunk(map[string]any{
+				"model": "qwen/qwen3-coder-next",
+				"choices": []any{map[string]any{
+					"index": 0,
+					"delta": map[string]any{
+						"role": "assistant",
+						"tool_calls": []any{map[string]any{
+							"index": 0,
+							"type":  "function",
+							"function": map[string]any{
+								"name":      "echo",
+								"arguments": `{"text":"probe"}`,
+							},
+						}},
+					},
+				}},
+				"usage": map[string]any{"prompt_tokens": 12, "completion_tokens": 4},
+			})
+		case 2:
+			if len(req.Messages) != 4 {
+				t.Fatalf("follow-up messages = %d, want 4", len(req.Messages))
+			}
+			assistant := req.Messages[2]
+			toolResult := req.Messages[3]
+			if len(assistant.ToolCalls) != 1 {
+				t.Fatalf("assistant tool calls = %d, want 1", len(assistant.ToolCalls))
+			}
+			callID := assistant.ToolCalls[0].ID
+			if callID == "" {
+				http.Error(w, `{"error":"Invalid 'messages' in payload. Please check the structure of your 'messages' and try again."}`, http.StatusBadRequest)
+				return
+			}
+			if toolResult.ToolCallID != callID {
+				t.Fatalf("tool result ID = %q, want assistant call ID %q", toolResult.ToolCallID, callID)
+			}
+			writeChunk(map[string]any{
+				"model": "qwen/qwen3-coder-next",
+				"choices": []any{map[string]any{
+					"index": 0,
+					"delta": map[string]any{"role": "assistant", "content": "done"},
+				}},
+				"usage": map[string]any{"prompt_tokens": 20, "completion_tokens": 1},
+			})
+		default:
+			t.Fatalf("unexpected request %d", requestCount.Load())
+		}
+
+		fmt.Fprint(w, "data: [DONE]\n\n")
+		flusher.Flush()
+	}))
+	defer srv.Close()
+
+	toolDefs := []map[string]any{{
+		"type": "function",
+		"function": map[string]any{
+			"name": "echo",
+			"parameters": map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"text": map[string]any{"type": "string"},
+				},
+			},
+		},
+	}}
+	client := providers.NewLMStudioClient(srv.URL, "", nil)
+	result, err := (&iterate.Engine{}).Run(context.Background(), iterate.Config{
+		MaxIterations: 3,
+		Model:         "qwen/qwen3-coder-next",
+		LLM:           client,
+		Stream:        func(llm.StreamEvent) {},
+		ToolDefs:      func(int) []map[string]any { return toolDefs },
+		Executor: &iterate.DirectExecutor{Exec: func(context.Context, string, string) (string, error) {
+			return `{"text":"probe"}`, nil
+		}},
+	}, []llm.Message{
+		{Role: "system", Content: "Use tools when requested."},
+		{Role: "user", Content: "Echo probe."},
+	})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if result.Content != "done" {
+		t.Fatalf("result.Content = %q, want done", result.Content)
+	}
+	if got := requestCount.Load(); got != 2 {
+		t.Fatalf("request count = %d, want 2", got)
+	}
+}


### PR DESCRIPTION
## Summary

- Preserve LM Studio runner-supplied tool-call IDs.
- Synthesize a UUIDv7-backed `call_...` ID when structured or text-parsed tool calls arrive without one.
- Cover the complete Qwen tool round trip, including the assistant call and matching tool-result message on the next iteration.

## Why

The follow-on investigation from #1395 captured the actual failed production history. The assistant tool call had an empty `id`, and the following tool result had an empty `tool_call_id`. LM Studio accepted the first completion but rejected that history on the next iteration with `400 Invalid 'messages' in payload`.

The adapter previously preserved the empty runner value. Because both wire fields use `omitempty`, Thane then omitted both correlation fields from the follow-up payload. Assigning the fallback before the assistant message enters iteration history lets the existing engine carry one matching ID through the complete exchange.

LM Studio can also return a tool call as text for Thane's shared fallback parser to promote after structured decoding. The provider now normalizes IDs after that fallback too, covering this LM Studio-specific strictness without changing shared Ollama behavior.

## User impact

Qwen models running through LM Studio can continue after structured or text-parsed tool calls when the runner omits the call ID. Provider-assigned IDs remain unchanged, and parallel missing calls receive distinct IDs.

## Test plan

- [x] `just ci`
- [x] Structured and text-parsed missing-ID calls each complete a two-iteration assistant/tool-result round trip.
- [x] Multiple missing IDs are synthesized uniquely.
- [x] Existing streamed and non-streamed runner IDs are preserved.

Refs #1395